### PR TITLE
Enrich 4 entries: fix statuses, annotation accuracy, outdated sorry refs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -2,12 +2,12 @@
   "id": "amgm-inequality-oq-03",
   "title": "Power Mean Interpolation: How Do Weighted Power Means Relate to AM and GM?",
   "slug": "amgm-inequality-oq-03",
-  "description": "The weighted power mean M_r(z,w) = (∑ wᵢzᵢ^r)^(1/r) forms a continuous monotone family as r varies: HM = M_{-1} ≤ GM = lim_{r→0} M_r ≤ AM = M_1 ≤ M_2 ≤ ... This formalization proves HM ≤ GM directly via AM-GM on inverse values, and proves M_r ≤ M_s for 0 < r ≤ s via Jensen's inequality. The general monotonicity for negative r remains open in Mathlib4 (explicitly noted as a TODO).",
+  "description": "The weighted power mean M_r(z,w) = (∑ wᵢzᵢ^r)^(1/r) forms a continuous monotone family as r varies: HM = M_{-1} ≤ GM = lim_{r→0} M_r ≤ AM = M_1 ≤ M_2 ≤ ... This formalization proves HM ≤ GM directly via AM-GM on inverse values, M_r ≤ M_s for 0 < r ≤ s via Jensen's inequality, and M_r ≤ M_s for r ≤ s < 0 via the duality identity M_r(z) = M_{-r}(z⁻¹)⁻¹. Fully verified with 0 sorries and 0 axioms.",
   "meta": {
     "author": "Hardy, Littlewood, Pólya (1934); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Power_mean",
     "date": "1934",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AmgmInequalityOQ03.lean",
     "tags": [
       "analysis",


### PR DESCRIPTION
## Summary
- **amgm-inequality-oq-03**: Fixed status from "formalized" to "verified" (0 sorries, 0 axioms), updated description to reflect negative-r monotonicity is proved
- **amgm-inequality-oq-02**: Fixed outdated sorry references (resolved in prior PRs), corrected theorem count 13→17
- **abel-ruffini**: Extended `ann-small-solvable` annotation range to cover theorem declarations
- **amgm-inequality**: Fixed annotation accuracy for Mathlib theorem references, added cross-references

## Test plan
- [x] All JSON validates
- [x] Lean file verification: 0 sorries, 0 axioms confirmed in amgm-inequality-oq-03
- [x] Cross-reference targets verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)