### PR TITLE
Research: erdos-278 - Fix buggy proofs, correct coprime formula

### DIFF
--- a/proofs/Proofs/Erdos278Problem.lean
+++ b/proofs/Proofs/Erdos278Problem.lean
@@ -157,9 +157,21 @@ axiom simpson_theorem (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n) :
     ∀ r : ℕ → ℕ,
       coverageDensity ⟨moduli, (fun _ => 0), hpos⟩ ≤ coverageDensity ⟨moduli, r, hpos⟩
 
+/-- (x % L + y) % L = (x + y) % L — factoring out a mod from an addend. -/
+private lemma mod_add_mod (x y L : ℕ) (hL : 0 < L) : (x % L + y) % L = (x + y) % L := by
+  rw [Nat.add_mod (x % L) y L, Nat.mod_eq_of_lt (Nat.mod_lt x hL), ← Nat.add_mod x y L]
+
+/-- If L ∣ c and m < L, then (m + c) % L = m. -/
+private lemma add_dvd_mod (m c L : ℕ) (hm : m < L) (hL : 0 < L) (hc : L ∣ c) :
+    (m + c) % L = m := by
+  obtain ⟨k, rfl⟩ := hc
+  rw [Nat.add_mod, show L * k % L = 0 from Nat.mul_mod_right L k,
+      Nat.add_zero, Nat.mod_eq_of_lt (Nat.mod_lt m hL), Nat.mod_eq_of_lt hm]
+
 /-- The coverage filter for constant residue a has the same cardinality as for
-    constant residue 0, via the cyclic shift m ↦ (m+a)%L on {0,...,L-1}.
-    Since n∣L for each modulus n, the shift preserves residue classes. -/
+    constant residue 0, via cyclic shift bijection on {0,...,L-1}.
+    Forward: m ↦ (m + (L - a%L)) % L maps "≡a" to "divisible" (shifts a↦0).
+    Backward: m ↦ (m + a) % L maps "divisible" to "≡a" (shifts 0↦a). -/
 private lemma coverage_card_shift (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n) (a : ℕ) :
     let L := systemLCM ⟨moduli, fun _ => a, hpos⟩
     ((Finset.range L).filter (fun m => ∃ n ∈ moduli, m % n = a % n)).card =
@@ -168,33 +180,58 @@ private lemma coverage_card_shift (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli
   have hLpos : 0 < L := systemLCM_pos ⟨moduli, fun _ => a, hpos⟩
   have hdvd : ∀ n ∈ moduli, n ∣ L := fun n hn =>
     dvd_systemLCM ⟨moduli, fun _ => a, hpos⟩ n hn
-  -- Bijection: forward m ↦ (m+a)%L, backward m ↦ (m+L-a%L)%L
-  apply Finset.card_bij' (fun m _ => (m + a) % L) (fun m _ => (m + L - a % L) % L)
-  -- Forward: maps "divisible" filter into "≡a" filter
+  set b := L - a % L with hb_def
+  have haL : a % L < L := Nat.mod_lt a hLpos
+  -- a + b and b + a are multiples of L (key for round-trips)
+  have hab_dvd : L ∣ (a + b) := by
+    refine ⟨a / L + 1, ?_⟩
+    rw [mul_add, mul_one]  -- L*(a/L+1) → L*(a/L) + L
+    have := Nat.div_add_mod a L; omega
+  have hba_dvd : L ∣ (b + a) := by rwa [Nat.add_comm]
+  -- Forward: (· + b) maps F_a → F_0; Backward: (· + a) maps F_0 → F_a
+  apply Finset.card_bij' (fun m _ => (m + b) % L) (fun m _ => (m + a) % L)
+  -- Forward: maps "≡a" filter into "divisible" filter
+  · intro m hm
+    simp only [Finset.mem_filter, Finset.mem_range] at hm ⊢
+    refine ⟨Nat.mod_lt _ hLpos, ?_⟩
+    obtain ⟨_, k, hk, hmod⟩ := hm
+    have hkL := hdvd k hk
+    exact ⟨k, hk, by
+      -- Goal: ((m + b) % L) % k = 0
+      -- Key: (a%k + (L-a%L)%k) % k = 0 because a%L + (L-a%L) = L and k∣L
+      rw [Nat.mod_mod_of_dvd _ hkL, Nat.add_mod, hmod,
+          ← Nat.mod_mod_of_dvd a hkL, ← Nat.add_mod]
+      -- Goal: (a % L + b) % k = 0
+      show (a % L + b) % k = 0
+      have : a % L + b = L := by omega
+      rw [this]
+      obtain ⟨q, hq⟩ := hkL; rw [hq]; exact Nat.mul_mod_right k q⟩
+  -- Backward: maps "divisible" filter into "≡a" filter
   · intro m hm
     simp only [Finset.mem_filter, Finset.mem_range] at hm ⊢
     refine ⟨Nat.mod_lt _ hLpos, ?_⟩
     obtain ⟨_, k, hk, hmod⟩ := hm
     exact ⟨k, hk, by
+      -- Goal: ((m + a) % L) % k = a % k
+      -- Key: m%k = 0, so (m+a)%k = a%k
       rw [Nat.mod_mod_of_dvd _ (hdvd k hk), Nat.add_mod, hmod, Nat.zero_add,
-          Nat.mod_mod_of_dvd _ (dvd_refl k)]⟩
-  -- Backward: maps "≡a" filter into "divisible" filter
+          Nat.mod_eq_of_lt (Nat.mod_lt a (hpos k hk))]⟩
+  -- Round-trip: g ∘ f = id on F_a (left_inv)
   · intro m hm
-    simp only [Finset.mem_filter, Finset.mem_range] at hm ⊢
-    refine ⟨Nat.mod_lt _ hLpos, ?_⟩
-    obtain ⟨hml, k, hk, hmod⟩ := hm
-    have hkL := hdvd k hk
-    exact ⟨k, hk, by
-      rw [Nat.mod_mod_of_dvd _ hkL]
-      have hLk : L % k = 0 := by obtain ⟨q, hq⟩ := hkL; rw [hq]; exact Nat.mul_mod_right k q
-      have haLk : (a % L) % k = a % k := Nat.mod_mod_of_dvd a hkL
-      omega⟩
-  -- Round-trip: backward ∘ forward = id
+    simp only [Finset.mem_filter, Finset.mem_range] at hm
+    -- g(f(m)) = ((m + b) % L + a) % L = m
+    calc ((m + b) % L + a) % L
+        = (m + b + a) % L := mod_add_mod (m + b) a L hLpos
+      _ = (m + (b + a)) % L := by ring_nf
+      _ = m := add_dvd_mod m (b + a) L hm.1 hLpos hba_dvd
+  -- Round-trip: f ∘ g = id on F_0 (right_inv)
   · intro m hm
-    simp only [Finset.mem_filter, Finset.mem_range] at hm; omega
-  -- Round-trip: forward ∘ backward = id
-  · intro m hm
-    simp only [Finset.mem_filter, Finset.mem_range] at hm; omega
+    simp only [Finset.mem_filter, Finset.mem_range] at hm
+    -- f(g(m)) = ((m + a) % L + b) % L = m
+    calc ((m + a) % L + b) % L
+        = (m + a + b) % L := mod_add_mod (m + a) b L hLpos
+      _ = (m + (a + b)) % L := by ring_nf
+      _ = m := add_dvd_mod m (a + b) L hm.1 hLpos hab_dvd
 
 /-- The all-equal-residue system achieves minimum density: the coverage density
     with constant residue a equals that with constant residue 0.
@@ -213,10 +250,16 @@ theorem equal_residues_minimize (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 
 
 -- ## Question 1: Maximum Density (OPEN)
 
-/-- For coprime moduli, the maximum is Σ 1/nᵢ (≤ 1). -/
+/-- For pairwise coprime moduli, the density is the SAME for all residue choices
+    (by CRT, the residue classes are independent). The common value is
+    1 - ∏ (1 - 1/nᵢ) = 1 - ∏(nᵢ - 1)/∏nᵢ.
+    NOTE: A previous version incorrectly stated Σ 1/nᵢ; the correct formula
+    accounts for overlaps via inclusion-exclusion on independent events.
+    Example: {2,3} gives density 1-(1-1/2)(1-1/3) = 2/3, not 1/2+1/3 = 5/6. -/
 axiom max_density_coprime_case (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n)
     (hcop : ∀ m ∈ moduli, ∀ n ∈ moduli, m ≠ n → Nat.Coprime m n) :
-    maxCoverageDensity moduli hpos = moduli.sum (fun n => (1 : ℝ) / n)
+    maxCoverageDensity moduli hpos =
+    1 - moduli.prod (fun n => (1 : ℝ) - 1 / n)
 
 /-- The maximum coverage density is at most 1 (follows from density_le_one). -/
 theorem erdos_278_density_le_one (moduli : Finset ℕ) (hpos : ∀ n ∈ moduli, 0 < n) :

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -26,7 +26,7 @@
     ],
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: simpson_theorem (minimum with equal residues — deep 1986 result), max_density_coprime_case (CRT coprime maximum). Previously axiomatized equal_residues_minimize, single_modulus_density, and erdos_278_density_le_one are now fully proved.",
-    "lineCount": 291
+    "lineCount": 334
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p.28), as part of their systematic study of covering systems — a topic Erdős championed from his groundbreaking 1950 paper showing that covering systems with distinct moduli greater than 1 exist. The problem asks: given fixed moduli, how should one choose residues to optimize coverage? R.J. Simpson resolved the minimum question in 1986 (Discrete Mathematics 59), proving by an elegant averaging argument that equal residues minimize coverage density. The maximum question remains open and connects to the broader structure theory of covering systems, which saw a major breakthrough when Bob Hough (2015, Annals of Mathematics) proved the minimum modulus conjecture — showing that any covering system with distinct moduli must include a modulus at most $10^{16}$. The interplay between coprime and non-coprime moduli connects to the Chinese Remainder Theorem and to sieve-theoretic methods in analytic number theory.",
@@ -109,8 +109,8 @@
       "title": "Maximum Density (Open)",
       "startLine": 133,
       "endLine": 148,
-      "summary": "Three axiomatized results: coprime maximum ($\\delta_{\\max} = \\sum 1/n_i$ by CRT), the open question ($\\delta_{\\max} \\leq 1$ for general moduli), and the single modulus base case ($\\delta = 1/n$).",
-      "mathContext": "Coprime case: $\\gcd(n_i, n_j) = 1 \\Rightarrow \\delta_{\\max} = \\sum 1/n_i$ (CRT). Open: general formula for $\\delta_{\\max}$."
+      "summary": "Axiomatized coprime maximum ($\\delta_{\\max} = 1 - \\prod(1 - 1/n_i)$ by CRT), proved $\\delta_{\\max} \\leq 1$ for general moduli, and the single modulus base case ($\\delta = 1/n$).",
+      "mathContext": "Coprime case: $\\gcd(n_i, n_j) = 1 \\Rightarrow \\delta_{\\max} = 1 - \\prod(1 - 1/n_i)$ (CRT independence). Open: general formula for $\\delta_{\\max}$."
     }
   ],
   "conclusion": {
@@ -133,10 +133,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 148,
+    "lineCount": 334,
     "axiomCount": 2,
-    "theoremCount": 8,
-    "definitionCount": 6
+    "theoremCount": 18,
+    "definitionCount": 7
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-278.json
+++ b/src/data/research/problems/erdos-278.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-278",
-  "title": "Erdős #278",
+  "title": "Erd\u0151s #278",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -29,30 +29,39 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved equal_residues_minimize (axiom→theorem) via cyclic shift bijection card_bij on {0..L-1}. File: 8 theorems/lemmas, 2 axioms, 0 sorries. Axiom count reduced 3→2.",
+    "progressSummary": "PROGRESS: Fixed buggy coverage_card_shift proof (swapped bijection dirs), corrected wrong coprime formula. File: 18 theorems/lemmas, 2 axioms, 0 sorries, 334 lines.",
     "builtItems": [
-      "Proved erdos_278_density_le_one (axiom → theorem) via csSup_le",
+      "Proved erdos_278_density_le_one (axiom \u2192 theorem) via csSup_le",
       "Fixed foldl_lcm_pos: updated List.mem_cons_self/mem_cons_of_mem to simp",
       "Proved single_modulus_density: for singleton {n}, maxCoverageDensity = 1/n (via systemLCM_singleton + coverageDensity_singleton)",
       "Added dvd_systemLCM: each modulus divides the system LCM (via init_dvd_foldl_lcm + mem_dvd_foldl_lcm)",
       "Added coverageDensity_eq: unfolds coverageDensity without the let binding",
-      "Proved equal_residues_minimize: coverage density with constant residue a = coverage density with constant residue 0 (via Finset.card_bij, cyclic shift m↦(m+a)%L)",
-      "Added coverage_card_shift: ℕ cardinality equality of coverage filters via bijection"
+      "Proved equal_residues_minimize: coverage density with constant residue a = coverage density with constant residue 0 (via Finset.card_bij, cyclic shift m\u21a6(m+a)%L)",
+      "Added coverage_card_shift: \u2115 cardinality equality of coverage filters via bijection",
+      "Fixed coverage_card_shift: swapped forward/backward bijection functions, proper shift directions",
+      "Added mod_add_mod helper: (x%L+y)%L = (x+y)%L",
+      "Added add_dvd_mod helper: (m+c)%L = m when L|c and m<L",
+      "Corrected max_density_coprime_case formula: 1-\u220f(1-1/n\u1d62) instead of \u03a31/n\u1d62"
     ],
     "insights": [
-      "erdos_278_open_question was trivially provable: maxCoverageDensity is sSup of densities, each ≤ 1",
+      "erdos_278_open_question was trivially provable: maxCoverageDensity is sSup of densities, each \u2264 1",
       "csSup_le + density_le_one eliminates the axiom in 3 lines",
       "List.mem_cons_self deprecated in current Mathlib - use simp instead",
-      "equal_residues_minimize proof strategy: cyclic shift bijection m↦(m+a)%L on {0,...,L-1}. Need add_mod_injOn (prove via by_contra + Nat.mul_le_mul_left for quotient equality), then dvd_mul_of_dvd_left for n|(a+c). Blocked on Lean omega not handling nonlinear L*(q₁-q₂)",
+      "equal_residues_minimize proof strategy: cyclic shift bijection m\u21a6(m+a)%L on {0,...,L-1}. Need add_mod_injOn (prove via by_contra + Nat.mul_le_mul_left for quotient equality), then dvd_mul_of_dvd_left for n|(a+c). Blocked on Lean omega not handling nonlinear L*(q\u2081-q\u2082)",
       "omega in Lean 4 handles modular arithmetic round-trips: ((m+a)%L + L - a%L)%L = m when m<L",
-      "Nat.mod_mod_of_dvd is the key lemma for shifting: if k∣L then (x%L)%k = x%k"
+      "Nat.mod_mod_of_dvd is the key lemma for shifting: if k\u2223L then (x%L)%k = x%k",
+      "coverage_card_shift on main was BUGGY: forward/backward functions were swapped, causing (a%k+a%k)%k=0 instead of correct shift. Fixed by using f=(\u00b7+b)%L for F_a\u2192F_0 and g=(\u00b7+a)%L for F_0\u2192F_a.",
+      "max_density_coprime_case formula was WRONG: stated \u03a31/n\u1d62 but correct formula is 1-\u220f(1-1/n\u1d62). For {2,3}: \u03a3=5/6 but actual density=2/3=1-(1/2)(2/3). Fixed to correct formula.",
+      "Round-trip proofs use helper lemmas mod_add_mod and add_dvd_mod: (x%L+y)%L=(x+y)%L, and (m+c)%L=m when L|c and m<L. omega cannot handle modular arithmetic directly.",
+      "Dvd for \u2115 in Lean 4 gives \u2203k,c=L*k (L on left). Nat.mul_mod_right L k : L*k%L=0. mul_add distributes for omega to handle divisibility goals."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove max_density_coprime_case using CRT: for coprime moduli, max density = Σ1/nᵢ",
-      "Consider whether simpson_theorem can be proved from Mathlib (deep result, likely requires significant infrastructure)"
+      "Prove max_density_coprime_case via CRT: for coprime moduli, density=1-\u220f(1-1/n\u1d62) for ALL residue choices",
+      "Prove simpson_theorem from literature (deep result, may need multi-session effort)",
+      "Add Aristotle companion file with routine helper lemmas"
     ],
-    "markdown": "# Erdős #278 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{n_1<\\cdots<n_r\\}$ be a finite set of integers. What is the maximum density of integers covered by a suitable choice of congruences $a_i\\pmod{n_i}$?\n\nIs the minimum density achieved when all the $a_i$ are equal?\n\n\n\nSimpson \\cite{Si86} has observed that the density of integers covered is at least\\[\\sum_i \\frac{1}{n_i}-\\sum_{i<j}\\frac{1}{[n_i,n_j]}+\\sum_{i<j<k}\\frac{1}{[n_i,n_j,n_k]}-\\cdot\\](where $[\\cdots]$ denotes the least common multiple) which is achieved when all $a_i$ are equal, settling the second question.\n\n\n\n\nReferences\n\n\n[Si86] Simpson, R. J., Exact coverings of the integers by arithmetic progressions. Discrete Math. (1986), 181--190.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #277\n- Problem #279\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Si86\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "markdown": "# Erd\u0151s #278 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{n_1<\\cdots<n_r\\}$ be a finite set of integers. What is the maximum density of integers covered by a suitable choice of congruences $a_i\\pmod{n_i}$?\n\nIs the minimum density achieved when all the $a_i$ are equal?\n\n\n\nSimpson \\cite{Si86} has observed that the density of integers covered is at least\\[\\sum_i \\frac{1}{n_i}-\\sum_{i<j}\\frac{1}{[n_i,n_j]}+\\sum_{i<j<k}\\frac{1}{[n_i,n_j,n_k]}-\\cdot\\](where $[\\cdots]$ denotes the least common multiple) which is achieved when all $a_i$ are equal, settling the second question.\n\n\n\n\nReferences\n\n\n[Si86] Simpson, R. J., Exact coverings of the integers by arithmetic progressions. Discrete Math. (1986), 181--190.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #277\n- Problem #279\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Si86\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- Fixed **buggy `coverage_card_shift` proof** on main: the bijection functions were swapped (forward should shift by `L - a%L` to go F_a→F_0, not by `a`). Added helper lemmas `mod_add_mod` and `add_dvd_mod` for clean round-trip proofs.
- **Corrected mathematically wrong `max_density_coprime_case` formula** from `Σ 1/nᵢ` to `1 - ∏(1 - 1/nᵢ)`. The old formula was inconsistent: for moduli {2,3}, density is 2/3 (by CRT), not 5/6.

## Progress
- File: 18 theorems/lemmas, 2 axioms (`simpson_theorem`, `max_density_coprime_case`), 0 sorries, 334 lines
- Docker build passes cleanly
- `equal_residues_minimize` theorem now compiles correctly (was broken on main)

## Findings
- Lean 4 `Dvd` gives `∃ k, c = L * k` (L on left), affecting `Nat.mul_mod_right` usage
- `omega` cannot handle modular arithmetic or nonlinear multiplication — need `mul_add`/`mul_one` rewrites first
- Round-trip proofs for cyclic shift bijection need `(x%L + y)%L = (x+y)%L` as a helper

## Status
**Outcome**: progress (fixed existing bugs + corrected formula)
**Next Steps**: Prove `max_density_coprime_case` via CRT for coprime moduli

Generated by researcher-2