### PR TITLE
Audit fix: 5 badge corrections (verified/original → mathlib)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01/meta.json
@@ -20,7 +20,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -59,7 +59,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 282,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core adjugate identity and Cayley-Hamilton connection derived from Mathlib's adjugate_mul, charmatrix_det_eq_charpoly, and matPolyEquiv."
   },
   "overview": {
     "historicalContext": "**The Unified Algebraic Identity**\n\nBoth Cramer's Rule and the Cayley-Hamilton theorem rest on the same algebraic foundation: the adjugate identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$. **Cayley** (1858) developed systematic matrix algebra in a paper that encompasses both results. The adjugate matrix — whose entries are signed minors (cofactors) — simultaneously provides explicit solution formulas for linear systems (Cramer's Rule) and the mechanism for proving that matrices annihilate their own characteristic polynomials (Cayley-Hamilton).\n\n**The Connection**\n\nThe classical proof of Cayley-Hamilton applies Cramer's adjugate identity to the \"characteristic matrix\" $\\lambda I - M$ (which has polynomial entries). The determinant of $\\lambda I - M$ is exactly $\\text{charpoly}(M)(\\lambda)$. Applying the adjugate identity and then evaluating at $\\lambda = M$ yields the zero matrix — which is Cayley-Hamilton.\n\n**The Formalization**\n\nThis formalization makes the connection explicit and checkable in Lean 4. It demonstrates that the research question \"Can Cayley-Hamilton be derived from Cramer's Rule?\" has the answer **YES** — and the proof is clean and self-contained.",

--- a/src/data/proofs/de-moivre-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01/meta.json
@@ -20,7 +20,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -65,7 +65,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 231,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core Chebyshev connection (cos(nθ) = T_n(cos θ)) derived from Mathlib's T_real_cos and U_real_cos. Extensive original derivations of explicit angle formulas."
   },
   "overview": {
     "historicalContext": "**De Moivre's Theorem and Multiple Angle Formulas**\n\nDe Moivre's theorem states $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$. By expanding the left side via the binomial theorem and comparing real and imaginary parts, one obtains explicit polynomial formulas:\n$$\\cos(n\\theta) = \\sum_{j=0}^{\\lfloor n/2\\rfloor} \\binom{n}{2j}(-1)^j \\cos^{n-2j}(\\theta)\\sin^{2j}(\\theta)$$\n$$\\sin(n\\theta) = \\sin\\theta \\cdot \\sum_{j=0}^{\\lfloor(n-1)/2\\rfloor} \\binom{n}{2j+1}(-1)^j \\cos^{n-2j-1}(\\theta)\\sin^{2j}(\\theta)$$\n\n**The Chebyshev Connection**\n\nThe abstract structure of these formulas is captured by Chebyshev polynomials: $T_n$ (first kind) and $U_n$ (second kind). The key identities are:\n- $T_n(\\cos\\theta) = \\cos(n\\theta)$ for all $n \\in \\mathbb{Z}$\n- $U_n(\\cos\\theta) \\cdot \\sin\\theta = \\sin((n+1)\\theta)$ for all $n \\in \\mathbb{Z}$\n\nThese polynomials satisfy the recurrences $T_{n+2} = 2X\\cdot T_{n+1} - T_n$ and $U_{n+2} = 2X\\cdot U_{n+1} - U_n$, which follow directly from the product-to-sum identity $\\cos(A+B) + \\cos(A-B) = 2\\cos A\\cos B$.\n\n**The Formalization**\n\nThis formalization directly answers the open question: can we formally extract explicit polynomial representations of $\\cos(n\\theta)$ and $\\sin(n\\theta)$ from De Moivre's theorem? The answer is **YES** — Mathlib's Chebyshev polynomial library provides the necessary infrastructure, and the formalization makes the connection between De Moivre and Chebyshev explicit and machine-checkable.",

--- a/src/data/proofs/de-moivre-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02/meta.json
@@ -21,7 +21,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -66,7 +66,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 157,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Composition identity derived from Mathlib's T_real_cos. Extensive original derivations of product-to-sum, parity, and root formulas."
   },
   "overview": {
     "historicalContext": "**Beyond the Basic Identity**\n\nThe OQ-01 extension established the fundamental connection: $T_n(\\cos\\theta) = \\cos(n\\theta)$. This OQ-02 extension explores the rich algebraic structure that follows from this identity.\n\n**Composition Monoid**\n\nSince $T_m(T_n(\\cos\\theta)) = T_m(\\cos(n\\theta)) = \\cos(mn\\theta) = T_{mn}(\\cos\\theta)$, the Chebyshev polynomials form a commutative monoid under function composition. This is a remarkable algebraic structure: $T_m \\circ T_n = T_{mn}$, with $T_1$ as the identity element.\n\n**Product-to-Sum**\n\nThe identity $2T_m(x)T_n(x) = T_{m+n}(x) + T_{m-n}(x)$ is the polynomial analog of the trigonometric product-to-sum formula $2\\cos(A)\\cos(B) = \\cos(A+B) + \\cos(A-B)$. This identity is central to Chebyshev spectral methods in numerical analysis.\n\n**Parity and Roots**\n\nThe parity relation $T_n(-x) = (-1)^nT_n(x)$ shows that even-index Chebyshev polynomials are even functions and odd-index ones are odd. The roots $x_k = \\cos\\frac{(2k+1)\\pi}{2n}$ are the Chebyshev nodes, optimal for polynomial interpolation.",

--- a/src/data/proofs/de-moivre-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-03/meta.json
@@ -16,7 +16,7 @@
       "roots-of-unity",
       "wiedijk-100"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -62,7 +62,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 275,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Fractional powers via Mathlib's cpow_def_of_ne_zero and exp/log. Original root enumeration and distinctness proofs."
   },
   "overview": {
     "historicalContext": "De Moivre's theorem (1707) states that $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$ for integer $n$. Abraham de Moivre, a French Huguenot mathematician exiled to England, published this result in the *Philosophical Transactions* of the Royal Society. While the integer case follows by induction on Euler's formula $e^{i\\theta} = \\cos\\theta + i\\sin\\theta$ (1748), the extension to fractional exponents $p/q$ introduces the fundamental complication of **multi-valuedness**: $z^{p/q}$ has exactly $q$ distinct values, reflecting the $q$-fold covering of $\\mathbb{C}^*$ by itself. This multi-valuedness was first systematically studied by Euler and later by Cauchy and Riemann, who introduced branch cuts and Riemann surfaces to resolve it. The modern approach defines $z^w = \\exp(w \\log z)$ and selects a **principal branch** via the principal logarithm ($-\\pi < \\arg z \\leq \\pi$). This formalization bridges classical root extraction with Mathlib's principal-branch `cpow`, providing the first complete formal treatment of fractional De Moivre including root enumeration, distinctness, and consistency.",

--- a/src/data/proofs/derangements-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-01/meta.json
@@ -9,7 +9,7 @@
     "date": "classical",
     "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02OQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "tags": [
       "combinatorics",
@@ -59,7 +59,7 @@
     "dateAdded": "2026-03-11",
     "axiomCount": 0,
     "lineCount": 123,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Main result transported from Fin n via Fintype.equivFin and permutation conjugation from parent entry."
   },
   "overview": {
     "historicalContext": "**Generalizing the Partial Derangement Formula**\n\nThe study of derangements dates to Montmort's *problème des rencontres* (1708): if $n$ cards numbered 1 through $n$ are shuffled, what is the probability that no card lands in its original position? Euler (1753) derived the alternating series $D(n) = n! \\sum_{k=0}^n (-1)^k/k!$ and the recurrence $D(n) = (n-1)(D(n-1) + D(n-2))$.\n\nThe partial derangement formula $S(n,k) = \\binom{n}{k} \\cdot D(n-k)$ extends this to count permutations with *exactly* $k$ fixed points: choose which $k$ elements to fix, then derange the rest. The original formalization (derangements-oq-02) proved this for $\\text{Fin}\\, n$.\n\nThe natural question is: does the same formula hold for **any** finite type $\\alpha$, not just the canonical $\\text{Fin}\\, n$? The answer is yes, by a transport argument: every finite type $\\alpha$ is equivalent to $\\text{Fin}\\, |\\alpha|$ via `Fintype.equivFin`, and permutation conjugation via `Equiv.permCongr` preserves the fixed-point count.\n\nThis generalization is important because mathematical structures rarely come labeled as $\\text{Fin}\\, n$. Graph automorphisms, symmetries of geometric objects, and group actions all involve permutations of abstract finite sets.",


### PR DESCRIPTION
## Summary

- Fix badge from `"verified"`/`"original"` to `"mathlib"` for 5 entries where core results derive from Mathlib
- Update assumptions field for each to honestly note the Mathlib dependency

## Entries Fixed

| Entry | Old Badge | Issue |
|-------|-----------|-------|
| cramers-rule-oq-01 | verified | 7/13 theorems are Mathlib wrappers (adjugate_mul, etc.) |
| de-moivre-oq-01 | verified | Core Chebyshev connection wraps T_real_cos/U_real_cos |
| de-moivre-oq-02 | verified | Composition identity wraps T_real_cos |
| de-moivre-oq-03 | verified | Fractional powers wrap cpow_def_of_ne_zero |
| derangements-oq-02-oq-01 | original | Transport proof via Fintype.equivFin |

## Context

All files have 0 sorries and 0 axioms. Each also contains substantial original content beyond the Mathlib calls. The badge change reflects that the core named results (not all content) derive from Mathlib.

Part of gallery integrity audit cycle. Severity: MEDIUM (Narrative Failure Mode #5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)