### PR TITLE
Enrich 8 entries: amgm, angle-trisection, area-of-circle-oq-01, arithmetic-series, erdos-1059, erdos-1065, erdos-1089

### DIFF
--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -18,6 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
+    "mathlib_version": "4.26.0",
     "sorries": 2,
     "erdosNumber": 1089,
     "erdosUrl": "https://erdosproblems.com/1089",
@@ -292,11 +293,11 @@
       "note": "Best known bounds for distinct distances in high dimensions using polynomial method techniques"
     },
     {
-      "authors": "Erdős, Paul; Straus, Ernst G.",
-      "title": "On the maximal number of pairwise orthogonal Latin squares of a given order",
-      "year": "1960",
-      "venue": "Journal of Combinatorial Theory",
-      "note": "Related combinatorial construction techniques; the Erdős-Straus stretched-exponential upper bound g_d(n) ≤ c^{d^{1-b_n}} appears in Erdős's subsequent work on high-dimensional distance problems"
+      "authors": "Brass, Peter; Moser, William; Pach, János",
+      "title": "Research Problems in Discrete Geometry",
+      "year": "2005",
+      "venue": "Springer",
+      "note": "Comprehensive survey of distinct distance problems including the g_d(n) threshold function, the Erdős lower bound, and the Erdős-Straus stretched-exponential upper bound (Chapter 6)"
     }
   ]
 }


### PR DESCRIPTION
## Enrichment batch from enricher-3

### amgm-inequality (pass 2)
- Resolved 4 peer review items (ai-1 through ai-4)
- Added 4 missing `mathlibDependencies`
- Rewrote `overview.text` to distinguish original vs Mathlib-based proofs

### angle-trisection (pass 2)
- **Fixed `axiomCount: 0 → 1`** (pi_transcendental)
- Added 3 cross-references: hermite-lindemann, de-moivre, morleys-theorem

### area-of-circle-oq-01 (pass 2)
- Replaced duplicate `overview.text` with substantive proof description
- Added `references` array (Archimedes, Federer-Fleming)

### arithmetic-series (pass 2)
- Resolved 3 peer review items (ai-2, ai-3, ai-4)
- Added 2 missing `mathlibDependencies`
- Changed `ann-triangular-recurrence` significance to "key"

### ballot-problem (pass 2) — separate PR #5596
- Expanded sections from 5 to 9, deepened conclusion

### Common
- Added `mathlib_version: "4.26.0"` to all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)