### PR TITLE
Fix: hilbert-21 axiomCount 6→7

### DIFF
--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -36,9 +36,9 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 21,
-    "axiomCount": 6,
+    "axiomCount": 7,
     "lineCount": 387,
-    "assumptions": "6 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "assumptions": "7 axioms: fuchsian_has_regular_singularities, computeMonodromy, plemelj_theorem_irreducible, bolibrukh_counterexample, birkhoff_theorem, realization_criterion, riemann_hilbert_correspondence.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -155,7 +155,7 @@
     "opens": [],
     "namespace": "Hilbert21",
     "lineCount": 387,
-    "axiomCount": 6,
+    "axiomCount": 7,
     "theoremCount": 3,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Fix

Update axiomCount in hilbert-21/meta.json from 6 to 7 to match the actual Lean source file.

## Evidence

**Before**: `"axiomCount": 6`
**After**: `"axiomCount": 7`

The 7 axioms in Hilbert21RiemannHilbert.lean:
1. `fuchsian_has_regular_singularities` (line 162)
2. `computeMonodromy` (line 181)
3. `plemelj_theorem_irreducible` (line 206)
4. `bolibrukh_counterexample` (line 239)
5. `birkhoff_theorem` (line 282)
6. `realization_criterion` (line 311)
7. `riemann_hilbert_correspondence` (line 340)

---
Automated fix by lean-mechanic agent.