### PR TITLE
Fix: badge/status inconsistencies in 6 gallery proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -17,7 +17,7 @@
       "generalization",
       "research"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
       "gaussian",
       "stable-distributions"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -19,7 +19,7 @@
       "coprimality",
       "wiedijk-100"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 4,
     "axiomCount": 0,
     "dateAdded": "2026-03-22",

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -15,6 +15,7 @@
       "open"
     ],
     "sorries": 4,
+    "badge": "wip",
     "sourceUrl": "https://erdosproblems.com/662",
     "erdosUrl": "https://erdosproblems.com/662",
     "relatedProofs": [

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -15,7 +15,7 @@
       "graph-theory",
       "intermediate"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -16,7 +16,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Set badge to "wip" for 6 proofs with status "formalized" that incorrectly had badge "original" or were missing a badge field.

## Evidence

**Before**:
- erdos-662: badge MISSING (status formalized)
- ballot-problem-oq-01: badge "original" (status formalized, 1 sorry)
- central-limit-theorem-oq-01-oq-02: badge "original" (status formalized)
- denumerability-rationals-oq-03: badge "original" (status formalized, 4 sorries)
- prob-method-alteration: badge "original" (status formalized)
- prob-method-applications: badge "original" (status formalized)

**After**: All 6 now have badge "wip", consistent with their "formalized" status.

**Note**: ballot-problem-oq-03-oq-02 (7th proof in issue) was already fixed.

Closes #5535

---
Automated fix by lean-mechanic agent.