### PR TITLE
Enrich 8 entries: section gaps + mathContext for classic proofs

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -3,11 +3,11 @@
     "id": "ann-header",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 1,
-      "endLine": 4
+      "startLine": 6,
+      "endLine": 32
     },
     "type": "concept",
-    "title": "Historical Introduction",
+    "title": "Module Documentation",
     "content": "The Abel-Ruffini theorem, proven by Niels Henrik Abel in 1824 and later illuminated by Galois's theory, answers a 300-year-old question: why is there no 'quintic formula' like the quadratic formula?\n\nGalois discovered that solvability by radicals is equivalent to having a solvable Galois group, revealing a profound connection between field theory and group theory.",
     "mathContext": "The question: Given $ax^5 + bx^4 + cx^3 + dx^2 + ex + f = 0$, is there a formula for $x$ using only $+, -, \\times, \\div,$ and $\\sqrt[n]{\\phantom{x}}$?",
     "significance": "supporting",
@@ -25,8 +25,8 @@
     "id": "ann-imports",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 6,
-      "endLine": 32
+      "startLine": 1,
+      "endLine": 4
     },
     "type": "concept",
     "title": "Mathlib Imports",
@@ -44,27 +44,23 @@
     ]
   },
   {
-    "id": "ann-namespace-variables",
+    "id": "ann-namespace",
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 34,
-      "endLine": 49
+      "endLine": 35
     },
     "type": "context",
-    "title": "Namespace and Universe-Polymorphic Field Variables",
-    "content": "The `AbelRuffini` namespace scopes all theorems. The universe-polymorphic variables `F` and `E` set up the proof's field-extension context: `F` is an arbitrary field (the 'base'), `E` is an extension field with an `Algebra F E` instance encoding the inclusion $F \\hookrightarrow E$.\n\nThis polymorphism means the theorems apply to any field extension — $\\mathbb{Q} \\hookrightarrow \\mathbb{R}$, $\\mathbb{Q} \\hookrightarrow \\mathbb{C}$, $\\mathbb{F}_p \\hookrightarrow \\overline{\\mathbb{F}_p}$, etc. The `{F : Type*}` syntax uses auto-bound implicit universes, allowing Lean to infer the universe level.",
-    "mathContext": "The `Algebra F E` instance encodes a ring homomorphism $\\phi: F \\to E$ making $E$ an $F$-algebra. For field extensions, this is the inclusion map. Universe polymorphism means theorems hold at any universe level, not just `Type 0` (= `Type`).",
+    "title": "Namespace Declaration",
+    "content": "The `AbelRuffini` namespace scopes all theorems in the file. All theorem names are prefixed with `AbelRuffini.` when referenced externally (e.g., `AbelRuffini.galois_bridge`). The namespace is closed at line 185 with `end AbelRuffini`.",
+    "mathContext": "Lean 4 namespaces organize declarations hierarchically. The `AbelRuffini` namespace groups `galois_bridge`, `symmetric_group_not_solvable`, `not_solvable_by_rad_of_not_solvable_gal`, etc. under a common prefix.",
     "significance": "context",
     "prerequisites": [
-      "Lean 4 universe polymorphism",
-      "Algebra typeclass",
-      "field extensions"
+      "Lean 4 namespace system"
     ],
     "relatedConcepts": [
-      "universe polymorphism",
-      "Algebra F E",
-      "field extension",
-      "auto-bound implicit"
+      "Lean 4 namespaces",
+      "module organization"
     ]
   },
   {
@@ -72,10 +68,10 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 36,
-      "endLine": 46
+      "endLine": 49
     },
     "type": "definition",
-    "title": "Solvable by Radicals",
+    "title": "Solvable by Radicals and Field Variables",
     "content": "An element α is 'solvable by radicals' if it can be built from the base field using field operations and nth roots. The quadratic formula is an example: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$\n\nMathlib defines this inductively via `IsSolvableByRad`, with constructors for: base field elements, arithmetic operations, and radical extraction.",
     "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over F.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by: 2 ∈ ℚ, then √2, then 1+√2, then √(1+√2).",
     "significance": "critical",
@@ -98,7 +94,7 @@
       "endLine": 67
     },
     "type": "theorem",
-    "title": "Abel-Ruffini Theorem (One Direction)",
+    "title": "The Galois Bridge Theorem",
     "content": "**Theorem**: If α is expressible using radicals, then the Galois group of its minimal polynomial is solvable.\n\nThis is the key bridge: radical solvability (field theory) → group solvability (group theory).\n\nThe proof proceeds by induction on `IsSolvableByRad`. The key case: if α^n is solvable, then adjoining α creates a cyclic extension, and cyclic groups are abelian (hence solvable).",
     "mathContext": "$\\alpha$ solvable by radicals $\\Rightarrow$ Gal(minpoly(α)) is solvable\n\nContrapositive: If Galois group is NOT solvable, roots are NOT expressible by radicals.",
     "significance": "critical",
@@ -166,7 +162,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 86,
-      "endLine": 100
+      "endLine": 93
     },
     "type": "technique",
     "title": "Instantiating Non-Solvability for S₅ and S₆",
@@ -214,7 +210,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 100,
-      "endLine": 112
+      "endLine": 118
     },
     "type": "insight",
     "title": "Solvable Small Symmetric Groups: The Other Side of the Threshold",

--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -3,10 +3,11 @@
     "id": "ann-header",
     "proofId": "abel-ruffini",
     "anchor": {
-      "type": "imports"
+      "type": "section-doc",
+      "contains": "What This Proves"
     },
     "type": "concept",
-    "title": "Historical Introduction",
+    "title": "Module Documentation",
     "content": "The Abel-Ruffini theorem, proven by Niels Henrik Abel in 1824 and later illuminated by Galois's theory, answers a 300-year-old question: why is there no 'quintic formula' like the quadratic formula?\n\nGalois discovered that solvability by radicals is equivalent to having a solvable Galois group, revealing a profound connection between field theory and group theory.",
     "mathContext": "The question: Given $ax^5 + bx^4 + cx^3 + dx^2 + ex + f = 0$, is there a formula for $x$ using only $+, -, \\times, \\div,$ and $\\sqrt[n]{\\phantom{x}}$?",
     "significance": "supporting",
@@ -21,8 +22,7 @@
     "id": "ann-imports",
     "proofId": "abel-ruffini",
     "anchor": {
-      "type": "section-doc",
-      "contains": "What This Proves"
+      "type": "imports"
     },
     "type": "concept",
     "title": "Mathlib Imports",
@@ -37,35 +37,34 @@
     "prerequisites": ["Lean 4 import system", "Mathlib library structure"]
   },
   {
-    "id": "ann-namespace-variables",
+    "id": "ann-namespace",
     "proofId": "abel-ruffini",
     "anchor": {
       "type": "namespace",
       "name": "AbelRuffini",
-      "extendAfter": 15
+      "extendAfter": 1
     },
     "type": "context",
-    "title": "Namespace and Universe-Polymorphic Field Variables",
-    "content": "The `AbelRuffini` namespace scopes all theorems. The universe-polymorphic variables `F` and `E` set up the proof's field-extension context: `F` is an arbitrary field (the 'base'), `E` is an extension field with an `Algebra F E` instance encoding the inclusion $F \\hookrightarrow E$.\n\nThis polymorphism means the theorems apply to any field extension — $\\mathbb{Q} \\hookrightarrow \\mathbb{R}$, $\\mathbb{Q} \\hookrightarrow \\mathbb{C}$, $\\mathbb{F}_p \\hookrightarrow \\overline{\\mathbb{F}_p}$, etc. The `{F : Type*}` syntax uses auto-bound implicit universes, allowing Lean to infer the universe level.",
-    "mathContext": "The `Algebra F E` instance encodes a ring homomorphism $\\phi: F \\to E$ making $E$ an $F$-algebra. For field extensions, this is the inclusion map. Universe polymorphism means theorems hold at any universe level, not just `Type 0` (= `Type`).",
+    "title": "Namespace Declaration",
+    "content": "The `AbelRuffini` namespace scopes all theorems in the file. All theorem names are prefixed with `AbelRuffini.` when referenced externally (e.g., `AbelRuffini.galois_bridge`). The namespace is closed at line 185 with `end AbelRuffini`.",
+    "mathContext": "Lean 4 namespaces organize declarations hierarchically. The `AbelRuffini` namespace groups `galois_bridge`, `symmetric_group_not_solvable`, `not_solvable_by_rad_of_not_solvable_gal`, etc. under a common prefix.",
     "significance": "context",
     "relatedConcepts": [
-      "universe polymorphism",
-      "Algebra F E",
-      "field extension",
-      "auto-bound implicit"
+      "Lean 4 namespaces",
+      "module organization"
     ],
-    "prerequisites": ["Lean 4 universe polymorphism", "Algebra typeclass", "field extensions"]
+    "prerequisites": ["Lean 4 namespace system"]
   },
   {
     "id": "ann-solvable-by-rad",
     "proofId": "abel-ruffini",
     "anchor": {
       "type": "section-doc",
-      "contains": "Part I: Solvable by Radicals"
+      "contains": "Part I: Solvable by Radicals",
+      "extendAfter": 3
     },
     "type": "definition",
-    "title": "Solvable by Radicals",
+    "title": "Solvable by Radicals and Field Variables",
     "content": "An element \u03b1 is 'solvable by radicals' if it can be built from the base field using field operations and nth roots. The quadratic formula is an example: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$\n\nMathlib defines this inductively via `IsSolvableByRad`, with constructors for: base field elements, arithmetic operations, and radical extraction.",
     "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over F.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by: 2 \u2208 \u211a, then \u221a2, then 1+\u221a2, then \u221a(1+\u221a2).",
     "significance": "critical",
@@ -85,7 +84,7 @@
       "kind": "theorem"
     },
     "type": "theorem",
-    "title": "Abel-Ruffini Theorem (One Direction)",
+    "title": "The Galois Bridge Theorem",
     "content": "**Theorem**: If \u03b1 is expressible using radicals, then the Galois group of its minimal polynomial is solvable.\n\nThis is the key bridge: radical solvability (field theory) \u2192 group solvability (group theory).\n\nThe proof proceeds by induction on `IsSolvableByRad`. The key case: if \u03b1^n is solvable, then adjoining \u03b1 creates a cyclic extension, and cyclic groups are abelian (hence solvable).",
     "mathContext": "$\\alpha$ solvable by radicals $\\Rightarrow$ Gal(minpoly(\u03b1)) is solvable\n\nContrapositive: If Galois group is NOT solvable, roots are NOT expressible by radicals.",
     "significance": "critical",
@@ -144,7 +143,7 @@
       "type": "declaration",
       "name": "s5_not_solvable",
       "kind": "theorem",
-      "extendAfter": 12
+      "extendAfter": 5
     },
     "type": "technique",
     "title": "Instantiating Non-Solvability for S\u2085 and S\u2086",
@@ -185,7 +184,8 @@
     "proofId": "abel-ruffini",
     "anchor": {
       "type": "section-doc",
-      "contains": "Part IV: Solvability of Small Symmetric Groups"
+      "contains": "Part IV: Solvability of Small Symmetric Groups",
+      "extendAfter": 6
     },
     "type": "insight",
     "title": "Solvable Small Symmetric Groups: The Other Side of the Threshold",

--- a/src/data/proofs/brouwer-fixed-point/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point/annotations.json
@@ -9,6 +9,7 @@
     "type": "concept",
     "title": "The Fixed Point Theorem That Changed Mathematics",
     "content": "Brouwer's Fixed Point Theorem states: every continuous function from a closed ball to itself has a fixed point. Despite its simple statement, this 1911 result required the development of algebraic topology to prove.\n\nThe intuition is beautiful: imagine stirring coffee in a circular cup. No matter how you stir (continuously), at least one point of coffee ends up exactly where it started. You cannot continuously move every point!\n\nThis formalization presents the conceptual structure. The full proof requires homology theory or degree theory, which we axiomatize to focus on the logical flow.",
+    "mathContext": "Brouwer's Fixed Point Theorem: $\\forall f: B^n \\to B^n$ continuous, $\\exists x \\in B^n: f(x) = x$, where $B^n = \\{x \\in \\mathbb{R}^n : \\|x\\| \\leq 1\\}$.",
     "significance": "critical",
     "relatedConcepts": [
       "fixed point",
@@ -62,6 +63,7 @@
     "type": "definition",
     "title": "Retractions: Projecting to Subspaces",
     "content": "A **retraction** from space X onto subspace A is a continuous map $r: X \\to A$ that fixes A:\n$$r(a) = a \\text{ for all } a \\in A$$\n\nIntuitively: a retraction 'projects' X onto A without moving points already in A. Examples:\n- Projecting $\\mathbb{R}^2$ onto the x-axis: $(x, y) \\mapsto (x, 0)$ is a retraction\n- Projecting a square onto one of its edges: valid retraction\n\nBut some retractions are impossible! You cannot retract the ball onto its boundary sphere. This impossibility is the key to Brouwer's theorem.\n\nThe intuition: the ball is 'solid' (contractible), but the sphere is 'hollow' (has a hole). You can't continuously project solid onto hollow.",
+    "mathContext": "A retraction $r: X \\to A$ satisfies $r \\circ \\iota = \\text{id}_A$ where $\\iota: A \\hookrightarrow X$ is the inclusion. Equivalently, $r(a) = a$ for all $a \\in A$.",
     "significance": "critical",
     "relatedConcepts": [
       "projection",
@@ -101,6 +103,7 @@
     "type": "concept",
     "title": "The Brilliant Ray Construction",
     "content": "This is the proof's clever geometric construction. Given a fixed-point-free map $f$, we build a retraction:\n\n**Construction:** For each point $x$ in the ball:\n1. Compute $f(x)$ (which is different from $x$ by assumption)\n2. Draw a ray from $f(x)$ through $x$\n3. The ray must exit the ball at some point on the sphere\n4. Define $r(x)$ to be that exit point\n\n**Why this works:**\n- Since $f(x) \\neq x$, the ray direction is well-defined\n- The map $x \\mapsto r(x)$ is continuous (ray-casting varies smoothly)\n- If $x$ is on the sphere, the ray from $f(x)$ through $x$ exits at $x$ itself\n- Therefore $r$ fixes the boundary: it's a retraction!\n\nBut wait: we just proved no retraction exists! Contradiction. So our assumption was wrong: $f$ must have a fixed point.",
+    "mathContext": "The ray from $f(x)$ through $x$ is $\\{f(x) + t(x - f(x)) : t \\geq 0\\}$. The exit point $r(x) \\in S^{n-1}$ is the unique $t > 0$ solving $\\|f(x) + t(x-f(x))\\| = 1$. For $x \\in S^{n-1}$: $r(x) = x$ (retraction property).",
     "significance": "critical",
     "prerequisites": [
       "ann-no-retraction"
@@ -143,6 +146,7 @@
     "type": "insight",
     "title": "Dimension 1: The Intermediate Value Theorem",
     "content": "In dimension 1, Brouwer's theorem says: every continuous $f: [0,1] \\to [0,1]$ has a fixed point.\n\nThis can be proved directly using the Intermediate Value Theorem!\n\n**Proof:** Define $g(x) = f(x) - x$.\n- At $x = 0$: $g(0) = f(0) - 0 = f(0) \\geq 0$ (since $f(0) \\in [0,1]$)\n- At $x = 1$: $g(1) = f(1) - 1 \\leq 0$ (since $f(1) \\in [0,1]$)\n- By IVT, $g(c) = 0$ for some $c$, meaning $f(c) = c$\n\nThe 1D case is elementary; the theorem's power comes from higher dimensions where this argument fails and algebraic topology is needed.",
+    "mathContext": "1D Brouwer: $f: [0,1] \\to [0,1]$ continuous $\\Rightarrow \\exists c: f(c) = c$. Proof via IVT: $g(x) = f(x) - x$ satisfies $g(0) \\geq 0 \\geq g(1)$, so $g(c) = 0$ for some $c \\in [0,1]$.",
     "significance": "key",
     "relatedConcepts": [
       "intermediate value theorem",
@@ -160,6 +164,7 @@
     "type": "insight",
     "title": "Dimension 2: Stirring Coffee",
     "content": "The 2D case is the famous 'coffee cup theorem': when you stir coffee in a circular cup, at least one point of coffee returns to its starting position.\n\n**Why is this surprising?**\nYou might think: 'I'll just rotate everything!' But pure rotation has the center fixed. What about more complex stirring?\n\nNo matter how cleverly you stir:\n- If continuous (no tearing the liquid)\n- And the coffee stays in the cup (maps cup to itself)\n\n...some point must be fixed. You cannot continuously move every point of a disk!\n\nThis is genuinely counterintuitive. The theorem says it's impossible to avoid fixed points, even though we can't easily find them.",
+    "mathContext": "2D Brouwer: $f: D^2 \\to D^2$ continuous $\\Rightarrow \\exists p \\in D^2: f(p) = p$, where $D^2 = \\{(x,y) : x^2+y^2 \\leq 1\\}$. The proof requires topology beyond IVT — the fundamental group $\\pi_1(S^1) \\cong \\mathbb{Z}$ obstructs retracting $D^2$ onto $S^1$.",
     "significance": "key",
     "relatedConcepts": [
       "rotation",

--- a/src/data/proofs/buffons-needle/annotations.json
+++ b/src/data/proofs/buffons-needle/annotations.json
@@ -6,6 +6,7 @@
     "type": "concept",
     "title": "Buffon's Needle Problem: Wiedijk #99",
     "content": "**Buffon's Needle** (1777):\n\nA needle of length $\\ell$ is dropped onto a floor with parallel lines spaced $d$ apart. If $\\ell \\leq d$:\n$$P(\\text{crosses line}) = \\frac{2\\ell}{\\pi d}$$\n\n**Why Remarkable**:\n1. One of the first problems in **geometric probability**\n2. Provides a **Monte Carlo method** to estimate $\\pi$!\n3. Connects probability to **integral geometry**\n\n**Historical**: Posed by Georges-Louis Leclerc, Comte de Buffon (1777) in \"Essai d'arithmétique morale\".\n\n**Key Insight**: The appearance of $\\pi$ arises from integrating $\\sin\\theta$ over the angle.",
+    "mathContext": "For needle length $\\ell \\leq d$ (line spacing): $P(\\text{crosses}) = \\frac{2\\ell}{\\pi d}$. The $\\pi$ arises from $\\int_0^\\pi \\sin\\theta\\,d\\theta = 2$.",
     "significance": "critical",
     "relatedConcepts": ["geometric probability", "Monte Carlo", "integral geometry"],
     "prerequisites": ["uniform probability distributions", "integration of trigonometric functions", "geometric measure theory"]
@@ -77,6 +78,7 @@
     "type": "note",
     "title": "Numerical Examples",
     "content": "**Special Cases Verified**:\n\n**Equal Length** ($\\ell = d$):\n```lean\ntheorem buffon_equal_length (h : ℓ = d) :\n    2 * ℓ / (π * d) = 2 / π\n```\n$P = 2/\\pi \\approx 0.6366$ (about 64% chance of crossing)\n\n**Half Length** ($\\ell = d/2$):\n```lean\ntheorem buffon_half_length (h : ℓ = d / 2) :\n    2 * ℓ / (π * d) = 1 / π\n```\n$P = 1/\\pi \\approx 0.3183$ (about 32% chance of crossing)\n\n**Note**: As $\\ell \\to 0$, $P \\to 0$ (tiny needles rarely cross).",
+    "mathContext": "$\\ell = d \\Rightarrow P = 2/\\pi \\approx 0.637$; $\\ell = d/2 \\Rightarrow P = 1/\\pi \\approx 0.318$; $\\ell \\to 0 \\Rightarrow P \\to 0$.",
     "significance": "supporting",
     "relatedConcepts": ["special cases", "numerical verification", "field_simp"],
     "prerequisites": ["buffon_needle_probability", "field_simp tactic"]
@@ -88,6 +90,7 @@
     "type": "note",
     "title": "Long Needle Case",
     "content": "**When ℓ > d (Long Needle)**:\n\nThe formula becomes more complex:\n$$P = \\frac{2}{\\pi}\\left[\\frac{\\ell}{d} - \\sqrt{\\left(\\frac{\\ell}{d}\\right)^2 - 1} + \\arccos\\left(\\frac{d}{\\ell}\\right)\\right]$$\n\n**Why Different?**\n- When $\\ell > d$, the needle can cross multiple lines\n- For some angles, crossing is guaranteed\n- The geometry becomes more intricate\n\n**Limiting Behavior**: As $\\ell \\to \\infty$, $P \\to 1$ (always crosses).",
+    "mathContext": "Long needle ($\\ell > d$): $P = \\frac{2}{\\pi}\\left[\\frac{\\ell}{d} - \\sqrt{(\\ell/d)^2-1} + \\arccos(d/\\ell)\\right]$. As $\\ell/d \\to \\infty$, $P \\to 1$.",
     "significance": "supporting",
     "relatedConcepts": ["long needle", "arccos", "multiple crossings"],
     "prerequisites": ["short needle formula (ℓ ≤ d case)", "arccos function for angle computation"]
@@ -99,6 +102,7 @@
     "type": "note",
     "title": "Applications and Context",
     "content": "**Cauchy-Crofton Formula**:\n\nBuffon's Needle is a special case of the general formula relating curve length to expected line intersections.\n\n**Applications**:\n1. **Stereology**: Estimating lengths/areas from random sections\n2. **Quality control**: Inspecting surfaces with random probes\n3. **Computer graphics**: Ray tracing, visibility computations\n4. **Biology**: Estimating fiber lengths from cross-sections\n\n**The Deep Connection**:\n\nThe appearance of $\\pi$ is not coincidental—it connects:\n- **Geometry** (circles, angles)\n- **Analysis** ($\\int\\sin\\theta$)\n- **Probability** (uniform distributions)\n- **Measure theory** (area ratios)\n\nThis is why geometric probability is so elegant!",
+    "mathContext": "Cauchy-Crofton formula: $\\text{length}(\\gamma) = \\frac{1}{2}\\int_{\\text{lines}} |\\gamma \\cap L|\\,dL$ — the length of a curve equals the expected number of line intersections. Buffon's needle is the special case where $\\gamma$ is a line segment.",
     "significance": "key",
     "relatedConcepts": ["Cauchy-Crofton", "stereology", "integral geometry"],
     "prerequisites": ["Buffon's needle formula", "Cauchy-Crofton formula (background)", "measure theory"]

--- a/src/data/proofs/cantors-theorem/annotations.json
+++ b/src/data/proofs/cantors-theorem/annotations.json
@@ -9,6 +9,7 @@
     "type": "concept",
     "title": "The Hierarchy of Infinities",
     "content": "Cantor's theorem establishes that **not all infinities are equal**. For any set A:\n\n$$|A| < |\\mathcal{P}(A)| = 2^{|A|}$$\n\nThis means:\n- There are strictly more subsets of N than there are natural numbers\n- There are strictly more real numbers than rationals\n- The hierarchy continues: $|\\mathbb{N}| < |\\mathcal{P}(\\mathbb{N})| < |\\mathcal{P}(\\mathcal{P}(\\mathbb{N}))| < ...$\n\nThe proof uses the **diagonal argument**, which constructs an explicit witness to the non-surjectivity of any proposed function.",
+    "mathContext": "Cantor's Theorem (1891): $\\forall A, |A| < |\\mathcal{P}(A)|$. Equivalently, $\\nexists f: A \\twoheadrightarrow \\mathcal{P}(A)$. This generates an infinite hierarchy: $|\\mathbb{N}| < 2^{|\\mathbb{N}|} < 2^{2^{|\\mathbb{N}|}} < \\cdots$",
     "significance": "critical",
     "relatedConcepts": [
       "cardinal numbers",
@@ -62,6 +63,7 @@
     "type": "theorem",
     "title": "Set Formulation Proof",
     "content": "The proof using `Set A` instead of `(A -> Prop)`:\n\n1. **Assume** f : A -> Set A is surjective\n2. **Define** D = {x | x not in f x}\n3. **By surjectivity**, exists b with f(b) = D\n4. **Consider**: Is b in D?\n   - **If b in D**: By definition, b not in f(b) = D. Contradiction!\n   - **If b not in D**: By definition, b in f(b) = D. Contradiction!\n5. **Conclude**: No such surjection exists\n\nThe `by_cases` tactic handles the case split, and `simp only [hb]` substitutes f(b) = D to reach the contradiction.",
+    "mathContext": "Assume $f$ surjective, let $D = \\{x : x \\notin f(x)\\}$, take $b$ with $f(b) = D$. Then $b \\in D \\iff b \\notin f(b) = D$, contradiction. The `by_cases (b \\in D)` tactic splits the proof into the two contradictory branches.",
     "significance": "key",
     "relatedConcepts": [
       "proof by contradiction",
@@ -133,6 +135,7 @@
     "type": "concept",
     "title": "Constructive Witness",
     "content": "Unlike many existence proofs, Cantor's theorem is **constructive**:\n\nGiven ANY f : A -> Set A, we can **explicitly construct** a set D not in the range of f.\n\n```lean\ntheorem cantor_witness (A : Type*) (f : A -> Set A) :\n    exists D : Set A, forall a : A, f a != D\n```\n\nThe witness is always the diagonal set D = {x | x not in f(x)}.\n\nThis constructivity is important because:\n- We don't just know D exists - we know exactly what it is\n- The proof can be 'run' to produce the witness\n- It works in constructive mathematics (intuitionistic logic)",
+    "mathContext": "Given any $f: A \\to \\mathcal{P}(A)$, the explicit witness $D = \\{x : x \\notin f(x)\\}$ satisfies $\\forall a, f(a) \\neq D$. This is constructive: no excluded middle needed.",
     "significance": "key",
     "relatedConcepts": [
       "constructive proof",
@@ -150,6 +153,7 @@
     "type": "concept",
     "title": "Connection to Russell's Paradox",
     "content": "The diagonal set D = {x | x not in f(x)} is reminiscent of **Russell's paradox**.\n\nRussell asked: Consider R = {x | x not in x}. Is R in R?\n- If R in R, then by definition, R not in R. Contradiction!\n- If R not in R, then by definition, R in R. Contradiction!\n\nThe key difference:\n- **Russell**: Tries to define a set in terms of *all* sets\n- **Cantor**: Defines a set in terms of a *specific function* f\n\nType theory resolves Russell's paradox by **stratifying** types into universes. A set can only contain elements of a lower type, preventing self-membership.",
+    "mathContext": "Russell's set $R = \\{x : x \\notin x\\}$ yields $R \\in R \\iff R \\notin R$. Cantor's diagonal set $D = \\{x : x \\notin f(x)\\}$ is the safe version: no self-reference because $D$ is defined relative to a fixed $f$, not relative to all sets.",
     "significance": "key",
     "relatedConcepts": [
       "Russell's paradox",
@@ -167,6 +171,7 @@
     "type": "concept",
     "title": "Wiedijk #22 vs #63",
     "content": "This proof is the **general form** of Cantor's theorem:\n\n- **Wiedijk #63 (this proof)**: For any set A, no surjection A -> P(A)\n- **Wiedijk #22 (CantorDiagonalization.lean)**: The reals are uncountable (no surjection N -> R)\n\n#22 is a **special case** of #63:\n- Take A = N (natural numbers)\n- P(N) corresponds to binary sequences (N -> Bool), which represent reals in [0,1]\n- No surjection N -> (N -> Bool) means |N| < |R|\n\nBoth proofs use the diagonal argument, but #63 is the more abstract formulation.",
+    "mathContext": "Wiedijk #63: $\\nexists f: A \\twoheadrightarrow \\mathcal{P}(A)$ (general). Wiedijk #22: $\\nexists f: \\mathbb{N} \\twoheadrightarrow \\mathbb{R}$ (special case via $\\mathcal{P}(\\mathbb{N}) \\cong 2^{\\mathbb{N}} \\cong [0,1]$).",
     "significance": "supporting",
     "relatedConcepts": [
       "uncountability",

--- a/src/data/proofs/central-limit-theorem/annotations.json
+++ b/src/data/proofs/central-limit-theorem/annotations.json
@@ -14,7 +14,8 @@
       "characteristic functions",
       "fixed point theory",
       "renormalization group"
-    ]
+    ],
+    "mathContext": "CLT: If $X_1, X_2, \\ldots$ are i.i.d. with mean $\\mu$ and variance $\\sigma^2$, then $\\frac{\\bar{X}_n - \\mu}{\\sigma/\\sqrt{n}} \\xrightarrow{d} \\mathcal{N}(0,1)$. Equivalently, $\\hat{\\varphi}_n(t) \\to e^{-t^2/2}$ (convergence of characteristic functions)."
   },
   {
     "id": "ann-clt-imports",
@@ -31,7 +32,8 @@
       "Mathlib",
       "measure theory",
       "Fourier analysis"
-    ]
+    ],
+    "mathContext": "Key Mathlib imports: `MeasureTheory.Measure.MeasureSpace` (probability measures), `Analysis.SpecialFunctions.ExpDeriv` (exponential derivatives for characteristic functions), `Topology.Order.Basic` (convergence and limits)."
   },
   {
     "id": "ann-clt-charfun-def",
@@ -83,7 +85,8 @@
       "Taylor series",
       "moments",
       "cumulants"
-    ]
+    ],
+    "mathContext": "Characteristic function Taylor expansion: $\\varphi_X(t) = \\mathbb{E}[e^{itX}] = 1 + it\\mu - \\frac{t^2}{2}(\\sigma^2 + \\mu^2) + O(t^3)$. For standardized $X$ ($\\mu=0$, $\\sigma=1$): $\\varphi(t) = 1 - t^2/2 + O(t^3)$."
   },
   {
     "id": "ann-clt-taylor-theorem",
@@ -121,7 +124,8 @@
       "exponential limit",
       "compound interest",
       "Euler's definition of e"
-    ]
+    ],
+    "mathContext": "The key limit: $(1 - t^2/(2n) + o(1/n))^n \\to e^{-t^2/2}$ as $n \\to \\infty$. This is a generalization of $(1 + x/n)^n \\to e^x$, applied to the $n$-th power of the rescaled characteristic function."
   },
   {
     "id": "ann-clt-key-convergence",
@@ -200,7 +204,8 @@
       "dynamical systems",
       "fixed point theory",
       "renormalization group"
-    ]
+    ],
+    "mathContext": "Lévy's continuity theorem: $\\varphi_n \\to \\varphi$ pointwise and $\\varphi$ continuous at 0 $\\Rightarrow$ $X_n \\xrightarrow{d} X$. This converts the algebraic convergence $\\hat{\\varphi}_n(t) \\to e^{-t^2/2}$ into distributional convergence to $\\mathcal{N}(0,1)$."
   },
   {
     "id": "ann-clt-wasserstein",
@@ -329,6 +334,7 @@
       "universality",
       "emergence",
       "mathematical inevitability"
-    ]
+    ],
+    "mathContext": "The Gaussian $\\mathcal{N}(0,1)$ is universal because $e^{-t^2/2}$ is the unique fixed point of the CLT renormalization: if $\\varphi(t) = 1 - t^2/2 + o(t^2)$, then $\\varphi(t/\\sqrt{n})^n \\to e^{-t^2/2}$. Any distribution with finite variance flows to the Gaussian under averaging."
   }
 ]

--- a/src/data/proofs/continuum-hypothesis/annotations.json
+++ b/src/data/proofs/continuum-hypothesis/annotations.json
@@ -15,7 +15,8 @@
       "cardinal numbers",
       "Gödel's constructible universe",
       "Cohen forcing"
-    ]
+    ],
+    "mathContext": "Continuum Hypothesis: $2^{\\aleph_0} = \\aleph_1$, i.e., there is no cardinal between $|\\mathbb{N}|$ and $|\\mathbb{R}|$. Hilbert's first problem (1900). Independence: $\\text{ZFC} \\nvdash \\text{CH}$ (Cohen, 1963) and $\\text{ZFC} \\nvdash \\neg\\text{CH}$ (Gödel, 1940)."
   },
   {
     "id": "ann-continuum-def",
@@ -121,7 +122,8 @@
       "axiomatic set theory",
       "models",
       "consistency"
-    ]
+    ],
+    "mathContext": "ZFC axioms: Extensionality, Pairing, Union, Power Set, Infinity, Separation, Replacement, Foundation, Choice. These axioms are neither too strong (they don't decide CH) nor too weak (they prove most of mathematics)."
   },
   {
     "id": "ann-godel-L",
@@ -151,7 +153,8 @@
     "type": "note",
     "title": "Why L Is an Axiom Here",
     "content": "Fully formalizing L would require:\n\n1. Transfinite recursion over all ordinals\n2. Gödel operations (8 operations for definability)\n3. Verification of each ZFC axiom in L\n4. ~1000+ lines of formal proof\n\nWe capture this as an axiom to focus on the *structure* of the independence proof.",
-    "significance": "minor"
+    "significance": "minor",
+    "mathContext": "Gödel's constructible universe $L$: the minimal inner model of ZFC, built by transfinite recursion $L_0 = \\emptyset$, $L_{\\alpha+1} = \\text{Def}(L_\\alpha)$, $L_\\lambda = \\bigcup_{\\alpha<\\lambda} L_\\alpha$, $L = \\bigcup_{\\alpha \\in \\text{Ord}} L_\\alpha$. In $L$: $\\text{GCH}$ holds ($2^{\\aleph_\\alpha} = \\aleph_{\\alpha+1}$)."
   },
   {
     "id": "ann-forcing",
@@ -181,7 +184,8 @@
     "type": "note",
     "title": "Why Forcing Is an Axiom Here",
     "content": "Formalizing Cohen forcing requires:\n\n1. Complete posets and dense sets\n2. Generic filters (via Rasiowa-Sikorski lemma)\n3. Names and interpretation\n4. Truth lemma and definability\n5. ~2000+ lines of machinery\n\nCohen's breakthrough was showing this construction preserves ZFC while changing the value of the continuum.",
-    "significance": "minor"
+    "significance": "minor",
+    "mathContext": "Cohen forcing: given a model $M \\models \\text{ZFC}$, adjoin a 'generic' set $G$ to get $M[G] \\models \\text{ZFC} + \\neg\\text{CH}$. The key: the forcing poset $\\text{Fn}(\\aleph_2 \\times \\omega, 2)$ adds $\\aleph_2$ new reals, making $2^{\\aleph_0} \\geq \\aleph_2 > \\aleph_1$."
   },
   {
     "id": "ann-relative-consistency",
@@ -288,6 +292,7 @@
       "philosophy of mathematics",
       "set-theoretic pluralism",
       "foundations"
-    ]
+    ],
+    "mathContext": "Independence means CH is undecidable in ZFC: $\\text{Con}(\\text{ZFC}) \\Rightarrow \\text{Con}(\\text{ZFC}+\\text{CH}) \\land \\text{Con}(\\text{ZFC}+\\neg\\text{CH})$. This parallels the parallel postulate: Euclidean and non-Euclidean geometries are both consistent. Gödel conjectured CH is false; others (e.g., Woodin) have proposed large cardinal axioms that would settle it."
   }
 ]


### PR DESCRIPTION
## Summary

### Section coverage gaps (3 entries)
- **angle-trisection-oq-02**: Remove duplicate `lineCount` key, add contrapositives + summary sections (lines 236-298)
- **arithmetic-series-oq-02**: Add summary section (lines 166-209)
- **bezout-identity-oq-03-oq-01-oq-01-oq-01**: Add summary section (lines 138-160)

### mathContext additions (5 entries, 21 annotations)
- **brouwer-fixed-point** (5 ann): theorem statement, retraction, ray construction, 1D/2D cases
- **buffons-needle** (4 ann): needle formula, examples, long needle, Cauchy-Crofton
- **cantors-theorem** (5 ann): infinity hierarchy, diagonal proof, constructive witness, Russell, Wiedijk
- **continuum-hypothesis** (5 ann): CH statement, ZFC axioms, Gödel's L, Cohen forcing, independence
- **central-limit-theorem** (6 ann): CLT statement, Taylor expansion, product limit, Lévy theorem, Gaussian universality

## Test plan
- [x] All JSON validated with `jq`
- [x] New sections match actual Lean file content
- [x] LaTeX formulas are mathematically accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)