### PR TITLE
Research: erdos-1158 - fix compilation, prove sorry, add structural theorems

### DIFF
--- a/proofs/Proofs/Erdos1158Problem.lean
+++ b/proofs/Proofs/Erdos1158Problem.lean
@@ -30,6 +30,7 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 namespace Erdos1158
 
@@ -66,11 +67,9 @@ hyperedges is r^t.
 A t-uniform hypergraph H on vertex set V contains K_t(r) as a sub-hypergraph
 if there exist t disjoint sets A₁, ..., A_t each of size r such that every
 transversal (one vertex from each Aᵢ) forms a hyperedge of H.
-
-We model this for the specific case of t = 2 (bipartite) for concreteness,
-and axiomatize the general case.
 -/
-def containsKtr (H : UniformHypergraph V t) [Fintype V] [DecidableEq V] (r : ℕ) : Prop :=
+def containsKtr {V : Type*} [Fintype V] [DecidableEq V] {t : ℕ}
+    (H : UniformHypergraph V t) (r : ℕ) : Prop :=
   ∃ (parts : Fin t → Finset V),
     -- Each part has exactly r vertices
     (∀ i, (parts i).card = r) ∧
@@ -83,7 +82,8 @@ def containsKtr (H : UniformHypergraph V t) [Fintype V] [DecidableEq V] (r : ℕ
 /--
 A t-uniform hypergraph is K_t(r)-free if it does not contain K_t(r).
 -/
-def isKtrFree (H : UniformHypergraph V t) [Fintype V] [DecidableEq V] (r : ℕ) : Prop :=
+def isKtrFree {V : Type*} [Fintype V] [DecidableEq V] {t : ℕ}
+    (H : UniformHypergraph V t) (r : ℕ) : Prop :=
   ¬containsKtr H r
 
 /-
@@ -98,9 +98,11 @@ The hypergraph Turán number ex_t(n, K_t(r)):
 the maximum number of edges in a K_t(r)-free t-uniform hypergraph on n vertices.
 -/
 noncomputable def exHypergraph (t n r : ℕ) : ℕ :=
-  sSup {m : ℕ | ∃ (V : Type) [Fintype V] [DecidableEq V],
-    ∃ (H : UniformHypergraph V t),
-      Fintype.card V = n ∧ isKtrFree H r ∧ H.edgeCount = m}
+  sSup {m : ℕ | ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V),
+    ∃ (H : @UniformHypergraph V ‹Fintype V› ‹DecidableEq V› t),
+      @Fintype.card V ‹Fintype V› = n ∧
+      @isKtrFree V ‹Fintype V› ‹DecidableEq V› t H r ∧
+      @UniformHypergraph.edgeCount V ‹Fintype V› ‹DecidableEq V› t H = m}
 
 /-
 ## Part IV: Known Upper Bound
@@ -119,7 +121,7 @@ The conjectured exponent for the hypergraph Turán number:
 For t=2: this gives 2 - r^{-1} = 2 - 1/r (the KST exponent).
 For t=3, r=2: this gives 3 - 2^{-2} = 3 - 1/4 = 11/4 = 2.75.
 -/
-def hypergraphExponent (t r : ℕ) : ℝ :=
+noncomputable def hypergraphExponent (t r : ℕ) : ℝ :=
   (t : ℝ) - (r : ℝ)^(1 - (t : ℝ))
 
 /--
@@ -191,28 +193,26 @@ This is exactly Erdős Problem #714.
 
 /--
 The t=2 exponent simplifies to the Kővári-Sós-Turán exponent:
-  hypergraphExponent 2 r = 2 - r^{-1} = 2 - 1/r
+  hypergraphExponent 2 r = 2 - 1/r
 -/
-theorem exponent_t2 (r : ℕ) (hr : r ≥ 1) :
+theorem exponent_t2 (r : ℕ) (_hr : r ≥ 1) :
     hypergraphExponent 2 r = 2 - (r : ℝ)⁻¹ := by
   unfold hypergraphExponent
-  simp [Real.rpow_natCast]
-  ring_nf
-  sorry -- requires rpow simplification for r^(-1 : ℝ) = r⁻¹
+  have h : (1 : ℝ) - (↑(2 : ℕ) : ℝ) = -1 := by norm_num
+  rw [h, Real.rpow_neg_one]
+  push_cast; ring
 
 /--
-For t=2, r=2: the exponent is 3/2.
+For t=2, r=2: the exponent is 3/2 (the Zarankiewicz exponent for C₄).
 -/
-theorem exponent_t2_r2 : hypergraphExponent 2 2 = 2 - (2 : ℝ)^((1 : ℝ) - 2) := by
-  unfold hypergraphExponent
-  norm_num
+theorem exponent_t2_r2 : hypergraphExponent 2 2 = 3 / 2 := by
+  rw [exponent_t2 2 (by norm_num)]; norm_num
 
 /--
-For t=2, r=3: the exponent is 5/3.
+For t=2, r=3: the exponent is 5/3 (Brown's exponent for K_{3,3}).
 -/
-theorem exponent_t2_r3 : hypergraphExponent 2 3 = 2 - (3 : ℝ)^((1 : ℝ) - 2) := by
-  unfold hypergraphExponent
-  norm_num
+theorem exponent_t2_r3 : hypergraphExponent 2 3 = 5 / 3 := by
+  rw [exponent_t2 3 (by norm_num)]; norm_num
 
 /-
 ## Part VIII: Known Cases of the Conjecture
@@ -275,5 +275,46 @@ axiom stepping_up_lemma (t r : ℕ) (ht : t ≥ 3) (hr : r ≥ 2)
 theorem erdos_1158_known_cases :
     erdos1158Conjecture 2 2 ∧ erdos1158Conjecture 2 3 := by
   exact ⟨conjecture_t2_r2, conjecture_t2_r3⟩
+
+/-
+## Part XI: Structural Properties of the Exponent
+-/
+
+/--
+The hypergraph exponent is strictly less than t for any r ≥ 2.
+This follows because r^{1-t} > 0 for positive r, so subtracting it gives less than t.
+-/
+theorem exponent_lt_t (t r : ℕ) (_ht : t ≥ 2) (hr : r ≥ 2) :
+    hypergraphExponent t r < (t : ℝ) := by
+  unfold hypergraphExponent
+  linarith [Real.rpow_pos_of_pos (show (0 : ℝ) < (r : ℝ) by positivity) ((1 : ℝ) - (t : ℝ))]
+
+/--
+The hypergraph exponent is at least t - 1 for r ≥ 1, t ≥ 1.
+Since r ≥ 1 and 1 - t ≤ 0, we have r^{1-t} ≤ r^0 = 1, giving t - r^{1-t} ≥ t - 1.
+-/
+theorem exponent_ge_t_sub_one (t r : ℕ) (ht : t ≥ 1) (hr : r ≥ 1) :
+    hypergraphExponent t r ≥ (t : ℝ) - 1 := by
+  unfold hypergraphExponent
+  have hr_cast : (1 : ℝ) ≤ (r : ℝ) := by exact_mod_cast hr
+  have ht_cast : (1 : ℝ) ≤ (t : ℝ) := by exact_mod_cast ht
+  have h_rpow_le : (r : ℝ) ^ ((1 : ℝ) - (t : ℝ)) ≤ 1 := by
+    calc (r : ℝ) ^ ((1 : ℝ) - (t : ℝ))
+        ≤ (r : ℝ) ^ (0 : ℝ) := by
+          apply Real.rpow_le_rpow_of_exponent_le hr_cast; linarith
+      _ = 1 := Real.rpow_zero _
+  linarith
+
+/--
+The hypergraph exponent is positive for t ≥ 2 and r ≥ 1.
+Combining t ≥ 2 with r^{1-t} ≤ 1 gives t - r^{1-t} ≥ 2 - 1 = 1 > 0.
+-/
+theorem exponent_pos (t r : ℕ) (ht : t ≥ 2) (hr : r ≥ 1) :
+    0 < hypergraphExponent t r := by
+  have h := exponent_ge_t_sub_one t r (by omega) hr
+  have : (1 : ℝ) ≤ (t : ℝ) - 1 := by
+    have : (2 : ℝ) ≤ (t : ℝ) := by exact_mod_cast ht
+    linarith
+  linarith
 
 end Erdos1158

--- a/research/problems/erdos-1158/knowledge.md
+++ b/research/problems/erdos-1158/knowledge.md
@@ -68,4 +68,39 @@ and ex_t(n, K_t(r)) is the hypergraph Turán number.
 
 ---
 
+### Session 2 (2026-03-24, researcher-4)
+
+**What Was Done:**
+- Fixed all pre-existing compilation errors (file now compiles cleanly with 0 warnings)
+  - Fixed Fintype synthesis: explicit type parameters in containsKtr/isKtrFree
+  - Fixed existential syntax in exHypergraph (brackets → explicit instances)
+  - Added noncomputable to hypergraphExponent
+- Proved the exponent_t2 sorry using Real.rpow_neg_one + push_cast
+- Strengthened exponent_t2_r2 and exponent_t2_r3 to compute exact numerical values (3/2 and 5/3)
+- Added 3 new fully proved structural theorems:
+  - exponent_lt_t: α(t,r) < t (rpow is positive)
+  - exponent_ge_t_sub_one: α(t,r) ≥ t-1 (rpow ≤ 1 for base ≥ 1, exponent ≤ 0)
+  - exponent_pos: α(t,r) > 0 for t ≥ 2
+- Added import for Mathlib.Analysis.SpecialFunctions.Pow.Real
+- Updated gallery metadata, annotations, and sections
+
+**Result:** 320 lines, 5 axioms, 7 theorems, 0 sorries (was: 279 lines, 4 theorems, 1 sorry)
+
+**Key Insights:**
+- Real.rpow_neg_one is unconditional (no hypothesis needed) — works even at x=0
+- Real.rpow_le_rpow_of_exponent_le is the correct monotonicity lemma for base ≥ 1
+- The original file had syntax errors from researcher-5 that prevented compilation
+
+**Axiom Assessment (unchanged):**
+All 5 axioms remain deep — none are routine enough to prove from Mathlib.
+
+**Next Steps:**
+- Consider explicit connection theorem between exHypergraph 2 and Erdos714 namespace
+- Potential Aristotle companion file if any supporting lemmas become clearer
+- The problem is essentially complete for formalization — main conjecture is open
+
+---
+
+*Updated by researcher-4 on 2026-03-24*
+
 *Updated by researcher-5 on 2026-03-23*

--- a/src/data/proofs/erdos-1158/annotations.json
+++ b/src/data/proofs/erdos-1158/annotations.json
@@ -113,7 +113,7 @@
     "range": { "startLine": 192, "endLine": 215 },
     "type": "technique",
     "title": "Reduction to the Graph Case (t = 2)",
-    "content": "When $t = 2$, a $2$-uniform hypergraph is simply a graph, $K_2(r) = K_{r,r}$, and the problem reduces to the Zarankiewicz problem (Erdős #714). The theorems `exponent_t2_r2` and `exponent_t2_r3` verify that the general exponent formula specializes correctly to $3/2$ and $5/3$ respectively. The `exponent_t2` theorem shows the general reduction $t - r^{1-t} \\mapsto 2 - 1/r$ (with one sorry for `rpow` simplification).",
+    "content": "When $t = 2$, a $2$-uniform hypergraph is simply a graph, $K_2(r) = K_{r,r}$, and the problem reduces to the Zarankiewicz problem (Erdős #714). The theorem `exponent_t2` proves $\\alpha(2, r) = 2 - 1/r$ using `Real.rpow_neg_one`. The special case theorems `exponent_t2_r2` and `exponent_t2_r3` compute the exact numerical values $3/2$ and $5/3$.",
     "mathContext": "For $t = 2$: $\\alpha(2, r) = 2 - r^{1-2} = 2 - r^{-1} = 2 - 1/r$. Special cases: $\\alpha(2,2) = 3/2$ and $\\alpha(2,3) = 5/3$. The Zarankiewicz number $z(n; r) = \\mathrm{ex}_2(n, K_{2,2}(r)) = \\mathrm{ex}(n; K_{r,r})$.",
     "significance": "supporting",
     "relatedConcepts": ["Zarankiewicz problem", "erdos-714", "norm_num tactic", "real power simplification"],
@@ -154,5 +154,17 @@
     "significance": "supporting",
     "relatedConcepts": ["And.intro", "axiom pairing", "problem status documentation"],
     "prerequisites": ["conjecture_t2_r2", "conjecture_t2_r3"]
+  },
+  {
+    "id": "structural-properties",
+    "proofId": "erdos-1158",
+    "range": { "startLine": 280, "endLine": 320 },
+    "type": "technique",
+    "title": "Structural Properties of the Exponent",
+    "content": "Three proved structural theorems about `hypergraphExponent`: (1) `exponent_lt_t` shows $\\alpha(t,r) < t$ since $r^{1-t} > 0$; (2) `exponent_ge_t_sub_one` shows $\\alpha(t,r) \\geq t - 1$ since $r^{1-t} \\leq 1$ for $r \\geq 1$; (3) `exponent_pos` shows $\\alpha(t,r) > 0$ for $t \\geq 2$. These bounds confirm the exponent lies in the interval $(t-1, t)$, which matches the combinatorial intuition that $K_t(r)$-free hypergraphs can have nearly $n^t$ edges but not quite.",
+    "mathContext": "$t - 1 \\leq \\alpha(t,r) < t$ for $t \\geq 1$ and $r \\geq 1$. The upper bound uses $r^{1-t} > 0$ for $r > 0$. The lower bound uses $r^{1-t} \\leq r^0 = 1$ for $r \\geq 1$ and $1-t \\leq 0$ (monotonicity of $x \\mapsto x^y$ for $x \\geq 1$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.rpow_pos_of_pos", "Real.rpow_le_rpow_of_exponent_le", "exponent bounds"],
+    "prerequisites": ["hypergraphExponent", "Real.rpow monotonicity", "linarith"]
   }
 ]

--- a/src/data/proofs/erdos-1158/meta.json
+++ b/src/data/proofs/erdos-1158/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1158,
     "erdosUrl": "https://erdosproblems.com/1158",
     "erdosProblemStatus": "open",
@@ -45,10 +45,16 @@
       "erdos_upper_bound axiom: Erdős (1964) upper bound",
       "erdos_lower_bound axiom: weaker lower bound with constant gap",
       "stepping_up_lemma axiom: Erdős-Hajnal stepping-up for uniformities",
-      "erdos_1158_known_cases theorem: t=2 with r=2,3 solved"
+      "erdos_1158_known_cases theorem: t=2 with r=2,3 solved",
+      "exponent_t2 theorem: KST exponent 2-1/r from general formula (proved)",
+      "exponent_t2_r2 theorem: exponent 3/2 for C₄ (proved)",
+      "exponent_t2_r3 theorem: exponent 5/3 for K_{3,3} (proved)",
+      "exponent_lt_t theorem: exponent strictly less than t (proved)",
+      "exponent_ge_t_sub_one theorem: exponent at least t-1 (proved)",
+      "exponent_pos theorem: exponent positive for t≥2 (proved)"
     ],
     "axiomCount": 5,
-    "lineCount": 279,
+    "lineCount": 320,
     "assumptions": "5 axiom(s): erdos_upper_bound (hypergraph KST), erdos_lower_bound (weaker probabilistic bound), conjecture_t2_r2 and conjecture_t2_r3 (known cases), stepping_up_lemma (Erdős-Hajnal)."
   },
   "overview": {
@@ -122,7 +128,7 @@
     {
       "id": "graph-reduction",
       "title": "Reduction to the Graph Case ($t = 2$)",
-      "summary": "Proves the exponent specializes correctly for graphs: `exponent_t2` shows $\\alpha(2, r) = 2 - 1/r$ (with one sorry for rpow simplification), and `exponent_t2_r2`/`exponent_t2_r3` verify the $r = 2$ and $r = 3$ special cases via `norm_num`. This connects Problem #1158 to Problem #714 (Zarankiewicz).",
+      "summary": "Proves the exponent specializes correctly for graphs: `exponent_t2` proves $\\alpha(2, r) = 2 - 1/r$ using `Real.rpow_neg_one`, and `exponent_t2_r2`/`exponent_t2_r3` compute the exact values $3/2$ and $5/3$. This connects Problem #1158 to Problem #714 (Zarankiewicz).",
       "startLine": 182,
       "endLine": 215
     },
@@ -132,6 +138,13 @@
       "summary": "Axiomatizes the two solved cases ($t = 2, r \\in \\{2, 3\\}$ via algebraic constructions) and the Erdős–Hajnal stepping-up lemma that lifts $(t-1)$-uniform bounds to $t$-uniform bounds with exponent $\\alpha + 1$. The final theorem `erdos_1158_known_cases` packages both solved cases. Stepping-up is the only tool for $t \\geq 3$ but compounds the constant gap.",
       "startLine": 217,
       "endLine": 279
+    },
+    {
+      "id": "structural-properties",
+      "title": "Structural Properties of the Exponent",
+      "summary": "Three fully proved theorems bounding `hypergraphExponent`: `exponent_lt_t` ($\\alpha < t$), `exponent_ge_t_sub_one` ($\\alpha \\geq t - 1$), and `exponent_pos` ($\\alpha > 0$ for $t \\geq 2$). Together these show the exponent lies in the interval $(t-1, t)$, matching combinatorial intuition.",
+      "startLine": 280,
+      "endLine": 320
     }
   ],
   "conclusion": {
@@ -162,9 +175,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1158",
-    "lineCount": 279,
+    "lineCount": 320,
     "axiomCount": 5,
-    "theoremCount": 4,
+    "theoremCount": 7,
     "definitionCount": 7
   }
 }

--- a/src/data/research/problems/erdos-1158.json
+++ b/src/data/research/problems/erdos-1158.json
@@ -43,18 +43,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created full Lean 4 formalization (279 lines, 5 axioms). Defined UniformHypergraph, containsKtr via transversals, exHypergraph as Turán number. Stated conjecture with ε-formulation. Axiomatized upper/lower bounds and stepping-up lemma. Proved known cases summary theorem.",
+    "progressSummary": "PROGRESS: Fixed all compilation errors, proved exponent_t2 sorry (rpow_neg_one), added 3 structural theorems (exponent_lt_t, exponent_ge_t_sub_one, exponent_pos). File now compiles cleanly: 320 lines, 5 axioms, 7 theorems, 0 sorries.",
     "builtItems": [
       "proofs/Proofs/Erdos1158Problem.lean: full formalization (279 lines)",
       "src/data/proofs/erdos-1158/: gallery integration (meta.json, annotations.json, index.ts)",
-      "research/problems/erdos-1158/knowledge.md: session notes"
+      "research/problems/erdos-1158/knowledge.md: session notes",
+      "exponent_t2 theorem: proved using Real.rpow_neg_one",
+      "exponent_lt_t, exponent_ge_t_sub_one, exponent_pos: structural bounds on hypergraphExponent"
     ],
     "insights": [
       "The exponent t - r^{1-t} unifies graph (2-1/r) and hypergraph cases",
       "The constant gap (C>1 vs C=1 in exponent) is the essential difficulty",
       "Stepping-up lemma compounds the constant gap across uniformities",
       "Only algebraic constructions (not probabilistic) achieve tight graph bounds",
-      "Connects to Problem #714 as the t=2 specialization"
+      "Connects to Problem #714 as the t=2 specialization",
+      "Real.rpow_neg_one is unconditional - no hypothesis needed",
+      "Original file had pre-existing compilation errors (Fintype synthesis, existential syntax, noncomputable)"
     ],
     "mathlibGaps": [
       "No t-uniform hypergraph theory in Mathlib",


### PR DESCRIPTION
## Summary
- Fixed all pre-existing compilation errors in Erdős #1158 formalization
- Proved the `exponent_t2` sorry (rpow simplification for KST exponent)
- Added 3 new fully proved structural theorems about `hypergraphExponent`

## Changes
**Lean file** (279→320 lines, 4→7 theorems, 1→0 sorries):
- Fixed Fintype synthesis: explicit type params for `containsKtr`/`isKtrFree`
- Fixed existential syntax in `exHypergraph` (brackets → explicit instances)
- Added `noncomputable` to `hypergraphExponent`
- Proved `exponent_t2`: `α(2,r) = 2 - 1/r` via `Real.rpow_neg_one` + `push_cast`
- Strengthened `exponent_t2_r2`/`exponent_t2_r3` to compute exact values (3/2 and 5/3)
- Added `exponent_lt_t`: α(t,r) < t
- Added `exponent_ge_t_sub_one`: α(t,r) ≥ t-1
- Added `exponent_pos`: α(t,r) > 0 for t ≥ 2

**Gallery**: Updated meta.json (sorries 1→0, theorems 4→7), annotations, sections

## Status
**Outcome**: completed
**Axioms**: 5 (all deep — none routine enough to eliminate from Mathlib)
**Sorries**: 0 (was 1)

🤖 Generated by researcher-4