### PR TITLE
Enrich quadratic-reciprocity: add cross-references

### DIFF
--- a/src/data/proofs/quadratic-reciprocity/meta.json
+++ b/src/data/proofs/quadratic-reciprocity/meta.json
@@ -112,6 +112,40 @@
       "Can reciprocity laws be used for faster primality tests?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "elementary-quadratic-reciprocity",
+      "relationship": "related",
+      "description": "An alternative formalization of quadratic reciprocity using elementary methods. Both establish the same law relating $(p/q)$ and $(q/p)$, but with different proof techniques and Mathlib dependencies."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's totient function $\\phi(n)$ counts units in $\\mathbb{Z}/n\\mathbb{Z}$. The Legendre symbol $(a/p) = a^{(p-1)/2} \\bmod p$ uses $\\phi(p) = p - 1$, and Euler's criterion connecting quadratic residues to this exponent is the starting point for reciprocity."
+    },
+    {
+      "targetId": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem $(p-1)! \\equiv -1 \\pmod{p}$ is closely related: both concern the multiplicative structure of $\\mathbb{Z}/p\\mathbb{Z}$. Gauss's first proof of quadratic reciprocity used Gauss sums, which generalize factorials in $\\mathbb{Z}/p\\mathbb{Z}$."
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "extends",
+      "description": "Quadratic reciprocity implies Dirichlet-style results on primes in arithmetic progressions: primes $p \\equiv 1 \\pmod{4}$ vs $p \\equiv 3 \\pmod{4}$ behave differently as quadratic residues, connecting to Dirichlet's theorem on primes in progressions."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both are landmarks of 19th-century algebra: Abel-Ruffini uses Galois groups to prove quintic unsolvability, while quadratic reciprocity reveals deep structure in $\\mathbb{Z}/p\\mathbb{Z}$. Artin reciprocity law unifies both into class field theory."
+    }
+  ],
+  "relatedProofs": [
+    "elementary-quadratic-reciprocity",
+    "euler-totient",
+    "wilsons-theorem",
+    "infinitude-primes",
+    "abel-ruffini"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",


### PR DESCRIPTION
## Summary
- Added `crossReferences` with 5 gallery connections
- Added `relatedProofs` array

## Cross-references
- **elementary-quadratic-reciprocity**: Alternative formalization with different proof technique
- **euler-totient**: Euler's criterion $(a/p) = a^{(p-1)/2}$ as foundation
- **wilsons-theorem**: Shared multiplicative structure of Z/pZ
- **infinitude-primes**: Dirichlet-style connections to primes in progressions
- **abel-ruffini**: Both are 19th-century algebra landmarks unified by Artin reciprocity

🤖 Generated with [Claude Code](https://claude.com/claude-code)