### PR TITLE
Fix: axiomCount mismatches in 7 gallery proofs

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,7 +20,7 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -70,9 +70,9 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 390,
-    "assumptions": "0 axioms, 0 sorries. Main theorem uses explicit hypotheses (Fubini integrability) rather than axioms."
+    "assumptions": "1 axiom: buffon_noodle_smooth_eq (the smooth curve crossing formula, stated as axiom pending full Fubini integration)."
   },
   "overview": {
     "historicalContext": "In buffons-needle-oq-01 (Buffon's Noodle), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector γ'(t), the integral of |crossings contribution| over all angles θ gives exactly 2‖γ'(t)‖. Integrating over t gives 2L/(πd).\n\nThe proof uses Complex.arg to find the rotation angle φ such that a sin θ + b cos θ = √(a²+b²) · sin(θ + φ), then applies the rotation-invariant identity ∫_0^π |sin(θ + c)| dθ = 2.",

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -22,8 +22,8 @@
       "erdos-660",
       "erdos-661"
     ],
-    "axiomCount": 0,
-    "assumptions": "No axioms. 4 sorry(s) remain in the formalization.",
+    "axiomCount": 3,
+    "assumptions": "3 axiom declarations. 4 sorry(s) remain in the formalization.",
     "proofRepoPath": "Proofs/Erdos662Problem.lean"
   },
   "sections": [


### PR DESCRIPTION
## Fix

Correct axiomCount values in 7 meta.json files to match actual axiom declarations in Lean source. Also fixes erroneous audit fix #5575 that set buffons-needle-oq-01-oq-01 to verified despite having an axiom.

## Evidence

**Overcounts fixed** (meta was higher than actual):
| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| erdos-28 | 8 | 6 | sidon_not_basis, erdos_40_from_28 are theorems, not axioms |
| erdos-42 | 7 | 5 | 2 declarations miscounted |
| erdos-654 | 5 | 4 | 1 declaration miscounted |

**Undercounts fixed** (meta was lower than actual):
| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| erdos-592 | 0 | 10 | axiomCount was missing; also fixed status to axiomatized |
| erdos-854 | 5 | 9 | 4 axioms undercounted |
| erdos-662 | 0 | 3 | axiomCount was 0 despite 3 axiom declarations |
| buffons-needle-oq-01-oq-01 | 0 | 1 | Corrects erroneous audit fix #5575; file has `axiom buffon_noodle_smooth_eq` |

**Note**: riemann-hypothesis (meta=41) and birch-swinnerton-dyer (meta=24) have structure-encoded assumptions making exact counts ambiguous — left unchanged.

Closes #5503

---
Automated fix by lean-mechanic agent.