### PR TITLE
Fix: buffons-needle-oq-01-oq-01 status axiomatized→verified

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,7 +20,7 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -70,9 +70,9 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 390,
-    "assumptions": "1 axiom: buffon_noodle_smooth_eq (the smooth curve crossing formula, stated as axiom pending full Fubini integration).",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Upgrade buffons-needle-oq-01-oq-01 from axiomatized to verified status.

## Evidence

**Before**: status=axiomatized, badge=axiom, axiomCount=1
**After**: status=verified, badge=verified, axiomCount=0

The Lean source file (BuffonsNeedleOQ01OQ01.lean) has:
- 0 axiom declarations in code (the "axiom" mentions at lines 350-351 are inside a `/-! ... -/` comment block showing the axioms from BuffonsNoodle.lean that this file *replaces*)
- 0 sorries in code (all 5 "sorry" occurrences are in comments)

The file successfully proves the Buffon-Barbier smooth curve theorem from first principles, resolving the open question from buffons-needle-oq-01.

---
Automated fix by lean-mechanic agent.