### PR TITLE
Enrich 5 entries: add cross-references and annotations

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -114,6 +114,11 @@
         "targetId": "shannon-entropy",
         "relationship": "related",
         "description": "Shannon entropy H(X) = -∑ pᵢ log pᵢ is the α→1 limit of Rényi entropy H_α = (1/(1-α))·log ∑ pᵢ^α. Since H_α ∝ log M_{α-1}, the duality M_r(z) = M_{-r}(z⁻¹)⁻¹ translates to a duality on Rényi entropies — the negative power mean monotonicity here implies the corresponding Rényi entropy monotonicity for α > 1"
+      },
+      {
+        "targetId": "mean-value-theorem",
+        "relationship": "related",
+        "description": "The mean value theorem underpins the r→0 limit case: proving lim_{r→0} M_r = GM requires L'Hôpital's rule (which depends on MVT). While this file handles only the r < 0 case, the mixed-sign crossing r < 0 < s ultimately depends on the r=0 bridge that MVT enables"
       }
     ],
     "dateAdded": "2026-03-21",
@@ -127,8 +132,9 @@
       "amgm-inequality-oq-03-oq-02",
       "cauchy-schwarz",
       "cauchy-schwarz-integral",
-    "triangle-inequality",
-    "shannon-entropy"
+      "triangle-inequality",
+      "shannon-entropy",
+      "mean-value-theorem"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

### abel-ruffini-oq-04
- Added `quadratic-reciprocity` cross-reference (Galois-theoretic connection via cyclotomic fields)
- Deepened derived-series annotation with Jordan-Hölder theorem context

### abel-ruffini
- Added annotation for Part II header (lines 51-57) covering the Galois-theoretic bridge
- Annotation coverage: 14 → 15 entries

### amgm-inequality-oq-02
- Added `vietas-formulas` cross-reference (elementary symmetric polynomials = polynomial coefficients)

### amgm-inequality-oq-03
- Added `isoperimetric-theorem` cross-reference (isoperimetric inequality via AM-GM)

### amgm-inequality-oq-03-oq-01
- Fixed inconsistent JSON indentation in relatedProofs
- Added `mean-value-theorem` cross-reference (MVT for the r→0 limit bridge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)