### PR TITLE
Research: erdos-936 - Prove 4 redundant axioms, 7→3

### DIFF
--- a/proofs/Proofs/Erdos936Problem.lean
+++ b/proofs/Proofs/Erdos936Problem.lean
@@ -231,41 +231,25 @@ axiom crowdmath_theorem :
 ## Part V: The Four Variants of Erdős #936
 -/
 
-/--
-**Erdős #936 Variant 1:**
-Is 2^n + 1 powerful for only finitely many n?
+/-- **Erdős #936 Variant 1** (from CrowdMath 2020): 2^n + 1 eventually not powerful. -/
+theorem erdos_936_two_pow_add_one :
+    abc_conjecture_holds → EventuallyNotPowerful (fun n => 2^n + 1) :=
+  fun h => (crowdmath_theorem h).1
 
-Conditionally YES (assuming ABC).
--/
-axiom erdos_936_two_pow_add_one :
-    abc_conjecture_holds → EventuallyNotPowerful (fun n => 2^n + 1)
+/-- **Erdős #936 Variant 2** (from CrowdMath 2020): 2^n - 1 eventually not powerful. -/
+theorem erdos_936_two_pow_sub_one :
+    abc_conjecture_holds → EventuallyNotPowerful (fun n => 2^n - 1) :=
+  fun h => (crowdmath_theorem h).2
 
-/--
-**Erdős #936 Variant 2:**
-Is 2^n - 1 powerful for only finitely many n?
+/-- **Erdős #936 Variant 3** (from Cushing-Pascoe 2016): n! + 1 eventually not powerful. -/
+theorem erdos_936_factorial_add_one :
+    abc_conjecture_holds → EventuallyNotPowerful (fun n => n! + 1) :=
+  fun h => (cushing_pascoe_theorem h).1
 
-Conditionally YES (assuming ABC).
--/
-axiom erdos_936_two_pow_sub_one :
-    abc_conjecture_holds → EventuallyNotPowerful (fun n => 2^n - 1)
-
-/--
-**Erdős #936 Variant 3:**
-Is n! + 1 powerful for only finitely many n?
-
-Conditionally YES (assuming ABC).
--/
-axiom erdos_936_factorial_add_one :
-    abc_conjecture_holds → EventuallyNotPowerful (fun n => n! + 1)
-
-/--
-**Erdős #936 Variant 4:**
-Is n! - 1 powerful for only finitely many n?
-
-Conditionally YES (assuming ABC).
--/
-axiom erdos_936_factorial_sub_one :
-    abc_conjecture_holds → EventuallyNotPowerful (fun n => n! - 1)
+/-- **Erdős #936 Variant 4** (from Cushing-Pascoe 2016): n! - 1 eventually not powerful. -/
+theorem erdos_936_factorial_sub_one :
+    abc_conjecture_holds → EventuallyNotPowerful (fun n => n! - 1) :=
+  fun h => (cushing_pascoe_theorem h).2
 
 /--
 **All Four Variants Combined:**

--- a/src/data/proofs/erdos-936/meta.json
+++ b/src/data/proofs/erdos-936/meta.json
@@ -61,9 +61,9 @@
       "Squarefree' definition and its relation to powerful numbers",
       "erdos_936_summary: complete status of the problem"
     ],
-    "axiomCount": 7,
-    "lineCount": 343,
-    "assumptions": "7 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 3,
+    "lineCount": 327,
+    "assumptions": "3 axioms: abc_conjecture_holds (the unproven ABC conjecture as a Prop), cushing_pascoe_theorem (2016: ABC → n!±1 eventually not powerful), crowdmath_theorem (2020: ABC → 2^n±1 eventually not powerful). The four variant axioms have been PROVED from these two conditional theorems."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #936**\n\nThis problem was posed by Paul Erdős in 1976 [Er76d, p.32] and concerns powerful numbers near special sequences.\n\n**Key History:**\n- Erdős (1976): Original problem formulation\n- Cushing-Pascoe (2016): Proved n! ± 1 case assuming ABC conjecture\n- CrowdMath (2020): Extended to 2^n ± 1 case assuming ABC conjecture\n\n**Mathematical Setting:**\nA number m is *powerful* if whenever a prime p divides m, then p² also divides m. Equivalently, m = a²b³ for positive integers a, b. The powerful numbers begin: 1, 4, 8, 9, 16, 25, 27, 32, 36, ...\n\nThe problem asks whether the sequences 2^n + 1, 2^n - 1, n! + 1, and n! - 1 are powerful for only finitely many n. This is connected to the ABC conjecture, one of the deepest unsolved problems in number theory.",
@@ -160,9 +160,9 @@
       "Finset"
     ],
     "namespace": "Erdos936",
-    "lineCount": 343,
-    "axiomCount": 7,
-    "theoremCount": 23,
+    "lineCount": 327,
+    "axiomCount": 3,
+    "theoremCount": 27,
     "definitionCount": 3
   }
 }


### PR DESCRIPTION
## Summary
- Four variant axioms were redundant — they follow directly from two parent conditional theorems
- Proved all four as term-mode theorems (e.g., `fun h => (crowdmath_theorem h).1`)
- **Axiom count reduced from 7 to 3**

## Proofs
- `erdos_936_two_pow_add_one` := `(crowdmath_theorem h).1`
- `erdos_936_two_pow_sub_one` := `(crowdmath_theorem h).2`
- `erdos_936_factorial_add_one` := `(cushing_pascoe_theorem h).1`
- `erdos_936_factorial_sub_one` := `(cushing_pascoe_theorem h).2`

## Remaining Axioms (3)
1. `abc_conjecture_holds` — the unproven ABC conjecture
2. `cushing_pascoe_theorem` — ABC → n!±1 eventually not powerful
3. `crowdmath_theorem` — ABC → 2^n±1 eventually not powerful

Generated by researcher-7