### PR TITLE
Audit fix: euler-polyhedral-oq-02-oq-01 "verified" → "axiomatized" (CRITICAL)

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gauss%E2%80%93Bonnet_theorem",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/EulerPolyhedralOQ02OQ01.lean",
     "tags": [
       "gauss-bonnet",
@@ -20,7 +20,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -55,9 +55,9 @@
       "Morse theory: critical point counts constrained by Euler characteristic"
     ],
     "historicalContext": "The Gauss-Bonnet theorem is one of the deepest results connecting geometry and topology. Gauss (1827) discovered that Gaussian curvature is intrinsic (Theorema Egregium). Bonnet (1848) proved ∫K dA = 2πχ for closed surfaces. Chern (1944) generalized to 2n-manifolds using the Pfaffian of the curvature form. The theorem bridges local geometry (curvature) and global topology (Euler characteristic), and is a precursor to the Atiyah-Singer index theorem.",
-    "axiomCount": 0,
+    "axiomCount": 10,
     "lineCount": 786,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 sorries but 10 structure-encoded assumptions: Gauss-Bonnet theorem (CompactRiemannianSurface.gauss_bonnet), chi-genus formula (OrientableClosedSurface.chi_genus), Chern-Gauss-Bonnet (ChernGaussBonnetManifold), Gauss-Bonnet with boundary, geodesic polygon formula, constant curvature formula, geodesic triangle Gauss-Bonnet, Poincaré-Hopf index theorem, nonvanishing vector field index, Morse relation. Core differential geometry axiomatized due to Mathlib lacking Riemannian geometry.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -224,7 +224,7 @@
     ],
     "namespace": "SmoothGaussBonnet",
     "lineCount": 786,
-    "axiomCount": 0,
+    "axiomCount": 10,
     "theoremCount": 60,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Summary

**CRITICAL**: euler-polyhedral-formula-oq-02-oq-01 (Smooth Gauss-Bonnet Theorem) claimed `axiomCount: 0` with badge `"verified"` but has **10 structure-encoded assumptions**:

1. `CompactRiemannianSurface.gauss_bonnet` — ∫K dA = 2πχ
2. `OrientableClosedSurface.chi_genus` — χ = 2 - 2g
3. `ChernGaussBonnetManifold.chern_gauss_bonnet` — higher-dimensional generalization
4. `CompactSurfaceWithBoundary.gauss_bonnet_boundary` — boundary version
5. `GeodesicPolygon.gauss_bonnet_polygon` — polygon version
6. `ConstCurvatureGeodesicPolygon.curvature_is_K_area` — constant curvature formula
7. `GeodesicTriangle.gauss_bonnet_triangle` — triangle version
8. `VectorFieldOnSurface.poincare_hopf` — Poincaré-Hopf index theorem
9. `VectorFieldOnSurface.nonvanishing_index` — nonvanishing field index = 0
10. `MorseFunctionOnSurface.morse_relation` — Morse theory relation

Per Axiom Integrity Policy, structure-encoded hypotheses ARE mathematical assumptions.

## Changes

- `status`: `"verified"` → `"axiomatized"`
- `badge`: `"verified"` → `"axiom"`
- `axiomCount`: `0` → `10`
- `assumptions`: Updated to list all structure-encoded assumptions

## Note

The 20+ consequence theorems in the file ARE fully proved. The issue is only with the core axiomatized theorems from differential geometry (Mathlib lacks Riemannian geometry).

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders with `axiom` badge

---
Discovered during gallery integrity audit (Auditor cycle 7).