### PR TITLE
Enrich 10 entries: add theorem breakdowns

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -253,6 +253,9 @@
     "lineCount": 249,
     "axiomCount": 8,
     "theoremCount": 8,
-    "definitionCount": 15
+    "substantiveTheoremCount": 8,
+    "trivialSpecializations": 0,
+    "definitionCount": 15,
+    "namespace": null
   }
 }

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -305,6 +305,9 @@
     "lineCount": 280,
     "axiomCount": 6,
     "theoremCount": 22,
-    "definitionCount": 12
+    "substantiveTheoremCount": 22,
+    "trivialSpecializations": 0,
+    "definitionCount": 12,
+    "namespace": null
   }
 }


### PR DESCRIPTION
## Summary
Added `substantiveTheoremCount`, `trivialSpecializations`, and `namespace` fields to `leanFile` metadata for 10 entries:

| Entry | Theorems | Substantive | Trivial |
|-------|----------|-------------|---------|
| erdos-287 | 1 | 1 | 0 |
| erdos-331 | 5 | 5 | 0 |
| erdos-444 | 2 | 2 | 0 |
| erdos-616 | 3 | 3 | 0 |
| erdos-620 | 8 | 8 | 0 |
| erdos-623 | 13 | 13 | 0 |
| erdos-626 | 13 | 13 | 0 |
| erdos-636 | 8 | 8 | 0 |
| erdos-1040 | 8 | 8 | 0 |
| erdos-1049 | 22 | 22 | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)