### PR TITLE
Research: erdos-828 - prove 4 of 5 axioms from Mathlib (5→1)

### DIFF
--- a/proofs/Proofs/Erdos828Problem.lean
+++ b/proofs/Proofs/Erdos828Problem.lean
@@ -41,12 +41,26 @@ def totientDivisors (a : ℤ) : Set ℕ :=
 
 /- ## Part II: Special Case a = 0 -/
 
-/-- Characterization: φ(n) | n iff n ≤ 1 or n = 2^a · 3^b for some a > 0. -/
+/-- Characterization: φ(n) | n iff n ≤ 1 or n = 2^a · 3^b for some a > 0.
+This is a non-trivial number-theoretic result not currently in Mathlib. -/
 axiom totient_dvd_self_iff (n : ℕ) :
     totient n ∣ n ↔ n ≤ 1 ∨ ∃ a > 0, ∃ b : ℕ, n = 2^a * 3^b
 
-/-- The set {n : φ(n) | n} is infinite (0, 1, 2, 4, 6, 8, 12, 16, ...). -/
-axiom totientDivisors_zero_infinite : (totientDivisors 0).Infinite
+/-- The set {n : φ(n) | n} is infinite.
+Proved via the family 2^(k+1): φ(2^(k+1)) = 2^k divides 2^(k+1). -/
+theorem totientDivisors_zero_infinite : (totientDivisors 0).Infinite := by
+  apply Set.infinite_of_injective_forall_mem (f := fun k => 2 ^ (k + 1))
+  · intro k₁ k₂ h
+    have := Nat.pow_right_injective (by norm_num : 1 < 2) h
+    omega
+  · intro k
+    simp only [totientDivisors, Set.mem_setOf_eq, add_zero]
+    have htot : totient (2 ^ (k + 1)) = 2 ^ k := by
+      rw [Nat.totient_prime_pow Nat.prime_two (by omega : 0 < k + 1)]
+      simp
+    rw [htot]
+    norm_cast
+    exact pow_dvd_pow 2 (by omega)
 
 /- ## Part III: Special Case a = -1 (Lehmer's Conjecture) -/
 
@@ -63,8 +77,16 @@ def lehmerConjecture : Prop :=
 theorem prime_totient_dvd_pred (p : ℕ) (hp : p.Prime) : totient p ∣ p - 1 := by
   rw [totient_prime hp]
 
-/-- There are infinitely many n with φ(n) | n - 1 (namely, all primes). -/
-axiom totientDivisors_neg_one_infinite : (totientDivisors (-1)).Infinite
+/-- There are infinitely many n with φ(n) | n - 1 (namely, all primes).
+For prime p: φ(p) = p - 1 divides p + (-1) = p - 1. -/
+theorem totientDivisors_neg_one_infinite : (totientDivisors (-1)).Infinite := by
+  apply Set.Infinite.mono (s := setOf Nat.Prime)
+  · intro p hp
+    simp only [totientDivisors, Set.mem_setOf_eq]
+    rw [totient_prime hp]
+    have h1 : 1 ≤ p := hp.one_le
+    exact ⟨1, by omega⟩
+  · exact Nat.infinite_setOf_prime
 
 /- ## Part IV: The Main Conjecture -/
 
@@ -78,16 +100,21 @@ def erdos828Conjecture : Prop :=
 
 /- ## Part V: Structural Properties -/
 
-/-- φ(n) is always even for n > 2. -/
-axiom totient_even (n : ℕ) (hn : n > 2) : 2 ∣ totient n
+/-- φ(n) is always even for n > 2.
+Proved from Mathlib's `Nat.totient_even`. -/
+theorem totient_even (n : ℕ) (hn : n > 2) : 2 ∣ totient n := by
+  obtain ⟨k, hk⟩ := Nat.totient_even (show 3 ≤ n by omega)
+  exact ⟨k, by omega⟩
 
 /-- For prime p, φ(p) = p - 1 (Mathlib wrapper). -/
 theorem totient_prime' (p : ℕ) (hp : p.Prime) : totient p = p - 1 :=
   totient_prime hp
 
-/-- For prime power p^k, φ(p^k) = p^(k-1) · (p - 1). -/
-axiom totient_prime_pow_formula (p k : ℕ) (hp : p.Prime) (hk : k > 0) :
-    totient (p^k) = p^(k-1) * (p - 1)
+/-- For prime power p^k, φ(p^k) = p^(k-1) · (p - 1).
+Direct application of Mathlib's `Nat.totient_prime_pow`. -/
+theorem totient_prime_pow_formula (p k : ℕ) (hp : p.Prime) (hk : k > 0) :
+    totient (p^k) = p^(k-1) * (p - 1) :=
+  Nat.totient_prime_pow hp hk
 
 /- ## Part VI: Summary -/
 

--- a/src/data/proofs/erdos-828/meta.json
+++ b/src/data/proofs/erdos-828/meta.json
@@ -44,28 +44,49 @@
         "theorem": "totient_prime",
         "description": "φ(p) = p - 1 for prime p",
         "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.totient_even",
+        "description": "φ(n) is even for n ≥ 3",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.totient_prime_pow",
+        "description": "φ(p^k) = p^(k-1)(p-1) for prime p",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.infinite_setOf_prime",
+        "description": "The set of primes is infinite",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Set.infinite_of_injective_forall_mem",
+        "description": "Injective function into a set implies the set is infinite",
+        "module": "Mathlib.Data.Set.Finite.Basic"
       }
     ],
     "originalContributions": [
       "totientDivisors definition: {n : φ(n) | n + a}",
-      "totient_dvd_self_iff axiom: a = 0 characterization",
-      "totientDivisors_zero_infinite axiom",
+      "totient_dvd_self_iff axiom: a = 0 characterization (deep, not in Mathlib)",
+      "totientDivisors_zero_infinite: proved via powers-of-2 family and Set.infinite_of_injective_forall_mem",
       "lehmerConjecture definition",
-      "prime_totient_dvd_pred theorem: constructive proof",
-      "totientDivisors_neg_one_infinite axiom",
+      "prime_totient_dvd_pred theorem: constructive proof via totient_prime",
+      "totientDivisors_neg_one_infinite: proved via Set.Infinite.mono with Nat.infinite_setOf_prime",
       "erdos828Conjecture definition",
-      "totient_even, totient_prime_pow_formula axioms",
+      "totient_even: proved from Nat.totient_even",
+      "totient_prime_pow_formula: proved from Nat.totient_prime_pow",
       "erdos_828_summary theorem"
     ],
-    "axiomCount": 5,
-    "lineCount": 105,
-    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 1,
+    "lineCount": 132,
+    "assumptions": "1 axiom: totient_dvd_self_iff (deep characterization of when φ(n) | n, not in Mathlib). 4 former axioms proved from Mathlib."
   },
   "overview": {
     "historicalContext": "Erdős Problem #828, from [Er83], asks a sweeping question about Euler's totient function: for every integer a, must there be infinitely many n with φ(n) | n + a? The conjecture is attributed to Graham and appears as Problem B37 in Guy's 'Unsolved Problems in Number Theory' (2004). It unifies several classical problems about totient divisibility into a single framework.\n\nThe case a = 0 is completely understood: φ(n) | n if and only if n ≤ 1 or n = 2^a · 3^b for some a > 0 (the 3-smooth numbers with a factor of 2). This characterization follows from the multiplicative formula φ(n)/n = ∏_{p|n}(1 - 1/p), which yields an integer ratio only when the prime factors are 2 and 3. The case a = -1 is far more famous: asking when φ(n) | n - 1 is essentially Lehmer's conjecture (1932), which asserts that the only solutions with n > 1 are the primes (where φ(p) = p - 1 trivially divides p - 1).\n\nThe general conjecture remains wide open. While the a = 0 and a = -1 cases have rich structure, extending the analysis to arbitrary a ∈ ℤ requires understanding the arithmetic of the totient function at a much deeper level. The problem connects to Carmichael's totient conjecture and to the Fermat-Euler theorem, which shows a^{φ(n)} ≡ 1 (mod n) for gcd(a,n) = 1.",
     "problemStatement": "**Problem Statement (Open)**\n\nFor any integer $a \\in \\mathbb{Z}$, are there infinitely many $n$ such that $\\varphi(n) \\mid n + a$?\n\n**Known Cases:**\n- $a = 0$: Completely characterized — $\\varphi(n) \\mid n$ iff $n = 2^a \\cdot 3^b$\n- $a = -1$: Lehmer's conjecture (1932) — only primes satisfy $\\varphi(n) \\mid n-1$ for $n > 1$ (OPEN)\n\n**Attribution:** Conjecture of Graham. See Guy (2004), Problem B37.",
     "text": "For any integer a, are there infinitely many n such that φ(n) divides n + a? Generalizes Lehmer's conjecture (a = -1) and the characterized case a = 0 (n = 2^a · 3^b). OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization defines totientDivisors(a) as the set {n ∈ ℕ : φ(n) | n + a} using integer arithmetic to handle negative a. The a = 0 characterization and infiniteness are axiomatized as totient_dvd_self_iff and totientDivisors_zero_infinite.\n\nFor a = -1, Lehmer's conjecture is stated as a definition (not axiomatized as true, since it's open), while the easy direction (primes satisfy φ(p) | p - 1) is proved constructively using Mathlib's totient_prime. Structural properties of the totient (evenness for n > 2, prime power formula) are axiomatized.\n\nThe summary theorem combines the two known infiniteness results using exact ⟨...⟩.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization defines totientDivisors(a) as the set {n ∈ ℕ : φ(n) | n + a} using integer arithmetic to handle negative a. Only the deep characterization totient_dvd_self_iff (φ(n)|n iff n=2^a·3^b) remains axiomatized.\n\nThe infiniteness of totientDivisors(0) is proved constructively by showing all powers of 2 are members (φ(2^(k+1))=2^k | 2^(k+1)) using Set.infinite_of_injective_forall_mem. The infiniteness of totientDivisors(-1) is proved via Set.Infinite.mono from Nat.infinite_setOf_prime, since all primes p satisfy φ(p)=p-1 | p+(-1).\n\nStructural properties (totient_even, totient_prime_pow_formula) are proved directly from Mathlib's Nat.totient_even and Nat.totient_prime_pow.",
     "keyInsights": [
       "**a = 0 Characterized:** φ(n) | n iff n = 2^a · 3^b — only 3-smooth numbers with a factor of 2",
       "**Lehmer's Conjecture (a = -1):** No composite n > 1 known with φ(n) | n - 1; open since 1932",
@@ -89,41 +110,41 @@
     {
       "id": "case-zero",
       "title": "Special Case a = 0",
-      "summary": "totient_dvd_self_iff axiom and totientDivisors_zero_infinite axiom",
+      "summary": "totient_dvd_self_iff axiom and totientDivisors_zero_infinite theorem (proved via 2^k family)",
       "startLine": 42,
-      "endLine": 49
+      "endLine": 63
     },
     {
       "id": "lehmer",
       "title": "Lehmer's Conjecture (a = -1)",
-      "summary": "lehmerConjecture definition, prime_totient_dvd_pred theorem, totientDivisors_neg_one_infinite axiom",
-      "startLine": 51,
-      "endLine": 67
+      "summary": "lehmerConjecture definition, prime_totient_dvd_pred theorem, totientDivisors_neg_one_infinite theorem (proved from primes)",
+      "startLine": 65,
+      "endLine": 92
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
       "summary": "erdos828Conjecture: ∀ a : ℤ, (totientDivisors a).Infinite",
-      "startLine": 69,
-      "endLine": 77
+      "startLine": 94,
+      "endLine": 99
     },
     {
       "id": "structural-properties",
       "title": "Structural Properties",
-      "summary": "totient_even, totient_prime', totient_prime_pow_formula",
-      "startLine": 79,
-      "endLine": 90
+      "summary": "totient_even (proved), totient_prime', totient_prime_pow_formula (proved from Mathlib)",
+      "startLine": 101,
+      "endLine": 118
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_828_summary: both a=0 and a=-1 cases are infinite",
-      "startLine": 92,
-      "endLine": 105
+      "startLine": 120,
+      "endLine": 132
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #828 asks whether totientDivisors(a) is infinite for every integer a. The a = 0 case is fully characterized (3-smooth numbers), and the a = -1 case is Lehmer's famous 1932 conjecture. The formalization proves φ(p) | p - 1 constructively and axiomatizes the characterization and infiniteness results.",
+    "summary": "Erdős Problem #828 asks whether totientDivisors(a) is infinite for every integer a. The a = 0 case is fully characterized (3-smooth numbers), and the a = -1 case is Lehmer's famous 1932 conjecture. The formalization constructively proves infiniteness for both a=0 (via powers of 2) and a=-1 (via primes), plus structural properties from Mathlib. Only the deep characterization totient_dvd_self_iff remains axiomatized.",
     "implications": "**Theoretical Significance**: **Number Theory Connections**\n\n1. **Lehmer's Conjecture:** The a = -1 case is one of the most famous open problems about the totient function\n\n**2. Totient Arithmetic:** Resolution would illuminate the divisibility structure of Euler's totient at a deep level\n\n3. **Carmichael's Conjecture:** Related conjecture that φ(n) = φ(m) always has a solution m ≠ n\n\n4. **Unification:** The problem unifies infinitely many specific divisibility questions into one conjecture.",
     "openQuestions": [
       "Are there composite Lehmer numbers (φ(n) | n - 1 with n > 1 composite)?",
@@ -145,9 +166,9 @@
       "Set"
     ],
     "namespace": "Erdos828",
-    "lineCount": 105,
-    "axiomCount": 5,
-    "theoremCount": 3,
+    "lineCount": 132,
+    "axiomCount": 1,
+    "theoremCount": 7,
     "definitionCount": 3
   }
 }

--- a/src/data/research/problems/erdos-828.json
+++ b/src/data/research/problems/erdos-828.json
@@ -29,9 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Eliminated 4 of 5 axioms. Only totient_dvd_self_iff remains (deep characterization, not in Mathlib). Axiom count: 5 → 1.",
+    "builtItems": [
+      "Proved totientDivisors_zero_infinite via Set.infinite_of_injective_forall_mem with f(k)=2^(k+1)",
+      "Proved totientDivisors_neg_one_infinite via Set.Infinite.mono from Nat.infinite_setOf_prime",
+      "Proved totient_even from Nat.totient_even",
+      "Proved totient_prime_pow_formula from Nat.totient_prime_pow"
+    ],
+    "insights": [
+      "4 of 5 axioms proved from Mathlib: totient_even, totient_prime_pow_formula, totientDivisors_zero_infinite, totientDivisors_neg_one_infinite",
+      "totientDivisors_zero_infinite proved via powers-of-2 family: phi(2^(k+1))=2^k divides 2^(k+1)",
+      "totientDivisors_neg_one_infinite proved via Set.Infinite.mono with Nat.infinite_setOf_prime",
+      "Only totient_dvd_self_iff (characterization of phi(n)|n) remains axiomatized - deep result not in Mathlib"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #828 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that, for any $a\\in\\mathbb{Z}$, there are infinitely many $n$ such that\\[\\phi(n) \\mid n+a?\\]\n\n\n\nA conjecture of Graham. Lehmer has conjectured that $\\phi(n)\\mid n-1$ if and only if $n$ is prime. It is an easy exercise to show that $\\phi(n) \\mid n$ if and only if $n=2^a3^b$.\n\nThis is discussed in problem B37 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #827\n- Problem #829\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er83\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"


### PR DESCRIPTION
## Summary
- Eliminated 4 of 5 axioms in Erdős #828 (Totient Divisibility) by proving them from Mathlib
- **Axiom count: 5 → 1** — only `totient_dvd_self_iff` remains (deep characterization not in Mathlib)
- Docker build verified: all proofs compile successfully

## Axioms Proved
| Axiom | Method |
|-------|--------|
| `totientDivisors_zero_infinite` | Powers-of-2 family via `Set.infinite_of_injective_forall_mem` |
| `totientDivisors_neg_one_infinite` | Infinitude of primes via `Set.Infinite.mono` + `Nat.infinite_setOf_prime` |
| `totient_even` | Direct from `Nat.totient_even` |
| `totient_prime_pow_formula` | Direct from `Nat.totient_prime_pow` |

## Files Modified
- `proofs/Proofs/Erdos828Problem.lean` — 4 axioms → theorems with proofs
- `src/data/proofs/erdos-828/meta.json` — updated axiom count, contributions, sections
- `src/data/research/problems/erdos-828.json` — updated knowledge

## Key Proof Techniques
- `totientDivisors_zero_infinite`: Shows `{2^(k+1) | k ∈ ℕ}` is an infinite subset of `totientDivisors 0` since `φ(2^(k+1)) = 2^k` divides `2^(k+1)`
- `totientDivisors_neg_one_infinite`: Shows all primes are in `totientDivisors (-1)` since `φ(p) = p-1` divides `p + (-1) = p - 1`

Generated by researcher-2