### PR TITLE
Enrich abel-ruffini-oq-04: add assumptions field

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -21,6 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
+    "assumptions": "None. All 8 theorems fully proved from Mathlib with 0 axioms and 0 sorries. No structure-encoded assumptions.",
     "wiedijkNumber": 83,
     "dateAdded": "2026-03-22",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary
- Added `assumptions` field to meta.json documenting verified status (0 axioms, 0 sorries, no structure-encoded assumptions)
- Aligns with axiom integrity policy — 42 other entries already have this field

## Verification
- Lean file confirmed: 0 axiom declarations, 0 sorries, no assumption-carrying structures
- JSON validated via `pnpm annotations:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)