### PR TITLE
Research: roth-theorem-k3 - prove Roth's theorem (roth_density_bound) via Mathlib bridge

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -1256,17 +1256,64 @@ private theorem gvInvolution_membership {r : ℕ} (cfg : LGVConfig r)
     have h_cj := cfg.source_le_target cj
     rcases h_final with h | h <;> omega
 
+-- ============================================================
+-- PART 7i: Prefix Lemma for Self-Inverse Proof
+-- ============================================================
+
+/-- northBeforeEast depends only on the prefix when the prefix contains > k East steps.
+    Key lemma for the GV tail-swap involution: swapping suffixes after a crossing
+    point doesn't change colEntry at earlier columns. -/
+private lemma northBeforeEast_prefix (pfx sfx₁ sfx₂ : LPath) (k : ℕ)
+    (hk : pfx.countP (· = false) > k) :
+    northBeforeEast (pfx ++ sfx₁) k = northBeforeEast (pfx ++ sfx₂) k := by
+  induction pfx generalizing k with
+  | nil => simp [List.countP] at hk
+  | cons b xs ih =>
+    cases b with
+    | false =>
+      cases k with
+      | zero => simp [northBeforeEast]
+      | succ k' =>
+        simp only [List.cons_append, northBeforeEast]
+        apply ih k'
+        simp only [List.countP_cons] at hk ⊢; omega
+    | true =>
+      simp only [List.cons_append, northBeforeEast]
+      have := ih k (by simp only [List.countP_cons] at hk ⊢; omega)
+      omega
+
+/-- colEntry at column k+1 depends only on the prefix when it has > k East steps. -/
+private lemma colEntry_prefix_eq (pfx sfx₁ sfx₂ : LPath) (k : ℕ)
+    (hk : pfx.countP (· = false) > k) :
+    colEntry (pfx ++ sfx₁) (k + 1) = colEntry (pfx ++ sfx₂) (k + 1) := by
+  exact northBeforeEast_prefix pfx sfx₁ sfx₂ k hk
+
 /-- The signed sum over cancellable (non-NI) tagged tuples is zero,
     by the GV sign-reversing involution.
-    This is the combinatorial engine of the LGV lemma. -/
+
+    **Proof structure** (via `Finset.sum_involution`):
+    The GV involution maps (σ, P) ↦ (σ * swap(ci,cj), P') where:
+    - (ci, cj) is the canonical first crossing pair (determined by the paths)
+    - P' tail-swaps paths ci, cj at their first shared lattice point
+    - Other paths are unchanged
+
+    Self-inverse follows from:
+    (1) σ * swap(ci,cj) * swap(ci,cj) = σ
+    (2) Double tail-swap = identity (List.take_append_drop)
+    (3) Canonical crossing preserved: `northBeforeEast_prefix` ensures colEntry
+        values at columns ≤ crossing column are unchanged by the tail swap.
+        New shared points from expanded ranges are all above y₀ (the canonical
+        shared row), so the lex-min (column, row, pair) datum is preserved.
+
+    Infrastructure proved: sign reversal (gvInvolution_sign_reversal),
+    no fixed points (gvInvolution_no_fixed), membership (gvInvolution_membership),
+    prefix lemma (northBeforeEast_prefix). The tail-swap construction requires
+    PathMN validity (from take_east_count_within_column + swapTailsAt) and
+    canonical crossing pair (from Finset.min' on overlapping pairs). -/
 private theorem cancellable_sum_eq_zero {r : ℕ} (cfg : LGVConfig r)
     (hwf : cfg.wellFormed) :
     (Finset.sum (Finset.univ.filter
       (fun t : TaggedPathTuple cfg => ¬isNonCancellable t)) taggedWeight) = 0 := by
-  -- Use Finset.sum_involution. The GV involution function g maps
-  -- (σ, paths) ↦ (σ * swap(i,j), northThenEast_paths).
-  -- Properties: (1) sign cancel, (2) no fixed pts, (3) membership, (4) self-inverse.
-  -- (1)-(3) are proved; (4) requires tail-swap construction (HARD sorry).
   sorry
 
 theorem gv_involution_cancellation {r : ℕ} (cfg : LGVConfig r)

--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -53,7 +53,7 @@ cancel via a sign-reversing involution (Gessel-Viennot involution).
 - [x] northThenEast_not_NI: these paths cross at column 0 under wellFormed (PROVED)
 - [x] gvInvolutionFn: uses northThenEast paths (well-typed, compiles)
 - [x] gvInvolution_sign_reversal + no_fixed: proved for northThenEast variant
-- [ ] Membership: image cancellable (sorry — needs toPathTuple cast unfolding)
+- [x] Membership: image cancellable (PROVED — cast_pathMN_val + northThenEast_not_NI)
 - [ ] Self-inverse: g(g(a)) = a (sorry — needs full tail-swap path construction)
 
 ## References
@@ -1088,6 +1088,12 @@ private lemma northThenEastList_east (m n : ℕ) :
 private def northThenEastPath (m n : ℕ) : PathMN m n :=
   ⟨northThenEastList m n, northThenEastList_length m n, northThenEastList_east m n⟩
 
+/-- Cast between PathMN types with equal n preserves the underlying list. -/
+private lemma cast_pathMN_val {m n₁ n₂ : ℕ} (hn : n₁ = n₂)
+    (p : PathMN m n₁) {heq : PathMN m n₁ = PathMN m n₂} :
+    (cast heq p).val = p.val := by
+  subst hn; rfl
+
 /-- colEntry of northThenEastList at column 0: the path has n North steps before any East step. -/
 private lemma northThenEast_colEntry_one (m n : ℕ) (hm : 0 < m) :
     colEntry (northThenEastList m n) 1 = n := by
@@ -1200,27 +1206,55 @@ private theorem gvInvolution_membership {r : ℕ} (cfg : LGVConfig r)
     (hwf : cfg.wellFormed) (t : TaggedPathTuple cfg)
     (ht : ¬isNonCancellable t) :
     ¬isNonCancellable (gvInvolutionFn cfg hwf t ht) := by
-  simp only [isNonCancellable, IsGVFixedPoint]
-  intro ⟨hσ, hni⟩
-  have hij := crossingI_lt_J cfg hwf t ht
-  set i := crossingI cfg hwf t ht with hi_def
-  set j := crossingJ cfg hwf t ht with hj_def
+  simp only [isNonCancellable, IsGVFixedPoint, not_exists]
+  intro hσ hni
   simp only [IsNonIntersecting] at hni
-  -- Specialize NI to pair (i, j) with i < j
-  have hpair := hni i j hij
-  -- The image has σ' = 1 (by hσ) and northThenEast paths
-  -- toPathTuple with σ' = 1 gives paths from sources(k) to targets(k)
-  -- These are northThenEastPath m (targets(k) - sources(k))
-  -- By wellFormed: sources(i) ≤ targets(j) and sources(j) ≤ targets(i)
-  -- So northThenEast paths at i and j cross
-  -- We need to show the hpair leads to contradiction
-  -- The NonIntersecting of northThenEast paths is ¬ for overlapping sources/targets
-  -- Membership proof requires careful unfolding of PermPathTuple.toPathTuple + cast
-  -- across the σ' = 1 specialization and the northThenEastPath definition.
-  -- This is a HARD sorry (engineering, not math) — the mathematical argument is:
-  -- paths i and j are northThenEast, they overlap at column 0 by wellFormed,
-  -- contradicting NonIntersecting.
-  sorry
+  have hij := crossingI_lt_J cfg hwf t ht
+  set ci := crossingI cfg hwf t ht
+  set cj := crossingJ cfg hwf t ht
+  have hpair := hni ci cj hij
+  -- gvNewPerm = 1 from hσ
+  have hperm_eq : gvNewPerm cfg hwf t ht = 1 := hσ
+  -- The n parameters of the paths match after substitution
+  have hn_eq : ∀ k : Fin r, cfg.targets ((gvNewPerm cfg hwf t ht) k) - cfg.sources k =
+      cfg.targets k - cfg.sources k := by
+    intro k; congr 1; simp [hperm_eq]
+  -- Show that the underlying lists in the toPathTuple are northThenEastList
+  -- toPathTuple applies cast, gvInvolutionFn gives northThenEastPath
+  have hval : ∀ k : Fin r,
+      ((gvInvolutionFn cfg hwf t ht).snd.toPathTuple hσ k).val =
+      northThenEastList cfg.m (cfg.targets k - cfg.sources k) := by
+    intro k
+    unfold PermPathTuple.toPathTuple
+    simp only [gvInvolutionFn]
+    rw [cast_pathMN_val (hn_eq k)]
+    simp only [northThenEastPath]
+    congr 1; exact hn_eq k
+  -- Rewrite hpair using hval
+  rw [hval ci, hval cj] at hpair
+  -- wellFormed gives overlap conditions
+  have hwf_ij : cfg.sources ci ≤ cfg.targets cj := hwf ci cj
+  have hwf_ji : cfg.sources cj ≤ cfg.targets ci := hwf cj ci
+  -- Case split on m > 0
+  have h_ci := cfg.source_le_target ci
+  have h_cj := cfg.source_le_target cj
+  by_cases hm : 0 < cfg.m
+  · -- northThenEast_not_NI needs: y₁ ≤ y₂ + n₂ and y₂ ≤ y₁ + n₁
+    -- where y₁ = sources ci, n₁ = targets ci - sources ci, etc.
+    -- sources(ci) + (targets(ci) - sources(ci)) = targets(ci) since sources ≤ targets
+    have hy₁n₂ : cfg.sources ci ≤ cfg.sources cj + (cfg.targets cj - cfg.sources cj) := by omega
+    have hy₂n₁ : cfg.sources cj ≤ cfg.sources ci + (cfg.targets ci - cfg.sources ci) := by omega
+    exact northThenEast_not_NI hm hy₁n₂ hy₂n₁ hpair
+  · -- m = 0 case: NonIntersecting final condition contradicts wellFormed
+    push_neg at hm
+    simp only [NonIntersecting] at hpair
+    obtain ⟨_, h_final⟩ := hpair
+    have hm0 : cfg.m = 0 := by omega
+    rw [hm0] at h_final
+    simp only [colEntry] at h_final
+    have h_ci := cfg.source_le_target ci
+    have h_cj := cfg.source_le_target cj
+    rcases h_final with h | h <;> omega
 
 /-- The signed sum over cancellable (non-NI) tagged tuples is zero,
     by the GV sign-reversing involution.

--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -1293,23 +1293,36 @@ private lemma colEntry_prefix_eq (pfx sfx₁ sfx₂ : LPath) (k : ℕ)
 
     **Proof structure** (via `Finset.sum_involution`):
     The GV involution maps (σ, P) ↦ (σ * swap(ci,cj), P') where:
-    - (ci, cj) is the canonical first crossing pair (determined by the paths)
+    - (ci, cj) is the canonical first crossing pair
     - P' tail-swaps paths ci, cj at their first shared lattice point
     - Other paths are unchanged
 
-    Self-inverse follows from:
-    (1) σ * swap(ci,cj) * swap(ci,cj) = σ
-    (2) Double tail-swap = identity (List.take_append_drop)
-    (3) Canonical crossing preserved: `northBeforeEast_prefix` ensures colEntry
-        values at columns ≤ crossing column are unchanged by the tail swap.
-        New shared points from expanded ranges are all above y₀ (the canonical
-        shared row), so the lex-min (column, row, pair) datum is preserved.
+    **Required components** (all proved except self-inverse):
+    1. Sign reversal: sign(σ * swap) = -sign(σ) [proved: gvInvolution_sign_reversal]
+    2. No fixed points: σ * swap(i,j) ≠ σ when i < j [proved: gvInvolution_no_fixed]
+    3. Membership: g(t) is cancellable [proved: gvInvolution_membership]
+    4. Self-inverse: g(g(t)) = t — THE KEY REMAINING CHALLENGE
 
-    Infrastructure proved: sign reversal (gvInvolution_sign_reversal),
-    no fixed points (gvInvolution_no_fixed), membership (gvInvolution_membership),
-    prefix lemma (northBeforeEast_prefix). The tail-swap construction requires
-    PathMN validity (from take_east_count_within_column + swapTailsAt) and
-    canonical crossing pair (from Finset.min' on overlapping pairs). -/
+    **Self-inverse proof strategy**:
+    - Permutation part: σ * swap(ci,cj) * swap(ci,cj) = σ (trivial from swap²=1)
+    - Path part: double tail-swap at the same point = identity (List.take_append_drop)
+    - Canonical crossing preserved: use (c, y, i, j) lex ordering where
+      c = crossing column, y = max(lower bounds). After tail-swap:
+      (a) At (c', y') < (c₀, y₀) lex: path prefixes unchanged → same crossings
+      (b) At (c₀, y₀): both paths still share this point (prefix preserved)
+      (c) No pair (i', j') < (i₀, j₀) newly shares (c₀, y₀) [proved by minimality]
+      → canonical crossing = same (c₀, y₀, i₀, j₀) for g(t) and t
+
+    **Implementation note**: The current gvInvolutionFn uses northThenEastPath
+    (which is NOT self-inverse). The correct implementation requires constructing
+    PathMN from tail-swap (take(P_i, k_i) ++ drop(P_j, k_j)) with validity proofs
+    for length and East count. Infrastructure: take_east_count_within_column,
+    swapTailsAt, northBeforeEast_prefix. Estimated: ~150 lines of new code.
+
+    **Critical discovery**: cancellable σ=1 tuples CAN have crossings only at the
+    final column (not at any c < m). The canonical crossing must handle both
+    interior (c < m) and final (c = m) columns. The tail-swap works for both:
+    at c = m, the suffix is pure North steps. -/
 private theorem cancellable_sum_eq_zero {r : ℕ} (cfg : LGVConfig r)
     (hwf : cfg.wellFormed) :
     (Finset.sum (Finset.univ.filter

--- a/proofs/Proofs/Erdos738Problem.lean
+++ b/proofs/Proofs/Erdos738Problem.lean
@@ -126,13 +126,21 @@ axiom kierstead_penrice_radius2 :
 
 /- ## Structural Observations -/
 
-/-- Triangle-free with large chromatic number implies large girth
-    neighborhoods: the local structure is tree-like. -/
-axiom triangle_free_large_chrom_local_tree :
+/-- Triangle-free with large chromatic number implies the conclusion holds
+    for any vertex: since G has infinite chromatic number, ¬ChromAtMost k
+    is immediate for all k, making the neighbor condition vacuous. -/
+theorem triangle_free_large_chrom_local_tree :
   ∀ {V : Type*} (G : SimpleGraph V),
     G.IsTriangleFree → G.HasInfiniteChrom →
       ∀ k : ℕ, ∃ v : V, ∀ w : V, G.Adj v w →
-        ¬G.ChromAtMost k
+        ¬G.ChromAtMost k := by
+  intro V G _ hinf k
+  -- G has infinite chromatic number, so it's not 1-colorable, hence V is nonempty
+  have hne : Nonempty V := by
+    by_contra h
+    rw [not_nonempty_iff] at h
+    exact hinf 1 ⟨⟨fun v => h.elim v, fun {v} => h.elim v⟩⟩
+  exact ⟨hne.some, fun _ _ => hinf k⟩
 
 /-- The conjecture generalizes: for any forest F, does every triangle-free
     graph with χ(G) ≥ f(|F|) contain F as an induced subgraph? -/

--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -533,6 +533,64 @@ theorem triple_count_fourier {N : ℕ} [NeZero N] (A : Finset (ZMod N)) :
 -- PART IV: LARGE FOURIER COEFFICIENT FROM AP-FREENESS
 -- ═══════════════════════════════════════════════════════════════════
 
+/-- An AP-free subset of ZMod N has strictly fewer than N elements when N ≥ 2.
+    The full set always contains the 3-AP {0, 1, 2·1}. -/
+theorem apFree_card_lt {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N)) (hAP : APFree A) :
+    A.card < N := by
+  haveI : NeZero N := ⟨by omega⟩
+  by_contra h; push_neg at h
+  have hfull : A = Finset.univ :=
+    Finset.eq_univ_of_card A (by have := card_le_nat A; simp only [ZMod.card]; omega)
+  haveI : Fact (1 < N) := ⟨hN⟩
+  exact hAP 0 1 one_ne_zero (hfull ▸ Finset.mem_univ _) (hfull ▸ Finset.mem_univ _)
+    (hfull ▸ Finset.mem_univ _)
+
+/-- In ZMod N, there is at most one nonzero element r with 2*r = 0.
+    Both a and b have additive order 2. In the cyclic group ZMod N, there is at most
+    one subgroup of order 2, so ⟨a⟩ = ⟨b⟩ and a = b. -/
+private lemma two_mul_eq_zero_unique {N : ℕ} [NeZero N]
+    (a b : ZMod N) (ha : a ≠ 0) (h2a : 2 * a = 0)
+    (hb : b ≠ 0) (h2b : 2 * b = 0) : a = b := by
+  -- Reduce to val(a) = val(b) via ZMod.val arithmetic
+  -- In ZMod N (= Fin N for N > 0), 2*a = 0 means (val a + val a) % N = 0
+  -- Since 0 < val a < N, this forces val a + val a = N, i.e., val a = N/2
+  -- Similarly val b = N/2, so a = b
+  have haa : a + a = 0 := by linear_combination h2a
+  have hbb : b + b = 0 := by linear_combination h2b
+  -- val(a + a) = (val a + val a) % N = 0
+  have hmod_a : (ZMod.val a + ZMod.val a) % N = 0 := by
+    have h := congr_arg ZMod.val haa; rw [ZMod.val_add, ZMod.val_zero] at h; exact h
+  have hmod_b : (ZMod.val b + ZMod.val b) % N = 0 := by
+    have h := congr_arg ZMod.val hbb; rw [ZMod.val_add, ZMod.val_zero] at h; exact h
+  -- N ∣ 2 * val a, and 0 < 2 * val a < 2N, so 2 * val a = N
+  have hva_pos : 0 < ZMod.val a := by
+    rw [Nat.pos_iff_ne_zero]; intro h; exact ha (by rwa [ZMod.val_eq_zero] at h)
+  have hvb_pos : 0 < ZMod.val b := by
+    rw [Nat.pos_iff_ne_zero]; intro h; exact hb (by rwa [ZMod.val_eq_zero] at h)
+  have hva_lt : ZMod.val a < N := ZMod.val_lt a
+  have hvb_lt : ZMod.val b < N := ZMod.val_lt b
+  -- Helper: if N ∣ s and 0 < s < 2N, then s = N
+  have dvd_range_eq : ∀ {s : ℕ}, N ∣ s → 0 < s → s < 2 * N → s = N := by
+    intro s hdvs hlo hhi
+    obtain ⟨k, hk⟩ := hdvs  -- s = N * k
+    subst hk
+    -- k = 0: N*0 = 0, contradicts 0 < s
+    -- k = 1: N*1 = N ✓
+    -- k ≥ 2: N*k ≥ 2N, contradicts s < 2N
+    rcases k with _ | _ | k
+    · omega
+    · omega
+    · exfalso
+      have h1 : N * 2 ≤ N * (k + 2) := Nat.mul_le_mul_left N (by omega)
+      linarith
+  have h2va : ZMod.val a + ZMod.val a = N :=
+    dvd_range_eq (Nat.dvd_of_mod_eq_zero hmod_a) (by omega) (by omega)
+  have h2vb : ZMod.val b + ZMod.val b = N :=
+    dvd_range_eq (Nat.dvd_of_mod_eq_zero hmod_b) (by omega) (by omega)
+  -- val a = val b (both = N/2), hence a = b
+  have hval_eq : ZMod.val a = ZMod.val b := by omega
+  exact ZMod.val_injective N hval_eq
+
 /-- Fourier coefficient at 0 equals the cardinality: Â(0) = |A|. -/
 theorem fourierCoeff_zero {N : ℕ} [NeZero N] (A : Finset (ZMod N)) :
     fourierCoeff A 0 = ↑A.card := by
@@ -583,7 +641,8 @@ theorem fourier_parseval_pigeonhole {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N))
   -- hall : ∀ r ≠ 0, ‖Â(r)‖² * (↑N - 1) < ↑A.card * (↑N - ↑A.card)
   -- Sum the multiplicative form: ∑ [f(r) * (N-1)] < |S| * C
   have hN1_pos : (0 : ℝ) < (↑N : ℝ) - 1 := by
-    have : (1 : ℝ) < ↑N := Nat.one_lt_cast.mpr hN; linarith
+    have : (1 : ℝ) < ↑N := by exact_mod_cast hN
+    linarith
   -- Each f(r) * (N-1) < C
   have hlt_mul : ∀ r ∈ S, ‖fourierCoeff A r‖ ^ 2 * (↑N - 1) <
       (A.card : ℝ) * (↑N - ↑A.card) :=
@@ -607,18 +666,175 @@ theorem fourier_parseval_pigeonhole {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N))
     nlinarith [hsum_bound]
   linarith [hpnz]
 
+set_option maxHeartbeats 800000 in
 /-- If A has no 3-AP and has density delta, then some Fourier coefficient
     is large. This is the key analytic step in Roth's proof.
 
     The bound δ²N/2 follows from the AP-free Fourier identity combined with
-    Parseval. When δ²N ≤ 1 (sparse regime), Parseval pigeonhole suffices.
-    When δ²N > 1 (dense regime), the Cauchy-Schwarz argument on the
-    Fourier identity ∑_{r≠0} Â(r)²conj(Â(2r)) = N|A| - |A|³ gives the bound. -/
-theorem fourier_large_coefficient {N : ℕ} (hN : 0 < N) (A : Finset (ZMod N))
+    Parseval. When δ²N ≤ 2 (sparse regime), Parseval pigeonhole gives
+    ‖Â(r)‖ ≥ 1 ≥ δ²N/2. When δ²N > 2 (dense regime), the Fourier identity
+    ∑_{r≠0} Â(r)²conj(Â(2r)) = N|A| - |A|³ combined with term-by-term bounds
+    gives δ²N ≤ 2, a contradiction. -/
+theorem fourier_large_coefficient {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N))
     (hAP : APFree A) (delta : ℝ) (hdelta : 0 < delta)
     (hdensity : (A.card : ℝ) ≥ delta * N) :
     ∃ r : ZMod N, r ≠ 0 ∧ ‖fourierCoeff A r‖ ≥ delta ^ 2 * N / 2 := by
-  sorry
+  haveI : NeZero N := ⟨by omega⟩
+  set n := A.card with hn_def
+  have hNpos : (0 : ℝ) < ↑N := Nat.cast_pos.mpr (by omega)
+  have hn_pos : 0 < n := by
+    rw [Nat.pos_iff_ne_zero]; intro h; rw [h] at hdensity; simp at hdensity; nlinarith
+  have hAne : A.Nonempty := Finset.card_pos.mp hn_pos
+  have hn_lt : n < N := apFree_card_lt hN A hAP
+  by_cases hcase : delta ^ 2 * ↑N ≤ 2
+  · -- CASE 1: δ²N ≤ 2, so δ²N/2 ≤ 1. Parseval pigeonhole gives ‖Â(r)‖ ≥ 1 ≥ δ²N/2.
+    obtain ⟨r, hr, hpig⟩ := fourier_parseval_pigeonhole hN A hAne
+    refine ⟨r, hr, ?_⟩
+    have hn_ge : (1 : ℝ) ≤ ↑n := Nat.one_le_cast.mpr hn_pos
+    have hn_le : (↑n : ℝ) ≤ ↑N - 1 := by
+      have : n ≤ N - 1 := Nat.lt_iff_le_pred (by omega : 0 < N) |>.mp hn_lt
+      have := Nat.cast_le (α := ℝ).mpr this
+      have : (↑(N - 1) : ℝ) = ↑N - 1 := by rw [Nat.cast_sub (by omega : 1 ≤ N)]; simp
+      linarith
+    have hprod : (↑n : ℝ) * (↑N - ↑n) ≥ ↑N - 1 := by nlinarith
+    have hN1_pos : (0 : ℝ) < ↑N - 1 := by
+      have : (1 : ℝ) < ↑N := by exact_mod_cast hN
+      linarith
+    have hnorm_sq : ‖fourierCoeff A r‖ ^ 2 ≥ 1 := by nlinarith
+    -- ‖Â(r)‖ ≥ 1 from ‖Â(r)‖² ≥ 1 and ‖Â(r)‖ ≥ 0
+    have hnorm_ge : ‖fourierCoeff A r‖ ≥ 1 := by
+      by_contra h; push_neg at h
+      have : ‖fourierCoeff A r‖ ^ 2 < 1 := by
+        calc ‖fourierCoeff A r‖ ^ 2
+            = ‖fourierCoeff A r‖ * ‖fourierCoeff A r‖ := sq _
+          _ ≤ ‖fourierCoeff A r‖ * 1 :=
+              mul_le_mul_of_nonneg_left (le_of_lt h) (norm_nonneg _)
+          _ = ‖fourierCoeff A r‖ := mul_one _
+          _ < 1 := h
+      linarith
+    linarith
+  · -- CASE 2: δ²N > 2. Fourier identity + contradiction.
+    push_neg at hcase
+    by_contra hall; push_neg at hall
+    -- Step A: n² > N (dense regime). From n ≥ δN and δ²N > 2: n² ≥ δ²N² > 2N > N
+    have hn_sq : (↑n : ℝ) ^ 2 ≥ (delta * ↑N) ^ 2 := by nlinarith [sq_nonneg (↑n - delta * ↑N)]
+    have hn_sq_gt : (↑n : ℝ) ^ 2 > ↑N := by nlinarith
+    -- Step B: Fourier identity from AP-freeness
+    have htc : tripleCount A = 0 := (apFree_iff_tripleCount_zero A).mp hAP
+    have hfi := triple_count_fourier A
+    rw [htc, Nat.cast_zero, zero_add] at hfi
+    have hN_ne : (↑N : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne N)
+    set F := fun r : ZMod N => fourierCoeff A r ^ 2 * starRingEnd ℂ (fourierCoeff A (2 * r))
+    have hfi2 : (↑N : ℂ) * ↑n = Finset.univ.sum F := by rw [hfi]; field_simp
+    -- Step C: Split sum at r = 0, F(0) = n³
+    have hF0 : F 0 = (↑n : ℂ) ^ 3 := by
+      simp only [F, mul_zero, fourierCoeff_zero, map_natCast]; ring
+    have hsplit : Finset.univ.sum F = F 0 + (Finset.univ.erase 0).sum F :=
+      (Finset.add_sum_erase _ F (Finset.mem_univ 0)).symm
+    -- Σ_{r≠0} F(r) = Nn - n³ (complex algebra, not linarith)
+    have hsum_ne0 : (Finset.univ.erase 0).sum F = (↑N : ℂ) * ↑n - (↑n : ℂ) ^ 3 := by
+      have h4 : (↑N : ℂ) * ↑n = (↑n : ℂ) ^ 3 + (Finset.univ.erase 0).sum F := by
+        calc (↑N : ℂ) * ↑n = Finset.univ.sum F := hfi2
+          _ = F 0 + (Finset.univ.erase 0).sum F := hsplit
+          _ = (↑n : ℂ) ^ 3 + (Finset.univ.erase 0).sum F := by rw [hF0]
+      linear_combination -h4
+    -- Step D: Triangle inequality
+    have htri : ‖(↑N : ℂ) * ↑n - (↑n : ℂ) ^ 3‖ ≤
+        (Finset.univ.erase 0).sum (fun r => ‖F r‖) := by
+      rw [← hsum_ne0]; exact norm_sum_le _ _
+    have hFnorm : ∀ r : ZMod N,
+        ‖F r‖ = ‖fourierCoeff A r‖ ^ 2 * ‖fourierCoeff A (2 * r)‖ := by
+      intro r; simp only [F, norm_mul, norm_pow, RCLike.norm_conj]
+    -- Step E: Split sum by 2r = 0 vs 2r ≠ 0
+    set S₁ := (Finset.univ.erase (0 : ZMod N)).filter (fun r => 2 * r ≠ 0)
+    set S₂ := (Finset.univ.erase (0 : ZMod N)).filter (fun r => 2 * r = 0)
+    have hunion : (Finset.univ.erase 0) = S₁ ∪ S₂ := by
+      ext r; simp [S₁, S₂, Finset.mem_filter, Finset.mem_erase]; tauto
+    have hdisj : Disjoint S₁ S₂ := by
+      rw [Finset.disjoint_filter]; intro r _ h1 h2; exact h1 h2
+    have hsum_split : (Finset.univ.erase 0).sum (fun r => ‖F r‖) =
+        S₁.sum (fun r => ‖F r‖) + S₂.sum (fun r => ‖F r‖) := by
+      rw [hunion]; exact Finset.sum_union hdisj
+    -- Step F: Bound S₁ (2r ≠ 0 so ‖Â(2r)‖ < δ²N/2)
+    have hS1_bound : S₁.sum (fun r => ‖F r‖) ≤
+        (delta ^ 2 * ↑N / 2) * ((↑n : ℝ) * (↑N - ↑n)) := by
+      simp_rw [hFnorm]
+      calc S₁.sum (fun r => ‖fourierCoeff A r‖ ^ 2 * ‖fourierCoeff A (2 * r)‖)
+          ≤ S₁.sum (fun r => ‖fourierCoeff A r‖ ^ 2 * (delta ^ 2 * ↑N / 2)) := by
+            apply Finset.sum_le_sum; intro r hr
+            exact mul_le_mul_of_nonneg_left
+              (le_of_lt (hall (2 * r) (Finset.mem_filter.mp hr).2)) (sq_nonneg _)
+        _ = (delta ^ 2 * ↑N / 2) * S₁.sum (fun r => ‖fourierCoeff A r‖ ^ 2) := by
+            rw [← Finset.sum_mul]; ring_nf
+        _ ≤ (delta ^ 2 * ↑N / 2) * ((↑n : ℝ) * (↑N - ↑n)) := by
+            apply mul_le_mul_of_nonneg_left _ (by positivity)
+            calc S₁.sum (fun r => ‖fourierCoeff A r‖ ^ 2)
+                ≤ (Finset.univ.erase 0).sum (fun r => ‖fourierCoeff A r‖ ^ 2) :=
+                  Finset.sum_le_sum_of_subset_of_nonneg
+                    (fun r hr => Finset.mem_of_mem_filter r hr)
+                    (fun _ _ _ => sq_nonneg _)
+              _ = _ := by
+                  rw [show Finset.univ.erase (0 : ZMod N) =
+                    Finset.univ.filter (· ≠ 0) from (Finset.filter_ne' _ _).symm]
+                  exact parseval_nonzero A
+    -- Step G: Bound S₂ (at most 1 element by two_mul_eq_zero_unique)
+    have hS2_card : S₂.card ≤ 1 := by
+      rw [Finset.card_le_one]; intro a ha b hb
+      have ha' := Finset.mem_filter.mp ha; have hb' := Finset.mem_filter.mp hb
+      exact two_mul_eq_zero_unique a b
+        (Finset.mem_erase.mp ha'.1).1 ha'.2 (Finset.mem_erase.mp hb'.1).1 hb'.2
+    have hS2_bound : S₂.sum (fun r => ‖F r‖) ≤ (delta ^ 2 * ↑N / 2) ^ 2 * ↑n := by
+      simp_rw [hFnorm]
+      calc S₂.sum (fun r => ‖fourierCoeff A r‖ ^ 2 * ‖fourierCoeff A (2 * r)‖)
+          ≤ S₂.sum (fun _ => (delta ^ 2 * ↑N / 2) ^ 2 * ↑n) := by
+            apply Finset.sum_le_sum; intro r hr
+            have hr' := Finset.mem_filter.mp hr
+            have hAr := sq_le_sq' (by linarith [norm_nonneg (fourierCoeff A r)])
+              (le_of_lt (hall r (Finset.mem_erase.mp hr'.1).1))
+            rw [hr'.2, fourierCoeff_zero, Complex.norm_natCast]
+            exact mul_le_mul_of_nonneg_right hAr (Nat.cast_nonneg n)
+        _ = ↑S₂.card * ((delta ^ 2 * ↑N / 2) ^ 2 * ↑n) := by
+            rw [Finset.sum_const, nsmul_eq_mul]
+        _ ≤ 1 * ((delta ^ 2 * ↑N / 2) ^ 2 * ↑n) := by
+            apply mul_le_mul_of_nonneg_right _ (by positivity)
+            exact_mod_cast hS2_card
+        _ = _ := one_mul _
+    -- Step H: ‖Nn - n³‖ = n(n² - N) as real numbers
+    have hn_cast_pos : (0 : ℝ) < ↑n := Nat.cast_pos.mpr hn_pos
+    have hsub_pos : (0 : ℝ) < (↑n : ℝ) ^ 2 - ↑N := sub_pos.mpr hn_sq_gt
+    set rval := (↑n : ℝ) * ((↑n : ℝ) ^ 2 - ↑N) with hrval_def
+    have hrval_pos : 0 < rval := mul_pos hn_cast_pos hsub_pos
+    have hnorm_real : ‖(↑N : ℂ) * ↑n - (↑n : ℂ) ^ 3‖ = rval := by
+      have hcast : (↑N : ℂ) * ↑n - (↑n : ℂ) ^ 3 = -↑rval := by
+        simp only [hrval_def]; push_cast; ring
+      rw [hcast, norm_neg, Complex.norm_real]
+      exact Real.norm_of_nonneg (le_of_lt hrval_pos)
+    -- Step I: Combine to get n(n²-N) ≤ (δ²N/2)·n(N-n) + (δ²N/2)²·n
+    have hcombined : (↑n : ℝ) * ((↑n : ℝ) ^ 2 - ↑N) ≤
+        (delta ^ 2 * ↑N / 2) * ((↑n : ℝ) * (↑N - ↑n)) +
+        (delta ^ 2 * ↑N / 2) ^ 2 * ↑n := by linarith [htri, hsum_split, hS1_bound, hS2_bound]
+    -- Step J: Divide by n > 0 and use δ²N/2 ≤ n to simplify
+    have hdelta_le : delta ≤ 1 := by
+      have : (↑n : ℝ) < ↑N := by exact_mod_cast hn_lt
+      nlinarith
+    have hα_le_n : delta ^ 2 * ↑N / 2 ≤ ↑n := by nlinarith
+    -- n²-N ≤ (δ²N/2)(N-n) + (δ²N/2)² ≤ (δ²N/2)·N (since δ²N/2 ≤ n means N-n+δ²N/2 ≤ N)
+    -- Step: α² ≤ α·n (since α ≤ n and α ≥ 0)
+    set α := delta ^ 2 * ↑N / 2 with hα_def
+    have hα_pos : (0 : ℝ) ≤ α := by positivity
+    have hα_sq_le : α ^ 2 ≤ α * ↑n :=
+      calc α ^ 2 = α * α := sq α
+        _ ≤ α * ↑n := mul_le_mul_of_nonneg_left hα_le_n hα_pos
+    -- n(n²-N) ≤ αn(N-n) + α²n ≤ αn(N-n+n) = αnN
+    have h_bound : ↑n * ((↑n : ℝ) ^ 2 - ↑N * (1 + α)) ≤ 0 := by nlinarith
+    -- Since n > 0 and n·x ≤ 0, we get x ≤ 0, i.e., n² ≤ N(1+α)
+    have hkey : (↑n : ℝ) ^ 2 ≤ ↑N * (1 + α) :=
+      le_of_not_gt fun h => by
+        have : (0 : ℝ) < (↑n : ℝ) ^ 2 - ↑N * (1 + α) := by linarith
+        linarith [mul_pos hn_cast_pos this]
+    -- From n ≥ δN: δ²N² ≤ n² ≤ N(1+α) = N + αN. So δ²N ≤ 1+α = 1+δ²N/2, giving δ²N ≤ 2
+    have hcontra : delta ^ 2 * ↑N ≤ 2 := by nlinarith
+    linarith
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART V: DENSITY INCREMENT LEMMA
@@ -634,11 +850,11 @@ theorem fourier_large_coefficient {N : ℕ} (hN : 0 < N) (A : Finset (ZMod N))
     length ~√N. By pigeonhole, A has increased density on at least one
     of these progressions. AP-freeness is preserved since any 3-AP in the
     subprogression would lift to a 3-AP in the original set. -/
-theorem density_increment_lemma {N : ℕ} (hN : 0 < N) (A : Finset (ZMod N))
+theorem density_increment_lemma {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N))
     (hAP : APFree A) (delta : ℝ) (hdelta : 0 < delta)
     (hdensity : (A.card : ℝ) ≥ delta * N) :
     ∃ (M : ℕ) (B : Finset (ZMod M)),
-      0 < M ∧
+      1 < M ∧
       M ≥ Nat.sqrt N ∧
       APFree B ∧
       (B.card : ℝ) ≥ (delta + delta ^ 2 / 100) * M := by
@@ -649,16 +865,16 @@ theorem density_increment_lemma {N : ℕ} (hN : 0 < N) (A : Finset (ZMod N))
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- Auxiliary: one step of the density increment iteration.
-    If there exists an AP-free set of density ≥ d in Z/NZ (with N > 0),
+    If there exists an AP-free set of density ≥ d in Z/NZ (with N > 1),
     then there exists an AP-free set of density ≥ d + d²/100 in some
-    Z/MZ with 0 < M. -/
-theorem density_increment_step {N : ℕ} (hN : 0 < N) (d : ℝ) (hd : 0 < d)
+    Z/MZ with 1 < M. -/
+theorem density_increment_step {N : ℕ} (hN : 1 < N) (d : ℝ) (hd : 0 < d)
     (A : Finset (ZMod N)) (hAP : APFree A)
     (hdens : (A.card : ℝ) ≥ d * N) :
     ∃ (M : ℕ) (B : Finset (ZMod M)),
-      0 < M ∧ APFree B ∧ (B.card : ℝ) ≥ (d + d ^ 2 / 100) * M :=
-  let ⟨M, B, hMpos, _, hBAP, hBdens⟩ := density_increment_lemma hN A hAP d hd hdens
-  ⟨M, B, hMpos, hBAP, hBdens⟩
+      1 < M ∧ APFree B ∧ (B.card : ℝ) ≥ (d + d ^ 2 / 100) * M :=
+  let ⟨M, B, hMgt, _, hBAP, hBdens⟩ := density_increment_lemma hN A hAP d hd hdens
+  ⟨M, B, hMgt, hBAP, hBdens⟩
 
 /-- After k iterations of density increment starting from density delta,
     the density reaches at least delta + k * delta² / 100.
@@ -667,19 +883,19 @@ theorem density_increment_step {N : ℕ} (hN : 0 < N) (d : ℝ) (hd : 0 < d)
     so the increment d²/100 ≥ delta²/100. Thus after k steps, the total
     increment is at least k * delta²/100. -/
 theorem density_iteration (delta : ℝ) (hdelta : 0 < delta) :
-    ∀ k : ℕ, ∀ N : ℕ, 0 < N →
+    ∀ k : ℕ, ∀ N : ℕ, 1 < N →
     ∀ A : Finset (ZMod N), APFree A →
     (A.card : ℝ) ≥ (delta + k * delta ^ 2 / 100) * N →
     ∃ (M : ℕ) (B : Finset (ZMod M)),
-      0 < M ∧ APFree B ∧
+      1 < M ∧ APFree B ∧
       (B.card : ℝ) ≥ (delta + (k + 1) * delta ^ 2 / 100) * M := by
   intro k N hN A hAP hdens
   -- Current density is d := delta + k * delta^2 / 100
   set d := delta + ↑k * delta ^ 2 / 100 with hd_def
   have hd_pos : 0 < d := by positivity
   -- Apply density increment at current density d
-  obtain ⟨M, B, hMpos, _, hBAP, hBdens⟩ := density_increment_lemma hN A hAP d hd_pos hdens
-  refine ⟨M, B, hMpos, hBAP, ?_⟩
+  obtain ⟨M, B, hMgt, _, hBAP, hBdens⟩ := density_increment_lemma hN A hAP d hd_pos hdens
+  refine ⟨M, B, hMgt, hBAP, ?_⟩
   -- hBdens : (B.card : ℝ) ≥ (d + d^2/100) * M
   -- Need: (B.card : ℝ) ≥ (delta + (k+1) * delta^2/100) * M
   -- Since d ≥ delta > 0, we have d^2 ≥ delta^2, so d + d^2/100 ≥ d + delta^2/100
@@ -708,28 +924,28 @@ theorem density_iteration (delta : ℝ) (hdelta : 0 < delta) :
 theorem roth_density_bound (delta : ℝ) (hdelta : 0 < delta) (hdelta1 : delta ≤ 1) :
     ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ → ∀ A : Finset (ZMod N),
       (A.card : ℝ) ≥ delta * N → ¬APFree A := by
-  -- N₀ = 1 works: the argument applies for all N ≥ 1
-  refine ⟨1, fun N hN A hdensity hAP => ?_⟩
-  have hNpos : 0 < N := by omega
+  -- N₀ = 2 works: the argument applies for all N ≥ 2
+  refine ⟨2, fun N hN A hdensity hAP => ?_⟩
+  have hNgt : 1 < N := by omega
   -- Iteration chain: after k density-increment steps, we get a set of
-  -- density ≥ delta + k * delta²/100 in some Z/MZ with M > 0
+  -- density ≥ delta + k * delta²/100 in some Z/MZ with M > 1
   have chain : ∀ k : ℕ, ∃ (M : ℕ) (B : Finset (ZMod M)),
-      0 < M ∧ APFree B ∧ (B.card : ℝ) ≥ (delta + ↑k * delta ^ 2 / 100) * ↑M := by
+      1 < M ∧ APFree B ∧ (B.card : ℝ) ≥ (delta + ↑k * delta ^ 2 / 100) * ↑M := by
     intro k
     induction k with
     | zero =>
       simp only [Nat.cast_zero, zero_mul, zero_div, add_zero]
-      exact ⟨N, A, hNpos, hAP, hdensity⟩
+      exact ⟨N, A, hNgt, hAP, hdensity⟩
     | succ k ih =>
-      obtain ⟨M, B, hMpos, hBAP, hBdens⟩ := ih
-      obtain ⟨M', B', hM'pos, hB'AP, hB'dens⟩ :=
-        density_iteration delta hdelta k M hMpos B hBAP hBdens
-      refine ⟨M', B', hM'pos, hB'AP, ?_⟩
+      obtain ⟨M, B, hMgt, hBAP, hBdens⟩ := ih
+      obtain ⟨M', B', hM'gt, hB'AP, hB'dens⟩ :=
+        density_iteration delta hdelta k M hMgt B hBAP hBdens
+      refine ⟨M', B', hM'gt, hB'AP, ?_⟩
       push_cast at hB'dens ⊢
       linarith
   -- Choose K large enough that delta + K * delta²/100 > 1
   obtain ⟨K, hK⟩ := exists_nat_gt (100 / delta ^ 2)
-  obtain ⟨M, B, hMpos, _, hBdens⟩ := chain K
+  obtain ⟨M, B, hMgt, _, hBdens⟩ := chain K
   haveI : NeZero M := ⟨by omega⟩
   -- Clear the denominator: 100/delta² < K implies 100 < K*delta²
   have hd2 : delta ^ 2 > 0 := by positivity
@@ -740,7 +956,7 @@ theorem roth_density_bound (delta : ℝ) (hdelta : 0 < delta) (hdelta1 : delta �
     linarith
   -- The density exceeds 1, so |B| > M
   have hgt1 : delta + ↑K * delta ^ 2 / 100 > 1 := by linarith
-  have hMcast : (0 : ℝ) < ↑M := Nat.cast_pos.mpr hMpos
+  have hMcast : (0 : ℝ) < ↑M := Nat.cast_pos.mpr (by omega : 0 < M)
   have hBgt : (B.card : ℝ) > ↑M := by
     calc (B.card : ℝ) ≥ (delta + ↑K * delta ^ 2 / 100) * ↑M := hBdens
       _ > 1 * ↑M := mul_lt_mul_of_pos_right hgt1 hMcast

--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -904,6 +904,47 @@ theorem apFree_coset_slice {N P : ℕ} [NeZero N] [NeZero P]
     exact Nat.not_dvd_of_pos_of_lt hval_e_pos hval_e_lt this
   exact hAP (a + (↑(ZMod.val b) : ZMod N) * r) d hd_ne hb (h1 ▸ hbe) (h2 ▸ hb2e)
 
+/-- Our APFree is equivalent to Mathlib's ThreeAPFree on ZMod N.
+    This bridges our Fourier-analytic definitions with Mathlib's regularity-based
+    proof of Roth's theorem. The equivalence is by contrapositive:
+    APFree says d ≠ 0 → a,a+d ∈ A → a+2d ∉ A, while ThreeAPFree says
+    a+c=2b for a,b,c ∈ A implies a=b (i.e., d=0). -/
+theorem apFree_iff_threeAPFree {N : ℕ} [NeZero N] (A : Finset (ZMod N)) :
+    APFree A ↔ ThreeAPFree (↑A : Set (ZMod N)) := by
+  constructor
+  · -- APFree → ThreeAPFree
+    intro hAP a ha b hb c hc habc
+    -- Given a + c = b + b with all in A, show a = b
+    by_contra hne
+    have hd : b - a ≠ 0 := sub_ne_zero.mpr (Ne.symm hne)
+    -- From a + c = b + b, derive c = a + 2*(b-a) algebraically
+    have hc_eq : c = a + 2 * (b - a) := sub_eq_zero.mp (show
+        c - (a + 2 * (b - a)) = 0 from by
+      calc c - (a + 2 * (b - a)) = (a + c) - (b + b) := by ring
+        _ = 0 := by rw [habc]; ring)
+    -- Apply APFree: a, a+(b-a)=b, a+2*(b-a)=c all in A contradicts APFree
+    exact hAP a (b - a) hd (Finset.mem_coe.mp ha)
+      (show a + (b - a) ∈ A by rwa [show a + (b - a) = b from by ring])
+      (show a + 2 * (b - a) ∈ A by rw [← hc_eq]; exact Finset.mem_coe.mp hc)
+  · -- ThreeAPFree → APFree
+    intro hfree a d hd ha had
+    -- Goal: a + 2*d ∉ A. Proceed by contradiction.
+    intro hadd
+    -- Apply ThreeAPFree with (a, a+d, a+2d): a + (a+2d) = (a+d) + (a+d)
+    have heq : a + (a + 2 * d) = (a + d) + (a + d) := by ring
+    have h : a = a + d := hfree (Finset.mem_coe.mpr ha) (Finset.mem_coe.mpr had)
+      (Finset.mem_coe.mpr hadd) heq
+    -- From a = a + d, derive d = 0, contradicting hd
+    exact hd (add_left_cancel (show a + d = a + 0 by rw [add_zero]; exact h.symm))
+
+-- ═══════════════════════════════════════════════════════════════════
+-- FOURIER-ANALYTIC DENSITY INCREMENT (OPEN FORMALIZATION CHALLENGE)
+-- The lemmas below represent the density-increment proof strategy.
+-- Note: density_increment_lemma as stated is too strong for δ near 2/3
+-- (max AP-free density in any Z/MZ with M>1 is 2/3, achieved at M=3).
+-- The main theorem roth_density_bound is proved independently via Mathlib.
+-- ═══════════════════════════════════════════════════════════════════
+
 /-- The density increment lemma: if A ⊆ Z/NZ has density delta and no 3-AP,
     then A has density at least delta + c·delta² on some long arithmetic
     subprogression, and the restriction is also AP-free. This is the
@@ -975,55 +1016,23 @@ theorem density_iteration (delta : ℝ) (hdelta : 0 < delta) :
     subset A ⊆ Z/NZ with |A| ≥ delta * N contains a 3-term arithmetic
     progression.
 
-    The proof iterates the density increment: each time the set has no
-    3-AP, its density increases by at least delta²/100 on a subprogression.
-    After K = ⌈100/delta²⌉ steps, the density would exceed 1, contradicting
-    the fact that any subset of Z/MZ has at most M elements.
-
-    The universe size at step k satisfies M_k ≥ N^{1/2^k} (since each
-    step gives M ≥ √N), so we need N₀ large enough that N₀^{1/2^K} ≥ 1,
-    which holds for any N₀ ≥ 1. -/
-theorem roth_density_bound (delta : ℝ) (hdelta : 0 < delta) (hdelta1 : delta ≤ 1) :
+    Proof: We bridge our APFree definition to Mathlib's ThreeAPFree via
+    `apFree_iff_threeAPFree`, then apply Mathlib's `roth_3ap_theorem`
+    which establishes Roth's theorem for finite abelian groups via the
+    corners theorem and Szemerédi regularity. -/
+theorem roth_density_bound (delta : ℝ) (hdelta : 0 < delta) (_hdelta1 : delta ≤ 1) :
     ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ → ∀ A : Finset (ZMod N),
       (A.card : ℝ) ≥ delta * N → ¬APFree A := by
-  -- N₀ = 2 works: the argument applies for all N ≥ 2
-  refine ⟨2, fun N hN A hdensity hAP => ?_⟩
-  have hNgt : 1 < N := by omega
-  -- Iteration chain: after k density-increment steps, we get a set of
-  -- density ≥ delta + k * delta²/100 in some Z/MZ with M > 1
-  have chain : ∀ k : ℕ, ∃ (M : ℕ) (B : Finset (ZMod M)),
-      1 < M ∧ APFree B ∧ (B.card : ℝ) ≥ (delta + ↑k * delta ^ 2 / 100) * ↑M := by
-    intro k
-    induction k with
-    | zero =>
-      simp only [Nat.cast_zero, zero_mul, zero_div, add_zero]
-      exact ⟨N, A, hNgt, hAP, hdensity⟩
-    | succ k ih =>
-      obtain ⟨M, B, hMgt, hBAP, hBdens⟩ := ih
-      obtain ⟨M', B', hM'gt, hB'AP, hB'dens⟩ :=
-        density_iteration delta hdelta k M hMgt B hBAP hBdens
-      refine ⟨M', B', hM'gt, hB'AP, ?_⟩
-      push_cast at hB'dens ⊢
-      linarith
-  -- Choose K large enough that delta + K * delta²/100 > 1
-  obtain ⟨K, hK⟩ := exists_nat_gt (100 / delta ^ 2)
-  obtain ⟨M, B, hMgt, _, hBdens⟩ := chain K
-  haveI : NeZero M := ⟨by omega⟩
-  -- Clear the denominator: 100/delta² < K implies 100 < K*delta²
-  have hd2 : delta ^ 2 > 0 := by positivity
-  have h_clear : (100 : ℝ) < ↑K * delta ^ 2 := by
-    have h1 : 100 / delta ^ 2 * delta ^ 2 < ↑K * delta ^ 2 :=
-      mul_lt_mul_of_pos_right hK hd2
-    have h2 : 100 / delta ^ 2 * delta ^ 2 = 100 := by field_simp
-    linarith
-  -- The density exceeds 1, so |B| > M
-  have hgt1 : delta + ↑K * delta ^ 2 / 100 > 1 := by linarith
-  have hMcast : (0 : ℝ) < ↑M := Nat.cast_pos.mpr (by omega : 0 < M)
-  have hBgt : (B.card : ℝ) > ↑M := by
-    calc (B.card : ℝ) ≥ (delta + ↑K * delta ^ 2 / 100) * ↑M := hBdens
-      _ > 1 * ↑M := mul_lt_mul_of_pos_right hgt1 hMcast
-      _ = ↑M := one_mul _
-  -- But |B| ≤ M for any Finset of ZMod M — contradiction
-  linarith [card_le_nat_real B]
+  -- N₀ = max 2 (cornersTheoremBound delta): ensures ZMod N is a large enough group
+  refine ⟨max 2 (cornersTheoremBound delta), fun N hN A hdensity hAP => ?_⟩
+  haveI : NeZero N := ⟨by omega⟩
+  -- Bridge: our APFree implies Mathlib's ThreeAPFree
+  have hfree : ThreeAPFree (↑A : Set (ZMod N)) := (apFree_iff_threeAPFree A).mp hAP
+  -- Apply Mathlib's Roth theorem: dense subsets of large abelian groups contain 3-APs
+  have hbound : cornersTheoremBound delta ≤ Fintype.card (ZMod N) := by
+    rw [ZMod.card N]; omega
+  have hdens : delta * ↑(Fintype.card (ZMod N)) ≤ ↑A.card := by
+    rw [ZMod.card N]; exact_mod_cast hdensity
+  exact absurd hfree (roth_3ap_theorem delta hdelta hbound A hdens)
 
 end Szemeredi.Roth

--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -840,6 +840,70 @@ theorem fourier_large_coefficient {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N))
 -- PART V: DENSITY INCREMENT LEMMA
 -- ═══════════════════════════════════════════════════════════════════
 
+/-- Key lemma: casting a natural number modulo P to ZMod N and multiplying by r
+    gives the same result as casting the original number, when P = addOrderOf r.
+    This is because (P : ZMod N) * r = 0, so the quotient vanishes. -/
+private lemma natCast_mod_mul_eq {N : ℕ} [NeZero N] (a : ℕ) (r : ZMod N) (P : ℕ)
+    (hord : addOrderOf r = P) :
+    (↑(a % P) : ZMod N) * r = (↑a : ZMod N) * r := by
+  have hPr : (↑P : ZMod N) * r = 0 := by
+    rw [← nsmul_eq_mul]; exact hord ▸ addOrderOf_nsmul_eq_zero r
+  have hsum : (↑P : ZMod N) * ↑(a / P) + ↑(a % P) = ↑a := by
+    have h : (↑(P * (a / P) + a % P) : ZMod N) = ↑a :=
+      congrArg Nat.cast (Nat.div_add_mod a P)
+    simp only [Nat.cast_add, Nat.cast_mul] at h; exact h
+  have hvanish : (↑P : ZMod N) * ↑(a / P) * r = 0 := by
+    calc (↑P : ZMod N) * ↑(a / P) * r
+        = ↑(a / P) * ((↑P : ZMod N) * r) := by ring
+      _ = ↑(a / P) * 0 := by rw [hPr]
+      _ = 0 := mul_zero _
+  calc (↑(a % P) : ZMod N) * r
+      = 0 + (↑(a % P) : ZMod N) * r := (zero_add _).symm
+    _ = (↑P : ZMod N) * ↑(a / P) * r + (↑(a % P) : ZMod N) * r := by rw [hvanish]
+    _ = ((↑P : ZMod N) * ↑(a / P) + ↑(a % P)) * r := by ring
+    _ = (↑a : ZMod N) * r := by rw [hsum]
+
+/-- The coset map k ↦ a + val(k)·r is additive: the val of a sum maps to the sum
+    of individual images. -/
+private lemma cosetMap_add {N P : ℕ} [NeZero N] [NeZero P]
+    (r : ZMod N) (hord : addOrderOf r = P)
+    (a : ZMod N) (k₁ k₂ : ZMod P) :
+    a + (↑(ZMod.val (k₁ + k₂)) : ZMod N) * r =
+    (a + (↑(ZMod.val k₁) : ZMod N) * r) + (↑(ZMod.val k₂) : ZMod N) * r := by
+  rw [ZMod.val_add, natCast_mod_mul_eq _ _ P hord, Nat.cast_add, add_mul]
+  ring
+
+/-- AP-freeness is preserved under the coset inclusion map.
+    If A ⊆ Z/NZ is AP-free, r has additive order P, and B = {k ∈ Z/PZ : a + val(k)·r ∈ A},
+    then B is AP-free in Z/PZ. -/
+theorem apFree_coset_slice {N P : ℕ} [NeZero N] [NeZero P]
+    (A : Finset (ZMod N)) (hAP : APFree A)
+    (r : ZMod N) (hord : addOrderOf r = P)
+    (a : ZMod N)
+    (B : Finset (ZMod P))
+    (hB : ∀ k : ZMod P, k ∈ B ↔ a + (↑(ZMod.val k) : ZMod N) * r ∈ A) :
+    APFree B := by
+  intro b e he hb hbe hb2e
+  rw [hB] at hb hbe hb2e
+  set d := (↑(ZMod.val e) : ZMod N) * r with hd_def
+  have h1 : a + (↑(ZMod.val (b + e)) : ZMod N) * r =
+      (a + (↑(ZMod.val b) : ZMod N) * r) + d :=
+    cosetMap_add r hord a b e
+  have h2 : a + (↑(ZMod.val (b + 2 * e)) : ZMod N) * r =
+      (a + (↑(ZMod.val b) : ZMod N) * r) + 2 * d := by
+    have : b + 2 * e = (b + e) + e := by ring
+    rw [this, cosetMap_add r hord a (b + e) e, cosetMap_add r hord a b e]; ring
+  have hd_ne : d ≠ 0 := by
+    rw [hd_def]; intro h
+    have hval_e_pos : 0 < ZMod.val e := by
+      rw [Nat.pos_iff_ne_zero]; intro h0; exact he (by rwa [ZMod.val_eq_zero] at h0)
+    have hval_e_lt : ZMod.val e < P := ZMod.val_lt e
+    have := addOrderOf_dvd_of_nsmul_eq_zero
+      (show (ZMod.val e) • r = 0 by rwa [nsmul_eq_mul])
+    rw [hord] at this
+    exact Nat.not_dvd_of_pos_of_lt hval_e_pos hval_e_lt this
+  exact hAP (a + (↑(ZMod.val b) : ZMod N) * r) d hd_ne hb (h1 ▸ hbe) (h2 ▸ hb2e)
+
 /-- The density increment lemma: if A ⊆ Z/NZ has density delta and no 3-AP,
     then A has density at least delta + c·delta² on some long arithmetic
     subprogression, and the restriction is also AP-free. This is the
@@ -855,7 +919,6 @@ theorem density_increment_lemma {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N))
     (hdensity : (A.card : ℝ) ≥ delta * N) :
     ∃ (M : ℕ) (B : Finset (ZMod M)),
       1 < M ∧
-      M ≥ Nat.sqrt N ∧
       APFree B ∧
       (B.card : ℝ) ≥ (delta + delta ^ 2 / 100) * M := by
   sorry
@@ -873,8 +936,7 @@ theorem density_increment_step {N : ℕ} (hN : 1 < N) (d : ℝ) (hd : 0 < d)
     (hdens : (A.card : ℝ) ≥ d * N) :
     ∃ (M : ℕ) (B : Finset (ZMod M)),
       1 < M ∧ APFree B ∧ (B.card : ℝ) ≥ (d + d ^ 2 / 100) * M :=
-  let ⟨M, B, hMgt, _, hBAP, hBdens⟩ := density_increment_lemma hN A hAP d hd hdens
-  ⟨M, B, hMgt, hBAP, hBdens⟩
+  density_increment_lemma hN A hAP d hd hdens
 
 /-- After k iterations of density increment starting from density delta,
     the density reaches at least delta + k * delta² / 100.
@@ -894,7 +956,7 @@ theorem density_iteration (delta : ℝ) (hdelta : 0 < delta) :
   set d := delta + ↑k * delta ^ 2 / 100 with hd_def
   have hd_pos : 0 < d := by positivity
   -- Apply density increment at current density d
-  obtain ⟨M, B, hMgt, _, hBAP, hBdens⟩ := density_increment_lemma hN A hAP d hd_pos hdens
+  obtain ⟨M, B, hMgt, hBAP, hBdens⟩ := density_increment_lemma hN A hAP d hd_pos hdens
   refine ⟨M, B, hMgt, hBAP, ?_⟩
   -- hBdens : (B.card : ℝ) ≥ (d + d^2/100) * M
   -- Need: (B.card : ℝ) ≥ (delta + (k+1) * delta^2/100) * M

--- a/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
@@ -332,3 +332,99 @@ double tail-swap = identity (via List.take_append_drop).
 ### Files Modified
 - `proofs/Proofs/BallotProblemOQ03OQ02.lean` (+35 lines: northBeforeEast_prefix, colEntry_prefix_eq)
 - `research/problems/ballot-problem-oq-03-oq-02/knowledge.md` (this session)
+
+---
+
+## Session 2026-03-23 (researcher-1, session 3) - Deep Analysis of Self-Inverse
+
+**Mode**: REVISIT (depth-first, RICH knowledge score 62)
+**Problem**: ballot-problem-oq-03-oq-02
+**Prior Status**: in-progress, ACT phase, 1 sorry (cancellable_sum_eq_zero)
+
+### Deep Analysis Performed
+
+Extensive analysis of the self-inverse proof for `cancellable_sum_eq_zero`:
+
+1. **Current gvInvolutionFn is NOT self-inverse**: It replaces ALL paths with
+   `northThenEastPath`, so g(g(t)).2 = NTE ≠ t.2. No workaround exists for NTE —
+   the correct approach MUST use actual tail-swap (prefix + suffix joining).
+
+2. **Tail-swap PathMN construction**: Joining take(P_i, k_i) ++ drop(P_j, k_j) gives
+   a valid PathMN m n' where n' = k_i + n_j - k_j = target(σ(j)) - source(i). ✓
+   - Length: k_i + (m + n_j - k_j) = m + n'
+   - East count: c + (m - c) = m (from take_east_count_within_column + countP_drop)
+   - Double swap: take(take(P,k) ++ drop(Q,k'), k) ++ drop(take(Q,k') ++ drop(P,k), k')
+     = take(P,k) ++ drop(P,k) = P (by List.take_left + List.drop_left + List.take_append_drop)
+
+3. **Canonical crossing ordering — (i,j) lex is INSUFFICIENT**: After tail-swap at (c₀, y₀)
+   between paths i₀ and j₀, a pair (i', j₀) with i' < i₀ can newly cross at column c₀
+   because path j₀'s y-range at c₀ changes (upper bound becomes source(i₀) + colEntry(P_i₀, c₀+1)
+   instead of source(j₀) + colEntry(P_j₀, c₀+1)). So lex-min (i,j) is NOT preserved.
+
+4. **Correct ordering: (c, y, i, j) with column+row first**: After tail-swap at (c₀, y₀):
+   - At (c', y') < (c₀, y₀) lex: path prefixes up to (c₀, y₀) are unchanged → same crossings
+   - (c₀, y₀, i₀, j₀) still valid: both paths have same prefix → same lower bounds at c₀ →
+     same y₀ = max(lower bounds). Both paths visit y₀ (join point of prefix + suffix).
+   - No (c₀, y₀, i', j') < (c₀, y₀, i₀, j₀) newly valid: path i' (or j') either unchanged
+     (if not i₀ or j₀) or didn't visit (c₀, y₀) before (by minimality of canonical crossing).
+   → Canonical crossing (c₀, y₀, i₀, j₀) is PRESERVED. ✓
+
+5. **CRITICAL DISCOVERY: `cancellable_has_interior_crossing` is FALSE**: For σ = 1 with
+   strictly ordered sources/targets, cancellable tuples CAN have crossings only at the
+   final column (c = m), not at any interior column. Example: when path i stays below
+   path j at all interior columns but overlaps at the final column boundary where
+   target(i) ≥ source(j) + colEntry(P_j, m).
+
+   **Fix**: The canonical crossing must include c = m (final column). At c = m, the
+   y-range is [source(i) + colEntry(P_i, m), target(σ(i))]. The upper bound depends
+   on σ (via target), but the LOWER bound (colEntry at m) depends only on the path prefix.
+   The tail-swap at c = m swaps pure-North suffixes, which is valid. Self-inverse works
+   because colEntry at m is preserved (same prefix with m East steps) and y₀ = max(lower
+   bounds at m) is preserved.
+
+6. **Updated docstring** in `cancellable_sum_eq_zero` with full proof strategy and
+   remaining work specification.
+
+### What Was NOT Done (Due to Complexity)
+
+The full tail-swap involution implementation (~200 lines) was not completed due to:
+- Complex type-level Lean 4 code for PathMN construction from tail-swap
+- Need for Finset on (c, y, i, j) quadruples (requires bounded y via Fintype)
+- Self-inverse proof requires careful argument about crossing preservation at both
+  interior and final columns
+
+### Concrete Implementation Plan for Next Session
+
+**Step 1** (~30 lines): Build `tailSwapPathMN` — construct PathMN from prefix+suffix
+- Input: P : PathMN m n₁, Q : PathMN m n₂, split positions k_i, k_j
+- Output: PathMN m (k_i + n₂ - k_j)
+- Needs: List.countP_append, countP_drop helper
+
+**Step 2** (~40 lines): Define canonical crossing using Nat encoding
+- Encode (c, y, i, j) → ℕ with bound B = max(targets) + 1
+- Define predicate "n encodes a crossing quadruple for tuple t"
+- Use Nat.find for canonical choice (deterministic, well-founded)
+
+**Step 3** (~20 lines): Define `gvProperInvolution` using Steps 1-2
+- New permutation: σ * swap(ci, cj)
+- New paths: tail-swap at ci, cj; identity elsewhere
+- Cast between PathMN types (σ'(k) = σ(k) for k ≠ ci, cj)
+
+**Step 4** (~10 lines): Prove sign_reversal and no_fixed
+- Only depend on permutation component, carry over from existing proofs
+
+**Step 5** (~30 lines): Prove membership
+- σ' ≠ 1: trivially cancellable
+- σ' = 1: tail-swapped paths still share (c₀, y₀) → ¬NI
+
+**Step 6** (~50 lines): Prove self-inverse
+- Show Nat.find gives same value for g(t): the key preservation argument
+  (crossings at (c', y') < (c₀, y₀) unchanged; (c₀, y₀, i₀, j₀) preserved)
+- Show double tail-swap = identity: List.take_left + List.drop_left + take_append_drop
+- Combine via Sigma.ext
+
+**Step 7** (~10 lines): Wire into Finset.sum_involution
+
+### Files Modified
+- `proofs/Proofs/BallotProblemOQ03OQ02.lean` (updated docstring for cancellable_sum_eq_zero)
+- `research/problems/ballot-problem-oq-03-oq-02/knowledge.md` (this session)

--- a/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
@@ -269,3 +269,66 @@ The self-inverse proof has this structure:
 
 ### Files Modified
 - `proofs/Proofs/BallotProblemOQ03OQ02.lean` (+30 lines: cast_pathMN_val helper, membership proof)
+
+---
+
+## Session 2026-03-23 (researcher-1, session 2) - Prefix Preservation Infrastructure
+
+**Mode**: REVISIT (depth-first, RICH knowledge score 61)
+**Problem**: ballot-problem-oq-03-oq-02
+**Prior Status**: in-progress, ACT phase, 1 sorry (cancellable_sum_eq_zero)
+
+### Work Done
+
+1. **PROVED `northBeforeEast_prefix`**: Key lemma for the tail-swap self-inverse proof.
+   Shows that northBeforeEast depends only on the list prefix when the prefix
+   contains > k East steps. Proof by induction on the prefix list.
+   - false head: decrements k, recurse on tail with k-1
+   - true head: adds 1, recurse with same k (prefix has same East count)
+
+2. **PROVED `colEntry_prefix_eq`**: Direct corollary — colEntry at column k+1
+   depends only on the prefix when it has > k East steps.
+
+3. **Documented full self-inverse proof strategy** in the cancellable_sum_eq_zero
+   docstring, including the key insight about range expansion.
+
+### Key Mathematical Insight: Range Expansion Only Adds Points Above y₀
+
+The self-inverse proof for the GV tail-swap involution requires showing the
+canonical first crossing (column, shared_row, pair) is preserved. The critical
+observation:
+
+When the tail-swap extends path i₀'s range at column c₀ (from [a_i₀, b_i₀] to
+[a_i₀, b_j₀] where b_j₀ ≥ b_i₀), any NEW shared lattice points with third
+paths are at y' ≥ b_i₀ + 1 > b_i₀ ≥ y₀. This is because:
+- The expansion only adds points at the TOP (from b_i₀ to b_j₀)
+- y₀ ≤ b_i₀ (since y₀ is in the original range of path i₀)
+- For pairs that didn't overlap in the original: the non-overlapping range gap
+  was above b_i₀, so new overlap starts at > y₀
+- For pairs that already overlapped: their shared row was ≥ y₀ by canonicality
+
+Therefore the canonical crossing datum (c₀, y₀, ci, cj) is preserved, and the
+same swap is applied twice, giving σ * swap(ci,cj) * swap(ci,cj) = σ and
+double tail-swap = identity (via List.take_append_drop).
+
+### Remaining Sorry
+
+1. **`cancellable_sum_eq_zero`** (1 sorry): The full tail-swap construction requires:
+   - Canonical crossing pair via Finset.min' with (sharedRow, i, j) ordering
+   - Split position computation at the shared lattice point
+   - PathMN validity of swapped paths (length + East count preservation)
+   - Applying Finset.sum_involution with all 4 properties
+
+   **Available infrastructure**:
+   - `northBeforeEast_prefix` + `colEntry_prefix_eq` (PROVED this session)
+   - `take_east_count_within_column` (PROVED earlier)
+   - `swapTailsAt` + length preservation (PROVED earlier)
+   - `gvInvolution_sign_reversal` (PROVED, only depends on perm)
+   - `gvInvolution_no_fixed` (PROVED, only depends on perm)
+
+   **Estimated remaining**: ~150 lines of path surgery (PathMN construction,
+   canonical crossing finder, self-inverse assembly).
+
+### Files Modified
+- `proofs/Proofs/BallotProblemOQ03OQ02.lean` (+35 lines: northBeforeEast_prefix, colEntry_prefix_eq)
+- `research/problems/ballot-problem-oq-03-oq-02/knowledge.md` (this session)

--- a/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
@@ -217,3 +217,55 @@ The self-inverse proof has this structure:
 
 ### Files Modified
 - `proofs/Proofs/BallotProblemOQ03OQ02.lean` (~+50 lines, northThenEast infrastructure)
+
+---
+
+## Session 2026-03-23 (researcher-1) - Membership Sorry PROVED
+
+**Mode**: REVISIT (depth-first, RICH knowledge score 59)
+**Problem**: ballot-problem-oq-03-oq-02
+**Prior Status**: in-progress, ACT phase, 2 sorries (membership + self-inverse)
+
+### Work Done
+
+1. **PROVED `gvInvolution_membership`**: The GV involution image is cancellable.
+   - Added `cast_pathMN_val` helper lemma: cast between PathMN types with equal n
+     preserves the underlying list (proved via `subst hn; rfl`)
+   - Main proof structure:
+     (a) Extract `gvNewPerm = 1` from hypothesis (σ' = σ * swap(i,j) = 1)
+     (b) Show n parameters match: `targets(σ'(k)) - sources(k) = targets(k) - sources(k)`
+         via `congr 1; simp [hperm_eq]`
+     (c) Show `.val` of cast toPathTuple paths = northThenEastList via `cast_pathMN_val`
+     (d) Rewrite `hpair` to use northThenEastList directly
+     (e) Case split on m > 0:
+         - m > 0: apply `northThenEast_not_NI` with wellFormed conditions (omega for nat sub)
+         - m = 0: derive contradiction from `NonIntersecting` final condition
+           (colEntry = 0, sources ≤ targets from wellFormed, omega closes)
+
+2. **Reduced sorry count**: 2 → 1
+
+### Key Technical Discoveries
+- `cast` between PathMN subtypes preserves `.val` when the n parameter is propositionally
+  equal. Proved via `subst hn; rfl` (Lean 4 proof irrelevance makes cast on same type = id)
+- `northThenEast_not_NI` requires `hy₁n₂ : y₁ ≤ y₂ + n₂` not `y₁ ≤ targets(j)` — need
+  omega with `source_le_target` to bridge natural subtraction: `a + (b - a) ≥ c` from `c ≤ b`
+- m = 0 case handled separately: NonIntersecting final condition gives `targets < sources`
+  which contradicts wellFormed
+
+### Remaining Sorry
+1. **`cancellable_sum_eq_zero`** (1 sorry): Uses `Finset.sum_involution` which requires
+   self-inverse. Current `gvInvolutionFn` replaces ALL paths with northThenEast, so it's
+   NOT self-inverse (g(g(σ,P)) = (σ, NTE) ≠ (σ, P)).
+
+   **Required construction**: suffix-swap involution (~200 lines):
+   - Canonical crossing pair via Finset.min' on lex-ordered (c, y, i, j)
+   - Split PathMN at shared lattice point into prefix + suffix
+   - Join prefix_i ++ suffix_j → valid PathMN (correct type for new permutation)
+   - Self-inverse: double swap restores originals (prefixes preserved → same crossing found)
+
+   **Pre-existing blockers**: `take_at_column_entry` and `take_east_count_within_column`
+   have Mathlib compat errors (`Bool.false_eq_false` unknown, ~14 errors). These lemmas
+   ARE needed for the suffix-swap construction. Fix these first.
+
+### Files Modified
+- `proofs/Proofs/BallotProblemOQ03OQ02.lean` (+30 lines: cast_pathMN_val helper, membership proof)

--- a/research/problems/roth-theorem-k3/knowledge.md
+++ b/research/problems/roth-theorem-k3/knowledge.md
@@ -239,3 +239,55 @@ All other sorries are eliminated. The proof of Roth's theorem is complete modulo
 **Difficulty**: HIGH (estimated 200+ lines of new infrastructure)
 **Aristotle-suitable**: NO (requires creative proof architecture, not just tactic search)
 **Simplification**: Could remove M ≥ √N from statement (unused) to simplify
+
+## Session 7 (2026-03-23, researcher-1)
+
+### What Was Done
+1. **Simplified `density_increment_lemma` statement**: Removed `M ≥ Nat.sqrt N` from the conclusion (unused downstream — destructured as `_` in both `density_increment_step` and `density_iteration`). Updated both downstream callers.
+2. **Proved `natCast_mod_mul_eq`**: Key modular arithmetic lemma showing `(↑(a % P) : ZMod N) * r = (↑a : ZMod N) * r` when `addOrderOf r = P`. Uses `Nat.div_add_mod` + the vanishing of `P • r = 0`.
+3. **Proved `cosetMap_add`**: The coset map φ(k) = a + val(k)·r is additive: `φ(k₁+k₂) = φ(k₁) + val(k₂)·r`. Uses `ZMod.val_add` + `natCast_mod_mul_eq`.
+4. **Proved `apFree_coset_slice`**: AP-freeness is preserved under the coset inclusion map. If A ⊆ Z/NZ is AP-free, the "slice" B = {k ∈ Z/PZ : a + val(k)·r ∈ A} is AP-free in Z/PZ. Key steps:
+   - 3-AP (b,b+e,b+2e) in B lifts to 3-AP in A via `cosetMap_add`
+   - Common difference `val(e)·r ≠ 0` since `0 < val(e) < P = addOrderOf r`
+   - Uses `addOrderOf_dvd_of_nsmul_eq_zero` for the non-vanishing
+
+### Key Technical Discoveries
+- `congrArg Nat.cast h` works for casting ℕ equalities to ZMod N when `exact_mod_cast` fails
+- `nsmul_eq_mul` converts between `P • r` (nsmul) and `↑P * r` (ring multiplication) in ZMod N
+- `addOrderOf_nsmul_eq_zero` gives `(addOrderOf r) • r = 0`
+- `Nat.not_dvd_of_pos_of_lt` shows `P ∤ val(e)` when `0 < val(e) < P`
+- ZMod N is commutative, so `ring` handles rearrangements like `↑P * ↑q * r = ↑q * (↑P * r)`
+
+### Remaining Sorry Dependency Chain (Updated Session 7)
+```
+density_increment_lemma (1 sorry) ── needs density boost on cosets
+    └→ roth_density_bound (PROVED)
+```
+
+All AP-freeness preservation infrastructure is now in place. The sole remaining challenge is the **density boost**: showing that some coset of ⟨r⟩ has density ≥ δ + δ²/100.
+
+### Analysis: Density Boost Approaches
+
+**Approach A: Subgroup cosets (P = addOrderOf r)**
+- ✅ AP-freeness preservation (proved via `apFree_coset_slice`)
+- ❌ Density boost: simple Cauchy-Schwarz on |f_a| ≤ |B_a| only gives max density ≈ δ²/2, not δ + δ²/100
+- ❌ Fails when N is prime (P = N, only 1 coset, no boost possible)
+- Mathlib has: `ZMod.addOrderOf_coe`, `addOrderOf_nsmul_eq_zero`
+
+**Approach B: Dirichlet approximation + arithmetic progressions**
+- Mathlib has: `exists_int_int_abs_mul_sub_le` (Dirichlet's theorem)
+- Choose step size q ≤ √N with |qr| ≈ 0 in Z/NZ
+- APs of step q have "approximately constant" character
+- ❌ Approximation error too large for Q = √N (error ≈ signal)
+- ✅ Works with Q = N^{2/3} for N > C/δ⁶ (error < signal)
+- ❌ Requires separate handling for small N
+
+**Approach C: Use Mathlib's `roth_3ap_theorem` directly**
+- Mathlib proves Roth via corners/regularity (different proof strategy)
+- Would bypass density increment entirely but change proof character
+- Would need to connect our `APFree` to Mathlib's `ThreeAPFree`
+
+**Recommended next steps:**
+1. Try Approach B with Q = N^{2/3}, handle small N separately
+2. OR try Approach A with refined Fourier analysis using the EXACT identity (not just magnitude bounds)
+3. The density boost is the deepest mathematical step — may require 2+ sessions

--- a/research/problems/roth-theorem-k3/knowledge.md
+++ b/research/problems/roth-theorem-k3/knowledge.md
@@ -183,3 +183,35 @@ tripleCount_add_card_eq_triple_sum (sorry) ─── pure combinatorics
 parseval_on_zmod (PROVED) ──┘    └→ density_increment_lemma (sorry)
                                        └→ roth_density_bound (PROVED)
 ```
+
+## Session 6 (2026-03-23, researcher-1)
+
+### What Was Done
+1. **Proved two_mul_eq_zero_unique** — uniqueness of 2-torsion in ZMod N
+   - Key technique: ZMod.val arithmetic. From 2a=0: (val a + val a) % N = 0.
+   - Since 0 < val a < N: val a + val a ∈ (0, 2N), only multiple of N is N itself.
+   - Helper `dvd_range_eq`: if N ∣ s and 0 < s < 2N then s = N (via Nat.le_of_dvd + contradiction)
+   - Final step: `ZMod.val_injective N hval_eq` (note: first arg is explicit `N : ℕ`)
+2. **Proved apFree_card_lt** — AP-free ⊂ Z/NZ has < N elements (need `card_le_nat A` in omega context)
+3. **Proved fourier_large_coefficient** — the key analytic step!
+   - Two-case argument: sparse regime (δ²N ≤ 2) via Parseval pigeonhole, dense (δ²N > 2) via Fourier identity + triangle inequality contradiction
+   - Required `set_option maxHeartbeats 800000` (nlinarith in dense case is expensive)
+4. **Fixed Mathlib API issues**: `Nat.one_lt_cast` → `exact_mod_cast`, `Nat.cast_lt` → `exact_mod_cast`
+5. **Reduced sorry count**: 3 → 1 (only `density_increment_lemma` remains)
+
+### Key Technical Discoveries
+- `ZMod N` is NOT `Fin N` at the type level for variable N (even with `NeZero N`). `Fin.ext` fails. Use `ZMod.val_injective N` instead.
+- `ZMod.val_injective` takes explicit `N : ℕ` as first argument: `ZMod.val_injective N hval_eq`
+- `ext` tactic doesn't find extensionality for `ZMod N` — not `@[ext]`-tagged
+- `Nat.one_lt_cast.mpr` fails with CharZero stuck — use `by exact_mod_cast hN` instead
+- `Nat.dvd_sub'` doesn't exist in current Mathlib — use `rcases` on divisor + `Nat.mul_le_mul_left`
+- `set_option maxHeartbeats 800000 in` must go BEFORE docstring, not between docstring and theorem
+- `linarith` handles `N * 2 ≤ N * k` and `N * (k+2) < 2 * N` via treating products as atoms
+
+### Remaining Sorry Dependency Chain (Updated Session 6)
+```
+density_increment_lemma (1 sorry) ── needs subprogression extraction
+    └→ roth_density_bound (PROVED)
+```
+
+All other sorries are eliminated. The proof of Roth's theorem is complete modulo `density_increment_lemma`.

--- a/research/problems/roth-theorem-k3/knowledge.md
+++ b/research/problems/roth-theorem-k3/knowledge.md
@@ -291,3 +291,56 @@ All AP-freeness preservation infrastructure is now in place. The sole remaining 
 1. Try Approach B with Q = N^{2/3}, handle small N separately
 2. OR try Approach A with refined Fourier analysis using the EXACT identity (not just magnitude bounds)
 3. The density boost is the deepest mathematical step — may require 2+ sessions
+
+## Session 8 (2026-03-23, researcher-1)
+
+### What Was Done
+1. **Discovered density_increment_lemma is FALSE as stated** — for δ ∈ (0.663, 2/3]:
+   - The hypothesis (AP-free A with density ≥ δ in Z/NZ) IS satisfiable (N=3, A={0,1})
+   - The conclusion (AP-free B with density ≥ δ+δ²/100 in Z/MZ, M>1) is IMPOSSIBLE
+   - Max AP-free density across all Z/MZ with M>1 is 2/3 (achieved at M=3 with B={0,1})
+   - For δ=2/3: target density 2/3 + 4/900 ≈ 0.671 > 0.667 = 2/3
+   - The "take B={0,1} in Z/3Z" trick works for δ < 0.663 but fails near 2/3
+2. **Proved `apFree_iff_threeAPFree`** — bridge between our APFree and Mathlib's ThreeAPFree
+   - Forward: APFree → ThreeAPFree via contrapositive (d = b-a, algebraic rearrangement)
+   - Backward: ThreeAPFree → APFree via add_left_cancel (a = a+d implies d = 0)
+3. **Proved `roth_density_bound` from Mathlib** — bypasses density_increment_lemma entirely
+   - Uses `roth_3ap_theorem` for ZMod N (finite abelian group)
+   - N₀ = max 2 (cornersTheoremBound delta)
+   - Direct: APFree → ThreeAPFree → roth_3ap_theorem gives ¬ThreeAPFree → contradiction
+4. **Main theorem is now fully proved** — no sorry dependencies in roth_density_bound
+
+### Key Technical Discoveries
+- `sub_eq_zero.mp` converts `x - y = 0` to `x = y` in any AddGroup
+- `add_left_cancel` works in ZMod N (it's an AddGroup): `a + d = a + 0 → d = 0`
+- `Finset.mem_coe.mp/mpr` converts between Finset and Set membership
+- `ZMod.card N` gives `Fintype.card (ZMod N) = N` for NeZero N
+- `roth_3ap_theorem` signature: ε hε hG A hAε → ¬ThreeAPFree ↑A
+
+### Proof Architecture (Updated Session 8)
+```
+Fourier-analytic approach (infrastructure complete, density_increment sorry):
+  char_orthogonality (PROVED)
+  parseval_on_zmod (PROVED)
+  triple_count_fourier (PROVED)
+  fourier_large_coefficient (PROVED)
+  apFree_coset_slice (PROVED)
+  density_increment_lemma (SORRY — statement is FALSE for δ near 2/3)
+    → density_increment_step (proved from sorry)
+    → density_iteration (proved from sorry)
+
+Mathlib bridge approach (fully proved, no sorries):
+  apFree_iff_threeAPFree (PROVED)
+  roth_3ap_theorem (Mathlib — via corners/regularity)
+  → roth_density_bound (PROVED — 0 sorries)
+```
+
+### Analysis: Why density_increment_lemma Fails
+The statement allows M to be ANY value > 1 with no relation to N. This means the iteration can "collapse" to M=3, B={0,1} (density 2/3). Once density approaches 2/3, no further boost is possible because max AP-free density in all Z/MZ is 2/3. The CORRECT formulation would either:
+- Require M ≥ f(N) for some growing function (prevents collapse)
+- Use a density boost proportional to 1/N (decreases with modulus)
+- Add a condition N ≥ g(δ) (makes hypothesis vacuous near the ceiling)
+
+### Files Modified
+- `proofs/Proofs/RothTheorem.lean` — +45 lines: bridge lemma, new roth_density_bound proof
+- `research/problems/roth-theorem-k3/knowledge.md` — Session 8 notes

--- a/research/problems/roth-theorem-k3/knowledge.md
+++ b/research/problems/roth-theorem-k3/knowledge.md
@@ -215,3 +215,27 @@ density_increment_lemma (1 sorry) ── needs subprogression extraction
 ```
 
 All other sorries are eliminated. The proof of Roth's theorem is complete modulo `density_increment_lemma`.
+
+### Analysis: density_increment_lemma proof requirements
+
+**Statement**: Given AP-free A ⊆ Z/NZ with density ≥ δ, find M ≥ √N and AP-free B ⊆ Z/MZ with density ≥ δ + δ²/100.
+
+**Key observation**: The M ≥ √N bound is NEVER USED downstream. In `density_iteration` and `roth_density_bound`, it's destructured as `_` (ignored). The proof only needs `1 < M`.
+
+**Proof approach** (requires new infrastructure):
+1. From `fourier_large_coefficient` (proved): ∃ r ≠ 0 with |Â(r)| ≥ δ²N/2
+2. Let P = addOrderOf r (order of r in Z/NZ). Then P | N, P ≥ 2.
+3. Z/NZ has N/P cosets of ⟨r⟩. Each coset ≅ Z/PZ.
+4. Need to show: the Fourier coefficient forces a coset to have density δ + Ω(δ²).
+5. AP-freeness preserves: a 3-AP in Z/PZ lifts to 3-AP in the coset ⊆ Z/NZ (since kr ≠ 0 for 0 < k < P).
+
+**New infrastructure needed**:
+- `addOrderOf r` and basic properties for ZMod N
+- Coset partition of Z/NZ by ⟨r⟩ (as Finset decomposition)
+- Bijection between each coset and Z/PZ
+- Fourier coefficient decomposition over cosets → density increment via pigeonhole
+- AP-freeness preservation under the coset→Z/PZ map
+
+**Difficulty**: HIGH (estimated 200+ lines of new infrastructure)
+**Aristotle-suitable**: NO (requires creative proof architecture, not just tactic search)
+**Simplification**: Could remove M ≥ √N from statement (unused) to simplify

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -35,7 +35,10 @@
       "REPLACED Classical.choice with northThenEastPath: canonical all-North-then-all-East path constructor. This ensures image paths cross at column 0 under wellFormed.",
       "northThenEast_not_NI PROVED: two northThenEast paths from different sources cross at column 0 when sources(i) ≤ targets(j)",
       "Self-inverse requires CANONICAL crossing (lex-min on (c,y,i,j)), NOT firstNonFixed (shown by 3-cycle counterexample)",
-      "Range expansion in GV tail-swap only adds shared points above y₀ (canonical row) — key for self-inverse preservation"
+      "Range expansion in GV tail-swap only adds shared points above y₀ (canonical row) — key for self-inverse preservation",
+      "CRITICAL: cancellable_has_interior_crossing is FALSE — σ=1 tuples CAN have crossings only at the final column. The canonical crossing must handle c=m (final) as well as c<m (interior).",
+      "Self-inverse requires (c,y,i,j) lex ordering with column+row first, NOT just (i,j). The (i,j) lex ordering fails because tail-swap can create new crossings at (i2,j0) with i2<i0 at columns >= c0.",
+      "The correct self-inverse argument: at (c2,y2) < (c0,y0) lex, path prefixes unchanged → same crossings. At (c0,y0), both paths still visit y0 (join point). No (i2,j2) < (i0,j0) newly visits (c0,y0) by minimality."
     ],
     "builtItems": [
       "BallotProblemOQ03OQ02.lean: r×r LGV lemma formalization (~1100 lines, expanded from 1050)",
@@ -72,11 +75,15 @@
       "Mathlib version drift: take_at_column_entry/take_east_count_within_column have pre-existing compat errors (~14 errors)"
     ],
     "nextSteps": [
-      "Build canonical crossing pair finder (Finset.min with sharedRow ordering)",
-      "Construct PathMN from tail-swapped lists (length + East count proofs)",
-      "Apply Finset.sum_involution with all 4 properties proved"
+      "Step 1 (~30 lines): Build tailSwapPathMN from prefix+suffix with length+East proofs",
+      "Step 2 (~40 lines): Canonical crossing via Nat encoding + Nat.find (handles c≤m)",
+      "Step 3 (~20 lines): gvProperInvolution using Steps 1-2",
+      "Step 4 (~10 lines): sign_reversal + no_fixed (perm-only, carry over)",
+      "Step 5 (~30 lines): Membership proof (σ≠1 trivial; σ=1 tail-swap still shares crossing)",
+      "Step 6 (~50 lines): Self-inverse via (c,y,i,j) preservation + double tail-swap = id",
+      "Step 7 (~10 lines): Wire into Finset.sum_involution → cancellable_sum_eq_zero"
     ],
-    "progressSummary": "PROGRESS: Membership sorry PROVED. 1 sorry remains (cancellable_sum_eq_zero — needs self-inverse involution via suffix-swap, ~200 lines). Pre-existing Mathlib compat errors in take_at_column_entry block suffix-swap work."
+    "progressSummary": "PROGRESS: Deep analysis of self-inverse completed. Current NTE-based involution cannot be self-inverse (paths lost). Full tail-swap + canonical (c,y,i,j) crossing needed. Critical discovery: final-column crossings must be handled. Estimated ~200 lines remaining."
   },
   "lastUpdate": "2026-03-23T22:00:00Z",
   "leanFiles": [

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -58,25 +58,26 @@
       "gvInvolutionFn_fst: first component accessor (PROVED by rfl)",
       "gvInvolution_sign_reversal: sign cancellation (PROVED modulo simp details)",
       "gvInvolution_no_fixed: no fixed points (PROVED modulo simp details)",
-      "cancellable_sum_eq_zero: structured via Finset.sum_involution (2 sorries remain)",
+      "cancellable_sum_eq_zero: structured via Finset.sum_involution (1 sorry remains — self-inverse)",
       "gvNewPerm RIGHT multiplication fix: σ*swap(i,j) instead of swap(i,j)*σ (PROVED)",
-      "pathMN_nonempty: Nonempty (PathMN m n) for all m,n (PROVED via pathMN_card + choose_pos)"
+      "pathMN_nonempty: Nonempty (PathMN m n) for all m,n (PROVED via pathMN_card + choose_pos)",
+      "cast_pathMN_val: cast between PathMN types with equal n preserves .val (PROVED)",
+      "gvInvolution_membership: image tuple is cancellable (PROVED via cast_pathMN_val + northThenEast_not_NI)"
     ],
     "openQuestions": [
       "Need canonical (deterministic) crossing pair for self-inverse — current crossingI/J use Classical.choose",
-      "Need specific tail-swapped paths for membership proof (when σ=swap(i,j), image paths must still cross)",
-      "Mathlib version drift: take_at_column_entry/take_east_count_within_column have pre-existing compat errors"
+      "Mathlib version drift: take_at_column_entry/take_east_count_within_column have pre-existing compat errors (~14 errors)"
     ],
     "nextSteps": [
-      "Close membership sorry: unfold PermPathTuple.toPathTuple cast under σ'=1, show it reduces to northThenEast paths, apply northThenEast_not_NI",
+      "Fix pre-existing Mathlib compat errors in take_at_column_entry (Bool.false_eq_false unknown) — needed for suffix-swap",
       "Build canonical crossing pair via Finset.min' on lex-ordered (c,y,i,j) crossing quadruples",
       "Build tail-swap PathMN construction: split at shared (c,y), join prefix+suffix, prove validity",
       "Prove self-inverse: canonical crossing preserved (prefix unchanged → lex-min same) + double swap = identity",
-      "Fix pre-existing Mathlib compat errors in take_at_column_entry (Bool.false_eq_false unknown)"
+      "Assemble cancellable_sum_eq_zero via Finset.sum_involution with the new self-inverse involution"
     ],
-    "progressSummary": "PROGRESS: Replaced Classical.choice with northThenEast paths. Proved northThenEast paths cross under wellFormed. sign_reversal + no_fixed proved. Membership: mathematical argument clear, needs cast unfolding (sorry). Self-inverse: needs full tail-swap + canonical crossing (~200 lines, well-understood architecture)."
+    "progressSummary": "PROGRESS: Membership sorry PROVED. 1 sorry remains (cancellable_sum_eq_zero — needs self-inverse involution via suffix-swap, ~200 lines). Pre-existing Mathlib compat errors in take_at_column_entry block suffix-swap work."
   },
-  "lastUpdate": "2026-03-23T18:00:00Z",
+  "lastUpdate": "2026-03-23T22:00:00Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -34,7 +34,8 @@
       "gvInvolutionFn simplified: uses Classical.choice for paths (makes it well-typed) — specific tail-swapped paths needed only for membership/self-inverse",
       "REPLACED Classical.choice with northThenEastPath: canonical all-North-then-all-East path constructor. This ensures image paths cross at column 0 under wellFormed.",
       "northThenEast_not_NI PROVED: two northThenEast paths from different sources cross at column 0 when sources(i) ≤ targets(j)",
-      "Self-inverse requires CANONICAL crossing (lex-min on (c,y,i,j)), NOT firstNonFixed (shown by 3-cycle counterexample)"
+      "Self-inverse requires CANONICAL crossing (lex-min on (c,y,i,j)), NOT firstNonFixed (shown by 3-cycle counterexample)",
+      "Range expansion in GV tail-swap only adds shared points above y₀ (canonical row) — key for self-inverse preservation"
     ],
     "builtItems": [
       "BallotProblemOQ03OQ02.lean: r×r LGV lemma formalization (~1100 lines, expanded from 1050)",
@@ -62,18 +63,18 @@
       "gvNewPerm RIGHT multiplication fix: σ*swap(i,j) instead of swap(i,j)*σ (PROVED)",
       "pathMN_nonempty: Nonempty (PathMN m n) for all m,n (PROVED via pathMN_card + choose_pos)",
       "cast_pathMN_val: cast between PathMN types with equal n preserves .val (PROVED)",
-      "gvInvolution_membership: image tuple is cancellable (PROVED via cast_pathMN_val + northThenEast_not_NI)"
+      "gvInvolution_membership: image tuple is cancellable (PROVED via cast_pathMN_val + northThenEast_not_NI)",
+      "northBeforeEast_prefix: prefix determines northBeforeEast (BallotProblemOQ03OQ02.lean:1266)",
+      "colEntry_prefix_eq: prefix determines colEntry (BallotProblemOQ03OQ02.lean:1287)"
     ],
     "openQuestions": [
       "Need canonical (deterministic) crossing pair for self-inverse — current crossingI/J use Classical.choose",
       "Mathlib version drift: take_at_column_entry/take_east_count_within_column have pre-existing compat errors (~14 errors)"
     ],
     "nextSteps": [
-      "Fix pre-existing Mathlib compat errors in take_at_column_entry (Bool.false_eq_false unknown) — needed for suffix-swap",
-      "Build canonical crossing pair via Finset.min' on lex-ordered (c,y,i,j) crossing quadruples",
-      "Build tail-swap PathMN construction: split at shared (c,y), join prefix+suffix, prove validity",
-      "Prove self-inverse: canonical crossing preserved (prefix unchanged → lex-min same) + double swap = identity",
-      "Assemble cancellable_sum_eq_zero via Finset.sum_involution with the new self-inverse involution"
+      "Build canonical crossing pair finder (Finset.min with sharedRow ordering)",
+      "Construct PathMN from tail-swapped lists (length + East count proofs)",
+      "Apply Finset.sum_involution with all 4 properties proved"
     ],
     "progressSummary": "PROGRESS: Membership sorry PROVED. 1 sorry remains (cancellable_sum_eq_zero — needs self-inverse involution via suffix-swap, ~200 lines). Pre-existing Mathlib compat errors in take_at_column_entry block suffix-swap work."
   },

--- a/src/data/research/problems/roth-theorem-k3.json
+++ b/src/data/research/problems/roth-theorem-k3.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 5b PROVED tripleCount_add_card_eq_triple_sum (combinatorial bijection). 2 sorries remain: fourier_large_coefficient, density_increment_lemma. The Fourier identity chain is now complete (triple_count_fourier fully proved).",
+    "progressSummary": "COMPLETE: roth_density_bound fully proved via Mathlib bridge. density_increment_lemma sorry remains (independent).",
     "builtItems": [
       "Fixed apFree_singleton proof, Complex.abs -> norm, added apFree_subset, removed incorrect apFree_pair",
       "Build now succeeds: 0 axioms, 3 sorries",
@@ -43,7 +43,9 @@
       "Proved char_orthogonality: Σ ψ(r·c) = N·δ(c=0) via shift argument (r↦r+1 bijection on ZMod N)",
       "Proved triple_count_fourier Part A: Fourier expansion ∑Â(r)²conj(Â(2r)) = N·∑δ(x+z=2y)",
       "PROVED triple_count_fourier: Fourier identity for AP counting, via fixed distribution + sum swap + orthogonality",
-      "PROVED tripleCount_add_card_eq_triple_sum: bijection (a,d)↦(a,a+d) between all APs and {(x,y)∈A²:2y-x∈A}, partition d=0/d≠0"
+      "PROVED tripleCount_add_card_eq_triple_sum: bijection (a,d)↦(a,a+d) between all APs and {(x,y)∈A²:2y-x∈A}, partition d=0/d≠0",
+      "apFree_iff_threeAPFree bridge lemma",
+      "roth_density_bound proved from Mathlib (0 sorry deps)"
     ],
     "insights": [
       "RothTheorem.lean had 3 build errors: deprecated Finset.not_mem_empty, broken apFree_singleton, non-existent Complex.abs",
@@ -67,7 +69,9 @@
       "linear_combination works for ZMod N ring equalities (x+z=2y ↔ z=2y-x)",
       "Finset.card_image_of_injective cleaner than card_bij for simple embeddings like a↦(a,0)",
       "For Finset partition: manually construct union via ext+tauto, then card_union_of_disjoint",
-      "norm_cast pushes Nat.cast through Finset.sum and ite — closes ↑(∑ℕ) = ∑ℂ goals"
+      "norm_cast pushes Nat.cast through Finset.sum and ite — closes ↑(∑ℕ) = ∑ℂ goals",
+      "density_increment_lemma as stated is FALSE for delta near 2/3",
+      "APFree↔ThreeAPFree bridge enables Mathlib roth_3ap_theorem"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

**Roth's Theorem is now fully proved** (0 sorry dependencies) via a Mathlib bridge approach.

### Key Results
- **`apFree_iff_threeAPFree`**: Bridge between our Fourier-analytic `APFree` definition and Mathlib's `ThreeAPFree`
- **`roth_density_bound`**: Proved directly from Mathlib's `roth_3ap_theorem` (corners/regularity approach)
- **Fourier infrastructure preserved**: All Parseval, character orthogonality, Fourier coefficient, and coset lemmas remain as proved independent results

### Discovery: density_increment_lemma is FALSE
The lemma as stated is unprovable for δ ∈ (0.663, 2/3]:
- Max AP-free density in any Z/MZ (M>1) is 2/3 (achieved at M=3 with {0,1})
- For δ=2/3: target density 2/3 + 4/900 ≈ 0.671 > 0.667 = 2/3
- The "take B={0,1} in Z/3Z" trick works for small δ but fails near the ceiling
- The main theorem is now proved independently, so this doesn't block anything

### Sorry count
- Before: 1 sorry (density_increment_lemma) blocking roth_density_bound
- After: 1 sorry (density_increment_lemma) NOT blocking anything — roth_density_bound proved via Mathlib

## Test plan
- [x] Docker build passes for Proofs.RothTheorem
- [x] roth_density_bound compiles with 0 sorry dependencies
- [x] All existing Fourier lemmas still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)