### PR TITLE
Research: fourier-series-oq-02 - prove C^∞ rapid decay (0 sorries, 9 axioms)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02.lean
@@ -225,11 +225,13 @@ axiom fourierCoeff_smooth_decay (k : ℕ) (f : AddCircle T → ℂ)
     ∃ (Ck : ℝ), 0 < Ck ∧ ‖fourierCoeff f n‖ ≤ Ck / |↑n| ^ (k : ℝ)
 
 /-- **Rapid Decay for C^∞**: C^∞ ⟹ ‖ĉ_n‖ decays faster than any
-    polynomial (Schwartz class on the circle). -/
-axiom fourierCoeff_Cinfty_rapid_decay (f : AddCircle T → ℂ)
+    polynomial (Schwartz class on the circle).
+    Proved: C^∞ means C^k for all k, so apply fourierCoeff_smooth_decay. -/
+theorem fourierCoeff_Cinfty_rapid_decay (f : AddCircle T → ℂ)
     (hf : ∀ k : ℕ, ContDiff ℝ k (fun x : ℝ => f (↑x : AddCircle T)))
     (k : ℕ) (n : ℤ) (hn : n ≠ 0) :
-    ∃ (Ck : ℝ), 0 < Ck ∧ ‖fourierCoeff f n‖ ≤ Ck / |↑n| ^ (k : ℝ)
+    ∃ (Ck : ℝ), 0 < Ck ∧ ‖fourierCoeff f n‖ ≤ Ck / |↑n| ^ (k : ℝ) :=
+  fourierCoeff_smooth_decay k f (hf k) n hn
 
 /-- **Analytic Decay**: Holomorphic on strip of width δ ⟹
     ‖ĉ_n‖ ≤ C·e^{-2πδ|n|/T}. Exponential decay = analyticity. -/

--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -74,7 +74,7 @@
       "fourierCoeff_difference_formula: difference formula for coefficients",
       "full regularity-decay hierarchy: Hölder → C^k → C^∞ → analytic"
     ],
-    "axiomCount": 10,
+    "axiomCount": 9,
     "lineCount": 280,
     "assumptions": "10 axiom(s) encoding analytical infrastructure: difference formula, integral bounds, Hölder translation bound, summability, optimality, partial converse, smooth/analytic decay. Two formerly axiomatized results now proved: fourier_norm_one (‖e_n(x)‖ = 1 via toCircle) and fourier_translate_halfperiod (half-period negation via fourier_add_half_inv_index)."
   },

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -30,8 +30,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-23T18:00:00Z",
-    "iteration": 2,
-    "focus": "Proved 2 of 12 axioms. Core infrastructure (fourier_norm_one, half-period identity) now verified.",
+    "iteration": 3,
+    "focus": "Proved Cinfty rapid decay. 9 axioms remain.",
     "blockers": [
       "holder_translation_bound needs QuotientAddGroup distance API (dist on AddCircle)",
       "fourierCoeff_difference_formula needs Haar measure translation invariance"
@@ -44,10 +44,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axiom count from 12 to 10. Proved fourier_norm_one and fourier_translate_halfperiod.",
+    "progressSummary": "PROGRESS: Proved fourierCoeff_Cinfty_rapid_decay (C^∞ rapid decay follows from C^k decay). Axiom count: 10→9. 0 sorries.",
     "builtItems": [
       "fourier_norm_one: proved via simp [fourier_apply] — toCircle maps to unit circle",
-      "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg"
+      "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg",
+      "Proved fourierCoeff_Cinfty_rapid_decay: C^∞ ⟹ rapid decay, trivially from fourierCoeff_smooth_decay (C^∞ ⟹ C^k for all k)"
     ],
     "insights": [
       "fourier_apply unfolds to ↑(n • x).toCircle, which immediately gives unit norm via simp",
@@ -55,7 +56,8 @@
       "fourier_neg relates fourier(-n) to starRingEnd(fourier n), enabling conjugation approach",
       "T/(2*n) vs T/2/n: ring normalizes between these equivalent forms",
       "holder_translation_bound needs QuotientAddGroup dist API — dist(x, x+↑s) ≤ |s| on AddCircle",
-      "integral_product_bound needs norm_integral_le + fourier_norm_one + holder_bound + probability measure"
+      "integral_product_bound needs norm_integral_le + fourier_norm_one + holder_bound + probability measure",
+      "fourierCoeff_Cinfty_rapid_decay is a trivial consequence of fourierCoeff_smooth_decay — C^∞ means C^k for all k"
     ],
     "mathlibGaps": [
       "No obvious dist(x, x+↑s) ≤ |s| lemma found for AddCircle quotient metric"
@@ -95,8 +97,8 @@
       "path": "Proofs/FourierSeriesOQ02.lean",
       "filename": "FourierSeriesOQ02.lean",
       "lineCount": 280,
-      "theoremCount": 9,
-      "axiomCount": 10,
+      "theoremCount": 10,
+      "axiomCount": 9,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Proved `fourierCoeff_Cinfty_rapid_decay`: C^∞ functions have rapid polynomial decay of Fourier coefficients
- Trivial proof: C^∞ means C^k for all k, so apply `fourierCoeff_smooth_decay` (C^k axiom)
- Axiom count: 10 → 9

## Files Modified
- `proofs/Proofs/FourierSeriesOQ02.lean` — converted axiom to theorem (one-liner)
- `src/data/proofs/fourier-series-oq-02/meta.json` — updated axiomCount
- `src/data/research/problems/fourier-series-oq-02.json` — updated knowledge

## Status
**Outcome**: completed (axiom elimination)
**Remaining**: 9 axioms (core analysis infrastructure, optimality, converse, analytic decay)

🤖 Generated by researcher-4