### PR TITLE
Audit fix: downgrade 19 corrupted Lean files to pending

### DIFF
--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -7,7 +7,7 @@
     "author": "J.W.S. Cassels, Paul Erdős, J.A. Haight",
     "sourceUrl": "https://erdosproblems.com/1000",
     "date": "1950-1964",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1000Problem.lean",
     "tags": [
       "erdos",
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "This problem originates in Cassels' 1950 work on Diophantine approximation, where he introduced the generalized totient φ_A to study the distribution of 'new' reduced denominators in increasing integer sequences. Cassels proved that for some sequences, the liminf of the Cesàro average of φ_A(k)/n_k is zero, and connected this to metric Diophantine approximation via the Khinchin-Groshev theorem. Erdős (1964) made the problem sharper: he proved that for any sequence, the individual ratio φ_A(k)/n_k cannot converge to 0, and established a remarkable dichotomy — if liminf = 0 then limsup = 1 — showing the density ratio must oscillate maximally. Erdős then asked whether the Cesàro average itself could vanish, conjecturing it could not. The lower bound φ_A(k) ≥ φ(n_k) (Euler's totient) and the fact that φ(n)/n averages to 6/π² supported his intuition. Haight's subsequent construction proved Erdős wrong: carefully chosen sequences of highly composite numbers force the average to 0 while the individual terms oscillate between 0 and 1. The problem illustrates the subtle gap between pointwise and averaged behavior of arithmetic functions.",

--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1002",
     "date": "",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1002Problem.lean",
     "tags": [
       "analysis",
@@ -24,7 +24,7 @@
     "relatedProblems": [],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "**Fractional Parts in Number Theory**\n\nThe study of fractional parts $\\{n\\alpha\\}$ for irrational $\\alpha$ is central to Diophantine approximation. Hermann Weyl's equidistribution theorem (1916) established that $\\{\\alpha\\}, \\{2\\alpha\\}, \\{3\\alpha\\}, \\ldots$ is uniformly distributed in $[0,1)$, a foundational result connecting number theory to ergodic theory.\n\n**Gauss and Continued Fractions**: Carl Friedrich Gauss studied the map $T(x) = \\{1/x\\}$ on $(0,1)$, discovering its invariant measure $d\\mu = dx/(\\log 2 \\cdot (1+x))$. The Gauss-Kuzmin theorem (Kuzmin 1928, Lévy 1929) describes the rate at which iterates of $T$ converge to this measure.\n\n**Erdős's Question**: Erdős asked whether $f(\\alpha, n) = \\frac{1}{\\log n}\\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\})$ has an asymptotic distribution function — does the proportion of $\\alpha$ with $f(\\alpha, n) \\le c$ converge as $n \\to \\infty$?\n\n**Kesten's Breakthrough**: Harry Kesten (1960) proved the two-parameter variant $f(\\alpha, \\beta, n) = \\frac{1}{\\log n}\\sum(1/2 - \\{\\beta + \\alpha k\\})$ has a Cauchy limit distribution $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + 1/2$, using the ergodic properties of the natural extension of the Gauss map. The extra parameter $\\beta$ provides the independence needed for the ergodic argument. Fixing $\\beta = 0$ destroys this independence, and the one-parameter problem remains **OPEN**.",

--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Carl Pomerance, András Sárközy",
     "sourceUrl": "https://erdosproblems.com/1004",
     "date": "1987",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1004Problem.lean",
     "tags": [
       "erdos",
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "Euler's totient function $\\varphi(n)$ — counting integers $1 \\leq k \\leq n$ coprime to $n$ — has been studied since Euler's 1763 work on modular arithmetic. Its value distribution is rich: by the prime number theorem, $\\varphi(p) = p - 1$ for primes, but composite numbers introduce collisions like $\\varphi(3) = \\varphi(4) = \\varphi(6) = 2$. Carmichael conjectured in 1907 that every value in the range of $\\varphi$ is attained at least twice, a conjecture still open after over a century. In their influential 1987 paper \"On locally repeated values of certain arithmetic functions, III,\" Erdős, Pomerance, and Sárközy (EPS) studied how often consecutive values of $\\varphi$ can be distinct. They proved the striking upper bound: if $\\varphi(n+1), \\ldots, \\varphi(n+K)$ are all distinct, then $K \\leq n/\\exp(c(\\log n)^{1/3})$ for some $c > 0$. This uses deep results on smooth number estimates (related to the de Bruijn $\\Psi$ function). Problem 1004 asks whether the complementary lower bound holds: can we always find runs of length $(\\log x)^c$ with distinct totient values? The analogous Problem 945 asks the same for the divisor function $\\tau(n)$. Both remain open.",

--- a/src/data/proofs/erdos-1005/meta.json
+++ b/src/data/proofs/erdos-1005/meta.json
@@ -7,7 +7,7 @@
     "author": "van Doorn (2025)",
     "sourceUrl": "https://erdosproblems.com/1005",
     "date": "2025",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1005Problem.lean",
     "tags": [
       "number-theory",
@@ -16,7 +16,7 @@
       "asymptotic-analysis",
       "combinatorics"
     ],
-    "badge": "pending",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1005,
     "erdosUrl": "https://erdosproblems.com/1005",
@@ -24,7 +24,7 @@
     "relatedProblems": [],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "The Farey sequence $F_n$ — the set of reduced fractions $a/b$ with $0 \\leq a \\leq b \\leq n$ arranged in increasing order — has been studied since the early 19th century (independently by Haros in 1802 and Farey in 1816). Cauchy gave the first proof that adjacent Farey fractions $a/b, c/d$ satisfy $|ad - bc| = 1$, a property connecting them to the modular group $SL_2(\\mathbb{Z})$ and continued fractions. In 1942, Mayer observed that consecutive Farey fractions tend to be 'similarly ordered' — meaning their numerators and denominators move in the same direction, i.e., $(a_k - a_l)(b_k - b_l) \\geq 0$ — and proved that the longest such run $f(n) \\to \\infty$. Erdős (1943) strengthened this to $f(n) \\gg n$, establishing linear growth. For over 80 years, no explicit constants were known. van Doorn (2025) finally established $(1/12 - o(1))n \\leq f(n) \\leq n/4 + O(1)$, with the upper bound using the determinant property of adjacent Farey fractions and the lower bound via explicit constructions. van Doorn conjectures $f(n)/n \\to 1/4$, but the factor-of-3 gap between the bounds remains a significant challenge. The problem connects to Stern-Brocot trees, lattice point geometry, and longest chain problems in partial orders.",

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -7,7 +7,7 @@
     "author": "Conlon-Fox-Sudakov (2014)",
     "sourceUrl": "https://erdosproblems.com/1008",
     "date": "2014",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1008Problem.lean",
     "tags": [
       "erdos",
@@ -17,14 +17,14 @@
       "subgraphs",
       "zarankiewicz"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1008,
     "erdosUrl": "https://erdosproblems.com/1008",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"verified\"."
   },
   "overview": {
     "historicalContext": "This problem was originally posed by Bollobás and Erdős at the 1966 Tihany graph theory colloquium in Hungary, asking whether every m-edge graph contains a C₄-free subgraph with ≫ m^{3/4} edges. Folkman quickly disproved this using the bipartite graph K_{n,n²}: it has n³ edges but every C₄-free subgraph has only O(n²) = O(m^{2/3}) edges, by the Kővári-Sós-Turán theorem. Erdős revised the conjecture to exponent 2/3 in 1971, noting that the trivial bound m^{1/2} follows easily from Kővári-Sós-Turán. He mentioned that Szemerédi had proved the 2/3 bound but gave no published reference. The problem remained formally open until Conlon, Fox, and Sudakov proved it in their 2014 paper using dependent random choice, a powerful probabilistic technique developed in the 2000s. A simpler proof was later given by Hunter. The result fits into the broader program of understanding Turán-type and Zarankiewicz-type problems: how dense can a graph be while avoiding a fixed forbidden subgraph? The C₄ case is special because C₄ = K_{2,2}, linking cycle-free conditions to bipartite Ramsey theory.",

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Goodman-Pósa (1966), Győri-Keszegh (2017)",
     "sourceUrl": "https://erdosproblems.com/1017",
     "date": "1966",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1017Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "clique-partition",
       "graph-decomposition"
     ],
-    "badge": "pending",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1017,
     "erdosUrl": "https://erdosproblems.com/1017",
@@ -24,7 +24,7 @@
     "relatedProblems": [],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "The clique partition problem has roots in the early days of graph decomposition theory. The fundamental question—how many complete subgraphs are needed to partition all edges of a graph?—connects to classical work of König (1931) on bipartite matching, Dilworth (1950) on chain decompositions, and the broader program of decomposing combinatorial structures into 'simple' pieces.\n\nErdős, Goodman, and Pósa (1966) proved the elegant theorem that $f(n,k) \\le \\lfloor n^2/4 \\rfloor$ for all $n$ and $k$, where $f(n,k)$ is the minimum number of complete subgraphs needed to partition any graph with $n$ vertices and $k$ edges. Their proof uses only edges ($K_2$'s) and triangles ($K_3$'s)—larger cliques are never required. The key insight is that a maximal set of edge-disjoint triangles leaves behind a triangle-free graph, which by Ramsey theory (or equivalently König's theorem) is bipartite. The triangle-free part then needs at most $\\lfloor n^2/4 \\rfloor$ individual edges for its partition, by Turán's theorem applied to its complement.\n\nThe bound $\\lfloor n^2/4 \\rfloor$ is tight: the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$ (the Turán graph $T(n,2)$) has exactly $\\lfloor n^2/4 \\rfloor$ edges and no triangles, so every edge must be its own clique in any partition. This extremal example is sparse—it has the maximum number of edges a triangle-free graph can have, by Turán's theorem.\n\nErdős then asked the natural follow-up: when $k > n^2/4$ (more edges than any triangle-free graph), the graph *must* contain triangles. Can these triangles be exploited to bring the partition count *below* $n^2/4$? This is the core of Problem #1017.\n\nThe major partial result came from Győri and Keszegh (2017), who completely resolved the $K_4$-free case. They proved: if $G$ is $K_4$-free with $\\lfloor n^2/4 \\rfloor + m$ edges, then $G$ contains $m$ edge-disjoint triangles. Since each triangle replaces 3 edges with 1 clique (saving 2 from the count), the clique partition number drops to $\\lfloor n^2/4 \\rfloor - m$ for such graphs. Their proof uses a sophisticated induction on $m$, combined with the Kruskal-Katona theorem to control the triangle distribution.\n\nThe general case—when $K_4$ and larger cliques are allowed—remains open. The difficulty is combinatorial: larger cliques offer bigger savings ($K_r$ replaces $\\binom{r}{2}$ edges with 1 piece), but edges may belong to multiple overlapping cliques, creating a complex optimization problem related to fractional relaxations and potentially NP-hard in the worst case.",

--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Lovász (1968)",
     "sourceUrl": "https://erdosproblems.com/1022",
     "date": "1971",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1022Problem.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "property-b",
       "set-families"
     ],
-    "badge": "pending",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1022,
     "erdosUrl": "https://erdosproblems.com/1022",
@@ -24,7 +24,7 @@
     "relatedProblems": [],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "Property B was introduced by E.W. Miller in 1937, who named it after Felix Bernstein's 1908 work on set partitions. The property asks: given a family $\\mathcal{F}$ of sets, can the elements be 2-colored so that no set in $\\mathcal{F}$ is monochromatic? This is precisely hypergraph 2-colorability, where $\\mathcal{F}$ is the set of hyperedges.\n\nThe study of property B became central to combinatorics through the work of Erdős and Hajnal in the 1960s. Erdős (1963) proved the foundational probabilistic bound: if all sets in $\\mathcal{F}$ have size $\\ge t$ and $|\\mathcal{F}| < 2^{t-1}$, then $\\mathcal{F}$ has property B. The proof is a beautiful application of the probabilistic method—a uniformly random 2-coloring fails to properly color a set of size $s$ with probability exactly $2^{1-s}$, and a union bound gives the result. This is tight: Erdős also constructed families of $2^{t-1}$ sets of size $t$ without property B.\n\nProblem #1022 asks a more refined question. Instead of bounding the total number of sets, it imposes a *local density* condition: for every set $X$, the number of family members that are subsets of $X$ must be fewer than $c_t |X|$. The conjecture is that the threshold $c_t$ can be chosen to tend to infinity with $t$, meaning that as the minimum set size grows, increasingly denser families can still be 2-colored.\n\nThe only solved case is $t = 2$, due to Lovász (1968): if every element of the ground set appears in fewer than $|X|$ of the subfamily of sets contained in $X$, the family has property B. Lovász's proof is related to his later work on the Lovász Local Lemma (1975, with Erdős), which provides a general framework for proving that events with limited dependencies cannot all occur simultaneously.\n\nThe problem connects to several major threads in combinatorics: the Lovász Local Lemma (which provides 2-colorings when dependencies are controlled), the theory of VC dimension (which bounds the combinatorial complexity of set families), Turán-type extremal problems (bounding structure by density), and the theory of cover-free families from combinatorial group testing and information theory. The sparseness condition $|\\{A \\in \\mathcal{F} : A \\subseteq X\\}| < c_t |X|$ is a 'trace' condition, bounding how many family members can appear inside any given set—a concept closely related to the Sauer-Shelah lemma and VC theory.",

--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -7,7 +7,7 @@
     "author": "Koishi Chan (proof)",
     "sourceUrl": "https://erdosproblems.com/1027",
     "date": "2024",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1027Problem.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "property-b",
       "2-colorable"
     ],
-    "badge": "pending",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1027,
     "erdosUrl": "https://erdosproblems.com/1027",
@@ -26,7 +26,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "Property B, named after Felix Bernstein's 1908 work on set partitions and formally introduced by E.W. Miller (1937), asks whether a family of sets can be 2-colored so that no set is monochromatic. Equivalently: does there exist a subset $B$ of the ground set that intersects every family member but contains none? Such a $B$ is called a 'good' set—its existence is precisely property B.\n\nErdős's 1963 probabilistic bound showed that if $|\\mathcal{F}| < 2^{t-1}$ and all sets have size $\\ge t$, then $\\mathcal{F}$ has property B. The proof is a gem of the probabilistic method: each set of size $s$ is monochromatic under a random 2-coloring with probability $2^{1-s}$, and the union bound gives the result. This bound is tight—Erdős constructed $2^{t-1}$ sets of size $t$ without property B.\n\nProblem #1027 asks a *quantitative* question that goes far beyond mere existence. Given a bounded family ($|\\mathcal{F}| \\le c \\cdot 2^n$, all sets of size $n$), must there be not just one good set but *exponentially many*? Specifically, are there $\\gg_c 2^{|X|}$ good subsets of $X = \\bigcup \\mathcal{F}$, where the implicit constant depends only on $c$? This is a supersaturation phenomenon: once property B holds, it holds abundantly.\n\nThe problem is closely related to Erdős Problem #901, which asks about property B for bounded families. Problem #1027 strengthens #901 from an existential statement (at least one good set) to a quantitative one (a constant fraction of all subsets are good).\n\nKoishi Chan resolved the problem affirmatively. The key insight is an amplification argument: given one good set $B$, local perturbations—flipping elements of $B$ that are 'far' from being critical for any family member—produce exponentially many other good sets. The probabilistic intuition is that a random subset $B \\subseteq X$ satisfies $\\Pr[B \\text{ good}] \\ge (1 - 2^{-n})^{2|\\mathcal{F}|} \\approx e^{-2c}$ for large $n$, giving an expected $e^{-2c} \\cdot 2^{|X|}$ good sets. Making this rigorous requires handling the dependencies between the events '$B$ intersects $A$' and '$A \\not\\subseteq B$' for different $A \\in \\mathcal{F}$.\n\nThe result connects to several areas: the Lovász Local Lemma (handling dependent events), supersaturation in extremal combinatorics (Erdős-Simonovits theory), the entropy method in combinatorics (Shearer's lemma), and the theory of containers (Balogh-Morris-Samotij, Saxton-Thomason), which provides a general framework for counting independent sets in hypergraphs.",

--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Rényi (question), Shelah (1998, solution)",
     "sourceUrl": "https://erdosproblems.com/1036",
     "date": "1998",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1036Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "induced-subgraphs",
       "isomorphism"
     ],
-    "badge": "pending",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1036,
     "erdosUrl": "https://erdosproblems.com/1036",
@@ -26,7 +26,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "This problem originates from a question of Erdős and Rényi about the structural complexity of graphs that avoid large homogeneous (trivial) subgraphs. By Ramsey's theorem (1930), every n-vertex graph contains a clique or independent set of size at least (1/2) log₂ n. Erdős (1947) showed via the probabilistic method that random graphs G(n,1/2) achieve the opposite extreme: their largest clique and independent set are both O(log n). Such 'non-Ramsey' graphs exist in abundance but must be structurally complex. Erdős and Hajnal (1989) proved the first result in this direction: graphs avoiding K_{k,k} in both G and its complement have 2^{Ω(n)} distinct induced subgraphs. Alon and Hajnal (1991) extended this to all non-Ramsey graphs, proving a sub-exponential bound of exp(n·(log n)^{-O(log log n)}) using Szemerédi's regularity lemma. The full exponential bound 2^{Ω(n)} remained open until Shelah (1998) proved it using a deep partition argument connected to the Hales-Jewett theorem. Independently, Prömel and Rödl (1999) proved the related result that non-Ramsey graphs are c·log(n)-universal (Problem 1031), which gives a weaker but conceptually elegant approach to induced subgraph diversity.",

--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (problem), Borwein (1991 proof)",
     "sourceUrl": "https://erdosproblems.com/1050",
     "date": "1991",
-    "status": "axiomatized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1050Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "transcendence",
       "solved"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1050,
     "erdosUrl": "https://erdosproblems.com/1050",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
   },
   "overview": {
     "historicalContext": "**From Lambert Series to Borwein's Theorem**\n\nThe study of series with exponential denominators began with Johann Heinrich Lambert's 1748 investigation of ∑ q^n/(1-q^n) — the Lambert series — which he connected to the divisor function τ(n). Euler recognized the identity ∑ 1/(q^n - 1) = ∑ τ(n)/q^n, linking these series to multiplicative number theory.\n\nIn 1948, Erdős published a foundational paper in the Journal of the Indian Mathematical Society proving that ∑ 1/(2^n - 1) is irrational. His method exploited the divisor function identity: if the sum were rational p/q, then ∑ τ(n)/2^n = p/q, and the arithmetic properties of τ (specifically, that τ(n) is often large — on average log n) would produce contradictions modulo carefully chosen primes. This result established the Erdős-Borwein constant E ≈ 1.60669 as one of the first explicitly-defined irrationals in this family.\n\nErdős conjectured much more: that ∑ 1/(2^n + t) should be transcendental for every integer t ≠ 0. Problem #1050 asks specifically about the case t = -3, i.e., whether ∑ 1/(2^n - 3) is irrational.\n\n**Peter Borwein (1991)** proved the definitive irrationality result in Math. Proc. Cambridge Philos. Soc.: for any integer q ≥ 2 and rational r ≠ 0 (with r ≠ -q^n for any n), the series ∑ 1/(q^n + r) is irrational. His proof used Padé approximation to the q-logarithm function log_q(1+x) = ∑ (-x)^n/(q^n - 1), constructing rational approximants whose quality exceeds the Dirichlet threshold. This completely solved Problem #1050 and subsumed Erdős's 1948 result as a special case.\n\nThe stronger transcendence conjecture remains OPEN. Even for the Erdős-Borwein constant ∑ 1/(2^n - 1), transcendence has not been established. The methods of Mahler (1929) and Nishioka (1996) for q-series transcendence do not directly apply to these Lambert-type series, and fundamentally new techniques appear to be needed.",

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -7,7 +7,7 @@
     "author": "Montgomery-Vaughan (1986 resolution)",
     "sourceUrl": "https://erdosproblems.com/220",
     "date": "1986",
-    "status": "axiomatized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos220Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "gaps",
       "solved"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 220,
     "erdosUrl": "https://erdosproblems.com/220",
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #220**\n\nThis problem concerns the gaps between consecutive reduced residues modulo n. The reduced residues are integers 1 ≤ m < n with gcd(m,n) = 1, and there are φ(n) of them.\n\n**Background:**\n- Average gap is n/φ(n)\n- Large gaps can occur (related to Jacobsthal's function)\n- Erdős asked if squared gaps sum to O(n²/φ(n))\n\n**History:**\n- Erdős posed the problem; $500 prize\n- The general γ ≥ 1 version was posed in [Er73]\n- Montgomery and Vaughan proved it in 1986 (Ann. of Math.)\n- Discussed in Guy's \"Unsolved Problems in Number Theory\" (B40)\n\n**Context:** The bound n²/φ(n) is what you'd get if all gaps were equal to the average. The theorem says even with gap variance, the squared sum doesn't exceed this by more than a constant factor.",

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Gimbel (1989 problem), Heckel-Steiner (2024 progress)",
     "sourceUrl": "https://erdosproblems.com/625",
     "date": "1989-2024",
-    "status": "axiomatized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos625Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "open-problem",
       "prize"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 625,
     "erdosUrl": "https://erdosproblems.com/625",
@@ -65,7 +65,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #625**\n\nProposed by Erdős and Gimbel at a random graph conference in Poznań, Poland (1989). The cochromatic number generalizes proper coloring by allowing color classes to induce either complete graphs (cliques) or empty graphs (independent sets).\n\n**Prize Structure:**\nErdős offered $100 for a proof that χ - ζ → ∞ almost surely, and $1000 for a proof of the opposite. He later remarked to Gimbel that \"$1000 was perhaps too much\" - suggesting he believed the affirmative answer is correct.\n\n**Recent Progress (2024):**\nHeckel and independently Steiner proved that χ(G) - ζ(G) is unbounded with high probability. Heckel further conjectured χ - ζ ≈ n/(log n)³ and proved χ - ζ ≥ n^{1-ε} for roughly 95% of all n. Despite this progress, the main question remains OPEN.",

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, investigated by Soifer",
     "sourceUrl": "https://erdosproblems.com/633",
     "date": "",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos633Problem.lean",
     "tags": [
       "erdos",
@@ -65,7 +65,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "This problem concerns the geometry of triangle dissections — partitioning a triangle into congruent triangular pieces. Every triangle can be dissected into n² congruent copies by subdividing each side into n equal segments and connecting corresponding points, forming an n × n grid of congruent sub-triangles.\n\nThe question is: are there triangles where n² is the ONLY achievable dissection count? Alexander Soifer investigated this systematically in his book 'How Does One Cut a Triangle?' (2009). He showed that the triangle with sides √2, √3, √4 has this 'square-only' property — it cannot be dissected into any non-square number of congruent triangles. The key constraint comes from the irrational side lengths: any tiling must respect algebraic relationships between the sides, and the only way to achieve area compatibility with matching angles forces the count to be a perfect square.\n\nSoifer's analysis connects to the concept of 'integral independence' of angles: if the three angles α, β, γ of a triangle satisfy no non-trivial integer linear relation (beyond α + β + γ = π), then dissection constraints force square-only counts. Equilateral triangles (angles π/3, π/3, π/3 — integrally dependent via α = β = γ) can be dissected into 3 pieces, and right isosceles triangles (π/4, π/4, π/2 — integrally dependent via α = β, γ = 2α) can be dissected into 2 pieces.\n\nThe complete classification of square-only triangles remains OPEN with a $25 Erdős prize. The conjecture is that integral independence of angles is the precise characterization.",

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Fon-Der-Flaass, Kostochka, Tuza",
     "sourceUrl": "https://erdosproblems.com/644",
     "date": "1992",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos644Problem.lean",
     "tags": [
       "erdos",
@@ -76,7 +76,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "Erdős, Fon-Der-Flaass, Kostochka, and Tuza introduced this problem in 1992, studying the covering function f(k,r) for k-uniform set families with the r-wise pair intersection property. They determined exact values for r = 3, 4, 5, 6, revealing a striking pattern of decreasing coefficients: c₃ = 2, c₄ = 3/2, c₅ = 5/4, c₆ = 1.\n\nThe r-wise pair property is a Helly-type condition: it requires that any r sets in the family are linked by a common pair intersecting all of them. As r increases, the condition becomes stronger, forcing more structure on the family and enabling smaller covering sets. The sequence of exact values suggests a regular pattern, but no general formula has been established.\n\nThe problem connects to several important themes in combinatorics: the sunflower lemma (Erdős-Rado 1960), Helly-type theorems, hypergraph transversal theory, and the recently improved sunflower bounds (Alweiss-Lovett-Wu-Zhang 2020). The open questions about f(k,7) and general asymptotics probe the fundamental limits of covering efficiency under structural constraints.",

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/660",
     "date": "1975",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos660Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "convex-geometry",
       "3D-geometry"
     ],
-    "badge": "mathlib",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 660,
     "erdosUrl": "https://erdosproblems.com/660",
@@ -76,7 +76,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"verified\"."
   },
   "overview": {
     "historicalContext": "**Origins: Erdős and the Convex Distance Problem (1975)**\n\nProblem #660 was posed by Erdős in 1975, building on a rich tradition of distance problems in convex geometry. The question is deceptively simple: must the vertices of a convex polyhedron in $\\mathbb{R}^3$ determine many distinct distances?\n\n**Altman's 2D Solution (1963)**\n\nThe 2D analogue was solved by Edward Altman in 1963: the $n$ vertices of a convex polygon determine at least $\\lfloor n/2 \\rfloor$ distinct distances. Altman's proof exploits the cyclic ordering of vertices on the convex hull — for each 'diagonal length,' there are at most 2 diagonals of that length connecting vertices of a convex polygon, giving the $n/2$ bound. Erdős mentioned that Altman may have proved an even stronger result ($\\gg n$ distances), but no reference was provided.\n\n**The Convexity Advantage**\n\nFor arbitrary point sets, the Guth-Katz theorem (2015) gives $\\Omega(n/\\log n)$ distinct distances — nearly optimal but with a logarithmic loss. For points in convex position, the rigidity of the convex hull is expected to eliminate this loss entirely, yielding a clean $\\Theta(n)$ bound. The conjecture's constant $1/2$ matches Altman's 2D result.\n\n**The 3D Challenge**\n\nThe jump from 2D to 3D is non-trivial because convex polyhedra lack the cyclic ordering that makes Altman's argument work. In 3D, the combinatorial structure of the face lattice (vertices, edges, faces) is far more complex, and the relationship between convex hull geometry and distance distributions is not well understood. Even proving a linear bound (without the $1/2$ constant) remains open.\n\n**Platonic Solid Tests**\n\nThe five Platonic solids provide test cases: tetrahedron (4 vertices, 1 distance), octahedron (6 vertices, 2 distances), cube (8 vertices, 3 distances), icosahedron (12 vertices, 3 distances), dodecahedron (20 vertices, 5 distances). All satisfy the conjecture, but they represent only highly symmetric special cases.",

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos-Vertesi (1980 divergence), Bernstein (1931 Lebesgue divergence)",
     "sourceUrl": "https://erdosproblems.com/671",
     "date": "1980",
-    "status": "axiomatized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos671Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "lebesgue-function",
       "open"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #671**\n\nThis is a deep problem in approximation theory about the relationship between the Lebesgue function and Lagrange interpolation convergence.\n\n**Key History:**\n- 1931: Bernstein proves lambda_n(x) diverges at some point for any interpolation scheme\n- 1980: Erdos and Vertesi prove that for any points, some continuous f has |L^n f(x)| -> infinity a.e.\n- Present: Questions 1 and 2 remain open with $250 prize\n\n**Mathematical Context:**\nThe Lebesgue function lambda_n(x) = sum |p_i^n(x)| controls interpolation error: the error is bounded by (1 + Lambda_n) times the best polynomial approximation. When Lambda_n grows, uniform convergence fails. The questions ask whether *pointwise* convergence can still occur when lambda_n diverges.",

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1979), solved by Cambie (2024)",
     "sourceUrl": "https://erdosproblems.com/678",
     "date": "1979",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos678Problem.lean",
     "tags": [
       "erdos",
@@ -65,7 +65,7 @@
       "Native decision procedures in Lean 4"
     ],
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1979, asking a counterintuitive question: can a shorter interval of consecutive integers have a larger LCM than a longer interval starting further along?\n\nThe referee of the 1979 paper (later identified as John Selfridge) immediately found examples: M(96,7) > M(104,8). The full answer—infinitely many such comparisons—was proved by Stijn Cambie in 2024, with a Lean-verified proof showing that for all sufficiently large k, such pairs exist. The phenomenon is driven by the distribution of prime powers: the LCM of an interval is essentially determined by which prime powers it contains, and an interval that captures a large prime power (such as 2^7 = 128) can have a much larger LCM than a slightly longer interval that misses it. Chebyshev's classical estimates show log M(n,k) ≈ k, making the precise combinatorics of prime power placement critical.",

--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős and Freud",
     "sourceUrl": "https://erdosproblems.com/840",
     "date": "1991",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos840Problem.lean",
     "tags": [
       "erdos",
@@ -16,14 +16,14 @@
       "sumsets",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 840,
     "erdosUrl": "https://erdosproblems.com/840",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"verified\"."
   },
   "overview": {
     "historicalContext": "Sidon sets (also called $B_2$ sequences) were introduced by Simon Sidon in a 1932 letter to Erdős, asking for the maximum size of a subset of $\\{1, \\ldots, N\\}$ with all pairwise sums distinct. Erdős and Turán (1941) proved the upper bound $|A| \\leq \\sqrt{N} + O(N^{1/4})$, while constructions by Singer (1938, using difference sets from projective planes) and Bose–Chowla (1962) achieved $|A| \\sim \\sqrt{N}$. The quasi-Sidon relaxation, introduced by Erdős and Freud in 1991, allows a vanishing fraction of sum collisions: $|A + A| = (1 + o(1)) \\binom{|A|}{2}$. This permits larger sets — the question is how much larger. Erdős and Freud proved $(2/\\sqrt{3})\\sqrt{N} \\leq f(N) \\leq 2\\sqrt{N}$ using a reflection construction and pigeonhole arguments. Pikhurko (2006) improved the upper bound to $\\approx 1.863\\sqrt{N}$ via a connection to edge-magic graph labelings and thin additive bases. Cilleruelo (2010) resolved the analogous problem for difference sets ($A - A$ instead of $A + A$), showing the answer is simply $\\sim \\sqrt{N}$ with constant 1. The sum version remains open, with the true constant lying in the interval $[2/\\sqrt{3}, 1.863] \\approx [1.155, 1.863]$.",

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Andrzej Schinzel, Cameron Stewart",
     "sourceUrl": "https://erdosproblems.com/977",
     "date": "1965-2013",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos977Problem.lean",
     "tags": [
       "erdos",
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
     "lineCount": 1,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries."
+    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\"."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem around 1965, asking whether the greatest prime factor of $2^n - 1$ grows faster than linearly. The first major progress came from Andrzej Schinzel in 1962, who proved $P(2^n - 1) > 2n$ for all $n > 12$ using algebraic factorization properties of cyclotomic polynomials. Cameron Stewart made further conditional progress in 1974, and finally settled the problem unconditionally in 2013 with the quantitative bound $P(2^n - 1) \\ge n^{1 + 1/(104 \\log\\log n)}$. Stewart's proof combines deep techniques from transcendental number theory (Baker's theory of linear forms in logarithms) with the arithmetic of cyclotomic fields.\n\nThe problem sits in a rich tradition connecting prime factorization to exponential sequences. Zsygmondy's theorem (1892) guarantees that $2^n - 1$ has a *primitive* prime factor for $n > 6$ — a prime not dividing $2^k - 1$ for any $k < n$. Such primes satisfy $p \\equiv 1 \\pmod{n}$, immediately giving $P(2^n - 1) \\ge n + 1$, but this falls short of the $n^{1+\\varepsilon}$ growth Erdős sought. The connection to Mersenne primes ($2^p - 1$ when prime) adds number-theoretic interest: for the 51 known Mersenne primes, $P(M_p) = M_p = 2^p - 1 \\gg 2^p$, far exceeding any polynomial bound. A related open problem asks whether $P(n! + 1)/n \\to \\infty$, where Lai (2021) proved the partial result $\\limsup P(n!+1)/n \\ge 1 + 9\\log 2 \\approx 7.238$.",


### PR DESCRIPTION
## Summary

19 Lean proof files contain only Aristotle job UUID references instead of actual Lean code (e.g., `27e0c7b5-4284-4195-b828-67256d8c054e-output.lean`).

**3 of these falsely claimed "verified" status** — the most serious gallery integrity violation found so far.

All 19 downgraded to `status: "pending"`, `badge: "wip"` until actual Lean files can be restored.

Fixes #5508

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Check gallery pages show correct "pending" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)