### PR TITLE
Enrich 4 entries: add mathContext to all sections

### DIFF
--- a/src/data/proofs/erdos-1006/meta.json
+++ b/src/data/proofs/erdos-1006/meta.json
@@ -49,35 +49,40 @@
       "title": "Graph Girth",
       "summary": "hasGirthAtLeast, hasGirth",
       "startLine": 50,
-      "endLine": 62
+      "endLine": 62,
+      "mathContext": "The girth $g(G)$ of a graph $G$ is the length of its shortest cycle ($\\infty$ if acyclic). `hasGirthAtLeast G k` means all cycles in $G$ have length $\\geq k$. High girth forces local tree-like structure, which intuitively should make acyclic orientations more robust."
     },
     {
       "id": "orientations",
       "title": "Directed Graphs and Orientations",
       "summary": "Orientation structure, hasDirectedPath, isAcyclic",
       "startLine": 64,
-      "endLine": 84
+      "endLine": 84,
+      "mathContext": "An orientation of $G$ assigns a direction to each edge. An orientation is acyclic iff there is no directed cycle, equivalently iff the vertices admit a topological ordering. Every graph has acyclic orientations (orient by any linear ordering of vertices). The question is whether 'robust' acyclicity is achievable."
     },
     {
       "id": "robust",
       "title": "Robust Acyclicity",
       "summary": "reverseEdge, isRobustlyAcyclic, admitsRobustlyAcyclicOrientation",
       "startLine": 86,
-      "endLine": 102
+      "endLine": 102,
+      "mathContext": "An acyclic orientation is *robustly acyclic* if reversing any single edge preserves acyclicity. Equivalently, no directed edge $u \\to v$ lies on a directed path from $v$ back to $u$. This is a strong structural property: the orientation must avoid all 'barely acyclic' configurations."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture (Disproved)",
       "summary": "oresConjecture",
       "startLine": 104,
-      "endLine": 113
+      "endLine": 113,
+      "mathContext": "Ore's conjecture (attributed by Erdős): every graph with girth $> 4$ admits a robustly acyclic orientation. The girth $> 4$ threshold excludes triangles and 4-cycles — the known obstructions at the time. Ore showed a girth-4 counterexample; the conjecture asked whether girth 5 suffices."
     },
     {
       "id": "counterexamples",
       "title": "Counterexamples",
       "summary": "grotzsch_counterexample, nesetril_rodl_1978, ores_conjecture_false",
       "startLine": 115,
-      "endLine": 141
+      "endLine": 141,
+      "mathContext": "Nešetřil-Rödl (1978) disproved the conjecture for ALL girths: for every $g \\geq 3$, $\\exists$ graph $G$ with $g(G) = g$ and $\\chi(G) \\geq 4$ that admits no robustly acyclic orientation. Their probabilistic construction uses the Lovász Local Lemma to build high-girth, high-chromatic-number graphs. The Grötzsch graph ($g = 4$, $\\chi = 4$, 11 vertices) is the smallest triangle-free non-3-colorable graph and provides a concrete counterexample at girth 4."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -57,28 +57,32 @@
       "title": "Core Definitions",
       "startLine": 24,
       "endLine": 42,
-      "summary": "`IsSidonSet` (unique pairwise sums), `greedySidon` (recursive Mian-Chowla construction via `sInf`), `greedySidonCount N`."
+      "summary": "`IsSidonSet` (unique pairwise sums), `greedySidon` (recursive Mian-Chowla construction via `sInf`), `greedySidonCount N`.",
+      "mathContext": "`IsSidonSet S`: $\\forall a, b, c, d \\in S$, $a \\leq b \\wedge c \\leq d \\wedge a + b = c + d \\Rightarrow a = c \\wedge b = d$. `greedySidon n` builds the Mian-Chowla sequence by recursively adding $\\inf\\{m > \\max(S) : S \\cup \\{m\\} \\text{ is Sidon}\\}$. The count function $f(N) = |\\text{greedySidon}(N) \\cap \\{1, \\ldots, N\\}|$ measures the sequence's density."
     },
     {
       "id": "initial-values",
       "title": "Known Initial Values",
       "startLine": 43,
       "endLine": 59,
-      "summary": "First 11 values of OEIS A005282, strict monotonicity, and Sidon invariant at every stage."
+      "summary": "First 11 values of OEIS A005282, strict monotonicity, and Sidon invariant at every stage.",
+      "mathContext": "OEIS A005282: $\\{0, 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97, \\ldots\\}$. The greedy algorithm adds the smallest integer preserving the Sidon property. Axioms assert strict monotonicity ($a_n < a_{n+1}$) and that each prefix is a Sidon set."
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
       "startLine": 61,
       "endLine": 74,
-      "summary": "Lower bound $\\Omega(N^{1/3})$ from forbidden-sum counting. Upper bound $\\sqrt{N} + O(N^{1/4})$ from Erdos-Turan."
+      "summary": "Lower bound $\\Omega(N^{1/3})$ from forbidden-sum counting. Upper bound $\\sqrt{N} + O(N^{1/4})$ from Erdos-Turan.",
+      "mathContext": "Lower bound: each element $a_n$ forbids $\\leq 2n$ future sums, so $a_n = O(n^3)$, giving $f(N) = \\Omega(N^{1/3})$. Upper bound (Erdős-Turán 1941): any Sidon set in $\\{1, \\ldots, N\\}$ has $\\leq \\sqrt{N} + O(N^{1/4})$ elements. The gap between $N^{1/3}$ and $N^{1/2}$ is the content of the conjecture."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture and Difference Set",
       "startLine": 76,
       "endLine": 104,
-      "summary": "Near-optimal growth conjecture ($N^{1/2-\\varepsilon}$), difference set density question, and random Sidon benchmark."
+      "summary": "Near-optimal growth conjecture ($N^{1/2-\\varepsilon}$), difference set density question, and random Sidon benchmark.",
+      "mathContext": "Conjecture: $f(N) \\gg N^{1/2 - \\varepsilon}$ for all $\\varepsilon > 0$, i.e., the greedy Sidon sequence is nearly as dense as the theoretical maximum. The difference set question: does $A - A = \\{a - b : a, b \\in A\\}$ have positive lower density in $\\mathbb{Z}$? A random Sidon set in $\\{1, \\ldots, N\\}$ has expected size $\\Theta(N^{1/3})$, so the greedy construction appears to outperform randomness."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -106,77 +106,88 @@
       "title": "Problem Statement and References",
       "startLine": 1,
       "endLine": 26,
-      "summary": "Documentation header with problem statement, Thomassen/Voigt resolution, context on list chromatic number, and namespace setup with $\\text{SimpleGraph}$ and $\\text{Finset}$"
+      "summary": "Documentation header with problem statement, Thomassen/Voigt resolution, context on list chromatic number, and namespace setup with $\\text{SimpleGraph}$ and $\\text{Finset}$",
+      "mathContext": "Erdős Problem #631: Does every planar graph $G$ satisfy $\\chi_L(G) \\leq 5$? Is this best possible? The list chromatic number $\\chi_L(G)$ is the minimum $k$ such that $G$ is $k$-choosable: for every assignment of lists of size $\\geq k$ to vertices, a proper coloring from the lists exists."
     },
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "startLine": 28,
       "endLine": 36,
-      "summary": "Defines $\\text{chromaticNumber}$ ($\\chi(G)$, noncomputable sorry) and $\\text{IsKColorable}$ ($\\exists f: V \\to \\text{Fin}\\,k$ with $f(v) \\neq f(w)$ for adjacent $v,w$)"
+      "summary": "Defines $\\text{chromaticNumber}$ ($\\chi(G)$, noncomputable sorry) and $\\text{IsKColorable}$ ($\\exists f: V \\to \\text{Fin}\\,k$ with $f(v) \\neq f(w)$ for adjacent $v,w$)",
+      "mathContext": "$\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$. A proper $k$-coloring is $f: V \\to \\{0, \\ldots, k-1\\}$ with $f(u) \\neq f(v)$ for every edge $uv$. The chromatic number is noncomputable (definition uses sorry)."
     },
     {
       "id": "list-coloring",
       "title": "List Coloring Definitions",
       "startLine": 38,
       "endLine": 57,
-      "summary": "Defines $\\text{ListAssignment}$ ($V \\to \\text{Finset}\\,C$), $\\text{IsListColoring}$ (proper coloring from lists), $\\text{IsKChoosable}$ ($\\forall L$ with $|L(v)| \\geq k$, $\\exists$ proper list coloring), and $\\text{listChromaticNumber}$ ($\\chi_L(G)$)"
+      "summary": "Defines $\\text{ListAssignment}$ ($V \\to \\text{Finset}\\,C$), $\\text{IsListColoring}$ (proper coloring from lists), $\\text{IsKChoosable}$ ($\\forall L$ with $|L(v)| \\geq k$, $\\exists$ proper list coloring), and $\\text{listChromaticNumber}$ ($\\chi_L(G)$)",
+      "mathContext": "A list assignment $L: V \\to \\text{Finset}\\,C$ gives each vertex a set of allowed colors. A list coloring $f$ satisfies $f(v) \\in L(v)$ and $f(u) \\neq f(v)$ for adjacent $u, v$. $G$ is $k$-choosable if every list assignment with $|L(v)| \\geq k$ for all $v$ admits a proper list coloring. $\\chi_L(G) = \\min\\{k : G \\text{ is } k\\text{-choosable}\\}$."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 59,
       "endLine": 91,
-      "summary": "Proves $\\chi_L \\geq \\chi$ (sorry), choosable monotonicity (sorry), and $k$-choosable $\\Rightarrow$ $k$-colorable (**proved by Aristotle** via contrapositive with $\\text{ULift}$)"
+      "summary": "Proves $\\chi_L \\geq \\chi$ (sorry), choosable monotonicity (sorry), and $k$-choosable $\\Rightarrow$ $k$-colorable (**proved by Aristotle** via contrapositive with $\\text{ULift}$)",
+      "mathContext": "$\\chi_L(G) \\geq \\chi(G)$ always holds: take $L(v) = \\{1, \\ldots, k\\}$ for all $v$, reducing list coloring to ordinary coloring. The inequality can be strict: $\\chi_L(K_{2,2}) = 3 > 2 = \\chi(K_{2,2})$. For complete bipartite graphs, $\\chi_L(K_{n,n}) = 1 + \\lceil \\log_2 n \\rceil$ (Galvin's theorem)."
     },
     {
       "id": "planar-graphs",
       "title": "Planar Graphs",
       "startLine": 92,
       "endLine": 108,
-      "summary": "Defines $\\text{IsPlanar}$ (sorry), Euler's formula $V - E + F = 2$, and edge bound $|E| \\leq 3|V| - 6$ as axioms"
+      "summary": "Defines $\\text{IsPlanar}$ (sorry), Euler's formula $V - E + F = 2$, and edge bound $|E| \\leq 3|V| - 6$ as axioms",
+      "mathContext": "A graph is planar if it embeds in $\\mathbb{R}^2$ without edge crossings. Euler's formula $|V| - |E| + |F| = 2$ for connected planar graphs implies $|E| \\leq 3|V| - 6$ (since each face has $\\geq 3$ boundary edges). This gives the average degree bound $\\bar{d} < 6$, which underlies the Five Color Theorem."
     },
     {
       "id": "four-color",
       "title": "The Four Color Theorem",
       "startLine": 110,
       "endLine": 120,
-      "summary": "Axiomatizes the Four Color Theorem ($\\chi \\leq 4$ for planar) and Five Color Theorem ($\\chi \\leq 5$)"
+      "summary": "Axiomatizes the Four Color Theorem ($\\chi \\leq 4$ for planar) and Five Color Theorem ($\\chi \\leq 5$)",
+      "mathContext": "The Four Color Theorem (Appel-Haken 1976, simplified by Robertson et al. 1997): every planar graph has $\\chi(G) \\leq 4$. The Five Color Theorem (Heawood 1890) has a short proof by induction using the $|E| \\leq 3|V| - 6$ bound. Note: $\\chi \\leq 4$ does NOT imply $\\chi_L \\leq 4$ — the list coloring analogue remains open."
     },
     {
       "id": "thomassen",
       "title": "Thomassen's Theorem",
       "startLine": 122,
       "endLine": 143,
-      "summary": "Main result: $\\chi_L(G) \\leq 5$ for planar $G$ (axiom). Includes proof technique description: induction on $|V|+|E|$ via near-triangulations with precolored edge"
+      "summary": "Main result: $\\chi_L(G) \\leq 5$ for planar $G$ (axiom). Includes proof technique description: induction on $|V|+|E|$ via near-triangulations with precolored edge",
+      "mathContext": "Thomassen's theorem (1994): every planar graph is 5-choosable. The proof uses induction on $|V| + |E|$ with a stronger hypothesis: in any near-triangulation with outer face bounded by a path $P = v_1 v_2 \\cdots v_k$, if $v_1$ and $v_2$ are precolored and each other outer vertex has a list of size $\\geq 3$ while inner vertices have lists of size $\\geq 5$, a proper list coloring exists."
     },
     {
       "id": "voigt",
       "title": "Voigt's Construction and Sharpness",
       "startLine": 145,
       "endLine": 165,
-      "summary": "Sharpness: $\\exists$ planar $G$ with $\\chi_L = 5$ (axiom). Voigt's 238-vertex construction, Gutner's simplification, smallest known $\\leq 63$ vertices"
+      "summary": "Sharpness: $\\exists$ planar $G$ with $\\chi_L = 5$ (axiom). Voigt's 238-vertex construction, Gutner's simplification, smallest known $\\leq 63$ vertices",
+      "mathContext": "Voigt (1993) constructed a planar graph that is not 4-choosable, proving $\\chi_L \\leq 5$ is tight. The original had 238 vertices. Gutner (1996) simplified to 75 vertices. Mirzakhani (1998) found a 63-vertex example. The smallest known non-4-choosable planar graph has $\\leq 63$ vertices — the exact minimum is unknown."
     },
     {
       "id": "list-conjecture",
       "title": "The List Coloring Conjecture",
       "startLine": 167,
       "endLine": 185,
-      "summary": "Open: $\\chi_L \\leq 4$ for planar? $\\texttt{chromatic\\_list\\_gap}$ bundles both bounds $\\langle\\text{Four Color}, \\text{Thomassen}\\rangle$ (proved from axioms)"
+      "summary": "Open: $\\chi_L \\leq 4$ for planar? $\\texttt{chromatic\\_list\\_gap}$ bundles both bounds $\\langle\\text{Four Color}, \\text{Thomassen}\\rangle$ (proved from axioms)",
+      "mathContext": "The List Coloring Conjecture for planar graphs: $\\chi_L(G) \\leq 4$ for every planar graph $G$. If true, this would be the list-coloring analog of the Four Color Theorem. Evidence: all known non-4-choosable planar graphs are carefully constructed, and many natural classes (bipartite planar, outerplanar, high-girth) satisfy $\\chi_L \\leq 3$."
     },
     {
       "id": "related-results",
       "title": "Related Results",
       "startLine": 187,
       "endLine": 232,
-      "summary": "Alon-Tarsi: bipartite planar $\\Rightarrow \\chi_L \\leq 3$. Outerplanar $\\Rightarrow \\chi_L \\leq 3$. Girth $\\geq 5$ planar $\\Rightarrow \\chi_L \\leq 3$. Thomassen's proof structure via key lemma and induction"
+      "summary": "Alon-Tarsi: bipartite planar $\\Rightarrow \\chi_L \\leq 3$. Outerplanar $\\Rightarrow \\chi_L \\leq 3$. Girth $\\geq 5$ planar $\\Rightarrow \\chi_L \\leq 3$. Thomassen's proof structure via key lemma and induction",
+      "mathContext": "Restricted planar classes with $\\chi_L \\leq 3$: (1) Bipartite planar (Alon-Tarsi 1992, via the combinatorial nullstellensatz and orientation parity); (2) Outerplanar (all vertices on the outer face, degeneracy $\\leq 2$); (3) Girth $\\geq 5$ planar (Thomassen 1995, the triangle-free case). The Alon-Tarsi method counts Eulerian subgraph orientations modulo 2."
     },
     {
       "id": "main-status",
       "title": "Main Problem Status",
       "startLine": 245,
       "endLine": 276,
-      "summary": "Theorem $\\texttt{erdos\\_631\\_status}$: $\\langle\\texttt{thomassen\\_five\\_list\\_theorem}, \\texttt{voigt\\_construction}\\rangle$ — both questions answered, bound is tight"
+      "summary": "Theorem $\\texttt{erdos\\_631\\_status}$: $\\langle\\texttt{thomassen\\_five\\_list\\_theorem}, \\texttt{voigt\\_construction}\\rangle$ — both questions answered, bound is tight",
+      "mathContext": "Problem #631 is SOLVED: $\\chi_L(G) \\leq 5$ for all planar $G$ (Thomassen 1994) and $\\exists$ planar $G$ with $\\chi_L(G) = 5$ (Voigt 1993). The formalization bundles both results as a conjunction, establishing the tight bound $\\max_G \\chi_L(G) = 5$ over all planar graphs $G$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Added `mathContext` field with LaTeX formulas to all sections in 4 entries:

- **erdos-156** (10 sections): Sidon sets, greedy construction, Erdős-Turán bounds, Ruzsa's construction, main conjecture, gap analysis, sumset/B₂ connection, infimum formulation
- **erdos-631** (11 sections): list coloring framework, Thomassen 5-choosability, Voigt sharpness, Alon-Tarsi method, planar graph theory, List Coloring Conjecture
- **erdos-340** (4 sections): Mian-Chowla sequence, OEIS values, Erdős-Turán bounds, growth conjecture
- **erdos-1006** (5 sections): graph girth, orientations, robust acyclicity, Ore's conjecture, Nešetřil-Rödl counterexamples

## Test plan
- [x] JSON validates (verified locally)
- [x] No changes to annotations or Lean files

🤖 Generated with [Claude Code](https://claude.com/claude-code)