### PR TITLE
Enrich batch: 10 entries - cross-references, references, meta

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -407,6 +407,27 @@
       "year": "1870",
       "venue": "Gauthier-Villars, Paris",
       "note": "The first systematic treatise on group theory and its application to polynomial equations — made Galois's posthumous manuscripts accessible to a wider audience and established the modern framework for studying permutation groups and solvability"
+    },
+    {
+      "authors": "Abel, Niels Henrik",
+      "title": "Beweis der Unmöglichkeit, algebraische Gleichungen von höheren Graden als dem vierten allgemein aufzulösen",
+      "year": "1826",
+      "venue": "Journal für die reine und angewandte Mathematik (Crelle's Journal), vol. 1, pp. 65–84",
+      "note": "Abel's expanded and refined proof of quintic unsolvability, published in the inaugural volume of Crelle's Journal — the first rigorous treatment, superseding his compressed 1824 pamphlet"
+    },
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Sur le nombre des valeurs qu'une fonction peut acquérir",
+      "year": "1815",
+      "venue": "Journal de l'École Polytechnique, vol. 10, pp. 1–28",
+      "note": "Foundational results on permutation groups, including the theorem that a primitive subgroup of S_p containing a p-cycle equals S_p — key precursor to the group-theoretic analysis of polynomial solvability"
+    },
+    {
+      "authors": "Neumann, Peter M.",
+      "title": "The Mathematical Writings of Évariste Galois",
+      "year": "2011",
+      "venue": "European Mathematical Society",
+      "note": "Definitive modern edition of Galois's complete mathematical writings with detailed commentary — includes the famous letter to Chevalier, the two Académie memoirs, and previously unpublished fragments"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
@@ -110,7 +110,34 @@
       "Commutative ring axioms and integral domains",
       "Lean 4 well-founded recursion and termination proofs"
     ],
-    "lineCount": 200
+    "lineCount": 200,
+    "leanFile": {
+      "lineCount": 200,
+      "structureCount": 0,
+      "axiomCount": 0,
+      "theoremCount": 11,
+      "lemmaCount": 0,
+      "defCount": 2,
+      "imports": [
+        "Mathlib.Data.Nat.GCD.Basic",
+        "Mathlib.Data.Int.GCD",
+        "Mathlib.Tactic"
+      ]
+    },
+    "relatedProblems": [
+      {
+        "id": "bezout-identity-oq-02-oq-02",
+        "relationship": "Parent formalization: Euclid's lemma generalized to commutative rings. This entry adds the constructive quotient computation"
+      },
+      {
+        "id": "bezout-identity-oq-02",
+        "relationship": "Grandparent formalization: the OQ about whether Euclid's lemma can be generalized and made constructive"
+      },
+      {
+        "id": "bezout-identity",
+        "relationship": "Root formalization: Bézout's identity au + bv = gcd(a,b), the foundation this entire chain builds upon"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "The **extended Euclidean algorithm** has roots in Euclid's *Elements* (~300 BCE, Book VII, Propositions 1-2), where the alternating subtraction method computes GCDs. The extension to computing Bézout coefficients was first published by **Bachet de Méziriac** in *Problèmes plaisants et délectables* (1624), well before Bézout's own treatise (1779). The Indian mathematician **Aryabhata** (5th century CE) independently described a similar algorithm (*kuṭṭaka*) for solving linear Diophantine equations.\n\nThe algorithm has $O(\\log \\min(a,b))$ bit complexity, making it one of the oldest known efficient algorithms. Knuth (1997) gives a thorough modern treatment, and the algorithm is foundational in computational number theory: it underlies RSA key generation (computing modular inverses), the Chinese Remainder Theorem, and continued fraction expansions.\n\nWhile Euclid's lemma (if $\\gcd(a,b) = 1$ and $a \\mid bc$, then $a \\mid c$, Elements VII.30) is classical, its **constructive content** — actually computing the quotient $c/a$ — is often overlooked in standard treatments. This formalization makes the construction explicit: given Bézout coefficients $u, v$ and a divisibility witness $k$, the quotient $q = uc + vk$ is extracted by a simple algebraic formula valid in any commutative ring. The core formula $q = uc + vk$ (where $ua + vb = 1$ and $bc = ak$) works in any commutative ring, and is instantiated over $\\mathbb{N}/\\mathbb{Z}$ via the extended GCD.",
@@ -262,20 +289,38 @@
       "targetId": "wilsons-theorem",
       "relationship": "related",
       "description": "Wilson's theorem $(p-1)! \\equiv -1 \\pmod{p}$ can be proved by pairing each $a \\in (ℤ/pℤ)^*$ with its modular inverse $a^{-1}$. The extended Euclidean algorithm constructively computes these inverses — the pairing argument is constructive when the inverse computation is"
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Gauss's quadratic reciprocity law concerns when $a$ is a square modulo $p$. The extended Euclidean algorithm provides the modular inverse needed to compute Legendre symbols and reduce quadratic congruences — the constructive machinery here underpins computational approaches to reciprocity"
+    },
+    {
+      "targetId": "primitive-roots",
+      "relationship": "related",
+      "description": "Primitive roots generate the cyclic group $(\\mathbb{Z}/p\\mathbb{Z})^*$. The Bézout coefficient $u$ with $ua + pv = 1$ gives $a^{-1} \\bmod p$, directly connecting to the group structure: computing discrete logarithms and testing primitivity require modular inverse operations"
+    },
+    {
+      "targetId": "bezout-identity-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling open question from the Bézout identity chain, exploring different extensions of the core identity — together these entries map the space of constructive number-theoretic algorithms derivable from the extended Euclidean algorithm"
     }
   ],
   "relatedProofs": [
     "bezout-identity",
     "bezout-identity-oq-02",
+    "bezout-identity-oq-02-oq-02",
+    "bezout-identity-oq-03",
     "chinese-remainder-constructive",
+    "chinese-remainder-non-coprime",
     "infinitude-primes",
     "fermat-two-squares",
-    "bezout-identity-oq-02-oq-02",
     "gcd-algorithm",
     "fundamental-arithmetic",
     "euler-totient",
-    "chinese-remainder-non-coprime",
-    "wilsons-theorem"
+    "wilsons-theorem",
+    "quadratic-reciprocity",
+    "primitive-roots"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -84,7 +84,32 @@
       "Set.Infinite for stating infinitary conjectures",
       "Decidable arithmetic: interval_cases and decide tactics"
     ],
-    "lineCount": 143
+    "lineCount": 143,
+    "leanFile": {
+      "lineCount": 143,
+      "structureCount": 0,
+      "axiomCount": 3,
+      "theoremCount": 6,
+      "lemmaCount": 0,
+      "defCount": 1,
+      "imports": [
+        "Mathlib.Data.Nat.Prime.Basic",
+        "Mathlib.Data.Nat.Factorial.Basic",
+        "Mathlib.Data.Set.Basic",
+        "Mathlib.Data.Finset.Basic",
+        "Mathlib.Tactic"
+      ]
+    },
+    "relatedProblems": [
+      {
+        "id": "erdos-1057",
+        "relationship": "Sister Erdős problem about prime-related counting; both concern infinitude of special prime sets"
+      },
+      {
+        "id": "erdos-68",
+        "relationship": "Both involve factorial-prime interactions from different angles"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "This problem appears as Problem A2 in Guy's *Unsolved Problems in Number Theory* [Gu04], attributed to Erdős circa 1980. It probes the interaction between two fundamental sequences in number theory — primes and factorials — through subtraction.\n\nThe factorials $1, 2, 6, 24, 120, 720, \\ldots$ grow super-exponentially (Stirling: $k! \\sim \\sqrt{2\\pi k}(k/e)^k$), so only $O(\\log n / \\log \\log n)$ factorials lie below $n$. This means the factorial-subtraction condition is mild: for $n \\sim 10^6$, only 9 factorials need checking. The known examples are $p = 101$ (factorials to check: $1, 2, 6, 24$) and $p = 211$ (factorials: $1, 2, 6, 24, 120$). The prime $89$ fails because $89 - 6 = 83$ is prime. These are listed in OEIS A064152.\n\nThe probabilistic heuristic is compelling: each $p - k!$ is prime independently with probability $\\sim 1/\\ln p$ (by the prime number theorem). With only $\\sim \\log p / \\log \\log p$ values to check, the probability that *all* subtractions are composite is $(1 - 1/\\ln p)^{O(\\log p / \\log \\log p)} \\to 1$ as $p \\to \\infty$. This suggests that not only are there infinitely many such primes, but *almost all* large primes satisfy the property — yet no rigorous proof exists.\n\nErdős suggested a potentially easier variant: find infinitely many $n$ in $(l!, (l+1)!]$ whose prime factors all exceed $l$ and whose factorial subtractions are all composite. This removes the requirement that $n$ itself be prime, possibly making the problem more tractable via sieve methods. The connection to smooth numbers (integers with only small prime factors) links this variant to the Dickman function $\\rho(u)$ and the theory of friable integers.",
@@ -202,6 +227,11 @@
       "targetId": "prime-number-theorem",
       "relationship": "foundational",
       "description": "The probabilistic heuristic for this problem relies on the PNT: the probability that a random integer near $p$ is prime is $\\sim 1/\\ln p$. With $O(\\log p / \\log \\log p)$ factorial subtractions to check, the expected number of prime subtractions is $O(\\log p / (\\log p \\cdot \\log \\log p)) \\to 0$, suggesting almost all large primes satisfy the property"
+    },
+    {
+      "targetId": "erdos-1058",
+      "relationship": "related",
+      "description": "Both problems concern the interplay between primes and factorials: #1058 studies prime divisors of $n!+1$ between consecutive primes, while #1059 studies primality of $p - k!$. Both exploit the super-exponential growth of factorials to reduce infinite problems to finite case analysis"
     }
   ],
   "relatedProofs": [
@@ -209,6 +239,7 @@
     "wilsons-theorem",
     "bertrands-postulate",
     "erdos-1057",
+    "erdos-1058",
     "erdos-68",
     "erdos-728-factorial-divisibility",
     "fundamental-arithmetic",

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -91,7 +91,17 @@
       "Asymptotic density of primes"
     ],
     "axiomCount": 2,
-    "lineCount": 162
+    "lineCount": 162,
+    "relatedProblems": [
+      {
+        "id": "erdos-1057",
+        "relationship": "Nearby Erdős problem about prime counting; both concern infinitude of special prime sets"
+      },
+      {
+        "id": "erdos-1059",
+        "relationship": "Sister problem about prime-factorial interactions; both use decidable arithmetic for computational verification of small cases"
+      }
+    ]
   },
   "sections": [
     {
@@ -212,6 +222,21 @@
       "targetId": "bertrands-postulate",
       "relationship": "related",
       "description": "Bertrand's postulate guarantees primes in every interval $(n, 2n)$; similar density arguments underlie the heuristic prediction that Form A primes have positive density among all primes"
+    },
+    {
+      "targetId": "erdos-1059",
+      "relationship": "related",
+      "description": "Both concern infinitude of primes with special arithmetic properties: #1059 requires $p - k!$ composite for all $k! < p$, while #1065 requires $p - 1$ to have restricted prime factorization. Both use decidable arithmetic for computational verification and probabilistic heuristics for the infinitude prediction"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The prime number theorem $\\pi(x) \\sim x/\\ln x$ underlies the density heuristic: the probability that $2^k q + 1$ is prime is $\\sim 1/\\ln(2^k q)$, and summing over valid $(k, q)$ pairs predicts the count of Form A primes up to $x$"
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Quadratic reciprocity governs when $a$ is a square modulo $p$, closely tied to primitive roots: Artin's conjecture (referenced in the formalization) predicts infinitely many primes have a given primitive root, and the factorization structure of $p-1$ determines the primitive root structure via quadratic residues"
     }
   ],
   "relatedProofs": [
@@ -219,10 +244,13 @@
     "primitive-roots",
     "dirichlets-theorem",
     "erdos-1057",
+    "erdos-1059",
     "wilsons-theorem",
     "euler-totient",
     "infinitude-primes",
-    "bertrands-postulate"
+    "bertrands-postulate",
+    "prime-number-theorem",
+    "quadratic-reciprocity"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -92,7 +92,32 @@
       "Threshold functions and extremal combinatorics",
       "Filter-based limits in Lean (Filter.Tendsto)"
     ],
-    "lineCount": 201
+    "lineCount": 201,
+    "leanFile": {
+      "lineCount": 201,
+      "structureCount": 0,
+      "axiomCount": 13,
+      "theoremCount": 3,
+      "lemmaCount": 0,
+      "defCount": 10,
+      "imports": [
+        "Mathlib"
+      ]
+    },
+    "relatedProblems": [
+      {
+        "id": "erdos-1083",
+        "relationship": "Related distinct distances problem in 2D; this entry generalizes to higher dimensions"
+      },
+      {
+        "id": "erdos-1082",
+        "relationship": "Unit distance problem in combinatorial geometry; both concern distance structure of point configurations"
+      },
+      {
+        "id": "erdos-1088",
+        "relationship": "Sister problem on distance sets in higher dimensions with related threshold functions"
+      }
+    ]
   },
   "sections": [
     {
@@ -208,6 +233,11 @@
       "targetId": "ramseys-theorem",
       "relationship": "related",
       "description": "The distinct distances threshold $g_d(n)$ is a Ramsey-type quantity: it asks for the minimum set size guaranteeing a structured subset (many distinct distances). The polynomial lower bound $g_d(n) \\gg d^{n-1}$ parallels Ramsey-type tower growth phenomena in combinatorics"
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "related",
+      "description": "The Borsuk-Ulam theorem is a key topological tool in combinatorial geometry: it implies that any continuous map $S^n \\to \\mathbb{R}^n$ identifies antipodal points. In distance problems, topological methods complement algebraic and combinatorial approaches — the Borsuk conjecture on partitions of sets with diameter constraints is closely tied to distance set questions in high dimensions"
     }
   ],
   "conclusion": {
@@ -227,7 +257,8 @@
     "combinations-formula",
     "erdos-1082",
     "erdos-1088",
-    "ramseys-theorem"
+    "ramseys-theorem",
+    "borsuk-ulam"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -52,7 +52,30 @@
         "note": "Improved lower bound to Ω(n^{1.778}), surpassing the probabilistic barrier"
       }
     ],
-    "lineCount": 374
+    "lineCount": 374,
+    "leanFile": {
+      "lineCount": 374,
+      "structureCount": 0,
+      "axiomCount": 6,
+      "theoremCount": 20,
+      "lemmaCount": 0,
+      "defCount": 8,
+      "imports": [
+        "Mathlib.Tactic",
+        "Mathlib.Data.Finset.Basic",
+        "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      ]
+    },
+    "relatedProblems": [
+      {
+        "id": "erdos-3",
+        "relationship": "Erdős's density conjecture for arithmetic progressions; both concern the structure of APs in dense integer sets"
+      },
+      {
+        "id": "roth-theorem-k3",
+        "relationship": "Roth's theorem guarantees 3-term APs in dense sets; this problem counts distinct common differences of such APs"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Erdős posed this problem at the 1989 Great Western Number Theory problem session in Asilomar, California. He asked: given an n-element set of integers, how many distinct common differences can three-term arithmetic progressions have? The Erdős-Spencer probabilistic argument (using random subsets of {1,...,N}) showed that Ω(n^{3/2}) is achievable, and Erdős conjectured this is the correct order. Jean Bourgain later connected the problem to his work on the Kakeya conjecture in geometric measure theory, reformulating it as a question about restricted sums and differences. In 1999, Nets Katz and Terence Tao established the best known upper bound of O(n^{11/6}) using incidence geometry techniques. Matan Lemm improved the lower bound in 2015 past n^{1.778}, and in 2025 Google DeepMind's AlphaEvolve achieved a marginal further improvement via automated search. The problem remains open, with its resolution expected to have implications for the Kakeya conjecture.",
@@ -175,14 +198,32 @@
       "targetId": "szemeredi-regularity",
       "relationship": "related",
       "description": "The regularity lemma provides pseudorandom decompositions used in counting arithmetic progressions. The 3-AP counting approach underlying Roth's theorem and its extensions connects to the common-differences question through energy increment arguments"
+    },
+    {
+      "targetId": "szemeredi-counting",
+      "relationship": "related",
+      "description": "The counting lemma quantifies substructure (including APs) in regular pairs. Counting 3-APs by common difference is the key to bounding $|D(A)|$ — the counting lemma provides the tool for extracting structured counts from pseudorandom decompositions"
+    },
+    {
+      "targetId": "szemeredi-full",
+      "relationship": "related",
+      "description": "The full Szemerédi theorem guarantees $k$-term APs in dense sets for all $k$. This problem specializes to $k = 3$ but strengthens the conclusion: not just existence of 3-APs, but a lower bound on the number of distinct common differences they exhibit"
+    },
+    {
+      "targetId": "erdos-1096",
+      "relationship": "related",
+      "description": "Sister problem in additive combinatorics on arithmetic progressions in integer sets. Both arise from the Asilomar sessions and concern quantitative bounds on AP structure"
     }
   ],
   "relatedProofs": [
     "szemeredi-theorem",
+    "szemeredi-counting",
+    "szemeredi-full",
+    "szemeredi-regularity",
     "erdos-3",
+    "erdos-1096",
     "arithmetic-series",
-    "roth-theorem-k3",
-    "szemeredi-regularity"
+    "roth-theorem-k3"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -110,6 +110,20 @@
         "year": "2016",
         "venue": "Wiley, 4th edition",
         "note": "Standard reference for probabilistic combinatorics; Chapter 14 covers random graph processes"
+      },
+      {
+        "authors": "A. Razborov",
+        "title": "On the minimal density of triangles in graphs",
+        "year": "2010",
+        "venue": "Combinatorics, Probability and Computing, vol. 19, pp. 201–214",
+        "note": "Flag algebra proof of the exact triangle density threshold in dense graphs; the supersaturation phenomenon governs the early stages of the triangle removal process when the graph is dense"
+      },
+      {
+        "authors": "P. Turán",
+        "title": "Eine Extremalaufgabe aus der Graphentheorie",
+        "year": "1941",
+        "venue": "Matematikai és Fizikai Lapok, vol. 48, pp. 436–452",
+        "note": "Foundation of extremal graph theory: the maximum number of edges in a K_{r+1}-free graph on n vertices is achieved by the complete r-partite graph. Mantel's 1907 result is the r=2 case. The terminal graph of the triangle removal process is K_3-free, connecting to the Turán bound"
       }
     ],
     "axiomCount": 5,
@@ -128,7 +142,11 @@
       "erdos-1155",
       "ramseys-theorem",
       "szemeredi-regularity",
+      "szemeredi-theorem",
+      "szemeredi-counting",
+      "szemeredi-full",
       "randomized-maxcut",
+      "randomized-maxcut-oq-01",
       "erdos-1009",
       "erdos-1010",
       "erdos-1104"
@@ -280,6 +298,26 @@
       "targetId": "erdos-1104",
       "relationship": "related",
       "description": "Maximum chromatic number of triangle-free graphs: the terminal graph of the triangle removal process is triangle-free, so its chromatic number is bounded by the Ramsey-type results formalized in #1104. The chromatic structure of the terminal graph may constrain the edge count f(n)"
+    },
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemerédi's theorem on arithmetic progressions in dense sets is a cornerstone of additive combinatorics. The triangle removal lemma (a key consequence of Szemerédi regularity) states that graphs with few triangles can be made triangle-free by removing few edges — the deterministic counterpart to the random triangle removal process studied here"
+    },
+    {
+      "targetId": "szemeredi-counting",
+      "relationship": "related",
+      "description": "The counting lemma complements the regularity lemma: it counts subgraph copies (including triangles) in regular partitions. Triangle counting governs the rate at which the random removal process depletes triangles, connecting the regularity-based counting to the process dynamics"
+    },
+    {
+      "targetId": "szemeredi-full",
+      "relationship": "related",
+      "description": "The full Szemerédi regularity lemma decomposes dense graphs into pseudorandom bipartite pairs. This decomposition is the foundation of the triangle removal lemma, which guarantees that graphs with o(n³) triangles can be made triangle-free by removing o(n²) edges — a deterministic structural result complementing the random process analysis"
+    },
+    {
+      "targetId": "randomized-maxcut-oq-01",
+      "relationship": "thematic",
+      "description": "Both formalize extensions of randomized graph algorithms: this entry extends the triangle removal process analysis with exact asymptotic gap characterization, while MaxCut OQ-01 extends the randomized cut analysis with derandomization and approximation guarantees"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -95,7 +95,32 @@
       "Asymptotic analysis: limit of M(N)/N"
     ],
     "assumptions": "6 axiom declarations: erdos_36_limit_exists (the limit c = lim M(N)/N exists — the main open question), erdos_lower_quarter (Erdős's 1/4 lower bound), scherk_lower (Scherk's 1−1/√2 ≈ 0.293 lower bound via Fourier), white_lower (White's 0.379 lower bound via convex optimization), upper_bound (Haugland's 0.381 upper bound), small_values (computed M(N) for small N). The limit existence and bounds are established results.",
-    "lineCount": 91
+    "lineCount": 91,
+    "leanFile": {
+      "lineCount": 91,
+      "structureCount": 0,
+      "axiomCount": 6,
+      "theoremCount": 0,
+      "lemmaCount": 0,
+      "defCount": 3,
+      "imports": [
+        "Mathlib.Data.Nat.Basic",
+        "Mathlib.Data.Int.Basic",
+        "Mathlib.Data.Finset.Basic",
+        "Mathlib.Data.Real.Basic",
+        "Mathlib.Tactic"
+      ]
+    },
+    "relatedProblems": [
+      {
+        "id": "erdos-335",
+        "relationship": "Related Erdős problem on overlap in set partitions"
+      },
+      {
+        "id": "erdos-66",
+        "relationship": "Related Erdős problem on covering systems and density"
+      }
+    ]
   },
   "leanFile": {
     "imports": [
@@ -229,12 +254,24 @@
       "targetId": "roth-theorem-k3",
       "relationship": "related",
       "description": "Both use Fourier-analytic methods on finite sets of integers. Roth's theorem counts 3-term APs via the Fourier transform; the minimum overlap problem reduces to convex optimization over Fourier coefficients. The same machinery (Parseval's identity, energy bounds) drives both results"
+    },
+    {
+      "targetId": "erdos-35",
+      "relationship": "related",
+      "description": "Both concern additive structure in integer subsets: #35 studies Schnirelmann density and when sets form additive bases (sumsets cover all integers), while #36 studies the unavoidable overlap in equal partitions. Both use density and counting arguments on $\\{1,\\ldots,N\\}$"
+    },
+    {
+      "targetId": "erdos-37",
+      "relationship": "related",
+      "description": "Neighboring Erdős problem on essential components and lacunary sets in additive number theory. Both #36 and #37 probe the structural constraints that additive combinatorics imposes on subsets of integers"
     }
   ],
   "relatedProofs": [
     "erdos-335",
     "erdos-66",
     "erdos-30",
+    "erdos-35",
+    "erdos-37",
     "fourier-series",
     "erdos-1",
     "roth-theorem-k3"

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -81,6 +81,21 @@
       "description": "Unique prime factorization is the foundation of smooth number theory: P⁺(n) (the largest prime factor) is well-defined by FTA, and smoothness is defined in terms of the factorization structure that FTA guarantees"
     },
     {
+      "targetId": "erdos-368",
+      "relationship": "related",
+      "description": "Erdős #368 studies the largest prime factor of $n(n+1)$, directly related to the smoothness of consecutive integers. If $P^+(n(n+1)) \\leq n^\\varepsilon$, then both $n$ and $n+1$ are $n^\\varepsilon$-smooth — exactly the $k=2$ case of #369"
+    },
+    {
+      "targetId": "erdos-371",
+      "relationship": "related",
+      "description": "Erdős #371 studies the density of integers where $P^+(n) < P^+(n+1)$ (the largest prime factor increases). Both #369 and #371 probe the multiplicative structure of consecutive integers: #369 asks for simultaneous smoothness, #371 asks for relative prime factor ordering"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes is foundational: smooth numbers are defined by having all prime factors below a threshold, and the distribution of primes (via PNT) governs the Dickman function $\\rho(u)$ that predicts smooth number density"
+    },
+    {
       "targetId": "erdos-4",
       "relationship": "related",
       "description": "Both problems connect smooth numbers to prime gaps. Problem #4 (large prime gaps) uses smooth number constructions (products of small primes create long prime-free intervals), while #369 directly studies consecutive smooth numbers. Rankin's large gap construction exploits the same smooth number density estimates"
@@ -174,11 +189,14 @@
   },
   "relatedProofs": [
     "erdos-370",
+    "erdos-368",
+    "erdos-371",
     "erdos-143",
+    "erdos-4",
     "prime-number-theorem",
     "bertrands-postulate",
     "fundamental-arithmetic",
-    "erdos-4"
+    "infinitude-primes"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/fundamental-theorem-calculus/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.json
@@ -1,165 +1,86 @@
 [
   {
+    "id": "ann-imports-docstring",
+    "proofId": "fundamental-theorem-calculus",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "Imports, Overview, and Setup",
+    "content": "Six Mathlib imports covering calculus (`FDeriv`, `Deriv`), measure-theoretic integration (`IntervalIntegral`, `FundThmCalculus`), the mean value theorem, and topology. Module docstring describes both parts of the FTC with historical context (Newton, Leibniz, Cauchy, Weierstrass). Opens five namespaces for concise notation and declares the `FundamentalTheoremCalculus` namespace.",
+    "mathContext": "FTC Part 1: $\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$. FTC Part 2: $\\int_a^b F'(x)\\,dx = F(b) - F(a)$.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib calculus", "interval integral", "measure theory"],
+    "prerequisites": ["Lean 4 imports", "real analysis"]
+  },
+  {
     "id": "ann-integral-function",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 8,
-      "endLine": 43
-    },
+    "range": { "startLine": 50, "endLine": 61 },
     "type": "definition",
-    "title": "The Integral Function F(x)",
-    "content": "We define **F(x) = ∫ₐˣ f(t) dt**, the cumulative integral from a fixed starting point $a$ to a variable endpoint $x$.\n\nThis function measures the 'accumulated area' under $f$ from $a$ to $x$. As $x$ increases, more area is accumulated (if $f$ is positive).\n\nThe key insight: F is constructed from f via integration, and we'll prove F' = f.",
-    "mathContext": "$F : \\mathbb{R} \\to \\mathbb{R}$\n\n$F(x) = \\int_a^x f(t)\\,dt$\n\nF(a) = 0 (integral over an empty interval)",
+    "title": "The Integral Function",
+    "content": "Defines `integralFunction f a` as $F(x) = \\int_a^x f(t)\\,dt$, the running integral of $f$ from fixed lower bound $a$. Marked `noncomputable` because real-valued integrals use classical choice. This is the function whose derivative FTC Part 1 computes.",
+    "mathContext": "$F(x) = \\int_a^x f(t)\\,dt$. This defines a new function $F : \\mathbb{R} \\to \\mathbb{R}$ from a given $f$ and basepoint $a$.",
     "significance": "key",
-    "relatedConcepts": [
-      "definite integral",
-      "area under curve",
-      "accumulation function"
-    ]
+    "relatedConcepts": ["interval integral", "noncomputable", "running integral"],
+    "prerequisites": ["interval integral notation", "Mathlib measure theory"]
   },
   {
     "id": "ann-ftc-part1",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 8,
-      "endLine": 43
-    },
-    "type": "theorem",
-    "title": "FTC Part 1: Derivative of an Integral",
-    "content": "**The derivative of the integral function equals the integrand.**\n\nIf $F(x) = \\int_a^x f(t)\\,dt$, then $F'(x) = f(x)$.\n\nThis is profound: integration 'builds' an antiderivative of any continuous function. Even if we can't write ∫f in closed form, the integral function exists and has f as its derivative.",
-    "mathContext": "$\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$\n\nIn Leibniz notation: $\\frac{d}{dx}F(x) = f(x)$",
+    "range": { "startLine": 63, "endLine": 78 },
+    "type": "technique",
+    "title": "FTC Part 1: Derivative of the Integral",
+    "content": "Two versions of FTC Part 1. `ftc_part1` uses minimal hypotheses (continuity at $b$, integrability on $[a,b]$, strong measurability at $b$), directly applying Mathlib's `integral_hasDerivAt_right`. `ftc_part1_continuous` provides the classical statement for globally continuous $f$: the integral function has derivative $f(x)$ at every point $x$.",
+    "mathContext": "If $f$ is continuous at $b$ and integrable on $[a,b]$: $F'(b) = f(b)$ where $F(x) = \\int_a^x f$. Globally: $f$ continuous $\\Rightarrow \\frac{d}{dx}\\int_a^x f = f(x)$ everywhere.",
     "significance": "key",
-    "relatedConcepts": [
-      "antiderivative",
-      "HasDerivAt",
-      "differentiability"
-    ]
-  },
-  {
-    "id": "ann-continuity-requirement",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 8,
-      "endLine": 43
-    },
-    "type": "concept",
-    "title": "Continuity is Essential",
-    "content": "The theorem requires **continuity at x** (for the pointwise statement) or **continuity on [a,b]** (for the global statement).\n\nWhy? The proof relies on limits: as the integration interval shrinks, the average value approaches f(x). This requires continuity.\n\nFor discontinuous functions, we need the more sophisticated Lebesgue-Stieltjes integral and almost-everywhere differentiability.",
-    "mathContext": "$f$ continuous at $x$ means:\n\n$\\lim_{h \\to 0} f(x+h) = f(x)$\n\nThis ensures $\\lim_{h \\to 0} \\frac{1}{h}\\int_x^{x+h} f(t)\\,dt = f(x)$",
-    "significance": "key",
-    "relatedConcepts": [
-      "continuity",
-      "ContinuousAt",
-      "limit definition"
-    ]
+    "relatedConcepts": ["HasDerivAt", "integral_hasDerivAt_right", "ContinuousAt"],
+    "prerequisites": ["interval integrability", "strong measurability", "HasDerivAt"]
   },
   {
     "id": "ann-ftc-part2",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 65,
-      "endLine": 69
-    },
-    "type": "theorem",
-    "title": "FTC Part 2: Evaluation Theorem",
-    "content": "**The integral of a derivative equals the net change.**\n\n$\\int_a^b F'(x)\\,dx = F(b) - F(a)$\n\nThis is the 'computational' part of FTC: it reduces the problem of integration (infinite sums) to simple evaluation at two points.\n\nEvery integral table and integration technique is ultimately about finding antiderivatives to apply this theorem.",
-    "mathContext": "$\\int_a^b f(x)\\,dx = F(b) - F(a)$\n\nwhere $F' = f$ on $[a, b]$\n\nOften written: $\\left[F(x)\\right]_a^b = F(b) - F(a)$",
+    "range": { "startLine": 80, "endLine": 105 },
+    "type": "technique",
+    "title": "FTC Part 2: Integral of the Derivative",
+    "content": "Two versions: `ftc_part2` (with $a \\leq b$) applies `integral_eq_sub_of_hasDerivAt_of_le` requiring continuity of $F$ on $[a,b]$ and differentiability on $(a,b)$. `ftc_part2_general` drops the $a \\leq b$ assumption using `uIcc` (unordered interval), applying `integral_eq_sub_of_hasDeriv_right`.",
+    "mathContext": "$\\int_a^b F'(x)\\,dx = F(b) - F(a)$. Hypotheses: $F$ continuous on $[a,b]$, $F' = f$ on $(a,b)$, $f$ integrable.",
     "significance": "key",
-    "relatedConcepts": [
-      "antiderivative",
-      "evaluation",
-      "net change"
-    ]
+    "relatedConcepts": ["evaluation theorem", "antiderivative", "net change theorem"],
+    "prerequisites": ["ContinuousOn", "HasDerivAt", "HasDerivWithinAt"]
   },
   {
-    "id": "ann-ftc-part2-conditions",
+    "id": "ann-unity-antiderivative",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 65,
-      "endLine": 69
-    },
-    "type": "concept",
-    "title": "Conditions for FTC Part 2",
-    "content": "The theorem requires:\n\n1. **F is differentiable** on [a, b]\n2. **F' is continuous** on [a, b] (or at least integrable)\n3. **a ≤ b** (the integration bounds are in order)\n\nThe continuity of F' is crucial: if F' has 'bad' discontinuities, the integral may not equal F(b) - F(a).\n\nCounterexamples exist for merely differentiable F with discontinuous derivative.",
-    "mathContext": "We need:\n- $\\forall x \\in [a,b], \\text{HasDerivAt } F (F'(x)) x$\n- $F' \\in C([a,b])$ (continuous on closed interval)",
-    "significance": "key",
-    "relatedConcepts": [
-      "differentiability",
-      "ContinuousOn",
-      "interval conditions"
-    ]
-  },
-  {
-    "id": "ann-antiderivative-def",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 91,
-      "endLine": 97
-    },
-    "type": "definition",
-    "title": "Antiderivative Definition",
-    "content": "**F is an antiderivative of f** if $F'(x) = f(x)$ for all $x$.\n\nAlso called a **primitive** or **indefinite integral** of f.\n\nThe key property: if F is an antiderivative of f, then so is F + C for any constant C. This is why indefinite integrals always have the '+C'.",
-    "mathContext": "$F$ is an antiderivative of $f$ means:\n\n$\\forall x, \\frac{d}{dx}F(x) = f(x)$\n\nNotation: $\\int f(x)\\,dx = F(x) + C$",
-    "significance": "key",
-    "relatedConcepts": [
-      "derivative",
-      "indefinite integral",
-      "primitive function"
-    ]
-  },
-  {
-    "id": "ann-uniqueness",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 107,
-      "endLine": 117
-    },
-    "type": "theorem",
-    "title": "Antiderivatives Differ by Constants",
-    "content": "**If F and G are both antiderivatives of f, then F - G is constant.**\n\nThis explains the '+C' in indefinite integrals:\n- F and G both satisfy F' = f and G' = f\n- So (F - G)' = 0\n- A function with zero derivative is constant (by MVT)\n- Therefore F = G + C\n\nThis means antiderivatives are 'unique up to a constant'.",
-    "mathContext": "$F' = G' = f \\Rightarrow (F - G)' = 0$\n\n$\\Rightarrow F - G = C$ (constant)\n\nSo $\\int f\\,dx$ represents a *family* of functions differing by constants.",
-    "significance": "key",
-    "relatedConcepts": [
-      "mean value theorem",
-      "constant function",
-      "uniqueness"
-    ]
-  },
-  {
-    "id": "ann-zero-derivative",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 124,
-      "endLine": 128
-    },
-    "type": "lemma",
-    "title": "Zero Derivative Implies Constant",
-    "content": "**If F'(x) = 0 for all x, then F is constant.**\n\nThis is a consequence of the Mean Value Theorem:\n\nFor any two points x and y, there exists c between them with\n$F(y) - F(x) = F'(c)(y - x) = 0 \\cdot (y - x) = 0$\n\nSo F(y) = F(x) for all x, y.\n\nThis lemma is essential for proving uniqueness of antiderivatives.",
-    "mathContext": "Mean Value Theorem: $F(y) - F(x) = F'(c)(y - x)$ for some $c \\in (x, y)$\n\nIf $F' \\equiv 0$, then $F(y) = F(x)$ for all $x, y$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "mean value theorem",
-      "constant function",
-      "convexity"
-    ]
-  },
-  {
-    "id": "ann-inverse-operations",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 80,
-      "endLine": 88
-    },
+    "range": { "startLine": 107, "endLine": 128 },
     "type": "insight",
-    "title": "The Unity of Calculus",
-    "content": "**Differentiation and integration are inverse operations.**\n\nIntegrate then differentiate: $\\frac{d}{dx}\\int_a^x f = f$ (FTC Part 1)\n\nDifferentiate then integrate: $\\int_a^x F' = F - F(a)$ (FTC Part 2)\n\nThis 'almost inverse' relationship (up to the constant F(a)) unifies the two branches of calculus that Newton and Leibniz developed from completely different perspectives.\n\nNewton saw derivatives as velocities and integrals as areas. Leibniz saw both through infinitesimals. FTC shows they were studying the same thing.",
-    "mathContext": "$D$ = differentiation, $I_a$ = integration from $a$\n\n$D \\circ I_a = \\text{id}$ (FTC Part 1)\n\n$I_a \\circ D = \\text{id} + \\text{const}$ (FTC Part 2, roughly)",
+    "title": "The Unity of Calculus and Antiderivatives",
+    "content": "Documentation explaining that FTC Parts 1 and 2 establish differentiation and integration as inverse operations. Defines `IsAntiderivative F f` as $F' = f$ everywhere. `integral_is_antiderivative` proves the integral function is an antiderivative of continuous $f$, directly from `ftc_part1_continuous`.",
+    "mathContext": "$\\frac{d}{dx}\\int_a^x f = f$ (integrate then differentiate). $\\int_a^b F' = F(b) - F(a)$ (differentiate then integrate). $F$ is an antiderivative of $f$ iff $F'(x) = f(x)$ for all $x$.",
     "significance": "key",
-    "relatedConcepts": [
-      "inverse functions",
-      "Newton",
-      "Leibniz",
-      "calculus unification"
-    ]
+    "relatedConcepts": ["antiderivative", "inverse operations", "IsAntiderivative"],
+    "prerequisites": ["ftc_part1_continuous", "HasDerivAt"]
+  },
+  {
+    "id": "ann-constant-theorem",
+    "proofId": "fundamental-theorem-calculus",
+    "range": { "startLine": 130, "endLine": 158 },
+    "type": "technique",
+    "title": "Antiderivatives Differ by a Constant",
+    "content": "Two supporting theorems. `hasDerivAt_zero_implies_constant`: a function with everywhere-zero derivative is constant, using `is_const_of_deriv_eq_zero` from Mathlib's mean value theorem infrastructure. `antiderivatives_differ_by_constant`: if $F$ and $G$ are both antiderivatives of $f$, then $F - G$ is constant — proved by showing $(F-G)' = f - f = 0$ and applying the zero-derivative theorem.",
+    "mathContext": "If $F' = 0$ everywhere, then $F$ is constant (consequence of MVT). Therefore: $F' = G' = f \\Rightarrow (F-G)' = 0 \\Rightarrow F - G = c$ for some constant $c$.",
+    "significance": "key",
+    "relatedConcepts": ["mean value theorem", "constant function", "uniqueness of antiderivatives"],
+    "prerequisites": ["is_const_of_deriv_eq_zero", "HasDerivAt.sub", "linarith"]
+  },
+  {
+    "id": "ann-verification",
+    "proofId": "fundamental-theorem-calculus",
+    "range": { "startLine": 160, "endLine": 165 },
+    "type": "context",
+    "title": "Verification",
+    "content": "Closes the namespace and type-checks four main theorems: `ftc_part1`, `ftc_part2`, `integral_is_antiderivative`, and `antiderivatives_differ_by_constant`.",
+    "mathContext": "All four theorems verified: Parts 1 and 2 of the FTC, the antiderivative property of the integral, and uniqueness up to constants.",
+    "significance": "context",
+    "relatedConcepts": ["#check command"],
+    "prerequisites": ["Lean 4 meta-commands"]
   }
 ]


### PR DESCRIPTION
## Summary
Enrichment pass on 10 gallery entries, focusing on:
- Adding missing `meta.leanFile` structural counts
- Adding missing `meta.relatedProblems` links
- Adding cross-references to related gallery entries
- Adding references cited in text but missing from references arrays

### Entries enriched:
1. **abel-ruffini**: +3 references (Abel 1826, Cauchy 1815, Neumann 2011)
2. **erdos-1155-oq-01**: +4 cross-refs (Szemerédi entries), +2 refs
3. **bezout-identity-oq-02-oq-02-oq-01**: +meta.leanFile, +relatedProblems, +3 cross-refs
4. **erdos-1059**: +meta.leanFile, +relatedProblems, +1 cross-ref
5. **erdos-1065**: +relatedProblems, +3 cross-refs
6. **erdos-1089**: +meta.leanFile, +relatedProblems, +1 cross-ref
7. **erdos-1097**: +meta.leanFile, +relatedProblems, +3 cross-refs
8. **erdos-36**: +meta.leanFile, +relatedProblems, +2 cross-refs
9. **erdos-369**: +3 cross-refs to neighboring problems
10. Previous: sqrt2-irrational, fundamental-theorem-calculus rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)