### PR TITLE
Research: erdos-276 - Prove gcd_propagation, axioms 4→3

### DIFF
--- a/proofs/Proofs/Erdos276Problem.lean
+++ b/proofs/Proofs/Erdos276Problem.lean
@@ -56,11 +56,18 @@ axiom graham_construction :
   ∃ a : ℕ → ℕ,
     IsLucasSequence a ∧ IsPrimefree a ∧ Nat.Coprime (a 0) (a 1)
 
-/-- **Coprimality is necessary**: if gcd(a₀, a₁) = d > 1, then d
-    divides every term, making the sequence trivially composite. -/
-axiom coprime_necessary :
-  ∀ a : ℕ → ℕ, IsLucasSequence a →
-    ∀ d : ℕ, d ∣ a 0 → d ∣ a 1 → ∀ k, d ∣ a k
+/-- **GCD propagation**: if d divides both a₀ and a₁, then d divides
+    every term. Proof: two-step induction using a_{n+2} = a_{n+1} + a_n. -/
+theorem gcd_propagation (a : ℕ → ℕ) (hluc : IsLucasSequence a)
+    (d : ℕ) (h0 : d ∣ a 0) (h1 : d ∣ a 1) : ∀ k, d ∣ a k := by
+  suffices ∀ k, d ∣ a k ∧ d ∣ a (k + 1) from fun k => (this k).1
+  intro k
+  induction k with
+  | zero => exact ⟨h0, h1⟩
+  | succ n ih => exact ⟨ih.2, hluc n ▸ dvd_add ih.2 ih.1⟩
+
+/- Note: gcd_propagation also implies that HasNoUniversalDivisor → Coprime(a₀, a₁)
+   by contrapositive. Any d > 1 dividing gcd(a₀, a₁) would divide all terms. -/
 
 /- ## Covering Congruence Mechanism -/
 

--- a/src/data/proofs/erdos-276/meta.json
+++ b/src/data/proofs/erdos-276/meta.json
@@ -65,9 +65,9 @@
         "relationship": "Sierpinski numbers: parallel question about covering systems as sole mechanism for compositeness"
       }
     ],
-    "axiomCount": 4,
-    "lineCount": 87,
-    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 3,
+    "lineCount": 94,
+    "assumptions": "3 axioms: erdos_276_existence (Graham 1964 existence), graham_construction (coprime primefree sequence), covering_system_mechanism (covering congruence structure). The former axiom coprime_necessary has been PROVED as gcd_propagation via two-step induction."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #276** belongs to the rich interface between linear recurrences and covering congruences in combinatorial number theory.\n\n**The Original Question:**\nErdős asked whether there exists a Lucas sequence $a_{n+2} = a_{n+1} + a_n$ where every term is composite, yet no single integer greater than 1 divides all terms. The condition that no universal divisor exists is crucial: if $\\gcd(a_0, a_1) = d > 1$, then $d$ divides every term by induction on the recurrence, giving a trivially composite sequence. The interesting case requires $\\gcd(a_0, a_1) = 1$.\n\n**Graham's Resolution (1964):**\nRonald Graham proved the existence of such sequences in his 1964 paper in *Mathematics Magazine*. His construction is elegant: choose initial values $a_0, a_1$ that are coprime and composite, such that a finite set of primes $S$ covers all index positions via the Pisano period structure. The key insight is that the Lucas sequence is periodic modulo each prime $p$, with period $\\pi(p)$ (the Pisano period). If the residue classes $\\{k \\bmod \\pi(p) : p \\mid a_k\\}$ for primes $p \\in S$ form a covering system of the natural numbers, then every term has at least one prime divisor from $S$. Graham's original starting values had 34 digits.\n\n**Subsequent Improvements:**\nDonald Knuth found smaller starting values. Vsemirnov (2004) achieved the current record: $a_0 = 106276436867$, $a_1 = 35256392432$ (12 digits). Ismailescu and Son (2014) studied explicit constructions further.\n\n**The Open Question:**\nWhile Graham showed that covering congruences *suffice* to construct primefree Lucas sequences, Erdős asked whether they are *necessary*. Could there exist a primefree Lucas sequence that is not explained by any covering system? This deeper question connects to fundamental issues about the structure of divisibility in linear recurrences and remains open.",
@@ -156,9 +156,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 87,
-    "axiomCount": 4,
-    "theoremCount": 0,
+    "lineCount": 94,
+    "axiomCount": 3,
+    "theoremCount": 1,
     "definitionCount": 3
   },
   "references": [


### PR DESCRIPTION
## Summary
- Converted `coprime_necessary` axiom to `gcd_propagation` **theorem** with proof
- Proof by two-step induction: if d | a(k) and d | a(k+1), then d | a(k+2) = a(k+1) + a(k)
- **Axiom count reduced from 4 to 3** (real formalization progress)

## The Proof
```lean
theorem gcd_propagation (a : ℕ → ℕ) (hluc : IsLucasSequence a)
    (d : ℕ) (h0 : d ∣ a 0) (h1 : d ∣ a 1) : ∀ k, d ∣ a k := by
  suffices ∀ k, d ∣ a k ∧ d ∣ a (k + 1) from fun k => (this k).1
  intro k
  induction k with
  | zero => exact ⟨h0, h1⟩
  | succ n ih => exact ⟨ih.2, hluc n ▸ dvd_add ih.2 ih.1⟩
```

## Remaining Axioms (3)
1. `erdos_276_existence` - Graham 1964 existence (deep)
2. `graham_construction` - coprime primefree construction (deep)
3. `covering_system_mechanism` - covering congruence structure (deep)

## Status
**Outcome**: completed (axiom elimination)

Generated by researcher-7