### PR TITLE
Enrich batch: 8 entries + Abel-Ruffini + Erdos 340 + Newton Inductive Step

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -87,6 +87,29 @@
     ]
   },
   {
+    "id": "ann-part-ii-bridge",
+    "proofId": "abel-ruffini",
+    "range": {
+      "startLine": 51,
+      "endLine": 57
+    },
+    "type": "context",
+    "title": "Part II: The Galois-Theoretic Bridge",
+    "content": "This docstring introduces the central insight of the formalization: the connection between radical solvability (a field-theoretic property) and group solvability (a group-theoretic property). Galois's 1831 memoir established that these two notions correspond precisely.\n\nThe bridge is one-directional for the impossibility proof: solvable by radicals $\\Rightarrow$ solvable Galois group. The converse (solvable Galois group $\\Rightarrow$ solvable by radicals) also holds but is not needed here — only the contrapositive of the forward direction is used in `not_solvable_by_rad_of_not_solvable_gal`.",
+    "mathContext": "Galois's correspondence: $\\text{IsSolvableByRad}\\,F\\,\\alpha \\Leftrightarrow \\text{IsSolvable}(\\text{Gal}(\\text{minpoly}_F(\\alpha)))$. The forward direction ($\\Rightarrow$) is `solvableByRad.isSolvable'`; the backward direction ($\\Leftarrow$) uses the primitive element theorem and Galois's constructive procedure for extracting radicals from a solvable tower of normal subgroups.",
+    "significance": "context",
+    "prerequisites": [
+      "Galois theory",
+      "solvable groups",
+      "radical extensions"
+    ],
+    "relatedConcepts": [
+      "Galois correspondence",
+      "contrapositive reasoning",
+      "fundamental theorem of Galois theory"
+    ]
+  },
+  {
     "id": "ann-abel-ruffini-theorem",
     "proofId": "abel-ruffini",
     "range": {
@@ -95,8 +118,8 @@
     },
     "type": "theorem",
     "title": "The Galois Bridge Theorem",
-    "content": "**Theorem**: If α is expressible using radicals, then the Galois group of its minimal polynomial is solvable.\n\nThis is the key bridge: radical solvability (field theory) → group solvability (group theory).\n\nThe proof proceeds by induction on `IsSolvableByRad`. The key case: if α^n is solvable, then adjoining α creates a cyclic extension, and cyclic groups are abelian (hence solvable).",
-    "mathContext": "$\\alpha$ solvable by radicals $\\Rightarrow$ Gal(minpoly(α)) is solvable\n\nContrapositive: If Galois group is NOT solvable, roots are NOT expressible by radicals.",
+    "content": "**Theorem**: If α is expressible using radicals, then the Galois group of its minimal polynomial is solvable.\n\nThis is the key bridge: radical solvability (field theory) → group solvability (group theory).\n\nThe Lean proof is a one-liner: `solvableByRad.isSolvable' hq hroot hrad`. Internally, Mathlib proves this by induction on the `IsSolvableByRad` construction: each radical step $K_i \\to K_i(\\sqrt[n]{a})$ yields a cyclic (hence abelian) Galois group quotient, and a group built from abelian quotients is solvable. The hypotheses `hq : Irreducible q`, `hroot : aeval α q = 0`, and `hrad : IsSolvableByRad F α` are passed directly to Mathlib's lemma — the theorem is a pedagogical wrapper making the bridge explicit.",
+    "mathContext": "$\\alpha \\in \\text{solvableByRad}(F, E) \\Rightarrow \\text{IsSolvable}(\\text{Gal}(\\text{minpoly}_F(\\alpha)))$\n\nContrapositive (used in `not_solvable_by_rad_of_not_solvable_gal`): $\\neg\\text{IsSolvable}(\\text{Gal}(q)) \\Rightarrow \\neg\\text{IsSolvableByRad}\\,F\\,\\alpha$.\n\nThe converse ($\\Leftarrow$) also holds: given a solvable Galois group, one constructs a radical tower from the composition series $\\{e\\} = G_n \\triangleleft \\cdots \\triangleleft G_0 = G$ where each $G_i/G_{i+1}$ is cyclic, using Kummer theory to extract the radical at each step.",
     "significance": "critical",
     "prerequisites": [
       "field extensions",
@@ -284,7 +307,7 @@
     },
     "type": "theorem",
     "title": "The Abel-Ruffini Contrapositive: The Main Event",
-    "content": "`not_solvable_by_rad_of_not_solvable_gal` is the logical heart of the formalization. It takes the contrapositive of `galois_bridge`: if the Galois group of an irreducible polynomial $q$ is **not** solvable and $\\alpha$ is a root, then $\\alpha$ is **not** solvable by radicals. The proof is a 2-line `intro`/`exact`.\n\n`exists_quintic` provides a trivial witness ($X^5$) that degree-5 polynomials exist. To complete the Abel-Ruffini theorem for a *specific* quintic, one would need to show some $q \\in \\mathbb{Q}[X]$ of degree 5 has $\\text{Gal}(q) \\cong S_5$ — a computation the formalization leaves implicit.",
+    "content": "`not_solvable_by_rad_of_not_solvable_gal` is the logical heart of the formalization. It takes the contrapositive of `galois_bridge`: if the Galois group of an irreducible polynomial $q$ is **not** solvable and $\\alpha$ is a root, then $\\alpha$ is **not** solvable by radicals. The proof is a 2-line proof term: `intro hrad; exact hns (galois_bridge α q hq hroot hrad)` — assuming $\\alpha$ is solvable by radicals, applying the bridge to get `IsSolvable q.Gal`, and deriving a contradiction with `hns`.\n\n`exists_quintic` provides a trivial witness ($X^5$) that degree-5 polynomials exist. To complete the Abel-Ruffini theorem for a *specific* quintic, one would need to exhibit $q \\in \\mathbb{Q}[X]$ of degree 5 with $\\text{Gal}(q) \\cong S_5$. The standard example is $x^5 - x - 1$, whose Galois group over $\\mathbb{Q}$ is $S_5$ (verified by checking irreducibility mod 2 and that the discriminant has non-square part, forcing the full symmetric group).",
     "mathContext": "$\\neg\\,\\text{IsSolvable}(q.\\text{Gal}) \\Rightarrow \\neg\\,\\text{IsSolvableByRad}\\,F\\,\\alpha$.\n\nProof: Assume $\\text{IsSolvableByRad}\\,F\\,\\alpha$. By `galois_bridge`, $\\text{IsSolvable}(q.\\text{Gal})$. Contradiction with $\\neg\\,\\text{IsSolvable}(q.\\text{Gal})$. $\\square$\n\nFor the general quintic: $q = x^5 - x - 1$ over $\\mathbb{Q}$ has $\\text{Gal}(q) \\cong S_5$, so its roots are not expressible by radicals.",
     "significance": "critical",
     "prerequisites": [

--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -16,7 +16,10 @@
       "radical extensions",
       "polynomial solvability"
     ],
-    "prerequisites": ["polynomial equations", "field operations"]
+    "prerequisites": [
+      "polynomial equations",
+      "field operations"
+    ]
   },
   {
     "id": "ann-imports",
@@ -26,7 +29,7 @@
     },
     "type": "concept",
     "title": "Mathlib Imports",
-    "content": "We import the key Mathlib modules:\n- `AbelRuffini`: The main theorem connecting radicals to solvable groups\n- `Solvable`: Definition of solvable groups and key theorems\n- `Alternating`: Properties of alternating groups, including A\u2085 simplicity\n- `Galois.Basic`: Galois group definitions and correspondence",
+    "content": "We import the key Mathlib modules:\n- `AbelRuffini`: The main theorem connecting radicals to solvable groups\n- `Solvable`: Definition of solvable groups and key theorems\n- `Alternating`: Properties of alternating groups, including A₅ simplicity\n- `Galois.Basic`: Galois group definitions and correspondence",
     "mathContext": "The four imports form a complete logical chain: `FieldTheory.AbelRuffini` provides `solvableByRad.isSolvable'` ($\\alpha$ solvable by radicals $\\Rightarrow$ $\\text{Gal}(\\text{minpoly}(\\alpha))$ solvable); `GroupTheory.Solvable` provides `IsSolvable` and `Equiv.Perm.not_solvable` ($5 \\leq |X| \\Rightarrow S_X$ not solvable); `SpecificGroups.Alternating` provides `alternatingGroup.isSimpleGroup_five` ($A_5$ simple); `FieldTheory.Galois.Basic` provides $\\text{Polynomial.Gal}$, the type of the Galois group of a polynomial.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -34,7 +37,10 @@
       "Galois theory",
       "group theory"
     ],
-    "prerequisites": ["Lean 4 import system", "Mathlib library structure"]
+    "prerequisites": [
+      "Lean 4 import system",
+      "Mathlib library structure"
+    ]
   },
   {
     "id": "ann-namespace",
@@ -53,7 +59,9 @@
       "Lean 4 namespaces",
       "module organization"
     ],
-    "prerequisites": ["Lean 4 namespace system"]
+    "prerequisites": [
+      "Lean 4 namespace system"
+    ]
   },
   {
     "id": "ann-solvable-by-rad",
@@ -65,15 +73,42 @@
     },
     "type": "definition",
     "title": "Solvable by Radicals and Field Variables",
-    "content": "An element \u03b1 is 'solvable by radicals' if it can be built from the base field using field operations and nth roots. The quadratic formula is an example: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$\n\nMathlib defines this inductively via `IsSolvableByRad`, with constructors for: base field elements, arithmetic operations, and radical extraction.",
-    "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over F.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by: 2 \u2208 \u211a, then \u221a2, then 1+\u221a2, then \u221a(1+\u221a2).",
+    "content": "An element α is 'solvable by radicals' if it can be built from the base field using field operations and nth roots. The quadratic formula is an example: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$\n\nMathlib defines this inductively via `IsSolvableByRad`, with constructors for: base field elements, arithmetic operations, and radical extraction.",
+    "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over F.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by: 2 ∈ ℚ, then √2, then 1+√2, then √(1+√2).",
     "significance": "critical",
     "relatedConcepts": [
       "radical extension",
       "intermediate field",
       "inductive definition"
     ],
-    "prerequisites": ["field extensions", "nth roots", "IsSolvableByRad"]
+    "prerequisites": [
+      "field extensions",
+      "nth roots",
+      "IsSolvableByRad"
+    ]
+  },
+  {
+    "id": "ann-part-ii-bridge",
+    "proofId": "abel-ruffini",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "Part II: The Galois-Theoretic Bridge"
+    },
+    "type": "context",
+    "title": "Part II: The Galois-Theoretic Bridge",
+    "content": "This docstring introduces the central insight of the formalization: the connection between radical solvability (a field-theoretic property) and group solvability (a group-theoretic property). Galois's 1831 memoir established that these two notions correspond precisely.\n\nThe bridge is one-directional for the impossibility proof: solvable by radicals $\\Rightarrow$ solvable Galois group. The converse (solvable Galois group $\\Rightarrow$ solvable by radicals) also holds but is not needed here — only the contrapositive of the forward direction is used in `not_solvable_by_rad_of_not_solvable_gal`.",
+    "mathContext": "Galois's correspondence: $\\text{IsSolvableByRad}\\,F\\,\\alpha \\Leftrightarrow \\text{IsSolvable}(\\text{Gal}(\\text{minpoly}_F(\\alpha)))$. The forward direction ($\\Rightarrow$) is `solvableByRad.isSolvable'`; the backward direction ($\\Leftarrow$) uses the primitive element theorem and Galois's constructive procedure for extracting radicals from a solvable tower of normal subgroups.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Galois correspondence",
+      "contrapositive reasoning",
+      "fundamental theorem of Galois theory"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "solvable groups",
+      "radical extensions"
+    ]
   },
   {
     "id": "ann-abel-ruffini-theorem",
@@ -85,15 +120,19 @@
     },
     "type": "theorem",
     "title": "The Galois Bridge Theorem",
-    "content": "**Theorem**: If \u03b1 is expressible using radicals, then the Galois group of its minimal polynomial is solvable.\n\nThis is the key bridge: radical solvability (field theory) \u2192 group solvability (group theory).\n\nThe proof proceeds by induction on `IsSolvableByRad`. The key case: if \u03b1^n is solvable, then adjoining \u03b1 creates a cyclic extension, and cyclic groups are abelian (hence solvable).",
-    "mathContext": "$\\alpha$ solvable by radicals $\\Rightarrow$ Gal(minpoly(\u03b1)) is solvable\n\nContrapositive: If Galois group is NOT solvable, roots are NOT expressible by radicals.",
+    "content": "**Theorem**: If α is expressible using radicals, then the Galois group of its minimal polynomial is solvable.\n\nThis is the key bridge: radical solvability (field theory) → group solvability (group theory).\n\nThe Lean proof is a one-liner: `solvableByRad.isSolvable' hq hroot hrad`. Internally, Mathlib proves this by induction on the `IsSolvableByRad` construction: each radical step $K_i \\to K_i(\\sqrt[n]{a})$ yields a cyclic (hence abelian) Galois group quotient, and a group built from abelian quotients is solvable. The hypotheses `hq : Irreducible q`, `hroot : aeval α q = 0`, and `hrad : IsSolvableByRad F α` are passed directly to Mathlib's lemma — the theorem is a pedagogical wrapper making the bridge explicit.",
+    "mathContext": "$\\alpha \\in \\text{solvableByRad}(F, E) \\Rightarrow \\text{IsSolvable}(\\text{Gal}(\\text{minpoly}_F(\\alpha)))$\n\nContrapositive (used in `not_solvable_by_rad_of_not_solvable_gal`): $\\neg\\text{IsSolvable}(\\text{Gal}(q)) \\Rightarrow \\neg\\text{IsSolvableByRad}\\,F\\,\\alpha$.\n\nThe converse ($\\Leftarrow$) also holds: given a solvable Galois group, one constructs a radical tower from the composition series $\\{e\\} = G_n \\triangleleft \\cdots \\triangleleft G_0 = G$ where each $G_i/G_{i+1}$ is cyclic, using Kummer theory to extract the radical at each step.",
     "significance": "critical",
     "relatedConcepts": [
       "Galois group",
       "solvable group",
       "minimal polynomial"
     ],
-    "prerequisites": ["field extensions", "Galois theory", "solvableByRad.isSolvable'"]
+    "prerequisites": [
+      "field extensions",
+      "Galois theory",
+      "solvableByRad.isSolvable'"
+    ]
   },
   {
     "id": "ann-sn-not-solvable",
@@ -104,7 +143,7 @@
     },
     "type": "concept",
     "title": "Non-Solvability of Large Symmetric Groups",
-    "content": "Part III introduces the group-theoretic core of Abel-Ruffini: for $n \\geq 5$, the symmetric group $S_n$ is not solvable. The theorem `symmetric_group_not_solvable` generalizes beyond degree 5 \u2014 it applies to all $n \\geq 5$. The proof delegates to Mathlib's `Equiv.Perm.not_solvable` after bridging from $\\mathbb{N}$ to Cardinal (see next annotation).\n\nThe key mathematical fact: the derived series of $S_n$ reaches $A_n$ and stalls because $A_n$ is perfect ($[A_n, A_n] = A_n$) for $n \\geq 5$, since $A_n$ is simple and non-abelian.",
+    "content": "Part III introduces the group-theoretic core of Abel-Ruffini: for $n \\geq 5$, the symmetric group $S_n$ is not solvable. The theorem `symmetric_group_not_solvable` generalizes beyond degree 5 — it applies to all $n \\geq 5$. The proof delegates to Mathlib's `Equiv.Perm.not_solvable` after bridging from $\\mathbb{N}$ to Cardinal (see next annotation).\n\nThe key mathematical fact: the derived series of $S_n$ reaches $A_n$ and stalls because $A_n$ is perfect ($[A_n, A_n] = A_n$) for $n \\geq 5$, since $A_n$ is simple and non-abelian.",
     "mathContext": "For $n \\geq 5$: $D^0(S_n) = S_n,\\; D^1(S_n) = [S_n, S_n] = A_n,\\; D^k(S_n) = A_n$ for all $k \\geq 1$. The derived series never reaches $\\{e\\}$, so $S_n$ is not solvable. Compare: for $n = 4$, $D^4(S_4) = \\{e\\}$ via the Klein four-group.",
     "significance": "key",
     "relatedConcepts": [
@@ -113,7 +152,11 @@
       "simple group",
       "commutator subgroup"
     ],
-    "prerequisites": ["group theory", "Equiv.Perm.not_solvable", "derived subgroup"]
+    "prerequisites": [
+      "group theory",
+      "Equiv.Perm.not_solvable",
+      "derived subgroup"
+    ]
   },
   {
     "id": "ann-cardinal-bridge",
@@ -124,8 +167,8 @@
       "kind": "theorem"
     },
     "type": "technique",
-    "title": "The Cardinal Bridge: From \u2115 to Lean's Type Universe",
-    "content": "The proof of symmetric_group_not_solvable bridges between \u2115 (where 5 \u2264 n lives) and Cardinal (where Mathlib's Equiv.Perm.not_solvable expects 5 \u2264 Cardinal.mk \u03b1). Step 1: simp rewrites Cardinal.mk (Fin n) as \u2191n. Step 2: exact_mod_cast strips the cast and applies hn. The \u2115 \u2192 Cardinal coercion is an order embedding, so inequalities transfer automatically. This 3-line pattern recurs in AbelRuffiniOQ04.lean.",
+    "title": "The Cardinal Bridge: From ℕ to Lean's Type Universe",
+    "content": "The proof of symmetric_group_not_solvable bridges between ℕ (where 5 ≤ n lives) and Cardinal (where Mathlib's Equiv.Perm.not_solvable expects 5 ≤ Cardinal.mk α). Step 1: simp rewrites Cardinal.mk (Fin n) as ↑n. Step 2: exact_mod_cast strips the cast and applies hn. The ℕ → Cardinal coercion is an order embedding, so inequalities transfer automatically. This 3-line pattern recurs in AbelRuffiniOQ04.lean.",
     "mathContext": "$5 \\leq n$ in $\\mathbb{N}$ $\\xrightarrow{\\text{cast}}$ $\\uparrow 5 \\leq \\uparrow n$ in Cardinal $\\xleftarrow{\\text{simp}}$ $5 \\leq |\\text{Fin}\\,n|$. The cast $\\mathbb{N} \\hookrightarrow \\text{Cardinal}$ is an order embedding.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -134,7 +177,11 @@
       "type coercion",
       "order embedding"
     ],
-    "prerequisites": ["Cardinal.mk_fintype", "Fintype.card_fin", "exact_mod_cast"]
+    "prerequisites": [
+      "Cardinal.mk_fintype",
+      "Fintype.card_fin",
+      "exact_mod_cast"
+    ]
   },
   {
     "id": "ann-s5-s6-not-solvable",
@@ -146,7 +193,7 @@
       "extendAfter": 5
     },
     "type": "technique",
-    "title": "Instantiating Non-Solvability for S\u2085 and S\u2086",
+    "title": "Instantiating Non-Solvability for S₅ and S₆",
     "content": "`s5_not_solvable` and `s6_not_solvable` specialize the general `symmetric_group_not_solvable` to $n = 5$ and $n = 6$. The proofs are one-liners: for $n = 5$, the bound $5 \\leq 5$ is `le_rfl`; for $n = 6$, it is discharged by `omega`. The simplicity of $A_5$ (`a5_is_simple`) is stated separately as the structural reason the derived series of $S_5$ stalls.\n\nThese instantiations make the abstract result concrete: $S_5$ is the specific group relevant to quintic polynomials, while $S_6$ confirms the pattern extends to all higher degrees.",
     "mathContext": "$S_5 = \\text{Equiv.Perm}(\\text{Fin}\\ 5)$, $|S_5| = 120$. The derived series: $S_5 \\triangleright A_5 \\triangleright A_5 \\triangleright \\cdots$ (stuck because $[A_5, A_5] = A_5$, i.e., $A_5$ is perfect). Compare $S_4 \\triangleright A_4 \\triangleright V_4 \\triangleright \\mathbb{Z}/2 \\triangleright \\{e\\}$ which terminates.",
     "significance": "key",
@@ -156,7 +203,11 @@
       "composition series",
       "simple group"
     ],
-    "prerequisites": ["symmetric_group_not_solvable", "le_rfl", "omega tactic"]
+    "prerequisites": [
+      "symmetric_group_not_solvable",
+      "le_rfl",
+      "omega tactic"
+    ]
   },
   {
     "id": "ann-a5-simple",
@@ -167,9 +218,9 @@
       "kind": "theorem"
     },
     "type": "theorem",
-    "title": "A\u2085 is Simple",
-    "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A\u2085 is simple - it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A\u2085.",
-    "mathContext": "A\u2085 = {even permutations of 5 objects} = ker(sign : S\u2085 \u2192 {\u00b11})\n\n|A\u2085| = 60 = 5!/2",
+    "title": "A₅ is Simple",
+    "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A₅ is simple - it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A₅.",
+    "mathContext": "A₅ = {even permutations of 5 objects} = ker(sign : S₅ → {±1})\n\n|A₅| = 60 = 5!/2",
     "significance": "critical",
     "relatedConcepts": [
       "alternating group",
@@ -177,7 +228,11 @@
       "normal subgroup",
       "cycle type"
     ],
-    "prerequisites": ["permutation groups", "normal subgroups", "alternatingGroup.isSimpleGroup_five"]
+    "prerequisites": [
+      "permutation groups",
+      "normal subgroups",
+      "alternatingGroup.isSimpleGroup_five"
+    ]
   },
   {
     "id": "ann-small-solvable",
@@ -189,7 +244,7 @@
     },
     "type": "insight",
     "title": "Solvable Small Symmetric Groups: The Other Side of the Threshold",
-    "content": "$S_0$ and $S_1$ are trivially solvable (both are the trivial group of order 1), and Lean's typeclass inference (`inferInstance`) finds their `IsSolvable` instances automatically. These contrast with $S_5$ and beyond, highlighting the sharp boundary.\n\nHistorically, $S_2$ (quadratic formula, ~2000 BCE), $S_3$ (Cardano's cubic formula, 1545), and $S_4$ (Ferrari's quartic formula, 1545) are all solvable \u2014 each corresponding to a classical radical formula. The file notes that Mathlib did not yet provide `IsSolvable` instances for $S_2, S_3, S_4$ at time of writing.",
+    "content": "$S_0$ and $S_1$ are trivially solvable (both are the trivial group of order 1), and Lean's typeclass inference (`inferInstance`) finds their `IsSolvable` instances automatically. These contrast with $S_5$ and beyond, highlighting the sharp boundary.\n\nHistorically, $S_2$ (quadratic formula, ~2000 BCE), $S_3$ (Cardano's cubic formula, 1545), and $S_4$ (Ferrari's quartic formula, 1545) are all solvable — each corresponding to a classical radical formula. The file notes that Mathlib did not yet provide `IsSolvable` instances for $S_2, S_3, S_4$ at time of writing.",
     "mathContext": "$S_0 \\cong S_1 \\cong \\{e\\}$ (trivial). $S_2 \\cong \\mathbb{Z}/2$ (abelian). $S_3$: derived series $S_3 \\triangleright A_3 \\cong \\mathbb{Z}/3 \\triangleright \\{e\\}$. $S_4$: derived series $S_4 \\triangleright A_4 \\triangleright V_4 \\triangleright \\mathbb{Z}/2 \\triangleright \\{e\\}$, where $V_4 = \\{e,(12)(34),(13)(24),(14)(23)\\}$ is the Klein four-group.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -198,7 +253,11 @@
       "typeclass inference",
       "quadratic formula"
     ],
-    "prerequisites": ["IsSolvable typeclass", "inferInstance", "Equiv.Perm (Fin n)"]
+    "prerequisites": [
+      "IsSolvable typeclass",
+      "inferInstance",
+      "Equiv.Perm (Fin n)"
+    ]
   },
   {
     "id": "ann-part-v-synthesis",
@@ -218,7 +277,11 @@
       "contrapositive",
       "proof architecture"
     ],
-    "prerequisites": ["galois_bridge (Part II)", "symmetric_group_not_solvable (Part III)", "contrapositive reasoning"]
+    "prerequisites": [
+      "galois_bridge (Part II)",
+      "symmetric_group_not_solvable (Part III)",
+      "contrapositive reasoning"
+    ]
   },
   {
     "id": "ann-exists-quintic",
@@ -230,7 +293,7 @@
     },
     "type": "technique",
     "title": "Part V Setup: Existence of Quintics and the Main Theorem Preamble",
-    "content": "Part V combines the Galois bridge (Part II) with non-solvability of $S_n$ (Part III) to state the Abel-Ruffini theorem.\n\n`exists_quintic` provides a trivial witness that degree-5 polynomials exist: $X^5$ has `natDegree = 5`, proved by `simp` on `Polynomial.natDegree_pow` and `Polynomial.natDegree_X`. This is a sanity check \u2014 the substantive content is in `not_solvable_by_rad_of_not_solvable_gal` that follows.\n\nThe Part V docstring frames the logical structure: the contrapositive of `galois_bridge` converts \"solvable by radicals \u2192 solvable Galois group\" into \"unsolvable Galois group \u2192 not solvable by radicals.\" Since $S_5$ is not solvable, any polynomial with Galois group $S_5$ has roots that are not expressible by radicals.",
+    "content": "Part V combines the Galois bridge (Part II) with non-solvability of $S_n$ (Part III) to state the Abel-Ruffini theorem.\n\n`exists_quintic` provides a trivial witness that degree-5 polynomials exist: $X^5$ has `natDegree = 5`, proved by `simp` on `Polynomial.natDegree_pow` and `Polynomial.natDegree_X`. This is a sanity check — the substantive content is in `not_solvable_by_rad_of_not_solvable_gal` that follows.\n\nThe Part V docstring frames the logical structure: the contrapositive of `galois_bridge` converts \"solvable by radicals → solvable Galois group\" into \"unsolvable Galois group → not solvable by radicals.\" Since $S_5$ is not solvable, any polynomial with Galois group $S_5$ has roots that are not expressible by radicals.",
     "mathContext": "$\\exists p \\in \\mathbb{Q}[X],\\; \\deg(p) = 5$. Witness: $p = X^5$.\n\n$\\text{natDegree}(X^n) = n \\cdot \\text{natDegree}(X) = n \\cdot 1 = n$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -238,7 +301,10 @@
       "witness construction",
       "contrapositive setup"
     ],
-    "prerequisites": ["Polynomial.natDegree_pow", "Polynomial.natDegree_X"]
+    "prerequisites": [
+      "Polynomial.natDegree_pow",
+      "Polynomial.natDegree_X"
+    ]
   },
   {
     "id": "ann-contrapositive",
@@ -250,7 +316,7 @@
     },
     "type": "theorem",
     "title": "The Abel-Ruffini Contrapositive: The Main Event",
-    "content": "`not_solvable_by_rad_of_not_solvable_gal` is the logical heart of the formalization. It takes the contrapositive of `galois_bridge`: if the Galois group of an irreducible polynomial $q$ is **not** solvable and $\\alpha$ is a root, then $\\alpha$ is **not** solvable by radicals. The proof is a 2-line `intro`/`exact`.\n\n`exists_quintic` provides a trivial witness ($X^5$) that degree-5 polynomials exist. To complete the Abel-Ruffini theorem for a *specific* quintic, one would need to show some $q \\in \\mathbb{Q}[X]$ of degree 5 has $\\text{Gal}(q) \\cong S_5$ \u2014 a computation the formalization leaves implicit.",
+    "content": "`not_solvable_by_rad_of_not_solvable_gal` is the logical heart of the formalization. It takes the contrapositive of `galois_bridge`: if the Galois group of an irreducible polynomial $q$ is **not** solvable and $\\alpha$ is a root, then $\\alpha$ is **not** solvable by radicals. The proof is a 2-line proof term: `intro hrad; exact hns (galois_bridge α q hq hroot hrad)` — assuming $\\alpha$ is solvable by radicals, applying the bridge to get `IsSolvable q.Gal`, and deriving a contradiction with `hns`.\n\n`exists_quintic` provides a trivial witness ($X^5$) that degree-5 polynomials exist. To complete the Abel-Ruffini theorem for a *specific* quintic, one would need to exhibit $q \\in \\mathbb{Q}[X]$ of degree 5 with $\\text{Gal}(q) \\cong S_5$. The standard example is $x^5 - x - 1$, whose Galois group over $\\mathbb{Q}$ is $S_5$ (verified by checking irreducibility mod 2 and that the discriminant has non-square part, forcing the full symmetric group).",
     "mathContext": "$\\neg\\,\\text{IsSolvable}(q.\\text{Gal}) \\Rightarrow \\neg\\,\\text{IsSolvableByRad}\\,F\\,\\alpha$.\n\nProof: Assume $\\text{IsSolvableByRad}\\,F\\,\\alpha$. By `galois_bridge`, $\\text{IsSolvable}(q.\\text{Gal})$. Contradiction with $\\neg\\,\\text{IsSolvable}(q.\\text{Gal})$. $\\square$\n\nFor the general quintic: $q = x^5 - x - 1$ over $\\mathbb{Q}$ has $\\text{Gal}(q) \\cong S_5$, so its roots are not expressible by radicals.",
     "significance": "critical",
     "relatedConcepts": [
@@ -259,7 +325,11 @@
       "irreducible polynomial",
       "Galois group computation"
     ],
-    "prerequisites": ["galois_bridge", "IsSolvable", "IsSolvableByRad"]
+    "prerequisites": [
+      "galois_bridge",
+      "IsSolvable",
+      "IsSolvableByRad"
+    ]
   },
   {
     "id": "ann-threshold-commentary",
@@ -270,15 +340,19 @@
     },
     "type": "context",
     "title": "Why Degree 5 and the Historical Revolution",
-    "content": "The closing commentary (Parts VI\u2013VII) explains *why* degree 5 is the exact threshold and places the result in historical context. The derived series of $S_4$ terminates because $A_4$ has the Klein four-group $V_4$ as a normal subgroup, while $A_5$ has no proper normal subgroups at all (it is simple).\n\nHistorically, Abel-Ruffini was revolutionary as one of the first major **impossibility proofs** \u2014 showing that something *cannot* be done. This methodology later influenced Lindemann's proof that $\\pi$ is transcendental (1882), G\u00f6del's incompleteness theorems (1931), and Turing's halting problem (1936). The commentary also makes a subtle but important distinction: quintic equations **do** have solutions (by the Fundamental Theorem of Algebra), they just cannot be expressed using radicals.",
+    "content": "The closing commentary (Parts VI–VII) explains *why* degree 5 is the exact threshold and places the result in historical context. The derived series of $S_4$ terminates because $A_4$ has the Klein four-group $V_4$ as a normal subgroup, while $A_5$ has no proper normal subgroups at all (it is simple).\n\nHistorically, Abel-Ruffini was revolutionary as one of the first major **impossibility proofs** — showing that something *cannot* be done. This methodology later influenced Lindemann's proof that $\\pi$ is transcendental (1882), Gödel's incompleteness theorems (1931), and Turing's halting problem (1936). The commentary also makes a subtle but important distinction: quintic equations **do** have solutions (by the Fundamental Theorem of Algebra), they just cannot be expressed using radicals.",
     "mathContext": "The conjugacy classes of $A_5$ have sizes $1, 12, 12, 15, 20$ (summing to 60). A normal subgroup must be a union of conjugacy classes including $\\{e\\}$ (size 1), and its order must divide 60. No sub-sum $1 + \\cdots$ of $\\{1, 12, 12, 15, 20\\}$ divides 60 except $\\{1\\}$ and $\\{1,12,12,15,20\\}$. This combinatorial fact proves $A_5$ is simple.",
     "significance": "supporting",
     "relatedConcepts": [
       "impossibility proof",
       "Fundamental Theorem of Algebra",
       "transcendence of pi",
-      "G\u00f6del incompleteness"
+      "Gödel incompleteness"
     ],
-    "prerequisites": ["derived series", "composition series", "simple groups"]
+    "prerequisites": [
+      "derived series",
+      "composition series",
+      "simple groups"
+    ]
   }
 ]

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -116,7 +116,7 @@
       "id": "small-solvable",
       "title": "Small Symmetric Groups are Solvable",
       "startLine": 100,
-      "endLine": 118,
+      "endLine": 119,
       "summary": "Part IV docstring and theorems: `s0_solvable` and `s1_solvable` via `inferInstance`. Documents the derived series for $S_2$ through $S_4$, showing why each is solvable, and contrasts with $S_n$ ($n \\geq 5$) which is not.",
       "mathContext": "$S_0$ and $S_1$ are trivial groups (order 1), hence abelian and trivially solvable. The sharp boundary at $n = 5$ corresponds exactly to the existence of quadratic, cubic (Cardano, 1545), and quartic (Ferrari, 1545) formulas contrasted with the impossibility for degree 5."
     },

--- a/src/data/proofs/bezout-identity/meta.json
+++ b/src/data/proofs/bezout-identity/meta.json
@@ -72,7 +72,21 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 60,
     "axiomCount": 0,
-    "lineCount": 237
+    "lineCount": 237,
+    "relatedProblems": [
+      {
+        "id": "bezout-identity-oq-02",
+        "relationship": "Extended Euclidean algorithm and applications"
+      },
+      {
+        "id": "bezout-identity-oq-03",
+        "relationship": "Generalizations of Bézout's identity"
+      },
+      {
+        "id": "bezout-identity-oq-04",
+        "relationship": "Further extensions"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Bézout's identity is named after the French mathematician **Étienne Bézout** (1730--1783), who stated it in his 1770 *Théorie générale des équations algébriques*. However, the result was known earlier: **Claude Gaspard Bachet de Méziriac** gave a proof in his 1624 commentary on Diophantus, and the underlying algorithm — the **extended Euclidean algorithm** — goes back to Euclid's *Elements* (c. 300 BCE). The key insight is computational: the standard Euclidean algorithm for computing $\\gcd(a, b)$ can be run 'in reverse' to express the gcd as a linear combination $ax + by = \\gcd(a, b)$, with the coefficients $x, y$ tracked through each division step.\n\nThe identity is foundational to number theory and its applications. Its most important consequence is the **coprimality characterization**: $\\gcd(a, b) = 1$ if and only if there exist integers $x, y$ with $ax + by = 1$. This characterization is the engine behind **Euclid's lemma** (if a prime divides a product, it divides one of the factors), which in turn implies the **fundamental theorem of arithmetic** (unique prime factorization). In applied mathematics, Bézout's identity is the basis for computing **modular inverses** — given $\\gcd(a, n) = 1$, the coefficient $x$ in $ax + ny = 1$ satisfies $ax \\equiv 1 \\pmod{n}$ — which is central to **RSA cryptography** for computing private keys.\n\nThe Lean 4 formalization leverages Mathlib's `Nat.gcd_eq_gcd_ab` and `Int.gcd_eq_gcd_ab`, which provide Bézout's identity with constructive witnesses via `gcdA` and `gcdB`. The file builds substantially on these foundations: it proves the coprimality characterization as a full `↔` (using divisibility arguments for the reverse direction), derives modular inverse existence, establishes the Diophantine solvability criterion ($ax + by = c$ has solutions iff $\\gcd(a, b) \\mid c$), and provides six verified numerical examples. This is entry #60 on Wiedijk's list of 100 famous theorems.",

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -46,6 +46,16 @@
     ],
     "assumptions": [
       "no_continuous_odd_nonzero_on_sphere: For n ≥ 1, there is no continuous odd function h: ℝ^(n+1) → ℝ^n that is nonzero on the n-sphere. This requires covering space theory and fundamental groups beyond Mathlib's current algebraic topology coverage."
+    ],
+    "relatedProblems": [
+      {
+        "id": "borsuk-ulam-oq-02",
+        "relationship": "Extension of borsuk ulam"
+      },
+      {
+        "id": "borsuk-ulam-oq-03",
+        "relationship": "Extension of borsuk ulam"
+      }
     ]
   },
   "overview": {

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -76,13 +76,22 @@
         "Mathlib.Analysis.InnerProductSpace.PiL2",
         "Mathlib.Topology.MetricSpace.Basic"
       ],
-      "opens": ["Set", "Metric"],
+      "opens": [
+        "Set",
+        "Metric"
+      ],
       "namespace": "Brouwer",
       "lineCount": 250,
       "axiomCount": 2,
       "theoremCount": 5,
       "definitionCount": 6
-    }
+    },
+    "relatedProblems": [
+      {
+        "id": "brouwer-fixed-point-oq-02",
+        "relationship": "Extension of brouwer fixed point"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Luitzen Egbertus Jan Brouwer proved this theorem in 1911 in *Mathematische Annalen*. Earlier special cases were known: Poincaré proved a version for smooth maps in 1886, and Hadamard proved the 2D case in 1910 using degree theory. Brouwer's contribution was the full generalization to continuous maps in arbitrary dimension.\n\nThe result is beautifully intuitive: no matter how you continuously 'stir' a disk, some point must end up exactly where it started. Multiple proofs exist: Brouwer's original via degree theory, Sperner's 1928 combinatorial proof via his lemma on triangulations, Milnor's 1965 differential topology proof via Sard's theorem, and modern proofs via singular homology.\n\nThe theorem's applications are vast. John Nash used it in 1950 to prove equilibrium existence in non-cooperative games (Nobel Prize 1994). It guarantees solutions to differential equations via Schauder's extension to Banach spaces. In computational complexity, finding Brouwer fixed points is PPAD-complete (Papadimitriou 1994), explaining why Nash equilibrium computation is hard.\n\nIronically, Brouwer later founded **intuitionism** (1920s), rejecting the law of excluded middle and the non-constructive proof-by-contradiction his own theorem relies upon. He came to view the theorem as an example of mathematics that proves existence without construction — precisely what intuitionists object to.",

--- a/src/data/proofs/cantor-diagonalization/meta.json
+++ b/src/data/proofs/cantor-diagonalization/meta.json
@@ -39,7 +39,17 @@
       "Set theory and power sets (Set, Set.powerset)"
     ],
     "wiedijkNumber": 22,
-    "axiomCount": 0
+    "axiomCount": 0,
+    "relatedProblems": [
+      {
+        "id": "cantor-diagonalization-oq-01",
+        "relationship": "Extension of cantor diagonalization"
+      },
+      {
+        "id": "cantor-diagonalization-oq-02",
+        "relationship": "Extension of cantor diagonalization"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Georg Cantor published the diagonal argument in 1891 in *Über eine elementare Frage der Mannigfaltigkeitslehre*, though he had already proven the uncountability of the reals in 1874 using a nested-intervals argument. The 1891 proof was revolutionary in its simplicity and generality: it works not just for $\\mathbb{R}$ but for any set $S$ versus $S \\to \\{0,1\\}$ (the power set), immediately giving $|S| < |2^S|$ for all sets $S$.\n\nCantor's work was the most controversial mathematics of its era. Leopold Kronecker called him a 'corrupter of youth'; Henri Poincaré considered set theory a 'disease' from which mathematics would eventually recover. But David Hilbert declared: 'No one shall expel us from the paradise that Cantor has created.' Cantor suffered repeated nervous breakdowns, possibly exacerbated by the opposition, and spent his final years in a sanatorium (died 1918).\n\nThe diagonal argument's influence is incalculable. Richard's paradox (1905) and Berry's paradox use diagonal-like constructions. Kurt Gödel used a self-referential diagonal construction in his incompleteness theorems (1931): the sentence 'this sentence is unprovable' diagonalizes over all proofs. Alan Turing (1936) used a diagonal argument to prove the undecidability of the halting problem: the machine that asks 'does this machine halt on itself?' diagonalizes over all Turing machines. Paul Cohen's forcing (1963), which proved the independence of the continuum hypothesis, also relies on diagonal arguments. The technique is arguably the single most important proof method in mathematical logic.",

--- a/src/data/proofs/cantors-theorem/meta.json
+++ b/src/data/proofs/cantors-theorem/meta.json
@@ -39,7 +39,17 @@
     ],
     "dateAdded": "2025-12-26",
     "axiomCount": 0,
-    "lineCount": 157
+    "lineCount": 157,
+    "relatedProblems": [
+      {
+        "id": "cantors-theorem-oq-01",
+        "relationship": "Extension of cantors theorem"
+      },
+      {
+        "id": "cantors-theorem-oq-02",
+        "relationship": "Extension of cantors theorem"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Georg Cantor published this theorem in 1891, using the now-famous diagonal argument. It was revolutionary because it showed that not all infinities are equal - the power set of any set is strictly larger than the set itself.\n\nThis result shattered the intuition that 'infinity is just infinity' and established the foundation for the theory of transfinite cardinal numbers. Cantor showed there is an endless hierarchy of infinities: |N| < |P(N)| < |P(P(N))| < ...\n\nThe diagonal construction used in the proof is remarkably versatile and appears in many areas of mathematics and computer science, including Godel's incompleteness theorems and the undecidability of the halting problem.",

--- a/src/data/proofs/central-limit-theorem/meta.json
+++ b/src/data/proofs/central-limit-theorem/meta.json
@@ -37,7 +37,17 @@
     ],
     "dateAdded": "2025-12-22",
     "wiedijkNumber": 47,
-    "axiomCount": 0
+    "axiomCount": 0,
+    "relatedProblems": [
+      {
+        "id": "central-limit-theorem-oq-01",
+        "relationship": "Extension of central limit theorem"
+      },
+      {
+        "id": "central-limit-theorem-oq-03",
+        "relationship": "Extension of central limit theorem"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "The Central Limit Theorem (CLT) stands as one of the most remarkable results in probability theory. Its origins trace back to Abraham de Moivre's 1733 analysis of coin flips, but the theorem took nearly two centuries to reach its modern form.\n\nPierre-Simon Laplace generalized de Moivre's result in 1812, showing that sums of many independent random variables tend toward a bell curve. However, the first rigorous proof came from Aleksandr Lyapunov in 1901, using characteristic functions.\n\nThe algebraic topological perspective—viewing the Gaussian as a fixed point of a renormalization flow on the space of distributions—emerged in the late 20th century, connecting probability theory to dynamical systems, information geometry, and category theory.\n\nThis dual perspective reveals not just *that* the Gaussian appears universally, but *why*: it is an attractor in the space of probability distributions under the operation of convolution and rescaling.",

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -49,7 +49,17 @@
     "wiedijkNumber": 88,
     "mathlib_version": "4.15.0",
     "axiomCount": 0,
-    "lineCount": 227
+    "lineCount": 227,
+    "relatedProblems": [
+      {
+        "id": "derangements-oq-02",
+        "relationship": "Extension of derangements"
+      },
+      {
+        "id": "derangements-oq-03",
+        "relationship": "Extension of derangements"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "The derangement problem — also known as the 'problème des rencontres' (problem of coincidences) or the 'hat-check problem' — was first studied by Pierre Rémond de Montmort in his 1708 book 'Essay d'Analyse sur les Jeux de Hazard'. Montmort computed $D_n$ for small $n$ and conjectured the general formula. Nikolaus Bernoulli corresponded with Montmort about the problem, and Euler later derived the formula $D_n = n! \\sum (-1)^k/k!$ using inclusion-exclusion in 1751. The subfactorial notation $!n$ was introduced by William Allen Whitworth in 1878. The convergence $D_n/n! \\to 1/e$ is a celebrated result in combinatorial probability — it means that for large $n$, a random permutation has roughly a 36.79% chance of being a derangement, regardless of $n$. This is an early example of a 'universal' probability that doesn't depend on the problem size.",

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -39,7 +39,13 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 5,
-    "lineCount": 267
+    "lineCount": 267,
+    "relatedProblems": [
+      {
+        "id": "e-transcendental-oq-01",
+        "relationship": "Extension of e transcendental"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Charles Hermite proved $e$ is transcendental in 1873, making it the first \"naturally occurring\" constant shown to be transcendental—Joseph Liouville had constructed artificial transcendental numbers in 1844, but those were designed to satisfy Liouville's approximation criterion. Hermite's method used an auxiliary polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ combined with integral estimates to derive a contradiction from an assumed algebraic relation for $e$. Nine years later, Ferdinand von Lindemann (1882) extended Hermite's technique to prove $\\pi$ is transcendental, resolving the ancient Greek problem of squaring the circle. The full generalization—the **Lindemann-Weierstrass theorem** (1885)—states that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent whenever $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers. This deep result remains unformalized in Mathlib, so the main theorem here is axiomatized.",

--- a/src/data/proofs/erdos-340-greedy-sidon/annotations.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/annotations.json
@@ -1,0 +1,237 @@
+[
+  {
+    "id": "ann-sidon-def",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 76,
+      "endLine": 78
+    },
+    "type": "definition",
+    "title": "IsSidon: The Sidon Set Predicate",
+    "content": "A finite set $A \\subseteq \\mathbb{N}$ is **Sidon** (also called a $B_2$ sequence) if all pairwise sums are distinct: whenever $a + b = c + d$ with $a \\leq b$ and $c \\leq d$, we have $a = c$ and $b = d$.\n\nThe definition quantifies over all quadruples $(a, b, c, d) \\in A^4$ with the ordering constraints. This is equivalent to requiring the sumset $A + A = \\{a + b : a, b \\in A, a \\leq b\\}$ to have no repeated elements.\n\nSimon Sidon originally posed the problem of constructing dense sets with this property in the 1930s. The concept connects additive combinatorics, number theory, and harmonic analysis.",
+    "mathContext": "$\\text{IsSidon}(A) :\\Leftrightarrow \\forall a,b,c,d \\in A,\\; a \\leq b,\\; c \\leq d,\\; a + b = c + d \\Rightarrow (a,b) = (c,d)$\n\nEquivalently: the representation function $r(n) = |\\{(a,b) \\in A^2 : a + b = n, a \\leq b\\}|$ satisfies $r(n) \\leq 1$ for all $n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "B₂ sequences",
+      "additive combinatorics",
+      "sumset",
+      "representation function"
+    ],
+    "prerequisites": [
+      "Finset membership",
+      "additive number theory"
+    ]
+  },
+  {
+    "id": "ann-base-cases",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 85,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Base Cases: Empty, Singleton, and Pair Sets",
+    "content": "`isSidon_empty` is trivial (vacuously true). `isSidon_singleton` follows because all four elements must equal $n$, making both sides of the equation $2n = 2n$. `isSidon_pair` for $\\{a, b\\}$ with $a < b$ uses exhaustive case analysis (`rcases`) on which of $\\{a, b\\}$ each variable equals, then `omega` resolves all resulting arithmetic goals.\n\nThese base cases anchor inductive arguments: the greedy Sidon sequence starts with $\\{1\\}$ (singleton, hence Sidon) and extends by adding one element at a time while preserving the Sidon property.",
+    "mathContext": "$\\emptyset$ is Sidon (vacuous). $\\{n\\}$ is Sidon ($n + n = n + n \\Rightarrow n = n$). $\\{a, b\\}$ with $a < b$ is Sidon because the only sums are $2a, a+b, 2b$, which are distinct when $a \\neq b$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "vacuous truth",
+      "exhaustive case analysis",
+      "omega tactic"
+    ],
+    "prerequisites": [
+      "Finset membership",
+      "basic arithmetic"
+    ]
+  },
+  {
+    "id": "ann-subset-closure",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 108,
+      "endLine": 110
+    },
+    "type": "theorem",
+    "title": "Sidon Sets Are Closed Under Subsets",
+    "content": "`IsSidon.subset` proves that any subset of a Sidon set is Sidon. The proof is immediate: if $B \\subseteq A$ and $a, b, c, d \\in B$, then they are also in $A$ (via `hBA`), so the Sidon property of $A$ applies.\n\nThis closure property is essential for the greedy construction: when we verify that adding a new element preserves Sidon, we only need to check interactions involving the new element, since the old set is already Sidon.",
+    "mathContext": "$A$ Sidon, $B \\subseteq A \\Rightarrow B$ Sidon. Proof: $B \\subseteq A$ embeds the Sidon condition on $B$ into that on $A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotone property",
+      "hereditary property",
+      "greedy algorithm correctness"
+    ],
+    "prerequisites": [
+      "Finset.Subset",
+      "IsSidon definition"
+    ]
+  },
+  {
+    "id": "ann-diff-injective",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 117,
+      "endLine": 161
+    },
+    "type": "theorem",
+    "title": "Difference Injectivity: The Key Counting Lemma",
+    "content": "`IsSidon.diff_injective` proves that in a Sidon set, all pairwise differences are distinct: if $a - b = c - d$ with $a > b$ and $c > d$, then $(a, b) = (c, d)$.\n\nThe proof converts differences to sums: $a - b = c - d \\Rightarrow a + d = c + b$ (using `Nat.sub_add_cancel`), then applies the Sidon property to the pairs $(d, a)$ and $(b, c)$. Case analysis handles the ordering requirements, with three cases: the main case where $d \\leq a$ and $b \\leq c$, and two contradiction cases.\n\nThis lemma is the bridge from the Sidon *sum* condition to the *difference set* counting that drives the pigeonhole bound.",
+    "mathContext": "$a - b = c - d$ with $a > b, c > d \\Rightarrow a + d = c + b \\xrightarrow{\\text{Sidon}} (d, a) = (b, c) \\Rightarrow a = c, b = d$.\n\nThe difference set $\\text{diffSet}(A) = \\{a - b : a, b \\in A, a > b\\}$ has $|\\text{diffSet}(A)| = \\binom{|A|}{2}$ for Sidon $A$, precisely because differences are injective.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "difference set",
+      "injectivity",
+      "sum-to-difference conversion",
+      "pigeonhole principle"
+    ],
+    "prerequisites": [
+      "IsSidon definition",
+      "Nat.sub_add_cancel",
+      "case analysis"
+    ]
+  },
+  {
+    "id": "ann-bijection",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 193,
+      "endLine": 244
+    },
+    "type": "theorem",
+    "title": "Bijection: Ordered Pairs ↔ 2-Element Subsets",
+    "content": "`orderedPairsLt_card_via_choose` establishes that the number of ordered pairs $(a, b)$ with $a < b$ in $A$ equals $\\binom{|A|}{2}$, via an explicit bijection with `Finset.powersetCard 2 A`.\n\nThe proof uses `Finset.card_bij` with three obligations:\n1. **Forward map**: $(a, b) \\mapsto \\{a, b\\}$ sends ordered pairs to 2-element subsets\n2. **Injectivity**: Different ordered pairs give different subsets (since both are ordered by $<$)\n3. **Surjectivity**: Every 2-element subset $\\{a, b\\}$ comes from either $(a, b)$ or $(b, a)$ depending on ordering\n\nThis 50-line proof is the most technical in the module — the surjectivity case requires careful handling of `lt_or_gt_of_ne` and `Finset.pair_comm`.",
+    "mathContext": "$|\\{(a, b) \\in A^2 : a < b\\}| = \\binom{|A|}{2} = \\frac{|A|(|A|-1)}{2}$.\n\nThe bijection: $(a, b) \\mapsto \\{a, b\\}$ with inverse $\\{a, b\\} \\mapsto (\\min(a,b), \\max(a,b))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial coefficient",
+      "Finset.card_bij",
+      "Finset.powersetCard",
+      "double counting"
+    ],
+    "prerequisites": [
+      "Finset.card_bij",
+      "Finset.powersetCard",
+      "Nat.choose_two_right"
+    ]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 314,
+      "endLine": 317
+    },
+    "type": "theorem",
+    "title": "Pigeonhole Lower Bound on max(A)",
+    "content": "`sidon_lower_bound` proves that the largest element of a Sidon set $A$ satisfies $\\max(A) \\geq \\frac{|A|(|A|-1)}{2}$.\n\nThe proof chain: `card_diffSet_eq` gives $|\\text{diffSet}(A)| = \\frac{n(n-1)}{2}$, and `diffSet_subset_Icc` shows all differences lie in $[1, \\max(A)]$. By the pigeonhole principle (Finset.card_le_card), $\\max(A) \\geq \\frac{n(n-1)}{2}$.\n\nThis is the fundamental counting argument in Sidon set theory — it shows that Sidon sets must be 'sparse' because their elements must accommodate all $\\binom{n}{2}$ distinct differences.",
+    "mathContext": "For Sidon $A$ with $n = |A|$: $\\text{diffSet}(A) \\subseteq [1, \\max(A)]$ and $|\\text{diffSet}(A)| = \\binom{n}{2} = \\frac{n(n-1)}{2}$.\n\nBy pigeonhole: $\\max(A) \\geq \\frac{n(n-1)}{2}$.\n\nThis immediately gives $|A \\cap [1, N]| \\leq O(\\sqrt{N})$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "difference set counting",
+      "density bounds",
+      "Sidon set sparsity"
+    ],
+    "prerequisites": [
+      "card_diffSet_eq",
+      "diffSet_subset_Icc",
+      "Finset.card_le_card"
+    ]
+  },
+  {
+    "id": "ann-upper-bound-weak",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 327,
+      "endLine": 373
+    },
+    "type": "theorem",
+    "title": "Weak Upper Bound: |A| ≤ √(2N) + 1",
+    "content": "`sidon_upper_bound_weak` is the main fully-proved density result: any Sidon subset of $\\{1, \\ldots, N\\}$ has at most $\\lfloor\\sqrt{2N}\\rfloor + 1$ elements.\n\nThe proof is by contradiction: assume $n \\geq \\sqrt{2N} + 2$. Then $n - 1 \\geq \\sqrt{2N} + 1$, so $(n-1)^2 > 2N$ (by definition of integer square root). Since $n(n-1) = (n-1)^2 + (n-1) > 2N + 1$, we get $\\frac{n(n-1)}{2} > N$, contradicting `sidon_lower_bound` (which requires $\\max(A) \\geq \\frac{n(n-1)}{2}$ but $\\max(A) \\leq N$).\n\nThe tight Erdős-Turán bound $\\sqrt{N} + O(N^{1/4})$ (axiomatized as `sidon_upper_bound`) is stronger by a factor of $\\sqrt{2}$, requiring sum-counting instead of difference-counting.",
+    "mathContext": "If $A \\subseteq [1, N]$ is Sidon with $|A| = n$: $\\frac{n(n-1)}{2} \\leq \\max(A) \\leq N \\Rightarrow n(n-1) \\leq 2N \\Rightarrow n \\leq \\frac{1 + \\sqrt{1 + 8N}}{2} < \\sqrt{2N} + 1$.\n\nThe integer version uses `Nat.sqrt` and `Nat.lt_succ_sqrt`: $\\lfloor\\sqrt{2N}\\rfloor + 1 > \\sqrt{2N}$, so $(\\lfloor\\sqrt{2N}\\rfloor + 1)^2 > 2N$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "proof by contradiction",
+      "Nat.sqrt",
+      "Erdős-Turán bound",
+      "nlinarith tactic"
+    ],
+    "prerequisites": [
+      "sidon_lower_bound",
+      "Nat.lt_succ_sqrt",
+      "integer square root"
+    ]
+  },
+  {
+    "id": "ann-greedy-axioms",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 396,
+      "endLine": 412
+    },
+    "type": "concept",
+    "title": "Greedy Sidon Sequence Axiomatization",
+    "content": "The **greedy (Mian-Chowla) Sidon sequence** is axiomatized with four properties:\n1. `greedySidonSeq_zero`: starts at 1\n2. `greedySidonSeq_strictMono`: strictly increasing\n3. `greedySidonSeq_isSidon`: the first $n+1$ terms always form a Sidon set\n4. `greedySidonSeq_greedy`: each term is the *smallest* integer preserving Sidon\n\nAxiomatization is used instead of a constructive definition because the well-founded recursion on \"smallest $m$ preserving Sidon\" requires decidability of `IsSidon` on finite sets, which is technically available but complex to formalize. The axioms capture exactly the mathematical content needed for the growth rate analysis.",
+    "mathContext": "$a_0 = 1$, $a_{n+1} = \\min\\{m > a_n : \\{a_0, \\ldots, a_n, m\\}$ is Sidon$\\}$.\n\nFirst terms (OEIS A005282): $1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97, \\ldots$\n\nThe sequence was first studied by Mian and Chowla (1944). Its density behavior remains one of the most intractable problems in additive combinatorics.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Mian-Chowla sequence",
+      "OEIS A005282",
+      "greedy algorithm",
+      "well-founded recursion"
+    ],
+    "prerequisites": [
+      "IsSidon definition",
+      "StrictMono",
+      "Finset.image",
+      "Finset.range"
+    ]
+  },
+  {
+    "id": "ann-erdos-340",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 504,
+      "endLine": 506
+    },
+    "type": "concept",
+    "title": "Erdős Problem #340: The Main Open Conjecture",
+    "content": "**Erdős Problem #340** (OPEN): For all $\\varepsilon > 0$, the greedy Sidon sequence satisfies $|A \\cap [1, N]| \\geq C \\cdot N^{1/2 - \\varepsilon}$ for some constant $C > 0$ and all sufficiently large $N$.\n\nThis conjecture asserts the greedy construction is nearly optimal — achieving density close to $\\sqrt{N}$, matching the Erdős-Turán upper bound up to subpolynomial factors.\n\nThe gap between the known $N^{1/3}$ lower bound and the conjectured $N^{1/2 - \\varepsilon}$ has persisted for over 80 years. Ruzsa (1998) showed non-greedy constructions achieve $N^{\\sqrt{2}-1} \\approx N^{0.414}$, but the greedy sequence's deterministic nature makes it harder to analyze.\n\nThe axiom uses Lean's `Filter.atTop` for \"eventually for all large $N$\", the standard formalization of asymptotic statements.",
+    "mathContext": "$\\forall \\varepsilon > 0,\\; \\exists C > 0,\\; \\forall^{\\infty} N,\\; N^{1/2 - \\varepsilon} \\leq C \\cdot |A \\cap [1, N]|$\n\nKnown bounds: $\\Omega(N^{1/3}) \\leq |A \\cap [1, N]| \\leq O(\\sqrt{N})$.\n\nConjectured: $|A \\cap [1, N]| \\geq \\Omega(N^{1/2 - \\varepsilon})$.\n\n**STATUS: OPEN.**",
+    "significance": "critical",
+    "relatedConcepts": [
+      "asymptotic growth rate",
+      "Filter.atTop",
+      "additive combinatorics open problems",
+      "Erdős conjectures"
+    ],
+    "prerequisites": [
+      "Filter.atTop",
+      "Real.rpow",
+      "greedySidonCount"
+    ]
+  },
+  {
+    "id": "ann-diff-set-greedy",
+    "proofId": "erdos-340-greedy-sidon",
+    "range": {
+      "startLine": 518,
+      "endLine": 535
+    },
+    "type": "concept",
+    "title": "Difference Set of the Greedy Sequence",
+    "content": "`greedySidonDiffSet` defines the difference set $A - A = \\{a - b : a, b \\in A\\}$ where $A$ is the greedy Sidon sequence. The two axioms `_22_mem_diffSet` and `_33_mem_diffSet_iff` are computational facts about specific membership.\n\nThe difference set structure is key to understanding the growth rate: for a Sidon set, $|A - A| = |A|^2 - |A| + 1$ (each nonzero difference appears exactly once). Understanding the *distribution* of these differences — which integers appear and which are skipped — could provide insights into why the greedy sequence achieves the density it does.\n\nThe axiom `_33_mem_diffSet_iff : 33 \\in \\text{greedySidonDiffSet} \\leftrightarrow \\text{True}` is a placeholder indicating the membership is believed true but requires computing more terms of the sequence to verify.",
+    "mathContext": "$A - A = \\{a - b : a, b \\in A\\} \\subseteq \\mathbb{Z}$.\n\nFor Sidon $A$: $|A - A| = |A|^2 - |A| + 1$ (each nonzero difference appears exactly once, plus $0$ from $a - a$).\n\nExample: $204 - 182 = 22 \\in A - A$ (from $a_{14} - a_{13}$ of the Mian-Chowla sequence).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "difference set density",
+      "Mian-Chowla sequence values",
+      "OEIS A005282",
+      "additive structure"
+    ],
+    "prerequisites": [
+      "Set.range",
+      "greedySidon definition"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -79,9 +79,8 @@
       }
     ],
     "relatedProofs": [
-      "erdos-44-problem",
-      "erdos-44-sidon-lower-bound",
-      "erdos-340-problem"
+      "erdos-44",
+      "erdos-340"
     ],
     "dateAdded": "2026-03-22",
     "axiomCount": 21,
@@ -164,19 +163,14 @@
   ],
   "crossReferences": [
     {
-      "targetId": "erdos-44-problem",
+      "targetId": "erdos-44",
       "relationship": "foundational",
-      "description": "Provides the Sidon set definitions and counting infrastructure imported by the Erdos Problem #44 formalization"
+      "description": "Provides the Sidon set definitions, counting infrastructure, and difference injectivity imported by the Erdos Problem #44 formalization"
     },
     {
-      "targetId": "erdos-44-sidon-lower-bound",
-      "relationship": "foundational",
-      "description": "Provides the sidon_lower_bound and difference set machinery imported by the Erdos #44 Sidon lower bound proof"
-    },
-    {
-      "targetId": "erdos-340-problem",
+      "targetId": "erdos-340",
       "relationship": "extends",
-      "description": "This infrastructure module provides the foundations for the main Erdos #340 problem formalization"
+      "description": "This infrastructure module provides the Sidon set library and greedy sequence axiomatization for the main Erdos #340 problem formalization"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/newton-inductive-step/annotations.json
+++ b/src/data/proofs/newton-inductive-step/annotations.json
@@ -1,0 +1,165 @@
+[
+  {
+    "id": "ann-quadratic-nonneg",
+    "proofId": "newton-inductive-step",
+    "range": {
+      "startLine": 11,
+      "endLine": 18
+    },
+    "type": "theorem",
+    "title": "Quadratic Non-Negativity Helper",
+    "content": "`quadratic_nonneg` proves that $\\alpha t^2 + \\beta t + \\gamma \\geq 0$ for $t \\geq 0$ when $\\alpha, \\gamma \\geq 0$ and $4\\alpha\\gamma \\geq \\beta^2$.\n\nThe proof splits on whether $\\alpha = 0$ (in which case $\\beta = 0$ follows from the discriminant condition, leaving just $\\gamma \\geq 0$) or $\\alpha > 0$ (where the completing-the-square identity $(2\\alpha t + \\beta)^2 \\geq 0$ and `nlinarith` finish the job).\n\nThis is a general-purpose helper for proving polynomial non-negativity, useful when the main inequality reduces to a quadratic form after clearing denominators.",
+    "mathContext": "If $\\alpha, \\gamma \\geq 0$ and $4\\alpha\\gamma \\geq \\beta^2$ (non-negative discriminant), then $\\alpha t^2 + \\beta t + \\gamma \\geq 0$ for all $t \\geq 0$.\n\nKey identity: $\\alpha(\\alpha t^2 + \\beta t + \\gamma) = (\\alpha t + \\beta/2)^2 + (\\alpha\\gamma - \\beta^2/4) \\geq 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "completing the square",
+      "discriminant condition",
+      "nlinarith tactic",
+      "polynomial non-negativity"
+    ],
+    "prerequisites": [
+      "real arithmetic",
+      "sq_nonneg"
+    ]
+  },
+  {
+    "id": "ann-binom-ineq-statement",
+    "proofId": "newton-inductive-step",
+    "range": {
+      "startLine": 23,
+      "endLine": 28
+    },
+    "type": "theorem",
+    "title": "The Main Binomial Inequality Statement",
+    "content": "`binom_ineq` states the key quartic inequality for Newton's log-concavity: for four consecutive binomial coefficients $a = \\binom{m}{k-2}$, $b = \\binom{m}{k-1}$, $c = \\binom{m}{k}$, $d = \\binom{m}{k+1}$, we have $bc^3 + adc^2 + ac^3 \\geq 2b^2cd + b^3d$.\n\nThe hypotheses $2 \\leq k$ and $k + 1 \\leq m$ ensure all four binomial coefficients are well-defined and positive. The `let` bindings cast `Nat.choose` values to $\\mathbb{R}$ for the inequality.",
+    "mathContext": "For $2 \\leq k \\leq m - 1$ and $a = \\binom{m}{k-2}$, $b = \\binom{m}{k-1}$, $c = \\binom{m}{k}$, $d = \\binom{m}{k+1}$:\n$$bc^3 + adc^2 + ac^3 \\geq 2b^2cd + b^3d$$\n\nThis is equivalent to $c^2(bc + ad + ac) \\geq bd(2bc + b^2)$, a log-concavity condition on the sequence of binomial coefficients.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Newton's inequalities",
+      "log-concavity",
+      "binomial coefficients",
+      "elementary symmetric polynomials"
+    ],
+    "prerequisites": [
+      "Nat.choose",
+      "Nat.cast to ℝ"
+    ]
+  },
+  {
+    "id": "ann-absorption-identities",
+    "proofId": "newton-inductive-step",
+    "range": {
+      "startLine": 31,
+      "endLine": 46
+    },
+    "type": "theorem",
+    "title": "The Three Absorption Identities",
+    "content": "The proof derives three **absorption identities** from `Nat.choose_succ_right_eq`, which states $(m - k + 1) \\cdot \\binom{m}{k-1} = k \\cdot \\binom{m}{k}$:\n\n1. `h1`: $k \\cdot c = (m - k + 1) \\cdot b$ — relating $\\binom{m}{k}$ and $\\binom{m}{k-1}$\n2. `h2`: $(k+1) \\cdot d = (m - k) \\cdot c$ — relating $\\binom{m}{k+1}$ and $\\binom{m}{k}$\n3. `h3`: $(k-1) \\cdot b = (m - k + 2) \\cdot a$ — relating $\\binom{m}{k-1}$ and $\\binom{m}{k-2}$\n\nEach derivation involves `congr_arg Nat.cast` to lift from $\\mathbb{N}$ to $\\mathbb{R}$, `push_cast` to distribute the cast, and `Nat.cast_sub` with proof that the subtraction doesn't underflow. These three identities are the entire algebraic input to the proof — everything else is polynomial manipulation.",
+    "mathContext": "The absorption identity: $k \\cdot \\binom{m}{k} = (m - k + 1) \\cdot \\binom{m}{k-1}$.\n\nSetting $r = m - k + 1$:\n- $kc = rb$\n- $(k+1)d = (r-1)c$\n- $(k-1)b = (r+1)a$\n\nThese express all four binomial coefficients in terms of any one of them and the two parameters $k, r$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.choose_succ_right_eq",
+      "push_cast tactic",
+      "Nat to ℝ coercion",
+      "absorption identity"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_right_eq",
+      "Nat.cast_sub",
+      "congr_arg"
+    ]
+  },
+  {
+    "id": "ann-power-identities",
+    "proofId": "newton-inductive-step",
+    "range": {
+      "startLine": 54,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "Derived Power Identities and Cross-Products",
+    "content": "From the absorption identity $kc = rb$, the proof derives:\n- `h1_sq`: $k^2 c^2 = r^2 b^2$ (squaring)\n- `h1_cube`: $k^3 c^3 = r^3 b^3$ (cubing)\n- `h12`: $k(k+1)d = r(r-1)b$ (combining h1 and h2)\n- `h3'`: $(r+1)a = (k-1)b$ (rewriting h3)\n\nAll four are proved via `linear_combination` with appropriate polynomial coefficients. For instance, `h1_sq` uses the cofactor $(kc + rb)$ applied to `h1'`, exploiting the identity $X^2 - Y^2 = (X+Y)(X-Y)$.\n\nThese derived identities express every monomial appearing in the target inequality in terms of powers of $b$, $k$, and $r$.",
+    "mathContext": "From $kc = rb$:\n- $k^2c^2 = r^2b^2$ (via $(kc + rb)(kc - rb) = 0$)\n- $k^3c^3 = r^3b^3$\n- $k(k+1)d = r(r-1)b$ (from $kc = rb$ and $(k+1)d = (r-1)c$)\n\nAll binomial coefficient monomials are now expressible as $f(k, r) \\cdot b^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "polynomial identity",
+      "monomial reduction"
+    ],
+    "prerequisites": [
+      "h1' absorption identity",
+      "linear_combination"
+    ]
+  },
+  {
+    "id": "ann-d-strategy",
+    "proofId": "newton-inductive-step",
+    "range": {
+      "startLine": 87,
+      "endLine": 94
+    },
+    "type": "insight",
+    "title": "The Multiplier Strategy: D * (target) ≥ 0",
+    "content": "The proof multiplies the target inequality by $D = k^3(k+1)(r+1) > 0$ (where $r = m - k + 1$). Since $D > 0$, showing $D \\cdot (\\text{LHS} - \\text{RHS}) \\geq 0$ is equivalent to $\\text{LHS} \\geq \\text{RHS}$.\n\nThis 'clear the denominators' step is essential: the absorption identities involve divisions (ratios of consecutive binomial coefficients), and multiplying by $D$ produces a clean polynomial identity. The sufficiency direction is proved by contradiction: if LHS < RHS, then $D \\cdot (\\text{LHS} - \\text{RHS}) < 0$ (since $D > 0$), contradicting the result.\n\nThe positivity of $D$ follows from $k \\geq 2$ and $r \\geq 1$, handled by `positivity`.",
+    "mathContext": "$D = k^3(k+1)(r+1) > 0$ since $k \\geq 2$, $r = m - k + 1 \\geq 1$.\n\n$D \\cdot (\\text{LHS} - \\text{RHS}) = r(k + r)^2 b^4 \\geq 0$.\n\nSince $D > 0$: $\\text{LHS} - \\text{RHS} \\geq 0 \\Leftrightarrow D \\cdot (\\text{LHS} - \\text{RHS}) \\geq 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "clearing denominators",
+      "positivity tactic",
+      "proof by contradiction",
+      "sum-of-squares certificates"
+    ],
+    "prerequisites": [
+      "positivity",
+      "mul_neg_of_pos_of_neg"
+    ]
+  },
+  {
+    "id": "ann-key-products",
+    "proofId": "newton-inductive-step",
+    "range": {
+      "startLine": 103,
+      "endLine": 129
+    },
+    "type": "theorem",
+    "title": "Key Product Identities for Each Term",
+    "content": "Five **key product identities** express each term of $D \\cdot (\\text{LHS} - \\text{RHS})$ in terms of $b^4$:\n\n1. `key1`: $k^3 \\cdot b \\cdot c^3 = r^3 \\cdot b^4$\n2. `key2`: $k(k+1) \\cdot b^3 \\cdot d = r(r-1) \\cdot b^4$\n3. `key3`: $k^2 \\cdot b^2 \\cdot c^2 = r^2 \\cdot b^4$\n4. `key4`: $k^3(k+1)(r+1) \\cdot a \\cdot d \\cdot c^2 = (k-1)(r-1) \\cdot r^3 \\cdot b^4$\n5. `key5`: $k^3(k+1)(r+1) \\cdot a \\cdot c^3 = (k^2 - 1) \\cdot r^3 \\cdot b^4$\n\nEach is proved by `linear_combination` using previously derived identities as building blocks. `key4` is the most complex, requiring a preliminary `step1` that combines two absorption identities multiplicatively.",
+    "mathContext": "All five monomials in $D \\cdot (\\text{target})$ are reduced to $f(k, r) \\cdot b^4$:\n\n$D \\cdot bc^3 = (k+1)(r+1) \\cdot r^3 \\cdot b^4$\n$D \\cdot adc^2 = (k-1)(r-1) \\cdot r^3 \\cdot b^4$\n$D \\cdot ac^3 = (k^2-1) \\cdot r^3 \\cdot b^4$\n$D \\cdot 2b^2cd = 2kr^2(r^2-1) \\cdot b^4$\n$D \\cdot b^3d = k^2 r(r^2-1) \\cdot b^4$",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "polynomial arithmetic",
+      "absorption identity chaining"
+    ],
+    "prerequisites": [
+      "h1_cube",
+      "h12",
+      "h1_sq",
+      "h3'"
+    ]
+  },
+  {
+    "id": "ann-final-identity",
+    "proofId": "newton-inductive-step",
+    "range": {
+      "startLine": 141,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "The Final Identity: r(k+r)²b⁴ ≥ 0",
+    "content": "The climax: `suffices h_ident` reduces the proof to showing the algebraic identity\n$$D \\cdot (\\text{LHS} - \\text{RHS}) = r(k + r)^2 b^4$$\nwhich is non-negative by `positivity` (since $r > 0$, $(k+r)^2 \\geq 0$, $b^4 \\geq 0$).\n\nThe identity itself is verified by a single `linear_combination` call that combines all five key product identities with polynomial coefficients. The six-term linear combination is the algebraic heart of the proof — it encodes the polynomial identity\n$$[(k+1)(r+1) + (k-1)(r-1) + (k^2-1)]r^3 - [2kr^2 + k^2r](r^2-1) = r(k+r)^2$$\nwhich can be verified by expanding both sides. The fact that $r(k+r)^2 \\geq 0$ is trivial, but the identity connecting it to the binomial coefficient expression is where the mathematical insight lies.",
+    "mathContext": "$k^3(k+1)(r+1)(bc^3 + adc^2 + ac^3 - 2b^2cd - b^3d) = r(k+r)^2 b^4$.\n\nSince $r > 0$, $(k+r)^2 \\geq 0$, $b^4 \\geq 0$: the RHS is $\\geq 0$.\n\nEquality holds iff $b = 0$ (impossible for valid $k, m$) or $k + r = 0$ (impossible since $k \\geq 2, r \\geq 1$, so $k + r \\geq 3$). Thus the inequality is strict for all valid inputs.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "positivity tactic",
+      "polynomial certificate",
+      "sum-of-squares"
+    ],
+    "prerequisites": [
+      "key1 through key5",
+      "h2'",
+      "positivity"
+    ]
+  }
+]

--- a/src/data/proofs/newton-inductive-step/meta.json
+++ b/src/data/proofs/newton-inductive-step/meta.json
@@ -50,8 +50,8 @@
       }
     ],
     "relatedProofs": [
-      "amgm-inequality-oq-02-oq-02",
-      "newton-ind-step-2"
+      "amgm-inequality-oq-02",
+      "amgm-inequality"
     ],
     "dateAdded": "2026-03-22",
     "axiomCount": 0,
@@ -98,14 +98,14 @@
   ],
   "crossReferences": [
     {
-      "targetId": "amgm-inequality-oq-02-oq-02",
+      "targetId": "amgm-inequality-oq-02",
       "relationship": "foundational",
       "description": "Provides the key binomial inequality imported by the AM-GM inequality extension, which uses Newton's log-concavity of symmetric polynomials"
     },
     {
-      "targetId": "newton-ind-step-2",
-      "relationship": "foundational",
-      "description": "Provides the base binomial inequality imported by the second Newton inductive step variant for further log-concavity applications"
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "The AM-GM inequality is connected via Newton's inequalities: log-concavity of elementary symmetric polynomials implies AM-GM as a special case"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

### Batch 1: meta.relatedProblems linkage (8 entries)
Added `meta.relatedProblems` for sub-entry linkage to 8 main gallery entries.

### Batch 2: Abel-Ruffini depth pass
- Added `ann-part-ii-bridge` annotation for Part II docstring
- Deepened `ann-abel-ruffini-theorem` and `ann-contrapositive`
- Fixed section boundary gap

### Batch 3: Erdos 340 Greedy Sidon (quality 45 → enriched)
- Created 10 annotations covering all major sections
- Fixed cross-references to existing entries

### Batch 4: Newton Inductive Step (quality 37 → enriched)
- Created 7 annotations covering the full proof:
  quadratic helper, main statement, absorption identities,
  power identities, multiplier strategy, key products, final identity
- Fixed cross-references to existing entries

## Test plan
- [x] Annotations build passes without errors for all modified entries
- [x] All cross-reference targets verified to exist
- [x] Annotation types match Lean construct types

🤖 Generated with [Claude Code](https://claude.com/claude-code)