### PR TITLE
Audit fix: erdos-10 axiomCount 5→8, lineCount 647→109

### DIFF
--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -24,9 +24,9 @@
     "crossReferences": [
       "erdos-949"
     ],
-    "axiomCount": 5,
-    "assumptions": "5 axioms: grechuk_not_3_powers (k=3 counterexample, computational), crocker_theorem_odd (infinite odd de Polignac), infinite_even_not_two_powers (infinite even non-representable), erdos_covering_congruence (covering congruence), chen_minimal_modulus (minimality of 11184810). Former trivial axioms (romanoff, gallagher, chen_density) proved.",
-    "lineCount": 647,
+    "axiomCount": 8,
+    "assumptions": "8 axiom declarations: erdos_10_conjecture (main conjecture), gallagher_density (density result), granville_soundararajan_odd/even (representation conjectures), grechuk_counterexample (k=3 counterexample), infinitely_many_exceptions_k2/k3 (exception existence), romanoff_positive_density (positive density). All results are deep number-theoretic facts axiomatized in the formalization.",
+    "lineCount": 109,
     "prerequisites": [
       "Prime numbers and their distribution",
       "Density of sets of integers (lower density, natural density)",


### PR DESCRIPTION
## Summary
- Restored correct `axiomCount: 8` (was incorrectly changed to 5)
- Restored correct `lineCount: 109` (was incorrectly changed to 647)
- Updated `assumptions` to list the actual axiom names from the Lean file

## Evidence
Commit 2206ee4bce claimed "prove 3 trivial axioms (8→5 axioms)" but only modified
meta.json, not the Lean file. The Lean file still has 8 `axiom` declarations:
```
axiom erdos_10_conjecture
axiom gallagher_density
axiom granville_soundararajan_odd
axiom granville_soundararajan_even
axiom grechuk_counterexample
axiom infinitely_many_exceptions_k2
axiom infinitely_many_exceptions_k3
axiom romanoff_positive_density
```

## Test plan
- [x] `grep -c '^axiom ' proofs/Proofs/Erdos10Problem.lean` = 8
- [x] `wc -l proofs/Proofs/Erdos10Problem.lean` = 109

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)