### PR TITLE
Audit fix: buffons-needle-oq-01-oq-01 axiomCount 1→0, status→verified

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,7 +20,7 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -70,9 +70,9 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 390,
-    "assumptions": "1 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "0 axioms, 0 sorries. Main theorem uses explicit hypotheses (Fubini integrability) rather than axioms."
   },
   "overview": {
     "historicalContext": "In buffons-needle-oq-01 (Buffon's Noodle), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector γ'(t), the integral of |crossings contribution| over all angles θ gives exactly 2‖γ'(t)‖. Integrating over t gives 2L/(πd).\n\nThe proof uses Complex.arg to find the rotation angle φ such that a sin θ + b cos θ = √(a²+b²) · sin(θ + φ), then applies the rotation-invariant identity ∫_0^π |sin(θ + c)| dθ = 2.",
@@ -194,7 +194,7 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01",
     "lineCount": 390,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 2
   },


### PR DESCRIPTION
## Summary

- `axiomCount`: 1 → 0 (the only `axiom` keyword was inside a comment block)
- `status`: `axiomatized` → `verified`
- `badge`: `axiom` → `verified`

## Evidence

The `axiom` at line 351 of `BuffonsNeedleOQ01OQ01.lean` is inside a `/-! ... -/` doc comment (lines 342-372) — it's a quoted code example, not an actual declaration. A Python script stripping all comments confirms 0 `axiom` declarations and 0 `sorry` keywords in the actual code.

The integrability condition `hInnerInt` is an explicit theorem hypothesis passed to `buffon_smooth_full`, not a Lean `axiom`.

## Test plan

- [ ] Verify meta.json is valid JSON
- [ ] Check gallery page displays correct badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)