### PR TITLE
Enrich 3 Wiedijk entries: add cross-references

### DIFF
--- a/src/data/proofs/mathematical-induction/meta.json
+++ b/src/data/proofs/mathematical-induction/meta.json
@@ -148,5 +148,27 @@
       "venue": "Braunschweig: Vieweg",
       "note": "Independent axiomatization of the natural numbers with induction as a foundational principle"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "related",
+      "description": "Gödel's incompleteness applies to any system containing enough arithmetic to formalize induction. Induction is the core reasoning principle whose power and limitations incompleteness theorems explore."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related",
+      "description": "The standard proof of the binomial theorem by induction on n uses Pascal's identity at the inductive step. Induction is the natural proof method for identities indexed by natural numbers."
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "related",
+      "description": "Euclid's proof of infinite primes uses a form of induction (given any finite list, construct a new prime). Strong induction and well-ordering — equivalent to induction — appear throughout number theory."
+    }
+  ],
+  "relatedProofs": [
+    "godel-incompleteness",
+    "binomial-theorem",
+    "infinitude-primes"
   ]
 }

--- a/src/data/proofs/perfect-numbers/meta.json
+++ b/src/data/proofs/perfect-numbers/meta.json
@@ -156,5 +156,21 @@
       "venue": "Carnegie Institution of Washington",
       "note": "Extensive history of perfect numbers from antiquity through the early 20th century"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Both concern the divisor structure of integers: perfect numbers satisfy σ(n) = 2n, while Euler's totient counts coprime residues. The sigma function σ and Euler's φ are both multiplicative arithmetic functions."
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "Even perfect numbers are 2^(p-1)(2^p - 1) where 2^p - 1 is a Mersenne prime. The infinitude of primes is foundational, and whether infinitely many Mersenne primes exist (hence infinitely many even perfect numbers) remains open."
+    }
+  ],
+  "relatedProofs": [
+    "euler-totient",
+    "infinitude-primes"
   ]
 }

--- a/src/data/proofs/triangle-angle-sum/meta.json
+++ b/src/data/proofs/triangle-angle-sum/meta.json
@@ -154,5 +154,27 @@
       "venue": "Alexandria",
       "note": "Proof that the angles of a triangle sum to two right angles (180°) — one of the most fundamental results in Euclidean geometry"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "Both are fundamental Euclidean geometry results. The Pythagorean theorem relates side lengths; the angle sum property relates angles. Together they characterize planar triangles."
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "The angle sum of π radians connects to circular geometry: the area formula A = πr² arises from the same relationship between angles and arc length that underlies the triangle angle sum."
+    },
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "extends",
+      "description": "Euler's formula V - E + F = 2 generalizes angle-sum properties to polyhedra: the angle defect at each vertex of a convex polyhedron sums to 4π (Descartes's theorem), a polyhedral analog of the triangle angle sum."
+    }
+  ],
+  "relatedProofs": [
+    "pythagorean-theorem",
+    "area-of-circle",
+    "euler-polyhedral-formula"
   ]
 }


### PR DESCRIPTION
## Summary
Added `crossReferences` and `relatedProofs` to 3 Wiedijk entries that had none.

## Entries enriched

### triangle-angle-sum (Wiedijk #27)
- pythagorean-theorem, area-of-circle, euler-polyhedral-formula

### perfect-numbers (Wiedijk #70)
- euler-totient, infinitude-primes (Mersenne prime connection)

### mathematical-induction (Wiedijk #74)
- godel-incompleteness, binomial-theorem, infinitude-primes

🤖 Generated with [Claude Code](https://claude.com/claude-code)