### PR TITLE
Fix: erdos-529 axiomCount 13→15

### DIFF
--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -106,9 +106,9 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 13,
+    "axiomCount": 15,
     "lineCount": 328,
-    "assumptions": "13 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "15 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #529: Self-Avoiding Walks**\n\nSelf-avoiding walks (SAWs) were first studied systematically by the chemist Paul Flory in 1949 as models for linear polymers in good solvents. Flory's mean-field prediction $\\nu = 3/(d+2)$ for the end-to-end distance exponent was remarkably accurate, setting the stage for decades of rigorous mathematical work.\n\nThe first rigorous high-dimensional result came from **Gordon Slade** (1987), who used the **lace expansion** — a perturbative technique introduced by Brydges and Spencer (1985) — to prove $d_k(n) \\sim D\\sqrt{n}$ for sufficiently large $k$. **Takashi Hara** and Slade (1991-92) refined this to all $k \\ge 5$, using computer-assisted bounds on the lace expansion coefficients. Their work established that mean-field behavior ($\\nu = 1/2$) holds above the upper critical dimension $d_c = 4$.\n\nThe low-dimensional case proved far more resistant. **Bernard Nienhuis** (1982) predicted $\\nu = 3/4$ in 2D using the exact solution of an O(n) loop model on the honeycomb lattice, and conformal field theory arguments connect 2D SAW to the SLE$_{8/3}$ process (Lawler, Schramm, Werner). The landmark result of **Hugo Duminil-Copin** and **Alan Hammond** (2013) proved $d_2(n) = o(n)$ (sub-ballistic growth) using a bridge decomposition argument, but the full Question 1 ($d_2(n)/\\sqrt{n} \\to \\infty$) remains open.\n\nThe definitive reference is the monograph *The Self-Avoiding Walk* by Madras and Slade (1993, 2nd ed. 2013). **Nathan Clisby** (2010) provided the most precise numerical estimates: $\\nu_3 \\approx 0.5876 \\pm 0.0002$.",
@@ -216,7 +216,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 328,
-    "axiomCount": 13,
+    "axiomCount": 15,
     "theoremCount": 6,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Fix

Update axiomCount in erdos-529/meta.json from 13 to 15 to match the actual Lean source file.

## Evidence

**Before**: `"axiomCount": 13`
**After**: `"axiomCount": 15`

The 15 axioms in Erdos529Problem.lean:
endToEndDistance, expectedEndDistance, tendsTo, slade_high_dim, haraSlade_five_dim,
duminilCopin_subBallistic, conjecture_2d, conjecture_implies_question1, conjecture_3d,
conjecture_4d, question2_high_dim, question2_false_3d, below_critical, above_critical,
at_critical.

---
Automated fix by lean-mechanic agent.