### PR TITLE
Audit fix: correct sorry counts in 54 meta.json files

### DIFF
--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -18,7 +18,7 @@
       "hadwiger-nelson"
     ],
     "badge": "open",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1070,
     "erdosUrl": "https://erdosproblems.com/1070",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 3,
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1129/meta.json
+++ b/src/data/proofs/erdos-1129/meta.json
@@ -20,7 +20,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 1129,
     "erdosUrl": "https://erdosproblems.com/1129",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-1143/meta.json
+++ b/src/data/proofs/erdos-1143/meta.json
@@ -17,7 +17,7 @@
       "inclusion-exclusion"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 7,
     "axioms": 3,
     "erdosNumber": 1143,
     "erdosUrl": "https://erdosproblems.com/1143",

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 1166,
     "erdosUrl": "https://erdosproblems.com/1166",
     "erdosProblemStatus": "proved",

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -17,7 +17,7 @@
       "kelley-meka"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 140,
     "erdosUrl": "https://erdosproblems.com/140",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-176/meta.json
+++ b/src/data/proofs/erdos-176/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 176,
     "erdosUrl": "https://erdosproblems.com/176",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-179/meta.json
+++ b/src/data/proofs/erdos-179/meta.json
@@ -17,7 +17,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 10,
     "erdosNumber": 179,
     "erdosUrl": "https://erdosproblems.com/179",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-195/meta.json
+++ b/src/data/proofs/erdos-195/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 195,
     "erdosUrl": "https://erdosproblems.com/195",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 4,
     "erdosNumber": 277,
     "erdosUrl": "https://erdosproblems.com/277",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-290/meta.json
+++ b/src/data/proofs/erdos-290/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 290,
     "erdosUrl": "https://erdosproblems.com/290",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-341/meta.json
+++ b/src/data/proofs/erdos-341/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 341,
     "erdosUrl": "https://erdosproblems.com/341",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -17,7 +17,7 @@
       "distinct-sums"
     ],
     "badge": "wip",
-    "sorries": 15,
+    "sorries": 16,
     "erdosNumber": 357,
     "erdosUrl": "https://erdosproblems.com/357",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 4,
     "erdosNumber": 378,
     "erdosUrl": "https://erdosproblems.com/378",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-43/meta.json
+++ b/src/data/proofs/erdos-43/meta.json
@@ -16,7 +16,7 @@
       "difference-sets"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 5,
     "erdosNumber": 43,
     "erdosUrl": "https://erdosproblems.com/43",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 5,
     "erdosNumber": 476,
     "erdosUrl": "https://erdosproblems.com/476",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 9,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-545/meta.json
+++ b/src/data/proofs/erdos-545/meta.json
@@ -15,7 +15,7 @@
       "combinatorics"
     ],
     "badge": "formalized",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 545,
     "erdosUrl": "https://erdosproblems.com/545",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -17,7 +17,7 @@
       "erdos"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 6,
     "erdosNumber": 548,
     "erdosUrl": "https://erdosproblems.com/548",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-559/meta.json
+++ b/src/data/proofs/erdos-559/meta.json
@@ -16,7 +16,7 @@
       "extremal-combinatorics"
     ],
     "badge": "mathlib",
-    "sorries": 9,
+    "sorries": 10,
     "erdosNumber": 559,
     "erdosUrl": "https://erdosproblems.com/559",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 604,
     "erdosUrl": "https://erdosproblems.com/604",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -16,7 +16,7 @@
       "erdos"
     ],
     "badge": "wip",
-    "sorries": 9,
+    "sorries": 11,
     "erdosNumber": 606,
     "erdosUrl": "https://erdosproblems.com/606",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -18,7 +18,7 @@
       "asymptotics"
     ],
     "badge": "solved",
-    "sorries": 17,
+    "sorries": 20,
     "erdosNumber": 607,
     "erdosUrl": "https://erdosproblems.com/607",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 11,
+    "sorries": 17,
     "erdosNumber": 610,
     "erdosUrl": "https://erdosproblems.com/610",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-611/meta.json
+++ b/src/data/proofs/erdos-611/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "conjecture",
-    "sorries": 11,
+    "sorries": 13,
     "erdosNumber": 611,
     "erdosUrl": "https://erdosproblems.com/611",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-612/meta.json
+++ b/src/data/proofs/erdos-612/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 12,
+    "sorries": 16,
     "erdosNumber": 612,
     "erdosUrl": "https://erdosproblems.com/612",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 13,
+    "sorries": 15,
     "erdosNumber": 626,
     "erdosUrl": "https://erdosproblems.com/626",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 13,
+    "sorries": 16,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 10,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "solved",
-    "sorries": 14,
+    "sorries": 15,
     "erdosNumber": 630,
     "erdosUrl": "https://erdosproblems.com/630",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-682/meta.json
+++ b/src/data/proofs/erdos-682/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 682,
     "erdosUrl": "https://erdosproblems.com/682",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 684,
     "erdosUrl": "https://erdosproblems.com/684",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 4,
     "erdosNumber": 695,
     "erdosUrl": "https://erdosproblems.com/695",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "mathlib",
-    "sorries": 12,
+    "sorries": 15,
     "erdosNumber": 715,
     "erdosUrl": "https://erdosproblems.com/715",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -17,7 +17,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 744,
     "erdosUrl": "https://erdosproblems.com/744",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "erdosNumber": 748,
     "erdosUrl": "https://erdosproblems.com/748",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 756,
     "erdosUrl": "https://erdosproblems.com/756",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -18,7 +18,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "erdosNumber": 76,
     "erdosUrl": "https://erdosproblems.com/76",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "erdosNumber": 781,
     "erdosUrl": "https://erdosproblems.com/781",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 6,
     "erdosNumber": 820,
     "erdosUrl": "https://erdosproblems.com/820",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-835/meta.json
+++ b/src/data/proofs/erdos-835/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 835,
     "erdosUrl": "https://erdosproblems.com/835",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -18,7 +18,7 @@
       "coprime-residues"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "erdosNumber": 854,
     "erdosUrl": "https://erdosproblems.com/854",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-860/meta.json
+++ b/src/data/proofs/erdos-860/meta.json
@@ -20,7 +20,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 860,
     "erdosUrl": "https://erdosproblems.com/860",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -18,7 +18,7 @@
       "popcount"
     ],
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 875,
     "erdosUrl": "https://erdosproblems.com/875",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -18,7 +18,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 9,
+    "sorries": 11,
     "erdosNumber": 895,
     "erdosUrl": "https://erdosproblems.com/895",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -17,7 +17,7 @@
       "classical"
     ],
     "badge": "mathlib",
-    "sorries": 6,
+    "sorries": 8,
     "erdosNumber": 898,
     "erdosUrl": "https://erdosproblems.com/898",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-900/meta.json
+++ b/src/data/proofs/erdos-900/meta.json
@@ -18,7 +18,7 @@
       "phase-transition"
     ],
     "badge": "mathlib",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 900,
     "erdosUrl": "https://erdosproblems.com/900",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-934/meta.json
+++ b/src/data/proofs/erdos-934/meta.json
@@ -18,7 +18,7 @@
       "2K2-free"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 8,
     "erdosNumber": 934,
     "erdosUrl": "https://erdosproblems.com/934",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -19,7 +19,7 @@
       "extremal-configuration"
     ],
     "badge": "wip",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 94,
     "erdosUrl": "https://erdosproblems.com/94",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-957/meta.json
+++ b/src/data/proofs/erdos-957/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 5,
     "erdosNumber": 957,
     "erdosUrl": "https://erdosproblems.com/957",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 5,
     "erdosNumber": 960,
     "erdosUrl": "https://erdosproblems.com/960",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Summary

Automated gallery integrity audit found sorry count mismatches between meta.json claims and actual sorry occurrences in 54 Lean source files. All had **understated** sorry counts.

The scan properly handles:
- Block comments (`/- ... -/`) — "sorry" in comments not counted
- Line comments (`-- ...`) — "sorry" in comments not counted

## Impact

- **54 files** with corrected sorry counts
- **0 verified-status proofs affected** — all verified proofs are genuinely sorry-free
- Most affected files are Erdős problem formalizations with `formalized` or `axiomatized` status

## Examples of fixes

| Proof | Old count | Actual count |
|-------|-----------|-------------|
| erdos-43 | 0 | 5 |
| erdos-960 | 0 | 5 |
| erdos-1095 | 0 | 3 |
| erdos-610 | 11 | 17 |
| erdos-607 | 17 | 20 |

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Spot-check a few corrected counts against Lean files

🤖 Generated with [Claude Code](https://claude.com/claude-code)