### PR TITLE
Enrich 2 entries: birthday-problem-oq-03 + power-mean-limit schema conformance

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -62,6 +62,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
+    "assumptions": "None. All 10 theorems fully proved from Mathlib with 0 axiom declarations and 0 sorries.",
     "prerequisites": [
       "Derivatives in Mathlib (HasDerivAt, hasDerivAt_iff_tendsto_slope)",
       "Real exp/log/rpow identities and derivatives",
@@ -190,9 +191,9 @@
       "id": "main-limit",
       "title": "Core Limit via Derivative Definition",
       "startLine": 143,
-      "endLine": 200,
-      "summary": "tendsto_log_sum_div_rpow: (log ∑ wᵢzᵢ^r)/r → ∑ wᵢ log zᵢ using hasDerivAt_iff_tendsto_slope. tendsto_powerMean_zero: MAIN THEOREM M_r → GM via exp continuity.",
-      "mathContext": "$\\frac{\\log(\\sum w_i z_i^r)}{r} = \\frac{f(r) - f(0)}{r - 0} \\to f'(0) = \\sum w_i \\log z_i$. Then $M_r = \\exp(f(r)/r) \\to \\exp(\\sum w_i \\log z_i) = \\text{GM}$."
+      "endLine": 171,
+      "summary": "tendsto_log_sum_div_rpow: the key intermediate limit (log ∑ wᵢzᵢ^r)/r → ∑ wᵢ log zᵢ. Uses hasDerivAt_iff_tendsto_slope to convert the derivative g'(0) into the slope limit g(r)/r → g'(0), exploiting g(0) = 0.",
+      "mathContext": "$\\frac{\\log(\\sum w_i z_i^r)}{r} = \\frac{g(r) - g(0)}{r - 0} \\to g'(0) = \\sum w_i \\log z_i$"
     },
     {
       "id": "supporting-identities",


### PR DESCRIPTION
## Summary
Enrichment pass for 2 gallery entries:

### birthday-problem-oq-03 (k-Way Birthday Coincidences)
- Added 5 new annotations (fiber partition, safe assignment set, probability monotonicity, injective function connection, population bound) — coverage doubled from 5 to 10
- Fixed annotation significance "standard" → "supporting"
- Added `proofRepoPath` to meta.json
- Filled empty `prerequisites` array with 5 concrete items
- Deepened `historicalContext` with Davenport, Flajolet-Gardy-Thimonier (1992) references and cryptographic applications

### amgm-inequality-oq-03-oq-02 (Power Mean Limit: GM)
- Fixed overlapping section ranges (main-limit 143-200 → 143-171, eliminating overlap with supporting-identities 173-214)
- Added missing `assumptions` field

## Test plan
- [x] JSON validates for both entries
- [x] Annotation build passes for both entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)