### PR TITLE
Enrich gallery: fix 27 status/badge mismatches, add cross-references

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Colin Maclaurin (1729); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Maclaurin%27s_inequality",
     "date": "1729",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02.lean",
     "tags": [
       "analysis",

--- a/src/data/proofs/borsuk-ulam-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Open (Borsuk 1933, Yang 1954, Dold 1983; general case open)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Borsuk%E2%80%93Ulam_theorem",
     "date": "1933",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BorsukUlamOQ02.lean",
     "tags": [
       "topology",
@@ -21,7 +21,7 @@
       "sphere",
       "cohomology"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Engelsma (2013), Polymath 8b (2014); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Polymath_project#Polymath8",
     "date": "2013",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BoundedPrimeGapsOQ03.lean",
     "tags": [
       "number-theory",
@@ -21,7 +21,7 @@
       "open-problem",
       "research"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "axioms": 1,
     "mathlibDependencies": [

--- a/src/data/proofs/cantors-theorem-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Cantor (1891); Easton (1970); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Beth_number",
     "date": "1891",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CantorsTheoremOQ01.lean",
     "tags": [
       "set-theory",
@@ -19,7 +19,7 @@
       "classic",
       "foundations"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "René Descartes (1637); Gauss (1826 proof); Mathlib 4.26.0 (upper bound only)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Descartes%27_rule_of_signs",
     "date": "1637",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ01.lean",
     "tags": [
       "algebra",
@@ -19,7 +19,7 @@
       "open-problem",
       "research"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/dirichlets-theorem-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Open (Siegel 1935 for bounds; Landau-Page theorem; Goldfeld 1976 conditional on GRH)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Siegel_zero",
     "date": "1935",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DirichletsTheoremOQ01.lean",
     "tags": [
       "number-theory",
@@ -21,7 +21,7 @@
       "research",
       "grh"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-1006-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Fisher, Fraughnaugh, Langley, West (1997); Nešetřil, Rödl (1978)",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "1997",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1006OQ02.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "probabilistic-method",
       "research"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/1007",
     "date": "2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1007OQ01.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -7,7 +7,7 @@
     "author": "Grunsky (question), Erdős-Herzog-Piranian (1958), Pommerenke (1961), Goodman (1966)",
     "sourceUrl": "https://erdosproblems.com/1047",
     "date": "1961",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1047Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1057/meta.json
+++ b/src/data/proofs/erdos-1057/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1956)",
     "sourceUrl": "https://erdosproblems.com/1057",
     "date": "1956",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1057Problem.lean",
     "mathlib_version": "4.24.0",
     "tags": [
@@ -18,7 +18,7 @@
       "counting-functions",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1057,
     "erdosUrl": "https://erdosproblems.com/1057",

--- a/src/data/proofs/erdos-1120/meta.json
+++ b/src/data/proofs/erdos-1120/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (via Halász Problem 4.22)",
     "sourceUrl": "https://erdosproblems.com/1120",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1120Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1138-oq-03/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Prime_gap",
     "date": "2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1138OQ03.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "analytic-number-theory",
       "research"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/400",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos400Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham-Ivić-Pomerance (1996), Sawhney (rediscovery)",
     "sourceUrl": "https://erdosproblems.com/419",
     "date": "1996",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos419Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Hofstadter, Erdős, Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/422",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos422Problem.lean",
     "leanFile": "Proofs/Erdos422Problem.lean",
     "tags": [

--- a/src/data/proofs/erdos-424/meta.json
+++ b/src/data/proofs/erdos-424/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1977)",
     "sourceUrl": "https://erdosproblems.com/424",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos424Problem.lean",
     "leanFile": "Proofs/Erdos424Problem.lean",
     "tags": [

--- a/src/data/proofs/erdos-428/meta.json
+++ b/src/data/proofs/erdos-428/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/428",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos428Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-542/meta.json
+++ b/src/data/proofs/erdos-542/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős; solved by Schinzel-Szekeres (1959)",
     "sourceUrl": "https://erdosproblems.com/542",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos542Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-811/meta.json
+++ b/src/data/proofs/erdos-811/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Pyber, and Tuza",
     "sourceUrl": "https://erdosproblems.com/811",
     "date": "1991",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos811Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-827/meta.json
+++ b/src/data/proofs/erdos-827/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1975, 1978)",
     "sourceUrl": "https://erdosproblems.com/827",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos827Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-896/meta.json
+++ b/src/data/proofs/erdos-896/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1972)",
     "sourceUrl": "https://erdosproblems.com/896",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos896Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-947/meta.json
+++ b/src/data/proofs/erdos-947/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Mirsky-Newman, Davenport-Rado",
     "sourceUrl": "https://erdosproblems.com/947",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos947Problem.lean",
     "leanFile": "Proofs/Erdos947Problem.lean",
     "tags": [

--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://en.wikipedia.org/wiki/Five_color_theorem",
     "date": "2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "graph-theory",
       "topology",
@@ -17,7 +17,7 @@
       "kempe-chains"
     ],
     "proofRepoPath": "Proofs/FiveColorTheorem.lean",
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -143,11 +143,17 @@
       "targetId": "sylow-theorems",
       "relationship": "related",
       "description": "Sylow theory reveals the subgroup structure of S₄ (Sylow 2-subgroups of order 8, Sylow 3-subgroups of order 3) that enables the composition series making S₄ solvable"
+    },
+    {
+      "targetId": "abel-ruffini-oq-04",
+      "relationship": "complementary",
+      "description": "The A₅ simplicity proof chain exposes each step from A₅ simple to 'no quintic formula' — this quartic file is the complementary 'last solvable case' showing S₄ solvable (derived series S₄ ▷ A₄ ▷ V₄ ▷ {e}) while S₅ is not"
     }
   ],
   "relatedProofs": [
     "solution-of-cubic",
     "abel-ruffini",
+    "abel-ruffini-oq-04",
     "fundamental-theorem-algebra",
     "angle-trisection",
     "lagrange-theorem",

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -7,9 +7,9 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Green%27s_theorem",
     "date": "1828 (Green), formalized 2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/GreensTheoremOQ03.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/lagrange-theorem-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hall_subgroup",
     "date": "2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeTheoremOQ03.lean",
     "tags": [
       "group-theory",

--- a/src/data/proofs/laws-of-large-numbers-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Kolmogorov (1930)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Law_of_large_numbers#Strong_law",
     "date": "1930",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ01.lean",
     "tags": [
       "probability",
@@ -19,7 +19,7 @@
       "open-problem",
       "research"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/randomized-maxcut-oq-01/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-01/meta.json
@@ -5,7 +5,7 @@
   "description": "Formalization of the Goemans-Williamson (1995) semidefinite programming approach to MaxCut, achieving an approximation ratio of α_GW ≈ 0.878 via hyperplane rounding of SDP relaxation.",
   "meta": {
     "author": "Lean Genius",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "graph-theory",
       "algorithms",
@@ -15,7 +15,7 @@
     ],
     "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/GoemansWilliamsonMaxCut.lean",
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "axioms": 9,
     "mathlibDependencies": [

--- a/src/data/proofs/solution-of-cubic/meta.json
+++ b/src/data/proofs/solution-of-cubic/meta.json
@@ -120,6 +120,11 @@
       "targetId": "angle-trisection",
       "relationship": "related-problem",
       "description": "The impossibility of angle trisection reduces to showing cos(20°) satisfies an irreducible cubic — the same cubic equation theory, applied to a geometric impossibility proof."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04",
+      "relationship": "complementary",
+      "description": "The A₅ simplicity proof chain shows exactly why no radical formula exists for degree ≥ 5: S₄ is solvable (so cubics and quartics yield to radical formulas) but S₅ is not — making the cubic formula one of the last explicit radical solutions"
     }
   ],
   "sections": [
@@ -194,6 +199,7 @@
   "relatedProofs": [
     "general-quartic",
     "abel-ruffini",
+    "abel-ruffini-oq-04",
     "fundamental-theorem-algebra",
     "de-moivre",
     "angle-trisection"

--- a/src/data/proofs/stirling-formula/meta.json
+++ b/src/data/proofs/stirling-formula/meta.json
@@ -8,7 +8,7 @@
     "author": "James Stirling / Abraham de Moivre (formalized via Mathlib)",
     "sourceUrl": "https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Analysis/SpecialFunctions/Stirling.lean",
     "date": "1730",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/StirlingFormula.lean",
     "tags": [
       "analysis",


### PR DESCRIPTION
## Summary

- Fix **27 entries** with `sorries: 0` and `axiomCount > 0` from `status: "formalized"` to `status: "axiomatized"` per the axiom integrity policy
- Fix **10 entries** with incorrect badge (e.g., `"open"`, `"wip"`, `"original"`) to `"axiom"` to match their axiom status
- Add `abel-ruffini-oq-04` as `relatedProof` and `crossReference` in `solution-of-cubic` and `general-quartic`
- Fix `amgm-inequality-oq-02` status from `"formalized"` to `"axiomatized"`

### Status fixes applied to:
borsuk-ulam-oq-02, bounded-prime-gaps-oq-03, cantors-theorem-oq-01, descartes-rule-of-signs-oq-01, dirichlets-theorem-oq-01, erdos-1006-oq-02, erdos-1007-oq-01, erdos-1047, erdos-1057, erdos-1120, erdos-1138-oq-03, erdos-400, erdos-419, erdos-422, erdos-424, erdos-428, erdos-542, erdos-811, erdos-827, erdos-896, erdos-947, euler-polyhedral-formula-oq-01-oq-01, greens-theorem-oq-03, lagrange-theorem-oq-03, laws-of-large-numbers-oq-01, randomized-maxcut-oq-01, stirling-formula

## Test plan
- [x] All modified JSON files validated with `jq`
- [x] Cross-reference target IDs verified to exist in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)