### PR TITLE
fix: Prevent future tags-undefined crashes at build and load time

### DIFF
--- a/scripts/research/build.ts
+++ b/scripts/research/build.ts
@@ -544,7 +544,7 @@ function generateListing(problem: ResearchProblem): ResearchListing {
     status: problem.status,
     tier: problem.tier,
     path: problem.path,
-    tags: problem.tags,
+    tags: problem.tags ?? [],
     started: problem.started,
     lastUpdate: problem.lastUpdate,
     completed: problem.completed,

--- a/src/data/research/index.ts
+++ b/src/data/research/index.ts
@@ -16,7 +16,11 @@ import type { ResearchListing, ResearchProblem } from '@/types/research'
 import listingsData from './research-listings.json'
 
 // Lightweight listings for ResearchPage - does not pull in full problem data
-export const researchListings: ResearchListing[] = listingsData as ResearchListing[]
+// Ensure tags always exists (defensive - build.ts should provide it)
+export const researchListings: ResearchListing[] = (listingsData as ResearchListing[]).map(l => ({
+  ...l,
+  tags: l.tags ?? [],
+}))
 
 /**
  * Asynchronously load research problem data for a given slug.


### PR DESCRIPTION
## Summary

Prevents the `a.tags is undefined` crash from recurring by fixing it at the source:

- **`scripts/research/build.ts`**: `tags: problem.tags ?? []` — ensures research-listings.json always has tags
- **`src/data/research/index.ts`**: Defensive `?? []` in loader as belt-and-suspenders

## Root cause
Seeker/researcher agents create problem JSONs without a `tags` field. The build script passed `undefined` through to research-listings.json, crashing the frontend.

## Test plan
- [ ] `pnpm build` passes
- [ ] Research page loads with problems that have no tags in source JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)