### PR TITLE
Enrich erdos-1049: align relatedProofs

### DIFF
--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -243,11 +243,7 @@
     "euler-totient",
     "fundamental-arithmetic",
     "erdos-1003",
-    "erdos-1004",
-    "erdos-1051",
-    "erdos-1053",
-    "erdos-1054",
-    "infinitude-primes"
+    "erdos-1051"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary

- Aligned `relatedProofs` (10 entries) with `crossReferences` (6 entries)
- Removed 4 orphaned relatedProofs entries that had no cross-reference descriptions

## Test plan

- [x] JSON validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)