### PR TITLE
Enrich abel-ruffini: fix schema + deepen A₅ annotation

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -80,7 +80,7 @@
     "title": "Solvable by Radicals and Field Variables",
     "content": "An element α is 'solvable by radicals' if it can be built from the base field using field operations and nth roots. The quadratic formula is an example: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$\n\nMathlib defines this inductively via `IsSolvableByRad`, with constructors for: base field elements, arithmetic operations (+, -, ×, ÷), and radical extraction ($\\alpha \\mapsto \\alpha^{1/n}$). The intermediate field `solvableByRad F E` is the largest subfield of $E$ whose elements are all solvable by radicals over $F$.\n\nThe variable declarations introduce a universe-polymorphic framework: `F` is an arbitrary field and `E/F` is a field extension with `[Algebra F E]`. This generality means the development applies to any characteristic, though the classical Abel-Ruffini theorem is typically stated over $\\mathbb{Q}$.",
     "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over $F$. Formally, $\\alpha \\in \\text{solvableByRad}(F, E)$ iff there exists a radical tower $F = K_0 \\subset K_1 \\subset \\cdots \\subset K_m$ with $\\alpha \\in K_m$ and each $K_{i+1} = K_i(\\beta_i)$ where $\\beta_i^{n_i} \\in K_i$.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by the tower $\\mathbb{Q} \\subset \\mathbb{Q}(\\sqrt{2}) \\subset \\mathbb{Q}(\\sqrt{2}, \\sqrt{1+\\sqrt{2}})$.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": [
       "field extensions",
       "nth roots",
@@ -129,7 +129,7 @@
     "title": "The Galois Bridge Theorem",
     "content": "**Theorem**: If α is expressible using radicals, then the Galois group of its minimal polynomial is solvable.\n\nThis is the key bridge: radical solvability (field theory) → group solvability (group theory).\n\nThe Lean proof is a one-liner: `solvableByRad.isSolvable' hq hroot hrad`. Internally, Mathlib proves this by induction on the `IsSolvableByRad` construction: each radical step $K_i \\to K_i(\\sqrt[n]{a})$ yields a cyclic (hence abelian) Galois group quotient, and a group built from abelian quotients is solvable. The hypotheses `hq : Irreducible q`, `hroot : aeval α q = 0`, and `hrad : IsSolvableByRad F α` are passed directly to Mathlib's lemma — the theorem is a pedagogical wrapper making the bridge explicit.",
     "mathContext": "$\\alpha \\in \\text{solvableByRad}(F, E) \\Rightarrow \\text{IsSolvable}(\\text{Gal}(\\text{minpoly}_F(\\alpha)))$\n\nContrapositive (used in `not_solvable_by_rad_of_not_solvable_gal`): $\\neg\\text{IsSolvable}(\\text{Gal}(q)) \\Rightarrow \\neg\\text{IsSolvableByRad}\\,F\\,\\alpha$.\n\nThe converse ($\\Leftarrow$) also holds: given a solvable Galois group, one constructs a radical tower from the composition series $\\{e\\} = G_n \\triangleleft \\cdots \\triangleleft G_0 = G$ where each $G_i/G_{i+1}$ is cyclic, using Kummer theory to extract the radical at each step.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": [
       "field extensions",
       "Galois theory",
@@ -172,7 +172,7 @@
       "startLine": 77,
       "endLine": 84
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The Cardinal Bridge: From ℕ to Lean's Type Universe",
     "content": "The proof of symmetric_group_not_solvable bridges between ℕ (where 5 ≤ n lives) and Cardinal (where Mathlib's Equiv.Perm.not_solvable expects 5 ≤ Cardinal.mk α). Step 1: simp rewrites Cardinal.mk (Fin n) as ↑n. Step 2: exact_mod_cast strips the cast and applies hn. The ℕ → Cardinal coercion is an order embedding, so inequalities transfer automatically. This 3-line pattern recurs in AbelRuffiniOQ04.lean.",
     "mathContext": "$5 \\leq n$ in $\\mathbb{N}$ $\\xrightarrow{\\text{cast}}$ $\\uparrow 5 \\leq \\uparrow n$ in Cardinal $\\xleftarrow{\\text{simp}}$ $5 \\leq |\\text{Fin}\\,n|$. The cast $\\mathbb{N} \\hookrightarrow \\text{Cardinal}$ is an order embedding.",
@@ -222,9 +222,9 @@
     },
     "type": "theorem",
     "title": "A₅ is Simple",
-    "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A₅ is simple - it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A₅.",
+    "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A\u2085 is simple \u2014 it's the smallest non-abelian simple group, with |A\u2085| = 60 = 5!/2.\n\n**Conjugacy class proof:** A\u2085 has five conjugacy classes of sizes 1, 12, 12, 15, 20 (corresponding to: identity, two classes of 5-cycles, products of two disjoint transpositions, and 3-cycles). Any normal subgroup must be a union of conjugacy classes including {e}, and its order must divide 60. No sub-sum of {1, 12, 12, 15, 20} starting with 1 divides 60 except 1 and 60 itself \u2014 so A\u2085 has no proper nontrivial normal subgroups.\n\n**Burnside context:** |A\u2085| = 60 = 2\u00b2\u00b73\u00b75 involves three distinct primes. Burnside's p^a q^b theorem (1904) shows every group of order p^a q^b (two primes) is solvable. A\u2085 is the smallest group escaping this criterion.\n\n**Feit-Thompson connection:** The odd-order theorem (1963) proves every group of odd order is solvable. This means any non-solvable group must have even order, and combined with Burnside's theorem, the constraints require |G| to be even and divisible by at least three primes \u2014 60 is the smallest such order admitting a simple group.\n\n**Geometric incarnation:** A\u2085 \u2245 the rotation group of the regular icosahedron (60 rotational symmetries). Klein (1884) exploited this isomorphism to solve the general quintic via the icosahedral equation, showing the quintic IS solvable using functions adapted to icosahedral symmetry \u2014 bypassing the radical barrier.",
     "mathContext": "$A_5 = \\ker(\\text{sign} : S_5 \\to \\{\\pm 1\\}) = \\{\\sigma \\in S_5 : \\text{sign}(\\sigma) = +1\\}$, $|A_5| = 60 = 5!/2$.\n\nConjugacy classes: identity (1), products of two disjoint transpositions (15), 3-cycles (20), and two classes of 5-cycles (12 + 12). A normal subgroup $N \\trianglelefteq A_5$ must be a union of conjugacy classes containing $\\{e\\}$ (size 1), and $|N|$ must divide 60. The possible sub-sums starting with 1 are: $1, 1{+}15{=}16, 1{+}20{=}21, 1{+}12{=}13, 1{+}15{+}20{=}36, \\ldots$ — none divides 60 except 1 and 60 itself. Therefore $A_5$ has no proper nontrivial normal subgroups.\n\nLean: `alternatingGroup.isSimpleGroup_five : IsSimpleGroup (alternatingGroup (Fin 5))`.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": [
       "permutation groups",
       "normal subgroups",
@@ -234,7 +234,11 @@
       "alternating group",
       "simple group",
       "normal subgroup",
-      "cycle type"
+      "cycle type",
+      "Burnside p^a q^b theorem",
+      "Feit-Thompson odd-order theorem",
+      "icosahedral symmetry",
+      "classification of finite simple groups"
     ]
   },
   {
@@ -320,7 +324,7 @@
     "title": "The Abel-Ruffini Contrapositive: The Main Event",
     "content": "`not_solvable_by_rad_of_not_solvable_gal` is the logical heart of the formalization. It takes the contrapositive of `galois_bridge`: if the Galois group of an irreducible polynomial $q$ is **not** solvable and $\\alpha$ is a root, then $\\alpha$ is **not** solvable by radicals. The proof is a 2-line proof term: `intro hrad; exact hns (galois_bridge α q hq hroot hrad)` — assuming $\\alpha$ is solvable by radicals, applying the bridge to get `IsSolvable q.Gal`, and deriving a contradiction with `hns`.\n\n`exists_quintic` provides a trivial witness ($X^5$) that degree-5 polynomials exist. To complete the Abel-Ruffini theorem for a *specific* quintic, one would need to exhibit $q \\in \\mathbb{Q}[X]$ of degree 5 with $\\text{Gal}(q) \\cong S_5$. The standard example is $x^5 - x - 1$, whose Galois group over $\\mathbb{Q}$ is $S_5$ (verified by checking irreducibility mod 2 and that the discriminant has non-square part, forcing the full symmetric group).",
     "mathContext": "$\\neg\\,\\text{IsSolvable}(q.\\text{Gal}) \\Rightarrow \\neg\\,\\text{IsSolvableByRad}\\,F\\,\\alpha$.\n\nProof: Assume $\\text{IsSolvableByRad}\\,F\\,\\alpha$. By `galois_bridge`, $\\text{IsSolvable}(q.\\text{Gal})$. Contradiction with $\\neg\\,\\text{IsSolvable}(q.\\text{Gal})$. $\\square$\n\nFor the general quintic: $q = x^5 - x - 1$ over $\\mathbb{Q}$ has $\\text{Gal}(q) \\cong S_5$, so its roots are not expressible by radicals.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": [
       "galois_bridge",
       "IsSolvable",

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -658,6 +658,13 @@
       "year": "1930",
       "venue": "Springer (English translation: Frederick Ungar, 1949; 7th German edition 1966)",
       "note": "The landmark textbook that established the modern abstract algebra curriculum. van der Waerden's presentation of Galois theory as the interplay between field extensions and automorphism groups (rather than permutations of roots) became the standard framework used in this Lean formalization. His Chapter 8 contains the cleanest classical proof of Abel-Ruffini via the derived series of Sₙ"
+    },
+    {
+      "authors": "Burnside, William",
+      "title": "On groups of order p^α q^β",
+      "year": "1904",
+      "venue": "Proceedings of the London Mathematical Society, 2(1), pp. 388–392",
+      "note": "Proved that every group of order p^a q^b (two primes) is solvable, establishing that non-solvability requires at least three distinct prime factors. A₅ (order 60 = 2²·3·5) is the smallest group escaping this criterion, making the connection to Abel-Ruffini explicit: the minimal non-solvable group has exactly the structure needed to block quintic radical solutions"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Second enrichment pass for the Abel-Ruffini Theorem entry. Fixes schema violations and adds mathematical depth:

- **Schema fixes**: 3 annotations used `"significance": "critical"` (not a valid value) → `"key"`; 1 annotation used `"type": "tactic"` (not valid) → `"technique"`
- **Deepened A₅ annotation**: Expanded `ann-a5-simple` with Burnside's p^a q^b theorem context, Feit-Thompson odd-order theorem connection, and Klein's icosahedral geometric incarnation
- **New reference**: Added Burnside (1904) to bibliography (referenced in conclusion but previously missing)
- **relatedConcepts**: Added Burnside theorem, Feit-Thompson, icosahedral symmetry, CFSG

## Test plan
- [x] JSON validates
- [x] `pnpm annotations:build` passes for this entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)