### PR TITLE
Enrich erdos-781: fix status, add annotations, update mathlib_version

### DIFF
--- a/src/data/proofs/erdos-781/annotations.json
+++ b/src/data/proofs/erdos-781/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-e781-header",
+    "proofId": "erdos-781",
+    "range": {
+      "startLine": 1,
+      "endLine": 24
+    },
+    "type": "context",
+    "title": "File Header: Problem Statement and Historical Context",
+    "content": "The file header documents Erdos Problem #781 on descending waves in 2-colorings. It records the problem source (erdosproblems.com/781), the DISPROVED status, the formal statement of f(k), and the two key results: the Brown-Erdos-Freedman bounds (1990) and the Alon-Spencer disproof (1989). References to both papers are included for traceability.",
+    "mathContext": "A descending wave $x_1 < x_2 < \\cdots < x_k$ satisfies $x_j \\geq (x_{j+1} + x_{j-1})/2$ for all interior points $j$. The function $f(k) = \\min\\{n : \\text{every 2-coloring of } \\{1,\\ldots,n\\} \\text{ has a monochromatic } k\\text{-wave}\\}$. Brown-Erdos-Freedman (1990) proved $k^2-k+1 \\leq f(k) \\leq (k^3-4k+9)/3$; Alon-Spencer (1989) proved $f(k) \\gg k^3$, disproving the conjecture $f(k) = k^2-k+1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "descending wave",
+      "Ramsey threshold",
+      "Brown-Erdos-Freedman",
+      "Alon-Spencer"
+    ],
+    "prerequisites": [
+      "Ramsey theory basics",
+      "2-colorings"
+    ]
+  },
+  {
     "id": "ann-e781-imports",
     "proofId": "erdos-781",
     "range": {
@@ -357,16 +380,41 @@
     ]
   },
   {
-    "id": "ann-e781-disproved",
+    "id": "ann-e781-specific-axioms",
     "proofId": "erdos-781",
     "range": {
       "startLine": 139,
       "endLine": 146
     },
     "type": "technique",
+    "title": "Specific Value Axioms: f(1), f(2), f(3)",
+    "content": "Three axioms encode the known small values of f(k):\n\n- `f_1 : f 1 = 1` -- any single element is a trivial 1-term wave\n- `f_2 : f 2 = 2` -- any two distinct elements form a 2-term wave (no interior points)\n- `f_3 : f 3 = 7` -- the k=3 case, matching the conjectured formula k^2 - k + 1 = 7\n\nCritically, f(2) = 2, not 3 as the conjecture predicts. This is the basis of the `conjecture_disproved` proof.",
+    "mathContext": "$f(1) = 1$: trivial. $f(2) = 2$: any two elements $x_1 < x_2$ form a descending wave (no interior constraint). $f(3) = 7$: proven by exhaustive enumeration. The conjecture gives $1, 3, 7$ for $k = 1, 2, 3$ but $f(2) = 2 \\neq 3$, so it fails at $k = 2$. These axioms are used in `small_k_correct` and `conjecture_disproved`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "f_1",
+      "f_2",
+      "f_3",
+      "conjecture_disproved",
+      "small case verification"
+    ],
+    "prerequisites": [
+      "f",
+      "IsDescendingWave",
+      "TwoColoring"
+    ]
+  },
+  {
+    "id": "ann-e781-disproved",
+    "proofId": "erdos-781",
+    "range": {
+      "startLine": 148,
+      "endLine": 154
+    },
+    "type": "technique",
     "title": "The Conjecture is Disproved",
-    "content": "`conjecture_disproved` proves ¬ErdosConjecture781 by contradiction:\n\n1. Assume f(k) = k² - k + 1 for all k (quadratic)\n2. By Alon-Spencer: ∃c > 0, f(k) ≥ c·k³ for all k\n3. For large k: c·k³ > k² - k + 1\n4. Contradiction: f(k) ≥ c·k³ > k² - k + 1 = f(k)\n\nThe `sorry` encodes the growth comparison step.",
-    "mathContext": "`conjecture_disproved : ¬ErdosConjecture781`. Proof sketch: assume `h : ∀ k ≥ 1, f k = k^2 - k + 1`. By `alon_spencer_cubic`, take $c > 0$. For $k$ large: $ck^3 > k^2 - k + 1$ (polynomial inequality, since $ck^3/k^2 = ck \\to \\infty$). Then $f(k) \\geq ck^3 > k^2 - k + 1 = f(k)$, contradiction. The `sorry` encodes this large-$k$ quantitative argument.",
+    "content": "`conjecture_disproved` proves `¬ErdosConjecture781` completely (no sorry) via a simple k=2 argument:\n\n1. Assume the conjecture: f(k) = k² - k + 1 for all k ≥ 1\n2. Instantiate at k = 2: f(2) = 2² - 2 + 1 = 3\n3. But axiom f_2 says f(2) = 2\n4. Rewrite with f_2 to get 2 = 3, and `omega` closes the contradiction\n\nThis is a fully machine-checked proof with no sorry.",
+    "mathContext": "`conjecture_disproved : ¬ErdosConjecture781`. The proof is complete: `intro h; have h2 := h 2 (by omega); rw [f_2] at h2; omega`. The conjecture claims $f(2) = 2^2 - 2 + 1 = 3$, but axiom `f_2` gives $f(2) = 2$. The rewrite produces $2 = 3$, which `omega` refutes. No appeal to Alon-Spencer or large-$k$ asymptotics is needed -- the conjecture fails at the smallest non-trivial case.",
     "significance": "key",
     "relatedConcepts": [
       "conjecture_disproved",
@@ -386,7 +434,7 @@
     "id": "ann-e781-small-k",
     "proofId": "erdos-781",
     "range": {
-      "startLine": 150,
+      "startLine": 156,
       "endLine": 161
     },
     "type": "technique",
@@ -439,7 +487,7 @@
     "id": "ann-e781-construction",
     "proofId": "erdos-781",
     "range": {
-      "startLine": 172,
+      "startLine": 169,
       "endLine": 186
     },
     "type": "technique",
@@ -466,7 +514,7 @@
     "id": "ann-e781-ascending",
     "proofId": "erdos-781",
     "range": {
-      "startLine": 190,
+      "startLine": 187,
       "endLine": 207
     },
     "type": "definition",
@@ -493,7 +541,7 @@
     "id": "ann-e781-quasi",
     "proofId": "erdos-781",
     "range": {
-      "startLine": 211,
+      "startLine": 208,
       "endLine": 221
     },
     "type": "definition",
@@ -519,7 +567,7 @@
     "id": "ann-e781-summary",
     "proofId": "erdos-781",
     "range": {
-      "startLine": 247,
+      "startLine": 222,
       "endLine": 254
     },
     "type": "technique",

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -7,7 +7,7 @@
     "author": "Brown-Erdős-Freedman (1990), Alon-Spencer (1989)",
     "sourceUrl": "https://erdosproblems.com/781",
     "date": "1990",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos781Problem.lean",
     "tags": [
       "erdos",
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/781",
     "erdosProblemStatus": "disproved",
     "dateAdded": "2026-01-18",
-    "mathlib_version": "4.15.0",
+    "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
         "theorem": "Finset",
@@ -111,17 +111,24 @@
       "endLine": 137
     },
     {
-      "id": "disproof",
-      "title": "The Disproof",
-      "summary": "Proves `conjecture_disproved : ¬ErdosConjecture781` by contradiction: if $f(k) = k^2-k+1$, then `alon_spencer_cubic` gives $ck^3 \\leq f(k) = k^2-k+1$, impossible for large $k$ since $k^3 \\gg k^2$. The `sorry` encodes this growth comparison.",
+      "id": "specific-values-axioms",
+      "title": "Specific Value Axioms",
+      "summary": "Axiomatizes $f(1)=1$, $f(2)=2$, $f(3)=7$. These known small values are stated as axioms. Critically, $f(2)=2 \\neq 3 = 2^2-2+1$, so the conjecture already fails at $k=2$.",
       "startLine": 139,
       "endLine": 146
     },
     {
+      "id": "disproof",
+      "title": "The Disproof",
+      "summary": "Proves `conjecture_disproved : ¬ErdosConjecture781` completely (no sorry). The proof instantiates the conjecture at $k=2$, obtaining $f(2) = 3$, then rewrites with axiom `f_2 : f 2 = 2` to get $2 = 3$, closed by `omega`.",
+      "startLine": 148,
+      "endLine": 154
+    },
+    {
       "id": "specific-values",
       "title": "Specific Values and Formula Identity",
-      "summary": "Axiomatizes $f(1)=1$, $f(2)=2$, $f(3)=7$ and proves `small_k_correct` (their conjunction). Proves `conjecture_formula: k^2-k+1 = k(k-1)+1` by `ring`. Note: $f(2) = 2 \\neq 3 = 2^2-2+1$, so the conjecture fails even for $k=2$.",
-      "startLine": 148,
+      "summary": "Proves `small_k_correct : f 1 = 1 ∧ f 2 = 2 ∧ f 3 = 7` (conjunction of the three axioms). Proves `conjecture_formula: k^2-k+1 = k(k-1)+1` by `ring`.",
+      "startLine": 156,
       "endLine": 168
     },
     {
@@ -177,7 +184,7 @@
     "lineCount": 258,
     "axiomCount": 12,
     "theoremCount": 5,
-    "definitionCount": 9
+    "definitionCount": 11
   },
   "crossReferences": [
     {


### PR DESCRIPTION
Enrichment pass for erdos-781.

- Updated `mathlib_version` from 4.15.0 to 4.26.0
- Fixed `status` from "formalized" to "axiomatized" (has 12 axiom declarations)
- Fixed `definitionCount` (9→11)
- Corrected disproof section range, added specific-values-axioms section
- Added 2 new annotations, expanded 5 annotation ranges
- Fixed disproof annotation to describe actual sorry-free proof