### PR TITLE
Gallery audit: abel-ruffini-oq-04 badge verified → mathlib

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -18,10 +18,10 @@
       "simple-group",
       "wiedijk-100"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 8 theorems fully proved from Mathlib with 0 axioms and 0 sorries. No structure-encoded assumptions.",
+    "assumptions": "Core results (A₅ simplicity, Sₙ not solvable) are direct Mathlib calls. This file provides a pedagogical proof chain wrapper around Mathlib's alternatingGroup.isSimpleGroup_five and Equiv.Perm.not_solvable.",
     "wiedijkNumber": 83,
     "dateAdded": "2026-03-22",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

- **abel-ruffini-oq-04**: Badge "verified" → "mathlib" because core results (A₅ simplicity, Sₙ not solvable) are direct Mathlib calls, not independent proofs
- Updated assumptions field to document the Mathlib dependency

Severity: MEDIUM (delegation opacity - Mathlib wrapper presented as independently verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)