### PR TITLE
Research: roth-theorem-k3 - density bound lemmas, linter fixes

### DIFF
--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -1016,7 +1016,7 @@ private lemma coset_fiber_card_eq {N : ℕ} [NeZero N] (A : Finset (ZMod N))
     exact Nat.eq_of_mul_eq_mul_right hg hprod_eq
   · -- Surjective
     intro x hx
-    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hx
+    simp only [Finset.mem_coe, Finset.mem_filter] at hx
     have hmod : ZMod.val x % g = j := by
       have := congr_arg Fin.val hx.2; exact this
     have hdiv : ZMod.val x / g < M :=
@@ -1096,7 +1096,7 @@ private lemma fourier_coset_decomp {N : ℕ} [NeZero N] (A : Finset (ZMod N))
     (congrArg Nat.cast (coset_fiber_card_eq A g hg hgN j hj).symm)
 
 /-- Character sum over compatible cosets vanishes. -/
-private lemma char_sum_cosets_zero {N : ℕ} [NeZero N] (g : ℕ) (hg : 0 < g) (hgN : g ∣ N)
+private lemma char_sum_cosets_zero {N : ℕ} [NeZero N] (g : ℕ) (_hg : 0 < g) (hgN : g ∣ N)
     (r : ZMod N) (hr : r ≠ 0) (hcompat : (N / g) ∣ ZMod.val r) :
     ∑ j : Fin g, ψ (r * (↑j.val : ZMod N)) = 0 := by
   set ω := ψ r with hω_def
@@ -1132,7 +1132,7 @@ private lemma char_sum_cosets_zero {N : ℕ} [NeZero N] (g : ℕ) (hg : 0 < g) (
     Σ(f_j - m) = 0 ⟹ Σ(f_j - m)⁺ ≥ δ²N/4.
     max(f_j) ≥ m + δ²N/(4g) = m + δ²M/4 where M = N/g. -/
 private theorem coset_density_increment {N : ℕ} [NeZero N] (hN : 1 < N)
-    (A : Finset (ZMod N)) (hAP : APFree A) (delta : ℝ) (hdelta : 0 < delta)
+    (A : Finset (ZMod N)) (_hAP : APFree A) (delta : ℝ) (hdelta : 0 < delta)
     (hdensity : (A.card : ℝ) ≥ delta * N) (g : ℕ) (hg : 0 < g) (hgN : g ∣ N)
     (r : ZMod N) (hr : r ≠ 0) (hlarge : ‖fourierCoeff A r‖ ≥ delta ^ 2 * N / 2)
     (hcompat : (N / g) ∣ ZMod.val r) :
@@ -1329,6 +1329,28 @@ theorem density_increment_lemma {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N))
 -- PART VI: ROTH'S THEOREM (MAIN RESULT)
 -- ═══════════════════════════════════════════════════════════════════
 
+/-- Any application of density_increment_lemma yields d + d²/100 ≤ 1, since the
+    output set B satisfies |B| ≤ M (card_le_nat) and |B| ≥ (d + d²/100) * M. -/
+private theorem density_bound_from_increment {N : ℕ} (hN : 1 < N) (A : Finset (ZMod N))
+    (hAP : APFree A) (delta : ℝ) (hdelta : 0 < delta)
+    (hdensity : (A.card : ℝ) ≥ delta * N) :
+    delta + delta ^ 2 / 100 ≤ 1 := by
+  obtain ⟨M, B, hMpos, _, _, hBdens⟩ := density_increment_lemma hN A hAP delta hdelta hdensity
+  haveI : NeZero M := ⟨by omega⟩
+  have hBle : (B.card : ℝ) ≤ ↑M := by exact_mod_cast card_le_nat B
+  have hMr : (0 : ℝ) < ↑M := Nat.cast_pos.mpr hMpos
+  nlinarith
+
+/-- For N ≥ 3, AP-free sets have density at most 2/3. -/
+private theorem apFree_density_lt_two_thirds {N : ℕ} [NeZero N] (hN3 : 2 < N)
+    (A : Finset (ZMod N)) (hAP : APFree A)
+    (delta : ℝ) (_hdelta : 0 < delta) (hdensity : (A.card : ℝ) ≥ delta * N) :
+    delta ≤ 2 / 3 := by
+  have h := apFree_card_le_two_thirds hN3 A hAP
+  have hN_pos : (0 : ℝ) < ↑N := Nat.cast_pos.mpr (by omega)
+  have : 3 * (A.card : ℝ) ≤ 2 * (N : ℝ) := by exact_mod_cast h
+  nlinarith
+
 /-- Extension of density_increment_lemma to N ≥ 1 for use in the iteration.
     Delegates to the fully-verified density_increment_lemma when N ≥ 2.
 
@@ -1367,10 +1389,22 @@ private theorem density_increment_iter {N : ℕ} (hN : 0 < N) (A : Finset (ZMod 
         simp only [Finset.card_univ, ZMod.card, Nat.cast_one, mul_one]
         linarith
     · -- Hard case: delta ∈ (0.99, 1] where delta + delta²/100 > 1 and N = 1.
-      -- The conclusion requires |B| ≥ (delta + delta²/100) * M > M for any M ≥ 1,
-      -- but |B| ≤ M always holds. This case is prevented in the standard proof by
-      -- Dirichlet's approximation theorem (Tao-Vu Ch.10), which ensures M ≥ √N
-      -- at each descent step. Formalizing Dirichlet approximation would close this.
+      -- This case is PROVABLY FALSE as stated: the conclusion requires
+      -- |B| ≥ (delta + delta²/100) * M > M, but |B| ≤ M always holds.
+      -- The hypotheses are consistent (A = {0} in ZMod 1 satisfies them).
+      --
+      -- FIX PATH: The standard proof (Tao-Vu Ch.10) uses Dirichlet's
+      -- approximation theorem to partition into subprogressions of length
+      -- L ≥ √N, ensuring M ≥ 2 at each descent step. This prevents the
+      -- iteration from reaching N = 1 with high density.
+      --
+      -- DirichletApproximation.lean already proves the key theorem:
+      --   ∃ p q, 1 ≤ q ∧ q ≤ Q ∧ |qα - p| < 1/Q
+      -- Integration requires:
+      -- 1. Dirichlet-based subprogression partition (~80 lines)
+      -- 2. Approximate character constancy on subprogressions (~60 lines)
+      -- 3. Density increment under approximate constancy (~60 lines)
+      -- 4. Modified density_increment_lemma guaranteeing M ≥ 2 (~20 lines)
       sorry
 
 /-- After k iterations of density increment starting from density delta,
@@ -1403,7 +1437,7 @@ private theorem density_iteration (delta : ℝ) (hdelta : 0 < delta) :
     3-AP, its density increases by at least delta²/100 on a subprogression.
     After K = ⌈100/delta²⌉ steps, the density would exceed 1, contradicting
     the fact that any subset of Z/MZ has at most M elements. -/
-theorem roth_density_bound (delta : ℝ) (hdelta : 0 < delta) (hdelta1 : delta ≤ 1) :
+theorem roth_density_bound (delta : ℝ) (hdelta : 0 < delta) (_hdelta1 : delta ≤ 1) :
     ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ → ∀ A : Finset (ZMod N),
       (A.card : ℝ) ≥ delta * N → ¬APFree A := by
   refine ⟨1, fun N hN A hdensity hAP => ?_⟩

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -44,7 +44,7 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 1442,
-    "assumptions": "No axioms. 1 sorry: density_increment_iter N=1 hard case (delta ∈ (0.99, 1]) — requires Dirichlet approximation to prevent descent reaching N=1 with high density."
+    "assumptions": "No axioms. 1 sorry: density_increment_iter N=1 hard case (delta ∈ (0.99, 1]) — requires Dirichlet approximation to prevent descent reaching N=1 with high density. DirichletApproximation.lean is already proved."
   },
   "overview": {
     "historicalContext": "Roth's theorem, proved by Klaus Friedrich Roth in 1953, was a landmark achievement in number theory and combinatorics. It confirmed the k=3 case of the Erdos-Turan conjecture (1936) that every dense subset of the integers contains arithmetic progressions of any length.\n\nRoth introduced Fourier-analytic methods to additive combinatorics, a revolutionary approach that opened an entirely new toolbox. His key insight was the density increment strategy: if a set A of density delta in [N] has no 3-term AP, then there exists a long arithmetic progression P where A has density at least delta + c*delta^2. Iterating this increment (which can only happen O(1/delta) times before density exceeds 1) yields a contradiction.\n\nThe quantitative bounds have been dramatically improved over the decades: Bourgain (1999, 2008), Sanders (2011), and most recently Bloom and Sisask (2020) achieved r_3(N) = O(N/(log N)^{1+c}). In 2023, Kelley and Meka achieved the breakthrough bound r_3(N) = O(N * exp(-c * (log N)^{1/12})).\n\nRoth's theorem is the natural starting point for the Szemeredi program because it introduces the core techniques (Fourier analysis, density increment) in their simplest setting.",
@@ -211,9 +211,9 @@
     ],
     "opens": [],
     "namespace": "Szemeredi.Roth",
-    "lineCount": 1442,
+    "lineCount": 1476,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 3
   },
   "references": [

--- a/src/data/research/problems/roth-theorem-k3.json
+++ b/src/data/research/problems/roth-theorem-k3.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-21",
-    "iteration": 11,
-    "focus": "Session 11: Proved density_increment_lemma sorry-free (1<N, M<N). Restructured roth_density_bound. Fixed multiple Mathlib API breakages.",
+    "iteration": 13,
+    "focus": "Session 13: Added density_bound_from_increment and apFree_density_lt_two_thirds lemmas. Fixed 4 linter warnings. Documented fix path for remaining sorry.",
     "blockers": [
       "Pre-existing Mathlib API breakages in fourier_large_coefficient (lines 583-800)",
       "Dirichlet approximation needed for N=1 iteration case (in density_increment_iter)"
     ],
-    "nextAction": "Fix remaining Mathlib API breakages in fourier_large_coefficient CASE 2",
+    "nextAction": "Integrate DirichletApproximation.lean to close last sorry",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 12 fixed all 6 pre-existing Mathlib API breakages in fourier_large_coefficient Case 2, proved N=1 easy case of density_increment_iter, updated meta.json. File now fully compiles with 0 axioms, 1 sorry (narrowed to N=1 hard case requiring Dirichlet approximation). 1442 lines.",
+    "progressSummary": "PROGRESS: Session 13 added density_bound_from_increment lemma (d+d²/100≤1 from density_increment_lemma+card_le_nat), apFree_density_lt_two_thirds lemma (δ≤2/3 for N≥3), fixed 4 linter warnings, improved sorry documentation with detailed fix path. File: 0 axioms, 1 sorry, 1476 lines.",
     "builtItems": [
       "Fixed apFree_singleton proof, Complex.abs -> norm, added apFree_subset, removed incorrect apFree_pair",
       "Build now succeeds: 0 axioms, 3 sorries",
@@ -64,7 +64,10 @@
       "Fixed Complex.norm_real → Complex.norm_real + Real.norm_eq_abs pattern",
       "Fixed lt_div_iff → lt_div_iff₀ for new Mathlib naming",
       "Restructured hn_gt_B proof: use delta<1 from n<N instead of strict division",
-      "Split nlinarith timeout into intermediate lemma hcaseN + linarith"
+      "Split nlinarith timeout into intermediate lemma hcaseN + linarith",
+      "PROVED density_bound_from_increment: δ+δ²/100≤1 from density_increment_lemma+card_le_nat",
+      "PROVED apFree_density_lt_two_thirds: δ≤2/3 for APFree on ZMod N with N≥3",
+      "Fixed 4 linter warnings: unused simp args (true_and, Finset.mem_univ), unused vars (_hg, _hAP, _hdelta1, _hdelta)"
     ],
     "insights": [
       "RothTheorem.lean had 3 build errors: deprecated Finset.not_mem_empty, broken apFree_singleton, non-existent Complex.abs",
@@ -108,13 +111,17 @@
       "fourier_large_coefficient Case 2 fully proved: fixed 6 Mathlib API breakages (Complex.norm_real→norm_real+norm_eq_abs, lt_div_iff→lt_div_iff₀, nlinarith hint needs, norm_pow congr pattern)",
       "density_increment_iter N=1 easy case proved: for delta+delta²/100≤1, take M=1 B=Finset.univ (APFree on ZMod 1 is vacuous since only one element)",
       "density_increment_iter N=1 hard case (delta∈(0.99,1]) is genuinely FALSE — conclusion requires |B|>(delta+delta²/100)*M>M but |B|≤M always. Needs Dirichlet approximation to prevent descent reaching N=1 with high density",
-      "Proof now has 0 axioms, 1 sorry, 1442 lines — all 6 Parts fully compilable"
+      "Proof now has 0 axioms, 1 sorry, 1442 lines — all 6 Parts fully compilable",
+      "density_bound_from_increment proves d+d²/100≤1 for ANY application of density_increment_lemma — this is the exact threshold L≈0.99 that the iteration cannot cross at M=1",
+      "apFree_card_le_two_thirds (3|A|≤2N for N≥3) gives δ≤2/3 directly — handles Roth for δ>2/3 without any iteration",
+      "The sorry is provably FALSE as stated (hypotheses consistent, conclusion unsatisfiable) — NOT a missing proof technique but a wrong theorem statement requiring Dirichlet",
+      "Without Dirichlet, density_increment_lemma can produce M=1 from ANY N≥2 (M=gcd(val(r),N)=1 for prime N), allowing descent to reach N=1 in one step"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize Dirichlet approximation theorem (~50-80 lines Lean) to close the last sorry",
-      "Alternative: prove density_increment_lemma_strong guaranteeing M≥√N (replaces current M≥1)",
-      "Alternative: restructure roth_density_bound to detect contradiction when density_increment_lemma produces M=1 with d+d²/4>1 (avoids Dirichlet entirely)"
+      "Integrate DirichletApproximation.lean into density_increment_lemma (~220 lines): use Dirichlet-based subprogression partition to guarantee M≥2",
+      "Alternative: restructure roth_density_bound to use apFree_card_le_two_thirds (δ≤2/3) as the contradiction target instead of card_le_nat (δ≤1) — would work if M≥2 can be guaranteed",
+      "Alternative: prove density_increment_lemma_dirichlet that uses approximate character constancy on Dirichlet subprogressions instead of exact constancy on cosets"
     ]
   },
   "tags": [
@@ -133,7 +140,7 @@
     "mathlib": []
   },
   "started": "2026-03-22T06:10:36.236Z",
-  "lastUpdate": "2026-03-23T21:00:00Z",
+  "lastUpdate": "2026-03-23T22:00:00Z",
   "significance": 9,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Added `density_bound_from_increment` lemma: proves δ+δ²/100≤1 from density_increment_lemma + card_le_nat
- Added `apFree_density_lt_two_thirds` lemma: proves δ≤2/3 for AP-free sets on ZMod N (N≥3)
- Fixed 4 linter warnings (unused simp args, unused variables)
- Improved sorry documentation with detailed Dirichlet integration fix path

## Status
- **0 axioms, 1 sorry, 1476 lines** (was 1442)
- Sorry is provably FALSE as stated (requires Dirichlet approximation to guarantee M≥2 in density descent)
- DirichletApproximation.lean already proved — integration is the next step

## Next Steps
Integrate DirichletApproximation.lean into density_increment_lemma (~220 lines) to close the last sorry

🤖 Generated by researcher-2