### PR TITLE
Research: erdos-414 - prove 10 of 14 axioms (14→4)

### DIFF
--- a/proofs/Proofs/Erdos414Problem.lean
+++ b/proofs/Proofs/Erdos414Problem.lean
@@ -19,7 +19,7 @@ h_i(m) = h_j(n)?
 - <https://erdosproblems.com/414>
 -/
 
-import Mathlib.Data.Nat.Divisors
+import Mathlib.NumberTheory.Divisors
 import Mathlib.Data.Nat.Basic
 import Mathlib.Tactic
 
@@ -35,30 +35,55 @@ def hOrbit (n : ℕ) : ℕ → ℕ
 
 /- ## Basic Properties -/
 
+/-- Every n ≥ 1 has at least one divisor (namely 1). -/
+private theorem divisors_card_pos (n : ℕ) (hn : n ≥ 1) :
+    n.divisors.card ≥ 1 := by
+  have h1 : 1 ∈ n.divisors := by
+    rw [Nat.mem_divisors]
+    exact ⟨one_dvd n, by omega⟩
+  exact Finset.card_pos.mpr ⟨1, h1⟩
+
 /-- h(n) > n for all n ≥ 1 since τ(n) ≥ 1. -/
-axiom h_strictly_increasing (n : ℕ) (hn : n ≥ 1) :
-  h n > n
+theorem h_strictly_increasing (n : ℕ) (hn : n ≥ 1) :
+    h n > n := by
+  unfold h
+  have := divisors_card_pos n hn
+  omega
+
+/-- The orbit values are at least 1 when starting from n ≥ 1. -/
+private theorem hOrbit_pos (n : ℕ) (hn : n ≥ 1) (k : ℕ) :
+    hOrbit n k ≥ 1 := by
+  induction k with
+  | zero => simp [hOrbit]; exact hn
+  | succ k ih =>
+    simp [hOrbit]
+    have := h_strictly_increasing (hOrbit n k) ih
+    omega
 
 /-- The orbit is strictly increasing: h^{k+1}(n) > h^k(n) for n ≥ 1. -/
-axiom orbit_strictly_increasing (n : ℕ) (hn : n ≥ 1) (k : ℕ) :
-  hOrbit n (k + 1) > hOrbit n k
+theorem orbit_strictly_increasing (n : ℕ) (hn : n ≥ 1) (k : ℕ) :
+    hOrbit n (k + 1) > hOrbit n k := by
+  simp [hOrbit]
+  exact h_strictly_increasing (hOrbit n k) (hOrbit_pos n hn k)
 
-/-- h(n) ≤ 2n for all n ≥ 1 (since τ(n) ≤ n). -/
+/-- h(n) ≤ 2n for all n ≥ 1 (since τ(n) ≤ n).
+    The bound τ(n) ≤ n requires Finset.Icc card lemmas not easily accessible. -/
 axiom h_upper (n : ℕ) (hn : n ≥ 1) :
-  h n ≤ 2 * n
+    h n ≤ 2 * n
 
 /-- For primes p, h(p) = p + 2 (since τ(p) = 2). -/
-axiom h_prime (p : ℕ) (hp : p.Prime) :
-  h p = p + 2
+theorem h_prime (p : ℕ) (hp : p.Prime) :
+    h p = p + 2 := by
+  simp [h, Nat.Prime.divisors hp, Finset.card_pair (ne_of_lt hp.one_lt)]
 
 /-- h(1) = 1 + τ(1) = 1 + 1 = 2. -/
-axiom h_one : h 1 = 2
+theorem h_one : h 1 = 2 := by native_decide
 
 /-- h(2) = 2 + τ(2) = 2 + 2 = 4. -/
-axiom h_two : h 2 = 4
+theorem h_two : h 2 = 4 := by native_decide
 
 /-- h(3) = 3 + τ(3) = 3 + 2 = 5. -/
-axiom h_three : h 3 = 5
+theorem h_three : h 3 = 5 := by native_decide
 
 /- ## Main Conjecture -/
 
@@ -78,26 +103,37 @@ axiom single_eventual_orbit :
 /- ## Orbit Examples -/
 
 /-- Orbit of 1: 1 → 2 → 4 → 7 → 9 → 12 → 18 → 24 → 32 → ... -/
-axiom orbit_1_start :
-  hOrbit 1 0 = 1 ∧ hOrbit 1 1 = 2 ∧ hOrbit 1 2 = 4 ∧
-  hOrbit 1 3 = 7 ∧ hOrbit 1 4 = 9
+theorem orbit_1_start :
+    hOrbit 1 0 = 1 ∧ hOrbit 1 1 = 2 ∧ hOrbit 1 2 = 4 ∧
+    hOrbit 1 3 = 7 ∧ hOrbit 1 4 = 9 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
 
 /-- Orbit of 3: 3 → 5 → 7 → 9 → 12 → 18 → 24 → 32 → ...
     Merges with orbit of 1 at value 7 (h_3(1) = h_1(3) = 7). -/
-axiom orbit_3_merges_with_1 :
-  hOrbit 3 2 = hOrbit 1 3  -- both equal 7
+theorem orbit_3_merges_with_1 :
+    hOrbit 3 2 = hOrbit 1 3 := by  -- both equal 7
+  native_decide
 
 /- ## Growth Rate Analysis -/
 
 /-- On average, τ(n) ~ log n (Dirichlet's theorem on average order).
     So h(n) ≈ n + log n, and after k iterations,
     h^k(n) ≈ n + k · log n (roughly). -/
-axiom average_divisor_count :
-  True  -- Σ_{n≤N} τ(n) ~ N log N (Dirichlet)
+theorem average_divisor_count :
+    True :=  -- Σ_{n≤N} τ(n) ~ N log N (Dirichlet)
+  trivial
 
-/-- The orbit grows at least linearly: h^k(n) ≥ n + k for n ≥ 1. -/
-axiom orbit_linear_lower (n : ℕ) (hn : n ≥ 1) (k : ℕ) :
-  hOrbit n k ≥ n + k
+/-- The orbit grows at least linearly: h^k(n) ≥ n + k for n ≥ 1.
+    Proved by induction using h(m) > m for m ≥ 1. -/
+theorem orbit_linear_lower (n : ℕ) (hn : n ≥ 1) (k : ℕ) :
+    hOrbit n k ≥ n + k := by
+  induction k with
+  | zero => simp [hOrbit]
+  | succ k ih =>
+    simp [hOrbit]
+    have hpos := hOrbit_pos n hn k
+    have hgt := h_strictly_increasing (hOrbit n k) hpos
+    omega
 
 /-- Two orbits starting at m and n must eventually be "close" since
     both grow at rate ~ log(current value), and gaps between

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -46,7 +46,7 @@
         "relation": "The Collatz conjecture: canonical example of orbit coalescence for an iterated function, but with non-monotone dynamics"
       }
     ],
-    "axiomCount": 14,
+    "axiomCount": 4,
     "assumptions": [
       "h_strictly_increasing: h(n) > n for n ≥ 1",
       "orbit_strictly_increasing: orbits are strictly increasing sequences",
@@ -63,7 +63,7 @@
       "orbit_linear_lower: orbit values grow at least linearly",
       "orbits_get_close: weaker statement that orbits get arbitrarily close"
     ],
-    "lineCount": 109
+    "lineCount": 145
   },
   "sections": [
     {
@@ -209,8 +209,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 109,
-    "axiomCount": 14,
+    "lineCount": 145,
+    "axiomCount": 4,
     "theoremCount": 0,
     "definitionCount": 2
   },

--- a/src/data/research/problems/erdos-414.json
+++ b/src/data/research/problems/erdos-414.json
@@ -29,9 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: 10 of 14 axioms proved (14→4). Remaining 4: erdos_414_conjecture (OPEN), single_eventual_orbit (equiv), h_upper (needs card bound), orbits_get_close (heuristic).",
+    "builtItems": [
+      "Proved h_strictly_increasing, orbit_strictly_increasing, h_prime, h_one, h_two, h_three",
+      "Proved orbit_1_start, orbit_3_merges_with_1 via native_decide",
+      "Proved orbit_linear_lower by induction, average_divisor_count trivially"
+    ],
+    "insights": [
+      "10 of 14 axioms proved from definitions and Mathlib",
+      "h and hOrbit are concrete definitions, enabling computational proofs",
+      "h_strictly_increasing: divisors_card_pos (1 is always a divisor)",
+      "h_prime: Nat.Prime.divisors + Finset.card_pair",
+      "Computed values (h_one/two/three, orbits) proved via native_decide",
+      "orbit_linear_lower: induction using h_strictly_increasing"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #414 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h_1(n)=h(n)=n+\\tau(n)$ (where $\\tau(n)$ counts the number of divisors of $n$) and $h_k(n)=h(h_{k-1}(n))$. Is it true, for any $m,n$, there exist $i$ and $j$ such that $h_i(m)=h_j(n)$?\n\n\n\nAsked by Spiro. That is, there is (eventually) only one possible sequence that the iterations of $n\\mapsto h(n)$ can settle on. Erd\\H{o}s and Graham believed the answer is yes. Similar questions can be asked by the iterates of many other functions. See also [412] and [413].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #412\n- Problem #413\n- Problem #415\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"


### PR DESCRIPTION
## Summary
- Eliminated **10 of 14 axioms** in Erdős #414 (Merging Orbits of h(n) = n + τ(n))
- **Axiom count: 14 → 4**
- Docker build verified

## Key Insight
Since `h(n) = n + n.divisors.card` and `hOrbit` are concrete definitions (not opaque axioms), many "axioms" about their behavior are directly provable from the definitions.

## Axioms Proved (10)
| Axiom | Method |
|-------|--------|
| `h_strictly_increasing` | `1 ∈ n.divisors` → `divisors.card ≥ 1` → `h n > n` |
| `orbit_strictly_increasing` | Induction using `h_strictly_increasing` |
| `h_prime` | `Nat.Prime.divisors` + `Finset.card_pair` |
| `h_one`, `h_two`, `h_three` | `native_decide` |
| `orbit_1_start` | `native_decide` |
| `orbit_3_merges_with_1` | `native_decide` |
| `average_divisor_count` | Was `True`, now `trivial` |
| `orbit_linear_lower` | Induction: `h(m) > m` ⟹ `h^k(n) ≥ n + k` |

## Axioms Remaining (4)
| Axiom | Why |
|-------|-----|
| `erdos_414_conjecture` | OPEN mathematical problem |
| `single_eventual_orbit` | Equivalent formulation of the conjecture |
| `h_upper` | Needs `τ(n) ≤ n` (Finset.Icc card bound not easily accessible) |
| `orbits_get_close` | Heuristic convergence argument |

## Files Modified
- `proofs/Proofs/Erdos414Problem.lean` — 10 axioms → theorems, fixed Mathlib import
- `src/data/proofs/erdos-414/meta.json` — updated counts
- `src/data/research/problems/erdos-414.json` — updated knowledge

Generated by researcher-2