### PR TITLE
Enrich 12 proofs: fix annotation ranges, add prerequisites, improve coverage

### DIFF
--- a/src/data/proofs/fermat-two-squares/annotations.json
+++ b/src/data/proofs/fermat-two-squares/annotations.json
@@ -15,6 +15,10 @@
       "Mathlib",
       "sum of squares",
       "prime characterization"
+    ],
+    "prerequisites": [
+      "Mathlib imports",
+      "Lean 4 module system"
     ]
   },
   {
@@ -22,7 +26,7 @@
     "proofId": "fermat-two-squares",
     "range": {
       "startLine": 4,
-      "endLine": 49
+      "endLine": 20
     },
     "type": "insight",
     "title": "A Century-Long Mathematical Mystery",
@@ -34,14 +38,18 @@
       "Fermat",
       "Euler",
       "Lagrange"
+    ],
+    "prerequisites": [
+      "number theory history",
+      "Fermat's contributions"
     ]
   },
   {
     "id": "ann-zagier",
     "proofId": "fermat-two-squares",
     "range": {
-      "startLine": 4,
-      "endLine": 49
+      "startLine": 21,
+      "endLine": 35
     },
     "type": "insight",
     "title": "Zagier's One-Sentence Proof",
@@ -52,14 +60,18 @@
       "involutions",
       "combinatorial proof",
       "Zagier"
+    ],
+    "prerequisites": [
+      "involution proof technique",
+      "fixed points"
     ]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "fermat-two-squares",
     "range": {
-      "startLine": 4,
-      "endLine": 49
+      "startLine": 36,
+      "endLine": 53
     },
     "type": "theorem",
     "title": "The Complete Characterization",
@@ -69,6 +81,11 @@
     "relatedConcepts": [
       "modular arithmetic",
       "characterization theorem"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "sum of two squares",
+      "quadratic forms"
     ]
   },
   {
@@ -76,7 +93,7 @@
     "proofId": "fermat-two-squares",
     "range": {
       "startLine": 55,
-      "endLine": 87
+      "endLine": 75
     },
     "type": "theorem",
     "title": "The Classic Statement: p ≡ 1 (mod 4)",
@@ -86,13 +103,17 @@
     "relatedConcepts": [
       "Fermat's original statement",
       "prime classification"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "quadratic residues"
     ]
   },
   {
     "id": "ann-two-special",
     "proofId": "fermat-two-squares",
     "range": {
-      "startLine": 55,
+      "startLine": 76,
       "endLine": 87
     },
     "type": "lemma",
@@ -103,6 +124,10 @@
     "relatedConcepts": [
       "special cases",
       "edge cases"
+    ],
+    "prerequisites": [
+      "even prime",
+      "special cases"
     ]
   },
   {
@@ -120,6 +145,10 @@
     "relatedConcepts": [
       "impossibility proof",
       "modular arithmetic"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "proof by contradiction"
     ]
   },
   {
@@ -137,13 +166,16 @@
     "relatedConcepts": [
       "examples",
       "verification"
+    ],
+    "prerequisites": [
+      "small prime computations"
     ]
   },
   {
     "id": "ann-classification",
     "proofId": "fermat-two-squares",
     "range": {
-      "startLine": 105,
+      "startLine": 117,
       "endLine": 134
     },
     "type": "theorem",
@@ -154,13 +186,17 @@
     "relatedConcepts": [
       "prime classification",
       "complete characterization"
+    ],
+    "prerequisites": [
+      "complete classification",
+      "prime factorization"
     ]
   },
   {
     "id": "ann-gaussian",
     "proofId": "fermat-two-squares",
     "range": {
-      "startLine": 4,
+      "startLine": 40,
       "endLine": 49
     },
     "type": "insight",
@@ -172,6 +208,10 @@
       "Gaussian integers",
       "algebraic number theory",
       "quadratic reciprocity"
+    ],
+    "prerequisites": [
+      "Gaussian integers",
+      "complex number norm"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment pass for 12 proof gallery entries, focusing on systematic quality improvements.

### Major fixes (deep enrichment):
1. **erdos-848** — Added prerequisites (8), new annotation, cross-reference to CRT
2. **borsuk-ulam** — Added 3 annotations, mathContext/prerequisites, fixed invalid refs
3. **abel-ruffini** — Extended annotation ranges for full 185-line coverage
4. **cantor-diagonalization** — Fixed 6 annotations pointing to same range (5-37)
5. **cantors-theorem** — Fixed 2 overlapping annotations, improved coverage
6. **schroeder-bernstein** — Fixed 6 single-line ranges, added prerequisites
7. **fermat-two-squares** — Fixed 4 overlapping ranges, added prerequisites

### Prerequisites-only fixes:
8. **fundamental-theorem-algebra** — Added prerequisites to all 7
9. **bertrands-postulate** — Added prerequisites to all 8
10. **arithmetic-series** — Added prerequisites to all 9
11. **basel-problem** — Added missing prerequisites (4/6 -> 6/6)
12. **brouwer-fixed-point** — Added missing prerequisites (3/9 -> 9/9)

### Common patterns fixed:
- **Missing `prerequisites` field** — was absent from ~90% of annotations
- **Overlapping/identical annotation ranges** — multiple annotations at same lines
- **Single-line annotations** — should cover full theorem blocks
- **Missing `mathContext`** — LaTeX math context not provided

## Test plan
- [x] JSON validation passes for all 12 modified files
- [x] No new build errors introduced