### PR TITLE
Research: tucker-handshaking - prove even_card_odd_degree and strengthen Tucker parity

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ03OQ01OQ01.lean
+++ b/proofs/Proofs/BorsukUlamOQ03OQ01OQ01.lean
@@ -1,4 +1,5 @@
 import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Tactic
@@ -302,6 +303,121 @@ triangulation that respects the antipodal structure.
 -/
 
 -- ========================================================================
+-- Part IX: SimpleGraph Handshaking → Even Odd-Degree Count
+-- ========================================================================
+
+/-
+## Connecting to Mathlib: Graph Handshaking Eliminates a Hypothesis
+
+The `tucker_parity_principle` above requires three hypotheses:
+1. `h_interior_deg`: interior Tucker degree = complementary degree
+2. `h_handshaking`: the number of odd-degree triangles is even
+3. `h_boundary_odd`: boundary has odd number of odd-degree triangles
+
+Hypothesis (2) is redundant when the Tucker graph is a `SimpleGraph`:
+Mathlib's handshaking lemma (`sum_degrees_eq_twice_card_edges`) implies
+that any finite simple graph has an even number of odd-degree vertices.
+
+This reduces Tucker's lemma to just two hypotheses:
+- Interior degree correspondence (structural)
+- Boundary oddness (from 1D Tucker)
+-/
+
+/-- Sum of values mod 2 equals count mod 2 when all values satisfy `f i % 2 = 1`. -/
+private theorem sum_mod2_eq_card_mod2 {ι : Type*} [DecidableEq ι]
+    (s : Finset ι) (f : ι → ℕ)
+    (h : ∀ i ∈ s, f i % 2 = 1) :
+    (∑ i ∈ s, f i) % 2 = s.card % 2 := by
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih =>
+    rw [Finset.sum_insert ha, Finset.card_insert_of_notMem ha]
+    have := h _ (Finset.mem_insert_self _ _)
+    have := ih (fun i hi => h i (Finset.mem_insert_of_mem hi))
+    omega
+
+/-- Sum of values mod 2 is 0 when all values satisfy `f i % 2 = 0`. -/
+private theorem sum_mod2_eq_zero {ι : Type*} [DecidableEq ι]
+    (s : Finset ι) (f : ι → ℕ)
+    (h : ∀ i ∈ s, f i % 2 = 0) :
+    (∑ i ∈ s, f i) % 2 = 0 := by
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih =>
+    rw [Finset.sum_insert ha]
+    have := h _ (Finset.mem_insert_self _ _)
+    have := ih (fun i hi => h i (Finset.mem_insert_of_mem hi))
+    omega
+
+/-- The number of odd-degree vertices in any finite simple graph is even.
+
+By the handshaking lemma, `∑ v, G.degree v = 2|E|` (even).
+Splitting by degree parity: the even-degree sum is even, the odd-degree
+sum has the same parity as its count, so the count must be even. -/
+theorem even_card_odd_degree_vertices
+    [Fintype T] [DecidableEq T]
+    (G : SimpleGraph T) [DecidableRel G.Adj] :
+    Even (Finset.univ.filter (fun v : T => Odd (G.degree v))).card := by
+  -- Convert Odd to % 2 = 1 for decidability
+  simp_rw [Nat.odd_iff]
+  rw [Nat.even_iff]
+  -- Partition vertices into odd-degree (% 2 = 1) and even-degree (% 2 = 0)
+  set S₁ := Finset.univ.filter (fun v : T => G.degree v % 2 = 1) with hS₁_def
+  set S₀ := Finset.univ.filter (fun v : T => G.degree v % 2 = 0) with hS₀_def
+  -- S₁ and S₀ are disjoint and cover univ
+  have hdisjoint : Disjoint S₁ S₀ := by
+    rw [Finset.disjoint_filter]
+    exact fun v _ h1 h0 => by omega
+  have hunion : S₁ ∪ S₀ = Finset.univ := by
+    ext v; constructor
+    · intro _; exact Finset.mem_univ v
+    · intro _; simp only [hS₁_def, hS₀_def, Finset.mem_union, Finset.mem_filter,
+        Finset.mem_univ, true_and]; omega
+  -- Total degree sum is even (handshaking lemma)
+  have hsum := G.sum_degrees_eq_twice_card_edges
+  have htot : (∑ v : T, G.degree v) % 2 = 0 := by omega
+  -- Split sum into two parts
+  have hsplit : ∑ v : T, G.degree v =
+      (∑ v ∈ S₁, G.degree v) + (∑ v ∈ S₀, G.degree v) := by
+    rw [← Finset.sum_union hdisjoint, hunion]
+  -- Even-degree sum ≡ 0 (mod 2)
+  have heven : (∑ v ∈ S₀, G.degree v) % 2 = 0 :=
+    sum_mod2_eq_zero _ _ (fun v hv =>
+      (Finset.mem_filter.mp hv).2)
+  -- Odd-degree sum ≡ count (mod 2)
+  have hodd : (∑ v ∈ S₁, G.degree v) % 2 = S₁.card % 2 :=
+    sum_mod2_eq_card_mod2 _ _ (fun v hv =>
+      (Finset.mem_filter.mp hv).2)
+  omega
+
+-- ========================================================================
+-- Part X: Tucker Parity with Graph-Derived Handshaking
+-- ========================================================================
+
+/-- **Strengthened Tucker parity**: the handshaking hypothesis is derived
+from graph structure rather than assumed.
+
+Given a `SimpleGraph T` representing the Tucker graph (where edges connect
+triangles sharing a complementary edge), the handshaking lemma
+(`∑ degrees = 2|E|`) automatically implies the parity condition.
+
+This reduces Tucker's parity argument to just two hypotheses:
+1. Interior degree correspondence (G.degree = complementaryDegree)
+2. Boundary oddness (from 1D Tucker on the boundary) -/
+theorem tucker_parity_from_graph
+    [Fintype V] [Fintype T] [DecidableEq V] [DecidableEq T]
+    [HasBoundary T]
+    (K : TriangulatedComplex V T) (l : TuckerLabeling V)
+    (G : SimpleGraph T) [DecidableRel G.Adj]
+    (h_interior_deg : ∀ t, ¬HasBoundary.isBoundary t →
+      G.degree t = complementaryDegree K l t)
+    (h_boundary_odd : Odd (Finset.univ.filter (fun t =>
+      HasBoundary.isBoundary t ∧ Odd (G.degree t))).card) :
+    ∃ t : T, ¬HasBoundary.isBoundary t ∧ hasComplementaryEdge K l t :=
+  tucker_parity_principle K l (fun t => G.degree t) h_interior_deg
+    (even_card_odd_degree_vertices G) h_boundary_odd
+
+-- ========================================================================
 -- Verification
 -- ========================================================================
 
@@ -312,5 +428,7 @@ triangulation that respects the antipodal structure.
 #check hasComplementaryEdge_iff_complementaryDegree_pos
 #check tucker_parity_principle
 #check tucker_2d_from_parity
+#check even_card_odd_degree_vertices
+#check tucker_parity_from_graph
 
 end TuckerPathFollowing

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Tucker (1946)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Tucker%27s_lemma",
     "date": "1946",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BorsukUlamOQ03OQ01OQ01.lean",
     "leanFile": "proofs/Proofs/BorsukUlamOQ03OQ01OQ01.lean",
     "tags": [
@@ -20,7 +20,7 @@
       "simplicial-complex"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-22",
     "mathlibDependencies": [
@@ -33,6 +33,11 @@
         "theorem": "Fintype",
         "description": "Finite type infrastructure for finite complexes",
         "module": "Mathlib.Data.Fintype.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.DegreeSum",
+        "description": "Handshaking lemma (sum_degrees_eq_twice_card_edges) for even parity proof",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
       }
     ],
     "originalContributions": [
@@ -41,7 +46,9 @@
       "complementary_pairs: classifies all possible complementary label pairs",
       "TriangulatedComplex: finite triangulated 2-complex with adjacency",
       "tucker_parity_principle: parity argument core (odd boundary → interior edge exists)",
-      "tucker_2d_from_parity: combines parity with 1D Tucker for full 2D result"
+      "tucker_2d_from_parity: combines parity with 1D Tucker for full 2D result",
+      "even_card_odd_degree_vertices: general graph theory result — any finite simple graph has even count of odd-degree vertices",
+      "tucker_parity_from_graph: strengthened Tucker parity eliminating handshaking hypothesis via SimpleGraph structure"
     ],
     "references": [
       {
@@ -82,7 +89,7 @@
         "description": "Quantitative Borsuk-Ulam and 1D Tucker (parent file providing boundary result)"
       }
     ],
-    "lineCount": 316
+    "lineCount": 434
   },
   "overview": {
     "historicalContext": "Tucker's lemma (1946) is the discrete combinatorial analogue of the Borsuk-Ulam theorem, one of the fundamental results of algebraic topology. Albert Tucker, a Princeton mathematician best known for the Karush-Kuhn-Tucker conditions in optimization, proved that any antipodal labeling of a triangulated sphere must contain a complementary edge — two adjacent vertices whose labels sum to zero. The graph-theoretic path-following proof, popularized by Matousek's influential textbook 'Using the Borsuk-Ulam Theorem' (2003), reveals the constructive content of Tucker's lemma: one can actually follow a path through the triangulation to find the complementary edge algorithmically. This constructive approach connects Tucker's lemma to the broader family of path-following algorithms in combinatorial topology, including Sperner's lemma (for fixed-point theorems) and the Lemke-Howson algorithm (for Nash equilibria). The equivalence between Tucker's lemma and Borsuk-Ulam was established by several authors, making the combinatorial version a powerful tool for proving topological results without homotopy theory.",
@@ -152,17 +159,23 @@
       "startLine": 215,
       "endLine": 249,
       "summary": "Provides a minimal 5-vertex, 3-triangle example illustrating complementary edge counting. Shows that non-antipodal triangulations can have even boundary count, emphasizing the necessity of the antipodal structure for the parity argument."
+    },
+    {
+      "id": "handshaking",
+      "title": "SimpleGraph Handshaking → Even Odd-Degree Count",
+      "startLine": 306,
+      "endLine": 395,
+      "summary": "Proves even_card_odd_degree_vertices: any finite SimpleGraph has an even number of odd-degree vertices. Uses Finset induction + omega for modular arithmetic. Derives from Mathlib handshaking lemma (sum_degrees_eq_twice_card_edges). Then proves tucker_parity_from_graph: a strengthened Tucker parity principle that eliminates the handshaking hypothesis — only 2 hypotheses needed (interior degree correspondence + boundary oddness) instead of 3."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the combinatorial core of Tucker's 2D lemma with 249 lines, 8 theorems, 5 definitions, and 1 sorry (the parity principle). The modular architecture separates labeling definitions, exhaustive pair classification, triangulated complex structure, and the parity argument. The only remaining sorry is the double-counting argument for the parity principle — all other theorems are fully machine-checked.",
+    "summary": "Formalizes the combinatorial core of Tucker's 2D lemma with 434 lines, 10 theorems, 3 definitions, 0 axioms, and 0 sorries. All theorems are fully machine-checked. The modular architecture separates labeling definitions, pair classification, triangulated complex structure, parity argument, and graph-theoretic handshaking connection.",
     "implications": "The modular decomposition (1D Tucker → parity → 2D Tucker) provides a clean proof architecture that separates topological content (triangulation existence) from combinatorial content (parity counting). The path-following interpretation gives algorithmic content: the proof is not just existential but describes a procedure to find the complementary edge. This connects Tucker's lemma to the broader program of constructive combinatorial topology.",
     "openQuestions": [
-      "Prove tucker_parity_principle via formal double-counting / handshaking lemma on the Tucker graph",
+      "Reformulate parent tucker_2d axiom to use TriangulatedComplex (current statement is too broad for arbitrary graphs)",
       "Formalize the path-following algorithm as a constructive proof with a termination argument",
-      "Connect to the tucker_2d axiom in the parent file BorsukUlamOQ03OQ01.lean",
-      "Extend to Tucker's lemma in higher dimensions (n-dimensional Tucker for S^n)",
-      "Formalize the equivalence between Tucker's lemma and the Borsuk-Ulam theorem"
+      "Build explicit Tucker SimpleGraph construction from TriangulatedComplex + edge-sharing property",
+      "Connect to OQ03OQ03 tucker_2d_grid axiom (the real bottleneck)"
     ]
   },
   "leanFile": {
@@ -170,15 +183,16 @@
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Data.Fintype.Basic",
       "Mathlib.Data.ZMod.Basic",
-      "Mathlib.Tactic"
+      "Mathlib.Tactic",
+      "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
     ],
     "opens": [
       "Finset"
     ],
     "namespace": "TuckerPathFollowing",
-    "lineCount": 316,
+    "lineCount": 434,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 5
   }
 }

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
@@ -16,7 +16,11 @@
       "The file compiles cleanly with 0 axioms, 1 sorry (the parity principle itself)",
       "tucker_parity_principle sorry requires edge-sharing data: TriangulatedComplex needs axiom that each non-boundary edge is shared by exactly 2 triangles. Without this, the double-counting argument cannot be formalized.",
       "Proved tucker_parity_principle: 1 sorry eliminated (0A, 0S now)",
-      "Key: original hypothesis (odd boundary triangle count) insufficient alone. Reformulated with Tucker graph degree function + handshaking + interior degree connection"
+      "Key: original hypothesis (odd boundary triangle count) insufficient alone. Reformulated with Tucker graph degree function + handshaking + interior degree connection",
+      "even_card_odd_degree_vertices: proved that any finite SimpleGraph has even count of odd-degree vertices, from Mathlib handshaking lemma",
+      "tucker_parity_from_graph: eliminates h_handshaking hypothesis by using SimpleGraph structure. Tucker parity now needs only 2 hypotheses (interior degree + boundary oddness) instead of 3",
+      "Proof uses Finset.induction + omega for modular arithmetic, partitioning vertices by degree % 2",
+      "Parent tucker_2d axiom in OQ01 is stated too broadly (arbitrary graphs) - Tucker lemma requires triangulation structure. Cannot be proved as stated."
     ],
     "builtItems": [
       "BorsukUlamOQ03OQ01OQ01.lean: Tucker path-following infrastructure (249 lines)",
@@ -28,20 +32,24 @@
       "tucker_2d_from_parity: combines parity with 1D Tucker",
       "complementaryDegree: Finset-based edge counting (no sorry)",
       "hasComplementaryEdge_iff_complementaryDegree_pos: complete iff proof",
-      "tucker_parity_principle: complete proof via Finset partition + parity"
+      "tucker_parity_principle: complete proof via Finset partition + parity",
+      "even_card_odd_degree_vertices: Even #{v | Odd (G.degree v)} for any SimpleGraph (434 lines total)",
+      "sum_mod2_eq_card_mod2: helper - sum of odd values mod 2 = count mod 2",
+      "sum_mod2_eq_zero: helper - sum of even values mod 2 = 0",
+      "tucker_parity_from_graph: 2-hypothesis Tucker parity (no handshaking assumption needed)"
     ],
     "openQuestions": [
-      "Could tuckerDeg hypotheses be derived from SimpleGraph + edge-sharing?",
-      "Can h_handshaking be proved from Mathlib SimpleGraph.even_card_odd_degree_vertices?"
+      "Parent tucker_2d axiom is false for arbitrary graphs - needs reformulation with triangulation hypotheses",
+      "OQ03OQ03 tucker_2d_grid axiom is the real bottleneck - can it be proved from this infrastructure?"
     ],
     "nextSteps": [
-      "Build Tucker SimpleGraph from TriangulatedComplex + edge-sharing",
-      "Derive h_handshaking from Mathlib handshaking lemma",
-      "Connect to BorsukUlamOQ03OQ01 tucker_2d axiom"
+      "Reformulate tucker_2d in OQ01 to use TriangulatedComplex + AntipodalTuckerLabeling",
+      "Build explicit Tucker SimpleGraph construction from TriangulatedComplex with edge-sharing",
+      "Connect tucker_parity_from_graph to OQ03OQ03 tucker_2d_grid"
     ],
-    "progressSummary": "COMPLETED: Eliminated sole sorry. File now 0A, 0S. Replaced broken EdgeSharingProperty with clean Tucker graph degree abstraction."
+    "progressSummary": "Proved even_card_odd_degree_vertices (general graph theory) and tucker_parity_from_graph (eliminates handshaking hypothesis). File now 434 lines, 10 theorems, 0A, 0S."
   },
-  "lastUpdate": "2026-03-22T06:20:52Z",
+  "lastUpdate": "2026-03-22T20:00:00Z",
   "leanFiles": [
     {
       "path": "Proofs/BorsukUlam.lean",
@@ -101,8 +109,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01OQ01.lean",
-      "lineCount": 317,
-      "theoremCount": 6,
+      "lineCount": 434,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- Proved `even_card_odd_degree_vertices`: any finite SimpleGraph has even count of odd-degree vertices (from Mathlib handshaking lemma `sum_degrees_eq_twice_card_edges`)
- Added `tucker_parity_from_graph`: eliminates `h_handshaking` hypothesis by deriving it from SimpleGraph structure
- Tucker parity now needs only 2 hypotheses (interior degree + boundary oddness) instead of 3

## Files Modified
- `proofs/Proofs/BorsukUlamOQ03OQ01OQ01.lean`: 317→434 lines, 6→10 theorems, 0A 0S (fully verified)
- `src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/meta.json`: updated line count, theorem count, status
- `src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json`: updated knowledge

## Key Theorems Added
1. `sum_mod2_eq_card_mod2`: sum of odd values mod 2 = count mod 2
2. `sum_mod2_eq_zero`: sum of even values mod 2 = 0
3. `even_card_odd_degree_vertices`: `Even #{v | Odd (G.degree v)}` for any SimpleGraph
4. `tucker_parity_from_graph`: Tucker parity with only 2 hypotheses (no handshaking needed)

## Status
**Outcome**: completed
**Next Steps**: Reformulate parent `tucker_2d` axiom with proper triangulation hypotheses; connect to `tucker_2d_grid` in OQ03OQ03

🤖 Generated by researcher-7