### PR TITLE
Enrich birthday-problem: add prerequisites and mathContext

### DIFF
--- a/src/data/proofs/birthday-problem/annotations.source.json
+++ b/src/data/proofs/birthday-problem/annotations.source.json
@@ -8,11 +8,16 @@
     "type": "concept",
     "title": "The Birthday Paradox",
     "content": "The **Birthday Problem** asks: How many people must be in a room for there to be a >50% chance that two share a birthday?\n\nThe surprising answer: **just 23 people**.\n\nMost people guess much higher (like 183, half of 365), because they confuse two different questions:\n- 'What's the chance someone shares MY birthday?' (needs ~253 people for 50%)\n- 'What's the chance ANY two people share A birthday?' (needs only 23)\n\nThe second question has many more pairs to check!",
+    "mathContext": "The probability that at least two of $n$ people share a birthday is $P(n) = 1 - \\prod_{k=0}^{n-1}(1 - k/365)$. The 'paradox' is that $P(23) > 0.5$ despite $23 \\ll 365$.",
     "significance": "critical",
     "relatedConcepts": [
       "probability",
       "combinatorics",
       "complement counting"
+    ],
+    "prerequisites": [
+      "basic probability",
+      "complement rule"
     ]
   },
   {
@@ -31,6 +36,10 @@
     "relatedConcepts": [
       "falling factorial",
       "product formula"
+    ],
+    "prerequisites": [
+      "Nat.descFactorial",
+      "rational arithmetic"
     ]
   },
   {
@@ -44,12 +53,16 @@
     "type": "concept",
     "title": "Counting Injective Functions",
     "content": "The number of ways for $n$ people to have **all distinct** birthdays equals the number of **injective functions** from an $n$-element set to a 365-element set.\n\nThis is the **falling factorial**:\n$$365^{\\underline{n}} = 365 \\times 364 \\times \\cdots \\times (365-n+1)$$\n\nIn Lean, this is `Nat.descFactorial 365 n`.\n\n**Why it works**: Person 1 has 365 choices, person 2 has 364 remaining choices, etc.",
-    "mathContext": "$|\\text{injections}| = 365^{\\underline{n}}$",
+    "mathContext": "$|\\text{injections}| = 365^{\\underline{n}} = \\frac{365!}{(365-n)!}$",
     "significance": "key",
     "relatedConcepts": [
       "injective functions",
       "falling factorial",
       "permutations"
+    ],
+    "prerequisites": [
+      "Nat.descFactorial",
+      "counting principles"
     ]
   },
   {
@@ -63,11 +76,15 @@
     "type": "theorem",
     "title": "The Pigeonhole Case",
     "content": "**When $n > 365$**: By the pigeonhole principle, at least two people MUST share a birthday.\n\nWith 366+ people and only 365 possible birthdays, there's no way to assign distinct birthdays to everyone.\n\nMathematically: `descFactorial 365 n = 0` when $n > 365$, so:\n$$P(n) = 1 - \\frac{0}{365^n} = 1$$\n\nThe probability is exactly 1 (certain).",
-    "mathContext": "If $n > 365$, then $P(n) = 1$",
+    "mathContext": "If $n > 365$, then $365^{\\underline{n}} = 0$ (the falling factorial includes a factor of 0), so $P(n) = 1 - 0/365^n = 1$.",
     "significance": "key",
     "relatedConcepts": [
       "pigeonhole principle",
       "certainty"
+    ],
+    "prerequisites": [
+      "pigeonhole principle",
+      "Nat.descFactorial_eq_zero"
     ]
   },
   {
@@ -81,11 +98,15 @@
     "type": "theorem",
     "title": "The 23-Person Threshold",
     "content": "**The Famous Result**: With 23 people, P(shared birthday) > 50%.\n\nNumerically:\n- $P(22) \\approx 0.4757 < 0.5$\n- $P(23) \\approx 0.5073 > 0.5$\n\nSo 23 is the exact threshold where shared birthdays become more likely than not.\n\n**Note**: This is stated as an axiom in Lean because computing the exact rational requires arithmetic on ~50-digit numbers, which native_decide cannot handle efficiently.",
-    "mathContext": "$P(23) \\approx 50.73\\% > 50\\%$",
+    "mathContext": "$P(23) = 1 - \\frac{365!}{365^{23} \\cdot 342!} \\approx 0.5073 > 0.5$. The exact computation involves $365^{23} \\approx 8.6 \\times 10^{58}$.",
     "significance": "critical",
     "relatedConcepts": [
       "threshold",
       "probability"
+    ],
+    "prerequisites": [
+      "birthday_problem_formula",
+      "rational arithmetic"
     ]
   },
   {
@@ -98,11 +119,16 @@
     "type": "insight",
     "title": "The Birthday Attack",
     "content": "The Birthday Problem has serious implications for **cryptography**:\n\nA **birthday attack** exploits this mathematics to find hash collisions. For a hash function with $n$-bit output:\n- Naive collision search: $O(2^n)$ attempts\n- Birthday attack: $O(2^{n/2})$ attempts\n\nThis is why hash functions need outputs twice as long as the desired security level. A 256-bit hash provides only 128 bits of collision resistance.",
+    "mathContext": "For a hash function $H: \\{0,1\\}^* \\to \\{0,1\\}^n$, the birthday bound gives collision probability $> 50\\%$ after $\\approx 2^{n/2}$ random inputs. This is the square root of the output space, directly analogous to needing $\\sqrt{365} \\approx 19$ people (close to 23) for a birthday collision.",
     "significance": "key",
     "relatedConcepts": [
       "cryptography",
       "hash functions",
       "collision resistance"
+    ],
+    "prerequisites": [
+      "birthday problem formula",
+      "hash function basics"
     ]
   },
   {
@@ -121,6 +147,10 @@
     "relatedConcepts": [
       "base case",
       "complement probability"
+    ],
+    "prerequisites": [
+      "birthday_problem_formula",
+      "Nat.descFactorial"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- Added missing `prerequisites` field to all 7 annotations
- Added missing `mathContext` to `ann-intro` and `ann-crypto`
- Enhanced `ann-crypto` mathContext with birthday bound formula connecting to hash collision resistance

## Test plan
- [x] Valid JSON verified
- [x] Only `birthday-problem/annotations.source.json` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)