### PR TITLE
Enrich 10 entries: expand vague assumptions (#7)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -67,7 +67,7 @@
       "Compass-and-straightedge constructibility (from OQ-01)"
     ],
     "lineCount": 298,
-    "assumptions": "1 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "1 axiom: wantzel_galois_characterization — the Wantzel-Galois biconditional: an algebraic number α is constructible by compass and straightedge iff the Galois group of its minimal polynomial over ℚ is a 2-group (IsPGroup 2 (minpoly ℚ α).Gal). Axiomatized because the full proof requires the Galois correspondence for intermediate fields. All other results (non-constructibility of ∛2 and cos(20°), constructibility of √2 and 2^{1/4}, hierarchy of criteria) are fully proved from this axiom with 0 sorries."
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary
Batch 6: 10 more entries with vague assumptions replaced by specific axiom descriptions.

- erdos-128, erdos-464, parallel-postulate-independence-oq-02, erdos-487, erdos-1025
- erdos-944, erdos-1013, erdos-63, erdos-119, erdos-1132

All axiom counts verified against Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)