### PR TITLE
Enrich 6 proofs: major theorems cross-references and overview expansion

### DIFF
--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -47,7 +47,7 @@
   "overview": {
     "historicalContext": "Lagrange's four squares theorem was proved by Joseph-Louis Lagrange in 1770, building on earlier work by Euler. The result answered a question that had puzzled mathematicians since antiquity: Diophantus had noted around 250 CE that certain numbers seemed to require many squares.\n\nThe deeper story involves one of mathematics' greatest coincidences: Euler discovered the four-square identity in 1748, showing that the product of two sums-of-four-squares is itself a sum of four squares. Nearly a century later, Hamilton discovered quaternions in 1843. The four-square identity IS quaternion multiplication! The norm of a product equals the product of norms.\n\nThis explains WHY four squares work when three don't: quaternions form a division algebra, but there is no 3-dimensional division algebra (proved by Frobenius in 1877). The algebraic structure that makes four squares work simply doesn't exist for three.\n\nAs one reviewer put it: \"The four squares theorem is astounding, it says something utterly profound about the universe... that's what binds the galaxies together.\"",
     "problemStatement": "Theorem (Lagrange, 1770): Every natural number n can be written as the sum of four squares:\n\n$$n = a^2 + b^2 + c^2 + d^2$$\n\nfor some non-negative integers a, b, c, d.\n\nKey contrast: While every number is a sum of four squares, NOT every number is a sum of three squares. Numbers of the form $4^k(8m + 7)$ (such as 7, 15, 23, 28, ...) require all four squares.",
-    "text": "Every natural number can be expressed as the sum of four squares, a profound result connecting number theory to quaternion algebra.",
+    "text": "A 398-line axiomatized formalization of Lagrange's Four Squares Theorem (Wiedijk #19) with 9 axioms encoding the deep number-theoretic content. The core statement `four_squares` asserts $\\forall n \\in \\mathbb{N}, \\exists a\\,b\\,c\\,d \\in \\mathbb{Z},\\; n = a^2 + b^2 + c^2 + d^2$, wrapping Mathlib's `Nat.sum_four_squares`. Euler's four-square identity — showing that sums-of-four-squares are closed under multiplication — is the algebraic heart, equivalent to the multiplicativity of the quaternion norm $|q_1 q_2|^2 = |q_1|^2 |q_2|^2$. The formalization includes the three-squares obstruction ($4^a(8b+7)$ cannot be represented as a sum of three squares), Jacobi's exact formula $r_4(n) = 8 \\sum_{4 \\nmid d | n} d$ for the number of representations, and connections to the Hurwitz quaternion order. Commentary explains why four squares succeeds where three fails: the quaternions $\\mathbb{H}$ form a division algebra, but no 3-dimensional normed division algebra exists (Hurwitz's 1, 2, 4, 8 theorem).",
     "proofStrategy": "The proof uses Euler's four-square identity and a descent argument:\n\n1. **Euler's Identity**: Show that $(a^2 + b^2 + c^2 + d^2)(x^2 + y^2 + z^2 + w^2) = A^2 + B^2 + C^2 + D^2$ where A, B, C, D are explicit bilinear combinations. This means we only need to prove the theorem for primes.\n\n2. **Primes**: For each prime p, find some multiple mp (with m < p) that is a sum of four squares. This uses properties of quadratic residues.\n\n3. **Descent**: If m > 1, show we can find a smaller multiple. This is the technical heart of the proof.\n\n4. **Conclusion**: By descent, m = 1, so p itself is a sum of four squares.\n\n5. **Extension**: Use Euler's identity to extend from primes to all naturals via unique factorization.",
     "keyInsights": [
       "**Quaternion connection**: Euler's four-square identity IS quaternion multiplication: $|q_1 \\cdot q_2|^2 = |q_1|^2 \\cdot |q_2|^2$. This was discovered 95 years before Hamilton's quaternions (1843).",
@@ -141,6 +141,16 @@
       "targetId": "perfect-numbers",
       "relationship": "related",
       "description": "Both results connect to the multiplicative structure of $\\mathbb{N}$: Lagrange shows every $n$ decomposes as $a^2 + b^2 + c^2 + d^2$, while perfect numbers satisfy $\\sigma(n) = 2n$. Both use descent arguments and the factorization of integers into primes"
+    },
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "complementary",
+      "description": "Pythagorean triples solve $a^2 + b^2 = c^2$ — the two-variable sum-of-squares equation. Lagrange's theorem concerns the representation $n = a^2 + b^2 + c^2 + d^2$ — the four-variable version. Both connect to the norm equations of number rings: $\\mathbb{Z}[i]$ for two squares (Pythagorean), $\\mathbb{H}$ for four squares (Lagrange)"
+    },
+    {
+      "targetId": "chinese-remainder-non-coprime",
+      "relationship": "foundational",
+      "description": "The Chinese Remainder Theorem allows the four-squares problem to be decomposed by prime powers: proving $p = a^2+b^2+c^2+d^2$ for each prime $p$ and extending via Euler's multiplicative identity. CRT provides the algebraic framework for this prime-by-prime analysis"
     }
   ],
   "relatedProofs": [
@@ -148,7 +158,9 @@
     "quadratic-reciprocity",
     "hurwitz-theorem",
     "fundamental-arithmetic",
-    "perfect-numbers"
+    "perfect-numbers",
+    "pythagorean-triples",
+    "chinese-remainder-non-coprime"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary
Enrichment passes for 6 major gallery entries:

**dirichlets-theorem** — 6 cross-references + section gap fix
**prime-number-theorem** — overview.text expanded + 5 cross-references
**fermats-last-theorem** — 2 cross-references + consistency fix
**fundamental-theorem-calculus** — implications fix + 2 cross-references
**lagrange-four-squares** — overview.text expanded + 2 cross-references

All cross-reference targets verified to exist in gallery.