### PR TITLE
fix: Guard against undefined tags in research pages

### DIFF
--- a/src/components/research/ResearchCard.tsx
+++ b/src/components/research/ResearchCard.tsx
@@ -76,7 +76,7 @@ export function ResearchCard({ problem }: ResearchCardProps) {
 
       {/* Tags */}
       <div className="flex flex-wrap gap-2">
-        {problem.tags.slice(0, 3).map((tag) => (
+        {(problem.tags ?? []).slice(0, 3).map((tag) => (
           <span
             key={tag}
             className="px-2 py-0.5 bg-muted rounded text-xs text-muted-foreground"
@@ -84,9 +84,9 @@ export function ResearchCard({ problem }: ResearchCardProps) {
             {tag}
           </span>
         ))}
-        {problem.tags.length > 3 && (
+        {(problem.tags ?? []).length > 3 && (
           <span className="text-xs text-muted-foreground">
-            +{problem.tags.length - 3} more
+            +{(problem.tags ?? []).length - 3} more
           </span>
         )}
       </div>

--- a/src/data/research/problems/abel-ruffini-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04.json
@@ -68,5 +68,6 @@
   "relatedProofs": [
     "abel-ruffini",
     "abel-ruffini-oq-04"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -124,5 +124,6 @@
     "area-of-circle-oq-01-oq-02-oq-02",
     "area-of-circle-oq-01-oq-03",
     "area-of-circle-oq-03-oq-02"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
@@ -88,5 +88,6 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-02"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -134,5 +134,6 @@
     "ballot-problem-oq-02",
     "ballot-problem-oq-03",
     "ballot-problem-oq-03-oq-02"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -187,5 +187,6 @@
     "bezout-identity-oq-03-oq-01-oq-01",
     "bezout-identity-oq-03-oq-01-oq-01-oq-01",
     "bezout-identity-oq-04"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/birthday-problem-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-02.json
@@ -85,5 +85,6 @@
   "relatedProofs": [
     "birthday-problem",
     "birthday-problem-oq-02"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
@@ -136,5 +136,6 @@
     "borsuk-ulam-oq-03-oq-01",
     "borsuk-ulam-oq-03-oq-01-oq-01",
     "borsuk-ulam-oq-03-oq-03"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/buffons-needle-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-01.json
@@ -80,5 +80,6 @@
     "buffons-needle-oq-01-oq-01",
     "buffons-needle-oq-02",
     "buffons-needle-oq-02-oq-01"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -154,5 +154,6 @@
     "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
     "cayley-hamilton-minpoly-oq-05"
   ],
-  "lastUpdate": "2026-03-22T22:15:00Z"
+  "lastUpdate": "2026-03-22T22:15:00Z",
+  "tags": []
 }

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
@@ -120,5 +120,6 @@
     "cayley-hamilton-minpoly-oq-02",
     "cayley-hamilton-minpoly-oq-02-oq-01",
     "cayley-hamilton-minpoly-oq-05"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-02.json
@@ -45,5 +45,6 @@
     "cayley-hamilton-reduction",
     "cayley-hamilton-reduction-oq-01",
     "cayley-hamilton-reduction-oq-02"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02.json
@@ -160,5 +160,6 @@
     "cevas-theorem-oq-02-oq-01",
     "cevas-theorem-oq-02-oq-02",
     "cevas-theorem-oq-04"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-03.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-03.json
@@ -116,5 +116,6 @@
   "relatedProofs": [
     "chinese-remainder-non-coprime",
     "chinese-remainder-non-coprime-oq-01"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/dissection-of-cubes-oq-02.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-02.json
@@ -94,5 +94,6 @@
     "dissection-of-cubes",
     "dissection-of-cubes-oq-01",
     "dissection-of-cubes-oq-02"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/erdos-44.json
+++ b/src/data/research/problems/erdos-44.json
@@ -198,11 +198,11 @@
     {
       "path": "Proofs/Erdos44Aristotle.lean",
       "filename": "Erdos44Aristotle.lean",
-      "lineCount": 87,
+      "lineCount": 88,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 11,
+      "sorryCount": 7,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos44Aristotle.lean"
     },
@@ -220,11 +220,11 @@
     {
       "path": "Proofs/Erdos44SidonLowerBound.lean",
       "filename": "Erdos44SidonLowerBound.lean",
-      "lineCount": 204,
+      "lineCount": 292,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos44SidonLowerBound.lean"
     }

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-01.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-01.json
@@ -62,5 +62,6 @@
   "relatedProofs": [
     "fundamental-theorem-calculus",
     "fundamental-theorem-calculus-oq-01"
-  ]
+  ],
+  "tags": []
 }

--- a/src/data/research/problems/szemeredi-counting.json
+++ b/src/data/research/problems/szemeredi-counting.json
@@ -79,11 +79,11 @@
     {
       "path": "Proofs/SzemerediCounting.lean",
       "filename": "SzemerediCounting.lean",
-      "lineCount": 833,
+      "lineCount": 841,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCounting.lean"
     }

--- a/src/pages/ResearchPage.tsx
+++ b/src/pages/ResearchPage.tsx
@@ -60,7 +60,7 @@ export function ResearchPage() {
       filtered = filtered.filter((problem) =>
         problem.title.toLowerCase().includes(query) ||
         problem.description.toLowerCase().includes(query) ||
-        problem.tags.some(tag => tag.toLowerCase().includes(query))
+        (problem.tags ?? []).some(tag => tag.toLowerCase().includes(query))
       )
     }
 

--- a/src/pages/ResearchProblemPage.tsx
+++ b/src/pages/ResearchProblemPage.tsx
@@ -396,13 +396,13 @@ export function ResearchProblemPage() {
                 )}
 
                 {/* Tags */}
-                {problem.tags.length > 0 && (
+                {(problem.tags ?? []).length > 0 && (
                   <section>
                     <h2 className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
                       Tags
                     </h2>
                     <div className="flex flex-wrap gap-2">
-                      {problem.tags.map((tag) => (
+                      {(problem.tags ?? []).map((tag) => (
                         <span
                           key={tag}
                           className="px-2 py-1 bg-muted rounded text-sm text-muted-foreground"


### PR DESCRIPTION
## Summary

- Fix crash on research page: `can't access property "slice", a.tags is undefined`
- Add `tags: []` to 15 research problem JSONs missing the field
- Add `?? []` null guards on all `.tags` accesses in research components

## Root cause
Research problems created by the Seeker sometimes lack a `tags` field in their JSON. The frontend components assumed `tags` always exists.

## Test plan
- [ ] Research page loads without error
- [ ] Research problem detail pages load without error
- [ ] Search by tag still works on research page

🤖 Generated with [Claude Code](https://claude.com/claude-code)