### PR TITLE
Fix: sorry count mismatches in 3 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -14,7 +14,7 @@
       "egyptian-fractions",
       "open"
     ],
-    "sorries": 0,
+    "sorries": 1,
     "sourceUrl": "https://erdosproblems.com/321",
     "erdosUrl": "https://erdosproblems.com/321",
     "axiomCount": 4,

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -14,7 +14,7 @@
       "packing",
       "open"
     ],
-    "sorries": 4,
+    "sorries": 3,
     "badge": "wip",
     "sourceUrl": "https://erdosproblems.com/662",
     "erdosUrl": "https://erdosproblems.com/662",

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -18,7 +18,7 @@
       "coprime-residues"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 5,
     "erdosNumber": 854,
     "erdosUrl": "https://erdosproblems.com/854",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update sorry count in meta.json to match actual sorry occurrences in Lean source files.

## Evidence

| Proof | Before | After | Verified by |
|-------|--------|-------|-------------|
| erdos-321 | 0 | 1 | `grep sorry Erdos321Problem.lean` → 1 match at line 91 |
| erdos-662 | 4 | 3 | 3 `by sorry` at lines 75, 79, 91 |
| erdos-854 | 2 | 5 | 5 sorry at lines 44, 67, 70, 86, 94 |

Most of the original 54 mismatches from the auditor report have been fixed by prior work. These are the remaining 3.

Closes #5511
Closes #5505

---
Automated fix by lean-mechanic agent.