### PR TITLE
Research: erdos-768 - fix math error (6∉A), reduce axioms 8→6

### DIFF
--- a/proofs/Proofs/Erdos768Problem.lean
+++ b/proofs/Proofs/Erdos768Problem.lean
@@ -49,11 +49,12 @@ def inSetA' (n : ℕ) : Prop :=
 theorem one_in_setA : 1 ∈ setA := by
   constructor
   · norm_num
-  · intro p hp hdiv
-    intro _ _
-    have : p = 1 := Nat.eq_one_of_pos_of_self_mul_self_le (Nat.Prime.pos hp) 
-      (by simpa using hdiv)
-    exact absurd this (Nat.Prime.ne_one hp)
+  · intro p hp hdiv _ _
+    -- p | 1 implies p ≤ 1, but p.Prime implies p ≥ 2: contradiction
+    exfalso
+    have h1 := Nat.le_of_dvd (by norm_num) hdiv
+    have h2 := hp.two_le
+    omega
 
 /-- Prime powers are NOT in A (no d > 1 with d ≡ 1 mod p can divide p^k) -/
 theorem prime_power_not_in_setA (p : ℕ) (k : ℕ) (hp : p.Prime) (hk : k ≥ 1) :
@@ -62,9 +63,19 @@ theorem prime_power_not_in_setA (p : ℕ) (k : ℕ) (hp : p.Prime) (hk : k ≥ 1
   have hpdiv : p ∣ p^k := dvd_pow_self p (Nat.one_le_iff_ne_zero.mp hk)
   specialize hA p hp hpdiv hp hpdiv
   obtain ⟨d, hd1, hdiv, hmod⟩ := hA
-  -- d | p^k means d = p^j for some j
-  -- d ≡ 1 (mod p) and d > 1 is impossible for d = p^j
-  sorry
+  -- d | p^k and d > 1 means p | d (since p is the only prime factor of p^k)
+  have hd_ne_one : d ≠ 1 := by omega
+  obtain ⟨q, hq_prime, hq_dvd_d⟩ := Nat.exists_prime_and_dvd hd_ne_one
+  have hq_dvd_pk : q ∣ p ^ k := dvd_trans hq_dvd_d hdiv
+  have hq_dvd_p : q ∣ p := hq_prime.dvd_of_dvd_pow hq_dvd_pk
+  have hq_eq_p : q = p := by
+    rcases hp.eq_one_or_self_of_dvd q hq_dvd_p with h | h
+    · exact absurd h hq_prime.ne_one
+    · exact h
+  have hp_dvd_d : p ∣ d := hq_eq_p ▸ hq_dvd_d
+  -- p | d means d % p = 0, but we assumed d % p = 1
+  rw [Nat.dvd_iff_mod_eq_zero] at hp_dvd_d
+  omega
 
 /-- Products of distinct primes p where (p-1) | n can be in A -/
 theorem product_special_primes_in_setA (ps : List ℕ) 
@@ -82,6 +93,7 @@ Let A(N) = |A ∩ [1,N]|. The question is about the asymptotic behavior of A(N)/
 
 /-- Count of elements of A up to N -/
 noncomputable def countA (N : ℕ) : ℕ :=
+  haveI : DecidablePred inSetA := Classical.decPred _
   (Finset.filter inSetA (Finset.range (N + 1))).card
 
 /-- The density of A up to N -/
@@ -134,12 +146,12 @@ of non-cyclic simple groups.
 
 /-- n is the order of a simple group -/
 def isSimpleGroupOrder (n : ℕ) : Prop :=
-  ∃ G : Type*, ∃ _ : Group G, ∃ _ : Fintype G, 
+  ∃ (G : Type) (_ : Group G) (_ : Fintype G),
     Fintype.card G = n ∧ IsSimpleGroup G
 
 /-- n is the order of a non-cyclic simple group -/
 def isNonCyclicSimpleGroupOrder (n : ℕ) : Prop :=
-  isSimpleGroupOrder n ∧ ¬∃ G : Type*, ∃ _ : Group G, ∃ _ : Fintype G,
+  isSimpleGroupOrder n ∧ ¬∃ (G : Type) (_ : Group G) (_ : Fintype G),
     Fintype.card G = n ∧ IsSimpleGroup G ∧ IsCyclic G
 
 /-- Orders of non-cyclic simple groups are in A -/
@@ -159,10 +171,6 @@ theorem squarefree_part_structure (n : ℕ) (p : ℕ)
     ∃ q : ℕ, q.Prime ∧ q ∣ n ∧ q ≠ p ∧ q % p = 1 := by
   -- The witness d ≡ 1 (mod p) with d > 1 and d | n must have a prime factor q ≡ 1 (mod p)
   sorry
-
-/-- The smallest element of A greater than 1 -/
-axiom smallest_nontrivial_in_setA :
-  ∃ n : ℕ, n > 1 ∧ n ∈ setA ∧ ∀ m : ℕ, 1 < m → m < n → m ∉ setA
 
 /-
 ## Asymptotic Analysis
@@ -188,21 +196,65 @@ OEIS A001034 lists orders of non-cyclic simple groups.
 OEIS A352287 lists elements of A.
 -/
 
-/-- Some small elements of A (OEIS A352287) -/
-axiom small_elements_of_A :
-  1 ∈ setA ∧ 6 ∈ setA ∧ 12 ∈ setA ∧ 56 ∈ setA
+/-- 6 = 2 × 3 is NOT in A: for p=3, no d > 1 divides 6 with d ≡ 1 (mod 3).
+    (The divisors of 6 > 1 are {2, 3, 6}; 2%3=2, 3%3=0, 6%3=0.) -/
+theorem six_not_in_setA : 6 ∉ setA := by
+  intro ⟨_, hA⟩
+  have := hA 3 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  obtain ⟨d, hd1, hdiv, hmod⟩ := this
+  -- d | 6 and d > 1 means d ∈ {2, 3, 6}
+  have hdle : d ≤ 6 := Nat.le_of_dvd (by norm_num) hdiv
+  interval_cases d <;> omega
 
-/-- 6 = 2 × 3 is in A because 3 ≡ 1 (mod 2) -/
-theorem six_in_setA : 6 ∈ setA := by
+/-- 12 = 2² × 3 is in A: for p=2, d=3 (3≡1 mod 2); for p=3, d=4 (4≡1 mod 3) -/
+theorem twelve_in_setA : 12 ∈ setA := by
   constructor
   · norm_num
-  · intro p hp hdiv
-    intro _ _
-    interval_cases p
-    all_goals {
-      use 3
-      constructor <;> norm_num
-    }
+  · intro p hp hdiv _ _
+    have hp_le : p ≤ 12 := Nat.le_of_dvd (by norm_num) hdiv
+    interval_cases p <;> first
+      | exact ⟨3, by omega, by omega, by omega⟩
+      | exact ⟨4, by omega, by omega, by omega⟩
+      | (exfalso; revert hp hdiv; norm_num)
+
+/-- 56 = 2³ × 7 is in A: for p=2, d=7 (7≡1 mod 2); for p=7, d=8 (8≡1 mod 7) -/
+theorem fiftysix_in_setA : 56 ∈ setA := by
+  constructor
+  · norm_num
+  · intro p hp hdiv _ _
+    have hp_le : p ≤ 56 := Nat.le_of_dvd (by norm_num) hdiv
+    interval_cases p <;> first
+      | exact ⟨7, by omega, by omega, by omega⟩
+      | exact ⟨8, by omega, by omega, by omega⟩
+      | (exfalso; revert hp hdiv; norm_num)
+
+/-- Some small elements of A (OEIS A352287). Originally axiomatized; now proved. -/
+theorem small_elements_of_A :
+  1 ∈ setA ∧ 12 ∈ setA ∧ 56 ∈ setA :=
+  ⟨one_in_setA, twelve_in_setA, fiftysix_in_setA⟩
+
+/-- The smallest element of A greater than 1 is 12.
+    2-11 are excluded: 2,3,5,7,11 are primes; 4,8,9 are prime powers;
+    6 fails at p=3; 10 fails at p=5. -/
+theorem smallest_nontrivial_in_setA :
+  ∃ n : ℕ, n > 1 ∧ n ∈ setA ∧ ∀ m : ℕ, 1 < m → m < n → m ∉ setA := by
+  refine ⟨12, by norm_num, twelve_in_setA, fun m hm1 hm12 => ?_⟩
+  interval_cases m
+  · exact prime_power_not_in_setA 2 1 (by norm_num) (by omega)
+  · exact prime_power_not_in_setA 3 1 (by norm_num) (by omega)
+  · exact prime_power_not_in_setA 2 2 (by norm_num) (by omega)
+  · exact prime_power_not_in_setA 5 1 (by norm_num) (by omega)
+  · exact six_not_in_setA
+  · exact prime_power_not_in_setA 7 1 (by norm_num) (by omega)
+  · exact prime_power_not_in_setA 2 3 (by norm_num) (by omega)
+  · exact prime_power_not_in_setA 3 2 (by norm_num) (by omega)
+  · -- 10 = 2 × 5: fails at p=5 (divisors > 1: {2, 5, 10}; none ≡ 1 mod 5)
+    intro ⟨_, hA⟩
+    have := hA 5 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+    obtain ⟨d, hd1, hdiv, hmod⟩ := this
+    have hdle : d ≤ 10 := Nat.le_of_dvd (by norm_num) hdiv
+    interval_cases d <;> omega
+  · exact prime_power_not_in_setA 11 1 (by norm_num) (by omega)
 
 /-
 ## Main Open Problem Statement

--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1002",
     "date": "",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1002Problem.lean",
     "tags": [
       "analysis",
@@ -16,16 +16,15 @@
       "distribution-functions",
       "fractional-parts"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 0,
-    "lineCount": 1,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
-    "mathlib_version": "4.26.0"
+    "axiomCount": 7,
+    "lineCount": 211,
+    "assumptions": "7 axioms: erdos_1002_conjecture (the OPEN main conjecture), cauchy_is_distribution (Cauchy CDF properties), kesten_theorem (Kesten 1960 two-parameter result), f_bounded_for_irrational (boundedness), innerSum_log_bound (log-scale bound), weyl_equidistribution (Weyl 1916), innerSum_periodic_rational (periodicity for rationals)."
   },
   "overview": {
     "historicalContext": "**Fractional Parts in Number Theory**\n\nThe study of fractional parts $\\{n\\alpha\\}$ for irrational $\\alpha$ is central to Diophantine approximation. Hermann Weyl's equidistribution theorem (1916) established that $\\{\\alpha\\}, \\{2\\alpha\\}, \\{3\\alpha\\}, \\ldots$ is uniformly distributed in $[0,1)$, a foundational result connecting number theory to ergodic theory.\n\n**Gauss and Continued Fractions**: Carl Friedrich Gauss studied the map $T(x) = \\{1/x\\}$ on $(0,1)$, discovering its invariant measure $d\\mu = dx/(\\log 2 \\cdot (1+x))$. The Gauss-Kuzmin theorem (Kuzmin 1928, Lévy 1929) describes the rate at which iterates of $T$ converge to this measure.\n\n**Erdős's Question**: Erdős asked whether $f(\\alpha, n) = \\frac{1}{\\log n}\\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\})$ has an asymptotic distribution function — does the proportion of $\\alpha$ with $f(\\alpha, n) \\le c$ converge as $n \\to \\infty$?\n\n**Kesten's Breakthrough**: Harry Kesten (1960) proved the two-parameter variant $f(\\alpha, \\beta, n) = \\frac{1}{\\log n}\\sum(1/2 - \\{\\beta + \\alpha k\\})$ has a Cauchy limit distribution $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + 1/2$, using the ergodic properties of the natural extension of the Gauss map. The extra parameter $\\beta$ provides the independence needed for the ergodic argument. Fixing $\\beta = 0$ destroys this independence, and the one-parameter problem remains **OPEN**.",
@@ -48,72 +47,72 @@
     {
       "id": "fractional-part",
       "title": "Fractional Part",
-      "summary": "$\\{x\\} = x - \\lfloor x \\rfloor$ fractional part definition and basic properties",
-      "startLine": 24,
-      "endLine": 1
+      "summary": "$\\{x\\} = x - \\lfloor x \\rfloor$ fractional part definition and deviation from midpoint",
+      "startLine": 34,
+      "endLine": 41
     },
     {
       "id": "weighted-sum",
       "title": "The Weighted Sum f(α, n)",
       "summary": "$S(\\alpha, n) = \\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\})$ and $f(\\alpha, n) = S(\\alpha, n)/\\log n$",
-      "startLine": 39,
-      "endLine": 1
+      "startLine": 43,
+      "endLine": 57
     },
     {
       "id": "distribution-functions",
       "title": "Distribution Functions",
       "summary": "$g : \\mathbb{R} \\to [0,1]$ non-decreasing with $g(-\\infty) = 0$, $g(+\\infty) = 1$",
-      "startLine": 56,
-      "endLine": 1
+      "startLine": 59,
+      "endLine": 70
     },
     {
       "id": "asymptotic-distribution",
       "title": "Asymptotic Distribution",
       "summary": "Level set $L(n,c) = \\{\\alpha : f(\\alpha,n) \\le c\\}$ and $\\mu(L(n,c)) \\to g(c)$ convergence",
-      "startLine": 70,
-      "endLine": 1
+      "startLine": 72,
+      "endLine": 90
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture (OPEN)",
       "summary": "OPEN: $\\exists\\, g,\\; \\mu(\\{\\alpha : f(\\alpha,n) \\le c\\}) \\to g(c)$ as $n \\to \\infty$",
-      "startLine": 90,
-      "endLine": 1
+      "startLine": 92,
+      "endLine": 99
     },
     {
       "id": "kesten-theorem",
       "title": "Kesten's Theorem (1960)",
-      "summary": "Kesten (1960): $f(\\alpha, \\beta, n)$ has Cauchy limit $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$",
-      "startLine": 103,
-      "endLine": 1
+      "summary": "Kesten (1960): Two-parameter variant has Cauchy limit $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$",
+      "startLine": 101,
+      "endLine": 140
     },
     {
       "id": "relationship",
       "title": "Relationship Between Problems",
-      "summary": "$f(\\alpha, n) = f(\\alpha, 0, n)$: one-parameter case is $\\beta = 0$ specialization",
-      "startLine": 135,
-      "endLine": 1
+      "summary": "$f(\\alpha, n) = f(\\alpha, 0, n)$: one-parameter case is $\\beta = 0$ specialization (proved)",
+      "startLine": 142,
+      "endLine": 152
     },
     {
       "id": "difficulty",
       "title": "Why the Problem is Difficult",
-      "summary": "Fixing $\\beta = 0$ destroys ergodic independence; Weyl equidistribution and oscillation for fixed $\\alpha$",
-      "startLine": 147,
-      "endLine": 1
+      "summary": "Boundedness of $f$ for irrational $\\alpha$ and $|S(\\alpha, n)| \\le C \\log n$ bound",
+      "startLine": 154,
+      "endLine": 167
     },
     {
       "id": "partial-results",
       "title": "Partial Results",
-      "summary": "$|f(\\alpha, n)| \\le C(\\alpha)$ boundedness and $|S(\\alpha, n)| \\le C \\log n$ continued fraction bound",
-      "startLine": 168,
-      "endLine": 1
+      "summary": "Weyl equidistribution implies sublinear growth; rational periodicity of inner sum",
+      "startLine": 169,
+      "endLine": 183
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Full problem formalization with 0 sorries; main conjecture OPEN (mathematical gap, not formalization gap)",
-      "startLine": 184,
-      "endLine": 1
+      "summary": "Complete formalization: 7 axioms, 0 sorries, 2 theorems; main conjecture OPEN (mathematical gap, not formalization gap)",
+      "startLine": 185,
+      "endLine": 211
     }
   ],
   "conclusion": {
@@ -232,12 +231,26 @@
     }
   ],
   "leanFile": {
-    "imports": [],
-    "opens": [],
-    "namespace": null,
-    "lineCount": 1,
-    "axiomCount": 0,
-    "theoremCount": 0,
-    "definitionCount": 0
+    "imports": [
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Order.Filter.AtTopBot.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan",
+      "Mathlib.Topology.Instances.Real.Basic",
+      "Mathlib.Data.Int.Floor"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Set",
+      "Filter",
+      "Real",
+      "Int"
+    ],
+    "namespace": "Erdos1002",
+    "lineCount": 211,
+    "axiomCount": 7,
+    "theoremCount": 2,
+    "definitionCount": 11
   }
 }

--- a/src/data/proofs/erdos-768/meta.json
+++ b/src/data/proofs/erdos-768/meta.json
@@ -16,7 +16,7 @@
       "group-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 768,
     "erdosUrl": "https://erdosproblems.com/768",
     "erdosProblemStatus": "open",
@@ -55,7 +55,7 @@
       "Erdős's bounds formalized as Filter.Tendsto statements",
       "Main conjecture as a disjunction: either the constant c exists or it doesn't"
     ],
-    "axiomCount": 8,
+    "axiomCount": 6,
     "lineCount": 230,
     "assumptions": "8 axiom(s) and 3 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
     "mathlib_version": "4.26.0"
@@ -160,7 +160,7 @@
     "opens": [],
     "namespace": "Erdos768",
     "lineCount": 230,
-    "axiomCount": 8,
+    "axiomCount": 6,
     "theoremCount": 5,
     "definitionCount": 10
   },

--- a/src/data/research/problems/erdos-768.json
+++ b/src/data/research/problems/erdos-768.json
@@ -29,11 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Fixed math error (6∉A, first nontrivial is 12). Reduced axioms 8→6, sorries 3→2. File now compiles.",
+    "builtItems": [
+      "Proved prime_power_not_in_setA (was sorry)",
+      "Proved six_not_in_setA (corrected math error: 6∉A)",
+      "Proved twelve_in_setA and fiftysix_in_setA (was axiom)",
+      "Proved smallest_nontrivial_in_setA = 12 (was axiom)",
+      "Fixed one_in_setA proof (removed nonexistent Nat lemma)",
+      "Fixed universe metavariable in isSimpleGroupOrder/isNonCyclicSimpleGroupOrder"
+    ],
+    "insights": [
+      "MATH FIX: 6 ∉ A (p=3 has no witness: divisors >1 of 6 are {2,3,6}, none ≡1 mod 3)",
+      "First nontrivial element of A is 12 (not 6). Elements: 1, 12, 24, 30, 36, 48, 56, ...",
+      "prime_power_not_in_setA: key step is p | d (via Nat.exists_prime_and_dvd), giving d%p=0≠1",
+      "Universe metavariable fix: use Type instead of Type* for isSimpleGroupOrder",
+      "DecidablePred fix: use Classical.decPred for Finset.filter on inSetA"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Fill product_special_primes_in_setA sorry (list/product reasoning)",
+      "Fill squarefree_part_structure sorry (number theory)"
+    ],
     "markdown": "# Erdős #768 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A\\subset\\mathbb{N}$ be the set of $n$ such that for every prime $p\\mid n$ there exists some $d\\mid n$ with $d>1$ such that $d\\equiv 1\\pmod{p}$. Is it true that there exists some constant $c>0$ such that for all large $N$\\[\\frac{\\lvert A\\cap [1,N]\\rvert}{N}=\\exp(-(c+o(1))\\sqrt{\\log N}\\log\\log N).\\]\n\n\n\nErd\\H{o}s could prove that there exists some constant $c>0$ such that for all large $N$\\[\\exp(-c\\sqrt{\\log N}\\log\\log N)\\leq \\frac{\\lvert A\\cap [1,N]\\rvert}{N}\\]and\\[\\frac{\\lvert A\\cap [1,N]\\rvert}{N}\\leq \\exp(-(1+o(1))\\sqrt{\\log N\\log\\log N}).\\]Erd\\H{o}s asked about this because $\\lvert A\\cap [1,N]\\rvert$ provides an upper bound for the number of integers $n\\leq N$ for which there is a non-cyclic simple group of order $n$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #767\n- Problem #769\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er74b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -50,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T08:32:32.167Z",
-  "lastUpdate": "2026-03-13T07:52:17.052Z",
+  "lastUpdate": "2026-03-23T07:00:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- Reopened from #5644 (accidentally closed during deployer rebase)
- erdos-768: fix math error, reduce axioms 8→6

## Test plan
- [x] Lean proof changes verified