### PR TITLE
Enrich gallery: fix schemas, cross-refs for liouville, hermite-lindemann, lagrange

### DIFF
--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -123,29 +123,44 @@
   },
   "crossReferences": [
     {
-      "proofId": "e-transcendental",
+      "targetId": "e-transcendental",
       "relationship": "specializes",
       "description": "The transcendence of $e$ (Wiedijk #67) is the $\\alpha = 1$ special case of Hermite-Lindemann; Hermite's 1873 proof was the first application"
     },
     {
-      "proofId": "pi-transcendental",
+      "targetId": "pi-transcendental",
       "relationship": "specializes",
       "description": "The transcendence of $\\pi$ (Wiedijk #53) follows from Hermite-Lindemann via Euler's identity: $e^{i\\pi} = -1$ is algebraic, so $i\\pi$ must be transcendental"
     },
     {
-      "proofId": "euler-identity",
+      "targetId": "euler-identity",
       "relationship": "uses",
       "description": "Euler's identity $e^{i\\pi} = -1$ is the bridge that connects Hermite-Lindemann to $\\pi$'s transcendence"
     },
     {
-      "proofId": "gelfond-schneider",
+      "targetId": "gelfond-schneider",
       "relationship": "generalized-by",
       "description": "The Gelfond-Schneider theorem (1934) extends transcendence theory from exponentials to $\\alpha^\\beta$, using techniques inspired by Hermite-Lindemann"
     },
     {
-      "proofId": "angle-trisection",
+      "targetId": "angle-trisection",
       "relationship": "related",
       "description": "Both resolve classical impossibility problems via algebraic number theory; squaring the circle fails because $\\pi$ is transcendental (Hermite-Lindemann), angle trisection because some angles need degree-3 extensions"
+    },
+    {
+      "targetId": "liouville-theorem",
+      "relationship": "extends",
+      "description": "Liouville (1844) gave the first transcendental numbers via approximation bounds; Hermite-Lindemann (1873-1882) proved specific important constants (e, π) transcendental using the more powerful auxiliary polynomial method"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both are impossibility results about expressibility: Abel-Ruffini shows some roots aren't expressible by radicals, Hermite-Lindemann shows e and π aren't even algebraic — a hierarchy from radical to algebraic to transcendental"
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "foundational",
+      "description": "Irrationality of √2 is the simplest expressibility barrier. The hierarchy is: √2 ∉ ℚ (irrational) → quintic roots ∉ radical extensions (Abel-Ruffini) → e,π ∉ algebraic numbers (Hermite-Lindemann)"
     }
   ],
   "leanFile": {
@@ -173,7 +188,12 @@
     "e-transcendental",
     "pi-transcendental",
     "angle-trisection",
-    "gelfond-schneider"
+    "gelfond-schneider",
+    "euler-identity",
+    "liouville-theorem",
+    "abel-ruffini",
+    "sqrt2-irrational",
+    "fundamental-theorem-algebra"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary
- **lagrange-theorem**: Added cross-refs to euler-totient, angle-trisection, inverse-galois; added Herstein reference
- **liouville-theorem**: Fixed `targetProofId` → `targetId` schema (6 occurrences), populated empty relatedProofs with 9 IDs, added FTA and Abel-Ruffini cross-refs
- **hermite-lindemann**: Fixed `proofId` → `targetId` schema (5 occurrences), added cross-refs to liouville-theorem, abel-ruffini, sqrt2-irrational; expanded relatedProofs from 4 to 9

## Test plan
- [x] All JSON files validate
- [x] All cross-reference targets exist
- [x] Schema normalized to `targetId` across all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)