### PR TITLE
Enrich abel-ruffini-oq-04: add substantive theorem count

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -216,6 +216,8 @@
     "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 8,
+    "substantiveTheoremCount": 2,
+    "trivialSpecializations": 6,
     "definitionCount": 0
   },
   "references": [


### PR DESCRIPTION
## Summary
- Added `substantiveTheoremCount` and `trivialSpecializations` fields to `leanFile` section in meta.json
- Addresses peer review inconsistency finding: the "8 theorems" count is numerically correct but qualitatively misleading without distinguishing the 2 substantive theorems from the 6 trivial specializations/typeclass inferences

## Context
Entry already at quality 100 with 3 prior passes and all enricher review items resolved. This is a minor metadata improvement addressing the remaining peer review inconsistency finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)