### PR TITLE
Gallery audit: fix sorry count mismatches in 2 proofs

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "area-of-circle-oq-01-oq-03",
   "title": "Isoperimetric Inequality: C² ≥ 4πA",
   "slug": "area-of-circle-oq-01-oq-03",
-  "description": "For any closed curve with circumference C enclosing area A, the isoperimetric inequality C² ≥ 4πA holds, with equality iff the curve is a circle. Proves 29 theorems (0 sorries, 2 axioms) including Wirtinger's inequality (proved from Fourier decomposition), the general isoperimetric inequality, equality characterization, and concrete verification for circles, squares, regular n-gons, and equilateral triangles.",
+  "description": "For any closed curve with circumference C enclosing area A, the isoperimetric inequality C² ≥ 4πA holds, with equality iff the curve is a circle. Proves 29 theorems (4 sorries, 0 axioms) including Wirtinger's inequality (proved from Fourier decomposition), the general isoperimetric inequality, equality characterization, and concrete verification for circles, squares, regular n-gons, and equilateral triangles.",
   "meta": {
     "author": "Hurwitz (1901), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
@@ -19,9 +19,8 @@
       "research",
       "isoperimetric"
     ],
-    "badge": "axiom",
-    "sorries": 0,
-    "axioms": 2,
+    "badge": "wip",
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",
@@ -63,7 +62,7 @@
   "overview": {
     "historicalContext": "The isoperimetric problem — find the shape of maximum area for a given perimeter — is one of the oldest optimization problems in mathematics, traced to ancient Dido of Carthage (~900 BCE). The problem asks: among all closed curves of length $L$, which encloses the most area? The answer is a circle, and the isoperimetric inequality $C^2 \\geq 4\\pi A$ quantifies how much any curve falls short. Archimedes knew the result informally (~250 BCE), but a rigorous proof waited until the 19th century. Steiner (1838) gave an elegant proof using symmetrization, but didn't prove existence of the maximizer. Weierstrass (1870s) gave the first complete proof using calculus of variations. The most elegant proof is due to Hurwitz (1901), who used Fourier series and the Wirtinger inequality.",
     "problemStatement": "**Isoperimetric Inequality**:\n\nFor any simple closed curve $\\gamma$ in the plane with circumference $C$ and enclosed area $A$:\n$$C^2 \\geq 4\\pi A$$\nwith equality if and only if $\\gamma$ is a circle.\n\n**Connection to OQ Chain**:\n- OQ01: $C = \\frac{dA}{dr}$ (circumference from differentiating area)\n- OQ01-OQ02: $A = \\int_0^r C(\\rho)\\,d\\rho$ (area from integrating circumference)\n- OQ01-OQ03 (this file): $C^2 \\geq 4\\pi A$ for ALL closed curves (isoperimetric inequality)",
-    "text": "For any closed curve with circumference C enclosing area A, the isoperimetric inequality C² ≥ 4πA holds, with equality iff the curve is a circle. Proves 29 theorems (0 sorries, 2 axioms) including Wirtinger's inequality (proved from Fourier decomposition), the general isoperimetric inequality, equality characterization, and concrete verification for circles, squares, regular n-gons, and equilateral triangles.",
+    "text": "For any closed curve with circumference C enclosing area A, the isoperimetric inequality C² ≥ 4πA holds, with equality iff the curve is a circle. Proves 29 theorems (4 sorries, 0 axioms) including Wirtinger's inequality (proved from Fourier decomposition), the general isoperimetric inequality, equality characterization, and concrete verification for circles, squares, regular n-gons, and equilateral triangles.",
     "proofStrategy": "The **Hurwitz proof** (1901) uses Fourier analysis:\n1. Parameterize the curve $\\gamma(t) = (x(t), y(t))$ with $t \\in [0, 2\\pi]$\n2. Apply **Green's theorem**: $A = \\frac{1}{2}|\\int_0^{2\\pi}(xy' - yx')\\,dt|$\n3. Apply **Wirtinger's inequality**: for $f$ with zero mean, $\\int_0^{2\\pi} f^2\\,dt \\leq \\int_0^{2\\pi}(f')^2\\,dt$\n4. Combined with **Cauchy-Schwarz** and **AM-GM**: this gives $4\\pi A \\leq L^2$\n\nWirtinger follows from **Parseval's theorem** for Fourier series: with $f(t) = \\sum_{n \\geq 1}(a_n \\cos(nt) + b_n \\sin(nt))$, Parseval gives $\\int f^2 = \\pi \\sum(a_n^2 + b_n^2)$ and $\\int(f')^2 = \\pi \\sum n^2(a_n^2 + b_n^2) \\geq \\int f^2$.",
     "keyInsights": [
       "**Equality for circles** is a trivial ring computation: $(2\\pi r)^2 = 4\\pi \\cdot \\pi r^2$",

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "original",
-    "sorries": 3,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Ballot.countedSequence",


### PR DESCRIPTION
## Summary

- **area-of-circle-oq-01-oq-03**: sorries 0→4, badge "axiom"→"wip", removed incorrect axiom count (file has 0 axiom declarations, 4 sorry placeholders)
- **ballot-problem-oq-01**: sorries 3→1 (prior sorries were fixed since meta was written)

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Confirm updated sorry counts match Lean source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)