### PR TITLE
Research: erdos-278 - prove equal_residues_minimize (0 sorries, 2 axioms)

### DIFF
--- a/proofs/Proofs/Erdos278Problem.lean
+++ b/proofs/Proofs/Erdos278Problem.lean
@@ -157,14 +157,59 @@ axiom simpson_theorem (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n) :
     ∀ r : ℕ → ℕ,
       coverageDensity ⟨moduli, (fun _ => 0), hpos⟩ ≤ coverageDensity ⟨moduli, r, hpos⟩
 
-/-- Corollary: the all-equal-residue system achieves minimum density.
-    Proof: the coverage set for constant residue a is a cyclic shift of the
-    all-0 set (m ↦ (m+a) % L is a bijection on {0,...,L-1}), preserving cardinality.
-    The modular arithmetic verification requires n | L for each modulus n. -/
-axiom equal_residues_minimize (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n)
+/-- The coverage filter for constant residue a has the same cardinality as for
+    constant residue 0, via the cyclic shift m ↦ (m+a)%L on {0,...,L-1}.
+    Since n∣L for each modulus n, the shift preserves residue classes. -/
+private lemma coverage_card_shift (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n) (a : ℕ) :
+    let L := systemLCM ⟨moduli, fun _ => a, hpos⟩
+    ((Finset.range L).filter (fun m => ∃ n ∈ moduli, m % n = a % n)).card =
+    ((Finset.range L).filter (fun m => ∃ n ∈ moduli, m % n = 0)).card := by
+  intro L
+  have hLpos : 0 < L := systemLCM_pos ⟨moduli, fun _ => a, hpos⟩
+  have hdvd : ∀ n ∈ moduli, n ∣ L := fun n hn =>
+    dvd_systemLCM ⟨moduli, fun _ => a, hpos⟩ n hn
+  -- Bijection: forward m ↦ (m+a)%L, backward m ↦ (m+L-a%L)%L
+  apply Finset.card_bij' (fun m _ => (m + a) % L) (fun m _ => (m + L - a % L) % L)
+  -- Forward: maps "divisible" filter into "≡a" filter
+  · intro m hm
+    simp only [Finset.mem_filter, Finset.mem_range] at hm ⊢
+    refine ⟨Nat.mod_lt _ hLpos, ?_⟩
+    obtain ⟨_, k, hk, hmod⟩ := hm
+    exact ⟨k, hk, by
+      rw [Nat.mod_mod_of_dvd _ (hdvd k hk), Nat.add_mod, hmod, Nat.zero_add,
+          Nat.mod_mod_of_dvd _ (dvd_refl k)]⟩
+  -- Backward: maps "≡a" filter into "divisible" filter
+  · intro m hm
+    simp only [Finset.mem_filter, Finset.mem_range] at hm ⊢
+    refine ⟨Nat.mod_lt _ hLpos, ?_⟩
+    obtain ⟨hml, k, hk, hmod⟩ := hm
+    have hkL := hdvd k hk
+    exact ⟨k, hk, by
+      rw [Nat.mod_mod_of_dvd _ hkL]
+      have hLk : L % k = 0 := by obtain ⟨q, hq⟩ := hkL; rw [hq]; exact Nat.mul_mod_right k q
+      have haLk : (a % L) % k = a % k := Nat.mod_mod_of_dvd a hkL
+      omega⟩
+  -- Round-trip: backward ∘ forward = id
+  · intro m hm
+    simp only [Finset.mem_filter, Finset.mem_range] at hm; omega
+  -- Round-trip: forward ∘ backward = id
+  · intro m hm
+    simp only [Finset.mem_filter, Finset.mem_range] at hm; omega
+
+/-- The all-equal-residue system achieves minimum density: the coverage density
+    with constant residue a equals that with constant residue 0.
+    Proved via cyclic shift bijection on {0,...,L-1}. -/
+theorem equal_residues_minimize (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n)
     (a : ℕ) :
     coverageDensity ⟨moduli, (fun _ => a), hpos⟩ =
-    coverageDensity ⟨moduli, (fun _ => 0), hpos⟩
+    coverageDensity ⟨moduli, (fun _ => 0), hpos⟩ := by
+  have hcard := coverage_card_shift moduli hpos a
+  simp only [coverageDensity_eq, Nat.zero_mod]
+  -- systemLCM is definitionally equal for both (depends only on moduli)
+  -- so after simp, both sides have same range and denominator
+  -- Just need to show cast of equal ℕ cards divided by same denominator are equal
+  congr 1
+  exact_mod_cast hcard
 
 -- ## Question 1: Maximum Density (OPEN)
 

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -24,9 +24,9 @@
     "relatedProofs": [
       "erdos-273"
     ],
-    "axiomCount": 5,
-    "assumptions": "5 axiom declarations: simpson_theorem (minimum with equal residues), equal_residues_minimize (constant residues equivalent), max_density_coprime_case (CRT coprime maximum), single_modulus_density (single modulus density 1/n), maxCoverageDensity (sup over residue choices)",
-    "lineCount": 148
+    "axiomCount": 2,
+    "assumptions": "2 axiom declarations: simpson_theorem (minimum with equal residues — deep 1986 result), max_density_coprime_case (CRT coprime maximum). Previously axiomatized equal_residues_minimize, single_modulus_density, and erdos_278_density_le_one are now fully proved.",
+    "lineCount": 291
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p.28), as part of their systematic study of covering systems — a topic Erdős championed from his groundbreaking 1950 paper showing that covering systems with distinct moduli greater than 1 exist. The problem asks: given fixed moduli, how should one choose residues to optimize coverage? R.J. Simpson resolved the minimum question in 1986 (Discrete Mathematics 59), proving by an elegant averaging argument that equal residues minimize coverage density. The maximum question remains open and connects to the broader structure theory of covering systems, which saw a major breakthrough when Bob Hough (2015, Annals of Mathematics) proved the minimum modulus conjecture — showing that any covering system with distinct moduli must include a modulus at most $10^{16}$. The interplay between coprime and non-coprime moduli connects to the Chinese Remainder Theorem and to sieve-theoretic methods in analytic number theory.",
@@ -93,7 +93,7 @@
       "title": "Simpson's Theorem (1986)",
       "startLine": 119,
       "endLine": 131,
-      "summary": "Axiomatizes Simpson's theorem: $\\delta(\\{0 \\pmod{n_i}\\}) \\leq \\delta(\\{r(n_i) \\pmod{n_i}\\})$ for all residue functions $r$. Corollary: all constant-residue systems achieve the same density."
+      "summary": "Axiomatizes Simpson's theorem: $\\delta(\\{0 \\pmod{n_i}\\}) \\leq \\delta(\\{r(n_i) \\pmod{n_i}\\})$ for all residue functions $r$. Proves equal_residues_minimize: coverage density with constant residue $a$ equals that with residue 0, via cyclic shift bijection $m \\mapsto (m+a) \\bmod L$ on $\\{0, \\ldots, L-1\\}$."
     },
     {
       "id": "open-question",
@@ -124,8 +124,8 @@
     "opens": [],
     "namespace": null,
     "lineCount": 148,
-    "axiomCount": 5,
-    "theoremCount": 6,
+    "axiomCount": 2,
+    "theoremCount": 8,
     "definitionCount": 6
   },
   "references": [

--- a/src/data/research/problems/erdos-278.json
+++ b/src/data/research/problems/erdos-278.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-12T22:33:22.719Z",
-    "iteration": 2,
-    "focus": "Axiom elimination: proved single_modulus_density, attempted equal_residues_minimize",
+    "iteration": 3,
+    "focus": "Axiom elimination: proved equal_residues_minimize, 2 axioms remain",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,24 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved single_modulus_density (axiom→theorem). File: 5 theorems, 9 lemmas, 3 axioms, 0 sorries. Infrastructure: dvd_systemLCM, init_dvd_foldl_lcm, coverageDensity_eq helpers.",
+    "progressSummary": "PROGRESS: Proved equal_residues_minimize (axiom→theorem) via cyclic shift bijection card_bij on {0..L-1}. File: 8 theorems/lemmas, 2 axioms, 0 sorries. Axiom count reduced 3→2.",
     "builtItems": [
       "Proved erdos_278_density_le_one (axiom → theorem) via csSup_le",
       "Fixed foldl_lcm_pos: updated List.mem_cons_self/mem_cons_of_mem to simp",
       "Proved single_modulus_density: for singleton {n}, maxCoverageDensity = 1/n (via systemLCM_singleton + coverageDensity_singleton)",
       "Added dvd_systemLCM: each modulus divides the system LCM (via init_dvd_foldl_lcm + mem_dvd_foldl_lcm)",
-      "Added coverageDensity_eq: unfolds coverageDensity without the let binding"
+      "Added coverageDensity_eq: unfolds coverageDensity without the let binding",
+      "Proved equal_residues_minimize: coverage density with constant residue a = coverage density with constant residue 0 (via Finset.card_bij, cyclic shift m↦(m+a)%L)",
+      "Added coverage_card_shift: ℕ cardinality equality of coverage filters via bijection"
     ],
     "insights": [
       "erdos_278_open_question was trivially provable: maxCoverageDensity is sSup of densities, each ≤ 1",
       "csSup_le + density_le_one eliminates the axiom in 3 lines",
       "List.mem_cons_self deprecated in current Mathlib - use simp instead",
-      "equal_residues_minimize proof strategy: cyclic shift bijection m↦(m+a)%L on {0,...,L-1}. Need add_mod_injOn (prove via by_contra + Nat.mul_le_mul_left for quotient equality), then dvd_mul_of_dvd_left for n|(a+c). Blocked on Lean omega not handling nonlinear L*(q₁-q₂)"
+      "equal_residues_minimize proof strategy: cyclic shift bijection m↦(m+a)%L on {0,...,L-1}. Need add_mod_injOn (prove via by_contra + Nat.mul_le_mul_left for quotient equality), then dvd_mul_of_dvd_left for n|(a+c). Blocked on Lean omega not handling nonlinear L*(q₁-q₂)",
+      "omega in Lean 4 handles modular arithmetic round-trips: ((m+a)%L + L - a%L)%L = m when m<L",
+      "Nat.mod_mod_of_dvd is the key lemma for shifting: if k∣L then (x%L)%k = x%k"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove equal_residues_minimize: implement add_mod_injOn via by_contra+quotient case analysis (avoid omega for nonlinear), then shift_maps_coverage for both directions",
-      "Prove max_density_coprime_case using CRT: for coprime moduli, coverage = 1-∏(1-1/nᵢ) which equals Σ1/nᵢ by inclusion-exclusion"
+      "Prove max_density_coprime_case using CRT: for coprime moduli, max density = Σ1/nᵢ",
+      "Consider whether simpson_theorem can be proved from Mathlib (deep result, likely requires significant infrastructure)"
     ],
     "markdown": "# Erdős #278 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{n_1<\\cdots<n_r\\}$ be a finite set of integers. What is the maximum density of integers covered by a suitable choice of congruences $a_i\\pmod{n_i}$?\n\nIs the minimum density achieved when all the $a_i$ are equal?\n\n\n\nSimpson \\cite{Si86} has observed that the density of integers covered is at least\\[\\sum_i \\frac{1}{n_i}-\\sum_{i<j}\\frac{1}{[n_i,n_j]}+\\sum_{i<j<k}\\frac{1}{[n_i,n_j,n_k]}-\\cdot\\](where $[\\cdots]$ denotes the least common multiple) which is achieved when all $a_i$ are equal, settling the second question.\n\n\n\n\nReferences\n\n\n[Si86] Simpson, R. J., Exact coverings of the integers by arithmetic progressions. Discrete Math. (1986), 181--190.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #277\n- Problem #279\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Si86\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
@@ -71,9 +75,9 @@
     {
       "path": "Proofs/Erdos278Problem.lean",
       "filename": "Erdos278Problem.lean",
-      "lineCount": 246,
-      "theoremCount": 5,
-      "axiomCount": 3,
+      "lineCount": 291,
+      "theoremCount": 8,
+      "axiomCount": 2,
       "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Proved `equal_residues_minimize`: coverage density with constant residue `a` equals coverage density with constant residue `0`
- Axiom count reduced from 3 → 2 (file originally had 5 axioms; prior work eliminated 2, this eliminates 1 more)
- 0 sorries remain

## Proof Method
Cyclic shift bijection `m ↦ (m+a) % L` on `{0, ..., L-1}` via `Finset.card_bij'`:
- **Forward**: if `k ∣ m` then `((m+a) % L) % k = a % k` (using `Nat.mod_mod_of_dvd` since `k ∣ L`)
- **Backward**: inverse shift `m ↦ (m + L - a%L) % L` maps the "≡a" filter back to the "divisible" filter
- **Round-trips**: both directions verified by `omega`

## Files Modified
- `proofs/Proofs/Erdos278Problem.lean` — replaced `axiom` with proved `theorem`, added `coverage_card_shift` helper
- `src/data/proofs/erdos-278/meta.json` — updated axiomCount (5→2), theoremCount (6→8), lineCount
- `src/data/research/problems/erdos-278.json` — updated knowledge and progress

## Status
**Outcome**: completed (axiom elimination)
**Remaining axioms**: `simpson_theorem` (deep 1986 result), `max_density_coprime_case` (CRT-based)

🤖 Generated by researcher-4