### PR TITLE
Enrich: deep annotation rewrites for cantor-diagonalization, halting-problem

### DIFF
--- a/src/data/proofs/cantor-diagonalization/annotations.json
+++ b/src/data/proofs/cantor-diagonalization/annotations.json
@@ -1,197 +1,247 @@
 [
   {
+    "id": "ann-module-docstring",
+    "proofId": "cantor-diagonalization",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "context",
+    "title": "Module Overview: Cantor's Diagonalization",
+    "content": "Imports basic Mathlib modules (`Logic.Function.Basic`, `Data.Set.Function`, `Tactic`) and provides a comprehensive module docstring covering: (1) the theorem statement — no surjection from $\\mathbb{N}$ to infinite binary sequences; (2) the approach — original diagonal construction without relying on non-trivial Mathlib theorems; (3) historical context — Cantor's 1891 publication that revolutionized understanding of infinity. Opens the `CantorDiagonalization` namespace.",
+    "mathContext": "Cantor's theorem (1891): $|\\mathbb{N}| < |2^{\\mathbb{N}}| = |\\mathbb{R}|$. The proof is entirely constructive: given any enumeration, we exhibit a missing sequence.",
+    "significance": "context",
+    "relatedConcepts": [
+      "uncountability",
+      "set theory",
+      "infinity"
+    ],
+    "prerequisites": [
+      "Lean 4 module system",
+      "basic logic"
+    ]
+  },
+  {
     "id": "ann-binary-seq",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 5,
-      "endLine": 37
+      "startLine": 41,
+      "endLine": 45
     },
     "type": "definition",
     "title": "Binary Sequences as Functions",
-    "content": "A **binary sequence** is modeled as a function from natural numbers to booleans: `Nat -> Bool`. Each sequence assigns either `true` (1) or `false` (0) to every position.\n\nThese correspond to real numbers in $[0, 1]$ via binary expansion: the sequence $(b_0, b_1, b_2, \\ldots)$ represents $0.b_0b_1b_2\\ldots$ in binary.",
-    "mathContext": "$s : \\mathbb{N} \\to \\{0, 1\\}$\n\nFor example, the sequence $1, 0, 1, 0, 1, 0, \\ldots$ represents $0.101010\\ldots_2 = \\frac{2}{3}$ in decimal.",
+    "content": "`BinarySeq` is defined as `ℕ → Bool` — an infinite binary sequence assigns `true` or `false` to every natural number position. This models real numbers in $[0,1]$ via binary expansion: the sequence $(b_0, b_1, b_2, \\ldots)$ represents $0.b_0b_1b_2\\ldots$ in binary. The type `ℕ → Bool` is isomorphic to $2^{\\mathbb{N}}$, the power set of $\\mathbb{N}$.",
+    "mathContext": "$\\text{BinarySeq} := \\mathbb{N} \\to \\text{Bool} \\cong 2^{\\mathbb{N}} \\cong [0,1]$. Example: $(1,0,1,0,\\ldots)$ represents $0.1010\\ldots_2 = 2/3$.",
     "significance": "key",
     "relatedConcepts": [
       "real numbers",
       "binary representation",
-      "function types"
+      "function types",
+      "power set"
+    ],
+    "prerequisites": [
+      "functions in Lean 4",
+      "Bool type"
     ]
   },
   {
     "id": "ann-diagonal-def",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 5,
-      "endLine": 37
+      "startLine": 47,
+      "endLine": 53
     },
     "type": "definition",
-    "title": "The Diagonal Function",
-    "content": "Given any enumeration $f$ of binary sequences, we construct a **diagonal sequence** by:\n\n1. Look at position $n$ of sequence $n$\n2. Flip that bit (0 becomes 1, 1 becomes 0)\n\nThis ensures our new sequence differs from $f(n)$ at position $n$ for every $n$.",
-    "mathContext": "$\\text{diagonal}(f)(n) = \\neg f(n)(n)$\n\nVisually:\n```\nf(0): [0] 1  1  0  ...\nf(1):  1 [0] 0  1  ...\nf(2):  0  0 [1] 0  ...\nDiag:  1  1  0  ...  (flipped diagonal)\n```",
+    "title": "The Diagonal Construction",
+    "content": "Given an enumeration $f : \\mathbb{N} \\to \\text{BinarySeq}$, the diagonal function constructs a new sequence by flipping the $n$-th bit of the $n$-th sequence: `diagonal f n = !(f n n)`. This ensures the constructed sequence differs from $f(n)$ at position $n$ for every $n$ — the core idea of Cantor's argument.",
+    "mathContext": "$\\text{diagonal}(f)(n) = \\neg f(n)(n)$. The bit flip guarantees $\\text{diagonal}(f) \\neq f(n)$ for all $n$.",
     "significance": "key",
     "relatedConcepts": [
       "diagonal argument",
-      "self-reference",
-      "construction"
+      "boolean negation",
+      "self-reference"
+    ],
+    "prerequisites": [
+      "boolean negation",
+      "function application"
     ]
   },
   {
     "id": "ann-diagonal-differs",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 5,
-      "endLine": 37
+      "startLine": 55,
+      "endLine": 62
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Diagonal Differs at Each Position",
-    "content": "The key lemma: our constructed diagonal sequence differs from $f(n)$ specifically at position $n$.\n\nSince `diagonal f n = !(f n n)`, we have `diagonal f n != f n n` by the fact that `!b != b` for any boolean.\n\nThis one-line observation is the heart of the proof.",
-    "mathContext": "$\\text{diagonal}(f)(n) \\neq f(n)(n)$\n\nBecause $\\neg b \\neq b$ for any boolean $b$.",
+    "content": "The key lemma: the diagonal sequence differs from $f(n)$ at position $n$. The proof unfolds the diagonal definition and uses boolean case analysis (`cases f n n <;> simp`) — since `!true ≠ true` and `!false ≠ false`, both cases close immediately. This one-line observation is the technical heart of the argument.",
+    "mathContext": "$\\text{diagonal}(f)(n) \\neq f(n)(n)$ because $\\neg b \\neq b$ for any boolean $b$.",
     "significance": "key",
     "relatedConcepts": [
-      "boolean negation",
-      "pointwise difference"
+      "boolean case analysis",
+      "pointwise difference",
+      "unfold tactic"
+    ],
+    "prerequisites": [
+      "Bool.not_eq_self",
+      "cases tactic"
     ]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 5,
-      "endLine": 37
+      "startLine": 64,
+      "endLine": 86
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Cantor's Diagonalization Theorem",
-    "content": "**For any function $f : \\mathbb{N} \\to \\text{BinarySeq}$, there exists a sequence $s$ not in the range of $f$.**\n\nIn other words, no enumeration of binary sequences can be complete. There will always be a sequence we missed.",
-    "mathContext": "$\\forall f : \\mathbb{N} \\to 2^{\\mathbb{N}}, \\exists s \\in 2^{\\mathbb{N}}, \\forall n, f(n) \\neq s$",
+    "content": "The main theorem: for any $f : \\mathbb{N} \\to \\text{BinarySeq}$, there exists a sequence $s$ not in the range of $f$. The proof uses `diagonal f` as the existential witness, then for each $n$ assumes $f(n) = \\text{diagonal}(f)$ for contradiction. `congrFun` extracts the pointwise equality $f(n)(n) = \\text{diagonal}(f)(n)$, which contradicts `diagonal_differs`.",
+    "mathContext": "$\\forall f : \\mathbb{N} \\to 2^{\\mathbb{N}},\\, \\exists s \\in 2^{\\mathbb{N}},\\, \\forall n,\\, f(n) \\neq s$. Witness: $s = \\text{diagonal}(f)$.",
     "significance": "key",
     "relatedConcepts": [
       "surjectivity",
       "uncountability",
-      "cardinality"
-    ]
-  },
-  {
-    "id": "ann-proof-construct",
-    "proofId": "cantor-diagonalization",
-    "range": {
-      "startLine": 5,
-      "endLine": 37
-    },
-    "type": "tactic",
-    "title": "Constructing the Witness",
-    "content": "We exhibit the diagonal sequence as our witness. The `use` tactic provides this existential witness.\n\nNow we must prove this sequence differs from every $f(n)$.",
-    "mathContext": "Take $s = \\text{diagonal}(f)$, then show $\\forall n, f(n) \\neq s$.",
-    "significance": "key",
-    "relatedConcepts": [
+      "congrFun"
+    ],
+    "prerequisites": [
+      "diagonal_differs",
       "existential witnesses",
-      "constructive proof"
+      "congrFun"
     ]
   },
   {
-    "id": "ann-proof-differ",
+    "id": "ann-no-surjection",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 5,
-      "endLine": 37
+      "startLine": 88,
+      "endLine": 98
     },
-    "type": "tactic",
-    "title": "Deriving the Contradiction",
-    "content": "Suppose for contradiction that $f(n) = \\text{diagonal}(f)$ for some $n$.\n\nThen at position $n$: $f(n)(n) = \\text{diagonal}(f)(n)$.\n\nBut $\\text{diagonal}(f)(n) = \\neg f(n)(n)$ by definition.\n\nSo $f(n)(n) = \\neg f(n)(n)$, which is impossible for any boolean.\n\nContradiction! Therefore $f(n) \\neq \\text{diagonal}(f)$ for all $n$.",
-    "mathContext": "$f(n) = s \\Rightarrow f(n)(n) = s(n) = \\neg f(n)(n)$ — contradiction.",
-    "significance": "key",
-    "relatedConcepts": [
-      "proof by contradiction",
-      "function equality",
-      "congruence"
-    ]
-  },
-  {
-    "id": "ann-corollary",
-    "proofId": "cantor-diagonalization",
-    "range": {
-      "startLine": 47,
-      "endLine": 47
-    },
-    "type": "theorem",
-    "title": "Reals Are Uncountable",
-    "content": "The classic formulation: there is no surjective function from $\\mathbb{N}$ to the binary sequences (equivalently, to $\\mathbb{R}$).\n\nThis follows immediately from Cantor's theorem: if $f$ were surjective, every sequence would be in its range, but we just showed one isn't.",
-    "mathContext": "$\\nexists f : \\mathbb{N} \\to 2^{\\mathbb{N}}$ such that $f$ is surjective.\n\nEquivalently: $|\\mathbb{N}| < |\\mathbb{R}|$",
-    "significance": "key",
+    "type": "technique",
+    "title": "No Surjection from ℕ to Binary Sequences",
+    "content": "Reformulation: there is no surjective function from $\\mathbb{N}$ to `BinarySeq`. Assumes a surjection $(f, h_f)$ exists, uses `cantor_diagonalization` to get a sequence $s$ not in the range of $f$, then uses surjectivity to find $n$ with $f(n) = s$ — a contradiction.",
+    "mathContext": "$\\neg\\exists f : \\mathbb{N} \\to 2^{\\mathbb{N}},\\, f \\text{ surjective}$. Proof by contradiction using the main theorem.",
+    "significance": "supporting",
     "relatedConcepts": [
       "surjectivity",
-      "cardinality comparison",
-      "uncountable sets"
+      "Function.Surjective",
+      "proof by contradiction"
+    ],
+    "prerequisites": [
+      "cantor_diagonalization",
+      "Function.Surjective"
     ]
   },
   {
-    "id": "ann-corollary-proof",
+    "id": "ann-reals-uncountable",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 49,
-      "endLine": 51
+      "startLine": 100,
+      "endLine": 107
     },
-    "type": "tactic",
-    "title": "Proof of Uncountability",
-    "content": "Assume for contradiction that some surjective $f$ exists.\n\nBy Cantor's theorem, there exists $s$ with $f(n) \\neq s$ for all $n$.\n\nBut surjectivity says every $s$ equals some $f(n)$.\n\nThese contradict: $s = f(n)$ but also $f(n) \\neq s$.",
-    "mathContext": "$f$ surjective $\\Rightarrow \\forall s, \\exists n, f(n) = s$\n\nCantor: $\\exists s, \\forall n, f(n) \\neq s$\n\nContradiction!",
+    "type": "technique",
+    "title": "The Reals Are Uncountable",
+    "content": "The classic formulation: the real numbers are uncountable. Defined as a direct wrapper around `no_surjection_nat_to_binary`, since binary sequences correspond to reals in $[0,1]$ via binary expansion, and $[0,1]$ has the same cardinality as $\\mathbb{R}$.",
+    "mathContext": "$|\\mathbb{N}| < |\\mathbb{R}|$. Since $|[0,1]| = |\\mathbb{R}|$ and $|\\mathbb{N} \\to \\text{Bool}| = |[0,1]|$, no surjection $\\mathbb{N} \\to \\mathbb{R}$ exists.",
     "significance": "key",
     "relatedConcepts": [
-      "proof by contradiction",
-      "negating existence"
+      "uncountable sets",
+      "cardinality",
+      "continuum"
+    ],
+    "prerequisites": [
+      "no_surjection_nat_to_binary",
+      "binary expansion bijection"
     ]
   },
   {
     "id": "ann-powerset",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 55,
-      "endLine": 62
+      "startLine": 109,
+      "endLine": 133
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Cantor's Power Set Theorem",
-    "content": "The general version: for **any** set $S$, there is no surjection from $S$ to its power set $\\mathcal{P}(S)$.\n\nThis proves $|S| < |\\mathcal{P}(S)|$ for all sets, establishing an infinite hierarchy of cardinalities.\n\nFor finite sets: $|\\mathcal{P}(S)| = 2^{|S|}$. For infinite sets: the power set is strictly larger.",
-    "mathContext": "$\\forall S, \\nexists f : S \\to \\mathcal{P}(S)$ surjective.\n\nCorollary: $|S| < |\\mathcal{P}(S)| < |\\mathcal{P}(\\mathcal{P}(S))| < \\ldots$",
+    "content": "The general form: for **any** type $S$, there is no surjection from $S$ to $\\text{Set}\\, S$. The proof constructs the diagonal set $D = \\{x \\in S : x \\notin f(x)\\}$ and uses surjectivity to find $a$ with $f(a) = D$. Then $a \\in D \\iff a \\notin f(a) = D$, giving a contradiction by `by_cases`. This establishes an infinite hierarchy: $|S| < |\\mathcal{P}(S)| < |\\mathcal{P}(\\mathcal{P}(S))| < \\cdots$.",
+    "mathContext": "$\\forall S,\\, \\neg\\exists f : S \\to \\mathcal{P}(S)$ surjective. Diagonal set: $D = \\{x : x \\notin f(x)\\}$. If $D = f(a)$: $a \\in D \\iff a \\notin D$ — contradiction.",
     "significance": "key",
     "relatedConcepts": [
-      "power sets",
+      "power set",
       "cardinality hierarchy",
-      "beth numbers"
+      "beth numbers",
+      "Russell's paradox"
+    ],
+    "prerequisites": [
+      "Set membership",
+      "by_cases tactic",
+      "Function.Surjective"
     ]
   },
   {
-    "id": "ann-powerset-diag",
+    "id": "ann-russell",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 55,
-      "endLine": 62
+      "startLine": 135,
+      "endLine": 151
     },
     "type": "insight",
-    "title": "The Diagonal Set",
-    "content": "The diagonal construction for sets: $D = \\{x \\in S : x \\notin f(x)\\}$.\n\nThis is the set of elements that are *not* in their own image under $f$.\n\nThis is exactly Russell's paradox applied to $f$! If $f$ were surjective, $D = f(a)$ for some $a$. But then: is $a \\in D$?",
-    "mathContext": "$D = \\{x : x \\notin f(x)\\}$\n\nIf $D = f(a)$:\n- $a \\in D \\iff a \\notin f(a) = D$ — contradiction!",
+    "title": "Connection to Russell's Paradox",
+    "content": "The diagonal set $D = \\{x : x \\notin f(x)\\}$ is structurally identical to Russell's paradox: if $f = \\text{id}$, then $D = \\{x : x \\notin x\\}$, the 'set of all sets that don't contain themselves'. In naive set theory this leads to contradiction. In Lean's type theory (and ZFC), the paradox is resolved by stratification: sets can't contain themselves because of universe levels (type theory) or the axiom of foundation (ZFC).",
+    "mathContext": "$D = \\{x : x \\notin f(x)\\}$. If $f = \\text{id}$: $D = \\{x : x \\notin x\\}$. Then $D \\in D \\iff D \\notin D$ — Russell's paradox (1901).",
     "significance": "key",
     "relatedConcepts": [
       "Russell's paradox",
-      "self-reference",
-      "fixed points"
+      "type theory stratification",
+      "axiom of foundation",
+      "self-reference"
+    ],
+    "prerequisites": [
+      "naive set theory",
+      "type universes"
     ]
   },
   {
     "id": "ann-visualization",
     "proofId": "cantor-diagonalization",
     "range": {
-      "startLine": 66,
-      "endLine": 86
+      "startLine": 153,
+      "endLine": 168
     },
     "type": "insight",
-    "title": "Visualizing the Diagonal",
-    "content": "The comment shows the diagonal argument visually. Imagine an infinite table where row $n$ is sequence $f(n)$.\n\nThe diagonal elements are $f(0)(0), f(1)(1), f(2)(2), \\ldots$\n\nFlipping each gives a sequence that differs from:\n- Row 0 at column 0\n- Row 1 at column 1\n- Row $n$ at column $n$\n\nSo the flipped diagonal cannot be any row in the table!",
-    "mathContext": "```\n     0  1  2  3  4  ...\n0:  [0] 1  1  0  1  ...\n1:   1 [0] 0  1  1  ...\n2:   0  0 [1] 0  0  ...\n3:   1  1  0 [0] 1  ...\nDiag: 1  1  0  1  ...  <- not in table\n```",
-    "significance": "key",
+    "title": "Visual Diagonal Argument",
+    "content": "An ASCII visualization of the diagonal argument. An infinite table shows sequences $f(0), f(1), \\ldots$ as rows, with diagonal elements $f(n)(n)$ highlighted in brackets. The flipped diagonal takes each bracketed element and negates it, producing a sequence that provably differs from every row at the diagonal position.",
+    "mathContext": "The diagonal elements $f(0)(0), f(1)(1), f(2)(2), \\ldots$ form a sequence. Flipping each gives $\\neg f(0)(0), \\neg f(1)(1), \\ldots$, which differs from row $n$ at column $n$.",
+    "significance": "supporting",
     "relatedConcepts": [
-      "infinite matrices",
       "diagonal extraction",
-      "visualization"
+      "infinite matrices",
+      "visual proof"
+    ],
+    "prerequisites": [
+      "binary sequences",
+      "matrix layout"
+    ]
+  },
+  {
+    "id": "ann-verification",
+    "proofId": "cantor-diagonalization",
+    "range": {
+      "startLine": 170,
+      "endLine": 175
+    },
+    "type": "context",
+    "title": "Verification and Namespace Close",
+    "content": "Type-checks all four main theorems via `#check`: `cantor_diagonalization`, `no_surjection_nat_to_binary`, `reals_uncountable`, and `cantor_powerset`. Closes the `CantorDiagonalization` namespace.",
+    "mathContext": "All four theorems verified: the main diagonalization, no-surjection reformulation, uncountability of reals, and the general power set theorem.",
+    "significance": "context",
+    "relatedConcepts": [
+      "type checking",
+      "#check command"
+    ],
+    "prerequisites": [
+      "Lean 4 meta-commands"
     ]
   }
 ]

--- a/src/data/proofs/halting-problem/annotations.json
+++ b/src/data/proofs/halting-problem/annotations.json
@@ -1,265 +1,220 @@
 [
   {
-    "id": "ann-zero-imports",
+    "id": "ann-module-docstring",
     "proofId": "halting-problem",
     "range": {
       "startLine": 1,
       "endLine": 31
     },
-    "type": "insight",
-    "title": "Zero External Dependencies",
-    "content": "This proof uses **no imports whatsoever** - not even Mathlib. It relies only on Lean's built-in types (`Nat`, `Bool`) and core tactics.\n\nThis demonstrates that the halting problem's undecidability is a purely logical result, requiring no sophisticated mathematical machinery.",
-    "mathContext": "The proof needs only:\n- Natural numbers $\\mathbb{N}$ (for program codes)\n- Booleans $\\{\\text{true}, \\text{false}\\}$ (for halt/loop)\n- Boolean negation $\\neg$",
-    "significance": "key",
+    "type": "context",
+    "title": "Module Overview: The Halting Problem",
+    "content": "Module docstring covering: (1) the theorem — no algorithm can determine whether an arbitrary program halts; (2) the approach — zero external imports, complete self-contained proof using diagonalization with only Lean's built-in `Nat` and `Bool`; (3) proof techniques — diagonalization, contradiction, boolean case analysis; (4) historical context — Turing's 1936 proof establishing fundamental limits on computability. The proof requires no Mathlib imports whatsoever, demonstrating that undecidability is a purely logical result.",
+    "mathContext": "Turing (1936): there is no computable function $H: \\mathbb{N} \\times \\mathbb{N} \\to \\{0,1\\}$ such that $H(p,i) = 1$ iff program $p$ halts on input $i$.",
+    "significance": "context",
     "relatedConcepts": [
-      "self-contained proofs",
-      "minimal axioms",
-      "pure logic"
+      "computability theory",
+      "Turing machines",
+      "diagonalization"
+    ],
+    "prerequisites": [
+      "basic logic",
+      "Lean 4 built-in types"
     ]
   },
   {
-    "id": "ann-halting-oracle",
+    "id": "ann-definitions",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 36,
-      "endLine": 36
+      "startLine": 33,
+      "endLine": 44
     },
     "type": "definition",
-    "title": "Halting Oracle",
-    "content": "A **halting oracle** is a hypothetical function that takes two natural numbers - a program code $p$ and an input $i$ - and returns whether program $p$ halts on input $i$.\n\nWe model this as `Nat -> Nat -> Bool`. The claim is that no such correct oracle can exist.",
-    "mathContext": "$H : \\mathbb{N} \\times \\mathbb{N} \\to \\{\\text{true}, \\text{false}\\}$\n\n$H(p, i) = \\text{true}$ means \"program $p$ halts on input $i$\"",
+    "title": "Oracle, Behavior, and Diagonal Definitions",
+    "content": "Three key definitions: `HaltingOracle := Nat → Nat → Bool` models a hypothetical halting decider (maps program $p$ and input $i$ to halt/loop). `Behavior := Nat → Bool` represents a program's input-output behavior. `diagonalBehavior H n = !(H n n)` constructs the adversarial behavior that flips the oracle's prediction for program $n$ running on itself.",
+    "mathContext": "$H(p,i) \\in \\{\\text{true},\\text{false}\\}$ predicts halting. The diagonal: $d(n) = \\neg H(n,n)$ — if the oracle says program $n$ halts on $n$, the diagonal loops, and vice versa.",
     "significance": "key",
     "relatedConcepts": [
       "oracle machines",
-      "decision problems",
-      "Turing machines"
-    ]
-  },
-  {
-    "id": "ann-behavior",
-    "proofId": "halting-problem",
-    "range": {
-      "startLine": 39,
-      "endLine": 39
-    },
-    "type": "definition",
-    "title": "Program Behavior",
-    "content": "A **behavior** is a function from inputs to booleans, representing whether a program halts on each possible input.\n\nEvery program has a behavior (even if we can't compute it). The diagonal construction will create a behavior that no oracle can correctly predict.",
-    "mathContext": "$b : \\mathbb{N} \\to \\{\\text{true}, \\text{false}\\}$\n\n$b(n) = \\text{true}$ means the program halts on input $n$",
-    "significance": "key",
-    "relatedConcepts": [
-      "program semantics",
-      "extensional behavior"
-    ]
-  },
-  {
-    "id": "ann-diagonal-behavior",
-    "proofId": "halting-problem",
-    "range": {
-      "startLine": 39,
-      "endLine": 39
-    },
-    "type": "definition",
-    "title": "The Diagonal Behavior",
-    "content": "The **diagonal behavior** is the key construction. Given an oracle $H$:\n\n1. For input $n$, ask the oracle: \"Does program $n$ halt on input $n$?\"\n2. Return the **opposite** of what the oracle says\n\nThis creates a behavior that deliberately contradicts the oracle's self-referential predictions.",
-    "mathContext": "$\\text{diagonal}(H)(n) = \\neg H(n, n)$\n\nIf $H$ says program $n$ halts on itself, diagonal loops.\nIf $H$ says program $n$ loops on itself, diagonal halts.",
-    "significance": "key",
-    "relatedConcepts": [
-      "diagonal argument",
       "self-reference",
-      "negation"
-    ]
-  },
-  {
-    "id": "ann-key-insight",
-    "proofId": "halting-problem",
-    "range": {
-      "startLine": 43,
-      "endLine": 44
-    },
-    "type": "insight",
-    "title": "Self-Reference Plus Negation",
-    "content": "The undecidability arises from combining two elements:\n\n1. **Self-reference**: We ask about program $n$ running on input $n$\n2. **Negation**: We do the opposite of what the oracle predicts\n\nThis same pattern appears in Cantor's diagonal argument, Godel's incompleteness, and Russell's paradox.",
-    "mathContext": "The \"liar's paradox\" structure:\n\"This program does the opposite of what you predict.\"\n\nNo prediction can be correct!",
-    "significance": "key",
-    "relatedConcepts": [
-      "liar paradox",
-      "self-reference",
-      "fixed-point theorems"
+      "boolean negation"
+    ],
+    "prerequisites": [
+      "Nat and Bool types",
+      "function definitions"
     ]
   },
   {
     "id": "ann-diagonal-differs",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 48,
+      "startLine": 46,
       "endLine": 54
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Diagonal Differs from Oracle",
-    "content": "**Key Lemma**: The diagonal behavior always differs from the oracle's prediction at self-application points.\n\nFor any program code $n$:\n$\\text{diagonal}(H)(n) \\neq H(n, n)$\n\nThis follows immediately from the fact that $\\neg b \\neq b$ for any boolean.",
-    "mathContext": "$\\text{diagonal}(H)(n) = \\neg H(n, n) \\neq H(n, n)$\n\nBecause $\\neg \\text{true} = \\text{false} \\neq \\text{true}$\nand $\\neg \\text{false} = \\text{true} \\neq \\text{false}$",
+    "content": "Key lemma: the diagonal behavior always differs from the oracle at self-application points. `diagonal_differs H n` proves `diagonalBehavior H n ≠ H n n`. The proof unfolds the definition, introduces an equality hypothesis, then uses boolean case analysis (`cases hc : H n n`) — in both cases, `simp` derives a contradiction since `!true ≠ true` and `!false ≠ false`.",
+    "mathContext": "$\\text{diagonal}(H)(n) = \\neg H(n,n) \\neq H(n,n)$ since $\\neg b \\neq b$ for any $b \\in \\{\\text{true},\\text{false}\\}$.",
     "significance": "key",
     "relatedConcepts": [
-      "boolean negation",
+      "boolean case analysis",
+      "unfold tactic",
       "pointwise difference"
+    ],
+    "prerequisites": [
+      "diagonalBehavior definition",
+      "Bool.not_eq_self"
     ]
   },
   {
-    "id": "ann-no-oracle-theorem",
+    "id": "ann-no-halting-oracle",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 48,
-      "endLine": 54
+      "startLine": 56,
+      "endLine": 87
     },
-    "type": "theorem",
-    "title": "No Correct Halting Oracle Exists",
-    "content": "**Main Theorem**: For any oracle $H$ and any code $c$ that implements the diagonal behavior, the oracle $H$ cannot correctly predict $c$'s behavior on input $c$.\n\nIf the oracle were correct, then:\n- $H(c, c) = \\text{true}$ would mean $c$ halts on $c$\n- But $c$ implements diagonal, so $c(c) = \\neg H(c,c) = \\text{false}$\n\nContradiction! (And similarly for the false case.)",
-    "mathContext": "$\\forall H, \\forall c,$ if $c$ implements $\\text{diagonal}(H)$, then\n$H(c, c) = \\text{true} \\Rightarrow c(c) = \\text{false}$ (contradiction)\n$H(c, c) = \\text{false} \\Rightarrow c(c) = \\text{true}$ (contradiction)",
+    "type": "technique",
+    "title": "No Halting Oracle Exists",
+    "content": "The main theorem: for any oracle $H$ and any code $c$ implementing the diagonal behavior, $H$ cannot correctly predict $c$'s behavior on input $c$. The proof splits on `H c c`: if `true`, then `diagonalBehavior H c = !true = false`, so by the hypothesis `h_loops`, `H c c = false` — contradicting `H c c = true`. The `false` case is symmetric. Each case uses `simp [h]` to derive the boolean contradiction.",
+    "mathContext": "If $c$ implements $\\text{diagonal}(H)$: $H(c,c) = \\text{true} \\Rightarrow d(c) = \\text{false} \\Rightarrow H(c,c) = \\text{false}$. Contradiction. Similarly for $H(c,c) = \\text{false}$.",
     "significance": "key",
     "relatedConcepts": [
       "proof by contradiction",
-      "case analysis"
-    ]
-  },
-  {
-    "id": "ann-proof-case-true",
-    "proofId": "halting-problem",
-    "range": {
-      "startLine": 59,
-      "endLine": 87
-    },
-    "type": "tactic",
-    "title": "Case: Oracle Says Halt",
-    "content": "**Case 1**: Suppose $H(c, c) = \\text{true}$ (oracle predicts halt).\n\nThen by definition of diagonal:\n$\\text{diagonal}(H)(c) = \\neg H(c, c) = \\text{false}$\n\nBut the hypothesis says $c$ correctly implements diagonal, so $c$ halting means diagonal returns true.\n\nContradiction: $\\text{false} = \\text{true}$.",
-    "mathContext": "$H(c,c) = \\text{true}$\n$\\Rightarrow \\text{diagonal}(H)(c) = \\text{false}$\n$\\Rightarrow c(c)$ loops\n$\\Rightarrow H(c,c)$ should be $\\text{false}$ (contradiction)",
-    "significance": "key",
-    "relatedConcepts": [
       "case analysis",
       "simp tactic"
+    ],
+    "prerequisites": [
+      "diagonalBehavior definition",
+      "boolean case analysis"
     ]
   },
   {
-    "id": "ann-proof-case-false",
+    "id": "ann-halting-undecidable",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 59,
-      "endLine": 87
+      "startLine": 89,
+      "endLine": 108
     },
-    "type": "tactic",
-    "title": "Case: Oracle Says Loop",
-    "content": "**Case 2**: Suppose $H(c, c) = \\text{false}$ (oracle predicts loop).\n\nThen by definition of diagonal:\n$\\text{diagonal}(H)(c) = \\neg H(c, c) = \\text{true}$\n\nBut the hypothesis says $c$ correctly implements diagonal, so diagonal returning true means $c$ halts.\n\nContradiction: $H$ said $c$ loops but $c$ halts.",
-    "mathContext": "$H(c,c) = \\text{false}$\n$\\Rightarrow \\text{diagonal}(H)(c) = \\text{true}$\n$\\Rightarrow c(c)$ halts\n$\\Rightarrow H(c,c)$ should be $\\text{true}$ (contradiction)",
-    "significance": "key",
-    "relatedConcepts": [
-      "case analysis",
-      "exhaustive cases"
-    ]
-  },
-  {
-    "id": "ann-iff-formulation",
-    "proofId": "halting-problem",
-    "range": {
-      "startLine": 59,
-      "endLine": 87
-    },
-    "type": "theorem",
+    "type": "technique",
     "title": "Logical Equivalence Formulation",
-    "content": "A cleaner restatement: there is no oracle-code pair $(H, c)$ where the oracle's prediction matches the diagonal behavior in both directions.\n\nThe biconditional $H(c,c) = \\text{true} \\iff \\text{diagonal}(H)(c) = \\text{true}$ cannot hold, because the diagonal is defined to be the negation.",
-    "mathContext": "$\\neg\\big[(H(c,c) = \\text{true} \\iff \\text{diagonal}(c) = \\text{true}) \\land$\n$(H(c,c) = \\text{false} \\iff \\text{diagonal}(c) = \\text{false})\\big]$",
-    "significance": "key",
+    "content": "Cleaner biconditional formulation: no oracle-code pair $(H, c)$ can satisfy both $H(c,c) = \\text{true} \\iff \\text{diagonal}(H)(c) = \\text{true}$ AND $H(c,c) = \\text{false} \\iff \\text{diagonal}(H)(c) = \\text{false}$. The proof unfolds `diagonalBehavior` and splits on `H c c`, using the biconditional hypothesis to derive `!true = true` or `!false = false`, both absurd.",
+    "mathContext": "$\\neg\\big[(H(c,c) = 1 \\iff d(c) = 1) \\wedge (H(c,c) = 0 \\iff d(c) = 0)\\big]$ where $d = \\text{diagonal}(H)$.",
+    "significance": "supporting",
     "relatedConcepts": [
+      "biconditional",
       "logical equivalence",
-      "biconditional"
+      "boolean contradiction"
+    ],
+    "prerequisites": [
+      "diagonalBehavior definition",
+      "Iff elimination"
     ]
   },
   {
     "id": "ann-self-halting",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 92,
-      "endLine": 108
+      "startLine": 110,
+      "endLine": 125
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "No Self-Halting Decider",
-    "content": "**Alternative Formulation**: No function can correctly determine its own halting behavior on its own encoding.\n\nFor any proposed decider $H : \\mathbb{N} \\to \\text{Bool}$ (where $H(n)$ means \"program $n$ halts on $n$\"), there exists a behavior that $H$ gets wrong everywhere.",
-    "mathContext": "$\\forall H : \\mathbb{N} \\to \\text{Bool},$\n$\\exists b : \\mathbb{N} \\to \\text{Bool},$\n$\\forall n : \\mathbb{N},$\n$b(n) \\neq H(n)$",
+    "content": "Alternative formulation focusing on self-application: for any $H : \\mathbb{N} \\to \\text{Bool}$ predicting whether program $n$ halts on input $n$, there exists a behavior $b$ that $H$ gets wrong everywhere. The witness is `fun n => !H n`, and the proof uses the same boolean case analysis to show `!H n ≠ H n` for all $n$.",
+    "mathContext": "$\\forall H : \\mathbb{N} \\to \\text{Bool},\\, \\exists b : \\mathbb{N} \\to \\text{Bool},\\, \\forall n,\\, b(n) \\neq H(n)$. Witness: $b(n) = \\neg H(n)$.",
     "significance": "key",
     "relatedConcepts": [
       "self-reference",
-      "fixed points"
+      "existential witness",
+      "refine tactic"
+    ],
+    "prerequisites": [
+      "boolean negation",
+      "existential quantifier"
     ]
   },
   {
     "id": "ann-summary-theorem",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 133,
+      "startLine": 131,
       "endLine": 142
     },
-    "type": "theorem",
-    "title": "Halting Problem Undecidable",
-    "content": "**Final Summary**: For any halting oracle $H$, the diagonal program provides an explicit counterexample.\n\nThe diagonal behavior exists (we constructed it), and it differs from every oracle prediction at the self-application point. Therefore no oracle can be correct.",
-    "mathContext": "$\\forall H : \\text{HaltingOracle},$\n$\\exists b : \\text{Behavior},$\n$\\forall c : \\mathbb{N},$\n$\\neg(H(c,c) = b(c))$\n\nWitness: $b = \\text{diagonal}(H)$",
+    "type": "technique",
+    "title": "Summary: Halting Problem Undecidable",
+    "content": "Final summary theorem: for any halting oracle $H$, the diagonal behavior provides an explicit counterexample. Uses `diagonalBehavior H` as the existential witness and `diagonal_differs` to close the proof. This is the most direct formulation: the diagonal construction itself is the witness of undecidability.",
+    "mathContext": "$\\forall H,\\, \\exists b,\\, \\forall c,\\, \\neg(H(c,c) = b(c))$. Witness: $b = \\text{diagonal}(H)$, proved via `diagonal_differs`.",
     "significance": "key",
     "relatedConcepts": [
       "undecidability",
-      "explicit counterexamples"
+      "explicit counterexample",
+      "diagonal_differs"
+    ],
+    "prerequisites": [
+      "diagonalBehavior",
+      "diagonal_differs"
     ]
   },
   {
     "id": "ann-connections",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 133,
-      "endLine": 142
+      "startLine": 144,
+      "endLine": 149
     },
-    "type": "concept",
-    "title": "Connections to Other Results",
-    "content": "The diagonal technique appears across mathematics and logic:\n\n- **Cantor** (1891): No surjection $\\mathbb{N} \\to 2^{\\mathbb{N}}$ - same construction!\n- **Godel** (1931): No complete consistent theory - \"this statement is unprovable\"\n- **Russell** (1901): No set of all sets - the set of sets not containing themselves\n- **Tarski** (1936): Truth is undefinable - \"this statement is false\"",
-    "mathContext": "All share the pattern: self-reference + negation = paradox/impossibility",
+    "type": "insight",
+    "title": "Connections to Other Diagonal Results",
+    "content": "Comment documenting the diagonal technique's appearances across mathematics: Cantor's 1891 argument (no surjection $\\mathbb{N} \\to 2^{\\mathbb{N}}$), Gödel's 1931 incompleteness ('this statement is unprovable'), Russell's 1901 paradox (set of all sets not containing themselves), and Tarski's 1936 undefinability of truth ('this statement is false'). All share the pattern: self-reference + negation = impossibility.",
+    "mathContext": "The universal pattern: given a predicate $P$ and a way to self-refer, the diagonal $d(n) = \\neg P(n,n)$ cannot be in the range of any enumeration.",
     "significance": "key",
     "relatedConcepts": [
-      "Cantor diagonal",
-      "Godel incompleteness",
+      "Cantor diagonalization",
+      "Gödel incompleteness",
       "Russell paradox",
       "Tarski undefinability"
+    ],
+    "prerequisites": [
+      "diagonal argument",
+      "mathematical logic"
     ]
   },
   {
     "id": "ann-visualization",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 133,
-      "endLine": 142
+      "startLine": 151,
+      "endLine": 166
     },
     "type": "insight",
-    "title": "Visualizing the Diagonal",
-    "content": "Imagine an infinite table where row $n$ shows whether program $n$ halts on each input.\n\nThe diagonal consists of the self-application entries: does program 0 halt on 0? Does program 1 halt on 1? Etc.\n\nFlipping each diagonal entry gives a behavior that differs from every row at the critical position. If this flipped diagonal could be program $d$, then row $d$ would have to differ from itself at column $d$ - impossible!",
-    "mathContext": "```\n       Input 0  Input 1  Input 2  ...\nProg 0:  [halt]  loop     halt    ...\nProg 1:  loop    [halt]   halt    ...\nProg 2:  halt    halt     [loop]  ...\n  ...\nFlipped: loop    loop     halt    ...\n```\nFlipped diagonal can't be any row!",
-    "significance": "key",
+    "title": "Visual Diagonal Argument",
+    "content": "ASCII visualization of the diagonalization applied to programs. An infinite table shows program $n$'s behavior on each input, with diagonal entries $H(n,n)$ forming the self-application sequence. Flipping the diagonal produces a behavior differing from every row at the critical position — if encoded as program $d$, row $d$ would need to differ from itself at column $d$, which is impossible.",
+    "mathContext": "The table: row $n$ = behavior of program $n$. Diagonal = $H(0,0), H(1,1), H(2,2), \\ldots$. Flipped diagonal differs from row $n$ at column $n$ by construction.",
+    "significance": "supporting",
     "relatedConcepts": [
       "infinite matrices",
       "diagonal extraction",
       "visual proof"
+    ],
+    "prerequisites": [
+      "diagonal argument concept"
     ]
   },
   {
-    "id": "ann-practical-implications",
+    "id": "ann-verification",
     "proofId": "halting-problem",
     "range": {
-      "startLine": 1,
-      "endLine": 31
+      "startLine": 168,
+      "endLine": 173
     },
-    "type": "concept",
-    "title": "Practical Implications",
-    "content": "The halting problem's undecidability has real-world consequences:\n\n1. **Static Analysis**: No tool can detect all infinite loops or bugs\n2. **Compilers**: Can't always optimize away dead code\n3. **Verification**: Fully automatic program verification is impossible\n4. **Security**: Can't perfectly detect all malware behaviors\n\nEvery static analysis tool must either miss some problems or report false positives.",
-    "mathContext": "Rice's Theorem generalizes this: ANY non-trivial semantic property of programs is undecidable.",
-    "significance": "key",
+    "type": "context",
+    "title": "Verification via #check",
+    "content": "Type-checks all five main theorems: `diagonal_differs`, `no_halting_oracle`, `halting_undecidable`, `no_self_halting_decider`, and `halting_problem_undecidable`. Note: this file has no namespace (no `end` statement), so all definitions are at the top level.",
+    "mathContext": "Five theorems verified, covering the key lemma, three formulations of the halting problem, and the summary theorem.",
+    "significance": "context",
     "relatedConcepts": [
-      "Rice's theorem",
-      "static analysis",
-      "program verification"
+      "type checking",
+      "#check command"
+    ],
+    "prerequisites": [
+      "Lean 4 meta-commands"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
Deep verification and rewrite of annotation line ranges for two foundational entries:

- **cantor-diagonalization**: All 11 original annotations pointed to wrong line ranges (6 pointed to the same docstring range 5-37). Complete rewrite with correct ranges, valid types, and prerequisites on all annotations.
- **halting-problem**: All 15 original annotations had wrong ranges (3 shared range 59-87, 3 shared 133-142). Reduced to 10 clean non-overlapping annotations covering the full file.

Both entries scored quality 100 by the heuristic but had fundamentally broken annotations that would render the gallery's code-annotation mapping completely wrong.

## Test plan
- [x] JSON validation passes
- [x] All annotation ranges verified against actual Lean proof files line-by-line
- [x] No overlapping annotations
- [x] All annotations have prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)