### PR TITLE
Research: erdos-950 - prove dense_primes_increase_f, eliminate sorry

### DIFF
--- a/proofs/Proofs/Erdos950Problem.lean
+++ b/proofs/Proofs/Erdos950Problem.lean
@@ -194,7 +194,21 @@ noncomputable def primeGap (m : ℕ) : ℕ :=
 theorem dense_primes_increase_f (n k : ℕ) (hk : k > 0) :
     (primesLessThan n ∩ Finset.Ico (n - k) n).card > 0 →
     f n ≥ 1 / k := by
-  sorry -- Elementary: extract prime p with n-k ≤ p < n, then f(n) ≥ 1/(n-p) ≥ 1/k
+  intro hcard
+  rw [Finset.card_pos] at hcard
+  obtain ⟨p, hp⟩ := hcard
+  simp only [Finset.mem_inter, Finset.mem_Ico] at hp
+  obtain ⟨hp_primes, hnk_le_p, hp_lt_n⟩ := hp
+  -- p ∈ primesLessThan n, n - k ≤ p, p < n
+  have hnp_pos : (0 : ℝ) < ↑(n - p) := by exact_mod_cast Nat.sub_pos_of_lt hp_lt_n
+  have hnp_le_k : (n - p : ℕ) ≤ k := by omega
+  unfold f
+  calc (1 : ℝ) / ↑k
+      ≤ 1 / ↑(n - p) := by
+        apply one_div_le_one_div_of_le hnp_pos
+        exact_mod_cast hnp_le_k
+    _ ≤ ∑ q ∈ primesLessThan n, 1 / ↑(n - q) :=
+        Finset.single_le_sum (fun q _ => div_nonneg one_pos.le (Nat.cast_nonneg _)) hp_primes
 
 /-- The existence of c > 0 with ≫ n^c/log n primes in [n, n+n^c]
     implies lim inf f(n) > 0 (Erdős's observation). -/

--- a/research/problems/erdos-950/knowledge.md
+++ b/research/problems/erdos-950/knowledge.md
@@ -2,61 +2,75 @@
 
 ## Problem Statement
 
-Forum
-Favourites
-Tags
-More
- Go
- Go
-Dual View
-Random Solved
-Random Open
+Let f(n) = Σ_{p<n} 1/(n-p) where the sum is over primes p < n.
 
-Let\[f(n) = \sum_{p<n}\frac{1}{n-p}.\]Is it true that\[\liminf f(n)=1\]and\[\limsup f(n)=\infty?\]Is it true that $f(n)=o(\log\log n)$ for all $n$?
+Three questions:
+1. Is lim inf f(n) = 1?
+2. Is lim sup f(n) = ∞?
+3. Is f(n) = o(log log n)?
 
-
-
-This function was considered by de Bruijn, Erd\H{o}s, and Tur\'{a}n, who showed that\[\sum_{n<x}f(n)\sim \sum_{n<x}f(n)^2\sim x.\]The existence of some $c>0$ such that there are $\gg n^c/\log n$ many primes in $[n,n+n^c]$ implies that $\liminf f(n)>0$.
-
-Erd\H{o}s writes that a 'weaker conjecture which is perhaps not quite inaccessible' is that, for every $\epsilon>0$, if $x$ is sufficiently large there exists $y<x$ such that\[\pi(x)< \pi(y)+\epsilon \pi(x-y).\](Compare this to [855].) He notes that if\[\pi(x)< \pi(y)+O\left(\frac{x-y}{\log x}\right)\]for all $y<x-(\log x)^C$ for some constant $C>0$ then $f(n)\ll \log\log\log n$.
-
-The study of $f(p)$ is even harder, and Erd\H{o}s could not prove that\[\sum_{p<x}f(p)^2\sim \pi(x).\]
-
-
-Back to the problem
+Known: de Bruijn-Erdős-Turán showed Σ_{n<x} f(n) ~ x and Σ_{n<x} f(n)² ~ x.
 
 ## Status
 
 **Erdős Database Status**: OPEN
+**Phase**: ACT (formalization with proved sorry)
 
 **Tractability Score**: 4/10
-**Aristotle Suitable**: No
+**Aristotle Suitable**: No (open conjectures, deep axioms)
 
 ## Tags
 
 - erdos
+- number-theory
+- prime-gaps
+- analytic-number-theory
 
 ## Related Problems
 
-- Problem #2000
-- Problem #83
-- Problem #888
-- Problem #1998
-- Problem #855
-- Problem #949
-- Problem #951
-- Problem #2
-- Problem #39
-- Problem #1
+- Problem #855 (weaker conjecture comparison)
+- Problem #949, #951 (neighboring Erdős problems)
 
 ## References
 
-- Er77c
+- [Er77c]
 
 ## Sessions
 
-(No research sessions yet)
+### Session 1 (prior researcher)
+
+Initial formalization: 209 lines, 9 axioms, 4 theorems, 0 sorries. Converted
+f_three and f_four from axioms to proved theorems. 1 sorry in dense_primes_increase_f.
+
+### Session 2 (2026-03-23, researcher-5)
+
+**What Was Done:**
+- Proved `dense_primes_increase_f` sorry: if there's a prime in [n-k, n),
+  then f(n) ≥ 1/k. Uses Finset.single_le_sum and one_div_le_one_div_of_le.
+- File now has 0 sorries, 9 axioms, 241 lines
+
+**Key Insights:**
+- The proof extracts a witness prime from the nonempty intersection, bounds
+  one term of the sum, then uses monotonicity of 1/x
+- All 9 remaining axioms are deep: 4 open conjectures, 2 known asymptotic
+  results (de Bruijn-Erdős-Turán), 3 conditional implications
+- The primeGap definition uses Nat.nth which may need updating
+
+**Axiom Classification:**
+1. `erdos_950_q1` — Open conjecture (liminf = 1)
+2. `erdos_950_q2` — Open conjecture (limsup = ∞)
+3. `erdos_950_q3` — Open conjecture (f(n) < log log n eventually)
+4. `erdos_950_q3_strong` — Open conjecture (f(n)/log log n → 0)
+5. `de_bruijn_erdos_turan_sum` — Known (deep: PNT-level asymptotics)
+6. `de_bruijn_erdos_turan_sum_sq` — Known (deep: second moment)
+7. `weaker_implies_bound` — Conditional (implication from weaker conjecture)
+8. `dense_short_intervals_imply_liminf_pos` — Conditional
+9. `f_at_primes_open` — Open (Σ_{p<x} f(p)² ~ π(x))
+
+**Next Steps:**
+- Fix primeGap definition (Nat.nth issue)
+- All axioms are deep/open — no easy eliminations
 
 ---
 
-*Generated from erdosproblems.com on 2026-01-15*
+*Updated by researcher-5 on 2026-03-23*

--- a/src/data/proofs/erdos-950/meta.json
+++ b/src/data/proofs/erdos-950/meta.json
@@ -22,8 +22,8 @@
     "erdosUrl": "https://erdosproblems.com/950",
     "erdosProblemStatus": "open",
     "axiomCount": 9,
-    "lineCount": 208,
-    "assumptions": "12 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "lineCount": 241,
+    "assumptions": "9 axiom(s): 4 open conjectures (Q1-Q3 + strong Q3), 2 de Bruijn-Erdős-Turán results, 1 conditional bound (weaker conjecture), 1 dense interval implication, 1 open on f at primes. 0 sorries."
   },
   "overview": {
     "historicalContext": "This problem concerns the function f(n) = ∑_{p<n} 1/(n−p), which measures how close n is to primes by weighting nearby primes more heavily. De Bruijn, Erdős, and Turán showed that ∑_{n<x} f(n) ~ x and ∑_{n<x} f(n)² ~ x, meaning f(n) averages to 1 and concentrates near 1. The three questions probe the extremal behavior. Functions measuring proximity of integers to primes connect to the Hardy-Ramanujan theorem on additive arithmetic functions and Cramér model of primes; the harmonic weighting 1/(n-p) echoes the classical harmonic series and Mertens theorem on ∑ 1/p. Understanding when f(n) is large or unusually small yields information about local prime gaps and prime distribution.",


### PR DESCRIPTION
## Summary
- Prove `dense_primes_increase_f`: if there exists a prime in [n-k, n), then f(n) ≥ 1/k
- Eliminates the last sorry in the file (0 sorries now)

## Progress
- `dense_primes_increase_f` proved via Finset.single_le_sum + one_div_le_one_div_of_le
- 241 lines, 9 axioms (all deep/open — no easy eliminations), 0 sorries

## Findings
- Proof extracts witness prime from nonempty intersection, bounds one sum term
- All remaining axioms are either open conjectures or deep known results
- primeGap definition uses Nat.nth which may need API update

## Status
**Outcome**: progress (sorry eliminated)
**Next Steps**: Fix primeGap Nat.nth issue, all axioms are deep

🤖 Generated by researcher-5