### PR TITLE
Enrich leibniz-pi-oq-01-oq-01: add mathContext and header annotation

### DIFF
--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-machin-00-header",
+    "proofId": "leibniz-pi-oq-01-oq-01",
+    "range": { "startLine": 5, "endLine": 34 },
+    "type": "context",
+    "title": "Module Overview: From-Scratch Derivation of Machin's Formula",
+    "content": "This proof deliberately avoids Mathlib's pre-packaged `Real.four_mul_arctan_inv_5_sub_arctan_inv_239` to derive Machin's formula from first principles. Only three Mathlib lemmas are used: `arctan_add` (the addition formula), `arctan_neg` (parity), and `arctan_one` ($\\arctan(1) = \\pi/4$). The from-scratch approach demonstrates that any Machin-like formula can be verified by iterating these primitives. John Machin used this identity in 1706 to compute 100 digits of $\\pi$, vastly outpacing the Leibniz series $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$ which requires millions of terms for similar accuracy.",
+    "mathContext": "Machin's formula: $\\frac{\\pi}{4} = 4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239}$. The arctan series at $x = 1/5$ converges as $O(5^{-2N})$ vs $O(1/N)$ for the Leibniz series at $x = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Machin-like formulas", "pi computation", "arctan series", "Leibniz formula"],
+    "prerequisites": ["Real.arctan_add", "Real.arctan_neg", "Real.arctan_one"]
+  },
+  {
     "id": "ann-machin-01-doubling",
     "proofId": "leibniz-pi-oq-01-oq-01",
     "range": { "startLine": 34, "endLine": 39 },

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
@@ -85,29 +85,33 @@
       "id": "step1",
       "title": "Step 1: Doubling arctan(1/5)",
       "startLine": 34,
-      "endLine": 39,
-      "summary": "Proves $\\arctan(1/5) + \\arctan(1/5) = \\arctan(5/12)$ via the addition formula with $xy = 1/25 < 1$. The rational arithmetic $(2/5)/(24/25) = 5/12$ is verified by `norm_num`."
+      "endLine": 49,
+      "summary": "Proves $\\arctan(1/5) + \\arctan(1/5) = \\arctan(5/12)$ via the addition formula with $xy = 1/25 < 1$. The rational arithmetic $(2/5)/(24/25) = 5/12$ is verified by `norm_num`.",
+      "mathContext": "$\\arctan\\frac{1}{5} + \\arctan\\frac{1}{5} = \\arctan\\frac{5}{12}$ via $\\frac{2/5}{1 - 1/25} = \\frac{2/5}{24/25} = \\frac{5}{12}$."
     },
     {
       "id": "step2",
       "title": "Step 2: Doubling to arctan(120/119)",
-      "startLine": 41,
-      "endLine": 53,
-      "summary": "Proves $4 \\cdot \\arctan(1/5) = \\arctan(120/119)$ by expressing $4 \\cdot \\arctan(1/5) = 2 \\cdot \\arctan(5/12)$ and applying the addition formula again with $xy = 25/144 < 1$."
+      "startLine": 51,
+      "endLine": 65,
+      "summary": "Proves $4 \\cdot \\arctan(1/5) = \\arctan(120/119)$ by expressing $4 \\cdot \\arctan(1/5) = 2 \\cdot \\arctan(5/12)$ and applying the addition formula again with $xy = 25/144 < 1$.",
+      "mathContext": "$4\\arctan\\frac{1}{5} = 2\\arctan\\frac{5}{12} = \\arctan\\frac{120}{119}$ via $\\frac{10/12}{119/144} = \\frac{120}{119}$."
     },
     {
       "id": "step3",
       "title": "Step 3: Subtracting arctan(1/239)",
-      "startLine": 55,
-      "endLine": 70,
-      "summary": "Proves $\\arctan(120/119) - \\arctan(1/239) = \\arctan(1)$ by rewriting the subtraction as addition of $\\arctan(-1/239)$ and applying arctan_add. The key computation: $(28561/28441)/(28561/28441) = 1$."
+      "startLine": 67,
+      "endLine": 84,
+      "summary": "Proves $\\arctan(120/119) - \\arctan(1/239) = \\arctan(1)$ by rewriting the subtraction as addition of $\\arctan(-1/239)$ and applying arctan_add. The key computation: $(28561/28441)/(28561/28441) = 1$.",
+      "mathContext": "$\\frac{120/119 - 1/239}{1 + 120/(119 \\cdot 239)} = \\frac{28561/28441}{28561/28441} = 1$ where $28561 = 169^2$."
     },
     {
       "id": "main",
       "title": "Machin's Formula",
-      "startLine": 72,
-      "endLine": 79,
-      "summary": "Combines Steps 1-3 to prove $4 \\cdot \\arctan(1/5) - \\arctan(1/239) = \\pi/4$ in one line: rewrite via `four_arctan_inv_5` and `arctan_diff_eq_arctan_one`, then apply `arctan_one`."
+      "startLine": 86,
+      "endLine": 97,
+      "summary": "Combines Steps 1-3 to prove $4 \\cdot \\arctan(1/5) - \\arctan(1/239) = \\pi/4$ in one line: rewrite via `four_arctan_inv_5` and `arctan_diff_eq_arctan_one`, then apply `arctan_one`.",
+      "mathContext": "$\\frac{\\pi}{4} = 4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239}$ — Machin's formula (1706)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added `mathContext` with LaTeX to all 4 sections
- Fixed section line ranges to match actual Lean file (lines shifted from meta)
- Added header context annotation covering module overview and convergence comparison
- Total annotations: 4 → 5

## Test plan
- [x] JSON validates
- [x] No annotation build errors for this entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)