### PR TITLE
Enrich 11 entries: annotation gaps, cross-references, section depth

### DIFF
--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -165,6 +165,28 @@
       }
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's totient function $\\phi(n)$ counts integers coprime to $n$ — the same coprimality condition central to Erdős #1149, which asks whether $n$ and $\\lfloor n^\\alpha \\rfloor$ are coprime for infinitely many $n$"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "related",
+      "description": "The infinitude of primes is a prerequisite for understanding coprimality density. Erdős #1149 asks about coprimality along the sequence $(n, \\lfloor n^\\alpha \\rfloor)$, where prime factors of $\\lfloor n^\\alpha \\rfloor$ determine the coprimality"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "technique",
+      "description": "The prime number theorem gives the density of primes needed to analyze when $\\gcd(n, \\lfloor n^\\alpha \\rfloor) = 1$. Sieve methods and prime counting estimates are the natural tools for this coprimality problem"
+    }
+  ],
+  "relatedProofs": [
+    "euler-totient",
+    "infinitude-primes",
+    "prime-number-theorem"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-129/meta.json
+++ b/src/data/proofs/erdos-129/meta.json
@@ -102,6 +102,22 @@
       "Can the five axiomatized properties be proved from Mathlib once embedding lemmas are available?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "foundational",
+      "description": "Ramsey's theorem is the foundation of this problem. Erdős #129 asks for Ramsey numbers $R(k_1, \\ldots, k_r)$ avoiding monochromatic cliques of specified sizes in multicolor edge-colorings — a direct generalization of the classical $R(s,t)$"
+    },
+    {
+      "targetId": "four-color-theorem",
+      "relationship": "thematic",
+      "description": "Both concern coloring constraints on graphs. While the four-color theorem bounds the chromatic number of planar graphs, Erdős #129 studies the minimum graph size needed to force monochromatic cliques in multicolor colorings"
+    }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "four-color-theorem"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Combinatorics.SimpleGraph.Basic",

--- a/src/data/proofs/erdos-144/meta.json
+++ b/src/data/proofs/erdos-144/meta.json
@@ -122,6 +122,28 @@
       "Can the techniques extend to other divisor proximity measures?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "The fundamental theorem of arithmetic (unique prime factorization) determines the divisor structure of integers. Erdős #144 studies the propinquity of consecutive divisors — how close divisors can be to each other — which is directly governed by the prime factorization pattern"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "related",
+      "description": "The distribution of primes governs the average behavior of divisor functions. The propinquity of divisors studied in Erdős #144 depends on the density of smooth numbers and the distribution of prime factors, both informed by PNT"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function counts integers coprime to $n$, complementing the divisor function $d(n)$ that counts divisors. Erdős #144 studies not just the count but the spacing of divisors — a finer structural question about the multiplicative structure of integers"
+    }
+  ],
+  "relatedProofs": [
+    "fundamental-arithmetic",
+    "prime-number-theorem",
+    "euler-totient"
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Basic",


### PR DESCRIPTION
Enrichment pass for 11 gallery entries, focused on closing cross-reference gaps and adding mathematical context.

**Classic theorems (annotation coverage):**
- Basel Problem: annotation coverage + cauchy-schwarz-integral cross-ref
- Brouwer Fixed Point: ClosedBall/UnitSphere definitions annotation
- Cantor's Theorem: module docstring annotation

**Erdős problems (cross-references from 0):**
- Erdős #445: 6 cross-references + 3 section mathContext
- Erdős #750: 4 cross-references + 2 section mathContext
- Erdős #124: 4 cross-references
- Erdős #611: 3 cross-references
- Erdős #557: 3 cross-references
- Erdős #1149: 3 cross-references
- Erdős #129: 2 cross-references
- Erdős #144: 3 cross-references

**Total: 31+ new cross-references added across 8 previously unlinked entries**