### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -4821,11 +4821,12 @@
     },
     {
       "slug": "brouwer-fixed-point-oq-02-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-21T17:10:19.192Z",
-      "status": "active",
-      "lastUpdate": "2026-03-22T03:02:07.238Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T00:45:41.601Z",
+      "completed": "2026-03-23T00:45:41.600Z"
     },
     {
       "slug": "buffons-needle-oq-02-oq-01",
@@ -5315,6 +5316,126 @@
       "started": "2026-03-22T22:32:23.162Z",
       "status": "active",
       "lastUpdate": "2026-03-22T22:32:23.162Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-05",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.641Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.641Z"
+    },
+    {
+      "slug": "angle-trisection-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.641Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.641Z"
+    },
+    {
+      "slug": "basel-problem-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.641Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.641Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "buffons-needle-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "cantors-theorem-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "cayley-hamilton-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "chinese-remainder-non-coprime-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "collatz-structured-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "continuum-hypothesis-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T00:45:41.642Z"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary
- Sync research listings and enrichment tracker data
- Update annotations for abel-ruffini, fermat-two-squares, fundamental-theorem-algebra, infinitude-primes
- Update research problem metadata (ballot-problem, brouwer-fixed-point, erdos-461, erdos-5, erdos-538, szemeredi)
- Add 4 new research problem entries to registry

Automated deploy sync.