### PR TITLE
feat: Add infrastructure gallery entries for 5 hub proof files

### DIFF
--- a/src/data/proofs/bounded-prime-gaps/meta.json
+++ b/src/data/proofs/bounded-prime-gaps/meta.json
@@ -207,11 +207,17 @@
       "targetId": "bounded-prime-gaps-oq-03-oq-01",
       "relationship": "extended-by",
       "description": "Analyzes how the $k$-tuple size parameter affects the gap bound: the Polymath 8b bound 246 comes from optimizing over 50-tuples, and this sub-entry explores whether larger tuples or different optimization strategies could improve the bound"
+    },
+    {
+      "targetId": "prime-gap-bounds",
+      "relationship": "depends-on",
+      "description": "Imports prime gap infrastructure: nth prime bounds (p_n <= 2^(n+1)), prime counting bounds (pi(2n) > pi(n)), and the order-preserving enumeration property of primes used in the prime gap analysis"
     }
   ],
   "relatedProofs": [
     "bertrands-postulate",
     "infinitude-primes",
+    "prime-gap-bounds",
     "prime-number-theorem",
     "prime-reciprocal-divergence",
     "riemann-hypothesis",

--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -1,0 +1,215 @@
+{
+  "id": "erdos-340-greedy-sidon",
+  "title": "Greedy Sidon Sequence Infrastructure (Erdos Problem #340)",
+  "slug": "erdos-340-greedy-sidon",
+  "description": "Comprehensive Sidon set library for Erdos Problem #340: defines Sidon sets, proves closure under subsets, difference injectivity, counting arguments (|diffSet| = n(n-1)/2), the pigeonhole upper bound max(A) >= n(n-1)/2, and the weak upper bound |A| <= sqrt(2N) + 1. Axiomatizes the greedy Sidon sequence and Erdos's conjecture that its growth is N^(1/2-epsilon). Imported by Erdos44Problem and Erdos44SidonLowerBound.",
+  "meta": {
+    "author": "Erdos, Mian-Chowla, Sidon, formalized in Lean 4",
+    "sourceUrl": "https://www.erdosproblems.com/340",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos340GreedySidon.lean",
+    "leanFile": "proofs/Proofs/Erdos340GreedySidon.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "sidon-sets",
+      "greedy-algorithms",
+      "additive-combinatorics",
+      "erdos",
+      "infrastructure"
+    ],
+    "badge": "infrastructure",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "Cardinality of image under injective function",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.powersetCard",
+        "description": "k-element subsets of a finite set",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Nat.sqrt",
+        "description": "Integer square root for the upper bound theorem",
+        "module": "Mathlib.Data.Nat.Basic"
+      },
+      {
+        "theorem": "Filter.atTop",
+        "description": "At-top filter for asymptotic statements",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
+    ],
+    "originalContributions": [
+      "IsSidon: formal definition of Sidon sets (B2 sequences) as finsets with unique pairwise sums",
+      "isSidon_empty, isSidon_singleton, isSidon_pair: base cases",
+      "IsSidon.subset: Sidon property closed under subsets",
+      "IsSidon.diff_injective: distinct differences in Sidon sets",
+      "sidon_pairDiff_injective: injectivity of the difference map on ordered pairs",
+      "orderedPairsLt_card_via_choose: bijection between ordered pairs and 2-element subsets",
+      "card_diffSet_eq: |diffSet(A)| = n(n-1)/2 for Sidon set A with n elements",
+      "sidon_lower_bound: max(A) >= n(n-1)/2 by pigeonhole on the difference set",
+      "sidon_upper_bound_weak: |A| <= sqrt(2N) + 1 for Sidon A in [1,N] (fully proved)",
+      "Greedy Sidon sequence axiomatization with strict monotonicity and the Sidon property",
+      "erdos_340: formal statement of Erdos's conjecture (OPEN)"
+    ],
+    "references": [
+      {
+        "key": "Er38",
+        "citation": "Erdos, P. and Turan, P. (1941). On a problem of Sidon in additive number theory. Journal of the London Mathematical Society, 16(4), 212-215.",
+        "type": "paper"
+      },
+      {
+        "key": "MC44",
+        "citation": "Mian, A. M. and Chowla, S. D. (1944). On the B2 sequences of Sidon. Proceedings of the National Academy of Sciences India, A14, 3-4.",
+        "type": "paper"
+      },
+      {
+        "key": "Ru98",
+        "citation": "Ruzsa, I. Z. (1998). An infinite Sidon set. Journal of Number Theory, 68(1), 63-71.",
+        "type": "paper"
+      },
+      {
+        "key": "Ch24",
+        "citation": "Cheng, Y. (2024). Greedy Sidon sets for linear forms. Journal of Number Theory.",
+        "type": "paper"
+      }
+    ],
+    "relatedProofs": [
+      "erdos-44-problem",
+      "erdos-44-sidon-lower-bound",
+      "erdos-340-problem"
+    ],
+    "dateAdded": "2026-03-22",
+    "axiomCount": 21,
+    "lineCount": 537,
+    "prerequisites": [
+      "Additive combinatorics (Sidon sets, sum-free sets, difference sets)",
+      "Finite set theory (Finset, card, image, filter, product)",
+      "Elementary number theory (pigeonhole principle, integer square root)",
+      "Asymptotic analysis (Filter.atTop, eventually)"
+    ],
+    "assumptions": [
+      "sidon_upper_bound: Erdos-Turan tight bound |A| <= sqrt(N) + O(N^{1/4}) (known result, needs formalization)",
+      "greedySidonSeq: existence and uniqueness of the greedy Sidon sequence",
+      "greedySidonSeq_zero/strictMono/isSidon/greedy: properties of the greedy sequence",
+      "greedySidon_0 through greedySidon_10: first 11 values of the sequence (OEIS A005282)",
+      "greedySidon_growth_third: greedy grows at least like N^(1/3) (known, needs formalization)",
+      "erdos_340: main conjecture - growth is N^(1/2-epsilon) for all epsilon > 0 (OPEN)",
+      "_22_mem_diffSet, _33_mem_diffSet_iff: difference set membership (computational)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Simon Sidon posed the problem of constructing dense sets of integers with all pairwise sums distinct in the 1930s. Erdos and Turan (1941) proved that any Sidon subset of {1,...,N} has at most sqrt(N) + O(N^{1/4}) elements, establishing the fundamental upper bound. The greedy (Mian-Chowla) construction starts with 1 and repeatedly adds the smallest integer preserving the Sidon property, producing the sequence 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97, ... (OEIS A005282).\n\nErdos conjectured (Problem #340) that the greedy Sidon sequence grows like N^(1/2-epsilon) for all epsilon > 0, meaning it is nearly as dense as the theoretical maximum sqrt(N). The best proven lower bound remains the trivial N^(1/3), unchanged for over 80 years. Ruzsa (1998) showed that non-greedy constructions can achieve N^(sqrt(2)-1) ~ N^0.414, but the greedy sequence's behavior remains mysterious.\n\nThis module provides the complete Sidon set infrastructure needed for Erdos Problem #340 and related problems, and is imported by two other formalizations dealing with Erdos Problem #44 (another Sidon-related problem).",
+    "problemStatement": "Provide a comprehensive library of Sidon set theory:\n\n1. **Definition**: IsSidon(A) iff all pairwise sums a+b (a <= b) are distinct\n2. **Closure properties**: Empty, singleton, pair are Sidon; subsets of Sidon sets are Sidon\n3. **Difference injectivity**: In a Sidon set, all pairwise differences are distinct\n4. **Counting**: The difference set has exactly n(n-1)/2 elements\n5. **Lower bound**: max(A) >= n(n-1)/2 (pigeonhole on differences)\n6. **Upper bound**: |A| <= sqrt(2N) + 1 for A in [1,N] (proved)\n7. **Greedy sequence**: Axiomatize the Mian-Chowla sequence and its properties\n8. **Main conjecture**: Formal statement of Erdos #340",
+    "proofStrategy": "The proved results use three main techniques:\n\n1. **Difference counting** (sidon_lower_bound): A Sidon set with n elements has n(n-1)/2 distinct positive differences, all in [1, max(A)]. By pigeonhole, max(A) >= n(n-1)/2.\n\n2. **Upper bound** (sidon_upper_bound_weak): If n(n-1)/2 <= N and n >= sqrt(2N) + 2, then (n-1)^2 > 2N, so n(n-1) = (n-1)^2 + (n-1) > 2N + 1, giving n(n-1)/2 > N, contradiction.\n\n3. **Bijection argument** (orderedPairsLt_card_via_choose): The number of ordered pairs with a < b equals C(n,2) = n(n-1)/2, established via an explicit bijection with 2-element subsets (powersetCard 2 A).\n\nThe axiomatized results include the Erdos-Turan tight upper bound (known but requires sum-counting machinery not yet formalized), the greedy sequence definition (requires well-founded recursion on a complex predicate), and the main conjecture (open problem).",
+    "keyInsights": [
+      "The difference-set approach gives sidon_lower_bound elegantly: n(n-1)/2 distinct positive differences must fit in [1, max(A)], giving max(A) >= n(n-1)/2",
+      "The bijection between orderedPairsLt and powersetCard 2 uses Finset.card_bij with explicit forward map, injectivity, and surjectivity proofs",
+      "The weak upper bound sqrt(2N) + 1 is proved from differences alone; the tight Erdos-Turan bound sqrt(N) + O(N^{1/4}) requires counting sums instead",
+      "21 axioms: 1 tight upper bound (known result), 5 greedy sequence properties, 11 specific values, 2 growth bounds, 2 difference set memberships. The high axiom count reflects the difficulty of constructive Sidon sequence theory",
+      "Erdos #340 is OPEN: the gap between the N^(1/3) lower bound and conjectured N^(1/2-epsilon) has persisted for 80+ years"
+    ],
+    "prerequisites": [
+      "Sidon sets (B2 sequences): sets where all pairwise sums are distinct",
+      "Finite combinatorics: Finset operations, card, filter, image, product",
+      "Pigeonhole principle: if n distinct values lie in [1,M], then M >= n",
+      "Asymptotic notation: Filter.atTop for eventually-true statements"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sidon-definition",
+      "title": "Sidon Set Definition and Base Cases",
+      "startLine": 1,
+      "endLine": 103,
+      "summary": "Defines IsSidon (all pairwise sums distinct) and IsSidon' (sumset cardinality). Proves empty, singleton, and pair sets are Sidon. The pair case uses exhaustive case analysis on which elements are equal.",
+      "mathContext": "$A$ is Sidon iff $a + b = c + d$ with $a \\leq b, c \\leq d, a,b,c,d \\in A$ implies $a = c, b = d$."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Sidon Set Properties and Difference Injectivity",
+      "startLine": 105,
+      "endLine": 191,
+      "summary": "Proves Sidon closed under subsets, difference injectivity (if a-b = c-d with a > b, c > d, then (a,b) = (c,d)), and the ordered pairs / difference map framework. Uses the key observation: a-b = c-d implies a+d = c+b, then applies the Sidon property.",
+      "mathContext": "Sidon $\\Rightarrow$ subset-Sidon. Differences injective: $a - b = c - d$ with $a > b, c > d$ implies $(a,b) = (c,d)$. Proved via $a + d = c + b$ and Sidon."
+    },
+    {
+      "id": "counting-arguments",
+      "title": "Counting Arguments and Pigeonhole Bounds",
+      "startLine": 192,
+      "endLine": 373,
+      "summary": "Proves orderedPairsLt has cardinality C(n,2) via bijection with powersetCard 2. Proves diffSet has cardinality n(n-1)/2. Derives sidon_lower_bound: max(A) >= n(n-1)/2. Proves sidon_upper_bound_weak: |A| <= sqrt(2N) + 1 by contradiction.",
+      "mathContext": "For Sidon $A$ with $n$ elements: $|\\text{diffSet}(A)| = \\binom{n}{2} = n(n-1)/2$. Pigeonhole: $\\max(A) \\geq n(n-1)/2$. If $A \\subseteq [1,N]$: $n \\leq \\sqrt{2N} + 1$."
+    },
+    {
+      "id": "greedy-sequence",
+      "title": "Greedy Sidon Sequence Axiomatization",
+      "startLine": 374,
+      "endLine": 443,
+      "summary": "Axiomatizes greedySidonSeq with properties: starts at 1, strictly monotone, first n+1 terms always Sidon, each term is the smallest preserving Sidon. Gives first 11 values as axioms (OEIS A005282). Defines greedySidonSet and greedySidonCount.",
+      "mathContext": "The greedy Sidon sequence: $a_0 = 1$, $a_{n+1} = \\min\\{m > a_n : \\{a_0, \\ldots, a_n, m\\}$ is Sidon$\\}$. First terms: 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97."
+    },
+    {
+      "id": "growth-conjecture",
+      "title": "Growth Rate and Main Conjecture",
+      "startLine": 444,
+      "endLine": 537,
+      "summary": "Axiomatizes greedySidon_growth_third (greedy grows >= N^{1/3}) and erdos_340 (the OPEN conjecture that growth is >= N^{1/2-epsilon}). Defines the difference set of the greedy sequence with two membership axioms.",
+      "mathContext": "Known: $|A \\cap [1,N]| \\geq \\Omega(N^{1/3})$ (trivial bound). **Conjecture (Erdos #340)**: $\\forall \\varepsilon > 0$, $|A \\cap [1,N]| \\geq \\Omega(N^{1/2 - \\varepsilon})$. **STATUS: OPEN.**"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-44-problem",
+      "relationship": "foundational",
+      "description": "Provides the Sidon set definitions and counting infrastructure imported by the Erdos Problem #44 formalization"
+    },
+    {
+      "targetId": "erdos-44-sidon-lower-bound",
+      "relationship": "foundational",
+      "description": "Provides the sidon_lower_bound and difference set machinery imported by the Erdos #44 Sidon lower bound proof"
+    },
+    {
+      "targetId": "erdos-340-problem",
+      "relationship": "extends",
+      "description": "This infrastructure module provides the foundations for the main Erdos #340 problem formalization"
+    }
+  ],
+  "conclusion": {
+    "summary": "This module provides a comprehensive Sidon set library (537 lines, 16 theorems/lemmas, 10 definitions, 21 axioms, 0 sorries) for Erdos Problem #340 and related problems. The fully proved results include Sidon closure, difference injectivity, counting arguments, the pigeonhole lower bound, and the weak upper bound. The axiomatized content includes the greedy sequence, its known N^(1/3) growth bound, and the open N^(1/2-epsilon) conjecture.",
+    "implications": "The Sidon set infrastructure is a foundation for additive combinatorics in Lean. The counting technique (bijection with powersetCard 2, then pigeonhole) is a pattern that extends to B_h sequences (sets where all h-fold sums are distinct). The 80-year gap between the N^(1/3) lower bound and the N^(1/2-epsilon) conjecture for the greedy sequence remains one of the most tantalizing open problems in combinatorial number theory.",
+    "openQuestions": [
+      "Prove the N^(1/3) greedy growth bound rigorously (currently axiomatized)",
+      "Formalize the Erdos-Turan tight upper bound sqrt(N) + O(N^{1/4}) using sum-counting",
+      "Any improvement beyond N^(1/3) for the greedy sequence would be publishable",
+      "Analyze the difference set density of the greedy sequence",
+      "Extend to B_h sequences: sets where all h-fold sums are distinct"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Data.Finset.Prod",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Data.Nat.Choose.Basic",
+      "Mathlib.Data.Set.Card",
+      "Mathlib.Analysis.Asymptotics.Defs",
+      "Mathlib.Analysis.Asymptotics.Lemmas",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Algebra.Order.Field.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+    ],
+    "opens": ["Finset", "Filter", "Set"],
+    "namespace": "Erdos340",
+    "lineCount": 537,
+    "axiomCount": 21,
+    "theoremCount": 16,
+    "definitionCount": 10
+  }
+}

--- a/src/data/proofs/feuerbachs-theorem-defs/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs/meta.json
@@ -1,0 +1,202 @@
+{
+  "id": "feuerbachs-theorem-defs",
+  "title": "Feuerbach's Theorem Definitions and Nine-Point Circle",
+  "slug": "feuerbachs-theorem-defs",
+  "description": "Core definitions and infrastructure for Feuerbach's Theorem (Wiedijk #29): triangle geometry in R^2 with coordinate formulas for circumcenter, orthocenter, incenter, excircles, nine-point circle, and altitude feet. Proves all 9 special points lie on the nine-point circle (3 side midpoints, 3 Euler midpoints, 3 altitude feet) with the Euler line relation. Imported by FeuerbachsTheoremOQ01.",
+  "meta": {
+    "author": "Karl Wilhelm Feuerbach (1822), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Nine-point_circle",
+    "date": "1822",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefs.lean",
+    "leanFile": "proofs/Proofs/FeuerbachsTheoremDefs.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "nine-point-circle",
+      "feuerbach",
+      "triangle",
+      "circumcenter",
+      "incircle",
+      "infrastructure"
+    ],
+    "badge": "infrastructure",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sqrt",
+        "description": "Square root function for distance computations",
+        "module": "Mathlib.Data.Real.Sqrt"
+      },
+      {
+        "theorem": "EuclideanGeometry",
+        "description": "Euclidean geometry framework from Mathlib",
+        "module": "Mathlib.Geometry.Euclidean.Triangle"
+      },
+      {
+        "theorem": "Metric.Sphere",
+        "description": "Sphere/circle definitions for circle tangency",
+        "module": "Mathlib.Geometry.Euclidean.Sphere.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Triangle structure: non-degenerate triangle in R^2 with coordinate vertices",
+      "Triangle special points: circumcenter, orthocenter, centroid, incenter formulas",
+      "Excircle infrastructure: excenter_a/b/c and exradius_a/b/c definitions",
+      "Nine-point circle: center N = midpoint(O, H), radius R/2",
+      "9 membership proofs: all 3 side midpoints, 3 Euler midpoints, 3 altitude feet on the nine-point circle",
+      "Euler line relation: G = (2O + H)/3",
+      "Circumcenter equidistance from all vertices (squared version via perpendicular bisectors)",
+      "Tangency definitions: internal and external circle tangency",
+      "Numerical verification: 3-4-5 right triangle with computed circumradius, inradius, incircle Feuerbach tangency"
+    ],
+    "references": [
+      {
+        "key": "Fe22",
+        "citation": "Feuerbach, K. W. (1822). Eigenschaften einiger merkwuerdigen Punkte des geradlinigen Dreiecks und mehrerer durch sie bestimmten Linien und Figuren.",
+        "type": "paper"
+      },
+      {
+        "key": "Co67",
+        "citation": "Coxeter, H. S. M. (1967). Geometry Revisited. Mathematical Association of America.",
+        "type": "book"
+      }
+    ],
+    "relatedProofs": [
+      "feuerbachs-theorem-oq-01",
+      "feuerbachs-theorem"
+    ],
+    "dateAdded": "2026-03-22",
+    "axiomCount": 0,
+    "lineCount": 687,
+    "wiedijkNumber": 29,
+    "prerequisites": [
+      "Euclidean geometry in R^2 (coordinates, distance formula)",
+      "Triangle geometry (circumcenter, orthocenter, incenter, excircles)",
+      "The nine-point circle and its properties",
+      "Coordinate geometry computations (field_simp, ring, nlinarith)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Karl Wilhelm Feuerbach proved in 1822 that the nine-point circle of a triangle is tangent to the incircle and all three excircles. The nine-point circle itself, passing through the midpoints of the sides, the feet of the altitudes, and the midpoints of segments from vertices to the orthocenter, had been discovered independently by several mathematicians (Brianchon-Poncelet 1821, Feuerbach 1822). The tangency point with the incircle is now called the Feuerbach point.\n\nThis module provides the complete definitional infrastructure for Feuerbach's Theorem: the Triangle structure with non-degeneracy, all special points (circumcenter, orthocenter, centroid, incenter, excenters), the nine-point circle with its center and radius, and crucially, the proofs that all 9 special points lie on the nine-point circle. The actual tangency relations (the heart of Feuerbach's theorem) are proved in FeuerbachsTheoremOQ01.lean using this infrastructure.\n\nThe approach uses explicit coordinate geometry in R^2, which makes the proofs computationally verifiable. The trade-off is longer algebraic manipulations (field_simp + ring), but the results are fully constructive and axiom-free.",
+    "problemStatement": "Provide the complete definitional and computational infrastructure for Feuerbach's Theorem:\n\n1. **Triangle structure**: Non-degenerate triangle in R^2 with side lengths, area, semiperimeter\n2. **Special points**: Circumcenter O, orthocenter H, centroid G, incenter I, excenters\n3. **Nine-point circle**: Center N = midpoint(O, H), radius R/2\n4. **Circle membership**: All 9 points (3 side midpoints, 3 Euler midpoints, 3 altitude feet) lie on the nine-point circle\n5. **Euler line**: G = (2O + H)/3\n6. **Tangency definitions**: Internal and external circle tangency\n7. **Numerical verification**: 3-4-5 right triangle as a concrete test case",
+    "proofStrategy": "The proofs use coordinate geometry with explicit formulas:\n\n1. **Circumcenter**: Computed via perpendicular bisector intersection. Equidistance proved via the perpendicular bisector condition (B-A) dot (B+A-2O) = 0, which is linear in O and verified by field_simp + ring after clearing the denominator.\n\n2. **Nine-point membership**: For each of the 9 points P, show dist(N, P) = R/2 by proving |P - N|^2 = |O - A|^2/4. The key lemma ninepoint_membership factors out the common proof structure: express P - N as half of some (O - V) vector, then use circumcenter equidistance.\n\n3. **Altitude feet**: The most computationally intensive proofs (maxHeartbeats 25,600,000). After unfolding the projection formula, clearing denominators (field_simp with circumcenter denom and side length sq), the result reduces to a polynomial identity verified by ring.\n\n4. **Numerical verification**: The 3-4-5 right triangle provides a concrete check: R = 5/2, r = 1, N = (3/4, 1), I = (1, 1), |NI| = 1/4 = |R/2 - r|, confirming Feuerbach tangency.",
+    "keyInsights": [
+      "Coordinate geometry trades elegance for verifiability: explicit formulas make every step machine-checkable at the cost of longer algebraic manipulations",
+      "The ninepoint_membership lemma factors out the common pattern: each of the 9 points satisfies P - N = (O - V)/2 for some vertex V, so dist(N, P) = dist(O, V)/2 = R/2",
+      "Circumcenter equidistance is proved via the perpendicular bisector condition, which is LINEAR in O (much easier than the quadratic distance equations)",
+      "The 3-4-5 right triangle is the simplest non-trivial test case: R = 5/2 (half the hypotenuse), r = 1, orthocenter at the right-angle vertex, confirming all formulas",
+      "Non-degeneracy (the signed area is nonzero) is the single structural hypothesis needed for all computations"
+    ],
+    "prerequisites": [
+      "Coordinate geometry: points in R^2, distance formula, midpoint formula",
+      "Triangle special points: circumcenter via perpendicular bisector intersection, orthocenter via Euler line",
+      "The nine-point circle: center is midpoint of circumcenter and orthocenter, radius is half the circumradius",
+      "Lean tactics: field_simp for clearing denominators, ring for polynomial identities, nlinarith for nonlinear arithmetic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "triangle-config",
+      "title": "Triangle Configuration in R^2",
+      "startLine": 1,
+      "endLine": 93,
+      "summary": "Defines Point = R x R, the Triangle structure with non-degeneracy condition, side lengths a/b/c via sqrt, semiperimeter, and area via the shoelace formula.",
+      "mathContext": "Triangle $ABC$ in $\\mathbb{R}^2$ with non-degeneracy: $(B_x - A_x)(C_y - A_y) - (C_x - A_x)(B_y - A_y) \\neq 0$. Side lengths via Euclidean distance, area via signed area formula."
+    },
+    {
+      "id": "special-points",
+      "title": "Special Points of a Triangle",
+      "startLine": 95,
+      "endLine": 186,
+      "summary": "Defines midpoints of sides, circumcenter O via perpendicular bisector formula, circumradius R, orthocenter H = A + B + C - 2O (Euler line relation), centroid G = (A+B+C)/3, and the dist2 distance function.",
+      "mathContext": "Circumcenter $O$: intersection of perpendicular bisectors. Orthocenter $H = A + B + C - 2O$. Centroid $G = (A+B+C)/3$. Euler line: $O$, $G$, $H$ collinear with $G$ dividing $OH$ in ratio $1:2$."
+    },
+    {
+      "id": "nine-point-circle",
+      "title": "The Nine-Point Circle",
+      "startLine": 139,
+      "endLine": 185,
+      "summary": "Defines nine-point center N = midpoint(O, H), nine-point radius R/2, Euler midpoints (midpoints of AH, BH, CH), altitude feet via orthogonal projection, and squared distance function.",
+      "mathContext": "Nine-point center $N = (O + H)/2$, nine-point radius $R_9 = R/2$. The 9 special points: side midpoints $M_a, M_b, M_c$; Euler midpoints mid$(A,H)$, mid$(B,H)$, mid$(C,H)$; altitude feet $H_a, H_b, H_c$."
+    },
+    {
+      "id": "incircle-excircles",
+      "title": "Incircle and Excircles",
+      "startLine": 189,
+      "endLine": 252,
+      "summary": "Defines incenter I as weighted average of vertices by opposite side lengths, inradius r = area/semiperimeter, three excenters and exradii. Defines internal and external circle tangency.",
+      "mathContext": "Incenter $I = (aA + bB + cC)/(a+b+c)$, inradius $r = \\Delta/s$. Excircle opposite $A$: center $I_A = (-aA + bB + cC)/(-a+b+c)$, exradius $r_A = \\Delta/(s-a)$."
+    },
+    {
+      "id": "euler-line-circumcenter",
+      "title": "Euler Line and Circumcenter Properties",
+      "startLine": 254,
+      "endLine": 372,
+      "summary": "Proves the Euler line relation G = (2O+H)/3, nine-point center on the Euler line, R/2 radius, helper lemmas (eq_of_sq_eq, dist2_nonneg, ninePointRadius_nonneg), circumcenter denominator nonzero, and circumcenter equidistance from vertices via perpendicular bisector conditions.",
+      "mathContext": "Euler line: $G = (2O + H)/3$. Circumcenter equidistance: $|OB|^2 = |OA|^2$ and $|OC|^2 = |OA|^2$, proved via the linear perpendicular bisector condition."
+    },
+    {
+      "id": "midpoint-membership",
+      "title": "Side Midpoints and Euler Midpoints on the Nine-Point Circle",
+      "startLine": 373,
+      "endLine": 440,
+      "summary": "Proves all 6 midpoints lie on the nine-point circle: 3 side midpoints (M_a - N = (O-A)/2 etc.) and 3 Euler midpoints (mid(A,H) - N = (A-O)/2 etc.). Uses the ninepoint_membership lemma and circumcenter equidistance.",
+      "mathContext": "For each midpoint $P$: $|P - N|^2 = |O - V|^2/4 = R^2/4$, so $\\text{dist}(N, P) = R/2$. Side midpoints use $M_a - N = (O - A)/2$; Euler midpoints use mid$(A,H) - N = (A - O)/2$."
+    },
+    {
+      "id": "altitude-feet",
+      "title": "Altitude Feet on the Nine-Point Circle",
+      "startLine": 442,
+      "endLine": 576,
+      "summary": "Proves all 3 altitude feet lie on the nine-point circle. These are the most computationally intensive proofs (maxHeartbeats 25,600,000): after clearing denominators (side length squared and circumcenter denominator), the equality reduces to a polynomial identity verified by ring.",
+      "mathContext": "Altitude foot $H_a$ = projection of $A$ onto $BC$. After clearing $|BC|^2$ and the circumcenter denominator $d$: $|H_a - N|^2 = R^2/4$ reduces to a polynomial identity in the vertex coordinates."
+    },
+    {
+      "id": "numerical-verification",
+      "title": "Numerical Verification: 3-4-5 Right Triangle",
+      "startLine": 577,
+      "endLine": 687,
+      "summary": "Constructs the 3-4-5 right triangle and verifies: area = 6, semiperimeter = 6, inradius = 1, circumcenter = (3/2, 2), circumradius = 5/2, orthocenter = (0,0), nine-point center = (3/4, 1), nine-point radius = 5/4, incenter = (1,1). Verifies Feuerbach incircle tangency: |NI| = |R/2 - r| = 1/4.",
+      "mathContext": "3-4-5 triangle: $R = 5/2$, $r = 1$, $R/2 - r = 1/4$. $|NI| = |(3/4, 1) - (1, 1)| = 1/4 = |R/2 - r|$, confirming internal tangency of nine-point circle and incircle."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-oq-01",
+      "relationship": "foundational",
+      "description": "Provides all definitions, special point formulas, and nine-point circle membership proofs imported by the main Feuerbach tangency proof (incircle and excircle tangency distance relations)"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "foundational",
+      "description": "Provides the definitional infrastructure assembled by the top-level Feuerbach's Theorem entry"
+    }
+  ],
+  "conclusion": {
+    "summary": "This module provides comprehensive, fully verified infrastructure (687 lines, 38 theorems/lemmas, 35 definitions, 1 structure, 0 axioms, 0 sorries) for Feuerbach's Theorem. All 9 special points are proved to lie on the nine-point circle, the Euler line relation is established, and the 3-4-5 triangle serves as a numerical verification. This is the largest infrastructure entry in the gallery.",
+    "implications": "The coordinate geometry approach, while algebraically intensive, makes the nine-point circle properties fully constructive and computationally verifiable. The factored ninepoint_membership lemma provides a reusable proof pattern that could be extended to other circle membership proofs. The numerical verification with the 3-4-5 triangle demonstrates that all formulas are consistent.",
+    "openQuestions": [
+      "Can the altitude foot proofs be optimized to require fewer heartbeats (currently 25.6M)?",
+      "Extend to prove the nine-point circle is the unique circle through all 9 points",
+      "Formalize the Feuerbach point as the tangency point between the nine-point circle and incircle",
+      "Connect to Mathlib's affine geometry framework for a more abstract treatment"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Geometry.Euclidean.Sphere.Basic",
+      "Mathlib.Geometry.Euclidean.Triangle",
+      "Mathlib.Geometry.Euclidean.Circumcenter",
+      "Mathlib.Data.Real.Sqrt",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real", "EuclideanGeometry"],
+    "namespace": "FeuerbachsTheorem",
+    "lineCount": 687,
+    "axiomCount": 0,
+    "theoremCount": 38,
+    "definitionCount": 35
+  }
+}

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -299,6 +299,11 @@
       "targetId": "fundamental-theorem-algebra",
       "relationship": "related",
       "description": "FTA guarantees polynomial roots exist over C; the Inverse Galois Problem asks about the symmetry structure of those roots over Q"
+    },
+    {
+      "targetId": "nth-root-irrational-oq-01",
+      "relationship": "depends-on",
+      "description": "Imports Eisenstein irreducibility and nth root irrationality infrastructure used for proving polynomial irreducibility in Galois group computations"
     }
   ],
   "relatedProofs": [
@@ -306,7 +311,8 @@
     "abel-ruffini-oq-04",
     "lagrange-theorem",
     "sylow-theorems",
-    "fundamental-theorem-algebra"
+    "fundamental-theorem-algebra",
+    "nth-root-irrational-oq-01"
   ],
   "references": [
     {

--- a/src/data/proofs/newton-inductive-step/meta.json
+++ b/src/data/proofs/newton-inductive-step/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "newton-inductive-step",
+  "title": "Newton's Log-Concavity Inductive Step",
+  "slug": "newton-inductive-step",
+  "description": "Proves the key binomial coefficient inequality for Newton's log-concavity theorem: bc^3 + adc^2 + ac^3 >= 2b^2cd + b^3d where a, b, c, d are consecutive binomial coefficients. Uses absorption identities to reduce to a polynomial identity verified by linear_combination. Imported by AmgmInequalityOQ02OQ02 and NewtonIndStep2.",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_inequalities",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NewtonInductiveStep.lean",
+    "leanFile": "proofs/Proofs/NewtonInductiveStep.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "inequalities",
+      "log-concavity",
+      "newton",
+      "infrastructure"
+    ],
+    "badge": "infrastructure",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose",
+        "description": "Binomial coefficients C(m, k)",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "Absorption identity: (m-k+1) * C(m,k) = (k+1) * C(m,k+1)",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "quadratic_nonneg: a quadratic alpha*t^2 + beta*t + gamma >= 0 for t >= 0 when alpha, gamma >= 0 and 4*alpha*gamma >= beta^2",
+      "binom_ineq: bc^3 + adc^2 + ac^3 >= 2b^2cd + b^3d for consecutive binomial coefficients C(m, k-2), C(m, k-1), C(m, k), C(m, k+1)",
+      "Key technique: absorption identities k*c = r*b, (k+1)*d = (r-1)*c, (k-1)*b = (r+1)*a reduce the inequality to D*(target) = r*(k+r)^2*b^4 >= 0 where D = k^3*(k+1)*(r+1) > 0"
+    ],
+    "references": [
+      {
+        "key": "Ne07",
+        "citation": "Niculescu, C. P. (2007). A new look at Newton's inequalities. Journal of Inequalities in Pure and Applied Mathematics, 1(2).",
+        "type": "paper"
+      },
+      {
+        "key": "HLP52",
+        "citation": "Hardy, G. H., Littlewood, J. E., and Polya, G. (1952). Inequalities. Cambridge University Press.",
+        "type": "book"
+      }
+    ],
+    "relatedProofs": [
+      "amgm-inequality-oq-02-oq-02",
+      "newton-ind-step-2"
+    ],
+    "dateAdded": "2026-03-22",
+    "axiomCount": 0,
+    "lineCount": 152,
+    "prerequisites": [
+      "Binomial coefficients and their properties (absorption identities)",
+      "Real arithmetic and polynomial inequalities",
+      "The linear_combination tactic for polynomial identity verification"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Newton's inequalities (also called Newton's log-concavity theorem) state that the elementary symmetric polynomials e_k of a sequence of real numbers satisfy the log-concavity condition e_k^2 >= e_{k-1} * e_{k+1}. Equivalently, for the binomial coefficients C(m, k), the sequence is ultra-log-concave. The inductive step in the classical proof requires a specific quartic inequality involving four consecutive binomial coefficients.\n\nThis module isolates and proves that key inequality using a technique based on absorption identities. The absorption identity k * C(m,k) = (m-k+1) * C(m,k-1) relates consecutive binomial coefficients, and by chaining three such identities, the entire inequality can be reduced to a polynomial identity in the parameters k and r = m-k+1, which is then verified algebraically.\n\nThe result is imported by two downstream proofs: the AM-GM inequality extension (which uses log-concavity of symmetric polynomials) and a second Newton inductive step variant.",
+    "problemStatement": "Prove the binomial coefficient inequality for Newton's log-concavity:\n\nFor integers m, k with 2 <= k and k+1 <= m, let a = C(m, k-2), b = C(m, k-1), c = C(m, k), d = C(m, k+1). Then:\n\n$$bc^3 + adc^2 + ac^3 \\geq 2b^2cd + b^3d$$\n\nAlso provide a helper lemma: a quadratic alpha*t^2 + beta*t + gamma >= 0 for t >= 0 when alpha, gamma >= 0 and 4*alpha*gamma >= beta^2.",
+    "proofStrategy": "The proof uses **absorption identities** to eliminate the binomial coefficients in favor of two parameters k and r = m - k + 1:\n\n1. **Absorption identities**: From Nat.choose_succ_right_eq, derive:\n   - k * c = r * b (relating C(m,k) and C(m,k-1))\n   - (k+1) * d = (r-1) * c (relating C(m,k+1) and C(m,k))\n   - (k-1) * b = (r+1) * a (relating C(m,k-1) and C(m,k-2))\n\n2. **Derive power identities**: Square and cube the first identity to get k^2*c^2 = r^2*b^2 and k^3*c^3 = r^3*b^3.\n\n3. **Multiply by D = k^3*(k+1)*(r+1) > 0**: Rewrite each term of D*(LHS - RHS) using the absorption identities and power identities.\n\n4. **Polynomial identity**: Show D*(LHS - RHS) = r*(k+r)^2*b^4 >= 0. This is verified by linear_combination using all the derived identities as hints.\n\n5. **Conclude**: Since D > 0 and D*(LHS - RHS) >= 0, we have LHS - RHS >= 0.",
+    "keyInsights": [
+      "Absorption identities convert binomial coefficient inequalities into polynomial identities in k and r, avoiding direct manipulation of factorials",
+      "The key algebraic identity D*(bc^3 + adc^2 + ac^3 - 2b^2cd - b^3d) = r*(k+r)^2*b^4 shows the inequality is tight only when b = 0 (impossible for valid k,m) or k + r = 0 (impossible since k >= 2, r >= 1)",
+      "The linear_combination tactic handles the polynomial identity verification, which involves combining 5 derived equations with specific polynomial coefficients",
+      "This is an instance of the 'clear denominators and verify a polynomial identity' paradigm common in formal combinatorial proofs"
+    ],
+    "prerequisites": [
+      "Binomial coefficients C(m,k) and the absorption identity k * C(m,k) = (m-k+1) * C(m,k-1)",
+      "Real arithmetic: positivity, non-negativity of squares, nlinarith for nonlinear arithmetic",
+      "The linear_combination tactic for combining algebraic identities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "quadratic-helper",
+      "title": "Quadratic Non-Negativity Helper",
+      "startLine": 1,
+      "endLine": 18,
+      "summary": "Proves quadratic_nonneg: alpha*t^2 + beta*t + gamma >= 0 for t >= 0 when alpha, gamma >= 0 and 4*alpha*gamma >= beta^2. Uses the completing-the-square identity (2*alpha*t + beta)^2 >= 0.",
+      "mathContext": "If $\\alpha, \\gamma \\geq 0$ and $4\\alpha\\gamma \\geq \\beta^2$, then $\\alpha t^2 + \\beta t + \\gamma \\geq 0$ for all $t \\geq 0$. Proof: $\\alpha(\\alpha t^2 + \\beta t + \\gamma) = (\\alpha t + \\beta/2)^2 + (\\alpha\\gamma - \\beta^2/4) \\geq 0$."
+    },
+    {
+      "id": "binomial-inequality",
+      "title": "Main Binomial Inequality via Absorption Identities",
+      "startLine": 20,
+      "endLine": 152,
+      "summary": "Proves binom_ineq: for consecutive binomial coefficients a, b, c, d = C(m, k-2..k+1), the inequality bc^3 + adc^2 + ac^3 >= 2b^2cd + b^3d holds. Derives three absorption identities, computes power identities, multiplies by D = k^3(k+1)(r+1) > 0, and shows D*(LHS-RHS) = r*(k+r)^2*b^4 via linear_combination.",
+      "mathContext": "For $a = \\binom{m}{k-2}$, $b = \\binom{m}{k-1}$, $c = \\binom{m}{k}$, $d = \\binom{m}{k+1}$ with $2 \\leq k \\leq m-1$:\n$$bc^3 + adc^2 + ac^3 \\geq 2b^2cd + b^3d$$\nEquivalently: $k^3(k+1)(r+1)(\\text{LHS} - \\text{RHS}) = r(k+r)^2 b^4 \\geq 0$ where $r = m - k + 1$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-02",
+      "relationship": "foundational",
+      "description": "Provides the key binomial inequality imported by the AM-GM inequality extension, which uses Newton's log-concavity of symmetric polynomials"
+    },
+    {
+      "targetId": "newton-ind-step-2",
+      "relationship": "foundational",
+      "description": "Provides the base binomial inequality imported by the second Newton inductive step variant for further log-concavity applications"
+    }
+  ],
+  "conclusion": {
+    "summary": "This module provides a fully verified proof (152 lines, 2 theorems, 0 axioms, 0 sorries) of the key binomial inequality for Newton's log-concavity. The absorption identity technique converts the problem into a clean polynomial identity, verified by linear_combination. It serves as infrastructure for 2 downstream proofs.",
+    "implications": "Newton's inequalities and log-concavity of binomial coefficients have deep connections to combinatorics, algebra, and probability. The technique of using absorption identities to reduce binomial coefficient inequalities to polynomial identities is broadly applicable: any inequality involving a fixed number of consecutive binomial coefficients can be handled this way, making it a powerful paradigm for formal verification.",
+    "openQuestions": [
+      "Formalize the full Newton's inequality e_k^2 >= e_{k-1} * e_{k+1} for elementary symmetric polynomials",
+      "Prove ultra-log-concavity of binomial coefficients: C(m,k)^2 / C(m,0)^2 is log-concave in k",
+      "Extend to q-binomial coefficients and their log-concavity properties"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0
+  }
+}

--- a/src/data/proofs/nth-root-irrational-oq-01/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "nth-root-irrational-oq-01",
+  "title": "Nth Root Irrationality via Irreducible Polynomials",
+  "slug": "nth-root-irrational-oq-01",
+  "description": "Algebraic irrationality via irreducible polynomials: proves that roots of irreducible polynomials of degree >= 2 over Q are irrational, applies Eisenstein's criterion to show X^n - p is irreducible for prime p, and derives irrationality of nth roots of primes. Imported by InverseGalois, InverseGaloisD4, InverseGaloisF20, and AngleTrisectionOQ02.",
+  "meta": {
+    "author": "Lang, Dummit-Foote, formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NthRootIrrationalOQ01.lean",
+    "leanFile": "proofs/Proofs/NthRootIrrationalOQ01.lean",
+    "tags": [
+      "algebra",
+      "irrationality",
+      "polynomials",
+      "eisenstein",
+      "galois-theory",
+      "infrastructure"
+    ],
+    "badge": "infrastructure",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Irreducible",
+        "description": "Irreducibility of polynomials over a ring",
+        "module": "Mathlib.RingTheory.Polynomial.Basic"
+      },
+      {
+        "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
+        "description": "Eisenstein's criterion for polynomial irreducibility over Z",
+        "module": "Mathlib.RingTheory.Polynomial.Eisenstein.Criterion"
+      },
+      {
+        "theorem": "IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+        "description": "Gauss lemma: Z-irreducibility transfers to Q for primitive polynomials",
+        "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
+      },
+      {
+        "theorem": "minpoly.irreducible",
+        "description": "The minimal polynomial of an integral element is irreducible",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      }
+    ],
+    "originalContributions": [
+      "irreducible_no_rational_root: irreducible p in Q[X] with deg >= 2 has no rational root",
+      "irrational_root_of_irreducible: real roots of such p are irrational",
+      "irrational_of_minpoly_degree_ge_two: algebraic degree >= 2 implies irrational",
+      "eisenstein_X_pow_sub_prime: X^n - p irreducible over Q for prime p via Eisenstein + Gauss",
+      "irrational_nthRoot_of_prime: nth root of prime is irrational",
+      "Concrete applications: sqrt(2), cbrt(2), cbrt(3), 5th-root(7)"
+    ],
+    "references": [
+      {
+        "key": "La02",
+        "citation": "Lang, S. (2002). Algebra. Ch. IV (Polynomials).",
+        "type": "book"
+      },
+      {
+        "key": "DF04",
+        "citation": "Dummit, D. S. and Foote, R. M. (2004). Abstract Algebra. Section 9.4 (Irreducibility Criteria).",
+        "type": "book"
+      }
+    ],
+    "relatedProofs": [
+      "inverse-galois",
+      "inverse-galois-d4",
+      "inverse-galois-f20",
+      "angle-trisection-oq-02"
+    ],
+    "dateAdded": "2026-03-22",
+    "axiomCount": 0,
+    "lineCount": 209,
+    "prerequisites": [
+      "Polynomial algebra over Q (irreducibility, roots, degree)",
+      "Eisenstein's criterion and the Gauss lemma",
+      "Minimal polynomials and algebraic elements",
+      "Real analysis (irrational numbers, algebraMap Q R)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The irrationality of square roots of non-square integers has been known since antiquity (the Pythagoreans discovered the irrationality of sqrt(2) around 500 BCE). The algebraic approach via irreducible polynomials provides a powerful generalization: any root of an irreducible polynomial of degree >= 2 over Q is irrational. This subsumes all nth-root irrationality results and connects to Galois theory, where the degree of the minimal polynomial determines the degree of the field extension.\n\nEisenstein's criterion (1850) gives a practical sufficient condition for irreducibility: if a polynomial's coefficients satisfy divisibility conditions with respect to a prime p, the polynomial is irreducible over Z, and hence over Q by the Gauss lemma. Applied to X^n - p for prime p, this immediately yields the irreducibility needed to prove nth roots of primes are irrational.\n\nThis module is imported by four other formalizations in the gallery: the Inverse Galois Problem (main, D4, and F20 variants) uses it for irrationality arguments in Galois group computations, and the Angle Trisection impossibility proof uses it for algebraic degree bounds.",
+    "problemStatement": "Provide a library of irrationality results based on irreducible polynomials:\n\n1. If p in Q[X] is irreducible with deg(p) >= 2, then p has no rational root\n2. Any real root of such a polynomial is irrational\n3. If the minimal polynomial of alpha over Q has degree >= 2, then alpha is irrational\n4. X^n - p is irreducible over Q for prime p and n >= 2 (Eisenstein + Gauss)\n5. For prime p and n >= 2, the nth root p^(1/n) is irrational",
+    "proofStrategy": "The proof proceeds through a clean hierarchy of increasingly specific results:\n\n1. **Core theorem** (irreducible_no_rational_root): If p is irreducible and has degree >= 2, any rational root r would give a factorization p = (X - r) * q. Since X - r has degree 1 and is not a unit, q must be a unit by irreducibility, forcing deg(p) = 1, contradicting deg(p) >= 2.\n\n2. **Irrationality lift** (irrational_root_of_irreducible): If alpha in R is rational, say alpha = r, then aeval(r, p) = 0, contradicting the core theorem. Uses injectivity of the algebraMap Q -> R.\n\n3. **Minimal polynomial variant** (irrational_of_minpoly_degree_ge_two): Applies the irrationality lift to the minimal polynomial, which is irreducible by Mathlib's minpoly.irreducible.\n\n4. **Eisenstein criterion** (eisenstein_X_pow_sub_prime): Proves X^n - p is irreducible over Z using Eisenstein's criterion at the prime ideal (p), then transfers to Q via the Gauss lemma for primitive polynomials.\n\n5. **Concrete irrationality** (irrational_nthRoot_of_prime): Combines steps 2 and 4, verifying that p^(1/n) is a root of X^n - p via real power arithmetic.",
+    "keyInsights": [
+      "The irreducible polynomial approach (Level 3) subsumes direct counting arguments (Level 2) for irrationality: one algebraic property implies all nth-root results",
+      "Eisenstein's criterion at the prime ideal (p) applies directly to X^n - p: the leading coefficient 1 is not in (p), all lower coefficients are in (p), and the constant term p is not in (p^2)",
+      "The Gauss lemma is essential: Eisenstein gives irreducibility over Z, but we need irreducibility over Q for the irrationality argument",
+      "The minimal polynomial characterization connects irrationality to algebraic degree: alpha is irrational iff its minimal polynomial over Q has degree >= 2",
+      "This module serves as shared infrastructure for Galois theory proofs, where knowing that nth roots of primes generate non-trivial field extensions is a foundational fact"
+    ],
+    "prerequisites": [
+      "Polynomial algebra: irreducibility, roots, factorization, degree computations in Q[X]",
+      "Eisenstein's criterion: divisibility conditions on polynomial coefficients implying irreducibility",
+      "Gauss lemma: irreducibility over Z implies irreducibility over Q for primitive polynomials",
+      "Minimal polynomials: uniqueness, irreducibility, and connection to algebraic degree"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Imports",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring explaining the algebraic irrationality approach. Imports Mathlib, opens Polynomial namespace, declares NthRootIrrationalOQ01 namespace with noncomputable section.",
+      "mathContext": "Sets up the algebraic framework: polynomials over Q, irreducibility, and the connection to irrationality of real numbers."
+    },
+    {
+      "id": "core-theorem",
+      "title": "Irreducible Polynomial Has No Rational Root",
+      "startLine": 38,
+      "endLine": 59,
+      "summary": "Proves irreducible_no_rational_root: if p in Q[X] is irreducible with degree >= 2, then p has no rational root. The proof uses the factorization p = (X - r) * q from a root r, then applies irreducibility to show either X - r or q is a unit, both leading to contradictions.",
+      "mathContext": "If $p \\in \\mathbb{Q}[X]$ is irreducible with $\\deg(p) \\geq 2$ and $r \\in \\mathbb{Q}$, then $p(r) \\neq 0$. Key step: $p = (X - r) \\cdot q$ forces $\\deg(q) = 0$ (unit), giving $\\deg(p) = 1$, contradiction."
+    },
+    {
+      "id": "irrationality-lift",
+      "title": "Irrational Roots of Irreducible Polynomials",
+      "startLine": 61,
+      "endLine": 89,
+      "summary": "Proves irrational_root_of_irreducible and irrational_of_minpoly_degree_ge_two. The first lifts the rational non-root result to real roots via injectivity of algebraMap Q -> R. The second applies this to minimal polynomials.",
+      "mathContext": "If $\\alpha \\in \\mathbb{R}$ satisfies $p(\\alpha) = 0$ for irreducible $p$ with $\\deg(p) \\geq 2$, then $\\alpha \\notin \\mathbb{Q}$. Equivalently, $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] \\geq 2 \\implies \\alpha$ is irrational."
+    },
+    {
+      "id": "eisenstein",
+      "title": "Eisenstein Criterion for X^n - p",
+      "startLine": 91,
+      "endLine": 154,
+      "summary": "Proves X^n - p is irreducible over Z (via Eisenstein at the prime ideal (p)) and then over Q (via the Gauss lemma). The Eisenstein verification checks: leading coefficient not in (p), lower coefficients in (p), constant term not in (p^2), and the polynomial is primitive (monic).",
+      "mathContext": "For prime $p$ and $n \\geq 2$: $X^n - p \\in \\mathbb{Z}[X]$ is irreducible by Eisenstein's criterion at $(p)$, hence irreducible in $\\mathbb{Q}[X]$ by the Gauss lemma. Also proves $\\deg(X^n - c) = n$ for $c \\neq 0$."
+    },
+    {
+      "id": "nth-root-irrationality",
+      "title": "Irrationality of Nth Roots of Primes",
+      "startLine": 156,
+      "endLine": 206,
+      "summary": "Proves irrational_nthRoot_of_prime: for prime p and n >= 2, p^(1/n) is irrational. Combines Eisenstein irreducibility with the irrationality lift. Concrete applications: sqrt(2), cbrt(2), cbrt(3), 5th-root(7). The structural_subsumes_counting theorem highlights that this approach subsumes counting arguments.",
+      "mathContext": "For prime $p$ and $n \\geq 2$: $p^{1/n}$ is a root of the irreducible polynomial $X^n - p$, hence irrational. Concrete: $\\sqrt{2}$, $\\sqrt[3]{2}$, $\\sqrt[3]{3}$, $\\sqrt[5]{7}$ are all irrational."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois",
+      "relationship": "foundational",
+      "description": "Provides irrationality and irreducibility infrastructure imported by the Inverse Galois Problem formalization for Galois group computations over Q"
+    },
+    {
+      "targetId": "inverse-galois-d4",
+      "relationship": "foundational",
+      "description": "Imported by the D4 Galois realization (X^4-2) which uses Eisenstein irreducibility for its polynomial"
+    },
+    {
+      "targetId": "inverse-galois-f20",
+      "relationship": "foundational",
+      "description": "Imported by the F20 Frobenius group realization (X^5-2) which uses Eisenstein irreducibility"
+    },
+    {
+      "targetId": "angle-trisection-oq-02",
+      "relationship": "foundational",
+      "description": "Imported by the angle trisection impossibility proof for algebraic degree bounds on constructible numbers"
+    }
+  ],
+  "conclusion": {
+    "summary": "This module provides a clean, fully verified library (209 lines, 12 theorems, 0 axioms, 0 sorries) of irrationality results via irreducible polynomials. The key chain is: Eisenstein criterion -> Gauss lemma -> irreducibility over Q -> no rational root -> irrational real root. It serves as shared infrastructure for 4 downstream proofs in the gallery.",
+    "implications": "The irreducible polynomial approach to irrationality is strictly more general than ad hoc arguments: it applies to any algebraic number of degree >= 2, not just nth roots. This generality is exactly what makes it useful as infrastructure for Galois theory proofs, where the degree of the minimal polynomial determines the structure of the field extension and its Galois group.",
+    "openQuestions": [
+      "Extend to algebraic irrationality of roots of cyclotomic polynomials and their subfields",
+      "Formalize the connection between algebraic degree and transcendence degree for more general irrationality results",
+      "Add Eisenstein criterion variants for polynomials other than X^n - p (e.g., trinomials)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": ["Polynomial"],
+    "namespace": "NthRootIrrationalOQ01",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0
+  }
+}

--- a/src/data/proofs/prime-gap-bounds/meta.json
+++ b/src/data/proofs/prime-gap-bounds/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "prime-gap-bounds",
+  "title": "Explicit Prime Gap Bounds from Bertrand's Postulate",
+  "slug": "prime-gap-bounds",
+  "description": "Derives explicit bounds on prime gaps and the n-th prime from Bertrand's postulate: pi(2n) > pi(n) for n >= 1, iterated doubling bounds pi(2^k * n) >= pi(n) + k, small value computations of pi, and the exponential bound p_n <= 2^(n+1) by induction. Imported by BoundedPrimeGaps and BertrandsPostulateOQ03.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bertrand%27s_postulate",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PrimeGapBounds.lean",
+    "leanFile": "proofs/Proofs/PrimeGapBounds.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "prime-gaps",
+      "bertrand",
+      "prime-counting",
+      "infrastructure"
+    ],
+    "badge": "infrastructure",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.exists_prime_lt_and_le_two_mul",
+        "description": "Bertrand's postulate: for n >= 1, there exists a prime p with n < p <= 2n",
+        "module": "Mathlib.NumberTheory.Bertrand"
+      },
+      {
+        "theorem": "Nat.primeCounting",
+        "description": "The prime counting function pi(n)",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "Nat.nth",
+        "description": "The n-th element of an infinite set (used for n-th prime)",
+        "module": "Mathlib.Data.Nat.Prime.Nth"
+      },
+      {
+        "theorem": "Nat.count_monotone",
+        "description": "Monotonicity of the counting function for primes",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      }
+    ],
+    "originalContributions": [
+      "bertrand_postulate: wrapper extracting Bertrand's postulate from Mathlib",
+      "primeCounting_double_gt: pi(2n) > pi(n) for n >= 1",
+      "primeCounting_double_ge_succ: pi(2n) >= pi(n) + 1",
+      "primeCounting_pow_two_mul: pi(2^k * n) >= pi(n) + k (iterated doubling)",
+      "Small value computations: pi(10) = 4, pi(20) = 8, pi(30) = 10, pi(50) = 15",
+      "nth_prime_succ_le_of_prime_gt: order-preserving enumeration property of primes",
+      "nth_prime_le_two_pow_succ: p_n <= 2^(n+1) proved by induction from Bertrand",
+      "nth_prime_le_two_pow: 1-indexed variant p_n <= 2^n"
+    ],
+    "references": [
+      {
+        "key": "Be45",
+        "citation": "Bertrand, J. (1845). Memoire sur le nombre de valeurs que peut prendre une fonction quand on y permute les lettres qu'elle renferme. Journal de l'Ecole Royale Polytechnique, 30, 123-140.",
+        "type": "paper"
+      },
+      {
+        "key": "Ch52",
+        "citation": "Chebyshev, P. L. (1852). Memoire sur les nombres premiers. Journal de Mathematiques Pures et Appliquees, 17, 366-390.",
+        "type": "paper"
+      }
+    ],
+    "relatedProofs": [
+      "bounded-prime-gaps",
+      "bertrands-postulate-oq-03",
+      "bertrands-postulate",
+      "prime-number-theorem",
+      "infinitude-primes"
+    ],
+    "dateAdded": "2026-03-22",
+    "axiomCount": 0,
+    "lineCount": 202,
+    "prerequisites": [
+      "Bertrand's postulate (from Mathlib)",
+      "Prime counting function pi(n) and its properties",
+      "The n-th prime function and its monotonicity",
+      "Basic number theory (divisibility, prime factorization)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Bertrand's postulate (1845), proved by Chebyshev (1852), states that for every n >= 1, there exists a prime between n and 2n. This fundamental result in number theory has numerous consequences for the distribution of primes. While the Prime Number Theorem (1896) gives asymptotic control over prime density, Bertrand's postulate provides explicit, non-asymptotic bounds that are computationally useful.\n\nThis module extracts concrete consequences of Bertrand's postulate: bounds on the prime counting function pi(n) under doubling, small value computations verified by decide, and the exponential bound p_n <= 2^(n+1) on the n-th prime. The exponential bound, while weaker than the PNT estimate p_n ~ n log n, has the advantage of being elementary (provable from Bertrand alone, without analytic methods) and is imported by the Bounded Prime Gaps formalization for its prime gap infrastructure.",
+    "problemStatement": "Derive explicit bounds from Bertrand's postulate:\n\n1. **Prime counting under doubling**: pi(2n) > pi(n) for n >= 1\n2. **Iterated doubling**: pi(2^k * n) >= pi(n) + k\n3. **Small values**: Verify pi(10) = 4, pi(20) = 8, pi(30) = 10, pi(50) = 15\n4. **Exponential bound on p_n**: The n-th prime satisfies p_n <= 2^(n+1)\n5. **Order property**: If q is prime and q > p_n, then p_{n+1} <= q",
+    "proofStrategy": "The proofs build systematically from Bertrand's postulate:\n\n1. **primeCounting_double_gt**: By Bertrand, there exists prime p with n < p <= 2n. Since p contributes to pi(2n) but not pi(n), we get pi(2n) > pi(n). Uses count_monotone and count_strict_mono.\n\n2. **primeCounting_pow_two_mul**: Induction on k, applying the doubling result at each step. The base case is trivial; the inductive step uses 2^(j+1) * n = 2 * (2^j * n).\n\n3. **Small values**: Verified by decide (kernel computation).\n\n4. **nth_prime_le_two_pow_succ**: Induction on n. Base: p_0 = 2 <= 2^1. Step: By Bertrand, there exists prime q with p_k < q <= 2*p_k. Since p_{k+1} is the smallest prime > p_k, we get p_{k+1} <= q <= 2*p_k <= 2*2^(k+1) = 2^(k+2).\n\n5. **nth_prime_succ_le_of_prime_gt**: Key lemma for the inductive step. If q is prime and q > p_n, then p_{n+1} <= q. Proved by contradiction using count_nth and the order-preserving nature of nth.",
+    "keyInsights": [
+      "Bertrand's postulate gives multiplicative control over prime density: doubling the range always captures at least one new prime",
+      "The iterated doubling bound pi(2^k * n) >= pi(n) + k shows primes grow at least logarithmically in the range parameter",
+      "The exponential bound p_n <= 2^(n+1) is tight enough for many applications while being elementary to prove",
+      "The key lemma nth_prime_succ_le_of_prime_gt captures the order-preserving enumeration of primes, essential for the inductive step",
+      "Small value computations (pi(10) = 4, etc.) serve as sanity checks verified by Lean's kernel"
+    ],
+    "prerequisites": [
+      "Bertrand's postulate: for n >= 1, there exists a prime p with n < p <= 2n",
+      "The prime counting function pi(n) = |{p <= n : p prime}|",
+      "The n-th prime function (0-indexed): p_0 = 2, p_1 = 3, p_2 = 5, ...",
+      "Basic properties of Nat.count and Nat.nth from Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Bertrand Wrapper",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring listing key results. Imports Mathlib.NumberTheory.Bertrand, PrimeCounting, and Nat.Prime.Nth. Wraps Bertrand's postulate as bertrand_postulate for convenient use.",
+      "mathContext": "Bertrand's postulate: for $n \\geq 1$, $\\exists p$ prime with $n < p \\leq 2n$."
+    },
+    {
+      "id": "prime-counting-bounds",
+      "title": "Prime Counting Bounds under Doubling",
+      "startLine": 38,
+      "endLine": 89,
+      "summary": "Proves pi(2n) > pi(n) for n >= 1, pi(2n) >= pi(n) + 1, and the iterated bound pi(2^k * n) >= pi(n) + k. The last uses induction on k with the doubling result at each step.",
+      "mathContext": "$\\pi(2n) > \\pi(n)$ for $n \\geq 1$. By induction: $\\pi(2^k n) \\geq \\pi(n) + k$. This gives logarithmic growth: $\\pi(N) \\geq \\log_2(N/n) + \\pi(n)$."
+    },
+    {
+      "id": "small-values",
+      "title": "Small Value Computations",
+      "startLine": 90,
+      "endLine": 110,
+      "summary": "Computes pi(10) = 4, pi(20) = 8, pi(30) = 10, pi(50) = 15 using decide (kernel computation). Verifies Bertrand computationally: pi(20) > pi(10).",
+      "mathContext": "$\\pi(10) = 4$, $\\pi(20) = 8$, $\\pi(30) = 10$, $\\pi(50) = 15$. These values are verified by Lean's kernel evaluator."
+    },
+    {
+      "id": "exponential-bound",
+      "title": "Exponential Bound on the n-th Prime",
+      "startLine": 111,
+      "endLine": 202,
+      "summary": "Proves the key lemma nth_prime_succ_le_of_prime_gt (if q is prime and q > p_n, then p_{n+1} <= q) and the main result nth_prime_le_two_pow_succ (p_n <= 2^(n+1)) by induction using Bertrand's postulate. Includes the 1-indexed corollary p_n <= 2^n.",
+      "mathContext": "$p_n \\leq 2^{n+1}$ (0-indexed). Base: $p_0 = 2 \\leq 2$. Step: Bertrand gives prime $q$ with $p_k < q \\leq 2p_k$, and $p_{k+1} \\leq q \\leq 2p_k \\leq 2 \\cdot 2^{k+1} = 2^{k+2}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "bounded-prime-gaps",
+      "relationship": "foundational",
+      "description": "Provides prime gap infrastructure (nth prime bounds, prime counting bounds) imported directly by the Bounded Prime Gaps formalization"
+    },
+    {
+      "targetId": "bertrands-postulate-oq-03",
+      "relationship": "foundational",
+      "description": "Extends the Bertrand's Postulate OQ-03 entry with derived bounds on prime counting and the n-th prime"
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "extends",
+      "description": "Builds on Bertrand's postulate (from Mathlib) to derive explicit quantitative bounds"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "related",
+      "description": "The PNT gives p_n ~ n log n asymptotically; this module provides the weaker but elementary bound p_n <= 2^(n+1) provable from Bertrand alone"
+    }
+  ],
+  "conclusion": {
+    "summary": "This module provides fully verified infrastructure (202 lines, 13 theorems/lemmas, 0 axioms, 0 sorries) deriving explicit prime bounds from Bertrand's postulate. The crown result is the exponential bound p_n <= 2^(n+1), proved by elementary induction. It serves as shared infrastructure for the Bounded Prime Gaps and Bertrand's Postulate gallery entries.",
+    "implications": "The exponential bound p_n <= 2^(n+1) is the strongest elementary bound on primes achievable from Bertrand's postulate alone. While much weaker than the PNT bound p_n ~ n log n, it requires no analytic machinery and is sufficient for many combinatorial applications in number theory. The iterated doubling framework demonstrates how a single existence result (Bertrand) can be amplified into quantitative density statements.",
+    "openQuestions": [
+      "Formalize Dusart-type bounds p_n <= n(ln n + ln ln n) from the Prime Number Theorem",
+      "Prove the Rosser-Schoenfeld bounds on pi(n) from explicit zero-free regions",
+      "Connect the exponential bound to the Chebyshev functions theta(x) and psi(x)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Bertrand",
+      "Mathlib.NumberTheory.PrimeCounting",
+      "Mathlib.Data.Nat.Prime.Nth",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Nat"],
+    "namespace": "PrimeGapBounds",
+    "lineCount": 202,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0
+  }
+}


### PR DESCRIPTION
## Summary

- Create gallery entries with `infrastructure` badge for 5 Lean files that are imported by 2+ other proofs but previously lacked gallery presence
- Add missing cross-references in 2 existing gallery entries

## New gallery entries

| Entry | Lean file | Status | Lines | Axioms | Imported by |
|-------|-----------|--------|-------|--------|-------------|
| `nth-root-irrational-oq-01` | `NthRootIrrationalOQ01.lean` | verified | 209 | 0 | InverseGalois, InverseGaloisD4, InverseGaloisF20, AngleTrisectionOQ02 |
| `prime-gap-bounds` | `PrimeGapBounds.lean` | verified | 202 | 0 | BoundedPrimeGaps, BertrandsPostulateOQ03 |
| `newton-inductive-step` | `NewtonInductiveStep.lean` | verified | 152 | 0 | AmgmInequalityOQ02OQ02, NewtonIndStep2 |
| `feuerbachs-theorem-defs` | `FeuerbachsTheoremDefs.lean` | verified | 687 | 0 | FeuerbachsTheoremOQ01 |
| `erdos-340-greedy-sidon` | `Erdos340GreedySidon.lean` | axiomatized | 537 | 21 | Erdos44Problem, Erdos44SidonLowerBound |

## Cross-reference updates

- `bounded-prime-gaps/meta.json`: added cross-ref to `prime-gap-bounds` (depends-on)
- `inverse-galois/meta.json`: added cross-ref to `nth-root-irrational-oq-01` (depends-on)

## Test plan

- [x] All 7 JSON files pass validation (python3 json.load)
- [x] Each entry follows the `szemeredi-core` infrastructure template format
- [x] Status fields match axiom integrity policy (verified for 0 axioms, axiomatized for 21 axioms)
- [x] Cross-references use `targetId` convention matching the codebase
- [ ] Verify `pnpm build` passes (gallery integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)