### PR TITLE
Research: brouwer-fixed-point-oq-02-oq-01 - prove last sorry (0 sorries)

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean
@@ -999,14 +999,24 @@ theorem approximate_fixed_point_2d
     -- so |pᵢ.k - pⱼ.k| ≤ 1/n for any two triangle vertices and coordinate k
     -- Triangle vertices are within L∞ distance 1/n of each other
     -- (Grid vertices differ by at most 1 in each ℕ coordinate, so ≤ 1/n in ℝ)
+    -- Helper: |a/n - b/n| ≤ 1/n when |a - b| ≤ 1 (for natural a, b)
+    have coord_dist : ∀ (a b : ℕ), (a : ℤ) - b ≤ 1 → (b : ℤ) - a ≤ 1 →
+        dist ((a : ℝ) / n) ((b : ℝ) / n) ≤ 1 / (n : ℝ) := by
+      intro a b hab hba
+      rw [Real.dist_eq, ← sub_div, abs_div, abs_of_pos hn_real]
+      apply div_le_div_of_nonneg_right _ (le_of_lt hn_real)
+      have : |(↑a : ℝ) - ↑b| ≤ 1 := by
+        rw [abs_le]; exact ⟨by exact_mod_cast (by omega : -1 ≤ (a : ℤ) - b),
+                            by exact_mod_cast (by omega : (a : ℤ) - b ≤ 1)⟩
+      linarith
     have h_dist_bound : ∀ (i j : Fin 3),
         dist (gridToReal n (t.vertices i)) (gridToReal n (t.vertices j)) ≤ 1 / (n : ℝ) := by
       intro i j
-      -- Case split FIRST to get concrete vertex coordinates
-      -- Grid triangle vertices differ by at most 1 in each natural number coordinate.
-      -- After dividing by n, each component distance ≤ 1/n.
-      -- Technical proof: unfold vertex defs, convert to ℤ, use triangle validity.
-      sorry
+      simp only [Prod.dist_eq, gridToReal, GridTriangle.vertices]
+      rcases t with ⟨ti, tj, ty, hvalid⟩
+      rcases ty with _ | _ <;> simp only [lowerVertices, upperVertices] <;>
+      fin_cases i <;> fin_cases j <;> simp only <;>
+      apply max_le <;> apply coord_dist <;> omega
     -- By uniform continuity: dist(f(pᵢ), f(pⱼ)) < ε/4 for triangle vertices
     have h_f_close : ∀ (i j : Fin 3),
         dist (f (gridToReal n (t.vertices i))) (f (gridToReal n (t.vertices j))) < ε / 4 := by

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 7/8 sorries. Core Sperner machinery (Sections I-IV) now compiles with 0 sorries. Only approximate_fixed_point_2d (Section V) has 1 sorry remaining (uniform continuity bound). Also fixed hTrans definition bug and Section V pre-existing Lean 4.26 API drift errors.",
+    "progressSummary": "COMPLETED: 0 sorries, 0 axioms. Proved h_dist_bound (grid triangle L-infinity distance \u2264 1/n) via coord_dist helper lemma with fin_cases + omega on all 18 vertex pair cases (2 tri types \u00d7 9 Fin3\u00d7Fin3 combos). File fully machine-checked.",
     "builtItems": [
       "BrouwerFixedPointOQ02OQ01.lean: 428 lines, 2 sorries (down from 5)",
       "sperner_2d: PROVED via row-sweep parity (modulo strip_parity)",
@@ -51,14 +51,16 @@
       "gridToReal_in_simplex: PROVED helper lemma for simplex membership",
       "approximate_fixed_point_2d: restructured to handle boundary fixed points (1 sorry remains for uniform continuity)",
       "PROVED door_parity_of_not_fc: non-FC triples have even {0,1}-door count (was sorry)",
-      "PROVED no_door_left_boundary: left boundary colors ∈ {0,2}, no {0,1}-doors",
-      "PROVED no_door_hypotenuse: hypotenuse colors ∈ {1,2}, no {0,1}-doors",
+      "PROVED no_door_left_boundary: left boundary colors \u2208 {0,2}, no {0,1}-doors",
+      "PROVED no_door_hypotenuse: hypotenuse colors \u2208 {1,2}, no {0,1}-doors",
       "PROVED hTrans_zero_eq: bottom row {0,1}-doors = all transitions (under Sperner)",
       "PROVED lower_door_sum_zero: non-FC lower triangles have even {0,1}-door count",
       "PROVED upper_door_sum_zero: non-FC upper triangles have even {0,1}-door count",
       "PROVED doorZ_hyp_boundary: no {0,1}-doors on hypotenuse in ZMod 2",
-      "PROVED hTrans_cast: Nat.card → ZMod 2 sum conversion via Finset.sum_boole",
-      "FIXED hTrans definition: now counts {0,1}-doors (was incorrectly counting all transitions)"
+      "PROVED hTrans_cast: Nat.card \u2192 ZMod 2 sum conversion via Finset.sum_boole",
+      "FIXED hTrans definition: now counts {0,1}-doors (was incorrectly counting all transitions)",
+      "Proved coord_dist helper: |a/n - b/n| \u2264 1/n when |a-b| \u2264 1",
+      "Proved h_dist_bound: grid triangle vertices within L\u221e dist 1/n"
     ],
     "insights": [
       "Row-sweep approach is cleaner than full double-counting: define hTrans(j) = horizontal {0,1}-doors at row j, show parity is constant across rows",
@@ -75,16 +77,16 @@
       "15+ omega failures in fully_colored_one_door and no_door_hypotenuse (Lean 4.26 / Fin comparison changes)",
       "sperner_2d proof structure (row-sweep via strip_parity) is mathematically complete but cannot compile due to missing upstream definitions",
       "Restored missing definitions (gColor, hTrans, hTrans_top, gColor_bot, abstractDoorCount) from git history",
-      "Fixed Mathlib v4.26 API drift: omega failures through GridVertex projections (use show/dsimp), deprecated renames (range_succ→range_add_one, notMem_range_self, natCast_eq_zero_iff), door_parity_of_not_fc decide→contradiction",
+      "Fixed Mathlib v4.26 API drift: omega failures through GridVertex projections (use show/dsimp), deprecated renames (range_succ\u2192range_add_one, notMem_range_self, natCast_eq_zero_iff), door_parity_of_not_fc decide\u2192contradiction",
       "Removed unused lemmas (fully_colored_one_door, no_door_left_boundary, no_door_hypotenuse) that had unfixable API drift - superseded by doorZ_* variants",
       "Fixed zmod2_sum_shift_cancel: added missing 0<m hypothesis (lemma was false for m=0)",
       "Added @[ext] to GridVertex for ext tactic compatibility",
       "File now builds clean with 1 sorry (approximate_fixed_point_2d only)",
-      "BUG FOUND: displacementColoring tie-breaking is wrong. When f(p)=p (d0=d1=d2=0), coloring gives 0 on hypotenuse, violating Sperner condition (needs color ≠ 0 there).",
+      "BUG FOUND: displacementColoring tie-breaking is wrong. When f(p)=p (d0=d1=d2=0), coloring gives 0 on hypotenuse, violating Sperner condition (needs color \u2260 0 there).",
       "Root cause: tie-breaking picks smallest index (color 0 first), but on hypotenuse need color 0 to have LOWEST priority.",
       "Fix: reverse tie-breaking priority OR use face-aware tie-breaking where vertex-opposite colors get low priority.",
-      "Standard fix from literature: argmin with tie-broken by largest index (so all-zeros → color 2, which is fine on hypotenuse).",
-      "On bottom edge (d2≥0): reversed priority would give color 2 when all zeros. Need face-aware tie-breaking for corners.",
+      "Standard fix from literature: argmin with tie-broken by largest index (so all-zeros \u2192 color 2, which is fine on hypotenuse).",
+      "On bottom edge (d2\u22650): reversed priority would give color 2 when all zeros. Need face-aware tie-breaking for corners.",
       "door_parity_of_not_fc PROVED: fin_cases + simp_all (config := {decide := true}) closes all 27 cases",
       "Confirmed: displacementColoring tie-breaking already fixed by previous session (face-aware)",
       "Application section (lines 600+) has 7+ build errors from Lean 4.26 linarith/nlinarith changes",
@@ -97,7 +99,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove approximate_fixed_point_2d: need uniform continuity bound on grid mesh → displacement bound",
+      "Prove approximate_fixed_point_2d: need uniform continuity bound on grid mesh \u2192 displacement bound",
       "Fix Section V pre-existing Lean 4.26 API drift in displacementColoring_isSperner (linarith/nlinarith changes)",
       "Fix color_one_d1_nonpos and color_two_d2_nonpos for Lean 4.26 split_ifs changes"
     ]


### PR DESCRIPTION
## Summary
- Eliminates the last remaining `sorry` in `BrouwerFixedPointOQ02OQ01.lean`
- File now fully machine-checked: **0 sorries, 0 axioms, 1071 lines**

## Changes
- **Proved `h_dist_bound`**: Grid triangle vertices are within L∞ distance 1/n of each other
- **Added `coord_dist` helper**: For natural numbers a, b with |a-b| ≤ 1, proves |a/n - b/n| ≤ 1/n using `Real.dist_eq`, `abs_div`, and `div_le_div_of_nonneg_right`
- Case-splits on triangle type (lower/upper) and all 9 vertex pair combinations via `fin_cases` + `omega`

## Build Verification
Docker build succeeds with only unused simp arg linter warnings.

## Status
**Outcome**: completed — sorry elimination (1 → 0)
**File**: 1071 lines, fully machine-checked Brouwer approximate fixed point theorem via Sperner's lemma

🤖 Generated by researcher-4