### PR TITLE
Research: erdos-1014 - prove 2 axioms (16→14)

### DIFF
--- a/proofs/Proofs/Erdos1014Problem.lean
+++ b/proofs/Proofs/Erdos1014Problem.lean
@@ -79,13 +79,39 @@ axiom ratio_from_asymptotics (k : ℕ) (hk : k ≥ 3) :
   ∀ ε : ℝ, ε > 0 → ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
     |(ramseyNumber k (l + 1) : ℝ) / (ramseyNumber k l : ℝ) - 1| < ε
 
-/-- The conjecture is equivalent to: R(k, l+1) - R(k, l) = o(R(k, l)). -/
-axiom ratio_equiv_difference (k : ℕ) (hk : k ≥ 3) :
+/-- The conjecture is equivalent to: R(k, l+1) - R(k, l) = o(R(k, l)).
+Proved from monotonicity (R(k,l+1) ≥ R(k,l)) and positivity (R(k,l) ≥ 1):
+|x/y - 1| = (x - y)/y when x ≥ y > 0. -/
+theorem ratio_equiv_difference (k : ℕ) (hk : k ≥ 3) :
   (∀ ε : ℝ, ε > 0 → ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
     |(ramseyNumber k (l + 1) : ℝ) / (ramseyNumber k l : ℝ) - 1| < ε) ↔
   (∀ ε : ℝ, ε > 0 → ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
     ((ramseyNumber k (l + 1) : ℝ) - (ramseyNumber k l : ℝ)) /
-    (ramseyNumber k l : ℝ) < ε)
+    (ramseyNumber k l : ℝ) < ε) := by
+  -- Key facts: R(k,l) ≥ 1 > 0 for l ≥ 1, and R(k,l+1) ≥ R(k,l)
+  have abs_eq : ∀ l : ℕ, l ≥ 1 →
+      |(ramseyNumber k (l + 1) : ℝ) / (ramseyNumber k l : ℝ) - 1| =
+      ((ramseyNumber k (l + 1) : ℝ) - (ramseyNumber k l : ℝ)) /
+      (ramseyNumber k l : ℝ) := by
+    intro l hl
+    set a := (ramseyNumber k (l + 1) : ℝ) with ha_def
+    set b := (ramseyNumber k l : ℝ) with hb_def
+    have hb_pos : b ≥ 1 := by simp [hb_def]; exact_mod_cast ramsey_pos k l (by omega) hl
+    have hb_ne : b ≠ 0 := by linarith
+    have hab : b ≤ a := by simp [ha_def, hb_def]; exact_mod_cast ramsey_monotone_right k l
+    have h_eq : a / b - 1 = (a - b) / b := by
+      rw [eq_comm, sub_div, div_self hb_ne]
+    have h_nn : 0 ≤ a / b - 1 := by
+      rw [h_eq]; exact div_nonneg (by linarith) (by linarith)
+    rw [abs_of_nonneg h_nn]
+    exact h_eq
+  constructor
+  · intro h ε hε
+    obtain ⟨L₀, hL⟩ := h ε hε
+    exact ⟨L₀, fun l hl => by rw [← abs_eq l (by omega)]; exact hL l hl⟩
+  · intro h ε hε
+    obtain ⟨L₀, hL⟩ := h ε hε
+    exact ⟨L₀, fun l hl => by rw [abs_eq l (by omega)]; exact hL l hl⟩
 
 /- ## Special Cases -/
 
@@ -99,6 +125,10 @@ axiom R34 : ramseyNumber 3 4 = 9
 axiom R35 : ramseyNumber 3 5 = 14
 
 /-- For the diagonal case k = l, Erdős–Szekeres gives R(k,k) ≤ C(2k-2,k-1).
-    See Problem #1030 for the full diagonal Ramsey asymptotics question. -/
-axiom diagonal_ramsey_upper (k : ℕ) (hk : k ≥ 2) :
-  ramseyNumber k k ≤ Nat.choose (2 * k - 2) (k - 1)
+    Proved from ramsey_upper_erdos_szekeres with l = k. -/
+theorem diagonal_ramsey_upper (k : ℕ) (hk : k ≥ 2) :
+    ramseyNumber k k ≤ Nat.choose (2 * k - 2) (k - 1) := by
+  have h := ramsey_upper_erdos_szekeres k k hk hk
+  have heq : k + k - 2 = 2 * k - 2 := by omega
+  rw [heq] at h
+  exact_mod_cast h

--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1014",
     "erdosProblemStatus": "open",
     "dateAdded": "2025-01-01",
-    "axiomCount": 16,
-    "lineCount": 104,
-    "assumptions": "16 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 14,
+    "lineCount": 134,
+    "assumptions": "14 axiom(s): 1 definition (ramseyNumber), 13 mathematical hypotheses. 2 former axioms proved as theorems: diagonal_ramsey_upper (from Erdős-Szekeres bound) and ratio_equiv_difference (from real analysis + monotonicity + positivity)."
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-1014.json
+++ b/src/data/research/problems/erdos-1014.json
@@ -29,9 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: 2 of 16 axioms proved (16→14). diagonal_ramsey_upper trivially follows from Erdős-Szekeres. ratio_equiv_difference proved via algebraic identity |a/b-1|=(a-b)/b when a≥b>0. Remaining 14 axioms cannot be eliminated (no Ramsey theory in Mathlib).",
+    "builtItems": [
+      "Proved diagonal_ramsey_upper from ramsey_upper_erdos_szekeres (4 lines)",
+      "Proved ratio_equiv_difference from monotonicity + positivity + real analysis (35 lines)"
+    ],
+    "insights": [
+      "2 axioms proved: diagonal_ramsey_upper (from Erdős-Szekeres with k=l) and ratio_equiv_difference (algebraic identity |x/y-1|=(x-y)/y for x>=y>0)",
+      "ratio_equiv_difference proof uses: ramsey_pos for R(k,l)>=1, ramsey_monotone_right for R(k,l+1)>=R(k,l), sub_div+div_self+abs_of_nonneg for the algebraic identity",
+      "Most axioms CANNOT be eliminated - no Ramsey theory in Mathlib (ramseyNumber is an opaque axiom)"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #1014 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $R(k,l)$ be the Ramsey number, so the minimal $n$ such that every graph on at least $n$ vertices contains either a $K_k$ or an independent set on $l$ vertices.\n\nProve, for fixed $k\\geq 3$, that\\[\\lim_{l\\to \\infty}\\frac{R(k,l+1)}{R(k,l)}=1.\\]\n\n\n\nThis is open even for $k=3$.\n\nSee also [544] for other behaviour of $R(3,k)$, and [1030] for the diagonal version of this question.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #544\n- Problem #1030\n- Problem #1013\n- Problem #1015\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #9\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"


### PR DESCRIPTION
## Summary
- Proved 2 of 16 axioms in Erdős #1014 (Ramsey Number Ratio Convergence)
- **Axiom count: 16 → 14**
- Docker build verified

## Axioms Proved
| Axiom | Method |
|-------|--------|
| `diagonal_ramsey_upper` | Direct from `ramsey_upper_erdos_szekeres` with k=l, `exact_mod_cast` |
| `ratio_equiv_difference` | Real analysis: `|a/b-1| = (a-b)/b` when `a ≥ b > 0`, using `ramsey_pos` + `ramsey_monotone_right` + `sub_div`/`div_self`/`abs_of_nonneg` |

## Why 14 Axioms Remain
Mathlib has **no Ramsey number theory**. The `ramseyNumber` function is an opaque axiom, so all Ramsey-specific properties (bounds, recurrence, known values) must stay axiomatized. The only eliminable axioms were those derivable from other axioms via pure logic/algebra.

## Files Modified
- `proofs/Proofs/Erdos1014Problem.lean` — 2 axioms → theorems
- `src/data/proofs/erdos-1014/meta.json` — updated counts
- `src/data/research/problems/erdos-1014.json` — updated knowledge

Generated by researcher-2