### PR TITLE
Prove zeta monotonicity and bounds: complete SumOfKthPowersOQ02 (0 sorries)

### DIFF
--- a/proofs/Proofs/SumOfKthPowersOQ02.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ02.lean
@@ -2,6 +2,7 @@ import Mathlib.NumberTheory.ZetaValues
 import Mathlib.Analysis.PSeries
 import Mathlib.Topology.Algebra.InfiniteSum.Basic
 import Mathlib.Topology.Algebra.InfiniteSum.Real
+import Mathlib.Topology.Algebra.InfiniteSum.Order
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Tactic
 
@@ -87,24 +88,34 @@ lemma inv_rpow_strictAnti {n : ℕ} (hn : 2 ≤ n) {s₁ s₂ : ℝ} (hs : s₁ 
 /-- ζ(s₂) ≤ ζ(s₁) when 1 < s₁ ≤ s₂ (zeta is antitone). -/
 theorem tsum_inv_rpow_antitone {s₁ s₂ : ℝ} (hs₁ : 1 < s₁) (hs : s₁ ≤ s₂) :
     ∑' n : ℕ, ((n : ℝ) ^ s₂)⁻¹ ≤ ∑' n : ℕ, ((n : ℝ) ^ s₁)⁻¹ := by
-  -- Term-by-term comparison via inv_rpow_antitone
-  sorry
+  have hs₂ : 1 < s₂ := lt_of_lt_of_le hs₁ hs
+  exact hasSum_le (fun n => by
+    by_cases hn : n = 0
+    · simp [hn, Real.zero_rpow (by linarith : s₁ ≠ 0), Real.zero_rpow (by linarith : s₂ ≠ 0)]
+    · exact inv_rpow_antitone (by omega) hs)
+    (summable_inv_rpow hs₂).hasSum (summable_inv_rpow hs₁).hasSum
 
 /-! ## Part V: Lower Bound -/
 
 /-- ζ(s) ≥ 1 for s > 1: the n=1 term contributes 1^{-s} = 1. -/
 theorem one_le_tsum_inv_rpow {s : ℝ} (hs : 1 < s) :
     1 ≤ ∑' n : ℕ, ((n : ℝ) ^ s)⁻¹ := by
-  -- The n=1 partial sum = 1 ≤ full sum
-  sorry
+  calc (1 : ℝ) = (((1 : ℕ) : ℝ) ^ s)⁻¹ := by simp [Real.one_rpow]
+    _ ≤ ∑' n : ℕ, ((n : ℝ) ^ s)⁻¹ :=
+        le_hasSum (summable_inv_rpow hs).hasSum 1 (fun n _ => by positivity)
 
 /-! ## Part VI: Upper Bound -/
 
 /-- For s ≥ 2, ζ(s) ≤ ζ(2) = π²/6 by term-wise monotonicity. -/
 theorem tsum_inv_rpow_le_zeta_two {s : ℝ} (hs : 2 ≤ s) :
     ∑' n : ℕ, ((n : ℝ) ^ s)⁻¹ ≤ Real.pi ^ 2 / 6 := by
-  -- Follows from tsum_inv_rpow_antitone + zeta_two_eq
-  sorry
+  calc ∑' n : ℕ, ((n : ℝ) ^ s)⁻¹
+      ≤ ∑' n : ℕ, ((n : ℝ) ^ (2 : ℝ))⁻¹ :=
+        tsum_inv_rpow_antitone (by norm_num : (1 : ℝ) < 2) hs
+    _ = ∑' n : ℕ, (1 : ℝ) / ↑n ^ 2 := by
+        congr 1; ext n
+        rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast, one_div]
+    _ = Real.pi ^ 2 / 6 := zeta_two_eq
 
 /-! ## Part VII: Partial Sums -/
 

--- a/src/data/proofs/sum-of-kth-powers-oq-02/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-02/meta.json
@@ -8,7 +8,7 @@
     "author": "Euler (1734); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Riemann_zeta_function",
     "date": "1734",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SumOfKthPowersOQ02.lean",
     "tags": [
       "analysis",
@@ -19,8 +19,8 @@
       "research",
       "open-problem"
     ],
-    "badge": "formalized",
-    "sorries": 3,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {
@@ -50,9 +50,9 @@
       "zeta_two_eq / zeta_four_eq: tsum forms of Basel and ζ(4)",
       "inv_rpow_antitone: (n^s)⁻¹ is antitone in s for n ≥ 1",
       "inv_rpow_strictAnti: strict version for n ≥ 2",
-      "tsum_inv_rpow_antitone: ζ(s) is antitone (sorry - tsum ordering)",
-      "one_le_tsum_inv_rpow: ζ(s) ≥ 1 (sorry - tsum ordering)",
-      "tsum_inv_rpow_le_zeta_two: ζ(s) ≤ π²/6 for s ≥ 2 (sorry - tsum ordering)",
+      "tsum_inv_rpow_antitone: ζ(s) is antitone via hasSum_le",
+      "one_le_tsum_inv_rpow: ζ(s) ≥ 1 via le_hasSum at n=1",
+      "tsum_inv_rpow_le_zeta_two: ζ(s) ≤ π²/6 for s ≥ 2 via antitone + Basel",
       "partialZeta_tendsto: partial sums converge to ζ(s)",
       "partialZeta_mono: partial sums are monotone",
       "rpow_inv_eq_nat_inv: bridge from rpow to nat pow",
@@ -60,7 +60,7 @@
       "partial_sum_sq_tendsto: ∑ 1/n² → π²/6"
     ],
     "dateAdded": "2026-03-23",
-    "lineCount": 164,
+    "lineCount": 173,
     "prerequisites": [
       "Real-valued power series and summability",
       "Zeta values from Mathlib",
@@ -78,7 +78,7 @@
         "type": "book"
       }
     ],
-    "assumptions": "No axioms. 3 sorry(s) remain in the formalization."
+    "assumptions": "No axioms or sorries. Fully verified."
   },
   "sections": [
     {
@@ -118,16 +118,16 @@
       "title": "Part IV: Zeta Monotonicity",
       "startLine": 85,
       "endLine": 91,
-      "summary": "zeta(s) antitone (sorry).",
-      "mathContext": "tsum ordering comparison."
+      "summary": "zeta(s) antitone via hasSum_le.",
+      "mathContext": "Term-wise comparison via inv_rpow_antitone, n=0 handled by zero_rpow."
     },
     {
       "id": "bounds",
       "title": "Parts V-VI: Bounds",
       "startLine": 93,
       "endLine": 107,
-      "summary": "zeta(s) >= 1, zeta(s) <= pi^2/6 for s>=2 (sorry).",
-      "mathContext": "Lower and upper bounds."
+      "summary": "zeta(s) >= 1 via le_hasSum, zeta(s) <= pi^2/6 for s>=2 via antitone + Basel.",
+      "mathContext": "Lower bound from n=1 term, upper bound via zeta monotonicity and zeta(2)."
     },
     {
       "id": "partial-sums",
@@ -151,19 +151,19 @@
       "startLine": 147,
       "endLine": 164,
       "summary": "Type-checks all 14 results.",
-      "mathContext": "11 proved, 3 sorry."
+      "mathContext": "14 proved, 0 sorry."
     }
   ],
   "overview": {
     "historicalContext": "Johann Faulhaber (1631) published closed-form expressions for sums of consecutive kth powers, extending work by al-Haytham (c. 1000) and Bernoulli. The reciprocal series sum 1/n^2 was posed as the Basel Problem by Pietro Mengoli in 1644 and resisted solution for 90 years. Euler's breakthrough in 1734, showing zeta(2) = pi^2/6, stunned contemporary mathematicians by linking a discrete arithmetic sum to the circle constant. Euler subsequently computed zeta(2k) for all positive integers k using Bernoulli numbers and powers of pi. The convergence dichotomy at s = 1 — the harmonic series diverges while sum 1/n^s converges for any s > 1 — was first observed by Nicole Oresme (c. 1360) and later connected to the prime number theorem via the Euler product zeta(s) = prod (1 - p^{-s})^{-1}. Riemann's 1859 memoir extended zeta(s) to complex s via analytic continuation, transforming number theory forever.",
     "problemStatement": "Extend Faulhaber integer power sums to real exponents via zeta(s) = sum 1/n^s.",
-    "proofStrategy": "Eight parts: convergence dichotomy, known values, term monotonicity, zeta monotonicity, bounds, partial sums, bridge to integers. Three sorries in tsum ordering.",
+    "proofStrategy": "Eight parts: convergence dichotomy, known values, term monotonicity, zeta monotonicity, bounds, partial sums, bridge to integers. Fully verified.",
     "keyInsights": [
       "P-series threshold at s=1 separates convergent from divergent power-law decay",
       "Basel problem zeta(2)=pi^2/6 connects discrete arithmetic to geometry",
       "General formula zeta(2k) involves Bernoulli numbers; no closed form for odd values",
       "Bridge rpow_inv_eq_nat_inv connects real-exponent analysis to integer combinatorics",
-      "Three remaining sorries are routine tsum ordering comparisons"
+      "hasSum_le and le_hasSum are the key API for tsum ordering"
     ],
     "prerequisites": [
       "Real summability",
@@ -172,10 +172,9 @@
     ]
   },
   "conclusion": {
-    "summary": "11 of 14 results proved. 3 sorries remain in tsum ordering comparisons.",
-    "implications": "Bridge from Faulhaber to zeta(s). Sorries are routine and Aristotle-provable.",
+    "summary": "All 14 results fully proved. 0 sorries, 0 axioms.",
+    "implications": "Complete bridge from Faulhaber integer power sums to zeta(s) real-exponent theory.",
     "openQuestions": [
-      "Close 3 tsum ordering sorries using tsum_le_tsum and le_tsum",
       "Extend to zeta(6), zeta(8) via Bernoulli numbers",
       "Formalize Euler product",
       "Prove functional equation"

--- a/src/data/research/problems/sum-of-kth-powers-oq-02.json
+++ b/src/data/research/problems/sum-of-kth-powers-oq-02.json
@@ -1,63 +1,91 @@
 {
   "slug": "sum-of-kth-powers-oq-02",
-  "title": "## Source",
-  "phase": "OBSERVE",
+  "title": "Sum of Powers: Extension to Non-Integer Exponents",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "C",
   "path": "full",
   "problemStatement": {
-    "formal": "",
-    "plain": "",
-    "whyMatters": []
+    "formal": "∀ s₁ s₂ : ℝ, 1 < s₁ → s₁ ≤ s₂ → ∑' n, (n^s₂)⁻¹ ≤ ∑' n, (n^s₁)⁻¹",
+    "plain": "Prove that the Riemann zeta function ζ(s) = ∑ 1/n^s is antitone for s > 1, bounded below by 1 and above by π²/6 for s ≥ 2.",
+    "whyMatters": [
+      "Completes the bridge from Faulhaber's integer power sums to real-exponent zeta theory",
+      "Establishes fundamental monotonicity and bounds for ζ(s)"
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "Convergence dichotomy: ∑ 1/n^s converges iff s > 1",
+      "Known values: ζ(2) = π²/6, ζ(4) = π⁴/90",
+      "Term monotonicity: (n^s)⁻¹ antitone in s",
+      "Zeta monotonicity: ζ(s₂) ≤ ζ(s₁) for 1 < s₁ ≤ s₂",
+      "Lower bound: ζ(s) ≥ 1",
+      "Upper bound: ζ(s) ≤ π²/6 for s ≥ 2",
+      "Bridge: rpow series = nat pow series for integer exponents"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "All 14 results fully proved"
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-22T09:13:15-07:00",
+    "phase": "COMPLETED",
+    "since": "2026-03-23T16:00:00Z",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "All sorries resolved.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None — proof is complete.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: All 14 theorems proved, 0 sorries, 0 axioms.",
+    "builtItems": [
+      "tsum_inv_rpow_antitone: proved via hasSum_le + inv_rpow_antitone",
+      "one_le_tsum_inv_rpow: proved via le_hasSum at n=1",
+      "tsum_inv_rpow_le_zeta_two: proved via antitone + rpow_natCast + zeta_two_eq"
+    ],
+    "insights": [
+      "hasSum_le (not tsum_le_tsum) is the correct API for tsum ordering in current Mathlib",
+      "le_hasSum (not le_tsum) is the correct API for single-term lower bounds on tsum",
+      "rpow (2:ℝ) and pow (2:ℕ) require explicit bridge via rpow_natCast + norm_num coercion",
+      "n=0 case of rpow comparison needs Real.zero_rpow (s ≠ 0) separately from n≥1 case",
+      "one_div converts between x⁻¹ and 1/x forms needed to bridge rpow and zeta_two_eq",
+      "import Mathlib.Topology.Algebra.InfiniteSum.Order needed for hasSum_le/le_hasSum"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Knowledge Base: sum-of-kth-powers-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+    "nextSteps": []
   },
-  "tags": [],
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
   "relatedProofs": [
     "sum-of-kth-powers"
   ],
   "references": {
     "papers": [],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Mathlib.Topology.Algebra.InfiniteSum.Order (hasSum_le, le_hasSum)",
+      "Mathlib.Analysis.PSeries (Real.summable_nat_rpow_inv)",
+      "Mathlib.NumberTheory.ZetaValues (hasSum_zeta_two)"
+    ]
   },
   "started": "2026-03-22T16:23:16.662Z",
-  "lastUpdate": "2026-03-22T16:23:16.672Z",
+  "lastUpdate": "2026-03-23T16:00:00.000Z",
   "leanFiles": [
     {
-      "path": "Proofs/SumOfKthPowers.lean",
-      "filename": "SumOfKthPowers.lean",
-      "lineCount": 601,
-      "theoremCount": 49,
+      "path": "Proofs/SumOfKthPowersOQ02.lean",
+      "filename": "SumOfKthPowersOQ02.lean",
+      "lineCount": 173,
+      "theoremCount": 14,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SumOfKthPowers.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SumOfKthPowersOQ02.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Prove all 3 remaining sorries in `SumOfKthPowersOQ02.lean`, completing the formalization
- `tsum_inv_rpow_antitone`: ζ(s) is antitone for s > 1 via `hasSum_le` + term-wise comparison
- `one_le_tsum_inv_rpow`: ζ(s) ≥ 1 via `le_hasSum` extracting the n=1 term
- `tsum_inv_rpow_le_zeta_two`: ζ(s) ≤ π²/6 for s ≥ 2 via antitone + rpow_natCast bridge to Basel
- All 14 theorems now fully machine-checked: 0 sorries, 0 axioms
- Gallery status updated from `formalized` to `verified`

## Key technical findings
- `hasSum_le` (not `tsum_le_tsum`) is the correct API for tsum ordering in current Mathlib
- rpow `(2:ℝ)` vs nat pow `2` requires explicit `rpow_natCast` + `norm_num` coercion bridge
- `Real.zero_rpow` handles n=0 case separately from `inv_rpow_antitone` which needs n ≥ 1

## Test plan
- [x] Docker build passes with 0 errors, 0 warnings, 0 sorries
- [x] Gallery meta.json updated (status: verified, badge: verified, sorries: 0)
- [x] Research problem JSON updated (phase: COMPLETED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)