### PR TITLE
Peer review: arithmetic-series (B)

### DIFF
--- a/src/data/proofs/arithmetic-series/review.json
+++ b/src/data/proofs/arithmetic-series/review.json
@@ -1,0 +1,115 @@
+{
+  "version": 1,
+  "proofId": "arithmetic-series",
+  "reviewDate": "2026-03-23T13:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "B",
+    "oneLiner": "Classic Wiedijk #68 formalization with excellent historical exposition and genuine extensions (odd numbers, triangular recurrence), but the core result is a direct Mathlib call and theorem count is inflated by wrappers and computational checks.",
+    "tier": "B",
+    "tierJustification": "The foundational result (gauss_sum_zero_indexed) is literally Finset.sum_range_id. The file adds real value through the general arithmetic series formula, sum-of-odd-numbers induction, and triangular number recurrence, but the mathematical heavy lifting is done by Mathlib."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json overview.historicalContext and references",
+      "finding": "The historical exposition is exemplary. It tells the Gauss anecdote responsibly (noting the earliest source is von Waltershausen's 1856 biography), mentions pre-Gauss origins (Archimedes, Aryabhata, Babylonian mathematics), and cites Brian Hayes's 2006 American Scientist article investigating the anecdote's accuracy. This level of historical rigor is rare in formalization projects.",
+      "recommendation": "Preserve this historical context as a model for other gallery entries."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "sum_odd_numbers (line 123-128) and triangular_recurrence (line 151-167)",
+      "finding": "These are the file's best proofs. sum_odd_numbers uses clean induction (sum_range_succ + ring), and triangular_recurrence tackles the tricky natural number division by 2 with an even/odd case split and a careful calc block. The divisibility argument for 2 | n*(n+1) is genuine proof work that isn't available as a single Mathlib call.",
+      "recommendation": "No changes needed. These demonstrate solid Lean proof technique."
+    },
+    {
+      "severity": "minor",
+      "category": "filler",
+      "location": "gauss_sum_zero_indexed, line 57-58",
+      "finding": "This theorem is literally Finset.sum_range_id n -- a one-token Mathlib call with zero added value. It serves as the foundation for gauss_sum but could be inlined. The annotation marks it significance 'key' which inflates its importance.",
+      "recommendation": "Consider inlining into gauss_sum or labeling it clearly as a Mathlib re-export. Not critical."
+    },
+    {
+      "severity": "minor",
+      "category": "filler",
+      "location": "gauss_100 (line 113) and sum_0_to_10 (line 116)",
+      "finding": "Both are native_decide computational checks with zero proof content. While pedagogically cute (verifying Gauss's original problem), they contribute nothing to the formal development. They inflate the theorem count from 9 to 11.",
+      "recommendation": "Keep as pedagogical examples but don't count them among 'original contributions'. They could be moved to a #eval or example block."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "Lines 180-185 (#check commands)",
+      "finding": "Six #check debug commands left at the end of the file. These are development artifacts that don't belong in production code. They don't affect correctness but signal incomplete cleanup.",
+      "recommendation": "Remove the #check lines. This is a trivial cleanup."
+    },
+    {
+      "severity": "minor",
+      "category": "overclaim",
+      "location": "meta.json originalContributions[4]",
+      "finding": "The fifth original contribution is listed as 'Historical context about Gauss's schoolboy discovery.' While the historical exposition is excellent, it is prose, not a formal mathematical contribution. Listing it alongside theorem formalizations conflates two different kinds of work and mildly inflates the contribution count from 4 to 5.",
+      "recommendation": "Remove this item from originalContributions or move it to a separate 'editorial contributions' field. The historical context speaks for itself in the overview."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json mathlibDependencies",
+      "finding": "Only 2 Mathlib dependencies are listed (sum_range_id, sum_range_id_mul_two), but the file uses at least 6 additional Mathlib lemmas: sum_add_distrib (line 106, crucial for arithmetic_series_sum), sum_const (line 106), card_range (line 106), sum_range_succ (line 127, crucial for sum_odd_numbers induction), sum_mul (line 135), and Nat.div_mul_cancel (line 172). The dependency list gives an incomplete picture of how much the file relies on Mathlib.",
+      "recommendation": "Add at minimum sum_add_distrib and sum_range_succ to mathlibDependencies, as these are structurally important to the two most substantive proofs."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "annotations.json ann-triangular-recurrence",
+      "finding": "The triangular_recurrence annotation has significance 'supporting', but this is the most technically demanding proof in the file (17 lines, even/odd case split, divisibility argument, calc block). It should be 'key' -- it demonstrates the most original Lean proof work of any theorem in the file.",
+      "recommendation": "Change significance from 'supporting' to 'key' for ann-triangular-recurrence."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Remove the six #check debug commands at lines 180-185 of ArithmeticSeries.lean. These are development artifacts.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Add missing mathlibDependencies: at minimum sum_add_distrib (from Mathlib.Algebra.BigOperators.Ring.Finset, used in arithmetic_series_sum) and sum_range_succ (from Mathlib.Algebra.BigOperators.Intervals, used in sum_odd_numbers induction step).",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Change annotation ann-triangular-recurrence significance from 'supporting' to 'key'. This is the most technically demanding proof in the file.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Remove 'Historical context about Gauss's schoolboy discovery' from originalContributions. The historical exposition is excellent but it is editorial work, not a formal mathematical contribution.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 6,
+    "originalityAccuracy": 6,
+    "completeness": 9,
+    "framingPrecision": 7,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 8,
+    "overall": 7.3
+  },
+
+  "suggestedBestFraming": "A Mathlib-based formalization of Gauss's summation formula (Wiedijk #68) that bridges the 0-indexed Finset.sum_range_id to the classical 1-indexed form, extends to a general arithmetic series formula, and proves the sum-of-odd-numbers identity and triangular number recurrence with genuine Lean proof techniques."
+}


### PR DESCRIPTION
## Summary

Peer review of **Sum of an Arithmetic Series** (`arithmetic-series`, Wiedijk #68).

**Grade: B** (7.3/10) | **Tier: B** (Mathlib-based formalization)

### Scores
| Dimension | Score |
|-----------|-------|
| Mathematical Substance | 6/10 |
| Originality Accuracy | 6/10 |
| Completeness | 9/10 |
| Framing Precision | 7/10 |
| Pedagogical Quality | 8/10 |
| Internal Consistency | 8/10 |

### Key Findings
- **Strengths**: Exemplary historical exposition with responsible attribution (cites Hayes 2006 on the Gauss anecdote's accuracy). Genuine Lean proof work in `triangular_recurrence` (divisibility argument) and `sum_odd_numbers` (induction).
- **Issues**: Core result (`gauss_sum_zero_indexed`) is a literal Mathlib re-export. Two `native_decide` computational checks inflate theorem count. `#check` debug commands left in production code. `mathlibDependencies` lists only 2 of 6+ used Mathlib lemmas. "Historical context" listed as an originalContribution alongside theorems.

### Action Items (4)
1. **Researcher** (low): Remove #check debug lines
2. **Enricher** (medium): Add missing mathlibDependencies (sum_add_distrib, sum_range_succ)
3. **Enricher** (low): Reclassify triangular_recurrence annotation to "key"
4. **Enricher** (low): Remove historical context from originalContributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)