### PR TITLE
Enrich 2 entries: abel-ruffini (pass 2), vietas-formulas-oq-03 (pass 1)

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -84,7 +84,8 @@
       "**Mathlib Integration Pattern:** The proof is a composition of Mathlib lemmas: `solvableByRad.isSolvable'` (Mathlib) + `Equiv.Perm.not_solvable` (Mathlib) → `not_solvable_by_rad_of_not_solvable_gal` (3-line `intro`/`exact`). Zero sorries in 185 lines.",
       "**S_n Unsolvability for n ≥ 5:** `symmetric_group_not_solvable` proves $\\forall n \\geq 5$, $S_n$ not solvable, using `Cardinal.mk (Fin n) ≥ 5` via `simp`. Instances for $S_0, S_1$ (`inferInstance`) vs the impossibility for $S_5, S_6, \\ldots$ illustrate the sharp boundary.",
       "**Original Contributions Are Wrappers:** The file's original theorems (`galois_bridge`, `symmetric_group_not_solvable`, `not_solvable_by_rad_of_not_solvable_gal`) are pedagogical wrappers that make the Mathlib results explicit and user-facing — a pattern for presenting Mathlib-based formalizations.",
-      "**Jordan-Hölder Guarantees Completeness:** The analysis of $S_n$ via derived series is not ad hoc — the Jordan-Hölder theorem guarantees that any two composition series of a finite group have the same multiset of composition factors (up to isomorphism). For $S_5$, the unique composition series is $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with factors $A_5$ (simple, order 60) and $\\mathbb{Z}/2$. Since $A_5$ is non-abelian, the group is not solvable — and no alternative decomposition can avoid this obstruction. This uniqueness is what makes the degree-5 boundary absolute rather than a limitation of one particular analysis."
+      "**Jordan-Hölder Guarantees Completeness:** The analysis of $S_n$ via derived series is not ad hoc — the Jordan-Hölder theorem guarantees that any two composition series of a finite group have the same multiset of composition factors (up to isomorphism). For $S_5$, the unique composition series is $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with factors $A_5$ (simple, order 60) and $\\mathbb{Z}/2$. Since $A_5$ is non-abelian, the group is not solvable — and no alternative decomposition can avoid this obstruction. This uniqueness is what makes the degree-5 boundary absolute rather than a limitation of one particular analysis.",
+      "**Discriminant Criterion for Galois Group Computation:** The theorem `not_solvable_by_rad_of_not_solvable_gal` requires exhibiting a polynomial with non-solvable Galois group. In practice, the discriminant provides a key tool: $\\text{Gal}(f) \\subseteq A_n$ if and only if $\\Delta(f)$ is a perfect square in $F$. For the standard example $x^5 - x - 1$, $\\Delta = 2869 = 19 \\times 151$, which is not a perfect square, so $\\text{Gal}(x^5 - x - 1/\\mathbb{Q}) \\not\\subseteq A_5$. Combined with irreducibility mod 2 and the existence of a 5-cycle in the Galois group (from the number of real roots), this forces $\\text{Gal}(x^5 - x - 1/\\mathbb{Q}) = S_5$. Formalizing this computation would bridge the gap between the abstract `not_solvable_by_rad_of_not_solvable_gal` and a concrete unsolvable quintic."
     ]
   },
   "sections": [
@@ -145,7 +146,8 @@
       "Mathlib notes that `IsSolvable` instances for $S_2, S_3, S_4$ were not available at time of writing. Can these be added and `s2_solvable`, `s3_solvable`, `s4_solvable` proved by `inferInstance`, completing the full picture of which $S_n$ are solvable?",
       "The Inverse Galois Problem — every finite group appears as a Galois group over $\\mathbb{Q}$ — is a deep open problem. Can partial results (e.g., every abelian group is a Galois group over $\\mathbb{Q}$ by Kronecker-Weber) be formalized in Lean?",
       "The file relies on `Equiv.Perm.not_solvable` and `solvableByRad.isSolvable'` as black boxes. Can we expose the full proof chain — derived series, composition factors, simplicity of $A_5$ — as individual Lean lemmas for a pedagogically complete formalization?",
-      "Charles Hermite (1858) showed that the general quintic *can* be solved using elliptic modular functions — bypassing the radical barrier by expanding the class of allowed operations. The Bring radical $\\text{BR}(a)$, the unique real root of $x^5 + x + a$, suffices to solve any quintic after Tschirnhaus transformation. Can this 'elliptic solution of the quintic' be formalized in Lean, showing that Abel-Ruffini's impossibility is specific to radicals and not to all closed-form expressions?"
+      "Charles Hermite (1858) showed that the general quintic *can* be solved using elliptic modular functions — bypassing the radical barrier by expanding the class of allowed operations. The Bring radical $\\text{BR}(a)$, the unique real root of $x^5 + x + a$, suffices to solve any quintic after Tschirnhaus transformation. Can this 'elliptic solution of the quintic' be formalized in Lean, showing that Abel-Ruffini's impossibility is specific to radicals and not to all closed-form expressions?",
+      "In positive characteristic $p > 0$, the Abel-Ruffini picture changes dramatically: the Abhyankar conjecture (proved by Raynaud 1994, Harbater 1994) characterizes which finite groups occur as Galois groups of covers of $\\mathbb{A}^1$ over algebraically closed fields of characteristic $p$ — every group whose $p$-Sylow subgroup is a $p$-group appears. Unlike characteristic 0, where $S_5$'s non-solvability creates an absolute barrier, in characteristic 5 the Galois theory of polynomial equations behaves quite differently because Artin-Schreier extensions replace radical extensions. Can Lean formalize how the Abel-Ruffini impossibility is characteristic-dependent?"
     ]
   },
   "crossReferences": [
@@ -350,9 +352,19 @@
       "description": "The non-coprime Chinese Remainder Theorem generalizes the decomposition of cyclic groups that underpins radical extensions: each radical step in the Galois bridge produces a cyclic Galois quotient $\\mathbb{Z}/n\\mathbb{Z}$, and understanding when such cyclic groups decompose as direct products (CRT) versus remaining indecomposable is essential to the composition series analysis that distinguishes solvable groups ($S_4$) from non-solvable ones ($S_5$)"
     },
     {
+      "targetId": "elementary-quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The Legendre symbol $(a/p)$ detects whether $a$ is a quadratic residue mod $p$ — equivalently, whether $x^2 - a$ splits over $\\mathbb{F}_p$. This is the simplest case of the Galois-theoretic question Abel-Ruffini addresses at degree 5: the Galois group of $x^2 - a$ over $\\mathbb{Q}$ is either trivial (if $a$ is a perfect square) or $\\mathbb{Z}/2 \\cong S_2$ (if not), and $S_2$ is always solvable — explaining why the quadratic formula always works. Quadratic reciprocity describes which primes $p$ make $x^2 - a$ split, a question that Artin reciprocity later generalized to arbitrary Galois extensions"
+    },
+    {
       "targetId": "elementary-quadratic-reciprocity-oq-01",
       "relationship": "related",
       "description": "Zolotarev's 1872 proof of quadratic reciprocity uses the sign homomorphism $\\text{sign}: S_n \\to \\{\\pm 1\\}$ — the same homomorphism whose kernel $A_n = \\ker(\\text{sign})$ is central to Abel-Ruffini's proof chain. In Zolotarev's proof, the Legendre symbol $(a/p)$ equals the signature of the multiplication-by-$a$ permutation on $(\\mathbb{Z}/p\\mathbb{Z})^{\\times}$, directly linking the symmetric group structure that drives Abel-Ruffini's impossibility to quadratic reciprocity"
+    },
+    {
+      "targetId": "elementary-quadratic-reciprocity-oq-03",
+      "relationship": "related",
+      "description": "The Jacobi symbol $J(m,n)$ extends quadratic reciprocity from prime to composite moduli, paralleling how Abel-Ruffini's group-theoretic analysis generalizes from specific degrees to all $n \\geq 5$. The generalized reciprocity law $J(m,n) \\cdot J(n,m) = (-1)^{(m-1)/2 \\cdot (n-1)/2}$ encodes the abelian structure of $(\\mathbb{Z}/n\\mathbb{Z})^{\\times}$ — precisely the cyclic groups whose abelianness makes each radical step work in the Galois bridge, and whose non-abelian analogue $S_5$ blocks the quintic"
     },
     {
       "targetId": "angle-trisection-oq-02-oq-03",
@@ -416,7 +428,9 @@
     "angle-trisection-oq-02-oq-01",
     "chinese-remainder-constructive",
     "chinese-remainder-non-coprime",
+    "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-03",
     "angle-trisection-oq-02-oq-03",
     "angle-trisection-oq-02-oq-03-oq-01",
     "bezout-identity",
@@ -555,6 +569,27 @@
       "year": "1884",
       "venue": "Teubner, Leipzig (English translation: Lectures on the Icosahedron, 1888, Trübner & Co.)",
       "note": "Klein's masterwork connecting the quintic to the symmetries of the icosahedron (rotation group ≅ A₅) and solving it via elliptic modular functions and hypergeometric series. Directly relevant to the open question about formalizing alternative quintic solutions beyond radicals: Klein showed that the icosahedral equation x⁵ + x + a can be solved by theta functions, linking A₅'s geometry to transcendental function theory"
+    },
+    {
+      "authors": "Serre, Jean-Pierre",
+      "title": "Topics in Galois Theory",
+      "year": "2008",
+      "venue": "A K Peters/CRC Press, 2nd edition (based on 1988 lecture notes)",
+      "note": "Serre's treatment of the inverse Galois problem includes the proof that Sₙ occurs as a Galois group over Q for all n (via Hilbert irreducibility), establishing that the Abel-Ruffini impossibility applies to infinitely many concrete polynomials over Q. Also covers rigidity methods and the Noether problem"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "John Wiley & Sons, 3rd edition",
+      "note": "The most widely-used graduate algebra textbook, with a complete treatment of Galois theory including the Abel-Ruffini theorem (Chapter 14). Contains the discriminant criterion for determining whether Gal(f) ⊆ Aₙ and explicit Galois group computations for specific quintics — the gap between the abstract theorem and concrete examples"
+    },
+    {
+      "authors": "van der Waerden, Bartel Leendert",
+      "title": "Algebra",
+      "year": "1930",
+      "venue": "Springer (English translation: Frederick Ungar, 1949; 7th German edition 1966)",
+      "note": "The landmark textbook that established the modern abstract algebra curriculum. van der Waerden's presentation of Galois theory as the interplay between field extensions and automorphism groups (rather than permutations of roots) became the standard framework used in this Lean formalization. His Chapter 8 contains the cleanest classical proof of Abel-Ruffini via the derived series of Sₙ"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1089/annotations.json
+++ b/src/data/proofs/erdos-1089/annotations.json
@@ -29,8 +29,8 @@
     "range": { "startLine": 51, "endLine": 57 },
     "type": "definition",
     "title": "Distinct Distances Set and Count",
-    "content": "**distinctDistances P** computes all positive pairwise distances in a point set, and **numDistinctDistances** returns its cardinality. These are the central quantities: the problem asks how many points guarantee n distinct values.",
-    "mathContext": "For $P \\subseteq \\mathbb{R}^d$, $\\Delta(P) = \\{\\|p - q\\| : p, q \\in P, p \\neq q\\}$. The count $|\\Delta(P)|$ is the number of distinct distances. Implemented via `Finset.product`, `Finset.image`, and `Finset.filter`.",
+    "content": "**distinctDistances P** computes all positive pairwise distances in a point set, and **numDistinctDistances** returns its cardinality. These are the central quantities: the problem asks how many points guarantee n distinct values.\n\nThe number of pairwise distances is at most $\\binom{|P|}{2}$ (see `combinations-formula`), so $|\\Delta(P)| \\leq \\binom{|P|}{2}$. The Guth-Katz breakthrough (2015) proved $|\\Delta(P)| \\geq c|P|/\\sqrt{\\log |P|}$ in the plane — the near-tight answer to the 2D distinct distances problem. Problem #1089 asks the orthogonal question: fixing the number of distinct distances $n$ and varying dimension $d$.",
+    "mathContext": "For $P \\subseteq \\mathbb{R}^d$, $\\Delta(P) = \\{\\|p - q\\| : p, q \\in P, p \\neq q\\}$. The count $|\\Delta(P)|$ is the number of distinct distances. Upper bound: $|\\Delta(P)| \\leq \\binom{|P|}{2}$. Lower bound (Guth-Katz, $d = 2$): $|\\Delta(P)| \\geq c|P|/\\sqrt{\\log |P|}$.",
     "significance": "key",
     "relatedConcepts": ["Distinct distances problem", "Guth-Katz theorem", "Euclidean distance"],
     "prerequisites": ["EuclideanSpace", "Finset.product", "Finset.image"]
@@ -125,8 +125,8 @@
     "range": { "startLine": 179, "endLine": 185 },
     "type": "definition",
     "title": "Connection to f_d(n) and Problem #1083",
-    "content": "**f d n** = max distinct distances from $n$ points in $\\mathbb{R}^d$. The relationship $g_d(n) = \\min\\{m : f_d(m) \\ge n\\}$ shows $g$ and $f$ are inverse perspectives on the same problem.",
-    "mathContext": "$f_d(n) = \\max\\{|\\Delta(P)| : P \\subseteq \\mathbb{R}^d, |P| = n\\}$ and $g_d(n) = \\inf\\{m : f_d(m) \\ge n\\}$. The `g_f_relationship` axiom formalizes this duality.",
+    "content": "**f d n** = max distinct distances from $n$ points in $\\mathbb{R}^d$. The relationship $g_d(n) = \\min\\{m : f_d(m) \\ge n\\}$ shows $g$ and $f$ are inverse perspectives on the same problem — a Galois connection between 'how many points for $n$ distances' and 'how many distances from $n$ points'. Problem #1083 (see `erdos-1083`) studies $f_d(n)$ directly.",
+    "mathContext": "$f_d(n) = \\max\\{|\\Delta(P)| : P \\subseteq \\mathbb{R}^d, |P| = n\\}$ and $g_d(n) = \\inf\\{m : f_d(m) \\ge n\\}$. The `g_f_relationship` axiom formalizes this duality. Guth-Katz (2015): $f_2(n) \\geq cn/\\sqrt{\\log n}$.",
     "significance": "key",
     "relatedConcepts": ["Galois connections", "Inverse functions", "Erdős Problem 1083"],
     "prerequisites": ["f definition", "Nat.sSup", "Nat.sInf"]

--- a/src/data/proofs/erdos-1097/annotations.json
+++ b/src/data/proofs/erdos-1097/annotations.json
@@ -20,7 +20,7 @@
     "content": "A three-term arithmetic progression with base $a$ and common difference $d$ in set $A$: the elements $a$, $a+d$, $a+2d$ all belong to $A$. This is the fundamental predicate underlying the entire formalization.",
     "mathContext": "A three-term AP is a triple $(a, a+d, a+2d)$ with $a, a+d, a+2d \\in A$. Equivalently, three elements $x < y < z$ form an AP iff $y - x = z - y$, i.e., $2y = x + z$.",
     "significance": "key",
-    "relatedConcepts": ["arithmetic progression", "Szemerédi's theorem", "additive combinatorics"],
+    "relatedConcepts": ["arithmetic progression", "Szemerédi's theorem", "additive combinatorics", "Roth's theorem"],
     "prerequisites": ["Set membership", "integer arithmetic"]
   },
   {
@@ -77,10 +77,10 @@
     "range": { "startLine": 293, "endLine": 301 },
     "type": "insight",
     "title": "Erdős's O(n^{3/2}) Conjecture",
-    "content": "The central open question: does $|D(A)| = O(n^{3/2})$? The Erdős-Spencer probabilistic construction achieves $\\Omega(n^{3/2})$, so the conjecture asserts this is essentially tight. The answer determines the exact growth rate of common differences.",
+    "content": "The central open question: does $|D(A)| = O(n^{3/2})$? The Erdős-Spencer probabilistic construction achieves $\\Omega(n^{3/2})$, so the conjecture asserts this is essentially tight. The answer determines the exact growth rate of common differences.\n\nThis connects to the broader landscape of additive combinatorics: Szemerédi's theorem (see `szemeredi-theorem`) guarantees that dense sets contain arbitrarily long APs, while this problem asks how many *distinct* common differences arise in 3-term APs. The Roth-type bounds (see `roth-theorem-k3`) on sets without 3-APs provide complementary constraints.",
     "mathContext": "The conjecture asks: $\\exists\\, C > 0$ such that for all $n \\in \\mathbb{N}$ and all $A \\subseteq \\mathbb{Z}$ with $|A| = n$, $|D(A)| \\le C \\cdot n^{3/2}$. Combined with the Erdős-Spencer lower bound, this would give $|D(A)| = \\Theta(n^{3/2})$.",
     "significance": "key",
-    "relatedConcepts": ["Erdős problems", "extremal combinatorics", "polynomial growth"],
+    "relatedConcepts": ["Erdős problems", "extremal combinatorics", "polynomial growth", "Szemerédi's theorem", "Roth's theorem"],
     "prerequisites": ["asymptotic notation", "real exponentiation"]
   },
   {

--- a/src/data/proofs/erdos-36/annotations.json
+++ b/src/data/proofs/erdos-36/annotations.json
@@ -253,13 +253,14 @@
     },
     "type": "insight",
     "title": "Erdős's Disproved Conjecture c = 1/2",
-    "content": "Erdős initially conjectured $c = 1/2$, meaning the trivial partition (first half vs second half) would be asymptotically optimal. This was disproved: better partitions exist, and $c \\approx 0.38 \\ll 1/2$.",
+    "content": "Erdős initially conjectured $c = 1/2$, meaning the trivial partition (first half vs second half) would be asymptotically optimal. This was disproved: better partitions exist, and $c \\approx 0.38 \\ll 1/2$. This mirrors a common pattern in additive combinatorics (see `szemeredi-theorem`, `roth-theorem-k3`) where naive bounds are far from the truth — structured problems have richer behavior than initial heuristics suggest.",
     "significance": "key",
     "mathContext": "The trivial partition $A = \\{1, \\ldots, N\\}$, $B = \\{N+1, \\ldots, 2N\\}$ has maximum overlap $N$ at $k = -N$ (every $a \\in A$ pairs with $b = a + N \\in B$). This gives overlap $N/N = 1$, not $1/2$. Instead, Erdős likely meant the 'balanced' partition where $A$ contains alternating elements. Scherk's counterexample showed $c \\leq 1 - 1/\\sqrt{2} \\approx 0.293$ was initially thought tight, but the true value turned out to be higher at $\\approx 0.380$. The failure of the $c = 1/2$ conjecture demonstrates how partition optimization over consecutive integers is subtler than it appears.",
     "relatedConcepts": [
       "trivial partition",
       "counterexample",
-      "partition optimization"
+      "partition optimization",
+      "Szemerédi's theorem"
     ],
     "prerequisites": [
       "erdos_36_limit_exists"
@@ -297,7 +298,7 @@
     },
     "type": "insight",
     "title": "Connection to Additive Combinatorics",
-    "content": "The minimum overlap problem is a fundamental question about the unavoidable additive structure in equal partitions of consecutive integers. It connects to sumset theory, representation functions, and the Plünnecke-Ruzsa inequality.",
+    "content": "The minimum overlap problem is a fundamental question about the unavoidable additive structure in equal partitions of consecutive integers. It connects to sumset theory, representation functions, and the Plünnecke-Ruzsa inequality. The regularity-based approach to additive combinatorics (see `szemeredi-regularity`) provides another perspective: the overlap structure can be analyzed via pseudorandom decompositions of the indicator function.",
     "significance": "key",
     "mathContext": "In the language of additive combinatorics, $M(N) = \\min_{|A|=N} \\|r_{A-B}\\|_\\infty$ where $r_{A-B}$ is the representation function of $A - B$ and $A \\cup B = \\{1,\\ldots,2N\\}$. The Plünnecke-Ruzsa inequality gives $|A - B| \\leq |A + A|^2 / |A|$, providing structural constraints on the difference set. The minimum overlap problem also connects to discrepancy theory: minimizing the maximum overlap is equivalent to making the difference multiset as 'flat' as possible, akin to low-discrepancy sequences. The problem appears as C17 in Guy's 'Unsolved Problems in Number Theory'.",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-369/annotations.json
+++ b/src/data/proofs/erdos-369/annotations.json
@@ -146,7 +146,8 @@
     "relatedConcepts": [
       "parameterized conjecture",
       "smoothness bound",
-      "Erdős-Graham (1980)"
+      "Erdős-Graham (1980)",
+      "prime number theorem"
     ],
     "prerequisites": [
       "HasConsecutiveSmoothRun"
@@ -161,7 +162,7 @@
     },
     "type": "concept",
     "title": "The k = 2 Case: Simplest Open Instance",
-    "content": "**ErdosConjecture369_k2**: Even for $k = 2$ (just two consecutive smooth numbers), the conjecture is open. Erdős and Graham called this 'very hard.'",
+    "content": "**ErdosConjecture369_k2**: Even for $k = 2$ (just two consecutive smooth numbers), the conjecture is open. Erdős and Graham called this 'very hard.' The difficulty stems from the complete independence of consecutive integers' factorizations ($\\gcd(m, m+1) = 1$, see `fundamental-arithmetic` for unique factorization). Compare with Bertrand's postulate (see `bertrands-postulate`), which guarantees primes between $n$ and $2n$ — smooth number gaps are much less understood than prime gaps.",
     "significance": "key",
     "mathContext": "The $k = 2$ case asks: for all large $n$, do there exist consecutive integers $m, m+1 \\leq n$ with both $m$ and $m+1$ being $n^\\varepsilon$-smooth? Since $\\gcd(m, m+1) = 1$, the prime factorizations are completely independent. The heuristic probability that both are smooth is $\\rho(1/\\varepsilon)^2$, so among $n$ candidates we expect $\\sim n \\rho(1/\\varepsilon)^2$ pairs — this grows, but converting 'many in expectation' to 'at least one for all large $n$' requires controlling the variance, which involves understanding correlations in the smoothness of nearby integers. This is related to the abc conjecture: if $abc$ held effectively, it would constrain how smooth consecutive integers can simultaneously be.",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-4/annotations.json
+++ b/src/data/proofs/erdos-4/annotations.json
@@ -182,7 +182,8 @@
       "Chinese Remainder Theorem",
       "primorial",
       "covering congruences",
-      "Euler-Mascheroni constant"
+      "Euler-Mascheroni constant",
+      "infinitude of primes"
     ],
     "prerequisites": [
       "erdos_4_conjecture"
@@ -392,7 +393,7 @@
     },
     "type": "concept",
     "title": "Average Gap Asymptotic",
-    "content": "The average prime gap near $n$ is $\\sim \\log n$, a consequence of the Prime Number Theorem: $p_n \\sim n \\log n$.",
+    "content": "The average prime gap near $n$ is $\\sim \\log n$, a consequence of the Prime Number Theorem (see `prime-number-theorem`): $p_n \\sim n \\log n$. This is the baseline against which all gap results are measured — Bertrand's postulate (see `bertrands-postulate`) gives the trivial upper bound $g_n < p_n$, while this problem asks about gaps *much larger* than average.",
     "significance": "supporting",
     "mathContext": "The Prime Number Theorem ($\\pi(x) \\sim x/\\log x$, equivalently $p_n \\sim n \\log n$) implies the average gap $g_n \\sim \\log p_n \\sim \\log n$. The formalization states this as $p_n / (n \\log n) \\to 1$, using `Filter.Tendsto` and `nhds 1`. Problem #4 asks about gaps exceeding this average by a factor growing with $n$ — the Erdős function grows as $\\sim (\\log\\log n / \\log\\log\\log n) \\cdot \\log n$, which is $\\omega(\\log n)$ but $o((\\log n)^{1+\\varepsilon})$.",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-414/annotations.json
+++ b/src/data/proofs/erdos-414/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "definition",
     "title": "The Function h(n) = n + τ(n)",
-    "content": "**h(n) = n + τ(n)** where τ(n) = |{d : d | n}| counts divisors. Since τ(n) ≥ 1 for all n ≥ 1, we have h(n) > n always — the map is strictly increasing. For n = 12: τ(12) = 6 (divisors: 1,2,3,4,6,12), so h(12) = 18. For primes p, τ(p) = 2, so h(p) = p + 2.",
+    "content": "**h(n) = n + τ(n)** where τ(n) = |{d : d | n}| counts divisors (related to `euler-totient` — Euler's totient $\\varphi(n)$ counts coprime residues while $\\tau(n)$ counts all divisors). Since τ(n) ≥ 1 for all n ≥ 1, we have h(n) > n always — the map is strictly increasing. For n = 12: τ(12) = 6 (divisors: 1,2,3,4,6,12), so h(12) = 18. For primes p, τ(p) = 2, so h(p) = p + 2.",
     "significance": "key",
     "mathContext": "The map n ↦ n + τ(n) is a natural example from **arithmetic dynamics** — the study of number-theoretic functions iterated as dynamical systems. Unlike the Collatz map (which can decrease), h is strictly increasing, eliminating cycles and fixed points. The divisor function τ is multiplicative: τ(mn) = τ(m)τ(n) for gcd(m,n) = 1, and τ(p^a) = a + 1 for prime powers. Its irregularity (τ oscillates between 2 at primes and large values at highly composite numbers) creates the complex orbit structure central to Problem #414.",
     "relatedConcepts": [
@@ -97,7 +97,7 @@
     },
     "type": "concept",
     "title": "Erdős Problem #414: All Orbits Merge (OPEN)",
-    "content": "**Conjecture**: For any m, n ≥ 1, there exist i, j ∈ ℕ with h^i(m) = h^j(n). Equivalently, all forward orbits of h eventually coalesce into a single infinite trajectory. Erdős and Graham believed the answer is YES.",
+    "content": "**Conjecture**: For any m, n ≥ 1, there exist i, j ∈ ℕ with h^i(m) = h^j(n). Equivalently, all forward orbits of h eventually coalesce into a single infinite trajectory. Erdős and Graham believed the answer is YES. This is analogous to the Collatz conjecture (all orbits merge at 1), but with a key simplification: h is strictly increasing, so there are no cycles — the question is purely about coalescence, not about convergence to a fixed point.",
     "significance": "key",
     "mathContext": "This is an **orbit coalescence** problem: does the directed graph on ℕ defined by n → h(n) have a single connected component when viewed 'forward in time'? The graph is a forest of infinite rays, and the question is whether all rays merge into one. Computationally, orbits starting from different values merge very quickly — orbits from 1 through 10^6 all merge within the first few hundred steps. However, no proof exists because: (1) controlling exact collisions requires understanding the joint distribution of τ along two different orbits, and (2) the divisor function's irregularity makes it hard to prove two specific values coincide. The problem appears in Erdős-Graham [ErGr80], p. 82, alongside the related Problems #412 and #413 about n + φ(n) and n - φ(n).",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-432/annotations.json
+++ b/src/data/proofs/erdos-432/annotations.json
@@ -103,7 +103,9 @@
     "relatedConcepts": [
       "density of coprime sets",
       "sumset density bounds",
-      "additive-multiplicative interplay"
+      "additive-multiplicative interplay",
+      "prime number theorem",
+      "Euler's totient function"
     ],
     "prerequisites": [
       "countingFn",

--- a/src/data/proofs/erdos-444/annotations.json
+++ b/src/data/proofs/erdos-444/annotations.json
@@ -27,7 +27,7 @@
     },
     "type": "definition",
     "title": "Generalized Divisor Function d_A(n)",
-    "content": "**d_A(n) = |{a ∈ A : a | n}|** counts divisors of n belonging to A. When A = ℕ, this is the standard divisor function d(n) = τ(n). When A = primes, this is ω(n), the number of distinct prime factors.",
+    "content": "**d_A(n) = |{a ∈ A : a | n}|** counts divisors of n belonging to A. When A = ℕ, this is the standard divisor function d(n) = τ(n) (related to `euler-totient` — Euler's totient $\\varphi(n)$ counts coprime residues while τ counts all divisors). When A = primes, this is ω(n), the number of distinct prime factors, central to unique factorization (see `fundamental-arithmetic`).",
     "significance": "key",
     "mathContext": "The **generalized divisor function** d_A is a multiplicative-flavored counting function that measures how 'divisible' n is with respect to A. When A is the set of all naturals, d_A = τ (the number-of-divisors function), whose average order is log n (Dirichlet) and maximal order is exp((1+o(1)) log 2 · log n / log log n) (Wigert/Ramanujan). When A = primes, d_A = ω, whose average order is log log n (Hardy-Ramanujan) and maximal order is (1+o(1)) log n / log log n. The problem asks whether the relationship M_A(x) ≫ H_A(x)^k always holds, capturing the idea that extremal divisibility is a **universal phenomenon** independent of which divisors are allowed.",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-499/meta.json
+++ b/src/data/proofs/erdos-499/meta.json
@@ -171,5 +171,21 @@
     "axiomCount": 8,
     "theoremCount": 5,
     "definitionCount": 7
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Both concern matrix algebra: Cayley-Hamilton studies the characteristic polynomial while this problem studies diagonal products in doubly stochastic matrices. The permanent (which bounds diagonal products) is a matrix invariant complementary to the determinant"
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "foundational",
+      "description": "The AM-GM inequality is the key tool: the product of n nonneg reals summing to 1 is maximized at 1/n each, giving the bound n^{-n}. The doubly stochastic constraint (rows and columns sum to 1) interacts with AM-GM through the permanent"
+    }
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "amgm-inequality"
+  ]
 }

--- a/src/data/proofs/erdos-630/annotations.json
+++ b/src/data/proofs/erdos-630/annotations.json
@@ -145,7 +145,7 @@
     },
     "type": "concept",
     "title": "Alon–Tarsi Theorem: The Main Result",
-    "content": "**`alon_tarsi_theorem`** (axiomatized): every planar bipartite graph is 3-choosable, i.e., $\\chi_L(G) \\le 3$.\n\n**`planar_bipartite_3_choosable`**: equivalent `IsKChoosable G 3` formulation, partially proved.\n\nThe Alon–Tarsi proof uses the graph polynomial and shows a certain coefficient is nonzero for planar bipartite graphs by relating it to even vs. odd Eulerian subgraphs in an appropriate orientation.",
+    "content": "**`alon_tarsi_theorem`** (axiomatized): every planar bipartite graph is 3-choosable, i.e., $\\chi_L(G) \\le 3$.\n\n**`planar_bipartite_3_choosable`**: equivalent `IsKChoosable G 3` formulation, partially proved.\n\nThe Alon-Tarsi proof uses the graph polynomial and Combinatorial Nullstellensatz: it shows a certain coefficient in the product $\\prod_{uv \\in E} (x_u - x_v)$ is nonzero for planar bipartite graphs by relating it to even vs. odd Eulerian subgraphs in an appropriate orientation. This algebraic technique is a breakthrough method in combinatorics, connecting graph coloring to polynomial identity testing.",
     "mathContext": "$$\\text{planar} \\wedge \\text{bipartite} \\implies \\chi_L(G) \\le 3$$",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -195,6 +195,40 @@
       "What is the analogous tight bound for counting edge-induced (non-vertex-induced) subgraph signatures?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "foundational",
+      "description": "The Ramsey condition (ω(G), α(G) ≤ C log n) is the defining hypothesis — Ramsey's theorem guarantees such graphs exist. This problem quantifies the induced subgraph complexity that Ramsey graphs must exhibit"
+    },
+    {
+      "targetId": "erdos-1",
+      "relationship": "related",
+      "description": "Both are foundational Erdős problems in Ramsey theory: #1 concerns Ramsey numbers R(k,k), while #636 concerns structural properties (induced subgraph diversity) of Ramsey graphs"
+    },
+    {
+      "targetId": "szemeredi-regularity",
+      "relationship": "related",
+      "description": "The regularity lemma provides pseudorandom decompositions relevant to analyzing induced subgraph structure in dense graphs; Ramsey graphs have density near 1/2 making regularity tools particularly applicable"
+    },
+    {
+      "targetId": "erdos-635",
+      "relationship": "related",
+      "description": "Adjacent Erdős problem in the same series on induced subgraph properties of Ramsey graphs"
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The binomial coefficient C(n,2) bounds the number of edges and appears in the signature (v,e) counting: for a v-vertex induced subgraph, e ranges from 0 to C(v,2)"
+    }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "erdos-1",
+    "szemeredi-regularity",
+    "erdos-635",
+    "combinations-formula"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-766/meta.json
+++ b/src/data/proofs/erdos-766/meta.json
@@ -173,6 +173,46 @@
       "How does f behave for specific graph families (trees, cycles, complete multipartite)?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Both are foundational results in extremal/Ramsey graph theory: Ramsey guarantees monochromatic cliques in edge-colored complete graphs, while extremal numbers quantify the threshold for forced subgraph copies in dense graphs"
+    },
+    {
+      "targetId": "szemeredi-regularity",
+      "relationship": "related",
+      "description": "The Szemerédi regularity lemma is the main structural tool for proving extremal graph theory results: it decomposes dense graphs into pseudorandom bipartite pairs, enabling subgraph counting that underlies Turán-type bounds like those studied here"
+    },
+    {
+      "targetId": "erdos-1009",
+      "relationship": "related",
+      "description": "Both concern edge-counting thresholds in extremal graph theory: #766 studies the minimum extremal number over graphs with given vertex and edge counts, while #1009 studies edge-disjoint subgraph packing beyond the Turán threshold"
+    },
+    {
+      "targetId": "erdos-767",
+      "relationship": "related",
+      "description": "Adjacent Erdős problem in the same series on extremal graph theory and Turán-type questions"
+    },
+    {
+      "targetId": "erdos-765",
+      "relationship": "related",
+      "description": "Adjacent Erdős problem studying related extremal graph theory questions about edge density thresholds"
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The binomial coefficient C(n,2) = n(n-1)/2 counts the maximum possible edges in an n-vertex graph and appears throughout extremal graph theory as the normalizing quantity for edge density"
+    }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "szemeredi-regularity",
+    "erdos-1009",
+    "erdos-767",
+    "erdos-765",
+    "combinations-formula"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Combinatorics.SimpleGraph.Basic",

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -172,5 +172,27 @@
     "axiomCount": 12,
     "theoremCount": 5,
     "definitionCount": 9
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "foundational",
+      "description": "Descending waves generalize monochromatic subsequences; Ramsey's theorem guarantees monochromatic cliques in edge-colorings, while this problem asks about more complex monochromatic structures (waves with descending gaps) in vertex-colorings of integers"
+    },
+    {
+      "targetId": "erdos-782",
+      "relationship": "related",
+      "description": "Adjacent Erdős problem in the same series on Ramsey-type coloring questions about structured monochromatic configurations in integer colorings"
+    },
+    {
+      "targetId": "erdos-780",
+      "relationship": "related",
+      "description": "Adjacent Erdős problem studying related coloring properties of integers under Ramsey-type constraints"
+    }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "erdos-782",
+    "erdos-780"
+  ]
 }

--- a/src/data/proofs/vietas-formulas-oq-03/annotations.json
+++ b/src/data/proofs/vietas-formulas-oq-03/annotations.json
@@ -1,1 +1,221 @@
-[]
+[
+  {
+    "id": "ann-header-doc",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Module Documentation and Imports",
+    "content": "This module formalizes Newton's identities, which express power sums $p_k = \\sum x_i^k$ in terms of elementary symmetric polynomials $e_j$ and vice versa. Newton stated these in *Arithmetica Universalis* (1707), though Albert Girard had earlier versions in *Invention nouvelle en l'algèbre* (1629).\n\nThe single import `Mathlib.Tactic` provides the `ring` and `field_simp` tactics that close all 31 theorems automatically — every Newton identity is a polynomial identity verifiable by normalization.",
+    "mathContext": "Newton's identities: $p_k = \\sum_{i=1}^{\\min(k,n)} (-1)^{i-1} e_i \\cdot p_{k-i} + (-1)^{k-1} k \\cdot e_k$ for $k \\leq n$, and $p_k = \\sum_{i=1}^{n} (-1)^{i-1} e_i \\cdot p_{k-i}$ for $k > n$. The generating function form: $\\sum_{k=1}^{\\infty} p_k t^{k-1} = \\frac{d}{dt} \\log \\prod_{i=1}^{n} \\frac{1}{1 - x_i t}$.",
+    "significance": "key",
+    "prerequisites": [
+      "elementary symmetric polynomials",
+      "power sums",
+      "ring tactic"
+    ],
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "symmetric function theory",
+      "generating functions",
+      "Girard-Newton identities"
+    ]
+  },
+  {
+    "id": "ann-two-var-setup",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 33, "endLine": 54 },
+    "type": "definition",
+    "title": "Two-Variable Setup and First Identity",
+    "content": "The simplest case: two variables $x, y$ with elementary symmetric polynomials $e_1 = x + y$ and $e_2 = xy$. The first identity $p_1 = e_1$ is trivially `rfl`. This section works over an arbitrary commutative ring $R$, requiring no field or characteristic assumptions.\n\nThe two-variable case is the workhorse of the formalization — the recurrence $p_k = e_1 \\cdot p_{k-1} - e_2 \\cdot p_{k-2}$ is a linear recurrence with constant coefficients, and its characteristic polynomial is $t^2 - e_1 t + e_2 = (t - x)(t - y)$.",
+    "mathContext": "For $n = 2$: $e_1 = x + y$, $e_2 = xy$, $e_k = 0$ for $k \\geq 3$. The recurrence simplifies to $p_k = e_1 \\cdot p_{k-1} - e_2 \\cdot p_{k-2}$, a second-order linear recurrence whose solution is $p_k = x^k + y^k$.",
+    "significance": "key",
+    "prerequisites": [
+      "CommRing",
+      "elementary symmetric polynomials"
+    ],
+    "relatedConcepts": [
+      "linear recurrence",
+      "characteristic polynomial of a recurrence",
+      "Chebyshev polynomials"
+    ]
+  },
+  {
+    "id": "ann-two-var-identities",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 55, "endLine": 85 },
+    "type": "technique",
+    "title": "Two-Variable Newton Identities (p₂ through p₄, Pure Forms)",
+    "content": "Newton's identities for $n = 2$, proved both in recursive form (each $p_k$ from previous power sums and elementary symmetric polynomials) and pure form (each $p_k$ expressed solely in $e_1, e_2$).\n\nAll proofs are one-liners using `ring`, which normalizes both sides to a canonical polynomial form and checks equality. This demonstrates that Newton's identities are purely algebraic — they hold in any commutative ring, not just over fields or $\\mathbb{Z}$.",
+    "mathContext": "Recursive: $p_2 = e_1^2 - 2e_2$, $p_3 = e_1 p_2 - e_2 p_1$, $p_4 = e_1 p_3 - e_2 p_2$.\n\nPure: $p_3 = e_1^3 - 3e_1 e_2$, $p_4 = e_1^4 - 4e_1^2 e_2 + 2e_2^2$.\n\nThe pure forms are obtained by substituting the recurrence repeatedly, eliminating all intermediate $p_j$.",
+    "significance": "key",
+    "prerequisites": [
+      "ring tactic",
+      "polynomial identity"
+    ],
+    "relatedConcepts": [
+      "ring normalization",
+      "polynomial identity testing",
+      "Schwartz-Zippel lemma"
+    ]
+  },
+  {
+    "id": "ann-three-var-setup",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 88, "endLine": 118 },
+    "type": "definition",
+    "title": "Three-Variable Setup and Abbreviations",
+    "content": "The three-variable case introduces the third elementary symmetric polynomial $e_3 = xyz$, which appears with an explicit coefficient in the identities. Private abbreviations `e1_3`, `e2_3`, `e3_3`, `p1_3`, `p2_3`, `p3_3`, `p4_3` keep theorem statements readable.\n\nThe use of `private abbrev` rather than `def` ensures these are definitionally transparent — the `unfold` tactic can expand them inline before `ring` closes the goal. This is a practical Lean 4 pattern for naming sub-expressions without introducing opaque definitions.",
+    "mathContext": "For $n = 3$: $e_1 = x + y + z$, $e_2 = xy + xz + yz$, $e_3 = xyz$, $e_k = 0$ for $k \\geq 4$. The recurrence: $p_k = e_1 p_{k-1} - e_2 p_{k-2} + e_3 p_{k-3}$ for $k > 3$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "CommRing",
+      "Lean 4 abbrev"
+    ],
+    "relatedConcepts": [
+      "definitional transparency",
+      "term reduction",
+      "abbreviation pattern"
+    ]
+  },
+  {
+    "id": "ann-three-var-identities",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 119, "endLine": 160 },
+    "type": "theorem",
+    "title": "Three-Variable Newton Identities (Recursive and Pure)",
+    "content": "Newton's identities for three variables, in both forms. The key new feature at $n = 3$ is that $p_3$ gets an explicit $3e_3$ term: $p_3 = e_1 p_2 - e_2 p_1 + 3e_3$.\n\nThe proof pattern is uniform: `unfold` all abbreviations, then `ring`. The pure forms eliminate intermediate power sums, expressing each $p_k$ directly in $e_1, e_2, e_3$. These pure forms are what matrix trace computations use in practice: given the characteristic polynomial (whose coefficients are $\\pm e_k$), compute $\\text{tr}(A^k) = p_k$ directly.",
+    "mathContext": "Recursive: $p_2 = e_1^2 - 2e_2$, $p_3 = e_1^3 - 3e_1 e_2 + 3e_3$, $p_4 = e_1^4 - 4e_1^2 e_2 + 2e_2^2 + 4e_1 e_3$.\n\nThe coefficient of $e_3$ in $p_3$ is $+3$ (not $+1$), reflecting the general pattern: the explicit $e_k$ term in $p_k$ has coefficient $(-1)^{k-1} k$.",
+    "significance": "key",
+    "prerequisites": [
+      "three-variable abbreviations",
+      "unfold + ring pattern"
+    ],
+    "relatedConcepts": [
+      "characteristic polynomial",
+      "matrix trace",
+      "symmetric function basis change"
+    ]
+  },
+  {
+    "id": "ann-four-var",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 162, "endLine": 204 },
+    "type": "theorem",
+    "title": "Four-Variable Newton Identities",
+    "content": "The four-variable case introduces $e_4 = abcd$ and the full fourth identity: $p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$. The coefficient $-4$ on $e_4$ follows the general pattern $(-1)^{k-1} k \\cdot e_k$.\n\nThis section demonstrates that Newton's identities scale to arbitrary variable counts with the same recurrence structure. The `ring` tactic handles the increasing polynomial complexity automatically — the four-variable $p_4$ identity involves 35 monomial terms when fully expanded.",
+    "mathContext": "For $n = 4$: $e_1 = a+b+c+d$, $e_2 = \\sum_{i<j} a_i a_j$ (6 terms), $e_3 = \\sum_{i<j<k} a_i a_j a_k$ (4 terms), $e_4 = abcd$.\n\n$p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$. The alternating signs $+, -, +, -$ and the explicit coefficient $-4e_4$ are the hallmarks of the general Newton identity at $k = n$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "four-variable abbreviations",
+      "ring tactic scaling"
+    ],
+    "relatedConcepts": [
+      "binomial coefficient",
+      "multinomial expansion",
+      "combinatorial identity"
+    ]
+  },
+  {
+    "id": "ann-inversion",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 206, "endLine": 232 },
+    "type": "technique",
+    "title": "Inversion: Recovering Elementary Symmetric Polynomials from Power Sums",
+    "content": "Newton's identities also work in reverse: the elementary symmetric polynomials $e_k$ can be recovered from the power sums $p_1, \\ldots, p_k$. This is crucial for spectral theory: given matrix traces $\\text{tr}(A), \\text{tr}(A^2), \\ldots$, recover the characteristic polynomial coefficients.\n\nThe inversion requires a field with characteristic zero (division by 2 and 6 appears). The proofs use `field_simp` to clear denominators, then `ring`. The formulas are: $e_2 = (p_1^2 - p_2)/2$ and $e_3 = (p_1^3 - 3p_1 p_2 + 2p_3)/6$.",
+    "mathContext": "$e_2 = \\frac{p_1^2 - p_2}{2}$, $e_3 = \\frac{p_1^3 - 3p_1 p_2 + 2p_3}{6}$.\n\nThese are instances of the general inversion via the exponential formula: $\\sum_{k=0}^{\\infty} e_k t^k = \\exp\\left(-\\sum_{j=1}^{\\infty} \\frac{(-1)^j p_j}{j} t^j\\right)$. The denominators $2, 6, \\ldots$ are $k!$, explaining the characteristic zero requirement.",
+    "significance": "key",
+    "prerequisites": [
+      "Field",
+      "CharZero",
+      "field_simp tactic",
+      "exponential generating function"
+    ],
+    "relatedConcepts": [
+      "spectral theory",
+      "characteristic polynomial recovery",
+      "Faddeev-LeVerrier algorithm",
+      "exponential formula"
+    ]
+  },
+  {
+    "id": "ann-discriminant",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 234, "endLine": 266 },
+    "type": "insight",
+    "title": "Application: Polynomial Discriminants via Symmetric Functions",
+    "content": "The discriminant $\\Delta = \\prod_{i<j} (r_i - r_j)^2$ of a polynomial is a symmetric function of the roots, hence expressible via $e_k$. This section verifies the quadratic discriminant $\\Delta = e_1^2 - 4e_2$ and the cubic discriminant $\\Delta = e_1^2 e_2^2 - 4e_2^3 - 4e_1^3 e_3 + 18e_1 e_2 e_3 - 27e_3^2$.\n\nThe cubic discriminant formula is particularly important: $\\Delta > 0$ means three real roots, $\\Delta = 0$ means a repeated root, and $\\Delta < 0$ means one real and two complex conjugate roots. In Galois theory, $\\Delta$ being a perfect square determines whether the Galois group lies in $A_n$.",
+    "mathContext": "Quadratic: $\\Delta = (r_1 - r_2)^2 = (r_1 + r_2)^2 - 4r_1 r_2 = e_1^2 - 4e_2$.\n\nCubic: $\\Delta = \\prod_{i<j}(r_i - r_j)^2 = e_1^2 e_2^2 - 4e_2^3 - 4e_1^3 e_3 + 18e_1 e_2 e_3 - 27e_3^2$.\n\nThe connection to power sums: $\\Delta = 2p_2 - p_1^2$ for $n = 2$.",
+    "significance": "key",
+    "prerequisites": [
+      "polynomial discriminant",
+      "Galois group containment in Aₙ",
+      "symmetric function"
+    ],
+    "relatedConcepts": [
+      "Galois group",
+      "resultant",
+      "Sylvester matrix",
+      "Abel-Ruffini discriminant criterion"
+    ]
+  },
+  {
+    "id": "ann-matrix-trace",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 268, "endLine": 296 },
+    "type": "insight",
+    "title": "Application: Matrix Traces and Cayley-Hamilton",
+    "content": "For an $n \\times n$ matrix $A$ with eigenvalues $\\lambda_1, \\ldots, \\lambda_n$, the trace of $A^k$ equals the power sum $p_k(\\lambda_1, \\ldots, \\lambda_n)$. Newton's identities then recover the characteristic polynomial $\\det(xI - A)$ from traces alone.\n\nThe theorem `cayley_hamilton_trace_2x2` shows that for $2 \\times 2$ matrices, Newton's second identity $p_2 - e_1 p_1 + 2e_2 = 0$ is precisely the Cayley-Hamilton theorem $A^2 - \\text{tr}(A) \\cdot A + \\det(A) \\cdot I = 0$ evaluated at the trace level. This connection is the basis for the Faddeev-LeVerrier algorithm for computing characteristic polynomials.",
+    "mathContext": "$\\text{tr}(A^k) = p_k(\\lambda_1, \\ldots, \\lambda_n) = \\sum_{i=1}^n \\lambda_i^k$.\n\nCayley-Hamilton in trace form (2×2): $p_2 - e_1 p_1 + 2e_2 = 0$, i.e., $\\text{tr}(A^2) - \\text{tr}(A)^2 + 2\\det(A) = 0$.\n\nFaddeev-LeVerrier: computes $e_1, e_2, \\ldots, e_n$ from $p_1, p_2, \\ldots, p_n$ using Newton's identities in $O(n^4)$ operations.",
+    "significance": "key",
+    "prerequisites": [
+      "matrix eigenvalues",
+      "trace",
+      "Cayley-Hamilton theorem"
+    ],
+    "relatedConcepts": [
+      "Faddeev-LeVerrier algorithm",
+      "spectral theory",
+      "characteristic polynomial",
+      "Cayley-Hamilton theorem"
+    ]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 298, "endLine": 330 },
+    "type": "technique",
+    "title": "Recurrence Verification for Higher Power Sums",
+    "content": "Verification that the recurrence pattern extends beyond $k = n$. For $k > n$, the explicit $e_k$ term vanishes (since $e_k = 0$ for $k > n$ variables), and the recurrence simplifies. This section proves $p_5$ and $p_6$ for 2 and 3 variables.\n\nFor 3 variables: $p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2$ (no $e_4$ or $e_5$ terms). For 2 variables: $p_5 = e_1 p_4 - e_2 p_3$ and $p_6 = e_1 p_5 - e_2 p_4$. The recurrence is finite-order: for $n$ variables, the recurrence has depth $n$.",
+    "mathContext": "For $k > n$: $p_k = \\sum_{i=1}^{n} (-1)^{i-1} e_i \\cdot p_{k-i}$. The recurrence has characteristic polynomial $t^n - e_1 t^{n-1} + e_2 t^{n-2} - \\cdots + (-1)^n e_n = \\prod_{i=1}^n (t - x_i)$, whose roots are the variables $x_1, \\ldots, x_n$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Newton identity recurrence",
+      "vanishing of higher eₖ"
+    ],
+    "relatedConcepts": [
+      "linear recurrence",
+      "characteristic polynomial",
+      "finite-order recurrence"
+    ]
+  },
+  {
+    "id": "ann-vieta-connection",
+    "proofId": "vietas-formulas-oq-03",
+    "range": { "startLine": 332, "endLine": 383 },
+    "type": "insight",
+    "title": "Connection to Vieta's Formulas and Sum-of-Cubes Factorization",
+    "content": "The closing section connects Newton's identities back to Vieta's formulas: the coefficients of a monic polynomial are $\\pm e_k$ of its roots (Vieta), and Newton's identities then express all power sums in terms of these coefficients.\n\nThe sum-of-cubes factorization $x^3 + y^3 + z^3 - 3xyz = (x+y+z)(x^2+y^2+z^2 - xy - xz - yz)$ is a direct consequence of Newton's third identity $p_3 = e_1^3 - 3e_1 e_2 + 3e_3$ rewritten as $p_3 - 3e_3 = e_1(e_1^2 - 3e_2) = e_1(p_2 - e_2)$. This factorization appears in AM-GM proofs and Schur's inequality.",
+    "mathContext": "Full pipeline: $(x - r_1)(x - r_2)(x - r_3) = x^3 - e_1 x^2 + e_2 x - e_3$ (Vieta), then $r_1^3 + r_2^3 + r_3^3 = e_1^3 - 3e_1 e_2 + 3e_3$ (Newton).\n\nFactorization: $x^3 + y^3 + z^3 - 3xyz = (x+y+z)(x^2+y^2+z^2 - xy - xz - yz)$. Corollary: if $x + y + z = 0$, then $x^3 + y^3 + z^3 = 3xyz$.",
+    "significance": "key",
+    "prerequisites": [
+      "Vieta's formulas",
+      "monic polynomial factorization"
+    ],
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "AM-GM inequality",
+      "Schur's inequality",
+      "sum of cubes identity"
+    ]
+  }
+]

--- a/src/data/proofs/vietas-formulas-oq-03/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03/meta.json
@@ -14,7 +14,6 @@
       "symmetric-functions",
       "polynomials",
       "research",
-      "open-problem",
       "newtons-identities",
       "power-sums"
     ],
@@ -46,43 +45,210 @@
       "Matrix trace connection: characteristic polynomial coefficients from traces via Newton's identities",
       "Sum-of-cubes factorization: x³ + y³ + z³ − 3xyz = (x+y+z)(x²+y²+z² − xy − xz − yz)"
     ],
-    "significance": 8,
-    "notes": "Newton's identities are fundamental to symmetric function theory. They bridge Vieta's formulas (coefficients ↔ roots) with power sum invariants, and underpin the Cayley-Hamilton theorem, characteristic polynomial computation, and Galois theory."
+    "dateAdded": "2025-12-21",
+    "prerequisites": [
+      "Elementary symmetric polynomials and their definitions",
+      "Commutative ring and field axioms",
+      "Polynomial identity verification (ring tactic)",
+      "Basic Galois theory for discriminant applications"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Newton's identities were first published by Isaac Newton in *Arithmetica Universalis* (1707), though Albert Girard had stated equivalent results without proof in *Invention nouvelle en l'algèbre* (1629). The identities provide an algorithmic bridge between two fundamental bases of symmetric function theory: the elementary symmetric polynomials $e_k$ (which appear as polynomial coefficients via Vieta's formulas) and the power sums $p_k$ (which appear as matrix traces and moment-generating invariants).\n\nThe historical significance extends far beyond polynomial manipulation. In the 18th century, Edward Waring used Newton's identities to study symmetric functions systematically, leading to the 'Waring problem' of representing integers as sums of powers. In the 19th century, the connection between Newton's identities and matrix theory became central through Cayley and Sylvester's invariant theory. The Faddeev-LeVerrier algorithm (1840, 1853) directly applies Newton's identities to compute characteristic polynomials from matrix traces, a method still used in numerical linear algebra.\n\nIn modern mathematics, Newton's identities are a special case of the theory of symmetric functions developed by Schur, Littlewood, and Macdonald. The ring of symmetric functions $\\Lambda$ has multiple bases (monomial, elementary, power sum, Schur), and Newton's identities describe the change-of-basis between $e_k$ and $p_k$. This perspective connects to representation theory via the Frobenius characteristic map, which sends characters of symmetric groups to symmetric functions.",
+    "problemStatement": "Newton's identities: Express the power sums $p_k = \\sum_{i=1}^n x_i^k$ in terms of the elementary symmetric polynomials $e_j = \\sum_{1 \\leq i_1 < \\cdots < i_j \\leq n} x_{i_1} \\cdots x_{i_j}$, and conversely.\n\nThe recursive form:\n$$p_k = \\sum_{i=1}^{\\min(k,n)} (-1)^{i-1} e_i \\cdot p_{k-i} + (-1)^{k-1} k \\cdot e_k \\quad (k \\leq n)$$\n$$p_k = \\sum_{i=1}^{n} (-1)^{i-1} e_i \\cdot p_{k-i} \\quad (k > n)$$\n\nThis formalization verifies these identities for $n = 2, 3, 4$ variables in both recursive and pure (closed-form) expressions.",
+    "proofStrategy": "Each Newton identity is a polynomial identity: both sides are equal as elements of the polynomial ring $\\mathbb{Z}[x_1, \\ldots, x_n]$. The Lean `ring` tactic decides such equalities by normalizing both sides to a canonical form and checking syntactic equality. This makes each proof a one-liner.\n\nThe formalization is organized in increasing complexity:\n1. **Two variables** ($n = 2$): The recurrence $p_k = e_1 p_{k-1} - e_2 p_{k-2}$ is a second-order linear recurrence. Proved for $k = 1$ through $6$, in both recursive and pure forms.\n2. **Three variables** ($n = 3$): The third elementary symmetric polynomial $e_3 = xyz$ introduces a new term. The key identity $p_3 = e_1^3 - 3e_1 e_2 + 3e_3$ is proved.\n3. **Four variables** ($n = 4$): Full fourth identity $p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$ verified.\n4. **Inversion**: Uses `field_simp` + `ring` over fields of characteristic zero to recover $e_k$ from $p_k$.\n5. **Applications**: Discriminants, matrix traces, Cayley-Hamilton, and the sum-of-cubes factorization.",
+    "keyInsights": [
+      "**Universal polynomial identity**: Newton's identities hold over any commutative ring — no field, characteristic, or algebraicity assumptions needed. The `ring` tactic verifies this by treating both sides as formal polynomial expressions.",
+      "**Recurrence structure**: For $n$ variables, the power sums satisfy an $n$th-order linear recurrence $p_k = \\sum_{i=1}^n (-1)^{i-1} e_i p_{k-i}$ whose characteristic polynomial is $\\prod (t - x_i)$ — the same polynomial whose roots are the variables. This is a manifestation of Cayley-Hamilton at the level of symmetric functions.",
+      "**Basis change in $\\Lambda$**: Newton's identities describe the change of basis between $\\{e_k\\}$ and $\\{p_k\\}$ in the ring of symmetric functions $\\Lambda$. The transition matrix involves binomial-like coefficients, and the generating function relation $\\sum p_k t^{k-1} = -\\frac{d}{dt} \\log E(-t)$ (where $E(t) = \\sum e_k t^k$) encodes all identities simultaneously.",
+      "**Inversion requires characteristic zero**: Recovering $e_k$ from $p_k$ introduces denominators $k!$, failing in characteristic $p \\leq k$. This reflects a deep algebraic fact: the power sum basis of $\\Lambda \\otimes \\mathbb{Q}$ does not extend to $\\Lambda \\otimes \\mathbb{F}_p$.",
+      "**Discriminant connection**: The cubic discriminant formula $\\Delta = e_1^2 e_2^2 - 4e_2^3 - 4e_1^3 e_3 + 18e_1 e_2 e_3 - 27e_3^2$ is directly derived from Newton's identities. In Galois theory, whether $\\Delta$ is a perfect square determines if the Galois group lies in $A_n$.",
+      "**Sum-of-cubes factorization**: $x^3 + y^3 + z^3 - 3xyz = (x+y+z)(x^2+y^2+z^2 - xy - xz - yz)$ is a direct consequence of Newton's third identity $p_3 = e_1(e_1^2 - 3e_2) + 3e_3$, rewritten as $p_3 - 3e_3 = e_1(p_2 - e_2)$."
+    ]
   },
   "sections": [
     {
-      "title": "Two Variables",
-      "description": "Newton's identities for elementary symmetric polynomials e₁ = x+y, e₂ = xy and power sums pₖ = xᵏ+yᵏ. The recurrence pₖ = e₁·pₖ₋₁ − e₂·pₖ₋₂ proved for k = 1 through 6."
+      "id": "header-imports",
+      "title": "Module Documentation and Import",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Module docstring describing Newton's identities, their historical context (Newton 1707, Girard 1629), and applications. Single import: `Mathlib.Tactic` (provides `ring` and `field_simp`). Opens the `NewtonIdentities` namespace.",
+      "mathContext": "Newton's identities: $p_k = \\sum_{i=1}^{\\min(k,n)} (-1)^{i-1} e_i p_{k-i} + (-1)^{k-1} k e_k$. The generating function: $\\sum_{k \\geq 1} p_k t^{k-1} = -\\frac{E'(-t)}{E(-t)}$ where $E(t) = \\sum_{k \\geq 0} e_k t^k = \\prod_i (1 + x_i t)$."
     },
     {
-      "title": "Three Variables",
-      "description": "Newton's identities for e₁, e₂, e₃ and power sums in three variables. Both recursive form (pₖ via previous power sums) and pure form (pₖ via elementary symmetric polynomials only)."
+      "id": "two-variables",
+      "title": "Two-Variable Newton Identities",
+      "startLine": 33,
+      "endLine": 86,
+      "summary": "Newton's identities for $n = 2$: $e_1 = x+y$, $e_2 = xy$. Recursive form ($p_k$ from previous power sums) for $k = 1$ through $4$, plus pure forms expressing $p_2, p_3, p_4$ solely in $e_1, e_2$. All proofs by `ring`. Works over any `CommRing R`.",
+      "mathContext": "The two-variable recurrence $p_k = e_1 p_{k-1} - e_2 p_{k-2}$ is a second-order linear recurrence with characteristic polynomial $(t-x)(t-y) = t^2 - e_1 t + e_2$. Pure forms: $p_2 = e_1^2 - 2e_2$, $p_3 = e_1^3 - 3e_1 e_2$, $p_4 = e_1^4 - 4e_1^2 e_2 + 2e_2^2$."
     },
     {
-      "title": "Four Variables",
-      "description": "Newton's identities for four variables, including the full fourth identity p₄ = e₁·p₃ − e₂·p₂ + e₃·p₁ − 4·e₄."
+      "id": "three-variables",
+      "title": "Three-Variable Newton Identities",
+      "startLine": 88,
+      "endLine": 160,
+      "summary": "Newton's identities for $n = 3$. Private abbreviations for $e_1, e_2, e_3$ and $p_1, \\ldots, p_4$. Recursive identities with the $+3e_3$ term in $p_3$. Pure forms eliminating intermediate power sums. Proofs by `unfold` + `ring`.",
+      "mathContext": "Key identity: $p_3 = e_1^3 - 3e_1 e_2 + 3e_3$. The coefficient $+3$ on $e_3$ follows the pattern $(-1)^{k-1} k \\cdot e_k$: for $k = 3$, this gives $(-1)^2 \\cdot 3 = +3$."
     },
     {
-      "title": "Inversion",
-      "description": "Recovering elementary symmetric polynomials from power sums: e₂ = (p₁² − p₂)/2 and e₃ = (p₁³ − 3p₁p₂ + 2p₃)/6."
+      "id": "four-variables",
+      "title": "Four-Variable Newton Identities",
+      "startLine": 162,
+      "endLine": 204,
+      "summary": "Newton's identities for $n = 4$: $p_2, p_3, p_4$ via the full four-variable recurrence. The fourth identity $p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$ verified by `unfold` + `ring`.",
+      "mathContext": "$e_4 = abcd$, and $p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$. The alternating signs $+,-,+,-$ and the coefficient $-4$ on $e_4$ follow $(-1)^{k-1} k = (-1)^3 \\cdot 4 = -4$."
     },
     {
-      "title": "Applications",
-      "description": "Discriminant formulas (quadratic and cubic), matrix trace identities, Cayley-Hamilton in trace form, and the sum-of-cubes factorization."
+      "id": "inversion",
+      "title": "Inversion: Elementary Symmetric from Power Sums",
+      "startLine": 206,
+      "endLine": 232,
+      "summary": "Newton's identities in reverse: $e_2 = (p_1^2 - p_2)/2$ and $e_3 = (p_1^3 - 3p_1 p_2 + 2p_3)/6$. Requires `Field` and `CharZero` for the divisions. Proofs by `field_simp` + `ring`.",
+      "mathContext": "The denominators $2$ and $6 = 3!$ arise from the exponential formula $\\sum e_k t^k = \\exp(-\\sum (-1)^j p_j t^j / j)$. The inversion fails in characteristic $p$ when $p \\leq k$."
+    },
+    {
+      "id": "discriminant",
+      "title": "Polynomial Discriminants via Symmetric Functions",
+      "startLine": 234,
+      "endLine": 266,
+      "summary": "Quadratic discriminant $\\Delta = e_1^2 - 4e_2$ and cubic discriminant $\\Delta = e_1^2 e_2^2 - 4e_2^3 - 4e_1^3 e_3 + 18e_1 e_2 e_3 - 27e_3^2$. Also $\\Delta$ via power sums: $\\Delta = 2p_2 - p_1^2$ for $n = 2$.",
+      "mathContext": "$\\Delta = \\prod_{i<j}(r_i - r_j)^2$ is a symmetric function of roots, hence expressible via $e_k$. Whether $\\sqrt{\\Delta} \\in F$ determines if $\\text{Gal}(f) \\subseteq A_n$."
+    },
+    {
+      "id": "matrix-trace",
+      "title": "Matrix Traces and Cayley-Hamilton",
+      "startLine": 268,
+      "endLine": 296,
+      "summary": "For $2 \\times 2$ matrices: $e_2 = (p_1^2 - p_2)/2$ recovers the determinant from traces. The Cayley-Hamilton identity $p_2 - e_1 p_1 + 2e_2 = 0$ is Newton's second identity.",
+      "mathContext": "$\\text{tr}(A^k) = p_k(\\lambda_1, \\ldots, \\lambda_n)$. Cayley-Hamilton at the trace level: $p_2 - e_1 p_1 + 2e_2 = 0$, equivalent to $A^2 - \\text{tr}(A) A + \\det(A) I = 0$."
+    },
+    {
+      "id": "recurrence",
+      "title": "Recurrence Verification for Higher Power Sums",
+      "startLine": 298,
+      "endLine": 330,
+      "summary": "Verification that the recurrence extends beyond $k = n$: for 3 variables, $p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2$ (no $e_4$, $e_5$ terms). For 2 variables, $p_5$ and $p_6$ verified.",
+      "mathContext": "For $k > n$: $p_k = \\sum_{i=1}^n (-1)^{i-1} e_i p_{k-i}$. The $e_k$ term vanishes for $k > n$ since there are only $n$ variables."
+    },
+    {
+      "id": "vieta-connection",
+      "title": "Connection to Vieta's Formulas and Sum-of-Cubes",
+      "startLine": 332,
+      "endLine": 383,
+      "summary": "Vieta's formulas for quadratic and cubic polynomials. Full pipeline: from cubic coefficients to $p_3$. The sum-of-cubes factorization $x^3 + y^3 + z^3 - 3xyz = (x+y+z)(x^2+y^2+z^2 - xy - xz - yz)$.",
+      "mathContext": "Vieta: $(x-r_1)(x-r_2)(x-r_3) = x^3 - e_1 x^2 + e_2 x - e_3$. Newton: $p_3 = e_1^3 - 3e_1 e_2 + 3e_3$. Combined: roots' cubes from polynomial coefficients."
     }
   ],
-  "overview": {
-    "what": "Newton's identities express power sums pₖ = Σxᵢᵏ as explicit polynomials in the elementary symmetric polynomials eⱼ, and vice versa.",
-    "whyMatters": "These identities are foundational to symmetric function theory and connect polynomial coefficients (Vieta's formulas) to trace-like invariants. They underpin the Cayley-Hamilton theorem, spectral theory, and are essential in Galois theory.",
-    "approach": "Direct algebraic verification using the ring tactic for 2, 3, and 4 variables. Each Newton identity is a polynomial identity that ring closes automatically. Inversion uses field_simp + ring.",
-    "keyInsight": "The recurrence pₖ = Σᵢ₌₁ⁿ (−1)^{i−1} eᵢ · pₖ₋ᵢ is a universal identity that holds for any number of variables n. For k > n, the eₖ term vanishes and the recurrence simplifies."
-  },
   "conclusion": {
-    "summary": "All 31 theorems proved with 0 sorries and 0 axioms. Newton's identities verified for 2, 3, and 4 variables in both recursive and pure forms, with applications to discriminants and matrix traces.",
-    "futureWork": [
-      "Generalize to n variables using MvPolynomial.esymm and Finset.powersum",
-      "Prove the general Newton identity via formal derivative of the generating function",
-      "Connect to Mathlib's Polynomial.Vieta infrastructure"
+    "summary": "All 31 theorems proved with 0 sorries and 0 axioms across 383 lines. Newton's identities verified for 2, 3, and 4 variables in both recursive and pure forms, with applications to polynomial discriminants, matrix traces, the Cayley-Hamilton theorem, and the classical sum-of-cubes factorization. Every proof is closed automatically by `ring` or `field_simp` + `ring`, demonstrating that Newton's identities are decidable polynomial equalities.",
+    "implications": "Newton's identities have applications across mathematics:\n\n1. SPECTRAL THEORY: The Faddeev-LeVerrier algorithm computes characteristic polynomials from matrix traces using exactly these identities, in O(n⁴) operations.\n\n2. GALOIS THEORY: The discriminant formulas connect to the Abel-Ruffini theorem — whether Δ is a perfect square determines if Gal(f) ⊆ Aₙ, the key criterion for radical solvability.\n\n3. REPRESENTATION THEORY: The Frobenius characteristic map sends characters of Sₙ to symmetric functions in Λ. Newton's identities describe the change of basis between the power sum and elementary bases, which correspond to different representation-theoretic constructions.\n\n4. NUMBER THEORY: Waring's problem (expressing integers as sums of k-th powers) was inspired by studying power sums and their relation to symmetric functions.\n\n5. COMBINATORICS: The cycle index of Sₙ expresses the generating function for conjugacy classes in terms of power sums, and Newton's identities convert this to elementary symmetric polynomials.\n\n6. NUMERICAL LINEAR ALGEBRA: Computing eigenvalues from traces (inverse eigenvalue problem) relies on Newton's inversion formulas, with characteristic zero being essential for the division steps.",
+    "openQuestions": [
+      "Generalize to $n$ variables using `MvPolynomial.esymm` and `Finset.powersum` from Mathlib, proving Newton's identities as a single theorem for arbitrary $n$ rather than case-by-case.",
+      "Prove the general Newton identity via the formal derivative of the generating function $E(t) = \\prod (1 + x_i t)$: differentiating $\\log E(t) = \\sum \\log(1 + x_i t)$ and comparing coefficients yields all identities simultaneously.",
+      "Connect to Mathlib's `Polynomial.Vieta` infrastructure to state Newton's identities for the roots of a given polynomial, bridging the abstract symmetric function perspective with concrete polynomial algebra.",
+      "Formalize the Faddeev-LeVerrier algorithm: given a matrix $A$, compute its characteristic polynomial using only matrix multiplications and traces, with Newton's identities as the correctness proof.",
+      "Extend the discriminant computations to degree 4 (the quartic discriminant has 16 terms in the elementary symmetric polynomial basis) and connect to the resolvent cubic used in Ferrari's quartic formula."
     ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "extends",
+      "description": "Parent formalization of Vieta's formulas (coefficients ↔ roots). Newton's identities extend Vieta by expressing all power sums pₖ = Σxᵢᵏ in terms of the elementary symmetric polynomials that Vieta relates to coefficients — providing the full bridge from polynomial coefficients to trace-like invariants"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley-Hamilton theorem (every matrix satisfies its characteristic polynomial) is intimately connected: Newton's second identity p₂ − e₁p₁ + 2e₂ = 0 is precisely Cayley-Hamilton at the trace level for 2×2 matrices. The formalization's matrix trace section makes this connection explicit"
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "related",
+      "description": "The minimal polynomial, whose relation to the characteristic polynomial is governed by the Cayley-Hamilton framework, connects to Newton's identities through the power sum recurrence: the minimal polynomial's roots are exactly the distinct eigenvalues, and Newton's identities recover all power sums from these roots"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "The discriminant formulas proved here (quadratic and cubic Δ via elementary symmetric polynomials) are essential tools in Galois theory: whether Δ is a perfect square determines if Gal(f) ⊆ Aₙ, the key criterion used in Abel-Ruffini's impossibility proof to determine radical solvability"
+    },
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "complementary",
+      "description": "Cardano's cubic formula explicitly uses Newton's identity p₃ = e₁³ − 3e₁e₂ + 3e₃ via the sum-of-cubes factorization: the resolvent cubic in Cardano's method involves expressing root combinations as symmetric functions, exactly the bridge Newton's identities provide"
+    },
+    {
+      "targetId": "general-quartic",
+      "relationship": "complementary",
+      "description": "Ferrari's quartic formula uses the resolvent cubic, whose discriminant is expressed via elementary symmetric polynomials using Newton's identities. The four-variable identities proved here directly apply to quartic polynomial analysis"
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization in Z[x₁,...,xₙ] guarantees that the polynomial identities proved by `ring` are valid — the ring tactic works by reducing to a normal form in the polynomial ring, and uniqueness of this form depends on the UFD property"
+    },
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "thematic",
+      "description": "Lagrange's four-squares theorem (every positive integer is a sum of four squares) is historically connected to Waring's problem, which was inspired by studying power sums and their relation to symmetric functions — the same objects Newton's identities describe"
+    }
+  ],
+  "relatedProofs": [
+    "vietas-formulas",
+    "cayley-hamilton",
+    "cayley-hamilton-minpoly",
+    "abel-ruffini",
+    "solution-of-cubic",
+    "general-quartic",
+    "fundamental-arithmetic",
+    "lagrange-four-squares"
+  ],
+  "references": [
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "Cambridge University Press",
+      "note": "First publication of Newton's identities relating power sums to elementary symmetric polynomials, though Newton had discovered them decades earlier"
+    },
+    {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": "1629",
+      "venue": "Amsterdam",
+      "note": "First statement of the relations between power sums and elementary symmetric polynomials, predating Newton by nearly 80 years — Girard stated them without proof for the cases n = 2, 3, 4"
+    },
+    {
+      "authors": "Macdonald, Ian G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford University Press, 2nd edition",
+      "note": "The definitive reference on the ring of symmetric functions Λ, including Newton's identities as the change-of-basis between the elementary and power sum bases, and connections to representation theory via the Frobenius characteristic map"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": "1999",
+      "venue": "Cambridge University Press",
+      "note": "Comprehensive treatment of symmetric functions in combinatorics, including Newton's identities, Schur functions, and the cycle index of the symmetric group expressed via power sums"
+    },
+    {
+      "authors": "Faddeev, D. K.; Sominskii, I. S.",
+      "title": "Problems in Higher Algebra",
+      "year": "1965",
+      "venue": "W. H. Freeman",
+      "note": "Contains the Faddeev-LeVerrier algorithm for computing characteristic polynomials from matrix traces using Newton's identities — the practical algorithm that motivates the inversion formulas in this formalization"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "NewtonIdentities",
+    "lineCount": 383,
+    "axiomCount": 0,
+    "theoremCount": 31,
+    "definitionCount": 15
   }
 }


### PR DESCRIPTION
## Summary
Enrichment batch from enricher-2.

### abel-ruffini (pass 2, quality 100 → 100+)
- Added **keyInsight** on discriminant criterion: Δ(f) ∈ F² ⟺ Gal(f) ⊆ Aₙ
- Added 3 **references**: Serre, Dummit & Foote, van der Waerden
- Added 2 **cross-references**: elementary-quadratic-reciprocity, oq-03
- Added **open question** on positive characteristic / Abhyankar conjecture

### vietas-formulas-oq-03 (pass 1, quality 15 → enriched)
- Added **11 annotations** (was 0 — empty file)
- Added `historicalContext` (1578 chars: Newton 1707, Girard 1629, Macdonald)
- Converted overview to standard schema with 6 keyInsights
- Added 9 sections with line ranges and mathContext
- Added 8 cross-references and 5 references
- Expanded conclusion with implications and 5 open questions

## Test plan
- [x] JSON validates for both entries
- [x] Annotation build passes (no errors on either entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)