### PR TITLE
Enrich 4 entries: axiom specificity, schema normalization

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -137,9 +137,11 @@
     "opens": [],
     "namespace": null,
     "lineCount": 372,
+    "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 3
+    "lemmaCount": 0,
+    "defCount": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -271,9 +271,11 @@
     ],
     "namespace": null,
     "lineCount": 316,
+    "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "lemmaCount": 0,
+    "defCount": 0
   },
   "relatedProofs": [
     "amgm-inequality-oq-03",


### PR DESCRIPTION
Enrichment batch: axiom integrity and leanFile schema normalization.

## amgm-inequality-oq-02
- Replaced generic assumptions ("2 axiom(s)...") with specific descriptions of
  newton_log_concavity and maclaurin_step per axiom integrity policy
- Schema normalization (structureCount, lemmaCount, defCount)

## amgm-inequality-oq-03, amgm-inequality-oq-03-oq-01, amgm-inequality-oq-03-oq-02
- Schema normalization: added missing structureCount/lemmaCount, normalized definitionCount→defCount