### PR TITLE
chore: sync research listings and data (deploy 2026-03-23)

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -5307,10 +5307,12 @@
     },
     {
       "slug": "birthday-problem-oq-03",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-22T15:12:20-07:00",
-      "status": "active"
+      "status": "graduated",
+      "completed": "2026-03-23T10:45:52.031Z",
+      "lastUpdate": "2026-03-23T10:45:52.032Z"
     },
     {
       "slug": "fourier-series-oq-02",


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (15 added, 73 updated, 981 total)
- Auto-generated by deployer agent

## Context
Post-merge data sync after deploying PRs #5112, #5113, #5114, #5115, #5116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)