### PR TITLE
Research: Machin formula from arctan addition

### DIFF
--- a/proofs/Proofs/MachinFromAddition.lean
+++ b/proofs/Proofs/MachinFromAddition.lean
@@ -1,0 +1,97 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv
+import Mathlib.Tactic
+
+/-
+# Machin's Formula from the Arctan Addition Formula
+
+## What This Proves
+
+Machin's formula (1706):
+  π/4 = 4·arctan(1/5) - arctan(1/239)
+
+derived step by step from the arctan addition formula:
+  arctan(x) + arctan(y) = arctan((x+y)/(1-xy))  when xy < 1
+
+## Approach
+
+Three applications of the addition formula:
+1. arctan(1/5) + arctan(1/5) = arctan(5/12)
+2. arctan(5/12) + arctan(5/12) = arctan(120/119)
+3. arctan(120/119) + arctan(-1/239) = arctan(1) = π/4
+
+## Why This Matters
+
+Machin used this identity in 1706 to compute 100 digits of π — a record
+at the time. The key insight is that arctan(1/5) converges much faster than
+the Leibniz series (arctan at 1). Each step is a pure algebraic consequence
+of the addition formula.
+
+This proof does NOT use Mathlib's pre-packaged
+`Real.four_mul_arctan_inv_5_sub_arctan_inv_239`. Instead, it derives
+the identity from scratch using only `Real.arctan_add`, `Real.arctan_neg`,
+and `Real.arctan_one`.
+-/
+
+namespace MachinFromAddition
+
+open Real
+
+/-- **Step 1**: Two applications of arctan(1/5) yield arctan(5/12).
+
+    arctan(1/5) + arctan(1/5) = arctan((1/5 + 1/5) / (1 - 1/5 · 1/5))
+                               = arctan((2/5) / (24/25))
+                               = arctan(5/12) -/
+theorem two_arctan_inv_5 :
+    arctan (1 / 5 : ℝ) + arctan (1 / 5 : ℝ) = arctan (5 / 12 : ℝ) := by
+  rw [arctan_add (by norm_num : (1 / 5 : ℝ) * (1 / 5) < 1)]
+  congr 1
+  norm_num
+
+/-- **Step 2**: Four applications of arctan(1/5) yield arctan(120/119).
+
+    4·arctan(1/5) = 2·(2·arctan(1/5))
+                  = 2·arctan(5/12)
+                  = arctan((5/12 + 5/12) / (1 - 5/12 · 5/12))
+                  = arctan((10/12) / (119/144))
+                  = arctan(120/119) -/
+theorem four_arctan_inv_5 :
+    4 * arctan (1 / 5 : ℝ) = arctan (120 / 119 : ℝ) := by
+  have h := two_arctan_inv_5
+  have : 4 * arctan (1 / 5 : ℝ) = (arctan (1 / 5 : ℝ) + arctan (1 / 5 : ℝ)) +
+                                    (arctan (1 / 5 : ℝ) + arctan (1 / 5 : ℝ)) := by ring
+  rw [this, h, arctan_add (by norm_num : (5 / 12 : ℝ) * (5 / 12) < 1)]
+  congr 1
+  norm_num
+
+/-- **Step 3**: Subtracting arctan(1/239) from arctan(120/119) gives arctan(1).
+
+    arctan(120/119) - arctan(1/239)
+      = arctan(120/119) + arctan(-1/239)
+      = arctan((120/119 - 1/239) / (1 + 120/(119·239)))
+      = arctan((28561/28441) / (28561/28441))
+      = arctan(1)
+
+    The numerator and denominator are both 28561/28441 = 169²/(119·239),
+    so the ratio is exactly 1. -/
+theorem arctan_diff_eq_arctan_one :
+    arctan (120 / 119 : ℝ) - arctan (1 / 239 : ℝ) = arctan (1 : ℝ) := by
+  have h : arctan (120 / 119 : ℝ) - arctan (1 / 239 : ℝ) =
+           arctan (120 / 119 : ℝ) + arctan (-(1 / 239) : ℝ) := by
+    rw [arctan_neg]; ring
+  rw [h, arctan_add (by norm_num : (120 / 119 : ℝ) * (-(1 / 239)) < 1)]
+  congr 1
+  norm_num
+
+/-- **Machin's Formula** (1706):
+
+    π/4 = 4·arctan(1/5) - arctan(1/239)
+
+    Proved from scratch using three applications of the arctan addition formula.
+    This was the identity John Machin used to compute 100 digits of π,
+    making it the most precise computation of its era. -/
+theorem machin_formula :
+    4 * arctan (1 / 5 : ℝ) - arctan (1 / 239 : ℝ) = π / 4 := by
+  rw [four_arctan_inv_5, arctan_diff_eq_arctan_one, arctan_one]
+
+end MachinFromAddition

--- a/research/problems/leibniz-pi-oq-01-oq-01/knowledge.md
+++ b/research/problems/leibniz-pi-oq-01-oq-01/knowledge.md
@@ -1,0 +1,39 @@
+# Knowledge Base: leibniz-pi-oq-01-oq-01
+
+**Problem**: Prove Machin formula from arctan addition formula
+**Status**: COMPLETED
+**Phase**: COMPLETED
+
+## Problem Summary
+
+Derive Machin's formula π/4 = 4·arctan(1/5) - arctan(1/239) step by step from the
+arctan addition formula, without using Mathlib's pre-packaged
+`four_mul_arctan_inv_5_sub_arctan_inv_239`.
+
+## Session 2026-03-23 (Session 1) - Complete Proof
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Scouted Mathlib for arctan addition API: `Real.arctan_add`, `Real.arctan_neg`, `Real.arctan_one`
+- Wrote `MachinFromAddition.lean` with step-by-step derivation
+- Three applications of `arctan_add`:
+  1. arctan(1/5) + arctan(1/5) = arctan(5/12) [xy = 1/25 < 1]
+  2. arctan(5/12) + arctan(5/12) = arctan(120/119) [xy = 25/144 < 1]
+  3. arctan(120/119) + arctan(-1/239) = arctan(1) [xy = -120/28441 < 1]
+- Docker build passed: 0 sorries, 0 axioms, 79 lines
+- Created gallery entry with meta.json, annotations.json, index.ts
+
+### Key Findings
+- The numerical coincidence 120*239 - 119 = 119*239 + 120 = 28561 = 169² makes the final step exact
+- `norm_num` handles all rational arithmetic automatically
+- `arctan_neg` converts subtraction to addition seamlessly
+- The technique generalizes to any Machin-like formula
+
+### Files Created
+- `proofs/Proofs/MachinFromAddition.lean` - The proof
+- `src/data/proofs/leibniz-pi-oq-01-oq-01/` - Gallery entry
+
+### Next Steps
+- None - proof is complete

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-machin-01-doubling",
+    "proofId": "leibniz-pi-oq-01-oq-01",
+    "range": { "startLine": 34, "endLine": 39 },
+    "type": "technique",
+    "title": "Doubling via Addition Formula",
+    "content": "two_arctan_inv_5 applies arctan_add with x = y = 1/5. The condition xy = 1/25 < 1 is trivially satisfied. The rational arithmetic (1/5 + 1/5)/(1 - 1/25) = (2/5)/(24/25) = 50/120 = 5/12 is verified by norm_num. This is the first of three applications of the addition formula.",
+    "mathContext": "$\\arctan\\frac{1}{5} + \\arctan\\frac{1}{5} = \\arctan\\frac{\\frac{1}{5}+\\frac{1}{5}}{1-\\frac{1}{5}\\cdot\\frac{1}{5}} = \\arctan\\frac{2/5}{24/25} = \\arctan\\frac{5}{12}$",
+    "significance": "key",
+    "relatedConcepts": ["arctan_add", "norm_num", "rational arithmetic"],
+    "prerequisites": ["Real.arctan_add"]
+  },
+  {
+    "id": "ann-machin-02-quadrupling",
+    "proofId": "leibniz-pi-oq-01-oq-01",
+    "range": { "startLine": 41, "endLine": 53 },
+    "type": "concept",
+    "title": "Quadrupling: 4*arctan(1/5) = arctan(120/119)",
+    "content": "four_arctan_inv_5 expresses 4*arctan(1/5) as two copies of the doubled result, then applies arctan_add with x = y = 5/12. The condition xy = 25/144 < 1 holds. The key computation: (10/12)/(119/144) = 1440/1428 = 120/119. The number 120/119 is remarkably close to 1, which is why the final step works.",
+    "mathContext": "$4\\arctan\\frac{1}{5} = 2\\arctan\\frac{5}{12} = \\arctan\\frac{\\frac{5}{12}+\\frac{5}{12}}{1-\\frac{25}{144}} = \\arctan\\frac{10/12}{119/144} = \\arctan\\frac{120}{119}$",
+    "significance": "key",
+    "relatedConcepts": ["arctan_add", "ring", "iterated doubling"],
+    "prerequisites": ["two_arctan_inv_5", "Real.arctan_add"]
+  },
+  {
+    "id": "ann-machin-03-subtraction",
+    "proofId": "leibniz-pi-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 70 },
+    "type": "concept",
+    "title": "The 28561 Coincidence",
+    "content": "arctan_diff_eq_arctan_one handles the subtraction by converting it to addition: arctan(a) - arctan(b) = arctan(a) + arctan(-b) via arctan_neg. Then arctan_add applies with x = 120/119, y = -1/239. The product xy = -120/28441 < 1 trivially. The beautiful numerical coincidence: 120*239 - 119 = 28561 and 119*239 + 120 = 28561, where 28561 = 169^2 = (13^2)^2. So numerator and denominator of the addition formula are both 28561/28441, giving a ratio of exactly 1.",
+    "mathContext": "$\\frac{\\frac{120}{119} - \\frac{1}{239}}{1 + \\frac{120}{119} \\cdot \\frac{1}{239}} = \\frac{\\frac{120 \\cdot 239 - 119}{119 \\cdot 239}}{\\frac{119 \\cdot 239 + 120}{119 \\cdot 239}} = \\frac{28561}{28561} = 1$",
+    "significance": "key",
+    "relatedConcepts": ["arctan_neg", "arctan_add", "169 squared", "numerical coincidence"],
+    "prerequisites": ["Real.arctan_add", "Real.arctan_neg"]
+  },
+  {
+    "id": "ann-machin-04-finale",
+    "proofId": "leibniz-pi-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 79 },
+    "type": "insight",
+    "title": "One-Line Assembly",
+    "content": "The final theorem machin_formula chains Steps 1-3 in a single rewrite sequence: rw [four_arctan_inv_5, arctan_diff_eq_arctan_one, arctan_one]. This illustrates the power of compositional proof: once each step is established, the final result is trivial. The proof uses only three Mathlib lemmas (arctan_add, arctan_neg, arctan_one) and pure rational arithmetic.",
+    "mathContext": "$4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239} = \\arctan\\frac{120}{119} - \\arctan\\frac{1}{239} = \\arctan 1 = \\frac{\\pi}{4}$",
+    "significance": "supporting",
+    "relatedConcepts": ["compositional proof", "rewrite chain", "arctan_one"],
+    "prerequisites": ["four_arctan_inv_5", "arctan_diff_eq_arctan_one", "Real.arctan_one"]
+  }
+]

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/index.ts
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MachinFromAddition.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const leibnizPiOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const leibnizPiOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const leibnizPiOQ01OQ01Data: ProofData = {
+  proof: leibnizPiOQ01OQ01Proof,
+  annotations: leibnizPiOQ01OQ01Annotations,
+}

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "leibniz-pi-oq-01-oq-01",
+  "title": "Machin's Formula from the Arctan Addition Formula",
+  "slug": "leibniz-pi-oq-01-oq-01",
+  "description": "Derives Machin's formula pi/4 = 4*arctan(1/5) - arctan(1/239) step by step from three applications of the arctan addition formula arctan(x) + arctan(y) = arctan((x+y)/(1-xy)). No pre-packaged Mathlib lemma is used for the final identity.",
+  "meta": {
+    "author": "John Machin (1706); step-by-step derivation formalized here",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Machin-like_formula",
+    "date": "1706",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MachinFromAddition.lean",
+    "tags": [
+      "analysis",
+      "pi",
+      "arctangent",
+      "series",
+      "computation",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.arctan_add",
+        "description": "arctan(x) + arctan(y) = arctan((x+y)/(1-xy)) when xy < 1",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan"
+      },
+      {
+        "theorem": "Real.arctan_neg",
+        "description": "arctan(-x) = -arctan(x)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan"
+      },
+      {
+        "theorem": "Real.arctan_one",
+        "description": "arctan(1) = pi/4",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan"
+      }
+    ],
+    "originalContributions": [
+      "Step-by-step derivation of Machin's formula using only the arctan addition formula",
+      "two_arctan_inv_5: proves arctan(1/5) + arctan(1/5) = arctan(5/12) via addition formula",
+      "four_arctan_inv_5: proves 4*arctan(1/5) = arctan(120/119) by doubling twice",
+      "arctan_diff_eq_arctan_one: proves arctan(120/119) - arctan(1/239) = arctan(1) using 28561/28441 cancellation"
+    ],
+    "references": [
+      {
+        "authors": "Machin, John",
+        "title": "The solution of Kepler's problem",
+        "year": "1706",
+        "venue": "Philosophical Transactions of the Royal Society",
+        "note": "Original discovery of the formula pi/4 = 4*arctan(1/5) - arctan(1/239)"
+      },
+      {
+        "authors": "Beckmann, Petr",
+        "title": "A History of Pi",
+        "year": "1971",
+        "venue": "Golem Press",
+        "note": "Chapter 10 discusses Machin's formula and its impact on pi computation"
+      }
+    ],
+    "prerequisites": [
+      "Arctan addition formula: arctan(x) + arctan(y) = arctan((x+y)/(1-xy)) for xy < 1",
+      "Arctan parity: arctan(-x) = -arctan(x)",
+      "arctan(1) = pi/4"
+    ],
+    "dateAdded": "2026-03-23",
+    "axiomCount": 0,
+    "lineCount": 79,
+    "leanFile": "proofs/Proofs/MachinFromAddition.lean"
+  },
+  "overview": {
+    "historicalContext": "In 1706, John Machin, professor of astronomy at Gresham College, London, discovered that $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$. He used this to compute 100 digits of $\\pi$, a record at the time. The formula's power lies in replacing the arctan series at $x=1$ (the Leibniz series, converging at rate $O(1/N)$) with evaluations at $x = 1/5$ and $x = 1/239$, where convergence is exponential.\n\nWilliam Shanks used Machin's formula in 1873 to compute 707 digits (later found to have an error after digit 527). Machin-like formulas dominated $\\pi$ computation for over 250 years until the Borwein and Chudnovsky algorithms introduced fundamentally faster approaches.\n\nThis formalization derives Machin's formula from scratch, applying the arctan addition formula three times. The derivation reveals the beautiful algebraic coincidence: $4\\arctan(1/5) = \\arctan(120/119)$, and $120/119$ is close enough to 1 that subtracting $\\arctan(1/239)$ yields exactly $\\arctan(1)$. The numerics work out because $169^2 = 28561$ appears in both numerator and denominator of the final fraction.",
+    "problemStatement": "**Open Question (from parent proof)**: Prove Machin's formula $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$ from the arctan addition formula, rather than invoking Mathlib's pre-packaged lemma.\n\n**Resolution**: Three applications of $\\arctan(x) + \\arctan(y) = \\arctan\\left(\\frac{x+y}{1-xy}\\right)$ suffice:\n1. $\\arctan(1/5) + \\arctan(1/5) = \\arctan(5/12)$\n2. $\\arctan(5/12) + \\arctan(5/12) = \\arctan(120/119)$\n3. $\\arctan(120/119) + \\arctan(-1/239) = \\arctan(1) = \\pi/4$",
+    "proofStrategy": "The proof applies `Real.arctan_add` three times with explicit rational arithmetic:\n\n**Step 1 (two_arctan_inv_5)**: With $x = y = 1/5$, the condition $xy = 1/25 < 1$ holds, giving $\\arctan(1/5) + \\arctan(1/5) = \\arctan\\left(\\frac{2/5}{24/25}\\right) = \\arctan(5/12)$.\n\n**Step 2 (four_arctan_inv_5)**: With $x = y = 5/12$, the condition $xy = 25/144 < 1$ holds, giving $2\\arctan(5/12) = \\arctan\\left(\\frac{10/12}{119/144}\\right) = \\arctan(120/119)$.\n\n**Step 3 (arctan_diff_eq_arctan_one)**: Rewrite the subtraction as addition using $\\arctan(-x) = -\\arctan(x)$. With $x = 120/119, y = -1/239$, the condition $xy = -120/28441 < 1$ holds, giving $\\arctan\\left(\\frac{28561/28441}{28561/28441}\\right) = \\arctan(1) = \\pi/4$.\n\nThe final step uses the fact that $120 \\cdot 239 - 119 = 28561 = 169^2$ and $119 \\cdot 239 + 120 = 28561$, so both numerator and denominator of the addition formula equal $28561/28441$, yielding a ratio of exactly 1.",
+    "keyInsights": [
+      "Three applications of arctan_add suffice to derive Machin's formula from first principles",
+      "The key numerical coincidence: 120*239 - 119 = 119*239 + 120 = 28561 = 169^2, making the final fraction exactly 1",
+      "The subtraction arctan(a) - arctan(b) is handled by arctan_neg + arctan_add, converting to arctan(a) + arctan(-b)",
+      "All three applications of arctan_add have xy < 1 trivially satisfied (either both factors < 1, or one factor is negative)",
+      "The proof technique generalizes: any Machin-like formula pi/4 = sum of c_i * arctan(a_i/b_i) can be verified by iterating arctan_add"
+    ]
+  },
+  "sections": [
+    {
+      "id": "step1",
+      "title": "Step 1: Doubling arctan(1/5)",
+      "startLine": 34,
+      "endLine": 39,
+      "summary": "Proves $\\arctan(1/5) + \\arctan(1/5) = \\arctan(5/12)$ via the addition formula with $xy = 1/25 < 1$. The rational arithmetic $(2/5)/(24/25) = 5/12$ is verified by `norm_num`."
+    },
+    {
+      "id": "step2",
+      "title": "Step 2: Doubling to arctan(120/119)",
+      "startLine": 41,
+      "endLine": 53,
+      "summary": "Proves $4 \\cdot \\arctan(1/5) = \\arctan(120/119)$ by expressing $4 \\cdot \\arctan(1/5) = 2 \\cdot \\arctan(5/12)$ and applying the addition formula again with $xy = 25/144 < 1$."
+    },
+    {
+      "id": "step3",
+      "title": "Step 3: Subtracting arctan(1/239)",
+      "startLine": 55,
+      "endLine": 70,
+      "summary": "Proves $\\arctan(120/119) - \\arctan(1/239) = \\arctan(1)$ by rewriting the subtraction as addition of $\\arctan(-1/239)$ and applying arctan_add. The key computation: $(28561/28441)/(28561/28441) = 1$."
+    },
+    {
+      "id": "main",
+      "title": "Machin's Formula",
+      "startLine": 72,
+      "endLine": 79,
+      "summary": "Combines Steps 1-3 to prove $4 \\cdot \\arctan(1/5) - \\arctan(1/239) = \\pi/4$ in one line: rewrite via `four_arctan_inv_5` and `arctan_diff_eq_arctan_one`, then apply `arctan_one`."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machin's formula is derived from scratch using only the arctan addition formula, arctan parity, and arctan(1) = pi/4. The proof is fully verified with 0 sorries and 0 axioms. Each step reduces to pure rational arithmetic verified by norm_num.",
+    "implications": "This resolves the open question from the parent proof (leibniz-pi-oq-01) about deriving Machin's formula from the addition formula. The technique generalizes to any Machin-like formula: each such identity can be verified by iterating arctan_add with norm_num checking the rational arithmetic.\n\nThe proof also demonstrates that Mathlib's arctan API is sufficient for compositional reasoning about arctangent identities, without needing to invoke specialized pre-packaged formulas.",
+    "openQuestions": [
+      "Can the technique be automated to verify arbitrary Machin-like formulas (e.g., Wetherfield's pi/4 = 12*arctan(1/49) + ...)?",
+      "What is the optimal Machin-like formula (minimizing terms for a given accuracy)?",
+      "Can Lean's norm_num be extended to verify Machin-like identities in a single tactic call?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real"],
+    "namespace": "MachinFromAddition",
+    "lineCount": 79,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "leibniz-pi-oq-01",
+      "relationship": "resolves",
+      "description": "Answers the open question about deriving Machin's formula from the arctan addition formula"
+    },
+    {
+      "targetId": "leibniz-pi",
+      "relationship": "extends",
+      "description": "Provides a constructive derivation of the faster-converging alternative to the Leibniz series"
+    }
+  ],
+  "relatedProofs": [
+    "leibniz-pi",
+    "leibniz-pi-oq-01"
+  ]
+}

--- a/src/data/research/problems/leibniz-pi-oq-01-oq-01.json
+++ b/src/data/research/problems/leibniz-pi-oq-01-oq-01.json
@@ -1,37 +1,57 @@
 {
   "slug": "leibniz-pi-oq-01-oq-01",
   "title": "Prove Machin formula from arctan addition formula",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE.",
-    "whyMatters": []
+    "formal": "theorem machin_formula : 4 * arctan (1 / 5 : ℝ) - arctan (1 / 239 : ℝ) = π / 4",
+    "plain": "Derive Machin's formula π/4 = 4·arctan(1/5) - arctan(1/239) step by step from the arctan addition formula, without using Mathlib's pre-packaged lemma.",
+    "whyMatters": [
+      "Resolves the open question from the parent proof about deriving Machin's formula from first principles",
+      "Demonstrates compositional use of Mathlib's arctan API",
+      "Historically significant: Machin used this to compute 100 digits of π in 1706"
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "Machin's formula derived from three applications of arctan_add",
+      "arctan(1/5) + arctan(1/5) = arctan(5/12)",
+      "4*arctan(1/5) = arctan(120/119)",
+      "arctan(120/119) - arctan(1/239) = arctan(1) = π/4"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "Complete proof from arctan addition formula"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-22T22:32:23.162Z",
+    "phase": "COMPLETED",
+    "since": "2026-03-23T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proof complete, PR pending.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Merge PR.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: Machin's formula proved from arctan addition in 79 lines, 0 sorries, 0 axioms. Builds successfully.",
+    "builtItems": [
+      "two_arctan_inv_5: arctan(1/5) + arctan(1/5) = arctan(5/12) in MachinFromAddition.lean",
+      "four_arctan_inv_5: 4*arctan(1/5) = arctan(120/119) in MachinFromAddition.lean",
+      "arctan_diff_eq_arctan_one: arctan(120/119) - arctan(1/239) = arctan(1) in MachinFromAddition.lean",
+      "machin_formula: 4*arctan(1/5) - arctan(1/239) = π/4 in MachinFromAddition.lean"
+    ],
+    "insights": [
+      "Three applications of Real.arctan_add suffice to derive Machin's formula",
+      "The key numerical coincidence: 120*239 - 119 = 119*239 + 120 = 28561 = 169^2",
+      "Subtraction is handled via arctan_neg converting to addition",
+      "norm_num handles all rational arithmetic verification automatically",
+      "The technique generalizes to any Machin-like formula"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },
@@ -39,7 +59,8 @@
     "seeker-selected",
     "analysis",
     "pi",
-    "series"
+    "series",
+    "completed"
   ],
   "relatedProofs": [
     "leibniz-pi",
@@ -48,13 +69,28 @@
   "references": {
     "papers": [],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Real.arctan_add",
+      "Real.arctan_neg",
+      "Real.arctan_one"
+    ]
   },
   "started": "2026-03-22T22:32:23.162Z",
-  "lastUpdate": "2026-03-22T22:32:23.162Z",
+  "lastUpdate": "2026-03-23T00:00:00Z",
   "significance": 6,
   "tractability": 7,
   "leanFiles": [
+    {
+      "path": "Proofs/MachinFromAddition.lean",
+      "filename": "MachinFromAddition.lean",
+      "lineCount": 79,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MachinFromAddition.lean"
+    },
     {
       "path": "Proofs/LeibnizPi.lean",
       "filename": "LeibnizPi.lean",


### PR DESCRIPTION
## Summary

- Proves Machin's formula π/4 = 4·arctan(1/5) - arctan(1/239) from scratch using three applications of the arctan addition formula
- Does NOT use Mathlib's pre-packaged `four_mul_arctan_inv_5_sub_arctan_inv_239` — derives it step by step
- Resolves the open question from the `leibniz-pi-oq-01` gallery entry

## Proof Steps

1. `two_arctan_inv_5`: arctan(1/5) + arctan(1/5) = arctan(5/12) via `arctan_add`
2. `four_arctan_inv_5`: 4·arctan(1/5) = arctan(120/119) by doubling twice
3. `arctan_diff_eq_arctan_one`: arctan(120/119) - arctan(1/239) = arctan(1) using the numerical coincidence 120·239 - 119 = 119·239 + 120 = 28561 = 169²

## Files

| File | Description |
|------|-------------|
| `proofs/Proofs/MachinFromAddition.lean` | Lean proof (79 lines, 4 theorems, 0 sorries, 0 axioms) |
| `src/data/proofs/leibniz-pi-oq-01-oq-01/` | Gallery entry (meta, annotations, index) |
| `research/problems/leibniz-pi-oq-01-oq-01/knowledge.md` | Research knowledge |

## Verification

Docker build passes successfully:
```
✔ [3063/3063] Built Proofs.MachinFromAddition (2.1s)
Build completed successfully (3063 jobs).
```

## Test plan

- [x] Docker build passes with 0 errors
- [x] 0 sorries, 0 axioms
- [x] Gallery entry follows existing patterns (meta.json, annotations.json, index.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)