### PR TITLE
Research: roth-theorem-k3 - Dirichlet-based proof restructuring

### DIFF
--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -1371,7 +1371,52 @@ private theorem density_increment_dirichlet {N : ℕ} (hN : 4 ≤ N)
       Nat.sqrt N ≤ M ∧ M < N ∧
       APFree B ∧
       (B.card : ℝ) ≥ (delta + delta ^ 2 / 100) * M := by
-  sorry
+  haveI : NeZero N := ⟨by omega⟩
+  have hN2 : 1 < N := by omega
+  -- Step 1: Get large Fourier coefficient
+  obtain ⟨r, hr, hfourier⟩ := fourier_large_coefficient hN2 A hAP delta hdelta hdensity
+  -- Step 2: Compute gcd and case split
+  set d := Nat.gcd (ZMod.val r) N
+  have hd_pos : 0 < d := Nat.pos_of_ne_zero (Nat.gcd_ne_zero_right (NeZero.ne N))
+  have hdN : d ∣ N := Nat.gcd_dvd_right _ _
+  have hd_dvd_r : d ∣ ZMod.val r := Nat.gcd_dvd_left _ _
+  have hval_pos : 0 < ZMod.val r := by
+    rw [Nat.pos_iff_ne_zero]; intro h; exact hr (by rwa [ZMod.val_eq_zero] at h)
+  have hd_lt_N : d < N := lt_of_le_of_lt (Nat.gcd_le_left N hval_pos) (ZMod.val_lt r)
+  set g := N / d
+  have hg_pos : 0 < g := Nat.div_pos (Nat.le_of_dvd (by omega) hdN) hd_pos
+  have hg_ge_two : 2 ≤ g := by
+    by_contra h; push_neg at h
+    have hg1 : g = 1 := by omega
+    have hgd : N / d * d = N := Nat.div_mul_cancel hdN
+    rw [show N / d = g from rfl, hg1, one_mul] at hgd; omega
+  have hgN : g ∣ N := Nat.div_dvd_of_dvd hdN
+  have hNg_eq : N / g = d := Nat.div_div_self hdN (by omega)
+  have hcompat : (N / g) ∣ ZMod.val r := hNg_eq ▸ hd_dvd_r
+  by_cases hd_large : Nat.sqrt N ≤ d
+  · -- CASE 1: gcd(val(r), N) ≥ √N → coset partition gives M = d ≥ √N
+    -- Apply coset density increment with this r
+    obtain ⟨j, hj, hdense⟩ := coset_density_increment hN2 A hAP delta hdelta hdensity
+      g hg_pos hgN r hr hfourier hcompat
+    have hM_pos : 0 < N / g := Nat.div_pos (Nat.le_of_dvd (by omega) hgN) hg_pos
+    have hM_lt_N : N / g < N := hNg_eq ▸ hd_lt_N
+    have hM_sqrt : Nat.sqrt N ≤ N / g := hNg_eq ▸ hd_large
+    have hMreal : (↑(N / g) : ℝ) = ↑N / ↑g :=
+      Nat.cast_div hgN (Nat.cast_ne_zero.mpr (by omega))
+    refine ⟨N / g, cosetRestrict A g hg_pos hgN j hj, hM_sqrt, hM_lt_N,
+      apFree_coset_restrict A hAP g hg_pos hgN j hj, ?_⟩
+    rw [hMreal]
+    calc (↑(cosetRestrict A g hg_pos hgN j hj).card : ℝ)
+        ≥ (delta + delta ^ 2 / 4) * (↑N / ↑g) := hdense
+      _ ≥ (delta + delta ^ 2 / 100) * (↑N / ↑g) := by
+          apply mul_le_mul_of_nonneg_right _ (by positivity)
+          nlinarith [sq_nonneg delta]
+  · -- CASE 2: gcd(val(r), N) < √N → need Dirichlet subprogression approach
+    -- Apply DirichletApproximation.dirichlet_approximation to
+    -- α = val(r)/N, Q = Nat.sqrt N. Get q ≤ Q with |qα - p| < 1/Q.
+    -- Subprogression partition with step q gives L = ⌊N/q⌋ ≥ √N pieces.
+    -- Approximate character constancy + density increment on densest piece.
+    sorry
 
 /-- Tower-of-squares threshold for Roth's theorem.
     roth_threshold 0 = 4, roth_threshold (k+1) = (roth_threshold k)².

--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -1351,125 +1351,149 @@ private theorem apFree_density_lt_two_thirds {N : ℕ} [NeZero N] (hN3 : 2 < N)
   have : 3 * (A.card : ℝ) ≤ 2 * (N : ℝ) := by exact_mod_cast h
   nlinarith
 
-/-- Extension of density_increment_lemma to N ≥ 1 for use in the iteration.
-    Delegates to the fully-verified density_increment_lemma when N ≥ 2.
+/-- Dirichlet-based density increment: uses Dirichlet's approximation theorem
+    to find subprogressions of ZMod N where the Fourier character ψ_r is
+    approximately constant. Unlike the coset-based density_increment_lemma
+    (which gives M = gcd(val(r), N), possibly 1 for prime N), this guarantees
+    M ≥ Nat.sqrt N ≥ 2 when N ≥ 4.
 
-    For N = 1 with delta + delta²/100 ≤ 1: uses M = 1, B = Finset.univ
-    (the unique element of ZMod 1). The remaining sorry is for the narrow
-    case N = 1, delta ∈ (0.99, 1] where delta + delta²/100 > 1. This case
-    is unreachable in the standard proof of Roth's theorem, which uses
-    Dirichlet's approximation theorem to ensure M ≥ √N at each descent
-    step, preventing the iteration from reaching N = 1 with high density.
-    Formalizing Dirichlet approximation would close this gap. -/
-private theorem density_increment_iter {N : ℕ} (hN : 0 < N) (A : Finset (ZMod N))
-    (hAP : APFree A) (delta : ℝ) (hdelta : 0 < delta)
+    The proof uses DirichletApproximation.dirichlet_approximation (fully proved)
+    applied to α = val(r)/N with Q = Nat.sqrt N. The Dirichlet output gives
+    q ≤ Q with |qα - p| < 1/Q. The partition into subprogressions of common
+    difference q yields pieces of length ≥ ⌊N/q⌋ ≥ ⌊N/Q⌋ ≥ Nat.sqrt N.
+    The large Fourier coefficient |Â(r)| ≥ δ²N/2 (from fourier_large_coefficient)
+    provides the density increment on the densest piece. -/
+private theorem density_increment_dirichlet {N : ℕ} (hN : 4 ≤ N)
+    (A : Finset (ZMod N)) (hAP : APFree A)
+    (delta : ℝ) (hdelta : 0 < delta)
     (hdensity : (A.card : ℝ) ≥ delta * N) :
     ∃ (M : ℕ) (B : Finset (ZMod M)),
-      0 < M ∧
+      Nat.sqrt N ≤ M ∧ M < N ∧
       APFree B ∧
       (B.card : ℝ) ≥ (delta + delta ^ 2 / 100) * M := by
-  by_cases hN2 : 1 < N
-  · obtain ⟨M, B, hMpos, _, hBAP, hBdens⟩ := density_increment_lemma hN2 A hAP delta hdelta hdensity
-    exact ⟨M, B, hMpos, hBAP, hBdens⟩
-  · -- N = 1: ZMod 1 has exactly one element
-    have hN1 : N = 1 := by omega
-    subst hN1
-    -- delta ≤ 1 since |A| ≤ 1 = N and |A| ≥ delta * 1 = delta
-    have hdelta_le : delta ≤ 1 := by
-      have : (A.card : ℝ) ≤ 1 := by exact_mod_cast card_le_nat A
-      simp only [Nat.cast_one, mul_one] at hdensity
-      linarith
-    by_cases hboost : delta + delta ^ 2 / 100 ≤ 1
-    · -- Easy case: delta + delta²/100 ≤ 1, use M = 1, B = Finset.univ
-      refine ⟨1, Finset.univ, Nat.one_pos, ?_, ?_⟩
-      · -- APFree on ZMod 1: vacuously true (ZMod 1 has one element, so d ≠ 0 is impossible)
-        intro a d hd
-        exact absurd (Subsingleton.elim d 0) hd
-      · -- |Finset.univ| = 1 ≥ (delta + delta²/100) * 1
-        simp only [Finset.card_univ, ZMod.card, Nat.cast_one, mul_one]
-        linarith
-    · -- Hard case: delta ∈ (0.99, 1] where delta + delta²/100 > 1 and N = 1.
-      -- This case is PROVABLY FALSE as stated: the conclusion requires
-      -- |B| ≥ (delta + delta²/100) * M > M, but |B| ≤ M always holds.
-      -- The hypotheses are consistent (A = {0} in ZMod 1 satisfies them).
-      --
-      -- FIX PATH: The standard proof (Tao-Vu Ch.10) uses Dirichlet's
-      -- approximation theorem to partition into subprogressions of length
-      -- L ≥ √N, ensuring M ≥ 2 at each descent step. This prevents the
-      -- iteration from reaching N = 1 with high density.
-      --
-      -- DirichletApproximation.lean already proves the key theorem:
-      --   ∃ p q, 1 ≤ q ∧ q ≤ Q ∧ |qα - p| < 1/Q
-      -- Integration requires:
-      -- 1. Dirichlet-based subprogression partition (~80 lines)
-      -- 2. Approximate character constancy on subprogressions (~60 lines)
-      -- 3. Density increment under approximate constancy (~60 lines)
-      -- 4. Modified density_increment_lemma guaranteeing M ≥ 2 (~20 lines)
-      sorry
+  sorry
 
-/-- After k iterations of density increment starting from density delta,
-    the density reaches at least delta + k * delta² / 100. -/
-private theorem density_iteration (delta : ℝ) (hdelta : 0 < delta) :
-    ∀ k : ℕ, ∀ N : ℕ, 0 < N →
+/-- Tower-of-squares threshold for Roth's theorem.
+    roth_threshold 0 = 4, roth_threshold (k+1) = (roth_threshold k)².
+    Ensures that after k Dirichlet-based density increments (each giving
+    M ≥ √N), the modulus stays ≥ 4 throughout the iteration. -/
+private def roth_threshold : ℕ → ℕ
+  | 0 => 4
+  | k + 1 => roth_threshold k ^ 2
+
+private theorem roth_threshold_ge_four : ∀ k, 4 ≤ roth_threshold k := by
+  intro k; induction k with
+  | zero => rfl
+  | succ k ih =>
+    show 4 ≤ roth_threshold k ^ 2
+    rw [sq]
+    calc 4 = 4 * 1 := by omega
+      _ ≤ roth_threshold k * 1 := Nat.mul_le_mul ih (by omega)
+      _ = roth_threshold k := by omega
+      _ ≤ roth_threshold k * roth_threshold k := Nat.le_mul_of_pos_right _ (by omega)
+
+/-- If N ≥ roth_threshold (k+1) = (roth_threshold k)², then Nat.sqrt N ≥ roth_threshold k. -/
+private theorem roth_threshold_sqrt {N k : ℕ} (h : roth_threshold (k + 1) ≤ N) :
+    roth_threshold k ≤ Nat.sqrt N := by
+  have hmul : roth_threshold k * roth_threshold k ≤ N := by
+    have : roth_threshold (k + 1) = roth_threshold k ^ 2 := rfl
+    rw [this, sq] at h; exact h
+  exact Nat.le_sqrt.mpr hmul
+
+/-- Iterated density increment via Dirichlet. After k+1 applications of
+    density_increment_dirichlet starting from N ≥ roth_threshold (k+1),
+    the density reaches ≥ d + (k+1)·d²/100. The roth_threshold tower
+    ensures N stays ≥ 4 at every step (since each step gives M ≥ √N
+    and the threshold tracks iterated square roots). -/
+private theorem density_chain :
+    ∀ k : ℕ, ∀ N : ℕ, roth_threshold (k + 1) ≤ N →
+    ∀ d : ℝ, 0 < d →
     ∀ A : Finset (ZMod N), APFree A →
-    (A.card : ℝ) ≥ (delta + k * delta ^ 2 / 100) * N →
+    (A.card : ℝ) ≥ d * ↑N →
     ∃ (M : ℕ) (B : Finset (ZMod M)),
       0 < M ∧ APFree B ∧
-      (B.card : ℝ) ≥ (delta + (k + 1) * delta ^ 2 / 100) * M := by
-  intro k N hN A hAP hdens
-  set d := delta + ↑k * delta ^ 2 / 100 with hd_def
-  have hd_pos : 0 < d := by positivity
-  obtain ⟨M, B, hMpos, hBAP, hBdens⟩ := density_increment_iter hN A hAP d hd_pos hdens
-  refine ⟨M, B, hMpos, hBAP, ?_⟩
-  have hd_ge_delta : d ≥ delta := by simp [hd_def]; positivity
-  have hd_sq : d ^ 2 ≥ delta ^ 2 := by nlinarith
-  calc (B.card : ℝ) ≥ (d + d ^ 2 / 100) * ↑M := hBdens
-    _ ≥ (delta + (↑k + 1) * delta ^ 2 / 100) * ↑M := by
-        apply mul_le_mul_of_nonneg_right _ (Nat.cast_nonneg M)
-        nlinarith
+      (B.card : ℝ) ≥ (d + (↑k + 1) * d ^ 2 / 100) * ↑M := by
+  intro k
+  induction k with
+  | zero =>
+    intro N hN d hd A hAP hdensity
+    have h4 : 4 ≤ N := le_trans (roth_threshold_ge_four 1) hN
+    obtain ⟨M, B, hM_sqrt, hM_lt, hBAP, hBdens⟩ :=
+      density_increment_dirichlet h4 A hAP d hd hdensity
+    have hM_pos : 0 < M := by
+      have : 2 ≤ Nat.sqrt N := Nat.le_sqrt.mpr (by omega)
+      omega
+    refine ⟨M, B, hM_pos, hBAP, ?_⟩
+    simp only [Nat.cast_zero, zero_add, one_mul]
+    exact hBdens
+  | succ k ih =>
+    intro N hN d hd A hAP hdensity
+    -- Apply density_increment_dirichlet to get (M, B) with density boost
+    have h4 : 4 ≤ N := le_trans (roth_threshold_ge_four (k + 2)) hN
+    obtain ⟨M, B, hM_sqrt, hM_lt, hBAP, hBdens⟩ :=
+      density_increment_dirichlet h4 A hAP d hd hdensity
+    -- M ≥ Nat.sqrt N ≥ roth_threshold (k+1) (from threshold property)
+    have hM_thresh : roth_threshold (k + 1) ≤ M :=
+      le_trans (roth_threshold_sqrt hN) hM_sqrt
+    -- Set d' := d + d²/100 (boosted density)
+    set d' := d + d ^ 2 / 100 with hd'_def
+    have hd'_pos : 0 < d' := by positivity
+    -- Apply IH with boosted density d'
+    obtain ⟨M', B', hM'_pos, hB'AP, hB'dens⟩ :=
+      ih M hM_thresh d' hd'_pos B hBAP hBdens
+    -- hB'dens: |B'| ≥ (d' + (k+1)*d'²/100) * M'
+    refine ⟨M', B', hM'_pos, hB'AP, ?_⟩
+    -- Show: d' + (k+1)*d'²/100 ≥ d + (k+2)*d²/100
+    -- Since d' = d + d²/100 ≥ d and d'² ≥ d²:
+    -- d' + (k+1)*d'²/100 ≥ d + d²/100 + (k+1)*d²/100 = d + (k+2)*d²/100
+    have hd'_ge : d ≤ d' := by simp [hd'_def]; positivity
+    have hd'_sq : d ^ 2 ≤ d' ^ 2 := by nlinarith [sq_nonneg (d' - d)]
+    have h_coeff : (↑k + 1 : ℝ) * d ^ 2 ≤ (↑k + 1) * d' ^ 2 :=
+      mul_le_mul_of_nonneg_left hd'_sq (by positivity)
+    -- Need: |B'| ≥ (d + (↑(k+1)+1) * d²/100) * M'
+    -- push_cast normalizes ↑(k+1) to ↑k+1
+    push_cast at hB'dens ⊢
+    -- Now goal has ↑k+1+1 and hB'dens has ↑k+1
+    calc (B'.card : ℝ) ≥ (d' + (↑k + 1) * d' ^ 2 / 100) * ↑M' := hB'dens
+      _ ≥ (d + (↑k + 1 + 1) * d ^ 2 / 100) * ↑M' := by
+        apply mul_le_mul_of_nonneg_right _ (Nat.cast_nonneg M')
+        nlinarith [hd'_def]
 
 /-- **Roth's Theorem**: r₃(N) = o(N).
     For every delta > 0, there exists N₀ such that for all N ≥ N₀, every
     subset A ⊆ Z/NZ with |A| ≥ delta * N contains a 3-term arithmetic
     progression.
 
-    The proof iterates the density increment: each time the set has no
-    3-AP, its density increases by at least delta²/100 on a subprogression.
-    After K = ⌈100/delta²⌉ steps, the density would exceed 1, contradicting
-    the fact that any subset of Z/MZ has at most M elements. -/
+    The proof iterates the Dirichlet-based density increment: each time the
+    set has no 3-AP, its density increases by at least delta²/100 on a
+    subprogression of size ≥ √N. After K+1 ≈ 100/delta² steps, the density
+    exceeds 1, contradicting |A| ≤ N. The Dirichlet-based increment prevents
+    the iteration from reaching N = 1 with high density (the bug in the
+    coset-based approach for prime N).
+
+    N₀ is a tower of squares: 4, 16, 256, 65536, ... of height K+1. -/
 theorem roth_density_bound (delta : ℝ) (hdelta : 0 < delta) (_hdelta1 : delta ≤ 1) :
     ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ → ∀ A : Finset (ZMod N),
       (A.card : ℝ) ≥ delta * N → ¬APFree A := by
-  refine ⟨1, fun N hN A hdensity hAP => ?_⟩
-  have hNpos : 0 < N := by omega
-  have chain : ∀ k : ℕ, ∃ (M : ℕ) (B : Finset (ZMod M)),
-      0 < M ∧ APFree B ∧ (B.card : ℝ) ≥ (delta + ↑k * delta ^ 2 / 100) * ↑M := by
-    intro k
-    induction k with
-    | zero =>
-      simp only [Nat.cast_zero, zero_mul, zero_div, add_zero]
-      exact ⟨N, A, hNpos, hAP, hdensity⟩
-    | succ k ih =>
-      obtain ⟨M, B, hMpos, hBAP, hBdens⟩ := ih
-      obtain ⟨M', B', hM'pos, hB'AP, hB'dens⟩ :=
-        density_iteration delta hdelta k M hMpos B hBAP hBdens
-      refine ⟨M', B', hM'pos, hB'AP, ?_⟩
-      push_cast at hB'dens ⊢
-      linarith
+  -- Choose K such that delta + (K+1)*delta²/100 > 1
   obtain ⟨K, hK⟩ := exists_nat_gt (100 / delta ^ 2)
-  obtain ⟨M, B, hMpos, _, hBdens⟩ := chain K
+  refine ⟨roth_threshold (K + 1), fun N hN A hdensity hAP => ?_⟩
+  -- Apply density_chain: K+1 Dirichlet-based density increments
+  obtain ⟨M, B, hMpos, _, hBdens⟩ :=
+    density_chain K N hN delta hdelta A hAP hdensity
+  -- Density ≥ delta + (K+1)*delta²/100 > 1
   haveI : NeZero M := ⟨by omega⟩
   have hd2 : delta ^ 2 > 0 := by positivity
-  have h_clear : (100 : ℝ) < ↑K * delta ^ 2 := by
+  have h_exceed : delta + (↑K + 1) * delta ^ 2 / 100 > 1 := by
     have h1 : 100 / delta ^ 2 * delta ^ 2 < ↑K * delta ^ 2 :=
       mul_lt_mul_of_pos_right hK hd2
     have h2 : 100 / delta ^ 2 * delta ^ 2 = 100 := by field_simp
     linarith
-  have hgt1 : delta + ↑K * delta ^ 2 / 100 > 1 := by linarith
+  -- |B| > M, contradicting |B| ≤ M
   have hMcast : (0 : ℝ) < ↑M := Nat.cast_pos.mpr hMpos
   have hBgt : (B.card : ℝ) > ↑M := by
-    calc (B.card : ℝ) ≥ (delta + ↑K * delta ^ 2 / 100) * ↑M := hBdens
-      _ > 1 * ↑M := mul_lt_mul_of_pos_right hgt1 hMcast
+    calc (B.card : ℝ) ≥ (delta + (↑K + 1) * delta ^ 2 / 100) * ↑M := hBdens
+      _ > 1 * ↑M := mul_lt_mul_of_pos_right h_exceed hMcast
       _ = ↑M := one_mul _
   linarith [card_le_nat_real B]
 


### PR DESCRIPTION
## Summary
- Restructured Roth's Theorem proof to use Dirichlet-based density increment, moving the sorry from a **provably FALSE** statement to a **provably TRUE** one
- The old sorry (N=1, delta>0.99 in `density_increment_iter`) was mathematically impossible to close — the theorem statement was wrong for those inputs
- The new sorry (`density_increment_dirichlet`) is provable using the already-proved `DirichletApproximation.dirichlet_approximation`

## Progress
- **Added** `density_increment_dirichlet`: Dirichlet-based density increment guaranteeing M ≥ √N (sorry, provably true)
- **Added** `roth_threshold`: tower-of-squares function (4, 16, 256, ...) ensuring N stays ≥ 4 throughout iteration
- **Added** `density_chain`: iterated density increment with universally quantified density parameter
- **Restructured** `roth_density_bound`: uses correct N₀ = roth_threshold(K+1) instead of wrong N₀ = 1
- **Removed** `density_increment_iter` (had FALSE sorry) and `density_iteration` (depended on it)

## Findings
- The coset-based density increment gives M = gcd(val(r), N) which equals 1 for prime N — this is why the iteration could reach N=1 with high density
- Dirichlet's approximation theorem guarantees subprogression size ≥ √N, preventing this pathological descent
- The tower-of-squares threshold tracks iterated square roots to ensure N ≥ 4 at every step

## Status
**Outcome**: progress (sorry moved from FALSE → TRUE)
**File**: 0 axioms, 1 sorry, 1500 lines, builds clean
**Next Steps**: Prove `density_increment_dirichlet` (~200 lines: subprogression partition + approximate character constancy + density increment)

🤖 Generated by researcher-2