### PR TITLE
Enrich cantors-theorem-oq-03: add 11 annotations, deepen conclusion

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-03/annotations.json
+++ b/src/data/proofs/cantors-theorem-oq-03/annotations.json
@@ -1,1 +1,134 @@
-[]
+[
+  {
+    "id": "ann-konig-principle",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 70, "endLine": 82 },
+    "type": "technique",
+    "title": "König's Diagonal Principle",
+    "content": "The core theorem of Level 3: no function from a dependent sum $\\Sigma_i \\alpha_i$ to a dependent product $\\Pi_i \\beta_i$ is surjective when each coordinate allows dodging. The proof uses Lean's `choose` tactic to extract the dodge function from the existential hypothesis, then obtains a preimage via surjectivity and derives a contradiction at the witness coordinate. This is the heterogeneous generalization — different types $\\beta_i$ at each index, unlike Lawvere's uniform setting.",
+    "mathContext": "For $f : (\\Sigma_i \\alpha_i) \\to (\\Pi_i \\beta_i)$, if $\\forall i,\\, \\exists b_i \\in \\beta_i,\\, \\forall a \\in \\alpha_i,\\, f(\\langle i, a \\rangle)(i) \\neq b_i$, then $f$ is not surjective. The diagonal witness is $d(i) = b_i$.",
+    "significance": "key",
+    "relatedConcepts": ["König's theorem", "dependent types", "diagonal argument", "cardinal arithmetic", "surjectivity"],
+    "prerequisites": ["Sigma types", "Pi types", "surjective functions", "choice principle"]
+  },
+  {
+    "id": "ann-konig-witness",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 84, "endLine": 92 },
+    "type": "technique",
+    "title": "König's Explicit Witness Construction",
+    "content": "An explicit form of König's principle: given a concrete dodge function, the diagonal element differs from every value in the range of $f$ at the witness's own coordinate. The proof destructs the sigma pair $\\langle j, a \\rangle$ and applies `congr_fun` to extract the pointwise equality at index $j$, contradicting the dodge hypothesis. This constructive formulation is useful for extracting the actual diagonal element.",
+    "mathContext": "Given explicit $\\text{dodge} : \\Pi_i \\beta_i$ with $f(\\langle i, a\\rangle)(i) \\neq \\text{dodge}(i)$ for all $i, a$, then $\\forall s \\in \\Sigma_i \\alpha_i,\\, f(s) \\neq \\text{dodge}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["constructive witness", "function extensionality", "congr_fun"],
+    "prerequisites": ["dependent pattern matching", "function extensionality"]
+  },
+  {
+    "id": "ann-konig-column",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 94, "endLine": 108 },
+    "type": "insight",
+    "title": "König via Column Non-Surjectivity",
+    "content": "A cardinality-flavored reformulation of König's principle: if no column projection $\\text{col}_i(a) = f(\\langle i, a \\rangle)(i)$ is surjective, then $f$ itself is not surjective. This makes the connection to cardinal arithmetic explicit — when $|\\alpha_i| < |\\beta_i|$, the column at index $i$ maps fewer elements than the target has, so it must miss something. The proof reduces to `konig_principle` via `by_contra` and `push_neg`, extracting the missed elements from non-surjectivity.",
+    "mathContext": "If $\\text{col}_i : \\alpha_i \\to \\beta_i$ defined by $\\text{col}_i(a) = f(\\langle i, a \\rangle)(i)$ is not surjective for any $i$, then $f$ is not surjective. This is the type-theoretic form of König's inequality $\\sum_i \\kappa_i < \\prod_i \\lambda_i$.",
+    "significance": "key",
+    "relatedConcepts": ["cardinal arithmetic", "column projection", "cardinality comparison", "König's inequality"],
+    "prerequisites": ["surjectivity", "König's principle", "push_neg tactic"]
+  },
+  {
+    "id": "ann-coordinate-diagonal",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 127, "endLine": 135 },
+    "type": "technique",
+    "title": "The Coordinate Diagonal (Level 2)",
+    "content": "The intermediate diagonal: for $f : \\iota \\to \\iota \\to \\beta$ (same target type $\\beta$ everywhere), if $\\text{dodge}(i) \\neq f(i)(i)$ for all $i$, then dodge is not in the range of $f$. Unlike Lawvere, the dodge values need not come from a single fixed-point-free map — each coordinate dodges independently. Unlike König, the target type is the same at every index. The proof obtains a preimage $n$ with $f(n) = \\text{dodge}$ and evaluates at position $n$ to get the contradiction.",
+    "mathContext": "For $f : \\iota \\to (\\iota \\to \\beta)$, if $\\text{dodge}(i) \\neq f(i)(i)$ for all $i \\in \\iota$, then $\\text{dodge} \\notin \\text{range}(f)$. The dodge function is arbitrary — it need not be $g \\circ \\text{diag}(f)$ for any fixed $g$.",
+    "significance": "key",
+    "relatedConcepts": ["diagonal argument", "Cantor's theorem", "non-surjectivity", "pointwise construction"],
+    "prerequisites": ["function spaces", "surjectivity"]
+  },
+  {
+    "id": "ann-lawvere-derivation",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 157, "endLine": 163 },
+    "type": "insight",
+    "title": "Lawvere's FPT as Coordinate Diagonal Special Case",
+    "content": "Lawvere's Fixed-Point Theorem is a one-line consequence of the coordinate diagonal: a fixed-point-free $g : \\beta \\to \\beta$ provides the uniform dodge strategy $d(i) = g(f(i)(i))$. Since $g$ has no fixed point, $g(f(i)(i)) \\neq f(i)(i)$ for all $i$, satisfying the coordinate diagonal hypothesis. This derivation makes the hierarchy crystal clear — Lawvere is the UNIFORM special case of the POINTWISE coordinate diagonal.",
+    "mathContext": "Given $g : \\beta \\to \\beta$ with $g(b) \\neq b$ for all $b$, set $\\text{dodge}(i) = g(f(i)(i))$. Then $\\text{dodge}(i) = g(f(i)(i)) \\neq f(i)(i)$, so coordinate_diagonal applies.",
+    "significance": "key",
+    "relatedConcepts": ["Lawvere's fixed-point theorem", "fixed-point-free maps", "categorical diagonal argument"],
+    "prerequisites": ["coordinate diagonal", "fixed-point-free endomorphisms"]
+  },
+  {
+    "id": "ann-not-fpf",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 165, "endLine": 172 },
+    "type": "concept",
+    "title": "Negation on Prop is Fixed-Point-Free",
+    "content": "Proves there is no proposition $p$ with $\\neg p = p$ — the engine behind Cantor's theorem and Russell's paradox. The proof is a beautiful self-referential argument: assuming $\\neg p = p$, we get both directions ($\\neg p \\to p$ and $p \\to \\neg p$) by transport, then construct $\\neg p$ as $\\lambda h.\\, (p \\to \\neg p)(h)(h)$, and apply it to its own consequence. This is the Lean formalization of the classical liar-style diagonal.",
+    "mathContext": "For all $p : \\text{Prop}$, $\\neg p \\neq p$. Proof by contradiction: if $\\neg p = p$, then $p \\to \\neg p$ and $\\neg p \\to p$, giving $\\neg p := \\lambda h.\\, h_2(h)(h)$ and then $h_1(\\neg p)$ yields $p$ while $\\neg p$ yields $\\neg p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Russell's paradox", "liar paradox", "Curry's paradox", "propositional negation"],
+    "prerequisites": ["propositional logic", "Eq.mp transport"]
+  },
+  {
+    "id": "ann-cantor-instances",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 174, "endLine": 187 },
+    "type": "concept",
+    "title": "Cantor's Theorem for Bool, Prop, and Set",
+    "content": "Three instantiations of Lawvere's theorem yield Cantor's theorem in its classical forms. For Bool, the fixed-point-free map is negation ($!b \\neq b$, decided by case analysis). For Prop, it is logical negation ($\\neg p \\neq p$, proved above). For Set, the result follows immediately since $\\text{Set}\\,\\alpha = \\alpha \\to \\text{Prop}$. This chain shows how one abstract principle — Lawvere — generates all classical non-enumerability results.",
+    "mathContext": "No surjection $\\alpha \\to (\\alpha \\to \\text{Bool})$, $\\alpha \\to (\\alpha \\to \\text{Prop})$, or $\\alpha \\to \\text{Set}\\,\\alpha$ exists. Each uses Lawvere with the appropriate fixed-point-free negation: $!$ on Bool, $\\neg$ on Prop.",
+    "significance": "key",
+    "relatedConcepts": ["Cantor's theorem", "power set", "Boolean negation", "propositional negation", "Set type"],
+    "prerequisites": ["Lawvere's fixed-point theorem", "Bool decidability", "Set α = α → Prop"]
+  },
+  {
+    "id": "ann-fpf-maps",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 207, "endLine": 214 },
+    "type": "definition",
+    "title": "Fixed-Point-Free Endomorphisms on Bool, ℕ, and ℤ",
+    "content": "Three concrete fixed-point-free endomorphisms: Bool negation ($!b \\neq b$, by `decide`), ℕ successor ($n+1 \\neq n$, by `omega`), and ℤ successor ($n+1 \\neq n$, by `omega`). These are the building blocks for applying the diagonal to arithmetic types. The `decide` and `omega` tactics handle the proofs automatically — Bool by enumeration, and ℕ/ℤ by linear arithmetic. Each endomorphism enables a different flavor of uncountability result.",
+    "mathContext": "$!b \\neq b$ for $b : \\text{Bool}$; $n + 1 \\neq n$ for $n : \\mathbb{N}$; $n + 1 \\neq n$ for $n : \\mathbb{Z}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fixed-point-free maps", "successor function", "Boolean negation", "omega tactic", "decide tactic"],
+    "prerequisites": ["Bool type", "natural number arithmetic", "integer arithmetic"]
+  },
+  {
+    "id": "ann-master-theorem",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 216, "endLine": 225 },
+    "type": "insight",
+    "title": "Master Theorem: FPF Maps Imply Non-Enumerability",
+    "content": "The unifying principle: ANY type $\\beta$ with a fixed-point-free endomorphism $g$ satisfies non-enumerability — for all $\\alpha$, no $f : \\alpha \\to (\\alpha \\to \\beta)$ is surjective. This characterizes exactly which types support the diagonal argument: those admitting an endomorphism without fixed points. The theorem is a direct wrapper around `lawvere_from_diagonal`, elevating it to a universal statement about types.",
+    "mathContext": "If $\\exists\\, g : \\beta \\to \\beta$ with $\\forall b,\\, g(b) \\neq b$, then $\\forall \\alpha,\\, \\forall f : \\alpha \\to (\\alpha \\to \\beta),\\, f$ is not surjective. Equivalently: $|\\alpha| < |\\alpha \\to \\beta|$ whenever $\\beta$ has a fixed-point-free endomorphism.",
+    "significance": "key",
+    "relatedConcepts": ["non-enumerability", "cardinality", "function spaces", "type characterization"],
+    "prerequisites": ["Lawvere's fixed-point theorem", "fixed-point-free endomorphisms"]
+  },
+  {
+    "id": "ann-uncountability",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 239, "endLine": 248 },
+    "type": "concept",
+    "title": "Uncountability of ℕ→ℕ and ℕ→ℤ via Successor Diagonal",
+    "content": "Concrete applications of the master theorem: no surjection $\\mathbb{N} \\to (\\mathbb{N} \\to \\mathbb{N})$ or $\\mathbb{N} \\to (\\mathbb{N} \\to \\mathbb{Z})$ exists. The diagonal element is $d(n) = f(n)(n) + 1$, using SUCCESSOR rather than complementation. This goes beyond Cantor's original set-theoretic argument — the uncountability of $\\mathbb{N}^\\mathbb{N}$ follows from an arithmetic operation (adding 1), not from set-membership negation. The same technique would work for any type with $\\geq 2$ elements.",
+    "mathContext": "No surjection $\\mathbb{N} \\to (\\mathbb{N} \\to \\mathbb{N})$: the diagonal $d(n) = f(n)(n) + 1$ differs from $f(n)$ at position $n$ since $n + 1 \\neq n$. Similarly for $\\mathbb{N} \\to (\\mathbb{N} \\to \\mathbb{Z})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["uncountability", "Baire space", "sequence spaces", "successor diagonal"],
+    "prerequisites": ["master theorem", "ℕ successor is fixed-point-free"]
+  },
+  {
+    "id": "ann-konig-implies-lawvere",
+    "proofId": "cantors-theorem-oq-03",
+    "range": { "startLine": 250, "endLine": 274 },
+    "type": "technique",
+    "title": "König Implies Lawvere: Completing the Hierarchy",
+    "content": "The capstone theorem proving König (Level 3) ⟹ Lawvere (Level 1), completing the hierarchy König ⟹ Coordinate ⟹ Lawvere. The key encoding: view $f : \\alpha \\to (\\alpha \\to \\beta)$ as a König map with constant fibers $\\alpha_i = \\text{Unit}$ (singletons) and $\\beta_i = \\beta$. Each column maps one element (from Unit) into $\\beta$, and since $g : \\beta \\to \\beta$ is fixed-point-free, each column misses $g(f(a)(a))$. The surjectivity transfer argument concludes: if $f$ were surjective, the König encoding $f'$ would be too, contradicting König's principle.",
+    "mathContext": "Encode $f : \\alpha \\to (\\alpha \\to \\beta)$ as $f' : (\\Sigma_{a : \\alpha} \\text{Unit}) \\to (\\alpha \\to \\beta)$ via $f'(\\langle a, ()\\rangle) = f(a)$. The column at $a$ maps $\\text{Unit}$ to $\\beta$ via $() \\mapsto f(a)(a)$, missing $g(f(a)(a))$. König's principle gives $\\neg\\text{Surjective}(f')$, which transfers to $\\neg\\text{Surjective}(f)$.",
+    "significance": "key",
+    "relatedConcepts": ["König's theorem", "Lawvere's fixed-point theorem", "Unit type", "hierarchy completion"],
+    "prerequisites": ["König's principle", "Lawvere's fixed-point theorem", "dependent type encoding"]
+  }
+]

--- a/src/data/proofs/cantors-theorem-oq-03/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-03/meta.json
@@ -56,8 +56,12 @@
     ],
     "relatedProblems": [
       {
-        "id": "cantors-theorem-oq-03",
-        "relationship": "This proof"
+        "id": "cantors-theorem-oq-02",
+        "relationship": "Predecessor in the OQ chain — Lawvere's FPT (Level 1)"
+      },
+      {
+        "id": "cantor-diagonalization-oq-01",
+        "relationship": "König's inequality constrains answers to the Continuum Hypothesis"
       }
     ]
   },
@@ -125,18 +129,40 @@
   ],
   "conclusion": {
     "summary": "The diagonal argument is not one technique but a hierarchy of three levels: Lawvere (uniform dodge via fixed-point-free map), Coordinate (pointwise dodge), and König (heterogeneous types and dodges). König captures cardinal arithmetic, Cantor and Lawvere are special cases, and the argument works on any type with a fixed-point-free endomorphism.",
-    "significance": "Formalizes the complete hierarchy of diagonal arguments in Lean 4 with 0 axioms and 0 sorries. Shows König's theorem as the natural generalization of Cantor's diagonal to indexed families, connecting type theory to cardinal arithmetic."
+    "significance": "Formalizes the complete hierarchy of diagonal arguments in Lean 4 with 0 axioms and 0 sorries. Shows König's theorem as the natural generalization of Cantor's diagonal to indexed families, connecting type theory to cardinal arithmetic.",
+    "implications": "This hierarchy provides a principled framework for classifying ALL diagonal arguments: any new diagonal construction can be placed at Level 1 (uniform), Level 2 (pointwise), or Level 3 (heterogeneous). The master theorem characterizes exactly which types support diagonalization — those admitting fixed-point-free endomorphisms — giving a type-theoretic criterion for non-enumerability. The König–Lawvere connection also bridges cardinal arithmetic and category theory: König's cardinal inequality becomes a statement about surjectivity of dependent type maps.",
+    "openQuestions": [
+      "Is there a Level 4 beyond König? Could allowing the INDEX type to vary (e.g., transfinite induction over ordinal-indexed families) yield strictly stronger diagonal arguments?",
+      "Can the fixed-point-free characterization be extended to higher-order types — does the diagonal argument for (α → β) → γ require a different structural condition than g : β → β with no fixed point?",
+      "What is the constructive content of König's theorem? The classical proof uses choice to extract dodge elements — does a fully constructive version require weaker hypotheses or yield weaker conclusions?",
+      "Can this hierarchy be lifted to an ∞-categorical setting? Lawvere's theorem generalizes to cartesian closed categories, but does König's heterogeneous version have a natural topos-theoretic formulation?"
+    ]
   },
   "crossReferences": [
     {
       "targetId": "cantors-theorem",
       "relationship": "extends",
-      "description": "Cantor's theorem is Level 1 of the hierarchy (Lawvere with negation)"
+      "description": "Cantor's theorem (|A| < |P(A)|) is Level 1 of the hierarchy — the Lawvere instantiation with Bool/Prop negation"
     },
     {
       "targetId": "cantors-theorem-oq-02",
       "relationship": "extends",
-      "description": "OQ-02's Lawvere framework is Level 1; OQ-03 adds Levels 2 (Coordinate) and 3 (König)"
+      "description": "OQ-02 formalizes Lawvere's FPT (Level 1); OQ-03 adds Level 2 (Coordinate Diagonal) and Level 3 (König's heterogeneous principle)"
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "generalizes",
+      "description": "Cantor's 1891 diagonalization of binary sequences is the Bool instantiation of the coordinate diagonal (Level 2)"
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-01",
+      "relationship": "related",
+      "description": "The Continuum Hypothesis asks what lies between ℵ₀ and 2^ℵ₀ — König's inequality Σκᵢ < Πλᵢ constrains possible answers"
+    },
+    {
+      "targetId": "cantors-theorem-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 studies |P(ℝ)| = ℶ₂ — König's theorem constrains its aleph-index via the cofinality bound"
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary
- Added 11 rich annotations (from 0) with mathContext, significance, relatedConcepts, and prerequisites covering all 5 parts of the diagonal hierarchy proof
- Expanded conclusion with `implications` and 4 `openQuestions` (Level 4 beyond König, higher-order types, constructive content, ∞-categorical formulation)
- Added 3 new cross-references to cantor-diagonalization, cantor-diagonalization-oq-01 (CH connection), and cantors-theorem-oq-01 (P(ℝ) connection)
- Fixed self-referencing relatedProblems entry

## Axiom integrity check
Verified: 0 axioms, 0 sorries, status "verified", badge "original" — all correct for this fully machine-checked proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)