### PR TITLE
Audit fix: correct badges and assumptions in 4 gallery entries

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -49,7 +49,7 @@
     "dateAdded": "2026-03-22",
     "axiomCount": 0,
     "lineCount": 161,
-    "assumptions": "0 axioms, 0 sorries. Core isomorphism derived from Mathlib's Ideal.quotientInfRingEquivPiQuotient."
+    "assumptions": "0 axioms, 0 sorries. Ideal-theoretic CRT derived from Mathlib Ideal.quotientInfRingEquivPiQuotient."
   },
   "overview": {
     "historicalContext": "The Chinese Remainder Theorem was first generalized from integers to arbitrary rings by Emmy Noether's school in the early 20th century. In modern commutative algebra, the CRT is stated for ideals: if I and J are coprime (meaning I + J = R), then R/(I ∩ J) ≅ R/I × R/J. This is Proposition 1.10 in Atiyah-Macdonald. The k-fold version states R/(⨅ Iᵢ) ≅ ∏ R/Iᵢ for pairwise coprime ideals. The key structural insight is that coprime ideals satisfy I ∩ J = I · J, connecting the intersection (lattice operation) with the product (ring operation).",

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "algebra",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -51,7 +51,7 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 249,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. k-fold CRT ring isomorphism constructed by recursive composition of Mathlib ZMod.chineseRemainder."
   },
   "overview": {
     "historicalContext": "The Chinese Remainder Theorem originates in Sunzi Suanjing (~3rd century CE), which posed: 'find a number giving remainders 2, 3, 2 when divided by 3, 5, 7.' The first general algorithm for arbitrary moduli was given by Qin Jiushao in his 1247 Shushu Jiuzhang (Mathematical Treatise in Nine Sections), predating European treatments by centuries. Euler stated the k-fold version for pairwise coprime moduli, and Gauss gave it systematic treatment in Disquisitiones Arithmeticae (1801, Articles 32-36). The modern ring-theoretic formulation as an isomorphism $\\mathbb{Z}/(\\prod n_i)\\mathbb{Z} \\cong \\prod_i \\mathbb{Z}/n_i\\mathbb{Z}$ captures both existence and uniqueness of solutions plus the full multiplicative structure. This k-fold generalization is foundational in modern cryptography: RSA key generation relies on the CRT decomposition $\\mathbb{Z}/pq\\mathbb{Z} \\cong \\mathbb{Z}/p\\mathbb{Z} \\times \\mathbb{Z}/q\\mathbb{Z}$ for efficient decryption, and multi-prime RSA uses the k-fold version directly.",

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01/meta.json
@@ -51,7 +51,7 @@
       "Real-valued rpow function"
     ],
     "lineCount": 220,
-    "assumptions": "0 axioms, 0 sorries. Analyticity of binomial series derived from Mathlib's Real.one_add_rpow_hasFPowerSeriesOnBall_zero."
+    "assumptions": "0 axioms, 0 sorries. Core analytic convergence derived from Mathlib Real.one_add_rpow_hasFPowerSeriesOnBall_zero via binomialSeries."
   },
   "overview": {
     "historicalContext": "Newton discovered the generalized binomial theorem around 1665, extending the finite binomial sum $(1+x)^n = \\sum \\binom{n}{k} x^k$ to arbitrary real exponents via the infinite series $(1+x)^\\alpha = \\sum_{k=0}^{\\infty} \\binom{\\alpha}{k} x^k$ for $|x| < 1$. The analytic function theory perspective emerged from Euler and Cauchy's work on ODEs: the function $f(x) = (1+x)^\\alpha$ is the unique solution to the initial value problem $(1+x)f'(x) = \\alpha f(x)$, $f(0) = 1$. This ODE approach is elegant because it determines the power series coefficients via a single recurrence relation, from which all properties (convergence, functional equation, special values) follow.",

--- a/src/data/proofs/binomial-theorem-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01/meta.json
@@ -57,7 +57,7 @@
       "Real analysis (HasSum, HasFPowerSeriesOnBall)"
     ],
     "lineCount": 264,
-    "assumptions": "0 axioms, 0 sorries. Main convergence theorem newton_generalized_binomial proved via Mathlib's Real.one_add_rpow_hasFPowerSeriesOnBall_zero (binomial power series)."
+    "assumptions": "0 axioms, 0 sorries. Core convergence result (newton_generalized_binomial) derived from Mathlib Real.one_add_rpow_hasFPowerSeriesOnBall_zero; standard binomial theorem uses Mathlib add_pow."
   },
   "overview": {
     "historicalContext": "Isaac Newton discovered the generalized binomial theorem around 1665 while still a student at Cambridge, publishing it in 1676 in his famous *Epistola Prior* and *Epistola Posterior* to Leibniz via Henry Oldenburg. For natural exponents $n$, the binomial theorem $(1+x)^n = \\sum_{k=0}^{n} \\binom{n}{k} x^k$ was already known to al-Karajī (c. 1000 CE) and Blaise Pascal (1654). Newton's breakthrough was extending this to arbitrary real (and later complex) exponents $\\alpha$, yielding the infinite series $(1+x)^\\alpha = \\sum_{k=0}^{\\infty} \\binom{\\alpha}{k} x^k$ converging for $|x| < 1$.\n\nThe generalized binomial coefficient $\\binom{\\alpha}{k} = \\prod_{i=0}^{k-1} (\\alpha - i) / k!$ reduces to the usual $\\binom{n}{k}$ when $\\alpha = n \\in \\mathbb{N}$ (terminating at $k > n$), but produces infinite non-terminating series for fractional $\\alpha$. Newton used this to compute $\\sqrt{2}$ and $\\pi$ to many decimal places. Abel (1826) gave the first rigorous proof of convergence, and the result became a cornerstone of analysis, appearing in Taylor series theory and the theory of formal power series.",


### PR DESCRIPTION
## Summary
- **bezout-identity-oq-03-oq-01-oq-01**: badge `"original"` → `"mathlib"` (k-fold CRT wraps Mathlib's `ZMod.chineseRemainder`)
- **bezout-identity-oq-03-oq-01-oq-01-oq-01**: improve assumptions text
- **binomial-theorem-oq-01**: improve assumptions text
- **binomial-theorem-oq-01-oq-01**: improve assumptions text

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Confirm badges display correctly on gallery pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)