### PR TITLE
Enrich 8 entries: annotations, cross-refs, references

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -220,7 +220,7 @@
     },
     "type": "theorem",
     "title": "A₅ is Simple",
-    "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A₅ is simple - it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A₅.",
+    "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A₅ is simple — it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A₅.\n\nGeometrically, $A_5$ is isomorphic to the rotation group of the regular icosahedron (and its dual, the dodecahedron). Felix Klein exploited this connection in his 1884 *Lectures on the Icosahedron* to solve the quintic by elliptic modular functions — bypassing the radical barrier by using the icosahedron's symmetries to reduce the quintic to a modular equation solvable by theta functions. This shows that $A_5$'s simplicity blocks radical solutions specifically, not all closed-form solutions.",
     "mathContext": "$A_5 = \\ker(\\text{sign} : S_5 \\to \\{\\pm 1\\}) = \\{\\sigma \\in S_5 : \\text{sign}(\\sigma) = +1\\}$, $|A_5| = 60 = 5!/2$.\n\nConjugacy classes: identity (1), products of two disjoint transpositions (15), 3-cycles (20), and two classes of 5-cycles (12 + 12). A normal subgroup $N \\trianglelefteq A_5$ must be a union of conjugacy classes containing $\\{e\\}$ (size 1), and $|N|$ must divide 60. The possible sub-sums starting with 1 are: $1, 1{+}15{=}16, 1{+}20{=}21, 1{+}12{=}13, 1{+}15{+}20{=}36, \\ldots$ — none divides 60 except 1 and 60 itself. Therefore $A_5$ has no proper nontrivial normal subgroups.\n\nLean: `alternatingGroup.isSimpleGroup_five : IsSimpleGroup (alternatingGroup (Fin 5))`.",
     "significance": "key",
     "prerequisites": [
@@ -232,7 +232,9 @@
       "alternating group",
       "simple group",
       "normal subgroup",
-      "cycle type"
+      "cycle type",
+      "icosahedral symmetry",
+      "Klein's icosahedron"
     ]
   },
   {
@@ -336,7 +338,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 185
+      "endLine": 183
     },
     "type": "context",
     "title": "Why Degree 5 and the Historical Revolution",

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -534,6 +534,27 @@
       "year": "1963",
       "venue": "Pacific Journal of Mathematics, vol. 13, no. 3, pp. 775–1029",
       "note": "The celebrated Odd Order Theorem: every finite group of odd order is solvable. This 255-page proof is the deepest result about group solvability since Galois and directly implies that any polynomial whose Galois group has odd order is solvable by radicals"
+    },
+    {
+      "authors": "Wiedijk, Freek",
+      "title": "Formalizing 100 Theorems",
+      "year": "2008",
+      "venue": "https://www.cs.ru.nl/~freek/100/",
+      "note": "The definitive list of 100 well-known mathematical theorems and their formalization status across proof assistants. The Abel-Ruffini theorem is #16. This formalization contributes to the Lean 4 / Mathlib column of the list"
+    },
+    {
+      "authors": "Pesic, Peter",
+      "title": "Abel's Proof: An Essay on the Sources and Meaning of Mathematical Unsolvability",
+      "year": "2003",
+      "venue": "MIT Press",
+      "note": "Accessible modern account tracing the intellectual journey from the Renaissance algebraists through Abel and Galois, placing the impossibility of the quintic in the broader context of mathematical thought about the limits of symbolic methods"
+    },
+    {
+      "authors": "Klein, Felix",
+      "title": "Vorlesungen über das Ikosaeder und die Auflösung der Gleichungen vom fünften Grade",
+      "year": "1884",
+      "venue": "Teubner, Leipzig (English translation: Lectures on the Icosahedron, 1888, Trübner & Co.)",
+      "note": "Klein's masterwork connecting the quintic to the symmetries of the icosahedron (rotation group ≅ A₅) and solving it via elliptic modular functions and hypergeometric series. Directly relevant to the open question about formalizing alternative quintic solutions beyond radicals: Klein showed that the icosahedral equation x⁵ + x + a can be solved by theta functions, linking A₅'s geometry to transcendental function theory"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -105,6 +105,13 @@
         "year": "1961",
         "venue": "Springer, Ergebnisse der Mathematik und ihrer Grenzgebiete, Band 30",
         "note": "Chapter 2: comprehensive treatment of means and their inequalities, including the power mean family and its continuity properties at r = 0"
+      },
+      {
+        "authors": "Kolmogorov, A.N.",
+        "title": "Sur la notion de la moyenne",
+        "year": "1930",
+        "venue": "Atti della Reale Accademia Nazionale dei Lincei, Rendiconti, Classe di Scienze Fisiche, Matematiche e Naturali, ser. 6, vol. 12, pp. 388–391",
+        "note": "Independently of Nagumo, characterized the power mean family as the unique class of quasi-arithmetic means satisfying continuity, strict monotonicity, and homogeneity. The r→0 limit proved in this formalization is the continuity condition at the singular point that makes the power mean family a smooth one-parameter family from min to max"
       }
     ]
   },
@@ -163,10 +170,15 @@
       "targetId": "fundamental-theorem-calculus",
       "relationship": "foundational",
       "description": "The fundamental theorem of calculus underpins the derivative machinery used throughout this proof. The key bridge hasDerivAt_iff_tendsto_slope — connecting HasDerivAt to the slope limit f(r)/r → f'(0) — is a consequence of the differential calculus framework that FTC establishes"
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The harmonic mean HM = (∑ wᵢ/zᵢ)⁻¹ = M_{-1} is the r = -1 case of the power mean family. This limit result establishes M_0 = GM, bridging the gap between HM and AM in the chain HM ≤ GM ≤ AM. The harmonic series divergence proof formalizes the arithmetic of reciprocals that underpins the HM ≤ GM step via the inversion trick"
     }
   ],
   "overview": {
-    "historicalContext": "The power mean $M_r(z,w) = (\\sum w_i z_i^r)^{1/r}$ is undefined at $r = 0$, but the limit exists and equals the geometric mean $\\text{GM} = \\prod z_i^{w_i}$. This was established by Hardy, Littlewood, and Pólya (*Inequalities*, 1934, §2.9) and makes the power mean a continuous interpolation between min ($r \\to -\\infty$), HM ($r=-1$), GM ($r=0$), AM ($r=1$), and max ($r \\to +\\infty$).\n\nThe result has deep connections to information theory. The expression $\\sum w_i \\log z_i$ appearing in the limit is exactly the negative of the Kullback-Leibler divergence $D_{KL}(w \\| \\text{uniform})$ applied to $\\log z$, and more broadly, the Rényi entropy $H_\\alpha = \\frac{1}{1-\\alpha}\\log\\sum p_i^\\alpha$ (Rényi, 1961) satisfies $\\lim_{\\alpha \\to 1} H_\\alpha = H_1 = -\\sum p_i \\log p_i$ (Shannon entropy) by the same derivative-at-zero technique used here. The power mean limit is thus a special case of the Rényi-to-Shannon entropy limit.\n\nThe proof uses the definition of derivative: $f(r) = \\log(\\sum w_i z_i^r)$ satisfies $f(0) = 0$ and $f'(0) = \\sum w_i \\log z_i$. Therefore $f(r)/r \\to f'(0)$ by the definition of derivative, and $M_r = \\exp(f(r)/r) \\to \\exp(\\sum w_i \\log z_i) = \\text{GM}$ by continuity of exp. The Lean 4 formalization uses `hasDerivAt_iff_tendsto_slope` as the key bridge, avoiding explicit L'Hôpital machinery.",
+    "historicalContext": "The power mean $M_r(z,w) = (\\sum w_i z_i^r)^{1/r}$ is undefined at $r = 0$, but the limit exists and equals the geometric mean $\\text{GM} = \\prod z_i^{w_i}$. This was established by Hardy, Littlewood, and Pólya (*Inequalities*, 1934, §2.9) and makes the power mean a continuous interpolation between min ($r \\to -\\infty$), HM ($r=-1$), GM ($r=0$), AM ($r=1$), and max ($r \\to +\\infty$).\n\nThe result has deep connections to information theory. The expression $\\sum w_i \\log z_i$ appearing in the limit is exactly the negative of the Kullback-Leibler divergence $D_{KL}(w \\| \\text{uniform})$ applied to $\\log z$, and more broadly, the Rényi entropy $H_\\alpha = \\frac{1}{1-\\alpha}\\log\\sum p_i^\\alpha$ (Rényi, 1961) satisfies $\\lim_{\\alpha \\to 1} H_\\alpha = H_1 = -\\sum p_i \\log p_i$ (Shannon entropy) by the same derivative-at-zero technique used here. The power mean limit is thus a special case of the Rényi-to-Shannon entropy limit.\n\nIn 1930, Kolmogorov and Nagumo independently proved that the power mean family is (essentially) the unique class of quasi-arithmetic means satisfying continuity, strict monotonicity, and homogeneity. The r→0 limit is the continuity condition at the singular point that makes the power mean a smooth one-parameter interpolation. Without it, the family would have a gap at r=0, and the Kolmogorov-Nagumo characterization would not hold.\n\nThe proof uses the definition of derivative: $f(r) = \\log(\\sum w_i z_i^r)$ satisfies $f(0) = 0$ and $f'(0) = \\sum w_i \\log z_i$. Therefore $f(r)/r \\to f'(0)$ by the definition of derivative, and $M_r = \\exp(f(r)/r) \\to \\exp(\\sum w_i \\log z_i) = \\text{GM}$ by continuity of exp. The Lean 4 formalization uses `hasDerivAt_iff_tendsto_slope` as the key bridge, avoiding explicit L'Hôpital machinery.",
     "problemStatement": "**Open Question (amgm-inequality-oq-03-oq-02)**: Formalize the limit lim_{r→0} M_r(z,w) = GM(z,w) in Lean 4.\n\n**Definitions**:\n- M_r(z,w) = (∑ wᵢzᵢ^r)^(1/r)  for r ≠ 0, wᵢ ≥ 0, ∑ wᵢ = 1, zᵢ > 0\n- GM(z,w) = ∏ zᵢ^wᵢ (weighted geometric mean)\n\n**The Limit**: Filter.Tendsto (fun r => (∑ wᵢzᵢ^r)^(1/r)) (nhdsWithin 0 {0}ᶜ) (nhds (∏ zᵢ^wᵢ))\n\n**Proof sketch**: f(r) = log(∑ wᵢzᵢ^r), f(0) = 0, f'(0) = ∑ wᵢ log zᵢ, so M_r = exp(f(r)/r) → exp(∑ wᵢ log zᵢ) = GM.",
     "proofStrategy": "**Step 1**: Establish M_r = exp((1/r)·log(∑ wᵢzᵢ^r)) for zᵢ > 0 via Real.rpow_def_of_pos.\n\n**Step 2**: Prove d/dr[∑ wᵢzᵢ^r]|_{r=0} = ∑ wᵢ log zᵢ:\n- Each term: HasDerivAt (fun r => zᵢ^r) (log zᵢ) 0 via Real.hasStrictDerivAt_const_rpow + rpow_zero\n- Apply HasDerivAt.const_mul and HasDerivAt.sum\n\n**Step 3**: Establish g(r) = log(∑ wᵢzᵢ^r) has g(0) = 0 and g'(0) = ∑ wᵢ log zᵢ:\n- Chain rule: Real.hasDerivAt_log composed with step 2\n- g(0) = log(1) = 0 since ∑ wᵢzᵢ^0 = ∑ wᵢ = 1\n\n**Step 4**: Conclude g(r)/r → g'(0) via hasDerivAt_iff_tendsto_slope (congr on slope formula).\n\n**Step 5**: Apply Real.continuous_exp.continuousAt to get M_r = exp(g(r)/r) → exp(∑ wᵢ log zᵢ) = GM.",
     "keyInsights": [
@@ -286,6 +298,7 @@
     "triangle-inequality",
     "cauchy-schwarz",
     "sum-of-kth-powers",
-    "fundamental-theorem-calculus"
+    "fundamental-theorem-calculus",
+    "harmonic-divergence"
   ]
 }

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -68,38 +68,53 @@
     ],
     "references": [
       {
-        "key": "Wa37",
-        "citation": "Wantzel, P.L., Recherches sur les moyens de reconnaître si un Problème de Géométrie peut se résoudre avec la règle et le compas, Journal de mathématiques pures et appliquées 2 (1837), 366–372.",
-        "type": "paper"
+        "authors": "Wantzel, Pierre Laurent",
+        "title": "Recherches sur les moyens de reconnaître si un Problème de Géométrie peut se résoudre avec la règle et le compas",
+        "year": "1837",
+        "venue": "Journal de Mathématiques Pures et Appliquées, vol. 2, pp. 366–372",
+        "note": "First rigorous proof that the three classical construction problems (trisection, doubling, squaring) are impossible. Wantzel showed that compass-and-straightedge constructions produce only algebraic numbers whose minimal polynomial degree is a power of 2"
       },
       {
-        "key": "St04",
-        "citation": "Stewart, I., Galois Theory, 3rd ed., Chapman & Hall/CRC (2004), Chapter 5.",
-        "type": "book"
-      },
-      {
-        "key": "Ga01",
-        "citation": "Gauss, C.F., Disquisitiones Arithmeticae (1801), §365.",
-        "type": "book",
+        "authors": "Gauss, Carl Friedrich",
+        "title": "Disquisitiones Arithmeticae",
+        "year": "1801",
+        "venue": "Gerhard Fleischer, Leipzig, §365",
         "note": "Gauss proved the regular 17-gon is constructible using the 2-group structure of Gal(ℚ(ζ₁₇)/ℚ) ≅ ℤ/16ℤ, implicitly anticipating the Galois characterization of constructibility"
       },
       {
-        "key": "Co04",
-        "citation": "Cox, D.A., Galois Theory, 2nd ed., Wiley (2004, 2012), Chapters 10–11.",
-        "type": "book",
+        "authors": "Stewart, Ian",
+        "title": "Galois Theory",
+        "year": "2004",
+        "venue": "Chapman & Hall/CRC, 3rd edition, Chapter 5",
+        "note": "Modern textbook treatment of the Galois-theoretic characterization of constructibility, including the connection between 2-groups and compass-and-straightedge constructions"
+      },
+      {
+        "authors": "Cox, David A.",
+        "title": "Galois Theory",
+        "year": "2012",
+        "venue": "Wiley, 2nd edition, Chapters 10–11",
         "note": "Detailed treatment of constructibility and the Galois correspondence: Chapter 10 covers compass-and-straightedge constructions and the characterization via 2-group Galois groups, Chapter 11 covers the Gauss-Wantzel theorem for regular polygons"
       },
       {
-        "key": "Ma98",
-        "citation": "Martin, G.E., Geometric Constructions, Springer Undergraduate Texts in Mathematics (1998).",
-        "type": "book",
+        "authors": "Martin, George E.",
+        "title": "Geometric Constructions",
+        "year": "1998",
+        "venue": "Springer Undergraduate Texts in Mathematics",
         "note": "Comprehensive reference on constructibility theory with algebraic proofs of the three classical impossibilities (trisection, doubling, squaring) via field extension degrees and Galois groups"
       },
       {
-        "key": "Ro95",
-        "citation": "Rotman, J.J., An Introduction to the Theory of Groups, 4th ed., Springer GTM 148 (1995), Chapter 5.",
-        "type": "book",
+        "authors": "Rotman, Joseph J.",
+        "title": "An Introduction to the Theory of Groups",
+        "year": "1995",
+        "venue": "Springer GTM 148, 4th edition, Chapter 5",
         "note": "Standard treatment of p-groups and Sylow theory: proves that p-groups have composition series with ℤ/pℤ factors, the structural fact underlying the Galois 2-group characterization of constructibility"
+      },
+      {
+        "authors": "Hadlock, Charles Robert",
+        "title": "Field Theory and Its Classical Problems",
+        "year": "1978",
+        "venue": "Carus Mathematical Monographs No. 19, MAA",
+        "note": "Elegant exposition connecting classical construction problems to field theory, with complete proofs that the three impossibilities follow from the Galois-theoretic characterization of constructibility"
       }
     ],
     "lineCount": 298
@@ -189,6 +204,11 @@
       "targetId": "e-transcendental",
       "relationship": "related",
       "description": "The transcendence of $e$ (Hermite 1873) is a strictly stronger impossibility than non-constructibility: transcendental numbers are not just non-constructible but satisfy no polynomial over $\\mathbb{Q}$ at all. The Galois criterion applies only to algebraic numbers — for transcendental numbers, even the Galois group framework does not apply"
+    },
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "complementary",
+      "description": "Cardano's cubic formula solves cubics by radicals (S₃ is solvable), but cos(20°) satisfies the cubic 8x³-6x-1=0 yet is NOT constructible — because S₃ is solvable but not a 2-group. This is the key distinction: solvability by radicals (solvable Galois group) is strictly weaker than constructibility (2-group Galois group). Cardano's formula gives cos(20°) in terms of cube roots, confirming it is solvable by radicals, yet the Galois 2-group criterion blocks constructibility"
     }
   ],
   "overview": {
@@ -327,6 +347,7 @@
     "primitive-roots",
     "euler-totient",
     "nth-root-irrational",
-    "e-transcendental"
+    "e-transcendental",
+    "solution-of-cubic"
   ]
 }

--- a/src/data/proofs/infinitude-primes/annotations.json
+++ b/src/data/proofs/infinitude-primes/annotations.json
@@ -225,16 +225,37 @@
     "proofId": "infinitude-primes",
     "range": {
       "startLine": 116,
-      "endLine": 116
+      "endLine": 121
     },
     "type": "technique",
     "title": "No Largest Prime",
-    "content": "There is no largest prime. If there were a prime $p$ such that all primes $q \\leq p$, then by unbounded_primes we could find a prime $q > p$, contradicting that $p$ is largest.\n\nThis is the contrapositive way of saying primes are infinite.",
-    "mathContext": "$\\neg \\exists p$ prime such that $\\forall q$ prime, $q \\leq p$",
+    "content": "There is no largest prime. If there were a prime $p$ such that all primes $q \\leq p$, then by `unbounded_primes` we could find a prime $q > p$ with $q > p$, but the assumption says $q \\leq p$ — contradiction via `omega`. The proof is a 4-line argument by contradiction using the unboundedness result.\n\nThis is the contrapositive way of saying primes are infinite: the negation of 'there exists a largest' is 'for all primes, there is a larger one.'",
+    "mathContext": "$\\neg \\exists p$ prime such that $\\forall q$ prime, $q \\leq p$. Proof: assume such $p$ exists. By `unbounded_primes`, $\\exists q$ prime with $q > p$. But $q \\leq p$ by assumption. $q > p$ and $q \\leq p$ is a contradiction.",
     "significance": "key",
     "relatedConcepts": [
       "unboundedness",
-      "proof by contradiction"
+      "proof by contradiction",
+      "omega tactic"
+    ]
+  },
+  {
+    "id": "ann-verification",
+    "proofId": "infinitude-primes",
+    "range": {
+      "startLine": 123,
+      "endLine": 127
+    },
+    "type": "context",
+    "title": "Verification and Namespace Close",
+    "content": "Type-checks the three main results: `unbounded_primes` (for any $n$, there exists a prime $> n$), `primes_infinite` (alias emphasizing infinitude), and `no_largest_prime` (negation of a largest prime). Together they give three equivalent formulations of the infinitude of primes, all fully verified with 0 sorries.",
+    "mathContext": "Three equivalent formulations: (1) $\\forall n, \\exists p > n, p$ prime; (2) $\\{p : p \\text{ prime}\\}$ is infinite; (3) $\\neg \\exists p$ prime, $\\forall q$ prime, $q \\leq p$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "#check verification",
+      "equivalent formulations"
+    ],
+    "prerequisites": [
+      "Lean 4 meta-commands"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

### angle-trisection-oq-02 (NEW)
- Normalized 6 references from key/citation to standard authors/title/year/venue/note format
- Added Hadlock (1978) reference on field theory and classical problems
- Added solution-of-cubic cross-reference (cubic formula vs constructibility distinction)

### abel-ruffini
- Added icosahedral geometry connection to A₅ simplicity annotation
- Added 3 scholarly references: Wiedijk, Pesic, Klein

### amgm-inequality-oq-03-oq-02 (Power Mean Limit)
- Added Kolmogorov (1930) reference, harmonic-divergence cross-reference
- Deepened historicalContext with Kolmogorov-Nagumo characterization

### erdos-10
- Added annotation for module docstring with Goldbach connection
- Added 3 cross-references

### pythagorean-theorem
- Added 3 annotations for uncovered sections

### fundamental-theorem-algebra
- Added 4 annotations for uncovered sections

### cantors-theorem
- Added mathContext to 5 annotations

### infinitude-primes
- Extended ann-no-largest, added ann-verification

## Test plan
- [x] JSON validation passes for all entries
- [x] All cross-reference targets verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)