### PR TITLE
Enrich 6 entries: bertrands-postulate, basel, birthday, abel-ruffini, cauchy-schwarz, FTA

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -189,6 +189,16 @@
       "targetId": "hermite-lindemann",
       "relationship": "related",
       "description": "Hermite-Lindemann proves e^α is transcendental for algebraic α ≠ 0. FTA concerns algebraic numbers (roots of polynomials); transcendental numbers like e and π lie permanently outside the algebraic closure of Q but inside C"
+    },
+    {
+      "targetId": "general-quartic",
+      "relationship": "specializes",
+      "description": "Ferrari's quartic formula provides explicit complex roots for degree-4 polynomials; FTA guarantees such roots exist for any degree, subsuming all explicit formula results"
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "Lagrange's theorem on subgroup orders underpins the group-theoretic proof of FTA via Sylow theory: the non-existence of degree-2 extensions of C follows from the fact that [C:R] = 2 and every odd-degree polynomial over R has a real root"
     }
   ],
   "relatedProofs": [


### PR DESCRIPTION
## Summary
Enrichment pass on 6 gallery entries:

### fundamental-theorem-algebra
- Added 2 missing cross-references (general-quartic, lagrange-theorem) to match relatedProofs

### cauchy-schwarz
- Added missing mathContext to correlation section
- Added prerequisites array, Heisenberg/cosine-similarity to relatedConcepts

### birthday-problem
- Added 2 missing annotations (setting, combinatorics), deepened all keyInsights
- Removed broken cross-reference to non-existent birthday-problem-oq-03

### bertrands-postulate
- Added 2 sections, 2 annotations, cross-ref to riemann-hypothesis, Nagura reference

### basel-problem
- Fixed relatedProofs inconsistency, added Rivoal 2000 reference

### abel-ruffini
- Added CFSG connections and composition series concepts

## Test plan
- [x] All JSON validates
- [x] No new annotation build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)