### PR TITLE
Enrich 7 entries: abel-ruffini, area-of-circle, brouwer, FTA, cantors, FLT, halting

### DIFF
--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -192,6 +192,27 @@
       "year": "1958",
       "venue": "McGraw-Hill (reprinted Dover, 1982)",
       "note": "Classic textbook treatment of recursion theory including detailed analysis of the halting problem, Rice's theorem, and the arithmetical hierarchy"
+    },
+    {
+      "authors": "Rice, Henry Gordon",
+      "title": "Classes of Recursively Enumerable Sets and Their Decision Problems",
+      "year": "1953",
+      "venue": "Transactions of the American Mathematical Society, vol. 74, pp. 358\u2013366",
+      "note": "Rice's theorem: every non-trivial semantic property of programs is undecidable. This is the most powerful generalization of the halting problem \u2014 it shows that undecidability is not a quirk of the halting predicate but a universal feature of program behavior"
+    },
+    {
+      "authors": "Hodges, Andrew",
+      "title": "Alan Turing: The Enigma",
+      "year": "1983",
+      "venue": "Simon & Schuster (updated edition 2014)",
+      "note": "Definitive biography of Turing covering both his mathematical contributions (the halting problem, Turing machines, the Entscheidungsproblem) and his wartime codebreaking work at Bletchley Park"
+    },
+    {
+      "authors": "Rogers, Hartley Jr.",
+      "title": "Theory of Recursive Functions and Effective Computability",
+      "year": "1967",
+      "venue": "McGraw-Hill (reprinted MIT Press, 1987)",
+      "note": "Graduate-level reference for recursion theory: covers the halting problem, the arithmetical hierarchy, the recursion theorem, and Post's problem \u2014 the standard for the full theory of computability"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **abel-ruffini (pass 2)**: +3 references (Gonthier Feit-Thompson, Raynaud/Harbater Abhyankar)
- **area-of-circle (pass 1)**: +3 cross-references, +3 references (Liu Hui, Rhind Papyrus, Laczkovich)
- **brouwer-fixed-point (pass 1)**: Fixed 2 overlapping annotation ranges, +3 references (Nash, Sperner, Papadimitriou)
- **fundamental-theorem-algebra (pass 1)**: +3 cross-references, +3 references (Girard, Artin-Schreier, Liouville)
- **cantors-theorem (pass 1)**: +5 mathContext fields, +2 cross-references, fixed duplicate reference
- **fermats-last-theorem (pass 1)**: +1 mathContext, +3 references (Ribet, Fermat, Buzzard/Commelin/Massot)
- **halting-problem (pass 1)**: +3 references (Rice, Hodges, Rogers)

## Test plan
- [x] JSON validates for all 7 entries
- [x] All cross-reference targets verified
- [x] No duplicate annotations or references

🤖 Generated with [Claude Code](https://claude.com/claude-code)