### PR TITLE
Research: skolem-noether - prove 3 core sorries

### DIFF
--- a/proofs/Proofs/SkolemNoetherMatrixAut.lean
+++ b/proofs/Proofs/SkolemNoetherMatrixAut.lean
@@ -98,9 +98,24 @@ theorem isInnerAut_trans {φ ψ : Matrix n n K ≃ₐ[K] Matrix n n K}
 section SkolemNoetherProof
 
 -- Key helper: matrix unit multiplication (routine computation)
+private theorem stdBasis_entry (i₀ j₀ : n) (c : K) (a₀ b₀ : n) :
+    Matrix.stdBasisMatrix i₀ j₀ c a₀ b₀ = if i₀ = a₀ ∧ j₀ = b₀ then c else 0 := by
+  simp [Matrix.stdBasisMatrix, Matrix.single]
+
 private theorem stdBasis_mul (i j k l : n) :
     Matrix.stdBasisMatrix i j (1 : K) * Matrix.stdBasisMatrix k l 1 =
-      if j = k then Matrix.stdBasisMatrix i l 1 else 0 := by sorry
+      if j = k then Matrix.stdBasisMatrix i l 1 else 0 := by
+  ext a b
+  simp only [Matrix.mul_apply, Matrix.zero_apply, stdBasis_entry]
+  by_cases hjk : j = k
+  · subst hjk; simp only [if_pos rfl, stdBasis_entry]
+    rw [Finset.sum_eq_single j
+      (fun m _ hm => by simp [Ne.symm hm])
+      (fun h => absurd (Finset.mem_univ _) h)]
+    split_ifs <;> simp_all [stdBasis_entry]
+  · simp only [if_neg hjk]
+    apply Finset.sum_eq_zero; intro m _
+    split_ifs <;> simp_all [stdBasis_entry]
 
 -- Key helper: phi preserves matrix unit multiplication
 private theorem f_mul (φ : Matrix n n K ≃ₐ[K] Matrix n n K) (i j k l : n) :
@@ -114,7 +129,11 @@ private theorem intertwine_prop
     (i j k : n) :
     (φ (Matrix.stdBasisMatrix i j 1)).mulVec
       ((φ (Matrix.stdBasisMatrix k i₀ 1)).mulVec v₀) =
-    if j = k then (φ (Matrix.stdBasisMatrix i i₀ 1)).mulVec v₀ else 0 := by sorry
+    if j = k then (φ (Matrix.stdBasisMatrix i i₀ 1)).mulVec v₀ else 0 := by
+  rw [Matrix.mulVec_mulVec, f_mul φ i j k i₀]
+  split_ifs
+  · rfl
+  · exact Matrix.zero_mulVec v₀
 
 -- Key helper: linear independence of constructed vectors
 private theorem p_linearIndependent
@@ -134,7 +153,22 @@ theorem skolemNoether [Nonempty n] (φ : Matrix n n K ≃ₐ[K] Matrix n n K) :
   obtain ⟨i₀⟩ := ‹Nonempty n›
   -- phi(E_{i0,i0}) != 0, so find v0 with nonzero action
   obtain ⟨v₀, hv₀⟩ : ∃ v : n → K,
-      (φ (Matrix.stdBasisMatrix i₀ i₀ 1)).mulVec v ≠ 0 := by sorry
+      (φ (Matrix.stdBasisMatrix i₀ i₀ 1)).mulVec v ≠ 0 := by
+    by_contra hall; push_neg at hall
+    have hzero : φ (Matrix.stdBasisMatrix i₀ i₀ 1) = 0 := by
+      have mulvec_single : ∀ (M : Matrix n n K) (i j : n),
+          M.mulVec (Pi.single j 1) i = M i j := by
+        intro M i j
+        simp [Matrix.mulVec, Matrix.vecMul, Pi.single_apply,
+              Finset.sum_ite_eq', Finset.mem_univ]
+      ext a b
+      have key := congr_fun (hall (Pi.single b 1)) a
+      simp only [Pi.zero_apply] at key
+      rwa [mulvec_single] at key
+    have hne : Matrix.stdBasisMatrix i₀ i₀ (1 : K) ≠ 0 := by
+      intro h; have := congr_fun (congr_fun h i₀) i₀
+      simp [Matrix.stdBasisMatrix, Matrix.of_apply] at this
+    exact hne (φ.injective (hzero.trans (map_zero φ).symm))
   -- Define column vectors p_j and matrix P
   set p : n → (n → K) := fun j => (φ (Matrix.stdBasisMatrix j i₀ 1)).mulVec v₀
   set Pmat : Matrix n n K := Matrix.of (fun i j => p j i)

--- a/proofs/Proofs/SkolemNoetherMatrixAutAristotle.lean
+++ b/proofs/Proofs/SkolemNoetherMatrixAutAristotle.lean
@@ -1,0 +1,77 @@
+/-
+  Aristotle targets for Skolem-Noether Matrix Automorphism proof
+  (cayley-hamilton-minpoly-oq-02-oq-01-oq-01)
+
+  Routine supporting lemmas for automated proof search.
+  See SkolemNoetherMatrixAut.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known results likely provable from Mathlib
+  - Clean theorem statements with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+
+  Remaining sorries in the main file:
+  1. p_linearIndependent: linearly independent vectors from intertwining
+  2. IsUnit Pmat: invertibility from linear independence
+  3. hintertwine: phi(A)*P = P*A by linearity from generators
+-/
+import Mathlib
+
+set_option linter.deprecated false
+
+namespace SkolemNoetherAristotle
+
+variable {K : Type*} [Field K]
+variable {n : Type*} [DecidableEq n] [Fintype n]
+
+/-
+  Lemma 1: Linear independence from intertwining property
+
+  Given vectors p_j = φ(E_{j,i₀}).mulVec(v₀) satisfying:
+    φ(E_{ij}).mulVec(p_k) = δ_{jk} · p_i
+
+  The p_j are linearly independent. Proof:
+  Suppose ∑ c_j p_j = 0. Apply φ(E_{kk}).mulVec:
+    ∑ c_j · φ(E_{kk}).mulVec(p_j) = 0
+    ∑ c_j · δ_{kj} · p_k = 0
+    c_k · p_k = 0
+  Since p_k ≠ 0 (from hv₀), c_k = 0.
+-/
+theorem linearIndependent_of_intertwine
+    (p : n → (n → K))
+    (hp_ne : ∀ j, p j ≠ 0)
+    (hfp : ∀ i j k, (fun a => ∑ m, (if i = a ∧ j = m then (1 : K) else 0) *
+      p k m) = if j = k then p i else 0) :
+    LinearIndependent K p := by sorry
+
+/-
+  Lemma 2: Square matrix with linearly independent columns is invertible
+
+  If the columns of an n×n matrix over a field are linearly independent,
+  the matrix is a unit (invertible). This is standard linear algebra.
+-/
+theorem isUnit_of_linearIndependent_cols
+    (P : Matrix n n K)
+    (hli : LinearIndependent K (fun j : n => fun i : n => P i j)) :
+    IsUnit P := by sorry
+
+/-
+  Lemma 3: Matrix decomposition into standard basis
+
+  Every matrix A can be written as A = ∑ᵢ ∑ⱼ A(i,j) • E_ij.
+  This is the standard basis decomposition for matrices.
+-/
+theorem matrix_eq_sum_stdBasisMatrix (A : Matrix n n K) :
+    A = ∑ i : n, ∑ j : n, A i j • Matrix.stdBasisMatrix i j 1 := by sorry
+
+/-
+  Lemma 4: mulVec distributes over Finset.sum with smul
+
+  M.mulVec (∑ j, c j • v j) = ∑ j, c j • M.mulVec (v j)
+-/
+theorem mulVec_finset_sum_smul (M : Matrix n n K) (c : n → K)
+    (v : n → (n → K)) :
+    M.mulVec (∑ j : n, c j • v j) = ∑ j : n, c j • M.mulVec (v j) := by sorry
+
+end SkolemNoetherAristotle

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -1,8 +1,8 @@
 {
   "id": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
   "name": "Skolem-Noether Theorem: K-Algebra Automorphisms of Mn(K)",
-  "status": "progress",
-  "phase": "ORIENT",
+  "status": "active",
+  "phase": "ACT",
   "knowledge": {
     "insights": [
       "Parent file CayleyHamiltonMinpolyOQ02OQ01.lean is complete (217 lines, 0 axioms, 0 sorries)",
@@ -29,7 +29,13 @@
       "Key structure: intertwine_prop gives phi(E_ij).mulVec(p_k) = delta_jk p_i",
       "Matrix.mulVec_mulVec needed careful handling: use show/rw not direct rewrite",
       "Matrix.stdBasisMatrix deprecated to Matrix.single in current Mathlib",
-      "congr_fun (intertwine_prop ...) a converts mulVec equality to entry-wise"
+      "congr_fun (intertwine_prop ...) a converts mulVec equality to entry-wise",
+      "PROVED stdBasis_entry: Matrix.stdBasisMatrix entry unfolding via Matrix.single",
+      "PROVED stdBasis_mul: E_ij * E_kl = δ_jk * E_il via Finset.sum_eq_single + split_ifs",
+      "PROVED intertwine_prop: phi(E_ij).mulVec(p_k) = δ_jk p_i via mulVec_mulVec + f_mul",
+      "PROVED ∃ v₀: nonzero matrix has nonzero mulVec action via Pi.single column test",
+      "Matrix.stdBasisMatrix normalizes to Matrix.single in current Mathlib - need Matrix.single in simp set",
+      "Matrix.dotProduct does NOT exist in current Mathlib - use Matrix.mulVec directly with Finset.sum_ite_eq"
     ],
     "builtItems": [
       "Complete elementary proof strategy (no Artin-Wedderburn needed)",
@@ -37,7 +43,10 @@
       "Proof steps 1-3 (hf_mul, hfp, hp_ne) have verified strategies",
       "stdBasisMatrix_mul: E_ij * E_kl = δ_jk * E_il (proved, key infrastructure for Skolem-Noether)",
       "theorem skolemNoether: 0 axioms, compiles with 7 helper sorries",
-      "Proof architecture: stdBasis_mul -> f_mul -> intertwine_prop -> p_linearIndependent -> skolemNoether"
+      "Proof architecture: stdBasis_mul -> f_mul -> intertwine_prop -> p_linearIndependent -> skolemNoether",
+      "stdBasis_entry helper lemma for unfolding Matrix.stdBasisMatrix entries",
+      "Aristotle companion file: SkolemNoetherMatrixAutAristotle.lean with 4 lemmas",
+      "mulvec_single helper: M.mulVec (Pi.single j 1) i = M i j"
     ],
     "openQuestions": [
       "RESOLVED: Artin-Wedderburn NOT needed",
@@ -53,7 +62,7 @@
       "hP_intertwine: Entry-wise via Matrix.mul_apply + Pi.single_apply + mulVec/dotProduct",
       "hP_comm: Extend from generators using matrix_eq_sum_single + congr lemmas"
     ],
-    "progressSummary": "PROGRESS: Eliminated axiom! Converted axiom skolemNoether to theorem with 7 helper sorries. 0 axioms, 7 sorries. Elementary matrix units proof structure compiles. Sorries are routine: matrix unit multiplication, intertwining, linear independence, invertibility."
+    "progressSummary": "PROGRESS: 3 more sorries eliminated (stdBasis_mul, intertwine_prop, ∃v₀). Down from 6 to 3 sorries, 0 axioms. Remaining: p_linearIndependent, IsUnit Pmat, hintertwine. Aristotle companion file created."
   },
   "leanFiles": [
     {

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-01.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-01.json
@@ -11,7 +11,13 @@
       "Mathlib has MeasureTheory.Integral.Bochner.FundThmCalculus with Lebesgue integral support",
       "Key Mathlib theorems: integral_hasDerivAt_right, integral_eq_sub_of_hasDerivAt already use measure theory",
       "Lipschitz→AC arithmetic: K*Σ(bk-ak) ≤ K*(ε/(K+1)) < ε by div_lt_self when K+1>1",
-      "AC→uniform continuity: instantiate with n=1, disjointness vacuous via Subsingleton.elim, use abs_sub_comm for direction"
+      "AC→uniform continuity: instantiate with n=1, disjointness vacuous via Subsingleton.elim, use abs_sub_comm for direction",
+      "BLOCKED: Jordan decomposition (BV → difference of monotone) NOT in Mathlib - key missing piece for axiom elimination",
+      "BLOCKED: AbsolutelyContinuousOn is custom-defined (not in Mathlib) - no Mathlib AC→BV path exists",
+      "Cantor function sorry requires full construction (~200+ lines): define via ternary expansion, prove continuous, monotone, not AC",
+      "Path to lebesgue_ftc_differentiable: AC→BV (provable) → Jordan decomp (MISSING) → Monotone.ae_differentiableAt (exists)",
+      "BoundedVariationOn and eVariationOn exist in Mathlib.Analysis.BoundedVariation",
+      "Monotone.ae_differentiableAt confirmed working in Mathlib (used in line 236)"
     ],
     "builtItems": [
       "lipschitz_implies_ac: proved via Finset.sum_le_sum + mul_le_mul_of_nonneg_left + div_lt_self chain",
@@ -22,11 +28,12 @@
       "Does Mathlib have the Lebesgue differentiation theorem for absolutely continuous functions?"
     ],
     "nextSteps": [
-      "Check Mathlib for absolutely continuous functions and their FTC",
-      "Formalize: AC function → derivative exists a.e. → integral of derivative equals function",
-      "Connect to Vitali covering lemma and Lebesgue density theorem if available"
+      "PREREQUISITE: Formalize Jordan decomposition for BV functions (BV → monotone₁ - monotone₂)",
+      "PREREQUISITE: Prove AC → BV using AC definition + partition argument",
+      "THEN: Combine to prove lebesgue_ftc_differentiable without axiom",
+      "SEPARATE: Construct Cantor function for counterexample sorry (non-blocking)"
     ],
-    "progressSummary": "PROGRESS: Eliminated 2 sorries (lipschitz_implies_ac arithmetic, ac_implies_uniformly_continuous Fin 1 instantiation). 1 sorry remains (Cantor function), 2 axioms (Lebesgue FTC)."
+    "progressSummary": "SURVEYED: Both axioms blocked on missing Jordan decomposition in Mathlib. Cantor function sorry needs ~200L construction. Infrastructure assessment complete."
   },
   "leanFiles": [
     {

--- a/src/data/research/problems/szemeredi-regularity.json
+++ b/src/data/research/problems/szemeredi-regularity.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 4 proved theorems supporting energy_increment_step. File: 342 lines, 13 theorems, 2 sorries (energy_increment_step, regularity_lemma_strong). The algebraic infrastructure for energy increment is now complete.",
+    "progressSummary": "NEAR-COMPLETE: Only energy_increment_step sorry remains. Main result regularity_lemma_strong already PROVED via Mathlib bridge. 0 axioms, 1 sorry.",
     "builtItems": [
       "edgeDensity_nonneg: 0 ≤ edgeDensity G A B (proved)",
       "edgeDensity_le_one: edgeDensity G A B ≤ 1 (proved)",
@@ -70,13 +70,17 @@
       "The four new lemmas are the key building blocks for energy_increment_step",
       "Positivity of parts.card*(parts.card-1) in ℚ needs case split on parts.card = 0 vs > 0",
       "energy_increment_step is the sole remaining sorry but is NOT used by regularity_lemma_strong (which bridges to Mathlib). It is standalone.",
-      "The proof requires: (1) extract irregular pair from non-regular partition, (2) get witness subsets, (3) construct refined partition, (4) prove energy increment >= eps^5, (5) bound cardinality. Steps 1-2 have helper lemmas (exists_irregular_witness). Step 3-4 need careful Finset construction and application of split_energy_excess_bound."
+      "The proof requires: (1) extract irregular pair from non-regular partition, (2) get witness subsets, (3) construct refined partition, (4) prove energy increment >= eps^5, (5) bound cardinality. Steps 1-2 have helper lemmas (exists_irregular_witness). Step 3-4 need careful Finset construction and application of split_energy_excess_bound.",
+      "STATUS CORRECTION: regularity_lemma_strong is PROVED (not sorry!) via Mathlib bridge to szemeredi_regularity",
+      "Only 1 sorry remains: energy_increment_step - non-critical since main result proved via Mathlib",
+      "File: 453 lines, 0 axioms, 1 sorry (energy_increment_step only)",
+      "energy_increment_step is standalone infrastructure for self-contained proof, not needed for regularity_lemma_strong"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "energy_increment_step: find irregular pair in partition, extract witness subsets, split vertices, apply density_sq_convex, bound energy gain by eps^5",
-      "regularity_lemma_strong: construct initial m₀-equipartition, iterate energy_increment_step, use max_iterations + partitionEnergy_le_one for termination",
-      "Consider creating SzemerediRegularityAristotle.lean companion file for provable supporting lemmas"
+      "OPTIONAL: Prove energy_increment_step for self-contained proof path (non-critical, main result already proved)",
+      "Steps: extract irregular pair, get witnesses, construct refined partition, prove energy gain >= eps^5",
+      "Algebraic infrastructure complete: split_energy_identity, split_energy_excess_bound"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Proved 3 of 6 sorries in the Skolem-Noether theorem for matrix automorphisms
- Created Aristotle companion file for the remaining 3 sorries
- File: `proofs/Proofs/SkolemNoetherMatrixAut.lean` (0 axioms, 3 sorries remaining)

## Progress
- **stdBasis_entry**: Helper lemma for `Matrix.stdBasisMatrix` entry unfolding (normalizes to `Matrix.single` in current Mathlib)
- **stdBasis_mul**: E_ij * E_kl = δ_jk * E_il — matrix unit multiplication rule
- **intertwine_prop**: φ(E_ij).mulVec(p_k) = δ_jk · p_i — intertwining property via `mulVec_mulVec` + `f_mul`
- **∃ v₀**: Nonzero matrix has nonzero column action — via `Pi.single` column test and `φ.injective`

## Remaining Sorries (3)
1. `p_linearIndependent` — constructed vectors are linearly independent
2. `IsUnit Pmat` — matrix with linearly independent columns is invertible
3. `hintertwine` — φ(A)*P = P*A extended from generators by K-linearity

## Findings
- `Matrix.dotProduct` does NOT exist in current Mathlib — use `Matrix.mulVec` directly
- `Matrix.stdBasisMatrix` normalizes to `Matrix.single` via deprecation simp — need `Matrix.single` in simp set for entry-level unfolding
- `ite_apply` needed to push function application through `if` for nested `Pi.single`

## Status
**Outcome**: progress (3/6 sorries proved)
**Next Steps**: Aristotle companion file submitted for automated proof search on remaining lemmas

🤖 Generated by researcher-1