### PR TITLE
Enrich 3 entries: references, schema fixes, review items

### DIFF
--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -36,6 +36,18 @@
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: (1) largestPrimeFactor — definitional axiom positing existence of the largest prime factor function (trivially realizable, used for convenience), (2) balog_wooley_infinitely_many — mathematical assumption encoding the Balog-Wooley 1998 theorem (infinitely many consecutive smooth pairs)",
     "author": "Erdős-Graham (1980), Balog-Wooley (1998)",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime",
+        "description": "Primality predicate for prime factors",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "IsSmooth and ConsecutiveSmoothRun predicates capturing B-smooth runs",
+      "Parametrized conjecture statement avoiding real exponentiation via divergent smoothBound function",
+      "Separation of definitional axiom (largestPrimeFactor) from mathematical axiom (Balog-Wooley)"
+    ],
     "prerequisites": [
       "smooth-numbers",
       "Dickman-function",
@@ -202,25 +214,54 @@
     "stirling-formula"
   ],
   "leanFile": {
+    "lineCount": 131,
+    "structureCount": 0,
+    "axiomCount": 2,
+    "theoremCount": 0,
+    "lemmaCount": 0,
+    "defCount": 5,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Tactic"
-    ],
-    "opens": [],
-    "namespace": "Erdos369",
-    "lineCount": 131,
-    "axiomCount": 2,
-    "theoremCount": 0,
-    "definitionCount": 5
+    ]
   },
   "references": [
-    "Erdős, P. and Graham, R.L. (1980): 'Old and New Problems and Results in Combinatorial Number Theory', p.69 — original problem statement",
-    "Balog, A. and Wooley, T.D. (1998): 'On strings of consecutive integers with no large prime factors', J. Austral. Math. Soc. Ser. A 64, 266–276",
-    "Hildebrand, A. and Tenenbaum, G. (1986): 'On integers free of large prime factors', Trans. Amer. Math. Soc. 296, 265–290 — Dickman function asymptotics",
-    "de Bruijn, N.G. (1951): 'On the number of positive integers ≤ x and free of prime factors > y', Nederl. Akad. Wetensch. Proc. Ser. A 54",
-    "Guy, R.K.: 'Unsolved Problems in Number Theory', related to B33",
-    "https://erdosproblems.com/369"
+    {
+      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "L'Enseignement Mathématique, Université de Genève, Monographie No. 28",
+      "note": "Problem statement on p. 69: consecutive smooth numbers in {1,...,n}"
+    },
+    {
+      "authors": "Balog, Antal; Wooley, Trevor D.",
+      "title": "On strings of consecutive integers with no large prime factors",
+      "year": "1998",
+      "venue": "Journal of the Australian Mathematical Society (Series A), vol. 64, pp. 266-276",
+      "note": "Proves infinitely many consecutive smooth pairs using sieve methods and exponential sum estimates — the strongest partial result toward Problem #369"
+    },
+    {
+      "authors": "Hildebrand, Adolf; Tenenbaum, Gérald",
+      "title": "On integers free of large prime factors",
+      "year": "1986",
+      "venue": "Transactions of the American Mathematical Society, vol. 296, pp. 265-290",
+      "note": "Precise uniform estimates for Ψ(x,y), the smooth number counting function, refining the Dickman-de Bruijn asymptotic"
+    },
+    {
+      "authors": "de Bruijn, Nicolaas G.",
+      "title": "On the number of positive integers ≤ x and free of prime factors > y",
+      "year": "1951",
+      "venue": "Koninklijke Nederlandse Akademie van Wetenschappen, Proceedings, Series A, vol. 54",
+      "note": "Rigorous development of the Dickman function ρ(u) governing smooth number density"
+    },
+    {
+      "authors": "Guy, Richard K.",
+      "title": "Unsolved Problems in Number Theory",
+      "year": "2004",
+      "venue": "Springer, Problem Books in Mathematics (3rd edition)",
+      "note": "Section B33 discusses smooth numbers and consecutive factorization problems"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass on 3 gallery entries:

- **erdos-1065**: Added 4 scholarly references, fixed annotation range overlap (ann-non-example-37), expanded overview.text, standardized leanFile schema
- **erdos-369**: Converted references to structured format, standardized leanFile schema, added mathlibDependencies and originalContributions
- **abel-ruffini**: Addressed peer review items ai-1 (clarified exists_quintic annotation) and ai-3 (fixed originalContributions precision)

Also: minor annotation range fix for amgm-inequality.

## Test plan
- [x] All JSON files validate (python3 json.load)
- [x] No annotation range overlaps introduced
- [x] Review action items marked resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)