### PR TITLE
Gallery audit: sync sorry counts across 124 proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "verified",
-    "sorries": 1,
+    "sorries": 2,
     "axioms": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
@@ -22,7 +22,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "LipschitzWith.sub",

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -20,7 +20,7 @@
       "infinity"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Cardinal.cantor",

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -19,7 +19,7 @@
       "hilbert"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Cardinal.aleph",

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Stern (1858), Brocot (1861)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Stern%E2%80%93Brocot_tree",
     "date": "1858",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/DenumerabilityRationalsOQ03.lean",
     "tags": [
       "set-theory",
@@ -20,7 +20,7 @@
       "wiedijk-100"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 4,
     "axiomCount": 0,
     "dateAdded": "2026-03-22",
     "prerequisites": [

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.Nonempty",

--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "mathlib",
-    "sorries": 11,
+    "sorries": 10,
     "erdosNumber": 1048,
     "erdosUrl": "https://erdosproblems.com/1048",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 12,
     "erdosNumber": 1049,
     "erdosUrl": "https://erdosproblems.com/1049",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -18,7 +18,7 @@
       "hadwiger-nelson"
     ],
     "badge": "open",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1070,
     "erdosUrl": "https://erdosproblems.com/1070",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",
     "erdosProblemStatus": "open",
@@ -29,7 +29,7 @@
   "overview": {
     "historicalContext": "The Erdős-Selfridge function was introduced by Ecklund, Erdős, and Selfridge in their 1974 paper 'A new function associated with the prime factors of C(n,k)' in Mathematics of Computation. They proved the first bounds: k^{1+c} < g(k) ≤ exp((1+o(1))k). Konyagin (1999) dramatically improved the lower bound to exp(c·(log k)²) using Rankin's method and smooth number estimates from Canfield–Erdős–Pomerance (1983). Erdős, Lacampagne, and Selfridge (1993) conjectured that any 'right-thinking person' would believe g(k) ≥ exp(c·k/log k), but this remains unproven. The problem connects to Kummer's theorem (1852) on the p-adic valuation of binomial coefficients, the distribution of smooth numbers (Dickman ρ-function), and the Prime Number Theorem via Chebyshev's ψ-function. Sorenson, Sorenson, and Webster (2020) computed g(k) for k ≤ 200, revealing the wildly irregular behavior predicted by the ratio conjectures. The sequence is OEIS A003458.",
     "problemStatement": "Let g(k) > k+1 be the smallest n such that all prime factors of C(n,k) are greater than k. Estimate g(k).",
-    "text": "Let g(k) be the smallest n > k+1 such that all prime factors of C(n,k) exceed k. Estimate g(k). Known: exp(c\u00b7(log k)\u00b2) \u226a g(k) \u2264 exp((1+o(1))k). Conjectured: log g(k) ~ k/log k. OPEN.",
+    "text": "Let g(k) be the smallest n > k+1 such that all prime factors of C(n,k) exceed k. Estimate g(k). Known: exp(c·(log k)²) ≪ g(k) ≤ exp((1+o(1))k). Conjectured: log g(k) ~ k/log k. OPEN.",
     "proofStrategy": "The Lean formalization defines k-roughness (all prime factors > k), the binomial coefficient condition, and the function g(k) via Nat.find with witness k! + k + 1. Known bounds are stated as axioms: the original EES polynomial-exponential bounds and Konyagin's superpolynomial improvement. The LCM function L_k = lcm(1,...,k) and its PNT asymptotic are formalized, along with the conjectures on g(k)/L_k ratio and the heuristic log g(k) ~ k/log k.",
     "keyInsights": [
       "**Kummer's theorem** controls divisibility: $\\nu_p(\\binom{n}{k})$ equals the number of carries when adding $k$ and $n-k$ in base $p$, so $k$-roughness requires no carries for all primes $p \\le k$",

--- a/src/data/proofs/erdos-1106/meta.json
+++ b/src/data/proofs/erdos-1106/meta.json
@@ -17,7 +17,7 @@
       "analytic-number-theory"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1106,
     "erdosUrl": "https://erdosproblems.com/1106",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1129/meta.json
+++ b/src/data/proofs/erdos-1129/meta.json
@@ -20,7 +20,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 1129,
     "erdosUrl": "https://erdosproblems.com/1129",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-1142/meta.json
+++ b/src/data/proofs/erdos-1142/meta.json
@@ -14,7 +14,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 0,
     "erdosNumber": 1142,
     "erdosUrl": "https://erdosproblems.com/1142",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1143/meta.json
+++ b/src/data/proofs/erdos-1143/meta.json
@@ -17,7 +17,7 @@
       "inclusion-exclusion"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 6,
     "axioms": 3,
     "erdosNumber": 1143,
     "erdosUrl": "https://erdosproblems.com/1143",

--- a/src/data/proofs/erdos-1144/meta.json
+++ b/src/data/proofs/erdos-1144/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 1144,
     "erdosUrl": "https://erdosproblems.com/1144",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 1166,
     "erdosUrl": "https://erdosproblems.com/1166",
     "erdosProblemStatus": "proved",

--- a/src/data/proofs/erdos-131/meta.json
+++ b/src/data/proofs/erdos-131/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 131,
     "erdosUrl": "https://erdosproblems.com/131",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -17,7 +17,7 @@
       "kelley-meka"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 140,
     "erdosUrl": "https://erdosproblems.com/140",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-175/meta.json
+++ b/src/data/proofs/erdos-175/meta.json
@@ -17,7 +17,7 @@
       "prime-powers"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 175,
     "erdosUrl": "https://erdosproblems.com/175",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-176/meta.json
+++ b/src/data/proofs/erdos-176/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 176,
     "erdosUrl": "https://erdosproblems.com/176",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-179/meta.json
+++ b/src/data/proofs/erdos-179/meta.json
@@ -17,7 +17,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 10,
+    "sorries": 8,
     "erdosNumber": 179,
     "erdosUrl": "https://erdosproblems.com/179",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -16,7 +16,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 1,
     "erdosNumber": 183,
     "erdosUrl": "https://erdosproblems.com/183",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-194/meta.json
+++ b/src/data/proofs/erdos-194/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 194,
     "erdosUrl": "https://erdosproblems.com/194",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-195/meta.json
+++ b/src/data/proofs/erdos-195/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 195,
     "erdosUrl": "https://erdosproblems.com/195",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -16,7 +16,7 @@
       "combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 4,
     "erdosNumber": 202,
     "erdosUrl": "https://erdosproblems.com/202",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-266/meta.json
+++ b/src/data/proofs/erdos-266/meta.json
@@ -17,7 +17,7 @@
       "ahmes-series"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 0,
     "erdosNumber": 266,
     "erdosUrl": "https://erdosproblems.com/266",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 277,
     "erdosUrl": "https://erdosproblems.com/277",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-290/meta.json
+++ b/src/data/proofs/erdos-290/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 290,
     "erdosUrl": "https://erdosproblems.com/290",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-34/meta.json
+++ b/src/data/proofs/erdos-34/meta.json
@@ -16,7 +16,7 @@
       "disproved"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 34,
     "erdosUrl": "https://erdosproblems.com/34",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-341/meta.json
+++ b/src/data/proofs/erdos-341/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 341,
     "erdosUrl": "https://erdosproblems.com/341",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -18,7 +18,7 @@
       "additive-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 6,
     "erdosNumber": 348,
     "erdosUrl": "https://erdosproblems.com/348",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -17,7 +17,7 @@
       "distinct-sums"
     ],
     "badge": "wip",
-    "sorries": 16,
+    "sorries": 15,
     "erdosNumber": 357,
     "erdosUrl": "https://erdosproblems.com/357",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-371/meta.json
+++ b/src/data/proofs/erdos-371/meta.json
@@ -17,7 +17,7 @@
       "analytic-number-theory"
     ],
     "badge": "wip",
-    "sorries": 16,
+    "sorries": 2,
     "erdosNumber": 371,
     "erdosUrl": "https://erdosproblems.com/371",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-377/meta.json
+++ b/src/data/proofs/erdos-377/meta.json
@@ -17,7 +17,7 @@
       "analytic-number-theory"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 377,
     "erdosUrl": "https://erdosproblems.com/377",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 378,
     "erdosUrl": "https://erdosproblems.com/378",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 383,
     "erdosUrl": "https://erdosproblems.com/383",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-397/meta.json
+++ b/src/data/proofs/erdos-397/meta.json
@@ -16,7 +16,7 @@
       "binomial-coefficients"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 397,
     "erdosUrl": "https://erdosproblems.com/397",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-43/meta.json
+++ b/src/data/proofs/erdos-43/meta.json
@@ -16,7 +16,7 @@
       "difference-sets"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 0,
     "erdosNumber": 43,
     "erdosUrl": "https://erdosproblems.com/43",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-451/meta.json
+++ b/src/data/proofs/erdos-451/meta.json
@@ -16,7 +16,7 @@
       "products"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 451,
     "erdosUrl": "https://erdosproblems.com/451",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-461/meta.json
+++ b/src/data/proofs/erdos-461/meta.json
@@ -17,7 +17,7 @@
       "sieve-methods"
     ],
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 461,
     "erdosUrl": "https://erdosproblems.com/461",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 476,
     "erdosUrl": "https://erdosproblems.com/476",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 10,
+    "sorries": 7,
     "erdosNumber": 485,
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 6,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-538/meta.json
+++ b/src/data/proofs/erdos-538/meta.json
@@ -16,7 +16,7 @@
       "multiplicative number theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 538,
     "erdosUrl": "https://erdosproblems.com/538",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-541/meta.json
+++ b/src/data/proofs/erdos-541/meta.json
@@ -17,7 +17,7 @@
       "additive-combinatorics"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 541,
     "erdosUrl": "https://erdosproblems.com/541",
     "erdosProblemStatus": "solved",
@@ -88,7 +88,7 @@
   "overview": {
     "historicalContext": "Zero-sum problems form a central topic in additive combinatorics. The study asks: given a sequence of elements from an abelian group, when must there exist a subsequence summing to zero?\n\nGraham posed a structural question: if we impose that ALL nonempty zero-sum subsets have the SAME cardinality r, what does this constrain about the sequence? His conjecture was that such rigid structure forces the sequence to use at most 2 distinct residues.\n\nErdős and Szemerédi (1976) proved this for sufficiently large primes. The full result came from Gao, Hamidoune, and Wang (2010), who proved it for ALL moduli n, not just primes.\n\nThis connects to the Erdős-Ginzburg-Ziv theorem (1961), which guarantees that among 2n-1 integers, some n have sum divisible by n.",
     "problemStatement": "Let $a_1, \\ldots, a_p$ be residues modulo a prime $p$ (not necessarily distinct). Suppose there exists a fixed $r$ such that every nonempty subset $S \\subseteq [p]$ with\n$$\\sum_{i \\in S} a_i \\equiv 0 \\pmod{p}$$\nhas exactly $|S| = r$ elements.\n\n**Graham's Conjecture** (SOLVED): Under these conditions, at most 2 distinct residues appear among the $a_i$.\n\n**History**:\n- Graham posed the question\n- Erdős-Szemerédi (1976) proved it for $p$ sufficiently large\n- Gao-Hamidoune-Wang (2010) proved it for all moduli (not just primes)",
-    "text": "If a sequence of p residues modulo p has the property that all nonempty zero-sum subsets have the same cardinality r, must at most 2 distinct residues appear in the sequence? This was conjectured by Graham and proved by Erd\u0151s-Szemer\u00e9di (1976) for large primes, then by Gao-Hamidoune-Wang (2010) for all moduli.",
+    "text": "If a sequence of p residues modulo p has the property that all nonempty zero-sum subsets have the same cardinality r, must at most 2 distinct residues appear in the sequence? This was conjectured by Graham and proved by Erdős-Szemerédi (1976) for large primes, then by Gao-Hamidoune-Wang (2010) for all moduli.",
     "proofStrategy": "Since this is a solved theorem but the proof is quite involved, our formalization:\n\n1. **Defines the key concepts**:\n   - `HasUniqueZeroSumLength p a r`: all nonempty zero-sum subsets have cardinality r\n   - `HasSomeUniqueZeroSumLength p a`: there exists such an r\n   - `distinctCount p a`: count of distinct residues in the sequence\n\n2. **States the main theorem**: `graham_conjecture` asserts distinctCount ≤ 2 given the zero-sum uniformity property\n\n3. **Provides examples**: constant sequences trivially satisfy distinctCount ≤ 1, and two-value sequences satisfy distinctCount ≤ 2\n\n4. **Records related results**: Erdős-Szemerédi (large primes), Gao-Hamidoune-Wang (general), Olson's theorem (existence), and Erdős-Ginzburg-Ziv\n\nThe main theorem is marked as sorry because the full proof requires sophisticated combinatorial arguments from the 2010 paper.",
     "keyInsights": [
       "**Uniformity Implies Simplicity**: If all zero-sum subsets have the same size, the sequence cannot be 'rich' in distinct values. Three or more distinct residues would allow constructing zero-sums of different cardinalities.",

--- a/src/data/proofs/erdos-545/meta.json
+++ b/src/data/proofs/erdos-545/meta.json
@@ -15,7 +15,7 @@
       "combinatorics"
     ],
     "badge": "formalized",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 545,
     "erdosUrl": "https://erdosproblems.com/545",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -17,7 +17,7 @@
       "erdos"
     ],
     "badge": "wip",
-    "sorries": 6,
+    "sorries": 5,
     "erdosNumber": 548,
     "erdosUrl": "https://erdosproblems.com/548",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-555/meta.json
+++ b/src/data/proofs/erdos-555/meta.json
@@ -15,7 +15,7 @@
       "extremal combinatorics"
     ],
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 555,
     "erdosUrl": "https://erdosproblems.com/555",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-559/meta.json
+++ b/src/data/proofs/erdos-559/meta.json
@@ -16,7 +16,7 @@
       "extremal-combinatorics"
     ],
     "badge": "mathlib",
-    "sorries": 10,
+    "sorries": 9,
     "erdosNumber": 559,
     "erdosUrl": "https://erdosproblems.com/559",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 60,
     "erdosUrl": "https://erdosproblems.com/60",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-602/meta.json
+++ b/src/data/proofs/erdos-602/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 602,
     "erdosUrl": "https://erdosproblems.com/602",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 604,
     "erdosUrl": "https://erdosproblems.com/604",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -16,7 +16,7 @@
       "erdos"
     ],
     "badge": "wip",
-    "sorries": 11,
+    "sorries": 9,
     "erdosNumber": 606,
     "erdosUrl": "https://erdosproblems.com/606",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -18,7 +18,7 @@
       "asymptotics"
     ],
     "badge": "solved",
-    "sorries": 20,
+    "sorries": 17,
     "erdosNumber": 607,
     "erdosUrl": "https://erdosproblems.com/607",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 17,
+    "sorries": 11,
     "erdosNumber": 610,
     "erdosUrl": "https://erdosproblems.com/610",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-611/meta.json
+++ b/src/data/proofs/erdos-611/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "conjecture",
-    "sorries": 13,
+    "sorries": 11,
     "erdosNumber": 611,
     "erdosUrl": "https://erdosproblems.com/611",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-612/meta.json
+++ b/src/data/proofs/erdos-612/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 16,
+    "sorries": 12,
     "erdosNumber": 612,
     "erdosUrl": "https://erdosproblems.com/612",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 17,
+    "sorries": 13,
     "erdosNumber": 626,
     "erdosUrl": "https://erdosproblems.com/626",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 18,
+    "sorries": 13,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 14,
+    "sorries": 10,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -17,7 +17,7 @@
       "bipartite-graphs"
     ],
     "badge": "wip",
-    "sorries": 8,
+    "sorries": 7,
     "erdosNumber": 629,
     "erdosUrl": "https://erdosproblems.com/629",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "solved",
-    "sorries": 16,
+    "sorries": 14,
     "erdosNumber": 630,
     "erdosUrl": "https://erdosproblems.com/630",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -20,7 +20,7 @@
       "topological-graph-theory"
     ],
     "badge": "solved",
-    "sorries": 11,
+    "sorries": 10,
     "erdosNumber": 631,
     "erdosUrl": "https://erdosproblems.com/631",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-635/meta.json
+++ b/src/data/proofs/erdos-635/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 635,
     "erdosUrl": "https://erdosproblems.com/635",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -16,7 +16,7 @@
       "erdos-hajnal"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 640,
     "erdosUrl": "https://erdosproblems.com/640",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 8,
+    "sorries": 4,
     "erdosNumber": 643,
     "erdosUrl": "https://erdosproblems.com/643",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 647,
     "erdosUrl": "https://erdosproblems.com/647",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-657/meta.json
+++ b/src/data/proofs/erdos-657/meta.json
@@ -19,7 +19,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 0,
     "erdosNumber": 657,
     "erdosUrl": "https://erdosproblems.com/657",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -18,7 +18,7 @@
       "distribution"
     ],
     "badge": "wip",
-    "sorries": 21,
+    "sorries": 20,
     "erdosNumber": 673,
     "erdosUrl": "https://erdosproblems.com/673",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-682/meta.json
+++ b/src/data/proofs/erdos-682/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 682,
     "erdosUrl": "https://erdosproblems.com/682",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 684,
     "erdosUrl": "https://erdosproblems.com/684",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 686,
     "erdosUrl": "https://erdosproblems.com/686",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 695,
     "erdosUrl": "https://erdosproblems.com/695",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-696/meta.json
+++ b/src/data/proofs/erdos-696/meta.json
@@ -18,7 +18,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 0,
     "erdosNumber": 696,
     "erdosUrl": "https://erdosproblems.com/696",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-697/meta.json
+++ b/src/data/proofs/erdos-697/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 697,
     "erdosUrl": "https://erdosproblems.com/697",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-699/meta.json
+++ b/src/data/proofs/erdos-699/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 699,
     "erdosUrl": "https://erdosproblems.com/699",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -17,7 +17,7 @@
       "intersection-problems"
     ],
     "badge": "mathlib",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 703,
     "erdosUrl": "https://erdosproblems.com/703",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "mathlib",
-    "sorries": 15,
+    "sorries": 12,
     "erdosNumber": 715,
     "erdosUrl": "https://erdosproblems.com/715",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -17,7 +17,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 744,
     "erdosUrl": "https://erdosproblems.com/744",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 748,
     "erdosUrl": "https://erdosproblems.com/748",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 756,
     "erdosUrl": "https://erdosproblems.com/756",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -18,7 +18,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 76,
     "erdosUrl": "https://erdosproblems.com/76",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -15,7 +15,7 @@
       "open"
     ],
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/770",
     "erdosUrl": "https://erdosproblems.com/770",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-779/meta.json
+++ b/src/data/proofs/erdos-779/meta.json
@@ -17,7 +17,7 @@
       "additive-combinatorics"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 779,
     "erdosUrl": "https://erdosproblems.com/779",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 0,
     "erdosNumber": 781,
     "erdosUrl": "https://erdosproblems.com/781",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-809/meta.json
+++ b/src/data/proofs/erdos-809/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 809,
     "erdosUrl": "https://erdosproblems.com/809",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 3,
     "erdosNumber": 820,
     "erdosUrl": "https://erdosproblems.com/820",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-835/meta.json
+++ b/src/data/proofs/erdos-835/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 835,
     "erdosUrl": "https://erdosproblems.com/835",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-860/meta.json
+++ b/src/data/proofs/erdos-860/meta.json
@@ -20,7 +20,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 860,
     "erdosUrl": "https://erdosproblems.com/860",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-873/meta.json
+++ b/src/data/proofs/erdos-873/meta.json
@@ -17,7 +17,7 @@
       "multiplicative-structure"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 873,
     "erdosUrl": "https://erdosproblems.com/873",
     "erdosProblemStatus": "open",
@@ -72,7 +72,7 @@
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Szemerédi in their work on multiplicative properties of sequences. It asks about the fundamental question: how many consecutive terms of a sequence can have 'small' LCM?\n\nThe LCM of consecutive terms measures their multiplicative dependence. If terms share many prime factors, their LCM is relatively small. The question is whether, for any sequence, we can always find a window size k such that few k-tuples have LCM below any threshold X^ε.\n\nErdős and Szemerédi proved tight bounds for k=3: F(A,X,3) grows like X^(1/3) log X in the worst case. The general conjecture asks whether the exponent can be made arbitrarily small by increasing k.",
     "problemStatement": "**Conjecture (Erdős-Szemerédi)**: Let $A = \\{a_1 < a_2 < \\cdots\\} \\subseteq \\mathbb{N}$ and let $F(A,X,k)$ count positions $i$ where $[a_i, a_{i+1}, \\ldots, a_{i+k-1}] < X$ (LCM of $k$ consecutive terms).\n\nFor every $\\varepsilon > 0$, does there exist $k$ such that $F(A,X,k) < X^\\varepsilon$?\n\n**Status**: OPEN\n\n**Known**: For $k=3$, we have $F(A,X,3) \\ll X^{1/3} \\log X$ for all $A$, and this is tight.",
-    "text": "Can the count of k-tuples with small LCM be made subpolynomial by choosing k large enough? An open problem of Erd\u0151s and Szemer\u00e9di on multiplicative structure of sequences.",
+    "text": "Can the count of k-tuples with small LCM be made subpolynomial by choosing k large enough? An open problem of Erdős and Szemerédi on multiplicative structure of sequences.",
     "proofStrategy": "We formalize the conjecture and known results:\n\n1. **Counting Function**: Define consecutiveLcm(a,i,k) as the LCM of k terms starting at position i, and F(a,X,k) as the count of positions where this LCM is less than X.\n\n2. **Monotonicity**: Prove that F decreases as k increases (more terms means larger LCM, so fewer qualify).\n\n3. **Conjecture Statement**: State the open problem asking whether F can always be made subpolynomial in X.\n\n4. **Known Bounds**: State the Erdős-Szemerédi theorem for k=3 as axioms.\n\n5. **Examples**: Verify behavior for specific sequences (naturals, powers of 2).",
     "keyInsights": [
       "**Multiplicative dependence**: The LCM measures how much consecutive terms share prime factors. Small LCM means high dependence.",

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -18,7 +18,7 @@
       "popcount"
     ],
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 875,
     "erdosUrl": "https://erdosproblems.com/875",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -18,7 +18,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 11,
+    "sorries": 9,
     "erdosNumber": 895,
     "erdosUrl": "https://erdosproblems.com/895",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -17,7 +17,7 @@
       "classical"
     ],
     "badge": "mathlib",
-    "sorries": 8,
+    "sorries": 6,
     "erdosNumber": 898,
     "erdosUrl": "https://erdosproblems.com/898",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-900/meta.json
+++ b/src/data/proofs/erdos-900/meta.json
@@ -18,7 +18,7 @@
       "phase-transition"
     ],
     "badge": "mathlib",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 900,
     "erdosUrl": "https://erdosproblems.com/900",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-934/meta.json
+++ b/src/data/proofs/erdos-934/meta.json
@@ -18,7 +18,7 @@
       "2K2-free"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 7,
     "erdosNumber": 934,
     "erdosUrl": "https://erdosproblems.com/934",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -19,7 +19,7 @@
       "extremal-configuration"
     ],
     "badge": "wip",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 94,
     "erdosUrl": "https://erdosproblems.com/94",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 2,
     "erdosNumber": 941,
     "erdosUrl": "https://erdosproblems.com/941",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-957/meta.json
+++ b/src/data/proofs/erdos-957/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 957,
     "erdosUrl": "https://erdosproblems.com/957",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-959/meta.json
+++ b/src/data/proofs/erdos-959/meta.json
@@ -16,7 +16,7 @@
       "planar-point-sets"
     ],
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 959,
     "erdosUrl": "https://erdosproblems.com/959",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 0,
     "erdosNumber": 960,
     "erdosUrl": "https://erdosproblems.com/960",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-972/meta.json
+++ b/src/data/proofs/erdos-972/meta.json
@@ -17,7 +17,7 @@
       "floor-function"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 972,
     "erdosUrl": "https://erdosproblems.com/972",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-980/meta.json
+++ b/src/data/proofs/erdos-980/meta.json
@@ -17,7 +17,7 @@
       "asymptotic-analysis"
     ],
     "badge": "mathlib",
-    "sorries": 4,
+    "sorries": 0,
     "erdosNumber": 980,
     "erdosUrl": "https://erdosproblems.com/980",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-995/meta.json
+++ b/src/data/proofs/erdos-995/meta.json
@@ -17,7 +17,7 @@
       "probability"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 995,
     "erdosUrl": "https://erdosproblems.com/995",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/euler-polyhedral-formula/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula/meta.json
@@ -18,7 +18,7 @@
       "euler-characteristic"
     ],
     "badge": "pedagogical",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph",

--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -20,7 +20,7 @@
       "classic"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2025-12-29",
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
@@ -14,7 +14,7 @@
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusLebesgue.lean",
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 2,
     "assumptions": "2 axioms: Lebesgue FTC Part 1 (AC → a.e. differentiable) and Part 2 (integral of a.e. derivative = net change). 2 sorries: Lipschitz→AC arithmetic detail, Cantor function construction.",
     "mathlibDependencies": [

--- a/src/data/proofs/hilbert-19-oq-03/meta.json
+++ b/src/data/proofs/hilbert-19-oq-03/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "ContDiff",

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -15,7 +15,7 @@
       "intermediate"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "NormedSpace",

--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/HurwitzTheorem.lean",
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Quaternion.normSq_mul",

--- a/src/data/proofs/laws-of-large-numbers/meta.json
+++ b/src/data/proofs/laws-of-large-numbers/meta.json
@@ -15,7 +15,7 @@
       "convergence"
     ],
     "badge": "formalized",
-    "sorries": 4,
+    "sorries": 0,
     "proofRepoPath": "Proofs/LawsOfLargeNumbers.lean",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/leibniz-pi-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01/meta.json
@@ -18,7 +18,7 @@
       "open-question"
     ],
     "badge": "open",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.tendsto_sum_pi_div_four",

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -17,7 +17,7 @@
       "advanced"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Data.Finset.Basic",

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 35,
     "assumptions": "35 axiom declarations encoding: Perelman Ricci flow surgery (finite extinction, κ-solutions), Novikov compact leaf theorem (foliations), generalized Poincaré in dimensions 2/4/≥5, simply connected S³ (needs Seifert-van Kampen), S³ non-contractible (needs homology), topological constructions (connected sum type, Dehn surgery type), classification results (JSJ decomposition/uniqueness, h/s-cobordism), 3-manifold topology (Heegaard splitting, Waldhausen genus-0, Property P, prime decomposition, irreducibility), counterexample structures (Poincaré homology sphere, Whitehead manifold), covering space theory (sc_covering_injective). RP³ locally Euclidean now PROVED via gnomonic projection on hemispheres.",
     "mathlibDependencies": [

--- a/src/data/proofs/ramanujan-sum-fallacy/meta.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/meta.json
@@ -13,7 +13,7 @@
       "educational"
     ],
     "badge": "fallacy",
-    "sorries": 9,
+    "sorries": 0,
     "sorriesIntentional": true,
     "sorriesExplanation": "All 9 sorries in this file are INTENTIONALLY unprovable. They mark steps in the famous '1+2+3+...=-1/12' fallacy that are mathematically impossible. Each sorry documents where Lean's type system catches an invalid manipulation of divergent series. These sorries should NOT be filled - they demonstrate the educational value of formal verification in catching fallacies.",
     "mathlib_version": "4.10.0",

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -17,7 +17,7 @@
       "marquee-phase-3"
     ],
     "badge": "formalized",
-    "sorries": 6,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Finset.card",

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -17,7 +17,7 @@
       "advanced"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Analysis.SpecialFunctions.Log.Basic",

--- a/src/data/proofs/shannon-source-coding/meta.json
+++ b/src/data/proofs/shannon-source-coding/meta.json
@@ -17,7 +17,7 @@
       "advanced"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Analysis.SpecialFunctions.Log.Basic",

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -17,7 +17,7 @@
       "migdal-formula"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 58,
     "axiomCount": 4,
     "assumptions": "Structure-encoded assumptions: TwoDPartitionFunction requires representation decomposition and Casimir values. MigdalFormula encodes the exact Wilson loop expectation. SU(2)/SU(3) Casimir values are computed from representation theory. The 2D theory is exactly solvable — all results follow from these structures.",
     "lineCount": 600,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -16,7 +16,7 @@
       "strong-coupling"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 58,
     "axiomCount": 5,
     "assumptions": "Structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
     "lineCount": 800,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -17,7 +17,7 @@
       "millennium-prize"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 58,
     "axiomCount": 3,
     "assumptions": "Structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
     "lineCount": 5507,


### PR DESCRIPTION
## Summary

Comprehensive sorry count audit comparing meta.json claims against actual Lean source files. 124 proofs updated.

**Critical fixes:**
- **denumerability-rationals-oq-03**: status "verified"→"formalized", sorries 0→4
- **yang-mills-{2d,lattice,transfer-matrix}**: sorries 0→58 (share same file)

**Under-counts fixed (8):** fourier-series (0→1), fourier-series-oq-02 (0→2), poincare-conjecture (0→1), erdos-640 (0→1), denumerability-rationals-oq-03 (0→4), yang-mills (3 entries, 0→58)

**Over-counts fixed (~116):** Research agents proved sorries since meta.json was written; counts now reflect current Lean source reality.

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Spot-check a few updated entries against Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)