### PR TITLE
Enrich 4 entries: fix section line range gaps

### DIFF
--- a/src/data/proofs/erdos-287/meta.json
+++ b/src/data/proofs/erdos-287/meta.json
@@ -72,7 +72,7 @@
   "overview": {
     "historicalContext": "**Erdős Problem #287: Egyptian Fraction Gap**\n\nThis problem concerns Egyptian fraction representations of 1 — writing 1 = 1/n₁ + 1/n₂ + ··· + 1/nₖ with distinct integers n₁ < n₂ < ··· < nₖ. Egyptian fractions have a remarkably long history: the Rhind Mathematical Papyrus (c. 1650 BCE, copied by the scribe Ahmes from an even older document) contains extensive tables for decomposing fractions as sums of distinct unit fractions. The ancient Egyptians used only unit fractions (with the exception of 2/3), making these decompositions a practical necessity for arithmetic.\n\nThe specific question of how 'dense' such a representation can be — how small the maximum gap between consecutive denominators can be — was posed by Erdős in connection with his 1932 result on consecutive integer reciprocals.\n\n**Erdős's 1932 Theorem:** The sum 1/n + 1/(n+1) + ··· + 1/(n+k) is never equal to 1 for n ≥ 2. The elegant proof uses Bertrand's postulate (Chebyshev's theorem): the largest prime p ≤ n+k satisfies p > (n+k)/2, so p appears exactly once among {n, ..., n+k}. Multiplying the sum by lcm(n, ..., n+k), exactly one term has odd p-adic valuation, making the numerator indivisible by p and hence not equal to the denominator.\n\nThis theorem immediately implies maxGap ≥ 2 for any Egyptian fraction representation of 1 (since gap 1 everywhere means consecutive integers). Erdős then asked the natural strengthening: must the maximum gap be at least 3?\n\n**The Conjecture (OPEN):** Every representation 1 = Σ 1/nᵢ has max(nᵢ₊₁ − nᵢ) ≥ 3. The example 1 = 1/2 + 1/3 + 1/6 with max gap 3 shows this would be sharp. Despite over 90 years of attention, the conjecture remains open. The difficulty lies in ruling out representations where gaps alternate between 1 and 2 — such sequences have more complex LCM structure than purely consecutive integers.\n\n**Connection to Prime Distribution:** Erdős observed that the conjecture would follow (for all but finitely many cases) from a conjecture in prime distribution theory: for all sufficiently large N, there exists a prime p ∈ [N, 2N] such that (p+1)/2 is also prime. This connects the Egyptian fraction gap problem to deep questions about prime pairs.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet $k \\ge 2$. For any distinct integers $1 < n_1 < n_2 < \\cdots < n_k$ such that\n$$1 = \\frac{1}{n_1} + \\frac{1}{n_2} + \\cdots + \\frac{1}{n_k},$$\nmust we have $\\max_{1 \\le i < k}(n_{i+1} - n_i) \\ge 3$?\n\n**Known Results:**\n- $\\max(n_{i+1} - n_i) \\ge 2$: **PROVED** (Erdős, 1932)\n- $\\max(n_{i+1} - n_i) = 3$ achievable: $1 = 1/2 + 1/3 + 1/6$\n- $\\max(n_{i+1} - n_i) \\ge 3$: **OPEN CONJECTURE**\n\n**Status**: OPEN",
-    "text": "For 1 = 1/n\u2081 + \u22ef + 1/n\u2096 with distinct integers, must max(n\u1d62\u208a\u2081 - n\u1d62) \u2265 3? The example 1 = 1/2 + 1/3 + 1/6 shows 3 is optimal. Gap \u2265 2 is proven. Status: OPEN.",
+    "text": "For 1 = 1/n₁ + ⋯ + 1/nₖ with distinct integers, must max(nᵢ₊₁ - nᵢ) ≥ 3? The example 1 = 1/2 + 1/3 + 1/6 shows 3 is optimal. Gap ≥ 2 is proven. Status: OPEN.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Definitions:** IsUnitFractionDecomp encodes a valid representation as a sorted list of distinct integers > 1 with rational reciprocals summing to 1. maxGap computes the maximum consecutive difference via zip/fold\n\n2. **The Example:** example_2_3_6 axiomatizes that [2, 3, 6] is valid with maxGap = 3 (could be proved by norm_num but kept as axiom for simplicity)\n\n3. **Lower Bound:** no_consecutive_reciprocals axiomatizes Erdős's 1932 result (gap ≥ 2). The proof via Bertrand's postulate is beyond the current formalization\n\n4. **Conjecture:** erdos_287_conjecture axiomatizes the open gap ≥ 3 conjecture, recording it as an axiom since it is unproved\n\n5. **Main Theorem:** erdos_287 is a genuine theorem proving gap ≥ 2 by invoking no_consecutive_reciprocals. This is the strongest proved result\n\n6. **Compactness:** The entire formalization is 91 lines, reflecting the clarity of the problem statement and the simplicity of the known partial results",
     "keyInsights": [
       "**LCM Obstruction via Bertrand's Postulate:** The proof that gap ≥ 2 works because consecutive integers always contain a prime p > (n+k)/2, and this prime appears exactly once in {n, ..., n+k}. Multiplying the sum by the LCM, the p-adic valuation argument shows the numerator cannot equal the denominator. For gap ≥ 3, one would need to handle sequences with gaps of 1 and 2, where the prime structure is more complex",
@@ -103,7 +103,7 @@
       "summary": "Defines IsUnitFractionDecomp as a sorted list of distinct integers > 1 with rational reciprocal sum = 1, and maxGap via zip/tail/foldl over consecutive differences. These are the two core building blocks for stating both the conjecture and the known results.",
       "mathContext": "$\\text{IsUnitFractionDecomp}(ns) \\iff |ns| \\ge 2 \\land ns \\text{ sorted} \\land (\\forall n \\in ns, n > 1) \\land \\sum_{n \\in ns} 1/n = 1$. $\\text{maxGap}(ns) = \\max_i(n_{i+1} - n_i)$.",
       "startLine": 25,
-      "endLine": 41
+      "endLine": 42
     },
     {
       "id": "example",
@@ -111,7 +111,7 @@
       "summary": "Axiomatizes example_2_3_6: [2, 3, 6] is a valid decomposition with maxGap = 3. This is the simplest representation of 1 and shows the conjectured bound 3 would be tight. Note: this axiom is trivially provable by computation (norm_num/decide) — an Aristotle candidate.",
       "mathContext": "$1/2 + 1/3 + 1/6 = 1$, gaps $= (1, 3)$, maxGap $= 3$. Provable axiom.",
       "startLine": 43,
-      "endLine": 49
+      "endLine": 50
     },
     {
       "id": "known-lower-bound",
@@ -119,7 +119,7 @@
       "summary": "Axiomatizes no_consecutive_reciprocals: Erdős's 1932 theorem that consecutive integer reciprocals never sum to 1, implying maxGap ≥ 2 for all representations. The proof uses Bertrand's postulate and p-adic valuation arguments.",
       "mathContext": "Erdős 1932: $\\sum_{i=n}^{n+k} 1/i \\neq 1$ for $n \\ge 2$. Proof uses Bertrand's postulate: the largest prime $p \\le n+k$ satisfies $v_p(\\text{lcm}(n,\\ldots,n+k)) = 1$.",
       "startLine": 51,
-      "endLine": 62
+      "endLine": 63
     },
     {
       "id": "conjecture",
@@ -127,7 +127,7 @@
       "summary": "Axiomatizes erdos_287_conjecture: the OPEN conjecture that maxGap ≥ 3 for all representations. Combined with the example [2, 3, 6], this would give a complete characterization: the minimum achievable maximum gap is exactly 3.",
       "mathContext": "Conjecture: $\\max_i(n_{i+1} - n_i) \\ge 3$ for all representations $\\sum 1/n_i = 1$. OPEN since 1932.",
       "startLine": 64,
-      "endLine": 74
+      "endLine": 75
     },
     {
       "id": "main-theorem",

--- a/src/data/proofs/erdos-331/meta.json
+++ b/src/data/proofs/erdos-331/meta.json
@@ -96,70 +96,70 @@
       "id": "header",
       "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 35,
+      "endLine": 36,
       "summary": "Problem header documenting the DISPROVED status, Ruzsa's binary counterexample, the unique representation property, and the reference to Erdős-Graham (1980, p. 50). Imports Mathlib for natural numbers, reals, finite sets, binary digits, and filters."
     },
     {
       "id": "counting-functions",
       "title": "Part I: Counting Functions",
       "startLine": 37,
-      "endLine": 55,
+      "endLine": 56,
       "summary": "Defines countingFunction via Finset.filter over Finset.Icc 1 N. HasDensityAtLeast(A, α) requires |A ∩ {1,...,N}| ≥ c·N^α for large N. HasSqrtDensity specializes to α = 1/2. HasExactSqrtDensity requires the counting function divided by √N to converge to c via Filter.Tendsto."
     },
     {
       "id": "common-differences",
       "title": "Part II: Common Differences",
       "startLine": 57,
-      "endLine": 72,
+      "endLine": 73,
       "summary": "Defines HasCommonDifference(A, B, d) requiring d ≠ 0 with d ∈ (A−A) ∩ (B−B). The set commonDifferences(A, B) collects all such d. HasInfinitelyManyCommonDifferences requires Set.Infinite on this set."
     },
     {
       "id": "conjecture",
       "title": "Part III: The Original Conjecture",
       "startLine": 74,
-      "endLine": 83,
+      "endLine": 84,
       "summary": "Formalizes ErdosConjecture331: for all A, B with sqrt density, there are infinitely many common differences. This universal statement is what Ruzsa disproves with his binary construction."
     },
     {
       "id": "ruzsa-construction",
       "title": "Part IV: Ruzsa's Counterexample",
       "startLine": 85,
-      "endLine": 114,
+      "endLine": 115,
       "summary": "Defines evenBinaryPositions (digits only in positions 0, 2, 4, ...) and oddBinaryPositions (digits only in positions 1, 3, 5, ...) via modular arithmetic. Names ruzsaA and ruzsaB as aliases. Axiomatizes sqrt density for both sets and the unique representation property: every n ≥ 1 has unique decomposition n = a + b."
     },
     {
       "id": "disproof",
       "title": "Part V: The Disproof",
       "startLine": 116,
-      "endLine": 141,
+      "endLine": 142,
       "summary": "Axiomatizes ruzsa_no_common_differences: CD(A,B) = ∅. GENUINELY PROVES ruzsa_counterexample by assembling density + emptiness + Set.not_infinite_empty. GENUINELY PROVES erdos_331_disproved by contradiction: instantiating the universal conjecture with Ruzsa's sets yields a contradiction."
     },
     {
       "id": "understanding",
       "title": "Part VI: Understanding the Counterexample",
       "startLine": 143,
-      "endLine": 161,
+      "endLine": 162,
       "summary": "Structural analysis: ruzsaA_characterization shows A = {sums of powers of 4}. Axiomatizes B = 2A (odd positions = doubled even positions). Axiomatizes exact growth ~c√N for both sets, confirming the construction sits precisely at the density threshold."
     },
     {
       "id": "variant",
       "title": "Part VII: Ruzsa's Stronger Variant",
       "startLine": 163,
-      "endLine": 178,
+      "endLine": 179,
       "summary": "Defines RuzsaVariant: with exact asymptotic density |A(N)| ~ c·√N (convergence, not just lower bound), must common differences exist? Axiomatized as OPEN. The distinction between ≫ √N and ~ c√N is subtle but may change the answer."
     },
     {
       "id": "difference-set",
       "title": "Part VIII: The Difference Set",
       "startLine": 180,
-      "endLine": 198,
+      "endLine": 199,
       "summary": "Defines differenceSet A − A = {a − a' : a, a' ∈ A}. Axiomatizes sparseness: |{d ∈ A−A : |d| ≤ N}| ≤ c√N for Ruzsa's A. This extreme sparseness (generic sets have |A−A| ~ N) is why (A−A) ∩ (B−B) can be empty."
     },
     {
       "id": "larger-density",
       "title": "Part IX: Comparison with Larger Densities",
       "startLine": 200,
-      "endLine": 213,
+      "endLine": 214,
       "summary": "Axiomatizes larger_density_common_differences: for α > 1/2, density N^α forces infinite common differences. This establishes √N as a sharp threshold — the counterexample exists precisely at the critical exponent."
     },
     {

--- a/src/data/proofs/erdos-444/meta.json
+++ b/src/data/proofs/erdos-444/meta.json
@@ -97,7 +97,7 @@
       "id": "section-1",
       "title": "Basic Definitions",
       "startLine": 31,
-      "endLine": 61,
+      "endLine": 62,
       "summary": "Defines **InfiniteSubset**, **d_A(n)** = |{a ∈ A : a | n}| (generalized divisor function), **H_A(x)** = Σ_{a∈A, a<x} 1/a (partial harmonic sum), and **M_A(x)** = max_{n<x} d_A(n) (maximum A-divisor count). These are the three quantities whose relationship the problem studies.",
       "mathContext": "$d_A(n) = |\\{a \\in A : a \\mid n\\}|$ generalizes $\\tau(n) = d_{\\mathbb{N}}(n)$. $H_A(x) = \\sum_{a \\in A, a \\leq x} 1/a$ (harmonic partial sum over $A$)."
     },
@@ -105,7 +105,7 @@
       "id": "section-2",
       "title": "The Main Conjecture (PROVED)",
       "startLine": 63,
-      "endLine": 85,
+      "endLine": 86,
       "summary": "**erdos_graham_conjecture**: ∀ infinite A, ∀ k ≥ 1, lim sup M_A(x)/H_A(x)^k = ∞. Formalized using `Filter.atTop` and `∃ᶠ`. **erdos_graham_conjecture_true**: axiomatized as proved by Erdős-Sárközy (1980) via extremal product constructions.",
       "mathContext": "Conjecture: $\\limsup_{x \\to \\infty} M_A(x) / (H_A(x))^k \\to \\infty$ where $M_A(x) = \\max_{n \\leq x} d_A(n)$."
     },
@@ -113,7 +113,7 @@
       "id": "section-3",
       "title": "Special Cases",
       "startLine": 87,
-      "endLine": 107,
+      "endLine": 108,
       "summary": "**A = ℕ**: d_A = τ, H_A ∼ log x, M_A ∼ exp(log 2 · log x / log log x) (highly composite numbers). **A = primes**: d_A = ω, H_A ∼ log log x (Mertens), M_A ∼ log x / log log x (primorials). Both cases confirm the general theorem.",
       "mathContext": "Classical case $A = \\mathbb{N}$: $d_A = \\tau$, $H_A(x) \\sim \\log x$, $M_A(x) \\sim \\exp(\\log 2 \\cdot \\log x / \\log\\log x)$ (Ramanujan 1915)."
     },
@@ -121,7 +121,7 @@
       "id": "section-4",
       "title": "Structural Properties",
       "startLine": 109,
-      "endLine": 130,
+      "endLine": 131,
       "summary": "**highly_composite_relative**: A-highly composite numbers exist for any A. **exponential_lower_bound**: M_A(x) ≥ exp(c · H_A(x)) frequently. **no_uniform_bound**: no function f bounds M_A(x) in terms of H_A(x) universally — the strongest form of the result.",
       "mathContext": "An $A$-highly composite number $n$ maximizes $d_A(n)$ up to $n$. These exist for any infinite $A$ (analogous to highly composite numbers for $\\tau$)."
     },

--- a/src/data/proofs/erdos-616/meta.json
+++ b/src/data/proofs/erdos-616/meta.json
@@ -94,63 +94,63 @@
       "title": "Header, References, and Imports",
       "summary": "Module docstring citing the Erdős-Hajnal-Tuza 1991 paper, plus Mathlib imports for Finset, Nat, Set, and Real",
       "startLine": 1,
-      "endLine": 40
+      "endLine": 41
     },
     {
       "id": "hypergraph-defs",
       "title": "Hypergraph Definitions",
       "summary": "Core structures: UniformHypergraph (r-uniform edge collection), IsCoveringSet (transversal property), coveringNumber (τ via infimum), and inducedSubhypergraph (restriction to vertex subset)",
       "startLine": 42,
-      "endLine": 77
+      "endLine": 78
     },
     {
       "id": "local-condition",
       "title": "The Local Covering Condition",
       "summary": "HasLocalCoveringBound predicate requiring τ(G[W]) ≤ 1 for all W with |W| ≤ k, plus the localThreshold function defining k = 3r-3",
       "startLine": 79,
-      "endLine": 98
+      "endLine": 99
     },
     {
       "id": "main-question",
       "title": "The Main Question: ErdosProblem616",
       "summary": "Formal statement parameterized by r and t, plus axiomatized optimalCoveringBound asserting existence of the extremal function",
       "startLine": 100,
-      "endLine": 118
+      "endLine": 119
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds: Erdős-Hajnal-Tuza 1991",
       "summary": "Axiomatized lower bound (3/16)r + 7/8 via explicit constructions and upper bound (1/5)r via counting arguments, with coefficient definitions and consistency check",
       "startLine": 120,
-      "endLine": 160
+      "endLine": 161
     },
     {
       "id": "special-cases",
       "title": "Special Cases and Small r",
       "summary": "Concrete threshold values for r = 3 (k = 6) and r = 4 (k = 9), with analysis showing bounds become meaningful only for large r",
       "startLine": 162,
-      "endLine": 185
+      "endLine": 186
     },
     {
       "id": "threshold-analysis",
       "title": "Why the Threshold 3r-3?",
       "summary": "Structural analysis of why 3r-3 is the critical threshold: connection to disjoint edge packings, sunflower structures, and the Erdős-Ko-Rado framework",
       "startLine": 187,
-      "endLine": 201
+      "endLine": 202
     },
     {
       "id": "equivalent-formulations",
       "title": "Equivalent Formulations: Kernel Property",
       "summary": "HasKernel definition and the proved theorem tau_one_iff_kernel establishing that τ ≤ 1 is equivalent to having a vertex common to all edges",
       "startLine": 203,
-      "endLine": 228
+      "endLine": 229
     },
     {
       "id": "fractional-relaxation",
       "title": "Fractional Relaxation",
       "summary": "Axiomatized fractional covering number τ*(G) as the LP relaxation, connecting to duality theory and integrality gap analysis",
       "startLine": 230,
-      "endLine": 244
+      "endLine": 245
     },
     {
       "id": "summary-theorem",


### PR DESCRIPTION
Batch enrichment pass fixing section coverage gaps.

**Entries enriched:**
- erdos-444 (4 gaps fixed)
- erdos-287 (4 gaps fixed)
- erdos-331 (10 gaps fixed)
- erdos-616 (9 gaps fixed)

All sections now tile their files with no gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)