### PR TITLE
Rename NonTrivial to HasNonGaussianCorrelations (#5298)

### DIFF
--- a/proofs/Proofs/OSBridge.lean
+++ b/proofs/Proofs/OSBridge.lean
@@ -484,7 +484,7 @@ def GaugeInvariant (_dμ : ProbabilityMeasure EFieldConfiguration) : Prop :=
 
     Reference: Glimm-Jaffe, Quantum Physics, Section 6.1 (Wick's theorem);
     Simon (1974), The P(phi)_2 Euclidean QFT, Ch. II. -/
-def NonTrivial (dμ : ProbabilityMeasure EFieldConfiguration) : Prop :=
+def HasNonGaussianCorrelations (dμ : ProbabilityMeasure EFieldConfiguration) : Prop :=
   ∃ (f : Fin 4 → ETestFunction),
     schwingerFunction dμ 4 f ≠
       schwingerFunction dμ 2 ![f 0, f 1] * schwingerFunction dμ 2 ![f 2, f 3] +
@@ -545,7 +545,7 @@ def YangMillsContinuumLimitFull (G : Type*) [Group G] [TopologicalSpace G]
   ∃ (dμ : ProbabilityMeasure EFieldConfiguration),
     SatisfiesAllOS dμ ∧
     GaugeInvariant dμ ∧
-    NonTrivial dμ ∧
+    HasNonGaussianCorrelations dμ ∧
     ∃ Δ : ℝ, hasExponentialClustering dμ Δ
 
 /-- **The Yang-Mills Millennium Prize theorem** (full chain).
@@ -589,7 +589,7 @@ For Yang-Mills (an interacting, non-abelian gauge theory), proving `SatisfiesAll
 is the core mathematical challenge. The lattice gauge theory approach
 (Wilson 1974) provides strong numerical evidence but no rigorous proof.
 
-The `NonTrivial` condition additionally rules out the Gaussian free field as
+The `HasNonGaussianCorrelations` condition additionally rules out the Gaussian free field as
 a solution to the Yang-Mills continuum limit problem: it requires the connected
 4-point function to be non-vanishing, which fails for any Gaussian measure
 by Wick's theorem. -/


### PR DESCRIPTION
## Summary
- Renames `NonTrivial` to `HasNonGaussianCorrelations` in `proofs/Proofs/OSBridge.lean` (3 locations: definition, usage in `YangMillsContinuumLimitFull`, doc comment)
- Avoids shadowing Mathlib's `Nontrivial` typeclass
- New name follows `Has...` predicate convention and describes the mathematical content (Wick's theorem violation)

Closes #5298

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.OSBridge` exits 0
- [x] No remaining references to old name: `grep NonTrivial proofs/Proofs/OSBridge.lean` returns empty
- [x] All 3 occurrences renamed: definition (line 487), usage (line 548), doc comment (line 592)

Generated with [Claude Code](https://claude.com/claude-code)