### PR TITLE
Enrich fundamental-theorem-algebra: fix duplicate references

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -248,21 +248,5 @@
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Gauss, Carl Friedrich",
-      "title": "Demonstratio nova theorematis omnem functionem algebraicam rationalem integram unius variabilis in factores reales primi vel secundi gradus resolvi posse",
-      "year": "1799",
-      "venue": "Helmstedt (doctoral dissertation)",
-      "note": "First rigorous proof (with a topological gap later filled) that every polynomial has a complex root"
-    },
-    {
-      "authors": "Fine, Benjamin; Rosenberger, Gerhard",
-      "title": "The Fundamental Theorem of Algebra",
-      "year": "1997",
-      "venue": "Springer Undergraduate Texts in Mathematics",
-      "note": "Collects and presents multiple proofs — algebraic, analytic, and topological"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- Fixed duplicate top-level `references` key that was causing the d'Alembert reference to be lost (JSON parsers take the last value of duplicate keys)
- Fixed trailing comma causing JSON parse error
- All 3 references now correctly preserved: Gauss (1799), Fine/Rosenberger (1997), d'Alembert (1746)

🤖 Generated with [Claude Code](https://claude.com/claude-code)