### PR TITLE
Audit fix: erdos-1072 axiomCount 9→8, schroeder-bernstein badge→mathlib

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1063,6 +1063,30 @@
       "lastAudited": "2026-03-24T06:04:35Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1072": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T06:24:08Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-96": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T06:24:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-21": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T06:24:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schroeder-bernstein": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T06:24:49Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   }
 }

--- a/src/data/proofs/erdos-1072/meta.json
+++ b/src/data/proofs/erdos-1072/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": 1072,
     "erdosUrl": "https://erdosproblems.com/1072",
     "erdosProblemStatus": "open",
-    "axiomCount": 9,
+    "axiomCount": 8,
     "lineCount": 125,
     "assumptions": "9 axiom(s). Proved: wilson_theorem (from Mathlib ZMod.wilsons_lemma) and f_le_pred (from Wilson). Removed wilson_prime_distinction (dubious claim). Remaining: 3 open conjectures + 4 small values + f_pos."
   },
@@ -222,7 +222,7 @@
     ],
     "namespace": null,
     "lineCount": 125,
-    "axiomCount": 9,
+    "axiomCount": 8,
     "theoremCount": 2,
     "definitionCount": 2
   }

--- a/src/data/proofs/schroeder-bernstein/meta.json
+++ b/src/data/proofs/schroeder-bernstein/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/SchroederBernstein.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -50,7 +50,7 @@
       "Function.Embedding and Equiv types in Lean/Mathlib"
     ],
     "lineCount": 198,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Core Schroeder-Bernstein theorem derived from Mathlib's Function.Embedding.schroeder_bernstein and Function.Embedding.antisymm. Original contributions include pedagogical examples and cardinal number corollaries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- Fix erdos-1072 axiomCount 9→8 (Lean file has exactly 8 axiom declarations)
- Fix schroeder-bernstein badge verified→mathlib (core theorem from Mathlib's Function.Embedding.schroeder_bernstein)
- 6 proofs audited total: 2 issues-fixed, 4 clean

## Proofs Fixed

| Proof | Issue | Fix |
|-------|-------|-----|
| erdos-1072 | axiomCount 9 but file has 8 `axiom` declarations | axiomCount 9→8 |
| schroeder-bernstein | Core SB theorem from Mathlib | badge verified→mathlib |

## Proofs Verified Clean

erdos-96, hilbert-21, cevas-theorem-oq-04, erdos-249

## Test plan

- [ ] Verify gallery pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)