### PR TITLE
Enrich angle-trisection: fill annotation gaps, add Axiom 2 coverage

### DIFF
--- a/src/data/proofs/angle-trisection/annotations.json
+++ b/src/data/proofs/angle-trisection/annotations.json
@@ -180,7 +180,7 @@
     "id": "ann-wantzel-axiom",
     "proofId": "angle-trisection",
     "range": {
-      "startLine": 197,
+      "startLine": 185,
       "endLine": 198
     },
     "type": "insight",
@@ -196,6 +196,29 @@
     "prerequisites": [
       "ann-constructible-def",
       "Galois theory"
+    ]
+  },
+  {
+    "id": "ann-axiom2-lindemann",
+    "proofId": "angle-trisection",
+    "range": {
+      "startLine": 200,
+      "endLine": 214
+    },
+    "type": "theorem",
+    "title": "Axiom 2 (Irreducibility) and Lindemann's Theorem",
+    "content": "Two results complete the algebraic setup:\n\n1. **Axiom 2** (`trisectionPolynomial_irreducible`): The polynomial $8x^3 - 6x - 1$ is irreducible over $\\mathbb{Q}$. Stated as an axiom because Mathlib's irreducibility API for specific polynomials is difficult to interface with `norm_num` verification. The computational evidence (`no_rational_roots`) makes the axiom well-justified: a degree-3 polynomial with no rational roots is irreducible over $\\mathbb{Q}$.\n\n2. **Lindemann's theorem** (`lindemann_pi_transcendental`): $\\pi$ is transcendental over $\\mathbb{Q}$. Unlike the axioms, this is **proved** from the project's own `PiTranscendental` module, which establishes transcendence over $\\mathbb{Z}$ and lifts via `IsFractionRing.isAlgebraic_iff`.",
+    "mathContext": "Irreducibility: a cubic $f \\in \\mathbb{Q}[X]$ is irreducible iff it has no root in $\\mathbb{Q}$. Since $\\deg(f) = 3 < 4$, any non-trivial factorization must include a linear factor, hence a rational root. Transcendence: $\\pi \\notin \\overline{\\mathbb{Q}}$ (Lindemann 1882), proved here via Hermite-Lindemann-Weierstrass.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "irreducibility",
+      "transcendental numbers",
+      "Lindemann-Weierstrass theorem",
+      "axiom justification"
+    ],
+    "prerequisites": [
+      "ann-no-rational-roots",
+      "PiTranscendental module"
     ]
   },
   {
@@ -309,6 +332,27 @@
     "prerequisites": [
       "prime factorization",
       "ann-three-not-power"
+    ]
+  },
+  {
+    "id": "ann-summary-close",
+    "proofId": "angle-trisection",
+    "range": {
+      "startLine": 370,
+      "endLine": 389
+    },
+    "type": "context",
+    "title": "Summary and Proof Architecture",
+    "content": "The closing summary recaps the three impossibilities and their distinct obstruction mechanisms: trisection and cube doubling fail because degree 3 is not a power of 2, while circle squaring fails because $\\pi$ (hence $\\sqrt{\\pi}$) is transcendental.\n\nThe proof architecture is carefully documented: 3 axioms (Wantzel's theorem, irreducibility of $8x^3 - 6x - 1$, and $\\pi$'s transcendence via the imported `PiTranscendental` module) serve as the deep inputs, while 18+ theorems are fully proved from these axioms and Mathlib. This layered design separates 'assumed deep results' from 'derived consequences', making the formalization both rigorous and pedagogically transparent.",
+    "mathContext": "The three obstructions: (1) $[\\mathbb{Q}(\\cos 20°) : \\mathbb{Q}] = 3 \\neq 2^n$, (2) $[\\mathbb{Q}(\\sqrt[3]{2}) : \\mathbb{Q}] = 3 \\neq 2^n$, (3) $\\sqrt{\\pi}$ is transcendental $\\Rightarrow$ no finite degree over $\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "proof architecture",
+      "axiom inventory",
+      "impossibility hierarchy"
+    ],
+    "prerequisites": [
+      "all previous sections"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- Expand `ann-wantzel-axiom` range to include docstring (185→185-198)
- Add `ann-axiom2-lindemann` annotation for lines 200-214 (Axiom 2 irreducibility + Lindemann theorem)
- Add `ann-summary-close` annotation for lines 370-389 (closing summary)
- Total annotations: 14 → 16

## Test plan
- [x] JSON validated
- [x] All 11 cross-references verified
- [x] lineCount correct at 389

🤖 Generated with [Claude Code](https://claude.com/claude-code)