### PR TITLE
Audit fix: birch-swinnerton-dyer axiomCount 21→24

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -15,7 +15,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 21,
+    "axiomCount": 24,
     "assumptions": "22 axiom declarations + 3 structure-encoded assumptions = 25 total. 21 former axiom declarations (algebraicRank, torsionSubgroup, localLFactor, conductor, LFunction, completedLFunction, rootNumber, analyticRank, realPeriod, regulator, shaOrder, tamagawaNumber, tamagawaProduct, torsionOrder, HasCM, NeronTateHeight, traceOfFrobenius, BSD_NumberField, BSD_AbelianVariety, regulatorValue, classNumber) converted to opaque — these are vocabulary declarations (type/constant definitions), not mathematical assumptions. Remaining 22 axioms encode proven BSD cases (rank 0 via Kolyvagin, rank 1 via Gross-Zagier, CM via Coates-Wiles), the Gross-Zagier formula, Hasse bound, specific curve data, congruent number results, parity conjecture, BSD generalizations, and more. Additionally, 3 structure-encoded assumptions: MordellWeilGroup.finitely_generated, GrossZagierData.gross_zagier, KolyvaginResult.sha_finite. The BSD conjecture itself remains open.",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary

- Fixed `axiomCount` for `birch-swinnerton-dyer` from 21 to 24
- 3 assumptions were encoded as structure fields (not `axiom` declarations) and were missing from the count:
  - `MordellWeilGroup.finitely_generated`
  - `GrossZagierData.gross_zagier`
  - `KolyvaginResult.sha_finite`

Per project policy: "axiomCount must reflect ALL assumptions: axiom declarations + assumption-carrying structure fields"

## Test plan

- [ ] Verify meta.json is valid JSON
- [ ] Confirm axiomCount displays correctly on gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)