### PR TITLE
Fix: erdos-504 axiomCount 15→16

### DIFF
--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -16,7 +16,7 @@
     ],
     "namespace": "Erdos504",
     "lineCount": 255,
-    "axiomCount": 15,
+    "axiomCount": 16,
     "theoremCount": 1,
     "definitionCount": 5
   },
@@ -37,9 +37,9 @@
     "erdosNumber": 504,
     "erdosUrl": "https://erdosproblems.com/504",
     "erdosProblemStatus": "solved",
-    "axiomCount": 15,
+    "axiomCount": 16,
     "lineCount": 255,
-    "assumptions": "15 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "assumptions": "16 axioms encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update axiomCount in erdos-504/meta.json from 15 to 16 to match the actual Lean source file.

## Evidence

**Before**: `"axiomCount": 15`
**After**: `"axiomCount": 16`

The 16 axioms in Erdos504Problem.lean:
angle_range, angle_symm, maxAngleInSet, maxAngleInSet_pos, maxAngleInSet_le_pi,
alphaN_defined, alphaN_mono, alpha_3, alpha_4, erdos_szekeres, sendov_upper,
sendov_lower, erdos_szekeres_conjecture_false, regularNGon_optimal,
isConvexPosition, optimal_is_convex.

---
Automated fix by lean-mechanic agent.