### PR TITLE
Replace axiomatized MeasurableSpace with cylinder sigma-algebra (#5281)

### DIFF
--- a/proofs/Proofs/OSBridge.lean
+++ b/proofs/Proofs/OSBridge.lean
@@ -67,22 +67,22 @@ abbrev ETestFunctionC := SchwartzMap ESpaceTime ℂ
     Schwartz space with the weak-* topology.
 
     In Douglas et al., this carries the cylinder sigma-algebra from the bochner
-    library (Minlos.NuclearSpace). We axiomatize the MeasurableSpace instance
-    since we don't have that dependency. -/
+    library (Minlos.NuclearSpace). We define the cylinder sigma-algebra directly
+    using standard Mathlib primitives. -/
 abbrev EFieldConfiguration := WeakDual ℝ (SchwartzMap ESpaceTime ℝ)
 
-/-- Axiomatized MeasurableSpace on field configurations.
+/-- The cylinder sigma-algebra on field configurations: the smallest sigma-algebra
+    making all evaluation maps omega -> omega(f) measurable.
+    This is the standard sigma-algebra for probability measures on duals of
+    nuclear spaces (see Glimm-Jaffe, Ch. 6; Douglas et al. arXiv:2603.15770). -/
+instance fieldConfigMeasurableSpace : MeasurableSpace EFieldConfiguration :=
+  ⨆ f : ETestFunction, (borel ℝ).comap (fun ω : EFieldConfiguration => ω f)
 
-    The correct sigma-algebra is the cylinder sigma-algebra: the smallest
-    sigma-algebra making all evaluation maps w -> w(f) measurable. In
-    Douglas et al. this is provided by the bochner library. We axiomatize
-    it here.
-
-    This is mathematically sound: the cylinder sigma-algebra exists and is
-    well-defined for any topological vector space. -/
-axiom fieldConfigMeasurableSpace : MeasurableSpace EFieldConfiguration
-
-attribute [instance] fieldConfigMeasurableSpace
+/-- Evaluation maps are measurable w.r.t. the cylinder sigma-algebra. -/
+theorem eval_measurable (f : ETestFunction) :
+    Measurable (fun ω : EFieldConfiguration => ω f) := by
+  rw [measurable_iff_comap_le]
+  exact le_iSup (fun g => (borel ℝ).comap (fun ω : EFieldConfiguration => ω g)) f
 
 /- ## Distribution Pairing
 


### PR DESCRIPTION
## Summary
- Replaces `axiom fieldConfigMeasurableSpace` with a concrete `instance` using the cylinder sigma-algebra (`iSup` of `(borel R).comap (fun omega => omega f)` over all test functions `f`)
- Adds `eval_measurable` theorem proving evaluation maps are measurable w.r.t. the cylinder sigma-algebra
- Axiom count in OSBridge.lean decreases from 8 to 7
- All downstream definitions (`generatingFunctional`, `schwingerFunction`, OS axioms, `millennium_prize_from_continuum_limit`) compile unchanged

Closes #5281

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.OSBridge`
- [x] `axiom fieldConfigMeasurableSpace` removed, concrete `instance` added
- [x] `eval_measurable` proved without sorry
- [x] All downstream definitions still compile (verified by successful build)
- [x] Axiom count reduced by exactly 1 (8 -> 7)

Generated with [Claude Code](https://claude.com/claude-code)