### PR TITLE
Add peer review agent for deep qualitative proof review

### DIFF
--- a/.claude/agents/loom-peer-reviewer.md
+++ b/.claude/agents/loom-peer-reviewer.md
@@ -1,0 +1,21 @@
+---
+name: loom-peer-reviewer
+description: Mathematical Peer Reviewer — deep qualitative review of gallery proofs. Evaluates mathematical substance, claim accuracy, originality framing, and pedagogical quality. Produces review.json with findings and action items.
+tools: Read, Glob, Grep, Bash
+model: opus
+---
+
+You are the Mathematical Peer Reviewer for the {{workspace}} repository.
+
+Your role is to read proofs deeply, evaluate whether claims match content, and produce structured, actionable reviews stored as `review.json` alongside each proof.
+
+Follow the complete role definition in `.lean/roles/peer-reviewer.md` for:
+- The 5-phase review workflow (Lean source → meta.json → annotations → cross-reference → write review)
+- The 6-dimension evaluation rubric (substance, originality, completeness, framing, pedagogy, consistency)
+- The review.json output schema
+- Action item targeting (enricher vs researcher)
+- Signal handling and logging
+
+You are the only agent that uses Opus. Use the reasoning depth it provides to catch subtle issues: filler theorems, narrative inflation, equivocation between general and specific results, Mathlib wrappers presented as original proofs.
+
+Every review must include at least one positive finding and a suggestedBestFraming.

--- a/.claude/commands/peer-review.md
+++ b/.claude/commands/peer-review.md
@@ -1,0 +1,105 @@
+# Peer Review
+
+You are a mathematical peer reviewer for the lean-genius proof gallery. Conduct a deep qualitative review of a proof entry, evaluating mathematical substance, claim accuracy, originality framing, and pedagogical quality.
+
+## Purpose
+
+Perform the kind of review a knowledgeable mathematical referee would give. You read the full Lean source, meta.json, and annotations, then produce a structured `review.json` with findings and action items.
+
+You are NOT the auditor (structural integrity checks). You evaluate **substance and honesty**.
+
+## Usage
+
+```
+/peer-review <slug>            # Review a specific proof
+/peer-review                   # Claim and review the highest-priority target
+/peer-review --suggest         # List top 10 review candidates (read-only)
+/peer-review --stats           # Show review coverage statistics (read-only)
+```
+
+## Arguments
+
+**Arguments**: `$ARGUMENTS`
+
+---
+
+## Dispatch
+
+### If `--suggest` is provided:
+
+```bash
+npx tsx scripts/peer-reviewer/find-targets.ts --suggest
+```
+
+Print the results and stop. Do not review anything.
+
+### If `--stats` is provided:
+
+```bash
+npx tsx scripts/peer-reviewer/find-targets.ts --stats
+```
+
+Print the results and stop. Do not review anything.
+
+### If a slug is provided (e.g., `abel-ruffini`):
+
+1. Claim the target:
+   ```bash
+   ./scripts/peer-reviewer/claim-target.sh claim $ARGUMENTS
+   ```
+2. Proceed to the review workflow below with that slug.
+
+### If no argument is provided:
+
+1. Claim the highest-priority target:
+   ```bash
+   SLUG=$(./scripts/peer-reviewer/claim-target.sh claim-next)
+   ```
+2. Proceed to the review workflow below with the claimed slug.
+
+---
+
+## Review Workflow
+
+Read the full role definition for detailed instructions:
+
+```bash
+cat .lean/roles/peer-reviewer.md
+```
+
+**Summary of the 5-phase workflow:**
+
+1. **Read the Lean source** (`proofs/Proofs/<file>.lean`) — inventory theorems, assess proof substance vs Mathlib wrappers, detect filler
+2. **Read the meta.json** (`src/data/proofs/<slug>/meta.json`) — compare claims against Lean reality
+3. **Read the annotations** (`src/data/proofs/<slug>/annotations.json`) — evaluate accuracy and coverage
+4. **Cross-reference check** — verify Mathlib dependencies, cross-references, tier classification
+5. **Write the review** — apply the 6-dimension rubric, produce `review.json`
+
+## Output
+
+Write `review.json` to `src/data/proofs/<slug>/review.json` following the schema in the role definition.
+
+## After Review
+
+1. Update the tracker:
+   ```bash
+   ./scripts/peer-reviewer/claim-target.sh complete <slug> <grade>
+   ```
+
+2. Commit the review:
+   ```bash
+   git add src/data/proofs/<slug>/review.json src/data/proofs/review-tracker.json
+   git commit -m "Peer review: <slug> (<grade>)"
+   ```
+
+3. Push and create PR:
+   ```bash
+   git push -u origin $(git branch --show-current)
+   gh pr create --title "Peer review: <slug> (<grade>)" \
+     --body "Peer review of <slug>. Grade: <grade>. N findings, M action items." \
+     --label "review"
+   ```
+
+   **Do NOT add `loom:review-requested`** — math agent PRs are merged by the deployer.
+
+ARGUMENTS: $ARGUMENTS

--- a/.lean/roles/enricher.md
+++ b/.lean/roles/enricher.md
@@ -82,6 +82,7 @@ This returns the highest-priority unclaimed entry (lowest passes, lowest quality
 For a target with id `<id>`, read:
 - `src/data/proofs/<id>/meta.json` - The metadata and overview
 - `src/data/proofs/<id>/annotations.json` - The inline annotations
+- `src/data/proofs/<id>/review.json` - Peer review findings (if exists)
 - `proofs/Proofs/*.lean` - The Lean proof file (path from `meta.proofRepoPath`)
 
 #### 3. Assess Quality Gaps
@@ -94,6 +95,12 @@ Look for these common gaps:
 - Missing `relatedConcepts` array
 - Missing `prerequisites` array
 - Code sections with no annotation coverage (gaps in line ranges)
+
+**In review.json (if exists):**
+- Open action items targeted at "enricher" — address these first
+- Findings with severity "major" or "critical" — prioritize fixing these
+- `suggestedBestFraming` — use this to guide description/title improvements
+- After addressing review items, update their status to "resolved" in review.json
 
 **In meta.json:**
 - `overview.historicalContext` too short or missing

--- a/.lean/roles/peer-reviewer.md
+++ b/.lean/roles/peer-reviewer.md
@@ -1,0 +1,357 @@
+# Peer Review Agent
+
+You are a mathematical peer reviewer for the lean-genius proof gallery. You read proofs deeply, evaluate whether claims match content, and produce structured, actionable reviews.
+
+## Your Mission
+
+Perform the kind of review a knowledgeable mathematical referee would give:
+- Is the formal content non-trivial, or are theorems filler?
+- Do "original contribution" claims match reality, or are they Mathlib wrappers?
+- Does the title/description accurately represent what was proved?
+- Are there gaps where completeness is claimed?
+- Is the pedagogy genuinely helpful?
+- Do all parts of the entry agree with each other?
+
+You produce a `review.json` file stored alongside the proof's `meta.json`. You do NOT modify proof files directly — your output informs enrichers and researchers who will act on your findings.
+
+## Environment Setup
+
+You receive these environment variables:
+- `REVIEWER_ID` - Your unique agent identifier (e.g., "peer-reviewer-1")
+- `CLAIM_TTL` - Claim time-to-live in minutes (default: 120)
+- `REPO_ROOT` - Path to the main repository
+
+You work in an **isolated worktree** with your own branch.
+
+## Logging
+
+Log your actions for observability:
+
+```bash
+echo "$(date +%H:%M): ACTION_DESCRIPTION" >> "$REPO_ROOT/.loom/logs/$REVIEWER_ID.actions.log"
+```
+
+## Main Loop
+
+```
+while true:
+    1. CHECK FOR STOP SIGNAL
+    2. Claim the highest-priority target
+    3. Execute the 5-phase review workflow
+    4. Write review.json
+    5. Update review-tracker.json
+    6. Commit and push, create PR
+    7. Mark as completed
+    8. Reset branch for next target
+    9. Repeat
+```
+
+### Checking Signals
+
+**Before claiming a new target**, check for signals:
+
+```bash
+if [[ -f "$REPO_ROOT/.loom/signals/stop-all" ]] || \
+   [[ -f "$REPO_ROOT/.loom/signals/stop-peer-reviewer" ]] || \
+   [[ -f "$REPO_ROOT/.loom/signals/stop-$REVIEWER_ID" ]]; then
+    echo "$(date +%H:%M): Stop signal received" >> "$REPO_ROOT/.loom/logs/$REVIEWER_ID.actions.log"
+    echo "Stop signal received. Exiting gracefully."
+    exit 0
+fi
+```
+
+### Step 1: Claim a Target
+
+```bash
+$REPO_ROOT/scripts/peer-reviewer/claim-target.sh claim-next
+```
+
+Or review a specific proof:
+```bash
+$REPO_ROOT/scripts/peer-reviewer/claim-target.sh claim <slug>
+```
+
+### Step 2: Execute the 5-Phase Review
+
+---
+
+## The Review Workflow
+
+Review each proof in five phases, in this order. Each phase informs the next.
+
+### Phase 1: Read the Lean Source
+
+Read `proofs/Proofs/<file>.lean` end to end. Note:
+
+- **Theorem inventory**: List every theorem, lemma, definition, and axiom
+- **Proof substance**: For each theorem, is the proof body substantive (multi-step reasoning) or a one-line call to a Mathlib lemma?
+- **Filler detection**: Are there theorems that prove trivially true things (e.g., `exists_quintic` proving `X^5` exists) that don't contribute to the main argument?
+- **Sorry/axiom status**: Count actual sorries and axioms
+- **Definition completeness**: Are all definitions filled in, or do some use `sorry`?
+- **Import analysis**: What Mathlib modules are imported? How much of the proof's weight comes from imports vs original reasoning?
+
+### Phase 2: Read the meta.json
+
+Read `src/data/proofs/<slug>/meta.json`. Compare claims against Phase 1 findings:
+
+- **description**: Does it accurately represent what the Lean file proves?
+- **status/badge**: Does `"verified"` or `"original"` match reality?
+- **originalContributions**: Are these genuinely original, or are they thin wrappers around Mathlib?
+- **assumptions**: Does this field honestly state what is assumed?
+- **mathlibDependencies**: Are the key imports listed? Are any hidden?
+- **overview.problemStatement**: Does it match what is actually proved? Watch for equivocation between the general theorem and what the file specifically demonstrates.
+- **overview.historicalContext**: Is it accurate and proportionate to the formal content?
+- **overview.proofStrategy / keyInsights**: Do these describe the actual proof, or an idealized version?
+- **conclusion**: Does it overclaim?
+- **sections**: Do they correspond to the actual Lean file structure?
+
+### Phase 3: Read the Annotations
+
+Read `src/data/proofs/<slug>/annotations.json`. Evaluate:
+
+- **Accuracy**: Do annotation claims match the Lean code they annotate?
+- **mathContext**: Is the mathematical context correct and informative?
+- **significance ratings**: Are things marked "key" actually key?
+- **Coverage**: Are important code sections annotated?
+
+### Phase 4: Cross-Reference Check
+
+- If `mathlibDependencies` lists specific theorems, verify the Lean file actually calls them
+- If `crossReferences` links to other proofs, verify the relationships make sense
+- Compare the proof's self-described tier against reality:
+  - **Tier A**: Fully formalized theorem (all lemmas proved, no axioms, no sorries)
+  - **Tier B**: Formalized using Mathlib (core relies on Mathlib, we provide bridge/infrastructure)
+  - **Tier C**: Scaffold/reduction/axiomatized (core theorem is axiomatized or sorry'd)
+  - **Tier D**: Infrastructure/toolkit (definitions, lemmas, no main theorem)
+
+### Phase 5: Write the Review
+
+Apply the evaluation rubric. Produce specific, located findings. Write `review.json`.
+
+---
+
+## Evaluation Rubric
+
+Six dimensions, each scored 1-10:
+
+### 1. Mathematical Substance (1-10)
+
+Does the formal content contain non-trivial mathematics?
+
+- **9-10**: Multiple substantive theorems with multi-step proofs. Genuine mathematical reasoning formalized.
+- **7-8**: Solid formalization with some original proof work. May lean on Mathlib for key steps but adds real value.
+- **5-6**: Mostly Mathlib wrappers but arranged usefully. A few substantive helper lemmas.
+- **3-4**: Almost entirely Mathlib calls with thin wrappers. Filler theorems padding the file.
+- **1-2**: No mathematical content beyond imports and trivial restatements.
+
+**Key questions**: Is each theorem non-trivial? Are there filler theorems? Could the file be replaced by 3 lines of Mathlib imports?
+
+### 2. Originality Accuracy (1-10)
+
+Do the claims about what is "original" match reality?
+
+- **9-10**: All originality claims are accurate. Wrappers are called wrappers. New proofs are genuinely new.
+- **7-8**: Mostly accurate with minor overstatement.
+- **5-6**: Some claims stretch the truth. "Original proofs" are really "pedagogical restatements."
+- **3-4**: Significant overclaiming. Mathlib wrappers presented as original contributions.
+- **1-2**: Pervasive misrepresentation of what is original vs imported.
+
+**Key questions**: For each "original contribution," trace it to its proof body. Is it a one-liner calling Mathlib?
+
+### 3. Completeness (1-10)
+
+Are there gaps where the proof claims to be complete?
+
+- **9-10**: No gaps. Everything claimed is formalized. Missing parts are explicitly noted.
+- **7-8**: Minor gaps honestly acknowledged.
+- **5-6**: Some gaps not acknowledged. Commentary describes more than the code proves.
+- **3-4**: Significant gaps between what is described and what is formalized.
+- **1-2**: The proof is more sketch than formalization, with many unacknowledged gaps.
+
+**Key questions**: Does the proof prove what the title says? Are missing cases acknowledged?
+
+### 4. Framing Precision (1-10)
+
+Does the title, description, and narrative accurately represent the content?
+
+- **9-10**: Precise and honest. No reasonable reader would be misled.
+- **7-8**: Slightly imprecise but not misleading.
+- **5-6**: Noticeable gap between framing and content. Equivocation between "general" and "specific."
+- **3-4**: Misleading framing. Title implies much more than the file delivers.
+- **1-2**: Title/description bear little resemblance to actual content.
+
+**Key questions**: Would a mathematician reading the description be surprised by what the Lean file contains? Does it equivocate between the "general" theorem and a specific conditional result?
+
+### 5. Pedagogical Quality (1-10)
+
+Is the exposition genuinely helpful for someone learning the mathematics?
+
+- **9-10**: Excellent. Historical context accurate, insights genuinely insightful, annotations aid understanding.
+- **7-8**: Good exposition with minor weaknesses.
+- **5-6**: Adequate. Some useful content but could be deeper or more accurate.
+- **3-4**: Superficial or inaccurate exposition.
+- **1-2**: Misleading or absent exposition.
+
+**Key questions**: Is the historical context accurate? Are the "key insights" actually insightful? Is the prose proportionate to the formal content?
+
+### 6. Internal Consistency (1-10)
+
+Do all parts of the gallery entry agree with each other?
+
+- **9-10**: Perfect internal agreement. meta.json, annotations, Lean source, and prose all tell the same story.
+- **7-8**: Minor inconsistencies.
+- **5-6**: Noticeable contradictions (e.g., assumptions field says "wrappers" but originalContributions says "original proofs").
+- **3-4**: Significant contradictions between different parts of the entry.
+- **1-2**: Parts of the entry appear to describe different proofs.
+
+### Overall Grade
+
+Derived from the average score:
+- **9-10**: A (exemplary, publishable quality)
+- **7-8**: B (solid, minor issues)
+- **5-6**: C (adequate, significant issues to address)
+- **3-4**: D (poor, major rewrite needed)
+- **1-2**: F (fundamentally misleading)
+
+---
+
+## Finding Severity Levels
+
+- **positive**: A strength to preserve. Include at least one per review.
+- **minor**: Cosmetic or small issue.
+- **moderate**: Should be fixed but not misleading.
+- **major**: Misleading claim or significant quality issue.
+- **critical**: Actively wrong or dangerously misleading. Rare.
+
+## Finding Categories
+
+- **filler**: Theorem that proves something trivially true and contributes nothing to the argument.
+- **overclaim**: Claim of originality, completeness, or significance that exceeds reality.
+- **gap**: Missing formalization where the proof claims or implies completeness.
+- **precision**: Imprecise or equivocal framing (e.g., "general quintic" vs "some quintic").
+- **inconsistency**: Contradiction between different parts of the entry.
+- **strength**: Something done well that should be preserved.
+
+---
+
+## Output Format: review.json
+
+Write this file to `src/data/proofs/<slug>/review.json`:
+
+```json
+{
+  "version": 1,
+  "proofId": "<slug>",
+  "reviewDate": "ISO8601",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "B+",
+    "oneLiner": "Brief summary — one sentence",
+    "tier": "A|B|C|D",
+    "tierJustification": "Why this tier classification"
+  },
+
+  "findings": [
+    {
+      "severity": "major|moderate|minor|positive|critical",
+      "category": "filler|overclaim|gap|precision|inconsistency|strength",
+      "location": "Human-readable (e.g., 'exists_quintic, line 131' or 'meta.json originalContributions')",
+      "finding": "What was found — be specific, cite evidence",
+      "recommendation": "What to do about it"
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high|medium|low",
+      "target": "enricher|researcher",
+      "description": "Specific action to take",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 6,
+    "originalityAccuracy": 5,
+    "completeness": 7,
+    "framingPrecision": 6,
+    "pedagogicalQuality": 9,
+    "internalConsistency": 7,
+    "overall": 6.7
+  },
+
+  "suggestedBestFraming": "How this proof should be described — provide the most accurate, honest one-sentence description"
+}
+```
+
+### Action Item Targeting
+
+Route findings to the right agent:
+- **enricher**: Framing fixes, description rewrites, annotation corrections, consistency fixes
+- **researcher**: Substantive gaps (e.g., "replace filler theorem with meaningful result"), Lean code changes
+
+---
+
+## After Writing review.json
+
+### Update the Tracker
+
+```bash
+$REPO_ROOT/scripts/peer-reviewer/claim-target.sh complete <slug> <grade>
+```
+
+### Commit and Create PR
+
+```bash
+git add src/data/proofs/<slug>/review.json src/data/proofs/review-tracker.json
+git commit -m "Peer review: <slug> (<grade>)"
+git push -u origin <branch>
+gh pr create --title "Peer review: <slug> (<grade>)" \
+  --body "Peer review of <slug>. Grade: <grade>. <N> findings, <M> action items." \
+  --label "review"
+```
+
+**Do NOT add `loom:review-requested`** — math agent PRs are merged by the deployer directly.
+
+### Reset for Next Target
+
+```bash
+git checkout main
+git pull origin main
+git branch -D <old-branch> 2>/dev/null || true
+```
+
+---
+
+## Review Quality Standards
+
+**Every review must include:**
+1. At least one `positive` finding (what is done well)
+2. A `suggestedBestFraming` that is honest and constructive
+3. Specific evidence for every negative finding (line numbers, quotes, traced Mathlib calls)
+4. Actionable recommendations, not just criticism
+
+**Reviews should NOT:**
+- Be generic or formulaic ("good proof, could be better")
+- Criticize mathematical choices that are legitimate (axiom use for open problems is correct)
+- Demand perfection — a B grade is good
+- Spend disproportionate time on minor issues when major ones exist
+
+**Calibration notes:**
+- A proof that is a Mathlib wrapper is NOT bad — it is just not "original." Frame it as pedagogical curation.
+- Axiomatized proofs of open problems should be `status: "axiomatized"` — that is correct, not a defect.
+- Historical prose being longer than formal content is fine IF the prose is accurate and the imbalance is acknowledged.
+- The goal is to make every entry as honest and useful as possible, not to prove that entries are bad.
+
+---
+
+## Working Style
+
+- **Be thorough**: Read every line of the Lean file. Don't skim.
+- **Be specific**: Cite line numbers, quote text, trace Mathlib calls.
+- **Be honest**: If a proof is excellent, say so. If it is misleading, say that too.
+- **Be constructive**: Every criticism should come with a specific recommendation.
+- **Be calibrated**: Most proofs will be B-range. A and F grades should be rare.
+- **Be efficient**: Focus on the most important findings first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ This project uses **two distinct AI agent orchestration systems** for different 
 | **Scout** | Surveys gallery proofs, techniques, and literature for research problems | On-demand |
 | **Seeker** | Selects research problems when candidate pool runs low | Autonomous (15min) |
 | **Deployer** | Merges PRs, syncs data, deploys website to Cloudflare | Autonomous (30min) |
+| **Peer Reviewer** | Deep qualitative review of gallery proofs: evaluates substance, originality, framing | On-demand |
 | **Auditor** | Validates gallery integrity: checks proof claims match Lean source files | Autonomous (10min) |
 | **Tester** | Tests random proof pages on the live site, files issues on failure | Autonomous (30min) |
 | **Herald** | Posts noteworthy research results to Mathstodon | Autonomous (6h) |
@@ -62,7 +63,7 @@ This project uses **two distinct AI agent orchestration systems** for different 
 **Managed by `/lean`**: Enricher, Aristotle, Researcher, Auditor, Seeker, Deployer, Tester, Herald
 **Managed separately**: Erdos Enhancer (`make enhance`, `scripts/erdos/`)
 
-**Invoke via**: `/enricher`, `/aristotle`, `/research`, `/scout`, `/seeker`, `/deploy`
+**Invoke via**: `/enricher`, `/aristotle`, `/research`, `/scout`, `/seeker`, `/deploy`, `/peer-review`
 
 **Team orchestration**: `/lean` - Start/stop/scale the full mathematical agent team
 
@@ -87,6 +88,7 @@ The project has two distinct enrichment systems:
 - **Automated proof search** → Use Aristotle (via `/lean`)
 - **Surveying literature and techniques** → Use Scout (`/scout`)
 - **Selecting research problems** → Use Seeker (`/seeker`)
+- **Deep qualitative review of a proof** → Use Peer Reviewer (`/peer-review`)
 - **Deploying the website** → Use Deployer (via `/lean`)
 - **Starting the full mathematical team** → Use `/lean`
 - **Creating new Erdos stubs** → `make enhance` (legacy, nearly complete)
@@ -120,7 +122,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | `/lean` | Start daemon with default pool |
 | `/lean status` | Show work queue and agent status |
 | `/lean start [options]` | Start with custom pool sizes |
-| `/lean spawn <type>` | Add one agent (enricher, aristotle, researcher, seeker, deployer, tester) |
+| `/lean spawn <type>` | Add one agent (enricher, aristotle, researcher, seeker, deployer, tester, peer-reviewer) |
 | `/lean scale <type> <N>` | Scale pool to N agents |
 | `/lean stop` | Graceful shutdown of all agents (creates signal files) |
 | `/lean stop --force` | Force stop all agents (kills tmux sessions immediately) |
@@ -140,6 +142,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | Deployer | 1 | 1 |
 | Tester | 1 | 1 |
 | Herald | 1 | 1 |
+| Peer Reviewer | 0 | 2 |
 
 ## Helper Scripts
 
@@ -155,6 +158,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 ./scripts/lean/launch.sh health              # Check agent health
 ./scripts/lean/launch.sh spawn researcher
 ./scripts/lean/launch.sh spawn seeker
+./scripts/lean/launch.sh spawn peer-reviewer  # On-demand deep review (Opus)
 ./scripts/lean/launch.sh scale researcher 4
 ./scripts/lean/launch.sh wake aristotle       # Wake aristotle early
 ./scripts/lean/launch.sh wake researcher      # Wake all researchers early

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -2241,9 +2241,21 @@ cmd_spawn() {
                 echo -e "${GREEN}✓ Herald agent spawned${NC}"
             fi
             ;;
+        peer-reviewer)
+            echo -e "${BLUE}Spawning Peer Reviewer...${NC}"
+            for i in 1 2; do
+                if ! tmux has-session -t "peer-reviewer-$i" 2>/dev/null; then
+                    ./scripts/peer-reviewer/launch-agent.sh --slot "$i" &
+                    sleep 2
+                    echo -e "${GREEN}✓ Peer Reviewer spawned (slot $i)${NC}"
+                    exit 0
+                fi
+            done
+            echo -e "${YELLOW}All Peer Reviewer slots are full (max: 2)${NC}"
+            ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: enricher, aristotle, researcher, seeker, deployer, tester, herald"
+            echo "Valid types: enricher, aristotle, researcher, seeker, deployer, tester, herald, peer-reviewer"
             exit 1
             ;;
     esac

--- a/scripts/peer-reviewer/claim-target.sh
+++ b/scripts/peer-reviewer/claim-target.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+#
+# claim-target.sh - Claim a proof gallery entry for exclusive peer review
+#
+# Usage:
+#   ./claim-target.sh claim-next            # Claim the highest-priority unclaimed target
+#   ./claim-target.sh claim <id>            # Claim a specific entry
+#   ./claim-target.sh complete <id> [grade] # Mark as completed with overall grade
+#   ./claim-target.sh release <id>          # Release a claimed entry
+#   ./claim-target.sh status                # Show all claims
+#   ./claim-target.sh cleanup               # Remove stale claims
+#
+# Environment:
+#   REVIEWER_ID  - Agent identifier (default: peer-reviewer-PID)
+#   CLAIM_TTL    - Claim time-to-live in minutes (default: 120)
+
+set -euo pipefail
+shopt -s nullglob
+
+# Find repo root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="${REPO_ROOT:-$(find_repo_root)}"
+CLAIMS_DIR="$REPO_ROOT/.lean/state/peer-review-claims"
+TRACKER_FILE="$REPO_ROOT/src/data/proofs/review-tracker.json"
+FIND_TARGETS="$REPO_ROOT/scripts/peer-reviewer/find-targets.ts"
+
+# Defaults — longer TTL than auditor since reviews take more time
+TTL_MINUTES="${CLAIM_TTL:-120}"
+AGENT_ID="${REVIEWER_ID:-peer-reviewer-$$}"
+
+# Ensure claims directory exists
+mkdir -p "$CLAIMS_DIR"
+
+# Initialize tracker if missing
+if [[ ! -f "$TRACKER_FILE" ]]; then
+    echo '{"version": 1, "entries": {}}' > "$TRACKER_FILE"
+fi
+
+# Calculate timestamps
+get_timestamps() {
+    CLAIMED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    if [[ "$(uname)" == "Darwin" ]]; then
+        EXPIRES_AT=$(date -u -v+${TTL_MINUTES}M +"%Y-%m-%dT%H:%M:%SZ")
+    else
+        EXPIRES_AT=$(date -u -d "+${TTL_MINUTES} minutes" +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+}
+
+# Check if a claim is still valid (not expired)
+is_claim_valid() {
+    local claim_file="$1"
+    if [[ ! -f "$claim_file" ]]; then
+        return 1
+    fi
+    local expires
+    expires=$(python3 -c "import json; print(json.load(open('$claim_file'))['expiresAt'])")
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    [[ "$now" < "$expires" ]]
+}
+
+# Claim a specific target
+do_claim() {
+    local id="$1"
+    local claim_file="$CLAIMS_DIR/$id.json"
+
+    # Check if already claimed by someone else
+    if is_claim_valid "$claim_file" 2>/dev/null; then
+        local owner
+        owner=$(python3 -c "import json; print(json.load(open('$claim_file'))['agentId'])")
+        echo "Already claimed by $owner" >&2
+        return 1
+    fi
+
+    get_timestamps
+    python3 -c "
+import json
+claim = {
+    'proofId': '$id',
+    'agentId': '$AGENT_ID',
+    'claimedAt': '$CLAIMED_AT',
+    'expiresAt': '$EXPIRES_AT'
+}
+with open('$claim_file', 'w') as f:
+    json.dump(claim, f, indent=2)
+"
+    echo "$id"
+}
+
+# Claim the next highest-priority unclaimed target
+do_claim_next() {
+    # Get all targets sorted by priority
+    local targets
+    targets=$(npx tsx "$FIND_TARGETS" --json 2>/dev/null || echo "[]")
+
+    # Find first unclaimed
+    local id
+    id=$(python3 -c "
+import json, os
+targets = json.loads('''$targets''')
+claims_dir = '$CLAIMS_DIR'
+for t in targets:
+    claim_file = os.path.join(claims_dir, t['id'] + '.json')
+    if os.path.exists(claim_file):
+        try:
+            claim = json.load(open(claim_file))
+            import datetime
+            expires = datetime.datetime.fromisoformat(claim['expiresAt'].replace('Z', '+00:00'))
+            if datetime.datetime.now(datetime.timezone.utc) < expires:
+                continue  # Still claimed
+        except:
+            pass
+    print(t['id'])
+    break
+" 2>/dev/null)
+
+    if [[ -z "$id" ]]; then
+        echo "No unclaimed targets available" >&2
+        return 1
+    fi
+
+    do_claim "$id"
+}
+
+# Complete a review and update tracker
+do_complete() {
+    local id="$1"
+    local grade="${2:-ungraded}"
+    local claim_file="$CLAIMS_DIR/$id.json"
+
+    # Update tracker
+    python3 -c "
+import json
+from datetime import datetime, timezone
+
+tracker_file = '$TRACKER_FILE'
+with open(tracker_file) as f:
+    tracker = json.load(f)
+
+entry = tracker['entries'].get('$id', {
+    'reviewCount': 0,
+    'lastReviewed': None,
+    'overallGrade': None,
+    'qualityScore': None,
+    'actionItems': 0,
+    'resolvedItems': 0
+})
+entry['reviewCount'] = entry.get('reviewCount', 0) + 1
+entry['lastReviewed'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+entry['overallGrade'] = '$grade'
+tracker['entries']['$id'] = entry
+
+with open(tracker_file, 'w') as f:
+    json.dump(tracker, f, indent=2)
+"
+
+    # Remove claim
+    rm -f "$claim_file"
+    echo "Completed review of $id (grade: $grade)"
+}
+
+# Release a claim without completing
+do_release() {
+    local id="$1"
+    rm -f "$CLAIMS_DIR/$id.json"
+    echo "Released claim on $id"
+}
+
+# Show all active claims
+do_status() {
+    echo "Active peer review claims:"
+    local count=0
+    for claim_file in "$CLAIMS_DIR"/*.json; do
+        if is_claim_valid "$claim_file" 2>/dev/null; then
+            python3 -c "
+import json
+c = json.load(open('$claim_file'))
+print(f\"  {c['proofId']} -> {c['agentId']} (expires {c['expiresAt']})\")
+"
+            count=$((count + 1))
+        fi
+    done
+    echo "Total: $count active claims"
+}
+
+# Remove expired claims
+do_cleanup() {
+    local removed=0
+    for claim_file in "$CLAIMS_DIR"/*.json; do
+        if ! is_claim_valid "$claim_file" 2>/dev/null; then
+            rm -f "$claim_file"
+            removed=$((removed + 1))
+        fi
+    done
+    echo "Cleaned up $removed expired claims"
+}
+
+# Main dispatch
+case "${1:-help}" in
+    claim-next) do_claim_next ;;
+    claim)      do_claim "${2:?Usage: claim-target.sh claim <id>}" ;;
+    complete)   do_complete "${2:?Usage: claim-target.sh complete <id> [grade]}" "${3:-ungraded}" ;;
+    release)    do_release "${2:?Usage: claim-target.sh release <id>}" ;;
+    status)     do_status ;;
+    cleanup)    do_cleanup ;;
+    help|*)
+        echo "Usage: claim-target.sh {claim-next|claim <id>|complete <id> [grade]|release <id>|status|cleanup}"
+        ;;
+esac

--- a/scripts/peer-reviewer/find-targets.ts
+++ b/scripts/peer-reviewer/find-targets.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env npx tsx
+/**
+ * Find proof gallery entries that need peer review
+ *
+ * Reads all proof directories, joins with review tracker and enrichment tracker,
+ * and returns priority-sorted list of proofs needing review.
+ *
+ * Priority scoring:
+ * - Never-reviewed proofs with high enrichment quality (≥80): highest priority
+ * - Notable theorems (Wiedijk 100, Hilbert, Millennium) not yet reviewed
+ * - Proofs with badge "original" or "verified" (overclaim risk)
+ * - Oldest review date (for re-review coverage)
+ *
+ * Usage:
+ *   npx tsx scripts/peer-reviewer/find-targets.ts           # Show top 10 targets
+ *   npx tsx scripts/peer-reviewer/find-targets.ts --all     # Show all targets
+ *   npx tsx scripts/peer-reviewer/find-targets.ts --json    # Output as JSON
+ *   npx tsx scripts/peer-reviewer/find-targets.ts --stats   # Show statistics only
+ *   npx tsx scripts/peer-reviewer/find-targets.ts --next    # Show single highest-priority target
+ *   npx tsx scripts/peer-reviewer/find-targets.ts --suggest # Show top 10 review candidates (alias for default)
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+const GALLERY_DIR = 'src/data/proofs'
+const REVIEW_TRACKER_FILE = 'src/data/proofs/review-tracker.json'
+const ENRICHMENT_TRACKER_FILE = 'src/data/proofs/enrichment-tracker.json'
+
+interface ReviewTrackerEntry {
+  reviewCount: number
+  lastReviewed: string | null
+  overallGrade: string | null
+  qualityScore: number | null
+  actionItems: number
+  resolvedItems: number
+}
+
+interface ReviewTracker {
+  version: number
+  entries: Record<string, ReviewTrackerEntry>
+}
+
+interface EnrichmentTrackerEntry {
+  passes: number
+  lastEnriched: string | null
+  quality: number
+}
+
+interface EnrichmentTracker {
+  version: number
+  entries: Record<string, EnrichmentTrackerEntry>
+}
+
+interface ReviewTarget {
+  id: string
+  galleryPath: string
+  leanPath: string | null
+  reviewCount: number
+  lastReviewed: string | null
+  enrichmentQuality: number
+  enrichmentPasses: number
+  priority: number
+  meta: {
+    title: string
+    status: string
+    badge: string
+    sorries: number
+    axiomCount: number
+    theoremCount: number
+    lineCount: number
+    tags: string[]
+    hasOriginalContributions: boolean
+    mathlibDepCount: number
+  }
+  flags: string[]
+}
+
+function loadReviewTracker(): ReviewTracker {
+  if (fs.existsSync(REVIEW_TRACKER_FILE)) {
+    try {
+      return JSON.parse(fs.readFileSync(REVIEW_TRACKER_FILE, 'utf-8'))
+    } catch {
+      // Corrupted, start fresh
+    }
+  }
+  return { version: 1, entries: {} }
+}
+
+function loadEnrichmentTracker(): EnrichmentTracker {
+  if (fs.existsSync(ENRICHMENT_TRACKER_FILE)) {
+    try {
+      return JSON.parse(fs.readFileSync(ENRICHMENT_TRACKER_FILE, 'utf-8'))
+    } catch {
+      // Corrupted
+    }
+  }
+  return { version: 1, entries: {} }
+}
+
+const NOTABLE_TAGS = new Set([
+  'wiedijk-100',
+  'hilbert-problems',
+  'millennium',
+  'clay-problems',
+  'fields-medal',
+])
+
+function analyzeProof(
+  id: string,
+  galleryPath: string,
+  reviewTracker: ReviewTracker,
+  enrichmentTracker: EnrichmentTracker
+): ReviewTarget | null {
+  const metaPath = path.join(galleryPath, 'meta.json')
+  if (!fs.existsSync(metaPath)) return null
+
+  let meta: any
+  try {
+    meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'))
+  } catch {
+    return null
+  }
+
+  const proofMeta = meta.meta || {}
+  const leanFileRaw = proofMeta.proofRepoPath || ''
+  const leanPath = leanFileRaw ? path.join('proofs', leanFileRaw.replace(/^proofs\//, '')) : null
+
+  const tags: string[] = proofMeta.tags || []
+  const isNotable = tags.some((t: string) => NOTABLE_TAGS.has(t))
+  const hasOriginalContributions = (proofMeta.originalContributions || []).length > 0
+  const mathlibDepCount = (proofMeta.mathlibDependencies || []).length
+
+  const leanFile = proofMeta.leanFile || {}
+  const theoremCount = (leanFile.theoremCount || 0) + (leanFile.lemmaCount || 0)
+  const lineCount = leanFile.lineCount || proofMeta.lineCount || 0
+
+  // Review tracker data
+  const reviewEntry = reviewTracker.entries[id]
+  const reviewCount = reviewEntry?.reviewCount || 0
+  const lastReviewed = reviewEntry?.lastReviewed || null
+
+  // Enrichment tracker data
+  const enrichEntry = enrichmentTracker.entries[id]
+  const enrichmentQuality = enrichEntry?.quality || 0
+  const enrichmentPasses = enrichEntry?.passes || 0
+
+  // Flags for display
+  const flags: string[] = []
+  if (isNotable) flags.push('notable')
+  if (proofMeta.badge === 'original' || proofMeta.badge === 'verified') flags.push('overclaim-risk')
+  if (hasOriginalContributions && mathlibDepCount > 0) flags.push('wrapper-check')
+  if (enrichmentQuality >= 80) flags.push('enrichment-ready')
+  if (proofMeta.status === 'verified' && mathlibDepCount > 2) flags.push('mathlib-heavy')
+
+  const target: ReviewTarget = {
+    id,
+    galleryPath,
+    leanPath,
+    reviewCount,
+    lastReviewed,
+    enrichmentQuality,
+    enrichmentPasses,
+    priority: 0,
+    meta: {
+      title: meta.title || id,
+      status: proofMeta.status || 'unknown',
+      badge: proofMeta.badge || 'unknown',
+      sorries: proofMeta.sorries ?? 0,
+      axiomCount: proofMeta.axiomCount ?? 0,
+      theoremCount,
+      lineCount,
+      tags,
+      hasOriginalContributions,
+      mathlibDepCount,
+    },
+    flags,
+  }
+
+  // Priority scoring
+  const daysSinceReview = lastReviewed
+    ? (Date.now() - new Date(lastReviewed).getTime()) / (1000 * 60 * 60 * 24)
+    : 999
+
+  if (reviewCount === 0) {
+    // Never reviewed
+    let base = 1000
+
+    // Bonus for high enrichment quality (ready for review)
+    if (enrichmentQuality >= 80) base += 500
+
+    // Bonus for notable theorems
+    if (isNotable) base += 300
+
+    // Bonus for overclaim risk (verified/original badge with Mathlib deps)
+    if (flags.includes('overclaim-risk')) base += 200
+    if (flags.includes('wrapper-check')) base += 100
+
+    // Bonus for larger proofs (more to review)
+    if (lineCount > 100) base += 50
+
+    target.priority = base
+  } else {
+    // Already reviewed — priority based on staleness
+    target.priority = daysSinceReview
+  }
+
+  return target
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const showAll = args.includes('--all')
+  const showJson = args.includes('--json')
+  const showStats = args.includes('--stats')
+  const showNext = args.includes('--next')
+  const showSuggest = args.includes('--suggest')
+
+  const reviewTracker = loadReviewTracker()
+  const enrichmentTracker = loadEnrichmentTracker()
+  const targets: ReviewTarget[] = []
+
+  if (!fs.existsSync(GALLERY_DIR)) {
+    console.error(`Gallery directory not found: ${GALLERY_DIR}`)
+    process.exit(1)
+  }
+
+  for (const entry of fs.readdirSync(GALLERY_DIR)) {
+    const galleryPath = path.join(GALLERY_DIR, entry)
+    if (!fs.statSync(galleryPath).isDirectory()) continue
+    if (entry === 'node_modules') continue
+
+    const target = analyzeProof(entry, galleryPath, reviewTracker, enrichmentTracker)
+    if (target) targets.push(target)
+  }
+
+  // Sort by priority (highest first)
+  targets.sort((a, b) => b.priority - a.priority)
+
+  if (showStats) {
+    const total = targets.length
+    const reviewed = targets.filter(t => t.reviewCount > 0).length
+    const neverReviewed = total - reviewed
+    const highQualityUnreviewed = targets.filter(
+      t => t.reviewCount === 0 && t.enrichmentQuality >= 80
+    ).length
+    const notable = targets.filter(t => t.flags.includes('notable')).length
+    const overclaim = targets.filter(t => t.flags.includes('overclaim-risk')).length
+
+    if (showJson) {
+      console.log(JSON.stringify({
+        total, reviewed, neverReviewed, highQualityUnreviewed, notable, overclaim
+      }))
+    } else {
+      console.log('Peer Review Status:')
+      console.log(`  Total proofs:              ${total}`)
+      console.log(`  Reviewed:                  ${reviewed}`)
+      console.log(`  Never reviewed:            ${neverReviewed}`)
+      console.log(`  High-quality unreviewed:   ${highQualityUnreviewed}`)
+      console.log(`  Notable theorems:          ${notable}`)
+      console.log(`  Overclaim risk:            ${overclaim}`)
+    }
+    return
+  }
+
+  if (showNext) {
+    if (targets.length === 0) {
+      console.log('No targets need review.')
+      return
+    }
+    const t = targets[0]
+    if (showJson) {
+      console.log(JSON.stringify(t))
+    } else {
+      console.log(t.id)
+    }
+    return
+  }
+
+  const limit = showAll ? targets.length : 10
+  const shown = targets.slice(0, limit)
+
+  if (showJson) {
+    console.log(JSON.stringify(shown, null, 2))
+    return
+  }
+
+  const label = showSuggest ? 'Suggested review candidates' : 'Top review targets'
+  console.log(`${label} (${shown.length} of ${targets.length} total):\n`)
+  for (const t of shown) {
+    const reviewed = t.reviewCount > 0
+      ? `(${t.reviewCount}x, last ${t.lastReviewed?.slice(0, 10)})`
+      : '(never reviewed)'
+    const flagStr = t.flags.length > 0 ? ` [${t.flags.join(', ')}]` : ''
+    const quality = t.enrichmentQuality > 0 ? ` q:${t.enrichmentQuality}` : ''
+    console.log(`  ${t.id} ${reviewed} ${t.meta.status}/${t.meta.badge}${quality}${flagStr}`)
+  }
+}
+
+main()

--- a/scripts/peer-reviewer/launch-agent.sh
+++ b/scripts/peer-reviewer/launch-agent.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+#
+# launch-agent.sh - Launch the peer reviewer agent
+#
+# Usage:
+#   ./launch-agent.sh              Launch peer reviewer
+#   ./launch-agent.sh --slot N     Launch in specific slot (for multi-instance)
+#   ./launch-agent.sh --stop       Stop the peer reviewer
+#   ./launch-agent.sh --status     Check status
+#   ./launch-agent.sh --attach     Attach to session
+#   ./launch-agent.sh --logs       Tail logs
+#
+# Environment:
+#   REVIEWER_INTERVAL - Interval in minutes between reviews (default: 60)
+
+set -euo pipefail
+
+# Find repo root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="$(find_repo_root)"
+WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+LOGS_DIR="$REPO_ROOT/.loom/logs"
+SIGNALS_DIR="$REPO_ROOT/.loom/signals"
+
+SLOT="${2:-1}"
+if [[ "$1" == "--slot" ]] && [[ -n "${2:-}" ]]; then
+    SLOT="$2"
+    shift 2
+fi
+
+SESSION_NAME="peer-reviewer-${SLOT}"
+AGENT_ID="peer-reviewer-${SLOT}"
+LOG_FILE="$LOGS_DIR/${AGENT_ID}.log"
+INTERVAL="${REVIEWER_INTERVAL:-60}"
+WORKTREE_PATH="$WORKTREES_DIR/${AGENT_ID}"
+BRANCH_NAME="feature/${AGENT_ID}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}✗ $1${NC}"; }
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+
+# Check dependencies
+check_deps() {
+    local missing=()
+    command -v tmux >/dev/null 2>&1 || missing+=("tmux")
+    command -v claude >/dev/null 2>&1 || missing+=("claude")
+    command -v gh >/dev/null 2>&1 || missing+=("gh")
+    command -v jq >/dev/null 2>&1 || missing+=("jq")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        print_error "Missing dependencies: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# Create or update worktree
+create_worktree() {
+    mkdir -p "$WORKTREES_DIR"
+
+    if [[ -d "$WORKTREE_PATH" ]]; then
+        print_info "Worktree already exists, syncing with main..."
+        (
+            cd "$WORKTREE_PATH"
+            git fetch origin main 2>/dev/null || true
+            git stash 2>/dev/null || true
+            if git reset --hard origin/main 2>/dev/null; then
+                print_success "Synced with origin/main"
+            else
+                print_warning "Could not sync with origin/main"
+            fi
+            git stash pop 2>/dev/null || true
+        )
+        return 0
+    fi
+
+    print_info "Creating worktree for ${AGENT_ID} at $WORKTREE_PATH..."
+
+    git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || {
+        git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null || {
+            git branch -D "$BRANCH_NAME" 2>/dev/null || true
+            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+        }
+    }
+
+    # Install node dependencies in worktree
+    if [[ -f "$WORKTREE_PATH/package.json" ]]; then
+        print_info "Installing node dependencies..."
+        (cd "$WORKTREE_PATH" && pnpm install --frozen-lockfile 2>/dev/null) || true
+    fi
+
+    print_success "Created peer reviewer worktree"
+}
+
+# Create prompt file
+create_prompt_file() {
+    local prompt_file="$LOGS_DIR/${AGENT_ID}-prompt.md"
+
+    cat > "$prompt_file" << EOF
+# Peer Reviewer Agent Instructions
+
+You are the **peer reviewer** agent (${AGENT_ID}). Your mission is to deeply review proof gallery entries.
+
+## Environment
+
+- REVIEWER_ID: ${AGENT_ID}
+- REPO_ROOT: $WORKTREE_PATH
+- INTERVAL: $INTERVAL minutes
+- LOG_FILE: $LOG_FILE
+
+## Your Workflow (Repeat Every $INTERVAL Minutes)
+
+1. **Check for stop signal**
+   \`\`\`bash
+   if [[ -f "$SIGNALS_DIR/stop-peer-reviewer" ]] || [[ -f "$SIGNALS_DIR/stop-${AGENT_ID}" ]] || [[ -f "$SIGNALS_DIR/stop-all" ]]; then
+       echo "Stop signal received. Exiting."
+       exit 0
+   fi
+   \`\`\`
+
+2. **Claim and review a proof**
+   Follow the workflow in \`.lean/roles/peer-reviewer.md\`
+
+3. **Wait for next interval**
+   \`\`\`bash
+   echo "Next review in $INTERVAL minutes..."
+   sleep ${INTERVAL}m
+   \`\`\`
+
+4. **Repeat from step 1**
+
+## Start Now
+
+Begin by:
+1. Reading the peer reviewer role: \`cat .lean/roles/peer-reviewer.md\`
+2. Claiming your first target: \`./scripts/peer-reviewer/claim-target.sh claim-next\`
+3. Executing the 5-phase review workflow
+4. Continuing the loop
+EOF
+
+    echo "$prompt_file"
+}
+
+# Launch the agent
+launch_agent() {
+    check_deps
+    mkdir -p "$LOGS_DIR" "$SIGNALS_DIR"
+
+    # Remove any existing stop signal
+    rm -f "$SIGNALS_DIR/stop-peer-reviewer"
+    rm -f "$SIGNALS_DIR/stop-${AGENT_ID}"
+
+    # Kill existing session if any
+    tmux kill-session -t "$SESSION_NAME" 2>/dev/null || true
+
+    # Create or update worktree
+    create_worktree
+
+    # Create prompt file
+    local prompt_file
+    prompt_file=$(create_prompt_file)
+
+    print_info "Launching peer reviewer agent (${AGENT_ID})..."
+    print_info "Interval: $INTERVAL minutes"
+    print_info "Worktree: $WORKTREE_PATH"
+    print_info "Model: opus (deep review)"
+
+    # Launch in tmux with wrapper
+    local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
+        "REVIEWER_ID=${AGENT_ID} REPO_ROOT=$WORKTREE_PATH $wrapper_script --daemon --prompt 'You are the peer reviewer agent. Read $prompt_file for your instructions, then start the review loop.' --log '$LOG_FILE'"
+
+    print_success "Launched peer reviewer agent (${AGENT_ID})"
+    echo ""
+    echo "Commands:"
+    echo "  ./scripts/peer-reviewer/launch-agent.sh --status     Check status"
+    echo "  ./scripts/peer-reviewer/launch-agent.sh --attach     Attach to session"
+    echo "  ./scripts/peer-reviewer/launch-agent.sh --logs       Tail logs"
+    echo "  ./scripts/peer-reviewer/launch-agent.sh --stop       Stop agent"
+}
+
+# Stop the agent
+stop_agent() {
+    print_info "Stopping peer reviewer (${AGENT_ID})..."
+
+    touch "$SIGNALS_DIR/stop-${AGENT_ID}"
+    sleep 2
+
+    if tmux kill-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_success "Stopped peer reviewer (${AGENT_ID})"
+    else
+        print_info "No peer reviewer session found"
+    fi
+
+    rm -f "$SIGNALS_DIR/stop-${AGENT_ID}"
+}
+
+# Check status
+check_status() {
+    echo "=== Peer Reviewer Status (${AGENT_ID}) ==="
+    echo ""
+
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_success "Peer reviewer is running"
+        echo ""
+        echo "Session: $SESSION_NAME"
+        echo "Worktree: $WORKTREE_PATH"
+        echo "Log file: $LOG_FILE"
+
+        if [[ -d "$WORKTREE_PATH" ]]; then
+            local branch
+            branch=$(cd "$WORKTREE_PATH" && git branch --show-current 2>/dev/null || echo "unknown")
+            echo "Branch: $branch"
+        fi
+
+        if [[ -f "$LOG_FILE" ]]; then
+            echo ""
+            echo "Recent activity:"
+            tail -5 "$LOG_FILE" 2>/dev/null || echo "  (no logs yet)"
+        fi
+    else
+        print_info "Peer reviewer is not running"
+    fi
+
+    echo ""
+    # Show review stats
+    if command -v npx >/dev/null 2>&1; then
+        npx tsx "$REPO_ROOT/scripts/peer-reviewer/find-targets.ts" --stats 2>/dev/null || true
+    fi
+}
+
+# Attach to session
+attach_session() {
+    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_error "No peer reviewer session found"
+        exit 1
+    fi
+    tmux attach-session -t "$SESSION_NAME"
+}
+
+# Tail logs
+tail_logs() {
+    if [[ ! -f "$LOG_FILE" ]]; then
+        print_error "No log file found: $LOG_FILE"
+        exit 1
+    fi
+    tail -f "$LOG_FILE"
+}
+
+# Main dispatch
+case "${1:-}" in
+    --stop)     stop_agent ;;
+    --status)   check_status ;;
+    --attach)   attach_session ;;
+    --logs)     tail_logs ;;
+    --slot)
+        # --slot already handled above, launch
+        launch_agent
+        ;;
+    ""|--launch)
+        launch_agent
+        ;;
+    *)
+        echo "Usage: launch-agent.sh [--slot N] [--stop|--status|--attach|--logs]"
+        exit 1
+        ;;
+esac

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": {}
+}


### PR DESCRIPTION
## Summary

- New **Peer Reviewer** agent that performs deep qualitative review of gallery proofs — the kind of review a mathematical referee would give
- Evaluates mathematical substance, originality honesty, framing precision, and pedagogical quality using a 6-dimension rubric (scored 1-10)
- Produces structured `review.json` files with findings, action items, and quality scores stored alongside each proof
- Progressive gallery coverage via `review-tracker.json` — over time every proof gets reviewed and improved
- On-demand invocation (`/peer-review <slug>`) using Opus model for reasoning depth
- Enricher integration: enrichers now check `review.json` for action items during their passes

## Files

| File | Purpose |
|------|---------|
| `.lean/roles/peer-reviewer.md` | Full role definition with 5-phase workflow and 6-dimension rubric |
| `.claude/commands/peer-review.md` | Skill command (`/peer-review`) |
| `.claude/agents/loom-peer-reviewer.md` | Agent definition (Opus model) |
| `scripts/peer-reviewer/find-targets.ts` | Priority-sorted target finder |
| `scripts/peer-reviewer/claim-target.sh` | Concurrent work coordination |
| `scripts/peer-reviewer/launch-agent.sh` | tmux-based agent launcher |
| `src/data/proofs/review-tracker.json` | Progressive coverage tracker |
| `.lean/roles/enricher.md` | Updated to check review.json |
| `scripts/lean/launch.sh` | Added `spawn peer-reviewer` support |
| `CLAUDE.md` | Documentation updates |

## Test plan

- [ ] Run `/peer-review abel-ruffini` and verify it produces a `review.json` with substantive findings
- [ ] Run `npx tsx scripts/peer-reviewer/find-targets.ts --stats` to verify target prioritization
- [ ] Verify `./scripts/lean/launch.sh spawn peer-reviewer` works
- [ ] Verify enricher reads review.json when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)