### PR TITLE
Audit fix: binomial-theorem-oq-01 badge original→mathlib

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01/meta.json
@@ -16,9 +16,14 @@
       "real-analysis",
       "newton"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
+      {
+        "theorem": "Real.one_add_rpow_hasFPowerSeriesOnBall_zero",
+        "description": "Binomial formal power series converges to (1+x)^α on the unit ball",
+        "module": "Mathlib.Analysis.Analytic.Binomial"
+      },
       {
         "theorem": "hasSum_geometric_of_norm_lt_one",
         "description": "Geometric series converges for |x| < 1",
@@ -42,7 +47,7 @@
       "geometric_series_is_genBinom_neg_one: HasSum for geometric series via α=-1 case",
       "standard_binomial: (1+x)^n = finite genBinom sum for natural n",
       "genBinom_ode_coeff: ODE coefficient identity (k+1)C(α,k+1) + kC(α,k) = αC(α,k)",
-      "newton_generalized_binomial axiom: main HasSum theorem (requires analytic function theory)"
+      "newton_generalized_binomial: main HasSum theorem proved via Mathlib's Real.one_add_rpow_hasFPowerSeriesOnBall_zero with coefficient bridge"
     ],
     "dateAdded": "2026-02-25",
     "axiomCount": 0,
@@ -52,12 +57,12 @@
       "Real analysis (HasSum, HasFPowerSeriesOnBall)"
     ],
     "lineCount": 264,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Main convergence theorem newton_generalized_binomial proved via Mathlib's Real.one_add_rpow_hasFPowerSeriesOnBall_zero (binomial power series)."
   },
   "overview": {
     "historicalContext": "Isaac Newton discovered the generalized binomial theorem around 1665 while still a student at Cambridge, publishing it in 1676 in his famous *Epistola Prior* and *Epistola Posterior* to Leibniz via Henry Oldenburg. For natural exponents $n$, the binomial theorem $(1+x)^n = \\sum_{k=0}^{n} \\binom{n}{k} x^k$ was already known to al-Karajī (c. 1000 CE) and Blaise Pascal (1654). Newton's breakthrough was extending this to arbitrary real (and later complex) exponents $\\alpha$, yielding the infinite series $(1+x)^\\alpha = \\sum_{k=0}^{\\infty} \\binom{\\alpha}{k} x^k$ converging for $|x| < 1$.\n\nThe generalized binomial coefficient $\\binom{\\alpha}{k} = \\prod_{i=0}^{k-1} (\\alpha - i) / k!$ reduces to the usual $\\binom{n}{k}$ when $\\alpha = n \\in \\mathbb{N}$ (terminating at $k > n$), but produces infinite non-terminating series for fractional $\\alpha$. Newton used this to compute $\\sqrt{2}$ and $\\pi$ to many decimal places. Abel (1826) gave the first rigorous proof of convergence, and the result became a cornerstone of analysis, appearing in Taylor series theory and the theory of formal power series.",
     "problemStatement": "**Newton's Generalized Binomial Theorem**: For any real α and |x| < 1:\n\n(1 + x)^α = Σ_{k=0}^∞ C(α,k) x^k\n\nwhere C(α,k) = α(α-1)···(α-k+1)/k! is the **generalized binomial coefficient**.\n\nSpecial cases:\n- α = n ∈ ℕ: reduces to standard binomial theorem (finite sum)\n- α = -1: (1+x)^(-1) = Σ (-1)^k x^k (geometric series)\n- α = 1/2: (1+x)^(1/2) = Σ C(1/2,k) x^k (square root series)",
-    "text": "This formalization defines the generalized binomial coefficient $\\binom{\\alpha}{k} = \\prod_{i=0}^{k-1}(\\alpha-i)/k!$ for real $\\alpha$ and proves 16 theorems about Newton's generalized binomial series. Key results include: `genBinom_nat_eq_choose` connecting to Mathlib's `Nat.choose`, `genBinom_neg_one` giving $\\binom{-1}{k} = (-1)^k$ (geometric series), `standard_binomial` proving the finite-sum case for natural exponents, and the ODE coefficient identity `genBinom_ode_coeff` showing the series formally satisfies $(1+x)f' = \\alpha f$. The main convergence theorem `newton_generalized_binomial` is axiomatized pending analytic function theory. All coefficient arithmetic is fully verified with 0 sorries.",
+    "text": "This formalization defines the generalized binomial coefficient $\\binom{\\alpha}{k} = \\prod_{i=0}^{k-1}(\\alpha-i)/k!$ for real $\\alpha$ and proves 16 theorems about Newton's generalized binomial series. Key results include: `genBinom_nat_eq_choose` connecting to Mathlib's `Nat.choose`, `genBinom_neg_one` giving $\\binom{-1}{k} = (-1)^k$ (geometric series), `standard_binomial` proving the finite-sum case for natural exponents, and the ODE coefficient identity `genBinom_ode_coeff` showing the series formally satisfies $(1+x)f' = \\alpha f$. The main convergence theorem `newton_generalized_binomial` is proved via Mathlib's `Real.one_add_rpow_hasFPowerSeriesOnBall_zero`. All coefficient arithmetic is fully verified with 0 sorries.",
     "proofStrategy": "**ODE Uniqueness Approach**: Both f(x) = Σ C(α,k) x^k and g(x) = (1+x)^α satisfy:\n- (1+x)·y' = α·y (the same linear ODE)\n- y(0) = 1\n\nBy ODE uniqueness (Picard-Lindelöf), they are equal on (-1,1).\n\nThe ODE identity for f follows from the coefficient recurrence:\n(k+1)C(α,k+1) + kC(α,k) = αC(α,k)\n\nThis is formalized in `genBinom_ode_coeff`.\n\n**Current Status**: The ODE uniqueness step is axiomatized as `newton_generalized_binomial`. The coefficient arithmetic (16 theorems) is fully proved.",
     "keyInsights": [
       "genBinom generalizes Nat.choose: for natural n and k ≤ n, C(n,k) = Nat.choose n k",
@@ -115,20 +120,19 @@
     },
     {
       "id": "main-theorem",
-      "title": "Newton's Theorem (Axiomatized) and Consequences",
+      "title": "Newton's Theorem (via Mathlib) and Consequences",
       "startLine": 148,
       "endLine": 175,
-      "summary": "newton_generalized_binomial axiom: HasSum (fun k => genBinom α k * x^k) ((1+x)^α). Consequences: sqrt_series, genBinom_series_summable, genBinom_series_tsum, geometric_from_newton.",
+      "summary": "newton_generalized_binomial (proved via Mathlib): HasSum (fun k => genBinom α k * x^k) ((1+x)^α). Consequences: sqrt_series, genBinom_series_summable, genBinom_series_tsum, geometric_from_newton.",
       "mathContext": "$(1+x)^\\alpha = \\sum_{k=0}^{\\infty} \\binom{\\alpha}{k} x^k$ for $|x| < 1$. Consequence: $\\sqrt{1+x} = \\sum \\binom{1/2}{k} x^k$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization proves 16 theorems about Newton's generalized binomial series with 0 sorries and 1 axiom. The axiom `newton_generalized_binomial` captures the main convergence result; all coefficient arithmetic and special cases (geometric series, square root, natural exponents) are fully proved.",
+    "summary": "This formalization proves 16 theorems about Newton's generalized binomial series with 0 sorries and 0 axioms. The main convergence theorem `newton_generalized_binomial` is proved via Mathlib's `Real.one_add_rpow_hasFPowerSeriesOnBall_zero`; all coefficient arithmetic and special cases (geometric series, square root, natural exponents) are fully proved.",
     "implications": "**Theoretical Significance**: **Applications:**\n1. **Analysis**: Power series expansions of all real powers (1+x)^α\n**2. Combinatorics**: Generalization of binomial coefficients to real parameters\n3. **Special functions**: Square root series C(1/2,k), reciprocal series C(-1,k)\n4. **ODE theory**: Connection to Picard-Lindelöf uniqueness theorem.",
     "openQuestions": [
-      "Prove newton_generalized_binomial from Mathlib's analytic function theory",
-      "ODE uniqueness path: show f and (1+x)^α both satisfy (1+x)y'=αy with y(0)=1",
-      "Use HasFPowerSeriesOnBall machinery to extract Taylor coefficients of (1+x)^α"
+      "ODE uniqueness path: show f and (1+x)^α both satisfy (1+x)y'=αy with y(0)=1 as an alternative proof route",
+      "Can the genBinom coefficient bridge be simplified using Mathlib's Ring.choose directly?"
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary

- Badge changed from `original` to `mathlib` for `binomial-theorem-oq-01`
- Main theorem `newton_generalized_binomial` is proved via Mathlib's `Real.one_add_rpow_hasFPowerSeriesOnBall_zero`, not independently
- Fixed multiple stale references to "1 axiom" and "axiomatized" from before the proof was completed via Mathlib
- Added the key Mathlib dependency to `mathlibDependencies`

## Evidence

The Lean file's own docstring says: "Proved from Mathlib's Real.one_add_rpow_hasFPowerSeriesOnBall_zero" (line 180). The proof directly invokes this Mathlib theorem as its core step.

## Test plan

- [ ] Verify meta.json is valid JSON
- [ ] Check badge displays correctly on gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)