### PR TITLE
Audit fix: binomial-theorem-oq-04 badge original → mathlib

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04/meta.json
@@ -16,7 +16,7 @@
       "convolution",
       "pascal-triangle"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [
@@ -58,7 +58,7 @@
     "dateAdded": "2026-02-26",
     "axiomCount": 0,
     "lineCount": 195,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Vandermonde identity derived from Mathlib Nat.add_choose_eq; binomial coefficient properties from Mathlib Nat.choose_symm and Nat.choose_succ_succ."
   },
   "overview": {
     "historicalContext": "Vandermonde's identity was published by Alexandre-Théophile Vandermonde in his 1772 memoir \"Mémoire sur des irrationnelles de différents ordres avec une application au cercle,\" presented to the Académie Royale des Sciences in Paris. However, the identity was known earlier — Zhu Shijie stated a version in his 1303 text *Siyuan Yujian* (Jade Mirror of the Four Unknowns), and the combinatorial interpretation was implicit in the work of Blaise Pascal (1654) and Isaac Newton.\n\nVandermonde's contribution was to systematically study determinants and combinatorial identities together. The identity is the cornerstone of combinatorial convolution theory: it underpins the hypergeometric distribution in probability (where the summand $\\binom{m}{k}\\binom{n}{r-k}/\\binom{m+n}{r}$ gives the PMF), the Cauchy product of generating functions, and lattice path counting via the Lindström–Gessel–Viennot lemma.\n\nThe special case $\\binom{2n}{n} = \\sum \\binom{n}{k}^2$ connects to the central binomial coefficient, which governs the asymptotics of random walks ($\\binom{2n}{n} \\sim 4^n / \\sqrt{\\pi n}$) and appears in the Catalan number formula $C_n = \\binom{2n}{n}/(n+1)$.",


### PR DESCRIPTION
## Summary
- Change badge from `"original"` to `"mathlib"` for binomial-theorem-oq-04
- Update assumptions field to credit Mathlib's `Nat.add_choose_eq`

Vandermonde identity is proved via Mathlib's `Nat.add_choose_eq` + `sum_antidiagonal_eq_sum_range_succ`. Badge should reflect Tier B.

## Test plan
- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)