### PR TITLE
Audit fix: cantor-diag-oq02-oq01 badge original → mathlib

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ02OQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -46,17 +46,14 @@
       }
     ],
     "originalContributions": [
-      "Aleph hierarchy: ℵ_α < ℵ_(α+1) for all ordinals α",
-      "Aleph strict monotonicity and injectivity",
-      "ℵ₁ regularity and cofinality = ℵ₁ (uncountable cofinality)",
-      "Countable cardinal characterization: κ < ℵ₁ ↔ κ ≤ ℵ₀",
-      "Ordinal characterization: α < (ℵ₁).ord ↔ card(α) ≤ ℵ₀",
-      "ω₁ is not countable: ¬(card((ℵ₁).ord) ≤ ℵ₀)"
+      "Bridge formalization organizing Mathlib's cardinal/ordinal theorems into a coherent ω₁ property reference",
+      "Countable cardinal characterization: κ < ℵ₁ ↔ κ ≤ ℵ₀ (derived from aleph_succ + lt_succ_iff)",
+      "Ordinal characterization: α < (ℵ₁).ord ↔ card(α) ≤ ℵ₀ (composition of lt_ord + above)"
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 130,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core results (aleph hierarchy, regularity, cofinality) derived from Mathlib's Cardinal.aleph_lt_aleph, isRegular_aleph_one, card_ord, and lt_ord."
   },
   "overview": {
     "historicalContext": "The ordinal $\\omega_1$ — the first uncountable ordinal — was introduced implicitly by Georg Cantor in his 1895 'Beiträge zur Begründung der transfiniten Mengenlehre'. Cantor established the existence of uncountable sets (1891) and the well-ordering of cardinals, but the systematic study of $\\omega_1$ and the aleph hierarchy ($\\aleph_0 < \\aleph_1 < \\aleph_2 < \\cdots$) was refined by Felix Hausdorff (1908) and later placed on rigorous axiomatic footing by von Neumann's ordinal construction. The concept of cofinality — how a limit ordinal is 'approached' by smaller ordinals — was developed by Hausdorff and became central to Easton's theorem and pcf theory. The regularity of $\\aleph_1$ (meaning $\\omega_1$ cannot be expressed as a supremum of countably many smaller ordinals) is a fundamental structural fact that distinguishes $\\aleph_1$ from singular cardinals like $\\aleph_\\omega$.",


### PR DESCRIPTION
## Summary
- Changed badge from `"original"` to `"mathlib"` for cantor-diagonalization-oq-02-oq-01
- Updated `originalContributions` to properly scope independent work (bridge formalization + derived characterizations)
- Updated `assumptions` to credit Mathlib dependencies

## Evidence
Every theorem in `CantorDiagonalizationOQ02OQ01.lean` directly calls Mathlib:
- `aleph_strictMono` = `Cardinal.aleph_lt_aleph.mpr`
- `aleph1_regular` = `Cardinal.isRegular_aleph_one`
- `card_ord_aleph1` = `Cardinal.card_ord _`
- `cof_ord_aleph1` = `Cardinal.isRegular_aleph_one.cof_eq`

Badge `"original"` overstates independent contribution. Per audit tier classification, this is Tier B (Mathlib bridge).

## Test plan
- [ ] Verify meta.json is valid JSON
- [ ] Verify gallery renders correctly

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)