### PR TITLE
Audit fix: correct badge original→mathlib for 2 proofs

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
@@ -16,7 +16,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ04OQ02.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "monte-carlo"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary

- `buffons-needle`: badge `original` → `mathlib` (main integral from Mathlib's `integral_sin`)
- `binomial-theorem-oq-04-oq-02`: badge `original` → `mathlib` (all theorems are one-line Mathlib wrappers)

## Evidence

**buffons-needle**: The proof of `integral_sin_zero_pi` at line 114 directly calls `rw [integral_sin]` — the core computation is Mathlib's. The named "Buffon's Needle Theorem" (`buffon_needle_probability`) is just `field_simp; ring` on an algebraic identity.

**binomial-theorem-oq-04-oq-02**: Every theorem delegates directly to a named Mathlib lemma: `pow_add`, `Nat.add_choose_eq`, `Polynomial.coeff_mul`, `Nat.choose_succ_succ`. No original proof content.

## Test plan

- [ ] Verify meta.json files are valid JSON
- [ ] Check badges display correctly on gallery pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)