### PR TITLE
Audit fix: downgrade 3 Mathlib-wrapper badges

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -186,6 +186,60 @@
       "lastAudited": "2026-03-24T03:35:12Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-02-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T03:46:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T03:49:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T03:49:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T03:49:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-03-oq-01-oq-01-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T03:49:23Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "bezout-identity-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T03:49:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T03:49:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T03:49:23Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "binomial-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T03:49:23Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   }
 }

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "chinese-remainder",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -49,7 +49,7 @@
     "dateAdded": "2026-03-22",
     "axiomCount": 0,
     "lineCount": 161,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core isomorphism derived from Mathlib's Ideal.quotientInfRingEquivPiQuotient."
   },
   "overview": {
     "historicalContext": "The Chinese Remainder Theorem was first generalized from integers to arbitrary rings by Emmy Noether's school in the early 20th century. In modern commutative algebra, the CRT is stated for ideals: if I and J are coprime (meaning I + J = R), then R/(I ∩ J) ≅ R/I × R/J. This is Proposition 1.10 in Atiyah-Macdonald. The k-fold version states R/(⨅ Iᵢ) ≅ ∏ R/Iᵢ for pairwise coprime ideals. The key structural insight is that coprime ideals satisfy I ∩ J = I · J, connecting the intersection (lattice operation) with the product (ring operation).",

--- a/src/data/proofs/bezout-identity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01/meta.json
@@ -19,7 +19,7 @@
       "idempotents",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -73,7 +73,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 315,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core ring isomorphism derived from Mathlib's ZMod.chineseRemainder."
   },
   "overview": {
     "historicalContext": "**Chinese Remainder Theorem as Ring Isomorphism**\n\nThe Chinese Remainder Theorem (CRT) dates to Sun Zi's Suanjing (~3rd century). In its modern algebraic form, for coprime ideals $I, J$ of a ring $R$, the natural map $R/(I \\cap J) \\to R/I \\times R/J$ is a ring isomorphism. For $R = \\mathbb{Z}$, $I = m\\mathbb{Z}$, $J = n\\mathbb{Z}$ with $\\gcd(m,n) = 1$: $\\mathbb{Z}/mn\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$.\n\nThis formalization wraps Mathlib's `ZMod.chineseRemainder` and extends it with applications: orthogonal idempotent decomposition, explicit Bézout solutions, and unit group characterization.",

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "ODE",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -51,7 +51,7 @@
       "Real-valued rpow function"
     ],
     "lineCount": 220,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Analyticity of binomial series derived from Mathlib's Real.one_add_rpow_hasFPowerSeriesOnBall_zero."
   },
   "overview": {
     "historicalContext": "Newton discovered the generalized binomial theorem around 1665, extending the finite binomial sum $(1+x)^n = \\sum \\binom{n}{k} x^k$ to arbitrary real exponents via the infinite series $(1+x)^\\alpha = \\sum_{k=0}^{\\infty} \\binom{\\alpha}{k} x^k$ for $|x| < 1$. The analytic function theory perspective emerged from Euler and Cauchy's work on ODEs: the function $f(x) = (1+x)^\\alpha$ is the unique solution to the initial value problem $(1+x)f'(x) = \\alpha f(x)$, $f(0) = 1$. This ODE approach is elegant because it determines the power series coefficients via a single recurrence relation, from which all properties (convergence, functional equation, special values) follow.",


### PR DESCRIPTION
## Summary
- **bezout-identity-oq-03-oq-01**: badge `verified`→`mathlib` (wraps `ZMod.chineseRemainder`)
- **bezout-identity-oq-03-oq-01-oq-01-oq-01**: badge `original`→`mathlib` (wraps `Ideal.quotientInfRingEquivPiQuotient`)
- **binomial-theorem-oq-01-oq-01**: badge `original`→`mathlib` (analyticity from `Real.one_add_rpow_hasFPowerSeriesOnBall_zero`)

Also audited clean (no fixes needed): bezout-identity-oq-02-oq-02-oq-01, bezout-identity-oq-02-oq-02-oq-01-oq-01, bezout-identity-oq-03, bezout-identity-oq-03-oq-01-oq-01, bezout-identity-oq-04, binomial-theorem-oq-01.

**Total this cycle**: 9 proofs audited, 3 fixed.

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Spot-check badge changes match Lean source Mathlib usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)