### PR TITLE
Enrich schroeder-bernstein: add cross-references

### DIFF
--- a/src/data/proofs/schroeder-bernstein/meta.json
+++ b/src/data/proofs/schroeder-bernstein/meta.json
@@ -141,6 +141,28 @@
       "note": "First published proof of the Cantor-Bernstein-Schröder theorem: if |A| ≤ |B| and |B| ≤ |A| then |A| = |B|"
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "complementary",
+      "description": "Cantor's diagonal argument shows $|\\mathbb{N}| < |\\mathbb{R}|$ (strict inequality exists). Schröder-Bernstein shows when injections in both directions exist, equality holds. Together they establish the theory of cardinal comparisons."
+    },
+    {
+      "targetId": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "Schröder-Bernstein establishes $|A| = |B|$ from mutual injections. The Continuum Hypothesis asks whether $|\\mathbb{N}| < |X| < |\\mathbb{R}|$ is possible — a question about strict cardinal inequality that Schröder-Bernstein cannot resolve."
+    },
+    {
+      "targetId": "denumerability-rationals",
+      "relationship": "related",
+      "description": "The denumerability of $\\mathbb{Q}$ can be proved via Schröder-Bernstein: $\\mathbb{N} \\hookrightarrow \\mathbb{Q}$ (obvious) and $\\mathbb{Q} \\hookrightarrow \\mathbb{N}$ (via Cantor pairing), so $|\\mathbb{Q}| = |\\mathbb{N}|$."
+    }
+  ],
+  "relatedProofs": [
+    "cantor-diagonalization",
+    "continuum-hypothesis",
+    "denumerability-rationals"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.SetTheory.Cardinal.SchroederBernstein",


### PR DESCRIPTION
## Summary
- Added `crossReferences` with 3 gallery connections
- Added `relatedProofs` array

## Cross-references
- **cantor-diagonalization**: Complementary — Cantor shows strict inequality, SB shows equality from mutual injections
- **continuum-hypothesis**: CH asks about strict inequality that SB cannot resolve
- **denumerability-rationals**: Q is countable via SB from mutual injections N↔Q

🤖 Generated with [Claude Code](https://claude.com/claude-code)