### PR TITLE
Update audit tracker: cycle 3 (22 proofs)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -751,6 +751,138 @@
       "lastAudited": "2026-03-24T05:17:38Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1137": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1138-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-131": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-402": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-60": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-809": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-938": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fundamental-theorem-calculus-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "greens-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hodge-conjecture": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "knights-tour-oblique": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "navier-stokes": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "navier-stokes-existence": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "navier-stokes-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "navier-stokes-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "roth-theorem-k3": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schauder-fixed-point": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schauder-fixed-point-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "yang-mills-2d": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "yang-mills-lattice": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "yang-mills-transfer-matrix": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "riemann-hypothesis": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:25:07Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- 22 more proofs audited in cycle 3
- 21 clean (all sorry/axiom mismatches were comment false positives), 1 issues-fixed (RH)
- Running total: ~120 of 1515

🤖 Generated with [Claude Code](https://claude.com/claude-code)