### PR TITLE
Research: erdos-792 - Prove interval_sum_free, axioms 11→10

### DIFF
--- a/proofs/Proofs/Erdos792Problem.lean
+++ b/proofs/Proofs/Erdos792Problem.lean
@@ -89,9 +89,13 @@ axiom f_asymptotic : Tendsto (fun n => (f n : ℝ) / n) atTop (nhds (1 / 3))
 
 -- Examples and Constructions
 
-/-- The interval [n, 2n-1] is sum-free since a + b ≥ 2n > 2n - 1 for a, b in the interval -/
-axiom interval_sum_free : ∀ n : ℕ, n ≥ 1 →
-  SumFreeFinset (Finset.Icc (n : ℤ) (2 * n - 1))
+/-- The interval [n, 2n-1] is sum-free since a + b ≥ 2n > 2n - 1 for a, b in the interval.
+    Proof: if a, b ∈ [n, 2n-1], then a+b ≥ 2n > 2n-1 ≥ c for any c ∈ [n, 2n-1]. -/
+theorem interval_sum_free : ∀ n : ℕ, n ≥ 1 →
+    SumFreeFinset (Finset.Icc (n : ℤ) (2 * n - 1)) := by
+  intro n hn a ha b hb c hc hab
+  simp [Finset.mem_Icc] at ha hb hc
+  omega
 
 /-- Middle-third construction: every finite set A has a sum-free subset of size ≥ |A|/3 -/
 axiom middle_third_construction : ∀ A : Finset ℤ,

--- a/src/data/proofs/erdos-792/meta.json
+++ b/src/data/proofs/erdos-792/meta.json
@@ -61,9 +61,9 @@
       "erdos_792_bounds: summary combining bounds",
       "erdos_792_lower_bound_chain: chain of lower bounds"
     ],
-    "axiomCount": 11,
-    "lineCount": 116,
-    "assumptions": "11 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 10,
+    "lineCount": 119,
+    "assumptions": "10 axioms: f (function), f_spec/f_tight (defining properties), erdos_lower_bound/alon_kleitman_bound/bourgain_bound/bedert_bound (lower bounds), egm_upper_bound/f_asymptotic (upper bounds), middle_third_construction (construction). Formerly 11 — interval_sum_free proved by omega."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #792: Sum-Free Subsets**\n\nThis fundamental problem in additive combinatorics asks about guaranteed sum-free subsets. A set is sum-free if no element equals the sum of two others.\n\n**Historical Timeline:**\n- Erdős (1965): Established basic bound f(n) >= n/3 using the 'middle third' construction\n- Alon & Kleitman (1990): Improved to f(n) >= (n+1)/3\n- Bourgain (1997): Further improved to f(n) >= (n+2)/3\n- Eberhard, Green & Manners (2014): Proved f(n) <= n/3 + o(n), showing main term is optimal\n- Bedert (2025): Achieved f(n) >= n/3 + c*log log n, the current best lower bound\n\n**Significance:** This is Problem 1 on Ben Green's open problems list, indicating its central importance to the field. The exact second-order term remains unknown.",
@@ -168,9 +168,9 @@
       "Filter"
     ],
     "namespace": "Erdos792",
-    "lineCount": 116,
-    "axiomCount": 11,
-    "theoremCount": 2,
+    "lineCount": 119,
+    "axiomCount": 10,
+    "theoremCount": 3,
     "definitionCount": 4
   }
 }


### PR DESCRIPTION
## Summary
- Converted `interval_sum_free` axiom to **theorem** with proof
- Proof: for a,b ∈ [n, 2n-1], a+b ≥ 2n > 2n-1 ≥ c, so a+b ≠ c
- Tactic: `simp [Finset.mem_Icc]` then `omega`
- **Axiom count reduced from 11 to 10**

## The Proof
```lean
theorem interval_sum_free : ∀ n : ℕ, n ≥ 1 →
    SumFreeFinset (Finset.Icc (n : ℤ) (2 * n - 1)) := by
  intro n hn a ha b hb c hc hab
  simp [Finset.mem_Icc] at ha hb hc
  omega
```

## Status
**Outcome**: completed (axiom elimination)

Generated by researcher-7