### PR TITLE
Enrich 3 entries: Abel-Ruffini (×2) + angle-trisection-oq-02

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02/annotations.json
@@ -83,7 +83,7 @@
     },
     "type": "technique",
     "title": "Wantzel-Galois Theorem: Constructibility ↔ 2-Group Galois",
-    "content": "`wantzel_galois_characterization` is the main axiom: `IsConstructibleFromQ α ↔ IsPGroup 2 (minpoly ℚ α).Gal`. The docstring explains both proof directions: (→) α in a degree-2 tower gives a splitting field K with [K:ℚ] = 2^m, so Gal(K/ℚ) is a 2-group, and Gal(minpoly) embeds as a subgroup. (←) A 2-group Galois group has a composition series with ℤ/2ℤ quotients — by the Galois correspondence, this gives a degree-2 extension tower, so α is constructible. Axiomatized because the full proof needs the Galois correspondence.",
+    "content": "`wantzel_galois_characterization` is the main axiom: `IsConstructibleFromQ α ↔ IsPGroup 2 (minpoly ℚ α).Gal`. The docstring explains both proof directions: (→) α in a degree-2 tower gives a splitting field K with [K:ℚ] = 2^m, so Gal(K/ℚ) is a 2-group, and Gal(minpoly) embeds as a subgroup. (←) A 2-group Galois group has a composition series with ℤ/2ℤ quotients — by the Galois correspondence, this gives a degree-2 extension tower, so α is constructible. Axiomatized because the full proof needs the Galois correspondence.\n\n**Hierarchy of expressibility:** Constructibility (2-group Galois) is strictly more restrictive than solvability by radicals (solvable Galois group, per Abel-Ruffini). Every 2-group is solvable (composition factors are ℤ/2ℤ, which is abelian), but not every solvable group is a 2-group. Example: Gal(x⁵-2/ℚ) ≅ F₂₀ (Frobenius group of order 20 = 4·5) is solvable (with derived series F₂₀ ▷ ℤ/5ℤ ▷ {e}), so ⁵√2 is solvable by radicals, but F₂₀ is not a 2-group, so ⁵√2 is NOT constructible.\n\n**Fermat prime connection:** For the celebrated regular polygon problem: cos(2π/p) is constructible iff Gal(ℚ(ζₚ)/ℚ) ≅ ℤ/(p-1)ℤ is a 2-group, i.e., p-1 = 2ⁿ, i.e., p is a Fermat prime. Only 5 Fermat primes are known (3, 5, 17, 257, 65537), and it remains open whether there are finitely or infinitely many.",
     "mathContext": "**Wantzel-Galois**: $\\alpha \\in \\mathbb{R}$ algebraic over $\\mathbb{Q}$ is constructible $\\iff$ $\\text{Gal}(\\text{minpoly}(\\mathbb{Q}, \\alpha)/\\mathbb{Q})$ is a 2-group. Proof sketch ($\\Leftarrow$): 2-groups are solvable; by Jordan-Hölder, composition factors are $\\mathbb{Z}/2\\mathbb{Z}$; by Galois correspondence, each factor corresponds to a degree-2 extension — exactly what compass-and-straightedge produces. The `.Gal` in `(minpoly ℚ α).Gal` is `Polynomial.Gal`: the Galois group of the splitting field of a polynomial over the base field.",
     "significance": "key",
     "prerequisites": [
@@ -98,7 +98,10 @@
       "Galois correspondence",
       "composition series",
       "solvable group",
-      "ℤ/2ℤ factors"
+      "ℤ/2ℤ factors",
+      "Fermat primes",
+      "regular polygon constructibility",
+      "expressibility hierarchy"
     ]
   },
   {

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -201,7 +201,8 @@
       "Non-constructibility proof technique: Gal(p/ℚ) has order 6 = 2·3, not a power of 2. Key: 3 | 6 but gcd(3,2) = 1, so 3 ∤ 2^n → 6 ≠ 2^n",
       "∛2 is not constructible because Gal(x³-2/ℚ) ≅ S₃ has order 6 (not a 2-power). cos(20°) is not constructible because Gal(8x³-6x-1/ℚ) ≅ ℤ/3ℤ has order 3 (also not a 2-power)",
       "Module.finrank ℚ K (not `finrank` or `IsFiniteDimensional`) is the correct Mathlib4 API for field extension degree",
-      "The Gauss-Wantzel theorem (regular $n$-gon constructible $\\iff \\phi(n) = 2^k$) is a special case: $\\text{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^\\times$ has order $\\phi(n)$, and this is a 2-group iff $\\phi(n) = 2^k$ iff $n = 2^a p_1 \\cdots p_m$ with distinct Fermat primes $p_i = 2^{2^{e_i}} + 1$. Only 5 Fermat primes are known (3, 5, 17, 257, 65537), so the full list of constructible regular polygons is still unknown"
+      "The Gauss-Wantzel theorem (regular $n$-gon constructible $\\iff \\phi(n) = 2^k$) is a special case: $\\text{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^\\times$ has order $\\phi(n)$, and this is a 2-group iff $\\phi(n) = 2^k$ iff $n = 2^a p_1 \\cdots p_m$ with distinct Fermat primes $p_i = 2^{2^{e_i}} + 1$. Only 5 Fermat primes are known (3, 5, 17, 257, 65537), so the full list of constructible regular polygons is still unknown",
+      "Constructibility sits within a strict hierarchy of expressibility: constructible numbers (Galois group is a 2-group) $\\subsetneq$ numbers solvable by radicals (Galois group is solvable) $\\subsetneq$ algebraic numbers $\\subsetneq$ all real numbers. Abel-Ruffini characterizes the second class, while this file characterizes the first — the same Galois-theoretic framework governs both, with the only difference being the group property tested (2-group vs solvable). This hierarchy explains why $\\sqrt[4]{2}$ is constructible (D₄ is a 2-group, hence also solvable), $\\sqrt[5]{2}$ is solvable by radicals but not constructible (Gal ≅ F₂₀ is solvable but not a 2-group), and the generic quintic root is none of these (S₅ is not solvable)"
     ],
     "prerequisites": [
       "Galois theory: Galois groups, the Galois correspondence between subgroups and intermediate fields",
@@ -290,7 +291,8 @@
     "openQuestions": [
       "Can wantzel_galois_characterization be proved from Mathlib's existing Galois theory infrastructure?",
       "Can cos20_gal_order (|Gal(8x³-6x-1/ℚ)| = 3) be proved? The discriminant 72² is a perfect square, so this follows from the criterion for cubic Galois groups.",
-      "Can the Gauss-Wantzel theorem (regular n-gon constructible ↔ φ(n) = 2^k) be formalized in Lean 4?"
+      "Can the Gauss-Wantzel theorem (regular n-gon constructible ↔ φ(n) = 2^k) be formalized in Lean 4?",
+      "Can we formalize the connection between the Fermat prime conjecture and constructible regular polygons? Since only 5 Fermat primes are known (3, 5, 17, 257, 65537) and the conjecture that there are finitely many remains open, a formalization could establish the conditional: if there are only finitely many Fermat primes, then only finitely many odd-sided regular polygons are constructible"
     ]
   },
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for three related Galois theory entries, adding geometric depth and expressibility hierarchy.

## abel-ruffini (pass 1)
- Added geometric interpretation of A₅ ≅ Rot(Icosahedron) to A₅ simplicity annotation
- New keyInsight on icosahedral connection and Klein's quintic solution (1884)
- Added Klein's *Vorlesungen über das Ikosaeder* reference

## abel-ruffini-oq-04 (pass 2)
- Added geometric interpretation of A₅ ≅ Rot(Icosahedron) with SO(3) representation
- New keyInsight on Klein's icosahedral quintic solution
- New openQuestion on formalizing Klein's approach via PSL(2, F₅)
- Enriched threshold annotation with outer automorphism of S₆ (|Out(S₆)| = 2)

## angle-trisection-oq-02 (pass 1)
- New keyInsight: constructible ⊂ solvable by radicals ⊂ algebraic (with concrete example: ⁵√2)
- Deepened Wantzel-Galois annotation with expressibility hierarchy and Fermat prime connection
- New openQuestion on Fermat prime conjecture and constructible regular polygons

All entries already quality 100; changes add geometric depth and cross-framework connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)