### PR TITLE
Enrich batch: 5 entries - annotation coverage improvements

### DIFF
--- a/src/data/proofs/lagrange-theorem/annotations.json
+++ b/src/data/proofs/lagrange-theorem/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-imports",
+    "proofId": "lagrange-theorem",
+    "range": {"startLine": 1, "endLine": 6},
+    "type": "concept",
+    "title": "Mathlib Group Theory Imports",
+    "content": "Six Mathlib imports provide the group theory infrastructure: `Coset.Basic` supplies left/right cosets and the quotient $G/H$; `Index` provides $[G:H]$ and `Subgroup.index_mul_card`; `OrderOfElement` gives `orderOf` and its properties; `SpecificGroups.Cyclic` provides `IsCyclic` and the classification of cyclic groups; `Data.Nat.Totient` provides Euler's $\\phi$ function for the Euler's theorem application; `Tactic` provides `omega`, `norm_num`, and other automation.\n\nThe imports reflect the theorem's reach: Lagrange's theorem connects subgroup structure (cosets, index) to element order and number theory (Fermat, Euler).",
+    "mathContext": "The import chain: `Coset.Basic` ($G/H$, coset partition) $\\to$ `Index` ($[G:H]$, $|G| = |H| \\cdot [G:H]$) $\\to$ `OrderOfElement` ($\\text{ord}(g) \\mid |G|$) $\\to$ `Cyclic` (cyclic group classification) $\\to$ `Totient` ($\\phi(n)$, Euler's theorem).",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib", "cosets", "subgroup index", "element order"],
+    "prerequisites": ["Lean 4 import system", "Mathlib group theory"]
+  },
+  {
     "id": "ann-intro",
     "proofId": "lagrange-theorem",
     "range": {"startLine": 8, "endLine": 55},


### PR DESCRIPTION
## Enrichment batch

### abel-ruffini
- Added Part II bridge annotation (lines 51-57) with Kummer theory context

### angle-trisection  
- Added Part III irreducibility + Part VII other impossibilities annotations
- Coverage: 20 annotations (was 16)

### fundamental-theorem-algebra
- Added 4 annotations: imports, examples, FTA section, significance
- Fixed anchor types for monic-factorization and quadratic-case

### pythagorean-theorem
- Added 4 annotations: Euclidean setup, perpendicular def, RightTriangle, applications

### lagrange-theorem
- Added imports annotation with Mathlib group theory chain

All cross-references verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)