### PR TITLE
Research: Prove GCD-LCM distributive law (CRT non-coprime OQ03)

### DIFF
--- a/proofs/Proofs/ChineseRemainderNonCoprimeOQ03.lean
+++ b/proofs/Proofs/ChineseRemainderNonCoprimeOQ03.lean
@@ -136,22 +136,188 @@ private theorem gcd_lcm_dvd_prod_gcd (a b c : R) :
 /-- Hard direction of the GCD-LCM distributive law:
     gcd(lcm(a,b), c) divides lcm(gcd(a,c), gcd(b,c)).
 
-    Proof: Let d = gcd(lcm(a,b), c), p = gcd(a,c), q = gcd(b,c),
-    G = gcd(p, q), M = lcm(p, q).
-    (1) M | d (easy direction, proved above as lcm_gcd_dvd_gcd_lcm)
-    (2) d | p*q (proved above as gcd_lcm_dvd_prod_gcd)
-    (3) G | d (since G | a, G | b, G | c, so G | lcm(a,b) and G | c)
-    From (3): d = G*d₁. From (2): G*d₁ | G*M, so d₁ | M.
-    From (1): M | G*d₁.
-    Since M = d₁*e₁, M | G*d₁ gives e₁ | G.
-    Since G*d₁ = d = M*r (from (1)), M*r = G*d₁ gives e₁*r = G.
-    So G = e₁*r with e₁ | G and r | G.
-    The proof d | M requires r | 1 (a unit), which follows from the
-    distributivity of the divisibility lattice in any UFD. -/
+    Proof strategy: We show that any common multiple z of gcd(a,c) and gcd(b,c)
+    is divisible by gcd(lcm(a,b), c). Applied to z = lcm(gcd(a,c), gcd(b,c)),
+    this gives the result.
+
+    The key step is writing z as a linear combination of g·α·β and c, where
+    g = gcd(a,b), a = g·α, b = g·β with IsCoprime α β. Since g·α·β is a
+    common multiple of a and b, lcm(a,b) divides it, so gcd(lcm(a,b),c) divides
+    both terms. The algebraic decomposition uses Bézout twice (for gcd(a,c) and
+    gcd(b,c)) plus coprime factoring through gcd(a,b) and gcd(gcd(a,b),c). -/
 theorem gcd_lcm_dvd_lcm_gcd (a b c : R) :
     EuclideanDomain.gcd (EuclideanDomain.lcm a b) c ∣
     EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c) := by
-  sorry
+  -- Handle zero case: gcd(a,b) = 0 implies a = b = 0
+  by_cases hg : EuclideanDomain.gcd a b = 0
+  · have ha : a = 0 := by
+      have := EuclideanDomain.gcd_dvd_left a b; rw [hg] at this
+      exact (zero_dvd_iff.mp this)
+    have hb : b = 0 := by
+      have := EuclideanDomain.gcd_dvd_right a b; rw [hg] at this
+      exact (zero_dvd_iff.mp this)
+    rw [ha, hb]
+    -- Goal: gcd(lcm(0,0), c) | lcm(gcd(0,c), gcd(0,c))
+    -- lcm(0,0) = 0, so gcd(0,c) | lcm(gcd(0,c), gcd(0,c)) by dvd_lcm_left
+    have h0 : EuclideanDomain.lcm (0 : R) 0 = 0 := by
+      simp [EuclideanDomain.lcm]
+    rw [h0]
+    exact EuclideanDomain.dvd_lcm_left _ _
+  · -- Main case: g = gcd(a,b) ≠ 0
+    -- Make gcd(a,b) opaque to prevent rw from rewriting inside it
+    set g := EuclideanDomain.gcd a b with hg_def
+    -- Factor a = g*α, b = g*β
+    obtain ⟨α, hα⟩ := EuclideanDomain.gcd_dvd_left a b
+    obtain ⟨β, hβ⟩ := EuclideanDomain.gcd_dvd_right a b
+    -- IsCoprime α β via Bézout cancellation
+    have hcop_αβ : IsCoprime α β := by
+      refine ⟨EuclideanDomain.gcdA a b, EuclideanDomain.gcdB a b, ?_⟩
+      apply mul_left_cancel₀ hg
+      calc g * (EuclideanDomain.gcdA a b * α + EuclideanDomain.gcdB a b * β)
+          = g * α * EuclideanDomain.gcdA a b +
+            g * β * EuclideanDomain.gcdB a b := by ring
+        _ = a * EuclideanDomain.gcdA a b + b * EuclideanDomain.gcdB a b := by
+            rw [← hα, ← hβ]
+        _ = g := (EuclideanDomain.gcd_eq_gcd_ab a b).symm
+        _ = g * 1 := (mul_one _).symm
+    -- Factor through gcd(g, c)
+    set d' := EuclideanDomain.gcd g c with hd'_def
+    have hd'_ne : d' ≠ 0 := by
+      intro h; apply hg
+      exact (zero_dvd_iff.mp (h ▸ EuclideanDomain.gcd_dvd_left g c))
+    obtain ⟨g', hg'⟩ := EuclideanDomain.gcd_dvd_left g c
+    obtain ⟨c', hc'⟩ := EuclideanDomain.gcd_dvd_right g c
+    -- IsCoprime g' c' via Bézout cancellation
+    have hcop_gc : IsCoprime g' c' := by
+      refine ⟨EuclideanDomain.gcdA g c, EuclideanDomain.gcdB g c, ?_⟩
+      apply mul_left_cancel₀ hd'_ne
+      calc d' * (EuclideanDomain.gcdA g c * g' + EuclideanDomain.gcdB g c * c')
+          = d' * g' * EuclideanDomain.gcdA g c +
+            d' * c' * EuclideanDomain.gcdB g c := by ring
+        _ = g * EuclideanDomain.gcdA g c + c * EuclideanDomain.gcdB g c := by
+            rw [← hg', ← hc']
+        _ = d' := (EuclideanDomain.gcd_eq_gcd_ab g c).symm
+        _ = d' * 1 := (mul_one _).symm
+    -- Bézout representations: M as combination of a,c and b,c
+    obtain ⟨k₁, hk₁⟩ := EuclideanDomain.dvd_lcm_left
+      (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c)
+    obtain ⟨k₂, hk₂⟩ := EuclideanDomain.dvd_lcm_right
+      (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c)
+    -- M = r₁*a + s₁*c  (from gcd(a,c) | M and Bézout for gcd(a,c))
+    have hM1 : EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c) =
+        (EuclideanDomain.gcdA a c * k₁) * a +
+        (EuclideanDomain.gcdB a c * k₁) * c := by
+      conv_lhs => rw [hk₁, EuclideanDomain.gcd_eq_gcd_ab a c]
+      ring
+    -- M = r₂*b + s₂*c  (from gcd(b,c) | M and Bézout for gcd(b,c))
+    have hM2 : EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c) =
+        (EuclideanDomain.gcdA b c * k₂) * b +
+        (EuclideanDomain.gcdB b c * k₂) * c := by
+      conv_lhs => rw [hk₂, EuclideanDomain.gcd_eq_gcd_ab b c]
+      ring
+    -- Make Bézout coefficient expressions opaque for safe rewriting later
+    set r₁ := EuclideanDomain.gcdA a c * k₁
+    set s₁ := EuclideanDomain.gcdB a c * k₁
+    set r₂ := EuclideanDomain.gcdA b c * k₂
+    set s₂ := EuclideanDomain.gcdB b c * k₂
+    -- Subtract: r₁*a - r₂*b = (s₂ - s₁)*c
+    have hrab : r₁ * a - r₂ * b = (s₂ - s₁) * c := by
+      have heq := hM1.symm.trans hM2
+      calc r₁ * a - r₂ * b
+          = (r₁ * a + s₁ * c) - (r₂ * b + s₂ * c) + (s₂ - s₁) * c := by ring
+        _ = (r₂ * b + s₂ * c) - (r₂ * b + s₂ * c) + (s₂ - s₁) * c := by rw [heq]
+        _ = (s₂ - s₁) * c := by ring
+    -- Substitute a = g*α, b = g*β: g*(r₁*α - r₂*β) = (s₂-s₁)*c
+    have hgrab : g * (r₁ * α - r₂ * β) = (s₂ - s₁) * c := by
+      calc g * (r₁ * α - r₂ * β)
+          = r₁ * (g * α) - r₂ * (g * β) := by ring
+        _ = r₁ * a - r₂ * b := by rw [← hα, ← hβ]
+        _ = _ := hrab
+    -- Cancel d' from both sides: g'*(r₁*α - r₂*β) = (s₂-s₁)*c'
+    have hgrab' : g' * (r₁ * α - r₂ * β) = (s₂ - s₁) * c' := by
+      apply mul_left_cancel₀ hd'_ne
+      have hlhs : d' * (g' * (r₁ * α - r₂ * β)) = (s₂ - s₁) * c := by
+        calc d' * (g' * (r₁ * α - r₂ * β))
+            = (d' * g') * (r₁ * α - r₂ * β) := by ring
+          _ = g * (r₁ * α - r₂ * β) := by rw [← hg']
+          _ = (s₂ - s₁) * c := hgrab
+      have hrhs : d' * ((s₂ - s₁) * c') = (s₂ - s₁) * c := by
+        calc d' * ((s₂ - s₁) * c') = (s₂ - s₁) * (d' * c') := by ring
+          _ = (s₂ - s₁) * c := by rw [← hc']
+      exact hlhs.trans hrhs.symm
+    -- c' divides (r₁*α - r₂*β) via IsCoprime g' c'
+    have hc'_dvd : c' ∣ (r₁ * α - r₂ * β) := by
+      obtain ⟨u, v, huv⟩ := hcop_gc  -- u * g' + v * c' = 1
+      obtain ⟨k, hk⟩ : c' ∣ g' * (r₁ * α - r₂ * β) := by
+        rw [hgrab']; exact dvd_mul_left c' _
+      exact ⟨u * k + v * (r₁ * α - r₂ * β), by
+        calc r₁ * α - r₂ * β
+            = (r₁ * α - r₂ * β) * (u * g' + v * c') := by rw [huv, mul_one]
+          _ = u * (g' * (r₁ * α - r₂ * β)) + v * c' * (r₁ * α - r₂ * β) := by ring
+          _ = u * (c' * k) + v * c' * (r₁ * α - r₂ * β) := by rw [hk]
+          _ = c' * (u * k + v * (r₁ * α - r₂ * β)) := by ring⟩
+    obtain ⟨w, hw⟩ := hc'_dvd
+    -- β divides (r₁ - p_b * c' * w) via IsCoprime α β
+    obtain ⟨p_b, q_b, hpq⟩ := hcop_αβ
+    have hβ_dvd : β ∣ (r₁ - p_b * (c' * w)) := by
+      have hr₁α : r₁ * α = r₂ * β + c' * w := by
+        calc r₁ * α = (r₁ * α - r₂ * β) + r₂ * β := by ring
+          _ = c' * w + r₂ * β := by rw [hw]
+          _ = r₂ * β + c' * w := by ring
+      have hqβ : q_b * β = 1 - p_b * α := by
+        calc q_b * β = (p_b * α + q_b * β) - p_b * α := by ring
+          _ = 1 - p_b * α := by rw [hpq]
+      have key : (r₁ - p_b * (c' * w)) * α = (r₂ + q_b * (c' * w)) * β := by
+        calc (r₁ - p_b * (c' * w)) * α
+            = r₁ * α - p_b * (c' * w) * α := by ring
+          _ = (r₂ * β + c' * w) - p_b * (c' * w) * α := by rw [hr₁α]
+          _ = r₂ * β + c' * w * (1 - p_b * α) := by ring
+          _ = r₂ * β + c' * w * (q_b * β) := by rw [← hqβ]
+          _ = (r₂ + q_b * (c' * w)) * β := by ring
+      exact ⟨p_b * (r₂ + q_b * (c' * w)) + q_b * (r₁ - p_b * (c' * w)), by
+        calc r₁ - p_b * (c' * w)
+            = (r₁ - p_b * (c' * w)) * (p_b * α + q_b * β) := by rw [hpq, mul_one]
+          _ = p_b * ((r₁ - p_b * (c' * w)) * α) +
+              q_b * (r₁ - p_b * (c' * w)) * β := by ring
+          _ = p_b * ((r₂ + q_b * (c' * w)) * β) +
+              q_b * (r₁ - p_b * (c' * w)) * β := by rw [key]
+          _ = β * (p_b * (r₂ + q_b * (c' * w)) + q_b * (r₁ - p_b * (c' * w))) := by ring⟩
+    obtain ⟨m, hm⟩ := hβ_dvd
+    -- r₁ = m*β + p_b*c'*w
+    have hr₁ : r₁ = m * β + p_b * (c' * w) := by
+      calc r₁ = (r₁ - p_b * (c' * w)) + p_b * (c' * w) := by ring
+        _ = β * m + p_b * (c' * w) := by rw [hm]
+        _ = m * β + p_b * (c' * w) := by ring
+    -- Key identity: c' * g = c * g'
+    have hcg : c' * g = c * g' := by
+      calc c' * g = c' * (d' * g') := by rw [hg']
+        _ = (d' * c') * g' := by ring
+        _ = c * g' := by rw [← hc']
+    -- Decompose M = m*(g*α*β) + T*c  (safe: g, r₁, s₁ are opaque)
+    have hM_decomp :
+        EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c) =
+        m * (g * α * β) + (p_b * w * g' * α + s₁) * c := by
+      calc EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c)
+          = r₁ * a + s₁ * c := hM1
+        _ = r₁ * (g * α) + s₁ * c := by rw [hα]
+        _ = (m * β + p_b * (c' * w)) * (g * α) + s₁ * c := by rw [hr₁]
+        _ = m * (g * α * β) + p_b * w * α * (c' * g) + s₁ * c := by ring
+        _ = m * (g * α * β) + p_b * w * α * (c * g') + s₁ * c := by rw [hcg]
+        _ = m * (g * α * β) + (p_b * w * g' * α + s₁) * c := by ring
+    -- d | g*α*β  (since lcm(a,b) | g*α*β, and d | lcm(a,b))
+    have hd_gab : EuclideanDomain.gcd (EuclideanDomain.lcm a b) c ∣ g * α * β := by
+      refine dvd_trans (EuclideanDomain.gcd_dvd_left _ _) ?_
+      refine EuclideanDomain.lcm_dvd ?_ ?_
+      · -- a | g*α*β (safe: rw [hα] only affects standalone a, g is opaque)
+        rw [hα]; exact dvd_mul_right _ _
+      · -- b | g*α*β
+        exact ⟨α, by calc g * α * β = g * β * α := by ring
+          _ = b * α := by rw [← hβ]⟩
+    -- Conclude: d | M
+    rw [hM_decomp]
+    exact dvd_add
+      (hd_gab.mul_left m)
+      ((EuclideanDomain.gcd_dvd_right (EuclideanDomain.lcm a b) c).mul_left _)
 
 /-
 ## Part III: Three-Moduli CRT Sufficiency
@@ -208,20 +374,18 @@ theorem ed_crt_three_unique {m₁ m₂ m₃ a₁ a₂ a₃ x y : R}
 /-
 ## Summary
 
-### Theorems proved (0 axioms):
+### Theorems proved (0 axioms, 0 sorries):
 1. `gcd_dvd_of_dvd_sub` — gcd divisibility from full divisibility
 2. `gcd_dvd_sub_of_congr` — pairwise condition transfers through solution
 3. `lcm_gcd_dvd_gcd_lcm` — easy direction of distributive law
-4. `gcd_lcm_dvd_lcm_gcd` — hard direction (1 sorry: needs coprime decomposition)
+4. `gcd_lcm_dvd_lcm_gcd` — hard direction (PROVED via Bézout decomposition)
 5. `ed_crt_three_sufficient` — 3-moduli CRT sufficiency
 6. `ed_crt_three_iff` — full iff for 3 moduli
 7. `ed_crt_three_unique` — uniqueness for 3 moduli
 
-### Previous: 0 sorries, 1 axiom (gcd_lcm_distrib)
-### Current: 1 sorry (gcd_lcm_dvd_lcm_gcd), 0 axioms
-### Status: Axiom eliminated, sorry needs UFD factorization to formalize
-### Proof strategy: Reduce to IsCoprime V W where V=lcm(a,b)/M, W=c/M
-### Helper lemmas: See ChineseRemainderNonCoprimeOQ03Aristotle.lean (coprime_gcd_dvd_lcm_gcd etc.)
+### History: 1 axiom (gcd_lcm_distrib) → 1 sorry → 0 sorries (fully verified)
+### Status: COMPLETE — all theorems machine-checked, 0 axioms, 0 sorries
+### Proof technique: Direct Bézout expansion + coprime factoring through gcd(a,b) and gcd(gcd(a,b),c)
 -/
 
 end ChineseRemainderNonCoprimeOQ03


### PR DESCRIPTION
## Summary
- Proved the hard direction of the GCD-LCM distributive law: `gcd(lcm(a,b), c) | lcm(gcd(a,c), gcd(b,c))` for general EuclideanDomains
- This was the **sole remaining sorry** in `ChineseRemainderNonCoprimeOQ03.lean`
- File now has **0 axioms, 0 sorries** — fully machine-checked

## Proof Technique
Direct Bézout expansion + coprime factoring. Key insight: any common multiple of `gcd(a,c)` and `gcd(b,c)` can be written as `S * (g·α·β) + T * c` using:
1. Bézout representations via `gcd(a,c)` and `gcd(b,c)`
2. Coprime decomposition through `gcd(a,b)` (giving `IsCoprime α β`)
3. Coprime decomposition through `gcd(gcd(a,b), c)` (giving `IsCoprime g' c'`)

Since `gcd(lcm(a,b), c)` divides both `g·α·β` (via `lcm(a,b)`) and `c`, it divides the combination.

## Files Modified
- `proofs/Proofs/ChineseRemainderNonCoprimeOQ03.lean` — replaced sorry with ~180 lines of proof

## Status
**Outcome**: completed
**Result**: Full 3-moduli CRT (necessity, sufficiency, iff, uniqueness) verified

🤖 Generated by researcher-1