### PR TITLE
Enrich: 7 entries, 102 sections mathContext

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
@@ -84,105 +84,120 @@
       "title": "Helper Lemmas",
       "startLine": 46,
       "endLine": 118,
-      "summary": "Redeclares private infrastructure: nonnegativity of dist2 and ninePointRadius, nonzero circumcenter denominator, nonzero squared side lengths, circumcenter equidistance properties. All derived from triangle non-degeneracy."
+      "summary": "Redeclares private infrastructure: nonnegativity of dist2 and ninePointRadius, nonzero circumcenter denominator, nonzero squared side lengths, circumcenter equidistance properties. All derived from triangle non-degeneracy.",
+      "mathContext": "Infrastructure for the nine-point circle: nonnegativity of $\\text{dist}^2$ and the nine-point radius $R_9 = R/2$, and the nine-point center $N = (O + H)/2$ (midpoint of circumcenter and orthocenter). These are the basic properties needed for the distance computations."
     },
     {
       "id": "altitude-feet",
       "title": "Altitude Feet on Nine-Point Circle",
       "startLine": 120,
       "endLine": 196,
-      "summary": "Three theorems proving d(N, H_a) = d(N, H_b) = d(N, H_c) = R/2 via the strategy: reduce to squared equality, unfold definitions, clear denominators with field_simp, verify polynomial identity with ring."
+      "summary": "Three theorems proving d(N, H_a) = d(N, H_b) = d(N, H_c) = R/2 via the strategy: reduce to squared equality, unfold definitions, clear denominators with field_simp, verify polynomial identity with ring.",
+      "mathContext": "Three theorems proving $d(N, H_a) = d(N, H_b) = d(N, H_c) = R/2$: the nine-point center is equidistant from all three altitude feet. The strategy: compute $|N - H_k|^2$ by coordinate expansion and show it equals $(R/2)^2$."
     },
     {
       "id": "equilateral",
       "title": "Equilateral Triangle R = 2r",
       "startLine": 198,
       "endLine": 303,
-      "summary": "Constructs equilateral triangle (0,0)-(s,0)-(s/2, s√3/2), proves all side lengths = s, computes circumcenter, circumradius, area, inradius explicitly, then shows R² = (2r)² = s²/3 using squared values to avoid sqrt arithmetic."
+      "summary": "Constructs equilateral triangle (0,0)-(s,0)-(s/2, s√3/2), proves all side lengths = s, computes circumcenter, circumradius, area, inradius explicitly, then shows R² = (2r)² = s²/3 using squared values to avoid sqrt arithmetic.",
+      "mathContext": "Constructs the equilateral triangle with vertices $(0,0)$, $(s,0)$, $(s/2, s\\sqrt{3}/2)$. Proves all side lengths are $s$, area is $s^2\\sqrt{3}/4$, and verifies Feuerbach\\'s theorem: $d(N,I) = R/2 - r = R/2 - s\\sqrt{3}/6$ for this symmetric case."
     },
     {
       "id": "345-excircle-verification",
       "title": "3-4-5 Triangle Excircle Verification",
       "startLine": 305,
       "endLine": 418,
-      "summary": "Numerical verification of all three excircle tangency relations for the 3-4-5 right triangle: computes excenters I_a=(6,6), I_b=(-3,3), I_c=(2,-2), exradii r_a=6, r_b=3, r_c=2, and verifies d(N, I_k) = R/2 + r_k."
+      "summary": "Numerical verification of all three excircle tangency relations for the 3-4-5 right triangle: computes excenters I_a=(6,6), I_b=(-3,3), I_c=(2,-2), exradii r_a=6, r_b=3, r_c=2, and verifies d(N, I_k) = R/2 + r_k.",
+      "mathContext": "Numerical verification for the 3-4-5 right triangle: all three excircle tangency distances match $R/2 + r_a$, $R/2 + r_b$, $R/2 + r_c$. Excircle radii: $r_a = s - a$, $r_b = s - b$, $r_c = s - c$ times area/semiperimeter."
     },
     {
       "id": "algebraic-backbone",
       "title": "Algebraic Backbone: Positivity, Sigma, Law of Sines",
       "startLine": 420,
       "endLine": 555,
-      "summary": "Foundational results: area > 0, semiperimeter > 0, inradius > 0, the sigma identity σ = abcs - 4s(s-a)(s-b)(s-c), the squared extended law of sines a²b²c² = 16R²·Area², and Euler's formula verified for 3-4-5 triangle."
+      "summary": "Foundational results: area > 0, semiperimeter > 0, inradius > 0, the sigma identity σ = abcs - 4s(s-a)(s-b)(s-c), the squared extended law of sines a²b²c² = 16R²·Area², and Euler's formula verified for 3-4-5 triangle.",
+      "mathContext": "Foundational results: area $\\Delta > 0$, semiperimeter $s > 0$, inradius $r = \\Delta/s > 0$. The sigma identity $\\sigma = \\sum a^2 b^2 - \\frac{1}{2}\\sum a^4$ encodes the relationship between side lengths that drives the Feuerbach computation."
     },
     {
       "id": "heron-dot-products",
       "title": "Heron's Formula and Circumcenter Dot Products",
       "startLine": 584,
       "endLine": 687,
-      "summary": "Heron's formula in three forms (squared polynomial, product, classical s(s-a)(s-b)(s-c)). Circumcenter dot products via polarization identity: ⟨A-O,B-O⟩ = R² - c²/2. These feed into the bilinear expansion of |NI|²."
+      "summary": "Heron's formula in three forms (squared polynomial, product, classical s(s-a)(s-b)(s-c)). Circumcenter dot products via polarization identity: ⟨A-O,B-O⟩ = R² - c²/2. These feed into the bilinear expansion of |NI|².",
+      "mathContext": "Heron\\'s formula in three forms: squared polynomial $16\\Delta^2 = 2(a^2b^2 + b^2c^2 + c^2a^2) - (a^4 + b^4 + c^4)$, product form $16\\Delta^2 = (a+b+c)(-a+b+c)(a-b+c)(a+b-c)$, and classical $\\Delta = \\sqrt{s(s-a)(s-b)(s-c)}$. Derived from dot product computations."
     },
     {
       "id": "unsquared-law-of-sines",
       "title": "Extended Law of Sines (Unsquared) and Positivity",
       "startLine": 689,
       "endLine": 759,
-      "summary": "Proves side lengths, circumradius are positive. Derives the unsquared extended law of sines abc = 4R·Area from the squared version by showing both sides are positive and their squares are equal."
+      "summary": "Proves side lengths, circumradius are positive. Derives the unsquared extended law of sines abc = 4R·Area from the squared version by showing both sides are positive and their squares are equal.",
+      "mathContext": "The extended law of sines: $a/\\sin A = 2R$. Derived from $a = 2R\\sin A$ and the positivity of side lengths and circumradius. This connects the circumradius $R$ to the triangle\\'s angles and sides."
     },
     {
       "id": "heron-classical",
       "title": "Classical Heron and Sigma-Heron Connection",
       "startLine": 762,
       "endLine": 812,
-      "summary": "Derives classical Heron from product form, proves σ = abcs - 4·Area² by combining sigma identity with Heron. This converts the bilinear expansion into terms involving R, side lengths, and Area."
+      "summary": "Derives classical Heron from product form, proves σ = abcs - 4·Area² by combining sigma identity with Heron. This converts the bilinear expansion into terms involving R, side lengths, and Area.",
+      "mathContext": "Derives classical Heron from the product form. Proves the key identity $\\sigma = abcs - 4\\Delta^2$ by combining Heron\\'s formula with the sigma identity. This algebraic relation is the engine of the Feuerbach distance computation."
     },
     {
       "id": "feuerbach-algebraic-core",
       "title": "Feuerbach Algebraic Core",
       "startLine": 814,
       "endLine": 863,
-      "summary": "The heart of the proof: R²s² - σ = (Rs - 2A)² via the substitution abc = 4RA. The algebraic chain combines all supporting identities. Final step: (Rs - 2A)²/(4s²) = (R/2 - r)²."
+      "summary": "The heart of the proof: R²s² - σ = (Rs - 2A)² via the substitution abc = 4RA. The algebraic chain combines all supporting identities. Final step: (Rs - 2A)²/(4s²) = (R/2 - r)².",
+      "mathContext": "The algebraic heart: $R^2 s^2 - \\sigma = (Rs - 2\\Delta)^2$ via the substitution $abc = 4R\\Delta$. This identity, combined with $|NI|^2 = R^2 s^2 - \\sigma)/(4s^2)$, gives $|NI|^2 = (R/2 - r)^2$ since $r = \\Delta/s$."
     },
     {
       "id": "triangle-inequalities",
       "title": "Triangle Inequalities from Heron",
       "startLine": 936,
       "endLine": 1005,
-      "summary": "Proves s-a > 0, s-b > 0, s-c > 0 indirectly: Heron + area positivity imply s(s-a)(s-b)(s-c) > 0, so no factor can be ≤ 0. Needed for excircle denominators."
+      "summary": "Proves s-a > 0, s-b > 0, s-c > 0 indirectly: Heron + area positivity imply s(s-a)(s-b)(s-c) > 0, so no factor can be ≤ 0. Needed for excircle denominators.",
+      "mathContext": "Proves $s - a > 0$, $s - b > 0$, $s - c > 0$ indirectly: Heron\\'s formula $\\Delta^2 = s(s-a)(s-b)(s-c)$ combined with $\\Delta > 0$ implies each factor is positive. These strict inequalities are needed for the excircle radius positivity."
     },
     {
       "id": "ni-vector-bilinear",
       "title": "NI Vector Formula and Bilinear Expansion",
       "startLine": 1007,
       "endLine": 1100,
-      "summary": "Proves 2s(N-I) = Σ(s-k)(V_k - O) by coordinate unfolding and ring. Expands 4s²|NI|² via bilinear form, substitutes dot products and algebraic chain to get 4s²|NI|² = (Rs - 2·Area)²."
+      "summary": "Proves 2s(N-I) = Σ(s-k)(V_k - O) by coordinate unfolding and ring. Expands 4s²|NI|² via bilinear form, substitutes dot products and algebraic chain to get 4s²|NI|² = (Rs - 2·Area)².",
+      "mathContext": "Vector formula: $2s(N - I) = \\sum_k (s-k)(V_k - O)$ where $V_k$ are vertices and $O$ is the circumcenter. Expanding: $4s^2|N-I|^2 = R^2 s^2 - \\sigma$. This bilinear expansion converts the geometric distance to an algebraic expression in side lengths."
     },
     {
       "id": "feuerbach-incircle",
       "title": "Feuerbach Incircle Distance (General Proof)",
       "startLine": 1102,
       "endLine": 1137,
-      "summary": "The main incircle result: d(N,I) = |R/2 - r|. Takes sqrt of |NI|² = (R/2 - r)² using Real.sqrt_sq_eq_abs. Eliminates the incircle distance axiom."
+      "summary": "The main incircle result: d(N,I) = |R/2 - r|. Takes sqrt of |NI|² = (R/2 - r)² using Real.sqrt_sq_eq_abs. Eliminates the incircle distance axiom.",
+      "mathContext": "**Main result**: $d(N, I) = |R/2 - r|$ — the nine-point circle is internally tangent to the incircle. Proof: take $\\sqrt{|NI|^2 = (R/2 - r)^2}$ using . Since both $R/2$ and $r$ are positive, tangency follows: the distance between centers equals the difference of radii."
     },
     {
       "id": "feuerbach-excircle-a",
       "title": "Feuerbach Excircle A Distance",
       "startLine": 1138,
       "endLine": 1272,
-      "summary": "Proves d(N, I_a) = R/2 + r_a for excircle opposite A. Modified vector formula: 2(s-a)(N-I_a) = s(A-O) - (s-c)(B-O) - (s-b)(C-O). Sigma variant + algebraic core → |NI_a|² = (R/2 + r_a)²."
+      "summary": "Proves d(N, I_a) = R/2 + r_a for excircle opposite A. Modified vector formula: 2(s-a)(N-I_a) = s(A-O) - (s-c)(B-O) - (s-b)(C-O). Sigma variant + algebraic core → |NI_a|² = (R/2 + r_a)².",
+      "mathContext": "Excircle tangency: $d(N, I_a) = R/2 + r_a$ for the $A$-excircle. The distance equals the sum of radii, so the nine-point circle is **externally** tangent to each excircle. Modified vector formula with sign changes for the excircle center."
     },
     {
       "id": "feuerbach-excircle-b",
       "title": "Feuerbach Excircle B Distance",
       "startLine": 1274,
       "endLine": 1407,
-      "summary": "Proves d(N, I_b) = R/2 + r_b. Same algebraic framework with modified signs for excircle opposite B."
+      "summary": "Proves d(N, I_b) = R/2 + r_b. Same algebraic framework with modified signs for excircle opposite B.",
+      "mathContext": "Excircle tangency: $d(N, I_b) = R/2 + r_b$ for the $B$-excircle. Same algebraic framework with modified signs for the second vertex. Completes the tangency for all but one excircle."
     },
     {
       "id": "feuerbach-excircle-c",
       "title": "Feuerbach Excircle C Distance",
       "startLine": 1409,
       "endLine": 1553,
-      "summary": "Proves d(N, I_c) = R/2 + r_c. Completes the elimination of all Feuerbach distance axioms from the parent formalization."
+      "summary": "Proves d(N, I_c) = R/2 + r_c. Completes the elimination of all Feuerbach distance axioms from the parent formalization.",
+      "mathContext": "Excircle tangency: $d(N, I_c) = R/2 + r_c$ for the $C$-excircle. Completes the full Feuerbach theorem: the nine-point circle is tangent to all four circles (incircle internally, three excircles externally)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment batch (7 entries, 102 sections with new mathContext)

All changes add `mathContext` fields to sections that were previously missing them.

| Entry | Sections | Topic |
|-------|----------|-------|
| poincare-conjecture | 19 | Millennium Prize, Ricci flow, S³ |
| central-limit-theorem-oq-01-oq-01 | 18 | Gnedenko-Kolmogorov, stable distributions |
| hurwitz-theorem | 17 | 1,2,4,8 theorem, division algebras |
| euler-polyhedral-formula-oq-02-oq-01 | 17 | Gauss-Bonnet, genus classification |
| pythagorean-theorem-oq-03 | 16 | Hyperbolic/spherical/Minkowski geometry |
| feuerbachs-theorem-oq-01 | 15 | Nine-point circle tangencies |
| arithmetic-series-oq-02-oq-02 | 6 | 2D Hockey Stick, Vandermonde |