### PR TITLE
Enrich godel-incompleteness: add cross-references

### DIFF
--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -128,6 +128,46 @@
       "Could new axioms (like large cardinals) help us prove currently unprovable statements, and how do we know which axioms to trust?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "halting-problem",
+      "relationship": "related",
+      "description": "Turing's halting problem (1936) is the computability-theoretic analog: no algorithm can decide whether an arbitrary program halts. Both are proved by diagonalization — Gödel's self-referential sentence 'I am unprovable' parallels the program that asks 'do I halt?'"
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "foundational",
+      "description": "Cantor's diagonal argument (1891) is the prototype for Gödel's technique: both construct objects that differ from every member of a countable list. Gödel numbers encode formulas as integers, then the diagonal lemma produces a sentence about its own Gödel number"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Both are impossibility results about formal methods: Abel-Ruffini shows no radical formula solves all quintics, Gödel shows no formal system proves all arithmetic truths. Each reveals fundamental limits of a class of mathematical tools"
+    },
+    {
+      "targetId": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "CH is independent of ZFC (Gödel 1940, Cohen 1963) — an example of a natural mathematical statement unprovable in standard axioms, illustrating incompleteness in practice rather than via self-reference"
+    },
+    {
+      "targetId": "hilbert-10",
+      "relationship": "extends",
+      "description": "Matiyasevich's theorem (1970) shows no algorithm decides Diophantine solvability. This extends Gödel's impossibility from provability to decidability: the set of true Diophantine statements is not recursively enumerable"
+    },
+    {
+      "targetId": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "Induction over natural numbers is the core reasoning principle that Gödel's system must be able to express. The incompleteness theorem applies to any consistent system containing enough arithmetic to formalize induction"
+    }
+  ],
+  "relatedProofs": [
+    "halting-problem",
+    "cantor-diagonalization",
+    "abel-ruffini",
+    "continuum-hypothesis",
+    "hilbert-10",
+    "mathematical-induction"
+  ],
   "references": [
     {
       "authors": "Gödel, Kurt",


### PR DESCRIPTION
## Summary
- Added `crossReferences` array with 6 mathematically and thematically connected gallery entries
- Added `relatedProofs` array

## Cross-references added
- **halting-problem**: Computability-theoretic analog via diagonalization
- **cantor-diagonalization**: Foundational technique prototype for Gödel numbering
- **abel-ruffini**: Thematic parallel as impossibility result about formal methods
- **continuum-hypothesis**: CH independence as a "real-world" incompleteness example
- **hilbert-10**: Extension from provability limits to decidability limits
- **mathematical-induction**: Core reasoning principle that Gödel's system must express

🤖 Generated with [Claude Code](https://claude.com/claude-code)