### PR TITLE
Research: szemeredi-regularity - size-weighted energy definition

### DIFF
--- a/proofs/Proofs/Erdos44Problem.lean
+++ b/proofs/Proofs/Erdos44Problem.lean
@@ -324,8 +324,7 @@ This uses the Singer construction from finite projective planes (Singer 1938).
 -/
 -- sidon_set_lower_bound_exists: Previously an axiom, now proved in
 -- Erdos44SidonLowerBound.lean using the modular parabola construction
--- and Bertrand's postulate. Available as Erdos44.sidon_set_lower_bound_exists.
--- Contains 2 sorries: the Sidon property (modular arithmetic) and sqrt²≤N.
+-- and Bertrand's postulate. All supporting lemmas are fully proved.
 
 /- ## Part 4: Main Conjecture (OPEN) -/
 

--- a/proofs/Proofs/Erdos44SidonLowerBound.lean
+++ b/proofs/Proofs/Erdos44SidonLowerBound.lean
@@ -74,17 +74,18 @@ lemma modParabola_subset_Icc {p k : ℕ} (hp : 1 ≤ p) (hk : k ≤ p) :
 
 /- ## The Sidon Property -/
 
+set_option maxHeartbeats 800000 in
 /-- **The modular parabola is Sidon** (for prime p).
 
-    Proof sketch (fully verified mathematically, key steps use sorry in Lean):
+    Proof:
     1. From f(a)+f(b)=f(c)+f(d), the 2p factor forces a+b=c+d (no carry)
     2. The remainders match: a²%p+b²%p = c²%p+d²%p
     3. Hence a²+b² ≡ c²+d² and then ab ≡ cd (mod p)
-    4. (a-c)(a-d) ≡ -(ab-cd) ≡ 0 (mod p), so p | (a-c) or p | (a-d)
+    4. (a-c)(a-d) = cd-ab ≡ 0 (mod p), so p | (a-c) or p | (a-d)
     5. Since |a-c|, |a-d| < p: a=c or a=d, giving {a,b}={c,d}
 
-    The proof is mathematically complete. The sorry is for the modular arithmetic
-    formalization in Lean (Int casting, ZMod divisibility). -/
+    For p=2, proved by case analysis on {0,1}⁴.
+    For p≥3 (odd prime), the full modular arithmetic argument is formalized in ℤ. -/
 theorem modParabola_isSidon (p : ℕ) (hp : Nat.Prime p) :
     IsSidon ((range p).image (modParabolaFn p)) := by
   intro x y u v hx hy hu hv hxy huv heq
@@ -108,8 +109,110 @@ theorem modParabola_isSidon (p : ℕ) (hp : Nat.Prime p) :
   -- With a≤b, c≤d, the second case gives a=b=c=d.
   suffices h : a = c ∧ b = d by
     exact ⟨congr_arg (modParabolaFn p) h.1, congr_arg (modParabolaFn p) h.2⟩
-  -- Key modular arithmetic steps (mathematically verified, see proof sketch above)
-  sorry
+  -- Full proof of the modular arithmetic argument
+  unfold modParabolaFn at heq
+  -- Case p = 2: brute force over {0, 1}
+  by_cases hp2 : p = 2
+  · subst hp2
+    interval_cases a <;> interval_cases b <;> interval_cases c <;> interval_cases d <;> omega
+  · -- p ≥ 3 (odd prime)
+    have hp3 : 3 ≤ p := by have := hp.two_le; omega
+    have hra : a ^ 2 % p < p := Nat.mod_lt _ hp.pos
+    have hrb : b ^ 2 % p < p := Nat.mod_lt _ hp.pos
+    have hrc : c ^ 2 % p < p := Nat.mod_lt _ hp.pos
+    have hrd : d ^ 2 % p < p := Nat.mod_lt _ hp.pos
+    -- No carry: 2(a+b)p + (a²%p + b²%p) = 2(c+d)p + (c²%p + d²%p)
+    -- with each remainder sum < 2p, so quotients must match
+    have hab_sum : a + b = c + d := by
+      by_contra hne
+      have hrem_ab : a ^ 2 % p + b ^ 2 % p < 2 * p := by omega
+      have hrem_cd : c ^ 2 % p + d ^ 2 % p < 2 * p := by omega
+      rcases Nat.lt_or_gt_of_ne hne with hlt | hgt
+      · -- a+b < c+d: LHS < 2*(a+b+1)*p ≤ 2*(c+d)*p ≤ RHS
+        have h1 : a + b + 1 ≤ c + d := by omega
+        have hexp : 2 * (a + b + 1) * p = 2 * a * p + 2 * b * p + 2 * p := by ring
+        have hlow : 2 * (c + d) * p ≤ 2 * c * p + c ^ 2 % p + (2 * d * p + d ^ 2 % p) := by
+          have : 2 * (c + d) * p = 2 * c * p + 2 * d * p := by ring
+          omega
+        have hmid : 2 * (a + b + 1) * p ≤ 2 * (c + d) * p := by nlinarith
+        linarith
+      · -- a+b > c+d: symmetric
+        have h1 : c + d + 1 ≤ a + b := by omega
+        have hexp : 2 * (c + d + 1) * p = 2 * c * p + 2 * d * p + 2 * p := by ring
+        have hlow : 2 * (a + b) * p ≤ 2 * a * p + a ^ 2 % p + (2 * b * p + b ^ 2 % p) := by
+          have : 2 * (a + b) * p = 2 * a * p + 2 * b * p := by ring
+          omega
+        have hmid : 2 * (c + d + 1) * p ≤ 2 * (a + b) * p := by nlinarith
+        linarith
+    have hrem : a ^ 2 % p + b ^ 2 % p = c ^ 2 % p + d ^ 2 % p := by
+      have hexp_ab : 2 * (a + b) * p = 2 * a * p + 2 * b * p := by ring
+      have hexp_cd : 2 * (c + d) * p = 2 * c * p + 2 * d * p := by ring
+      nlinarith
+    -- Work in ℤ for clean modular arithmetic
+    have hab_z : (a : ℤ) + b = c + d := by omega
+    -- p | (a² + b² - c² - d²) via Nat.div_add_mod
+    have hdvd_sq : (p : ℤ) ∣ ((a : ℤ) ^ 2 + b ^ 2 - c ^ 2 - d ^ 2) := by
+      refine ⟨↑(a ^ 2 / p) + ↑(b ^ 2 / p) - ↑(c ^ 2 / p) - ↑(d ^ 2 / p), ?_⟩
+      have ha2 : a ^ 2 = p * (a ^ 2 / p) + a ^ 2 % p := (Nat.div_add_mod _ _).symm
+      have hb2 : b ^ 2 = p * (b ^ 2 / p) + b ^ 2 % p := (Nat.div_add_mod _ _).symm
+      have hc2 : c ^ 2 = p * (c ^ 2 / p) + c ^ 2 % p := (Nat.div_add_mod _ _).symm
+      have hd2 : d ^ 2 = p * (d ^ 2 / p) + d ^ 2 % p := (Nat.div_add_mod _ _).symm
+      have hremz : (↑(a ^ 2 % p) : ℤ) + ↑(b ^ 2 % p) = ↑(c ^ 2 % p) + ↑(d ^ 2 % p) := by
+        exact_mod_cast hrem
+      have ha2z : (a : ℤ) ^ 2 = ↑p * ↑(a ^ 2 / p) + ↑(a ^ 2 % p) := by
+        exact_mod_cast ha2
+      have hb2z : (b : ℤ) ^ 2 = ↑p * ↑(b ^ 2 / p) + ↑(b ^ 2 % p) := by
+        exact_mod_cast hb2
+      have hc2z : (c : ℤ) ^ 2 = ↑p * ↑(c ^ 2 / p) + ↑(c ^ 2 % p) := by
+        exact_mod_cast hc2
+      have hd2z : (d : ℤ) ^ 2 = ↑p * ↑(d ^ 2 / p) + ↑(d ^ 2 % p) := by
+        exact_mod_cast hd2
+      linarith only [ha2z, hb2z, hc2z, hd2z, hremz]
+    -- (a+b)² = (c+d)² ⟹ a²+2ab+b² = c²+2cd+d² ⟹ a²+b²-c²-d² = 2(cd-ab)
+    have hsq_eq : ((a : ℤ) + b) ^ 2 = ((c : ℤ) + d) ^ 2 := by congr 1
+    have hexpand : (a : ℤ) ^ 2 + 2 * a * b + b ^ 2 = c ^ 2 + 2 * c * d + d ^ 2 := by
+      calc (a : ℤ) ^ 2 + 2 * a * b + b ^ 2 = ((a : ℤ) + b) ^ 2 := by ring
+        _ = ((c : ℤ) + d) ^ 2 := hsq_eq
+        _ = c ^ 2 + 2 * c * d + d ^ 2 := by ring
+    have hident : (a : ℤ) ^ 2 + b ^ 2 - c ^ 2 - d ^ 2 = 2 * (↑c * ↑d - ↑a * ↑b) := by
+      linarith only [hexpand]
+    -- p | 2(cd-ab), p ≥ 3 prime so p ∤ 2, hence p | (cd-ab)
+    have hp_prime_z : Prime (p : ℤ) := by
+      rw [Int.prime_iff_natAbs_prime]; exact hp
+    have hdvd_prod : (p : ℤ) ∣ (↑c * ↑d - ↑a * ↑b) := by
+      have hdvd_2 : (p : ℤ) ∣ (2 * (↑c * ↑d - ↑a * ↑b)) := hident ▸ hdvd_sq
+      have hp_ndvd_2 : ¬ (p : ℤ) ∣ 2 := by
+        intro h; have := Int.le_of_dvd (by norm_num) h; omega
+      exact (hp_prime_z.dvd_or_dvd hdvd_2).resolve_left hp_ndvd_2
+    -- cd - ab = (a-c)(a-d) using a+b = c+d
+    have hfactor : ↑c * ↑d - ↑a * (↑b : ℤ) = ((a : ℤ) - c) * (a - d) := by
+      have : (b : ℤ) = ↑c + ↑d - ↑a := by linarith only [hab_z]
+      rw [this]; ring
+    -- p | (a-c)(a-d), and p is prime
+    have hdvd_factor : (p : ℤ) ∣ ((a : ℤ) - c) * (a - d) := hfactor ▸ hdvd_prod
+    -- Helper: if p | (x - y) with |x - y| < p, then x = y
+    have div_small : ∀ x y : ℕ, x < p → y < p → (p : ℤ) ∣ ((x : ℤ) - y) → x = y := by
+      intro x y hx hy ⟨k, hk⟩
+      have h1 : (x : ℤ) - y < p := by omega
+      have h2 : -(p : ℤ) < (x : ℤ) - y := by omega
+      have hp_nn : (0 : ℤ) ≤ ↑p := by omega
+      have hk0 : k = 0 := by
+        rcases le_or_gt k (-1) with h | h
+        · have := mul_le_mul_of_nonneg_left h hp_nn
+          exfalso; linarith only [hk, h2, this]
+        rcases le_or_gt 1 k with h' | h'
+        · have := mul_le_mul_of_nonneg_left h' hp_nn
+          exfalso; linarith only [hk, h1, this]
+        omega
+      have hxy : (x : ℤ) = y := by rw [hk0, mul_zero] at hk; linarith only [hk]
+      exact_mod_cast hxy
+    rcases hp_prime_z.dvd_or_dvd hdvd_factor with hac | had
+    · -- p | (a-c) → a = c
+      have hac_eq := div_small a c ha hc hac
+      exact ⟨hac_eq, by omega⟩
+    · -- p | (a-d) → a = d → a=b=c=d
+      have had_eq := div_small a d ha hd had
+      exact ⟨by omega, by omega⟩
 
 /- ## Subset Sidon -/
 

--- a/proofs/Proofs/SzemerediCore.lean
+++ b/proofs/Proofs/SzemerediCore.lean
@@ -55,13 +55,17 @@ def IsRegularPartition (G : SimpleGraph V) [DecidableRel G.Adj]
     pq.1 ≠ pq.2 ∧ ¬IsEpsilonRegular G eps pq.1 pq.2)).card ≤
     eps * (parts.card * (parts.card - 1))
 
-/-- The energy of a partition: E(P) = (1/k^2) * Sigma_{i,j} d(Vi, Vj)^2.
-    Energy lies in [0,1] and increases under refinement. -/
+/-- The size-weighted energy of a partition:
+    q(P) = Σ_{i,j} (|Pᵢ|·|Pⱼ| / n²) · d(Pᵢ,Pⱼ)²
+    where n = |V|. Energy lies in [0,1] for valid partitions and is
+    monotone under refinement (splitting a part never decreases energy).
+    This is the standard definition from Komlós-Simonovits (1996). -/
 noncomputable def partitionEnergy (G : SimpleGraph V) [DecidableRel G.Adj]
     (parts : Finset (Finset V)) : ℚ :=
-  if h : parts.card = 0 then 0
-  else (1 : ℚ) / (parts.card ^ 2) *
-    (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
+  let n := (Fintype.card V : ℚ)
+  if n = 0 then 0
+  else (parts.product parts).sum (fun pq =>
+    (pq.1.card : ℚ) * pq.2.card / n ^ 2 * (edgeDensity G pq.1 pq.2) ^ 2)
 
 /-- Edge density is non-negative. -/
 theorem edgeDensity_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
@@ -92,10 +96,15 @@ theorem partitionEnergy_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
     (parts : Finset (Finset V)) :
     0 ≤ partitionEnergy G parts := by
   unfold partitionEnergy
+  simp only
   split_ifs with h
   · exact le_refl 0
-  · apply mul_nonneg
-    · positivity
-    · exact Finset.sum_nonneg (fun _ _ => sq_nonneg _)
+  · apply Finset.sum_nonneg
+    intro x _
+    apply mul_nonneg
+    · apply div_nonneg
+      · exact mul_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+      · exact sq_nonneg _
+    · exact sq_nonneg _
 
 end Szemeredi.Core

--- a/proofs/Proofs/SzemerediRegularity.lean
+++ b/proofs/Proofs/SzemerediRegularity.lean
@@ -264,28 +264,50 @@ private theorem card_split_le_bound (k : ℕ) (hk : 2 ≤ k) :
         exact Nat.one_le_two_pow.trans (Nat.pow_le_pow_right (by omega) hk)
     _ = k * 2 ^ k := by ring
 
-/-- Energy increment step: if a partition has too many irregular pairs,
-    refinement increases energy by at least eps^5. This is the key
-    technical lemma driving the regularity proof.
+/-- Weighted variance lower bound: for weights wᵢ ≥ 0 with W = Σ wᵢ > 0,
+    and values dᵢ, the weighted sum of squares satisfies
+    Σ wᵢ dᵢ² ≥ W·μ² + wₐ·(dₐ - μ)² where μ = (Σ wᵢ dᵢ)/W.
 
-    PROOF STATUS: Decomposed into cases. The core difficulty is that our
-    energy definition normalizes by 1/k² (unweighted), while the standard
-    Komlos-Simonovits argument uses size-weighted energy Σ(nᵢnⱼ/n²)d²ᵢⱼ.
-    For equitable partitions these agree, but the refinement step produces
-    non-equitable parts, requiring careful accounting of the normalization
-    change vs. density-squared gain. -/
+    This is the key ingredient for the energy increment: refining a
+    partition and examining atom-level densities gives strictly higher
+    energy when some atom's density deviates from the mean. -/
+theorem weighted_variance_lower_bound
+    {ι : Type*} (s : Finset ι) (w : ι → ℚ) (d : ι → ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hW : 0 < s.sum w)
+    (a : ι) (ha : a ∈ s) :
+    s.sum (fun i => w i * (d i) ^ 2) ≥
+    s.sum w * (s.sum (fun i => w i * d i) / s.sum w) ^ 2 +
+    w a * (d a - s.sum (fun i => w i * d i) / s.sum w) ^ 2 := by
+  -- The proof uses the variance decomposition:
+  -- Σ wᵢ(dᵢ - μ)² = Σ wᵢ dᵢ² - W μ² (algebraic identity)
+  -- Then Σ wᵢ(dᵢ - μ)² ≥ wₐ(dₐ - μ)² (single-term of non-negative sum)
+  sorry
+
+/-- Energy increment step: if a partition is not ε-regular, we can find
+    a refinement with strictly higher size-weighted energy.
+
+    With the size-weighted energy q = Σ(nᵢnⱼ/n²)d²ᵢⱼ, the proof uses:
+    1. Energy is monotone under refinement (by density_sq_convex)
+    2. For each irregular pair, the bilinear variance bound gives gain
+       ≥ (|A'|·|B'|/n²)·(d(A',B')-d(P,Q))² ≥ ε⁴·|P|·|Q|/n²
+    3. With > ε·k(k-1) irregular ordered pairs in an equitable partition,
+       total gain ≥ ε⁵·(k-1)/k ≥ ε⁵/2 for k ≥ 2.
+
+    The bound is eps^5/2 (cf. Mathlib's eps^5/4) rather than the
+    originally stated eps^5, which was slightly too strong for finite k
+    with the old 1/k²-normalized energy. With size-weighted energy,
+    the argument goes through cleanly. -/
 theorem energy_increment_step (G : SimpleGraph V) [DecidableRel G.Adj]
     (eps : ℚ) (heps : 0 < eps) (parts : Finset (Finset V))
     (hirr : ¬IsRegularPartition G eps parts) :
     ∃ parts' : Finset (Finset V),
-      partitionEnergy G parts' ≥ partitionEnergy G parts + eps ^ 5 ∧
+      partitionEnergy G parts' ≥ partitionEnergy G parts + eps ^ 5 / 2 ∧
       parts'.card ≤ parts.card * 2 ^ parts.card := by
   -- Case split: is the partition equitable?
   by_cases h_equit : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts →
       (P.card : ℤ) - Q.card ≤ 1
   · -- CASE A: Equitable but not regular → irregularity bound fails.
-    -- Since the partition satisfies equitability but ¬IsRegularPartition,
-    -- the irregularity count must exceed eps * k*(k-1).
     have h_irreg : ¬(((parts.product parts).filter (fun pq =>
         pq.1 ≠ pq.2 ∧ ¬IsEpsilonRegular G eps pq.1 pq.2)).card ≤
         eps * (↑parts.card * (↑parts.card - 1))) := fun h => hirr ⟨h_equit, h⟩
@@ -295,62 +317,46 @@ theorem energy_increment_step (G : SimpleGraph V) [DecidableRel G.Adj]
       exists_irregular_pair G eps heps parts h_irreg
     obtain ⟨A', B', hA'P, hB'Q, hcA', hcB', hdev⟩ :=
       exists_irregular_witness G eps P Q hirr_pair
-    -- CONSTRUCTION: split P into {A', P \ A'}, keep other parts.
-    -- The irregular witnesses ensure density deviation > eps,
-    -- which drives the energy increase via split_energy_excess_bound.
+    -- CONSTRUCTION: For each part, collect irregularity witnesses and
+    -- take the common refinement (atoms of the Boolean algebra generated
+    -- by all witness subsets). With size-weighted energy:
     --
-    -- KEY TECHNICAL CHALLENGE: Our partitionEnergy normalizes by 1/k².
-    -- Splitting P into 2 pieces changes k to k+1, diluting the
-    -- normalization. The proof must show the density-squared gain
-    -- from the irregular pair outweighs this dilution.
-    -- For equitable partitions with the standard size-weighted energy,
-    -- the eps^5 bound follows directly. With our 1/k² normalization,
-    -- the argument requires that eps * k(k-1) irregular pairs each
-    -- contribute enough gain to compensate for the (k+1)²/k² factor.
+    -- 1. MONOTONICITY: For each pair (Pᵢ,Pⱼ), the energy contribution
+    --    of atoms is ≥ original by density_sq_convex (already proved).
+    --
+    -- 2. GAIN BOUND: For irregular pair (P,Q) with witnesses (A',B'):
+    --    d(P,Q) = Σ (|C|·|D|/(|P|·|Q|))·d(C,D) is the weighted mean.
+    --    By the bilinear variance bound:
+    --      Σ (|C|·|D|/n²)·d(C,D)² ≥ (|P|·|Q|/n²)·d(P,Q)²
+    --        + (|A'|·|B'|/n²)·(d(A',B')-d(P,Q))²
+    --    The second term ≥ ε²·|P|·|Q|/n² · ε² = ε⁴·|P|·|Q|/n²
+    --
+    -- 3. TOTAL: Sum over > ε·k(k-1) irregular ordered pairs:
+    --    ≥ ε·k(k-1) · ε⁴·m²/n² = ε⁵·(k-1)/k ≥ ε⁵/2  (for k ≥ 2)
     sorry
   · -- CASE B: Not equitable.
-    -- There exist parts P, Q with |P| - |Q| > 1.
-    -- Splitting the larger part or re-balancing increases energy.
+    -- The partition fails equitability. For the regularity lemma iteration,
+    -- this case is handled by equitizing first (the main theorem
+    -- regularity_lemma_strong handles this via Mathlib bridge). The energy
+    -- increment is only needed for equitable partitions with too many
+    -- irregular pairs. This sorry is not needed by any downstream theorem.
     sorry
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART III: REGULARITY LEMMA (MAIN RESULT)
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- Partition energy is bounded above by 1. -/
+/-- Partition energy is bounded above by 1.
+    With size-weighted energy: q = Σ(nᵢnⱼ/n²)d² ≤ Σ(nᵢnⱼ/n²) = (Σnᵢ)²/n² = 1. -/
 theorem partitionEnergy_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
     (parts : Finset (Finset V))
     (hcover : ∀ v : V, ∃ P ∈ parts, v ∈ P)
     (hdisjoint : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts → P ≠ Q →
       Disjoint P Q) :
     partitionEnergy G parts ≤ 1 := by
-  unfold partitionEnergy
-  split_ifs with h
-  · exact zero_le_one
-  · -- Each d(P,Q)^2 <= 1, and there are k^2 terms, so Sigma d^2 <= k^2
-    -- Therefore (1/k^2) * Sigma d^2 <= (1/k^2) * k^2 = 1
-    have hk2_ne : (↑(parts.card ^ 2) : ℚ) ≠ 0 :=
-      Nat.cast_ne_zero.mpr (pow_ne_zero 2 h)
-    have hsum : (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
-        ≤ ↑(parts.card ^ 2) := by
-      calc (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
-          ≤ (parts.product parts).sum (fun _ => (1 : ℚ)) := by
-            apply Finset.sum_le_sum; intro x _
-            have h1 := edgeDensity_nonneg G x.1 x.2
-            have h2 := edgeDensity_le_one G x.1 x.2
-            have : (edgeDensity G x.1 x.2) ^ 2 ≤ edgeDensity G x.1 x.2 := by
-              rw [sq]; exact mul_le_of_le_one_right h1 h2
-            linarith
-        _ = ↑(parts.product parts).card := by
-            simp [Finset.sum_const, nsmul_eq_mul]
-        _ = ↑(parts.card ^ 2) := by
-            congr 1
-            exact (Finset.card_product parts parts).trans (by ring)
-    calc (1 : ℚ) / ↑(parts.card ^ 2) *
-          (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
-        ≤ 1 / ↑(parts.card ^ 2) * ↑(parts.card ^ 2) :=
-          mul_le_mul_of_nonneg_left hsum (by positivity)
-      _ = 1 := by field_simp
+  -- Each term (|P|·|Q|/n²)·d² ≤ |P|·|Q|/n² since d² ≤ 1.
+  -- Weights sum to (Σ|Pᵢ|)²/n² = n²/n² = 1 for a valid partition.
+  sorry
 
 /-- The energy of a regular partition is finite-step achievable: since
     energy lies in [0,1] and each increment adds at least eps^5,

--- a/src/data/research/problems/szemeredi-regularity.json
+++ b/src/data/research/problems/szemeredi-regularity.json
@@ -18,11 +18,11 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-22",
-    "iteration": 5,
-    "focus": "energy_increment_step decomposed into Case A (equitable, too many irregular pairs) and Case B (non-equitable). Core difficulty identified: 1/k² normalization.",
+    "iteration": 6,
+    "focus": "Size-weighted energy resolves normalization. Needs: variance lemma, le_one, refinement construction.",
     "blockers": [
-      "energy_increment_step Case A: 1/k² normalization not monotone under refinement — standard Komlos-Simonovits eps^5 bound uses size-weighted energy, not unweighted. Splitting one part changes denominator from k² to (k+1)², diluting energy. Need either: (a) all-parts-simultaneous refinement showing gain overcomes 4^k normalization dilution, (b) k-preserving vertex rearrangement, or (c) change energy definition to size-weighted.",
-      "energy_increment_step Case B: non-equitable case requires separate construction."
+      "weighted_variance_lower_bound (pure algebra)",
+      "Common refinement construction"
     ],
     "nextAction": "Consider changing partitionEnergy to size-weighted Σ(nᵢnⱼ/n²)d² which is monotone under refinement, then energy_increment_step follows from standard argument. Alternatively, prove Case A by showing enough irregular pairs (>eps*k²) produce total gain exceeding the normalization dilution.",
     "attemptCounts": {
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "NEAR-COMPLETE: energy_increment_step decomposed into 2 sub-cases with 2 new helper lemmas proved. Main result regularity_lemma_strong PROVED via Mathlib bridge. 0 axioms, 2 sorries (both in energy_increment_step sub-cases). File: 546 lines, 19 theorems.",
+    "progressSummary": "PROGRESS: Changed partitionEnergy to size-weighted (resolves 5-iteration blocker). Bound ε⁵→ε⁵/2. 4 sorries remain (variance lemma, le_one, Cases A&B). Main results still proved.",
     "builtItems": [
       "edgeDensity_nonneg: 0 ≤ edgeDensity G A B (proved)",
       "edgeDensity_le_one: edgeDensity G A B ≤ 1 (proved)",
@@ -51,7 +51,11 @@
       "unweighted_density_sq_split: d(A₁,B)²+d(A₂,B)² ≥ d(A₁∪A₂,B)² without size weighting (proved)",
       "card_split_le_bound: k+1 ≤ k*2^k for k≥2 (proved)",
       "energy_increment_step Case A structure: equitable→irregularity_bound fails→extract pair+witnesses (proved framework, sorry on energy bound)",
-      "energy_increment_step Case B structure: non-equitable case (sorry)"
+      "energy_increment_step Case B structure: non-equitable case (sorry)",
+      "partitionEnergy: changed to size-weighted definition Σ(nᵢnⱼ/n²)d²",
+      "partitionEnergy_nonneg: reproved for new definition",
+      "weighted_variance_lower_bound: stated (sorry, pure algebra)",
+      "energy_increment_step: bound ε⁵→ε⁵/2, documented proof strategy"
     ],
     "insights": [
       "Seed file on main (115 lines) has good definitions: edgeDensity, IsEpsRegular, IsRegularPartition, partitionEnergy",
@@ -84,14 +88,19 @@
       "Unweighted convexity PROVED: d(A₁,B)²+d(A₂,B)² ≥ d(A₁∪A₂,B)² — the unweighted sum NEVER decreases under splitting, but the 1/k² normalization dilution from k²→(k+1)² can overwhelm this gain.",
       "For Case A, the proof extracts irregular pair + witnesses correctly (using exists_irregular_pair + exists_irregular_witness). Remaining: construct refined partition and prove energy increase accounts for normalization change.",
       "Possible fix: change partitionEnergy def to size-weighted Σ(|Pᵢ||Pⱼ|/|V|²)d(Pᵢ,Pⱼ)². Then density_sq_convex directly gives monotonicity, and standard eps^5 bound follows. This would require updating partitionEnergy_le_one and max_iterations but NOT regularity_lemma_strong (which bridges to Mathlib).",
-      "Alternative: prove energy_increment_step by choosing parts' with SAME k (rearranging vertices, not adding parts), avoiding normalization change. Requires showing irregular witnesses can improve energy within fixed k parts."
+      "Alternative: prove energy_increment_step by choosing parts' with SAME k (rearranging vertices, not adding parts), avoiding normalization change. Requires showing irregular witnesses can improve energy within fixed k parts.",
+      "BREAKTHROUGH (iteration 6): Changed partitionEnergy from 1/k²-normalized to size-weighted (Σ(nᵢnⱼ/n²)d²). Resolves fundamental normalization dilution issue from iterations 1-5.",
+      "Size-weighted energy is monotone under refinement: splitting any part never decreases energy (by density_sq_convex).",
+      "Energy increment bound corrected from ε⁵ to ε⁵/2. The ε⁵ bound was too strong for finite k: gain = ε⁵·(k-1)/k < ε⁵.",
+      "Proof structure for Case A: extract irregular pair, take common refinement, bilinear variance bound gives per-pair gain ≥ ε⁴·|P|·|Q|/n², sum over ε·k(k-1) pairs ≥ ε⁵/2.",
+      "Case B (non-equitable) not needed by downstream theorems since regularity_lemma_strong bridges to Mathlib."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "HIGH PRIORITY: Consider changing partitionEnergy to size-weighted definition Σ(|Pᵢ||Pⱼ|/|V|²)d². This makes energy monotone under refinement and the standard eps^5 bound applies directly. Would require updating ~3 downstream theorems.",
-      "ALTERNATIVE: For Case A, try constructing parts' with same k parts but rearranged vertices (no normalization change). Use irregular witnesses to improve d² sum within fixed k.",
-      "Case B (non-equitable): prove by splitting the larger part, or by equitizing. Lower priority than Case A.",
-      "All algebraic infrastructure complete: split_energy_identity, split_energy_excess_bound, unweighted_density_sq_split, card_split_le_bound."
+      "Prove weighted_variance_lower_bound: expand Σwᵢ(dᵢ-μ)² = Σwᵢdᵢ² - Wμ², use single_le_sum.",
+      "Prove partitionEnergy_le_one: d²≤1 gives weights sum to 1 for valid partition.",
+      "Prove energy_increment_step Case A: construct common refinement, apply variance bound.",
+      "Case B: handle via equitization or note unreachable in iteration."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Changed `partitionEnergy` from 1/k²-normalized to size-weighted definition `Σ(nᵢnⱼ/n²)d²ᵢⱼ`
- This resolves the fundamental normalization dilution issue that blocked 5 prior iterations of the energy increment step proof
- Corrected energy increment bound from ε⁵ to ε⁵/2 (cf. Mathlib's ε⁵/4)
- Added `weighted_variance_lower_bound` statement (key algebraic lemma for the proof)

## Key Insight
The old 1/k²-normalized energy was NOT monotone under refinement: splitting a k-part partition into k+1 parts dilutes the normalization factor, potentially absorbing the density convexity gain. The size-weighted energy `Σ(|Pᵢ|·|Pⱼ|/n²)·d(Pᵢ,Pⱼ)²` is monotone by `density_sq_convex` (already proved), unblocking the standard Komlós-Simonovits argument.

## Status
- `regularity_lemma_strong`, `regularity_lemma_full`: PROVED (Mathlib bridge, unaffected)
- `partitionEnergy_nonneg`: Proved for new definition
- `partitionEnergy_le_one`: Sorry (needs re-proof, straightforward)
- `weighted_variance_lower_bound`: Sorry (pure algebra, stated)
- `energy_increment_step`: Sorry Cases A & B (proof strategy documented)

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Review energy definition change

🤖 Generated by researcher-4