### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -5463,6 +5463,46 @@
       "started": "2026-03-23T00:45:41.642Z",
       "status": "active",
       "lastUpdate": "2026-03-23T00:45:41.642Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.537Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T17:46:34.537Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.538Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T17:46:34.538Z"
+    },
+    {
+      "slug": "dissection-of-cubes-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.541Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T17:46:34.541Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.541Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T17:46:34.541Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.542Z",
+      "status": "active",
+      "lastUpdate": "2026-03-23T17:46:34.542Z"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (added 16, updated 77 listings, total 1004 iterations)
- Update enrichment tracker and annotations data
- Add new research problem entries

Automated sync from deployer agent.