### PR TITLE
Gallery audit: fix 3 proofs with True stubs claimed as verified

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lévy (1934), Khintchine (1937); formalized 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%C3%A9vy%E2%80%93Khintchine_representation",
     "date": "1937",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
     "tags": [
       "probability",
@@ -19,7 +19,7 @@
       "gaussian",
       "stable-distributions"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -41,7 +41,7 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 312,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "stable_inf_divisible proves True (placeholder). 19/20 theorems fully proved; 1 True stub remains for α-stable infinite divisibility."
   },
   "overview": {
     "historicalContext": "The Lévy-Khintchine formula stands as one of the deepest results in probability theory, characterizing all infinitely divisible distributions through a single canonical representation. Paul Lévy established the formula in 1934 as part of his systematic study of stochastic processes with independent increments, building on earlier work by Bruno de Finetti (1929) on the structure of infinitely divisible laws. Aleksandr Khintchine independently proved the same result in 1937 using characteristic function methods. The formula reveals that every infinitely divisible distribution is uniquely determined by three objects: a drift parameter γ, a Gaussian variance σ², and a Lévy measure ν that describes the jump structure. This trichotomy — drift, diffusion, jumps — became the foundation for the modern theory of Lévy processes, with far-reaching applications in mathematical finance (jump-diffusion models of Merton 1976), physics (anomalous diffusion), and statistics (stable distributions as limit laws for heavy-tailed data).",
@@ -118,7 +118,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization builds the complete algebraic framework for the Lévy-Khintchine representation: Lévy triplets as the canonical parameterization of infinitely divisible distributions, explicit Gaussian and Poisson instances as fundamental building blocks, componentwise triplet addition reflecting independent sums, the Lévy-Itô decomposition into continuous and jump parts, and classification theorems that reduce distribution identification to checking which triplet components vanish. With 21 theorems, 0 sorries, and 0 axioms, it provides a clean type-theoretic foundation for Lévy process theory.",
+    "summary": "This formalization builds the complete algebraic framework for the Lévy-Khintchine representation: Lévy triplets as the canonical parameterization of infinitely divisible distributions, explicit Gaussian and Poisson instances as fundamental building blocks, componentwise triplet addition reflecting independent sums, the Lévy-Itô decomposition into continuous and jump parts, and classification theorems that reduce distribution identification to checking which triplet components vanish. With 20 theorems (19 fully proved, 1 True stub for stable infinite divisibility) and 0 axioms, it provides a near-complete type-theoretic foundation for Lévy process theory.",
     "implications": "The framework opens several formalization directions: full Lévy-Khintchine existence and uniqueness (from triplet to distribution), Lévy process construction via the Lévy-Itô theorem, jump-diffusion models for mathematical finance, and the connection between stable distributions and generalized central limit theorems. The algebraic structure of triplet addition also suggests formalizing infinitely divisible distributions as a commutative monoid in Lean's algebraic hierarchy.",
     "openQuestions": [
       "Can gaussianExponent_zero be closed with simp/ring lemmas for Complex.ofReal arithmetic?",

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdos, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1960",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ProbMethodAlteration.lean",
     "tags": [
       "probabilistic-method",
@@ -15,7 +15,7 @@
       "graph-theory",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -49,7 +49,7 @@
       "Property B and hypergraph 2-colorability",
       "Optimization of probability parameters"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "property_b_bound proves True (placeholder, needs hypergraph type). 2/3 theorems fully proved; 1 True stub remains."
   },
   "overview": {
     "historicalContext": "The alteration method, also called the deletion method, is a refinement of the basic probabilistic method developed by Erdos and collaborators in the 1960s and 1970s. While the first moment method requires the random construction to satisfy all constraints simultaneously, the alteration method relaxes this: start with a random object that is close to what we want, then deterministically fix the few violations.\n\nThe key insight is that if a random construction has few expected defects, we can afford to delete or modify the problematic parts while retaining most of the desirable structure. This two-phase approach -- random construction followed by deterministic alteration -- dramatically expands the range of existence results the probabilistic method can prove.\n\nClassic applications include the best known bounds for independent set size in sparse graphs, Property B of hypergraphs (2-colorability), and Ramsey multiplicity problems. The alteration method is particularly effective when we want a large structure (like an independent set) but the random approach occasionally includes unwanted elements (like adjacent vertices).",

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos and collaborators, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1947",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ProbMethodApplications.lean",
     "tags": [
       "probabilistic-method",
@@ -16,7 +16,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -75,7 +75,7 @@
       }
     ],
     "lineCount": 51,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "high_girth_high_chromatic proves True (placeholder). Several theorems prove simplified/weakened statements. 5/6 non-placeholder theorems; 1 True stub remains."
   },
   "overview": {
     "historicalContext": "The probabilistic method, developed by Paul Erdos from 1947 onward, transformed combinatorics by providing non-constructive existence proofs for objects that seemed impossibly difficult to construct explicitly. This applications module brings together the four core techniques -- first moment, alteration, second moment, and the Lovasz Local Lemma -- and demonstrates them on classical problems.\n\nThe applications span the major areas of probabilistic combinatorics: Ramsey theory (lower bounds on R(k,k) and off-diagonal Ramsey numbers), graph coloring (upper bounds on chromatic number from maximum degree), hypergraph coloring (Property B and its extensions), and extremal graph theory (independent set bounds in various graph families).\n\nThese results collectively demonstrate why the probabilistic method became one of the most important tools in 20th-century mathematics. Many of the bounds proved here remained the best known for decades, and some still are. The unity of the approach is striking: the same handful of probabilistic principles yield the strongest known results across diverse combinatorial domains.",


### PR DESCRIPTION
## Summary

- Fix 3 CRITICAL gallery integrity issues where proofs with True stub placeholders (`: True := trivial`) were claiming `"status": "verified"` and `"badge": "verified"`
- **central-limit-theorem-oq-01-oq-02**: `stable_inf_divisible` is True stub (19/20 theorems real)
- **prob-method-alteration**: `property_b_bound` is True stub (2/3 theorems real)
- **prob-method-applications**: `high_girth_high_chromatic` is True stub (5/6 theorems real)

All three: status → `"formalized"`, badge → `"original"`, assumptions field updated.

## Test plan

- [ ] Verify `pnpm build` passes with updated meta.json
- [ ] Confirm gallery pages render correctly with new status/badge values

🤖 Generated with [Claude Code](https://claude.com/claude-code)