### PR TITLE
Enrich basel-problem: add mathlib_version

### DIFF
--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -56,6 +56,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 164,
+    "mathlib_version": "4.26.0",
     "relatedProblems": [
       {
         "id": "basel-problem-oq-01",


### PR DESCRIPTION
Enrichment pass for basel-problem (Wiedijk #14, passes: 0→1).

**Improvements:**
- Added `mathlib_version` (4.26.0)
- Verified all 12 cross-reference targets exist in gallery
- Entry was already well-enriched with 8 keyInsights, 8 references, comprehensive historicalContext