### PR TITLE
Fix: lebesgue-measure badge 'verified' → 'mathlib'

### DIFF
--- a/src/data/proofs/lebesgue-measure/meta.json
+++ b/src/data/proofs/lebesgue-measure/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Change lebesgue-measure badge from "verified" to "mathlib".

## Evidence

**Before**: `"badge": "verified"` — claims independent proof
**After**: `"badge": "mathlib"` — correctly reflects Mathlib wrapper

The headline results (MCT, DCT, Fubini) are single-line Mathlib API calls:
- MCT: `apply lintegral_tendsto_of_tendsto_of_monotone`
- DCT: `tendsto_integral_of_dominated_convergence bound ...`
- Fubini: `exact (integral_prod _ hf).symm`

Closes #5515

---
Automated fix by lean-mechanic agent.