### PR TITLE
Enrich Szemeredi Core: deep enrichment pass

### DIFF
--- a/src/data/proofs/szemeredi-core/annotations.json
+++ b/src/data/proofs/szemeredi-core/annotations.json
@@ -1,13 +1,45 @@
 [
   {
+    "id": "szemeredi-core-preamble",
+    "proofId": "szemeredi-core",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "context",
+    "title": "Module Setup and Pipeline Architecture",
+    "content": "The module opens with a docstring documenting its role as the shared definition layer for the Szemerédi regularity pipeline. It imports the full Mathlib library (a single `import Mathlib` rather than selective imports for convenience), opens `Classical` to make all propositions decidable (needed for definitions like `IsEpsilonRegular` which quantify over subsets), and declares the vertex type variable `V` with `Fintype` and `DecidableEq` instances. The `Szemeredi.Core` namespace isolates these definitions from the rest of the codebase while allowing downstream files (`SzemerediRegularity`, `SzemerediCounting`) to `open Szemeredi.Core` for direct access.",
+    "mathContext": "The setup declares $V$ as a finite type with decidable equality: these are the vertices of the simple graph $G : \\text{SimpleGraph}\\, V$ that appears in all definitions below.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lean 4 namespace system",
+      "Mathlib import",
+      "classical logic",
+      "module architecture"
+    ],
+    "prerequisites": [
+      "Lean 4 module system",
+      "classical vs constructive reasoning"
+    ]
+  },
+  {
     "id": "szemeredi-core-edge-density",
     "proofId": "szemeredi-core",
     "range": { "startLine": 29, "endLine": 34 },
     "type": "definition",
-    "title": "Edge Density",
-    "content": "The edge density d(A,B) counts the fraction of possible edges between vertex subsets A and B that are actually present. Returns 0 when either set is empty.",
-    "mathContext": "d(A,B) = |{(a,b) in A x B : a ~ b}| / (|A| * |B|). Fundamental to all regularity arguments.",
-    "significance": "critical"
+    "title": "Edge Density Between Vertex Subsets",
+    "content": "The edge density $d(A,B)$ counts the fraction of potential edges between vertex subsets $A$ and $B$ that actually exist in $G$. Formally, it filters the Cartesian product $A \\times B$ for adjacent pairs and divides by $|A| \\cdot |B|$. The definition handles the degenerate case (either set empty) by returning 0 via the `if h : ... = 0 then 0` guard. Marked `noncomputable` because rational division in Lean 4 is noncomputable.\n\nThis definition is the quantitative foundation of the regularity method: all subsequent concepts (epsilon-regularity, partition energy) are stated in terms of edge density. The definition works over $\\mathbb{Q}$ rather than $\\mathbb{R}$ for cleaner arithmetic — all quantities in this file are rational since they involve only finite cardinalities and their ratios.",
+    "mathContext": "$d(A,B) = \\frac{|\\{(a,b) \\in A \\times B : G.\\text{Adj}\\, a\\, b\\}|}{|A| \\cdot |B|}$ with the convention $d(A,B) = 0$ when $|A| \\cdot |B| = 0$. Values lie in $[0,1]$ (proved in `edgeDensity_le_one`).",
+    "significance": "key",
+    "relatedConcepts": [
+      "bipartite graph density",
+      "Cartesian product of Finsets",
+      "noncomputable definition",
+      "rational arithmetic"
+    ],
+    "prerequisites": [
+      "simple graphs",
+      "Finset.product",
+      "Finset.filter",
+      "rational division"
+    ]
   },
   {
     "id": "szemeredi-core-epsilon-regular",
@@ -15,9 +47,21 @@
     "range": { "startLine": 36, "endLine": 45 },
     "type": "definition",
     "title": "Epsilon-Regular Pair",
-    "content": "A pair (A, B) is epsilon-regular if every sufficiently large sub-pair has edge density close to d(A,B). This captures the notion that the pair behaves like a random bipartite graph.",
-    "mathContext": "For all A' subset A, B' subset B with |A'| >= eps*|A| and |B'| >= eps*|B|: |d(A',B') - d(A,B)| <= eps.",
-    "significance": "critical"
+    "content": "A pair $(A, B)$ is $\\varepsilon$-regular if every sufficiently large sub-pair has edge density close to $d(A,B)$. 'Sufficiently large' means $|A'| \\geq \\varepsilon|A|$ and $|B'| \\geq \\varepsilon|B|$ — subsets below this threshold are ignored because they carry too little statistical weight. This definition captures the idea that the pair behaves like a random bipartite graph: in a truly random graph $G(n,p)$, all large sub-pairs have density close to $p$ with high probability.\n\nThe quantifier structure (universally quantified over all large sub-pairs) makes this a strong uniformity condition. It is the key property that enables the counting lemma: in an epsilon-regular pair of density $d$, the number of copies of any fixed bipartite graph $H$ is approximately $d^{e(H)} \\cdot |A|^{|V_1(H)|} \\cdot |B|^{|V_2(H)|}$, just as in a random graph.",
+    "mathContext": "$(A,B)$ is $\\varepsilon$-regular iff $\\forall A' \\subseteq A,\\, B' \\subseteq B$ with $|A'| \\geq \\varepsilon|A|,\\, |B'| \\geq \\varepsilon|B|$: $|d(A',B') - d(A,B)| \\leq \\varepsilon$. This captures pseudorandomness: the pair 'looks random' to any large induced sub-pair.",
+    "significance": "key",
+    "relatedConcepts": [
+      "pseudorandomness",
+      "uniformity",
+      "counting lemma",
+      "random bipartite graph",
+      "Chernoff bound"
+    ],
+    "prerequisites": [
+      "edge density",
+      "graph theory",
+      "epsilon-delta arguments"
+    ]
   },
   {
     "id": "szemeredi-core-regular-partition",
@@ -25,35 +69,85 @@
     "range": { "startLine": 47, "endLine": 56 },
     "type": "definition",
     "title": "Regular Partition",
-    "content": "An equitable partition where at most epsilon * C(k,2) pairs are not epsilon-regular. The regularity lemma guarantees such partitions exist for any epsilon > 0.",
-    "significance": "critical"
+    "content": "An equitable partition is $\\varepsilon$-regular if at most $\\varepsilon k(k-1)$ of the $k(k-1)$ ordered pairs $(P_i, P_j)$ with $i \\neq j$ are not $\\varepsilon$-regular. The definition has two conjuncts: (1) equitability — all parts differ in cardinality by at most 1, formalized as $|P.\\text{card} - Q.\\text{card}| \\leq 1$ using integer subtraction; (2) bounded irregularity — the count of irregular pairs is at most $\\varepsilon k(k-1)$, where $k = |\\text{parts}|$.\n\nEquitability is crucial: without it, one could trivially create a 'regular' partition by putting all vertices in one part (which is vacuously regular). The equitability condition forces the partition to spread vertices evenly, ensuring the partition energy potential argument works correctly.",
+    "mathContext": "$\\mathcal{P}$ is an $\\varepsilon$-regular partition iff: (1) $\\forall P,Q \\in \\mathcal{P}: ||P| - |Q|| \\leq 1$ (equitable), and (2) $|\\{(i,j) : i \\neq j,\\, (P_i,P_j) \\text{ not } \\varepsilon\\text{-regular}\\}| \\leq \\varepsilon k(k-1)$ (bounded irregularity).",
+    "significance": "key",
+    "relatedConcepts": [
+      "equitable partition",
+      "regularity lemma",
+      "reduced graph",
+      "Szemerédi partition"
+    ],
+    "prerequisites": [
+      "epsilon-regular pair",
+      "graph partitions",
+      "integer arithmetic"
+    ]
   },
   {
     "id": "szemeredi-core-partition-energy",
     "proofId": "szemeredi-core",
     "range": { "startLine": 58, "endLine": 68 },
     "type": "definition",
-    "title": "Partition Energy",
-    "content": "The size-weighted energy q(P) = sum of (|Pi|*|Pj|/n^2) * d(Pi,Pj)^2 over all pairs. This potential function drives the regularity lemma proof: it increases by at least eps^5 at each refinement step and is bounded by 1.",
-    "mathContext": "q(P) in [0,1] and monotone under refinement. The key insight: bounded energy + positive increment = termination.",
-    "significance": "critical"
+    "title": "Partition Energy (Potential Function)",
+    "content": "The partition energy $q(\\mathcal{P})$ is the size-weighted sum of squared edge densities across all pairs of parts. This is the central potential function in the regularity lemma proof: it is bounded above by 1 (since it is a weighted average of values in $[0,1]$) and increases by at least $\\varepsilon^5$ whenever an irregular pair is refined. Since $q \\in [0,1]$ and each refinement increases $q$ by at least $\\varepsilon^5$, at most $1/\\varepsilon^5$ refinement steps are possible — guaranteeing termination.\n\nThe size-weighting by $|P_i||P_j|/n^2$ ensures that the energy is a convex combination when the partition covers all vertices. The definition handles the empty graph case ($n = 0$) by returning 0. Following Komlós-Simonovits (1996), the energy uses the full ordered sum over $\\mathcal{P} \\times \\mathcal{P}$ (including diagonal and both orderings), which simplifies the Lean formalization at the cost of double-counting.",
+    "mathContext": "$q(\\mathcal{P}) = \\sum_{(P_i, P_j) \\in \\mathcal{P} \\times \\mathcal{P}} \\frac{|P_i| \\cdot |P_j|}{n^2} \\cdot d(P_i, P_j)^2 \\in [0,1]$. Key property: if $\\mathcal{P}'$ refines an irregular pair in $\\mathcal{P}$, then $q(\\mathcal{P}') \\geq q(\\mathcal{P}) + \\varepsilon^5$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "potential function",
+      "convexity",
+      "energy increment",
+      "termination argument",
+      "Cauchy-Schwarz inequality"
+    ],
+    "prerequisites": [
+      "edge density",
+      "equitable partition",
+      "summation over Finset.product"
+    ]
   },
   {
     "id": "szemeredi-core-density-bounds",
     "proofId": "szemeredi-core",
     "range": { "startLine": 70, "endLine": 92 },
-    "type": "theorem",
-    "title": "Edge Density Bounds",
-    "content": "Edge density lies in [0,1]. The upper bound uses that the number of edges between A and B is at most |A|*|B| (every pair contributes at most one edge).",
-    "significance": "key"
+    "type": "technique",
+    "title": "Edge Density Lies in [0,1]",
+    "content": "Two theorems establishing the basic sanity check for edge density:\n\n**edgeDensity_nonneg**: In the zero case, $d = 0 \\geq 0$ trivially. In the non-zero case, both numerator (a cardinality) and denominator (a product of cardinalities) are non-negative, so the quotient is non-negative. Lean's `positivity` tactic handles this automatically.\n\n**edgeDensity_le_one**: The key step is showing that $|\\text{filter}(A \\times B, \\text{Adj})| \\leq |A \\times B| = |A| \\cdot |B|$. The first inequality is `Finset.card_filter_le` (filtering can only remove elements), and the equality is `Finset.card_product`. Then `div_le_one` converts $|\\text{num}| / |\\text{den}| \\leq 1$ to $|\\text{num}| \\leq |\\text{den}|$, and `exact_mod_cast` handles the $\\mathbb{N} \\to \\mathbb{Q}$ coercion.",
+    "mathContext": "$0 \\leq d(A,B) \\leq 1$. The upper bound uses $|\\{(a,b) \\in A \\times B : a \\sim b\\}| \\leq |A \\times B| = |A| \\cdot |B|$ since filtering can only reduce cardinality.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positivity tactic",
+      "Finset.card_filter_le",
+      "Finset.card_product",
+      "div_le_one",
+      "exact_mod_cast"
+    ],
+    "prerequisites": [
+      "rational arithmetic",
+      "Finset cardinality lemmas",
+      "Lean tactics"
+    ]
   },
   {
     "id": "szemeredi-core-energy-nonneg",
     "proofId": "szemeredi-core",
-    "range": { "startLine": 94, "endLine": 109 },
-    "type": "theorem",
+    "range": { "startLine": 94, "endLine": 110 },
+    "type": "technique",
     "title": "Partition Energy Non-negativity",
-    "content": "Each summand in the partition energy is a product of non-negative factors (natural number casts, squares), so the sum is non-negative.",
-    "significance": "supporting"
+    "content": "Proves $q(\\mathcal{P}) \\geq 0$ by showing each summand is non-negative. The proof structure mirrors the definition: after unfolding and splitting on the empty case, `Finset.sum_nonneg` reduces the goal to showing each term $(|P_i| \\cdot |P_j| / n^2) \\cdot d(P_i,P_j)^2 \\geq 0$. This is a product of two non-negative factors: the weight $|P_i| \\cdot |P_j| / n^2 \\geq 0$ (by `div_nonneg` and `mul_nonneg` on natural number casts) and $d(P_i,P_j)^2 \\geq 0$ (by `sq_nonneg`).\n\nThis is the first half of the boundedness argument for the regularity lemma. Combined with the upper bound $q(\\mathcal{P}) \\leq 1$ (proved in the regularity module), it establishes that energy lies in $[0,1]$.",
+    "mathContext": "$q(\\mathcal{P}) = \\sum_{i,j} \\underbrace{\\frac{|P_i||P_j|}{n^2}}_{\\geq 0} \\cdot \\underbrace{d(P_i,P_j)^2}_{\\geq 0} \\geq 0$. Each summand is a product of non-negative factors.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_nonneg",
+      "mul_nonneg",
+      "sq_nonneg",
+      "div_nonneg",
+      "Nat.cast_nonneg"
+    ],
+    "prerequisites": [
+      "partition energy definition",
+      "non-negativity of squares",
+      "Lean positivity arguments"
+    ]
   }
 ]

--- a/src/data/proofs/szemeredi-core/meta.json
+++ b/src/data/proofs/szemeredi-core/meta.json
@@ -9,6 +9,7 @@
     "date": "1975",
     "status": "verified",
     "proofRepoPath": "Proofs/SzemerediCore.lean",
+    "leanFile": "proofs/Proofs/SzemerediCore.lean",
     "tags": [
       "szemeredi",
       "combinatorics",
@@ -42,18 +43,66 @@
       "Size-weighted partition energy following Komlos-Simonovits (1996)",
       "Proved: edgeDensity_nonneg, edgeDensity_le_one, partitionEnergy_nonneg"
     ],
-    "dateAdded": "03/22/26",
+    "references": [
+      {
+        "key": "Sz75",
+        "citation": "Szemerédi, E., On sets of integers containing no k elements in arithmetic progression, Acta Arithmetica 27 (1975), 199–245.",
+        "type": "paper"
+      },
+      {
+        "key": "KS96",
+        "citation": "Komlós, J. and Simonovits, M., Szemerédi's Regularity Lemma and its applications in graph theory, in: Combinatorics, Paul Erdős is Eighty, Vol. 2, Bolyai Society Mathematical Studies 2 (1996), 295–352.",
+        "type": "paper"
+      },
+      {
+        "key": "Sz78",
+        "citation": "Szemerédi, E., Regular partitions of graphs, in: Problèmes combinatoires et théorie des graphes (Colloq. Internat. CNRS, Orsay 1976), Colloq. Internat. CNRS 260 (1978), 399–401.",
+        "type": "paper"
+      },
+      {
+        "key": "Go10",
+        "citation": "Gowers, W.T., Decompositions, approximate structure, transference, and the Hahn-Banach theorem, Bulletin of the London Mathematical Society 42(4) (2010), 573–606.",
+        "type": "paper"
+      },
+      {
+        "key": "Ta06",
+        "citation": "Tao, T., Szemerédi's regularity lemma revisited, Contributions to Discrete Mathematics 1(1) (2006), 8–28.",
+        "type": "paper"
+      }
+    ],
+    "relatedProofs": [
+      "szemeredi-regularity",
+      "szemeredi-counting",
+      "szemeredi-full",
+      "szemeredi-theorem",
+      "roth-theorem-k3",
+      "ramseys-theorem"
+    ],
+    "dateAdded": "2026-03-22",
     "axiomCount": 0,
-    "lineCount": 110
+    "lineCount": 110,
+    "prerequisites": [
+      "Graph theory (simple graphs, adjacency, vertex subsets)",
+      "Rational arithmetic (division, positivity, bounds)",
+      "Finite combinatorics (Cartesian products, cardinality, filters)",
+      "Familiarity with Lean 4 and Mathlib"
+    ]
   },
   "overview": {
-    "historicalContext": "The definitions in this module form the foundation of the Szemeredi regularity pipeline. Edge density, epsilon-regularity, and partition energy were introduced in Szemeredi's 1975 proof of his theorem on arithmetic progressions, and later refined by Komlos and Simonovits (1996) into the standard toolkit for regularity-based arguments.\n\nBy extracting these shared definitions into a core module, both the regularity lemma and the counting/removal lemma files can import a single source of truth, preventing definition drift across the pipeline.",
+    "historicalContext": "The Szemerédi regularity lemma (1975/1978) is one of the most influential results in modern combinatorics. Endre Szemerédi first developed the regularity method as a tool within his proof that every dense subset of the integers contains arbitrarily long arithmetic progressions (1975), settling a conjecture of Erdős and Turán from 1936. The regularity lemma itself was then published separately in 1978, and rapidly became a cornerstone of extremal graph theory.\n\nThe key conceptual innovation was the notion of epsilon-regularity: a pair of vertex sets that behaves pseudorandomly in that all large sub-pairs have approximately the same edge density. This allowed Szemerédi to replace complicated dense graphs with simpler 'reduced graphs' that retain the essential combinatorial structure. The partition energy function, formalized here following the exposition of Komlós and Simonovits (1996), provides the potential argument that drives the regularity lemma: energy lies in $[0,1]$, increases by at least $\\varepsilon^5$ at each refinement step, and therefore the refinement process must terminate.\n\nThis core module extracts the shared definitions used by the full Szemerédi pipeline (regularity, counting, removal, and the main theorem on arithmetic progressions), preventing definition drift across files. The modularity mirrors the mathematical structure: the same definitions of edge density and epsilon-regularity appear in applications ranging from the triangle removal lemma (Ruzsa-Szemerédi 1978) to the Green-Tao theorem on primes in arithmetic progressions (2008).",
     "problemStatement": "Define the fundamental concepts for graph regularity:\n\n- **Edge density** $d(A,B) = |E(A,B)| / (|A| \\cdot |B|)$ between vertex subsets\n- **Epsilon-regular pair**: $(A,B)$ is $\\varepsilon$-regular if all large sub-pairs have density within $\\varepsilon$ of $d(A,B)$\n- **Regular partition**: at most $\\varepsilon \\binom{k}{2}$ pairs are irregular\n- **Partition energy**: $q(\\mathcal{P}) = \\sum_{i,j} \\frac{|P_i||P_j|}{n^2} d(P_i,P_j)^2$\n\nProve that edge density lies in $[0,1]$ and partition energy is non-negative.",
-    "proofStrategy": "The module provides definitions and three proved lemmas:\n\n1. **edgeDensity_nonneg**: By positivity of the numerator and denominator.\n2. **edgeDensity_le_one**: The number of edges between $A$ and $B$ is at most $|A| \\cdot |B|$ (every pair in the product can contribute at most one edge).\n3. **partitionEnergy_nonneg**: Each summand is a product of non-negative factors (cardinalities, squares).",
+    "proofStrategy": "The module provides definitions and three proved lemmas:\n\n1. **edgeDensity_nonneg**: By positivity of the numerator and denominator.\n2. **edgeDensity_le_one**: The number of edges between $A$ and $B$ is at most $|A| \\cdot |B|$ (every pair in the product can contribute at most one edge). Uses `Finset.card_filter_le` and `Finset.card_product` to bound the filtered edge count.\n3. **partitionEnergy_nonneg**: Each summand is a product of non-negative factors (cardinalities, squares). Uses `Finset.sum_nonneg` with term-by-term `mul_nonneg` and `sq_nonneg` arguments.",
     "keyInsights": [
       "Centralizing definitions prevents the regularity and counting modules from using incompatible variants of edge density or regularity",
       "Edge density bounds (0 to 1) are fundamental sanity checks used throughout the regularity pipeline",
-      "Partition energy is the key potential function: bounded above by 1 and increasing with each refinement step"
+      "Partition energy is the key potential function: bounded above by 1 and increasing with each refinement step, so at most $1/\\varepsilon^5$ refinements are possible",
+      "The epsilon-regularity definition captures pseudorandomness: an epsilon-regular pair behaves like a random bipartite graph with density $d(A,B)$ for the purposes of counting subgraphs",
+      "The equitability condition in IsRegularPartition (parts differ in size by at most 1) is essential for the energy increment argument — without it, concentrating vertices in one part could defeat the potential function"
+    ],
+    "prerequisites": [
+      "Graph theory: simple graphs, vertex subsets, bipartite edge counts, and the adjacency relation $G.\\text{Adj}$",
+      "Rational arithmetic: division, positivity arguments, and the $[0,1]$ bound via `div_le_one`",
+      "Finite combinatorics: Cartesian products `A \\times B$, `Finset.card_filter_le`, `Finset.card_product`, and `Finset.sum_nonneg`"
     ]
   },
   "sections": [
@@ -62,53 +111,93 @@
       "title": "Preamble and Imports",
       "startLine": 1,
       "endLine": 27,
-      "summary": "Module docstring listing all definitions and lemmas. Imports Mathlib, opens Classical, and declares finite vertex type variables."
+      "summary": "Module docstring listing all definitions and lemmas. Imports Mathlib, opens Classical (for decidability of propositions), and declares the finite vertex type variable $V$ with `Fintype` and `DecidableEq` instances.",
+      "mathContext": "Variables: $V$ is a finite type with decidable equality. Classical reasoning is opened to allow decidable propositions in definitions."
     },
     {
       "id": "edge-density",
       "title": "Edge Density Definition",
       "startLine": 29,
       "endLine": 34,
-      "summary": "Defines edgeDensity G A B as |{(a,b) in A x B : G.Adj a b}| / (|A| * |B|), handling the zero case."
+      "summary": "Defines `edgeDensity G A B` as $|\\{(a,b) \\in A \\times B : G.\\text{Adj}\\, a\\, b\\}| / (|A| \\cdot |B|)$. Returns 0 when either set is empty (guarded by the `if h` branch on the denominator being zero). Marked `noncomputable` because it involves division in $\\mathbb{Q}$.",
+      "mathContext": "$d(A,B) = \\frac{|\\{(a,b) \\in A \\times B : a \\sim b\\}|}{|A| \\cdot |B|}$ with $d(A,B) = 0$ when $|A| \\cdot |B| = 0$."
     },
     {
       "id": "regularity-defs",
       "title": "Epsilon-Regularity and Regular Partitions",
       "startLine": 36,
       "endLine": 56,
-      "summary": "Defines IsEpsilonRegular (all large sub-pairs have density within epsilon) and IsRegularPartition (equitable with bounded irregular pairs)."
+      "summary": "Defines `IsEpsilonRegular G eps A B`: for all $A' \\subseteq A$, $B' \\subseteq B$ with $|A'| \\geq \\varepsilon|A|$ and $|B'| \\geq \\varepsilon|B|$, $|d(A',B') - d(A,B)| \\leq \\varepsilon$. Defines `IsRegularPartition G eps parts`: equitability (parts differ by at most 1 in size) and at most $\\varepsilon k(k-1)$ irregular pairs.",
+      "mathContext": "$(A,B)$ is $\\varepsilon$-regular iff $\\forall A' \\subseteq A,\\, B' \\subseteq B$ with $|A'| \\geq \\varepsilon|A|,\\, |B'| \\geq \\varepsilon|B|$: $|d(A',B') - d(A,B)| \\leq \\varepsilon$. Partition is regular iff equitable and $|\\{(i,j) : \\text{not } \\varepsilon\\text{-regular}\\}| \\leq \\varepsilon k(k-1)$."
     },
     {
       "id": "partition-energy",
       "title": "Partition Energy",
       "startLine": 58,
       "endLine": 68,
-      "summary": "Defines the size-weighted partition energy q(P) following Komlos-Simonovits (1996)."
+      "summary": "Defines `partitionEnergy G parts` as $q(\\mathcal{P}) = \\sum_{(P_i, P_j) \\in \\mathcal{P} \\times \\mathcal{P}} \\frac{|P_i| \\cdot |P_j|}{n^2} \\cdot d(P_i, P_j)^2$, where $n = |V|$. Returns 0 for empty graphs. Size-weighting by $|P_i||P_j|/n^2$ normalizes the energy to $[0,1]$.",
+      "mathContext": "$q(\\mathcal{P}) = \\sum_{i,j} \\frac{|P_i||P_j|}{n^2} d(P_i,P_j)^2 \\in [0,1]$. Key property: $q(\\mathcal{P}') \\geq q(\\mathcal{P}) + \\varepsilon^5$ when $\\mathcal{P}'$ refines an irregular pair."
     },
     {
       "id": "basic-lemmas",
       "title": "Basic Lemmas",
       "startLine": 70,
       "endLine": 110,
-      "summary": "Proves edgeDensity_nonneg, edgeDensity_le_one (via card_filter_le and card_product), and partitionEnergy_nonneg (via sum_nonneg)."
+      "summary": "Proves three foundational properties: `edgeDensity_nonneg` (by `positivity`), `edgeDensity_le_one` (via `Finset.card_filter_le` and `Finset.card_product` to bound filtered edges by $|A| \\cdot |B|$, then `div_le_one`), and `partitionEnergy_nonneg` (via `Finset.sum_nonneg` with term-by-term `mul_nonneg`/`sq_nonneg`). These are the basic sanity checks needed by downstream regularity arguments.",
+      "mathContext": "$0 \\leq d(A,B) \\leq 1$ and $q(\\mathcal{P}) \\geq 0$. The upper bound uses $|\\text{filter}(A \\times B)| \\leq |A \\times B| = |A| \\cdot |B|$."
     }
   ],
   "crossReferences": [
     {
-      "proofId": "szemeredi-regularity",
-      "relationship": "Provides core definitions imported by the regularity lemma"
+      "targetId": "szemeredi-regularity",
+      "relationship": "foundational",
+      "description": "Provides the core definitions (edge density, epsilon-regularity, regular partition, partition energy) imported by the regularity lemma proof, which uses the energy increment argument to establish existence of regular partitions"
     },
     {
-      "proofId": "szemeredi-counting",
-      "relationship": "Provides core definitions imported by the counting and removal lemmas"
+      "targetId": "szemeredi-counting",
+      "relationship": "foundational",
+      "description": "Provides the core definitions imported by the counting and triangle removal lemmas, which use epsilon-regularity to count subgraph copies in regular pairs"
+    },
+    {
+      "targetId": "szemeredi-full",
+      "relationship": "foundational",
+      "description": "The full Szemerédi theorem on arithmetic progressions depends on the regularity pipeline that begins with these core definitions"
+    },
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "foundational",
+      "description": "The main Szemerédi theorem statement imports and uses the regularity infrastructure built on these definitions"
+    },
+    {
+      "targetId": "roth-theorem-k3",
+      "relationship": "related",
+      "description": "Roth's theorem (1953) on 3-term arithmetic progressions was the first major application of regularity-type ideas. While Roth used Fourier analysis, modern proofs of Roth's theorem use the regularity lemma with these exact definitions of edge density and epsilon-regularity applied to the tripartite graph encoding arithmetic progressions"
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey's theorem guarantees monochromatic complete subgraphs in edge-colorings. The regularity lemma generalizes this perspective: instead of finding exact monochromatic structure, it decomposes any dense graph into pseudorandom pieces (epsilon-regular pairs) that approximate the structure of random graphs"
     }
   ],
   "conclusion": {
-    "summary": "This module provides the shared mathematical vocabulary for the Szemeredi regularity pipeline. All definitions are sorry-free and axiom-free, with basic properties proved.",
-    "implications": "By centralizing edge density, epsilon-regularity, regular partitions, and partition energy in a single module, the full Szemeredi pipeline (regularity, counting, removal, and the full theorem) can share definitions without drift.",
+    "summary": "This module provides the shared mathematical vocabulary for the Szemerédi regularity pipeline in 110 lines with 4 definitions and 3 proved lemmas (0 sorries, 0 axioms). All definitions are verified and basic properties (density bounds, energy non-negativity) are established.",
+    "implications": "By centralizing edge density, epsilon-regularity, regular partitions, and partition energy in a single module, the full Szemerédi pipeline (regularity, counting, removal, and the main theorem) shares definitions without drift. The partition energy potential function $q(\\mathcal{P}) \\in [0,1]$ with energy increment $\\geq \\varepsilon^5$ is the engine that drives the regularity lemma's termination argument — this module establishes its non-negativity, while the regularity module proves the increment and upper bound. The same definitions extend to applications far beyond Szemerédi's original theorem: the graph removal lemma, property testing, the hypergraph regularity lemma (Gowers 2007, Rödl-Skokan 2004), and the Green-Tao theorem on primes in arithmetic progressions.",
     "openQuestions": [
-      "Should the module also include the energy increment lemma statement?",
-      "Can these definitions be generalized to weighted graphs or hypergraphs?"
+      "Formalize the energy increment lemma: if a partition has an irregular pair, the refinement increases energy by at least $\\varepsilon^5$",
+      "Extend these definitions to the strong regularity lemma (Alon-Fischer-Krivelevich-Szegedy 2000), which achieves a regular partition where almost all pairs are very regular",
+      "Generalize to hypergraph regularity (Gowers 2007), where epsilon-regularity requires conditions on $(k-1)$-uniform sub-hypergraphs rather than just pairs of vertex subsets",
+      "Formalize the algorithmic version: Alon-Duke-Lefmann-Rödl-Yuster (1994) showed the regularity partition can be found in polynomial time, giving a constructive version of Szemerédi's existential result"
     ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": ["Classical"],
+    "namespace": "Szemeredi.Core",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 4
   }
 }


### PR DESCRIPTION
## Summary
First enrichment pass for `szemeredi-core` (quality 85 → comprehensive).

- Deepened `historicalContext` (~1200 chars): Szemerédi 1975/1978, Komlós-Simonovits 1996, applications to removal lemma and Green-Tao
- Added 5 academic references (Szemerédi, Komlós-Simonovits, Gowers, Tao)
- Added 6 cross-references with descriptions (regularity, counting, full, theorem, Roth, Ramsey)
- Expanded `keyInsights` from 3 to 5 (added pseudorandomness interpretation, equitability importance)
- Added `mathContext` to all 5 sections
- Rewrote all annotations with `relatedConcepts`, `prerequisites`, and deeper mathematical content
- Added preamble annotation covering lines 1-27
- Fixed `crossReferences` format (`proofId` → `targetId` with relationship + description)
- Expanded `conclusion` with energy increment context, hypergraph regularity, and algorithmic version
- Added `leanFile` metadata, `relatedProofs`, `references`, `prerequisites`
- Fixed `dateAdded` format

## Test plan
- [x] JSON validated (python3 json.load)
- [x] Annotations build passes with 0 errors for this entry
- [x] All cross-reference targets verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)