### PR TITLE
Enrich gallery: fix alignments, add coverage, normalize relatedProofs (35 entries)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -227,25 +227,9 @@
     "definitionCount": 3
   },
   "relatedProofs": [
-    {
-      "id": "amgm-inequality",
-      "relationship": "extends",
-      "description": "Base AM-GM inequality — Maclaurin's chain refines it by providing n-1 intermediate inequalities between AM and GM"
-    },
-    {
-      "id": "amgm-inequality-oq-03",
-      "relationship": "related",
-      "description": "Power mean inequalities provide another refinement of AM-GM, connecting through different averaging methods"
-    },
-    {
-      "id": "cauchy-schwarz",
-      "relationship": "uses",
-      "description": "Cauchy-Schwarz sum inequality n·∑xᵢ² ≥ (∑xᵢ)² is the key engine for the M₁² ≥ M₂ proof"
-    },
-    {
-      "id": "binomial-theorem",
-      "relationship": "related",
-      "description": "Binomial coefficients C(n,k) normalize the elementary symmetric polynomials to form Maclaurin means Mₖ = (eₖ/C(n,k))^(1/k)"
-    }
+    "amgm-inequality",
+    "amgm-inequality-oq-03",
+    "cauchy-schwarz",
+    "binomial-theorem"
   ]
 }

--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -191,31 +191,11 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "derangements",
-      "relationship": "related",
-      "description": "Both are central combinatorial results; derangements use inclusion-exclusion which relies on binomial coefficients"
-    },
-    {
-      "id": "combinations-formula",
-      "relationship": "foundational",
-      "description": "Binomial coefficients C(n,k) are the key building blocks of the binomial theorem"
-    },
-    {
-      "id": "pascals-hexagon",
-      "relationship": "related",
-      "description": "Pascal's triangle encodes binomial coefficients; the hexagon theorem is about its multiplicative structure"
-    },
-    {
-      "id": "stirling-formula",
-      "relationship": "related",
-      "description": "Stirling's approximation is used to estimate binomial coefficients for large n"
-    },
-    {
-      "id": "binomial-theorem-oq-01",
-      "relationship": "extends",
-      "description": "Extension exploring further properties and applications of the binomial theorem"
-    }
+    "derangements",
+    "combinations-formula",
+    "pascals-hexagon",
+    "stirling-formula",
+    "binomial-theorem-oq-01"
   ],
   "references": [
     {

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -145,26 +145,10 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "area-of-circle",
-      "relationship": "technique",
-      "description": "Both involve integrating trigonometric functions connecting geometry to π; area of circle (πr²) and Buffon's probability (2ℓ/πd)"
-    },
-    {
-      "id": "birthday-problem",
-      "relationship": "related",
-      "description": "Both are classic probability problems with surprising answers — Buffon connects geometric randomness to π"
-    },
-    {
-      "id": "pi-transcendental",
-      "relationship": "related",
-      "description": "Buffon's needle provides a probabilistic method to estimate the transcendental number π"
-    },
-    {
-      "id": "stirling-formula",
-      "relationship": "related",
-      "description": "Stirling's formula appears in the asymptotic analysis of Buffon's needle experiments with many drops"
-    }
+    "area-of-circle",
+    "birthday-problem",
+    "pi-transcendental",
+    "stirling-formula"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -219,57 +219,11 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "cauchy-schwarz-integral",
-      "relationship": "extends",
-      "description": "The integral form of Cauchy-Schwarz: (∫fg)² ≤ (∫f²)(∫g²) — a continuous analogue of the finite sum version"
-    },
-    {
-      "id": "triangle-inequality",
-      "relationship": "related",
-      "description": "The triangle inequality for inner product spaces follows directly from Cauchy-Schwarz: ||u+v|| ≤ ||u|| + ||v||"
-    },
-    {
-      "id": "amgm-inequality",
-      "relationship": "related",
-      "description": "AM-GM implies Cauchy-Schwarz via 2ab ≤ a² + b²; both are fundamental tools in analysis"
-    },
-    {
-      "id": "cauchy-schwarz-oq-01",
-      "relationship": "extends",
-      "description": "Extension exploring applications and generalizations of Cauchy-Schwarz"
-    }
+    "cauchy-schwarz-integral",
+    "triangle-inequality",
+    "amgm-inequality",
+    "cauchy-schwarz-oq-01"
   ],
-  "references": [
-    {
-      "authors": "Cauchy, Augustin-Louis",
-      "title": "Cours d'analyse de l'École Royale Polytechnique",
-      "year": "1821",
-      "venue": "Paris: Debure",
-      "note": "Contains the finite sum version: (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²)"
-    },
-    {
-      "authors": "Schwarz, Hermann Amandus",
-      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung",
-      "year": "1885",
-      "venue": "Acta Societatis Scientiarum Fennicae 15, pp. 315-362",
-      "note": "Extended Cauchy's inequality to integrals: (∫fg)² ≤ (∫f²)(∫g²)"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.Analysis.InnerProductSpace.Basic",
-      "Mathlib.Analysis.InnerProductSpace.PiL2",
-      "Mathlib.Algebra.BigOperators.Ring.Finset",
-      "Mathlib.Tactic"
-    ],
-    "opens": [],
-    "namespace": "CauchySchwarz",
-    "lineCount": 232,
-    "axiomCount": 0,
-    "theoremCount": 9,
-    "definitionCount": 0
-  },
   "references": [
     {
       "authors": "Cauchy, Augustin-Louis",
@@ -292,5 +246,19 @@
       "venue": "Cambridge University Press",
       "note": "Comprehensive treatment of the inequality and its applications across mathematics"
     }
-  ]
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Algebra.BigOperators.Ring.Finset",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CauchySchwarz",
+    "lineCount": 232,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0
+  }
 }

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -208,26 +208,10 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "inclusion-exclusion",
-      "relationship": "uses",
-      "description": "The derangement count D_n = n!∑(-1)^k/k! is derived via inclusion-exclusion on fixed-point sets"
-    },
-    {
-      "id": "euler-totient",
-      "relationship": "related",
-      "description": "Both use Möbius-style inclusion-exclusion over divisor/subset lattices"
-    },
-    {
-      "id": "fundamental-arithmetic",
-      "relationship": "related",
-      "description": "Prime factorization underlies the Euler product form of the derangement subfactorial"
-    },
-    {
-      "id": "binomial-theorem",
-      "relationship": "uses",
-      "description": "Binomial coefficients C(n,k) appear in the inclusion-exclusion derivation of D_n"
-    }
+    "inclusion-exclusion",
+    "euler-totient",
+    "fundamental-arithmetic",
+    "binomial-theorem"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -133,61 +133,11 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "pi-transcendental",
-      "relationship": "related",
-      "description": "Lindemann (1882) extended Hermite's technique to prove π transcendental — settling squaring the circle"
-    },
-    {
-      "id": "hermite-lindemann",
-      "relationship": "related",
-      "description": "The full Hermite-Lindemann theorem generalizes e's transcendence: e^α is transcendental for algebraic α ≠ 0"
-    },
-    {
-      "id": "leibniz-pi",
-      "relationship": "related",
-      "description": "Leibniz series for π uses the same transcendental constant that Lindemann proved irrational"
-    },
-    {
-      "id": "euler-identity",
-      "relationship": "related",
-      "description": "Euler's identity e^(iπ) + 1 = 0 connects e and π — both transcendental by Hermite-Lindemann"
-    }
+    "pi-transcendental",
+    "hermite-lindemann",
+    "leibniz-pi",
+    "euler-identity"
   ],
-  "references": [
-    {
-      "authors": "Hermite, Charles",
-      "title": "Sur la fonction exponentielle",
-      "year": "1873",
-      "venue": "Comptes rendus de l'Académie des Sciences 77, pp. 18-24",
-      "note": "First proof that e is transcendental — the first number proven transcendental by construction (Liouville's 1844 examples were specifically designed)"
-    },
-    {
-      "authors": "Niven, Ivan",
-      "title": "Irrational Numbers",
-      "year": "1956",
-      "venue": "Carus Mathematical Monographs #11, MAA",
-      "note": "Standard reference for transcendence proofs including Hermite's method and the Lindemann-Weierstrass theorem"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.RingTheory.Algebraic.Basic",
-      "Mathlib.Analysis.SpecialFunctions.ExpDeriv",
-      "Mathlib.Analysis.SpecialFunctions.Complex.Analytic",
-      "Mathlib.Data.Real.Irrational",
-      "Mathlib.Data.Complex.ExponentialBounds"
-    ],
-    "opens": [
-      "Real",
-      "Polynomial"
-    ],
-    "namespace": null,
-    "lineCount": 268,
-    "axiomCount": 5,
-    "theoremCount": 8,
-    "definitionCount": 0
-  },
   "references": [
     {
       "authors": "Hermite, Charles",
@@ -210,5 +160,23 @@
       "venue": "Cambridge University Press",
       "note": "Standard reference for transcendence methods including Hermite's approach and its generalizations"
     }
-  ]
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Algebraic.Basic",
+      "Mathlib.Analysis.SpecialFunctions.ExpDeriv",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Analytic",
+      "Mathlib.Data.Real.Irrational",
+      "Mathlib.Data.Complex.ExponentialBounds"
+    ],
+    "opens": [
+      "Real",
+      "Polynomial"
+    ],
+    "namespace": null,
+    "lineCount": 268,
+    "axiomCount": 5,
+    "theoremCount": 8,
+    "definitionCount": 0
+  }
 }

--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -131,22 +131,10 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "erdos-101",
-      "relationship": "Problem #101 asks whether four-point lines are $o(n^2)$ for no-five-collinear sets. Problem #102's divergence would imply Problem #101's answer is yes, via the bridge axiom `connection_101`."
-    },
-    {
-      "id": "erdos-588",
-      "relationship": "Problem #588 generalizes to $k$-rich lines: is $f_k(n) = o(n^2)$ for $k \\ge 4$? Problem #101 is the $k=4$ case, and Problem #102 studies the dual question of maximum collinear count."
-    },
-    {
-      "id": "erdos-669",
-      "relationship": "The Orchard Problem (#669) studies $f_k(n)$ (lines through exactly $k$ points) and $F_k(n)$ (lines through at least $k$ points). For $k=3$, the answer is $n^2/6 - O(n)$ (Burr–Grünbaum–Sloane 1974). The $k \\ge 4$ case connects to Problems #101, #102, and #588."
-    },
-    {
-      "id": "desargues-theorem",
-      "relationship": "Desargues's theorem is foundational to projective incidence geometry; the collinearity and concurrence duality underlying Problems #101–#102 extends the same perspective-line framework."
-    }
+    "erdos-101",
+    "erdos-588",
+    "erdos-669",
+    "desargues-theorem"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -183,21 +183,9 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "erdos-382",
-      "relationship": "directly-related",
-      "description": "A positive answer to #383 (k=1 case) directly resolves Part 2 of #382 about primes where all factors of p²+1 are ≤ p"
-    },
-    {
-      "id": "erdos-334",
-      "relationship": "related",
-      "description": "Both involve smooth numbers: #334 asks about sums of smooth numbers, #383 asks about smooth numbers near prime squares"
-    },
-    {
-      "id": "erdos-368",
-      "relationship": "related",
-      "description": "Both concern the largest prime factor of products of consecutive integers: #368 studies P(n(n+1)), #383 studies P(∏(p²+i))"
-    }
+    "erdos-382",
+    "erdos-334",
+    "erdos-368"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-487/meta.json
+++ b/src/data/proofs/erdos-487/meta.json
@@ -129,11 +129,7 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "erdos-483",
-      "relationship": "related",
-      "description": "Both are Erdős problems about structure forced by density: #483 studies Schur numbers (monochromatic a+b=c in colorings), #487 studies LCM triples in dense sets"
-    }
+    "erdos-483"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-519/meta.json
+++ b/src/data/proofs/erdos-519/meta.json
@@ -160,14 +160,8 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "erdos-973",
-      "relationship": "Erdős Problem #973 studies the dual question: how small can $\\max_k |\\sum z_i^k|$ be when $|z_i| \\ge 1$? Both problems arise from Turán's power sum method"
-    },
-    {
-      "id": "de-moivre",
-      "relationship": "De Moivre's formula underpins the roots of unity analysis: $e^{2\\pi i k/n}$ raised to powers exhibits the periodic cancellation central to understanding power sum extremals"
-    }
+    "erdos-973",
+    "de-moivre"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-55/meta.json
+++ b/src/data/proofs/erdos-55/meta.json
@@ -109,34 +109,13 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "erdos-54",
-      "relationship": "Sibling problem — Erdős #54 focuses on the r=2 case of Ramsey completeness, also solved by Conlon-Fox-Pham (2021)"
-    },
-    {
-      "id": "ramseys-theorem",
-      "relationship": "Foundational — Ramsey's theorem provides the partition-theoretic framework underlying the notion of Ramsey r-completeness"
-    },
-    {
-      "id": "erdos-546",
-      "relationship": "Related Ramsey bound — asks whether R(G) ≤ 2^{O(√m)} for graphs with m edges, sharing Ramsey-theoretic growth rate analysis"
-    },
-    {
-      "id": "szemeredi-theorem",
-      "relationship": "Additive combinatorics — Szemerédi's theorem on arithmetic progressions in dense sets shares the density-vs-structure paradigm"
-    },
-    {
-      "id": "erdos-88",
-      "relationship": "Ramsey graph structure — studies induced subgraphs in Ramsey graphs, related through structural Ramsey theory"
-    },
-    {
-      "id": "erdos-87",
-      "relationship": "Ramsey-chromatic connection — relates chromatic number to Ramsey numbers, sharing the coloring framework"
-    },
-    {
-      "id": "erdos-szekeres",
-      "relationship": "Classical Ramsey application — the Erdős-Szekeres theorem on monotonic subsequences uses pigeonhole/Ramsey arguments"
-    }
+    "erdos-54",
+    "ramseys-theorem",
+    "erdos-546",
+    "szemeredi-theorem",
+    "erdos-88",
+    "erdos-87",
+    "erdos-szekeres"
   ],
   "references": [
     "Burr, S.A. and Erdős, P. (1985). 'On a Ramsey-type problem in additive number theory.' J. Combin. Theory Ser. A, 40(1), 39–63.",

--- a/src/data/proofs/erdos-562/meta.json
+++ b/src/data/proofs/erdos-562/meta.json
@@ -104,34 +104,13 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "erdos-564",
-      "relationship": "Sibling problem — addresses 3-uniform hypergraph Ramsey numbers R₃(n) with the same tower function framework"
-    },
-    {
-      "id": "ramseys-theorem",
-      "relationship": "Foundational — Ramsey's theorem provides the existence guarantee for monochromatic substructures that underlies the entire hypergraph Ramsey hierarchy"
-    },
-    {
-      "id": "erdos-546",
-      "relationship": "Graph Ramsey variant — studies R(G) ≤ 2^{O(√m)} for graphs with m edges, sharing exponential-growth analysis at the r=2 level"
-    },
-    {
-      "id": "erdos-545",
-      "relationship": "Ramsey number optimization — asks which graphs maximize Ramsey numbers, complementing the hypergraph growth rate question"
-    },
-    {
-      "id": "erdos-szekeres",
-      "relationship": "Classical foundation — the Erdős-Szekeres theorem on monotonic subsequences uses the same pigeonhole/Ramsey principles"
-    },
-    {
-      "id": "erdos-55",
-      "relationship": "Ramsey + additive combinatorics — growth rate characterization of Ramsey r-complete sets shares the density analysis paradigm"
-    },
-    {
-      "id": "erdos-500",
-      "relationship": "Hypergraph extremal theory — Turán density of K₄³ studies 3-uniform hypergraph extremal problems with related methodology"
-    }
+    "erdos-564",
+    "ramseys-theorem",
+    "erdos-546",
+    "erdos-545",
+    "erdos-szekeres",
+    "erdos-55",
+    "erdos-500"
   ],
   "references": [
     "Erdős, P., Hajnal, A., and Rado, R. (1965). 'Partition relations for cardinal numbers.' Acta Math. Acad. Sci. Hungar., 16, 93–196.",

--- a/src/data/proofs/erdos-577/meta.json
+++ b/src/data/proofs/erdos-577/meta.json
@@ -131,30 +131,12 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "erdos-622",
-      "relationship": "Same density regime — cycle-spanning subsets in regular graphs on 2n vertices with degree n+1, using Dirac's theorem and absorbing method"
-    },
-    {
-      "id": "erdos-570",
-      "relationship": "Cycle Ramsey numbers — R(C_k, H) bounds for cycles vs arbitrary graphs, sharing the cycle-theoretic framework"
-    },
-    {
-      "id": "erdos-572",
-      "relationship": "Extremal even cycle theory — lower bounds for ex(n; C_{2k}), studying how many edges force even cycles"
-    },
-    {
-      "id": "erdos-599",
-      "relationship": "Vertex-disjoint paths — Erdős-Menger conjecture extends Menger's theorem, sharing the vertex-disjoint covering paradigm"
-    },
-    {
-      "id": "erdos-546",
-      "relationship": "Graph Ramsey bounds — R(G) ≤ 2^{O(√m)} uses similar extremal graph theory tools"
-    },
-    {
-      "id": "erdos-579",
-      "relationship": "Dense graph structure — independent sets in K₂,₂,₂-free dense graphs share the minimum degree threshold analysis"
-    }
+    "erdos-622",
+    "erdos-570",
+    "erdos-572",
+    "erdos-599",
+    "erdos-546",
+    "erdos-579"
   ],
   "references": [
     "Wang, H. (2010). 'Proof of the Erdős-Faudree conjecture on quadrilaterals.' Graphs and Combinatorics, 26(6), 833–877.",

--- a/src/data/proofs/erdos-578/meta.json
+++ b/src/data/proofs/erdos-578/meta.json
@@ -172,11 +172,7 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "ramseys-theorem",
-      "relationship": "related",
-      "description": "Ramsey theory — guaranteed substructures in combinatorial objects"
-    }
+    "ramseys-theorem"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-596/meta.json
+++ b/src/data/proofs/erdos-596/meta.json
@@ -152,11 +152,7 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "ramseys-theorem",
-      "relationship": "foundational",
-      "description": "Classical Ramsey theorem — the finite Ramsey property generalizes Ramsey's theorem to forbidden subgraph classes"
-    }
+    "ramseys-theorem"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-603/meta.json
+++ b/src/data/proofs/erdos-603/meta.json
@@ -181,11 +181,7 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "ramseys-theorem",
-      "relationship": "related",
-      "description": "Ramsey theory — foundational coloring/partition result; #603 extends this paradigm to hypergraph vertex coloring with intersection constraints"
-    }
+    "ramseys-theorem"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -154,10 +154,7 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "erdos-620",
-      "relationship": "Both address threshold phenomena in infinite combinatorics—erdos-620 concerns Ramsey-type bounds while erdos-623 concerns independence at singular cardinals"
-    }
+    "erdos-620"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -161,10 +161,7 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "erdos-613",
-      "relationship": "Both involve Ramsey-theoretic phenomena in graph theory—erdos-613 addresses size Ramsey numbers while erdos-627 uses Ramsey bounds to constrain the χ/ω limit"
-    }
+    "erdos-613"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -119,26 +119,11 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "four-color-theorem",
-      "relationship": "The Four Color Theorem shows $\\chi \\leq 4$ for planar graphs; Thomassen (1994) proved the stronger result that planar graphs are 5-choosable, connecting ordinary and list coloring"
-    },
-    {
-      "id": "erdos-87",
-      "relationship": "Erdős Problem #87 relates Ramsey numbers to chromatic numbers; both problems explore how graph-theoretic parameters constrain each other in unexpected ways"
-    },
-    {
-      "id": "erdos-60",
-      "relationship": "Erdős Problem #60 on supersaturation also involves extremal thresholds for graph properties, sharing the flavor of determining the minimal structure forcing a given property"
-    },
-    {
-      "id": "randomized-maxcut",
-      "relationship": "Both formalizations involve the probabilistic method applied to graph coloring/partition problems — MaxCut uses random vertex partition, while this uses random color partition"
-    },
-    {
-      "id": "ramseys-theorem",
-      "relationship": "Ramsey's theorem and list coloring both involve adversarial coloring arguments where structure must persist regardless of how colors are assigned"
-    }
+    "four-color-theorem",
+    "erdos-87",
+    "erdos-60",
+    "randomized-maxcut",
+    "ramseys-theorem"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -137,11 +137,7 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "erdos-678",
-      "relationship": "related",
-      "description": "Problem #678 studies LCM of consecutive integers — complementary to #686's ratio of products formulation"
-    }
+    "erdos-678"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-71/meta.json
+++ b/src/data/proofs/erdos-71/meta.json
@@ -159,11 +159,7 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "erdos-219",
-      "relationship": "related",
-      "description": "Both concern arithmetic progressions: #219 in prime numbers, #71 in cycle lengths of graphs"
-    }
+    "erdos-219"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-759/meta.json
+++ b/src/data/proofs/erdos-759/meta.json
@@ -204,11 +204,7 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "erdos-760",
-      "relationship": "related",
-      "description": "Consecutive Erdős problem in the surface graph theory family"
-    }
+    "erdos-760"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -109,14 +109,8 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "ramseys-theorem",
-      "relationship": "Both problems involve extremal combinatorics where optimal configurations emerge from simple structures (primes for sieving, monochromatic cliques for Ramsey)."
-    },
-    {
-      "id": "erdos-szekeres",
-      "relationship": "The Erdős–Szekeres theorem and this sieve problem both ask for optimal configurations in a combinatorial setting with a resource constraint."
-    }
+    "ramseys-theorem",
+    "erdos-szekeres"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-784/meta.json
+++ b/src/data/proofs/erdos-784/meta.json
@@ -215,11 +215,7 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "erdos-760",
-      "relationship": "related",
-      "description": "Nearby Erdős problem in the number-theoretic sieving family"
-    }
+    "erdos-760"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -111,22 +111,10 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "erdos-1",
-      "relationship": "Erdős Problem #1 studies distinct subset sums from the dual perspective: given $A \\subseteq \\{1,\\ldots,N\\}$ with all $2^n$ subset sums distinct, how large must $N$ be? Both problems concern the injectivity of the subset-sum map."
-    },
-    {
-      "id": "erdos-954",
-      "relationship": "Rosen's greedy additive sequence also employs a greedy algorithm to control representation counts, mirroring the greedy construction in the dissociated subset lower bound."
-    },
-    {
-      "id": "erdos-949",
-      "relationship": "Sum-free sets and Sidon sets share the additive structure constraints of dissociated sets; the Sidon condition (distinct pairwise sums) is a weakening of the dissociated condition (distinct all-subset sums)."
-    },
-    {
-      "id": "erdos-948",
-      "relationship": "Hindman-type problems on subset sums and colorings explore the Ramsey-theoretic side of subset-sum structures, complementing the extremal perspective of dissociated sets."
-    }
+    "erdos-1",
+    "erdos-954",
+    "erdos-949",
+    "erdos-948"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -118,18 +118,9 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "erdos-976",
-      "relationship": "Problem #976 studies the greatest prime factor of polynomial products $\\prod_{m=1}^n f(m)$ — the polynomial analogue of the exponential sequence $2^n - 1$. Both problems use sieve methods and transcendental number theory."
-    },
-    {
-      "id": "erdos-728-factorial-divisibility",
-      "relationship": "Erdős #728 on factorial divisibility connects via the $P(n!+1)$ open problem stated in this formalization; both explore prime factor behavior near factorials."
-    },
-    {
-      "id": "erdos-970",
-      "relationship": "Jacobsthal's function studies gaps between integers coprime to a given modulus — a different perspective on how primes interact with multiplicative structure, relevant to the coprimality analysis in Zsygmondy's theorem."
-    }
+    "erdos-976",
+    "erdos-728-factorial-divisibility",
+    "erdos-970"
   ],
   "leanFile": {
     "imports": [],

--- a/src/data/proofs/euler-polyhedral-formula/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula/meta.json
@@ -93,36 +93,24 @@
     ]
   },
   "relatedProofs": [
-    {
-      "id": "platonic-solids",
-      "relationship": "related",
-      "description": "The classification of Platonic solids uses Euler's formula V-E+F=2 as a key constraint"
-    },
-    {
-      "id": "euler-polyhedral-formula-oq-02",
-      "relationship": "extends",
-      "description": "Extension exploring further applications of Euler's formula"
-    },
-    {
-      "id": "picks-theorem",
-      "relationship": "related",
-      "description": "Pick's theorem relates lattice point counts to area; both are fundamental results connecting combinatorics to geometry"
-    }
+    "platonic-solids",
+    "euler-polyhedral-formula-oq-02",
+    "picks-theorem"
   ],
   "references": [
     {
       "authors": "Euler, Leonhard",
       "title": "Elementa doctrinae solidorum",
       "year": "1758",
-      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae 4, pp. 109-140",
-      "note": "Euler's original statement of V - E + F = 2 for convex polyhedra"
+      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae 4, 109–140",
+      "note": "Original statement of V - E + F = 2 for convex polyhedra"
     },
     {
       "authors": "Lakatos, Imre",
-      "title": "Proofs and Refutations: The Logic of Mathematical Discovery",
+      "title": "Proofs and Refutations",
       "year": "1976",
       "venue": "Cambridge University Press",
-      "note": "Classic study of the evolution of Euler's formula through successive counterexamples and refinements"
+      "note": "Famous philosophical analysis of the history and proof of Euler's formula, using it to illustrate the nature of mathematical discovery"
     }
   ],
   "leanFile": {
@@ -145,21 +133,5 @@
     "axiomCount": 1,
     "theoremCount": 65,
     "definitionCount": 27
-  },
-  "references": [
-    {
-      "authors": "Euler, Leonhard",
-      "title": "Elementa doctrinae solidorum",
-      "year": "1758",
-      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae 4, 109–140",
-      "note": "Original statement of V - E + F = 2 for convex polyhedra"
-    },
-    {
-      "authors": "Lakatos, Imre",
-      "title": "Proofs and Refutations",
-      "year": "1976",
-      "venue": "Cambridge University Press",
-      "note": "Famous philosophical analysis of the history and proof of Euler's formula, using it to illustrate the nature of mathematical discovery"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -127,14 +127,8 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "ramseys-theorem",
-      "relationship": "Both involve graph coloring and combinatorial arguments on graph structure"
-    },
-    {
-      "id": "erdos-807",
-      "relationship": "Both involve graph decomposition problems — bipartite decomposition vs chromatic decomposition"
-    }
+    "ramseys-theorem",
+    "erdos-807"
   ],
   "references": [
     {

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -204,46 +204,6 @@
       "authors": "Fourier, Joseph",
       "title": "Théorie analytique de la chaleur",
       "year": "1822",
-      "venue": "Firmin Didot, Paris",
-      "note": "Founding work where Fourier introduced trigonometric series representations of functions to solve the heat equation"
-    },
-    {
-      "authors": "Carleson, Lennart",
-      "title": "On convergence and growth of partial sums of Fourier series",
-      "year": "1966",
-      "venue": "Acta Mathematica 116(1), 135–157",
-      "note": "Proved that Fourier series of L² functions converge pointwise almost everywhere — a landmark in harmonic analysis"
-    },
-    {
-      "authors": "Katznelson, Yitzhak",
-      "title": "An Introduction to Harmonic Analysis",
-      "year": "2004",
-      "venue": "Cambridge University Press, 3rd edition",
-      "note": "Modern treatment of Fourier series convergence, Fejér's theorem, and related topics in harmonic analysis"
-    }
-  ],
-  "relatedProofs": [
-    {
-      "id": "basel-problem",
-      "relationship": "related",
-      "description": "Parseval's theorem applied to f(x)=x on [-π,π] proves the Basel identity ∑1/n² = π²/6"
-    },
-    {
-      "id": "area-of-circle-oq-01-oq-02-oq-02",
-      "relationship": "related",
-      "description": "Fourier coefficient derivative formula ĉₙ(f') = in·ĉₙ(f) — key infrastructure for the isoperimetric inequality"
-    },
-    {
-      "id": "isoperimetric-theorem",
-      "relationship": "related",
-      "description": "Hurwitz's 1902 Fourier-analytic proof of L² ≥ 4πA uses Fourier series and Parseval's identity"
-    }
-  ],
-  "references": [
-    {
-      "authors": "Fourier, Joseph",
-      "title": "Théorie analytique de la chaleur",
-      "year": "1822",
       "venue": "Paris: Firmin Didot",
       "note": "Foundational work introducing the representation of functions as trigonometric series"
     },
@@ -254,5 +214,10 @@
       "venue": "Acta Mathematica 116, pp. 135-157",
       "note": "Proved pointwise convergence of Fourier series for L² functions"
     }
+  ],
+  "relatedProofs": [
+    "basel-problem",
+    "area-of-circle-oq-01-oq-02-oq-02",
+    "isoperimetric-theorem"
   ]
 }

--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -156,57 +156,11 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "abel-ruffini",
-      "relationship": "complementary",
-      "description": "FTA guarantees every polynomial has complex roots; Abel-Ruffini shows those roots cannot always be expressed by radicals for degree ≥ 5"
-    },
-    {
-      "id": "angle-trisection",
-      "relationship": "related",
-      "description": "FTA guarantees the trisection polynomial 8x³-6x-1 has roots; the impossibility is about constructibility, not existence"
-    },
-    {
-      "id": "inverse-galois",
-      "relationship": "related",
-      "description": "FTA implies every finite group occurs as a quotient of the absolute Galois group of ℚ — the starting point of the inverse Galois problem"
-    },
-    {
-      "id": "solution-of-cubic",
-      "relationship": "related",
-      "description": "Cardano's formula gives explicit roots for cubics; FTA guarantees their existence without constructive extraction"
-    }
+    "abel-ruffini",
+    "angle-trisection",
+    "inverse-galois",
+    "solution-of-cubic"
   ],
-  "references": [
-    {
-      "authors": "Gauss, Carl Friedrich",
-      "title": "Demonstratio nova theorematis omnem functionem algebraicam rationalem integram unius variabilis in factores reales primi vel secundi gradus resolvi posse",
-      "year": "1799",
-      "venue": "Doctoral dissertation, University of Helmstedt",
-      "note": "Gauss's first proof of FTA — he gave four proofs total throughout his career"
-    },
-    {
-      "authors": "Fine, Benjamin; Rosenberger, Gerhard",
-      "title": "The Fundamental Theorem of Algebra",
-      "year": "1997",
-      "venue": "Springer Undergraduate Texts in Mathematics",
-      "note": "Modern exposition covering algebraic, analytic, and topological proofs of FTA"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.Analysis.Complex.Polynomial.Basic",
-      "Mathlib.Algebra.Polynomial.Basic",
-      "Mathlib.Algebra.Polynomial.Degree.Definitions",
-      "Mathlib.FieldTheory.IsAlgClosed.Basic"
-    ],
-    "opens": [],
-    "namespace": "FundamentalTheoremAlgebra",
-    "lineCount": 214,
-    "axiomCount": 0,
-    "theoremCount": 4,
-    "definitionCount": 0
-  },
   "references": [
     {
       "authors": "Gauss, Carl Friedrich",
@@ -222,5 +176,19 @@
       "venue": "Springer Undergraduate Texts in Mathematics",
       "note": "Collects and presents multiple proofs — algebraic, analytic, and topological"
     }
-  ]
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Complex.Polynomial.Basic",
+      "Mathlib.Algebra.Polynomial.Basic",
+      "Mathlib.Algebra.Polynomial.Degree.Definitions",
+      "Mathlib.FieldTheory.IsAlgClosed.Basic"
+    ],
+    "opens": [],
+    "namespace": "FundamentalTheoremAlgebra",
+    "lineCount": 214,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0
+  }
 }

--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -170,26 +170,10 @@
     "definitionCount": 1
   },
   "relatedProofs": [
-    {
-      "id": "e-transcendental",
-      "relationship": "specializes",
-      "description": "e's transcendence is the α=1 case: e^1 = e is transcendental since 1 is algebraic and nonzero"
-    },
-    {
-      "id": "pi-transcendental",
-      "relationship": "specializes",
-      "description": "π's transcendence follows: if π were algebraic, e^(iπ) = -1 would be transcendental by H-L, contradiction"
-    },
-    {
-      "id": "angle-trisection",
-      "relationship": "related",
-      "description": "H-L proves π transcendental, which proves squaring the circle is impossible"
-    },
-    {
-      "id": "gelfond-schneider",
-      "relationship": "related",
-      "description": "Gelfond-Schneider (1934) extends H-L: a^b is transcendental for algebraic a≠0,1 and irrational algebraic b"
-    }
+    "e-transcendental",
+    "pi-transcendental",
+    "angle-trisection",
+    "gelfond-schneider"
   ],
   "references": [
     {

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -142,41 +142,32 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "infinitude-primes",
-      "relationship": "extends",
-      "description": "Euclid proved infinitely many primes exist; PNT quantifies their asymptotic density as π(x) ~ x/ln(x)"
-    },
-    {
-      "id": "riemann-hypothesis",
-      "relationship": "related",
-      "description": "RH would give the best possible error term in PNT: π(x) = Li(x) + O(√x·log x)"
-    },
-    {
-      "id": "basel-problem",
-      "relationship": "related",
-      "description": "Both involve the Riemann zeta function — Basel gives ζ(2) = π²/6, PNT uses the non-vanishing of ζ on Re(s)=1"
-    },
-    {
-      "id": "prime-reciprocal-divergence",
-      "relationship": "related",
-      "description": "∑1/p diverges — a consequence of PNT since primes have density ~1/ln(n)"
-    }
+    "infinitude-primes",
+    "riemann-hypothesis",
+    "basel-problem",
+    "prime-reciprocal-divergence"
   ],
   "references": [
     {
       "authors": "Hadamard, Jacques",
       "title": "Sur la distribution des zéros de la fonction ζ(s) et ses conséquences arithmétiques",
       "year": "1896",
-      "venue": "Bulletin de la Société Mathématique de France 24, pp. 199-220",
-      "note": "One of the two independent proofs of PNT in 1896, using the non-vanishing of ζ(s) on the line Re(s)=1"
+      "venue": "Bulletin de la Société Mathématique de France 24, 199–220",
+      "note": "Independent proof (with de la Vallée Poussin) of the Prime Number Theorem: π(x) ~ x/ln(x)"
     },
     {
       "authors": "de la Vallée Poussin, Charles-Jean",
       "title": "Recherches analytiques sur la théorie des nombres premiers",
       "year": "1896",
-      "venue": "Annales de la Société scientifique de Bruxelles 20, pp. 183-256",
-      "note": "The other independent proof of PNT in 1896, also using complex analysis and ζ(s)"
+      "venue": "Annales de la Société Scientifique de Bruxelles 20, 183–256",
+      "note": "Independent proof of PNT in the same year as Hadamard, using non-vanishing of ζ(1+it)"
+    },
+    {
+      "authors": "Selberg, Atle",
+      "title": "An elementary proof of the prime-number theorem",
+      "year": "1949",
+      "venue": "Annals of Mathematics 50(2), 305–313",
+      "note": "Elementary proof avoiding complex analysis — alongside Erdős's independent elementary proof"
     }
   ],
   "leanFile": {
@@ -206,28 +197,5 @@
     "axiomCount": 13,
     "theoremCount": 15,
     "definitionCount": 9
-  },
-  "references": [
-    {
-      "authors": "Hadamard, Jacques",
-      "title": "Sur la distribution des zéros de la fonction ζ(s) et ses conséquences arithmétiques",
-      "year": "1896",
-      "venue": "Bulletin de la Société Mathématique de France 24, 199–220",
-      "note": "Independent proof (with de la Vallée Poussin) of the Prime Number Theorem: π(x) ~ x/ln(x)"
-    },
-    {
-      "authors": "de la Vallée Poussin, Charles-Jean",
-      "title": "Recherches analytiques sur la théorie des nombres premiers",
-      "year": "1896",
-      "venue": "Annales de la Société Scientifique de Bruxelles 20, 183–256",
-      "note": "Independent proof of PNT in the same year as Hadamard, using non-vanishing of ζ(1+it)"
-    },
-    {
-      "authors": "Selberg, Atle",
-      "title": "An elementary proof of the prime-number theorem",
-      "year": "1949",
-      "venue": "Annals of Mathematics 50(2), 305–313",
-      "note": "Elementary proof avoiding complex analysis — alongside Erdős's independent elementary proof"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -154,20 +154,8 @@
     }
   ],
   "relatedProofs": [
-    {
-      "id": "lagrange-theorem",
-      "relationship": "foundational",
-      "description": "Lagrange's theorem (|H| divides |G|) is a prerequisite; Sylow I provides a partial converse for prime power divisors"
-    },
-    {
-      "id": "abel-ruffini-oq-04",
-      "relationship": "related",
-      "description": "Sylow theory provides structural information about A₅: its Sylow subgroups witness |A₅| = 60 = 2²·3·5 and help prove simplicity"
-    },
-    {
-      "id": "angle-trisection-oq-02",
-      "relationship": "related",
-      "description": "Sylow theory for 2-groups underlies the constructibility characterization — constructible numbers have 2-group Galois groups"
-    }
+    "lagrange-theorem",
+    "abel-ruffini-oq-04",
+    "angle-trisection-oq-02"
   ]
 }


### PR DESCRIPTION
## Summary

### Batch normalization (35 entries)
- Convert `relatedProofs` from object array `[{id, relationship, description}]` to string array `["id1", "id2"]` across 35 gallery entries
- This information was redundant with `crossReferences` which already stores relationship details
- Net reduction: ~500 lines of duplicated structure

### abel-ruffini (annotations.source.json)
- Fix `ann-solvable-by-rad` and `ann-a5-simple` anchor alignment
- Add `ann-symmetric-not-solvable` and `ann-exists-quintic` (9→11 annotations)
- Add Jordan's *Traité des substitutions* (1870) reference

### angle-trisection
- Add `ann-derivation` and `ann-irreducibility-axiom-and-lindemann` (14→16 annotations)
- Expand `ann-wantzel-axiom` range; add Gauss reference

### amgm-inequality-oq-02
- Add `ann-amgm-oq02-castsucc-infra` and `ann-amgm-oq02-structural` (8→10 annotations)

### amgm-inequality-oq-03
- Add cross-reference to oq-01; expand openQuestions 2→4

### amgm-inequality-oq-03-oq-01
- Move `crossReferences` and `relatedProofs` from nested `meta` to top level

### angle-trisection-oq-02
- Add missing `relatedProofs` array

## Test plan
- [x] All 35 modified meta.json files validate as JSON
- [x] `npx tsx scripts/annotations/build.ts` passes with no warnings for annotation changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)