### PR TITLE
fix: convert implications arrays to strings for TypeScript compatibility

### DIFF
--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -238,12 +238,7 @@
   ],
   "conclusion": {
     "summary": "The threshold function g_d(n) captures how many points in ℝ^d guarantee n distinct distances. The cube construction shows g_d(d+1) > 2^d, while Erdős proved g_d(n) ≫ d^{n-1}. The Erdős-Straus upper bound g_d(n) ≤ c^{d^{1-b_n}} leaves a vast gap between polynomial and stretched-exponential growth. Whether g_d(n)/d^{n-1} converges as d → ∞ remains the central open question.",
-    "implications": [
-      "Connects to the famous planar distinct distances problem (Guth-Katz 2015) by studying how distance structure changes with dimension rather than with point count",
-      "Probes the fundamental geometry of high-dimensional Euclidean space: whether distance configurations stabilize as dimension grows",
-      "The polynomial-vs-stretched-exponential gap in g_d(n) bounds reflects a deep open question about whether high-dimensional distance structure is polynomial or super-polynomial in nature",
-      "Resolution would inform extremal combinatorial geometry, coding theory (distance codes), and the theory of finite metric spaces"
-    ],
+    "implications": "Connects to the famous planar distinct distances problem (Guth-Katz 2015) by studying how distance structure changes with dimension rather than with point count. Probes the fundamental geometry of high-dimensional Euclidean space: whether distance configurations stabilize as dimension grows. The polynomial-vs-stretched-exponential gap in g_d(n) bounds reflects a deep open question about whether high-dimensional distance structure is polynomial or super-polynomial in nature. Resolution would inform extremal combinatorial geometry, coding theory (distance codes), and the theory of finite metric spaces",
     "openQuestions": [
       "Does lim_{d→∞} g_d(n)/d^{n-1} exist for each fixed n ≥ 2?",
       "What is the true growth rate of g_d(n): closer to d^{n-1} or to the stretched exponential?",

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -143,12 +143,7 @@
   ],
   "conclusion": {
     "summary": "Formalizes Erdős Problem #1097 on common differences in 3-term APs, developing 14 proven infrastructure lemmas alongside axiomatized research bounds. Captures the O(n^{3/2}) conjecture, four lower bounds (Erdős-Spencer, Erdős-Ruzsa, Lemm, AlphaEvolve), the Katz-Tao upper bound, and the deep connection to Bourgain's sums-differences problem via Chan's equivalence.",
-    "implications": [
-      "Progress on this problem would directly impact the Kakeya conjecture through Bourgain's arithmetic approach and Chan's equivalence theorem",
-      "The 14 proven infrastructure lemmas (translation invariance, dilation covariance, symmetry) provide a reusable foundation for future Lean-based work in additive combinatorics",
-      "The gap between n^{1.778} and n^{11/6} remains one of the central open problems connecting discrete combinatorics to harmonic analysis and geometric measure theory",
-      "AI-assisted methods (AlphaEvolve) achieving marginal improvements suggests this problem is amenable to computational search, potentially yielding further bounds"
-    ],
+    "implications": "Progress on this problem would directly impact the Kakeya conjecture through Bourgain's arithmetic approach and Chan's equivalence theorem. The 14 proven infrastructure lemmas (translation invariance, dilation covariance, symmetry) provide a reusable foundation for future Lean-based work in additive combinatorics. The gap between n^{1.778} and n^{11/6} remains one of the central open problems connecting discrete combinatorics to harmonic analysis and geometric measure theory. AI-assisted methods (AlphaEvolve) achieving marginal improvements suggests this problem is amenable to computational search, potentially yielding further bounds",
     "openQuestions": [
       "Is the true exponent 3/2 as Erdős conjectured, or is Lemm's n^{1.778} closer to the truth?",
       "Can the Katz-Tao 11/6 upper bound be improved using recent decoupling techniques?",

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -179,12 +179,7 @@
   },
   "conclusion": {
     "summary": "The minimum overlap problem asks for the exact asymptotic constant $c = \\lim M(N)/N$ where $M(N)$ is the minimum maximum overlap in equal partitions of $\\{1,\\ldots,2N\\}$. The constant is pinned between $0.379005$ (White 2022, via Fourier/convex optimization) and $0.380876$ (TTT-Discover 2026, via step-function constructions). The gap of less than $0.002$ is remarkably tight, yet the exact value of $c$ remains unknown.",
-    "implications": [
-      "Determining c would resolve a fundamental question in additive combinatorics about unavoidable structure in equal partitions of consecutive integers",
-      "The Fourier-analytic framework (reducing combinatorial optimization to SDP) has broader applications to discrepancy theory, sumset problems, and representation function asymptotics",
-      "AI optimization successfully improved the upper bound (TTT-Discover 2026), suggesting computational approaches may eventually close the gap entirely",
-      "The connection between partition overlap and autocorrelation provides a template for attacking similar minimax problems in additive combinatorics"
-    ],
+    "implications": "Determining c would resolve a fundamental question in additive combinatorics about unavoidable structure in equal partitions of consecutive integers. The Fourier-analytic framework (reducing combinatorial optimization to SDP) has broader applications to discrepancy theory, sumset problems, and representation function asymptotics. AI optimization successfully improved the upper bound (TTT-Discover 2026), suggesting computational approaches may eventually close the gap entirely. The connection between partition overlap and autocorrelation provides a template for attacking similar minimax problems in additive combinatorics",
     "openQuestions": [
       "What is the exact value of c = lim M(N)/N? Is it algebraic, transcendental, or even rational?",
       "Can the gap between 0.379005 and 0.380876 be further narrowed by refined Fourier methods or better constructions?",

--- a/src/data/proofs/erdos-4/meta.json
+++ b/src/data/proofs/erdos-4/meta.json
@@ -239,13 +239,7 @@
   },
   "conclusion": {
     "summary": "Erdős Problem #4 is SOLVED: for any $C > 0$, infinitely many prime gaps exceed $C$ times the Erdős function. Proved independently by Maynard and Ford-Green-Konyagin-Tao in 2016, with an improved bound by all five authors in 2018. This resolved a 75-year-old question about the growth rate of maximal prime gaps.",
-    "implications": [
-      "Prime gaps can far exceed the average gap of log n, with Rankin's amplification factor growing without bound — answering a question open since the 1930s",
-      "Maynard's multidimensional sieve techniques became fundamental tools in analytic number theory, leading to his Fields Medal-winning work on bounded gaps (p_{n+1} - p_n ≤ 246 infinitely often)",
-      "The FGKT probabilistic hypergraph covering approach bridges combinatorics and analytic number theory, with applications to additive combinatorics and Ramsey theory",
-      "Under the Riemann Hypothesis, the maximum gap below x is O(√x log x), far below the unconditional (log x)² prediction — the gap between conditional and unconditional results remains a central mystery",
-      "The $10,000 prize for gaps exceeding (log n)^{1+c} remains open and would require fundamentally new ideas beyond current sieve methods"
-    ],
+    "implications": "Prime gaps can far exceed the average gap of log n, with Rankin's amplification factor growing without bound — answering a question open since the 1930s. Maynard's multidimensional sieve techniques became fundamental tools in analytic number theory, leading to his Fields Medal-winning work on bounded gaps (p_{n+1} - p_n ≤ 246 infinitely often). The FGKT probabilistic hypergraph covering approach bridges combinatorics and analytic number theory, with applications to additive combinatorics and Ramsey theory. Under the Riemann Hypothesis, the maximum gap below x is O(√x log x), far below the unconditional (log x)² prediction — the gap between conditional and unconditional results remains a central mystery. The $10,000 prize for gaps exceeding (log n)^{1+c} remains open and would require fundamentally new ideas beyond current sieve methods",
     "openQuestions": [
       "Erdős's $10,000 conjecture: Does p_{n+1} - p_n > (log n)^{1+c} hold for some c > 0 and infinitely many n?",
       "Cramér's conjecture: Is p_{n+1} - p_n = O((log p_n)²)?",

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -179,12 +179,7 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #414 remains OPEN. The conjecture that all orbits of h(n) = n + τ(n) eventually merge is supported by overwhelming computational evidence and plausible heuristics, but no proof exists. The difficulty is fundamentally about controlling the cumulative irregularity of the divisor function along different trajectories to guarantee an exact collision.",
-    "implications": [
-      "A resolution would advance the theory of arithmetic dynamics — understanding when simple number-theoretic iterations have universal limiting behavior",
-      "The problem connects divisor function regularity (Dirichlet divisor problem), additive combinatorics (collision conditions), and discrete dynamical systems (orbit coalescence)",
-      "Techniques developed for this problem could apply to the broader family of 'n + f(n)' iterations for multiplicative arithmetic functions f",
-      "The collision mechanism h(a) = h(b) when τ(a) - τ(b) = b - a connects to the distribution of values of τ, a classical topic in multiplicative number theory"
-    ],
+    "implications": "A resolution would advance the theory of arithmetic dynamics — understanding when simple number-theoretic iterations have universal limiting behavior. The problem connects divisor function regularity (Dirichlet divisor problem), additive combinatorics (collision conditions), and discrete dynamical systems (orbit coalescence). Techniques developed for this problem could apply to the broader family of 'n + f(n)' iterations for multiplicative arithmetic functions f. The collision mechanism h(a) = h(b) when τ(a) - τ(b) = b - a connects to the distribution of values of τ, a classical topic in multiplicative number theory",
     "openQuestions": [
       "Does the merging conjecture hold? Can any pair of orbits be shown to collide?",
       "Even weaker: can orbits be shown to get arbitrarily close (|h^i(m) − h^j(n)| < D for any D)?",


### PR DESCRIPTION
## Summary
- Five gallery entries had `conclusion.implications` as `string[]` instead of the expected `string` type
- This caused TypeScript build failures blocking deployment
- Converted all array values to joined strings

## Affected entries
- erdos-1089, erdos-1097, erdos-36, erdos-4, erdos-414

## Test plan
- [x] Verify build passes after fix

Co-Authored-By: Claude <noreply@anthropic.com>