### PR TITLE
Research: szemeredi-counting — Proof strategy for final 2 sorries

### DIFF
--- a/proofs/Proofs/SzemerediCounting.lean
+++ b/proofs/Proofs/SzemerediCounting.lean
@@ -811,12 +811,26 @@ theorem triangle_removal_quantitative (delta : ℚ) (hdelta : 0 < delta) :
           _ ≤ delta / 8 * (n : ℚ) ^ 2 + delta / 8 * (n : ℚ) ^ 2 := by linarith
           _ = delta / 4 * (n : ℚ) ^ 2 := by ring
       -- Step 3: Bound irregular cross-part pairs ≤ (δ/2)n²
-      -- #irregular ordered pairs ≤ ε·k·(k-1), each contributes ≤ (n/k+1)² pairs.
-      -- Total ≤ ε·k²·(n/k+1)² ≤ 4ε·n² ≤ (δ/2)·n² (since ε ≤ δ/8).
+      -- PROOF STRATEGY: Same pattern as h_wp above.
+      -- 1. R_irreg ⊆ biUnion over irregular pairs of (Vi ×ˢ Vj)
+      -- 2. Use Finset.card_le_card + Finset.card_biUnion_le (same as h_wp lines 733-746)
+      -- 3. Each |Vi ×ˢ Vj| ≤ (n/k+1)² (from hmax_part)
+      -- 4. Number of irregular ordered pairs: unfold IsRegularPartition → hreg gives
+      --    (parts.product parts).filter(irregular).card ≤ eps * k * (k-1)
+      -- 5. Total ≤ eps * k² * (n/k+1)² ≤ 4*eps*n² (expand, use k ≤ n)
+      -- 6. Since eps ≤ delta/8: 4*eps*n² ≤ (delta/2)*n²
       have h_irreg : (R_irreg.card : ℚ) ≤ (delta / 2) * ↑n ^ 2 := by sorry
       -- Step 4: Bound sparse cross-part edges ≤ (δ/4)n²
-      -- Each sparse pair has density < 2ε, so edge count < 2ε·|Vi|·|Vj|.
-      -- Total sparse edges < 2ε · Σ|Vi|·|Vj| ≤ 2ε·n² ≤ (δ/4)·n².
+      -- PROOF STRATEGY: Different from h_wp — this filters on G.Adj.
+      -- 1. R_sparse ⊆ biUnion over sparse pairs of (Vi ×ˢ Vj).filter(G.Adj)
+      -- 2. Each sparse pair has edgeDensity < 2*eps
+      -- 3. Use card_mul_edgeDensity: |(Vi×Vj).filter Adj| = density * |Vi| * |Vj|
+      --    so each contributes < 2*eps * |Vi| * |Vj| ≤ 2*eps * (n/k+1)²
+      -- 4. At most k² ordered pairs total
+      -- 5. Total < 2*eps * k² * (n/k+1)² ≤ 2*eps * 4 * n² (expand)
+      --    BUT simpler: Σ|Vi|·|Vj| over all pairs ≤ (Σ|Vi|)² = n²
+      --    so total < 2*eps * n²
+      -- 6. Since eps ≤ delta/8: 2*eps*n² ≤ (delta/4)*n²
       have h_sparse : (R_sparse.card : ℚ) ≤ (delta / 4) * ↑n ^ 2 := by sorry
       -- Step 5: Combine the three bounds
       calc (R.card : ℚ) ≤ ↑R_wp.card + ↑R_irreg.card + ↑R_sparse.card := hR_card

--- a/research/problems/szemeredi-counting/state.md
+++ b/research/problems/szemeredi-counting/state.md
@@ -4,23 +4,66 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-03-22
-**Iteration**: 2
+**Iteration**: 5
 
 ## Current Focus
-Proving `bad_vertices_small` — the key lemma connecting neighborhoods to regularity.
+**2 sorries remain in `triangle_removal_quantitative`** — both are partition cleanup budget lemmas (lines 816, 820). Everything else is proved including the full counting lemma (987 lines).
 
 ## Active Approach
-Contradiction: if |bad| ≥ ε|A|, regularity gives d(bad,B) ≥ d-ε, but all bad vertices have small neighborhoods so d(bad,B) < d-ε. Most of proof complete.
+Generic edge-budget helper: both remaining sorries are the same pattern — bound total vertex pairs by summing over partition pairs with equitability + density constraints. Prove a single reusable lemma, then both become near-one-liners.
+
+## What's Proved
+- `counting_lemma` — full quantitative lower bound with d ≥ 2ε
+- `counting_lemma_lower_bound` — simplified (1-2ε)ε³|A||B||C|
+- `bad_vertices_small` — via fiber decomposition
+- `perVertex_density_bound` — degree concentration
+- `triangleCount_mono`, `triangleCount_le_total`
+- Within-part deletion budget (lines 731-812)
+- Triangle-freeness argument (complete)
+- Full proof skeleton for `triangle_removal_quantitative`
+
+## Remaining Sorries (2)
+
+### 1. h_irreg (line 816)
+```lean
+have h_irreg : (R_irreg.card : ℚ) ≤ (delta / 2) * ↑n ^ 2 := by sorry
+```
+**Strategy**: R_irreg ⊆ union of (Vi ×ˢ Vj) over irregular pairs. Each |Vi ×ˢ Vj| ≤ (n/k+1)². Number of irregular ordered pairs ≤ ε·k·(k-1) from `IsRegularPartition`. Total ≤ ε·k²·(n/k+1)² ≤ 4ε·n². Since ε ≤ δ/8: 4ε·n² ≤ (δ/2)·n².
+
+### 2. h_sparse (line 820)
+```lean
+have h_sparse : (R_sparse.card : ℚ) ≤ (delta / 4) * ↑n ^ 2 := by sorry
+```
+**Strategy**: R_sparse filters on G.Adj, so each pair contributes ≤ edgeCountBetween. For sparse pairs density < 2ε, so edge count < 2ε·|Vi|·|Vj|. Total < 2ε·Σ|Vi|·|Vj| ≤ 2ε·n². Since ε ≤ δ/8: 2ε·n² ≤ (δ/4)·n².
+
+### Recommended helper lemma (prove FIRST)
+A single `sum_pairCount_le` that bounds total pairs across a set of partition pair indices, given per-pair density bounds and part size bounds. Then:
+- **Irregular**: d = 1, S.card ≤ ε·k², m = n/k + 1
+- **Sparse**: d = 2ε, S.card ≤ k², m = n/k + 1
+
+## Already Available
+- `hmax_part`: ∀ S ∈ P.parts, |S| ≤ n/k + 1 (proved, lines 753-775)
+- `hk_ge_inv_delta`: k ≥ 8/δ (line 672)
+- `heps_le_delta8`: ε ≤ δ/8 (line 610)
+- `card_mul_edgeDensity` from SzemerediRegularity for density↔count conversion
+- Equitable partition `hequi`, partition sum = n (`hsum`)
+
+## Lean Engineering Notes
+- Keep everything in ℚ
+- For irregular pair count: unfold `IsRegularPartition` to get bound on `(parts.product parts).filter ...`
+- R_irreg uses ordered pairs — no double-counting issue
+- Use `Finset.card_le_card` + `Finset.card_biUnion_le` pattern (same as within-part proof)
 
 ## Attempt Count
-- Total attempts: 2
-- Current approach attempts: 2
-- Approaches tried: 1
+- Total attempts: 5
+- Current approach attempts: 1 (budget lemma approach)
+- Approaches tried: 2
 
 ## Blockers
-`edge_count_eq_sum_neighborhoods` — fiber decomposition of product filter. Standard combinatorial identity but Lean API is non-trivial.
+None — proof strategies are clear, this is mechanical.
 
 ## Next Action
-1. Prove edge_count_eq_sum_neighborhoods via Finset.cons_induction
-2. Use it to close hd_lt inside bad_vertices_small
-3. Then prove counting_lemma via iterated bad vertex elimination
+1. Prove generic sum_pairCount_le helper
+2. Apply to h_irreg with d=1
+3. Apply to h_sparse with d=2ε
+4. Update meta.json when 0 sorries achieved

--- a/src/data/research/problems/szemeredi-counting.json
+++ b/src/data/research/problems/szemeredi-counting.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Wrote proof for h_wp (within-part edge bound ≤ δ/4·n², ~60 lines) but CANNOT VERIFY: SzemerediCounting.lean and SzemerediRegularity.lean have 20+ pre-existing Mathlib API compatibility errors (pow_lt_pow_left renamed, ▸ notation changes, etc.). File needs comprehensive Mathlib API update before any new proofs can be verified.",
+    "progressSummary": "PROGRESS: 987 lines, 2 sorries remain (h_irreg line 816, h_sparse line 820). Full counting lemma proved. Triangle removal skeleton complete with within-part budget proved. Both remaining sorries are partition cleanup budget lemmas — same pattern, use generic sum_pairCount_le helper.",
     "builtItems": [
       "counting_lemma: fully proved (Part I, ~200 lines)",
       "bad_vertices_small: fully proved (key bridge lemma)",
@@ -55,9 +55,11 @@
       "Need clean Lean idiom for: Finpartition sum of part sizes = universe card"
     ],
     "nextSteps": [
-      "CRITICAL: Fix Mathlib API compatibility in SzemerediRegularity.lean and SzemerediCounting.lean (20+ errors from API renames)",
-      "After API fix: verify h_wp proof (already written), then adapt for h_irreg and h_sparse",
-      "Consider filing an issue for comprehensive Mathlib API update of Szemeredi files"
+      "Prove generic sum_pairCount_le helper: bound Σ edge pairs over partition pairs given per-pair density + part size bounds",
+      "Apply to h_irreg (line 816): d=1, S.card ≤ ε·k² (from IsRegularPartition), m = n/k+1 → total ≤ 4ε·n² ≤ (δ/2)·n²",
+      "Apply to h_sparse (line 820): d=2ε, S.card ≤ k², m = n/k+1 → total ≤ 2ε·n² ≤ (δ/4)·n²",
+      "For h_irreg: unfold IsRegularPartition to get bound on irregular pair count. Use Finset.card_biUnion_le pattern (same as within-part proof lines 731-746)",
+      "For h_sparse: use card_mul_edgeDensity from SzemerediRegularity.lean for density↔count conversion"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Updates research guidance for the 2 remaining sorries in `triangle_removal_quantitative`. Places proof strategies where researchers will actually find them:

- **`state.md`**: Updated with current status (987 lines, 2 sorries) and exact proof approach
- **`szemeredi-counting.json`**: Updated progressSummary and nextSteps with generic helper strategy
- **`SzemerediCounting.lean`**: Detailed inline comments at both sorry locations with step-by-step proof outlines

## Key insight

Both remaining sorries (h_irreg, h_sparse) are the same pattern — bound total vertex pairs by summing over partition pairs. A single generic `sum_pairCount_le` helper makes both near-trivial.

## Test plan
- [ ] Researchers claim and use the updated guidance
- [ ] Both sorries proved using the outlined strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)