### PR TITLE
Research: erdos-472 - fix build issues and survey

### DIFF
--- a/proofs/Proofs/Erdos472Problem.lean
+++ b/proofs/Proofs/Erdos472Problem.lean
@@ -13,9 +13,7 @@ A problem due to Ulam. Starting with `3, 5`, the sequence continues
 Erdős–Graham (1980).
 -/
 
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.List.Basic
-import Mathlib.Tactic
+import Mathlib
 
 /- ## Ulam prime extension -/
 
@@ -49,7 +47,7 @@ def ErdosProblem472 : Prop :=
     ∃ (seed : List ℕ),
       (∀ p ∈ seed, p.Prime) ∧
       seed.length ≥ 2 ∧
-      List.Sorted (· < ·) seed ∧
+      List.Pairwise (· < ·) seed ∧
       ∃ f : ℕ → ℕ, IsUlamPrimeSeq seed f
 
 /- ## Known example -/
@@ -62,7 +60,7 @@ def ulamSeed35 : List ℕ := [3, 5]
 theorem ulamSeed35_prime : ∀ p ∈ ulamSeed35, p.Prime := by decide
 
 /-- The seed `[3, 5]` is sorted in increasing order. -/
-theorem ulamSeed35_sorted : List.Sorted (· < ·) ulamSeed35 := by decide
+theorem ulamSeed35_sorted : List.Pairwise (· < ·) ulamSeed35 := by decide
 
 /-- The seed `[3, 5]` has at least 2 elements. -/
 theorem ulamSeed35_length : ulamSeed35.length ≥ 2 := by decide
@@ -182,12 +180,11 @@ theorem candidates_odd_of_odd (last q : ℕ)
     · exact absurd hq' hq
     · omega
 
-/-- For p ≥ 3, p + 2 - 1 = p + 1 is even. So the candidate from seed element 2
-is always even (for p ≥ 3), hence never prime (except p = 1 which is impossible). -/
-theorem seed_two_gives_even (p : ℕ) (hp : p ≥ 3) : Even (p + 2 - 1) := by
-  rcases Nat.even_or_odd p with ⟨k, hk⟩ | ⟨k, hk⟩
-  · exact ⟨k + 1, by omega⟩
-  · exact ⟨k + 1, by omega⟩
+/-- For odd p ≥ 3, p + 2 - 1 = p + 1 is even. So the candidate from seed element 2
+is always even for odd primes, hence never prime. -/
+theorem seed_two_gives_even (p : ℕ) (hp : p ≥ 3) (hodd : Odd p) : Even (p + 2 - 1) := by
+  obtain ⟨k, hk⟩ := hodd
+  exact ⟨k + 1, by omega⟩
 
 /-- For odd p and odd q, the candidate p + q - 1 is odd,
 hence potentially prime. This is why odd seeds are preferred. -/
@@ -214,7 +211,7 @@ theorem ulam35_all_prime_8 :
 
 /-- All terms in the first 8 elements are strictly increasing. -/
 theorem ulam35_increasing_8 :
-    List.Sorted (· < ·) [3, 5, 7, 11, 13, 17, 19, 23] := by decide
+    List.Pairwise (· < ·) [3, 5, 7, 11, 13, 17, 19, 23] := by decide
 
 /- ## Growth observation -/
 

--- a/proofs/Proofs/Erdos938Problem.lean
+++ b/proofs/Proofs/Erdos938Problem.lean
@@ -23,14 +23,9 @@ integers can all be powerful.
 The asymptotic count of powerful numbers ≤ x is (ζ(3/2)/ζ(3))·√x ≈ 2.17·√x.
 -/
 
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.Nat.Defs
-import Mathlib.Order.Filter.Basic
-import Mathlib.Topology.Order.Basic
-import Mathlib.Analysis.SpecialFunctions.Pow.Real
-import Mathlib.Data.Finset.Card
+import Mathlib
 
-open Nat Finset Filter
+open Nat Finset Filter Classical
 
 namespace Erdos938
 
@@ -57,45 +52,64 @@ def powerfulSet : Set ℕ := {n | Powerful n}
 
 /-- 1 is powerful (vacuously: no prime divides 1). -/
 example : Powerful 1 := ⟨le_refl 1, fun p hp hdiv => by
-  have := Nat.Prime.one_lt hp
+  have h1 := hp.one_lt
+  have h2 := Nat.le_of_dvd (by omega) hdiv
   omega⟩
 
 /-- 4 = 2² is powerful. -/
 example : Powerful 4 := ⟨by omega, fun p hp hdiv => by
-  have h4 : 4 = 2 ^ 2 := rfl
-  interval_cases p <;> simp_all⟩
+  have h1 := hp.one_lt
+  have h2 := Nat.le_of_dvd (by omega) hdiv
+  interval_cases p <;> simp_all; exact absurd hp (by decide)⟩
 
 /-- 8 = 2³ is powerful. -/
 example : Powerful 8 := ⟨by omega, fun p hp hdiv => by
-  have h8 : 8 = 2 ^ 3 := rfl
-  interval_cases p <;> simp_all⟩
+  have h1 := hp.one_lt
+  have h2 := Nat.le_of_dvd (by omega) hdiv
+  interval_cases p <;> simp_all <;> exact absurd hp (by decide)⟩
 
 /-- 9 = 3² is powerful. -/
 example : Powerful 9 := ⟨by omega, fun p hp hdiv => by
-  have h9 : 9 = 3 ^ 2 := rfl
-  interval_cases p <;> simp_all⟩
+  have h1 := hp.one_lt
+  have h2 := Nat.le_of_dvd (by omega) hdiv
+  interval_cases p <;> simp_all; exact absurd hp (by decide)⟩
 
 /-
 ## Enumeration of Powerful Numbers
 
-We define an enumeration of powerful numbers using a noncomputable choice function.
-The n-th powerful number P(n) is the (n+1)-th smallest element of powerfulSet.
+We define an enumeration of powerful numbers using Mathlib's `Nat.nth` function,
+which enumerates elements of an infinite subset of ℕ in increasing order.
 -/
+
+/-- The set of powerful numbers is infinite (every perfect square k² is powerful). -/
+theorem infinite_powerful : (setOf Powerful).Infinite := by
+  intro hfin
+  obtain ⟨M, hM⟩ := hfin.bddAbove
+  have hpow : (M + 1) ^ 2 ∈ setOf Powerful := by
+    constructor
+    · exact pow_pos (Nat.succ_pos M) 2
+    · intro p hp hdvd
+      exact pow_dvd_pow_of_dvd (hp.dvd_of_dvd_pow hdvd) 2
+  have := hM hpow
+  nlinarith
 
 /-- The ordered enumeration of powerful numbers (0-indexed).
     P(0) = 1, P(1) = 4, P(2) = 8, P(3) = 9, ...
-    Axiomatized since the enumeration function is defined by ordering
-    an irregular subset of ℕ. -/
-axiom nthPowerful : ℕ → ℕ
+    Defined via Mathlib's Nat.nth, which enumerates elements of an infinite
+    subset of ℕ in increasing order. -/
+noncomputable def nthPowerful (n : ℕ) : ℕ := Nat.nth Powerful n
 
 /-- nthPowerful is strictly increasing. -/
-axiom nthPowerful_strictMono : StrictMono nthPowerful
+theorem nthPowerful_strictMono : StrictMono nthPowerful :=
+  Nat.nth_strictMono infinite_powerful
 
 /-- Every value of nthPowerful is powerful. -/
-axiom nthPowerful_mem : ∀ n, Powerful (nthPowerful n)
+theorem nthPowerful_mem : ∀ n, Powerful (nthPowerful n) :=
+  Nat.nth_mem_of_infinite infinite_powerful
 
 /-- Every powerful number appears in the enumeration. -/
-axiom nthPowerful_surj : ∀ m, Powerful m → ∃ n, nthPowerful n = m
+theorem nthPowerful_surj : ∀ m, Powerful m → ∃ n, nthPowerful n = m :=
+  fun m hm => ⟨Nat.count Powerful m, Nat.nth_count hm⟩
 
 /-
 ## Arithmetic Progression Condition

--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős [Er76d]",
     "sourceUrl": "https://erdosproblems.com/938",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos938Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 938,
     "erdosUrl": "https://erdosproblems.com/938",
     "erdosProblemStatus": "open",
@@ -59,9 +59,9 @@
       "differences_finite_of_indices_finite lemma: derived finiteness result",
       "Concrete examples: 1, 4, 8, 9 verified as powerful"
     ],
-    "axiomCount": 7,
-    "lineCount": 203,
-    "assumptions": "7 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "axiomCount": 3,
+    "lineCount": 217,
+    "assumptions": "3 axioms: erdos_938 (open conjecture), erdos_364_conjecture (open conjecture), powerful_count_asymptotic (deep analytic number theory). 4 former enumeration axioms now proved via Mathlib's Nat.nth."
   },
   "overview": {
     "historicalContext": "Erdős Problem #938 was posed by Paul Erdős in 1976 [Er76d] and concerns the distribution of powerful numbers (also called squarefull numbers). A positive integer n is powerful if p | n implies p² | n for every prime p, or equivalently n = a²b³ for some positive integers a, b. The sequence of powerful numbers begins 1, 4, 8, 9, 16, 25, 27, 32, 36, 49, ... (OEIS A001694).\n\nThe problem sits at the intersection of multiplicative number theory and additive combinatorics. While the global distribution of powerful numbers is well understood — the count up to x is asymptotically (ζ(3/2)/ζ(3))·√x ≈ 2.17·√x — the local structure of gaps between consecutive powerful numbers is far more mysterious. The question of whether three consecutive powerful numbers can form an arithmetic progression infinitely often probes this local irregularity.\n\nThe problem is closely related to Erdős Problem #364, which makes the stronger conjecture that no three consecutive integers n, n+1, n+2 can all be powerful. If Problem #364 is true, it would forbid the simplest type of three-term AP (with common difference 1) among consecutive powerful numbers. Problem #938 remains open and cannot be resolved by finite computation alone.",
@@ -113,7 +113,7 @@
     {
       "id": "enumeration",
       "title": "Enumeration of Powerful Numbers",
-      "summary": "nthPowerful with axioms for monotonicity, membership, surjectivity",
+      "summary": "infinite_powerful theorem, nthPowerful via Nat.nth with proved monotonicity, membership, surjectivity",
       "startLine": 78,
       "endLine": 96
     },
@@ -166,22 +166,18 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Data.Nat.Defs",
-      "Mathlib.Order.Filter.Basic",
-      "Mathlib.Topology.Order.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
-      "Mathlib.Data.Finset.Card"
+      "Mathlib"
     ],
     "opens": [
       "Nat",
       "Finset",
-      "Filter"
+      "Filter",
+      "Classical"
     ],
     "namespace": "Erdos938",
-    "lineCount": 203,
-    "axiomCount": 7,
-    "theoremCount": 2,
+    "lineCount": 217,
+    "axiomCount": 3,
+    "theoremCount": 6,
     "definitionCount": 9
   }
 }

--- a/src/data/research/problems/erdos-472.json
+++ b/src/data/research/problems/erdos-472.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-472",
-  "title": "Erdős #472",
-  "phase": "OBSERVE",
+  "title": "Erd\u0151s #472",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,25 +16,40 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-13T04:11:10.513Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Fixed build issues: deprecated List.Sorted \u2192 List.Pairwise, incorrect theorem hypothesis, import consolidation",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "File now compiles cleanly. Only 1 irreducible axiom remains (open conjecture).",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEY+FIX: Fixed 3 build issues in well-developed file (19 theorems, 1 axiom). Replaced deprecated List.Sorted with List.Pairwise. Fixed incorrect seed_two_gives_even theorem (added missing Odd p hypothesis). Consolidated imports to import Mathlib. File now compiles cleanly. The single remaining axiom (ulam35_contains_all_odd_primes_conjecture) is an open problem and cannot be eliminated.",
+    "builtItems": [
+      "Fixed seed_two_gives_even: added missing Odd p hypothesis (theorem was false for even p)",
+      "Replaced deprecated List.Sorted with List.Pairwise (3 occurrences)",
+      "Consolidated imports to import Mathlib"
+    ],
+    "insights": [
+      "File is well-developed: 19 theorems including computational verification of 8 terms",
+      "Single axiom ulam35_contains_all_odd_primes_conjecture is genuinely open",
+      "The {3,5} Ulam sequence is conjectured to contain all odd primes",
+      "Computational step function (ulamNextCandidate, ulamStep, ulamExtend) enables native_decide verification",
+      "List.Sorted deprecated in current Mathlib in favor of List.Pairwise",
+      "seed_two_gives_even was incorrectly stated for all p >= 3 - only true for odd p"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #472 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nGiven some initial finite sequence of primes $q_1<\\cdots<q_m$ extend it so that $q_{n+1}$ is the smallest prime of the form $q_n+q_i-1$ for $n\\geq m$. Is there an initial starting sequence so that the resulting sequence is infinite?\n\n\n\nA problem due to Ulam. For example if we begin with $3,5$ then the sequence continues $3,5,7,11,13,17,\\ldots$. It is possible that this sequence is infinite.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #471\n- Problem #473\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "nextSteps": [
+      "No axiom elimination possible - single axiom is an open conjecture",
+      "Could extend computational verification beyond 8 terms",
+      "Could prove the conjectured equivalence: Ulam {3,5} sequence = all odd primes"
+    ],
+    "markdown": "# Erd\u0151s #472 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nGiven some initial finite sequence of primes $q_1<\\cdots<q_m$ extend it so that $q_{n+1}$ is the smallest prime of the form $q_n+q_i-1$ for $n\\geq m$. Is there an initial starting sequence so that the resulting sequence is infinite?\n\n\n\nA problem due to Ulam. For example if we begin with $3,5$ then the sequence continues $3,5,7,11,13,17,\\ldots$. It is possible that this sequence is infinite.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #471\n- Problem #473\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"

--- a/src/data/research/problems/erdos-938.json
+++ b/src/data/research/problems/erdos-938.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-938",
-  "title": "Erdős #938",
-  "phase": "OBSERVE",
+  "title": "Erd\u0151s #938",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,37 +16,46 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-01-15T11:50:52.409Z",
-    "iteration": 2,
-    "focus": "Surveyed: 4 of 7 axioms eliminable via proper enumeration",
+    "iteration": 3,
+    "focus": "Eliminated 4 enumeration axioms via Nat.nth (7\u21923 axioms)",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Problem complete: only 3 irreducible axioms remain (open conjectures + deep analytic NT)",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
+      "total": 1,
+      "currentApproach": 1,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: 7 axioms (4 eliminable via proper enumeration definition, 3 deep/open). 0 sorries. File structure is clean. Priority: define nthPowerful properly to eliminate 4 axioms.",
-    "builtItems": [],
+    "progressSummary": "COMPLETED: Eliminated 4 of 7 axioms. Defined nthPowerful via Nat.nth Powerful. Proved infinite_powerful (squares are powerful), nthPowerful_strictMono, nthPowerful_mem, nthPowerful_surj from Mathlib. Remaining 3 axioms are irreducible: erdos_938 (open), erdos_364_conjecture (open), powerful_count_asymptotic (deep analytic NT). Also fixed pre-existing build failures in examples.",
+    "builtItems": [
+      "infinite_powerful: proved powerfulSet is infinite via squares argument (Erdos938Problem.lean:85)",
+      "nthPowerful: defined as Nat.nth Powerful (Erdos938Problem.lean:100)",
+      "nthPowerful_strictMono: proved via Nat.nth_strictMono (Erdos938Problem.lean:103)",
+      "nthPowerful_mem: proved via Nat.nth_mem_of_infinite (Erdos938Problem.lean:107)",
+      "nthPowerful_surj: proved via Nat.nth_count (Erdos938Problem.lean:111)",
+      "Fixed examples (Powerful 1/4/8/9): added Nat.le_of_dvd bounds for interval_cases"
+    ],
     "insights": [
       "7 axioms total: 4 are enumeration axioms (nthPowerful + properties), 3 are deep/open results",
       "The 4 enumeration axioms CAN be eliminated: define nthPowerful using Nat.nth or Set.Nat.nth from Mathlib if available, or build from well-ordering",
-      "powerfulSet is provably infinite: contains all perfect squares k² (if p|k² then p|k so p²|k²)",
-      "Powerful is decidable for fixed n: check primes up to n for p²|n condition",
+      "powerfulSet is provably infinite: contains all perfect squares k\u00b2 (if p|k\u00b2 then p|k so p\u00b2|k\u00b2)",
+      "Powerful is decidable for fixed n: check primes up to n for p\u00b2|n condition",
       "erdos_938 (open conjecture), erdos_364_conjecture (open), powerful_count_asymptotic (deep analytic NT) cannot be proved from Mathlib",
-      "The file has 0 sorries despite metadata claiming 1 - the open problem uses axiom, not sorry"
+      "The file has 0 sorries despite metadata claiming 1 - the open problem uses axiom, not sorry",
+      "Nat.nth provides clean enumeration API: nth_strictMono, nth_mem_of_infinite, nth_count are the key lemmas",
+      "pow_pos (not Nat.pos_pow_of_pos) is the correct Mathlib name for 0 < a^n given 0 < a",
+      "interval_cases needs explicit upper bounds from Nat.le_of_dvd when dealing with prime/divisibility hypotheses"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Define nthPowerful using Mathlib enumeration (Nat.nth or Set.Nat.nth): noncomputable def nthPowerful := Set.Nat.nth powerfulSet",
-      "Prove powerfulSet.Infinite from squares_subset: ∀ k≥1, Powerful (k²)",
-      "Derive nthPowerful_strictMono, nthPowerful_mem, nthPowerful_surj from Set.Nat.nth API",
-      "Alternative: use Nat.find iteratively if Set.Nat.nth unavailable"
+      "No further axiom reduction possible: erdos_938 and erdos_364_conjecture are open problems, powerful_count_asymptotic is deep analytic NT",
+      "Could prove PowerfulAlt \u2194 Powerful equivalence as bonus infrastructure",
+      "Could add Aristotle companion file for routine supporting lemmas"
     ],
-    "markdown": "# Erdős #938 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{n_1<n_2<\\cdots\\}$ be the sequence of powerful numbers (if $p\\mid n$ then $p^2\\mid n$).\n\nAre there only finitely many three-term progressions of consecutive terms $n_k,n_{k+1},n_{k+2}$?\n\n\n\nErd\\H{o}s also conjectured (see [364]) that there are no triples of powerful numbers of the shape $n,n+1,n+2$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #364\n- Problem #937\n- Problem #939\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erd\u0151s #938 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{n_1<n_2<\\cdots\\}$ be the sequence of powerful numbers (if $p\\mid n$ then $p^2\\mid n$).\n\nAre there only finitely many three-term progressions of consecutive terms $n_k,n_{k+1},n_{k+2}$?\n\n\n\nErd\\H{o}s also conjectured (see [364]) that there are no triples of powerful numbers of the shape $n,n+1,n+2$.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #364\n- Problem #937\n- Problem #939\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -69,11 +78,11 @@
     {
       "path": "Proofs/Erdos938Problem.lean",
       "filename": "Erdos938Problem.lean",
-      "lineCount": 204,
-      "theoremCount": 2,
-      "axiomCount": 7,
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 3,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos938Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Fixed 3 pre-existing build failures in Erdős #472 (Ulam Prime Sequences)
- File now compiles cleanly with current Mathlib

## Changes
1. **List.Sorted → List.Pairwise**: Deprecated API replacement (3 occurrences)
2. **seed_two_gives_even**: Added missing `Odd p` hypothesis — theorem was incorrectly stated for all `p ≥ 3` (false for even p like p=4: `4+2-1=5` is odd)
3. **Import consolidation**: Replaced specific imports with `import Mathlib`

## Status
- 19 theorems (all proved), 1 axiom (open conjecture), 0 sorries
- The single axiom (`ulam35_contains_all_odd_primes_conjecture`) is an open problem
- Computational verification of 8 terms via `native_decide`

🤖 Generated by researcher-5