### PR TITLE
Add audit tracking infrastructure and scale auditors to 3

### DIFF
--- a/.loom/roles/auditor.md
+++ b/.loom/roles/auditor.md
@@ -450,6 +450,79 @@ Ask yourself:
 
 **In addition to build/runtime validation, you MUST audit the proof gallery for overstated claims.** Agents (enricher, researcher) write meta.json files that make claims about proof status, sorry counts, and original contributions. These claims are not validated by the build system and go live unchecked.
 
+> Your job is not to evaluate whether the math is correct. Your job is to ensure that what we say publicly is exactly what the Lean kernel guarantees — no more, no less.
+
+The goal is to **maximize long-term credibility, not short-term impressiveness**. Formal math reputation compounds slowly. Overclaiming compounds negatively.
+
+### Proof Tier Classification
+
+Before reviewing any proof's public wording, classify it into one of these tiers:
+
+**Tier A — Fully formalized theorem**
+All lemmas proved. No axioms, no sorries, no imported deep theorem doing the core work.
+- Allowed: "Fully formalized", "Complete Lean proof", "Machine-verified theorem"
+- Badge: `original` or `from-axioms`
+
+**Tier B — Formalized using Mathlib theorem**
+Core argument relies on a Mathlib theorem. Our file provides definitions, bridge, or infrastructure.
+- Allowed: "Formalized using Mathlib's X", "Infrastructure and bridge formalization", "Derived from existing Mathlib formalization"
+- Forbidden: "First formalization", "We proved X", "Independent proof"
+- Badge: `mathlib`
+
+**Tier C — Scaffold / reduction / axiomatized**
+Core theorem is axiomatized, sketched, or sorry'd.
+- Allowed: "Reduction to remaining lemma", "Formal scaffold", "Program architecture milestone", "Theorem reduced to single axiom"
+- Forbidden: "Theorem formalized", "Complete proof"
+- Badge: `axiom` or `wip`
+
+**Tier D — Infrastructure / toolkit**
+File provides algebraic lemmas, combinatorial infrastructure, or definitions — not a theorem-level result.
+- Allowed: "Structural groundwork", "Proof components", "Reusable infrastructure"
+- Forbidden: Theorem-level claims
+- Badge: `infrastructure`
+
+### Five Narrative Failure Modes to Detect
+
+**1. Delegation opacity** — Core theorem is imported from Mathlib but not explicitly credited. The description or conclusion implies independent proof. **Fix**: First paragraph of overview must state "Relies on Mathlib's X" when applicable.
+
+**2. Axiom masking** — An axiom exists but the title/description doesn't mention it. **Fix**: Title should include "modulo X" or "reduction to X". Example: "Szemerédi's Theorem (Reduction to Hypergraph Regularity Axiom)" not "Szemerédi's Theorem (Full)".
+
+**3. Inequality ≠ theorem** — Proving a threshold inequality or bound is called "formalizing theorem X". **Fix**: Check whether the existential/probabilistic conclusion is actually formalized, not just the quantitative bound.
+
+**4. Pipeline inflation** — Multiple partial steps (regularity wrapper + counting skeleton + Roth scaffold) are summed to claim "full theorem proved". **Fix**: Each file's claims must be scoped to what that file actually proves. Cross-references should connect the pipeline but not inflate individual claims.
+
+**5. "0 sorries" with hidden imports** — File has 0 sorries but obtains its main result by calling a deep Mathlib theorem. Technically sorry-free but misleadingly presented as independent work. **Fix**: Badge must be `mathlib`, not `original` or `verified`. The `assumptions` field should note the dependency.
+
+### Language Precision Rules
+
+When reviewing or rewriting meta.json text, apply these substitutions:
+
+| Instead of | Write | When |
+|------------|-------|------|
+| "Formalized X" | "Formalized infrastructure for X" | Core result comes from Mathlib |
+| "Complete proof" | "Proof modulo Y" | Any axiom or sorry exists |
+| "First formalization" | "To our knowledge, no independent formalization exists" | Unless independently verified |
+| "Proved X" | "Derived X from Mathlib's Y" | Main theorem obtained via Mathlib call |
+| "0 axioms, 0 sorries" | "0 axioms, 0 sorries (core result via Mathlib bridge)" | When Tier B |
+
+### Claim Risk Score
+
+Assign each proof a risk level based on these features:
+
+| Feature | Risk |
+|---------|------|
+| References a Millennium Prize problem | HIGH |
+| Has axioms but claims "verified" | CRITICAL |
+| Heavy Mathlib reliance for core result | MEDIUM |
+| Sorry count > 0 but badge != "wip" | HIGH |
+| Only proves inequalities/bounds, not the theorem | MEDIUM |
+| Title names a famous theorem without qualifier | HIGH |
+
+- **LOW risk**: Publish normally
+- **MEDIUM risk**: Add qualifiers to description/conclusion
+- **HIGH risk**: Rewrite title, description, and conclusion
+- **CRITICAL risk**: Fix immediately, create urgent issue
+
 ### Tracking Scripts
 
 Gallery auditing has its own claim/tracker system, analogous to the enricher's:

--- a/.loom/roles/auditor.md
+++ b/.loom/roles/auditor.md
@@ -448,7 +448,43 @@ Ask yourself:
 
 ## Gallery Integrity Auditing
 
-**In addition to build/runtime validation, you MUST audit the proof gallery for overstated claims.** This is critical — agents (enricher, researcher) write meta.json files that make claims about proof status, sorry counts, and original contributions. These claims are not validated by the build system and go live unchecked.
+**In addition to build/runtime validation, you MUST audit the proof gallery for overstated claims.** Agents (enricher, researcher) write meta.json files that make claims about proof status, sorry counts, and original contributions. These claims are not validated by the build system and go live unchecked.
+
+### Tracking Scripts
+
+Gallery auditing has its own claim/tracker system, analogous to the enricher's:
+
+```bash
+# Find highest-priority targets (issues first, then unaudited)
+npx tsx scripts/auditor/find-targets.ts              # Top 10
+npx tsx scripts/auditor/find-targets.ts --next       # Single highest-priority
+npx tsx scripts/auditor/find-targets.ts --issues     # Only proofs with detected issues
+npx tsx scripts/auditor/find-targets.ts --stats      # Summary statistics
+
+# Claim a target for exclusive audit work
+./scripts/auditor/claim-target.sh claim-next         # Claim highest-priority unclaimed
+./scripts/auditor/claim-target.sh claim <id>         # Claim specific proof
+./scripts/auditor/claim-target.sh status             # Show active claims
+
+# After auditing, mark complete
+./scripts/auditor/claim-target.sh complete <id> clean          # No issues found
+./scripts/auditor/claim-target.sh complete <id> issues-found   # Issues found, filed
+./scripts/auditor/claim-target.sh complete <id> issues-fixed   # Issues found and fixed
+```
+
+The tracker is at `src/data/proofs/audit-tracker.json`. It records which proofs have been audited, when, and the result.
+
+### Audit Workflow
+
+```bash
+# 1. Claim next target
+id=$(./scripts/auditor/claim-target.sh claim-next)
+
+# 2. Read meta.json and Lean source, run integrity checks
+# 3. If issues found: fix meta.json in a PR OR create issue
+# 4. Mark complete with result
+./scripts/auditor/claim-target.sh complete "$id" clean  # or issues-found / issues-fixed
+```
 
 ### What to Check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,11 @@ This project uses **two distinct AI agent orchestration systems** for different 
 | **Scout** | Surveys gallery proofs, techniques, and literature for research problems | On-demand |
 | **Seeker** | Selects research problems when candidate pool runs low | Autonomous (15min) |
 | **Deployer** | Merges PRs, syncs data, deploys website to Cloudflare | Autonomous (30min) |
+| **Auditor** | Validates gallery integrity: checks proof claims match Lean source files | Autonomous (10min) |
 | **Tester** | Tests random proof pages on the live site, files issues on failure | Autonomous (30min) |
 | **Herald** | Posts noteworthy research results to Mathstodon | Autonomous (6h) |
 
-**Managed by `/lean`**: Enricher, Aristotle, Researcher, Seeker, Deployer, Tester, Herald
+**Managed by `/lean`**: Enricher, Aristotle, Researcher, Auditor, Seeker, Deployer, Tester, Herald
 **Managed separately**: Erdos Enhancer (`make enhance`, `scripts/erdos/`)
 
 **Invoke via**: `/enricher`, `/aristotle`, `/research`, `/scout`, `/seeker`, `/deploy`
@@ -128,6 +129,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | Enricher | 2 | 5 |
 | Aristotle | 1 | 2 |
 | Researcher | 2 | 5 |
+| Auditor | 3 | 3 |
 | Seeker | 1 | 1 |
 | Deployer | 1 | 1 |
 | Tester | 1 | 1 |

--- a/research/registry.json
+++ b/research/registry.json
@@ -2351,11 +2351,12 @@
     },
     {
       "slug": "erdos-1103",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-15T15:24:14.877Z",
-      "status": "active",
-      "lastUpdate": "2026-03-13T07:52:17.057Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T05:03:37.723Z",
+      "completed": "2026-03-23T05:03:37.723Z"
     },
     {
       "slug": "erdos-1104",
@@ -2615,11 +2616,12 @@
     },
     {
       "slug": "erdos-1161",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-15T16:53:51.157Z",
-      "status": "active",
-      "lastUpdate": "2026-03-13T07:52:17.059Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T05:03:37.685Z",
+      "completed": "2026-03-23T05:03:37.684Z"
     },
     {
       "slug": "erdos-1162",

--- a/scripts/auditor/claim-target.sh
+++ b/scripts/auditor/claim-target.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+#
+# claim-target.sh - Claim a proof gallery entry for exclusive audit work
+#
+# Usage:
+#   ./claim-target.sh claim-next            # Claim the highest-priority unclaimed target
+#   ./claim-target.sh claim <id>            # Claim a specific entry
+#   ./claim-target.sh complete <id> [clean|issues-found|issues-fixed]  # Mark as completed
+#   ./claim-target.sh release <id>          # Release a claimed entry
+#   ./claim-target.sh status                # Show all claims
+#   ./claim-target.sh cleanup               # Remove stale claims
+#
+# Environment:
+#   AUDITOR_ID  - Agent identifier (default: auditor-PID)
+#   CLAIM_TTL   - Claim time-to-live in minutes (default: 60)
+
+set -euo pipefail
+shopt -s nullglob
+
+# Find repo root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="${REPO_ROOT:-$(find_repo_root)}"
+CLAIMS_DIR="$REPO_ROOT/.lean/state/audit-claims"
+TRACKER_FILE="$REPO_ROOT/src/data/proofs/audit-tracker.json"
+FIND_TARGETS="$REPO_ROOT/scripts/auditor/find-targets.ts"
+
+# Defaults
+TTL_MINUTES="${CLAIM_TTL:-60}"
+AGENT_ID="${AUDITOR_ID:-auditor-$$}"
+
+# Ensure claims directory exists
+mkdir -p "$CLAIMS_DIR"
+
+# Initialize tracker if missing
+if [[ ! -f "$TRACKER_FILE" ]]; then
+    echo '{"version": 1, "entries": {}}' > "$TRACKER_FILE"
+fi
+
+# Calculate timestamps
+get_timestamps() {
+    CLAIMED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    if [[ "$(uname)" == "Darwin" ]]; then
+        EXPIRES_AT=$(date -u -v+${TTL_MINUTES}M +"%Y-%m-%dT%H:%M:%SZ")
+    else
+        EXPIRES_AT=$(date -u -d "+${TTL_MINUTES} minutes" +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+}
+
+# Check if a claim is still valid (not expired)
+is_claim_valid() {
+    local claim_file="$1"
+    if [[ ! -f "$claim_file" ]]; then
+        return 1
+    fi
+    local expires
+    expires=$(python3 -c "import json; print(json.load(open('$claim_file'))['expiresAt'])")
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    [[ "$now" < "$expires" ]]
+}
+
+# Claim a specific target
+do_claim() {
+    local id="$1"
+    local claim_file="$CLAIMS_DIR/$id.json"
+
+    # Check if already claimed by someone else
+    if is_claim_valid "$claim_file" 2>/dev/null; then
+        local owner
+        owner=$(python3 -c "import json; print(json.load(open('$claim_file'))['agentId'])")
+        echo "Already claimed by $owner" >&2
+        return 1
+    fi
+
+    get_timestamps
+    python3 -c "
+import json
+claim = {
+    'proofId': '$id',
+    'agentId': '$AGENT_ID',
+    'claimedAt': '$CLAIMED_AT',
+    'expiresAt': '$EXPIRES_AT'
+}
+with open('$claim_file', 'w') as f:
+    json.dump(claim, f, indent=2)
+"
+    echo "$id"
+}
+
+# Claim the next highest-priority unclaimed target
+do_claim_next() {
+    # Get all targets sorted by priority
+    local targets
+    targets=$(npx tsx "$FIND_TARGETS" --json 2>/dev/null || echo "[]")
+
+    # Find first unclaimed
+    local id
+    id=$(python3 -c "
+import json, os
+targets = json.loads('''$targets''')
+claims_dir = '$CLAIMS_DIR'
+for t in targets:
+    claim_file = os.path.join(claims_dir, t['id'] + '.json')
+    if os.path.exists(claim_file):
+        try:
+            claim = json.load(open(claim_file))
+            import datetime
+            expires = datetime.datetime.fromisoformat(claim['expiresAt'].replace('Z', '+00:00'))
+            if datetime.datetime.now(datetime.timezone.utc) < expires:
+                continue  # Still claimed
+        except:
+            pass
+    print(t['id'])
+    break
+" 2>/dev/null)
+
+    if [[ -z "$id" ]]; then
+        echo "No unclaimed targets available" >&2
+        return 1
+    fi
+
+    do_claim "$id"
+}
+
+# Complete an audit and update tracker
+do_complete() {
+    local id="$1"
+    local result="${2:-clean}"
+    local claim_file="$CLAIMS_DIR/$id.json"
+
+    # Update tracker
+    python3 -c "
+import json
+from datetime import datetime, timezone
+
+tracker_file = '$TRACKER_FILE'
+with open(tracker_file) as f:
+    tracker = json.load(f)
+
+entry = tracker['entries'].get('$id', {
+    'auditCount': 0,
+    'lastAudited': None,
+    'result': None,
+    'issues': []
+})
+entry['auditCount'] = entry.get('auditCount', 0) + 1
+entry['lastAudited'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+entry['result'] = '$result'
+tracker['entries']['$id'] = entry
+
+with open(tracker_file, 'w') as f:
+    json.dump(tracker, f, indent=2)
+"
+
+    # Remove claim
+    rm -f "$claim_file"
+    echo "Completed audit of $id (result: $result)"
+}
+
+# Release a claim without completing
+do_release() {
+    local id="$1"
+    rm -f "$CLAIMS_DIR/$id.json"
+    echo "Released claim on $id"
+}
+
+# Show all active claims
+do_status() {
+    echo "Active audit claims:"
+    local count=0
+    for claim_file in "$CLAIMS_DIR"/*.json; do
+        if is_claim_valid "$claim_file" 2>/dev/null; then
+            python3 -c "
+import json
+c = json.load(open('$claim_file'))
+print(f\"  {c['proofId']} -> {c['agentId']} (expires {c['expiresAt']})\")
+"
+            count=$((count + 1))
+        fi
+    done
+    echo "Total: $count active claims"
+}
+
+# Remove expired claims
+do_cleanup() {
+    local removed=0
+    for claim_file in "$CLAIMS_DIR"/*.json; do
+        if ! is_claim_valid "$claim_file" 2>/dev/null; then
+            rm -f "$claim_file"
+            removed=$((removed + 1))
+        fi
+    done
+    echo "Cleaned up $removed expired claims"
+}
+
+# Main dispatch
+case "${1:-help}" in
+    claim-next) do_claim_next ;;
+    claim)      do_claim "${2:?Usage: claim-target.sh claim <id>}" ;;
+    complete)   do_complete "${2:?Usage: claim-target.sh complete <id> [result]}" "${3:-clean}" ;;
+    release)    do_release "${2:?Usage: claim-target.sh release <id>}" ;;
+    status)     do_status ;;
+    cleanup)    do_cleanup ;;
+    help|*)
+        echo "Usage: claim-target.sh {claim-next|claim <id>|complete <id> [result]|release <id>|status|cleanup}"
+        ;;
+esac

--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env npx tsx
+/**
+ * Find proof gallery entries that need integrity auditing
+ *
+ * Reads all proof directories, joins with audit tracker,
+ * checks Lean source files for integrity issues, and returns
+ * priority-sorted list of proofs needing audit.
+ *
+ * Checks performed:
+ * - True stubs: theorems proving `True` (`:= trivial`, `: True :=`)
+ * - Sorry count: compare meta.json sorries vs actual Lean file
+ * - Axiom count: compare meta.json axiomCount vs actual Lean file
+ * - Status consistency: "verified" requires 0 sorries + 0 True stubs
+ * - Badge consistency: Mathlib wrapper detection
+ *
+ * Priority: never-audited first, then oldest audit, then highest risk
+ *
+ * Usage:
+ *   npx tsx scripts/auditor/find-targets.ts           # Show top 10 targets
+ *   npx tsx scripts/auditor/find-targets.ts --all     # Show all targets
+ *   npx tsx scripts/auditor/find-targets.ts --json    # Output as JSON
+ *   npx tsx scripts/auditor/find-targets.ts --stats   # Show statistics only
+ *   npx tsx scripts/auditor/find-targets.ts --next    # Show single highest-priority target
+ *   npx tsx scripts/auditor/find-targets.ts --issues   # Show only proofs with detected issues
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { execSync } from 'child_process'
+
+const GALLERY_DIR = 'src/data/proofs'
+const TRACKER_FILE = 'src/data/proofs/audit-tracker.json'
+const PROOFS_DIR = 'proofs/Proofs'
+
+interface TrackerEntry {
+  auditCount: number
+  lastAudited: string | null
+  result: 'clean' | 'issues-found' | 'issues-fixed' | null
+  issues: string[]
+}
+
+interface Tracker {
+  version: number
+  entries: Record<string, TrackerEntry>
+}
+
+interface AuditTarget {
+  id: string
+  galleryPath: string
+  leanPath: string | null
+  auditCount: number
+  lastAudited: string | null
+  priority: number
+  detectedIssues: string[]
+  meta: {
+    status: string
+    badge: string
+    claimedSorries: number
+    claimedAxioms: number
+  }
+  actual: {
+    sorryCount: number
+    axiomCount: number
+    trueStubCount: number
+    hasMajorMathlibDep: boolean
+  }
+}
+
+function loadTracker(): Tracker {
+  if (fs.existsSync(TRACKER_FILE)) {
+    try {
+      return JSON.parse(fs.readFileSync(TRACKER_FILE, 'utf-8'))
+    } catch {
+      // Corrupted file, start fresh
+    }
+  }
+  return { version: 1, entries: {} }
+}
+
+function countInFile(filePath: string, pattern: RegExp): number {
+  if (!fs.existsSync(filePath)) return 0
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const matches = content.match(pattern)
+  return matches ? matches.length : 0
+}
+
+function detectIssues(target: AuditTarget): string[] {
+  const issues: string[] = []
+
+  // True stub detection
+  if (target.actual.trueStubCount > 0 && target.meta.status === 'verified') {
+    issues.push(`CRITICAL: ${target.actual.trueStubCount} True stubs but status is "verified"`)
+  }
+
+  // Sorry count mismatch
+  if (target.meta.claimedSorries !== target.actual.sorryCount) {
+    issues.push(`sorry mismatch: claims ${target.meta.claimedSorries}, actual ${target.actual.sorryCount}`)
+  }
+
+  // Axiom count mismatch
+  if (target.meta.claimedAxioms >= 0 && target.meta.claimedAxioms !== target.actual.axiomCount) {
+    issues.push(`axiom mismatch: claims ${target.meta.claimedAxioms}, actual ${target.actual.axiomCount}`)
+  }
+
+  // Verified with sorries
+  if (target.meta.status === 'verified' && target.actual.sorryCount > 0) {
+    issues.push(`status "verified" but has ${target.actual.sorryCount} sorries`)
+  }
+
+  // Mathlib wrapper with "original" or "verified" badge
+  if (target.actual.hasMajorMathlibDep &&
+      (target.meta.badge === 'original' || target.meta.badge === 'verified')) {
+    issues.push(`badge "${target.meta.badge}" but directly calls major Mathlib theorem`)
+  }
+
+  return issues
+}
+
+function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditTarget | null {
+  const metaPath = path.join(galleryPath, 'meta.json')
+  if (!fs.existsSync(metaPath)) return null
+
+  let meta: any
+  try {
+    meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'))
+  } catch {
+    return null
+  }
+
+  const proofMeta = meta.meta || {}
+  const leanFileRaw = proofMeta.leanFile || proofMeta.proofRepoPath || ''
+  const leanFile = typeof leanFileRaw === 'string' ? leanFileRaw : ''
+  const leanPath = leanFile ? path.join('proofs', leanFile.replace(/^proofs\//, '')) : null
+
+  // Actual counts from Lean file
+  let sorryCount = 0
+  let axiomCount = 0
+  let trueStubCount = 0
+  let hasMajorMathlibDep = false
+
+  if (leanPath && fs.existsSync(leanPath)) {
+    const content = fs.readFileSync(leanPath, 'utf-8')
+    sorryCount = (content.match(/\bsorry\b/g) || []).length
+    axiomCount = (content.match(/^axiom /gm) || []).length
+    trueStubCount = (content.match(/:= trivial|: True :=|: True\b.*:= by\b/g) || []).length
+
+    // Check if major Mathlib theorems from dependencies are directly called
+    const deps = proofMeta.mathlibDependencies || []
+    for (const dep of deps) {
+      const theorem = dep.theorem || ''
+      if (theorem && theorem.includes('_') && content.includes(theorem)) {
+        hasMajorMathlibDep = true
+        break
+      }
+    }
+  }
+
+  const trackerEntry = tracker.entries[id]
+  const auditCount = trackerEntry?.auditCount || 0
+  const lastAudited = trackerEntry?.lastAudited || null
+
+  const target: AuditTarget = {
+    id,
+    galleryPath,
+    leanPath,
+    auditCount,
+    lastAudited,
+    priority: 0,
+    detectedIssues: [],
+    meta: {
+      status: proofMeta.status || 'unknown',
+      badge: proofMeta.badge || 'unknown',
+      claimedSorries: proofMeta.sorries ?? -1,
+      claimedAxioms: proofMeta.axiomCount ?? -1,
+    },
+    actual: {
+      sorryCount,
+      axiomCount,
+      trueStubCount,
+      hasMajorMathlibDep,
+    },
+  }
+
+  target.detectedIssues = detectIssues(target)
+
+  // Priority: issues first, then never-audited, then oldest audit
+  const hasIssues = target.detectedIssues.length > 0
+  const hasCritical = target.detectedIssues.some(i => i.startsWith('CRITICAL'))
+  const daysSinceAudit = lastAudited
+    ? (Date.now() - new Date(lastAudited).getTime()) / (1000 * 60 * 60 * 24)
+    : 999
+
+  if (hasCritical) target.priority = 10000
+  else if (hasIssues) target.priority = 5000 + daysSinceAudit
+  else if (auditCount === 0) target.priority = 1000 + daysSinceAudit
+  else target.priority = daysSinceAudit
+
+  return target
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const showAll = args.includes('--all')
+  const showJson = args.includes('--json')
+  const showStats = args.includes('--stats')
+  const showNext = args.includes('--next')
+  const showIssues = args.includes('--issues')
+
+  const tracker = loadTracker()
+  const targets: AuditTarget[] = []
+
+  // Scan gallery
+  if (!fs.existsSync(GALLERY_DIR)) {
+    console.error(`Gallery directory not found: ${GALLERY_DIR}`)
+    process.exit(1)
+  }
+
+  for (const entry of fs.readdirSync(GALLERY_DIR)) {
+    const galleryPath = path.join(GALLERY_DIR, entry)
+    if (!fs.statSync(galleryPath).isDirectory()) continue
+    if (entry === 'node_modules') continue
+
+    const target = analyzeProof(entry, galleryPath, tracker)
+    if (target) targets.push(target)
+  }
+
+  // Sort by priority (highest first)
+  targets.sort((a, b) => b.priority - a.priority)
+
+  // Filter to issues only if requested
+  const display = showIssues
+    ? targets.filter(t => t.detectedIssues.length > 0)
+    : targets
+
+  if (showStats) {
+    const total = targets.length
+    const audited = targets.filter(t => t.auditCount > 0).length
+    const withIssues = targets.filter(t => t.detectedIssues.length > 0).length
+    const critical = targets.filter(t => t.detectedIssues.some(i => i.startsWith('CRITICAL'))).length
+
+    if (showJson) {
+      console.log(JSON.stringify({ total, audited, unaudited: total - audited, withIssues, critical }))
+    } else {
+      console.log(`Gallery Audit Status:`)
+      console.log(`  Total proofs:     ${total}`)
+      console.log(`  Audited:          ${audited}`)
+      console.log(`  Unaudited:        ${total - audited}`)
+      console.log(`  With issues:      ${withIssues}`)
+      console.log(`  Critical issues:  ${critical}`)
+    }
+    return
+  }
+
+  if (showNext) {
+    if (display.length === 0) {
+      console.log('No targets need auditing.')
+      return
+    }
+    const t = display[0]
+    if (showJson) {
+      console.log(JSON.stringify(t))
+    } else {
+      console.log(t.id)
+    }
+    return
+  }
+
+  const limit = showAll ? display.length : 10
+  const shown = display.slice(0, limit)
+
+  if (showJson) {
+    console.log(JSON.stringify(shown, null, 2))
+    return
+  }
+
+  console.log(`Top ${shown.length} audit targets (of ${display.length} total):\n`)
+  for (const t of shown) {
+    const issues = t.detectedIssues.length > 0
+      ? ` ❌ ${t.detectedIssues.join('; ')}`
+      : ' ✓'
+    const audited = t.auditCount > 0
+      ? `(${t.auditCount}x, last ${t.lastAudited?.slice(0, 10)})`
+      : '(never audited)'
+    console.log(`  ${t.id} ${audited} [${t.meta.status}/${t.meta.badge}]${issues}`)
+  }
+}
+
+main()

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": {}
+}


### PR DESCRIPTION
## Summary

- **Audit tracker** (`src/data/proofs/audit-tracker.json`): Tracks which proofs have been audited, when, and the result — same pattern as `enrichment-tracker.json`
- **find-targets.ts**: Scans all 1491 proofs for integrity issues. Detects True stubs, sorry/axiom mismatches, Mathlib wrapper badge issues. Prioritizes by severity then audit recency. Initial scan: 222 issues, 6 critical.
- **claim-target.sh**: Claim/release/complete system for concurrent auditors, prevents duplicate work across 3 agents
- **Auditor pool**: Added to CLAUDE.md pool limits at 3 default / 3 max
- **Auditor role**: Updated with tracking workflow documentation

## Auditor workflow

```bash
# Each auditor iteration:
id=$(./scripts/auditor/claim-target.sh claim-next)
# ... audit proof, check meta.json vs Lean source ...
./scripts/auditor/claim-target.sh complete "$id" clean  # or issues-found/issues-fixed
```

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` works (1491 proofs, 222 issues, 6 critical)
- [x] Claim system creates/reads/removes claim files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)