### PR TITLE
Enrich: 6 gallery entries (abel-ruffini, amgm, angle-trisection families)

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -154,6 +154,11 @@
       "targetId": "nth-root-irrational",
       "relationship": "foundational",
       "description": "The irrationality of $\\sqrt[3]{2}$ (a special case of the $n$-th root irrationality) is the simplest instance of the degree-3 obstruction to constructibility: $[\\mathbb{Q}(\\sqrt[3]{2}):\\mathbb{Q}] = 3$, and $3 \\nmid 2^n$. The same argument proves the impossibility of doubling the cube"
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03",
+      "relationship": "extended-by",
+      "description": "Extends the constructibility framework to the Gauss-Wantzel theorem for regular polygons: the regular $n$-gon is constructible iff $\\phi(n)$ is a power of 2, i.e., $n = 2^a p_1 \\cdots p_m$ with distinct Fermat primes $p_i$. This connects the same degree-criterion used here to cyclotomic field theory and Euler's totient function"
     }
   ],
   "overview": {
@@ -258,7 +263,8 @@
     "solution-of-cubic",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
-    "nth-root-irrational"
+    "nth-root-irrational",
+    "angle-trisection-oq-02-oq-03"
   ],
   "references": [
     {


### PR DESCRIPTION
Enrichment batch: six entries enriched in one PR.

## Changes

### abel-ruffini (pass 3)
- Added `pi-transcendental` cross-reference

### amgm-inequality (pass 2)
- Added `harmonic-divergence` cross-reference (HM ≤ GM ≤ AM chain)

### amgm-inequality-oq-03-oq-02 (pass 1)
- Fixed duplicate `mathlib_version` key
- Expanded conclusion implications from 3 to 5 items

### angle-trisection (pass 2)
- Added `angle-trisection-oq-02-oq-03` cross-reference (Gauss-Wantzel)

### angle-trisection-oq-02 (pass 1)
- Added `sylow-theorems` cross-reference (p-group theory)

### angle-trisection-oq-02-oq-01 (pass 1)
- Added `sylow-theorems` cross-reference
- Expanded conclusion implications from 2 to 4 items

All cross-references verified to exist in the gallery.