### PR TITLE
fix: add missing implications field to yang-mills conclusions

### DIFF
--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -86,7 +86,8 @@
     "openQuestions": [
       "Can the 2D techniques (heat kernel, representation decomposition) extend to 3D?",
       "Does the 2D→4D interpolation preserve the mass gap structure?"
-    ]
+    ],
+    "implications": "Provides a rigorous existence proof for confinement in 2D gauge theory and serves as a benchmark for techniques aimed at the unsolved 4D Millennium Prize problem."
   },
   "crossReferences": [
     {

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -86,7 +86,8 @@
       "Does the mass gap survive the infinite-volume limit ($L \\to \\infty$)?",
       "Does the mass gap survive the continuum limit ($a \\to 0$ with physics fixed)?",
       "Can the strong coupling result be extended to weak coupling via analytic continuation?"
-    ]
+    ],
+    "implications": "Establishes the strongest rigorous result in the Yang-Mills formalization: the finite-volume mass gap is strictly positive for lattice gauge theories with distinct leading transfer matrix eigenvalues."
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary
- Two yang-mills meta.json files (`yang-mills-2d`, `yang-mills-transfer-matrix`) were missing the required `implications` field in their `conclusion` objects
- This caused TypeScript build failures since `ProofConclusion` requires `implications: string`

## Test plan
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)