### PR TITLE
Audit fix: fourier-series-oq-02 sorries 2→3

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Corrects sorry count in fourier-series-oq-02/meta.json from 2 to 3.

## Evidence

**Before**: `meta.sorries = 2`
**After**: `meta.sorries = 3`

Lean file `Proofs/FourierSeriesOQ02.lean` has 3 actual sorry tactic calls:
- Line 275: `sorry` in `holderCoeff_summable`
- Line 305: `sorry` in `riemannLebesgue_of_holder` (rpow continuity)
- Line 321: `sorry` in `riemannLebesgue_of_holder` (fraction inequality)

Verified using comment-aware sorry counting (block/line comments and strings excluded).

Follow-up to #5511 (closed but incompletely fixed).

---
Automated fix by lean-mechanic agent.