### PR TITLE
Research: skolem-noether - prove p_linearIndependent and p_ne_zero

### DIFF
--- a/proofs/Proofs/SkolemNoetherMatrixAut.lean
+++ b/proofs/Proofs/SkolemNoetherMatrixAut.lean
@@ -135,12 +135,46 @@ private theorem intertwine_prop
   · rfl
   · exact Matrix.zero_mulVec v₀
 
+-- Key helper: each p_j is nonzero
+private theorem p_ne_zero
+    (φ : Matrix n n K ≃ₐ[K] Matrix n n K) (i₀ : n)
+    (v₀ : n → K) (hv₀ : (φ (Matrix.stdBasisMatrix i₀ i₀ 1)).mulVec v₀ ≠ 0)
+    (j : n) : (φ (Matrix.stdBasisMatrix j i₀ 1)).mulVec v₀ ≠ 0 := by
+  intro hpj
+  -- By intertwine_prop: phi(E_{i0,j}).mulVec(p_j) = p_{i0} (nonzero)
+  have h := intertwine_prop φ i₀ v₀ i₀ j j
+  simp only [if_pos rfl] at h
+  -- But p_j = 0, so phi(E_{i0,j}).mulVec(0) = 0
+  rw [hpj, Matrix.mulVec_zero] at h
+  -- 0 = p_{i0}, contradicting hv₀
+  exact hv₀ h.symm
+
 -- Key helper: linear independence of constructed vectors
 private theorem p_linearIndependent
     (φ : Matrix n n K ≃ₐ[K] Matrix n n K) (i₀ : n)
     (v₀ : n → K) (hv₀ : (φ (Matrix.stdBasisMatrix i₀ i₀ 1)).mulVec v₀ ≠ 0) :
     LinearIndependent K
-      (fun j : n => (φ (Matrix.stdBasisMatrix j i₀ 1)).mulVec v₀) := by sorry
+      (fun j : n => (φ (Matrix.stdBasisMatrix j i₀ 1)).mulVec v₀) := by
+  rw [Fintype.linearIndependent_iff]
+  intro c hsum k
+  -- hsum: ∑ j, c j • p_j = 0
+  -- Apply phi(E_{k,k}).mulVec to both sides via the linear map mulVecLin
+  set M := Matrix.mulVecLin (φ (Matrix.stdBasisMatrix k k 1)) with hM_def
+  have key : M (∑ j : n, c j • (φ (Matrix.stdBasisMatrix j i₀ 1)).mulVec v₀) = 0 := by
+    rw [hsum]; exact map_zero M
+  -- Distribute: M(∑ c_j • p_j) = ∑ c_j • M(p_j)
+  rw [map_sum] at key
+  simp only [map_smul] at key
+  -- Apply intertwine_prop: M(p_j) = phi(E_{k,k}).mulVec(p_j) = delta_{k,j} * p_k
+  simp only [hM_def, show ∀ j, Matrix.mulVecLin (φ (Matrix.stdBasisMatrix k k 1))
+      ((φ (Matrix.stdBasisMatrix j i₀ 1)).mulVec v₀) =
+      if k = j then (φ (Matrix.stdBasisMatrix k i₀ 1)).mulVec v₀ else 0 from
+      fun j => intertwine_prop φ i₀ v₀ k k j] at key
+  -- Sum collapses: ∑ c_j • (if k=j then p_k else 0) = c_k • p_k
+  simp only [smul_ite, smul_zero] at key
+  simp only [Finset.sum_ite_eq, Finset.mem_univ, ite_true] at key
+  -- key: c_k • p_k = 0, and p_k ≠ 0, so c_k = 0
+  exact (smul_eq_zero.mp key).resolve_right (p_ne_zero φ i₀ v₀ hv₀ k)
 
 /-- **Skolem-Noether Theorem**: Every K-algebra automorphism of Mn(K) is inner.
 

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -35,7 +35,12 @@
       "PROVED intertwine_prop: phi(E_ij).mulVec(p_k) = δ_jk p_i via mulVec_mulVec + f_mul",
       "PROVED ∃ v₀: nonzero matrix has nonzero mulVec action via Pi.single column test",
       "Matrix.stdBasisMatrix normalizes to Matrix.single in current Mathlib - need Matrix.single in simp set",
-      "Matrix.dotProduct does NOT exist in current Mathlib - use Matrix.mulVec directly with Finset.sum_ite_eq"
+      "Matrix.dotProduct does NOT exist in current Mathlib - use Matrix.mulVec directly with Finset.sum_ite_eq",
+      "PROVED p_ne_zero: each p_j ≠ 0 via intertwine_prop contradiction",
+      "PROVED p_linearIndependent: uses Fintype.linearIndependent_iff, mulVecLin distribution, intertwine_prop, Finset.sum_ite_eq, smul_eq_zero",
+      "Key technique: set M = Matrix.mulVecLin, then map_sum + map_smul distributes over Finset.sum",
+      "Remaining IsUnit: need linearIndependent cols → det ≠ 0 → IsUnit M path",
+      "Remaining hintertwine: need matrix_eq_sum_stdBasis decomposition + linearity extension"
     ],
     "builtItems": [
       "Complete elementary proof strategy (no Artin-Wedderburn needed)",
@@ -46,7 +51,9 @@
       "Proof architecture: stdBasis_mul -> f_mul -> intertwine_prop -> p_linearIndependent -> skolemNoether",
       "stdBasis_entry helper lemma for unfolding Matrix.stdBasisMatrix entries",
       "Aristotle companion file: SkolemNoetherMatrixAutAristotle.lean with 4 lemmas",
-      "mulvec_single helper: M.mulVec (Pi.single j 1) i = M i j"
+      "mulvec_single helper: M.mulVec (Pi.single j 1) i = M i j",
+      "p_ne_zero: proved each p_j vector is nonzero via intertwine_prop + contradiction",
+      "p_linearIndependent: proved from intertwine_prop + mulVecLin linearity + Finset.sum_ite_eq collapse"
     ],
     "openQuestions": [
       "RESOLVED: Artin-Wedderburn NOT needed",
@@ -54,15 +61,11 @@
       "Does Matrix.mulVec_sum exist in this Mathlib version?"
     ],
     "nextSteps": [
-      "DEEP DIVE: Implement full Lean4 proof using matrix units approach",
-      "hf_mul: ext + Pi.single_apply + Finset.sum_ite_eq + split_ifs",
-      "hfp: Matrix.mulVec_mulVec + hf_mul",
-      "hp_li: May need manual induction for mulVec distribution over Finset.sum",
-      "hP_isUnit: Try basisOfLinearIndependentOfCardEqFinrank + Basis change of basis",
-      "hP_intertwine: Entry-wise via Matrix.mul_apply + Pi.single_apply + mulVec/dotProduct",
-      "hP_comm: Extend from generators using matrix_eq_sum_single + congr lemmas"
+      "IsUnit Pmat: use Matrix.isUnit_iff_isUnit_det + det ≠ 0 from linearIndependent cols",
+      "hintertwine: decompose A = ∑ A_{ij} E_{ij}, use phi linearity + existing E_ij intertwining",
+      "Possibly use basisOfLinearIndependentOfCardEqFinrank for IsUnit proof"
     ],
-    "progressSummary": "PROGRESS: 3 more sorries eliminated (stdBasis_mul, intertwine_prop, ∃v₀). Down from 6 to 3 sorries, 0 axioms. Remaining: p_linearIndependent, IsUnit Pmat, hintertwine. Aristotle companion file created."
+    "progressSummary": "PROGRESS: Eliminated p_linearIndependent sorry (the mathematical core). Down from 3 to 2 sorries, 0 axioms. Remaining: IsUnit Pmat, hintertwine (Lean API plumbing)."
   },
   "leanFiles": [
     {
@@ -150,5 +153,6 @@
     "cayley-hamilton-minpoly-oq-02-oq-01",
     "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
     "cayley-hamilton-minpoly-oq-05"
-  ]
+  ],
+  "lastUpdate": "2026-03-22T21:00:00Z"
 }


### PR DESCRIPTION
## Summary
- Proved `p_ne_zero`: each vector p_j is nonzero (via intertwine_prop + contradiction)
- Proved `p_linearIndependent`: the constructed vectors are linearly independent
  - Uses `mulVecLin` for sum/smul distribution, `intertwine_prop` for the delta collapse, `Finset.sum_ite_eq` for sum simplification
- Sorries reduced from 3 to 2 in the Skolem-Noether proof

## Files Modified
- `proofs/Proofs/SkolemNoetherMatrixAut.lean`: eliminated p_linearIndependent sorry
- `src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json`: updated knowledge

## Remaining Sorries
1. `IsUnit Pmat` — matrix with linearly independent columns is invertible
2. `hintertwine` — extend phi(E_ij)*P = P*E_ij to all matrices by linearity

## Status
**Outcome**: progress
**Next Steps**: Prove IsUnit via det approach; prove hintertwine via basis decomposition

🤖 Generated by researcher-7