### PR TITLE
Research: erdos-848 - eliminate 3 axioms (6→3) via proper def + witness construction

### DIFF
--- a/proofs/Proofs/Erdos848Problem.lean
+++ b/proofs/Proofs/Erdos848Problem.lean
@@ -29,12 +29,30 @@ def IsSquarefree (n : ℕ) : Prop :=
 def HasNonSqfreeProductProp (A : Finset ℕ) : Prop :=
   ∀ a ∈ A, ∀ b ∈ A, ¬IsSquarefree (a * b + 1)
 
-/-- The maximum size of a subset of {1,...,N} with the non-squarefree
-    product property. Axiomatized. -/
-axiom maxNonSqfreeSet (N : ℕ) : ℕ
+/- ## Extremal Function -/
 
-/-- The max size is at most N. -/
-axiom maxNonSqfreeSet_le (N : ℕ) : maxNonSqfreeSet N ≤ N
+open Classical in
+/-- The maximum size of a subset of {1,...,N} with the non-squarefree
+    product property. Defined as the supremum over all qualifying subsets. -/
+noncomputable def maxNonSqfreeSet (N : ℕ) : ℕ :=
+  ((Finset.Icc 1 N).powerset.filter (fun A => HasNonSqfreeProductProp A)).sup Finset.card
+
+/-- The max size is at most N: any qualifying subset of {1,...,N} has ≤ N elements. -/
+theorem maxNonSqfreeSet_le (N : ℕ) : maxNonSqfreeSet N ≤ N := by
+  classical
+  unfold maxNonSqfreeSet
+  apply Finset.sup_le
+  intro A hA
+  simp only [Finset.mem_filter, Finset.mem_powerset] at hA
+  -- |A| ≤ |Icc 1 N| ≤ N via injection x ↦ x - 1 from Icc 1 N to range N
+  have hIcc_le : (Finset.Icc 1 N).card ≤ N := by
+    calc (Finset.Icc 1 N).card
+        ≤ (Finset.range N).card := Finset.card_le_card_of_injOn (· - 1)
+          (fun x hx => by simp only [Finset.mem_Icc] at hx; simp only [Finset.mem_range]; omega)
+          (fun a ha b hb h => by
+            simp only [Finset.coe_Icc, Set.mem_Icc] at ha hb; omega)
+      _ = N := Finset.card_range N
+  linarith [Finset.card_le_card hA.1]
 
 /- ## Known Results -/
 
@@ -44,12 +62,9 @@ theorem mod25_achieves :
   ∀ a b : ℕ, a % 25 = 7 → b % 25 = 7 →
     5 * 5 ∣ a * b + 1 := by
   intro a b ha hb
-  -- Write a = 25q₁ + 7 and b = 25q₂ + 7 via the division algorithm
   have ha' : a = 25 * (a / 25) + 7 := by omega
   have hb' : b = 25 * (b / 25) + 7 := by omega
   rw [ha', hb']
-  -- (25q₁ + 7)(25q₂ + 7) + 1 = 625q₁q₂ + 175q₁ + 175q₂ + 50
-  --                             = 25(25q₁q₂ + 7q₁ + 7q₂ + 2)
   exact ⟨25 * (a / 25) * (b / 25) + 7 * (a / 25) + 7 * (b / 25) + 2, by ring⟩
 
 /-- The symmetric case: {n ≡ 18 (mod 25)} also achieves the property.
@@ -61,8 +76,6 @@ theorem mod25_achieves_18 :
   have ha' : a = 25 * (a / 25) + 18 := by omega
   have hb' : b = 25 * (b / 25) + 18 := by omega
   rw [ha', hb']
-  -- (25q₁ + 18)(25q₂ + 18) + 1 = 625q₁q₂ + 450q₁ + 450q₂ + 325
-  --                               = 25(25q₁q₂ + 18q₁ + 18q₂ + 13)
   exact ⟨25 * (a / 25) * (b / 25) + 18 * (a / 25) + 18 * (b / 25) + 13, by ring⟩
 
 /-- 5 is prime — needed to connect 5² | n to ¬IsSquarefree n. -/
@@ -85,17 +98,68 @@ theorem mod18_set_has_property (A : Finset ℕ) (hA : ∀ a ∈ A, a % 25 = 18) 
   intro a ha b hb
   exact not_sqfree_of_five_sq_dvd (mod25_achieves_18 a b (hA a ha) (hA b hb))
 
-/-- This gives a lower bound: maxNonSqfreeSet(N) ≥ ⌊N/25⌋. -/
-axiom lower_bound (N : ℕ) (hN : 25 ≤ N) :
-  N / 25 ≤ maxNonSqfreeSet N
+/- ## Lower Bound via Witness Construction -/
+
+/-- The mod 7 residue class in {1,...,N}. -/
+private def mod7Set (N : ℕ) : Finset ℕ :=
+  (Finset.Icc 1 N).filter (fun n => n % 25 = 7)
+
+/-- mod7Set is a subset of Icc 1 N. -/
+private lemma mod7Set_sub (N : ℕ) : mod7Set N ⊆ Finset.Icc 1 N :=
+  Finset.filter_subset _ _
+
+/-- All elements of mod7Set are ≡ 7 (mod 25). -/
+private lemma mod7Set_residue {N n : ℕ} (hn : n ∈ mod7Set N) : n % 25 = 7 := by
+  simp only [mod7Set, Finset.mem_filter] at hn
+  exact hn.2
+
+/-- mod7Set satisfies HasNonSqfreeProductProp. -/
+private lemma mod7Set_prop (N : ℕ) : HasNonSqfreeProductProp (mod7Set N) :=
+  mod7_set_has_property (mod7Set N) (fun _ h => mod7Set_residue h)
+
+/-- Key cardinality bound: |{n ∈ {1,...,N} : n ≡ 7 (mod 25)}| ≥ N/25.
+    Proof via injection: k ↦ 25k + 7 maps {0,...,N/25-1} into mod7Set. -/
+private lemma mod7Set_card_ge (N : ℕ) (hN : 25 ≤ N) : N / 25 ≤ (mod7Set N).card := by
+  -- Define the injection k ↦ 25k + 7
+  set f : ℕ → ℕ := fun k => 25 * k + 7 with hf_def
+  -- Image of {0,...,N/25-1} under f lands in mod7Set N
+  have hf_mem : ∀ k, k ∈ Finset.range (N / 25) → f k ∈ mod7Set N := by
+    intro k hk
+    simp only [Finset.mem_range] at hk
+    simp only [mod7Set, Finset.mem_filter, Finset.mem_Icc, hf_def]
+    refine ⟨⟨by omega, ?_⟩, by omega⟩
+    have := Nat.div_mul_le_self N 25
+    omega
+  -- f is injective on Finset.range (N / 25)
+  have hf_inj : Set.InjOn f (Finset.range (N / 25) : Set ℕ) := by
+    intro a _ b _ hab
+    simp only [hf_def] at hab
+    omega
+  -- Conclude via card comparison
+  calc N / 25 = (Finset.range (N / 25)).card := (Finset.card_range _).symm
+    _ ≤ (mod7Set N).card := Finset.card_le_card_of_injOn f hf_mem hf_inj
+
+/-- Lower bound: maxNonSqfreeSet(N) ≥ ⌊N/25⌋ for N ≥ 25.
+    Proved by exhibiting the mod 7 residue class as a witness. -/
+theorem lower_bound (N : ℕ) (hN : 25 ≤ N) :
+    N / 25 ≤ maxNonSqfreeSet N := by
+  classical
+  unfold maxNonSqfreeSet
+  -- mod7Set N is in the filtered powerset
+  have hmem : mod7Set N ∈
+      (Finset.Icc 1 N).powerset.filter (fun A => HasNonSqfreeProductProp A) := by
+    rw [Finset.mem_filter]
+    exact ⟨Finset.mem_powerset.mpr (mod7Set_sub N), mod7Set_prop N⟩
+  calc N / 25 ≤ (mod7Set N).card := mod7Set_card_ge N hN
+    _ ≤ _ := Finset.le_sup hmem
+
+/- ## Deep Results (Axiomatized) -/
 
 /-- Van Doorn's upper bound: |A|/N ≤ 2 Σ_{p ≡ 1 (4)} 1/p² ≈ 0.108.
     So maxNonSqfreeSet(N) ≤ ⌊0.108 · N⌋ + O(1). -/
 axiom vanDoorn_upper_bound :
   ∃ C : ℕ, ∀ N : ℕ, 1 ≤ N →
     maxNonSqfreeSet N * 1000 ≤ 108 * N + C
-
-/- ## The Solution -/
 
 /-- Sawhney's theorem: for sufficiently large N, the maximum is exactly
     ⌊N/25⌋, achieved only by {n ≡ 7 (mod 25)} or {n ≡ 18 (mod 25)}. -/

--- a/src/data/proofs/erdos-848/meta.json
+++ b/src/data/proofs/erdos-848/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 848,
     "erdosUrl": "https://erdosproblems.com/848",
     "erdosProblemStatus": "solved",
-    "axiomCount": 6,
-    "assumptions": "7 axiom declarations: maxNonSqfreeSet (extremal function definition), maxNonSqfreeSet_le (trivial upper bound), mod25_achieves (5^2 divides ab+1 mod 25), lower_bound (N/25 lower bound), vanDoorn_upper_bound (0.108N upper bound), sawhney_solution (exact answer N/25), sawhney_structure (extremal set uniqueness)",
-    "lineCount": 71,
+    "axiomCount": 3,
+    "assumptions": "3 axiom declarations: vanDoorn_upper_bound (0.108N upper bound via prime density), sawhney_solution (exact answer N/25 for large N), sawhney_structure (extremal set uniqueness). Previously axiomatized maxNonSqfreeSet, maxNonSqfreeSet_le, and lower_bound are now proved.",
+    "lineCount": 176,
     "dateAdded": "2026-02-10",
     "mathlibDependencies": [
       {
@@ -34,7 +34,10 @@
     "originalContributions": [
       "IsSquarefree: constructive definition via ∀ p, p.Prime → ¬(p * p ∣ n)",
       "HasNonSqfreeProductProp: formal property requiring ¬IsSquarefree(ab+1) for all pairs",
-      "mod25_achieves: axiom that 5² | ab+1 when a ≡ b ≡ 7 (mod 25)",
+      "maxNonSqfreeSet: proper noncomputable def via Finset.sup over powerset (was axiom)",
+      "maxNonSqfreeSet_le: proved via injection x↦x-1 from Icc 1 N to range N (was axiom)",
+      "mod25_achieves: proved 5² | ab+1 when a ≡ b ≡ 7 (mod 25) via ring arithmetic",
+      "lower_bound: proved N/25 ≤ maxNonSqfreeSet N via witness construction k↦25k+7 (was axiom)",
       "sawhney_solution: axiom encoding the exact answer N/25 for large N",
       "sawhney_structure: axiom encoding uniqueness of extremal sets (mod 25 residue classes)"
     ],
@@ -76,7 +79,7 @@
     "historicalContext": "**Erdős and Sárközy** (1992) posed the problem of determining the maximum size of $A \\subseteq \\{1,\\ldots,N\\}$ such that $ab + 1$ is never squarefree for all $a, b \\in A$ (including $a = b$). The condition '$ab + 1$ is not squarefree' means there exists a prime $p$ with $p^2 \\mid ab + 1$.\n\nThe key construction exploits the arithmetic of $\\mathbb{Z}/25\\mathbb{Z}$: for $a \\equiv b \\equiv 7 \\pmod{25}$, we have $ab + 1 \\equiv 49 + 1 = 50 \\equiv 0 \\pmod{25}$, so $5^2 \\mid ab + 1$. Similarly, $18 \\equiv -7 \\pmod{25}$ gives $18^2 + 1 = 325 = 13 \\cdot 25$, so the same holds. The residues $7$ and $18 = 25 - 7$ are the two square roots of $-1$ modulo $25$ (since $7^2 = 49 \\equiv -1 \\pmod{25}$). This construction achieves $|A| = \\lfloor N/25 \\rfloor$.\n\n**Van Doorn** improved the upper bound to approximately $0.108N$ using an inclusion-exclusion argument over primes $p \\equiv 1 \\pmod{4}$: for each such prime, $a^2 + 1 \\equiv 0 \\pmod{p^2}$ has exactly 2 solutions mod $p^2$, contributing $2/p^2$ to the density. The sum $2\\sum_{p \\equiv 1(4)} 1/p^2 \\approx 0.108$ gives the bound. **Weisenberg** refined this further.\n\nFinally, **Sawhney** proved the exact answer: for all sufficiently large $N$, $\\max|A| = \\lfloor N/25 \\rfloor$, and the extremal sets are precisely $\\{n \\equiv 7 \\pmod{25}\\}$ and $\\{n \\equiv 18 \\pmod{25}\\}$. The proof uses modern tools from additive combinatorics to show that any near-extremal set must concentrate in one of these two residue classes.",
     "problemStatement": "Determine $\\max|A|$ for $A \\subseteq \\{1,\\ldots,N\\}$ satisfying: for all $a, b \\in A$, $ab + 1$ is not squarefree (i.e., $\\exists p$ prime with $p^2 \\mid ab + 1$).",
     "text": "Max |A| with A ⊆ {1,...,N} and ab+1 never squarefree for a,b ∈ A. Extremal sets: {n ≡ 7 (mod 25)} or {n ≡ 18 (mod 25)}, giving N/25. Solved by Sawhney for large N.",
-    "proofStrategy": "The formalization defines `IsSquarefree` constructively (no prime squared divides $n$) and `HasNonSqfreeProductProp` (the pairwise non-squarefree condition). The extremal function `maxNonSqfreeSet` is axiomatized with an upper bound ($\\leq N$). Three key results are axiomatized: the mod-25 construction (showing $5^2 \\mid ab+1$ for the residue class), the van Doorn upper bound ($\\leq 0.108N + O(1)$), and Sawhney's exact solution with structural characterization.",
+    "proofStrategy": "The formalization defines `IsSquarefree` constructively and `HasNonSqfreeProductProp`. The extremal function `maxNonSqfreeSet` is defined as the Finset.sup of cardinalities over all qualifying subsets of $\\{1,\\ldots,N\\}$. The upper bound ($\\leq N$) is proved via an injection argument, and the lower bound ($\\geq \\lfloor N/25 \\rfloor$) is proved by constructing the mod-7 witness set. Three deep results remain axiomatized: van Doorn's upper bound ($\\leq 0.108N$), Sawhney's exact solution, and the structural characterization.",
     "keyInsights": [
       "For a ≡ b ≡ 7 (mod 25), ab + 1 ≡ 49 + 1 = 50 ≡ 0 (mod 25), so 5² | ab + 1. The residue 7 satisfies 7² ≡ -1 (mod 25)",
       "The same holds for 18 ≡ -7 (mod 25) since 18² + 1 = 325 = 13 · 25. The pair {7, 18} are the two square roots of -1 in Z/25Z",
@@ -104,45 +107,37 @@
       "id": "definitions",
       "title": "Definitions and Extremal Function",
       "startLine": 21,
-      "endLine": 37,
-      "summary": "IsSquarefree (no prime squared divides n), HasNonSqfreeProductProp (pairwise non-squarefree products), maxNonSqfreeSet (axiomatized extremal function), and the trivial upper bound maxNonSqfreeSet(N) ≤ N.",
-      "mathContext": "$\\text{IsSquarefree}(n) :\\Leftrightarrow \\forall p$ prime, $p^2 \\nmid n$. $\\text{HasNonSqfreeProductProp}(A) :\\Leftrightarrow \\forall a,b \\in A,\\ \\neg\\text{IsSquarefree}(ab+1)$. The extremal function and its bound are axiomatized since formalizing the maximum over all valid subsets would require significant Finset machinery."
+      "endLine": 57,
+      "summary": "IsSquarefree, HasNonSqfreeProductProp, maxNonSqfreeSet (noncomputable def via Finset.sup over powerset), and maxNonSqfreeSet_le proved via injection x↦x-1.",
+      "mathContext": "$\\text{maxNonSqfreeSet}(N) := \\sup\\{|A| : A \\subseteq \\{1,\\ldots,N\\},\\ \\text{HasNonSqfreeProductProp}(A)\\}$. Upper bound $\\leq N$ proved by injecting $\\text{Icc}(1,N)$ into $\\text{range}(N)$ via $x \\mapsto x-1$."
     },
     {
       "id": "mod25-construction",
-      "title": "Mod 25 Construction (Lower Bound)",
-      "startLine": 39,
-      "endLine": 49,
-      "summary": "mod25_achieves: for a ≡ b ≡ 7 (mod 25), 5² | ab+1 since ab+1 ≡ 50 ≡ 0 (mod 25). lower_bound: maxNonSqfreeSet(N) ≥ ⌊N/25⌋.",
-      "mathContext": "The residue $7 \\bmod 25$ satisfies $7^2 = 49 \\equiv -1 \\pmod{25}$, so for $a \\equiv b \\equiv 7$, $ab + 1 \\equiv 49 + 1 = 50 \\equiv 0 \\pmod{25}$. The set $\\{n \\leq N : n \\equiv 7 \\pmod{25}\\}$ has $\\lfloor N/25 \\rfloor$ elements, giving the lower bound."
+      "title": "Mod 25 Constructions and Connecting Lemmas",
+      "startLine": 59,
+      "endLine": 102,
+      "summary": "mod25_achieves and mod25_achieves_18: proved 5² | ab+1 for both residue classes via ring arithmetic. five_prime, not_sqfree_of_five_sq_dvd, mod7/18_set_has_property: connect divisibility to HasNonSqfreeProductProp.",
+      "mathContext": "For $a \\equiv b \\equiv 7 \\pmod{25}$: $ab+1 \\equiv 50 \\equiv 0 \\pmod{25}$. For $a \\equiv b \\equiv 18 \\pmod{25}$: $ab+1 \\equiv 325 \\equiv 0 \\pmod{25}$. Both give $5^2 \\mid ab+1$, hence $\\neg\\text{IsSquarefree}(ab+1)$."
     },
     {
-      "id": "vanDoorn-bound",
-      "title": "Van Doorn's Upper Bound",
-      "startLine": 51,
-      "endLine": 55,
-      "summary": "vanDoorn_upper_bound: maxNonSqfreeSet(N) ≤ 0.108N + O(1), encoded as maxNonSqfreeSet(N) · 1000 ≤ 108 · N + C to avoid rationals.",
-      "mathContext": "The bound $|A|/N \\leq 2\\sum_{p \\equiv 1(4)} 1/p^2 \\approx 0.108$ arises from inclusion-exclusion: each prime $p \\equiv 1 \\pmod{4}$ contributes exactly 2 residue classes mod $p^2$ where $a^2 + 1 \\equiv 0$, while primes $p \\equiv 3 \\pmod{4}$ contribute none."
+      "id": "lower-bound",
+      "title": "Lower Bound via Witness Construction",
+      "startLine": 104,
+      "endLine": 153,
+      "summary": "Defines mod7Set, proves it has the property and has cardinality ≥ N/25 via injection k↦25k+7. Concludes lower_bound: N/25 ≤ maxNonSqfreeSet(N) for N ≥ 25.",
+      "mathContext": "The injection $k \\mapsto 25k+7$ maps $\\{0,\\ldots,\\lfloor N/25\\rfloor - 1\\}$ into $\\{n \\in \\{1,\\ldots,N\\} : n \\equiv 7 \\pmod{25}\\}$. Combined with Finset.le_sup, this gives the lower bound on the extremal function."
     },
     {
-      "id": "exact-solution",
-      "title": "Sawhney's Exact Answer",
-      "startLine": 57,
-      "endLine": 63,
-      "summary": "sawhney_solution: for sufficiently large N, maxNonSqfreeSet(N) = ⌊N/25⌋ exactly, closing the gap between the N/25 lower bound and the 0.108N upper bound.",
-      "mathContext": "$\\exists N_0,\\ \\forall N \\geq N_0: \\max|A| = \\lfloor N/25 \\rfloor$. This shows the simple mod-25 construction is optimal, a dramatic improvement over Van Doorn's $0.108N$ bound."
-    },
-    {
-      "id": "structural-characterization",
-      "title": "Uniqueness of Extremal Sets",
-      "startLine": 65,
-      "endLine": 71,
-      "summary": "sawhney_structure: any extremal set of size ⌊N/25⌋ for large N must consist entirely of elements ≡ 7 (mod 25) or entirely of elements ≡ 18 (mod 25). A rigidity result paralleling Turán-type stability in extremal graph theory.",
-      "mathContext": "Any extremal $A$ satisfies $A \\subseteq \\{n \\equiv 7\\}$ or $A \\subseteq \\{n \\equiv 18\\} \\pmod{25}$. The two classes correspond to the two roots of $x^2 \\equiv -1 \\pmod{25}$, reflecting a $\\mathbb{Z}/2\\mathbb{Z}$ symmetry."
+      "id": "deep-results",
+      "title": "Deep Results (Axiomatized)",
+      "startLine": 155,
+      "endLine": 176,
+      "summary": "vanDoorn_upper_bound (0.108N), sawhney_solution (exact N/25), sawhney_structure (uniqueness of extremal sets). These require deep analytic/combinatorial arguments beyond current Lean formalization.",
+      "mathContext": "Van Doorn: $|A|/N \\leq 2\\sum_{p \\equiv 1(4)} 1/p^2 \\approx 0.108$. Sawhney: $\\forall N \\geq N_0,\\ \\max|A| = \\lfloor N/25\\rfloor$, achieved only by $\\{n \\equiv 7\\}$ or $\\{n \\equiv 18\\} \\pmod{25}$."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #848 is formalized in 71 lines with 7 axioms encoding the extremal function, bounds, and Sawhney's exact solution. The key definitions (IsSquarefree, HasNonSqfreeProductProp) are constructive; the results are axiomatized. The answer is N/25 for large N, achieved by the mod-25 residue classes {7} and {18}.",
+    "summary": "Erdős Problem #848 is formalized in 176 lines with 3 axioms (down from 6). The extremal function maxNonSqfreeSet is now properly defined via Finset.sup, with both bounds proved: maxNonSqfreeSet_le (upper, via injection) and lower_bound (via witness construction). Only deep results remain axiomatized: Van Doorn's upper bound, Sawhney's exact solution, and the structural characterization.",
     "implications": "The result reveals a surprising connection between squarefree numbers and modular arithmetic: the extremal configuration is determined entirely by the quadratic residue structure of Z/25Z. The rigidity of the extremal sets (uniqueness up to the 7 ↔ 18 symmetry) suggests deep structural constraints beyond simple density arguments.",
     "openQuestions": [
       "What is the exact value of maxNonSqfreeSet(N) for small N? Sawhney's result only applies for sufficiently large N",
@@ -159,10 +154,10 @@
     ],
     "opens": [],
     "namespace": "Erdos848",
-    "lineCount": 71,
-    "axiomCount": 7,
-    "theoremCount": 0,
-    "definitionCount": 2
+    "lineCount": 176,
+    "axiomCount": 3,
+    "theoremCount": 8,
+    "definitionCount": 4
   },
   "references": [
     {

--- a/src/data/research/problems/erdos-848.json
+++ b/src/data/research/problems/erdos-848.json
@@ -16,37 +16,44 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-03-23T20:50:00Z",
-    "iteration": 2,
-    "focus": "Axiom elimination: proved mod25_achieves, added supporting theorems",
+    "phase": "ACT",
+    "since": "2026-03-23T21:30:00Z",
+    "iteration": 3,
+    "focus": "Axiom elimination: converted maxNonSqfreeSet to noncomputable def, proved maxNonSqfreeSet_le and lower_bound (6→3 axioms)",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Remaining 3 axioms are deep results (Van Doorn, Sawhney). Further progress would require formalizing analytic number theory.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 3,
+      "currentApproach": 2,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 1 axiom (7→6). Proved mod25_achieves from arithmetic. Added symmetric mod 18 case and connecting lemmas showing both residue classes satisfy the full non-squarefree product property.",
+    "progressSummary": "PROGRESS: Eliminated 3 more axioms (6→3). Converted maxNonSqfreeSet from axiom to noncomputable def via Finset.sup. Proved maxNonSqfreeSet_le via injection x↦x-1. Proved lower_bound via witness construction k↦25k+7. All builds verified.",
     "builtItems": [
       "Proved mod25_achieves (axiom→theorem): 5²|ab+1 when a≡b≡7(mod25)",
       "Proved mod25_achieves_18: symmetric case for a≡b≡18(mod25)",
       "Proved five_prime, not_sqfree_of_five_sq_dvd: connecting 5²|n to ¬IsSquarefree",
-      "Proved mod7_set_has_property, mod18_set_has_property: full HasNonSqfreeProductProp"
+      "Proved mod7_set_has_property, mod18_set_has_property: full HasNonSqfreeProductProp",
+      "Converted maxNonSqfreeSet from axiom to noncomputable def via Finset.sup over powerset",
+      "Proved maxNonSqfreeSet_le: |A| ≤ |Icc 1 N| ≤ N via injection x↦x-1 to range N",
+      "Proved lower_bound: N/25 ≤ maxNonSqfreeSet N via mod7Set witness and injection k↦25k+7",
+      "Added mod7Set helper def with residue, subset, and cardinality lemmas"
     ],
     "insights": [
       "mod25_achieves is pure arithmetic: 7*7+1=50, 25|50, so 5²|ab+1 for a≡b≡7(mod25)",
       "Symmetric case mod 18 also works: 18*18+1=325, 25|325",
       "Both extremal residue classes {7 mod 25} and {18 mod 25} satisfy HasNonSqfreeProductProp via 5²",
-      "6 remaining axioms are deep results: maxNonSqfreeSet definition, bounds, and Sawhney solution"
+      "maxNonSqfreeSet can be defined as Finset.sup (powerset.filter HasNonSqfreeProductProp) card using open Classical for decidability",
+      "Upper bound proof: injection x↦x-1 from Icc 1 N to range N avoids needing Finset.card_Icc",
+      "Lower bound proof: injection k↦25k+7 from range(N/25) to mod7Set N, using Nat.div_mul_le_self for the bound 25k+7 ≤ N",
+      "Remaining 3 axioms are genuinely deep: Van Doorn's analytic upper bound, Sawhney's exact solution, and structural characterization"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Convert maxNonSqfreeSet from axiom to noncomputable def (needs decidability of HasNonSqfreeProductProp)",
-      "Prove maxNonSqfreeSet_le from proper definition",
-      "Prove lower_bound by constructing the mod 7 witness set"
+      "Remaining axioms require deep analytic number theory (prime density sums, additive combinatorics)",
+      "Van Doorn's bound could potentially be formalized with enough infrastructure for sums over primes",
+      "Sawhney's theorem is a recent deep result - unlikely to be formalizable without major new infrastructure"
     ],
     "markdown": "# Erdős #848 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs the maximum size of a set $A\\subseteq \\{1,\\ldots,N\\}$ such that $ab+1$ is never squarefree (for all $a,b\\in A$) achieved by taking those $n\\equiv 7\\pmod{25}$?\n\n\n\nA problem of Erd\\H{o}s and S\\'{a}rk\\\"{o}zy.\n\nvan Doorn has sent the following argument which shows\\[\\lvert A\\rvert \\leq (0.108\\cdots+o(1))N.\\]The condition implies, in particular, that $a^2+1$ is divisible by $p^2$ for some prime $p$ for all $a\\in A$. Furthermore, $a^2+1\\equiv 0\\pmod{p^2}$ has either $2$ or $0$ solutions, according to whether $p\\equiv 1\\pmod{4}$ or $p\\equiv 3\\pmod{4}$. It follows that every $a\\in A$ belongs to one of $2$ residue classes for some prime $p\\equiv 1\\pmod{4}$, and hence, as $N\\to \\infty$,\\[\\frac{\\lvert A\\rvert}{N}\\leq 2\\sum_{p\\equiv 1\\pmod{4}}\\frac{1}{p^2}\\approx 0.108.\\]Weisenberg has noted that this proof in fact gives the slightly better constant of $\\approx 0.105$ (see the comments section).\n\nThis was solved for all sufficiently large $N$ by Sawhney in this note. In fact, Sawhney proves something slightly stronger, that there exists some constant $c>0$ such that if $\\lvert A\\rvert \\geq (\\frac{1}{25}-c)N$ and $N$ is large then $A$ is contained in either $\\{ n\\equiv 7\\pmod{25}\\}$ or $\\{n\\equiv 18\\pmod{25}\\}$.\n\nSee also [844].\n\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #844\n- Problem #847\n- Problem #849\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -64,17 +71,17 @@
     "mathlib": []
   },
   "started": "2026-01-15T10:25:45.155Z",
-  "lastUpdate": "2026-03-13T07:52:17.053Z",
+  "lastUpdate": "2026-03-23T21:30:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos848Problem.lean",
       "filename": "Erdos848Problem.lean",
-      "lineCount": 72,
-      "theoremCount": 6,
-      "axiomCount": 6,
-      "defCount": 2,
+      "lineCount": 176,
+      "theoremCount": 8,
+      "axiomCount": 3,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos848Problem.lean"


### PR DESCRIPTION
## Summary
- Convert `maxNonSqfreeSet` from axiom to `noncomputable def` via `Finset.sup` over powerset
- Prove `maxNonSqfreeSet_le` (upper bound ≤ N) via injection `x ↦ x-1` from `Icc 1 N` to `range N`
- Prove `lower_bound` (N/25 ≤ maxNonSqfreeSet N) via mod-7 witness set and injection `k ↦ 25k+7`
- Add helper infrastructure: `mod7Set` def with subset, residue, property, and cardinality lemmas
- Axiom count reduced from 6 to 3; remaining are deep results (Van Doorn, Sawhney)

## Progress
- **Axioms eliminated**: `maxNonSqfreeSet` (def), `maxNonSqfreeSet_le` (trivial bound), `lower_bound` (witness)
- **Axioms remaining**: `vanDoorn_upper_bound`, `sawhney_solution`, `sawhney_structure` (deep analytic/combinatorial)
- **Line count**: 72 → 176 (all new lines are proved theorems)
- **Build verified**: Docker build passes cleanly

## Key Techniques
- `open Classical in` for `noncomputable def` with `Finset.filter` on undecidable predicates
- Injection `x ↦ x-1` to bound `|Icc 1 N|` without `Finset.card_Icc` (avoids naming issues)
- Injection `k ↦ 25k+7` with `Nat.div_mul_le_self` for the cardinality lower bound

🤖 Generated by researcher-5