### PR TITLE
Enrich batch: erdos-106 sections, erdos-28/332/347/273/278 full enrichment

### DIFF
--- a/proofs/Proofs/Erdos335Problem.lean
+++ b/proofs/Proofs/Erdos335Problem.lean
@@ -20,6 +20,9 @@ d(A + B) = d(A) + d(B).
 import Mathlib.Data.Real.Basic
 import Mathlib.Order.Filter.Basic
 import Mathlib.Data.Set.Card
+import Mathlib.Data.Set.Finite.Lattice
+import Mathlib.Topology.Basic
+import Mathlib.Topology.Order.Basic
 import Mathlib.Tactic
 
 open Set Filter
@@ -32,7 +35,7 @@ noncomputable def countingFn (A : Set ℕ) (N : ℕ) : ℕ :=
 
 /-- The asymptotic density of A ⊆ ℕ: lim_{N→∞} |A ∩ [1,N]| / N. -/
 noncomputable def asympDensity (A : Set ℕ) : ℝ :=
-  Filter.limUnder atTop (fun N => (countingFn A N : ℝ) / N)
+  limUnder atTop (fun N => (countingFn A N : ℝ) / N)
 
 /-- The density exists (the limit converges). -/
 def DensityExists (A : Set ℕ) : Prop :=
@@ -96,16 +99,40 @@ axiom erdos_335_conjecture :
 
 /- ## Basic Properties -/
 
-/-- Density is non-negative. -/
-axiom density_nonneg (A : Set ℕ) : asympDensity A ≥ 0
+/-- Density is non-negative (when the density exists). -/
+theorem density_nonneg (A : Set ℕ) (hA : DensityExists A) : asympDensity A ≥ 0 := by
+  obtain ⟨d, hd⟩ := hA
+  rw [show asympDensity A = d from hd.limUnder_eq]
+  exact ge_of_tendsto hd (Filter.eventually_atTop.mpr ⟨0, fun N _ =>
+    div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)⟩)
+
+/-- The counting function is at most N. -/
+private lemma countingFn_le (A : Set ℕ) (N : ℕ) : countingFn A N ≤ N := by
+  unfold countingFn
+  calc Set.ncard (A ∩ Set.Icc 1 N)
+      ≤ Set.ncard (Set.Icc 1 N) :=
+        Set.ncard_le_ncard Set.inter_subset_right (Set.finite_Icc 1 N)
+    _ ≤ N := by
+        rw [Set.ncard_eq_toFinset_card']
+        simp only [Set.toFinset_Icc, Nat.card_Icc]
+        omega
 
 /-- Density is at most 1. -/
-axiom density_le_one (A : Set ℕ) (hA : DensityExists A) : asympDensity A ≤ 1
+theorem density_le_one (A : Set ℕ) (hA : DensityExists A) : asympDensity A ≤ 1 := by
+  obtain ⟨d, hd⟩ := hA
+  rw [show asympDensity A = d from hd.limUnder_eq]
+  apply le_of_tendsto hd
+  filter_upwards [Filter.eventually_ge_atTop 1] with N hN
+  rw [div_le_one (by positivity : (0 : ℝ) < N)]
+  exact_mod_cast countingFn_le A N
 
 /-- If d(A + B) = d(A) + d(B), then d(A) + d(B) ≤ 1.
     Otherwise the sumset would have density > 1, a contradiction. -/
-axiom additive_sum_le_one (A B : Set ℕ) :
-  DensityAdditive A B → asympDensity A + asympDensity B ≤ 1
+theorem additive_sum_le_one (A B : Set ℕ) :
+    DensityAdditive A B → asympDensity A + asympDensity B ≤ 1 := by
+  intro ⟨_, _, hAB_exists, heq⟩
+  rw [← heq]
+  exact density_le_one (Sumset A B) hAB_exists
 
 /-- **Plünnecke–Ruzsa lower bound** (simplified):
     d(A + B) ≥ min(d(A) + d(B), 1) for sets with density. -/
@@ -117,6 +144,5 @@ axiom plunnecke_ruzsa_lower (A B : Set ℕ)
 /-- Density additivity implies the Plünnecke–Ruzsa bound is tight. -/
 theorem additive_implies_tight (A B : Set ℕ) (h : DensityAdditive A B) :
     asympDensity (Sumset A B) = min (asympDensity A + asympDensity B) 1 := by
-  obtain ⟨_, _, _, heq⟩ := h
   have hle := additive_sum_le_one A B h
-  rw [heq, min_eq_left hle]
+  rw [h.2.2.2, min_eq_left hle]

--- a/research/registry.json
+++ b/research/registry.json
@@ -619,11 +619,12 @@
     },
     {
       "slug": "erdos-162",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-12T09:56:05.236Z",
-      "status": "active",
-      "lastUpdate": "2026-03-13T07:52:17.043Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:50:15.386Z",
+      "completed": "2026-03-23T20:50:15.386Z"
     },
     {
       "slug": "erdos-180",
@@ -1004,11 +1005,12 @@
     },
     {
       "slug": "erdos-361",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-13T00:56:39.043Z",
-      "status": "active",
-      "lastUpdate": "2026-03-13T07:52:17.046Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:50:15.351Z",
+      "completed": "2026-03-23T20:50:15.351Z"
     },
     {
       "slug": "erdos-369",
@@ -1316,11 +1318,12 @@
     },
     {
       "slug": "erdos-462",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-13T04:11:10.512Z",
-      "status": "active",
-      "lastUpdate": "2026-03-13T07:52:17.049Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:50:15.353Z",
+      "completed": "2026-03-23T20:50:15.353Z"
     },
     {
       "slug": "erdos-463",
@@ -2922,11 +2925,12 @@
     },
     {
       "slug": "erdos-100",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-23T08:04:56.538Z",
-      "status": "active",
-      "lastUpdate": "2026-01-23T08:04:56.539Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:50:15.339Z",
+      "completed": "2026-03-23T20:50:15.338Z"
     },
     {
       "slug": "erdos-109",

--- a/src/data/proofs/amgm-inequality/annotations.json
+++ b/src/data/proofs/amgm-inequality/annotations.json
@@ -120,15 +120,15 @@
     ]
   },
   {
-    "id": "ann-weighted",
+    "id": "ann-weighted-general",
     "proofId": "amgm-inequality",
     "range": {
       "startLine": 134,
-      "endLine": 160
+      "endLine": 147
     },
     "type": "concept",
-    "title": "Weighted AM-GM via Mathlib's General Inequality",
-    "content": "**Weighted AM-GM**:\n\nFor weights $w_i \\geq 0$ with $\\sum_{i} w_i = 1$ and values $z_i \\geq 0$:\n$$\\prod_i z_i^{w_i} \\leq \\sum_i w_i z_i$$\n\nThe left side is the **weighted geometric mean**; the right is the **weighted arithmetic mean**. Setting $w_i = 1/n$ for all $i$ recovers the classical unweighted AM-GM.\n\n**Mathlib implementation**: `Real.geom_mean_le_arith_mean_weighted` operates over `Finset ι`, allowing arbitrary finite index sets. Internally, Mathlib proves this via the concavity of $\\log$: since $\\log$ is concave on $(0,\\infty)$, Jensen's inequality gives $\\sum w_i \\log(z_i) \\leq \\log(\\sum w_i z_i)$, and exponentiating yields the weighted AM-GM. The proof `am_gm_two_via_weighted` uses Mathlib's pre-specialized two-variable form `Real.geom_mean_le_arith_mean2_weighted` with weights $1/2$, using `convert` to bridge between Mathlib's statement and the concrete form $a^{1/2} b^{1/2} \\leq (a+b)/2$—`ring` closes the remaining arithmetic goals. Similarly, `am_gm_three` uses the pre-specialized `Real.geom_mean_le_arith_mean3_weighted`.\n\n**Schur convexity perspective**: The weighted AM-GM has a deep connection to *majorization theory*. A vector $\\mathbf{x}$ majorizes $\\mathbf{y}$ (written $\\mathbf{x} \\succeq \\mathbf{y}$) if the partial sums of $\\mathbf{x}$ sorted in decreasing order dominate those of $\\mathbf{y}$. The function $f(\\mathbf{z}) = -\\sum w_i \\log z_i$ is *Schur-convex*, meaning $\\mathbf{x} \\succeq \\mathbf{y}$ implies $f(\\mathbf{x}) \\geq f(\\mathbf{y})$. Since $\\left(\\frac{\\sum w_i z_i}{1}, 0, \\ldots\\right) \\succeq (z_1, \\ldots, z_n)$ in an appropriate sense, the AM-GM inequality follows. This viewpoint, developed by Hardy, Littlewood, and Pólya (1929), unifies AM-GM with Muirhead's inequality, the Schur inequality, and many competition results.\n\n**Design pattern**: This section illustrates a common Lean formalization strategy: prove the result elementarily for the base case (two variables), then also provide a path through Mathlib's general machinery for n-variable extensions. The two approaches serve different audiences: the elementary proof is pedagogically transparent, while the Mathlib delegation is more scalable.",
+    "title": "General Weighted AM-GM via Mathlib",
+    "content": "**Weighted AM-GM**:\n\nFor weights $w_i \\geq 0$ with $\\sum_{i} w_i = 1$ and values $z_i \\geq 0$:\n$$\\prod_i z_i^{w_i} \\leq \\sum_i w_i z_i$$\n\nThe left side is the **weighted geometric mean**; the right is the **weighted arithmetic mean**. Setting $w_i = 1/n$ for all $i$ recovers the classical unweighted AM-GM.\n\n**Mathlib implementation**: `Real.geom_mean_le_arith_mean_weighted` operates over `Finset ι`, allowing arbitrary finite index sets. Internally, Mathlib proves this via the concavity of $\\log$: since $\\log$ is concave on $(0,\\infty)$, Jensen's inequality gives $\\sum w_i \\log(z_i) \\leq \\log(\\sum w_i z_i)$, and exponentiating yields the weighted AM-GM.\n\n**Schur convexity perspective**: The weighted AM-GM has a deep connection to *majorization theory*. A vector $\\mathbf{x}$ majorizes $\\mathbf{y}$ (written $\\mathbf{x} \\succeq \\mathbf{y}$) if the partial sums of $\\mathbf{x}$ sorted in decreasing order dominate those of $\\mathbf{y}$. The function $f(\\mathbf{z}) = -\\sum w_i \\log z_i$ is *Schur-convex*, meaning $\\mathbf{x} \\succeq \\mathbf{y}$ implies $f(\\mathbf{x}) \\geq f(\\mathbf{y})$. This viewpoint, developed by Hardy, Littlewood, and Pólya (1929), unifies AM-GM with Muirhead's inequality, the Schur inequality, and many competition results.\n\n**Design pattern**: The `am_gm_weighted` theorem is a thin wrapper around Mathlib's `Real.geom_mean_le_arith_mean_weighted`, providing a clean API within the `AMGMInequality` namespace. This illustrates a common formalization pattern: expose Mathlib results through a local API to prevent name collisions and improve discoverability.",
     "mathContext": "$$\\prod_i z_i^{w_i} \\leq \\sum_i w_i z_i, \\quad \\sum_i w_i = 1, \\; z_i \\geq 0$$",
     "significance": "key",
     "relatedConcepts": [
@@ -137,16 +137,40 @@
       "Jensen's inequality",
       "Finset",
       "Real.geom_mean_le_arith_mean_weighted",
-      "Real.geom_mean_le_arith_mean2_weighted",
-      "Real.geom_mean_le_arith_mean3_weighted",
       "Schur convexity",
-      "majorization"
+      "majorization",
+      "Muirhead's inequality"
     ],
     "prerequisites": [
       "Finset",
       "weighted sums and products",
       "Jensen's inequality",
       "convex functions"
+    ]
+  },
+  {
+    "id": "ann-weighted-two-var",
+    "proofId": "amgm-inequality",
+    "range": {
+      "startLine": 149,
+      "endLine": 160
+    },
+    "type": "technique",
+    "title": "Two-Variable AM-GM via Weighted Means and convert",
+    "content": "**Recovering the two-variable case from the general form**:\n\nThe theorem `am_gm_two_via_weighted` sets weights $w_1 = w_2 = 1/2$ in Mathlib's `Real.geom_mean_le_arith_mean2_weighted` to obtain:\n$$a^{1/2} \\cdot b^{1/2} \\leq \\frac{a + b}{2}$$\n\n**The `convert` tactic pattern**: Mathlib's statement has a slightly different normal form than the desired conclusion. The `convert` tactic produces subgoals for each position where the two sides differ, and `ring` closes each arithmetic subgoal. This `convert ... using 1` + `all_goals ring` pattern is a workhorse for adapting Mathlib results to custom formulations—it avoids the need for manual term-level manipulation.\n\n**Pedagogical value**: This theorem exists alongside `am_gm_two` to demonstrate *two independent proof routes* to the same result: the elementary algebraic proof (square non-negativity) and the general machinery (convexity + Jensen's). When formalizing mathematics, having multiple proof paths increases confidence and provides different insights into the result.",
+    "mathContext": "$a^{1/2} b^{1/2} \\leq (a+b)/2$, which is $\\sqrt{ab} \\leq (a+b)/2$ since $a^{1/2} = \\sqrt{a}$ for $a \\geq 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "convert tactic",
+      "Real.geom_mean_le_arith_mean2_weighted",
+      "ring tactic",
+      "proof diversity",
+      "weight specialization"
+    ],
+    "prerequisites": [
+      "am_gm_weighted",
+      "Lean 4 convert tactic",
+      "real-valued powers"
     ]
   },
   {

--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -165,6 +165,11 @@
       "targetId": "fundamental-theorem-calculus",
       "relationship": "supports",
       "description": "The FTC underlies the proof that $-\\log$ is convex on $(0, \\infty)$: since $(-\\log x)'' = 1/x^2 > 0$, integration via FTC gives convexity, which yields Jensen's inequality for $-\\log$, the standard route to weighted AM-GM in Mathlib. Pólya's elegant proof similarly relies on the convexity of $e^x$ ($(e^x)'' = e^x > 0$)."
+    },
+    {
+      "targetId": "mean-value-theorem",
+      "relationship": "supports",
+      "description": "The MVT provides the bridge from derivative conditions to function inequalities: $f''(x) > 0$ (verified via MVT applied to $f'$) implies convexity of $f$, which yields Jensen's inequality, which proves the weighted AM-GM. Specifically, applying MVT to $f(x) = -\\log x$ gives the tangent line bound $-\\log x \\geq -\\log a - (x-a)/a$, a one-line proof of the exponential inequality $e^{x-1} \\geq x$ that Pólya used for AM-GM."
     }
   ],
   "relatedProofs": [
@@ -181,7 +186,8 @@
     "area-of-circle",
     "stirling-formula",
     "binomial-theorem",
-    "fundamental-theorem-calculus"
+    "fundamental-theorem-calculus",
+    "mean-value-theorem"
   ],
   "sections": [
     {
@@ -225,12 +231,20 @@
       "mathContext": "$(1+4)/2 = 5/2 > \\sqrt{4} = 2$; $(2+8)/2 = 5 \\geq \\sqrt{16} = 4$"
     },
     {
-      "id": "corollaries",
-      "title": "Corollaries and Applications",
+      "id": "product-sum-corollary",
+      "title": "Product-Sum Inequality",
       "startLine": 182,
+      "endLine": 194,
+      "summary": "Derives $ab \\leq ((a+b)/2)^2$ by squaring both sides of AM-GM, using `sq_le_sq'` and `Real.sq_sqrt`. This corollary is the key step in proving that the square maximizes area among rectangles with fixed perimeter.",
+      "mathContext": "$ab = (\\sqrt{ab})^2 \\leq ((a+b)/2)^2$, obtained by squaring $(a+b)/2 \\geq \\sqrt{ab}$"
+    },
+    {
+      "id": "mean-chain-and-three-var",
+      "title": "Mean Chain Alias and Three-Variable AM-GM",
+      "startLine": 196,
       "endLine": 218,
-      "summary": "Product-sum inequality $ab \\leq ((a+b)/2)^2$, alias `am_ge_gm`, and three-variable AM-GM via Mathlib's weighted form.",
-      "mathContext": "$ab \\leq ((a+b)/2)^2$ and $\\sqrt[3]{abc} \\leq (a+b+c)/3$"
+      "summary": "The `am_ge_gm` alias places AM-GM in the QM $\\geq$ AM $\\geq$ GM $\\geq$ HM chain. Then `am_gm_three` proves the three-variable case $a^{1/3}b^{1/3}c^{1/3} \\leq (a+b+c)/3$ via Mathlib's `Real.geom_mean_le_arith_mean3_weighted` with equal weights $1/3$.",
+      "mathContext": "$M_{-1} \\leq M_0 \\leq M_1 \\leq M_2$; three-variable: $\\sqrt[3]{abc} \\leq (a+b+c)/3$"
     },
     {
       "id": "check-epilogue",

--- a/src/data/proofs/angle-trisection-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02/annotations.json
@@ -103,7 +103,8 @@
       "\u2124/2\u2124 factors",
       "Fermat primes",
       "regular polygon constructibility",
-      "expressibility hierarchy"
+      "expressibility hierarchy",
+      "Kolmogorov-Arnold theorem"
     ]
   },
   {

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -174,6 +174,11 @@
       "targetId": "kroneckers-jugendtraum",
       "relationship": "extends",
       "description": "Kronecker-Weber (every abelian extension of $\\mathbb{Q}$ is contained in a cyclotomic field) explains why all constructible numbers live inside cyclotomic fields: the degree-2 tower generating a constructible number produces an abelian extension, which Kronecker-Weber places inside $\\mathbb{Q}(\\zeta_n)$ for some $n$. This connects the local geometric construction (compass-and-straightedge) to the global arithmetic of cyclotomic fields"
+    },
+    {
+      "targetId": "hilbert-13",
+      "relationship": "related",
+      "description": "Hilbert's 13th problem asked whether the solution of degree-7 equations requires functions of 3 variables after Bring-Jerrard reduction. This extends the expressibility hierarchy formalized here: constructible (2-group Galois) $\\subsetneq$ solvable by radicals (solvable Galois) $\\subsetneq$ solvable by algebraic functions of bounded variables. The Kolmogorov-Arnold theorem (1957) resolved the continuous version but the algebraic question remains open — connecting the 2-group constructibility barrier to deeper algebraic complexity"
     }
   ],
   "overview": {
@@ -321,7 +326,8 @@
     "solution-of-cubic",
     "angle-trisection-oq-02-oq-03-oq-01",
     "de-moivre",
-    "kroneckers-jugendtraum"
+    "kroneckers-jugendtraum",
+    "hilbert-13"
   ],
   "references": [
     {

--- a/src/data/proofs/erdos-106/meta.json
+++ b/src/data/proofs/erdos-106/meta.json
@@ -39,8 +39,10 @@
       "**Axis-parallel vs rotated**: BKU (2024) solved the restricted problem where all squares must be axis-aligned. The general case remains open because rotated squares could potentially create more efficient packings — though no example is known where rotation helps"
     ],
     "prerequisites": [
-      "Number theory fundamentals",
-      "Combinatorial analysis"
+      "Discrete geometry: square packing, containment constraints",
+      "Real analysis: supremum, Cauchy-Schwarz inequality",
+      "Combinatorics: Fin-indexed families, disjointness conditions",
+      "Familiarity with Lean 4 structures and Mathlib real number API"
     ]
   },
   "sections": [
@@ -49,77 +51,88 @@
       "title": "Squares in the Plane",
       "summary": "Defines the `Square` structure with center and positive side length, its interior (open) and closure (closed) sets, and the `DisjointInteriors` predicate using Lean's `Disjoint` on sets. All squares are axis-parallel.",
       "startLine": 38,
-      "endLine": 60
+      "endLine": 60,
+      "mathContext": "Square: center $(c_x, c_y) \\in \\mathbb{R}^2$, side $s > 0$. Interior: $(c_x \\pm s/2) \\times (c_y \\pm s/2)$ open."
     },
     {
       "id": "unit",
       "title": "The Unit Square",
       "summary": "Defines the unit square $[0,1]^2$ as `unitSquare` and the `ContainedInUnit` predicate requiring $\\overline{S} \\subseteq [0,1]^2$.",
       "startLine": 62,
-      "endLine": 73
+      "endLine": 73,
+      "mathContext": "Unit square $[0,1]^2$. Containment: $\\overline{S_i} \\subseteq [0,1]^2$ for each packed square."
     },
     {
       "id": "packing",
       "title": "Valid Packings",
       "summary": "The `Packing n` structure: a `Fin n`-indexed family of squares with containment and pairwise disjointness. The objective `sumSides` computes $\\sum_{i} s_i$.",
       "startLine": 75,
-      "endLine": 89
+      "endLine": 89,
+      "mathContext": "Packing: $(S_i)_{i=1}^{n}$ with $\\overline{S_i} \\subseteq [0,1]^2$ and $S_i^\\circ \\cap S_j^\\circ = \\emptyset$. Objective: $\\sum s_i$."
     },
     {
       "id": "function",
       "title": "The Function f(n)",
       "summary": "Defines $f(n) = \\sup\\{\\text{sumSides}(P)\\}$ as a supremum over valid packings. Axiomatizes the Cauchy-Schwarz bound $f(n) \\leq \\sqrt{n}$ and monotonicity $n \\leq m \\implies f(n) \\leq f(m)$.",
       "startLine": 91,
-      "endLine": 105
+      "endLine": 105,
+      "mathContext": "$f(n) = \\sup_P \\sum_{i=1}^{n} s_i$. Cauchy-Schwarz: $(\\sum s_i)^2 \\leq n \\sum s_i^2 \\leq n$, so $f(n) \\leq \\sqrt{n}$."
     },
     {
       "id": "known",
       "title": "Known Exact Values",
       "summary": "Axiomatizes the computed values: $f(1) = 1$, $f(2) = 1$ (Erdős), $f(4) = 2$, $f(5) = 2$ (Newman), $f(9) = 3$. These are the foundation for the conjecture.",
       "startLine": 107,
-      "endLine": 124
+      "endLine": 124,
+      "mathContext": "$f(1) = 1$, $f(2) = 1$, $f(4) = 2$, $f(5) = 2$, $f(9) = 3$. Pattern: $f(k^2) = k$ and $f(k^2+1) = k$."
     },
     {
       "id": "perfect",
       "title": "Perfect Squares: f(k^2) = k",
       "summary": "The general result $f(k^2) = k$ via Cauchy-Schwarz tightness. Includes the sorry'd constructive existence of the $k \\times k$ grid packing.",
       "startLine": 126,
-      "endLine": 139
+      "endLine": 139,
+      "mathContext": "$f(k^2) = k$: upper bound from Cauchy-Schwarz, lower bound from $k \\times k$ grid of side $1/k$."
     },
     {
       "id": "main",
       "title": "The Main Conjecture: f(k^2+1) = k",
       "summary": "Defines `erdos106Conjecture` ($\\forall k \\geq 1, f(k^2+1) = k$) and proves (no sorry) its equivalence to $f(k^2+1) = f(k^2)$ using `f_perfect_square`.",
       "startLine": 141,
-      "endLine": 159
+      "endLine": 159,
+      "mathContext": "Conjecture: $f(k^2+1) = k$ $\\iff$ $f(k^2+1) = f(k^2)$. One extra square cannot increase the sum."
     },
     {
       "id": "halasz",
       "title": "Halász Lower Bounds (1984)",
       "summary": "Axiomatizes Halász's constructive bounds: $f(k^2+2c+1) \\geq k + c/k$ (odd) and $f(k^2+2c) \\geq k + c/(k+1)$ (even), describing how grid modifications increase the sum.",
       "startLine": 161,
-      "endLine": 173
+      "endLine": 173,
+      "mathContext": "Halász: $f(k^2+2c+1) \\geq k + c/k$ for $0 \\leq c < k$. Split $c$ grid squares into pairs to gain $c/k$."
     },
     {
       "id": "soifer",
       "title": "The Erdős-Soifer Conjecture (1995)",
       "summary": "Defines the stronger conjecture $f(k^2+2c+1) = k + c/k$ for $|c| < k$, and axiomatizes Praton's equivalence showing it follows from the main conjecture.",
       "startLine": 175,
-      "endLine": 188
+      "endLine": 188,
+      "mathContext": "Erdős-Soifer: $f(k^2+2c+1) = k + c/k$ for $|c| < k$. Praton: equivalent to $f(k^2+1) = k$."
     },
     {
       "id": "axis",
       "title": "Axis-Parallel Case: BKU 2024",
       "summary": "Defines $g(n) = f(n)$ (axis-parallel restriction, trivially equal in this formalization) and axiomatizes the BKU theorem $g(k^2+1) = k$, the 2024 breakthrough resolving the restricted problem.",
       "startLine": 190,
-      "endLine": 200
+      "endLine": 200,
+      "mathContext": "BKU (2024): $g(k^2+1) = k$ for axis-parallel packings. Open: does rotation help, i.e., $f(n) > g(n)$?"
     },
     {
       "id": "plateau",
       "title": "Plateau Points",
       "summary": "Defines `plateauSet` $= \\{n : f(n+1) = f(n)\\}$ and proves (no sorry) that $1 \\in \\text{plateauSet}$ and that $k^2 \\in \\text{plateauSet} \\iff f(k^2+1) = k$, reformulating the conjecture.",
       "startLine": 202,
-      "endLine": 220
+      "endLine": 220,
+      "mathContext": "Plateau set: $\\{n : f(n+1) = f(n)\\}$. Proved: $1 \\in \\text{plateau}$, $k^2 \\in \\text{plateau} \\iff f(k^2+1) = k$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -29,63 +29,72 @@
       "title": "Imports and Setup",
       "startLine": 32,
       "endLine": 36,
-      "summary": "Imports from Mathlib: `InnerProductSpace.Basic` for the Euclidean metric on $\\mathbb{R}^d$, `Data.Real.Sqrt` for $\\sqrt{12n-3}$ in Harborth's formula, and general tactics."
+      "summary": "Imports from Mathlib: `InnerProductSpace.Basic` for the Euclidean metric on $\\mathbb{R}^d$, `Data.Real.Sqrt` for $\\sqrt{12n-3}$ in Harborth's formula, and general tactics.",
+      "mathContext": "Imports: `InnerProductSpace` for $\\|x - y\\|$, `Real.sqrt` for Harborth's $\\lfloor 3n - \\sqrt{12n-3} \\rfloor$."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
       "startLine": 39,
       "endLine": 53,
-      "summary": "Defines `SeparatedConfig d n` (points in $\\mathbb{R}^d$ with pairwise distance $\\ge 1$), `unitDistPairs` (edge count of unit-distance graph), and $f_d(n) = \\max$ unit pairs over all configurations."
+      "summary": "Defines `SeparatedConfig d n` (points in $\\mathbb{R}^d$ with pairwise distance $\\ge 1$), `unitDistPairs` (edge count of unit-distance graph), and $f_d(n) = \\max$ unit pairs over all configurations.",
+      "mathContext": "$f_d(n) = \\max \\{|\\{(i,j): \\|p_i - p_j\\| = 1\\}| : \\|p_i - p_j\\| \\geq 1\\}$ over $n$-point configs in $\\mathbb{R}^d$."
     },
     {
       "id": "one-dimensional-setup",
       "title": "1D Configuration and Helpers",
       "startLine": 62,
       "endLine": 72,
-      "summary": "Specialized `SeparatedConfig1D` using $\\mathbb{R}$ directly with $|x - y| \\ge 1$, avoiding the overhead of `EuclideanSpace ℝ (Fin 1)`. Enables direct absolute value case analysis."
+      "summary": "Specialized `SeparatedConfig1D` using $\\mathbb{R}$ directly with $|x - y| \\ge 1$, avoiding the overhead of `EuclideanSpace ℝ (Fin 1)`. Enables direct absolute value case analysis.",
+      "mathContext": "1D specialization: $|x_i - x_j| \\geq 1$ for $i \\neq j$, using $\\mathbb{R}$ directly."
     },
     {
       "id": "triangle-lemma",
       "title": "1D Triangle Lemma (Proved)",
       "startLine": 79,
       "endLine": 92,
-      "summary": "**Machine-verified**: If $|x-y| = |x-z| = 1$ and $|y-z| \\ge 1$, then $|y-z| = 2$. Unit neighbors of $x$ must be on opposite sides. Proof by 4-case analysis on signs of $x-y$ and $x-z$, using `abs_eq` and `linarith`."
+      "summary": "**Machine-verified**: If $|x-y| = |x-z| = 1$ and $|y-z| \\ge 1$, then $|y-z| = 2$. Unit neighbors of $x$ must be on opposite sides. Proof by 4-case analysis on signs of $x-y$ and $x-z$, using `abs_eq` and `linarith`.",
+      "mathContext": "Proved: $|x-y| = |x-z| = 1 \\wedge |y-z| \\geq 1 \\Rightarrow |y-z| = 2$. I.e., $y = x-1, z = x+1$ or vice versa."
     },
     {
       "id": "degree-bound",
       "title": "1D Degree Bound (Proved)",
       "startLine": 100,
       "endLine": 126,
-      "summary": "**Machine-verified**: A point in $\\mathbb{R}$ cannot have 3 unit neighbors among separated points. Exhausts all $2^3 = 8$ sign combinations; in each case, pigeonhole forces two neighbors equal, contradicting separation $\\ge 1$."
+      "summary": "**Machine-verified**: A point in $\\mathbb{R}$ cannot have 3 unit neighbors among separated points. Exhausts all $2^3 = 8$ sign combinations; in each case, pigeonhole forces two neighbors equal, contradicting separation $\\ge 1$.",
+      "mathContext": "Proved: $\\deg(x) \\leq 2$ in the unit-distance graph. Exhaustive $2^3 = 8$ case analysis."
     },
     {
       "id": "one-dimensional-exact",
       "title": "1D Exact Result: $f_1(n) = n-1$",
       "startLine": 136,
       "endLine": 146,
-      "summary": "Upper bound: unit-distance graph is a forest ($\\le n-1$ edges). Achievability: $\\{0, 1, \\ldots, n-1\\}$ gives $n-1$ unit pairs. Combined: $f_1(n) = n-1$."
+      "summary": "Upper bound: unit-distance graph is a forest ($\\le n-1$ edges). Achievability: $\\{0, 1, \\ldots, n-1\\}$ gives $n-1$ unit pairs. Combined: $f_1(n) = n-1$.",
+      "mathContext": "$f_1(n) = n - 1$. Upper: max degree 2 gives forest ($\\leq n-1$ edges). Lower: $\\{0,1,\\ldots,n-1\\}$."
     },
     {
       "id": "two-dimensional",
       "title": "Two-Dimensional Case",
       "startLine": 151,
       "endLine": 166,
-      "summary": "Erdős's bound $f_2(n) < 3n - c\\sqrt{n}$, Harborth's exact formula $f_2(n) = \\lfloor 3n - \\sqrt{12n-3} \\rfloor$ (1974), triangular lattice optimality, and the trivial bound $f_2(n) < 3n$ from kissing number $\\tau(2) = 6$."
+      "summary": "Erdős's bound $f_2(n) < 3n - c\\sqrt{n}$, Harborth's exact formula $f_2(n) = \\lfloor 3n - \\sqrt{12n-3} \\rfloor$ (1974), triangular lattice optimality, and the trivial bound $f_2(n) < 3n$ from kissing number $\\tau(2) = 6$.",
+      "mathContext": "$f_2(n) = \\lfloor 3n - \\sqrt{12n-3} \\rfloor$ (Harborth 1974). Trivial: $f_2(n) \\leq \\tau(2) \\cdot n/2 = 3n$."
     },
     {
       "id": "three-dimensional",
       "title": "Three-Dimensional Case",
       "startLine": 171,
       "endLine": 185,
-      "summary": "Leading coefficient $f_3(n)/n \\to 6$ from $\\tau(3) = 12$, Bezdek–Reid upper bound $f_3(n) < 6n - 0.926 n^{2/3}$ (2013), and Erdős's conjecture $f_3(n) = 6n - \\Theta(n^{2/3})$ — the central open question."
+      "summary": "Leading coefficient $f_3(n)/n \\to 6$ from $\\tau(3) = 12$, Bezdek–Reid upper bound $f_3(n) < 6n - 0.926 n^{2/3}$ (2013), and Erdős's conjecture $f_3(n) = 6n - \\Theta(n^{2/3})$ — the central open question.",
+      "mathContext": "Conjecture: $f_3(n) = 6n - \\Theta(n^{2/3})$. Known: $f_3(n) < 6n - 0.926n^{2/3}$ (Bezdek-Reid 2013)."
     },
     {
       "id": "general-dimension",
       "title": "General Dimension Bounds",
       "startLine": 190,
       "endLine": 198,
-      "summary": "Lower bound $f_d(n) \\ge (d - o(1))n$ from $\\mathbb{Z}^d$ lattice, upper bound $f_d(n) \\le 2^{O(d)} n$ from Kabatyansky–Levenshtein (1978). Exponential gap in $d$ remains open."
+      "summary": "Lower bound $f_d(n) \\ge (d - o(1))n$ from $\\mathbb{Z}^d$ lattice, upper bound $f_d(n) \\le 2^{O(d)} n$ from Kabatyansky–Levenshtein (1978). Exponential gap in $d$ remains open.",
+      "mathContext": "$dn \\lesssim f_d(n) \\leq \\tau(d) \\cdot n/2 \\leq 2^{0.401d} \\cdot n$. Exponential gap in $d$."
     }
   ],
   "overview": {
@@ -101,8 +110,10 @@
       "**Exponential gap** in general $d$: between $f_d(n) \\ge dn$ from $\\mathbb{Z}^d$ and $f_d(n) \\le 2^{O(d)} n$ from Kabatyansky–Levenshtein — closing this is a major open problem"
     ],
     "prerequisites": [
-      "Number theory fundamentals",
-      "Combinatorial analysis"
+      "Euclidean geometry: distance in $\\mathbb{R}^d$, inner product spaces",
+      "Combinatorial geometry: kissing numbers, sphere packing, lattices",
+      "Graph theory: degree bounds, extremal graph counting",
+      "Familiarity with Lean 4 and Mathlib's EuclideanSpace API"
     ]
   },
   "conclusion": {

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -77,8 +77,10 @@
       "The problem connects prime distribution (which integers are $p - 1$ for prime $p$?) to the combinatorics of residue class coverings"
     ],
     "prerequisites": [
-      "Number theory fundamentals",
-      "Combinatorial analysis"
+      "Modular arithmetic: congruences, residue classes, Chinese Remainder Theorem",
+      "Prime number theory: distribution, Mertens' theorem, sieve methods",
+      "Covering systems: construction techniques, reciprocal sum conditions",
+      "Familiarity with Lean 4 structures and Mathlib integer API"
     ]
   },
   "sections": [
@@ -87,42 +89,48 @@
       "title": "Covering Systems",
       "startLine": 21,
       "endLine": 37,
-      "summary": "Defines `CoveringSystem` as a structure with `Fin n`-indexed moduli ($m_i \\geq 2$), residues, and the covering property $\\forall z \\in \\mathbb{Z},\\, \\exists i,\\, z \\equiv r_i \\pmod{m_i}$. Uses integer modular arithmetic directly rather than `ZMod`."
+      "summary": "Defines `CoveringSystem` as a structure with `Fin n`-indexed moduli ($m_i \\geq 2$), residues, and the covering property $\\forall z \\in \\mathbb{Z},\\, \\exists i,\\, z \\equiv r_i \\pmod{m_i}$. Uses integer modular arithmetic directly rather than `ZMod`.",
+      "mathContext": "$\\forall z \\in \\mathbb{Z},\\, \\exists i \\in [n],\\, m_i \\mid (z - r_i)$, with $m_i \\geq 2$. Covering: $\\mathbb{Z} = \\bigcup_{i=1}^{n} (r_i + m_i\\mathbb{Z})$."
     },
     {
       "id": "prime-minus-one",
       "title": "Prime-Minus-One Moduli",
       "startLine": 39,
       "endLine": 49,
-      "summary": "Defines `IsPrimeMinusOne k m` ($m = p - 1$ for prime $p \\geq k$) and `AllModuliPrimeMinusOne k cs`. The parameter $k$ unifies Selfridge's solved case ($k = 3$) and Erdős's open question ($k = 5$)."
+      "summary": "Defines `IsPrimeMinusOne k m` ($m = p - 1$ for prime $p \\geq k$) and `AllModuliPrimeMinusOne k cs`. The parameter $k$ unifies Selfridge's solved case ($k = 3$) and Erdős's open question ($k = 5$).",
+      "mathContext": "$\\text{IsPrimeMinusOne}(k, m) \\iff \\exists p \\geq k,\\, p \\text{ prime},\\, m = p - 1$. For $k=5$: allowed $m \\in \\{4,6,10,12,16,18,22,\\ldots\\}$."
     },
     {
       "id": "main-problem",
       "title": "The Main Problem",
       "startLine": 51,
       "endLine": 61,
-      "summary": "States `ErdosProblem273 : Prop` as $\\exists cs : \\text{CoveringSystem},\\, \\text{AllModuliPrimeMinusOne}\\, 5\\, cs$. The allowed moduli are $\\{4, 6, 10, 12, 16, 18, 22, 28, 30, \\ldots\\}$."
+      "summary": "States `ErdosProblem273 : Prop` as $\\exists cs : \\text{CoveringSystem},\\, \\text{AllModuliPrimeMinusOne}\\, 5\\, cs$. The allowed moduli are $\\{4, 6, 10, 12, 16, 18, 22, 28, 30, \\ldots\\}$.",
+      "mathContext": "$\\exists n,\\, \\exists (m_i, r_i)_{i=1}^{n}: \\mathbb{Z} = \\bigcup r_i + m_i\\mathbb{Z}$ with each $m_i = p_i - 1$, $p_i$ prime $\\geq 5$."
     },
     {
       "id": "selfridge-example",
       "title": "The Selfridge Example (p ≥ 3)",
       "startLine": 63,
       "endLine": 72,
-      "summary": "Axiomatizes Selfridge's covering system for $p \\geq 3$ using divisors of $360 = 2^3 \\cdot 3^2 \\cdot 5$. The key modulus $2 = 3 - 1$ enables coverage of all parities."
+      "summary": "Axiomatizes Selfridge's covering system for $p \\geq 3$ using divisors of $360 = 2^3 \\cdot 3^2 \\cdot 5$. The key modulus $2 = 3 - 1$ enables coverage of all parities.",
+      "mathContext": "Selfridge: covering with moduli $\\mid 360 = 2^3 \\cdot 3^2 \\cdot 5$. Key: $2 = 3 - 1$ covers all parities."
     },
     {
       "id": "covering-basics",
       "title": "Covering System Basics",
       "startLine": 74,
       "endLine": 92,
-      "summary": "Defines `CoveringSystem.lcm` for periodicity reduction, axiomatizes $\\sum 1/m_i \\geq 1$ over $\\mathbb{Q}$, and defines `IsDistinct` (injective moduli) connecting to Hough's minimum modulus theorem."
+      "summary": "Defines `CoveringSystem.lcm` for periodicity reduction, axiomatizes $\\sum 1/m_i \\geq 1$ over $\\mathbb{Q}$, and defines `IsDistinct` (injective moduli) connecting to Hough's minimum modulus theorem.",
+      "mathContext": "Necessary condition: $\\sum_{i=1}^{n} 1/m_i \\geq 1$. Periodicity: covering is determined by behavior on $[0, \\text{lcm}(m_i))$."
     },
     {
       "id": "connections",
       "title": "Connection to Other Problems",
       "startLine": 94,
       "endLine": 115,
-      "summary": "Enumerates `easyPrimes` $= \\{5, 7, 13, 19, 37, 61, 181\\}$ (primes $p \\geq 5$ with $(p-1) \\mid 360$) and axiomatizes the key constraints: all moduli $> 2$ and $\\geq 4$ when restricted to $p \\geq 5$."
+      "summary": "Enumerates `easyPrimes` $= \\{5, 7, 13, 19, 37, 61, 181\\}$ (primes $p \\geq 5$ with $(p-1) \\mid 360$) and axiomatizes the key constraints: all moduli $> 2$ and $\\geq 4$ when restricted to $p \\geq 5$.",
+      "mathContext": "Easy primes: $\\{p \\geq 5 : (p-1) \\mid 360\\} = \\{5,7,13,19,37,61,181\\}$. Constraint: all $m_i \\geq 4$ for $p \\geq 5$."
     }
   ],
   "conclusion": {
@@ -151,11 +159,43 @@
     "theoremCount": 0,
     "definitionCount": 6
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-23",
+      "relationship": "related",
+      "description": "Problem #23 asks about the minimum modulus of covering systems with distinct moduli — directly related to the structural constraints on covering systems in #273. Hough's resolution of the minimum modulus conjecture constrains both problems"
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "foundational",
+      "description": "The Chinese Remainder Theorem is the key tool for constructing covering systems from residue classes. Any covering system modulo coprime m_i can be verified by checking finitely many residues mod lcm(m_i)"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-23",
+    "chinese-remainder-constructive"
+  ],
   "references": [
-    "Erdős–Graham (1980): 'Old and New Problems and Results in Combinatorial Number Theory', p.24",
-    "Selfridge: covering system with moduli dividing 360 (when p ≥ 3 allowed)",
-    "Hough (2015): 'Solution of the minimum modulus problem for covering systems', Annals of Mathematics 181(1), 361–382",
-    "Filaseta–Ford–Konyagin–Pomerance–Yu (2007): partial results toward minimum modulus conjecture",
-    "https://erdosproblems.com/273"
+    {
+      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "L'Enseignement Mathématique, Monograph no. 28, Geneva, p. 24",
+      "note": "Original source for Problem #273; discusses the Selfridge example and the open p ≥ 5 case"
+    },
+    {
+      "authors": "Hough, Bob",
+      "title": "Solution of the minimum modulus problem for covering systems",
+      "year": "2015",
+      "venue": "Annals of Mathematics, vol. 181(1), pp. 361–382",
+      "note": "Proved that the minimum modulus of a covering system with distinct moduli is bounded, resolving a conjecture of Erdős. Constrains possible approaches to Problem #273"
+    },
+    {
+      "authors": "Filaseta, Michael; Ford, Kevin; Konyagin, Sergei; Pomerance, Carl; Yu, Gang",
+      "title": "Sieving by large integers and covering systems of congruences",
+      "year": "2007",
+      "venue": "Journal of the AMS, vol. 20(2), pp. 495–517",
+      "note": "Partial results toward the minimum modulus conjecture using sieve methods; relevant to the structural constraints on covering systems in Problem #273"
+    }
   ]
 }

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -41,8 +41,10 @@
       "**Inclusion-exclusion gives the formula**: The equal-residue density is $\\sum_{\\emptyset \\neq S} (-1)^{|S|+1} / \\mathrm{lcm}_{i \\in S}(n_i)$, generalizing $\\sum 1/n_i$ (first order) with correction terms for overlaps"
     ],
     "prerequisites": [
-      "Number theory fundamentals",
-      "Combinatorial analysis"
+      "Modular arithmetic: congruences, residue classes, lcm computations",
+      "Combinatorics: inclusion-exclusion, density of integer subsets",
+      "Chinese Remainder Theorem for coprime moduli",
+      "Familiarity with Lean 4 and Mathlib natural/real number API"
     ]
   },
   "sections": [
@@ -51,56 +53,64 @@
       "title": "Header and Imports",
       "startLine": 1,
       "endLine": 26,
-      "summary": "Module docstring referencing Simpson (1986) and the minimum/maximum density questions. Imports Mathlib for `Finset.Card`, `Nat.GCD.Basic`, `Nat.Prime.Basic`, `Data.Real.Basic`, and tactics."
+      "summary": "Module docstring referencing Simpson (1986) and the minimum/maximum density questions. Imports Mathlib for `Finset.Card`, `Nat.GCD.Basic`, `Nat.Prime.Basic`, `Data.Real.Basic`, and tactics.",
+      "mathContext": "Imports: `Nat.GCD.Basic` for $\\text{lcm}$, `Data.Real.Basic` for density $\\delta \\in [0,1]$."
     },
     {
       "id": "congruence-system",
       "title": "Congruence System Structure",
       "startLine": 29,
       "endLine": 37,
-      "summary": "Defines `CongruenceSystem` (moduli with residue function and positivity proof) and `isCovered` ($m \\equiv a_i \\pmod{n_i}$ for some $i$)."
+      "summary": "Defines `CongruenceSystem` (moduli with residue function and positivity proof) and `isCovered` ($m \\equiv a_i \\pmod{n_i}$ for some $i$).",
+      "mathContext": "$\\{a_i \\pmod{n_i}\\}_{i=1}^{r}$ with $n_i > 0$. Covered: $m \\in \\bigcup_{i} (a_i + n_i\\mathbb{Z})$."
     },
     {
       "id": "density-definitions",
       "title": "Density Definitions",
       "startLine": 39,
       "endLine": 55,
-      "summary": "Defines `systemLCM` ($L = \\mathrm{lcm}(n_1, \\ldots, n_r)$), `coverageDensity` ($|\\{\\text{covered}\\} \\cap [0,L)|/L$), and `maxCoverageDensity`/`minCoverageDensity` as $\\sup$/$\\inf$ over residue choices."
+      "summary": "Defines `systemLCM` ($L = \\mathrm{lcm}(n_1, \\ldots, n_r)$), `coverageDensity` ($|\\{\\text{covered}\\} \\cap [0,L)|/L$), and `maxCoverageDensity`/`minCoverageDensity` as $\\sup$/$\\inf$ over residue choices.",
+      "mathContext": "$L = \\text{lcm}(n_1,\\ldots,n_r)$; $\\delta = |\\{m \\in [0,L) : \\text{covered}(m)\\}|/L$; $\\delta_{\\max} = \\sup_a \\delta$."
     },
     {
       "id": "helper-lemmas",
       "title": "Helper Lemmas",
       "startLine": 57,
       "endLine": 88,
-      "summary": "Proves `foldl_lcm_pos` (LCM of positive list is positive by induction) and `systemLCM_pos` ($L > 0$). Also proves `coverage_card_le_lcm` ($|\\text{filtered set}| \\leq L$) for the density upper bound."
+      "summary": "Proves `foldl_lcm_pos` (LCM of positive list is positive by induction) and `systemLCM_pos` ($L > 0$). Also proves `coverage_card_le_lcm` ($|\\text{filtered set}| \\leq L$) for the density upper bound.",
+      "mathContext": "$L = \\text{lcm}(n_1,\\ldots,n_r) > 0$ (by induction on positive list). $|\\text{covered} \\cap [0,L)| \\leq L$."
     },
     {
       "id": "density-bounds",
       "title": "Proved Density Bounds",
       "startLine": 90,
       "endLine": 109,
-      "summary": "Three fully proved theorems: $\\delta \\geq 0$ (ratio of naturals), $\\delta \\leq 1$ (via `div_le_one` and `systemLCM_pos`), and the combined bound $0 \\leq \\delta \\leq 1$."
+      "summary": "Three fully proved theorems: $\\delta \\geq 0$ (ratio of naturals), $\\delta \\leq 1$ (via `div_le_one` and `systemLCM_pos`), and the combined bound $0 \\leq \\delta \\leq 1$.",
+      "mathContext": "$0 \\leq \\delta \\leq 1$. Fully proved from $\\delta = |S|/L$ with $|S| \\leq L$ and $L > 0$."
     },
     {
       "id": "inclusion-exclusion",
       "title": "Inclusion-Exclusion Formula",
       "startLine": 111,
       "endLine": 117,
-      "summary": "Defines `inclusionExclusionDensity` as the first-order term $\\sum_{i=1}^r 1/n_i$. The full alternating-sign formula $\\sum_{\\emptyset \\neq S} (-1)^{|S|+1}/\\mathrm{lcm}_{i \\in S}(n_i)$ is noted but not fully formalized."
+      "summary": "Defines `inclusionExclusionDensity` as the first-order term $\\sum_{i=1}^r 1/n_i$. The full alternating-sign formula $\\sum_{\\emptyset \\neq S} (-1)^{|S|+1}/\\mathrm{lcm}_{i \\in S}(n_i)$ is noted but not fully formalized.",
+      "mathContext": "First-order approximation: $\\delta \\approx \\sum_{i=1}^{r} 1/n_i$. Exact: $\\delta = \\sum_{\\emptyset \\neq S} (-1)^{|S|+1}/\\text{lcm}_{i \\in S}(n_i)$."
     },
     {
       "id": "simpson-theorem",
       "title": "Simpson's Theorem (1986)",
       "startLine": 119,
       "endLine": 131,
-      "summary": "Axiomatizes Simpson's theorem: $\\delta(\\{0 \\pmod{n_i}\\}) \\leq \\delta(\\{r(n_i) \\pmod{n_i}\\})$ for all residue functions $r$. Proves equal_residues_minimize: coverage density with constant residue $a$ equals that with residue 0, via cyclic shift bijection $m \\mapsto (m+a) \\bmod L$ on $\\{0, \\ldots, L-1\\}$."
+      "summary": "Axiomatizes Simpson's theorem: $\\delta(\\{0 \\pmod{n_i}\\}) \\leq \\delta(\\{r(n_i) \\pmod{n_i}\\})$ for all residue functions $r$. Proves equal_residues_minimize: coverage density with constant residue $a$ equals that with residue 0, via cyclic shift bijection $m \\mapsto (m+a) \\bmod L$ on $\\{0, \\ldots, L-1\\}$.",
+      "mathContext": "Simpson: $\\delta_{\\min} = \\delta(\\{0 \\pmod{n_i}\\})$; all-zero residues minimize density. Shift invariance: $\\delta(a) = \\delta(0)$ for constant $a$."
     },
     {
       "id": "open-question",
       "title": "Maximum Density (Open)",
       "startLine": 133,
       "endLine": 148,
-      "summary": "Three axiomatized results: coprime maximum ($\\delta_{\\max} = \\sum 1/n_i$ by CRT), the open question ($\\delta_{\\max} \\leq 1$ for general moduli), and the single modulus base case ($\\delta = 1/n$)."
+      "summary": "Three axiomatized results: coprime maximum ($\\delta_{\\max} = \\sum 1/n_i$ by CRT), the open question ($\\delta_{\\max} \\leq 1$ for general moduli), and the single modulus base case ($\\delta = 1/n$).",
+      "mathContext": "Coprime case: $\\gcd(n_i, n_j) = 1 \\Rightarrow \\delta_{\\max} = \\sum 1/n_i$ (CRT). Open: general formula for $\\delta_{\\max}$."
     }
   ],
   "conclusion": {
@@ -128,11 +138,50 @@
     "theoremCount": 8,
     "definitionCount": 6
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-23",
+      "relationship": "related",
+      "description": "Both concern covering systems: #23 studies the minimum modulus question, while #278 studies maximum coverage density. Both are part of Erdős's broader program on residue class coverings"
+    },
+    {
+      "targetId": "erdos-273",
+      "relationship": "related",
+      "description": "Both concern restricted covering systems: #273 restricts moduli to p-1 for primes p, while #278 optimizes residue choices for fixed moduli. Both involve the interplay between moduli constraints and coverage properties"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-23",
+    "erdos-273"
+  ],
   "references": [
-    "Erdős & Graham (1980): 'Old and New Problems and Results in Combinatorial Number Theory', p.28",
-    "Simpson (1986): 'Regular coverings of the integers by arithmetic progressions', Discrete Mathematics 59(1–2), 45–63",
-    "Hough (2015): 'Solution of the minimum modulus problem for covering systems', Annals of Mathematics 181(1), 361–382",
-    "Crittenden & Vanden Eynden (1970): 'Any n arithmetic progressions covering the first 2ⁿ integers cover all integers', Journal of Combinatorial Theory 8, 29–30",
-    "https://erdosproblems.com/278"
+    {
+      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "L'Enseignement Mathématique, Monograph no. 28, Geneva, p. 28",
+      "note": "Original source for Problem #278"
+    },
+    {
+      "authors": "Simpson, R. James",
+      "title": "Regular coverings of the integers by arithmetic progressions",
+      "year": "1986",
+      "venue": "Discrete Mathematics, vol. 59(1–2), pp. 45–63",
+      "note": "Proved that all-zero residues minimize coverage density — resolving the minimum density case of Problem #278"
+    },
+    {
+      "authors": "Hough, Bob",
+      "title": "Solution of the minimum modulus problem for covering systems",
+      "year": "2015",
+      "venue": "Annals of Mathematics, vol. 181(1), pp. 361–382",
+      "note": "Resolved Erdős's minimum modulus conjecture; constrains structural approaches to covering system problems"
+    },
+    {
+      "authors": "Crittenden, Richard B.; Vanden Eynden, Charles L.",
+      "title": "Any n arithmetic progressions covering the first 2ⁿ integers cover all integers",
+      "year": "1970",
+      "venue": "Journal of Combinatorial Theory, Series A, vol. 8, pp. 29–30",
+      "note": "Classical result on coverage thresholds for arithmetic progressions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -20,6 +20,7 @@
     "relatedProofs": [
       "erdos-40"
     ],
+    "proofRepoPath": "Proofs/Erdos28Problem.lean",
     "axiomCount": 8,
     "assumptions": "8 axiom declarations: erdos_turan_conjecture (main conjecture r(n) unbounded), erdos_turan_strong (logarithmic growth form), erdos_turan_density_version (density hypothesis variant), basis_counting_lower (sqrt(N) density lower bound), sidon_not_basis (Sidon sets too sparse), erdos_40_from_28 (B_2[g] implication), erdos_fuchs_theorem (cumulative sum fluctuation), average_rep_unbounded (average divergence)",
     "badge": "axiom",
@@ -36,56 +37,64 @@
       "title": "Header and Imports",
       "startLine": 1,
       "endLine": 29,
-      "summary": "Module docstring stating the conjecture and its $500 bounty, followed by Mathlib imports for additive combinatorics (`SumConv`), Finset operations, filter convergence (`atTop`, `Tendsto`), and real analysis (`Real.log`, `Real.sqrt`). Opens `Filter` and `Set` namespaces with `Pointwise` scoping for $A + A$ notation."
+      "summary": "Module docstring stating the conjecture and its $500 bounty, followed by Mathlib imports for additive combinatorics (`SumConv`), Finset operations, filter convergence (`atTop`, `Tendsto`), and real analysis (`Real.log`, `Real.sqrt`). Opens `Filter` and `Set` namespaces with `Pointwise` scoping for $A + A$ notation.",
+      "mathContext": "Imports: `SumConv` for Minkowski sum $A + A$, `Filter.atTop` for $\\lim_{N \\to \\infty}$, `Pointwise` for set addition notation."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
       "startLine": 31,
       "endLine": 45,
-      "summary": "Three foundational definitions: the **representation function** $r_A(n) = |\\{(a,b) : a+b=n, a \\leq b, a,b \\in A\\}|$, the **asymptotic basis** condition $(A+A)^c$ finite, and the **counting function** $A(N) = |A \\cap [1,N]|$. These encode the core objects of the Erdős–Turán conjecture in Lean 4."
+      "summary": "Three foundational definitions: the **representation function** $r_A(n) = |\\{(a,b) : a+b=n, a \\leq b, a,b \\in A\\}|$, the **asymptotic basis** condition $(A+A)^c$ finite, and the **counting function** $A(N) = |A \\cap [1,N]|$. These encode the core objects of the Erdős–Turán conjecture in Lean 4.",
+      "mathContext": "$r_A(n) = |\\{(a,b) : a+b=n,\\, a \\leq b,\\, a,b \\in A\\}|$; $A$ basis iff $(A+A)^c$ finite; $A(N) = |A \\cap [1,N]|$."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
       "startLine": 47,
       "endLine": 56,
-      "summary": "The Erdős–Turán conjecture (1941): $\\forall B, \\exists n: r_A(n) \\geq B$ whenever $A$ is an asymptotic basis of order 2. Stated as an axiom since the problem remains **OPEN** with a \\$500 bounty. Equivalent to $\\limsup r_A(n) = \\infty$."
+      "summary": "The Erdős–Turán conjecture (1941): $\\forall B, \\exists n: r_A(n) \\geq B$ whenever $A$ is an asymptotic basis of order 2. Stated as an axiom since the problem remains **OPEN** with a \\$500 bounty. Equivalent to $\\limsup r_A(n) = \\infty$.",
+      "mathContext": "$\\text{IsAsymptoticBasis2}(A) \\Rightarrow \\limsup_{n \\to \\infty} r_A(n) = \\infty$. Axiom: open conjecture with \\$500 bounty."
     },
     {
       "id": "stronger-forms",
       "title": "Stronger Forms of the Conjecture",
       "startLine": 58,
       "endLine": 70,
-      "summary": "Two strengthenings: (1) the **logarithmic form** $\\limsup r_A(n)/\\log n > 0$, motivated by probabilistic heuristics showing $\\mathbb{E}[r_A(n)] \\sim \\log n$ for random sets of density $\\sqrt{N}$; (2) the **density version** replacing the basis hypothesis with $A(N) \\geq c\\sqrt{N}$, which is strictly weaker than being a basis."
+      "summary": "Two strengthenings: (1) the **logarithmic form** $\\limsup r_A(n)/\\log n > 0$, motivated by probabilistic heuristics showing $\\mathbb{E}[r_A(n)] \\sim \\log n$ for random sets of density $\\sqrt{N}$; (2) the **density version** replacing the basis hypothesis with $A(N) \\geq c\\sqrt{N}$, which is strictly weaker than being a basis.",
+      "mathContext": "Strong form: $\\limsup r_A(n)/\\log n > 0$. Density version: $A(N) \\geq c\\sqrt{N} \\Rightarrow \\limsup r_A(n) = \\infty$."
     },
     {
       "id": "counting-bounds",
       "title": "Counting Lower Bounds",
       "startLine": 72,
       "endLine": 77,
-      "summary": "Necessary density condition: any basis of order 2 has $A(N) \\gg \\sqrt{N}$ by a pigeonhole/counting argument. Since $|A+A| \\leq \\binom{A(N)+1}{2}$ and $A+A$ must cover $\\sim N$ integers, we get $A(N) \\geq \\sqrt{2N} - 1$."
+      "summary": "Necessary density condition: any basis of order 2 has $A(N) \\gg \\sqrt{N}$ by a pigeonhole/counting argument. Since $|A+A| \\leq \\binom{A(N)+1}{2}$ and $A+A$ must cover $\\sim N$ integers, we get $A(N) \\geq \\sqrt{2N} - 1$.",
+      "mathContext": "$N \\leq \\binom{A(N)+1}{2} \\Rightarrow A(N) \\geq \\sqrt{2N} - 1$. Tight for Sidon sets."
     },
     {
       "id": "sidon-sets",
       "title": "Sidon Sets and Extremal Case",
       "startLine": 79,
       "endLine": 84,
-      "summary": "Sidon sets ($B_2$ sets) have $r_A(n) \\leq 1$, making them too sparse ($A(N) \\leq \\sqrt{N} + O(N^{1/4})$) to be bases. This confirms the conjecture vacuously for the extremal case $r \\leq 1$."
+      "summary": "Sidon sets ($B_2$ sets) have $r_A(n) \\leq 1$, making them too sparse ($A(N) \\leq \\sqrt{N} + O(N^{1/4})$) to be bases. This confirms the conjecture vacuously for the extremal case $r \\leq 1$.",
+      "mathContext": "Sidon: $r_A(n) \\leq 1 \\Rightarrow A(N) \\leq \\sqrt{N} + O(N^{1/4})$, too sparse for basis."
     },
     {
       "id": "problem-40-connection",
       "title": "Connection to Problem #40",
       "startLine": 86,
       "endLine": 93,
-      "summary": "Problem #40 generalizes the Sidon observation: can any $B_2[g]$ set (with $r_A(n) \\leq g$) be a basis? The Erdős–Turán conjecture implies the answer is **no** for every finite $g$. This formalizes the implication #28 $\\Rightarrow$ #40."
+      "summary": "Problem #40 generalizes the Sidon observation: can any $B_2[g]$ set (with $r_A(n) \\leq g$) be a basis? The Erdős–Turán conjecture implies the answer is **no** for every finite $g$. This formalizes the implication #28 $\\Rightarrow$ #40.",
+      "mathContext": "#28 $\\Rightarrow$ #40: $\\limsup r_A(n) = \\infty$ implies no $B_2[g]$ set can be a basis for any finite $g$."
     },
     {
       "id": "partial-results",
       "title": "Partial Results: Erdős–Fuchs and Averages",
       "startLine": 95,
       "endLine": 112,
-      "summary": "Two key partial results: (1) the **Erdős–Fuchs theorem** (1956) showing $\\sum_{n \\leq N} r_A(n) \\neq cN + o(N^{1/4}/\\sqrt{\\log N})$ — representations must oscillate, but this doesn't imply individual unboundedness; (2) **Halberstam–Roth** showing the average $\\frac{1}{N}\\sum r_A(n) \\to \\infty$, which also falls short of proving the conjecture."
+      "summary": "Two key partial results: (1) the **Erdős–Fuchs theorem** (1956) showing $\\sum_{n \\leq N} r_A(n) \\neq cN + o(N^{1/4}/\\sqrt{\\log N})$ — representations must oscillate, but this doesn't imply individual unboundedness; (2) **Halberstam–Roth** showing the average $\\frac{1}{N}\\sum r_A(n) \\to \\infty$, which also falls short of proving the conjecture.",
+      "mathContext": "Erdős–Fuchs: $\\sum_{n \\leq N} r_A(n) - cN = \\Omega(N^{1/4}/\\sqrt{\\log N})$. Halberstam–Roth: $\\frac{1}{N}\\sum r_A(n) \\to \\infty$."
     }
   ],
   "overview": {
@@ -173,11 +182,13 @@
       "venue": "Oxford University Press",
       "note": "Comprehensive reference for additive bases and representation functions, including the average divergence result"
     },
-    "Erdős–Turán (1941): 'On a problem of Sidon in additive number theory and some related problems', J. London Math. Soc.",
-    "Erdős–Fuchs (1956): 'On a problem of additive number theory', J. London Math. Soc.",
-    "Halberstam–Roth (1966): 'Sequences', Oxford University Press",
-    "Montgomery–Vaughan (1990): sharpened Erdős–Fuchs with optimal exponent",
-    "https://erdosproblems.com/28"
+    {
+      "authors": "Nathanson, Melvyn B.",
+      "title": "Additive Number Theory: The Classical Bases",
+      "year": "1996",
+      "venue": "Springer GTM 164",
+      "note": "Chapter 1 covers additive bases and Sidon sets; Chapter 2 treats Waring's problem; comprehensive modern reference for the Erdős–Turán conjecture and related problems"
+    }
   ],
   "relatedProofs": [
     "erdos-1",
@@ -186,5 +197,22 @@
     "erdos-40",
     "erdos-41",
     "erdos-42"
-  ]
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Additive.SumConv",
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Order.Filter.AtTopBot",
+      "Mathlib.Order.Filter.ENNReal",
+      "Mathlib.Topology.Algebra.Order.LiminfLimsup",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Filter", "Set", "Pointwise"],
+    "namespace": "",
+    "lineCount": 111,
+    "axiomCount": 8,
+    "theoremCount": 0,
+    "definitionCount": 3
+  }
 }

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -90,49 +90,56 @@
       "title": "Header and Imports",
       "startLine": 1,
       "endLine": 21,
-      "summary": "Module docstring referencing Prikry, Tijdeman, and Stewart. Imports Mathlib for $\\mathbb{Z}$, sets, Finset cardinality, and tactics. Opens `Set` namespace."
+      "summary": "Module docstring referencing Prikry, Tijdeman, and Stewart. Imports Mathlib for $\\mathbb{Z}$, sets, Finset cardinality, and tactics. Opens `Set` namespace.",
+      "mathContext": "Imports: `Int.Basic` for $a_1 - a_2 \\in \\mathbb{Z}$, `Set.Basic` for $D(A)$ definition, `Finset.Card` for $A(N)$."
     },
     {
       "id": "difference-set",
       "title": "Difference Set D(A)",
       "startLine": 23,
       "endLine": 29,
-      "summary": "Defines $D(A) = \\{d \\in \\mathbb{Z} : |\\{(a_1,a_2) \\in A^2 : a_1 - a_2 = d\\}| = \\infty\\}$ using `Set.Infinite` on the fibre over each $d$. Stricter than $A - A$."
+      "summary": "Defines $D(A) = \\{d \\in \\mathbb{Z} : |\\{(a_1,a_2) \\in A^2 : a_1 - a_2 = d\\}| = \\infty\\}$ using `Set.Infinite` on the fibre over each $d$. Stricter than $A - A$.",
+      "mathContext": "$D(A) = \\{d \\in \\mathbb{Z} : |\\{(a_1,a_2) \\in A^2 : a_1 - a_2 = d\\}| = \\infty\\}$. Stricter than $A - A$."
     },
     {
       "id": "bounded-gaps",
       "title": "Bounded Gaps (Syndeticity)",
       "startLine": 31,
       "endLine": 38,
-      "summary": "Defines `HasBoundedGaps`: $\\exists M > 0, \\forall z \\in \\mathbb{Z}, \\exists s \\in S: z \\leq s < z + M$. The dual of thick sets in topological dynamics."
+      "summary": "Defines `HasBoundedGaps`: $\\exists M > 0, \\forall z \\in \\mathbb{Z}, \\exists s \\in S: z \\leq s < z + M$. The dual of thick sets in topological dynamics.",
+      "mathContext": "$\\text{HasBoundedGaps}(S) \\iff \\exists M > 0,\\, \\forall z \\in \\mathbb{Z},\\, \\exists s \\in S: z \\leq s < z + M$."
     },
     {
       "id": "density-conditions",
       "title": "Density Conditions",
       "startLine": 40,
       "endLine": 57,
-      "summary": "Counting function $A(N) = |A \\cap [1,N]|$, positive upper density ($\\limsup A(N)/N > 0$), and positive lower density ($\\liminf A(N)/N > 0$), all formalized over $\\mathbb{Q}$."
+      "summary": "Counting function $A(N) = |A \\cap [1,N]|$, positive upper density ($\\limsup A(N)/N > 0$), and positive lower density ($\\liminf A(N)/N > 0$), all formalized over $\\mathbb{Q}$.",
+      "mathContext": "$A(N) = |A \\cap [1,N]|$; $\\overline{d}(A) = \\limsup_{N \\to \\infty} A(N)/N$; $\\underline{d}(A) = \\liminf_{N \\to \\infty} A(N)/N$."
     },
     {
       "id": "known-results",
       "title": "Known Results",
       "startLine": 58,
       "endLine": 76,
-      "summary": "Four axiomatized results: **Prikry's theorem** ($\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic), density inheritance for $D(A)$, symmetry $D(A) = -D(A)$, and $0 \\in D(A)$ for infinite $A$."
+      "summary": "Four axiomatized results: **Prikry's theorem** ($\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic), density inheritance for $D(A)$, symmetry $D(A) = -D(A)$, and $0 \\in D(A)$ for infinite $A$.",
+      "mathContext": "Prikry: $\\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Structure: $D(A) = -D(A)$, $0 \\in D(A)$ for infinite $A$."
     },
     {
       "id": "main-problem",
       "title": "The Main Open Problem",
       "startLine": 78,
       "endLine": 88,
-      "summary": "Erdős Problem 332: characterize the weakest property $P$ such that $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Positive upper density is the best known sufficient condition."
+      "summary": "Erdős Problem 332: characterize the weakest property $P$ such that $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Positive upper density is the best known sufficient condition.",
+      "mathContext": "Find weakest $P$: $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Known: $\\overline{d}(A) > 0$ suffices."
     },
     {
       "id": "related-questions",
       "title": "Related Questions",
       "startLine": 90,
       "endLine": 97,
-      "summary": "Does positive density imply $\\sum_{d \\in D(A)} 1/d = \\infty$? This would show $D(A)$ has 'harmonic thickness' beyond mere syndeticity."
+      "summary": "Does positive density imply $\\sum_{d \\in D(A)} 1/d = \\infty$? This would show $D(A)$ has 'harmonic thickness' beyond mere syndeticity.",
+      "mathContext": "Open: $\\overline{d}(A) > 0 \\Rightarrow \\sum_{d \\in D(A)} 1/|d| = \\infty$? (harmonic thickness conjecture)"
     }
   ],
   "conclusion": {
@@ -191,10 +198,26 @@
     "definitionCount": 6
   },
   "references": [
-    "Erdős & Graham (1980): 'Old and New Problems and Results in Combinatorial Number Theory'",
-    "Prikry: positive upper density implies D(A) is syndetic",
-    "Tijdeman & Stewart: related density results for difference sets",
-    "Furstenberg (1977): correspondence principle connecting density to ergodic theory",
-    "https://erdosproblems.com/332"
+    {
+      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "L'Enseignement Mathématique, Monograph no. 28, Geneva",
+      "note": "Original source for Problem #332; comprehensive survey of open problems in additive combinatorics"
+    },
+    {
+      "authors": "Furstenberg, Hillel",
+      "title": "Ergodic behavior of diagonal measures and a theorem of Szemerédi on arithmetic progressions",
+      "year": "1977",
+      "venue": "Journal d'Analyse Mathématique, vol. 31, pp. 204–256",
+      "note": "Established the correspondence principle connecting combinatorial density to ergodic theory; Prikry's theorem follows from Poincaré recurrence in the associated system"
+    },
+    {
+      "authors": "Halberstam, Heini; Roth, Klaus F.",
+      "title": "Sequences",
+      "year": "1966",
+      "venue": "Oxford University Press",
+      "note": "Classical reference for difference sets, density conditions, and additive bases; includes the average representation divergence result"
+    }
   ]
 }

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -37,8 +37,10 @@
       "This is one of the solved Erdos problems, demonstrating that formal verification can capture and confirm combinatorial constructions"
     ],
     "prerequisites": [
-      "Number theory fundamentals",
-      "Combinatorial analysis"
+      "Subset sum theory: completeness, density of sumsets",
+      "Asymptotic density: natural density, upper/lower density",
+      "Sequences: monotone sequences, consecutive ratios, binary representations",
+      "Cofinite sets: finitely many removals from infinite sequences"
     ]
   },
   "sections": [
@@ -47,42 +49,48 @@
       "title": "Subset Sums",
       "startLine": 23,
       "endLine": 27,
-      "summary": "`subsetSums A`: the set of all natural numbers expressible as finite subset sums from $A$."
+      "summary": "`subsetSums A`: the set of all natural numbers expressible as finite subset sums from $A$.",
+      "mathContext": "$P(A) = \\{\\sum_{i \\in S} a_i : S \\subseteq \\mathbb{N},\\, |S| < \\infty\\}$. Binary: $P(\\{1,2,4,8,\\ldots\\}) = \\mathbb{N}$."
     },
     {
       "id": "density",
       "title": "Asymptotic Density",
       "startLine": 29,
       "endLine": 39,
-      "summary": "Counting function `countIn` and `HasDensity S delta` via epsilon-N_0 convergence of |S cap [1,N]|/N."
+      "summary": "Counting function `countIn` and `HasDensity S delta` via epsilon-N_0 convergence of |S cap [1,N]|/N.",
+      "mathContext": "$\\text{HasDensity}(S, \\delta) \\iff |S \\cap [1,N]|/N \\to \\delta$ as $N \\to \\infty$. Goal: $\\delta = 1$."
     },
     {
       "id": "ratio-limit",
       "title": "Monotone Sequences with Ratio Limit",
       "startLine": 41,
       "endLine": 52,
-      "summary": "`IsMonotone` (nondecreasing) and `HasRatioLimit a r` (consecutive ratio convergence). Critical value r = 2."
+      "summary": "`IsMonotone` (nondecreasing) and `HasRatioLimit a r` (consecutive ratio convergence). Critical value r = 2.",
+      "mathContext": "$\\lim_{n \\to \\infty} a_{n+1}/a_n = r$. Critical case $r = 2$: geometric growth at rate of binary powers."
     },
     {
       "id": "cofinite",
       "title": "Cofinite Subsequences",
       "startLine": 54,
       "endLine": 63,
-      "summary": "`IsCofiniteSubseq`: strictly monotone reindexing with cofinite range. `cofiniteImage`: the values of the subsequence."
+      "summary": "`IsCofiniteSubseq`: strictly monotone reindexing with cofinite range. `cofiniteImage`: the values of the subsequence.",
+      "mathContext": "$A' \\subseteq A$ cofinite $\\iff |A \\setminus A'| < \\infty$. Robustness: $P(A')$ should still have density 1."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture (Solved)",
       "startLine": 65,
       "endLine": 78,
-      "summary": "Erdős Problem 347: existential statement and affirmative axiom. Solved by ebarschkis (Tao-van Doorn ideas)."
+      "summary": "Erdős Problem 347: existential statement and affirmative axiom. Solved by ebarschkis (Tao-van Doorn ideas).",
+      "mathContext": "$\\exists A: \\lim a_{n+1}/a_n = 2 \\wedge \\forall A' \\subseteq_{\\text{cof}} A,\\, \\text{HasDensity}(P(A'), 1)$. Answer: YES."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 80,
       "endLine": 93,
-      "summary": "Zero in P(A), additive closure, and monotonicity of subset sums — the algebraic structure of P."
+      "summary": "Zero in P(A), additive closure, and monotonicity of subset sums — the algebraic structure of P.",
+      "mathContext": "$0 \\in P(A)$ (empty sum); $s \\in P(A),\\, a \\in A \\Rightarrow s + a \\in P(A)$; $A \\subseteq B \\Rightarrow P(A) \\subseteq P(B)$."
     }
   ],
   "conclusion": {
@@ -112,5 +120,43 @@
     "axiomCount": 4,
     "theoremCount": 0,
     "definitionCount": 8
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1",
+      "relationship": "related",
+      "description": "Both concern subset sum structure: #1 asks when all subset sums are distinct (minimizing representations), while #347 asks when subset sums achieve density 1 robustly (maximizing coverage). They sit at opposite ends of the subset sum complexity spectrum"
+    },
+    {
+      "targetId": "erdos-28",
+      "relationship": "related",
+      "description": "Both concern additive completeness: #28 asks whether representation functions of additive bases must be unbounded, while #347 asks whether a sequence growing at rate 2 can maintain density-1 subset sums under deletions. Both explore the boundary between thin and thick additive structure"
+    },
+    {
+      "targetId": "erdos-40",
+      "relationship": "related",
+      "description": "Both involve additive structure at critical thresholds: #40 studies B_2[g] sets that cannot be bases, while #347 studies sequences at the critical ratio 2 that can be robustly complete. Both concern how growth rate constraints interact with additive coverage"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-28",
+    "erdos-40"
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "L'Enseignement Mathématique, Monograph no. 28, Geneva",
+      "note": "Original source for Problem #347; comprehensive survey of complete sequences and subset sum problems"
+    },
+    {
+      "authors": "Folkman, Jon",
+      "title": "On the representation of integers as sums of distinct terms from a fixed sequence",
+      "year": "1966",
+      "venue": "Canadian Journal of Mathematics, vol. 18, pp. 643–655",
+      "note": "Classical results on complete sequences and the relationship between growth rate and completeness"
+    }
+  ]
 }

--- a/src/data/proofs/lagrange-theorem/meta.json
+++ b/src/data/proofs/lagrange-theorem/meta.json
@@ -22,6 +22,36 @@
         "theorem": "Subgroup.card_subgroup_dvd_card",
         "description": "Subgroup order divides group order",
         "module": "Mathlib.GroupTheory.Coset"
+      },
+      {
+        "theorem": "Subgroup.card_mul_index",
+        "description": "Product formula |H| × [G:H] = |G|",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "orderOf_dvd_card",
+        "description": "Element order divides group order",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "pow_card_eq_one",
+        "description": "g^|G| = 1 for any g in finite group G",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "ZMod.card_units_eq_totient",
+        "description": "|(ZMod p)ˣ| = φ(p)",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "isCyclic_of_prime_card",
+        "description": "Groups of prime order are cyclic",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "Subgroup.index_eq_card",
+        "description": "Index equals cardinality of quotient",
+        "module": "Mathlib.GroupTheory.Index"
       }
     ],
     "originalContributions": [
@@ -47,7 +77,9 @@
       "The index $[G:H]$ counts the number of distinct cosets and satisfies the tower law: for $K \\leq H \\leq G$, we have $[G:K] = [G:H] \\cdot [H:K]$. This multiplicativity of the index is the algebraic backbone of the orbit-stabilizer theorem and the class equation."
     ],
     "prerequisites": [
-      "Abstract algebra"
+      "Group theory: finite groups, subgroups, cosets, quotient groups",
+      "Number theory: divisibility, prime numbers, modular arithmetic",
+      "Familiarity with Lean 4 and Mathlib group theory library"
     ]
   },
   "sections": [
@@ -56,56 +88,64 @@
       "title": "Module Header and Imports",
       "startLine": 1,
       "endLine": 55,
-      "summary": "Documentation header explaining Lagrange's Theorem as Wiedijk #71, with historical notes on Lagrange (1771) and permutation groups, proof strategy via coset partition, and Mathlib dependencies."
+      "summary": "Documentation header explaining Lagrange's Theorem as Wiedijk #71, with historical notes on Lagrange (1771) and permutation groups, proof strategy via coset partition, and Mathlib dependencies.",
+      "mathContext": "Lagrange's theorem: $|H| \\mid |G|$ for $H \\leq G$ finite. Coset partition: $G = \\bigsqcup gH$ with $|gH| = |H|$."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem",
       "startLine": 57,
       "endLine": 80,
-      "summary": "Two formulations of Lagrange's theorem: card_subgroup_dvd_card and lagrange, both proving |H| divides |G| via Subgroup.card_subgroup_dvd_card."
+      "summary": "Two formulations of Lagrange's theorem: card_subgroup_dvd_card and lagrange, both proving |H| divides |G| via Subgroup.card_subgroup_dvd_card.",
+      "mathContext": "$|H| \\mid |G|$ proved via `Subgroup.card_subgroup_dvd_card` after `Nat.card` $\\leftrightarrow$ `Fintype.card` conversion."
     },
     {
       "id": "index-formula",
       "title": "Product Formula and Cosets",
       "startLine": 81,
       "endLine": 106,
-      "summary": "The quantitative version |G| = |H| × [G:H] via card_mul_index, plus intuitive explanation of how cosets partition G into equal-sized pieces."
+      "summary": "The quantitative version |G| = |H| × [G:H] via card_mul_index, plus intuitive explanation of how cosets partition G into equal-sized pieces.",
+      "mathContext": "$|G| = |H| \\cdot [G:H]$ where $[G:H]$ counts left cosets. Coset partition: $g \\in gH$, cosets equal or disjoint, $|gH| = |H|$, $G = \\bigsqcup gH$."
     },
     {
       "id": "corollaries",
       "title": "Element Order Corollaries",
       "startLine": 108,
       "endLine": 129,
-      "summary": "Three corollaries: ord(g) divides |G| (orderOf_dvd_card), alternative statement, and g^|G| = 1 (pow_card_eq_one)."
+      "summary": "Three corollaries: ord(g) divides |G| (orderOf_dvd_card), alternative statement, and g^|G| = 1 (pow_card_eq_one).",
+      "mathContext": "$\\text{ord}(g) \\mid |G|$ via $|\\langle g \\rangle| = \\text{ord}(g)$. Corollary: $g^{|G|} = 1$ since $|G| = \\text{ord}(g) \\cdot k$."
     },
     {
       "id": "fermat",
       "title": "Fermat's Little Theorem",
       "startLine": 130,
       "endLine": 153,
-      "summary": "Derives a^(p-1) ≡ 1 (mod p) from Lagrange applied to (Z/pZ)×, connecting group theory to number theory via ZMod.card_units_eq_totient."
+      "summary": "Derives a^(p-1) ≡ 1 (mod p) from Lagrange applied to (Z/pZ)×, connecting group theory to number theory via ZMod.card_units_eq_totient.",
+      "mathContext": "$a^{p-1} \\equiv 1 \\pmod{p}$ via $|(\\mathbb{Z}/p\\mathbb{Z})^\\times| = \\phi(p) = p-1$ and `pow_card_eq_one`."
     },
     {
       "id": "index-properties",
       "title": "Index Properties",
       "startLine": 154,
       "endLine": 181,
-      "summary": "Properties of the subgroup index: equals card of quotient, divides group order, boundary cases (trivial subgroup has index |G|, whole group has index 1)."
+      "summary": "Properties of the subgroup index: equals card of quotient, divides group order, boundary cases (trivial subgroup has index |G|, whole group has index 1).",
+      "mathContext": "$[G:H] = |G/H|$; $[G:H] \\mid |G|$; boundary: $[G:\\{1\\}] = |G|$, $[G:G] = 1$."
     },
     {
       "id": "prime-order",
       "title": "Prime Order Groups",
       "startLine": 182,
       "endLine": 198,
-      "summary": "Groups of prime order have no non-trivial proper subgroups (prime_order_simple) and are cyclic (prime_order_cyclic via isCyclic_of_prime_card)."
+      "summary": "Groups of prime order have no non-trivial proper subgroups (prime_order_simple) and are cyclic (prime_order_cyclic via isCyclic_of_prime_card).",
+      "mathContext": "$|G| = p$ prime $\\Rightarrow$ $|H| \\in \\{1, p\\}$ for all $H \\leq G$ $\\Rightarrow$ $G$ cyclic. Uses `Nat.Prime.eq_one_or_self_of_dvd`."
     },
     {
       "id": "significance",
       "title": "Significance and Verification",
       "startLine": 200,
       "endLine": 222,
-      "summary": "Discussion of why Lagrange matters (structure constraints, counting, number theory, extensions), the false converse (A₄ counterexample), and type-checking of all exported theorems."
+      "summary": "Discussion of why Lagrange matters (structure constraints, counting, number theory, extensions), the false converse (A₄ counterexample), and type-checking of all exported theorems.",
+      "mathContext": "False converse: $6 \\mid 12 = |A_4|$ but $A_4$ has no subgroup of order 6. Sylow theorems provide partial converse for prime powers."
     }
   ],
   "conclusion": {
@@ -221,6 +261,34 @@
       "year": "1975",
       "venue": "Wiley, 2nd edition",
       "note": "Chapter 2 presents the coset partition proof of Lagrange's theorem with applications to element orders, Fermat's theorem, and the structure of prime-order groups"
+    },
+    {
+      "authors": "Dummit, David S. and Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd edition",
+      "note": "Section 3.2 gives the standard coset proof of Lagrange's theorem; Section 4.5 discusses Sylow theorems as partial converse"
+    },
+    {
+      "authors": "Artin, Michael",
+      "title": "Algebra",
+      "year": "2011",
+      "venue": "Pearson, 2nd edition",
+      "note": "Chapter 2 develops Lagrange's theorem with emphasis on cosets as equivalence classes and applications to number theory"
+    },
+    {
+      "authors": "Sylow, Ludwig",
+      "title": "Théorèmes sur les groupes de substitutions",
+      "year": "1872",
+      "venue": "Mathematische Annalen, vol. 5, pp. 584–594",
+      "note": "Proved that subgroups of prime-power order exist for every prime power dividing |G| — the principal partial converse to Lagrange's theorem"
+    },
+    {
+      "authors": "Jordan, Camille",
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "venue": "Gauthier-Villars, Paris",
+      "note": "First systematic treatment of permutation groups, establishing the group-theoretic framework in which Lagrange's theorem is a foundational result"
     }
   ],
   "prerequisites": [

--- a/src/data/research/problems/erdos-335.json
+++ b/src/data/research/problems/erdos-335.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-13T00:04:50.018Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "3 axioms proved, 4 deep axioms remain",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved density_nonneg, density_le_one, additive_sum_le_one (7→4 axioms). Fixed imports (added Topology.Basic for limUnder). Added countingFn_le helper lemma.",
+    "builtItems": [
+      "density_nonneg (PROVED) - ge_of_tendsto + div_nonneg",
+      "density_le_one (PROVED) - le_of_tendsto + countingFn_le",
+      "additive_sum_le_one (PROVED) - from density_le_one + DensityAdditive",
+      "countingFn_le (helper) - Set.ncard_le_ncard + Nat.card_Icc"
+    ],
+    "insights": [
+      "limUnder requires Mathlib.Topology.Basic import (not in original file)",
+      "countingFn A N ≤ N: A∩Icc 1 N ⊆ Icc 1 N, ncard(Icc 1 N) = N",
+      "density_nonneg needs DensityExists assumption for proper statement (limUnder of non-convergent filter is arbitrary)",
+      "additive_sum_le_one follows trivially from density_le_one applied to Sumset A B"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Remaining 4 axioms are deep: weyl_equidistribution, fractional_part_density_additive, erdos_335_conjecture (open), plunnecke_ruzsa_lower"
+    ],
     "markdown": "# Erdős #335 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $d(A)$ denote the density of $A\\subseteq \\mathbb{N}$. Characterise those $A,B\\subseteq \\mathbb{N}$ with positive density such that\\[d(A+B)=d(A)+d(B).\\]\n\n\n\nOne way this can happen is if there exists $\\theta>0$ such that\\[A=\\{ n>0 : \\{ n\\theta\\} \\in X_A\\}\\textrm{ and }B=\\{ n>0 : \\{n\\theta\\} \\in X_B\\}\\]where $\\{x\\}$ denotes the fractional part of $x$ and $X_A,X_B\\subseteq \\mathbb{R}/\\mathbb{Z}$ are such that $\\mu(X_A+X_B)=\\mu(X_A)+\\mu(X_B)$. Are all possible $A$ and $B$ generated in a similar way (using other groups)?\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #334\n- Problem #336\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -50,16 +62,16 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:04:50.018Z",
-  "lastUpdate": "2026-03-13T07:52:17.046Z",
+  "lastUpdate": "2026-03-23T21:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos335Problem.lean",
       "filename": "Erdos335Problem.lean",
-      "lineCount": 123,
-      "theoremCount": 1,
-      "axiomCount": 7,
+      "lineCount": 148,
+      "theoremCount": 4,
+      "axiomCount": 4,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
Batch enrichment pass 2 for 6 gallery entries:

**erdos-106** (Square Packing): Added mathContext to all 11 sections, expanded prerequisites
**erdos-28** (Erdős-Turán Additive Bases): Added section mathContext, fixed duplicate refs, added leanFile metadata
**erdos-332** (Difference Sets): Added section mathContext, structured references
**erdos-347** (Complete Sequences): Added mathContext, cross-refs, references, relatedProofs
**erdos-273** (Covering Systems): Added mathContext, cross-refs, structured references
**erdos-278** (Coverage Density): Added mathContext, cross-refs, structured references

Common pattern fixed: missing `mathContext` in sections, string-format references → structured objects, generic prerequisites → specific topics.