### PR TITLE
Audit: fix CRITICAL axiom masking in angle-trisection

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -2,12 +2,12 @@
   "id": "angle-trisection",
   "title": "Impossibility of Trisecting an Angle",
   "slug": "angle-trisection",
-  "description": "The three classical Greek impossibility problems resolved in one file (Wiedijk #8): angle trisection, cube doubling, and circle squaring. Wantzel's 1837 algebraic criterion ($\\cos(20°)$ satisfies an irreducible cubic $8x^3-6x-1$, degree 3 $\\neq 2^n$) settles the first two; Lindemann's transcendence of $\\pi$ (1882, imported from companion file) settles the third. 389 lines, 0 sorries, 0 axioms.",
+  "description": "The three classical Greek impossibility problems resolved in one file (Wiedijk #8): angle trisection, cube doubling, and circle squaring. Wantzel's 1837 algebraic criterion ($\\cos(20°)$ satisfies an irreducible cubic $8x^3-6x-1$, degree 3 $\\neq 2^n$) settles the first two; Lindemann's transcendence of $\\pi$ (1882, axiomatized in companion file) settles the third. 389 lines, 0 sorries; circle squaring depends on 1 axiom (pi_transcendental) from PiTranscendental.lean.",
   "meta": {
     "author": "Pierre Wantzel (1837)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Angle_trisection",
     "date": "1837",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "geometry",
       "galois-theory",
@@ -17,7 +17,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/AngleTrisection.lean",
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 8,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Field extensions and algebraic degree",
       "Polynomial rings and irreducibility over Q",
@@ -71,7 +71,7 @@
         "relationship": "Further extensions of the constructibility framework"
       }
     ],
-    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. The three former axioms are now proved: Wantzel's constructibility criterion via exhaustive rational root checking and degree computation, trisection polynomial irreducibility via Galois group computation in companion file `AngleTrisectionCos20Gal.lean`, and Lindemann's $\\pi$ transcendence via companion file `PiTranscendental.lean`. All 18 theorems compose these verified results with no remaining assumptions."
+    "assumptions": "1 axiom (transitive): pi_transcendental from PiTranscendental.lean — transcendence of π over ℤ, not yet in Mathlib. Angle trisection and cube doubling are fully verified (0 axioms). Circle squaring depends on this axiom via pi_transcendental_over_rationals. Wantzel's constructibility criterion and trisection polynomial irreducibility are proved without axioms."
   },
   "leanFile": {
     "imports": [
@@ -87,7 +87,7 @@
     "namespace": "AngleTrisection",
     "lineCount": 389,
     "structureCount": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 18,
     "lemmaCount": 0,
     "defCount": 4,
@@ -208,7 +208,7 @@
   "overview": {
     "historicalContext": "The problem of trisecting an arbitrary angle using only compass and straightedge is one of the three famous classical Greek problems, alongside doubling the cube and squaring the circle. These problems appear to have been formulated by the 5th century BCE. Hippocrates of Chios (c. 470–410 BCE) made the first recorded attempt at cube doubling by reducing it to finding two mean proportionals between 1 and 2. The Delian problem — doubling the altar of Apollo — is attributed by Eratosthenes to an oracle's demand during a plague on Delos (c. 430 BCE), though this may be apocryphal.\n\nGreek mathematicians found solutions using curves beyond compass and straightedge: Hippias's quadratrix (c. 420 BCE) could trisect angles, Menaechmus (c. 350 BCE) solved cube doubling using conic sections, and Archimedes (c. 250 BCE) demonstrated angle trisection by *neusis* (a marked ruler slid between two constraints). Nicomedes' conchoid (c. 200 BCE) could also trisect angles. These solutions were considered legitimate but geometrically 'impure' — the restriction to compass and straightedge was a philosophical choice, not a practical one.\n\nThe impossibility question remained open for two millennia until Pierre Laurent Wantzel published his proof in 1837 in the *Journal de Mathématiques Pures et Appliquées*. Wantzel, only 23 at the time, showed that compass-and-straightedge constructions correspond to towers of quadratic field extensions, so constructible numbers have degree $2^n$ over the rationals. Since $\\cos(20°)$ satisfies an irreducible cubic, its degree is 3 (not a power of 2), and the trisection of 60° is impossible. Wantzel's paper — barely 7 pages — was largely overlooked for decades; he died in 1848 at age 33 from overwork and stimulant abuse, and his priority was not fully recognized until the 20th century.\n\nThe squaring of the circle was proven impossible by Ferdinand von Lindemann in 1882, when he showed that $\\pi$ is transcendental. This was a strictly stronger result: constructibility requires algebraic degree $2^n$, but $\\pi$ has no algebraic degree at all. Lindemann's proof, building on Hermite's 1873 proof that $e$ is transcendental, completed the resolution of all three classical problems.\n\nRemarkably, angle trisection 'cranks' — amateur mathematicians claiming to have trisected the angle — persisted well into the 20th century. Augustus De Morgan catalogued such claims in his *Budget of Paradoxes* (1872), and mathematics departments continued receiving purported constructions long after Wantzel's proof.",
     "problemStatement": "Given an arbitrary angle θ, can it be divided into three equal parts using only a compass and unmarked straightedge?\n\nThe answer is NO for a general angle. In particular, a 60° angle cannot be trisected.\n\nTo trisect 60°, we would need to construct a 20° angle, which is equivalent to constructing the number cos(20°). Using the triple angle formula:\n$$\\cos(60°) = 4\\cos^3(20°) - 3\\cos(20°)$$\n$$\\frac{1}{2} = 4x^3 - 3x$$\n$$8x^3 - 6x - 1 = 0$$\n\nSo cos(20°) satisfies an irreducible cubic polynomial over ℚ.",
-    "text": "A 389-line Lean 4 formalization of the impossibility of angle trisection, doubling the cube, and squaring the circle with 37 declarations, 0 sorries, 0 axioms. Imports `AngleTrisectionCos20Gal` (Galois group computation) and `PiTranscendental` ($\\pi$ transcendence). The core argument: `trisectionPolynomial` ($8x^3 - 6x - 1$) is shown irreducible by exhaustive rational root checking (all 8 candidates via `norm_num`), `cos_20_satisfies_cubic` connects it to $\\cos(20°)$ via the triple-angle formula, and `three_not_power_of_two` establishes that degree 3 is incompatible with Wantzel's constructibility criterion ($[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 2^n$). The `not_constructible_cos20`, `angle_trisection_impossible`, `doubling_cube_impossible`, and `squaring_circle_impossible` theorems complete all three classical Greek problems.",
+    "text": "A 389-line Lean 4 formalization of the impossibility of angle trisection, doubling the cube, and squaring the circle with 37 declarations and 0 sorries. Imports `AngleTrisectionCos20Gal` (Galois group computation) and `PiTranscendental` (π transcendence, axiomatized). Angle trisection and cube doubling are fully verified; circle squaring depends on 1 axiom (pi_transcendental). The core argument: `trisectionPolynomial` ($8x^3 - 6x - 1$) is shown irreducible by exhaustive rational root checking, `cos_20_satisfies_cubic` connects it to $\\cos(20°)$ via the triple-angle formula, and `three_not_power_of_two` establishes that degree 3 is incompatible with Wantzel's constructibility criterion.",
     "proofStrategy": "The proof proceeds in several stages:\n\n1. **Algebraic Translation**: Show that trisecting 60° requires constructing cos(20°).\n\n2. **Find the Minimal Polynomial**: Use the triple angle formula to derive that cos(20°) satisfies 8x³ - 6x - 1 = 0.\n\n3. **Prove Irreducibility**: By the rational root theorem, check that ±1, ±1/2, ±1/4, ±1/8 are not roots. For cubics, no rational roots means irreducible over ℚ.\n\n4. **Degree Argument**: Since the polynomial is irreducible of degree 3, we have [ℚ(cos 20°) : ℚ] = 3.\n\n5. **Constructibility Criterion**: Wantzel's theorem: constructible numbers have degree 2^n over ℚ.\n\n6. **Contradiction**: 3 is not a power of 2, so cos(20°) is not constructible.",
     "keyInsights": [
       "Compass and straightedge constructions correspond to quadratic field extensions - each new point requires solving at most a quadratic equation",


### PR DESCRIPTION
## Summary

**CRITICAL integrity fix**: `angle-trisection` meta.json claimed 0 axioms, "verified" status, and "verified" badge, but the circle squaring result depends on `pi_transcendental` — an axiom declared in `PiTranscendental.lean`.

- status: `verified` → `axiomatized`
- badge: `verified` → `axiom`  
- axiomCount: 0 → 1 (transitive `pi_transcendental`)
- assumptions field: now accurately describes which results are fully verified (angle trisection, cube doubling) vs axiom-dependent (circle squaring)
- Removed "0 axioms" claims from description and overview text

**Note**: Angle trisection and cube doubling remain fully verified. Only circle squaring depends on the axiom.

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Check gallery page renders with updated badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)