### PR TITLE
Enrich gallery: add mathlib_version to 693 entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -70,6 +70,7 @@
       "Weighted AM-GM inequality (Mathlib)"
     ],
     "lineCount": 316,
+    "mathlib_version": "4.26.0",
     "relatedProblems": [
       {
         "id": "amgm-inequality-oq-03",

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -94,7 +94,8 @@
         "id": "brouwer-fixed-point-oq-02",
         "relationship": "Extension of brouwer fixed point"
       }
-    ]
+    ],
+    "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Luitzen Egbertus Jan Brouwer proved this theorem in 1911 in *Mathematische Annalen*. Earlier special cases were known: Poincaré proved a version for smooth maps in 1886, and Hadamard proved the 2D case in 1910 using degree theory. Brouwer's contribution was the full generalization to continuous maps in arbitrary dimension.\n\nThe result is beautifully intuitive: no matter how you continuously 'stir' a disk, some point must end up exactly where it started. Multiple proofs exist: Brouwer's original via degree theory, Sperner's 1928 combinatorial proof via his lemma on triangulations, Milnor's 1965 differential topology proof via Sard's theorem, and modern proofs via singular homology.\n\nThe theorem's applications are vast. John Nash used it in 1950 to prove equilibrium existence in non-cooperative games (Nobel Prize 1994). It guarantees solutions to differential equations via Schauder's extension to Banach spaces. In computational complexity, finding Brouwer fixed points is PPAD-complete (Papadimitriou 1994), explaining why Nash equilibrium computation is hard.\n\nIronically, Brouwer later founded **intuitionism** (1920s), rejecting the law of excluded middle and the non-constructive proof-by-contradiction his own theorem relies upon. He came to view the theorem as an example of mathematics that proves existence without construction — precisely what intuitionists object to.",

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -28,7 +28,8 @@
     ],
     "axiomCount": 4,
     "badge": "axiom",
-    "assumptions": "4 axiom(s): golden_ratio_conjecture (open), graham_disjoint_segments (deep), floor_3_2_odd/even_infinitely (open). erdos_349_characterization proved (tautology)."
+    "assumptions": "4 axiom(s): golden_ratio_conjecture (open), graham_disjoint_segments (deep), floor_3_2_odd/even_infinitely (open). erdos_349_characterization proved (tautology).",
+    "mathlib_version": "4.26.0"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -21,7 +21,8 @@
     "axiomCount": 5,
     "assumptions": "5 axiom declarations: erdos_turan_conjecture (basis implies unbounded), erdos_40_conjecture (density forces unbounded), problem_40_implies_28 (P40 implies P28), sidon_density_bound (Sidon set sqrt bound), b2g_density_bound (B2[g] density bound). Removed 2 trivial True axioms (random_heuristic, threshold_heuristic) and added 3 proved theorems.",
     "lineCount": 120,
-    "badge": "axiom"
+    "badge": "axiom",
+    "mathlib_version": "4.26.0"
   },
   "sections": [
     {


### PR DESCRIPTION
## Summary
- Added `mathlib_version: "4.26.0"` to 693 meta.json entries that were missing this field
- All 1515 gallery entries now consistently include the mathlib_version field matching `proofs/lakefile.toml`

## Test plan
- [x] JSON validation passes on all modified files
- [x] Verified sample entries have correct field value

🤖 Generated with [Claude Code](https://claude.com/claude-code)