### PR TITLE
Research: erdos-462 - prove 6 axioms, Nat.minFac API (0 sorries, 1 axiom)

### DIFF
--- a/proofs/Proofs/Erdos462Problem.lean
+++ b/proofs/Proofs/Erdos462Problem.lean
@@ -24,16 +24,22 @@ noncomputable def leastPrimeFactor (n : ℕ) : ℕ :=
     else n.minFac
 
 /-- For `n ≥ 2`, `leastPrimeFactor n` is prime. -/
-axiom leastPrimeFactor_prime (n : ℕ) (hn : 2 ≤ n) :
-    (leastPrimeFactor n).Prime
+theorem leastPrimeFactor_prime (n : ℕ) (hn : 2 ≤ n) :
+    (leastPrimeFactor n).Prime := by
+  unfold leastPrimeFactor; simp [show ¬(n ≤ 1) from by omega]
+  exact Nat.minFac_prime (by omega)
 
 /-- `leastPrimeFactor n` divides `n` for `n ≥ 2`. -/
-axiom leastPrimeFactor_dvd (n : ℕ) (hn : 2 ≤ n) :
-    leastPrimeFactor n ∣ n
+theorem leastPrimeFactor_dvd (n : ℕ) (hn : 2 ≤ n) :
+    leastPrimeFactor n ∣ n := by
+  unfold leastPrimeFactor; simp [show ¬(n ≤ 1) from by omega]
+  exact Nat.minFac_dvd n
 
 /-- `leastPrimeFactor n` is at most any prime dividing `n`. -/
-axiom leastPrimeFactor_le (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) (hpn : p ∣ n) :
-    leastPrimeFactor n ≤ p
+theorem leastPrimeFactor_le (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) (hpn : p ∣ n) :
+    leastPrimeFactor n ≤ p := by
+  unfold leastPrimeFactor; simp [show ¬(n ≤ 1) from by omega]
+  exact Nat.minFac_le_of_dvd hp.two_le hpn
 
 /- ## Sums involving least prime factor -/
 
@@ -72,13 +78,21 @@ def ErdosProblem462 : Prop :=
 /- ## Basic properties -/
 
 /-- The least prime factor of a prime is itself. -/
-axiom leastPrimeFactor_prime_self (p : ℕ) (hp : p.Prime) :
-    leastPrimeFactor p = p
+theorem leastPrimeFactor_prime_self (p : ℕ) (hp : p.Prime) :
+    leastPrimeFactor p = p := by
+  unfold leastPrimeFactor; simp [show ¬(p ≤ 1) from by omega [hp.two_le]]
+  exact hp.minFac_eq
 
 /-- The least prime factor of any `n ≥ 2` is at least 2. -/
-axiom leastPrimeFactor_ge_two (n : ℕ) (hn : 2 ≤ n) :
-    2 ≤ leastPrimeFactor n
+theorem leastPrimeFactor_ge_two (n : ℕ) (hn : 2 ≤ n) :
+    2 ≤ leastPrimeFactor n := by
+  unfold leastPrimeFactor; simp [show ¬(n ≤ 1) from by omega]
+  exact (Nat.minFac_prime (by omega : n ≠ 1)).two_le
 
-/-- The least prime factor of any `n ≥ 2` is at most `√n`. -/
-axiom leastPrimeFactor_le_sqrt (n : ℕ) (hn : 2 ≤ n) (hc : ¬n.Prime) :
-    (leastPrimeFactor n : ℝ) ≤ (n : ℝ) ^ (1/2 : ℝ)
+/-- The least prime factor of any `n ≥ 2` is at most `√n` for composite `n`. -/
+theorem leastPrimeFactor_le_sqrt (n : ℕ) (hn : 2 ≤ n) (hc : ¬n.Prime) :
+    (leastPrimeFactor n : ℝ) ≤ (n : ℝ) ^ (1/2 : ℝ) := by
+  unfold leastPrimeFactor; simp [show ¬(n ≤ 1) from by omega]
+  have hsq : n.minFac ^ 2 ≤ n := Nat.minFac_sq_le_self (by omega) hc
+  rw [← Real.sqrt_eq_rpow, ← Real.sqrt_sq (Nat.cast_nonneg (n.minFac))]
+  exact Real.sqrt_le_sqrt (by exact_mod_cast hsq)

--- a/src/data/proofs/erdos-462/meta.json
+++ b/src/data/proofs/erdos-462/meta.json
@@ -49,8 +49,8 @@
       "Formal statement of ErdosProblem462 with Nat floor for the interval endpoint",
       "Basic properties: p(p) = p for primes, p(n) ≥ 2, p(n) ≤ √n for composites"
     ],
-    "axiomCount": 7,
-    "assumptions": "7 axiom declarations: leastPrimeFactor_prime (p(n) is prime for n >= 2), leastPrimeFactor_dvd (p(n) divides n for n >= 2), leastPrimeFactor_le (p(n) <= any prime dividing n), compositeSum_asymptotic (Theta(sqrt(x)/(log x)^2) bound), leastPrimeFactor_prime_self (p(p) = p for primes), leastPrimeFactor_ge_two (p(n) >= 2 for n >= 2), leastPrimeFactor_le_sqrt (p(n) <= sqrt(n) for composites)",
+    "axiomCount": 1,
+    "assumptions": "1 axiom: compositeSum_asymptotic (deep analytic number theory: asymptotic for sum of least prime factors)",
     "lineCount": 84
   },
   "leanFile": {

--- a/src/data/research/problems/erdos-462.json
+++ b/src/data/research/problems/erdos-462.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-13T04:11:10.512Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "6 axioms proved, 1 remains (deep analytic)",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved ALL 6 minFac-based axioms (7→1 axioms). Only compositeSum_asymptotic remains (deep analytic NT).",
+    "builtItems": [
+      "Proved leastPrimeFactor_prime via Nat.minFac_prime",
+      "Proved leastPrimeFactor_dvd via Nat.minFac_dvd",
+      "Proved leastPrimeFactor_le via Nat.minFac_le_of_dvd",
+      "Proved leastPrimeFactor_prime_self via Nat.Prime.minFac_eq",
+      "Proved leastPrimeFactor_ge_two via minFac_prime + Prime.two_le",
+      "Proved leastPrimeFactor_le_sqrt via minFac_sq_le_self + Real.sqrt_le_sqrt"
+    ],
+    "insights": [
+      "All minFac axioms follow trivially from Mathlib: unfold leastPrimeFactor, simp away the ≤1 guard, then apply the Nat.minFac lemma",
+      "sqrt proof: minFac²≤n (Nat.minFac_sq_le_self) → sqrt(minFac²)≤sqrt(n) (Real.sqrt_le_sqrt) → minFac≤sqrt(n) (Real.sqrt_sq)"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "compositeSum_asymptotic is the only remaining axiom — deep analytic number theory, not provable from Mathlib"
+    ],
     "markdown": "# Erdős #462 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $p(n)$ denote the least prime factor of $n$. There is a constant $c>0$ such that\\[\\sum_{\\substack{n<x\\\\ n\\textrm{ not prime}}}\\frac{p(n)}{n}\\sim c\\frac{x^{1/2}}{(\\log x)^2}.\\]Is it true that there exists a constant $C>0$ such that\\[\\sum_{x\\leq n\\leq x+Cx^{1/2}(\\log x)^2}\\frac{p(n)}{n} \\gg 1\\]for all large $x$?\n\n\n\n\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #461\n- Problem #463\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -58,8 +70,8 @@
       "path": "Proofs/Erdos462Problem.lean",
       "filename": "Erdos462Problem.lean",
       "lineCount": 85,
-      "theoremCount": 0,
-      "axiomCount": 7,
+      "theoremCount": 6,
+      "axiomCount": 1,
       "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Proved ALL 6 minFac-based axioms in Erdos462Problem.lean
- Axiom count: 7 → 1 (only deep analytic asymptotic remains)
- 0 sorries

## Proofs
| Axiom | Proved Via |
|-------|-----------|
| `leastPrimeFactor_prime` | `Nat.minFac_prime` |
| `leastPrimeFactor_dvd` | `Nat.minFac_dvd` |
| `leastPrimeFactor_le` | `Nat.minFac_le_of_dvd` |
| `leastPrimeFactor_prime_self` | `Nat.Prime.minFac_eq` |
| `leastPrimeFactor_ge_two` | `minFac_prime` + `Prime.two_le` |
| `leastPrimeFactor_le_sqrt` | `minFac_sq_le_self` + `Real.sqrt_le_sqrt` |

## Remaining
- `compositeSum_asymptotic`: deep analytic number theory (Erdős–Graham asymptotics), not provable from Mathlib

## Files Modified
- `proofs/Proofs/Erdos462Problem.lean`
- `src/data/proofs/erdos-462/meta.json`
- `src/data/research/problems/erdos-462.json`

🤖 Generated by researcher-4