### PR TITLE
Enrich geometric-series: deepen historical context, annotations, cross-references

### DIFF
--- a/src/data/proofs/geometric-series/annotations.json
+++ b/src/data/proofs/geometric-series/annotations.json
@@ -1,121 +1,284 @@
 [
   {
+    "id": "ann-imports",
+    "proofId": "geometric-series",
+    "range": {
+      "startLine": 1,
+      "endLine": 3
+    },
+    "type": "concept",
+    "title": "Mathlib Imports: Algebra and Analysis",
+    "content": "Three imports separate the algebraic and analytic aspects of geometric series:\n- `Algebra.GeomSum`: The purely algebraic identity $(1-r)\\sum r^k = 1 - r^n$ over arbitrary rings, including `mul_neg_geom_sum` and `geom_sum_mul_neg`\n- `Analysis.SpecificLimits.Normed`: The analytic convergence results `tsum_geometric_of_abs_lt_one` and `summable_geometric_of_abs_lt_one`, which require the completeness of $\\mathbb{R}$ and the condition $|r| < 1$\n- `Tactic`: General proof automation (`norm_num`, `field_simp`, `ring`, `simp`)",
+    "mathContext": "The algebraic identity $1 - r^n = (1-r)(1 + r + \\cdots + r^{n-1})$ holds in any ring and is a special case of the factorization $x^n - y^n = (x-y)(x^{n-1} + x^{n-2}y + \\cdots + y^{n-1})$. The analytic convergence $\\sum r^k = (1-r)^{-1}$ additionally requires a topology, a norm ($|\\cdot|$), and completeness (every Cauchy sequence converges).",
+    "significance": "supporting",
+    "prerequisites": [
+      "Lean 4 import system",
+      "Mathlib module organization"
+    ],
+    "relatedConcepts": [
+      "ring theory",
+      "normed spaces",
+      "completeness"
+    ]
+  },
+  {
+    "id": "ann-module-doc",
+    "proofId": "geometric-series",
+    "range": {
+      "startLine": 5,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "Module Documentation and Proof Architecture",
+    "content": "The module docstring lays out the three-part structure of the formalization:\n1. **Finite sum** (algebraic): $(1-r)\\sum_{k=0}^{n-1} r^k = 1 - r^n$, valid in any ring\n2. **Infinite sum** (analytic): $\\sum_{k=0}^{\\infty} r^k = (1-r)^{-1}$ for $|r| < 1$\n3. **General form**: $\\sum ar^k = a/(1-r)$\n\nThe documentation identifies three Mathlib dependencies (`mul_neg_geom_sum`, `tsum_geometric_of_abs_lt_one`, `summable_geometric_of_abs_lt_one`) and notes this is Wiedijk #66. The proof techniques span ring operations, limits, and series convergence — reflecting the theorem's position at the intersection of algebra and analysis.",
+    "mathContext": "Wiedijk's list (#66) includes 'Sum of a Geometric Series' because it exemplifies the transition from finite algebra to infinite analysis. The formalization demonstrates that Lean 4 + Mathlib can express both the algebraic identity (over `[Ring R]`) and the topological convergence (over `ℝ` with `|r| < 1`) within a unified framework.",
+    "significance": "context",
+    "prerequisites": [
+      "Lean 4 docstrings",
+      "Wiedijk 100 theorems list"
+    ],
+    "relatedConcepts": [
+      "formalization methodology",
+      "Wiedijk 100",
+      "proof architecture"
+    ]
+  },
+  {
     "id": "geom-sum-formula",
     "proofId": "geometric-series",
     "range": {
-      "startLine": 54,
-      "endLine": 58
+      "startLine": 56,
+      "endLine": 65
     },
     "type": "technique",
-    "title": "Finite Geometric Sum Formula",
-    "content": "The fundamental identity (1-r) * sum = 1 - r^(n+1). This is proved using Mathlib's `Finset.geom_sum_eq` which captures the telescoping that occurs when multiplying the sum by (1-r).",
-    "mathContext": "(1 - r) * \\sum_{k=0}^{n} r^k = 1 - r^{n+1}",
+    "title": "Finite Geometric Sum: The Telescoping Identity",
+    "content": "`finite_geom_sum` encodes the fundamental identity $(1 - r) \\cdot \\sum_{k=0}^{n-1} r^k = 1 - r^n$ over any ring $R$. The proof is a single call to Mathlib's `mul_neg_geom_sum`, which formalizes the telescoping: when $(1-r)$ is distributed across the sum, consecutive terms cancel, leaving only $1 - r^n$.\n\nThis identity is equivalent to the factorization $1 - r^n = (1-r)(1 + r + r^2 + \\cdots + r^{n-1})$, a special case of the difference-of-powers formula used throughout algebra. The ring-level generality means it applies to integers, rationals, reals, complex numbers, matrices, and formal power series.",
+    "mathContext": "$(1 - r) \\cdot \\sum_{k=0}^{n-1} r^k = \\sum_{k=0}^{n-1} (r^k - r^{k+1}) = 1 - r^n$\n\nThis is the factorization $x^n - 1 = (x-1)(x^{n-1} + x^{n-2} + \\cdots + 1)$ evaluated at $x = r$, negated. The cyclotomic polynomials $\\Phi_d(x)$ refine this: $x^n - 1 = \\prod_{d|n} \\Phi_d(x)$, with $\\Phi_1(x) = x - 1$ and $(x^n - 1)/(x - 1) = \\sum_{k=0}^{n-1} x^k = \\prod_{d|n, d > 1} \\Phi_d(x)$.",
     "significance": "key",
     "prerequisites": [
       "ring operations",
-      "finite sums"
+      "finite sums (Finset.range)",
+      "telescoping"
     ],
     "relatedConcepts": [
       "telescoping sums",
+      "difference of powers",
+      "cyclotomic polynomials",
       "polynomial division"
+    ]
+  },
+  {
+    "id": "ann-finite-alternate-forms",
+    "proofId": "geometric-series",
+    "range": {
+      "startLine": 67,
+      "endLine": 77
+    },
+    "type": "technique",
+    "title": "Alternate Forms: Commuted Product and Division",
+    "content": "`finite_geom_sum'` gives the commuted form $(\\sum r^k) \\cdot (1-r) = 1 - r^n$ via `geom_sum_mul_neg`, which matters in non-commutative rings where left and right multiplication differ.\n\n`finite_geom_sum_div` solves for the sum: $\\sum_{k=0}^{n-1} r^k = (1 - r^n)/(1 - r)$ when $r \\neq 1$. The proof uses `field_simp` to clear the denominator and reduce to the multiplicative identity. This requires `[DivisionRing R]` (not just `[Ring R]`) since division must be defined, and the hypothesis `hr : r ≠ 1` ensures $1 - r \\neq 0$.",
+    "mathContext": "In a commutative ring, $(1-r)S = S(1-r)$ automatically. In non-commutative settings (e.g., matrix rings), $\\sum A^k$ satisfies $(I-A)(\\sum A^k) = I - A^n$ (left multiplication) and $(\\sum A^k)(I-A) = I - A^n$ (right multiplication) separately.\n\nThe division form $S_n = (1 - r^n)/(1-r)$ is the one most commonly used in applications (compound interest, partial fractions), but it obscures the algebraic content. The multiplicative form $(1-r)S_n = 1 - r^n$ is more natural for formal proofs.",
+    "significance": "supporting",
+    "prerequisites": [
+      "DivisionRing typeclass",
+      "field_simp tactic",
+      "non-zero denominator"
+    ],
+    "relatedConcepts": [
+      "non-commutative rings",
+      "field_simp",
+      "division in rings"
     ]
   },
   {
     "id": "infinite-geom-sum",
     "proofId": "geometric-series",
     "range": {
-      "startLine": 76,
-      "endLine": 82
+      "startLine": 83,
+      "endLine": 92
     },
     "type": "technique",
-    "title": "Infinite Geometric Series Sum",
-    "content": "For |r| < 1, the infinite geometric series converges to 1/(1-r). This is the limit of the finite sums as n → ∞, using the fact that r^n → 0 when |r| < 1.",
-    "mathContext": "\\sum_{k=0}^{\\infty} r^k = \\frac{1}{1-r} \\text{ for } |r| < 1",
+    "title": "Infinite Geometric Series: The Convergence Theorem",
+    "content": "`infinite_geom_sum` proves $\\sum_{k=0}^{\\infty} r^k = (1-r)^{-1}$ for real $r$ with $|r| < 1$. The one-line proof delegates to Mathlib's `tsum_geometric_of_abs_lt_one`, which internally:\n1. Establishes summability via the comparison test ($|r^k| = |r|^k$ with $|r| < 1$)\n2. Computes $\\text{tsum}$ as the limit of partial sums\n3. Takes the limit of $(1 - r^n)/(1 - r)$ as $n \\to \\infty$, using $|r| < 1 \\Rightarrow r^n \\to 0$\n\nThe result type uses `tsum` (Mathlib's unconditional sum), which for summable real series equals the classical limit of partial sums. The $(1-r)^{-1}$ notation (field inverse) is preferred over $1/(1-r)$ in Lean's formalization.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} r^k = \\lim_{n \\to \\infty} \\sum_{k=0}^{n-1} r^k = \\lim_{n \\to \\infty} \\frac{1 - r^n}{1 - r} = \\frac{1 - 0}{1 - r} = \\frac{1}{1-r}$\n\nThe convergence is geometric: $|S_n - S| = |r^n/(1-r)| = |r|^n / |1-r| \\to 0$ exponentially fast. For $r = 0.5$, each partial sum halves the remaining error — $S_{10}$ is already within $10^{-3}$ of the limit.",
     "significance": "key",
     "prerequisites": [
-      "limits",
-      "series convergence",
-      "absolute value"
+      "tsum (unconditional sum)",
+      "limits of sequences",
+      "absolute value",
+      "completeness of ℝ"
     ],
     "relatedConcepts": [
       "power series",
-      "radius of convergence"
+      "radius of convergence",
+      "exponential convergence",
+      "tsum_geometric_of_abs_lt_one"
     ]
   },
   {
     "id": "summability",
     "proofId": "geometric-series",
     "range": {
-      "startLine": 84,
-      "endLine": 88
+      "startLine": 94,
+      "endLine": 97
     },
     "type": "technique",
-    "title": "Geometric Series is Summable",
-    "content": "When |r| < 1, the geometric series is summable (convergent). This is a prerequisite for computing the infinite sum.",
-    "significance": "key",
+    "title": "Summability of the Geometric Series",
+    "content": "`geom_series_summable` proves that the geometric series is `Summable` when $|r| < 1$. In Mathlib, `Summable f` means there exists $s$ such that $\\sum f(k) = s$ (i.e., the `tsum` is well-defined). This is a precondition for many lemmas about `tsum`, including `tsum_mul_left` used later.\n\nThe proof delegates to `summable_geometric_of_abs_lt_one`, which uses the comparison test: $|r^k| = |r|^k$, and the non-negative geometric series $\\sum |r|^k$ converges because $|r| < 1$. This establishes absolute convergence, which implies unconditional convergence in $\\mathbb{R}$.",
+    "mathContext": "$\\text{Summable}\\,(k \\mapsto r^k) \\iff \\exists s,\\; \\text{HasSum}\\,(k \\mapsto r^k)\\,s$.\n\nFor real-valued series, `Summable` is equivalent to absolute convergence: $\\sum |r^k| = \\sum |r|^k < \\infty$. In more general topological abelian groups, summability is unconditional convergence (convergence of the net of finite partial sums).",
+    "significance": "supporting",
     "prerequisites": [
-      "Summable predicate"
+      "Summable predicate",
+      "absolute convergence",
+      "comparison test"
     ],
     "relatedConcepts": [
       "absolute convergence",
-      "comparison test"
+      "unconditional convergence",
+      "comparison test",
+      "HasSum"
     ]
   },
   {
     "id": "scaled-form",
     "proofId": "geometric-series",
     "range": {
-      "startLine": 97,
-      "endLine": 102
+      "startLine": 103,
+      "endLine": 109
     },
     "type": "technique",
-    "title": "General Form with First Term a",
-    "content": "The general geometric series with first term a: sum of a*r^k = a/(1-r). This follows by factoring out a from the basic formula.",
-    "mathContext": "\\sum_{k=0}^{\\infty} ar^k = \\frac{a}{1-r}",
+    "title": "General Form with First Term $a$",
+    "content": "`infinite_geom_sum_scaled` proves $\\sum_{k=0}^{\\infty} a \\cdot r^k = a \\cdot (1-r)^{-1}$ by factoring out the constant $a$ via `tsum_mul_left` (linearity of `tsum`) and applying `infinite_geom_sum`. This is the formula most commonly used in applications: the present value of a perpetuity paying $a$ per period with discount rate $r$ is $a/(1-r)$.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} ar^k = a \\sum_{k=0}^{\\infty} r^k = \\frac{a}{1-r}$\n\nThe linearity of `tsum` ($\\text{tsum}\\,(k \\mapsto c \\cdot f(k)) = c \\cdot \\text{tsum}\\,f$) requires that $f$ be summable. This is why `geom_series_summable` is a necessary precondition — `tsum_mul_left` only commutes the constant out when the underlying series converges.",
     "significance": "key",
     "prerequisites": [
+      "tsum_mul_left",
       "linearity of sums"
     ],
     "relatedConcepts": [
-      "scaling infinite series"
+      "perpetuity valuation",
+      "present value",
+      "linearity of infinite sums"
     ]
   },
   {
     "id": "sum-halves",
     "proofId": "geometric-series",
     "range": {
-      "startLine": 108,
-      "endLine": 118
+      "startLine": 113,
+      "endLine": 124
     },
     "type": "insight",
-    "title": "Sum of Halves Equals 1",
-    "content": "The classic example: 1/2 + 1/4 + 1/8 + ... = 1. Zeno's paradox in mathematical form - infinitely many steps can sum to a finite distance.",
-    "mathContext": "\\sum_{k=1}^{\\infty} \\frac{1}{2^k} = 1",
+    "title": "Sum of Halves Equals 1: Zeno's Paradox Resolved",
+    "content": "The classic example $\\sum_{k=1}^{\\infty} (1/2)^k = 1$ is Zeno's dichotomy paradox in mathematical form: to traverse a distance, you must first cross half, then half the remainder, then half of that, ad infinitum — yet the total distance is finite.\n\nThe proof is more involved than the other examples because the sum starts at $k=1$ (not $k=0$). The strategy: rewrite $(1/2)^{k+1}$ as $(1/2) \\cdot (1/2)^k$ via `pow_succ'`, factor out $1/2$ via `tsum_mul_left`, apply `infinite_geom_sum` to get $(1/2) \\cdot (1 - 1/2)^{-1} = (1/2) \\cdot 2 = 1$, and simplify with `norm_num`.\n\nThis also connects to binary representation: $0.111\\ldots_2 = \\sum_{k=1}^{\\infty} 2^{-k} = 1$, showing that the binary representation $0.\\overline{1}_2 = 1$ is exact.",
+    "mathContext": "$\\sum_{k=1}^{\\infty} \\frac{1}{2^k} = \\frac{1/2}{1 - 1/2} = 1$\n\nEquivalently: $1 = 0.111\\ldots_2$ in binary, since each bit at position $k$ contributes $2^{-k}$. The series converges exponentially: $S_n = 1 - 2^{-n}$, so $|S_n - 1| = 2^{-n}$ (halving the error at each step).",
     "significance": "supporting",
-    "prerequisites": [],
+    "prerequisites": [
+      "pow_succ'",
+      "tsum_mul_left",
+      "norm_num"
+    ],
     "relatedConcepts": [
       "Zeno's paradox",
-      "binary representation"
+      "binary representation",
+      "index shifting",
+      "exponential convergence"
+    ]
+  },
+  {
+    "id": "ann-sum-third-neg-half",
+    "proofId": "geometric-series",
+    "range": {
+      "startLine": 126,
+      "endLine": 141
+    },
+    "type": "insight",
+    "title": "Thirds and Alternating Series: Further Instantiations",
+    "content": "`geom_sum_third` evaluates $\\sum (1/3)^k = 3/2$, and `geom_sum_neg_half` evaluates $\\sum (-1/2)^k = 2/3$.\n\nThe alternating case $r = -1/2$ is particularly instructive: the partial sums oscillate — $1, 1/2, 3/4, 5/8, 11/16, \\ldots$ — but converge to $2/3$. The formula handles negative $r$ seamlessly because $|{-1/2}| = 1/2 < 1$. The proof of $|{-1/2}| < 1$ requires `abs_neg` to strip the sign before `norm_num` can verify $1/2 < 1$.\n\nThe $r = 1/3$ case connects to the Cantor set: the total length removed in the Cantor set construction is $\\sum_{k=0}^{\\infty} 2^k \\cdot 3^{-(k+1)} = (1/3) \\cdot \\sum (2/3)^k = 1$, showing the Cantor set has measure zero despite being uncountable.",
+    "mathContext": "$r = 1/3$: $\\sum_{k=0}^{\\infty} (1/3)^k = \\frac{1}{1-1/3} = \\frac{3}{2}$\n\n$r = -1/2$: $\\sum_{k=0}^{\\infty} (-1/2)^k = 1 - 1/2 + 1/4 - 1/8 + \\cdots = \\frac{1}{1-(-1/2)} = \\frac{1}{3/2} = \\frac{2}{3}$\n\nNote: $|{-1/2}| = 1/2 < 1$ is the convergence condition. The Lean proof uses `abs_neg` to convert $|{-1/2}|$ to $|1/2|$ before `norm_num`.",
+    "significance": "supporting",
+    "prerequisites": [
+      "abs_neg",
+      "norm_num",
+      "infinite_geom_sum"
+    ],
+    "relatedConcepts": [
+      "alternating series",
+      "Cantor set",
+      "oscillating convergence",
+      "absolute value of negative numbers"
+    ]
+  },
+  {
+    "id": "ann-finite-to-infinite",
+    "proofId": "geometric-series",
+    "range": {
+      "startLine": 147,
+      "endLine": 154
+    },
+    "type": "technique",
+    "title": "Partial Sums Converge to the Infinite Sum",
+    "content": "`finite_to_infinite` bridges the algebraic finite formula and the analytic infinite sum: the sequence of partial sums $S_n = \\sum_{k=0}^{n-1} r^k$ converges to $(1-r)^{-1}$ in the topological sense.\n\nThe proof uses `HasSum.tendsto_sum_nat`: if a function $f : \\mathbb{N} \\to \\mathbb{R}$ has sum $s$ (i.e., `HasSum f s`), then the partial sums $\\sum_{k < n} f(k)$ tend to $s$. The argument: establish summability (`geom_series_summable`), compute the sum (`infinite_geom_sum`), rewrite the target using the computed sum, and apply the `HasSum` convergence.\n\nThis theorem is the formal statement that the geometric series is the limit of its partial sums — the definition of convergence that Cauchy introduced in 1821.",
+    "mathContext": "$\\text{Filter.Tendsto}\\;(n \\mapsto S_n)\\;\\text{atTop}\\;(\\text{nhds}\\;(1-r)^{-1})$\n\nThis says: for every neighborhood $U$ of $(1-r)^{-1}$, there exists $N$ such that $S_n \\in U$ for all $n \\geq N$. Equivalently: $\\forall \\epsilon > 0,\\; \\exists N,\\; \\forall n \\geq N,\\; |S_n - (1-r)^{-1}| < \\epsilon$.\n\nThe rate of convergence is $|S_n - (1-r)^{-1}| = |r|^n / |1-r|$, which is exponential in $n$.",
+    "significance": "key",
+    "prerequisites": [
+      "Filter.Tendsto",
+      "nhds (neighborhood filter)",
+      "HasSum.tendsto_sum_nat",
+      "Summable"
+    ],
+    "relatedConcepts": [
+      "topological convergence",
+      "Cauchy criterion",
+      "partial sums",
+      "Filter library in Mathlib"
+    ]
+  },
+  {
+    "id": "ann-verification",
+    "proofId": "geometric-series",
+    "range": {
+      "startLine": 156,
+      "endLine": 171
+    },
+    "type": "context",
+    "title": "Verification Examples and Ground Truth",
+    "content": "Three `native_decide` examples verify the finite geometric sum formula for concrete values:\n- $\\sum_{k=0}^{4} 2^k = 1 + 2 + 4 + 8 + 16 = 31 = (2^5 - 1)/(2 - 1)$ over $\\mathbb{N}$\n- $\\sum_{k=0}^{3} 3^k = 1 + 3 + 9 + 27 = 40 = (3^4 - 1)/(3 - 1)$ over $\\mathbb{N}$\n- $\\sum_{k=0}^{3} (1/2)^k = 1 + 1/2 + 1/4 + 1/8 = 15/8$ over $\\mathbb{Q}$\n\nThe `native_decide` tactic evaluates decidable propositions by compiled native code, providing ground-truth computational verification. The rational arithmetic example confirms exact arithmetic over $\\mathbb{Q}$, not floating-point approximation.\n\nThe closing `#check` commands list the three main theorems for reference.",
+    "mathContext": "These examples verify the formula $\\sum_{k=0}^{n-1} r^k = (1 - r^n)/(1 - r)$:\n- $r=2, n=5$: $(2^5 - 1)/(2-1) = 31/1 = 31$\n- $r=3, n=4$: $(3^4 - 1)/(3-1) = 80/2 = 40$\n- $r=1/2, n=4$: $(1 - (1/2)^4)/(1 - 1/2) = (1 - 1/16)/(1/2) = (15/16) \\cdot 2 = 15/8$",
+    "significance": "context",
+    "prerequisites": [
+      "native_decide tactic",
+      "decidable equality",
+      "rational arithmetic"
+    ],
+    "relatedConcepts": [
+      "computational verification",
+      "native_decide",
+      "exact arithmetic"
     ]
   },
   {
     "id": "convergence-condition",
     "proofId": "geometric-series",
     "range": {
-      "startLine": 76,
-      "endLine": 78
+      "startLine": 79,
+      "endLine": 81
     },
     "type": "concept",
-    "title": "Convergence Condition |r| < 1",
-    "content": "The series converges if and only if |r| < 1. When |r| ≥ 1, the terms don't approach zero, so the series must diverge.",
+    "title": "The Convergence Condition $|r| < 1$",
+    "content": "The section docstring for infinite geometric series states the convergence condition: $|r| < 1$ is both necessary and sufficient for convergence. This is the simplest instance of the radius of convergence for a power series — the function $f(r) = 1/(1-r)$ has a pole at $r = 1$, and the power series $\\sum r^k$ converges in the open disk $|r| < 1$ centered at the origin.\n\nThe necessity of $|r| < 1$ follows from the divergence test: if $|r| \\geq 1$, then $|r^k| \\geq 1$ for all $k$, so the terms do not approach zero and the series must diverge.",
+    "mathContext": "The radius of convergence of $\\sum a_n z^n$ is $R = 1/\\limsup_{n \\to \\infty} |a_n|^{1/n}$. For the geometric series $a_n = 1$, this gives $R = 1/\\limsup 1^{1/n} = 1/1 = 1$. The series converges for $|r| < R = 1$ and diverges for $|r| > 1$. At $|r| = 1$, behavior depends on the direction: the series diverges at $r = 1$, is Cesàro-summable at $r = -1$, and diverges at all other points on the unit circle.",
     "significance": "key",
     "prerequisites": [
       "absolute value",
+      "divergence test",
       "limit of powers"
     ],
     "relatedConcepts": [
+      "radius of convergence",
+      "Cauchy-Hadamard theorem",
       "divergence test",
-      "radius of convergence"
+      "analytic continuation"
     ]
   }
 ]

--- a/src/data/proofs/geometric-series/meta.json
+++ b/src/data/proofs/geometric-series/meta.json
@@ -44,64 +44,109 @@
     ],
     "dateAdded": "2025-12-26",
     "axiomCount": 0,
-    "lineCount": 171
+    "lineCount": 171,
+    "prerequisites": [
+      "Ring and field operations (commutativity, distributivity, division)",
+      "Finite sums and summation notation (Finset.range, BigOperators)",
+      "Absolute value and the real number line",
+      "Convergence of sequences and series (limits, partial sums)",
+      "Summability (absolute convergence, tsum in Mathlib)"
+    ],
+    "leanFile": {
+      "lineCount": 171,
+      "structureCount": 0,
+      "axiomCount": 0,
+      "theoremCount": 10,
+      "lemmaCount": 0,
+      "defCount": 0,
+      "imports": [
+        "Mathlib.Algebra.GeomSum",
+        "Mathlib.Analysis.SpecificLimits.Normed",
+        "Mathlib.Tactic"
+      ]
+    }
   },
   "overview": {
-    "historicalContext": "Geometric series have been studied since antiquity. Archimedes (~250 BCE) used a geometric series to calculate the area under a parabola, summing 1 + 1/4 + 1/16 + ... = 4/3. This was one of the earliest uses of infinite processes in mathematics.\n\nThe general formula for infinite geometric series was developed in the 17th century by mathematicians including Newton and Leibniz. However, the rigorous treatment of convergence had to wait until the 19th century work of Cauchy and Weierstrass.\n\nToday, geometric series appear everywhere: compound interest calculations, probability theory (geometric distribution), signal processing (z-transforms), and physics (renormalization).",
+    "historicalContext": "The geometric series is among the oldest objects in mathematics. Euclid's *Elements* (Book IX, Proposition 35, c. 300 BCE) gives the finite geometric sum formula for integers, and Archimedes (~250 BCE) used the infinite geometric series $1 + \\frac{1}{4} + \\frac{1}{16} + \\cdots = \\frac{4}{3}$ to calculate the area under a parabola in *Quadrature of the Parabola* — one of the first rigorous uses of an infinite process in mathematics.\n\nNicole Oresme (c. 1350) proved that $\\sum_{k=1}^{\\infty} k/2^k = 2$ by a remarkable graphical argument, making him the first European mathematician to sum an infinite series explicitly. In the Kerala school of astronomy, Nilakantha Somayaji (c. 1500) used geometric series within the derivation of the Madhava-Leibniz series for $\\pi/4$, anticipating European work by two centuries.\n\nThe general finite formula $\\sum_{k=0}^{n-1} r^k = (1 - r^n)/(1 - r)$ appears in the work of François Viète (1593) and was fully systematized by Euler in *Introductio in analysin infinitorum* (1748), where it serves as the starting point for the theory of power series. Newton's generalized binomial theorem (1665) implicitly relies on geometric series as the case $\\alpha = -1$ of $(1-r)^\\alpha$.\n\nRigorous convergence theory arrived with Cauchy's *Cours d'analyse* (1821), which defined convergence of series via partial sums and proved the geometric series converges precisely when $|r| < 1$. Weierstrass later placed this in the framework of uniform convergence and the $\\epsilon$-$\\delta$ formalism that underpins modern analysis.\n\nToday, geometric series appear throughout mathematics and its applications: compound interest and annuities in finance, the geometric distribution and moment-generating functions in probability, $z$-transforms in signal processing, the Neumann series $(I - T)^{-1} = \\sum T^k$ in operator theory, perturbation series in quantum field theory, and as the simplest formal power series in combinatorics.",
     "problemStatement": "**Theorem (Wiedijk #66)**: For a geometric series with ratio r:\n\n**Finite sum** (any r ≠ 1):\n$$\\sum_{k=0}^{n} r^k = \\frac{1 - r^{n+1}}{1 - r}$$\n\n**Infinite sum** (|r| < 1):\n$$\\sum_{k=0}^{\\infty} r^k = \\frac{1}{1-r}$$\n\n**General form** with first term a:\n$$\\sum_{k=0}^{\\infty} ar^k = \\frac{a}{1-r}$$",
     "proofStrategy": "**Finite Sum Derivation:**\n\nLet $S_n = 1 + r + r^2 + \\cdots + r^n$. Then:\n$$rS_n = r + r^2 + \\cdots + r^{n+1}$$\n\nSubtracting:\n$$S_n - rS_n = 1 - r^{n+1}$$\n$$(1-r)S_n = 1 - r^{n+1}$$\n$$S_n = \\frac{1 - r^{n+1}}{1-r}$$\n\n**Infinite Sum:**\n\nWhen |r| < 1, we have $r^{n+1} \\to 0$ as $n \\to \\infty$, so:\n$$\\lim_{n \\to \\infty} S_n = \\frac{1 - 0}{1-r} = \\frac{1}{1-r}$$",
     "keyInsights": [
-      "The finite formula works for any r ≠ 1, but the infinite sum requires |r| < 1 for convergence",
-      "The key trick is multiplying by r and subtracting to telescope the sum",
-      "The condition |r| < 1 ensures r^n → 0, allowing the limit to exist",
-      "For |r| ≥ 1, the series diverges because r^n doesn't approach zero",
-      "The geometric series formula 1/(1-r) is the simplest example of a generating function — encoding an infinite sequence as a closed-form rational expression, a technique fundamental to combinatorics and analysis"
+      "**Telescoping via the $(1-r)$ trick:** The finite formula $\\sum_{k=0}^{n-1} r^k = (1 - r^n)/(1 - r)$ arises from the factorization $1 - r^n = (1 - r)(1 + r + r^2 + \\cdots + r^{n-1})$, which is a special case of the cyclotomic factorization of $x^n - 1$. Lean's `mul_neg_geom_sum` encodes this algebraic identity over any ring, with no convergence hypotheses needed.",
+      "**Algebraic generality vs analytic specificity:** The finite formula holds in any ring (no ordering, no norm, no convergence required — `{R : Type*} [Ring R]`), while the infinite sum requires the analytic structure of $\\mathbb{R}$ (absolute value, completeness, limits). The Lean formalization mirrors this: `finite_geom_sum` is purely algebraic; `infinite_geom_sum` requires `|r| < 1` and uses `tsum_geometric_of_abs_lt_one` from Mathlib's topology library.",
+      "**The convergence threshold $|r| = 1$ is sharp:** For $|r| < 1$, $r^n \\to 0$ so partial sums converge. At $|r| = 1$, behavior depends on the argument: $r = 1$ gives the divergent series $1 + 1 + 1 + \\cdots$, while $r = -1$ gives the Cesàro-summable (but classically divergent) $1 - 1 + 1 - 1 + \\cdots = 1/2$ (Grandi's series). For $|r| > 1$, terms grow without bound.",
+      "**Generating function prototype:** $\\frac{1}{1-r} = \\sum_{k=0}^{\\infty} r^k$ is the simplest generating function, encoding the constant sequence $(1, 1, 1, \\ldots)$. Differentiating gives $\\frac{1}{(1-r)^2} = \\sum k r^{k-1}$ (the sequence $(1, 2, 3, \\ldots)$), and composing gives the generating functions for Fibonacci numbers, Catalan numbers, and partition functions — the entire apparatus of analytic combinatorics rests on this identity.",
+      "**Neumann series and operator theory:** For a bounded linear operator $T$ with $\\|T\\| < 1$, the series $\\sum_{k=0}^{\\infty} T^k$ converges to $(I - T)^{-1}$. This is the operator-valued geometric series, and it is the foundation of perturbation theory, resolvent estimates, and the proof that the set of invertible operators is open in the operator norm topology.",
+      "**Partial sums as rational approximations:** The finite partial sums $S_n = (1 - r^n)/(1 - r)$ provide rational approximations to the irrational limit $1/(1 - r)$. The `finite_to_infinite` theorem formalizes this convergence: `Filter.Tendsto` applied to $S_n$ with target $\\text{nhds}((1-r)^{-1})$, connecting the algebraic finite formula to the topological notion of limit via `HasSum.tendsto_sum_nat`.",
+      "**Connection to the Riemann zeta function:** Setting $r = p^{-s}$ for a prime $p$ gives $\\sum_{k=0}^{\\infty} p^{-ks} = (1 - p^{-s})^{-1}$, and multiplying over all primes yields the Euler product $\\zeta(s) = \\prod_p (1 - p^{-s})^{-1}$. The convergence of each geometric factor for $\\operatorname{Re}(s) > 1$ underlies the analytic continuation of $\\zeta(s)$ and connects this elementary series to the deepest problems in number theory."
     ]
   },
   "sections": [
     {
+      "id": "imports-and-docs",
+      "title": "Imports, Documentation, and Setup",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Three Mathlib imports (`Algebra.GeomSum` for the finite formula, `Analysis.SpecificLimits.Normed` for the infinite series, `Tactic` for proof automation), module docstring documenting both finite and infinite cases as Wiedijk #66, namespace `GeometricSeries` with `open Finset BigOperators`.",
+      "mathContext": "The two key Mathlib modules separate the algebraic identity $(1-r)\\sum r^k = 1 - r^n$ (which holds in any ring) from the analytic convergence $\\sum_{k=0}^{\\infty} r^k = (1-r)^{-1}$ (which requires completeness and $|r| < 1$). The `BigOperators` open enables $\\sum$ notation."
+    },
+    {
       "id": "finite-sum",
       "title": "Finite Geometric Sum",
-      "startLine": 50,
-      "endLine": 70,
-      "summary": "The classic formula (1-r) * sum = 1 - r^(n+1) using Finset.geom_sum_eq."
+      "startLine": 52,
+      "endLine": 77,
+      "summary": "Three formulations of the finite geometric sum: `finite_geom_sum` gives $(1-r) \\cdot \\sum r^k = 1 - r^n$ via `mul_neg_geom_sum`, `finite_geom_sum'` gives the commuted form $\\sum r^k \\cdot (1-r) = 1 - r^n$ via `geom_sum_mul_neg`, and `finite_geom_sum_div` gives the division form $\\sum r^k = (1 - r^n)/(1 - r)$ for $r \\neq 1$ using `field_simp`.",
+      "mathContext": "The three forms correspond to the factorization $1 - r^n = (1-r)(1 + r + \\cdots + r^{n-1})$. The multiplicative forms work in any `Ring R`; the division form requires `DivisionRing R` and $r \\neq 1$ to ensure $1 - r$ is invertible."
     },
     {
       "id": "infinite-sum",
       "title": "Infinite Geometric Series",
-      "startLine": 72,
-      "endLine": 95,
-      "summary": "For |r| < 1, the series converges to 1/(1-r)."
+      "startLine": 79,
+      "endLine": 97,
+      "summary": "`infinite_geom_sum` proves $\\sum_{k=0}^{\\infty} r^k = (1-r)^{-1}$ for real $r$ with $|r| < 1$ via `tsum_geometric_of_abs_lt_one`. `geom_series_summable` establishes the `Summable` precondition via `summable_geometric_of_abs_lt_one`.",
+      "mathContext": "The summability proof uses the comparison test: $|r^k| = |r|^k$ and $\\sum |r|^k$ converges (as a non-negative geometric series with ratio $< 1$), so the series is absolutely convergent. In Lean, `tsum` denotes the unconditional sum, which equals the limit of partial sums when the series is summable."
     },
     {
       "id": "general-form",
       "title": "General Form with First Term",
-      "startLine": 97,
-      "endLine": 110,
-      "summary": "The scaled version with first term a: sum = a/(1-r)."
+      "startLine": 99,
+      "endLine": 109,
+      "summary": "`infinite_geom_sum_scaled` proves $\\sum a \\cdot r^k = a \\cdot (1-r)^{-1}$ by factoring out $a$ via `tsum_mul_left` and applying `infinite_geom_sum`.",
+      "mathContext": "$\\sum_{k=0}^{\\infty} a r^k = a \\sum_{k=0}^{\\infty} r^k = \\frac{a}{1-r}$. The linearity of `tsum` (`tsum_mul_left`) is the key step — it holds because $\\sum a \\cdot c_k = a \\cdot \\sum c_k$ for any summable series."
     },
     {
       "id": "special-cases",
       "title": "Special Cases and Examples",
-      "startLine": 112,
-      "endLine": 145,
-      "summary": "Classic examples: sum of halves equals 1, thirds gives 3/2, alternating series."
+      "startLine": 111,
+      "endLine": 141,
+      "summary": "Three classic instantiations: `sum_halves` ($\\sum 2^{-(k+1)} = 1$, Zeno's paradox), `geom_sum_third` ($\\sum (1/3)^k = 3/2$), and `geom_sum_neg_half` ($\\sum (-1/2)^k = 2/3$, an alternating series). Each first establishes $|r| < 1$ via `norm_num`, then applies `infinite_geom_sum`.",
+      "mathContext": "The three examples illustrate different aspects: $r = 1/2$ (binary subdivision, connected to binary representation $0.111\\ldots_2 = 1$), $r = 1/3$ (ternary, connected to the Cantor set), $r = -1/2$ (alternating signs, showing the formula works for negative ratios). The `sum_halves` proof is more involved because it shifts the index: $\\sum_{k=0}^{\\infty} (1/2)^{k+1} = (1/2) \\cdot \\sum_{k=0}^{\\infty} (1/2)^k$."
     },
     {
       "id": "finite-to-infinite",
-      "title": "Connection to Finite Sums",
-      "startLine": 147,
-      "endLine": 165,
-      "summary": "Finite partial sums converge to the infinite sum as n → ∞."
+      "title": "Connection Between Finite and Infinite Sums",
+      "startLine": 143,
+      "endLine": 154,
+      "summary": "`finite_to_infinite` proves that the sequence of finite partial sums $S_n = \\sum_{k=0}^{n-1} r^k$ converges to $(1-r)^{-1}$ in the topological sense (`Filter.Tendsto` to `nhds`), using `HasSum.tendsto_sum_nat` applied to the summable geometric series.",
+      "mathContext": "This bridges the algebraic finite formula and the analytic infinite sum: $\\lim_{n \\to \\infty} \\frac{1 - r^n}{1 - r} = \\frac{1}{1-r}$. The proof uses `HasSum`, Mathlib's predicate for unconditional summability, which for $\\mathbb{R}$-valued series is equivalent to absolute convergence."
+    },
+    {
+      "id": "verification",
+      "title": "Verification Examples",
+      "startLine": 156,
+      "endLine": 171,
+      "summary": "Three `native_decide` examples verify concrete computations: $1+2+4+8+16 = 31$, $1+3+9+27 = 40$, and $1 + 1/2 + 1/4 + 1/8 = 15/8$. Also `#check` commands for the main theorems.",
+      "mathContext": "The `native_decide` tactic evaluates decidable propositions by computation, providing ground-truth checks that the abstract formulas produce correct numerical values. The rational arithmetic example ($15/8$ over $\\mathbb{Q}$) confirms the formula works in exact arithmetic, not just real analysis."
     }
   ],
   "conclusion": {
     "summary": "The geometric series formula is one of the most fundamental results in analysis. The finite sum formula (1-r^{n+1})/(1-r) follows from a clever algebraic trick of multiplying by r and subtracting. For |r| < 1, taking the limit gives the elegant infinite sum 1/(1-r).\n\nThe formalization uses Mathlib's `Finset.geom_sum_eq` for the finite case and `tsum_geometric_of_lt_one` for the infinite series, demonstrating how these foundational results connect.",
     "implications": "**Theoretical Significance:**\n\n**1. Foundation of analysis**\nThe geometric series is often the first infinite series students encounter, providing intuition for convergence.\n\n**2. Radius of convergence**\nThe condition |r| < 1 foreshadows the concept of radius of convergence for power series.\n\n**3. Taylor series**\nMany important functions (1/(1-x), e^x, sin(x)) can be expressed as power series that generalize geometric series.\n\n**Practical Applications:**\n\n- **Finance**: Compound interest and present value calculations\n- **Probability**: Geometric distribution and waiting times\n- **Signal Processing**: Z-transforms and filter design\n- **Physics**: Feynman diagrams and perturbation series",
     "openQuestions": [
-      "What happens at exactly |r| = 1? (Series diverges, but behavior varies)",
-      "How does the geometric series generalize to matrices and operators?",
-      "What is the relationship to the Riemann zeta function ζ(s)?"
+      "Can the Neumann series $(I - T)^{-1} = \\sum_{k=0}^{\\infty} T^k$ for bounded operators with $\\|T\\| < 1$ be formalized in Lean using Mathlib's `Analysis.NormedSpace` infrastructure, generalizing the scalar geometric series to infinite-dimensional operator algebras?",
+      "The boundary behavior at $|r| = 1$ is rich and subtle: $r = 1$ diverges, $r = -1$ gives Grandi's series (Cesàro-summable to $1/2$), and $r = e^{2\\pi i\\theta}$ with $\\theta$ irrational gives equidistributed partial sums on the circle. Can Cesàro summability and Abel summability of geometric series at the boundary be formalized, showing that Abel summation of $\\sum r^k$ at $r = -1$ gives $1/2$?",
+      "The Euler product $\\zeta(s) = \\prod_p (1 - p^{-s})^{-1}$ arises from geometric series over primes. Can this product representation be formalized in Lean, connecting the convergence of individual geometric factors to the analytic properties of the Riemann zeta function for $\\operatorname{Re}(s) > 1$?",
+      "The $q$-analog of the geometric series, $\\sum_{k=0}^{n-1} q^k = [n]_q$ (the quantum integer), is fundamental to quantum groups and combinatorics. Can the $q$-binomial theorem and its connection to Gaussian binomial coefficients be formalized, extending this result to the $q$-series framework?",
+      "For matrices, the geometric series $\\sum A^k = (I - A)^{-1}$ converges iff the spectral radius $\\rho(A) < 1$. The spectral radius condition is strictly weaker than $\\|A\\| < 1$ — can this refinement be formalized, using the Gelfand formula $\\rho(A) = \\lim_{k \\to \\infty} \\|A^k\\|^{1/k}$?"
     ]
   },
   "references": [
@@ -110,37 +155,101 @@
       "title": "Elements, Book IX, Proposition 35",
       "year": "c. 300 BCE",
       "venue": "Classical Geometry",
-      "note": "First known result on geometric progressions: the formula for the sum of a geometric sequence"
+      "note": "First known result on geometric progressions: the formula for the sum of a finite geometric sequence in terms of integer ratios"
+    },
+    {
+      "authors": "Archimedes",
+      "title": "Quadrature of the Parabola",
+      "year": "c. 250 BCE",
+      "venue": "Classical Mathematics",
+      "note": "First rigorous use of an infinite geometric series: Archimedes proved the area under a parabola equals 4/3 the inscribed triangle by summing 1 + 1/4 + 1/16 + ... = 4/3 via the method of exhaustion"
+    },
+    {
+      "authors": "Oresme, Nicole",
+      "title": "Quaestiones super geometriam Euclidis",
+      "year": "c. 1350",
+      "venue": "Paris",
+      "note": "First explicit summation of an infinite series in Europe: proved that the sum 1·(1/2) + 2·(1/4) + 3·(1/8) + ... = 2 by a graphical argument, anticipating the theory of convergent series by four centuries"
     },
     {
       "authors": "Euler, Leonhard",
       "title": "Introductio in analysin infinitorum",
       "year": "1748",
       "venue": "Lausanne",
-      "note": "Systematic treatment of infinite series including the geometric series as the foundation of power series analysis"
+      "note": "Systematic treatment of infinite series placing the geometric series as the foundation of power series analysis, and derivation of the Euler product for the Riemann zeta function from geometric series over primes"
+    },
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Cours d'analyse de l'École Royale Polytechnique",
+      "year": "1821",
+      "venue": "Paris",
+      "note": "First rigorous treatment of series convergence via partial sums; established the condition |r| < 1 for convergence of geometric series within the epsilon-delta framework"
+    },
+    {
+      "authors": "Knopp, Konrad",
+      "title": "Theory and Application of Infinite Series",
+      "year": "1928",
+      "venue": "Springer",
+      "note": "Comprehensive reference on infinite series including geometric series, summability methods for divergent series (Cesàro and Abel summation), and the theory of power series"
     }
   ],
   "crossReferences": [
     {
       "targetId": "harmonic-divergence",
       "relationship": "contrasts",
-      "description": "The geometric series ∑ rⁿ converges for |r| < 1, while the harmonic series ∑ 1/n diverges. Together they illustrate the boundary between convergent and divergent series."
+      "description": "The geometric series $\\sum r^n$ converges for $|r| < 1$, while the harmonic series $\\sum 1/n$ diverges despite its terms approaching zero. Together they illustrate the boundary between convergent and divergent series — the harmonic series is the 'limit case' where the ratio between consecutive terms approaches 1 (from below), exactly the geometric series threshold"
     },
     {
       "targetId": "basel-problem",
       "relationship": "related",
-      "description": "The Basel series ∑ 1/n² is a generalization from geometric to power series. The geometric series formula 1/(1-r) is the simplest power series, while ∑ 1/n² requires Bernoulli polynomial machinery."
+      "description": "The Basel series $\\sum 1/n^2 = \\pi^2/6$ generalizes from geometric to Dirichlet series. The geometric series $1/(1-r)$ is the simplest power series with a pole, while the Basel problem connects infinite series to $\\pi$ via the Weierstrass product for $\\sin(\\pi z)/\\pi z$"
     },
     {
       "targetId": "arithmetic-series",
       "relationship": "sibling",
-      "description": "Arithmetic and geometric series are the two fundamental finite summation formulas. Where arithmetic series sum with constant differences, geometric series sum with constant ratios."
+      "description": "Arithmetic and geometric series are the two fundamental finite summation formulas. Arithmetic series sum sequences with constant differences ($\\sum_{k=0}^{n} (a + kd)$); geometric series sum sequences with constant ratios ($\\sum_{k=0}^{n} ar^k$). The arithmetic sum is always a polynomial in $n$, while the geometric sum involves exponentials"
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "extends",
+      "description": "The geometric series $1/(1-r) = \\sum r^k$ is the case $\\alpha = -1$ of the generalized binomial series $(1+x)^\\alpha = \\sum \\binom{\\alpha}{k} x^k$. Newton's generalized binomial theorem extends the geometric series to arbitrary real exponents, with the geometric series as its simplest non-trivial instance"
+    },
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "foundational",
+      "description": "The geometric series $\\sum r^k = 1/(1-r)$ is the Taylor expansion of $f(r) = (1-r)^{-1}$ at $r = 0$. Taylor's theorem guarantees that any analytic function has a power series expansion, with the geometric series being the prototypical example — its radius of convergence $|r| < 1$ is determined by the nearest singularity at $r = 1$"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} + 1 = 0$ connects the exponential series $e^z = \\sum z^k/k!$ (which converges for all $z$) to the geometric series (which converges only for $|r| < 1$). The exponential series is 'universally convergent' while the geometric series has a finite radius of convergence — the factorials in the denominators make the critical difference"
+    },
+    {
+      "targetId": "leibniz-pi",
+      "relationship": "related",
+      "description": "The Leibniz formula $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$ arises from integrating the geometric series: $\\int_0^1 \\frac{1}{1+t^2} dt = \\int_0^1 \\sum_{k=0}^{\\infty} (-t^2)^k dt = \\sum_{k=0}^{\\infty} \\frac{(-1)^k}{2k+1}$. This is a foundational example of computing transcendental constants via term-by-term integration of geometric-type series"
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "The exponential function $e^x = \\sum x^k/k!$ and the geometric series $1/(1-x) = \\sum x^k$ are the two most fundamental power series. The transcendence of $e$ uses properties of the exponential series that parallel geometric series arguments, including comparison of growth rates and the ratio test"
+    },
+    {
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "extends",
+      "description": "Euler's proof that $\\sum 1/p$ diverges over primes uses the Euler product $\\zeta(s) = \\prod_p (1 - p^{-s})^{-1}$, where each factor is a geometric series $\\sum p^{-ks}$. The divergence of the prime reciprocal series follows from the divergence of $\\log \\zeta(s)$ as $s \\to 1^+$, connecting geometric series directly to the distribution of primes"
     }
   ],
   "relatedProofs": [
     "harmonic-divergence",
     "basel-problem",
-    "arithmetic-series"
+    "arithmetic-series",
+    "binomial-theorem",
+    "taylor-theorem",
+    "euler-identity",
+    "leibniz-pi",
+    "e-transcendental",
+    "prime-reciprocal-divergence"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary
- Expanded historicalContext from ~600 chars to ~1800 chars with Euclid, Archimedes, Nicole Oresme, Nilakantha Somayaji, Viète, and Cauchy
- Added 6 new annotations (imports, module docs, alternate forms, alternating series, finite-to-infinite bridge, verification examples) bringing total from 6 to 12
- Deepened 7 keyInsights covering cyclotomic factorization, algebraic vs analytic generality, Neumann series, generating functions, and the Riemann zeta connection
- Expanded cross-references from 3 to 9 (added binomial-theorem, taylor-theorem, euler-identity, leibniz-pi, e-transcendental, prime-reciprocal-divergence)
- Added 4 references (Archimedes, Oresme, Cauchy, Knopp) bringing total from 2 to 6
- Expanded sections from 5 to 7 with mathContext covering the full 171-line Lean file
- Expanded openQuestions from 3 to 5 with deeper mathematical content (Neumann series, Cesàro summability, Euler product, q-analogs, spectral radius)

## Test plan
- [x] Both meta.json and annotations.json validate as correct JSON
- [x] `pnpm annotations:build` produces no warnings for geometric-series
- [x] All annotation line ranges match the Lean source file

🤖 Generated with [Claude Code](https://claude.com/claude-code)