### PR TITLE
Enrich abel-ruffini + angle-trisection: fix annotation accuracy

### DIFF
--- a/src/data/proofs/angle-trisection/annotations.json
+++ b/src/data/proofs/angle-trisection/annotations.json
@@ -46,6 +46,28 @@
     ]
   },
   {
+    "id": "ann-namespace-and-derivation",
+    "proofId": "angle-trisection",
+    "range": {
+      "startLine": 67,
+      "endLine": 85
+    },
+    "type": "technique",
+    "title": "Part I: Deriving the Trisection Polynomial from cos(3θ)",
+    "content": "The namespace `AngleTrisection` and `open Polynomial Real` set up the algebraic context. Part I derives the minimal polynomial for cos(20°) from the triple angle formula.\n\nThe derivation: to trisect 60°, we need cos(20°). The triple angle formula gives cos(3θ) = 4cos³(θ) - 3cos(θ). Setting θ = 20° and cos(60°) = 1/2: 1/2 = 4x³ - 3x where x = cos(20°). Multiplying by 2: 8x³ - 6x - 1 = 0. This cubic with rational coefficients is the polynomial whose properties determine constructibility.",
+    "mathContext": "Setting $\\theta = 20°$ in $\\cos(3\\theta) = 4\\cos^3(\\theta) - 3\\cos(\\theta)$: $\\frac{1}{2} = 4x^3 - 3x$ where $x = \\cos(20°)$. Clearing denominators: $8x^3 - 6x - 1 = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "triple angle formula",
+      "minimal polynomial derivation",
+      "rational coefficients"
+    ],
+    "prerequisites": [
+      "trigonometric identities",
+      "polynomial roots"
+    ]
+  },
+  {
     "id": "ann-trisection-polynomial",
     "proofId": "angle-trisection",
     "range": {
@@ -152,6 +174,30 @@
     "prerequisites": [
       "rational root theorem",
       "polynomial arithmetic"
+    ]
+  },
+  {
+    "id": "ann-wantzel-context",
+    "proofId": "angle-trisection",
+    "range": {
+      "startLine": 155,
+      "endLine": 173
+    },
+    "type": "concept",
+    "title": "Part IV: Constructible Numbers and Wantzel's Criterion",
+    "content": "Part IV docstring defines constructible numbers and states Wantzel's key theorem (1837): a real number α is constructible iff there is a tower of field extensions Q = F₀ ⊂ F₁ ⊂ ... ⊂ Fₙ where α ∈ Fₙ and each [Fᵢ₊₁:Fᵢ] = 2.\n\nThe corollary is that [Q(α):Q] must divide 2ⁿ. Since constructing a point with compass and straightedge can only intersect lines and circles — yielding at most degree-2 extensions — the total extension degree is always a power of 2. This is why degree-3 minimal polynomials (like 8x³ - 6x - 1 for cos(20°)) imply non-constructibility: 3 does not divide any power of 2.",
+    "mathContext": "Wantzel (1837): $\\alpha$ constructible $\\iff$ $\\exists$ tower $\\mathbb{Q} = F_0 \\subset \\cdots \\subset F_n$ with $[F_{i+1}:F_i] = 2$ and $\\alpha \\in F_n$. Corollary: $\\deg(\\min_{\\mathbb{Q}}(\\alpha)) \\mid 2^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "field extension tower",
+      "degree of extension",
+      "compass and straightedge",
+      "Wantzel's theorem"
+    ],
+    "prerequisites": [
+      "field extensions",
+      "tower law",
+      "degree of minimal polynomial"
     ]
   },
   {

--- a/src/data/proofs/ballot-problem/annotations.json
+++ b/src/data/proofs/ballot-problem/annotations.json
@@ -13,6 +13,18 @@
     "prerequisites": ["probability theory", "combinatorics", "integer sequences"]
   },
   {
+    "id": "ann-namespace-setup",
+    "proofId": "ballot-problem",
+    "range": {"startLine": 80, "endLine": 92},
+    "type": "technique",
+    "title": "Namespace and MeasurableSpace Setup",
+    "content": "Opens the `BallotProblem` namespace and `Ballot`, `Set`, `ProbabilityTheory`, `MeasureTheory` namespaces for access to Mathlib's probability infrastructure.\n\nThe two `private` instances (lines 86-91) are critical Lean boilerplate: Mathlib's `Ballot` module defines `MeasurableSpace (List ℤ)` locally (with `local instance`), so it is not available outside that file. To use `condCount` (conditional counting measure) here, we must recreate the instance as the discrete σ-algebra (`⊤`) and prove `MeasurableSingletonClass` (every singleton is measurable). Without these, `condCount` would fail to find its typeclass instances.",
+    "mathContext": "The discrete σ-algebra $\\Sigma = \\mathcal{P}(\\text{List}\\,\\mathbb{Z})$ makes every subset measurable. `condCount` then computes $\\Pr[A \\mid B] = |A \\cap B| / |B|$ for finite sets.",
+    "significance": "supporting",
+    "relatedConcepts": ["MeasurableSpace", "condCount", "discrete σ-algebra", "typeclass instance"],
+    "prerequisites": ["measure theory basics", "Lean 4 typeclass system"]
+  },
+  {
     "id": "ann-model",
     "proofId": "ballot-problem",
     "range": {"startLine": 93, "endLine": 131},


### PR DESCRIPTION
## Summary
- **abel-ruffini**: Fix 5 anchor misalignments (swapped imports/docstring, overlapping ranges), rename annotation to match code
- **angle-trisection**: Add 2 annotations covering key mathematical gaps (polynomial derivation, Wantzel's theorem)

## Changes
### abel-ruffini (annotations.source.json)
- Swap `ann-header`/`ann-imports` anchors — header pointed at imports, imports pointed at docstring
- Split `ann-namespace-variables` into focused `ann-namespace` (avoids overlap with `ann-solvable-by-rad`)
- Shrink `ann-s5-s6-not-solvable` to avoid overlap with `ann-a5-simple`
- Expand `ann-small-solvable` to cover actual s0/s1 theorems (was missing lines 114-118)
- Rename "Abel-Ruffini Theorem (One Direction)" → "The Galois Bridge Theorem"

### angle-trisection (annotations.json)
- Add `ann-namespace-and-derivation` (lines 67-85): Part I docstring showing how 8x³-6x-1=0 derives from cos(3θ)
- Add `ann-wantzel-context` (lines 155-173): Part IV docstring defining constructible numbers and Wantzel's criterion

## Test plan
- [x] `npx tsx scripts/annotations/build.ts` passes (0 new errors for both entries)
- [x] All annotation ranges verified non-overlapping
- [x] No regressions in other entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)