### PR TITLE
Enable multi-slot auditor spawning

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -2059,11 +2059,12 @@
     },
     {
       "slug": "erdos-932",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-15T11:43:50.650Z",
-      "status": "active",
-      "lastUpdate": "2026-03-13T07:52:17.054Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T02:40:09.410Z",
+      "completed": "2026-03-24T02:40:09.409Z"
     },
     {
       "slug": "erdos-935",

--- a/scripts/auditor/launch-agent.sh
+++ b/scripts/auditor/launch-agent.sh
@@ -37,11 +37,11 @@ REPO_ROOT="$(find_repo_root)"
 WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
-SESSION_NAME="auditor-agent"
-LOG_FILE="$LOGS_DIR/auditor.log"
+SESSION_NAME="${SESSION_NAME:-auditor-agent}"
+LOG_FILE="$LOGS_DIR/${SESSION_NAME}.log"
 INTERVAL="${AUDITOR_INTERVAL:-10}"
-WORKTREE_PATH="$WORKTREES_DIR/auditor"
-BRANCH_NAME="feature/auditor"
+WORKTREE_PATH="$WORKTREES_DIR/${SESSION_NAME}"
+BRANCH_NAME="feature/${SESSION_NAME}"
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -2319,13 +2319,23 @@ cmd_spawn() {
             fi
             ;;
         auditor)
-            echo -e "${BLUE}Spawning Auditor agent...${NC}"
+            echo -e "${BLUE}Spawning additional Auditor...${NC}"
+            for i in 1 2 3; do
+                local sname="auditor-$i"
+                if ! tmux has-session -t "$sname" 2>/dev/null; then
+                    SESSION_NAME="$sname" ./scripts/auditor/launch-agent.sh &
+                    sleep 2
+                    echo -e "${GREEN}✓ Auditor spawned (slot $i)${NC}"
+                    exit 0
+                fi
+            done
+            # Check legacy singleton name too
             if tmux has-session -t "auditor-agent" 2>/dev/null; then
-                echo -e "${YELLOW}Auditor agent already running${NC}"
+                echo -e "${YELLOW}All Auditor slots are full (max: $MAX_AUDITOR)${NC}"
             else
-                ./scripts/auditor/launch-agent.sh &
-                sleep 1
-                echo -e "${GREEN}✓ Auditor agent spawned${NC}"
+                SESSION_NAME="auditor-agent" ./scripts/auditor/launch-agent.sh &
+                sleep 2
+                echo -e "${GREEN}✓ Auditor spawned (legacy slot)${NC}"
             fi
             ;;
         peer-reviewer)


### PR DESCRIPTION
Fixes auditor to support 3 concurrent instances via SESSION_NAME env var. 🤖 Generated with [Claude Code](https://claude.com/claude-code)