### PR TITLE
Enrich erdos-414: add coverage, flag placeholder axiom

### DIFF
--- a/src/data/proofs/erdos-414/annotations.json
+++ b/src/data/proofs/erdos-414/annotations.json
@@ -67,6 +67,50 @@
     ]
   },
   {
+    "id": "orbit-inc-upper",
+    "proofId": "erdos-414",
+    "range": {
+      "startLine": 42,
+      "endLine": 48
+    },
+    "type": "technique",
+    "title": "Orbit Monotonicity and Upper Bound",
+    "content": "**orbit_strictly_increasing**: h^{k+1}(n) > h^k(n) for n ≥ 1. This follows from h_strictly_increasing applied at each step. **h_upper**: h(n) ≤ 2n since τ(n) ≤ n. These two bounds together show orbits advance by at least 1 and at most n at each step, giving the growth rate window: n + k ≤ h^k(n) ≤ 2^k · n.",
+    "significance": "supporting",
+    "mathContext": "The linear lower bound $h^k(n) \\geq n + k$ and exponential upper bound $h^k(n) \\leq 2^k n$ bracket the orbit growth. In practice, the average growth $h^k(n) \\approx n + k \\log n$ (from Dirichlet's $\\tau(n) \\approx \\log n$) is between these extremes. The upper bound $\\tau(n) \\leq n$ is crude — Wigert's theorem gives $\\tau(n) = O(2^{(1+o(1))\\log n/\\log\\log n})$, and even $\\tau(n) \\leq 2\\sqrt{n}$ for all $n$ suffices. Both `orbit_strictly_increasing` and `h_upper` are axiomatized but could be proved from the definition of $h$ and basic properties of `Nat.divisors.card`.",
+    "relatedConcepts": [
+      "orbit growth bounds",
+      "Wigert's theorem",
+      "divisor bound"
+    ],
+    "prerequisites": [
+      "h_strictly_increasing",
+      "Nat.divisors.card"
+    ]
+  },
+  {
+    "id": "concrete-values",
+    "proofId": "erdos-414",
+    "range": {
+      "startLine": 54,
+      "endLine": 61
+    },
+    "type": "technique",
+    "title": "Concrete Values: h(1)=2, h(2)=4, h(3)=5",
+    "content": "Three concrete axioms: **h_one**: h(1) = 1 + τ(1) = 1 + 1 = 2, **h_two**: h(2) = 2 + τ(2) = 2 + 2 = 4, **h_three**: h(3) = 3 + τ(3) = 3 + 2 = 5. These are axiomatized but are trivially computable — they could be proved by `decide` or `native_decide` since `Nat.divisors.card` is decidable for specific values. The values establish the initial orbit segment 1 → 2 → 4 and the branching point 3 → 5 → 7 that merges with the main orbit.",
+    "significance": "supporting",
+    "mathContext": "These compute $h$ at the three smallest positive integers:\n- $\\tau(1) = 1$ (only divisor: 1), so $h(1) = 2$\n- $\\tau(2) = 2$ (divisors: 1, 2), so $h(2) = 4$\n- $\\tau(3) = 2$ (divisors: 1, 3), so $h(3) = 5$\n\nNote the asymmetry: $h(1) = 2$ and $h(2) = 4$ are on the same orbit, but $h(3) = 5$ starts a different branch that merges with the main orbit at 7 (via $h(5) = 5 + 2 = 7 = h(4) = 4 + 3$). These axioms could be Aristotle candidates — all three are trivially provable by computation.",
+    "relatedConcepts": [
+      "computable axiom pattern",
+      "Aristotle candidate",
+      "orbit branching"
+    ],
+    "prerequisites": [
+      "h definition",
+      "Nat.divisors.card"
+    ]
+  },
+  {
     "id": "h-prime",
     "proofId": "erdos-414",
     "range": {
@@ -184,7 +228,7 @@
     },
     "type": "concept",
     "title": "Dirichlet's Average Order of τ",
-    "content": "**Dirichlet (1849)**: Σ_{n≤N} τ(n) = N log N + (2γ - 1)N + O(√N), where γ ≈ 0.5772 is the Euler-Mascheroni constant. On average, τ(n) ≈ log n.",
+    "content": "**Dirichlet (1849)**: Σ_{n≤N} τ(n) = N log N + (2γ - 1)N + O(√N), where γ ≈ 0.5772 is the Euler-Mascheroni constant. On average, τ(n) ≈ log n.\n\n**Note**: The Lean declaration `axiom average_divisor_count : True` is a placeholder — it states `True` rather than the actual Dirichlet asymptotic. This axiom contributes no mathematical content and could be removed without affecting the formalization. A meaningful version would use `Filter.Tendsto` to state $\\sum_{k \\leq n} \\tau(k) / (n \\log n) \\to 1$.",
     "significance": "key",
     "mathContext": "Dirichlet's **divisor problem** gives the average order of τ(n) as log n, with the error term being the famous **Dirichlet divisor problem**: what is the true order of the remainder Δ(N) = Σ_{n≤N} τ(n) - N log N - (2γ-1)N? It is known that Δ(N) = O(N^{131/416}) (Huxley, 2003) and Δ(N) = Ω(N^{1/4}). For the orbit merging problem, this average tells us that a 'typical' orbit step near N has size ≈ log N, so the orbit of n reaches value V ≈ n + k·log(V) after k steps. But the irregularity of τ around its average is precisely what makes proving exact collisions so difficult.",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -59,7 +59,7 @@
       "single_eventual_orbit: equivalent single-orbit formulation",
       "orbit_1_start: orbit from 1 is 1, 2, 4, 7, 9, ...",
       "orbit_3_merges_with_1: orbit from 3 reaches 7, merging with orbit from 1",
-      "average_divisor_count: ∑ τ(k) ~ n log n (Dirichlet's average order)",
+      "average_divisor_count: PLACEHOLDER — declares `True`, not the actual Dirichlet asymptotic. Contributes no mathematical content",
       "orbit_linear_lower: orbit values grow at least linearly",
       "orbits_get_close: weaker statement that orbits get arbitrarily close"
     ],
@@ -117,7 +117,8 @@
       "**Two-speed dynamics**: primes advance by 2 (minimum), highly composite numbers jump by τ ≫ log n — this irregular spacing creates the orbit structure",
       "**Collision mechanism**: h(a) = h(b) when a + τ(a) = b + τ(b), i.e., b − a = τ(a) − τ(b). The divisor function's irregularity makes these collisions common but unpredictable",
       "**Heuristic for merging**: orbit spacing ∼ log V at value V, so collision probability ∼ 1/(log V)² per step. Since Σ 1/(log V)² diverges, infinitely many collisions are expected — but this heuristic is not rigorous",
-      "**Even the weak form is open**: proving that orbits merely get arbitrarily close (without exact collision) is already unproven"
+      "**Even the weak form is open**: proving that orbits merely get arbitrarily close (without exact collision) is already unproven",
+      "**Many axioms are provable**: Of the 14 axiom declarations, several are trivially computable (h_one, h_two, h_three, orbit_1_start) and could be proved by `decide`/`native_decide`. The `average_divisor_count : True` axiom is a placeholder that states nothing. Only 4 axioms encode genuinely open mathematics (erdos_414_conjecture, single_eventual_orbit, orbits_get_close, and the unproven orbit_3_merges_with_1). The remaining are provable properties of h that could be Aristotle candidates"
     ],
     "prerequisites": [
       "Number theory: divisor functions and multiplicative functions",


### PR DESCRIPTION
Enrichment pass for erdos-414 (Merging Orbits of h(n) = n + τ(n)).

**Changes:**
- Added 2 annotations for uncovered code sections (orbit monotonicity/upper bound at lines 42-48, concrete values at lines 54-61)
- Flagged `average_divisor_count : True` as a placeholder axiom that contributes no mathematical content
- Added keyInsight documenting that many of the 14 axiom declarations are trivially provable computations (h_one, h_two, h_three, orbit_1_start could use `decide`)
- Updated assumptions field to note the placeholder

Quality: 77 → improved (pass 2)