### PR TITLE
Enrich 18 entries: fix 297 annotation errors (Aristotle pointers)

### DIFF
--- a/src/data/proofs/erdos-1000/annotations.json
+++ b/src/data/proofs/erdos-1000/annotations.json
@@ -2,14 +2,10 @@
   {
     "id": "ann-1000-imports",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 1,
-      "endLine": 33
-    },
     "type": "context",
     "title": "Imports and Module Documentation",
-    "content": "Imports for natural number arithmetic (Nat.GCD), Finset, real number casts, and filter limits. The module formalizes Erd\u0151s Problem #1000 on generalized totients and Diophantine approximation.",
-    "mathContext": "The formalization uses `Nat.gcd` for computing reduced fractions, `Finset.filter` for counting integers satisfying the totient condition, and `Filter.Tendsto` for expressing limit behavior of the Ces\u00e0ro averages.",
+    "content": "Imports for natural number arithmetic (Nat.GCD), Finset, real number casts, and filter limits. The module formalizes Erdős Problem #1000 on generalized totients and Diophantine approximation.",
+    "mathContext": "The formalization uses `Nat.gcd` for computing reduced fractions, `Finset.filter` for counting integers satisfying the totient condition, and `Filter.Tendsto` for expressing limit behavior of the Cesàro averages.",
     "significance": "supporting",
     "relatedConcepts": [
       "greatest common divisor",
@@ -25,13 +21,9 @@
   {
     "id": "ann-1000-incseq",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 46,
-      "endLine": 49
-    },
     "type": "definition",
     "title": "IncreasingSeq",
-    "content": "A strictly increasing sequence of positive integers A = {n\u2081 < n\u2082 < \u22ef}. This is the fundamental input to the generalized totient function.",
+    "content": "A strictly increasing sequence of positive integers A = {n₁ < n₂ < ⋯}. This is the fundamental input to the generalized totient function.",
     "mathContext": "A sequence $A : \\mathbb{N} \\to \\mathbb{N}$ is **strictly increasing** if $A(i) < A(j)$ for $i < j$ and $A(0) \\geq 1$. The choice of sequence $A$ determines the behavior of $\\varphi_A$: sparse sequences (e.g., powers of 2) behave very differently from dense ones (e.g., all of $\\mathbb{N}$).",
     "significance": "key",
     "relatedConcepts": [
@@ -47,10 +39,6 @@
   {
     "id": "ann-1000-reduced-denom",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 55,
-      "endLine": 55
-    },
     "type": "definition",
     "title": "Reduced Denominator",
     "content": "For m/n, the reduced denominator is n/gcd(m,n). This is the denominator when m/n is written in lowest terms.",
@@ -70,13 +58,9 @@
   {
     "id": "ann-1000-phiA",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 64,
-      "endLine": 67
-    },
     "type": "definition",
-    "title": "Generalized Totient \u03c6_A",
-    "content": "Count of m \u2264 n_k such that the reduced denominator of m/n_k is different from all previous sequence elements n_j (j < k). This measures how many fractions with denominator n_k are 'new' relative to earlier denominators.",
+    "title": "Generalized Totient φ_A",
+    "content": "Count of m ≤ n_k such that the reduced denominator of m/n_k is different from all previous sequence elements n_j (j < k). This measures how many fractions with denominator n_k are 'new' relative to earlier denominators.",
     "mathContext": "The **generalized totient** $\\varphi_A(k) = |\\{1 \\leq m \\leq n_k : n_k/\\gcd(m,n_k) \\notin \\{n_1, \\ldots, n_{k-1}\\}\\}|$ counts integers $m$ whose reduced fraction $m/n_k$ has a denominator not already seen in the sequence. When $A = \\mathbb{N}$, $\\varphi_A(k) = \\varphi(k)$ (Euler's totient).",
     "significance": "key",
     "relatedConcepts": [
@@ -94,12 +78,8 @@
   {
     "id": "ann-1000-phiA-bound",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 81,
-      "endLine": 83
-    },
     "type": "technique",
-    "title": "\u03c6_A(k) \u2265 \u03c6(n_k)",
+    "title": "φ_A(k) ≥ φ(n_k)",
     "content": "The generalized totient is always at least the Euler totient. This provides a universal lower bound independent of the sequence A.",
     "mathContext": "Since $\\varphi(n_k)$ counts $m \\leq n_k$ with $\\gcd(m, n_k) = 1$ (reduced denominator $= n_k$), and the condition for $\\varphi_A$ is weaker (denominator $\\notin \\{n_1, \\ldots, n_{k-1}\\}$ rather than denominator $= n_k$), we always have $\\varphi_A(k) \\geq \\varphi(n_k)$. Tight when $A = \\mathbb{N}$.",
     "significance": "key",
@@ -116,19 +96,15 @@
   {
     "id": "ann-1000-naturalSeq",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 88,
-      "endLine": 91
-    },
     "type": "definition",
     "title": "Natural Numbers Sequence",
-    "content": "The natural numbers as an increasing sequence: n \u21a6 n+1. The baseline case where \u03c6_A reduces to Euler's totient.",
-    "mathContext": "When $A = \\{1, 2, 3, \\ldots\\}$, $\\varphi_A(k) = \\varphi(k)$ and the Ces\u00e0ro average converges to $(1/N)\\sum_{k=1}^N \\varphi(k)/k \\to 6/\\pi^2 \\neq 0$ by the well-known identity $\\sum_{n=1}^\\infty \\varphi(n)/n^2 = \\zeta(2)/\\zeta(2) \\cdot \\ldots$ More precisely, the average density of coprime pairs is $6/\\pi^2$.",
+    "content": "The natural numbers as an increasing sequence: n ↦ n+1. The baseline case where φ_A reduces to Euler's totient.",
+    "mathContext": "When $A = \\{1, 2, 3, \\ldots\\}$, $\\varphi_A(k) = \\varphi(k)$ and the Cesàro average converges to $(1/N)\\sum_{k=1}^N \\varphi(k)/k \\to 6/\\pi^2 \\neq 0$ by the well-known identity $\\sum_{n=1}^\\infty \\varphi(n)/n^2 = \\zeta(2)/\\zeta(2) \\cdot \\ldots$ More precisely, the average density of coprime pairs is $6/\\pi^2$.",
     "significance": "supporting",
     "relatedConcepts": [
       "Euler's totient",
       "Riemann zeta function",
-      "6/\u03c0\u00b2 density"
+      "6/π² density"
     ],
     "prerequisites": [
       "increasing sequence",
@@ -138,13 +114,9 @@
   {
     "id": "ann-1000-density",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 110,
-      "endLine": 111
-    },
     "type": "definition",
     "title": "Density Ratio",
-    "content": "The ratio \u03c6_A(k)/n_k for a single term. This measures the proportion of integers up to n_k that produce 'new' denominators.",
+    "content": "The ratio φ_A(k)/n_k for a single term. This measures the proportion of integers up to n_k that produce 'new' denominators.",
     "mathContext": "The **density ratio** $\\rho_A(k) = \\varphi_A(k)/n_k \\in [0, 1]$ measures the fraction of $m \\in \\{1, \\ldots, n_k\\}$ that are 'new.' By $\\varphi_A(k) \\geq \\varphi(n_k)$, we have $\\rho_A(k) \\geq \\varphi(n_k)/n_k = \\prod_{p | n_k}(1 - 1/p)$, which can be small for highly composite numbers but is bounded below by $c/\\log\\log n_k$.",
     "significance": "key",
     "relatedConcepts": [
@@ -161,18 +133,14 @@
   {
     "id": "ann-1000-cesaro",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 116,
-      "endLine": 118
-    },
     "type": "definition",
-    "title": "Ces\u00e0ro Average",
-    "content": "The average (1/N) \u03a3_{k\u2264N} \u03c6_A(k)/n_k. The central question asks whether this can converge to 0.",
-    "mathContext": "The **Ces\u00e0ro average** $C_A(N) = \\frac{1}{N} \\sum_{k=1}^{N} \\rho_A(k)$ regularizes the density ratios. By Ces\u00e0ro's theorem, if $\\rho_A(k) \\to L$ then $C_A(N) \\to L$, but the converse fails: Ces\u00e0ro averages can converge even when individual terms oscillate. This asymmetry is what Haight's construction exploits.",
+    "title": "Cesàro Average",
+    "content": "The average (1/N) Σ_{k≤N} φ_A(k)/n_k. The central question asks whether this can converge to 0.",
+    "mathContext": "The **Cesàro average** $C_A(N) = \\frac{1}{N} \\sum_{k=1}^{N} \\rho_A(k)$ regularizes the density ratios. By Cesàro's theorem, if $\\rho_A(k) \\to L$ then $C_A(N) \\to L$, but the converse fails: Cesàro averages can converge even when individual terms oscillate. This asymmetry is what Haight's construction exploits.",
     "significance": "key",
     "relatedConcepts": [
-      "Ces\u00e0ro summation",
-      "Fej\u00e9r's theorem",
+      "Cesàro summation",
+      "Fejér's theorem",
       "Tauberian theorems",
       "Abel summation"
     ],
@@ -185,14 +153,10 @@
   {
     "id": "ann-1000-cassels",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 135,
-      "endLine": 137
-    },
     "type": "context",
     "title": "Cassels' Result (1950)",
-    "content": "There exist sequences where liminf of the Ces\u00e0ro average is 0. The first indication that averages could be made small.",
-    "mathContext": "Cassels (1950) proved $\\exists A: \\liminf_{N \\to \\infty} C_A(N) = 0$, constructing sequences where the Ces\u00e0ro average dips arbitrarily close to 0 along a subsequence. His construction uses rapidly growing sequences related to continued fraction convergents and metric Diophantine approximation.",
+    "content": "There exist sequences where liminf of the Cesàro average is 0. The first indication that averages could be made small.",
+    "mathContext": "Cassels (1950) proved $\\exists A: \\liminf_{N \\to \\infty} C_A(N) = 0$, constructing sequences where the Cesàro average dips arbitrarily close to 0 along a subsequence. His construction uses rapidly growing sequences related to continued fraction convergents and metric Diophantine approximation.",
     "significance": "key",
     "relatedConcepts": [
       "liminf",
@@ -201,21 +165,17 @@
       "metric Diophantine approximation"
     ],
     "prerequisites": [
-      "Ces\u00e0ro average",
+      "Cesàro average",
       "continued fractions"
     ]
   },
   {
     "id": "ann-1000-erdos-limit",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 152,
-      "endLine": 153
-    },
     "type": "context",
-    "title": "Erd\u0151s: No Zero Limit",
-    "content": "For any sequence, the individual density ratio \u03c6_A(k)/n_k cannot converge to 0. A strong constraint: sparsity is limited term-by-term.",
-    "mathContext": "Erd\u0151s (1964) proved $\\lim_{k \\to \\infty} \\rho_A(k) \\neq 0$ for any $A$. The proof uses $\\rho_A(k) \\geq \\varphi(n_k)/n_k = \\prod_{p|n_k}(1-1/p) \\geq c/\\log\\log n_k$ (by Mertens' theorem) and the fact that $n_k \\to \\infty$ slowly enough that this lower bound cannot vanish.",
+    "title": "Erdős: No Zero Limit",
+    "content": "For any sequence, the individual density ratio φ_A(k)/n_k cannot converge to 0. A strong constraint: sparsity is limited term-by-term.",
+    "mathContext": "Erdős (1964) proved $\\lim_{k \\to \\infty} \\rho_A(k) \\neq 0$ for any $A$. The proof uses $\\rho_A(k) \\geq \\varphi(n_k)/n_k = \\prod_{p|n_k}(1-1/p) \\geq c/\\log\\log n_k$ (by Mertens' theorem) and the fact that $n_k \\to \\infty$ slowly enough that this lower bound cannot vanish.",
     "significance": "key",
     "relatedConcepts": [
       "Mertens' theorem",
@@ -231,14 +191,10 @@
   {
     "id": "ann-1000-erdos-dichotomy",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 166,
-      "endLine": 168
-    },
     "type": "context",
-    "title": "Erd\u0151s' Dichotomy",
-    "content": "If liminf \u03c6_A(k)/n_k = 0, then limsup = 1. The density ratio cannot merely be small \u2014 if it approaches 0, it must also approach 1.",
-    "mathContext": "Erd\u0151s (1964) proved: $\\liminf_{k} \\rho_A(k) = 0 \\Rightarrow \\limsup_{k} \\rho_A(k) = 1$. The density ratio oscillates maximally. The proof uses the Euler product $\\varphi(n)/n = \\prod_{p|n}(1-1/p)$ and properties of smooth numbers to show that subsequences with small $\\rho_A$ force the existence of subsequences with $\\rho_A$ near 1.",
+    "title": "Erdős' Dichotomy",
+    "content": "If liminf φ_A(k)/n_k = 0, then limsup = 1. The density ratio cannot merely be small — if it approaches 0, it must also approach 1.",
+    "mathContext": "Erdős (1964) proved: $\\liminf_{k} \\rho_A(k) = 0 \\Rightarrow \\limsup_{k} \\rho_A(k) = 1$. The density ratio oscillates maximally. The proof uses the Euler product $\\varphi(n)/n = \\prod_{p|n}(1-1/p)$ and properties of smooth numbers to show that subsequences with small $\\rho_A$ force the existence of subsequences with $\\rho_A$ near 1.",
     "significance": "key",
     "relatedConcepts": [
       "oscillation",
@@ -248,42 +204,34 @@
     ],
     "prerequisites": [
       "density ratio",
-      "Erd\u0151s' no-zero-limit theorem"
+      "Erdős' no-zero-limit theorem"
     ]
   },
   {
     "id": "ann-1000-vanishing",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 181,
-      "endLine": 182
-    },
     "type": "definition",
     "title": "Vanishing Average",
-    "content": "A sequence has vanishing average if its Ces\u00e0ro average of density ratios tends to 0. This is the central predicate of Erd\u0151s Problem #1000.",
-    "mathContext": "The predicate $\\text{VanishingAverage}(A) \\iff \\lim_{N \\to \\infty} C_A(N) = 0$ asks whether the arithmetic mean converges to zero. By Erd\u0151s' no-zero-limit theorem, the individual terms cannot converge to 0, so vanishing average requires the 'near-1' spikes to become increasingly rare.",
+    "content": "A sequence has vanishing average if its Cesàro average of density ratios tends to 0. This is the central predicate of Erdős Problem #1000.",
+    "mathContext": "The predicate $\\text{VanishingAverage}(A) \\iff \\lim_{N \\to \\infty} C_A(N) = 0$ asks whether the arithmetic mean converges to zero. By Erdős' no-zero-limit theorem, the individual terms cannot converge to 0, so vanishing average requires the 'near-1' spikes to become increasingly rare.",
     "significance": "key",
     "relatedConcepts": [
-      "Ces\u00e0ro convergence",
+      "Cesàro convergence",
       "oscillation",
       "averaging phenomena"
     ],
     "prerequisites": [
-      "Ces\u00e0ro average",
-      "Erd\u0151s' no-zero-limit"
+      "Cesàro average",
+      "Erdős' no-zero-limit"
     ]
   },
   {
     "id": "ann-1000-question",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 190,
-      "endLine": 191
-    },
     "type": "definition",
     "title": "The Main Question",
-    "content": "Does there exist a sequence with vanishing average? Erd\u0151s conjectured NO, believing the lower bound from Euler's totient would prevent it.",
-    "mathContext": "Erd\u0151s asked $\\exists A : \\text{VanishingAverage}(A)$? His heuristic: $\\varphi_A(k) \\geq \\varphi(n_k)$ and averages of $\\varphi(n)/n$ are bounded below. But this ignores that sequences with rapidly growing, highly composite terms can make the 'near-1' events increasingly sparse while the 'near-0' events dominate the average.",
+    "content": "Does there exist a sequence with vanishing average? Erdős conjectured NO, believing the lower bound from Euler's totient would prevent it.",
+    "mathContext": "Erdős asked $\\exists A : \\text{VanishingAverage}(A)$? His heuristic: $\\varphi_A(k) \\geq \\varphi(n_k)$ and averages of $\\varphi(n)/n$ are bounded below. But this ignores that sequences with rapidly growing, highly composite terms can make the 'near-1' events increasingly sparse while the 'near-0' events dominate the average.",
     "significance": "key",
     "relatedConcepts": [
       "existence problems",
@@ -298,14 +246,10 @@
   {
     "id": "ann-1000-haight",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 207,
-      "endLine": 207
-    },
     "type": "context",
     "title": "Haight's Theorem",
-    "content": "Such sequences exist, contrary to Erd\u0151s' expectation. Haight constructed a sequence with vanishing Ces\u00e0ro average, resolving the problem affirmatively.",
-    "mathContext": "Haight proved $\\exists A : \\lim_{N \\to \\infty} C_A(N) = 0$. The construction uses rapidly growing subsequences of highly composite numbers, where $\\rho_A(k)$ spends most of its time near 0 (at highly composite $n_k$) and occasionally jumps to near 1, with the jumps becoming increasingly rare to force the Ces\u00e0ro average to 0.",
+    "content": "Such sequences exist, contrary to Erdős' expectation. Haight constructed a sequence with vanishing Cesàro average, resolving the problem affirmatively.",
+    "mathContext": "Haight proved $\\exists A : \\lim_{N \\to \\infty} C_A(N) = 0$. The construction uses rapidly growing subsequences of highly composite numbers, where $\\rho_A(k)$ spends most of its time near 0 (at highly composite $n_k$) and occasionally jumps to near 1, with the jumps becoming increasingly rare to force the Cesàro average to 0.",
     "significance": "key",
     "relatedConcepts": [
       "highly composite numbers",
@@ -314,20 +258,16 @@
     ],
     "prerequisites": [
       "vanishing average",
-      "Erd\u0151s' dichotomy"
+      "Erdős' dichotomy"
     ]
   },
   {
     "id": "ann-1000-solved",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 213,
-      "endLine": 213
-    },
     "type": "technique",
     "title": "Problem #1000 Solved",
-    "content": "The answer is YES \u2014 sequences with vanishing average exist. This resolves Erd\u0151s' question affirmatively, overturning his conjecture.",
-    "mathContext": "The resolution $\\exists A, \\text{VanishingAverage}(A)$ follows directly from Haight's theorem. This is one of many instances where Erd\u0151s' intuition was overturned by a clever construction exploiting the gap between pointwise and averaged behavior.",
+    "content": "The answer is YES — sequences with vanishing average exist. This resolves Erdős' question affirmatively, overturning his conjecture.",
+    "mathContext": "The resolution $\\exists A, \\text{VanishingAverage}(A)$ follows directly from Haight's theorem. This is one of many instances where Erdős' intuition was overturned by a clever construction exploiting the gap between pointwise and averaged behavior.",
     "significance": "key",
     "relatedConcepts": [
       "existence theorem",
@@ -340,24 +280,20 @@
   {
     "id": "ann-1000-oscillation",
     "proofId": "erdos-1000",
-    "range": {
-      "startLine": 252,
-      "endLine": 262
-    },
     "type": "technique",
     "title": "Haight Oscillation",
-    "content": "Haight's sequence has vanishing Ces\u00e0ro average yet its density ratio oscillates between 0 and 1. The oscillation is not a defect but a necessity from Erd\u0151s' dichotomy.",
-    "mathContext": "For Haight's sequence $A$: $\\lim C_A(N) = 0$ while $\\liminf \\rho_A(k) = 0$ and $\\limsup \\rho_A(k) = 1$. By Erd\u0151s' dichotomy, any vanishing-average sequence must exhibit this maximal oscillation. The 'near-1' values become increasingly sparse: if the $k$-th spike occurs at index $N_k$, then $N_k$ grows fast enough that $(1/N_k) \\cdot 1 \\to 0$.",
+    "content": "Haight's sequence has vanishing Cesàro average yet its density ratio oscillates between 0 and 1. The oscillation is not a defect but a necessity from Erdős' dichotomy.",
+    "mathContext": "For Haight's sequence $A$: $\\lim C_A(N) = 0$ while $\\liminf \\rho_A(k) = 0$ and $\\limsup \\rho_A(k) = 1$. By Erdős' dichotomy, any vanishing-average sequence must exhibit this maximal oscillation. The 'near-1' values become increasingly sparse: if the $k$-th spike occurs at index $N_k$, then $N_k$ grows fast enough that $(1/N_k) \\cdot 1 \\to 0$.",
     "significance": "key",
     "relatedConcepts": [
-      "Ces\u00e0ro-Erd\u0151s interplay",
+      "Cesàro-Erdős interplay",
       "oscillation necessity",
       "sparse spikes"
     ],
     "prerequisites": [
       "Haight's theorem",
-      "Erd\u0151s' dichotomy",
-      "Ces\u00e0ro averages"
+      "Erdős' dichotomy",
+      "Cesàro averages"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1002/annotations.json
+++ b/src/data/proofs/erdos-1002/annotations.json
@@ -2,145 +2,217 @@
   {
     "id": "ann-1002-frac",
     "proofId": "erdos-1002",
-    "range": { "startLine": 30, "endLine": 31 },
     "type": "definition",
     "title": "Fractional Part Function",
     "content": "The fractional part $\\{x\\} = x - \\lfloor x \\rfloor$ maps $\\mathbb{R}$ to $[0, 1)$. For irrational $\\alpha$, the sequence $\\{\\alpha\\}, \\{2\\alpha\\}, \\{3\\alpha\\}, \\ldots$ is equidistributed in $[0,1)$ by Weyl's equidistribution theorem (1916). The deviation $1/2 - \\{x\\}$ has mean zero over $[0,1)$, so the sum $\\sum (1/2 - \\{\\alpha k\\})$ measures the cumulative deviation from uniformity.",
     "mathContext": "$\\{x\\} = x - \\lfloor x \\rfloor \\in [0, 1)$ with $\\int_0^1 (1/2 - \\{x\\})\\,dx = 0$",
     "significance": "supporting",
-    "relatedConcepts": ["floor function", "equidistribution", "Weyl's theorem"],
-    "prerequisites": ["Int.floor", "Int.fract"]
+    "relatedConcepts": [
+      "floor function",
+      "equidistribution",
+      "Weyl's theorem"
+    ],
+    "prerequisites": [
+      "Int.floor",
+      "Int.fract"
+    ]
   },
   {
     "id": "ann-1002-innersum",
     "proofId": "erdos-1002",
-    "range": { "startLine": 48, "endLine": 54 },
     "type": "definition",
     "title": "Inner Sum and Weighted Function f(alpha, n)",
     "content": "The inner sum $S(\\alpha, n) = \\sum_{k=1}^{n} (1/2 - \\{\\alpha k\\})$ accumulates the deviation of $\\{\\alpha k\\}$ from the midpoint $1/2$. The normalized function $f(\\alpha, n) = S(\\alpha, n)/\\log n$ rescales by the natural logarithm. The choice of $\\log n$ normalization is natural because for 'typical' $\\alpha$, the inner sum grows roughly as $\\log n$ — this follows from the theory of continued fractions and the Gauss-Kuzmin statistics of the partial quotients.",
     "mathContext": "$f(\\alpha, n) = \\frac{1}{\\log n} \\sum_{k=1}^{n} \\left(\\frac{1}{2} - \\{\\alpha k\\}\\right)$",
     "significance": "key",
-    "relatedConcepts": ["Weyl sums", "discrepancy", "logarithmic normalization"],
-    "prerequisites": ["Int.fract", "Real.log", "Finset.sum"]
+    "relatedConcepts": [
+      "Weyl sums",
+      "discrepancy",
+      "logarithmic normalization"
+    ],
+    "prerequisites": [
+      "Int.fract",
+      "Real.log",
+      "Finset.sum"
+    ]
   },
   {
     "id": "ann-1002-distfunc",
     "proofId": "erdos-1002",
-    "range": { "startLine": 63, "endLine": 68 },
     "type": "definition",
     "title": "Distribution Function",
     "content": "A distribution function $g : \\mathbb{R} \\to [0,1]$ is a non-decreasing function with $\\lim_{c \\to -\\infty} g(c) = 0$ and $\\lim_{c \\to +\\infty} g(c) = 1$. In the context of this problem, $g(c)$ represents the limiting proportion of $\\alpha \\in (0,1)$ for which $f(\\alpha, n) \\le c$. The existence of such a $g$ means the 'statistical behavior' of $f$ over all $\\alpha$ stabilizes as $n \\to \\infty$.",
     "mathContext": "$g : \\mathbb{R} \\to [0,1]$ non-decreasing with $g(-\\infty) = 0$, $g(+\\infty) = 1$",
     "significance": "key",
-    "relatedConcepts": ["cumulative distribution function", "weak convergence", "measure theory"],
-    "prerequisites": ["Monotone", "Filter.Tendsto"]
+    "relatedConcepts": [
+      "cumulative distribution function",
+      "weak convergence",
+      "measure theory"
+    ],
+    "prerequisites": [
+      "Monotone",
+      "Filter.Tendsto"
+    ]
   },
   {
     "id": "ann-1002-levelset",
     "proofId": "erdos-1002",
-    "range": { "startLine": 77, "endLine": 88 },
     "type": "definition",
     "title": "Level Set and Asymptotic Distribution",
     "content": "The level set $L(n, c) = \\{\\alpha \\in (0,1) : f(\\alpha, n) \\le c\\}$ is a measurable subset of $(0,1)$ whose Lebesgue measure $\\mu(L(n,c))$ is the proportion of $\\alpha$ values with $f(\\alpha, n) \\le c$. The function $f$ has an **asymptotic distribution** if there exists a distribution function $g$ such that $\\mu(L(n, c)) \\to g(c)$ for every continuity point $c$ of $g$. This is precisely weak convergence of the induced measures.",
     "mathContext": "$L(n, c) = \\{\\alpha \\in (0,1) : f(\\alpha, n) \\le c\\}$, $\\mu(L(n,c)) \\to g(c)$ as $n \\to \\infty$",
     "significance": "key",
-    "relatedConcepts": ["Lebesgue measure", "weak convergence", "Prokhorov's theorem"],
-    "prerequisites": ["MeasureTheory.MeasureSpace", "Filter.Tendsto"]
+    "relatedConcepts": [
+      "Lebesgue measure",
+      "weak convergence",
+      "Prokhorov's theorem"
+    ],
+    "prerequisites": [
+      "MeasureTheory.MeasureSpace",
+      "Filter.Tendsto"
+    ]
   },
   {
     "id": "ann-1002-conjecture",
     "proofId": "erdos-1002",
-    "range": { "startLine": 97, "endLine": 98 },
     "type": "definition",
     "title": "Main Conjecture (OPEN)",
     "content": "The central question: does $f(\\alpha, n)$ possess an asymptotic distribution function? Erdős conjectured it does, but the answer remains unknown. If the distribution exists, a natural guess (motivated by Kesten's theorem) is the Cauchy distribution $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$ for some parameter $\\rho > 0$. However, fixing $\\beta = 0$ may change the distributional behavior entirely.",
     "mathContext": "$\\exists\\, g,\\; \\forall\\, c,\\; \\lim_{n \\to \\infty} \\mu(\\{\\alpha : f(\\alpha, n) \\le c\\}) = g(c)$",
     "significance": "key",
-    "relatedConcepts": ["Erdős problems", "open problems", "limit distributions"],
-    "prerequisites": ["hasAsymptoticDistribution", "f"]
+    "relatedConcepts": [
+      "Erdős problems",
+      "open problems",
+      "limit distributions"
+    ],
+    "prerequisites": [
+      "hasAsymptoticDistribution",
+      "f"
+    ]
   },
   {
     "id": "ann-1002-twoparam",
     "proofId": "erdos-1002",
-    "range": { "startLine": 109, "endLine": 122 },
     "type": "definition",
     "title": "Two-Parameter Variant and Cauchy Distribution",
     "content": "The two-parameter variant introduces a shift: $f(\\alpha, \\beta, n) = \\frac{1}{\\log n} \\sum_{k=1}^{n} (1/2 - \\{\\beta + \\alpha k\\})$. The extra parameter $\\beta$ allows averaging over both $\\alpha$ and $\\beta$, which provides the ergodic independence needed for limit theorems. The Cauchy distribution function $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$ arises naturally from the connection to continued fractions and the Gauss map $T(x) = \\{1/x\\}$ on $(0,1)$.",
     "mathContext": "$f(\\alpha, \\beta, n) = \\frac{1}{\\log n} \\sum_{k=1}^{n} \\left(\\frac{1}{2} - \\{\\beta + \\alpha k\\}\\right)$, $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$",
     "significance": "key",
-    "relatedConcepts": ["Cauchy distribution", "Gauss map", "ergodic theory"],
-    "prerequisites": ["Real.arctan", "f"]
+    "relatedConcepts": [
+      "Cauchy distribution",
+      "Gauss map",
+      "ergodic theory"
+    ],
+    "prerequisites": [
+      "Real.arctan",
+      "f"
+    ]
   },
   {
     "id": "ann-1002-kesten",
     "proofId": "erdos-1002",
-    "range": { "startLine": 128, "endLine": 133 },
     "type": "technique",
     "title": "Kesten's Theorem (1960)",
     "content": "Harry Kesten (1960) proved that the two-parameter variant $f(\\alpha, \\beta, n)$ has an asymptotic Cauchy distribution when averaged over both $\\alpha$ and $\\beta$ uniformly on $(0,1)^2$. The proof uses the connection between continued fractions and the ergodic properties of the natural extension of the Gauss map. This landmark result in the metric theory of continued fractions remains one of the deepest applications of ergodic theory to number theory.",
     "mathContext": "$\\mu(\\{(\\alpha, \\beta) : f(\\alpha, \\beta, n) \\le c\\}) \\to \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$",
     "significance": "key",
-    "relatedConcepts": ["metric number theory", "Gauss-Kuzmin theorem", "natural extension"],
-    "prerequisites": ["twoParamF", "cauchyDistribution"]
+    "relatedConcepts": [
+      "metric number theory",
+      "Gauss-Kuzmin theorem",
+      "natural extension"
+    ],
+    "prerequisites": [
+      "twoParamF",
+      "cauchyDistribution"
+    ]
   },
   {
     "id": "ann-1002-special",
     "proofId": "erdos-1002",
-    "range": { "startLine": 142, "endLine": 145 },
     "type": "technique",
     "title": "One-Parameter as Special Case",
     "content": "The one-parameter function satisfies $f(\\alpha, n) = f(\\alpha, 0, n)$: it is the two-parameter variant with $\\beta = 0$. This relationship shows why Problem #1002 is a natural refinement of Kesten's theorem — but fixing $\\beta = 0$ eliminates the averaging that makes Kesten's proof work. The conditional distribution (given $\\beta = 0$) may differ from the unconditional Cauchy distribution.",
     "mathContext": "$f(\\alpha, n) = f(\\alpha, 0, n)$, i.e., the one-parameter case is $\\beta = 0$",
     "significance": "key",
-    "relatedConcepts": ["conditional distribution", "marginal distribution", "specialization"],
-    "prerequisites": ["f", "twoParamF"]
+    "relatedConcepts": [
+      "conditional distribution",
+      "marginal distribution",
+      "specialization"
+    ],
+    "prerequisites": [
+      "f",
+      "twoParamF"
+    ]
   },
   {
     "id": "ann-1002-weyl",
     "proofId": "erdos-1002",
-    "range": { "startLine": 154, "endLine": 159 },
     "type": "technique",
     "title": "Weyl Equidistribution Theorem",
     "content": "Hermann Weyl's theorem (1916): for irrational $\\alpha$, the sequence $(\\{n\\alpha\\})_{n \\ge 1}$ is equidistributed modulo 1, meaning $\\frac{1}{N}\\#\\{1 \\le n \\le N : \\{n\\alpha\\} \\in [a,b)\\} \\to b - a$ as $N \\to \\infty$. This implies $\\frac{1}{n}\\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\}) \\to 0$, so the inner sum grows sublinearly. The $\\log n$ normalization captures the precise growth rate.",
     "mathContext": "$\\frac{1}{N}\\#\\{n \\le N : \\{n\\alpha\\} \\in [a,b)\\} \\to b - a$ (Weyl 1916)",
     "significance": "supporting",
-    "relatedConcepts": ["Weyl's criterion", "exponential sums", "ergodic theorem"],
-    "prerequisites": ["Irrational"]
+    "relatedConcepts": [
+      "Weyl's criterion",
+      "exponential sums",
+      "ergodic theorem"
+    ],
+    "prerequisites": [
+      "Irrational"
+    ]
   },
   {
     "id": "ann-1002-oscillation",
     "proofId": "erdos-1002",
-    "range": { "startLine": 161, "endLine": 166 },
     "type": "technique",
     "title": "Oscillation for Fixed alpha",
     "content": "For fixed irrational $\\alpha$, the function $n \\mapsto f(\\alpha, n)$ oscillates: it does not converge to a limit. This oscillation reflects the arithmetic structure of $\\alpha$'s continued fraction expansion — the partial quotients cause the sum to swing as denominators of convergents are reached. The distribution question asks about the statistical behavior over *all* $\\alpha$, not a single fixed one.",
     "mathContext": "For fixed irrational $\\alpha$, $f(\\alpha, n)$ does not converge as $n \\to \\infty$",
     "significance": "key",
-    "relatedConcepts": ["continued fractions", "convergents", "three-distance theorem"],
-    "prerequisites": ["f", "Irrational"]
+    "relatedConcepts": [
+      "continued fractions",
+      "convergents",
+      "three-distance theorem"
+    ],
+    "prerequisites": [
+      "f",
+      "Irrational"
+    ]
   },
   {
     "id": "ann-1002-bounded",
     "proofId": "erdos-1002",
-    "range": { "startLine": 174, "endLine": 182 },
     "type": "technique",
     "title": "Boundedness and Continued Fraction Bound",
     "content": "Two partial results: (1) $f(\\alpha, n)$ is bounded for each $\\alpha \\in (0,1)$, ensuring no extreme outliers, and (2) $|S(\\alpha, n)| \\le C \\log n$ for irrational $\\alpha$, where $C$ depends on $\\alpha$'s continued fraction expansion. This bound follows from the classical estimate $|\\sum_{k=1}^{n} e^{2\\pi i k\\alpha}| \\le \\cot(\\pi \\|\\alpha\\|/2)$ and the three-distance theorem. These bounds justify the $\\log n$ normalization.",
     "mathContext": "$|f(\\alpha, n)| \\le C(\\alpha)$ and $|S(\\alpha, n)| \\le C(\\alpha) \\log n$",
     "significance": "key",
-    "relatedConcepts": ["Erdős-Turán inequality", "exponential sums", "three-distance theorem"],
-    "prerequisites": ["f", "innerSum", "Real.log"]
+    "relatedConcepts": [
+      "Erdős-Turán inequality",
+      "exponential sums",
+      "three-distance theorem"
+    ],
+    "prerequisites": [
+      "f",
+      "innerSum",
+      "Real.log"
+    ]
   },
   {
     "id": "ann-1002-summary",
     "proofId": "erdos-1002",
-    "range": { "startLine": 184, "endLine": 208 },
     "type": "concept",
     "title": "Summary and Open Status",
     "content": "The formalization captures the full problem setup: the weighted sum $f(\\alpha, n)$, the notion of asymptotic distribution, Kesten's two-parameter theorem with Cauchy distribution, and the relationship to the one-parameter case. All definitions are complete (0 sorries), but the main conjecture remains **OPEN** — this is a mathematical, not formalization, gap. The problem connects Diophantine approximation, ergodic theory, and probability, making it one of the more analytically deep Erdős problems.",
     "mathContext": "Problem #1002: Does $f(\\alpha, n)$ have an asymptotic distribution? Status: OPEN",
     "significance": "key",
-    "relatedConcepts": ["open problems", "Diophantine approximation", "analytic number theory"],
-    "prerequisites": ["erdos_1002_conjecture"]
+    "relatedConcepts": [
+      "open problems",
+      "Diophantine approximation",
+      "analytic number theory"
+    ],
+    "prerequisites": [
+      "erdos_1002_conjecture"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1004/annotations.json
+++ b/src/data/proofs/erdos-1004/annotations.json
@@ -2,157 +2,236 @@
   {
     "id": "ann-1004-header",
     "proofId": "erdos-1004",
-    "range": { "startLine": 1, "endLine": 32 },
     "type": "concept",
     "title": "Module Header and Imports",
     "content": "File documentation for Erdős Problem 1004 on distinct consecutive totient values, citing EPS (1987). Imports Mathlib's `EulerPhi.Basic` (providing `Nat.totient`), `ArithmeticFunction`, logarithms and powers over $\\mathbb{R}$, and the real number topology needed for asymptotic statements via `Filter.atTop`.",
     "mathContext": "The formalization uses `Nat.totient` from Mathlib, which computes $\\varphi(n) = |\\{k : 1 \\leq k \\leq n,\\ \\gcd(k,n) = 1\\}|$. Asymptotic bounds require coercion to $\\mathbb{R}$ and `Real.log`, `Real.exp`.",
     "significance": "supporting",
-    "relatedConcepts": ["Nat.totient", "Mathlib arithmetic functions", "Filter.atTop"],
-    "prerequisites": ["Lean 4 basics", "Mathlib library"]
+    "relatedConcepts": [
+      "Nat.totient",
+      "Mathlib arithmetic functions",
+      "Filter.atTop"
+    ],
+    "prerequisites": [
+      "Lean 4 basics",
+      "Mathlib library"
+    ]
   },
   {
     "id": "ann-1004-phi-def",
     "proofId": "erdos-1004",
-    "range": { "startLine": 38, "endLine": 39 },
     "type": "definition",
     "title": "Euler's Totient Function",
     "content": "Defines `phi(n)` as `Nat.totient n`, counting integers $1 \\leq k \\leq n$ with $\\gcd(k,n) = 1$. Euler's product formula gives $\\varphi(n) = n \\prod_{p | n} (1 - 1/p)$, and the function is multiplicative: $\\varphi(mn) = \\varphi(m)\\varphi(n)$ when $\\gcd(m,n) = 1$. The totient function appears throughout number theory, from Euler's theorem ($a^{\\varphi(n)} \\equiv 1 \\pmod{n}$) to the distribution of primitive roots.",
     "mathContext": "$\\varphi(n) = |\\{k : 1 \\leq k \\leq n,\\ \\gcd(k,n) = 1\\}| = n \\prod_{p | n}(1 - 1/p)$",
     "significance": "key",
-    "relatedConcepts": ["multiplicative functions", "Euler's product formula", "Euler's theorem", "primitive roots"],
-    "prerequisites": ["coprimality", "prime factorization"]
+    "relatedConcepts": [
+      "multiplicative functions",
+      "Euler's product formula",
+      "Euler's theorem",
+      "primitive roots"
+    ],
+    "prerequisites": [
+      "coprimality",
+      "prime factorization"
+    ]
   },
   {
     "id": "ann-1004-phi-prime",
     "proofId": "erdos-1004",
-    "range": { "startLine": 44, "endLine": 46 },
     "type": "technique",
     "title": "Totient of Primes",
     "content": "For prime $p$, $\\varphi(p) = p - 1$ since every integer from $1$ to $p-1$ is coprime to $p$. Proved directly from `Nat.totient_prime`. This makes primes the easiest case for the totient function and means consecutive primes have distinct totient values (since primes are distinct).",
     "mathContext": "$p$ prime $\\Rightarrow \\varphi(p) = p - 1$",
     "significance": "key",
-    "relatedConcepts": ["prime numbers", "Fermat's little theorem"],
-    "prerequisites": ["prime definition", "coprimality with primes"]
+    "relatedConcepts": [
+      "prime numbers",
+      "Fermat's little theorem"
+    ],
+    "prerequisites": [
+      "prime definition",
+      "coprimality with primes"
+    ]
   },
   {
     "id": "ann-1004-phi-bounds",
     "proofId": "erdos-1004",
-    "range": { "startLine": 48, "endLine": 58 },
     "type": "technique",
     "title": "Basic Bounds on Totient",
     "content": "Three fundamental bounds: (1) $\\varphi(n) > 0$ for $n > 0$, (2) $\\varphi(n) \\leq n$, and (3) $\\varphi(n) < n$ for $n > 1$. These are all proved from Mathlib lemmas. The strict inequality for $n > 1$ follows because $n$ itself is not coprime to $n$. Together they show $\\varphi(n) \\in [1, n-1]$ for $n > 1$, giving at most $n-1$ possible values.",
     "mathContext": "$\\varphi(n) > 0$ for $n > 0$; $\\varphi(n) \\leq n$; $\\varphi(n) < n$ for $n > 1$.",
     "significance": "supporting",
-    "relatedConcepts": ["totient range", "Carmichael's conjecture"],
-    "prerequisites": ["totient definition", "coprimality"]
+    "relatedConcepts": [
+      "totient range",
+      "Carmichael's conjecture"
+    ],
+    "prerequisites": [
+      "totient definition",
+      "coprimality"
+    ]
   },
   {
     "id": "ann-1004-distinct-run",
     "proofId": "erdos-1004",
-    "range": { "startLine": 62, "endLine": 85 },
     "type": "definition",
     "title": "Distinct Totient Run",
     "content": "A run of $K$ consecutive integers starting at $n+1$ has **distinct totient values** if $\\varphi(n+i) \\neq \\varphi(n+j)$ for all $1 \\leq i < j \\leq K$. An equivalent definition via `Set.InjOn` asserts $\\varphi$ is injective on $\\{n+1, \\ldots, n+K\\}$. The empty and single-element runs are proved trivially distinct via `omega`.",
     "mathContext": "$\\text{IsDistinctTotientRun}(n, K) \\iff \\varphi|_{\\{n+1, \\ldots, n+K\\}}$ is injective",
     "significance": "key",
-    "relatedConcepts": ["injectivity", "distinct values", "collision-free sequences"],
-    "prerequisites": ["function injectivity", "universal quantification"]
+    "relatedConcepts": [
+      "injectivity",
+      "distinct values",
+      "collision-free sequences"
+    ],
+    "prerequisites": [
+      "function injectivity",
+      "universal quantification"
+    ]
   },
   {
     "id": "ann-1004-max-length",
     "proofId": "erdos-1004",
-    "range": { "startLine": 89, "endLine": 96 },
     "type": "definition",
     "title": "Maximum Distinct Run Length",
     "content": "For each $n$, `maxDistinctRunLength(n)` is the supremum of $\\{K : \\text{IsDistinctTotientRun}(n, K)\\}$ — the longest collision-free run of totient values starting at $n+1$. The existence proof shows at least $K = 1$ works. The EPS87 bound shows this supremum is finite and grows sublinearly in $n$.",
     "mathContext": "$f(n) := \\sup\\{K : \\varphi(n+1), \\ldots, \\varphi(n+K) \\text{ all distinct}\\}$",
     "significance": "key",
-    "relatedConcepts": ["supremum", "run length", "maximal collision-free sequences"],
-    "prerequisites": ["sSup in natural numbers", "existential witnesses"]
+    "relatedConcepts": [
+      "supremum",
+      "run length",
+      "maximal collision-free sequences"
+    ],
+    "prerequisites": [
+      "sSup in natural numbers",
+      "existential witnesses"
+    ]
   },
   {
     "id": "ann-1004-eps87",
     "proofId": "erdos-1004",
-    "range": { "startLine": 100, "endLine": 118 },
     "type": "technique",
     "title": "Erdős–Pomerance–Sárközy Upper Bound (1987)",
     "content": "The central known result: if $\\varphi(n+k)$ are all distinct for $1 \\leq k \\leq K$, then $K \\leq n / \\exp(c (\\log n)^{1/3})$ for an absolute constant $c > 0$. Axiomatized via `eps87_constant` and `eps87_upper_bound`. The bound comes from sieve methods and the distribution of smooth numbers. The corollary `run_length_sublinear` shows $f(n)/n \\to 0$, ruling out linear-length runs. The exponent $1/3$ in $(\\log n)^{1/3}$ reflects deep results on smooth number estimates.",
     "mathContext": "$K \\leq \\frac{n}{\\exp(c (\\log n)^{1/3})}$ for some $c > 0$. Corollary: $\\lim_{n \\to \\infty} f(n)/n = 0$.",
     "significance": "key",
-    "relatedConcepts": ["smooth numbers", "sieve methods", "sublinear growth", "de Bruijn's estimate"],
-    "prerequisites": ["analytic number theory", "exponential estimates", "Filter.Tendsto"]
+    "relatedConcepts": [
+      "smooth numbers",
+      "sieve methods",
+      "sublinear growth",
+      "de Bruijn's estimate"
+    ],
+    "prerequisites": [
+      "analytic number theory",
+      "exponential estimates",
+      "Filter.Tendsto"
+    ]
   },
   {
     "id": "ann-1004-conjecture",
     "proofId": "erdos-1004",
-    "range": { "startLine": 122, "endLine": 152 },
     "type": "definition",
     "title": "Erdős Problem 1004: Main Conjecture and Variants",
     "content": "The main conjecture: for any $c > 0$, if $x$ is large enough, there exists $n \\leq x$ such that $\\varphi(n+1), \\ldots, \\varphi(n + \\lfloor (\\log x)^c \\rfloor)$ are all distinct. Stated using `Filter.Eventually` (`∀ᶠ`). The negation says there exists some threshold $c_0 > 0$ beyond which no such $n$ exists. Also states `SmallCaseConjecture` (the conjecture for small $c$) and a heuristic that the EPS bound constrains $c \\leq 1/3$.",
     "mathContext": "$\\forall c > 0,\\ \\forall^\\infty x,\\ \\exists n \\leq x : \\varphi(n+1), \\ldots, \\varphi(n + \\lfloor (\\log x)^c \\rfloor) \\text{ all distinct}$",
     "significance": "key",
-    "relatedConcepts": ["asymptotic existence", "Filter.Eventually", "logarithmic run lengths"],
-    "prerequisites": ["real analysis", "floor function", "Filter.atTop"]
+    "relatedConcepts": [
+      "asymptotic existence",
+      "Filter.Eventually",
+      "logarithmic run lengths"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "floor function",
+      "Filter.atTop"
+    ]
   },
   {
     "id": "ann-1004-examples",
     "proofId": "erdos-1004",
-    "range": { "startLine": 156, "endLine": 176 },
     "type": "technique",
     "title": "Concrete Examples of Distinct Runs",
     "content": "Two verified examples: (1) At $n=1$: $\\varphi(2) = 1, \\varphi(3) = 2, \\varphi(4) = 2$, so the run has length exactly 2. (2) At $n=2$: $\\varphi(3) = \\varphi(4) = 2$, so the run has length exactly 1. Both are proved by `interval_cases` and `simp`. A general statement asserts longer runs require larger starting points.",
     "mathContext": "$n=1$: $\\varphi(2)=1, \\varphi(3)=2, \\varphi(4)=2$ gives run length 2. $n=2$: $\\varphi(3)=\\varphi(4)=2$ gives run length 1.",
     "significance": "supporting",
-    "relatedConcepts": ["concrete computations", "interval_cases tactic"],
-    "prerequisites": ["totient computation", "decidable equality"]
+    "relatedConcepts": [
+      "concrete computations",
+      "interval_cases tactic"
+    ],
+    "prerequisites": [
+      "totient computation",
+      "decidable equality"
+    ]
   },
   {
     "id": "ann-1004-collisions",
     "proofId": "erdos-1004",
-    "range": { "startLine": 180, "endLine": 201 },
     "type": "concept",
     "title": "Totient Value Collisions",
     "content": "Defines `TotientCollision(a, b)` as $\\varphi(a) = \\varphi(b)$ with $a \\neq b$. Proves $\\varphi(1) = \\varphi(2) = 1$ and $\\varphi(3) = \\varphi(4) = 2$. The theorem `collision_ends_run` shows that a collision within a run immediately bounds its length. Carmichael's conjecture (1907, still open) asserts every totient value has multiplicity $\\geq 2$, meaning collisions are inescapable.",
     "mathContext": "$\\varphi(a) = \\varphi(b),\\ a \\neq b$ is a collision. Carmichael's conjecture: $|\\varphi^{-1}(m)| \\geq 2$ for all $m$ in the range of $\\varphi$.",
     "significance": "key",
-    "relatedConcepts": ["Carmichael's conjecture", "totient valence", "Ford's theorem"],
-    "prerequisites": ["totient computation", "proof by contradiction"]
+    "relatedConcepts": [
+      "Carmichael's conjecture",
+      "totient valence",
+      "Ford's theorem"
+    ],
+    "prerequisites": [
+      "totient computation",
+      "proof by contradiction"
+    ]
   },
   {
     "id": "ann-1004-divisor",
     "proofId": "erdos-1004",
-    "range": { "startLine": 205, "endLine": 217 },
     "type": "definition",
     "title": "Connection to Problem 945 (Divisor Function)",
     "content": "Defines $\\tau(n) = |\\{d : d | n\\}|$ and `IsDistinctDivisorRun` analogously to `IsDistinctTotientRun`. Problem 945 asks: for any $c > 0$ and large $x$, does there exist $n \\leq x$ with $\\tau(n+1), \\ldots, \\tau(n + \\lfloor (\\log x)^c \\rfloor)$ all distinct? Both problems are open and study the same phenomenon for different arithmetic functions.",
     "mathContext": "$\\tau(n) = |\\{d : d | n\\}|$. Problem 945: same question for $\\tau$ instead of $\\varphi$.",
     "significance": "key",
-    "relatedConcepts": ["divisor function", "Erdős Problem 945", "arithmetic function runs"],
-    "prerequisites": ["divisor counting", "Finset.divisors"]
+    "relatedConcepts": [
+      "divisor function",
+      "Erdős Problem 945",
+      "arithmetic function runs"
+    ],
+    "prerequisites": [
+      "divisor counting",
+      "Finset.divisors"
+    ]
   },
   {
     "id": "ann-1004-birthday",
     "proofId": "erdos-1004",
-    "range": { "startLine": 219, "endLine": 236 },
     "type": "insight",
     "title": "Birthday Problem Heuristic for Collisions",
     "content": "The birthday paradox provides intuition: if there are $V \\sim n / \\log n$ distinct totient values near $n$, the probability that $K$ consecutive values are all distinct is $\\approx \\prod_{k=0}^{K-1}(1 - k/V)$, dropping below $1/2$ when $K \\approx \\sqrt{V} \\sim \\sqrt{n/\\log n}$. The asymptotic `distinct_totients_asymptotic` formalizes $|\\{\\varphi(k) : k \\leq x\\}| \\sim x / \\log x$ (proof sorry'd).",
     "mathContext": "$V(x) := |\\{\\varphi(n) : n \\leq x\\}| \\sim x / \\log x$. Collisions likely after $K \\approx \\sqrt{V} \\sim \\sqrt{x / \\log x}$.",
     "significance": "key",
-    "relatedConcepts": ["birthday paradox", "distinct value counting", "Ford's theorem on totient valence"],
-    "prerequisites": ["probability heuristics", "asymptotic analysis"]
+    "relatedConcepts": [
+      "birthday paradox",
+      "distinct value counting",
+      "Ford's theorem on totient valence"
+    ],
+    "prerequisites": [
+      "probability heuristics",
+      "asymptotic analysis"
+    ]
   },
   {
     "id": "ann-1004-special",
     "proofId": "erdos-1004",
-    "range": { "startLine": 250, "endLine": 263 },
     "type": "technique",
     "title": "Special Totient Values",
     "content": "Characterizations of small totient values: $\\varphi(n) = 1 \\iff n \\in \\{1, 2\\}$, $\\varphi(n) = 2 \\iff n \\in \\{3, 4, 6\\}$, $\\varphi(n) = 4 \\iff n \\in \\{5, 8, 10, 12\\}$. The increasing preimage sizes (2, 3, 4) illustrate Carmichael's conjecture that every totient value is attained at least twice. These show why collisions are common for small totient values.",
     "mathContext": "$\\varphi^{-1}(1) = \\{1,2\\}$, $\\varphi^{-1}(2) = \\{3,4,6\\}$, $\\varphi^{-1}(4) = \\{5,8,10,12\\}$.",
     "significance": "supporting",
-    "relatedConcepts": ["totient preimages", "Carmichael's conjecture", "inverse totient problem"],
-    "prerequisites": ["totient computation", "finite enumeration"]
+    "relatedConcepts": [
+      "totient preimages",
+      "Carmichael's conjecture",
+      "inverse totient problem"
+    ],
+    "prerequisites": [
+      "totient computation",
+      "finite enumeration"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1005/annotations.json
+++ b/src/data/proofs/erdos-1005/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-1005-imports",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 16,
-      "endLine": 22
-    },
     "type": "concept",
     "title": "Imports and Namespace",
     "content": "Imports rational numbers (`Rat.Defs`), finite sets (`Finset`), divisor functions (`NumberTheory.Divisors`), real numbers, and core tactics. The entire formalization lives in the `Erdos1005` namespace. The divisors import supports the Euler totient function $\\varphi(n)$, which controls $|F_n| = 1 + \\sum_{k=1}^{n} \\varphi(k)$.",
@@ -24,10 +20,6 @@
   {
     "id": "ann-1005-fareyfrac",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 34,
-      "endLine": 39
-    },
     "type": "definition",
     "title": "Farey Fraction Structure",
     "content": "A `FareyFraction` is a structure with fields `num` and `denom` (both natural numbers), equipped with proofs that the denominator is positive, the numerator does not exceed the denominator (so the fraction lies in $[0,1]$), and that $\\gcd(a,b) = 1$. This models the reduced fractions $a/b$ with $0 \\leq a/b \\leq 1$ that comprise Farey sequences.",
@@ -48,10 +40,6 @@
   {
     "id": "ann-1005-fareyseq",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 41,
-      "endLine": 43
-    },
     "type": "definition",
     "title": "Farey Sequence of Order n",
     "content": "The Farey sequence $F_n$ as a `Finset FareyFraction`: all Farey fractions with denominator at most $n$, ordered by value. The construction is left as `sorry` because building the ordered sequence computationally from the coprimality condition is non-trivial. In practice, $F_n$ can be built by inserting mediants: $F_{n+1}$ is obtained from $F_n$ by inserting the mediant $(a+c)/(b+d)$ whenever $b + d = n+1$ for adjacent fractions $a/b, c/d$ in $F_n$.",
@@ -70,10 +58,6 @@
   {
     "id": "ann-1005-count",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 48,
-      "endLine": 50
-    },
     "type": "technique",
     "title": "Farey Count Asymptotic",
     "content": "The number of Farey fractions of order $n$ satisfies $|F_n| = \\frac{3n^2}{\\pi^2} + O(n \\log n)$. This follows from the identity $|F_n| = 1 + \\sum_{k=1}^{n} \\varphi(k)$ and the classical estimate $\\sum_{k=1}^{n} \\varphi(k) = \\frac{3n^2}{\\pi^2} + O(n \\log n)$, which in turn relies on the Möbius inversion formula and the zeta function value $\\zeta(2) = \\pi^2/6$.",
@@ -93,10 +77,6 @@
   {
     "id": "ann-1005-simord",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 60,
-      "endLine": 63
-    },
     "type": "definition",
     "title": "Similarly Ordered Fractions",
     "content": "Two Farey fractions $a/b$ and $c/d$ are **similarly ordered** if $(a - c)(b - d) \\geq 0$, meaning numerator and denominator change in the same direction. Equivalently, either $a \\geq c$ and $b \\geq d$, or $a \\leq c$ and $b \\leq d$. In the lattice point interpretation, the points $(a, b)$ and $(c, d)$ in $\\mathbb{Z}^2$ are comparable in the product order. This is the central concept of Problem 1005.",
@@ -116,10 +96,6 @@
   {
     "id": "ann-1005-symm",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 65,
-      "endLine": 73
-    },
     "type": "technique",
     "title": "Symmetry of Similar Ordering",
     "content": "The similarly ordered relation is symmetric: `similarlyOrdered f g ↔ similarlyOrdered g f`. This is proved by case analysis on the two disjuncts, swapping the direction of inequalities. Together with reflexivity (proved below), this shows `similarlyOrdered` is an equivalence-like relation, though it is not transitive (which is what makes the run-length question non-trivial).",
@@ -137,10 +113,6 @@
   {
     "id": "ann-1005-issimord",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 91,
-      "endLine": 96
-    },
     "type": "definition",
     "title": "Pairwise Similarly Ordered Run",
     "content": "A run of $k$ consecutive Farey fractions starting at index $i$ is **pairwise similarly ordered** if every pair of fractions in the run satisfies `similarlyOrdered`. This is stronger than requiring only adjacent pairs to be similarly ordered, because the relation is not transitive. The non-transitivity is what makes long runs difficult: each new fraction must be comparable with *all* previous fractions in the run.",
@@ -159,10 +131,6 @@
   {
     "id": "ann-1005-mayerf",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 104,
-      "endLine": 107
-    },
     "type": "definition",
     "title": "The Mayer–Erdős Function f(n)",
     "content": "The function $f(n) = \\sup\\{k : \\exists i,\\ \\text{isSimOrdered}(n, i, k)\\}$ measures the longest run of consecutive pairwise similarly ordered Farey fractions in $F_n$. Defined using `sSup` (supremum in $\\mathbb{N}$). This is the central quantity of Erdős Problem 1005. The existence of the supremum is guaranteed since the Farey sequence is finite.",
@@ -181,10 +149,6 @@
   {
     "id": "ann-1005-mayer",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 115,
-      "endLine": 116
-    },
     "type": "technique",
     "title": "Mayer's Theorem (1942)",
     "content": "Mayer (1942) proved that $f(n) \\to \\infty$ as $n \\to \\infty$: the longest similarly ordered run grows without bound. This was the first result on the problem, showing that the phenomenon Erdős later quantified is real. Stated via `Filter.Tendsto` to express that `mayerErdosF` tends to infinity along the `atTop` filter.",
@@ -203,10 +167,6 @@
   {
     "id": "ann-1005-erdos43",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 118,
-      "endLine": 119
-    },
     "type": "technique",
     "title": "Erdős's Linear Growth (1943)",
     "content": "Erdős (1943) strengthened Mayer's result by proving $f(n) \\geq cn$ for some absolute constant $c > 0$: the longest run grows at least linearly in $n$. This established the correct order of magnitude and motivated the search for the precise asymptotic constant. The proof used a probabilistic/counting argument to show that a linear-length run must exist somewhere in $F_n$.",
@@ -225,10 +185,6 @@
   {
     "id": "ann-1005-vdlower",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 127,
-      "endLine": 129
-    },
     "type": "technique",
     "title": "van Doorn Lower Bound (2025)",
     "content": "van Doorn (2025) proved $f(n) \\geq (1/12 - o(1))n$: the explicit lower bound constant $1/12$. The proof constructs explicit long similarly ordered runs by analyzing the local structure of Farey fractions near specific denominators. The $o(1)$ term means: for every $\\varepsilon > 0$, there exists $N$ such that for $n \\geq N$, $f(n) \\geq (1/12 - \\varepsilon)n$.",
@@ -247,10 +203,6 @@
   {
     "id": "ann-1005-vdupper",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 131,
-      "endLine": 133
-    },
     "type": "technique",
     "title": "van Doorn Upper Bound (2025)",
     "content": "van Doorn (2025) proved $f(n) \\leq n/4 + O(1)$: no similarly ordered run can exceed $n/4$ plus a bounded constant. The proof analyzes obstructions to similar ordering using the mediant property: adjacent Farey fractions satisfy $|ad - bc| = 1$, which constrains how long a chain of pairwise similarly ordered fractions can be. The upper bound argument identifies a pigeonhole obstruction at length $\\sim n/4$.",
@@ -269,10 +221,6 @@
   {
     "id": "ann-1005-combined",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 135,
-      "endLine": 140
-    },
     "type": "technique",
     "title": "Combined van Doorn Bounds",
     "content": "A theorem packaging both van Doorn bounds into a single statement: $(1/12 - o(1))n \\leq f(n) \\leq n/4 + O(1)$. The proof simply pairs the lower and upper bound axioms. The factor of 3 gap between $1/12$ and $1/4$ is the central remaining challenge.",
@@ -290,10 +238,6 @@
   {
     "id": "ann-1005-hasconst",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 147,
-      "endLine": 150
-    },
     "type": "definition",
     "title": "Existence of Asymptotic Constant (OPEN)",
     "content": "The central open question: does $f(n)/n$ converge to a constant $c > 0$ as $n \\to \\infty$? Written as $\\exists c > 0,\\ \\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall n \\geq N,\\ |f(n)/n - c| < \\varepsilon$. This is a genuine open problem — it is not even known whether the limit exists, let alone its value. The van Doorn bounds constrain $c \\in [1/12, 1/4]$ if it exists.",
@@ -312,10 +256,6 @@
   {
     "id": "ann-1005-vdconj",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 152,
-      "endLine": 154
-    },
     "type": "definition",
     "title": "van Doorn's Conjecture: c = 1/4",
     "content": "van Doorn conjectures that $c = 1/4$, meaning the upper bound is tight: $f(n)/n \\to 1/4$. This would mean the upper bound obstruction (based on the mediant/pigeonhole argument) is the true limiting factor, and the lower bound construction can be improved from $1/12$ to $1/4$.",
@@ -334,10 +274,6 @@
   {
     "id": "ann-1005-mediant",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 168,
-      "endLine": 170
-    },
     "type": "definition",
     "title": "Mediant of Farey Fractions",
     "content": "The mediant of $a/b$ and $c/d$ is $(a+c)/(b+d)$. The mediant property is fundamental to Farey sequences: if $a/b$ and $c/d$ are adjacent in $F_n$, their mediant $(a+c)/(b+d)$ is the first fraction to appear between them in $F_{b+d}$. The mediant lies strictly between the two fractions and is in lowest terms when the original fractions are adjacent.",
@@ -356,10 +292,6 @@
   {
     "id": "ann-1005-adjacent",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 172,
-      "endLine": 177
-    },
     "type": "technique",
     "title": "Farey Adjacent Determinant Property",
     "content": "Adjacent Farey fractions $a/b$ and $c/d$ in $F_n$ satisfy $|ad - bc| = 1$. This is equivalent to saying the $2 \\times 2$ matrix $\\begin{pmatrix} a & c \\\\ b & d \\end{pmatrix}$ has determinant $\\pm 1$, i.e., it lies in $GL_2(\\mathbb{Z})$. This determinant condition is what makes Farey fractions so structured and is key to van Doorn's upper bound: it constrains how many consecutive fractions can be pairwise similarly ordered.",
@@ -379,10 +311,6 @@
   {
     "id": "ann-1005-monotone",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 189,
-      "endLine": 208
-    },
     "type": "technique",
     "title": "Geometric Characterization: Monotone in Both Coordinates",
     "content": "The similarly ordered condition is equivalent to monotonicity in both coordinates when viewing fractions as lattice points: `similarlyOrdered f g ↔ (f.num ≤ g.num ∧ f.denom ≤ g.denom) ∨ (f.num ≥ g.num ∧ f.denom ≥ g.denom)`. This is the product order on $\\mathbb{Z}^2$. The proof proceeds by case analysis on the disjuncts and uses `omega` for the integer arithmetic. A pairwise similarly ordered run thus corresponds to a chain in the product order — connecting to Dilworth's theorem and longest chain problems.",
@@ -403,10 +331,6 @@
   {
     "id": "ann-1005-gap",
     "proofId": "erdos-1005",
-    "range": {
-      "startLine": 217,
-      "endLine": 226
-    },
     "type": "insight",
     "title": "The 3:1 Gap Between Bounds",
     "content": "Two simple verified computations: $\\frac{1/4}{1/12} = 3$ and $1/4 - 1/12 = 1/6$, quantifying the gap between van Doorn's bounds. The factor of 3 suggests that the lower bound construction captures only about a third of the true behavior. Closing this gap likely requires either finding longer explicit constructions (improving $1/12$) or identifying sharper obstructions (improving $1/4$). van Doorn conjectures the upper bound is tight, meaning the lower bound must be tripled.",

--- a/src/data/proofs/erdos-1008/annotations.json
+++ b/src/data/proofs/erdos-1008/annotations.json
@@ -2,14 +2,10 @@
   {
     "id": "ann-1008-imports",
     "proofId": "erdos-1008",
-    "range": {
-      "startLine": 1,
-      "endLine": 37
-    },
     "type": "context",
     "title": "Imports and Problem Overview",
-    "content": "Module documentation and imports for graph theory (SimpleGraph), finite sets, and real number operations. Formalizes Erd\u0151s Problem #1008 on finding large C\u2084-free subgraphs, originally posed with exponent 3/4 (disproved by Folkman), resolved with optimal exponent 2/3 by Conlon-Fox-Sudakov (2014).",
-    "mathContext": "The formalization uses `SimpleGraph V` (undirected, simple graphs on vertex type $V$) and `Finset` for edge counting. The main objects are the predicate `isC4Free` (no 4-cycle) and the existence of large C\u2084-free subgraphs with $\\Omega(m^{2/3})$ edges.",
+    "content": "Module documentation and imports for graph theory (SimpleGraph), finite sets, and real number operations. Formalizes Erdős Problem #1008 on finding large C₄-free subgraphs, originally posed with exponent 3/4 (disproved by Folkman), resolved with optimal exponent 2/3 by Conlon-Fox-Sudakov (2014).",
+    "mathContext": "The formalization uses `SimpleGraph V` (undirected, simple graphs on vertex type $V$) and `Finset` for edge counting. The main objects are the predicate `isC4Free` (no 4-cycle) and the existence of large C₄-free subgraphs with $\\Omega(m^{2/3})$ edges.",
     "significance": "supporting",
     "relatedConcepts": [
       "simple graphs",
@@ -24,19 +20,15 @@
   {
     "id": "ann-1008-c4def",
     "proofId": "erdos-1008",
-    "range": {
-      "startLine": 45,
-      "endLine": 57
-    },
     "type": "definition",
-    "title": "4-Cycles and C\u2084-Freeness",
-    "content": "A C\u2084 (4-cycle) is a cycle a-b-c-d-a on 4 distinct vertices. The predicate hasC4 detects such cycles and isC4Free asserts their absence. Crucially, C\u2084 = K_{2,2}, connecting this to the Zarankiewicz problem.",
-    "mathContext": "A **4-cycle** in $G$ is a tuple $(a,b,c,d)$ of distinct vertices with edges $ab, bc, cd, da \\in E(G)$. Since $C_4 \\cong K_{2,2}$ (the complete bipartite graph on $2+2$ vertices), $C_4$-freeness is equivalent to $K_{2,2}$-freeness. By the **K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem**, a $K_{2,2}$-free graph on $n$ vertices has at most $\\frac{1}{2}(1 + \\sqrt{4n-3})$ edges, i.e., $O(n^{3/2})$.",
+    "title": "4-Cycles and C₄-Freeness",
+    "content": "A C₄ (4-cycle) is a cycle a-b-c-d-a on 4 distinct vertices. The predicate hasC4 detects such cycles and isC4Free asserts their absence. Crucially, C₄ = K_{2,2}, connecting this to the Zarankiewicz problem.",
+    "mathContext": "A **4-cycle** in $G$ is a tuple $(a,b,c,d)$ of distinct vertices with edges $ab, bc, cd, da \\in E(G)$. Since $C_4 \\cong K_{2,2}$ (the complete bipartite graph on $2+2$ vertices), $C_4$-freeness is equivalent to $K_{2,2}$-freeness. By the **Kővári-Sós-Turán theorem**, a $K_{2,2}$-free graph on $n$ vertices has at most $\\frac{1}{2}(1 + \\sqrt{4n-3})$ edges, i.e., $O(n^{3/2})$.",
     "significance": "key",
     "relatedConcepts": [
       "complete bipartite graphs",
       "Zarankiewicz problem",
-      "K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem",
+      "Kővári-Sós-Turán theorem",
       "forbidden subgraphs"
     ],
     "prerequisites": [
@@ -47,10 +39,6 @@
   {
     "id": "ann-1008-subgraph",
     "proofId": "erdos-1008",
-    "range": {
-      "startLine": 59,
-      "endLine": 69
-    },
     "type": "definition",
     "title": "Subgraphs and Edge Count",
     "content": "A subgraph H of G uses only edges from G. The edge count |E(H)| is the cardinality of the edge set. The problem asks: how many edges can we retain while eliminating all 4-cycles?",
@@ -69,69 +57,57 @@
   {
     "id": "ann-1008-trivial",
     "proofId": "erdos-1008",
-    "range": {
-      "startLine": 71,
-      "endLine": 86
-    },
     "type": "technique",
     "title": "Trivial Bound: m^{1/2}",
-    "content": "The bound m^{1/2} is trivially achievable. By K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n, C\u2084-free graphs on n vertices have O(n^{3/2}) edges. A greedy edge-deletion argument gives a C\u2084-free subgraph with \u03a9(\u221am) edges.",
-    "mathContext": "The **trivial lower bound** $f(m) \\geq c\\sqrt{m}$ follows from the K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem: a $C_4$-free graph on $n$ vertices has $\\leq \\frac{1}{2}n^{3/2}$ edges, so any $m$-edge graph on $n$ vertices (with $m \\leq \\binom{n}{2}$) has a $C_4$-free subgraph with $\\Omega(\\sqrt{m})$ edges by a greedy or probabilistic argument.",
+    "content": "The bound m^{1/2} is trivially achievable. By Kővári-Sós-Turán, C₄-free graphs on n vertices have O(n^{3/2}) edges. A greedy edge-deletion argument gives a C₄-free subgraph with Ω(√m) edges.",
+    "mathContext": "The **trivial lower bound** $f(m) \\geq c\\sqrt{m}$ follows from the Kővári-Sós-Turán theorem: a $C_4$-free graph on $n$ vertices has $\\leq \\frac{1}{2}n^{3/2}$ edges, so any $m$-edge graph on $n$ vertices (with $m \\leq \\binom{n}{2}$) has a $C_4$-free subgraph with $\\Omega(\\sqrt{m})$ edges by a greedy or probabilistic argument.",
     "significance": "supporting",
     "relatedConcepts": [
-      "K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem",
+      "Kővári-Sós-Turán theorem",
       "greedy algorithms",
       "edge deletion"
     ],
     "prerequisites": [
-      "C\u2084-freeness",
+      "C₄-freeness",
       "extremal graph bounds"
     ]
   },
   {
     "id": "ann-1008-folkman",
     "proofId": "erdos-1008",
-    "range": {
-      "startLine": 88,
-      "endLine": 102
-    },
     "type": "technique",
     "title": "Folkman's Counterexample",
-    "content": "Folkman disproved the original m^{3/4} conjecture using K_{n,n\u00b2}. This bipartite graph has n\u00b3 edges, but every C\u2084-free subgraph has only O(n\u00b2) = O((n\u00b3)^{2/3}) edges, showing 3/4 is impossible and 2/3 is optimal.",
-    "mathContext": "The bipartite graph $K_{n,n^2}$ has $n \\cdot n^2 = n^3 = m$ edges. Any $C_4$-free subgraph $H$ of $K_{n,n^2}$ must be $K_{2,2}$-free, so by K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n applied to the $(n, n^2)$-bipartition, $|E(H)| \\leq \\frac{1}{2}(n + n^2\\sqrt{n}) = O(n^{5/2})$. But $m^{3/4} = n^{9/4}$ while the actual bound is $O(n^2) = O(m^{2/3})$. This shows $f(m) = O(m^{2/3})$, making 2/3 the best possible exponent.",
+    "content": "Folkman disproved the original m^{3/4} conjecture using K_{n,n²}. This bipartite graph has n³ edges, but every C₄-free subgraph has only O(n²) = O((n³)^{2/3}) edges, showing 3/4 is impossible and 2/3 is optimal.",
+    "mathContext": "The bipartite graph $K_{n,n^2}$ has $n \\cdot n^2 = n^3 = m$ edges. Any $C_4$-free subgraph $H$ of $K_{n,n^2}$ must be $K_{2,2}$-free, so by Kővári-Sós-Turán applied to the $(n, n^2)$-bipartition, $|E(H)| \\leq \\frac{1}{2}(n + n^2\\sqrt{n}) = O(n^{5/2})$. But $m^{3/4} = n^{9/4}$ while the actual bound is $O(n^2) = O(m^{2/3})$. This shows $f(m) = O(m^{2/3})$, making 2/3 the best possible exponent.",
     "significance": "key",
     "relatedConcepts": [
       "complete bipartite graphs",
       "upper bounds",
       "extremal constructions",
-      "K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n"
+      "Kővári-Sós-Turán"
     ],
     "prerequisites": [
-      "C\u2084-freeness",
+      "C₄-freeness",
       "bipartite graphs",
-      "K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem"
+      "Kővári-Sós-Turán theorem"
     ]
   },
   {
     "id": "ann-1008-main",
     "proofId": "erdos-1008",
-    "range": {
-      "startLine": 104,
-      "endLine": 122
-    },
     "type": "technique",
     "title": "Main Result: m^{2/3}",
-    "content": "Conlon, Fox, and Sudakov (2014) proved the optimal bound: every graph with m edges has a C\u2084-free subgraph with \u03a9(m^{2/3}) edges. Combined with Folkman's upper bound, the exponent 2/3 is tight.",
-    "mathContext": "The **Conlon-Fox-Sudakov theorem** (2014): $f(m) = \\Theta(m^{2/3})$. Their proof uses **dependent random choice**: select a random subset $S$ of vertices, then show that with positive probability, the induced subgraph on the common neighborhood of $S$ is $C_4$-free and retains $\\Omega(m^{2/3})$ edges. A simpler proof by Hunter uses a direct probabilistic argument with the Lov\u00e1sz Local Lemma.",
+    "content": "Conlon, Fox, and Sudakov (2014) proved the optimal bound: every graph with m edges has a C₄-free subgraph with Ω(m^{2/3}) edges. Combined with Folkman's upper bound, the exponent 2/3 is tight.",
+    "mathContext": "The **Conlon-Fox-Sudakov theorem** (2014): $f(m) = \\Theta(m^{2/3})$. Their proof uses **dependent random choice**: select a random subset $S$ of vertices, then show that with positive probability, the induced subgraph on the common neighborhood of $S$ is $C_4$-free and retains $\\Omega(m^{2/3})$ edges. A simpler proof by Hunter uses a direct probabilistic argument with the Lovász Local Lemma.",
     "significance": "key",
     "relatedConcepts": [
       "dependent random choice",
-      "Lov\u00e1sz Local Lemma",
+      "Lovász Local Lemma",
       "probabilistic method",
-      "Tur\u00e1n-type problems"
+      "Turán-type problems"
     ],
     "prerequisites": [
-      "C\u2084-freeness",
+      "C₄-freeness",
       "Folkman's counterexample",
       "probabilistic combinatorics"
     ]
@@ -139,23 +115,19 @@
   {
     "id": "ann-1008-kst",
     "proofId": "erdos-1008",
-    "range": {
-      "startLine": 124,
-      "endLine": 146
-    },
     "type": "definition",
     "title": "Generalization to K_{s,t}",
-    "content": "The problem generalizes from C\u2084 = K_{2,2} to avoiding K_{s,t} for general s,t. Conlon-Fox-Sudakov prove results for this broader setting, connecting to the classical Zarankiewicz problem in extremal graph theory.",
-    "mathContext": "The **Zarankiewicz problem** $z(n; s,t)$ asks for the maximum edges in a bipartite graph on $n+n$ vertices avoiding $K_{s,t}$. The K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem gives $z(n; s,t) = O(n^{2-1/s})$ for $s \\leq t$. The Conlon-Fox-Sudakov generalization: every $m$-edge graph has a $K_{s,t}$-free subgraph with $\\Omega(m^{1-1/s})$ edges when $t$ is sufficiently large relative to $s$.",
+    "content": "The problem generalizes from C₄ = K_{2,2} to avoiding K_{s,t} for general s,t. Conlon-Fox-Sudakov prove results for this broader setting, connecting to the classical Zarankiewicz problem in extremal graph theory.",
+    "mathContext": "The **Zarankiewicz problem** $z(n; s,t)$ asks for the maximum edges in a bipartite graph on $n+n$ vertices avoiding $K_{s,t}$. The Kővári-Sós-Turán theorem gives $z(n; s,t) = O(n^{2-1/s})$ for $s \\leq t$. The Conlon-Fox-Sudakov generalization: every $m$-edge graph has a $K_{s,t}$-free subgraph with $\\Omega(m^{1-1/s})$ edges when $t$ is sufficiently large relative to $s$.",
     "significance": "key",
     "relatedConcepts": [
       "Zarankiewicz problem",
-      "K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem",
-      "Tur\u00e1n numbers",
+      "Kővári-Sós-Turán theorem",
+      "Turán numbers",
       "extremal graph theory"
     ],
     "prerequisites": [
-      "C\u2084-free subgraphs",
+      "C₄-free subgraphs",
       "complete bipartite graphs",
       "Ramsey-type problems"
     ]

--- a/src/data/proofs/erdos-1017/annotations.json
+++ b/src/data/proofs/erdos-1017/annotations.json
@@ -2,13 +2,9 @@
   {
     "id": "ann-1017-header",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 1,
-      "endLine": 22
-    },
     "type": "context",
     "title": "Problem Documentation and Imports",
-    "content": "The header documents Erd\u0151s Problem #1017 on clique partitions of graphs. The key question: given the Erd\u0151s-Goodman-P\u00f3sa bound $f(n,k) \\le \\lfloor n^2/4 \\rfloor$, can this be improved when $k > n^2/4$? The file imports Mathlib's `SimpleGraph` infrastructure for graph theory, `Clique` for clique-related definitions, and `Finset`/`Fintype` for finite combinatorics.",
+    "content": "The header documents Erdős Problem #1017 on clique partitions of graphs. The key question: given the Erdős-Goodman-Pósa bound $f(n,k) \\le \\lfloor n^2/4 \\rfloor$, can this be improved when $k > n^2/4$? The file imports Mathlib's `SimpleGraph` infrastructure for graph theory, `Clique` for clique-related definitions, and `Finset`/`Fintype` for finite combinatorics.",
     "mathContext": "$f(n,k) = \\min\\{m : \\text{every } G \\text{ with } |V|=n, |E|=k \\text{ has a clique partition of size } \\le m\\}$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -25,10 +21,6 @@
   {
     "id": "ann-1017-edgecount",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 33,
-      "endLine": 38
-    },
     "type": "definition",
     "title": "Edge and Vertex Count",
     "content": "Basic graph parameters: `edgeCount G` returns $|E(G)|$ via the cardinality of `G.edgeFinset`, and `vertexCount` returns $|V|$ via `Fintype.card V`. These are the two parameters $(n,k)$ in the function $f(n,k)$.",
@@ -47,13 +39,9 @@
   {
     "id": "ann-1017-isclique",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 46,
-      "endLine": 48
-    },
     "type": "definition",
     "title": "Clique Predicate",
-    "content": "A set $S \\subseteq V$ is a clique in $G$ if every pair of distinct vertices in $S$ is adjacent: $\\forall u,v \\in S, u \\ne v \\Rightarrow G.\\text{Adj}\\;u\\;v$. This is the building block for clique partitions\u2014each piece of the partition must be a complete subgraph.",
+    "content": "A set $S \\subseteq V$ is a clique in $G$ if every pair of distinct vertices in $S$ is adjacent: $\\forall u,v \\in S, u \\ne v \\Rightarrow G.\\text{Adj}\\;u\\;v$. This is the building block for clique partitions—each piece of the partition must be a complete subgraph.",
     "mathContext": "$\\text{isClique}(G, S) \\iff S \\text{ induces } K_{|S|} \\text{ in } G$",
     "significance": "key",
     "relatedConcepts": [
@@ -69,10 +57,6 @@
   {
     "id": "ann-1017-completeon",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 50,
-      "endLine": 54
-    },
     "type": "definition",
     "title": "Complete Graph on a Vertex Set",
     "content": "`completeOn S` constructs the complete graph $K_S$ on vertex set $S$: vertices $u,v$ are adjacent iff both lie in $S$ and $u \\ne v$. This is used to represent individual cliques as `SimpleGraph` objects, enabling the definition of edge-disjointness between cliques.",
@@ -91,10 +75,6 @@
   {
     "id": "ann-1017-edgedisjoint",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 62,
-      "endLine": 64
-    },
     "type": "definition",
     "title": "Edge-Disjoint Subgraphs",
     "content": "Two subgraphs $G_1, G_2$ are edge-disjoint if no edge belongs to both: $\\forall u,v: \\neg(G_1.\\text{Adj}\\;u\\;v \\wedge G_2.\\text{Adj}\\;u\\;v)$. This is the crucial constraint distinguishing clique *partitions* from clique *covers*. In a partition, each edge is assigned to exactly one clique.",
@@ -112,13 +92,9 @@
   {
     "id": "ann-1017-pairwise",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 66,
-      "endLine": 68
-    },
     "type": "definition",
     "title": "Pairwise Edge-Disjointness",
-    "content": "A list of cliques is pairwise edge-disjoint if every pair $(i,j)$ with $i < j$ satisfies `edgeDisjoint`. Combined with the union covering all edges, this ensures each edge appears in exactly one clique\u2014a true partition.",
+    "content": "A list of cliques is pairwise edge-disjoint if every pair $(i,j)$ with $i < j$ satisfies `edgeDisjoint`. Combined with the union covering all edges, this ensures each edge appears in exactly one clique—a true partition.",
     "mathContext": "$\\forall i < j < |\\mathcal{C}|: E(K_{C_i}) \\cap E(K_{C_j}) = \\emptyset$",
     "significance": "key",
     "relatedConcepts": [
@@ -133,10 +109,6 @@
   {
     "id": "ann-1017-cliqueunion",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 70,
-      "endLine": 74
-    },
     "type": "definition",
     "title": "Union of Clique Subgraphs",
     "content": "`cliqueUnion` takes a list of vertex sets and forms the graph whose edges are the union of all complete graphs on those sets. An edge $\\{u,v\\}$ exists iff some $S$ in the list contains both $u$ and $v$. When this equals $G$, the cliques partition $G$'s edges.",
@@ -155,13 +127,9 @@
   {
     "id": "ann-1017-partition",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 78,
-      "endLine": 80
-    },
     "type": "definition",
     "title": "Clique Partition of a Graph",
-    "content": "`isCliquePartition G cliques` holds when the cliques are pairwise edge-disjoint and their union equals $G$. This is the central predicate\u2014it captures the graph-theoretic notion of an *edge partition into complete subgraphs*, also known as a clique edge cover or clique decomposition.",
+    "content": "`isCliquePartition G cliques` holds when the cliques are pairwise edge-disjoint and their union equals $G$. This is the central predicate—it captures the graph-theoretic notion of an *edge partition into complete subgraphs*, also known as a clique edge cover or clique decomposition.",
     "mathContext": "$G = \\bigsqcup_{i=1}^{m} K_{S_i}$ where $E(K_{S_i}) \\cap E(K_{S_j}) = \\emptyset$ for $i \\ne j$",
     "significance": "key",
     "relatedConcepts": [
@@ -177,10 +145,6 @@
   {
     "id": "ann-1017-canpartition",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 88,
-      "endLine": 102
-    },
     "type": "definition",
     "title": "Universal Partition Predicate and $f(n,k)$",
     "content": "`canPartitionInto n k m` asserts that *every* graph with $n$ vertices and $k$ edges admits a clique partition of size $\\le m$. The clique partition number $f(n,k) = \\min\\{m : \\text{canPartitionInto}(n,k,m)\\}$ is defined via `Nat.find`, requiring a proof that the trivial bound $m = n^2$ works (each edge is its own $K_2$).",
@@ -199,10 +163,6 @@
   {
     "id": "ann-1017-edgestriangles",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 111,
-      "endLine": 113
-    },
     "type": "definition",
     "title": "Edges-and-Triangles Restriction",
     "content": "`usesOnlyEdgesAndTriangles` restricts a partition to use only $K_2$'s (edges) and $K_3$'s (triangles). The remarkable content of the EGP theorem is that this restriction *does not increase* the partition size: $f(n,k)$ can always be achieved using only edges and triangles, never requiring $K_4$ or larger.",
@@ -220,17 +180,13 @@
   {
     "id": "ann-1017-egp",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 115,
-      "endLine": 128
-    },
     "type": "technique",
-    "title": "Erd\u0151s-Goodman-P\u00f3sa Theorem (1966)",
-    "content": "The foundational result: every graph on $n$ vertices can be partitioned into at most $\\lfloor n^2/4 \\rfloor$ edge-disjoint cliques, using only edges and triangles. Axiomatized as `erdos_goodman_posa`. The theorem `cliquePartitionNumber_le` then derives $f(n,k) \\le n^2/4$. The proof idea: greedily extract edge-disjoint triangles from $G$; the remaining triangle-free graph is bipartite (by the Ramsey-type argument), needing at most $\\lfloor n^2/4 \\rfloor$ edge-cliques by Tur\u00e1n's theorem.",
+    "title": "Erdős-Goodman-Pósa Theorem (1966)",
+    "content": "The foundational result: every graph on $n$ vertices can be partitioned into at most $\\lfloor n^2/4 \\rfloor$ edge-disjoint cliques, using only edges and triangles. Axiomatized as `erdos_goodman_posa`. The theorem `cliquePartitionNumber_le` then derives $f(n,k) \\le n^2/4$. The proof idea: greedily extract edge-disjoint triangles from $G$; the remaining triangle-free graph is bipartite (by the Ramsey-type argument), needing at most $\\lfloor n^2/4 \\rfloor$ edge-cliques by Turán's theorem.",
     "mathContext": "$f(n,k) \\le \\lfloor n^2/4 \\rfloor$ for all $k$; achieved using only $K_2$ and $K_3$",
     "significance": "key",
     "relatedConcepts": [
-      "Tur\u00e1n's theorem",
+      "Turán's theorem",
       "triangle-free graphs",
       "bipartite graphs"
     ],
@@ -242,17 +198,13 @@
   {
     "id": "ann-1017-bipartite",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 136,
-      "endLine": 156
-    },
     "type": "definition",
-    "title": "Complete Bipartite Graph \u2014 Extremal Example",
-    "content": "`completeBipartite A B` constructs $K_{|A|,|B|}$: edges exist only between vertices in $A$ and vertices in $B$. When $|A| = |B| = n/2$, this graph has $n^2/4$ edges and is triangle-free\u2014so every edge must be its own clique in any partition, achieving the EGP bound with equality. This proves $f(n, n^2/4) = n^2/4$.",
+    "title": "Complete Bipartite Graph — Extremal Example",
+    "content": "`completeBipartite A B` constructs $K_{|A|,|B|}$: edges exist only between vertices in $A$ and vertices in $B$. When $|A| = |B| = n/2$, this graph has $n^2/4$ edges and is triangle-free—so every edge must be its own clique in any partition, achieving the EGP bound with equality. This proves $f(n, n^2/4) = n^2/4$.",
     "mathContext": "$K_{n/2, n/2}$ has $\\lfloor n^2/4 \\rfloor$ edges, no triangles, so $\\text{cp}(K_{n/2,n/2}) = \\lfloor n^2/4 \\rfloor$",
     "significance": "key",
     "relatedConcepts": [
-      "Tur\u00e1n graph",
+      "Turán graph",
       "extremal graph",
       "bipartite graph"
     ],
@@ -265,13 +217,9 @@
   {
     "id": "ann-1017-openproblem",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 158,
-      "endLine": 173
-    },
     "type": "definition",
     "title": "The Open Problem: Dense Graphs ($k > n^2/4$)",
-    "content": "`canImproveForDenseGraphs` asks whether there exists a function $f'(n,k) < n^2/4$ that still bounds the clique partition number for all graphs with $k > n^2/4$ edges. This is the core of Erd\u0151s #1017: the EGP bound is tight for sparse (bipartite) graphs, but dense graphs have triangles and larger cliques available\u2014can these reduce the partition count below $n^2/4$?",
+    "content": "`canImproveForDenseGraphs` asks whether there exists a function $f'(n,k) < n^2/4$ that still bounds the clique partition number for all graphs with $k > n^2/4$ edges. This is the core of Erdős #1017: the EGP bound is tight for sparse (bipartite) graphs, but dense graphs have triangles and larger cliques available—can these reduce the partition count below $n^2/4$?",
     "mathContext": "$\\exists f': \\forall n,k \\text{ with } k > n^2/4, f'(n,k) < n^2/4 \\text{ and } f(n,k) \\le f'(n,k)$",
     "significance": "key",
     "relatedConcepts": [
@@ -287,18 +235,14 @@
   {
     "id": "ann-1017-lovasz",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 175,
-      "endLine": 193
-    },
     "type": "technique",
-    "title": "Lov\u00e1sz's Covering Result (1968)",
-    "content": "Lov\u00e1sz proved that any graph $G$ with $n$ vertices and $k$ edges is the union (not necessarily edge-disjoint!) of $\\binom{n}{2} - k + t$ complete subgraphs, where $t$ is the largest integer with $t^2 - t \\le \\binom{n}{2} - k$. The parameter `lovaszT` computes $t \\approx \\sqrt{\\binom{n}{2} - k}$. This is a *covering* result, not a *partition* result\u2014it allows edge overlap, making it weaker than EGP for partitions but useful as a structural tool.",
+    "title": "Lovász's Covering Result (1968)",
+    "content": "Lovász proved that any graph $G$ with $n$ vertices and $k$ edges is the union (not necessarily edge-disjoint!) of $\\binom{n}{2} - k + t$ complete subgraphs, where $t$ is the largest integer with $t^2 - t \\le \\binom{n}{2} - k$. The parameter `lovaszT` computes $t \\approx \\sqrt{\\binom{n}{2} - k}$. This is a *covering* result, not a *partition* result—it allows edge overlap, making it weaker than EGP for partitions but useful as a structural tool.",
     "mathContext": "$G = \\bigcup_{i=1}^{\\binom{n}{2} - k + t} K_{S_i}$ where $t = \\lfloor \\sqrt{\\binom{n}{2} - k} \\rfloor$",
     "significance": "key",
     "relatedConcepts": [
       "clique cover",
-      "Lov\u00e1sz theta function",
+      "Lovász theta function",
       "intersection number"
     ],
     "prerequisites": [
@@ -310,12 +254,8 @@
   {
     "id": "ann-1017-k4free",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 195,
-      "endLine": 227
-    },
     "type": "technique",
-    "title": "Gy\u0151ri-Keszegh Theorem (2017): $K_4$-Free Case",
+    "title": "Győri-Keszegh Theorem (2017): $K_4$-Free Case",
     "content": "The major partial result: if $G$ is $K_4$-free with $n$ vertices and $\\lfloor n^2/4 \\rfloor + m$ edges, then $G$ contains $m$ edge-disjoint triangles. Since $G$ is $K_4$-free, all cliques in $G$ have size $\\le 3$, so the only way to improve on the edge-by-edge partition is via triangles. Each triangle replaces 3 edges with 1 clique, saving 2 from the count. The theorem `k4free_triangle_partition` derives the partition size.",
     "mathContext": "$G$ is $K_4$-free, $|E(G)| = \\lfloor n^2/4 \\rfloor + m \\Rightarrow G$ has $m$ edge-disjoint triangles; partition size $= \\lfloor n^2/4 \\rfloor - 2m + m = \\lfloor n^2/4 \\rfloor - m$",
     "significance": "key",
@@ -333,13 +273,9 @@
   {
     "id": "ann-1017-harder",
     "proofId": "erdos-1017",
-    "range": {
-      "startLine": 229,
-      "endLine": 243
-    },
     "type": "insight",
     "title": "Why the General Case Is Harder",
-    "content": "When $K_4$ and larger cliques are present, a single $K_r$-clique replaces $\\binom{r}{2}$ edges with 1 piece\u2014a much bigger saving than the 2-for-1 of triangles. But the difficulty is that edges may participate in multiple potential larger cliques, creating a complex optimization landscape. The theorem `larger_cliques_help` illustrates: a $K_r$ with $r \\ge 4$ can be partitioned into $\\binom{r}{2}$ edges or 1 clique, showing the potential savings but not how to realize them globally.",
+    "content": "When $K_4$ and larger cliques are present, a single $K_r$-clique replaces $\\binom{r}{2}$ edges with 1 piece—a much bigger saving than the 2-for-1 of triangles. But the difficulty is that edges may participate in multiple potential larger cliques, creating a complex optimization landscape. The theorem `larger_cliques_help` illustrates: a $K_r$ with $r \\ge 4$ can be partitioned into $\\binom{r}{2}$ edges or 1 clique, showing the potential savings but not how to realize them globally.",
     "mathContext": "$K_r$ has $\\binom{r}{2}$ edges but is 1 clique; savings $= \\binom{r}{2} - 1$. For $r=4$: 6 edges $\\to$ 1 clique (saves 5)",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1022/annotations.json
+++ b/src/data/proofs/erdos-1022/annotations.json
@@ -2,13 +2,9 @@
   {
     "id": "ann-1022-header",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 1,
-      "endLine": 19
-    },
     "type": "context",
     "title": "Problem Documentation and Imports",
-    "content": "The header documents Erd\u0151s Problem #1022 on property B for sparse set families. Property B asks when a family of sets can be 2-colored so that no set is monochromatic. The sparseness condition bounds how many family members can be subsets of any given set $X$. Imports Mathlib's `Finset`, `Fintype`, and `Real` modules.",
+    "content": "The header documents Erdős Problem #1022 on property B for sparse set families. Property B asks when a family of sets can be 2-colored so that no set is monochromatic. The sparseness condition bounds how many family members can be subsets of any given set $X$. Imports Mathlib's `Finset`, `Fintype`, and `Real` modules.",
     "mathContext": "$\\exists c_t \\to \\infty: \\text{hasMinSize}(\\mathcal{F}, t) \\wedge \\text{isSparse}(\\mathcal{F}, c_t) \\Rightarrow \\text{hasPropertyB}(\\mathcal{F})$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -25,13 +21,9 @@
   {
     "id": "ann-1022-setfamily",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 22,
-      "endLine": 39
-    },
     "type": "definition",
     "title": "Set Family, Ground Set, and Minimum Size",
-    "content": "`SetFamily \u03b1` is `Finset (Finset \u03b1)`\u2014a finite collection of finite subsets of $\\alpha$. The `groundSet` is $\\bigcup \\mathcal{F}$ (computed via `Finset.sup`). `minSetSize` returns the minimum cardinality across all sets in $\\mathcal{F}$, the parameter $t$ in the problem. These are the basic objects of the hypergraph coloring problem.",
+    "content": "`SetFamily α` is `Finset (Finset α)`—a finite collection of finite subsets of $\\alpha$. The `groundSet` is $\\bigcup \\mathcal{F}$ (computed via `Finset.sup`). `minSetSize` returns the minimum cardinality across all sets in $\\mathcal{F}$, the parameter $t$ in the problem. These are the basic objects of the hypergraph coloring problem.",
     "mathContext": "$\\mathcal{F} \\subseteq 2^{\\alpha}$ finite; $\\text{groundSet}(\\mathcal{F}) = \\bigcup_{A \\in \\mathcal{F}} A$; $t = \\min_{A \\in \\mathcal{F}} |A|$",
     "significance": "key",
     "relatedConcepts": [
@@ -47,10 +39,6 @@
   {
     "id": "ann-1022-propertyb",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 41,
-      "endLine": 61
-    },
     "type": "definition",
     "title": "Property B (2-Colorability)",
     "content": "`hasPropertyB F` holds if there exists a 2-coloring $c: \\alpha \\to \\text{Bool}$ such that every set $A \\in \\mathcal{F}$ with $|A| \\ge 2$ is non-monochromatic: it contains both a true-colored and a false-colored element. Named after Felix Bernstein (1908), property B is the fundamental notion of hypergraph 2-colorability. The tautological equivalence `propertyB_iff_chromatic2` shows this is definitional.",
@@ -69,10 +57,6 @@
   {
     "id": "ann-1022-chromatic",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 63,
-      "endLine": 87
-    },
     "type": "definition",
     "title": "Chromatic Number of a Set Family",
     "content": "Generalizes property B to $k$ colors. `isKColorable F k` requires a $k$-coloring making all sets non-monochromatic (containing at least 2 distinct colors). `chromaticNumber F` is the minimum such $k$, defined via `Nat.find`. The theorem `propertyB_iff_chromatic_le2` connects property B to $\\chi(\\mathcal{F}) \\le 2$.",
@@ -91,10 +75,6 @@
   {
     "id": "ann-1022-sparseness",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 89,
-      "endLine": 105
-    },
     "type": "definition",
     "title": "Sparseness Condition",
     "content": "The key condition: `subsetCount F X` counts how many sets in $\\mathcal{F}$ are subsets of $X$. `isSparse F c` requires this count to be $< c \\cdot |X|$ for *every* finite set $X$ (not just sets in $\\mathcal{F}$). This is a strong structural condition: it bounds the 'local density' of the family near any set. `hasMinSize F t` requires all sets to have $|A| \\ge t$.",
@@ -113,10 +93,6 @@
   {
     "id": "ann-1022-conjecture",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 107,
-      "endLine": 124
-    },
     "type": "definition",
     "title": "The Main Conjecture: $c_t \\to \\infty$",
     "content": "`erdos_1022_conjecture` asks: does there exist a `ThresholdFunction` $c: \\mathbb{N} \\to \\mathbb{R}$ with $c_t \\to \\infty$ such that for all $t \\ge 2$, every set family with minimum size $t$ and sparseness $< c_t$ has property B? The divergence condition $c_t \\to \\infty$ means larger sets allow progressively sparser families to still be 2-colorable.",
@@ -136,17 +112,13 @@
   {
     "id": "ann-1022-lovasz",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 126,
-      "endLine": 147
-    },
     "type": "technique",
-    "title": "Lov\u00e1sz's Theorem (1968): $c_2 = 1$",
+    "title": "Lovász's Theorem (1968): $c_2 = 1$",
     "content": "The only solved case: for $t = 2$ (all sets have $\\ge 2$ elements), the threshold $c_2 = 1$ works. That is, if for every set $X$ fewer than $|X|$ family members are subsets of $X$, the family has property B. Axiomatized as `lovasz_theorem`. The derived `t2_case_solved` packages this as an existential witness ($c = 1 > 0$).",
     "mathContext": "$\\forall \\mathcal{F}: \\text{minSize} \\ge 2 \\wedge (\\forall X: |\\{A \\in \\mathcal{F}: A \\subseteq X\\}| < |X|) \\Rightarrow \\text{propertyB}(\\mathcal{F})$",
     "significance": "key",
     "relatedConcepts": [
-      "Lov\u00e1sz Local Lemma",
+      "Lovász Local Lemma",
       "Hall's theorem",
       "transversal theory"
     ],
@@ -159,13 +131,9 @@
   {
     "id": "ann-1022-hypergraph",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 149,
-      "endLine": 172
-    },
     "type": "definition",
     "title": "Hypergraph Formulation",
-    "content": "Defines `Hypergraph \u03b1` as an alias for `SetFamily \u03b1`, `hypergraphChromaticNumber` as `chromaticNumber`, and `erdos_1022_hypergraph` as the conjecture restated using hypergraph language ($\\chi(H) \\le 2$). The equivalence `formulations_equiv` shows the two statements are logically identical. This dual viewpoint is useful: set-family language emphasizes subset structure, while hypergraph language emphasizes coloring.",
+    "content": "Defines `Hypergraph α` as an alias for `SetFamily α`, `hypergraphChromaticNumber` as `chromaticNumber`, and `erdos_1022_hypergraph` as the conjecture restated using hypergraph language ($\\chi(H) \\le 2$). The equivalence `formulations_equiv` shows the two statements are logically identical. This dual viewpoint is useful: set-family language emphasizes subset structure, while hypergraph language emphasizes coloring.",
     "mathContext": "$\\text{Hypergraph} \\equiv \\text{SetFamily}$; $\\chi(H) \\le 2 \\iff \\text{propertyB}(H)$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -181,10 +149,6 @@
   {
     "id": "ann-1022-necessary",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 174,
-      "endLine": 208
-    },
     "type": "technique",
     "title": "Necessary Conditions and Subset Density",
     "content": "If $c_t$ exists and tends to infinity, it must be eventually positive (`threshold_positive`) and must grow unboundedly (`threshold_grows`). The `subsetDensity` function normalizes the count: $\\text{subsetDensity}(\\mathcal{F}, X) = |\\{A \\subseteq X\\}| / |X|$. The theorem `sparse_iff_low_density` shows sparseness is equivalent to low density for all nonempty $X$.",
@@ -203,18 +167,14 @@
   {
     "id": "ann-1022-probabilistic",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 210,
-      "endLine": 228
-    },
     "type": "insight",
     "title": "Probabilistic Intuition: Random Colorings",
-    "content": "`expectedMonochromatic F` computes the expected number of monochromatic sets under a uniformly random 2-coloring: each set $A$ with $|A| = s$ is monochromatic with probability $2^{1-s}$ (all same color). The axiom `expected_less_one_implies_propertyB` asserts that if this expectation is $< 1$, property B holds\u2014this is the first-moment method (or a consequence of the Lov\u00e1sz Local Lemma). The theorem `sparse_bounds_expected` shows sparseness controls this expectation.",
+    "content": "`expectedMonochromatic F` computes the expected number of monochromatic sets under a uniformly random 2-coloring: each set $A$ with $|A| = s$ is monochromatic with probability $2^{1-s}$ (all same color). The axiom `expected_less_one_implies_propertyB` asserts that if this expectation is $< 1$, property B holds—this is the first-moment method (or a consequence of the Lovász Local Lemma). The theorem `sparse_bounds_expected` shows sparseness controls this expectation.",
     "mathContext": "$\\mathbb{E}[\\text{mono}] = \\sum_{A \\in \\mathcal{F}} 2^{1-|A|}$; if $< 1$ then property B holds; sparseness gives $\\le c_t \\cdot |\\bigcup \\mathcal{F}| \\cdot 2^{1-t}$",
     "significance": "key",
     "relatedConcepts": [
       "first-moment method",
-      "Lov\u00e1sz Local Lemma",
+      "Lovász Local Lemma",
       "probabilistic method"
     ],
     "prerequisites": [
@@ -225,10 +185,6 @@
   {
     "id": "ann-1022-coverfree",
     "proofId": "erdos-1022",
-    "range": {
-      "startLine": 230,
-      "endLine": 244
-    },
     "type": "definition",
     "title": "Cover-Free Families",
     "content": "`isCoverFree F r` means no set in $\\mathcal{F}$ is contained in the union of $r$ others: $\\forall A \\in \\mathcal{F}: A \\not\\subseteq \\bigcup_{B \\in \\mathcal{B}} B$ for any $\\mathcal{B} \\subseteq \\mathcal{F}$ with $|\\mathcal{B}| \\le r$. The theorem `coverFree_implies_sparse` shows $r$-cover-freeness implies $(r+1)$-sparseness. Cover-free families arise in combinatorial group testing and error-correcting codes.",

--- a/src/data/proofs/erdos-1027/annotations.json
+++ b/src/data/proofs/erdos-1027/annotations.json
@@ -2,13 +2,9 @@
   {
     "id": "ann-1027-header",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 1,
-      "endLine": 21
-    },
     "type": "context",
     "title": "Problem Documentation and Imports",
-    "content": "The header documents Erd\u0151s Problem #1027 on the abundance of 'good' sets for bounded set families. Given a family $\\mathcal{F}$ of at most $c \\cdot 2^n$ sets of size $n$, the problem asks whether there exist $\\gg_c 2^{|X|}$ subsets $B \\subseteq X = \\bigcup \\mathcal{F}$ that intersect every set in $\\mathcal{F}$ but contain none. Koishi Chan proved the answer is YES. Imports Mathlib's `Finset`, `Fintype`, `Powerset`, and `Real` modules.",
+    "content": "The header documents Erdős Problem #1027 on the abundance of 'good' sets for bounded set families. Given a family $\\mathcal{F}$ of at most $c \\cdot 2^n$ sets of size $n$, the problem asks whether there exist $\\gg_c 2^{|X|}$ subsets $B \\subseteq X = \\bigcup \\mathcal{F}$ that intersect every set in $\\mathcal{F}$ but contain none. Koishi Chan proved the answer is YES. Imports Mathlib's `Finset`, `Fintype`, `Powerset`, and `Real` modules.",
     "mathContext": "$|\\mathcal{F}| \\le c \\cdot 2^n, \\; |A| = n \\; \\forall A \\in \\mathcal{F} \\;\\Rightarrow\\; |\\{B \\subseteq X : B \\cap A \\ne \\emptyset \\wedge A \\not\\subseteq B, \\; \\forall A \\in \\mathcal{F}\\}| \\gg_c 2^{|X|}$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -25,13 +21,9 @@
   {
     "id": "ann-1027-setfamily",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 24,
-      "endLine": 41
-    },
     "type": "definition",
     "title": "Set Family, Union, and Uniformity",
-    "content": "`SetFamily \u03b1` is `Finset (Finset \u03b1)`\u2014a finite collection of finite subsets. `familyUnion F` computes $X = \\bigcup \\mathcal{F}$ via `Finset.sup`. `isNUniform F n` requires every set $A \\in \\mathcal{F}$ to have $|A| = n$ (an $n$-uniform hypergraph). These are the basic objects: $\\mathcal{F}$ is the hypergraph, $X$ is the ground set, and $n$ is the uniformity parameter.",
+    "content": "`SetFamily α` is `Finset (Finset α)`—a finite collection of finite subsets. `familyUnion F` computes $X = \\bigcup \\mathcal{F}$ via `Finset.sup`. `isNUniform F n` requires every set $A \\in \\mathcal{F}$ to have $|A| = n$ (an $n$-uniform hypergraph). These are the basic objects: $\\mathcal{F}$ is the hypergraph, $X$ is the ground set, and $n$ is the uniformity parameter.",
     "mathContext": "$\\mathcal{F} \\subseteq 2^\\alpha$ finite; $X = \\bigcup_{A \\in \\mathcal{F}} A$; $n$-uniform: $|A| = n \\; \\forall A \\in \\mathcal{F}$",
     "significance": "key",
     "relatedConcepts": [
@@ -47,13 +39,9 @@
   {
     "id": "ann-1027-goodset",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 43,
-      "endLine": 64
-    },
     "type": "definition",
     "title": "Good Sets: Intersecting All, Containing None",
-    "content": "The central definition. `intersectsAll B F` requires $(A \\cap B) \\ne \\emptyset$ for all $A \\in \\mathcal{F}$: $B$ 'hits' every hyperedge. `containsNone B F` requires $A \\not\\subseteq B$ for all $A \\in \\mathcal{F}$: $B$ does not swallow any hyperedge. A 'good' set $B$ satisfies both simultaneously\u2014it is a transversal that is not a cover. `goodSets F` collects all good $B \\subseteq X$. In 2-coloring language, $B$ corresponds to the 'true' color class of a proper 2-coloring.",
+    "content": "The central definition. `intersectsAll B F` requires $(A \\cap B) \\ne \\emptyset$ for all $A \\in \\mathcal{F}$: $B$ 'hits' every hyperedge. `containsNone B F` requires $A \\not\\subseteq B$ for all $A \\in \\mathcal{F}$: $B$ does not swallow any hyperedge. A 'good' set $B$ satisfies both simultaneously—it is a transversal that is not a cover. `goodSets F` collects all good $B \\subseteq X$. In 2-coloring language, $B$ corresponds to the 'true' color class of a proper 2-coloring.",
     "mathContext": "$B \\text{ good} \\iff \\forall A \\in \\mathcal{F}: A \\cap B \\ne \\emptyset \\wedge A \\not\\subseteq B$; equivalently, both color classes of $(B, X \\setminus B)$ hit every $A$",
     "significance": "key",
     "relatedConcepts": [
@@ -69,10 +57,6 @@
   {
     "id": "ann-1027-propertyb",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 66,
-      "endLine": 85
-    },
     "type": "definition",
     "title": "Property B and 2-Colorability",
     "content": "`hasPropertyB F` holds if at least one good set exists. `is2Colorable F` requires a function $f: \\alpha \\to \\text{Bool}$ such that every $A \\in \\mathcal{F}$ has both true-colored and false-colored elements. The theorem `propertyB_iff_2colorable` shows these are equivalent: a good set $B$ defines the coloring $f(x) = (x \\in B)$, and conversely $B = f^{-1}(\\text{true})$ is a good set. Property B (Bernstein 1908) is the foundational notion of hypergraph 2-colorability.",
@@ -91,13 +75,9 @@
   {
     "id": "ann-1027-conjecture",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 87,
-      "endLine": 104
-    },
     "type": "definition",
     "title": "The Main Conjecture: Exponentially Many Good Sets",
-    "content": "`goodSetCount F` counts good sets via `Finset.filter` on the powerset. `erdos_1027_conjecture c` asserts: for $c > 0$, there exist $\\delta > 0$ and $N$ such that for $n \\ge N$, every $n$-uniform family $\\mathcal{F}$ with $|\\mathcal{F}| \\le c \\cdot 2^n$ has at least $\\delta \\cdot 2^{|X|}$ good sets. The key quantifier structure is: $\\delta$ depends on $c$ but not on $n$ or $\\mathcal{F}$\u2014a constant fraction of all subsets of $X$ are good.",
+    "content": "`goodSetCount F` counts good sets via `Finset.filter` on the powerset. `erdos_1027_conjecture c` asserts: for $c > 0$, there exist $\\delta > 0$ and $N$ such that for $n \\ge N$, every $n$-uniform family $\\mathcal{F}$ with $|\\mathcal{F}| \\le c \\cdot 2^n$ has at least $\\delta \\cdot 2^{|X|}$ good sets. The key quantifier structure is: $\\delta$ depends on $c$ but not on $n$ or $\\mathcal{F}$—a constant fraction of all subsets of $X$ are good.",
     "mathContext": "$\\forall c > 0, \\exists \\delta > 0, \\exists N, \\forall n \\ge N: |\\mathcal{F}| \\le c \\cdot 2^n \\wedge \\text{uniform}(n) \\Rightarrow |\\text{good}| \\ge \\delta \\cdot 2^{|X|}$",
     "significance": "key",
     "relatedConcepts": [
@@ -113,13 +93,9 @@
   {
     "id": "ann-1027-solution",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 106,
-      "endLine": 123
-    },
     "type": "technique",
     "title": "The Solution: Koishi Chan's Theorem",
-    "content": "`erdos_1027_solution` axiomatizes the affirmative answer (proved by Koishi Chan): for every $c > 0$, the conjecture holds. `erdos_1027_solved` derives the explicit statement: there exist $\\delta > 0$ and $N$ such that for all large enough $n$-uniform families of size $\\le c \\cdot 2^n$, the good set count is $\\ge \\delta \\cdot 2^{|X|}$. This resolves Erd\u0151s's question: not only does property B hold for bounded families, but the number of witnesses is exponentially large.",
+    "content": "`erdos_1027_solution` axiomatizes the affirmative answer (proved by Koishi Chan): for every $c > 0$, the conjecture holds. `erdos_1027_solved` derives the explicit statement: there exist $\\delta > 0$ and $N$ such that for all large enough $n$-uniform families of size $\\le c \\cdot 2^n$, the good set count is $\\ge \\delta \\cdot 2^{|X|}$. This resolves Erdős's question: not only does property B hold for bounded families, but the number of witnesses is exponentially large.",
     "mathContext": "$\\forall c > 0: \\text{erdos\\_1027\\_conjecture}(c)$ holds; i.e., a $\\delta(c)$-fraction of all subsets of $X$ are good",
     "significance": "key",
     "relatedConcepts": [
@@ -135,13 +111,9 @@
   {
     "id": "ann-1027-problem901",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 125,
-      "endLine": 139
-    },
     "type": "technique",
-    "title": "Connection to Erd\u0151s Problem #901",
-    "content": "Problem #901 asks about property B itself\u2014whether bounded families are 2-colorable. Problem #1027 strengthens this: not just one 2-coloring, but exponentially many. `problem_901_connection` states `hasPropertyB F \u2194 is2Colorable F` universally, and `problem_901` derives it from `propertyB_iff_2colorable`. This shows #1027 is a quantitative supersaturation of #901.",
+    "title": "Connection to Erdős Problem #901",
+    "content": "Problem #901 asks about property B itself—whether bounded families are 2-colorable. Problem #1027 strengthens this: not just one 2-coloring, but exponentially many. `problem_901_connection` states `hasPropertyB F ↔ is2Colorable F` universally, and `problem_901` derives it from `propertyB_iff_2colorable`. This shows #1027 is a quantitative supersaturation of #901.",
     "mathContext": "$\\text{Problem 901}: \\text{hasPropertyB} \\iff \\text{is2Colorable}$; Problem 1027: $|\\text{good sets}| \\gg_c 2^{|X|}$",
     "significance": "key",
     "relatedConcepts": [
@@ -157,13 +129,9 @@
   {
     "id": "ann-1027-existence",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 141,
-      "endLine": 160
-    },
     "type": "technique",
     "title": "Existence and Abundance of Good Sets",
-    "content": "`propertyB_for_bounded` axiomatizes that for $c > 0$ and large $n$, every $n$-uniform family of size $\\le c \\cdot 2^n$ has property B\u2014at least one good set. `single_implies_many` is the key structural insight: from *one* good set $B$, local perturbations (flipping elements near but not in $A$ for each $A$) produce exponentially many good sets. This 'amplification' from existence to abundance is the heart of Koishi Chan's argument.",
+    "content": "`propertyB_for_bounded` axiomatizes that for $c > 0$ and large $n$, every $n$-uniform family of size $\\le c \\cdot 2^n$ has property B—at least one good set. `single_implies_many` is the key structural insight: from *one* good set $B$, local perturbations (flipping elements near but not in $A$ for each $A$) produce exponentially many good sets. This 'amplification' from existence to abundance is the heart of Koishi Chan's argument.",
     "mathContext": "$\\exists B \\text{ good} \\Rightarrow \\exists \\delta > 0: |\\text{good sets}| \\ge \\delta \\cdot 2^{|X|}$",
     "significance": "key",
     "relatedConcepts": [
@@ -179,19 +147,15 @@
   {
     "id": "ann-1027-probabilistic",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 162,
-      "endLine": 188
-    },
     "type": "insight",
     "title": "Probabilistic Intuition: Random Sets Are Often Good",
-    "content": "Defines the probability that a uniformly random subset $B \\subseteq X$ is good. For a single set $A$ of size $n$: $\\Pr[B \\cap A \\ne \\emptyset] = 1 - 2^{-n}$ and $\\Pr[A \\not\\subseteq B] = 1 - 2^{-n}$. For a family of $m \\le c \\cdot 2^n$ sets, a naive union bound gives $\\mathbb{E}[\\text{good}] \\approx 2^{|X|} \\cdot (1 - 2^{-n})^{2m} \\approx 2^{|X|} \\cdot e^{-2c}$ for large $n$. The theorem `expected_good_positive` formalizes that this expectation is positive for large $n$, but the actual proof requires handling dependencies via the Lov\u00e1sz Local Lemma or a more careful counting argument.",
+    "content": "Defines the probability that a uniformly random subset $B \\subseteq X$ is good. For a single set $A$ of size $n$: $\\Pr[B \\cap A \\ne \\emptyset] = 1 - 2^{-n}$ and $\\Pr[A \\not\\subseteq B] = 1 - 2^{-n}$. For a family of $m \\le c \\cdot 2^n$ sets, a naive union bound gives $\\mathbb{E}[\\text{good}] \\approx 2^{|X|} \\cdot (1 - 2^{-n})^{2m} \\approx 2^{|X|} \\cdot e^{-2c}$ for large $n$. The theorem `expected_good_positive` formalizes that this expectation is positive for large $n$, but the actual proof requires handling dependencies via the Lovász Local Lemma or a more careful counting argument.",
     "mathContext": "$\\Pr[B \\text{ good}] \\ge (1 - 2^{-n})^{2|\\mathcal{F}|} \\approx e^{-2c}$ for $|\\mathcal{F}| \\le c \\cdot 2^n$; $\\mathbb{E}[|\\text{good}|] \\approx e^{-2c} \\cdot 2^{|X|}$",
     "significance": "key",
     "relatedConcepts": [
       "first-moment method",
       "union bound",
-      "Lov\u00e1sz Local Lemma"
+      "Lovász Local Lemma"
     ],
     "prerequisites": [
       "probIntersects",
@@ -201,13 +165,9 @@
   {
     "id": "ann-1027-density",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 190,
-      "endLine": 207
-    },
     "type": "definition",
     "title": "Density of Good Sets",
-    "content": "`goodSetDensity F` $= |\\text{good sets}| / 2^{|X|}$: the fraction of all subsets of $X$ that are good. `goodSetDensity_lower` axiomatizes the main result in density form: for bounded families, the density is $\\ge \\delta(c) > 0$\u2014a constant fraction depending only on $c$, not on $n$ or the specific family. This is the strongest form of the result: good sets are not merely numerous but *dense* among all subsets.",
+    "content": "`goodSetDensity F` $= |\\text{good sets}| / 2^{|X|}$: the fraction of all subsets of $X$ that are good. `goodSetDensity_lower` axiomatizes the main result in density form: for bounded families, the density is $\\ge \\delta(c) > 0$—a constant fraction depending only on $c$, not on $n$ or the specific family. This is the strongest form of the result: good sets are not merely numerous but *dense* among all subsets.",
     "mathContext": "$\\text{density}(\\mathcal{F}) = |\\{B \\subseteq X : B \\text{ good}\\}| / 2^{|X|} \\ge \\delta(c) > 0$",
     "significance": "key",
     "relatedConcepts": [
@@ -223,13 +183,9 @@
   {
     "id": "ann-1027-specialcases",
     "proofId": "erdos-1027",
-    "range": {
-      "startLine": 209,
-      "endLine": 235
-    },
     "type": "technique",
     "title": "Special Cases and Inclusion-Exclusion",
-    "content": "Three verification results. `empty_family_good`: when $\\mathcal{F} = \\emptyset$, all $2^{|\\alpha|}$ subsets are good (vacuously). `singleton_family_good`: for $\\mathcal{F} = \\{A\\}$, good sets are those intersecting $A$ but not containing it, giving $\\ge 2^{|A| - 1}$ good sets. `good_set_inclusion_exclusion`: a general lower bound via inclusion-exclusion, showing $|\\text{good}| \\ge \\frac{1}{4} \\cdot 2^{|X|} - |\\mathcal{F}| \\cdot 2^{|X| - 1}$, which is positive when $|\\mathcal{F}| < \\frac{1}{2}$\u2014a very rough bound that the main theorem far surpasses.",
+    "content": "Three verification results. `empty_family_good`: when $\\mathcal{F} = \\emptyset$, all $2^{|\\alpha|}$ subsets are good (vacuously). `singleton_family_good`: for $\\mathcal{F} = \\{A\\}$, good sets are those intersecting $A$ but not containing it, giving $\\ge 2^{|A| - 1}$ good sets. `good_set_inclusion_exclusion`: a general lower bound via inclusion-exclusion, showing $|\\text{good}| \\ge \\frac{1}{4} \\cdot 2^{|X|} - |\\mathcal{F}| \\cdot 2^{|X| - 1}$, which is positive when $|\\mathcal{F}| < \\frac{1}{2}$—a very rough bound that the main theorem far surpasses.",
     "mathContext": "$\\mathcal{F} = \\emptyset \\Rightarrow |\\text{good}| = 2^{|\\alpha|}$; $\\mathcal{F} = \\{A\\} \\Rightarrow |\\text{good}| \\ge 2^{|A|-1}$; general: $|\\text{good}| \\ge \\frac{1}{4} \\cdot 2^{|X|} - |\\mathcal{F}| \\cdot 2^{|X|-1}$",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1036/annotations.json
+++ b/src/data/proofs/erdos-1036/annotations.json
@@ -2,13 +2,9 @@
   {
     "id": "ann-1036-imports",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 1,
-      "endLine": 27
-    },
     "type": "context",
     "title": "Imports and Problem Overview",
-    "content": "Module documentation describing Erd\u0151s Problem #1036 on distinct induced subgraphs in non-Ramsey graphs. Imports SimpleGraph, Finset, Fintype, and real number infrastructure for counting arguments.",
+    "content": "Module documentation describing Erdős Problem #1036 on distinct induced subgraphs in non-Ramsey graphs. Imports SimpleGraph, Finset, Fintype, and real number infrastructure for counting arguments.",
     "mathContext": "A graph $G$ on $n$ vertices is non-Ramsey with parameter $c$ if it has no trivial (empty or complete) induced subgraph on more than $c \\log n$ vertices. Problem 1036 asks whether such graphs must contain $2^{\\Omega_c(n)}$ non-isomorphic induced subgraphs.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -25,14 +21,10 @@
   {
     "id": "ann-1036-vertexcount",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 36,
-      "endLine": 37
-    },
     "type": "definition",
     "title": "vertexCount",
     "content": "Number of vertices in a simple graph, defined as the cardinality of the Fintype vertex set.",
-    "mathContext": "$|V(G)|$ \u2014 the number of vertices of the graph $G$. All graphs are finite throughout this formalization.",
+    "mathContext": "$|V(G)|$ — the number of vertices of the graph $G$. All graphs are finite throughout this formalization.",
     "significance": "supporting",
     "relatedConcepts": [
       "graph order",
@@ -45,10 +37,6 @@
   {
     "id": "ann-1036-trivial",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 45,
-      "endLine": 48
-    },
     "type": "definition",
     "title": "isTrivialInduced",
     "content": "A vertex subset S induces a trivial subgraph if the induced subgraph is either empty (independent set) or complete (clique). These are the 'homogeneous' subgraphs in Ramsey theory terminology.",
@@ -69,10 +57,6 @@
   {
     "id": "ann-1036-independent",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 50,
-      "endLine": 52
-    },
     "type": "definition",
     "title": "isIndependentSet",
     "content": "A vertex set S is independent if no two vertices in S are adjacent: the induced subgraph G[S] has no edges.",
@@ -90,10 +74,6 @@
   {
     "id": "ann-1036-clique",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 54,
-      "endLine": 56
-    },
     "type": "definition",
     "title": "isClique",
     "content": "A vertex set S is a clique if every pair of distinct vertices in S are adjacent: the induced subgraph G[S] is complete.",
@@ -111,10 +91,6 @@
   {
     "id": "ann-1036-trivialiff",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 58,
-      "endLine": 61
-    },
     "type": "technique",
     "title": "trivial_iff",
     "content": "Characterizes trivial induced subgraphs: S is trivial if and only if S is an independent set or S is a clique.",
@@ -132,10 +108,6 @@
   {
     "id": "ann-1036-nolargetrivial",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 69,
-      "endLine": 71
-    },
     "type": "definition",
     "title": "noLargeTrivial",
     "content": "A graph G satisfies noLargeTrivial k if every trivial induced subgraph has fewer than k vertices. This is the non-Ramsey condition.",
@@ -154,13 +126,9 @@
   {
     "id": "ann-1036-nonramsey",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 73,
-      "endLine": 75
-    },
     "type": "definition",
     "title": "isNonRamsey",
-    "content": "A graph G on n vertices is non-Ramsey with parameter c if it has no trivial subgraph on more than c log n vertices. By Ramsey's theorem, this requires c \u2265 some constant depending on the graph.",
+    "content": "A graph G on n vertices is non-Ramsey with parameter c if it has no trivial subgraph on more than c log n vertices. By Ramsey's theorem, this requires c ≥ some constant depending on the graph.",
     "mathContext": "$G$ is non-Ramsey with parameter $c$ if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log_2 n$. By Ramsey's theorem, $R(k,k) \\leq 4^k$, so every $n$-vertex graph has a trivial subgraph of size $\\geq \\frac{1}{2}\\log_2 n$.",
     "significance": "key",
     "relatedConcepts": [
@@ -176,18 +144,14 @@
   {
     "id": "ann-1036-ramsey",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 77,
-      "endLine": 81
-    },
     "type": "context",
     "title": "ramsey_theorem",
     "content": "Axiomatizes the existence of non-Ramsey graphs: for sufficiently large n, there exist n-vertex graphs with no trivial subgraph larger than O(log n). Random graphs achieve this with high probability.",
-    "mathContext": "By Ramsey's theorem, $R(k,k) \\leq 4^k$. Conversely, Erd\u0151s (1947) showed $R(k,k) \\geq 2^{k/2}$ by the probabilistic method: the random graph $G(n, 1/2)$ has $\\omega(G), \\alpha(G) = O(\\log n)$ with high probability.",
+    "mathContext": "By Ramsey's theorem, $R(k,k) \\leq 4^k$. Conversely, Erdős (1947) showed $R(k,k) \\geq 2^{k/2}$ by the probabilistic method: the random graph $G(n, 1/2)$ has $\\omega(G), \\alpha(G) = O(\\log n)$ with high probability.",
     "significance": "key",
     "relatedConcepts": [
       "probabilistic method",
-      "Erd\u0151s 1947",
+      "Erdős 1947",
       "random graph",
       "Ramsey number lower bound"
     ],
@@ -198,10 +162,6 @@
   {
     "id": "ann-1036-induced",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 89,
-      "endLine": 93
-    },
     "type": "definition",
     "title": "inducedSubgraph",
     "content": "The induced subgraph G[S] on vertex subset S: vertices are elements of S, edges are those of G restricted to pairs in S.",
@@ -220,10 +180,6 @@
   {
     "id": "ann-1036-inducedpair",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 95,
-      "endLine": 99
-    },
     "type": "definition",
     "title": "InducedPair",
     "content": "A pair of induced subgraphs of the same size, used for comparing isomorphism types.",
@@ -241,10 +197,6 @@
   {
     "id": "ann-1036-graphiso",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 107,
-      "endLine": 109
-    },
     "type": "definition",
     "title": "GraphIso",
     "content": "Graph isomorphism: a bijection between vertex sets that preserves adjacency. Two graphs are isomorphic if such a bijection exists.",
@@ -263,13 +215,9 @@
   {
     "id": "ann-1036-inducediso",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 111,
-      "endLine": 114
-    },
     "type": "definition",
     "title": "inducedIso",
-    "content": "Isomorphism of induced subgraphs: G[S\u2081] \u2245 G[S\u2082] via some bijection preserving adjacency.",
+    "content": "Isomorphism of induced subgraphs: G[S₁] ≅ G[S₂] via some bijection preserving adjacency.",
     "mathContext": "Two induced subgraphs $G[S_1]$ and $G[S_2]$ are isomorphic if there is a bijection $\\phi: S_1 \\to S_2$ preserving the adjacency relation of $G$ restricted to these sets.",
     "significance": "key",
     "relatedConcepts": [
@@ -284,13 +232,9 @@
   {
     "id": "ann-1036-isorefl",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 116,
-      "endLine": 119
-    },
     "type": "technique",
     "title": "inducedIso_refl",
-    "content": "Induced subgraph isomorphism is reflexive: G[S] \u2245 G[S] via the identity.",
+    "content": "Induced subgraph isomorphism is reflexive: G[S] ≅ G[S] via the identity.",
     "mathContext": "$G[S] \\cong G[S]$ via the identity bijection $\\text{id}: S \\to S$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -304,13 +248,9 @@
   {
     "id": "ann-1036-isosymm",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 121,
-      "endLine": 124
-    },
     "type": "technique",
     "title": "inducedIso_symm",
-    "content": "Induced subgraph isomorphism is symmetric: G[S\u2081] \u2245 G[S\u2082] implies G[S\u2082] \u2245 G[S\u2081] via the inverse bijection.",
+    "content": "Induced subgraph isomorphism is symmetric: G[S₁] ≅ G[S₂] implies G[S₂] ≅ G[S₁] via the inverse bijection.",
     "mathContext": "If $\\phi: G[S_1] \\cong G[S_2]$, then $\\phi^{-1}: G[S_2] \\cong G[S_1]$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -324,13 +264,9 @@
   {
     "id": "ann-1036-isotrans",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 126,
-      "endLine": 129
-    },
     "type": "technique",
     "title": "inducedIso_trans",
-    "content": "Induced subgraph isomorphism is transitive: G[S\u2081] \u2245 G[S\u2082] and G[S\u2082] \u2245 G[S\u2083] imply G[S\u2081] \u2245 G[S\u2083] via composition.",
+    "content": "Induced subgraph isomorphism is transitive: G[S₁] ≅ G[S₂] and G[S₂] ≅ G[S₃] imply G[S₁] ≅ G[S₃] via composition.",
     "mathContext": "If $\\phi: G[S_1] \\cong G[S_2]$ and $\\psi: G[S_2] \\cong G[S_3]$, then $\\psi \\circ \\phi: G[S_1] \\cong G[S_3]$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -344,10 +280,6 @@
   {
     "id": "ann-1036-allsubsets",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 137,
-      "endLine": 139
-    },
     "type": "definition",
     "title": "allInducedSubsets",
     "content": "The collection of all vertex subsets of G, whose induced subgraphs give all possible induced subgraphs. There are 2^n such subsets for an n-vertex graph.",
@@ -364,13 +296,9 @@
   {
     "id": "ann-1036-sameisoclass",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 141,
-      "endLine": 143
-    },
     "type": "definition",
     "title": "sameIsoClass",
-    "content": "Equivalence relation on vertex subsets: S\u2081 ~ S\u2082 if and only if G[S\u2081] \u2245 G[S\u2082]. The number of equivalence classes is the number of distinct induced subgraph types.",
+    "content": "Equivalence relation on vertex subsets: S₁ ~ S₂ if and only if G[S₁] ≅ G[S₂]. The number of equivalence classes is the number of distinct induced subgraph types.",
     "mathContext": "Define $S_1 \\sim S_2$ iff $G[S_1] \\cong G[S_2]$. This is an equivalence relation (reflexive, symmetric, transitive). The quotient $\\mathcal{P}(V) / {\\sim}$ gives the set of distinct induced subgraph isomorphism types.",
     "significance": "key",
     "relatedConcepts": [
@@ -388,10 +316,6 @@
   {
     "id": "ann-1036-distinctcount",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 145,
-      "endLine": 147
-    },
     "type": "definition",
     "title": "distinctInducedCount",
     "content": "The number of non-isomorphic induced subgraphs of G: the cardinality of the quotient of the power set by the isomorphism equivalence relation.",
@@ -409,13 +333,9 @@
   {
     "id": "ann-1036-hasdistinct",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 149,
-      "endLine": 153
-    },
     "type": "definition",
     "title": "hasDistinctInduced",
-    "content": "Predicate asserting that G has at least k non-isomorphic induced subgraphs. The conjecture asks for k = 2^{\u03a9(n)}.",
+    "content": "Predicate asserting that G has at least k non-isomorphic induced subgraphs. The conjecture asks for k = 2^{Ω(n)}.",
     "mathContext": "$G$ has $\\geq k$ distinct induced subgraphs means $i(G) \\geq k$, i.e., there exist $k$ vertex subsets $S_1, \\ldots, S_k$ with $G[S_i] \\not\\cong G[S_j]$ for $i \\neq j$.",
     "significance": "key",
     "relatedConcepts": [
@@ -429,17 +349,13 @@
   {
     "id": "ann-1036-conjecture",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 161,
-      "endLine": 168
-    },
     "type": "definition",
     "title": "erdos_renyi_conjecture",
-    "content": "The Erd\u0151s-R\u00e9nyi conjecture: for every constant c > 0, there exists c' > 0 such that every non-Ramsey graph with parameter c on n vertices has at least 2^{c'n} non-isomorphic induced subgraphs.",
+    "content": "The Erdős-Rényi conjecture: for every constant c > 0, there exists c' > 0 such that every non-Ramsey graph with parameter c on n vertices has at least 2^{c'n} non-isomorphic induced subgraphs.",
     "mathContext": "For every $c > 0$, $\\exists c' > 0$ such that if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log n$, then $i(G) \\geq 2^{c' n}$. This says non-Ramsey graphs must be structurally diverse at an exponential scale.",
     "significance": "key",
     "relatedConcepts": [
-      "Erd\u0151s-R\u00e9nyi conjecture",
+      "Erdős-Rényi conjecture",
       "exponential diversity",
       "Ramsey avoidance"
     ],
@@ -451,14 +367,10 @@
   {
     "id": "ann-1036-ahexp",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 176,
-      "endLine": 178
-    },
     "type": "definition",
     "title": "alonHajnalExponent",
-    "content": "The Alon-Hajnal exponent n\u00b7(log n)^{-O(log log n)}: a sub-exponential but super-polynomial growth rate, weaker than the conjectured 2^{\u03a9(n)}.",
-    "mathContext": "The Alon-Hajnal (1991) bound gives $i(G) \\geq \\exp(n (\\log n)^{-O(\\log \\log n)})$, which is $2^{o(n)}$ \u2014 sub-exponential in $n$ but still super-polynomial.",
+    "content": "The Alon-Hajnal exponent n·(log n)^{-O(log log n)}: a sub-exponential but super-polynomial growth rate, weaker than the conjectured 2^{Ω(n)}.",
+    "mathContext": "The Alon-Hajnal (1991) bound gives $i(G) \\geq \\exp(n (\\log n)^{-O(\\log \\log n)})$, which is $2^{o(n)}$ — sub-exponential in $n$ but still super-polynomial.",
     "significance": "key",
     "relatedConcepts": [
       "sub-exponential bound",
@@ -472,17 +384,13 @@
   {
     "id": "ann-1036-ahbound",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 180,
-      "endLine": 186
-    },
     "type": "context",
     "title": "Alon-Hajnal Bound",
-    "content": "Axiomatizes the Alon-Hajnal (1991) result: every non-Ramsey graph has at least exp(n\u00b7(log n)^{-O(log log n)}) distinct induced subgraphs. This was the strongest result before Shelah.",
-    "mathContext": "Alon and Hajnal (1991) proved: if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log n$, then $i(G) \\geq \\exp(n (\\log n)^{-O(\\log \\log n)})$. Their proof uses Szemer\u00e9di's regularity lemma.",
+    "content": "Axiomatizes the Alon-Hajnal (1991) result: every non-Ramsey graph has at least exp(n·(log n)^{-O(log log n)}) distinct induced subgraphs. This was the strongest result before Shelah.",
+    "mathContext": "Alon and Hajnal (1991) proved: if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log n$, then $i(G) \\geq \\exp(n (\\log n)^{-O(\\log \\log n)})$. Their proof uses Szemerédi's regularity lemma.",
     "significance": "key",
     "relatedConcepts": [
-      "Szemer\u00e9di regularity lemma",
+      "Szemerédi regularity lemma",
       "Alon-Hajnal 1991"
     ],
     "prerequisites": [
@@ -493,13 +401,9 @@
   {
     "id": "ann-1036-ahweaker",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 188,
-      "endLine": 191
-    },
     "type": "technique",
     "title": "alon_hajnal_weaker",
-    "content": "The Alon-Hajnal bound is strictly weaker than Shelah's theorem: for large n, exp(n\u00b7(log n)^{-O(log log n)}) < 2^{c'n}.",
+    "content": "The Alon-Hajnal bound is strictly weaker than Shelah's theorem: for large n, exp(n·(log n)^{-O(log log n)}) < 2^{c'n}.",
     "mathContext": "For large $n$: $\\exp(n (\\log n)^{-O(\\log \\log n)}) = 2^{o(n)} < 2^{c'n}$, so Shelah's bound is exponentially stronger.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -514,10 +418,6 @@
   {
     "id": "ann-1036-bipartite",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 199,
-      "endLine": 202
-    },
     "type": "definition",
     "title": "hasCompleteBipartite",
     "content": "Predicate for containing a complete bipartite subgraph K_{s,t} as an induced subgraph.",
@@ -535,10 +435,6 @@
   {
     "id": "ann-1036-avoidsbip",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 204,
-      "endLine": 206
-    },
     "type": "definition",
     "title": "avoidsBipartite",
     "content": "A graph avoids bipartite if neither G nor its complement contains K_{k,k}. This is stronger than being non-Ramsey.",
@@ -555,17 +451,13 @@
   {
     "id": "ann-1036-ehbip",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 208,
-      "endLine": 214
-    },
     "type": "context",
-    "title": "Erd\u0151s-Hajnal Bipartite",
-    "content": "Axiomatizes the Erd\u0151s-Hajnal (1989) result: graphs avoiding K_{k,k} in both G and its complement have 2^{\u03a9(n)} distinct induced subgraphs. This was the first exponential bound in a restricted setting.",
-    "mathContext": "Erd\u0151s and Hajnal (1989) proved: if neither $G$ nor $\\bar{G}$ contains $K_{k,k}$, then $i(G) \\geq 2^{cn}$ for a constant $c = c(k) > 0$. This uses a direct counting argument on neighborhoods.",
+    "title": "Erdős-Hajnal Bipartite",
+    "content": "Axiomatizes the Erdős-Hajnal (1989) result: graphs avoiding K_{k,k} in both G and its complement have 2^{Ω(n)} distinct induced subgraphs. This was the first exponential bound in a restricted setting.",
+    "mathContext": "Erdős and Hajnal (1989) proved: if neither $G$ nor $\\bar{G}$ contains $K_{k,k}$, then $i(G) \\geq 2^{cn}$ for a constant $c = c(k) > 0$. This uses a direct counting argument on neighborhoods.",
     "significance": "key",
     "relatedConcepts": [
-      "Erd\u0151s-Hajnal 1989",
+      "Erdős-Hajnal 1989",
       "bipartite avoidance",
       "neighborhood counting"
     ],
@@ -577,13 +469,9 @@
   {
     "id": "ann-1036-nonramseyavoids",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 216,
-      "endLine": 219
-    },
     "type": "technique",
     "title": "nonRamsey_avoids_bipartite",
-    "content": "Non-Ramsey graphs avoid large complete bipartite subgraphs: if max(\u03c9(G), \u03b1(G)) \u2264 c log n, then neither G nor its complement contains K_{k,k} for appropriate k.",
+    "content": "Non-Ramsey graphs avoid large complete bipartite subgraphs: if max(ω(G), α(G)) ≤ c log n, then neither G nor its complement contains K_{k,k} for appropriate k.",
     "mathContext": "If $\\max(\\omega(G), \\alpha(G)) \\leq c \\log n$, then for $k = c \\log n$, $G$ avoids $K_{k,k}$ (since $K_{k,k}$ contains an independent set of size $k$) and similarly for $\\bar{G}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -597,10 +485,6 @@
   {
     "id": "ann-1036-shelah",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 227,
-      "endLine": 233
-    },
     "type": "context",
     "title": "Shelah's Theorem",
     "content": "Axiomatizes Shelah's 1998 theorem: every non-Ramsey graph on n vertices has at least 2^{c'n} non-isomorphic induced subgraphs, where c' depends on the Ramsey parameter c. This fully resolves Problem 1036.",
@@ -619,18 +503,14 @@
   {
     "id": "ann-1036-solved",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 235,
-      "endLine": 239
-    },
     "type": "technique",
     "title": "erdos_1036_solved",
-    "content": "Shelah's theorem implies the Erd\u0151s-R\u00e9nyi conjecture, resolving Problem 1036 affirmatively.",
-    "mathContext": "Shelah's theorem directly establishes the Erd\u0151s-R\u00e9nyi conjecture: $i(G) \\geq 2^{c'n}$ for non-Ramsey $G$, which is $2^{\\Omega(n)}$ as conjectured.",
+    "content": "Shelah's theorem implies the Erdős-Rényi conjecture, resolving Problem 1036 affirmatively.",
+    "mathContext": "Shelah's theorem directly establishes the Erdős-Rényi conjecture: $i(G) \\geq 2^{c'n}$ for non-Ramsey $G$, which is $2^{\\Omega(n)}$ as conjectured.",
     "significance": "key",
     "relatedConcepts": [
       "conjecture resolution",
-      "Erd\u0151s-R\u00e9nyi conjecture"
+      "Erdős-Rényi conjecture"
     ],
     "prerequisites": [
       "shelah_theorem",
@@ -640,10 +520,6 @@
   {
     "id": "ann-1036-shelahbound",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 247,
-      "endLine": 248
-    },
     "type": "definition",
     "title": "shelahBound",
     "content": "The Shelah bound 2^{c'n} expressed as a function of n and the constant c'.",
@@ -660,13 +536,9 @@
   {
     "id": "ann-1036-ahbounddef",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 250,
-      "endLine": 252
-    },
     "type": "definition",
     "title": "alonHajnalBound",
-    "content": "The Alon-Hajnal bound exp(n\u00b7(log n)^{-O(log log n)}) expressed as a concrete function.",
+    "content": "The Alon-Hajnal bound exp(n·(log n)^{-O(log log n)}) expressed as a concrete function.",
     "mathContext": "$\\text{alonHajnalBound}(n) = \\exp(n \\cdot (\\log n)^{-O(\\log \\log n)})$, the sub-exponential bound from 1991.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -680,13 +552,9 @@
   {
     "id": "ann-1036-shelahbetter",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 254,
-      "endLine": 257
-    },
     "type": "technique",
     "title": "shelah_better",
-    "content": "Shelah's bound is asymptotically stronger than Alon-Hajnal's: 2^{c'n} grows exponentially faster than exp(n\u00b7(log n)^{-O(log log n)}).",
+    "content": "Shelah's bound is asymptotically stronger than Alon-Hajnal's: 2^{c'n} grows exponentially faster than exp(n·(log n)^{-O(log log n)}).",
     "mathContext": "For large $n$: $2^{c'n} \\gg \\exp(n (\\log n)^{-O(\\log \\log n)})$. The ratio $2^{c'n} / \\exp(n (\\log n)^{-O(\\log \\log n)}) \\to \\infty$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -701,10 +569,6 @@
   {
     "id": "ann-1036-distinctupper",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 265,
-      "endLine": 268
-    },
     "type": "technique",
     "title": "distinct_upper",
     "content": "Trivial upper bound: any n-vertex graph has at most 2^n distinct induced subgraphs (one per subset of vertices).",
@@ -722,17 +586,13 @@
   {
     "id": "ann-1036-random",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 270,
-      "endLine": 275
-    },
     "type": "context",
     "title": "random_graph_distinct",
     "content": "Axiomatizes the fact that random graphs G(n, 1/2) have asymptotically 2^n distinct induced subgraphs with high probability. This represents the 'maximum diversity' benchmark.",
     "mathContext": "For $G \\sim G(n, 1/2)$: $i(G) = (1 - o(1)) \\cdot 2^n$ with high probability. Random graphs are maximally diverse in induced subgraph types.",
     "significance": "supporting",
     "relatedConcepts": [
-      "Erd\u0151s-R\u00e9nyi random graph",
+      "Erdős-Rényi random graph",
       "maximum diversity"
     ],
     "prerequisites": [
@@ -742,10 +602,6 @@
   {
     "id": "ann-1036-randomlike",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 277,
-      "endLine": 284
-    },
     "type": "technique",
     "title": "nonRamsey_random_like",
     "content": "Non-Ramsey graphs are 'random-like' in diversity: their induced subgraph count is exponential in n, matching the random graph up to a constant in the exponent.",
@@ -763,10 +619,6 @@
   {
     "id": "ann-1036-inducedsize",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 292,
-      "endLine": 294
-    },
     "type": "definition",
     "title": "inducedOfSize",
     "content": "The set of all k-vertex subsets of G, representing all possible induced subgraphs of a fixed size.",
@@ -784,10 +636,6 @@
   {
     "id": "ann-1036-distinctsize",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 296,
-      "endLine": 298
-    },
     "type": "definition",
     "title": "distinctOfSize",
     "content": "The number of distinct isomorphism types among k-vertex induced subgraphs of G.",
@@ -805,10 +653,6 @@
   {
     "id": "ann-1036-hasdistinctsize",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 300,
-      "endLine": 303
-    },
     "type": "definition",
     "title": "hasDistinctOfSize",
     "content": "Predicate asserting G has at least m distinct isomorphism types among its k-vertex induced subgraphs.",
@@ -824,10 +668,6 @@
   {
     "id": "ann-1036-fixedsize",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 305,
-      "endLine": 311
-    },
     "type": "context",
     "title": "nonRamsey_fixed_size",
     "content": "Axiomatizes that non-Ramsey graphs have many distinct k-vertex induced subgraphs for appropriate k: a strengthening of the counting argument to fixed sizes.",
@@ -845,10 +685,6 @@
   {
     "id": "ann-1036-compnonramsey",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 319,
-      "endLine": 322
-    },
     "type": "technique",
     "title": "complement_nonRamsey",
     "content": "The complement of a non-Ramsey graph is also non-Ramsey: if G has no large clique or independent set, then the complement (which swaps cliques and independent sets) has the same property.",
@@ -865,10 +701,6 @@
   {
     "id": "ann-1036-compdistinct",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 324,
-      "endLine": 327
-    },
     "type": "technique",
     "title": "complement_distinct",
     "content": "G and its complement have the same number of distinct induced subgraphs, since complementation preserves the isomorphism type structure.",
@@ -886,18 +718,14 @@
   {
     "id": "ann-1036-kuniversal",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 335,
-      "endLine": 341
-    },
     "type": "definition",
     "title": "isKUniversal",
-    "content": "A graph G is k-universal if it contains every graph on at most k vertices as an induced subgraph. Pr\u00f6mel and R\u00f6dl (1999) proved non-Ramsey graphs are c\u00b7log(n)-universal.",
+    "content": "A graph G is k-universal if it contains every graph on at most k vertices as an induced subgraph. Prömel and Rödl (1999) proved non-Ramsey graphs are c·log(n)-universal.",
     "mathContext": "$G$ is $k$-universal if for every graph $H$ with $|V(H)| \\leq k$, there exists $S \\subseteq V(G)$ with $G[S] \\cong H$. The number of graphs on $k$ vertices is $2^{\\binom{k}{2}}$, so $k$-universality implies $i(G) \\geq 2^{\\binom{k}{2}}$.",
     "significance": "key",
     "relatedConcepts": [
       "universal graph",
-      "Pr\u00f6mel-R\u00f6dl theorem",
+      "Prömel-Rödl theorem",
       "induced universality"
     ],
     "prerequisites": [
@@ -908,10 +736,6 @@
   {
     "id": "ann-1036-univdistinct",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 343,
-      "endLine": 346
-    },
     "type": "technique",
     "title": "universal_implies_distinct",
     "content": "k-universality implies having at least 2^{C(k,2)} distinct induced subgraphs, since there are that many non-isomorphic graphs on k vertices.",
@@ -929,17 +753,13 @@
   {
     "id": "ann-1036-viauniv",
     "proofId": "erdos-1036",
-    "range": {
-      "startLine": 348,
-      "endLine": 355
-    },
     "type": "technique",
     "title": "via_universality",
-    "content": "Alternative proof of Problem 1036 via Pr\u00f6mel-R\u00f6dl universality (Problem 1031): non-Ramsey graphs are c\u00b7log(n)-universal, and universality implies exponentially many distinct induced subgraphs.",
-    "mathContext": "By Pr\u00f6mel-R\u00f6dl (Problem 1031), non-Ramsey $G$ is $c \\log n$-universal. Hence $i(G) \\geq 2^{\\binom{c \\log n}{2}} = 2^{\\Omega((\\log n)^2)}$. Note: this gives a weaker bound than Shelah's $2^{\\Omega(n)}$ but provides a conceptually cleaner proof via universality.",
+    "content": "Alternative proof of Problem 1036 via Prömel-Rödl universality (Problem 1031): non-Ramsey graphs are c·log(n)-universal, and universality implies exponentially many distinct induced subgraphs.",
+    "mathContext": "By Prömel-Rödl (Problem 1031), non-Ramsey $G$ is $c \\log n$-universal. Hence $i(G) \\geq 2^{\\binom{c \\log n}{2}} = 2^{\\Omega((\\log n)^2)}$. Note: this gives a weaker bound than Shelah's $2^{\\Omega(n)}$ but provides a conceptually cleaner proof via universality.",
     "significance": "key",
     "relatedConcepts": [
-      "Pr\u00f6mel-R\u00f6dl universality",
+      "Prömel-Rödl universality",
       "alternative proof",
       "Problem 1031 connection"
     ],

--- a/src/data/proofs/erdos-1050/annotations.json
+++ b/src/data/proofs/erdos-1050/annotations.json
@@ -2,421 +2,574 @@
   {
     "id": "ann-1050-header",
     "proofId": "erdos-1050",
-    "range": { "startLine": 1, "endLine": 18 },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #1050: Irrationality of ∑ 1/(2^n - 3)**\n\nIs ∑_{n≥1} 1/(2^n - 3) irrational?\n\n**Status**: SOLVED by Peter Borwein (1991)\n\n**Answer**: YES. Borwein proved ∑ 1/(q^n + r) is irrational for integer q ≥ 2 and rational r ≠ 0, r ≠ -q^n for any n. This subsumes Erdős's 1948 result on ∑ 1/(2^n - 1) as the special case q = 2, r = -1.",
     "significance": "key",
     "mathContext": "The series ∑ 1/(2^n - 3) is a Lambert-type series where each denominator is an exponential shifted by a constant. Borwein's approach uses Padé approximation to the q-logarithm function, constructing rational approximants whose convergence rate exceeds what would be possible if the sum were rational — a contradiction.",
-    "relatedConcepts": ["Lambert series", "Padé approximation", "irrationality proofs", "q-series"],
-    "prerequisites": ["convergence of geometric series", "irrationality criterion"]
+    "relatedConcepts": [
+      "Lambert series",
+      "Padé approximation",
+      "irrationality proofs",
+      "q-series"
+    ],
+    "prerequisites": [
+      "convergence of geometric series",
+      "irrationality criterion"
+    ]
   },
   {
     "id": "ann-1050-T-def",
     "proofId": "erdos-1050",
-    "range": { "startLine": 32, "endLine": 34 },
     "type": "definition",
     "title": "General Series T",
     "content": "**T q r**: T(q, r) = ∑_{n≥1} 1/(q^n + r).\n\nThe general family of series covered by Borwein's theorem. Each term decays exponentially as 1/q^n for large n, ensuring convergence. The parameter r shifts each denominator, and the condition r ≠ -q^n for any n ensures no denominator vanishes.",
     "significance": "key",
     "mathContext": "T(q, r) generalizes several classical series: T(q, -1) = ∑ 1/(q^n - 1) is the Lambert series that Erdős studied in 1948 (Problem #1049), T(q, 0) = 1/(q-1) is rational (geometric series), and T(q, 1) = ∑ 1/(q^n + 1) is the 'alternating' companion. The family T(q, r) forms a one-parameter subfamily of Lambert series with constant coefficients.",
-    "relatedConcepts": ["Lambert series", "geometric series", "parametric families of series"],
-    "prerequisites": ["definition of infinite series", "absolute convergence"]
+    "relatedConcepts": [
+      "Lambert series",
+      "geometric series",
+      "parametric families of series"
+    ],
+    "prerequisites": [
+      "definition of infinite series",
+      "absolute convergence"
+    ]
   },
   {
     "id": "ann-1050-S-def",
     "proofId": "erdos-1050",
-    "range": { "startLine": 36, "endLine": 37 },
     "type": "definition",
     "title": "Series S",
     "content": "**S**: S = T(2, -3) = ∑_{n≥1} 1/(2^n - 3).\n\nThe specific series of Erdős Problem #1050. The choice r = -3 makes this a natural test case: 3 is not a power of 2, so no denominator vanishes, but the first term 1/(2-3) = -1 is negative, creating an interesting cancellation pattern.",
     "significance": "key",
     "mathContext": "The shift by -3 rather than -1 distinguishes this from the Erdős-Borwein constant ∑ 1/(2^n - 1) ≈ 1.607. The value S ≈ 0.287 is smaller because the first term is -1 and the second is +1 (exact cancellation), so the series effectively starts from n = 3.",
-    "relatedConcepts": ["Erdős-Borwein constant", "partial cancellation in series"],
-    "prerequisites": ["T(q,r) series definition"]
+    "relatedConcepts": [
+      "Erdős-Borwein constant",
+      "partial cancellation in series"
+    ],
+    "prerequisites": [
+      "T(q,r) series definition"
+    ]
   },
   {
     "id": "ann-1050-alt",
     "proofId": "erdos-1050",
-    "range": { "startLine": 39, "endLine": 41 },
     "type": "definition",
     "title": "Alternative Form",
     "content": "**sumTwoMinusThree**: Alternative definition of ∑ 1/(2^n - 3) as a direct tsum.\n\nShows the explicit form bypassing the T(q,r) parametrization, useful for direct computation.",
     "significance": "supporting",
     "mathContext": "The direct definition makes clear that the denominators are -1, 1, 5, 13, 29, 61, 125, ... (sequence 2^n - 3). These grow exponentially, ensuring rapid convergence after the initial cancellation.",
-    "relatedConcepts": ["tsum (topological sum)", "explicit series representation"],
-    "prerequisites": ["Mathlib tsum definition"]
+    "relatedConcepts": [
+      "tsum (topological sum)",
+      "explicit series representation"
+    ],
+    "prerequisites": [
+      "Mathlib tsum definition"
+    ]
   },
   {
     "id": "ann-1050-summable",
     "proofId": "erdos-1050",
-    "range": { "startLine": 53, "endLine": 57 },
     "type": "technique",
     "title": "Convergence",
     "content": "**T_summable**: T(q, r) converges (is summable) for q ≥ 2 and r ≠ -q^n for all n.\n\nFor large n, |1/(q^n + r)| ≤ 2/q^n, and ∑ 1/q^n converges as a geometric series with ratio 1/q < 1. The pole-avoidance condition r ≠ -q^n ensures each term is finite.",
     "significance": "key",
     "mathContext": "Summability in Mathlib's sense (Summable) means the net of partial sums converges in ℝ. For absolutely convergent series this reduces to the classical notion. The comparison with the geometric series ∑ 1/q^n via the comparison test is the standard approach.",
-    "relatedConcepts": ["comparison test", "geometric series convergence", "Summable typeclass"],
-    "prerequisites": ["geometric series formula", "absolute convergence criterion"]
+    "relatedConcepts": [
+      "comparison test",
+      "geometric series convergence",
+      "Summable typeclass"
+    ],
+    "prerequisites": [
+      "geometric series formula",
+      "absolute convergence criterion"
+    ]
   },
   {
     "id": "ann-1050-S-summable",
     "proofId": "erdos-1050",
-    "range": { "startLine": 59, "endLine": 61 },
     "type": "technique",
     "title": "S Convergence",
     "content": "**S_summable**: ∑ 1/(2^n - 3) converges.\n\nSpecializes T_summable to q = 2, r = -3. Need to verify 3 ≠ 2^n for all n ≥ 1, which holds since 2^n ∈ {2, 4, 8, 16, ...} never equals 3.",
     "significance": "supporting",
     "mathContext": "The key verification that 3 is not a power of 2 is equivalent to saying log₂(3) is irrational — a basic fact following from the fundamental theorem of arithmetic (2 and 3 are distinct primes). This ensures every term of the series is well-defined.",
-    "relatedConcepts": ["powers of 2", "fundamental theorem of arithmetic"],
-    "prerequisites": ["T_summable", "3 is not a power of 2"]
+    "relatedConcepts": [
+      "powers of 2",
+      "fundamental theorem of arithmetic"
+    ],
+    "prerequisites": [
+      "T_summable",
+      "3 is not a power of 2"
+    ]
   },
   {
     "id": "ann-1050-denom",
     "proofId": "erdos-1050",
-    "range": { "startLine": 63, "endLine": 65 },
     "type": "technique",
     "title": "Nonzero Denominators",
     "content": "**denom_nonzero**: 2^n - 3 ≠ 0 for all n ≥ 1.\n\nFor n = 1: 2^1 - 3 = -1 ≠ 0. For n ≥ 2: 2^n ≥ 4 > 3, so 2^n - 3 ≥ 1 > 0.",
     "significance": "supporting",
     "mathContext": "This is the well-definedness check ensuring no term has a zero denominator. The proof splits into the case n = 1 (negative denominator) and n ≥ 2 (positive denominator), reflecting the sign change in the denominators.",
-    "relatedConcepts": ["exponential growth", "well-definedness of series terms"],
-    "prerequisites": ["basic properties of powers of 2"]
+    "relatedConcepts": [
+      "exponential growth",
+      "well-definedness of series terms"
+    ],
+    "prerequisites": [
+      "basic properties of powers of 2"
+    ]
   },
   {
     "id": "ann-1050-first",
     "proofId": "erdos-1050",
-    "range": { "startLine": 67, "endLine": 69 },
     "type": "technique",
     "title": "First Term",
     "content": "**first_term**: 1/(2^1 - 3) = 1/(-1) = -1.\n\nThe first term is negative! This is unusual for irrationality problems — the series has a large negative initial term that nearly cancels the second term 1/(2² - 3) = 1/1 = 1, leaving a small positive remainder ≈ 0.287.",
     "significance": "key",
     "mathContext": "The negative first term distinguishes this series from the Erdős-Borwein constant ∑ 1/(2^n - 1) where all terms are positive. The near-cancellation -1 + 1 = 0 means S is dominated by the 'tail' ∑_{n≥3} 1/(2^n - 3), making direct irrationality proofs via digit extraction more difficult.",
-    "relatedConcepts": ["sign changes in series", "cancellation phenomena"],
-    "prerequisites": ["arithmetic of powers of 2"]
+    "relatedConcepts": [
+      "sign changes in series",
+      "cancellation phenomena"
+    ],
+    "prerequisites": [
+      "arithmetic of powers of 2"
+    ]
   },
   {
     "id": "ann-1050-term1",
     "proofId": "erdos-1050",
-    "range": { "startLine": 77, "endLine": 78 },
     "type": "technique",
     "title": "Term 1",
     "content": "**term_1**: 2^1 - 3 = -1.\n\nThe unique negative denominator in the series.",
     "significance": "supporting",
     "mathContext": "The fact that 2^1 < 3 while 2^n > 3 for all n ≥ 2 means there is exactly one negative term in the series.",
-    "relatedConcepts": ["denominator sign analysis"],
+    "relatedConcepts": [
+      "denominator sign analysis"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-term2",
     "proofId": "erdos-1050",
-    "range": { "startLine": 80, "endLine": 81 },
     "type": "technique",
     "title": "Term 2",
     "content": "**term_2**: 2^2 - 3 = 1.\n\nGives the second term 1/(2²-3) = 1, which exactly cancels the first term -1.",
     "significance": "supporting",
     "mathContext": "The exact cancellation 1/(2¹-3) + 1/(2²-3) = -1 + 1 = 0 means the 'effective series' starts at n = 3.",
-    "relatedConcepts": ["telescoping", "exact cancellation"],
+    "relatedConcepts": [
+      "telescoping",
+      "exact cancellation"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-term3",
     "proofId": "erdos-1050",
-    "range": { "startLine": 83, "endLine": 84 },
     "type": "technique",
     "title": "Term 3",
     "content": "**term_3**: 2^3 - 3 = 5.\n\nThe third term 1/5 = 0.2 is the first contribution to the 'effective value' of S after cancellation of the first two terms.",
     "significance": "supporting",
     "mathContext": "From n = 3 onward, the denominators 5, 13, 29, 61, ... grow as 2^n - 3, and all terms are positive and decreasing.",
-    "relatedConcepts": ["monotone decreasing terms"],
+    "relatedConcepts": [
+      "monotone decreasing terms"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-first-terms",
     "proofId": "erdos-1050",
-    "range": { "startLine": 92, "endLine": 96 },
     "type": "technique",
     "title": "First Terms",
     "content": "**S_first_terms**: S = -1 + 1 + 1/5 + 1/13 + 1/29 + 1/61 + ...\n\nAfter the first two terms cancel (-1 + 1 = 0), the sum equals 1/5 + 1/13 + 1/29 + 1/61 + ... ≈ 0.287. The denominators grow as 2^n - 3, ensuring rapid convergence.",
     "significance": "key",
     "mathContext": "The rapid convergence after cancellation means S is very well-approximated by a few terms: S ≈ 1/5 + 1/13 + 1/29 + 1/61 + 1/125 ≈ 0.2 + 0.077 + 0.034 + 0.016 + 0.008 ≈ 0.287. This makes numerical verification easy but irrationality proof requires Borwein's deeper methods.",
-    "relatedConcepts": ["numerical series evaluation", "rapid convergence"],
-    "prerequisites": ["term computations term_1 through term_3"]
+    "relatedConcepts": [
+      "numerical series evaluation",
+      "rapid convergence"
+    ],
+    "prerequisites": [
+      "term computations term_1 through term_3"
+    ]
   },
   {
     "id": "ann-1050-borwein",
     "proofId": "erdos-1050",
-    "range": { "startLine": 104, "endLine": 108 },
     "type": "context",
     "title": "Borwein's Theorem",
     "content": "**borwein_irrationality (1991)**: ∑ 1/(q^n + r) is irrational for integer q ≥ 2, rational r ≠ 0, and r ≠ -q^n for any n ≥ 1.\n\nAxiomatized from Borwein's 1991 paper in Math. Proc. Cambridge Philos. Soc. The proof constructs Padé-type rational approximants to the q-logarithm function whose convergence rate forces irrationality.",
     "significance": "key",
     "mathContext": "Borwein's proof technique uses Padé approximation to the function -log_q(1 + r/q^n), constructing sequences of rationals p_k/q_k with |S - p_k/q_k| < c^k/q_k for some c < 1. If S = a/b were rational, then |S - p_k/q_k| ≥ 1/(b·q_k) for p_k/q_k ≠ S, contradicting the exponential convergence for large k. This is a generalization of Apéry's method and extends Erdős's 1948 approach which worked only for integer r.",
-    "relatedConcepts": ["Padé approximation", "irrationality measure", "Apéry's method", "q-logarithm"],
-    "prerequisites": ["convergence of T(q,r)", "rational approximation theory"]
+    "relatedConcepts": [
+      "Padé approximation",
+      "irrationality measure",
+      "Apéry's method",
+      "q-logarithm"
+    ],
+    "prerequisites": [
+      "convergence of T(q,r)",
+      "rational approximation theory"
+    ]
   },
   {
     "id": "ann-1050-S-irr",
     "proofId": "erdos-1050",
-    "range": { "startLine": 110, "endLine": 139 },
     "type": "technique",
     "title": "S is Irrational",
     "content": "**S_irrational**: ∑ 1/(2^n - 3) is irrational.\n\nApplies Borwein's theorem with q = 2, r = -3. The verification that -3 ≠ -2^n for any n uses the fact that 3 is not a power of 2 (since 2^n ∈ {2, 4, 8, 16, ...} never equals 3).",
     "significance": "key",
     "mathContext": "This is the answer to Erdős Problem #1050. The irrationality of S follows immediately from Borwein's general theorem once the pole-avoidance condition is verified. The verification is elementary: 2^n takes values 2, 4, 8, 16, ... (all even except 2^0 = 1), and 3 is not among them.",
-    "relatedConcepts": ["instantiation of general irrationality theorems", "pole avoidance"],
-    "prerequisites": ["borwein_irrationality", "S_summable", "3 is not a power of 2"]
+    "relatedConcepts": [
+      "instantiation of general irrationality theorems",
+      "pole avoidance"
+    ],
+    "prerequisites": [
+      "borwein_irrationality",
+      "S_summable",
+      "3 is not a power of 2"
+    ]
   },
   {
     "id": "ann-1050-2n-1",
     "proofId": "erdos-1050",
-    "range": { "startLine": 147, "endLine": 164 },
     "type": "technique",
     "title": "∑ 1/(2^n - 1)",
     "content": "**sum_2n_minus_1_irrational**: ∑ 1/(2^n - 1) is irrational.\n\nThis is Erdős's original 1948 result, now recovered as the special case T(2, -1) of Borwein's theorem. The sum ∑ 1/(2^n - 1) = 1 + 1/3 + 1/7 + 1/15 + ... ≈ 1.607 is the Erdős-Borwein constant.",
     "significance": "key",
     "mathContext": "Erdős's 1948 proof in the Journal of the Indian Mathematical Society used different techniques from Borwein: he exploited the identity ∑ 1/(2^n - 1) = ∑ τ(n)/2^n (where τ is the divisor function) and used properties of τ to rule out rationality. Borwein's approach is more general but less elementary. The Erdős-Borwein constant E = ∑ 1/(2^n - 1) ≈ 1.60669 appears in digital sum problems and binary representations.",
-    "relatedConcepts": ["Erdős-Borwein constant", "divisor function identity", "Lambert series"],
-    "prerequisites": ["borwein_irrationality", "1 is not a power of 2"]
+    "relatedConcepts": [
+      "Erdős-Borwein constant",
+      "divisor function identity",
+      "Lambert series"
+    ],
+    "prerequisites": [
+      "borwein_irrationality",
+      "1 is not a power of 2"
+    ]
   },
   {
     "id": "ann-1050-2n+1",
     "proofId": "erdos-1050",
-    "range": { "startLine": 166, "endLine": 179 },
     "type": "technique",
     "title": "∑ 1/(2^n + 1)",
     "content": "**sum_2n_plus_1_irrational**: ∑ 1/(2^n + 1) is irrational.\n\nApplies Borwein's theorem with q = 2, r = 1. The condition r ≠ -q^n is automatic since 1 > 0 while -2^n < 0.",
     "significance": "supporting",
     "mathContext": "The sum ∑ 1/(2^n + 1) = 1/3 + 1/5 + 1/9 + 1/17 + ... ≈ 0.7645 is the 'alternating companion' to the Erdős-Borwein constant. The identity ∑ 1/(2^n - 1) - ∑ 1/(2^n + 1) = ∑ 2/(2^{2n} - 1) shows these two constants are related via a series with squared exponential denominators.",
-    "relatedConcepts": ["companion series", "difference of reciprocal series"],
-    "prerequisites": ["borwein_irrationality"]
+    "relatedConcepts": [
+      "companion series",
+      "difference of reciprocal series"
+    ],
+    "prerequisites": [
+      "borwein_irrationality"
+    ]
   },
   {
     "id": "ann-1050-3n-1",
     "proofId": "erdos-1050",
-    "range": { "startLine": 181, "endLine": 200 },
     "type": "technique",
     "title": "∑ 1/(3^n - 1)",
     "content": "**sum_3n_minus_1_irrational**: ∑ 1/(3^n - 1) is irrational.\n\nExtends to base q = 3 with r = -1. The sum = 1/2 + 1/8 + 1/26 + 1/80 + ... ≈ 0.6634. Verification: 1 ≠ 3^n for any n ≥ 1 since 3^n ≥ 3.",
     "significance": "supporting",
     "mathContext": "Changing the base from 2 to 3 gives a different constant with the same irrationality proof structure. The identity ∑ 1/(3^n - 1) = ∑ τ₃(n)/3^n (where τ₃ counts 'ternary divisors') generalizes the Erdős divisor identity to other bases, connecting to Problem #1049's framework.",
-    "relatedConcepts": ["base-3 Lambert series", "generalized divisor functions"],
-    "prerequisites": ["borwein_irrationality"]
+    "relatedConcepts": [
+      "base-3 Lambert series",
+      "generalized divisor functions"
+    ],
+    "prerequisites": [
+      "borwein_irrationality"
+    ]
   },
   {
     "id": "ann-1050-general",
     "proofId": "erdos-1050",
-    "range": { "startLine": 202, "endLine": 205 },
     "type": "technique",
     "title": "General Case",
     "content": "**general_irrational**: ∑ 1/(q^n + r) is irrational for all valid q ≥ 2 and rational r ≠ 0, r ≠ -q^n.\n\nThe full generality of Borwein's theorem instantiated: for any choice of parameters satisfying the hypotheses, the resulting series is irrational.",
     "significance": "key",
     "mathContext": "This gives an infinite family of irrational numbers, parametrized by (q, r). The excluded values r = -q^n (which produce divergent series) form a countable set, so 'almost all' rational shifts r produce irrational sums. Borwein's theorem does not give irrationality measures; the question of how irrational these numbers are (their irrationality exponent) remains open.",
-    "relatedConcepts": ["irrationality exponent", "parametric irrationality results"],
-    "prerequisites": ["borwein_irrationality", "T_summable"]
+    "relatedConcepts": [
+      "irrationality exponent",
+      "parametric irrationality results"
+    ],
+    "prerequisites": [
+      "borwein_irrationality",
+      "T_summable"
+    ]
   },
   {
     "id": "ann-1050-trans-conj",
     "proofId": "erdos-1050",
-    "range": { "startLine": 213, "endLine": 216 },
     "type": "definition",
     "title": "Transcendence Conjecture",
     "content": "**ErdosTranscendenceConjecture**: ∑ 1/(2^n + t) is transcendental for integer t ≠ 0.\n\nErdős's stronger conjecture, going beyond irrationality to transcendence. If true, these numbers are not roots of any polynomial with integer coefficients. Status: OPEN.",
     "significance": "key",
     "mathContext": "Transcendence is strictly stronger than irrationality: every transcendental number is irrational but not conversely (√2 is irrational but algebraic). The conjecture would place all T(2, t) for t ≠ 0 in the same class as e and π. Progress toward transcendence would likely require Mahler's method or the Nesterenko-Zudilin framework for q-series, which has proved transcendence for related theta-function values.",
-    "relatedConcepts": ["Mahler's method", "transcendence theory", "q-series", "Nesterenko-Zudilin"],
-    "prerequisites": ["definition of transcendental number", "Borwein's irrationality result"]
+    "relatedConcepts": [
+      "Mahler's method",
+      "transcendence theory",
+      "q-series",
+      "Nesterenko-Zudilin"
+    ],
+    "prerequisites": [
+      "definition of transcendental number",
+      "Borwein's irrationality result"
+    ]
   },
   {
     "id": "ann-1050-gen-trans",
     "proofId": "erdos-1050",
-    "range": { "startLine": 218, "endLine": 222 },
     "type": "definition",
     "title": "General Transcendence",
     "content": "**GeneralTranscendenceConjecture**: T(q, r) is transcendental for all valid integer q ≥ 2 and rational r ≠ 0.\n\nThe general form extending Erdős's conjecture to all bases q and all rational shifts r.",
     "significance": "key",
     "mathContext": "This is a vast generalization of Erdős's specific conjecture. Even for the simplest case T(2, -1) = ∑ 1/(2^n - 1) (the Erdős-Borwein constant), transcendence is unknown. The strongest known results toward this use Nishioka's theorem on Mahler functions, which proves transcendence for certain q-hypergeometric series but does not directly apply to T(q, r).",
-    "relatedConcepts": ["Nishioka's theorem", "Mahler functions", "algebraic independence"],
-    "prerequisites": ["definition of transcendental number"]
+    "relatedConcepts": [
+      "Nishioka's theorem",
+      "Mahler functions",
+      "algebraic independence"
+    ],
+    "prerequisites": [
+      "definition of transcendental number"
+    ]
   },
   {
     "id": "ann-1050-trans-implies",
     "proofId": "erdos-1050",
-    "range": { "startLine": 224, "endLine": 230 },
     "type": "technique",
     "title": "Transcendence Implies Irrationality",
     "content": "**transcendence_implies_irrationality**: If T(q,r) is transcendental, then it is irrational.\n\nEvery transcendental number is irrational (since every rational number is algebraic: a/b is a root of bx - a = 0). So the transcendence conjecture strictly strengthens Borwein's theorem.",
     "significance": "supporting",
     "mathContext": "This is a basic fact in number theory: the hierarchy is ℚ ⊂ algebraic numbers ⊂ ℝ, with transcendental = ℝ \\ algebraic. The transcendence conjecture would give strictly more information than Borwein's irrationality result.",
-    "relatedConcepts": ["algebraic number", "number field hierarchy"],
-    "prerequisites": ["definition of transcendental and irrational"]
+    "relatedConcepts": [
+      "algebraic number",
+      "number field hierarchy"
+    ],
+    "prerequisites": [
+      "definition of transcendental and irrational"
+    ]
   },
   {
     "id": "ann-1050-status",
     "proofId": "erdos-1050",
-    "range": { "startLine": 232, "endLine": 235 },
     "type": "context",
     "title": "Conjecture Status",
     "content": "**transcendence_conjecture_status**: The transcendence conjecture for ∑ 1/(q^n + r) remains open as of 2026.\n\nRecorded as an axiom for documentation purposes. No progress beyond irrationality has been established for any T(q, r).",
     "significance": "supporting",
     "mathContext": "The gap between irrationality (proved by Borwein 1991) and transcendence (conjectured by Erdős) has remained unbridged for over 35 years, suggesting fundamentally new methods are needed.",
-    "relatedConcepts": ["open problems in transcendence theory"],
+    "relatedConcepts": [
+      "open problems in transcendence theory"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-S1049",
     "proofId": "erdos-1050",
-    "range": { "startLine": 243, "endLine": 245 },
     "type": "definition",
     "title": "Problem #1049 Series",
     "content": "**S_1049 t**: S(t) = ∑ 1/(t^n - 1) from Problem #1049.\n\nThis equals T(t, -1) in the T(q,r) parametrization. Problem #1049 asks about irrationality of S(t) for rational t > 1, while #1050 handles the general shift r.",
     "significance": "supporting",
     "mathContext": "The connection S(t) = T(t, -1) shows that Problem #1049 is a special case of the family studied in #1050. Erdős proved S(t) irrational for integer t ≥ 2 using the divisor function identity ∑ 1/(t^n - 1) = ∑ τ(n)/t^n. Borwein's theorem recovers this and extends to all rational r.",
-    "relatedConcepts": ["Problem #1049 connection", "divisor function identity"],
-    "prerequisites": ["T(q,r) definition", "Problem #1049 series"]
+    "relatedConcepts": [
+      "Problem #1049 connection",
+      "divisor function identity"
+    ],
+    "prerequisites": [
+      "T(q,r) definition",
+      "Problem #1049 series"
+    ]
   },
   {
     "id": "ann-1050-T-eq-S1049",
     "proofId": "erdos-1050",
-    "range": { "startLine": 247, "endLine": 249 },
     "type": "technique",
     "title": "Connection",
     "content": "**T_eq_S_1049**: T(q, -1) = S_1049(q) = ∑ 1/(q^n - 1).\n\nEstablishes the formal equivalence between the r = -1 case of T(q, r) and the series from Problem #1049. This makes explicit that Borwein's theorem subsumes Erdős's 1948 result.",
     "significance": "key",
     "mathContext": "This identity is purely algebraic: 1/(q^n + (-1)) = 1/(q^n - 1). Its significance is structural — it connects two problems in Erdős's catalogue and shows that Borwein's framework provides a unified approach to both.",
-    "relatedConcepts": ["problem interconnection", "parameter specialization"],
-    "prerequisites": ["T(q,r) definition", "S_1049 definition"]
+    "relatedConcepts": [
+      "problem interconnection",
+      "parameter specialization"
+    ],
+    "prerequisites": [
+      "T(q,r) definition",
+      "S_1049 definition"
+    ]
   },
   {
     "id": "ann-1050-related",
     "proofId": "erdos-1050",
-    "range": { "startLine": 251, "endLine": 256 },
     "type": "technique",
     "title": "Problems Related",
     "content": "**problems_related**: Both T(q, -1) = ∑ 1/(q^n - 1) and T(q, r) = ∑ 1/(q^n + r) are irrational for valid parameters.\n\nShows that Problem #1049 and #1050 share the same resolution method via Borwein's theorem.",
     "significance": "supporting",
     "mathContext": "The unification through Borwein's theorem illustrates a common phenomenon in number theory: initially distinct irrationality questions often yield to a single, more general technique (here, Padé approximation to q-logarithms).",
-    "relatedConcepts": ["unification of irrationality results"],
-    "prerequisites": ["borwein_irrationality", "T_eq_S_1049"]
+    "relatedConcepts": [
+      "unification of irrationality results"
+    ],
+    "prerequisites": [
+      "borwein_irrationality",
+      "T_eq_S_1049"
+    ]
   },
   {
     "id": "ann-1050-approx",
     "proofId": "erdos-1050",
-    "range": { "startLine": 264, "endLine": 265 },
     "type": "context",
     "title": "Approximation",
     "content": "**S_approx**: 0.286 < S < 0.288, so S ≈ 0.287.\n\nAxiomatized numerical bounds. Verified by computing the first ~10 terms: S ≈ 0 + 1/5 + 1/13 + 1/29 + 1/61 + 1/125 + ... ≈ 0.28719.",
     "significance": "supporting",
     "mathContext": "The rapid convergence (terms decay as 1/2^n) means just 10 terms give accuracy to within 10⁻³. The value 0.287... does not match any known closed-form expression, consistent with the transcendence conjecture.",
-    "relatedConcepts": ["numerical series evaluation", "decimal expansion"],
-    "prerequisites": ["S_summable", "first terms computation"]
+    "relatedConcepts": [
+      "numerical series evaluation",
+      "decimal expansion"
+    ],
+    "prerequisites": [
+      "S_summable",
+      "first terms computation"
+    ]
   },
   {
     "id": "ann-1050-positive",
     "proofId": "erdos-1050",
-    "range": { "startLine": 267, "endLine": 270 },
     "type": "technique",
     "title": "S Positive",
     "content": "**S_positive**: S > 0.\n\nDespite the first term being -1, the series sums to a positive value. This follows from the exact cancellation of the first two terms (-1 + 1 = 0) and the positivity of all subsequent terms (1/5 + 1/13 + ... > 0).",
     "significance": "supporting",
     "mathContext": "The positivity is needed for the numerical bounds S ∈ (0.286, 0.288) and confirms the series is a well-defined positive real constant, not merely a formal series.",
-    "relatedConcepts": ["sign analysis of series", "positivity from tail domination"],
-    "prerequisites": ["S_first_terms"]
+    "relatedConcepts": [
+      "sign analysis of series",
+      "positivity from tail domination"
+    ],
+    "prerequisites": [
+      "S_first_terms"
+    ]
   },
   {
     "id": "ann-1050-lt-one",
     "proofId": "erdos-1050",
-    "range": { "startLine": 272, "endLine": 275 },
     "type": "technique",
     "title": "S < 1",
     "content": "**S_lt_one**: S < 1.\n\nAfter the cancellation of -1 + 1 = 0, the remaining series 1/5 + 1/13 + 1/29 + ... < 1/5 · (1 + 1/2 + 1/4 + ...) = 1/5 · 2 = 2/5 < 1.",
     "significance": "supporting",
     "mathContext": "The bound S < 1 combined with S > 0 places S in the unit interval (0, 1). More precisely, S ≈ 0.287 is closer to 0 than to 1.",
-    "relatedConcepts": ["series upper bounds", "geometric series comparison"],
-    "prerequisites": ["S_positive", "comparison with geometric series"]
+    "relatedConcepts": [
+      "series upper bounds",
+      "geometric series comparison"
+    ],
+    "prerequisites": [
+      "S_positive",
+      "comparison with geometric series"
+    ]
   },
   {
     "id": "ann-1050-partial",
     "proofId": "erdos-1050",
-    "range": { "startLine": 277, "endLine": 282 },
     "type": "technique",
     "title": "Partial Sums",
     "content": "**partial_sums_converge**: The partial sums Sₙ = ∑_{k=1}^{n} 1/(2^k - 3) converge to S.\n\nStandard convergence statement relating finite partial sums to the infinite series via Mathlib's tsum machinery.",
     "significance": "supporting",
     "mathContext": "In Mathlib, tsum is defined as the limit of partial sums when the series is summable (HasSum). This theorem establishes the standard limit relationship, enabling passage between finite and infinite computations.",
-    "relatedConcepts": ["HasSum", "tsum", "partial sum convergence"],
-    "prerequisites": ["S_summable"]
+    "relatedConcepts": [
+      "HasSum",
+      "tsum",
+      "partial sum convergence"
+    ],
+    "prerequisites": [
+      "S_summable"
+    ]
   },
   {
     "id": "ann-1050-oeis",
     "proofId": "erdos-1050",
-    "range": { "startLine": 290, "endLine": 293 },
     "type": "definition",
     "title": "OEIS Sequence",
     "content": "**oeis_A331372**: The denominator sequence 2^n - 3 for n ≥ 1.\n\nRelated to OEIS sequence A331372. Values: -1, 1, 5, 13, 29, 61, 125, 253, 509, 1021, ...",
     "significance": "supporting",
     "mathContext": "The OEIS connection provides a bridge to computational number theory. The sequence 2^n - 3 is a shifted Mersenne sequence (Mersenne numbers are 2^n - 1). Like Mersenne numbers, primality of 2^n - 3 is studied: 2^n - 3 is prime for n = 3, 4, 5, 9, 17, ... (no simple pattern).",
-    "relatedConcepts": ["OEIS", "Mersenne numbers", "shifted exponential sequences"],
+    "relatedConcepts": [
+      "OEIS",
+      "Mersenne numbers",
+      "shifted exponential sequences"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-1050-denom-seq",
     "proofId": "erdos-1050",
-    "range": { "startLine": 295, "endLine": 298 },
     "type": "technique",
     "title": "Denominator Sequence",
     "content": "**denom_sequence**: oeis_A331372(n) = 2^n - 3 for n ≥ 1.\n\nVerifies the sequence definition matches the OEIS entry.",
     "significance": "supporting",
     "mathContext": "This is a definitional verification linking the formal Lean definition to the external database.",
-    "relatedConcepts": ["sequence verification"],
-    "prerequisites": ["oeis_A331372 definition"]
+    "relatedConcepts": [
+      "sequence verification"
+    ],
+    "prerequisites": [
+      "oeis_A331372 definition"
+    ]
   },
   {
     "id": "ann-1050-growth",
     "proofId": "erdos-1050",
-    "range": { "startLine": 300, "endLine": 303 },
     "type": "technique",
     "title": "Exponential Growth",
     "content": "**denom_growth**: For n ≥ 3, 2^n - 3 > 2^(n-1).\n\nThe denominators grow exponentially, ensuring the series terms 1/(2^n - 3) decay at rate 1/2^n. This is stronger than polynomial growth and guarantees rapid convergence.",
     "significance": "supporting",
     "mathContext": "The growth rate 2^n - 3 ~ 2^n means the terms 1/(2^n - 3) ~ 1/2^n, so the series converges at the same rate as the geometric series ∑ 1/2^n. The error from truncating after N terms is O(1/2^N).",
-    "relatedConcepts": ["exponential growth", "convergence rate", "truncation error"],
-    "prerequisites": ["basic properties of 2^n"]
+    "relatedConcepts": [
+      "exponential growth",
+      "convergence rate",
+      "truncation error"
+    ],
+    "prerequisites": [
+      "basic properties of 2^n"
+    ]
   },
   {
     "id": "ann-1050-main",
     "proofId": "erdos-1050",
-    "range": { "startLine": 311, "endLine": 321 },
     "type": "technique",
     "title": "Main Result",
     "content": "**erdos_1050**: ∑ 1/(2^n - 3) is irrational.\n\nThe complete answer to Erdős Problem #1050, solved by Peter Borwein (1991). Follows from S_irrational which applies borwein_irrationality with q = 2, r = -3. The transcendence conjecture (is S transcendental?) remains OPEN.",
     "significance": "key",
     "mathContext": "This is the capstone theorem unifying the entire formalization. It chains: T(q,r) definition → convergence → Borwein's theorem (axiom) → pole avoidance verification → irrationality of S. The problem is fully resolved for irrationality but the stronger transcendence question posed by Erdős remains one of the outstanding open problems in analytic number theory.",
-    "relatedConcepts": ["capstone theorem", "problem resolution"],
-    "prerequisites": ["S_irrational", "borwein_irrationality"]
+    "relatedConcepts": [
+      "capstone theorem",
+      "problem resolution"
+    ],
+    "prerequisites": [
+      "S_irrational",
+      "borwein_irrationality"
+    ]
   },
   {
     "id": "ann-1050-answer",
     "proofId": "erdos-1050",
-    "range": { "startLine": 323, "endLine": 329 },
     "type": "definition",
     "title": "Final Answer",
     "content": "**erdos_1050_answer**: \"SOLVED: ∑ 1/(2^n - 3) is irrational (Borwein 1991)\"\n\n**erdos_1050_status**: \"SOLVED by Peter Borwein (1991)\"",
     "significance": "key",
     "mathContext": "Erdős Problem #1050 joins the resolved problems in his catalogue. The resolution came 43 years after Erdős's initial 1948 work on related series, through Borwein's generalization of the techniques.",
-    "relatedConcepts": ["Erdős problem catalogue"],
-    "prerequisites": ["erdos_1050"]
+    "relatedConcepts": [
+      "Erdős problem catalogue"
+    ],
+    "prerequisites": [
+      "erdos_1050"
+    ]
   },
   {
     "id": "ann-1050-borwein-thm",
     "proofId": "erdos-1050",
-    "range": { "startLine": 331, "endLine": 334 },
     "type": "technique",
     "title": "Borwein's Full Theorem",
     "content": "**borwein_theorem**: ∑ 1/(q^n + r) is irrational for integer q ≥ 2, rational r ≠ 0, and r ≠ -q^n for any n.\n\nThe complete restatement of Borwein's 1991 result, emphasizing it covers rational (not just integer) shifts r. This extends the theorem's reach beyond what Erdős originally asked.",
     "significance": "key",
     "mathContext": "The extension from integer to rational r is significant: for r = p/q' with q' > 1, the series T(q, p/q') = ∑ q'/(q'·q^n + p) involves integer denominators but non-integer coefficients when rewritten. Borwein's Padé approximation technique handles this uniformly, making the rationality of r irrelevant to the proof structure.",
-    "relatedConcepts": ["rational parameter extension", "Padé approximation uniformity"],
-    "prerequisites": ["borwein_irrationality"]
+    "relatedConcepts": [
+      "rational parameter extension",
+      "Padé approximation uniformity"
+    ],
+    "prerequisites": [
+      "borwein_irrationality"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-220/annotations.json
+++ b/src/data/proofs/erdos-220/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-220-header",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 1,
-      "endLine": 30
-    },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #220 ($500)**\n\nFor reduced residues a₁ < ⋯ < a_{φ(n)} mod n, is ∑(a_{k+1}-a_k)² ≪ n²/φ(n)?\n\n**Status:** SOLVED (Montgomery-Vaughan 1986)",
@@ -20,10 +16,6 @@
   {
     "id": "ann-220-residues",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 50,
-      "endLine": 52
-    },
     "type": "definition",
     "title": "Reduced Residues",
     "content": "**reducedResidues n:**\n\n{m : 1 ≤ m < n, gcd(m,n) = 1}\n\nThe set of integers in [1, n-1] that are coprime to n. Has exactly φ(n) elements.",
@@ -38,10 +30,6 @@
   {
     "id": "ann-220-cardinality",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 54,
-      "endLine": 57
-    },
     "type": "technique",
     "title": "Cardinality Equals φ(n)",
     "content": "**card_reducedResidues:**\n\n|reducedResidues n| = φ(n)\n\nThis is essentially the definition of Euler's totient function.",
@@ -55,10 +43,6 @@
   {
     "id": "ann-220-sorted",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 59,
-      "endLine": 65
-    },
     "type": "definition",
     "title": "Sorted Residues",
     "content": "**sortedResidues n, a n k:**\n\nThe reduced residues sorted in increasing order, and the k-th element.\n\nWritten as a₁ < a₂ < ⋯ < a_{φ(n)}.",
@@ -72,10 +56,6 @@
   {
     "id": "ann-220-gap",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 71,
-      "endLine": 73
-    },
     "type": "definition",
     "title": "Gap Definition",
     "content": "**gap n k:**\n\na_{k+1} - a_k\n\nThe difference between consecutive reduced residues.",
@@ -89,10 +69,6 @@
   {
     "id": "ann-220-gaplist",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 75,
-      "endLine": 77
-    },
     "type": "definition",
     "title": "Gap List",
     "content": "**gapList n:**\n\nThe list of all gaps [gap(0), gap(1), ..., gap(φ(n)-2)].\n\nThere are φ(n) - 1 gaps between φ(n) elements.",
@@ -106,10 +82,6 @@
   {
     "id": "ann-220-sumpowers",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 83,
-      "endLine": 89
-    },
     "type": "definition",
     "title": "Sum of Gap Powers",
     "content": "**sumGapPowers n γ:**\n\n∑_{k=1}^{φ(n)-1} (a_{k+1} - a_k)^γ\n\nThe sum of γ-th powers of all gaps.\n\n**sumSquaredGaps n** is the γ = 2 case.",
@@ -123,10 +95,6 @@
   {
     "id": "ann-220-bound",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 95,
-      "endLine": 97
-    },
     "type": "definition",
     "title": "The Bound n²/φ(n)",
     "content": "**boundedSquaredGaps n:**\n\nn² / φ(n)\n\nThis is the \"expected\" squared sum if all gaps were equal to average n/φ(n).",
@@ -140,10 +108,6 @@
   {
     "id": "ann-220-conjecture",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 99,
-      "endLine": 101
-    },
     "type": "definition",
     "title": "Erdős Conjecture",
     "content": "**erdos_220_conjecture:**\n\n∃C > 0: ∀n ≥ 1, ∑(gap)² ≤ C · n²/φ(n)\n\nThe squared gaps sum is at most a constant times the \"all-equal\" bound.",
@@ -157,10 +121,6 @@
   {
     "id": "ann-220-general",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 103,
-      "endLine": 109
-    },
     "type": "definition",
     "title": "General γ-Power Bound",
     "content": "**erdos_220_general:**\n\nFor any γ ≥ 1: ∑(gap)^γ ≪ n^γ/φ(n)^{γ-1}\n\nThis generalizes from squares to arbitrary powers.",
@@ -174,10 +134,6 @@
   {
     "id": "ann-220-mv-squared",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 115,
-      "endLine": 122
-    },
     "type": "concept",
     "title": "Montgomery-Vaughan (Squares)",
     "content": "**montgomery_vaughan_squared:**\n\n∃C > 0: ∀n ≥ 1, ∑(gap)² ≤ C · n²/φ(n)\n\nThe main result confirming Erdős's conjecture.",
@@ -191,10 +147,6 @@
   {
     "id": "ann-220-mv-general",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 124,
-      "endLine": 131
-    },
     "type": "concept",
     "title": "Montgomery-Vaughan (General)",
     "content": "**montgomery_vaughan_general:**\n\nFor any γ ≥ 1: ∃C > 0: ∀n ≥ 1, ∑(gap)^γ ≤ C · n^γ/φ(n)^{γ-1}\n\nThe full generalization to all powers.",
@@ -208,10 +160,6 @@
   {
     "id": "ann-220-average",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 137,
-      "endLine": 139
-    },
     "type": "definition",
     "title": "Average Gap",
     "content": "**averageGap n:**\n\nn / φ(n)\n\nWith φ(n) residues spread over [1,n-1], average spacing is n/φ(n).",
@@ -225,10 +173,6 @@
   {
     "id": "ann-220-prime",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 161,
-      "endLine": 166
-    },
     "type": "technique",
     "title": "Prime Case",
     "content": "**prime_case:**\n\nFor prime p, reduced residues are {1, 2, ..., p-1} with all gaps = 1.\n\nSum of squares = p - 2, bound = p²/(p-1) ≈ p. Bound holds easily.",
@@ -242,10 +186,6 @@
   {
     "id": "ann-220-power2",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 168,
-      "endLine": 173
-    },
     "type": "technique",
     "title": "Power of 2 Case",
     "content": "**power_of_two_case:**\n\nFor n = 2^k, residues are {1, 3, 5, ..., 2^k - 1} with all gaps = 2.\n\nSum = 2^{k+1}, bound = 2^{k+1}. The bound is TIGHT here.",
@@ -260,10 +200,6 @@
   {
     "id": "ann-220-jacobsthal",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 185,
-      "endLine": 187
-    },
     "type": "definition",
     "title": "Jacobsthal's Function",
     "content": "**jacobsthal n:**\n\nmax{gap} = maximum gap between consecutive reduced residues.\n\nRelated to the smallest prime not dividing n.",
@@ -278,10 +214,6 @@
   {
     "id": "ann-220-maxbound",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 189,
-      "endLine": 191
-    },
     "type": "concept",
     "title": "Maximum Gap Bound",
     "content": "**maximum_gap_bound:**\n\nmax(gap) ≤ C · (n/φ(n)) · (log n)²\n\nThe maximum gap is at most average times a logarithmic factor.",
@@ -295,10 +227,6 @@
   {
     "id": "ann-220-summary",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 232,
-      "endLine": 236
-    },
     "type": "technique",
     "title": "Summary Theorem",
     "content": "**erdos_220_summary:**\n\nCombines all components: Montgomery-Vaughan proved the squared gaps conjecture.\n\n∑(gap)² ≪ n²/φ(n)",
@@ -312,10 +240,6 @@
   {
     "id": "ann-220-solved",
     "proofId": "erdos-220",
-    "range": {
-      "startLine": 238,
-      "endLine": 239
-    },
     "type": "technique",
     "title": "Problem Solved",
     "content": "**erdos_220_solved:**\n\nErdős Problem #220 was completely resolved by Montgomery-Vaughan (1986).\n\nThe $500 prize problem is solved.",

--- a/src/data/proofs/erdos-625/annotations.json
+++ b/src/data/proofs/erdos-625/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-625-header",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 1,
-      "endLine": 19
-    },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #625**\n\nFor random graph G(n, 1/2), does χ(G) - ζ(G) → ∞ almost surely?\n\n**Status: OPEN**\n\n**Prize:** $1000 for FALSE, $100 for TRUE\n\nThe 2024 Heckel-Steiner breakthrough shows the difference is unbounded, but the exact asymptotic remains open.",
@@ -21,10 +17,6 @@
   {
     "id": "ann-625-cochromatic-class",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 35,
-      "endLine": 38
-    },
     "type": "definition",
     "title": "Cochromatic Color Class",
     "content": "**IsCochromaticClass G S:**\n\nA set S of vertices is cochromatic if it induces either:\n- A complete graph (all pairs adjacent), OR\n- An empty graph (no pairs adjacent)\n\nThis is the key relaxation from proper colorings, which only allow independent sets.",
@@ -39,10 +31,6 @@
   {
     "id": "ann-625-cochromatic-coloring",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 40,
-      "endLine": 43
-    },
     "type": "definition",
     "title": "Cochromatic Coloring",
     "content": "**CochromaticColoring G k:**\n\nA structure with:\n- color : V → Fin k (assignment of colors)\n- cochromatic : each color class is cochromatic\n\nEvery proper coloring is cochromatic (all classes are independent sets), but cochromatic colorings can also have clique classes.",
@@ -57,10 +45,6 @@
   {
     "id": "ann-625-cochromatic-number",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 45,
-      "endLine": 50
-    },
     "type": "definition",
     "title": "Cochromatic Number ζ(G)",
     "content": "**cochromaticNumber G:**\n\nThe minimum k such that G has a cochromatic k-coloring. Defined using Nat.find.\n\n**Properties:**\n- ζ(G) ≤ χ(G) (every proper coloring is cochromatic)\n- ζ(G) = ζ(Gᶜ) (symmetric under complement)",
@@ -75,10 +59,6 @@
   {
     "id": "ann-625-chromatic-number",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 52,
-      "endLine": 57
-    },
     "type": "definition",
     "title": "Chromatic Number χ(G)",
     "content": "**chromaticNumber G:**\n\nThe minimum k such that G has a proper k-coloring (no two adjacent vertices share a color).\n\nFor random G(n, 1/2):\nχ(G) ≤ (1+o(1))n/(2 log₂ n) almost surely.",
@@ -93,10 +73,6 @@
   {
     "id": "ann-625-proper-is-cochromatic",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 61,
-      "endLine": 64
-    },
     "type": "technique",
     "title": "Proper ⊆ Cochromatic",
     "content": "**proper_is_cochromatic:**\n\nEvery proper k-coloring is also a cochromatic k-coloring.\n\n**Proof idea:** In a proper coloring, each color class is an independent set. An independent set is trivially cochromatic (the 'empty' case).",
@@ -111,10 +87,6 @@
   {
     "id": "ann-625-le-chromatic",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 66,
-      "endLine": 69
-    },
     "type": "technique",
     "title": "ζ(G) ≤ χ(G)",
     "content": "**cochromatic_le_chromatic:**\n\nThe cochromatic number is at most the chromatic number.\n\n**Proof:** Any proper χ(G)-coloring is also cochromatic, so ζ(G) ≤ χ(G).\n\nThis is why the question χ - ζ → ∞ is interesting: how much better can cochromatic colorings be?",
@@ -129,10 +101,6 @@
   {
     "id": "ann-625-complement-le",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 71,
-      "endLine": 74
-    },
     "type": "technique",
     "title": "Complement Inequality",
     "content": "**cochromatic_complement:**\n\nζ(G) ≤ ζ(Gᶜ) for any graph G.\n\nThis follows from the symmetry of the cochromatic condition under swapping 'complete' and 'empty'.",
@@ -146,10 +114,6 @@
   {
     "id": "ann-625-complement-eq",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 76,
-      "endLine": 79
-    },
     "type": "technique",
     "title": "ζ(G) = ζ(Gᶜ)",
     "content": "**cochromatic_eq_complement:**\n\nThe cochromatic number is invariant under graph complement!\n\n**Proof:** Apply cochromatic_complement in both directions.\n\nThis is a beautiful symmetry property that chromatic number lacks (χ(G) ≠ χ(Gᶜ) in general).",
@@ -164,10 +128,6 @@
   {
     "id": "ann-625-random-graph",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 83,
-      "endLine": 89
-    },
     "type": "definition",
     "title": "Random Graph Model",
     "content": "**RandomGraph n p:**\n\nThe Erdős-Rényi random graph G(n, p): n vertices, each edge included independently with probability p.\n\n**ErdosRenyi n:** G(n, 1/2) - the symmetric case where G and Gᶜ have the same distribution.",
@@ -182,10 +142,6 @@
   {
     "id": "ann-625-almost-surely",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 91,
-      "endLine": 93
-    },
     "type": "definition",
     "title": "Almost Surely",
     "content": "**AlmostSurely P:**\n\nA property P holds almost surely (a.s.) if the probability it fails goes to 0 as n → ∞.\n\nFormally: ∀ε > 0, ∃N, ∀n ≥ N, Pr[¬P(G)] < ε.\n\n(Placeholder definition - full measure theory is beyond current Mathlib scope.)",
@@ -200,10 +156,6 @@
   {
     "id": "ann-625-cochromatic-lower",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 97,
-      "endLine": 100
-    },
     "type": "technique",
     "title": "Lower Bound on ζ",
     "content": "**cochromatic_lower_bound:**\n\nAlmost surely: ζ(G) ≥ n/(2 log₂ n).\n\nThis follows from bounds on clique and independence numbers: both ω(G) and α(G) are roughly 2 log₂ n a.s.",
@@ -218,10 +170,6 @@
   {
     "id": "ann-625-bollobas",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 102,
-      "endLine": 106
-    },
     "type": "technique",
     "title": "Bollobás Upper Bound (1988)",
     "content": "**bollobas_upper_bound:**\n\nAlmost surely: χ(G) ≤ (1+o(1))n/(2 log₂ n).\n\nBollobás proved this in 1988, showing the chromatic number of G(n, 1/2) is well-concentrated.\n\nCombined with the lower bound on ζ, this gives:\nn/(2 log₂ n) ≤ ζ(G) ≤ χ(G) ≤ (1+o(1))n/(2 log₂ n)",
@@ -236,10 +184,6 @@
   {
     "id": "ann-625-sandwich",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 108,
-      "endLine": 113
-    },
     "type": "technique",
     "title": "The Sandwich Bound",
     "content": "**chromatic_cochromatic_sandwich:**\n\nAlmost surely: ζ(G) ≤ χ(G) ≤ 1.01 · n/(2 log₂ n).\n\nThis 'sandwiches' both χ and ζ in a narrow band. The main question asks: do they separate within this band?",
@@ -253,10 +197,6 @@
   {
     "id": "ann-625-main-question",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 117,
-      "endLine": 121
-    },
     "type": "definition",
     "title": "The Main Question",
     "content": "**MainQuestion:**\n\nDoes χ(G) - ζ(G) → ∞ almost surely as n → ∞?\n\nThis is the central open problem. Erdős offered prizes:\n- $100 for YES\n- $1000 for NO\n\nThe asymmetric prizes suggest Erdős believed the answer is YES.",
@@ -271,10 +211,6 @@
   {
     "id": "ann-625-main-axiom",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 123,
-      "endLine": 124
-    },
     "type": "concept",
     "title": "Main Question OPEN",
     "content": "**main_question_open:**\n\nAxiom stating the main question is true. This is a placeholder - the problem is OPEN.\n\nThe axiom allows us to state implications like: if the main question is true, then [consequence].",
@@ -289,10 +225,6 @@
   {
     "id": "ann-625-prize",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 126,
-      "endLine": 128
-    },
     "type": "definition",
     "title": "Prize Value",
     "content": "**PrizeValue answer:**\n\n- If answer = true (χ - ζ → ∞): $100\n- If answer = false: $1000\n\nThe 10:1 ratio reflects Erdős's belief that YES is more likely. He later remarked that \"$1000 was perhaps too much.\"",
@@ -306,10 +238,6 @@
   {
     "id": "ann-625-heckel-steiner",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 132,
-      "endLine": 136
-    },
     "type": "technique",
     "title": "Heckel-Steiner Unboundedness (2024)",
     "content": "**heckel_steiner_unbounded:**\n\nFor all M: almost surely χ(G) - ζ(G) ≥ M.\n\nHeckel (2024) and independently Steiner (2024) proved the difference is unbounded with high probability.\n\nThis is a major breakthrough, but doesn't fully resolve the problem (needs χ - ζ → ∞ a.s., not just unbounded w.h.p.).",
@@ -325,10 +253,6 @@
   {
     "id": "ann-625-difference-lower",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 138,
-      "endLine": 143
-    },
     "type": "technique",
     "title": "Difference Lower Bound",
     "content": "**difference_lower_bound:**\n\nFor any ε > 0, along some subsequence:\nχ - ζ ≥ n^{1/2 - ε} almost surely.\n\nThis shows the difference can grow polynomially, not just logarithmically.",
@@ -342,10 +266,6 @@
   {
     "id": "ann-625-density",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 145,
-      "endLine": 151
-    },
     "type": "technique",
     "title": "Heckel Density Result (2024)",
     "content": "**heckel_density_result:**\n\nFor any ε > 0: χ - ζ ≥ n^{1-ε} for roughly 95% of all n.\n\nThis is remarkably strong - for most n, the difference grows almost linearly!",
@@ -360,10 +280,6 @@
   {
     "id": "ann-625-heckel-conj",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 155,
-      "endLine": 160
-    },
     "type": "definition",
     "title": "Heckel's Conjecture",
     "content": "**HeckelConjecture:**\n\nχ(G) - ζ(G) ≈ n/(log n)³ with high probability.\n\nMore precisely: ∃ c₁, c₂ > 0 such that a.s.:\nc₁ · n/(log n)³ ≤ χ - ζ ≤ c₂ · n/(log n)³\n\nThis predicts the exact growth rate of the gap.",
@@ -378,10 +294,6 @@
   {
     "id": "ann-625-heckel-implies",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 165,
-      "endLine": 167
-    },
     "type": "technique",
     "title": "Heckel ⟹ Main Question",
     "content": "**heckel_implies_main:**\n\nIf Heckel's conjecture holds, then the main question has answer YES.\n\nSince n/(log n)³ → ∞ as n → ∞, the conjecture implies χ - ζ → ∞ a.s.",
@@ -395,10 +307,6 @@
   {
     "id": "ann-625-clique",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 171,
-      "endLine": 173
-    },
     "type": "definition",
     "title": "Clique Number ω(G)",
     "content": "**cliqueNumber G:**\n\nThe size of the largest clique (complete subgraph) in G.\n\nFor G(n, 1/2): ω(G) ≈ 2 log₂ n almost surely.\n\nThis is used in bounds on the cochromatic number.",
@@ -413,10 +321,6 @@
   {
     "id": "ann-625-independence",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 175,
-      "endLine": 177
-    },
     "type": "definition",
     "title": "Independence Number α(G)",
     "content": "**independenceNumber G:**\n\nThe size of the largest independent set (no edges) in G. Defined as ω(Gᶜ).\n\nFor G(n, 1/2): α(G) ≈ 2 log₂ n almost surely.\n\nBy symmetry of G(n, 1/2), α and ω have the same distribution.",
@@ -431,10 +335,6 @@
   {
     "id": "ann-625-clique-independence-bound",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 179,
-      "endLine": 184
-    },
     "type": "technique",
     "title": "Clique/Independence Bound",
     "content": "**clique_independence_bound:**\n\nAlmost surely: ω(G), α(G) ≤ 2.1 · log₂ n.\n\nThese bounds are tight: ω ≈ α ≈ 2 log₂ n.\n\nThis limits how much each color class can cover, giving the lower bound on ζ.",
@@ -449,10 +349,6 @@
   {
     "id": "ann-625-cochromatic-clique-independence",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 186,
-      "endLine": 189
-    },
     "type": "technique",
     "title": "ζ ≥ n/(ω + α)",
     "content": "**cochromatic_clique_independence:**\n\nζ(G) · (ω(G) + α(G)) ≥ n.\n\nThus: ζ(G) ≥ n / (ω(G) + α(G)).\n\n**Proof idea:** Each color class has size at most max(ω, α) ≤ ω + α. So we need at least n/(ω + α) classes.",
@@ -466,10 +362,6 @@
   {
     "id": "ann-625-chromatic-concentration",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 193,
-      "endLine": 197
-    },
     "type": "technique",
     "title": "Chromatic Concentration",
     "content": "**chromatic_concentration:**\n\nAlmost surely: χ(G) lies in an interval of width O(n/log²n) around its mean.\n\nThe chromatic number is concentrated, but the exact width of concentration is still being refined.",
@@ -484,10 +376,6 @@
   {
     "id": "ann-625-cochromatic-concentration",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 199,
-      "endLine": 203
-    },
     "type": "technique",
     "title": "Cochromatic Concentration",
     "content": "**cochromatic_concentration:**\n\nAlmost surely: ζ(G) lies in an interval of width O(n/log n) around its mean.\n\nLess is known about concentration of ζ than χ. Better bounds might help resolve the main question.",
@@ -501,10 +389,6 @@
   {
     "id": "ann-625-known-summary",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 237,
-      "endLine": 243
-    },
     "type": "technique",
     "title": "Summary of Known Results",
     "content": "**known_summary:**\n\nCombines the two key structural properties:\n1. ζ(G) ≤ χ(G) for all G\n2. ζ(G) = ζ(Gᶜ) for all G\n\nThese are the foundational facts about the cochromatic number.",
@@ -518,10 +402,6 @@
   {
     "id": "ann-625-problem-status",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 245,
-      "endLine": 249
-    },
     "type": "technique",
     "title": "Problem Status",
     "content": "**problem_status:**\n\nThe Heckel-Steiner unboundedness result implies χ and ζ are not always equal.\n\nHowever, the main question (whether χ - ζ → ∞ a.s.) remains OPEN despite significant recent progress.",
@@ -535,10 +415,6 @@
   {
     "id": "ann-625-summary",
     "proofId": "erdos-625",
-    "range": {
-      "startLine": 253,
-      "endLine": 272
-    },
     "type": "concept",
     "title": "File Summary",
     "content": "**Summary of Erdős Problem #625 Formalization:**\n\n**Status:** OPEN (Prize: $1000 false / $100 true)\n\n**Main Question:** χ(G) - ζ(G) → ∞ a.s. for G(n, 1/2)?\n\n**Known Results:**\n- ζ ≤ χ ≤ (1+o(1))n/(2 log₂ n) a.s.\n- Heckel/Steiner 2024: difference unbounded\n- Heckel conjecture: χ - ζ ≈ n/(log n)³\n\n**Key sorries:** cochromatic_le_chromatic, heckel_steiner_unbounded, main_question_open",

--- a/src/data/proofs/erdos-633/annotations.json
+++ b/src/data/proofs/erdos-633/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-e633-triangle-struct",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 39,
-      "endLine": 50
-    },
     "type": "definition",
     "title": "Triangle Structure",
     "content": "A triangle is represented by three positive real side lengths $(a, b, c)$ satisfying the **triangle inequality**: $a + b > c$, $b + c > a$, $c + a > b$. This ensures the sides can actually form a non-degenerate triangle in the plane.",
@@ -24,10 +20,6 @@
   {
     "id": "ann-e633-triangle-angles",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 52,
-      "endLine": 60
-    },
     "type": "definition",
     "title": "Triangle by Angles",
     "content": "An alternative representation using three angles $(\\alpha, \\beta, \\gamma)$ in radians, with each angle in $(0, \\pi)$ and $\\alpha + \\beta + \\gamma = \\pi$. This representation is essential for the integral independence condition, which constrains dissection possibilities through angle relationships.",
@@ -46,10 +38,6 @@
   {
     "id": "ann-e633-heron",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 62,
-      "endLine": 65
-    },
     "type": "definition",
     "title": "Heron's Formula",
     "content": "The area of a triangle with sides $a, b, c$: $\\text{Area} = \\sqrt{s(s-a)(s-b)(s-c)}$ where $s = (a+b+c)/2$ is the semi-perimeter. This is key for dissection counting: $n$ congruent pieces each have area $\\text{Area}(T)/n$, constraining the scaling factor to $1/\\sqrt{n}$.",
@@ -68,10 +56,6 @@
   {
     "id": "ann-e633-dissection",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 69,
-      "endLine": 74
-    },
     "type": "definition",
     "title": "Congruent Dissection",
     "content": "A **congruent dissection** of $T$ into $n$ copies of $S$ requires area compatibility ($\\text{Area}(T) = n \\times \\text{Area}(S)$) and that the pieces $S$ are congruent (same shape and size). The pieces must tile $T$ exactly with no gaps or overlaps. In practice, the pieces are similar to $T$ with scaling factor $1/\\sqrt{n}$.",
@@ -91,10 +75,6 @@
   {
     "id": "ann-e633-can-dissect",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 76,
-      "endLine": 78
-    },
     "type": "definition",
     "title": "Can Dissect Into",
     "content": "The predicate `CanDissectInto T n` asserts that triangle $T$ can be divided into exactly $n$ congruent triangular pieces. This is the core relation: for which $n$ does a valid dissection of $T$ into $n$ congruent copies exist?",
@@ -113,10 +93,6 @@
   {
     "id": "ann-e633-dissection-counts",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 80,
-      "endLine": 82
-    },
     "type": "definition",
     "title": "Dissection Counts",
     "content": "The set of all valid dissection counts for a triangle $T$: $\\text{DissectionCounts}(T) = \\{n \\geq 1 : T \\text{ can be dissected into } n \\text{ congruent pieces}\\}$. The problem asks: for which $T$ is this set exactly $\\{1, 4, 9, 16, 25, \\ldots\\}$ (the perfect squares)?",
@@ -133,10 +109,6 @@
   {
     "id": "ann-e633-is-square",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 86,
-      "endLine": 87
-    },
     "type": "definition",
     "title": "Perfect Square",
     "content": "A natural number $n$ is a **perfect square** if $n = k^2$ for some $k \\in \\mathbb{N}$. The sequence $1, 4, 9, 16, 25, 36, \\ldots$ These are exactly the achievable dissection counts for the grid construction.",
@@ -153,10 +125,6 @@
   {
     "id": "ann-e633-square-only",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 89,
-      "endLine": 92
-    },
     "type": "definition",
     "title": "Square-Only Property",
     "content": "A triangle has the **square-only property** if every valid dissection count is a perfect square: $\\forall n \\in \\text{DissectionCounts}(T),\\ \\exists k,\\ n = k^2$. This is the restrictive property Erdős asked to classify — triangles where the grid subdivision is the ONLY way to dissect into congruent copies.",
@@ -175,10 +143,6 @@
   {
     "id": "ann-e633-universal",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 100,
-      "endLine": 103
-    },
     "type": "technique",
     "title": "Universal Square Dissections",
     "content": "**Every triangle can be dissected into $n^2$ congruent triangles for any $n \\geq 1$.** The construction: divide each side into $n$ equal parts and connect corresponding division points to form an $n \\times n$ grid of $n^2$ similar (and congruent) sub-triangles, each scaled by factor $1/n$. This shows square numbers are always achievable; the question is whether NON-square numbers are also achievable.",
@@ -198,10 +162,6 @@
   {
     "id": "ann-e633-soifer-def",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 115,
-      "endLine": 145
-    },
     "type": "definition",
     "title": "Soifer's Triangle",
     "content": "**Soifer's Example:** The triangle with sides $\\sqrt{2}, \\sqrt{3}, \\sqrt{4} = 2$. This satisfies the triangle inequality ($\\sqrt{2} + \\sqrt{3} > 2$, etc.) and has angles that are 'integrally independent' over $\\pi$. Soifer proved this triangle can ONLY be dissected into square numbers of congruent pieces — the irrational side lengths constrain possible tilings so severely that only the grid construction works.",
@@ -220,10 +180,6 @@
   {
     "id": "ann-e633-soifer-thm",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 147,
-      "endLine": 149
-    },
     "type": "technique",
     "title": "Soifer's Theorem",
     "content": "**soifer_square_only** (sorry): The triangle $(\\sqrt{2}, \\sqrt{3}, \\sqrt{4})$ has the square-only property. The proof involves careful analysis of how the irrational side lengths constrain possible tilings — any dissection must respect the algebraic relationships between sides, forcing the count to be a perfect square.",
@@ -242,10 +198,6 @@
   {
     "id": "ann-e633-integral-ind",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 153,
-      "endLine": 157
-    },
     "type": "definition",
     "title": "Integral Independence",
     "content": "Angles $\\alpha, \\beta, \\gamma$ are **integrally independent** (modulo $\\alpha + \\beta + \\gamma = \\pi$) if: for integers $a, b, c$, $a\\alpha + b\\beta + c\\gamma = 0$ implies $a = b = c = 0$. This algebraic condition on the angles constrains how pieces can fit together in a dissection, since rotations must respect angle compatibility at each vertex.",
@@ -265,10 +217,6 @@
   {
     "id": "ann-e633-equilateral",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 171,
-      "endLine": 174
-    },
     "type": "technique",
     "title": "Equilateral Dissects to 3",
     "content": "**Counterexample to square-only:** The equilateral triangle can be dissected into 3 congruent triangles (not a perfect square!). Construction: connect the centroid to the three vertices, creating three congruent triangles with angles $30°$-$30°$-$120°$. This shows equilateral triangles do NOT have the square-only property.",
@@ -287,10 +235,6 @@
   {
     "id": "ann-e633-right-isoceles",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 176,
-      "endLine": 179
-    },
     "type": "technique",
     "title": "Right Isosceles Dissects to 2",
     "content": "**Another counterexample:** The 45-45-90 right isosceles triangle can be dissected into 2 congruent right isosceles triangles. Construction: draw the altitude from the right angle to the hypotenuse, creating two congruent copies. Since 2 is not a perfect square, this triangle does NOT have the square-only property.",
@@ -309,10 +253,6 @@
   {
     "id": "ann-e633-similar",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 188,
-      "endLine": 191
-    },
     "type": "technique",
     "title": "Similar Dissection Theorem",
     "content": "**Related result (similar, not congruent):** Every triangle can be dissected into $n$ similar triangles for $n \\neq 2, 3, 5$. Some triangles cannot be dissected into 2, 3, or 5 similar copies. This is a complete characterization for the similar case — much cleaner than the congruent case, which remains open.",
@@ -331,10 +271,6 @@
   {
     "id": "ann-e633-classification",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 201,
-      "endLine": 207
-    },
     "type": "definition",
     "title": "The Classification Problem",
     "content": "**Erdős Problem #633 (OPEN, \\$25 prize):** Find a predicate $P$ on triangles such that $\\text{HasSquareOnlyProperty}(T) \\leftrightarrow P(T)$, where $P$ is a 'nice' geometric condition (like angle relationships or side ratios). The conjecture is that integral independence of angles characterizes the square-only property, but this remains unproven.",
@@ -353,10 +289,6 @@
   {
     "id": "ann-e633-soifer-family",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 215,
-      "endLine": 220
-    },
     "type": "definition",
     "title": "Soifer's Family",
     "content": "**Generalization:** Triangles with sides $(\\sqrt{p}, \\sqrt{q}, \\sqrt{r})$ for distinct positive integers $p, q, r$ satisfying the triangle inequality form Soifer's family. The conjecture is that all such triangles have the square-only property — the algebraic independence of $\\sqrt{p}, \\sqrt{q}, \\sqrt{r}$ over $\\mathbb{Q}$ prevents non-square dissection counts.",
@@ -376,10 +308,6 @@
   {
     "id": "ann-e633-main",
     "proofId": "erdos-633",
-    "range": {
-      "startLine": 228,
-      "endLine": 232
-    },
     "type": "technique",
     "title": "Main Result: Square-Only Triangles Exist",
     "content": "**erdos_633_exists** (sorry): There exists a triangle with the square-only property, witnessed by Soifer's triangle $(\\sqrt{2}, \\sqrt{3}, \\sqrt{4})$. The complete classification of all such triangles remains the open problem worth \\$25.",

--- a/src/data/proofs/erdos-644/annotations.json
+++ b/src/data/proofs/erdos-644/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-644-kfamily",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 39,
-      "endLine": 42
-    },
     "type": "definition",
     "title": "KFamily",
     "content": "**KFamily.** A k-uniform family: a collection of sets each of cardinality exactly k. This is the basic object of study — families of k-element subsets of a ground set.",
@@ -26,10 +22,6 @@
   {
     "id": "ann-644-pair-intersects",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 44,
-      "endLine": 50
-    },
     "type": "definition",
     "title": "PairIntersects",
     "content": "**PairIntersects.** A pair {x, y} intersects a set A if x ∈ A or y ∈ A (i.e., the pair shares at least one element with A). This is the basic intersection primitive for the r-wise pair property.",
@@ -49,10 +41,6 @@
   {
     "id": "ann-644-rwise",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 52,
-      "endLine": 55
-    },
     "type": "definition",
     "title": "HasRWisePairProperty",
     "content": "**HasRWisePairProperty.** A family has the r-wise pair property if every r sets in the family share a common pair {x, y} that intersects all r of them. This strengthens pairwise intersection to r-wise coherence.",
@@ -73,10 +61,6 @@
   {
     "id": "ann-644-covering",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 57,
-      "endLine": 63
-    },
     "type": "definition",
     "title": "IsCoveringSet",
     "content": "**IsCoveringSet.** A set S is a covering set for a family if S intersects every set in the family: for every Aᵢ in the family, S ∩ Aᵢ ≠ ∅. The minimum such |S| is the covering number.",
@@ -97,10 +81,6 @@
   {
     "id": "ann-644-f",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 67,
-      "endLine": 70
-    },
     "type": "definition",
     "title": "f(k,r)",
     "content": "**f(k,r).** The minimum size of a covering set guaranteed to exist for any k-uniform family with the r-wise pair property. This is the central function of Problem #644.",
@@ -122,10 +102,6 @@
   {
     "id": "ann-644-known-values",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 78,
-      "endLine": 92
-    },
     "type": "technique",
     "title": "Known Values (EFKT92)",
     "content": "**Known exact values.** Erdős-Fon-Der-Flaass-Kostochka-Tuza (1992) determined: f(k,3) = 2k, f(k,4) = ⌊3k/2⌋, f(k,5) = ⌊5k/4⌋, f(k,6) = k. Each requires both an upper bound (covering algorithm) and matching lower bound (extremal construction).",
@@ -146,10 +122,6 @@
   {
     "id": "ann-644-coeff",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 96,
-      "endLine": 102
-    },
     "type": "definition",
     "title": "Coefficient Sequence",
     "content": "**coefficientSequence.** The sequence c₃ = 2, c₄ = 3/2, c₅ = 5/4, c₆ = 1, representing the leading coefficient of f(k,r) ≈ cᵣ · k. The pattern suggests c₇ = 3/4.",
@@ -169,10 +141,6 @@
   {
     "id": "ann-644-q1",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 122,
-      "endLine": 128
-    },
     "type": "concept",
     "title": "Question 1: f(k,7) = (3/4+o(1))k?",
     "content": "**Question 1.** Is f(k,7) = (3/4 + o(1))k? This asks whether the decreasing coefficient pattern continues to c₇ = 3/4, dropping below the natural barrier c₆ = 1.",
@@ -193,10 +161,6 @@
   {
     "id": "ann-644-q2",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 140,
-      "endLine": 147
-    },
     "type": "concept",
     "title": "Question 2: General Asymptotics",
     "content": "**Question 2.** For all r ≥ 3, does f(k,r) = (cᵣ + o(1))k for some constant cᵣ? This asks whether the linear-in-k behavior persists for all r, not just the computed cases r = 3,...,6.",
@@ -217,10 +181,6 @@
   {
     "id": "ann-644-extremal",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 156,
-      "endLine": 165
-    },
     "type": "definition",
     "title": "Extremal Families",
     "content": "**Extremal Families.** Constructions achieving the lower bounds for f(k,r). These show the known values are tight by exhibiting k-uniform families with the r-wise pair property that cannot be covered by fewer than f(k,r) elements.",
@@ -241,10 +201,6 @@
   {
     "id": "ann-644-mono",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 174,
-      "endLine": 180
-    },
     "type": "technique",
     "title": "Monotonicity Properties",
     "content": "**Monotonicity.** f(k,r) is non-increasing in r (stronger coherence allows smaller covers) and non-decreasing in k (larger sets need larger covers). These are natural structural properties.",
@@ -264,10 +220,6 @@
   {
     "id": "ann-644-sunflower",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 188,
-      "endLine": 199
-    },
     "type": "technique",
     "title": "Sunflower Connection",
     "content": "**Sunflower Connection.** The r-wise pair property relates to the sunflower lemma (Erdős-Ko 1960). A sunflower is a family where all pairwise intersections are the same 'core.' The Erdős-Ko sunflower lemma bounds family sizes, and the pair property provides a weaker structural guarantee that still enables efficient covering.",
@@ -289,10 +241,6 @@
   {
     "id": "ann-644-main",
     "proofId": "erdos-644",
-    "range": {
-      "startLine": 231,
-      "endLine": 236
-    },
     "type": "definition",
     "title": "Main Conjecture",
     "content": "**Main Conjecture.** The conjunction of Question 1 (f(k,7) = (3/4+o(1))k) and Question 2 (existence of limiting coefficients cᵣ for all r). These two questions together would establish the complete asymptotic picture of the covering function.",

--- a/src/data/proofs/erdos-660/annotations.json
+++ b/src/data/proofs/erdos-660/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-660-statement",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 7,
-      "endLine": 19
-    },
     "type": "concept",
     "title": "Problem Statement",
     "content": "The core question: given $n$ vertices of a convex polyhedron in $\\mathbb{R}^3$, must there be at least $(1-o(1)) \\cdot n/2$ distinct pairwise distances? The $(1-o(1))$ factor means the lower bound approaches $n/2$ as $n \\to \\infty$, so the conjecture asserts an asymptotically sharp linear bound.",
@@ -26,10 +22,6 @@
   {
     "id": "ann-660-altman",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 17,
-      "endLine": 22
-    },
     "type": "insight",
     "title": "Altman's 2D Result (1963)",
     "content": "Edward Altman proved in 1963 that the vertices of a convex $n$-gon in $\\mathbb{R}^2$ determine at least $\\lfloor n/2 \\rfloor$ distinct distances. The proof exploits the cyclic ordering of vertices on the convex hull: consecutive vertices at different 'levels' of the polygon must have distinct distances. This is the solved 2D analogue that motivates the 3D conjecture.",
@@ -48,10 +40,6 @@
   {
     "id": "ann-660-context",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 24,
-      "endLine": 29
-    },
     "type": "insight",
     "title": "Broader Distinct Distances Landscape",
     "content": "The distinct distances problem, posed by Erdős in 1946, asks for the minimum number of distinct pairwise distances among $n$ points. For arbitrary point sets in $\\mathbb{R}^2$, Guth-Katz (2015) proved $\\Omega(n/\\log n)$. For points in *convex position* (vertices of a convex body), the geometric constraint should force even more distances — the conjecture predicts $\\Theta(n)$ rather than $\\Theta(n/\\log n)$.",
@@ -71,10 +59,6 @@
   {
     "id": "ann-660-point3d",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 43,
-      "endLine": 44
-    },
     "type": "definition",
     "title": "Point in $\\mathbb{R}^3$",
     "content": "Points in $\\mathbb{R}^3$ are represented using Mathlib's `EuclideanSpace` type, which provides the full metric space structure including the Euclidean distance. This is a more sophisticated choice than bare $\\mathbb{R} \\times \\mathbb{R} \\times \\mathbb{R}$, giving access to Mathlib's inner product space API.",
@@ -92,10 +76,6 @@
   {
     "id": "ann-660-dist",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 46,
-      "endLine": 48
-    },
     "type": "definition",
     "title": "Euclidean Distance in 3D",
     "content": "Uses Mathlib's built-in `dist` function from the metric space structure. In $\\mathbb{R}^3$, this computes $d(p,q) = \\sqrt{(p_1-q_1)^2 + (p_2-q_2)^2 + (p_3-q_3)^2}$. The metric space API provides symmetry, triangle inequality, and non-negativity for free.",
@@ -114,10 +94,6 @@
   {
     "id": "ann-660-polyhedron",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 50,
-      "endLine": 55
-    },
     "type": "definition",
     "title": "Convex Polyhedron Vertices",
     "content": "Captures the geometric notion of a convex polyhedron's vertex set: a nonempty finite set $S \\subset \\mathbb{R}^3$ where every point is an extreme point of the convex hull $\\text{conv}(S)$. An extreme point cannot be written as a convex combination of other points in the set. This ensures $S$ truly consists of vertices (not interior or edge points).",
@@ -138,10 +114,6 @@
   {
     "id": "ann-660-pairwise",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 57,
-      "endLine": 59
-    },
     "type": "definition",
     "title": "Pairwise Distance Set",
     "content": "Computes all pairwise distances via the Cartesian product $S \\times S$ mapped through the distance function. The result is a finite set of reals (automatically deduplicated by `Finset.image`). Includes the zero distance from self-pairs.",
@@ -160,10 +132,6 @@
   {
     "id": "ann-660-distinct",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 61,
-      "endLine": 63
-    },
     "type": "definition",
     "title": "Distinct Distances Count",
     "content": "Counts genuinely different positive distances by filtering out zero (self-distances where $p = q$) and taking cardinality. This gives the standard distinct distances count $|\\Delta^+(S)|$, the central quantity in the problem.",
@@ -182,10 +150,6 @@
   {
     "id": "ann-660-altman-thm",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 83,
-      "endLine": 92
-    },
     "type": "technique",
     "title": "Altman's Theorem (2D Case)",
     "content": "Formalizes Altman's 1963 result: any convex polygon with $n \\geq 3$ vertices determines at least $\\lfloor n/2 \\rfloor$ distinct distances. The proof relies on the cyclic structure of convex polygons: for each diagonal length, there are at most 2 diagonals of that length in a convex polygon, giving the $n/2$ bound. Marked `sorry` since the full geometric argument requires substantial development.",
@@ -204,10 +168,6 @@
   {
     "id": "ann-660-littleo",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 96,
-      "endLine": 98
-    },
     "type": "definition",
     "title": "Little-o Asymptotic Notation",
     "content": "Formalizes $f(n) = o(g(n))$ as: for every $\\varepsilon > 0$, there exists $N$ such that for all $n \\geq N$, $|f(n)/g(n)| < \\varepsilon$. In the conjecture, $(1 - o(1))$ means a factor approaching 1, so the bound $(1 - o(1)) \\cdot n/2$ is asymptotically $n/2$.",
@@ -226,10 +186,6 @@
   {
     "id": "ann-660-conjecture",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 100,
-      "endLine": 112
-    },
     "type": "technique",
     "title": "Main Conjecture (OPEN)",
     "content": "The open conjecture: there exists a vanishing function $\\varepsilon(n) \\to 0$ such that any convex polyhedron with $n$ vertices determines at least $(1 - \\varepsilon(n)) \\cdot n/2$ distinct distances. This extends Altman's exact $\\lfloor n/2 \\rfloor$ bound from 2D to an asymptotic $n/2$ bound in 3D. The weaker form (some linear bound $cn$) is also open.",
@@ -249,10 +205,6 @@
   {
     "id": "ann-660-trivial",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 116,
-      "endLine": 121
-    },
     "type": "technique",
     "title": "Trivial Lower Bound",
     "content": "The weakest possible bound: any $n \\geq 2$ points must have at least 1 distinct distance (since two distinct points are at positive distance). The gap between this trivial bound and the conjectured $\\Theta(n)$ illustrates the difficulty of the problem.",
@@ -270,10 +222,6 @@
   {
     "id": "ann-660-tetrahedron",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 134,
-      "endLine": 139
-    },
     "type": "context",
     "title": "Regular Tetrahedron (4 Vertices, 1 Distance)",
     "content": "The regular tetrahedron is the simplest Platonic solid: all 4 vertices are mutually equidistant at edge length $a$. With $|\\Delta^+| = 1$ vs. the conjectured bound $\\approx 2$, it shows the conjecture is not tight for small $n$. The tetrahedron is the unique convex polytope in $\\mathbb{R}^3$ with all edges equal.",
@@ -292,10 +240,6 @@
   {
     "id": "ann-660-cube",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 141,
-      "endLine": 147
-    },
     "type": "context",
     "title": "Cube (8 Vertices, 3 Distances)",
     "content": "The cube has 8 vertices with exactly 3 distinct distances: edge length $a$, face diagonal $a\\sqrt{2}$, and space diagonal $a\\sqrt{3}$. With $|\\Delta^+| = 3$ vs. the conjectured $\\approx 4$, the cube is already close to the conjectured threshold. The distance structure reflects the three types of vertex pairs: adjacent, face-diagonal, and space-diagonal.",
@@ -315,10 +259,6 @@
   {
     "id": "ann-660-octahedron",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 149,
-      "endLine": 154
-    },
     "type": "context",
     "title": "Octahedron (6 Vertices, 2 Distances)",
     "content": "The regular octahedron has 6 vertices with exactly 2 distinct distances: the edge length $a\\sqrt{2}$ (between adjacent vertices) and the axis length $2a$ (between opposite vertices). With $|\\Delta^+| = 2$ vs. conjectured $\\approx 3$, it illustrates how high symmetry can reduce the distance count.",
@@ -337,10 +277,6 @@
   {
     "id": "ann-660-guthkatz",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 170,
-      "endLine": 177
-    },
     "type": "technique",
     "title": "Guth-Katz Theorem (2015)",
     "content": "The landmark result by Larry Guth and Nets Hawk Katz: any $n$ points in $\\mathbb{R}^2$ determine at least $\\Omega(n/\\log n)$ distinct distances. This resolved Erdős's 1946 conjecture up to the logarithmic factor. The proof uses the polynomial partitioning method. For points in convex position, the convexity constraint should eliminate the $\\log n$ loss, which is why Problem #660 conjectures a clean $\\Theta(n)$ bound.",

--- a/src/data/proofs/erdos-671/annotations.json
+++ b/src/data/proofs/erdos-671/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-e671-header",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 1,
-      "endLine": 27
-    },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdos Problem #671**\n\nTwo profound questions about Lagrange interpolation:\n\n**Q1:** Can L^n f(x) -> f(x) at points where lambda_n(x) -> infinity?\n**Q2:** Can lambda_n(x) -> infinity EVERYWHERE, yet still have convergence somewhere?\n\n**Prize: $250**\n\n**Key Results:**\n- Bernstein (1931): lambda_n diverges somewhere\n- Erdos-Vertesi (1980): |L^n f| -> infinity a.e. for some f",
@@ -20,10 +16,6 @@
   {
     "id": "ann-e671-points",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 36,
-      "endLine": 40
-    },
     "type": "definition",
     "title": "InterpolationPoints",
     "content": "**InterpolationPoints**\n\nA structure containing n distinct points in [-1, 1] for interpolation.\n\n```lean\nstructure InterpolationPoints (n : N) where\n  points : Fin n -> R\n  in_interval : forall i, points i in Icc (-1) 1\n  distinct : forall i j, i != j -> points i != points j\n```\n\nExamples: Chebyshev nodes, equidistant nodes, random points.",
@@ -37,10 +29,6 @@
   {
     "id": "ann-e671-lagrange",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 45,
-      "endLine": 48
-    },
     "type": "definition",
     "title": "Lagrange Basis Polynomials",
     "content": "**lagrangeBasis**\n\nThe Lagrange basis polynomial p_i^n satisfies:\n- p_i(a_i) = 1\n- p_i(a_j) = 0 for j != i\n- degree at most n - 1\n\n```lean\ndef lagrangeBasis (pts) (i) : Polynomial R :=\n  prod j in univ.filter (. != i),\n    C (1 / (pts.points i - pts.points j)) * (X - C (pts.points j))\n```",
@@ -50,10 +38,6 @@
   {
     "id": "ann-e671-interp",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 62,
-      "endLine": 64
-    },
     "type": "definition",
     "title": "Lagrange Interpolation Operator",
     "content": "**lagrangeInterp**\n\nThe interpolation operator:\n$$L^n f(x) = \\sum_{i=1}^{n} f(a_i) p_i^n(x)$$\n\nThis is the unique polynomial of degree < n passing through all the data points (a_i, f(a_i)).",
@@ -63,10 +47,6 @@
   {
     "id": "ann-e671-lebesgue",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 79,
-      "endLine": 81
-    },
     "type": "definition",
     "title": "Lebesgue Function",
     "content": "**lebesgueFunction**\n\n$$\\lambda_n(x) = \\sum_{i=1}^{n} |p_i^n(x)|$$\n\nThe Lebesgue function measures how much the interpolation operator can amplify errors.\n\n**Error bound:** |L^n f(x) - f(x)| <= (1 + lambda_n(x)) * best_approx_error",
@@ -76,10 +56,6 @@
   {
     "id": "ann-e671-constant",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 88,
-      "endLine": 90
-    },
     "type": "definition",
     "title": "Lebesgue Constant",
     "content": "**lebesgueConstant**\n\n$$\\Lambda_n = \\max_{x \\in [-1,1]} \\lambda_n(x)$$\n\nThe worst-case amplification factor over the entire interval.\n\n**Growth rates:**\n- Chebyshev nodes: Lambda_n ~ (2/pi) log n (optimal)\n- Equidistant nodes: Lambda_n ~ 2^n / n (exponential)",
@@ -89,10 +65,6 @@
   {
     "id": "ann-e671-bernstein",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 100,
-      "endLine": 104
-    },
     "type": "technique",
     "title": "Bernstein's Theorem (1931)",
     "content": "**bernstein**\n\nFor ANY choice of interpolation nodes:\n$$\\exists x_0 \\in [-1,1]: \\limsup_{n\\to\\infty} \\lambda_n(x_0) = \\infty$$\n\nThis is a fundamental negative result: uniform convergence for all continuous functions is impossible regardless of node choice.",
@@ -106,10 +78,6 @@
   {
     "id": "ann-e671-ev",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 118,
-      "endLine": 123
-    },
     "type": "technique",
     "title": "Erdos-Vertesi Theorem (1980)",
     "content": "**erdos_vertesi**\n\nFor ANY choice of interpolation nodes, there exists a continuous function f such that:\n$$|L^n f(x)| \\to \\infty \\text{ for almost every } x$$\n\nEven stronger than Bernstein: not just the Lebesgue function, but the actual interpolation diverges a.e. for some f.",
@@ -119,10 +87,6 @@
   {
     "id": "ann-e671-q1",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 132,
-      "endLine": 137
-    },
     "type": "definition",
     "title": "Question 1 (OPEN, $250)",
     "content": "**Question1**\n\nDoes there exist a point sequence such that for EVERY continuous f, there exists some x where:\n- limsup lambda_n(x) = infinity (Lebesgue diverges)\n- Yet L^n f(x) -> f(x) (interpolation converges)\n\nThis asks: can convergence occur despite local Lebesgue divergence?",
@@ -132,10 +96,6 @@
   {
     "id": "ann-e671-q2",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 144,
-      "endLine": 151
-    },
     "type": "definition",
     "title": "Question 2 (OPEN, $250)",
     "content": "**Question2**\n\nDoes there exist a point sequence where:\n- lambda_n(x) -> infinity for ALL x in [-1,1] (universal Lebesgue divergence)\n- Yet for every continuous f, some x has L^n f(x) -> f(x)\n\nThis is stronger than Q1: the Lebesgue function diverges EVERYWHERE, yet convergence still occurs somewhere for each f.",
@@ -145,10 +105,6 @@
   {
     "id": "ann-e671-cheby",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 162,
-      "endLine": 166
-    },
     "type": "definition",
     "title": "Chebyshev Nodes",
     "content": "**chebyshevNodes**\n\n$$x_k = \\cos\\left(\\frac{(2k-1)\\pi}{2n}\\right), \\quad k = 1, \\ldots, n$$\n\nThese are the zeros of the Chebyshev polynomial T_n(x).\n\n**Optimal property:** Chebyshev nodes minimize the Lebesgue constant among all node choices, achieving Lambda_n ~ (2/pi) log n.",
@@ -158,10 +114,6 @@
   {
     "id": "ann-e671-equi",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 168,
-      "endLine": 172
-    },
     "type": "definition",
     "title": "Equidistant Nodes",
     "content": "**equidistantNodes**\n\n$$x_k = -1 + \\frac{2k}{n-1}, \\quad k = 0, \\ldots, n-1$$\n\nEqually-spaced points seem natural but perform poorly.\n\n**Runge phenomenon:** Lambda_n grows exponentially like 2^n/n, causing wild oscillations near endpoints.",
@@ -174,10 +126,6 @@
   {
     "id": "ann-e671-faber",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 200,
-      "endLine": 205
-    },
     "type": "technique",
     "title": "Faber's Theorem",
     "content": "**faber**\n\nFor ANY choice of interpolation nodes, there exists a continuous function f for which L^n f does NOT converge uniformly to f.\n\nThis is another fundamental negative result: universal uniform convergence is impossible.",
@@ -187,10 +135,6 @@
   {
     "id": "ann-e671-pos",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 214,
-      "endLine": 219
-    },
     "type": "technique",
     "title": "Positive Measure Divergence",
     "content": "**positive_measure_divergence**\n\nFor any point sequence, there exists a continuous f such that the set where |L^n f(x)| -> infinity has positive measure.\n\nCombined with Erdos-Vertesi (a.e. divergence), this shows how widespread divergence can be.",
@@ -200,10 +144,6 @@
   {
     "id": "ann-e671-main",
     "proofId": "erdos-671",
-    "range": {
-      "startLine": 231,
-      "endLine": 236
-    },
     "type": "definition",
     "title": "The Main Conjecture",
     "content": "**MainConjecture**\n\nQuestion 1 iff Question 2?\n\nQ2 trivially implies Q1 (if Lebesgue diverges everywhere, it certainly diverges at some point).\n\nThe conjecture asks whether Q1 implies Q2 - is local Lebesgue divergence with convergence only possible when Lebesgue diverges everywhere?",

--- a/src/data/proofs/erdos-678/annotations.json
+++ b/src/data/proofs/erdos-678/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-e678-interval-lcm",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 39,
-      "endLine": 41
-    },
     "type": "definition",
     "title": "Interval LCM Definition",
     "content": "The LCM of k consecutive integers starting at n+1:\n\nM(n,k) = lcm{n+1, n+2, ..., n+k}\n\nImplemented by folding `lcm` over `Finset.range k`, mapping each index i to n+1+i.",
@@ -26,10 +22,6 @@
   {
     "id": "ann-e678-interval-lcm-alt",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 43,
-      "endLine": 45
-    },
     "type": "definition",
     "title": "Alternative Definition",
     "content": "An equivalent definition using `Finset.Icc` (closed interval) directly:\n\nlcm over {n+1, ..., n+k}\n\nThis is sometimes more natural for proofs involving interval membership.",
@@ -44,10 +36,6 @@
   {
     "id": "ann-e678-zero-one",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 54,
-      "endLine": 62
-    },
     "type": "technique",
     "title": "Base Cases",
     "content": "**Empty interval:** M(n,0) = 1 (lcm of nothing is 1)\n\n**Single element:** M(n,1) = n+1 (lcm of one number is itself)\n\nThese base cases are proved by unfolding definitions and using `Finset.fold` properties.",
@@ -62,10 +50,6 @@
   {
     "id": "ann-e678-monotonicity",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 64,
-      "endLine": 67
-    },
     "type": "technique",
     "title": "Divisibility Under Extension",
     "content": "**Key property:** When we extend an interval by one element, the old LCM divides the new one:\n\nM(n,k) | M(n,k+1)\n\nThis is because lcm(a,b) is divisible by a. However, this does NOT mean M(n,k) ≤ M(n,k+1) in all parameterizations!",
@@ -90,10 +74,6 @@
   {
     "id": "ann-e678-comparison-def",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 76,
-      "endLine": 78
-    },
     "type": "definition",
     "title": "Erdős Comparison Property",
     "content": "The predicate `erdosLcmComparison n m k` asserts:\n\n1. k ≥ 3 (interval has at least 3 elements)\n2. m ≥ n + k (the second interval starts after the first ends)\n3. M(n,k) > M(m,k+1) (shorter interval has LARGER lcm)\n\nThis captures the counterintuitive phenomenon Erdős asked about.",
@@ -109,10 +89,6 @@
   {
     "id": "ann-e678-selfridge-1",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 80,
-      "endLine": 86
-    },
     "type": "technique",
     "title": "Selfridge's First Example",
     "content": "**Historical example from 1979:**\n\nM(96,7) = lcm{97,98,99,100,101,102,103} = 1,073,741,700\nM(104,8) = lcm{105,106,107,108,109,110,111,112} = 786,145,080\n\nSo M(96,7) > M(104,8) even though the second interval is longer and starts later!\n\nProved via `native_decide` — Lean computes both values and confirms the inequality.",
@@ -128,10 +104,6 @@
   {
     "id": "ann-e678-selfridge-2",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 88,
-      "endLine": 94
-    },
     "type": "technique",
     "title": "Selfridge's Second Example",
     "content": "**Another example:**\n\nM(132,7) > M(139,8)\n\nThis shows the phenomenon is not isolated — multiple examples exist even for k=7.",
@@ -146,10 +118,6 @@
   {
     "id": "ann-e678-computed-values",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 98,
-      "endLine": 108
-    },
     "type": "technique",
     "title": "Verified LCM Computations",
     "content": "**Explicit values computed and verified by Lean:**\n\n- M(96,7) = 1,073,741,700\n- M(104,8) = 786,145,080\n\nThe `native_decide` tactic compiles the computation to native code and executes it, giving a verified result.\n\nNote: 1,073,741,700 ≈ 2^30 — these are large numbers but still tractable.",
@@ -165,10 +133,6 @@
   {
     "id": "ann-e678-infinitely-many",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 112,
-      "endLine": 116
-    },
     "type": "technique",
     "title": "Infinitude Result",
     "content": "**Erdős Problem #678 Main Question:**\n\nFor every N, there exist n, m, k with k > N satisfying the comparison.\n\nThis means infinitely many valid triples exist — the phenomenon persists at all scales.",
@@ -193,10 +157,6 @@
   {
     "id": "ann-e678-cambie",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 118,
-      "endLine": 121
-    },
     "type": "technique",
     "title": "Cambie's 2024 Theorem",
     "content": "**Cambie's Stronger Result:**\n\nThere exists K such that for ALL k ≥ K, valid pairs (n,m) exist.\n\nThis is stronger than just infinitely many: it says the phenomenon occurs for all sufficiently large interval lengths, not just some sparse sequence.",
@@ -212,10 +172,6 @@
   {
     "id": "ann-e678-prime-power",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 125,
-      "endLine": 129
-    },
     "type": "technique",
     "title": "Prime Power Divisibility",
     "content": "**Key mechanism:**\n\nIf an interval contains a prime power p^a, then p^a divides the interval's LCM.\n\nFor example, {97,...,103} contains no power of 2 larger than 2^2 = 4 (since 64 and 128 are outside), while {105,...,112} contains 112 = 16×7, contributing 2^4.\n\nBut the crucial factor is which PRIMES appear, not just prime powers.",
@@ -235,10 +191,6 @@
   {
     "id": "ann-e678-skip",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 131,
-      "endLine": 136
-    },
     "type": "technique",
     "title": "Prime Power Skipping",
     "content": "**The Key Insight:**\n\nAn interval can 'skip' a prime power if no element in the interval is divisible by that power.\n\n{97,...,103} skips high powers of 2 (nearest are 64 and 128, both outside)\n{105,...,112} must include 112 = 2^4 × 7\n\nBut {97,...,103} includes primes 97, 101, 103 which contribute large prime factors absent from {105,...,112}.",
@@ -254,10 +206,6 @@
   {
     "id": "ann-e678-growth",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 140,
-      "endLine": 148
-    },
     "type": "technique",
     "title": "LCM Growth Bounds",
     "content": "**Asymptotic behavior:**\n\nlog M(n,k) ≈ k (for typical n)\n\nMore precisely, M(n,k) ≤ 4^k by Chebyshev-type bounds.\n\nThis follows from the prime number theorem: the product of primes up to x is about e^x, and lcm is bounded by this product.",
@@ -276,10 +224,6 @@
   {
     "id": "ann-e678-minimal-n",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 152,
-      "endLine": 158
-    },
     "type": "definition",
     "title": "Minimal Starting Point",
     "content": "**Erdős's observation:**\n\nLet n_k be the minimal n for which some m exists with M(n,k) > M(m,k+1).\n\nErdős proved n_k/k → ∞, meaning valid examples require increasingly large starting points relative to interval length.\n\nHe knew no good upper bounds for n_k.",
@@ -295,10 +239,6 @@
   {
     "id": "ann-e678-final",
     "proofId": "erdos-678",
-    "range": {
-      "startLine": 162,
-      "endLine": 166
-    },
     "type": "technique",
     "title": "Main Result",
     "content": "**Erdős Problem #678: SOLVED**\n\nWe prove existence constructively using Selfridge's example:\n\n∃ n m k, erdosLcmComparison n m k\n\nis witnessed by (96, 104, 7).\n\nCambie's theorem extends this to infinitely many examples.",

--- a/src/data/proofs/erdos-840/annotations.json
+++ b/src/data/proofs/erdos-840/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-840-statement",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 7,
-      "endLine": 16
-    },
     "type": "concept",
     "title": "Problem Statement",
     "content": "The core question: how large can a quasi-Sidon subset of {1,...,N} be? A quasi-Sidon set has sumset size approaching the binomial coefficient C(|A|,2) asymptotically, allowing a vanishing fraction of sum collisions.",
@@ -26,10 +22,6 @@
   {
     "id": "ann-840-sumset",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 45,
-      "endLine": 47
-    },
     "type": "definition",
     "title": "Sumset A + A",
     "content": "The sumset A + A = {a + b : a, b ∈ A} is the set of all pairwise sums from A. For a set of size k, trivially |A + A| ≤ k(k+1)/2 (with equality for Sidon sets). The quasi-Sidon condition asks for |A + A| ≈ C(k,2) = k(k-1)/2.",
@@ -49,10 +41,6 @@
   {
     "id": "ann-840-sidon",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 49,
-      "endLine": 52
-    },
     "type": "definition",
     "title": "Sidon Set (B₂ Sequence)",
     "content": "A Sidon set (B₂ sequence) has all pairwise sums distinct: a₁ + a₂ = a₃ + a₄ implies {a₁, a₂} = {a₃, a₄}. Named after Simon Sidon who posed the problem to Erdős in 1932. Maximum size in {1,...,N} is √N + O(N^{1/4}).",
@@ -72,10 +60,6 @@
   {
     "id": "ann-840-quasi",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 74,
-      "endLine": 78
-    },
     "type": "definition",
     "title": "Quasi-Sidon Definition",
     "content": "A set A is quasi-Sidon if |A + A| = (1 + o(1)) · C(|A|, 2) as |A| → ∞. This allows some collisions in the sumset as long as they are asymptotically negligible — the number of 'excess' representations is o(|A|²).",
@@ -96,10 +80,6 @@
   {
     "id": "ann-840-f-function",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 82,
-      "endLine": 86
-    },
     "type": "definition",
     "title": "The Function f(N)",
     "content": "f(N) is the maximum cardinality of a quasi-Sidon subset of {1,...,N}. Axiomatized with witness and optimality. The growth rate f(N) = Θ(√N) is known, but the exact asymptotic constant is open.",
@@ -118,10 +98,6 @@
   {
     "id": "ann-840-lower",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 95,
-      "endLine": 100
-    },
     "type": "technique",
     "title": "Erdős–Freud Lower Bound",
     "content": "Erdős and Freud (1991) proved f(N) ≥ (2/√3 + o(1))√N ≈ 1.155√N. The construction takes a Sidon set B ⊆ [1, N/3] of size ~√(N/3) and forms A = B ∪ {N - b : b ∈ B}. The key insight: sums from different halves cluster near N, avoiding collisions with sums within each half.",
@@ -140,10 +116,6 @@
   {
     "id": "ann-840-construction",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 108,
-      "endLine": 118
-    },
     "type": "definition",
     "title": "Lower Bound Construction Detail",
     "content": "The reflection construction in detail: B ⊆ [1, N/3] is Sidon, so B-sums lie in [2, 2N/3]. The reflected set N - B has sums in [2N - 2N/3, 2N - 2] = [4N/3, 2N - 2]. Cross sums b + (N - b') = N + (b - b') lie near N. These three sum ranges are nearly disjoint, making A quasi-Sidon.",
@@ -162,10 +134,6 @@
   {
     "id": "ann-840-upper-ef",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 120,
-      "endLine": 124
-    },
     "type": "technique",
     "title": "Erdős–Freud Upper Bound",
     "content": "The original upper bound f(N) ≤ (2 + o(1))√N by Erdős and Freud (1991), using a counting argument on the number of sums. Superseded by Pikhurko's sharper bound.",
@@ -184,10 +152,6 @@
   {
     "id": "ann-840-pikhurko",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 126,
-      "endLine": 132
-    },
     "type": "technique",
     "title": "Pikhurko's Upper Bound",
     "content": "Pikhurko (2006) improved the upper bound to f(N) ≤ c_P√N where c_P = (1/4 + 1/(π+2)²)^{-1/2} ≈ 1.863. The proof uses a connection between quasi-Sidon sets and edge-magic graph labelings, combined with analytic optimization over trigonometric sums.",
@@ -208,10 +172,6 @@
   {
     "id": "ann-840-constant",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 134,
-      "endLine": 138
-    },
     "type": "insight",
     "title": "The Pikhurko Constant",
     "content": "The constant c_P = (1/4 + 1/(π+2)²)^{-1/2} ≈ 1.863 is remarkable: π appears in a purely combinatorial problem about integer subsets. This reflects the Fourier-analytic nature of the proof, where trigonometric polynomials optimize the sum representation constraint.",
@@ -230,10 +190,6 @@
   {
     "id": "ann-840-question",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 142,
-      "endLine": 152
-    },
     "type": "concept",
     "title": "The Open Question",
     "content": "What is the exact constant c such that f(N) ~ c√N? Currently 2/√3 ≤ c ≤ 1.863, a gap of about 38%. Determining c would reveal whether the reflection construction is optimal or whether fundamentally different constructions exist.",
@@ -252,10 +208,6 @@
   {
     "id": "ann-840-diffset",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 160,
-      "endLine": 166
-    },
     "type": "technique",
     "title": "Cilleruelo's Difference Set Result",
     "content": "Cilleruelo (2010) proved the analogous problem for A - A instead of A + A is simpler: the maximum quasi-Sidon size (for differences) is ~√N with constant 1. The asymmetry between sums and differences is related to the fact that A - A is symmetric while A + A is not.",
@@ -274,10 +226,6 @@
   {
     "id": "ann-840-sidon-bound",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 170,
-      "endLine": 174
-    },
     "type": "technique",
     "title": "Classical Sidon Bound",
     "content": "For actual Sidon sets (not quasi-Sidon), the maximum size in {1,...,N} is √N + O(N^{1/4}) (Erdős–Turán 1941 upper bound, Singer 1938 / Bose–Chowla 1962 lower bound). The quasi-Sidon relaxation gains a factor of at least 2/√3 ≈ 1.155.",
@@ -296,10 +244,6 @@
   {
     "id": "ann-840-gap",
     "proofId": "erdos-840",
-    "range": {
-      "startLine": 184,
-      "endLine": 194
-    },
     "type": "insight",
     "title": "The Gap Analysis",
     "content": "The current gap between bounds is about 38%: from ~1.155 to ~1.863. If the lower bound is tight (c = 2/√3), then the reflection construction is optimal and quasi-Sidon sets cannot be much larger than Sidon sets. If the upper bound is tight, fundamentally new constructions exist.",

--- a/src/data/proofs/erdos-977/annotations.json
+++ b/src/data/proofs/erdos-977/annotations.json
@@ -2,10 +2,6 @@
   {
     "id": "ann-977-gpf",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 33,
-      "endLine": 36
-    },
     "type": "definition",
     "title": "Greatest Prime Factor",
     "content": "Defines $P(n)$ as the largest prime dividing $n$, returning 0 for $n \\le 1$. This is the central function in the problem. For composite $n = p_1^{a_1} \\cdots p_k^{a_k}$ with $p_1 < \\cdots < p_k$, we have $P(n) = p_k$. The function is multiplicative in the sense that $P(mn) = \\max(P(m), P(n))$.",
@@ -25,10 +21,6 @@
   {
     "id": "ann-977-gpfdvd",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 42,
-      "endLine": 43
-    },
     "type": "technique",
     "title": "P(n) Divides n",
     "content": "The greatest prime factor of $n$ divides $n$. This is immediate from the definition: $P(n)$ is one of the prime factors of $n$. Used throughout the formalization to connect $P(2^n-1)$ to the arithmetic of Mersenne numbers.",
@@ -47,10 +39,6 @@
   {
     "id": "ann-977-gpfprime",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 46,
-      "endLine": 47
-    },
     "type": "technique",
     "title": "P(n) is Prime",
     "content": "For $n \\ge 2$, $P(n)$ is a prime number. This ensures $P(n)$ is well-defined as a prime and enables reasoning about congruence conditions like $P(2^n-1) \\equiv 1 \\pmod{n}$ for primitive prime factors.",
@@ -69,10 +57,6 @@
   {
     "id": "ann-977-mersenne",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 57,
-      "endLine": 57
-    },
     "type": "definition",
     "title": "Mersenne Number",
     "content": "Defines $M_n = 2^n - 1$, the $n$-th Mersenne number. Named after Marin Mersenne (1588–1648), who studied which values of $n$ make $2^n - 1$ prime. The factorization $2^n - 1 = \\prod_{d \\mid n} \\Phi_d(2)$ via cyclotomic polynomials is the key algebraic structure exploited by Schinzel and Stewart.",
@@ -91,10 +75,6 @@
   {
     "id": "ann-977-mainq",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 75,
-      "endLine": 76
-    },
     "type": "definition",
     "title": "Main Question: $P(2^n-1)/n \\to \\infty$",
     "content": "The formalization of Erdős's central question: does the ratio $P(2^n - 1)/n$ tend to infinity? This asks whether the greatest prime factor of Mersenne numbers grows super-linearly. Trivially $P(2^n-1) \\ge n+1$ by Zsygmondy, so the question is about *how fast* beyond linear growth.",
@@ -114,10 +94,6 @@
   {
     "id": "ann-977-stewart",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 79,
-      "endLine": 80
-    },
     "type": "technique",
     "title": "Stewart's Theorem (2013): Yes",
     "content": "Cameron Stewart proved in 2013 that $P(2^n - 1)/n \\to \\infty$, fully resolving Erdős's question. The proof uses Baker's theory of linear forms in logarithms: if $P(2^n - 1)$ were bounded by $Cn$, then $2^n - 1$ would be $(Cn)$-smooth, and the logarithmic representation $n \\log 2 = \\sum a_i \\log p_i$ would give a linear form in logarithms too close to zero, contradicting Baker's lower bounds.",
@@ -138,10 +114,6 @@
   {
     "id": "ann-977-schinzel",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 85,
-      "endLine": 87
-    },
     "type": "technique",
     "title": "Schinzel's Bound (1962)",
     "content": "Andrzej Schinzel proved $P(2^n - 1) > 2n$ for all $n > 12$. The proof uses the cyclotomic factorization $2^n - 1 = \\prod_{d \\mid n} \\Phi_d(2)$ and the fact that primitive prime factors of $\\Phi_n(2)$ satisfy $p \\equiv 1 \\pmod{n}$, hence $p \\ge 2n + 1 > 2n$. The finitely many exceptions $n \\le 12$ are checked computationally.",
@@ -161,10 +133,6 @@
   {
     "id": "ann-977-stewartq",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 97,
-      "endLine": 100
-    },
     "type": "technique",
     "title": "Stewart's Quantitative Bound",
     "content": "Stewart's 2013 result with explicit growth rate: $P(2^n - 1) \\ge n^{1 + 1/(104 \\log\\log n)}$ for sufficiently large $n$. This gives super-polynomial but sub-exponential growth, with the exponent $1 + 1/(104 \\log\\log n)$ tending slowly to 1. The constant 104 arises from the effective bounds in Baker's theory.",
@@ -184,10 +152,6 @@
   {
     "id": "ann-977-m2",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 112,
-      "endLine": 113
-    },
     "type": "technique",
     "title": "$P(M_2) = 3$",
     "content": "$P(2^2 - 1) = P(3) = 3$, the simplest case. Here $M_2 = 3$ is itself prime. The ratio $P(M_2)/2 = 3/2 > 1$, consistent with Schinzel's bound for this small case.",
@@ -205,10 +169,6 @@
   {
     "id": "ann-977-mersenneprime",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 134,
-      "endLine": 134
-    },
     "type": "definition",
     "title": "Mersenne Prime",
     "content": "A Mersenne prime is a prime of the form $M_p = 2^p - 1$ where $p$ itself must be prime (since if $d \\mid n$ with $1 < d < n$, then $2^d - 1 \\mid 2^n - 1$). As of 2024, 51 Mersenne primes are known, the largest being $M_{82589933} = 2^{82589933} - 1$ (24,862,048 digits). It is unknown whether infinitely many exist.",
@@ -228,10 +188,6 @@
   {
     "id": "ann-977-gpfmp",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 137,
-      "endLine": 139
-    },
     "type": "technique",
     "title": "GPF of Mersenne Prime",
     "content": "When $M_n$ is prime, $P(M_n) = M_n = 2^n - 1$. This is trivial (a prime's greatest prime factor is itself) but highlights that Mersenne primes represent extreme cases where $P(2^n-1)/n = (2^n-1)/n$, growing exponentially — far beyond what the problem asks.",
@@ -250,10 +206,6 @@
   {
     "id": "ann-977-related",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 149,
-      "endLine": 150
-    },
     "type": "definition",
     "title": "Related Open Problem: $P(n! + 1)$",
     "content": "The formalization also states the open analogue: does $P(n! + 1)/(n \\log n) \\to \\infty$? Unlike $2^n - 1$, the factorial $n!+1$ lacks a cyclotomic-type factorization, making Baker's method inapplicable. The best known result is Lai's (2021) limsup bound.",
@@ -273,10 +225,6 @@
   {
     "id": "ann-977-lai",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 158,
-      "endLine": 161
-    },
     "type": "technique",
     "title": "Lai's Bound (2021)",
     "content": "Lai proved $\\limsup_{n \\to \\infty} P(n! + 1)/n \\ge 1 + 9\\log 2 \\approx 7.238$. This is a partial result: it shows $P(n!+1)$ exceeds $7n$ infinitely often, but doesn't establish divergence. The proof uses sieve methods and properties of smooth numbers near factorials.",
@@ -295,10 +243,6 @@
   {
     "id": "ann-977-primitive",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 167,
-      "endLine": 168
-    },
     "type": "definition",
     "title": "Primitive Prime Factor",
     "content": "A prime $p$ is a *primitive* prime factor of $2^n - 1$ if $p \\mid 2^n - 1$ but $p \\nmid 2^k - 1$ for any $0 < k < n$. Equivalently, $\\text{ord}_p(2) = n$, so by Fermat's little theorem $n \\mid p - 1$, giving $p \\ge n + 1$. This is the algebraic engine behind all lower bounds on $P(2^n - 1)$.",
@@ -317,10 +261,6 @@
   {
     "id": "ann-977-zsygmondy",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 171,
-      "endLine": 173
-    },
     "type": "technique",
     "title": "Zsygmondy's Theorem",
     "content": "Karl Zsygmondy proved in 1892 that for $n > 6$, the number $2^n - 1$ has a primitive prime factor. The exceptions at $n \\le 6$ are: $n = 1$ ($M_1 = 1$), $n = 2$ ($M_2 = 3$, primitive), $n = 6$ ($M_6 = 63 = 7 \\cdot 9$, all primes divide earlier Mersenne numbers). This immediately gives $P(2^n - 1) \\ge n + 1$ for $n > 6$.",
@@ -340,10 +280,6 @@
   {
     "id": "ann-977-ord",
     "proofId": "erdos-977",
-    "range": {
-      "startLine": 183,
-      "endLine": 184
-    },
     "type": "definition",
     "title": "Multiplicative Order of 2 mod p",
     "content": "Defines $\\text{ord}_p(2)$ as the smallest positive integer $k$ with $2^k \\equiv 1 \\pmod{p}$. The key connection: $p \\mid 2^n - 1$ if and only if $\\text{ord}_p(2) \\mid n$. This links the prime factorization of $2^n - 1$ to the group structure of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ and explains why primitive prime factors satisfy $p \\equiv 1 \\pmod{n}$.",


### PR DESCRIPTION
## Summary
Fix annotation validation errors for 18 entries whose Lean source files are Aristotle UUID pointers (not actual Lean code). Removed invalid `range` fields; annotation content preserved.

## Entries fixed (297 total errors)

**Commit 1 (10 entries, 200 errors):**
erdos-1050 (35), erdos-625 (31), erdos-220 (19), erdos-1005 (19), erdos-633 (18), erdos-660 (16), erdos-1017 (16), erdos-1000 (16), erdos-678 (15), erdos-671 (15)

**Commit 2 (8 entries, 97 errors):**
erdos-977 (16), erdos-840 (14), erdos-1004 (13), erdos-644 (13), erdos-1002 (12), erdos-1022 (11), erdos-1027 (11), erdos-1008 (7)

All 18 entries now pass `annotations:build` validation with 0 errors.