### PR TITLE
Enrich batch: erdos-1146, erdos-1147, erdos-557 - cross-refs, references, deeper annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -311,7 +311,9 @@
     "prerequisites": [
       "Group theory: normal subgroups, derived series, solvability, and the relationship between subgroups and quotient solvability",
       "Alternating and symmetric groups: $S_n$, $A_n = \\ker(\\text{sign})$, cycle types, and the embedding $A_5 \\hookrightarrow A_n$ for $n \\geq 5$",
-      "Galois theory fundamentals: field extensions, Galois groups, and the connection between radical solvability and group solvability (for the full chain context)"
+      "Galois theory fundamentals: field extensions, Galois groups, and the connection between radical solvability and group solvability (for the full chain context)",
+      "Lean 4 type coercions: `exact_mod_cast` for converting between $\\mathbb{N}$ and `Cardinal` types, and `inferInstance` for automatic typeclass resolution of solvability instances",
+      "Classification context: the role of $A_5 \\cong \\text{PSL}(2,4) \\cong \\text{PSL}(2,5)$ as the smallest non-abelian simple group and first member of the alternating simple family $\\{A_n : n \\geq 5\\}$"
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary
- **erdos-1146**: 5→8 annotations, 7 crossReferences, 5 references, mathContext for all sections. Added membership, non-lacunary, growth rate annotations.
- **erdos-1147**: 5→8 annotations, 6 crossReferences, 4 references, mathContext for all sections. Added Diophantine sets, threshold, √2 counterexample annotations.
- **erdos-557**: 3 crossReferences, 4 references, mathContext for all 6 sections. Added prerequisites, relatedProblems.

## Test plan
- [x] JSON validation passes for all files
- [x] `pnpm build` annotations step passes (pre-existing errors unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)