### PR TITLE
Enrich yang-mills-transfer-matrix: add depth annotations (pass 1)

### DIFF
--- a/src/data/proofs/yang-mills-transfer-matrix/annotations.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-ymtm-transfer-matrix-structure",
+    "proofId": "yang-mills-transfer-matrix",
+    "range": { "startLine": 5326, "endLine": 5346 },
+    "type": "definition",
+    "title": "Lattice Transfer Matrix Structure",
+    "content": "The transfer matrix for lattice gauge theory acts on $L^2(G^{d \\cdot L^d}, d\\mu_{\\text{Haar}})$ where $G$ is the gauge group, $d$ the spatial dimension, and $L$ the lattice size. It decomposes as $T = T_E^{1/2} \\cdot T_B \\cdot T_E^{1/2}$ where $T_E = \\exp(-ag^2 \\sum E^2/2)$ is the electric (kinetic) part and $T_B = \\exp(-a/(g^2) \\sum (1 - \\operatorname{Re}\\operatorname{Tr} U_\\square / N))$ is the magnetic (potential) part. Both are positive operators, ensuring $T$ is positive. The structure parametrizes $N \\ge 2$ colors, spatial dimension $d \\ge 1$, lattice size $L \\ge 1$, coupling $g^2 > 0$, and spacing $a > 0$.",
+    "mathContext": "$T = T_E^{1/2} T_B T_E^{1/2}$ on $L^2(G^{d L^d}, d\\mu_{\\text{Haar}})$; $T_E = e^{-ag^2 \\sum E^2/2}$, $T_B = e^{-a/(g^2) \\sum (1 - \\text{Re Tr}\\,U_\\square/N)}$",
+    "significance": "key",
+    "relatedConcepts": ["positive operator", "Haar measure", "lattice Hamiltonian", "Kogut-Susskind Hamiltonian"],
+    "prerequisites": ["lattice gauge theory", "functional analysis", "Hilbert spaces"]
+  },
+  {
+    "id": "ann-ymtm-perron-frobenius",
+    "proofId": "yang-mills-transfer-matrix",
+    "range": { "startLine": 5355, "endLine": 5363 },
+    "type": "concept",
+    "title": "Perron-Frobenius Spectral Gap",
+    "content": "The Perron-Frobenius theorem guarantees that a strictly positive matrix has a unique largest eigenvalue $\\lambda_0$ with a strictly positive eigenvector (the vacuum state). The spectral gap $\\lambda_0 > \\lambda_1$ follows from the strict positivity of the transfer matrix, which in turn comes from the heat kernel being strictly positive for any finite coupling. This is the mathematical core of the finite-volume mass gap: the Perron-Frobenius gap is the physics mass gap.",
+    "mathContext": "$\\lambda_0 > \\lambda_1 > 0$ from Perron-Frobenius; vacuum $|\\Omega\\rangle$ is the unique eigenvector of $\\lambda_0$",
+    "significance": "key",
+    "relatedConcepts": ["Perron-Frobenius theorem", "spectral gap", "ground state", "heat kernel positivity"],
+    "prerequisites": ["linear algebra", "spectral theory", "positive matrices"]
+  },
+  {
+    "id": "ann-ymtm-finite-volume-gap",
+    "proofId": "yang-mills-transfer-matrix",
+    "range": { "startLine": 5372, "endLine": 5397 },
+    "type": "definition",
+    "title": "Finite-Volume Mass Gap: Definition and Proof",
+    "content": "The mass gap is defined as $\\Delta = \\log(\\lambda_0/\\lambda_1)$ in temporal lattice units, and $m = \\Delta/a$ in physical units. The proof that $\\Delta > 0$ is a direct consequence of $\\lambda_0 > \\lambda_1 > 0$: the ratio $\\lambda_0/\\lambda_1 > 1$, so $\\log(\\lambda_0/\\lambda_1) > 0$. This is a THEOREM (not a conjecture) for any finite-volume lattice gauge theory with any coupling $g^2 > 0$. The Millennium Prize problem asks whether this gap survives the infinite-volume ($L \\to \\infty$) and continuum ($a \\to 0$) limits.",
+    "mathContext": "$\\Delta = \\log(\\lambda_0/\\lambda_1) > 0$; physical: $m = \\Delta/a = \\log(\\lambda_0/\\lambda_1)/a > 0$",
+    "significance": "key",
+    "relatedConcepts": ["mass gap", "spectral gap", "Millennium Prize Problem", "continuum limit"],
+    "prerequisites": ["logarithmic inequalities", "lattice gauge theory"]
+  },
+  {
+    "id": "ann-ymtm-partition-function",
+    "proofId": "yang-mills-transfer-matrix",
+    "range": { "startLine": 5407, "endLine": 5413 },
+    "type": "definition",
+    "title": "Partition Function from Transfer Matrix",
+    "content": "The partition function for temporal extent $N_t$ is $Z(N_t) = \\operatorname{Tr}(T^{N_t}) = \\sum_i \\lambda_i^{N_t}$. At large $N_t$ (low temperature), the ground state dominates: $Z \\approx \\lambda_0^{N_t}(1 + (\\lambda_1/\\lambda_0)^{N_t} + \\cdots)$. The mass gap controls how quickly the excited states are suppressed. This connection between the Euclidean path integral and Hamiltonian spectrum is the foundation of lattice QCD simulations.",
+    "mathContext": "$Z(N_t) = \\operatorname{Tr}(T^{N_t}) = \\sum_i \\lambda_i^{N_t} \\approx \\lambda_0^{N_t}$ for large $N_t$",
+    "significance": "supporting",
+    "relatedConcepts": ["partition function", "Euclidean path integral", "statistical mechanics", "lattice QCD"],
+    "prerequisites": ["statistical mechanics", "spectral decomposition"]
+  },
+  {
+    "id": "ann-ymtm-correlation-decay",
+    "proofId": "yang-mills-transfer-matrix",
+    "range": { "startLine": 5421, "endLine": 5450 },
+    "type": "insight",
+    "title": "Correlation Decay and Mass Gap Equivalence",
+    "content": "Correlation functions decay as $\\langle O(t)O(0)\\rangle/\\langle O(0)^2\\rangle \\to (\\lambda_1/\\lambda_0)^n = e^{-n\\Delta}$ for temporal separation $t = na$. Three properties are proved: (1) the decay rate $r = \\lambda_1/\\lambda_0 < 1$ (exponential decay); (2) $r > 0$ (correlations are positive); (3) the mass gap equals $-\\log r$. This establishes the fundamental equivalence: the spectral gap of the transfer matrix IS the exponential decay rate of correlation functions.",
+    "mathContext": "$\\langle O(na)O(0)\\rangle \\sim (\\lambda_1/\\lambda_0)^n = e^{-n\\Delta}$; $0 < \\lambda_1/\\lambda_0 < 1$; $\\Delta = -\\log(\\lambda_1/\\lambda_0)$",
+    "significance": "key",
+    "relatedConcepts": ["correlation length", "exponential clustering", "spectral gap", "Osterwalder-Schrader reconstruction"],
+    "prerequisites": ["spectral theory", "logarithmic identities", "quantum field theory"]
+  },
+  {
+    "id": "ann-ymtm-strong-coupling",
+    "proofId": "yang-mills-transfer-matrix",
+    "range": { "startLine": 5463, "endLine": 5505 },
+    "type": "definition",
+    "title": "Strong Coupling Mass Gap Computation",
+    "content": "At strong coupling ($g^2 \\to \\infty$), the electric term dominates the transfer matrix. The eigenvalues become $\\lambda_R = \\exp(-ag^2 C_2(R)/2)$ for each irreducible representation $R$, giving: $\\lambda_0 = 1$ (trivial rep, $C_2 = 0$) and $\\lambda_1 = \\exp(-ag^2 C_2(\\text{fund})/2)$. The mass gap is then $\\Delta = ag^2 C_2(\\text{fund})/2$. For SU(2): $\\Delta = 3ag^2/8$. For SU(3): $\\Delta = 2ag^2/3$. Three results are proved: the eigenvalue ratio $r \\in (0,1)$, the exact mass gap formula $-\\log r = ag^2 C_2/2$, and positivity of the gap.",
+    "mathContext": "$\\lambda_R = e^{-ag^2 C_2(R)/2}$; gap: $\\Delta = ag^2 C_2(\\text{fund})/2$; SU(2): $\\Delta = 3ag^2/8$; SU(3): $\\Delta = 2ag^2/3$",
+    "significance": "key",
+    "relatedConcepts": ["strong coupling expansion", "character expansion", "Casimir operator", "asymptotic freedom"],
+    "prerequisites": ["representation theory", "exponential function properties"]
+  },
+  {
+    "id": "ann-ymtm-early-transfer-matrix",
+    "proofId": "yang-mills-transfer-matrix",
+    "range": { "startLine": 506, "endLine": 548 },
+    "type": "definition",
+    "title": "Abstract Transfer Matrix (Early Formulation)",
+    "content": "An earlier, more abstract formulation of the transfer matrix with eigenvalues $\\lambda_0 \\ge \\lambda_1 > 0$ and a partition function. The mass gap definition $\\Delta = -\\ln(\\lambda_1/\\lambda_0)/a$ and the proof of $\\Delta > 0$ when $\\lambda_1 < \\lambda_0$ appear here first. The correlation decay theorem $\\lambda_1/\\lambda_0 \\le 1$ and partition function ground state dominance are also proved. This serves as the mathematical prelude to the full lattice gauge theory treatment in Part LVI.",
+    "mathContext": "$\\Delta = -\\ln(\\lambda_1/\\lambda_0)/a > 0$; decay rate $\\lambda_1/\\lambda_0 \\le 1$; $Z \\sim \\lambda_0^{N_t}$ at large $N_t$",
+    "significance": "supporting",
+    "relatedConcepts": ["spectral gap", "eigenvalue ordering", "logarithmic inequalities"],
+    "prerequisites": ["real analysis", "spectral theory"]
+  }
+]

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 3,
     "assumptions": "Structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
-    "lineCount": 250,
+    "lineCount": 5507,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_pos",
@@ -38,7 +38,7 @@
     "dateAdded": "2026-03-23"
   },
   "overview": {
-    "historicalContext": "The transfer matrix method connects the Euclidean lattice path integral to Hamiltonian quantum mechanics. For a lattice with temporal extent $N_t$, the partition function is $Z = \\text{Tr}(T^{N_t})$ where $T$ is the transfer matrix. This technique, developed by Wilson (1974) and refined by Creutz, Jacobs, and Rebbi (1983), allows extraction of the mass spectrum from lattice simulations.",
+    "historicalContext": "The transfer matrix method was introduced to lattice gauge theory by Wilson (1974) and developed into a rigorous tool by Osterwalder and Seiler (1978) and Creutz (1983). The key insight is that the Euclidean lattice partition function $Z = \\operatorname{Tr}(T^{N_t})$ connects to Hamiltonian quantum mechanics through the Perron-Frobenius theorem: the transfer matrix $T$ is a strictly positive operator, so it has a unique largest eigenvalue $\\lambda_0$ (the vacuum) with a spectral gap to $\\lambda_1$ (the first excited state). Kogut and Susskind (1975) established the Hamiltonian formulation, decomposing $T = T_E^{1/2} T_B T_E^{1/2}$ into electric (kinetic) and magnetic (potential) parts. Glimm and Jaffe (1987) placed the mass gap extraction on firm mathematical footing in their constructive QFT framework. The finite-volume mass gap is a theorem for any coupling; the Clay Millennium Prize asks whether it persists in the continuum and infinite-volume limits.",
     "problemStatement": "Given a lattice gauge theory with transfer matrix $T$ having eigenvalues $\\lambda_0 > \\lambda_1 > 0$, prove that the mass gap $\\Delta = -\\ln(\\lambda_1/\\lambda_0)/a > 0$.",
     "text": "Proven finite-volume mass gap via transfer matrix eigenvalue ratio. This is the strongest rigorous result in the Yang-Mills formalization.",
     "proofStrategy": "The proof is direct: given $\\lambda_0 > \\lambda_1 > 0$, we have $\\lambda_1/\\lambda_0 < 1$, so $\\ln(\\lambda_1/\\lambda_0) < 0$, so $\\Delta = -\\ln(\\lambda_1/\\lambda_0)/a > 0$ for positive lattice spacing $a > 0$. The physical content is that the transfer matrix eigenvalue gap implies exponential decay of correlation functions.",
@@ -48,36 +48,55 @@
       "Correlation functions decay as $e^{-\\Delta t}$ where $t$ is Euclidean time separation",
       "In strong coupling ($\\beta \\ll 1$), the mass gap is large and computable: $\\Delta \\approx -\\ln(\\beta/(2N^2))/a$"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Spectral theory (eigenvalues, Perron-Frobenius theorem)",
+      "Lattice gauge theory (plaquettes, link variables, Wilson action)",
+      "Functional analysis (positive operators, $L^2$ spaces)",
+      "Representation theory (Casimir operators for strong coupling)"
+    ]
   },
   "sections": [
     {
-      "id": "transfer-matrix-def",
-      "title": "Transfer Matrix Definition",
-      "summary": "Defines `TransferMatrix` with eigenvalues $\\lambda_0 \\geq \\lambda_1 > 0$ and lattice spacing $a > 0$. The mass gap is $\\Delta = -\\ln(\\lambda_1/\\lambda_0)/a$.",
-      "startLine": 1,
-      "endLine": 50
+      "id": "abstract-transfer-matrix",
+      "title": "Abstract Transfer Matrix (Part XV)",
+      "summary": "Initial formulation with eigenvalues $\\lambda_0 \\ge \\lambda_1 > 0$. Defines the mass gap $\\Delta = -\\ln(\\lambda_1/\\lambda_0)/a$, proves positivity, and establishes correlation decay rate $\\lambda_1/\\lambda_0 \\le 1$.",
+      "startLine": 506,
+      "endLine": 548
+    },
+    {
+      "id": "lattice-transfer-matrix",
+      "title": "Lattice Transfer Matrix (Part LVI)",
+      "summary": "Full lattice gauge theory transfer matrix $T = T_E^{1/2} T_B T_E^{1/2}$ parametrized by gauge group SU(N), spatial dimension, lattice size, coupling, and spacing.",
+      "startLine": 5326,
+      "endLine": 5346
+    },
+    {
+      "id": "perron-frobenius-gap",
+      "title": "Perron-Frobenius Spectral Data",
+      "summary": "Encodes the Perron-Frobenius theorem: the transfer matrix has $\\lambda_0 > \\lambda_1 > 0$ from strict positivity of the heat kernel.",
+      "startLine": 5355,
+      "endLine": 5363
     },
     {
       "id": "mass-gap-proof",
-      "title": "Mass Gap Positivity",
-      "summary": "Proves $\\Delta > 0$ when $\\lambda_0 > \\lambda_1$: the ratio $\\lambda_1/\\lambda_0 < 1$ gives $\\ln(\\lambda_1/\\lambda_0) < 0$, so $\\Delta = -\\ln(\\cdot)/a > 0$.",
-      "startLine": 51,
-      "endLine": 100
+      "title": "Mass Gap Positivity and Physical Units",
+      "summary": "Proves $\\Delta = \\log(\\lambda_0/\\lambda_1) > 0$ in temporal lattice units and $m = \\Delta/a > 0$ in physical units. This is a theorem for all finite-volume lattice gauge theories.",
+      "startLine": 5372,
+      "endLine": 5397
     },
     {
       "id": "correlation-decay",
-      "title": "Correlation Decay",
-      "summary": "Proves that the correlation decay rate $r = \\lambda_1/\\lambda_0$ satisfies $0 < r < 1$, giving exponential decay of two-point functions.",
-      "startLine": 101,
-      "endLine": 150
+      "title": "Correlation Decay and Mass Gap Equivalence",
+      "summary": "Proves exponential decay $\\langle O(t)O(0)\\rangle \\sim (\\lambda_1/\\lambda_0)^n$ with $0 < r < 1$, and that the mass gap equals $-\\log r$.",
+      "startLine": 5421,
+      "endLine": 5450
     },
     {
       "id": "strong-coupling",
       "title": "Strong Coupling Mass Gap",
-      "summary": "In the strong coupling regime ($\\beta \\ll 1$), computes the mass gap explicitly from the expansion parameter $u = \\beta/(2N^2) < 1$.",
-      "startLine": 151,
-      "endLine": 250
+      "summary": "At strong coupling, eigenvalues are $\\lambda_R = e^{-ag^2 C_2(R)/2}$. Proves the gap $\\Delta = ag^2 C_2(\\text{fund})/2$ with concrete values for SU(2) and SU(3).",
+      "startLine": 5463,
+      "endLine": 5507
     }
   ],
   "conclusion": {
@@ -85,7 +104,8 @@
     "openQuestions": [
       "Does the mass gap survive the infinite-volume limit ($L \\to \\infty$)?",
       "Does the mass gap survive the continuum limit ($a \\to 0$ with physics fixed)?",
-      "Can the strong coupling result be extended to weak coupling via analytic continuation?"
+      "Can the strong coupling result be extended to weak coupling via analytic continuation?",
+      "Can the Perron-Frobenius gap be bounded uniformly in the lattice size $L$?"
     ],
     "implications": "Establishes the strongest rigorous result in the Yang-Mills formalization: the finite-volume mass gap is strictly positive for lattice gauge theories with distinct leading transfer matrix eigenvalues."
   },
@@ -94,6 +114,16 @@
       "targetId": "yang-mills",
       "relationship": "part-of",
       "description": "Sub-module of the comprehensive Yang-Mills formalization"
+    },
+    {
+      "targetId": "yang-mills-2d",
+      "relationship": "related",
+      "description": "The 2D mass gap from Migdal formula connects to the strong coupling transfer matrix computation"
+    },
+    {
+      "targetId": "yang-mills-lattice",
+      "relationship": "depends-on",
+      "description": "Uses lattice plaquette action and gauge invariance as foundation for the transfer matrix"
     }
   ],
   "relatedProofs": [


### PR DESCRIPTION
## Enrichment: yang-mills-transfer-matrix

First enrichment pass for the Yang-Mills Finite-Volume Mass Gap (Transfer Matrix) gallery entry.

### Changes
- **7 annotations** with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` covering the full transfer matrix formalism: lattice structure, Perron-Frobenius gap, finite-volume mass gap proof, partition function, correlation decay, and strong coupling computation
- **6 sections** (fixed from placeholder lines 1-250 to actual code lines: Part XV at 506-548, Part LVI at 5326-5507)
- **Deepened historicalContext** with Osterwalder-Seiler (1978), Kogut-Susskind (1975), Glimm-Jaffe (1987) citations
- **Prerequisites** array filled (spectral theory, lattice gauge theory, functional analysis, representation theory)
- **Cross-references** added to yang-mills-2d and yang-mills-lattice
- **4th open question** added (uniform Perron-Frobenius bounds in lattice size)

### Quality metrics
- Annotations: 0 -> 7 (all with mathContext and significance)
- Sections: 4 -> 6 (with corrected line references)

### Integrity check
- `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 3` -- unchanged; consistent with structure-encoded assumptions in TransferMatrix and LatticeTransferMatrix

Note: This PR replaced the previous yang-mills-2d enrichment (PR #5360 was reused via branch rebase).