### PR TITLE
Audit fix: correct badge for bezout-identity-oq-03-oq-01

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01/meta.json
@@ -19,7 +19,7 @@
       "idempotents",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -73,7 +73,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 315,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core CRT ring isomorphism derived from Mathlib's ZMod.chineseRemainder; Euler totient multiplicativity from Nat.totient_mul."
   },
   "overview": {
     "historicalContext": "**Chinese Remainder Theorem as Ring Isomorphism**\n\nThe Chinese Remainder Theorem (CRT) dates to Sun Zi's Suanjing (~3rd century). In its modern algebraic form, for coprime ideals $I, J$ of a ring $R$, the natural map $R/(I \\cap J) \\to R/I \\times R/J$ is a ring isomorphism. For $R = \\mathbb{Z}$, $I = m\\mathbb{Z}$, $J = n\\mathbb{Z}$ with $\\gcd(m,n) = 1$: $\\mathbb{Z}/mn\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$.\n\nThis formalization wraps Mathlib's `ZMod.chineseRemainder` and extends it with applications: orthogonal idempotent decomposition, explicit Bézout solutions, and unit group characterization.",


### PR DESCRIPTION
## Summary
- Change badge from `"verified"` to `"mathlib"` for bezout-identity-oq-03-oq-01
- Update assumptions field to credit Mathlib's `ZMod.chineseRemainder` and `Nat.totient_mul`

The core CRT ring isomorphism in this entry is a direct wrapper of `ZMod.chineseRemainder` from Mathlib. Badge should reflect Tier B (Mathlib-derived), not independent verification.

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Confirm badge displays correctly on gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)