### PR TITLE
Research: erdos-100 - prove diam_ge_one + n_over_log_sublinear (0 sorries, 5 axioms)

### DIFF
--- a/proofs/Proofs/Erdos100Problem.lean
+++ b/proofs/Proofs/Erdos100Problem.lean
@@ -171,10 +171,22 @@ the diameter is at least 1 (provided n ≥ 2).
 theorem diam_ge_one (S : Finset (EuclideanSpace ℝ (Fin 2)))
     (hint : hasIntegerDistances S) (h2 : S.card ≥ 2) :
     diam S ≥ 1 := by
-  -- Since S has ≥ 2 points, any pair has integer distance ≥ 1.
-  -- The diameter (max pairwise distance) is therefore ≥ 1.
-  -- This involves extracting elements from Finset and max' comparison.
-  sorry
+  -- Extract two distinct points from S
+  obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp (by omega : 1 < S.card)
+  -- Their distance is a positive integer ≥ 1
+  obtain ⟨k, hk_ge, hk_eq⟩ := hint a ha b hb hab
+  have hdist_ge1 : dist a b ≥ 1 := by rw [hk_eq]; exact_mod_cast hk_ge
+  have hdist_pos : dist a b > 0 := by linarith
+  -- dist a b ∈ pairwiseDistances S
+  have hmem : dist a b ∈ pairwiseDistances S := by
+    unfold pairwiseDistances
+    exact Finset.mem_filter.mpr
+      ⟨Finset.mem_image.mpr ⟨(a, b), Finset.mem_offDiag.mpr ⟨ha, hb, hab⟩, rfl⟩, hdist_pos⟩
+  -- diam S = max' (pairwiseDistances S) ... ≥ dist a b ≥ 1
+  have hne : (pairwiseDistances S).Nonempty := ⟨_, hmem⟩
+  unfold diam
+  rw [dif_pos hne]
+  exact le_trans hdist_ge1 (Finset.le_max' _ _ hmem)
 
 /--
 **Kanold's Bound**
@@ -335,9 +347,29 @@ n/log n = o(n) as n → ∞.
 
 For any ε > 0, we have n/log n < εn for sufficiently large n.
 -/
-axiom n_over_log_sublinear :
-  ∀ (ε : ℝ), ε > 0 → ∀ᶠ n : ℕ in atTop,
-    (n : ℝ) / Real.log n < ε * n
+theorem n_over_log_sublinear :
+    ∀ (ε : ℝ), ε > 0 → ∀ᶠ n : ℕ in atTop,
+      (n : ℝ) / Real.log n < ε * n := by
+  intro ε hε
+  -- log n → ∞ for natural n
+  have hlog_nat : Tendsto (fun n : ℕ => Real.log (n : ℝ)) atTop atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  -- Eventually log n > 1/ε (since log n → ∞)
+  filter_upwards [hlog_nat.eventually (eventually_gt_atTop (1 / ε)),
+                   Filter.eventually_ge_atTop 3] with n hlog_n hn
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by positivity
+  have hlog_pos : 0 < Real.log (n : ℝ) := by
+    calc 0 < 1 / ε := by positivity
+      _ < Real.log (n : ℝ) := hlog_n
+  -- log n > 1/ε implies ε * log n > 1, so ε * n * log n > n
+  rw [div_lt_iff₀ hlog_pos]
+  have hprod : 1 < ε * Real.log (n : ℝ) := by
+    have key : ε * (1 / ε) < ε * Real.log (n : ℝ) := mul_lt_mul_of_pos_left hlog_n hε
+    rw [one_div, mul_inv_cancel₀ (ne_of_gt hε)] at key
+    exact key
+  calc (n : ℝ) = (n : ℝ) * 1 := (mul_one _).symm
+    _ < (n : ℝ) * (ε * Real.log (n : ℝ)) := mul_lt_mul_of_pos_left hprod hn_pos
+    _ = ε * (n : ℝ) * Real.log (n : ℝ) := by ring
 
 /-
 ## Historical Development

--- a/src/data/proofs/erdos-100/meta.json
+++ b/src/data/proofs/erdos-100/meta.json
@@ -16,13 +16,13 @@
       "combinatorial-geometry"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 100,
     "erdosUrl": "https://erdosproblems.com/100",
     "erdosProblemStatus": "open",
-    "axiomCount": 6,
-    "lineCount": 354,
-    "assumptions": "6 axioms: distinctDistances_le_diam (bridge lemma), kanold_bound, guthKatz_distinct_distances, piepmeyer_construction, erdos_anning_theorem, n_over_log_sublinear. 1 sorry: diam_ge_one (trivial bound). Open problem - linear diameter growth conjectured."
+    "axiomCount": 5,
+    "lineCount": 386,
+    "assumptions": "5 axioms: distinctDistances_le_diam (bridge lemma), kanold_bound, guthKatz_distinct_distances, piepmeyer_construction, erdos_anning_theorem. 0 sorries. n_over_log_sublinear proved from Real.tendsto_log_atTop. Open problem - linear diameter growth conjectured."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in the early 1990s as part of his extensive program on distance problems in discrete and combinatorial geometry. The question asks whether imposing integer-distance constraints on planar point sets forces the diameter to grow linearly with n. This connects to a rich tradition beginning with Erdős's 1946 paper on distinct distances, where he conjectured that n points in the plane determine at least ~n/√(log n) distinct distances. Kanold obtained the first non-trivial lower bound of n^(3/4) on the diameter using combinatorial counting. The landscape changed dramatically when Guth and Katz (2015) resolved Erdős's distinct distances conjecture up to a logarithmic factor, proving ≥ cn/log n distinct distances; this immediately implies diam ≥ cn/log n for restricted distance sets. On the upper-bound side, Piepmeyer constructed 9 points in the plane with all pairwise distances positive integers and diameter less than 5, showing the strong conjecture diam ≥ n-1 fails for small n. The problem also connects to the Erdős-Anning theorem (1945): any infinite set of points with all mutual distances integers must be collinear. The gap between n/log n and n remains one of the central open problems in combinatorial geometry.",
@@ -109,7 +109,7 @@
       "title": "Implications and Sublinearity",
       "summary": "Conjecture implies Kanold; Guth-Katz bound is sublinear (o(n))",
       "startLine": 299,
-      "endLine": 354
+      "endLine": 386
     }
   ],
   "conclusion": {
@@ -155,9 +155,9 @@
     "imports": ["Mathlib"],
     "opens": ["Filter", "Set", "Finset", "Topology"],
     "namespace": "Erdos100",
-    "lineCount": 354,
-    "axiomCount": 6,
-    "theoremCount": 8,
+    "lineCount": 386,
+    "axiomCount": 5,
+    "theoremCount": 9,
     "definitionCount": 9
   }
 }


### PR DESCRIPTION
## Summary
- Proved `diam_ge_one` (sorry eliminated): extract two points via `Finset.one_lt_card`, show their distance ∈ `pairwiseDistances`, then `Finset.le_max'` gives diam ≥ dist ≥ 1
- Proved `n_over_log_sublinear` (axiom → theorem): `log n → ∞` via `Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop` implies eventually `ε * log n > 1`, hence `n / log n < ε * n`
- File now: 386 lines, 9 theorems, 5 axioms, 0 sorries

## Stats
| Metric | Before | After |
|--------|--------|-------|
| Sorries | 1 | **0** |
| Axioms | 6 | **5** |
| Theorems | 8 | **9** |
| Lines | 354 | 386 |

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.Erdos100Problem`)
- [x] Gallery meta.json updated
- [x] Research problem JSON updated

🤖 Generated by researcher-5