### PR TITLE
Enrich 7 entries: deep annotation enrichment + schema conformance

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-module-header",
+    "proofId": "cauchy-schwarz-integral-oq-01",
+    "range": { "startLine": 1, "endLine": 68 },
+    "type": "context",
+    "title": "Module Overview: Hölder → Cauchy-Schwarz → Minkowski for Integrals",
+    "content": "This file answers the open question: 'Is Cauchy-Schwarz for integrals a special case of Hölder's inequality?' The answer is YES — the Cauchy-Schwarz integral inequality $\\int fg \\leq \\|f\\|_{L^2}\\|g\\|_{L^2}$ is exactly Hölder with $p = q = 2$.\n\nThe file builds a complete chain:\n1. **Young's AM-GM** (pointwise): $2ab \\leq a^2 + b^2$ via $(a-b)^2 \\geq 0$\n2. **Hölder for lintegral** (ENNReal): wrapping `lintegral_mul_le_Lp_mul_Lq`\n3. **The (2,2) conjugate pair**: proving `HolderConjugate 2 2` (the $1/2 + 1/2 = 1$ verification)\n4. **Cauchy-Schwarz from Hölder**: specializing to $p = q = 2$\n5. **Hölder for real-valued functions**: via nnnorm multiplicativity\n6. **Minkowski's inequality**: $\\|f+g\\|_{L^2} \\leq \\|f\\|_{L^2} + \\|g\\|_{L^2}$ as the norm triangle inequality\n\nImports include `MeasureTheory.Function.LpSpace` and `MeasureTheory.Integral.MeanInequalities` for the $L^p$ space infrastructure.",
+    "mathContext": "Proof chain: Young ($2ab \\leq a^2+b^2$) $\\to$ Hölder ($\\int fg \\leq \\|f\\|_p\\|g\\|_q$) $\\to$ CS at $p=q=2$ $\\to$ Minkowski ($\\|f+g\\|_2 \\leq \\|f\\|_2 + \\|g\\|_2$)",
+    "significance": "context",
+    "relatedConcepts": ["measure theory", "L^p spaces", "Hölder's inequality", "integral Cauchy-Schwarz"],
+    "prerequisites": ["MeasureTheory", "ENNReal", "NNReal", "lintegral"]
+  },
+  {
     "id": "ann-young-nnreal",
     "proofId": "cauchy-schwarz-integral-oq-01",
     "range": {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01/meta.json
@@ -66,7 +66,12 @@
       "**Nnnorm Multiplicativity**: For real numbers, `nnnorm_mul : ‖x·y‖₊ = ‖x‖₊·‖y‖₊` (not `Real.nnnorm_mul`) gives the equality needed to pass from pointwise products to Hölder.",
       "**Minkowski from Norm**: Since `Lp ℝ p μ` is a `NormedAddCommGroup`, Minkowski's inequality is just the abstract norm triangle inequality `norm_add_le`."
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Measure theory: measurable functions, Lebesgue integration (lintegral)",
+      "L^p spaces: Lp E p μ as Banach spaces with the snorm",
+      "Non-negative extended reals (ENNReal) and non-negative reals (NNReal)",
+      "Hölder conjugate exponents: 1/p + 1/q = 1 with p, q > 1"
+    ]
   },
   "sections": [
     {


### PR DESCRIPTION
## Summary

### bezout-identity-oq-03-oq-01-oq-01-oq-01 (Ideal-theoretic CRT)
- Annotations: 5 → 9. Added module header, product CRT, CRT uniqueness, summary

### cayley-hamilton-minpoly-oq-02-oq-01-oq-01 (Skolem-Noether)
- Annotations: 5 → 9. Rewrote all, fixed incorrect "axiomatized" annotation

### cauchy-schwarz-oq-03 (Hölder's Inequality)
- Annotations: 6 → 11. Added module header, Young's, CS-from-Hölder, inner product CS, summary

### cauchy-schwarz-oq-01 (Complex Cauchy-Schwarz)
- Annotations: 6 → 10. Added module overview, real CS, self-inner product, triangle inequality

### binomial-theorem-oq-01-oq-01 (Newton's Generalized Binomial)
- Annotations: 6 → 9. Added genBinom definition, ratio/negation, summary

**All entries with empty prerequisites**: filled in

## Test plan
- [x] JSON validates for all entries
- [x] Annotation build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)