### PR TITLE
Audit fix: cantor-diagonalization-oq-02-oq-01 badge original→mathlib

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ02OQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary

- Badge `original` → `mathlib` for `cantor-diagonalization-oq-02-oq-01`
- All theorems are thin wrappers over named Mathlib lemmas (`Cardinal.aleph_lt_aleph`, `Cardinal.isRegular_aleph_one`, `Cardinal.card_ord`)

## Test plan

- [ ] Verify meta.json is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)