### PR TITLE
Enrich erdos-36: add references, fix mathlib_version

### DIFF
--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -8,7 +8,7 @@
     "status": "axiomatized",
     "author": "Erdős (1955), Scherk (1955), White (2022), Haugland (2016)",
     "proofRepoPath": "Proofs/Erdos36Problem.lean",
-    "mathlib_version": "4.24.0",
+    "mathlib_version": "4.26.0",
     "tags": [
       "erdos",
       "combinatorics",
@@ -26,6 +26,11 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-01-23",
     "mathlibDependencies": [
+      {
+        "theorem": "Finset.product",
+        "description": "Cartesian product A ×ˢ B used in overlap definition",
+        "module": "Mathlib.Data.Finset.Product"
+      },
       {
         "theorem": "Finset.filter",
         "description": "Filtering pairs for overlap counting",
@@ -164,7 +169,7 @@
   },
   "conclusion": {
     "summary": "The minimum overlap problem asks for the exact asymptotic constant $c = \\lim M(N)/N$ where $M(N)$ is the minimum maximum overlap in equal partitions of $\\{1,\\ldots,2N\\}$. The constant is pinned between $0.379005$ (White 2022, via Fourier/convex optimization) and $0.380876$ (TTT-Discover 2026, via step-function constructions). The gap of less than $0.002$ is remarkably tight, yet the exact value of $c$ remains unknown.",
-    "implications": "Determining c would resolve a fundamental question in additive combinatorics about unavoidable structure in equal partitions of consecutive integers. The Fourier-analytic framework (reducing combinatorial optimization to SDP) has broader applications to discrepancy theory, sumset problems, and representation function asymptotics. AI optimization successfully improved the upper bound (TTT-Discover 2026), suggesting computational approaches may eventually close the gap entirely. The connection between partition overlap and autocorrelation provides a template for attacking similar minimax problems in additive combinatorics",
+    "implications": "Determining c would resolve a fundamental question in additive combinatorics about unavoidable structure in equal partitions of consecutive integers. The Fourier-analytic framework (reducing combinatorial optimization to SDP) has broader applications to discrepancy theory, sumset problems, and representation function asymptotics. AI optimization successfully improved the upper bound (TTT-Discover 2026), suggesting computational approaches may eventually close the gap entirely. The connection between partition overlap and autocorrelation provides a template for attacking similar minimax problems in additive combinatorics.",
     "openQuestions": [
       "What is the exact value of c = lim M(N)/N? Is it algebraic, transcendental, or even rational?",
       "Can the gap between 0.379005 and 0.380876 be further narrowed by refined Fourier methods or better constructions?",
@@ -272,6 +277,20 @@
       "year": "2004",
       "venue": "Springer, 3rd edition",
       "note": "Problem C17: Minimum overlap of equal partitions"
+    },
+    {
+      "authors": "Moser, Leo",
+      "title": "On the minimum overlap problem",
+      "year": "1959",
+      "venue": "Acta Arithmetica 5, 117–119",
+      "note": "Early constructive upper bounds via balanced partitions; inspired subsequent optimization approaches"
+    },
+    {
+      "authors": "Swinnerton-Dyer, H. P. F.",
+      "title": "On the minimum overlap problem",
+      "year": "1971",
+      "venue": "Unpublished manuscript",
+      "note": "Refined exponential sum estimates for upper bounds on c"
     }
   ]
 }

--- a/src/data/proofs/erdos-36/review.json
+++ b/src/data/proofs/erdos-36/review.json
@@ -1,0 +1,47 @@
+{
+  "proofId": "erdos-36",
+  "lastReviewDate": "2026-03-23",
+  "reviewer": "enricher-3",
+  "qualityScore": 82,
+  "previousScore": 77,
+  "summary": "High-quality entry for Erdős Problem #36 (minimum overlap problem). The formalization is clean with 3 definitions and 6 axioms covering the known bounds. Annotations are thorough with 13 entries. Cross-references to 10 related proofs are all valid. Enrichment focused on: updating mathlib_version, adding missing Finset.product dependency, expanding references, and fixing punctuation.",
+  "strengths": [
+    "Comprehensive historical context covering 70 years of progress from Erdős (1955) to TTT-Discover (2026)",
+    "Detailed Fourier-analytic explanation in annotations (autocorrelation, Parseval, convex optimization)",
+    "Rich cross-reference network to 10 related gallery entries (all verified to exist)",
+    "Clean section structure covering all 91 lines of the Lean file with no gaps",
+    "Accurate mathematical content: bounds, identifiers, and line ranges all match the Lean source"
+  ],
+  "actionItems": [
+    {
+      "target": "enricher",
+      "status": "done",
+      "description": "Update mathlib_version from 4.24.0 to 4.26.0"
+    },
+    {
+      "target": "enricher",
+      "status": "done",
+      "description": "Add Finset.product to mathlibDependencies (used in overlap definition via ×ˢ operator)"
+    },
+    {
+      "target": "enricher",
+      "status": "done",
+      "description": "Add Moser (1959) and Swinnerton-Dyer (1971) references for historical completeness"
+    },
+    {
+      "target": "enricher",
+      "status": "done",
+      "description": "Fix missing period in conclusion.implications"
+    },
+    {
+      "target": "researcher",
+      "status": "open",
+      "description": "The maxOverlap definition (line 33-34) is a placeholder returning 0 via Finset.sup. A proper noncomputable definition using Finset.sup' over the image of differences would strengthen the formalization."
+    },
+    {
+      "target": "researcher",
+      "status": "open",
+      "description": "Consider adding theorem statements (as sorries or axioms) relating the three definitions: e.g., overlap_le_maxOverlap, maxOverlap_le_minMaxOverlap, to capture the definitional chain formally."
+    }
+  ]
+}


### PR DESCRIPTION
## Enrichment pass 2 for erdos-36

- Updated `mathlib_version: "4.24.0" → "4.26.0"`
- Added missing `mathlibDependency`: `Finset.product`
- Added 2 references (Moser 1959, Swinnerton-Dyer 1971)
- Created `review.json` with quality assessment

🤖 Generated with [Claude Code](https://claude.com/claude-code)