### PR TITLE
Enrich area-of-circle: fix duplicate JSON keys, add cross-references

### DIFF
--- a/src/data/proofs/area-of-circle/annotations.json
+++ b/src/data/proofs/area-of-circle/annotations.json
@@ -2,12 +2,12 @@
   {
     "id": "ann-intro",
     "proofId": "area-of-circle",
-    "range": {"startLine": 1, "endLine": 50},
+    "range": {"startLine": 1, "endLine": 51},
     "type": "concept",
     "title": "Introduction: Area of a Circle (Wiedijk #9)",
     "content": "The file opens with imports of `Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls` (providing `Complex.volume_ball`) and `Mathlib.Tactic`. The extensive doc comment establishes this as Wiedijk #9 — one of the 100 most famous theorems. It explains the measure-theoretic approach: area is formalized as Lebesgue measure in $\\mathbb{R}^2$, modeled via $\\mathbb{C}$. The historical note credits Archimedes (c. 287–212 BCE) with the first rigorous proof using the method of exhaustion, where he showed the area equals that of a right triangle with base = circumference and height = radius.",
     "mathContext": "The method of exhaustion, formalized by Eudoxus of Cnidus and perfected by Archimedes, proves equalities by showing that the difference between two quantities can be made smaller than any given positive value — essentially the $\\varepsilon$-$\\delta$ definition of a limit. Archimedes inscribed $n$-gons with area $\\frac{n}{2}r^2 \\sin(2\\pi/n) \\to \\pi r^2$ as $n \\to \\infty$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Lebesgue measure", "Archimedes", "Wiedijk 100 theorems", "method of exhaustion"],
     "prerequisites": ["measure theory basics", "complex plane as ℝ²", "Mathlib library structure"]
   },
@@ -17,9 +17,9 @@
     "range": {"startLine": 52, "endLine": 84},
     "type": "theorem",
     "title": "Main Theorems: Open and Closed Disk Area = πr²",
-    "content": "The core results. `area_of_circle` proves that the Lebesgue measure of an open ball in $\\mathbb{C}$ with center $c$ and radius $r$ equals $r^2 \\cdot \\pi$, expressed as `ENNReal.ofReal r ^ 2 * ↑NNReal.pi`. The proof is a single line: `Complex.volume_ball center r`. Similarly, `area_of_closed_disk` proves the same for closed balls via `Complex.volume_closedBall`. The equality of open and closed disk areas reflects the measure-theoretic fact that the boundary circle (a 1-dimensional manifold) has 2-dimensional Lebesgue measure zero.",
+    "content": "The core results. `area_of_circle` proves that the Lebesgue measure of an open ball in $\\mathbb{C}$ with center $c$ and radius $r$ equals $r^2 \\cdot \\pi$, expressed as `ENNReal.ofReal r ^ 2 * ↑NNReal.pi`. The proof is a single line: `Complex.volume_ball center r`. Similarly, `area_of_closed_disk` proves the same for closed balls via `Complex.volume_closedBall`. The equality of open and closed disk areas reflects the measure-theoretic fact that the boundary circle (a 1-dimensional manifold) has 2-dimensional Lebesgue measure zero. Internally, `Complex.volume_ball` uses the general $n$-dimensional ball volume formula $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ specialized to $n=2$, where $\\Gamma(2) = 1! = 1$.",
     "mathContext": "The result is stated using `ENNReal` (extended non-negative reals $[0, \\infty]$) because Lebesgue measure takes values in $\\overline{\\mathbb{R}_{\\geq 0}}$. The `ENNReal.ofReal r` coercion maps negative $r$ to 0, handling the edge case of negative radius. `NNReal.pi` is $\\pi$ as a non-negative real. The `open MeasureTheory Metric` command brings `volume` and `ball`/`closedBall` into scope.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Complex.volume_ball", "Complex.volume_closedBall", "ENNReal", "NNReal.pi", "MeasureTheory.volume"],
     "prerequisites": ["Lebesgue measure", "metric balls in ℂ", "ENNReal coercions"]
   },

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -144,6 +144,16 @@
       "targetId": "pythagorean-theorem",
       "relationship": "foundational",
       "description": "The circle x²+y²=r² is defined by the Pythagorean relation — the equation underpinning the Lebesgue measure computation of the disk's area"
+    },
+    {
+      "targetId": "hermite-lindemann",
+      "relationship": "related",
+      "description": "The Hermite-Lindemann theorem proves π is transcendental, meaning the area πr² is transcendental for all nonzero algebraic r — connecting the geometric formula to number-theoretic impossibility"
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "The transcendence of e connects to the area formula via the Gaussian integral: ∫∫ e^{-(x²+y²)} dA = π, where converting to polar coordinates uses the area element from A = πr²"
     }
   ],
   "relatedProofs": [
@@ -151,7 +161,9 @@
     "buffons-needle",
     "pi-transcendental",
     "fundamental-theorem-calculus",
-    "pythagorean-theorem"
+    "pythagorean-theorem",
+    "hermite-lindemann",
+    "e-transcendental"
   ],
   "leanFile": {
     "imports": [
@@ -182,41 +194,13 @@
       "year": "2010",
       "venue": "Springer, 3rd edition",
       "note": "Historical account of Archimedes's method and its connection to integral calculus"
-    }
-  ],
-  "relatedProofs": [
-    "angle-trisection",
-    "buffons-needle"
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls",
-      "Mathlib.Tactic"
-    ],
-    "opens": [
-      "MeasureTheory",
-      "Metric"
-    ],
-    "namespace": "AreaOfCircle",
-    "lineCount": 155,
-    "axiomCount": 0,
-    "theoremCount": 7,
-    "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Archimedes",
-      "title": "Measurement of a Circle",
-      "year": "~250 BCE",
-      "venue": "Syracuse",
-      "note": "First rigorous calculation of the area of a circle using the method of exhaustion — bounded π between 3 10/71 and 3 1/7"
     },
     {
-      "authors": "Stillwell, John",
-      "title": "Mathematics and Its History",
-      "year": "2010",
-      "venue": "Springer, 3rd edition",
-      "note": "Historical account of Archimedes's method and its connection to integral calculus"
+      "authors": "Heath, Thomas L. (translator)",
+      "title": "The Works of Archimedes",
+      "year": "1897",
+      "venue": "Cambridge University Press",
+      "note": "Definitive English translation of Archimedes' works including 'Measurement of a Circle' — the primary source for his proof that the area of a circle equals that of a right triangle with legs equal to the circumference and radius"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Fixed critical data integrity bug**: Removed duplicate `relatedProofs`, `leanFile`, `references` keys in meta.json (JSON parser silently took last value, losing 3 cross-references and 1 reference)
- Fixed 2 annotations using non-standard `"significance": "critical"` → `"key"`
- Extended `ann-intro` range to cover line 51 gap
- Added cross-references to `hermite-lindemann` (π transcendence) and `e-transcendental` (Gaussian integral connection)
- Added Heath (1897) translation reference for Archimedes' original works
- Deepened `ann-main-theorem` with gamma function specialization detail

## Quality
- All 7 cross-references verified (gallery entries exist)
- JSON validated, no duplicate keys at any level
- Axiom integrity: 0 sorries, 0 axioms, verified status correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)