### PR TITLE
Enrich feuerbachs-theorem: add mathContext to all 11 sections

### DIFF
--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -60,77 +60,88 @@
       "title": "Triangle Configuration in R²",
       "startLine": 55,
       "endLine": 93,
-      "summary": "Defines Point (R²), Triangle structure with non-degeneracy, side lengths a, b, c via distance formula, semi-perimeter, and area via shoelace formula."
+      "summary": "Defines Point (R²), Triangle structure with non-degeneracy, side lengths a, b, c via distance formula, semi-perimeter, and area via shoelace formula.",
+      "mathContext": "A triangle $\\triangle ABC$ in $\\mathbb{R}^2$ with vertices $A, B, C$ (non-collinear). Side lengths $a = |BC|$, $b = |CA|$, $c = |AB|$. Semiperimeter $s = (a+b+c)/2$. Area $\\Delta = \\sqrt{s(s-a)(s-b)(s-c)}$ (Heron's formula)."
     },
     {
       "id": "special-points",
       "title": "Special Points of a Triangle",
       "startLine": 94,
       "endLine": 136,
-      "summary": "Defines midpoints, circumcenter O (via perpendicular bisector intersection), circumradius R, orthocenter H (via H = A+B+C-2O), and centroid G."
+      "summary": "Defines midpoints, circumcenter O (via perpendicular bisector intersection), circumradius R, orthocenter H (via H = A+B+C-2O), and centroid G.",
+      "mathContext": "Circumcenter $O$: intersection of perpendicular bisectors, equidistant from all vertices with $R = |OA| = |OB| = |OC|$. Orthocenter $H$: intersection of altitudes, satisfying $\\vec{OH} = \\vec{OA} + \\vec{OB} + \\vec{OC}$. Centroid $G = (A+B+C)/3$."
     },
     {
       "id": "nine-point-circle",
       "title": "The Nine-Point Circle",
       "startLine": 138,
       "endLine": 157,
-      "summary": "Nine-point center N = midpoint(O,H), nine-point radius R₉ = R/2, and the three Euler points (midpoints of AH, BH, CH)."
+      "summary": "Nine-point center N = midpoint(O,H), nine-point radius R₉ = R/2, and the three Euler points (midpoints of AH, BH, CH).",
+      "mathContext": "The nine-point circle passes through 9 special points: side midpoints $M_a, M_b, M_c$, altitude feet $H_a, H_b, H_c$, and Euler points (midpoints of $AH, BH, CH$). Center $N = (O+H)/2$ (midpoint of circumcenter and orthocenter), radius $R_9 = R/2$."
     },
     {
       "id": "incircle-excircles",
       "title": "Incircle and Excircles",
       "startLine": 159,
       "endLine": 164,
-      "summary": "Incenter I via barycentric coordinates (weights a:b:c), inradius r = Area/s. Three excenters via signed weights, exradii r_k = Area/(s-k)."
+      "summary": "Incenter I via barycentric coordinates (weights a:b:c), inradius r = Area/s. Three excenters via signed weights, exradii r_k = Area/(s-k).",
+      "mathContext": "Incenter $I$ at barycentric coordinates $(a:b:c)$, inradius $r = \\Delta/s$. Excenter $I_a$ opposite $A$ at $(-a:b:c)$, exradius $r_a = \\Delta/(s-a)$. Similarly for $I_b, I_c$. The incircle is internally tangent to all three sides; each excircle is externally tangent to one side and internally tangent to the extensions of the other two."
     },
     {
       "id": "tangency-defs",
       "title": "Tangency Definitions",
       "startLine": 212,
       "endLine": 164,
-      "summary": "Internal tangency (d = |r₁-r₂|) and external tangency (d = r₁+r₂) for circles."
+      "summary": "Internal tangency (d = |r₁-r₂|) and external tangency (d = r₁+r₂) for circles.",
+      "mathContext": "Two circles are **internally tangent** if $d(O_1, O_2) = |r_1 - r_2|$ (one inside the other, touching at exactly one point). **Externally tangent** if $d(O_1, O_2) = r_1 + r_2$ (touching at one point, neither inside the other)."
     },
     {
       "id": "euler-line",
       "title": "Euler Line Relations (Proved)",
       "startLine": 226,
       "endLine": 164,
-      "summary": "Proves G = (O+2H)/3 (Euler line relation) and N = midpoint(O,H) by coordinate computation with ring tactic."
+      "summary": "Proves G = (O+2H)/3 (Euler line relation) and N = midpoint(O,H) by coordinate computation with ring tactic.",
+      "mathContext": "The Euler line passes through $O$, $G$, $H$, $N$ with ratios $OG:GH = 1:2$ and $N = (O+H)/2$. Proved by coordinate computation: if $O$ is the origin, then $H = A+B+C$ and $G = (A+B+C)/3 = H/3 = (O + 2H)/3$."
     },
     {
       "id": "distance-relations",
       "title": "Feuerbach Distance Relations (Proved)",
       "startLine": 245,
       "endLine": 164,
-      "summary": "Four theorems proved by coordinate computation: d(N,I) = |R/2-r| (incircle), d(N,I_k) = R/2+r_k for k=a,b,c (excircles). Proofs in FeuerbachsTheoremOQ01.lean."
+      "summary": "Four theorems proved by coordinate computation: d(N,I) = |R/2-r| (incircle), d(N,I_k) = R/2+r_k for k=a,b,c (excircles). Proofs in FeuerbachsTheoremOQ01.lean.",
+      "mathContext": "The four Feuerbach distances: $d(N, I) = |R/2 - r|$ (tangent to incircle), $d(N, I_a) = R/2 + r_a$, $d(N, I_b) = R/2 + r_b$, $d(N, I_c) = R/2 + r_c$ (tangent to excircles). Since $R_9 = R/2$: incircle tangency is internal ($d = |R_9 - r|$), excircle tangencies are external ($d = R_9 + r_k$)."
     },
     {
       "id": "nine-point-props",
       "title": "Nine-Point Circle Membership (Proved)",
       "startLine": 272,
       "endLine": 164,
-      "summary": "All nine points proved to lie on the nine-point circle: d(N,P) = R/2 for side midpoints, Euler points, and altitude feet."
+      "summary": "All nine points proved to lie on the nine-point circle: d(N,P) = R/2 for side midpoints, Euler points, and altitude feet.",
+      "mathContext": "Membership proofs: for each of the 9 points $P$, show $d(N, P) = R/2$ by coordinate computation. For side midpoints: $M_a = (B+C)/2$ and $d((O+H)/2, (B+C)/2) = R/2$. Similar for Euler points and altitude feet."
     },
     {
       "id": "main-theorem",
       "title": "Feuerbach's Theorem: Complete Statement",
       "startLine": 304,
       "endLine": 164,
-      "summary": "Combines the four proved distance relations into the full theorem: internal tangency with incircle ∧ external tangency with all three excircles. Fully proved."
+      "summary": "Combines the four proved distance relations into the full theorem: internal tangency with incircle ∧ external tangency with all three excircles. Fully proved.",
+      "mathContext": "**Feuerbach's Theorem (1822)**: The nine-point circle of any triangle is internally tangent to the incircle and externally tangent to all three excircles. Formally: $d(N,I) = |R/2 - r|$ and $d(N,I_k) = R/2 + r_k$ for $k = a, b, c$. The tangent point with the incircle is the **Feuerbach point** $X(11)$ in Kimberling's notation."
     },
     {
       "id": "equilateral",
       "title": "Equilateral Triangle Special Case",
       "startLine": 366,
       "endLine": 164,
-      "summary": "Proves R = 2r for equilateral triangles via coordinate computation, implying the nine-point circle and incircle coincide (degenerate tangency)."
+      "summary": "Proves R = 2r for equilateral triangles via coordinate computation, implying the nine-point circle and incircle coincide (degenerate tangency).",
+      "mathContext": "For equilateral triangles: $R = 2r$ (circumradius = twice inradius), so $d(N, I) = |R/2 - r| = |r - r| = 0$, meaning the nine-point circle and incircle coincide. This is the degenerate case where internal tangency becomes coincidence. Also $O = H = I = G = N$ (all centers coincide)."
     },
     {
       "id": "numerical",
       "title": "Numerical Verification: 3-4-5 Triangle",
       "startLine": 405,
       "endLine": 164,
-      "summary": "Fully proves area = 6, semiperimeter = 6, inradius = 1 for the 3-4-5 right triangle using norm_num and sqrt computations."
+      "summary": "Fully proves area = 6, semiperimeter = 6, inradius = 1 for the 3-4-5 right triangle using norm_num and sqrt computations.",
+      "mathContext": "3-4-5 right triangle: $a = 3, b = 4, c = 5$, $s = 6$, $\\Delta = 6$, $r = \\Delta/s = 1$, $R = c/2 = 5/2$ (right triangle formula). Feuerbach: $d(N, I) = |5/4 - 1| = 1/4 = R/2 - r = 5/4 - 1$. Verified by `norm_num` in Lean."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enrichment pass for feuerbachs-theorem (Wiedijk #29, 0 passes → 1):

- **Added mathContext to all 11 sections** (0/11 → 11/11)
- Covers triangle configuration, special points, nine-point circle definition, incircle/excircles, tangency definitions, Euler line, Feuerbach distance relations, nine-point membership proofs, main theorem statement, equilateral special case, and 3-4-5 numerical verification

All JSON validated.