### PR TITLE
Add Aristotle companion file for Erdős #674

### DIFF
--- a/proofs/Proofs/Erdos674Aristotle.lean
+++ b/proofs/Proofs/Erdos674Aristotle.lean
@@ -1,0 +1,92 @@
+/-
+  Aristotle targets for Erdős Problem #674
+  Routine supporting lemmas for automated proof search.
+  See Erdos674Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture or deep theorems (Ko, Schinzel, Dem'janenko, etc.)
+  - Known results likely provable from Mathlib (arithmetic, algebraic identities)
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos674Aristotle
+
+open Nat
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Section 1: Ko's Example — Arithmetic Verification
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Ko's example: x = 2^12 · 3^6. -/
+def koX : ℕ := 2 ^ 12 * 3 ^ 6
+
+/-- Ko's example: y = 2^8 · 3^8. -/
+def koY : ℕ := 2 ^ 8 * 3 ^ 8
+
+/-- Ko's example: z = 2^11 · 3^7. -/
+def koZ : ℕ := 2 ^ 11 * 3 ^ 7
+
+/-- koX > 1. -/
+theorem koX_gt_one : koX > 1 := by
+  unfold koX; norm_num
+
+/-- koY > 1. -/
+theorem koY_gt_one : koY > 1 := by
+  unfold koY; norm_num
+
+/-- koZ > 1. -/
+theorem koZ_gt_one : koZ > 1 := by
+  unfold koZ; norm_num
+
+/-- Ko's family satisfies 4xy = z². -/
+theorem ko_family_ratio : 4 * koX * koY = koZ ^ 2 := by sorry
+
+/-- koX = 2985984. -/
+theorem koX_value : koX = 2985984 := by sorry
+
+/-- koY = 1679616. -/
+theorem koY_value : koY = 1679616 := by sorry
+
+/-- koZ = 4478976. -/
+theorem koZ_value : koZ = 4478976 := by sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Section 2: Conjectured Formula Properties
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The conjectured formula: (k-1)(n-1) + 1. -/
+def ConjecturedFormula (k n : ℕ) : ℕ := (k - 1) * (n - 1) + 1
+
+/-- The conjectured formula is monotone in both arguments. -/
+theorem formula_mono (k₁ k₂ n₁ n₂ : ℕ) (hk : k₁ ≤ k₂) (hn : n₁ ≤ n₂) :
+    ConjecturedFormula k₁ n₁ ≤ ConjecturedFormula k₂ n₂ := by sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Section 3: GCD and Divisibility Lemmas
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- If gcd(x, y) = 1 and p | x, then ¬(p | y). -/
+theorem coprime_prime_div (x y p : ℕ) (hcop : x.gcd y = 1)
+    (hp : p.Prime) (hdvd : p ∣ x) : ¬(p ∣ y) := by sorry
+
+/-- gcd(x, y) > 1 ↔ gcd(x, y) ≠ 1 for x, y > 1. -/
+theorem gcd_gt_one_iff (x y : ℕ) (hx : x > 1) (hy : y > 1) :
+    x.gcd y > 1 ↔ x.gcd y ≠ 1 := by sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Section 4: Power and Exponentiation Identities
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- x^(2x) = (x^x)^2 = x^x * x^x. -/
+theorem pow_double_eq_sq (x : ℕ) : x ^ (2 * x) = (x ^ x) ^ 2 := by sorry
+
+/-- x^(2x) = x^x * x^x. -/
+theorem pow_double_eq_mul (x : ℕ) : x ^ (2 * x) = x ^ x * x ^ x := by sorry
+
+/-- For a, b > 1 with a^a * b^b = c^c, we have c > 1. -/
+theorem solution_z_gt_one (a b c : ℕ) (ha : a > 1) (hb : b > 1)
+    (heq : a ^ a * b ^ b = c ^ c) : c > 1 := by sorry
+
+end Erdos674Aristotle


### PR DESCRIPTION
## Fix

Create Aristotle companion file for Erdős Problem #674 (x^x y^y = z^z), which has 22 sorries and no existing companion.

## Evidence

**Before**: No Aristotle companion file — 22 sorries unreachable by automated proof search
**After**: `Erdos674Aristotle.lean` with 13 routine lemmas for Aristotle:
- Arithmetic verification of Ko's example values (koX, koY, koZ)
- Ko's family ratio identity (4xy = z²)
- Formula monotonicity
- GCD/divisibility lemmas
- Power/exponentiation identities

All pre-submission checks pass:
- No definition sorries
- No axiom declarations
- No placeholder True theorems
- No `/-!` docstring sections

---
Automated fix by lean-mechanic agent.