### PR TITLE
Enrich 6 proofs: sections mathContext, new annotations, line fixes

### DIFF
--- a/src/data/proofs/erdos-557/meta.json
+++ b/src/data/proofs/erdos-557/meta.json
@@ -28,42 +28,48 @@
       "title": "Problem Statement and Imports",
       "summary": "Documentation header with problem statement, star lower bound, path results, Burr-Erdős connection, references, and Mathlib imports for SimpleGraph",
       "startLine": 1,
-      "endLine": 27
+      "endLine": 27,
+      "mathContext": "Conjecture: $\\exists C, \\forall T, k: R(T; k) \\leq kn + C$ where $T$ is a tree on $n$ vertices"
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions: Trees, Colorings, Ramsey Numbers",
       "summary": "Tree structure on Fin n, EdgeColoring as m→m→Fin k, HasMonochromaticCopy via injective embedding with uniform color, multicolorRamseyTree with Nat.find, axiomatized ramseyTree with spec and minimality",
       "startLine": 29,
-      "endLine": 64
+      "endLine": 64,
+      "mathContext": "$R(T; k) = \\min\\{m : \\text{every } k\\text{-coloring of } K_m \\text{ contains a monochromatic copy of } T\\}$"
     },
     {
       "id": "main-conjecture",
       "title": "Erdős Problem #557: Linear Bound Conjecture (OPEN)",
       "summary": "erdos_557_conjecture axiom: ∃ C, R(T;k) ≤ k·n + C for all trees T on n vertices, all k ≥ 1",
       "startLine": 66,
-      "endLine": 72
+      "endLine": 72,
+      "mathContext": "$\\exists C \\in \\mathbb{N}, \\forall T \\text{ tree on } n \\text{ vertices}, \\forall k \\geq 1: R(T; k) \\leq kn + C$"
     },
     {
       "id": "star-lower-bound",
       "title": "Star Lower Bound: R(S_n; k) >= k(n-1) + 1",
       "summary": "starTree defines K_{1,n-1} with center vertex 0, star_ramsey_lower axiom via pigeonhole on vertex degrees showing conjecture is tight",
       "startLine": 74,
-      "endLine": 96
+      "endLine": 96,
+      "mathContext": "$R(K_{1,n-1}; k) \\geq k(n-1) + 1$ by pigeonhole: in $K_{k(n-1)}$, some color class has $\\leq n-2$ edges at the center"
     },
     {
       "id": "known-cases",
       "title": "Known Special Cases: k=2 and Monotonicity",
       "summary": "two_color_tree_ramsey: R(T;2) ≤ 2n-2. path_two_color: Gerencsér-Gyárfás formula ⌊3(n-1)/2⌋+1. ramsey_tree_monotone_k: R(T;k) ≤ R(T;k+1)",
       "startLine": 98,
-      "endLine": 112
+      "endLine": 112,
+      "mathContext": "$R(T; 2) \\leq 2n - 2$; $R(P_n; 2) = \\lfloor 3(n-1)/2 \\rfloor + 1$ (Gerencsér-Gyárfás); $R(T; k) \\leq R(T; k+1)$"
     },
     {
       "id": "burr-erdos-connection",
       "title": "Burr-Erdős Connection and Problem #548",
       "summary": "burr_erdos_trees: Lee (2017) proved R(G;2) = O(n) for bounded degeneracy. problem_548_implies_557: multicolor Burr-Erdős for degeneracy d would resolve #557 for trees (d=1)",
       "startLine": 114,
-      "endLine": 129
+      "endLine": 129,
+      "mathContext": "Burr-Erdős: $R(G; 2) = O(n)$ for degeneracy-$d$ graphs (Lee 2017). Trees have $d = 1$."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
Six enrichment passes in a single PR:

### 1. leibniz-pi-oq-01-oq-01 (Machin's Formula)
- Fixed annotation line ranges, added header annotation, fixed lineCount 79→97, added sections mathContext

### 2. bezout-identity-oq-03-oq-01-oq-01-oq-01 (Ideal CRT)
- Added mathContext to all 5 sections, added 2 new annotations (now 7 total)

### 3. derangements-oq-02-oq-01 (Partial Derangements)
- Added mathContext to all 5 sections, added prerequisites to all 5 annotations

### 4. divisibility-truncation-general-oq-01 (Unified Osculator)
- Added mathContext to all 6 sections

### 5. cayley-hamilton-minpoly-oq-02-oq-01-oq-01 (Skolem-Noether)
- Added mathContext to all 8 sections (570-line proof)

### 6. erdos-557 (Multicolor Tree Ramsey)
- Added mathContext to all 6 sections

## Test plan
- [x] JSON validation passes for all entries
- [x] No new annotation build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)