### PR TITLE
Enrich batch: 13 entries - references, cross-refs, depth

### DIFF
--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -218,6 +218,11 @@
       "targetId": "prob-method-expectation",
       "relationship": "related",
       "description": "The probabilistic method uses expectation to prove existence: in the birthday problem, the expected number of matching pairs is $\\binom{n}{2}/365 > 1$ for $n \\geq 28$, guaranteeing a match exists in expectation. The birthday bound is a key ingredient in probabilistic method arguments for hash collisions and random graph coloring"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The number of birthday collisions among $n$ people follows a distribution that converges to Poisson (and thence to Gaussian via CLT) as $n$ grows. The Poisson approximation $P \\approx 1 - e^{-n^2/(2m)}$ for $m$ buckets is the CLT-style limit that explains the $\\sqrt{m}$ scaling of the birthday threshold"
     }
   ],
   "relatedProofs": [
@@ -231,7 +236,8 @@
     "inclusion-exclusion",
     "stirling-formula",
     "combinations-formula",
-    "prob-method-expectation"
+    "prob-method-expectation",
+    "central-limit-theorem"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Enrichment batch (13 entries)

### References added
- **abel-ruffini**: Wantzel (1837), Kronecker (1853)
- **amgm-inequality**: Euclid's Elements (~300 BCE)
- **amgm-inequality-oq-02**: Pólya-Szegő
- **amgm-inequality-oq-03**: Rényi (1961)

### Cross-references added
- **abel-ruffini**: annotation cleanup (build validation)
- **amgm-inequality**: binomial-theorem, harmonic-divergence
- **amgm-inequality-oq-03**: lhopital
- **amgm-inequality-oq-03-oq-01**: lhopital
- **angle-trisection**: de-moivre, kroneckers-jugendtraum
- **area-of-circle**: isoperimetric-theorem, lebesgue-measure, leibniz-pi
- **arithmetic-series**: combinations-formula, picks-theorem + expanded historicalContext
- **basel-problem**: taylor-theorem, dirichlets-theorem
- **bertrands-postulate**: stirling-formula, mathematical-induction
- **bezout-identity**: gcd-algorithm, pell-equation
- **binomial-theorem**: taylor-theorem, de-moivre
- **birthday-problem**: central-limit-theorem

All cross-references verified as existing gallery entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)