### PR TITLE
Enrich 2 entries: angle-trisection-oq-02 + oq-02-oq-01 schema conformance

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -61,6 +61,7 @@
     "dateAdded": "2026-03-21",
     "lineCount": 115,
     "axiomCount": 0,
+    "assumptions": "None. All 4 theorems fully proved from Mathlib and OQ-01 with 0 axioms and 0 sorries.",
     "prerequisites": [
       "Galois theory and Galois groups of polynomials",
       "Field extensions and the tower law",


### PR DESCRIPTION
## Summary
Schema conformance pass for 2 angle-trisection sub-entries:

### angle-trisection-oq-02 (Constructible Numbers / Galois Groups)
- Added missing `assumptions` field documenting the 1 axiom (wantzel_galois_characterization)

### angle-trisection-oq-02-oq-01 (Wantzel-Galois from Mathlib)
- Added missing `assumptions` field confirming 0 axioms, 0 sorries

## Test plan
- [x] JSON validates for both entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)