### PR TITLE
Enrich borsuk-ulam: add mathContext to annotations

### DIFF
--- a/src/data/proofs/borsuk-ulam/annotations.json
+++ b/src/data/proofs/borsuk-ulam/annotations.json
@@ -9,6 +9,7 @@
     "type": "concept",
     "title": "The Theorem That Connects Temperature to Topology",
     "content": "The Borsuk-Ulam Theorem states: for any continuous function f: S^n -> R^n, there exist antipodal points x and -x with f(x) = f(-x).\n\nThe intuition is captivating: at any moment, there are two points on opposite sides of Earth with exactly the same temperature AND pressure. You can continuously measure any n quantities on an n-sphere, and somewhere, antipodal points match.\n\nThis 1933 result by Karol Borsuk (answering Stanislaw Ulam's question) became a cornerstone of algebraic topology with surprising applications from graph theory to fair division.\n\nThis formalization presents the conceptual structure. The full proof requires covering space theory, which we axiomatize to focus on the logical flow.",
+    "mathContext": "$\\forall f: S^n \\to \\mathbb{R}^n$ continuous, $\\exists x \\in S^n: f(x) = f(-x)$. Equivalently, there is no continuous odd map $S^n \\to S^{n-1}$. Here $S^n = \\{x \\in \\mathbb{R}^{n+1} : \\|x\\| = 1\\}$, defined via `Metric.sphere 0 1` in `EuclideanSpace \\mathbb{R} (\\mathrm{Fin}(n+1))$.",
     "significance": "critical",
     "relatedConcepts": [
       "antipodal points",
@@ -26,6 +27,7 @@
     "type": "definition",
     "title": "The Antipodal Map: Flipping the Sphere",
     "content": "The **antipodal map** A: S^n -> S^n sends each point to its diametrically opposite point: A(x) = -x.\n\nKey properties:\n- **Involution**: A(A(x)) = x (applying twice returns to original)\n- **No fixed points**: A(x) != x for all x (you can't be your own opposite)\n- **Isometry**: Preserves distances on the sphere\n- **Free Z_2 action**: The two-element group {1, A} acts freely on S^n\n\nThe quotient space S^n / Z_2 (identifying x with -x) is **real projective space** RP^n. This quotient is central to the proof:\n- RP^n has fundamental group Z_2\n- The quotient map p: S^n -> RP^n is a 2-sheeted covering\n- This covering space structure is what makes the theorem work",
+    "mathContext": "The antipodal map $A: S^n \\to S^n$ is $A(x) = -x$. Since $\\|-x\\| = \\|x\\| = 1$, $A$ preserves the sphere. $A^2 = \\mathrm{id}$ (involution) with no fixed points. The quotient $S^n / \\langle A \\rangle = \\mathbb{R}P^n$ is real projective space with $\\pi_1(\\mathbb{R}P^n) \\cong \\mathbb{Z}/2\\mathbb{Z}$.",
     "significance": "key",
     "relatedConcepts": [
       "involution",
@@ -64,6 +66,7 @@
     "type": "concept",
     "title": "Covering Spaces: The Topological Machinery",
     "content": "**Covering space theory** is the algebraic topology machinery that powers the proof.\n\n**Key ideas**:\n1. **Real Projective Space**: RP^n = S^n / Z_2 (identify antipodal points)\n2. **Covering Map**: p: S^n -> RP^n is a 2-sheeted covering\n3. **Fundamental Group**: pi_1(RP^n) = Z_2 for n >= 1\n\n**Why this matters**:\n- An odd map h: S^n -> S^(n-1) respects the antipodal action\n- So h induces a map h_bar: RP^n -> RP^(n-1)\n- On fundamental groups: h_bar*: Z_2 -> Z_2\n- The covering structure forces h_bar* to be injective\n- But S^n is simply connected (n >= 2), so h_bar* must be trivial\n- Injective AND trivial? Only if Z_2 = 0. Contradiction!\n\nFor n=1, a direct argument using the intermediate value theorem works.",
+    "mathContext": "The 2-sheeted covering $p: S^n \\to \\mathbb{R}P^n$ has $\\pi_1(\\mathbb{R}P^n) \\cong \\mathbb{Z}/2$. An odd map $h: S^n \\to S^{n-1}$ descends to $\\bar{h}: \\mathbb{R}P^n \\to \\mathbb{R}P^{n-1}$. The induced map $\\bar{h}_*: \\mathbb{Z}/2 \\to \\mathbb{Z}/2$ is forced to be both injective (by covering theory) and trivial (since $S^n$ is simply connected for $n \\geq 2$), a contradiction.",
     "significance": "critical",
     "prerequisites": [
       "ann-sphere",


### PR DESCRIPTION
## Summary
- Added `mathContext` field to 3 annotations that were missing it (ann-intro, ann-antipode-map, ann-covering-space)
- Quality score: 96 → 100

## Enrichment details
- **ann-intro**: Added formal statement $\forall f: S^n \to \mathbb{R}^n$ continuous, $\exists x: f(x) = f(-x)$ and the `Metric.sphere` definition
- **ann-antipode-map**: Added $A(x) = -x$ as involution, real projective space quotient, $\pi_1(\mathbb{R}P^n) \cong \mathbb{Z}/2$
- **ann-covering-space**: Added the covering theory contradiction: $\bar{h}_*$ forced to be both injective and trivial

🤖 Generated with [Claude Code](https://claude.com/claude-code)