### PR TITLE
Research: erdos-848 - prove mod25_achieves (0 sorries, 6 axioms)

### DIFF
--- a/proofs/Proofs/Erdos848Problem.lean
+++ b/proofs/Proofs/Erdos848Problem.lean
@@ -39,10 +39,16 @@ axiom maxNonSqfreeSet_le (N : ℕ) : maxNonSqfreeSet N ≤ N
 /- ## Known Results -/
 
 /-- The set {n ∈ {1,...,N} : n ≡ 7 (mod 25)} achieves the property:
-    for a ≡ b ≡ 7 (mod 25), ab + 1 ≡ 50 ≡ 0 (mod 25), so 5² | ab + 1. -/
-axiom mod25_achieves :
+    for a ≡ b ≡ 7 (mod 25), ab + 1 ≡ 50 ≡ 0 (mod 25), so 5² | ab + 1.
+    Proof: a*b ≡ 7*7 = 49 ≡ -1 (mod 25), so a*b+1 ≡ 0 (mod 25). -/
+theorem mod25_achieves :
   ∀ a b : ℕ, a % 25 = 7 → b % 25 = 7 →
-    5 * 5 ∣ a * b + 1
+    5 * 5 ∣ a * b + 1 := by
+  intro a b ha hb
+  show 25 ∣ a * b + 1
+  have : (a * b + 1) % 25 = 0 := by
+    rw [Nat.add_mod, Nat.mul_mod, ha, hb]; norm_num
+  exact Nat.dvd_of_mod_eq_zero this
 
 /-- This gives a lower bound: maxNonSqfreeSet(N) ≥ ⌊N/25⌋. -/
 axiom lower_bound (N : ℕ) (hN : 25 ≤ N) :

--- a/src/data/proofs/erdos-848/meta.json
+++ b/src/data/proofs/erdos-848/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 848,
     "erdosUrl": "https://erdosproblems.com/848",
     "erdosProblemStatus": "solved",
-    "axiomCount": 7,
+    "axiomCount": 6,
     "assumptions": "7 axiom declarations: maxNonSqfreeSet (extremal function definition), maxNonSqfreeSet_le (trivial upper bound), mod25_achieves (5^2 divides ab+1 mod 25), lower_bound (N/25 lower bound), vanDoorn_upper_bound (0.108N upper bound), sawhney_solution (exact answer N/25), sawhney_structure (extremal set uniqueness)",
     "lineCount": 71,
     "dateAdded": "2026-02-10",

--- a/src/data/research/problems/erdos-848.json
+++ b/src/data/research/problems/erdos-848.json
@@ -29,9 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved mod25_achieves (7→6 axioms). Remaining 6 axioms are deep results (maxNonSqfreeSet definition, bounds, Sawhney solution).",
+    "builtItems": [
+      "Proved mod25_achieves: a≡b≡7(mod 25) implies 25|ab+1, via Nat.mul_mod+Nat.add_mod+norm_num"
+    ],
+    "insights": [
+      "mod25_achieves is pure modular arithmetic: 7*7=49≡-1(mod 25), so ab+1≡0(mod 25)"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #848 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs the maximum size of a set $A\\subseteq \\{1,\\ldots,N\\}$ such that $ab+1$ is never squarefree (for all $a,b\\in A$) achieved by taking those $n\\equiv 7\\pmod{25}$?\n\n\n\nA problem of Erd\\H{o}s and S\\'{a}rk\\\"{o}zy.\n\nvan Doorn has sent the following argument which shows\\[\\lvert A\\rvert \\leq (0.108\\cdots+o(1))N.\\]The condition implies, in particular, that $a^2+1$ is divisible by $p^2$ for some prime $p$ for all $a\\in A$. Furthermore, $a^2+1\\equiv 0\\pmod{p^2}$ has either $2$ or $0$ solutions, according to whether $p\\equiv 1\\pmod{4}$ or $p\\equiv 3\\pmod{4}$. It follows that every $a\\in A$ belongs to one of $2$ residue classes for some prime $p\\equiv 1\\pmod{4}$, and hence, as $N\\to \\infty$,\\[\\frac{\\lvert A\\rvert}{N}\\leq 2\\sum_{p\\equiv 1\\pmod{4}}\\frac{1}{p^2}\\approx 0.108.\\]Weisenberg has noted that this proof in fact gives the slightly better constant of $\\approx 0.105$ (see the comments section).\n\nThis was solved for all sufficiently large $N$ by Sawhney in this note. In fact, Sawhney proves something slightly stronger, that there exists some constant $c>0$ such that if $\\lvert A\\rvert \\geq (\\frac{1}{25}-c)N$ and $N$ is large then $A$ is contained in either $\\{ n\\equiv 7\\pmod{25}\\}$ or $\\{n\\equiv 18\\pmod{25}\\}$.\n\nSee also [844].\n\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #844\n- Problem #847\n- Problem #849\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
@@ -58,8 +62,8 @@
       "path": "Proofs/Erdos848Problem.lean",
       "filename": "Erdos848Problem.lean",
       "lineCount": 72,
-      "theoremCount": 0,
-      "axiomCount": 7,
+      "theoremCount": 1,
+      "axiomCount": 6,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Proved `mod25_achieves`: for a ≡ b ≡ 7 (mod 25), 25 divides ab+1
- Proof: 7×7 = 49 ≡ -1 (mod 25), so ab+1 ≡ 0 (mod 25)
- Axiom count: 7 → 6

## Files Modified
- `proofs/Proofs/Erdos848Problem.lean`
- `src/data/proofs/erdos-848/meta.json`
- `src/data/research/problems/erdos-848.json`

🤖 Generated by researcher-4