### PR TITLE
Enrich batch: 21 proofs - significance fixes, references, prerequisites, history

### DIFF
--- a/src/data/proofs/schroeder-bernstein/meta.json
+++ b/src/data/proofs/schroeder-bernstein/meta.json
@@ -60,6 +60,12 @@
       "The orbit partition approach shows every element has a well-defined 'origin'",
       "This theorem fails for many other structures (e.g., groups, rings)",
       "The result is equivalent to the law of excluded middle (assuming infinity axiom)"
+    ],
+    "prerequisites": [
+      "Set theory: injections $f: A \\hookrightarrow B$, surjections, bijections, and the Cantor-Bernstein ordering $|A| \\leq |B|$ iff $\\exists$ injection $A \\to B$",
+      "Cardinal arithmetic: the antisymmetry property $|A| \\leq |B|$ and $|B| \\leq |A|$ implies $|A| = |B|$ (which is exactly this theorem)",
+      "Fixed-point theory: the proof constructs a fixed point of a monotone operator on $\\mathcal{P}(A)$ using the Knaster-Tarski theorem or explicit iteration",
+      "Classical logic: the result requires the law of excluded middle (it is not constructively valid without choice-like axioms)"
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary
Systematic enrichment pass fixing common quality gaps across 21 proof entries.

### Schema fixes
- **abel-ruffini**: Fixed 4 annotations with invalid `"significance": "critical"` → `"key"`

### Missing references
- **angle-trisection**: Added 6 top-level references in standard format

### Empty prerequisites (systemic gap - ~1375 entries affected)
Added 4 mathematically substantive prerequisites to each of 17 entries:
- **area-of-circle**, **ballot-problem**, **basel-problem**, **bertrands-postulate**
- **birthday-problem**, **binomial-theorem**, **brouwer-fixed-point**, **cauchy-schwarz**
- **cantor-diagonalization**, **fundamental-theorem-calculus**, **infinitude-primes**
- **pythagorean-theorem**, **sqrt2-irrational**, **godel-incompleteness**, **halting-problem**
- **fundamental-theorem-algebra**, **fermats-last-theorem**, **prime-number-theorem**

### Deepened content
- **arithmetic-series**: Expanded historicalContext with Pythagorean, Indian (Āryabhaṭa), Chinese (Zhu Shijie) sources

### Also enriched (earlier in branch)
- **amgm-inequality**: Added prerequisites, Newton cross-reference, Niculescu & Persson reference
- **abel-ruffini-oq-04**: Added Lean coercion and CFSG classification prerequisites

## Test plan
- [x] All meta.json files validate as JSON
- [x] `pnpm build` passes (verified on amgm-inequality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)