### PR TITLE
Research: erdos-1150 - prove ultraflat equivalence forward direction

### DIFF
--- a/proofs/Proofs/Erdos1150Problem.lean
+++ b/proofs/Proofs/Erdos1150Problem.lean
@@ -91,13 +91,53 @@ def IsUltraflat (P : ℕ → Polynomial ℂ) : Prop :=
   (∀ n, (P n).natDegree = n) ∧
   Filter.Tendsto (fun n => supNorm (P n) / Real.sqrt n) atTop (nhds 1)
 
-/-- Erdős #1150 is equivalent to: no ultraflat Littlewood sequence exists.
+/-- **Forward direction (proved):**
+    If the conjecture holds (∃ c > 0 with max|P| > (1+c)√n eventually),
+    then no ultraflat Littlewood sequence exists.
 
-    If ∃ c > 0 with max|P| > (1+c)√n, then supNorm/√n > 1+c, can't → 1.
-    Conversely, if no ultraflat sequence exists, then the ratio is
-    bounded away from 1, giving the required c. -/
-axiom conjecture_equiv_no_ultraflat :
-    Erdos1150Conjecture ↔ ∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P
+    Proof: If supNorm(P_n) > (1+c)√n eventually, then
+    supNorm(P_n)/√n > 1+c eventually, which contradicts
+    supNorm(P_n)/√n → 1. -/
+theorem conjecture_implies_no_ultraflat :
+    Erdos1150Conjecture → ∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P := by
+  intro ⟨c, hc, hev⟩ P ⟨hlit, hdeg, htend⟩
+  -- From the conjecture: eventually supNorm(P n) > (1+c)√n
+  -- Since P n has degree n and is Littlewood, eventually ratio > 1+c
+  have hev' : ∀ᶠ n in atTop, supNorm (P n) / Real.sqrt n > 1 + c := by
+    apply hev.mono
+    intro n hn
+    have hspecial := hn (P n) (hdeg n) (hlit n)
+    have hsqrt_pos : (0 : ℝ) < Real.sqrt n := by
+      apply Real.sqrt_pos_of_pos
+      exact_mod_cast Nat.pos_of_ne_zero (by
+        intro heq; subst heq
+        simp [supNorm] at hspecial)
+    exact lt_div_iff₀ hsqrt_pos |>.mpr (by linarith)
+  -- From ultraflat: supNorm(P n)/√n → 1, so eventually < 1 + c
+  have hlt : ∀ᶠ n in atTop, supNorm (P n) / Real.sqrt n < 1 + c := by
+    have hmem : Set.Iio (1 + c) ∈ nhds (1 : ℝ) := Iio_mem_nhds (by linarith)
+    exact (htend hmem).mono fun n hn => hn
+  -- Contradiction: eventually > 1+c AND eventually < 1+c
+  have hboth := hev'.and hlt
+  obtain ⟨n, hgt, hlt'⟩ := hboth.exists
+  linarith
+
+/-- **Backward direction (axiomatized):**
+    If no ultraflat Littlewood sequence exists, then the conjecture holds.
+
+    Proof sketch: By contrapositive. If no c works, then for each k,
+    there exists n_k and a Littlewood P_k of degree n_k with
+    supNorm(P_k) ≤ (1+1/k)√n_k. Taking k → ∞ yields an ultraflat
+    sequence, contradicting the hypothesis.
+
+    This requires countable choice and a careful diagonal argument. -/
+axiom no_ultraflat_implies_conjecture :
+    (∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P) → Erdos1150Conjecture
+
+/-- The full equivalence follows from both directions. -/
+theorem conjecture_equiv_no_ultraflat :
+    Erdos1150Conjecture ↔ ∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P :=
+  ⟨conjecture_implies_no_ultraflat, no_ultraflat_implies_conjecture⟩
 
 /-
 ## Known Results
@@ -191,6 +231,10 @@ every degree-n ±1 polynomial has max_{|z|=1} |P(z)| > (1+c)√n?
 
 **Gap**: We know flat ±1 polynomials exist but not whether
 ultraflat ±1 polynomials exist. Erdős conjectured they don't.
+
+**Proved in this file**:
+5. Conjecture ↔ no ultraflat ±1 sequences (forward direction proved,
+   backward direction axiomatized)
 -/
 theorem erdos_1150_summary :
     -- Parseval lower bound holds
@@ -201,7 +245,9 @@ theorem erdos_1150_summary :
       ∀ᶠ n in atTop, ∃ p : Polynomial ℂ,
         p.natDegree = n ∧ IsLittlewoodPolynomial p ∧
         ∀ z : ℂ, ‖z‖ = 1 →
-          c₁ * Real.sqrt n ≤ ‖p.eval z‖ ∧ ‖p.eval z‖ ≤ c₂ * Real.sqrt n) := by
-  exact ⟨parseval_lower_bound, bbmst_flat⟩
+          c₁ * Real.sqrt n ≤ ‖p.eval z‖ ∧ ‖p.eval z‖ ≤ c₂ * Real.sqrt n) ∧
+    -- Equivalence: conjecture ↔ no ultraflat sequences
+    (Erdos1150Conjecture ↔ ∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P) := by
+  exact ⟨parseval_lower_bound, bbmst_flat, conjecture_equiv_no_ultraflat⟩
 
 end Erdos1150

--- a/research/problems/erdos-1150/knowledge.md
+++ b/research/problems/erdos-1150/knowledge.md
@@ -2,36 +2,77 @@
 
 ## Problem Statement
 
-Problem statement not found
+Does there exist c > 0 such that for all large n and all polynomials P of
+degree n with coefficients ±1: max_{|z|=1} |P(z)| > (1+c)√n?
+
+Equivalently: do ultraflat Littlewood polynomials NOT exist?
 
 ## Status
 
 **Erdős Database Status**: OPEN
+**Phase**: ACT (formalization enhanced with proved equivalence)
 
 **Tractability Score**: 6/10
-**Aristotle Suitable**: No
+**Aristotle Suitable**: No (open conjecture, deep axioms)
 
 ## Tags
 
 - erdos
+- analysis
+- polynomials
+- harmonic-analysis
 
 ## Related Problems
 
-- Problem #2000
-- Problem #83
-- Problem #888
-- Problem #2
-- Problem #39
-- Problem #1
+- Problem #228 (flat Littlewood polynomials - SOLVED by BBMST 2019)
+- Problem #230 (ultraflat unimodular polynomials - SOLVED by Kahane 1980)
 
 ## References
 
-- (None available)
+- [Ha74, Problem 4.31]
+- [Va99, Problem 2.36]
+- Balister-Bollobás-Morris-Sahasrabudhe-Tiba (2019)
+- Kahane (1980)
 
 ## Sessions
 
-(No research sessions yet)
+### Session 1 (2026-03-11, researcher-5)
+
+Initial formalization: definitions, conjecture statement, axiomatized known results.
+208 lines, 5 axioms, 4 theorems, 1 sorry.
+
+### Session 2 (2026-03-23, researcher-5)
+
+**What Was Done:**
+- Proved `conjecture_implies_no_ultraflat`: forward direction of equivalence
+  (conjecture → no ultraflat Littlewood sequences) using Filter.Tendsto contradiction
+- Replaced axiom `conjecture_equiv_no_ultraflat` with:
+  - Proved theorem `conjecture_implies_no_ultraflat` (forward)
+  - Axiom `no_ultraflat_implies_conjecture` (backward only)
+  - Proved theorem `conjecture_equiv_no_ultraflat` (combines both)
+- Updated summary theorem to include the equivalence
+- 253 lines, 5 axioms, 7 theorems, 1 sorry
+
+**Key Insights:**
+- The forward direction is a clean filter contradiction: if supNorm > (1+c)√n
+  eventually, then supNorm/√n can't tend to 1
+- The backward direction genuinely requires countable choice / diagonal argument:
+  if no c works, construct ultraflat sequence from witnesses for each 1/k
+- The remaining sorry (bbmst_upper_bound_exists) requires ciSup_le for conditional
+  supremum over the unit circle — technically involved but mathematically trivial
+
+**Axiom Classification:**
+1. `parseval_lower_bound` — Deep (requires Fourier analysis on unit circle)
+2. `no_ultraflat_implies_conjecture` — Medium (needs diagonal argument + choice)
+3. `bbmst_flat` — Deep (2019 breakthrough, probabilistic construction)
+4. `kahane_unimodular_ultraflat` — Deep (1980, continuous phase optimization)
+5. `rudin_shapiro_bound` — Medium (constructive but recursive bound proof)
+
+**Next Steps:**
+- Fix bbmst_upper_bound_exists sorry (needs ciSup handling for conditional supremum)
+- Potentially prove no_ultraflat_implies_conjecture (diagonal argument)
+- Consider whether Parseval can be proved from Mathlib integration theory
 
 ---
 
-*Generated from erdosproblems.com on 2026-01-15*
+*Updated by researcher-5 on 2026-03-23*

--- a/src/data/proofs/erdos-1150/meta.json
+++ b/src/data/proofs/erdos-1150/meta.json
@@ -28,17 +28,19 @@
     "originalContributions": [
       "Definition IsLittlewoodPolynomial, supNorm, IsUltraflat, Erdos1150Conjecture",
       "Proved parseval_bound_pos (√(n+1) > 0)",
+      "Proved conjecture_implies_no_ultraflat (forward direction: conjecture → no ultraflat)",
+      "Proved conjecture_equiv_no_ultraflat (full iff from proved forward + axiom backward)",
       "Proved flat_does_not_imply_ultraflat (flat ≠ ultraflat)",
-      "Proved erdos_1150_summary (Parseval + BBMST combined)",
+      "Proved erdos_1150_summary (Parseval + BBMST + equivalence combined)",
       "Axiom parseval_lower_bound (sup ≥ √(n+1))",
-      "Axiom conjecture_equiv_no_ultraflat (equivalence with no ultraflat)",
+      "Axiom no_ultraflat_implies_conjecture (backward direction: requires diagonal argument)",
       "Axiom bbmst_flat (flat Littlewood polynomials exist)",
       "Axiom kahane_unimodular_ultraflat (ultraflat for unimodular coefficients)",
       "Axiom rudin_shapiro_bound (concrete ≤ √(2n) family)"
     ],
     "axiomCount": 5,
-    "lineCount": 207,
-    "assumptions": "5 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 253,
+    "assumptions": "5 axiom(s) and 1 sorry(s). Forward direction of equivalence (conjecture → no ultraflat) is proved; backward direction axiomatized."
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #1150 as part of his investigations into extremal properties of polynomials with restricted coefficients. The study of Littlewood polynomials — polynomials with all coefficients ±1 — dates to J.E. Littlewood's 1966 monograph, where he asked about the minimal sup norm on the unit circle. By Parseval's identity, every degree-$n$ Littlewood polynomial satisfies $\\max_{|z|=1}|P(z)| \\ge \\sqrt{n+1}$, since the $L^2$ norm equals $\\sqrt{n+1}$. The question is whether this can be improved by a multiplicative constant. Kahane's 1980 breakthrough showed that for general unimodular coefficients ($|a_k| = 1$, complex phases allowed), ultraflat polynomials exist — the sup norm can be made $(1+o(1))\\sqrt{n}$. This made the ±1 restriction the essential barrier. The problem gained renewed attention after Balister, Bollobás, Morris, Sahasrabudhe, and Tiba (BBMST, 2019) proved flat Littlewood polynomials exist ($c_1\\sqrt{n} \\le |P(z)| \\le c_2\\sqrt{n}$), resolving Erdős Problem #228. But flat is weaker than ultraflat: the gap between 'bounded ratio' and 'ratio converging to 1' is precisely what Problem #1150 asks about. The Rudin-Shapiro polynomials, constructed recursively since the 1950s, provide the best explicit examples with sup norm at most $\\sqrt{2(n+1)}$.",
@@ -85,36 +87,36 @@
       "id": "ultraflat-equivalence",
       "title": "Ultraflat Equivalence",
       "startLine": 83,
-      "endLine": 100,
-      "summary": "Defines IsUltraflat (sequence of Littlewood polynomials with supNorm/√n → 1) and axiomatizes that the conjecture is equivalent to non-existence of such sequences."
+      "endLine": 140,
+      "summary": "Defines IsUltraflat (supNorm/√n → 1). Proves forward direction: conjecture → no ultraflat (by contradiction with Filter.Tendsto). Axiomatizes backward direction (requires diagonal/choice argument). Full equivalence is a theorem."
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 102,
-      "endLine": 143,
+      "startLine": 142,
+      "endLine": 183,
       "summary": "Axiomatizes three landmark results: BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), and derives the BBMST upper bound consequence (contains 1 sorry for the supremum step)."
     },
     {
       "id": "gap-analysis",
       "title": "Flat vs Ultraflat Gap",
-      "startLine": 144,
-      "endLine": 161,
+      "startLine": 184,
+      "endLine": 200,
       "summary": "Formally shows that flat does not logically imply ultraflat. The existence of bounded-ratio polynomials (BBMST) does not give ratio-converging-to-1 polynomials (ultraflat). This is the essential gap that Problem #1150 asks about."
     },
     {
       "id": "rudin-shapiro",
       "title": "Rudin-Shapiro Bound",
-      "startLine": 162,
-      "endLine": 172,
+      "startLine": 201,
+      "endLine": 213,
       "summary": "Axiomatizes the Rudin-Shapiro construction: for each k ≥ 1, a degree-(2^k - 1) Littlewood polynomial with sup norm at most √(2·2^k). Provides the best known explicit upper bound on minimal sup norm."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
-      "startLine": 174,
-      "endLine": 207,
-      "summary": "Packages the two main known results (Parseval bound + BBMST flat existence) into a single theorem erdos_1150_summary, proved directly from the axioms. Documents the state of knowledge in both the docstring and the formal statement."
+      "startLine": 214,
+      "endLine": 253,
+      "summary": "Packages Parseval bound + BBMST flat existence + ultraflat equivalence into erdos_1150_summary, proved from axioms. Now includes the equivalence conjecture ↔ ¬ultraflat as a proved component."
     }
   ],
   "conclusion": {
@@ -155,9 +157,9 @@
       "Filter"
     ],
     "namespace": "Erdos1150",
-    "lineCount": 207,
+    "lineCount": 253,
     "axiomCount": 5,
-    "theoremCount": 4,
+    "theoremCount": 7,
     "definitionCount": 4
   }
 }

--- a/src/data/research/problems/erdos-1150.json
+++ b/src/data/research/problems/erdos-1150.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1150",
   "title": "Erdős #1150",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "ACT",
+  "status": "in-progress",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS: Proved forward direction of equivalence (conjecture → no ultraflat). Reduced axiom conjecture_equiv_no_ultraflat to only the backward direction. File now has 253 lines, 5 axioms, 7 theorems, 1 sorry.",
+    "builtItems": [
+      "conjecture_implies_no_ultraflat theorem: forward direction proved via filter contradiction",
+      "conjecture_equiv_no_ultraflat theorem: full equivalence from proved forward + axiom backward"
+    ],
+    "insights": [
+      "Forward direction is clean: supNorm/√n > 1+c eventually contradicts Tendsto ... (nhds 1)",
+      "Backward direction needs countable choice: extract witnesses for 1/k, build ultraflat sequence",
+      "The bbmst_upper_bound_exists sorry requires ciSup handling for conditional supremum",
+      "Parseval axiom potentially provable if Mathlib has circle integration theory"
+    ],
+    "mathlibGaps": [
+      "ciSup over conditional types in ConditionallyCompleteLattice",
+      "Integration on unit circle (for Parseval)"
+    ],
+    "nextSteps": [
+      "Fix bbmst_upper_bound_exists sorry",
+      "Prove no_ultraflat_implies_conjecture (diagonal argument)",
+      "Explore whether parseval_lower_bound is provable from Mathlib"
+    ],
     "markdown": "# Erdős #1150 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Prove forward direction of the ultraflat equivalence: conjecture → no ultraflat sequences
- Replace full axiom with proved theorem + weaker backward-only axiom
- Update summary theorem to include equivalence as proved component

## Progress
- Proved `conjecture_implies_no_ultraflat` via filter contradiction (supNorm/√n > 1+c eventually contradicts Tendsto → nhds 1)
- `conjecture_equiv_no_ultraflat` is now a theorem (was axiom), combining proved forward + axiomatized backward
- 253 lines, 5 axioms (weaker: only backward direction), 7 theorems (up from 4), 1 sorry

## Findings
- Forward direction is clean: the filter-based proof naturally captures "eventually > 1+c" vs "converges to 1"
- Backward direction genuinely needs countable choice / diagonal argument
- The remaining sorry (bbmst_upper_bound_exists) needs ciSup handling for conditional supremum

## Status
**Outcome**: progress (proved equivalence forward direction)
**Next Steps**: Fix bbmst_upper_bound_exists sorry, potentially prove backward direction

🤖 Generated by researcher-5