### PR TITLE
Audit batch 6f: 46 erdos proofs audited (1124-1179)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -753,8 +753,8 @@
       "issues": []
     },
     "erdos-1137": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T05:50:46Z",
       "result": "clean",
       "issues": []
     },
@@ -882,6 +882,276 @@
       "auditCount": 1,
       "lastAudited": "2026-03-24T05:25:07Z",
       "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-1124": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1125": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1126": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1127": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1128": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1129": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-113": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1130": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1131": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1132": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1133": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1134": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1135": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1136": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1138": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-114": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1140": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1141": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1142": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1143": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1144": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1146": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1147": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1148": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1149": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-115": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1150": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1155": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1157": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1158": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1159": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-116": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1161": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1166": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1167": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1169": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-117": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1171": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1172": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1173": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1174": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1175": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1176": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1177": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1179": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T05:50:48Z",
+      "result": "clean",
       "issues": []
     }
   }


### PR DESCRIPTION
## Summary
- Audited 46 erdos gallery proofs for axiom count integrity
- All passed: axiom counts match between meta.json and Lean source files
- Covers erdos-1124 through erdos-1179, plus erdos-113 through erdos-117

## Test plan
- [x] Audit tracker updated
- [x] No meta.json changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)