### PR TITLE
Audit fix: divisibility-by-3-oq-01/02 badge → mathlib

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-01/meta.json
@@ -16,7 +16,7 @@
       "comprehensive"
     ],
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -52,7 +52,7 @@
     "dateAdded": "2026-02-10",
     "axiomCount": 0,
     "lineCount": 550,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core digit-sum congruence from Mathlib's Nat.modEq_digits_sum and Nat.dvd_iff_dvd_digits_sum."
   },
   "overview": {
     "historicalContext": "Divisibility rules have been known since ancient times. This extension formalizes a comprehensive collection of such rules in Lean 4, going far beyond the basic divisibility-by-3 rule.\n\nThe rules fall into three families:\n1. **Last-k-digits rules**: When d divides the base power (e.g., 4|100), check the last k digits\n2. **Digit-sum rules**: When base ≡ 1 (mod d), check the digit sum\n3. **Truncation rules**: Reduce the number by removing a digit and adjusting (e.g., for 7 and 13)\n\nAll three families are unified through modular arithmetic.",

--- a/src/data/proofs/divisibility-by-3-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-02/meta.json
@@ -16,7 +16,7 @@
       "open-problem"
     ],
     "proofRepoPath": "Proofs/DivisibilityBy3OQ02.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "prerequisites": [
       "modular arithmetic",
@@ -57,7 +57,7 @@
         "relationship": "Parent proof for base-10 divisibility by 3 and 9; this generalizes to all bases"
       }
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Base-b digit-sum congruence derived from Mathlib's Nat.modEq_digits_sum and Nat.dvd_iff_dvd_digits_sum."
   },
   "overview": {
     "historicalContext": "Divisibility rules based on digit sums trace back to medieval Islamic mathematics: al-Khwārizmī (c. 825) described 'casting out nines' for verifying arithmetic. The method was widely transmitted to Europe via Fibonacci's *Liber Abaci* (1202). The underlying algebraic principle—that $b \\equiv 1 \\pmod{b-1}$ makes every positional digit-sum a modular invariant—was understood by Euler and Gauss in the 18th century as a consequence of modular arithmetic. This formalization generalizes the base-10 rule (parent proof) to arbitrary bases, revealing that 'casting out nines' is just one instance of a universal phenomenon: in any base $b$, digit sums determine remainders modulo $b-1$ and its factors. The cross-base theorem (Part VI) appears to be a novel formalization, connecting digit-sum tests across different bases.",


### PR DESCRIPTION
## Summary

- Fix badge for `divisibility-by-3-oq-01` from `"verified"` to `"mathlib"`
- Fix badge for `divisibility-by-3-oq-02` from `"original"` to `"mathlib"`
- Update assumptions field for both

## Evidence

Both entries' core theorems directly wrap Mathlib's `Nat.modEq_digits_sum` and `Nat.dvd_iff_dvd_digits_sum` with minimal reformulation. Specific rules (div by 3/9, hexadecimal, octal) are instantiations of the Mathlib-provided generic theorem.

## Test plan

- [ ] Verify gallery renders correctly
- [ ] Confirm badges display as "mathlib"

🤖 Generated with [Claude Code](https://claude.com/claude-code)