### PR TITLE
Research: erdos-278 + fourier-series-oq-02 - axiom eliminations

### DIFF
--- a/proofs/Proofs/Erdos278Problem.lean
+++ b/proofs/Proofs/Erdos278Problem.lean
@@ -157,14 +157,124 @@ axiom simpson_theorem (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n) :
     ∀ r : ℕ → ℕ,
       coverageDensity ⟨moduli, (fun _ => 0), hpos⟩ ≤ coverageDensity ⟨moduli, r, hpos⟩
 
-/-- Corollary: the all-equal-residue system achieves minimum density.
-    Proof: the coverage set for constant residue a is a cyclic shift of the
-    all-0 set (m ↦ (m+a) % L is a bijection on {0,...,L-1}), preserving cardinality.
-    The modular arithmetic verification requires n | L for each modulus n. -/
-axiom equal_residues_minimize (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n)
+-- ===== Proving equal_residues_minimize (axiom → theorem) =====
+
+/-- Helper: if (x + y) % n = y and x < n, then x = 0.
+    Uses Euclidean division and case analysis on the quotient. -/
+private lemma add_mod_eq_right_imp (x y n : ℕ) (hx : x < n)
+    (h : (x + y) % n = y) : x = 0 := by
+  have h1 := Nat.div_add_mod (x + y) n
+  rw [h] at h1
+  -- h1 : n * ((x + y) / n) + y = x + y, so n * ((x + y) / n) = x
+  -- Since x < n, the quotient must be 0
+  have hq : (x + y) / n < 2 := by
+    rw [Nat.div_lt_iff_lt_mul (by omega : 0 < n)]; omega
+  interval_cases ((x + y) / n) <;> omega
+
+/-- Cyclic shift preserves coverage: n | m ↔ (m + a) % L ≡ a (mod n), when n ∣ L. -/
+private lemma shift_coverage_iff (m a n L : ℕ) (hn : 0 < n) (hL : 0 < L)
+    (hndvdL : n ∣ L) :
+    m % n = 0 ↔ (m + a) % L % n = a % n := by
+  constructor
+  · intro hm
+    rw [Nat.mod_mod_of_dvd _ hndvdL, Nat.add_mod, hm, Nat.zero_add]
+    exact Nat.mod_eq_of_lt (Nat.mod_lt a hn)
+  · intro h
+    rw [Nat.mod_mod_of_dvd _ hndvdL, Nat.add_mod] at h
+    exact add_mod_eq_right_imp (m % n) (a % n) n (Nat.mod_lt m hn) h
+
+/-- Modular addition cancellation: if a, b < n and (a+c) ≡ (b+c) (mod n), then a = b. -/
+private lemma mod_add_cancel_right {a b c n : ℕ} (ha : a < n) (hb : b < n)
+    (h : (a + c) % n = (b + c) % n) : a = b := by
+  -- Reduce c to d = c % n
+  set d := c % n with hd_def
+  have hdn : d < n := Nat.mod_lt c (by omega)
+  -- (a + c) % n = (a + d) % n  and  (b + c) % n = (b + d) % n
+  have h1 : (a + c) % n = (a + d) % n := by
+    rw [Nat.add_mod a c n, Nat.add_mod a d n, Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt ha,
+        show d % n = d from Nat.mod_eq_of_lt hdn]
+  have h2 : (b + c) % n = (b + d) % n := by
+    rw [Nat.add_mod b c n, Nat.add_mod b d n, Nat.mod_eq_of_lt hb, Nat.mod_eq_of_lt hb,
+        show d % n = d from Nat.mod_eq_of_lt hdn]
+  rw [h1, h2] at h
+  -- Use Euclidean division to case-split on the quotients
+  have da := Nat.div_add_mod (a + d) n
+  have db := Nat.div_add_mod (b + d) n
+  rw [h] at da
+  have qa_lt : (a + d) / n < 2 := by
+    rw [Nat.div_lt_iff_lt_mul (by omega : 0 < n)]; omega
+  have qb_lt : (b + d) / n < 2 := by
+    rw [Nat.div_lt_iff_lt_mul (by omega : 0 < n)]; omega
+  interval_cases ((a + d) / n) <;> interval_cases ((b + d) / n) <;> omega
+
+/-- (x % L + a) % L = (x + a) % L: taking mod before adding preserves the result. -/
+private lemma mod_add_mod (x a L : ℕ) (hL : 0 < L) :
+    (x % L + a) % L = (x + a) % L := by
+  rw [Nat.add_mod (x % L) a L, Nat.add_mod x a L,
+      show x % L % L = x % L from Nat.mod_eq_of_lt (Nat.mod_lt x hL)]
+
+/-- The inverse shift: ((m + (L - a%L)) % L + a) % L = m, for m < L.
+    This establishes that the cyclic shift by a has an inverse. -/
+private lemma shift_inverse (m a L : ℕ) (hm : m < L) (hL : 0 < L) :
+    ((m + (L - a % L)) % L + a) % L = m := by
+  have haL : a % L < L := Nat.mod_lt a hL
+  -- Step 1: Reduce (x%L + a)%L to (x + a)%L
+  rw [mod_add_mod _ a L hL, Nat.add_assoc]
+  -- Step 2: (L - a%L) + a is a positive multiple of L
+  have harith : L - a % L + a = L * (1 + a / L) := by
+    have := Nat.div_add_mod a L; omega
+  rw [harith]
+  -- Step 3: (m + L * k) % L = m % L = m
+  simp only [Nat.add_mod, Nat.mul_mod_right, Nat.add_zero,
+             Nat.mod_eq_of_lt (Nat.mod_lt m hL), Nat.mod_eq_of_lt hm]
+
+/-- All-equal-residue systems have the same coverage density regardless of the
+    common residue value. Proof: the cyclic shift m ↦ (m+a) % L bijects
+    coverage-for-0 onto coverage-for-a, preserving cardinality. -/
+theorem equal_residues_minimize (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n)
     (a : ℕ) :
     coverageDensity ⟨moduli, (fun _ => a), hpos⟩ =
-    coverageDensity ⟨moduli, (fun _ => 0), hpos⟩
+    coverageDensity ⟨moduli, (fun _ => 0), hpos⟩ := by
+  rw [coverageDensity_eq, coverageDensity_eq]
+  -- Both systems share the same LCM period (systemLCM depends only on moduli)
+  set L := systemLCM ⟨moduli, (fun _ => 0), hpos⟩ with hL_def
+  have hLpos : 0 < L := systemLCM_pos ⟨moduli, (fun _ => 0), hpos⟩
+  have hdvd : ∀ n ∈ moduli, n ∣ L := fun n hn =>
+    dvd_systemLCM ⟨moduli, (fun _ => 0), hpos⟩ n hn
+  have hL_eq : systemLCM ⟨moduli, fun _ => a, hpos⟩ = L := rfl
+  rw [hL_eq]
+  -- Suffices: the two filtered finsets have the same cardinality
+  suffices hcard :
+      ((Finset.range L).filter (fun m => ∃ n ∈ moduli, m % n = a % n)).card =
+      ((Finset.range L).filter (fun m => ∃ n ∈ moduli, m % n = 0)).card by
+    push_cast [hcard]
+  -- Bijection from filter₀ to filterₐ via (· + a) % L
+  symm
+  exact Finset.card_bij (fun m _ => (m + a) % L)
+    -- hi: shift maps filter₀ into filterₐ
+    (fun m hm => by
+      simp only [Finset.mem_filter, Finset.mem_range] at hm ⊢
+      exact ⟨Nat.mod_lt _ hLpos, by
+        obtain ⟨n, hn, hmod⟩ := hm.2
+        exact ⟨n, hn, (shift_coverage_iff m a n L (hpos n hn) hLpos (hdvd n hn)).mp hmod⟩⟩)
+    -- i_inj: shift is injective on filter₀
+    (fun m₁ hm₁ m₂ hm₂ h => by
+      simp only [Finset.mem_filter, Finset.mem_range] at hm₁ hm₂
+      exact mod_add_cancel_right hm₁.1 hm₂.1 h)
+    -- i_surj: shift is surjective onto filterₐ
+    (fun m hm => by
+      simp only [Finset.mem_filter, Finset.mem_range] at hm
+      -- Preimage: m' = (m + (L - a%L)) % L
+      refine ⟨(m + (L - a % L)) % L, ?_, shift_inverse m a L hm.1 hLpos⟩
+      simp only [Finset.mem_filter, Finset.mem_range]
+      refine ⟨Nat.mod_lt _ hLpos, ?_⟩
+      obtain ⟨n, hn, hmod⟩ := hm.2
+      exact ⟨n, hn, by
+        -- Need: (m + (L - a%L)) % L % n = 0
+        -- By shift_coverage_iff: equivalent to ((m+(L-a%L))%L + a)%L%n = a%n
+        rw [shift_coverage_iff _ a n L (hpos n hn) hLpos (hdvd n hn),
+            shift_inverse m a L hm.1 hLpos]
+        exact hmod⟩)
 
 -- ## Question 1: Maximum Density (OPEN)
 

--- a/proofs/Proofs/FourierSeriesOQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02.lean
@@ -120,20 +120,68 @@ axiom fourierCoeff_difference_formula (f : AddCircle T → ℂ) (n : ℤ) (hn : 
         (f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x ∂haarAddCircle
 
 /-- Hölder bound on translation differences:
-    ‖f(x) - f(x + T/(2n))‖ ≤ C · (T/(2|n|))^α -/
-axiom holder_translation_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
+    ‖f(x) - f(x + T/(2n))‖ ≤ C · (T/(2|n|))^α
+
+    Proof: HolderWith gives dist(fx, fy) ≤ C · dist(x,y)^α.
+    The quotient norm bound gives dist(x, x+↑s) = ‖↑s‖ ≤ |s| = T/(2|n|). -/
+theorem holder_translation_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
     (hf : IsHolderOnCircle C α f) (n : ℤ) (hn : n ≠ 0) (x : AddCircle T) :
     ‖f x - f (circleTranslate (halfPeriod T n) x)‖ ≤
-      ↑C * (T / (2 * |↑n|)) ^ (α : ℝ)
+      ↑C * (T / (2 * |↑n|)) ^ (α : ℝ) := by
+  unfold circleTranslate halfPeriod
+  simp only [hn, ite_false]
+  set s := T / (2 * (↑n : ℝ)) with hs_def
+  -- |s| = T / (2 * |↑n|) since T > 0
+  have hs_abs : |s| = T / (2 * |(↑n : ℝ)|) := by
+    rw [hs_def, abs_div, abs_of_pos hT.out, abs_mul, abs_of_pos (by positivity : (2 : ℝ) > 0)]
+  -- Quotient norm bound: ‖↑s‖_{AddCircle T} ≤ |s|
+  have h_norm_le : ‖(↑s : AddCircle T)‖ ≤ |s| := by
+    calc ‖(↑s : AddCircle T)‖
+        ≤ ‖s‖ := quotient_norm_mk_le' (AddSubgroup.zmultiples T) s
+      _ = |s| := Real.norm_eq_abs s
+  -- Distance bound: dist x (x + ↑s) = ‖↑s‖ ≤ |s|
+  have h_dist : dist x (x + (↑s : AddCircle T)) ≤ |s| := by
+    rw [dist_eq_norm]
+    have : x - (x + (↑s : AddCircle T)) = -(↑s : AddCircle T) := by group
+    rw [this, norm_neg]
+    exact h_norm_le
+  -- Apply Hölder condition
+  have hle := hf.dist_le_of_le h_dist
+  rw [dist_eq_norm, hs_abs] at hle
+  exact hle
 
 /-- The integral of the product is bounded by the Hölder constant.
     Uses: (1) norm_integral_le_integral_norm, (2) ‖e_{-n}(x)‖ = 1,
     (3) Hölder bound on difference, (4) probability measure total mass 1. -/
-axiom integral_product_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
+theorem integral_product_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
     (hf : IsHolderOnCircle C α f) (n : ℤ) (hn : n ≠ 0) :
     ‖∫ x : AddCircle T,
       (f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x ∂haarAddCircle‖ ≤
-      ↑C * (T / (2 * |↑n|)) ^ (α : ℝ)
+      ↑C * (T / (2 * |↑n|)) ^ (α : ℝ) := by
+  -- Step 1: ‖∫ g dx‖ ≤ ∫ ‖g x‖ dx
+  calc ‖∫ x : AddCircle T,
+        (f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x ∂haarAddCircle‖
+      ≤ ∫ x : AddCircle T,
+        ‖(f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x‖ ∂haarAddCircle :=
+        norm_integral_le_integral_norm _
+    _ = ∫ x : AddCircle T,
+        ‖f x - f (circleTranslate (halfPeriod T n) x)‖ * ‖fourier (-n) x‖ ∂haarAddCircle := by
+        congr 1; ext x; exact norm_mul _ _
+    _ = ∫ x : AddCircle T,
+        ‖f x - f (circleTranslate (halfPeriod T n) x)‖ * 1 ∂haarAddCircle := by
+        congr 1; ext x; rw [fourier_norm_one, mul_one]
+    _ = ∫ x : AddCircle T,
+        ‖f x - f (circleTranslate (halfPeriod T n) x)‖ ∂haarAddCircle := by
+        congr 1; ext x; ring
+    _ ≤ ∫ _ : AddCircle T,
+        (↑C * (T / (2 * |↑n|)) ^ (α : ℝ)) ∂haarAddCircle := by
+        apply MeasureTheory.integral_mono_of_nonneg
+        · exact Eventually.of_forall (fun x => norm_nonneg _)
+        · exact integrable_const _
+        · exact Eventually.of_forall (fun x => holder_translation_bound C α f hf n hn x)
+    _ = ↑C * (T / (2 * |↑n|)) ^ (α : ℝ) := by
+        rw [MeasureTheory.integral_const]
+        simp [haarAddCircle_eq_volume, MeasureTheory.IsProbabilityMeasure.measure_univ]
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -24,9 +24,9 @@
     "relatedProofs": [
       "erdos-273"
     ],
-    "axiomCount": 5,
-    "assumptions": "5 axiom declarations: simpson_theorem (minimum with equal residues), equal_residues_minimize (constant residues equivalent), max_density_coprime_case (CRT coprime maximum), single_modulus_density (single modulus density 1/n), maxCoverageDensity (sup over residue choices)",
-    "lineCount": 148
+    "axiomCount": 2,
+    "assumptions": "2 axiom declarations: simpson_theorem (minimum density with equal residues, Simpson 1986), max_density_coprime_case (CRT-based maximum for coprime moduli). Previously axiomatized equal_residues_minimize now fully proved via cyclic shift bijection.",
+    "lineCount": 356
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p.28), as part of their systematic study of covering systems — a topic Erdős championed from his groundbreaking 1950 paper showing that covering systems with distinct moduli greater than 1 exist. The problem asks: given fixed moduli, how should one choose residues to optimize coverage? R.J. Simpson resolved the minimum question in 1986 (Discrete Mathematics 59), proving by an elegant averaging argument that equal residues minimize coverage density. The maximum question remains open and connects to the broader structure theory of covering systems, which saw a major breakthrough when Bob Hough (2015, Annals of Mathematics) proved the minimum modulus conjecture — showing that any covering system with distinct moduli must include a modulus at most $10^{16}$. The interplay between coprime and non-coprime moduli connects to the Chinese Remainder Theorem and to sieve-theoretic methods in analytic number theory.",
@@ -90,17 +90,17 @@
     },
     {
       "id": "simpson-theorem",
-      "title": "Simpson's Theorem (1986)",
-      "startLine": 119,
-      "endLine": 131,
-      "summary": "Axiomatizes Simpson's theorem: $\\delta(\\{0 \\pmod{n_i}\\}) \\leq \\delta(\\{r(n_i) \\pmod{n_i}\\})$ for all residue functions $r$. Corollary: all constant-residue systems achieve the same density."
+      "title": "Simpson's Theorem and Equal Residue Invariance",
+      "startLine": 152,
+      "endLine": 280,
+      "summary": "Axiomatizes Simpson's theorem ($\\delta_{\\min}$ with equal residues). **Proves** `equal_residues_minimize`: constant-residue systems have the same density regardless of residue value, via cyclic shift bijection $m \\mapsto (m+a) \\bmod L$."
     },
     {
       "id": "open-question",
       "title": "Maximum Density (Open)",
-      "startLine": 133,
-      "endLine": 148,
-      "summary": "Three axiomatized results: coprime maximum ($\\delta_{\\max} = \\sum 1/n_i$ by CRT), the open question ($\\delta_{\\max} \\leq 1$ for general moduli), and the single modulus base case ($\\delta = 1/n$)."
+      "startLine": 282,
+      "endLine": 356,
+      "summary": "Axiomatizes coprime maximum ($\\delta_{\\max} = \\sum 1/n_i$ by CRT). Proves $\\delta_{\\max} \\leq 1$ and single modulus base case ($\\delta = 1/n$)."
     }
   ],
   "conclusion": {
@@ -123,8 +123,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 148,
-    "axiomCount": 5,
+    "lineCount": 356,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 6
   },

--- a/src/data/research/problems/erdos-278.json
+++ b/src/data/research/problems/erdos-278.json
@@ -29,19 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved single_modulus_density (axiom→theorem). File: 5 theorems, 9 lemmas, 3 axioms, 0 sorries. Infrastructure: dvd_systemLCM, init_dvd_foldl_lcm, coverageDensity_eq helpers.",
+    "progressSummary": "PROGRESS: Proved equal_residues_minimize (axiom->theorem) via cyclic shift bijection. File: 6 theorems, 2 lemmas, 2 axioms, 0 sorries.",
     "builtItems": [
       "Proved erdos_278_density_le_one (axiom → theorem) via csSup_le",
       "Fixed foldl_lcm_pos: updated List.mem_cons_self/mem_cons_of_mem to simp",
       "Proved single_modulus_density: for singleton {n}, maxCoverageDensity = 1/n (via systemLCM_singleton + coverageDensity_singleton)",
       "Added dvd_systemLCM: each modulus divides the system LCM (via init_dvd_foldl_lcm + mem_dvd_foldl_lcm)",
-      "Added coverageDensity_eq: unfolds coverageDensity without the let binding"
+      "Added coverageDensity_eq: unfolds coverageDensity without the let binding",
+      "Proved equal_residues_minimize: constant residue a gives same density as residue 0, via cyclic shift m->(m+a)%L bijection (Erdos278Problem.lean:234)"
     ],
     "insights": [
       "erdos_278_open_question was trivially provable: maxCoverageDensity is sSup of densities, each ≤ 1",
       "csSup_le + density_le_one eliminates the axiom in 3 lines",
       "List.mem_cons_self deprecated in current Mathlib - use simp instead",
-      "equal_residues_minimize proof strategy: cyclic shift bijection m↦(m+a)%L on {0,...,L-1}. Need add_mod_injOn (prove via by_contra + Nat.mul_le_mul_left for quotient equality), then dvd_mul_of_dvd_left for n|(a+c). Blocked on Lean omega not handling nonlinear L*(q₁-q₂)"
+      "equal_residues_minimize proof strategy: cyclic shift bijection m↦(m+a)%L on {0,...,L-1}. Need add_mod_injOn (prove via by_contra + Nat.mul_le_mul_left for quotient equality), then dvd_mul_of_dvd_left for n|(a+c). Blocked on Lean omega not handling nonlinear L*(q₁-q₂)",
+      "Cyclic shift bijection: (L-a%L)+a = L*(1+a/L) makes shift_inverse clean",
+      "Modular addition cancellation via Euclidean division + interval_cases on quotients"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -72,8 +75,8 @@
       "path": "Proofs/Erdos278Problem.lean",
       "filename": "Erdos278Problem.lean",
       "lineCount": 246,
-      "theoremCount": 5,
-      "axiomCount": 3,
+      "theoremCount": 6,
+      "axiomCount": 2,
       "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -44,10 +44,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axiom count from 12 to 10. Proved fourier_norm_one and fourier_translate_halfperiod.",
+    "progressSummary": "PROGRESS: Proved holder_translation_bound and integral_product_bound (2 axioms->theorems). File: 11 theorems, 8 axioms, 0 sorries.",
     "builtItems": [
       "fourier_norm_one: proved via simp [fourier_apply] — toCircle maps to unit circle",
-      "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg"
+      "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg",
+      "Proved holder_translation_bound via quotient_norm_mk_le + HolderWith.dist_le_of_le",
+      "Proved integral_product_bound via norm_integral_le + holder_translation_bound + IsProbabilityMeasure"
     ],
     "insights": [
       "fourier_apply unfolds to ↑(n • x).toCircle, which immediately gives unit norm via simp",
@@ -55,7 +57,9 @@
       "fourier_neg relates fourier(-n) to starRingEnd(fourier n), enabling conjugation approach",
       "T/(2*n) vs T/2/n: ring normalizes between these equivalent forms",
       "holder_translation_bound needs QuotientAddGroup dist API — dist(x, x+↑s) ≤ |s| on AddCircle",
-      "integral_product_bound needs norm_integral_le + fourier_norm_one + holder_bound + probability measure"
+      "integral_product_bound needs norm_integral_le + fourier_norm_one + holder_bound + probability measure",
+      "quotient_norm_mk_le from Mathlib.Analysis.Normed.Group.Quotient gives ||mk s|| <= |s| for AddCircle",
+      "integral_product_bound: chain norm_integral_le -> norm_mul -> fourier_norm_one -> holder_bound -> integral_const on probability measure"
     ],
     "mathlibGaps": [
       "No obvious dist(x, x+↑s) ≤ |s| lemma found for AddCircle quotient metric"
@@ -94,9 +98,9 @@
     {
       "path": "Proofs/FourierSeriesOQ02.lean",
       "filename": "FourierSeriesOQ02.lean",
-      "lineCount": 280,
-      "theoremCount": 9,
-      "axiomCount": 10,
+      "lineCount": 328,
+      "theoremCount": 11,
+      "axiomCount": 8,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
Two axiom elimination sessions proving 3 axioms across 2 proof files:

### Erdos-278: Maximum Covering Density of Congruence Systems
- **Proved `equal_residues_minimize`**: constant-residue congruence systems have the same coverage density, via cyclic shift bijection m ↦ (m+a) % L
- Axiom count: 3 → 2

### Fourier-Series-OQ-02: Hölder Continuity Coefficient Decay
- **Proved `holder_translation_bound`**: Hölder bound on translation differences via quotient_norm_mk_le' + HolderWith.dist_le_of_le
- **Proved `integral_product_bound`**: integral bound via norm_integral_le + fourier_norm_one + IsProbabilityMeasure
- Axiom count: 10 → 8

## Files Modified
- `proofs/Proofs/Erdos278Problem.lean` (246 → 356 lines, 2 axioms)
- `proofs/Proofs/FourierSeriesOQ02.lean` (280 → 328 lines, 8 axioms)
- Research metadata updated

## Test plan
- [x] Docker build passes for both files
- [x] 0 sorries in both files

🤖 Generated by researcher-3