### PR TITLE
Research: brouwer-fixed-point-oq-02-oq-01 - prove approximate_fixed_point_2d (0S 0A)

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean
@@ -687,6 +687,17 @@ noncomputable def displacementColoring (n : ℕ)
   else if d1 ≤ d2 then 1
   else 2
 
+-- The tie-breaking condition in displacementColoring implies f(v)=v, which contradicts hno_fix
+private lemma displacementColoring_no_tie {n : ℕ} {f : ℝ × ℝ → ℝ × ℝ}
+    (v : GridVertex n) (hne : f (gridToReal n v) ≠ gridToReal n v) :
+    ¬(-((f (gridToReal n v)).1 - (gridToReal n v).1 +
+        ((f (gridToReal n v)).2 - (gridToReal n v).2)) =
+      (f (gridToReal n v)).1 - (gridToReal n v).1 ∧
+      (f (gridToReal n v)).1 - (gridToReal n v).1 =
+      (f (gridToReal n v)).2 - (gridToReal n v).2) := by
+  rintro ⟨h1, h2⟩
+  exact hne (Prod.ext (by linarith) (by linarith))
+
 -- Helper: grid vertices map into the simplex
 private lemma gridToReal_in_simplex {n : ℕ} (hn : 0 < n) (v : GridVertex n) :
     (gridToReal n v).1 ≥ 0 ∧ (gridToReal n v).2 ≥ 0 ∧
@@ -711,11 +722,15 @@ private lemma displacementColoring_isSperner (n : ℕ) (hn : 0 < n)
   have hn' : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   -- (1) c(0,0) = 0: at origin, d1=f₁≥0, d2=f₂≥0, d0=-(f₁+f₂)≤0 is the minimum
-  · simp only [displacementColoring, gridToReal, Nat.cast_zero, zero_div, sub_zero]
+  · simp only [displacementColoring]
+    rw [if_neg (displacementColoring_no_tie ⟨0, 0, by omega⟩ (hno_fix ⟨0, 0, by omega⟩))]
+    simp only [gridToReal, Nat.cast_zero, zero_div, sub_zero]
     obtain ⟨hf1, hf2, _⟩ := hrange (0, 0) le_rfl le_rfl (by norm_num)
     rw [if_pos ⟨by linarith, by linarith⟩]
   -- (2) c(n,0) = 1: d1=f₁-1≤0, d2=f₂≥0, so d1≤d2. d0≤d1 iff f=(1,0) (fixed point).
-  · simp only [displacementColoring, gridToReal, Nat.cast_zero, zero_div, sub_zero, div_self hn']
+  · simp only [displacementColoring]
+    rw [if_neg (displacementColoring_no_tie ⟨n, 0, by omega⟩ (hno_fix ⟨n, 0, by omega⟩))]
+    simp only [gridToReal, Nat.cast_zero, zero_div, sub_zero, div_self hn']
     obtain ⟨hf1, hf2, hf12⟩ := hrange (1, 0) (by norm_num) le_rfl (by norm_num)
     rw [if_neg, if_pos (show (f (1, 0)).1 - 1 ≤ (f (1, 0)).2 by linarith)]
     intro ⟨h_le, _⟩
@@ -725,7 +740,9 @@ private lemma displacementColoring_isSperner (n : ℕ) (hn : 0 < n)
       simp only [gridToReal, Nat.cast_zero, zero_div, div_self hn']
       exact Prod.ext hf1_eq hf2_eq) (hno_fix ⟨n, 0, by omega⟩)
   -- (3) c(0,n) = 2: d1=f₁≥0, d2=f₂-1≤0, d0=1-f₁-f₂≥0. Neither if-branch unless fixed pt.
-  · simp only [displacementColoring, gridToReal, Nat.cast_zero, zero_div, sub_zero, div_self hn']
+  · simp only [displacementColoring]
+    rw [if_neg (displacementColoring_no_tie ⟨0, n, by omega⟩ (hno_fix ⟨0, n, by omega⟩))]
+    simp only [gridToReal, Nat.cast_zero, zero_div, sub_zero, div_self hn']
     obtain ⟨hf1, hf2, hf12⟩ := hrange (0, 1) le_rfl (by norm_num) (by norm_num)
     rw [if_neg, if_neg]
     · -- ¬(d1 ≤ d2): f₁ > f₂-1, unless f=(0,1) (fixed point)
@@ -747,6 +764,7 @@ private lemma displacementColoring_isSperner (n : ℕ) (hn : 0 < n)
   -- But d0>d1 or d0>d2 then gives f₂<0, contradicting hrange.
   · intro v hj hi0 hin heq
     simp only [displacementColoring] at heq
+    rw [if_neg (displacementColoring_no_tie v (hno_fix v))] at heq
     split_ifs at heq with h1 h2
     · exact absurd heq (by decide)
     · exact absurd heq (by decide)
@@ -764,6 +782,7 @@ private lemma displacementColoring_isSperner (n : ℕ) (hn : 0 < n)
   -- Symmetric to bottom edge: d1=f₁-0=f₁≥0, d1≤d2, d0>d1 or d0>d2 gives f₁<0.
   · intro v hi hj0 hjn heq
     simp only [displacementColoring] at heq
+    rw [if_neg (displacementColoring_no_tie v (hno_fix v))] at heq
     split_ifs at heq with h1 h2
     · exact absurd heq (by decide)
     · -- h1: ¬(d0 ≤ d1 ∧ d0 ≤ d2), h2: d1 ≤ d2 (TRUE from split_ifs)
@@ -780,6 +799,7 @@ private lemma displacementColoring_isSperner (n : ℕ) (hn : 0 < n)
   -- d0=1-f₁-f₂≥0. d0≤d1∧d0≤d2 forces f₁+f₂=1 and f₁=p₁, f₂=p₂, i.e. fixed point.
   · intro v hsum hi0 hj0 heq
     simp only [displacementColoring] at heq
+    rw [if_neg (displacementColoring_no_tie v (hno_fix v))] at heq
     split_ifs at heq with h1 h2
     · have hv := gridToReal_in_simplex hn v
       obtain ⟨hf1, hf2, hf12⟩ := hrange _ hv.1 hv.2.1 hv.2.2
@@ -796,25 +816,81 @@ private lemma displacementColoring_isSperner (n : ℕ) (hn : 0 < n)
     · exact absurd heq (by decide)
     · exact absurd heq (by decide)
 
+-- Coordinate bounds for vertices of a grid triangle
+private lemma triangle_vertex_i_sub_le {n : ℕ} {t : GridTriangle n} (a b : Fin 3) :
+    (t.vertices a).i ≤ (t.vertices b).i + 1 := by
+  rcases t with ⟨ti, tj, ty, hv⟩
+  cases ty <;> fin_cases a <;> fin_cases b <;>
+    simp [GridTriangle.vertices, lowerVertices, upperVertices] <;> omega
+
+private lemma triangle_vertex_j_sub_le {n : ℕ} {t : GridTriangle n} (a b : Fin 3) :
+    (t.vertices a).j ≤ (t.vertices b).j + 1 := by
+  rcases t with ⟨ti, tj, ty, hv⟩
+  cases ty <;> fin_cases a <;> fin_cases b <;>
+    simp [GridTriangle.vertices, lowerVertices, upperVertices] <;> omega
+
+-- Vertices of a grid triangle are within 1/n in L∞ distance
+private lemma triangle_vertices_close {n : ℕ} (hn : 0 < n) (t : GridTriangle n)
+    (a b : Fin 3) :
+    dist (gridToReal n (t.vertices a)) (gridToReal n (t.vertices b)) ≤ 1 / (n : ℝ) := by
+  have hn' : (0 : ℝ) < n := Nat.cast_pos.mpr hn
+  simp only [Prod.dist_eq, Real.dist_eq, gridToReal]
+  have hi1 : (↑(t.vertices a).i : ℝ) ≤ ↑(t.vertices b).i + 1 := by
+    exact_mod_cast triangle_vertex_i_sub_le a b
+  have hi2 : (↑(t.vertices b).i : ℝ) ≤ ↑(t.vertices a).i + 1 := by
+    exact_mod_cast triangle_vertex_i_sub_le b a
+  have hj1 : (↑(t.vertices a).j : ℝ) ≤ ↑(t.vertices b).j + 1 := by
+    exact_mod_cast triangle_vertex_j_sub_le a b
+  have hj2 : (↑(t.vertices b).j : ℝ) ≤ ↑(t.vertices a).j + 1 := by
+    exact_mod_cast triangle_vertex_j_sub_le b a
+  apply max_le <;> {
+    rw [← sub_div, abs_div, abs_of_pos hn']
+    gcongr; rw [abs_le]; constructor <;> linarith
+  }
+
+-- Grid vertices lie in [0,1]²
+private lemma gridToReal_mem_Icc {n : ℕ} (hn : 0 < n) (v : GridVertex n) :
+    gridToReal n v ∈ Set.Icc ((0 : ℝ), (0 : ℝ)) ((1 : ℝ), (1 : ℝ)) := by
+  have hn' : (0 : ℝ) < n := Nat.cast_pos.mpr hn
+  have hvi : (v.i : ℝ) ≤ n := by exact_mod_cast (show v.i ≤ n from le_of_add_le_left v.valid)
+  have hvj : (v.j : ℝ) ≤ n := by exact_mod_cast (show v.j ≤ n from le_of_add_le_right v.valid)
+  simp only [Set.mem_Icc, Prod.le_def, gridToReal]
+  exact ⟨⟨by positivity, by positivity⟩,
+         ⟨by rwa [div_le_one hn'], by rwa [div_le_one hn']⟩⟩
+
 -- Color 1 implies d₁ ≤ 0 (d₁ is the minimum displacement component)
 private lemma color_one_d1_nonpos {n : ℕ} {f : ℝ × ℝ → ℝ × ℝ} (v : GridVertex n)
     (hc : displacementColoring n f v = 1) :
     (f (gridToReal n v)).1 - (gridToReal n v).1 ≤ 0 := by
   simp only [displacementColoring] at hc
-  split_ifs at hc with h1 h2
-  · exact absurd hc (by decide)
-  · by_contra hd; push_neg at hd; exact h1 ⟨by linarith, by linarith⟩
-  · exact absurd hc (by decide)
+  by_cases h_tie : -((f (gridToReal n v)).1 - (gridToReal n v).1 +
+      ((f (gridToReal n v)).2 - (gridToReal n v).2)) =
+    (f (gridToReal n v)).1 - (gridToReal n v).1 ∧
+    (f (gridToReal n v)).1 - (gridToReal n v).1 =
+    (f (gridToReal n v)).2 - (gridToReal n v).2
+  · linarith [h_tie.1, h_tie.2]  -- tie → d₁ = 0
+  · rw [if_neg h_tie] at hc
+    split_ifs at hc with h1 h2
+    · exact absurd hc (by decide)
+    · by_contra hd; push_neg at hd; exact h1 ⟨by linarith, by linarith⟩
+    · exact absurd hc (by decide)
 
 -- Color 2 implies d₂ ≤ 0 (d₂ is the minimum displacement component)
 private lemma color_two_d2_nonpos {n : ℕ} {f : ℝ × ℝ → ℝ × ℝ} (v : GridVertex n)
     (hc : displacementColoring n f v = 2) :
     (f (gridToReal n v)).2 - (gridToReal n v).2 ≤ 0 := by
   simp only [displacementColoring] at hc
-  split_ifs at hc with h1 h2
-  · exact absurd hc (by decide)
-  · exact absurd hc (by decide)
-  · by_contra hd; push_neg at hd h2; exact h1 ⟨by linarith, by linarith⟩
+  by_cases h_tie : -((f (gridToReal n v)).1 - (gridToReal n v).1 +
+      ((f (gridToReal n v)).2 - (gridToReal n v).2)) =
+    (f (gridToReal n v)).1 - (gridToReal n v).1 ∧
+    (f (gridToReal n v)).1 - (gridToReal n v).1 =
+    (f (gridToReal n v)).2 - (gridToReal n v).2
+  · linarith [h_tie.1, h_tie.2]  -- tie → d₂ = 0
+  · rw [if_neg h_tie] at hc
+    split_ifs at hc with h1 h2
+    · exact absurd hc (by decide)
+    · exact absurd hc (by decide)
+    · by_contra hd; push_neg at hd h2; exact h1 ⟨by linarith, by linarith⟩
 
 -- Approximate Brouwer fixed point via Sperner's lemma + uniform continuity.
 theorem approximate_fixed_point_2d
@@ -833,7 +909,8 @@ theorem approximate_fixed_point_2d
   obtain ⟨δ, hδ_pos, hδ⟩ := huc (ε / 4) (by linarith)
   -- Step 3: Choose n so that grid mesh 1/n < min(δ, ε/4)
   obtain ⟨n, hn⟩ := exists_nat_gt (max (1 / δ) (4 / ε))
-  have hn_pos : 0 < n := by positivity
+  have hn_pos : 0 < n := by
+    by_contra h; push_neg at h; interval_cases n; simp at hn; linarith
   -- Step 4: Either grid fixed point (done) or Sperner coloring
   by_cases h : ∃ v : GridVertex n, f (gridToReal n v) = gridToReal n v
   · obtain ⟨v, hv⟩ := h
@@ -860,8 +937,150 @@ theorem approximate_fixed_point_2d
     -- By uniform continuity across the triangle (diameter ≤ 1/n in max-norm),
     -- d₁(v₀) < ε/2 and d₂(v₀) < ε/2. Color 0 structure at v₀ gives lower bounds.
     -- Therefore dist = max(|d₁|, |d₂|) < ε/2 < ε in the max-norm on ℝ × ℝ.
-    have _hd1_neg := color_one_d1_nonpos (t.vertices i₁) hi₁
-    have _hd2_neg := color_two_d2_nonpos (t.vertices i₂) hi₂
-    sorry
+    have hd1_neg := color_one_d1_nonpos (t.vertices i₁) hi₁
+    have hd2_neg := color_two_d2_nonpos (t.vertices i₂) hi₂
+    -- Extract color-0 vertex
+    obtain ⟨i₀, hi₀⟩ : ∃ i : Fin 3, displacementColoring n f (t.vertices i) = 0 := by
+      have : (0 : Fin 3) ∈ Finset.image ((displacementColoring n f) ∘ t.vertices) Finset.univ :=
+        by unfold IsFullyColored at ht; rw [ht]; simp
+      simpa using this
+    -- Numerical bounds: 1/n < δ and 1/n < ε/4
+    have hn' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
+    have h_inv_delta : 1 / (n : ℝ) < δ := by
+      have h1 : (n : ℝ) > 1 / δ := lt_of_le_of_lt (le_max_left _ _) (by exact_mod_cast hn)
+      have h_nδ : 1 < (n : ℝ) * δ :=
+        calc (1 : ℝ) = 1 / δ * δ := by field_simp
+          _ < (n : ℝ) * δ := mul_lt_mul_of_pos_right h1 hδ_pos
+      rw [div_lt_iff₀ hn']; linarith
+    have h_inv_eps4 : 1 / (n : ℝ) < ε / 4 := by
+      have h1 : (n : ℝ) > 4 / ε := lt_of_le_of_lt (le_max_right _ _) (by exact_mod_cast hn)
+      have h_nε : 4 < (n : ℝ) * ε :=
+        calc (4 : ℝ) = 4 / ε * ε := by field_simp
+          _ < (n : ℝ) * ε := mul_lt_mul_of_pos_right h1 hε
+      rw [div_lt_div_iff₀ hn' (by norm_num : (0:ℝ) < 4)]; linarith
+    -- All triangle vertices are in [0,1]² and within δ of each other
+    have h_mem : ∀ k : Fin 3,
+        gridToReal n (t.vertices k) ∈ Set.Icc ((0:ℝ),(0:ℝ)) ((1:ℝ),(1:ℝ)) :=
+      fun k => gridToReal_mem_Icc hn_pos (t.vertices k)
+    have h_close : ∀ a b : Fin 3,
+        dist (gridToReal n (t.vertices a)) (gridToReal n (t.vertices b)) < δ :=
+      fun a b => lt_of_le_of_lt (triangle_vertices_close hn_pos t a b) h_inv_delta
+    -- Uniform continuity: f-values at triangle vertices are within ε/4
+    have h_f_close : ∀ a b : Fin 3,
+        dist (f (gridToReal n (t.vertices a))) (f (gridToReal n (t.vertices b))) < ε / 4 :=
+      fun a b => hδ _ (h_mem a) _ (h_mem b) (h_close a b)
+    -- Abbreviations for readability
+    set p₀ := gridToReal n v₀ with hp₀_def
+    set p₁ := gridToReal n (t.vertices i₁) with hp₁_def
+    set p₂ := gridToReal n (t.vertices i₂) with hp₂_def
+    set p₀' := gridToReal n (t.vertices i₀) with hp₀'_def
+    -- Extract component-wise f-closeness from L∞ distance
+    have hfc1 : ∀ a b : Fin 3,
+        |(f (gridToReal n (t.vertices a))).1 - (f (gridToReal n (t.vertices b))).1| < ε / 4 := by
+      intro a b; have h := h_f_close a b
+      calc _ ≤ dist (f (gridToReal n (t.vertices a))).1 (f (gridToReal n (t.vertices b))).1 :=
+                le_of_eq (Real.dist_eq _ _).symm
+           _ ≤ max (dist (f (gridToReal n (t.vertices a))).1 (f (gridToReal n (t.vertices b))).1)
+                   (dist (f (gridToReal n (t.vertices a))).2 (f (gridToReal n (t.vertices b))).2) :=
+                le_max_left _ _
+           _ = dist (f (gridToReal n (t.vertices a))) (f (gridToReal n (t.vertices b))) :=
+                Prod.dist_eq.symm
+           _ < ε / 4 := h
+    have hfc2 : ∀ a b : Fin 3,
+        |(f (gridToReal n (t.vertices a))).2 - (f (gridToReal n (t.vertices b))).2| < ε / 4 := by
+      intro a b; have h := h_f_close a b
+      calc _ ≤ dist (f (gridToReal n (t.vertices a))).2 (f (gridToReal n (t.vertices b))).2 :=
+                le_of_eq (Real.dist_eq _ _).symm
+           _ ≤ max (dist (f (gridToReal n (t.vertices a))).1 (f (gridToReal n (t.vertices b))).1)
+                   (dist (f (gridToReal n (t.vertices a))).2 (f (gridToReal n (t.vertices b))).2) :=
+                le_max_right _ _
+           _ = dist (f (gridToReal n (t.vertices a))) (f (gridToReal n (t.vertices b))) :=
+                Prod.dist_eq.symm
+           _ < ε / 4 := h
+    -- Extract component-wise vertex closeness
+    have hpc1 : ∀ a b : Fin 3,
+        |(gridToReal n (t.vertices a)).1 - (gridToReal n (t.vertices b)).1| < ε / 4 := by
+      intro a b
+      have h := triangle_vertices_close hn_pos t a b
+      calc _ ≤ dist (gridToReal n (t.vertices a)).1 (gridToReal n (t.vertices b)).1 :=
+                le_of_eq (Real.dist_eq _ _).symm
+           _ ≤ max (dist (gridToReal n (t.vertices a)).1 (gridToReal n (t.vertices b)).1)
+                   (dist (gridToReal n (t.vertices a)).2 (gridToReal n (t.vertices b)).2) :=
+                le_max_left _ _
+           _ = dist (gridToReal n (t.vertices a)) (gridToReal n (t.vertices b)) :=
+                Prod.dist_eq.symm
+           _ ≤ 1 / (n : ℝ) := h
+           _ < ε / 4 := h_inv_eps4
+    have hpc2 : ∀ a b : Fin 3,
+        |(gridToReal n (t.vertices a)).2 - (gridToReal n (t.vertices b)).2| < ε / 4 := by
+      intro a b
+      have h := triangle_vertices_close hn_pos t a b
+      calc _ ≤ dist (gridToReal n (t.vertices a)).2 (gridToReal n (t.vertices b)).2 :=
+                le_of_eq (Real.dist_eq _ _).symm
+           _ ≤ max (dist (gridToReal n (t.vertices a)).1 (gridToReal n (t.vertices b)).1)
+                   (dist (gridToReal n (t.vertices a)).2 (gridToReal n (t.vertices b)).2) :=
+                le_max_right _ _
+           _ = dist (gridToReal n (t.vertices a)) (gridToReal n (t.vertices b)) :=
+                Prod.dist_eq.symm
+           _ ≤ 1 / (n : ℝ) := h
+           _ < ε / 4 := h_inv_eps4
+    -- One-sided bounds from absolute values (for linarith)
+    -- Upper bounds: a ≤ |a| < c gives a < c
+    -- Lower bounds: |a| < c gives -c < a via abs_lt
+    -- f-value bounds at v₀ vs v₁, v₂, v₀'
+    have hf01_1 := lt_of_le_of_lt (le_abs_self _) (hfc1 0 i₁)  -- (f p₀).1 - (f p₁).1 < ε/4
+    have hf02_2 := lt_of_le_of_lt (le_abs_self _) (hfc2 0 i₂)  -- (f p₀).2 - (f p₂).2 < ε/4
+    have hf00'_1 := lt_of_le_of_lt (le_abs_self _) (hfc1 0 i₀)  -- (f p₀).1 - (f p₀').1 < ε/4
+    have hf00'_1' := (abs_lt.mp (hfc1 0 i₀)).1  -- -(ε/4) < (f p₀).1 - (f p₀').1
+    have hf00'_2 := lt_of_le_of_lt (le_abs_self _) (hfc2 0 i₀)  -- (f p₀).2 - (f p₀').2 < ε/4
+    have hf00'_2' := (abs_lt.mp (hfc2 0 i₀)).1  -- -(ε/4) < (f p₀).2 - (f p₀').2
+    -- vertex component bounds at v₀ vs v₁, v₂, v₀'
+    have hp01_1 := lt_of_le_of_lt (le_abs_self _) (hpc1 i₁ 0)  -- p₁.1 - p₀.1 < ε/4
+    have hp02_2 := lt_of_le_of_lt (le_abs_self _) (hpc2 i₂ 0)  -- p₂.2 - p₀.2 < ε/4
+    have hp00'_1' := (abs_lt.mp (hpc1 i₀ 0)).1  -- -(ε/4) < p₀'.1 - p₀.1
+    have hp00'_2' := (abs_lt.mp (hpc2 i₀ 0)).1  -- -(ε/4) < p₀'.2 - p₀.2
+    -- f-closeness between i₀ and i₂ (for d₂ at color-0 vertex)
+    have hf0'2_2 := lt_of_le_of_lt (le_abs_self _) (hfc2 i₀ i₂)  -- (f p₀').2 - (f p₂).2 < ε/4
+    have hp0'2_2 := lt_of_le_of_lt (le_abs_self _) (hpc2 i₂ i₀)  -- p₂.2 - p₀'.2 < ε/4
+    -- f-closeness between i₀ and i₁ (for d₁ at color-0 vertex)
+    have hf0'1_1 := lt_of_le_of_lt (le_abs_self _) (hfc1 i₀ i₁)  -- (f p₀').1 - (f p₁).1 < ε/4
+    have hp0'1_1 := lt_of_le_of_lt (le_abs_self _) (hpc1 i₁ i₀)  -- p₁.1 - p₀'.1 < ε/4
+    -- === UPPER BOUNDS on displacements at v₀ ===
+    -- d₁(v₀) = [(f p₀).1 - (f p₁).1] + [(f p₁).1 - p₁.1] + [p₁.1 - p₀.1] < ε/4 + 0 + ε/4
+    have hd1_ub : (f p₀).1 - p₀.1 < ε / 2 := by linarith
+    have hd2_ub : (f p₀).2 - p₀.2 < ε / 2 := by linarith
+    -- === Color-0 displacement constraints ===
+    -- At the color-0 vertex, d₀ ≤ d₁ ∧ d₀ ≤ d₂ (standard branch, tie-breaking ruled out)
+    have h0_disp :
+        -((f p₀').1 - p₀'.1 + ((f p₀').2 - p₀'.2)) ≤ (f p₀').1 - p₀'.1 ∧
+        -((f p₀').1 - p₀'.1 + ((f p₀').2 - p₀'.2)) ≤ (f p₀').2 - p₀'.2 := by
+      -- Tie-breaking requires f(v) = v, which contradicts h
+      have h_ne := h (t.vertices i₀)
+      have h_not_tie : ¬(-((f p₀').1 - p₀'.1 + ((f p₀').2 - p₀'.2)) =
+          (f p₀').1 - p₀'.1 ∧ (f p₀').1 - p₀'.1 = (f p₀').2 - p₀'.2) := by
+        rintro ⟨h1, h2⟩
+        exact h_ne (Prod.ext (by linarith) (by linarith))
+      simp only [displacementColoring] at hi₀
+      rw [if_neg h_not_tie] at hi₀
+      split_ifs at hi₀ with h_std
+      · exact h_std
+      all_goals exact absurd hi₀ (by decide)
+    -- d₁(v₀') is bounded below: from 2d₁'+d₂' ≥ 0 and d₂'(v₀') < ε/2
+    -- d₂(v₀') < (f p₂).2 - p₂.2 + ε/2 ≤ 0 + ε/2 = ε/2
+    have hd2'_ub : (f p₀').2 - p₀'.2 < ε / 2 := by linarith
+    -- From 2d₁' + d₂' ≥ 0: d₁' ≥ -d₂'/2 > -ε/4
+    have hd1'_lb : (f p₀').1 - p₀'.1 > -(ε / 4) := by linarith [h0_disp.1]
+    -- Similarly: d₁(v₀') < ε/2 and d₁'+2d₂' ≥ 0 gives d₂' > -ε/4
+    have hd1'_ub : (f p₀').1 - p₀'.1 < ε / 2 := by linarith
+    have hd2'_lb : (f p₀').2 - p₀'.2 > -(ε / 4) := by linarith [h0_disp.2]
+    -- === LOWER BOUNDS on displacements at v₀ (via transfer from color-0 vertex) ===
+    -- d₁(v₀) > d₁(v₀') - ε/2 > -ε/4 - ε/2 = -3ε/4 > -ε
+    have hd1_lb : (f p₀).1 - p₀.1 > -ε := by linarith
+    have hd2_lb : (f p₀).2 - p₀.2 > -ε := by linarith
+    -- === Combine into dist < ε ===
+    rw [Prod.dist_eq, Real.dist_eq, Real.dist_eq]
+    apply max_lt <;> rw [abs_sub_comm, abs_lt]
+    · exact ⟨by linarith, by linarith⟩
+    · exact ⟨by linarith, by linarith⟩
 
 end Sperner2D


### PR DESCRIPTION
## Summary
- Proved `approximate_fixed_point_2d`: the final sorry in `BrouwerFixedPointOQ02OQ01.lean` — 2D Sperner's lemma applied to derive approximate Brouwer fixed points via uniform continuity
- Fixed Mathlib v4.26 API drift in `displacementColoring_isSperner` (6 cases), `color_one_d1_nonpos`, `color_two_d2_nonpos`
- File now compiles with **0 sorries, 0 axioms** (was 1 sorry + broken by Mathlib update)

## Key Proof Technique
The `approximate_fixed_point_2d` proof:
1. Uses uniform continuity of f on compact [0,1]² to get δ for ε/4
2. Chooses grid mesh 1/n < min(δ, ε/4) 
3. Applies 2D Sperner's lemma to find a fully-colored triangle
4. Extracts displacement bounds from color-0/1/2 vertices via triangle inequality chains
5. Combines upper bounds (d₁ < ε/2, d₂ < ε/2) and lower bounds (d₁ > -3ε/4, d₂ > -3ε/4) to get dist < ε

## Mathlib v4.26 Fix
Added `displacementColoring_no_tie` helper that proves the tie-breaking condition implies f(v)=v (contradiction with hno_fix). This eliminates the tie-breaking branch via `if_neg` before `split_ifs`, restoring the 3-branch proof structure that the original proofs relied on.

## Stats
- **1086 lines**, 37 theorems, 17 definitions
- **0 sorries, 0 axioms** (fully verified)

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ02OQ01`

🤖 Generated by researcher-7