### PR TITLE
feat: Add infrastructure badge and proof dependency links

### DIFF
--- a/src/components/proof/ProofConclusion.tsx
+++ b/src/components/proof/ProofConclusion.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
-import { ChevronDown, ChevronUp, MessageSquare, AlertCircle, Lightbulb } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { ChevronDown, ChevronUp, MessageSquare, AlertCircle, Lightbulb, ArrowRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { MarkdownMath, MarkdownMathInline } from '@/components/ui/markdown-math'
-import type { Proof } from '@/types/proof'
+import type { Proof, CrossReference } from '@/types/proof'
 
 interface ProofConclusionProps {
   proof: Proof
@@ -171,6 +172,37 @@ export function ProofConclusion({ proof }: ProofConclusionProps) {
                   )}
                 </div>
               )}
+            </section>
+          )}
+
+          {/* Related Proofs */}
+          {(proof.crossReferences ?? []).length > 0 && (
+            <section>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+                Related Proofs
+              </h3>
+              <ul className="space-y-2">
+                {(proof.crossReferences ?? []).map((ref: CrossReference, i: number) => {
+                  const refSlug = ref.proofId ?? ref.targetId
+                  if (!refSlug) return null
+                  return (
+                    <li key={i}>
+                      <Link
+                        to={`/proof/${refSlug}`}
+                        className="group flex items-start gap-3 text-sm bg-muted/20 rounded-lg p-3 border border-border/50 hover:border-annotation/30 hover:bg-muted/30 transition-colors"
+                      >
+                        <ArrowRight className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground group-hover:text-annotation transition-colors" />
+                        <div>
+                          <span className="font-medium text-annotation group-hover:underline">{refSlug}</span>
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {ref.description ?? ref.relationship}
+                          </p>
+                        </div>
+                      </Link>
+                    </li>
+                  )
+                })}
+              </ul>
             </section>
           )}
 

--- a/src/components/proof/ProofOverview.tsx
+++ b/src/components/proof/ProofOverview.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
-import { ChevronDown, ChevronUp, ExternalLink, Lightbulb, Package, Award, History, CheckCircle, Clock, AlertCircle, AlertTriangle, Eye, Play } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { ChevronDown, ChevronUp, ExternalLink, Lightbulb, Package, Award, History, CheckCircle, Clock, AlertCircle, AlertTriangle, Eye, Play, ArrowRight } from 'lucide-react'
 import { MarkdownMath, MarkdownMathInline } from '@/components/ui/markdown-math'
 import { ProofBadge } from '@/components/ui/proof-badge'
 import { BADGE_INFO } from '@/types/proof'
-import type { Proof, ProofVersionInfo, VersionHistoryEntry } from '@/types/proof'
+import type { Proof, ProofVersionInfo, VersionHistoryEntry, CrossReference } from '@/types/proof'
 import { ErdosProblemCard } from './ErdosProblemCard'
 import {
   Dialog,
@@ -339,6 +340,47 @@ export function ProofOverview({ proof, versionInfo }: ProofOverviewProps) {
               <div className="bg-muted/20 rounded-lg p-4 border border-border/50">
                 <VisualizationComponent />
               </div>
+            </section>
+          )}
+
+          {/* Infrastructure banner */}
+          {meta.badge === 'infrastructure' && (
+            <div className="flex items-center gap-3 text-sm bg-slate-500/10 rounded-lg px-4 py-3 border border-slate-500/20">
+              <span className="text-base">🧱</span>
+              <span className="text-foreground/90">
+                This is a shared library module providing definitions used by other proofs.
+              </span>
+            </div>
+          )}
+
+          {/* Related Proofs */}
+          {(proof.crossReferences ?? []).length > 0 && (
+            <section>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+                Related Proofs
+              </h3>
+              <ul className="space-y-2">
+                {(proof.crossReferences ?? []).map((ref: CrossReference, i: number) => {
+                  const refSlug = ref.proofId ?? ref.targetId
+                  if (!refSlug) return null
+                  return (
+                    <li key={i}>
+                      <Link
+                        to={`/proof/${refSlug}`}
+                        className="group flex items-start gap-3 text-sm bg-muted/20 rounded-lg p-3 border border-border/50 hover:border-annotation/30 hover:bg-muted/30 transition-colors"
+                      >
+                        <ArrowRight className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground group-hover:text-annotation transition-colors" />
+                        <div>
+                          <span className="font-medium text-annotation group-hover:underline">{refSlug}</span>
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {ref.description ?? ref.relationship}
+                          </p>
+                        </div>
+                      </Link>
+                    </li>
+                  )
+                })}
+              </ul>
             </section>
           )}
         </div>

--- a/src/components/ui/proof-badge.tsx
+++ b/src/components/ui/proof-badge.tsx
@@ -183,7 +183,7 @@ interface BadgeFilterProps {
  * Filter buttons for selecting proof badges
  */
 export function BadgeFilter({ selectedBadges, onToggle, className = '' }: BadgeFilterProps) {
-  const badges: ProofBadgeType[] = ['ai-solved', 'original', 'mathlib', 'pedagogical', 'from-axioms', 'axiom', 'wip']
+  const badges: ProofBadgeType[] = ['ai-solved', 'original', 'mathlib', 'pedagogical', 'from-axioms', 'axiom', 'infrastructure', 'wip']
 
   return (
     <div className={`flex flex-wrap gap-2 ${className}`}>

--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -70,9 +70,19 @@ export async function getProofAsync(slug: string): Promise<ProofData | undefined
           sections: m.sections || [],
           overview: m.overview,
           conclusion: m.conclusion,
+          crossReferences: m.crossReferences,
           source: '',
         },
         annotations: (module.annotations?.default || module.annotations || []) as Annotation[],
+      }
+    }
+
+    // Inject crossReferences from raw meta.json if the proof object doesn't have them
+    if (proofData?.proof && !proofData.proof.crossReferences) {
+      const rawMeta = module.meta?.default || module.meta || module.default?.proof
+      const crossRefs = rawMeta?.crossReferences
+      if (crossRefs && Array.isArray(crossRefs)) {
+        proofData.proof.crossReferences = crossRefs
       }
     }
 

--- a/src/data/proofs/szemeredi-core/annotations.json
+++ b/src/data/proofs/szemeredi-core/annotations.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "szemeredi-core-edge-density",
+    "proofId": "szemeredi-core",
+    "range": { "startLine": 29, "endLine": 34 },
+    "type": "definition",
+    "title": "Edge Density",
+    "content": "The edge density d(A,B) counts the fraction of possible edges between vertex subsets A and B that are actually present. Returns 0 when either set is empty.",
+    "mathContext": "d(A,B) = |{(a,b) in A x B : a ~ b}| / (|A| * |B|). Fundamental to all regularity arguments.",
+    "significance": "critical"
+  },
+  {
+    "id": "szemeredi-core-epsilon-regular",
+    "proofId": "szemeredi-core",
+    "range": { "startLine": 36, "endLine": 45 },
+    "type": "definition",
+    "title": "Epsilon-Regular Pair",
+    "content": "A pair (A, B) is epsilon-regular if every sufficiently large sub-pair has edge density close to d(A,B). This captures the notion that the pair behaves like a random bipartite graph.",
+    "mathContext": "For all A' subset A, B' subset B with |A'| >= eps*|A| and |B'| >= eps*|B|: |d(A',B') - d(A,B)| <= eps.",
+    "significance": "critical"
+  },
+  {
+    "id": "szemeredi-core-regular-partition",
+    "proofId": "szemeredi-core",
+    "range": { "startLine": 47, "endLine": 56 },
+    "type": "definition",
+    "title": "Regular Partition",
+    "content": "An equitable partition where at most epsilon * C(k,2) pairs are not epsilon-regular. The regularity lemma guarantees such partitions exist for any epsilon > 0.",
+    "significance": "critical"
+  },
+  {
+    "id": "szemeredi-core-partition-energy",
+    "proofId": "szemeredi-core",
+    "range": { "startLine": 58, "endLine": 68 },
+    "type": "definition",
+    "title": "Partition Energy",
+    "content": "The size-weighted energy q(P) = sum of (|Pi|*|Pj|/n^2) * d(Pi,Pj)^2 over all pairs. This potential function drives the regularity lemma proof: it increases by at least eps^5 at each refinement step and is bounded by 1.",
+    "mathContext": "q(P) in [0,1] and monotone under refinement. The key insight: bounded energy + positive increment = termination.",
+    "significance": "critical"
+  },
+  {
+    "id": "szemeredi-core-density-bounds",
+    "proofId": "szemeredi-core",
+    "range": { "startLine": 70, "endLine": 92 },
+    "type": "theorem",
+    "title": "Edge Density Bounds",
+    "content": "Edge density lies in [0,1]. The upper bound uses that the number of edges between A and B is at most |A|*|B| (every pair contributes at most one edge).",
+    "significance": "key"
+  },
+  {
+    "id": "szemeredi-core-energy-nonneg",
+    "proofId": "szemeredi-core",
+    "range": { "startLine": 94, "endLine": 109 },
+    "type": "theorem",
+    "title": "Partition Energy Non-negativity",
+    "content": "Each summand in the partition energy is a product of non-negative factors (natural number casts, squares), so the sum is non-negative.",
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/szemeredi-core/index.ts
+++ b/src/data/proofs/szemeredi-core/index.ts
@@ -1,0 +1,46 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/SzemerediCore.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/szemeredi-core/meta.json
+++ b/src/data/proofs/szemeredi-core/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "szemeredi-core",
+  "title": "Szemeredi Core Definitions",
+  "slug": "szemeredi-core",
+  "description": "Shared definitions and basic lemmas for the Szemeredi regularity pipeline: edge density, epsilon-regular pairs, regular partitions, and partition energy. Imported by both SzemerediRegularity and SzemerediCounting.",
+  "meta": {
+    "author": "Szemeredi (1975), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Szemer%C3%A9di_regularity_lemma",
+    "date": "1975",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SzemerediCore.lean",
+    "tags": [
+      "szemeredi",
+      "combinatorics",
+      "graph-theory",
+      "regularity",
+      "infrastructure"
+    ],
+    "badge": "infrastructure",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph",
+        "description": "Graph structure for vertex and edge operations",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "Finset.product",
+        "description": "Cartesian product for edge counting between subsets",
+        "module": "Mathlib.Data.Finset.Product"
+      },
+      {
+        "theorem": "Fintype.card",
+        "description": "Cardinality of finite types for partition energy normalization",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ],
+    "originalContributions": [
+      "Edge density definition for SimpleGraph bipartite subgraphs",
+      "Epsilon-regular pair definition with quantified subset condition",
+      "Regular partition definition combining equitability and bounded irregularity",
+      "Size-weighted partition energy following Komlos-Simonovits (1996)",
+      "Proved: edgeDensity_nonneg, edgeDensity_le_one, partitionEnergy_nonneg"
+    ],
+    "dateAdded": "03/22/26",
+    "axiomCount": 0,
+    "lineCount": 110
+  },
+  "overview": {
+    "historicalContext": "The definitions in this module form the foundation of the Szemeredi regularity pipeline. Edge density, epsilon-regularity, and partition energy were introduced in Szemeredi's 1975 proof of his theorem on arithmetic progressions, and later refined by Komlos and Simonovits (1996) into the standard toolkit for regularity-based arguments.\n\nBy extracting these shared definitions into a core module, both the regularity lemma and the counting/removal lemma files can import a single source of truth, preventing definition drift across the pipeline.",
+    "problemStatement": "Define the fundamental concepts for graph regularity:\n\n- **Edge density** $d(A,B) = |E(A,B)| / (|A| \\cdot |B|)$ between vertex subsets\n- **Epsilon-regular pair**: $(A,B)$ is $\\varepsilon$-regular if all large sub-pairs have density within $\\varepsilon$ of $d(A,B)$\n- **Regular partition**: at most $\\varepsilon \\binom{k}{2}$ pairs are irregular\n- **Partition energy**: $q(\\mathcal{P}) = \\sum_{i,j} \\frac{|P_i||P_j|}{n^2} d(P_i,P_j)^2$\n\nProve that edge density lies in $[0,1]$ and partition energy is non-negative.",
+    "proofStrategy": "The module provides definitions and three proved lemmas:\n\n1. **edgeDensity_nonneg**: By positivity of the numerator and denominator.\n2. **edgeDensity_le_one**: The number of edges between $A$ and $B$ is at most $|A| \\cdot |B|$ (every pair in the product can contribute at most one edge).\n3. **partitionEnergy_nonneg**: Each summand is a product of non-negative factors (cardinalities, squares).",
+    "keyInsights": [
+      "Centralizing definitions prevents the regularity and counting modules from using incompatible variants of edge density or regularity",
+      "Edge density bounds (0 to 1) are fundamental sanity checks used throughout the regularity pipeline",
+      "Partition energy is the key potential function: bounded above by 1 and increasing with each refinement step"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Imports",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Module docstring listing all definitions and lemmas. Imports Mathlib, opens Classical, and declares finite vertex type variables."
+    },
+    {
+      "id": "edge-density",
+      "title": "Edge Density Definition",
+      "startLine": 29,
+      "endLine": 34,
+      "summary": "Defines edgeDensity G A B as |{(a,b) in A x B : G.Adj a b}| / (|A| * |B|), handling the zero case."
+    },
+    {
+      "id": "regularity-defs",
+      "title": "Epsilon-Regularity and Regular Partitions",
+      "startLine": 36,
+      "endLine": 56,
+      "summary": "Defines IsEpsilonRegular (all large sub-pairs have density within epsilon) and IsRegularPartition (equitable with bounded irregular pairs)."
+    },
+    {
+      "id": "partition-energy",
+      "title": "Partition Energy",
+      "startLine": 58,
+      "endLine": 68,
+      "summary": "Defines the size-weighted partition energy q(P) following Komlos-Simonovits (1996)."
+    },
+    {
+      "id": "basic-lemmas",
+      "title": "Basic Lemmas",
+      "startLine": 70,
+      "endLine": 110,
+      "summary": "Proves edgeDensity_nonneg, edgeDensity_le_one (via card_filter_le and card_product), and partitionEnergy_nonneg (via sum_nonneg)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "szemeredi-regularity",
+      "relationship": "Provides core definitions imported by the regularity lemma"
+    },
+    {
+      "proofId": "szemeredi-counting",
+      "relationship": "Provides core definitions imported by the counting and removal lemmas"
+    }
+  ],
+  "conclusion": {
+    "summary": "This module provides the shared mathematical vocabulary for the Szemeredi regularity pipeline. All definitions are sorry-free and axiom-free, with basic properties proved.",
+    "implications": "By centralizing edge density, epsilon-regularity, regular partitions, and partition energy in a single module, the full Szemeredi pipeline (regularity, counting, removal, and the full theorem) can share definitions without drift.",
+    "openQuestions": [
+      "Should the module also include the energy increment lemma statement?",
+      "Can these definitions be generalized to weighted graphs or hypergraphs?"
+    ]
+  }
+}

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -127,6 +127,11 @@
   ],
   "crossReferences": [
     {
+      "targetId": "szemeredi-core",
+      "relationship": "depends-on",
+      "description": "Uses shared definitions from the core infrastructure module"
+    },
+    {
       "targetId": "szemeredi-regularity",
       "relationship": "depends-on",
       "description": "The counting and removal lemmas are direct applications of the Regularity Lemma"

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -154,6 +154,10 @@
   },
   "crossReferences": [
     {
+      "proofId": "szemeredi-core",
+      "relationship": "Uses shared definitions from the core infrastructure module"
+    },
+    {
       "proofId": "szemeredi-counting",
       "relationship": "The counting and removal lemmas are the primary applications of regularity"
     },

--- a/src/types/proof.ts
+++ b/src/types/proof.ts
@@ -1,3 +1,18 @@
+/**
+ * Cross-reference linking one proof to another with a description of the relationship.
+ * Existing meta.json files use either `proofId` or `targetId` for the linked proof's slug.
+ */
+export interface CrossReference {
+  /** Slug of the related proof (preferred field name) */
+  proofId?: string
+  /** Slug of the related proof (legacy field name, treated as alias for proofId) */
+  targetId?: string
+  /** Human-readable description of the relationship */
+  relationship: string
+  /** Optional extended description */
+  description?: string
+}
+
 export interface Proof {
   id: string
   title: string
@@ -8,6 +23,8 @@ export interface Proof {
   meta: ProofMeta
   overview?: ProofOverview
   conclusion?: ProofConclusion
+  /** Links to related proofs with relationship descriptions */
+  crossReferences?: CrossReference[]
 }
 
 export interface ProofOverview {
@@ -46,6 +63,7 @@ export type ProofBadge =
   | 'wip'                // 🚧 Has sorries or incomplete sections
   | 'ai-solved'          // 🤖 Open problem solved by AI
   | 'axiom'              // 📜 States key results as axioms (axiomatized formalization)
+  | 'infrastructure'     // 🧱 Shared library providing reusable definitions for other proofs
 
 /**
  * Display information for proof badges
@@ -98,6 +116,12 @@ export const BADGE_INFO: Record<ProofBadge, { emoji: string; label: string; colo
     label: 'Axiomatized',
     color: '#A855F7',
     description: 'States key results as axioms for formalization'
+  },
+  'infrastructure': {
+    emoji: '🧱',
+    label: 'Infrastructure',
+    color: '#64748B',
+    description: 'Shared library providing reusable definitions for other proofs'
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `infrastructure` badge type (slate #64748B) for shared library modules like SzemerediCore.lean
- Renders `crossReferences` from meta.json as clickable "Related Proofs" links in both ProofOverview and ProofConclusion
- Creates the szemeredi-core gallery entry (verified, 0 sorries, infrastructure badge) with cross-references to szemeredi-regularity and szemeredi-counting
- Updates szemeredi-regularity and szemeredi-counting meta.json to link back to szemeredi-core

## Changes

### Types (`src/types/proof.ts`)
- Added `'infrastructure'` to `ProofBadge` union type
- Added `infrastructure` entry to `BADGE_INFO` constant
- Added `CrossReference` interface with support for both `proofId` (preferred) and `targetId` (legacy) field names
- Added `crossReferences?: CrossReference[]` to `Proof` interface

### Data Loader (`src/data/proofs/index.ts`)
- Pass `crossReferences` through in the legacy meta.json fallback path
- Add normalization step to inject `crossReferences` from raw meta when proof objects miss them

### ProofOverview (`src/components/proof/ProofOverview.tsx`)
- Import `Link` from react-router-dom and `ArrowRight` from lucide-react
- Show infrastructure banner when `meta.badge === 'infrastructure'`
- Render "Related Proofs" section with linked slugs after Key Insights

### ProofConclusion (`src/components/proof/ProofConclusion.tsx`)
- Import `Link` and `ArrowRight`
- Render "Related Proofs" section before the status reminder

### Badge Filter (`src/components/ui/proof-badge.tsx`)
- Include `'infrastructure'` in the badge filter options array

### Data Files
- New: `src/data/proofs/szemeredi-core/` (meta.json, annotations.json, index.ts)
- Updated: `szemeredi-regularity/meta.json` - added szemeredi-core cross-reference
- Updated: `szemeredi-counting/meta.json` - added szemeredi-core cross-reference

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally, clean)
- [ ] No new lint errors (pre-existing VisualizationComponent lint issue unchanged)
- [ ] Proof pages without crossReferences render normally (optional chaining used throughout)
- [ ] szemeredi-core page shows infrastructure badge and banner
- [ ] szemeredi-regularity page shows "Related Proofs" section including szemeredi-core link
- [ ] Clicking a related proof link navigates to `/proof/{slug}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)