### PR TITLE
Enrich abel-ruffini: theorem breakdown, trim cross-refs

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -220,21 +220,6 @@
       "description": "Hermite's proof that $e$ is transcendental (1873) sits one level above Abel-Ruffini in the expressibility hierarchy: Abel-Ruffini shows certain algebraic numbers escape radical expressions, while transcendence shows $e$ escapes all polynomial equations over $\\mathbb{Q}$. Lindemann's extension to $\\pi$ (1882) resolved the ancient problem of squaring the circle"
     },
     {
-      "targetId": "godel-incompleteness",
-      "relationship": "related",
-      "description": "Gödel's incompleteness theorem (1931) extends the impossibility paradigm inaugurated by Abel-Ruffini: Abel showed no radical formula solves all quintics, Gödel showed no consistent formal system proves all true arithmetic statements. Both reveal inherent limitations of formal frameworks"
-    },
-    {
-      "targetId": "halting-problem",
-      "relationship": "related",
-      "description": "Turing's undecidability of the halting problem (1936) continues Abel-Ruffini's impossibility tradition: no algorithm can decide whether an arbitrary program halts, just as no radical formula can solve an arbitrary quintic. Both are proved by structural obstructions (diagonal argument vs non-solvable Galois group)"
-    },
-    {
-      "targetId": "hilbert-10",
-      "relationship": "related",
-      "description": "Matiyasevich's negative resolution of Hilbert's 10th problem (1970) — no algorithm decides solvability of arbitrary Diophantine equations — is the number-theoretic descendant of Abel-Ruffini's impossibility. Both concern the limits of what can be 'solved' within a given formal framework"
-    },
-    {
       "targetId": "primitive-roots",
       "relationship": "foundational",
       "description": "Primitive roots and cyclotomic extensions supply the abelian Galois groups $(\\mathbb{Z}/n\\mathbb{Z})^{\\times}$ that form each layer of a radical tower via Kummer theory. Each radical step $K \\to K(\\sqrt[n]{a})$ has cyclic Galois group precisely because the $n$th roots of unity form a cyclic group. Abel-Ruffini's impossibility arises when the target Galois group $S_5$ cannot be decomposed into such abelian cyclotomic layers"
@@ -254,9 +239,6 @@
     "fundamental-theorem-algebra",
     "kroneckers-jugendtraum",
     "e-transcendental",
-    "godel-incompleteness",
-    "halting-problem",
-    "hilbert-10",
     "primitive-roots"
   ],
   "references": [
@@ -434,6 +416,8 @@
     "lineCount": 185,
     "axiomCount": 0,
     "theoremCount": 9,
+    "substantiveTheoremCount": 3,
+    "trivialSpecializations": 6,
     "definitionCount": 0
   }
 }


### PR DESCRIPTION
## Summary
- Added `substantiveTheoremCount` (3) and `trivialSpecializations` (6) to `leanFile` metadata, distinguishing the 3 substantive wrappers from the 6 one-line specializations/inferInstance calls
- Removed 3 purely thematic cross-references (godel-incompleteness, halting-problem, hilbert-10) that inflate apparent centrality — consistent with the sibling oq-04 entry's cross-reference trimming

## Context
Entry at quality 100 with 2 prior passes and all enricher review items resolved. These are minor metadata refinements for consistency and precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)