### PR TITLE
Enrich 8 entries: fix section gaps (batch 5)

### DIFF
--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -59,7 +59,8 @@
         "relationship": "Additional ballot problem variants"
       }
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "The Ballot Problem was posed by Joseph Bertrand in 1887 in the *Comptes Rendus* of the French Academy of Sciences, and solved by Désiré André in the very next issue of the same journal. It asks: in an election where candidate A receives $p$ votes and candidate B receives $q$ votes (with $p > q$), what is the probability that A is ahead of B throughout the entire counting process?\n\nThe answer is the elegant formula $(p-q)/(p+q)$. André's proof introduced the **reflection principle** — a bijective argument that pairs each 'bad' vote sequence (where A falls behind or ties) with a reflected path. The reflection principle has since become one of the most powerful tools in enumerative combinatorics, applied to Catalan numbers, random walks, queueing theory, and financial mathematics.\n\nThe problem has a rich genealogy: it was studied independently by Émile Barbier (1887), rediscovered by Aeppli (1924), and generalized by Takács (1962) and others. William Feller popularized it in his classic textbook *An Introduction to Probability Theory and Its Applications* (1968), where it appears as a gateway to the theory of random walks and fluctuation theory.\n\nThe result appears as Theorem #30 in Wiedijk's Formalizing 100 Theorems list, and was formalized in Mathlib by Sébastien Gouëzel.",
@@ -85,7 +86,7 @@
       "id": "setting",
       "title": "The Setting",
       "startLine": 93,
-      "endLine": 111,
+      "endLine": 112,
       "summary": "Modeling vote counting as sequences of +1 and -1.",
       "mathContext": "Vote sequences: elements of $\\{+1, -1\\}^{p+q}$ with exactly $p$ values $+1$ and $q$ values $-1$. `countedSequence p q` is the Finset of all such lists, with $|\\text{countedSequence}\\, p\\, q| = \\binom{p+q}{p}$. `staysPositive` holds when $\\forall i \\geq 1,\\, \\sum_{j=1}^{i} v_j > 0$."
     },
@@ -93,7 +94,7 @@
       "id": "key-properties",
       "title": "Key Properties",
       "startLine": 113,
-      "endLine": 130,
+      "endLine": 131,
       "summary": "Properties of counted sequences and their cardinalities.",
       "mathContext": "Cardinality: $|\\text{countedSequence}\\, p\\, q| = \\binom{p+q}{p}$. The good paths (where A leads throughout) number $\\binom{p+q}{p} - \\binom{p+q}{q}$. This uses the algebraic identity $\\frac{\\binom{p+q}{p} - \\binom{p+q}{q}}{\\binom{p+q}{p}} = \\frac{p-q}{p+q}$ for $p > q$."
     },
@@ -101,7 +102,7 @@
       "id": "main-theorem",
       "title": "The Ballot Theorem",
       "startLine": 132,
-      "endLine": 152,
+      "endLine": 153,
       "summary": "The main result: probability of A leading throughout equals (p-q)/(p+q).",
       "mathContext": "$\\text{condCount}(\\text{countedSequence}\\, p\\, q,\\, \\text{staysPositive}) = \\frac{p-q}{p+q}$ for $p > q$. The conditional probability is computed as the ratio $\\frac{|\\{s \\in \\text{countedSequence}\\, p\\, q \\mid \\text{staysPositive}(s)\\}|}{|\\text{countedSequence}\\, p\\, q|}$."
     },
@@ -117,7 +118,7 @@
       "id": "reflection-principle",
       "title": "The Reflection Principle",
       "startLine": 216,
-      "endLine": 249,
+      "endLine": 255,
       "summary": "Detailed explanation of the bijective proof technique.",
       "mathContext": "André's reflection bijection: for any 'bad' path (first touching $y=0$ at step $k$), reflect all votes before step $k$ ($+1 \\leftrightarrow -1$). This maps bad paths ending at $(p+q, p-q)$ bijectively to ALL paths ending at $(p+q, q-p)$. Count: $\\binom{p+q}{q}$ bad paths, so good paths $= \\binom{p+q}{p} - \\binom{p+q}{q}$."
     }

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -40,7 +40,8 @@
     "dateAdded": "2025-12-29",
     "axiomCount": 6,
     "assumptions": "6 axiom declarations: ch_implies_no_intermediate (CH implies no cardinal between aleph_0 and continuum), no_intermediate_implies_ch (no intermediate cardinal implies CH), L_exists (constructible universe L exists as ZFC model), L_satisfies_CH (L satisfies CH), forcing_extension_exists (Cohen forcing extension exists), forcing_violates_CH (forcing model violates CH)",
-    "lineCount": 366
+    "lineCount": 366,
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Cantor first posed the Continuum Hypothesis in his 1878 paper *Ein Beitrag zur Mannigfaltigkeitslehre*, conjecturing that $2^{\\aleph_0} = \\aleph_1$ after proving the reals are uncountable (1873). Hilbert placed it as Problem #1 in his famous 1900 Paris address, calling it the most important open problem in mathematics. After decades of failed attempts, Gödel resolved half the question in 1940 by constructing the *Constructible Universe* L—a minimal model of ZFC in which CH holds—proving Con(ZFC) → Con(ZFC+CH). Cohen revolutionised logic in 1963 by inventing *forcing*, a general method for extending set-theoretic models, and used it to produce models where CH fails (Con(ZFC) → Con(ZFC+¬CH)). Cohen received the Fields Medal in 1966, the only one awarded for work in logic. Together, Gödel and Cohen showed CH is *independent* of ZFC—Hilbert's first problem was answered, but not by deciding its truth.",
@@ -63,7 +64,7 @@
       "id": "module-header",
       "title": "Module Header and Setup",
       "startLine": 1,
-      "endLine": 48,
+      "endLine": 49,
       "summary": "Lean 4 imports, ZFC axiom framework, and problem description for the independence of CH."
     },
     {
@@ -91,7 +92,7 @@
       "id": "independence",
       "title": "The Independence Theorem",
       "startLine": 225,
-      "endLine": 280,
+      "endLine": 366,
       "summary": "Main result: CH is independent of ZFC."
     }
   ],

--- a/src/data/proofs/erdos-151/meta.json
+++ b/src/data/proofs/erdos-151/meta.json
@@ -59,7 +59,8 @@
         "relationship": "Both involve graph coloring/independence structure; the four-color theorem guarantees large independent sets in planar graphs"
       }
     ],
-    "lineCount": 194
+    "lineCount": 194,
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Paul Erdős and Tibor Gallai proposed this conjecture connecting two fundamental graph-theoretic quantities: the clique transversal number $\\tau(G)$ and the triangle-free independence function $H(n)$. The function $H(n)$, defined as the largest $k$ such that every triangle-free graph on $n$ vertices has an independent set of size $\\ge k$, is intimately tied to the Ramsey number $R(3,t)$. Kim (1995) proved $R(3,t) = \\Theta(t^2/\\log t)$, implying $H(n) = \\Theta(\\sqrt{n \\log n})$. The easy bound $\\tau(G) \\le n - \\sqrt{n}$ follows from the Ramsey-theoretic lower bound on independence numbers: every graph on $n$ vertices has $\\alpha(G) \\ge \\sqrt{n}$ (since $R(\\omega+1, t) \\ge t$ for some $t \\sim \\sqrt{n}$), and the complement of any independent set is a clique transversal. Erdős famously described this conjecture as 'perhaps completely wrongheaded,' expressing genuine uncertainty about its truth — unusual for Erdős, who typically had strong intuitions. Even the restricted case for $K_4$-free graphs remains open, suggesting the problem is fundamentally hard.",
@@ -91,14 +92,14 @@
       "id": "graph-properties",
       "title": "Graph Properties",
       "startLine": 26,
-      "endLine": 40,
+      "endLine": 41,
       "summary": "Axiomatised cliques, maximal cliques, independence, and triangle-freeness."
     },
     {
       "id": "clique-transversal",
       "title": "Clique Transversal Number",
       "startLine": 42,
-      "endLine": 53,
+      "endLine": 54,
       "summary": "Definition of clique transversal and axiomatisation of τ(G)."
     },
     {
@@ -112,7 +113,7 @@
       "id": "main-conjecture",
       "title": "Main Conjecture",
       "startLine": 78,
-      "endLine": 88,
+      "endLine": 194,
       "summary": "Erdős–Gallai: τ(G) ≤ n − H(n) for all n-vertex graphs."
     }
   ],

--- a/src/data/proofs/erdos-187/meta.json
+++ b/src/data/proofs/erdos-187/meta.json
@@ -23,7 +23,8 @@
     ],
     "axiomCount": 7,
     "assumptions": "7 axiom declarations: maxMonoAPLength (max monochromatic AP length function), maxMonoAPLength_pos (maxMonoAPLength >= 1 for positive d), optAPBound (optimal AP bound function f(d)), vanDerWaerden_implies_growth (f(d) tends to infinity), beck_upper_bound (f(d) <= C*log_2(d) for large d), erdos_sqrt2_construction (sqrt(2)-coloring limits AP length to O(d)), erdos_187_optimal_bound (f(d) = Theta(log d) conjecture)",
-    "lineCount": 78
+    "lineCount": 78,
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "The problem of finding long monochromatic arithmetic progressions (APs) in 2-colorings of the integers has its roots in van der Waerden's 1927 theorem, which guarantees that any finite coloring of ℤ contains arbitrarily long monochromatic APs. Van der Waerden's original proof was non-constructive and gave tower-type bounds; Shelah (1988) later gave a primitive-recursive proof, but the quantitative bounds remain astronomical. Cohen and Erdős sharpened the question by fixing the common difference d: what is f(d), the maximum AP length that every 2-coloring must contain with difference d for infinitely many d? Erdős noted that the irrational rotation coloring χ(n) = ⌊√2 · n⌋ mod 2 limits monochromatic AP lengths, illustrating that Diophantine approximation governs the extremal colorings. The landmark result of Beck (1980) used discrepancy-theoretic methods to show f(d) ≤ (1+o(1))log₂ d — a striking logarithmic upper bound from probabilistic combinatorics. As of 2025, no lower bound beyond f(d) → ∞ (from van der Waerden) is known, making the gap between O(log d) and ω(1) the central open difficulty.",
@@ -53,28 +54,28 @@
       "id": "definitions",
       "title": "Part I: Definitions",
       "startLine": 22,
-      "endLine": 43,
+      "endLine": 44,
       "summary": "TwoColoring = ℕ → Fin 2. IsMonoAP χ a d k: {a, a+d, ..., a+(k-1)d} is monochromatic under χ. maxMonoAPLength χ d: longest monochromatic AP with difference d. optAPBound d = f(d): infimum over all 2-colorings."
     },
     {
       "id": "van-der-waerden",
       "title": "Part II: Van der Waerden's Theorem",
       "startLine": 45,
-      "endLine": 51,
+      "endLine": 52,
       "summary": "Axiom: f(d) → ∞. Van der Waerden's theorem guarantees that every 2-coloring contains monochromatic APs of any length; as a consequence, f(d) is unbounded."
     },
     {
       "id": "beck-bound",
       "title": "Part III: Beck's Upper Bound",
       "startLine": 53,
-      "endLine": 59,
+      "endLine": 60,
       "summary": "Axiom: ∃ C, D₀, ∀ d ≥ D₀, f(d) ≤ C · (log₂ d + 1). Beck (1980) constructs a low-discrepancy 2-coloring limiting monochromatic AP length to O(log d)."
     },
     {
       "id": "sqrt2-coloring",
       "title": "Part IV: Erdős's √2-Coloring",
       "startLine": 61,
-      "endLine": 66,
+      "endLine": 67,
       "summary": "Axiom: ∃ a Diophantine coloring achieving f(d) ≪ d. The coloring χ(n) = ⌊√2·n⌋ mod 2 uses equidistribution of {√2·nd} to limit monochromatic AP lengths."
     },
     {

--- a/src/data/proofs/erdos-294/meta.json
+++ b/src/data/proofs/erdos-294/meta.json
@@ -115,7 +115,7 @@
       "id": "sec-greedy",
       "title": "Greedy Algorithm",
       "startLine": 239,
-      "endLine": 265,
+      "endLine": 330,
       "summary": "Connection to greedy Egyptian fraction algorithms"
     }
   ],

--- a/src/data/proofs/erdos-403/meta.json
+++ b/src/data/proofs/erdos-403/meta.json
@@ -81,7 +81,7 @@
       "title": "Basic Definitions",
       "summary": "Defines `sumFactorials(S) = Σₐ∈S a!` as the core function over `Finset ℕ`, along with `isStrictlyIncreasing`, `IsPowerOfTwoFactorialSum(m)` (∃S≠∅: sumFactorials(S) = 2^m), and `IsPrimePowerFactorialSum(p,m)` for the generalized predicate. Using `Finset ℕ` automatically enforces distinctness.",
       "startLine": 34,
-      "endLine": 66,
+      "endLine": 67,
       "mathContext": "$\\mathrm{sumFactorials}(S) = \\sum_{a \\in S} a!$ where $S$ is a `Finset ℕ` (enforcing distinctness). $\\mathrm{IsPowerOfTwoFactorialSum}(m) \\iff \\exists S \\neq \\emptyset,\\; \\sum_{a \\in S} a! = 2^m$."
     },
     {
@@ -89,7 +89,7 @@
       "title": "Known Solutions",
       "summary": "Computationally verifies three key facts: `solution_m1` (2^1 = 2!), `solution_m7` (2^7 = 2! + 3! + 5! = 128, the maximum), and `maximal_solution_elements` (2! = 2, 3! = 6, 5! = 120, 2+6+120 = 128). Uses `native_decide` for efficient kernel evaluation.",
       "startLine": 68,
-      "endLine": 97,
+      "endLine": 98,
       "mathContext": "$2^1 = 2!$, $2^2 = 0! + 1! + 2!$, $2^3 = 0! + 1! + 3!$, $2^7 = 2! + 3! + 5! = 2 + 6 + 120 = 128$ (maximal). Verified by `native_decide`."
     },
     {
@@ -97,7 +97,7 @@
       "title": "Main Finiteness Result",
       "summary": "Defines `solutionExponents = {1,2,3,4,5,6,7}` as the candidate set. States `lin_theorem_finiteness` (axiom: IsPowerOfTwoFactorialSum(m) → m ≤ 7) and derives `solution_set_finite` by `Set.Finite.subset (Set.finite_le_nat 7)` — the set of solutions is contained in the finite set {n ≤ 7}.",
       "startLine": 99,
-      "endLine": 128,
+      "endLine": 129,
       "mathContext": "Lin's theorem: $\\mathrm{IsPowerOfTwoFactorialSum}(m) \\implies m \\leq 7$. Finiteness: $\\{m : \\mathrm{IsPowerOfTwoFactorialSum}(m)\\} \\subseteq \\{0, \\ldots, 7\\}$, which is finite."
     },
     {
@@ -105,7 +105,7 @@
       "title": "2-adic Bounds",
       "summary": "Defines `twoAdicValuation(n)` via `Nat.factorization 2`. States `lin_two_adic_bound` (axiom: 2 ∈ S → v₂(sumFactorials S) ≤ 254) and derives `power_of_two_bound` (if 2^m = sumFactorials S with 2 ∈ S then m ≤ 254). This is the technical engine behind finiteness, based on mod-2^k analysis of factorial sums.",
       "startLine": 130,
-      "endLine": 160,
+      "endLine": 161,
       "mathContext": "Legendre's formula: $v_2(n!) = \\sum_{k=1}^{\\infty} \\lfloor n/2^k \\rfloor = n - s_2(n)$. Lin's bound: $2 \\in S \\implies v_2(\\sum_{a \\in S} a!) \\leq 254$, so $2^m \\mid \\sum a! \\implies m \\leq 254$."
     },
     {
@@ -113,7 +113,7 @@
       "title": "Powers of 3: Complete Classification",
       "summary": "Defines `threeExponentSolutions = {0,1,2,3,6}` and verifies each: 3^0=1!, 3^1=1!+2!, 3^2=1!+2!+3!, 3^3=1!+2!+4!, 3^6=1!+2!+3!+6!. States `lin_theorem_powers_of_three` (axiom: 3^m = Σa! ↔ m ∈ {0,1,2,3,6}) — a complete biconditional, not just a bound.",
       "startLine": 162,
-      "endLine": 209,
+      "endLine": 210,
       "mathContext": "$3^m = \\sum a_i!$ has exactly 5 solutions: $3^0 = 1!$, $3^1 = 1! + 2!$, $3^2 = 1! + 2! + 3!$, $3^3 = 1! + 2! + 4!$, $3^6 = 1! + 2! + 3! + 6!$. Note the gap at $m = 4, 5$."
     },
     {
@@ -121,7 +121,7 @@
       "title": "Why Finiteness Holds: Growth Analysis",
       "summary": "Axiomatizes three bounds: `factorial_dominates_exponential` (∀c ∃N ∀a≥N: a! > 2^(a+c)), `few_terms_in_solution` (max(S)≥8 → |S|≤8, since 8!=40320>2^15), and `max_element_bound` (max(S)≤13, since 14! ≈ 87 billion exhausts any power-of-2 range). Together these constrain the search space to finitely many candidates.",
       "startLine": 211,
-      "endLine": 244,
+      "endLine": 245,
       "mathContext": "$n! > 2^{n+c}$ for large $n$ (Stirling). $\\max(S) \\geq 8 \\implies |S| \\leq 8$ since $8! = 40320 > 2^{15}$. $\\max(S) \\leq 13$ since $14! \\approx 8.7 \\times 10^{10}$ exceeds any power-of-2 range."
     },
     {
@@ -129,7 +129,7 @@
       "title": "Connection to Problem 404: The f(a,p) Function",
       "summary": "Defines `maxPrimePowerDiv(a,p) = sSup{k | ∃S∋a, p^k | sumFactorials(S)}` as a `noncomputable` function using `sSup`. States `lin_f22_bound` (f(2,2) ≤ 254) and `problem_404_generalizes_403` (IsPowerOfTwoFactorialSum(m) → m ≤ f(2,2)), embedding Problem 403 as the special case a=2, p=2 of Erdős Problem 404.",
       "startLine": 246,
-      "endLine": 276,
+      "endLine": 277,
       "mathContext": "$f(a, p) = \\sup\\{k : \\exists S \\ni a,\\; p^k \\mid \\sum_{x \\in S} x!\\}$. Problem 403 is the instance $f(2, 2) \\leq 254$. Problem 404 asks for the general $f(a, p)$."
     },
     {
@@ -137,7 +137,7 @@
       "title": "Computational Verification: Explicit Witnesses",
       "summary": "Constructs IsPowerOfTwoFactorialSum witnesses for m=1,2,3,7 using explicit Finset witnesses and `native_decide`. Demonstrates that not all m≤7 need solutions (Lin's bound is an upper bound, not a characterization). The pattern ⟨S, nonempty_proof, sum_proof⟩ illustrates Lean's constructive existentials.",
       "startLine": 278,
-      "endLine": 309,
+      "endLine": 310,
       "mathContext": "Constructive witnesses: $\\langle \\{2\\}, \\ldots, 2! = 2 = 2^1 \\rangle$, $\\langle \\{2,3,5\\}, \\ldots, 128 = 2^7 \\rangle$. Each uses `native_decide` for the arithmetic equality."
     },
     {

--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -22,12 +22,13 @@
     "erdosProblemStatus": "open",
     "axiomCount": 5,
     "assumptions": "5 axiom declarations: lcmInterval_example1 (lcm(5,6,7)=lcm(14,15)), lcmInterval_example2 (lcm(4,5,6,7)=lcm(20,21)), thue_siegel_finiteness (finitely many solutions per k), lcmInterval_dvd_product (LCM divides product), lcmInterval_pos (LCM is positive)",
-    "lineCount": 97
+    "lineCount": 97,
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Erdős posed this problem about the distinctness of lcm of consecutive integer blocks. The Thue-Siegel theorem implies finiteness for fixed k. Erdős knew only two cross-parameter examples: lcm(5,6,7) = lcm(14,15) = 210 and lcm(4,5,6,7) = lcm(20,21) = 420. A stronger conjecture asserts that consecutive products can rarely share the same prime factor set. The LCM of k consecutive integers equals k! times a binomial coefficient, and the prime factorization structure is deeply connected to Sylvester-Schur theory; the analogous problem for products (rather than LCMs) of consecutive integers relates to Catalan-type Diophantine equations and was studied by Stormer and others in the early 20th century.",
     "problemStatement": "Let M(n,k) = lcm(n+1,...,n+k). Is M(m,k) ≠ M(n,k) for all m ≥ n+k?",
-    "text": "Is M(n,k) = lcm(n+1,...,n+k) always distinct for m \u2265 n+k? The Thue\u2013Siegel theorem gives finiteness for fixed k. Only two cross-parameter examples are known.",
+    "text": "Is M(n,k) = lcm(n+1,...,n+k) always distinct for m ≥ n+k? The Thue–Siegel theorem gives finiteness for fixed k. Only two cross-parameter examples are known.",
     "proofStrategy": "We define lcmInterval using Finset.fold with Nat.lcm, consecutiveProduct using Finset.prod, and samePrimeFactors via Nat.primeFactors. The main conjecture and its stronger variant are stated as Prop. Thue–Siegel finiteness is an axiom.",
     "keyInsights": [
       "The Thue–Siegel theorem gives finiteness for fixed k but not the full conjecture",
@@ -46,7 +47,7 @@
       "id": "lcm",
       "title": "LCM of Consecutive Integers",
       "startLine": 30,
-      "endLine": 35,
+      "endLine": 36,
       "summary": "Defines lcmInterval n k as the fold of Nat.lcm over range k.",
       "mathContext": "$M(n, k) = \\text{lcm}(n+1, n+2, \\ldots, n+k) = \\text{Finset.fold}\\, \\text{Nat.lcm}\\, 1\\, (\\text{range}\\, k)\\, (\\lambda i, n + i + 1)$."
     },
@@ -54,7 +55,7 @@
       "id": "conjecture",
       "title": "Main Conjecture",
       "startLine": 37,
-      "endLine": 41,
+      "endLine": 42,
       "summary": "ErdosProblem677: M(m,k) ≠ M(n,k) for all m ≥ n+k.",
       "mathContext": "$\\forall m, n, k > 0: m \\ge n + k \\implies M(m, k) \\neq M(n, k)$. The LCM function is injective on well-separated intervals of the same length."
     },
@@ -62,7 +63,7 @@
       "id": "examples",
       "title": "Known Examples",
       "startLine": 43,
-      "endLine": 48,
+      "endLine": 49,
       "summary": "The two known cross-parameter equalities: M(4,3) = M(13,2) and M(3,4) = M(19,2).",
       "mathContext": "$\\text{lcm}(5,6,7) = \\text{lcm}(14,15) = 210$ and $\\text{lcm}(4,5,6,7) = \\text{lcm}(20,21) = 420$. Cross-parameter equalities ($k$ differs) that do not contradict the conjecture."
     },
@@ -70,7 +71,7 @@
       "id": "strong",
       "title": "Stronger Conjecture and Thue–Siegel",
       "startLine": 50,
-      "endLine": 72,
+      "endLine": 73,
       "summary": "Stronger prime-factor conjecture and Thue–Siegel finiteness theorem.",
       "mathContext": "$\\forall k > 2: |\\{(m,n) : m \\ge n + k,\\, \\text{rad}(\\prod_{i=1}^k (n+i)) = \\text{rad}(\\prod_{i=1}^k (m+i))\\}| < \\infty$. Stronger than the LCM conjecture; same prime factors implies same LCM but not conversely. Thue-Siegel: for fixed $k$, only finitely many pairs with $M(m,k) = M(n,k)$."
     },


### PR DESCRIPTION
Batch enrichment pass for quality 90-95 tier entries.

**8 entries fixed:** section line range gaps and/or missing mathlib_version

🤖 Generated with [Claude Code](https://claude.com/claude-code)