### PR TITLE
Enrich erdos-623, erdos-626, erdos-636, erdos-780: mathlib_version, coverage, metadata

### DIFF
--- a/src/data/proofs/erdos-780/annotations.json
+++ b/src/data/proofs/erdos-780/annotations.json
@@ -28,8 +28,8 @@
     "id": "ann-e780-imports",
     "proofId": "erdos-780",
     "range": {
-      "startLine": 21,
-      "endLine": 28
+      "startLine": 20,
+      "endLine": 35
     },
     "type": "concept",
     "title": "Imports and Setup",
@@ -74,8 +74,8 @@
     "id": "ann-e780-pairwise",
     "proofId": "erdos-780",
     "range": {
-      "startLine": 46,
-      "endLine": 54
+      "startLine": 45,
+      "endLine": 62
     },
     "type": "definition",
     "title": "Matchings and Colorings",
@@ -97,7 +97,7 @@
     "proofId": "erdos-780",
     "range": {
       "startLine": 63,
-      "endLine": 73
+      "endLine": 80
     },
     "type": "definition",
     "title": "Kneser Hypergraph Structure",
@@ -119,7 +119,7 @@
     "proofId": "erdos-780",
     "range": {
       "startLine": 81,
-      "endLine": 82
+      "endLine": 83
     },
     "type": "definition",
     "title": "The Threshold Function",
@@ -140,7 +140,7 @@
     "proofId": "erdos-780",
     "range": {
       "startLine": 84,
-      "endLine": 94
+      "endLine": 101
     },
     "type": "technique",
     "title": "Alon-Frankl-Lovász Main Theorem (1986)",
@@ -162,8 +162,8 @@
     "id": "ann-e780-tight",
     "proofId": "erdos-780",
     "range": {
-      "startLine": 102,
-      "endLine": 113
+      "startLine": 95,
+      "endLine": 122
     },
     "type": "technique",
     "title": "Tightness Construction",
@@ -185,7 +185,7 @@
     "proofId": "erdos-780",
     "range": {
       "startLine": 123,
-      "endLine": 132
+      "endLine": 139
     },
     "type": "technique",
     "title": "Kneser's Conjecture ($k = 2$)",
@@ -207,7 +207,7 @@
     "proofId": "erdos-780",
     "range": {
       "startLine": 140,
-      "endLine": 150
+      "endLine": 159
     },
     "type": "technique",
     "title": "Small Cases",
@@ -229,7 +229,7 @@
     "proofId": "erdos-780",
     "range": {
       "startLine": 160,
-      "endLine": 165
+      "endLine": 172
     },
     "type": "technique",
     "title": "Erdős-Ko-Rado Connection",
@@ -251,7 +251,7 @@
     "proofId": "erdos-780",
     "range": {
       "startLine": 173,
-      "endLine": 179
+      "endLine": 187
     },
     "type": "technique",
     "title": "Main Result Theorem",
@@ -272,7 +272,7 @@
     "proofId": "erdos-780",
     "range": {
       "startLine": 188,
-      "endLine": 198
+      "endLine": 200
     },
     "type": "technique",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -24,7 +24,7 @@
     "erdosUrl": "https://erdosproblems.com/780",
     "erdosProblemStatus": "solved",
     "dateAdded": "2026-01-22",
-    "mathlib_version": "4.15.0",
+    "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
         "theorem": "SetFamily.Intersecting",
@@ -103,49 +103,49 @@
       "id": "kneser-hypergraph",
       "title": "The Kneser Hypergraph",
       "summary": "Defines `KneserHypergraph` structure with vertices ($r$-subsets), edges ($k$-tuples of pairwise disjoint $r$-sets), uniformity and inclusion constraints. Axiomatizes `chromaticNumber` $\\chi(KG^r(n,k))$.",
-      "startLine": 63,
+      "startLine": 55,
       "endLine": 73
     },
     {
       "id": "main-theorem",
       "title": "The Main Theorem (AFL 1986)",
       "summary": "Defines `threshold k r t` $= kr + (t-1)(k-1)$. Axiomatizes `alon_frankl_lovasz_1986`: $n \\geq n_0 \\implies$ monochromatic $k$-matching in every $t$-coloring. Also `kneser_hypergraph_chromatic_number`: $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$.",
-      "startLine": 75,
+      "startLine": 74,
       "endLine": 94
     },
     {
       "id": "tightness",
       "title": "Tightness Construction",
       "summary": "Defines `tightBound` $= kr - 1 + (t-1)(k-1)$. Axiomatizes `tightness_construction`: partition coloring with $|X_1| = kr-1$, $|X_i| = k-1$ avoids $k$ disjoint monochromatic edges, proving optimality of the threshold.",
-      "startLine": 96,
+      "startLine": 95,
       "endLine": 113
     },
     {
       "id": "kneser-conjecture",
       "title": "Kneser's Conjecture ($k = 2$)",
       "summary": "Axiomatizes `kneser_conjecture`: $\\chi(KG(n,r)) = n - 2r + 2$ for $n \\geq 2r$ (Lovász 1978). Defines `KneserGraph` and `kneserAdj` (disjointness adjacency).",
-      "startLine": 115,
+      "startLine": 114,
       "endLine": 132
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
       "summary": "Four axiomatized instances: $\\chi(KG(5,2)) = 3$ (Petersen graph), $\\chi(KG(7,3)) = 2$, $\\chi(KG(2r,r)) = 2$ (perfect matching), $\\chi(KG(2r+1,r)) = 3$ (odd graph).",
-      "startLine": 134,
+      "startLine": 133,
       "endLine": 150
     },
     {
       "id": "connections",
       "title": "Erdős-Ko-Rado Connection",
       "summary": "Axiomatizes `erdos_ko_rado`: maximum intersecting family of $r$-subsets of $[n]$ has size $\\binom{n-1}{r-1}$ for $n \\geq 2r$, giving $\\alpha(KG(n,r)) = \\binom{n-1}{r-1}$.",
-      "startLine": 152,
+      "startLine": 151,
       "endLine": 165
     },
     {
       "id": "summary",
       "title": "Summary Theorems",
       "summary": "**Proves** `erdos_780_main` (wrapper for AFL axiom) and `erdos_780_summary` (conjunction of AFL + Kneser's conjecture). 0 sorries.",
-      "startLine": 167,
+      "startLine": 166,
       "endLine": 200
     }
   ],
@@ -200,7 +200,7 @@
     "lineCount": 200,
     "axiomCount": 10,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "relatedProofs": [
     "borsuk-ulam",


### PR DESCRIPTION
## Enrichment passes (batch)

### erdos-623
- Added `mathlib_version: "4.26.0"`, 4 new annotations, extended 15 ranges

### erdos-626
- Added `mathlib_version: "4.26.0"`, corrected all section/annotation ranges (~15 line shift), fixed definitionCount

### erdos-636
- Updated `mathlib_version` to 4.26.0, fixed definitionCount, added erdos-637 cross-ref, extended 12 ranges

### erdos-780
- Updated `mathlib_version` to 4.26.0, fixed definitionCount (10→11), made sections contiguous, extended 11 annotation ranges