### PR TITLE
Enrich Sylow's Theorems: expand description, detail assumptions

### DIFF
--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -2,7 +2,7 @@
   "id": "sylow-theorems",
   "title": "Sylow's Theorems",
   "slug": "sylow-theorems",
-  "description": "The three Sylow theorems: existence of Sylow p-subgroups, their conjugacy, and counting constraints. Fundamental structure theorems for finite groups.",
+  "description": "Sylow's Theorems (Wiedijk #72): for a finite group $G$ and prime $p \\mid |G|$, (1) Sylow $p$-subgroups exist, (2) they are all conjugate, (3) their number $n_p \\equiv 1 \\pmod{p}$ and $n_p \\mid |G|/p^k$. Formalized in Lean 4 via Mathlib's `Sylow` infrastructure. The strongest partial converse to Lagrange's theorem. 0 sorries, 0 axioms.",
   "meta": {
     "wiedijkNumber": 72,
     "author": "Peter Ludwig Mejdell Sylow (formalized via Mathlib)",
@@ -62,7 +62,7 @@
       "theoremCount": 10,
       "definitionCount": 1
     },
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. All three Sylow theorems delegate to Mathlib's `Sylow` module: existence via `Sylow.exists`, conjugacy via `Sylow.equiv`, and counting via `Sylow.card_sylow_modEq_one`. Original contributions are pedagogical wrappers — `unique_sylow_normal` (unique Sylow subgroup is normal) and `cauchy_theorem` (Cauchy's theorem as corollary) provide accessible named statements composing Mathlib results."
   },
   "overview": {
     "historicalContext": "Peter Ludwig Mejdell Sylow (1832-1918) was a Norwegian mathematician who spent most of his career as a high school teacher in Halden, proving these landmark theorems as a side pursuit. He published them in *Mathematische Annalen* (1872, vol. 5) — a single paper that transformed finite group theory.\n\nGeorg Frobenius (1849-1917) gave streamlined alternative proofs in 1887 and strengthened the counting theorem. William Burnside (1852-1927) deployed Sylow's theorems extensively, proving in 1904 that all groups of order p^a·q^b are solvable — a result later reproved by Feit-Thompson (1963) as part of the monumental Odd Order Theorem.\n\nThe theorems became a cornerstone of the Classification of Finite Simple Groups (CFSG), completed ~2004 by Aschbacher, Smith, and others: Sylow counting immediately eliminates most orders from being simple, while conjugacy ensures uniform subgroup structure within each prime family.",


### PR DESCRIPTION
Enrichment pass for sylow-theorems (pass 2).

- Expanded description to mention Wiedijk #72, all three theorem statements (existence, conjugacy, counting), Mathlib delegation, and connection to Lagrange's theorem
- Detailed assumptions to identify Mathlib proof paths (`Sylow.exists`, `Sylow.equiv`, `Sylow.card_sylow_modEq_one`) and pedagogical wrapper contributions