### PR TITLE
Enrich abel-ruffini-oq-04: fix Wiedijk number #83→#16

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "context",
     "title": "Module Overview and Imports",
-    "content": "The file imports three Mathlib modules: `GroupTheory.Solvable` (definition of `IsSolvable` and the derived series), `GroupTheory.SpecificGroups.Alternating` (the proof that $A_5$ is simple via `alternatingGroup.isSimpleGroup_five`), and `Tactic` (general-purpose tactics). The module documents the 4-step proof chain from $A_5$ simplicity to Abel-Ruffini and connects to two sibling files in the gallery: `AbelRuffini.lean` (base theorem via `solvableByRad`) and `AbelRuffiniGaloisExtensions.lean` (solvability classifications). This is part of Wiedijk's \"100 Theorems\" project (#83).",
+    "content": "The file imports three Mathlib modules: `GroupTheory.Solvable` (definition of `IsSolvable` and the derived series), `GroupTheory.SpecificGroups.Alternating` (the proof that $A_5$ is simple via `alternatingGroup.isSimpleGroup_five`), and `Tactic` (general-purpose tactics). The module documents the 4-step proof chain from $A_5$ simplicity to Abel-Ruffini and connects to two sibling files in the gallery: `AbelRuffini.lean` (base theorem via `solvableByRad`) and `AbelRuffiniGaloisExtensions.lean` (solvability classifications). This is part of Wiedijk's \"100 Theorems\" project (#16, Insolvability of General Higher Degree Equations).",
     "mathContext": "The file formalizes the proof chain: $A_5$ simple $\\Rightarrow$ $S_n$ ($n \\geq 5$) not solvable $\\Rightarrow$ no radical formula for the general quintic. All group-theoretic content comes from Mathlib's `GroupTheory` library.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "abel-ruffini-oq-04",
   "title": "Abel-Ruffini Proof Chain: From A₅ Simplicity to Non-Solvability",
   "slug": "abel-ruffini-oq-04",
-  "description": "Exposes the key group-theoretic steps of the Abel-Ruffini proof chain with each step as a named theorem: A₅ is simple → Sₙ (n≥5) not solvable, plus a 2-line type-coercion bridge from Mathlib's cardinal-level statement to natural numbers. Steps 4–5 (Galois bridge, generic quintic Galois group) are documented but not formalized here. Part of Wiedijk's 100 Theorems (#83). Fully verified with 0 sorries and 0 axioms.",
+  "description": "Exposes the key group-theoretic steps of the Abel-Ruffini proof chain with each step as a named theorem: A₅ is simple → Sₙ (n≥5) not solvable, plus a 2-line type-coercion bridge from Mathlib's cardinal-level statement to natural numbers. Steps 4–5 (Galois bridge, generic quintic Galois group) are documented but not formalized here. Part of Wiedijk's 100 Theorems (#16, Insolvability of General Higher Degree Equations). Fully verified with 0 sorries and 0 axioms.",
   "meta": {
     "author": "Abel (1824), Galois (1832)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem",
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "Core results (A₅ simplicity, Sₙ not solvable) are direct Mathlib calls. This file provides a pedagogical proof chain wrapper around Mathlib's alternatingGroup.isSimpleGroup_five and Equiv.Perm.not_solvable.",
-    "wiedijkNumber": 83,
+    "wiedijkNumber": 16,
     "dateAdded": "2026-03-22",
     "mathlibDependencies": [
       {
@@ -115,7 +115,7 @@
   "overview": {
     "historicalContext": "The Abel-Ruffini theorem (1824) stands as one of the most profound results in the history of algebra, settling a question that had occupied mathematicians for centuries. After Cardano (1545) and Ferrari (1540) found radical solutions for cubics and quartics, the search for a quintic formula consumed generations of mathematicians including Euler, Lagrange, and Vandermonde. Paolo Ruffini published the first attempted proof of impossibility in 1799 in his *Teoria Generale delle Equazioni*, running to over 500 pages. Ruffini's argument, based on permutation analysis, contained a gap: he assumed without proof that any radical expression for the roots must take a specific 'standard form,' and his treatment of the permutations was not fully rigorous. Despite submitting his work to leading mathematicians including Lagrange (who never responded) and Cauchy (who acknowledged its importance), Ruffini's proof was not widely accepted during his lifetime. Niels Henrik Abel, working independently in near-poverty in Norway, provided the first complete proof in 1824 at age 21 — a 6-page paper that succeeded precisely where Ruffini's argument was incomplete. Abel died of tuberculosis in 1829, just two days before a letter arrived offering him a professorship in Berlin. Évariste Galois, before his death in a duel at 20, went much further in 1832: he characterized exactly which polynomials are solvable by radicals in terms of their symmetry groups, founding what we now call Galois theory. The key group-theoretic insight is that A₅, the alternating group on 5 elements, is the smallest non-abelian simple group — with order 60, it has no proper non-trivial normal subgroups, causing the derived series to get stuck. This single fact propagates upward through the chain: A₅ not solvable → Sₙ (n ≥ 5) not solvable → generic quintic not solvable by radicals. The classification of finite simple groups (completed circa 2004) shows that A₅ is the first in the infinite family of simple alternating groups Aₙ (n ≥ 5).",
     "problemStatement": "Expose the key group-theoretic steps of the Abel-Ruffini proof chain as named, machine-verified theorems: $A_5$ simple $\\Rightarrow$ $S_n$ ($n \\geq 5$) not solvable, with a type-coercion bridge from Mathlib's cardinal-level statement. Steps 4–5 (Galois bridge, generic quintic Galois group) are documented but not formalized here.",
-    "text": "A pedagogical Mathlib wrapper that names each step in the A₅-simplicity-to-Abel-Ruffini proof chain, providing a 2-line type-coercion bridge (cardinal to natural number) for Equiv.Perm.not_solvable and structured documentation of the complete 5-step argument including degree-by-degree comparison tables. Part of Wiedijk's 100 Theorems (#83). Fully verified with 0 sorries and 0 axioms.",
+    "text": "A pedagogical Mathlib wrapper that names each step in the A₅-simplicity-to-Abel-Ruffini proof chain, providing a 2-line type-coercion bridge (cardinal to natural number) for Equiv.Perm.not_solvable and structured documentation of the complete 5-step argument including degree-by-degree comparison tables. Part of Wiedijk's 100 Theorems (#16, Insolvability of General Higher Degree Equations). Fully verified with 0 sorries and 0 axioms.",
     "proofStrategy": "The file decomposes the Abel-Ruffini proof chain into five named, independently verifiable steps. The key technical theorem is `symmetric_not_solvable`, which bridges Mathlib's cardinal-level non-solvability statement (`Equiv.Perm.not_solvable`, stated for `5 ≤ Cardinal.mk α`) to a natural number bound (`5 ≤ n`) via `exact_mod_cast` — this type-level coercion is the main new proof content. The pedagogical architecture then builds upward: `a5_is_simple` extracts the foundation from Mathlib, specific instances (`s5_not_solvable`, `s6_not_solvable`, `s7_not_solvable`) demonstrate the theorem for individual degrees, contrast cases (`s0_solvable`, `s1_solvable`) establish the solvable side, and `five_is_the_threshold` packages the sharp dichotomy. The file concludes with structured documentation of the complete 5-step chain including Steps 4–5 (Galois bridge and field theory) which are handled by Mathlib internally.",
     "keyInsights": [
       "A₅ (order 60) is the smallest non-abelian simple group — this single fact drives the entire Abel-Ruffini theorem through a chain of group-theoretic implications",
@@ -140,7 +140,7 @@
       "title": "Module Header and Imports",
       "startLine": 1,
       "endLine": 31,
-      "summary": "Imports three Mathlib modules (GroupTheory.Solvable, SpecificGroups.Alternating, Tactic) and documents the 4-step proof chain architecture. Part of Wiedijk's 100 Theorems (#83). References sibling files AbelRuffini.lean and AbelRuffiniGaloisExtensions.lean.",
+      "summary": "Imports three Mathlib modules (GroupTheory.Solvable, SpecificGroups.Alternating, Tactic) and documents the 4-step proof chain architecture. Part of Wiedijk's 100 Theorems (#16, Insolvability of General Higher Degree Equations). References sibling files AbelRuffini.lean and AbelRuffiniGaloisExtensions.lean.",
       "mathContext": "Dependencies: `IsSolvable`, `alternatingGroup`, `isSimpleGroup_five`, `Equiv.Perm.not_solvable` from Mathlib's group theory library."
     },
     {


### PR DESCRIPTION
Enrichment pass for abel-ruffini-oq-04 fixing a factual error.

**Changes:**
- Fixed `wiedijkNumber: 83` → `16` in meta.json — #83 is the Friendship Theorem, #16 is Insolvability of General Higher Degree Equations (Abel-Ruffini)
- Fixed all 3 description/text references from "#83" to "#16" in meta.json
- Fixed annotation reference from "#83" to "#16" in annotations.json
- Lean file docstring (line 27) also says "#83" — deferred to builder

Factual correction, no structural changes.