### PR TITLE
Fix 27 status misclassifications, enrich cauchy-schwarz, Hall's theorem cross-ref

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -85,7 +85,8 @@
       "pi-transcendental",
       "godel-incompleteness",
       "halting-problem",
-      "cantor-diagonalization"
+      "cantor-diagonalization",
+      "lagrange-theorem-oq-03"
     ],
     "prerequisites": [
       "Group theory (normal subgroups, derived series, solvability)",
@@ -175,12 +176,17 @@
       "targetId": "cantor-diagonalization",
       "relationship": "thematic",
       "description": "Cantor's diagonal argument (1891) established the impossibility proof paradigm used in different form by Abel-Ruffini: no enumeration captures all reals, just as no radical formula captures all quintic roots — both prove that certain 'natural' operations cannot reach all targets"
+    },
+    {
+      "targetId": "lagrange-theorem-oq-03",
+      "relationship": "complementary",
+      "description": "Hall's theorem (1928) gives a structural characterization of solvable groups: a finite group G is solvable iff for every divisor d of |G| with gcd(d, |G|/d) = 1, G has a subgroup of order d. This is the converse direction of the solvability concept central to Abel-Ruffini — where this file uses non-solvability of S₅ to prove impossibility, Hall's theorem provides the positive characterization of exactly which groups are solvable"
     }
   ],
   "overview": {
     "historicalContext": "The Abel-Ruffini theorem (1824) stands as one of the most profound results in the history of algebra, settling a question that had occupied mathematicians for centuries. After Cardano (1545) and Ferrari (1540) found radical solutions for cubics and quartics, the search for a quintic formula consumed generations of mathematicians including Euler, Lagrange, and Vandermonde. Paolo Ruffini published the first attempted proof of impossibility in 1799 in his *Teoria Generale delle Equazioni*, running to over 500 pages. Ruffini's argument, based on permutation analysis, contained a gap: he assumed without proof that any radical expression for the roots must take a specific 'standard form,' and his treatment of the permutations was not fully rigorous. Despite submitting his work to leading mathematicians including Lagrange (who never responded) and Cauchy (who acknowledged its importance), Ruffini's proof was not widely accepted during his lifetime. Niels Henrik Abel, working independently in near-poverty in Norway, provided the first complete proof in 1824 at age 21 — a 6-page paper that succeeded precisely where Ruffini's argument was incomplete. Abel died of tuberculosis in 1829, just two days before a letter arrived offering him a professorship in Berlin. Évariste Galois, before his death in a duel at 20, went much further in 1832: he characterized exactly which polynomials are solvable by radicals in terms of their symmetry groups, founding what we now call Galois theory. The key group-theoretic insight is that A₅, the alternating group on 5 elements, is the smallest non-abelian simple group — with order 60, it has no proper non-trivial normal subgroups, causing the derived series to get stuck. This single fact propagates upward through the chain: A₅ not solvable → Sₙ (n ≥ 5) not solvable → generic quintic not solvable by radicals. The classification of finite simple groups (completed circa 2004) shows that A₅ is the first in the infinite family of simple alternating groups Aₙ (n ≥ 5).",
     "problemStatement": "Expose the full proof chain from $A_5$ simplicity to the Abel-Ruffini theorem with each step as a named, machine-verified theorem: $A_5$ simple $\\Rightarrow$ $S_n$ ($n \\geq 5$) not solvable $\\Rightarrow$ no radical formula for the general degree-$n$ polynomial ($n \\geq 5$).",
-    "proofStrategy": "The file provides a pedagogical exposition rather than new mathematical content: it wraps Mathlib's existing theorems (alternatingGroup.isSimpleGroup_five and Equiv.Perm.not_solvable) in named theorems with comprehensive documentation. The key technical contribution is symmetric_not_solvable, which bridges from Mathlib's cardinal-level statement to a natural number inequality via exact_mod_cast. The proof chain is made explicit by naming each link and documenting the logical dependencies.",
+    "proofStrategy": "The file decomposes the Abel-Ruffini proof chain into five named, independently verifiable steps. The key technical theorem is `symmetric_not_solvable`, which bridges Mathlib's cardinal-level non-solvability statement (`Equiv.Perm.not_solvable`, stated for `5 ≤ Cardinal.mk α`) to a natural number bound (`5 ≤ n`) via `exact_mod_cast` — this type-level coercion is the main new proof content. The pedagogical architecture then builds upward: `a5_is_simple` extracts the foundation from Mathlib, specific instances (`s5_not_solvable`, `s6_not_solvable`, `s7_not_solvable`) demonstrate the theorem for individual degrees, contrast cases (`s0_solvable`, `s1_solvable`) establish the solvable side, and `five_is_the_threshold` packages the sharp dichotomy. The file concludes with structured documentation of the complete 5-step chain including Steps 4–5 (Galois bridge and field theory) which are handled by Mathlib internally.",
     "keyInsights": [
       "A₅ (order 60) is the smallest non-abelian simple group — this single fact drives the entire Abel-Ruffini theorem through a chain of group-theoretic implications",
       "The derived series gets stuck: for simple non-abelian G, [G,G] = G (since [G,G] is a non-trivial normal subgroup), so the series G ⊵ G ⊵ G ⊵ ··· never reaches {e}",

--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -82,6 +82,11 @@
         "key": "Ne87",
         "citation": "Newton, I., Arithmetica Universalis (1707; results from c. 1687). Contains Newton's inequalities for symmetric functions.",
         "type": "book"
+      },
+      {
+        "key": "BH20",
+        "citation": "Brändén, P. and Huh, J., Lorentzian polynomials, Annals of Mathematics 192(3) (2020), 821–891. Unified framework for log-concavity including Newton's inequalities.",
+        "type": "paper"
       }
     ]
   },
@@ -120,6 +125,16 @@
       "targetId": "fundamental-theorem-algebra",
       "relationship": "related",
       "description": "FTA guarantees that elementary symmetric polynomials e_k(x₁,...,xₙ) equal the coefficients (up to sign) of ∏(t - xᵢ) — the Vieta connection that makes Maclaurin's chain a statement about polynomial coefficients"
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-02",
+      "relationship": "complementary",
+      "description": "Power mean limit: lim_{r→0} M_r = GM shows the geometric mean as a continuous limit of power means M_r = (∑ wᵢxᵢʳ)^{1/r}. Maclaurin means M_k are a discrete analog indexed by k rather than r, and the Maclaurin chain M₁ ≥ ⋯ ≥ Mₙ parallels the monotonicity of power means in r"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The integral Cauchy-Schwarz inequality (∫fg)² ≤ (∫f²)(∫g²) is the continuous analog of the finite Cauchy-Schwarz sum n·∑xᵢ² ≥ (∑xᵢ)² used here as the key engine for proving M₁² ≥ M₂"
     }
   ],
   "overview": {
@@ -258,6 +273,8 @@
     "binomial-theorem",
     "triangle-inequality",
     "sum-of-kth-powers",
-    "fundamental-theorem-algebra"
+    "fundamental-theorem-algebra",
+    "amgm-inequality-oq-03-oq-02",
+    "cauchy-schwarz-integral"
   ]
 }

--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -109,6 +109,11 @@
         "targetId": "triangle-inequality",
         "relationship": "related",
         "description": "For p ≥ 1, power mean monotonicity M₁ ≤ M_p implies Minkowski's inequality (the L^p triangle inequality), connecting the discrete mean hierarchy to normed space geometry"
+      },
+      {
+        "targetId": "shannon-entropy",
+        "relationship": "related",
+        "description": "Shannon entropy H(X) = -∑ pᵢ log pᵢ is the α→1 limit of Rényi entropy H_α = (1/(1-α))·log ∑ pᵢ^α. Since H_α ∝ log M_{α-1}, the duality M_r(z) = M_{-r}(z⁻¹)⁻¹ translates to a duality on Rényi entropies — the negative power mean monotonicity here implies the corresponding Rényi entropy monotonicity for α > 1"
       }
     ],
     "dateAdded": "2026-03-21",
@@ -122,7 +127,8 @@
       "amgm-inequality-oq-03-oq-02",
       "cauchy-schwarz",
       "cauchy-schwarz-integral",
-    "triangle-inequality"
+    "triangle-inequality",
+    "shannon-entropy"
     ]
   },
   "overview": {

--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -121,6 +121,11 @@
       "targetId": "triangle-inequality",
       "relationship": "related",
       "description": "For p ≥ 1, the power mean inequality M₁ ≤ M_p implies (via Minkowski) the L^p triangle inequality — connecting discrete power means to the geometry of normed spaces"
+    },
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "related",
+      "description": "Shannon entropy H(X) = -∑ pᵢ log pᵢ is the α→1 limit of Rényi entropy H_α = (1/(1-α))·log ∑ pᵢ^α, which is essentially log M_{α-1} of the distribution. Power mean monotonicity M_r ≤ M_s (r ≤ s) implies Rényi entropy monotonicity H_β ≤ H_α (α ≤ β) — formalizing this connection would bridge the inequality and information theory libraries"
     }
   ],
   "overview": {
@@ -233,6 +238,7 @@
     "amgm-inequality-oq-03-oq-02",
     "cauchy-schwarz-integral",
     "mean-value-theorem",
-    "triangle-inequality"
+    "triangle-inequality",
+    "shannon-entropy"
   ]
 }

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -263,35 +263,5 @@
     "sqrt2-irrational",
     "hermite-lindemann",
     "solution-of-cubic"
-  ],
-  "references": [
-    {
-      "authors": "Wantzel, Pierre Laurent",
-      "title": "Recherches sur les moyens de reconnaître si un Problème de Géométrie peut se résoudre avec la règle et le compas",
-      "year": "1837",
-      "venue": "Journal de Mathématiques Pures et Appliquées",
-      "note": "First rigorous proof that angle trisection is impossible with compass and straightedge, establishing the degree criterion"
-    },
-    {
-      "authors": "Lindemann, Ferdinand von",
-      "title": "Über die Zahl π",
-      "year": "1882",
-      "venue": "Mathematische Annalen",
-      "note": "Proved π is transcendental, completing the impossibility of squaring the circle — the third and final classical Greek problem to be resolved"
-    },
-    {
-      "authors": "Martin, George E.",
-      "title": "Geometric Constructions",
-      "year": "1998",
-      "venue": "Springer Undergraduate Texts in Mathematics",
-      "note": "Modern textbook covering constructibility theory, field extension characterization, and all three classical impossibilities with full algebraic proofs"
-    },
-    {
-      "authors": "Gauss, Carl Friedrich",
-      "title": "Disquisitiones Arithmeticae",
-      "year": "1801",
-      "venue": "Leipzig",
-      "note": "Section VII proves the constructibility of the regular 17-gon and establishes that a regular n-gon is constructible iff n is a product of a power of 2 and distinct Fermat primes — the foundational result connecting number theory to constructibility"
-    }
   ]
 }

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -222,21 +222,5 @@
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Archimedes",
-      "title": "Measurement of a Circle",
-      "year": "~250 BCE",
-      "venue": "Syracuse",
-      "note": "First rigorous calculation of the area of a circle using the method of exhaustion — bounded π between 3 10/71 and 3 1/7"
-    },
-    {
-      "authors": "Stillwell, John",
-      "title": "Mathematics and Its History",
-      "year": "2010",
-      "venue": "Springer, 3rd edition",
-      "note": "Historical account of Archimedes's method and its connection to integral calculus"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -163,21 +163,5 @@
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Schwarz, Hermann Amandus",
-      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung",
-      "year": "1885",
-      "venue": "Acta Societatis Scientiarum Fennicae 15, 315–362",
-      "note": "Extension of Cauchy's discrete inequality to integral form for L² functions"
-    },
-    {
-      "authors": "Rudin, Walter",
-      "title": "Real and Complex Analysis",
-      "year": "1987",
-      "venue": "McGraw-Hill, 3rd edition",
-      "note": "Standard treatment of the Cauchy-Schwarz inequality in the context of L^p spaces and measure theory"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/chinese-remainder-constructive/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive/meta.json
@@ -228,28 +228,5 @@
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 2
-  },
-  "references": [
-    {
-      "authors": "Sunzi (Sun Tzu)",
-      "title": "Sunzi Suanjing (The Mathematical Classic of Sun Tzu)",
-      "year": "~400 CE",
-      "venue": "Chinese mathematical manuscript",
-      "note": "Earliest known statement of the Chinese Remainder Theorem: 'There are things whose number is unknown. When divided by 3, remainder 2; by 5, remainder 3; by 7, remainder 2. What is the number?'"
-    },
-    {
-      "authors": "Gauss, Carl Friedrich",
-      "title": "Disquisitiones Arithmeticae",
-      "year": "1801",
-      "venue": "Leipzig: Gerhard Fleischer",
-      "note": "Systematic treatment of modular arithmetic and congruence systems in Articles 32–36"
-    },
-    {
-      "authors": "Ireland, Kenneth; Rosen, Michael",
-      "title": "A Classical Introduction to Modern Number Theory",
-      "year": "1990",
-      "venue": "Springer GTM 84, 2nd edition",
-      "note": "Modern exposition with the ring-theoretic generalization and applications to polynomial rings"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -222,21 +222,5 @@
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Cramer, Gabriel",
-      "title": "Introduction à l'analyse des lignes courbes algébriques",
-      "year": "1750",
-      "venue": "Geneva: Frères Cramer et Claude Philibert",
-      "note": "Original publication of Cramer's rule for solving systems of linear equations via determinants"
-    },
-    {
-      "authors": "Strang, Gilbert",
-      "title": "Linear Algebra and Its Applications",
-      "year": "2006",
-      "venue": "Thomson Brooks/Cole, 4th edition",
-      "note": "Modern treatment of Cramer's rule in the context of linear algebra, with discussion of computational efficiency"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/de-moivre/meta.json
+++ b/src/data/proofs/de-moivre/meta.json
@@ -189,21 +189,5 @@
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "de Moivre, Abraham",
-      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
-      "year": "1730",
-      "venue": "London: J. Tonson & J. Watts",
-      "note": "Contains the formula (cos θ + i sin θ)^n = cos nθ + i sin nθ, though stated without modern notation"
-    },
-    {
-      "authors": "Euler, Leonhard",
-      "title": "Introductio in analysin infinitorum",
-      "year": "1748",
-      "venue": "Lausanne: Marcum-Michaelem Bousquet",
-      "note": "Reformulated de Moivre's result using e^(iθ) = cos θ + i sin θ, connecting it to the exponential function"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/denumerability-rationals/meta.json
+++ b/src/data/proofs/denumerability-rationals/meta.json
@@ -227,14 +227,5 @@
     "schroeder-bernstein",
     "continuum-hypothesis",
     "sqrt2-irrational"
-  ],
-  "references": [
-    {
-      "authors": "Cantor, Georg",
-      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
-      "year": "1874",
-      "venue": "Journal für die reine und angewandte Mathematik 77, 258–262",
-      "note": "Established the countability of algebraic numbers (hence rationals) and the uncountability of reals"
-    }
   ]
 }

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -182,14 +182,5 @@
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 8
-  },
-  "references": [
-    {
-      "authors": "Dehn, Max",
-      "title": "Über den Rauminhalt",
-      "year": "1900",
-      "venue": "Mathematische Annalen 55, 465–478",
-      "note": "Proved that a regular tetrahedron cannot be dissected into a cube of equal volume — solving Hilbert's Third Problem"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -195,28 +195,5 @@
     "axiomCount": 5,
     "theoremCount": 8,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Hermite, Charles",
-      "title": "Sur la fonction exponentielle",
-      "year": "1873",
-      "venue": "Comptes Rendus de l'Académie des Sciences 77, 18–24, 74–79, 226–233, 285–293",
-      "note": "The original proof that e is transcendental, using auxiliary polynomial constructions"
-    },
-    {
-      "authors": "Niven, Ivan",
-      "title": "Irrational Numbers",
-      "year": "1956",
-      "venue": "Carus Mathematical Monographs 11, Mathematical Association of America",
-      "note": "Contains a simplified proof of the transcendence of e accessible to undergraduates"
-    },
-    {
-      "authors": "Baker, Alan",
-      "title": "Transcendental Number Theory",
-      "year": "1975",
-      "venue": "Cambridge University Press",
-      "note": "Standard reference for transcendence methods including Hermite's approach and its generalizations"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/euler-polyhedral-formula/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula/meta.json
@@ -133,21 +133,5 @@
     "axiomCount": 1,
     "theoremCount": 65,
     "definitionCount": 27
-  },
-  "references": [
-    {
-      "authors": "Euler, Leonhard",
-      "title": "Elementa doctrinae solidorum",
-      "year": "1758",
-      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae 4, 109–140",
-      "note": "Original statement of V - E + F = 2 for convex polyhedra"
-    },
-    {
-      "authors": "Lakatos, Imre",
-      "title": "Proofs and Refutations",
-      "year": "1976",
-      "venue": "Cambridge University Press",
-      "note": "Famous philosophical analysis of the history and proof of Euler's formula, using it to illustrate the nature of mathematical discovery"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -202,21 +202,5 @@
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Euler, Leonhard",
-      "title": "Theoremata arithmetica nova methodo demonstrata",
-      "year": "1763",
-      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae 8, 74–104",
-      "note": "Introduction of the totient function φ(n) and proof of the product formula"
-    },
-    {
-      "authors": "Ireland, Kenneth; Rosen, Michael",
-      "title": "A Classical Introduction to Modern Number Theory",
-      "year": "1990",
-      "venue": "Springer GTM 84, 2nd edition",
-      "note": "Modern treatment of Euler's totient function and its multiplicativity"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -193,21 +193,5 @@
     "axiomCount": 9,
     "theoremCount": 6,
     "definitionCount": 5
-  },
-  "references": [
-    {
-      "authors": "Ferrari, Lodovico (via Cardano)",
-      "title": "Ars Magna",
-      "year": "1545",
-      "venue": "Nürnberg: Petreius",
-      "note": "First publication of the quartic formula, discovered by Ferrari (Cardano's student) and published in Cardano's treatise"
-    },
-    {
-      "authors": "van der Waerden, B.L.",
-      "title": "A History of Algebra",
-      "year": "1985",
-      "venue": "Springer",
-      "note": "Historical treatment of the resolution of cubic and quartic equations in the Renaissance"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/hilbert-10/meta.json
+++ b/src/data/proofs/hilbert-10/meta.json
@@ -157,21 +157,5 @@
     "halting-problem",
     "godel-incompleteness",
     "pell-equation"
-  ],
-  "references": [
-    {
-      "authors": "Matiyasevich, Yuri V.",
-      "title": "Enumerable sets are Diophantine",
-      "year": "1970",
-      "venue": "Doklady Akademii Nauk SSSR 191(2), 279–282",
-      "note": "Completed the negative resolution of Hilbert's 10th problem by showing every r.e. set is Diophantine — no algorithm for Diophantine equations exists"
-    },
-    {
-      "authors": "Davis, Martin",
-      "title": "Hilbert's Tenth Problem is Unsolvable",
-      "year": "1973",
-      "venue": "The American Mathematical Monthly 80(3), 233–269",
-      "note": "Accessible exposition of the Davis-Putnam-Robinson-Matiyasevich theorem"
-    }
   ]
 }

--- a/src/data/proofs/hilbert-5/meta.json
+++ b/src/data/proofs/hilbert-5/meta.json
@@ -217,28 +217,5 @@
     "axiomCount": 6,
     "theoremCount": 7,
     "definitionCount": 6
-  },
-  "references": [
-    {
-      "authors": "Hilbert, David",
-      "title": "Mathematische Probleme",
-      "year": "1900",
-      "venue": "Nachrichten von der Gesellschaft der Wissenschaften zu Göttingen, 253–297",
-      "note": "The original lecture listing 23 problems that would shape 20th century mathematics"
-    },
-    {
-      "authors": "Gleason, Andrew M.",
-      "title": "Groups without small subgroups",
-      "year": "1952",
-      "venue": "Annals of Mathematics 56(2), 193–212",
-      "note": "Key contribution to the positive resolution of Hilbert's 5th problem — locally compact groups without small subgroups are Lie groups"
-    },
-    {
-      "authors": "Montgomery, Deane; Zippin, Leo",
-      "title": "Topological Transformation Groups",
-      "year": "1955",
-      "venue": "Interscience Publishers",
-      "note": "Completed the solution of Hilbert's 5th problem — every locally compact topological group that is locally Euclidean is a Lie group"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/isosceles-triangle/meta.json
+++ b/src/data/proofs/isosceles-triangle/meta.json
@@ -185,14 +185,5 @@
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Euclid",
-      "title": "Elements, Book I, Proposition 5",
-      "year": "~300 BCE",
-      "venue": "Alexandria",
-      "note": "The pons asinorum: base angles of an isosceles triangle are equal — traditionally considered the first non-trivial theorem in the Elements"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -197,28 +197,5 @@
     "axiomCount": 13,
     "theoremCount": 15,
     "definitionCount": 9
-  },
-  "references": [
-    {
-      "authors": "Hadamard, Jacques",
-      "title": "Sur la distribution des zéros de la fonction ζ(s) et ses conséquences arithmétiques",
-      "year": "1896",
-      "venue": "Bulletin de la Société Mathématique de France 24, 199–220",
-      "note": "Independent proof (with de la Vallée Poussin) of the Prime Number Theorem: π(x) ~ x/ln(x)"
-    },
-    {
-      "authors": "de la Vallée Poussin, Charles-Jean",
-      "title": "Recherches analytiques sur la théorie des nombres premiers",
-      "year": "1896",
-      "venue": "Annales de la Société Scientifique de Bruxelles 20, 183–256",
-      "note": "Independent proof of PNT in the same year as Hadamard, using non-vanishing of ζ(1+it)"
-    },
-    {
-      "authors": "Selberg, Atle",
-      "title": "An elementary proof of the prime-number theorem",
-      "year": "1949",
-      "venue": "Annals of Mathematics 50(2), 305–313",
-      "note": "Elementary proof avoiding complex analysis — alongside Erdős's independent elementary proof"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -188,14 +188,5 @@
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Ptolemy, Claudius",
-      "title": "Almagest (Μαθηματικὴ Σύνταξις), Book I, Chapter 10",
-      "year": "~150 CE",
-      "venue": "Alexandria",
-      "note": "Used the theorem that for a cyclic quadrilateral, the product of diagonals equals the sum of products of opposite sides — the foundation of his chord tables"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -170,14 +170,5 @@
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 7
-  },
-  "references": [
-    {
-      "authors": "Szemerédi, Endre",
-      "title": "On sets of integers containing no k elements in arithmetic progression",
-      "year": "1975",
-      "venue": "Acta Arithmetica 27, 199–245",
-      "note": "Proved that any set of integers with positive upper density contains arbitrarily long arithmetic progressions — won the Abel Prize in 2012"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -175,21 +175,5 @@
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 4
-  },
-  "references": [
-    {
-      "authors": "Szemerédi, Endre",
-      "title": "On sets of integers containing no k elements in arithmetic progression",
-      "year": "1975",
-      "venue": "Acta Arithmetica 27, 199–245",
-      "note": "Proved that any set of integers with positive upper density contains arbitrarily long arithmetic progressions — won the Abel Prize in 2012"
-    },
-    {
-      "authors": "Szemerédi, Endre",
-      "title": "Regular partitions of graphs",
-      "year": "1978",
-      "venue": "Problèmes Combinatoires et Théorie des Graphes, Colloques internationaux CNRS 260, 399–401",
-      "note": "The regularity lemma — a powerful structural result for large graphs used in the proof of Szemerédi's theorem"
-    }
-  ]
+  }
 }

--- a/src/data/proofs/yang-mills-mass-gap/meta.json
+++ b/src/data/proofs/yang-mills-mass-gap/meta.json
@@ -757,21 +757,5 @@
     "",
     "",
     ""
-  ],
-  "references": [
-    {
-      "authors": "Yang, Chen-Ning; Mills, Robert L.",
-      "title": "Conservation of Isotopic Spin and Isotopic Gauge Invariance",
-      "year": "1954",
-      "venue": "Physical Review 96(1), 191–195",
-      "note": "Introduced non-abelian gauge fields — the mass gap problem asks whether these theories have a positive-mass ground state"
-    },
-    {
-      "authors": "Jaffe, Arthur; Witten, Edward",
-      "title": "Quantum Yang-Mills Theory",
-      "year": "2000",
-      "venue": "Clay Mathematics Institute Millennium Problems",
-      "note": "Official problem statement: prove that quantum Yang-Mills theory exists and has a positive mass gap Δ > 0"
-    }
   ]
 }


### PR DESCRIPTION
## Summary

Previous enrichment work in this PR:
- Fixed 27 status/badge misclassifications across gallery entries
- Enriched cauchy-schwarz entry
- Removed 20 duplicate references arrays

Latest commit:
- Added `lagrange-theorem-oq-03` (Hall's theorem) cross-reference to `abel-ruffini-oq-04`
- Refined `proofStrategy` to highlight the `symmetric_not_solvable` cardinal-to-ℕ bridging

## Verification
- All JSON files validated
- Axiom integrity checked on modified entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)