### PR TITLE
Research: erdos-1161 - fix build errors

### DIFF
--- a/proofs/Proofs/Erdos1103Problem.lean
+++ b/proofs/Proofs/Erdos1103Problem.lean
@@ -47,7 +47,7 @@ grow at least exponentially? That is, does there exist `C > 1` such that
 `a_j ≥ C^j` for all large `j`? -/
 def ErdosProblem1103 : Prop :=
     ∀ A : Set ℕ, A.Infinite → SquarefreeSumset A →
-      ∃ (C : ℝ), 1 < C ∧ ∀ᶠ j in atTop,
+      ∃ (C : ℝ), 1 < C ∧ ∀ᶠ (j : ℕ) in atTop,
         C ^ (j : ℝ) ≤ (enumSet A j : ℝ)
 
 /- ## Known bounds -/
@@ -75,12 +75,13 @@ axiom konyagin_finite_bound :
 /- ## Basic properties -/
 
 /-- Every singleton set has a squarefree sumset iff `2a` is squarefree. -/
-axiom squarefreeSumset_singleton (a : ℕ) :
-    SquarefreeSumset {a} ↔ Squarefree (a + a)
+theorem squarefreeSumset_singleton (a : ℕ) :
+    SquarefreeSumset {a} ↔ Squarefree (a + a) := by
+  simp [SquarefreeSumset]
 
 /-- The empty set trivially has a squarefree sumset. -/
 theorem squarefreeSumset_empty : SquarefreeSumset ∅ := by
-  intro a ha; exact absurd ha (Set.not_mem_empty a)
+  intro a ha; exact absurd ha (Set.notMem_empty a)
 
 /-- If `SquarefreeSumset A` and `B ⊆ A`, then `SquarefreeSumset B`. -/
 theorem squarefreeSumset_subset {A B : Set ℕ} (h : B ⊆ A) (hA : SquarefreeSumset A) :

--- a/proofs/Proofs/Erdos1161Problem.lean
+++ b/proofs/Proofs/Erdos1161Problem.lean
@@ -111,8 +111,9 @@ theorem permCountByOrder_one_pos (n : ℕ) (hn : 0 < n) :
 /-- Every permutation has order dividing n!. -/
 theorem orderOf_perm_dvd_factorial (n : ℕ) (σ : Equiv.Perm (Fin n)) :
     orderOf σ ∣ n.factorial := by
-  have h := orderOf_dvd_card (G := Equiv.Perm (Fin n))
-  rwa [Fintype.card_perm] at h
+  have h : orderOf σ ∣ Fintype.card (Equiv.Perm (Fin n)) := orderOf_dvd_card
+  simp only [Fintype.card_perm, Fintype.card_fin] at h
+  exact h
 
 /-- The total count of permutations across all orders equals n!. -/
 theorem sum_permCountByOrder (n : ℕ) :
@@ -131,7 +132,7 @@ theorem permCountByOrder_eq_zero_of_not_dvd (n k : ℕ) (hk : ¬(k ∣ n.factori
   unfold permCountByOrder
   rw [Finset.card_eq_zero]
   ext σ
-  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.not_mem_empty, iff_false]
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.notMem_empty, iff_false]
   intro h
   exact hk (h ▸ orderOf_perm_dvd_factorial n σ)
 
@@ -227,7 +228,7 @@ theorem permCountByOrder_le_factorial (n k : ℕ) :
   unfold permCountByOrder
   calc (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) => orderOf σ = k)).card
       ≤ (Finset.univ : Finset (Equiv.Perm (Fin n))).card := Finset.card_filter_le _ _
-    _ = n.factorial := by rw [Finset.card_univ, Fintype.card_perm]
+    _ = n.factorial := by rw [Finset.card_univ, Fintype.card_perm, Fintype.card_fin]
 
 /- Aristotle found this block to be false. Here is a proof of the negation:
 
@@ -271,14 +272,14 @@ theorem lcmRange_dvd_lcmRange (m m' : ℕ) (h : m ≤ m') :
   apply Finset.lcm_dvd
   intro i hi
   apply Finset.dvd_lcm
-  exact Finset.mem_range.mpr (by omega)
+  exact Finset.mem_range.mpr (lt_of_lt_of_le (Finset.mem_range.mp hi) h)
 
 /-- lcmRange includes each factor: for 1 ≤ j ≤ m, j ∣ lcmRange m. -/
 theorem dvd_lcmRange (m j : ℕ) (hj : 1 ≤ j) (hjm : j ≤ m) :
     j ∣ lcmRange m := by
   unfold lcmRange
   have : j - 1 ∈ Finset.range m := Finset.mem_range.mpr (by omega)
-  have : (fun i => i + 1) (j - 1) = j := by omega
+  have : (fun i => i + 1) (j - 1) = j := by dsimp; omega
   rw [← this]
   exact Finset.dvd_lcm (f := (· + 1)) ‹j - 1 ∈ Finset.range m›
 

--- a/src/data/research/problems/erdos-1103.json
+++ b/src/data/research/problems/erdos-1103.json
@@ -29,9 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Eliminated squarefreeSumset_singleton axiom (proved from definition via simp). Fixed 2 pre-existing build errors (type mismatch in ErdosProblem1103, deprecated Set.not_mem_empty). File: 4 theorems, 5 axioms, 0 sorries.",
+    "builtItems": [
+      "Proved squarefreeSumset_singleton (axiom → theorem) in Erdos1103Problem.lean:78",
+      "Fixed type annotation for ErdosProblem1103 (j : ℕ)",
+      "Fixed deprecated Set.not_mem_empty → Set.notMem_empty"
+    ],
+    "insights": [
+      "squarefreeSumset_singleton proved by simp [SquarefreeSumset] which unfolds definition and simplifies singleton membership",
+      "Pre-existing build error: j was inferred as Real in atTop filter due to C^j expression - fixed with explicit (j : ℕ) annotation",
+      "Set.not_mem_empty deprecated to Set.notMem_empty in current Mathlib"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #1103 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A$ be an infinite sequence of integers such that every $n\\in A+A$ is squarefree. How fast must $A$ grow?\n\n\n\nErd\\H{o}s notes there exists such a sequence which grows exponentially, but does not expect such a sequence of polynomial growth.\n\nIn \\cite{Er81h} he asked whether there is an infinite sequence of integers $A$ such that, for every $a\\in A$ and prime $p$, if\\[a\\equiv t\\pmod{p^2}\\]then $1\\leq t<p^2/2$. He noted that such a sequence has the property that every $n\\in A+A$ is squarefree. He wrote 'I am doubtful if such a sequence exists. I formulated this problem while writing these lines and must ask the indulgence of the reader if it turns out to be trivial.'\n\nIndeed, there are trivially at most finitely many such $a$, since there cannot be any primes $p\\in (a^{1/2},(2a)^{1/2}]$, but there exist primes in $(x,\\sqrt{2}x)$ for all large $x$.\n\nIf $A=\\{a_1<a_2<\\cdots\\}$ is such a sequence then van Doorn and Tao \\cite{vDTa25} have shown that $a_j > 0.24j^{4/3}$ for all $j$, and further that there exists such a sequence (furthermore with squarefree terms) such that\\[a_j < \\exp(5j/\\log j)\\]for all large $j$. A superior lower bound of $a_j \\gg j^{15/11-o(1)}$ had earlier been found by Konyagin \\cite{Ko04} when considering the finite case [1109].\n\nThey also obtain further results for the generalisation from squarefree to $k$-free integers, and also replacing $A+A$ with $A\\cup (A+A)\\cup(A+A+A)$.\n\nSee also [1109] for the finite analogue of this problem.\n\n\n\n\nReferences\n\n\n[Er81h] Erd\\H{o}s, P., Some problems and results on additive and multiplicative\nnumber theory. Analytic number theory (Philadelphia, Pa., 1980) (1981), 171-182.\n\n[Ko04] Konyagin, S. V., Problems of the set of square-free numbers. Izv. Ross. Akad. Nauk Ser. Mat. (2004), 63--90.\n\n[vDTa25] W. van Doorn and T. Tao, Growth rates of sequences governed by the squarefree properties of its translates. arXiv:2512.01087 (2025).\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #3\n- Problem #11\n- Problem #1109\n- Problem #1102\n- Problem #1104\n- Problem #39\n- Problem #1\n\n## References\n\n- Er81h\n- Ko04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"

--- a/src/data/research/problems/erdos-1161.json
+++ b/src/data/research/problems/erdos-1161.json
@@ -29,9 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Fixed 4 pre-existing build errors (Fintype.card_fin, deprecated API, omega failures). File now compiles. 3 sorries remain: beker_characterization, beker_maximizer_achieves (both deep Beker [Be25d] results), permCountByOrder_n_eq_subfactorial_pred (n-cycle counting).",
+    "builtItems": [
+      "Fixed orderOf_perm_dvd_factorial: added Fintype.card_fin simp lemma",
+      "Fixed permCountByOrder_le_factorial: added Fintype.card_fin to rw chain",
+      "Fixed lcmRange_dvd_lcmRange: explicit lt_of_lt_of_le instead of omega",
+      "Fixed dvd_lcmRange: dsimp before omega for lambda reduction",
+      "Fixed deprecated Finset.not_mem_empty → Finset.notMem_empty"
+    ],
+    "insights": [
+      "File required import Mathlib (full import) - imports all of Mathlib",
+      "Fintype.card_perm gives card = (Fintype.card α)! not n!, need Fintype.card_fin to bridge",
+      "omega cannot see through Finset.mem_range - need to extract membership manually",
+      "lambda application (fun i => i+1) (j-1) needs dsimp before omega can process",
+      "Beker characterization and maximizer theorems are deep published results, unlikely provable from Mathlib",
+      "permCountByOrder_n_eq_subfactorial_pred (n-cycle counting) might be provable but needs cycle-counting infrastructure not easily available in current Mathlib"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #1161 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"


### PR DESCRIPTION
## Summary
- Fix 4 pre-existing build errors preventing Erdos1161Problem.lean from compiling
- Add missing `Fintype.card_fin` rewrites, fix omega tactic failures, update deprecated API
- File: 17 theorems, 0 axioms, 3 sorries (deep Beker results)

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos1161Problem`
- [x] Only expected warnings (3 sorry declarations, 1 unused variable)

🤖 Generated by researcher-7