### PR TITLE
Enrich 18 entries: fix section gaps (batch 6)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -67,7 +67,8 @@
     ],
     "axiomCount": 0,
     "lineCount": 130,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "**The Discrete IVT and the Cycle Lemma**\n\nThe Dvoretzky-Motzkin Cycle Lemma (1947) states: given a sequence with $a$ copies of $+1$ and $b$ copies of $-k$ satisfying $a > kb$, exactly $a - kb$ of the $a + b$ cyclic rotations have all partial sums positive.\n\nThe proof has two parts:\n- **Upper bound** ($|\\text{goodRotations}| \\leq a-kb$): Via an injection from good rotations to distinct prefix sum levels — proved in BallotProblemOQ01.lean via `goodRotations_card_le`.\n- **Lower bound** ($|\\text{goodRotations}| \\geq a-kb$): Requires showing that for each level $v$ in $[\\mu, \\mu + S)$ (where $\\mu$ is the minimum prefix sum and $S$ is the total sum), there exists a good rotation achieving level $v$. This uses:\n  1. A **discrete IVT** to show every level is achieved by some prefix\n  2. The **rightmost position** at each level is a good rotation\n\nThe discrete IVT formalized here (`ballot_discrete_ivt`) captures the essential analytic content: if a {+1, -k}-sequence achieves prefix sum $v$ at some position, and the final sum exceeds $v$, then the rightmost position with prefix sum $\\leq v$ actually has prefix sum exactly $v$. This is because the rightmost such position must be followed by $+1$ (not $-k$, which would give prefix sum $\\leq v-k < v$).",
@@ -94,7 +95,7 @@
       "id": "imports-header",
       "title": "Imports and Problem Overview",
       "startLine": 1,
-      "endLine": 37,
+      "endLine": 38,
       "summary": "Header documenting the open question and proof strategy. Imports: `Mathlib.Tactic`, `Mathlib.Data.List.Basic`, `Mathlib.Data.Finset.Basic`.",
       "mathContext": "The Dvoretzky-Motzkin Cycle Lemma (1947): for a sequence with $a$ copies of $+1$ and $b$ copies of $-k$ satisfying $a > kb$, exactly $a - kb$ of the $a+b$ cyclic rotations have all partial sums positive. The prefix sum $P(i) = \\sum_{j=0}^{i-1} l_j$ tracks cumulative value at each position."
     },
@@ -102,7 +103,7 @@
       "id": "ballot-discrete-ivt",
       "title": "Discrete IVT for Ballot Sequences",
       "startLine": 39,
-      "endLine": 89,
+      "endLine": 90,
       "summary": "Theorem `ballot_discrete_ivt`: For a {+1,-k}-list, if some position achieves prefix sum v and the final sum exceeds v, then a strict prefix achieves prefix sum exactly v. Proved via `Finset.max'` of positions with prefix sum ≤ v; the maximal such position must be followed by +1 (not -k), forcing its prefix sum to equal exactly v.",
       "mathContext": "For $l \\in \\{+1, -k\\}^*$, define $S = \\{i \\in [0, |l|] : P(i) \\leq v\\}$. Let $j = \\max S$. Then $j < |l|$ (since $P(|l|) > v$), $P(j+1) > v$ (by maximality), and $l[j] = 1$ (else $P(j+1) = P(j)-k \\leq v-k < v$). So $P(j) = P(j+1)-1 \\geq v$ and $P(j) \\leq v$ give $P(j) = v$."
     },
@@ -125,7 +126,7 @@
       "id": "placeholder-theorems",
       "title": "Placeholder Theorems",
       "startLine": 108,
-      "endLine": 109,
+      "endLine": 130,
       "summary": "cycle_lemma_lower_bound_via_ivt: placeholder theorem (1+1=2) documenting how ballot_discrete_ivt iteratively produces good rotations at each prefix sum level, yielding |goodRotations| ≥ a - kb. Combined with the upper bound from OQ-01, this gives the full cycle lemma equality."
     }
   ],

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -100,7 +100,7 @@
       "title": "Imports and Namespace",
       "summary": "Imports `InnerProductSpace.Basic`, `InnerProductSpace.PiL2` (for `EuclideanSpace`), `BigOperators.Ring.Finset` (for $\\sum$), and general tactics.",
       "startLine": 1,
-      "endLine": 49,
+      "endLine": 50,
       "mathContext": "Provides `InnerProductSpace ℝ F` (real inner product spaces), `EuclideanSpace ℝ (Fin n)` ($\\mathbb{R}^n$ with standard inner product), and `∑` notation over finite sets."
     },
     {
@@ -108,7 +108,7 @@
       "title": "Inner Product Form",
       "summary": "States and proves $|\\langle u,v\\rangle_{\\mathbb{R}}| \\leq \\|u\\|\\|v\\|$ via `abs_real_inner_le_norm`. Also derives the squared form $\\langle u,v\\rangle^2 \\leq \\langle u,u\\rangle\\langle v,v\\rangle$.",
       "startLine": 51,
-      "endLine": 79,
+      "endLine": 80,
       "mathContext": "$|\\langle u,v \\rangle| \\leq \\|u\\| \\cdot \\|v\\|$ and equivalently $\\langle u,v \\rangle^2 \\leq \\langle u,u \\rangle \\langle v,v \\rangle$ since $\\|u\\|^2 = \\langle u,u \\rangle$."
     },
     {
@@ -116,7 +116,7 @@
       "title": "Two-Variable Algebraic Form",
       "summary": "Elementary proof of $(a_1b_1+a_2b_2)^2 \\leq (a_1^2+a_2^2)(b_1^2+b_2^2)$ using the Lagrange identity $(a_1b_2-a_2b_1)^2 \\geq 0$, plus the equality characterization $a_1b_2 = a_2b_1$.",
       "startLine": 81,
-      "endLine": 114,
+      "endLine": 115,
       "mathContext": "Lagrange identity: $(a_1^2+a_2^2)(b_1^2+b_2^2) - (a_1b_1+a_2b_2)^2 = (a_1b_2-a_2b_1)^2 \\geq 0$."
     },
     {
@@ -124,7 +124,7 @@
       "title": "Finite Sum Form",
       "summary": "Proves $(\\sum a_ib_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ by embedding into `EuclideanSpace $\\mathbb{R}$ (Fin $n$)` and the non-squared form via `Real.sqrt_le_sqrt`.",
       "startLine": 116,
-      "endLine": 157,
+      "endLine": 158,
       "mathContext": "$(\\sum_{i=1}^n a_ib_i)^2 \\leq (\\sum_{i=1}^n a_i^2)(\\sum_{i=1}^n b_i^2)$ — the classical Cauchy inequality for finite sums."
     },
     {
@@ -132,7 +132,7 @@
       "title": "Equality Characterization",
       "summary": "Proves $|\\langle u,v\\rangle| = \\|u\\|\\|v\\| \\iff \\exists c: u = cv$ for nonzero vectors, using `norm_inner_eq_norm_iff` and `inner_smul_left`.",
       "startLine": 159,
-      "endLine": 179,
+      "endLine": 180,
       "mathContext": "$|\\langle u,v\\rangle| = \\|u\\|\\|v\\| \\iff \\exists c \\in \\mathbb{R}: u = cv$ — equality iff vectors are collinear."
     },
     {
@@ -140,7 +140,7 @@
       "title": "Verified Examples",
       "summary": "Numerical verifications: strict inequality $(196 < 200)$ for non-proportional vectors, equality $(100 = 100)$ for proportional vectors $(1,2)$ and $(2,4)$, and $\\mathbb{R}^2$ specialization.",
       "startLine": 181,
-      "endLine": 196,
+      "endLine": 197,
       "mathContext": "Strict: $(1 \\cdot 2 + 3 \\cdot 4)^2 = 196 < 200 = (1^2+3^2)(2^2+4^2)$. Equality: $(1 \\cdot 2 + 2 \\cdot 4)^2 = 100 = (1^2+2^2)(2^2+4^2)$ because $(2,4) = 2(1,2)$."
     },
     {
@@ -148,7 +148,7 @@
       "title": "Application: Triangle Inequality",
       "summary": "Derives $\\|u+v\\|^2 \\leq (\\|u\\|+\\|v\\|)^2$ from Cauchy-Schwarz via `norm_add_sq_real` expansion and $\\langle u,v\\rangle \\leq |\\langle u,v\\rangle| \\leq \\|u\\|\\|v\\|$.",
       "startLine": 198,
-      "endLine": 212,
+      "endLine": 213,
       "mathContext": "$\\|u+v\\|^2 = \\|u\\|^2 + 2\\langle u,v\\rangle + \\|v\\|^2 \\leq \\|u\\|^2 + 2\\|u\\|\\|v\\| + \\|v\\|^2 = (\\|u\\|+\\|v\\|)^2$"
     },
     {

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
@@ -60,7 +60,8 @@
       "Trigonometry: arccos, arcsin, sin-ratio formula",
       "Projective and barycentric coordinates"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Ceva's theorem (1678) states that in a triangle ABC, cevians AD, BE, CF are concurrent iff (BD/DC)·(CE/EA)·(AF/FB) = 1. The spherical version replaces length ratios with sin-ratios: sin(BD)/sin(DC) · sin(CE)/sin(EA) · sin(AF)/sin(FB) = 1, where BD, DC etc. are arc lengths on the sphere.\n\nThis formalization answers the open question OQ-02-OQ-01: can the spherical Ceva theorem be stated using concrete unit vectors in a real inner product space? The answer is YES, via weight parameters. A point D on arc BC is defined as D = normalize(α·B + β·C), and the sin-ratio sin(BD)/sin(DC) equals β/α — a purely algebraic criterion independent of the specific positions of B and C (as long as they are distinct non-antipodal points).\n\nThis bridges two earlier formalizations: CevasTheoremSinRatio.lean (which proves the sin-ratio formula for one cevian) and CevasTheoremNonEuclidean.lean (which uses abstract arc lengths for the full spherical Ceva condition).",

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -76,56 +76,56 @@
       "title": "Imports and Documentation",
       "summary": "Imports `Mathlib.LinearAlgebra.Matrix.Adjugate` (providing `Matrix.cramer`, `mulVec_cramer`, `mul_adjugate`) and `Mathlib.Tactic` for proof automation. The module docstring explains the general identity $A \\cdot \\text{cramer}(A,b) = \\det(A) \\cdot b$ and the classical formula $x_i = \\det(A_i)/\\det(A)$.",
       "startLine": 1,
-      "endLine": 50
+      "endLine": 51
     },
     {
       "id": "setup",
       "title": "Namespace and Type Variables",
       "summary": "Opens the `CramersRule` namespace, declares universe-polymorphic variables: $n$ with `DecidableEq` and `Fintype` (enabling finite sums for the Leibniz determinant formula $\\det(A) = \\sum_{\\sigma \\in S_n} \\text{sgn}(\\sigma)\\prod_i A_{i,\\sigma(i)}$), and $R$ as a `CommRing` (providing $+$, $\\times$, $0$, $1$, $-$).",
       "startLine": 52,
-      "endLine": 57
+      "endLine": 58
     },
     {
       "id": "cramer-map",
       "title": "The Cramer Map",
       "summary": "Defines the component formula: $\\text{cramer}(A,b)_i = \\det(A.\\text{updateColumn}\\,i\\,b)$ via `Matrix.cramer_apply`.",
       "startLine": 59,
-      "endLine": 72
+      "endLine": 73
     },
     {
       "id": "main-identity",
       "title": "Main Identity (Wiedijk #97)",
       "summary": "States and proves $A \\cdot \\text{cramer}(A,b) = \\det(A) \\cdot b$ via `Matrix.mulVec_cramer`. Derives the solution formula when `Invertible A.det`.",
       "startLine": 74,
-      "endLine": 96
+      "endLine": 97
     },
     {
       "id": "adjugate",
       "title": "Connection to Adjugate Matrix",
       "summary": "Proves $\\text{cramer}(A,b) = \\text{adj}(A) \\cdot b$ and the fundamental identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$ via `Matrix.mul_adjugate`.",
       "startLine": 98,
-      "endLine": 111
+      "endLine": 112
     },
     {
       "id": "transpose",
       "title": "Transpose (Row-Based) Form",
       "summary": "Proves $\\text{cramer}(A^T,b)_i = \\det(A.\\text{updateRow}\\,i\\,b)$ via `cramer_transpose_apply`, connecting column operations on $A^T$ to row operations on $A$.",
       "startLine": 113,
-      "endLine": 120
+      "endLine": 121
     },
     {
       "id": "linearity",
       "title": "Linearity Properties",
       "summary": "Proves additivity ($\\text{cramer}(A,b+c) = \\text{cramer}(A,b) + \\text{cramer}(A,c)$), homogeneity ($\\text{cramer}(A,rb) = r \\cdot \\text{cramer}(A,b)$), and zero-preservation using Mathlib's `LinearMap` API.",
       "startLine": 122,
-      "endLine": 139
+      "endLine": 140
     },
     {
       "id": "example-2x2",
       "title": "2x2 System Example",
       "summary": "Specializes to `Matrix (Fin 2) (Fin 2) F` over a `Field`, recovering the classical formula $x = (ed-bf)/(ad-bc)$ via `inv_mul_cancel`.",
       "startLine": 141,
-      "endLine": 152
+      "endLine": 153
     },
     {
       "id": "verification",

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -86,7 +86,7 @@
       "id": "docstring",
       "title": "Module Documentation",
       "startLine": 1,
-      "endLine": 53,
+      "endLine": 54,
       "summary": "Imports `Combinatorics.Derangements.Finite` and `.Basic`. Docstring with $D_n = n! \\sum (-1)^k/k!$, approach, Mathlib dependencies, and historical note on Montmort (1708) and Euler (1751).",
       "mathContext": "The four Mathlib dependencies form a complete API: `numDerangements_sum` (closed-form), `numDerangements_add_two` (recurrence), `card_derangements_eq_numDerangements` (cardinality bridge), `mem_derangements_iff_fixedPoints_eq_empty` (definition). Together they encode the full algebraic and combinatorial theory of derangements."
     },
@@ -94,7 +94,7 @@
       "id": "core-definition",
       "title": "Core Definition",
       "startLine": 55,
-      "endLine": 75,
+      "endLine": 76,
       "summary": "Formal characterization: $f \\in \\text{derangements}(\\alpha) \\iff \\forall x, f(x) \\neq x$, equivalently `fixedPoints f = ∅`. Connects to `Equiv.Perm` and `Function.fixedPoints`.",
       "mathContext": "A derangement is a permutation $\\sigma \\in S_n$ with no fixed points: $\\sigma(i) \\neq i$ for all $i$. In Lean: `f ∈ derangements α ↔ ∀ x, f x ≠ x`."
     },
@@ -102,7 +102,7 @@
       "id": "recurrence",
       "title": "Base Cases and Recurrence",
       "startLine": 77,
-      "endLine": 99,
+      "endLine": 100,
       "summary": "$D_0 = 1$, $D_1 = 0$, and the recurrence $D_{n+2} = (n+1)(D_n + D_{n+1})$ via `numDerangements_add_two`. Combinatorial proof by case analysis on element 1's image.",
       "mathContext": "$D_0 = 1$ (empty permutation), $D_1 = 0$ (identity is the only permutation of 1 element). Recurrence: $D_{n+2} = (n+1)(D_{n+1} + D_n)$. Proof: element 1 maps to some $j \\neq 1$ ($n+1$ choices); if $j$ maps back to 1, the rest is a derangement of $n$ elements ($D_n$); otherwise, it's a derangement of $n+1$ elements with 1 replaced by $j$ ($D_{n+1}$)."
     },
@@ -118,7 +118,7 @@
       "id": "examples",
       "title": "Concrete Examples",
       "startLine": 128,
-      "endLine": 160,
+      "endLine": 161,
       "summary": "$D_2=1$ through $D_6=265$ verified by `native_decide`. Hat-check probability table showing $D_n/n!$ oscillating toward $1/e \\approx 0.3679$.",
       "mathContext": "$D_2 = 1$ (just $(12)$), $D_3 = 2$ (two 3-cycles), $D_4 = 9$ (nine derangements including three products of disjoint transpositions and six 4-cycles), $D_5 = 44$, $D_6 = 265$. The ratios $D_n/n! = 1/2, 1/3, 3/8, 11/30, 53/144$ alternate around $1/e$."
     },
@@ -126,7 +126,7 @@
       "id": "properties",
       "title": "Algebraic Properties",
       "startLine": 162,
-      "endLine": 201,
+      "endLine": 202,
       "summary": "Identity $\\notin$ derangements (for nonempty types). Derangements not closed under composition: $(0\\,1)^2 = \\text{id}$. Subfactorial $!n$ notation and value table.",
       "mathContext": "The derangement set $\\mathcal{D}_n \\subset S_n$ is conjugacy-invariant (conjugation preserves having no fixed points) but not a subgroup: $(01) \\in \\mathcal{D}_2$ but $(01)^2 = \\text{id} \\notin \\mathcal{D}_2$. The identity $\\text{id}$ has $n$ fixed points, so $\\text{id} \\notin \\mathcal{D}_n$ for $n \\geq 1$, meaning $\\mathcal{D}_n$ lacks the identity element required of any subgroup."
     },
@@ -134,7 +134,7 @@
       "id": "inclusion-exclusion",
       "title": "Inclusion-Exclusion Derivation",
       "startLine": 203,
-      "endLine": 220,
+      "endLine": 221,
       "summary": "Derivation of $D_n = n! \\sum (-1)^k/k!$ via inclusion-exclusion on fixed-point sets $A_i$, using $|A_{i_1} \\cap \\cdots \\cap A_{i_k}| = (n-k)!$.",
       "mathContext": "Let $A_i = \\{\\sigma \\in S_n : \\sigma(i) = i\\}$. Then $D_n = |S_n \\setminus \\bigcup A_i| = \\sum_{k=0}^n (-1)^k \\binom{n}{k}(n-k)! = n! \\sum_{k=0}^n \\frac{(-1)^k}{k!}$, using $|A_{i_1} \\cap \\cdots \\cap A_{i_k}| = (n-k)!$ (permutations fixing $k$ specified points)."
     },

--- a/src/data/proofs/erdos-1127/meta.json
+++ b/src/data/proofs/erdos-1127/meta.json
@@ -80,42 +80,42 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "startLine": 47,
-      "endLine": 82,
+      "endLine": 83,
       "summary": "Point type, distance function, distinct distances property, countable decomposition"
     },
     {
       "id": "main-question",
       "title": "The Main Question",
       "startLine": 84,
-      "endLine": 101,
+      "endLine": 102,
       "summary": "Formal statement of Erdős Problem #1127"
     },
     {
       "id": "continuum-hypothesis",
       "title": "Connection to the Continuum Hypothesis",
       "startLine": 103,
-      "endLine": 123,
+      "endLine": 124,
       "summary": "Definition of CH and ℚ-linear independence"
     },
     {
       "id": "erdos-kakutani",
       "title": "The Erdős-Kakutani Theorem",
       "startLine": 125,
-      "endLine": 166,
+      "endLine": 167,
       "summary": "CH ↔ countable union of ℚ-linearly independent sets"
     },
     {
       "id": "davies-theorem",
       "title": "Davies' Theorem (1972)",
       "startLine": 168,
-      "endLine": 176,
+      "endLine": 177,
       "summary": "Extension to n=2 under CH"
     },
     {
       "id": "kunen-theorem",
       "title": "Kunen's Theorem (1987)",
       "startLine": 178,
-      "endLine": 187,
+      "endLine": 188,
       "summary": "Full solution for all dimensions under CH"
     },
     {
@@ -129,7 +129,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 259,
-      "endLine": 307,
+      "endLine": 309,
       "summary": "Main theorem and key results combined"
     }
   ],

--- a/src/data/proofs/erdos-117/meta.json
+++ b/src/data/proofs/erdos-117/meta.json
@@ -91,21 +91,21 @@
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 23,
-      "endLine": 42,
+      "endLine": 43,
       "summary": "Defines three key objects: `HasNCommutingProperty G n` asserting that every `Finset G` of cardinality $> n$ contains distinct commuting elements $x \\neq y$ with $xy = yx$; `IsAbelianSubgroup G H` asserting pairwise commutativity $\\forall x, y \\in H, xy = yx$; and `abelianCoverNumber n` as the infimum $\\inf\\{k : \\forall G \\text{ with } n\\text{-commuting property}, G \\text{ covered by } k \\text{ Abelian subgroups}\\}$ via `sInf`."
     },
     {
       "id": "main-problem",
       "title": "Main Problem Statement",
       "startLine": 44,
-      "endLine": 51,
+      "endLine": 52,
       "summary": "Axiomatizes the main problem as `erdos_117_problem`: there exist real constants $c_2 > c_1 > 1$ such that for all $n > 0$, $c_1^n < h(n) < c_2^n$, establishing exponential growth of the Abelian covering number."
     },
     {
       "id": "known-results",
       "title": "Known Results: Pyber and Isaacs",
       "startLine": 53,
-      "endLine": 66,
+      "endLine": 67,
       "summary": "Axiomatizes two key results. `pyber_1987`: exponential bounds $c_1^n \\leq h(n) \\leq c_2^n$ for constants $c_2 > c_1 > 1$, using $\\leq$ rather than strict inequalities. `isaacs_lower`: the independent exponential lower bound $c^n \\leq h(n)$ for some $c > 1$, established before Pyber's comprehensive treatment."
     },
     {

--- a/src/data/proofs/erdos-319/meta.json
+++ b/src/data/proofs/erdos-319/meta.json
@@ -90,21 +90,21 @@
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 26,
-      "endLine": 46,
+      "endLine": 47,
       "summary": "Defines `IsSigning A δ` ($\\delta(n) \\in \\{\\pm 1\\}$ for $n \\in A$), `signedSum A δ = \\sum_{n \\in A} \\delta(n)/n \\in \\mathbb{Q}$, `IsIrreducibleZeroSum A δ` (signing + zero sum + no proper nonempty zero-sum subset), and `maxIrreducibleSize N` as the supremum of $|A|$ over the powerset of $\\{1,\\ldots,N\\}$ filtered by existence of an irreducible zero sum."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
       "startLine": 48,
-      "endLine": 55,
+      "endLine": 56,
       "summary": "Axiomatizes `erdos_319_conjecture`: for every $\\varepsilon > 0$, for large enough $N$, $c(N) \\geq (1 - 1/e - \\varepsilon)N$, using `Real.exp 1` for Euler's number $e$. This is the strongest known lower bound."
     },
     {
       "id": "known-results",
       "title": "Known Results",
       "startLine": 57,
-      "endLine": 77,
+      "endLine": 78,
       "summary": "Axiomatizes `adenwalla_lower_bound` ($c(N) \\geq (1 - 1/e + o(1))N$ via the $B \\cup \\{1\\}$ construction), `trivial_upper_bound` ($c(N) \\leq N$), and `croot_unit_fraction_theorem` (every positive integer $k \\leq N$ is a sum of distinct unit fractions $1/n$ with $n \\in \\{1,\\ldots,N\\}$ for large $N$)."
     },
     {

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -20,49 +20,50 @@
     "axiomCount": 4,
     "assumptions": "4 axiom declarations: bleicher_erdos_lower (R(N) >= N/log N), bleicher_erdos_upper (R(N) <= C*(N/log N)*log log N), main_term_n_over_log_n (R(N) = Theta(N/log N)), erdos_321_asymptotics (precise asymptotic form exists)",
     "badge": "axiom",
-    "proofRepoPath": "Proofs/Erdos321Problem.lean"
+    "proofRepoPath": "Proofs/Erdos321Problem.lean",
+    "mathlib_version": "4.26.0"
   },
   "sections": [
     {
       "id": "header-imports",
       "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 22,
+      "endLine": 23,
       "summary": "Module docstring stating the Bleicher–Erdős bounds with iterated logarithm notation. Imports Mathlib for $\\mathbb{N}$, $\\mathbb{Q}$ (exact reciprocal sums), $\\mathbb{R}$ (asymptotics with $\\log N$), and tactics."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 24,
-      "endLine": 42,
+      "endLine": 43,
       "summary": "Three foundational definitions: **unitFractions** $\\{1/n : n \\in [N]\\}$, **HasDistinctReciprocalSums** requiring all $2^{|A|}$ subset sums over $\\mathbb{Q}$ to be distinct, and **maxDistinctReciprocal** $R(N) = \\max|A|$ over valid subsets of $[N]$."
     },
     {
       "id": "main-question",
       "title": "The Main Asymptotic Question",
       "startLine": 44,
-      "endLine": 50,
+      "endLine": 51,
       "summary": "States the problem: determine $R(N)$ asymptotically. Axiomatizes existence of a function $f$ with $R(N) = f(N)$ for $N \\geq 2$. The precise form of $f$ — whether $R(N) \\sim c \\cdot N/\\log N$ or involves iterated log corrections — is the open question."
     },
     {
       "id": "lower-bound",
       "title": "Bleicher–Erdős Lower Bound (1975)",
       "startLine": 52,
-      "endLine": 59,
+      "endLine": 60,
       "summary": "Lower bound: $R(N) \\geq (N/\\log N) \\cdot \\prod_{i=3}^k \\log_i N$ via a constructive argument using integers with controlled prime factorizations. Simplified in Lean to $R(N) \\geq N/\\log N$."
     },
     {
       "id": "upper-bound",
       "title": "Bleicher–Erdős Upper Bound (1976)",
       "startLine": 61,
-      "endLine": 66,
+      "endLine": 67,
       "summary": "Upper bound: $R(N) \\leq (1/\\log 2) \\cdot \\log_r N \\cdot (N/\\log N) \\cdot \\prod_{i=3}^r \\log_i N$, via a counting argument bounding distinct sums by $2^{|A|} \\leq \\text{lcm}(1,\\ldots,N)$. Simplified to $R(N) \\leq C \\cdot (N/\\log N) \\cdot \\log\\log N$."
     },
     {
       "id": "main-term",
       "title": "Main Term Summary",
       "startLine": 68,
-      "endLine": 74,
+      "endLine": 75,
       "summary": "Combined statement: $c_1 \\cdot N/\\log N \\leq R(N) \\leq c_2 \\cdot (N/\\log N) \\cdot \\log\\log N$. The gap is essentially one iterated logarithm factor — the entire content of the open problem."
     },
     {

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -23,7 +23,8 @@
     "erdosProblemStatus": "open",
     "axiomCount": 8,
     "assumptions": "8 axiom declarations: greedy_sidon_values (first 11 Mian-Chowla values), greedy_sidon_strict_mono (strict monotonicity), greedy_sidon_is_sidon (Sidon invariant each stage), lower_bound_cube_root (N^{1/3} lower bound), sidon_upper_bound (Erdos-Turan sqrt upper bound), erdos_340_conjecture (near-optimal growth conjecture), erdos_340_diff_set_question (difference set density), random_sidon_context (random Sidon benchmark)",
-    "lineCount": 104
+    "lineCount": 104,
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "The Mian-Chowla sequence was introduced independently by Abdul Majid Mian and S.D. Chowla in 1944 as the natural greedy construction for Sidon sets. Erdős and Graham asked about its growth rate in their 1980 monograph, noting the striking gap between the known $\\Omega(N^{1/3})$ lower bound and the theoretical $O(\\sqrt{N})$ upper bound for any Sidon set. The problem is a fundamental test case for whether greedy algorithms in additive combinatorics can achieve near-optimal density. In many combinatorial settings (graph colouring, independent sets), greedy constructions are provably suboptimal by polynomial factors. But numerical evidence for the Mian-Chowla sequence is remarkably encouraging: computations up to $N \\approx 10^{15}$ show $|A \\cap [1,N]| \\approx N^{0.497...}$, extremely close to $\\sqrt{N}$. The $N^{1/3}$ lower bound comes from a simple forbidden-sum counting argument: each of the $O(k^2)$ existing pairwise sums blocks at most one future candidate per step, so the $k$-th element is at most $O(k^3)$. Improving this to $N^{1/3+\\delta}$ for any $\\delta > 0$ would be significant. The separate question about the density of the difference set $A - A$ connects to the theory of return times and recurrence in additive number theory.",
@@ -64,7 +65,7 @@
       "id": "initial-values",
       "title": "Known Initial Values",
       "startLine": 43,
-      "endLine": 59,
+      "endLine": 60,
       "summary": "First 11 values of OEIS A005282, strict monotonicity, and Sidon invariant at every stage.",
       "mathContext": "OEIS A005282: $\\{0, 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97, \\ldots\\}$. The greedy algorithm adds the smallest integer preserving the Sidon property. Axioms assert strict monotonicity ($a_n < a_{n+1}$) and that each prefix is a Sidon set."
     },
@@ -72,7 +73,7 @@
       "id": "bounds",
       "title": "Known Bounds",
       "startLine": 61,
-      "endLine": 74,
+      "endLine": 75,
       "summary": "Lower bound $\\Omega(N^{1/3})$ from forbidden-sum counting. Upper bound $\\sqrt{N} + O(N^{1/4})$ from Erdos-Turan.",
       "mathContext": "Lower bound: each element $a_n$ forbids $\\leq 2n$ future sums, so $a_n = O(n^3)$, giving $f(N) = \\Omega(N^{1/3})$. Upper bound (Erdős-Turán 1941): any Sidon set in $\\{1, \\ldots, N\\}$ has $\\leq \\sqrt{N} + O(N^{1/4})$ elements. The gap between $N^{1/3}$ and $N^{1/2}$ is the content of the conjecture."
     },

--- a/src/data/proofs/erdos-341/meta.json
+++ b/src/data/proofs/erdos-341/meta.json
@@ -23,7 +23,8 @@
     "erdosProblemStatus": "open",
     "axiomCount": 9,
     "assumptions": "9 axiom declarations: erdos_341_conjecture (eventual periodicity conjecture), dickson_strictly_increasing (strict monotonicity), dickson_diff_pos (positive differences), dickson_avoids_sums (sum avoidance property), dickson_minimal (greedy minimality), singleton_one_example (Mian-Chowla special case), squares_slow_periodicity (slow emergence for squares), period_depends_on_initial (period varies with start), dickson_linear_growth (at-least-linear growth)",
-    "lineCount": 116
+    "lineCount": 116,
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "This is an old problem of Dickson from the early 20th century, brought to wider attention by Erdős and Graham in their 1980 monograph (p. 53). The construction is beautifully simple: start with any finite set of positive integers, then repeatedly adjoin the smallest integer not expressible as a sum of two elements already in the set. The resulting sequence always appears to develop eventually periodic differences, but proving this has resisted all attempts. The problem connects greedy algorithms to questions of periodicity in dynamical systems — a theme that appears throughout number theory (Collatz conjecture, continued fractions, digit patterns). Even starting from the first five perfect squares {1,4,9,16,25}, periodicity takes thousands of terms to emerge, making computational verification impractical for all but small starting sets. Ben Green includes this as Problem 7 on his influential open problems list, reflecting its position at the frontier of additive combinatorics. The singleton starting set {1} produces the Mian-Chowla sequence (Problem #340), creating a direct link between the two problems.",
@@ -82,21 +83,21 @@
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 23,
-      "endLine": 53,
+      "endLine": 54,
       "summary": "`pairwiseSums`, `IsSumRepresentable`, `dicksonSeq` (greedy extension via `Nat.find`), `dicksonDiff`, and `IsEventuallyPeriodic`."
     },
     {
       "id": "conjecture",
       "title": "Main Conjecture",
       "startLine": 55,
-      "endLine": 61,
+      "endLine": 62,
       "summary": "Erdos-Dickson conjecture: for every finite nonempty starting set, the difference sequence is eventually periodic."
     },
     {
       "id": "structural",
       "title": "Structural Properties",
       "startLine": 63,
-      "endLine": 87,
+      "endLine": 88,
       "summary": "Strict monotonicity, positive differences, sum avoidance at each step, and minimality of the greedy choice."
     },
     {

--- a/src/data/proofs/erdos-518/meta.json
+++ b/src/data/proofs/erdos-518/meta.json
@@ -88,7 +88,7 @@
       "title": "Two-Coloring of Complete Graphs",
       "summary": "Color type and TwoColoring definition",
       "startLine": 35,
-      "endLine": 55,
+      "endLine": 56,
       "mathContext": "A two-coloring of $K_n$ is a function $\\chi : \\{(i,j) : i < j\\} \\to \\{\\text{Red}, \\text{Blue}\\}$ assigning a color to each edge."
     },
     {
@@ -96,7 +96,7 @@
       "title": "Paths in Graphs",
       "summary": "Path structure with vertices, vertexSet, and length",
       "startLine": 57,
-      "endLine": 82,
+      "endLine": 83,
       "mathContext": "A path is a vertex sequence $(v_1, \\ldots, v_k)$ with no repeated vertices. In $K_n$ all edges exist, so any such sequence is a valid path."
     },
     {
@@ -104,7 +104,7 @@
       "title": "Monochromatic Paths",
       "summary": "IsMonochromaticPath, IsRedPath, IsBluePath definitions",
       "startLine": 84,
-      "endLine": 109,
+      "endLine": 110,
       "mathContext": "A monochromatic path has all edges the same color: $\\chi(v_i, v_{i+1}) = c$ for all consecutive pairs. The same-color constraint is what distinguishes this from the easier mixed-color problem."
     },
     {
@@ -112,7 +112,7 @@
       "title": "Path Covers",
       "summary": "PathCover structure and IsMonochromaticCover definition",
       "startLine": 111,
-      "endLine": 136,
+      "endLine": 137,
       "mathContext": "A path cover partitions the vertex set $\\{1, \\ldots, n\\}$ into vertex-disjoint paths. A monochromatic cover requires all paths to be the same color."
     },
     {
@@ -120,7 +120,7 @@
       "title": "Classical Results",
       "summary": "Gerencsér-Gyárfás (1967): 2 mixed-color paths suffice. Erdős-Gyárfás (1995): $2\\sqrt{n}$ same-color paths suffice. Lower bound: $\\sqrt{n} - 1$ paths sometimes needed",
       "startLine": 138,
-      "endLine": 166,
+      "endLine": 167,
       "mathContext": "Gerencsér-Gyárfás: $\\forall \\chi, \\exists$ a cover by 2 paths (colors may differ). Erdős-Gyárfás: $\\forall \\chi, \\exists$ a same-color cover by $\\le 2\\sqrt{n}$ paths. Lower bound: $\\exists \\chi$ requiring $\\ge \\sqrt{n} - 1$ same-color paths."
     },
     {
@@ -128,7 +128,7 @@
       "title": "The Erdős-Gyárfás Conjecture",
       "summary": "Statement of the $\\sqrt{n}$ conjecture",
       "startLine": 168,
-      "endLine": 181,
+      "endLine": 182,
       "mathContext": "Conjecture (1995): $\\forall n, \\forall \\chi$ on $K_n$, $\\exists$ a monochromatic path cover of size $\\le \\lceil\\sqrt{n}\\rceil$, all paths the same color."
     },
     {
@@ -136,7 +136,7 @@
       "title": "The Solution (PVW 2024)",
       "summary": "Main theorem confirming the conjecture",
       "startLine": 183,
-      "endLine": 208,
+      "endLine": 209,
       "mathContext": "Pokrovskiy-Versteegen-Williams (2024): the conjecture is true. For every two-coloring $\\chi$ of $K_n$, $\\sqrt{n}$ same-color paths suffice."
     },
     {
@@ -144,7 +144,7 @@
       "title": "Tightness of the Bound",
       "summary": "Combining upper and lower bounds to show $\\sqrt{n}$ is optimal",
       "startLine": 210,
-      "endLine": 229,
+      "endLine": 230,
       "mathContext": "The bound $\\sqrt{n}$ is tight up to lower-order terms: $\\sqrt{n} - 1 \\le \\text{opt}(n) \\le \\sqrt{n}$."
     },
     {
@@ -152,7 +152,7 @@
       "title": "Comparison with Two-Colored Cover",
       "summary": "color_matters theorem contrasting mixed vs same color requirements",
       "startLine": 231,
-      "endLine": 251,
+      "endLine": 252,
       "mathContext": "The gap between 2 (mixed colors) and $\\sqrt{n}$ (same color) quantifies how much harder the same-color constraint makes the covering problem."
     },
     {
@@ -160,7 +160,7 @@
       "title": "Summary",
       "summary": "erdos_518_summary combining all results into a single conjunction",
       "startLine": 253,
-      "endLine": 283,
+      "endLine": 286,
       "mathContext": "Summary theorem: $\\forall n \\ge 1, \\forall \\chi$: (1) $\\exists$ 2-path mixed cover, (2) $\\exists$ $\\sqrt{n}$ same-color cover, (3) the bound is tight."
     }
   ],

--- a/src/data/proofs/erdos-519/meta.json
+++ b/src/data/proofs/erdos-519/meta.json
@@ -89,7 +89,7 @@
       "id": "imports-namespace",
       "title": "Imports and Namespace",
       "startLine": 31,
-      "endLine": 39,
+      "endLine": 40,
       "summary": "Imports Mathlib modules for complex numbers, exponential functions, natural numbers, and finite sets; opens the `Complex` and `Finset` namespaces",
       "mathContext": "The formalization depends on Mathlib's `Complex.abs` (complex modulus), `Complex.exp` (for roots of unity), and `Finset.sum` (finite summation)."
     },
@@ -97,7 +97,7 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "startLine": 41,
-      "endLine": 71,
+      "endLine": 72,
       "summary": "Defines the core objects: the $k$-th power sum $S_k(z) = \\sum_i z_i^k$, its magnitude $|S_k|$, the maximum power sum $\\max_{1 \\le k \\le n} |S_k|$, and the normalization constraint $z_1 = 1$",
       "mathContext": "These definitions set up the extremal problem: minimize $\\max_k |S_k|$ over all configurations $z$ with $z_1 = 1$."
     },
@@ -105,7 +105,7 @@
       "id": "turan-result",
       "title": "Turán's Original Result",
       "startLine": 73,
-      "endLine": 94,
+      "endLine": 95,
       "summary": "Axiomatizes Turán's bound $\\max_k |S_k| \\ge c/n$ and formally states the question of whether an absolute (n-independent) constant exists",
       "mathContext": "Turán's power sum method: the bound $c/n$ degrades with $n$, leaving open whether the dependence is essential."
     },
@@ -113,7 +113,7 @@
       "id": "atkinson",
       "title": "Atkinson's Theorem (1961)",
       "startLine": 96,
-      "endLine": 117,
+      "endLine": 118,
       "summary": "Axiomatizes Atkinson's breakthrough: $\\max_k |S_k| > 1/6$ for all $n$ and all $z$ with $z_1 = 1$. Derives `turan_question_yes` as a direct corollary",
       "mathContext": "Atkinson's result settles Turán's question affirmatively: the constant $c = 1/6$ is absolute, independent of $n$."
     },
@@ -121,7 +121,7 @@
       "id": "biro",
       "title": "Biró's Improvements",
       "startLine": 119,
-      "endLine": 148,
+      "endLine": 149,
       "summary": "Axiomatizes Biró's improved bounds: $c = 1/2$ (1994) and $c > 1/2$ (2000), plus the placeholder conjecture that the optimal constant is approximately $0.7$",
       "mathContext": "Biró's refinements doubled Atkinson's constant and broke the $1/2$ barrier, but the conjectured optimal $c \\approx 0.7$ remains unproved."
     },
@@ -129,7 +129,7 @@
       "id": "key-observations",
       "title": "Key Observations",
       "startLine": 150,
-      "endLine": 178,
+      "endLine": 179,
       "summary": "Proves the trivial case $n=1$ directly ($S_k = 1^k = 1$ for all $k$) and explains why the constraint $z_1 = 1$ is essential: without it, taking all $z_i = 0$ trivializes the problem",
       "mathContext": "The decomposition $S_k = 1 + \\sum_{i > 0} z_i^k$ shows that each power sum includes the anchor term $1^k = 1$, so cancellation must come from the remaining terms."
     },
@@ -137,7 +137,7 @@
       "id": "special-cases",
       "title": "Roots of Unity and Special Cases",
       "startLine": 180,
-      "endLine": 220,
+      "endLine": 221,
       "summary": "Defines $n$-th roots of unity via $\\omega_k = e^{2\\pi i k/n}$ and axiomatizes their power sum behavior: $\\sum \\omega_k^j = n$ if $n | j$, else $0$. Notes connection to Problem #973",
       "mathContext": "Roots of unity exhibit the orthogonality relation $\\sum_{k=0}^{n-1} e^{2\\pi i jk/n} = n \\cdot \\mathbf{1}_{n | j}$, a cornerstone of discrete Fourier analysis."
     },
@@ -145,7 +145,7 @@
       "id": "optimal-constant",
       "title": "The Optimal Constant",
       "startLine": 222,
-      "endLine": 247,
+      "endLine": 248,
       "summary": "Packages Biró's result as `optimal_lower_bound` and axiomatizes the computational evidence that $c \\approx 0.7$; notes the remaining gap between proved and conjectured values",
       "mathContext": "The gap $1/2 < c_{\\text{proved}} < c_{\\text{optimal}} \\approx 0.7$ represents the frontier of the problem."
     },

--- a/src/data/proofs/erdos-526/meta.json
+++ b/src/data/proofs/erdos-526/meta.json
@@ -73,12 +73,13 @@
       "Poisson processes and renewal theory fundamentals",
       "Geometric probability on the unit circle"
     ],
-    "lineCount": 278
+    "lineCount": 278,
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Dvoretzky posed this problem in 1956, asking for a characterization of when random arcs on a circle provide complete coverage. Kahane (1959) showed a_n = (1+c)/n covers with probability 1. Erdős (unpublished) proved a_n = 1/n is the critical case: it covers, but a_n = (1-c)/n fails. Shepp (1972) gave the complete answer via the elegant criterion Σ exp(S_n)/n² = ∞, where S_n is the partial sum of arc lengths. The random coverage problem connects to the Poisson process on the circle and to Borel-Cantelli type arguments; the logarithmic threshold a_n ~ 1/n is a one-dimensional analogue of the threshold for covering a d-dimensional cube, where a_n ~ (d log n)/n is required, as proved by Flajolet, Grabner, Kirschenhofer, and Prodinger in 1993.",
     "problemStatement": "Let a_n ≥ 0 with a_n → 0 and Σa_n = ∞. Find a necessary and sufficient condition on the a_n such that random arcs of lengths a_n, placed uniformly and independently on the unit circle, cover the entire circle with probability 1.",
-    "text": "Given arc lengths a_n \u2192 0 with \u03a3a_n = \u221e, when do random arcs cover the unit circle with probability 1? Shepp (1972) proved the necessary and sufficient condition is \u03a3 exp(a_1+...+a_n)/n\u00b2 = \u221e.",
+    "text": "Given arc lengths a_n → 0 with Σa_n = ∞, when do random arcs cover the unit circle with probability 1? Shepp (1972) proved the necessary and sufficient condition is Σ exp(a_1+...+a_n)/n² = ∞.",
     "proofStrategy": "Shepp used Poisson process techniques to analyze the expected number of uncovered points. The key insight is that at a_n = 1/n, the partial sum S_n grows like log n, making exp(S_n)/n² ~ 1/n, which barely diverges. Below 1/n, the sum converges and coverage fails.",
     "keyInsights": [
       "Shepp's criterion: Σ exp(a_1+...+a_n)/n² = ∞",
@@ -128,7 +129,7 @@
       "id": "poisson-connection",
       "title": "Poisson Connection",
       "startLine": 201,
-      "endLine": 250,
+      "endLine": 278,
       "summary": "Proof techniques via Poisson processes"
     }
   ],

--- a/src/data/proofs/erdos-539/meta.json
+++ b/src/data/proofs/erdos-539/meta.json
@@ -90,7 +90,7 @@
       "id": "header",
       "title": "Problem Overview and Imports",
       "startLine": 1,
-      "endLine": 33,
+      "endLine": 34,
       "summary": "Documentation header describing the problem, imports from Mathlib",
       "mathContext": "For $A \\subseteq \\mathbb{N}$ with $|A| = n$, define $Q(A) = \\{a/\\gcd(a,b) : a, b \\in A\\}$. The function $h(n) = \\min_{|A|=n} |Q(A)|$ measures the minimum quotient set size."
     },
@@ -106,7 +106,7 @@
       "id": "bounds",
       "title": "Erdős-Szemerédi and Freiman-Lev Bounds",
       "startLine": 96,
-      "endLine": 135,
+      "endLine": 136,
       "summary": "The main asymptotic bounds: $n^{1/2} \\ll h(n) \\ll n^{2/3}$",
       "mathContext": "Erdős-Szemerédi: $\\exists c_1, c_2 > 0$ such that $c_1 n^{1/2} \\le h(n) \\le c_2 n^{1-c}$ for some $c > 0$. Freiman-Lev improved the upper bound: $h(n) \\ll n^{2/3}$."
     },
@@ -114,7 +114,7 @@
       "id": "examples",
       "title": "Examples: APs and GPs",
       "startLine": 137,
-      "endLine": 159,
+      "endLine": 160,
       "summary": "Quotient set sizes for arithmetic and geometric progressions",
       "mathContext": "For an AP $\\{a, a+d, \\ldots, a+(n-1)d\\}$: $|Q(A)| \\sim n$. For a GP $\\{1, p, p^2, \\ldots\\}$ with prime $p$: $|Q(A)| = 2n-1$ (all powers $p^j$ for $|j| < n$)."
     },
@@ -122,7 +122,7 @@
       "id": "structure",
       "title": "Matrix and Geometric Views",
       "startLine": 161,
-      "endLine": 213,
+      "endLine": 214,
       "summary": "GCD/quotient matrices, Granville-Roesler reformulation, extremal structure",
       "mathContext": "The GCD matrix $G_{ij} = \\gcd(a_i, a_j)$ and quotient matrix $Q_{ij} = a_i/\\gcd(a_i, a_j)$ encode the divisibility structure. Granville-Roesler reformulate via lattice points in dilated simplices."
     },

--- a/src/data/proofs/erdos-848/meta.json
+++ b/src/data/proofs/erdos-848/meta.json
@@ -51,7 +51,8 @@
       "fermat-two-squares",
       "elementary-quadratic-reciprocity",
       "erdos-844"
-    ]
+    ],
+    "mathlib_version": "4.26.0"
   },
   "crossReferences": [
     {
@@ -107,7 +108,7 @@
       "id": "definitions",
       "title": "Definitions and Extremal Function",
       "startLine": 21,
-      "endLine": 57,
+      "endLine": 58,
       "summary": "IsSquarefree, HasNonSqfreeProductProp, maxNonSqfreeSet (noncomputable def via Finset.sup over powerset), and maxNonSqfreeSet_le proved via injection x↦x-1.",
       "mathContext": "$\\text{maxNonSqfreeSet}(N) := \\sup\\{|A| : A \\subseteq \\{1,\\ldots,N\\},\\ \\text{HasNonSqfreeProductProp}(A)\\}$. Upper bound $\\leq N$ proved by injecting $\\text{Icc}(1,N)$ into $\\text{range}(N)$ via $x \\mapsto x-1$."
     },
@@ -115,7 +116,7 @@
       "id": "mod25-construction",
       "title": "Mod 25 Constructions and Connecting Lemmas",
       "startLine": 59,
-      "endLine": 102,
+      "endLine": 103,
       "summary": "mod25_achieves and mod25_achieves_18: proved 5² | ab+1 for both residue classes via ring arithmetic. five_prime, not_sqfree_of_five_sq_dvd, mod7/18_set_has_property: connect divisibility to HasNonSqfreeProductProp.",
       "mathContext": "For $a \\equiv b \\equiv 7 \\pmod{25}$: $ab+1 \\equiv 50 \\equiv 0 \\pmod{25}$. For $a \\equiv b \\equiv 18 \\pmod{25}$: $ab+1 \\equiv 325 \\equiv 0 \\pmod{25}$. Both give $5^2 \\mid ab+1$, hence $\\neg\\text{IsSquarefree}(ab+1)$."
     },
@@ -123,7 +124,7 @@
       "id": "lower-bound",
       "title": "Lower Bound via Witness Construction",
       "startLine": 104,
-      "endLine": 153,
+      "endLine": 154,
       "summary": "Defines mod7Set, proves it has the property and has cardinality ≥ N/25 via injection k↦25k+7. Concludes lower_bound: N/25 ≤ maxNonSqfreeSet(N) for N ≥ 25.",
       "mathContext": "The injection $k \\mapsto 25k+7$ maps $\\{0,\\ldots,\\lfloor N/25\\rfloor - 1\\}$ into $\\{n \\in \\{1,\\ldots,N\\} : n \\equiv 7 \\pmod{25}\\}$. Combined with Finset.le_sup, this gives the lower bound on the extremal function."
     },

--- a/src/data/proofs/erdos-szekeres/meta.json
+++ b/src/data/proofs/erdos-szekeres/meta.json
@@ -43,7 +43,8 @@
     "wiedijkNumber": 73,
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: erdos_szekeres_existence_axiom (monotone subsequence exists), erdos_szekeres_tight_axiom (bound (r-1)(s-1)+1 is tight)",
-    "lineCount": 280
+    "lineCount": 280,
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Paul Erdős and George Szekeres proved this theorem in 1935 in their paper \"A combinatorial problem in geometry.\" It was one of Erdős's first major results, published when he was just 22 years old. The theorem arose from the Happy Ending Problem about convex polygons and has since become a cornerstone of combinatorics and Ramsey theory. The elegant pigeonhole proof gives an exact tight bound. Dilworth's theorem (1950) generalized it: in any finite partially ordered set, the minimum number of chains covering it equals the maximum antichain size; the Erdős-Szekeres theorem is the linear order special case. The result is also a foundational instance of the general Ramsey principle that any large enough structure must contain order.",
@@ -84,7 +85,7 @@
       "id": "classic-form",
       "title": "Classic Form",
       "startLine": 142,
-      "endLine": 153,
+      "endLine": 154,
       "summary": "The n²+1 corollary: any sequence of n²+1 elements has a monotonic subsequence of length n+1.",
       "mathContext": "$n = m^2 + 1 \\implies$ any injective sequence of length $n$ has a monotonic subsequence of length $m + 1$. Special case $r = s = m + 1$: $(m+1-1)(m+1-1) + 1 = m^2 + 1$."
     },
@@ -92,7 +93,7 @@
       "id": "tightness",
       "title": "Tightness of Bound",
       "startLine": 155,
-      "endLine": 183,
+      "endLine": 184,
       "summary": "Construction showing the bound (r-1)(s-1) + 1 cannot be improved.",
       "mathContext": "$\\exists f : \\text{Fin}\\, ((r-1)(s-1)) \\to \\mathbb{N}$ injective with no increasing length $r$ and no decreasing length $s$. Construction: $s-1$ increasing blocks of $r-1$ elements, blocks in decreasing order."
     },
@@ -100,7 +101,7 @@
       "id": "examples",
       "title": "Concrete Examples",
       "startLine": 185,
-      "endLine": 229,
+      "endLine": 230,
       "summary": "Examples demonstrating the theorem on specific sequences.",
       "mathContext": "For $r = s = 3$: sequence $[3, 4, 1, 2]$ has length $(3-1)(3-1) = 4$. No increasing length 3 (blocked), no decreasing length 3 (only 2 blocks). Adding one more element forces a monotonic triple."
     },
@@ -108,7 +109,7 @@
       "id": "ramsey-perspective",
       "title": "Ramsey-Theoretic Perspective",
       "startLine": 231,
-      "endLine": 274,
+      "endLine": 280,
       "summary": "The Erdős–Szekeres number and its connection to Ramsey theory.",
       "mathContext": "$ES(r,s) = (r-1)(s-1) + 1$. 2-color pairs $(i,j)$ by comparing $f(i)$ vs $f(j)$. The theorem guarantees a red $r$-clique (increasing) or blue $s$-clique (decreasing). $ES(r,s) = ES(s,r)$ by symmetry."
     }

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -51,7 +51,8 @@
       "Finsler geometry and projective metrics",
       "Convex geometry and the triangle inequality",
       "Hilbert geometry and the cross-ratio"
-    ]
+    ],
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Hilbert's 4th Problem (1900) asked for the characterization of geometries where straight lines are shortest paths between points, weakening congruence axioms and omitting the parallel postulate. Hamel (1903) showed in 2D that only Minkowski geometries satisfy these conditions. Busemann provided a more complete solution in 1955 using his theory of G-spaces. The problem is closely related to Finsler geometry, developed by Finsler (1918) and Cartan (1934), where lengths are defined by a smoothly varying norm on the tangent bundle. Pogorelov (1973) gave a more precise characterization in higher dimensions, and the problem remains active in the theory of metric spaces and sub-Riemannian geometry.",
@@ -118,7 +119,7 @@
       "id": "examples",
       "title": "Examples",
       "startLine": 281,
-      "endLine": 350,
+      "endLine": 457,
       "summary": "Euclidean, taxicab, and Chebyshev norms as examples.",
       "mathContext": "Euclidean: $\\|x\\|_2 = \\sqrt{\\sum x_i^2}$, unit ball is a sphere. Taxicab: $\\|x\\|_1 = \\sum |x_i|$, unit ball is a cross-polytope. Chebyshev: $\\|x\\|_\\infty = \\max |x_i|$, unit ball is a hypercube. All are Minkowski geometries with convex unit balls, hence straight-line geodesics."
     }


### PR DESCRIPTION
Batch enrichment pass for quality 95-100 tier entries.

**18 entries fixed:** section line range gaps and/or missing mathlib_version

🤖 Generated with [Claude Code](https://claude.com/claude-code)