### PR TITLE
Audit fix: cayley-hamilton-minpoly-oq-02-oq-01 badge verified→mathlib

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
       "similarity",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -51,12 +51,8 @@
     ],
     "originalContributions": [
       "conjAlgEquiv: conjugation by invertible matrix P as a K-algebra automorphism (AlgEquiv, not just AlgHom)",
-      "minpoly_similar_via_abstract: matrix similarity preserves minpoly, derived from abstract minpoly.algEquiv_eq",
-      "minpoly_conj_inv_via_abstract: minpoly(PAP⁻¹) = minpoly(A) via abstract theory",
-      "minpoly_algAut_invariant: any algebra automorphism of Mat(n,K) preserves minpoly",
-      "minpoly_subalgebra_eq: subalgebra inclusion preserves minpoly",
-      "minpoly_similar_under_algHom: similar matrices remain indistinguishable under injective algebra homomorphisms",
-      "conjAlgEquiv_trans: composition of conjugation is conjugation by the product"
+      "conjAlgEquiv_trans: composition of conjugation is conjugation by the product",
+      "Bridge connecting Mathlib's abstract minpoly invariance to concrete matrix similarity"
     ],
     "dateAdded": "2026-03-07",
     "relatedProblems": [
@@ -75,7 +71,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 217,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Abstract minpoly invariance derived from Mathlib's minpoly.algEquiv_eq and minpoly.algHom_eq. Original contribution is the conjAlgEquiv construction connecting abstract theory to matrix similarity."
   },
   "overview": {
     "historicalContext": "**Minimal Polynomial as a K-Algebra Invariant**\n\nThe minimal polynomial $\\mu_x$ of an element $x$ in a $K$-algebra $R$ is the monic generator of the ideal $\\ker(\\text{ev}_x : K[X] \\to R)$. A natural question is: if $\\varphi : R \\xrightarrow{\\sim} S$ is a $K$-algebra isomorphism, does $\\mu_{\\varphi(x)} = \\mu_x$?\n\nThe answer is YES, and it follows from a simple observation: polynomial evaluation commutes with algebra homomorphisms. If $\\varphi$ is a $K$-algebra map, then $\\text{ev}_{\\varphi(x)}(p) = \\varphi(\\text{ev}_x(p))$ for any $p \\in K[X]$. So if $\\mu_x$ annihilates $x$, it also annihilates $\\varphi(x)$, and vice versa when $\\varphi$ is injective.\n\nMatrix similarity ($B = P^{-1}AP$) is a special case: the conjugation map $A \\mapsto P^{-1}AP$ is a $K$-algebra automorphism of $M_n(K)$. By the abstract result, similar matrices share the same minimal polynomial.\n\nThis formalization upgrades the conjugation from an AlgHom (as in OQ-02) to an AlgEquiv (the correct abstraction), and derives the matrix result as a one-line corollary of Mathlib's `minpoly.algEquiv_eq`.",


### PR DESCRIPTION
## Summary

- Fix badge from `"verified"` to `"mathlib"` for cayley-hamilton-minpoly-oq-02-oq-01
- Core abstract invariance theorems (minpoly.algEquiv_eq, minpoly.algHom_eq) come directly from Mathlib
- Trim originalContributions to exclude Mathlib re-exports
- Update assumptions field to note Mathlib dependency

## Evidence

**meta.json claimed**: badge "verified", originalContributions listed 7 items including Mathlib re-exports
**Lean file shows**: 4 of 9 theorems are pure Mathlib re-exports (minpoly_invariant_algEquiv, minpoly_invariant_algHom, minpoly_algAut_invariant, minpoly_subalgebra_eq)

## Audit context

Part of gallery integrity audit cycle. Severity: MEDIUM (Narrative Failure Mode #5: "0 sorries" with hidden imports).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)