### PR TITLE
Enrich cauchy-schwarz: fix lineCount, relatedProofs, add coverage

### DIFF
--- a/src/data/proofs/cauchy-schwarz/annotations.json
+++ b/src/data/proofs/cauchy-schwarz/annotations.json
@@ -22,6 +22,28 @@
     ]
   },
   {
+    "id": "cs-docstring-setup",
+    "proofId": "cauchy-schwarz",
+    "type": "context",
+    "range": {
+      "startLine": 6,
+      "endLine": 60
+    },
+    "title": "Module Docstring and Proof Architecture",
+    "content": "The module docstring surveys the Cauchy-Schwarz inequality in all its forms and outlines the formalization strategy. The file proceeds through a hierarchy:\n\n1. **Abstract inner product form** (Part I): $|\\langle u,v\\rangle| \\leq \\|u\\|\\|v\\|$ via Mathlib's `abs_real_inner_le_norm`\n2. **Two-variable algebraic form** (Part II): elementary proof via Lagrange identity\n3. **Finite sum form** (Part III): embedding into `EuclideanSpace` to get $(\\sum a_ib_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$\n4. **Equality characterization** (Part IV): linear dependence condition\n5. **Applications** (Part V–VI): triangle inequality and correlation bound\n\nThe architecture demonstrates how abstract Mathlib results can be specialized to concrete, familiar forms. Variables `F` (the inner product space) and `u, v` are declared universe-polymorphically.",
+    "mathContext": "The three forms are logically equivalent but represent different perspectives: the inner product form is most general (any real inner product space), the finite sum form is most computational (Cauchy's original 1821 formulation), and the two-variable form is most elementary (requires only $(a_1b_2-a_2b_1)^2 \\geq 0$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "proof architecture",
+      "inner product spaces",
+      "Mathlib API design"
+    ],
+    "prerequisites": [
+      "inner product space axioms",
+      "normed spaces"
+    ]
+  },
+  {
     "id": "cs-inner-product",
     "proofId": "cauchy-schwarz",
     "type": "theorem",

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -164,14 +164,16 @@
       "title": "Verified Examples",
       "summary": "Numerical verifications: strict inequality $(196 < 200)$ for non-proportional vectors, equality $(100 = 100)$ for proportional vectors $(1,2)$ and $(2,4)$, and $\\mathbb{R}^2$ specialization.",
       "startLine": 181,
-      "endLine": 196
+      "endLine": 196,
+      "mathContext": "Strict: $(1 \\cdot 2 + 3 \\cdot 4)^2 = 196 < 200 = (1^2+3^2)(2^2+4^2)$. Equality: $(1 \\cdot 2 + 2 \\cdot 4)^2 = 100 = (1^2+2^2)(2^2+4^2)$ because $(2,4) = 2(1,2)$."
     },
     {
       "id": "triangle",
       "title": "Application: Triangle Inequality",
       "summary": "Derives $\\|u+v\\|^2 \\leq (\\|u\\|+\\|v\\|)^2$ from Cauchy-Schwarz via `norm_add_sq_real` expansion and $\\langle u,v\\rangle \\leq |\\langle u,v\\rangle| \\leq \\|u\\|\\|v\\|$.",
       "startLine": 198,
-      "endLine": 212
+      "endLine": 212,
+      "mathContext": "$\\|u+v\\|^2 = \\|u\\|^2 + 2\\langle u,v\\rangle + \\|v\\|^2 \\leq \\|u\\|^2 + 2\\|u\\|\\|v\\| + \\|v\\|^2 = (\\|u\\|+\\|v\\|)^2$"
     },
     {
       "id": "correlation",
@@ -222,7 +224,11 @@
     "cauchy-schwarz-integral",
     "triangle-inequality",
     "amgm-inequality",
-    "cauchy-schwarz-oq-01"
+    "cauchy-schwarz-oq-01",
+    "cauchy-schwarz-oq-03",
+    "cauchy-schwarz-oq-04",
+    "hurwitz-theorem",
+    "yang-mills"
   ],
   "references": [
     {
@@ -256,7 +262,7 @@
     ],
     "opens": [],
     "namespace": "CauchySchwarz",
-    "lineCount": 232,
+    "lineCount": 231,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0


### PR DESCRIPTION
## Summary
- Fix `leanFile.lineCount` from 232 to 231
- Add 4 missing entries to `relatedProofs` (oq-03, oq-04, hurwitz-theorem, yang-mills)
- Add `mathContext` to sections `examples` and `triangle` (were missing)
- Add `cs-docstring-setup` annotation covering lines 6-60 (55-line gap)

## Test plan
- [x] JSON validated
- [x] All cross-references verified to exist
- [x] lineCount verified at 231

🤖 Generated with [Claude Code](https://claude.com/claude-code)