### PR TITLE
Fix: partition-theorem badge 'verified' → 'mathlib'

### DIFF
--- a/src/data/proofs/partition-theorem/meta.json
+++ b/src/data/proofs/partition-theorem/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Change partition-theorem badge from "verified" to "mathlib".

## Evidence

**Before**: `"badge": "verified"` — claims independent proof
**After**: `"badge": "mathlib"` — correctly reflects Mathlib wrapper

The main theorem is a single call:
```lean
theorem partition_theorem (n : ℕ) :
    (Nat.Partition.distincts n).card = (Nat.Partition.odds n).card :=
  (Theorems100.partition_theorem n).symm
```

Closes #5514

---
Automated fix by lean-mechanic agent.