### PR TITLE
Enrich 5 entries: fix errors, add references, standardize format

### DIFF
--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -153,39 +153,29 @@
   },
   "references": [
     {
-      "authors": "Euler, Leonhard",
-      "title": "De summis serierum reciprocarum",
-      "year": "1735",
-      "venue": "Commentarii academiae scientiarum Petropolitanae, 7, pp. 123-134",
-      "note": "Euler's original solution to the Basel Problem, presented to the St. Petersburg Academy in 1734 and published in 1735, using the sin(x)/x infinite product factorization"
+      "key": "Eu35",
+      "citation": "Euler, L., De summis serierum reciprocarum, Commentarii academiae scientiarum Petropolitanae 7 (1735), 123–134. Euler's original solution using the sin(x)/x infinite product factorization, presented to the St. Petersburg Academy in 1734.",
+      "type": "paper"
     },
     {
-      "authors": "Mengoli, Pietro",
-      "title": "Novae quadraturae arithmeticae, seu de additione fractionum",
-      "year": "1650",
-      "venue": "Bologna",
-      "note": "First posing of the Basel Problem: what is the exact sum of 1 + 1/4 + 1/9 + 1/16 + ...?"
+      "key": "Me50",
+      "citation": "Mengoli, P., Novae quadraturae arithmeticae, seu de additione fractionum, Bologna (1650). First posing of the Basel Problem.",
+      "type": "book"
     },
     {
-      "authors": "Apéry, Roger",
-      "title": "Irrationalité de ζ(2) et ζ(3)",
-      "year": "1979",
-      "venue": "Astérisque 61, pp. 11-13",
-      "note": "Proved ζ(3) is irrational — the first odd zeta value shown to be irrational, a major breakthrough"
+      "key": "Ap79",
+      "citation": "Apéry, R., Irrationalité de ζ(2) et ζ(3), Astérisque 61 (1979), 11–13. Proved ζ(3) is irrational — the first odd zeta value shown to be irrational.",
+      "type": "paper"
     },
     {
-      "authors": "Dunham, William",
-      "title": "Euler: The Master of Us All",
-      "year": "1999",
-      "venue": "MAA Dolciani Mathematical Expositions 22",
-      "note": "Chapter 3 gives a detailed account of Euler's Basel Problem solution including the sin(x)/x factorization, his computation of higher zeta values, and the historical context of the Bernoulli family's failed attempts"
+      "key": "Du99",
+      "citation": "Dunham, W., Euler: The Master of Us All, MAA Dolciani Mathematical Expositions 22 (1999), Chapter 3. Detailed account of Euler's Basel Problem solution.",
+      "type": "book"
     },
     {
-      "authors": "Rivoal, Tanguy",
-      "title": "La fonction zêta de Riemann prend une infinité de valeurs irrationnelles aux entiers impairs",
-      "year": "2000",
-      "venue": "Comptes Rendus de l'Académie des Sciences, Série I, 331, pp. 267-270",
-      "note": "Proved that infinitely many odd zeta values ζ(2k+1) are irrational — a partial resolution of the mystery of odd zeta values that contrasts with the explicit Basel formula for even values"
+      "key": "Ri00",
+      "citation": "Rivoal, T., La fonction zêta de Riemann prend une infinité de valeurs irrationnelles aux entiers impairs, Comptes Rendus Acad. Sci. Paris Sér. I 331 (2000), 267–270.",
+      "type": "paper"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

Enrichment pass across 5 gallery entries:

### amgm-inequality-oq-02
- Fixed annotation count inconsistency ("13 results" → "17 proved theorems")
- Added 3 references: Huh (2022), Schur (1923), Marshall-Olkin-Arnold (2011)
- Detailed the 2 axioms in assumptions field

### amgm-inequality-oq-03
- Fixed theorem count in preamble ("7 results" → "13 theorems: 7 main + 6 helpers")
- Added 2 references: Hölder (1889), Riesz (1927)

### angle-trisection
- Fixed annotation claiming "3 deep results" axiomatized (Lindemann is proved, not axiomatized)
- Detailed the 2 axioms in assumptions field

### arithmetic-series
- Standardized 6 references from non-standard format to key/citation/type schema

### basel-problem
- Standardized 5 references from non-standard format to key/citation/type schema

## Test plan
- [ ] All JSON parses cleanly (verified locally)
- [ ] No annotation validation errors for these entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)