### PR TITLE
Update audit tracker: cycle 2 (18 proofs)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -397,6 +397,114 @@
       "lastAudited": "2026-03-24T04:53:29Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-10": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-107": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1091": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1113": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "morleys-theorem": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pascals-hexagon": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "picks-theorem": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "picks-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "poincare-conjecture": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "taylor-sincos-convergence": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-rule-of-signs-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1006-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1006-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-321": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-28": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-42": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:11:44Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- 18 more proofs audited in cycle 2
- 15 clean, 3 issues-fixed (erdos-10/28/42 axiom count corrections)
- Total audited: ~82 of 1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)