### PR TITLE
Enrich batch: prob-method-expectation, prob-method-second-moment

### DIFF
--- a/src/data/proofs/prob-method-second-moment/annotations.json
+++ b/src/data/proofs/prob-method-second-moment/annotations.json
@@ -116,5 +116,25 @@
       "Finset.sum_le_sum_of_subset_of_nonneg",
       "nlinarith"
     ]
+  },
+  {
+    "id": "ann-smm-end",
+    "proofId": "prob-method-second-moment",
+    "range": {
+      "startLine": 160,
+      "endLine": 161
+    },
+    "type": "context",
+    "title": "Namespace Closure",
+    "content": "Closes the `ProbMethod.SecondMoment` namespace. The six theorems — `chebyshev_ineq`, `paley_zygmund`, `finite_cauchy_schwarz`, `sum_pos_eq_sum_filter_pos`, `sum_sq_filter_le`, and `second_moment_existence` — are accessible as `ProbMethod.SecondMoment.*` when imported. Together with `ProbMethod.Expectation` and `ProbMethod.Alteration`, this forms a complete toolkit for probabilistic method arguments in combinatorics.",
+    "mathContext": "The probabilistic method toolkit hierarchy is now: first moment (expectation) → alteration (deletion) → second moment (concentration) → Lovász Local Lemma (dependency), ordered by increasing sophistication.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Lean 4 namespaces",
+      "probabilistic method library"
+    ],
+    "prerequisites": [
+      "all preceding theorems"
+    ]
   }
 ]

--- a/src/data/proofs/prob-method-second-moment/meta.json
+++ b/src/data/proofs/prob-method-second-moment/meta.json
@@ -56,7 +56,7 @@
   "overview": {
     "historicalContext": "The second moment method extends the first moment method by incorporating variance to prove that random variables are concentrated near their expectation. While the first moment method can only guarantee that a maximum or minimum exists, the second moment method shows that typical outcomes are close to the mean — and in particular, that a positive-mean random variable is positive with substantial probability.\n\nChebyshev's inequality, published by Pafnuty Chebyshev in 1867, is the foundation: $\\Pr[|X - E[X]| \\geq t] \\leq \\operatorname{Var}[X]/t^2$. The inequality was proved using Chebyshev's elegant application of Markov's inequality to the squared deviation. Irénée-Jules Bienaymé had stated a version earlier (1853), so the result is sometimes called the Bienaymé-Chebyshev inequality.\n\nThe Paley-Zygmund inequality, due to Raymond Paley and Antoni Zygmund (1932), provides a complementary lower bound: for $X \\geq 0$, $\\Pr[X > 0] \\geq (E[X])^2/E[X^2]$. While Chebyshev bounds the probability of large deviations from above, Paley-Zygmund bounds the probability of positivity from below — exactly what combinatorial existence proofs require.\n\nThe second moment method became indispensable in the study of random graphs after Erdős and Rényi's foundational 1959 paper 'On Random Graphs I,' which introduced the $G(n,p)$ model. Their key insight was that many graph properties exhibit sharp thresholds: a property either holds with probability tending to 0 or to 1, with a sharp transition at a critical edge probability $p^*(n)$. The second moment method is the standard tool for establishing these thresholds. Bollobás, Friedgut, and others later developed the theory of sharp thresholds into a rich field connecting probability, combinatorics, and statistical physics.",
     "problemStatement": "Chebyshev's Inequality: For any random variable $X$ with finite variance, $\\Pr[|X - E[X]| \\geq t] \\leq \\operatorname{Var}[X] / t^2$.\n\nPaley-Zygmund Inequality: For a non-negative random variable $X$, $\\Pr[X > 0] \\geq (E[X])^2 / E[X^2]$.\n\nApplication: If the expected number of copies of a subgraph $H$ in a random graph $G(n,p)$ tends to infinity and the variance is controlled, then $G(n,p)$ contains $H$ with high probability.",
-    "text": "Chebyshev and Paley-Zygmund inequalities for concentration and existence proofs in combinatorics.",
+    "text": "A 161-line formalization of the second moment method with 0 sorries, providing the concentration toolkit for probabilistic combinatorics. The file builds three layers: (1) a discrete Chebyshev inequality bounding the number of elements deviating from the mean by at least $t$ as $|s| \\cdot \\operatorname{Var}[f]/t^2$; (2) a qualitative Paley-Zygmund inequality proving that non-negative functions with positive sum have a positive element; and (3) a quantitative existence theorem showing that if $E[X^2] \\cdot |s| \\leq 2(E[X])^2$, then at least half the sample space has $X > 0$. Supporting helper lemmas include a finite Cauchy-Schwarz inequality $(\\sum f)^2 \\leq |s| \\cdot \\sum f^2$ proved by induction, and support/monotonicity lemmas for non-negative functions. The framework uses $\\mathbb{Q}$-valued functions on `Finset` for exact arithmetic, avoiding measure-theoretic overhead while capturing the essential probabilistic arguments.",
     "proofStrategy": "The formalization builds the second moment toolkit:\n\n1. **Variance definition**: $\\operatorname{Var}[X] = E[X^2] - (E[X])^2$ for finite probability spaces, with the Finset-based computation framework.\n\n2. **Chebyshev's inequality**: From Markov's inequality applied to $(X - E[X])^2$. This gives an upper bound on the probability of large deviations.\n\n3. **Paley-Zygmund inequality**: By Cauchy-Schwarz, $E[X]^2 = E[X \\cdot \\mathbf{1}_{X>0}]^2 \\leq E[X^2] \\cdot \\Pr[X > 0]$. Rearranging gives the lower bound on $\\Pr[X > 0]$.\n\n4. **Application to indicator sums**: For $X = \\sum_i X_i$ with indicators $X_i$, compute $\\operatorname{Var}[X] = \\sum_i \\operatorname{Var}[X_i] + \\sum_{i \\neq j} \\operatorname{Cov}[X_i, X_j]$. When the covariance sum is small relative to $(E[X])^2$, the second moment method yields strong concentration.",
     "keyInsights": [
       "The second moment method converts variance bounds into existence guarantees: low variance relative to the mean squared ensures positive probability",
@@ -140,6 +140,11 @@
       "targetId": "prob-method-alteration",
       "relationship": "related",
       "description": "The alteration method often combines with second moment bounds: first prove a structure exists with high probability, then alter it to achieve additional properties"
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey number lower bounds via the second moment method sharpen the first moment bounds: where E[X] > 0 gives existence, Var[X] = o(E[X]²) gives high probability, proving that almost all colorings avoid monochromatic cliques for n below the threshold"
     }
   ],
   "conclusion": {
@@ -156,7 +161,8 @@
     "prob-method-lovasz-local",
     "prob-method-applications",
     "cauchy-schwarz",
-    "prob-method-alteration"
+    "prob-method-alteration",
+    "ramseys-theorem"
   ],
   "leanFile": {
     "imports": [
@@ -171,11 +177,32 @@
   },
   "references": [
     {
+      "authors": "Chebyshev, Pafnuty",
+      "title": "Des valeurs moyennes",
+      "year": "1867",
+      "venue": "Journal de Mathématiques Pures et Appliquées, 2nd series, vol. 12, pp. 177–184",
+      "note": "Original proof of Chebyshev's inequality via Markov's inequality applied to (X - μ)². Bienaymé stated a version in 1853"
+    },
+    {
+      "authors": "Paley, Raymond; Zygmund, Antoni",
+      "title": "A note on analytic functions in the unit circle",
+      "year": "1932",
+      "venue": "Mathematical Proceedings of the Cambridge Philosophical Society 28(3), 266–272",
+      "note": "Introduces the Paley-Zygmund inequality: Pr[X > θE[X]] >= (1-θ)² (E[X])²/E[X²], the key lower tail bound for existence proofs"
+    },
+    {
       "authors": "Alon, Noga; Spencer, Joel H.",
       "title": "The Probabilistic Method",
       "year": "2016",
       "venue": "Wiley, 4th edition",
-      "note": "The definitive textbook on the probabilistic method in combinatorics, covering all major techniques"
+      "note": "Chapter 4 covers the second moment method, including Chebyshev, Paley-Zygmund, and applications to random graph thresholds"
+    },
+    {
+      "authors": "Erdős, Paul; Rényi, Alfréd",
+      "title": "On random graphs I",
+      "year": "1959",
+      "venue": "Publicationes Mathematicae Debrecen 6, 290–297",
+      "note": "Foundational paper introducing the G(n,p) random graph model where the second moment method finds its primary combinatorial application — establishing threshold phenomena for graph properties"
     }
   ]
 }


### PR DESCRIPTION
## Summary

### prob-method-expectation (pass 1)
- Added 4 new annotations covering Part IV (exists_zero, max_exceeds_avg, min_below_avg) — 5 → 9 total
- Fixed stale annotation ranges and sections referencing "sorry'd" proofs (all 0 sorries)
- Expanded overview.text from 1 sentence to full mathematical description
- Updated open questions (removed resolved item, added Campos 2023)
- Added references: Erdős 1947, Campos et al. 2023 (1 → 3)
- Added cross-refs: ramseys-theorem, friendship-theorem (4 → 6)

### prob-method-second-moment (pass 1)
- Expanded overview.text from 97 chars to full description
- Added namespace closure annotation (5 → 6)
- Added cross-ref to ramseys-theorem (5 → 6)
- Added references: Chebyshev 1867, Paley-Zygmund 1932, Erdős-Rényi 1959 (1 → 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)