### PR TITLE
Enrich Basel Problem: deepen annotations, add references

### DIFF
--- a/src/data/proofs/basel-problem/annotations.json
+++ b/src/data/proofs/basel-problem/annotations.json
@@ -51,7 +51,7 @@
     "id": "ann-basel-main",
     "proofId": "basel-problem",
     "range": {
-      "startLine": 58,
+      "startLine": 62,
       "endLine": 70
     },
     "type": "theorem",
@@ -81,8 +81,8 @@
     },
     "type": "theorem",
     "title": "The tsum Version",
-    "content": "The `tsum` (topological sum) version: `∑' n, 1/n² = π²/6`. This is the form using Lean's notation for infinite sums.",
-    "mathContext": "`tsum` is defined as the limit of partial sums when the series is summable, and 0 otherwise. For summable series, `HasSum.tsum_eq` converts between the two forms.",
+    "content": "`basel_tsum` restates the Basel identity using Lean's `tsum` (topological sum) notation: $\\sum' n, 1/n^2 = \\pi^2/6$. The proof is a one-liner: `basel_hasSum.tsum_eq`.\n\nLean provides two complementary APIs for infinite sums: `HasSum f s` is a *proof-relevant* proposition asserting that the partial sums converge to $s$; `tsum f` is a *function* returning the sum (or 0 if the series diverges). `HasSum.tsum_eq` bridges them: given a proof of `HasSum f s`, it produces `tsum f = s`. Having both forms is useful: `HasSum` composes better in proofs (it carries the convergence witness), while `tsum` allows equational rewriting.",
+    "mathContext": "`tsum f = lim_{S \\to \\text{univ}} \\sum_{n \\in S} f(n)$, where the limit is over finite subsets directed by inclusion. When `f` is not summable, `tsum f = 0` by convention. `HasSum.tsum_eq : HasSum f s → tsum f = s`.",
     "significance": "supporting",
     "prerequisites": [
       "HasSum.tsum_eq",
@@ -90,8 +90,9 @@
     ],
     "relatedConcepts": [
       "tsum",
-      "notation",
-      "equivalence"
+      "HasSum",
+      "topological sum",
+      "summability"
     ]
   },
   {
@@ -103,9 +104,9 @@
     },
     "type": "theorem",
     "title": "Series Convergence",
-    "content": "The series $\\sum 1/n^2$ converges because it's a p-series with $p = 2 > 1$. This is a fundamental result in analysis.",
-    "mathContext": "We use `Real.summable_nat_rpow_inv` which proves that $\\sum n^{-p}$ converges for $p > 1$. The harmonic series ($p = 1$) is the boundary case that diverges.",
-    "significance": "key",
+    "content": "This section header introduces the convergence proof for $\\sum 1/n^2$. Convergence is logically prior to evaluation: before asserting $\\sum 1/n^2 = \\pi^2/6$, one must show the series defines a real number at all. The p-series test ($\\sum n^{-p}$ converges iff $p > 1$) provides the criterion, with $p = 2$ comfortably above the boundary. The harmonic series $p = 1$ is the classical divergence boundary — Jakob Bernoulli (1689) knew $\\sum 1/n^2$ converges (he bounded it below 2 by comparison with a telescoping series) but could not evaluate it.",
+    "mathContext": "The p-series test: $\\sum_{n=1}^{\\infty} n^{-p}$ converges $\\iff p > 1$. For $p = 2$: `Real.summable_nat_rpow_inv` with $p = 2 > 1$ gives summability. The boundary $p = 1$ (harmonic series) diverges as $\\sum_{n=1}^{N} 1/n \\sim \\ln N \\to \\infty$. Bernoulli's bound: $\\sum 1/n^2 < 1 + \\sum_{n=2}^{\\infty} 1/(n(n-1)) = 1 + 1 = 2$.",
+    "significance": "supporting",
     "prerequisites": [
       "Real.summable_nat_rpow_inv",
       "rpow_natCast",
@@ -190,13 +191,13 @@
     "id": "ann-zeta-four",
     "proofId": "basel-problem",
     "range": {
-      "startLine": 125,
+      "startLine": 130,
       "endLine": 132
     },
     "type": "theorem",
     "title": "Higher Zeta Values",
-    "content": "Euler generalized the Basel identity: $\\zeta(4) = \\pi^4/90$, $\\zeta(6) = \\pi^6/945$, and in general $\\zeta(2k)$ is a rational multiple of $\\pi^{2k}$ involving Bernoulli numbers.",
-    "mathContext": "The general formula is $\\zeta(2k) = (-1)^{k+1} \\cdot 2^{2k-1} \\cdot \\pi^{2k} \\cdot B_{2k} / (2k)!$ where $B_{2k}$ is the $(2k)$-th Bernoulli number.",
+    "content": "`zeta_four_hasSum` proves $\\zeta(4) = \\pi^4/90$ via Mathlib's `hasSum_zeta_four`. This is the next case after Basel: Euler computed it in 1735 by comparing the $x^4$ coefficient in his $\\sin(x)/x$ factorization.\n\nEuler eventually tabulated $\\zeta(2k)$ up to $k = 13$ (i.e., $\\zeta(26)$), each time finding a rational multiple of $\\pi^{2k}$. The pattern is governed by Bernoulli numbers $B_{2k}$: $\\zeta(2) = \\pi^2/6$ uses $B_2 = 1/6$, $\\zeta(4) = \\pi^4/90$ uses $B_4 = -1/30$, $\\zeta(6) = \\pi^6/945$ uses $B_6 = 1/42$. The Bernoulli numbers grow super-exponentially: $|B_{2k}| \\sim 4\\sqrt{\\pi k}(k/\\pi e)^{2k}$, which implies $|\\zeta(2k)| \\to 1$ as $k \\to \\infty$ (the sum is increasingly dominated by the $n = 1$ term).",
+    "mathContext": "$\\zeta(4) = \\sum_{n=1}^{\\infty} \\frac{1}{n^4} = \\frac{\\pi^4}{90}$. From Euler's $x^4$ coefficient: $\\sum \\frac{1}{n^4\\pi^4} + \\sum_{i<j} \\frac{1}{i^2 j^2 \\pi^4} = \\frac{1}{120}$. Combined with $(\\sum 1/n^2\\pi^2)^2 = 1/36$, Euler extracted $\\zeta(4) = \\pi^4/90$. The general formula: $\\zeta(2k) = \\frac{(-1)^{k+1} 2^{2k-1} \\pi^{2k} B_{2k}}{(2k)!}$.",
     "significance": "key",
     "prerequisites": [
       "hasSum_zeta_four",
@@ -206,7 +207,8 @@
     "relatedConcepts": [
       "Bernoulli numbers",
       "zeta values",
-      "special functions"
+      "even zeta values",
+      "power sums"
     ]
   },
   {

--- a/src/data/proofs/basel-problem/annotations.source.json
+++ b/src/data/proofs/basel-problem/annotations.source.json
@@ -82,13 +82,14 @@
     },
     "type": "theorem",
     "title": "The tsum Version",
-    "content": "The `tsum` (topological sum) version: `∑' n, 1/n² = π²/6`. This is the form using Lean's notation for infinite sums.",
-    "mathContext": "`tsum` is defined as the limit of partial sums when the series is summable, and 0 otherwise. For summable series, `HasSum.tsum_eq` converts between the two forms.",
+    "content": "`basel_tsum` restates the Basel identity using Lean's `tsum` (topological sum) notation: $\\sum' n, 1/n^2 = \\pi^2/6$. The proof is a one-liner: `basel_hasSum.tsum_eq`.\n\nLean provides two complementary APIs for infinite sums: `HasSum f s` is a *proof-relevant* proposition asserting that the partial sums converge to $s$; `tsum f` is a *function* returning the sum (or 0 if the series diverges). `HasSum.tsum_eq` bridges them: given a proof of `HasSum f s`, it produces `tsum f = s`. Having both forms is useful: `HasSum` composes better in proofs (it carries the convergence witness), while `tsum` allows equational rewriting.",
+    "mathContext": "`tsum f = lim_{S \\to \\text{univ}} \\sum_{n \\in S} f(n)$, where the limit is over finite subsets directed by inclusion. When `f` is not summable, `tsum f = 0` by convention. `HasSum.tsum_eq : HasSum f s → tsum f = s`.",
     "significance": "supporting",
     "relatedConcepts": [
       "tsum",
-      "notation",
-      "equivalence"
+      "HasSum",
+      "topological sum",
+      "summability"
     ],
     "prerequisites": [
       "HasSum.tsum_eq",
@@ -104,9 +105,9 @@
     },
     "type": "theorem",
     "title": "Series Convergence",
-    "content": "The series $\\sum 1/n^2$ converges because it's a p-series with $p = 2 > 1$. This is a fundamental result in analysis.",
-    "mathContext": "We use `Real.summable_nat_rpow_inv` which proves that $\\sum n^{-p}$ converges for $p > 1$. The harmonic series ($p = 1$) is the boundary case that diverges.",
-    "significance": "key",
+    "content": "This section header introduces the convergence proof for $\\sum 1/n^2$. Convergence is logically prior to evaluation: before asserting $\\sum 1/n^2 = \\pi^2/6$, one must show the series defines a real number at all. The p-series test ($\\sum n^{-p}$ converges iff $p > 1$) provides the criterion, with $p = 2$ comfortably above the boundary. The harmonic series $p = 1$ is the classical divergence boundary — Jakob Bernoulli (1689) knew $\\sum 1/n^2$ converges (he bounded it below 2 by comparison with a telescoping series) but could not evaluate it.",
+    "mathContext": "The p-series test: $\\sum_{n=1}^{\\infty} n^{-p}$ converges $\\iff p > 1$. For $p = 2$: `Real.summable_nat_rpow_inv` with $p = 2 > 1$ gives summability. The boundary $p = 1$ (harmonic series) diverges as $\\sum_{n=1}^{N} 1/n \\sim \\ln N \\to \\infty$. Bernoulli's bound: $\\sum 1/n^2 < 1 + \\sum_{n=2}^{\\infty} 1/(n(n-1)) = 1 + 1 = 2$.",
+    "significance": "supporting",
     "relatedConcepts": [
       "p-series",
       "Summable",
@@ -200,13 +201,14 @@
     },
     "type": "theorem",
     "title": "Higher Zeta Values",
-    "content": "Euler generalized the Basel identity: $\\zeta(4) = \\pi^4/90$, $\\zeta(6) = \\pi^6/945$, and in general $\\zeta(2k)$ is a rational multiple of $\\pi^{2k}$ involving Bernoulli numbers.",
-    "mathContext": "The general formula is $\\zeta(2k) = (-1)^{k+1} \\cdot 2^{2k-1} \\cdot \\pi^{2k} \\cdot B_{2k} / (2k)!$ where $B_{2k}$ is the $(2k)$-th Bernoulli number.",
+    "content": "`zeta_four_hasSum` proves $\\zeta(4) = \\pi^4/90$ via Mathlib's `hasSum_zeta_four`. This is the next case after Basel: Euler computed it in 1735 by comparing the $x^4$ coefficient in his $\\sin(x)/x$ factorization.\n\nEuler eventually tabulated $\\zeta(2k)$ up to $k = 13$ (i.e., $\\zeta(26)$), each time finding a rational multiple of $\\pi^{2k}$. The pattern is governed by Bernoulli numbers $B_{2k}$: $\\zeta(2) = \\pi^2/6$ uses $B_2 = 1/6$, $\\zeta(4) = \\pi^4/90$ uses $B_4 = -1/30$, $\\zeta(6) = \\pi^6/945$ uses $B_6 = 1/42$. The Bernoulli numbers grow super-exponentially: $|B_{2k}| \\sim 4\\sqrt{\\pi k}(k/\\pi e)^{2k}$, which implies $|\\zeta(2k)| \\to 1$ as $k \\to \\infty$ (the sum is increasingly dominated by the $n = 1$ term).",
+    "mathContext": "$\\zeta(4) = \\sum_{n=1}^{\\infty} \\frac{1}{n^4} = \\frac{\\pi^4}{90}$. From Euler's $x^4$ coefficient: $\\sum \\frac{1}{n^4\\pi^4} + \\sum_{i<j} \\frac{1}{i^2 j^2 \\pi^4} = \\frac{1}{120}$. Combined with $(\\sum 1/n^2\\pi^2)^2 = 1/36$, Euler extracted $\\zeta(4) = \\pi^4/90$. The general formula: $\\zeta(2k) = \\frac{(-1)^{k+1} 2^{2k-1} \\pi^{2k} B_{2k}}{(2k)!}$.",
     "significance": "key",
     "relatedConcepts": [
       "Bernoulli numbers",
       "zeta values",
-      "special functions"
+      "even zeta values",
+      "power sums"
     ],
     "prerequisites": [
       "hasSum_zeta_four",

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -180,6 +180,21 @@
       "key": "Ri00",
       "citation": "Rivoal, T., La fonction zêta de Riemann prend une infinité de valeurs irrationnelles aux entiers impairs, Comptes Rendus Acad. Sci. Paris Sér. I 331 (2000), 267–270.",
       "type": "paper"
+    },
+    {
+      "key": "We76",
+      "citation": "Weierstrass, K., Zur Theorie der eindeutigen analytischen Functionen, Abhandlungen der Königlich Preussischen Akademie der Wissenschaften zu Berlin (1876), 11–60. Established the factorization theorem for entire functions, rigorously justifying Euler's 1734 infinite product factorization of sin(x)/x.",
+      "type": "paper"
+    },
+    {
+      "key": "Ch11",
+      "citation": "Chapman, R., Evaluating ζ(2), preprint (1999, revised 2003). Collects and compares fourteen proofs of ζ(2) = π²/6, including Euler's product, Parseval, residue calculus, and double integral approaches.",
+      "type": "paper"
+    },
+    {
+      "key": "Be1713",
+      "citation": "Bernoulli, J., Ars Conjectandi (posthumous, 1713). Contains the Bernoulli numbers B_k and their connection to power sums — the same B_k that appear in Euler's formula ζ(2k) = (-1)^(k+1) 2^(2k-1) π^(2k) B_{2k} / (2k)!.",
+      "type": "book"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

First enrichment pass for `basel-problem` (quality 100, passes 0 → 1).

- Expanded 3 brief annotations (`ann-convergence`, `ann-basel-tsum`, `ann-zeta-four`) with mathematical depth
- Added 3 scholarly references: Weierstrass (1876), Chapman fourteen-proofs survey, Bernoulli *Ars Conjectandi* (1713)
- Corrected `ann-convergence` significance from "key" to "supporting" (section header, not theorem)

## Test plan

- [x] JSON validation passes for all modified files
- [x] `pnpm annotations:build` shows no errors for `basel-problem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)