### PR TITLE
Enrich amgm-inequality-oq-02: add cross-references, fill annotation gap

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["Finset.powersetCard", "Real.rpow", "Real.geom_mean_le_arith_mean_weighted"]
   },
   {
+    "id": "ann-amgm-oq02-part-i-setup",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 36, "endLine": 43 },
+    "type": "context",
+    "title": "Import and Part I: Foundation Setup",
+    "content": "The single `import Mathlib` loads the entire Mathlib library, giving access to `Finset.powersetCard` (for symmetric polynomial definition), `Real.rpow` (for fractional powers in Maclaurin means), `Real.geom_mean_le_arith_mean_weighted` (for AM-GM), and `sq_nonneg` (for sum-of-squares arguments). The `open Finset Real` declaration brings Finset operations (sum, prod, powersetCard, univ) and real analysis functions (sqrt, rpow) into scope without qualification. Part I begins the formal development with elementary symmetric polynomial definitions.",
+    "mathContext": "Mathlib provides the complete real analysis and combinatorics foundation. Key dependencies: `Finset.powersetCard k` (the set of $k$-element subsets), `Real.rpow` ($x^r$ for real $r$), `Real.geom_mean_le_arith_mean_weighted` (weighted AM-GM), and `sq_nonneg` ($x^2 \\geq 0$).",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib import", "Finset API", "Real analysis API"],
+    "prerequisites": ["Lean 4 module system"]
+  },
+  {
     "id": "ann-amgm-oq02-elemsymm",
     "proofId": "amgm-inequality-oq-02",
     "range": { "startLine": 44, "endLine": 60 },

--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -105,6 +105,21 @@
       "targetId": "binomial-theorem",
       "relationship": "related",
       "description": "Binomial coefficients C(n,k) normalize the elementary symmetric polynomials to form Maclaurin means"
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "related",
+      "description": "Both are fundamental inequalities formalized from first principles — the triangle inequality controls absolute sums while Maclaurin's chain controls symmetric polynomial means"
+    },
+    {
+      "targetId": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Power sums p_k = ∑ xᵢᵏ are related to elementary symmetric polynomials via Newton's identities (Newton-Girard formulas): p_k - e₁p_{k-1} + e₂p_{k-2} - ⋯ = (-1)^{k+1}ke_k. The Cauchy-Schwarz sum n·p₂ ≥ p₁² used here is a special case"
+    },
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "FTA guarantees that elementary symmetric polynomials e_k(x₁,...,xₙ) equal the coefficients (up to sign) of ∏(t - xᵢ) — the Vieta connection that makes Maclaurin's chain a statement about polynomial coefficients"
     }
   ],
   "overview": {
@@ -238,6 +253,9 @@
     "amgm-inequality",
     "amgm-inequality-oq-03",
     "cauchy-schwarz",
-    "binomial-theorem"
+    "binomial-theorem",
+    "triangle-inequality",
+    "sum-of-kth-powers",
+    "fundamental-theorem-algebra"
   ]
 }


### PR DESCRIPTION
## Summary
- Added 1 new annotation (`ann-amgm-oq02-part-i-setup`) filling gap at lines 36-43
- Added 3 cross-references: `triangle-inequality`, `sum-of-kth-powers`, `fundamental-theorem-algebra`
- 12 annotations total (up from 11), 7 cross-references (up from 4)

## Test plan
- [x] `pnpm build` passes
- [x] All cross-referenced proof IDs verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)