### PR TITLE
Enrich 4 entries: erdos-848, angle-trisection, abel-ruffini-oq-04, area-of-circle

### DIFF
--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -155,6 +155,11 @@
       "targetId": "e-transcendental",
       "relationship": "related",
       "description": "The transcendence of e connects to the area formula via the Gaussian integral: ∫∫ e^{-(x²+y²)} dA = π, where converting to polar coordinates uses the area element from A = πr²"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Euler's Basel problem (∑1/n² = π²/6) provides another unexpected appearance of π — the same constant whose geometric meaning as the area-to-radius² ratio is formalized here. Euler's proof connecting ∑1/n² to sin(x)/x reveals π's dual role in geometry and analysis"
     }
   ],
   "relatedProofs": [
@@ -164,7 +169,8 @@
     "fundamental-theorem-calculus",
     "pythagorean-theorem",
     "hermite-lindemann",
-    "e-transcendental"
+    "e-transcendental",
+    "basel-problem"
   ],
   "leanFile": {
     "imports": [
@@ -203,24 +209,5 @@
       "venue": "Cambridge University Press",
       "note": "Definitive English translation of Archimedes' works including 'Measurement of a Circle' — the primary source for his proof that the area of a circle equals that of a right triangle with legs equal to the circumference and radius"
     }
-  ],
-  "relatedProofs": [
-    "angle-trisection",
-    "buffons-needle"
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls",
-      "Mathlib.Tactic"
-    ],
-    "opens": [
-      "MeasureTheory",
-      "Metric"
-    ],
-    "namespace": "AreaOfCircle",
-    "lineCount": 155,
-    "axiomCount": 0,
-    "theoremCount": 7,
-    "definitionCount": 0
-  }
+  ]
 }


### PR DESCRIPTION
## Summary

### area-of-circle
- **Fixed duplicate keys bug**: `relatedProofs` and `leanFile` appeared twice, second copy was overwriting first (losing 5/7 related proof links)
- Added cross-reference to `basel-problem`

### Erdős #848
- Added `prerequisites` arrays to all annotations
- Added new annotations: imports section, trivial upper bound
- Added `date: "1992"`, Van Doorn reference

### angle-trisection
- Added annotations for Part VII intro and circle squaring intro
- Added cross-reference to `fermats-last-theorem`
- Added Dudley (1987) reference

### abel-ruffini-oq-04
- Added keyInsight on Jordan-Hölder theorem
- Added cross-references to FLT and quadratic-reciprocity
- Added Edwards (1984) and Jordan (1870) references

## Test plan
- [x] All JSON files validate
- [x] All cross-reference targets exist
- [x] Duplicate key bug fixed and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)