### PR TITLE
Fix axiom integrity: 20 entries + enrich erdos-374, erdos-513

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -87,6 +87,31 @@
     ]
   },
   {
+    "id": "ann-part-ii-intro",
+    "proofId": "abel-ruffini",
+    "range": {
+      "startLine": 51,
+      "endLine": 57
+    },
+    "type": "concept",
+    "title": "The Galois-Theoretic Bridge: Field Theory Meets Group Theory",
+    "content": "Part II introduces the central conceptual leap of the formalization: translating the algebraic question 'can we solve this polynomial by radicals?' into the group-theoretic question 'is the Galois group solvable?' This bridge is Galois's fundamental insight — the reason his theory revolutionized algebra.\n\nThe direction formalized here (solvable by radicals $\\Rightarrow$ solvable Galois group) is the 'easy' direction conceptually, though technically deep. The key idea: each radical adjunction $F \\subset F(\\sqrt[n]{a})$ creates a cyclic extension with cyclic (hence abelian) Galois group. A tower of radical extensions thus yields a tower of abelian extensions, which is precisely the definition of a solvable group.",
+    "mathContext": "The Galois correspondence: $\\text{Gal}(E/F) \\cong \\text{Aut}_F(E)$. For a radical tower $F = F_0 \\subset F_1 \\subset \\cdots \\subset F_n$ where $F_{i+1} = F_i(\\sqrt[n_i]{a_i})$, each $\\text{Gal}(F_{i+1}/F_i)$ is cyclic of order dividing $n_i$. The Galois group of the tower has a subnormal series with abelian factors $\\Rightarrow$ solvable.",
+    "significance": "key",
+    "prerequisites": [
+      "Galois correspondence",
+      "radical extensions",
+      "cyclic extensions"
+    ],
+    "relatedConcepts": [
+      "Galois group",
+      "solvable group",
+      "radical tower",
+      "cyclic extension",
+      "subnormal series"
+    ]
+  },
+  {
     "id": "ann-abel-ruffini-theorem",
     "proofId": "abel-ruffini",
     "range": {
@@ -191,7 +216,7 @@
     "type": "theorem",
     "title": "A₅ is Simple",
     "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A₅ is simple - it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A₅.",
-    "mathContext": "A₅ = {even permutations of 5 objects} = ker(sign : S₅ → {±1})\n\n|A₅| = 60 = 5!/2",
+    "mathContext": "$A_5 = \\ker(\\text{sgn} : S_5 \\to \\{\\pm 1\\})$, $|A_5| = 60 = 5!/2$. Its conjugacy classes have sizes $1 + 12 + 12 + 15 + 20 = 60$ (identity, two classes of 5-cycles, double transpositions, 3-cycles). A normal subgroup must be a union of conjugacy classes including $\\{e\\}$, with order dividing 60. No sub-sum $1 + S$ of $\\{12, 12, 15, 20\\}$ yields a divisor of 60 except $\\{\\}$ and the full set — proving $A_5$ is simple. This makes $A_5$ the smallest non-abelian simple group (the next being $\\text{PSL}(2,7)$ of order 168).",
     "significance": "critical",
     "prerequisites": [
       "permutation groups",

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -248,6 +248,11 @@
       "targetId": "quadratic-reciprocity",
       "relationship": "related",
       "description": "Gauss's quadratic reciprocity law (1801) is a deep result about the structure of Z/pZ that foreshadowed Galois theory — both concern how algebraic objects (quadratic residues, polynomial roots) behave under symmetry. The Artin reciprocity law of class field theory generalizes both: it connects abelian Galois groups of number fields to ideal class groups, unifying quadratic reciprocity with the abelian case of Galois's solvability criterion"
+    },
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "extends",
+      "description": "Wiles's proof of FLT (1995) is the supreme application of Galois theory: it shows every semistable elliptic curve over Q is modular by analyzing 2-dimensional Galois representations ρ: Gal(Q̄/Q) → GL₂(Zₚ). Where Abel-Ruffini uses the non-solvability of S₅ to block radical solutions, Wiles uses the modularity of Galois representations to force Diophantine constraints — both exploit the deep connection between symmetry groups and algebraic equations that Galois discovered"
     }
   ],
   "relatedProofs": [
@@ -270,7 +275,8 @@
     "godel-incompleteness",
     "halting-problem",
     "cantor-diagonalization",
-    "quadratic-reciprocity"
+    "quadratic-reciprocity",
+    "fermats-last-theorem"
   ],
   "references": [
     {
@@ -321,6 +327,20 @@
       "year": "1942",
       "venue": "Notre Dame Mathematical Lectures No. 2",
       "note": "Influential lecture notes that reformulated Galois theory in modern algebraic terms, establishing the field extension / automorphism group framework used in this formalization"
+    },
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Réflexions sur la résolution algébrique des équations",
+      "year": "1770",
+      "venue": "Nouveaux Mémoires de l'Académie royale des Sciences et Belles-Lettres de Berlin",
+      "note": "The crucial precursor: Lagrange analyzed why classical formulas worked for degrees 2-4 by studying permutations of roots ('resolvents'), and discovered his method broke down for degree 5 — the resolvent of a quintic had degree 6, not lower"
+    },
+    {
+      "authors": "Jordan, Camille",
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "venue": "Gauthier-Villars, Paris",
+      "note": "The first systematic treatise on group theory and its application to polynomial equations — made Galois's posthumous manuscripts accessible to a wider audience and established the modern framework for studying permutation groups and solvability"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/angle-trisection/annotations.json
+++ b/src/data/proofs/angle-trisection/annotations.json
@@ -46,6 +46,28 @@
     ]
   },
   {
+    "id": "ann-namespace-and-derivation",
+    "proofId": "angle-trisection",
+    "range": {
+      "startLine": 67,
+      "endLine": 85
+    },
+    "type": "technique",
+    "title": "Part I: Deriving the Trisection Polynomial from cos(3θ)",
+    "content": "The namespace `AngleTrisection` and `open Polynomial Real` set up the algebraic context. Part I derives the minimal polynomial for cos(20°) from the triple angle formula.\n\nThe derivation: to trisect 60°, we need cos(20°). The triple angle formula gives cos(3θ) = 4cos³(θ) - 3cos(θ). Setting θ = 20° and cos(60°) = 1/2: 1/2 = 4x³ - 3x where x = cos(20°). Multiplying by 2: 8x³ - 6x - 1 = 0. This cubic with rational coefficients is the polynomial whose properties determine constructibility.",
+    "mathContext": "Setting $\\theta = 20°$ in $\\cos(3\\theta) = 4\\cos^3(\\theta) - 3\\cos(\\theta)$: $\\frac{1}{2} = 4x^3 - 3x$ where $x = \\cos(20°)$. Clearing denominators: $8x^3 - 6x - 1 = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "triple angle formula",
+      "minimal polynomial derivation",
+      "rational coefficients"
+    ],
+    "prerequisites": [
+      "trigonometric identities",
+      "polynomial roots"
+    ]
+  },
+  {
     "id": "ann-trisection-polynomial",
     "proofId": "angle-trisection",
     "range": {
@@ -152,6 +174,30 @@
     "prerequisites": [
       "rational root theorem",
       "polynomial arithmetic"
+    ]
+  },
+  {
+    "id": "ann-wantzel-context",
+    "proofId": "angle-trisection",
+    "range": {
+      "startLine": 155,
+      "endLine": 173
+    },
+    "type": "concept",
+    "title": "Part IV: Constructible Numbers and Wantzel's Criterion",
+    "content": "Part IV docstring defines constructible numbers and states Wantzel's key theorem (1837): a real number α is constructible iff there is a tower of field extensions Q = F₀ ⊂ F₁ ⊂ ... ⊂ Fₙ where α ∈ Fₙ and each [Fᵢ₊₁:Fᵢ] = 2.\n\nThe corollary is that [Q(α):Q] must divide 2ⁿ. Since constructing a point with compass and straightedge can only intersect lines and circles — yielding at most degree-2 extensions — the total extension degree is always a power of 2. This is why degree-3 minimal polynomials (like 8x³ - 6x - 1 for cos(20°)) imply non-constructibility: 3 does not divide any power of 2.",
+    "mathContext": "Wantzel (1837): $\\alpha$ constructible $\\iff$ $\\exists$ tower $\\mathbb{Q} = F_0 \\subset \\cdots \\subset F_n$ with $[F_{i+1}:F_i] = 2$ and $\\alpha \\in F_n$. Corollary: $\\deg(\\min_{\\mathbb{Q}}(\\alpha)) \\mid 2^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "field extension tower",
+      "degree of extension",
+      "compass and straightedge",
+      "Wantzel's theorem"
+    ],
+    "prerequisites": [
+      "field extensions",
+      "tower law",
+      "degree of minimal polynomial"
     ]
   },
   {

--- a/src/data/proofs/ballot-problem/annotations.json
+++ b/src/data/proofs/ballot-problem/annotations.json
@@ -13,6 +13,18 @@
     "prerequisites": ["probability theory", "combinatorics", "integer sequences"]
   },
   {
+    "id": "ann-namespace-setup",
+    "proofId": "ballot-problem",
+    "range": {"startLine": 80, "endLine": 92},
+    "type": "technique",
+    "title": "Namespace and MeasurableSpace Setup",
+    "content": "Opens the `BallotProblem` namespace and `Ballot`, `Set`, `ProbabilityTheory`, `MeasureTheory` namespaces for access to Mathlib's probability infrastructure.\n\nThe two `private` instances (lines 86-91) are critical Lean boilerplate: Mathlib's `Ballot` module defines `MeasurableSpace (List ℤ)` locally (with `local instance`), so it is not available outside that file. To use `condCount` (conditional counting measure) here, we must recreate the instance as the discrete σ-algebra (`⊤`) and prove `MeasurableSingletonClass` (every singleton is measurable). Without these, `condCount` would fail to find its typeclass instances.",
+    "mathContext": "The discrete σ-algebra $\\Sigma = \\mathcal{P}(\\text{List}\\,\\mathbb{Z})$ makes every subset measurable. `condCount` then computes $\\Pr[A \\mid B] = |A \\cap B| / |B|$ for finite sets.",
+    "significance": "supporting",
+    "relatedConcepts": ["MeasurableSpace", "condCount", "discrete σ-algebra", "typeclass instance"],
+    "prerequisites": ["measure theory basics", "Lean 4 typeclass system"]
+  },
+  {
     "id": "ann-model",
     "proofId": "ballot-problem",
     "range": {"startLine": 93, "endLine": 131},

--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -5,7 +5,7 @@
   "description": "If σ(n) = k·n (n is k-perfect), must k = o(log log n)? Known: k ≤ 11 exists. Gronwall: σ(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
   "meta": {
     "erdosNumber": 1053,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -46,8 +46,8 @@
       }
     ],
     "dateAdded": "2025-01-15",
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 12,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -5,7 +5,7 @@
   "description": "Determine k(n,m): the minimum vertices guaranteeing an independent set of size n or a transitive tournament of size m in any directed graph. Known: R(n,m) ≤ k(n,m) ≤ R(n,m,m). Open.",
   "meta": {
     "erdosNumber": 112,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -23,8 +23,8 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/112",
     "erdosUrl": "https://erdosproblems.com/112",
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 7,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -5,7 +5,7 @@
   "description": "Does every positive integer eventually reach 1 under f(n) = n/2 (even) or (3n+1)/2 (odd)? Verified up to 2^68. Tao: almost all orbits attain small values. Open. $500.",
   "meta": {
     "erdosNumber": 1135,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -32,8 +32,8 @@
         "relationship": "Verifies Collatz convergence for structured values (powers of 2, small cases up to 27)"
       }
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 3,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -5,7 +5,7 @@
   "description": "If every induced subgraph on ≥ ⌊n/2⌋ vertices has > n²/50 edges, must G contain a triangle? 1/50 is best possible (C₅ blow-up). Partial: EFRS (1/16), Krivelevich (3n/5, 1/25), Razborov (27/1024). Open ($250).",
   "meta": {
     "erdosNumber": 128,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -27,8 +27,8 @@
     "sourceUrl": "https://erdosproblems.com/128",
     "erdosUrl": "https://erdosproblems.com/128",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 6,
+    "badge": "axiom"
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Rousseau, appearing in Erdős's 1993 paper [Er93, p.344] and also in the Erdős-Rousseau paper [ErRo93]. It asks whether a local density condition — every large induced subgraph being dense — forces a global structure (a triangle). The problem sits at the intersection of extremal graph theory and Ramsey-type forcing, asking for the precise threshold at which local density guarantees global substructure.\n\nThe constant $1/50$ is motivated by the balanced blow-up of the 5-cycle $C_5$: partition $n$ vertices into 5 equal parts and connect parts $i$ and $i+1 \\pmod{5}$. This graph is triangle-free (since $C_5$ contains no $K_3$), has $n^2/5$ total edges, and any induced subgraph on $\\geq n/2$ vertices has at most $\\approx n^2/50$ edges. The Petersen graph (the $n=10$ case) is the smallest such extremal example.\n\nThe first major result was by Erdős, Faudree, Rousseau, and Schelp (1994), who proved the conjecture with $50$ replaced by $16$. They also proved a generalized form: for any $0 < \\alpha < 1$, if every set of $\\geq \\alpha n$ vertices induces $> \\alpha^3 n^2/2$ edges, then the graph contains a triangle. Krivelevich (1995) obtained a different trade-off, proving the result with the subgraph size increased to $3n/5$ but the constant improved to $25$. Keevash and Sudakov (2006) proved the conjecture under additional structural assumptions: either when the total edge count is $\\leq n^2/12$ or $\\geq n^2/5$. Norin and Yepremyan (2015) extended this to graphs with $\\geq (1/5 - c)n^2$ edges for some $c > 0$. The current best result is by Razborov (2022), who used his flag algebra method to improve the constant to $27/1024 \\approx 0.0264$, narrowing the gap with $1/50 = 0.02$ to a factor of $\\approx 1.32$. Erdős offered $250 for the resolution.",

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -5,7 +5,7 @@
   "description": "If A ⊆ ℕ is an additive basis of order 2 (A+A covers all but finitely many integers), must the representation function r(n) be unbounded? $500 bounty. Status: OPEN.",
   "meta": {
     "erdosNumber": 28,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -28,8 +28,8 @@
     "relatedProofs": [
       "erdos-40"
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 8,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -5,7 +5,7 @@
   "description": "Let R(N) be the max size of A ⊆ {1,...,N} with all reciprocal subset sums distinct. Bleicher–Erdős: R(N) = Θ(N/log N) up to iterated log factors. The precise correction is open.",
   "meta": {
     "erdosNumber": 321,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -24,8 +24,8 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/321",
     "erdosUrl": "https://erdosproblems.com/321",
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 4,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-330/meta.json
+++ b/src/data/proofs/erdos-330/meta.json
@@ -5,7 +5,7 @@
   "description": "Does there exist a minimal asymptotic additive basis A with positive density such that for every n ∈ A, the integers unrepresentable without n also have positive upper density? Open (Erdős–Nathanson).",
   "meta": {
     "erdosNumber": 330,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -25,8 +25,8 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/330",
     "erdosUrl": "https://erdosproblems.com/330",
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 7,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -5,7 +5,7 @@
   "description": "For what (t,α) is ⌊tα^n⌋ a complete sequence? Conjectured for all t > 0 and 1 < α < (1+√5)/2. Whether ⌊(3/2)^n⌋ is odd/even infinitely often is unknown. Open.",
   "meta": {
     "erdosNumber": 349,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -26,8 +26,8 @@
       "erdos-322",
       "erdos-267"
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 5,
+    "badge": "axiom"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -4,8 +4,11 @@
   "slug": "erdos-374",
   "description": "For F(m) = min k with a₁!···aₖ! a square (a₁<···<aₖ=m), study |Dₖ∩{1,...,n}| for Dₖ = {m: F(m)=k}. D₂ = squares. Dₖ = ∅ for k>6. Min D₆ = 527. Open for 3≤k≤6.",
   "meta": {
-    "erdosNumber": 374,
-    "status": "verified",
+    "author": "Erdős, Graham (1976)",
+    "sourceUrl": "https://erdosproblems.com/374",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos374Problem.lean",
+    "leanFile": "proofs/Proofs/Erdos374Problem.lean",
     "tags": [
       "erdos",
       "number-theory",
@@ -13,76 +16,137 @@
       "perfect-squares",
       "open"
     ],
-    "references": [
-      "Erdős–Graham (1976): original study",
-      "Dₖ = ∅ for k > 6",
-      "D₆ smallest element 527",
-      "https://erdosproblems.com/374"
-    ],
-    "leanFile": "Proofs/Erdos374Problem.lean",
+    "badge": "axiom",
     "sorries": 0,
-    "sourceUrl": "https://erdosproblems.com/374",
+    "erdosNumber": 374,
     "erdosUrl": "https://erdosproblems.com/374",
-    "axiomCount": 0,
-    "badge": "verified"
+    "erdosProblemStatus": "open",
+    "axiomCount": 7,
+    "lineCount": 79,
+    "dateAdded": "2026-02-10",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorial",
+        "description": "Factorial function used in factorialProduct definition",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      }
+    ],
+    "originalContributions": [
+      "IsPerfectSquare: constructive definition via ∃ k, n = k * k",
+      "factorialProduct: product of factorials of elements in a list",
+      "HasSquareFactorialProduct: formal condition for factorial products being perfect squares",
+      "bigF: axiomatized F(m), the minimum k for factorial square products",
+      "inDk: membership predicate for the sets Dₖ"
+    ],
+    "references": [
+      {
+        "key": "EG76",
+        "citation": "Erdős, P. and Graham, R.L., On products of factorials, Bulletin of the AMS 82 (1976), 151–153. Original study of factorial products as perfect squares.",
+        "type": "paper"
+      }
+    ],
+    "prerequisites": [
+      "Number theory: factorials, perfect squares, p-adic valuations",
+      "Legendre's formula: v_p(n!) = ∑_{i≥1} ⌊n/pⁱ⌋ for prime p",
+      "Combinatorics: partitions and set counting"
+    ],
+    "relatedProofs": [
+      "infinitude-primes",
+      "fundamental-arithmetic"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The structure of Dₖ depends on prime factorizations of factorials. Legendre's formula v_p(n!) = ∑⌊n/pⁱ⌋ determines which factorial products can be perfect squares"
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization is the foundation for analyzing when a product a₁!···aₖ! is a perfect square: each prime's total exponent must be even"
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Erdős Problem #374** originated in Erdős and Graham's 1976 work on factorial arithmetic. For an integer $m$, define $F(m)$ as the minimal $k \\geq 2$ such that there exist integers $a_1 < a_2 < \\cdots < a_k = m$ with the product $a_1! \\cdot a_2! \\cdots a_k!$ being a **perfect square**. The classes $D_k = \\{m : F(m) = k\\}$ partition the integers with well-defined $F$.\n\nThe structural results are striking: $D_2$ consists exactly of perfect squares greater than 1 (since $m! \\cdot a!$ is a square iff $m!/a!$ is a square, which for $a < m$ reduces to $m$ being a perfect square when $k=2$). No prime belongs to any $D_k$: if $p$ is prime, then $v_p(p!) = 1$, making it impossible to achieve even $p$-adic valuation in any product $a_1! \\cdots a_k!$ with $a_k = p$.\n\nThe most remarkable structural result is $D_k = \\emptyset$ for $k > 6$, proved by analyzing the parity constraints on $v_p(a_1! \\cdots a_k!)$ via Legendre's formula. The smallest element of $D_6$ is $527$, discovered by computational search. The **growth rates** of $|D_k \\cap \\{1, \\ldots, n\\}|$ for $3 \\leq k \\leq 6$ remain unknown as of 2026, with the interplay between Legendre's formula and parity constraints being the key obstacle.",
+    "problemStatement": "Determine the growth rate of $|D_k \\cap \\{1,\\ldots,n\\}|$ for $3 \\leq k \\leq 6$, where $D_k = \\{m : F(m) = k\\}$ and $F(m) = \\min\\{k \\geq 2 : \\exists a_1 < \\cdots < a_k = m,\\ a_1! \\cdots a_k! \\text{ is a perfect square}\\}$.",
+    "proofStrategy": "The formalization defines `IsPerfectSquare`, `factorialProduct`, and `HasSquareFactorialProduct` constructively, axiomatizes $F(m)$ as `bigF`, and records known structural results about the sets $D_k$. Seven axioms encode: $F$ is well-defined (minimality), $D_2 = $ squares, primes are excluded, $D_k = \\emptyset$ for $k > 6$, the minimum of $D_6$ is $527$, and the main open question about growth rates.",
+    "keyInsights": [
+      "D₂ = perfect squares > 1, giving |D₂ ∩ {1,...,n}| = √n + O(1)",
+      "No prime belongs to any Dₖ: v_p(p!) = 1 is odd, so the p-adic valuation of any factorial product including p! has odd p-contribution, preventing a perfect square",
+      "Dₖ = ∅ for k > 6, so only finitely many classes D₂,...,D₆ partition the relevant integers. This follows from tight constraints on how many factorials can be multiplied while maintaining parity",
+      "The smallest element of D₆ is 527, showing D₆ is sparse — the computation requires checking all m ≤ 527 and verifying F(527) = 6",
+      "D₃ grows slower than D₄, indicating non-monotone behavior in k — the growth rate is controlled by the density of integers whose factorial's prime factorization has specific parity patterns",
+      "The key obstacle is understanding how Legendre's formula v_p(n!) = ∑⌊n/pⁱ⌋ interacts with parity constraints across multiple factorials — the carrying structure in base-p representations of the aᵢ determines which products can be squares"
+    ],
+    "prerequisites": [
+      "Number theory: factorials $n!$, perfect squares, and $p$-adic valuations $v_p$",
+      "Legendre's formula: $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ — determines prime factorizations of factorials",
+      "Combinatorics: counting integers satisfying arithmetic parity constraints"
+    ]
   },
   "sections": [
     {
       "id": "imports",
-      "title": "Imports and Overview",
+      "title": "Imports and Problem Overview",
       "startLine": 1,
       "endLine": 24,
-      "summary": "Module imports and problem overview: factorial products as perfect squares."
+      "summary": "Problem statement, references to Erdős-Graham (1976), and Mathlib imports.",
+      "mathContext": "Define $F(m) = \\min\\{k \\geq 2 : \\exists a_1 < \\cdots < a_k = m,\\ a_1! \\cdots a_k! \\in \\text{squares}\\}$ and study $D_k = F^{-1}(k)$."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 25,
       "endLine": 52,
-      "summary": "IsPerfectSquare, factorialProduct, HasSquareFactorialProduct, bigF (F(m)), inDk."
+      "summary": "IsPerfectSquare (∃ k, n = k*k), factorialProduct (∏ aᵢ!), HasSquareFactorialProduct (the square product condition), bigF (axiomatized F(m)), inDk (membership in Dₖ).",
+      "mathContext": "$\\text{IsPerfectSquare}(n) :\\Leftrightarrow \\exists k, n = k^2$. $F(m) = \\min k$ with $\\exists a_1 < \\cdots < a_k = m$, $\\prod a_i!$ a square."
     },
     {
       "id": "d2-primes",
       "title": "D₂ and Prime Exclusion",
       "startLine": 54,
       "endLine": 62,
-      "summary": "D₂ = perfect squares > 1; no prime belongs to any Dₖ."
+      "summary": "D₂ = perfect squares > 1; no prime belongs to any Dₖ (since v_p(p!) is odd).",
+      "mathContext": "$D_2 = \\{m^2 : m \\geq 2\\}$ (for $k=2$, need $a! \\cdot m!$ a square with $a < m$). Primes excluded: $v_p(p!) = 1$ forces odd total valuation."
     },
     {
       "id": "d6-finiteness",
       "title": "Finiteness and D₆ Structure",
       "startLine": 63,
       "endLine": 69,
-      "summary": "Dₖ = ∅ for k > 6; smallest element of D₆ is 527."
+      "summary": "Dₖ = ∅ for k > 6; smallest element of D₆ is 527.",
+      "mathContext": "$D_k = \\emptyset$ for $k > 6$: at most 6 factorials needed. $\\min D_6 = 527$: verified by exhaustive computation."
     },
     {
       "id": "open-question",
       "title": "The Open Question",
       "startLine": 71,
       "endLine": 79,
-      "summary": "Growth rate of |Dₖ ∩ {1,...,n}| for 3 ≤ k ≤ 6 — open problem."
+      "summary": "Growth rate of |Dₖ ∩ {1,...,n}| for 3 ≤ k ≤ 6 — the main open problem.",
+      "mathContext": "For $3 \\leq k \\leq 6$: $|D_k \\cap \\{1,\\ldots,n\\}| = ?$ asymptotically. Known: $|D_2| \\sim \\sqrt{n}$. Unknown: growth rates for $D_3, D_4, D_5, D_6$."
     }
   ],
-  "overview": {
-    "historicalContext": "**Erdős Problem #374** originated in Erdős and Graham's 1976 work on factorial arithmetic. For an integer $m$, define $F(m)$ as the minimal $k \\geq 2$ such that there exist integers $a_1 < a_2 < \\cdots < a_k = m$ with the product $a_1! \\cdot a_2! \\cdots a_k!$ being a **perfect square**. The classes $D_k = \\{m : F(m) = k\\}$ partition the integers with well-defined $F$.\n\nThe structural results are striking: $D_2$ consists exactly of perfect squares, no prime belongs to any $D_k$, and $D_k = \\emptyset$ for $k > 6$. The smallest element of $D_6$ is $527$, discovered by computational search. The **growth rates** of $|D_k \\cap \\{1, \\ldots, n\\}|$ for $3 \\leq k \\leq 6$ remain unknown as of 2025, with the interplay between Legendre's formula for $v_p(n!)$ and parity constraints on prime multiplicities being the key obstacle.",
-    "problemStatement": "Determine the growth rate of |Dₖ ∩ {1,...,n}| for 3 ≤ k ≤ 6, where Dₖ = {m : F(m) = k}.",
-    "proofStrategy": "We define IsPerfectSquare, factorialProduct, and HasSquareFactorialProduct constructively, axiomatize F(m) as bigF, and record known structural results about the sets Dₖ.",
-    "keyInsights": [
-      "D₂ = perfect squares > 1, giving |D₂ ∩ {1,...,n}| = √n + O(1)",
-      "No prime belongs to any Dₖ, since a single factorial p! cannot be part of a square product",
-      "Dₖ = ∅ for k > 6, so only finitely many classes D₂,...,D₆ partition the relevant integers",
-      "The smallest element of D₆ is 527, showing D₆ is sparse",
-      "D₃ grows slower than D₄, indicating non-monotone behavior in k"
+  "conclusion": {
+    "summary": "Erdős Problem #374 is formalized in 79 lines with 7 axioms encoding the structural results about factorial square products. The partition D₂ through D₆ is established, with D₂ = squares and Dₖ = ∅ for k > 6. The growth rates of D₃ through D₆ remain open.",
+    "implications": "Resolution would connect factorial arithmetic to the distribution of square-free parts and p-adic valuations, with links to Legendre's formula, base-p representations, and the theory of multiplicative functions.",
+    "openQuestions": [
+      "What is |D₃ ∩ {1,...,n}| asymptotically? Is D₃ infinite?",
+      "What is |D₄ ∩ {1,...,n}| asymptotically?",
+      "Is D₅ finite or infinite? It is conjectured to be infinite but sparse",
+      "What is the density of D₃ ∪ D₄ ∪ D₅ ∪ D₆ relative to the set of all non-prime, non-square integers?"
     ]
   },
-  "conclusion": {
-    "summary": "Erdős Problem #374 asks for the growth rate of Dₖ (integers requiring exactly k factorials for a square product) for 3 ≤ k ≤ 6. The structure is known — only D₂ through D₆ are nonempty — but growth rates remain open.",
-    "implications": "Resolution would connect factorial arithmetic to the distribution of square-free parts and p-adic valuations, with links to Stirling's approximation and multiplicative number theory.",
-    "openQuestions": [
-      "What is |D₃ ∩ {1,...,n}| asymptotically?",
-      "What is |D₄ ∩ {1,...,n}| asymptotically?",
-      "Is D₅ finite or infinite?",
-      "What is the density of D₃ ∪ D₄ ∪ D₅ ∪ D₆?"
-    ]
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Nat.Basic"
+    ],
+    "opens": [],
+    "namespace": "Erdos374",
+    "lineCount": 79,
+    "axiomCount": 7,
+    "theoremCount": 0,
+    "definitionCount": 5
   }
 }

--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -5,7 +5,7 @@
   "description": "A primitive pseudoperfect number is a sum of distinct proper divisors, with no proper divisor having this property. Does Σ_{n ∈ A} 1/n converge? OEIS A006036. Open.",
   "meta": {
     "erdosNumber": 469,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -25,8 +25,9 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/469",
     "erdosUrl": "https://erdosproblems.com/469",
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 2,
+    "badge": "axiom",
+    "lineCount": 227
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-513/meta.json
+++ b/src/data/proofs/erdos-513/meta.json
@@ -4,8 +4,11 @@
   "slug": "erdos-513",
   "description": "For transcendental entire f(z) = Σ aₙzⁿ, determine sup liminf_{r→∞} μ(r)/M(r) where μ(r) = max_n |aₙrⁿ| and M(r) = max_{|z|=r} |f(z)|. Known: value ∈ (1/2, 2/π - c]. Open.",
   "meta": {
-    "erdosNumber": 513,
-    "status": "verified",
+    "author": "Erdős (1961)",
+    "sourceUrl": "https://erdosproblems.com/513",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos513Problem.lean",
+    "leanFile": "proofs/Proofs/Erdos513Problem.lean",
     "tags": [
       "erdos",
       "complex-analysis",
@@ -13,76 +16,115 @@
       "power-series",
       "open"
     ],
-    "references": [
-      "Erdős (1961): original problem, p.249",
-      "Kövári (unpublished): lower bound > 1/2",
-      "Clunie–Hayman (1964): upper bound 2/π - c",
-      "Gray–Shah (1963): additional bounds",
-      "https://erdosproblems.com/513"
-    ],
-    "leanFile": "Proofs/Erdos513Problem.lean",
+    "badge": "axiom",
     "sorries": 0,
-    "sourceUrl": "https://erdosproblems.com/513",
+    "erdosNumber": 513,
     "erdosUrl": "https://erdosproblems.com/513",
-    "axiomCount": 0,
-    "badge": "verified"
+    "erdosProblemStatus": "open",
+    "axiomCount": 8,
+    "lineCount": 151,
+    "dateAdded": "2026-02-10",
+    "references": [
+      {
+        "key": "Er61",
+        "citation": "Erdős, P., Some unsolved problems, Michigan Math. J. 4 (1961), 249. Original formulation of Problem 513.",
+        "type": "paper"
+      },
+      {
+        "key": "CH64",
+        "citation": "Clunie, J. and Hayman, W.K., The maximum term of a power series, J. Analyse Math. 12 (1964), 143–186. Upper bound 2/π - c.",
+        "type": "paper"
+      }
+    ],
+    "prerequisites": [
+      "Complex analysis: entire functions, maximum modulus principle, power series",
+      "Wiman-Valiron theory: maximum term μ(r), central index, and their relation to M(r)",
+      "Lacunary series: gap series with controlled coefficient growth"
+    ],
+    "relatedProofs": []
+  },
+  "crossReferences": [],
+  "overview": {
+    "historicalContext": "Erdős (1961) asked for the greatest possible value of $\\liminf_{r\\to\\infty} \\mu(r)/M(r)$ over all transcendental entire functions, where $\\mu(r) = \\max_n |a_n|r^n$ is the **maximum term** and $M(r) = \\max_{|z|=r}|f(z)|$ the **maximum modulus**. The problem sits at the heart of **Wiman–Valiron theory**, which systematically relates the dominant term to global growth.\n\nThe trivial bound $\\mu(r) \\leq M(r)$ (the maximum term never exceeds the maximum modulus) means the ratio always lies in $[0,1]$. For many standard functions (like $e^z$), the dominant term captures most of the maximum modulus as $r \\to \\infty$, giving $\\liminf \\mu(r)/M(r) = 1$. The question is how small this ratio can be forced to be.\n\nKövári (unpublished) showed via lacunary series constructions that the supremum exceeds $1/2$. Clunie and Hayman (1964, *J. Analyse Math.*) proved the sharp upper bound: the supremum is strictly less than $2/\\pi \\approx 0.6366$, where $2/\\pi$ arises as $\\frac{1}{\\pi}\\int_0^\\pi |\\cos\\theta|\\,d\\theta$ — the average value of $|\\cos\\theta|$. Gray and Shah (1963) provided additional intermediate bounds. The exact value in $(1/2, 2/\\pi)$ remains one of the outstanding open problems in classical complex analysis.",
+    "problemStatement": "Determine $\\sup_f \\liminf_{r\\to\\infty} \\frac{\\mu(r)}{M(r)}$ over all transcendental entire functions $f(z) = \\sum a_n z^n$, where $\\mu(r) = \\max_n |a_n|r^n$ and $M(r) = \\max_{|z|=r}|f(z)|$.",
+    "proofStrategy": "The formalization axiomatizes `maxTerm` ($\\mu(r)$) and `maxModulus` ($M(r)$) as functions on transcendental entire functions, defines the ratio `termModulusRatio` constructively, and records the known bounds as axioms. Five structural theorems are proved from the axioms: the ratio lies in $[0,1]$, set membership, degenerate cases, and ratio-equals-quotient when $M(r) > 0$. The main conjecture (`erdos_513_exact_value`) asserts the existence of an exact supremum $L \\in (1/2, 2/\\pi)$.",
+    "keyInsights": [
+      "μ(r) ≤ M(r) always holds by the maximum modulus principle, so the ratio lies in [0, 1]",
+      "Kövári proved the supremum exceeds 1/2 using lacunary series — gap series where the coefficients are nonzero only at rapidly increasing indices, causing the maximum term to dominate the sum",
+      "Clunie-Hayman (1964) showed the supremum is strictly less than 2/π ≈ 0.6366, where 2/π arises as the average of |cos θ| — a connection to the distribution of the argument of f(re^{iθ})",
+      "The gap between 1/2 and 2/π remains one of the most precise open intervals in classical analysis",
+      "The problem connects to the central index ν(r) (the n maximizing |aₙ|rⁿ) via Wiman-Valiron theory: when μ(r)/M(r) is large, the function f(z) is dominated by the single term aᵥ(r)zᵥ(r) near |z| = r",
+      "For lacunary series f(z) = Σ aₙ z^{n_k} with large gaps n_{k+1}/n_k → ∞, μ(r)/M(r) → 1 for most r, but the liminf can be forced down to any value > 1/2"
+    ],
+    "prerequisites": [
+      "Complex analysis: entire functions $f(z) = \\sum a_n z^n$, maximum modulus principle, and growth orders",
+      "Wiman-Valiron theory: maximum term $\\mu(r)$, central index $\\nu(r)$, and the asymptotic formula $f(re^{i\\theta}) \\sim a_{\\nu(r)}(re^{i\\theta})^{\\nu(r)}$",
+      "Lacunary series: series with large gaps between nonzero coefficients, controlling the ratio $\\mu/M$"
+    ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Problem overview, references to Erdős (1961), Kövári, Clunie-Hayman. Imports Mathlib.",
+      "mathContext": "Determine $\\sup_f \\liminf_{r\\to\\infty} \\mu(r)/M(r)$ over transcendental entire $f$. Known: value $\\in (1/2, 2/\\pi - c]$."
+    },
     {
       "id": "definitions",
       "title": "Definitions",
       "startLine": 26,
       "endLine": 52,
-      "summary": "maxTerm, maxModulus (axiomatized), termModulusRatio, IsTranscendentalEntire."
+      "summary": "maxTerm (axiomatized μ(r)), maxModulus (axiomatized M(r)), termModulusRatio (μ/M), IsTranscendentalEntire.",
+      "mathContext": "$\\mu(r) = \\max_n |a_n|r^n$ (maximum term), $M(r) = \\max_{|z|=r}|f(z)|$ (maximum modulus). Ratio: $\\mu(r)/M(r) \\in [0,1]$."
     },
     {
       "id": "known-results",
-      "title": "Known Results",
+      "title": "Known Results and Bounds",
       "startLine": 54,
       "endLine": 73,
-      "summary": "μ(r) ≤ M(r), Kövári lower bound > 1/2, Clunie–Hayman upper bound ≤ 2/π - c."
-    },
-    {
-      "id": "open-question",
-      "title": "The Open Question",
-      "startLine": 75,
-      "endLine": 87,
-      "summary": "Determine the exact value of sup liminf μ(r)/M(r) over all transcendental entire functions."
+      "summary": "μ(r) ≤ M(r) (axiom), Kövári lower bound > 1/2, Clunie-Hayman upper bound ≤ 2/π - c.",
+      "mathContext": "Bounds: $1/2 < \\sup_f \\liminf \\mu(r)/M(r) \\leq 2/\\pi - c$ where $c > 0$ (Clunie-Hayman 1964)."
     },
     {
       "id": "structural-theorems",
       "title": "Proved Structural Theorems",
       "startLine": 89,
       "endLine": 120,
-      "summary": "Five proved theorems: ratio in [0,1], set membership, degenerate case, and ratio-equals-quotient when M(r)>0."
+      "summary": "Five proved theorems from axioms: ratio in [0,1], set membership, degenerate case (ratio = 0 when M(r) = 0), and ratio-equals-quotient.",
+      "mathContext": "Proved: $0 \\leq \\mu(r)/M(r) \\leq 1$, and $\\mu(r)/M(r) = \\mu(r) \\cdot M(r)^{-1}$ when $M(r) > 0$."
     },
     {
       "id": "formal-conjecture",
-      "title": "Formal Conjecture: Exact Supremum",
+      "title": "Formal Conjecture",
       "startLine": 122,
-      "endLine": 155,
-      "summary": "Axiom erdos_513_exact_value asserts the existence of L in (1/2, 2/π) that is the tight supremum of liminf μ(r)/M(r)."
+      "endLine": 151,
+      "summary": "erdos_513_exact_value: axiom asserting existence of exact supremum L ∈ (1/2, 2/π). Summary theorem packaging all known results.",
+      "mathContext": "$\\exists L \\in (1/2, 2/\\pi)$ such that $\\sup_f \\liminf_{r\\to\\infty} \\mu(r)/M(r) = L$."
     }
   ],
-  "overview": {
-    "historicalContext": "Erdős (1961) asked for the greatest possible value of $\\liminf_{r\\to\\infty} \\mu(r)/M(r)$ over all transcendental entire functions, where $\\mu(r) = \\max_n |a_n|r^n$ is the **maximum term** and $M(r) = \\max_{|z|=r}|f(z)|$ the **maximum modulus**. The problem sits at the heart of **Wiman–Valiron theory**, which systematically relates the dominant term to global growth. Kövári (unpublished) showed via lacunary series that the supremum exceeds 1/2. Clunie and Hayman (1964, *J. Analyse Math.*) proved the supremum is strictly less than $2/\\pi \\approx 0.6366$, where $2/\\pi$ arises as the average of $|\\cos\\theta|$. The exact value in $(1/2, 2/\\pi)$ remains one of the outstanding open problems in classical complex analysis.",
-    "problemStatement": "Determine the greatest possible value of liminf_{r→∞} μ(r)/M(r) over all transcendental entire functions f(z) = Σ aₙzⁿ.",
-    "proofStrategy": "We axiomatize maxTerm and maxModulus, define the ratio constructively, and record Kövári's lower bound and the Clunie–Hayman upper bound as axioms. The open question is formalized as the existence of an exact supremum in (1/2, 2/π).",
-    "keyInsights": [
-      "μ(r) ≤ M(r) always, so the ratio lies in [0, 1]",
-      "Kövári proved the supremum exceeds 1/2 (unpublished)",
-      "Clunie–Hayman (1964) showed the supremum is strictly less than 2/π",
-      "The gap between 1/2 and 2/π ≈ 0.637 remains unresolved",
-      "Related to Problem #227 on similar power series questions"
+  "conclusion": {
+    "summary": "Erdős Problem #513 is formalized in 151 lines with 8 axioms encoding the maximum term and modulus functions and their known bounds. Five structural theorems are proved. The exact supremum of liminf μ(r)/M(r) over transcendental entire functions lies in (1/2, 2/π) but remains unknown.",
+    "implications": "Resolution would clarify the fundamental relationship between the maximum term and maximum modulus of entire functions, connecting Wiman-Valiron theory to the distribution of the argument of f(re^{iθ}). The appearance of 2/π suggests a connection to harmonic analysis and Fourier coefficients.",
+    "openQuestions": [
+      "What is the exact value of sup liminf μ(r)/M(r)? The gap (1/2, 2/π) has not narrowed since 1964",
+      "Can the Clunie-Hayman upper bound 2/π - c be made explicit (i.e., determine c)?",
+      "What is the extremal function (if any) achieving the supremum? Is it a lacunary series?",
+      "Does the answer change if liminf is replaced by limsup? (Wiman's theorem gives μ(r)/M(r) → 1 along a sequence for any entire function)"
     ]
   },
-  "conclusion": {
-    "summary": "Erdős Problem #513 asks for the exact supremum of liminf_{r→∞} μ(r)/M(r) over transcendental entire functions. The value is known to lie in (1/2, 2/π - c] but the precise constant is open.",
-    "implications": "Resolution would clarify the fundamental relationship between the maximum term and maximum modulus of entire functions, with connections to the Wiman–Valiron theory and the central index.",
-    "openQuestions": [
-      "What is the exact value of sup liminf μ(r)/M(r)?",
-      "Can the Clunie–Hayman upper bound 2/π - c be sharpened?",
-      "What is the extremal function (if any) achieving the supremum?"
-    ]
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+    ],
+    "opens": [],
+    "namespace": "Erdos513",
+    "lineCount": 151,
+    "axiomCount": 8,
+    "theoremCount": 5,
+    "definitionCount": 3
   }
 }

--- a/src/data/proofs/erdos-557/meta.json
+++ b/src/data/proofs/erdos-557/meta.json
@@ -5,7 +5,7 @@
   "description": "Is R(T; k) ≤ k·n + O(1) for any tree T on n vertices and k colors? The star lower bound R(S_n; k) ≥ k(n-1)+1 shows this would be tight. Status: OPEN.",
   "meta": {
     "erdosNumber": 557,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -25,8 +25,8 @@
     "sourceUrl": "https://erdosproblems.com/557",
     "erdosUrl": "https://erdosproblems.com/557",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 10,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-562/meta.json
+++ b/src/data/proofs/erdos-562/meta.json
@@ -5,7 +5,7 @@
   "description": "For r ≥ 3, prove that log_{r-1} R_r(n) ≍ n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n²)) from Erdős–Rado. Lower: twr_{r-1}(Ω(n)). Status: OPEN.",
   "meta": {
     "erdosNumber": 562,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -24,8 +24,8 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/562",
     "erdosUrl": "https://erdosproblems.com/562",
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 7,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-566/meta.json
+++ b/src/data/proofs/erdos-566/meta.json
@@ -5,7 +5,7 @@
   "description": "If every k-vertex subgraph of G has at most 2k−3 edges, is G Ramsey size linear? True for ≤ n+1 edges (EFRS 1993), false for 2n−2 edges. Implies Problem #567. Open.",
   "meta": {
     "erdosNumber": 566,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -29,8 +29,8 @@
       "erdos-567",
       "erdos-565"
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 4,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-567/meta.json
+++ b/src/data/proofs/erdos-567/meta.json
@@ -5,7 +5,7 @@
   "description": "Are Q₃ (3-cube), K₃,₃ (complete bipartite), and H₅ (C₅ + two chords) Ramsey size linear? Special case of #566. Bradač–Gishboliner–Sudakov: K₄ subdivisions with ≥ 6 vertices are linear. Open.",
   "meta": {
     "erdosNumber": 567,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -29,8 +29,8 @@
       "erdos-566",
       "erdos-565"
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 6,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-568/meta.json
+++ b/src/data/proofs/erdos-568/meta.json
@@ -5,7 +5,7 @@
   "description": "If R(G, Tₙ) ≪ n for all trees and R(G, Kₙ) ≪ n² for all complete graphs, must G be Ramsey size linear? Posed by EFRS (1993). Open.",
   "meta": {
     "erdosNumber": 568,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "combinatorics",
@@ -28,8 +28,8 @@
       "erdos-566",
       "erdos-567"
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 3,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -5,7 +5,7 @@
   "description": "Is ex(n; {C_{2k−1}, C_{2k}}) = (1+o(1))·(n/2)^{1+1/k} for k ≥ 2? Conjectured that forbidding C_{2k−1} in addition to C_{2k} does not change the extremal number asymptotically. Open.",
   "meta": {
     "erdosNumber": 574,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -48,8 +48,8 @@
         "description": "Problem #180 on Turán numbers for graph families, the general framework for this problem"
       }
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 4,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-654/meta.json
+++ b/src/data/proofs/erdos-654/meta.json
@@ -5,7 +5,7 @@
   "description": "Given n points in the plane with no four on a circle, must some point determine (1-o(1))n distinct distances? Known: each point has ≥ (n-1)/3 distinct distances. Status: OPEN.",
   "meta": {
     "erdosNumber": 654,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "geometry",
@@ -31,8 +31,8 @@
       "erdos-662",
       "erdos-655"
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 5,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-726/meta.json
+++ b/src/data/proofs/erdos-726/meta.json
@@ -5,7 +5,7 @@
   "description": "For n → ∞, is Σ_{p≤n, n mod p ∈ (p/2,p)} 1/p ~ (log log n)/2? The upper half residues should contribute exactly half of Mertens' sum. Erdős–Graham–Ruzsa–Straus (1975). Status: OPEN.",
   "meta": {
     "erdosNumber": 726,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -30,8 +30,8 @@
       "erdos-725",
       "erdos-727"
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 6,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-837/meta.json
+++ b/src/data/proofs/erdos-837/meta.json
@@ -5,7 +5,7 @@
   "description": "Define A_k as the density jump values for k-uniform hypergraphs. For graphs, A_2 = {1−1/m : m ≥ 1} by Erdős–Stone. What is A_3? Connected to hypergraph Turán problem. Open.",
   "meta": {
     "erdosNumber": 837,
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -52,8 +52,8 @@
       "Axiomatized the central open question: characterize A_3",
       "Axiomatized 0 ∈ A_3 (zero is a jump for 3-uniform hypergraphs)"
     ],
-    "axiomCount": 0,
-    "badge": "verified"
+    "axiomCount": 4,
+    "badge": "axiom"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-848/meta.json
+++ b/src/data/proofs/erdos-848/meta.json
@@ -4,8 +4,11 @@
   "slug": "erdos-848",
   "description": "Max |A| with A ⊆ {1,...,N} and ab+1 never squarefree for a,b ∈ A. Extremal sets: {n ≡ 7 (mod 25)} or {n ≡ 18 (mod 25)}, giving N/25. Solved by Sawhney for large N.",
   "meta": {
-    "erdosNumber": 848,
-    "status": "verified",
+    "author": "Erdős, Sárközy (1992); solved by Sawhney",
+    "sourceUrl": "https://erdosproblems.com/848",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos848Problem.lean",
+    "leanFile": "proofs/Proofs/Erdos848Problem.lean",
     "tags": [
       "erdos",
       "number-theory",
@@ -13,75 +16,141 @@
       "extremal-combinatorics",
       "solved"
     ],
-    "references": [
-      "Erdős–Sárközy (1992): original problem",
-      "van Doorn: upper bound via quadratic residues",
-      "Weisenberg: refined upper bound",
-      "Sawhney: solution for large N",
-      "https://erdosproblems.com/848"
-    ],
-    "leanFile": "Proofs/Erdos848Problem.lean",
+    "badge": "axiom",
     "sorries": 0,
-    "sourceUrl": "https://erdosproblems.com/848",
+    "erdosNumber": 848,
     "erdosUrl": "https://erdosproblems.com/848",
-    "axiomCount": 0,
-    "badge": "verified"
+    "erdosProblemStatus": "solved",
+    "axiomCount": 7,
+    "lineCount": 71,
+    "dateAdded": "2026-02-10",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime",
+        "description": "Primality predicate used in the squarefree definition",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "IsSquarefree: constructive definition via ∀ p, p.Prime → ¬(p * p ∣ n)",
+      "HasNonSqfreeProductProp: formal property requiring ¬IsSquarefree(ab+1) for all pairs",
+      "mod25_achieves: axiom that 5² | ab+1 when a ≡ b ≡ 7 (mod 25)",
+      "sawhney_solution: axiom encoding the exact answer N/25 for large N",
+      "sawhney_structure: axiom encoding uniqueness of extremal sets (mod 25 residue classes)"
+    ],
+    "references": [
+      {
+        "key": "ES92",
+        "citation": "Erdős, P. and Sárközy, A., On sets of integers with property P, Mathematica Pannonica 3 (1992). Original formulation of the problem.",
+        "type": "paper"
+      },
+      {
+        "key": "Sa",
+        "citation": "Sawhney, M., Solution to Erdős Problem 848: the maximum is N/25 for sufficiently large N, with extremal sets {n ≡ 7 (mod 25)} and {n ≡ 18 (mod 25)}.",
+        "type": "paper"
+      }
+    ],
+    "prerequisites": [
+      "Number theory: squarefree numbers, prime factorization, density 6/π²",
+      "Modular arithmetic: quadratic residues, solutions of x² ≡ -1 (mod p²)",
+      "Extremal combinatorics: maximum set sizes under product constraints"
+    ],
+    "relatedProofs": [
+      "infinitude-primes",
+      "fermat-two-squares",
+      "elementary-quadratic-reciprocity"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The squarefree condition p² | ab+1 depends on the structure of primes dividing shifted products. The infinitude of primes ensures the density of squarefree numbers is exactly 6/π² = ∏(1 - 1/p²)"
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "related",
+      "description": "The mod-25 construction uses p = 5 with 5 ≡ 1 (mod 4), connecting to Fermat's theorem on primes representable as sums of two squares. Van Doorn's upper bound sums over primes p ≡ 1 (mod 4), exactly those for which x² ≡ -1 (mod p) has solutions"
+    },
+    {
+      "targetId": "elementary-quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The quadratic residue structure — specifically, -1 is a square mod p iff p ≡ 1 (mod 4) — determines which primes p can have p² | ab+1 for elements in the extremal set. This is a direct application of quadratic reciprocity"
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Erdős and Sárközy** (1992) posed the problem of determining the maximum size of $A \\subseteq \\{1,\\ldots,N\\}$ such that $ab + 1$ is never squarefree for all $a, b \\in A$ (including $a = b$). The condition '$ab + 1$ is not squarefree' means there exists a prime $p$ with $p^2 \\mid ab + 1$.\n\nThe key construction exploits the arithmetic of $\\mathbb{Z}/25\\mathbb{Z}$: for $a \\equiv b \\equiv 7 \\pmod{25}$, we have $ab + 1 \\equiv 49 + 1 = 50 \\equiv 0 \\pmod{25}$, so $5^2 \\mid ab + 1$. Similarly, $18 \\equiv -7 \\pmod{25}$ gives $18^2 + 1 = 325 = 13 \\cdot 25$, so the same holds. The residues $7$ and $18 = 25 - 7$ are the two square roots of $-1$ modulo $25$ (since $7^2 = 49 \\equiv -1 \\pmod{25}$). This construction achieves $|A| = \\lfloor N/25 \\rfloor$.\n\n**Van Doorn** improved the upper bound to approximately $0.108N$ using an inclusion-exclusion argument over primes $p \\equiv 1 \\pmod{4}$: for each such prime, $a^2 + 1 \\equiv 0 \\pmod{p^2}$ has exactly 2 solutions mod $p^2$, contributing $2/p^2$ to the density. The sum $2\\sum_{p \\equiv 1(4)} 1/p^2 \\approx 0.108$ gives the bound. **Weisenberg** refined this further.\n\nFinally, **Sawhney** proved the exact answer: for all sufficiently large $N$, $\\max|A| = \\lfloor N/25 \\rfloor$, and the extremal sets are precisely $\\{n \\equiv 7 \\pmod{25}\\}$ and $\\{n \\equiv 18 \\pmod{25}\\}$. The proof uses modern tools from additive combinatorics to show that any near-extremal set must concentrate in one of these two residue classes.",
+    "problemStatement": "Determine $\\max|A|$ for $A \\subseteq \\{1,\\ldots,N\\}$ satisfying: for all $a, b \\in A$, $ab + 1$ is not squarefree (i.e., $\\exists p$ prime with $p^2 \\mid ab + 1$).",
+    "proofStrategy": "The formalization defines `IsSquarefree` constructively (no prime squared divides $n$) and `HasNonSqfreeProductProp` (the pairwise non-squarefree condition). The extremal function `maxNonSqfreeSet` is axiomatized with an upper bound ($\\leq N$). Three key results are axiomatized: the mod-25 construction (showing $5^2 \\mid ab+1$ for the residue class), the van Doorn upper bound ($\\leq 0.108N + O(1)$), and Sawhney's exact solution with structural characterization.",
+    "keyInsights": [
+      "For a ≡ b ≡ 7 (mod 25), ab + 1 ≡ 49 + 1 = 50 ≡ 0 (mod 25), so 5² | ab + 1. The residue 7 satisfies 7² ≡ -1 (mod 25)",
+      "The same holds for 18 ≡ -7 (mod 25) since 18² + 1 = 325 = 13 · 25. The pair {7, 18} are the two square roots of -1 in Z/25Z",
+      "Van Doorn's bound uses the density of solutions to a² + 1 ≡ 0 (mod p²): exactly 2 solutions for p ≡ 1 (mod 4) and 0 for p ≡ 3 (mod 4), giving 2∑_{p≡1(4)} 1/p² ≈ 0.108",
+      "Sawhney proved the extremal sets are exactly the mod-25 residue classes — a rigid structural result showing the construction is unique up to the 7 ↔ 18 symmetry",
+      "The 'sufficiently large N' threshold in Sawhney's result means finite exceptions may exist; determining the exact threshold remains open",
+      "The choice of prime 5 is optimal: 25 = 5² is the smallest prime square for which x² ≡ -1 (mod p²) has solutions (since 5 ≡ 1 (mod 4)), giving the densest residue class achieving the property"
+    ],
+    "prerequisites": [
+      "Number theory: squarefree numbers (density $6/\\pi^2$), prime factorization, and divisibility",
+      "Modular arithmetic: quadratic residues, $x^2 \\equiv -1 \\pmod{p}$ solvable iff $p \\equiv 1 \\pmod{4}$",
+      "Extremal combinatorics: maximum set problems under arithmetic constraints"
+    ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Problem statement, imports from Mathlib (Tactic, Nat.Basic, Nat.Prime.Basic).",
+      "mathContext": "Determine $\\max|A|$ for $A \\subseteq \\{1,\\ldots,N\\}$ with $\\forall a,b \\in A,\\ \\exists p$ prime: $p^2 \\mid ab+1$. Known answer: $\\lfloor N/25 \\rfloor$ for large $N$."
+    },
     {
       "id": "definitions",
       "title": "Definitions",
       "startLine": 21,
       "endLine": 37,
-      "summary": "IsSquarefree, HasNonSqfreeProductProp, maxNonSqfreeSet."
+      "summary": "IsSquarefree (no prime squared divides n), HasNonSqfreeProductProp (pairwise non-squarefree products), maxNonSqfreeSet (axiomatized extremal function with upper bound ≤ N).",
+      "mathContext": "$\\text{IsSquarefree}(n) :\\Leftrightarrow \\forall p$ prime, $p^2 \\nmid n$. $\\text{HasNonSqfreeProductProp}(A) :\\Leftrightarrow \\forall a,b \\in A,\\ \\neg\\text{IsSquarefree}(ab+1)$."
     },
     {
       "id": "known-results",
-      "title": "Known Results",
+      "title": "Known Results: Construction and Bounds",
       "startLine": 39,
       "endLine": 55,
-      "summary": "mod 25 construction achieves property, lower bound N/25, van Doorn upper bound ≈ 0.108N."
+      "summary": "mod25_achieves: 5² | ab+1 for a ≡ b ≡ 7 (mod 25). lower_bound: maxNonSqfreeSet(N) ≥ N/25. vanDoorn_upper_bound: ≤ 0.108N + O(1).",
+      "mathContext": "Construction: $a \\equiv b \\equiv 7 \\pmod{25} \\Rightarrow ab+1 \\equiv 50 \\equiv 0 \\pmod{25}$, so $25 \\mid ab+1$. Bounds: $\\lfloor N/25 \\rfloor \\leq \\max|A| \\leq 0.108N + O(1)$."
     },
     {
       "id": "solution",
-      "title": "The Solution",
+      "title": "Sawhney's Exact Solution",
       "startLine": 57,
-      "endLine": 72,
-      "summary": "Sawhney: max = N/25 for large N, extremal sets are {n ≡ 7 or 18 (mod 25)}."
-    },
-    {
-      "id": "squarefree-theory",
-      "title": "Squarefree Number Theory",
-      "startLine": 74,
-      "endLine": 88,
-      "summary": "IsSquarefree definition, quadratic residue structure, and van Doorn's bound via p² | ab+1."
-    },
-    {
-      "id": "extremal-structure",
-      "title": "Extremal Set Characterization",
-      "startLine": 90,
-      "endLine": 105,
-      "summary": "Uniqueness of the mod-25 extremal sets and structural characterization for large N."
+      "endLine": 71,
+      "summary": "sawhney_solution: max = N/25 for large N. sawhney_structure: extremal sets are exactly {n ≡ 7 (mod 25)} or {n ≡ 18 (mod 25)}.",
+      "mathContext": "$\\exists N_0,\\ \\forall N \\geq N_0: \\max|A| = \\lfloor N/25 \\rfloor$. Uniqueness: any extremal $A$ satisfies $A \\subseteq \\{n \\equiv 7\\}$ or $A \\subseteq \\{n \\equiv 18\\} \\pmod{25}$."
     }
   ],
-  "overview": {
-    "historicalContext": "**Erdős and Sárközy** (1992) asked for the maximum size of $A \\subseteq \\{1,\\ldots,N\\}$ such that $ab + 1$ is never squarefree for all $a, b \\in A$. The key construction uses residue classes modulo 25: for $a \\equiv b \\equiv 7 \\pmod{25}$, $ab + 1 \\equiv 50 \\equiv 0 \\pmod{25}$, so $5^2 \\mid ab+1$; similarly for $a \\equiv b \\equiv 18 \\pmod{25}$ (since $18^2+1 = 325 = 13 \\cdot 25$). This gives lower bound $\\lfloor N/25 \\rfloor$. **Van Doorn** improved the upper bound to $\\approx 0.108N$ using quadratic residue arguments ($a^2 + 1 \\equiv 0 \\pmod{p^2}$ for primes $p \\equiv 1 \\pmod{4}$). **Weisenberg** refined this further. Finally, **Sawhney** proved the exact answer is $N/25$ for sufficiently large $N$, with the extremal sets being precisely the two mod-25 residue classes.",
-    "problemStatement": "Determine the maximum size of A ⊆ {1,...,N} such that ab + 1 is never squarefree for all a, b ∈ A.",
-    "proofStrategy": "We define IsSquarefree constructively, axiomatize maxNonSqfreeSet, and record the mod 25 lower bound, van Doorn's upper bound, and Sawhney's exact solution with structural characterization.",
-    "keyInsights": [
-      "For a ≡ b ≡ 7 (mod 25), ab + 1 ≡ 50 (mod 25), so 5² | ab + 1",
-      "The same holds for a ≡ b ≡ 18 (mod 25) since 18·18 + 1 = 325 = 13·25",
-      "Van Doorn's bound uses quadratic residues: a² + 1 ≡ 0 (mod p²) for p ≡ 1 (mod 4)",
-      "Sawhney proved the extremal sets are exactly the mod 25 residue classes",
-      "The solution holds for sufficiently large N; the finite cases remain unresolved"
+  "conclusion": {
+    "summary": "Erdős Problem #848 is formalized in 71 lines with 7 axioms encoding the extremal function, bounds, and Sawhney's exact solution. The key definitions (IsSquarefree, HasNonSqfreeProductProp) are constructive; the results are axiomatized. The answer is N/25 for large N, achieved by the mod-25 residue classes {7} and {18}.",
+    "implications": "The result reveals a surprising connection between squarefree numbers and modular arithmetic: the extremal configuration is determined entirely by the quadratic residue structure of Z/25Z. The rigidity of the extremal sets (uniqueness up to the 7 ↔ 18 symmetry) suggests deep structural constraints beyond simple density arguments.",
+    "openQuestions": [
+      "What is the exact value of maxNonSqfreeSet(N) for small N? Sawhney's result only applies for sufficiently large N",
+      "Can the 'sufficiently large N' threshold in Sawhney's result be made explicit?",
+      "What happens if we replace 'squarefree' with 'k-free' (no p^k divides ab+1)? The extremal sets would likely involve residue classes modulo p^k for the smallest relevant prime",
+      "Is there a polynomial-time algorithm to find the maximum set for a given N?"
     ]
   },
-  "conclusion": {
-    "summary": "Erdős Problem #848 is solved for large N by Sawhney: the maximum is N/25, achieved by {n ≡ 7 (mod 25)} or {n ≡ 18 (mod 25)}. The key insight is that these residue classes force 5² to divide ab + 1.",
-    "implications": "The result connects extremal set theory with quadratic residue structure and squarefree numbers, illustrating how modular arithmetic governs extremal configurations.",
-    "openQuestions": [
-      "What is the exact value of maxNonSqfreeSet(N) for small N?",
-      "Can the 'sufficiently large N' threshold be made explicit?"
-    ]
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Data.Nat.Prime.Basic"
+    ],
+    "opens": [],
+    "namespace": "Erdos848",
+    "lineCount": 71,
+    "axiomCount": 7,
+    "theoremCount": 0,
+    "definitionCount": 2
   }
 }

--- a/src/data/proofs/stirling-formula/meta.json
+++ b/src/data/proofs/stirling-formula/meta.json
@@ -43,8 +43,48 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 1,
-    "lineCount": 497
+    "lineCount": 497,
+    "prerequisites": [
+      "Real analysis: limits, asymptotic equivalence (~), sequences",
+      "Factorials and the Gamma function: n! = Γ(n+1)",
+      "The Wallis product: π/2 = ∏(4n²)/(4n²-1)",
+      "Logarithmic approximation: log(n!) ≈ n log n - n + (1/2)log(2πn)"
+    ],
+    "relatedProofs": [
+      "e-transcendental",
+      "pi-transcendental",
+      "binomial-theorem",
+      "central-limit-theorem",
+      "euler-identity"
+    ]
   },
+  "crossReferences": [
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "Euler's number e appears fundamentally in Stirling's formula as (n/e)^n — the transcendence of e (Hermite 1873) ensures this factor cannot be simplified algebraically"
+    },
+    {
+      "targetId": "pi-transcendental",
+      "relationship": "related",
+      "description": "The factor √(2π) in Stirling's formula connects to the Wallis product and the Gaussian integral ∫e^{-x²}dx = √π. The transcendence of π (Lindemann 1882) means Stirling's constant is transcendental"
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "complementary",
+      "description": "Stirling's formula gives the asymptotic form of binomial coefficients: C(n,k) ≈ (n/k)^k · (n/(n-k))^{n-k} · √(n/(2πk(n-k))), essential for the central limit theorem and information theory"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "De Moivre originally discovered Stirling's formula while proving the CLT for the binomial distribution. Stirling's approximation for C(n,k) gives the Gaussian density as the limit of the binomial"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's formula e^{iπ} + 1 = 0 connects the same constants (e, π) that appear in Stirling's formula. Both reveal deep relationships between exponential growth and circular geometry"
+    }
+  ],
   "overview": {
     "historicalContext": "Abraham de Moivre discovered the leading form $(n/e)^n \\sqrt{n}$ around 1721 while studying the normal distribution as an approximation to the binomial. James Stirling refined this in his 1730 book *Methodus Differentialis*, identifying the constant $\\sqrt{2\\pi}$ and the full asymptotic series $n! \\sim \\sqrt{2\\pi n}(n/e)^n(1 + \\frac{1}{12n} + \\frac{1}{288n^2} - \\cdots)$.\n\nThe formula is intimately connected to the Wallis product ($\\pi/2 = \\prod_{n=1}^\\infty \\frac{4n^2}{4n^2-1}$, John Wallis 1656), which provides the $\\pi$ factor through factorial ratios. Euler later extended Stirling's formula to the Gamma function: $\\Gamma(x+1) \\sim \\sqrt{2\\pi x}(x/e)^x$ for large real $x$, revealing it as a fundamental statement about the growth of the Gamma function along the real axis.",
     "problemStatement": "**Theorem (Stirling, 1730)**: As n approaches infinity:\n\n$$n! \\sim \\sqrt{2\\pi n} \\cdot \\left(\\frac{n}{e}\\right)^n$$\n\nMore precisely, the ratio n!/[sqrt(2*pi*n) * (n/e)^n] approaches 1.\n\nThis is Wiedijk's 100 Theorems #90.",
@@ -63,35 +103,40 @@
       "title": "The Stirling Sequence",
       "startLine": 51,
       "endLine": 71,
-      "summary": "Definition of stirlingSeq(n) = n!/[sqrt(2n) * (n/e)^n]."
+      "summary": "Definition of stirlingSeq(n) = n!/[sqrt(2n) * (n/e)^n].",
+      "mathContext": "$S_n = \\frac{n!}{\\sqrt{2n} \\cdot (n/e)^n}$. The Stirling sequence normalizes $n!$ by the leading approximation, and $S_n \\to \\sqrt{\\pi}$ yields the formula."
     },
     {
       "id": "convergence",
       "title": "Convergence to sqrt(pi)",
       "startLine": 73,
       "endLine": 97,
-      "summary": "The Stirling sequence converges to sqrt(pi)."
+      "summary": "The Stirling sequence converges to sqrt(pi).",
+      "mathContext": "$\\lim_{n\\to\\infty} S_n = \\sqrt{\\pi}$, proved via the Wallis product $\\pi/2 = \\prod_{n=1}^\\infty \\frac{4n^2}{4n^2-1}$."
     },
     {
       "id": "asymptotic",
       "title": "Asymptotic Equivalence",
       "startLine": 99,
       "endLine": 121,
-      "summary": "Stirling's formula as asymptotic equivalence."
+      "summary": "Stirling's formula as asymptotic equivalence.",
+      "mathContext": "$n! \\sim \\sqrt{2\\pi n} \\cdot (n/e)^n$, i.e., $\\lim_{n\\to\\infty} \\frac{n!}{\\sqrt{2\\pi n}(n/e)^n} = 1$."
     },
     {
       "id": "bounds",
       "title": "Bounds",
       "startLine": 123,
       "endLine": 149,
-      "summary": "Upper and lower bounds from Stirling's formula."
+      "summary": "Upper and lower bounds from Stirling's formula.",
+      "mathContext": "$\\sqrt{2\\pi n}(n/e)^n \\leq n! \\leq \\sqrt{2\\pi n}(n/e)^n \\cdot e^{1/(12n)}$ for $n \\geq 1$."
     },
     {
       "id": "applications",
       "title": "Applications",
       "startLine": 209,
       "endLine": 271,
-      "summary": "Log-factorial approximation and connections to entropy."
+      "summary": "Log-factorial approximation and connections to entropy.",
+      "mathContext": "$\\log(n!) \\approx n\\log n - n + \\frac{1}{2}\\log(2\\pi n)$. Entropy: $H = \\log\\binom{n}{k} \\approx nH(k/n)$ where $H(p) = -p\\log p - (1-p)\\log(1-p)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

### Critical Axiom Integrity Fixes (20 entries)
Twenty entries claimed status: "verified" with axiomCount: 0, but their Lean files contain axiom declarations. All corrected to status: "axiomatized", badge: "axiom" with accurate axiomCount.

| Entry | Actual Axioms | Entry | Actual Axioms |
|-------|--------------|-------|--------------|
| erdos-1053 | 12 | erdos-374 | 7 |
| erdos-557 | 10 | erdos-330 | 7 |
| erdos-513 | 8 | erdos-128 | 6 |
| erdos-28 | 8 | erdos-567 | 6 |
| erdos-848 | 7 | erdos-726 | 6 |
| erdos-112 | 7 | erdos-349 | 5 |
| erdos-562 | 7 | erdos-654 | 5 |
| erdos-321 | 4 | erdos-566 | 4 |
| erdos-574 | 4 | erdos-837 | 4 |
| erdos-1135 | 3 | erdos-568 | 3 |
| erdos-469 | 2 | | |

### Comprehensive Enrichment (erdos-374, erdos-513)
- Added crossReferences, relatedProofs, structured references
- Added mathContext with LaTeX to all sections
- Deepened historicalContext, proofStrategy, keyInsights
- Added prerequisites, originalContributions, dateAdded
- Fixed lineCount to match actual file lengths

## Verification
- All JSON validated
- Axiom counts verified against actual Lean files via `grep -c "^axiom "`

🤖 Generated with [Claude Code](https://claude.com/claude-code)