### PR TITLE
Enrich 5 entries: add cross-references, references

### DIFF
--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -169,5 +169,57 @@
     "axiomCount": 0,
     "theoremCount": 1009,
     "definitionCount": 104
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "navier-stokes",
+      "relationship": "extends",
+      "description": "Extends the base Navier-Stokes formalization with quantitative enstrophy decay estimates and the energy identity for 2D flows"
+    },
+    {
+      "targetId": "navier-stokes-oq-02",
+      "relationship": "related",
+      "description": "Companion formalization covering additional aspects of the 2D Navier-Stokes regularity theory"
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "The energy identity and enstrophy estimates rely on integration by parts, which is the multidimensional generalization of the fundamental theorem of calculus"
+    }
+  ],
+  "relatedProofs": [
+    "navier-stokes",
+    "navier-stokes-oq-02",
+    "fundamental-theorem-calculus"
+  ],
+  "references": [
+    {
+      "authors": "Leray, Jean",
+      "title": "Sur le mouvement d'un liquide visqueux emplissant l'espace",
+      "year": "1934",
+      "venue": "Acta Mathematica 63, 193-248",
+      "note": "Foundational paper establishing existence of weak solutions to the Navier-Stokes equations and introducing the energy inequality"
+    },
+    {
+      "authors": "Ladyzhenskaya, Olga A.",
+      "title": "The Mathematical Theory of Viscous Incompressible Flow",
+      "year": "1969",
+      "venue": "Gordon and Breach, 2nd edition",
+      "note": "Classical reference for 2D Navier-Stokes regularity, including global existence and uniqueness results that underpin the enstrophy decay analysis"
+    },
+    {
+      "authors": "Temam, Roger",
+      "title": "Navier-Stokes Equations: Theory and Numerical Analysis",
+      "year": "2001",
+      "venue": "AMS Chelsea Publishing",
+      "note": "Standard reference for the mathematical theory of Navier-Stokes equations, including energy methods and enstrophy estimates"
+    },
+    {
+      "authors": "Constantin, Peter; Foias, Ciprian",
+      "title": "Navier-Stokes Equations",
+      "year": "1988",
+      "venue": "University of Chicago Press",
+      "note": "Comprehensive treatment of the functional analytic framework for Navier-Stokes, including energy and enstrophy evolution equations"
+    }
+  ]
 }

--- a/src/data/proofs/pythagorean-triples-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-01/meta.json
@@ -241,5 +241,50 @@
     "axiomCount": 7,
     "theoremCount": 117,
     "definitionCount": 39
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "extends",
+      "description": "The Pythagorean theorem establishes a^2 + b^2 = c^2; this entry counts how many primitive solutions exist with c <= N, giving the asymptotic density N/(2pi)"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The coprime fraction 6/pi^2 = 1/zeta(2) arises from the probability that two random integers are coprime, which depends on the distribution of primes"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function underlies the coprimality analysis: the density of coprime pairs in the lattice point count uses Euler products over primes"
+    }
+  ],
+  "relatedProofs": [
+    "pythagorean-theorem",
+    "infinitude-primes",
+    "euler-totient"
+  ],
+  "references": [
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "Classic reference for the parametrization of Pythagorean triples and asymptotic density results (Chapter 12)"
+    },
+    {
+      "authors": "Lehmer, D. N.",
+      "title": "Asymptotic Evaluation of Certain Totient Sums",
+      "year": "1900",
+      "venue": "American Journal of Mathematics 22(4), 293-335",
+      "note": "Early work on counting lattice points in sectors with coprimality constraints, relevant to the asymptotic density N/(2pi)"
+    },
+    {
+      "authors": "Niven, Ivan; Zuckerman, Herbert S.; Montgomery, Hugh L.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1991",
+      "venue": "Wiley, 5th edition",
+      "note": "Standard textbook covering Pythagorean triples, their parametrization, and density results"
+    }
+  ]
 }

--- a/src/data/proofs/randomized-maxcut-oq-01/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-01/meta.json
@@ -198,5 +198,64 @@
     "axiomCount": 8,
     "theoremCount": 34,
     "definitionCount": 7
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "randomized-maxcut",
+      "relationship": "extends",
+      "description": "The simple 1/2-approximation via independent random assignment. The GW algorithm improves this from 0.5 to 0.878 by using SDP-guided correlations between vertex assignments"
+    },
+    {
+      "targetId": "p-vs-np",
+      "relationship": "related",
+      "description": "MaxCut is NP-hard, so exact polynomial-time solutions are unlikely. The GW algorithm achieves the best possible polynomial-time approximation (under UGC), illustrating how approximation algorithms circumvent NP-hardness"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "The Cauchy-Schwarz inequality underpins the SDP relaxation: inner products v_i . v_j of unit vectors satisfy |v_i . v_j| <= 1, and the SDP optimizes over these inner products"
+    }
+  ],
+  "relatedProofs": [
+    "randomized-maxcut",
+    "p-vs-np",
+    "cauchy-schwarz"
+  ],
+  "references": [
+    {
+      "authors": "Goemans, Michel X.; Williamson, David P.",
+      "title": "Improved Approximation Algorithms for Maximum Cut and Satisfiability Problems Using Semidefinite Programming",
+      "year": "1995",
+      "venue": "Journal of the ACM 42(6), 1115-1145",
+      "note": "The seminal paper introducing SDP relaxation with hyperplane rounding for MaxCut, achieving the 0.878-approximation ratio"
+    },
+    {
+      "authors": "Khot, Subhash; Kindler, Guy; Mossel, Elchanan; O'Donnell, Ryan",
+      "title": "Optimal Inapproximability Results for MAX-CUT and Other 2-Variable CSPs?",
+      "year": "2007",
+      "venue": "SIAM Journal on Computing 37(1), 319-357",
+      "note": "Proved that under the Unique Games Conjecture, the GW approximation ratio is optimal for MaxCut"
+    },
+    {
+      "authors": "Khot, Subhash",
+      "title": "On the Power of Unique 2-prover 1-round Games",
+      "year": "2002",
+      "venue": "Proceedings of the 34th Annual ACM Symposium on Theory of Computing (STOC), 767-775",
+      "note": "Introduced the Unique Games Conjecture, which implies the conditional optimality of the GW algorithm"
+    },
+    {
+      "authors": "Vazirani, Vijay V.",
+      "title": "Approximation Algorithms",
+      "year": "2001",
+      "venue": "Springer",
+      "note": "Standard textbook covering LP/SDP-based approximation algorithms including the GW MaxCut result (Chapter 26)"
+    },
+    {
+      "authors": "Williamson, David P.; Shmoys, David B.",
+      "title": "The Design of Approximation Algorithms",
+      "year": "2011",
+      "venue": "Cambridge University Press",
+      "note": "Comprehensive reference on approximation algorithm design, with detailed treatment of the GW SDP rounding technique (Chapter 6)"
+    }
+  ]
 }

--- a/src/data/proofs/vietas-formulas/meta.json
+++ b/src/data/proofs/vietas-formulas/meta.json
@@ -113,6 +113,28 @@
     "theoremCount": 7,
     "definitionCount": 0
   },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "foundational",
+      "description": "Vieta's formulas express coefficients as elementary symmetric functions of roots, which is why the Galois group acts by permutations on roots — the key structural fact underlying Abel-Ruffini"
+    },
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "The FTA guarantees that polynomials factor completely over C, providing the roots that Vieta's formulas relate to coefficients"
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The quadratic formula, a special case of Vieta's formulas for degree 2, connects to quadratic residues and reciprocity"
+    }
+  ],
+  "relatedProofs": [
+    "abel-ruffini",
+    "fundamental-theorem-algebra",
+    "quadratic-reciprocity"
+  ],
   "references": [
     {
       "authors": "Viète, François",

--- a/src/data/proofs/wolstenholme-theorem/meta.json
+++ b/src/data/proofs/wolstenholme-theorem/meta.json
@@ -120,6 +120,28 @@
     "theoremCount": 16,
     "definitionCount": 6
   },
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem ((p-1)! ≡ -1 mod p) is a classical primality criterion; Wolstenholme's theorem strengthens the divisibility to p^3 for specific binomial coefficients"
+    },
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Wolstenholme primes (primes where C(2p,p) ≡ 2 mod p^4) are connected to Fermat's Last Theorem: if p is a Wolstenholme prime, the first case of FLT holds for p"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes provides the setting for Wolstenholme's theorem, which characterizes a divisibility property of all primes p >= 5"
+    }
+  ],
+  "relatedProofs": [
+    "wilsons-theorem",
+    "fermats-last-theorem",
+    "infinitude-primes"
+  ],
   "references": [
     {
       "authors": "Wolstenholme, Joseph",


### PR DESCRIPTION
## Summary

Batch enrichment pass adding missing cross-references and references to 5 gallery entries:

- **randomized-maxcut-oq-01** (GW 0.878-Approximation): Added 3 cross-refs (randomized-maxcut, p-vs-np, cauchy-schwarz) and 5 references (Goemans-Williamson 1995, Khot et al. 2007, Khot 2002, Vazirani, Williamson-Shmoys)
- **pythagorean-triples-oq-01** (Density of Primitive Triples): Added 3 cross-refs and 3 references (Hardy-Wright, Lehmer, Niven-Zuckerman-Montgomery)
- **navier-stokes-oq-01** (2D NS Enstrophy Decay): Added 3 cross-refs and 4 references (Leray 1934, Ladyzhenskaya, Temam, Constantin-Foias)
- **wolstenholme-theorem**: Added 3 cross-refs (Wilson's theorem, FLT, infinitude of primes)
- **vietas-formulas**: Added 3 cross-refs (Abel-Ruffini, FTA, quadratic reciprocity)

## Test plan
- [x] All 5 meta.json files pass JSON validation