### PR TITLE
Enrich shannon-channel-coding-oq-04: deep annotation pass

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-04/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "ann-binary-entropy-def",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 25, "endLine": 32 },
+    "type": "definition",
+    "title": "Binary Entropy Function Definition",
+    "content": "Defines the binary entropy function h(p) = -(p·log p + (1-p)·log(1-p)) using Lean's natural logarithm. The 0·log 0 = 0 convention is automatically handled by Mathlib's Real.log 0 = 0, which eliminates the need for a piecewise definition. A base-2 variant hBits(p) = h(p)/ln 2 converts nats to bits, the standard unit in information theory.",
+    "mathContext": "$h(p) = -(p \\ln p + (1-p) \\ln(1-p))$, with the convention $0 \\cdot \\ln 0 = 0$. The base-2 variant $h_2(p) = h(p)/\\ln 2$ measures entropy in bits.",
+    "significance": "key",
+    "relatedConcepts": ["Shannon entropy", "information content", "Bernoulli distribution", "natural logarithm"],
+    "prerequisites": ["Real.log properties in Mathlib", "measure-theoretic probability"]
+  },
+  {
+    "id": "ann-boundary-values",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 38, "endLine": 42 },
+    "type": "concept",
+    "title": "Boundary Values: Deterministic Sources Have Zero Entropy",
+    "content": "Proves h(0) = h(1) = 0 by simplification using Real.log_one and the 0·log 0 = 0 convention. These boundary values reflect the information-theoretic principle that a deterministic source (always 0 or always 1) carries no uncertainty and requires zero bits to encode.",
+    "mathContext": "$h(0) = h(1) = 0$: a deterministic binary source has zero entropy.",
+    "significance": "supporting",
+    "relatedConcepts": ["deterministic source", "entropy minimization", "degenerate distribution"],
+    "prerequisites": ["Real.log_one"]
+  },
+  {
+    "id": "ann-symmetry",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 48, "endLine": 51 },
+    "type": "insight",
+    "title": "Symmetry as a Ring Identity",
+    "content": "The symmetry h(p) = h(1-p) is proved purely by ring arithmetic — no analysis required. This reflects the deeper fact that relabeling outcomes of a binary source (swapping 0 and 1) does not change its information content. In coding theory, this means the BSC capacity C = 1 - h(p) depends only on the error rate, not on which bit is more likely to flip.",
+    "mathContext": "$h(p) = h(1-p)$ for all $p \\in \\mathbb{R}$, proved by the ring identity $p \\ln p + (1-p)\\ln(1-p) = (1-p)\\ln(1-p) + p \\ln p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["binary symmetric channel", "label invariance", "permutation symmetry of entropy"],
+    "prerequisites": ["commutative ring axioms"]
+  },
+  {
+    "id": "ann-half-value",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 57, "endLine": 70 },
+    "type": "concept",
+    "title": "Maximum Entropy: The Fair Coin",
+    "content": "Proves h(1/2) = ln 2 and hBits(1/2) = 1 using Real.log_inv to compute log(1/2) = -log 2. The result hBits(1/2) = 1 bit is the iconic identity of information theory: a fair coin flip carries exactly one bit of information. This is the maximum entropy for any binary source, achieved uniquely at p = 1/2 (which follows from the concavity theorem proved later).",
+    "mathContext": "$h(1/2) = \\ln 2$ nats $= 1$ bit. The key step: $\\ln(1/2) = \\ln(2^{-1}) = -\\ln 2$, so $h(1/2) = -(2 \\cdot \\tfrac{1}{2}(-\\ln 2)) = \\ln 2$.",
+    "significance": "key",
+    "relatedConcepts": ["maximum entropy principle", "fair coin", "bit as unit of information", "Shannon's source coding theorem"],
+    "prerequisites": ["Real.log_inv", "div_self"]
+  },
+  {
+    "id": "ann-mul-log-nonpos",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 76, "endLine": 79 },
+    "type": "technique",
+    "title": "Helper: Product Sign Analysis",
+    "content": "Establishes that t·log(t) ≤ 0 for t ∈ (0,1] by sign analysis: t > 0 and log(t) ≤ 0 for t ≤ 1 (since log is monotone and log 1 = 0). This helper lemma is the workhorse for non-negativity, isolating the sign analysis that makes h(p) = -(negative + negative) ≥ 0.",
+    "mathContext": "For $0 < t \\leq 1$: $t \\cdot \\ln t \\leq 0$, since $t > 0$ and $\\ln t \\leq 0$.",
+    "significance": "technical",
+    "relatedConcepts": ["sign analysis", "logarithm monotonicity", "mul_nonpos_of_nonneg_of_nonpos"],
+    "prerequisites": ["Real.log_nonpos"]
+  },
+  {
+    "id": "ann-nonneg",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 81, "endLine": 90 },
+    "type": "concept",
+    "title": "Non-negativity: Entropy Cannot Be Negative",
+    "content": "Proves h(p) ≥ 0 for p ∈ [0,1] by case-splitting on boundary vs interior. For interior points, both p·log(p) and (1-p)·log(1-p) are non-positive (by the helper lemma), so their negated sum is non-negative. Boundary cases p = 0 and p = 1 reduce to h_zero and h_one. This is the foundational inequality of information theory: uncertainty is always non-negative.",
+    "mathContext": "$h(p) \\geq 0$ for $p \\in [0,1]$. Decomposition: $h(p) = \\underbrace{(-p \\ln p)}_{\\geq 0} + \\underbrace{(-(1-p)\\ln(1-p))}_{\\geq 0}$.",
+    "significance": "key",
+    "relatedConcepts": ["Gibbs inequality", "entropy non-negativity", "information measure axioms"],
+    "prerequisites": ["mul_log_nonpos helper", "case analysis on endpoints"]
+  },
+  {
+    "id": "ann-kl-term-bound",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 96, "endLine": 109 },
+    "type": "technique",
+    "title": "KL Divergence Term Bound: The Gibbs Inequality Kernel",
+    "content": "Proves the fundamental inequality p·log(p/q) ≥ p - q for p, q > 0, which is the atomic building block of the Gibbs inequality (KL divergence non-negativity). The proof reduces to log(x) ≤ x - 1 applied to x = q/p, then negates to get the reverse direction. This is the single most reused inequality in information theory — it implies data processing, Fano's, and all entropy bounds.",
+    "mathContext": "$p \\ln(p/q) \\geq p - q$ for $p, q > 0$. Derived from $\\ln x \\leq x - 1$ applied to $x = q/p$: $p \\ln(q/p) \\leq p(q/p - 1) = q - p$, then $p \\ln(p/q) = -p \\ln(q/p) \\geq p - q$.",
+    "significance": "key",
+    "relatedConcepts": ["Kullback-Leibler divergence", "Gibbs inequality", "log-sum inequality", "information inequality"],
+    "prerequisites": ["Real.log_le_sub_one_of_pos", "logarithm quotient rules"]
+  },
+  {
+    "id": "ann-upper-bound",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 111, "endLine": 145 },
+    "type": "technique",
+    "title": "Upper Bound via Binary Gibbs Inequality",
+    "content": "Proves the sharp upper bound h(p) ≤ ln 2 by applying the KL term bound twice with uniform reference measure q = 1/2. Setting q = 1/2 for both p and 1-p gives: p·log(2p) ≥ p - 1/2 and (1-p)·log(2(1-p)) ≥ (1-p) - 1/2. Expanding log(2p) = log 2 + log p and summing yields log 2 + p·log p + (1-p)·log(1-p) ≥ 0, which rearranges to h(p) ≤ log 2. This is precisely KL(Bernoulli(p) ∥ Uniform) ≥ 0.",
+    "mathContext": "$h(p) \\leq \\ln 2$ via $D_{\\mathrm{KL}}(\\mathrm{Ber}(p) \\| \\mathrm{Uniform}) = \\ln 2 - h(p) \\geq 0$. The key expansion: $\\ln(2p) = \\ln 2 + \\ln p$.",
+    "significance": "key",
+    "relatedConcepts": ["maximum entropy principle", "KL divergence", "uniform distribution optimality", "binary symmetric channel capacity"],
+    "prerequisites": ["kl_term_bound", "logarithm product rule"]
+  },
+  {
+    "id": "ann-zero-char",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 157, "endLine": 183 },
+    "type": "insight",
+    "title": "Zero Entropy Characterization: Only Deterministic Sources",
+    "content": "Proves the if-and-only-if characterization h(p) = 0 ⟺ p ∈ {0,1}. The reverse direction is trivial (boundary values). The forward direction uses strict negativity: for 0 < p < 1, both log(p) < 0 and log(1-p) < 0 (via log_lt_log and log 1 = 0), making both terms p·log p and (1-p)·log(1-p) strictly negative — their sum cannot vanish. This is the entropy analog of saying 'the only certain events are those with probability 0 or 1'.",
+    "mathContext": "$h(p) = 0 \\iff p \\in \\{0, 1\\}$. For $0 < p < 1$: $\\ln p < \\ln 1 = 0$ and $\\ln(1-p) < 0$, so $p \\ln p < 0$ and $(1-p)\\ln(1-p) < 0$.",
+    "significance": "key",
+    "relatedConcepts": ["strict positivity of entropy", "deterministic distributions", "support of probability measures"],
+    "prerequisites": ["Real.log_lt_log for strict monotonicity", "mul_neg_of_pos_of_neg"]
+  },
+  {
+    "id": "ann-concavity",
+    "proofId": "shannon-channel-coding-oq-04",
+    "range": { "startLine": 189, "endLine": 222 },
+    "type": "technique",
+    "title": "Concavity from Mathlib's Convexity of x·log(x)",
+    "content": "Proves ConcaveOn ℝ (Set.Icc 0 1) h by leveraging Mathlib's convexOn_mul_log (x·log x is convex on [0,∞)). The key insight: h(p) = -f(p) - f(1-p) where f(x) = x·log x. Convexity of f gives two inequalities — one at points (x,y) and one at (1-x, 1-y). The affine substitution a(1-x) + b(1-y) = 1 - (ax + by) connects the second application. Adding both inequalities and negating yields the concavity of h. This is the standard 'entropy is concave' proof adapted to Lean's algebraic framework.",
+    "mathContext": "$h$ is concave on $[0,1]$: for $a + b = 1$, $a,b \\geq 0$,\n$$h(ax + by) \\geq a \\cdot h(x) + b \\cdot h(y)$$\nProved via: $f(x) = x \\ln x$ convex $\\Rightarrow$ $-f(x) - f(1-x)$ concave, using the identity $a(1-x) + b(1-y) = 1 - (ax+by)$.",
+    "significance": "key",
+    "relatedConcepts": ["convexity of neg-entropy", "Jensen's inequality", "mixing increases entropy", "Schur concavity"],
+    "prerequisites": ["convexOn_mul_log from Mathlib", "affine combinations", "convex_Icc"]
+  }
+]

--- a/src/data/proofs/shannon-channel-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04/meta.json
@@ -65,7 +65,9 @@
     "keyInsights": [
       "The 0·log(0) = 0 convention is automatic in Lean via Mathlib's Real.log 0 = 0, avoiding the need for conditional definitions",
       "The upper bound h(p) ≤ log 2 is equivalent to KL divergence non-negativity for binary distributions against uniform — the log(x) ≤ x-1 inequality is the universal tool",
-      "Concavity decomposes into two applications of convexity of x·log(x), one for each 'leg' of h(p) = f(p) + f(1-p) where f(x) = -x·log(x), connected by the affine identity on weights"
+      "Concavity decomposes into two applications of convexity of x·log(x), one for each 'leg' of h(p) = f(p) + f(1-p) where f(x) = -x·log(x), connected by the affine identity on weights",
+      "The zero characterization h(p)=0 iff p∈{0,1} uses strict log monotonicity to upgrade the non-negativity proof: the same sign argument that gives ≤ 0 becomes < 0 in the interior, forcing both terms to be simultaneously zero only at the boundary",
+      "The symmetry h(p) = h(1-p) is proved purely by ring arithmetic with no analysis, reflecting that entropy depends only on the multiset of probabilities — relabeling outcomes cannot change information content"
     ]
   },
   "sections": [
@@ -144,6 +146,11 @@
       "targetId": "shannon-entropy",
       "relationship": "specializes",
       "description": "Binary entropy is Shannon entropy for the Bernoulli(p) distribution on {0,1}"
+    },
+    {
+      "targetId": "shannon-source-coding",
+      "relationship": "supports",
+      "description": "Binary entropy h(p) determines the optimal compression rate for a Bernoulli(p) source via Shannon's source coding theorem"
     }
   ],
   "conclusion": {
@@ -158,7 +165,8 @@
   "relatedProofs": [
     "shannon-channel-coding",
     "shannon-entropy",
-    "shannon-source-coding"
+    "shannon-source-coding",
+    "shannon-source-coding-oq-02"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary
- Created 10 comprehensive annotations covering the entire binary entropy proof (annotations.json was previously empty)
- Each annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`
- Added 2 additional `keyInsights` to meta.json (now 5 total)
- Added cross-reference to `shannon-source-coding` and `shannon-source-coding-oq-02`

## Key annotations added
- **Binary entropy definition**: 0·log 0 convention via Mathlib
- **KL divergence term bound**: The Gibbs inequality kernel (log x ≤ x-1)
- **Upper bound via binary Gibbs inequality**: KL(Ber(p) ∥ Uniform) ≥ 0
- **Concavity from convexOn_mul_log**: Two-leg decomposition technique
- **Zero characterization**: Strict log monotonicity upgrade

## Test plan
- [x] JSON validation passes (node -e JSON.parse)
- [x] No annotation build errors for this entry
- [x] Pre-existing build issues (candidate-pool.json, 3502 legacy annotation warnings) are unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)