### PR TITLE
Enrich 8 entries: add cross-refs, references, deepen history

### DIFF
--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -47,7 +47,7 @@
     "lineCount": 255
   },
   "overview": {
-    "historicalContext": "The Ballot Problem was posed by Joseph Bertrand in 1887 and solved by Désiré André the same year. It asks: in an election where candidate A receives $p$ votes and candidate B receives $q$ votes (with $p > q$), what is the probability that A is ahead of B throughout the entire counting process?\n\nThe answer is the elegant formula $(p-q)/(p+q)$. André's original proof used the **reflection principle** — a bijective argument that pairs each 'bad' vote sequence (where A falls behind or ties) with a path to a reflected endpoint. This bijection is one of the most celebrated elementary arguments in combinatorics.\n\nThe result appears as Theorem #30 in Wiedijk's Formalizing 100 Theorems list, and was formalized in Mathlib by Sébastien Gouëzel.",
+    "historicalContext": "The Ballot Problem was posed by Joseph Bertrand in 1887 in the *Comptes Rendus* of the French Academy of Sciences, and solved by Désiré André in the very next issue of the same journal. It asks: in an election where candidate A receives $p$ votes and candidate B receives $q$ votes (with $p > q$), what is the probability that A is ahead of B throughout the entire counting process?\n\nThe answer is the elegant formula $(p-q)/(p+q)$. André's proof introduced the **reflection principle** — a bijective argument that pairs each 'bad' vote sequence (where A falls behind or ties) with a reflected path. The reflection principle has since become one of the most powerful tools in enumerative combinatorics, applied to Catalan numbers, random walks, queueing theory, and financial mathematics.\n\nThe problem has a rich genealogy: it was studied independently by Émile Barbier (1887), rediscovered by Aeppli (1924), and generalized by Takács (1962) and others. William Feller popularized it in his classic textbook *An Introduction to Probability Theory and Its Applications* (1968), where it appears as a gateway to the theory of random walks and fluctuation theory.\n\nThe result appears as Theorem #30 in Wiedijk's Formalizing 100 Theorems list, and was formalized in Mathlib by Sébastien Gouëzel.",
     "problemStatement": "**Theorem (Bertrand, 1887)**: In an election where candidate A receives p votes and candidate B receives q votes, with p > q, the probability that A leads B throughout the counting is:\n\n$$P = \\frac{p - q}{p + q}$$\n\nThis is Wiedijk's 100 Theorems #30.",
     "proofStrategy": "**The Reflection Principle**:\n\n1. Model vote counting as a path in a lattice (each vote moves the cumulative total up or down)\n2. 'A leads throughout' means the path never touches the x-axis after time 0\n3. Count 'bad' paths by reflecting them across the axis at their first touch point\n4. This creates a bijection with paths to a different endpoint\n5. The probability follows from counting good vs total paths",
     "keyInsights": [
@@ -129,6 +129,26 @@
       "targetId": "combinations-formula",
       "relationship": "uses",
       "description": "The ballot probability is a ratio of binomial coefficients C(p+q,p); the counting argument relies on the combinations formula"
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "related",
+      "description": "Both are classic probability problems solved by counting arguments over finite sample spaces — the birthday problem counts collisions in random assignments, the ballot problem counts lattice paths staying positive"
+    },
+    {
+      "targetId": "ballot-problem-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry extending the ballot problem with generalizations and additional analysis"
+    },
+    {
+      "targetId": "ballot-problem-oq-02",
+      "relationship": "extended-by",
+      "description": "Sub-entry exploring further connections of the ballot problem"
+    },
+    {
+      "targetId": "ballot-problem-oq-03",
+      "relationship": "extended-by",
+      "description": "Sub-entry with additional ballot problem variants and applications"
     }
   ],
   "relatedProofs": [
@@ -167,6 +187,20 @@
       "year": "1887",
       "venue": "Comptes Rendus de l'Académie des Sciences, Paris 105",
       "note": "First solution using the reflection principle — the celebrated bijective argument"
+    },
+    {
+      "authors": "Feller, William",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. I",
+      "year": "1968",
+      "venue": "Wiley, 3rd edition, Chapter III",
+      "note": "Classic treatment of the ballot problem and its connection to random walks, fluctuation theory, and the arc-sine law"
+    },
+    {
+      "authors": "Renault, Marc",
+      "title": "Four Proofs of the Ballot Theorem",
+      "year": "2007",
+      "venue": "Mathematics Magazine 80(5): 345–352",
+      "note": "Survey of four distinct proof techniques for the ballot theorem: André's reflection, induction, cycle lemma, and direct counting"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass for 8 entries

### abel-ruffini
- +7 cross-refs, +3 references, expanded history (Lagrange, Hermite, Liouville)

### amgm-inequality-oq-02
- +3 cross-refs, +2 references, expanded history (Newton's Arithmetica Universalis)

### amgm-inequality-oq-03
- +3 cross-refs, expanded history (Pythagorean means), +2 open questions

### angle-trisection
- +4 cross-refs, +2 references, expanded history (Archimedes, Gauss's 17-gon)

### angle-trisection-oq-02
- +6 cross-refs, +2 references, expanded history (Wantzel/Galois criterion)

### area-of-circle
- +6 cross-refs, +2 references, expanded history (Babylonians, Eudoxus)

### arithmetic-series
- +6 cross-refs (was 0!), +5 section mathContexts, +4 prerequisites, +1 reference

### ballot-problem
- +4 cross-refs, +2 references, expanded history (Barbier, Aeppli, Takács, Feller)

**Totals**: 39 new cross-references, 17 new academic references, 8 deepened historicalContexts

JSON validated for all entries.