### PR TITLE
Enrich abel-ruffini + abel-ruffini-oq-04: fix annotation types, add cross-refs

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -75,7 +75,7 @@
     "title": "Solvable by Radicals and Field Variables",
     "content": "An element α is 'solvable by radicals' if it can be built from the base field using field operations and nth roots. The quadratic formula is an example: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$\n\nMathlib defines this inductively via `IsSolvableByRad`, with constructors for: base field elements, arithmetic operations (+, -, ×, ÷), and radical extraction ($\\alpha \\mapsto \\alpha^{1/n}$). The intermediate field `solvableByRad F E` is the largest subfield of $E$ whose elements are all solvable by radicals over $F$.\n\nThe variable declarations introduce a universe-polymorphic framework: `F` is an arbitrary field and `E/F` is a field extension with `[Algebra F E]`. This generality means the development applies to any characteristic, though the classical Abel-Ruffini theorem is typically stated over $\\mathbb{Q}$.",
     "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over $F$. Formally, $\\alpha \\in \\text{solvableByRad}(F, E)$ iff there exists a radical tower $F = K_0 \\subset K_1 \\subset \\cdots \\subset K_m$ with $\\alpha \\in K_m$ and each $K_{i+1} = K_i(\\beta_i)$ where $\\beta_i^{n_i} \\in K_i$.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by the tower $\\mathbb{Q} \\subset \\mathbb{Q}(\\sqrt{2}) \\subset \\mathbb{Q}(\\sqrt{2}, \\sqrt{1+\\sqrt{2}})$.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": [
       "field extensions",
       "nth roots",
@@ -124,7 +124,7 @@
     "title": "The Galois Bridge Theorem",
     "content": "**Theorem**: If α is expressible using radicals, then the Galois group of its minimal polynomial is solvable.\n\nThis is the key bridge: radical solvability (field theory) → group solvability (group theory).\n\nThe Lean proof is a one-liner: `solvableByRad.isSolvable' hq hroot hrad`. Internally, Mathlib proves this by induction on the `IsSolvableByRad` construction: each radical step $K_i \\to K_i(\\sqrt[n]{a})$ yields a cyclic (hence abelian) Galois group quotient, and a group built from abelian quotients is solvable. The hypotheses `hq : Irreducible q`, `hroot : aeval α q = 0`, and `hrad : IsSolvableByRad F α` are passed directly to Mathlib's lemma — the theorem is a pedagogical wrapper making the bridge explicit.",
     "mathContext": "$\\alpha \\in \\text{solvableByRad}(F, E) \\Rightarrow \\text{IsSolvable}(\\text{Gal}(\\text{minpoly}_F(\\alpha)))$\n\nContrapositive (used in `not_solvable_by_rad_of_not_solvable_gal`): $\\neg\\text{IsSolvable}(\\text{Gal}(q)) \\Rightarrow \\neg\\text{IsSolvableByRad}\\,F\\,\\alpha$.\n\nThe converse ($\\Leftarrow$) also holds: given a solvable Galois group, one constructs a radical tower from the composition series $\\{e\\} = G_n \\triangleleft \\cdots \\triangleleft G_0 = G$ where each $G_i/G_{i+1}$ is cyclic, using Kummer theory to extract the radical at each step.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": [
       "field extensions",
       "Galois theory",
@@ -219,7 +219,7 @@
     "title": "A₅ is Simple",
     "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A₅ is simple - it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A₅.",
     "mathContext": "$A_5 = \\ker(\\text{sign} : S_5 \\to \\{\\pm 1\\}) = \\{\\sigma \\in S_5 : \\text{sign}(\\sigma) = +1\\}$, $|A_5| = 60 = 5!/2$.\n\nConjugacy classes: identity (1), products of two disjoint transpositions (15), 3-cycles (20), and two classes of 5-cycles (12 + 12). A normal subgroup $N \\trianglelefteq A_5$ must be a union of conjugacy classes containing $\\{e\\}$ (size 1), and $|N|$ must divide 60. The possible sub-sums starting with 1 are: $1, 1{+}15{=}16, 1{+}20{=}21, 1{+}12{=}13, 1{+}15{+}20{=}36, \\ldots$ — none divides 60 except 1 and 60 itself. Therefore $A_5$ has no proper nontrivial normal subgroups.\n\nLean: `alternatingGroup.isSimpleGroup_five : IsSimpleGroup (alternatingGroup (Fin 5))`.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": [
       "permutation groups",
       "normal subgroups",
@@ -315,7 +315,7 @@
     "title": "The Abel-Ruffini Contrapositive: The Main Event",
     "content": "`not_solvable_by_rad_of_not_solvable_gal` is the logical heart of the formalization. It takes the contrapositive of `galois_bridge`: if the Galois group of an irreducible polynomial $q$ is **not** solvable and $\\alpha$ is a root, then $\\alpha$ is **not** solvable by radicals. The proof is a 2-line proof term: `intro hrad; exact hns (galois_bridge α q hq hroot hrad)` — assuming $\\alpha$ is solvable by radicals, applying the bridge to get `IsSolvable q.Gal`, and deriving a contradiction with `hns`.\n\n`exists_quintic` provides a trivial witness ($X^5$) that degree-5 polynomials exist. To complete the Abel-Ruffini theorem for a *specific* quintic, one would need to exhibit $q \\in \\mathbb{Q}[X]$ of degree 5 with $\\text{Gal}(q) \\cong S_5$. The standard example is $x^5 - x - 1$, whose Galois group over $\\mathbb{Q}$ is $S_5$ (verified by checking irreducibility mod 2 and that the discriminant has non-square part, forcing the full symmetric group).",
     "mathContext": "$\\neg\\,\\text{IsSolvable}(q.\\text{Gal}) \\Rightarrow \\neg\\,\\text{IsSolvableByRad}\\,F\\,\\alpha$.\n\nProof: Assume $\\text{IsSolvableByRad}\\,F\\,\\alpha$. By `galois_bridge`, $\\text{IsSolvable}(q.\\text{Gal})$. Contradiction with $\\neg\\,\\text{IsSolvable}(q.\\text{Gal})$. $\\square$\n\nFor the general quintic: $q = x^5 - x - 1$ over $\\mathbb{Q}$ has $\\text{Gal}(q) \\cong S_5$, so its roots are not expressible by radicals.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": [
       "galois_bridge",
       "IsSolvable",

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -353,6 +353,16 @@
       "targetId": "elementary-quadratic-reciprocity-oq-01",
       "relationship": "related",
       "description": "Zolotarev's 1872 proof of quadratic reciprocity uses the sign homomorphism $\\text{sign}: S_n \\to \\{\\pm 1\\}$ — the same homomorphism whose kernel $A_n = \\ker(\\text{sign})$ is central to Abel-Ruffini's proof chain. In Zolotarev's proof, the Legendre symbol $(a/p)$ equals the signature of the multiplication-by-$a$ permutation on $(\\mathbb{Z}/p\\mathbb{Z})^{\\times}$, directly linking the symmetric group structure that drives Abel-Ruffini's impossibility to quadratic reciprocity"
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03",
+      "relationship": "related",
+      "description": "The Gauss-Wantzel theorem characterizes constructible regular n-gons via Fermat primes, paralleling Abel-Ruffini's characterization of radical solvability via solvable Galois groups. Both are Galois-theoretic impossibility results: constructibility requires the Galois group to be a 2-group (tower of degree-2 extensions), while radical solvability requires a solvable Galois group (tower of cyclic extensions). Together they illustrate how Galois theory provides a unified framework for impossibility proofs across algebra and geometry"
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03-oq-01",
+      "relationship": "related",
+      "description": "The cyclotomic field approach to Gauss-Wantzel connects directly to Abel-Ruffini's radical solvability paradigm: cyclotomic polynomials have abelian Galois groups $(\\mathbb{Z}/n\\mathbb{Z})^{\\times}$, which are always solvable — explaining why roots of unity are expressible by radicals. The Abel-Ruffini impossibility arises when the Galois group escapes this abelian cyclotomic world, as the generic quintic's Galois group $S_5$ is not solvable"
     }
   ],
   "relatedProofs": [
@@ -396,7 +406,9 @@
     "angle-trisection-oq-02-oq-01",
     "chinese-remainder-constructive",
     "chinese-remainder-non-coprime",
-    "elementary-quadratic-reciprocity-oq-01"
+    "elementary-quadratic-reciprocity-oq-01",
+    "angle-trisection-oq-02-oq-03",
+    "angle-trisection-oq-02-oq-03-oq-01"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary
Two enrichment passes in one PR:

**abel-ruffini-oq-04** (pass 3):
- Added cross-references to Gauss-Wantzel theorem entries and nth-root-irrational-oq-01

**abel-ruffini** (pass 1):
- Fixed 4 annotations using non-standard `"critical"` significance to `"key"` (schema compliance)
- Added cross-references to Gauss-Wantzel theorem entries as parallel Galois-theoretic impossibility results

## Test plan
- [x] JSON validated for both entries
- [x] All cross-referenced gallery entries verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)