### PR TITLE
Enrich 16 entries: add cross-references, bibliography, annotations

### DIFF
--- a/src/data/proofs/hilbert-13/meta.json
+++ b/src/data/proofs/hilbert-13/meta.json
@@ -139,6 +139,24 @@
     "theoremCount": 4,
     "definitionCount": 8
   },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-14",
+      "relationship": "related",
+      "description": "Both address structural questions from Hilbert's 1900 list about the nature of algebraic and analytic objects: Problem 13 asks about representing functions via superpositions, while Problem 14 asks about finite generation of invariant rings"
+    },
+    {
+      "targetId": "hilbert-23",
+      "relationship": "related",
+      "description": "The Kolmogorov-Arnold representation theorem connects to the calculus of variations through approximation theory and the study of function spaces, both central themes of Hilbert's research program"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Hilbert's 13th problem was motivated by the unsolvability of the general septic by radicals (Abel-Ruffini); the Bring-Jerrard reduction of the degree-7 polynomial directly links to the algebraic impossibility results"
+    }
+  ],
+  "relatedProofs": ["hilbert-14", "hilbert-23", "abel-ruffini"],
   "references": [
     {
       "authors": "Kolmogorov, Andrey N.",

--- a/src/data/proofs/hilbert-14/meta.json
+++ b/src/data/proofs/hilbert-14/meta.json
@@ -135,6 +135,24 @@
     "theoremCount": 5,
     "definitionCount": 1
   },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-13",
+      "relationship": "related",
+      "description": "Both address algebraic structural questions from Hilbert's programme: Problem 14 concerns finite generation of invariant rings under group actions, while Problem 13 concerns the representation of functions via superpositions"
+    },
+    {
+      "targetId": "hilbert-23",
+      "relationship": "related",
+      "description": "Invariant theory and the calculus of variations share deep connections through symmetry and Noether's theorem, which links continuous symmetries of variational problems to conservation laws"
+    },
+    {
+      "targetId": "hilbert-20",
+      "relationship": "related",
+      "description": "Both problems involve functional analysis and existence questions: Problem 14 asks when invariant rings are finitely generated, while Problem 20 asks when boundary value problems have solutions; Noetherian conditions appear in both contexts"
+    }
+  ],
+  "relatedProofs": ["hilbert-13", "hilbert-23", "hilbert-20"],
   "references": [
     {
       "authors": "Hilbert, David",

--- a/src/data/proofs/hilbert-19/meta.json
+++ b/src/data/proofs/hilbert-19/meta.json
@@ -140,6 +140,24 @@
     "theoremCount": 7,
     "definitionCount": 11
   },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-20",
+      "relationship": "related",
+      "description": "Problems 19 and 20 are deeply intertwined: Problem 19 asks about regularity of variational solutions, while Problem 20 asks about existence of solutions to boundary value problems; the Schauder estimates and Sobolev space framework underpin both"
+    },
+    {
+      "targetId": "hilbert-23",
+      "relationship": "related",
+      "description": "Problem 19 is essentially a regularity question within the calculus of variations (Problem 23): Hilbert asked whether minimizers of well-behaved variational functionals are necessarily smooth"
+    },
+    {
+      "targetId": "navier-stokes",
+      "relationship": "related",
+      "description": "The De Giorgi-Nash-Moser regularity theory developed for Hilbert's 19th problem directly informs the Navier-Stokes regularity question; the gap between elliptic regularity (solved) and parabolic/nonlinear regularity (open) is central to both"
+    }
+  ],
+  "relatedProofs": ["hilbert-20", "hilbert-23", "navier-stokes"],
   "references": [
     {
       "authors": "Hilbert, David",

--- a/src/data/proofs/hilbert-20/meta.json
+++ b/src/data/proofs/hilbert-20/meta.json
@@ -136,6 +136,29 @@
     "theoremCount": 1,
     "definitionCount": 7
   },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-19",
+      "relationship": "related",
+      "description": "Problems 19 and 20 form a natural pair: Problem 20 establishes existence of solutions to boundary value problems via Lax-Milgram, while Problem 19 shows those solutions are smooth via De Giorgi-Nash-Moser regularity theory"
+    },
+    {
+      "targetId": "hilbert-22",
+      "relationship": "related",
+      "description": "The Dirichlet problem (central to Problem 20) connects to uniformization (Problem 22) through potential theory: solving boundary value problems on Riemann surfaces is key to the Perron method proof of the uniformization theorem"
+    },
+    {
+      "targetId": "navier-stokes",
+      "relationship": "related",
+      "description": "The Navier-Stokes equations are a nonlinear boundary value problem; the Lax-Milgram framework from Problem 20 provides existence for the linearized (Stokes) equations, but the full nonlinear problem remains open"
+    },
+    {
+      "targetId": "schauder-fixed-point",
+      "relationship": "related",
+      "description": "Schauder's fixed point theorem is used to prove existence of solutions to nonlinear boundary value problems by converting PDE existence into a fixed point problem in function spaces"
+    }
+  ],
+  "relatedProofs": ["hilbert-19", "hilbert-22", "navier-stokes", "schauder-fixed-point"],
   "references": [
     {
       "authors": "Hilbert, David",

--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -135,6 +135,24 @@
     "theoremCount": 6,
     "definitionCount": 6
   },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-20",
+      "relationship": "related",
+      "description": "The Perron method proof of the uniformization theorem relies on solving the Dirichlet problem (central to Problem 20) for the Laplacian on Riemann surfaces; boundary value solvability is a prerequisite for uniformization"
+    },
+    {
+      "targetId": "hilbert-23",
+      "relationship": "related",
+      "description": "Uniformization connects to the calculus of variations through the Plateau problem and minimal surfaces: finding conformal parametrizations of surfaces is a variational problem on the space of maps"
+    },
+    {
+      "targetId": "poincare-conjecture",
+      "relationship": "related",
+      "description": "The uniformization theorem classifies 2-dimensional surfaces by geometry (spherical, flat, hyperbolic), while the Poincare conjecture (proved by Perelman) extends this classification idea to 3-manifolds via Ricci flow and geometrization"
+    }
+  ],
+  "relatedProofs": ["hilbert-20", "hilbert-23", "poincare-conjecture"],
   "references": [
     {
       "authors": "Hilbert, David",

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -142,6 +142,24 @@
     "theoremCount": 4,
     "definitionCount": 9
   },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-19",
+      "relationship": "related",
+      "description": "Problem 19 is a specific regularity question within the calculus of variations (Problem 23): whether minimizers of regular variational integrals are necessarily analytic, answered by De Giorgi-Nash-Moser theory"
+    },
+    {
+      "targetId": "hilbert-20",
+      "relationship": "related",
+      "description": "The weak formulation of boundary value problems (Problem 20) via Lax-Milgram is a direct application of the direct methods in the calculus of variations; Sobolev spaces serve both problems"
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "related",
+      "description": "The fundamental theorem of calculus underpins the entire variational framework: the Euler-Lagrange equation is derived via integration by parts, and the fundamental lemma of the calculus of variations is a generalization of the classical result"
+    }
+  ],
+  "relatedProofs": ["hilbert-19", "hilbert-20", "fundamental-theorem-calculus"],
   "references": [
     {
       "authors": "Hilbert, David",

--- a/src/data/proofs/mean-value-theorem-oq-03/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-03/meta.json
@@ -196,6 +196,28 @@
     "theoremCount": 17,
     "definitionCount": 0
   },
+  "crossReferences": [
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "The Intermediate Value Theorem underpins the scalar MVT equality f'(c) = slope, which has no vector analogue. The vector MVT inequality replaces the IVT-based argument with the triangle inequality."
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "related",
+      "description": "The Fundamental Theorem of Calculus connects differentiation and integration. The MVT inequality can be seen as a norm estimate on the integral: ||f(b)-f(a)|| = ||integral of f'|| <= C(b-a)."
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "foundational",
+      "description": "The triangle inequality in normed spaces is the key tool replacing IVT in the vector-valued setting, enabling the norm bound ||f(b)-f(a)|| <= C(b-a) that defines the mean value inequality."
+    }
+  ],
+  "relatedProofs": [
+    "intermediate-value-theorem",
+    "fundamental-theorem-calculus",
+    "triangle-inequality"
+  ],
   "references": [
     {
       "authors": "Jean Dieudonné",

--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -167,6 +167,22 @@
     "theoremCount": 26,
     "definitionCount": 17
   },
+  "crossReferences": [
+    {
+      "targetId": "hodge-conjecture",
+      "relationship": "thematic",
+      "description": "Both concern the algebraic geometry of complex varieties — the Hodge conjecture asks about algebraic cycles on smooth projective varieties, while motivic classes encode the K-theory of maps between flag varieties"
+    },
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "foundational",
+      "description": "The fundamental theorem of algebra (every polynomial has a root) underpins the algebraic framework — the q-binomial coefficients and Gaussian polynomials in the motivic class computation rely on polynomial factorization over algebraically closed fields"
+    }
+  ],
+  "relatedProofs": [
+    "hodge-conjecture",
+    "fundamental-theorem-algebra"
+  ],
   "references": [
     {
       "authors": "Voevodsky, Vladimir",

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -125,6 +125,28 @@
       "Can the 3D analogue NSSolutionPair3D be formalized, making explicit where the uniqueness argument fails?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "navier-stokes",
+      "relationship": "parent",
+      "description": "Parent Navier-Stokes formalization providing the foundational structures (GlobalNSSolution2D, enstrophy bounds) that this well-posedness proof builds upon."
+    },
+    {
+      "targetId": "navier-stokes-existence",
+      "relationship": "related",
+      "description": "The Clay Millennium Prize problem on 3D Navier-Stokes existence and smoothness. This 2D well-posedness result highlights exactly where the 3D argument breaks: unbounded enstrophy."
+    },
+    {
+      "targetId": "schauder-fixed-point",
+      "relationship": "foundational",
+      "description": "Fixed-point methods for existence of PDE solutions. The Schauder fixed-point theorem provides existence results that complement the uniqueness and stability proved here."
+    }
+  ],
+  "relatedProofs": [
+    "navier-stokes",
+    "navier-stokes-existence",
+    "schauder-fixed-point"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Calculus.Deriv.Basic",

--- a/src/data/proofs/partition-theorem-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01/meta.json
@@ -241,6 +241,28 @@
     "theoremCount": 143,
     "definitionCount": 40
   },
+  "crossReferences": [
+    {
+      "targetId": "partition-theorem",
+      "relationship": "parent",
+      "description": "Parent formalization of Euler's partition theorem (distinct parts equal odd parts), which this extends to the deeper Rogers-Ramanujan and Schur identities."
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity and q-series connections: the Rogers-Ramanujan identities are fundamentally q-series identities whose generating functions generalize Euler's product formulas."
+    },
+    {
+      "targetId": "ramanujan-sum-fallacy",
+      "relationship": "related",
+      "description": "Ramanujan's broader work in number theory: Ramanujan independently rediscovered the Rogers-Ramanujan identities c. 1913 and communicated them to Hardy."
+    }
+  ],
+  "relatedProofs": [
+    "partition-theorem",
+    "euler-identity",
+    "ramanujan-sum-fallacy"
+  ],
   "references": [
     {
       "authors": "L. J. Rogers",

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -243,8 +243,34 @@
   ],
   "crossReferences": [
     {
-      "relationship": "Both establish classification theorems: Hurwitz classifies normed division algebras ($n \\in \\{1,2,4,8\\}$), Poincaré classifies simply connected closed 3-manifolds (only $S^3$). Both use biconditional characterizations.",
-      "targetId": "hurwitz-theorem"
+      "targetId": "hurwitz-theorem",
+      "relationship": "thematic",
+      "description": "Both establish classification theorems: Hurwitz classifies normed division algebras ($n \\in \\{1,2,4,8\\}$), Poincaré classifies simply connected closed 3-manifolds (only $S^3$). Both use biconditional characterizations"
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "foundational",
+      "description": "The Brouwer fixed point theorem is a cornerstone of algebraic topology — the same homotopy-theoretic machinery (fundamental group, simple connectivity) that underlies the Poincaré conjecture's statement"
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "foundational",
+      "description": "The Borsuk-Ulam theorem ($f: S^n \\to \\mathbb{R}^n$ has a point with $f(x) = f(-x)$) is another deep result about sphere topology — both rely on the topological properties of $S^n$ that the Poincaré conjecture characterizes"
+    },
+    {
+      "targetId": "navier-stokes",
+      "relationship": "thematic",
+      "description": "Both are Clay Millennium Prize Problems — the Poincaré conjecture (solved by Perelman, 2003) and Navier-Stokes existence/smoothness (open) represent the pinnacle of mathematical challenges in topology and PDE theory respectively"
+    },
+    {
+      "targetId": "hodge-conjecture",
+      "relationship": "thematic",
+      "description": "Another Clay Millennium Prize Problem — the Hodge conjecture concerns the algebraic topology of complex manifolds, complementing the Poincaré conjecture's classification of topological manifolds"
+    },
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "thematic",
+      "description": "Gödel's incompleteness theorems constrain what formal systems can prove — Perelman's proof of the Poincaré conjecture was verified in this formalization using axiomatized deep results (Ricci flow, surgery), raising questions about the boundary between verified and axiomatized mathematics"
     }
   ],
   "conclusion": {
@@ -293,7 +319,12 @@
     "definitionCount": 369
   },
   "relatedProofs": [
-    ""
+    "hurwitz-theorem",
+    "brouwer-fixed-point",
+    "borsuk-ulam",
+    "navier-stokes",
+    "hodge-conjecture",
+    "godel-incompleteness"
   ],
   "references": [
     {
@@ -309,6 +340,27 @@
       "year": "2007",
       "venue": "American Mathematical Society, Clay Mathematics Monographs 3",
       "note": "Complete detailed verification of Perelman's proof of the Poincaré conjecture"
+    },
+    {
+      "authors": "Hamilton, Richard S.",
+      "title": "Three-manifolds with positive Ricci curvature",
+      "year": "1982",
+      "venue": "Journal of Differential Geometry 17(2), 255–306",
+      "note": "Introduced the Ricci flow equation $\\partial g/\\partial t = -2\\text{Ric}(g)$ and proved convergence to constant curvature for positive Ricci 3-manifolds — the foundation for Perelman's approach"
+    },
+    {
+      "authors": "Smale, Stephen",
+      "title": "Generalized Poincaré's conjecture in dimensions greater than four",
+      "year": "1961",
+      "venue": "Annals of Mathematics 74(2), 391–406",
+      "note": "Proved the generalized Poincaré conjecture for dimensions ≥ 5 using h-cobordism, earning the Fields Medal"
+    },
+    {
+      "authors": "Freedman, Michael H.",
+      "title": "The topology of four-dimensional manifolds",
+      "year": "1982",
+      "venue": "Journal of Differential Geometry 17(3), 357–453",
+      "note": "Proved the topological Poincaré conjecture in dimension 4, earning the Fields Medal — the smooth case remains open"
     }
   ]
 }

--- a/src/data/proofs/pythagorean-theorem-oq-03/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03/meta.json
@@ -208,6 +208,28 @@
       "Can we formalize the rapidity-velocity relation β = tanh(φ) and derive relativistic velocity addition?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "parent",
+      "description": "The original Euclidean Pythagorean theorem (a^2 + b^2 = c^2) that posed the open question answered by this non-Euclidean generalization."
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "The law of cosines generalizes the Pythagorean theorem to non-right triangles. Both the spherical and hyperbolic laws of cosines reduce to the Pythagorean form when the included angle is pi/2."
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "Hyperbolic and spherical area formulas connect to circle area through the angular defect/excess: hyperbolic triangle area = pi - alpha - beta - gamma, with connections to hyperbolic disk area formulas."
+    }
+  ],
+  "relatedProofs": [
+    "pythagorean-theorem",
+    "law-of-cosines",
+    "area-of-circle"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Real.Basic",

--- a/src/data/proofs/ramanujan-sum-fallacy/meta.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/meta.json
@@ -152,6 +152,34 @@
     "theoremCount": 13,
     "definitionCount": 3
   },
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "foundational",
+      "description": "The divergence of the harmonic series $\\sum 1/n$ is the fundamental example of a divergent series — the Ramanujan sum $1+2+3+\\cdots$ diverges even faster, making the 'equals $-1/12$' claim all the more striking"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Euler's $\\sum 1/n^2 = \\pi^2/6$ is a convergent relative of the Ramanujan sum — the Riemann zeta function $\\zeta(s) = \\sum n^{-s}$ connects both: convergent for $s > 1$ (Basel at $s=2$), needing analytic continuation for $s = -1$ (Ramanujan)"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "thematic",
+      "description": "Euler's identity $e^{i\\pi}+1=0$ connects fundamental constants — similarly, $\\zeta(-1) = -1/12$ connects the integers to the zeta function's analytic continuation, both revealing unexpected structure"
+    },
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "thematic",
+      "description": "Both expose limitations of formal systems: Gödel shows not everything true is provable, while the Ramanujan fallacy shows that naive algebraic manipulation of infinite series can produce 'results' that contradict basic analysis"
+    }
+  ],
+  "relatedProofs": [
+    "harmonic-divergence",
+    "basel-problem",
+    "euler-identity",
+    "godel-incompleteness"
+  ],
   "references": [
     {
       "authors": "Ramanujan, Srinivasa",

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -149,6 +149,40 @@
       "Can we construct the infinite-dimensional counterexample explicitly in Lean?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "foundational",
+      "description": "Brouwer's fixed point theorem is the finite-dimensional special case — Schauder generalizes it to infinite-dimensional Banach spaces by approximating compact maps with finite-dimensional projections and applying Brouwer"
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "thematic",
+      "description": "The Borsuk-Ulam theorem is another topological fixed point result for spheres — both belong to the family of theorems showing that continuous maps on compact domains must have certain coincidence or fixed point properties"
+    },
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "The intermediate value theorem is the 1-dimensional fixed point theorem: continuous $f: [a,b] \\to [a,b]$ has a fixed point. Brouwer generalizes to $n$ dimensions, and Schauder to infinite dimensions"
+    },
+    {
+      "targetId": "navier-stokes",
+      "relationship": "thematic",
+      "description": "The Schauder theorem is a key tool in PDE existence theory — proving that Navier-Stokes and other nonlinear PDE systems have solutions often reduces to finding fixed points of compact operators on function spaces"
+    },
+    {
+      "targetId": "poincare-conjecture",
+      "relationship": "thematic",
+      "description": "Both concern topological properties of manifolds and spaces — the Poincaré conjecture classifies 3-spheres, while Schauder characterizes when continuous maps on infinite-dimensional spaces must have fixed points"
+    }
+  ],
+  "relatedProofs": [
+    "brouwer-fixed-point",
+    "borsuk-ulam",
+    "intermediate-value-theorem",
+    "navier-stokes",
+    "poincare-conjecture"
+  ],
   "references": [
     {
       "authors": "Schauder, Juliusz",
@@ -156,6 +190,20 @@
       "year": "1930",
       "venue": "Studia Mathematica 2, 171–180",
       "note": "Generalized Brouwer's fixed point theorem to infinite-dimensional Banach spaces for compact convex sets"
+    },
+    {
+      "authors": "Granas, Andrzej; Dugundji, James",
+      "title": "Fixed Point Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics",
+      "note": "Comprehensive modern treatment of fixed point theory from Brouwer through Schauder, Kakutani, and set-valued extensions — standard graduate reference"
+    },
+    {
+      "authors": "Zeidler, Eberhard",
+      "title": "Nonlinear Functional Analysis and its Applications I: Fixed-Point Theorems",
+      "year": "1986",
+      "venue": "Springer",
+      "note": "Covers the Schauder theorem and its applications to nonlinear PDEs, integral equations, and the Peano existence theorem for ODEs"
     }
   ]
 }

--- a/src/data/proofs/sqrt2-from-axioms/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms/meta.json
@@ -112,6 +112,34 @@
     "theoremCount": 15,
     "definitionCount": 3
   },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "The standard formalization of $\\sqrt{2}$ irrationality using Mathlib — this entry proves the same result from first principles without Mathlib, making every axiom explicit"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "Both are classical number-theoretic results proved from basic properties of integers — the infinitude of primes and irrationality of $\\sqrt{2}$ are the foundational examples of proof by contradiction in number theory"
+    },
+    {
+      "targetId": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The well-ordering principle (equivalent to induction) underpins the infinite descent argument used in the classic proof of $\\sqrt{2}$'s irrationality"
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "foundational",
+      "description": "The GCD algorithm and the notion of coprimality ($\\gcd(p,q)=1$) are central to the standard proof: if $p^2 = 2q^2$ with $\\gcd(p,q)=1$, then both $p$ and $q$ must be even, contradicting coprimality"
+    }
+  ],
+  "relatedProofs": [
+    "sqrt2-irrational",
+    "infinitude-primes",
+    "mathematical-induction",
+    "gcd-algorithm"
+  ],
   "references": [
     {
       "authors": "Hardy, G.H.; Wright, E.M.",

--- a/src/data/proofs/subset-count/meta.json
+++ b/src/data/proofs/subset-count/meta.json
@@ -126,6 +126,40 @@
     "theoremCount": 10,
     "definitionCount": 0
   },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "The binomial theorem $(1+1)^n = \\sum_{k=0}^n \\binom{n}{k}$ is the algebraic identity underlying $|\\mathcal{P}(S)| = 2^n$ — the number of subsets equals the sum of binomial coefficients"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "related",
+      "description": "Cantor's theorem ($|S| < |\\mathcal{P}(S)|$) is the infinite generalization: for infinite sets, the power set is strictly larger, proved by the diagonal argument"
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "Cantor's diagonalization establishes the uncountability of $\\mathcal{P}(\\mathbb{N})$ — while this entry counts finite subsets ($2^n$), the diagonal argument shows the infinite case is qualitatively different"
+    },
+    {
+      "targetId": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The proof that $|\\mathcal{P}(S)| = 2^n$ typically proceeds by induction: adding one element doubles the number of subsets"
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "thematic",
+      "description": "The birthday problem uses combinatorial counting over subsets — the same power-set enumeration framework, applied to probability"
+    }
+  ],
+  "relatedProofs": [
+    "binomial-theorem",
+    "cantors-theorem",
+    "cantor-diagonalization",
+    "mathematical-induction",
+    "birthday-problem"
+  ],
   "references": [
     {
       "authors": "Graham, Ronald L.; Knuth, Donald E.; Patashnik, Oren",


### PR DESCRIPTION
## Enrichment pass for 16 gallery entries

### High-profile entries (6)
1. **poincare-conjecture** - 5 xrefs, 3 refs, fixed relatedProofs
2. **subset-count** - 5 xrefs
3. **schauder-fixed-point** - 5 xrefs, 2 refs
4. **ramanujan-sum-fallacy** - 4 xrefs
5. **sqrt2-from-axioms** - 4 xrefs
6. **motivic-flag-maps** - 2 xrefs

### Hilbert's Problems (6)
7. **hilbert-13** - 3 xrefs
8. **hilbert-14** - 3 xrefs
9. **hilbert-19** - 3 xrefs
10. **hilbert-20** - 4 xrefs
11. **hilbert-22** - 3 xrefs
12. **hilbert-23** - 3 xrefs

### Open Question spinoffs (4)
13. **partition-theorem-oq-01** - 3 xrefs
14. **navier-stokes-oq-02** - 3 xrefs
15. **mean-value-theorem-oq-03** - 3 xrefs
16. **pythagorean-theorem-oq-03** - 3 xrefs

All entries validated and build clean.