### PR TITLE
Enrich erdos-1036, erdos-1050, erdos-625: fix 111 annotation errors

### DIFF
--- a/src/data/proofs/erdos-1036/annotations.json
+++ b/src/data/proofs/erdos-1036/annotations.json
@@ -2,13 +2,9 @@
   {
     "id": "ann-1036-imports",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 1,
-      "endLine": 27
-    },
     "type": "context",
     "title": "Imports and Problem Overview",
-    "content": "Module documentation describing Erd\u0151s Problem #1036 on distinct induced subgraphs in non-Ramsey graphs. Imports SimpleGraph, Finset, Fintype, and real number infrastructure for counting arguments.",
+    "content": "Module documentation describing Erdős Problem #1036 on distinct induced subgraphs in non-Ramsey graphs. Imports SimpleGraph, Finset, Fintype, and real number infrastructure for counting arguments.",
     "mathContext": "A graph $G$ on $n$ vertices is non-Ramsey with parameter $c$ if it has no trivial (empty or complete) induced subgraph on more than $c \\log n$ vertices. Problem 1036 asks whether such graphs must contain $2^{\\Omega_c(n)}$ non-isomorphic induced subgraphs.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -25,14 +21,10 @@
   {
     "id": "ann-1036-vertexcount",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 36,
-      "endLine": 37
-    },
     "type": "definition",
     "title": "vertexCount",
     "content": "Number of vertices in a simple graph, defined as the cardinality of the Fintype vertex set.",
-    "mathContext": "$|V(G)|$ \u2014 the number of vertices of the graph $G$. All graphs are finite throughout this formalization.",
+    "mathContext": "$|V(G)|$ — the number of vertices of the graph $G$. All graphs are finite throughout this formalization.",
     "significance": "supporting",
     "relatedConcepts": [
       "graph order",
@@ -45,10 +37,6 @@
   {
     "id": "ann-1036-trivial",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 45,
-      "endLine": 48
-    },
     "type": "definition",
     "title": "isTrivialInduced",
     "content": "A vertex subset S induces a trivial subgraph if the induced subgraph is either empty (independent set) or complete (clique). These are the 'homogeneous' subgraphs in Ramsey theory terminology.",
@@ -69,10 +57,6 @@
   {
     "id": "ann-1036-independent",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 50,
-      "endLine": 52
-    },
     "type": "definition",
     "title": "isIndependentSet",
     "content": "A vertex set S is independent if no two vertices in S are adjacent: the induced subgraph G[S] has no edges.",
@@ -90,10 +74,6 @@
   {
     "id": "ann-1036-clique",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 54,
-      "endLine": 56
-    },
     "type": "definition",
     "title": "isClique",
     "content": "A vertex set S is a clique if every pair of distinct vertices in S are adjacent: the induced subgraph G[S] is complete.",
@@ -111,10 +91,6 @@
   {
     "id": "ann-1036-trivialiff",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 58,
-      "endLine": 61
-    },
     "type": "technique",
     "title": "trivial_iff",
     "content": "Characterizes trivial induced subgraphs: S is trivial if and only if S is an independent set or S is a clique.",
@@ -132,10 +108,6 @@
   {
     "id": "ann-1036-nolargetrivial",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 69,
-      "endLine": 71
-    },
     "type": "definition",
     "title": "noLargeTrivial",
     "content": "A graph G satisfies noLargeTrivial k if every trivial induced subgraph has fewer than k vertices. This is the non-Ramsey condition.",
@@ -154,13 +126,9 @@
   {
     "id": "ann-1036-nonramsey",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 73,
-      "endLine": 75
-    },
     "type": "definition",
     "title": "isNonRamsey",
-    "content": "A graph G on n vertices is non-Ramsey with parameter c if it has no trivial subgraph on more than c log n vertices. By Ramsey's theorem, this requires c \u2265 some constant depending on the graph.",
+    "content": "A graph G on n vertices is non-Ramsey with parameter c if it has no trivial subgraph on more than c log n vertices. By Ramsey's theorem, this requires c ≥ some constant depending on the graph.",
     "mathContext": "$G$ is non-Ramsey with parameter $c$ if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log_2 n$. By Ramsey's theorem, $R(k,k) \\leq 4^k$, so every $n$-vertex graph has a trivial subgraph of size $\\geq \\frac{1}{2}\\log_2 n$.",
     "significance": "key",
     "relatedConcepts": [
@@ -176,18 +144,14 @@
   {
     "id": "ann-1036-ramsey",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 77,
-      "endLine": 81
-    },
     "type": "context",
     "title": "ramsey_theorem",
     "content": "Axiomatizes the existence of non-Ramsey graphs: for sufficiently large n, there exist n-vertex graphs with no trivial subgraph larger than O(log n). Random graphs achieve this with high probability.",
-    "mathContext": "By Ramsey's theorem, $R(k,k) \\leq 4^k$. Conversely, Erd\u0151s (1947) showed $R(k,k) \\geq 2^{k/2}$ by the probabilistic method: the random graph $G(n, 1/2)$ has $\\omega(G), \\alpha(G) = O(\\log n)$ with high probability.",
+    "mathContext": "By Ramsey's theorem, $R(k,k) \\leq 4^k$. Conversely, Erdős (1947) showed $R(k,k) \\geq 2^{k/2}$ by the probabilistic method: the random graph $G(n, 1/2)$ has $\\omega(G), \\alpha(G) = O(\\log n)$ with high probability.",
     "significance": "key",
     "relatedConcepts": [
       "probabilistic method",
-      "Erd\u0151s 1947",
+      "Erdős 1947",
       "random graph",
       "Ramsey number lower bound"
     ],
@@ -198,10 +162,6 @@
   {
     "id": "ann-1036-induced",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 89,
-      "endLine": 93
-    },
     "type": "definition",
     "title": "inducedSubgraph",
     "content": "The induced subgraph G[S] on vertex subset S: vertices are elements of S, edges are those of G restricted to pairs in S.",
@@ -220,10 +180,6 @@
   {
     "id": "ann-1036-inducedpair",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 95,
-      "endLine": 99
-    },
     "type": "definition",
     "title": "InducedPair",
     "content": "A pair of induced subgraphs of the same size, used for comparing isomorphism types.",
@@ -241,10 +197,6 @@
   {
     "id": "ann-1036-graphiso",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 107,
-      "endLine": 109
-    },
     "type": "definition",
     "title": "GraphIso",
     "content": "Graph isomorphism: a bijection between vertex sets that preserves adjacency. Two graphs are isomorphic if such a bijection exists.",
@@ -263,13 +215,9 @@
   {
     "id": "ann-1036-inducediso",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 111,
-      "endLine": 114
-    },
     "type": "definition",
     "title": "inducedIso",
-    "content": "Isomorphism of induced subgraphs: G[S\u2081] \u2245 G[S\u2082] via some bijection preserving adjacency.",
+    "content": "Isomorphism of induced subgraphs: G[S₁] ≅ G[S₂] via some bijection preserving adjacency.",
     "mathContext": "Two induced subgraphs $G[S_1]$ and $G[S_2]$ are isomorphic if there is a bijection $\\phi: S_1 \\to S_2$ preserving the adjacency relation of $G$ restricted to these sets.",
     "significance": "key",
     "relatedConcepts": [
@@ -284,13 +232,9 @@
   {
     "id": "ann-1036-isorefl",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 116,
-      "endLine": 119
-    },
     "type": "technique",
     "title": "inducedIso_refl",
-    "content": "Induced subgraph isomorphism is reflexive: G[S] \u2245 G[S] via the identity.",
+    "content": "Induced subgraph isomorphism is reflexive: G[S] ≅ G[S] via the identity.",
     "mathContext": "$G[S] \\cong G[S]$ via the identity bijection $\\text{id}: S \\to S$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -304,13 +248,9 @@
   {
     "id": "ann-1036-isosymm",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 121,
-      "endLine": 124
-    },
     "type": "technique",
     "title": "inducedIso_symm",
-    "content": "Induced subgraph isomorphism is symmetric: G[S\u2081] \u2245 G[S\u2082] implies G[S\u2082] \u2245 G[S\u2081] via the inverse bijection.",
+    "content": "Induced subgraph isomorphism is symmetric: G[S₁] ≅ G[S₂] implies G[S₂] ≅ G[S₁] via the inverse bijection.",
     "mathContext": "If $\\phi: G[S_1] \\cong G[S_2]$, then $\\phi^{-1}: G[S_2] \\cong G[S_1]$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -324,13 +264,9 @@
   {
     "id": "ann-1036-isotrans",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 126,
-      "endLine": 129
-    },
     "type": "technique",
     "title": "inducedIso_trans",
-    "content": "Induced subgraph isomorphism is transitive: G[S\u2081] \u2245 G[S\u2082] and G[S\u2082] \u2245 G[S\u2083] imply G[S\u2081] \u2245 G[S\u2083] via composition.",
+    "content": "Induced subgraph isomorphism is transitive: G[S₁] ≅ G[S₂] and G[S₂] ≅ G[S₃] imply G[S₁] ≅ G[S₃] via composition.",
     "mathContext": "If $\\phi: G[S_1] \\cong G[S_2]$ and $\\psi: G[S_2] \\cong G[S_3]$, then $\\psi \\circ \\phi: G[S_1] \\cong G[S_3]$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -344,10 +280,6 @@
   {
     "id": "ann-1036-allsubsets",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 137,
-      "endLine": 139
-    },
     "type": "definition",
     "title": "allInducedSubsets",
     "content": "The collection of all vertex subsets of G, whose induced subgraphs give all possible induced subgraphs. There are 2^n such subsets for an n-vertex graph.",
@@ -364,13 +296,9 @@
   {
     "id": "ann-1036-sameisoclass",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 141,
-      "endLine": 143
-    },
     "type": "definition",
     "title": "sameIsoClass",
-    "content": "Equivalence relation on vertex subsets: S\u2081 ~ S\u2082 if and only if G[S\u2081] \u2245 G[S\u2082]. The number of equivalence classes is the number of distinct induced subgraph types.",
+    "content": "Equivalence relation on vertex subsets: S₁ ~ S₂ if and only if G[S₁] ≅ G[S₂]. The number of equivalence classes is the number of distinct induced subgraph types.",
     "mathContext": "Define $S_1 \\sim S_2$ iff $G[S_1] \\cong G[S_2]$. This is an equivalence relation (reflexive, symmetric, transitive). The quotient $\\mathcal{P}(V) / {\\sim}$ gives the set of distinct induced subgraph isomorphism types.",
     "significance": "key",
     "relatedConcepts": [
@@ -388,10 +316,6 @@
   {
     "id": "ann-1036-distinctcount",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 145,
-      "endLine": 147
-    },
     "type": "definition",
     "title": "distinctInducedCount",
     "content": "The number of non-isomorphic induced subgraphs of G: the cardinality of the quotient of the power set by the isomorphism equivalence relation.",
@@ -409,13 +333,9 @@
   {
     "id": "ann-1036-hasdistinct",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 149,
-      "endLine": 153
-    },
     "type": "definition",
     "title": "hasDistinctInduced",
-    "content": "Predicate asserting that G has at least k non-isomorphic induced subgraphs. The conjecture asks for k = 2^{\u03a9(n)}.",
+    "content": "Predicate asserting that G has at least k non-isomorphic induced subgraphs. The conjecture asks for k = 2^{Ω(n)}.",
     "mathContext": "$G$ has $\\geq k$ distinct induced subgraphs means $i(G) \\geq k$, i.e., there exist $k$ vertex subsets $S_1, \\ldots, S_k$ with $G[S_i] \\not\\cong G[S_j]$ for $i \\neq j$.",
     "significance": "key",
     "relatedConcepts": [
@@ -429,17 +349,13 @@
   {
     "id": "ann-1036-conjecture",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 161,
-      "endLine": 168
-    },
     "type": "definition",
     "title": "erdos_renyi_conjecture",
-    "content": "The Erd\u0151s-R\u00e9nyi conjecture: for every constant c > 0, there exists c' > 0 such that every non-Ramsey graph with parameter c on n vertices has at least 2^{c'n} non-isomorphic induced subgraphs.",
+    "content": "The Erdős-Rényi conjecture: for every constant c > 0, there exists c' > 0 such that every non-Ramsey graph with parameter c on n vertices has at least 2^{c'n} non-isomorphic induced subgraphs.",
     "mathContext": "For every $c > 0$, $\\exists c' > 0$ such that if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log n$, then $i(G) \\geq 2^{c' n}$. This says non-Ramsey graphs must be structurally diverse at an exponential scale.",
     "significance": "key",
     "relatedConcepts": [
-      "Erd\u0151s-R\u00e9nyi conjecture",
+      "Erdős-Rényi conjecture",
       "exponential diversity",
       "Ramsey avoidance"
     ],
@@ -451,14 +367,10 @@
   {
     "id": "ann-1036-ahexp",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 176,
-      "endLine": 178
-    },
     "type": "definition",
     "title": "alonHajnalExponent",
-    "content": "The Alon-Hajnal exponent n\u00b7(log n)^{-O(log log n)}: a sub-exponential but super-polynomial growth rate, weaker than the conjectured 2^{\u03a9(n)}.",
-    "mathContext": "The Alon-Hajnal (1991) bound gives $i(G) \\geq \\exp(n (\\log n)^{-O(\\log \\log n)})$, which is $2^{o(n)}$ \u2014 sub-exponential in $n$ but still super-polynomial.",
+    "content": "The Alon-Hajnal exponent n·(log n)^{-O(log log n)}: a sub-exponential but super-polynomial growth rate, weaker than the conjectured 2^{Ω(n)}.",
+    "mathContext": "The Alon-Hajnal (1991) bound gives $i(G) \\geq \\exp(n (\\log n)^{-O(\\log \\log n)})$, which is $2^{o(n)}$ — sub-exponential in $n$ but still super-polynomial.",
     "significance": "key",
     "relatedConcepts": [
       "sub-exponential bound",
@@ -472,17 +384,13 @@
   {
     "id": "ann-1036-ahbound",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 180,
-      "endLine": 186
-    },
     "type": "context",
     "title": "Alon-Hajnal Bound",
-    "content": "Axiomatizes the Alon-Hajnal (1991) result: every non-Ramsey graph has at least exp(n\u00b7(log n)^{-O(log log n)}) distinct induced subgraphs. This was the strongest result before Shelah.",
-    "mathContext": "Alon and Hajnal (1991) proved: if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log n$, then $i(G) \\geq \\exp(n (\\log n)^{-O(\\log \\log n)})$. Their proof uses Szemer\u00e9di's regularity lemma.",
+    "content": "Axiomatizes the Alon-Hajnal (1991) result: every non-Ramsey graph has at least exp(n·(log n)^{-O(log log n)}) distinct induced subgraphs. This was the strongest result before Shelah.",
+    "mathContext": "Alon and Hajnal (1991) proved: if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log n$, then $i(G) \\geq \\exp(n (\\log n)^{-O(\\log \\log n)})$. Their proof uses Szemerédi's regularity lemma.",
     "significance": "key",
     "relatedConcepts": [
-      "Szemer\u00e9di regularity lemma",
+      "Szemerédi regularity lemma",
       "Alon-Hajnal 1991"
     ],
     "prerequisites": [
@@ -493,13 +401,9 @@
   {
     "id": "ann-1036-ahweaker",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 188,
-      "endLine": 191
-    },
     "type": "technique",
     "title": "alon_hajnal_weaker",
-    "content": "The Alon-Hajnal bound is strictly weaker than Shelah's theorem: for large n, exp(n\u00b7(log n)^{-O(log log n)}) < 2^{c'n}.",
+    "content": "The Alon-Hajnal bound is strictly weaker than Shelah's theorem: for large n, exp(n·(log n)^{-O(log log n)}) < 2^{c'n}.",
     "mathContext": "For large $n$: $\\exp(n (\\log n)^{-O(\\log \\log n)}) = 2^{o(n)} < 2^{c'n}$, so Shelah's bound is exponentially stronger.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -514,10 +418,6 @@
   {
     "id": "ann-1036-bipartite",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 199,
-      "endLine": 202
-    },
     "type": "definition",
     "title": "hasCompleteBipartite",
     "content": "Predicate for containing a complete bipartite subgraph K_{s,t} as an induced subgraph.",
@@ -535,10 +435,6 @@
   {
     "id": "ann-1036-avoidsbip",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 204,
-      "endLine": 206
-    },
     "type": "definition",
     "title": "avoidsBipartite",
     "content": "A graph avoids bipartite if neither G nor its complement contains K_{k,k}. This is stronger than being non-Ramsey.",
@@ -555,17 +451,13 @@
   {
     "id": "ann-1036-ehbip",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 208,
-      "endLine": 214
-    },
     "type": "context",
-    "title": "Erd\u0151s-Hajnal Bipartite",
-    "content": "Axiomatizes the Erd\u0151s-Hajnal (1989) result: graphs avoiding K_{k,k} in both G and its complement have 2^{\u03a9(n)} distinct induced subgraphs. This was the first exponential bound in a restricted setting.",
-    "mathContext": "Erd\u0151s and Hajnal (1989) proved: if neither $G$ nor $\\bar{G}$ contains $K_{k,k}$, then $i(G) \\geq 2^{cn}$ for a constant $c = c(k) > 0$. This uses a direct counting argument on neighborhoods.",
+    "title": "Erdős-Hajnal Bipartite",
+    "content": "Axiomatizes the Erdős-Hajnal (1989) result: graphs avoiding K_{k,k} in both G and its complement have 2^{Ω(n)} distinct induced subgraphs. This was the first exponential bound in a restricted setting.",
+    "mathContext": "Erdős and Hajnal (1989) proved: if neither $G$ nor $\\bar{G}$ contains $K_{k,k}$, then $i(G) \\geq 2^{cn}$ for a constant $c = c(k) > 0$. This uses a direct counting argument on neighborhoods.",
     "significance": "key",
     "relatedConcepts": [
-      "Erd\u0151s-Hajnal 1989",
+      "Erdős-Hajnal 1989",
       "bipartite avoidance",
       "neighborhood counting"
     ],
@@ -577,13 +469,9 @@
   {
     "id": "ann-1036-nonramseyavoids",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 216,
-      "endLine": 219
-    },
     "type": "technique",
     "title": "nonRamsey_avoids_bipartite",
-    "content": "Non-Ramsey graphs avoid large complete bipartite subgraphs: if max(\u03c9(G), \u03b1(G)) \u2264 c log n, then neither G nor its complement contains K_{k,k} for appropriate k.",
+    "content": "Non-Ramsey graphs avoid large complete bipartite subgraphs: if max(ω(G), α(G)) ≤ c log n, then neither G nor its complement contains K_{k,k} for appropriate k.",
     "mathContext": "If $\\max(\\omega(G), \\alpha(G)) \\leq c \\log n$, then for $k = c \\log n$, $G$ avoids $K_{k,k}$ (since $K_{k,k}$ contains an independent set of size $k$) and similarly for $\\bar{G}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -597,10 +485,6 @@
   {
     "id": "ann-1036-shelah",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 227,
-      "endLine": 233
-    },
     "type": "context",
     "title": "Shelah's Theorem",
     "content": "Axiomatizes Shelah's 1998 theorem: every non-Ramsey graph on n vertices has at least 2^{c'n} non-isomorphic induced subgraphs, where c' depends on the Ramsey parameter c. This fully resolves Problem 1036.",
@@ -619,18 +503,14 @@
   {
     "id": "ann-1036-solved",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 235,
-      "endLine": 239
-    },
     "type": "technique",
     "title": "erdos_1036_solved",
-    "content": "Shelah's theorem implies the Erd\u0151s-R\u00e9nyi conjecture, resolving Problem 1036 affirmatively.",
-    "mathContext": "Shelah's theorem directly establishes the Erd\u0151s-R\u00e9nyi conjecture: $i(G) \\geq 2^{c'n}$ for non-Ramsey $G$, which is $2^{\\Omega(n)}$ as conjectured.",
+    "content": "Shelah's theorem implies the Erdős-Rényi conjecture, resolving Problem 1036 affirmatively.",
+    "mathContext": "Shelah's theorem directly establishes the Erdős-Rényi conjecture: $i(G) \\geq 2^{c'n}$ for non-Ramsey $G$, which is $2^{\\Omega(n)}$ as conjectured.",
     "significance": "key",
     "relatedConcepts": [
       "conjecture resolution",
-      "Erd\u0151s-R\u00e9nyi conjecture"
+      "Erdős-Rényi conjecture"
     ],
     "prerequisites": [
       "shelah_theorem",
@@ -640,10 +520,6 @@
   {
     "id": "ann-1036-shelahbound",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 247,
-      "endLine": 248
-    },
     "type": "definition",
     "title": "shelahBound",
     "content": "The Shelah bound 2^{c'n} expressed as a function of n and the constant c'.",
@@ -660,13 +536,9 @@
   {
     "id": "ann-1036-ahbounddef",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 250,
-      "endLine": 252
-    },
     "type": "definition",
     "title": "alonHajnalBound",
-    "content": "The Alon-Hajnal bound exp(n\u00b7(log n)^{-O(log log n)}) expressed as a concrete function.",
+    "content": "The Alon-Hajnal bound exp(n·(log n)^{-O(log log n)}) expressed as a concrete function.",
     "mathContext": "$\\text{alonHajnalBound}(n) = \\exp(n \\cdot (\\log n)^{-O(\\log \\log n)})$, the sub-exponential bound from 1991.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -680,13 +552,9 @@
   {
     "id": "ann-1036-shelahbetter",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 254,
-      "endLine": 257
-    },
     "type": "technique",
     "title": "shelah_better",
-    "content": "Shelah's bound is asymptotically stronger than Alon-Hajnal's: 2^{c'n} grows exponentially faster than exp(n\u00b7(log n)^{-O(log log n)}).",
+    "content": "Shelah's bound is asymptotically stronger than Alon-Hajnal's: 2^{c'n} grows exponentially faster than exp(n·(log n)^{-O(log log n)}).",
     "mathContext": "For large $n$: $2^{c'n} \\gg \\exp(n (\\log n)^{-O(\\log \\log n)})$. The ratio $2^{c'n} / \\exp(n (\\log n)^{-O(\\log \\log n)}) \\to \\infty$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -701,10 +569,6 @@
   {
     "id": "ann-1036-distinctupper",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 265,
-      "endLine": 268
-    },
     "type": "technique",
     "title": "distinct_upper",
     "content": "Trivial upper bound: any n-vertex graph has at most 2^n distinct induced subgraphs (one per subset of vertices).",
@@ -722,17 +586,13 @@
   {
     "id": "ann-1036-random",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 270,
-      "endLine": 275
-    },
     "type": "context",
     "title": "random_graph_distinct",
     "content": "Axiomatizes the fact that random graphs G(n, 1/2) have asymptotically 2^n distinct induced subgraphs with high probability. This represents the 'maximum diversity' benchmark.",
     "mathContext": "For $G \\sim G(n, 1/2)$: $i(G) = (1 - o(1)) \\cdot 2^n$ with high probability. Random graphs are maximally diverse in induced subgraph types.",
     "significance": "supporting",
     "relatedConcepts": [
-      "Erd\u0151s-R\u00e9nyi random graph",
+      "Erdős-Rényi random graph",
       "maximum diversity"
     ],
     "prerequisites": [
@@ -742,10 +602,6 @@
   {
     "id": "ann-1036-randomlike",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 277,
-      "endLine": 284
-    },
     "type": "technique",
     "title": "nonRamsey_random_like",
     "content": "Non-Ramsey graphs are 'random-like' in diversity: their induced subgraph count is exponential in n, matching the random graph up to a constant in the exponent.",
@@ -763,10 +619,6 @@
   {
     "id": "ann-1036-inducedsize",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 292,
-      "endLine": 294
-    },
     "type": "definition",
     "title": "inducedOfSize",
     "content": "The set of all k-vertex subsets of G, representing all possible induced subgraphs of a fixed size.",
@@ -784,10 +636,6 @@
   {
     "id": "ann-1036-distinctsize",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 296,
-      "endLine": 298
-    },
     "type": "definition",
     "title": "distinctOfSize",
     "content": "The number of distinct isomorphism types among k-vertex induced subgraphs of G.",
@@ -805,10 +653,6 @@
   {
     "id": "ann-1036-hasdistinctsize",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 300,
-      "endLine": 303
-    },
     "type": "definition",
     "title": "hasDistinctOfSize",
     "content": "Predicate asserting G has at least m distinct isomorphism types among its k-vertex induced subgraphs.",
@@ -824,10 +668,6 @@
   {
     "id": "ann-1036-fixedsize",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 305,
-      "endLine": 311
-    },
     "type": "context",
     "title": "nonRamsey_fixed_size",
     "content": "Axiomatizes that non-Ramsey graphs have many distinct k-vertex induced subgraphs for appropriate k: a strengthening of the counting argument to fixed sizes.",
@@ -845,10 +685,6 @@
   {
     "id": "ann-1036-compnonramsey",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 319,
-      "endLine": 322
-    },
     "type": "technique",
     "title": "complement_nonRamsey",
     "content": "The complement of a non-Ramsey graph is also non-Ramsey: if G has no large clique or independent set, then the complement (which swaps cliques and independent sets) has the same property.",
@@ -865,10 +701,6 @@
   {
     "id": "ann-1036-compdistinct",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 324,
-      "endLine": 327
-    },
     "type": "technique",
     "title": "complement_distinct",
     "content": "G and its complement have the same number of distinct induced subgraphs, since complementation preserves the isomorphism type structure.",
@@ -886,18 +718,14 @@
   {
     "id": "ann-1036-kuniversal",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 335,
-      "endLine": 341
-    },
     "type": "definition",
     "title": "isKUniversal",
-    "content": "A graph G is k-universal if it contains every graph on at most k vertices as an induced subgraph. Pr\u00f6mel and R\u00f6dl (1999) proved non-Ramsey graphs are c\u00b7log(n)-universal.",
+    "content": "A graph G is k-universal if it contains every graph on at most k vertices as an induced subgraph. Prömel and Rödl (1999) proved non-Ramsey graphs are c·log(n)-universal.",
     "mathContext": "$G$ is $k$-universal if for every graph $H$ with $|V(H)| \\leq k$, there exists $S \\subseteq V(G)$ with $G[S] \\cong H$. The number of graphs on $k$ vertices is $2^{\\binom{k}{2}}$, so $k$-universality implies $i(G) \\geq 2^{\\binom{k}{2}}$.",
     "significance": "key",
     "relatedConcepts": [
       "universal graph",
-      "Pr\u00f6mel-R\u00f6dl theorem",
+      "Prömel-Rödl theorem",
       "induced universality"
     ],
     "prerequisites": [
@@ -908,10 +736,6 @@
   {
     "id": "ann-1036-univdistinct",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 343,
-      "endLine": 346
-    },
     "type": "technique",
     "title": "universal_implies_distinct",
     "content": "k-universality implies having at least 2^{C(k,2)} distinct induced subgraphs, since there are that many non-isomorphic graphs on k vertices.",
@@ -929,17 +753,13 @@
   {
     "id": "ann-1036-viauniv",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 348,
-      "endLine": 355
-    },
     "type": "technique",
     "title": "via_universality",
-    "content": "Alternative proof of Problem 1036 via Pr\u00f6mel-R\u00f6dl universality (Problem 1031): non-Ramsey graphs are c\u00b7log(n)-universal, and universality implies exponentially many distinct induced subgraphs.",
-    "mathContext": "By Pr\u00f6mel-R\u00f6dl (Problem 1031), non-Ramsey $G$ is $c \\log n$-universal. Hence $i(G) \\geq 2^{\\binom{c \\log n}{2}} = 2^{\\Omega((\\log n)^2)}$. Note: this gives a weaker bound than Shelah's $2^{\\Omega(n)}$ but provides a conceptually cleaner proof via universality.",
+    "content": "Alternative proof of Problem 1036 via Prömel-Rödl universality (Problem 1031): non-Ramsey graphs are c·log(n)-universal, and universality implies exponentially many distinct induced subgraphs.",
+    "mathContext": "By Prömel-Rödl (Problem 1031), non-Ramsey $G$ is $c \\log n$-universal. Hence $i(G) \\geq 2^{\\binom{c \\log n}{2}} = 2^{\\Omega((\\log n)^2)}$. Note: this gives a weaker bound than Shelah's $2^{\\Omega(n)}$ but provides a conceptually cleaner proof via universality.",
     "significance": "key",
     "relatedConcepts": [
-      "Pr\u00f6mel-R\u00f6dl universality",
+      "Prömel-Rödl universality",
       "alternative proof",
       "Problem 1031 connection"
     ],

--- a/src/data/proofs/erdos-1050/annotations.json
+++ b/src/data/proofs/erdos-1050/annotations.json
@@ -2,421 +2,574 @@
   {
     "id": "ann-1050-header",
     "proofId": "erdos-1050",
-    "range": { "startLine": 1, "endLine": 18 },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #1050: Irrationality of ∑ 1/(2^n - 3)**\n\nIs ∑_{n≥1} 1/(2^n - 3) irrational?\n\n**Status**: SOLVED by Peter Borwein (1991)\n\n**Answer**: YES. Borwein proved ∑ 1/(q^n + r) is irrational for integer q ≥ 2 and rational r ≠ 0, r ≠ -q^n for any n. This subsumes Erdős's 1948 result on ∑ 1/(2^n - 1) as the special case q = 2, r = -1.",
     "significance": "key",
     "mathContext": "The series ∑ 1/(2^n - 3) is a Lambert-type series where each denominator is an exponential shifted by a constant. Borwein's approach uses Padé approximation to the q-logarithm function, constructing rational approximants whose convergence rate exceeds what would be possible if the sum were rational — a contradiction.",
-    "relatedConcepts": ["Lambert series", "Padé approximation", "irrationality proofs", "q-series"],
-    "prerequisites": ["convergence of geometric series", "irrationality criterion"]
+    "relatedConcepts": [
+      "Lambert series",
+      "Padé approximation",
+      "irrationality proofs",
+      "q-series"
+    ],
+    "prerequisites": [
+      "convergence of geometric series",
+      "irrationality criterion"
+    ]
   },
   {
     "id": "ann-1050-T-def",
     "proofId": "erdos-1050",
-    "range": { "startLine": 32, "endLine": 34 },
     "type": "definition",
     "title": "General Series T",
     "content": "**T q r**: T(q, r) = ∑_{n≥1} 1/(q^n + r).\n\nThe general family of series covered by Borwein's theorem. Each term decays exponentially as 1/q^n for large n, ensuring convergence. The parameter r shifts each denominator, and the condition r ≠ -q^n for any n ensures no denominator vanishes.",
     "significance": "key",
     "mathContext": "T(q, r) generalizes several classical series: T(q, -1) = ∑ 1/(q^n - 1) is the Lambert series that Erdős studied in 1948 (Problem #1049), T(q, 0) = 1/(q-1) is rational (geometric series), and T(q, 1) = ∑ 1/(q^n + 1) is the 'alternating' companion. The family T(q, r) forms a one-parameter subfamily of Lambert series with constant coefficients.",
-    "relatedConcepts": ["Lambert series", "geometric series", "parametric families of series"],
-    "prerequisites": ["definition of infinite series", "absolute convergence"]
+    "relatedConcepts": [
+      "Lambert series",
+      "geometric series",
+      "parametric families of series"
+    ],
+    "prerequisites": [
+      "definition of infinite series",
+      "absolute convergence"
+    ]
   },
   {
     "id": "ann-1050-S-def",
     "proofId": "erdos-1050",
-    "range": { "startLine": 36, "endLine": 37 },
     "type": "definition",
     "title": "Series S",
     "content": "**S**: S = T(2, -3) = ∑_{n≥1} 1/(2^n - 3).\n\nThe specific series of Erdős Problem #1050. The choice r = -3 makes this a natural test case: 3 is not a power of 2, so no denominator vanishes, but the first term 1/(2-3) = -1 is negative, creating an interesting cancellation pattern.",
     "significance": "key",
     "mathContext": "The shift by -3 rather than -1 distinguishes this from the Erdős-Borwein constant ∑ 1/(2^n - 1) ≈ 1.607. The value S ≈ 0.287 is smaller because the first term is -1 and the second is +1 (exact cancellation), so the series effectively starts from n = 3.",
-    "relatedConcepts": ["Erdős-Borwein constant", "partial cancellation in series"],
-    "prerequisites": ["T(q,r) series definition"]
+    "relatedConcepts": [
+      "Erdős-Borwein constant",
+      "partial cancellation in series"
+    ],
+    "prerequisites": [
+      "T(q,r) series definition"
+    ]
   },
   {
     "id": "ann-1050-alt",
     "proofId": "erdos-1050",
-    "range": { "startLine": 39, "endLine": 41 },
     "type": "definition",
     "title": "Alternative Form",
     "content": "**sumTwoMinusThree**: Alternative definition of ∑ 1/(2^n - 3) as a direct tsum.\n\nShows the explicit form bypassing the T(q,r) parametrization, useful for direct computation.",
     "significance": "supporting",
     "mathContext": "The direct definition makes clear that the denominators are -1, 1, 5, 13, 29, 61, 125, ... (sequence 2^n - 3). These grow exponentially, ensuring rapid convergence after the initial cancellation.",
-    "relatedConcepts": ["tsum (topological sum)", "explicit series representation"],
-    "prerequisites": ["Mathlib tsum definition"]
+    "relatedConcepts": [
+      "tsum (topological sum)",
+      "explicit series representation"
+    ],
+    "prerequisites": [
+      "Mathlib tsum definition"
+    ]
   },
   {
     "id": "ann-1050-summable",
     "proofId": "erdos-1050",
-    "range": { "startLine": 53, "endLine": 57 },
     "type": "technique",
     "title": "Convergence",
     "content": "**T_summable**: T(q, r) converges (is summable) for q ≥ 2 and r ≠ -q^n for all n.\n\nFor large n, |1/(q^n + r)| ≤ 2/q^n, and ∑ 1/q^n converges as a geometric series with ratio 1/q < 1. The pole-avoidance condition r ≠ -q^n ensures each term is finite.",
     "significance": "key",
     "mathContext": "Summability in Mathlib's sense (Summable) means the net of partial sums converges in ℝ. For absolutely convergent series this reduces to the classical notion. The comparison with the geometric series ∑ 1/q^n via the comparison test is the standard approach.",
-    "relatedConcepts": ["comparison test", "geometric series convergence", "Summable typeclass"],
-    "prerequisites": ["geometric series formula", "absolute convergence criterion"]
+    "relatedConcepts": [
+      "comparison test",
+      "geometric series convergence",
+      "Summable typeclass"
+    ],
+    "prerequisites": [
+      "geometric series formula",
+      "absolute convergence criterion"
+    ]
   },
   {
     "id": "ann-1050-S-summable",
     "proofId": "erdos-1050",
-    "range": { "startLine": 59, "endLine": 61 },
     "type": "technique",
     "title": "S Convergence",
     "content": "**S_summable**: ∑ 1/(2^n - 3) converges.\n\nSpecializes T_summable to q = 2, r = -3. Need to verify 3 ≠ 2^n for all n ≥ 1, which holds since 2^n ∈ {2, 4, 8, 16, ...} never equals 3.",
     "significance": "supporting",
     "mathContext": "The key verification that 3 is not a power of 2 is equivalent to saying log₂(3) is irrational — a basic fact following from the fundamental theorem of arithmetic (2 and 3 are distinct primes). This ensures every term of the series is well-defined.",
-    "relatedConcepts": ["powers of 2", "fundamental theorem of arithmetic"],
-    "prerequisites": ["T_summable", "3 is not a power of 2"]
+    "relatedConcepts": [
+      "powers of 2",
+      "fundamental theorem of arithmetic"
+    ],
+    "prerequisites": [
+      "T_summable",
+      "3 is not a power of 2"
+    ]
   },
   {
     "id": "ann-1050-denom",
     "proofId": "erdos-1050",
-    "range": { "startLine": 63, "endLine": 65 },
     "type": "technique",
     "title": "Nonzero Denominators",
     "content": "**denom_nonzero**: 2^n - 3 ≠ 0 for all n ≥ 1.\n\nFor n = 1: 2^1 - 3 = -1 ≠ 0. For n ≥ 2: 2^n ≥ 4 > 3, so 2^n - 3 ≥ 1 > 0.",
     "significance": "supporting",
     "mathContext": "This is the well-definedness check ensuring no term has a zero denominator. The proof splits into the case n = 1 (negative denominator) and n ≥ 2 (positive denominator), reflecting the sign change in the denominators.",
-    "relatedConcepts": ["exponential growth", "well-definedness of series terms"],
-    "prerequisites": ["basic properties of powers of 2"]
+    "relatedConcepts": [
+      "exponential growth",
+      "well-definedness of series terms"
+    ],
+    "prerequisites": [
+      "basic properties of powers of 2"
+    ]
   },
   {
     "id": "ann-1050-first",
     "proofId": "erdos-1050",
-    "range": { "startLine": 67, "endLine": 69 },
     "type": "technique",
     "title": "First Term",
     "content": "**first_term**: 1/(2^1 - 3) = 1/(-1) = -1.\n\nThe first term is negative! This is unusual for irrationality problems — the series has a large negative initial term that nearly cancels the second term 1/(2² - 3) = 1/1 = 1, leaving a small positive remainder ≈ 0.287.",
     "significance": "key",
     "mathContext": "The negative first term distinguishes this series from the Erdős-Borwein constant ∑ 1/(2^n - 1) where all terms are positive. The near-cancellation -1 + 1 = 0 means S is dominated by the 'tail' ∑_{n≥3} 1/(2^n - 3), making direct irrationality proofs via digit extraction more difficult.",
-    "relatedConcepts": ["sign changes in series", "cancellation phenomena"],
-    "prerequisites": ["arithmetic of powers of 2"]
+    "relatedConcepts": [
+      "sign changes in series",
+      "cancellation phenomena"
+    ],
+    "prerequisites": [
+      "arithmetic of powers of 2"
+    ]
   },
   {
     "id": "ann-1050-term1",
     "proofId": "erdos-1050",
-    "range": { "startLine": 77, "endLine": 78 },
     "type": "technique",
     "title": "Term 1",
     "content": "**term_1**: 2^1 - 3 = -1.\n\nThe unique negative denominator in the series.",
     "significance": "supporting",
     "mathContext": "The fact that 2^1 < 3 while 2^n > 3 for all n ≥ 2 means there is exactly one negative term in the series.",
-    "relatedConcepts": ["denominator sign analysis"],
+    "relatedConcepts": [
+      "denominator sign analysis"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-term2",
     "proofId": "erdos-1050",
-    "range": { "startLine": 80, "endLine": 81 },
     "type": "technique",
     "title": "Term 2",
     "content": "**term_2**: 2^2 - 3 = 1.\n\nGives the second term 1/(2²-3) = 1, which exactly cancels the first term -1.",
     "significance": "supporting",
     "mathContext": "The exact cancellation 1/(2¹-3) + 1/(2²-3) = -1 + 1 = 0 means the 'effective series' starts at n = 3.",
-    "relatedConcepts": ["telescoping", "exact cancellation"],
+    "relatedConcepts": [
+      "telescoping",
+      "exact cancellation"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-term3",
     "proofId": "erdos-1050",
-    "range": { "startLine": 83, "endLine": 84 },
     "type": "technique",
     "title": "Term 3",
     "content": "**term_3**: 2^3 - 3 = 5.\n\nThe third term 1/5 = 0.2 is the first contribution to the 'effective value' of S after cancellation of the first two terms.",
     "significance": "supporting",
     "mathContext": "From n = 3 onward, the denominators 5, 13, 29, 61, ... grow as 2^n - 3, and all terms are positive and decreasing.",
-    "relatedConcepts": ["monotone decreasing terms"],
+    "relatedConcepts": [
+      "monotone decreasing terms"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-first-terms",
     "proofId": "erdos-1050",
-    "range": { "startLine": 92, "endLine": 96 },
     "type": "technique",
     "title": "First Terms",
     "content": "**S_first_terms**: S = -1 + 1 + 1/5 + 1/13 + 1/29 + 1/61 + ...\n\nAfter the first two terms cancel (-1 + 1 = 0), the sum equals 1/5 + 1/13 + 1/29 + 1/61 + ... ≈ 0.287. The denominators grow as 2^n - 3, ensuring rapid convergence.",
     "significance": "key",
     "mathContext": "The rapid convergence after cancellation means S is very well-approximated by a few terms: S ≈ 1/5 + 1/13 + 1/29 + 1/61 + 1/125 ≈ 0.2 + 0.077 + 0.034 + 0.016 + 0.008 ≈ 0.287. This makes numerical verification easy but irrationality proof requires Borwein's deeper methods.",
-    "relatedConcepts": ["numerical series evaluation", "rapid convergence"],
-    "prerequisites": ["term computations term_1 through term_3"]
+    "relatedConcepts": [
+      "numerical series evaluation",
+      "rapid convergence"
+    ],
+    "prerequisites": [
+      "term computations term_1 through term_3"
+    ]
   },
   {
     "id": "ann-1050-borwein",
     "proofId": "erdos-1050",
-    "range": { "startLine": 104, "endLine": 108 },
     "type": "context",
     "title": "Borwein's Theorem",
     "content": "**borwein_irrationality (1991)**: ∑ 1/(q^n + r) is irrational for integer q ≥ 2, rational r ≠ 0, and r ≠ -q^n for any n ≥ 1.\n\nAxiomatized from Borwein's 1991 paper in Math. Proc. Cambridge Philos. Soc. The proof constructs Padé-type rational approximants to the q-logarithm function whose convergence rate forces irrationality.",
     "significance": "key",
     "mathContext": "Borwein's proof technique uses Padé approximation to the function -log_q(1 + r/q^n), constructing sequences of rationals p_k/q_k with |S - p_k/q_k| < c^k/q_k for some c < 1. If S = a/b were rational, then |S - p_k/q_k| ≥ 1/(b·q_k) for p_k/q_k ≠ S, contradicting the exponential convergence for large k. This is a generalization of Apéry's method and extends Erdős's 1948 approach which worked only for integer r.",
-    "relatedConcepts": ["Padé approximation", "irrationality measure", "Apéry's method", "q-logarithm"],
-    "prerequisites": ["convergence of T(q,r)", "rational approximation theory"]
+    "relatedConcepts": [
+      "Padé approximation",
+      "irrationality measure",
+      "Apéry's method",
+      "q-logarithm"
+    ],
+    "prerequisites": [
+      "convergence of T(q,r)",
+      "rational approximation theory"
+    ]
   },
   {
     "id": "ann-1050-S-irr",
     "proofId": "erdos-1050",
-    "range": { "startLine": 110, "endLine": 139 },
     "type": "technique",
     "title": "S is Irrational",
     "content": "**S_irrational**: ∑ 1/(2^n - 3) is irrational.\n\nApplies Borwein's theorem with q = 2, r = -3. The verification that -3 ≠ -2^n for any n uses the fact that 3 is not a power of 2 (since 2^n ∈ {2, 4, 8, 16, ...} never equals 3).",
     "significance": "key",
     "mathContext": "This is the answer to Erdős Problem #1050. The irrationality of S follows immediately from Borwein's general theorem once the pole-avoidance condition is verified. The verification is elementary: 2^n takes values 2, 4, 8, 16, ... (all even except 2^0 = 1), and 3 is not among them.",
-    "relatedConcepts": ["instantiation of general irrationality theorems", "pole avoidance"],
-    "prerequisites": ["borwein_irrationality", "S_summable", "3 is not a power of 2"]
+    "relatedConcepts": [
+      "instantiation of general irrationality theorems",
+      "pole avoidance"
+    ],
+    "prerequisites": [
+      "borwein_irrationality",
+      "S_summable",
+      "3 is not a power of 2"
+    ]
   },
   {
     "id": "ann-1050-2n-1",
     "proofId": "erdos-1050",
-    "range": { "startLine": 147, "endLine": 164 },
     "type": "technique",
     "title": "∑ 1/(2^n - 1)",
     "content": "**sum_2n_minus_1_irrational**: ∑ 1/(2^n - 1) is irrational.\n\nThis is Erdős's original 1948 result, now recovered as the special case T(2, -1) of Borwein's theorem. The sum ∑ 1/(2^n - 1) = 1 + 1/3 + 1/7 + 1/15 + ... ≈ 1.607 is the Erdős-Borwein constant.",
     "significance": "key",
     "mathContext": "Erdős's 1948 proof in the Journal of the Indian Mathematical Society used different techniques from Borwein: he exploited the identity ∑ 1/(2^n - 1) = ∑ τ(n)/2^n (where τ is the divisor function) and used properties of τ to rule out rationality. Borwein's approach is more general but less elementary. The Erdős-Borwein constant E = ∑ 1/(2^n - 1) ≈ 1.60669 appears in digital sum problems and binary representations.",
-    "relatedConcepts": ["Erdős-Borwein constant", "divisor function identity", "Lambert series"],
-    "prerequisites": ["borwein_irrationality", "1 is not a power of 2"]
+    "relatedConcepts": [
+      "Erdős-Borwein constant",
+      "divisor function identity",
+      "Lambert series"
+    ],
+    "prerequisites": [
+      "borwein_irrationality",
+      "1 is not a power of 2"
+    ]
   },
   {
     "id": "ann-1050-2n+1",
     "proofId": "erdos-1050",
-    "range": { "startLine": 166, "endLine": 179 },
     "type": "technique",
     "title": "∑ 1/(2^n + 1)",
     "content": "**sum_2n_plus_1_irrational**: ∑ 1/(2^n + 1) is irrational.\n\nApplies Borwein's theorem with q = 2, r = 1. The condition r ≠ -q^n is automatic since 1 > 0 while -2^n < 0.",
     "significance": "supporting",
     "mathContext": "The sum ∑ 1/(2^n + 1) = 1/3 + 1/5 + 1/9 + 1/17 + ... ≈ 0.7645 is the 'alternating companion' to the Erdős-Borwein constant. The identity ∑ 1/(2^n - 1) - ∑ 1/(2^n + 1) = ∑ 2/(2^{2n} - 1) shows these two constants are related via a series with squared exponential denominators.",
-    "relatedConcepts": ["companion series", "difference of reciprocal series"],
-    "prerequisites": ["borwein_irrationality"]
+    "relatedConcepts": [
+      "companion series",
+      "difference of reciprocal series"
+    ],
+    "prerequisites": [
+      "borwein_irrationality"
+    ]
   },
   {
     "id": "ann-1050-3n-1",
     "proofId": "erdos-1050",
-    "range": { "startLine": 181, "endLine": 200 },
     "type": "technique",
     "title": "∑ 1/(3^n - 1)",
     "content": "**sum_3n_minus_1_irrational**: ∑ 1/(3^n - 1) is irrational.\n\nExtends to base q = 3 with r = -1. The sum = 1/2 + 1/8 + 1/26 + 1/80 + ... ≈ 0.6634. Verification: 1 ≠ 3^n for any n ≥ 1 since 3^n ≥ 3.",
     "significance": "supporting",
     "mathContext": "Changing the base from 2 to 3 gives a different constant with the same irrationality proof structure. The identity ∑ 1/(3^n - 1) = ∑ τ₃(n)/3^n (where τ₃ counts 'ternary divisors') generalizes the Erdős divisor identity to other bases, connecting to Problem #1049's framework.",
-    "relatedConcepts": ["base-3 Lambert series", "generalized divisor functions"],
-    "prerequisites": ["borwein_irrationality"]
+    "relatedConcepts": [
+      "base-3 Lambert series",
+      "generalized divisor functions"
+    ],
+    "prerequisites": [
+      "borwein_irrationality"
+    ]
   },
   {
     "id": "ann-1050-general",
     "proofId": "erdos-1050",
-    "range": { "startLine": 202, "endLine": 205 },
     "type": "technique",
     "title": "General Case",
     "content": "**general_irrational**: ∑ 1/(q^n + r) is irrational for all valid q ≥ 2 and rational r ≠ 0, r ≠ -q^n.\n\nThe full generality of Borwein's theorem instantiated: for any choice of parameters satisfying the hypotheses, the resulting series is irrational.",
     "significance": "key",
     "mathContext": "This gives an infinite family of irrational numbers, parametrized by (q, r). The excluded values r = -q^n (which produce divergent series) form a countable set, so 'almost all' rational shifts r produce irrational sums. Borwein's theorem does not give irrationality measures; the question of how irrational these numbers are (their irrationality exponent) remains open.",
-    "relatedConcepts": ["irrationality exponent", "parametric irrationality results"],
-    "prerequisites": ["borwein_irrationality", "T_summable"]
+    "relatedConcepts": [
+      "irrationality exponent",
+      "parametric irrationality results"
+    ],
+    "prerequisites": [
+      "borwein_irrationality",
+      "T_summable"
+    ]
   },
   {
     "id": "ann-1050-trans-conj",
     "proofId": "erdos-1050",
-    "range": { "startLine": 213, "endLine": 216 },
     "type": "definition",
     "title": "Transcendence Conjecture",
     "content": "**ErdosTranscendenceConjecture**: ∑ 1/(2^n + t) is transcendental for integer t ≠ 0.\n\nErdős's stronger conjecture, going beyond irrationality to transcendence. If true, these numbers are not roots of any polynomial with integer coefficients. Status: OPEN.",
     "significance": "key",
     "mathContext": "Transcendence is strictly stronger than irrationality: every transcendental number is irrational but not conversely (√2 is irrational but algebraic). The conjecture would place all T(2, t) for t ≠ 0 in the same class as e and π. Progress toward transcendence would likely require Mahler's method or the Nesterenko-Zudilin framework for q-series, which has proved transcendence for related theta-function values.",
-    "relatedConcepts": ["Mahler's method", "transcendence theory", "q-series", "Nesterenko-Zudilin"],
-    "prerequisites": ["definition of transcendental number", "Borwein's irrationality result"]
+    "relatedConcepts": [
+      "Mahler's method",
+      "transcendence theory",
+      "q-series",
+      "Nesterenko-Zudilin"
+    ],
+    "prerequisites": [
+      "definition of transcendental number",
+      "Borwein's irrationality result"
+    ]
   },
   {
     "id": "ann-1050-gen-trans",
     "proofId": "erdos-1050",
-    "range": { "startLine": 218, "endLine": 222 },
     "type": "definition",
     "title": "General Transcendence",
     "content": "**GeneralTranscendenceConjecture**: T(q, r) is transcendental for all valid integer q ≥ 2 and rational r ≠ 0.\n\nThe general form extending Erdős's conjecture to all bases q and all rational shifts r.",
     "significance": "key",
     "mathContext": "This is a vast generalization of Erdős's specific conjecture. Even for the simplest case T(2, -1) = ∑ 1/(2^n - 1) (the Erdős-Borwein constant), transcendence is unknown. The strongest known results toward this use Nishioka's theorem on Mahler functions, which proves transcendence for certain q-hypergeometric series but does not directly apply to T(q, r).",
-    "relatedConcepts": ["Nishioka's theorem", "Mahler functions", "algebraic independence"],
-    "prerequisites": ["definition of transcendental number"]
+    "relatedConcepts": [
+      "Nishioka's theorem",
+      "Mahler functions",
+      "algebraic independence"
+    ],
+    "prerequisites": [
+      "definition of transcendental number"
+    ]
   },
   {
     "id": "ann-1050-trans-implies",
     "proofId": "erdos-1050",
-    "range": { "startLine": 224, "endLine": 230 },
     "type": "technique",
     "title": "Transcendence Implies Irrationality",
     "content": "**transcendence_implies_irrationality**: If T(q,r) is transcendental, then it is irrational.\n\nEvery transcendental number is irrational (since every rational number is algebraic: a/b is a root of bx - a = 0). So the transcendence conjecture strictly strengthens Borwein's theorem.",
     "significance": "supporting",
     "mathContext": "This is a basic fact in number theory: the hierarchy is ℚ ⊂ algebraic numbers ⊂ ℝ, with transcendental = ℝ \\ algebraic. The transcendence conjecture would give strictly more information than Borwein's irrationality result.",
-    "relatedConcepts": ["algebraic number", "number field hierarchy"],
-    "prerequisites": ["definition of transcendental and irrational"]
+    "relatedConcepts": [
+      "algebraic number",
+      "number field hierarchy"
+    ],
+    "prerequisites": [
+      "definition of transcendental and irrational"
+    ]
   },
   {
     "id": "ann-1050-status",
     "proofId": "erdos-1050",
-    "range": { "startLine": 232, "endLine": 235 },
     "type": "context",
     "title": "Conjecture Status",
     "content": "**transcendence_conjecture_status**: The transcendence conjecture for ∑ 1/(q^n + r) remains open as of 2026.\n\nRecorded as an axiom for documentation purposes. No progress beyond irrationality has been established for any T(q, r).",
     "significance": "supporting",
     "mathContext": "The gap between irrationality (proved by Borwein 1991) and transcendence (conjectured by Erdős) has remained unbridged for over 35 years, suggesting fundamentally new methods are needed.",
-    "relatedConcepts": ["open problems in transcendence theory"],
+    "relatedConcepts": [
+      "open problems in transcendence theory"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-S1049",
     "proofId": "erdos-1050",
-    "range": { "startLine": 243, "endLine": 245 },
     "type": "definition",
     "title": "Problem #1049 Series",
     "content": "**S_1049 t**: S(t) = ∑ 1/(t^n - 1) from Problem #1049.\n\nThis equals T(t, -1) in the T(q,r) parametrization. Problem #1049 asks about irrationality of S(t) for rational t > 1, while #1050 handles the general shift r.",
     "significance": "supporting",
     "mathContext": "The connection S(t) = T(t, -1) shows that Problem #1049 is a special case of the family studied in #1050. Erdős proved S(t) irrational for integer t ≥ 2 using the divisor function identity ∑ 1/(t^n - 1) = ∑ τ(n)/t^n. Borwein's theorem recovers this and extends to all rational r.",
-    "relatedConcepts": ["Problem #1049 connection", "divisor function identity"],
-    "prerequisites": ["T(q,r) definition", "Problem #1049 series"]
+    "relatedConcepts": [
+      "Problem #1049 connection",
+      "divisor function identity"
+    ],
+    "prerequisites": [
+      "T(q,r) definition",
+      "Problem #1049 series"
+    ]
   },
   {
     "id": "ann-1050-T-eq-S1049",
     "proofId": "erdos-1050",
-    "range": { "startLine": 247, "endLine": 249 },
     "type": "technique",
     "title": "Connection",
     "content": "**T_eq_S_1049**: T(q, -1) = S_1049(q) = ∑ 1/(q^n - 1).\n\nEstablishes the formal equivalence between the r = -1 case of T(q, r) and the series from Problem #1049. This makes explicit that Borwein's theorem subsumes Erdős's 1948 result.",
     "significance": "key",
     "mathContext": "This identity is purely algebraic: 1/(q^n + (-1)) = 1/(q^n - 1). Its significance is structural — it connects two problems in Erdős's catalogue and shows that Borwein's framework provides a unified approach to both.",
-    "relatedConcepts": ["problem interconnection", "parameter specialization"],
-    "prerequisites": ["T(q,r) definition", "S_1049 definition"]
+    "relatedConcepts": [
+      "problem interconnection",
+      "parameter specialization"
+    ],
+    "prerequisites": [
+      "T(q,r) definition",
+      "S_1049 definition"
+    ]
   },
   {
     "id": "ann-1050-related",
     "proofId": "erdos-1050",
-    "range": { "startLine": 251, "endLine": 256 },
     "type": "technique",
     "title": "Problems Related",
     "content": "**problems_related**: Both T(q, -1) = ∑ 1/(q^n - 1) and T(q, r) = ∑ 1/(q^n + r) are irrational for valid parameters.\n\nShows that Problem #1049 and #1050 share the same resolution method via Borwein's theorem.",
     "significance": "supporting",
     "mathContext": "The unification through Borwein's theorem illustrates a common phenomenon in number theory: initially distinct irrationality questions often yield to a single, more general technique (here, Padé approximation to q-logarithms).",
-    "relatedConcepts": ["unification of irrationality results"],
-    "prerequisites": ["borwein_irrationality", "T_eq_S_1049"]
+    "relatedConcepts": [
+      "unification of irrationality results"
+    ],
+    "prerequisites": [
+      "borwein_irrationality",
+      "T_eq_S_1049"
+    ]
   },
   {
     "id": "ann-1050-approx",
     "proofId": "erdos-1050",
-    "range": { "startLine": 264, "endLine": 265 },
     "type": "context",
     "title": "Approximation",
     "content": "**S_approx**: 0.286 < S < 0.288, so S ≈ 0.287.\n\nAxiomatized numerical bounds. Verified by computing the first ~10 terms: S ≈ 0 + 1/5 + 1/13 + 1/29 + 1/61 + 1/125 + ... ≈ 0.28719.",
     "significance": "supporting",
     "mathContext": "The rapid convergence (terms decay as 1/2^n) means just 10 terms give accuracy to within 10⁻³. The value 0.287... does not match any known closed-form expression, consistent with the transcendence conjecture.",
-    "relatedConcepts": ["numerical series evaluation", "decimal expansion"],
-    "prerequisites": ["S_summable", "first terms computation"]
+    "relatedConcepts": [
+      "numerical series evaluation",
+      "decimal expansion"
+    ],
+    "prerequisites": [
+      "S_summable",
+      "first terms computation"
+    ]
   },
   {
     "id": "ann-1050-positive",
     "proofId": "erdos-1050",
-    "range": { "startLine": 267, "endLine": 270 },
     "type": "technique",
     "title": "S Positive",
     "content": "**S_positive**: S > 0.\n\nDespite the first term being -1, the series sums to a positive value. This follows from the exact cancellation of the first two terms (-1 + 1 = 0) and the positivity of all subsequent terms (1/5 + 1/13 + ... > 0).",
     "significance": "supporting",
     "mathContext": "The positivity is needed for the numerical bounds S ∈ (0.286, 0.288) and confirms the series is a well-defined positive real constant, not merely a formal series.",
-    "relatedConcepts": ["sign analysis of series", "positivity from tail domination"],
-    "prerequisites": ["S_first_terms"]
+    "relatedConcepts": [
+      "sign analysis of series",
+      "positivity from tail domination"
+    ],
+    "prerequisites": [
+      "S_first_terms"
+    ]
   },
   {
     "id": "ann-1050-lt-one",
     "proofId": "erdos-1050",
-    "range": { "startLine": 272, "endLine": 275 },
     "type": "technique",
     "title": "S < 1",
     "content": "**S_lt_one**: S < 1.\n\nAfter the cancellation of -1 + 1 = 0, the remaining series 1/5 + 1/13 + 1/29 + ... < 1/5 · (1 + 1/2 + 1/4 + ...) = 1/5 · 2 = 2/5 < 1.",
     "significance": "supporting",
     "mathContext": "The bound S < 1 combined with S > 0 places S in the unit interval (0, 1). More precisely, S ≈ 0.287 is closer to 0 than to 1.",
-    "relatedConcepts": ["series upper bounds", "geometric series comparison"],
-    "prerequisites": ["S_positive", "comparison with geometric series"]
+    "relatedConcepts": [
+      "series upper bounds",
+      "geometric series comparison"
+    ],
+    "prerequisites": [
+      "S_positive",
+      "comparison with geometric series"
+    ]
   },
   {
     "id": "ann-1050-partial",
     "proofId": "erdos-1050",
-    "range": { "startLine": 277, "endLine": 282 },
     "type": "technique",
     "title": "Partial Sums",
     "content": "**partial_sums_converge**: The partial sums Sₙ = ∑_{k=1}^{n} 1/(2^k - 3) converge to S.\n\nStandard convergence statement relating finite partial sums to the infinite series via Mathlib's tsum machinery.",
     "significance": "supporting",
     "mathContext": "In Mathlib, tsum is defined as the limit of partial sums when the series is summable (HasSum). This theorem establishes the standard limit relationship, enabling passage between finite and infinite computations.",
-    "relatedConcepts": ["HasSum", "tsum", "partial sum convergence"],
-    "prerequisites": ["S_summable"]
+    "relatedConcepts": [
+      "HasSum",
+      "tsum",
+      "partial sum convergence"
+    ],
+    "prerequisites": [
+      "S_summable"
+    ]
   },
   {
     "id": "ann-1050-oeis",
     "proofId": "erdos-1050",
-    "range": { "startLine": 290, "endLine": 293 },
     "type": "definition",
     "title": "OEIS Sequence",
     "content": "**oeis_A331372**: The denominator sequence 2^n - 3 for n ≥ 1.\n\nRelated to OEIS sequence A331372. Values: -1, 1, 5, 13, 29, 61, 125, 253, 509, 1021, ...",
     "significance": "supporting",
     "mathContext": "The OEIS connection provides a bridge to computational number theory. The sequence 2^n - 3 is a shifted Mersenne sequence (Mersenne numbers are 2^n - 1). Like Mersenne numbers, primality of 2^n - 3 is studied: 2^n - 3 is prime for n = 3, 4, 5, 9, 17, ... (no simple pattern).",
-    "relatedConcepts": ["OEIS", "Mersenne numbers", "shifted exponential sequences"],
+    "relatedConcepts": [
+      "OEIS",
+      "Mersenne numbers",
+      "shifted exponential sequences"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-denom-seq",
     "proofId": "erdos-1050",
-    "range": { "startLine": 295, "endLine": 298 },
     "type": "technique",
     "title": "Denominator Sequence",
     "content": "**denom_sequence**: oeis_A331372(n) = 2^n - 3 for n ≥ 1.\n\nVerifies the sequence definition matches the OEIS entry.",
     "significance": "supporting",
     "mathContext": "This is a definitional verification linking the formal Lean definition to the external database.",
-    "relatedConcepts": ["sequence verification"],
-    "prerequisites": ["oeis_A331372 definition"]
+    "relatedConcepts": [
+      "sequence verification"
+    ],
+    "prerequisites": [
+      "oeis_A331372 definition"
+    ]
   },
   {
     "id": "ann-1050-growth",
     "proofId": "erdos-1050",
-    "range": { "startLine": 300, "endLine": 303 },
     "type": "technique",
     "title": "Exponential Growth",
     "content": "**denom_growth**: For n ≥ 3, 2^n - 3 > 2^(n-1).\n\nThe denominators grow exponentially, ensuring the series terms 1/(2^n - 3) decay at rate 1/2^n. This is stronger than polynomial growth and guarantees rapid convergence.",
     "significance": "supporting",
     "mathContext": "The growth rate 2^n - 3 ~ 2^n means the terms 1/(2^n - 3) ~ 1/2^n, so the series converges at the same rate as the geometric series ∑ 1/2^n. The error from truncating after N terms is O(1/2^N).",
-    "relatedConcepts": ["exponential growth", "convergence rate", "truncation error"],
-    "prerequisites": ["basic properties of 2^n"]
+    "relatedConcepts": [
+      "exponential growth",
+      "convergence rate",
+      "truncation error"
+    ],
+    "prerequisites": [
+      "basic properties of 2^n"
+    ]
   },
   {
     "id": "ann-1050-main",
     "proofId": "erdos-1050",
-    "range": { "startLine": 311, "endLine": 321 },
     "type": "technique",
     "title": "Main Result",
     "content": "**erdos_1050**: ∑ 1/(2^n - 3) is irrational.\n\nThe complete answer to Erdős Problem #1050, solved by Peter Borwein (1991). Follows from S_irrational which applies borwein_irrationality with q = 2, r = -3. The transcendence conjecture (is S transcendental?) remains OPEN.",
     "significance": "key",
     "mathContext": "This is the capstone theorem unifying the entire formalization. It chains: T(q,r) definition → convergence → Borwein's theorem (axiom) → pole avoidance verification → irrationality of S. The problem is fully resolved for irrationality but the stronger transcendence question posed by Erdős remains one of the outstanding open problems in analytic number theory.",
-    "relatedConcepts": ["capstone theorem", "problem resolution"],
-    "prerequisites": ["S_irrational", "borwein_irrationality"]
+    "relatedConcepts": [
+      "capstone theorem",
+      "problem resolution"
+    ],
+    "prerequisites": [
+      "S_irrational",
+      "borwein_irrationality"
+    ]
   },
   {
     "id": "ann-1050-answer",
     "proofId": "erdos-1050",
-    "range": { "startLine": 323, "endLine": 329 },
     "type": "definition",
     "title": "Final Answer",
     "content": "**erdos_1050_answer**: \"SOLVED: ∑ 1/(2^n - 3) is irrational (Borwein 1991)\"\n\n**erdos_1050_status**: \"SOLVED by Peter Borwein (1991)\"",
     "significance": "key",
     "mathContext": "Erdős Problem #1050 joins the resolved problems in his catalogue. The resolution came 43 years after Erdős's initial 1948 work on related series, through Borwein's generalization of the techniques.",
-    "relatedConcepts": ["Erdős problem catalogue"],
-    "prerequisites": ["erdos_1050"]
+    "relatedConcepts": [
+      "Erdős problem catalogue"
+    ],
+    "prerequisites": [
+      "erdos_1050"
+    ]
   },
   {
     "id": "ann-1050-borwein-thm",
     "proofId": "erdos-1050",
-    "range": { "startLine": 331, "endLine": 334 },
     "type": "technique",
     "title": "Borwein's Full Theorem",
     "content": "**borwein_theorem**: ∑ 1/(q^n + r) is irrational for integer q ≥ 2, rational r ≠ 0, and r ≠ -q^n for any n.\n\nThe complete restatement of Borwein's 1991 result, emphasizing it covers rational (not just integer) shifts r. This extends the theorem's reach beyond what Erdős originally asked.",
     "significance": "key",
     "mathContext": "The extension from integer to rational r is significant: for r = p/q' with q' > 1, the series T(q, p/q') = ∑ q'/(q'·q^n + p) involves integer denominators but non-integer coefficients when rewritten. Borwein's Padé approximation technique handles this uniformly, making the rationality of r irrelevant to the proof structure.",
-    "relatedConcepts": ["rational parameter extension", "Padé approximation uniformity"],
-    "prerequisites": ["borwein_irrationality"]
+    "relatedConcepts": [
+      "rational parameter extension",
+      "Padé approximation uniformity"
+    ],
+    "prerequisites": [
+      "borwein_irrationality"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-625/annotations.json
+++ b/src/data/proofs/erdos-625/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-625-header",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 1,
-      "endLine": 19
-    },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #625**\n\nFor random graph G(n, 1/2), does χ(G) - ζ(G) → ∞ almost surely?\n\n**Status: OPEN**\n\n**Prize:** $1000 for FALSE, $100 for TRUE\n\nThe 2024 Heckel-Steiner breakthrough shows the difference is unbounded, but the exact asymptotic remains open.",
@@ -21,10 +17,6 @@
   {
     "id": "ann-625-cochromatic-class",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 35,
-      "endLine": 38
-    },
     "type": "definition",
     "title": "Cochromatic Color Class",
     "content": "**IsCochromaticClass G S:**\n\nA set S of vertices is cochromatic if it induces either:\n- A complete graph (all pairs adjacent), OR\n- An empty graph (no pairs adjacent)\n\nThis is the key relaxation from proper colorings, which only allow independent sets.",
@@ -39,10 +31,6 @@
   {
     "id": "ann-625-cochromatic-coloring",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 40,
-      "endLine": 43
-    },
     "type": "definition",
     "title": "Cochromatic Coloring",
     "content": "**CochromaticColoring G k:**\n\nA structure with:\n- color : V → Fin k (assignment of colors)\n- cochromatic : each color class is cochromatic\n\nEvery proper coloring is cochromatic (all classes are independent sets), but cochromatic colorings can also have clique classes.",
@@ -57,10 +45,6 @@
   {
     "id": "ann-625-cochromatic-number",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 45,
-      "endLine": 50
-    },
     "type": "definition",
     "title": "Cochromatic Number ζ(G)",
     "content": "**cochromaticNumber G:**\n\nThe minimum k such that G has a cochromatic k-coloring. Defined using Nat.find.\n\n**Properties:**\n- ζ(G) ≤ χ(G) (every proper coloring is cochromatic)\n- ζ(G) = ζ(Gᶜ) (symmetric under complement)",
@@ -75,10 +59,6 @@
   {
     "id": "ann-625-chromatic-number",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 52,
-      "endLine": 57
-    },
     "type": "definition",
     "title": "Chromatic Number χ(G)",
     "content": "**chromaticNumber G:**\n\nThe minimum k such that G has a proper k-coloring (no two adjacent vertices share a color).\n\nFor random G(n, 1/2):\nχ(G) ≤ (1+o(1))n/(2 log₂ n) almost surely.",
@@ -93,10 +73,6 @@
   {
     "id": "ann-625-proper-is-cochromatic",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 61,
-      "endLine": 64
-    },
     "type": "technique",
     "title": "Proper ⊆ Cochromatic",
     "content": "**proper_is_cochromatic:**\n\nEvery proper k-coloring is also a cochromatic k-coloring.\n\n**Proof idea:** In a proper coloring, each color class is an independent set. An independent set is trivially cochromatic (the 'empty' case).",
@@ -111,10 +87,6 @@
   {
     "id": "ann-625-le-chromatic",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 66,
-      "endLine": 69
-    },
     "type": "technique",
     "title": "ζ(G) ≤ χ(G)",
     "content": "**cochromatic_le_chromatic:**\n\nThe cochromatic number is at most the chromatic number.\n\n**Proof:** Any proper χ(G)-coloring is also cochromatic, so ζ(G) ≤ χ(G).\n\nThis is why the question χ - ζ → ∞ is interesting: how much better can cochromatic colorings be?",
@@ -129,10 +101,6 @@
   {
     "id": "ann-625-complement-le",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 71,
-      "endLine": 74
-    },
     "type": "technique",
     "title": "Complement Inequality",
     "content": "**cochromatic_complement:**\n\nζ(G) ≤ ζ(Gᶜ) for any graph G.\n\nThis follows from the symmetry of the cochromatic condition under swapping 'complete' and 'empty'.",
@@ -146,10 +114,6 @@
   {
     "id": "ann-625-complement-eq",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 76,
-      "endLine": 79
-    },
     "type": "technique",
     "title": "ζ(G) = ζ(Gᶜ)",
     "content": "**cochromatic_eq_complement:**\n\nThe cochromatic number is invariant under graph complement!\n\n**Proof:** Apply cochromatic_complement in both directions.\n\nThis is a beautiful symmetry property that chromatic number lacks (χ(G) ≠ χ(Gᶜ) in general).",
@@ -164,10 +128,6 @@
   {
     "id": "ann-625-random-graph",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 83,
-      "endLine": 89
-    },
     "type": "definition",
     "title": "Random Graph Model",
     "content": "**RandomGraph n p:**\n\nThe Erdős-Rényi random graph G(n, p): n vertices, each edge included independently with probability p.\n\n**ErdosRenyi n:** G(n, 1/2) - the symmetric case where G and Gᶜ have the same distribution.",
@@ -182,10 +142,6 @@
   {
     "id": "ann-625-almost-surely",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 91,
-      "endLine": 93
-    },
     "type": "definition",
     "title": "Almost Surely",
     "content": "**AlmostSurely P:**\n\nA property P holds almost surely (a.s.) if the probability it fails goes to 0 as n → ∞.\n\nFormally: ∀ε > 0, ∃N, ∀n ≥ N, Pr[¬P(G)] < ε.\n\n(Placeholder definition - full measure theory is beyond current Mathlib scope.)",
@@ -200,10 +156,6 @@
   {
     "id": "ann-625-cochromatic-lower",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 97,
-      "endLine": 100
-    },
     "type": "technique",
     "title": "Lower Bound on ζ",
     "content": "**cochromatic_lower_bound:**\n\nAlmost surely: ζ(G) ≥ n/(2 log₂ n).\n\nThis follows from bounds on clique and independence numbers: both ω(G) and α(G) are roughly 2 log₂ n a.s.",
@@ -218,10 +170,6 @@
   {
     "id": "ann-625-bollobas",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 102,
-      "endLine": 106
-    },
     "type": "technique",
     "title": "Bollobás Upper Bound (1988)",
     "content": "**bollobas_upper_bound:**\n\nAlmost surely: χ(G) ≤ (1+o(1))n/(2 log₂ n).\n\nBollobás proved this in 1988, showing the chromatic number of G(n, 1/2) is well-concentrated.\n\nCombined with the lower bound on ζ, this gives:\nn/(2 log₂ n) ≤ ζ(G) ≤ χ(G) ≤ (1+o(1))n/(2 log₂ n)",
@@ -236,10 +184,6 @@
   {
     "id": "ann-625-sandwich",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 108,
-      "endLine": 113
-    },
     "type": "technique",
     "title": "The Sandwich Bound",
     "content": "**chromatic_cochromatic_sandwich:**\n\nAlmost surely: ζ(G) ≤ χ(G) ≤ 1.01 · n/(2 log₂ n).\n\nThis 'sandwiches' both χ and ζ in a narrow band. The main question asks: do they separate within this band?",
@@ -253,10 +197,6 @@
   {
     "id": "ann-625-main-question",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 117,
-      "endLine": 121
-    },
     "type": "definition",
     "title": "The Main Question",
     "content": "**MainQuestion:**\n\nDoes χ(G) - ζ(G) → ∞ almost surely as n → ∞?\n\nThis is the central open problem. Erdős offered prizes:\n- $100 for YES\n- $1000 for NO\n\nThe asymmetric prizes suggest Erdős believed the answer is YES.",
@@ -271,10 +211,6 @@
   {
     "id": "ann-625-main-axiom",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 123,
-      "endLine": 124
-    },
     "type": "concept",
     "title": "Main Question OPEN",
     "content": "**main_question_open:**\n\nAxiom stating the main question is true. This is a placeholder - the problem is OPEN.\n\nThe axiom allows us to state implications like: if the main question is true, then [consequence].",
@@ -289,10 +225,6 @@
   {
     "id": "ann-625-prize",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 126,
-      "endLine": 128
-    },
     "type": "definition",
     "title": "Prize Value",
     "content": "**PrizeValue answer:**\n\n- If answer = true (χ - ζ → ∞): $100\n- If answer = false: $1000\n\nThe 10:1 ratio reflects Erdős's belief that YES is more likely. He later remarked that \"$1000 was perhaps too much.\"",
@@ -306,10 +238,6 @@
   {
     "id": "ann-625-heckel-steiner",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 132,
-      "endLine": 136
-    },
     "type": "technique",
     "title": "Heckel-Steiner Unboundedness (2024)",
     "content": "**heckel_steiner_unbounded:**\n\nFor all M: almost surely χ(G) - ζ(G) ≥ M.\n\nHeckel (2024) and independently Steiner (2024) proved the difference is unbounded with high probability.\n\nThis is a major breakthrough, but doesn't fully resolve the problem (needs χ - ζ → ∞ a.s., not just unbounded w.h.p.).",
@@ -325,10 +253,6 @@
   {
     "id": "ann-625-difference-lower",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 138,
-      "endLine": 143
-    },
     "type": "technique",
     "title": "Difference Lower Bound",
     "content": "**difference_lower_bound:**\n\nFor any ε > 0, along some subsequence:\nχ - ζ ≥ n^{1/2 - ε} almost surely.\n\nThis shows the difference can grow polynomially, not just logarithmically.",
@@ -342,10 +266,6 @@
   {
     "id": "ann-625-density",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 145,
-      "endLine": 151
-    },
     "type": "technique",
     "title": "Heckel Density Result (2024)",
     "content": "**heckel_density_result:**\n\nFor any ε > 0: χ - ζ ≥ n^{1-ε} for roughly 95% of all n.\n\nThis is remarkably strong - for most n, the difference grows almost linearly!",
@@ -360,10 +280,6 @@
   {
     "id": "ann-625-heckel-conj",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 155,
-      "endLine": 160
-    },
     "type": "definition",
     "title": "Heckel's Conjecture",
     "content": "**HeckelConjecture:**\n\nχ(G) - ζ(G) ≈ n/(log n)³ with high probability.\n\nMore precisely: ∃ c₁, c₂ > 0 such that a.s.:\nc₁ · n/(log n)³ ≤ χ - ζ ≤ c₂ · n/(log n)³\n\nThis predicts the exact growth rate of the gap.",
@@ -378,10 +294,6 @@
   {
     "id": "ann-625-heckel-implies",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 165,
-      "endLine": 167
-    },
     "type": "technique",
     "title": "Heckel ⟹ Main Question",
     "content": "**heckel_implies_main:**\n\nIf Heckel's conjecture holds, then the main question has answer YES.\n\nSince n/(log n)³ → ∞ as n → ∞, the conjecture implies χ - ζ → ∞ a.s.",
@@ -395,10 +307,6 @@
   {
     "id": "ann-625-clique",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 171,
-      "endLine": 173
-    },
     "type": "definition",
     "title": "Clique Number ω(G)",
     "content": "**cliqueNumber G:**\n\nThe size of the largest clique (complete subgraph) in G.\n\nFor G(n, 1/2): ω(G) ≈ 2 log₂ n almost surely.\n\nThis is used in bounds on the cochromatic number.",
@@ -413,10 +321,6 @@
   {
     "id": "ann-625-independence",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 175,
-      "endLine": 177
-    },
     "type": "definition",
     "title": "Independence Number α(G)",
     "content": "**independenceNumber G:**\n\nThe size of the largest independent set (no edges) in G. Defined as ω(Gᶜ).\n\nFor G(n, 1/2): α(G) ≈ 2 log₂ n almost surely.\n\nBy symmetry of G(n, 1/2), α and ω have the same distribution.",
@@ -431,10 +335,6 @@
   {
     "id": "ann-625-clique-independence-bound",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 179,
-      "endLine": 184
-    },
     "type": "technique",
     "title": "Clique/Independence Bound",
     "content": "**clique_independence_bound:**\n\nAlmost surely: ω(G), α(G) ≤ 2.1 · log₂ n.\n\nThese bounds are tight: ω ≈ α ≈ 2 log₂ n.\n\nThis limits how much each color class can cover, giving the lower bound on ζ.",
@@ -449,10 +349,6 @@
   {
     "id": "ann-625-cochromatic-clique-independence",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 186,
-      "endLine": 189
-    },
     "type": "technique",
     "title": "ζ ≥ n/(ω + α)",
     "content": "**cochromatic_clique_independence:**\n\nζ(G) · (ω(G) + α(G)) ≥ n.\n\nThus: ζ(G) ≥ n / (ω(G) + α(G)).\n\n**Proof idea:** Each color class has size at most max(ω, α) ≤ ω + α. So we need at least n/(ω + α) classes.",
@@ -466,10 +362,6 @@
   {
     "id": "ann-625-chromatic-concentration",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 193,
-      "endLine": 197
-    },
     "type": "technique",
     "title": "Chromatic Concentration",
     "content": "**chromatic_concentration:**\n\nAlmost surely: χ(G) lies in an interval of width O(n/log²n) around its mean.\n\nThe chromatic number is concentrated, but the exact width of concentration is still being refined.",
@@ -484,10 +376,6 @@
   {
     "id": "ann-625-cochromatic-concentration",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 199,
-      "endLine": 203
-    },
     "type": "technique",
     "title": "Cochromatic Concentration",
     "content": "**cochromatic_concentration:**\n\nAlmost surely: ζ(G) lies in an interval of width O(n/log n) around its mean.\n\nLess is known about concentration of ζ than χ. Better bounds might help resolve the main question.",
@@ -501,10 +389,6 @@
   {
     "id": "ann-625-known-summary",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 237,
-      "endLine": 243
-    },
     "type": "technique",
     "title": "Summary of Known Results",
     "content": "**known_summary:**\n\nCombines the two key structural properties:\n1. ζ(G) ≤ χ(G) for all G\n2. ζ(G) = ζ(Gᶜ) for all G\n\nThese are the foundational facts about the cochromatic number.",
@@ -518,10 +402,6 @@
   {
     "id": "ann-625-problem-status",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 245,
-      "endLine": 249
-    },
     "type": "technique",
     "title": "Problem Status",
     "content": "**problem_status:**\n\nThe Heckel-Steiner unboundedness result implies χ and ζ are not always equal.\n\nHowever, the main question (whether χ - ζ → ∞ a.s.) remains OPEN despite significant recent progress.",
@@ -535,10 +415,6 @@
   {
     "id": "ann-625-summary",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 253,
-      "endLine": 272
-    },
     "type": "concept",
     "title": "File Summary",
     "content": "**Summary of Erdős Problem #625 Formalization:**\n\n**Status:** OPEN (Prize: $1000 false / $100 true)\n\n**Main Question:** χ(G) - ζ(G) → ∞ a.s. for G(n, 1/2)?\n\n**Known Results:**\n- ζ ≤ χ ≤ (1+o(1))n/(2 log₂ n) a.s.\n- Heckel/Steiner 2024: difference unbounded\n- Heckel conjecture: χ - ζ ≈ n/(log n)³\n\n**Key sorries:** cochromatic_le_chromatic, heckel_steiner_unbounded, main_question_open",


### PR DESCRIPTION
## Summary
Fix annotation validation errors for 3 entries whose Lean source files are Aristotle UUID pointers (not actual code). Removed invalid `range` fields from all annotations; content preserved.

## Entries fixed
| Entry | Errors fixed | Root cause |
|---|---|---|
| erdos-1036 | 45 | Aristotle UUID pointer file |
| erdos-1050 | 35 | Aristotle UUID pointer file |
| erdos-625 | 31 | Aristotle UUID pointer file |

**Total: 111 annotation errors resolved**