### PR TITLE
Enrich 4 proofs: abel-ruffini, area-of-circle, arithmetic-series, basel-problem

### DIFF
--- a/src/data/proofs/basel-problem/annotations.source.json
+++ b/src/data/proofs/basel-problem/annotations.source.json
@@ -7,13 +7,16 @@
     },
     "type": "concept",
     "title": "Mathlib Imports",
-    "content": "We import `Mathlib.NumberTheory.ZetaValues` which contains the main Basel identity theorem, plus `Mathlib.Analysis.PSeries` for convergence and `Mathlib.Topology.Algebra.InfiniteSum.Basic` for the `HasSum` and `Summable` predicates.",
+    "content": "We import `Mathlib.NumberTheory.ZetaValues` which contains `hasSum_zeta_two` (the main Basel identity theorem) and `hasSum_zeta_four` (for ζ(4)), plus `Mathlib.Analysis.PSeries` for p-series convergence and `Mathlib.Topology.Algebra.InfiniteSum.Basic` for the `HasSum` and `Summable` predicates. The `ZetaValues` module builds on Bernoulli polynomial theory and Fourier analysis — the one-line proof `hasSum_zeta_two` conceals hundreds of supporting lemmas.",
+    "mathContext": "The four imports form the foundation: `ZetaValues` provides $\\zeta(2k) = (-1)^{k+1} 2^{2k-1} \\pi^{2k} B_{2k}/(2k)!$; `PSeries` provides $\\sum n^{-p} < \\infty \\iff p > 1$; `InfiniteSum` provides the `HasSum` predicate and `tsum` notation.",
     "significance": "supporting",
     "relatedConcepts": [
       "Mathlib",
       "zeta values",
-      "infinite sums"
-    ]
+      "infinite sums",
+      "Bernoulli polynomials"
+    ],
+    "prerequisites": ["Lean 4 import system", "Mathlib library structure", "HasSum/Summable API"]
   },
   {
     "id": "ann-basel-main",
@@ -32,7 +35,8 @@
       "HasSum",
       "convergence",
       "Basel problem"
-    ]
+    ],
+    "prerequisites": ["hasSum_zeta_two", "HasSum predicate", "real division"]
   },
   {
     "id": "ann-basel-tsum",
@@ -69,7 +73,8 @@
       "p-series",
       "Summable",
       "comparison test"
-    ]
+    ],
+    "prerequisites": ["Real.summable_nat_rpow_inv", "rpow_natCast", "Summable predicate"]
   },
   {
     "id": "ann-euler-history",
@@ -106,6 +111,7 @@
       "Bernoulli numbers",
       "zeta values",
       "special functions"
-    ]
+    ],
+    "prerequisites": ["hasSum_zeta_four", "hasSum_zeta_nat", "Bernoulli number theory"]
   }
 ]

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -71,6 +71,14 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Introduction and Historical Context",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports `ZetaValues`, `InfiniteSum.Basic`, `PSeries`, and `Tactic`. Extensive docstring covering the Basel Problem statement ($\\zeta(2) = \\pi^2/6$), Wiedijk #14 reference, mathematical approach via Bernoulli polynomials and Fourier analysis, Mathlib dependencies, and historical context (Mengoli 1650, Bernoulli family's failed attempts, Euler's 1734 solution).",
+      "mathContext": "The Basel Problem: $\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6} \\approx 1.6449$. Posed by Mengoli in 1650, solved by Euler in 1734 using the factorization $\\frac{\\sin x}{x} = \\prod_{n=1}^{\\infty}(1 - x^2/n^2\\pi^2)$."
+    },
+    {
       "id": "main-theorem",
       "title": "The Basel Identity",
       "startLine": 58,
@@ -198,6 +206,16 @@
       "targetId": "stirling-formula",
       "relationship": "related",
       "description": "Stirling's approximation $n! \\approx \\sqrt{2\\pi n}(n/e)^n$ shares the same mysterious appearance of π in a discrete context. Both results ultimately trace to Fourier analysis: Basel via Bernoulli polynomial Fourier expansions, Stirling via the saddle-point method on the Gamma function."
+    },
+    {
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "Euler proved ∑ 1/p diverges using the Euler product ζ(s) = ∏(1-p⁻ˢ)⁻¹ — the same zeta function framework. The divergence of ∑ 1/p contrasts with the convergence of ∑ 1/n² = π²/6, highlighting how prime density differs from integer density"
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "The Basel identity ζ(2) = π²/6 involves two transcendental constants: π (Lindemann 1882) and implicitly e via the Gamma function and Bernoulli number machinery underlying the proof"
     }
   ],
   "relatedProofs": [


### PR DESCRIPTION
## Summary

### abel-ruffini
- Added 2 new annotations (lines 47-57, 120-129) to fill coverage gaps
- Extended ann-small-solvable range to include s0/s1 theorem bodies
- Added Pesic's "Abel's Proof" to references

### area-of-circle
- Fixed duplicate JSON keys (relatedProofs, leanFile, references all duplicated)
- Added cross-references to basel-problem and euler-identity
- Added 2 scholarly references

### arithmetic-series
- Added header section and mathContext to all 6 sections
- Added 2 new annotations (header, pairing_identity_mul_two)
- Added prerequisites to 5 annotations; added refs and cross-refs

### basel-problem
- Added header-imports section (lines 1-56)
- Fixed crossReferences gap (prime-reciprocal-divergence, e-transcendental were in relatedProofs but missing from crossReferences)
- Added prerequisites to 4 annotations; expanded imports annotation

## Test plan
- [x] JSON validates for all entries
- [x] No annotation build errors for any entry
- [x] All cross-reference targets verified to exist
- [x] lineCount matches actual Lean files

🤖 Generated with [Claude Code](https://claude.com/claude-code)