### PR TITLE
Enrich abel-ruffini-oq-04: fill annotation coverage gaps

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04/annotations.json
@@ -179,6 +179,27 @@
     ]
   },
   {
+    "id": "ann-part-iv-header",
+    "proofId": "abel-ruffini-oq-04",
+    "range": {
+      "startLine": 77,
+      "endLine": 80
+    },
+    "type": "context",
+    "title": "Part IV: Packaging the Sharp Dichotomy",
+    "content": "Part IV distills the results of Parts II and III into a single theorem witnessing the solvability threshold. Where Part II proved non-solvability for n ≥ 5 and Part III showed solvability for small n, Part IV packages these into a conjunction that formally locates the phase transition. This step is mathematically trivial but pedagogically essential: it makes the sharp dichotomy at n = 5 a single quotable result rather than a pair of separate theorems scattered across the file.",
+    "mathContext": "The solvability threshold theorem: $\\text{IsSolvable}(S_1) \\wedge \\neg\\text{IsSolvable}(S_5)$ witnesses the exact transition at $n = 5$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "phase transition",
+      "proof packaging",
+      "pedagogical formalization"
+    ],
+    "prerequisites": [
+      "Parts II and III of this file"
+    ]
+  },
+  {
     "id": "ann-threshold",
     "proofId": "abel-ruffini-oq-04",
     "range": {
@@ -198,6 +219,28 @@
     "prerequisites": [
       "group theory",
       "finite group classification"
+    ]
+  },
+  {
+    "id": "ann-part-v-header",
+    "proofId": "abel-ruffini-oq-04",
+    "range": {
+      "startLine": 88,
+      "endLine": 91
+    },
+    "type": "context",
+    "title": "Part V: The Full Chain in Documentation",
+    "content": "Part V shifts from executable Lean code to comprehensive mathematical documentation. While Parts I–IV contain machine-checked theorems, Part V reconstructs the complete 5-step proof chain (including Steps 2, 4, and 5 which are handled internally by Mathlib or require field theory not formalized here) in a structured comment. This serves a dual purpose: it connects the formalized steps to the full mathematical narrative, and it provides degree-by-degree comparison tables that make the 'Why 5?' question visually concrete.",
+    "mathContext": "The full chain: $A_5$ simple $\\Rightarrow$ $A_5$ not solvable $\\Rightarrow$ $S_n$ ($n \\geq 5$) not solvable $\\Rightarrow$ solvable Galois group needed $\\Rightarrow$ generic quintic unsolvable by radicals.",
+    "significance": "context",
+    "relatedConcepts": [
+      "literate programming",
+      "proof documentation",
+      "Galois bridge"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "Parts I–IV of this file"
     ]
   },
   {

--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -215,8 +215,8 @@
     {
       "id": "not-solvable",
       "title": "Sₙ Not Solvable for n ≥ 5",
-      "startLine": 42,
-      "endLine": 65,
+      "startLine": 41,
+      "endLine": 66,
       "summary": "Part II: Proves symmetric_not_solvable — Sₙ is not solvable for n ≥ 5. Converts natural number bound to cardinal bound via exact_mod_cast, then applies Mathlib's Equiv.Perm.not_solvable. Instantiates for S₅, S₆, S₇ using le_rfl and omega.",
       "mathContext": "$\\forall n \\geq 5,\\ \\neg\\text{IsSolvable}(S_n)$. Proof: $5 \\leq |\\text{Fin}\\, n|$ via `exact_mod_cast`, then `Equiv.Perm.not_solvable`."
     },
@@ -224,7 +224,7 @@
       "id": "small",
       "title": "Small Symmetric Groups Are Solvable",
       "startLine": 67,
-      "endLine": 75,
+      "endLine": 76,
       "summary": "Shows S₀ and S₁ are solvable via Lean's typeclass inference (inferInstance). These trivial cases contrast with the non-solvable S₅ and above.",
       "mathContext": "$S_0 \\cong S_1 \\cong \\{e\\}$ are trivially solvable. Full picture: $S_n$ solvable $\\iff n \\leq 4$."
     },
@@ -232,7 +232,7 @@
       "id": "threshold",
       "title": "The Solvability Threshold",
       "startLine": 77,
-      "endLine": 86,
+      "endLine": 87,
       "summary": "Packages the sharp dichotomy: S₁ solvable ∧ S₅ not solvable. Witnesses the exact transition point at n = 5 where radical solvability breaks.",
       "mathContext": "$\\text{IsSolvable}(S_1) \\wedge \\neg\\text{IsSolvable}(S_5)$: the transition is sharp at $n = 5$."
     },
@@ -240,7 +240,7 @@
       "id": "chain",
       "title": "The Complete Proof Chain (Documentation)",
       "startLine": 88,
-      "endLine": 152,
+      "endLine": 153,
       "summary": "Comprehensive documentation of the 5-step proof chain (A₅ simple → non-solvable → Sₙ not solvable → Galois bridge → generic quintic). Includes 'Why Exactly 5?' table (derived series for S₁ through S₅) and 'Crucial Asymmetry' table (degree-by-degree radical solvability with historical formula discoverers).",
       "mathContext": "$A_5$ simple $\\Rightarrow$ $[A_5, A_5] = A_5$ $\\Rightarrow$ $S_n$ not solvable $\\Rightarrow$ $\\text{Gal}(x^5 + \\cdots) \\cong S_5$ not solvable $\\Rightarrow$ no radical formula."
     },


### PR DESCRIPTION
## Summary
- Added 2 annotations (Part IV header lines 77-80, Part V header lines 88-91) to eliminate annotation coverage gaps
- Extended section boundaries to close trivial line gaps at separator lines
- Verified all 15 cross-references point to existing gallery entries
- Entry already at quality 100; this is a verification pass with minor completeness fixes

## Changes
- `annotations.json`: Added `ann-part-iv-header` and `ann-part-v-header` annotations
- `meta.json`: Adjusted section `startLine`/`endLine` boundaries to eliminate 1-line gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)