### PR TITLE
Enrich gallery: cross-refs for 15 entries (51 new cross-refs)

### DIFF
--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -126,9 +126,29 @@
       "mathContext": "The paradigm: from \"trust the computation\" (Appel-Haken) to \"trust the proof checker\" (Gonthier). Coq's kernel is small enough for human audit."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "essential-dependency",
+      "description": "Euler's formula V - E + F = 2 is the structural backbone of the four color proof: it forces every planar graph to contain a vertex of degree at most 5, enabling the inductive reducibility argument."
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "topological-connection",
+      "description": "Both theorems rely on topological properties of planar/spherical objects. Brouwer's fixed point theorem and the four color theorem both exploit the topology of the 2-sphere, where map coloring is equivalent to graph coloring on the sphere."
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "topological-connection",
+      "description": "The Borsuk-Ulam theorem constrains continuous maps from spheres, and like the four color theorem, reveals how topological structure imposes combinatorial constraints on planar and spherical configurations."
+    }
+  ],
   "relatedProofs": [
     "ramseys-theorem",
-    "erdos-807"
+    "erdos-807",
+    "euler-polyhedral-formula",
+    "brouwer-fixed-point",
+    "borsuk-ulam"
   ],
   "references": [
     {

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -118,6 +118,46 @@
       "summary": "A concise summary of the proof strategy: encoding, representability, self-reference, the truth of G, and the final conclusion."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "halting-problem",
+      "relationship": "foundational-parallel",
+      "description": "Gödel's diagonalization directly inspired Turing's proof that the halting problem is undecidable. Both use self-referential constructions to establish fundamental limits of formal systems."
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "technique-ancestor",
+      "description": "Cantor's theorem that no set surjects onto its power set employs the same diagonal argument that Gödel adapted to construct self-referential sentences in arithmetic."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "shared-technique",
+      "description": "Cantor's diagonalization of the reals and Gödel's diagonal lemma share the core technique of constructing an object that differs from every element in an enumeration."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "impossibility-result",
+      "description": "Both are landmark impossibility theorems: Abel-Ruffini shows no general algebraic formula exists for degree 5+ polynomials, while Gödel shows no consistent formal system can prove all arithmetic truths."
+    },
+    {
+      "targetId": "hilbert-10",
+      "relationship": "direct-consequence",
+      "description": "Hilbert's Tenth Problem (undecidability of Diophantine equations) was resolved using ideas flowing from Gödel's incompleteness, linking undecidability in logic to undecidability in number theory."
+    },
+    {
+      "targetId": "continuum-hypothesis",
+      "relationship": "independence-phenomenon",
+      "description": "The continuum hypothesis is independent of ZFC (Gödel 1940, Cohen 1963), exemplifying the incompleteness phenomenon Gödel discovered: a natural mathematical statement that standard axioms can neither prove nor refute."
+    }
+  ],
+  "relatedProofs": [
+    "halting-problem",
+    "cantors-theorem",
+    "cantor-diagonalization",
+    "hilbert-10",
+    "continuum-hypothesis",
+    "abel-ruffini"
+  ],
   "conclusion": {
     "summary": "Gödel's First Incompleteness Theorem demonstrates that mathematical truth forever exceeds formal provability. Any consistent system powerful enough to express arithmetic contains true statements it cannot prove. This isn't a flaw in specific systems—it's a fundamental feature of formal reasoning itself.",
     "implications": "The incompleteness theorems transformed our understanding of foundations. Hilbert's vision of a complete, mechanizable mathematics was shown to be impossible. In computer science, the same techniques yield the undecidability of the Halting Problem. Philosophically, the theorems raise profound questions: Does human mathematical insight transcend algorithmic computation? Is there a limit to what we can know through formal methods? Gödel's work suggests that creativity and intuition in mathematics cannot be fully captured by any fixed set of rules.",

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -239,8 +239,39 @@
   ],
   "crossReferences": [
     {
-      "proofId": "hurwitz-theorem",
-      "relationship": "Both establish classification theorems: Hurwitz classifies normed division algebras ($n \\in \\{1,2,4,8\\}$), Poincaré classifies simply connected closed 3-manifolds (only $S^3$). Both use biconditional characterizations."
+      "targetId": "hurwitz-theorem",
+      "relationship": "classification-parallel",
+      "description": "Both establish classification theorems: Hurwitz classifies normed division algebras ($n \\in \\{1,2,4,8\\}$), Poincaré classifies simply connected closed 3-manifolds (only $S^3$). Both use biconditional characterizations."
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "topological-foundation",
+      "description": "Brouwer's fixed point theorem is a cornerstone of algebraic topology that shares the same homotopy-theoretic foundations used in the Poincaré conjecture, particularly the role of the fundamental group and simple connectivity."
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "sphere-topology",
+      "description": "The Borsuk-Ulam theorem constrains continuous maps on spheres and relies on the same topological invariants (fundamental group, homology) that distinguish S^3 from other closed 3-manifolds in the Poincaré conjecture."
+    },
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "topological-invariant",
+      "description": "Euler's formula defines the Euler characteristic, a topological invariant closely related to the homology groups that Poincaré originally used to study 3-manifolds before discovering that simple connectivity is the key distinguishing property."
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "millennium-prize",
+      "description": "Both are Millennium Prize Problems. The Poincaré conjecture (solved by Perelman, 2003) was the first to fall; the Riemann hypothesis remains open, and both problems connect deep structure in their respective domains."
+    },
+    {
+      "targetId": "yang-mills-mass-gap",
+      "relationship": "millennium-prize",
+      "description": "Both are Millennium Prize Problems involving geometric analysis. Yang-Mills theory uses gauge connections on fiber bundles over manifolds, and Perelman's Ricci flow techniques have inspired geometric approaches to gauge-theoretic problems."
+    },
+    {
+      "targetId": "navier-stokes",
+      "relationship": "millennium-prize-pde",
+      "description": "Both are Millennium Prize Problems whose solutions involve deep PDE analysis. Perelman's proof uses Ricci flow (a geometric PDE), while Navier-Stokes concerns fluid dynamics PDEs; both require controlling singularity formation."
     }
   ],
   "conclusion": {
@@ -289,7 +320,13 @@
     "definitionCount": 369
   },
   "relatedProofs": [
-    ""
+    "hurwitz-theorem",
+    "brouwer-fixed-point",
+    "borsuk-ulam",
+    "euler-polyhedral-formula",
+    "riemann-hypothesis",
+    "yang-mills-mass-gap",
+    "navier-stokes"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary

Enrichment pass adding cross-references and relatedProofs to 15 gallery entries that had 0 (or minimal) cross-references:

### Set Theory & Logic
| Entry | Cross-refs Added |
|-------|-----------------|
| cantors-theorem | 6 |
| continuum-hypothesis | 3 |
| schroeder-bernstein | 3 |
| godel-incompleteness | 6 |

### Topology
| Entry | Cross-refs Added |
|-------|-----------------|
| brouwer-fixed-point | 5 |
| schauder-fixed-point | 2 |
| intermediate-value-theorem | 2 |
| borsuk-ulam → poincare-conjecture | 6 |
| four-color-theorem | 3 |

### Number Theory & Algebra
| Entry | Cross-refs Added |
|-------|-----------------|
| bounded-prime-gaps | 5 |
| central-limit-theorem | 2 |
| chinese-remainder-constructive | 2 |
| euler-polyhedral-formula | 1 |
| descartes-rule-of-signs | 2 |
| factor-remainder-theorem | 3 |

**Total**: 51 new cross-references across 15 entries, all targets verified to exist.

## Test plan
- [x] JSON validates for all entries
- [x] All cross-reference targets verified as existing gallery directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)