### PR TITLE
Enrich amgm-inequality, abel-ruffini-oq-04, basel-problem

### DIFF
--- a/src/data/proofs/basel-problem/annotations.json
+++ b/src/data/proofs/basel-problem/annotations.json
@@ -7,14 +7,27 @@
       "endLine": 4
     },
     "type": "concept",
-    "title": "Mathlib Imports",
-    "content": "We import `Mathlib.NumberTheory.ZetaValues` which contains the main Basel identity theorem, plus `Mathlib.Analysis.PSeries` for convergence and `Mathlib.Topology.Algebra.InfiniteSum.Basic` for the `HasSum` and `Summable` predicates.",
+    "title": "Mathlib Imports for Zeta Values and Series",
+    "content": "Four Mathlib imports provide the complete mathematical infrastructure:\n- `NumberTheory.ZetaValues`: Contains `hasSum_zeta_two` (the Basel identity), `hasSum_zeta_four` ($\\zeta(4) = \\pi^4/90$), and `hasSum_zeta_nat` (general Euler formula for $\\zeta(2k)$), all proved via Bernoulli polynomial theory\n- `Topology.Algebra.InfiniteSum.Basic`: The `HasSum` predicate (a series converges to a given value) and `tsum` (the topological sum operator), foundational for working with infinite series in Lean\n- `Analysis.PSeries`: `Real.summable_nat_rpow_inv` proving p-series $\\sum n^{-p}$ converges iff $p > 1$\n- `Mathlib.Tactic`: General tactics including `positivity`, `norm_num`, `simp`",
+    "mathContext": "The key Mathlib theorem is `hasSum_zeta_two`: $\\text{HasSum}\\,(n \\mapsto 1/n^2)\\,(\\pi^2/6)$, proved internally via the Fourier expansion of Bernoulli polynomials $B_2(x)$ evaluated at $x = 0$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Mathlib",
-      "zeta values",
-      "infinite sums"
-    ]
+    "relatedConcepts": ["Mathlib", "zeta values", "infinite sums", "Bernoulli polynomials"],
+    "prerequisites": ["Lean 4 import system", "Mathlib library structure"]
+  },
+  {
+    "id": "ann-docstring",
+    "proofId": "basel-problem",
+    "range": {
+      "startLine": 6,
+      "endLine": 56
+    },
+    "type": "context",
+    "title": "Module Docstring, Namespace, and Open Declarations",
+    "content": "The module docstring establishes the Basel Problem's historical context (Mengoli 1650, Euler 1734, Wiedijk #14) and documents the proof approach via Mathlib's Bernoulli polynomial machinery. The namespace `BaselProblem` scopes all definitions, and five `open` declarations bring `Finset`, `BigOperators` ($\\sum$ notation), `Filter`, `Topology` (for `HasSum`/`tsum`), and `Real` (for $\\pi$) into scope.\n\nThe `open` declarations are essential for readability: without `open BigOperators`, one would need `@Finset.sum` with explicit type arguments instead of the $\\sum$ notation.",
+    "mathContext": "The docstring gives both the classical statement $\\sum_{n=1}^{\\infty} 1/n^2 = \\pi^2/6$ and notes the three proof approaches: Bernoulli polynomials (Mathlib's method), Fourier analysis (Parseval's theorem), and Euler's original infinite product factorization of $\\sin(x)/x$.",
+    "significance": "context",
+    "relatedConcepts": ["namespace scoping", "open declarations", "BigOperators notation"],
+    "prerequisites": ["Lean 4 namespaces", "Mathlib conventions"]
   },
   {
     "id": "ann-basel-main",
@@ -24,15 +37,12 @@
       "endLine": 70
     },
     "type": "theorem",
-    "title": "The Basel Identity",
-    "content": "**The Main Result**: $\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}$. This is Euler's celebrated 1734 solution to the Basel Problem.",
-    "mathContext": "In Lean, `HasSum f s` means the series $\\sum f(n)$ converges to $s$. We prove `HasSum (fun n => 1 / n^2) (π^2 / 6)` using Mathlib's `hasSum_zeta_two`.",
-    "significance": "critical",
-    "relatedConcepts": [
-      "HasSum",
-      "convergence",
-      "Basel problem"
-    ]
+    "title": "The Basel Identity: ∑ 1/n² = π²/6",
+    "content": "**The Main Result**: $\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}$. This is Euler's celebrated 1734 solution to the Basel Problem.\n\nThe proof is a single line: `exact hasSum_zeta_two`. This brevity conceals hundreds of Mathlib lemmas: Bernoulli polynomial definitions, their Fourier expansions, convergence of the Fourier series, and evaluation at $x = 0$ to extract $\\zeta(2)$. The `HasSum` predicate asserts that the partial sums $\\sum_{n=0}^{N} 1/n^2$ converge to $\\pi^2/6$ in the topology of $\\mathbb{R}$.",
+    "mathContext": "$$\\text{HasSum}\\,(n \\mapsto 1/n^2)\\,(\\pi^2/6) \\;\\iff\\; \\lim_{N \\to \\infty} \\sum_{n=0}^{N} \\frac{1}{n^2} = \\frac{\\pi^2}{6}$$",
+    "significance": "key",
+    "relatedConcepts": ["HasSum", "convergence", "Basel problem", "hasSum_zeta_two"],
+    "prerequisites": ["real analysis", "infinite series", "Bernoulli polynomials"]
   },
   {
     "id": "ann-basel-tsum",
@@ -41,34 +51,43 @@
       "startLine": 72,
       "endLine": 74
     },
-    "type": "theorem",
-    "title": "The tsum Version",
-    "content": "The `tsum` (topological sum) version: `∑' n, 1/n² = π²/6`. This is the form using Lean's notation for infinite sums.",
-    "mathContext": "`tsum` is defined as the limit of partial sums when the series is summable, and 0 otherwise. For summable series, `HasSum.tsum_eq` converts between the two forms.",
+    "type": "technique",
+    "title": "The tsum Version: Notation Equivalence",
+    "content": "The `tsum` (topological sum) version: `∑' n, 1/n² = π²/6`. While `HasSum f s` is a proposition asserting convergence to $s$, `tsum f` is a *function* returning the sum (or 0 if the series diverges). The conversion uses `HasSum.tsum_eq`, which extracts the value from a `HasSum` proof.\n\nIn practice, `tsum` is more convenient for algebraic manipulations (it can be substituted into equations), while `HasSum` is the fundamental convergence statement.",
+    "mathContext": "`tsum f = s` is equivalent to `HasSum f s` when the series is summable. `tsum` is defined as the limit of the net of finite partial sums when it exists, and 0 otherwise.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "tsum",
-      "notation",
-      "equivalence"
-    ]
+    "relatedConcepts": ["tsum", "HasSum.tsum_eq", "topological sum"],
+    "prerequisites": ["HasSum predicate", "tsum definition"]
   },
   {
     "id": "ann-convergence",
     "proofId": "basel-problem",
     "range": {
-      "startLine": 76,
-      "endLine": 78
+      "startLine": 80,
+      "endLine": 91
     },
-    "type": "theorem",
-    "title": "Series Convergence",
-    "content": "The series $\\sum 1/n^2$ converges because it's a p-series with $p = 2 > 1$. This is a fundamental result in analysis.",
-    "mathContext": "We use `Real.summable_nat_rpow_inv` which proves that $\\sum n^{-p}$ converges for $p > 1$. The harmonic series ($p = 1$) is the boundary case that diverges.",
+    "type": "technique",
+    "title": "Series Convergence via p-Series Test",
+    "content": "Two equivalent formulations of convergence for $\\sum 1/n^2$:\n\n1. `summable_one_div_sq`: Uses `Real.summable_nat_rpow_inv` (p-series test: $\\sum n^{-p}$ converges iff $p > 1$) with $p = 2$. The proof requires `convert` because Mathlib's p-series uses real powers `rpow` while our series uses natural powers, so `rpow_natCast` bridges the gap.\n\n2. `summable_nat_sq_inv`: Reformulates using $n^{-2}$ instead of $1/n^2$, converting via `div_eq_mul_inv`. This form is sometimes more convenient in algebraic manipulations.\n\nThe p-series test itself is proved in Mathlib via the integral test: $\\sum n^{-p}$ converges iff $\\int_1^{\\infty} x^{-p}\\,dx < \\infty$, which holds for $p > 1$.",
+    "mathContext": "$$\\sum_{n=1}^{\\infty} \\frac{1}{n^p} < \\infty \\iff p > 1$$\n\nThe boundary case $p = 1$ is the harmonic series, which diverges logarithmically: $\\sum_{n=1}^{N} 1/n \\approx \\ln N + \\gamma$ where $\\gamma \\approx 0.5772$ is the Euler-Mascheroni constant.",
     "significance": "key",
-    "relatedConcepts": [
-      "p-series",
-      "Summable",
-      "comparison test"
-    ]
+    "relatedConcepts": ["p-series test", "Summable", "rpow_natCast", "integral test", "harmonic series"],
+    "prerequisites": ["real analysis", "convergence tests", "Real.summable_nat_rpow_inv"]
+  },
+  {
+    "id": "ann-basic-props",
+    "proofId": "basel-problem",
+    "range": {
+      "startLine": 93,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "Basic Properties via Positivity Tactic",
+    "content": "Three simple facts established entirely by Lean's `positivity` tactic:\n\n1. `one_div_sq_pos`: Each term $1/n^2 > 0$ for $n \\neq 0$ — since $n^2 > 0$ for $n \\geq 1$ and $1 > 0$\n2. `one_div_sq_nonneg`: Each term $1/n^2 \\geq 0$ — weaker but universally true (including $n = 0$ where $1/0^2 = 0$ in Lean)\n3. `basel_value_pos`: The sum $\\pi^2/6 > 0$ — since $\\pi > 0$ implies $\\pi^2 > 0$\n\nThe `positivity` tactic is a decision procedure for goals of the form `0 < e` or `0 ≤ e` over ordered fields. It decomposes the expression into factors and checks each is positive/nonneg.",
+    "mathContext": "$$\\frac{1}{n^2} \\geq 0 \\;\\forall n, \\quad \\frac{1}{n^2} > 0 \\;\\forall n \\geq 1, \\quad \\frac{\\pi^2}{6} > 0$$",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity tactic", "non-negative terms", "monotone series"],
+    "prerequisites": ["ordered field arithmetic", "positivity tactic"]
   },
   {
     "id": "ann-euler-history",
@@ -78,32 +97,41 @@
       "endLine": 123
     },
     "type": "insight",
-    "title": "Euler's Original Proof",
-    "content": "Euler's 1734 proof used the Weierstrass factorization of $\\sin(x)/x$. By comparing the $x^2$ coefficient in the infinite product with the Taylor series, he derived the Basel identity.",
-    "mathContext": "Euler wrote $\\sin(x)/x = \\prod_{n=1}^{\\infty}(1 - x^2/(n\\pi)^2)$. Expanding and comparing with $1 - x^2/6 + \\ldots$ gives $1/6 = \\sum 1/(n\\pi)^2$, hence $\\sum 1/n^2 = \\pi^2/6$.",
+    "title": "Euler's Original Proof: The sin(x)/x Factorization",
+    "content": "Euler's 1734 proof used a bold analogy with finite polynomials. A polynomial with roots $r_1, \\ldots, r_n$ factors as $c(x - r_1)\\cdots(x - r_n)$. Euler applied this to $\\sin(x)/x$, whose zeros are $\\pm\\pi, \\pm 2\\pi, \\ldots$:\n\n$$\\frac{\\sin x}{x} = \\left(1 - \\frac{x^2}{\\pi^2}\\right)\\left(1 - \\frac{x^2}{4\\pi^2}\\right)\\left(1 - \\frac{x^2}{9\\pi^2}\\right)\\cdots$$\n\nExpanding the product, the $x^2$ coefficient is $-\\sum 1/(n^2\\pi^2)$. From the Taylor series $\\sin(x)/x = 1 - x^2/6 + \\cdots$, the $x^2$ coefficient is $-1/6$. Equating: $\\sum 1/n^2 = \\pi^2/6$.\n\nThis reasoning was not rigorous (the Weierstrass factorization theorem justifying infinite products was proved only in 1876), but Euler's intuition was correct. The modern Mathlib proof instead uses Fourier analysis via Bernoulli polynomials.",
+    "mathContext": "Euler's coefficient comparison: $-\\frac{1}{\\pi^2}\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = -\\frac{1}{6}$, hence $\\sum \\frac{1}{n^2} = \\frac{\\pi^2}{6}$.",
     "significance": "key",
-    "relatedConcepts": [
-      "Weierstrass factorization",
-      "Taylor series",
-      "infinite products"
-    ]
+    "relatedConcepts": ["Weierstrass factorization", "Taylor series", "infinite products", "coefficient comparison"],
+    "prerequisites": ["Taylor series of sin(x)", "infinite product representation", "Weierstrass factorization theorem"]
   },
   {
-    "id": "ann-zeta-four",
+    "id": "ann-zeta-values",
     "proofId": "basel-problem",
     "range": {
-      "startLine": 130,
-      "endLine": 132
+      "startLine": 125,
+      "endLine": 143
     },
-    "type": "theorem",
-    "title": "Higher Zeta Values",
-    "content": "Euler generalized the Basel identity: $\\zeta(4) = \\pi^4/90$, $\\zeta(6) = \\pi^6/945$, and in general $\\zeta(2k)$ is a rational multiple of $\\pi^{2k}$ involving Bernoulli numbers.",
-    "mathContext": "The general formula is $\\zeta(2k) = (-1)^{k+1} \\cdot 2^{2k-1} \\cdot \\pi^{2k} \\cdot B_{2k} / (2k)!$ where $B_{2k}$ is the $(2k)$-th Bernoulli number.",
+    "type": "concept",
+    "title": "Higher Zeta Values and the General Euler Formula",
+    "content": "Two theorems extending the Basel identity to all even zeta values:\n\n1. `zeta_four_hasSum`: $\\zeta(4) = \\pi^4/90$ via `hasSum_zeta_four` — the next case after Basel\n2. `zeta_general`: The full Euler formula $\\zeta(2k) = (-1)^{k+1} 2^{2k-1} \\pi^{2k} B_{2k} / (2k)!$ for all $k \\geq 1$, via `hasSum_zeta_nat`\n\nThe Bernoulli numbers $B_n$ are defined by $x/(e^x - 1) = \\sum B_n x^n / n!$. The first few even values: $B_2 = 1/6$, $B_4 = -1/30$, $B_6 = 1/42$, $B_8 = -1/30$. These yield:\n- $\\zeta(2) = \\pi^2/6$ (Basel)\n- $\\zeta(4) = \\pi^4/90$\n- $\\zeta(6) = \\pi^6/945$\n- $\\zeta(8) = \\pi^8/9450$\n\nIn contrast, odd zeta values $\\zeta(3), \\zeta(5), \\ldots$ have no known closed-form expressions in terms of $\\pi$.",
+    "mathContext": "$$\\zeta(2k) = \\frac{(-1)^{k+1} 2^{2k-1} \\pi^{2k} B_{2k}}{(2k)!}, \\quad B_{2k} \\text{ the } 2k\\text{-th Bernoulli number}$$",
     "significance": "key",
-    "relatedConcepts": [
-      "Bernoulli numbers",
-      "zeta values",
-      "special functions"
-    ]
+    "relatedConcepts": ["Bernoulli numbers", "zeta function", "even zeta values", "hasSum_zeta_nat"],
+    "prerequisites": ["Bernoulli number generating function", "factorial", "Riemann zeta function"]
+  },
+  {
+    "id": "ann-numerical",
+    "proofId": "basel-problem",
+    "range": {
+      "startLine": 145,
+      "endLine": 164
+    },
+    "type": "context",
+    "title": "Numerical Verification and Convergence Rate",
+    "content": "Four concrete examples verify the series behavior:\n\n1. The $n = 0$ term is 0 (since $1/0^2 = 0$ in Lean's convention for division by zero)\n2. The $n = 1$ term is 1\n3. The $n = 2$ term is $1/4$\n4. Partial sum: $\\sum_{n=0}^{1} 1/n^2 = 0 + 1 = 1$\n\nThe documentation notes slow convergence: after $N$ terms, the error is approximately $1/N$ (from the integral estimate $\\int_N^{\\infty} x^{-2}\\,dx = 1/N$). This means achieving 6 digits of accuracy requires $N \\approx 10^6$ terms — making the closed form $\\pi^2/6$ vastly more practical than numerical summation.\n\nThe `simp` and `norm_num` tactics handle the concrete computations, with `Finset.sum_range_succ` unfolding the partial sum into individual terms.",
+    "mathContext": "$$\\left|\\frac{\\pi^2}{6} - \\sum_{n=1}^{N} \\frac{1}{n^2}\\right| \\approx \\frac{1}{N} \\quad \\text{(from } \\int_N^{\\infty} x^{-2}\\,dx = 1/N\\text{)}$$",
+    "significance": "supporting",
+    "relatedConcepts": ["convergence rate", "Finset.sum_range_succ", "norm_num tactic", "division by zero convention"],
+    "prerequisites": ["Finset.range", "norm_num", "simp tactic"]
   }
 ]

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -149,6 +149,13 @@
       "year": "1979",
       "venue": "Astérisque 61, pp. 11-13",
       "note": "Proved ζ(3) is irrational — the first odd zeta value shown to be irrational, a major breakthrough"
+    },
+    {
+      "authors": "Dunham, William",
+      "title": "Euler: The Master of Us All",
+      "year": "1999",
+      "venue": "MAA Dolciani Mathematical Expositions 22",
+      "note": "Chapter 3 gives a detailed account of Euler's Basel Problem solution including the sin(x)/x factorization, his computation of higher zeta values, and the historical context of the Bernoulli family's failed attempts"
     }
   ],
   "crossReferences": [
@@ -181,6 +188,16 @@
       "targetId": "infinitude-primes",
       "relationship": "related",
       "description": "Euler's proof of the infinitude of primes uses the Euler product ζ(s) = ∏(1-p⁻ˢ)⁻¹ — the same zeta function whose value at s=2 is the Basel problem"
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "related",
+      "description": "Both reveal π in unexpected contexts: Basel finds π in a sum over integers, Buffon finds π in a probability of needle crossings. Together they illustrate π's ubiquity beyond geometry — connecting number theory and probability to the circle constant."
+    },
+    {
+      "targetId": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\approx \\sqrt{2\\pi n}(n/e)^n$ shares the same mysterious appearance of π in a discrete context. Both results ultimately trace to Fourier analysis: Basel via Bernoulli polynomial Fourier expansions, Stirling via the saddle-point method on the Gamma function."
     }
   ],
   "relatedProofs": [
@@ -190,7 +207,9 @@
     "euler-identity",
     "prime-reciprocal-divergence",
     "pi-transcendental",
-    "e-transcendental"
+    "e-transcendental",
+    "buffons-needle",
+    "stirling-formula"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary
**amgm-inequality:**
- Added cross-references to `herons-formula` and `hilbert-17`
- Added Wiedijk (2008) reference

**abel-ruffini-oq-04:**
- Normalized 5 references to gallery-standard `authors/title/year/venue/note` format

**basel-problem:**
- Full annotation rewrite: 6 → 9 annotations, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- 3 new annotations covering previously uncovered sections (docstring, basic properties, numerical verification)
- Added cross-references to `buffons-needle` and `stirling-formula`
- Added Dunham (1999) reference

## Test plan
- [x] All meta.json and annotations.json files validate as well-formed JSON
- [x] Cross-reference target IDs exist in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)