### PR TITLE
Research: fourier-series-oq-02 - proof strategy analysis

### DIFF
--- a/research/problems/fourier-series-oq-02/knowledge.md
+++ b/research/problems/fourier-series-oq-02/knowledge.md
@@ -44,12 +44,80 @@ Prove that Fourier coefficients of α-Hölder continuous functions on AddCircle 
 
 ---
 
-## Remaining Axioms (8)
-1. `fourierCoeff_difference_formula` — difference formula via Haar translation (NEXT TARGET)
-2. `fourierCoeff_sq_summable_of_holder` — square-summability for α > 1/2
-3. `riemannLebesgue_of_holder` — Riemann-Lebesgue from Hölder
-4. `holder_decay_is_optimal` — optimality (constructive, hard)
-5. `decay_implies_regularity` — partial converse (Sobolev embedding, hard)
-6. `fourierCoeff_smooth_decay` — C^k decay
-7. `fourierCoeff_Cinfty_rapid_decay` — C^∞ rapid decay
-8. `fourierCoeff_analytic_decay` — analytic exponential decay
+## Current State (2026-03-24)
+
+**File**: 382 lines, 4 axioms, 15 theorems, 2 sorries
+
+### Remaining Axioms (4 — all deep)
+1. `holder_decay_is_optimal` — optimality via Weierstrass function
+2. `decay_implies_regularity` — Sobolev embedding on circle
+3. `fourierCoeff_smooth_decay` — C^k decay via integration by parts
+4. `fourierCoeff_analytic_decay` — analytic exponential decay
+
+### Remaining Sorries (2)
+1. `fourierCoeff_sq_summable_of_holder` (line ~275) — square-summability for α > 1/2
+2. `riemannLebesgue_of_holder` (line ~288) — Riemann-Lebesgue from Hölder decay
+
+---
+
+## Session: researcher-4 (2026-03-24) — Proof Strategy Analysis
+
+### riemannLebesgue_of_holder — Detailed Proof Strategy
+
+**Goal after existing setup:**
+```
+⊢ Set.Finite {n : ℤ | ¬‖fourierCoeff f n‖ < ε}
+```
+
+**Proof approach:**
+1. Case split on `C = 0` vs `C > 0`:
+   - **C = 0**: Bound is 0 for all n ≠ 0, so bad set ⊆ {0} which is finite.
+   - **C > 0**: The bound `(C/2)(T/(2(k+1)))^α` tends to 0 as k → ∞.
+2. For C > 0, show the bound sequence tends to 0:
+   - `T / (2*(k+1)) → 0` via `tendsto_const_nhds.div_atTop` (denom → ∞)
+   - `x^α → 0` as `x → 0` via `Filter.Tendsto.rpow_const` with `Or.inr hα_pos.ne'`
+   - Multiply by constant C/2
+3. Extract N₀ from the convergence via `Filter.eventually_atTop`
+4. Show bad set ⊆ `Set.Icc (-(N₀+1)) (N₀+1)` which is finite
+5. For n with `n.natAbs > N₀+1` and n ≠ 0: use rpow monotonicity + decay bound < ε
+
+**Key Lean API needed:**
+- `tendsto_atTop_add_const_right atTop 1 tendsto_natCast_atTop_atTop` — for k+1 → ∞
+- `Filter.Tendsto.atTop_mul_const` — for 2*(k+1) → ∞
+- `tendsto_const_nhds.div_atTop` — for T/(2*(k+1)) → 0
+- `Filter.Tendsto.rpow_const` — for x^α composition with filter
+- `Real.zero_rpow hα_pos.ne'` — for 0^α = 0 when α > 0
+- `Real.rpow_le_rpow` — for rpow monotonicity (smaller base → smaller rpow)
+- `div_le_div_left` — for T/c ≤ T/b when b ≤ c (larger denom → smaller fraction)
+- `Set.finite_Icc` — bounded integer intervals are finite
+
+**Main difficulty**: The rpow monotonicity step requires careful handling of:
+- `0 ≤ T/(2|n|)` (nonneg base for rpow_le_rpow)
+- `T/(2|n|) ≤ T/(2(N₀+1))` (base comparison)
+- `0 ≤ α` (nonneg exponent)
+- Converting between `n.natAbs` (ℕ) and `|↑n|` (ℝ) via `Int.abs_cast_natAbs`
+
+**Blocker**: Many small positivity/cast obligations. Recommend using `positivity` where possible and `push_cast` + `omega` for ℤ ↔ ℕ conversions.
+
+### fourierCoeff_sq_summable_of_holder — Detailed Proof Strategy
+
+**Goal:** `Summable (fun n : ℤ => ‖fourierCoeff f n‖ ^ 2)`
+
+**Proof approach:**
+1. For n ≠ 0: `‖ĉ_n‖² ≤ ((C/2)(T/(2|n|))^α)² = K * |n|^{-2α}` where K = (C²/4)(T/2)^{2α}
+2. Σ K/|n|^{2α} converges since 2α > 1 (hypothesis)
+3. Use `Summable.of_nonneg_of_le` for comparison
+4. Handle ℤ → ℕ conversion for the sum
+
+**Key API:**
+- `Real.summable_nat_rpow_inv.mpr` — p-series convergence for p > 1
+- `Summable.of_nonneg_of_le` — comparison test (available in codebase, widely used)
+- Squaring the rpow bound: `(x^α)² = x^{2α}` via `rpow_natCast` or manual
+- ℤ summability: split into positive and negative parts
+
+**Difficulty**: Converting between ℤ-indexed sums and ℕ-indexed sums, and the rpow algebra for squaring the bound.
+
+### General Observations
+- Both sorries are "routine analysis" in human terms but require significant formalization effort due to rpow arithmetic, filter composition, and ℤ ↔ ℕ conversions
+- The 4 remaining axioms are genuinely deep (require Weierstrass functions, Sobolev embedding, integration by parts, complex analysis)
+- No axioms are "routine" enough to eliminate from Mathlib alone

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -67,16 +67,18 @@
       "The non-integrable edge case in fourierCoeff_difference_formula is genuinely hard: f-f∘τ can be integrable when f isn't. Needs Continuous f hypothesis.",
       "ContinuousOn.integrableOn_compact isCompact_univ is the right API for showing continuous functions on compact spaces are integrable (with respect to any measure)",
       "(fourier (-n)).continuous.smul hf_cont gives continuity of fun x => fourier(-n) x • f x in Lean 4 Mathlib",
-      "Metric.tendsto_nhds unfolds Tendsto into epsilon-delta form; Filter.eventually_cofinite characterizes the cofinite filter"
+      "Metric.tendsto_nhds unfolds Tendsto into epsilon-delta form; Filter.eventually_cofinite characterizes the cofinite filter",
+      "riemannLebesgue: proof via tendsto_const_nhds.div_atTop + rpow_const + Set.finite_Icc; main blocker is rpow monotonicity + ℤ↔ℕ casts",
+      "fourierCoeff_sq_summable: proof via Real.summable_nat_rpow_inv + Summable.of_nonneg_of_le; main blocker is ℤ-sum conversion",
+      "All 4 remaining axioms are deep (Weierstrass, Sobolev, IBP, complex analysis) — no routine eliminations possible"
     ],
     "mathlibGaps": [
       "No obvious dist(x, x+↑s) ≤ |s| lemma found for AddCircle quotient metric"
     ],
     "nextSteps": [
-      "Prove riemannLebesgue_of_holder: either via Mathlib R-L for L¹ or squeeze theorem with decay bound",
-      "Prove fourierCoeff_sq_summable_of_holder: decay bound + p-series convergence",
-      "Prove fourierCoeff_smooth_decay: integration by parts for C^k functions",
-      "holder_decay_is_optimal and decay_implies_regularity are deep results — likely stay as axioms"
+      "Fill riemannLebesgue sorry: C=0 case is trivial, C>0 needs tendsto+rpow composition (detailed strategy in knowledge.md)",
+      "Fill sq_summable sorry: comparison with p-series via Real.summable_nat_rpow_inv",
+      "fourierCoeff_smooth_decay axiom is moderate difficulty (IBP on AddCircle) but still substantial"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Analyzed the 2 remaining sorries in FourierSeriesOQ02.lean
- Documented complete proof strategies with exact Lean API references
- Confirmed all 4 axioms are deep (no routine eliminations from Mathlib)

## Findings
**riemannLebesgue_of_holder sorry**: Case split C=0 (trivial) vs C>0 (tendsto+rpow composition). Main blocker is rpow monotonicity + ℤ↔ℕ casts. Detailed step-by-step strategy with API references in knowledge.md.

**fourierCoeff_sq_summable_of_holder sorry**: Comparison with p-series via `Real.summable_nat_rpow_inv` + `Summable.of_nonneg_of_le`. Main blocker is ℤ-sum conversion and rpow algebra for squaring the bound.

## Status
**Outcome**: surveyed (proof strategies documented, no code changes)
**Next Steps**: Implement the documented proof strategies

🤖 Generated by researcher-4