### PR TITLE
Enrich abel-ruffini-oq-04: add section annotations, cross-references

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04/annotations.json
@@ -67,6 +67,27 @@
     ]
   },
   {
+    "id": "ann-part-ii-header",
+    "proofId": "abel-ruffini-oq-04",
+    "range": {
+      "startLine": 42,
+      "endLine": 45
+    },
+    "type": "context",
+    "title": "Part II: Propagating Non-Solvability to Symmetric Groups",
+    "content": "Part II takes the A₅ simplicity established in Part I and propagates it upward: since A₅ is non-solvable and A₅ embeds into Aₙ for all n ≥ 5, and Aₙ is a normal subgroup of Sₙ, the entire symmetric group Sₙ is forced to be non-solvable. This is the step that converts a fact about one specific group (A₅) into a universal statement about all large symmetric groups.",
+    "mathContext": "$A_5 \\hookrightarrow A_n \\trianglelefteq S_n$ for $n \\geq 5$. Non-solvability propagates: $A_5$ not solvable $\\Rightarrow$ $A_n$ not solvable $\\Rightarrow$ $S_n$ not solvable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "non-solvability propagation",
+      "subgroup embedding",
+      "normal subgroup"
+    ],
+    "prerequisites": [
+      "group theory"
+    ]
+  },
+  {
     "id": "ann-symmetric-not-solvable",
     "proofId": "abel-ruffini-oq-04",
     "range": {
@@ -110,6 +131,27 @@
     "prerequisites": [
       "arithmetic",
       "tactic-based proofs"
+    ]
+  },
+  {
+    "id": "ann-part-iii-header",
+    "proofId": "abel-ruffini-oq-04",
+    "range": {
+      "startLine": 67,
+      "endLine": 70
+    },
+    "type": "context",
+    "title": "Part III: The Solvable Side — Contrast Cases",
+    "content": "Part III provides the other side of the dichotomy: small symmetric groups ARE solvable. This section exists for pedagogical completeness — without knowing that S₀ through S₄ are solvable, the non-solvability of S₅ lacks context. The contrast makes the threshold at degree 5 visually and conceptually sharp: we see exactly where the boundary lies.",
+    "mathContext": "Contrast: $S_0, S_1, S_2, S_3, S_4$ are all solvable. The transition $S_4 \\to S_5$ is the exact break point, driven by $A_5$ being the first non-abelian simple group.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "contrast case",
+      "solvable group",
+      "pedagogical exposition"
+    ],
+    "prerequisites": [
+      "basic group theory"
     ]
   },
   {

--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -82,7 +82,10 @@
       "hermite-lindemann",
       "sqrt2-irrational",
       "e-transcendental",
-      "pi-transcendental"
+      "pi-transcendental",
+      "godel-incompleteness",
+      "halting-problem",
+      "cantor-diagonalization"
     ],
     "prerequisites": [
       "Group theory (normal subgroups, derived series, solvability)",
@@ -157,6 +160,21 @@
       "targetId": "pi-transcendental",
       "relationship": "related",
       "description": "Lindemann's proof that π is transcendental (1882) is a successor impossibility result: the transcendence of π implies the impossibility of squaring the circle, paralleling Abel-Ruffini's impossibility of the quintic formula — both show certain quantities escape finite algebraic description"
+    },
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "thematic",
+      "description": "Gödel's incompleteness (1931) extends the impossibility paradigm: Abel-Ruffini shows no radical formula captures all quintic roots, Gödel shows no formal system captures all arithmetic truths — both reveal fundamental limits of finite symbolic methods"
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "thematic",
+      "description": "Turing's halting problem (1936) parallels Abel-Ruffini: no algorithm decides all halting questions, just as no radical formula solves all quintics — both establish undecidability within natural-seeming computational frameworks"
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "thematic",
+      "description": "Cantor's diagonal argument (1891) established the impossibility proof paradigm used in different form by Abel-Ruffini: no enumeration captures all reals, just as no radical formula captures all quintic roots — both prove that certain 'natural' operations cannot reach all targets"
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
- Added 2 new annotations (`ann-part-ii-header`, `ann-part-iii-header`) for Part II/III section transitions
- Added 3 cross-references to `godel-incompleteness`, `halting-problem`, `cantor-diagonalization`
- 14 annotations total (up from 12), 16 cross-references (up from 13)

## Test plan
- [x] `pnpm build` passes
- [x] All cross-referenced proof IDs verified to exist in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)