### PR TITLE
Enrich: fix significance values across entries

### DIFF
--- a/src/data/proofs/cauchy-schwarz/annotations.json
+++ b/src/data/proofs/cauchy-schwarz/annotations.json
@@ -3,132 +3,248 @@
     "id": "cs-imports",
     "proofId": "cauchy-schwarz",
     "type": "concept",
-    "range": { "startLine": 1, "endLine": 4 },
+    "range": {
+      "startLine": 1,
+      "endLine": 4
+    },
     "title": "Library Imports",
     "content": "Imports Mathlib for inner product spaces, Euclidean space ($\\mathbb{R}^n$ as `EuclideanSpace`), finite sums over `Finset`, and general tactics (`nlinarith`, `norm_num`, `simp`).",
     "mathContext": "The formalization uses `InnerProductSpace \\mathbb{R} E` for the abstract setting, `EuclideanSpace \\mathbb{R} (\\text{Fin}\\,n)` for finite-dimensional $\\mathbb{R}^n$, and `Finset.sum` for $\\sum_{i} a_i b_i$. The key Mathlib lemma `abs_real_inner_le_norm` provides the abstract Cauchy-Schwarz directly.",
     "significance": "supporting",
-    "relatedConcepts": ["inner product spaces", "Euclidean space", "finite sums"],
-    "prerequisites": ["Lean 4 basics", "Mathlib imports"]
+    "relatedConcepts": [
+      "inner product spaces",
+      "Euclidean space",
+      "finite sums"
+    ],
+    "prerequisites": [
+      "Lean 4 basics",
+      "Mathlib imports"
+    ]
   },
   {
     "id": "cs-inner-product",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 62, "endLine": 65 },
+    "range": {
+      "startLine": 62,
+      "endLine": 65
+    },
     "title": "Cauchy-Schwarz: Inner Product Form (Wiedijk #78)",
     "content": "For vectors $u, v$ in a real inner product space: $|\\langle u, v \\rangle_{\\mathbb{R}}| \\leq \\|u\\| \\cdot \\|v\\|$. This is the abstract, coordinate-free version. Proved by direct appeal to Mathlib's `abs_real_inner_le_norm`.",
     "mathContext": "cauchy_schwarz_inner$(u, v)$: $|\\langle u, v\\rangle_{\\mathbb{R}}| \\leq \\|u\\| \\cdot \\|v\\|$. The Mathlib proof uses the standard quadratic argument: $0 \\leq \\|u - tv\\|^2 = \\|u\\|^2 - 2t\\langle u,v\\rangle + t^2\\|v\\|^2$ has non-positive discriminant, yielding $\\langle u,v\\rangle^2 \\leq \\|u\\|^2\\|v\\|^2$. This is Wiedijk's 100 Theorems #78.",
-    "significance": "critical",
-    "relatedConcepts": ["abs_real_inner_le_norm", "inner product", "norm", "Wiedijk 100"],
-    "prerequisites": ["NormedAddCommGroup", "InnerProductSpace"]
+    "significance": "key",
+    "relatedConcepts": [
+      "abs_real_inner_le_norm",
+      "inner product",
+      "norm",
+      "Wiedijk 100"
+    ],
+    "prerequisites": [
+      "NormedAddCommGroup",
+      "InnerProductSpace"
+    ]
   },
   {
     "id": "cs-squared-form",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 70, "endLine": 79 },
+    "range": {
+      "startLine": 70,
+      "endLine": 79
+    },
     "title": "Cauchy-Schwarz: Squared Form",
     "content": "Equivalent formulation: $\\langle u, v\\rangle^2 \\leq \\langle u, u\\rangle \\cdot \\langle v, v\\rangle$. Derived from the norm form using $\\|u\\|^2 = \\langle u, u\\rangle$ (`real_inner_self_eq_norm_sq`).",
     "mathContext": "cauchy_schwarz_inner_sq$(u, v)$: $\\langle u, v\\rangle_{\\mathbb{R}}^2 \\leq \\langle u, u\\rangle_{\\mathbb{R}} \\cdot \\langle v, v\\rangle_{\\mathbb{R}}$. The proof chains: $\\langle u,v\\rangle^2 \\leq |\\langle u,v\\rangle|^2 \\leq (\\|u\\|\\|v\\|)^2 = \\|u\\|^2\\|v\\|^2 = \\langle u,u\\rangle\\langle v,v\\rangle$. Uses `sq_le_sq'` and `real_inner_self_eq_norm_sq`.",
     "significance": "key",
-    "relatedConcepts": ["squared inequality", "real_inner_self_eq_norm_sq", "sq_le_sq'"],
-    "prerequisites": ["cauchy_schwarz_inner", "inner product axioms"]
+    "relatedConcepts": [
+      "squared inequality",
+      "real_inner_self_eq_norm_sq",
+      "sq_le_sq'"
+    ],
+    "prerequisites": [
+      "cauchy_schwarz_inner",
+      "inner product axioms"
+    ]
   },
   {
     "id": "cs-two-variable",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 92, "endLine": 95 },
+    "range": {
+      "startLine": 92,
+      "endLine": 95
+    },
     "title": "Two-Variable Algebraic Form",
     "content": "For real numbers $a_1, a_2, b_1, b_2$: $(a_1 b_1 + a_2 b_2)^2 \\leq (a_1^2 + a_2^2)(b_1^2 + b_2^2)$. The direct algebraic proof uses $(a_1 b_2 - a_2 b_1)^2 \\geq 0$ via `sq_nonneg`, then `nlinarith` closes the gap.",
     "mathContext": "cauchy_schwarz_two: the difference $(a_1^2+a_2^2)(b_1^2+b_2^2) - (a_1b_1+a_2b_2)^2 = (a_1b_2-a_2b_1)^2 \\geq 0$ is the **Lagrange identity** for $n=2$. This elementary proof generalizes: for $n$ variables, the difference equals $\\sum_{i<j}(a_ib_j-a_jb_i)^2$.",
     "significance": "key",
-    "relatedConcepts": ["Lagrange identity", "sq_nonneg", "nlinarith", "elementary proof"],
-    "prerequisites": ["real number arithmetic", "sq_nonneg"]
+    "relatedConcepts": [
+      "Lagrange identity",
+      "sq_nonneg",
+      "nlinarith",
+      "elementary proof"
+    ],
+    "prerequisites": [
+      "real number arithmetic",
+      "sq_nonneg"
+    ]
   },
   {
     "id": "cs-two-eq",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 101, "endLine": 114 },
+    "range": {
+      "startLine": 101,
+      "endLine": 114
+    },
     "title": "Two-Variable Equality Condition",
     "content": "Equality in the two-variable case holds iff $a_1 b_2 = a_2 b_1$, i.e., vectors $(a_1, a_2)$ and $(b_1, b_2)$ are proportional. The proof shows $(a_1b_2 - a_2b_1)^2 = 0$ iff the cross term vanishes.",
     "mathContext": "cauchy_schwarz_two_eq_iff: $(a_1b_1+a_2b_2)^2 = (a_1^2+a_2^2)(b_1^2+b_2^2) \\iff a_1b_2 = a_2b_1$. Forward direction: equality forces $(a_1b_2-a_2b_1)^2 = 0$ via `sq_eq_zero_iff`. Reverse: zero cross product means the Lagrange identity residual vanishes.",
     "significance": "key",
-    "relatedConcepts": ["proportionality", "linear dependence", "sq_eq_zero_iff"],
-    "prerequisites": ["cauchy_schwarz_two", "Lagrange identity"]
+    "relatedConcepts": [
+      "proportionality",
+      "linear dependence",
+      "sq_eq_zero_iff"
+    ],
+    "prerequisites": [
+      "cauchy_schwarz_two",
+      "Lagrange identity"
+    ]
   },
   {
     "id": "cs-finite-sum",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 127, "endLine": 145 },
+    "range": {
+      "startLine": 127,
+      "endLine": 145
+    },
     "title": "Finite Sum Form",
     "content": "For sequences $a, b : \\text{Fin}\\,n \\to \\mathbb{R}$: $(\\sum_i a_i b_i)^2 \\leq (\\sum_i a_i^2)(\\sum_i b_i^2)$. The proof interprets sequences as vectors in `EuclideanSpace` and applies the squared inner product form.",
     "mathContext": "cauchy_schwarz_sum: embeds $a, b$ into `EuclideanSpace $\\mathbb{R}$ (Fin $n$)` where $\\langle u, v\\rangle = \\sum_i u_i v_i$ (via `EuclideanSpace.inner_eq_star_dotProduct`). Then $\\langle u,v\\rangle^2 \\leq \\langle u,u\\rangle\\langle v,v\\rangle$ translates directly to the sum inequality. This is the standard Cauchy (1821) formulation.",
-    "significance": "critical",
-    "relatedConcepts": ["EuclideanSpace", "dot product", "inner_eq_star_dotProduct", "Fin n"],
-    "prerequisites": ["cauchy_schwarz_inner_sq", "EuclideanSpace", "Finset.sum"]
+    "significance": "key",
+    "relatedConcepts": [
+      "EuclideanSpace",
+      "dot product",
+      "inner_eq_star_dotProduct",
+      "Fin n"
+    ],
+    "prerequisites": [
+      "cauchy_schwarz_inner_sq",
+      "EuclideanSpace",
+      "Finset.sum"
+    ]
   },
   {
     "id": "cs-sum-abs",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 150, "endLine": 157 },
+    "range": {
+      "startLine": 150,
+      "endLine": 157
+    },
     "title": "Finite Sum Non-Squared Form",
     "content": "Alternate form: $|\\sum_i a_i b_i| \\leq \\sqrt{\\sum_i a_i^2} \\cdot \\sqrt{\\sum_i b_i^2}$. Derived from the squared form via `Real.sqrt_le_sqrt` and `Real.sqrt_sq_eq_abs`.",
     "mathContext": "cauchy_schwarz_sum_abs: takes the square root of both sides of `cauchy_schwarz_sum`. Uses monotonicity of $\\sqrt{\\cdot}$ (`Real.sqrt_le_sqrt`) and $\\sqrt{x^2} = |x|$ (`Real.sqrt_sq_eq_abs`). Also uses $\\sqrt{ab} = \\sqrt{a}\\sqrt{b}$ via `Real.sqrt_mul`.",
     "significance": "supporting",
-    "relatedConcepts": ["square root monotonicity", "Real.sqrt_le_sqrt", "absolute value"],
-    "prerequisites": ["cauchy_schwarz_sum", "Real.sqrt properties"]
+    "relatedConcepts": [
+      "square root monotonicity",
+      "Real.sqrt_le_sqrt",
+      "absolute value"
+    ],
+    "prerequisites": [
+      "cauchy_schwarz_sum",
+      "Real.sqrt properties"
+    ]
   },
   {
     "id": "cs-equality-iff",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 164, "endLine": 179 },
+    "range": {
+      "startLine": 164,
+      "endLine": 179
+    },
     "title": "Equality iff Linear Dependence",
     "content": "For nonzero $u, v$: $|\\langle u, v\\rangle| = \\|u\\| \\cdot \\|v\\|$ iff $u = cv$ for some scalar $c$. Uses Mathlib's `norm_inner_eq_norm_iff` for the forward direction.",
     "mathContext": "cauchy_schwarz_eq_iff_parallel$(u, v, hu, hv)$: $|\\langle u,v\\rangle_{\\mathbb{R}}| = \\|u\\|\\|v\\| \\iff \\exists c: u = cv$. The forward direction uses `norm_inner_eq_norm_iff` which gives $u = r \\cdot v$ for some $r$, then inverts $r$. The reverse substitutes $u = cv$ and computes both sides using `inner_smul_left` and `real_inner_self_eq_norm_sq`.",
-    "significance": "critical",
-    "relatedConcepts": ["linear dependence", "norm_inner_eq_norm_iff", "scalar multiplication"],
-    "prerequisites": ["cauchy_schwarz_inner", "InnerProductSpace", "smul"]
+    "significance": "key",
+    "relatedConcepts": [
+      "linear dependence",
+      "norm_inner_eq_norm_iff",
+      "scalar multiplication"
+    ],
+    "prerequisites": [
+      "cauchy_schwarz_inner",
+      "InnerProductSpace",
+      "smul"
+    ]
   },
   {
     "id": "cs-examples",
     "proofId": "cauchy-schwarz",
     "type": "concept",
-    "range": { "startLine": 184, "endLine": 196 },
+    "range": {
+      "startLine": 184,
+      "endLine": 196
+    },
     "title": "Verified Numerical Examples",
     "content": "Three concrete verifications: (1) strict inequality $(1\\cdot2+3\\cdot4)^2 = 196 \\leq 200 = (1^2+3^2)(2^2+4^2)$; (2) equality $(1\\cdot2+2\\cdot4)^2 = 100 = (1^2+2^2)(2^2+4^2)$ when vectors are proportional; (3) $\\mathbb{R}^2$ specialization. All verified by `norm_num`.",
     "mathContext": "The strict case $(1,3)$ vs $(2,4)$: $\\det\\begin{pmatrix}1&2\\\\3&4\\end{pmatrix} = -2 \\neq 0$, so vectors are linearly independent and inequality is strict. The equality case $(1,2)$ vs $(2,4) = 2(1,2)$: determinant is zero, vectors are proportional.",
     "significance": "supporting",
-    "relatedConcepts": ["norm_num", "strict inequality", "proportional vectors"],
-    "prerequisites": ["cauchy_schwarz_two", "cauchy_schwarz_sum"]
+    "relatedConcepts": [
+      "norm_num",
+      "strict inequality",
+      "proportional vectors"
+    ],
+    "prerequisites": [
+      "cauchy_schwarz_two",
+      "cauchy_schwarz_sum"
+    ]
   },
   {
     "id": "cs-triangle",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 204, "endLine": 212 },
+    "range": {
+      "startLine": 204,
+      "endLine": 212
+    },
     "title": "Triangle Inequality via Cauchy-Schwarz",
     "content": "The triangle inequality $\\|u+v\\|^2 \\leq (\\|u\\|+\\|v\\|)^2$ follows from Cauchy-Schwarz. Expanding both sides, the comparison reduces to $\\langle u,v\\rangle \\leq |\\langle u,v\\rangle| \\leq \\|u\\|\\|v\\|$.",
     "mathContext": "triangle_sq_via_cauchy_schwarz: $\\|u+v\\|^2 = \\|u\\|^2 + 2\\langle u,v\\rangle + \\|v\\|^2 \\leq \\|u\\|^2 + 2\\|u\\|\\|v\\| + \\|v\\|^2 = (\\|u\\|+\\|v\\|)^2$. The middle step uses $\\langle u,v\\rangle \\leq |\\langle u,v\\rangle|$ (`le_abs_self`) then Cauchy-Schwarz. Uses `norm_add_sq_real` for the expansion.",
     "significance": "key",
-    "relatedConcepts": ["triangle inequality", "norm_add_sq_real", "le_abs_self"],
-    "prerequisites": ["cauchy_schwarz_inner", "norm expansion"]
+    "relatedConcepts": [
+      "triangle inequality",
+      "norm_add_sq_real",
+      "le_abs_self"
+    ],
+    "prerequisites": [
+      "cauchy_schwarz_inner",
+      "norm expansion"
+    ]
   },
   {
     "id": "cs-correlation",
     "proofId": "cauchy-schwarz",
     "type": "theorem",
-    "range": { "startLine": 219, "endLine": 224 },
+    "range": {
+      "startLine": 219,
+      "endLine": 224
+    },
     "title": "Correlation Coefficient Bound",
     "content": "For nonzero vectors: $|\\langle u,v\\rangle|/(\\|u\\|\\|v\\|) \\leq 1$. This is the mathematical reason the Pearson correlation coefficient satisfies $|\\rho| \\leq 1$.",
     "mathContext": "covariance_bound$(u, v, hu, hv)$: $\\frac{|\\langle u,v\\rangle_{\\mathbb{R}}|}{\\|u\\|\\|v\\|} \\leq 1$. Proved by `div_le_one` (since $\\|u\\|\\|v\\| > 0$ for nonzero vectors via `norm_pos_iff`) applied to Cauchy-Schwarz. In probability, for centered random variables $X, Y$: $\\text{Cov}(X,Y)^2 \\leq \\text{Var}(X)\\text{Var}(Y)$.",
     "significance": "key",
-    "relatedConcepts": ["correlation coefficient", "covariance", "div_le_one", "statistics"],
-    "prerequisites": ["cauchy_schwarz_inner", "norm_pos_iff"]
+    "relatedConcepts": [
+      "correlation coefficient",
+      "covariance",
+      "div_le_one",
+      "statistics"
+    ],
+    "prerequisites": [
+      "cauchy_schwarz_inner",
+      "norm_pos_iff"
+    ]
   }
 ]


### PR DESCRIPTION
Batch enrichment fixing invalid `"significance": "critical"` values to `"key"` across multiple gallery entries.

**Entries fixed in this PR:**
- `cauchy-schwarz` - 3 critical → key
- `binomial-theorem` - 1 critical → key
- `basel-problem` - 1 critical → key

**Previously fixed (via force-push, now superseded):**
- `amgm-inequality-oq-02` - 3 new annotations, fixed section overlaps, added cross-ref
- `abel-ruffini` - 4 critical → key, fixed duplicate annotation range
- `angle-trisection` - 5 critical → key
- `amgm-inequality` - added prerequisites, expanded cross-references

The `"critical"` significance value is not part of the valid annotation schema (`key|supporting|technical|context`). These were systematically replaced with `"key"` to match the schema.

Note: 1028 gallery entries have this issue. This PR addresses a representative sample.