### PR TITLE
Enrich taylor-sincos + abel-ruffini + erdos-1155-oq-01 + cauchy-schwarz-integral

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -47,7 +47,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Bunyakovsky's Extension to Integrals**\n\nViktor Bunyakovsky proved the integral form of the Cauchy-Schwarz inequality in 1859, extending Cauchy's 1821 discrete version to continuous functions. Hermann Schwarz independently proved it in 1885. The inequality states that for square-integrable functions $f, g$:\n\n$$\\left(\\int f \\cdot g \\, d\\mu\\right)^2 \\leq \\left(\\int f^2 \\, d\\mu\\right) \\cdot \\left(\\int g^2 \\, d\\mu\\right)$$\n\nThis is fundamental to functional analysis: it shows that the $L^2$ inner product is well-defined and that $L^2$ is a Hilbert space.\n\n**Modern Formalization Strategy**\n\nIn Mathlib, $L^2(\\mu)$ is already equipped with an `InnerProductSpace` instance, where $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$. The abstract Cauchy-Schwarz inequality $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ therefore immediately gives the integral form. The key insight is that the bridge theorem connecting the abstract inner product to the concrete integral is the critical step.",
+    "historicalContext": "**From Discrete Sums to Integrals: A Three-Generation Story**\n\nAugustin-Louis Cauchy first stated the discrete inequality $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ in his 1821 *Cours d'Analyse*, proving it as a lemma for bounding products of sums. The proof was algebraic: expand $(\\sum a_i b_j - a_j b_i)^2 \\geq 0$ and rearrange — the Binet-Cauchy identity. This inequality became a workhorse of 19th-century analysis.\n\nViktor Yakovlevich Bunyakovsky (1804–1889) recognized in 1859 that Cauchy's argument extends to integrals. In his memoir *Sur quelques inégalités concernant les intégrales ordinaires et les intégrales aux différences finies*, published in the Memoirs of the St. Petersburg Academy, he proved the continuous version:\n$$\\left(\\int_a^b f(x) g(x) \\, dx\\right)^2 \\leq \\int_a^b f(x)^2 \\, dx \\cdot \\int_a^b g(x)^2 \\, dx$$\nfor Riemann-integrable functions on $[a,b]$. His proof replaced finite sums with Riemann sums and passed to the limit — the natural generalization of Cauchy's method.\n\nHermann Amandus Schwarz (1843–1921) independently proved the integral form in 1885 in the context of minimal surfaces and variational calculus, using it to bound the first variation of area functionals. Because Bunyakovsky's work was published in Russian and French in the St. Petersburg memoirs, it was less widely known in Western Europe, and the inequality is often called 'Cauchy-Schwarz' despite Bunyakovsky's priority.\n\nThe modern measure-theoretic formulation replaces Riemann integrals with Lebesgue integrals and works in $L^2(\\mu)$ for arbitrary measures. This version was established through the work of Frigyes Riesz (1907) and Ernst Fischer (1907), who independently proved the completeness of $L^2$ — the Fischer-Riesz theorem. With $L^2$ as a complete inner product space (Hilbert space), Cauchy-Schwarz becomes a consequence of the abstract inner product axioms.\n\n**Modern Formalization Strategy**\n\nIn Mathlib, $L^2(\\mu)$ is already equipped with an `InnerProductSpace` instance, where $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$. The abstract Cauchy-Schwarz inequality $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ therefore immediately gives the integral form. The key insight is that the bridge theorem connecting the abstract inner product to the concrete integral is the critical step — once established, the integral inequality is a one-line rewrite.",
     "problemStatement": "**Bunyakovsky-Schwarz Integral Inequality**\n\nFor $L^2$ functions $f, g$:\n$$\\left|\\int f \\cdot g \\, d\\mu\\right| \\leq \\|f\\|_{L^2} \\cdot \\|g\\|_{L^2}$$\n\nEquivalently in squared form:\n$$(\\int f \\cdot g \\, d\\mu)^2 \\leq \\|f\\|_{L^2}^2 \\cdot \\|g\\|_{L^2}^2$$\n\nEquality holds if and only if $f$ and $g$ are linearly dependent in $L^2$.",
     "text": "(integral f*g)^2 <= (integral f^2)*(integral g^2). The integral form of Cauchy-Schwarz via L^2 inner product spaces.",
     "proofStrategy": "**Formalization Strategy**\n\n1. **L2 is an InnerProductSpace:** Mathlib provides `InnerProductSpace \\mathbb{R} (Lp \\mathbb{R} 2 \\mu)` as an instance.\n2. **Abstract Cauchy-Schwarz:** Apply `abs_real_inner_le_norm` to get $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$.\n3. **Bridge theorem:** Show $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$ using `L2.inner_def`.\n4. **Rewrite:** Substitute the bridge into the abstract inequality to obtain the integral form.\n5. **Equality:** Use `norm_inner_eq_norm_iff` to characterize equality as linear dependence in $L^2$.",
@@ -59,7 +59,11 @@
       "**Measure-theoretic generality:** The formalization works for arbitrary $\\sigma$-finite measure spaces $(\\Omega, \\mathcal{F}, \\mu)$, not just Lebesgue measure on $\\mathbb{R}$ — encompassing counting measure (recovering the discrete Cauchy-Schwarz) and probability measures (covariance bounds)"
     ],
     "prerequisites": [
-      "Mathematical analysis"
+      "Measure theory (Lebesgue integration, $\\sigma$-algebras, measurable functions)",
+      "Functional analysis (inner product spaces, Hilbert space structure, completeness)",
+      "$L^p$ spaces (definition, norm, completeness for $p = 2$)",
+      "Bochner integration (vector-valued integration in Banach spaces)",
+      "Real analysis (absolute value inequalities, monotonicity of squaring on non-negatives)"
     ]
   },
   "sections": [
@@ -68,40 +72,45 @@
       "title": "Imports and Setup",
       "summary": "Imports Mathlib's L2 space, Bochner integration, inner product space theory, and tactics. Opens `MeasureTheory` namespace and sets up universe variables for a measurable space $(\\alpha, \\mu)$.",
       "startLine": 1,
-      "endLine": 42
+      "endLine": 42,
+      "mathContext": "The setup is parametric over an arbitrary measure space $(\\alpha, \\mathcal{F}, \\mu)$, ensuring the results hold for Lebesgue measure on $\\mathbb{R}^n$, counting measure on $\\mathbb{Z}$, probability measures, and any $\\sigma$-finite measure. The `noncomputable section` is needed because $L^2(\\mu)$ elements are equivalence classes of functions (agreeing $\\mu$-a.e.), which are not computably decidable."
     },
     {
       "id": "abstract-l2",
       "title": "Abstract L2 Cauchy-Schwarz",
       "summary": "Establishes that `Lp \\mathbb{R} 2 \\mu` is an `InnerProductSpace` (via `inferInstance`) and states the abstract Cauchy-Schwarz $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ and its squared form.",
       "startLine": 44,
-      "endLine": 60
+      "endLine": 60,
+      "mathContext": "The abstract Cauchy-Schwarz inequality $|\\langle u, v \\rangle| \\leq \\|u\\| \\cdot \\|v\\|$ holds in any inner product space. The standard proof expands $\\|u - tv\\|^2 \\geq 0$ for optimal $t = \\langle u,v\\rangle / \\|v\\|^2$, yielding a non-negative discriminant condition. The squared form $(\\langle f,g\\rangle)^2 \\leq \\|f\\|^2 \\|g\\|^2$ avoids absolute values and is algebraically cleaner for applications."
     },
     {
       "id": "bridge",
       "title": "Bridge: Inner Product = Integral",
       "summary": "Proves `L2_inner_eq_integral`: $\\langle f, g \\rangle = \\int f(a) \\cdot g(a) \\, d\\mu(a)$, connecting the abstract inner product to concrete integration via `L2.inner_def`.",
       "startLine": 62,
-      "endLine": 73
+      "endLine": 73,
+      "mathContext": "The bridge theorem $\\langle f, g \\rangle_{L^2} = \\int_\\alpha f(a) g(a) \\, d\\mu(a)$ is the Riesz representation in action: the abstract inner product on $L^2$ is *defined* as this integral, but Lean's typeclass system abstracts this away. The proof unfolds `L2.inner_def` and uses `inner x y = x * y` for $x, y \\in \\mathbb{R}$ (since the real inner product is just multiplication). This is the key step that makes the abstract inequality concrete."
     },
     {
       "id": "integral-form",
       "title": "Bunyakovsky-Schwarz Inequality",
       "summary": "States and proves the integral form in both absolute value ($|\\int fg| \\leq \\|f\\|\\|g\\|$) and squared ($(\\int fg)^2 \\leq \\|f\\|^2\\|g\\|^2$) versions by rewriting the bridge theorem into the abstract inequality.",
       "startLine": 75,
-      "endLine": 93
+      "endLine": 93,
+      "mathContext": "The integral Cauchy-Schwarz: $\\left|\\int_\\alpha f \\cdot g \\, d\\mu\\right| \\leq \\left(\\int_\\alpha f^2 \\, d\\mu\\right)^{1/2} \\left(\\int_\\alpha g^2 \\, d\\mu\\right)^{1/2}$. Each proof is a single rewrite substituting the bridge theorem into the abstract inequality — the entire mathematical content is in the type-level identification $L^2(\\mu) \\cong \\text{InnerProductSpace}$, and the proofs are purely structural."
     },
     {
       "id": "equality",
       "title": "Equality Characterization",
       "summary": "Proves equality holds iff $f$ and $g$ are linearly dependent in $L^2$: $|\\langle f, g \\rangle| = \\|f\\|\\|g\\| \\iff \\exists c: f = c \\cdot g$, using `norm_inner_eq_norm_iff`.",
       "startLine": 95,
-      "endLine": 116
+      "endLine": 116,
+      "mathContext": "Equality $|\\langle f, g \\rangle| = \\|f\\| \\cdot \\|g\\|$ holds iff $f = cg$ a.e. for some $c \\in \\mathbb{R}$. Geometrically, this means the 'angle' between $f$ and $g$ in $L^2$ is $0$ or $\\pi$ — they point in the same or opposite directions. The proof uses the standard Hilbert space fact: $\\|u - tv\\|^2 = 0$ for some $t$ iff $u$ and $v$ are proportional. In probability, equality means $Y = aX + b$ a.s. (perfect linear correlation $|\\rho| = 1$)."
     }
   ],
   "conclusion": {
     "summary": "The formalization proves the Bunyakovsky-Schwarz integral inequality by exploiting Mathlib's L2 inner product space structure. The key insight is that the bridge theorem `L2_inner_eq_integral` connecting abstract inner products to concrete integrals turns the abstract Cauchy-Schwarz into the integral form in a single rewrite. All proofs are complete with zero sorries.",
-    "implications": "**Theoretical Significance**: **Implications and Connections**\n\n1. **Hilbert Space Theory:** The inequality is the fundamental tool showing that $L^2(\\mu)$ is a Hilbert space, with $\\langle f, g \\rangle = \\int fg \\, d\\mu$ as a well-defined inner product.\n\n2. **Quantum Mechanics:** The Heisenberg uncertainty principle $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is a direct consequence of this inequality applied to wave functions.\n\n3.\n\n**Broader Connections**: **Probability Theory:** For random variables $X, Y$ with finite variance, $\\text{Cov}(X,Y)^2 \\leq \\text{Var}(X) \\cdot \\text{Var}(Y)$, bounding the correlation coefficient.\n\n4. **Signal Processing:** The matched filter theorem, showing that correlation detection is optimal, is a consequence of Cauchy-Schwarz in $L^2$.\n\n5. **Extends Cauchy-Schwarz Gallery:** This proof completes the Cauchy-Schwarz trilogy: discrete (finite sums), abstract (inner product spaces), and integral (measure-theoretic $L^2$).",
+    "implications": "**Implications and Connections**\n\n1. **Hilbert Space Theory:** The inequality is the fundamental tool showing that $L^2(\\mu)$ is a Hilbert space, with $\\langle f, g \\rangle = \\int fg \\, d\\mu$ as a well-defined inner product. The completeness of $L^2$ (Fischer-Riesz theorem, 1907) together with Cauchy-Schwarz makes $L^2$ the canonical example of an infinite-dimensional Hilbert space.\n\n2. **Quantum Mechanics:** The Heisenberg uncertainty principle $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is a direct consequence of this inequality applied to wave functions in $L^2(\\mathbb{R}^3)$. Robertson's generalization (1929) shows $\\sigma_A \\sigma_B \\geq \\frac{1}{2}|\\langle [A,B] \\rangle|$ for any observables $A, B$, which reduces to Cauchy-Schwarz when the commutator is a scalar.\n\n3. **Probability Theory:** For random variables $X, Y$ with finite variance, $\\text{Cov}(X,Y)^2 \\leq \\text{Var}(X) \\cdot \\text{Var}(Y)$, bounding the Pearson correlation coefficient $|\\rho_{XY}| \\leq 1$. This is Cauchy-Schwarz applied to centered random variables in $L^2(\\Omega, \\mathcal{F}, P)$.\n\n4. **Signal Processing:** The matched filter theorem — that correlation detection is optimal for detecting a known signal in Gaussian noise — follows from Cauchy-Schwarz in $L^2$: the signal-to-noise ratio $\\text{SNR} = |\\int s(t)h(t)\\,dt|^2 / \\int |h(t)|^2\\,dt$ is maximized when $h \\propto s$.\n\n5. **Extends Cauchy-Schwarz Gallery:** This proof completes the Cauchy-Schwarz trilogy: discrete (finite sums), abstract (inner product spaces), and integral (measure-theoretic $L^2$). The measure-theoretic generality subsumes all three: counting measure recovers the discrete case, and any inner product space embeds into some $L^2$.",
     "openQuestions": [
       "Can Holder's inequality be formalized as a generalization, recovering Cauchy-Schwarz for p=q=2?",
       "Can the Minkowski inequality for integrals be derived as a corollary?",
@@ -160,25 +169,39 @@
   },
   "references": [
     {
-      "authors": "V. Y. Bunyakovsky",
-      "title": "Sur quelques inegalites concernant les integrales ordinaires et les integrales aux differences finies",
+      "authors": "Cauchy, A.-L.",
+      "title": "Cours d'Analyse de l'École Royale Polytechnique, Première Partie: Analyse Algébrique",
+      "year": "1821",
+      "venue": "Imprimerie Royale, Paris",
+      "note": "Contains the original discrete Cauchy-Schwarz inequality (Note III) as $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ — the finite-dimensional ancestor of the integral form"
+    },
+    {
+      "authors": "Bunyakovsky, V. Y.",
+      "title": "Sur quelques inégalités concernant les intégrales ordinaires et les intégrales aux différences finies",
       "year": "1859",
-      "venue": "Memoires de l'Academie Imperiale des Sciences de St.-Petersbourg",
-      "note": "First proof of the integral form"
+      "venue": "Mémoires de l'Académie Impériale des Sciences de St.-Pétersbourg, VIIe série, vol. 1, no. 9",
+      "note": "First proof of the integral form, extending Cauchy's discrete inequality to continuous functions via Riemann sum limits"
     },
     {
-      "authors": "H. A. Schwarz",
-      "title": "Uber ein die Flachen kleinsten Flacheninhalts betreffendes Problem der Variationsrechnung",
+      "authors": "Schwarz, H. A.",
+      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung",
       "year": "1885",
-      "venue": "Acta Societatis Scientiarum Fennicae",
-      "note": "Independent proof of the integral version"
+      "venue": "Acta Societatis Scientiarum Fennicae, vol. 15, pp. 315–362",
+      "note": "Independent proof of the integral version in the context of minimal surface problems and variational calculus"
     },
     {
-      "authors": "J. M. Steele",
-      "title": "The Cauchy-Schwarz Master Class",
+      "authors": "Riesz, F.",
+      "title": "Sur les systèmes orthogonaux de fonctions",
+      "year": "1907",
+      "venue": "Comptes Rendus de l'Académie des Sciences, vol. 144, pp. 615–619",
+      "note": "Proved completeness of L² (Fischer-Riesz theorem), establishing L² as a Hilbert space where the abstract Cauchy-Schwarz applies"
+    },
+    {
+      "authors": "Steele, J. M.",
+      "title": "The Cauchy-Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
       "year": "2004",
       "venue": "Cambridge University Press",
-      "note": "Comprehensive treatment including the integral form"
+      "note": "Comprehensive treatment of Cauchy-Schwarz and its generalizations, including the integral form, Hölder's inequality, and applications across mathematics"
     }
   ]
 }

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -100,7 +100,18 @@
       "Topological convergence (Filter.Tendsto, nhds)",
       "Asymptotic notation (Θ, O, Ω)"
     ],
-    "lineCount": 489
+    "lineCount": 489,
+    "leanFile": {
+      "lineCount": 489,
+      "structureCount": 0,
+      "axiomCount": 5,
+      "theoremCount": 20,
+      "lemmaCount": 0,
+      "defCount": 6,
+      "imports": [
+        "Mathlib"
+      ]
+    }
   },
   "sections": [
     {


### PR DESCRIPTION
## Summary

### taylor-sincos-convergence (quality 0 -> enriched, pass 1)
- Restructured meta.json with proper `overview`, `sections`, `conclusion`, `references` schema
- Created annotations.json with 12 annotations covering all 348 lines
- Added Madhava/Kerala school historical context (c. 1350)
- Added cross-reference to `fourier-series`

### abel-ruffini (quality 100, pass 2 cleanup)
- Fixed 4 non-standard "critical" significance values to "key"
- Trimmed cross-references from 53 to 15 most meaningful (-234 lines bloat)

### erdos-1155-oq-01 (quality 45, pass 2 minor)
- Added missing meta.leanFile field for schema consistency

### cauchy-schwarz-integral (quality 100, pass 1 deep enrichment)
- Expanded historicalContext from 2 paragraphs to full three-generation lineage: Cauchy (1821 discrete), Bunyakovsky (1859 integrals), Schwarz (1885 variational), Fischer-Riesz (1907 L² completeness)
- Fixed broken conclusion.implications formatting (empty item 3, malformed section headers)
- Added mathContext to all 5 sections (previously only 1 had it)
- Expanded overview.prerequisites from 1 generic item to 5 specific mathematical topics
- Added 2 references: Cauchy 1821 *Cours d'Analyse*, Riesz 1907 Fischer-Riesz theorem
- Added volume/page details to existing Bunyakovsky and Schwarz references
- Deepened quantum mechanics implications (Robertson 1929 generalization)
- Added probability interpretation of equality condition (perfect correlation |ρ| = 1)

## Test plan
- [x] JSON validates for all files
- [x] All cross-reference targets verified to exist
- [x] No non-standard significance values
- [x] Axiom integrity verified
- [x] `pnpm annotations:build` passes without errors for cauchy-schwarz-integral

🤖 Generated with [Claude Code](https://claude.com/claude-code)