### PR TITLE
Fix startup to apply time-based schedule and targeted slot spawning

### DIFF
--- a/scripts/enricher/parallel-enrich.sh
+++ b/scripts/enricher/parallel-enrich.sh
@@ -394,6 +394,70 @@ case "${1:-}" in
         fi
         attach_agent "$2"
         ;;
+    --slot)
+        if [[ -z "${2:-}" ]]; then
+            print_error "Usage: $0 --slot <agent-number>"
+            exit 1
+        fi
+        local slot_num="$2"
+        if [[ $slot_num -lt 1 || $slot_num -gt $MAX_AGENTS ]]; then
+            print_error "Slot must be between 1 and $MAX_AGENTS (got: $slot_num)"
+            exit 1
+        fi
+        check_deps
+        mkdir -p "$LOGS_DIR" "$WORKTREES_DIR" "$SIGNALS_DIR"
+        mkdir -p "$REPO_ROOT/.lean/state/enrichment-claims"
+        if [[ ! -f "$REPO_ROOT/src/data/proofs/enrichment-tracker.json" ]]; then
+            echo '{"version": 1, "entries": {}}' > "$REPO_ROOT/src/data/proofs/enrichment-tracker.json"
+        fi
+        print_info "Updating main branch..."
+        git fetch origin main 2>/dev/null || true
+        git checkout main 2>/dev/null || true
+        git pull origin main 2>/dev/null || true
+
+        local i="$slot_num"
+        local session="$SESSION_PREFIX-$i"
+        local log_file="$LOGS_DIR/$session.log"
+        local enricher_id="enricher-$i"
+        local worktree_path
+        worktree_path=$(create_agent_worktree "$i")
+        tmux kill-session -t "$session" 2>/dev/null || true
+        tmux new-session -d -s "$session" -c "$worktree_path"
+        tmux send-keys -t "$session" "export ENRICHER_ID='$enricher_id'" Enter
+        tmux send-keys -t "$session" "export CLAIM_TTL='$CLAIM_TTL'" Enter
+        tmux send-keys -t "$session" "export REPO_ROOT='$REPO_ROOT'" Enter
+        local prompt_file="$LOGS_DIR/$session-prompt.md"
+        cat > "$prompt_file" << PROMPT_EOF
+# Proof Enrichment Agent $enricher_id
+
+You are working in an isolated git worktree with your own branch.
+
+**Your worktree:** $worktree_path
+**Your branch:** feature/enricher-$i
+**Claim script:** \$REPO_ROOT/scripts/enricher/claim-target.sh
+
+## Quick Start
+
+1. Read the full instructions: \`cat .lean/roles/enricher.md\`
+2. **Check for stop signal before each iteration:**
+   \`[[ -f \$REPO_ROOT/.loom/signals/stop-all ]] && echo "Stopping" && exit 0\`
+3. Claim a target: \`\$REPO_ROOT/scripts/enricher/claim-target.sh claim-next\`
+4. Enrich it (improve meta.json, annotations.json - add depth, cross-refs, context)
+5. Build: \`pnpm build\`
+6. Commit: \`git add src/data/proofs/<id>/ && git commit -m "Enrich <title>: add depth"\`
+7. Push: \`git push -u origin feature/enricher-$i\`
+8. Create PR: \`gh pr create --title "Enrich <title>" --body "Enrichment pass" --label enrichment\`
+9. Mark complete: \`\$REPO_ROOT/scripts/enricher/claim-target.sh complete <id>\`
+10. Reset for next: \`git checkout main && git pull && git checkout -B feature/enricher-$i main\`
+11. Repeat from step 2
+
+Start now by running step 1 to read the full instructions, then claim and enrich a target.
+PROMPT_EOF
+        local simple_prompt="You are $enricher_id. Read $prompt_file for your instructions, then start the enrichment workflow."
+        local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+        tmux send-keys -t "$session" "$wrapper_script --prompt '$simple_prompt' --log '$log_file' --max-retries 5" Enter
+        print_success "Launched $session (worktree: $worktree_path)"
+        ;;
     --help|-h)
         cat << EOF
 Parallel Proof Enrichment (with Worktree Isolation)
@@ -403,6 +467,7 @@ Each agent works in its own git worktree with a dedicated branch.
 
 Usage:
   $0 [count]            Launch N agents (default: $DEFAULT_AGENTS, max: $MAX_AGENTS)
+  $0 --slot N           Launch a single agent at slot N
   $0 --status           Show running agents, worktrees, and claims
   $0 --graceful-stop    Signal agents to stop after current work
   $0 --graceful-stop N  Signal agent N to stop after current work

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -390,7 +390,10 @@ cmd_start() {
     local tester=$DEFAULT_TESTER
     local herald=$DEFAULT_HERALD
 
-    # Parse options
+    # Apply time-based schedule (overrides defaults before CLI args)
+    apply_schedule
+
+    # Parse options (explicit CLI args override schedule)
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --enricher)
@@ -1551,7 +1554,10 @@ cmd_daemon() {
     local herald=$DEFAULT_HERALD
     local monitor_only=false
 
-    # Parse options
+    # Apply time-based schedule (overrides defaults before CLI args)
+    apply_schedule
+
+    # Parse options (explicit CLI args override schedule)
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --monitor-only)
@@ -2165,10 +2171,9 @@ cmd_spawn() {
             # Find next available slot
             for i in 1 2 3 4 5; do
                 if ! tmux has-session -t "enricher-$i" 2>/dev/null; then
-                    # Spawn single enricher
-                    ./scripts/enricher/parallel-enrich.sh 1 &
+                    ./scripts/enricher/parallel-enrich.sh --slot "$i" &
                     sleep 2
-                    echo -e "${GREEN}✓ Enricher spawned${NC}"
+                    echo -e "${GREEN}✓ Enricher spawned (slot $i)${NC}"
                     exit 0
                 fi
             done
@@ -2188,9 +2193,9 @@ cmd_spawn() {
             echo -e "${BLUE}Spawning additional Researcher...${NC}"
             for i in $(seq 1 $MAX_RESEARCHER); do
                 if ! tmux has-session -t "researcher-$i" 2>/dev/null; then
-                    ./scripts/research/parallel-research.sh 1 &
+                    ./scripts/research/parallel-research.sh --slot "$i" &
                     sleep 2
-                    echo -e "${GREEN}✓ Researcher spawned${NC}"
+                    echo -e "${GREEN}✓ Researcher spawned (slot $i)${NC}"
                     exit 0
                 fi
             done
@@ -2307,8 +2312,15 @@ cmd_scale() {
                 local to_add=$((count - current))
                 echo -e "${BLUE}Scaling Enrichers from $current to $count (adding $to_add)...${NC}"
                 update_daemon_config "enricher" "$count"
-                ./scripts/enricher/parallel-enrich.sh "$to_add" &
-                sleep 2
+                local added=0
+                for i in 1 2 3 4 5; do
+                    [[ $added -ge $to_add ]] && break
+                    if ! tmux has-session -t "enricher-$i" 2>/dev/null; then
+                        ./scripts/enricher/parallel-enrich.sh --slot "$i" &
+                        sleep 2
+                        added=$((added + 1))
+                    fi
+                done
                 echo -e "${GREEN}✓ Scaled to $count Enrichers${NC}"
             elif [[ $count -lt $current ]]; then
                 scale_down_multi "enricher" "enricher" "$current" "$count"
@@ -2333,8 +2345,15 @@ cmd_scale() {
                 local to_add=$((count - current))
                 echo -e "${BLUE}Scaling Researchers from $current to $count (adding $to_add)...${NC}"
                 update_daemon_config "researcher" "$count"
-                ./scripts/research/parallel-research.sh "$to_add" &
-                sleep 2
+                local added=0
+                for i in $(seq 1 $MAX_RESEARCHER); do
+                    [[ $added -ge $to_add ]] && break
+                    if ! tmux has-session -t "researcher-$i" 2>/dev/null; then
+                        ./scripts/research/parallel-research.sh --slot "$i" &
+                        sleep 2
+                        added=$((added + 1))
+                    fi
+                done
                 echo -e "${GREEN}✓ Scaled to $count Researchers${NC}"
             elif [[ $count -lt $current ]]; then
                 scale_down_multi "researcher" "researcher" "$current" "$count"

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -3,7 +3,8 @@
 # parallel-research.sh - Launch parallel research agents
 #
 # Usage:
-#   ./parallel-research.sh [count]           Launch N agents (default: 2, max: 7)
+#   ./parallel-research.sh [count]           Launch N agents (default: 2, max: 16)
+#   ./parallel-research.sh --slot N          Launch a single agent at slot N
 #   ./parallel-research.sh --status          Show running agents and claims
 #   ./parallel-research.sh --graceful-stop   Signal agents to stop after current work
 #   ./parallel-research.sh --stop            Force stop all agents immediately
@@ -242,8 +243,8 @@ launch_agents() {
     local wait_interval="${RESEARCHER_WAIT_INTERVAL:-15}"
 
     # Validate count
-    if [[ $count -lt 1 || $count -gt 7 ]]; then
-        print_error "Agent count must be between 1 and 5 (got: $count)"
+    if [[ $count -lt 1 || $count -gt 16 ]]; then
+        print_error "Agent count must be between 1 and 16 (got: $count)"
         exit 1
     fi
 
@@ -443,6 +444,24 @@ case "${1:-}" in
         fi
         attach_to_agent "$2"
         ;;
+    --slot)
+        if [[ -z "${2:-}" ]]; then
+            print_error "Usage: $0 --slot <agent-number>"
+            exit 1
+        fi
+        local slot_num="$2"
+        if [[ $slot_num -lt 1 || $slot_num -gt 16 ]]; then
+            print_error "Slot must be between 1 and 16 (got: $slot_num)"
+            exit 1
+        fi
+        check_deps
+        mkdir -p "$WORKTREES_DIR" "$LOGS_DIR" "$SIGNALS_DIR"
+        print_info "Updating main branch..."
+        git fetch origin main 2>/dev/null || true
+        git checkout main 2>/dev/null || true
+        git pull origin main 2>/dev/null || true
+        launch_agent "$slot_num"
+        ;;
     --help|-h)
         cat << EOF
 Parallel Research Agents (with Worktree Isolation)
@@ -451,7 +470,8 @@ Launch multiple Claude Code agents to work on research problems concurrently.
 Each agent works in its own git worktree with a dedicated branch.
 
 Usage:
-  ./parallel-research.sh [count]            Launch N agents (default: 2, max: 7)
+  ./parallel-research.sh [count]            Launch N agents (default: 2, max: 16)
+  ./parallel-research.sh --slot N           Launch a single agent at slot N
   ./parallel-research.sh --status           Show running agents and claims
   ./parallel-research.sh --continue         Resume all agents after API limits reset
   ./parallel-research.sh --continue N       Resume agent N specifically


### PR DESCRIPTION
## Summary
- **`start` now applies time-based schedule**: `apply_schedule` called in both `cmd_start` and `cmd_daemon` before arg parsing, so `launch.sh start` with no args respects `.loom/lean-schedule.json` (10 researchers off-peak, 5 during peak)
- **`--slot N` flag**: New targeted launch for `parallel-research.sh` and `parallel-enrich.sh` to create a single agent at a specific slot
- **`spawn`/`scale` fixed**: Now find free slots and use `--slot N` instead of bulk-launching from slot 1 (which would restart existing agents)
- **Agent cap raised**: `parallel-research.sh` max raised from 7 to 16 to match `MAX_RESEARCHER`

## Test plan
- [ ] `./scripts/lean/launch.sh start` with no args should start 10 researchers off-peak / 5 during peak
- [ ] `./scripts/lean/launch.sh start --researcher 3` should override schedule to 3
- [ ] `./scripts/lean/launch.sh spawn researcher` should create the next free slot (not restart slot 1)
- [ ] `./scripts/lean/launch.sh scale researcher 10` from 8 should add slots 9-10 (not restart 1-2)
- [ ] `./scripts/research/parallel-research.sh --slot 9` should launch researcher-9 specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)