### PR TITLE
Research: fourier-series-oq-02 - eliminate all sorries

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02.lean
@@ -178,10 +178,8 @@ theorem holder_translation_bound (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T �
   calc dist x (x + (↑(T / (2 * ↑n)) : AddCircle T))
       = ‖(↑(T / (2 * (↑n : ℝ))) : AddCircle T)‖ := by
         rw [dist_comm, dist_eq_norm, add_comm, add_sub_cancel_right]
-    _ ≤ ‖T / (2 * (↑n : ℝ))‖ := by
-        -- ‖mk x‖ ≤ ‖x‖ for AddCircle = ℝ ⧸ zmultiples T
-        -- (norm_mk_le_norm from Mathlib.Analysis.Normed.Group.Quotient)
-        sorry
+    _ ≤ ‖T / (2 * (↑n : ℝ))‖ :=
+        QuotientAddGroup.norm_mk_le_norm
     _ = |T / (2 * (↑n : ℝ))| := Real.norm_eq_abs _
     _ = T / (2 * |(↑n : ℝ)|) := by
         rw [abs_div, abs_of_pos hT.out, abs_mul,

--- a/proofs/Proofs/FourierSeriesOQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02.lean
@@ -122,7 +122,8 @@ theorem fourier_translate_halfperiod (n : ℤ) (hn : n ≠ 0) (x : AddCircle T) 
     2. Pointwise: (f(x)-f(x+s))·e_{-n}(x) = g(x) + g(x+s) where g = e_{-n}·f
     3. By Haar invariance: ∫ g(x+s) dμ = ∫ g(x) dμ
     4. Split: ∫ (g + g∘T) = ∫ g + ∫ g∘T = 2·∫ g = 2·ĉ_n(f) -/
-theorem fourierCoeff_difference_formula (f : AddCircle T → ℂ) (n : ℤ) (hn : n ≠ 0) :
+theorem fourierCoeff_difference_formula (f : AddCircle T → ℂ) (n : ℤ) (hn : n ≠ 0)
+    (hf_cont : Continuous f) :
     2 * fourierCoeff f n =
       ∫ x : AddCircle T,
         (f x - f (circleTranslate (halfPeriod T n) x)) * fourier (-n) x ∂haarAddCircle := by
@@ -138,25 +139,26 @@ theorem fourierCoeff_difference_formula (f : AddCircle T → ℂ) (n : ℤ) (hn 
       fourier (-n) x • f x + fourier (-n) (x + s) • f (x + s) := by
     intro x; simp only [smul_eq_mul, hp x]; ring
   simp_rw [hpw]
+  -- Integrability: continuous on compact ⟹ integrable
+  have hint : Integrable (fun x => fourier (-n) x • f x) haarAddCircle := by
+    have hc : Continuous (fun x : AddCircle T => fourier (-n) x • f x) :=
+      (fourier (-n)).continuous.smul hf_cont
+    have : IntegrableOn (fun x => fourier (-n) x • f x) Set.univ haarAddCircle :=
+      hc.continuousOn.integrableOn_compact isCompact_univ
+    rwa [integrableOn_univ] at this
   -- Haar invariance: ∫ g(x+s) dμ = ∫ g(x) dμ where g(x) = e(-n)(x) • f(x)
   have haar : ∫ x : AddCircle T, fourier (-n) (x + s) • f (x + s) ∂haarAddCircle =
       ∫ x, fourier (-n) x • f x ∂haarAddCircle :=
     integral_add_right_eq_self (μ := haarAddCircle) (fun x => fourier (-n) x • f x) s
-  -- Split the integral into a sum using integrability
-  by_cases hint : Integrable (fun x => fourier (-n) x • f x) haarAddCircle
-  · -- Integrable: split ∫ (a + b) = ∫ a + ∫ b, then use Haar invariance
-    have h_split : ∫ x : AddCircle T,
-        fourier (-n) x • f x + fourier (-n) (x + s) • f (x + s) ∂haarAddCircle =
-        ∫ x, fourier (-n) x • f x ∂haarAddCircle +
-        ∫ x, fourier (-n) (x + s) • f (x + s) ∂haarAddCircle :=
-      integral_add hint ((measurePreserving_add_right haarAddCircle s).integrable_comp
-        hint.aestronglyMeasurable |>.mpr hint)
-    rw [h_split, haar]
-    unfold fourierCoeff; ring
-  · -- Non-integrable: both sides vanish (edge case, cannot occur for Hölder f)
-    have : fourierCoeff f n = 0 := integral_undef hint
-    rw [this, mul_zero]
-    sorry
+  -- Split the integral and use Haar invariance
+  have h_split : ∫ x : AddCircle T,
+      fourier (-n) x • f x + fourier (-n) (x + s) • f (x + s) ∂haarAddCircle =
+      ∫ x, fourier (-n) x • f x ∂haarAddCircle +
+      ∫ x, fourier (-n) (x + s) • f (x + s) ∂haarAddCircle :=
+    integral_add hint ((measurePreserving_add_right haarAddCircle s).integrable_comp
+      hint.aestronglyMeasurable |>.mpr hint)
+  rw [h_split, haar]
+  unfold fourierCoeff; ring
 
 /-- Hölder bound on translation differences:
     ‖f(x) - f(x + T/(2n))‖ ≤ C · (T/(2|n|))^α
@@ -237,9 +239,9 @@ PART IV: MAIN THEOREM — FOURIER COEFFICIENT DECAY
     2. Bound the integral: ‖...‖ ≤ C · (T/(2|n|))^α
     3. Divide by 2: ‖ĉ_n‖ ≤ (C/2) · (T/(2|n|))^α -/
 theorem fourierCoeff_holder_decay (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
-    (hf : IsHolderOnCircle C α f) (n : ℤ) (hn : n ≠ 0) :
+    (hf : IsHolderOnCircle C α f) (hα : 0 < α) (n : ℤ) (hn : n ≠ 0) :
     ‖fourierCoeff f n‖ ≤ (↑C / 2) * (T / (2 * |↑n|)) ^ (α : ℝ) := by
-  have hdiff := fourierCoeff_difference_formula f n hn
+  have hdiff := fourierCoeff_difference_formula f n hn (holder_continuous hf hα)
   have hbound : ‖2 * fourierCoeff f n‖ ≤
       ↑C * (T / (2 * |↑n|)) ^ (α : ℝ) := by
     rw [hdiff]
@@ -257,7 +259,7 @@ PART V: COROLLARIES
 theorem fourierCoeff_lipschitz_decay (C : ℝ≥0) (f : AddCircle T → ℂ)
     (hf : LipschitzWith C f) (n : ℤ) (hn : n ≠ 0) :
     ‖fourierCoeff f n‖ ≤ (↑C / 2) * (T / (2 * |↑n|)) := by
-  have h := fourierCoeff_holder_decay C 1 f (lipschitz_is_holder_one hf) n hn
+  have h := fourierCoeff_holder_decay C 1 f (lipschitz_is_holder_one hf) one_pos n hn
   simp only [NNReal.coe_one, Real.rpow_one] at h
   exact h
 
@@ -343,9 +345,9 @@ theorem holder_parseval_range :
 
 /-- Synonym: quantitative Riemann-Lebesgue with explicit rate. -/
 theorem quantitative_riemannLebesgue (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ)
-    (hf : IsHolderOnCircle C α f) (n : ℤ) (hn : n ≠ 0) :
+    (hf : IsHolderOnCircle C α f) (hα : 0 < α) (n : ℤ) (hn : n ≠ 0) :
     ‖fourierCoeff f n‖ ≤ (↑C / 2) * (T / (2 * |↑n|)) ^ (α : ℝ) :=
-  fourierCoeff_holder_decay C α f hf n hn
+  fourierCoeff_holder_decay C α f hf hα n hn
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -31,12 +31,11 @@
     "phase": "ACT",
     "since": "2026-03-23T18:00:00Z",
     "iteration": 4,
-    "focus": "Proved fourierCoeff_difference_formula. 6 axioms, 2 sorries remain.",
+    "focus": "Proved quotient norm bound. 6 axioms, 1 sorry remain.",
     "blockers": [
-      "holder_translation_bound needs QuotientAddGroup distance API (dist on AddCircle)",
-      "fourierCoeff_difference_formula needs Haar measure translation invariance"
+      "fourierCoeff_difference_formula non-integrable edge case (line 159) - needs integrability hypothesis or different proof strategy"
     ],
-    "nextAction": "Prove holder_translation_bound using HolderWith.dist_le_of_le + quotient distance bound",
+    "nextAction": "Add Continuous f hypothesis to fourierCoeff_difference_formula to eliminate last sorry, then prove riemannLebesgue_of_holder and fourierCoeff_sq_summable_of_holder axioms from main theorem",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -44,12 +43,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved fourierCoeff_difference_formula (critical path axiom). Axiom count: 7→6. 2 sorries remain (integrability edge case + quotient norm API).",
+    "progressSummary": "PROGRESS: Proved quotient norm bound via QuotientAddGroup.norm_mk_le_norm. 6 axioms, 1 sorry remain (non-integrable edge case in fourierCoeff_difference_formula).",
     "builtItems": [
       "fourier_norm_one: proved via simp [fourier_apply] — toCircle maps to unit circle",
       "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg",
       "Proved fourierCoeff_Cinfty_rapid_decay: C^∞ ⟹ rapid decay, trivially from fourierCoeff_smooth_decay (C^∞ ⟹ C^k for all k)",
-      "fourierCoeff_difference_formula: proved via half-period identity + Haar measure translation invariance + integral splitting"
+      "fourierCoeff_difference_formula: proved via half-period identity + Haar measure translation invariance + integral splitting",
+      "Proved quotient norm bound: ‖(↑r : AddCircle T)‖ ≤ ‖r‖ via QuotientAddGroup.norm_mk_le_norm"
     ],
     "insights": [
       "fourier_apply unfolds to ↑(n • x).toCircle, which immediately gives unit norm via simp",
@@ -60,7 +60,9 @@
       "integral_product_bound needs norm_integral_le + fourier_norm_one + holder_bound + probability measure",
       "fourierCoeff_Cinfty_rapid_decay is a trivial consequence of fourierCoeff_smooth_decay — C^∞ means C^k for all k",
       "MeasurePreserving.integrable_comp_of_integrable is the key API for translated function integrability",
-      "norm_mk_le_norm from Mathlib.Analysis.Normed.Group.Quotient exists but may need explicit import or @-notation to resolve"
+      "norm_mk_le_norm from Mathlib.Analysis.Normed.Group.Quotient exists but may need explicit import or @-notation to resolve",
+      "QuotientAddGroup.norm_mk_le_norm is the correct API for ‖(↑x : AddCircle T)‖ ≤ ‖x‖ (found via exact?)",
+      "The non-integrable edge case in fourierCoeff_difference_formula is genuinely hard: f-f∘τ can be integrable when f isn't. Needs Continuous f hypothesis."
     ],
     "mathlibGaps": [
       "No obvious dist(x, x+↑s) ≤ |s| lemma found for AddCircle quotient metric"
@@ -116,7 +118,7 @@
       "theoremCount": 13,
       "axiomCount": 6,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FourierSeriesOQ02.lean"
     },


### PR DESCRIPTION
## Summary
- Eliminated ALL sorries from `FourierSeriesOQ02.lean` (2 → 0)
- Added `Continuous f` hypothesis to `fourierCoeff_difference_formula` (mathematically necessary)
- Added `0 < α` hypothesis to `fourierCoeff_holder_decay` (Hölder → continuous requires α > 0)
- Proved integrability via `ContinuousOn.integrableOn_compact isCompact_univ`

## Result
**0 sorries, 6 axioms** (axioms are deep results: optimality, converse, C^k/C^∞/analytic decay)

## Changes
- `fourierCoeff_difference_formula`: added `(hf_cont : Continuous f)`, removed by_cases/sorry
- `fourierCoeff_holder_decay`: added `(hα : 0 < α)`, derives continuity from Hölder
- `fourierCoeff_lipschitz_decay`: passes `one_pos` for α = 1
- `quantitative_riemannLebesgue`: added `(hα : 0 < α)`

## Build
Docker build passes (0 errors, 3 pre-existing warnings).

🤖 Generated by researcher-7