### PR TITLE
Enrich 4 entries: fix section line range gaps (batch 2)

### DIFF
--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -95,7 +95,7 @@
       "id": "header",
       "title": "Module Header",
       "startLine": 1,
-      "endLine": 17,
+      "endLine": 18,
       "summary": "Problem statement: partition {1,...,2N} into equal halves, minimize maximum overlap. Known bounds 0.379 < c < 0.381. Status: OPEN.",
       "mathContext": "Partition $\\{1, \\ldots, 2N\\}$ into $A \\sqcup B$ with $|A| = |B| = N$. Define $M(N) = \\min_{(A,B)} \\max_k |\\{(a,b) : a - b = k\\}|$. The limit $c = \\lim_{N \\to \\infty} M(N)/N$ exists with $0.379005 < c < 0.380876$."
     },
@@ -103,7 +103,7 @@
       "id": "imports",
       "title": "Imports",
       "startLine": 19,
-      "endLine": 23,
+      "endLine": 24,
       "summary": "Imports Mathlib's **Nat.Basic**, **Int.Basic**, **Finset.Basic**, **Real.Basic**, and **Tactic** for integer differences, finite set cardinality, and real-valued asymptotic bounds.",
       "mathContext": "Imports: `Finset.filter`/`Finset.card` for counting overlaps, `Real.sqrt` for Scherk's $1 - 1/\\sqrt{2}$ bound, standard arithmetic for the minimax definition."
     },
@@ -111,7 +111,7 @@
       "id": "definition",
       "title": "Core Definitions",
       "startLine": 25,
-      "endLine": 38,
+      "endLine": 39,
       "summary": "Defines **overlap**(A,B,k) as the representation function $r_{A-B}(k)$, **maxOverlap** as $\\max_k r_{A-B}(k)$, and **minMaxOverlap** $M(N) = \\min_{(A,B)} \\max_k \\text{overlap}(A,B,k)$.",
       "mathContext": "$\\text{overlap}(A,B,k) = |\\{(a,b) \\in A \\times B : a - b = k\\}| = r_{A-B}(k)$. $M(N) = \\min_{A \\sqcup B = [2N],\\,|A|=|B|=N} \\max_k r_{A-B}(k)$."
     },
@@ -119,7 +119,7 @@
       "id": "main-question",
       "title": "Main Question: The Asymptotic Constant",
       "startLine": 40,
-      "endLine": 47,
+      "endLine": 48,
       "summary": "States the existence of $c = \\lim M(N)/N > 0$ via $\\varepsilon$-$N_0$ definition. The exact value of $c$ is the central open question.",
       "mathContext": "$c = \\lim_{N \\to \\infty} M(N)/N$ exists and $c > 0$. Currently $0.379005 < c < 0.380876$."
     },
@@ -127,7 +127,7 @@
       "id": "known-bounds",
       "title": "Known Bounds",
       "startLine": 49,
-      "endLine": 70,
+      "endLine": 71,
       "summary": "Axiomatizes four bounds: **Erdős** ($> 1/4$, 1955), **Scherk** ($> 1 - 1/\\sqrt{2}$, 1955), **White** ($> 0.379005$, 2022 via Fourier/SDP), **Haugland-TTT** ($< 0.380876$, 2016/2026 via step functions).",
       "mathContext": "$1/4 < 1 - 1/\\sqrt{2} \\approx 0.293 < 0.379005 < c < 0.380876 < 0.381$. Four progressively tighter bounds spanning 70 years of research."
     },
@@ -135,7 +135,7 @@
       "id": "small-values",
       "title": "Small Values",
       "startLine": 72,
-      "endLine": 78,
+      "endLine": 79,
       "summary": "Records $M(1)=1, M(2)=1, M(3)=2, M(4)=2, M(5)=3$. Computed by exhaustive enumeration; the ratios $M(N)/N$ oscillate toward $c \\approx 0.38$.",
       "mathContext": "$M(1)/1 = 1, M(2)/2 = 0.5, M(3)/3 \\approx 0.667, M(4)/4 = 0.5, M(5)/5 = 0.6$. The ratios oscillate and converge toward $c \\approx 0.38$."
     },

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -126,7 +126,7 @@
       "id": "header",
       "title": "Problem Statement and Imports",
       "startLine": 1,
-      "endLine": 35,
+      "endLine": 36,
       "summary": "Docstring defining Erdős Problem #369: for $\\varepsilon > 0$ and $k \\geq 2$, does $\\{1,\\ldots,n\\}$ contain $k$ consecutive $n^\\varepsilon$-smooth integers for all large $n$? References Erdős-Graham (1980), Balog-Wooley (1998). Imports Mathlib for primes, divisibility, and finite sets.",
       "mathContext": "$m$ is $B$-smooth if $P^+(m) \\leq B$. Question: $\\forall \\varepsilon > 0, k \\geq 2, \\exists N_0: n \\geq N_0 \\implies$ $k$ consecutive $n^\\varepsilon$-smooth integers in $[1,n]$."
     },
@@ -134,7 +134,7 @@
       "id": "smooth-numbers",
       "title": "Part I: Smooth Numbers",
       "startLine": 37,
-      "endLine": 48,
+      "endLine": 49,
       "summary": "Defines **IsSmooth m B** ($P^+(m) \\leq B$, all prime factors bounded) and axiomatizes **largestPrimeFactor**. The Dickman-de Bruijn function governs the density of $B$-smooth numbers: $\\Psi(x, x^{1/u}) \\sim x\\rho(u)$.",
       "mathContext": "$\\text{IsSmooth}(m, B) \\iff \\forall p \\mid m,\\, p\\text{ prime} \\implies p \\leq B$. Density: $\\Psi(x, x^{1/u}) \\sim x\\rho(u)$ where $\\rho$ satisfies $u\\rho'(u) = -\\rho(u-1)$."
     },
@@ -142,7 +142,7 @@
       "id": "consecutive-runs",
       "title": "Part II: Consecutive Smooth Runs",
       "startLine": 50,
-      "endLine": 67,
+      "endLine": 68,
       "summary": "Defines **ConsecutiveSmoothRun m k B** ($k \\geq 2$ consecutive $B$-smooth integers from $m$) and **HasConsecutiveSmoothRun** (existence within $\\{1,\\ldots,n\\}$). Coprimality of consecutive integers makes joint smoothness a multiplicatively independent condition.",
       "mathContext": "$\\text{ConsecutiveSmoothRun}(m, k, B) \\iff \\forall i < k: P^+(m+i) \\leq B$. Key difficulty: $\\gcd(m, m+1) = 1$ makes their smoothness independent."
     },
@@ -150,7 +150,7 @@
       "id": "conjecture",
       "title": "Part III: The Erdős-Graham Conjecture",
       "startLine": 69,
-      "endLine": 87,
+      "endLine": 88,
       "summary": "**ErdosConjecture369**: parametrized by `smoothBound : ℕ → ℕ` (divergent, $\\leq n$), asserts $\\forall k \\geq 2, \\exists N_0, \\forall n \\geq N_0$, a $k$-run of smooth integers exists. Elegantly avoids real exponentiation.",
       "mathContext": "Parametrized: given $B : \\mathbb{N} \\to \\mathbb{N}$ with $B(n) \\to \\infty, B(n) \\leq n$: $\\forall k \\geq 2, \\exists N_0, \\forall n \\geq N_0: \\text{HasConsecutiveSmoothRun}(n,k,B(n))$."
     },
@@ -158,7 +158,7 @@
       "id": "k2-case",
       "title": "Part IV: The k = 2 Case",
       "startLine": 89,
-      "endLine": 105,
+      "endLine": 106,
       "summary": "**ErdosConjecture369_k2**: the simplest open instance. Even two consecutive smooth numbers for all large $n$ is unresolved. Erdős-Graham: 'the problem seems very hard.'",
       "mathContext": "$k = 2$: $\\exists N_0, \\forall n \\geq N_0, \\exists m \\leq n: P^+(m) \\leq B(n) \\wedge P^+(m+1) \\leq B(n)$. The simplest open case."
     },
@@ -166,7 +166,7 @@
       "id": "balog-wooley",
       "title": "Part V: Balog-Wooley Partial Result (1998)",
       "startLine": 107,
-      "endLine": 120,
+      "endLine": 121,
       "summary": "Axiomatizes **balog_wooley_infinitely_many**: infinitely many $n$ with $n, n+1$ both smooth. Uses sieve methods and exponential sums. Falls short of 'all sufficiently large $n$.'",
       "mathContext": "Balog-Wooley: $|\\{n \\leq x : P^+(n) \\leq n^\\varepsilon \\wedge P^+(n+1) \\leq n^\\varepsilon\\}| = \\infty$. Gap: this is $\\exists^\\infty$ not $\\forall^\\infty$."
     },

--- a/src/data/proofs/erdos-620/meta.json
+++ b/src/data/proofs/erdos-620/meta.json
@@ -96,84 +96,84 @@
       "id": "imports-setup",
       "title": "Imports and Setup",
       "startLine": 32,
-      "endLine": 43,
+      "endLine": 44,
       "summary": "Imports Mathlib modules for simple graphs, cliques, subgraphs, cardinality, and logarithms. Opens `SimpleGraph` and `Finset` namespaces with generic finite type variable $V$."
     },
     {
       "id": "cliques-forbidden",
       "title": "Cliques and Forbidden Subgraphs",
       "startLine": 45,
-      "endLine": 67,
+      "endLine": 68,
       "summary": "Defines `HasTriangle`, `TriangleFree`, `HasK4`, and `K4Free`. Includes a complete Lean proof of `triangleFree_implies_K4Free` via existential destruction — one of the file's fully verified results."
     },
     {
       "id": "induced-subgraphs",
       "title": "Induced Subgraphs",
       "startLine": 69,
-      "endLine": 86,
+      "endLine": 87,
       "summary": "Defines `inducedSubgraph G S` as the graph on subtype $S$ inheriting adjacency from $G$. Defines `InducedTriangleFree` and `maxTriangleFreeInduced` via $\\sup$ over triangle-free induced subgraph sizes."
     },
     {
       "id": "erdos-rogers-function",
       "title": "The Erdős-Rogers Function",
       "startLine": 88,
-      "endLine": 103,
+      "endLine": 104,
       "summary": "Defines the core function `erdosRogers n` $= \\inf\\{k : \\forall G \\text{ on Fin}(n),\\, K_4\\text{-free} \\Rightarrow \\text{maxTF}(G) \\ge k\\}$ and the alternative `ErdosRogersProperty n k` as an explicit universal statement."
     },
     {
       "id": "main-problem",
       "title": "Main Problem Statement",
       "startLine": 105,
-      "endLine": 115,
+      "endLine": 116,
       "summary": "Formalizes `Erdos620Statement`: existence of a tight function $f$ with $\\forall G,\\, f(n) \\le \\text{maxTF}(G)$ and attainment $\\exists G,\\, \\text{maxTF}(G) = f(n)$."
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds (1991-2024)",
       "startLine": 117,
-      "endLine": 167,
+      "endLine": 168,
       "summary": "Axiomatizes six bounds: trivial lower ($c\\sqrt{n}$), Shearer ($\\sqrt{n}\\sqrt{\\log n}/\\log\\log n$), Bollobás-Hind ($n^{7/10+o(1)}$), Krivelevich ($n^{2/3}(\\log n)^{1/3}$), Wolfovitz ($\\sqrt{n}(\\log n)^{120}$), and Mubayi-Verstraëte ($\\sqrt{n}\\log n$)."
     },
     {
       "id": "current-state",
       "title": "Current State of Knowledge",
       "startLine": 169,
-      "endLine": 187,
+      "endLine": 188,
       "summary": "Complete proof of `current_bounds` combining Shearer and Mubayi-Verstraëte. Complete proof of `gap_analysis` extracting constants $c, C > 0$ with the full sandwich inequality for $n \\ge 16$."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "startLine": 189,
-      "endLine": 204,
+      "endLine": 205,
       "summary": "Sparse graph case: $|E| \\le n$ implies triangle-free induced subgraph of size $\\ge n/3$. Defines the Turán graph $T(n,3)$ via $i \\bmod 3 \\ne j \\bmod 3$ adjacency and states $K_4$-freeness."
     },
     {
       "id": "ramsey-connection",
       "title": "Ramsey Connection",
       "startLine": 206,
-      "endLine": 224,
+      "endLine": 225,
       "summary": "Defines `ramsey3k k` and axiomatizes Kim's theorem $R(3,k) = \\Theta(k^2/\\log k)$. States the Erdős-Rogers to Ramsey connection: if $n \\ge R(3,k)$, then $f(n) \\ge k$ or every $K_4$-free graph has a triangle."
     },
     {
       "id": "probabilistic",
       "title": "Probabilistic Bounds",
       "startLine": 226,
-      "endLine": 242,
+      "endLine": 243,
       "summary": "Axiomatizes probabilistic upper bound (near-tight construction achieving $(1+\\varepsilon)\\sqrt{n}\\log n$) and dependent random choice lower bound ($c\\sqrt{n}$ baseline). Both directions use randomized arguments."
     },
     {
       "id": "generalizations",
       "title": "Generalizations",
       "startLine": 244,
-      "endLine": 262,
+      "endLine": 263,
       "summary": "Defines $f_{s,t}(n)$ via `generalizedErdosRogers` using Mathlib's `CliqueFree`. States `original_is_f43` and axiomatizes $f_{s,2}(n) = \\Theta(n^{1/(s-1)} \\cdot (\\log n)^{O(1)})$ from Ramsey theory."
     },
     {
       "id": "open-status",
       "title": "Open Status",
       "startLine": 264,
-      "endLine": 278,
+      "endLine": 314,
       "summary": "Formalizes the problem's openness as non-existence of a pure power-law $f(n) \\asymp n^\\alpha$. The theorem `erdos_620_unsolved` (sorry'd) encodes that no single exponent captures the logarithmic correction."
     }
   ],

--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -87,77 +87,77 @@
       "title": "Imports and Setup",
       "summary": "Imports `Cardinal.Ordinal` for $\\aleph$ functions, `Cardinal.Cofinality` for $\\mathrm{cof}(\\kappa)$, and `Finset.Basic` for finite subset operations. Opens the `Cardinal` and `Set` namespaces.",
       "startLine": 27,
-      "endLine": 35
+      "endLine": 36
     },
     {
       "id": "cardinals",
       "title": "Cardinal Background",
       "summary": "Defines $\\aleph_\\omega = \\aleph_{\\omega}$ as the first singular cardinal, proves it is a limit cardinal via `Cardinal.isLimit_aleph`, establishes singularity ($\\neg\\mathrm{IsRegular}$), and shows $\\aleph_n < \\aleph_\\omega$ for all $n < \\omega$.",
       "startLine": 37,
-      "endLine": 59
+      "endLine": 60
     },
     {
       "id": "free-functions",
       "title": "Free Functions",
       "summary": "Defines `IsFreeFunction` as $\\forall A \\in [X]^{<\\omega},\\, f(A) \\notin A$. Proves existence of free functions on infinite sets by choosing elements outside finite subsets (using the infinite pigeonhole principle).",
       "startLine": 61,
-      "endLine": 74
+      "endLine": 75
     },
     {
       "id": "independent-sets",
       "title": "Independent Sets",
       "summary": "Defines `IsIndependent` as $\\forall B \\in [Y]^{<\\omega},\\, f(B) \\notin Y$. Proves $\\emptyset$ is trivially independent and characterizes singleton independence: $\\{x\\}$ is independent iff $f(\\{x\\}) \\neq x$.",
       "startLine": 76,
-      "endLine": 100
+      "endLine": 101
     },
     {
       "id": "erdos-hajnal",
       "title": "Erdős-Hajnal Negative Result",
       "summary": "Axiomatizes the Erdős-Hajnal theorem (1958): for $|X| < \\aleph_\\omega$, there exists a free $f$ with no infinite independent set. Derives the consequence for each specific $\\aleph_n$ via `counterexample_at_aleph_n`.",
       "startLine": 102,
-      "endLine": 119
+      "endLine": 120
     },
     {
       "id": "main-problem",
       "title": "The Main Problem (OPEN)",
       "summary": "States `erdos_623_conjecture`: $\\forall X$ with $|X| = \\aleph_\\omega$, every free $f$ admits an infinite independent set. Also states the negative formulation and proves the dichotomy `erdos_623_conjecture \\lor \\text{erdos\\_623\\_negative}`.",
       "startLine": 121,
-      "endLine": 146
+      "endLine": 147
     },
     {
       "id": "undecidability",
       "title": "Potential Undecidability",
       "summary": "Discusses Erdős's 1999 suggestion of ZFC-independence. Proves `cofinality_aleph_omega : $\\mathrm{cof}(\\aleph_\\omega) = \\omega$` using `Cardinal.cof_aleph`, establishing the singular nature that drives independence phenomena.",
       "startLine": 148,
-      "endLine": 162
+      "endLine": 163
     },
     {
       "id": "related",
       "title": "Related Concepts",
       "summary": "Provides a chromatic interpretation (`ChromaticVersion`): coloring finite sets so the image avoids $Y$. Also gives a `RamseyInterpretation` viewing the problem as a partition regularity question for singular cardinals.",
       "startLine": 164,
-      "endLine": 173
+      "endLine": 174
     },
     {
       "id": "finite-cases",
       "title": "Finite and Countable Cases",
       "summary": "Proves `finite_case_trivial`: for finite $X$, no infinite $Y$ exists (via `Set.toFinite`). Proves `countable_case_no`: for $|X| = \\aleph_0$, reduces to Erdős-Hajnal since $\\aleph_0 = \\aleph_0 < \\aleph_\\omega$.",
       "startLine": 175,
-      "endLine": 190
+      "endLine": 191
     },
     {
       "id": "gap",
       "title": "The Gap",
       "summary": "Summarizes known results in a table: NO for all $\\aleph_n$ ($n < \\omega$), OPEN at $\\aleph_\\omega$, UNKNOWN above. The theorem `known_results_summary` formalizes the universal negative below $\\aleph_\\omega$.",
       "startLine": 192,
-      "endLine": 212
+      "endLine": 213
     },
     {
       "id": "variants",
       "title": "Strengthenings and Variants",
       "summary": "Defines `erdos_623_uncountable`: must $Y$ have $|Y| > \\aleph_0$? Defines `erdos_623_weak`: does at least one free $f$ have an infinite independent set? Proves the weak version follows from the strong conjecture.",
       "startLine": 214,
-      "endLine": 233
+      "endLine": 268
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Batch enrichment pass fixing section coverage gaps.

**Entries enriched:**
- erdos-620 (12 gaps fixed)
- erdos-623 (11 gaps fixed)
- erdos-36 (6 gaps fixed)
- erdos-369 (6 gaps fixed)

All sections now tile their files with no gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)