### PR TITLE
Add math agent PR label policy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,12 @@ This project uses **two distinct AI agent orchestration systems** for different 
 
 **Team orchestration**: `/lean` - Start/stop/scale the full mathematical agent team
 
+### PR Labels for Math Agents
+
+**Math agents (Researcher, Enricher, Aristotle, Erdos Enhancer) must NOT add `loom:review-requested` to their PRs.** The deployer merges math PRs directly without Judge review. Only add content-specific labels like `research`, `enrichment`, or `aristotle-integration`.
+
+If you want a specific PR to go through Loom Judge review, manually add `loom:review-requested` — the deployer will skip it until a Judge approves it.
+
 ### Two Enrichment Systems
 
 The project has two distinct enrichment systems:


### PR DESCRIPTION
## Summary
- Math agents were still adding `loom:review-requested` to PRs because CLAUDE.md Loom examples showed it
- Added explicit policy note in the math orchestration section: math agents must NOT add this label
- Also removed the label from PR #5245 which was created after the earlier fix

Follows up on #4995 which removed the label from role definitions and deployer scripts.

## Test plan
- [x] Verified no other references instruct math agents to add the label
- [ ] Next researcher PR cycle should create PRs without `loom:review-requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)