### PR TITLE
Enrich 5 entries: abel-ruffini, angle-trisection, area-of-circle, arithmetic-series, basel-problem

### DIFF
--- a/src/data/proofs/basel-problem/annotations.json
+++ b/src/data/proofs/basel-problem/annotations.json
@@ -24,6 +24,30 @@
     ]
   },
   {
+    "id": "ann-module-docstring",
+    "proofId": "basel-problem",
+    "range": {
+      "startLine": 6,
+      "endLine": 52
+    },
+    "type": "context",
+    "title": "Module Overview: The Basel Problem",
+    "content": "The module docstring introduces the Basel Problem — one of the most famous results in analysis. Named after the Bernoulli family's home city of Basel, Switzerland, the problem was posed by Pietro Mengoli in 1650: find the exact sum of $\\sum 1/n^2$. Jakob Bernoulli (1689) had bounded the sum between 1 and 2, noting it converges more slowly than the geometric series, but could not find the exact value.\n\nEuler solved it in 1734 at age 27, and this breakthrough launched his career. The approach documented here uses Mathlib's `hasSum_zeta_two`, which proves the result via Bernoulli polynomial theory and Fourier analysis — a modern rigorous approach that avoids the subtlety of Euler's original $\\sin(x)/x$ factorization (which required the Weierstrass factorization theorem, not available until 1876).",
+    "mathContext": "The Basel Problem: $\\zeta(2) = \\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6} \\approx 1.6449$. The appearance of $\\pi$ in a sum over integers was shocking to Euler's contemporaries — it revealed a deep connection between number theory and analysis that would later be formalized through the Riemann zeta function $\\zeta(s) = \\sum n^{-s}$.",
+    "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "infinite series",
+      "convergence tests"
+    ],
+    "relatedConcepts": [
+      "Riemann zeta function",
+      "Bernoulli numbers",
+      "Fourier analysis",
+      "Weierstrass factorization"
+    ]
+  },
+  {
     "id": "ann-basel-main",
     "proofId": "basel-problem",
     "range": {
@@ -58,6 +82,10 @@
     "content": "The `tsum` (topological sum) version: `∑' n, 1/n² = π²/6`. This is the form using Lean's notation for infinite sums.",
     "mathContext": "`tsum` is defined as the limit of partial sums when the series is summable, and 0 otherwise. For summable series, `HasSum.tsum_eq` converts between the two forms.",
     "significance": "supporting",
+    "prerequisites": [
+      "HasSum.tsum_eq",
+      "ann-basel-main"
+    ],
     "relatedConcepts": [
       "tsum",
       "notation",
@@ -88,6 +116,53 @@
     ]
   },
   {
+    "id": "ann-summable-proofs",
+    "proofId": "basel-problem",
+    "range": {
+      "startLine": 80,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Convergence Proofs: p-Series with p = 2",
+    "content": "`summable_one_div_sq` and `summable_nat_sq_inv` prove that $\\sum 1/n^2$ is summable (convergent) using two equivalent formulations. The proofs convert to `Real.summable_nat_rpow_inv` with $p = 2 > 1$, using `rpow_natCast` to bridge between the natural number exponent $n^2$ and the real-valued power $n^{2.0}$.\n\nThe p-series test ($\\sum n^{-p}$ converges $\\iff p > 1$) is the standard convergence criterion. The boundary case $p = 1$ (harmonic series $\\sum 1/n$) diverges — proved by the integral test or Cauchy condensation.",
+    "mathContext": "The p-series test: $\\sum_{n=1}^{\\infty} n^{-p} < \\infty \\iff p > 1$. For $p = 2$: convergence follows from comparison with the telescoping series $\\sum (1/n - 1/(n+1)) = 1$, since $1/n^2 < 1/(n(n-1))$ for $n \\geq 2$. The proof converts between `1/n^2` (natural number power) and `n^{(-2:ℝ)}` (real-valued power) via `rpow_natCast` and `div_eq_mul_inv`.",
+    "significance": "key",
+    "prerequisites": [
+      "Real.summable_nat_rpow_inv",
+      "rpow coercion",
+      "norm_num"
+    ],
+    "relatedConcepts": [
+      "p-series test",
+      "Summable",
+      "integral test",
+      "rpow_natCast"
+    ]
+  },
+  {
+    "id": "ann-basic-properties",
+    "proofId": "basel-problem",
+    "range": {
+      "startLine": 93,
+      "endLine": 101
+    },
+    "type": "theorem",
+    "title": "Positivity and Basic Properties",
+    "content": "Three positivity lemmas: `one_div_sq_pos` ($1/n^2 > 0$ for $n > 0$), `one_div_sq_nonneg` ($1/n^2 \\geq 0$ for all $n$), and `basel_value_pos` ($\\pi^2/6 > 0$). All proved by Lean's `positivity` tactic, which chains positivity/nonnegativity facts automatically.\n\nThese lemmas are supporting infrastructure: positivity of terms ensures the partial sums are increasing (important for monotone convergence), and positivity of the limit confirms the sum is meaningful.",
+    "mathContext": "For $n \\geq 1$: $1/n^2 > 0$ since $n^2 > 0$. For $n = 0$: $1/0^2 = 0 \\geq 0$ (Lean's convention). The value $\\pi^2/6 > 0$ since $\\pi > 0$ implies $\\pi^2 > 0$. The `positivity` tactic automatically chains `sq_nonneg`, `div_pos`, and `pi_pos` to close these goals.",
+    "significance": "supporting",
+    "prerequisites": [
+      "positivity tactic",
+      "sq_nonneg",
+      "pi_pos"
+    ],
+    "relatedConcepts": [
+      "positivity tactic",
+      "monotone convergence",
+      "nonnegative terms"
+    ]
+  },
+  {
     "id": "ann-euler-history",
     "proofId": "basel-problem",
     "range": {
@@ -99,6 +174,10 @@
     "content": "Euler's 1734 proof used the Weierstrass factorization of $\\sin(x)/x$. By comparing the $x^2$ coefficient in the infinite product with the Taylor series, he derived the Basel identity.",
     "mathContext": "Euler wrote $\\sin(x)/x = \\prod_{n=1}^{\\infty}(1 - x^2/(n\\pi)^2)$. Expanding and comparing with $1 - x^2/6 + \\ldots$ gives $1/6 = \\sum 1/(n\\pi)^2$, hence $\\sum 1/n^2 = \\pi^2/6$.",
     "significance": "key",
+    "prerequisites": [
+      "Weierstrass factorization theorem",
+      "Taylor series of sin(x)"
+    ],
     "relatedConcepts": [
       "Weierstrass factorization",
       "Taylor series",
@@ -126,6 +205,52 @@
       "Bernoulli numbers",
       "zeta values",
       "special functions"
+    ]
+  },
+  {
+    "id": "ann-zeta-general",
+    "proofId": "basel-problem",
+    "range": {
+      "startLine": 134,
+      "endLine": 143
+    },
+    "type": "theorem",
+    "title": "The General Zeta Value Formula",
+    "content": "`zeta_general` proves the general formula for even zeta values: $\\zeta(2k) = (-1)^{k+1} \\cdot 2^{2k-1} \\cdot \\pi^{2k} \\cdot B_{2k} / (2k)!$, where $B_{2k}$ is the $(2k)$-th Bernoulli number. This is Euler's generalization of the Basel Problem to all even positive integers.\n\nThe first few values: $B_2 = 1/6$ gives $\\zeta(2) = \\pi^2/6$, $B_4 = -1/30$ gives $\\zeta(4) = \\pi^4/90$, $B_6 = 1/42$ gives $\\zeta(6) = \\pi^6/945$. The odd zeta values $\\zeta(3), \\zeta(5), \\ldots$ remain mysterious — Apéry (1978) proved $\\zeta(3)$ is irrational, but no closed form in terms of $\\pi$ is known.",
+    "mathContext": "$\\zeta(2k) = \\frac{(-1)^{k+1} 2^{2k-1} \\pi^{2k} B_{2k}}{(2k)!}$ for $k \\geq 1$. The Bernoulli numbers satisfy $B_0 = 1$, $B_1 = -1/2$, $B_{2k+1} = 0$ for $k \\geq 1$ (odd Bernoulli numbers vanish). The generating function is $t/(e^t - 1) = \\sum B_n t^n/n!$.",
+    "significance": "key",
+    "prerequisites": [
+      "hasSum_zeta_nat",
+      "Bernoulli number theory",
+      "factorial"
+    ],
+    "relatedConcepts": [
+      "Bernoulli numbers",
+      "Euler's formula for ζ(2k)",
+      "Apéry's theorem",
+      "odd zeta values"
+    ]
+  },
+  {
+    "id": "ann-numerical",
+    "proofId": "basel-problem",
+    "range": {
+      "startLine": 145,
+      "endLine": 161
+    },
+    "type": "context",
+    "title": "Numerical Approximation and Convergence Rate",
+    "content": "The closing section provides numerical context. The partial sums $S_N = \\sum_{n=1}^{N} 1/n^2$ converge to $\\pi^2/6 \\approx 1.6449$ relatively slowly: $S_{10} \\approx 1.5498$ (6% error), $S_{100} \\approx 1.6350$ (0.6% error), $S_{1000} \\approx 1.6439$ (0.06% error). The error decays as $O(1/N)$ since $\\sum_{n>N} 1/n^2 \\approx \\int_N^{\\infty} x^{-2}\\,dx = 1/N$.\n\nThe `example` declarations computationally verify individual terms: $f(0) = 0$ (the $n = 0$ convention), $f(1) = 1$, $f(2) = 1/4$. These are discharged by `simp` and `norm_num`.",
+    "mathContext": "$\\pi^2/6 \\approx 1.6449340668$. The error in the $N$-th partial sum: $\\pi^2/6 - S_N = \\sum_{n>N} 1/n^2 \\sim 1/N$ as $N \\to \\infty$. For faster convergence, Euler used the Euler-Maclaurin formula to accelerate the series.",
+    "significance": "supporting",
+    "prerequisites": [
+      "numerical computation",
+      "norm_num tactic"
+    ],
+    "relatedConcepts": [
+      "partial sums",
+      "rate of convergence",
+      "Euler-Maclaurin formula"
     ]
   }
 ]

--- a/src/data/proofs/basel-problem/annotations.source.json
+++ b/src/data/proofs/basel-problem/annotations.source.json
@@ -16,7 +16,35 @@
       "infinite sums",
       "Bernoulli polynomials"
     ],
-    "prerequisites": ["Lean 4 import system", "Mathlib library structure", "HasSum/Summable API"]
+    "prerequisites": [
+      "Lean 4 import system",
+      "Mathlib library structure",
+      "HasSum/Summable API"
+    ]
+  },
+  {
+    "id": "ann-module-docstring",
+    "proofId": "basel-problem",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "The Basel Problem"
+    },
+    "type": "context",
+    "title": "Module Overview: The Basel Problem",
+    "content": "The module docstring introduces the Basel Problem — one of the most famous results in analysis. Named after the Bernoulli family's home city of Basel, Switzerland, the problem was posed by Pietro Mengoli in 1650: find the exact sum of $\\sum 1/n^2$. Jakob Bernoulli (1689) had bounded the sum between 1 and 2, noting it converges more slowly than the geometric series, but could not find the exact value.\n\nEuler solved it in 1734 at age 27, and this breakthrough launched his career. The approach documented here uses Mathlib's `hasSum_zeta_two`, which proves the result via Bernoulli polynomial theory and Fourier analysis — a modern rigorous approach that avoids the subtlety of Euler's original $\\sin(x)/x$ factorization (which required the Weierstrass factorization theorem, not available until 1876).",
+    "mathContext": "The Basel Problem: $\\zeta(2) = \\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6} \\approx 1.6449$. The appearance of $\\pi$ in a sum over integers was shocking to Euler's contemporaries — it revealed a deep connection between number theory and analysis that would later be formalized through the Riemann zeta function $\\zeta(s) = \\sum n^{-s}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Riemann zeta function",
+      "Bernoulli numbers",
+      "Fourier analysis",
+      "Weierstrass factorization"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "infinite series",
+      "convergence tests"
+    ]
   },
   {
     "id": "ann-basel-main",
@@ -36,7 +64,11 @@
       "convergence",
       "Basel problem"
     ],
-    "prerequisites": ["hasSum_zeta_two", "HasSum predicate", "real division"]
+    "prerequisites": [
+      "hasSum_zeta_two",
+      "HasSum predicate",
+      "real division"
+    ]
   },
   {
     "id": "ann-basel-tsum",
@@ -55,6 +87,10 @@
       "tsum",
       "notation",
       "equivalence"
+    ],
+    "prerequisites": [
+      "HasSum.tsum_eq",
+      "ann-basel-main"
     ]
   },
   {
@@ -74,7 +110,61 @@
       "Summable",
       "comparison test"
     ],
-    "prerequisites": ["Real.summable_nat_rpow_inv", "rpow_natCast", "Summable predicate"]
+    "prerequisites": [
+      "Real.summable_nat_rpow_inv",
+      "rpow_natCast",
+      "Summable predicate"
+    ]
+  },
+  {
+    "id": "ann-summable-proofs",
+    "proofId": "basel-problem",
+    "anchor": {
+      "type": "declaration",
+      "name": "summable_one_div_sq",
+      "kind": "theorem",
+      "extendAfter": 6
+    },
+    "type": "theorem",
+    "title": "Convergence Proofs: p-Series with p = 2",
+    "content": "`summable_one_div_sq` and `summable_nat_sq_inv` prove that $\\sum 1/n^2$ is summable (convergent) using two equivalent formulations. The proofs convert to `Real.summable_nat_rpow_inv` with $p = 2 > 1$, using `rpow_natCast` to bridge between the natural number exponent $n^2$ and the real-valued power $n^{2.0}$.\n\nThe p-series test ($\\sum n^{-p}$ converges $\\iff p > 1$) is the standard convergence criterion. The boundary case $p = 1$ (harmonic series $\\sum 1/n$) diverges — proved by the integral test or Cauchy condensation.",
+    "mathContext": "The p-series test: $\\sum_{n=1}^{\\infty} n^{-p} < \\infty \\iff p > 1$. For $p = 2$: convergence follows from comparison with the telescoping series $\\sum (1/n - 1/(n+1)) = 1$, since $1/n^2 < 1/(n(n-1))$ for $n \\geq 2$. The proof converts between `1/n^2` (natural number power) and `n^{(-2:ℝ)}` (real-valued power) via `rpow_natCast` and `div_eq_mul_inv`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "p-series test",
+      "Summable",
+      "integral test",
+      "rpow_natCast"
+    ],
+    "prerequisites": [
+      "Real.summable_nat_rpow_inv",
+      "rpow coercion",
+      "norm_num"
+    ]
+  },
+  {
+    "id": "ann-basic-properties",
+    "proofId": "basel-problem",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "Basic Properties",
+      "extendAfter": 6
+    },
+    "type": "theorem",
+    "title": "Positivity and Basic Properties",
+    "content": "Three positivity lemmas: `one_div_sq_pos` ($1/n^2 > 0$ for $n > 0$), `one_div_sq_nonneg` ($1/n^2 \\geq 0$ for all $n$), and `basel_value_pos` ($\\pi^2/6 > 0$). All proved by Lean's `positivity` tactic, which chains positivity/nonnegativity facts automatically.\n\nThese lemmas are supporting infrastructure: positivity of terms ensures the partial sums are increasing (important for monotone convergence), and positivity of the limit confirms the sum is meaningful.",
+    "mathContext": "For $n \\geq 1$: $1/n^2 > 0$ since $n^2 > 0$. For $n = 0$: $1/0^2 = 0 \\geq 0$ (Lean's convention). The value $\\pi^2/6 > 0$ since $\\pi > 0$ implies $\\pi^2 > 0$. The `positivity` tactic automatically chains `sq_nonneg`, `div_pos`, and `pi_pos` to close these goals.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positivity tactic",
+      "monotone convergence",
+      "nonnegative terms"
+    ],
+    "prerequisites": [
+      "positivity tactic",
+      "sq_nonneg",
+      "pi_pos"
+    ]
   },
   {
     "id": "ann-euler-history",
@@ -92,6 +182,10 @@
       "Weierstrass factorization",
       "Taylor series",
       "infinite products"
+    ],
+    "prerequisites": [
+      "Weierstrass factorization theorem",
+      "Taylor series of sin(x)"
     ]
   },
   {
@@ -112,6 +206,58 @@
       "zeta values",
       "special functions"
     ],
-    "prerequisites": ["hasSum_zeta_four", "hasSum_zeta_nat", "Bernoulli number theory"]
+    "prerequisites": [
+      "hasSum_zeta_four",
+      "hasSum_zeta_nat",
+      "Bernoulli number theory"
+    ]
+  },
+  {
+    "id": "ann-zeta-general",
+    "proofId": "basel-problem",
+    "anchor": {
+      "type": "declaration",
+      "name": "zeta_general",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "The General Zeta Value Formula",
+    "content": "`zeta_general` proves the general formula for even zeta values: $\\zeta(2k) = (-1)^{k+1} \\cdot 2^{2k-1} \\cdot \\pi^{2k} \\cdot B_{2k} / (2k)!$, where $B_{2k}$ is the $(2k)$-th Bernoulli number. This is Euler's generalization of the Basel Problem to all even positive integers.\n\nThe first few values: $B_2 = 1/6$ gives $\\zeta(2) = \\pi^2/6$, $B_4 = -1/30$ gives $\\zeta(4) = \\pi^4/90$, $B_6 = 1/42$ gives $\\zeta(6) = \\pi^6/945$. The odd zeta values $\\zeta(3), \\zeta(5), \\ldots$ remain mysterious — Apéry (1978) proved $\\zeta(3)$ is irrational, but no closed form in terms of $\\pi$ is known.",
+    "mathContext": "$\\zeta(2k) = \\frac{(-1)^{k+1} 2^{2k-1} \\pi^{2k} B_{2k}}{(2k)!}$ for $k \\geq 1$. The Bernoulli numbers satisfy $B_0 = 1$, $B_1 = -1/2$, $B_{2k+1} = 0$ for $k \\geq 1$ (odd Bernoulli numbers vanish). The generating function is $t/(e^t - 1) = \\sum B_n t^n/n!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bernoulli numbers",
+      "Euler's formula for ζ(2k)",
+      "Apéry's theorem",
+      "odd zeta values"
+    ],
+    "prerequisites": [
+      "hasSum_zeta_nat",
+      "Bernoulli number theory",
+      "factorial"
+    ]
+  },
+  {
+    "id": "ann-numerical",
+    "proofId": "basel-problem",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "Numerical Approximation",
+      "extendAfter": 8
+    },
+    "type": "context",
+    "title": "Numerical Approximation and Convergence Rate",
+    "content": "The closing section provides numerical context. The partial sums $S_N = \\sum_{n=1}^{N} 1/n^2$ converge to $\\pi^2/6 \\approx 1.6449$ relatively slowly: $S_{10} \\approx 1.5498$ (6% error), $S_{100} \\approx 1.6350$ (0.6% error), $S_{1000} \\approx 1.6439$ (0.06% error). The error decays as $O(1/N)$ since $\\sum_{n>N} 1/n^2 \\approx \\int_N^{\\infty} x^{-2}\\,dx = 1/N$.\n\nThe `example` declarations computationally verify individual terms: $f(0) = 0$ (the $n = 0$ convention), $f(1) = 1$, $f(2) = 1/4$. These are discharged by `simp` and `norm_num`.",
+    "mathContext": "$\\pi^2/6 \\approx 1.6449340668$. The error in the $N$-th partial sum: $\\pi^2/6 - S_N = \\sum_{n>N} 1/n^2 \\sim 1/N$ as $N \\to \\infty$. For faster convergence, Euler used the Euler-Maclaurin formula to accelerate the series.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "partial sums",
+      "rate of convergence",
+      "Euler-Maclaurin formula"
+    ],
+    "prerequisites": [
+      "numerical computation",
+      "norm_num tactic"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment pass for five gallery entries.

### abel-ruffini (Abel-Ruffini Theorem)
- New annotation `ann-part-ii-bridge`: Galois's radical tower connection
- Enhanced mathContext for `ann-abel-ruffini-theorem` and `ann-a5-simple`
- Annotations: 13 → 15

### angle-trisection (Impossibility of Trisecting an Angle)
- New annotations: `ann-part-iii-irreducibility`, `ann-part-vii-classical`
- Enhanced `ann-general-framework` with Gauss constructibility theorem
- Added cross-reference to `general-quartic`
- Annotations: 16 → 20

### area-of-circle (Area of a Circle)
- Split `ann-special-cases` into `ann-unit-disk` and `ann-edge-cases`
- Added cross-reference to `isoperimetric-theorem`
- Annotations: 5 → 6

### arithmetic-series (Sum of an Arithmetic Series)
- New annotation `ann-imports-docstring`
- Added prerequisites to all existing annotations
- Enhanced mathContext for 3 key theorems
- Added cross-references to `basel-problem` and `infinitude-primes`
- Annotations: 9 → 10

### basel-problem (The Basel Problem)
- 5 new annotations: module docstring, convergence proofs, basic properties, general ζ(2k) formula, numerical approximation
- Added prerequisites to 2 existing annotations
- Annotations: 6 → 11 (near-complete coverage of 164-line file)

## Test plan

- [x] `pnpm annotations:build` passes (no new errors)
- [x] `pnpm build` succeeds
- [x] All cross-references verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)