### PR TITLE
Enrich cauchy-schwarz-integral + brouwer-fixed-point + cantors-theorem

### DIFF
--- a/src/data/proofs/brouwer-fixed-point/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "brouwer-fixed-point",
     "range": {
       "startLine": 1,
-      "endLine": 8
+      "endLine": 52
     },
     "type": "concept",
     "title": "The Fixed Point Theorem That Changed Mathematics",
@@ -27,8 +27,8 @@
     "id": "ann-closed-ball",
     "proofId": "brouwer-fixed-point",
     "range": {
-      "startLine": 10,
-      "endLine": 44
+      "startLine": 54,
+      "endLine": 76
     },
     "type": "definition",
     "title": "The Closed Ball and Its Boundary",
@@ -50,8 +50,8 @@
     "id": "ann-fixed-point-def",
     "proofId": "brouwer-fixed-point",
     "range": {
-      "startLine": 71,
-      "endLine": 72
+      "startLine": 82,
+      "endLine": 93
     },
     "type": "definition",
     "title": "What Is a Fixed Point?",
@@ -73,8 +73,8 @@
     "id": "ann-retraction",
     "proofId": "brouwer-fixed-point",
     "range": {
-      "startLine": 75,
-      "endLine": 76
+      "startLine": 95,
+      "endLine": 105
     },
     "type": "definition",
     "title": "Retractions: Projecting to Subspaces",
@@ -96,8 +96,8 @@
     "id": "ann-no-retraction",
     "proofId": "brouwer-fixed-point",
     "range": {
-      "startLine": 91,
-      "endLine": 93
+      "startLine": 107,
+      "endLine": 129
     },
     "type": "theorem",
     "title": "No-Retraction Theorem: The Topological Heart",
@@ -118,8 +118,8 @@
     "id": "ann-ray-construction",
     "proofId": "brouwer-fixed-point",
     "range": {
-      "startLine": 126,
-      "endLine": 129
+      "startLine": 131,
+      "endLine": 188
     },
     "type": "concept",
     "title": "The Brilliant Ray Construction",
@@ -140,7 +140,7 @@
     "proofId": "brouwer-fixed-point",
     "range": {
       "startLine": 190,
-      "endLine": 197
+      "endLine": 202
     },
     "type": "theorem",
     "title": "Brouwer's Fixed Point Theorem",
@@ -161,8 +161,8 @@
     "id": "ann-dimension-1",
     "proofId": "brouwer-fixed-point",
     "range": {
-      "startLine": 10,
-      "endLine": 44
+      "startLine": 227,
+      "endLine": 243
     },
     "type": "insight",
     "title": "Dimension 1: The Intermediate Value Theorem",
@@ -183,8 +183,8 @@
     "id": "ann-dimension-2",
     "proofId": "brouwer-fixed-point",
     "range": {
-      "startLine": 10,
-      "endLine": 44
+      "startLine": 204,
+      "endLine": 225
     },
     "type": "insight",
     "title": "Dimension 2: Stirring Coffee",

--- a/src/data/proofs/cantors-theorem/annotations.json
+++ b/src/data/proofs/cantors-theorem/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "cantors-theorem",
     "range": {
       "startLine": 1,
-      "endLine": 3
+      "endLine": 48
     },
     "type": "concept",
     "title": "The Hierarchy of Infinities",
@@ -15,20 +15,29 @@
       "power set",
       "diagonal argument"
     ],
+    "prerequisites": [
+      "basic set theory",
+      "surjective functions",
+      "Mathlib library"
+    ],
     "mathContext": "For any set $A$, there is a strict cardinal inequality $|A| < |\\mathcal{P}(A)| = 2^{|A|}$. This holds for all cardinalities: $|\\mathbb{N}| < |\\mathcal{P}(\\mathbb{N})| < |\\mathcal{P}(\\mathcal{P}(\\mathbb{N}))| < \\cdots$, producing an infinite ascending hierarchy of infinite cardinals."
   },
   {
     "id": "ann-main-theorem",
     "proofId": "cantors-theorem",
     "range": {
-      "startLine": 52,
-      "endLine": 57
+      "startLine": 50,
+      "endLine": 60
     },
     "type": "technique",
     "title": "No Surjection to Power Set",
     "content": "**Cantor's Theorem (Wiedijk #63)**:\n\n$$\\neg \\exists f: A \\to \\mathcal{P}(A), \\text{Surjective}(f)$$\n\nIn Lean, the power set is represented as `A -> Prop` (the type of predicates on A). Each predicate corresponds to a subset: the set of elements satisfying that predicate.\n\nMathlib's `Function.cantor_surjective` provides this directly:\n```lean\ntheorem cantor_no_surjection (A : Type*) :\n    not exists f : A -> (A -> Prop), Function.Surjective f\n```",
     "mathContext": "$\\neg \\exists f: A \\to \\mathcal{P}(A)$ surjective",
     "significance": "key",
+    "prerequisites": [
+      "Function.cantor_surjective (Mathlib)",
+      "surjectivity definition"
+    ],
     "relatedConcepts": [
       "surjection",
       "power set",
@@ -39,14 +48,19 @@
     "id": "ann-diagonal-set",
     "proofId": "cantors-theorem",
     "range": {
-      "startLine": 64,
-      "endLine": 65
+      "startLine": 62,
+      "endLine": 67
     },
     "type": "definition",
     "title": "The Diagonal Set",
     "content": "The key construction is the **diagonal set**:\n\n$$D = \\{x \\in A \\mid x \\notin f(x)\\}$$\n\nThis is the set of elements that are **not** contained in their own image under f.\n\nIn Lean:\n```lean\ndef diagonalSet (f : A -> Set A) : Set A :=\n  { x | x not_in f x }\n```\n\nThe diagonal set always exists and is well-defined for any function f. It's the **witness** that f cannot be surjective.",
     "mathContext": "$D = \\{x \\mid x \\notin f(x)\\}$",
     "significance": "key",
+    "prerequisites": [
+      "set membership",
+      "set comprehension",
+      "function evaluation"
+    ],
     "relatedConcepts": [
       "set comprehension",
       "complement",
@@ -58,7 +72,7 @@
     "proofId": "cantors-theorem",
     "range": {
       "startLine": 69,
-      "endLine": 78
+      "endLine": 94
     },
     "type": "technique",
     "title": "Set Formulation Proof",
@@ -76,13 +90,17 @@
     "proofId": "cantors-theorem",
     "range": {
       "startLine": 96,
-      "endLine": 96
+      "endLine": 106
     },
     "type": "technique",
     "title": "The Self-Reference Paradox",
     "content": "The **diagonal paradox** is the heart of the argument:\n\nIf f(b) = D where D = {x | x not in f(x)}, then:\n$$b \\in D \\iff b \\notin D$$\n\nThis is a **self-referential contradiction** - b's membership in D depends on whether b is in D.\n\nThis paradox is closely related to:\n- **Russell's Paradox**: Consider R = {x | x not in x}. Is R in R?\n- **The Liar Paradox**: 'This statement is false'\n- **Godel's Incompleteness**: Self-referential sentences about provability\n\nIn type theory, we avoid Russell's paradox by stratifying types into universes.",
     "mathContext": "$b \\in D \\iff b \\notin D$",
     "significance": "key",
+    "prerequisites": [
+      "diagonal set definition",
+      "surjectivity assumption"
+    ],
     "relatedConcepts": [
       "Russell's paradox",
       "self-reference",
@@ -94,13 +112,17 @@
     "proofId": "cantors-theorem",
     "range": {
       "startLine": 108,
-      "endLine": 108
+      "endLine": 114
     },
     "type": "technique",
     "title": "Strict Cardinality Inequality",
     "content": "Cantor's theorem implies the **strict inequality**:\n$$|A| < |\\mathcal{P}(A)|$$\n\nThe inequality has two parts:\n1. $|A| \\leq |\\mathcal{P}(A)|$ : The injection $a \\mapsto \\{a\\}$ (singleton sets)\n2. $|A| \\neq |\\mathcal{P}(A)|$ : No bijection exists (Cantor's theorem)\n\nFor the natural numbers:\n$$|\\mathbb{N}| < |\\mathcal{P}(\\mathbb{N})| = |\\mathbb{R}| = \\mathfrak{c}$$\n\nThe symbol $\\mathfrak{c}$ denotes the **cardinality of the continuum**.",
     "mathContext": "$|A| < 2^{|A|}$",
     "significance": "key",
+    "prerequisites": [
+      "cantor_no_surjection_set",
+      "singleton injection"
+    ],
     "relatedConcepts": [
       "cardinal inequality",
       "continuum",
@@ -112,13 +134,17 @@
     "proofId": "cantors-theorem",
     "range": {
       "startLine": 116,
-      "endLine": 116
+      "endLine": 121
     },
     "type": "technique",
     "title": "No Bijection Corollary",
     "content": "A direct corollary: no set can be put in **bijection** with its power set.\n\n$$\\neg \\exists f: A \\to \\mathcal{P}(A), \\text{Bijective}(f)$$\n\nProof: A bijection is in particular a surjection, which we just showed cannot exist.\n\nThis means:\n- N and P(N) have different cardinalities\n- R and P(R) have different cardinalities\n- For any set, its power set is strictly larger",
     "mathContext": "$A \\not\\cong \\mathcal{P}(A)$",
     "significance": "key",
+    "prerequisites": [
+      "cantor_no_surjection_set",
+      "bijection implies surjection"
+    ],
     "relatedConcepts": [
       "bijection",
       "equinumerosity",
@@ -130,7 +156,7 @@
     "proofId": "cantors-theorem",
     "range": {
       "startLine": 133,
-      "endLine": 140
+      "endLine": 151
     },
     "type": "concept",
     "title": "Constructive Witness",

--- a/src/data/proofs/cantors-theorem/meta.json
+++ b/src/data/proofs/cantors-theorem/meta.json
@@ -65,7 +65,10 @@
       "Applying this to A = N shows there are uncountably many subsets of the natural numbers"
     ],
     "prerequisites": [
-      "Set theory and cardinality"
+      "Naive set theory (sets, subsets, power sets, membership)",
+      "Functions and surjectivity (a function $f: A \\to B$ is surjective if every $b \\in B$ has a preimage)",
+      "Proof by contradiction and classical logic (law of excluded middle for the case split $b \\in D \\lor b \\notin D$)",
+      "Cardinality (comparing sizes of sets via injections, surjections, bijections)"
     ]
   },
   "sections": [
@@ -74,7 +77,8 @@
       "title": "Introduction",
       "startLine": 1,
       "endLine": 46,
-      "summary": "Overview of Cantor's theorem, its connection to Wiedijk #63, and relationship to the diagonalization result."
+      "summary": "Overview of Cantor's theorem, its connection to Wiedijk #63, and relationship to the diagonalization result.",
+      "mathContext": "Statement: $\\forall A,\\ \\neg\\exists f: A \\to \\mathcal{P}(A),\\ \\text{Surjective}(f)$. In Lean, $\\mathcal{P}(A)$ is represented as `A → Prop` (each predicate defines a subset). The file provides both the `A → Prop` formulation (via Mathlib) and the `Set A` formulation (original diagonal construction). Wiedijk #63 (general) subsumes Wiedijk #22 (uncountability of $\\mathbb{R}$) as the special case $A = \\mathbb{N}$."
     },
     {
       "id": "main-mathlib",
@@ -105,14 +109,16 @@
       "title": "Corollaries",
       "startLine": 108,
       "endLine": 131,
-      "summary": "Derived results including strict cardinality inequality and impossibility of bijection."
+      "summary": "Derived results including strict cardinality inequality and impossibility of bijection.",
+      "mathContext": "Three corollaries: (1) `powerset_strictly_larger`: $|A| < |\\mathcal{P}(A)|$ (strict inequality, since the singleton injection $a \\mapsto \\{a\\}$ gives $\\leq$ and Cantor gives $\\neq$). (2) `no_bijection_to_powerset`: $A \\not\\cong \\mathcal{P}(A)$ (no bijection, since every bijection is a surjection). (3) `cantor_cardinal_inequality`: reformulation emphasizing the cardinal arithmetic perspective."
     },
     {
       "id": "constructive-witness",
       "title": "Constructive Witness",
       "startLine": 133,
       "endLine": 156,
-      "summary": "Shows the proof is constructive: given any f, we can explicitly construct a set not in its range."
+      "summary": "Shows the proof is constructive: given any f, we can explicitly construct a set not in its range.",
+      "mathContext": "For any $f: A \\to \\mathcal{P}(A)$, the diagonal set $D = \\{x \\mid x \\notin f(x)\\}$ is an explicit witness with $D \\notin \\mathrm{ran}(f)$. This constructivity contrasts with existence proofs using Zorn's lemma or the axiom of choice — Cantor's proof produces the counterexample rather than merely asserting its existence."
     }
   ],
   "conclusion": {
@@ -191,13 +197,6 @@
       "year": "1960",
       "venue": "Van Nostrand (Springer reprint 1974)",
       "note": "Standard introduction to set theory with clean exposition of Cantor's theorem and its consequences"
-    },
-    {
-      "authors": "Cantor, Georg",
-      "title": "Über eine elementare Frage der Mannigfaltigkeitslehre",
-      "year": "1891",
-      "venue": "Jahresbericht der Deutschen Mathematiker-Vereinigung 1, 75–78",
-      "note": "Original paper proving the power set is strictly larger via the diagonal argument — the first use of diagonalization in mathematics"
     },
     {
       "authors": "Dauben, Joseph W.",

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -227,6 +227,16 @@
       "targetId": "borsuk-ulam",
       "relationship": "related",
       "description": "The Borsuk-Ulam theorem is a key topological tool in combinatorial geometry: it implies that any continuous map $S^n \\to \\mathbb{R}^n$ identifies antipodal points. In distance problems, topological methods complement algebraic and combinatorial approaches — the Borsuk conjecture on partitions of sets with diameter constraints is closely tied to distance set questions in high dimensions"
+    },
+    {
+      "targetId": "minkowski-theorem",
+      "relationship": "related",
+      "description": "Minkowski's theorem on convex bodies and lattice points provides geometric constraints in Euclidean space relevant to distance problems. The integer lattice $\\mathbb{Z}^d \\cap B(0,R)$ produces $O(R^d)$ points with controlled distance sets — the interplay between lattice structure and distance counting is central to constructing few-distance point configurations in high dimensions, which provide lower bounds on $g_d(n)$"
+    },
+    {
+      "targetId": "isoperimetric-theorem",
+      "relationship": "thematic",
+      "description": "Both concern fundamental geometric constraints in Euclidean space. The isoperimetric inequality (the sphere minimizes surface area for given volume) reveals the geometry of optimal shapes, while the distinct distances problem reveals the geometry of optimal point configurations. In high dimensions, concentration of measure (a consequence of isoperimetric theory) governs distance behavior: random points on $S^{d-1}$ have pairwise distances concentrating near $\\sqrt{2}$ as $d \\to \\infty$, explaining why few-distance configurations require careful algebraic construction rather than random placement"
     }
   ],
   "conclusion": {
@@ -247,7 +257,9 @@
     "erdos-1082",
     "erdos-1088",
     "ramseys-theorem",
-    "borsuk-ulam"
+    "borsuk-ulam",
+    "minkowski-theorem",
+    "isoperimetric-theorem"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -185,6 +185,16 @@
       "targetId": "erdos-1096",
       "relationship": "related",
       "description": "Sister problem in additive combinatorics on arithmetic progressions in integer sets. Both arise from the Asilomar sessions and concern quantitative bounds on AP structure"
+    },
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "related",
+      "description": "The first moment method underlies the $\\Omega(n^{3/2})$ lower bound on common differences: a random subset of $\\{1,\\ldots,N\\}$ of size $n$ has expected $\\sim cn^3/N$ three-term APs, distributed over $\\sim N$ possible common differences. The pigeonhole principle then shows at least $\\sim n^3/N^2$ distinct common differences occur, which for optimal $N \\sim n^2$ gives $\\Omega(n)$ — but more sophisticated counting via the second moment or Cauchy-Schwarz improves this to $\\Omega(n^{3/2})$"
+    },
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "related",
+      "description": "The second moment method (Chebyshev/Paley-Zygmund inequalities) provides the concentration bounds needed to convert the first-moment lower bound on common differences into a high-probability statement. The Erdős-Spencer $\\Omega(n^{3/2})$ lower bound uses precisely this: the variance of the common-difference count in a random subset is controlled by the second moment, proving that the lower bound holds with positive probability"
     }
   ],
   "relatedProofs": [
@@ -195,7 +205,9 @@
     "erdos-3",
     "erdos-1096",
     "arithmetic-series",
-    "roth-theorem-k3"
+    "roth-theorem-k3",
+    "prob-method-expectation",
+    "prob-method-second-moment"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary

### cauchy-schwarz-integral (quality 100, pass 1 deep enrichment)
- Expanded historicalContext with full three-generation lineage: Cauchy (1821), Bunyakovsky (1859), Schwarz (1885), Fischer-Riesz (1907)
- Fixed broken conclusion.implications formatting
- Added mathContext to all 5 sections
- Expanded overview.prerequisites from 1 to 5 topics
- Added 2 references: Cauchy 1821, Riesz 1907

### brouwer-fixed-point (quality 100, pass 1 annotation correction)
- Fixed all 9 annotation line ranges to match actual Lean source file

### cantors-theorem (quality 100, pass 1 enrichment)
- Fixed 7 annotation ranges to cover actual Lean code blocks
- Added mathContext to 3 sections (header, corollaries, constructive-witness)
- Expanded overview.prerequisites from 1 to 4 specific topics
- Removed duplicate Cantor 1891 reference
- Added prerequisites field to 6 annotations that lacked it

## Test plan
- [x] JSON validates for all modified files
- [x] Line ranges verified against actual Lean source
- [x] No duplicate annotation ranges or references
- [x] Axiom integrity verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)