### PR TITLE
Enrich birthday-problem-oq-03: annotation coverage + deeper strategy

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03/annotations.json
@@ -84,6 +84,42 @@
     "prerequisites": ["Finset.one_lt_card", "Function.Injective"]
   },
   {
+    "id": "ann-bpoq03-complement",
+    "proofId": "birthday-problem-oq-03",
+    "range": { "startLine": 150, "endLine": 172 },
+    "type": "theorem",
+    "title": "Complement Characterization: Small Fibers ↔ Injective",
+    "content": "`no_kway_two_iff_injective` proves the complement of the classical recovery: all fibers have $< 2$ elements if and only if $f$ is injective. Forward: if all fibers are singletons or empty, then two people assigned to the same day would create a fiber of size $\\geq 2$, contradicting the hypothesis. Backward: injectivity means each day is assigned to at most one person, so every fiber has $\\leq 1$ element.\n\nThis complement form is essential for the probability framework: the 'safe' set `noKWaySet n d 2` is characterized as the set of injective functions, enabling the classical birthday probability formula $P(\\text{no collision}) = d^{\\underline{n}} / d^n$.",
+    "mathContext": "$(\\forall j,\\; |f^{-1}(j)| < 2) \\iff f \\text{ is injective}$\n\nThis is the complement of `hasKWay_two_iff_not_injective`: $\\neg(\\exists j,\\; |f^{-1}(j)| \\ge 2) \\iff \\neg\\neg\\text{Inj}(f)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["complement", "injectivity", "fiber singleton", "birthday probability"],
+    "prerequisites": ["Finset.one_lt_card", "Function.Injective"]
+  },
+  {
+    "id": "ann-bpoq03-trivial-cases",
+    "proofId": "birthday-problem-oq-03",
+    "range": { "startLine": 203, "endLine": 227 },
+    "type": "insight",
+    "title": "Edge Cases: k=0 and k=1 Validate the Definition",
+    "content": "Two edge cases validate that `HasKWay` is well-defined:\n\n`hasKWay_zero`: A 0-way coincidence is trivially satisfied (when $d > 0$), since every fiber has $\\geq 0$ elements. This confirms the definition handles the degenerate case correctly.\n\n`hasKWay_one_iff`: A 1-way coincidence for *all* assignments $f$ holds iff $n > 0$. Forward: if $n = 0$ then $f = \\text{Fin.elim0}$ and every fiber is empty. Backward: if $n > 0$ then person 0 exists and the fiber at $f(0)$ contains at least person 0. The proof uses `Fin.elim0` to handle the empty type and `Finset.one_le_card` for the existence witness.\n\nThese are 'smoke tests' for the formalization — trivial mathematically but important for catching definition errors.",
+    "mathContext": "$k = 0$: $\\text{HasKWay}(f, 0)$ always holds (for $d > 0$).\n$k = 1$: $(\\forall f,\\; \\text{HasKWay}(f, 1)) \\iff n > 0$.",
+    "significance": "context",
+    "relatedConcepts": ["edge case", "vacuous truth", "Fin.elim0", "well-definedness"],
+    "prerequisites": ["Nat.zero_le", "Finset.one_le_card"]
+  },
+  {
+    "id": "ann-bpoq03-counting-small",
+    "proofId": "birthday-problem-oq-03",
+    "range": { "startLine": 307, "endLine": 332 },
+    "type": "insight",
+    "title": "Counting Verification: Small Population Cases",
+    "content": "Three theorems verify the probability framework against trivially checkable cases:\n\n`noKWaySet_one_person`: With 1 person and any number of days, $\\text{noKWaySet}(1, d, 2) = \\text{univ}$ — no pairwise collision is possible. The proof shows every fiber has $\\leq 1$ element via `Finset.card_le_one` and `Fin.ext`.\n\n`fiberAt_empty`: With 0 people, every fiber is empty (elements of $\\text{Fin}\\,0$ are eliminated by `Fin.elim0`).\n\n`noKWaySet_zero_people`: With 0 people and $k > 0$, $\\text{noKWaySet}(0, d, k) = \\text{univ}$ — all assignments avoid k-way coincidences since all fibers are empty.\n\nThese serve as regression tests: any definition error in `noKWaySet` or `fiberAt` would cause these to fail.",
+    "mathContext": "$n = 1 \\implies P(\\text{2-way}) = 0$ (one person cannot collide with themselves).\n$n = 0 \\implies P(\\text{k-way}) = 0$ for $k > 0$ (no people, no coincidences).",
+    "significance": "context",
+    "relatedConcepts": ["verification", "ground truth", "edge case", "regression test"],
+    "prerequisites": ["Finset.card_le_one", "Fin.elim0"]
+  },
+  {
     "id": "ann-bpoq03-monotonicity",
     "proofId": "birthday-problem-oq-03",
     "range": { "startLine": 184, "endLine": 193 },

--- a/src/data/proofs/birthday-problem-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03/meta.json
@@ -67,13 +67,14 @@
   "overview": {
     "historicalContext": "The birthday problem, first stated by Richard von Mises in *Über Aufteilungs- und Besetzungswahrscheinlichkeiten* (1939), asks how many people are needed for a >50% chance of a shared birthday. The answer — just 23 — is famously counterintuitive and became a staple of probability pedagogy.\n\nThe natural generalization to k-way coincidences asks: when do k people share a birthday? This connects to the classical occupancy problem in combinatorics, studied by Flajolet, Gardy, and Thimonier (1992) using analytic combinatorics, and by Wendl (2003) in the context of DNA sequence assembly. The threshold for a k-way collision scales roughly as $d^{(k-1)/k} \\cdot (k!)^{1/k}$: for $d = 365$ days, $k=2$ needs ~23 people, $k=3$ needs ~88, and $k=4$ needs ~187.\n\nThe generalized pigeonhole principle underlying this formalization was first explicitly formulated by Dirichlet (1834) as the *Schubfachprinzip* (drawer principle). The k-way version — if $n > (k-1)d$ items are placed in $d$ containers, some container holds $\\geq k$ items — is a straightforward extension that appears in virtually every combinatorics textbook. Applications range from hash table collision analysis in computer science to the coupon collector's problem and urn models in probability.",
     "problemStatement": "Formalize k-way birthday coincidences: given n people and d days, prove the generalized pigeonhole bound (n > (k-1)*d implies a k-way coincidence is certain), and show the k=2 case recovers the classical birthday problem.",
-    "proofStrategy": "The proof uses fiber decomposition: each assignment f : Fin n -> Fin d partitions people into fibers by day. The fiber sizes sum to n (partition of unity). The generalized pigeonhole follows by contradiction: if every fiber has < k elements, then n <= (k-1)*d. The classical recovery connects 2-way coincidences to non-injectivity by showing fibers of size >= 2 correspond to collisions.",
+    "proofStrategy": "The proof architecture has three layers. **Layer 1 (Structural foundation)**: Model birthday assignments as functions $f : \\text{Fin}\\,n \\to \\text{Fin}\\,d$ and define fibers $f^{-1}(j)$ via `Finset.filter`. Prove the partition-of-unity identity $\\sum_j |f^{-1}(j)| = n$ using `Finset.card_eq_sum_card_fiberwise`. **Layer 2 (Combinatorial core)**: The generalized pigeonhole follows by contradiction — if every fiber has $< k$ elements then $n \\leq (k-1)d$, contradicting the hypothesis. Classical recovery shows `HasKWay f 2 ↔ ¬Injective f` by extracting distinct witnesses from fibers of size $\\geq 2$ via `Finset.one_lt_card`. Monotonicity is a direct `le_trans`. **Layer 3 (Probabilistic framework)**: Define `noKWaySet` (safe assignments) and `probKWay` via complementary counting. The pigeonhole bound lifts to $P = 1$, the population bound gives $P = 0$, and set containment gives monotonicity in $k$. The $k=2$ case connects to the classical formula by identifying safe assignments with injections.",
     "keyInsights": [
       "The fiber decomposition (using Finset.card_eq_sum_card_fiberwise) is the key structural tool: it converts the global constraint on n into local constraints on each day",
       "The generalized pigeonhole follows from a simple averaging argument: n people in d bins with each bin having < k means n < k*d",
       "The k=2 classical recovery uses Finset.one_lt_card to extract two distinct elements from a fiber, connecting fiber size >= 2 to non-injectivity",
       "Monotonicity in k is immediate: if some day has >= k people, it certainly has >= k' people for k' <= k",
-      "The probability monotonicity follows from set containment: fewer safe assignments for smaller k means higher collision probability"
+      "The probability monotonicity follows from set containment: fewer safe assignments for smaller k means higher collision probability",
+      "The three-regime structure ($P=0$ for $n<k$, $0<P<1$ for $k \\leq n \\leq (k-1)d$, $P=1$ for $n>(k-1)d$) completely brackets the probability and shows the interesting behavior lies in the intermediate regime where the exact computation requires counting bounded-multiplicity functions"
     ],
     "prerequisites": [
       "Finite sets and cardinality (Finset, Finset.card)",
@@ -88,14 +89,14 @@
       "title": "Core Definitions",
       "startLine": 34,
       "endLine": 47,
-      "summary": "Defines fiberAt (the set of people assigned to a day) and HasKWay (some day has at least k people)."
+      "summary": "Defines `fiberAt f j` (the preimage fiber — the set of people assigned to day j) and `HasKWay f k` (existential predicate: some day has ≥ k people). These two definitions drive the entire formalization."
     },
     {
       "id": "fiber-partition",
       "title": "Fiber Partition of Unity",
       "startLine": 49,
       "endLine": 63,
-      "summary": "Proves fiber sizes sum to n using Finset.card_eq_sum_card_fiberwise."
+      "summary": "Proves the partition-of-unity identity: fiber sizes sum to n. Uses `Finset.card_eq_sum_card_fiberwise` — the structural foundation for the generalized pigeonhole argument."
     },
     {
       "id": "pigeonhole",
@@ -151,7 +152,7 @@
       "title": "Population Bounds",
       "startLine": 332,
       "endLine": 366,
-      "summary": "Proves that n < k people cannot have a k-way coincidence, and the probability is 0."
+      "summary": "Proves that n < k people cannot have a k-way coincidence (fiber sizes are bounded by n), and the probability is exactly 0. Together with the pigeonhole regime (P=1), this brackets the probability into three regimes."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added 3 new annotations covering previously unannotated sections: complement characterization (`no_kway_two_iff_injective`), trivial cases (k=0, k=1), and counting verification (0/1 person cases)
- Expanded `proofStrategy` with three-layer architecture description (structural → combinatorial → probabilistic)
- Added 6th keyInsight on the three-regime probability structure (P=0, 0<P<1, P=1)
- Deepened 3 section summaries (definitions, fiber partition, bounds)
- Total annotations: 13 → 16, now covering all major code sections

## Test plan
- [x] JSON validates (`python3 -c "import json; ..."`)
- [x] Annotation build passes with no errors for this entry
- [x] No pre-existing errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)