### PR TITLE
Enrich leibniz-pi-oq-01-oq-01: fix annotation ranges, add preamble section, deepen cross-references

### DIFF
--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/annotations.json
@@ -14,10 +14,10 @@
   {
     "id": "ann-machin-01-doubling",
     "proofId": "leibniz-pi-oq-01-oq-01",
-    "range": { "startLine": 34, "endLine": 39 },
+    "range": { "startLine": 40, "endLine": 49 },
     "type": "technique",
     "title": "Doubling via Addition Formula",
-    "content": "two_arctan_inv_5 applies arctan_add with x = y = 1/5. The condition xy = 1/25 < 1 is trivially satisfied. The rational arithmetic (1/5 + 1/5)/(1 - 1/25) = (2/5)/(24/25) = 50/120 = 5/12 is verified by norm_num. This is the first of three applications of the addition formula.",
+    "content": "two_arctan_inv_5 applies arctan_add with x = y = 1/5. The condition xy = 1/25 < 1 is trivially satisfied. The rational arithmetic (1/5 + 1/5)/(1 - 1/25) = (2/5)/(24/25) = 50/120 = 5/12 is verified by norm_num. This is the first of three applications of the addition formula. The `congr 1` tactic reduces the arctan equality to equality of the arguments, which `norm_num` then verifies as pure rational arithmetic.",
     "mathContext": "$\\arctan\\frac{1}{5} + \\arctan\\frac{1}{5} = \\arctan\\frac{\\frac{1}{5}+\\frac{1}{5}}{1-\\frac{1}{5}\\cdot\\frac{1}{5}} = \\arctan\\frac{2/5}{24/25} = \\arctan\\frac{5}{12}$",
     "significance": "key",
     "relatedConcepts": ["arctan_add", "norm_num", "rational arithmetic"],
@@ -26,7 +26,7 @@
   {
     "id": "ann-machin-02-quadrupling",
     "proofId": "leibniz-pi-oq-01-oq-01",
-    "range": { "startLine": 41, "endLine": 53 },
+    "range": { "startLine": 51, "endLine": 65 },
     "type": "concept",
     "title": "Quadrupling: 4*arctan(1/5) = arctan(120/119)",
     "content": "four_arctan_inv_5 expresses 4*arctan(1/5) as two copies of the doubled result, then applies arctan_add with x = y = 5/12. The condition xy = 25/144 < 1 holds. The key computation: (10/12)/(119/144) = 1440/1428 = 120/119. The number 120/119 is remarkably close to 1, which is why the final step works.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-machin-03-subtraction",
     "proofId": "leibniz-pi-oq-01-oq-01",
-    "range": { "startLine": 55, "endLine": 70 },
+    "range": { "startLine": 67, "endLine": 84 },
     "type": "concept",
     "title": "The 28561 Coincidence",
     "content": "arctan_diff_eq_arctan_one handles the subtraction by converting it to addition: arctan(a) - arctan(b) = arctan(a) + arctan(-b) via arctan_neg. Then arctan_add applies with x = 120/119, y = -1/239. The product xy = -120/28441 < 1 trivially. The beautiful numerical coincidence: 120*239 - 119 = 28561 and 119*239 + 120 = 28561, where 28561 = 169^2 = (13^2)^2. So numerator and denominator of the addition formula are both 28561/28441, giving a ratio of exactly 1.",
@@ -50,10 +50,10 @@
   {
     "id": "ann-machin-04-finale",
     "proofId": "leibniz-pi-oq-01-oq-01",
-    "range": { "startLine": 72, "endLine": 79 },
+    "range": { "startLine": 86, "endLine": 97 },
     "type": "insight",
     "title": "One-Line Assembly",
-    "content": "The final theorem machin_formula chains Steps 1-3 in a single rewrite sequence: rw [four_arctan_inv_5, arctan_diff_eq_arctan_one, arctan_one]. This illustrates the power of compositional proof: once each step is established, the final result is trivial. The proof uses only three Mathlib lemmas (arctan_add, arctan_neg, arctan_one) and pure rational arithmetic.",
+    "content": "The final theorem machin_formula chains Steps 1-3 in a single rewrite sequence: `rw [four_arctan_inv_5, arctan_diff_eq_arctan_one, arctan_one]`. This illustrates the power of compositional proof: once each step is established, the final result is trivial. The proof uses only three Mathlib lemmas (arctan_add, arctan_neg, arctan_one) and pure rational arithmetic. Historically, this identity enabled Machin to compute 100 digits of $\\pi$ in 1706, and William Shanks later extended the computation to 707 digits (with an error after digit 527, discovered by D.F. Ferguson in 1946 using a desk calculator).",
     "mathContext": "$4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239} = \\arctan\\frac{120}{119} - \\arctan\\frac{1}{239} = \\arctan 1 = \\frac{\\pi}{4}$",
     "significance": "supporting",
     "relatedConcepts": ["compositional proof", "rewrite chain", "arctan_one"],

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
@@ -77,14 +77,23 @@
       "The key numerical coincidence: 120*239 - 119 = 119*239 + 120 = 28561 = 169^2, making the final fraction exactly 1",
       "The subtraction arctan(a) - arctan(b) is handled by arctan_neg + arctan_add, converting to arctan(a) + arctan(-b)",
       "All three applications of arctan_add have xy < 1 trivially satisfied (either both factors < 1, or one factor is negative)",
-      "The proof technique generalizes: any Machin-like formula pi/4 = sum of c_i * arctan(a_i/b_i) can be verified by iterating arctan_add"
+      "The proof technique generalizes: any Machin-like formula pi/4 = sum of c_i * arctan(a_i/b_i) can be verified by iterating arctan_add",
+      "Machin's formula reduces pi computation from O(N) terms (Leibniz) to O(log N) terms: the arctan series at x = 1/5 converges as O(5^{-2N}) and at x = 1/239 as O(239^{-2N}), making each additional term worth many digits"
     ]
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Imports, Module Documentation, and Namespace",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Imports Mathlib's arctan API (`Arctan`, `ArctanDeriv`) and general tactics. The module docstring outlines the three-step strategy for deriving Machin's formula from the addition formula alone, without using Mathlib's pre-packaged identity. Opens the `Real` namespace for direct access to `arctan`, `arctan_add`, `arctan_neg`, and `arctan_one`.",
+      "mathContext": "Dependencies: $\\arctan(x) + \\arctan(y) = \\arctan\\!\\left(\\frac{x+y}{1-xy}\\right)$ for $xy < 1$, $\\arctan(-x) = -\\arctan(x)$, and $\\arctan(1) = \\pi/4$."
+    },
+    {
       "id": "step1",
       "title": "Step 1: Doubling arctan(1/5)",
-      "startLine": 34,
+      "startLine": 40,
       "endLine": 49,
       "summary": "Proves $\\arctan(1/5) + \\arctan(1/5) = \\arctan(5/12)$ via the addition formula with $xy = 1/25 < 1$. The rational arithmetic $(2/5)/(24/25) = 5/12$ is verified by `norm_num`.",
       "mathContext": "$\\arctan\\frac{1}{5} + \\arctan\\frac{1}{5} = \\arctan\\frac{5}{12}$ via $\\frac{2/5}{1 - 1/25} = \\frac{2/5}{24/25} = \\frac{5}{12}$."
@@ -146,10 +155,28 @@
       "targetId": "leibniz-pi",
       "relationship": "extends",
       "description": "Provides a constructive derivation of the faster-converging alternative to the Leibniz series"
+    },
+    {
+      "targetId": "pi-transcendental",
+      "relationship": "related",
+      "description": "Both concern fundamental properties of pi; Machin's formula accelerates the computation of a number whose transcendence was proved by Lindemann in 1882"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Another classical identity involving pi (pi^2/6 = sum of 1/n^2); both demonstrate exact closed-form evaluations via analytic methods"
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "related",
+      "description": "The arctan Taylor series arctan(x) = x - x^3/3 + x^5/5 - ... is a variant of the geometric series identity; Machin's formula exploits its rapid convergence at small arguments"
     }
   ],
   "relatedProofs": [
     "leibniz-pi",
-    "leibniz-pi-oq-01"
+    "leibniz-pi-oq-01",
+    "pi-transcendental",
+    "basel-problem",
+    "geometric-series"
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed all 4 annotation line ranges to match actual Lean file positions (were shifted by 6-14 lines)
- Added preamble section covering imports, module documentation, and namespace (lines 1-38)
- Added cross-references to pi-transcendental, basel-problem, and geometric-series
- Added 6th key insight on convergence rate improvement (O(1/N) → O(5^{-2N}))
- Deepened finale annotation with Shanks/Ferguson historical detail (1946 error discovery)
- Added congr tactic explanation to doubling annotation

## Test plan
- [x] JSON validated with python3 json.tool
- [x] No build warnings for leibniz-pi-oq-01-oq-01 in annotations build

🤖 Generated with [Claude Code](https://claude.com/claude-code)