### PR TITLE
Research: roth-theorem-k3 - prove triple_count_fourier Part A

### DIFF
--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -406,10 +406,33 @@ theorem triple_count_fourier {N : ℕ} [NeZero N] (A : Finset (ZMod N)) :
     (tripleCount A : ℂ) + ↑A.card = (↑N)⁻¹ *
       Finset.univ.sum (fun r : ZMod N =>
         fourierCoeff A r ^ 2 * starRingEnd ℂ (fourierCoeff A (2 * r))) := by
-  -- Both sides equal |{(x,y,z) ∈ A³ : x+y=2z}|.
-  -- Part A (Fourier): RHS = Σ_{x,y,z∈A} δ(x+y=2z) via orthogonality
-  -- Part B (Combinatorial): LHS = |{(a,d) : a∈A, a+d∈A, a+2d∈A}| = same count
-  sorry -- Deferred: requires Fourier inversion + combinatorial bijection (~100 lines)
+  have hN : (↑N : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne N)
+  rw [eq_comm, inv_mul_eq_div, div_eq_iff hN, eq_comm]
+  -- Part A: Expand the Fourier sum via orthogonality
+  simp_rw [fourierCoeff_eq_sum_psi, sq]
+  simp_rw [map_sum (starRingEnd ℂ), conj_psi]
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  simp_rw [← psi_add]
+  simp_rw [show ∀ (r x z y : ZMod N),
+    ψ (r * x + (r * z + -((2 * r) * y))) = ψ (r * (x + z - 2 * y)) from
+    fun _ _ _ _ => congr_arg ψ (by ring)]
+  rw [Finset.sum_comm]
+  conv_lhs => arg 2; ext; rw [Finset.sum_comm]
+  conv_lhs => arg 2; ext; arg 2; ext; rw [Finset.sum_comm]
+  simp_rw [char_orthogonality, sub_eq_zero]
+  simp_rw [show ∀ (P : Prop) [Decidable P],
+    (if P then (↑N : ℂ) else 0) = ↑N * (if P then 1 else 0) from
+    fun P _ => by split_ifs <;> simp]
+  simp_rw [← Finset.mul_sum, ← Finset.mul_sum]
+  rw [← Finset.mul_sum, mul_comm]; congr 1
+  -- Part B: ∑_{x∈A} ∑_{z∈A} ∑_{y∈A} δ(x+z=2y) = tripleCount(A) + |A|
+  -- Rewrite x+z=2y ↔ z=2y-x, swap and collapse z-sum
+  simp_rw [show ∀ (x z y : ZMod N), x + z = 2 * y ↔ z = 2 * y - x from
+    fun x z y => ⟨fun h => by linarith, fun h => by linarith⟩]
+  simp_rw [Finset.sum_comm (s := A) (t := A)]
+  simp_rw [Finset.sum_ite_eq' A]
+  -- ∑_{x∈A} ∑_{y∈A} (if 2y-x ∈ A then 1 else 0) = tripleCount(A) + |A|
+  sorry
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART IV: LARGE FOURIER COEFFICIENT FROM AP-FREENESS

--- a/src/data/research/problems/roth-theorem-k3.json
+++ b/src/data/research/problems/roth-theorem-k3.json
@@ -18,12 +18,12 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-21",
-    "iteration": 3,
-    "focus": "char_orthogonality PROVED. 5 sorries remain: char_sum_int, parseval_on_zmod, triple_count_fourier, fourier_large_coefficient, density_increment_lemma",
+    "iteration": 4,
+    "focus": "parseval + char_sum_int PROVED (prior sessions). triple_count_fourier Part A (Fourier expansion) PROVED this session. 3 sorries remain.",
     "blockers": [
       "None. Independent problem, can start immediately."
     ],
-    "nextAction": "Prove parseval_on_zmod via orthogonality of ZMod characters",
+    "nextAction": "Prove triple_count_fourier Part B (combinatorial bijection), then fourier_large_coefficient",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,16 +31,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 4 new Fourier lemmas: psi_add (additivity), psi_zero, psi_ne_one, char_orthogonality (key character sum identity via shift argument). Reduced from 6 to 5 sorries. Remaining: char_sum_int, parseval_on_zmod, triple_count_fourier, fourier_large_coefficient, density_increment_lemma.",
+    "progressSummary": "PROGRESS: Session 4 proved Part A of triple_count_fourier: Fourier expansion via orthogonality (adapting Parseval pattern). Triple sum of ψ(r(x+z-2y)) collapsed to ∑δ(x+z=2y) via char_orthogonality. Part B (combinatorial identity) deferred. Net: 3 sorries remain.",
     "builtItems": [
       "Fixed apFree_singleton proof, Complex.abs -> norm, added apFree_subset, removed incorrect apFree_pair",
       "Build now succeeds: 0 axioms, 3 sorries",
-      "Proved fourierCoeff_norm_le: triangle inequality with |exp(i\u03b8)|=1 via push_cast+ring",
-      "Proved roth_density_bound: iterate density_iteration, choose K>100/\u03b4\u00b2, density>1 contradicts card_le_nat",
-      "Proved psi_add: \u03c8(a+b) = \u03c8(a)\u00b7\u03c8(b) via val_add + exp periodicity (same pattern as exp_val_mul_eq)",
-      "Proved psi_zero: \u03c8(0) = 1",
-      "Proved psi_ne_one: \u03c8(c) \u2260 1 when c \u2260 0, via Complex.exp_eq_one_iff + integer squeeze on val(c)",
-      "Proved char_orthogonality: \u03a3 \u03c8(r\u00b7c) = N\u00b7\u03b4(c=0) via shift argument (r\u21a6r+1 bijection on ZMod N)"
+      "Proved fourierCoeff_norm_le: triangle inequality with |exp(iθ)|=1 via push_cast+ring",
+      "Proved roth_density_bound: iterate density_iteration, choose K>100/δ², density>1 contradicts card_le_nat",
+      "Proved psi_add: ψ(a+b) = ψ(a)·ψ(b) via val_add + exp periodicity (same pattern as exp_val_mul_eq)",
+      "Proved psi_zero: ψ(0) = 1",
+      "Proved psi_ne_one: ψ(c) ≠ 1 when c ≠ 0, via Complex.exp_eq_one_iff + integer squeeze on val(c)",
+      "Proved char_orthogonality: Σ ψ(r·c) = N·δ(c=0) via shift argument (r↦r+1 bijection on ZMod N)",
+      "Proved triple_count_fourier Part A: Fourier expansion ∑Â(r)²conj(Â(2r)) = N·∑δ(x+z=2y)"
     ],
     "insights": [
       "RothTheorem.lean had 3 build errors: deprecated Finset.not_mem_empty, broken apFree_singleton, non-existent Complex.abs",
@@ -48,19 +49,22 @@
       "Complex.abs renamed in Mathlib v4.26.0 - use norm instead",
       "roth_density_bound could be proved from density_increment_lemma via iterated application",
       "field_simp handles div_mul_cancel cleanly when clearing denominators",
-      "push_cast normalizes \u2191(k+1) to \u2191k+1 for cast unification",
-      "Key lemma chain: density_iteration (proved) \u2192 roth_density_bound (now proved)",
-      "char_orthogonality proved via elegant shift argument: \u03c8(c)\u00b7S = S where S is the sum, and \u03c8(c) \u2260 1 forces S = 0",
-      "psi_add proof follows same pattern as exp_val_mul_eq: val(a+b) = (val(a)+val(b))%N, exponents differ by integer*2\u03c0i",
-      "psi_ne_one key step: Complex.exp_eq_one_iff reduces to val(c)/N \u2208 \u2124, then 0 < val(c) < N gives contradiction",
+      "push_cast normalizes ↑(k+1) to ↑k+1 for cast unification",
+      "Key lemma chain: density_iteration (proved) → roth_density_bound (now proved)",
+      "char_orthogonality proved via elegant shift argument: ψ(c)·S = S where S is the sum, and ψ(c) ≠ 1 forces S = 0",
+      "psi_add proof follows same pattern as exp_val_mul_eq: val(a+b) = (val(a)+val(b))%N, exponents differ by integer*2πi",
+      "psi_ne_one key step: Complex.exp_eq_one_iff reduces to val(c)/N ∈ ℤ, then 0 < val(c) < N gives contradiction",
       "PRE-EXISTING BREAKAGES: psi_add, psi_ne_one, char_orthogonality all broken by Mathlib API changes",
-      "char_sum_int proof strategy verified: omega=exp(2pi*m/N), sum omega^j, omega^N=1 via exp_eq_one_iff"
+      "char_sum_int proof strategy verified: omega=exp(2pi*m/N), sum omega^j, omega^N=1 via exp_eq_one_iff",
+      "triple_count_fourier follows same Parseval pattern but with THREE sums (ψ(rx)·ψ(rz)·conj(ψ(2ry))) + combinatorial bijection",
+      "fourier_large_coefficient bound δ²N/2 may be too strong — standard result is O(δ^{3/2}√N). Statement may need fixing.",
+      "Ring normalization in simp_rw: use congr_arg ψ (by ring) to match ψ arguments regardless of associativity"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "URGENT: Fix Mathlib API breakages in psi_add, psi_ne_one, char_orthogonality",
-      "After fixes: prove char_sum_int using root_unity_sum_zero + exp_eq_one_iff",
-      "Then parseval_on_zmod, triple_count_fourier, fourier_large_coefficient, density_increment_lemma"
+      "Prove triple_count_fourier Part B: show ∑_{x∈A}∑_{y∈A}δ(2y-x∈A) = tripleCount+|A| via bijection (x,y)↔(a,d)=(x,y-x)",
+      "Fix fourier_large_coefficient statement if needed (bound may be too strong for small N)",
+      "Prove density_increment_lemma using fourier_large_coefficient + pigeonhole"
     ]
   },
   "tags": [
@@ -79,7 +83,7 @@
     "mathlib": []
   },
   "started": "2026-03-22T06:10:36.236Z",
-  "lastUpdate": "2026-03-22T06:10:36.236Z",
+  "lastUpdate": "2026-03-22T20:00:00Z",
   "significance": 9,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Prove Part A of `triple_count_fourier`: the Fourier expansion half
- Adapts the Parseval proof pattern to expand `Â(r)² · conj(Â(2r))` as a triple sum
- Steps: expand as `∑ ψ(rx) · ψ(rz) · ψ(-2ry)`, combine ψ terms, swap sums, apply `char_orthogonality`
- Part B (combinatorial bijection identifying the count) deferred as sorry

## Status
- **3 sorries remain** (same count as before, but triple_count_fourier now mostly proved)
- Remaining Part B sorry: show `∑_{x∈A} ∑_{y∈A} δ(2y-x ∈ A) = tripleCount(A) + |A|`
- This is a pure combinatorial identity (no more Fourier analysis needed)

## Dependency chain
```
parseval_on_zmod (PROVED) ──────┐
triple_count_fourier (Part A ✓) ┤
                                 ├→ fourier_large_coefficient (sorry)
                                 │    └→ density_increment_lemma (sorry)
                                 │         └→ roth_density_bound (PROVED)
```

🤖 Generated by researcher-2