### PR TITLE
Enrich erdos-4: add coverage annotations, flag bound error

### DIFF
--- a/src/data/proofs/erdos-4/annotations.json
+++ b/src/data/proofs/erdos-4/annotations.json
@@ -428,6 +428,28 @@
     ]
   },
   {
+    "id": "ann-e4-improved-stronger",
+    "proofId": "erdos-4",
+    "range": {
+      "startLine": 186,
+      "endLine": 192
+    },
+    "type": "technique",
+    "title": "FGKMT Dominance: Improved ≥ Original (sorry)",
+    "content": "**improved_stronger**: For $n \\geq 100$, the FGKMT improved function dominates the original Erdős function. This is the file's only `sorry` — a technical inequality comparing $(\\log\\log\\log n)^2$ vs $\\log\\log\\log n$ in the denominator. The proof unfolds both definitions and needs to verify that $1/(\\log\\log\\log n)^2 \\leq 1/\\log\\log\\log n$ for $n \\geq 100$, which follows from $\\log\\log\\log n \\geq 1$.",
+    "significance": "supporting",
+    "mathContext": "The claim: $f(n) \\leq f'(n)$ where $f(n) = \\frac{\\log n \\cdot \\log\\log n \\cdot \\log\\log\\log\\log n}{(\\log\\log\\log n)^2}$ and $f'(n) = \\frac{\\log n \\cdot \\log\\log n \\cdot \\log\\log\\log\\log n}{\\log\\log\\log n}$. This reduces to $\\frac{1}{(\\log\\log\\log n)^2} \\leq \\frac{1}{\\log\\log\\log n}$, i.e., $\\log\\log\\log n \\geq 1$, which holds for $n \\geq e^{e^e} \\approx 3814279$. For $n \\geq 100$, $\\log\\log\\log 100 \\approx 0.83 < 1$, so the bound actually fails at $n = 100$ — this sorry may be genuinely unprovable as stated. An Aristotle candidate if the bound is corrected to $n \\geq 10^7$.",
+    "relatedConcepts": [
+      "iterated log comparison",
+      "technical inequality",
+      "sorry classification"
+    ],
+    "prerequisites": [
+      "erdosFunction",
+      "improvedErdosFunction"
+    ]
+  },
+  {
     "id": "ann-e4-stronger",
     "proofId": "erdos-4",
     "range": {
@@ -469,6 +491,29 @@
     "prerequisites": [
       "nthPrime",
       "primeGap"
+    ]
+  },
+  {
+    "id": "ann-e4-summary",
+    "proofId": "erdos-4",
+    "range": {
+      "startLine": 216,
+      "endLine": 243
+    },
+    "type": "context",
+    "title": "Summary: SOLVED Status and Open Questions",
+    "content": "The closing commentary summarizes the complete resolution of Erdős Problem #4 and the remaining frontier. The file contains 16 definitions, 2 theorems, and 9 axiom declarations across 243 lines. The single sorry (`improved_stronger`) is a technical inequality comparing the original and improved Erdős functions.\n\nThe summary lists the four key milestones: Rankin (1938, $\\exists C$), Maynard (2016, $\\forall C$), FGKT (2016, independent $\\forall C$), and FGKMT (2018, improved bound). Three open questions remain: Cramér's conjecture, the $\\$10{,}000$ growth rate conjecture, and the exact growth rate of $G(x) = \\max_{p_n \\leq x} g_n$.",
+    "significance": "supporting",
+    "mathContext": "The file formalizes a complete hierarchy of prime gap results:\n- **Lower bounds**: $\\omega(\\log n \\cdot \\log\\log n / \\log\\log\\log n)$ (FGKMT 2018) — the state of the art\n- **Upper bounds**: $O(n^{0.525})$ unconditionally (BHP 2001), $O(n^{1/2+\\varepsilon})$ under RH\n- **Conjectured**: $\\Theta((\\log n)^2)$ (Cramér), with lim sup constant $2e^{-\\gamma}$ (Granville)\n\nThe enormous gap between lower and upper bounds — roughly $(\\log n)^{1+o(1)}$ vs $n^{0.525}$ — is one of the most striking open problems in analytic number theory.",
+    "relatedConcepts": [
+      "prime gap hierarchy",
+      "SOLVED status",
+      "open problems in prime distribution"
+    ],
+    "prerequisites": [
+      "erdos_4_conjecture",
+      "maynard_theorem",
+      "cramer_conjecture"
     ]
   }
 ]

--- a/src/data/proofs/erdos-4/meta.json
+++ b/src/data/proofs/erdos-4/meta.json
@@ -227,7 +227,8 @@
       "**Two independent proofs**: Maynard (multidimensional sieve) and FGKT (probabilistic + additive combinatorics) solved it simultaneously, suggesting the problem was 'ripe'",
       "**Sieve revolution**: Maynard's approach uses the same multidimensional sieve that proved bounded gaps ($\\liminf g_n \\leq 246$), applied in reverse to prove unbounded gaps",
       "**Upper-lower gap**: Current bounds span from $\\omega(\\log n \\cdot \\log\\log n / \\log\\log\\log n)$ (lower) to $O(n^{0.525})$ (upper) — an enormous range reflecting our ignorance about prime distribution",
-      "**$10,000 still open**: Erdős's stronger conjecture ($g_n > (\\log n)^{1+c}$) remains unresolved and would require fundamentally new ideas beyond current sieve methods"
+      "**$10,000 still open**: Erdős's stronger conjecture ($g_n > (\\log n)^{1+c}$) remains unresolved and would require fundamentally new ideas beyond current sieve methods",
+      "**Potential bound error**: The `improved_stronger` theorem (the file's only sorry) claims $f(n) \\leq f'(n)$ for $n \\geq 100$, but $\\log\\log\\log 100 \\approx 0.83 < 1$, so the inequality may fail at the stated threshold — the correct bound is $n \\geq e^{e^e} \\approx 3{,}814{,}279$. This is a candidate for correction and Aristotle proof search"
     ],
     "prerequisites": [
       "Analytic number theory: the Prime Number Theorem and its consequences",


### PR DESCRIPTION
Enrichment pass for erdos-4 (Large Prime Gaps).

**Changes:**
- Added annotation for `improved_stronger` theorem (lines 186-192) — the file's only sorry
- Flagged potential bound error: `improved_stronger` claims `n ≥ 100` but `log(log(log(100))) ≈ 0.83 < 1`, so the inequality may fail at the stated threshold. Correct bound: `n ≥ e^(e^e) ≈ 3,814,279`
- Added annotation for summary section (lines 216-243) 
- Added keyInsight about the incorrect bound threshold
- Total annotations: 22 → 24

Quality: 77 → improved (pass 2)