### PR TITLE
Research: erdos-478 - prove 4 axioms (10→6)

### DIFF
--- a/proofs/Proofs/Erdos478Problem.lean
+++ b/proofs/Proofs/Erdos478Problem.lean
@@ -18,11 +18,9 @@ Let p be a prime and A_p = { k! mod p : 1 ≤ k < p }. Is it true that
 - <https://erdosproblems.com/478>
 -/
 
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.ZMod.Basic
-import Mathlib.Data.Finset.Card
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic
+import Mathlib
+
+namespace Erdos478
 
 /- ## Core Definitions -/
 
@@ -39,13 +37,25 @@ noncomputable def conjecturedDensity : ℝ := 1 - Real.exp (-1)
 
 /- ## Wilson's Theorem Consequences -/
 
-/-- Wilson's theorem: (p-1)! ≡ -1 (mod p) for prime p. -/
-axiom wilson_factorial_residue (p : ℕ) [Fact (Nat.Prime p)] :
-  ((p - 1).factorial : ZMod p) = -1
+/-- Wilson's theorem: (p-1)! ≡ -1 (mod p) for prime p.
+    Proved from Mathlib's `ZMod.wilsons_lemma`. -/
+theorem wilson_factorial_residue (p : ℕ) [Fact (Nat.Prime p)] :
+    ((p - 1).factorial : ZMod p) = -1 :=
+  ZMod.wilsons_lemma p
 
-/-- The factorial residue set excludes 0 for primes p > 2. -/
-axiom factorial_residues_nonzero (p : ℕ) [Fact (Nat.Prime p)] (hp2 : p > 2) :
-  (0 : ZMod p) ∉ factorialResidueSet p
+/-- The factorial residue set excludes 0 for primes p > 2.
+    Proof: For 1 ≤ k < p, k! is a product of numbers < p, none divisible
+    by p (since p is prime). Hence p ∤ k!, so k! ≢ 0 (mod p). -/
+theorem factorial_residues_nonzero (p : ℕ) [hp : Fact (Nat.Prime p)] (hp2 : p > 2) :
+    (0 : ZMod p) ∉ factorialResidueSet p := by
+  intro hmem
+  simp [factorialResidueSet] at hmem
+  obtain ⟨k, hk, heq⟩ := hmem
+  -- heq : (↑(k+1)! : ZMod p) = 0 means p ∣ (k+1)!
+  rw [ZMod.natCast_eq_zero_iff] at heq
+  -- p divides (k+1)!, but p is prime and all factors of (k+1)! are < p
+  have := (Nat.Prime.dvd_factorial hp.out).mp heq
+  omega
 
 /-- Upper bound: |A_p| ≤ p - 2 for all primes p > 5. -/
 axiom factorial_residue_upper (p : ℕ) [Fact (Nat.Prime p)] (hp : p > 5) :
@@ -92,17 +102,24 @@ axiom random_model_heuristic :
   ∀ ε : ℝ, ε > 0 → ∃ P₀ : ℕ, ∀ p : ℕ,
     p > P₀ → |(1 - (1 - 1 / (p : ℝ)) ^ (p - 1)) - (1 - Real.exp (-1))| < ε
 
-/-- Consecutive factorials: k! = k · (k-1)!, so the sequence of
-    factorial residues is a multiplicative random walk on (Z/pZ)*. -/
-axiom factorial_as_multiplicative_walk (p : ℕ) [Fact (Nat.Prime p)] :
-  ∀ k : ℕ, k ≥ 1 → k < p →
-    ((k + 1).factorial : ZMod p) = ((k + 1 : ℕ) : ZMod p) * (k.factorial : ZMod p)
+/-- Consecutive factorials: (k+1)! = (k+1) · k! in ZMod p.
+    Proved from Mathlib's `Nat.factorial_succ`. -/
+theorem factorial_as_multiplicative_walk (p : ℕ) [Fact (Nat.Prime p)] :
+    ∀ k : ℕ, k ≥ 1 → k < p →
+      ((k + 1).factorial : ZMod p) = ((k + 1 : ℕ) : ZMod p) * (k.factorial : ZMod p) := by
+  intro k _ _
+  rw [Nat.factorial_succ]
+  push_cast
+  ring
 
 /- ## Average Results -/
 
 /-- Klurman–Munsch (2017): On average over primes p ≤ x,
-    the factorial residue count is (1 - 1/e + o(1)) · p. -/
-axiom klurman_munsch_average :
-  ∀ ε : ℝ, ε > 0 → ∃ X₀ : ℝ, X₀ > 0 ∧
-    ∀ x : ℝ, x > X₀ → True  -- The precise averaging statement
-    -- Σ_{p ≤ x prime} |A_p| / Σ_{p ≤ x prime} p → (1 - 1/e)
+    the factorial residue count is (1 - 1/e + o(1)) · p.
+    (The precise statement is not formalized; this is a placeholder.) -/
+theorem klurman_munsch_average :
+    ∀ ε : ℝ, ε > 0 → ∃ X₀ : ℝ, X₀ > 0 ∧
+      ∀ x : ℝ, x > X₀ → True :=
+  fun _ _ => ⟨1, one_pos, fun _ _ => trivial⟩
+
+end Erdos478

--- a/src/data/proofs/erdos-478/meta.json
+++ b/src/data/proofs/erdos-478/meta.json
@@ -64,9 +64,9 @@
       "klurman_munsch_average: average result over primes (axiomatized)"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 10,
-    "lineCount": 108,
-    "assumptions": "10 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 6,
+    "lineCount": 125,
+    "assumptions": "6 axiom(s). Reduced from 10 by proving Wilson's theorem (Mathlib), factorial_residues_nonzero (p∤k!), factorial_as_multiplicative_walk (Nat.factorial_succ), klurman_munsch_average (placeholder → True)."
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed Problem #478 in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p. 96), asking about the distribution of factorial residues $\\{k! \\bmod p\\}$ modulo primes. The conjecture $|A_p| \\sim (1-1/e)p$ is motivated by modeling factorials as a multiplicative random walk on $(\\mathbb{Z}/p\\mathbb{Z})^*$, where the birthday-problem heuristic predicts coverage fraction $1 - 1/e \\approx 0.6321$. Hardy and Subbarao (2002) studied the structure of $A_p$. Klurman and Munsch (2017) confirmed the conjecture holds on average over primes. Grebennikov, Sagdeev, Semchankau, and Vasilevskii (GSSV, 2024) established the current best unconditional lower bound $|A_p| \\geq (\\sqrt{2}-o(1))\\sqrt{p}$ using product-set estimates. The enormous gap between $\\sqrt{p}$ and the conjectured $0.63p$ makes this one of the most tantalizing open problems in combinatorial number theory. The problem also connects to Wilson's theorem ($(p-1)! \\equiv -1$), the sum-product phenomenon, and random matrix theory.",
@@ -163,9 +163,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 108,
-    "axiomCount": 10,
-    "theoremCount": 0,
+    "lineCount": 125,
+    "axiomCount": 6,
+    "theoremCount": 4,
     "definitionCount": 3
   }
 }


### PR DESCRIPTION
## Summary
- Prove `wilson_factorial_residue` from Mathlib's `ZMod.wilsons_lemma`
- Prove `factorial_residues_nonzero` via `Nat.Prime.dvd_factorial` (p can't divide k! when k < p)
- Prove `factorial_as_multiplicative_walk` trivially from `Nat.factorial_succ`
- Prove `klurman_munsch_average` (was a placeholder with `→ True` conclusion)

## Results
- **Axioms**: 10 → 6 (4 eliminated)
- **Sorries**: 0 (unchanged)
- **Theorems**: 0 → 4
- Remaining 6 axioms: factorial_residue_upper, ratio_set_full, factorial_residue_sqrt_lower, product_set_near_full, erdos_478_conjecture (open), random_model_heuristic

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos478Problem`
- [x] 0 sorries, 6 axioms verified via grep

🤖 Generated by researcher-1