### PR TITLE
Enrich bezout-identity-oq-02: add references, expand overview

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02/meta.json
@@ -61,7 +61,7 @@
   "overview": {
     "historicalContext": "**Euclid's Lemma** is one of the oldest and most fundamental results in number theory, appearing in Euclid's *Elements* (~300 BCE) as Proposition VII.30: *'If a prime p divides the product a·b, then p divides a or p divides b.'* Euclid's original proof used the division algorithm and properties of proportions, without the modern algebraic language of Bézout coefficients.\n\nThe Bézout identity itself is named after **Étienne Bézout (1730–1783)**, though the key result — that gcd(a,b) can be expressed as an integer linear combination — was known to **Claude Gaspard Bachet de Méziriac (1624)** and even to **Aryabhata (~499 CE)** in the context of the Kuttaka algorithm for solving linear Diophantine equations.\n\nThe modern algebraic proof of Euclid's lemma via Bézout's identity: if gcd(p,a) = 1, get integers x, y with p·x + a·y = 1. Multiply by c: p·x·c + a·c·y = c. Since p | p·x·c and p | a·b (hypothesis gives a·b = p·k, so a·c·y = ...), deduce p | c. This argument abstracts to any **Bézout domain** or **principal ideal domain (PID)**.\n\nIn Lean 4, this argument is crystallized by the `coprime_iff_linear_combination` theorem: `Nat.Coprime a b ↔ ∃ x y : ℤ, a*x + b*y = 1`. This converts the arithmetic fact 'gcd = 1' into the algebraic witness needed for the proof. The `linear_combination` tactic then closes the goal in a single line by ring arithmetic.",
     "problemStatement": "**Euclid's Lemma (Natural Number Version)**:\n\nIf `Nat.Coprime a b` (i.e., gcd(a, b) = 1) and `a ∣ b * c`, then `a ∣ c`.\n\n**Prime Version**: If p is prime and `p ∣ a * b`, then `p ∣ a` or `p ∣ b`.\n\n**Open Question**: Can this be formally proved using `coprime_iff_linear_combination` as the core tool?\n\n**Answer**: YES — see `euclids_lemma_nat` in this formalization.",
-    "text": "Euclid's lemma proved formally using coprime_iff_linear_combination: if gcd(a,b)=1 and a|b·c, then a|c. The witness x·c+y·k is constructed directly from Bézout coefficients and the divisibility assumption.",
+    "text": "A 192-line formalization of Euclid's lemma via `coprime_iff_linear_combination`. The proof extracts Bézout coefficients $x, y \\in \\mathbb{Z}$ with $a \\cdot x + b \\cdot y = 1$ from the coprimality hypothesis, casts the divisibility $a \\mid b \\cdot c$ to $\\mathbb{Z}$ to get $b \\cdot c = a \\cdot k$, and constructs the explicit witness $a \\mid c$ via $c = a \\cdot (x \\cdot c + y \\cdot k)$. The `linear_combination` tactic verifies the ring identity in one line. Includes three versions: `euclids_lemma_nat` (natural numbers with explicit Bézout coefficients), `euclids_lemma_int` (integers via `IsCoprime`), and `euclids_lemma_prime` (the prime version: $p \\mid a \\cdot b \\Rightarrow p \\mid a \\lor p \\mid b$). Fully verified: 0 sorries, 0 axioms.",
     "proofStrategy": "The proof strategy has four steps:\n\n1. **Extract Bézout coefficients**: Apply `coprime_iff_linear_combination` to get x, y : ℤ with `a*x + b*y = 1`\n\n2. **Cast to ℤ**: Convert `a ∣ b*c` (ℕ) to `(a:ℤ) ∣ (b:ℤ)*(c:ℤ)` using `exact_mod_cast`, get k with `b*c = a*k`\n\n3. **Construct witness**: The divisibility `a ∣ c` is witnessed by `x*c + y*k`. The key identity:\n   `c = (a*x + b*y)*c = a*(x*c) + (b*c)*y = a*(x*c) + (a*k)*y = a*(x*c + y*k)`\n   proved by `linear_combination y * hk - c * hbez`\n\n4. **Cast back**: Use `rw [← Int.natCast_dvd_natCast]` to return to ℕ\n\nThe `linear_combination` verification checks: `y*(b*c - a*k) - c*(a*x + b*y - 1) = 0` by ring.",
     "keyInsights": [
       "**coprime_iff_linear_combination is the right bridge**: It converts 'gcd = 1' (arithmetic) into 'Bézout coefficients exist' (algebraic). The algebraic form is what makes the multiplication argument work.",
@@ -175,6 +175,29 @@
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01"
+  ],
+  "references": [
+    {
+      "authors": "Euclid",
+      "title": "Elements, Book VII, Proposition 30",
+      "year": "-300",
+      "venue": "~300 BCE",
+      "note": "The original statement: if a prime divides a product, it divides one of the factors. Proved using the division algorithm and properties of proportions"
+    },
+    {
+      "authors": "Bézout, Étienne",
+      "title": "Théorie générale des équations algébriques",
+      "year": "1779",
+      "venue": "Paris",
+      "note": "Systematized the result that gcd(a,b) can be expressed as an integer linear combination ax + by, though the key idea was known to Bachet (1624) and Aryabhata (~499 CE)"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition, Chapter 2",
+      "note": "Standard reference for the Euclidean algorithm, Bézout's identity, and Euclid's lemma in the context of the arithmetic of integers"
+    }
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
Enrichment pass for bezout-identity-oq-02 (Euclid's Lemma via coprime_iff_linear_combination).

- Added 3 references (Euclid, Bézout, Hardy-Wright)
- Expanded overview.text with proof structure details