### PR TITLE
Enrich erdos-724: add section mathContext, cross-references, references

### DIFF
--- a/src/data/proofs/erdos-276/meta.json
+++ b/src/data/proofs/erdos-276/meta.json
@@ -51,36 +51,18 @@
       "coprime_necessary axiom (GCD propagation)",
       "covering_system_mechanism axiom"
     ],
-    "crossReferences": [
-      {
-        "proofId": "erdos-275",
-        "relationship": "Foundational covering congruence result (2^r bound) — the theoretical backbone of Graham's construction in erdos-276"
-      },
-      {
-        "proofId": "erdos-277",
-        "relationship": "Adjacent covering system problem from the same Erdős-Graham investigation"
-      },
-      {
-        "proofId": "erdos-2",
-        "relationship": "Minimum modulus problem for covering systems — constrains what covering constructions are possible"
-      },
-      {
-        "proofId": "erdos-7",
-        "relationship": "Odd covering systems problem — parity constraints on covering moduli relevant to Lucas recurrence analysis"
-      },
-      {
-        "proofId": "erdos-1113",
-        "relationship": "Sierpinski numbers without covering sets — parallel question about whether covering systems are the only mechanism for compositeness"
-      }
-    ],
     "relatedProblems": [
       {
         "id": "erdos-275",
-        "relation": "Covering congruence 2^r bound — foundational to Graham's construction"
+        "relationship": "Covering congruence 2^r bound — foundational to Graham's construction"
+      },
+      {
+        "id": "erdos-277",
+        "relationship": "Adjacent covering system problem from the same Erdős-Graham investigation"
       },
       {
         "id": "erdos-1113",
-        "relation": "Sierpinski numbers: parallel question about covering systems as sole mechanism for compositeness"
+        "relationship": "Sierpinski numbers: parallel question about covering systems as sole mechanism for compositeness"
       }
     ],
     "axiomCount": 4,
@@ -110,42 +92,48 @@
       "title": "Imports",
       "summary": "Imports Mathlib's natural number arithmetic, GCD, primality, and tactic libraries.",
       "startLine": 20,
-      "endLine": 23
+      "endLine": 23,
+      "mathContext": "Requires `Nat.Composite` ($n$ has a nontrivial factorization), `Nat.Coprime` ($\\gcd(a,b) = 1$), `Nat.Prime`, and divisibility ($\\mid$) from Mathlib."
     },
     {
       "id": "definition",
       "title": "Core Definitions",
       "summary": "Defines **IsLucasSequence** ($a_{n+2} = a_{n+1} + a_n$), **IsPrimefree** ($\\forall k, a_k$ composite), and **HasNoUniversalDivisor** ($\\forall d > 1, \\exists k, d \\nmid a_k$). These three predicates capture the problem's requirements precisely.",
       "startLine": 25,
-      "endLine": 38
+      "endLine": 38,
+      "mathContext": "Three predicates: $\\text{IsLucasSequence}(a) :\\equiv \\forall n,\\, a(n+2) = a(n+1) + a(n)$; $\\text{IsPrimefree}(a) :\\equiv \\forall k,\\, a(k).\\text{Composite}$; $\\text{HasNoUniversalDivisor}(a) :\\equiv \\forall d > 1,\\, \\exists k,\\, d \\nmid a(k)$."
     },
     {
       "id": "main-question",
       "title": "Main Question (Existence)",
       "summary": "Axiomatizes **erdos_276_existence**: there exists a Lucas sequence that is primefree with no universal divisor. This is the resolved part of the problem (Graham 1964).",
       "startLine": 40,
-      "endLine": 47
+      "endLine": 47,
+      "mathContext": "$\\exists a : \\mathbb{N} \\to \\mathbb{N},\\; \\text{IsLucasSequence}(a) \\wedge \\text{IsPrimefree}(a) \\wedge \\text{HasNoUniversalDivisor}(a)$. Graham (1964) proved existence via covering congruences."
     },
     {
       "id": "graham-construction",
       "title": "Graham's Construction",
       "summary": "Axiomatizes **graham_construction** (coprime primefree Lucas sequence exists) and **coprime_necessary** (any common divisor of $a_0, a_1$ divides all terms). Together, these show coprimality is the right condition for nontriviality.",
       "startLine": 49,
-      "endLine": 63
+      "endLine": 63,
+      "mathContext": "Graham's strengthening: $\\exists a,\\, \\text{IsLucasSequence}(a) \\wedge \\text{IsPrimefree}(a) \\wedge \\gcd(a_0, a_1) = 1$. GCD propagation: $d \\mid a_0 \\wedge d \\mid a_1 \\Rightarrow \\forall k,\\, d \\mid a_k$ (by induction on $a_{n+2} = a_{n+1} + a_n$)."
     },
     {
       "id": "covering-mechanism",
       "title": "Covering Congruence Mechanism",
       "summary": "Axiomatizes **covering_system_mechanism**: a finite set of primes covers all index positions via Pisano period residue classes. This captures how Graham's construction works and poses the open question of whether this mechanism is necessary.",
       "startLine": 65,
-      "endLine": 77
+      "endLine": 77,
+      "mathContext": "$\\exists S \\subseteq \\{\\text{primes}\\},\\; \\forall a,\\; \\text{IsLucas}(a) \\wedge \\gcd(a_0,a_1)=1 \\wedge \\text{Primefree}(a) \\Rightarrow \\forall k,\\, \\exists p \\in S,\\, p \\mid a_k$. The Lucas sequence is periodic mod $p$ with Pisano period $\\pi(p)$."
     },
     {
       "id": "further-results",
       "title": "Further Results and Open Questions",
       "summary": "Comments on Vsemirnov's (2004) record-small starting values ($a_0 = 106276436867$) and the central open question: are covering congruences the only mechanism for primefree Lucas sequences?",
       "startLine": 79,
-      "endLine": 87
+      "endLine": 87,
+      "mathContext": "Current record: $a_0 = 106276436867$, $a_1 = 35256392432$ (Vsemirnov 2004). Open: is every primefree coprime Lucas sequence explained by a covering system?"
     }
   ],
   "conclusion": {
@@ -174,27 +162,59 @@
     "definitionCount": 3
   },
   "references": [
-    "Graham (1964): 'A Fibonacci-like sequence of composite numbers', Mathematics Magazine 37, 322–324",
-    "Vsemirnov (2004): 'Two new records concerning primefree Fibonacci-like sequences'",
-    "Ismailescu–Son (2014): 'On primefree sequences generated by Lucas recurrences'",
-    "Knuth (1990): Note on smaller primefree starting values",
-    "Erdős–Graham (1980): Old and New Problems and Results in Combinatorial Number Theory",
-    "https://erdosproblems.com/276"
+    {
+      "key": "Gr64",
+      "citation": "Graham, R.L., A Fibonacci-like sequence of composite numbers, Mathematics Magazine 37 (1964), 322–324.",
+      "type": "paper"
+    },
+    {
+      "key": "Vs04",
+      "citation": "Vsemirnov, M., Two new records concerning primefree Fibonacci-like sequences (2004).",
+      "type": "paper"
+    },
+    {
+      "key": "IS14",
+      "citation": "Ismailescu, D. and Son, J., On primefree sequences generated by Lucas recurrences (2014).",
+      "type": "paper"
+    },
+    {
+      "key": "EG80",
+      "citation": "Erdős, P. and Graham, R.L., Old and New Problems and Results in Combinatorial Number Theory, Monographies de L'Enseignement Mathématique 28, Université de Genève (1980).",
+      "type": "book"
+    }
   ],
   "crossReferences": [
     {
       "targetId": "erdos-275",
+      "relationship": "foundational",
+      "description": "Covering congruence 2^r bound — the theoretical backbone of Graham's covering system construction for primefree Lucas sequences"
+    },
+    {
+      "targetId": "erdos-277",
       "relationship": "related",
-      "description": "Related formalization"
+      "description": "Adjacent covering system problem from the same Erdős-Graham investigation into Fibonacci-like recurrences and compositeness"
+    },
+    {
+      "targetId": "erdos-2",
+      "relationship": "related",
+      "description": "Minimum modulus problem for covering systems (resolved by Hough 2015) — constrains what covering constructions are possible for primefree sequences"
+    },
+    {
+      "targetId": "erdos-7",
+      "relationship": "related",
+      "description": "Odd covering systems problem — parity constraints on covering moduli relevant to Lucas recurrence divisibility analysis"
     },
     {
       "targetId": "erdos-1113",
       "relationship": "related",
-      "description": "Related formalization"
+      "description": "Sierpinski numbers without covering sets — parallel open question about whether covering systems are the only mechanism for compositeness phenomena"
     }
   ],
   "relatedProofs": [
     "erdos-275",
+    "erdos-277",
+    "erdos-2",
+    "erdos-7",
     "erdos-1113"
   ]
 }

--- a/src/data/proofs/erdos-508/meta.json
+++ b/src/data/proofs/erdos-508/meta.json
@@ -89,7 +89,9 @@
       "**Unit-distance graph formalization**: `unitDistGraph` uses Mathlib's `SimpleGraph` on `EuclideanSpace ℝ (Fin 2)`, with adjacency defined by `dist x y = 1 ∧ x ≠ y`. The symmetry proof (`dist_comm`) and loopless proof (contradiction) are fully formalized, providing a clean foundation."
     ],
     "prerequisites": [
-      "Combinatorics and number theory"
+      "Graph theory (chromatic number, graph coloring)",
+      "Euclidean geometry and metric spaces",
+      "Mathlib SimpleGraph and Coloring API"
     ]
   },
   "sections": [
@@ -98,42 +100,48 @@
       "title": "Problem Statement and Imports",
       "summary": "Hadwiger-Nelson problem statement, known bounds 5 ≤ χ ≤ 7, references; imports SimpleGraph, Coloring, Nat, Tactic",
       "startLine": 1,
-      "endLine": 24
+      "endLine": 24,
+      "mathContext": "The chromatic number $\\chi(G)$ of a graph $G$ is the minimum number of colors in a proper coloring. The unit-distance graph has vertex set $\\mathbb{R}^2$ and edges between points at Euclidean distance 1."
     },
     {
       "id": "definitions",
       "title": "Definitions",
       "summary": "unitDistGraph on EuclideanSpace ℝ (Fin 2) with proved symmetry (dist_comm) and looplessness; planeChromatic axiomatized as unknown ℕ",
       "startLine": 25,
-      "endLine": 37
+      "endLine": 37,
+      "mathContext": "`unitDistGraph : SimpleGraph (EuclideanSpace \\mathbb{R} (\\text{Fin } 2))` with adjacency $x \\sim y \\iff d(x,y) = 1 \\wedge x \\neq y$. Symmetry: $d(x,y) = d(y,x)$. Loopless: $d(x,x) = 0 \\neq 1$."
     },
     {
       "id": "main-problem",
       "title": "Main Problem Statement",
       "summary": "erdos_508_problem axiom: 5 ≤ planeChromatic ∧ planeChromatic ≤ 7, constraining the answer to {5, 6, 7}",
       "startLine": 39,
-      "endLine": 44
+      "endLine": 44,
+      "mathContext": "$5 \\leq \\chi(\\mathbb{R}^2) \\leq 7$. The answer is one of $\\{5, 6, 7\\}$."
     },
     {
       "id": "lower-bounds",
       "title": "Known Lower Bounds",
       "summary": "Progressive axioms: chromatic_ge_3 (equilateral triangle K₃), chromatic_ge_4_moser (Moser spindle, 7 vertices), de_grey_2018 (1581 vertices, SAT verification)",
       "startLine": 46,
-      "endLine": 58
+      "endLine": 58,
+      "mathContext": "$\\chi \\geq 3$: equilateral triangle $K_3$ embeds as a unit-distance graph. $\\chi \\geq 4$: Moser spindle (7 vertices, 11 edges). $\\chi \\geq 5$: de Grey's 1581-vertex graph (2018), reduced to 509 vertices by Polymath."
     },
     {
       "id": "upper-bound",
       "title": "Known Upper Bound",
       "summary": "chromatic_le_7_isbell axiom: hexagonal tiling with diameter < 1 hexagons in 7-color periodic pattern",
       "startLine": 60,
-      "endLine": 65
+      "endLine": 65,
+      "mathContext": "$\\chi \\leq 7$: tile $\\mathbb{R}^2$ with regular hexagons of diameter $< 1$; 7 colors suffice in a periodic pattern where no two same-colored hexagons are within unit distance."
     },
     {
       "id": "related-results",
       "title": "Related Results",
       "summary": "fractional_chromatic_bounds (4 ≤ χ_f ≤ 4.36), higher_dimensions (6 ≤ χ(ℝ³) ≤ 15), erdos_de_bruijn compactness theorem (finite reduction)",
       "startLine": 67,
-      "endLine": 87
+      "endLine": 87,
+      "mathContext": "Fractional: $4 \\leq \\chi_f(\\mathbb{R}^2) \\leq 4.36$. Higher dimensions: $6 \\leq \\chi(\\mathbb{R}^3) \\leq 15$; $\\chi(\\mathbb{R}^d)$ grows exponentially (Frankl-Wilson). Erdős-de Bruijn: $\\chi(\\mathbb{R}^2) = \\sup\\{\\chi(G) : G \\text{ finite unit-distance subgraph}\\}$."
     }
   ],
   "conclusion": {
@@ -160,5 +168,54 @@
     "axiomCount": 9,
     "theoremCount": 0,
     "definitionCount": 1
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-143",
+      "relationship": "related",
+      "description": "Sparseness of dilation-avoiding sets — both problems concern geometric constraints on point configurations in Euclidean space"
+    },
+    {
+      "targetId": "erdos-169",
+      "relationship": "related",
+      "description": "AP-free sets with harmonic sum constraints — related extremal combinatorics with coloring-theoretic connections via van der Waerden's theorem"
+    },
+    {
+      "targetId": "erdos-808",
+      "relationship": "related",
+      "description": "Graph-restricted sum-product bounds — related graph-theoretic extremal problems in combinatorial geometry"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-143",
+    "erdos-169",
+    "erdos-808"
+  ],
+  "references": [
+    {
+      "key": "dG18",
+      "citation": "de Grey, A.D.N.J., The chromatic number of the plane is at least 5, Geombinatorics 28 (2018), 18–31.",
+      "type": "paper"
+    },
+    {
+      "key": "HN50",
+      "citation": "Hadwiger, H., Überdeckung des euklidischen Raumes durch kongruente Mengen, Portugaliae Mathematica 4 (1945), 238–242; Nelson, E., Problem (1950), posed at University of Chicago.",
+      "type": "paper"
+    },
+    {
+      "key": "MS61",
+      "citation": "Moser, L. and Moser, W., Solution to Problem 10, Canadian Mathematical Bulletin 4 (1961), 187–189.",
+      "type": "paper"
+    },
+    {
+      "key": "EdB51",
+      "citation": "Erdős, P. and de Bruijn, N.G., A colour problem for infinite graphs and a problem in the theory of relations, Indagationes Mathematicae 13 (1951), 371–373.",
+      "type": "paper"
+    },
+    {
+      "key": "So09",
+      "citation": "Soifer, A., The Mathematical Coloring Book: Mathematics of Coloring and the Colorful Life of its Creators, Springer (2009).",
+      "type": "book"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-724/meta.json
+++ b/src/data/proofs/erdos-724/meta.json
@@ -79,8 +79,10 @@
       "**Exponent Gap**: Best known ≈ 0.068, conjectured ≈ 0.5 — a 7× difference"
     ],
     "prerequisites": [
-      "Combinatorics and number theory",
-      "Combinatorics (counting, extremal problems)"
+      "Latin squares and orthogonality (quasigroup theory)",
+      "Finite fields and projective planes",
+      "Combinatorial number theory (asymptotic bounds)",
+      "Mathlib Matrix, Fintype, Fin APIs"
     ]
   },
   "sections": [
@@ -89,70 +91,80 @@
       "title": "Latin Squares",
       "summary": "Definition of Latin squares via row/column bijection property",
       "startLine": 48,
-      "endLine": 67
+      "endLine": 67,
+      "mathContext": "An $n \\times n$ Latin square is a matrix $L$ over $\\{1,\\ldots,n\\}$ where each row and column is a permutation. Equivalently, $L$ is the Cayley table of a quasigroup of order $n$."
     },
     {
       "id": "orthogonality",
       "title": "Orthogonal Latin Squares",
       "summary": "Definition of orthogonality and mutual orthogonality for sets of Latin squares",
       "startLine": 69,
-      "endLine": 88
+      "endLine": 88,
+      "mathContext": "Latin squares $L_1, L_2$ are orthogonal if the superposition $(L_1(i,j), L_2(i,j))$ covers all $n^2$ ordered pairs. A set of $k$ squares is mutually orthogonal (MOLS) if every pair is orthogonal."
     },
     {
       "id": "mols-function",
       "title": "The MOLS Function f(n)",
       "summary": "Definition of f(n) as supremum over finite MOLS sets",
       "startLine": 90,
-      "endLine": 110
+      "endLine": 110,
+      "mathContext": "$f(n) = \\max\\{k : \\exists k \\text{ MOLS of order } n\\}$. Upper bound: $f(n) \\leq n - 1$. Achieved: $f(n) = n - 1$ for all prime powers $n = p^k$."
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
       "summary": "Upper bound f(n) ≤ n-1, prime power theorem, Bose-Parker-Shrikhande",
       "startLine": 112,
-      "endLine": 152
+      "endLine": 152,
+      "mathContext": "Upper bound: $f(n) \\leq n - 1$. Prime power construction: $f(p^k) = p^k - 1$ via finite field $\\text{GF}(p^k)$. Bose-Parker-Shrikhande (1960): disproved Euler's conjecture that $f(n) = 1$ for $n \\equiv 2 \\pmod{4}$."
     },
     {
       "id": "lower-bound-progress",
       "title": "Lower Bound Progress",
       "summary": "Chowla-Erdős-Straus, Wilson, and Beth's improvements",
       "startLine": 154,
-      "endLine": 184
+      "endLine": 184,
+      "mathContext": "Lower bounds: Chowla-Erdős-Straus (1960): $f(n) \\gg n^{1/91}$. Wilson (1974): $f(n) \\gg n^{1/17}$. Beth (1983): $f(n) \\gg n^{1/14.8}$ (current best)."
     },
     {
       "id": "conjecture",
       "title": "Erdős Conjecture",
       "summary": "Statement of the conjecture f(n) ≫ n^(1/2)",
       "startLine": 186,
-      "endLine": 205
+      "endLine": 205,
+      "mathContext": "**Erdős conjecture**: $f(n) \\gg n^{1/2}$. The gap: best known exponent $\\approx 0.068$ vs conjectured $0.5$ — a seven-fold improvement needed."
     },
     {
       "id": "examples",
       "title": "Examples and Constructions",
       "summary": "Concrete MOLS examples for orders 3, 4, 5",
       "startLine": 207,
-      "endLine": 242
+      "endLine": 242,
+      "mathContext": "Order 3: $f(3) = 2$ (from $\\text{GF}(3)$). Order 4: $f(4) = 3$ (from $\\text{GF}(4) \\cong \\mathbb{F}_2[x]/(x^2+x+1)$). Order 6: $f(6) = 1$ (Euler was right for $n=6$, but wrong in general)."
     },
     {
       "id": "projective-planes",
       "title": "Projective Plane Connection",
       "summary": "Equivalence between maximal MOLS and projective planes",
       "startLine": 244,
-      "endLine": 266
+      "endLine": 266,
+      "mathContext": "$f(n) = n - 1 \\iff$ a projective plane of order $n$ exists. A projective plane of order $n$ has $n^2 + n + 1$ points and lines. Existence is open for $n = 12, 15, 18, \\ldots$ (non-prime-powers)."
     },
     {
       "id": "macneish",
       "title": "MacNeish's Conjecture",
       "summary": "The disproved MacNeish bound",
       "startLine": 268,
-      "endLine": 283
+      "endLine": 283,
+      "mathContext": "MacNeish (1922) conjectured $f(n) = \\min_{p^k \\| n}(p^k - 1)$ where $p^k \\| n$ means $p^k$ exactly divides $n$. Disproved by Bose-Parker-Shrikhande (1960): $f(n)$ can exceed the MacNeish bound."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Summary theorems and the exponent gap",
       "startLine": 285,
-      "endLine": 328
+      "endLine": 328,
+      "mathContext": "State of knowledge: $n^{1/14.8} \\ll f(n) \\leq n - 1$. The main open problem: close the exponent gap from $1/14.8$ to $1/2$ (Erdős conjecture)."
     }
   ],
   "conclusion": {
@@ -182,5 +194,54 @@
     "axiomCount": 17,
     "theoremCount": 3,
     "definitionCount": 8
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-143",
+      "relationship": "related",
+      "description": "Dilation-avoiding sets in Euclidean space — both problems study extremal configurations under geometric/combinatorial constraints"
+    },
+    {
+      "targetId": "erdos-169",
+      "relationship": "related",
+      "description": "AP-free sets with harmonic sum constraints — related extremal combinatorics with coloring-theoretic connections"
+    },
+    {
+      "targetId": "erdos-808",
+      "relationship": "related",
+      "description": "Graph-restricted sum-product bounds — related graph-theoretic extremal problems in combinatorics"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-143",
+    "erdos-169",
+    "erdos-808"
+  ],
+  "references": [
+    {
+      "key": "BPS60",
+      "citation": "Bose, R.C., Shrikhande, S.S., and Parker, E.T., Further results on the construction of mutually orthogonal Latin squares and the falsity of Euler's conjecture, Canadian Journal of Mathematics 12 (1960), 189–203.",
+      "type": "paper"
+    },
+    {
+      "key": "CES60",
+      "citation": "Chowla, S., Erdős, P., and Straus, E.G., On the maximal number of pairwise orthogonal Latin squares of a given order, Canadian Journal of Mathematics 12 (1960), 204–208.",
+      "type": "paper"
+    },
+    {
+      "key": "Wi74",
+      "citation": "Wilson, R.M., Concerning the number of mutually orthogonal Latin squares, Discrete Mathematics 9 (1974), 181–198.",
+      "type": "paper"
+    },
+    {
+      "key": "Be83",
+      "citation": "Beth, T., Eine Bemerkung zur Abschätzung der Anzahl orthogonaler lateinischer Quadrate mittels Siebverfahren, Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 53 (1983), 284–288.",
+      "type": "paper"
+    },
+    {
+      "key": "LTS89",
+      "citation": "Lam, C.W.H., Thiel, L., and Swiercz, S., The non-existence of finite projective planes of order 10, Canadian Journal of Mathematics 41 (1989), 1117–1123.",
+      "type": "paper"
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for erdos-724 (MOLS / Mutually Orthogonal Latin Squares).

- Added mathContext (LaTeX formulas) to all 10 sections
- Added top-level crossReferences for 3 related entries
- Added 5 structured references (Bose-Parker-Shrikhande 1960, Chowla-Erdős-Straus 1960, Wilson 1974, Beth 1983, Lam-Thiel-Swiercz 1989)
- Fixed prerequisites from generic to specific (Latin squares, finite fields, Mathlib APIs)