### PR TITLE
Enrich A₅ Simplicity Proof Chain: Feit-Thompson context

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04/annotations.json
@@ -51,7 +51,7 @@
     },
     "type": "concept",
     "title": "A₅ Is Simple — The Foundation",
-    "content": "The cornerstone of the entire chain: the alternating group A₅ is simple (has no proper non-trivial normal subgroups). This is the deepest fact used, proved in Mathlib by explicit computation on permutations. A₅ is the smallest non-abelian simple group, with order |A₅| = 60 = 5!/2. Its simplicity is equivalent to saying that the only normal subgroups are {e} and A₅ itself. The complete list of simple groups (the Classification of Finite Simple Groups) shows that A₅ ≅ PSL(2,4) ≅ PSL(2,5) is the first in the infinite family of alternating simple groups.\n\n**Why A₅ is simple (standard proof):** The conjugacy classes of A₅ have sizes 1, 12, 12, 15, 20. Any normal subgroup must be a union of conjugacy classes including {e}, and its order must divide 60. The only sub-sums of {1, 12, 12, 15, 20} that include 1 and divide 60 are 1 and 60 — so the only normal subgroups are {e} and A₅.\n\n**Burnside context:** Note that |A₅| = 60 = 2² · 3 · 5 involves three distinct primes. By Burnside's p^a q^b theorem (1904), every group of order p^a q^b (two primes) is solvable. A₅ is the smallest group escaping this criterion, making it the minimal counterexample to solvability in a precise sense.",
+    "content": "The cornerstone of the entire chain: the alternating group A₅ is simple (has no proper non-trivial normal subgroups). This is the deepest fact used, proved in Mathlib by explicit computation on permutations. A₅ is the smallest non-abelian simple group, with order |A₅| = 60 = 5!/2. Its simplicity is equivalent to saying that the only normal subgroups are {e} and A₅ itself. The complete list of simple groups (the Classification of Finite Simple Groups) shows that A₅ ≅ PSL(2,4) ≅ PSL(2,5) is the first in the infinite family of alternating simple groups.\n\n**Why A₅ is simple (standard proof):** The conjugacy classes of A₅ have sizes 1, 12, 12, 15, 20. Any normal subgroup must be a union of conjugacy classes including {e}, and its order must divide 60. The only sub-sums of {1, 12, 12, 15, 20} that include 1 and divide 60 are 1 and 60 — so the only normal subgroups are {e} and A₅.\n\n**Burnside context:** Note that |A₅| = 60 = 2² · 3 · 5 involves three distinct primes. By Burnside's p^a q^b theorem (1904), every group of order p^a q^b (two primes) is solvable. A₅ is the smallest group escaping this criterion, making it the minimal counterexample to solvability in a precise sense.\n\n**Feit-Thompson connection:** The Feit-Thompson odd-order theorem (1963) proves that every finite group of odd order is solvable — a 255-page proof that earned Thompson the Fields Medal (1970). This means any non-solvable finite group must have even order. Since |A₅| = 60 is even, this is consistent — but the theorem explains *why* the search for a non-solvable group inevitably leads to even-order groups. Combined with Burnside's theorem, the constraints tighten: A₅ must have order divisible by at least three distinct primes and be even, and 60 = 2²·3·5 is the smallest such number admitting a simple group.",
     "mathContext": "$A_5$ is simple: the only normal subgroups are $\\{e\\}$ and $A_5$. $|A_5| = 60 = 2^2 \\cdot 3 \\cdot 5$. By the Jordan-Hölder theorem, $A_5$ appears as the unique composition factor (up to isomorphism) in any composition series of $S_5$ that passes through $A_5$.",
     "significance": "key",
     "relatedConcepts": [
@@ -61,7 +61,8 @@
       "classification of finite simple groups",
       "Jordan-Hölder theorem",
       "composition series",
-      "Burnside p^a q^b theorem"
+      "Burnside p^a q^b theorem",
+      "Feit-Thompson odd-order theorem"
     ],
     "prerequisites": [
       "group theory",

--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -102,6 +102,11 @@
         "key": "Wu07",
         "citation": "Wussing, H., The Genesis of the Abstract Group Concept: A Contribution to the History of the Origin of Abstract Group Theory, Dover (2007, reprint of 1984 MIT Press edition).",
         "type": "book"
+      },
+      {
+        "key": "FT63",
+        "citation": "Feit, W. and Thompson, J.G., Solvability of groups of odd order, Pacific Journal of Mathematics 13(3) (1963), 775–1029.",
+        "type": "paper"
       }
     ],
     "relatedProofs": [


### PR DESCRIPTION
## Summary
- Added Feit-Thompson odd-order theorem (1963) reference — every group of odd order is solvable, explaining why non-solvable groups like A₅ must have even order
- Enhanced A₅ simplicity annotation with Feit-Thompson + Burnside constraint analysis showing |A₅| = 60 is the minimal non-solvable order
- Added `Feit-Thompson odd-order theorem` to relatedConcepts

*Note: Previous enrichment (AM-GM Hölder cross-reference) was superseded by branch reset. The AM-GM changes will be re-applied in a future enrichment pass.*

## Test plan
- [x] JSON valid (python3 parse check)
- [x] No new annotation build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)