### PR TITLE
Enrich cayley-hamilton-minpoly-oq-05-oq-01: module theory, prime avoidance

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "context",
     "title": "Module Documentation: Nonderogatory Implies Cyclic Vector",
-    "content": "This module proves the central theorem of rational canonical form theory: over an infinite field $K$, a nonderogatory matrix (minpoly = charpoly) has a cyclic vector. The proof uses three independent techniques — union avoidance over infinite fields, GCD annihilation via Bezout, and irreducible factorization from UniqueFactorizationMonoid — composed into a clean contradiction argument.\n\nThis resolves the sorry left in the backward direction of OQ-04/OQ-05, completing the equivalence: $M$ is nonderogatory $\\Leftrightarrow$ $M$ has a cyclic vector (over infinite fields).",
+    "content": "This module proves the central theorem of rational canonical form theory: over an infinite field $K$, a nonderogatory matrix (minpoly = charpoly) has a cyclic vector. The proof uses three independent techniques — union avoidance over infinite fields, GCD annihilation via Bezout, and irreducible factorization from UniqueFactorizationMonoid — composed into a clean contradiction argument.\n\nThis resolves the sorry left in the backward direction of OQ-04/OQ-05, completing the equivalence: $M$ is nonderogatory $\\Leftrightarrow$ $M$ has a cyclic vector (over infinite fields). Module-theoretically, this says the $K[X]$-module $K^n$ (with $X$ acting as $M$) is cyclic iff it has a single invariant factor — the structure theorem for finitely generated modules over PIDs in its most concrete matrix incarnation.",
     "mathContext": "Nonderogatory: $\\mu_M = \\chi_M$ (minimal polynomial equals characteristic polynomial). Cyclic vector: $v \\in K^n$ such that $\\{v, Mv, M^2v, \\ldots, M^{n-1}v\\}$ spans $K^n$, equivalently no nonzero polynomial of degree $< n$ annihilates $v$ under $M$.",
     "significance": "key",
     "prerequisites": [
@@ -83,7 +83,7 @@
     "content": "The most technically intricate helper: over an infinite field $K$, a nontrivial $K$-vector space cannot be a finite union of proper subspaces. Proved by induction on the number of subspaces, using a line argument. Given $v \\notin S_k$ and $w \\notin S_1 \\cup \\cdots \\cup S_{k-1}$ (from the inductive hypothesis), the line $\\{v + tw : t \\in K\\}$ meets each $S_i$ in at most one point — because two intersections $v + t_1 w, v + t_2 w \\in S_i$ would force $(t_1 - t_2)w \\in S_i$, hence $w \\in S_i$ (contradicting the choice of $w$). Since $K$ is infinite and there are only finitely many bad values of $t$, some $v + tw$ avoids all subspaces.",
     "mathContext": "For proper subspaces $S_1, \\ldots, S_k \\subsetneq V$ over infinite $K$: $\\exists v \\in V \\setminus (S_1 \\cup \\cdots \\cup S_k)$. The key: $|\\{t \\in K : v + tw \\in S_i\\}| \\leq 1$ for each $i$, so the set of bad parameters has $|\\text{bad}| \\leq k < |K| = \\infty$.",
     "significance": "key",
-    "relatedConcepts": ["prime avoidance", "Zariski topology", "generic points"],
+    "relatedConcepts": ["prime avoidance", "Zariski topology", "generic points", "Davis avoidance lemma", "structure theorem for modules over PIDs"],
     "prerequisites": ["Finset.induction_on", "Submodule.smul_mem", "Set.Finite"]
   },
   {
@@ -121,18 +121,6 @@
     "significance": "key",
     "relatedConcepts": ["unique factorization", "associated elements", "normalizedFactors", "contradiction"],
     "prerequisites": ["exists_mem_normalizedFactors_of_dvd", "dvd_of_mem_normalizedFactors"]
-  },
-  {
-    "id": "ann-ker-proper",
-    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01",
-    "range": { "startLine": 134, "endLine": 144 },
-    "type": "technique",
-    "title": "Proper Kernel of Nonzero Matrix",
-    "content": "If a matrix $A \\neq 0$, then $\\ker(A) \\neq K^n$ (the kernel is a proper subspace). Proved by contrapositive: if $\\ker(A) = K^n$, then $A e_j = 0$ for every standard basis vector $e_j$, so every column of $A$ is zero, contradicting $A \\neq 0$. This is used in Phase 2 to show that each cofactor kernel $\\ker((\\mu/q)(M))$ is a proper subspace — since $\\deg(\\mu/q) < n = \\deg(\\mu)$, the matrix $(\\mu/q)(M)$ is nonzero by the minimality of the minimal polynomial.",
-    "mathContext": "$A \\neq 0 \\implies \\ker(A) \\subsetneq K^n$. The proof extracts column $j$ via $A e_j = 0$ using `Pi.single j 1` as the standard basis vector, then reads off the matrix entry $A_{ij}$ from the dot product.",
-    "significance": "supporting",
-    "relatedConcepts": ["kernel of linear map", "standard basis", "proper subspace"],
-    "prerequisites": ["Matrix.mulVecLin", "LinearMap.mem_ker", "Pi.single"]
   },
   {
     "id": "ann-phase2-subspaces",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -89,7 +89,8 @@
       "Union avoidance is the key: over an infinite field, finitely many proper subspaces cannot cover the whole space",
       "The GCD/Bezout argument connects polynomial annihilation to the factor structure of the minimal polynomial",
       "Polynomial evaluations at the same matrix commute, enabling the d(M)v = 0 argument via mul_comm",
-      "normalizedFactors provides the canonical finite set of irreducible factors needed for union avoidance"
+      "normalizedFactors provides the canonical finite set of irreducible factors needed for union avoidance",
+      "The proof structure mirrors the prime avoidance lemma in commutative algebra (Davis 1964): proper submodules replace prime ideals, and the line argument replaces the pigeonhole argument — a concrete instance of the algebra/geometry dictionary"
     ]
   },
   "sections": [
@@ -130,9 +131,10 @@
     "summary": "Complete proof that nonderogatory matrices over infinite fields have cyclic vectors. All 5 theorems and 2 definitions are fully verified with 0 sorries, 0 axioms, using Mathlib's UniqueFactorizationMonoid infrastructure.",
     "implications": "This resolves the sorry in CayleyHamiltonMinpolyOQ04Backward.lean (which had the complete proof architecture but couldn't import UFD due to DecidableEq conflicts). Combined with the forward direction from OQ04, this gives a complete characterization: over infinite fields, M is nonderogatory iff it has a cyclic vector.",
     "openQuestions": [
-      "Can the infinite field hypothesis be weakened to fields with |K| > n?",
-      "What is the measure of cyclic vectors among all vectors (Zariski density)?",
-      "Extend to nonderogatory operators on infinite-dimensional spaces"
+      "Can the infinite field hypothesis be weakened to fields with $|K| > n$? The union avoidance argument only needs $|K| \\geq k$ where $k$ is the number of irreducible factors, which is at most $n$.",
+      "What is the measure of cyclic vectors? Over $\\mathbb{R}$ or $\\mathbb{C}$, the set of cyclic vectors is Zariski-open (complement of a determinantal variety), hence has full Lebesgue measure — can this be formalized?",
+      "Extend to nonderogatory operators on infinite-dimensional spaces, where the structure theorem for modules over PIDs gives a countable invariant factor decomposition",
+      "Over finite fields $\\mathbb{F}_q$ with $q \\leq n$, the union avoidance lemma fails. What is the exact threshold: for which $(n, q)$ pairs does every nonderogatory $M \\in M_n(\\mathbb{F}_q)$ have a cyclic vector?"
     ]
   },
   "sorryCount": 0,
@@ -173,13 +175,25 @@
       "targetId": "fundamental-arithmetic",
       "relationship": "uses",
       "description": "Unique factorization in $K[X]$ (a Euclidean domain, hence UFD) provides the irreducible factor decomposition of the minimal polynomial, which drives the union avoidance construction"
+    },
+    {
+      "targetId": "cayley-hamilton-reduction",
+      "relationship": "related",
+      "description": "Both extend the Cayley-Hamilton theorem in different directions: reduction develops computational aspects, while this proof develops the structural characterization via cyclic vectors"
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "uses-concept",
+      "description": "The Euclidean algorithm for polynomial GCD is the computational backbone of the Bezout identity used in the GCD annihilation lemma"
     }
   ],
   "relatedProofs": [
     "cayley-hamilton",
     "cayley-hamilton-minpoly",
     "bezout-identity",
-    "fundamental-arithmetic"
+    "fundamental-arithmetic",
+    "cayley-hamilton-reduction",
+    "gcd-algorithm"
   ],
   "references": [
     {
@@ -202,6 +216,13 @@
       "year": "2008",
       "venue": "Springer GTM 135, 3rd edition",
       "note": "Graduate text with a thorough development of the cyclic decomposition theorem and its connection to the rational canonical form via invariant factors"
+    },
+    {
+      "authors": "Davis, Edward D.",
+      "title": "Ideals of the principal class, R-sequences, and a certain monoidal transformation",
+      "year": "1964",
+      "venue": "Pacific Journal of Mathematics",
+      "note": "Contains the prime avoidance lemma in commutative algebra, whose linear algebra analogue (union avoidance over infinite fields) is the key technical tool in this proof"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Deep enrichment pass on Nonderogatory Matrices Have Cyclic Vectors proof:

- **Fixed duplicate annotation** (ann-ker-proper appeared twice)
- **Module-theoretic perspective**: cyclic K[X]-module = single invariant factor
- **Prime avoidance link**: keyInsight connecting union avoidance to Davis (1964)
- **Davis (1964) reference** for prime avoidance
- **Deeper open questions** with LaTeX, finite field threshold
- **Expanded cross-references**: cayley-hamilton-reduction, gcd-algorithm

## Test plan

- [x] JSON validation passes
- [x] Only target proof files modified (2 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)