### PR TITLE
Enrich angle-trisection-oq-02-oq-01: fix refs, add coverage

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-module-docstring",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 11 },
+    "type": "context",
+    "title": "Module Overview: Axiom Elimination via Mathlib Bridge",
+    "content": "The module docstring frames the file's purpose: proving `galois_2group_implies_degree_pow2` — which was an axiom in AngleTrisectionOQ02.lean — by generalizing Mathlib's `prime_degree_dvd_card` to all irreducible polynomials. This reduces the parent's axiom count from 6 to 5.\n\nThe docstring establishes the file's position in the formalization hierarchy: it sits between OQ-01 (degree characterization, fully verified) and OQ-02 (Galois characterization, partially axiomatized), providing a bridge that strengthens the connection between Mathlib's infrastructure and the constructibility theorems.",
+    "mathContext": "The axiom being eliminated: `galois_2group_implies_degree_pow2 : IsPGroup 2 (minpoly ℚ α).Gal → ∃ n, natDegree (minpoly ℚ α) ∣ 2^n`. The file proves this from Mathlib via the tower law, reducing the axiom count of the OQ-02 formalization.",
+    "significance": "context",
+    "relatedConcepts": ["axiom elimination", "Mathlib bridge", "formalization hierarchy"],
+    "prerequisites": ["AngleTrisectionOQ02", "AngleTrisectionOQ01"]
+  },
+  {
     "id": "ann-imports-context",
     "proofId": "angle-trisection-oq-02-oq-01",
     "range": { "startLine": 13, "endLine": 18 },

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -58,43 +58,6 @@
       "galois_2group_implies_degree_is_pow2: Stronger — natDegree IS a power of 2, using OQ-01's dvd_pow_two_is_pow_two",
       "galois_criterion_implies_degree_criterion: Bridges the Galois criterion (2-group Gal) to the degree criterion (degree = 2^k)"
     ],
-    "references": [
-      {
-        "authors": "P. L. Wantzel",
-        "title": "Recherches sur les moyens de reconnaître si un Problème de Géométrie peut se résoudre avec la règle et le compas",
-        "year": "1837",
-        "venue": "Journal de Mathématiques Pures et Appliquées",
-        "note": "First rigorous proof that trisection, doubling the cube, and constructing regular n-gons are impossible for most cases — established the degree criterion"
-      },
-      {
-        "authors": "É. Galois (posthumous, edited by J. Liouville)",
-        "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
-        "year": "1846",
-        "venue": "Journal de Mathématiques Pures et Appliquées",
-        "note": "Foundational work introducing group theory and the Galois group, providing the deeper characterization of constructibility via 2-groups"
-      },
-      {
-        "authors": "I. Stewart",
-        "title": "Galois Theory",
-        "year": "2015",
-        "venue": "Chapman and Hall/CRC (4th edition)",
-        "note": "Modern treatment of the Wantzel-Galois constructibility criterion using the tower law, paralleling this formalization's approach"
-      },
-      {
-        "authors": "Morandi, P.",
-        "title": "Field and Galois Theory",
-        "year": "1996",
-        "venue": "Springer GTM 167",
-        "note": "Chapter 4: tower law for field extensions and its applications to degree computations — the exact technique used in natDegree_dvd_card_gal"
-      },
-      {
-        "authors": "Cox, D.A.",
-        "title": "Galois Theory",
-        "year": "2012",
-        "venue": "Wiley, 2nd edition",
-        "note": "Chapter 10: detailed treatment of constructibility and the Galois characterization, including the tower law argument connecting Galois group order to extension degree"
-      }
-    ],
     "dateAdded": "2026-03-21",
     "lineCount": 115,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary
- Removed duplicate `references` array from inside `meta` (canonical location is root level)
- Added module docstring annotation (lines 1-11) for complete annotation coverage

## Test plan
- [x] JSON validation passes
- [x] No duplicate data

🤖 Generated with [Claude Code](https://claude.com/claude-code)