### PR TITLE
Research: erdos-197 - Eliminate 3 axioms (5→2)

### DIFF
--- a/proofs/Proofs/Erdos197Problem.lean
+++ b/proofs/Proofs/Erdos197Problem.lean
@@ -29,10 +29,10 @@ References:
 
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Set.Function
-import Mathlib.Data.Set.Finite
 import Mathlib.Data.Nat.Basic
 import Mathlib.Logic.Function.Basic
 import Mathlib.Order.Basic
+import Mathlib.Tactic
 
 open Set Function
 
@@ -132,13 +132,22 @@ to avoid monotone 3-APs?
 Does there exist a partition of ℕ into two sets A and B such that both
 A and B can be permuted to avoid monotone 3-term arithmetic progressions?
 
-This is axiomatized as the problem remains open.
+This disjunction holds by excluded middle — the problem is open because we
+don't know which disjunct is true.
 -/
-axiom erdos_197_conjecture :
+theorem erdos_197_conjecture :
     (∃ A B : Set ℕ, isTwoPartition A B ∧
       canPermuteTo3APFree A ∧ canPermuteTo3APFree B) ∨
     (∀ A B : Set ℕ, isTwoPartition A B →
-      ¬canPermuteTo3APFree A ∨ ¬canPermuteTo3APFree B)
+      ¬canPermuteTo3APFree A ∨ ¬canPermuteTo3APFree B) := by
+  by_cases h : ∃ A B : Set ℕ, isTwoPartition A B ∧
+      canPermuteTo3APFree A ∧ canPermuteTo3APFree B
+  · exact Or.inl h
+  · right
+    intro A B hpart
+    by_contra habs
+    push_neg at habs
+    exact h ⟨A, B, hpart, habs.1, habs.2⟩
 
 /-
 ## Part V: The Three-Set Case (Solved)
@@ -166,16 +175,12 @@ axiom erdos_graham_three_sets :
 -/
 
 /--
-**Constant Sequence Avoids 3-AP:**
-A constant sequence trivially avoids non-trivial 3-APs since we require i < j < k.
+**Constant Sequence Has 3-APs:**
+A constant sequence f(n) = c has trivial 3-APs at every triple of indices,
+since c + c = 2c always holds.
 -/
-theorem constant_avoids_3AP (c : ℕ) : avoids3AP (fun _ => c) := by
-  intro ⟨i, j, k, hij, hjk, hap⟩
-  simp only [isArithmeticProgression] at hap
-  -- c + c = 2 * c is always true, so this is actually not a contradiction
-  -- The issue is that constant sequences DO have "trivial" 3-APs
-  -- Let me reconsider - we need stricter definition
-  omega
+theorem constant_has_3AP (c : ℕ) : hasMonotone3AP (fun _ => c) := by
+  exact ⟨0, 1, 2, by omega, by omega, by simp [isArithmeticProgression]; ring⟩
 
 /--
 **Strictly Increasing Sequences:**
@@ -208,25 +213,31 @@ theorem identity_has_3AP : hasMonotone3AP id := by
 /--
 **Powers of 2 avoid 3-APs:**
 The sequence 1, 2, 4, 8, 16, ... avoids 3-APs.
-This is because 2^a + 2^c = 2 * 2^b implies a = b = c (for distinct a, b, c).
+
+Proof: If 2^i + 2^k = 2 * 2^j with i < j < k, then since j < k we have
+2^k ≥ 2^(j+1) = 2 * 2^j, and since 2^i ≥ 1, we get
+2^i + 2^k ≥ 1 + 2 * 2^j > 2 * 2^j, contradicting the equation.
 -/
-axiom powers_of_2_avoid_3AP :
-    avoids3AP (fun n => 2 ^ n)
+theorem powers_of_2_avoid_3AP :
+    avoids3AP (fun n => 2 ^ n) := by
+  intro ⟨i, j, k, hij, hjk, hap⟩
+  simp only [isArithmeticProgression] at hap
+  -- hap : 2 ^ i + 2 ^ k = 2 * 2 ^ j
+  -- Since j < k, 2^k ≥ 2^(j+1) = 2 * 2^j, and 2^i ≥ 1
+  have hk : 2 * 2 ^ j ≤ 2 ^ k := by
+    have : 2 ^ (j + 1) ≤ 2 ^ k := Nat.pow_le_pow_right (by omega) hjk
+    linarith [show 2 ^ (j + 1) = 2 * 2 ^ j from by ring]
+  have hi : 0 < 2 ^ i := pow_pos (by omega : (0 : ℕ) < 2) i
+  linarith
 
 /-
 ## Part VIII: Computational Intractability
--/
 
-/--
-**Non-Computability:**
-The two-set version cannot be resolved by finite computation.
+The two-set version cannot be resolved by finite computation alone.
 Any finite portion of ℕ can be partitioned to avoid 3-APs in both parts,
-but this doesn't extend to all of ℕ.
+but this does not extend to all of ℕ. This is a known meta-mathematical
+observation rather than a formal theorem.
 -/
-axiom erdos_197_not_finite_checkable :
-    ¬∃ N : ℕ, ∀ A B : Set ℕ, isTwoPartition A B →
-      ((∃ f : ℕ → ℕ, isEnumeration A f ∧ avoids3AP f) ↔
-       (∃ f : Fin N → ℕ, True))  -- Placeholder for finite verification
 
 /-
 ## Part IX: Related Sequences
@@ -242,9 +253,9 @@ Begins: 0, 1, 3, 5, 9, 11, 13, 15, 25, 27, ...
 def isStanleySequence (f : ℕ → ℕ) : Prop :=
   f 0 = 0 ∧ f 1 = 1 ∧
   avoids3AP f ∧
-  ∀ n ≥ 2, f n = Nat.find (fun m =>
-    m > f (n - 1) ∧
-    ∀ i j, i < j → j < n → ¬isArithmeticProgression (f i) (f j) m)
+  StrictlyIncreasing f ∧
+  ∀ n ≥ 2, ∀ m, f (n - 1) < m → m < f n →
+    ∃ i j, i < j ∧ j < n ∧ isArithmeticProgression (f i) (f j) m
 
 /--
 **Stanley Sequence Avoids 3-AP:**
@@ -260,18 +271,15 @@ axiom stanley_avoids_3AP :
 /--
 **Problem Status:**
 Erdős Problem #197 remains open. We know:
-1. The three-set version is solvable (erdos_graham_three_sets)
-2. The problem cannot be resolved by finite computation
-3. Individual 3-AP-free sequences exist (powers_of_2_avoid_3AP)
+1. The three-set version is solvable (erdos_graham_three_sets, axiom)
+2. Individual 3-AP-free sequences exist (powers_of_2_avoid_3AP, proved)
+3. The two-set question is undecided (erdos_197_conjecture, by excluded middle)
 -/
 theorem erdos_197_status :
     (∃ A B C : Set ℕ, isThreePartition A B C ∧
       canPermuteTo3APFree A ∧ canPermuteTo3APFree B ∧ canPermuteTo3APFree C) ∧
     (∃ f : ℕ → ℕ, avoids3AP f) := by
-  constructor
-  · exact erdos_graham_three_sets
-  · use (fun n => 2 ^ n)
-    exact powers_of_2_avoid_3AP
+  exact ⟨erdos_graham_three_sets, ⟨fun n => 2 ^ n, powers_of_2_avoid_3AP⟩⟩
 
 /--
 **The Main Open Question:**

--- a/src/data/proofs/erdos-197/meta.json
+++ b/src/data/proofs/erdos-197/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-197",
-  "title": "Erdős Problem #197: Partition of ℕ Avoiding Monotone 3-AP Permutations",
+  "title": "Erd\u0151s Problem #197: Partition of \u2115 Avoiding Monotone 3-AP Permutations",
   "slug": "erdos-197",
-  "description": "Can ℕ be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions? This problem remains OPEN.",
+  "description": "Can \u2115 be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions? This problem remains OPEN.",
   "meta": {
-    "author": "Erdős-Graham (three-set case solved)",
+    "author": "Erd\u0151s-Graham (three-set case solved)",
     "sourceUrl": "https://erdosproblems.com/197",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos197Problem.lean",
@@ -42,10 +42,10 @@
       "isArithmeticProgression definition: a + c = 2 * b",
       "hasMonotone3AP definition: 3-AP in indexed sequence",
       "avoids3AP definition: sequence with no monotone 3-AP",
-      "isEnumeration definition: bijection from ℕ to a set",
+      "isEnumeration definition: bijection from \u2115 to a set",
       "canPermuteTo3APFree definition: set permutable to 3-AP-free",
-      "isTwoPartition definition: partition of ℕ into two disjoint sets",
-      "isThreePartition definition: partition of ℕ into three disjoint sets",
+      "isTwoPartition definition: partition of \u2115 into two disjoint sets",
+      "isThreePartition definition: partition of \u2115 into three disjoint sets",
       "erdos_197_conjecture axiom: the open two-set question",
       "erdos_graham_three_sets axiom: three sets suffice",
       "powers_of_2_avoid_3AP axiom: 2^n sequence is 3-AP-free",
@@ -54,15 +54,15 @@
       "erdos_197_status theorem: summary of known results",
       "erdos_197_open_question theorem: the main conjecture"
     ],
-    "axiomCount": 5,
+    "axiomCount": 2,
     "lineCount": 287,
-    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "2 axioms: erdos_graham_three_sets (deep combinatorial result), stanley_avoids_3AP (greedy construction). Previously 5 axioms; 3 eliminated by proving powers_of_2_avoid_3AP, erdos_197_conjecture (from classical logic), and removing malformed erdos_197_not_finite_checkable."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #197**\n\nThis problem originates from Erdős and Graham's foundational work on arithmetic progressions in the late 1970s and early 1980s, documented in [ErGr79] and [ErGr80].\n\n**Key History:**\n- Erdős and Graham posed the original question about partitioning ℕ\n- The three-set version was proved solvable by Erdős-Graham\n- The two-set version remains open and cannot be resolved by finite computation\n\n**Mathematical Setting:**\nA monotone 3-term arithmetic progression (3-AP) in a sequence f is a triple (i, j, k) with i < j < k where f(i), f(j), f(k) form an arithmetic progression. The question asks whether ℕ can be split into two parts, each rearrangeable to avoid such patterns.",
-    "problemStatement": "**Problem Statement (Open)**\n\nCan ℕ be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions?\n\n**Formal Statement:**\nDoes there exist A, B ⊆ ℕ with A ∩ B = ∅ and A ∪ B = ℕ such that both A and B admit enumerations f: ℕ → A and g: ℕ → B with no i < j < k satisfying f(i) + f(k) = 2f(j) or g(i) + g(k) = 2g(j)?\n\n**Answer: UNKNOWN**\n\nThe three-set version is solvable (Erdős-Graham), indicating a threshold phenomenon.",
-    "text": "Can ℕ be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions? This problem remains OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Arithmetic Progressions:** Define isArithmeticProgression and monotone 3-AP detection\n\n2. **Sequence Properties:** Define hasMonotone3AP and avoids3AP predicates\n\n3. **Set Permutations:** Define when a set can be permuted to avoid 3-APs\n\n4. **Partition Definitions:** isTwoPartition and isThreePartition\n\n5. **Main Results:**\n   - Axiomatize the open conjecture\n   - Axiomatize Erdős-Graham's three-set result\n   - Prove supporting properties\n\n6. **Examples:** Powers of 2, identity sequence, Stanley sequence",
+    "historicalContext": "**Erd\u0151s Problem #197**\n\nThis problem originates from Erd\u0151s and Graham's foundational work on arithmetic progressions in the late 1970s and early 1980s, documented in [ErGr79] and [ErGr80].\n\n**Key History:**\n- Erd\u0151s and Graham posed the original question about partitioning \u2115\n- The three-set version was proved solvable by Erd\u0151s-Graham\n- The two-set version remains open and cannot be resolved by finite computation\n\n**Mathematical Setting:**\nA monotone 3-term arithmetic progression (3-AP) in a sequence f is a triple (i, j, k) with i < j < k where f(i), f(j), f(k) form an arithmetic progression. The question asks whether \u2115 can be split into two parts, each rearrangeable to avoid such patterns.",
+    "problemStatement": "**Problem Statement (Open)**\n\nCan \u2115 be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions?\n\n**Formal Statement:**\nDoes there exist A, B \u2286 \u2115 with A \u2229 B = \u2205 and A \u222a B = \u2115 such that both A and B admit enumerations f: \u2115 \u2192 A and g: \u2115 \u2192 B with no i < j < k satisfying f(i) + f(k) = 2f(j) or g(i) + g(k) = 2g(j)?\n\n**Answer: UNKNOWN**\n\nThe three-set version is solvable (Erd\u0151s-Graham), indicating a threshold phenomenon.",
+    "text": "Can \u2115 be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions? This problem remains OPEN.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Arithmetic Progressions:** Define isArithmeticProgression and monotone 3-AP detection\n\n2. **Sequence Properties:** Define hasMonotone3AP and avoids3AP predicates\n\n3. **Set Permutations:** Define when a set can be permuted to avoid 3-APs\n\n4. **Partition Definitions:** isTwoPartition and isThreePartition\n\n5. **Main Results:**\n   - Axiomatize the open conjecture\n   - Axiomatize Erd\u0151s-Graham's three-set result\n   - Prove supporting properties\n\n6. **Examples:** Powers of 2, identity sequence, Stanley sequence",
     "keyInsights": [
       "**Threshold Phenomenon:** Three sets suffice, but two sets remain unknown",
       "**Non-Computability:** The problem cannot be resolved by checking finite cases",
@@ -93,7 +93,7 @@
     },
     {
       "id": "partitions",
-      "title": "Partitions of ℕ",
+      "title": "Partitions of \u2115",
       "summary": "isTwoPartition definition and partition_mem_iff theorem",
       "startLine": 91,
       "endLine": 122
@@ -149,14 +149,14 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #197 asks whether ℕ can be partitioned into two sets, each permutable to avoid monotone 3-term arithmetic progressions. The answer is UNKNOWN. We do know that three sets suffice (Erdős-Graham) and that the problem cannot be resolved by finite computation. The formalization captures the open conjecture as an axiom representing the disjunction of the two possible answers.",
+    "summary": "Erd\u0151s Problem #197 asks whether \u2115 can be partitioned into two sets, each permutable to avoid monotone 3-term arithmetic progressions. The answer is UNKNOWN. We do know that three sets suffice (Erd\u0151s-Graham) and that the problem cannot be resolved by finite computation. The formalization captures the open conjecture as an axiom representing the disjunction of the two possible answers.",
     "implications": "**Theoretical Significance**: **Combinatorial Number Theory Connections**\n\n1. **Ramsey Theory:** Related to coloring problems and unavoidable patterns\n\n2. **Density Bounds:** Connected to Roth's theorem on 3-AP-free sets\n\n**3. Permutation Avoidance:** Links to pattern avoidance in combinatorics\n\n4. **Threshold Phenomena:** The jump from 2 to 3 sets marks a structural boundary\n\n5. **Algorithmic Questions:** Stanley sequences and greedy constructions.",
     "openQuestions": [
       "Does the answer change for arithmetic progressions of length > 3?",
       "What is the minimum number of parts needed for length-k AP avoidance?",
       "Are there explicit constructions if the answer is YES?",
       "What density constraints exist on such partitions?",
-      "How does this relate to Szemerédi's theorem generalizations?"
+      "How does this relate to Szemer\u00e9di's theorem generalizations?"
     ]
   },
   "leanFile": {
@@ -173,9 +173,9 @@
       "Function"
     ],
     "namespace": "Erdos197",
-    "lineCount": 287,
-    "axiomCount": 5,
-    "theoremCount": 5,
+    "lineCount": 295,
+    "axiomCount": 2,
+    "theoremCount": 7,
     "definitionCount": 10
   }
 }

--- a/src/data/research/problems/erdos-197.json
+++ b/src/data/research/problems/erdos-197.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-197",
-  "title": "Erdős #197",
+  "title": "Erd\u0151s #197",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-12T16:01:50.837Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination: 5 -> 2 axioms",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,12 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "AXIOM HUNT: Reduced from 5 axioms to 2. Proved powers_of_2_avoid_3AP, erdos_197_conjecture (from classical logic), removed malformed erdos_197_not_finite_checkable. Fixed false constant_avoids_3AP theorem. Fixed broken Mathlib imports.",
+    "builtItems": [
+      "Proved powers_of_2_avoid_3AP: 2^n avoids 3-APs (since j<k => 2^k >= 2*2^j)",
+      "Proved erdos_197_conjecture from Classical.em + De Morgan",
+      "Fixed constant_has_3AP (was incorrectly claiming constant sequences avoid 3-APs)",
+      "Fixed isStanleySequence definition (Nat.find API change)"
+    ],
+    "insights": [
+      "2^i + 2^k = 2*2^j is impossible for i<j<k because 2^k >= 2*2^j and 2^i >= 1",
+      "erdos_197_conjecture (P or not-P) is just excluded middle, not a real axiom",
+      "erdos_197_not_finite_checkable had a placeholder True making it malformed",
+      "constant_avoids_3AP was a false theorem: constant sequences DO have 3-APs"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #197 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nCan $\\mathbb{N}$ be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions?\n\n\n\nIf three sets are allowed then this is possible.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #196\n- Problem #198\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr79\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "nextSteps": [
+      "Could try to prove stanley_avoids_3AP (greedy construction argument)",
+      "erdos_graham_three_sets is the remaining deep axiom - needs serious combinatorics"
+    ],
+    "markdown": "# Erd\u0151s #197 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nCan $\\mathbb{N}$ be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions?\n\n\n\nIf three sets are allowed then this is possible.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #196\n- Problem #198\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr79\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
     "erdos"
@@ -50,7 +63,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T16:01:50.837Z",
-  "lastUpdate": "2026-03-13T07:52:17.044Z",
+  "lastUpdate": "2026-03-24T06:03:17.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- **Axiom elimination**: Reduced from 5 axioms to 2 in Erdős #197 formalization
- Proved `powers_of_2_avoid_3AP` from scratch (2^n avoids 3-APs)
- Proved `erdos_197_conjecture` from `Classical.em` (was trivial P∨¬P)
- Removed malformed `erdos_197_not_finite_checkable` (placeholder `True`)

## Progress
- `powers_of_2_avoid_3AP`: If i < j < k, then 2^k ≥ 2·2^j and 2^i ≥ 1, so 2^i + 2^k > 2·2^j, contradicting the AP equation
- `erdos_197_conjecture`: P ∨ ¬P follows from `by_cases` (classical logic), not a mathematical axiom
- Fixed `constant_avoids_3AP` → `constant_has_3AP` (constant sequences DO have 3-APs, the old theorem was false)
- Fixed broken `Mathlib.Data.Set.Finite` import and `Nat.find` API change

## Remaining Axioms (2)
1. `erdos_graham_three_sets`: Deep combinatorial result (ℕ CAN be 3-partitioned AP-free)
2. `stanley_avoids_3AP`: Greedy construction produces AP-free sequence

## Status
**Outcome**: progress (axiom elimination)
**Axioms**: 5 → 2

🤖 Generated by researcher-2