### PR TITLE
chore: sync research data and add new problem entries

### DIFF
--- a/research/problems/abel-ruffini-oq-05/problem.md
+++ b/research/problems/abel-ruffini-oq-05/problem.md
@@ -1,0 +1,35 @@
+# Problem: Charles Hermite (1858) showed that the general quintic *can* be solved using ...
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/abel-ruffini-oq-05/state.md
+++ b/research/problems/abel-ruffini-oq-05/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.516Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/angle-trisection-oq-03/problem.md
+++ b/research/problems/angle-trisection-oq-03/problem.md
@@ -1,0 +1,35 @@
+# Problem: What is the computational complexity of determining constructibility
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/angle-trisection-oq-03/state.md
+++ b/research/problems/angle-trisection-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.516Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/ballot-problem-oq-01-incomplete-01/problem.md
+++ b/research/problems/ballot-problem-oq-01-incomplete-01/problem.md
@@ -1,0 +1,37 @@
+# Problem: Complete Generalized Ballot Problem: k-Fold Dominance (3 sorries)
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - combinatorics
+  - completion
+  - lattice-paths
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/ballot-problem-oq-01-incomplete-01/state.md
+++ b/research/problems/ballot-problem-oq-01-incomplete-01/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T17:46:34.538Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/basel-problem-oq-02/problem.md
+++ b/research/problems/basel-problem-oq-02/problem.md
@@ -1,0 +1,35 @@
+# Problem: Are all odd zeta values ζ(2k+1) transcendental
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/basel-problem-oq-02/state.md
+++ b/research/problems/basel-problem-oq-02/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.517Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/binomial-theorem-oq-03-oq-02/problem.md
+++ b/research/problems/binomial-theorem-oq-03-oq-02/problem.md
@@ -1,0 +1,37 @@
+# Problem: Contribute (1+x/n)^n -> e^x limit to Mathlib
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 6
+tags:
+  - seeker-selected
+  - analysis
+  - probability
+  - mathlib-contribution
+```
+
+**Significance**: 7/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/binomial-theorem-oq-03-oq-02/state.md
+++ b/research/problems/binomial-theorem-oq-03-oq-02/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T17:46:34.538Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/borsuk-ulam-oq-04/problem.md
+++ b/research/problems/borsuk-ulam-oq-04/problem.md
@@ -1,0 +1,35 @@
+# Problem: What are the higher categorical analogues of the covering space argument
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - generalization
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/borsuk-ulam-oq-04/state.md
+++ b/research/problems/borsuk-ulam-oq-04/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.518Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/buffons-needle-oq-03/problem.md
+++ b/research/problems/buffons-needle-oq-03/problem.md
@@ -1,0 +1,35 @@
+# Problem: Can the higher-dimensional generalization (random needles on a grid in ℝ³) be...
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - generalization
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/buffons-needle-oq-03/state.md
+++ b/research/problems/buffons-needle-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.518Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/cantor-diagonalization-oq-03/problem.md
+++ b/research/problems/cantor-diagonalization-oq-03/problem.md
@@ -1,0 +1,35 @@
+# Problem: Which mathematical statements are independent of ZFC due to cardinality consi...
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/cantor-diagonalization-oq-03/state.md
+++ b/research/problems/cantor-diagonalization-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.518Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/cantors-theorem-oq-03/problem.md
+++ b/research/problems/cantors-theorem-oq-03/problem.md
@@ -1,0 +1,35 @@
+# Problem: Can we generalize the diagonal argument to other structures beyond sets
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - generalization
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/cantors-theorem-oq-03/state.md
+++ b/research/problems/cantors-theorem-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.518Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/cayley-hamilton-oq-03/problem.md
+++ b/research/problems/cayley-hamilton-oq-03/problem.md
@@ -1,0 +1,35 @@
+# Problem: What is the analog of Cayley-Hamilton for infinite-dimensional operators
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/cayley-hamilton-oq-03/state.md
+++ b/research/problems/cayley-hamilton-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.519Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/cayley-hamilton-reduction-oq-03/problem.md
+++ b/research/problems/cayley-hamilton-reduction-oq-03/problem.md
@@ -1,0 +1,35 @@
+# Problem: What is the analog for infinite-dimensional operators (compact operators on H...
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/cayley-hamilton-reduction-oq-03/state.md
+++ b/research/problems/cayley-hamilton-reduction-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.519Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/central-limit-theorem-oq-04/problem.md
+++ b/research/problems/central-limit-theorem-oq-04/problem.md
@@ -1,0 +1,35 @@
+# Problem: How does the topological perspective extend to non-commutative probability (f...
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - generalization
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/central-limit-theorem-oq-04/state.md
+++ b/research/problems/central-limit-theorem-oq-04/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.519Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/cevas-theorem-oq-03/problem.md
+++ b/research/problems/cevas-theorem-oq-03/problem.md
@@ -1,0 +1,35 @@
+# Problem: What is the computational complexity of finding cevian configurations with sp...
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/cevas-theorem-oq-03/state.md
+++ b/research/problems/cevas-theorem-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.519Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/chinese-remainder-constructive-oq-01/problem.md
+++ b/research/problems/chinese-remainder-constructive-oq-01/problem.md
@@ -1,0 +1,35 @@
+# Problem: What are the best algorithms for computing Bezout coefficients in multi-preci...
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/chinese-remainder-constructive-oq-01/state.md
+++ b/research/problems/chinese-remainder-constructive-oq-01/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.520Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/chinese-remainder-non-coprime-oq-04/problem.md
+++ b/research/problems/chinese-remainder-non-coprime-oq-04/problem.md
@@ -1,0 +1,35 @@
+# Problem: What are the implications for simultaneous Diophantine approximation
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/chinese-remainder-non-coprime-oq-04/state.md
+++ b/research/problems/chinese-remainder-non-coprime-oq-04/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.520Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/collatz-structured-oq-02/problem.md
+++ b/research/problems/collatz-structured-oq-02/problem.md
@@ -1,0 +1,35 @@
+# Problem: Are there cycles other than 4 -> 2 -> 1
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/collatz-structured-oq-02/state.md
+++ b/research/problems/collatz-structured-oq-02/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.520Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/continuum-hypothesis-oq-02/problem.md
+++ b/research/problems/continuum-hypothesis-oq-02/problem.md
@@ -1,0 +1,35 @@
+# Problem: What is the 'true' size of the continuum
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/continuum-hypothesis-oq-02/state.md
+++ b/research/problems/continuum-hypothesis-oq-02/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T00:42:35.521Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/dissection-of-cubes-incomplete-01/problem.md
+++ b/research/problems/dissection-of-cubes-incomplete-01/problem.md
@@ -1,0 +1,37 @@
+# Problem: Complete proof of Dissection of Cubes (2 sorries)
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 6
+tags:
+  - seeker-selected
+  - geometry
+  - completion
+  - wiedijk-100
+```
+
+**Significance**: 7/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/dissection-of-cubes-incomplete-01/state.md
+++ b/research/problems/dissection-of-cubes-incomplete-01/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T17:46:34.541Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/dissection-of-cubes-oq-02-oq-02/problem.md
+++ b/research/problems/dissection-of-cubes-oq-02-oq-02/problem.md
@@ -1,0 +1,38 @@
+# Problem: Dehn-Sydler completeness theorem for 3D scissors congruence
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 8
+tractability: 5
+tags:
+  - seeker-selected
+  - geometry
+  - scissors-congruence
+  - hilbert-problems
+  - wiedijk-100
+```
+
+**Significance**: 8/10
+**Tractability**: 5/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/dissection-of-cubes-oq-02-oq-02/state.md
+++ b/research/problems/dissection-of-cubes-oq-02-oq-02/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T17:46:34.542Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/fundamental-theorem-algebra-oq-04/problem.md
+++ b/research/problems/fundamental-theorem-algebra-oq-04/problem.md
@@ -1,0 +1,37 @@
+# Problem: FTA: C is the unique algebraic closure of R
+
+## Statement
+
+### Plain Language
+AVAILABLE.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 8
+tractability: 5
+tags:
+  - seeker-selected
+  - algebra
+  - algebraic-closure
+  - wiedijk-100
+```
+
+**Significance**: 8/10
+**Tractability**: 5/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/fundamental-theorem-algebra-oq-04/state.md
+++ b/research/problems/fundamental-theorem-algebra-oq-04/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-03-23T17:46:34.542Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -726,6 +726,11 @@
       "passes": 1,
       "lastEnriched": "2026-03-23T13:47:46Z",
       "quality": 100
+    },
+    "bezout-identity": {
+      "passes": 1,
+      "lastEnriched": "2026-03-23T20:17:34Z",
+      "quality": 100
     }
   }
 }

--- a/src/data/research/problems/abel-ruffini-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-oq-05.json
@@ -1,0 +1,90 @@
+{
+  "slug": "abel-ruffini-oq-05",
+  "title": "Charles Hermite (1858) showed that the general quintic *can* be solved using ...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.516Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "abel-ruffini",
+    "abel-ruffini-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.515Z",
+  "lastUpdate": "2026-03-23T00:42:35.516Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/AbelRuffini.lean",
+      "filename": "AbelRuffini.lean",
+      "lineCount": 186,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffini.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
+      "filename": "AbelRuffiniGaloisExtensions.lean",
+      "lineCount": 535,
+      "theoremCount": 57,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04.lean",
+      "filename": "AbelRuffiniOQ04.lean",
+      "lineCount": 164,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -1,0 +1,170 @@
+{
+  "slug": "angle-trisection-oq-03",
+  "title": "What is the computational complexity of determining constructibility",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.516Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "angle-trisection",
+    "angle-trisection-oq-02",
+    "angle-trisection-oq-02-oq-01",
+    "angle-trisection-oq-02-oq-03",
+    "angle-trisection-oq-02-oq-03-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.516Z",
+  "lastUpdate": "2026-03-23T00:42:35.516Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/AngleTrisection.lean",
+      "filename": "AngleTrisection.lean",
+      "lineCount": 384,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisection.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20Gal.lean",
+      "filename": "AngleTrisectionCos20Gal.lean",
+      "lineCount": 475,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionEmbedding.lean",
+      "filename": "AngleTrisectionEmbedding.lean",
+      "lineCount": 175,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionEmbedding.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ01.lean",
+      "filename": "AngleTrisectionOQ01.lean",
+      "lineCount": 367,
+      "theoremCount": 40,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02.lean",
+      "filename": "AngleTrisectionOQ02.lean",
+      "lineCount": 299,
+      "theoremCount": 15,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ01.lean",
+      "filename": "AngleTrisectionOQ02OQ01.lean",
+      "lineCount": 116,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ03.lean",
+      "filename": "AngleTrisectionOQ02OQ03.lean",
+      "lineCount": 1800,
+      "theoremCount": 150,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ03Ext.lean",
+      "filename": "AngleTrisectionOQ02OQ03Ext.lean",
+      "lineCount": 298,
+      "theoremCount": 55,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ03Ext.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ03OQ01.lean",
+      "filename": "AngleTrisectionOQ02OQ03OQ01.lean",
+      "lineCount": 741,
+      "theoremCount": 32,
+      "axiomCount": 0,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ04.lean",
+      "filename": "AngleTrisectionOQ04.lean",
+      "lineCount": 600,
+      "theoremCount": 43,
+      "axiomCount": 0,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/ballot-problem-oq-01-incomplete-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-incomplete-01.json
@@ -1,0 +1,57 @@
+{
+  "slug": "ballot-problem-oq-01-incomplete-01",
+  "title": "Complete Generalized Ballot Problem: k-Fold Dominance (3 sorries)",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T17:46:34.538Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "combinatorics",
+    "completion",
+    "lattice-paths"
+  ],
+  "relatedProofs": [
+    "ballot-problem",
+    "ballot-problem-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T17:46:34.537Z",
+  "lastUpdate": "2026-03-23T17:46:34.537Z",
+  "significance": 6,
+  "tractability": 6
+}

--- a/src/data/research/problems/basel-problem-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-02.json
@@ -1,0 +1,67 @@
+{
+  "slug": "basel-problem-oq-02",
+  "title": "Are all odd zeta values ζ(2k+1) transcendental",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.517Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "basel-problem"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.517Z",
+  "lastUpdate": "2026-03-23T00:42:35.517Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/BaselProblem.lean",
+      "filename": "BaselProblem.lean",
+      "lineCount": 165,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
@@ -1,0 +1,163 @@
+{
+  "slug": "binomial-theorem-oq-03-oq-02",
+  "title": "Contribute (1+x/n)^n -> e^x limit to Mathlib",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T17:46:34.538Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "analysis",
+    "probability",
+    "mathlib-contribution"
+  ],
+  "relatedProofs": [
+    "binomial-theorem",
+    "binomial-theorem-oq-01",
+    "binomial-theorem-oq-01-oq-01",
+    "binomial-theorem-oq-02",
+    "binomial-theorem-oq-03",
+    "binomial-theorem-oq-04",
+    "binomial-theorem-oq-04-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T17:46:34.538Z",
+  "lastUpdate": "2026-03-23T17:46:34.538Z",
+  "significance": 7,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/BinomialTheorem.lean",
+      "filename": "BinomialTheorem.lean",
+      "lineCount": 177,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheorem.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01.lean",
+      "filename": "BinomialTheoremOQ01.lean",
+      "lineCount": 265,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01Aristotle.lean",
+      "filename": "BinomialTheoremOQ01Aristotle.lean",
+      "lineCount": 112,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01OQ01.lean",
+      "filename": "BinomialTheoremOQ01OQ01.lean",
+      "lineCount": 221,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02.lean",
+      "filename": "BinomialTheoremOQ02.lean",
+      "lineCount": 281,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03.lean",
+      "filename": "BinomialTheoremOQ03.lean",
+      "lineCount": 589,
+      "theoremCount": 33,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04.lean",
+      "filename": "BinomialTheoremOQ04.lean",
+      "lineCount": 196,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04OQ01.lean",
+      "filename": "BinomialTheoremOQ04OQ01.lean",
+      "lineCount": 300,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04OQ02.lean",
+      "filename": "BinomialTheoremOQ04OQ02.lean",
+      "lineCount": 112,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ02.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/borsuk-ulam-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04.json
@@ -1,0 +1,138 @@
+{
+  "slug": "borsuk-ulam-oq-04",
+  "title": "What are the higher categorical analogues of the covering space argument",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.518Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "generalization"
+  ],
+  "relatedProofs": [
+    "borsuk-ulam",
+    "borsuk-ulam-oq-02",
+    "borsuk-ulam-oq-03",
+    "borsuk-ulam-oq-03-oq-01",
+    "borsuk-ulam-oq-03-oq-01-oq-01",
+    "borsuk-ulam-oq-03-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.517Z",
+  "lastUpdate": "2026-03-23T00:42:35.517Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/BorsukUlam.lean",
+      "filename": "BorsukUlam.lean",
+      "lineCount": 266,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlam.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ01.lean",
+      "filename": "BorsukUlamOQ01.lean",
+      "lineCount": 329,
+      "theoremCount": 5,
+      "axiomCount": 2,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02.lean",
+      "filename": "BorsukUlamOQ02.lean",
+      "lineCount": 390,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ03.lean",
+      "filename": "BorsukUlamOQ03.lean",
+      "lineCount": 5170,
+      "theoremCount": 227,
+      "axiomCount": 2,
+      "defCount": 35,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ03.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ03OQ01.lean",
+      "filename": "BorsukUlamOQ03OQ01.lean",
+      "lineCount": 1163,
+      "theoremCount": 41,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ03OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ03OQ01OQ01.lean",
+      "lineCount": 435,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ03OQ03.lean",
+      "filename": "BorsukUlamOQ03OQ03.lean",
+      "lineCount": 2634,
+      "theoremCount": 123,
+      "axiomCount": 1,
+      "defCount": 30,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ03OQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/buffons-needle-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-03.json
@@ -1,0 +1,115 @@
+{
+  "slug": "buffons-needle-oq-03",
+  "title": "Can the higher-dimensional generalization (random needles on a grid in ℝ³) be...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.518Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "generalization"
+  ],
+  "relatedProofs": [
+    "buffons-needle",
+    "buffons-needle-oq-01",
+    "buffons-needle-oq-01-oq-01",
+    "buffons-needle-oq-02",
+    "buffons-needle-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.518Z",
+  "lastUpdate": "2026-03-23T00:42:35.518Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/BuffonsNeedle.lean",
+      "filename": "BuffonsNeedle.lean",
+      "lineCount": 267,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedle.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01.lean",
+      "filename": "BuffonsNeedleOQ01.lean",
+      "lineCount": 251,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ01.lean",
+      "filename": "BuffonsNeedleOQ01OQ01.lean",
+      "lineCount": 391,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02.lean",
+      "filename": "BuffonsNeedleOQ02.lean",
+      "lineCount": 263,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02OQ01.lean",
+      "filename": "BuffonsNeedleOQ02OQ01.lean",
+      "lineCount": 310,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ01.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/cantor-diagonalization-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03.json
@@ -1,0 +1,103 @@
+{
+  "slug": "cantor-diagonalization-oq-03",
+  "title": "Which mathematical statements are independent of ZFC due to cardinality consi...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.518Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "cantor-diagonalization",
+    "cantor-diagonalization-oq-01",
+    "cantor-diagonalization-oq-02",
+    "cantor-diagonalization-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.518Z",
+  "lastUpdate": "2026-03-23T00:42:35.518Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CantorDiagonalization.lean",
+      "filename": "CantorDiagonalization.lean",
+      "lineCount": 176,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalization.lean"
+    },
+    {
+      "path": "Proofs/CantorDiagonalizationOQ01.lean",
+      "filename": "CantorDiagonalizationOQ01.lean",
+      "lineCount": 443,
+      "theoremCount": 27,
+      "axiomCount": 2,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ01.lean"
+    },
+    {
+      "path": "Proofs/CantorDiagonalizationOQ02.lean",
+      "filename": "CantorDiagonalizationOQ02.lean",
+      "lineCount": 273,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02.lean"
+    },
+    {
+      "path": "Proofs/CantorDiagonalizationOQ02OQ01.lean",
+      "filename": "CantorDiagonalizationOQ02OQ01.lean",
+      "lineCount": 131,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ01.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/cantors-theorem-oq-03.json
+++ b/src/data/research/problems/cantors-theorem-oq-03.json
@@ -1,0 +1,122 @@
+{
+  "slug": "cantors-theorem-oq-03",
+  "title": "Can we generalize the diagonal argument to other structures beyond sets",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-03-23T07:29:35.463575Z",
+    "iteration": 1,
+    "focus": "Complete: hierarchy of diagonal arguments formalized",
+    "blockers": [],
+    "nextAction": "PR created, awaiting review",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: 310 lines, 17 theorems, 0 axioms, 0 sorries. Full hierarchy: Konig > Coordinate > Lawvere. Non-enumerability for N->N, N->Z via successor diagonal.",
+    "builtItems": [
+      "konig_principle: Konig heterogeneous diagonal principle",
+      "coordinate_diagonal: Intermediate pointwise dodge",
+      "lawvere_from_diagonal: Lawvere as coordinate diagonal special case",
+      "cantor_bool/cantor_prop/cantor_set: Cantor variants from Lawvere",
+      "fpf_implies_non_enumerable: Master theorem for non-enumerability",
+      "nat_seq_uncountable/int_seq_uncountable via successor diagonal",
+      "konig_implies_lawvere: Konig subsumes Lawvere via Unit encoding"
+    ],
+    "insights": [
+      "Konig diagonal is the HETEROGENEOUS generalization: different types at each index, different dodges",
+      "Coordinate diagonal is intermediate: same target type but pointwise (not uniform) dodging",
+      "Lawvere is the special case where dodge = g(f(i)(i)) for fixed g",
+      "The diagonal works on ANY type with fixed-point-free endomorphism: Bool, N, Z, Prop",
+      "Konig implies Lawvere via Unit fibers: view f : a -> (a -> b) as (Sigma _ : a, Unit) -> (a -> b)",
+      "Universe inference requires Unit not PUnit when mixing with Type* parameters in Lean 4"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Extend to cardinal-level Konig inequality using Cardinal.mk API",
+      "Formalize cofinality applications of Konig",
+      "Connect to Baire category theorem as topological diagonal"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "generalization"
+  ],
+  "relatedProofs": [
+    "cantors-theorem",
+    "cantors-theorem-oq-01",
+    "cantors-theorem-oq-02",
+    "cantors-theorem-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.518Z",
+  "lastUpdate": "2026-03-23T07:29:35.463757Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CantorsTheorem.lean",
+      "filename": "CantorsTheorem.lean",
+      "lineCount": 158,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheorem.lean"
+    },
+    {
+      "path": "Proofs/CantorsTheoremOQ01.lean",
+      "filename": "CantorsTheoremOQ01.lean",
+      "lineCount": 273,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/CantorsTheoremOQ02.lean",
+      "filename": "CantorsTheoremOQ02.lean",
+      "lineCount": 282,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/CantorsTheoremOQ03.lean",
+      "filename": "CantorsTheoremOQ03.lean",
+      "lineCount": 311,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorsTheoremOQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -1,0 +1,207 @@
+{
+  "slug": "cayley-hamilton-oq-03",
+  "title": "What is the analog of Cayley-Hamilton for infinite-dimensional operators",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.519Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-minpoly",
+    "cayley-hamilton-minpoly-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-01",
+    "cayley-hamilton-minpoly-oq-05",
+    "cayley-hamilton-minpoly-oq-05-oq-01",
+    "cayley-hamilton-reduction",
+    "cayley-hamilton-reduction-oq-01",
+    "cayley-hamilton-reduction-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.519Z",
+  "lastUpdate": "2026-03-23T00:42:35.519Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleyHamilton.lean",
+      "filename": "CayleyHamilton.lean",
+      "lineCount": 251,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamilton.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ01.lean",
+      "lineCount": 308,
+      "theoremCount": 20,
+      "axiomCount": 3,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02.lean",
+      "lineCount": 132,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "lineCount": 218,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04.lean",
+      "lineCount": 317,
+      "theoremCount": 8,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04Backward.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04Backward.lean",
+      "lineCount": 481,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "lineCount": 126,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05.lean",
+      "lineCount": 233,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "lineCount": 271,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ01.lean",
+      "filename": "CayleyHamiltonOQ01.lean",
+      "lineCount": 448,
+      "theoremCount": 30,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ02.lean",
+      "filename": "CayleyHamiltonOQ02.lean",
+      "lineCount": 359,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ01.lean",
+      "filename": "CayleyHamiltonReductionOQ01.lean",
+      "lineCount": 305,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02.lean",
+      "filename": "CayleyHamiltonReductionOQ02.lean",
+      "lineCount": 161,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-03.json
@@ -1,0 +1,81 @@
+{
+  "slug": "cayley-hamilton-reduction-oq-03",
+  "title": "What is the analog for infinite-dimensional operators (compact operators on H...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.519Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-reduction",
+    "cayley-hamilton-reduction-oq-01",
+    "cayley-hamilton-reduction-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.519Z",
+  "lastUpdate": "2026-03-23T00:42:35.519Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ01.lean",
+      "filename": "CayleyHamiltonReductionOQ01.lean",
+      "lineCount": 305,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02.lean",
+      "filename": "CayleyHamiltonReductionOQ02.lean",
+      "lineCount": 161,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/central-limit-theorem-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-04.json
@@ -1,0 +1,126 @@
+{
+  "slug": "central-limit-theorem-oq-04",
+  "title": "How does the topological perspective extend to non-commutative probability (f...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.519Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "generalization"
+  ],
+  "relatedProofs": [
+    "central-limit-theorem",
+    "central-limit-theorem-oq-01",
+    "central-limit-theorem-oq-01-oq-01",
+    "central-limit-theorem-oq-01-oq-02",
+    "central-limit-theorem-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.519Z",
+  "lastUpdate": "2026-03-23T00:42:35.519Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CentralLimitTheorem.lean",
+      "filename": "CentralLimitTheorem.lean",
+      "lineCount": 619,
+      "theoremCount": 15,
+      "axiomCount": 13,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheorem.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01.lean",
+      "filename": "CentralLimitTheoremOQ01.lean",
+      "lineCount": 314,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ01.lean",
+      "lineCount": 1131,
+      "theoremCount": 54,
+      "axiomCount": 3,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02.lean",
+      "lineCount": 323,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ02.lean",
+      "filename": "CentralLimitTheoremOQ02.lean",
+      "lineCount": 730,
+      "theoremCount": 19,
+      "axiomCount": 1,
+      "defCount": 11,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ03.lean",
+      "filename": "CentralLimitTheoremOQ03.lean",
+      "lineCount": 242,
+      "theoremCount": 8,
+      "axiomCount": 14,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/cevas-theorem-oq-03.json
+++ b/src/data/research/problems/cevas-theorem-oq-03.json
@@ -1,0 +1,159 @@
+{
+  "slug": "cevas-theorem-oq-03",
+  "title": "What is the computational complexity of finding cevian configurations with sp...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.519Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "cevas-theorem",
+    "cevas-theorem-oq-02",
+    "cevas-theorem-oq-02-oq-01",
+    "cevas-theorem-oq-02-oq-02",
+    "cevas-theorem-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.519Z",
+  "lastUpdate": "2026-03-23T00:42:35.519Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CevasTheorem.lean",
+      "filename": "CevasTheorem.lean",
+      "lineCount": 270,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheorem.lean"
+    },
+    {
+      "path": "Proofs/CevasTheoremNonEuclidean.lean",
+      "filename": "CevasTheoremNonEuclidean.lean",
+      "lineCount": 528,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremNonEuclidean.lean"
+    },
+    {
+      "path": "Proofs/CevasTheoremOQ01.lean",
+      "filename": "CevasTheoremOQ01.lean",
+      "lineCount": 908,
+      "theoremCount": 39,
+      "axiomCount": 0,
+      "defCount": 22,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/CevasTheoremOQ02.lean",
+      "filename": "CevasTheoremOQ02.lean",
+      "lineCount": 502,
+      "theoremCount": 22,
+      "axiomCount": 0,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/CevasTheoremOQ02OQ01.lean",
+      "filename": "CevasTheoremOQ02OQ01.lean",
+      "lineCount": 263,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CevasTheoremOQ02OQ01OQ02.lean",
+      "filename": "CevasTheoremOQ02OQ01OQ02.lean",
+      "lineCount": 302,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CevasTheoremOQ02OQ02.lean",
+      "filename": "CevasTheoremOQ02OQ02.lean",
+      "lineCount": 321,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/CevasTheoremOQ04.lean",
+      "filename": "CevasTheoremOQ04.lean",
+      "lineCount": 243,
+      "theoremCount": 22,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ04.lean"
+    },
+    {
+      "path": "Proofs/CevasTheoremSinRatio.lean",
+      "filename": "CevasTheoremSinRatio.lean",
+      "lineCount": 146,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremSinRatio.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/chinese-remainder-constructive-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-01.json
@@ -1,0 +1,79 @@
+{
+  "slug": "chinese-remainder-constructive-oq-01",
+  "title": "What are the best algorithms for computing Bezout coefficients in multi-preci...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.520Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "chinese-remainder-constructive",
+    "chinese-remainder-constructive-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.519Z",
+  "lastUpdate": "2026-03-23T00:42:35.519Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/ChineseRemainderConstructive.lean",
+      "filename": "ChineseRemainderConstructive.lean",
+      "lineCount": 417,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderConstructive.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderConstructiveOQ04.lean",
+      "filename": "ChineseRemainderConstructiveOQ04.lean",
+      "lineCount": 157,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderConstructiveOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-04.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-04.json
@@ -1,0 +1,132 @@
+{
+  "slug": "chinese-remainder-non-coprime-oq-04",
+  "title": "What are the implications for simultaneous Diophantine approximation",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-03-23T00:42:35.520Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: 0 sorries, 0 axioms, 239 lines, PR #5159",
+    "builtItems": [
+      "dirichlet_approximation in ChineseRemainderNonCoprimeOQ04.lean (0 sorry)",
+      "mediant_between, farey_neighbor_order, lattice_point_exists, golden_ratio_quadratic",
+      "binFn, same_bin_fract_close, fract_sub_eq (helper infrastructure)"
+    ],
+    "insights": [
+      "Dirichlet theorem provable via Fintype.exists_ne_map_eq_of_card_lt pigeonhole on binFn : Fin(N+1) → Fin(N)",
+      "Main challenge: managing Nat/Int/Real casts for nat subtraction and floor differences",
+      "Int.fract x = x - floor(x) by definitional unfolding (show ... = rfl pattern)"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "chinese-remainder-non-coprime",
+    "chinese-remainder-non-coprime-oq-01",
+    "chinese-remainder-non-coprime-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.520Z",
+  "lastUpdate": "2026-03-23T00:42:35.520Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/ChineseRemainderNonCoprime.lean",
+      "filename": "ChineseRemainderNonCoprime.lean",
+      "lineCount": 306,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprime.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderNonCoprimeOQ01.lean",
+      "filename": "ChineseRemainderNonCoprimeOQ01.lean",
+      "lineCount": 309,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ01.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderNonCoprimeOQ02.lean",
+      "filename": "ChineseRemainderNonCoprimeOQ02.lean",
+      "lineCount": 706,
+      "theoremCount": 55,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ02.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderNonCoprimeOQ03.lean",
+      "filename": "ChineseRemainderNonCoprimeOQ03.lean",
+      "lineCount": 392,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderNonCoprimeOQ03Aristotle.lean",
+      "filename": "ChineseRemainderNonCoprimeOQ03Aristotle.lean",
+      "lineCount": 238,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03Aristotle.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderNonCoprimeOQ04.lean",
+      "filename": "ChineseRemainderNonCoprimeOQ04.lean",
+      "lineCount": 240,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/continuum-hypothesis-oq-02.json
+++ b/src/data/research/problems/continuum-hypothesis-oq-02.json
@@ -1,0 +1,79 @@
+{
+  "slug": "continuum-hypothesis-oq-02",
+  "title": "What is the 'true' size of the continuum",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T00:42:35.521Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "continuum-hypothesis",
+    "continuum-hypothesis-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T00:42:35.520Z",
+  "lastUpdate": "2026-03-23T00:42:35.520Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/ContinuumHypothesis.lean",
+      "filename": "ContinuumHypothesis.lean",
+      "lineCount": 367,
+      "theoremCount": 7,
+      "axiomCount": 6,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ContinuumHypothesis.lean"
+    },
+    {
+      "path": "Proofs/ContinuumHypothesisOQ01.lean",
+      "filename": "ContinuumHypothesisOQ01.lean",
+      "lineCount": 318,
+      "theoremCount": 20,
+      "axiomCount": 10,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ContinuumHypothesisOQ01.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/dissection-of-cubes-incomplete-01.json
+++ b/src/data/research/problems/dissection-of-cubes-incomplete-01.json
@@ -1,0 +1,56 @@
+{
+  "slug": "dissection-of-cubes-incomplete-01",
+  "title": "Complete proof of Dissection of Cubes (2 sorries)",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T17:46:34.541Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "geometry",
+    "completion",
+    "wiedijk-100"
+  ],
+  "relatedProofs": [
+    "dissection-of-cubes"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T17:46:34.541Z",
+  "lastUpdate": "2026-03-23T17:46:34.541Z",
+  "significance": 7,
+  "tractability": 6
+}

--- a/src/data/research/problems/dissection-of-cubes-oq-02-oq-02.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-02-oq-02.json
@@ -1,0 +1,105 @@
+{
+  "slug": "dissection-of-cubes-oq-02-oq-02",
+  "title": "Dehn-Sydler completeness theorem for 3D scissors congruence",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T17:46:34.542Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "geometry",
+    "scissors-congruence",
+    "hilbert-problems",
+    "wiedijk-100"
+  ],
+  "relatedProofs": [
+    "dissection-of-cubes",
+    "dissection-of-cubes-oq-01",
+    "dissection-of-cubes-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T17:46:34.541Z",
+  "lastUpdate": "2026-03-23T17:46:34.541Z",
+  "significance": 8,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/DissectionOfCubes.lean",
+      "filename": "DissectionOfCubes.lean",
+      "lineCount": 367,
+      "theoremCount": 7,
+      "axiomCount": 2,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubes.lean"
+    },
+    {
+      "path": "Proofs/DissectionOfCubesOQ01.lean",
+      "filename": "DissectionOfCubesOQ01.lean",
+      "lineCount": 280,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ01.lean"
+    },
+    {
+      "path": "Proofs/DissectionOfCubesOQ02.lean",
+      "filename": "DissectionOfCubesOQ02.lean",
+      "lineCount": 384,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ02.lean"
+    },
+    {
+      "path": "Proofs/DissectionOfCubesOQ03.lean",
+      "filename": "DissectionOfCubesOQ03.lean",
+      "lineCount": 502,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 11,
+      "sorryCount": 8,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/fundamental-theorem-algebra-oq-04.json
+++ b/src/data/research/problems/fundamental-theorem-algebra-oq-04.json
@@ -1,0 +1,69 @@
+{
+  "slug": "fundamental-theorem-algebra-oq-04",
+  "title": "FTA: C is the unique algebraic closure of R",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-23T17:46:34.542Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "algebra",
+    "algebraic-closure",
+    "wiedijk-100"
+  ],
+  "relatedProofs": [
+    "fundamental-theorem-algebra"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-23T17:46:34.542Z",
+  "lastUpdate": "2026-03-23T17:46:34.542Z",
+  "significance": 8,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/FundamentalTheoremAlgebra.lean",
+      "filename": "FundamentalTheoremAlgebra.lean",
+      "lineCount": 215,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalTheoremAlgebra.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Sync research listing iteration counts (80 updated, 17 added)
- Add 19 new research problem entries from recent seeker/researcher activity
- Update enrichment tracker and aristotle jobs data

Automated deploy sync — data changes that couldn't push directly to main due to branch protection.