### PR TITLE
Enrich 6 entries: collatz-oq-02, erdos-504, three-place-identity, randomized-maxcut, erdos-959, poincare-conjecture

### DIFF
--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -62,80 +62,92 @@
       "targetId": "erdos-1026",
       "relationship": "related",
       "description": "Monotonic subsequence optimization — uses the classical Erdős–Szekeres theorem (1935), which shares foundational roots with the point-set geometry studied here"
+    },
+    {
+      "targetId": "erdos-500",
+      "relationship": "related",
+      "description": "Another Erdős discrete geometry problem in the 500-series — part of the same cluster of extremal point-set problems that Erdős systematically studied from the 1930s onward"
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "foundational",
+      "description": "The law of cosines $c^2 = a^2 + b^2 - 2ab\\cos C$ provides the algebraic foundation for computing angles between points via the dot product formula used to define $\\angle(x,y,z)$"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem underpins the Euclidean norm $\\|v\\| = \\sqrt{v_1^2 + v_2^2}$ used in the angle definition $\\angle(x,y,z) = \\arccos\\bigl(\\frac{(x-y)\\cdot(z-y)}{\\|x-y\\|\\|z-y\\|}\\bigr)$"
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "thematic",
+      "description": "The inscribed angle theorem — central to proving regular polygon optimality for $\\alpha_{2^n}$ — is intimately connected to the circle geometry formalized in the area-of-circle entry"
     }
   ],
   "sections": [
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "range": {
-        "startLine": 43,
-        "endLine": 66
-      },
-      "content": "Defines the angle $\\angle(x,y,z)$ at vertex $y$ using the dot product formula $\\arccos\\bigl(\\frac{(x-y)\\cdot(z-y)}{\\|x-y\\|\\|z-y\\|}\\bigr)$, with axioms for range $[0,\\pi]$ and symmetry $\\angle(x,y,z) = \\angle(z,y,x)$."
+      "startLine": 43,
+      "endLine": 66,
+      "content": "Defines the angle $\\angle(x,y,z)$ at vertex $y$ using the dot product formula $\\arccos\\bigl(\\frac{(x-y)\\cdot(z-y)}{\\|x-y\\|\\|z-y\\|}\\bigr)$, with axioms for range $[0,\\pi]$ and symmetry $\\angle(x,y,z) = \\angle(z,y,x)$.",
+      "proofMethod": "Direct computation via dot product and arccos, with axioms for range and symmetry."
     },
     {
       "id": "max-angle",
       "title": "Maximum Angle in a Point Set",
-      "range": {
-        "startLine": 68,
-        "endLine": 83
-      },
-      "content": "Axiomatized `maxAngleInSet` function giving $\\max_{x,y,z \\in A}\\angle(x,y,z)$ for a finite set $A$, with positivity for $|A| \\ge 3$ and the upper bound $\\le \\pi$."
+      "startLine": 68,
+      "endLine": 83,
+      "content": "Axiomatized `maxAngleInSet` function giving $\\max_{x,y,z \\in A}\\angle(x,y,z)$ for a finite set $A$, with positivity for $|A| \\ge 3$ and the upper bound $\\le \\pi$.",
+      "proofMethod": "Axiomatized to avoid Finset.sup' nonempty proof obligations."
     },
     {
       "id": "alpha-n",
-      "title": "The α_n Function",
-      "range": {
-        "startLine": 85,
-        "endLine": 111
-      },
-      "content": "Defines $\\alpha_n = \\inf\\{\\operatorname{maxAngle}(A) : |A| = n\\}$ as the infimum over all $n$-point configurations. Includes well-definedness ($0 < \\alpha_n \\le \\pi$ for $n \\ge 3$), monotonicity ($\\alpha_n \\le \\alpha_m$ for $m \\le n$), and small cases $\\alpha_3 = \\alpha_4 = \\pi$."
+      "title": "The α_n Function and Small Cases",
+      "startLine": 85,
+      "endLine": 111,
+      "content": "Defines $\\alpha_n = \\inf\\{\\operatorname{maxAngle}(A) : |A| = n\\}$ as the infimum over all $n$-point configurations. Includes well-definedness ($0 < \\alpha_n \\le \\pi$ for $n \\ge 3$), monotonicity ($\\alpha_n \\le \\alpha_m$ for $m \\le n$), and small cases $\\alpha_3 = \\alpha_4 = \\pi$.",
+      "proofMethod": "iInf definition with axioms for monotonicity and boundary values."
     },
     {
       "id": "erdos-szekeres",
       "title": "Erdős-Szekeres Results (1960)",
-      "range": {
-        "startLine": 113,
-        "endLine": 127
-      },
-      "content": "The Erdős–Szekeres formula $\\alpha_{2^n} = \\pi(1 - 1/n)$ for powers of 2, where the regular $2^n$-gon achieves the minimum maximum angle."
+      "startLine": 113,
+      "endLine": 127,
+      "content": "The Erdős–Szekeres formula $\\alpha_{2^n} = \\pi(1 - 1/n)$ for powers of 2 ($n \\ge 2$), where the regular $2^n$-gon achieves the minimum maximum angle.",
+      "proofMethod": "Axiomatized formula erdosSzekeresFormula with the main theorem axiom erdos_szekeres."
     },
     {
       "id": "sendov-solution",
       "title": "Sendov's Complete Solution (1993)",
-      "range": {
-        "startLine": 129,
-        "endLine": 167
-      },
-      "content": "The full determination of $\\alpha_N$: for the upper range $2^{n-1} + 2^{n-3} < N \\le 2^n$, $\\alpha_N = \\pi(1-1/n)$; for the lower range $2^{n-1} < N \\le 2^{n-1} + 2^{n-3}$, $\\alpha_N = \\pi(1-1/(2n-1))$."
+      "startLine": 129,
+      "endLine": 167,
+      "content": "The full determination of $\\alpha_N$: for the upper range $2^{n-1} + 2^{n-3} < N \\le 2^n$, $\\alpha_N = \\pi(1-1/n)$; for the lower range $2^{n-1} < N \\le 2^{n-1} + 2^{n-3}$, $\\alpha_N = \\pi(1-1/(2n-1))$. The threshold $5 \\cdot 2^{n-3}$ splits each dyadic interval.",
+      "proofMethod": "Two axiomatized formulas (sendov_upper, sendov_lower) with separate range conditions."
     },
     {
       "id": "counterexample",
       "title": "Counterexample to Erdős-Szekeres Conjecture",
-      "range": {
-        "startLine": 169,
-        "endLine": 182
-      },
-      "content": "Sendov's 1992 disproof of the Erdős–Szekeres conjecture: $\\exists\\, n, N$ with $2^{n-1} < N \\le 2^n$ such that $\\alpha_N \\ne \\pi(1-1/n)$."
+      "startLine": 169,
+      "endLine": 182,
+      "content": "Sendov's 1992 disproof: $\\exists\\, n, N$ with $2^{n-1} < N \\le 2^n$ such that $\\alpha_N \\ne \\pi(1-1/n)$. The smallest instance is $N = 5$ with $n = 3$.",
+      "proofMethod": "Axiomatized existential statement erdos_szekeres_conjecture_false."
     },
     {
       "id": "optimal-configs",
       "title": "Optimal Configurations and Convex Position",
-      "range": {
-        "startLine": 184,
-        "endLine": 219
-      },
-      "content": "Defines regular $n$-gon vertices via $\\bigl(\\cos(2\\pi k/n), \\sin(2\\pi k/n)\\bigr)$, proves optimality for $N = 2^k$, and shows optimal configurations achieving $\\alpha_N$ are always in convex position."
+      "startLine": 184,
+      "endLine": 219,
+      "content": "Defines regular $n$-gon vertices via $\\bigl(\\cos(2\\pi k/n), \\sin(2\\pi k/n)\\bigr)$, proves optimality for $N = 2^k$, and shows optimal configurations achieving $\\alpha_N$ are always in convex position.",
+      "proofMethod": "Finset.image for polygon vertices, axioms for optimality and convexity."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "range": {
-        "startLine": 221,
-        "endLine": 255
-      },
-      "content": "The `erdos_504_summary` theorem combining Sendov's upper and lower range formulas with the Erdős–Szekeres counterexample into a single proved statement using the axiomatized results."
+      "title": "Summary Theorem",
+      "startLine": 221,
+      "endLine": 255,
+      "content": "The `erdos_504_summary` theorem combining Sendov's upper and lower range formulas with the Erdős–Szekeres counterexample into a single conjunction, proved by direct application of the axioms.",
+      "proofMethod": "Conjunction introduction from sendov_upper, sendov_lower, and erdos_szekeres_conjecture_false."
     }
   ],
   "conclusion": {
@@ -150,6 +162,57 @@
   "relatedProofs": [
     "erdos-507",
     "erdos-506",
-    "erdos-1026"
+    "erdos-1026",
+    "erdos-500",
+    "law-of-cosines",
+    "pythagorean-theorem",
+    "area-of-circle"
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Topology.MetricSpace.Basic",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Data.Real.Basic"
+    ],
+    "opens": [
+      "Real",
+      "Set"
+    ],
+    "namespace": "Erdos504",
+    "lineCount": 255,
+    "axiomCount": 15,
+    "theoremCount": 1,
+    "definitionCount": 5
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul; Szekeres, George",
+      "title": "On some extremum problems in elementary geometry",
+      "year": "1960",
+      "venue": "Annales Universitatis Scientiarum Budapestinensis de Rolando Eötvös Nominatae, Sectio Mathematica 3–4, 53–62",
+      "note": "Proved the formula α_{2^n} = π(1 − 1/n) for powers of 2, showing regular 2^n-gons are optimal, and conjectured this extends to all N in the dyadic range"
+    },
+    {
+      "authors": "Sendov, Blagovest",
+      "title": "On the theorem of Erdős–Szekeres",
+      "year": "1993",
+      "venue": "Rendiconti del Circolo Matematico di Palermo, Series II, 42(2), 244–248",
+      "note": "Complete determination of α_N for all N, revealing the binary threshold phenomenon at N = 5·2^{n-3} and disproving the Erdős–Szekeres conjecture"
+    },
+    {
+      "authors": "Szekeres, George",
+      "title": "On an extremum problem in the plane",
+      "year": "1941",
+      "venue": "American Journal of Mathematics 63(1), 208–210",
+      "note": "First systematic bounds on α_n, establishing the framework for the maximum angle problem"
+    },
+    {
+      "authors": "Pach, János; Agarwal, Pankaj K.",
+      "title": "Combinatorial Geometry",
+      "year": "1995",
+      "venue": "Wiley-Interscience",
+      "note": "Standard reference for discrete geometry including extremal problems on point configurations, the Erdős–Szekeres theorem, and Heilbronn-type problems"
+    }
   ]
 }

--- a/src/data/proofs/erdos-959/annotations.json
+++ b/src/data/proofs/erdos-959/annotations.json
@@ -10,6 +10,7 @@
     "title": "Problem Overview: Distance Frequency Gaps",
     "content": "Given **n points** in the plane with distinct distances d_1, ..., d_k ordered by frequency f(d_1) >= f(d_2) >= ..., Erdos asked: how large can the **frequency gap** f(d_1) - f(d_2) be? Clemen, Dumitrescu, and Liu (2025) proved the gap can be at least **Omega(n log n)** and conjectured a stronger bound of n^{1 + c / log log n}.",
     "mathContext": "This problem sits at the intersection of **combinatorial geometry** and **extremal combinatorics**. The frequency of a distance d is the number of unordered pairs of points at distance d. The Erdos distinct distances problem (resolved by Guth-Katz) controls how many distinct distances exist; this problem instead asks about the **distribution** of those distances -- specifically, how unevenly frequencies can be distributed among the top two distances.",
+    "significance": "key",
     "relatedConcepts": [
       "distinct distances",
       "combinatorial geometry",

--- a/src/data/proofs/erdos-959/meta.json
+++ b/src/data/proofs/erdos-959/meta.json
@@ -139,5 +139,56 @@
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 8
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-957",
+      "relationship": "related",
+      "description": "Erdős problem #957 studies the product of extreme distance frequencies — a closely related combinatorial geometry problem asking about multiplicative rather than additive gaps in the distance frequency spectrum of planar point sets"
+    },
+    {
+      "targetId": "erdos-958",
+      "relationship": "related",
+      "description": "Erdős problem #958 concerns distance multiplicities and point configurations — another variant of the distance frequency problem, asking how many times specific distances can occur"
+    },
+    {
+      "targetId": "erdos-960",
+      "relationship": "related",
+      "description": "Erdős problem #960 on ordinary lines and collinear Ramsey thresholds — a sibling combinatorial geometry problem in the same problem cluster studying structural properties of planar point sets"
+    },
+    {
+      "targetId": "erdos-504",
+      "relationship": "thematic",
+      "description": "Both are extremal problems on finite planar point configurations — #504 optimizes angles while #959 optimizes distance frequency gaps, but both use the interplay between metric structure and combinatorial counting"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-957",
+    "erdos-958",
+    "erdos-960",
+    "erdos-504"
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "On sets of distances of n points",
+      "year": "1946",
+      "venue": "The American Mathematical Monthly 53(5), 248–250",
+      "note": "Foundational paper establishing the distinct distances problem: n points in the plane determine at least Ω(n/√(log n)) distinct distances"
+    },
+    {
+      "authors": "Guth, Larry; Katz, Nets Hawk",
+      "title": "On the Erdős distinct distances problem in the plane",
+      "year": "2015",
+      "venue": "Annals of Mathematics 181(1), 155–190",
+      "note": "Nearly optimal Ω(n/log n) lower bound on distinct distances, resolving the Erdős conjecture up to logarithmic factors — the algebraic-geometric techniques developed here underpin modern distance frequency analysis"
+    },
+    {
+      "authors": "Pach, János; Sharir, Micha",
+      "title": "Repeated angles in the plane and related problems",
+      "year": "1992",
+      "venue": "Journal of Combinatorial Theory, Series A 59(1), 12–22",
+      "note": "Studies repeated geometric configurations in point sets — the frequency analysis framework relevant to understanding distance frequency gaps"
+    }
+  ]
 }

--- a/src/data/proofs/randomized-maxcut/meta.json
+++ b/src/data/proofs/randomized-maxcut/meta.json
@@ -156,6 +156,40 @@
       "How would we formalize the derandomization via conditional expectations?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-196",
+      "relationship": "related",
+      "description": "Erdős problem on graph coloring — both concern extremal properties of graph partitions, with MaxCut seeking the largest bipartition and chromatic problems seeking the fewest colors"
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "thematic",
+      "description": "Ramsey theory guarantees monochromatic substructures in large graphs — the complementary perspective to MaxCut, which seeks to maximize bichromatic edges. Both use probabilistic arguments in their non-constructive proofs"
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "foundational",
+      "description": "The birthday problem illustrates probabilistic counting over combinatorial structures — the same linearity of expectation technique that powers the MaxCut approximation proof"
+    },
+    {
+      "targetId": "randomized-maxcut-oq-01",
+      "relationship": "extended-by",
+      "description": "Extends the 1/2-approximation result with additional analysis of the MaxCut algorithm"
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "thematic",
+      "description": "MaxCut is NP-Complete — its computational intractability motivates the approximation approach. The halting problem establishes fundamental computability limits that underpin the P vs NP question"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-196",
+    "ramseys-theorem",
+    "birthday-problem",
+    "randomized-maxcut-oq-01",
+    "halting-problem"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Finset.Basic",

--- a/src/data/proofs/three-place-identity/meta.json
+++ b/src/data/proofs/three-place-identity/meta.json
@@ -149,6 +149,46 @@
       "seeAlso": "For an alternative Lean 4 formalization that addresses some of these concerns with a more modular approach, see [Jim Bowery's RelativeIdentity project](https://github.com/jabowery/RelativeIdentity)."
     }
   },
+  "crossReferences": [
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "thematic",
+      "description": "Gödel's incompleteness theorems demonstrate the limits of formal foundations — the meta-level/object-level distinction central to evaluating Etter's universality claim is precisely the distinction Gödel exploited in his diagonal argument"
+    },
+    {
+      "targetId": "russell-1-plus-1",
+      "relationship": "foundational",
+      "description": "Russell and Whitehead's proof that 1+1=2 in Principia Mathematica exemplifies the traditional set-theoretic foundation that Etter's identity theory proposes to replace — both address the question of what constitutes a sufficient foundation for arithmetic"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "thematic",
+      "description": "Cantor's theorem ($|S| < |\\mathcal{P}(S)|$) is a core result of ZF set theory — the system whose axioms Etter's bridges translate to and from three-place identity structures"
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "thematic",
+      "description": "Cantor's diagonal argument establishes the uncountability of the reals within set-theoretic foundations — a result that identity theory must be able to express if it is truly foundationally adequate"
+    },
+    {
+      "targetId": "schroeder-bernstein",
+      "relationship": "thematic",
+      "description": "The Schröder-Bernstein theorem on set bijections relies on the membership relation that Etter's D1 bridge derives from identity — showing how classical set-theoretic results emerge from the identity-first perspective"
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "thematic",
+      "description": "The halting problem's undecidability constrains what any foundational system can prove — Etter's identity theory, being mutually interpretable with ZF, inherits the same computability-theoretic limitations"
+    }
+  ],
+  "relatedProofs": [
+    "godel-incompleteness",
+    "russell-1-plus-1",
+    "cantors-theorem",
+    "cantor-diagonalization",
+    "schroeder-bernstein",
+    "halting-problem"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Tactic.Tauto",
@@ -164,11 +204,39 @@
   },
   "references": [
     {
+      "authors": "Etter, Tom",
+      "title": "Three-Place Identity",
+      "year": "2006",
+      "venue": "Boundary Institute Working Paper",
+      "note": "The original paper proposing three-place relative identity as a foundation for mathematics, with the universality theorem and bridges D1/D2"
+    },
+    {
+      "authors": "Benacerraf, Paul",
+      "title": "What Numbers Could Not Be",
+      "year": "1965",
+      "venue": "The Philosophical Review 74(1), 47–73",
+      "note": "The classic paper questioning whether numbers are sets — motivates Etter's search for an alternative foundation where objects are defined by identity relations rather than membership"
+    },
+    {
+      "authors": "Quine, Willard Van Orman",
+      "title": "Word and Object",
+      "year": "1960",
+      "venue": "MIT Press",
+      "note": "Develops the notion of identity as indiscernibility relative to predicates — the philosophical ancestor of Etter's Id_mem(x,y,z) iff (y ∈ x ↔ z ∈ x)"
+    },
+    {
+      "authors": "Rota, Gian-Carlo",
+      "title": "Indiscrete Thoughts",
+      "year": "1997",
+      "venue": "Birkhäuser",
+      "note": "Contains Rota's slogan 'Identity precedes existence' that Etter's formalization makes mathematically precise"
+    },
+    {
       "authors": "Mac Lane, Saunders",
       "title": "Categories for the Working Mathematician",
       "year": "1998",
       "venue": "Springer GTM 5, 2nd edition",
-      "note": "Standard reference for categorical identities and coherence theorems"
+      "note": "Standard reference for categorical identities and coherence theorems — relevant to the categorical semantics question raised in the open questions"
     }
   ]
 }


### PR DESCRIPTION
## Enrichment pass for 6 gallery entries

### 1. collatz-structured-oq-02 (Collatz Cycles)
- Created annotations.json (10 annotations with mathContext/significance/relatedConcepts)
- Deepened historicalContext, restructured conclusion, added 3 xrefs + 3 refs

### 2. erdos-504 (Maximum Angle in Point Sets)
- Fixed 8 sections to flat startLine/endLine, added proofMethod
- Added 4 xrefs + 4 refs + leanFile metadata

### 3. three-place-identity (Universality of Three-Place Identity)
- Added 6 xrefs (godel, russell, cantor, etc.), expanded refs from 1 to 5

### 4. randomized-maxcut (Randomized MaxCut Approximation)
- Added 5 xrefs (erdos-196, ramseys-theorem, birthday-problem, etc.)

### 5. erdos-959 (Distance Frequency Gaps)
- Added 4 xrefs + 3 refs, fixed missing annotation significance

### 6. poincare-conjecture (Poincaré Conjecture)
- Added 5 new xrefs (brouwer, borsuk-ulam, navier-stokes, hodge, godel)
- Fixed empty relatedProofs, added 3 refs (Hamilton, Smale, Freedman)