### PR TITLE
Enrich four-color-theorem: add cross-references

### DIFF
--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -126,9 +126,39 @@
       "mathContext": "The paradigm: from \"trust the computation\" (Appel-Haken) to \"trust the proof checker\" (Gonthier). Coq's kernel is small enough for human audit."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "foundational",
+      "description": "Euler's formula $V - E + F = 2$ for connected planar graphs is the starting point for the discharging method: assigning charge $6 - \\deg(v)$ to each vertex gives total charge $6V - 2E = 6(E - F + 2) - 2E = 12$ (using $2E \\geq 3F$). This positive total forces low-degree vertices to exist."
+    },
+    {
+      "targetId": "konigsberg",
+      "relationship": "foundational",
+      "description": "Euler's Königsberg bridge problem (1736) founded graph theory — the mathematical framework in which the Four Color Theorem is stated. Both concern properties of planar graphs: Euler paths in Königsberg, vertex coloring here."
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Both are results about graph coloring: Ramsey theory guarantees monochromatic substructures in edge-colored complete graphs, while 4CT guarantees proper vertex colorings of planar graphs. The chromatic number of planar graphs (4) connects to Ramsey-type bounds."
+    },
+    {
+      "targetId": "erdos-szekeres",
+      "relationship": "related",
+      "description": "The Erdős-Szekeres theorem on monotone subsequences is another combinatorial result where the proof structure — showing a finite set of configurations is unavoidable — parallels the Four Color Theorem's unavoidable set approach."
+    },
+    {
+      "targetId": "erdos-807",
+      "relationship": "related",
+      "description": "Erdős Problem #807 concerns graph coloring bounds, directly connecting to the chromatic theory that the Four Color Theorem resolves for planar graphs."
+    }
+  ],
   "relatedProofs": [
     "ramseys-theorem",
-    "erdos-807"
+    "erdos-807",
+    "euler-polyhedral-formula",
+    "konigsberg",
+    "erdos-szekeres"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary
- Added `crossReferences` array with 5 gallery connections
- Expanded `relatedProofs` from 2 to 5 entries

## Cross-references added
- **euler-polyhedral-formula**: Foundation for the discharging method (V-E+F=2 gives total charge 12)
- **konigsberg**: Euler's founding of graph theory, the framework for 4CT
- **ramseys-theorem**: Graph coloring connections (vertex vs edge coloring)
- **erdos-szekeres**: Parallel unavoidable-set proof technique
- **erdos-807**: Direct graph coloring bound connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)