### PR TITLE
Enrich infinitude-primes: fix lineCount, add references

### DIFF
--- a/src/data/proofs/infinitude-primes/annotations.json
+++ b/src/data/proofs/infinitude-primes/annotations.json
@@ -74,7 +74,7 @@
   {
     "id": "ann-epilogue",
     "proofId": "infinitude-primes",
-    "range": { "startLine": 123, "endLine": 128 },
+    "range": { "startLine": 123, "endLine": 127 },
     "type": "context",
     "title": "API Verification and Namespace Close",
     "content": "Three `#check` commands verify the main theorem signatures: `unbounded_primes`, `primes_infinite`, and `no_largest_prime`. The `InfinitudePrimes` namespace closes at line 127.",

--- a/src/data/proofs/infinitude-primes/meta.json
+++ b/src/data/proofs/infinitude-primes/meta.json
@@ -123,6 +123,20 @@
       "year": "1737",
       "venue": "Commentarii academiae scientiarum Petropolitanae",
       "note": "Proved the divergence of Σ 1/p (sum over primes), giving an analytic proof of infinitely many primes"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "venue": "Oxford University Press",
+      "note": "Section 2.1 gives four proofs of the infinitude of primes including Euclid's, Euler's analytic proof, and proofs via Fermat numbers and Mersenne numbers"
+    },
+    {
+      "authors": "Aigner, Martin; Ziegler, Günter M.",
+      "title": "Proofs from THE BOOK",
+      "year": "1998",
+      "venue": "Springer",
+      "note": "Chapter 1 presents six proofs of the infinitude of primes, calling it 'the first theorem in the BOOK' — includes Euclid's, Euler's, Goldbach's, Furstenberg's topological proof, and more"
     }
   ],
   "crossReferences": [
@@ -181,7 +195,7 @@
     ],
     "opens": [],
     "namespace": "InfinitudePrimes",
-    "lineCount": 128,
+    "lineCount": 127,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0


### PR DESCRIPTION
## Summary
- Fix `leanFile.lineCount` from 128 to 127
- Fix `ann-epilogue` endLine from 128 to 127
- Add 2 academic references (Hardy & Wright, Aigner & Ziegler)

## Test plan
- [x] JSON validated
- [x] All 9 cross-references verified
- [x] lineCount verified at 127

🤖 Generated with [Claude Code](https://claude.com/claude-code)