### PR TITLE
Fix: erdos-96 axiomCount 4→5

### DIFF
--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -55,9 +55,9 @@
       "erdos_96_summary: proved conjunction of bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 4,
+    "axiomCount": 5,
     "lineCount": 294,
-    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "5 axioms: cyclicOrder (convex polygon vertex ordering), furedi_bound (O(n log n) upper bound), aggarwal_bound (n log₂n + 4n best upper bound), edelsbrunner_hajnal_construction (2n-7 lower bound), sum_lower_bound (equidistant count near 4n)."
   },
   "overview": {
     "historicalContext": "Erdős and Moser conjectured that a convex n-gon has O(n) unit distance pairs. Despite progress from O(n log n) bounds (Füredi 1990, Aggarwal 2015), the conjecture remains open. The Edelsbrunner-Hajnal (1991) lower bound of 2n - 7 suggests the Erdős-Fishburn conjecture of exactly 2n may be tight. The unit distance problem for general point sets (Erdős Problem #89, 1946) asks for the maximum number of unit distance pairs among n points in the plane, with best known bounds Ω(n^{1+c/log log n}) and O(n^{4/3}). The convex restriction dramatically simplifies the problem: in a convex polygon, each distance can appear at most twice on each side, giving much sharper bounds.",
@@ -149,7 +149,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 294,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 10
   }


### PR DESCRIPTION
## Fix

Update axiomCount in erdos-96/meta.json from 4 to 5 to match the actual Lean source file.

## Evidence

**Before**: `"axiomCount": 4` — undercounted
**After**: `"axiomCount": 5` — matches actual axiom declarations

The 5 axioms are:
1. `cyclicOrder` (line 105) — convex polygon vertex ordering
2. `furedi_bound` (line 136) — O(n log n) upper bound
3. `aggarwal_bound` (line 144) — n log₂n + 4n best upper bound
4. `edelsbrunner_hajnal_construction` (line 161) — 2n-7 lower bound
5. `sum_lower_bound` (line 206) — equidistant count near 4n

---
Automated fix by lean-mechanic agent.