### PR TITLE
Enrich birthday-problem + brouwer-fixed-point: cross-refs, axiom fix, mathContext

### DIFF
--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -193,6 +193,26 @@
       "targetId": "birthday-problem-oq-02",
       "relationship": "extended-by",
       "description": "Sub-entry exploring further birthday problem variants and generalizations"
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Both are classic combinatorial problems counting structured functions: the birthday problem counts injective functions (all-distinct assignments) while derangements count fixed-point-free permutations. Both use complement counting — $P(\\text{match}) = 1 - P(\\text{all distinct})$ parallels the inclusion-exclusion for derangement count $D_n = n! \\sum_{k=0}^{n} (-1)^k/k!$"
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "uses",
+      "description": "The birthday formula $P(n) = 1 - \\prod_{i=0}^{n-1}(1 - i/365)$ is a complement-counting argument, the simplest form of inclusion-exclusion. For the generalized birthday problem (counting exact number of collisions), full inclusion-exclusion over overlapping pair events is needed"
+    },
+    {
+      "targetId": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\approx \\sqrt{2\\pi n}(n/e)^n$ enables the Poisson approximation $P(n) \\approx 1 - e^{-n^2/(2 \\cdot 365)}$, which gives the asymptotic threshold $n \\approx \\sqrt{2 \\cdot 365 \\cdot \\ln 2} \\approx 22.5$ for the 50% crossover — explaining why 23 is the exact threshold"
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "uses",
+      "description": "The binomial coefficient $\\binom{n}{2} = n(n-1)/2$ counts the number of person-pairs, which is the key to the birthday 'paradox': 23 people yield 253 pairs, and each pair has probability $1/365$ of matching. The expected number of matching pairs is $\\binom{n}{2}/365$"
     }
   ],
   "relatedProofs": [
@@ -201,7 +221,11 @@
     "ballot-problem",
     "buffons-needle",
     "binomial-theorem",
-    "arithmetic-series"
+    "arithmetic-series",
+    "derangements",
+    "inclusion-exclusion",
+    "stirling-formula",
+    "combinations-formula"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary

**brouwer-fixed-point** (deep enrichment + axiom integrity fix):
- **CRITICAL FIX**: status "verified" → "axiomatized", badge "original" → "axiom", axiomCount 0 → 2 (file has `no_retraction_axiom` + `retraction_construction`)
- Added mathContext to all 7 sections with Lean theorem names and LaTeX
- Updated section summaries with actual line ranges from Lean file
- Added leanFile metadata (8 imports, 5 theorems, 6 definitions, 2 axioms)
- Added prerequisites array, expanded mathlibDependencies (1→6)
- Added cross-refs: schauder-fixed-point, poincare-conjecture, mean-value-theorem
- Made openQuestions specific (homology formalization, ray construction, Sperner, Kakutani)

**birthday-problem** (cross-reference enrichment):
- Added cross-ref to derangements (complement counting parallel)
- Added cross-ref to inclusion-exclusion (complement counting foundation)
- Added cross-ref to stirling-formula (Poisson approximation gives √(2·365·ln2) threshold)
- Added cross-ref to combinations-formula (C(n,2) pair counting explains the 'paradox')

## Test plan
- [x] JSON validity verified (python3 json.load) for all modified files
- [x] All cross-reference targets verified to exist in gallery
- [x] Axiom integrity verified: brouwer Lean file has 2 `axiom` declarations → status corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)