### PR TITLE
Enrich batch: 8 entries - cross-references for classics

### DIFF
--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -143,5 +143,45 @@
       "venue": "Mathematical Association of America",
       "note": "Elegant treatment of Ceva's theorem alongside Menelaus's theorem with numerous applications"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "herons-formula",
+      "relationship": "related",
+      "description": "Both concern triangle geometry: Heron's formula computes area from side lengths, while Ceva's theorem characterizes when three cevians (lines through vertices) are concurrent — both use ratios and products involving triangle side lengths"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem provides the metric foundation for triangle geometry, while Ceva's theorem adds the affine-projective layer — together they span from metric to projective properties of triangles"
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "Both are fundamental triangle theorems: the law of cosines generalizes Pythagoras metrically, while Ceva's theorem characterizes concurrency of cevians — the law of cosines can be used to derive coordinate proofs of Ceva's theorem"
+    },
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "foundational",
+      "description": "The angle sum property (180 degrees) is the most basic triangle theorem, while Ceva's theorem is a deeper structural result — both concern the fundamental geometry of triangles"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "related",
+      "description": "Both are classical triangle geometry results: Ceva's theorem concerns cevian concurrency, while Feuerbach's theorem concerns the tangency of the nine-point circle and incircle — both reveal deep structure in triangle configurations"
+    },
+    {
+      "targetId": "isosceles-triangle",
+      "relationship": "foundational",
+      "description": "The isosceles triangle theorem is the simplest symmetry result in triangle geometry, while Ceva's theorem handles the general asymmetric case — both concern the interplay of vertices and sides"
+    }
+  ],
+  "relatedProofs": [
+    "herons-formula",
+    "pythagorean-theorem",
+    "law-of-cosines",
+    "triangle-angle-sum",
+    "feuerbachs-theorem",
+    "isosceles-triangle"
   ]
 }

--- a/src/data/proofs/desargues-theorem/meta.json
+++ b/src/data/proofs/desargues-theorem/meta.json
@@ -178,5 +178,39 @@
       "venue": "Springer, 2nd edition",
       "note": "Standard treatment of Desargues's theorem in the axiomatic framework of projective planes"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pascals-hexagon",
+      "relationship": "complementary",
+      "description": "Desargues's and Pascal's theorems are the two fundamental theorems of projective geometry: Desargues concerns perspective triangles, while Pascal concerns hexagons inscribed in conics — together they form the backbone of projective geometry"
+    },
+    {
+      "targetId": "cevas-theorem",
+      "relationship": "related",
+      "description": "Both concern concurrency and collinearity in triangle configurations: Ceva's theorem characterizes cevian concurrency, while Desargues's theorem relates the perspective center (concurrency) to the perspective axis (collinearity)"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem operates in Euclidean (metric) geometry, while Desargues's theorem operates in projective geometry — the contrast illustrates how different geometric frameworks reveal different truths about figures"
+    },
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "thematic",
+      "description": "Both concern fundamental structural properties of geometric objects: Euler's formula constrains polyhedra topologically (V-E+F=2), while Desargues's theorem constrains triangle configurations projectively"
+    },
+    {
+      "targetId": "four-color-theorem",
+      "relationship": "thematic",
+      "description": "Both are foundational results about planar geometric/combinatorial structures: the four-color theorem concerns graph coloring on the plane, while Desargues's theorem concerns projective configurations — both involve deep structural analysis"
+    }
+  ],
+  "relatedProofs": [
+    "pascals-hexagon",
+    "cevas-theorem",
+    "pythagorean-theorem",
+    "euler-polyhedral-formula",
+    "four-color-theorem"
   ]
 }

--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -167,5 +167,45 @@
       "venue": "Houghton Mifflin (Dover reprint 2007)",
       "note": "Classic reference containing multiple proofs and generalizations of Feuerbach's theorem"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cevas-theorem",
+      "relationship": "related",
+      "description": "Both are classical triangle geometry theorems: Ceva's characterizes cevian concurrency, while Feuerbach's establishes the tangency of the nine-point circle and incircle — both reveal deep structure in triangle configurations"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem provides the distance formula needed to compute the nine-point circle's radius (R/2) and the incircle's radius (r), which are central to Feuerbach's tangency condition"
+    },
+    {
+      "targetId": "herons-formula",
+      "relationship": "related",
+      "description": "Heron's formula provides the triangle area A = sqrt(s(s-a)(s-b)(s-c)), from which the inradius r = A/s is derived — this inradius is one of the key quantities in Feuerbach's theorem"
+    },
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "thematic",
+      "description": "Both are named after pioneering mathematicians and concern fundamental geometric structures: Euler's formula for polyhedra V-E+F=2 and Feuerbach's theorem for triangle circles — both reveal surprising constraints on geometric configurations"
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "foundational",
+      "description": "The law of cosines provides the computational foundation for establishing the nine-point circle's properties, including the circumradius R that determines the nine-point circle's radius R/2"
+    },
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "foundational",
+      "description": "The angle sum property is the most basic constraint on triangle geometry, while Feuerbach's theorem is one of the deepest — both concern the rigid geometric structure of triangles"
+    }
+  ],
+  "relatedProofs": [
+    "cevas-theorem",
+    "pythagorean-theorem",
+    "herons-formula",
+    "euler-polyhedral-formula",
+    "law-of-cosines",
+    "triangle-angle-sum"
   ]
 }

--- a/src/data/proofs/hilbert-6/meta.json
+++ b/src/data/proofs/hilbert-6/meta.json
@@ -146,5 +146,45 @@
       "venue": "Springer, Archimedes 10",
       "note": "Historical analysis of Hilbert's program for axiomatizing physics including his work on general relativity"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-5",
+      "relationship": "related",
+      "description": "The 5th (Lie groups) and 6th (axiomatization of physics) are directly connected: the resolution of the 5th guarantees that continuous symmetry groups in physics are automatically Lie groups, providing the mathematical foundation that the 6th seeks to axiomatize"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "Hilbert's 6th problem specifically calls for axiomatization of probability and statistical mechanics. The central limit theorem is one of the key results that any such axiomatization must recover"
+    },
+    {
+      "targetId": "hilbert-19",
+      "relationship": "thematic",
+      "description": "Both concern the mathematical foundations of physical theories: the 6th asks for axioms, while the 19th asks about regularity of solutions — together they frame the question of what mathematical structure physics requires"
+    },
+    {
+      "targetId": "hilbert-20",
+      "relationship": "thematic",
+      "description": "Both concern the solvability of physical equations: the 20th asks about boundary value problems (arising in physics), while the 6th asks for the axiomatic framework within which such equations are formulated"
+    },
+    {
+      "targetId": "navier-stokes-existence",
+      "relationship": "related",
+      "description": "The Navier-Stokes equations are one of the key examples in Hilbert's program: axiomatizing fluid mechanics requires understanding existence and regularity — the open Millennium Prize problem shows how far this program remains from completion"
+    },
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "related",
+      "description": "Shannon entropy axiomatizes information-theoretic aspects that connect to Hilbert's 6th through statistical mechanics: the Boltzmann-Gibbs-Shannon entropy framework is a partial success story in axiomatizing physical theories"
+    }
+  ],
+  "relatedProofs": [
+    "hilbert-5",
+    "central-limit-theorem",
+    "hilbert-19",
+    "hilbert-20",
+    "navier-stokes-existence",
+    "shannon-entropy"
   ]
 }

--- a/src/data/proofs/hilbert-9-reciprocity/meta.json
+++ b/src/data/proofs/hilbert-9-reciprocity/meta.json
@@ -124,5 +124,45 @@
       "venue": "Abhandlungen aus dem mathematischen Seminar der Universität Hamburg 5, 353–363",
       "note": "Proved the general reciprocity law for number fields using the Artin map — the main achievement toward Hilbert's 9th problem"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "Gauss's quadratic reciprocity law is the starting point for Hilbert's 9th problem: the 9th asks for the most general reciprocity law, of which quadratic reciprocity is the simplest case — the full answer came through class field theory and the Langlands program"
+    },
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Wiles's proof of FLT (1995) uses the modularity of Galois representations, which is deeply connected to the reciprocity laws sought by Hilbert's 9th — the Langlands program (generalizing the 9th) provided key ideas for Wiles's approach"
+    },
+    {
+      "targetId": "kroneckers-jugendtraum",
+      "relationship": "complementary",
+      "description": "Kronecker's Jugendtraum (Hilbert's 12th) and the 9th are closely related: the 12th asks about generating abelian extensions via special values, while the 9th asks about the reciprocity laws governing these extensions — class field theory resolves both"
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "The Riemann hypothesis concerns the zeta function, whose generalization to L-functions is central to the reciprocity laws of the 9th — the Langlands program connects automorphic L-functions to Galois representations via reciprocity"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Abel-Ruffini uses non-solvability of S_5 to block radical solutions. The 9th problem's reciprocity laws describe when and how Galois groups control arithmetic — both connect Galois theory to fundamental algebraic questions"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's totient function phi(n) gives the degree of cyclotomic extensions [Q(zeta_n):Q] = phi(n), with Galois group (Z/nZ)^x. Class field theory (answering the 9th) generalizes this: all abelian extensions of Q arise from cyclotomic extensions (Kronecker-Weber)"
+    }
+  ],
+  "relatedProofs": [
+    "quadratic-reciprocity",
+    "fermats-last-theorem",
+    "kroneckers-jugendtraum",
+    "riemann-hypothesis",
+    "abel-ruffini",
+    "euler-totient"
   ]
 }

--- a/src/data/proofs/konigsberg/meta.json
+++ b/src/data/proofs/konigsberg/meta.json
@@ -155,5 +155,39 @@
       "venue": "Oxford University Press",
       "note": "Historical account of graph theory from Euler's bridge problem to modern developments"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "four-color-theorem",
+      "relationship": "related",
+      "description": "Both are foundational results in graph theory: the Konigsberg bridges problem (1736) established graph theory as a discipline, while the four-color theorem (1976) is its most famous result — both concern structural properties of graphs embedded in surfaces"
+    },
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "related",
+      "description": "Both are due to Euler and concern topological invariants: the polyhedral formula V-E+F=2 and the Konigsberg bridges criterion (all vertices must have even degree for an Eulerian circuit) — both revealed the importance of combinatorial topology"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "thematic",
+      "description": "Both are named after Euler: the totient function concerns number-theoretic structure, while the Konigsberg problem concerns graph structure — together they illustrate the breadth of Euler's contributions across mathematics"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "thematic",
+      "description": "Both are accessibility results that introduced powerful mathematical paradigms: Euclid's infinitude of primes established proof by contradiction, while Euler's Konigsberg bridges established graph theory as an abstraction tool"
+    },
+    {
+      "targetId": "pascals-hexagon",
+      "relationship": "thematic",
+      "description": "Both concern geometric configurations analyzed via combinatorial structure: Pascal's hexagon theorem uses projective geometry, while the Konigsberg problem abstracts geography into graph theory — both pioneered the use of structural abstraction in geometry"
+    }
+  ],
+  "relatedProofs": [
+    "four-color-theorem",
+    "euler-polyhedral-formula",
+    "euler-totient",
+    "infinitude-primes",
+    "pascals-hexagon"
   ]
 }

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -260,5 +260,45 @@
       "venue": "American Mathematical Society, Chelsea Publishing",
       "note": "Standard reference for existence and uniqueness theory of Navier-Stokes equations"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "navier-stokes",
+      "relationship": "complementary",
+      "description": "The main Navier-Stokes formalization defines the equations and basic properties, while this entry focuses specifically on the Millennium Prize existence and smoothness question — whether smooth solutions exist globally in 3D"
+    },
+    {
+      "targetId": "yang-mills-mass-gap",
+      "relationship": "thematic",
+      "description": "Both are Clay Millennium Prize problems concerning PDEs from physics: Navier-Stokes asks about fluid dynamics regularity, while Yang-Mills asks about existence of a mass gap in quantum gauge theory — both remain open"
+    },
+    {
+      "targetId": "poincare-conjecture",
+      "relationship": "thematic",
+      "description": "Both are (former) Millennium Prize problems: Poincare was resolved by Perelman (2003) using Ricci flow (a PDE technique), while Navier-Stokes remains open — Ricci flow shares the nonlinear PDE regularity challenges of Navier-Stokes"
+    },
+    {
+      "targetId": "hilbert-19",
+      "relationship": "related",
+      "description": "Hilbert's 19th (regularity of variational minimizers) was resolved by De Giorgi-Nash for elliptic PDEs. Navier-Stokes regularity is the analogous open question for parabolic-hyperbolic Navier-Stokes — the methods overlap but the Navier-Stokes nonlinearity poses additional obstacles"
+    },
+    {
+      "targetId": "hilbert-20",
+      "relationship": "related",
+      "description": "Hilbert's 20th (boundary value problem existence) was resolved via Lax-Milgram for elliptic PDEs. Navier-Stokes existence is the analogous question for incompressible fluid equations — Leray's weak solutions exist but global regularity is unknown"
+    },
+    {
+      "targetId": "birch-swinnerton-dyer",
+      "relationship": "thematic",
+      "description": "Both are unsolved Clay Millennium Prize problems: BSD concerns L-functions of elliptic curves, while Navier-Stokes concerns fluid dynamics — both represent frontier challenges in their respective fields"
+    }
+  ],
+  "relatedProofs": [
+    "navier-stokes",
+    "yang-mills-mass-gap",
+    "poincare-conjecture",
+    "hilbert-19",
+    "hilbert-20",
+    "birch-swinnerton-dyer"
   ]
 }

--- a/src/data/proofs/platonic-solids/meta.json
+++ b/src/data/proofs/platonic-solids/meta.json
@@ -142,5 +142,39 @@
       "venue": "Dover Publications, 3rd edition",
       "note": "Definitive treatment of regular polyhedra and their higher-dimensional generalizations"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "complementary",
+      "description": "Euler's formula V-E+F=2 is the key constraint used to prove there are exactly 5 Platonic solids: the formula, combined with regularity conditions (identical faces, same valence at each vertex), yields exactly 5 solutions"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem provides the metric relationships needed to construct the Platonic solids: the icosahedron and dodecahedron involve the golden ratio phi = (1+sqrt(5))/2, whose properties depend on Pythagorean relationships"
+    },
+    {
+      "targetId": "four-color-theorem",
+      "relationship": "thematic",
+      "description": "Both concern fundamental properties of embedded geometric structures: the four-color theorem concerns graph coloring on the sphere, while Platonic solids classify regular polyhedra — both constrain what geometric configurations are possible"
+    },
+    {
+      "targetId": "isoperimetric-theorem",
+      "relationship": "related",
+      "description": "Among all polyhedra with n faces, the Platonic solids are the most symmetric. The isoperimetric theorem (sphere maximizes volume for given surface area) is the continuous analog — both concern optimal geometric shapes"
+    },
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "foundational",
+      "description": "The angle sum property (180 degrees for planar triangles) constrains face geometry. For Platonic solids, the angle defect at each vertex (360 minus the sum of face angles) must be positive, directly yielding the finiteness of regular polyhedra"
+    }
+  ],
+  "relatedProofs": [
+    "euler-polyhedral-formula",
+    "pythagorean-theorem",
+    "four-color-theorem",
+    "isoperimetric-theorem",
+    "triangle-angle-sum"
   ]
 }


### PR DESCRIPTION
## Summary

Added cross-references to 8 high-visibility gallery entries spanning Millennium Prize problems, Hilbert problems, and classic geometry theorems.

### Entries enriched

- **navier-stokes-existence** (Millennium Prize): Links to NS formalization, Yang-Mills, Poincare conjecture, Hilbert 19/20, BSD
- **konigsberg** (graph theory classic): Links to four-color theorem, Euler polyhedral formula, Euler totient, infinitude of primes, Pascal hexagon
- **cevas-theorem** (triangle geometry): Links to Heron, Pythagorean, law of cosines, angle sum, Feuerbach, isosceles triangle
- **feuerbachs-theorem** (triangle geometry): Links to Ceva, Pythagorean, Heron, Euler polyhedral, law of cosines, angle sum
- **desargues-theorem** (projective geometry): Links to Pascal hexagon, Ceva, Pythagorean, Euler polyhedral, four-color
- **platonic-solids** (Wiedijk-100): Links to Euler polyhedral, Pythagorean, four-color, isoperimetric, angle sum
- **hilbert-6** (axiomatization): Links to H5, CLT, H19, H20, Navier-Stokes, Shannon entropy
- **hilbert-9-reciprocity** (reciprocity laws): Links to quadratic reciprocity, FLT, Kronecker, RH, Abel-Ruffini, Euler totient

## Test plan

- [x] All JSON validates
- [x] All 28 cross-referenced proofs exist in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)