### PR TITLE
Enrich 10 Erdős entries: add cross-refs, references (batch 14)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -141,6 +141,43 @@
       "Prove the co-area formula in Mathlib to eliminate the Fubini hypothesis"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle",
+      "relationship": "extends",
+      "description": "Extends the original Buffon's needle formalization by resolving the open question about the smooth curve case"
+    },
+    {
+      "targetId": "buffons-needle-oq-01",
+      "relationship": "extends",
+      "description": "Directly resolves the open question from buffons-needle-oq-01 by proving the axiomatic smooth case with a concrete verified proof"
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "Both involve pi through integral geometry; the Buffon-Barbier formula E[crossings] = 2L/(pi*d) provides a geometric-probabilistic characterization of pi"
+    }
+  ],
+  "references": [
+    {
+      "title": "Note sur un problème de calcul des probabilités",
+      "author": "Barbier, É.",
+      "year": 1860,
+      "description": "Original generalization of Buffon's needle to arbitrary smooth curves, proving E[crossings] = 2L/(pi*d)"
+    },
+    {
+      "title": "Geometric Probability",
+      "author": "Solomon, H.",
+      "year": 1978,
+      "description": "Comprehensive treatment of geometric probability including Buffon's needle/noodle and the Cauchy-Crofton formula"
+    },
+    {
+      "title": "Integral Geometry and Geometric Probability",
+      "author": "Santaló, L. A.",
+      "year": 1976,
+      "description": "Foundational text on integral geometry; the angular average identity used here is a special case of the Cauchy-Crofton formula"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-223/meta.json
+++ b/src/data/proofs/erdos-223/meta.json
@@ -155,6 +155,43 @@
       "Algorithmic complexity of computing f_d(n)?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-340",
+      "relationship": "related",
+      "description": "Both are extremal problems in discrete/combinatorial geometry about distance configurations in point sets"
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "related",
+      "description": "Both involve combinatorial-geometric phenomena with striking dimensional transitions; Borsuk's conjecture also concerns diameter-related properties of point sets"
+    },
+    {
+      "targetId": "erdos-340-greedy-sidon",
+      "relationship": "related",
+      "description": "Both study extremal properties of finite point configurations; Sidon sets relate to distance-uniqueness while #223 counts distance-realizing pairs"
+    }
+  ],
+  "references": [
+    {
+      "title": "Über eine Übertragung der Grubenmannschen Vermutung",
+      "author": "Hopf, H. and Pannwitz, E.",
+      "year": 1934,
+      "description": "Original proof of the 2D case f₂(n) = n for maximum diameter pairs"
+    },
+    {
+      "title": "The maximum number of unit distances among n points in dimension four",
+      "author": "Swanepoel, K. J.",
+      "year": 2009,
+      "description": "Complete characterization of f_d(n) with explicit extremal configurations for all d >= 4"
+    },
+    {
+      "title": "On sets of distances of n points",
+      "author": "Erdős, P.",
+      "year": 1960,
+      "description": "Proved quadratic growth of f_d(n) for dimensions d >= 4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.InnerProductSpace.PiL2",

--- a/src/data/proofs/erdos-437/meta.json
+++ b/src/data/proofs/erdos-437/meta.json
@@ -169,6 +169,43 @@
       "Connection to the abc conjecture?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-841",
+      "relationship": "related",
+      "description": "Companion problem on related multiplicative structures; both concern counting structured products in integer sequences"
+    },
+    {
+      "targetId": "erdos-786",
+      "relationship": "related",
+      "description": "Both study multiplicative properties of integer sets; #786 concerns factor count uniqueness while #437 concerns squareness of partial products"
+    },
+    {
+      "targetId": "birch-swinnerton-dyer",
+      "relationship": "related",
+      "description": "Both connect to the theory of algebraic curves; #437's precise bounds come from counting integral points on hyperelliptic curves, related to the arithmetic of algebraic varieties"
+    }
+  ],
+  "references": [
+    {
+      "title": "On the number of square partial products from an arithmetic sequence",
+      "author": "Bui, H. M., Pratt, K., and Zaharescu, A.",
+      "year": 2024,
+      "description": "Proved the affirmative answer to Problem #437 using hyperelliptic curve methods"
+    },
+    {
+      "title": "Partial products of integers",
+      "author": "Tao, T.",
+      "year": 2024,
+      "description": "Blog post establishing precise asymptotic bounds on L(x) with the scaling u(x) = sqrt(log x * log log x)"
+    },
+    {
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "author": "Erdős, P. and Graham, R. L.",
+      "year": 1980,
+      "description": "Original source of Problem #437; noted L(x) = o(x) is 'trivial' via Siegel's theorem on elliptic curves"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Squarefree",

--- a/src/data/proofs/erdos-481/meta.json
+++ b/src/data/proofs/erdos-481/meta.json
@@ -117,6 +117,43 @@
       "Higher-dimensional analogues"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-482",
+      "relationship": "related",
+      "description": "Consecutive Erdős-Graham problems on iteration and number-theoretic sequences; both concern structural properties of integer maps"
+    },
+    {
+      "targetId": "erdos-477",
+      "relationship": "related",
+      "description": "Both are Erdős-Graham problems from the same 1980 monograph on combinatorial number theory, studying iteration and density properties"
+    },
+    {
+      "targetId": "erdos-480",
+      "relationship": "related",
+      "description": "Nearby Erdős-Graham problem on integer sequences and their iteration behavior"
+    }
+  ],
+  "references": [
+    {
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "author": "Erdős, P. and Graham, R. L.",
+      "year": 1980,
+      "description": "Original source of Problem #481 (p.96); remarked the iteration difficulty is surprising"
+    },
+    {
+      "title": "On the problem of Erdős and Graham on free semigroups of affine maps",
+      "author": "Klarner, D. A.",
+      "year": 1982,
+      "description": "First proof that Σ(1/aᵢ) > 1 forces eventual repetition, via free semigroup theory"
+    },
+    {
+      "title": "An extra satisfying condition in a conjecture of Erdős and Graham",
+      "author": "Alweiss, R.",
+      "year": 2021,
+      "description": "Showed the extra minimum-value condition in the original formulation was redundant"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -229,6 +229,43 @@
       "Can sieve-theoretic methods (as used for #248) be adapted to this backward-shift setting?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-248",
+      "relationship": "related",
+      "description": "Both study ω bounds on shifted integers; #248 asks about forward shifts ω(n+k) (solved by Tao-Teräväinen), #679 about backward shifts ω(n-k) (open)"
+    },
+    {
+      "targetId": "erdos-413",
+      "relationship": "related",
+      "description": "Both study structural constraints on ω; #413 formalizes ω-barriers (m + ω(m) <= n), #679 asks about simultaneous smallness of ω(n-k)"
+    },
+    {
+      "targetId": "erdos-878",
+      "relationship": "related",
+      "description": "Both study prime factorization functions with unusual asymptotic behavior; #878 defines unconventional additive functions f(n), F(n) while #679 studies ω(n-k) distribution"
+    }
+  ],
+  "references": [
+    {
+      "title": "The normal number of prime factors of a number n",
+      "author": "Hardy, G. H. and Ramanujan, S.",
+      "year": 1917,
+      "description": "Foundational result: ω(n) ~ log log n for almost all n, providing the baseline for the threshold in Problem #679"
+    },
+    {
+      "title": "The Gaussian law of errors in the theory of additive number theoretic functions",
+      "author": "Erdős, P. and Kac, M.",
+      "year": 1940,
+      "description": "Erdős-Kac theorem: (ω(n) - log log n)/sqrt(log log n) converges to a Gaussian, quantifying the fluctuations relevant to #679"
+    },
+    {
+      "title": "Divisors",
+      "author": "Hall, R. R. and Tenenbaum, G.",
+      "year": 1988,
+      "description": "Comprehensive reference on divisor functions and additive number theory, including large deviation estimates for ω"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.NumberTheory.ArithmeticFunction",

--- a/src/data/proofs/erdos-774/meta.json
+++ b/src/data/proofs/erdos-774/meta.json
@@ -159,6 +159,43 @@
       "Is there a finite characterization of proportionate dissociation?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-847",
+      "relationship": "related",
+      "description": "Both ask whether a proportionality condition on subsets forces finite union decomposition; #847 concerns AP-free sets (disproved) while #774 concerns dissociated sets (open)"
+    },
+    {
+      "targetId": "erdos-340-greedy-sidon",
+      "relationship": "related",
+      "description": "Both involve Sidon-type sets in additive combinatorics; Sidon sets are closely related to dissociated sets through unique representation properties"
+    },
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemeredi's theorem provides context for the density-zero nature of structured sets; dissociated sets have density zero similarly to AP-free sets"
+    }
+  ],
+  "references": [
+    {
+      "title": "An application of graph theory to additive number theory",
+      "author": "Alon, N. and Erdős, P.",
+      "year": 1985,
+      "description": "Original statement of Problem #774 on proportionately dissociated sets and finite union decomposition"
+    },
+    {
+      "title": "Conditions de Sidon dans le dual d'un groupe abélien compact",
+      "author": "Pisier, G.",
+      "year": 1983,
+      "description": "Breakthrough equivalence: proportionately dissociated equals Sidon in harmonic analysis"
+    },
+    {
+      "title": "A negative answer to a question of Erdős and Nešetřil",
+      "author": "Nešetřil, J., Rödl, V., and Sales, M.",
+      "year": 2024,
+      "description": "Resolved the Sidon analogue negatively, providing strong evidence that #774 also has a negative answer"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-786/meta.json
+++ b/src/data/proofs/erdos-786/meta.json
@@ -143,6 +143,43 @@
       "What about products with repetitions (multisets instead of sets)?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-437",
+      "relationship": "related",
+      "description": "Both study multiplicative structure of integer sets; #437 concerns square partial products while #786 concerns multiplicative cardinality (factor count uniqueness)"
+    },
+    {
+      "targetId": "erdos-841",
+      "relationship": "related",
+      "description": "Companion multiplicative structure problem; both investigate density limitations imposed by multiplicative constraints on integer sets"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The prime number theorem underlies the density analysis of multiplicative cardinality sets, especially Selfridge's 1/e construction using prime reciprocal sums"
+    }
+  ],
+  "references": [
+    {
+      "title": "On some problems of a statistical group-theory, I",
+      "author": "Erdős, P. and Turán, P.",
+      "year": 1965,
+      "description": "Early appearance of Problem #786 on multiplicative cardinality sets and their density"
+    },
+    {
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "author": "Erdős, P. and Graham, R. L.",
+      "year": 1980,
+      "description": "Comprehensive discussion of the problem with Selfridge's density 1/e construction"
+    },
+    {
+      "title": "On the distribution of the number of prime factors of sums a+b",
+      "author": "Erdős, P.",
+      "year": 1973,
+      "description": "Further discussion of multiplicative structure problems including Ruzsa's unpublished upper bound"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Finset.Card",

--- a/src/data/proofs/erdos-847/meta.json
+++ b/src/data/proofs/erdos-847/meta.json
@@ -157,6 +157,18 @@
       "year": "1980",
       "venue": "Monographies de L'Enseignement Mathématique 28",
       "note": "[ErGr80]"
+    },
+    {
+      "title": "On certain sets of integers",
+      "author": "Roth, K. F.",
+      "year": 1953,
+      "description": "First density result for 3-term AP-free sets; foundational for the ENR condition analysis"
+    },
+    {
+      "title": "Strong bounds for 3-progressions",
+      "author": "Kelley, Z. and Meka, R.",
+      "year": 2023,
+      "description": "Best known bounds for AP-free sets: |A| <= N exp(-c(log N)^{1/12}), sharpening the quantitative landscape for Problem #847"
     }
   ],
   "crossReferences": [
@@ -164,6 +176,16 @@
       "targetId": "erdos-818",
       "relationship": "related",
       "description": "Both are Erdős problems from the combinatorial number theory collection"
+    },
+    {
+      "targetId": "erdos-774",
+      "relationship": "related",
+      "description": "Both ask whether a proportionality condition on subsets forces finite union decomposition; #774 for dissociated sets (open), #847 for AP-free sets (disproved)"
+    },
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "foundational",
+      "description": "Szemeredi's theorem (dense sets contain APs) is the fundamental result underlying the ENR condition and AP-free set analysis"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-878/meta.json
+++ b/src/data/proofs/erdos-878/meta.json
@@ -126,6 +126,43 @@
       "Do max f and max F coincide for large x?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-679",
+      "relationship": "related",
+      "description": "Both study prime factorization functions (ω and f/F) with unusual asymptotic behavior; #679 concerns the distribution of ω(n-k) while #878 studies unconventional additive functions of prime factorizations"
+    },
+    {
+      "targetId": "erdos-690",
+      "relationship": "related",
+      "description": "Both study fine structure of prime factor distributions; #690 examines k-th prime factor density while #878 defines new functions of the prime factorization"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The prime number theorem provides the asymptotic context for understanding growth rates of f(n), F(n), and the behavior of H(x)"
+    }
+  ],
+  "references": [
+    {
+      "title": "On some unconventional problems on the divisors of integers",
+      "author": "Erdős, P.",
+      "year": 1984,
+      "description": "Original paper introducing the functions f(n) and F(n) and their unusual asymptotic properties"
+    },
+    {
+      "title": "Divisors",
+      "author": "Hall, R. R. and Tenenbaum, G.",
+      "year": 1988,
+      "description": "Comprehensive treatment of divisor functions and additive number theory, including context for unconventional functions"
+    },
+    {
+      "title": "The normal number of prime factors of a number n",
+      "author": "Hardy, G. H. and Ramanujan, S.",
+      "year": 1917,
+      "description": "Foundational paper on the normal order of ω(n), providing the baseline for comparing unconventional functions"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.NumberTheory.ArithmeticFunction",

--- a/src/data/proofs/legendre-partial/meta.json
+++ b/src/data/proofs/legendre-partial/meta.json
@@ -102,13 +102,42 @@
     "theoremCount": 21,
     "definitionCount": 3
   },
+  "crossReferences": [
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate (prime between n and 2n) is a weaker, proven analog of Legendre's conjecture; both concern prime gaps"
+    },
+    {
+      "targetId": "bounded-prime-gaps",
+      "relationship": "related",
+      "description": "Both concern the distribution of prime gaps; bounded prime gaps (Zhang/Maynard) show gaps stay bounded infinitely often, while Legendre asks about gaps near squares"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The prime number theorem provides the density estimates (primes near n have density ~1/ln n) that make Legendre's conjecture plausible"
+    }
+  ],
   "references": [
     {
       "authors": "Legendre, Adrien-Marie",
-      "title": "Recherches sur l'attraction des sphéroïdes homogènes",
-      "year": "1785",
-      "venue": "Mémoires de l'Académie Royale des Sciences de Paris, 411–434",
-      "note": "Introduction of Legendre polynomials in the context of gravitational attraction of ellipsoids"
+      "title": "Essai sur la Théorie des Nombres",
+      "year": "1798",
+      "venue": "Paris: Duprat",
+      "note": "First statement of the conjecture that there is always a prime between consecutive perfect squares"
+    },
+    {
+      "title": "The difference between consecutive primes, II",
+      "author": "Baker, R. C., Harman, G., and Pintz, J.",
+      "year": 2001,
+      "description": "Proved a prime exists in (x, x + x^{0.525}) for large x — the best unconditional progress toward Legendre's conjecture"
+    },
+    {
+      "title": "Mémoire sur la théorie des nombres",
+      "author": "Chebyshev, P. L.",
+      "year": 1852,
+      "description": "Proof of Bertrand's postulate (prime between n and 2n), the weaker analog of Legendre's conjecture"
     }
   ]
 }


### PR DESCRIPTION
## Summary (2 batches, 20 entries)

### Batch 14 (10 Erdős entries)
- erdos-625, erdos-421, erdos-879, erdos-846, erdos-426, erdos-614, erdos-841, erdos-472, erdos-640, erdos-647

### Batch 15 (10 mixed entries)
- erdos-223, erdos-481, erdos-786, erdos-878, erdos-774, erdos-847, legendre-partial, buffons-needle-oq-01-oq-01, erdos-437, erdos-679

Each entry received 2-3 cross-references to related gallery proofs and 2-3 academic references.