### PR TITLE
Research: erdos-538 (3S→1S) + szemeredi-counting + erdos-1055 surveys

### DIFF
--- a/proofs/Proofs/Erdos538Problem.lean
+++ b/proofs/Proofs/Erdos538Problem.lean
@@ -256,6 +256,7 @@ theorem sum_reprCount_bound (A : Finset ℕ) (N : ℕ)
   -- Step 3: The remaining set has N elements, each contributing ≤ A.card
   have hcard_erase : ((Finset.range (N + 1)).erase 0).card = N := by
     rw [Finset.card_erase_of_mem h0_mem, Finset.card_range]
+    omega
   calc ∑ m ∈ (Finset.range (N + 1)).erase 0, reprCount A m
       ≤ ∑ m ∈ (Finset.range (N + 1)).erase 0, A.card :=
         Finset.sum_le_sum (fun m _ => reprCount_le_card A m)
@@ -268,39 +269,49 @@ theorem sum_reprCount_bound (A : Finset ℕ) (N : ℕ)
 ## Section VIII: Connections to Multiplicative Structure
 -/
 
-/-- The problem is related to the multiplicative energy of A with primes.
-    The set E = {(a₁, a₂) ∈ A × A : ∃ p₁ p₂ prime, p₁a₁ = p₂a₂} measures
-    how "multiplicatively correlated" A is with the primes. -/
-theorem multiplicative_energy_bound (A : Finset ℕ) (N r : ℕ)
-    (hA : A ⊆ Finset.range (N + 1)) (hr : HasBoundedRepr A r) :
+/-- The multiplicative energy of A with primes: the number of pairs (a₁, a₂)
+    in A × A with ∃ p₁ p₂ prime, p₁a₁ = p₂a₂. Always includes the diagonal
+    (|A| pairs with a₁ = a₂, using any prime for both).
+    Note: the bound r²·|A| is FALSE. Counterexample: A = {2,3,5,7,11} with
+    N=11 has r=2, but all 25 pairs satisfy the condition (any two primes
+    p_i, p_j have gcd 1, and p_i/1, p_j/1 are both prime), while r²·|A| = 20.
+    The trivial bound |A|² always holds. -/
+theorem multiplicative_energy_trivial_bound (A : Finset ℕ) (N : ℕ)
+    (hA : A ⊆ Finset.range (N + 1)) :
     (Finset.card ((A ×ˢ A).filter (fun p =>
       ∃ q₁ q₂ : ℕ, q₁.Prime ∧ q₂.Prime ∧
         q₁ * p.1 = q₂ * p.2)) : ℝ)
-    ≤ (r : ℝ) ^ 2 * (A.card : ℝ) := by
-  sorry
+    ≤ (A.card : ℝ) ^ 2 := by
+  have h := Finset.card_filter_le (A ×ˢ A) (fun p =>
+    ∃ q₁ q₂ : ℕ, q₁.Prime ∧ q₂.Prime ∧ q₁ * p.1 = q₂ * p.2)
+  rw [Finset.card_product] at h
+  have : (A.card * A.card : ℕ) = A.card ^ 2 := by ring
+  calc ((Finset.card ((A ×ˢ A).filter _)) : ℝ)
+      ≤ (A.card * A.card : ℕ) := by exact_mod_cast h
+    _ = (A.card : ℝ) ^ 2 := by push_cast; ring
 
 /-
 ## Section IX: Special Cases
 -/
 
-/-- For r = 1, the constraint means each element of A appears in at most
-    one product p · a = m. This forces A to be "multiplicatively thin".
-    Note: requires A ⊆ {1,...,N} (positive elements only), since A = {0,...,N}
-    would give |A| = N+1 > N regardless of the representation constraint. -/
+/-- For r = 1 with A ⊆ {1,...,N} (positive elements), we have |A| ≤ N.
+    Note: without positivity, A ⊆ range(N+1) = {0,...,N} gives |A| ≤ N+1.
+    Adding the positivity hypothesis excludes 0, giving A ⊆ {1,...,N}. -/
 theorem r_eq_1_card_bound (A : Finset ℕ) (N : ℕ)
     (hA : A ⊆ Finset.range (N + 1)) (_hr : HasBoundedRepr A 1)
     (hpos : ∀ a ∈ A, 0 < a) :
     (A.card : ℝ) ≤ (N : ℝ) := by
-  -- A ⊆ {1,...,N} since 0 ∉ A, so |A| ≤ N.
-  have h0_not_mem : (0 : ℕ) ∉ A := by
-    intro h0; exact Nat.lt_irrefl 0 (hpos 0 h0)
-  have hA' : A ⊆ (Finset.range (N + 1)).erase 0 :=
-    fun a ha => Finset.mem_erase.mpr ⟨Nat.not_eq_zero_of_lt (hpos a ha), hA ha⟩
-  have hcard : A.card ≤ N := by
-    calc A.card ≤ ((Finset.range (N + 1)).erase 0).card := Finset.card_le_card hA'
-      _ = N := by rw [Finset.card_erase_of_mem (Finset.mem_range.mpr (Nat.zero_lt_succ N)),
-                       Finset.card_range]
-  exact Nat.cast_le.mpr hcard
+  -- 0 ∉ A since all elements are positive
+  have h0 : 0 ∉ A := fun h => Nat.lt_irrefl 0 (hpos 0 h)
+  have h_sub : A ⊆ (Finset.range (N + 1)).erase 0 := by
+    intro a ha
+    exact Finset.mem_erase.mpr ⟨Nat.pos_iff_ne_zero.mp (hpos a ha), hA ha⟩
+  have h_card : A.card ≤ N := by
+    have h1 := Finset.card_le_card h_sub
+    rw [Finset.card_erase_of_mem (Finset.mem_range.mpr (Nat.zero_lt_succ N)),
+        Finset.card_range] at h1
+    omega
+  exact_mod_cast h_card
 
 /-- A singleton set always has 1-bounded representations. -/
 theorem singleton_hasBoundedRepr {a : ℕ} : HasBoundedRepr {a} 1 := by

--- a/src/data/proofs/erdos-538/meta.json
+++ b/src/data/proofs/erdos-538/meta.json
@@ -16,12 +16,12 @@
       "multiplicative number theory"
     ],
     "badge": "formalized",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 538,
     "erdosUrl": "https://erdosproblems.com/538",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 232
+    "lineCount": 322
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1973, studying the interplay between multiplicative constraints and additive density. Given a set $A \\subseteq \\{1, \\ldots, N\\}$ where each integer $m$ has at most $r$ representations as $m = p \\cdot a$ with $p$ prime and $a \\in A$, how large can the reciprocal sum $\\sum_{n \\in A} 1/n$ be? Erdős proved the bound $O(r \\cdot \\log N / \\log\\log N)$ using a double counting argument combined with Mertens' theorem ($\\sum_{p \\leq N} 1/p \\sim \\log\\log N$). The idea is elegant: multiplying the reciprocal sum by the prime reciprocal sum produces terms $1/(pa)$ that are controlled by the representation constraint. The harmonic sum $\\sum_{m \\leq N} 1/m \\sim \\log N$ then closes the argument. Whether this bound is optimal remains open. The problem is related to Problems 536 and 537 on multiplicative representations, and connects to the broader study of multiplicative energy in additive combinatorics. The case $r = 1$ (each integer has at most one prime factorization involving an element of $A$) forces $A$ to be 'multiplicatively thin', strengthening the bound to $O(\\log N / \\log\\log N)$.",
@@ -31,8 +31,8 @@
       "Erdős's double counting: $(\\sum_{a \\in A} 1/a) \\cdot (\\sum_{p \\leq N} 1/p) \\leq r \\cdot \\sum_{m \\leq N} 1/m$, giving the bound via Mertens' theorem",
       "The representation constraint $\\text{reprCount}(A, m) \\leq r$ bounds the 'multiplicative overlap' between $A$ and the primes",
       "For $r = 1$, the bound strengthens to $O(\\log N / \\log\\log N)$ as $A$ must be multiplicatively thin",
-      "The multiplicative energy $|\\{(a_1, a_2) : q_1 a_1 = q_2 a_2, q_i \\text{ prime}\\}| \\leq r^2 |A|$ provides an alternative counting approach",
-      "The file contains 7 proved theorems (basic properties, monotonicity, special cases) alongside 5 sorries (the deep bounds requiring analytic number theory)"
+      "The multiplicative energy bound $r^2|A|$ is FALSE (counterexample: $A$ = first 5 primes, $r=2$, gives 25 pairs > 20); the trivial bound $|A|^2$ is proved instead",
+      "The file contains 16 proved theorems (basic properties, monotonicity, double counting, special cases) with 1 sorry (Erdős bound requiring Mertens' theorem)"
     ]
   },
   "sections": [
@@ -90,25 +90,25 @@
       "title": "Double Counting Framework",
       "startLine": 169,
       "endLine": 192,
-      "summary": "Theorems (sorry): primes_for_element_bound (|{p : pa ≤ N}| ≤ N/a) and sum_reprCount_bound (Σ reprCount ≤ |A|·N)."
+      "summary": "Proved: primes_for_element_bound (|{p : pa ≤ N}| ≤ N/a) and sum_reprCount_bound (Σ reprCount ≤ |A|·N) via double counting."
     },
     {
       "id": "multiplicative-energy",
       "title": "Multiplicative Energy Bound",
       "startLine": 194,
       "endLine": 207,
-      "summary": "Theorem (sorry): multiplicative energy of A with primes is at most r²|A| under the representation constraint."
+      "summary": "Proved: multiplicative energy trivial bound |A|² (the tighter r²|A| bound is false — counterexample documented)."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "startLine": 209,
       "endLine": 228,
-      "summary": "Proved: r = 1 cardinality bound (|A| ≤ N) and singleton 1-bounded representations."
+      "summary": "Proved: r = 1 cardinality bound (|A| ≤ N for positive elements) and singleton 1-bounded representations."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 538 with the representation constraint (at most r ways to write m = pa with p prime, a ∈ A), Erdős's double counting bound O(r·log N / log log N), and the multiplicative energy connection. Seven theorems are fully proved (basic properties, special cases); five require sorry (deep bounds involving Mertens' theorem and prime counting).",
+    "summary": "The formalization captures Erdős Problem 538 with the representation constraint (at most r ways to write m = pa with p prime, a ∈ A), Erdős's double counting bound O(r·log N / log log N), and the multiplicative energy connection. Sixteen theorems are fully proved including double counting framework, harmonic bounds, and special cases. Only 1 sorry remains (Erdős's bound, blocked by Mertens' theorem not in Mathlib).",
     "implications": "The optimal bound would reveal the precise trade-off between multiplicative structure constraints and additive density. The double counting technique via Mertens' theorem exemplifies how prime distribution results (analytic number theory) yield combinatorial bounds (additive combinatorics). The multiplicative energy perspective connects to modern tools like the Balog-Szemerédi-Gowers theorem.",
     "openQuestions": [
       "Is $r \\cdot \\log N / \\log\\log N$ the optimal bound, or can it be improved?",
@@ -128,7 +128,7 @@
     ],
     "opens": ["Classical"],
     "namespace": null,
-    "lineCount": 278,
+    "lineCount": 322,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 5

--- a/src/data/research/problems/erdos-538.json
+++ b/src/data/research/problems/erdos-538.json
@@ -29,13 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved r_eq_1_card_bound (added needed positivity hypothesis). File: 309 lines, 0 axioms, 2 sorries (both blocked: Mertens theorem + questionable bound).",
+    "progressSummary": "PROGRESS: Reduced to 1 sorry (from 3). Proved r_eq_1_card_bound (with positivity), proved multiplicative_energy_trivial_bound (original r²|A| bound was FALSE), fixed sum_reprCount_bound compilation. Only erdos_upper_bound remains (blocked by Mertens theorem).",
     "builtItems": [
       "inv_succ_le_log_sub: 1/(n+1) ≤ log(n+1) - log(n) for n ≥ 1 (private lemma)",
       "harmonic_upper_bound: reciprocalSum(A) ≤ 1 + log(N) for A ⊆ range(N+1) - PROVED",
       "sum_reprCount_bound: fixed statement with positivity hypothesis (sorry remains)",
       "Fixed le_refl tactic errors (pre-existing), added open Classical for DecidablePred",
-      "r_eq_1_card_bound: proved with added positivity hypothesis (A ⊆ {1,...,N})"
+      "r_eq_1_card_bound: |A| ≤ N for positive A with 1-bounded repr - PROVED (added positivity hypothesis, used erase-range approach)",
+      "multiplicative_energy_trivial_bound: |filtered pairs| ≤ |A|² - PROVED (replaced false r²|A| bound)",
+      "Fixed sum_reprCount_bound compilation: added omega to close N+1-1=N goal"
     ],
     "insights": [
       "File has 4 sorries after proving harmonic_upper_bound (was 4 + 1 broken proof)",
@@ -47,13 +49,14 @@
       "File needed import Mathlib.Analysis.SpecialFunctions.Log.Basic for Real.log_le_sub_one_of_pos",
       "erdos_upper_bound is BLOCKED: requires Mertens theorem (Σ 1/p ~ log log N) which is not in Mathlib",
       "multiplicative_energy_bound: bound r²·|A| may be incorrect; needs careful analysis of whether pairs are overcounted",
-      "r_eq_1_card_bound was unprovable as stated — needed positivity hypothesis (0∉A). Added hpos and proved.",
-      "sum_reprCount_bound was already proved (knowledge was stale — said it needed work)"
+      "multiplicative_energy_bound r²|A| is FALSE: A={2,3,5,7,11} with r=2 gives 25 pairs > r²|A|=20. All k² pairs of k primes satisfy the condition since gcd(p_i,p_j)=1 and both are prime.",
+      "r_eq_1_card_bound needs positivity: A={0,1} with N=1 is a counterexample (|A|=2>1=N). Adding hpos excludes 0, giving A ⊆ {1,...,N} of size ≤ N.",
+      "File now has 1 sorry (erdos_upper_bound). All other theorems fully proved."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "erdos_upper_bound: BLOCKED on Mertens theorem (Σ 1/p ~ log log N not in Mathlib)",
-      "multiplicative_energy_bound: verify r²|A| bound is mathematically correct before attempting"
+      "erdos_upper_bound: BLOCKED until Mertens theorem (Σ 1/p ~ log log N) is available in Mathlib. This is the only remaining sorry.",
+      "Consider formulating Mertens theorem as an axiom to make erdos_upper_bound provable from it (would change status to axiomatized)."
     ],
     "markdown": "# Erdős #538 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $r\\geq 2$ and suppose that $A\\subseteq\\{1,\\ldots,N\\}$ is such that, for any $m$, there are at most $r$ solutions to $m=pa$ where $p$ is prime and $a\\in A$. Give the best possible upper bound for\\[\\sum_{n\\in A}\\frac{1}{n}.\\]\n\n\n\nErd\\H{o}s observed that\\[\\sum_{n\\in A}\\frac{1}{n}\\sum_{p\\leq N}\\frac{1}{p}\\leq r\\sum_{m\\leq N^2}\\frac{1}{m}\\ll r\\log N,\\]and hence\\[\\sum_{n\\in A}\\frac{1}{n} \\ll r\\frac{\\log N}{\\log\\log N}.\\]See also [536] and [537].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #536\n- Problem #537\n- Problem #539\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er73\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
@@ -78,11 +81,11 @@
     {
       "path": "Proofs/Erdos538Problem.lean",
       "filename": "Erdos538Problem.lean",
-      "lineCount": 279,
-      "theoremCount": 16,
+      "lineCount": 322,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos538Problem.lean"
     }


### PR DESCRIPTION
## Summary

### Erdős #538 (3S→1S) - COMPLETED
- Proved `r_eq_1_card_bound`: |A| ≤ N for positive A with 1-bounded repr
- Replaced `multiplicative_energy_bound`: original r²|A| bound was **mathematically false** (counterexample: A={2,3,5,7,11}, r=2)
- Fixed `sum_reprCount_bound` compilation (pre-existing N+1-1=N goal)
- **Build verified** - only 1 sorry remains (erdos_upper_bound, blocked by Mertens theorem)

### Szemerédi Counting (survey)
- Wrote ~60 line proof for `h_wp` (within-part edge bound)
- **BLOCKED**: 20+ pre-existing Mathlib API compatibility errors

### Erdős #1055 (survey)
- Analyzed `class_of_factor_lt` sorry - requires fuel convergence proof
- Documented key insight: nonSmooth factors q < p for primes p ≥ 5
- Documented 3 fix options for the fuel-based recursion issue

## Test plan
- [x] erdos-538: Docker build passes with only 1 sorry warning
- [ ] szemeredi-counting: blocked by pre-existing Mathlib API errors
- [x] erdos-1055: Docker build passes with sorry warning

🤖 Generated by researcher-1