### PR TITLE
Enrich leibniz-pi-oq-01-oq-01: Gaussian integer context, expanded cross-refs

### DIFF
--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/annotations.json
@@ -5,10 +5,10 @@
     "range": { "startLine": 5, "endLine": 34 },
     "type": "context",
     "title": "Module Overview: From-Scratch Derivation of Machin's Formula",
-    "content": "This proof deliberately avoids Mathlib's pre-packaged `Real.four_mul_arctan_inv_5_sub_arctan_inv_239` to derive Machin's formula from first principles. Only three Mathlib lemmas are used: `arctan_add` (the addition formula), `arctan_neg` (parity), and `arctan_one` ($\\arctan(1) = \\pi/4$). The from-scratch approach demonstrates that any Machin-like formula can be verified by iterating these primitives. John Machin used this identity in 1706 to compute 100 digits of $\\pi$, vastly outpacing the Leibniz series $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$ which requires millions of terms for similar accuracy.",
-    "mathContext": "Machin's formula: $\\frac{\\pi}{4} = 4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239}$. The arctan series at $x = 1/5$ converges as $O(5^{-2N})$ vs $O(1/N)$ for the Leibniz series at $x = 1$.",
+    "content": "This proof deliberately avoids Mathlib's pre-packaged `Real.four_mul_arctan_inv_5_sub_arctan_inv_239` to derive Machin's formula from first principles. Only three Mathlib lemmas are used: `arctan_add` (the addition formula), `arctan_neg` (parity), and `arctan_one` ($\\arctan(1) = \\pi/4$). The from-scratch approach demonstrates that any Machin-like formula can be verified by iterating these primitives.\n\nJohn Machin used this identity in 1706 to compute 100 digits of $\\pi$, vastly outpacing the Leibniz series $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$ which requires millions of terms for similar accuracy. The deeper reason Machin's formula exists is the Gaussian integer factorization $(2+i)^4(239+i) = -2(1+i) \\cdot 169^2 / |\\cdot|$, which encodes the identity in the ring $\\mathbb{Z}[i]$. Størmer's theorem (1899) classifies all two-term Machin-like formulas via this algebraic structure.",
+    "mathContext": "Machin's formula: $\\frac{\\pi}{4} = 4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239}$. Convergence: arctan series at $x = 1/5$ converges as $O(5^{-2N})$ vs $O(1/N)$ for the Leibniz series at $x = 1$. In $\\mathbb{Z}[i]$: $\\arg((2+i)^4(239+i)) = 4\\arctan(1/5) + \\arctan(1/239)$.",
     "significance": "context",
-    "relatedConcepts": ["Machin-like formulas", "pi computation", "arctan series", "Leibniz formula"],
+    "relatedConcepts": ["Machin-like formulas", "pi computation", "arctan series", "Leibniz formula", "Gaussian integers", "Størmer's theorem"],
     "prerequisites": ["Real.arctan_add", "Real.arctan_neg", "Real.arctan_one"]
   },
   {
@@ -32,7 +32,7 @@
     "content": "four_arctan_inv_5 expresses 4*arctan(1/5) as two copies of the doubled result, then applies arctan_add with x = y = 5/12. The condition xy = 25/144 < 1 holds. The key computation: (10/12)/(119/144) = 1440/1428 = 120/119. The number 120/119 is remarkably close to 1, which is why the final step works.",
     "mathContext": "$4\\arctan\\frac{1}{5} = 2\\arctan\\frac{5}{12} = \\arctan\\frac{\\frac{5}{12}+\\frac{5}{12}}{1-\\frac{25}{144}} = \\arctan\\frac{10/12}{119/144} = \\arctan\\frac{120}{119}$",
     "significance": "key",
-    "relatedConcepts": ["arctan_add", "ring", "iterated doubling"],
+    "relatedConcepts": ["arctan_add", "ring tactic", "iterated doubling", "repeated squaring", "tangent half-angle"],
     "prerequisites": ["two_arctan_inv_5", "Real.arctan_add"]
   },
   {
@@ -41,10 +41,10 @@
     "range": { "startLine": 67, "endLine": 84 },
     "type": "concept",
     "title": "The 28561 Coincidence",
-    "content": "arctan_diff_eq_arctan_one handles the subtraction by converting it to addition: arctan(a) - arctan(b) = arctan(a) + arctan(-b) via arctan_neg. Then arctan_add applies with x = 120/119, y = -1/239. The product xy = -120/28441 < 1 trivially. The beautiful numerical coincidence: 120*239 - 119 = 28561 and 119*239 + 120 = 28561, where 28561 = 169^2 = (13^2)^2. So numerator and denominator of the addition formula are both 28561/28441, giving a ratio of exactly 1.",
-    "mathContext": "$\\frac{\\frac{120}{119} - \\frac{1}{239}}{1 + \\frac{120}{119} \\cdot \\frac{1}{239}} = \\frac{\\frac{120 \\cdot 239 - 119}{119 \\cdot 239}}{\\frac{119 \\cdot 239 + 120}{119 \\cdot 239}} = \\frac{28561}{28561} = 1$",
+    "content": "arctan_diff_eq_arctan_one handles the subtraction by converting it to addition: arctan(a) - arctan(b) = arctan(a) + arctan(-b) via arctan_neg. Then arctan_add applies with x = 120/119, y = -1/239. The product xy = -120/28441 < 1 trivially. The beautiful numerical coincidence: $120 \\cdot 239 - 119 = 28561$ and $119 \\cdot 239 + 120 = 28561$, where $28561 = 169^2 = (13^2)^2$. So numerator and denominator of the addition formula are both 28561/28441, giving a ratio of exactly 1.\n\nThis coincidence is not accidental: in $\\mathbb{Z}[i]$, the computation $(2+i)^4 = -7 + 24i$ encodes $4\\arctan(1/5)$ as the argument, and multiplying by $(239+i)$ gives a real multiple of $(1+i)$, which has argument $\\pi/4$. The number $169 = 13^2 = |2+i|^4 \\cdot ... $ appears because $|2+i|^2 = 5$ and $5^2 = 25$ propagates through the squaring.",
+    "mathContext": "$\\frac{\\frac{120}{119} - \\frac{1}{239}}{1 + \\frac{120}{119} \\cdot \\frac{1}{239}} = \\frac{\\frac{120 \\cdot 239 - 119}{119 \\cdot 239}}{\\frac{119 \\cdot 239 + 120}{119 \\cdot 239}} = \\frac{28561}{28561} = 1$, where $28561 = 169^2 = 13^4$.",
     "significance": "key",
-    "relatedConcepts": ["arctan_neg", "arctan_add", "169 squared", "numerical coincidence"],
+    "relatedConcepts": ["arctan_neg", "arctan_add", "Gaussian integers", "169 squared", "numerical coincidence", "argument of complex number"],
     "prerequisites": ["Real.arctan_add", "Real.arctan_neg"]
   },
   {
@@ -56,7 +56,7 @@
     "content": "The final theorem machin_formula chains Steps 1-3 in a single rewrite sequence: `rw [four_arctan_inv_5, arctan_diff_eq_arctan_one, arctan_one]`. This illustrates the power of compositional proof: once each step is established, the final result is trivial. The proof uses only three Mathlib lemmas (arctan_add, arctan_neg, arctan_one) and pure rational arithmetic. Historically, this identity enabled Machin to compute 100 digits of $\\pi$ in 1706, and William Shanks later extended the computation to 707 digits (with an error after digit 527, discovered by D.F. Ferguson in 1946 using a desk calculator).",
     "mathContext": "$4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239} = \\arctan\\frac{120}{119} - \\arctan\\frac{1}{239} = \\arctan 1 = \\frac{\\pi}{4}$",
     "significance": "supporting",
-    "relatedConcepts": ["compositional proof", "rewrite chain", "arctan_one"],
+    "relatedConcepts": ["compositional proof", "rewrite chain", "arctan_one", "modular proof architecture"],
     "prerequisites": ["four_arctan_inv_5", "arctan_diff_eq_arctan_one", "Real.arctan_one"]
   }
 ]

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
@@ -56,6 +56,20 @@
         "year": "1971",
         "venue": "Golem Press",
         "note": "Chapter 10 discusses Machin's formula and its impact on pi computation"
+      },
+      {
+        "authors": "Størmer, Carl",
+        "title": "Sur l'application de la théorie des nombres entiers complexes à la solution en nombres rationnels",
+        "year": "1899",
+        "venue": "Archiv for Mathematik og Naturvidenskab",
+        "note": "Classifies all two-term Machin-like formulas via Gaussian integer factorizations"
+      },
+      {
+        "authors": "Wetherfield, Michael",
+        "title": "The Enhancement of Machin's Formula by Todd's Process",
+        "year": "1996",
+        "venue": "The Mathematical Gazette",
+        "note": "Discusses optimized multi-term Machin-like formulas for high-precision pi computation"
       }
     ],
     "prerequisites": [
@@ -78,7 +92,8 @@
       "The subtraction arctan(a) - arctan(b) is handled by arctan_neg + arctan_add, converting to arctan(a) + arctan(-b)",
       "All three applications of arctan_add have xy < 1 trivially satisfied (either both factors < 1, or one factor is negative)",
       "The proof technique generalizes: any Machin-like formula pi/4 = sum of c_i * arctan(a_i/b_i) can be verified by iterating arctan_add",
-      "Machin's formula reduces pi computation from O(N) terms (Leibniz) to O(log N) terms: the arctan series at x = 1/5 converges as O(5^{-2N}) and at x = 1/239 as O(239^{-2N}), making each additional term worth many digits"
+      "Machin's formula reduces pi computation from O(N) terms (Leibniz) to O(log N) terms: the arctan series at x = 1/5 converges as O(5^{-2N}) and at x = 1/239 as O(239^{-2N}), making each additional term worth many digits",
+      "The 28561 = 169^2 coincidence is explained by Gaussian integers: $(2+i)^4(239+i)$ is a real multiple of $(1+i)$, so $4\\arg(2+i) + \\arg(239+i) = \\arg(1+i) = \\pi/4$ — Størmer's theorem (1899) classifies all such two-term identities via $\\mathbb{Z}[i]$ factorizations"
     ]
   },
   "sections": [
@@ -124,12 +139,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Machin's formula is derived from scratch using only the arctan addition formula, arctan parity, and arctan(1) = pi/4. The proof is fully verified with 0 sorries and 0 axioms. Each step reduces to pure rational arithmetic verified by norm_num.",
-    "implications": "This resolves the open question from the parent proof (leibniz-pi-oq-01) about deriving Machin's formula from the addition formula. The technique generalizes to any Machin-like formula: each such identity can be verified by iterating arctan_add with norm_num checking the rational arithmetic.\n\nThe proof also demonstrates that Mathlib's arctan API is sufficient for compositional reasoning about arctangent identities, without needing to invoke specialized pre-packaged formulas.",
+    "summary": "Machin's formula is derived from scratch using only the arctan addition formula, arctan parity, and arctan(1) = pi/4. The proof is fully verified with 0 sorries and 0 axioms. Each step reduces to pure rational arithmetic verified by norm_num. The derivation reveals the algebraic coincidence $169^2 = 28561$ that makes the formula work — a fact obscured when citing a pre-packaged identity.",
+    "implications": "This resolves the open question from the parent proof (leibniz-pi-oq-01) about deriving Machin's formula from the addition formula. The technique generalizes to any Machin-like formula: each such identity can be verified by iterating arctan_add with norm_num checking the rational arithmetic.\n\nThe proof also demonstrates that Mathlib's arctan API is sufficient for compositional reasoning about arctangent identities, without needing to invoke specialized pre-packaged formulas.\n\nHistorically, this approach mirrors how Machin-like formulas were discovered: mathematicians searched for integers $a, b$ such that iterating the tangent addition formula on $1/a$ eventually produced a rational close to 1, with $1/b$ as the correction. Størmer (1899) proved that any Machin-like formula with two arctan terms corresponds to a Gaussian integer factorization of $(1+i)^n$.",
     "openQuestions": [
-      "Can the technique be automated to verify arbitrary Machin-like formulas (e.g., Wetherfield's pi/4 = 12*arctan(1/49) + ...)?",
-      "What is the optimal Machin-like formula (minimizing terms for a given accuracy)?",
-      "Can Lean's norm_num be extended to verify Machin-like identities in a single tactic call?"
+      "Can the technique be automated to verify arbitrary Machin-like formulas (e.g., Wetherfield's $\\pi/4 = 12\\arctan(1/49) + 32\\arctan(1/57) - 5\\arctan(1/239) + 12\\arctan(1/110443)$)?",
+      "What is the optimal Machin-like formula minimizing terms for a given accuracy? Hwang (2003) showed that minimizing the number of terms is related to factorizations in $\\mathbb{Z}[i]$.",
+      "Can Lean's norm_num be extended to verify Machin-like identities in a single tactic call, given a list of $(c_k, a_k)$ with $\\sum c_k \\arctan(1/a_k) = \\pi/4$?",
+      "Is there a purely algebraic (non-analytic) proof that $4\\arctan(1/5) - \\arctan(1/239) = \\pi/4$, avoiding the arctan function entirely?"
     ]
   },
   "leanFile": {
@@ -170,6 +186,16 @@
       "targetId": "geometric-series",
       "relationship": "related",
       "description": "The arctan Taylor series arctan(x) = x - x^3/3 + x^5/5 - ... is a variant of the geometric series identity; Machin's formula exploits its rapid convergence at small arguments"
+    },
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "uses-concept",
+      "description": "The arctan series $\\arctan(x) = x - x^3/3 + x^5/5 - \\cdots$ that Machin's formula accelerates is a special case of Taylor expansion"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Both results connect pi to analytic function identities; Euler's identity uses $e^{i\\pi}$ while Machin uses arctan composition — both are ultimately statements about arguments of complex numbers"
     }
   ],
   "relatedProofs": [
@@ -177,6 +203,8 @@
     "leibniz-pi-oq-01",
     "pi-transcendental",
     "basel-problem",
-    "geometric-series"
+    "geometric-series",
+    "taylor-theorem",
+    "euler-identity"
   ]
 }


### PR DESCRIPTION
## Summary

Deep enrichment pass on Machin's Formula proof (leibniz-pi-oq-01-oq-01):

- **Gaussian integer connection**: Added explanation of why 28561 = 169² = 13⁴ appears — Størmer's theorem (1899) shows all two-term Machin-like formulas correspond to Z[i] factorizations
- **New keyInsight**: The coincidence is explained by (2+i)⁴(239+i) being a real multiple of (1+i)
- **New references**: Størmer (1899), Wetherfield (1996)
- **Deeper conclusion**: Størmer historical context, Hwang (2003) on optimal formulas, 4th open question
- **Expanded cross-references**: taylor-theorem, euler-identity

## Test plan

- [x] JSON validation passes
- [x] Only target proof files modified (2 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)