### PR TITLE
Enrich 3 entries: review fixes, Wiedijk correction, axiom specificity

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -67,7 +67,7 @@
       "Finset combinatorics (powersetCard, sum, prod)"
     ],
     "lineCount": 543,
-    "assumptions": "2 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms."
   },
   "crossReferences": [
     {
@@ -263,9 +263,11 @@
     ],
     "namespace": null,
     "lineCount": 543,
+    "structureCount": 0,
     "axiomCount": 2,
     "theoremCount": 17,
-    "definitionCount": 3
+    "lemmaCount": 0,
+    "defCount": 3
   },
   "relatedProofs": [
     "amgm-inequality",


### PR DESCRIPTION
Enrichment batch addressing review findings, factual errors, and axiom integrity.

## abel-ruffini (PR #5421, merged separately)
- Fixed originalContributions[2] per peer review ai-3
- Updated description for Mathlib precision
- Clarified exists_quintic annotation per review ai-1

## abel-ruffini-oq-04 (PR #5421, merged separately)
- Fixed Wiedijk number #83→#16 (was Friendship Theorem, should be Abel-Ruffini)

## amgm-inequality + amgm-inequality-oq-02
- **amgm-inequality**: Added missing structureCount/lemmaCount, normalized defCount
- **amgm-inequality-oq-02**: Replaced generic assumptions ("2 axiom(s)...") with specific
  descriptions of newton_log_concavity and maclaurin_step per axiom integrity policy.
  Added structureCount/lemmaCount, normalized defCount.