### PR TITLE
Create lean-mechanic agent (#5525)

### DIFF
--- a/.claude/commands/lean-mechanic.md
+++ b/.claude/commands/lean-mechanic.md
@@ -1,0 +1,225 @@
+# Lean Mechanic (Repair Agent)
+
+You are a repair specialist for the {{workspace}} repository. Your sole responsibility is fixing issues discovered by auditors, peer reviewers, and automated integrity checks. You close the gap between finding problems and fixing them.
+
+> "Measure twice, cut once." -- Carpenter's proverb
+
+Your job is not to discover new issues. Your job is to pick up existing findings and apply targeted, minimal repairs -- fixing metadata, correcting Lean code, or creating Aristotle companion files so the deployer can ship clean results.
+
+## Work Sources (Priority Order)
+
+1. **Auditor issues** -- GitHub issues titled "Gallery integrity: ..." filed by the auditor agent (label: `loom:auditor`)
+2. **Unaddressed peer review comments** -- Open PR review comments that request changes but have not been acted on
+3. **Sorry-heavy proofs** -- Gallery proofs with high sorry counts that could benefit from Aristotle companion files
+
+## Triage Decision Tree
+
+After claiming a work item, classify the required fix:
+
+```
+Is the problem in meta.json only?
+  YES --> Metadata Fix (fastest path)
+  NO  --> Does the Lean file need code changes?
+            YES --> Is it a sorry that Aristotle could prove?
+                      YES --> Create Aristotle Companion File
+                      NO  --> Lean Code Repair
+            NO  --> Re-read the issue; you may have misunderstood it
+```
+
+### Fix Type A: Metadata Fix
+
+Update `src/data/proofs/<slug>/meta.json` to match reality in the Lean source file.
+
+Common repairs:
+- `sorries` count does not match actual sorry count in `.lean` file
+- `axiomCount` does not match actual axiom + structure-encoded assumption count
+- `status` is `"verified"` but there are sorries or axioms
+- `badge` is `"original"` but core result comes from Mathlib
+- `title` or `overview` overstates what the proof achieves
+
+**Validation**: After editing meta.json, run:
+```bash
+pnpm build 2>&1 | head -50
+```
+
+### Fix Type B: Lean Code Repair
+
+Fix issues in `proofs/Proofs/<Name>.lean` files. This includes:
+- Removing dead code or unreachable sorry branches
+- Fixing type errors introduced by Mathlib version bumps
+- Correcting namespace or import issues
+- Replacing True-stub theorems with meaningful statements
+
+**NEVER run `lake build` directly.** Use the Docker wrapper:
+```bash
+./proofs/scripts/docker-build.sh Proofs.YourProof
+```
+
+### Fix Type C: Aristotle Companion File
+
+For proofs with routine sorries that Aristotle could prove, create a companion file:
+
+```lean
+/-
+  Aristotle targets for <Name>
+  Routine supporting lemmas for automated proof search.
+  See <Name>.lean for the main formalization.
+-/
+import Mathlib
+
+namespace <Namespace>
+
+-- Routine lemmas (NOT the main open conjecture)
+lemma helper_bound : ... := by sorry
+lemma routine_calc : ... := by sorry
+
+end <Namespace>
+```
+
+**Pre-submission checklist** (companion files only):
+- [ ] No `def ... := sorry` (definition sorries -- Aristotle skips these)
+- [ ] No `axiom` declarations (convert to `theorem ... := by sorry`)
+- [ ] No `theorem ... : True` placeholders
+- [ ] No `/-!` docstring sections (use `/-` instead)
+- [ ] No open conjectures (Aristotle cannot discover new proofs)
+
+## Workflow (Repeat Every Cycle)
+
+### 1. Check for stop signal
+
+```bash
+if [[ -f ".loom/signals/stop-mechanic" ]] || [[ -f ".loom/signals/stop-all" ]]; then
+    echo "Stop signal received. Exiting."
+    exit 0
+fi
+```
+
+### 2. Sync with main
+
+```bash
+git fetch origin main 2>/dev/null
+git reset --hard origin/main 2>/dev/null
+```
+
+### 3. Find work
+
+```bash
+# Priority 1: Auditor issues
+gh issue list --label="loom:auditor" --state=open --limit=10 --json number,title
+
+# Priority 2: Unaddressed peer review comments
+gh pr list --state=open --json number,title,reviewDecision \
+  --jq '.[] | select(.reviewDecision == "CHANGES_REQUESTED")'
+
+# Priority 3: Sorry-heavy proofs (check gallery data)
+# Look for proofs with sorries > 3 that lack Aristotle companion files
+```
+
+### 4. Claim work (branch-based claiming)
+
+To avoid collisions between mechanic slots, use a branch-based claim pattern:
+
+```bash
+# Create a unique branch for this fix
+ISSUE_NUM=<number>
+BRANCH="fix/mechanic-${ISSUE_NUM}"
+git checkout -b "$BRANCH" origin/main
+
+# If branch already exists on remote, someone else claimed it -- skip
+git ls-remote --heads origin "$BRANCH" 2>/dev/null | grep -q "$BRANCH" && echo "Already claimed" && continue
+```
+
+### 5. Apply fix
+
+Follow the triage decision tree above. Make the minimal change needed.
+
+### 6. Validate
+
+```bash
+# For metadata fixes
+pnpm build 2>&1 | head -50
+
+# For Lean code fixes (NEVER run lake build directly)
+./proofs/scripts/docker-build.sh Proofs.YourProof
+
+# For companion files
+grep -n "def.*:=.*sorry" proofs/Proofs/*Aristotle.lean     # Should find nothing
+grep -n "^axiom " proofs/Proofs/*Aristotle.lean             # Should find nothing
+```
+
+### 7. Submit PR
+
+```bash
+git add -A
+git commit -m "Fix: <brief description> (#ISSUE_NUM)"
+git push -u origin "$BRANCH"
+
+gh pr create \
+  --title "Fix: <brief description>" \
+  --body "$(cat <<'PREOF'
+## Fix
+
+<one-line description>
+
+## Evidence
+
+**Before**: <what was wrong>
+**After**: <what is now correct>
+
+Closes #ISSUE_NUM
+
+---
+Automated fix by lean-mechanic agent.
+PREOF
+)"
+```
+
+**Do NOT add `loom:review-requested`.** The deployer merges math agent PRs directly.
+
+### 8. Clean up and wait
+
+```bash
+git checkout main
+git branch -D "$BRANCH" 2>/dev/null || true
+
+echo "Next cycle in 15 minutes..."
+sleep 15m
+```
+
+### 9. Repeat from step 1
+
+## Scope Discipline
+
+- **One fix per PR.** Do not bundle unrelated fixes.
+- **Minimal diffs.** Change only what the issue describes. If you notice adjacent problems, file a new issue instead of expanding scope.
+- **Do not re-audit.** Trust the auditor's findings. Your job is to fix, not to second-guess.
+- **Do not refactor.** If the code works but is ugly, that is not your problem.
+
+## Terminal Probe Protocol
+
+When you receive a probe command, respond with:
+
+```
+AGENT:LeanMechanic:repairing-gallery
+```
+
+Or if idle:
+
+```
+AGENT:LeanMechanic:idle-awaiting-repairs
+```
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration.**
+
+After completing your repair iteration, execute:
+
+```
+/clear
+```
+
+This is important because:
+- Each iteration is independent (always checking latest main)
+- Lean source data is large and does not need to carry over
+- Reduces API costs significantly over long-running daemon sessions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,11 @@ This project uses **two distinct AI agent orchestration systems** for different 
 | **Deployer** | Merges PRs, syncs data, deploys website to Cloudflare | Autonomous (30min) |
 | **Peer Reviewer** | Deep qualitative review of gallery proofs: evaluates substance, originality, framing | On-demand |
 | **Auditor** | Validates gallery integrity: checks proof claims match Lean source files | Autonomous (10min) |
+| **Mechanic** | Repairs issues found by auditors and peer reviewers: metadata, Lean code, companion files | Autonomous (15min) |
 | **Tester** | Tests random proof pages on the live site, files issues on failure | Autonomous (30min) |
 | **Herald** | Posts noteworthy research results to Mathstodon | Autonomous (6h) |
 
-**Managed by `/lean-daemon`**: Enricher, Aristotle, Researcher, Auditor, Seeker, Deployer, Tester, Herald
+**Managed by `/lean-daemon`**: Enricher, Aristotle, Researcher, Auditor, Mechanic, Seeker, Deployer, Tester, Herald
 **Managed separately**: Erdos Enhancer (`make enhance`, `scripts/erdos/`)
 
 **Invoke via**: `/enricher`, `/aristotle`, `/lean-research`, `/lean-scout`, `/lean-seeker`, `/lean-deploy`, `/peer-review`
@@ -138,6 +139,7 @@ The `/lean-daemon` skill provides a unified interface to start, stop, and scale 
 | Aristotle | 1 | 2 |
 | Researcher | 2 | 5 |
 | Auditor | 3 | 3 |
+| Mechanic | 1 | 3 |
 | Seeker | 1 | 1 |
 | Deployer | 1 | 1 |
 | Tester | 1 | 1 |

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -52,6 +52,7 @@ DEFAULT_DEPLOYER=1
 DEFAULT_AUDITOR=1
 DEFAULT_TESTER=1
 DEFAULT_HERALD=1
+DEFAULT_MECHANIC=1
 
 # Max pool sizes
 MAX_ENRICHER=5
@@ -62,6 +63,7 @@ MAX_SEEKER=1
 MAX_DEPLOYER=1
 MAX_TESTER=1
 MAX_HERALD=1
+MAX_MECHANIC=3
 
 # Helper: Print usage
 usage() {
@@ -87,6 +89,7 @@ Start Options:
   --auditor N            Number of Auditors (default: $DEFAULT_AUDITOR, max: $MAX_AUDITOR)
   --tester N             Number of Testers (default: $DEFAULT_TESTER, max: $MAX_TESTER)
   --herald N             Number of Heralds (default: $DEFAULT_HERALD, max: $MAX_HERALD)
+  --mechanic N           Number of Mechanics (default: $DEFAULT_MECHANIC, max: $MAX_MECHANIC)
 
 Stop Options:
   <type>                 Stop only agents of this type (enricher, aristotle, etc.)
@@ -103,6 +106,7 @@ Daemon Options:
   --deployer N           Target Deployer count (default: $DEFAULT_DEPLOYER, max: $MAX_DEPLOYER)
   --tester N             Target Tester count (default: $DEFAULT_TESTER, max: $MAX_TESTER)
   --herald N             Target Herald count (default: $DEFAULT_HERALD, max: $MAX_HERALD)
+  --mechanic N           Target Mechanic count (default: $DEFAULT_MECHANIC, max: $MAX_MECHANIC)
 
 Agent Types:
   enricher    Enriches proof gallery entries with deeper annotations and commentary
@@ -113,6 +117,7 @@ Agent Types:
   deployer    Merges PRs and deploys website
   tester      Tests random proof pages on the live site
   herald      Posts noteworthy results to Mathstodon
+  mechanic    Repairs issues found by auditors and peer reviewers
 
 Examples:
   $0 start                              # Start with defaults
@@ -154,6 +159,7 @@ init_state() {
     local deployer="${6:-$DEFAULT_DEPLOYER}"
     local tester="${7:-$DEFAULT_TESTER}"
     local herald="${8:-$DEFAULT_HERALD}"
+    local mechanic="${9:-$DEFAULT_MECHANIC}"
 
     mkdir -p "$(dirname "$STATE_FILE")"
 
@@ -177,6 +183,7 @@ init_state() {
         --argjson deployer "$deployer" \
         --argjson tester "$tester" \
         --argjson herald "$herald" \
+        --argjson mechanic "$mechanic" \
         --argjson prev_stats "$prev_stats" \
         '{
             started_at: $started_at,
@@ -189,7 +196,8 @@ init_state() {
                 seeker: $seeker,
                 deployer: $deployer,
                 tester: $tester,
-                herald: $herald
+                herald: $herald,
+                mechanic: $mechanic
             },
             agents: {},
             session_stats: (
@@ -290,6 +298,16 @@ get_sessions_for_type() {
                 sessions+=("herald-agent")
             fi
             ;;
+        mechanic)
+            for i in 1 2 3; do
+                if tmux has-session -t "mechanic-$i" 2>/dev/null; then
+                    sessions+=("mechanic-$i")
+                fi
+            done
+            if tmux has-session -t "mechanic-agent" 2>/dev/null; then
+                sessions+=("mechanic-agent")
+            fi
+            ;;
     esac
 
     if [[ ${#sessions[@]} -gt 0 ]]; then
@@ -331,6 +349,9 @@ signal_stop_session() {
             ;;
         herald)
             touch "$SIGNALS_DIR/stop-herald"
+            ;;
+        mechanic)
+            touch "$SIGNALS_DIR/stop-mechanic"
             ;;
     esac
 }
@@ -406,6 +427,7 @@ cmd_start() {
     local auditor=$DEFAULT_AUDITOR
     local tester=$DEFAULT_TESTER
     local herald=$DEFAULT_HERALD
+    local mechanic=$DEFAULT_MECHANIC
 
     # Apply time-based schedule (overrides defaults before CLI args)
     apply_schedule
@@ -443,6 +465,10 @@ cmd_start() {
                 ;;
             --herald)
                 herald="$2"
+                shift 2
+                ;;
+            --mechanic)
+                mechanic="$2"
                 shift 2
                 ;;
             *)
@@ -486,6 +512,10 @@ cmd_start() {
         echo -e "${YELLOW}Warning: Herald count $herald exceeds max $MAX_HERALD, using $MAX_HERALD${NC}"
         herald=$MAX_HERALD
     fi
+    if [[ $mechanic -gt $MAX_MECHANIC ]]; then
+        echo -e "${YELLOW}Warning: Mechanic count $mechanic exceeds max $MAX_MECHANIC, using $MAX_MECHANIC${NC}"
+        mechanic=$MAX_MECHANIC
+    fi
 
     echo -e "${BOLD}Starting Lean Genius Mathematical Orchestration${NC}"
     echo ""
@@ -498,13 +528,14 @@ cmd_start() {
     echo "  Deployers: $deployer"
     echo "  Testers: $tester"
     echo "  Heralds: $herald"
+    echo "  Mechanics: $mechanic"
     echo ""
 
     # Migrate state file from old location if needed
     migrate_state_file
 
     # Initialize state
-    init_state "$enricher" "$aristotle" "$researcher" "$auditor" "$seeker" "$deployer" "$tester" "$herald"
+    init_state "$enricher" "$aristotle" "$researcher" "$auditor" "$seeker" "$deployer" "$tester" "$herald" "$mechanic"
 
     # Start agents
     local started=0
@@ -571,6 +602,17 @@ cmd_start() {
             ./scripts/auditor/launch-agent.sh &
             sleep 1
             echo -e "${GREEN}\xe2\x9c\x93 Auditor agent launched${NC}"
+            started=$((started + 1))
+        fi
+    fi
+
+    # Mechanic
+    if [[ $mechanic -gt 0 ]]; then
+        echo -e "${BLUE}Starting Mechanic agent...${NC}"
+        if check_script "./scripts/mechanic/launch-agent.sh"; then
+            ./scripts/mechanic/launch-agent.sh &
+            sleep 1
+            echo -e "${GREEN}✓ Mechanic agent launched${NC}"
             started=$((started + 1))
         fi
     fi
@@ -648,6 +690,15 @@ get_all_agent_sessions() {
     # Herald
     if tmux has-session -t "herald-agent" 2>/dev/null; then
         sessions+=("herald-agent")
+    fi
+    # Mechanic
+    for i in 1 2 3; do
+        if tmux has-session -t "mechanic-$i" 2>/dev/null; then
+            sessions+=("mechanic-$i")
+        fi
+    done
+    if tmux has-session -t "mechanic-agent" 2>/dev/null; then
+        sessions+=("mechanic-agent")
     fi
     if [[ ${#sessions[@]} -gt 0 ]]; then
         printf '%s\n' "${sessions[@]}"
@@ -814,7 +865,7 @@ is_polling_agent() {
     local session="$1"
     local agent_type
     agent_type=$(get_agent_type "$session")
-    [[ "$agent_type" == "deployer" || "$agent_type" == "seeker" || "$agent_type" == "auditor" || "$agent_type" == "tester" || "$agent_type" == "herald" ]]
+    [[ "$agent_type" == "deployer" || "$agent_type" == "seeker" || "$agent_type" == "auditor" || "$agent_type" == "tester" || "$agent_type" == "herald" || "$agent_type" == "mechanic" ]]
 }
 
 # Helper: Get consecutive failure count from agent log
@@ -829,6 +880,7 @@ get_consecutive_failures() {
         seeker-agent) log_file="$log_dir/seeker.log" ;;
         auditor-agent) log_file="$log_dir/auditor.log" ;;
         herald-agent) log_file="$log_dir/herald.log" ;;
+        mechanic-*) log_file="$log_dir/${session}.log" ;;
         aristotle-agent) log_file="$log_dir/aristotle.log" ;;
         tester-agent) log_file="$log_dir/tester-agent.log" ;;
         *) echo "0"; return ;;
@@ -1244,6 +1296,9 @@ apply_schedule() {
     new_val=$(echo "$pools" | jq -r '.herald // empty' 2>/dev/null)
     [[ -n "$new_val" ]] && herald=$(( new_val > MAX_HERALD ? MAX_HERALD : new_val ))
 
+    new_val=$(echo "$pools" | jq -r '.mechanic // empty' 2>/dev/null)
+    [[ -n "$new_val" ]] && mechanic=$(( new_val > MAX_MECHANIC ? MAX_MECHANIC : new_val ))
+
     daemon_log "INFO" "Schedule: window=$window_name (${current_time} ${tz}), targets: enricher=$enricher, researcher=$researcher, aristotle=$aristotle"
 
     # Update state file config to reflect scheduled values
@@ -1281,6 +1336,7 @@ get_agent_type() {
         deployer)         echo "deployer" ;;
         tester-agent)     echo "tester" ;;
         herald-agent)     echo "herald" ;;
+        mechanic-*)       echo "mechanic" ;;
         *)                echo "unknown" ;;
     esac
 }
@@ -1452,6 +1508,15 @@ _do_respawn_agent() {
                 daemon_log "WARN" "Cannot respawn herald: script not found"
             fi
             ;;
+        mechanic)
+            if check_script "./scripts/mechanic/launch-agent.sh" 2>/dev/null; then
+                SESSION_NAME="$session" ./scripts/mechanic/launch-agent.sh &
+                sleep 1
+                daemon_log "INFO" "Mechanic agent respawned (session: $session)"
+            else
+                daemon_log "WARN" "Cannot respawn mechanic: script not found"
+            fi
+            ;;
         *)
             daemon_log "WARN" "Unknown agent type for session: $session"
             ;;
@@ -1608,6 +1673,7 @@ cmd_daemon() {
     local auditor=$DEFAULT_AUDITOR
     local tester=$DEFAULT_TESTER
     local herald=$DEFAULT_HERALD
+    local mechanic=$DEFAULT_MECHANIC
     local monitor_only=false
 
     # Apply time-based schedule (overrides defaults before CLI args)
@@ -1656,6 +1722,10 @@ cmd_daemon() {
                 herald="$2"
                 shift 2
                 ;;
+            --mechanic)
+                mechanic="$2"
+                shift 2
+                ;;
             *)
                 echo -e "${RED}Unknown daemon option: $1${NC}" >&2
                 usage
@@ -1694,7 +1764,7 @@ cmd_daemon() {
     trap 'daemon_log "INFO" "Received SIGINT"; exit 0' INT
 
     daemon_log "INFO" "Starting daemon (PID $$, interval ${interval}s, monitor_only=$monitor_only)"
-    daemon_log "INFO" "Pool config: enricher=$enricher, aristotle=$aristotle, researcher=$researcher, auditor=$auditor, seeker=$seeker, deployer=$deployer, tester=$tester, herald=$herald"
+    daemon_log "INFO" "Pool config: enricher=$enricher, aristotle=$aristotle, researcher=$researcher, auditor=$auditor, seeker=$seeker, deployer=$deployer, tester=$tester, herald=$herald, mechanic=$mechanic"
 
     if [[ "$monitor_only" == "true" ]]; then
         daemon_log "INFO" "Monitor-only mode: skipping agent startup, monitoring existing sessions"
@@ -1717,7 +1787,7 @@ cmd_daemon() {
         fi
     else
         # Start initial agents via cmd_start
-        cmd_start --enricher "$enricher" --aristotle "$aristotle" --researcher "$researcher" --auditor "$auditor" --seeker "$seeker" --deployer "$deployer" --tester "$tester" --herald "$herald"
+        cmd_start --enricher "$enricher" --aristotle "$aristotle" --researcher "$researcher" --auditor "$auditor" --seeker "$seeker" --deployer "$deployer" --tester "$tester" --herald "$herald" --mechanic "$mechanic"
     fi
 
     local cycle_count=0
@@ -1827,7 +1897,7 @@ cmd_daemon() {
 
         # 2a-post. Sweep for orphaned claude processes (detached from any tmux session)
         local orphan_pids
-        orphan_pids=$(ps aux | grep '[c]laude -p.*\(researcher\|enricher\|deployer\|seeker\|aristotle\|auditor\)' | awk '$7 == "??" {print $2}')
+        orphan_pids=$(ps aux | grep '[c]laude -p.*\(researcher\|enricher\|deployer\|seeker\|aristotle\|auditor\|mechanic\)' | awk '$7 == "??" {print $2}')
         if [[ -n "$orphan_pids" ]]; then
             local orphan_count
             orphan_count=$(echo "$orphan_pids" | wc -l | tr -d ' ')
@@ -1850,12 +1920,13 @@ cmd_daemon() {
             auditor=$(jq -r '.config.auditor // 0' "$STATE_FILE" 2>/dev/null || echo "$auditor")
             deployer=$(jq -r '.config.deployer // 0' "$STATE_FILE" 2>/dev/null || echo "$deployer")
             herald=$(jq -r '.config.herald // 0' "$STATE_FILE" 2>/dev/null || echo "$herald")
+            mechanic=$(jq -r '.config.mechanic // 0' "$STATE_FILE" 2>/dev/null || echo "$mechanic")
         fi
 
         # Apply time-based schedule overrides
         apply_schedule
 
-        local enricher_active=0 researcher_active=0 aristotle_active=0 auditor_active=0 seeker_active=0 deployer_active=0 herald_active=0
+        local enricher_active=0 researcher_active=0 aristotle_active=0 auditor_active=0 seeker_active=0 deployer_active=0 herald_active=0 mechanic_active=0
         for i in $(seq 1 $MAX_ENRICHER); do
             tmux has-session -t "enricher-$i" 2>/dev/null && enricher_active=$((enricher_active + 1))
         done
@@ -1867,6 +1938,10 @@ cmd_daemon() {
         tmux has-session -t "seeker-agent" 2>/dev/null && seeker_active=1
         tmux has-session -t "deployer" 2>/dev/null && deployer_active=1
         tmux has-session -t "herald-agent" 2>/dev/null && herald_active=1
+        for i in 1 2 3; do
+            tmux has-session -t "mechanic-$i" 2>/dev/null && mechanic_active=$((mechanic_active + 1))
+        done
+        tmux has-session -t "mechanic-agent" 2>/dev/null && mechanic_active=$((mechanic_active + 1))
 
         if [[ $enricher_active -lt $enricher ]]; then
             local missing_enricher=$((enricher - enricher_active))
@@ -1934,6 +2009,22 @@ cmd_daemon() {
             fi
         fi
 
+        if [[ $mechanic_active -lt $mechanic ]]; then
+            local missing_mech=$((mechanic - mechanic_active))
+            daemon_log "INFO" "Pool gap: mechanic has $mechanic_active/$mechanic, spawning $missing_mech"
+            for i in 1 2 3; do
+                [[ $missing_mech -le 0 ]] && break
+                if ! tmux has-session -t "mechanic-$i" 2>/dev/null; then
+                    if is_cooldown_elapsed "mechanic-$i"; then
+                        if respawn_agent "mechanic-$i"; then
+                            total_respawns=$((total_respawns + 1))
+                            missing_mech=$((missing_mech - 1))
+                        fi
+                    fi
+                fi
+            done
+        fi
+
         # 3. Work queue assessment (with timeout protection)
         local queue_stats
         queue_stats=$(get_work_queue_stats)
@@ -1986,13 +2077,13 @@ cmd_stop() {
                 force=true
                 shift
                 ;;
-            enricher|aristotle|researcher|auditor|seeker|deployer|herald)
+            enricher|aristotle|researcher|auditor|seeker|deployer|herald|mechanic)
                 agent_type="$1"
                 shift
                 ;;
             *)
                 echo -e "${RED}Unknown stop option: $1${NC}" >&2
-                echo "Usage: $0 stop [enricher|aristotle|researcher|auditor|seeker|deployer|herald] [--force]"
+                echo "Usage: $0 stop [enricher|aristotle|researcher|auditor|seeker|deployer|herald|mechanic] [--force]"
                 exit 1
                 ;;
         esac
@@ -2044,7 +2135,7 @@ cmd_stop() {
         # Safety net: kill any remaining agent sessions
         echo -e "${BLUE}Catch-all: cleaning remaining agent sessions...${NC}"
         local remaining_sessions
-        remaining_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(enricher-|researcher-|aristotle-agent$|auditor-agent$|seeker-agent$|deployer$|herald-agent$|tester-agent$)' || true)
+        remaining_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(enricher-|researcher-|mechanic-|aristotle-agent$|auditor-agent$|mechanic-agent$|seeker-agent$|deployer$|herald-agent$|tester-agent$)' || true)
         if [[ -n "$remaining_sessions" ]]; then
             while IFS= read -r session; do
                 echo -e "  Killing stale session: $session"
@@ -2055,7 +2146,7 @@ cmd_stop() {
         # Sweep for orphaned claude processes that survived session destruction
         echo -e "${BLUE}Sweeping orphaned claude processes...${NC}"
         local orphan_pids
-        orphan_pids=$(ps aux | grep '[c]laude -p.*\(researcher\|enricher\|deployer\|seeker\|aristotle\|auditor\)' | awk '$7 == "??" {print $2}')
+        orphan_pids=$(ps aux | grep '[c]laude -p.*\(researcher\|enricher\|deployer\|seeker\|aristotle\|auditor\|mechanic\)' | awk '$7 == "??" {print $2}')
         if [[ -n "$orphan_pids" ]]; then
             local orphan_count
             orphan_count=$(echo "$orphan_pids" | wc -l | tr -d ' ')
@@ -2064,7 +2155,7 @@ cmd_stop() {
             sleep 1
             # Force-kill any that didn't exit gracefully
             local remaining_orphans
-            remaining_orphans=$(ps aux | grep '[c]laude -p.*\(researcher\|enricher\|deployer\|seeker\|aristotle\|auditor\)' | awk '$7 == "??" {print $2}')
+            remaining_orphans=$(ps aux | grep '[c]laude -p.*\(researcher\|enricher\|deployer\|seeker\|aristotle\|auditor\|mechanic\)' | awk '$7 == "??" {print $2}')
             if [[ -n "$remaining_orphans" ]]; then
                 echo "$remaining_orphans" | xargs kill -9 2>/dev/null || true
             fi
@@ -2119,6 +2210,9 @@ cmd_stop() {
 
         echo -e "${BLUE}Signaling Auditor agent...${NC}"
         touch "$SIGNALS_DIR/stop-auditor" 2>/dev/null || true
+
+        echo -e "${BLUE}Signaling Mechanic agent(s)...${NC}"
+        touch "$SIGNALS_DIR/stop-mechanic" 2>/dev/null || true
 
         echo -e "${BLUE}Signaling Seeker agent...${NC}"
         touch "$SIGNALS_DIR/stop-seeker" 2>/dev/null || true
@@ -2224,6 +2318,11 @@ cmd_stop_type() {
             herald)
                 if [[ -x "./scripts/herald/launch-agent.sh" ]]; then
                     ./scripts/herald/launch-agent.sh --graceful-stop 2>/dev/null || true
+                fi
+                ;;
+            mechanic)
+                if [[ -x "./scripts/mechanic/launch-agent.sh" ]]; then
+                    ./scripts/mechanic/launch-agent.sh --graceful-stop 2>/dev/null || true
                 fi
                 ;;
         esac
@@ -2338,6 +2437,26 @@ cmd_spawn() {
                 echo -e "${GREEN}✓ Auditor spawned (legacy slot)${NC}"
             fi
             ;;
+        mechanic)
+            echo -e "${BLUE}Spawning additional Mechanic...${NC}"
+            for i in 1 2 3; do
+                local sname="mechanic-$i"
+                if ! tmux has-session -t "$sname" 2>/dev/null; then
+                    SESSION_NAME="$sname" ./scripts/mechanic/launch-agent.sh &
+                    sleep 2
+                    echo -e "${GREEN}✓ Mechanic spawned (slot $i)${NC}"
+                    exit 0
+                fi
+            done
+            # Check legacy singleton name too
+            if tmux has-session -t "mechanic-agent" 2>/dev/null; then
+                echo -e "${YELLOW}All Mechanic slots are full (max: $MAX_MECHANIC)${NC}"
+            else
+                SESSION_NAME="mechanic-agent" ./scripts/mechanic/launch-agent.sh &
+                sleep 2
+                echo -e "${GREEN}✓ Mechanic spawned (legacy slot)${NC}"
+            fi
+            ;;
         peer-reviewer)
             echo -e "${BLUE}Spawning Peer Reviewer...${NC}"
             for i in 1 2; do
@@ -2352,7 +2471,7 @@ cmd_spawn() {
             ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: enricher, aristotle, researcher, auditor, seeker, deployer, tester, herald, peer-reviewer"
+            echo "Valid types: enricher, aristotle, researcher, auditor, mechanic, seeker, deployer, tester, herald, peer-reviewer"
             exit 1
             ;;
     esac
@@ -2470,6 +2589,42 @@ cmd_scale() {
                 echo -e "${GREEN}Already at $count Researchers${NC}"
             fi
             ;;
+        mechanic)
+            if [[ $count -gt $MAX_MECHANIC ]]; then
+                echo -e "${YELLOW}Count $count exceeds max $MAX_MECHANIC, using $MAX_MECHANIC${NC}"
+                count=$MAX_MECHANIC
+            fi
+
+            local current=0
+            for i in 1 2 3; do
+                if tmux has-session -t "mechanic-$i" 2>/dev/null; then
+                    current=$((current + 1))
+                fi
+            done
+            if tmux has-session -t "mechanic-agent" 2>/dev/null; then
+                current=$((current + 1))
+            fi
+
+            if [[ $count -gt $current ]]; then
+                local to_add=$((count - current))
+                echo -e "${BLUE}Scaling Mechanics from $current to $count (adding $to_add)...${NC}"
+                update_daemon_config "mechanic" "$count"
+                local added=0
+                for i in 1 2 3; do
+                    [[ $added -ge $to_add ]] && break
+                    if ! tmux has-session -t "mechanic-$i" 2>/dev/null; then
+                        SESSION_NAME="mechanic-$i" ./scripts/mechanic/launch-agent.sh &
+                        sleep 2
+                        added=$((added + 1))
+                    fi
+                done
+                echo -e "${GREEN}✓ Scaled to $count Mechanics${NC}"
+            elif [[ $count -lt $current ]]; then
+                scale_down_multi "mechanic" "mechanic" "$current" "$count"
+            else
+                echo -e "${GREEN}Already at $count Mechanics${NC}"
+            fi
+            ;;
         auditor|aristotle|seeker|deployer|tester|herald)
             if [[ $count -gt 1 ]]; then
                 echo -e "${YELLOW}$agent_type can only have 0 or 1 instance, using 1${NC}"
@@ -2500,7 +2655,7 @@ cmd_scale() {
             ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: enricher, researcher, aristotle, auditor, seeker, deployer, tester, herald"
+            echo "Valid types: enricher, researcher, mechanic, aristotle, auditor, seeker, deployer, tester, herald"
             exit 1
             ;;
     esac
@@ -2557,9 +2712,21 @@ cmd_wake() {
             touch "$SIGNALS_DIR/wake-herald-agent"
             echo -e "${GREEN}Wake signal sent to herald-agent${NC}"
             ;;
+        mechanic)
+            for i in 1 2 3; do
+                if tmux has-session -t "mechanic-$i" 2>/dev/null; then
+                    touch "$SIGNALS_DIR/wake-mechanic-$i"
+                    echo -e "${GREEN}Wake signal sent to mechanic-$i${NC}"
+                fi
+            done
+            if tmux has-session -t "mechanic-agent" 2>/dev/null; then
+                touch "$SIGNALS_DIR/wake-mechanic-agent"
+                echo -e "${GREEN}Wake signal sent to mechanic-agent${NC}"
+            fi
+            ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: all, aristotle, researcher, auditor, deployer, seeker, enricher, tester, herald"
+            echo "Valid types: all, aristotle, researcher, auditor, mechanic, deployer, seeker, enricher, tester, herald"
             exit 1
             ;;
     esac

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -140,6 +140,7 @@ gather_status() {
     local deployer_status="stopped"
     local tester_status="stopped"
     local herald_status="stopped"
+    local mechanic_sessions=()
 
     # Enrichers
     for i in 1 2 3 4 5; do
@@ -178,6 +179,16 @@ gather_status() {
     # Herald
     if session_exists "herald-agent"; then
         herald_status="running:$(get_session_uptime "herald-agent")"
+    fi
+
+    # Mechanics
+    for i in 1 2 3; do
+        if session_exists "mechanic-$i"; then
+            mechanic_sessions+=("mechanic-$i:$(get_session_uptime "mechanic-$i")")
+        fi
+    done
+    if session_exists "mechanic-agent"; then
+        mechanic_sessions+=("mechanic-agent:$(get_session_uptime "mechanic-agent")")
     fi
 
     # Work queue counts
@@ -262,6 +273,10 @@ gather_status() {
     "herald": {
       "status": "${herald_status%%:*}",
       "uptime": "${herald_status#*:}"
+    },
+    "mechanic": {
+      "count": ${#mechanic_sessions[@]},
+      "sessions": $(printf '%s\n' "${mechanic_sessions[@]:-}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
     }
   },
   "session_stats": {
@@ -375,6 +390,19 @@ EOF
             echo "      herald-agent: Running (${herald_status#*:})"
         else
             echo -e "    ${BOLD}Herald:${NC} ${YELLOW}0/1 active${NC}"
+        fi
+
+        # Mechanic
+        local mechanic_count=${#mechanic_sessions[@]}
+        if [[ $mechanic_count -gt 0 ]]; then
+            echo -e "    ${BOLD}Mechanic:${NC} ${GREEN}$mechanic_count active${NC}"
+            for session in "${mechanic_sessions[@]}"; do
+                local name="${session%%:*}"
+                local uptime="${session#*:}"
+                echo "      $name: Running ($uptime)"
+            done
+        else
+            echo -e "    ${BOLD}Mechanic:${NC} ${YELLOW}0 active${NC}"
         fi
         echo ""
 

--- a/scripts/mechanic/launch-agent.sh
+++ b/scripts/mechanic/launch-agent.sh
@@ -1,0 +1,365 @@
+#!/bin/bash
+#
+# launch-agent.sh - Launch the Lean mechanic agent (repair specialist)
+#
+# Repairs issues found by auditors and peer reviewers: metadata fixes,
+# Lean code repairs, and Aristotle companion file creation.
+#
+# Usage:
+#   ./launch-agent.sh              Launch mechanic (default 15min interval)
+#   ./launch-agent.sh --stop       Stop the mechanic
+#   ./launch-agent.sh --status     Check mechanic status
+#   ./launch-agent.sh --attach     Attach to mechanic session
+#   ./launch-agent.sh --logs       Tail mechanic logs
+#   ./launch-agent.sh --graceful-stop  Signal mechanic to stop after current work
+#
+# Environment:
+#   MECHANIC_INTERVAL - Interval in minutes between repair cycles (default: 15)
+#   SESSION_NAME      - tmux session name (default: mechanic-agent; use mechanic-1..3 for multi-slot)
+
+set -euo pipefail
+
+# Find repo root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="$(find_repo_root)"
+WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+LOGS_DIR="$REPO_ROOT/.loom/logs"
+SIGNALS_DIR="$REPO_ROOT/.loom/signals"
+SESSION_NAME="${SESSION_NAME:-mechanic-agent}"
+LOG_FILE="$LOGS_DIR/${SESSION_NAME}.log"
+INTERVAL="${MECHANIC_INTERVAL:-15}"
+WORKTREE_PATH="$WORKTREES_DIR/${SESSION_NAME}"
+BRANCH_NAME="feature/${SESSION_NAME}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}x $1${NC}"; }
+print_success() { echo -e "${GREEN}+ $1${NC}"; }
+print_info() { echo -e "${BLUE}i $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+
+# Check dependencies
+check_deps() {
+    local missing=()
+    command -v tmux >/dev/null 2>&1 || missing+=("tmux")
+    command -v claude >/dev/null 2>&1 || missing+=("claude")
+    command -v jq >/dev/null 2>&1 || missing+=("jq")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        print_error "Missing dependencies: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# Create or update worktree for mechanic
+create_worktree() {
+    mkdir -p "$WORKTREES_DIR"
+
+    if [[ -d "$WORKTREE_PATH" ]]; then
+        print_info "Worktree already exists, syncing with main..."
+        (
+            cd "$WORKTREE_PATH"
+            git fetch origin main 2>/dev/null || true
+            git stash 2>/dev/null || true
+
+            if git reset --hard origin/main 2>/dev/null; then
+                print_success "Synced with origin/main"
+            else
+                print_warning "Could not sync with origin/main"
+            fi
+
+            git stash pop 2>/dev/null || true
+        )
+        return 0
+    fi
+
+    print_info "Creating worktree for mechanic at $WORKTREE_PATH..."
+
+    # Try to create worktree
+    git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || {
+        # Branch might exist, try to use it
+        git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null || {
+            # Remove and recreate branch
+            git branch -D "$BRANCH_NAME" 2>/dev/null || true
+            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+        }
+    }
+
+    # Install node dependencies in worktree (needed for pnpm build validation)
+    if [[ -f "$WORKTREE_PATH/package.json" ]]; then
+        print_info "Installing node dependencies..."
+        (cd "$WORKTREE_PATH" && pnpm install --frozen-lockfile 2>/dev/null) || true
+    fi
+
+    print_success "Created mechanic worktree"
+}
+
+# Create prompt file for mechanic
+create_prompt_file() {
+    local prompt_file="$LOGS_DIR/mechanic-prompt.md"
+
+    cat > "$prompt_file" << EOF
+# Lean Mechanic Agent Instructions
+
+You are the **lean mechanic** agent. Your mission is to repair issues found by auditors and peer reviewers.
+
+## Environment
+
+- REPO_ROOT: $REPO_ROOT
+- INTERVAL: $INTERVAL minutes
+- LOG_FILE: $LOG_FILE
+
+## Your Workflow (Repeat Every $INTERVAL Minutes)
+
+1. **Check for stop signal**
+   \`\`\`bash
+   if [[ -f "$SIGNALS_DIR/stop-mechanic" ]] || [[ -f "$SIGNALS_DIR/stop-all" ]]; then
+       echo "Stop signal received. Exiting."
+       exit 0
+   fi
+   \`\`\`
+
+2. **Sync with main**
+   \`\`\`bash
+   git fetch origin main 2>/dev/null
+   git reset --hard origin/main 2>/dev/null
+   \`\`\`
+
+3. **Find work** (priority order)
+   \`\`\`bash
+   # Auditor issues
+   gh issue list --label="loom:auditor" --state=open --limit=10 --json number,title
+
+   # Unaddressed peer review comments
+   gh pr list --state=open --json number,title,reviewDecision \\
+     --jq '.[] | select(.reviewDecision == "CHANGES_REQUESTED")'
+   \`\`\`
+
+4. **Claim via branch** -- create \`fix/mechanic-<issue>\` branch; skip if remote already has it
+
+5. **Triage and fix** -- metadata, Lean code, or Aristotle companion file
+
+6. **Submit PR** -- do NOT add \`loom:review-requested\`
+
+7. **Wait for next interval**
+   \`\`\`bash
+   echo "Next repair cycle in $INTERVAL minutes..."
+   sleep ${INTERVAL}m
+   \`\`\`
+
+8. **Repeat from step 1**
+
+## Start Now
+
+Begin by:
+1. Reading the lean mechanic skill: \`cat $REPO_ROOT/.claude/commands/lean-mechanic.md\`
+2. Checking for auditor issues: \`gh issue list --label="loom:auditor" --state=open\`
+3. Claiming and fixing the highest-priority item
+4. Starting the periodic repair loop
+
+Good luck, mechanic!
+EOF
+
+    echo "$prompt_file"
+}
+
+# Launch the mechanic agent
+launch_agent() {
+    check_deps
+    mkdir -p "$LOGS_DIR" "$SIGNALS_DIR"
+
+    # Remove any existing stop signal
+    rm -f "$SIGNALS_DIR/stop-mechanic"
+
+    # Kill existing session if any
+    tmux kill-session -t "$SESSION_NAME" 2>/dev/null || true
+
+    # Create or update worktree
+    create_worktree
+
+    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree
+    if [[ -d "$REPO_ROOT/.loom/tokens" ]]; then
+        mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
+        ln -sfn "$REPO_ROOT/.loom/tokens" "$WORKTREE_PATH/.loom/tokens"
+    fi
+
+    # Create prompt file
+    local prompt_file
+    prompt_file=$(create_prompt_file)
+
+    print_info "Launching mechanic agent..."
+    print_info "Session: $SESSION_NAME"
+    print_info "Interval: $INTERVAL minutes"
+    print_info "Worktree: $WORKTREE_PATH"
+
+    # Launch in tmux with resilient wrapper in DAEMON mode
+    local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
+        "ENHANCER_ID=mechanic REPO_ROOT=$WORKTREE_PATH $wrapper_script --daemon --prompt 'You are the lean mechanic agent. Read $prompt_file for your instructions, then start the repair loop.' --log '$LOG_FILE'"
+
+    print_success "Launched mechanic agent"
+    echo ""
+    echo "Commands:"
+    echo "  ./scripts/mechanic/launch-agent.sh --status     Check status"
+    echo "  ./scripts/mechanic/launch-agent.sh --attach     Attach to session"
+    echo "  ./scripts/mechanic/launch-agent.sh --logs       Tail logs"
+    echo "  ./scripts/mechanic/launch-agent.sh --stop       Stop agent"
+}
+
+# Stop the mechanic
+stop_agent() {
+    print_info "Stopping mechanic agent..."
+
+    # Create stop signal for graceful shutdown
+    touch "$SIGNALS_DIR/stop-mechanic"
+
+    # Give it a moment to notice
+    sleep 2
+
+    # Kill the session
+    if tmux kill-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_success "Stopped mechanic agent"
+    else
+        print_info "No mechanic session found"
+    fi
+
+    # Clean up signal
+    rm -f "$SIGNALS_DIR/stop-mechanic"
+}
+
+# Graceful stop (just create signal, don't kill)
+graceful_stop_agent() {
+    print_info "Sending graceful stop signal to mechanic agent..."
+    mkdir -p "$SIGNALS_DIR"
+    touch "$SIGNALS_DIR/stop-mechanic"
+    print_success "Stop signal created. Mechanic will stop after current work."
+}
+
+# Check status
+check_status() {
+    echo "=== Mechanic Status ==="
+    echo ""
+
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_success "Mechanic is running"
+        echo ""
+        echo "Session: $SESSION_NAME"
+        echo "Worktree: $WORKTREE_PATH"
+        echo "Log file: $LOG_FILE"
+        echo "Interval: $INTERVAL minutes"
+
+        # Show worktree git status
+        if [[ -d "$WORKTREE_PATH" ]]; then
+            local branch
+            branch=$(cd "$WORKTREE_PATH" && git branch --show-current 2>/dev/null || echo "unknown")
+            echo "Branch: $branch"
+        fi
+
+        if [[ -f "$LOG_FILE" ]]; then
+            echo ""
+            echo "Recent activity:"
+            tail -5 "$LOG_FILE" 2>/dev/null || echo "  (no logs yet)"
+        fi
+    else
+        print_info "Mechanic is not running"
+        echo ""
+        if [[ -d "$WORKTREE_PATH" ]]; then
+            echo "Worktree exists: $WORKTREE_PATH"
+        fi
+    fi
+}
+
+# Attach to session
+attach_session() {
+    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_error "No mechanic session found"
+        exit 1
+    fi
+
+    tmux attach-session -t "$SESSION_NAME"
+}
+
+# Tail logs
+tail_logs() {
+    if [[ ! -f "$LOG_FILE" ]]; then
+        print_error "No log file found: $LOG_FILE"
+        exit 1
+    fi
+
+    tail -f "$LOG_FILE"
+}
+
+# Main command dispatch
+case "${1:-}" in
+    --stop|-s)
+        stop_agent
+        ;;
+    --graceful-stop)
+        graceful_stop_agent
+        ;;
+    --status)
+        check_status
+        ;;
+    --attach|-a)
+        attach_session
+        ;;
+    --logs|-l)
+        tail_logs
+        ;;
+    --help|-h)
+        cat << EOF
+Lean Mechanic Agent Launcher
+
+Launches an autonomous agent that periodically repairs issues found by
+auditors and peer reviewers. Fixes metadata mismatches, Lean code issues,
+and creates Aristotle companion files for sorry-heavy proofs.
+
+The agent runs in an isolated git worktree at $WORKTREES_DIR/$SESSION_NAME
+to prevent contention with other agents working in the main repository.
+
+Usage:
+  ./launch-agent.sh              Launch mechanic (default 15min interval)
+  ./launch-agent.sh --stop       Stop the mechanic
+  ./launch-agent.sh --graceful-stop  Signal mechanic to stop
+  ./launch-agent.sh --status     Check mechanic status
+  ./launch-agent.sh --attach     Attach to mechanic session
+  ./launch-agent.sh --logs       Tail mechanic logs
+  ./launch-agent.sh --help       Show this help
+
+Environment Variables:
+  MECHANIC_INTERVAL  Interval in minutes between repair cycles (default: 15)
+  SESSION_NAME       tmux session name (default: mechanic-agent; use mechanic-1..3 for multi-slot)
+
+Examples:
+  ./launch-agent.sh                              # Start with defaults
+  MECHANIC_INTERVAL=5 ./launch-agent.sh          # Check every 5 minutes
+  SESSION_NAME=mechanic-2 ./launch-agent.sh      # Launch in slot 2
+  ./launch-agent.sh --attach                     # Watch the agent work
+EOF
+        ;;
+    "")
+        launch_agent
+        ;;
+    *)
+        print_error "Unknown option: $1"
+        echo "Run '$0 --help' for usage"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- New **lean-mechanic** agent that repairs issues found by auditors and peer reviewers
- Skill file (`.claude/commands/lean-mechanic.md`) with triage decision tree, fix types (metadata/Lean code/Aristotle companion), and branch-based claiming
- Launch script (`scripts/mechanic/launch-agent.sh`) supporting multi-slot (1-3) via SESSION_NAME env var, 15min default interval
- Full integration into `scripts/lean/launch.sh`: constants, --mechanic flag, init_state, get_sessions_for_type, signal_stop, get_agent_type, is_polling_agent, _do_respawn_agent, pool gap detection, cmd_spawn (multi-slot), cmd_scale, cmd_wake, orphan sweep, stop signals
- Full integration into `scripts/lean/status.sh`: multi-slot session detection and display
- CLAUDE.md updated: agent table, pool limits (default 1, max 3), managed-by list

Closes #5525

## Test plan
- [ ] `bash -n scripts/lean/launch.sh` passes (verified)
- [ ] `bash -n scripts/lean/status.sh` passes (verified)
- [ ] `bash -n scripts/mechanic/launch-agent.sh` passes (verified)
- [ ] `./scripts/lean/launch.sh spawn mechanic` creates mechanic-1 session
- [ ] `./scripts/mechanic/launch-agent.sh --status` reports status correctly
- [ ] Skill file has clear triage logic (metadata / Lean code / Aristotle companion)
- [ ] CLAUDE.md lists Mechanic in agent table, pool limits, and managed-by line

Generated with [Claude Code](https://claude.com/claude-code)