### PR TITLE
Enrich batch: 4 entries - schema fixes, cross-references, bugfix

### DIFF
--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -49,7 +49,31 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 38,
     "axiomCount": 0,
-    "lineCount": 225
+    "lineCount": 225,
+    "relatedProblems": [
+      {
+        "id": "amgm-inequality-oq-02",
+        "relationship": "Sub-entry exploring extensions or open questions arising from AM-GM"
+      },
+      {
+        "id": "amgm-inequality-oq-03",
+        "relationship": "Power mean hierarchy generalizing the AM-GM chain"
+      }
+    ],
+    "leanFile": {
+      "lineCount": 225,
+      "structureCount": 0,
+      "axiomCount": 0,
+      "theoremCount": 8,
+      "lemmaCount": 0,
+      "defCount": 0,
+      "imports": [
+        "Mathlib.Analysis.MeanInequalities",
+        "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+        "Mathlib.Algebra.Order.Field.Basic",
+        "Mathlib.Tactic"
+      ]
+    }
   },
   "overview": {
     "historicalContext": "The AM-GM inequality has ancient origins. Euclid implicitly used it in Book VI of the *Elements* (~300 BCE): if you inscribe a right triangle in a semicircle and drop an altitude from the right angle to the hypotenuse, the altitude's length is the geometric mean of the two segments of the hypotenuse. Since the altitude can be no longer than the radius (the arithmetic mean of the two segments), this gives AM ≥ GM geometrically.\n\nThe first general n-variable proof was given by Augustin-Louis Cauchy in his 1821 *Cours d'analyse*. Cauchy's elegant method uses **forward-backward induction**: he first proves the inequality for powers of 2 (by repeatedly applying the two-variable case), then shows that if AM-GM holds for n numbers, it holds for n-1 numbers as well (by setting one variable equal to the mean). This backward step is the clever insight that makes the induction work without needing $n$ to increase by 1 each time.\n\nIndependently, Colin Maclaurin (1729) discovered a hierarchy of symmetric inequalities that imply AM-GM as a special case. His *Maclaurin inequalities* relate the elementary symmetric polynomial means and strictly strengthen AM-GM for distinct values.\n\nGeorge Pólya later gave what many consider the most elegant proof: the exponential inequality $e^{x-1} \\geq x$ (with equality iff $x=1$) applied to each ratio $a_i / G$ (where $G$ is the geometric mean) immediately yields $e^{A/G - 1} \\geq A/G \\geq 1$, hence $A \\geq G$. This proof, featured in Steele's *Cauchy-Schwarz Master Class*, reveals AM-GM as a consequence of the convexity of $e^x$.\n\nToday AM-GM is one of the most ubiquitous tools in mathematical analysis, combinatorics, and optimization. It appears in proofs of the Cauchy-Schwarz inequality, bounds on entropy in information theory, and the isoperimetric inequality. It is #38 on Wiedijk's landmark list of 100 theorems deemed important to formalize in proof assistants.",
@@ -124,6 +148,16 @@
       "targetId": "area-of-circle",
       "relationship": "related",
       "description": "AM-GM's product-sum corollary $ab \\leq ((a+b)/2)^2$ proves that the square maximizes area among rectangles with fixed perimeter — the discrete analogue of the continuous isoperimetric principle that the circle maximizes area for given perimeter, yielding $A = \\pi r^2$."
+    },
+    {
+      "targetId": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\approx \\sqrt{2\\pi n}(n/e)^n$ uses the log-AM-GM inequality in its derivation: bounding $\\sum \\log k$ by integrals of $\\log x$ relies on the concavity of $\\log$ (the same convexity argument underlying the weighted AM-GM)."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related",
+      "description": "AM-GM yields central binomial coefficient estimates: $\\binom{2n}{n} \\leq 4^n$ follows from $\\binom{2n}{n} = \\sum \\binom{n}{k}^2 / \\binom{2n}{n}$ via AM-GM-like counting, and the entropy bound $\\binom{n}{k} \\leq 2^{nH(k/n)}$ uses the AM-GM / Jensen connection through the binary entropy function."
     }
   ],
   "relatedProofs": [
@@ -137,7 +171,9 @@
     "amgm-inequality-oq-03-oq-01",
     "amgm-inequality-oq-03-oq-02",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
-    "area-of-circle"
+    "area-of-circle",
+    "stirling-formula",
+    "binomial-theorem"
   ],
   "sections": [
     {
@@ -203,7 +239,8 @@
     "openQuestions": [
       "How does AM-GM generalize to operator means in matrix analysis? The matrix AM-GM inequality $A \\# B \\leq (A+B)/2$ (where $\\#$ is the geometric mean of positive-definite matrices) requires substantially deeper machinery.",
       "Maclaurin's inequalities $e_1/\\binom{n}{1} \\geq (e_2/\\binom{n}{2})^{1/2} \\geq \\cdots \\geq (e_n/\\binom{n}{n})^{1/n}$ (where $e_k$ are elementary symmetric polynomials) strictly refine AM-GM—are these fully formalized in Mathlib?",
-      "How do weighted power means $M_p = (\\sum w_i z_i^p)^{1/p}$ interpolate between GM ($p \\to 0$) and AM ($p=1$), and can Lean verify the full monotonicity of $p \\mapsto M_p$?"
+      "How do weighted power means $M_p = (\\sum w_i z_i^p)^{1/p}$ interpolate between GM ($p \\to 0$) and AM ($p=1$), and can Lean verify the full monotonicity of $p \\mapsto M_p$?",
+      "The Gauss arithmetic-geometric mean iteration $a_{n+1} = (a_n + b_n)/2$, $b_{n+1} = \\sqrt{a_n b_n}$ converges quadratically to the AGM, which computes elliptic integrals: $\\int_0^{\\pi/2} d\\theta/\\sqrt{a^2\\cos^2\\theta + b^2\\sin^2\\theta} = \\pi/(2\\cdot\\text{AGM}(a,b))$. Can this convergence and the elliptic integral connection be formalized in Lean?"
     ]
   },
   "references": [
@@ -241,6 +278,13 @@
       "year": "2003",
       "venue": "Kluwer Academic Publishers (Mathematics and Its Applications, vol. 560)",
       "note": "Encyclopedic reference cataloging over 50 types of means and their ordering properties. Chapter III covers the AM-GM inequality with 15 distinct proofs including Cauchy's forward-backward induction, Pólya's exponential proof, and proofs via Schur convexity and majorization"
+    },
+    {
+      "authors": "Cox, David A.",
+      "title": "The Arithmetic-Geometric Mean of Gauss",
+      "year": "1984",
+      "venue": "L'Enseignement Mathématique, vol. 30, pp. 275–330",
+      "note": "Definitive account of Gauss's arithmetic-geometric mean iteration and its connection to elliptic integrals — the most beautiful computational application of the AM-GM inequality, achieving quadratic convergence for computing π and elliptic functions"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -56,6 +56,20 @@
       "Basic Galois theory (constructibility criterion)"
     ],
     "lineCount": 389,
+    "relatedProblems": [
+      {
+        "id": "angle-trisection-oq-02",
+        "relationship": "Galois characterization of constructibility extending the degree argument"
+      },
+      {
+        "id": "angle-trisection-oq-02-oq-01",
+        "relationship": "Wantzel-Galois characterization connecting Polynomial.Gal to constructibility"
+      },
+      {
+        "id": "angle-trisection-oq-02-oq-03",
+        "relationship": "Further extensions of the constructibility framework"
+      }
+    ],
     "references": [
       {
         "key": "Wa37",
@@ -213,6 +227,16 @@
       "targetId": "cantor-diagonalization",
       "relationship": "thematic",
       "description": "Both belong to the impossibility proof tradition: Cantor's diagonal argument proves no enumeration reaches all reals (1891), Wantzel's argument proves no compass-straightedge construction trisects all angles (1837). Both show that natural-seeming operations (enumeration, geometric construction) have provable limitations"
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Proves the Wantzel-Galois characterization connecting Polynomial.Gal to constructibility — strengthening the degree criterion to a full group-theoretic characterization: α is constructible iff the Galois group of its minimal polynomial is a 2-group"
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "foundational",
+      "description": "The irrationality of $\\sqrt[3]{2}$ (a special case of the $n$-th root irrationality) is the simplest instance of the degree-3 obstruction to constructibility: $[\\mathbb{Q}(\\sqrt[3]{2}):\\mathbb{Q}] = 3$, and $3 \\nmid 2^n$. The same argument proves the impossibility of doubling the cube"
     }
   ],
   "overview": {
@@ -324,6 +348,8 @@
     "godel-incompleteness",
     "area-of-circle",
     "vietas-formulas",
-    "cantor-diagonalization"
+    "cantor-diagonalization",
+    "angle-trisection-oq-02-oq-01",
+    "nth-root-irrational"
   ]
 }

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -49,6 +49,16 @@
     "wiedijkNumber": 9,
     "axiomCount": 0,
     "lineCount": 155,
+    "relatedProblems": [
+      {
+        "id": "area-of-circle-oq-01",
+        "relationship": "Derives circumference C = 2πr via differentiation of area"
+      },
+      {
+        "id": "area-of-circle-oq-03",
+        "relationship": "Formalizes Archimedes' method of exhaustion directly"
+      }
+    ],
     "prerequisites": [
       "Real analysis (integration, limits)",
       "Measure theory (Lebesgue measure for area)",
@@ -298,41 +308,6 @@
       "year": "2005",
       "venue": "Princeton Lectures in Analysis, vol. 3, Princeton University Press",
       "note": "Modern treatment of Lebesgue measure and volume computation for balls in ℝⁿ — the framework underlying this formalization's approach via MeasureTheory.volume"
-    }
-  ],
-  "relatedProofs": [
-    "angle-trisection",
-    "buffons-needle"
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls",
-      "Mathlib.Tactic"
-    ],
-    "opens": [
-      "MeasureTheory",
-      "Metric"
-    ],
-    "namespace": "AreaOfCircle",
-    "lineCount": 155,
-    "axiomCount": 0,
-    "theoremCount": 7,
-    "definitionCount": 0
-  },
-  "references": [
-    {
-      "authors": "Archimedes",
-      "title": "Measurement of a Circle",
-      "year": "~250 BCE",
-      "venue": "Syracuse",
-      "note": "First rigorous calculation of the area of a circle using the method of exhaustion — bounded π between 3 10/71 and 3 1/7"
-    },
-    {
-      "authors": "Stillwell, John",
-      "title": "Mathematics and Its History",
-      "year": "2010",
-      "venue": "Springer, 3rd edition",
-      "note": "Historical account of Archimedes's method and its connection to integral calculus"
     }
   ]
 }

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -41,7 +41,30 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 68,
     "axiomCount": 0,
-    "lineCount": 187
+    "lineCount": 187,
+    "relatedProblems": [
+      {
+        "id": "arithmetic-series-oq-02",
+        "relationship": "Generalizes to simplicial numbers and higher-dimensional arithmetic sums"
+      },
+      {
+        "id": "arithmetic-series-oq-02-oq-02",
+        "relationship": "Further extensions of simplicial number theory"
+      }
+    ],
+    "leanFile": {
+      "lineCount": 187,
+      "structureCount": 0,
+      "axiomCount": 0,
+      "theoremCount": 11,
+      "lemmaCount": 0,
+      "defCount": 1,
+      "imports": [
+        "Mathlib.Algebra.BigOperators.Intervals",
+        "Mathlib.Algebra.BigOperators.Ring.Finset",
+        "Mathlib.Tactic"
+      ]
+    }
   },
   "overview": {
     "historicalContext": "The formula for 1 + 2 + ... + n = n(n+1)/2 is famously attributed to Carl Friedrich Gauss, who allegedly discovered it as a schoolboy around 1785. The story goes that when his teacher asked the class to sum the numbers 1 to 100 (hoping for a quiet classroom), young Gauss immediately answered 5050.\n\nGauss realized that pairing 1+100, 2+99, 3+98, etc. gives 50 pairs, each summing to 101, yielding 50 x 101 = 5050. This pairing argument is the essence of the proof.\n\nWhile this anecdote may be apocryphal, the formula was known to the ancient Greeks and appears in works by Archimedes. It also appears in Babylonian mathematics and was studied extensively by Indian mathematicians.",
@@ -53,9 +76,22 @@
       "**Triangular Number Recurrence:** $T_n = \\frac{n(n+1)}{2}$ satisfies $T_{n+1} = T_n + (n+1)$ — the inductive structure that Lean proofs exploit. Triangular numbers count pairs: $T_n = \\binom{n+1}{2}$.",
       "**General Arithmetic Series:** $\\sum_{k=0}^{n-1}(a + kd) = na + d\\frac{n(n-1)}{2}$. The formalization derives this from the base case ($d = 1$, $a = 0$) by linearity of summation — Mathlib's `Finset.sum_add_const` and `Finset.sum_mul`.",
       "**Gauss's Original Problem:** $\\sum_{k=1}^{100} k = 100 \\cdot 101/2 = 5050$. The legend of 10-year-old Gauss solving this instantly demonstrates that algebraic insight (pairing) beats brute-force computation — the same principle Lean's `omega` and `ring` tactics mechanize."
+    ],
+    "prerequisites": [
+      "Natural number arithmetic and divisibility",
+      "Finite sums and sigma notation ($\\sum_{k=0}^{n} f(k)$)",
+      "Basic algebraic manipulation (factoring, rearranging)"
     ]
   },
   "sections": [
+    {
+      "id": "header-docs",
+      "title": "Imports and Historical Documentation",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Imports Mathlib's `BigOperators.Intervals` and `BigOperators.Ring.Finset` for finite sum manipulation, plus `Tactic`. Module docstring covering the formula, Gauss anecdote, proof approach (pairing argument), and Wiedijk #68 status.",
+      "mathContext": "The Gauss summation formula $\\sum_{k=1}^{n} k = n(n+1)/2$ is Wiedijk #68. Mathlib provides `Finset.sum_range_id` for the 0-indexed version $\\sum_{k=0}^{n-1} k = n(n-1)/2$."
+    },
     {
       "id": "gauss-formula",
       "title": "Gauss's Summation Formula",
@@ -157,6 +193,11 @@
       "targetId": "triangular-reciprocals",
       "relationship": "related",
       "description": "The reciprocals of triangular numbers $T_n = n(n+1)/2$ telescope to give $\\sum 1/T_n = 2(1 - 1/(n+1))$ — connecting the arithmetic series formula directly to a convergent reciprocal sum via partial fractions"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Euler's solution $\\sum 1/k^2 = \\pi^2/6$ extends the idea of summing natural number expressions from $\\sum k$ (polynomial, closed-form) to $\\sum 1/k^2$ (convergent series, transcendental value) — both are instances of evaluating the Riemann zeta function at integers: $\\zeta(-1) = -1/12$ (regularized $\\sum k$) and $\\zeta(2) = \\pi^2/6$"
     }
   ],
   "relatedProofs": [
@@ -166,7 +207,8 @@
     "arithmetic-series-oq-02",
     "sum-of-kth-powers",
     "harmonic-divergence",
-    "triangular-reciprocals"
+    "triangular-reciprocals",
+    "basel-problem"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary
Enrichment pass for 4 gallery entries:

**AM-GM Inequality**:
- Added `meta.leanFile` and `meta.relatedProblems` for schema consistency
- Added cross-references to `stirling-formula` and `binomial-theorem`
- Added Gauss AGM iteration open question (elliptic integral connection)
- Added Cox 1984 reference

**Angle Trisection**:
- Added `meta.relatedProblems` for 3 sub-entries
- Added cross-references to `angle-trisection-oq-02-oq-01` and `nth-root-irrational`

**Area of Circle** (BUGFIX):
- Fixed duplicate JSON keys that caused 14 cross-references and 5 references to be invisible
- Added `meta.relatedProblems` for 2 sub-entries

**Arithmetic Series**:
- Added `meta.leanFile`, `meta.relatedProblems`, and `overview.prerequisites` (was missing)
- Added header-docs section for lines 1-49
- Added cross-reference to `basel-problem` (zeta function connection)

## Test plan
- [x] JSON validated for all 4 entries
- [x] All cross-reference targets verified to exist
- [x] Area of circle: verified 18 relatedProofs and 7 references now accessible (was 2 each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)