### PR TITLE
Enrich basel-problem: fix annotation ranges, add coverage and cross-refs

### DIFF
--- a/src/data/proofs/basel-problem/annotations.json
+++ b/src/data/proofs/basel-problem/annotations.json
@@ -99,9 +99,9 @@
       "startLine": 76,
       "endLine": 78
     },
-    "type": "theorem",
+    "type": "context",
     "title": "Series Convergence",
-    "content": "The series $\\sum 1/n^2$ converges because it's a p-series with $p = 2 > 1$. This is a fundamental result in analysis.",
+    "content": "The series $\\sum 1/n^2$ converges because it's a p-series with $p = 2 > 1$. This is a fundamental result in analysis — the integral test shows $\\sum n^{-p}$ converges iff $\\int_1^{\\infty} x^{-p} dx < \\infty$, which holds iff $p > 1$. The boundary case $p = 1$ (harmonic series) diverges logarithmically: $\\sum_{n=1}^{N} 1/n \\sim \\ln N$.",
     "mathContext": "We use `Real.summable_nat_rpow_inv` which proves that $\\sum n^{-p}$ converges for $p > 1$. The harmonic series ($p = 1$) is the boundary case that diverges.",
     "significance": "key",
     "prerequisites": [
@@ -144,11 +144,11 @@
     "proofId": "basel-problem",
     "range": {
       "startLine": 93,
-      "endLine": 101
+      "endLine": 106
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Positivity and Basic Properties",
-    "content": "Three positivity lemmas: `one_div_sq_pos` ($1/n^2 > 0$ for $n > 0$), `one_div_sq_nonneg` ($1/n^2 \\geq 0$ for all $n$), and `basel_value_pos` ($\\pi^2/6 > 0$). All proved by Lean's `positivity` tactic, which chains positivity/nonnegativity facts automatically.\n\nThese lemmas are supporting infrastructure: positivity of terms ensures the partial sums are increasing (important for monotone convergence), and positivity of the limit confirms the sum is meaningful.",
+    "content": "Three positivity lemmas: `one_div_sq_pos` ($1/n^2 > 0$ for $n > 0$), `one_div_sq_nonneg` ($1/n^2 \\geq 0$ for all $n$), and `basel_value_pos` ($\\pi^2/6 > 0$). All proved by Lean's `positivity` tactic, which chains positivity/nonnegativity facts automatically.\n\nThese lemmas are supporting infrastructure: positivity of terms ensures the partial sums are increasing (important for monotone convergence), and positivity of the limit confirms the sum is meaningful. The `positivity` tactic works by recursively decomposing the goal into subgoals about positivity or nonnegativity of components: for $1/n^2$, it uses `sq_nonneg` to establish $n^2 \\geq 0$, then `div_pos` or `div_nonneg`; for $\\pi^2/6$, it chains `pi_pos` through `sq_pos_of_pos` and `div_pos`.",
     "mathContext": "For $n \\geq 1$: $1/n^2 > 0$ since $n^2 > 0$. For $n = 0$: $1/0^2 = 0 \\geq 0$ (Lean's convention). The value $\\pi^2/6 > 0$ since $\\pi > 0$ implies $\\pi^2 > 0$. The `positivity` tactic automatically chains `sq_nonneg`, `div_pos`, and `pi_pos` to close these goals.",
     "significance": "supporting",
     "prerequisites": [

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -255,6 +255,26 @@
       "targetId": "sum-of-kth-powers",
       "relationship": "related",
       "description": "Faulhaber's formulas for $\\sum k^p$ involve Bernoulli numbers $B_k$, which also determine $\\zeta(2n) = (-1)^{n+1} (2\\pi)^{2n} B_{2n} / (2(2n)!)$ — the Basel problem's $\\zeta(2) = \\pi^2/6$ is the $n=1$ case with $B_2 = 1/6$"
+    },
+    {
+      "targetId": "leibniz-pi",
+      "relationship": "complementary",
+      "description": "Leibniz's formula $\\pi/4 = 1 - 1/3 + 1/5 - 1/7 + \\cdots$ and Basel's $\\sum 1/n^2 = \\pi^2/6$ are both series evaluations producing $\\pi$. Leibniz's series (a Dirichlet L-function $L(1, \\chi_4)$) converges conditionally, while Basel's $\\zeta(2)$ converges absolutely — the two represent different families of special values: Dirichlet L-values vs Riemann zeta values"
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "foundational",
+      "description": "The geometric series $\\sum r^n = 1/(1-r)$ for $|r| < 1$ is the simplest convergent series with closed form. The Basel series $\\sum 1/n^2$ is the next level — a power series with closed form involving $\\pi$. Both exemplify the paradigm of exact summation, but while geometric series sum by elementary algebra, Basel requires analytic methods (Bernoulli polynomials, Fourier theory)"
+    },
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "technique",
+      "description": "Euler's original proof compares the Taylor expansion $\\sin(x)/x = 1 - x^2/6 + x^4/120 - \\cdots$ with the infinite product $\\prod(1 - x^2/n^2\\pi^2)$. The Taylor expansion provides the $x^2$ coefficient $-1/6$ that, matched against the product expansion, yields the Basel identity. Taylor's theorem thus provides one half of the input to Euler's proof"
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "The integral test for series convergence ($\\sum f(n)$ converges iff $\\int f$ converges for decreasing $f > 0$) relies on FTC to evaluate $\\int_1^{\\infty} x^{-2}dx = 1$. This confirms convergence of $\\sum 1/n^2$ and provides the crude bound $\\sum 1/n^2 < 2$, but cannot determine the exact value $\\pi^2/6$ — for that, the deeper Bernoulli polynomial machinery is needed"
     }
   ],
   "relatedProofs": [
@@ -272,7 +292,11 @@
     "arithmetic-series",
     "basel-problem-oq-01",
     "euler-totient",
-    "sum-of-kth-powers"
+    "sum-of-kth-powers",
+    "leibniz-pi",
+    "geometric-series",
+    "taylor-theorem",
+    "fundamental-theorem-calculus"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary
- Fixed `ann-basic-properties` range (93-101 → 93-106) to cover all 3 positivity lemmas
- Fixed `ann-convergence` type from `theorem` to `context` (covers section header comment, not theorem code)
- Added `ann-namespace-setup` annotation for lines 53-60 (namespace/open declarations — previously uncovered)
- Added `ann-zeta-values-intro` annotation for lines 125-128 (zeta values section intro — previously uncovered)
- Deepened `ann-convergence` and `ann-basic-properties` content with integral test and positivity tactic details
- Added 4 cross-references: `leibniz-pi`, `geometric-series`, `taylor-theorem`, `fundamental-theorem-calculus`

## Test plan
- [x] JSON validity verified (python3 json.load)
- [x] annotations:build passes with no errors for basel-problem
- [x] All cross-referenced gallery entries verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)