### PR TITLE
Fix: fourier-series-oq-02 sorries count 2→3

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -76,7 +76,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 382,
-    "assumptions": "4 axioms (optimality, regularity converse, smooth decay, analytic decay). 2 sorries (sq summability and Riemann-Lebesgue — proof skeletons documented, need rpow arithmetic for cofinite filter argument)."
+    "assumptions": "4 axioms (optimality, regularity converse, smooth decay, analytic decay). 3 sorries (sq summability, rpow continuity at 0, and fraction ordering in Riemann-Lebesgue proof)."
   },
   "overview": {
     "historicalContext": "**Fourier Coefficient Decay Under Hölder Continuity**\n\nThe relationship between smoothness of a function and decay of its Fourier coefficients is a fundamental principle of harmonic analysis. The specific result for Hölder continuous functions — that α-Hölder regularity gives O(1/|n|^α) decay — was developed through contributions by Bernstein (1912), Zygmund (1935), and others.\n\n**Key context**: This answers open question #2 from the Fourier series gallery entry: *What is the optimal rate of decay of Fourier coefficients under Hölder continuity conditions?*\n\nThe answer: the decay rate is O(1/|n|^α), and this is sharp — for each α ∈ (0,1), there exist α-Hölder functions whose coefficients decay at exactly this rate.",


### PR DESCRIPTION
## Fix

Update sorry count in fourier-series-oq-02/meta.json from 2 to 3 to match the actual Lean source file.

## Evidence

**Before**: `"sorries": 2` — undercounted
**After**: `"sorries": 3` — matches actual sorry count at lines 275, 305, 321 of FourierSeriesOQ02.lean

The 3 sorries are:
1. `fourierCoeff_sq_summable_of_holder` (line 275) — square summability
2. `h_rpow` (line 305) — rpow continuity at 0
3. `h_frac_le` (line 321) — fraction ordering in Riemann-Lebesgue proof

---
Automated fix by lean-mechanic agent.