### PR TITLE
Enrich: area-of-circle sections mathContext + geometric-series-oq-01

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -87,7 +87,8 @@
       "**S_n Unsolvability for n ≥ 5:** `symmetric_group_not_solvable` proves $\\forall n \\geq 5$, $S_n$ not solvable, using `Cardinal.mk (Fin n) ≥ 5` via `simp`. Instances for $S_0, S_1$ (`inferInstance`) vs the impossibility for $S_5, S_6, \\ldots$ illustrate the sharp boundary.",
       "**Original Contributions Are Wrappers:** The file's original theorems (`galois_bridge`, `symmetric_group_not_solvable`, `not_solvable_by_rad_of_not_solvable_gal`) are pedagogical wrappers that make the Mathlib results explicit and user-facing — a pattern for presenting Mathlib-based formalizations.",
       "**Jordan-Hölder Guarantees Completeness:** The analysis of $S_n$ via derived series is not ad hoc — the Jordan-Hölder theorem guarantees that any two composition series of a finite group have the same multiset of composition factors (up to isomorphism). For $S_5$, the unique composition series is $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with factors $A_5$ (simple, order 60) and $\\mathbb{Z}/2$. Since $A_5$ is non-abelian, the group is not solvable — and no alternative decomposition can avoid this obstruction. This uniqueness is what makes the degree-5 boundary absolute rather than a limitation of one particular analysis.",
-      "**Discriminant Criterion for Galois Group Computation:** The theorem `not_solvable_by_rad_of_not_solvable_gal` requires exhibiting a polynomial with non-solvable Galois group. In practice, the discriminant provides a key tool: $\\text{Gal}(f) \\subseteq A_n$ if and only if $\\Delta(f)$ is a perfect square in $F$. For the standard example $x^5 - x - 1$, $\\Delta = 2869 = 19 \\times 151$, which is not a perfect square, so $\\text{Gal}(x^5 - x - 1/\\mathbb{Q}) \\not\\subseteq A_5$. Combined with irreducibility mod 2 and the existence of a 5-cycle in the Galois group (from the number of real roots), this forces $\\text{Gal}(x^5 - x - 1/\\mathbb{Q}) = S_5$. Formalizing this computation would bridge the gap between the abstract `not_solvable_by_rad_of_not_solvable_gal` and a concrete unsolvable quintic."
+      "**Discriminant Criterion for Galois Group Computation:** The theorem `not_solvable_by_rad_of_not_solvable_gal` requires exhibiting a polynomial with non-solvable Galois group. In practice, the discriminant provides a key tool: $\\text{Gal}(f) \\subseteq A_n$ if and only if $\\Delta(f)$ is a perfect square in $F$. For the standard example $x^5 - x - 1$, $\\Delta = 2869 = 19 \\times 151$, which is not a perfect square, so $\\text{Gal}(x^5 - x - 1/\\mathbb{Q}) \\not\\subseteq A_5$. Combined with irreducibility mod 2 and the existence of a 5-cycle in the Galois group (from the number of real roots), this forces $\\text{Gal}(x^5 - x - 1/\\mathbb{Q}) = S_5$. Formalizing this computation would bridge the gap between the abstract `not_solvable_by_rad_of_not_solvable_gal` and a concrete unsolvable quintic.",
+      "**Roots of Unity as the Engine of Radical Extensions:** Every radical step $K_i \\to K_i(\\sqrt[n]{a})$ implicitly requires the $n$th roots of unity $\\zeta_n = e^{2\\pi i/n}$. The cyclotomic extension $\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}$ has Galois group $(\\mathbb{Z}/n\\mathbb{Z})^{\\times}$, which is abelian (hence solvable). This is the hidden ingredient in the Galois bridge: each radical step contributes an abelian Galois quotient precisely because the underlying cyclotomic symmetries are abelian (by De Moivre's formula, the $n$th roots of unity form a cyclic group under multiplication). The Abel-Ruffini impossibility arises when the polynomial's Galois group $S_5$ cannot be decomposed into such abelian layers — a failure of solvability that no choice of radical tower can circumvent."
     ],
     "prerequisites": [
       "Galois theory and field extensions",
@@ -443,6 +444,21 @@
       "targetId": "dirichlets-theorem",
       "relationship": "related",
       "description": "Dirichlet's theorem on primes in arithmetic progressions (1837) uses Dirichlet characters — group homomorphisms $\\chi: (\\mathbb{Z}/n\\mathbb{Z})^{\\times} \\to \\mathbb{C}^{\\times}$ — which are precisely the representations of the Galois group $\\text{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^{\\times}$. This abelian Galois group is always solvable (in fact cyclic or a product of cyclics), which is why cyclotomic extensions are solvable by radicals. Dirichlet's analytic proof via L-functions launched the program of using Galois representations in number theory — the same program that, through Artin L-functions and the Langlands correspondence, generalizes the abelian/solvable distinction central to Abel-Ruffini to non-abelian settings"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "De Moivre's formula $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$ gives the $n$th roots of unity $\\zeta_n = e^{2\\pi i/n}$, which generate the cyclotomic extensions fundamental to radical solvability. Adjoining $\\sqrt[n]{a}$ to a field requires $\\zeta_n$, and the cyclotomic extension $\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}$ has abelian Galois group $(\\mathbb{Z}/n\\mathbb{Z})^{\\times}$ — the abelianness of this group is precisely why each radical step in the Galois bridge produces a solvable quotient"
+    },
+    {
+      "targetId": "de-moivre-oq-03",
+      "relationship": "foundational",
+      "description": "Root extraction via fractional exponents $z^{p/q}$ formalizes the radical operations central to Abel-Ruffini: the operation $\\alpha \\mapsto \\alpha^{1/n}$ is exactly the radical step in the tower $F = K_0 \\subset K_1 \\subset \\cdots \\subset K_m$ where each $K_{i+1} = K_i(\\beta_i^{1/n_i})$. The multivaluedness of $z^{1/n}$ (yielding $n$ distinct roots) corresponds to the $n$ cosets of the stabilizer in the Galois group, connecting the analytic notion of root extraction to the algebraic symmetry that drives Abel-Ruffini's impossibility"
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "foundational",
+      "description": "Maclaurin's inequalities are built from elementary symmetric polynomials $e_k(x_1,\\ldots,x_n)$ — the same objects that underpin Galois theory via Vieta's formulas: the coefficients of a polynomial are the elementary symmetric polynomials of its roots, and the Galois group is defined as the group of permutations that preserve these symmetric functions. The inequality chain $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$ between the normalized symmetric means reveals the analytical structure of the same symmetric polynomials whose algebraic structure (invariance under $S_n$) drives the Abel-Ruffini impossibility"
     }
   ],
   "relatedProofs": [
@@ -502,7 +518,10 @@
     "erdos-226",
     "solution-of-cubic-oq-03",
     "platonic-solids",
-    "dirichlets-theorem"
+    "dirichlets-theorem",
+    "de-moivre",
+    "de-moivre-oq-03",
+    "amgm-inequality-oq-02"
   ],
   "references": [
     {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/annotations.json
@@ -2,273 +2,145 @@
   {
     "id": "ann-pmlo-01-header",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 1,
-      "endLine": 48
-    },
-    "type": "context",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
     "title": "The Power Mean Limit: Overview",
-    "content": "This file formalizes the classical theorem that the weighted power mean M_r(z,w) = (\u2211 w\u1d62z\u1d62^r)^(1/r) converges to the geometric mean GM = \u220f z\u1d62^w\u1d62 as r \u2192 0. The proof uses the exp/log representation and the definition of derivative, formalized via Mathlib's `hasDerivAt_iff_tendsto_slope`.\n\n**The indeterminate form:** At r = 0, M_r = (\u2211 w\u1d62z\u1d62^0)^(1/0) = 1^\u221e, a classical indeterminate form. The standard resolution is logarithmic: log M_r = (1/r)\u00b7log(\u2211 w\u1d62z\u1d62^r) = f(r)/r where f(r) = log(\u2211 w\u1d62z\u1d62^r). Since f(0) = log(1) = 0, this is a 0/0 form resolvable by the definition of derivative. The result fills a known gap in Mathlib.Analysis.MeanInequalitiesPow.",
+    "content": "This file formalizes the classical theorem that the weighted power mean M_r(z,w) = (∑ wᵢzᵢ^r)^(1/r) converges to the geometric mean GM = ∏ zᵢ^wᵢ as r → 0. The proof uses the exp/log representation and the definition of derivative, formalized via Mathlib's `hasDerivAt_iff_tendsto_slope`.\n\n**The indeterminate form:** At r = 0, M_r = (∑ wᵢzᵢ^0)^(1/0) = 1^∞, a classical indeterminate form. The standard resolution is logarithmic: log M_r = (1/r)·log(∑ wᵢzᵢ^r) = f(r)/r where f(r) = log(∑ wᵢzᵢ^r). Since f(0) = log(1) = 0, this is a 0/0 form resolvable by the definition of derivative. The result fills a known gap in Mathlib.Analysis.MeanInequalitiesPow.",
     "mathContext": "$\\lim_{r \\to 0} M_r(\\mathbf{z}, \\mathbf{w}) = \\prod_i z_i^{w_i} = \\text{GM}(\\mathbf{z}, \\mathbf{w})$ where $M_r = \\left(\\sum_i w_i z_i^r\\right)^{1/r}$",
     "significance": "supporting",
-    "relatedConcepts": [
-      "power means",
-      "geometric mean",
-      "L'H\u00f4pital rule",
-      "derivative definition"
-    ],
-    "prerequisites": [
-      "weighted inequalities",
-      "real analysis",
-      "HasDerivAt in Mathlib"
-    ]
+    "relatedConcepts": ["power means", "geometric mean", "L'Hôpital rule", "derivative definition"],
+    "prerequisites": ["weighted inequalities", "real analysis", "HasDerivAt in Mathlib"]
   },
   {
     "id": "ann-pmlo-02-positivity",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 54,
-      "endLine": 73
-    },
+    "range": { "startLine": 54, "endLine": 73 },
     "type": "technique",
-    "title": "Sum Positivity: \u2211 w\u1d62z\u1d62^r > 0",
-    "content": "`sum_weighted_rpow_pos` proves the denominator \u2211 w\u1d62z\u1d62^r is positive whenever \u2211 w\u1d62 = 1 and all z\u1d62 > 0. The key step is finding a strictly positive weight: if all weights were zero their sum couldn't be 1. Uses `Finset.single_le_sum` to bound a single positive term against the full sum.\n\n**Why this matters:** Positivity of \u2211 w\u1d62z\u1d62^r is needed twice downstream \u2014 once for the chain rule via `Real.hasDerivAt_log` (which requires a nonzero argument) and once for the exp/log rewrite `rpow_def_of_pos`. The proof by contradiction is the cleanest approach: assuming all weights vanish contradicts \u2211 w\u1d62 = 1.",
+    "title": "Sum Positivity: ∑ wᵢzᵢ^r > 0",
+    "content": "`sum_weighted_rpow_pos` proves the denominator ∑ wᵢzᵢ^r is positive whenever ∑ wᵢ = 1 and all zᵢ > 0. The key step is finding a strictly positive weight: if all weights were zero their sum couldn't be 1. Uses `Finset.single_le_sum` to bound a single positive term against the full sum.\n\n**Why this matters:** Positivity of ∑ wᵢzᵢ^r is needed twice downstream — once for the chain rule via `Real.hasDerivAt_log` (which requires a nonzero argument) and once for the exp/log rewrite `rpow_def_of_pos`. The proof by contradiction is the cleanest approach: assuming all weights vanish contradicts ∑ wᵢ = 1.",
     "mathContext": "Since $\\sum_i w_i = 1 > 0$ and $w_i \\geq 0$, some $w_{i_0} > 0$. Then $\\sum_i w_i z_i^r \\geq w_{i_0} z_{i_0}^r > 0$ since $z_{i_0}^r > 0$ for $z_{i_0} > 0$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "positivity",
-      "weighted sums",
-      "Finset.single_le_sum"
-    ],
-    "prerequisites": [
-      "finite sums",
-      "rpow positivity"
-    ]
+    "relatedConcepts": ["positivity", "weighted sums", "Finset.single_le_sum"],
+    "prerequisites": ["finite sums", "rpow positivity"]
   },
   {
     "id": "ann-pmlo-03-deriv",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 83,
-      "endLine": 98
-    },
+    "range": { "startLine": 83, "endLine": 98 },
     "type": "technique",
-    "title": "Derivative of \u2211 w\u1d62z\u1d62^r at r = 0",
-    "content": "`hasDerivAt_sum_weighted_rpow_zero` computes the derivative of r \u21a6 \u2211 w\u1d62z\u1d62^r at r = 0, yielding \u2211 w\u1d62 log z\u1d62. For each term: `Real.hasStrictDerivAt_const_rpow` gives HasDerivAt for z\u1d62^r with derivative z\u1d62^0 \u00b7 log z\u1d62 = log z\u1d62. `HasDerivAt.const_mul` and `HasDerivAt.sum` then differentiate the full weighted sum.",
+    "title": "Derivative of ∑ wᵢzᵢ^r at r = 0",
+    "content": "`hasDerivAt_sum_weighted_rpow_zero` computes the derivative of r ↦ ∑ wᵢzᵢ^r at r = 0, yielding ∑ wᵢ log zᵢ. For each term: `Real.hasStrictDerivAt_const_rpow` gives HasDerivAt for zᵢ^r with derivative zᵢ^0 · log zᵢ = log zᵢ. `HasDerivAt.const_mul` and `HasDerivAt.sum` then differentiate the full weighted sum.",
     "mathContext": "$\\left.\\frac{d}{dr}\\sum_i w_i z_i^r\\right|_{r=0} = \\sum_i w_i \\cdot z_i^0 \\cdot \\log z_i = \\sum_i w_i \\log z_i$",
     "significance": "key",
-    "relatedConcepts": [
-      "HasDerivAt",
-      "Real.hasStrictDerivAt_const_rpow",
-      "differentiation under sum"
-    ],
-    "prerequisites": [
-      "HasDerivAt API",
-      "rpow derivative",
-      "Finset sum differentiation"
-    ]
+    "relatedConcepts": ["HasDerivAt", "Real.hasStrictDerivAt_const_rpow", "differentiation under sum"],
+    "prerequisites": ["HasDerivAt API", "rpow derivative", "Finset sum differentiation"]
   },
   {
     "id": "ann-pmlo-03b-log-zero",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 100,
-      "endLine": 111
-    },
+    "range": { "startLine": 100, "endLine": 111 },
     "type": "technique",
     "title": "The Log Identity: f(0) = 0",
-    "content": "`log_sum_weighted_rpow_zero` proves that f(0) = log(\u2211 w\u1d62z\u1d62^0) = log(1) = 0. This identity is essential for the slope argument: since f(0) = 0, the difference quotient f(r)/r = (f(r) - f(0))/(r - 0) is exactly the slope that converges to f'(0) by the definition of derivative. Without f(0) = 0, the slope limit would give (f(r) - f(0))/r \u2192 f'(0), not f(r)/r \u2192 f'(0).",
+    "content": "`log_sum_weighted_rpow_zero` proves that f(0) = log(∑ wᵢzᵢ^0) = log(1) = 0. This identity is essential for the slope argument: since f(0) = 0, the difference quotient f(r)/r = (f(r) - f(0))/(r - 0) is exactly the slope that converges to f'(0) by the definition of derivative. Without f(0) = 0, the slope limit would give (f(r) - f(0))/r → f'(0), not f(r)/r → f'(0).",
     "mathContext": "$f(0) = \\log\\left(\\sum_i w_i z_i^0\\right) = \\log\\left(\\sum_i w_i\\right) = \\log(1) = 0$ since $z_i^0 = 1$ and $\\sum w_i = 1$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "rpow_zero",
-      "log_one",
-      "slope at zero"
-    ],
-    "prerequisites": [
-      "Real.rpow_zero",
-      "Real.log_one",
-      "weight normalization"
-    ]
+    "relatedConcepts": ["rpow_zero", "log_one", "slope at zero"],
+    "prerequisites": ["Real.rpow_zero", "Real.log_one", "weight normalization"]
   },
   {
     "id": "ann-pmlo-04-log-deriv",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 117,
-      "endLine": 137
-    },
+    "range": { "startLine": 117, "endLine": 137 },
     "type": "technique",
-    "title": "HasDerivAt for log(\u2211 w\u1d62z\u1d62^r) at r = 0",
-    "content": "`hasDerivAt_log_sum_weighted_rpow` applies the chain rule to compose log with the weighted sum. Since the inner function evaluates to 1 at r = 0 (as \u2211 w\u1d62z\u1d62^0 = \u2211 w\u1d62 = 1), the chain rule gives (1/1) \u00b7 \u2211 w\u1d62 log z\u1d62 = \u2211 w\u1d62 log z\u1d62.",
+    "title": "HasDerivAt for log(∑ wᵢzᵢ^r) at r = 0",
+    "content": "`hasDerivAt_log_sum_weighted_rpow` applies the chain rule to compose log with the weighted sum. Since the inner function evaluates to 1 at r = 0 (as ∑ wᵢzᵢ^0 = ∑ wᵢ = 1), the chain rule gives (1/1) · ∑ wᵢ log zᵢ = ∑ wᵢ log zᵢ.",
     "mathContext": "Chain rule: $(\\log \\circ h)'(0) = \\frac{h'(0)}{h(0)} = \\frac{\\sum_i w_i \\log z_i}{1} = \\sum_i w_i \\log z_i$",
     "significance": "key",
-    "relatedConcepts": [
-      "HasDerivAt.comp",
-      "Real.hasDerivAt_log",
-      "chain rule"
-    ],
-    "prerequisites": [
-      "HasDerivAt composition",
-      "log derivative"
-    ]
+    "relatedConcepts": ["HasDerivAt.comp", "Real.hasDerivAt_log", "chain rule"],
+    "prerequisites": ["HasDerivAt composition", "log derivative"]
   },
   {
     "id": "ann-pmlo-05-slope-limit",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 143,
-      "endLine": 171
-    },
+    "range": { "startLine": 143, "endLine": 171 },
     "type": "technique",
-    "title": "Core Limit: (log \u2211 w\u1d62z\u1d62^r)/r \u2192 \u2211 w\u1d62 log z\u1d62",
-    "content": "`tendsto_log_sum_div_rpow` is the key intermediate limit. Since g(r) = log(\u2211 w\u1d62z\u1d62^r) satisfies g(0) = 0 and g'(0) = \u2211 w\u1d62 log z\u1d62, we have g(r)/r = (g(r) - g(0))/(r - 0) \u2192 g'(0) by the definition of derivative. The Lean proof uses `hasDerivAt_iff_tendsto_slope` which directly connects HasDerivAt to this slope limit, then `congr'` with `slope g 0 = g r / r` (since g 0 = 0).",
+    "title": "Core Limit: (log ∑ wᵢzᵢ^r)/r → ∑ wᵢ log zᵢ",
+    "content": "`tendsto_log_sum_div_rpow` is the key intermediate limit. Since g(r) = log(∑ wᵢzᵢ^r) satisfies g(0) = 0 and g'(0) = ∑ wᵢ log zᵢ, we have g(r)/r = (g(r) - g(0))/(r - 0) → g'(0) by the definition of derivative. The Lean proof uses `hasDerivAt_iff_tendsto_slope` which directly connects HasDerivAt to this slope limit, then `congr'` with `slope g 0 = g r / r` (since g 0 = 0).",
     "mathContext": "$\\frac{g(r)}{r} = \\frac{g(r) - g(0)}{r - 0} \\to g'(0) = \\sum_i w_i \\log z_i$ by the definition of derivative.",
     "significance": "key",
-    "relatedConcepts": [
-      "hasDerivAt_iff_tendsto_slope",
-      "slope",
-      "nhdsWithin",
-      "derivative definition"
-    ],
-    "prerequisites": [
-      "filter limits",
-      "HasDerivAt API",
-      "slope lemma in Mathlib"
-    ]
+    "relatedConcepts": ["hasDerivAt_iff_tendsto_slope", "slope", "nhdsWithin", "derivative definition"],
+    "prerequisites": ["filter limits", "HasDerivAt API", "slope lemma in Mathlib"]
   },
   {
     "id": "ann-pmlo-06-geom-mean",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 177,
-      "endLine": 189
-    },
+    "range": { "startLine": 177, "endLine": 189 },
     "type": "technique",
     "title": "Geometric Mean as Exponential",
-    "content": "`geomMean_eq_exp_sum_log` proves GM = \u220f z\u1d62^w\u1d62 = exp(\u2211 w\u1d62 log z\u1d62). The proof rewrites the product using `Real.exp_log` (since GM > 0), then shows log GM = \u2211 w\u1d62 log z\u1d62 via `Real.log_prod` (product of positives) and `Real.log_rpow` (log of rpow).",
+    "content": "`geomMean_eq_exp_sum_log` proves GM = ∏ zᵢ^wᵢ = exp(∑ wᵢ log zᵢ). The proof rewrites the product using `Real.exp_log` (since GM > 0), then shows log GM = ∑ wᵢ log zᵢ via `Real.log_prod` (product of positives) and `Real.log_rpow` (log of rpow).",
     "mathContext": "$\\prod_i z_i^{w_i} = \\exp\\left(\\log \\prod_i z_i^{w_i}\\right) = \\exp\\left(\\sum_i \\log z_i^{w_i}\\right) = \\exp\\left(\\sum_i w_i \\log z_i\\right)$",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Real.log_prod",
-      "Real.log_rpow",
-      "Real.exp_log"
-    ],
-    "prerequisites": [
-      "exp/log identity",
-      "Finset.prod API"
-    ]
+    "relatedConcepts": ["Real.log_prod", "Real.log_rpow", "Real.exp_log"],
+    "prerequisites": ["exp/log identity", "Finset.prod API"]
   },
   {
     "id": "ann-pmlo-06b-exp-identity",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 191,
-      "endLine": 214
-    },
+    "range": { "startLine": 191, "endLine": 214 },
     "type": "technique",
-    "title": "Supporting Identities: M\u2081 = AM and M_r = exp(log/r)",
-    "content": "Two supporting identities bridge definitions and the main limit. `powerMean_one_eq_arithMean` shows M\u2081 = AM by simplifying z^1 = z via `rpow_one`. `powerMean_eq_exp_log` rewrites the power mean as M_r = exp((1/r) \u00b7 log(\u2211 w\u1d62z\u1d62^r)) using `rpow_def_of_pos` \u2014 this is the form where f(r)/r appears, connecting the power mean to the slope limit. The proof is 3 lines: rewrite via rpow_def_of_pos, then `congr 1; ring` aligns the exponents.",
+    "title": "Supporting Identities: M₁ = AM and M_r = exp(log/r)",
+    "content": "Two supporting identities bridge definitions and the main limit. `powerMean_one_eq_arithMean` shows M₁ = AM by simplifying z^1 = z via `rpow_one`. `powerMean_eq_exp_log` rewrites the power mean as M_r = exp((1/r) · log(∑ wᵢzᵢ^r)) using `rpow_def_of_pos` — this is the form where f(r)/r appears, connecting the power mean to the slope limit. The proof is 3 lines: rewrite via rpow_def_of_pos, then `congr 1; ring` aligns the exponents.",
     "mathContext": "$M_1 = \\sum w_i z_i^1 = \\sum w_i z_i = \\text{AM}$. For $r \\neq 0$: $(\\sum w_i z_i^r)^{1/r} = \\exp\\left(\\frac{1}{r} \\cdot \\log(\\sum w_i z_i^r)\\right)$ via $x^a = e^{a \\log x}$ for $x > 0$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "rpow_def_of_pos",
-      "exp/log representation",
-      "arithmetic mean"
-    ],
-    "prerequisites": [
-      "rpow_one",
-      "rpow_def_of_pos",
-      "sum_weighted_rpow_pos"
-    ]
+    "relatedConcepts": ["rpow_def_of_pos", "exp/log representation", "arithmetic mean"],
+    "prerequisites": ["rpow_one", "rpow_def_of_pos", "sum_weighted_rpow_pos"]
   },
   {
     "id": "ann-pmlo-07-main",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 220,
-      "endLine": 247
-    },
+    "range": { "startLine": 220, "endLine": 247 },
     "type": "insight",
-    "title": "MAIN THEOREM: lim_{r\u21920} M_r = GM",
-    "content": "`tendsto_powerMean_zero` is the main result. The proof:\n1. Gets exp(\u2211 w\u1d62 log z\u1d62) as the limit via composing `tendsto_log_sum_div_rpow` with continuity of exp\n2. Rewrites the target GM = exp(\u2211 w\u1d62 log z\u1d62) via `geomMean_eq_exp_sum_log`\n3. Applies `congr'` with the identity (\u2211 w\u1d62z\u1d62^r)^(1/r) = exp(log(\u2211 w\u1d62z\u1d62^r)/r) for all r\nThe congr step uses `rpow_def_of_pos` and ring arithmetic.",
+    "title": "MAIN THEOREM: lim_{r→0} M_r = GM",
+    "content": "`tendsto_powerMean_zero` is the main result. The proof:\n1. Gets exp(∑ wᵢ log zᵢ) as the limit via composing `tendsto_log_sum_div_rpow` with continuity of exp\n2. Rewrites the target GM = exp(∑ wᵢ log zᵢ) via `geomMean_eq_exp_sum_log`\n3. Applies `congr'` with the identity (∑ wᵢzᵢ^r)^(1/r) = exp(log(∑ wᵢzᵢ^r)/r) for all r\nThe congr step uses `rpow_def_of_pos` and ring arithmetic.",
     "mathContext": "$\\lim_{r \\to 0, r \\neq 0} \\left(\\sum_i w_i z_i^r\\right)^{1/r} = \\lim_{r \\to 0} e^{g(r)/r} = e^{\\sum_i w_i \\log z_i} = \\prod_i z_i^{w_i}$",
     "significance": "key",
-    "relatedConcepts": [
-      "tendsto composition",
-      "Filter.Tendsto.congr'",
-      "continuity of exp"
-    ],
-    "prerequisites": [
-      "filter limits",
-      "exp/log",
-      "power mean definition"
-    ]
+    "relatedConcepts": ["tendsto composition", "Filter.Tendsto.congr'", "continuity of exp"],
+    "prerequisites": ["filter limits", "exp/log", "power mean definition"]
   },
   {
     "id": "ann-pmlo-08-chain",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 249,
-      "endLine": 292
-    },
+    "range": { "startLine": 249, "endLine": 292 },
     "type": "technique",
-    "title": "Completing the Chain: HM \u2264 GM \u2264 AM",
-    "content": "`powerMean_neg1_le_geomMean_le_arithMean` proves both inequalities:\n- **HM \u2264 GM**: Apply AM-GM to inverse values z\u207b\u00b9. Since GM(z\u207b\u00b9) = GM(z)\u207b\u00b9 and GM(z\u207b\u00b9) \u2264 AM(z\u207b\u00b9) = \u2211 w\u1d62/z\u1d62 = 1/HM, we get 1/GM \u2264 1/HM hence HM \u2264 GM.\n- **GM \u2264 AM**: Direct from `Real.geom_mean_le_arith_mean_weighted`.\n\n**The inversion trick:** The HM \u2264 GM direction is a classic example of reducing one inequality to another by symmetry. The proof applies AM-GM to z\u207b\u00b9 instead of z, exploiting the fact that GM(z\u207b\u00b9) = GM(z)\u207b\u00b9 (geometric mean commutes with inversion). This technique generalizes: many power mean inequalities reduce to the r > 0 case by replacing z\u1d62 with z\u1d62\u207b\u00b9 and r with -r.",
+    "title": "Completing the Chain: HM ≤ GM ≤ AM",
+    "content": "`powerMean_neg1_le_geomMean_le_arithMean` proves both inequalities:\n- **HM ≤ GM**: Apply AM-GM to inverse values z⁻¹. Since GM(z⁻¹) = GM(z)⁻¹ and GM(z⁻¹) ≤ AM(z⁻¹) = ∑ wᵢ/zᵢ = 1/HM, we get 1/GM ≤ 1/HM hence HM ≤ GM.\n- **GM ≤ AM**: Direct from `Real.geom_mean_le_arith_mean_weighted`.\n\n**The inversion trick:** The HM ≤ GM direction is a classic example of reducing one inequality to another by symmetry. The proof applies AM-GM to z⁻¹ instead of z, exploiting the fact that GM(z⁻¹) = GM(z)⁻¹ (geometric mean commutes with inversion). This technique generalizes: many power mean inequalities reduce to the r > 0 case by replacing zᵢ with zᵢ⁻¹ and r with -r.",
     "mathContext": "$\\text{HM} = \\left(\\sum_i \\frac{w_i}{z_i}\\right)^{-1} \\leq \\prod_i z_i^{w_i} = \\text{GM} \\leq \\sum_i w_i z_i = \\text{AM}$",
     "significance": "supporting",
-    "relatedConcepts": [
-      "AM-GM inequality",
-      "harmonic mean",
-      "inverse AM-GM"
-    ],
-    "prerequisites": [
-      "AM-GM",
-      "rpow algebra",
-      "Finset.prod_inv_distrib"
-    ]
+    "relatedConcepts": ["AM-GM inequality", "harmonic mean", "inverse AM-GM"],
+    "prerequisites": ["AM-GM", "rpow algebra", "Finset.prod_inv_distrib"]
   },
   {
     "id": "ann-pmlo-00-setup",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 45,
-      "endLine": 48
-    },
-    "type": "context",
+    "range": { "startLine": 45, "endLine": 48 },
+    "type": "concept",
     "title": "Proof Environment: Open Namespaces and Variables",
-    "content": "`open Finset Real Filter` brings three namespaces into scope: `Finset` for finite sum/product operations (`Finset.sum`, `Finset.prod`, `Finset.single_le_sum`); `Real` for real analysis (`Real.rpow`, `Real.log`, `Real.exp`, `Real.continuous_exp`); and `Filter` for limit formalization (`Filter.Tendsto`, `nhdsWithin`). The `variable` declarations introduce `\u03b9` (an abstract index type), `s` (a finite index set), `w` (weights), and `z` (values) \u2014 making all theorems universe-polymorphic and applicable to any finite weighted collection.",
+    "content": "`open Finset Real Filter` brings three namespaces into scope: `Finset` for finite sum/product operations (`Finset.sum`, `Finset.prod`, `Finset.single_le_sum`); `Real` for real analysis (`Real.rpow`, `Real.log`, `Real.exp`, `Real.continuous_exp`); and `Filter` for limit formalization (`Filter.Tendsto`, `nhdsWithin`). The `variable` declarations introduce `ι` (an abstract index type), `s` (a finite index set), `w` (weights), and `z` (values) — making all theorems universe-polymorphic and applicable to any finite weighted collection.",
     "mathContext": "The variables $s \\subseteq \\iota$, $w : \\iota \\to \\mathbb{R}$ (weights), $z : \\iota \\to \\mathbb{R}$ (values) parameterize the power mean $M_r(z,w) = \\left(\\sum_{i \\in s} w_i z_i^r\\right)^{1/r}$. The abstract index type $\\iota$ allows the theorems to apply to any finite collection, not just $\\{1, \\ldots, n\\}$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Lean 4 open command",
-      "Finset API",
-      "Filter.Tendsto"
-    ],
-    "prerequisites": [
-      "Lean 4 namespaces",
-      "variable declarations"
-    ]
+    "relatedConcepts": ["Lean 4 open command", "Finset API", "Filter.Tendsto"],
+    "prerequisites": ["Lean 4 namespaces", "variable declarations"]
   },
   {
     "id": "ann-pmlo-09-summary",
     "proofId": "amgm-inequality-oq-03-oq-02",
-    "range": {
-      "startLine": 294,
-      "endLine": 316
-    },
-    "type": "context",
+    "range": { "startLine": 294, "endLine": 316 },
+    "type": "concept",
     "title": "Summary: Complete Proof Inventory (10 Theorems, 0 Sorries)",
-    "content": "The summary section lists all 10 proved results forming the complete chain from auxiliary lemmas to the main theorem:\n\n1. `sum_weighted_rpow_pos` \u2014 positivity of weighted rpow sum\n2. `hasDerivAt_sum_weighted_rpow_zero` \u2014 derivative at r=0\n3. `log_sum_weighted_rpow_zero` \u2014 f(0) = 0 identity\n4. `hasDerivAt_log_sum_weighted_rpow` \u2014 chain rule composition\n5. `tendsto_log_sum_div_rpow` \u2014 core slope limit\n6. `geomMean_eq_exp_sum_log` \u2014 GM = exp(\u2211 w\u1d62 log z\u1d62)\n7. `powerMean_one_eq_arithMean` \u2014 M\u2081 = AM\n8. `powerMean_eq_exp_log` \u2014 exp/log representation\n9. `tendsto_powerMean_zero` \u2014 MAIN THEOREM\n10. `powerMean_neg1_le_geomMean_le_arithMean` \u2014 HM \u2264 GM \u2264 AM\n\nThe dependency graph is linear: (1) \u2192 (2) \u2192 (4) \u2192 (5) \u2192 (9) \u2190 (6), with (3) feeding into (5), and (7)+(8) as supporting identities. Result (10) uses Mathlib's AM-GM independently.",
-    "mathContext": "The 10 results collectively establish: $\\lim_{r \\to 0} M_r = \\text{GM}$ (theorem 9), $\\text{HM} \\leq \\text{GM} \\leq \\text{AM}$ (theorem 10), and the supporting chain of derivatives and identities (theorems 1\u20138). Zero `sorry` declarations \u2014 every step is machine-verified.",
+    "content": "The summary section lists all 10 proved results forming the complete chain from auxiliary lemmas to the main theorem:\n\n1. `sum_weighted_rpow_pos` — positivity of weighted rpow sum\n2. `hasDerivAt_sum_weighted_rpow_zero` — derivative at r=0\n3. `log_sum_weighted_rpow_zero` — f(0) = 0 identity\n4. `hasDerivAt_log_sum_weighted_rpow` — chain rule composition\n5. `tendsto_log_sum_div_rpow` — core slope limit\n6. `geomMean_eq_exp_sum_log` — GM = exp(∑ wᵢ log zᵢ)\n7. `powerMean_one_eq_arithMean` — M₁ = AM\n8. `powerMean_eq_exp_log` — exp/log representation\n9. `tendsto_powerMean_zero` — MAIN THEOREM\n10. `powerMean_neg1_le_geomMean_le_arithMean` — HM ≤ GM ≤ AM\n\nThe dependency graph is linear: (1) → (2) → (4) → (5) → (9) ← (6), with (3) feeding into (5), and (7)+(8) as supporting identities. Result (10) uses Mathlib's AM-GM independently.",
+    "mathContext": "The 10 results collectively establish: $\\lim_{r \\to 0} M_r = \\text{GM}$ (theorem 9), $\\text{HM} \\leq \\text{GM} \\leq \\text{AM}$ (theorem 10), and the supporting chain of derivatives and identities (theorems 1–8). Zero `sorry` declarations — every step is machine-verified.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "proof inventory",
-      "dependency graph",
-      "sorry-free verification"
-    ],
-    "prerequisites": [
-      "all preceding theorems in this file"
-    ]
+    "relatedConcepts": ["proof inventory", "dependency graph", "sorry-free verification"],
+    "prerequisites": ["all preceding theorems in this file"]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -164,7 +164,8 @@
       "GM = exp(∑ wᵢ log zᵢ) proved via Real.log_prod (on positive terms) + Real.log_rpow",
       "The rpow_def_of_pos identity rewrites both M_r and the limit target to the exp form, making congr' close the goal",
       "Once limit is established, HM ≤ GM ≤ AM follows from AM-GM on inverse values",
-      "This limit is structurally identical to $\\lim_{\\alpha \\to 1} H_\\alpha = H_1$ (Rényi entropy converges to Shannon entropy): both use the derivative of $\\log(\\sum p_i^\\alpha)$ at the singular point, with $f(1) = 0$ and $f'(1) = \\sum p_i \\log p_i$. The `hasDerivAt_iff_tendsto_slope` technique applies verbatim to formalize the Rényi-to-Shannon limit in Lean"
+      "This limit is structurally identical to $\\lim_{\\alpha \\to 1} H_\\alpha = H_1$ (Rényi entropy converges to Shannon entropy): both use the derivative of $\\log(\\sum p_i^\\alpha)$ at the singular point, with $f(1) = 0$ and $f'(1) = \\sum p_i \\log p_i$. The `hasDerivAt_iff_tendsto_slope` technique applies verbatim to formalize the Rényi-to-Shannon limit in Lean",
+      "**Kolmogorov-Nagumo uniqueness:** The power mean family is essentially the unique class of quasi-arithmetic means satisfying continuity, strict monotonicity, and homogeneity (Kolmogorov 1930, Nagumo 1930, independently). The $r \\to 0$ limit proved here is the continuity condition at the singular point that makes the power mean a smooth one-parameter interpolation from $\\min$ ($r \\to -\\infty$) through $\\text{HM}$ ($r=-1$), $\\text{GM}$ ($r=0$), $\\text{AM}$ ($r=1$) to $\\max$ ($r \\to +\\infty$). Without this limit, the family would have a discontinuity at $r=0$ and the uniqueness characterization would fail — making this result not just a computation but a foundational continuity requirement"
     ],
     "prerequisites": [
       "Derivatives in Mathlib (HasDerivAt, hasDerivAt_iff_tendsto_slope)",

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/annotations.json
@@ -6,10 +6,10 @@
       "startLine": 1,
       "endLine": 11
     },
-    "type": "context",
+    "type": "concept",
     "title": "Module Overview: Axiom Elimination via Mathlib Bridge",
-    "content": "The module docstring frames the file's purpose: proving `galois_2group_implies_degree_pow2` \u2014 which was an axiom in AngleTrisectionOQ02.lean \u2014 by generalizing Mathlib's `prime_degree_dvd_card` to all irreducible polynomials. This reduces the parent's axiom count from 6 to 5.\n\nThe docstring establishes the file's position in the formalization hierarchy: it sits between OQ-01 (degree characterization, fully verified) and OQ-02 (Galois characterization, partially axiomatized), providing a bridge that strengthens the connection between Mathlib's infrastructure and the constructibility theorems.",
-    "mathContext": "The axiom being eliminated: `galois_2group_implies_degree_pow2 : IsPGroup 2 (minpoly \u211a \u03b1).Gal \u2192 \u2203 n, natDegree (minpoly \u211a \u03b1) \u2223 2^n`. The file proves this from Mathlib via the tower law, reducing the axiom count of the OQ-02 formalization.",
+    "content": "The module docstring frames the file's purpose: proving `galois_2group_implies_degree_pow2` — which was an axiom in AngleTrisectionOQ02.lean — by generalizing Mathlib's `prime_degree_dvd_card` to all irreducible polynomials. This reduces the parent's axiom count from 6 to 5.\n\nThe docstring establishes the file's position in the formalization hierarchy: it sits between OQ-01 (degree characterization, fully verified) and OQ-02 (Galois characterization, partially axiomatized), providing a bridge that strengthens the connection between Mathlib's infrastructure and the constructibility theorems.",
+    "mathContext": "The axiom being eliminated: `galois_2group_implies_degree_pow2 : IsPGroup 2 (minpoly ℚ α).Gal → ∃ n, natDegree (minpoly ℚ α) ∣ 2^n`. The file proves this from Mathlib via the tower law, reducing the axiom count of the OQ-02 formalization.",
     "significance": "supporting",
     "relatedConcepts": [
       "axiom elimination",
@@ -32,9 +32,9 @@
       "startLine": 13,
       "endLine": 18
     },
-    "type": "context",
+    "type": "concept",
     "title": "Mathlib and OQ-01 Dependencies",
-    "content": "Imports the full Mathlib library (for `Polynomial.Gal`, `IsPGroup`, `Prime.dvd_of_dvd_pow`, `IntermediateField.adjoin.finrank`) and the parent file `AngleTrisectionOQ01` which provides `dvd_pow_two_is_pow_two` \u2014 the lemma that any positive divisor of $2^n$ is itself a power of 2. The `open Polynomial` and `open scoped IntermediateField` declarations bring polynomial notation `F[X]` and the intermediate field notation `F\u27ee\u03b1\u27ef` into scope.\n\n**Design principle:** The file is organized as a progressive chain: Part I establishes the general divisibility result (natDegree | |Gal|), Part II specializes to 2-groups, and Part III bridges to the constructibility definition \u2014 each part building on the previous with minimal dependencies.",
+    "content": "Imports the full Mathlib library (for `Polynomial.Gal`, `IsPGroup`, `Prime.dvd_of_dvd_pow`, `IntermediateField.adjoin.finrank`) and the parent file `AngleTrisectionOQ01` which provides `dvd_pow_two_is_pow_two` — the lemma that any positive divisor of $2^n$ is itself a power of 2. The `open Polynomial` and `open scoped IntermediateField` declarations bring polynomial notation `F[X]` and the intermediate field notation `F⟮α⟯` into scope.\n\n**Design principle:** The file is organized as a progressive chain: Part I establishes the general divisibility result (natDegree | |Gal|), Part II specializes to 2-groups, and Part III bridges to the constructibility definition — each part building on the previous with minimal dependencies.",
     "mathContext": "The key Mathlib theorems used are: (1) `Polynomial.Gal.card_of_separable`: $|\\text{Gal}(p)| = \\text{finrank}(F, \\text{SplittingField}(p))$ for separable $p$; (2) `IsPGroup.iff_card`: $G$ is a $p$-group $\\iff |G| = p^n$; (3) `Prime.dvd_of_dvd_pow`: $p \\mid a^n \\Rightarrow p \\mid a$ for prime $p$. From OQ-01: `dvd_pow_two_is_pow_two`: $d > 0 \\wedge d \\mid 2^n \\Rightarrow \\exists k, d = 2^k$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -57,7 +57,7 @@
       "endLine": 58
     },
     "type": "technique",
-    "title": "natDegree Divides |Gal| \u2014 Tower Law Argument",
+    "title": "natDegree Divides |Gal| — Tower Law Argument",
     "content": "The central theorem of the file: for any irreducible polynomial $p$ over a CharZero field $F$, $\\text{natDegree}(p) \\mid |\\text{Gal}(p)|$. This generalizes Mathlib's `prime_degree_dvd_card` (which requires prime degree) to all degrees.\n\nThe proof uses the **tower law** on the chain $F \\subset F(\\alpha) \\subset \\text{SplittingField}(p)$, where $\\alpha$ is a root of $p$ in the splitting field. By Galois theory, $|\\text{Gal}(p)| = [\\text{SplittingField}(p) : F]$. The tower law gives $[\\text{SplittingField}(p) : F] = [\\text{SplittingField}(p) : F(\\alpha)] \\cdot [F(\\alpha) : F]$, and since $[F(\\alpha) : F] = \\deg(\\text{minpoly}(F, \\alpha)) = \\deg(p)$ (because $p$ is irreducible and $\\alpha$ is a root), we get $\\deg(p) \\mid |\\text{Gal}(p)|$.",
     "mathContext": "Tower law: $[L:F] = [L:K] \\cdot [K:F]$ for $F \\subseteq K \\subseteq L$. Here $L = \\text{SplittingField}(p)$, $K = F(\\alpha)$, so $|\\text{Gal}(p)| = [L:F] = [L:F(\\alpha)] \\cdot [F(\\alpha):F]$, giving $\\deg(p) = [F(\\alpha):F] \\mid |\\text{Gal}(p)|$. The key subtlety: showing $\\text{minpoly}(F, \\alpha) = p$ (up to associates) uses irreducibility of $p$ plus the fact that $\\text{minpoly}(F, \\alpha) \\mid p$ (since $\\alpha$ is a root of $p$).",
     "significance": "key",
@@ -110,8 +110,8 @@
       "endLine": 58
     },
     "type": "insight",
-    "title": "Minimal Polynomial Equals p \u2014 Irreducibility Argument",
-    "content": "The crux of the tower law argument: showing $\\text{natDegree}(\\text{minpoly}(F, \\alpha)) = \\text{natDegree}(p)$. This proceeds in two steps:\n\n1. **minpoly divides p**: Since $\\alpha$ is a root of $p$ and minpoly is the minimal such polynomial, $\\text{minpoly}(F, \\alpha) \\mid p$. This uses `minpoly.dvd` after rewriting `aeval` through `eval\u2082_eq_eval_map`.\n\n2. **p divides minpoly**: Since $p$ is irreducible and $\\text{minpoly}(F, \\alpha)$ is also irreducible (by `minpoly.irreducible`), and they share a divisibility relation, `Irreducible.dvd_symm` gives the reverse direction.\n\nMutual divisibility of irreducible polynomials means they are associates, so they have equal degrees.",
+    "title": "Minimal Polynomial Equals p — Irreducibility Argument",
+    "content": "The crux of the tower law argument: showing $\\text{natDegree}(\\text{minpoly}(F, \\alpha)) = \\text{natDegree}(p)$. This proceeds in two steps:\n\n1. **minpoly divides p**: Since $\\alpha$ is a root of $p$ and minpoly is the minimal such polynomial, $\\text{minpoly}(F, \\alpha) \\mid p$. This uses `minpoly.dvd` after rewriting `aeval` through `eval₂_eq_eval_map`.\n\n2. **p divides minpoly**: Since $p$ is irreducible and $\\text{minpoly}(F, \\alpha)$ is also irreducible (by `minpoly.irreducible`), and they share a divisibility relation, `Irreducible.dvd_symm` gives the reverse direction.\n\nMutual divisibility of irreducible polynomials means they are associates, so they have equal degrees.",
     "mathContext": "For irreducible $p \\in F[X]$ and $\\alpha$ a root: $\\text{minpoly}(F, \\alpha) \\mid p$ (minimality). Since both are irreducible in a UFD, mutual divisibility implies $\\text{minpoly}(F, \\alpha) \\sim p$ (associate), hence $\\deg(\\text{minpoly}(F, \\alpha)) = \\deg(p)$. Then $[F(\\alpha):F] = \\deg(\\text{minpoly}(F, \\alpha)) = \\deg(p)$, completing the tower law decomposition.",
     "significance": "key",
     "relatedConcepts": [
@@ -119,7 +119,7 @@
       "irreducible polynomial",
       "associates in UFD",
       "aeval",
-      "eval\u2082_eq_eval_map"
+      "eval₂_eq_eval_map"
     ],
     "prerequisites": [
       "Mathlib.FieldTheory.Minpoly.Basic",
@@ -135,7 +135,7 @@
       "endLine": 72
     },
     "type": "technique",
-    "title": "2-Group Gal \u2192 Degree Divides 2^n",
+    "title": "2-Group Gal → Degree Divides 2^n",
     "content": "Chains two results: (1) `natDegree_dvd_card_gal` gives $\\deg(\\text{minpoly}(\\mathbb{Q}, \\alpha)) \\mid |\\text{Gal}(\\text{minpoly}(\\mathbb{Q}, \\alpha))|$, and (2) `IsPGroup.iff_card` gives $|\\text{Gal}| = 2^n$ when Gal is a 2-group. Transitivity of divisibility yields $\\deg \\mid 2^n$. This theorem eliminates the axiom `galois_2group_implies_degree_pow2` from OQ-02, which was one of 6 axioms in the parent formalization.",
     "mathContext": "If $\\text{Gal}(\\text{minpoly}(\\mathbb{Q}, \\alpha))$ is a 2-group, then $|\\text{Gal}| = 2^n$ for some $n$. Combined with $\\deg(\\text{minpoly}) \\mid |\\text{Gal}|$, we get $\\deg(\\text{minpoly}) \\mid 2^n$. This is the divisibility form; the next theorem strengthens it to equality.",
     "significance": "key",
@@ -183,9 +183,9 @@
       "endLine": 94
     },
     "type": "definition",
-    "title": "IsConstructibleFromQ \u2014 Field Extension Characterization",
+    "title": "IsConstructibleFromQ — Field Extension Characterization",
     "content": "Defines constructibility of $\\alpha \\in \\mathbb{R}$: there exists an intermediate field $K$ with $\\mathbb{Q} \\subseteq K \\subseteq \\mathbb{R}$ such that $K/\\mathbb{Q}$ is finite-dimensional, $[K:\\mathbb{Q}] = 2^n$, and $\\alpha \\in K$. This is identical to the definition in OQ-02, reproduced here for self-containedness. The power-of-2 degree condition captures the geometric intuition: each compass-and-straightedge step extends the field by at most degree 2 (adding a square root).",
-    "mathContext": "$\\alpha$ is constructible $\\iff \\exists K$, $\\mathbb{Q} \\subseteq K \\subseteq \\mathbb{R}$, $[K:\\mathbb{Q}] = 2^n$, $\\alpha \\in K$. Equivalently, $\\alpha$ is reachable from $\\mathbb{Q}$ by $+, -, \\times, \\div, \\sqrt{\\cdot}$ (with real outputs). The degree-$2^n$ condition rules out cube roots ($\\sqrt[3]{2}$ has degree 3), cos(20\u00b0) (degree 3), and other algebraic numbers requiring odd-degree extensions.",
+    "mathContext": "$\\alpha$ is constructible $\\iff \\exists K$, $\\mathbb{Q} \\subseteq K \\subseteq \\mathbb{R}$, $[K:\\mathbb{Q}] = 2^n$, $\\alpha \\in K$. Equivalently, $\\alpha$ is reachable from $\\mathbb{Q}$ by $+, -, \\times, \\div, \\sqrt{\\cdot}$ (with real outputs). The degree-$2^n$ condition rules out cube roots ($\\sqrt[3]{2}$ has degree 3), cos(20°) (degree 3), and other algebraic numbers requiring odd-degree extensions.",
     "significance": "supporting",
     "relatedConcepts": [
       "constructible number",
@@ -195,7 +195,7 @@
       "Module.finrank"
     ],
     "prerequisites": [
-      "IntermediateField \u211a \u211d",
+      "IntermediateField ℚ ℝ",
       "FiniteDimensional",
       "Module.finrank"
     ]
@@ -229,9 +229,9 @@
       "startLine": 102,
       "endLine": 115
     },
-    "type": "context",
+    "type": "concept",
     "title": "Summary: Axiom Elimination Progress",
-    "content": "The file achieves 4 theorems with 0 sorries and 0 axioms, eliminating 1 of OQ-02's 6 axioms (`galois_2group_implies_degree_pow2`). The key achievement is proving `natDegree_dvd_card_gal` \u2014 a general result not restricted to prime degree \u2014 which enables the entire 2-group-to-degree-power-of-2 chain. This demonstrates that Mathlib's `Polynomial.Gal` infrastructure, combined with the tower law, suffices for the structural argument without computing explicit Galois group orders.",
+    "content": "The file achieves 4 theorems with 0 sorries and 0 axioms, eliminating 1 of OQ-02's 6 axioms (`galois_2group_implies_degree_pow2`). The key achievement is proving `natDegree_dvd_card_gal` — a general result not restricted to prime degree — which enables the entire 2-group-to-degree-power-of-2 chain. This demonstrates that Mathlib's `Polynomial.Gal` infrastructure, combined with the tower law, suffices for the structural argument without computing explicit Galois group orders.",
     "mathContext": "Axiom status in the OQ-02 family: OQ-02 started with 6 axioms. This file (OQ-02-OQ-01) eliminates 1 axiom by proving the degree-divisibility implication from Mathlib. The sibling file OQ-02-OQ-03 addresses the Gauss-Wantzel direction (regular polygon constructibility). The parent OQ-02 retains 5 axioms after this contribution.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/angle-trisection-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 1,
       "endLine": 37
     },
-    "type": "context",
+    "type": "concept",
     "title": "The Gauss-Wantzel OQ Chain: From Galois Groups to Fermat Primes",
     "content": "This file is the third level of the constructibility OQ chain. OQ01 proved the degree criterion ($\\alpha$ constructible $\\Rightarrow$ $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 2^k$, necessary but not sufficient). OQ02 proved the complete Galois criterion ($\\alpha$ constructible $\\iff$ Gal(minpoly) is a 2-group). OQ02-OQ03 (this file) applies OQ02 to $\\cos(2\\pi/n)$ to get the Gauss-Wantzel theorem: a regular $n$-gon is constructible $\\iff$ $\\varphi(n)$ is a power of 2.",
     "mathContext": "**Gauss-Wantzel**: regular $n$-gon constructible $\\iff$ $\\varphi(n) = 2^k$. **Key chain**: $\\cos(2\\pi/n)$ generates maximal real subfield of $\\mathbb{Q}(\\zeta_n)$; $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$; $\\text{Gal}(\\Phi_n/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^*$.",
@@ -32,9 +32,9 @@
     },
     "type": "technique",
     "title": "Totient Computations and Power-of-2 Tests",
-    "content": "Core computations: $\\varphi(n)$ for $n = 3, \\ldots, 17, 257, 65537$ proved by `decide`/`native_decide`. The key helper `not_pow_two_of_odd_prime_dvd` shows: if $p \\mid n$ with $p$ an odd prime, then $n \\neq 2^k$. Proof: $p \\mid 2^k \\Rightarrow p \\mid 2$ (by `Prime.dvd_of_dvd_pow`) $\\Rightarrow p \\le 2$, contradicting $p \\ge 3$.\n\n**Positive**: $\\varphi(3) = 2$, $\\varphi(5) = 4$, $\\varphi(17) = 16$, $\\varphi(257) = 256$, $\\varphi(65537) = 65536$ \u2014 all $2^k$.\n**Negative**: $\\varphi(7) = 6$ ($3 \\mid 6$), $\\varphi(9) = 6$, $\\varphi(11) = 10$ ($5 \\mid 10$), $\\varphi(13) = 12$ ($3 \\mid 12$).",
+    "content": "Core computations: $\\varphi(n)$ for $n = 3, \\ldots, 17, 257, 65537$ proved by `decide`/`native_decide`. The key helper `not_pow_two_of_odd_prime_dvd` shows: if $p \\mid n$ with $p$ an odd prime, then $n \\neq 2^k$. Proof: $p \\mid 2^k \\Rightarrow p \\mid 2$ (by `Prime.dvd_of_dvd_pow`) $\\Rightarrow p \\le 2$, contradicting $p \\ge 3$.\n\n**Positive**: $\\varphi(3) = 2$, $\\varphi(5) = 4$, $\\varphi(17) = 16$, $\\varphi(257) = 256$, $\\varphi(65537) = 65536$ — all $2^k$.\n**Negative**: $\\varphi(7) = 6$ ($3 \\mid 6$), $\\varphi(9) = 6$, $\\varphi(11) = 10$ ($5 \\mid 10$), $\\varphi(13) = 12$ ($3 \\mid 12$).",
     "mathContext": "$p \\mid n$, $p$ odd prime $\\Rightarrow n \\neq 2^k$. Proof: $p \\mid 2^k \\Rightarrow p \\mid 2 \\Rightarrow p \\leq 2$, contradiction.",
-    "significance": "technical",
+    "significance": "supporting",
     "relatedConcepts": [
       "Nat.totient",
       "Nat.Prime.dvd_of_dvd_pow",
@@ -54,10 +54,10 @@
       "startLine": 120,
       "endLine": 210
     },
-    "type": "context",
+    "type": "concept",
     "title": "The Gauss-Wantzel Theorem and IsConstructibleNgon (NOW PROVED)",
     "content": "**IsConstructibleNgon** defines a regular $n$-gon as constructible when $\\cos(2\\pi/n)$ lies in some intermediate field $K$ of $\\mathbb{R}/\\mathbb{Q}$ with $[K:\\mathbb{Q}] = 2^k$.\n\nThe **gauss_wantzel_theorem** was originally axiomatized but is now fully proved (0 axioms remain). The proof uses: (1) `IsCyclotomicExtension.finrank` for $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$; (2) Chebyshev polynomials showing $\\cos(2\\pi/n)$ is algebraic; (3) cyclotomic tower law showing $[\\mathbb{Q}(\\cos(2\\pi/n)):\\mathbb{Q}] = \\varphi(n)/2$; (4) the 2-group criterion from OQ-02. The file grew from ~548 lines to 1799 lines in the process of eliminating all axioms.",
-    "mathContext": "**Proved**: `IsConstructibleNgon n \u2194 TotientIsPow2 n` for $n \\ge 3$. **Definition**: `IsConstructibleNgon n := \\exists K \\le \\mathbb{R},\\; [K:\\mathbb{Q}] = 2^k \\wedge \\cos(2\\pi/n) \\in K$.",
+    "mathContext": "**Proved**: `IsConstructibleNgon n ↔ TotientIsPow2 n` for $n \\ge 3$. **Definition**: `IsConstructibleNgon n := \\exists K \\le \\mathbb{R},\\; [K:\\mathbb{Q}] = 2^k \\wedge \\cos(2\\pi/n) \\in K$.",
     "significance": "key",
     "relatedConcepts": [
       "gauss_wantzel_theorem",
@@ -80,7 +80,7 @@
     },
     "type": "insight",
     "title": "Constructible Polygons: From Triangle to 65537-gon",
-    "content": "Ten constructible polygons proved via Gauss-Wantzel: $n = 3, 4, 5, 6, 8, 10, 12, 17, 257, 65537$.\n\n**Highlights**:\n- **Gauss's 17-gon** (March 30, 1796): $\\varphi(17) = 16 = 2^4$. First new construction since antiquity. Gauss was 18.\n- **Richelot's 257-gon** (1832): $\\varphi(257) = 256 = 2^8$. Explicit construction: 80 pages.\n- **Hermes's 65537-gon** (1879\u20131889): $\\varphi(65537) = 65536 = 2^{16}$. Hermes spent 10 years; manuscript donated to G\u00f6ttingen, never published.",
+    "content": "Ten constructible polygons proved via Gauss-Wantzel: $n = 3, 4, 5, 6, 8, 10, 12, 17, 257, 65537$.\n\n**Highlights**:\n- **Gauss's 17-gon** (March 30, 1796): $\\varphi(17) = 16 = 2^4$. First new construction since antiquity. Gauss was 18.\n- **Richelot's 257-gon** (1832): $\\varphi(257) = 256 = 2^8$. Explicit construction: 80 pages.\n- **Hermes's 65537-gon** (1879–1889): $\\varphi(65537) = 65536 = 2^{16}$. Hermes spent 10 years; manuscript donated to Göttingen, never published.",
     "mathContext": "$\\varphi(3) = 2$, $\\varphi(4) = 2$, $\\varphi(5) = 4$, $\\varphi(6) = 2$, $\\varphi(8) = 4$, $\\varphi(10) = 4$, $\\varphi(12) = 4$, $\\varphi(17) = 16$, $\\varphi(257) = 256$, $\\varphi(65537) = 65536$.",
     "significance": "key",
     "relatedConcepts": [
@@ -104,8 +104,8 @@
     },
     "type": "technique",
     "title": "Non-Constructible Polygons: The Odd Prime Obstruction",
-    "content": "Four non-constructible polygons: $n = 7, 9, 11, 13$.\n\n- **7-gon**: $\\varphi(7) = 6 = 2 \\cdot 3$. The factor 3 prevents a 2-tower.\n- **9-gon**: $\\varphi(9) = 6$. Despite 3 being Fermat, $9 = 3^2$ fails \u2014 primes must appear at most once.\n- **11-gon**: $\\varphi(11) = 10 = 2 \\cdot 5$. 11 is prime but not Fermat ($11 \\neq 2^{2^k}+1$).\n- **13-gon**: $\\varphi(13) = 12 = 4 \\cdot 3$. Odd factor 3 is the obstruction.",
-    "mathContext": "$\\varphi(7) = 6$, $\\varphi(9) = 6$, $\\varphi(11) = 10$, $\\varphi(13) = 12$ \u2014 none powers of 2.",
+    "content": "Four non-constructible polygons: $n = 7, 9, 11, 13$.\n\n- **7-gon**: $\\varphi(7) = 6 = 2 \\cdot 3$. The factor 3 prevents a 2-tower.\n- **9-gon**: $\\varphi(9) = 6$. Despite 3 being Fermat, $9 = 3^2$ fails — primes must appear at most once.\n- **11-gon**: $\\varphi(11) = 10 = 2 \\cdot 5$. 11 is prime but not Fermat ($11 \\neq 2^{2^k}+1$).\n- **13-gon**: $\\varphi(13) = 12 = 4 \\cdot 3$. Odd factor 3 is the obstruction.",
+    "mathContext": "$\\varphi(7) = 6$, $\\varphi(9) = 6$, $\\varphi(11) = 10$, $\\varphi(13) = 12$ — none powers of 2.",
     "significance": "supporting",
     "relatedConcepts": [
       "heptagon impossibility",
@@ -126,7 +126,7 @@
     },
     "type": "concept",
     "title": "Fermat Primes and the General Constructibility Theorem",
-    "content": "**Fermat primes**: primes of the form $p = 2^{2^k}+1$. The five known: $F_0 = 3$, $F_1 = 5$, $F_2 = 17$, $F_3 = 257$, $F_4 = 65537$.\n\nThe general theorem `fermat_prime_totient_pow2`: if $p = 2^{2^k}+1$ is prime, then $\\varphi(p) = 2^{2^k}$ (a power of 2). Then `fermat_prime_ngon_constructible` applies Gauss-Wantzel.\n\n$F_5 = 2^{32}+1 = 641 \\times 6700417$ (Euler, 1732) \u2014 composite. No Fermat prime beyond $F_4$ is known.",
+    "content": "**Fermat primes**: primes of the form $p = 2^{2^k}+1$. The five known: $F_0 = 3$, $F_1 = 5$, $F_2 = 17$, $F_3 = 257$, $F_4 = 65537$.\n\nThe general theorem `fermat_prime_totient_pow2`: if $p = 2^{2^k}+1$ is prime, then $\\varphi(p) = 2^{2^k}$ (a power of 2). Then `fermat_prime_ngon_constructible` applies Gauss-Wantzel.\n\n$F_5 = 2^{32}+1 = 641 \\times 6700417$ (Euler, 1732) — composite. No Fermat prime beyond $F_4$ is known.",
     "mathContext": "$F_k = 2^{2^k}+1$. If prime, $\\varphi(F_k) = 2^{2^k}$. Known: $F_0 = 3, F_1 = 5, F_2 = 17, F_3 = 257, F_4 = 65537$.",
     "significance": "key",
     "relatedConcepts": [
@@ -195,9 +195,9 @@
       "startLine": 560,
       "endLine": 579
     },
-    "type": "context",
+    "type": "concept",
     "title": "Euler's Factorization of F5 and the Open Fermat Prime Problem",
-    "content": "**Euler (1732)**: $F_5 = 2^{32}+1 = 4294967297 = 641 \\times 6700417$.\n\nThe file proves `f5_factorization`, `f5_value`, `f5_not_prime` (by `native_decide`), and `f5_not_fermat_prime`.\n\nEuler found the factor 641 by observing $641 = 5^4 + 2^4 = 5 \\cdot 2^7 + 1$, which yields $641 \\mid 2^{32}+1$ through modular arithmetic.\n\n**Open problem**: are there any Fermat primes beyond $F_4 = 65537$? As of 2026, $F_n$ checked up to $n = 32$ \u2014 all composite. It is conjectured that only 5 Fermat primes exist, but this is unproved.",
+    "content": "**Euler (1732)**: $F_5 = 2^{32}+1 = 4294967297 = 641 \\times 6700417$.\n\nThe file proves `f5_factorization`, `f5_value`, `f5_not_prime` (by `native_decide`), and `f5_not_fermat_prime`.\n\nEuler found the factor 641 by observing $641 = 5^4 + 2^4 = 5 \\cdot 2^7 + 1$, which yields $641 \\mid 2^{32}+1$ through modular arithmetic.\n\n**Open problem**: are there any Fermat primes beyond $F_4 = 65537$? As of 2026, $F_n$ checked up to $n = 32$ — all composite. It is conjectured that only 5 Fermat primes exist, but this is unproved.",
     "mathContext": "$F_5 = 2^{2^5}+1 = 4294967297 = 641 \\times 6700417$. Euler: $641 = 5^4 + 2^4$ and $641 = 5 \\cdot 128 + 1$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/angle-trisection-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 1,
       "endLine": 44
     },
-    "type": "context",
+    "type": "concept",
     "title": "Module Overview: From Degree Criterion to Galois Criterion",
     "content": "The file imports Mathlib (for p-groups, Galois groups, field extensions, polynomials) plus four project-local files: `InverseGalois` (S\u2083 as Galois group of x\u00b3-2), `InverseGaloisD4` (D\u2084 as Galois group of x\u2074-2), `NthRootIrrationalOQ01` (irreducibility of x^n-a), and `AngleTrisectionCos20Gal` (Galois group of the trisection polynomial). The module docstring explains the upgrade from OQ-01's necessary condition (degree divides 2^n) to OQ-02's exact biconditional (constructibility \u2194 2-group Galois). This is a fundamental shift: degree is a numerical shadow of the richer group-theoretic structure.\n\n**Why the upgrade matters:** The degree criterion alone cannot distinguish \u221a2 (constructible, degree 2) from \u221b2 (non-constructible, degree 3). But it also fails more subtly: there exist algebraic numbers whose degree IS a power of 2 but which are NOT constructible \u2014 because the Galois group, though of 2-power order, may not embed into the right intermediate field structure. The 2-group Galois criterion captures the exact obstruction.",
     "mathContext": "The upgrade: OQ-01 says $\\alpha$ constructible $\\Rightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] \\mid 2^n$ (necessary). OQ-02 says $\\alpha$ constructible $\\iff \\text{Gal}(\\text{minpoly}(\\mathbb{Q},\\alpha))$ is a 2-group (necessary AND sufficient).",
@@ -221,7 +221,7 @@
       "startLine": 263,
       "endLine": 298
     },
-    "type": "context",
+    "type": "concept",
     "title": "Summary: 22 Declarations, 1 Axiom",
     "content": "The file contains 15 public theorems, 2 private lemmas, 4 private theorems, 1 definition (`IsConstructibleFromQ`), and 1 axiom (`wantzel_galois_characterization`). The Galois group orders for x\u00b3-2 and cos(20\u00b0)'s minimal polynomial are proved (not axiomatized) \u2014 they reference results in companion files InverseGalois.lean and AngleTrisectionCos20Gal.lean.\n\nThe only axiom remaining is `wantzel_galois_characterization` (the biconditional requiring the full Galois correspondence). All other results are either proved from Mathlib lemmas or derived from first principles.\n\n**Verification methodology:** The six `#check` commands at the end test both proved theorems and imported results: `isPGroup_iff_card_pow_two` (basic 2-group fact), `x_cube_sub_2_gal_not_2group` (\u221b2 non-constructible), `cos20_gal_not_2group` (trisection impossible), `x_sq_sub_2_gal_is_2group` (\u221a2 constructible), `x_4th_sub_2_gal_is_2group` (2^(1/4) constructible), and `constructible_implies_degree_dvd_pow2` (OQ-02 implies OQ-01).",
     "mathContext": "22 total declarations: 15 public theorems + 6 private lemmas/theorems + 1 definition + 1 axiom. The sole axiom `wantzel_galois_characterization` is the only gap: it requires the Galois correspondence $\\text{Gal}(K/\\mathbb{Q})$ subgroups $\\leftrightarrow$ intermediate fields, which Mathlib provides but the full proof chain is complex.",

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -164,6 +164,16 @@
       "targetId": "angle-trisection-oq-02-oq-03-oq-01",
       "relationship": "extended-by",
       "description": "Bridges the Gauss-Wantzel constructibility theorem to Mathlib's cyclotomic field infrastructure. Connects the 2-group Galois criterion proved here to the concrete setting of $\\zeta_n = e^{2\\pi i/n}$ and Chebyshev polynomials, showing how the abstract group-theoretic characterization manifests in the cyclotomic world that governs regular polygon constructibility"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "De Moivre's formula $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$ expresses the $n$th roots of unity $\\zeta_n = e^{2\\pi i/n}$ that generate cyclotomic extensions. The Gauss-Wantzel theorem is a direct application: the regular $p$-gon is constructible iff $\\text{Gal}(\\mathbb{Q}(\\zeta_p)/\\mathbb{Q}) \\cong (\\mathbb{Z}/p\\mathbb{Z})^{\\times}$ is a 2-group, i.e., $p-1 = 2^k$. Gauss's construction of the 17-gon used the 2-group structure to recursively extract square roots of the Gauss periods $\\eta_i = \\sum_{j} \\zeta_{17}^{g^{2j+i}}$, which are real numbers expressed via De Moivre's formula"
+    },
+    {
+      "targetId": "kroneckers-jugendtraum",
+      "relationship": "extends",
+      "description": "Kronecker-Weber (every abelian extension of $\\mathbb{Q}$ is contained in a cyclotomic field) explains why all constructible numbers live inside cyclotomic fields: the degree-2 tower generating a constructible number produces an abelian extension, which Kronecker-Weber places inside $\\mathbb{Q}(\\zeta_n)$ for some $n$. This connects the local geometric construction (compass-and-straightedge) to the global arithmetic of cyclotomic fields"
     }
   ],
   "overview": {
@@ -309,7 +319,9 @@
     "nth-root-irrational",
     "e-transcendental",
     "solution-of-cubic",
-    "angle-trisection-oq-02-oq-03-oq-01"
+    "angle-trisection-oq-02-oq-03-oq-01",
+    "de-moivre",
+    "kroneckers-jugendtraum"
   ],
   "references": [
     {

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -94,7 +94,7 @@
       "startLine": 1,
       "endLine": 50,
       "summary": "Imports `VolumeOfBalls` and `Tactic`, extensive doc comment covering what is proved ($A = \\pi r^2$), the Wiedijk #9 reference, the mathematical statement, the measure-theoretic approach via $\\mathbb{C} \\cong \\mathbb{R}^2$, proof status, Mathlib dependencies, and historical note on Archimedes.",
-      "mathContext": "Area of a circle: $A = \\pi r^2$. The disc $D(r) = \\{(x,y) : x^2 + y^2 \\leq r^2\\}$ has Lebesgue measure $\\pi r^2$."
+      "mathContext": "Area of a circle: $A = \\pi r^2$. The disc $D(c, r) = \\{z \\in \\mathbb{C} : |z - c| \\leq r\\}$ has Lebesgue measure $\\lambda^2(D) = \\pi r^2$. The proof uses the general $n$-dimensional ball volume formula $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2 + 1)$ specialized to $n = 2$: $V_2(r) = \\pi r^2 / \\Gamma(2) = \\pi r^2$ since $\\Gamma(2) = 1! = 1$. Mathlib provides this as `Complex.volume_ball` via the identification $\\mathbb{C} \\cong \\mathbb{R}^2$."
     },
     {
       "id": "main-theorems",
@@ -102,7 +102,7 @@
       "startLine": 52,
       "endLine": 84,
       "summary": "Opens namespace and `MeasureTheory Metric`. Proves `area_of_circle`: volume of open ball in $\\mathbb{C}$ equals $r^2 \\cdot \\pi$ via `Complex.volume_ball`. Proves `area_of_closed_disk`: closed ball has the same measure via `Complex.volume_closedBall`.",
-      "mathContext": "Main result: $\\text{volume}(\\text{Metric.closedBall}(0, r)) = \\pi r^2$ in $\\mathbb{R}^2$, using Mathlib's `MeasureTheory.volume_closedBall`."
+      "mathContext": "Main results: `volume (ball c r) = ENNReal.ofReal r ^ 2 * NNReal.pi` and `volume (closedBall c r) = ENNReal.ofReal r ^ 2 * NNReal.pi`. The equality of open and closed ball measures reflects $\\lambda^2(\\partial D) = 0$ — the boundary circle $\\{z : |z - c| = r\\}$ is a 1-dimensional manifold with 2-dimensional Lebesgue measure zero. Both proofs are one-liners delegating to `Complex.volume_ball` and `Complex.volume_closedBall` respectively."
     },
     {
       "id": "special-cases",
@@ -110,7 +110,7 @@
       "startLine": 86,
       "endLine": 115,
       "summary": "Derives special cases: unit disk area is $\\pi$ (both open and closed), zero radius gives area 0 (point has measure zero), negative radius gives area 0 (empty ball). Uses `simp` with `ENNReal.ofReal_one`, `ball_zero`, `closedBall_zero`, and `ball_eq_empty`.",
-      "mathContext": "Unit circle: $A = \\pi \\cdot 1^2 = \\pi$. This is equivalent to the definition of $\\pi$ as the area of the unit disc."
+      "mathContext": "Five edge cases: (1) $r = 1$: $A = \\pi \\cdot 1^2 = \\pi$, the definition of $\\pi$ as the area of the unit disc. (2-3) $r = 0$: open ball is $\\emptyset$, closed ball is $\\{c\\}$ — both have $\\lambda^2$-measure 0 since singletons are 0-dimensional. (4) $r < 0$: $\\text{ball}(c, r) = \\emptyset$ since $|z - c| < r < 0$ is impossible. All follow from $\\text{ENNReal.ofReal}(r)^2 \\cdot \\pi$ mapping $r \\leq 0$ to 0."
     },
     {
       "id": "significance",
@@ -118,7 +118,7 @@
       "startLine": 117,
       "endLine": 136,
       "summary": "Doc section explaining the significance of $A = \\pi r^2$ across mathematics and science: foundational for geometry, the first polar coordinate integral in calculus, essential in physics (optics, mechanics), probability (Gaussian integral), and engineering.",
-      "mathContext": "One of the oldest known mathematical results: Archimedes (c. 250 BC) proved $A = \\pi r^2$ by the method of exhaustion, approximating the circle with inscribed/circumscribed polygons."
+      "mathContext": "The formula connects to analysis through the polar coordinate integral $\\int_0^{2\\pi} \\int_0^r \\rho\\, d\\rho\\, d\\theta = \\pi r^2$ and to probability through the Gaussian integral $\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}$, proved by squaring and converting to polar coordinates: $\\left(\\int e^{-x^2} dx\\right)^2 = \\iint e^{-(x^2+y^2)} dA = \\int_0^{2\\pi} \\int_0^{\\infty} e^{-r^2} r\\, dr\\, d\\theta = \\pi$."
     },
     {
       "id": "circumference-connection",
@@ -126,7 +126,7 @@
       "startLine": 138,
       "endLine": 155,
       "summary": "Doc section explaining how $A = \\pi r^2$ relates to circumference $C = 2\\pi r$ via integration of annular rings: $dA = 2\\pi\\rho\\, d\\rho$, giving $A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$. References Archimedes' conceptualization of the disk as concentric circular strips. Ends with `#check` commands and namespace closing.",
-      "mathContext": "Circumference $C = 2\\pi r$ is the derivative of area with respect to $r$: $\\frac{dA}{dr} = \\frac{d}{dr}(\\pi r^2) = 2\\pi r$. This reflects the infinitesimal shell argument."
+      "mathContext": "The annular ring argument yields $A(r) = \\int_0^r C(\\rho)\\, d\\rho = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$, giving $A'(r) = C(r) = 2\\pi r$. This derivative relationship generalizes to all dimensions: the surface area of an $n$-ball is $S_n(r) = \\frac{d}{dr} V_n(r)$. For $n = 3$: $V_3(r) = \\frac{4}{3}\\pi r^3$ and $S_3(r) = 4\\pi r^2$. Archimedes discovered both the 2D and 3D cases, proving that the surface area and volume of a sphere relate to its circumscribing cylinder as $2:3$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1085/annotations.json
+++ b/src/data/proofs/erdos-1085/annotations.json
@@ -42,7 +42,7 @@
       "startLine": 90,
       "endLine": 97
     },
-    "type": "context",
+    "type": "concept",
     "title": "Trivial Bounds",
     "content": "**axiom trivial_upper_bound**:\n  f_d(n) ≤ n(n-1)/2 = C(n,2)\n\nAt most every pair can be unit distance.\n\n**axiom linear_lower_bound**:\n  f_d(n) ≥ n - 1 for d ≥ 1, n ≥ 2\n\nPlace n points at consecutive integers on a line.",
     "mathContext": "The trivial bounds show f_d(n) = Θ(n) at minimum and O(n²) at maximum. The interesting question is the exact exponent.",
@@ -60,7 +60,7 @@
       "startLine": 106,
       "endLine": 130
     },
-    "type": "context",
+    "type": "concept",
     "title": "Dimension 2 (Classical - OPEN)",
     "content": "**axiom erdos_1946_lower_d2**:\n  f_2(n) > n^{1 + c/log log n} for some c > 0\n\nErdős's 1946 grid-like construction.\n\n**axiom sst_1984_upper_d2**:\n  f_2(n) = O(n^{4/3})\n\nSpencer-Szemerédi-Trotter used the crossing number inequality.\n\n**def erdos_1085_2d_conjecture**: f_2(n) = O(n^{1+o(1)})\n\n**axiom erdos_1085_2d_open**: The 2D conjecture remains OPEN!\n\nThe gap between n^{1+o(1)} and n^{4/3} has persisted since 1946.",
     "mathContext": "This is perhaps the most famous open problem in discrete geometry. The SST upper bound improved Erdős's original O(n^{3/2}).",
@@ -78,7 +78,7 @@
       "startLine": 138,
       "endLine": 160
     },
-    "type": "context",
+    "type": "concept",
     "title": "Dimension 3 (Partially OPEN)",
     "content": "**axiom erdos_1960_lower_d3**:\n  f_3(n) = Ω(n^{4/3} log log n)\n\nGeneralizes 2D using spherical caps.\n\n**axiom cegsw_1990_upper_d3**:\n  f_3(n) = O(n^{3/2} β(n))\n\nwhere β is inverse Ackermann (very slow growing).\n\n**def erdos_1085_3d_open_question**: Is f_3(n) = O(n^{4/3} log log n)?\n\n**axiom erdos_1085_3d_open**: This remains OPEN.",
     "mathContext": "The 3D case has a similar gap to 2D but with different exponents. The CEGSW bound uses sophisticated computational geometry.",
@@ -96,7 +96,7 @@
       "startLine": 169,
       "endLine": 187
     },
-    "type": "context",
+    "type": "concept",
     "title": "Dimension ≥ 4 (Essentially Solved)",
     "content": "**def lenzCoefficient d**: (p-1)/(2p) where p = ⌊d/2⌋\n\n**axiom lenz_lower_d4**: Lenz construction gives\n  f_d(n) ≥ (p-1)/(2p)·n² - O(1)\n\nPlace n/2 points on each of two orthogonal unit circles.\n\n**axiom erdos_stone_upper_d4**: Erdős-Stone gives\n  f_d(n) ≤ ((p-1)/(2p) + o(1))·n²\n\nFor d ≥ 4: f_d(n) ≈ (p-1)/(2p)·n²",
     "mathContext": "The Lenz construction is elegant: orthogonal circles in ℝ^d give near-optimal unit distance counts.",
@@ -114,7 +114,7 @@
       "startLine": 195,
       "endLine": 213
     },
-    "type": "context",
+    "type": "concept",
     "title": "Exact Results (d ≥ 4)",
     "content": "**axiom brass_1997_d4**: EXACT for d = 4\n  f_4(n) = ⌊n²/4⌋ + n - ⌊n/2⌋ - 1 for n ≥ 3\n\n**axiom swanepoel_2009_even**: EXACT for even d ≥ 6\n  f_d(n) = (p-1)/(2p)·n² + O(n)\n\n**axiom erdos_pach_1990_odd**: For odd d ≥ 5\n  f_d(n) = (p-1)/(2p)·n² ± O(n^{4/3})\n\nThe high-dimensional cases are completely resolved!",
     "mathContext": "Brass and Swanepoel gave exact closed-form expressions. The odd-dimensional case has a larger error term but is still tight.",
@@ -132,7 +132,7 @@
       "startLine": 219,
       "endLine": 230
     },
-    "type": "context",
+    "type": "concept",
     "title": "Small Examples",
     "content": "**axiom example_d2_n3**: f_2(3) = 3\n  Equilateral triangle.\n\n**axiom example_d2_n4**: f_2(4) = 5\n  NOT the square (which gives 4)!\n\n**axiom example_d2_n5**: f_2(5) = 7\n\n**axiom example_d3_n4**: f_3(4) = 6\n  Regular tetrahedron with edge 1.",
     "mathContext": "The optimal 4-point configuration in 2D is surprising: it beats the square. Small cases often have non-obvious optima.",
@@ -150,7 +150,7 @@
       "startLine": 241,
       "endLine": 249
     },
-    "type": "context",
+    "type": "concept",
     "title": "Connections",
     "content": "**axiom crossing_number_connection**:\n  f_2(n)² ≤ O(n³)\n\nThe unit distance graph has crossing number related to f_2(n).\n\n**axiom incidence_bound**:\n  f_2(n) ≤ n²\n\nRelates to point-circle incidences where all circles have radius 1.",
     "mathContext": "The SST upper bound comes from crossing number arguments. Incidence geometry provides another perspective on the problem.",
@@ -168,7 +168,7 @@
       "startLine": 267,
       "endLine": 274
     },
-    "type": "context",
+    "type": "concept",
     "title": "High Dimensions Solved",
     "content": "**axiom high_dim_solved**:\nFor d ≥ 4, ∃ C such that ∀ n ≥ 1:\n  (p-1)/(2p)·n² - C ≤ f_d(n) ≤ (p-1)/(2p)·n² + Cn²/10\n\n**Follows from**:\n1. Lower: Lenz construction (lenz_lower_d4)\n2. Upper: Erdős-Stone theorem (erdos_stone_upper_d4)\n\nThe high-dimensional case (d ≥ 4) is essentially solved, with f_d(n) ≈ (p-1)/(2p)·n² where p = ⌊d/2⌋.",
     "mathContext": "This axiom captures the resolution of the high-dimensional case by combining Lenz's construction with the Erdős-Stone theorem.",


### PR DESCRIPTION
## Enrichment batch

### area-of-circle
Deepened `mathContext` fields across all 5 sections to match annotation depth:
- Header: n-dimensional ball volume formula specialization
- Main theorems: boundary measure zero explanation
- Special cases: ENNReal edge case behavior analysis
- Significance: Gaussian integral proof via polar coordinates
- Circumference: dimension generalization and Archimedes' sphere-cylinder result

### geometric-series-oq-01
Previous enrichment pass (annotations, context deepening).