### PR TITLE
Fix crossReference schema in 51 entries (id → targetId)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -122,34 +122,34 @@
   ],
   "crossReferences": [
     {
-      "id": "bezout-identity",
       "relationship": "ancestor",
-      "description": "The root formalization of Bézout's identity, which establishes the extended Euclidean algorithm used here"
+      "description": "The root formalization of Bézout's identity, which establishes the extended Euclidean algorithm used here",
+      "targetId": "bezout-identity"
     },
     {
-      "id": "bezout-identity-oq-02",
       "relationship": "ancestor",
-      "description": "Euclid's lemma via coprimality — the classical (noncomputable) version that this entry makes computable"
+      "description": "Euclid's lemma via coprimality — the classical (noncomputable) version that this entry makes computable",
+      "targetId": "bezout-identity-oq-02"
     },
     {
-      "id": "bezout-identity-oq-02-oq-02-oq-01",
       "relationship": "parent",
-      "description": "The direct parent: constructive divisibility via Bézout coefficients using classical choice (`hdvd.choose`)"
+      "description": "The direct parent: constructive divisibility via Bézout coefficients using classical choice (`hdvd.choose`)",
+      "targetId": "bezout-identity-oq-02-oq-02-oq-01"
     },
     {
-      "id": "bezout-identity-oq-02-oq-02",
       "relationship": "related",
-      "description": "Euclid's lemma in Bézout domains and PIDs — the abstract algebraic generalization"
+      "description": "Euclid's lemma in Bézout domains and PIDs — the abstract algebraic generalization",
+      "targetId": "bezout-identity-oq-02-oq-02"
     },
     {
-      "id": "bezout-identity-oq-02-oq-01",
       "relationship": "related",
-      "description": "The Fundamental Theorem of Arithmetic from Euclid's lemma — a key application of the divisibility result made computable here"
+      "description": "The Fundamental Theorem of Arithmetic from Euclid's lemma — a key application of the divisibility result made computable here",
+      "targetId": "bezout-identity-oq-02-oq-01"
     },
     {
-      "id": "chinese-remainder-non-coprime",
       "relationship": "related",
-      "description": "The Chinese Remainder Theorem uses similar coprimality and Bézout coefficient techniques"
+      "description": "The Chinese Remainder Theorem uses similar coprimality and Bézout coefficient techniques",
+      "targetId": "chinese-remainder-non-coprime"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/cantors-theorem-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-02/meta.json
@@ -138,34 +138,34 @@
   ],
   "crossReferences": [
     {
-      "id": "cantors-theorem",
       "relationship": "parent",
-      "description": "The base Cantor's theorem proof; this entry derives it as a corollary of Lawvere's fixed-point theorem"
+      "description": "The base Cantor's theorem proof; this entry derives it as a corollary of Lawvere's fixed-point theorem",
+      "targetId": "cantors-theorem"
     },
     {
-      "id": "cantors-theorem-oq-01",
       "relationship": "sibling",
-      "description": "OQ-01 explores cardinality aspects of Cantor's theorem; OQ-02 explores the categorical unification via Lawvere"
+      "description": "OQ-01 explores cardinality aspects of Cantor's theorem; OQ-02 explores the categorical unification via Lawvere",
+      "targetId": "cantors-theorem-oq-01"
     },
     {
-      "id": "cantor-diagonalization",
       "relationship": "related",
-      "description": "The direct diagonalization proof for uncountability of the reals; Part V of this entry reproduces the diagonal witness construction"
+      "description": "The direct diagonalization proof for uncountability of the reals; Part V of this entry reproduces the diagonal witness construction",
+      "targetId": "cantor-diagonalization"
     },
     {
-      "id": "godel-incompleteness",
       "relationship": "related",
-      "description": "Gödel's incompleteness theorem; Part IV of this entry shows the core diagonal mechanism underlying it"
+      "description": "Gödel's incompleteness theorem; Part IV of this entry shows the core diagonal mechanism underlying it",
+      "targetId": "godel-incompleteness"
     },
     {
-      "id": "brouwer-fixed-point",
       "relationship": "contrast",
-      "description": "Brouwer's fixed-point theorem guarantees fixed points for continuous maps on compact convex sets — a topological analog, whereas Lawvere's theorem forces fixed points from surjectivity"
+      "description": "Brouwer's fixed-point theorem guarantees fixed points for continuous maps on compact convex sets — a topological analog, whereas Lawvere's theorem forces fixed points from surjectivity",
+      "targetId": "brouwer-fixed-point"
     },
     {
-      "id": "schauder-fixed-point",
       "relationship": "contrast",
-      "description": "Schauder's fixed-point theorem extends Brouwer to infinite dimensions; both contrast with Lawvere's algebraic/categorical fixed-point result"
+      "description": "Schauder's fixed-point theorem extends Brouwer to infinite dimensions; both contrast with Lawvere's algebraic/categorical fixed-point result",
+      "targetId": "schauder-fixed-point"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -143,19 +143,19 @@
   },
   "crossReferences": [
     {
-      "id": "collatz-structured",
       "relationship": "parent",
-      "description": "Parent formalization proving Collatz conjecture for powers of 2 and closure under multiplication by 2^k"
+      "description": "Parent formalization proving Collatz conjecture for powers of 2 and closure under multiplication by 2^k",
+      "targetId": "collatz-structured"
     },
     {
-      "id": "dirichlets-theorem",
       "relationship": "related",
-      "description": "Dirichlet's theorem on primes in arithmetic progressions — the residue class analysis (mod 4) used in the 3/4 contraction connects to the distribution of primes in residue classes"
+      "description": "Dirichlet's theorem on primes in arithmetic progressions — the residue class analysis (mod 4) used in the 3/4 contraction connects to the distribution of primes in residue classes",
+      "targetId": "dirichlets-theorem"
     },
     {
-      "id": "fermat-two-squares",
       "relationship": "related",
-      "description": "Fermat's two-squares theorem uses mod 4 residue analysis in a different number-theoretic context, illustrating how parity and divisibility arguments appear across number theory"
+      "description": "Fermat's two-squares theorem uses mod 4 residue analysis in a different number-theoretic context, illustrating how parity and divisibility arguments appear across number theory",
+      "targetId": "fermat-two-squares"
     }
   ]
 }

--- a/src/data/proofs/erdos-100/meta.json
+++ b/src/data/proofs/erdos-100/meta.json
@@ -125,24 +125,24 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-89",
       "relationship": "foundation",
-      "description": "Erdős #89 (distinct distances) provides the current best lower bound via Guth-Katz: Δ(A) ≥ cn/log n implies diam ≥ cn/log n for restricted distance sets."
+      "description": "Erdős #89 (distinct distances) provides the current best lower bound via Guth-Katz: Δ(A) ≥ cn/log n implies diam ≥ cn/log n for restricted distance sets.",
+      "targetId": "erdos-89"
     },
     {
-      "id": "erdos-104",
       "relationship": "related",
-      "description": "Erdős #104 (unit circles through points) shares the discrete geometry setting and incidence-counting techniques."
+      "description": "Erdős #104 (unit circles through points) shares the discrete geometry setting and incidence-counting techniques.",
+      "targetId": "erdos-104"
     },
     {
-      "id": "erdos-1066",
       "relationship": "related",
-      "description": "Erdős #1066 (independence number of unit distance graphs) studies graph-theoretic properties of the same unit distance structure used here."
+      "description": "Erdős #1066 (independence number of unit distance graphs) studies graph-theoretic properties of the same unit distance structure used here.",
+      "targetId": "erdos-1066"
     },
     {
-      "id": "erdos-1007",
       "relationship": "related",
-      "description": "Erdős #1007 (graph dimension and unit distance embedding) connects to the geometric embedding questions underlying restricted distance sets."
+      "description": "Erdős #1007 (graph dimension and unit distance embedding) connects to the geometric embedding questions underlying restricted distance sets.",
+      "targetId": "erdos-1007"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -129,24 +129,24 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1001",
       "relationship": "related",
-      "description": "Erdős #1001 (Diophantine approximation density) studies related density questions for approximation sequences, sharing the Cassels-Erdős framework."
+      "description": "Erdős #1001 (Diophantine approximation density) studies related density questions for approximation sequences, sharing the Cassels-Erdős framework.",
+      "targetId": "erdos-1001"
     },
     {
-      "id": "erdos-1003",
       "relationship": "related",
-      "description": "Erdős #1003 (consecutive equal totients) studies the Euler totient function φ(n), which provides the lower bound φ_A(k) ≥ φ(n_k) central to this problem."
+      "description": "Erdős #1003 (consecutive equal totients) studies the Euler totient function φ(n), which provides the lower bound φ_A(k) ≥ φ(n_k) central to this problem.",
+      "targetId": "erdos-1003"
     },
     {
-      "id": "erdos-1004",
       "relationship": "related",
-      "description": "Erdős #1004 (distinct consecutive totient values) also concerns the distribution of Euler's totient, the baseline function underlying φ_A."
+      "description": "Erdős #1004 (distinct consecutive totient values) also concerns the distribution of Euler's totient, the baseline function underlying φ_A.",
+      "targetId": "erdos-1004"
     },
     {
-      "id": "erdos-1002",
       "relationship": "related",
-      "description": "Erdős #1002 (weighted fractional sums) studies Diophantine approximation distribution functions, sharing the analytic framework of Cassels' work."
+      "description": "Erdős #1002 (weighted fractional sums) studies Diophantine approximation distribution functions, sharing the analytic framework of Cassels' work.",
+      "targetId": "erdos-1002"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1001/meta.json
+++ b/src/data/proofs/erdos-1001/meta.json
@@ -166,29 +166,29 @@
   },
   "crossReferences": [
     {
-      "id": "prime-reciprocal-divergence",
       "relationship": "related",
-      "description": "Both concern the distribution and density of number-theoretic objects; the divergence of prime reciprocals relates to the Euler product that produces the π² constant"
+      "description": "Both concern the distribution and density of number-theoretic objects; the divergence of prime reciprocals relates to the Euler product that produces the π² constant",
+      "targetId": "prime-reciprocal-divergence"
     },
     {
-      "id": "infinitude-primes",
       "relationship": "related",
-      "description": "The density of coprime pairs (6/π²) underlying the EST formula depends on the distribution of primes via Euler's product formula"
+      "description": "The density of coprime pairs (6/π²) underlying the EST formula depends on the distribution of primes via Euler's product formula",
+      "targetId": "infinitude-primes"
     },
     {
-      "id": "lebesgue-measure",
       "relationship": "uses",
-      "description": "S(N,A,c) is defined as the Lebesgue measure of the approximation set, using MeasureTheory.volume"
+      "description": "S(N,A,c) is defined as the Lebesgue measure of the approximation set, using MeasureTheory.volume",
+      "targetId": "lebesgue-measure"
     },
     {
-      "id": "basel-problem",
       "relationship": "related",
-      "description": "The Basel problem's result ζ(2) = π²/6 directly explains the π² in the EST formula f(A,c) = 12A log(c)/π² via coprime pair density 6/π²"
+      "description": "The Basel problem's result ζ(2) = π²/6 directly explains the π² in the EST formula f(A,c) = 12A log(c)/π² via coprime pair density 6/π²",
+      "targetId": "basel-problem"
     },
     {
-      "id": "hurwitz-theorem",
       "relationship": "related",
-      "description": "Hurwitz's theorem gives the optimal constant 1/√5 for Diophantine approximation quality, providing context for the approximability threshold A/y² used here"
+      "description": "Hurwitz's theorem gives the optimal constant 1/√5 for Diophantine approximation quality, providing context for the approximability threshold A/y² used here",
+      "targetId": "hurwitz-theorem"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -139,34 +139,34 @@
   },
   "crossReferences": [
     {
-      "id": "euler-totient",
       "relationship": "foundation",
-      "description": "The Euler totient function $\\varphi(n)$ is the central object in Problem 1004. The euler-totient proof establishes its core properties — multiplicativity, the formula $\\varphi(p^k) = p^{k-1}(p-1)$, and the identity $\\sum_{d \\mid n} \\varphi(d) = n$ — that underpin the collision and run-length analysis in this problem."
+      "description": "The Euler totient function $\\varphi(n)$ is the central object in Problem 1004. The euler-totient proof establishes its core properties — multiplicativity, the formula $\\varphi(p^k) = p^{k-1}(p-1)$, and the identity $\\sum_{d \\mid n} \\varphi(d) = n$ — that underpin the collision and run-length analysis in this problem.",
+      "targetId": "euler-totient"
     },
     {
-      "id": "erdos-1003",
       "relationship": "sibling",
-      "description": "Erdős Problem 1003 studies locally repeated values of arithmetic functions, the direct predecessor of Problem 1004 in the EPS (1987) series 'On locally repeated values of certain arithmetic functions.' Both problems ask about consecutive distinct values of $\\varphi$ and arise from the same paper."
+      "description": "Erdős Problem 1003 studies locally repeated values of arithmetic functions, the direct predecessor of Problem 1004 in the EPS (1987) series 'On locally repeated values of certain arithmetic functions.' Both problems ask about consecutive distinct values of $\\varphi$ and arise from the same paper.",
+      "targetId": "erdos-1003"
     },
     {
-      "id": "erdos-1005",
       "relationship": "sibling",
-      "description": "Erdős Problem 1005 is the next problem in the EPS series on locally repeated values, studying further properties of totient and related multiplicative functions. Together, Problems 1003–1005 form a cohesive cluster on the local distribution of $\\varphi$."
+      "description": "Erdős Problem 1005 is the next problem in the EPS series on locally repeated values, studying further properties of totient and related multiplicative functions. Together, Problems 1003–1005 form a cohesive cluster on the local distribution of $\\varphi$.",
+      "targetId": "erdos-1005"
     },
     {
-      "id": "erdos-1049",
       "relationship": "analogy",
-      "description": "Erdős Problem 1049 concerns the divisor function $\\tau(n)$, which appears explicitly in the Problem 1004 formalization as 'Problem 945' — the parallel conjecture asking whether runs of length $(\\log x)^c$ with distinct $\\tau$-values exist. Both problems share the same open status and heuristic evidence."
+      "description": "Erdős Problem 1049 concerns the divisor function $\\tau(n)$, which appears explicitly in the Problem 1004 formalization as 'Problem 945' — the parallel conjecture asking whether runs of length $(\\log x)^c$ with distinct $\\tau$-values exist. Both problems share the same open status and heuristic evidence.",
+      "targetId": "erdos-1049"
     },
     {
-      "id": "infinitude-primes",
       "relationship": "dependency",
-      "description": "The EPS upper bound on distinct totient runs relies on smooth number estimates, which in turn depend on the distribution of primes. The infinitude of primes underpins the fact that $\\varphi(p) = p - 1$ for infinitely many $p$, which drives both the richness of totient values and the upper-bound argument via $\\Psi(x, y)$."
+      "description": "The EPS upper bound on distinct totient runs relies on smooth number estimates, which in turn depend on the distribution of primes. The infinitude of primes underpins the fact that $\\varphi(p) = p - 1$ for infinitely many $p$, which drives both the richness of totient values and the upper-bound argument via $\\Psi(x, y)$.",
+      "targetId": "infinitude-primes"
     },
     {
-      "id": "fundamental-arithmetic",
       "relationship": "dependency",
-      "description": "The unique factorization theorem is essential for totient calculations: $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$ uses prime factorizations. The section on special totient preimages ($\\varphi^{-1}(1), \\varphi^{-1}(2), \\varphi^{-1}(4)$) relies directly on factoring arguments from fundamental arithmetic."
+      "description": "The unique factorization theorem is essential for totient calculations: $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$ uses prime factorizations. The section on special totient preimages ($\\varphi^{-1}(1), \\varphi^{-1}(2), \\varphi^{-1}(4)$) relies directly on factoring arguments from fundamental arithmetic.",
+      "targetId": "fundamental-arithmetic"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -107,19 +107,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1009",
       "relationship": "related",
-      "description": "Erdős #1009 (edge-disjoint triangles beyond Turán) studies related extremal graph questions about finding structured subgraphs in dense graphs."
+      "description": "Erdős #1009 (edge-disjoint triangles beyond Turán) studies related extremal graph questions about finding structured subgraphs in dense graphs.",
+      "targetId": "erdos-1009"
     },
     {
-      "id": "erdos-613",
       "relationship": "related",
-      "description": "Erdős #613 (graph decomposition and size Ramsey numbers) connects to the problem of partitioning graphs into forbidden-subgraph-free pieces."
+      "description": "Erdős #613 (graph decomposition and size Ramsey numbers) connects to the problem of partitioning graphs into forbidden-subgraph-free pieces.",
+      "targetId": "erdos-613"
     },
     {
-      "id": "erdos-1006",
       "relationship": "related",
-      "description": "Erdős #1006 (robust acyclic orientations) uses the probabilistic method in graph theory, sharing the dependent random choice technique."
+      "description": "Erdős #1006 (robust acyclic orientations) uses the probabilistic method in graph theory, sharing the dependent random choice technique.",
+      "targetId": "erdos-1006"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -28,14 +28,14 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1030",
       "relationship": "related",
-      "description": "Problem #1030 concerns diagonal Ramsey asymptotics R(k,k)^{1/k}; this file's diagonal_ramsey_upper connects to that question."
+      "description": "Problem #1030 concerns diagonal Ramsey asymptotics R(k,k)^{1/k}; this file's diagonal_ramsey_upper connects to that question.",
+      "targetId": "erdos-1030"
     },
     {
-      "id": "erdos-544",
       "relationship": "related",
-      "description": "Problem #544 studies R(3,k) behavior, directly relevant to the k=3 case of ratio convergence."
+      "description": "Problem #544 studies R(3,k) behavior, directly relevant to the k=3 case of ratio convergence.",
+      "targetId": "erdos-544"
     }
   ],
   "sections": [

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -146,19 +146,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1021",
       "relationship": "related",
-      "description": "Erdős #1021 (extremal numbers for bipartite pair graphs G_k) studies related Turán-type extremal questions about forbidden subgraph densities."
+      "description": "Erdős #1021 (extremal numbers for bipartite pair graphs G_k) studies related Turán-type extremal questions about forbidden subgraph densities.",
+      "targetId": "erdos-1021"
     },
     {
-      "id": "erdos-1008",
       "relationship": "related",
-      "description": "Erdős #1008 (C₄-free subgraphs with m^{2/3} edges) uses related extremal techniques including dependent random choice."
+      "description": "Erdős #1008 (C₄-free subgraphs with m^{2/3} edges) uses related extremal techniques including dependent random choice.",
+      "targetId": "erdos-1008"
     },
     {
-      "id": "erdos-530",
       "relationship": "related",
-      "description": "Erdős #530 (maximum Sidon subsets) studies analogous extremal problems in additive combinatorics, where the probabilistic deletion method parallels the matching conjecture approach."
+      "description": "Erdős #530 (maximum Sidon subsets) studies analogous extremal problems in additive combinatorics, where the probabilistic deletion method parallels the matching conjecture approach.",
+      "targetId": "erdos-530"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -176,19 +176,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1031",
       "relationship": "related",
-      "description": "Erdős #1031 (induced regular subgraphs in non-Ramsey graphs) proves Prömel-Rödl universality, which provides an alternative proof path for the induced subgraph diversity of Problem 1036."
+      "description": "Erdős #1031 (induced regular subgraphs in non-Ramsey graphs) proves Prömel-Rödl universality, which provides an alternative proof path for the induced subgraph diversity of Problem 1036.",
+      "targetId": "erdos-1031"
     },
     {
-      "id": "erdos-szekeres",
       "relationship": "related",
-      "description": "The Erdős-Szekeres theorem is a foundational result in Ramsey theory (monotone subsequences), sharing the theme that avoiding simple structure forces complex patterns."
+      "description": "The Erdős-Szekeres theorem is a foundational result in Ramsey theory (monotone subsequences), sharing the theme that avoiding simple structure forces complex patterns.",
+      "targetId": "erdos-szekeres"
     },
     {
-      "id": "erdos-88",
       "relationship": "related",
-      "description": "Erdős #88 studies Ramsey-theoretic questions about graph colorings, connecting to the non-Ramsey graph framework underlying Problem 1036."
+      "description": "Erdős #88 studies Ramsey-theoretic questions about graph colorings, connecting to the non-Ramsey graph framework underlying Problem 1036.",
+      "targetId": "erdos-88"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -144,14 +144,14 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1036",
       "relationship": "related",
-      "description": "Erdős #1036 (distinct induced subgraphs in non-Ramsey graphs) explores the complementary question: non-Ramsey graphs must have exponentially many distinct induced subgraphs (Shelah 1998), while Problem 1037 shows degree diversity alone does not help improve Ramsey bounds."
+      "description": "Erdős #1036 (distinct induced subgraphs in non-Ramsey graphs) explores the complementary question: non-Ramsey graphs must have exponentially many distinct induced subgraphs (Shelah 1998), while Problem 1037 shows degree diversity alone does not help improve Ramsey bounds.",
+      "targetId": "erdos-1036"
     },
     {
-      "id": "erdos-1031",
       "relationship": "related",
-      "description": "Erdős #1031 (induced regular subgraphs in non-Ramsey graphs) studies universality properties of non-Ramsey graphs. Problem 1037 shows that degree diversity, unlike Ramsey deficiency, does not force structural complexity."
+      "description": "Erdős #1031 (induced regular subgraphs in non-Ramsey graphs) studies universality properties of non-Ramsey graphs. Problem 1037 shows that degree diversity, unlike Ramsey deficiency, does not force structural complexity.",
+      "targetId": "erdos-1031"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -150,14 +150,14 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1038",
       "relationship": "related",
-      "description": "Erdős #1038 (sublevel sets of monic polynomials) studies the measure-theoretic properties of the same sublevel sets whose inscribed disc radius is the subject of Problem 1039."
+      "description": "Erdős #1038 (sublevel sets of monic polynomials) studies the measure-theoretic properties of the same sublevel sets whose inscribed disc radius is the subject of Problem 1039.",
+      "targetId": "erdos-1038"
     },
     {
-      "id": "erdos-1040",
       "relationship": "related",
-      "description": "Erdős #1040 (transfinite diameter and sublevel set measure) connects to Problem 1039 through potential theory: the transfinite diameter controls the Green's function, which in turn bounds both the sublevel set measure and the inscribed disc radius."
+      "description": "Erdős #1040 (transfinite diameter and sublevel set measure) connects to Problem 1039 through potential theory: the transfinite diameter controls the Green's function, which in turn bounds both the sublevel set measure and the inscribed disc radius.",
+      "targetId": "erdos-1040"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -169,34 +169,34 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1039",
       "relationship": "sibling",
-      "description": "Erdős #1039 (polynomial lemniscate disc radius) asks for the largest inscribed disc in sublevel sets {z: |f(z)| < 1}, the complementary geometric quantity to the total sublevel set area studied in Problem 1040."
+      "description": "Erdős #1039 (polynomial lemniscate disc radius) asks for the largest inscribed disc in sublevel sets {z: |f(z)| < 1}, the complementary geometric quantity to the total sublevel set area studied in Problem 1040.",
+      "targetId": "erdos-1039"
     },
     {
-      "id": "erdos-1038",
       "relationship": "related",
-      "description": "Erdős #1038 (sublevel sets of monic polynomials) studies measure properties of the same polynomial sublevel sets, providing the direct precursor to Problem 1040's investigation of how the infimum μ(F) depends on the root set."
+      "description": "Erdős #1038 (sublevel sets of monic polynomials) studies measure properties of the same polynomial sublevel sets, providing the direct precursor to Problem 1040's investigation of how the infimum μ(F) depends on the root set.",
+      "targetId": "erdos-1038"
     },
     {
-      "id": "erdos-1041",
       "relationship": "related",
-      "description": "Erdős #1041 (paths in polynomial level sets) investigates connectivity and path structure within level curves of polynomials, sharing the lemniscate geometry framework central to Problems 1039–1042."
+      "description": "Erdős #1041 (paths in polynomial level sets) investigates connectivity and path structure within level curves of polynomials, sharing the lemniscate geometry framework central to Problems 1039–1042.",
+      "targetId": "erdos-1041"
     },
     {
-      "id": "erdos-1042",
       "relationship": "related",
-      "description": "Erdős #1042 (connected components of polynomial lemniscates) studies the topology of polynomial level sets from the same EHP 1958 research program, complementing the measure-theoretic angle of Problem 1040."
+      "description": "Erdős #1042 (connected components of polynomial lemniscates) studies the topology of polynomial level sets from the same EHP 1958 research program, complementing the measure-theoretic angle of Problem 1040.",
+      "targetId": "erdos-1042"
     },
     {
-      "id": "lebesgue-measure",
       "relationship": "foundational",
-      "description": "The definition of μ(F) as the Lebesgue measure of sublevel sets in the complex plane relies directly on MeasureTheory.volume, the Lebesgue measure formalized in Mathlib."
+      "description": "The definition of μ(F) as the Lebesgue measure of sublevel sets in the complex plane relies directly on MeasureTheory.volume, the Lebesgue measure formalized in Mathlib.",
+      "targetId": "lebesgue-measure"
     },
     {
-      "id": "fundamental-theorem-algebra",
       "relationship": "foundational",
-      "description": "The Fundamental Theorem of Algebra underpins the polynomial infrastructure, ensuring that monic polynomials with roots in F are well-defined and that their root factorization is complete over ℂ."
+      "description": "The Fundamental Theorem of Algebra underpins the polynomial infrastructure, ensuring that monic polynomials with roots in F are well-defined and that their root factorization is complete over ℂ.",
+      "targetId": "fundamental-theorem-algebra"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -173,44 +173,44 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1047",
       "relationship": "sibling",
-      "description": "Erdős #1047 asks whether lemniscate components must be convex for small c — another geometric property of polynomial sublevel sets disproved by Pommerenke (1961) and Goodman (1966). Both problems show that polynomial lemniscate geometry is more complex than initially conjectured."
+      "description": "Erdős #1047 asks whether lemniscate components must be convex for small c — another geometric property of polynomial sublevel sets disproved by Pommerenke (1961) and Goodman (1966). Both problems show that polynomial lemniscate geometry is more complex than initially conjectured.",
+      "targetId": "erdos-1047"
     },
     {
-      "id": "erdos-1046",
       "relationship": "sibling",
-      "description": "Erdős #1046 asks whether a connected lemniscate L(f,1) is contained in a disc of radius 2, answered YES by Pommerenke (1959). Where #1048 studies diameter of components from below, #1046 studies containment from above — complementary geometric bounds on the same objects."
+      "description": "Erdős #1046 asks whether a connected lemniscate L(f,1) is contained in a disc of radius 2, answered YES by Pommerenke (1959). Where #1048 studies diameter of components from below, #1046 studies containment from above — complementary geometric bounds on the same objects.",
+      "targetId": "erdos-1046"
     },
     {
-      "id": "erdos-1042",
       "relationship": "related",
-      "description": "Erdős #1042 studies how many connected components L(f,1) can have depending on root set geometry, solved by Ghosh-Ramachandran (2024). The component count question is the combinatorial counterpart to #1048's metric question about component diameters."
+      "description": "Erdős #1042 studies how many connected components L(f,1) can have depending on root set geometry, solved by Ghosh-Ramachandran (2024). The component count question is the combinatorial counterpart to #1048's metric question about component diameters.",
+      "targetId": "erdos-1042"
     },
     {
-      "id": "erdos-1039",
       "relationship": "related",
-      "description": "Erdős #1039 asks for the radius of the largest inscribed disc in L(f,1) for polynomials with roots in the unit disc — a finer geometric invariant than the diameter studied in #1048. Both use potential-theoretic techniques (logarithmic capacity bounds)."
+      "description": "Erdős #1039 asks for the radius of the largest inscribed disc in L(f,1) for polynomials with roots in the unit disc — a finer geometric invariant than the diameter studied in #1048. Both use potential-theoretic techniques (logarithmic capacity bounds).",
+      "targetId": "erdos-1039"
     },
     {
-      "id": "erdos-1041",
       "relationship": "related",
-      "description": "Erdős #1041 studies path lengths within lemniscate components connecting roots, complementing #1048's diameter analysis with metric connectivity questions about the same sublevel sets."
+      "description": "Erdős #1041 studies path lengths within lemniscate components connecting roots, complementing #1048's diameter analysis with metric connectivity questions about the same sublevel sets.",
+      "targetId": "erdos-1041"
     },
     {
-      "id": "erdos-1038",
       "relationship": "related",
-      "description": "Erdős #1038 studies the Lebesgue measure of polynomial sublevel sets {x : |f(x)| < 1} on the real line (solved: supremum = 2√2 by Tao 2025). Where #1048 studies diameter in ℂ, #1038 studies measure on ℝ — different geometric invariants of polynomial sublevel sets."
+      "description": "Erdős #1038 studies the Lebesgue measure of polynomial sublevel sets {x : |f(x)| < 1} on the real line (solved: supremum = 2√2 by Tao 2025). Where #1048 studies diameter in ℂ, #1038 studies measure on ℝ — different geometric invariants of polynomial sublevel sets.",
+      "targetId": "erdos-1038"
     },
     {
-      "id": "erdos-1040",
       "relationship": "related",
-      "description": "Erdős #1040 asks whether the measure of L(f,1) is determined by the transfinite diameter of the root set — connecting to the same potential-theoretic framework (logarithmic capacity, transfinite diameter) that underlies #1048's diameter bounds."
+      "description": "Erdős #1040 asks whether the measure of L(f,1) is determined by the transfinite diameter of the root set — connecting to the same potential-theoretic framework (logarithmic capacity, transfinite diameter) that underlies #1048's diameter bounds.",
+      "targetId": "erdos-1040"
     },
     {
-      "id": "fundamental-theorem-algebra",
       "relationship": "foundational",
-      "description": "The Fundamental Theorem of Algebra guarantees that a degree-n monic polynomial has exactly n roots in ℂ (with multiplicity). This underpins the entire lemniscate theory: the root count determines the maximum number of connected components, and the root distribution controls the lemniscate geometry."
+      "description": "The Fundamental Theorem of Algebra guarantees that a degree-n monic polynomial has exactly n roots in ℂ (with multiplicity). This underpins the entire lemniscate theory: the root count determines the maximum number of connected components, and the root distribution controls the lemniscate geometry.",
+      "targetId": "fundamental-theorem-algebra"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -170,19 +170,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1049",
       "relationship": "sibling",
-      "description": "Problem #1049 asks about irrationality of ∑ 1/(t^n - 1) for rational t > 1. This is the special case T(t, -1) of the family T(q, r) studied here. Borwein's theorem resolves both problems simultaneously, and the formalization proves T_eq_S_1049 making the connection explicit."
+      "description": "Problem #1049 asks about irrationality of ∑ 1/(t^n - 1) for rational t > 1. This is the special case T(t, -1) of the family T(q, r) studied here. Borwein's theorem resolves both problems simultaneously, and the formalization proves T_eq_S_1049 making the connection explicit.",
+      "targetId": "erdos-1049"
     },
     {
-      "id": "erdos-1051",
       "relationship": "related",
-      "description": "Problem #1051 studies irrationality of ∑ 1/(aₙ·aₙ₊₁) for rapidly growing sequences — a different family of irrationality problems where the denominators grow super-exponentially rather than exponentially as in T(q, r)."
+      "description": "Problem #1051 studies irrationality of ∑ 1/(aₙ·aₙ₊₁) for rapidly growing sequences — a different family of irrationality problems where the denominators grow super-exponentially rather than exponentially as in T(q, r).",
+      "targetId": "erdos-1051"
     },
     {
-      "id": "erdos-257",
       "relationship": "related",
-      "description": "Problem #257 asks whether ∑_{n∈A} 1/(2^n - 1) is irrational for every infinite set A of positive integers. This is a 'subset selection' variant of the Lambert series that Erdős proved irrational in 1948 (the case A = ℕ), which is T(2, -1) in our framework."
+      "description": "Problem #257 asks whether ∑_{n∈A} 1/(2^n - 1) is irrational for every infinite set A of positive integers. This is a 'subset selection' variant of the Lambert series that Erdős proved irrational in 1948 (the case A = ℕ), which is T(2, -1) in our framework.",
+      "targetId": "erdos-257"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -92,19 +92,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-544",
       "relationship": "related-problem",
-      "description": "Erdős #544 concerns odd perfect numbers (σ(n) = 2n with standard divisors). Both problems ask about parity constraints on number-theoretic perfection conditions."
+      "description": "Erdős #544 concerns odd perfect numbers (σ(n) = 2n with standard divisors). Both problems ask about parity constraints on number-theoretic perfection conditions.",
+      "targetId": "erdos-544"
     },
     {
-      "id": "erdos-987",
       "relationship": "uses-same-technique",
-      "description": "Both use Finset-based divisor computations with filter predicates and coprimality conditions, demonstrating the Finset API for number-theoretic problems."
+      "description": "Both use Finset-based divisor computations with filter predicates and coprimality conditions, demonstrating the Finset API for number-theoretic problems.",
+      "targetId": "erdos-987"
     },
     {
-      "id": "euclid-euler",
       "relationship": "related-problem",
-      "description": "Euclid-Euler characterizes even ordinary perfect numbers as 2^{p-1}(2^p-1) where 2^p-1 is Mersenne prime. No analogous characterization is known for unitary perfect numbers."
+      "description": "Euclid-Euler characterizes even ordinary perfect numbers as 2^{p-1}(2^p-1) where 2^p-1 is Mersenne prime. No analogous characterization is known for unitary perfect numbers.",
+      "targetId": "euclid-euler"
     }
   ],
   "sections": [

--- a/src/data/proofs/erdos-1057/meta.json
+++ b/src/data/proofs/erdos-1057/meta.json
@@ -245,34 +245,34 @@
   },
   "crossReferences": [
     {
-      "id": "euler-totient",
       "relationship": "foundational result",
-      "description": "Euler's generalization of Fermat's little theorem ($a^{\\phi(n)} \\equiv 1 \\pmod{n}$ for $\\gcd(a,n)=1$) is the number-theoretic bedrock exploited by Carmichael: Carmichael numbers are precisely composites $n$ where $\\lambda(n) \\mid n-1$, an analogue of Euler's totient condition."
+      "description": "Euler's generalization of Fermat's little theorem ($a^{\\phi(n)} \\equiv 1 \\pmod{n}$ for $\\gcd(a,n)=1$) is the number-theoretic bedrock exploited by Carmichael: Carmichael numbers are precisely composites $n$ where $\\lambda(n) \\mid n-1$, an analogue of Euler's totient condition.",
+      "targetId": "euler-totient"
     },
     {
-      "id": "wilsons-theorem",
       "relationship": "complementary primality criterion",
-      "description": "Wilson's theorem gives a perfect primality test ($n$ prime iff $(n-1)! \\equiv -1 \\pmod{n}$), while Carmichael numbers show the Fermat criterion $a^{n-1} \\equiv 1$ is not sufficient; together they illustrate the difficulty of fast primality testing."
+      "description": "Wilson's theorem gives a perfect primality test ($n$ prime iff $(n-1)! \\equiv -1 \\pmod{n}$), while Carmichael numbers show the Fermat criterion $a^{n-1} \\equiv 1$ is not sufficient; together they illustrate the difficulty of fast primality testing.",
+      "targetId": "wilsons-theorem"
     },
     {
-      "id": "prime-number-theorem",
       "relationship": "asymptotic comparison",
-      "description": "The Prime Number Theorem gives $\\pi(x) \\sim x/\\log x$. Erdős's problem asks whether $C(x) = x^{1-o(1)}$, which would put Carmichael numbers in a density regime between primes and composites — making the relative growth rate a central open question."
+      "description": "The Prime Number Theorem gives $\\pi(x) \\sim x/\\log x$. Erdős's problem asks whether $C(x) = x^{1-o(1)}$, which would put Carmichael numbers in a density regime between primes and composites — making the relative growth rate a central open question.",
+      "targetId": "prime-number-theorem"
     },
     {
-      "id": "fundamental-arithmetic",
       "relationship": "structural prerequisite",
-      "description": "The Fundamental Theorem of Arithmetic underpins both Korselt's criterion and the squarefreeness requirement: Carmichael numbers must factor as products of distinct primes, and the Lean proofs rely on Mathlib's prime factorization infrastructure."
+      "description": "The Fundamental Theorem of Arithmetic underpins both Korselt's criterion and the squarefreeness requirement: Carmichael numbers must factor as products of distinct primes, and the Lean proofs rely on Mathlib's prime factorization infrastructure.",
+      "targetId": "fundamental-arithmetic"
     },
     {
-      "id": "bertrands-postulate",
       "relationship": "sieve-method context",
-      "description": "Bertrand's postulate (a prime between $n$ and $2n$) and the AGP Carmichael lower bound both use sieve-theoretic and analytic number theory arguments; the AGP construction builds Carmichael numbers from primes satisfying simultaneous divisibility conditions."
+      "description": "Bertrand's postulate (a prime between $n$ and $2n$) and the AGP Carmichael lower bound both use sieve-theoretic and analytic number theory arguments; the AGP construction builds Carmichael numbers from primes satisfying simultaneous divisibility conditions.",
+      "targetId": "bertrands-postulate"
     },
     {
-      "id": "dirichlets-theorem",
       "relationship": "prime distribution tool",
-      "description": "The AGP (Alford-Granville-Pomerance) construction of infinitely many Carmichael numbers uses Dirichlet's theorem to find primes $p \\equiv 1 \\pmod{L}$ in arithmetic progressions, ensuring the Korselt divisibility condition $(p-1)\\mid(n-1)$."
+      "description": "The AGP (Alford-Granville-Pomerance) construction of infinitely many Carmichael numbers uses Dirichlet's theorem to find primes $p \\equiv 1 \\pmod{L}$ in arithmetic progressions, ensuring the Korselt divisibility condition $(p-1)\\mid(n-1)$.",
+      "targetId": "dirichlets-theorem"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1058/meta.json
+++ b/src/data/proofs/erdos-1058/meta.json
@@ -110,9 +110,9 @@
   ],
   "crossReferences": [
     {
-      "id": "wilsons-theorem",
       "relationship": "dependency",
-      "description": "Wilson's theorem (p-1)! ≡ -1 (mod p) ensures p_k divides (p_k-1)!+1, providing the starting divisor that motivates the problem"
+      "description": "Wilson's theorem (p-1)! ≡ -1 (mod p) ensures p_k divides (p_k-1)!+1, providing the starting divisor that motivates the problem",
+      "targetId": "wilsons-theorem"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -135,9 +135,9 @@
   ],
   "crossReferences": [
     {
-      "id": "erdos-1058",
       "relationship": "thematic",
-      "description": "Both problems concern restricted prime factorization of expressions involving factorials or divisor functions — the interplay between rapid growth and few prime factors"
+      "description": "Both problems concern restricted prime factorization of expressions involving factorials or divisor functions — the interplay between rapid growth and few prime factors",
+      "targetId": "erdos-1058"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -119,28 +119,28 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1067",
-      "relationship": "Direct predecessor: Problem 1067 asked for an uncountable infinitely connected subgraph with χ = ℵ₁, which Soukup (2015) disproved. Problem 1068 is the surviving countable variant of exactly the same Erdős–Hajnal question."
+      "relationship": "Direct predecessor: Problem 1067 asked for an uncountable infinitely connected subgraph with χ = ℵ₁, which Soukup (2015) disproved. Problem 1068 is the surviving countable variant of exactly the same Erdős–Hajnal question.",
+      "targetId": "erdos-1067"
     },
     {
-      "id": "erdos-62",
-      "relationship": "Parallel open problem in the same infinite chromatic setting: asks whether two graphs with χ = ℵ₁ must share a common subgraph with χ ≥ 4. Both problems probe what structural properties uncountable chromatic number forces."
+      "relationship": "Parallel open problem in the same infinite chromatic setting: asks whether two graphs with χ = ℵ₁ must share a common subgraph with χ ≥ 4. Both problems probe what structural properties uncountable chromatic number forces.",
+      "targetId": "erdos-62"
     },
     {
-      "id": "erdos-63",
-      "relationship": "Related structural result on infinite chromatic graphs: Liu–Montgomery showed graphs with infinite χ contain cycles of length 2ⁿ for infinitely many n. Illustrates the broader program of forcing substructures from large chromatic number."
+      "relationship": "Related structural result on infinite chromatic graphs: Liu–Montgomery showed graphs with infinite χ contain cycles of length 2ⁿ for infinitely many n. Illustrates the broader program of forcing substructures from large chromatic number.",
+      "targetId": "erdos-63"
     },
     {
-      "id": "erdos-61",
-      "relationship": "The Erdős–Hajnal conjecture is the finite analogue of the same forcing philosophy: H-free graphs must contain large homogeneous sets. Problem 1068 is the infinite-chromatic counterpart asking what connectivity structures are forced."
+      "relationship": "The Erdős–Hajnal conjecture is the finite analogue of the same forcing philosophy: H-free graphs must contain large homogeneous sets. Problem 1068 is the infinite-chromatic counterpart asking what connectivity structures are forced.",
+      "targetId": "erdos-61"
     },
     {
-      "id": "erdos-1011",
-      "relationship": "Chromatic forcing in the finite setting: investigates when high chromatic number forces triangles. Shares the core theme of deducing local structure (subgraph existence) from a global chromatic condition."
+      "relationship": "Chromatic forcing in the finite setting: investigates when high chromatic number forces triangles. Shares the core theme of deducing local structure (subgraph existence) from a global chromatic condition.",
+      "targetId": "erdos-1011"
     },
     {
-      "id": "erdos-1013",
-      "relationship": "Triangle-free chromatic threshold: studies how large chromatic number can grow in triangle-free graphs (Mycielski constructions). Relevant background for understanding the relationship between χ and subgraph structure that underlies Problem 1068."
+      "relationship": "Triangle-free chromatic threshold: studies how large chromatic number can grow in triangle-free graphs (Mycielski constructions). Relevant background for understanding the relationship between χ and subgraph structure that underlies Problem 1068.",
+      "targetId": "erdos-1013"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -144,17 +144,16 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1070",
       "title": "Independence Number of Unit Distance Graphs",
       "relationship": "Both problems study extremal properties of geometric graphs built from unit distances. Erdős #1070 asks for the minimum independence number f(n) of n-point unit distance graphs in ℝ², while #1071 studies maximal packings (maximal independent sets) in the intersection graph of all possible unit segments.",
       "sharedConcepts": [
         "unit-distance-graphs",
         "independence-number",
         "combinatorial-geometry"
-      ]
+      ],
+      "targetId": "erdos-1070"
     },
     {
-      "id": "erdos-1066",
       "title": "Independence Number of Unit Distance Graphs (Planar)",
       "relationship": "Closely related problem on independence numbers in planar unit distance graphs. A maximal packing of unit segments is a maximal independent set in the intersection graph of unit segments; Erdős #1066 studies independence numbers in the planar unit-distance setting, sharing the geometric graph-theoretic framework.",
       "sharedConcepts": [
@@ -162,10 +161,10 @@
         "unit-distance-graphs",
         "independence-number",
         "planar-graphs"
-      ]
+      ],
+      "targetId": "erdos-1066"
     },
     {
-      "id": "erdos-1069",
       "title": "Szemerédi-Trotter Theorem on k-Rich Lines",
       "relationship": "Both problems fall within incidence geometry. The Szemerédi-Trotter theorem (#1069) bounds incidences between points and lines in ℝ², a fundamental result in the same combinatorial geometry setting where segment packing questions arise. Density and counting arguments used in Szemerédi-Trotter inform packing bounds.",
       "sharedConcepts": [
@@ -173,10 +172,10 @@
         "combinatorial-geometry",
         "lines-and-segments",
         "point-line-incidences"
-      ]
+      ],
+      "targetId": "erdos-1069"
     },
     {
-      "id": "erdos-97",
       "title": "Equidistant Vertices in Convex Polygons",
       "relationship": "Erdős #97 investigates unit-distance constraints among vertices of convex polygons, sharing the unit-distance geometric framework with #1071. Both problems concern how many geometric objects at unit scale can coexist subject to disjointness or equidistance constraints in the plane.",
       "sharedConcepts": [
@@ -184,10 +183,10 @@
         "unit-distance",
         "geometry",
         "combinatorial-geometry"
-      ]
+      ],
+      "targetId": "erdos-97"
     },
     {
-      "id": "borsuk-ulam",
       "title": "Borsuk-Ulam Theorem",
       "relationship": "The Borsuk-Ulam theorem provides topological tools (compactness, antipodal arguments) applicable to blocking and covering problems in geometry. Compactness arguments are central to proving that any packing of unit segments in [0,1]² must be finite — the same topological reasoning that underpins Borsuk-type results.",
       "sharedConcepts": [
@@ -195,7 +194,8 @@
         "geometric-topology",
         "blocking-sets",
         "covering"
-      ]
+      ],
+      "targetId": "borsuk-ulam"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1081/meta.json
+++ b/src/data/proofs/erdos-1081/meta.json
@@ -159,34 +159,34 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-940",
       "title": "Erdős #940: Sums of r-Powerful Numbers",
-      "relationship": "Direct generalization: Problem #940 asks whether sums of r r-powerful numbers have density 0 for r ≥ 3, directly extending the squarefull (r=2) setting of Problem #1081. Baker-Brüdern (1994) contributed to both problems."
+      "relationship": "Direct generalization: Problem #940 asks whether sums of r r-powerful numbers have density 0 for r ≥ 3, directly extending the squarefull (r=2) setting of Problem #1081. Baker-Brüdern (1994) contributed to both problems.",
+      "targetId": "erdos-940"
     },
     {
-      "id": "prime-number-theorem",
       "title": "The Prime Number Theorem",
-      "relationship": "The asymptotic π(x) ~ x/ln(x) is a prototype for counting-function asymptotics in analytic number theory; the methods of Dirichlet series, complex analysis, and log-power exponents used to prove PNT are the same toolkit Blomer-Granville deploy to obtain the exponent α for A(x)."
+      "relationship": "The asymptotic π(x) ~ x/ln(x) is a prototype for counting-function asymptotics in analytic number theory; the methods of Dirichlet series, complex analysis, and log-power exponents used to prove PNT are the same toolkit Blomer-Granville deploy to obtain the exponent α for A(x).",
+      "targetId": "prime-number-theorem"
     },
     {
-      "id": "fermat-two-squares",
       "title": "Fermat's Sum of Two Squares",
-      "relationship": "Fermat's theorem characterizes primes expressible as sums of two squares via quadratic forms. The Blomer-Granville proof of the correct A(x) exponent relies on representation counts of binary quadratic forms, making this a foundational technical precursor."
+      "relationship": "Fermat's theorem characterizes primes expressible as sums of two squares via quadratic forms. The Blomer-Granville proof of the correct A(x) exponent relies on representation counts of binary quadratic forms, making this a foundational technical precursor.",
+      "targetId": "fermat-two-squares"
     },
     {
-      "id": "lagrange-four-squares",
       "title": "Lagrange's Four Squares Theorem",
-      "relationship": "Every integer is a sum of four squares; studying which integers are sums of structured sets (squares, squarefull numbers) is a common analytic number theory theme. Lagrange's result anchors the broader programme of additive representations that includes Problem #1081."
+      "relationship": "Every integer is a sum of four squares; studying which integers are sums of structured sets (squares, squarefull numbers) is a common analytic number theory theme. Lagrange's result anchors the broader programme of additive representations that includes Problem #1081.",
+      "targetId": "lagrange-four-squares"
     },
     {
-      "id": "fundamental-arithmetic",
       "title": "Fundamental Theorem of Arithmetic",
-      "relationship": "The definition of squarefull (every prime factor p satisfies p² | m) depends critically on unique prime factorization. The Fundamental Theorem of Arithmetic underpins all structural properties of squarefull numbers used in this formalization."
+      "relationship": "The definition of squarefull (every prime factor p satisfies p² | m) depends critically on unique prime factorization. The Fundamental Theorem of Arithmetic underpins all structural properties of squarefull numbers used in this formalization.",
+      "targetId": "fundamental-arithmetic"
     },
     {
-      "id": "riemann-hypothesis",
       "title": "The Riemann Hypothesis",
-      "relationship": "The density of squarefull numbers S(x) ~ c√x and the exact leading constant in A(x) both involve the Riemann zeta function ζ(3/2)/ζ(3). Conditional results on A(x) error terms connect to the zero-free region of ζ(s), making RH relevant to the open questions in this problem."
+      "relationship": "The density of squarefull numbers S(x) ~ c√x and the exact leading constant in A(x) both involve the Riemann zeta function ζ(3/2)/ζ(3). Conditional results on A(x) error terms connect to the zero-free region of ζ(s), making RH relevant to the open questions in this problem.",
+      "targetId": "riemann-hypothesis"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -119,40 +119,40 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-656",
       "slug": "erdos-656",
       "title": "Erdős Problem #656: Density Version of Hindman's Theorem",
-      "relationship": "Direct strengthening by the same team: Kra, Moreira, and Richter extended their sumset techniques to prove that positive-density sets contain B+B+t for some infinite B and integer t, a density analogue of Hindman's theorem."
+      "relationship": "Direct strengthening by the same team: Kra, Moreira, and Richter extended their sumset techniques to prove that positive-density sets contain B+B+t for some infinite B and integer t, a density analogue of Hindman's theorem.",
+      "targetId": "erdos-656"
     },
     {
-      "id": "erdos-139",
       "slug": "erdos-139",
       "title": "Erdős #139: Szemerédi's Theorem",
-      "relationship": "Paradigmatic parallel: Szemerédi's theorem shows positive upper density forces arithmetic progressions; Problem #109 shows it forces infinite sumsets B+C. Both use the Furstenberg correspondence principle to translate density hypotheses into ergodic recurrence."
+      "relationship": "Paradigmatic parallel: Szemerédi's theorem shows positive upper density forces arithmetic progressions; Problem #109 shows it forces infinite sumsets B+C. Both use the Furstenberg correspondence principle to translate density hypotheses into ergodic recurrence.",
+      "targetId": "erdos-139"
     },
     {
-      "id": "erdos-3",
       "slug": "erdos-3",
       "title": "Erdős Problem #3: Arithmetic Progressions in Large Sets",
-      "relationship": "Companion density-forces-structure conjecture: Erdős conjectures that divergent reciprocal sum (a weaker condition than positive density) still forces arbitrarily long arithmetic progressions, making Problem #3 harder than Szemerédi and philosophically linked to Problem #109."
+      "relationship": "Companion density-forces-structure conjecture: Erdős conjectures that divergent reciprocal sum (a weaker condition than positive density) still forces arbitrarily long arithmetic progressions, making Problem #3 harder than Szemerédi and philosophically linked to Problem #109.",
+      "targetId": "erdos-3"
     },
     {
-      "id": "erdos-31",
       "slug": "erdos-31",
       "title": "Erdős Problem #31: Additive Complements",
-      "relationship": "Sumset covering perspective: while Problem #31 asks when A+B covers ℕ (with B of density 0), Problem #109 asks when A itself contains an infinite sumset — complementary questions about the additive structure forced by density conditions."
+      "relationship": "Sumset covering perspective: while Problem #31 asks when A+B covers ℕ (with B of density 0), Problem #109 asks when A itself contains an infinite sumset — complementary questions about the additive structure forced by density conditions.",
+      "targetId": "erdos-31"
     },
     {
-      "id": "erdos-245",
       "slug": "erdos-245",
       "title": "Erdős Problem #245: Sumset Growth Ratio",
-      "relationship": "Sumset size and structure: Freiman's result (limsup |A+A|/|A| ≥ 3 for zero-density A) and Plünnecke-Ruzsa theory provide the finite sumset toolkit that informs the infinite sumset theory underlying Problem #109."
+      "relationship": "Sumset size and structure: Freiman's result (limsup |A+A|/|A| ≥ 3 for zero-density A) and Plünnecke-Ruzsa theory provide the finite sumset toolkit that informs the infinite sumset theory underlying Problem #109.",
+      "targetId": "erdos-245"
     },
     {
-      "id": "szemeredi-theorem",
       "slug": "szemeredi-theorem",
       "title": "Szemerédi's Theorem (k=3 via Mathlib)",
-      "relationship": "Lean formalization of the k=3 Szemerédi theorem (Roth's theorem); shares the density framework and limsup-based definitions that appear in the Erdős-109 Lean file, making it a direct technical companion in the gallery."
+      "relationship": "Lean formalization of the k=3 Szemerédi theorem (Roth's theorem); shares the density framework and limsup-based definitions that appear in the Erdős-109 Lean file, making it a direct technical companion in the gallery.",
+      "targetId": "szemeredi-theorem"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1108/meta.json
+++ b/src/data/proofs/erdos-1108/meta.json
@@ -149,28 +149,28 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-398",
-      "relationship": "The Brocard-Ramanujan conjecture (n! + 1 = m²) is the most directly adjacent problem: both concern when factorial expressions yield perfect powers. Problem #398 asks about a single factorial plus one; Problem #1108 asks about arbitrary finite sums of distinct factorials."
+      "relationship": "The Brocard-Ramanujan conjecture (n! + 1 = m²) is the most directly adjacent problem: both concern when factorial expressions yield perfect powers. Problem #398 asks about a single factorial plus one; Problem #1108 asks about arbitrary finite sums of distinct factorials.",
+      "targetId": "erdos-398"
     },
     {
-      "id": "erdos-399",
-      "relationship": "Problem #399 asks whether n! = x^k ± y^k has solutions with xy > 1 and k > 2. Both #399 and #1108 investigate the intersection of factorials with the multiplicative structure of perfect powers, using Diophantine methods."
+      "relationship": "Problem #399 asks whether n! = x^k ± y^k has solutions with xy > 1 and k > 2. Both #399 and #1108 investigate the intersection of factorials with the multiplicative structure of perfect powers, using Diophantine methods.",
+      "targetId": "erdos-399"
     },
     {
-      "id": "erdos-1107",
-      "relationship": "Problem #1107 asks whether every sufficiently large integer is a sum of at most r+1 many r-powerful numbers. Both problems study the additive and multiplicative structure of powerful numbers; #1108 asks whether factorial sums can produce them, #1107 asks how many are needed to represent all integers."
+      "relationship": "Problem #1107 asks whether every sufficiently large integer is a sum of at most r+1 many r-powerful numbers. Both problems study the additive and multiplicative structure of powerful numbers; #1108 asks whether factorial sums can produce them, #1107 asks how many are needed to represent all integers.",
+      "targetId": "erdos-1107"
     },
     {
-      "id": "erdos-390",
-      "relationship": "Problem #390 studies factorizations of n! into large factors, revealing deep multiplicative structure in factorials. Understanding how prime powers distribute in n! informs why factorial sums are unlikely to be perfect powers."
+      "relationship": "Problem #390 studies factorizations of n! into large factors, revealing deep multiplicative structure in factorials. Understanding how prime powers distribute in n! informs why factorial sums are unlikely to be perfect powers.",
+      "targetId": "erdos-390"
     },
     {
-      "id": "perfect-numbers",
-      "relationship": "Perfect numbers are a classical instance of numbers with highly constrained multiplicative structure (all prime factors to even powers for even perfects). The IsPowerful predicate generalizes this: powerful numbers require every prime factor to appear with exponent ≥ 2, placing them in the same circle of ideas."
+      "relationship": "Perfect numbers are a classical instance of numbers with highly constrained multiplicative structure (all prime factors to even powers for even perfects). The IsPowerful predicate generalizes this: powerful numbers require every prime factor to appear with exponent ≥ 2, placing them in the same circle of ideas.",
+      "targetId": "perfect-numbers"
     },
     {
-      "id": "erdos-728",
-      "relationship": "Problem #728 concerns factorial divisibility conditions and logarithmic gap constraints. Both problems exploit the rapid growth of factorials and their prime factorization structure to establish finiteness or impossibility results."
+      "relationship": "Problem #728 concerns factorial divisibility conditions and logarithmic gap constraints. Both problems exploit the rapid growth of factorials and their prime factorization structure to establish finiteness or impossibility results.",
+      "targetId": "erdos-728"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1112/meta.json
+++ b/src/data/proofs/erdos-1112/meta.json
@@ -143,40 +143,40 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-880",
       "title": "Erdős Problem #880: Gaps in Restricted Additive Bases",
       "relationship": "Parallel dichotomy: k=2 sumsets have bounded gaps (YES), k≥3 sumsets do not (NO) — mirrors the k=2 vs k≥3 avoidance phase transition in Problem #1112.",
-      "relevance": "high"
+      "relevance": "high",
+      "targetId": "erdos-880"
     },
     {
-      "id": "erdos-875",
       "title": "Erdős Problem #875: Admissible Sequences with Disjoint Sumsets",
       "relationship": "Studies growth constraints on sequences whose r-fold sumsets are pairwise disjoint, directly connecting r-fold sumset density to sequence growth rate.",
-      "relevance": "high"
+      "relevance": "high",
+      "targetId": "erdos-875"
     },
     {
-      "id": "erdos-949",
       "title": "Erdős Problem #949: Sum-Free Sets and Continuum-Sized Sumset Avoidance",
       "relationship": "Asks whether large subsets avoiding a sum-free set S can have their sumset contained in the complement of S — a structural avoidance question for sumsets closely related to lacunary avoidance.",
-      "relevance": "medium"
+      "relevance": "medium",
+      "targetId": "erdos-949"
     },
     {
-      "id": "erdos-153",
       "title": "Erdős Problem #153: Gap Variance in Sidon Sumsets",
       "relationship": "Investigates gap distribution in sumsets A+A for Sidon sets, providing structural context for how bounded-gap sequences interact with sumset geometry.",
-      "relevance": "medium"
+      "relevance": "medium",
+      "targetId": "erdos-153"
     },
     {
-      "id": "erdos-894",
       "title": "Erdős Problem #894: Chromatic Numbers of Lacunary Cayley Graphs",
       "relationship": "Concerns avoidance of lacunary difference sets via graph colorings — the same lacunary growth condition (n_{k+1} ≥ (1+ε)n_k) appears in both problems.",
-      "relevance": "medium"
+      "relevance": "medium",
+      "targetId": "erdos-894"
     },
     {
-      "id": "erdos-866",
       "title": "Erdős Problem #866: Pairwise Sums Threshold",
       "relationship": "Establishes density thresholds for subsets of {1,...,2N} to contain all k-fold pairwise sums, quantifying how k-fold sumsets saturate the integers as k grows.",
-      "relevance": "medium"
+      "relevance": "medium",
+      "targetId": "erdos-866"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1114/meta.json
+++ b/src/data/proofs/erdos-1114/meta.json
@@ -141,29 +141,29 @@
   },
   "crossReferences": [
     {
-      "id": "mean-value-theorem",
       "title": "Mean Value Theorem",
-      "relationship": "Rolle's Theorem — the engine of this proof — is the special case of the Mean Value Theorem where f(a) = f(b). Every critical point between consecutive AP roots is supplied by a single application of Rolle's Theorem."
+      "relationship": "Rolle's Theorem — the engine of this proof — is the special case of the Mean Value Theorem where f(a) = f(b). Every critical point between consecutive AP roots is supplied by a single application of Rolle's Theorem.",
+      "targetId": "mean-value-theorem"
     },
     {
-      "id": "fundamental-theorem-algebra",
       "title": "Fundamental Theorem of Algebra",
-      "relationship": "Guarantees that a degree-n real polynomial has exactly n roots (counted with multiplicity). Bálint's theorem takes root structure one step further by analyzing how a specific root geometry (arithmetic progression) shapes the root geometry of the derivative."
+      "relationship": "Guarantees that a degree-n real polynomial has exactly n roots (counted with multiplicity). Bálint's theorem takes root structure one step further by analyzing how a specific root geometry (arithmetic progression) shapes the root geometry of the derivative.",
+      "targetId": "fundamental-theorem-algebra"
     },
     {
-      "id": "erdos-1125",
       "title": "Erdős Problem #1125: Kemperman's Inequality and Monotonicity",
-      "relationship": "Both problems study outward monotonicity arising from convexity arguments on the real line. Kemperman's inequality derives sub-additivity from concavity; Bálint's theorem derives gap monotonicity from the convexity of auxiliary functions built from the AP root structure."
+      "relationship": "Both problems study outward monotonicity arising from convexity arguments on the real line. Kemperman's inequality derives sub-additivity from concavity; Bálint's theorem derives gap monotonicity from the convexity of auxiliary functions built from the AP root structure.",
+      "targetId": "erdos-1125"
     },
     {
-      "id": "erdos-229",
       "title": "Erdős Problem #229: Zeros of Derivatives of Entire Functions",
-      "relationship": "Shares the central theme of understanding how zeros of f' relate to zeros of f. Problem #229 asks about density of derivative zeros for entire functions; Problem #1114 answers a precise spacing question for the polynomial case when roots are in arithmetic progression."
+      "relationship": "Shares the central theme of understanding how zeros of f' relate to zeros of f. Problem #229 asks about density of derivative zeros for entire functions; Problem #1114 answers a precise spacing question for the polynomial case when roots are in arithmetic progression.",
+      "targetId": "erdos-229"
     },
     {
-      "id": "erdos-906",
       "title": "Erdős Problem #906: Dense Zeros of Derivative Subsequences",
-      "relationship": "Another problem in the root–derivative relationship cluster. Problem #906 studies density of zeros for subsequences of derivatives of entire functions; Problem #1114 studies monotone gap structure of zeros of the first derivative for polynomial families."
+      "relationship": "Another problem in the root–derivative relationship cluster. Problem #906 studies density of zeros for subsequences of derivatives of entire functions; Problem #1114 studies monotone gap structure of zeros of the first derivative for polynomial families.",
+      "targetId": "erdos-906"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -91,40 +91,40 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-513",
       "slug": "erdos-513",
       "title": "Erdős Problem #513: Maximum Term of a Power Series",
-      "relationship": "Both problems concern the maximum modulus function M(r) = max_{|z|=r} |f(z)| for entire functions. Problem #513 studies the ratio μ(r)/M(r) of the maximum term to maximum modulus, while #1117 studies the count of points achieving M(r). The Wiman–Valiron central index N(r) connects both problems."
+      "relationship": "Both problems concern the maximum modulus function M(r) = max_{|z|=r} |f(z)| for entire functions. Problem #513 studies the ratio μ(r)/M(r) of the maximum term to maximum modulus, while #1117 studies the count of points achieving M(r). The Wiman–Valiron central index N(r) connects both problems.",
+      "targetId": "erdos-513"
     },
     {
-      "id": "erdos-516",
       "slug": "erdos-516",
       "title": "Erdős Problem #516: Gap Series and the Minimum Modulus Problem",
-      "relationship": "Problem #516 studies minimum modulus m(r) vs maximum modulus M(r) for lacunary (Fabry gap) series. The Herzog–Piranian 1968 construction resolving Problem #1117 Question 1 also uses lacunary power series techniques, creating functions where dominant terms rotate to produce many maximum-modulus points at specific radii."
+      "relationship": "Problem #516 studies minimum modulus m(r) vs maximum modulus M(r) for lacunary (Fabry gap) series. The Herzog–Piranian 1968 construction resolving Problem #1117 Question 1 also uses lacunary power series techniques, creating functions where dominant terms rotate to produce many maximum-modulus points at specific radii.",
+      "targetId": "erdos-516"
     },
     {
-      "id": "erdos-1115",
       "slug": "erdos-1115",
       "title": "Erdős Problem #1115: Path Length for Entire Functions",
-      "relationship": "Neighboring problem from the same 1974 Hayman collection, also studying asymptotic behavior related to M(r). Problem #1115 asks about paths to infinity along which growth is controlled relative to M(r), with Gol'dberg–Eremenko providing the disproof — sharing the same classical function theory context and authors."
+      "relationship": "Neighboring problem from the same 1974 Hayman collection, also studying asymptotic behavior related to M(r). Problem #1115 asks about paths to infinity along which growth is controlled relative to M(r), with Gol'dberg–Eremenko providing the disproof — sharing the same classical function theory context and authors.",
+      "targetId": "erdos-1115"
     },
     {
-      "id": "erdos-1116",
       "slug": "erdos-1116",
       "title": "Erdős Problem #1116: Extreme Value Distribution of Entire Functions",
-      "relationship": "Direct neighbor in Hayman's collection: Problem #1116 asks whether entire functions can have extreme asymmetry in the counting function n(r,a) of a-points (Nevanlinna theory). Problem #1117 similarly asks about the counting function ν(r) of maximum-modulus points, representing dual aspects of value distribution theory for entire functions."
+      "relationship": "Direct neighbor in Hayman's collection: Problem #1116 asks whether entire functions can have extreme asymmetry in the counting function n(r,a) of a-points (Nevanlinna theory). Problem #1117 similarly asks about the counting function ν(r) of maximum-modulus points, representing dual aspects of value distribution theory for entire functions.",
+      "targetId": "erdos-1116"
     },
     {
-      "id": "erdos-1118",
       "slug": "erdos-1118",
       "title": "Erdős Problem #1118: Entire Functions with Finite Measure Superlevel Sets",
-      "relationship": "Neighboring problem about the geometry of level sets {z : |f(z)| > c}. Problem #1117 counts points on the level set |f(z)| = M(r) (the maximum modulus level set on a circle), while #1118 studies area properties of superlevel sets. Both probe the measure-theoretic and geometric structure of entire function level sets."
+      "relationship": "Neighboring problem about the geometry of level sets {z : |f(z)| > c}. Problem #1117 counts points on the level set |f(z)| = M(r) (the maximum modulus level set on a circle), while #1118 studies area properties of superlevel sets. Both probe the measure-theoretic and geometric structure of entire function level sets.",
+      "targetId": "erdos-1118"
     },
     {
-      "id": "erdos-906",
       "slug": "erdos-906",
       "title": "Erdős Problem #906: Dense Zeros of Derivative Subsequences",
-      "relationship": "Both problems involve entire functions with remarkable asymptotic or geometric properties that appear hard to achieve simultaneously. Problem #906 asks for transcendental entire functions with dense zeros of derivative subsequences; both exemplify Erdős's interest in extremal entire function constructions."
+      "relationship": "Both problems involve entire functions with remarkable asymptotic or geometric properties that appear hard to achieve simultaneously. Problem #906 asks for transcendental entire functions with dense zeros of derivative subsequences; both exemplify Erdős's interest in extremal entire function constructions.",
+      "targetId": "erdos-906"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1119/meta.json
+++ b/src/data/proofs/erdos-1119/meta.json
@@ -149,34 +149,34 @@
   },
   "crossReferences": [
     {
-      "id": "continuum-hypothesis",
       "title": "Independence of the Continuum Hypothesis",
-      "relationship": "The Wetzel problem (𝔪 = ℵ₀ case of Problem #1119) is equivalent to the negation of CH; this entry formalizes CH independence, the foundational set-theoretic backdrop for the entire problem"
+      "relationship": "The Wetzel problem (𝔪 = ℵ₀ case of Problem #1119) is equivalent to the negation of CH; this entry formalizes CH independence, the foundational set-theoretic backdrop for the entire problem",
+      "targetId": "continuum-hypothesis"
     },
     {
-      "id": "erdos-1118",
       "title": "Erdős Problem #1118: Entire Functions with Finite Measure Superlevel Sets",
-      "relationship": "A neighboring Erdős problem also concerning entire functions and analytic constraints; both problems probe how global analytic properties bound the size of function families"
+      "relationship": "A neighboring Erdős problem also concerning entire functions and analytic constraints; both problems probe how global analytic properties bound the size of function families",
+      "targetId": "erdos-1118"
     },
     {
-      "id": "cantor-diagonalization",
       "title": "Cantor's Diagonalization Theorem",
-      "relationship": "The diagonalization technique underlies the easy case (𝔪⁺ < 𝔠): one diagonalizes over value sets using the identity theorem to show the family is small"
+      "relationship": "The diagonalization technique underlies the easy case (𝔪⁺ < 𝔠): one diagonalizes over value sets using the identity theorem to show the family is small",
+      "targetId": "cantor-diagonalization"
     },
     {
-      "id": "godel-incompleteness",
       "title": "Gödel's First Incompleteness Theorem",
-      "relationship": "Both results demonstrate that natural mathematical statements can be undecidable; Problem #1119 is independent of ZFC when 𝔪⁺ = 𝔠, paralleling independence phenomena in logic"
+      "relationship": "Both results demonstrate that natural mathematical statements can be undecidable; Problem #1119 is independent of ZFC when 𝔪⁺ = 𝔠, paralleling independence phenomena in logic",
+      "targetId": "godel-incompleteness"
     },
     {
-      "id": "fundamental-theorem-algebra",
       "title": "Fundamental Theorem of Algebra",
-      "relationship": "Shares the setting of complex analysis; entire functions are the natural extension of polynomials to ℂ, and the identity theorem (central to Problem #1119) is a fundamental tool of complex function theory"
+      "relationship": "Shares the setting of complex analysis; entire functions are the natural extension of polynomials to ℂ, and the identity theorem (central to Problem #1119) is a fundamental tool of complex function theory",
+      "targetId": "fundamental-theorem-algebra"
     },
     {
-      "id": "parallel-postulate-independence",
       "title": "Independence of the Parallel Postulate",
-      "relationship": "A classical independence result: just as the parallel postulate is independent of the other Euclidean axioms, the Wetzel bound at 𝔪⁺ = 𝔠 is independent of ZFC, illustrating the same model-theoretic methodology"
+      "relationship": "A classical independence result: just as the parallel postulate is independent of the other Euclidean axioms, the Wetzel bound at 𝔪⁺ = 𝔠 is independent of ZFC, illustrating the same model-theoretic methodology",
+      "targetId": "parallel-postulate-independence"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1124/meta.json
+++ b/src/data/proofs/erdos-1124/meta.json
@@ -165,34 +165,34 @@
   ],
   "crossReferences": [
     {
-      "id": "lebesgue-measure",
       "title": "Lebesgue Measure",
-      "relationship": "The Dubins-Hirsch-Karush obstruction depends fundamentally on Lebesgue measure theory: translations are measure-preserving, so any translation-equidecomposition of Lebesgue-measurable sets must preserve measure, making the unit disk (area π) and unit square (area 1) measurably inequidecomposable"
+      "relationship": "The Dubins-Hirsch-Karush obstruction depends fundamentally on Lebesgue measure theory: translations are measure-preserving, so any translation-equidecomposition of Lebesgue-measurable sets must preserve measure, making the unit disk (area π) and unit square (area 1) measurably inequidecomposable",
+      "targetId": "lebesgue-measure"
     },
     {
-      "id": "area-of-circle",
       "title": "Area of a Circle",
-      "relationship": "The equal-area condition π·r² = s² is central to Tarski's problem — the disk and square must have the same area for equidecomposition to be geometrically possible, directly connecting the formula A = πr² to the problem's hypothesis"
+      "relationship": "The equal-area condition π·r² = s² is central to Tarski's problem — the disk and square must have the same area for equidecomposition to be geometrically possible, directly connecting the formula A = πr² to the problem's hypothesis",
+      "targetId": "area-of-circle"
     },
     {
-      "id": "angle-trisection",
       "title": "Impossibility of Trisecting an Angle",
-      "relationship": "Both are classical geometry impossibility-then-possibility problems: angle trisection is impossible with compass and straightedge, while Tarski's circle-squaring is impossible with measurable pieces but possible (non-constructively) with arbitrary sets — both illustrate how strengthening or weakening the allowed operations changes feasibility"
+      "relationship": "Both are classical geometry impossibility-then-possibility problems: angle trisection is impossible with compass and straightedge, while Tarski's circle-squaring is impossible with measurable pieces but possible (non-constructively) with arbitrary sets — both illustrate how strengthening or weakening the allowed operations changes feasibility",
+      "targetId": "angle-trisection"
     },
     {
-      "id": "parallel-postulate-independence",
       "title": "Independence of the Parallel Postulate",
-      "relationship": "Both results reveal unexpected independence: the parallel postulate is independent of the other Euclidean axioms, while Laczkovich's decomposition is independent of any constructive procedure — both require stepping outside the 'natural' framework (Euclidean geometry / measurable sets) to obtain the result"
+      "relationship": "Both results reveal unexpected independence: the parallel postulate is independent of the other Euclidean axioms, while Laczkovich's decomposition is independent of any constructive procedure — both require stepping outside the 'natural' framework (Euclidean geometry / measurable sets) to obtain the result",
+      "targetId": "parallel-postulate-independence"
     },
     {
-      "id": "erdos-1071",
       "title": "Maximal Packings of Unit Segments in the Unit Square",
-      "relationship": "Both are Erdős combinatorial geometry problems about finite decompositions and extremal configurations in the plane, exploring the boundary between finite combinatorial arguments and measure-theoretic obstructions"
+      "relationship": "Both are Erdős combinatorial geometry problems about finite decompositions and extremal configurations in the plane, exploring the boundary between finite combinatorial arguments and measure-theoretic obstructions",
+      "targetId": "erdos-1071"
     },
     {
-      "id": "erdos-1124-oq-01",
       "title": "How Few Pieces to Square a Circle?",
-      "relationship": "Direct open question arising from this formalization: Laczkovich's ~10^50 upper bound on piece count is almost certainly far from optimal, and this companion entry explores the open problem of determining or improving the minimum number of pieces required"
+      "relationship": "Direct open question arising from this formalization: Laczkovich's ~10^50 upper bound on piece count is almost certainly far from optimal, and this companion entry explores the open problem of determining or improving the minimum number of pieces required",
+      "targetId": "erdos-1124-oq-01"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1129/meta.json
+++ b/src/data/proofs/erdos-1129/meta.json
@@ -158,40 +158,40 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1130",
       "title": "Erdős Problem #1130: Lagrange Basis Function Sums",
       "relationship": "Companion problem: asks whether the minimum over subintervals of the maximum Lebesgue function is O(log n), directly complementing #1129's full characterization of optimal nodes and the (2/π) log n asymptotic.",
-      "relevance": "high"
+      "relevance": "high",
+      "targetId": "erdos-1130"
     },
     {
-      "id": "erdos-1131",
       "title": "Minimizing Lagrange Interpolation Basis Polynomial Integrals",
       "relationship": "L² analog of #1129: minimizes ∫ Σ|l_k(x)|² dx (Legendre nodes) rather than the L∞ Lebesgue constant. The equal-height equioscillation structure in #1129 has no direct L² counterpart, leaving the L² problem open.",
-      "relevance": "high"
+      "relevance": "high",
+      "targetId": "erdos-1131"
     },
     {
-      "id": "erdos-671",
       "title": "Erdős Problem #671: Lagrange Interpolation Convergence",
       "relationship": "Studies whether Lagrange interpolation at general nodes converges for continuous functions; uses the same Lebesgue constant framework and Faber's logarithmic lower bound established in #1129.",
-      "relevance": "high"
+      "relevance": "high",
+      "targetId": "erdos-671"
     },
     {
-      "id": "erdos-1132",
       "title": "Erdős Problem #1132: Lagrange Interpolation and Lebesgue Functions",
       "relationship": "Asks for sharp pointwise bounds on individual Lebesgue basis functions; shares the core definitions of LagrangeBasis and LebesgueFunction developed in #1129.",
-      "relevance": "medium"
+      "relevance": "medium",
+      "targetId": "erdos-1132"
     },
     {
-      "id": "erdos-1133",
       "title": "Erdős Problem #1133: Large Polynomial Interpolation Bound",
       "relationship": "Investigates the maximum of Lagrange interpolation polynomials for bounded functions; the Lebesgue constant bounds from #1129 provide key inputs to these upper estimates.",
-      "relevance": "medium"
+      "relevance": "medium",
+      "targetId": "erdos-1133"
     },
     {
-      "id": "de-moivre-oq-02",
       "title": "Chebyshev Polynomial Properties via De Moivre's Theorem",
       "relationship": "Establishes the recurrence, extremal, and equioscillation properties of Chebyshev polynomials T_n via De Moivre's theorem; these properties underlie the ChebyshevNodes definition and the upper bound Λ ≤ (2/π) log n + O(1) in #1129.",
-      "relevance": "medium"
+      "relevance": "medium",
+      "targetId": "de-moivre-oq-02"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1133/meta.json
+++ b/src/data/proofs/erdos-1133/meta.json
@@ -166,34 +166,34 @@
   ],
   "crossReferences": [
     {
-      "id": "erdos-1132",
       "title": "Erdős Problem #1132",
-      "relationship": "Direct companion: studies Lebesgue functions for infinite node sequences and Bernstein's density theorem. Together #1132 and #1133 form Erdős's paired attack on interpolation divergence phenomena."
+      "relationship": "Direct companion: studies Lebesgue functions for infinite node sequences and Bernstein's density theorem. Together #1132 and #1133 form Erdős's paired attack on interpolation divergence phenomena.",
+      "targetId": "erdos-1132"
     },
     {
-      "id": "erdos-1130",
       "title": "Erdős Problem #1130",
-      "relationship": "Studies the Υ functional (sums of Lagrange basis functions on subintervals), solved by de Boor–Pinkus (1978) with Υ ≤ (2/π) log n + O(1). The Lebesgue constant growth rate proved there underlies the divergence used in #1133."
+      "relationship": "Studies the Υ functional (sums of Lagrange basis functions on subintervals), solved by de Boor–Pinkus (1978) with Υ ≤ (2/π) log n + O(1). The Lebesgue constant growth rate proved there underlies the divergence used in #1133.",
+      "targetId": "erdos-1130"
     },
     {
-      "id": "erdos-1131",
       "title": "Erdős Problem #1131",
-      "relationship": "L² optimization of Lagrange basis polynomial integrals — a parallel to #1133's L∞ perspective. Both problems ask how optimal node placement interacts with polynomial norm bounds in different function spaces."
+      "relationship": "L² optimization of Lagrange basis polynomial integrals — a parallel to #1133's L∞ perspective. Both problems ask how optimal node placement interacts with polynomial norm bounds in different function spaces.",
+      "targetId": "erdos-1131"
     },
     {
-      "id": "taylor-theorem",
       "title": "Taylor's Theorem",
-      "relationship": "Foundational: Taylor polynomial approximation with explicit remainder bounds underpins interpolation error analysis. The remainder formula via divided differences makes Taylor's theorem the algebraic backbone of Lagrange theory."
+      "relationship": "Foundational: Taylor polynomial approximation with explicit remainder bounds underpins interpolation error analysis. The remainder formula via divided differences makes Taylor's theorem the algebraic backbone of Lagrange theory.",
+      "targetId": "taylor-theorem"
     },
     {
-      "id": "mean-value-theorem",
       "title": "Mean Value Theorem",
-      "relationship": "The Lagrange interpolation remainder R_n(x) = f^(n)(ξ)/(n!) · Π(x − x_i) relies on the generalized MVT for higher derivatives. Bounding this remainder is central to controlling interpolation error on [-1,1]."
+      "relationship": "The Lagrange interpolation remainder R_n(x) = f^(n)(ξ)/(n!) · Π(x − x_i) relies on the generalized MVT for higher derivatives. Bounding this remainder is central to controlling interpolation error on [-1,1].",
+      "targetId": "mean-value-theorem"
     },
     {
-      "id": "fourier-series",
       "title": "Fourier Series",
-      "relationship": "Parallel theory: Fourier approximation is L²-optimal while polynomial interpolation is analyzed in L∞. Both exhibit convergence-divergence phenomena (Carleson's theorem vs Faber's theorem), making their comparison a cornerstone of modern approximation theory."
+      "relationship": "Parallel theory: Fourier approximation is L²-optimal while polynomial interpolation is analyzed in L∞. Both exhibit convergence-divergence phenomena (Carleson's theorem vs Faber's theorem), making their comparison a cornerstone of modern approximation theory.",
+      "targetId": "fourier-series"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -99,34 +99,34 @@
   },
   "crossReferences": [
     {
-      "id": "collatz-structured",
       "title": "Collatz Conjecture for Structured Values",
-      "relationship": "Direct structural companion: #collatz-structured verifies Collatz convergence for powers of 2 and small concrete cases (including 27's 111-step orbit) using the same compressed map f(n) = n/2 or (3n+1)/2. Together these two entries present the full formalization strategy: computable definitions for concrete verification in collatz-structured, and axiomatized deep results (Tao, Krasikov–Lagarias) in erdos-1135."
+      "relationship": "Direct structural companion: #collatz-structured verifies Collatz convergence for powers of 2 and small concrete cases (including 27's 111-step orbit) using the same compressed map f(n) = n/2 or (3n+1)/2. Together these two entries present the full formalization strategy: computable definitions for concrete verification in collatz-structured, and axiomatized deep results (Tao, Krasikov–Lagarias) in erdos-1135.",
+      "targetId": "collatz-structured"
     },
     {
-      "id": "riemann-hypothesis",
       "title": "The Riemann Hypothesis",
-      "relationship": "Peer open Millennium-class conjecture: both the Collatz conjecture and RH are prize problems that remain open despite massive computational evidence and significant partial results. RH has been verified to enormous height for zeta zeros; Collatz has been checked to 2^68. Both are formalized via axiomatization of the deepest partial results, and both may require fundamentally new mathematics to resolve."
+      "relationship": "Peer open Millennium-class conjecture: both the Collatz conjecture and RH are prize problems that remain open despite massive computational evidence and significant partial results. RH has been verified to enormous height for zeta zeros; Collatz has been checked to 2^68. Both are formalized via axiomatization of the deepest partial results, and both may require fundamentally new mathematics to resolve.",
+      "targetId": "riemann-hypothesis"
     },
     {
-      "id": "fermats-last-theorem",
       "title": "Fermat's Last Theorem",
-      "relationship": "Instructive contrast: FLT stood open for 358 years despite simple statement and heavy computational evidence, then fell to a deep synthesis of modular forms and elliptic curves. Conway's undecidability result for generalized Collatz maps hints that the 3n+1 problem may require an equally unexpected conceptual bridge — possibly between ergodic theory, logic, and number theory."
+      "relationship": "Instructive contrast: FLT stood open for 358 years despite simple statement and heavy computational evidence, then fell to a deep synthesis of modular forms and elliptic curves. Conway's undecidability result for generalized Collatz maps hints that the 3n+1 problem may require an equally unexpected conceptual bridge — possibly between ergodic theory, logic, and number theory.",
+      "targetId": "fermats-last-theorem"
     },
     {
-      "id": "poincare-conjecture",
       "title": "The Poincaré Conjecture",
-      "relationship": "Resolved Millennium Prize problem used for methodological comparison: Perelman's proof required completely new analytical machinery (Ricci flow with surgery), bypassing all classical approaches. The Collatz conjecture, like the Poincaré Conjecture before its resolution, may await an unforeseen conceptual leap rather than incremental strengthening of existing density or ergodic bounds."
+      "relationship": "Resolved Millennium Prize problem used for methodological comparison: Perelman's proof required completely new analytical machinery (Ricci flow with surgery), bypassing all classical approaches. The Collatz conjecture, like the Poincaré Conjecture before its resolution, may await an unforeseen conceptual leap rather than incremental strengthening of existing density or ergodic bounds.",
+      "targetId": "poincare-conjecture"
     },
     {
-      "id": "bertrands-postulate",
       "title": "Bertrand's Postulate",
-      "relationship": "Erdős connection and proof culture: Erdős gave his celebrated elementary proof of Bertrand's Postulate in 1932 at age 19, demonstrating his characteristic style of 'elementary but deep' argument. The Collatz problem carries a $500 Erdős prize and shares the same 'deceptively elementary statement, resistant to elementary methods' character that fascinated Erdős throughout his career."
+      "relationship": "Erdős connection and proof culture: Erdős gave his celebrated elementary proof of Bertrand's Postulate in 1932 at age 19, demonstrating his characteristic style of 'elementary but deep' argument. The Collatz problem carries a $500 Erdős prize and shares the same 'deceptively elementary statement, resistant to elementary methods' character that fascinated Erdős throughout his career.",
+      "targetId": "bertrands-postulate"
     },
     {
-      "id": "prime-number-theorem",
       "title": "The Prime Number Theorem",
-      "relationship": "Analytic number theory benchmark: Tao's 2019 Collatz result uses entropy-decrement techniques on cyclic groups drawing on Fourier-analytic ideas from the same tradition as PNT proofs. Both results establish 'almost all' or 'typical' behavior — density for almost all integers — while the full exceptional-set question (all integers for Collatz, all zeros for RH) remains open."
+      "relationship": "Analytic number theory benchmark: Tao's 2019 Collatz result uses entropy-decrement techniques on cyclic groups drawing on Fourier-analytic ideas from the same tradition as PNT proofs. Both results establish 'almost all' or 'typical' behavior — density for almost all integers — while the full exceptional-set question (all integers for Collatz, all zeros for RH) remains open.",
+      "targetId": "prime-number-theorem"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1140/meta.json
+++ b/src/data/proofs/erdos-1140/meta.json
@@ -142,34 +142,34 @@
   },
   "crossReferences": [
     {
-      "id": "quadratic-reciprocity",
       "title": "Quadratic Reciprocity",
-      "relationship": "Gauss's law of quadratic reciprocity determines when 2 is a quadratic residue mod p. The Epure-Gica proof for n ≡ 1 (mod 4) uses this to analyze which residue classes can contain primes of the form n - 2x², forming the core of their sieve argument."
+      "relationship": "Gauss's law of quadratic reciprocity determines when 2 is a quadratic residue mod p. The Epure-Gica proof for n ≡ 1 (mod 4) uses this to analyze which residue classes can contain primes of the form n - 2x², forming the core of their sieve argument.",
+      "targetId": "quadratic-reciprocity"
     },
     {
-      "id": "fermat-two-squares",
       "title": "Fermat's Two-Square Theorem",
-      "relationship": "Fermat's theorem (p = a² + b² iff p ≡ 1 mod 4) exhibits the same mod-4 splitting structure central to the erdos-1140 disproof. Both results classify primes by residue behavior of quadratic forms, reflecting the same underlying theory of binary quadratic forms."
+      "relationship": "Fermat's theorem (p = a² + b² iff p ≡ 1 mod 4) exhibits the same mod-4 splitting structure central to the erdos-1140 disproof. Both results classify primes by residue behavior of quadratic forms, reflecting the same underlying theory of binary quadratic forms.",
+      "targetId": "fermat-two-squares"
     },
     {
-      "id": "chinese-remainder-constructive",
       "title": "Chinese Remainder Theorem (Constructive)",
-      "relationship": "The Epure-Gica sieve for the n ≡ 1 (mod 4) case combines congruence constraints on n - 2x² modulo small primes. The Chinese Remainder Theorem is used to assemble these local obstructions into a global finiteness argument eliminating all but finitely many candidates."
+      "relationship": "The Epure-Gica sieve for the n ≡ 1 (mod 4) case combines congruence constraints on n - 2x² modulo small primes. The Chinese Remainder Theorem is used to assemble these local obstructions into a global finiteness argument eliminating all but finitely many candidates.",
+      "targetId": "chinese-remainder-constructive"
     },
     {
-      "id": "bertrands-postulate",
       "title": "Bertrand's Postulate",
-      "relationship": "Bertrand's postulate guarantees a prime in (n, 2n], establishing that primes are 'common' at the logarithmic scale. This contextualizes the extreme rarity in erdos-1140: requiring all of {n, n-2, n-8, n-18, ...} to be simultaneously prime is far stronger than Bertrand's single-prime guarantee."
+      "relationship": "Bertrand's postulate guarantees a prime in (n, 2n], establishing that primes are 'common' at the logarithmic scale. This contextualizes the extreme rarity in erdos-1140: requiring all of {n, n-2, n-8, n-18, ...} to be simultaneously prime is far stronger than Bertrand's single-prime guarantee.",
+      "targetId": "bertrands-postulate"
     },
     {
-      "id": "dirichlets-theorem",
       "title": "Dirichlet's Theorem on Primes in Arithmetic Progressions",
-      "relationship": "Dirichlet's theorem shows primes are equidistributed across residue classes coprime to the modulus. The erdos-1140 problem requires primes in multiple arithmetic progressions simultaneously; the finiteness of solutions shows that Dirichlet density alone cannot sustain the simultaneous primality conditions for large n."
+      "relationship": "Dirichlet's theorem shows primes are equidistributed across residue classes coprime to the modulus. The erdos-1140 problem requires primes in multiple arithmetic progressions simultaneously; the finiteness of solutions shows that Dirichlet density alone cannot sustain the simultaneous primality conditions for large n.",
+      "targetId": "dirichlets-theorem"
     },
     {
-      "id": "prime-number-theorem",
       "title": "Prime Number Theorem",
-      "relationship": "The prime number theorem gives the probability that a number near n is prime as ~1/ln(n). Since AllShiftsArePrime(n) requires ~√(n/2) independent primality events, heuristically the expected number of solutions above N is ~∑ (1/ln(n))^{√(n/2)}, which converges — consistent with finitely many solutions."
+      "relationship": "The prime number theorem gives the probability that a number near n is prime as ~1/ln(n). Since AllShiftsArePrime(n) requires ~√(n/2) independent primality events, heuristically the expected number of solutions above N is ~∑ (1/ln(n))^{√(n/2)}, which converges — consistent with finitely many solutions.",
+      "targetId": "prime-number-theorem"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1141/meta.json
+++ b/src/data/proofs/erdos-1141/meta.json
@@ -156,34 +156,34 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1140",
       "relationship": "structural-sibling",
-      "description": "Erdős #1140 asks the same question but with 2x² instead of k² (restricted to coprime k). Epure-Gica disproved infinitude for that variant, making it a resolved counterpart to this open problem. The contrast illustrates how small structural changes to the subtraction formula can shift the problem from open to resolved."
+      "description": "Erdős #1140 asks the same question but with 2x² instead of k² (restricted to coprime k). Epure-Gica disproved infinitude for that variant, making it a resolved counterpart to this open problem. The contrast illustrates how small structural changes to the subtraction formula can shift the problem from open to resolved.",
+      "targetId": "erdos-1140"
     },
     {
-      "id": "erdos-1142",
       "relationship": "structural-sibling",
-      "description": "Erdős #1142 replaces the coprime-square condition with powers of 2: n − 2^k prime for all 1 < 2^k < n. The known values (up to 105) are even sparser than OEIS A214583, and the problem is likewise unresolved. Both problems share the same skeleton — requiring n minus every element of a structured set to be prime simultaneously."
+      "description": "Erdős #1142 replaces the coprime-square condition with powers of 2: n − 2^k prime for all 1 < 2^k < n. The known values (up to 105) are even sparser than OEIS A214583, and the problem is likewise unresolved. Both problems share the same skeleton — requiring n minus every element of a structured set to be prime simultaneously.",
+      "targetId": "erdos-1142"
     },
     {
-      "id": "erdos-1059",
       "relationship": "thematic",
-      "description": "Erdős #1059 asks whether infinitely many primes p satisfy p − k! composite for all k with k! < p. The flavor is dual: #1141 demands primality of n − k² for all eligible k, while #1059 demands compositeness of p − k!. Both are open problems where a universal primality/compositeness condition over a structured set forces the candidate values to be extremely rare."
+      "description": "Erdős #1059 asks whether infinitely many primes p satisfy p − k! composite for all k with k! < p. The flavor is dual: #1141 demands primality of n − k² for all eligible k, while #1059 demands compositeness of p − k!. Both are open problems where a universal primality/compositeness condition over a structured set forces the candidate values to be extremely rare.",
+      "targetId": "erdos-1059"
     },
     {
-      "id": "erdos-680",
       "relationship": "thematic",
-      "description": "Erdős #680 asks about the least prime factor of integers near n exceeding k² + 1. This problem directly involves the interplay between squares and prime factors, touching the same quadratic-prime boundary that defines the good values in #1141. Both problems concern how quadratic growth interacts with primality constraints."
+      "description": "Erdős #680 asks about the least prime factor of integers near n exceeding k² + 1. This problem directly involves the interplay between squares and prime factors, touching the same quadratic-prime boundary that defines the good values in #1141. Both problems concern how quadratic growth interacts with primality constraints.",
+      "targetId": "erdos-680"
     },
     {
-      "id": "erdos-17",
       "relationship": "thematic",
-      "description": "Erdős #17 on cluster primes asks whether every even n ≤ p − 3 is a difference of two primes ≤ p. The structural idea of representing integers as differences involving primes — and asking which n make this universal — parallels the coprime-square subtraction property. Both probe universality-of-primeness questions over finite ranges."
+      "description": "Erdős #17 on cluster primes asks whether every even n ≤ p − 3 is a difference of two primes ≤ p. The structural idea of representing integers as differences involving primes — and asking which n make this universal — parallels the coprime-square subtraction property. Both probe universality-of-primeness questions over finite ranges.",
+      "targetId": "erdos-17"
     },
     {
-      "id": "erdos-203",
       "relationship": "methodological",
-      "description": "Erdős #203 on covering systems and prime avoidance asks whether covering congruences can block all primality. Covering systems are a key tool for proving that sequences of the form n − f(k) contain no primes; they provide one potential route to showing the good-value sequence in #1141 is finite by constructing a covering for large n."
+      "description": "Erdős #203 on covering systems and prime avoidance asks whether covering congruences can block all primality. Covering systems are a key tool for proving that sequences of the form n − f(k) contain no primes; they provide one potential route to showing the good-value sequence in #1141 is finite by constructing a covering for large n.",
+      "targetId": "erdos-203"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -129,24 +129,24 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-156",
       "relationship": "related",
-      "description": "Erdős #156 (Minimum Size of Maximal Sidon Sets) — both problems study Sidon sets; #156 asks about maximality while #157 asks about basis properties"
+      "description": "Erdős #156 (Minimum Size of Maximal Sidon Sets) — both problems study Sidon sets; #156 asks about maximality while #157 asks about basis properties",
+      "targetId": "erdos-156"
     },
     {
-      "id": "erdos-158",
       "relationship": "related",
-      "description": "Erdős #158 (B₂[g] Sets) — generalizes Sidon sets (B₂ = B₂[1]) to allow g representations per sum; the density constraints change as g grows"
+      "description": "Erdős #158 (B₂[g] Sets) — generalizes Sidon sets (B₂ = B₂[1]) to allow g representations per sum; the density constraints change as g grows",
+      "targetId": "erdos-158"
     },
     {
-      "id": "erdos-1",
       "relationship": "related",
-      "description": "Erdős #1 (Distinct Subset Sums) — another problem about additive structure of sets, exploring how sums interact with set density"
+      "description": "Erdős #1 (Distinct Subset Sums) — another problem about additive structure of sets, exploring how sums interact with set density",
+      "targetId": "erdos-1"
     },
     {
-      "id": "prob-method-alteration",
       "relationship": "foundational",
-      "description": "Pilatte's proof uses the probabilistic method (specifically the Lovász Local Lemma) — the alteration method is a key technique in this family of arguments"
+      "description": "Pilatte's proof uses the probabilistic method (specifically the Lovász Local Lemma) — the alteration method is a key technique in this family of arguments",
+      "targetId": "prob-method-alteration"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-170/meta.json
+++ b/src/data/proofs/erdos-170/meta.json
@@ -168,19 +168,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-340-greedy-sidon",
       "title": "Greedy Sidon Sequence Infrastructure (Erdős Problem #340)",
-      "relationship": "Both study difference-based combinatorial structures: Sidon sets require all pairwise differences to be distinct, while perfect rulers require all differences 1..N to be realized"
+      "relationship": "Both study difference-based combinatorial structures: Sidon sets require all pairwise differences to be distinct, while perfect rulers require all differences 1..N to be realized",
+      "targetId": "erdos-340-greedy-sidon"
     },
     {
-      "id": "erdos-169",
       "title": "Erdős Problem #169: Harmonic Sum of AP-Free Sets",
-      "relationship": "Both concern extremal problems on sets of integers with constraints on their additive structure — AP-free sets vs. difference bases"
+      "relationship": "Both concern extremal problems on sets of integers with constraints on their additive structure — AP-free sets vs. difference bases",
+      "targetId": "erdos-169"
     },
     {
-      "id": "erdos-176",
       "title": "Erdős Problem #176: Discrepancy of Arithmetic Progressions",
-      "relationship": "Both involve arithmetic structure and optimal covering/balancing of integer ranges; difference bases cover all residues while discrepancy bounds measure uniformity"
+      "relationship": "Both involve arithmetic structure and optimal covering/balancing of integer ranges; difference bases cover all residues while discrepancy bounds measure uniformity",
+      "targetId": "erdos-176"
     }
   ]
 }

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -193,19 +193,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-173",
       "title": "Erdős Problem #173: Monochromatic Triangles in Plane Colorings",
-      "relationship": "Both concern chromatic properties of the Euclidean plane — #171 asks for χ(ℝ²) under unit distance constraints, #173 asks about monochromatic triangles under arbitrary plane colorings"
+      "relationship": "Both concern chromatic properties of the Euclidean plane — #171 asks for χ(ℝ²) under unit distance constraints, #173 asks about monochromatic triangles under arbitrary plane colorings",
+      "targetId": "erdos-173"
     },
     {
-      "id": "erdos-174",
       "title": "Erdős Problem #174: Euclidean Ramsey Sets",
-      "relationship": "Both involve geometric Ramsey theory in Euclidean space; unit distance graphs and Euclidean Ramsey sets both study unavoidable monochromatic geometric configurations"
+      "relationship": "Both involve geometric Ramsey theory in Euclidean space; unit distance graphs and Euclidean Ramsey sets both study unavoidable monochromatic geometric configurations",
+      "targetId": "erdos-174"
     },
     {
-      "id": "prob-method-lovasz-local",
       "title": "Lovász Local Lemma",
-      "relationship": "The Lovász Local Lemma is a key tool in chromatic number bounds for geometric graphs, including approaches to the Hadwiger-Nelson problem"
+      "relationship": "The Lovász Local Lemma is a key tool in chromatic number bounds for geometric graphs, including approaches to the Hadwiger-Nelson problem",
+      "targetId": "prob-method-lovasz-local"
     }
   ]
 }

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -162,19 +162,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-160",
       "title": "Erdős Problem #160: Rainbow-Free Colorings of Arithmetic Progressions",
-      "relationship": "Both concern partition regularity and monochromatic structures under finite colorings of ℕ — #172 seeks monochromatic sum-product sets, #160 avoids rainbow APs"
+      "relationship": "Both concern partition regularity and monochromatic structures under finite colorings of ℕ — #172 seeks monochromatic sum-product sets, #160 avoids rainbow APs",
+      "targetId": "erdos-160"
     },
     {
-      "id": "ramseys-theorem",
       "title": "Ramsey's Theorem",
-      "relationship": "Ramsey's theorem is the foundational result in partition regularity; Erdős #172 extends the Ramsey paradigm to combined additive and multiplicative structure"
+      "relationship": "Ramsey's theorem is the foundational result in partition regularity; Erdős #172 extends the Ramsey paradigm to combined additive and multiplicative structure",
+      "targetId": "ramseys-theorem"
     },
     {
-      "id": "erdos-174",
       "title": "Erdős Problem #174: Euclidean Ramsey Sets",
-      "relationship": "Both are Ramsey-type problems asking for unavoidable monochromatic configurations — #172 in arithmetic, #174 in geometry"
+      "relationship": "Both are Ramsey-type problems asking for unavoidable monochromatic configurations — #172 in arithmetic, #174 in geometry",
+      "targetId": "erdos-174"
     }
   ]
 }

--- a/src/data/proofs/erdos-174/meta.json
+++ b/src/data/proofs/erdos-174/meta.json
@@ -193,19 +193,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-171",
       "title": "Erdős Problem #171: Unit Distance Chromatic Number",
-      "relationship": "Both study chromatic/Ramsey properties of Euclidean space — #171 colors points to avoid unit distances, #174 colors points to avoid congruent copies of configurations"
+      "relationship": "Both study chromatic/Ramsey properties of Euclidean space — #171 colors points to avoid unit distances, #174 colors points to avoid congruent copies of configurations",
+      "targetId": "erdos-171"
     },
     {
-      "id": "ramseys-theorem",
       "title": "Ramsey's Theorem",
-      "relationship": "Euclidean Ramsey theory extends classical Ramsey theory to geometric settings; the EGMRSS framework generalizes Ramsey's graph-theoretic result to point configurations"
+      "relationship": "Euclidean Ramsey theory extends classical Ramsey theory to geometric settings; the EGMRSS framework generalizes Ramsey's graph-theoretic result to point configurations",
+      "targetId": "ramseys-theorem"
     },
     {
-      "id": "erdos-173",
       "title": "Erdős Problem #173: Monochromatic Triangles in Plane Colorings",
-      "relationship": "Both ask about unavoidable monochromatic geometric configurations in colored Euclidean space"
+      "relationship": "Both ask about unavoidable monochromatic geometric configurations in colored Euclidean space",
+      "targetId": "erdos-173"
     }
   ]
 }

--- a/src/data/proofs/erdos-175/meta.json
+++ b/src/data/proofs/erdos-175/meta.json
@@ -188,19 +188,19 @@
   },
   "crossReferences": [
     {
-      "id": "kummer-theorem",
       "title": "Kummer's Theorem on Binomial Coefficients",
-      "relationship": "Kummer's theorem is the central tool: v_p(C(2n,n)) equals the number of carries in base-p addition of n+n, governing the prime power structure of central binomial coefficients"
+      "relationship": "Kummer's theorem is the central tool: v_p(C(2n,n)) equals the number of carries in base-p addition of n+n, governing the prime power structure of central binomial coefficients",
+      "targetId": "kummer-theorem"
     },
     {
-      "id": "erdos-728-factorial-divisibility",
       "title": "Erdős Problem #728: Factorial Divisibility",
-      "relationship": "Both study p-adic valuations of combinatorial quantities — #175 examines v_p(C(2n,n)), #728 examines divisibility properties of factorials"
+      "relationship": "Both study p-adic valuations of combinatorial quantities — #175 examines v_p(C(2n,n)), #728 examines divisibility properties of factorials",
+      "targetId": "erdos-728-factorial-divisibility"
     },
     {
-      "id": "binomial-theorem",
       "title": "The Binomial Theorem",
-      "relationship": "The binomial theorem provides the algebraic foundation for binomial coefficients whose squarefreeness is studied in this problem"
+      "relationship": "The binomial theorem provides the algebraic foundation for binomial coefficients whose squarefreeness is studied in this problem",
+      "targetId": "binomial-theorem"
     }
   ]
 }

--- a/src/data/proofs/erdos-176/meta.json
+++ b/src/data/proofs/erdos-176/meta.json
@@ -200,19 +200,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-177",
       "title": "Erdős Problem #177: Discrepancy of Arithmetic Progressions",
-      "relationship": "Both concern discrepancy of colorings with respect to arithmetic progressions — #176 studies ±1 colorings, #177 addresses a closely related discrepancy formulation"
+      "relationship": "Both concern discrepancy of colorings with respect to arithmetic progressions — #176 studies ±1 colorings, #177 addresses a closely related discrepancy formulation",
+      "targetId": "erdos-177"
     },
     {
-      "id": "erdos-178",
       "title": "Erdős Problem #178: Balancing Infinite Collections of Integer Sequences",
-      "relationship": "Both are discrepancy problems asking for balanced colorings; #176 balances APs while #178 balances arbitrary infinite sequence families"
+      "relationship": "Both are discrepancy problems asking for balanced colorings; #176 balances APs while #178 balances arbitrary infinite sequence families",
+      "targetId": "erdos-178"
     },
     {
-      "id": "szemeredi-theorem",
       "title": "Szemerédi's Theorem (k=3 via Mathlib)",
-      "relationship": "Szemerédi's theorem on APs in dense sets is a fundamental companion result; the discrepancy problem #176 asks about ±1 balance on APs rather than AP existence"
+      "relationship": "Szemerédi's theorem on APs in dense sets is a fundamental companion result; the discrepancy problem #176 asks about ±1 balance on APs rather than AP existence",
+      "targetId": "szemeredi-theorem"
     }
   ]
 }

--- a/src/data/proofs/erdos-178/meta.json
+++ b/src/data/proofs/erdos-178/meta.json
@@ -205,19 +205,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-176",
       "title": "Erdős Problem #176: Discrepancy of Arithmetic Progressions",
-      "relationship": "Both are combinatorial discrepancy problems: #176 measures ±1 discrepancy on APs, while #178 asks whether infinite sequence families can be uniformly balanced"
+      "relationship": "Both are combinatorial discrepancy problems: #176 measures ±1 discrepancy on APs, while #178 asks whether infinite sequence families can be uniformly balanced",
+      "targetId": "erdos-176"
     },
     {
-      "id": "erdos-177",
       "title": "Erdős Problem #177: Discrepancy of Arithmetic Progressions",
-      "relationship": "Part of the same family of Erdős discrepancy problems; all three (#176, #177, #178) study the limits of balanced colorings for structured set systems"
+      "relationship": "Part of the same family of Erdős discrepancy problems; all three (#176, #177, #178) study the limits of balanced colorings for structured set systems",
+      "targetId": "erdos-177"
     },
     {
-      "id": "erdos-162",
       "title": "Erdős Problem #162: Discrepancy in 2-Coloured Complete Graphs",
-      "relationship": "Both concern discrepancy in combinatorial structures — #162 studies graph colorings while #178 studies sequence balancing"
+      "relationship": "Both concern discrepancy in combinatorial structures — #162 studies graph colorings while #178 studies sequence balancing",
+      "targetId": "erdos-162"
     }
   ]
 }

--- a/src/data/proofs/erdos-180/meta.json
+++ b/src/data/proofs/erdos-180/meta.json
@@ -181,19 +181,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-182",
       "title": "Erdős Problem #182: Maximum Edges Avoiding k-Regular Subgraphs",
-      "relationship": "Both are extremal graph theory problems asking for edge-density thresholds that force specific substructures — forbidden graph families (#180) vs. regular subgraphs (#182)"
+      "relationship": "Both are extremal graph theory problems asking for edge-density thresholds that force specific substructures — forbidden graph families (#180) vs. regular subgraphs (#182)",
+      "targetId": "erdos-182"
     },
     {
-      "id": "szemeredi-regularity",
       "title": "Szemerédi Regularity Lemma",
-      "relationship": "The regularity lemma is a key tool in extremal graph theory; the Erdős-Stone theorem (central to #180) is proved via regularity arguments"
+      "relationship": "The regularity lemma is a key tool in extremal graph theory; the Erdős-Stone theorem (central to #180) is proved via regularity arguments",
+      "targetId": "szemeredi-regularity"
     },
     {
-      "id": "erdos-167",
       "title": "Erdős Problem #167: Tuza's Conjecture",
-      "relationship": "Both concern extremal properties of graph families — Tuza's conjecture relates triangle covering to packing, while #180 asks about Turán number domination"
+      "relationship": "Both concern extremal properties of graph families — Tuza's conjecture relates triangle covering to packing, while #180 asks about Turán number domination",
+      "targetId": "erdos-167"
     }
   ]
 }

--- a/src/data/proofs/erdos-182/meta.json
+++ b/src/data/proofs/erdos-182/meta.json
@@ -191,19 +191,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-180",
       "title": "Erdős Problem #180: Turán Numbers for Graph Families",
-      "relationship": "Both are extremal graph theory problems about edge-density thresholds — #180 asks about Turán number domination, #182 about the threshold for forced k-regular subgraphs"
+      "relationship": "Both are extremal graph theory problems about edge-density thresholds — #180 asks about Turán number domination, #182 about the threshold for forced k-regular subgraphs",
+      "targetId": "erdos-180"
     },
     {
-      "id": "erdos-181",
       "title": "Erdős Problem #181: Ramsey Number of the Hypercube",
-      "relationship": "Both are graph-theoretic problems by Erdős concerning structural properties of dense graphs — forced substructures (regular subgraphs vs. hypercubes)"
+      "relationship": "Both are graph-theoretic problems by Erdős concerning structural properties of dense graphs — forced substructures (regular subgraphs vs. hypercubes)",
+      "targetId": "erdos-181"
     },
     {
-      "id": "szemeredi-regularity",
       "title": "Szemerédi Regularity Lemma",
-      "relationship": "The regularity lemma is a standard tool in extremal graph theory; the iterative argument in Janzer-Sudakov's resolution uses regularity-type structural decompositions"
+      "relationship": "The regularity lemma is a standard tool in extremal graph theory; the iterative argument in Janzer-Sudakov's resolution uses regularity-type structural decompositions",
+      "targetId": "szemeredi-regularity"
     }
   ]
 }

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -175,19 +175,19 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-165",
       "title": "Erdős Problem #165: Asymptotic Formula for R(3,k)",
-      "relationship": "Both concern triangle Ramsey numbers — #165 studies the two-color R(3,k), while #183 generalizes to the k-color R(3;k)"
+      "relationship": "Both concern triangle Ramsey numbers — #165 studies the two-color R(3,k), while #183 generalizes to the k-color R(3;k)",
+      "targetId": "erdos-165"
     },
     {
-      "id": "erdos-166",
       "title": "Erdős Problem #166: Ramsey Number R(4,k) Lower Bound",
-      "relationship": "Both study growth rates of Ramsey numbers; #166 concerns R(4,k) lower bounds while #183 concerns the multicolor triangle Ramsey number R(3;k)"
+      "relationship": "Both study growth rates of Ramsey numbers; #166 concerns R(4,k) lower bounds while #183 concerns the multicolor triangle Ramsey number R(3;k)",
+      "targetId": "erdos-166"
     },
     {
-      "id": "ramseys-theorem",
       "title": "Ramsey's Theorem",
-      "relationship": "Ramsey's theorem guarantees the finiteness of R(3;k); the multicolor generalization of Ramsey's theorem is the starting point for #183"
+      "relationship": "Ramsey's theorem guarantees the finiteness of R(3;k); the multicolor generalization of Ramsey's theorem is the starting point for #183",
+      "targetId": "ramseys-theorem"
     }
   ]
 }

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -214,29 +214,29 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-65",
       "title": "Erdős Problem #65: Cycle Lengths in Dense Graphs",
-      "relationship": "Companion problem on cycle length diversity: #65 asks whether Σ 1/aᵢ ≫ log k for cycle lengths in kn-edge graphs, while #64 asks whether the specific sparse set {4,8,16,...} is unavoidable. Both are driven by Gyárfás's work on cycle structure and use the Liu-Montgomery even-cycle spectrum as a key tool."
+      "relationship": "Companion problem on cycle length diversity: #65 asks whether Σ 1/aᵢ ≫ log k for cycle lengths in kn-edge graphs, while #64 asks whether the specific sparse set {4,8,16,...} is unavoidable. Both are driven by Gyárfás's work on cycle structure and use the Liu-Montgomery even-cycle spectrum as a key tool.",
+      "targetId": "erdos-65"
     },
     {
-      "id": "erdos-72",
       "title": "Erdős Problem #72: Unavoidable Cycle Lengths",
-      "relationship": "Direct thematic sibling: #72 asks which sparse sets A of natural numbers become unavoidable cycle lengths at high enough average degree. Problem #64 is the special case A = {2^k : k ≥ 2}. Both problems resist the same proof strategies and illustrate how exponentially sparse sets are hardest to force."
+      "relationship": "Direct thematic sibling: #72 asks which sparse sets A of natural numbers become unavoidable cycle lengths at high enough average degree. Problem #64 is the special case A = {2^k : k ≥ 2}. Both problems resist the same proof strategies and illustrate how exponentially sparse sets are hardest to force.",
+      "targetId": "erdos-72"
     },
     {
-      "id": "erdos-1012",
       "title": "Erdős Problem #1012: Long Cycles in Dense Graphs",
-      "relationship": "Complements #64 from the dense end: #1012 (Woodall's conjecture) concerns near-Hamiltonian long cycles in graphs above a clique-density threshold, while #64 concerns sparse power-of-two cycles at minimum degree 3. Together they span the degree spectrum of cycle-forcing results."
+      "relationship": "Complements #64 from the dense end: #1012 (Woodall's conjecture) concerns near-Hamiltonian long cycles in graphs above a clique-density threshold, while #64 concerns sparse power-of-two cycles at minimum degree 3. Together they span the degree spectrum of cycle-forcing results.",
+      "targetId": "erdos-1012"
     },
     {
-      "id": "ramseys-theorem",
       "title": "Ramsey's Theorem",
-      "relationship": "Foundational unavoidability result that motivates the framework of #64. Ramsey theory establishes that sufficiently dense structures must contain ordered substructures; #64 asks an analogous question in the cycle-length setting: does minimum degree 3 force a combinatorially structured cycle length."
+      "relationship": "Foundational unavoidability result that motivates the framework of #64. Ramsey theory establishes that sufficiently dense structures must contain ordered substructures; #64 asks an analogous question in the cycle-length setting: does minimum degree 3 force a combinatorially structured cycle length.",
+      "targetId": "ramseys-theorem"
     },
     {
-      "id": "szemeredi-regularity",
       "title": "Szemerédi Regularity Lemma",
-      "relationship": "The Liu-Montgomery proof (which resolves #64 for large minimum degree) relies on regularity-method ideas to find even cycles in a geometric length range. The regularity lemma is the key technical engine behind this partial resolution, making this the most important proof-technique cross-reference for #64."
+      "relationship": "The Liu-Montgomery proof (which resolves #64 for large minimum degree) relies on regularity-method ideas to find even cycles in a geometric length range. The regularity lemma is the key technical engine behind this partial resolution, making this the most important proof-technique cross-reference for #64.",
+      "targetId": "szemeredi-regularity"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-65/meta.json
+++ b/src/data/proofs/erdos-65/meta.json
@@ -115,28 +115,28 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-64",
-      "relevance": "Companion problem on cycle lengths in graphs with minimum degree 3; both problems study how graph structure forces specific cycle lengths."
+      "relevance": "Companion problem on cycle lengths in graphs with minimum degree 3; both problems study how graph structure forces specific cycle lengths.",
+      "targetId": "erdos-64"
     },
     {
-      "id": "erdos-72",
-      "relevance": "Directly related: asks which cycle lengths are unavoidable in dense graphs, complementing the reciprocal-sum question of Problem 65."
+      "relevance": "Directly related: asks which cycle lengths are unavoidable in dense graphs, complementing the reciprocal-sum question of Problem 65.",
+      "targetId": "erdos-72"
     },
     {
-      "id": "erdos-73",
-      "relevance": "Concerns almost-bipartite graphs, connecting to the role of complete bipartite graphs as extremal examples in Problem 65."
+      "relevance": "Concerns almost-bipartite graphs, connecting to the role of complete bipartite graphs as extremal examples in Problem 65.",
+      "targetId": "erdos-73"
     },
     {
-      "id": "erdos-1012",
-      "relevance": "Asks about long cycles in dense graphs; shares the edge-density vs cycle-structure theme and uses overlapping techniques."
+      "relevance": "Asks about long cycles in dense graphs; shares the edge-density vs cycle-structure theme and uses overlapping techniques.",
+      "targetId": "erdos-1012"
     },
     {
-      "id": "szemeredi-regularity",
-      "relevance": "The Szemerédi Regularity Lemma is a key tool in proving cycle-structure results for dense graphs, including the GKS theorem approach."
+      "relevance": "The Szemerédi Regularity Lemma is a key tool in proving cycle-structure results for dense graphs, including the GKS theorem approach.",
+      "targetId": "szemeredi-regularity"
     },
     {
-      "id": "ramseys-theorem",
-      "relevance": "Ramsey theory underlies extremal combinatorics; forbidden-subgraph methods used in the Zarankiewicz connection appear here."
+      "relevance": "Ramsey theory underlies extremal combinatorics; forbidden-subgraph methods used in the Zarankiewicz connection appear here.",
+      "targetId": "ramseys-theorem"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-67/meta.json
+++ b/src/data/proofs/erdos-67/meta.json
@@ -137,29 +137,29 @@
   },
   "crossReferences": [
     {
-      "id": "erdos-1028",
       "title": "Erdős Problem #1028: Discrepancy of Sign Functions",
-      "relationship": "Direct sibling in discrepancy theory. Where Erdős #67 asks about ±1 sequences on arithmetic progressions, #1028 studies H(n) = the min-max discrepancy of ±1 functions on pairs, establishing H(n) = Θ(n^(3/2)). Both problems probe how evenly ±1 assignments can be balanced over structured combinatorial objects."
+      "relationship": "Direct sibling in discrepancy theory. Where Erdős #67 asks about ±1 sequences on arithmetic progressions, #1028 studies H(n) = the min-max discrepancy of ±1 functions on pairs, establishing H(n) = Θ(n^(3/2)). Both problems probe how evenly ±1 assignments can be balanced over structured combinatorial objects.",
+      "targetId": "erdos-1028"
     },
     {
-      "id": "ramseys-theorem",
       "title": "Ramsey's Theorem",
-      "relationship": "Foundational companion in combinatorics. Ramsey theory guarantees unavoidable monochromatic structure in colorings; the discrepancy problem guarantees unavoidable imbalance in ±1 sequences. Tao's proof borrows Ramsey-type density arguments when reducing to multiplicative functions."
+      "relationship": "Foundational companion in combinatorics. Ramsey theory guarantees unavoidable monochromatic structure in colorings; the discrepancy problem guarantees unavoidable imbalance in ±1 sequences. Tao's proof borrows Ramsey-type density arguments when reducing to multiplicative functions.",
+      "targetId": "ramseys-theorem"
     },
     {
-      "id": "szemeredi-regularity",
       "title": "Szemerédi Regularity Lemma",
-      "relationship": "Deep structural connection via arithmetic progressions. Szemerédi's regularity machinery underlies results about dense subsets of integers containing arithmetic progressions, and Tao's proof of the discrepancy problem uses related harmonic-analysis and ergodic-theory techniques that grew from this tradition."
+      "relationship": "Deep structural connection via arithmetic progressions. Szemerédi's regularity machinery underlies results about dense subsets of integers containing arithmetic progressions, and Tao's proof of the discrepancy problem uses related harmonic-analysis and ergodic-theory techniques that grew from this tradition.",
+      "targetId": "szemeredi-regularity"
     },
     {
-      "id": "erdos-1",
       "title": "Erdős Problem #1: Distinct Subset Sums",
-      "relationship": "Related extremal combinatorics. Both problems concern the extremal behavior of integer-valued sequences under summation constraints. Techniques for bounding subset sums inform the discrepancy framework, and both problems illustrate Erdős's style of seeking sharp quantitative thresholds."
+      "relationship": "Related extremal combinatorics. Both problems concern the extremal behavior of integer-valued sequences under summation constraints. Techniques for bounding subset sums inform the discrepancy framework, and both problems illustrate Erdős's style of seeking sharp quantitative thresholds.",
+      "targetId": "erdos-1"
     },
     {
-      "id": "erdos-72",
       "title": "Erdős Problem #72: Unavoidable Cycle Lengths",
-      "relationship": "Thematic parallel in unavoidability results. Erdős #72 proves that certain combinatorial patterns cannot be avoided; the discrepancy theorem proves that imbalance cannot be suppressed. Both exemplify the principle that sufficiently dense or long structures must contain unavoidable substructure."
+      "relationship": "Thematic parallel in unavoidability results. Erdős #72 proves that certain combinatorial patterns cannot be avoided; the discrepancy theorem proves that imbalance cannot be suppressed. Both exemplify the principle that sufficiently dense or long structures must contain unavoidable substructure.",
+      "targetId": "erdos-72"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-72/meta.json
+++ b/src/data/proofs/erdos-72/meta.json
@@ -164,24 +164,24 @@
   ],
   "crossReferences": [
     {
-      "id": "erdos-64",
-      "relationship": "Direct companion problem: asks whether minimum-degree-3 graphs contain power-of-2 cycles, sharing the same central set A = {2^k} with Problem #72's Liu-Montgomery answer"
+      "relationship": "Direct companion problem: asks whether minimum-degree-3 graphs contain power-of-2 cycles, sharing the same central set A = {2^k} with Problem #72's Liu-Montgomery answer",
+      "targetId": "erdos-64"
     },
     {
-      "id": "erdos-65",
-      "relationship": "Sibling problem on cycle lengths in dense graphs: asks about the reciprocal sum of cycle lengths, complementing Problem #72's existence question for unavoidable sets"
+      "relationship": "Sibling problem on cycle lengths in dense graphs: asks about the reciprocal sum of cycle lengths, complementing Problem #72's existence question for unavoidable sets",
+      "targetId": "erdos-65"
     },
     {
-      "id": "erdos-1012",
-      "relationship": "Related extremal result: characterizes graphs with long cycles via edge density, using similar density-threshold techniques to Problem #72's unavoidability framework"
+      "relationship": "Related extremal result: characterizes graphs with long cycles via edge density, using similar density-threshold techniques to Problem #72's unavoidability framework",
+      "targetId": "erdos-1012"
     },
     {
-      "id": "szemeredi-regularity",
-      "relationship": "Core technique in the Liu-Montgomery (2020) proof: the regularity lemma is used to decompose dense graphs into structured pieces where cycle detection proceeds"
+      "relationship": "Core technique in the Liu-Montgomery (2020) proof: the regularity lemma is used to decompose dense graphs into structured pieces where cycle detection proceeds",
+      "targetId": "szemeredi-regularity"
     },
     {
-      "id": "ramseys-theorem",
-      "relationship": "Foundational combinatorics result underpinning extremal graph theory; the density-forcing philosophy of Ramsey theory informs why high average degree compels specific substructures"
+      "relationship": "Foundational combinatorics result underpinning extremal graph theory; the density-forcing philosophy of Ramsey theory informs why high average degree compels specific substructures",
+      "targetId": "ramseys-theorem"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/sophie-germain/meta.json
+++ b/src/data/proofs/sophie-germain/meta.json
@@ -119,29 +119,29 @@
   ],
   "crossReferences": [
     {
-      "id": "fermats-last-theorem",
       "relationship": "related",
-      "description": "Sophie Germain's original motivation: she proved the first case of FLT holds for Sophie Germain prime exponents"
+      "description": "Sophie Germain's original motivation: she proved the first case of FLT holds for Sophie Germain prime exponents",
+      "targetId": "fermats-last-theorem"
     },
     {
-      "id": "infinitude-primes",
       "relationship": "related",
-      "description": "Whether there are infinitely many Sophie Germain primes remains open, analogous to the infinitude of primes result"
+      "description": "Whether there are infinitely many Sophie Germain primes remains open, analogous to the infinitude of primes result",
+      "targetId": "infinitude-primes"
     },
     {
-      "id": "twin-primes-special",
       "relationship": "related",
-      "description": "The Sophie Germain prime conjecture is analogous to the twin prime conjecture — both ask about structured prime pairs"
+      "description": "The Sophie Germain prime conjecture is analogous to the twin prime conjecture — both ask about structured prime pairs",
+      "targetId": "twin-primes-special"
     },
     {
-      "id": "dirichlets-theorem",
       "relationship": "related",
-      "description": "Dirichlet's theorem on primes in arithmetic progressions provides the framework for understanding primes ≡ 5 (mod 6)"
+      "description": "Dirichlet's theorem on primes in arithmetic progressions provides the framework for understanding primes ≡ 5 (mod 6)",
+      "targetId": "dirichlets-theorem"
     },
     {
-      "id": "wilsons-theorem",
       "relationship": "related",
-      "description": "Wilson's theorem provides another primality criterion; safe primes have special properties under Wilson's characterization"
+      "description": "Wilson's theorem provides another primality criterion; safe primes have special properties under Wilson's characterization",
+      "targetId": "wilsons-theorem"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Bulk fix for 51 gallery entries that used non-standard `id` field in `crossReferences` instead of the expected `targetId` field. No content changes, only field name normalization.

Affected entries span erdos problems, bezout-identity, cantors-theorem, collatz, and sophie-germain.

## Test plan

- [x] JSON validation passes for all 51 files
- [x] No content changes (only key renames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)