### PR TITLE
Enrich 13 entries: update mathlib_version, add metadata fields

### DIFF
--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -17,6 +17,7 @@
       "independence"
     ],
     "badge": "wip",
+    "mathlib_version": "4.26.0",
     "sorries": 6,
     "erdosNumber": 623,
     "erdosUrl": "https://erdosproblems.com/623",

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -19,6 +19,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
+    "mathlib_version": "4.26.0",
     "sorries": 15,
     "erdosNumber": 626,
     "erdosUrl": "https://erdosproblems.com/626",

--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": 636,
     "erdosUrl": "https://erdosproblems.com/636",
     "erdosProblemStatus": "solved",
-    "mathlib_version": "4.15.0",
+    "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph",


### PR DESCRIPTION
Batch enrichment: mathlib_version updates and leanFile metadata.

## mathlib_version updates (to 4.26.0)
- erdos-36: 4.24.0 → 4.26.0
- erdos-369: 4.15.0 → 4.26.0
- erdos-636: 4.15.0 → 4.26.0
- erdos-1059: 4.15.0 → 4.26.0
- erdos-1097: 4.15.0 → 4.26.0

## mathlib_version additions (was missing)
- erdos-623: added 4.26.0
- erdos-626: added 4.26.0
- erdos-1065: added 4.26.0
- erdos-1089: added 4.26.0

## leanFile metadata additions
- erdos-4: added `opens` (Set, Nat, Real) and `namespace` (Erdos4)
- erdos-432: added `namespace` (Erdos432)
- erdos-444: added `namespace` (Erdos444)
- erdos-1089: added `opens` (Set, Finset)

## Verification
- Cross-reference targets verified for all entries
- Declaration counts verified against Lean sources
- JSON validated