### PR TITLE
Enrich abel-ruffini: fix overlapping annotation ranges

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -338,7 +338,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -365,7 +365,7 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
+      "startLine": 164,
       "endLine": 183
     },
     "type": "context",


### PR DESCRIPTION
## Summary
- Fixed overlapping annotation ranges in `abel-ruffini` entry
- `ann-part-vi-threshold` narrowed from 151-183 to 151-163 (Part VI only)
- `ann-part-vii-historical` adjusted from 151-183 to 164-183 (Part VII only)
- Ranges now align with the existing `meta.json` section boundaries

## Test plan
- [x] JSON validates correctly
- [x] Annotation ranges match Lean file structure (Part VI: lines 151-163, Part VII: lines 164-183)

🤖 Generated with [Claude Code](https://claude.com/claude-code)