### PR TITLE
Research: erdos-327 - eliminate unitFraction axiom (2→1 axioms)

### DIFF
--- a/proofs/Proofs/Erdos327Problem.lean
+++ b/proofs/Proofs/Erdos327Problem.lean
@@ -65,9 +65,39 @@ def ErdosProblem327_variant : Prop :=
 
 /- ## Unit fraction equivalence -/
 
-/-- `a + b ∣ a * b` iff `1/a + 1/b` is a unit fraction (i.e., `1/c` for some `c`). -/
-axiom sumDvdProd_iff_unitFraction (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
-    a + b ∣ a * b ↔ ∃ c : ℕ, 0 < c ∧ (1 : ℚ) / a + (1 : ℚ) / b = (1 : ℚ) / c
+/-- `a + b ∣ a * b` iff `1/a + 1/b` is a unit fraction (i.e., `1/c` for some `c`).
+    Proof: 1/a + 1/b = (a+b)/(ab), which equals 1/c iff c = ab/(a+b), iff (a+b) | ab. -/
+theorem sumDvdProd_iff_unitFraction (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
+    a + b ∣ a * b ↔ ∃ c : ℕ, 0 < c ∧ (1 : ℚ) / a + (1 : ℚ) / b = (1 : ℚ) / c := by
+  have ha' : (a : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  have hb' : (b : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  have hab : (a : ℚ) * b ≠ 0 := mul_ne_zero ha' hb'
+  have hab_pos : 0 < (a : ℚ) * b := by positivity
+  constructor
+  · -- (→) If (a+b) | ab, then c = ab/(a+b) is a positive natural number
+    intro ⟨c, hc⟩
+    have hc_pos : 0 < c := by
+      by_contra h; push_neg at h
+      have hc0 : c = 0 := by omega
+      rw [hc0, mul_zero] at hc
+      have := Nat.mul_pos ha hb
+      omega
+    refine ⟨c, hc_pos, ?_⟩
+    -- 1/a + 1/b = (a+b)/(ab) = (a+b)/((a+b)*c) = 1/c
+    have hc_ne : (c : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+    rw [div_add_div _ _ ha' hb', div_eq_div_iff (mul_ne_zero ha' hb') hc_ne]
+    have hc_q : (↑a : ℚ) * ↑b = (↑a + ↑b) * ↑c := by exact_mod_cast hc
+    linarith
+  · -- (←) If 1/a + 1/b = 1/c, then (a+b) | ab
+    intro ⟨c, hc_pos, heq⟩
+    have hc' : (c : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+    have hab' : (↑a + ↑b : ℚ) ≠ 0 := by positivity
+    -- From 1/a + 1/b = 1/c: (a+b)/(ab) = 1/c, so c*(a+b) = ab
+    have key : (↑c : ℚ) * (↑a + ↑b) = ↑a * ↑b := by
+      have := heq; field_simp at this; linarith
+    -- Extract the ℕ identity
+    have key_nat : c * (a + b) = a * b := by exact_mod_cast key
+    exact ⟨c, by linarith [key_nat]⟩
 
 /- ## Basic properties -/
 

--- a/src/data/research/problems/erdos-327.json
+++ b/src/data/research/problems/erdos-327.json
@@ -29,9 +29,10 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: sumDvdProd_iff_reduced_divides_gcd fully proved. File has 0 sorries, 7 complete theorems, 2 axioms (vanDoorn_bound + unitFraction equiv). GCD characterization proved via coprimality of reduced fractions and mul_dvd_mul_iff_left.",
+    "progressSummary": "PROGRESS: sumDvdProd_iff_unitFraction axiom ELIMINATED (proved as theorem). File now: 0 sorries, 1 axiom (vanDoorn bound only). Proof uses div_add_div + div_eq_div_iff + exact_mod_cast.",
     "builtItems": [
-      "Proved sumDvdProd_iff_reduced_divides_gcd in Erdos327Problem.lean:144-168 - complete proof replacing sorry"
+      "Proved sumDvdProd_iff_reduced_divides_gcd in Erdos327Problem.lean:144-168 - complete proof replacing sorry",
+      "sumDvdProd_iff_unitFraction: axiom→theorem via div_add_div + div_eq_div_iff in ℚ"
     ],
     "insights": [
       "Proof strategy: write a=d*a', b=d*b' with d=gcd. Then (a+b)|a*b ↔ (a'+b')|d via coprimality of a'+b' and a'*b'",
@@ -39,7 +40,8 @@
       "Main Mathlib API challenge: finding exact lemma names for Nat.Coprime.add_left style results",
       "Proof uses coprime_div_gcd_div_gcd to get gcd(a/d, b/d)=1, then derives gcd(a/d+b/d, a/d*b/d)=1 via Coprime.mul_right",
       "Key Mathlib API: mul_dvd_mul_iff_left cancels common factor d from divisibility, Coprime.dvd_of_dvd_mul_right extracts the coprime factor",
-      "coprime_self_add_right is the bridge: gcd(a, a+b) = gcd(a, b) allows lifting coprimality to the sum"
+      "coprime_self_add_right is the bridge: gcd(a, a+b) = gcd(a, b) allows lifting coprimality to the sum",
+      "sumDvdProd_iff_unitFraction provable: 1/a+1/b=(a+b)/(ab), equals 1/c iff c*(a+b)=ab iff (a+b)|ab. Forward: div_add_div combines fractions, div_eq_div_iff clears denominators. Backward: field_simp in ℚ + exact_mod_cast back to ℕ."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -70,9 +72,9 @@
     {
       "path": "Proofs/Erdos327Problem.lean",
       "filename": "Erdos327Problem.lean",
-      "lineCount": 147,
-      "theoremCount": 7,
-      "axiomCount": 2,
+      "lineCount": 186,
+      "theoremCount": 8,
+      "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 1,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Prove `sumDvdProd_iff_unitFraction` as a theorem (was axiom)
- `a + b ∣ a * b ↔ ∃ c, 1/a + 1/b = 1/c` via rational arithmetic
- File: 0 sorries, 1 axiom (van Doorn bound, justified deep result)

## Proof Technique
- **Forward**: `div_add_div` combines `1/a + 1/b = (a+b)/(ab)`, `div_eq_div_iff` clears denominators, `exact_mod_cast` bridges ℕ↔ℚ
- **Backward**: `field_simp` in ℚ extracts `c*(a+b) = a*b`, `exact_mod_cast` lifts to ℕ divisibility

## Files Modified
- `proofs/Proofs/Erdos327Problem.lean` — Replace axiom with theorem
- `src/data/research/problems/erdos-327.json` — Update axiom count 2→1

## Status
**Outcome**: completed (axiom eliminated)

🤖 Generated by researcher-4