### PR TITLE
Research: Fourier Hölder decay - prove 2 axioms (0 sorries, 8 axioms)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02.lean
@@ -120,20 +120,66 @@ axiom fourierCoeff_difference_formula (f : AddCircle T → ℂ) (n : ℤ) (hn : 
         (f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x ∂haarAddCircle
 
 /-- Hölder bound on translation differences:
-    ‖f(x) - f(x + T/(2n))‖ ≤ C · (T/(2|n|))^α -/
-axiom holder_translation_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
+    ‖f(x) - f(x + T/(2n))‖ ≤ C · (T/(2|n|))^α
+
+    Proof: From HolderWith.dist_le_of_le + quotient norm bound.
+    The key insight is that dist(x, x+↑s) = ‖↑s‖ on AddCircle T,
+    and the quotient norm satisfies ‖↑s‖ ≤ |s| by norm_mk_le_norm. -/
+theorem holder_translation_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
     (hf : IsHolderOnCircle C α f) (n : ℤ) (hn : n ≠ 0) (x : AddCircle T) :
     ‖f x - f (circleTranslate (halfPeriod T n) x)‖ ≤
-      ↑C * (T / (2 * |↑n|)) ^ (α : ℝ)
+      ↑C * (T / (2 * |↑n|)) ^ (α : ℝ) := by
+  -- Step 1: Bound the distance on AddCircle
+  have hdist : dist x (circleTranslate (halfPeriod T n) x) ≤ T / (2 * |(↑n : ℝ)|) := by
+    unfold circleTranslate halfPeriod
+    simp only [hn, ite_false]
+    -- dist x (x + ↑s) = ‖x - (x + ↑s)‖ = ‖↑s‖ (via norm_sub_rev + add_sub_cancel_left)
+    rw [dist_eq_norm, norm_sub_rev, add_sub_cancel_left]
+    -- ‖(↑s : AddCircle T)‖ ≤ ‖s‖ₐ = |s| by quotient norm bound
+    calc ‖(↑(T / (2 * (↑n : ℝ))) : AddCircle T)‖
+        ≤ ‖T / (2 * (↑n : ℝ))‖ := QuotientAddGroup.norm_mk_le_norm
+      _ = |T / (2 * (↑n : ℝ))| := Real.norm_eq_abs _
+      _ = T / (2 * |(↑n : ℝ)|) := by
+          rw [abs_div, abs_of_pos hT.out, abs_mul,
+            abs_of_pos (show (0 : ℝ) < 2 by norm_num)]
+  -- Step 2: Apply HolderWith.dist_le_of_le to get norm bound
+  have h := hf.dist_le_of_le hdist
+  rwa [dist_eq_norm] at h
 
 /-- The integral of the product is bounded by the Hölder constant.
-    Uses: (1) norm_integral_le_integral_norm, (2) ‖e_{-n}(x)‖ = 1,
-    (3) Hölder bound on difference, (4) probability measure total mass 1. -/
-axiom integral_product_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
+    Uses: (1) norm_integral_le_of_norm_le_const, (2) ‖e_{-n}(x)‖ = 1,
+    (3) Hölder bound on difference, (4) probability measure total mass 1.
+
+    Proof: Bound ‖g(x)‖ ≤ C·d^α pointwise (where g = (f-f∘τ)·e_{-n}),
+    then integrate the constant bound over the probability space. -/
+theorem integral_product_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
     (hf : IsHolderOnCircle C α f) (n : ℤ) (hn : n ≠ 0) :
     ‖∫ x : AddCircle T,
       (f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x ∂haarAddCircle‖ ≤
-      ↑C * (T / (2 * |↑n|)) ^ (α : ℝ)
+      ↑C * (T / (2 * |↑n|)) ^ (α : ℝ) := by
+  set bound := ↑C * (T / (2 * |(↑n : ℝ)|)) ^ (↑α : ℝ) with hbound_def
+  -- Pointwise norm bound: ‖(f x - f(x+s)) · e_{-n}(x)‖ ≤ bound
+  have hpointwise : ∀ x : AddCircle T,
+      ‖(f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x‖ ≤ bound := by
+    intro x
+    rw [norm_mul, fourier_norm_one, mul_one]
+    exact holder_translation_bound C α f hf n hn x
+  -- Apply norm_integral_le bound with probability measure
+  calc ‖∫ x : AddCircle T,
+        (f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x ∂haarAddCircle‖
+      ≤ ∫ x : AddCircle T,
+        ‖(f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x‖ ∂haarAddCircle :=
+        norm_integral_le_integral_norm _
+    _ ≤ ∫ _ : AddCircle T, bound ∂haarAddCircle := by
+        apply MeasureTheory.integral_mono_of_nonneg
+        · exact Eventually.of_forall (fun x => norm_nonneg _)
+        · exact integrable_const _
+        · exact Eventually.of_forall (fun x => hpointwise x)
+    _ = bound * (haarAddCircle (Set.univ)).toReal := by
+        rw [MeasureTheory.integral_const]
+        ring
+    _ = bound := by
+        rw [IsProbabilityMeasure.measure_univ, ENNReal.one_toReal, mul_one]
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════

--- a/proofs/Proofs/FourierSeriesOQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02.lean
@@ -4,6 +4,7 @@ import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.InnerProductSpace.l2Space
 import Mathlib.MeasureTheory.Function.L2Space
 import Mathlib.Topology.MetricSpace.Holder
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
 import Mathlib.Tactic
 
 /-
@@ -228,10 +229,45 @@ axiom fourierCoeff_sq_summable_of_holder (C : ℝ≥0) (α : ℝ≥0)
     (hα : (1 : ℝ) / 2 < (α : ℝ)) :
     Summable (fun n : ℤ => ‖fourierCoeff f n‖ ^ 2)
 
-/-- **Riemann-Lebesgue from Hölder**: ‖ĉ_n‖ = O(1/|n|^α) → 0. -/
-axiom riemannLebesgue_of_holder (C : ℝ≥0) (α : ℝ≥0)
+/-- **Riemann-Lebesgue from Hölder**: ‖ĉ_n‖ = O(1/|n|^α) → 0.
+
+    Proof: From the main decay theorem, ‖ĉ_n‖ ≤ K·|n|^(-α) for n ≠ 0.
+    Since α > 0, |n|^(-α) → 0 as |n| → ∞ through cofinite.
+    By the squeeze theorem (squeeze_zero_norm), fourierCoeff → 0. -/
+theorem riemannLebesgue_of_holder (C : ℝ≥0) (α : ℝ≥0)
     (f : AddCircle T → ℂ) (hf : IsHolderOnCircle C α f) (hα : 0 < α) :
-    Tendsto (fun n : ℤ => fourierCoeff f n) cofinite (𝓝 0)
+    Tendsto (fun n : ℤ => fourierCoeff f n) cofinite (𝓝 0) := by
+  set K := (↑C / 2 : ℝ) * (T / 2) ^ (↑α : ℝ) with hK_def
+  -- Squeeze: ‖ĉ_n‖ ≤ K · |n|^(-α) → 0
+  apply squeeze_zero_norm
+  · -- Pointwise bound: ‖ĉ_n‖ ≤ K · |n|^(-α) eventually
+    filter_upwards [Filter.eventually_cofinite_ne (0 : ℤ)] with n hn
+    have hbound := fourierCoeff_holder_decay C α f hf n hn
+    -- Rewrite (C/2)(T/(2|n|))^α = (C/2)(T/2)^α · |n|^(-α) = K · |n|^(-α)
+    calc ‖fourierCoeff f n‖
+        ≤ (↑C / 2) * (T / (2 * |↑n|)) ^ (↑α : ℝ) := hbound
+      _ = K * |(↑n : ℝ)| ^ (-(↑α : ℝ)) := by
+          rw [hK_def]
+          have hn_ne : (↑n : ℝ) ≠ 0 := Int.cast_ne_zero.mpr hn
+          have hn_abs_pos : 0 < |(↑n : ℝ)| := abs_pos.mpr hn_ne
+          rw [div_rpow (le_of_lt hT.out) (by positivity : (0 : ℝ) ≤ 2 * |(↑n : ℝ)|),
+            mul_rpow (by positivity : (0 : ℝ) ≤ 2) (abs_nonneg _),
+            rpow_neg (abs_nonneg _)]
+          ring
+  · -- The bound K · |n|^(-α) → 0 through cofinite
+    have hα_pos : (0 : ℝ) < ↑α := hα
+    -- |n| → ∞ through cofinite, and x^(-α) → 0 at ∞
+    have h_abs_atTop : Tendsto (fun n : ℤ => ‖(↑n : ℝ)‖) cofinite atTop :=
+      tendsto_norm_cocompact_atTop.comp Int.tendsto_coe_cofinite
+    have h_rpow_zero : Tendsto (fun x : ℝ => x ^ (-(↑α : ℝ))) atTop (𝓝 0) :=
+      tendsto_rpow_neg_atTop hα_pos
+    have h_abs_rpow : Tendsto (fun n : ℤ => ‖(↑n : ℝ)‖ ^ (-(↑α : ℝ))) cofinite (𝓝 0) :=
+      h_rpow_zero.comp h_abs_atTop
+    -- ‖n‖ = |n| for reals, so convert
+    have h_eq : (fun n : ℤ => ‖(↑n : ℝ)‖ ^ (-(↑α : ℝ))) = (fun n : ℤ => |(↑n : ℝ)| ^ (-(↑α : ℝ))) := by
+      ext n; rw [Real.norm_eq_abs]
+    rw [h_eq] at h_abs_rpow
+    exact Tendsto.const_mul h_abs_rpow K
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════

--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -73,9 +73,9 @@
       "fourierCoeff_difference_formula: difference formula for coefficients",
       "full regularity-decay hierarchy: Hölder → C^k → C^∞ → analytic"
     ],
-    "axiomCount": 10,
-    "lineCount": 280,
-    "assumptions": "10 axiom(s) encoding analytical infrastructure: difference formula, integral bounds, Hölder translation bound, summability, optimality, partial converse, smooth/analytic decay. Two formerly axiomatized results now proved: fourier_norm_one (‖e_n(x)‖ = 1 via toCircle) and fourier_translate_halfperiod (half-period negation via fourier_add_half_inv_index)."
+    "axiomCount": 8,
+    "lineCount": 326,
+    "assumptions": "8 axiom(s) remaining: difference formula (Haar invariance), summability, Riemann-Lebesgue, optimality, partial converse, C^k/C^∞/analytic decay. Four formerly axiomatized results now proved: fourier_norm_one, fourier_translate_halfperiod, holder_translation_bound (Hölder + quotient norm), integral_product_bound (norm_integral + probability measure)."
   },
   "overview": {
     "historicalContext": "**Fourier Coefficient Decay Under Hölder Continuity**\n\nThe relationship between smoothness of a function and decay of its Fourier coefficients is a fundamental principle of harmonic analysis. The specific result for Hölder continuous functions — that α-Hölder regularity gives O(1/|n|^α) decay — was developed through contributions by Bernstein (1912), Zygmund (1935), and others.\n\n**Key context**: This answers open question #2 from the Fourier series gallery entry: *What is the optimal rate of decay of Fourier coefficients under Hölder continuity conditions?*\n\nThe answer: the decay rate is O(1/|n|^α), and this is sharp — for each α ∈ (0,1), there exist α-Hölder functions whose coefficients decay at exactly this rate.",
@@ -169,8 +169,8 @@
     "summary": "This formalization establishes the optimal Fourier coefficient decay rate for Hölder continuous functions: ‖ĉ_n‖ = O(1/|n|^α) for α-Hölder f, proved via the half-period translation trick. The main theorem is proved from axiomatized analytical infrastructure (difference formula, integral bounds). The formalization also establishes optimality, a partial converse via Sobolev embedding, and places the result in the full regularity-decay hierarchy from L² through analytic.",
     "implications": "**Theoretical Significance**: The Hölder decay theorem is a cornerstone of harmonic analysis, quantifying the fundamental principle that smoothness ↔ spectral decay.\n\n**Broader Connections**: The half-period translation trick generalizes to prove decay rates in other settings (torus, locally compact abelian groups). The critical threshold α = 1/2 connects to Sobolev embedding theory and the circle of ideas around Carleson's theorem.",
     "openQuestions": [
-      "Can the axiomatized integral bounds be proved from Mathlib's integration API?",
-      "Can the half-period identity be proved from Mathlib's AddCircle API?",
+      "Can the difference formula (fourierCoeff_difference_formula) be proved from integral_add_right_eq_self?",
+      "Can Riemann-Lebesgue for Hölder be proved from the main decay theorem via squeeze?",
       "What is the sharp constant in the decay bound for specific α?",
       "Can the optimality construction (Weierstrass lacunary series) be formalized?"
     ]

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -1,13 +1,13 @@
 {
   "slug": "fourier-series-oq-02",
-  "title": "Fourier Coefficient Decay Under Hölder Continuity",
+  "title": "Fourier Coefficient Decay Under H\u00f6lder Continuity",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "∀ (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ), IsHolderOnCircle C α f → ∀ n ≠ 0, ‖fourierCoeff f n‖ ≤ (C/2) * (T / (2|n|))^α",
-    "plain": "Prove that the Fourier coefficients of an α-Hölder continuous function on the circle decay at rate O(1/|n|^α), and that this bound is optimal.",
+    "formal": "\u2200 (C : \u211d\u22650) (\u03b1 : \u211d\u22650) (f : AddCircle T \u2192 \u2102), IsHolderOnCircle C \u03b1 f \u2192 \u2200 n \u2260 0, \u2016fourierCoeff f n\u2016 \u2264 (C/2) * (T / (2|n|))^\u03b1",
+    "plain": "Prove that the Fourier coefficients of an \u03b1-H\u00f6lder continuous function on the circle decay at rate O(1/|n|^\u03b1), and that this bound is optimal.",
     "whyMatters": [
       "Fundamental result in harmonic analysis connecting smoothness to frequency decay",
       "Bridges Faulhaber integer power sums to real-exponent zeta theory"
@@ -15,17 +15,17 @@
   },
   "knownResults": {
     "proven": [
-      "fourier_norm_one: ‖fourier n x‖ = 1 (via toCircle)",
+      "fourier_norm_one: \u2016fourier n x\u2016 = 1 (via toCircle)",
       "fourier_translate_halfperiod: fourier(-n)(x + T/(2n)) = -fourier(-n)(x)",
       "fourierCoeff_holder_decay: main theorem from axioms",
       "fourierCoeff_lipschitz_decay: Lipschitz special case",
-      "holder_continuous: Hölder ⟹ continuous",
-      "lipschitz_is_holder_one: Lipschitz ⊂ Hölder(1)",
-      "holder_translation_bound: ‖f(x) - f(x+T/(2n))‖ ≤ C·(T/(2|n|))^α (via HolderWith.dist_le_of_le + QuotientAddGroup.norm_mk_le_norm)",
-      "integral_product_bound: ‖∫(f-f∘τ)·e_{-n}‖ ≤ C·(T/(2|n|))^α (via norm_integral_le + probability measure)"
+      "holder_continuous: H\u00f6lder \u27f9 continuous",
+      "lipschitz_is_holder_one: Lipschitz \u2282 H\u00f6lder(1)",
+      "holder_translation_bound: \u2016f(x) - f(x+T/(2n))\u2016 \u2264 C\u00b7(T/(2|n|))^\u03b1 (via HolderWith.dist_le_of_le + QuotientAddGroup.norm_mk_le_norm)",
+      "integral_product_bound: \u2016\u222b(f-f\u2218\u03c4)\u00b7e_{-n}\u2016 \u2264 C\u00b7(T/(2|n|))^\u03b1 (via norm_integral_le + probability measure)"
     ],
     "open": [
-      "Prove remaining 8 axioms: difference formula, summability, R-L, optimality, converse, C^k/C^∞/analytic decay"
+      "Prove remaining 8 axioms: difference formula, summability, R-L, optimality, converse, C^k/C^\u221e/analytic decay"
     ],
     "goal": "Prove fourierCoeff_difference_formula (Haar translation invariance), then tackle corollaries"
   },
@@ -33,7 +33,7 @@
     "phase": "ACT",
     "since": "2026-03-23T20:00:00Z",
     "iteration": 3,
-    "focus": "Proved 4 of 12 axioms (holder_translation_bound, integral_product_bound now verified). 8 axioms remain.",
+    "focus": "Proved 5 of 12 axioms. 7 axioms remain: difference formula, summability, optimality, converse, C^k/C^\u221e/analytic.",
     "blockers": [
       "fourierCoeff_difference_formula needs integral_add_right_eq_self for haarAddCircle + integrability conditions",
       "riemannLebesgue_of_holder needs squeeze lemma + power decay Tendsto"
@@ -46,29 +46,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axiom count from 12 to 8. Sessions 1-2 proved fourier_norm_one, fourier_translate_halfperiod. Session 3 proved holder_translation_bound and integral_product_bound.",
+    "progressSummary": "PROGRESS: Reduced axiom count from 12 to 7. Sessions 1-2 proved fourier_norm_one, fourier_translate_halfperiod. Session 3 proved holder_translation_bound, integral_product_bound, riemannLebesgue_of_holder.",
     "builtItems": [
-      "fourier_norm_one: proved via simp [fourier_apply] — toCircle maps to unit circle",
+      "fourier_norm_one: proved via simp [fourier_apply] \u2014 toCircle maps to unit circle",
       "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg",
       "holder_translation_bound: proved via HolderWith.dist_le_of_le + QuotientAddGroup.norm_mk_le_norm (quotient distance bound)",
-      "integral_product_bound: proved via norm_integral_le_integral_norm + integral_mono_of_nonneg + holder_translation_bound + IsProbabilityMeasure"
+      "integral_product_bound: proved via norm_integral_le_integral_norm + integral_mono_of_nonneg + holder_translation_bound + IsProbabilityMeasure",
+      "riemannLebesgue_of_holder: proved via squeeze_zero_norm + tendsto_rpow_neg_atTop + Int.tendsto_coe_cofinite composition"
     ],
     "insights": [
-      "fourier_apply unfolds to ↑(n • x).toCircle, which immediately gives unit norm via simp",
-      "fourier_add_half_inv_index takes explicit (hT : 0 < T), not Fact instance — need hT.out",
+      "fourier_apply unfolds to \u2191(n \u2022 x).toCircle, which immediately gives unit norm via simp",
+      "fourier_add_half_inv_index takes explicit (hT : 0 < T), not Fact instance \u2014 need hT.out",
       "fourier_neg relates fourier(-n) to starRingEnd(fourier n), enabling conjugation approach",
       "T/(2*n) vs T/2/n: ring normalizes between these equivalent forms",
-      "QuotientAddGroup.norm_mk_le_norm gives ‖(↑s : AddCircle T)‖ ≤ ‖s‖ = |s| — the key quotient distance bound",
-      "dist x (x+↑s) = ‖↑s‖ on AddCircle via dist_eq_norm + norm_sub_rev + add_sub_cancel_left",
-      "HolderWith.dist_le_of_le converts distance bound to function distance bound: dist (f x) (f y) ≤ C * d ^ α",
+      "QuotientAddGroup.norm_mk_le_norm gives \u2016(\u2191s : AddCircle T)\u2016 \u2264 \u2016s\u2016 = |s| \u2014 the key quotient distance bound",
+      "dist x (x+\u2191s) = \u2016\u2191s\u2016 on AddCircle via dist_eq_norm + norm_sub_rev + add_sub_cancel_left",
+      "HolderWith.dist_le_of_le converts distance bound to function distance bound: dist (f x) (f y) \u2264 C * d ^ \u03b1",
       "integral_mono_of_nonneg requires: ae nonneg lower bound, integrable upper bound, ae pointwise bound",
-      "IsProbabilityMeasure.measure_univ + ENNReal.one_toReal collapses ∫ const = const on probability space",
-      "haarAddCircle derives IsAddHaarMeasure from addHaarMeasure ⊤ — has integral_add_right_eq_self for translation invariance"
+      "IsProbabilityMeasure.measure_univ + ENNReal.one_toReal collapses \u222b const = const on probability space",
+      "haarAddCircle derives IsAddHaarMeasure from addHaarMeasure \u22a4 \u2014 has integral_add_right_eq_self for translation invariance",
+      "squeeze_zero_norm + tendsto_rpow_neg_atTop + tendsto_norm_cocompact_atTop.comp Int.tendsto_coe_cofinite cleanly proves Riemann-Lebesgue from decay bound"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Prove fourierCoeff_difference_formula via integral_add_right_eq_self + fourier_translate_halfperiod (needs integrability handling)",
-      "Prove riemannLebesgue_of_holder via squeeze theorem with 1/|n|^α → 0 bound",
+      "Prove riemannLebesgue_of_holder via squeeze theorem with 1/|n|^\u03b1 \u2192 0 bound",
       "Prove fourierCoeff_sq_summable_of_holder via comparison with Real.summable_nat_rpow_inv"
     ]
   },
@@ -104,8 +106,8 @@
       "path": "Proofs/FourierSeriesOQ02.lean",
       "filename": "FourierSeriesOQ02.lean",
       "lineCount": 326,
-      "theoremCount": 11,
-      "axiomCount": 8,
+      "theoremCount": 12,
+      "axiomCount": 7,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -20,50 +20,56 @@
       "fourierCoeff_holder_decay: main theorem from axioms",
       "fourierCoeff_lipschitz_decay: Lipschitz special case",
       "holder_continuous: Hölder ⟹ continuous",
-      "lipschitz_is_holder_one: Lipschitz ⊂ Hölder(1)"
+      "lipschitz_is_holder_one: Lipschitz ⊂ Hölder(1)",
+      "holder_translation_bound: ‖f(x) - f(x+T/(2n))‖ ≤ C·(T/(2|n|))^α (via HolderWith.dist_le_of_le + QuotientAddGroup.norm_mk_le_norm)",
+      "integral_product_bound: ‖∫(f-f∘τ)·e_{-n}‖ ≤ C·(T/(2|n|))^α (via norm_integral_le + probability measure)"
     ],
     "open": [
-      "Prove remaining 10 axioms: difference formula, Hölder translation bound, integral product bound, summability, optimality, converse, C^k/C^∞/analytic decay"
+      "Prove remaining 8 axioms: difference formula, summability, R-L, optimality, converse, C^k/C^∞/analytic decay"
     ],
-    "goal": "Reduce axiom count further by proving core analytical infrastructure"
+    "goal": "Prove fourierCoeff_difference_formula (Haar translation invariance), then tackle corollaries"
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-03-23T18:00:00Z",
-    "iteration": 2,
-    "focus": "Proved 2 of 12 axioms. Core infrastructure (fourier_norm_one, half-period identity) now verified.",
+    "since": "2026-03-23T20:00:00Z",
+    "iteration": 3,
+    "focus": "Proved 4 of 12 axioms (holder_translation_bound, integral_product_bound now verified). 8 axioms remain.",
     "blockers": [
-      "holder_translation_bound needs QuotientAddGroup distance API (dist on AddCircle)",
-      "fourierCoeff_difference_formula needs Haar measure translation invariance"
+      "fourierCoeff_difference_formula needs integral_add_right_eq_self for haarAddCircle + integrability conditions",
+      "riemannLebesgue_of_holder needs squeeze lemma + power decay Tendsto"
     ],
-    "nextAction": "Prove holder_translation_bound using HolderWith.dist_le_of_le + quotient distance bound",
+    "nextAction": "Prove fourierCoeff_difference_formula using integral_add_right_eq_self + fourier_translate_halfperiod",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axiom count from 12 to 10. Proved fourier_norm_one and fourier_translate_halfperiod.",
+    "progressSummary": "PROGRESS: Reduced axiom count from 12 to 8. Sessions 1-2 proved fourier_norm_one, fourier_translate_halfperiod. Session 3 proved holder_translation_bound and integral_product_bound.",
     "builtItems": [
       "fourier_norm_one: proved via simp [fourier_apply] — toCircle maps to unit circle",
-      "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg"
+      "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg",
+      "holder_translation_bound: proved via HolderWith.dist_le_of_le + QuotientAddGroup.norm_mk_le_norm (quotient distance bound)",
+      "integral_product_bound: proved via norm_integral_le_integral_norm + integral_mono_of_nonneg + holder_translation_bound + IsProbabilityMeasure"
     ],
     "insights": [
       "fourier_apply unfolds to ↑(n • x).toCircle, which immediately gives unit norm via simp",
       "fourier_add_half_inv_index takes explicit (hT : 0 < T), not Fact instance — need hT.out",
       "fourier_neg relates fourier(-n) to starRingEnd(fourier n), enabling conjugation approach",
       "T/(2*n) vs T/2/n: ring normalizes between these equivalent forms",
-      "holder_translation_bound needs QuotientAddGroup dist API — dist(x, x+↑s) ≤ |s| on AddCircle",
-      "integral_product_bound needs norm_integral_le + fourier_norm_one + holder_bound + probability measure"
+      "QuotientAddGroup.norm_mk_le_norm gives ‖(↑s : AddCircle T)‖ ≤ ‖s‖ = |s| — the key quotient distance bound",
+      "dist x (x+↑s) = ‖↑s‖ on AddCircle via dist_eq_norm + norm_sub_rev + add_sub_cancel_left",
+      "HolderWith.dist_le_of_le converts distance bound to function distance bound: dist (f x) (f y) ≤ C * d ^ α",
+      "integral_mono_of_nonneg requires: ae nonneg lower bound, integrable upper bound, ae pointwise bound",
+      "IsProbabilityMeasure.measure_univ + ENNReal.one_toReal collapses ∫ const = const on probability space",
+      "haarAddCircle derives IsAddHaarMeasure from addHaarMeasure ⊤ — has integral_add_right_eq_self for translation invariance"
     ],
-    "mathlibGaps": [
-      "No obvious dist(x, x+↑s) ≤ |s| lemma found for AddCircle quotient metric"
-    ],
+    "mathlibGaps": [],
     "nextSteps": [
-      "Prove holder_translation_bound via HolderWith API + quotient distance bound",
-      "Prove integral_product_bound from norm_integral_le + fourier_norm_one + holder_bound",
-      "Prove fourierCoeff_difference_formula via Haar translation invariance"
+      "Prove fourierCoeff_difference_formula via integral_add_right_eq_self + fourier_translate_halfperiod (needs integrability handling)",
+      "Prove riemannLebesgue_of_holder via squeeze theorem with 1/|n|^α → 0 bound",
+      "Prove fourierCoeff_sq_summable_of_holder via comparison with Real.summable_nat_rpow_inv"
     ]
   },
   "tags": [
@@ -83,20 +89,23 @@
       "fourier_apply (Mathlib.Analysis.Fourier.AddCircle)",
       "fourier_add_half_inv_index (Mathlib.Analysis.Fourier.AddCircle)",
       "fourier_neg (Mathlib.Analysis.Fourier.AddCircle)",
-      "HolderWith (Mathlib.Topology.MetricSpace.Holder)"
+      "HolderWith (Mathlib.Topology.MetricSpace.Holder)",
+      "HolderWith.dist_le_of_le (Mathlib.Topology.MetricSpace.Holder)",
+      "QuotientAddGroup.norm_mk_le_norm (Mathlib.Analysis.Normed.Group.Quotient)",
+      "integral_add_right_eq_self (Mathlib.MeasureTheory.Group.Integral)"
     ]
   },
   "started": "2026-03-22T15:12:20-07:00",
-  "lastUpdate": "2026-03-23T18:00:00Z",
+  "lastUpdate": "2026-03-23T20:00:00Z",
   "significance": 7,
-  "tractability": 6,
+  "tractability": 7,
   "leanFiles": [
     {
       "path": "Proofs/FourierSeriesOQ02.lean",
       "filename": "FourierSeriesOQ02.lean",
-      "lineCount": 280,
-      "theoremCount": 9,
-      "axiomCount": 10,
+      "lineCount": 326,
+      "theoremCount": 11,
+      "axiomCount": 8,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Proved `holder_translation_bound` and `integral_product_bound` in FourierSeriesOQ02.lean
- Reduced axiom count from 10 to 8 (4 of 12 original axioms now verified)
- 0 sorries, builds cleanly with Docker

## Progress
- **holder_translation_bound**: The Hölder bound on translation differences, proved via `HolderWith.dist_le_of_le` combined with the quotient norm bound `QuotientAddGroup.norm_mk_le_norm` (which gives `‖↑s‖ ≤ |s|` on AddCircle)
- **integral_product_bound**: The integral of the product bounded by the Hölder constant, proved via `norm_integral_le_integral_norm` + pointwise Hölder bound + probability measure normalization

## Findings
- `QuotientAddGroup.norm_mk_le_norm` is the key bridge between the abstract HolderWith edist bounds and concrete distance estimates on AddCircle
- `dist x (x + ↑s) = ‖↑s‖` on AddCircle follows from `dist_eq_norm` + `norm_sub_rev` + `add_sub_cancel_left`
- `integral_mono_of_nonneg` + `IsProbabilityMeasure.measure_univ` cleanly collapses constant integrals on probability spaces

## Status
**Outcome**: progress
**Next Steps**: Prove `fourierCoeff_difference_formula` (needs `integral_add_right_eq_self` for Haar measure), then tackle corollaries (Riemann-Lebesgue, summability)

🤖 Generated by researcher-9