### PR TITLE
Peer review: continuum-hypothesis (C-)

### DIFF
--- a/src/data/proofs/continuum-hypothesis/review.json
+++ b/src/data/proofs/continuum-hypothesis/review.json
@@ -1,0 +1,164 @@
+{
+  "version": 1,
+  "proofId": "continuum-hypothesis",
+  "reviewDate": "2026-03-23T19:30:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "C-",
+    "oneLiner": "Excellent pedagogical commentary on a landmark independence result, but the formal content is hollow — holds_CH and holds_notCH are both defined as True, making the main theorem vacuously satisfied, and 'Easton's Theorem' proves 1+1=2.",
+    "tier": "C",
+    "tierJustification": "Tier C: Scaffold/axiomatized. The central independence theorem is vacuously true because holds_CH and holds_notCH are placeholder definitions (fun _ => True). The 6 axiom declarations partially capture the proof structure, but 2 of them (L_satisfies_CH, forcing_violates_CH) have type True. The only genuinely proved result is gch_implies_ch. The file is an illustrative scaffold, not a real axiomatization."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "BallotProblem.lean lines 300-356 (Part 8: Consequences and Philosophy)",
+      "finding": "The philosophical commentary is genuinely thoughtful and well-sourced. It covers four distinct perspectives (Platonism, Formalism, Multiverse view, Pragmatism), names specific researchers (Hamkins, Woodin), and describes active research programs (inner model theory, forcing axioms, Ultimate L). The L and forcing explanations in Parts 4-5 (lines 147-220) are clear and mathematically accurate. The historical narrative (Cantor 1878 → Hilbert 1900 → Gödel 1940 → Cohen 1963) is precise and well-structured.",
+      "recommendation": "Preserve. This commentary is the file's primary value and is genuinely educational."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "ContinuumHypothesis.lean lines 106-112 (gch_implies_ch)",
+      "finding": "The proof that GCH implies CH is the only genuinely substantive formal result in the file. It unfolds definitions, applies the GCH at α=0, and uses Mathlib's cardinal arithmetic (Cardinal.aleph_zero). This is real Lean proof work, not a wrapper or placeholder.",
+      "recommendation": "Preserve and highlight. This should be prominently featured as the file's main formal contribution."
+    },
+    {
+      "severity": "critical",
+      "category": "gap",
+      "location": "ContinuumHypothesis.lean lines 138, 141 (holds_CH, holds_notCH)",
+      "finding": "holds_CH and holds_notCH are both defined as `fun (_ : ZFCModel) => True`. This means holds_CH M = True and holds_notCH M = True for ALL models M, simultaneously. Consequence: the main theorem `continuum_hypothesis_independent` (line 269) asserts (∃ M, True) ∧ (∃ M, True), which is trivially true without any axioms. The axioms L_satisfies_CH and forcing_violates_CH both have type True. The entire independence 'proof' structure is vacuous — it does not distinguish models where CH holds from models where CH fails.",
+      "recommendation": "Replace holds_CH with a definition that actually references the CH proposition in the model. For example: `def holds_CH (M : ZFCModel) : Prop := sorry` would at least leave the connection as an explicit gap. Better: define a satisfaction relation so that holds_CH and holds_notCH are genuinely contradictory predicates. The current definitions make the file's central theorem mathematically meaningless."
+    },
+    {
+      "severity": "major",
+      "category": "filler",
+      "location": "ContinuumHypothesis.lean line 294 (easton_flexibility)",
+      "finding": "The theorem is named 'easton_flexibility' with docstring 'Easton's Theorem (1970): For regular cardinals, the function κ ↦ 2^κ can be almost anything consistent with König's theorem.' But the Lean statement is: `theorem easton_flexibility : (1 : ℕ) + 1 = 2 := rfl`. This is egregious filler — attaching a famous theorem's name and description to a completely unrelated trivial identity. A reader seeing 'Easton's Theorem' in the declaration list would be actively misled about the file's content.",
+      "recommendation": "Either remove entirely, or rename to something honest like `trivial_arithmetic` with a comment 'Easton's theorem is not formalized here.' If Easton's theorem is desired, it should be a genuine axiom or sorry'd statement about cardinal exponentiation."
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "meta.json originalContributions",
+      "finding": "The three listed contributions — 'Framework for ZFC models and relative consistency', 'Godel's constructible universe L axiomatized', 'Cohen's forcing approach outlined' — significantly overclaim. The 'framework' has all predicates defined as True. The 'axiomatization' of L is a structure with True fields (V_eq_L: True, L_satisfies_CH: True). The forcing 'approach' is similarly hollow. These are prose descriptions of mathematical ideas, not formal axiomatizations.",
+      "recommendation": "Reframe honestly: 'Illustrative scaffold showing the logical structure of the Gödel-Cohen independence proof, with key metamathematical facts as axioms and placeholder model definitions.'"
+    },
+    {
+      "severity": "major",
+      "category": "gap",
+      "location": "ContinuumHypothesis.lean lines 226-230 (RelativelyConsistent)",
+      "finding": "RelativelyConsistent is defined as `fun _ => ZFCModel → ∃ M : ZFCModel, True`. This definition ignores the proposition it's supposed to be relative to (the parameter is unused). Any ZFCModel witness trivially satisfies this. The 'consistency' theorems ch_consistent_with_zfc and not_ch_consistent_with_zfc are therefore vacuously true — they don't actually assert that specific models satisfy CH or ¬CH.",
+      "recommendation": "Either make RelativelyConsistent actually use its proposition parameter (e.g., via a satisfaction predicate), or honestly mark it as a placeholder with a sorry."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "ContinuumHypothesis.lean lines 23-28 (docstring status)",
+      "finding": "The file's status checklist says '[x] Incomplete (has sorries)' but there are no sorry declarations in the file (meta.json correctly says sorries: 0). The file has axioms, not sorries. These are semantically different: axioms are explicit assumptions, sorries are proof gaps.",
+      "recommendation": "Change to '[x] Axiomatized (has axiom declarations)' to accurately describe the file's status."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json axiomCount: 6 and assumptions field",
+      "finding": "The assumptions field describes real mathematical content for L_satisfies_CH ('L satisfies CH') and forcing_violates_CH ('forcing model violates CH'). But these axioms actually have type True due to the placeholder definitions. The assumptions field implies these axioms carry mathematical weight they don't actually have. Additionally, axiomCount: 6 is numerically correct but doesn't distinguish genuine axioms (ch_implies_no_intermediate, no_intermediate_implies_ch) from trivially-True ones.",
+      "recommendation": "Either fix the placeholder definitions so the axioms carry real content, or note in assumptions that L_satisfies_CH and forcing_violates_CH are trivially True due to placeholder model predicates."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "annotations.json ann-gch line 101",
+      "finding": "The annotation says 'Göran proved GCH holds in L' — this should be 'Gödel.' 'Göran' is a Swedish first name, not the mathematician who proved this result. Kurt Gödel proved GCH holds in L in his 1940 monograph.",
+      "recommendation": "Fix: 'Gödel proved GCH holds in L'."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json sections",
+      "finding": "Sections overlap at line 185 (godel ends at 185, cohen starts at 185) and miss several file parts: Part 3 (ZFC Set Theory, lines 114-141), Part 7 (Related Results, lines 280-295), Part 8 (Philosophy, lines 296-356).",
+      "recommendation": "Fix overlap and add missing sections."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "ContinuumHypothesis.lean lines 361-366 (#check commands)",
+      "finding": "Six #check debug commands left in production code.",
+      "recommendation": "Remove."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "researcher",
+      "description": "Fix holds_CH and holds_notCH definitions to be non-trivial predicates that actually distinguish models. At minimum, replace `True` with `sorry` placeholders. Ideally, define a satisfaction relation that connects ZFCModel to the CH proposition. This is the most critical issue — it makes the entire independence 'proof' vacuous.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "high",
+      "target": "researcher",
+      "description": "Remove or replace easton_flexibility. Currently proves 1+1=2 while claiming to be 'Easton's Theorem'. Either remove entirely or replace with a genuine axiomatization of Easton's result about cardinal exponentiation.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "high",
+      "target": "researcher",
+      "description": "Fix RelativelyConsistent to actually use its proposition parameter. Current definition ignores the input proposition, making consistency theorems vacuous.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Reframe originalContributions to honestly describe placeholder scaffold rather than claiming 'framework' and 'axiomatization'. Suggested: 'Illustrative scaffold showing the logical structure of the Gödel-Cohen independence proof.'",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix Göran → Gödel typo in annotations.json ann-gch.",
+      "status": "open"
+    },
+    {
+      "id": "ai-6",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix docstring status checklist: change '[x] Incomplete (has sorries)' to '[x] Axiomatized (has axiom declarations)'. Also update assumptions field to note which axioms are trivially True.",
+      "status": "open"
+    },
+    {
+      "id": "ai-7",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Fix section overlaps and add missing sections for ZFC Set Theory (lines 114-141), Related Results (lines 280-295), and Philosophy (lines 296-356).",
+      "status": "open"
+    },
+    {
+      "id": "ai-8",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Remove #check debug lines at end of file (lines 361-366).",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 4,
+    "originalityAccuracy": 4,
+    "completeness": 4,
+    "framingPrecision": 4,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 4,
+    "overall": 4.7
+  },
+
+  "suggestedBestFraming": "A pedagogical scaffold illustrating the logical structure of the Gödel-Cohen independence proof for CH, with genuine Lean definitions for CH, GCH, and ℵ₁ using Mathlib's cardinal arithmetic, one substantive proof (GCH → CH), and axiomatized placeholder models for the constructible universe and forcing extension — the central independence theorem is illustrative rather than formally meaningful due to placeholder model predicates."
+}


### PR DESCRIPTION
## Summary
- Peer review of continuum-hypothesis gallery entry
- Grade: **C-** (overall 4.7/10) — Tier C (scaffold/axiomatized)
- 11 findings (2 positive, 1 critical, 3 major, 3 moderate, 2 minor), 8 action items

## Key Findings
- **Critical**: `holds_CH` and `holds_notCH` are both `fun _ => True`, making the main independence theorem vacuously true — it asserts `(∃ M, True) ∧ (∃ M, True)`
- **Major (filler)**: `easton_flexibility` claims to be "Easton's Theorem (1970)" but proves `(1:ℕ)+1=2 := rfl`
- **Major**: `RelativelyConsistent` ignores its proposition parameter, making consistency theorems vacuous
- **Strength**: Excellent pedagogical commentary (philosophical implications, L, forcing)
- **Strength**: `gch_implies_ch` is the one genuinely proved result using Mathlib cardinal arithmetic

## Test plan
- [ ] Verify review.json is valid JSON
- [ ] Verify review-tracker.json updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)