### PR TITLE
Research: erdos-538 - fix Mathlib API breakage

### DIFF
--- a/proofs/Proofs/Erdos538Problem.lean
+++ b/proofs/Proofs/Erdos538Problem.lean
@@ -231,7 +231,7 @@ theorem erdos_upper_bound :
           (c * Real.log (Real.log ↑N)) := by
         rw [mul_div_cancel_right₀ _ hcll_ne]
       _ ≤ (3 * ↑r * Real.log ↑N) / (c * Real.log (Real.log ↑N)) :=
-        (div_le_div_right hcll_pos).mpr key
+        div_le_div_of_nonneg_right key (le_of_lt hcll_pos)
       _ = 3 / c * ↑r * Real.log ↑N / Real.log (Real.log ↑N) := by ring
 
 /-

--- a/src/data/research/problems/erdos-538.json
+++ b/src/data/research/problems/erdos-538.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-538",
-  "title": "Erdős #538",
+  "title": "Erd\u0151s #538",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
@@ -31,44 +31,45 @@
   "knowledge": {
     "progressSummary": "PROGRESS: erdos_upper_bound PROVED from Mertens axiom + double_counting sorry. File: 1 axiom, 1 sorry (was 0 axioms, 1 sorry). Added primeReciprocalSum def, exp_one_lt_three, log_gt_one_of_ge_three, log_log_pos_of_ge_three helper lemmas.",
     "builtItems": [
-      "inv_succ_le_log_sub: 1/(n+1) ≤ log(n+1) - log(n) for n ≥ 1 (private lemma)",
-      "harmonic_upper_bound: reciprocalSum(A) ≤ 1 + log(N) for A ⊆ range(N+1) - PROVED",
+      "inv_succ_le_log_sub: 1/(n+1) \u2264 log(n+1) - log(n) for n \u2265 1 (private lemma)",
+      "harmonic_upper_bound: reciprocalSum(A) \u2264 1 + log(N) for A \u2286 range(N+1) - PROVED",
       "sum_reprCount_bound: fixed statement with positivity hypothesis (sorry remains)",
       "Fixed le_refl tactic errors (pre-existing), added open Classical for DecidablePred",
-      "r_eq_1_card_bound: |A| ≤ N for positive A with 1-bounded repr - PROVED (added positivity hypothesis, used erase-range approach)",
-      "multiplicative_energy_trivial_bound: |filtered pairs| ≤ |A|² - PROVED (replaced false r²|A| bound)",
+      "r_eq_1_card_bound: |A| \u2264 N for positive A with 1-bounded repr - PROVED (added positivity hypothesis, used erase-range approach)",
+      "multiplicative_energy_trivial_bound: |filtered pairs| \u2264 |A|\u00b2 - PROVED (replaced false r\u00b2|A| bound)",
       "Fixed sum_reprCount_bound compilation: added omega to close N+1-1=N goal",
-      "primeReciprocalSum: sum of 1/p over primes p ≤ N",
+      "primeReciprocalSum: sum of 1/p over primes p \u2264 N",
       "mertens_prime_reciprocal_lower: axiom for Mertens second theorem lower bound",
-      "double_counting_bound: (reciprocalSum A)·(primeReciprocalSum N) ≤ r·(1+2·log N) (sorry)",
+      "double_counting_bound: (reciprocalSum A)\u00b7(primeReciprocalSum N) \u2264 r\u00b7(1+2\u00b7log N) (sorry)",
       "exp_one_lt_three: exp(1) < 3 via Taylor bound",
-      "log_gt_one_of_ge_three: 1 < log N for N ≥ 3",
-      "log_log_pos_of_ge_three: 0 < log(log N) for N ≥ 3",
-      "erdos_upper_bound: PROVED from Mertens + double counting"
+      "log_gt_one_of_ge_three: 1 < log N for N \u2265 3",
+      "log_log_pos_of_ge_three: 0 < log(log N) for N \u2265 3",
+      "erdos_upper_bound: PROVED from Mertens + double counting",
+      "Fixed Mathlib API: div_le_div_right \u2192 div_le_div_of_nonneg_right (file now builds)"
     ],
     "insights": [
       "File has 4 sorries after proving harmonic_upper_bound (was 4 + 1 broken proof)",
-      "harmonic_upper_bound proved by induction using log(x) ≤ x - 1 (Real.log_le_sub_one_of_pos)",
-      "Key inequality: 1/(n+1) ≤ log(n+1) - log(n) follows from applying log(x) ≤ x-1 to x = n/(n+1)",
+      "harmonic_upper_bound proved by induction using log(x) \u2264 x - 1 (Real.log_le_sub_one_of_pos)",
+      "Key inequality: 1/(n+1) \u2264 log(n+1) - log(n) follows from applying log(x) \u2264 x-1 to x = n/(n+1)",
       "sum_reprCount_bound statement was FALSE: counterexample A={0}, N=0 gives reprCount=1 > 0=|A|*N. Fixed by adding positivity hypothesis.",
-      "r_eq_1_card_bound proof was broken: ⊆ range(N+1) gives |A| ≤ N+1, not ≤ N. Needs bounded repr constraint or positivity.",
-      "File needed open Classical for DecidablePred on ∃ quantifiers in Finset.filter",
+      "r_eq_1_card_bound proof was broken: \u2286 range(N+1) gives |A| \u2264 N+1, not \u2264 N. Needs bounded repr constraint or positivity.",
+      "File needed open Classical for DecidablePred on \u2203 quantifiers in Finset.filter",
       "File needed import Mathlib.Analysis.SpecialFunctions.Log.Basic for Real.log_le_sub_one_of_pos",
-      "erdos_upper_bound is BLOCKED: requires Mertens theorem (Σ 1/p ~ log log N) which is not in Mathlib",
-      "multiplicative_energy_bound: bound r²·|A| may be incorrect; needs careful analysis of whether pairs are overcounted",
-      "multiplicative_energy_bound r²|A| is FALSE: A={2,3,5,7,11} with r=2 gives 25 pairs > r²|A|=20. All k² pairs of k primes satisfy the condition since gcd(p_i,p_j)=1 and both are prime.",
-      "r_eq_1_card_bound needs positivity: A={0,1} with N=1 is a counterexample (|A|=2>1=N). Adding hpos excludes 0, giving A ⊆ {1,...,N} of size ≤ N.",
+      "erdos_upper_bound is BLOCKED: requires Mertens theorem (\u03a3 1/p ~ log log N) which is not in Mathlib",
+      "multiplicative_energy_bound: bound r\u00b2\u00b7|A| may be incorrect; needs careful analysis of whether pairs are overcounted",
+      "multiplicative_energy_bound r\u00b2|A| is FALSE: A={2,3,5,7,11} with r=2 gives 25 pairs > r\u00b2|A|=20. All k\u00b2 pairs of k primes satisfy the condition since gcd(p_i,p_j)=1 and both are prime.",
+      "r_eq_1_card_bound needs positivity: A={0,1} with N=1 is a counterexample (|A|=2>1=N). Adding hpos excludes 0, giving A \u2286 {1,...,N} of size \u2264 N.",
       "File now has 1 sorry (erdos_upper_bound). All other theorems fully proved.",
-      "erdos_upper_bound PROVED: uses Mertens axiom (primeReciprocalSum N ≥ c·log(log N)) + double_counting_bound sorry + calc chain dividing by c·log(log N)",
-      "exp_one_lt_three proved using Real.exp_bound Taylor series (n=5): |exp 1 - S₅| ≤ error, S₅ + error < 3",
-      "double_counting_bound remains as only sorry: needs Finset.sum_fiberwise to regroup Σ 1/(ap) by m=ap, then bound each fiber by reprCount ≤ r"
+      "erdos_upper_bound PROVED: uses Mertens axiom (primeReciprocalSum N \u2265 c\u00b7log(log N)) + double_counting_bound sorry + calc chain dividing by c\u00b7log(log N)",
+      "exp_one_lt_three proved using Real.exp_bound Taylor series (n=5): |exp 1 - S\u2085| \u2264 error, S\u2085 + error < 3",
+      "double_counting_bound remains as only sorry: needs Finset.sum_fiberwise to regroup \u03a3 1/(ap) by m=ap, then bound each fiber by reprCount \u2264 r"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "double_counting_bound: Prove using Finset.sum_fiberwise_of_maps_to to regroup products, then bound fibers by HasBoundedRepr",
       "Alternatively: submit double_counting_bound to Aristotle companion file"
     ],
-    "markdown": "# Erdős #538 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $r\\geq 2$ and suppose that $A\\subseteq\\{1,\\ldots,N\\}$ is such that, for any $m$, there are at most $r$ solutions to $m=pa$ where $p$ is prime and $a\\in A$. Give the best possible upper bound for\\[\\sum_{n\\in A}\\frac{1}{n}.\\]\n\n\n\nErd\\H{o}s observed that\\[\\sum_{n\\in A}\\frac{1}{n}\\sum_{p\\leq N}\\frac{1}{p}\\leq r\\sum_{m\\leq N^2}\\frac{1}{m}\\ll r\\log N,\\]and hence\\[\\sum_{n\\in A}\\frac{1}{n} \\ll r\\frac{\\log N}{\\log\\log N}.\\]See also [536] and [537].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #536\n- Problem #537\n- Problem #539\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er73\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erd\u0151s #538 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $r\\geq 2$ and suppose that $A\\subseteq\\{1,\\ldots,N\\}$ is such that, for any $m$, there are at most $r$ solutions to $m=pa$ where $p$ is prime and $a\\in A$. Give the best possible upper bound for\\[\\sum_{n\\in A}\\frac{1}{n}.\\]\n\n\n\nErd\\H{o}s observed that\\[\\sum_{n\\in A}\\frac{1}{n}\\sum_{p\\leq N}\\frac{1}{p}\\leq r\\sum_{m\\leq N^2}\\frac{1}{m}\\ll r\\log N,\\]and hence\\[\\sum_{n\\in A}\\frac{1}{n} \\ll r\\frac{\\log N}{\\log\\log N}.\\]See also [536] and [537].\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #536\n- Problem #537\n- Problem #539\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er73\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- Fix Mathlib API rename: `div_le_div_right` → `div_le_div_of_nonneg_right`
- File now builds cleanly (1 sorry remaining: `double_counting_bound`)

## Status
**Outcome**: progress — API fix restores buildability
**Remaining**: 1 sorry (`double_counting_bound` - needs product-of-sums expansion + fiberwise regrouping), 1 axiom (Mertens)

🤖 Generated by researcher-4