### PR TITLE
Audit fix: badge original→mathlib for amgm-oq-03 family

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -16,7 +16,7 @@
       "classic",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -54,7 +54,7 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 372,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core building blocks (Jensen, rpow arithmetic) from Mathlib; original proofs for duality identity and negative-exponent monotonicity."
   },
   "overview": {
     "historicalContext": "The Power Mean Inequality states that $M_r \\leq M_s$ whenever $r \\leq s$. While the positive-exponent case ($0 < r \\leq s$) follows directly from Jensen's inequality applied to the convex function $t \\mapsto t^{s/r}$, the negative-exponent case requires a fundamentally different approach.\n\nThe classical trick, due to Hardy, Littlewood, and Pólya (*Inequalities*, 1934, §2.9), exploits the algebraic duality $M_r(z) = M_{-r}(z^{-1})^{-1}$ between positive and negative power means via value inversion. This duality is an instance of a pervasive pattern in analysis: Hölder duality ($\\|f\\|_p^* = \\|f\\|_{p/(p-1)}$), Legendre-Fenchel duality in convex analysis ($f^{**} = f$ for convex $f$), and Pontryagin duality in harmonic analysis all exploit the same principle — negating or inverting a parameter transforms one inequality into another. The power mean duality is perhaps the simplest non-trivial example.\n\nAs of early 2026, Mathlib4 had an explicit TODO noting the gap for 'generalized mean inequality with any $p \\leq q$, including negative numbers.' This formalization fills that gap for the $r \\leq s < 0$ case, complementing the positive case proved in the parent file. The proof technique — reducing to a known case via an algebraic identity — is a model for how duality arguments can systematically extend results across parameter boundaries.",

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -62,7 +62,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms, 0 sorries. All 10 theorems proved from Mathlib with no custom axioms or structure-encoded assumptions.",
+    "assumptions": "0 axioms, 0 sorries. Main limit theorem is original; uses Mathlib calculus infrastructure (derivatives, exp/log, AM-GM) as building blocks.",
     "prerequisites": [
       "Derivatives in Mathlib (HasDerivAt, hasDerivAt_iff_tendsto_slope)",
       "Real exp/log/rpow identities and derivatives",

--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "amgm-inequality-oq-03",
   "title": "Power Mean Interpolation: How Do Weighted Power Means Relate to AM and GM?",
   "slug": "amgm-inequality-oq-03",
-  "description": "The weighted power mean M_r(z,w) = (∑ wᵢzᵢ^r)^(1/r) forms a continuous monotone family as r varies: HM = M_{-1} ≤ GM = lim_{r→0} M_r ≤ AM = M_1 ≤ M_2 ≤ ... This formalization proves HM ≤ GM directly via AM-GM on inverse values, M_r ≤ M_s for 0 < r ≤ s via Jensen's inequality, and M_r ≤ M_s for r ≤ s < 0 via the duality identity M_r(z) = M_{-r}(z⁻¹)⁻¹. Fully verified with 0 sorries and 0 axioms.",
+  "description": "The weighted power mean M_r(z,w) = (∑ wᵢzᵢ^r)^(1/r) forms a continuous monotone family as r varies: HM = M_{-1} ≤ GM = lim_{r→0} M_r ≤ AM = M_1 ≤ M_2 ≤ ... This formalization proves HM ≤ GM directly via AM-GM on inverse values, M_r ≤ M_s for 0 < r ≤ s via Jensen's inequality, and M_r ≤ M_s for r ≤ s < 0 via the duality identity M_r(z) = M_{-r}(z⁻¹)⁻¹. Core building blocks (AM-GM, Jensen) from Mathlib; original proofs for HM ≤ GM and power mean monotonicity. 0 sorries and 0 axioms.",
   "meta": {
     "author": "Hardy, Littlewood, Pólya (1934); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Power_mean",
@@ -17,7 +17,7 @@
       "research",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -58,7 +58,7 @@
       "Finset product and sum operations"
     ],
     "lineCount": 372,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core building blocks (AM-GM, Jensen, AM ≤ M_p) from Mathlib; original proofs for HM ≤ GM, power mean monotonicity (positive and negative exponents), and duality identity."
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Gallery integrity audit found badge misclassification in the AM-GM power mean family:

- **amgm-inequality-oq-03**: Badge `original` → `mathlib` (core building blocks AM-GM, Jensen from Mathlib)
- **amgm-inequality-oq-03-oq-01**: Badge `original` → `mathlib` (same Lean file as oq-03)
- **amgm-inequality-oq-03-oq-02**: Badge `original` kept (main limit theorem is independent), but assumptions clarified

All three had `assumptions` fields updated to accurately credit Mathlib infrastructure.

## Evidence

The shared Lean file `AmgmInequalityOQ03.lean` directly calls:
- `Real.arith_mean_le_rpow_mean` (AM ≤ M_p)
- `Real.geom_mean_le_arith_mean_weighted` (AM-GM)
- `Real.rpow_arith_mean_le_arith_mean_rpow` (Jensen)

Per gallery integrity policy, badge should be `mathlib` when core results come from Mathlib.

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Check gallery pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)