### PR TITLE
Research: erdos-488 - Eliminate 3 axioms via Mathlib proofs

### DIFF
--- a/proofs/Proofs/Erdos488Problem.lean
+++ b/proofs/Proofs/Erdos488Problem.lean
@@ -16,11 +16,7 @@ Originally posed in Erdős (1961). The 1961 version had `a ∤ n`
 *Reference:* [erdosproblems.com/488](https://www.erdosproblems.com/488)
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Finset.Card
-import Mathlib.Data.Rat.Basic
-import Mathlib.Tactic
+import Mathlib
 
 /- ## Multiples set -/
 
@@ -45,20 +41,17 @@ noncomputable def multiplesRatio (A : Finset ℕ) (N : ℕ) : ℚ :=
 every `m > n ≥ max(A)`, we have
 `|B ∩ [1,m]| / m < 2 · |B ∩ [1,n]| / n`. -/
 def ErdosProblem488 : Prop :=
-    ∀ (A : Finset ℕ),
-      A.Nonempty →
+    ∀ (A : Finset ℕ) (hA : A.Nonempty),
       (∀ a ∈ A, 2 ≤ a) →
         ∀ (n m : ℕ),
-          A.max' A.nonempty ≤ n →
+          A.max' hA ≤ n →
           n < m →
             multiplesRatio A m < 2 * multiplesRatio A n
 
 /- ## Optimality of constant 2 -/
 
 /-- The constant 2 is optimal: for `A = {a}`, `n = 2a-1`, `m = 2a`,
-the ratio approaches 2 as `a → ∞`. Specifically,
-`|B ∩ [1,2a]| / (2a) = 1/a · ⌊2a/a⌋ / 2 = 1` while
-`|B ∩ [1,2a-1]| / (2a-1)` is slightly more than `1/2`. -/
+the ratio approaches 2 as `a → ∞`. -/
 axiom constant_2_optimal :
     ∀ (ε : ℚ), 0 < ε →
       ∃ a : ℕ, 2 ≤ a ∧
@@ -69,17 +62,72 @@ axiom constant_2_optimal :
 
 /- ## Inclusion–exclusion for multiples -/
 
-/-- For a singleton `A = {a}`, `|B ∩ [1,N]| = ⌊N/a⌋`. -/
-axiom singleton_multiplesCount (a N : ℕ) (ha : 1 ≤ a) :
-    multiplesCount ({a} : Finset ℕ) N = N / a
+/-- For a singleton `A = {a}`, `|B ∩ [1,N]| = ⌊N/a⌋`.
+Proved via a bijection between `Finset.range (N/a)` and the multiples of `a`
+in `[1, N]`, sending `k ↦ (k+1)*a`. -/
+theorem singleton_multiplesCount (a N : ℕ) (ha : 1 ≤ a) :
+    multiplesCount ({a} : Finset ℕ) N = N / a := by
+  unfold multiplesCount
+  -- Simplify singleton existential to plain divisibility
+  have hfilt : ((Finset.Icc 1 N).filter (fun n => ∃ a' ∈ ({a} : Finset ℕ), a' ∣ n)) =
+               ((Finset.Icc 1 N).filter (fun n => a ∣ n)) := by
+    apply Finset.filter_congr
+    intro x _
+    simp only [Finset.mem_singleton, exists_eq_left]
+  rw [hfilt, ← Finset.card_range (N / a)]
+  -- Bijection: range (N/a) → (Icc 1 N).filter (a ∣ ·) via k ↦ (k+1)*a
+  symm
+  apply Finset.card_bij (fun k _ => (k + 1) * a)
+  · -- Forward: (k+1)*a ∈ filtered set
+    intro k hk
+    rw [Finset.mem_range] at hk
+    rw [Finset.mem_filter, Finset.mem_Icc]
+    refine ⟨⟨?_, ?_⟩, dvd_mul_left a (k + 1)⟩
+    · -- 1 ≤ (k + 1) * a
+      exact le_trans ha (le_mul_of_one_le_left (Nat.zero_le a) (by omega))
+    · -- (k + 1) * a ≤ N
+      exact le_trans (Nat.mul_le_mul_right a (by omega : k + 1 ≤ N / a))
+                     (Nat.div_mul_le_self N a)
+  · -- Injectivity
+    intro k₁ _ k₂ _ h
+    have := mul_right_cancel₀ (show (a : ℕ) ≠ 0 by omega) h
+    omega
+  · -- Surjectivity: every multiple a*m in [1,N] has m-1 ∈ range (N/a)
+    intro n hn
+    rw [Finset.mem_filter, Finset.mem_Icc] at hn
+    obtain ⟨⟨hn1, hnN⟩, hdvd⟩ := hn
+    obtain ⟨m, rfl⟩ := hdvd
+    have hm1 : 1 ≤ m := by
+      rcases m with _ | m
+      · simp at hn1
+      · omega
+    refine ⟨m - 1, Finset.mem_range.mpr ?_, ?_⟩
+    · -- m - 1 < N / a
+      have : m ≤ N / a := by
+        rw [Nat.le_div_iff_mul_le (by omega : 0 < a)]
+        rwa [mul_comm]
+      omega
+    · -- (m - 1 + 1) * a = a * m
+      have : m - 1 + 1 = m := by omega
+      rw [this, mul_comm]
 
 /-- Monotonicity: `|B ∩ [1,M]| ≤ |B ∩ [1,N]|` when `M ≤ N`. -/
-axiom multiplesCount_mono (A : Finset ℕ) (M N : ℕ) (h : M ≤ N) :
-    multiplesCount A M ≤ multiplesCount A N
+theorem multiplesCount_mono (A : Finset ℕ) (M N : ℕ) (h : M ≤ N) :
+    multiplesCount A M ≤ multiplesCount A N := by
+  unfold multiplesCount
+  apply Finset.card_le_card
+  intro n hn
+  simp only [Finset.mem_filter, Finset.mem_Icc] at *
+  exact ⟨⟨hn.1.1, le_trans hn.1.2 h⟩, hn.2⟩
 
 /-- Adding elements to `A` can only increase the multiples count. -/
-axiom multiplesCount_subset (A B : Finset ℕ) (h : A ⊆ B) (N : ℕ) :
-    multiplesCount A N ≤ multiplesCount B N
+theorem multiplesCount_subset (A B : Finset ℕ) (h : A ⊆ B) (N : ℕ) :
+    multiplesCount A N ≤ multiplesCount B N := by
+  unfold multiplesCount
+  apply Finset.card_le_card
+  intro n hn
+  simp only [Finset.mem_filter] at *
+  exact ⟨hn.1, let ⟨a, haA, hdvd⟩ := hn.2; ⟨a, h haA, hdvd⟩⟩
 
 /- ## Davenport's density -/
 

--- a/src/data/proofs/erdos-488/meta.json
+++ b/src/data/proofs/erdos-488/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 488,
     "erdosUrl": "https://erdosproblems.com/488",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 92,
-    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "axiomCount": 2,
+    "lineCount": 140,
+    "assumptions": "2 axiom(s): constant_2_optimal (optimality of 2 via limit argument), multiplesSet_density_exists (Davenport's density theorem). 3 former axioms now proved: singleton count formula, monotonicity, subset monotonicity.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -83,7 +83,7 @@
       "title": "Inclusion-Exclusion for Multiples",
       "startLine": 72,
       "endLine": 82,
-      "summary": "Three axioms: the singleton count formula $|B(\\{a\\}) \\cap [1,N]| = \\lfloor N/a \\rfloor$, monotonicity of `multiplesCount` in $N$, and monotonicity in $A$ (adding elements increases the count)."
+      "summary": "Three proved theorems (formerly axioms): the singleton count formula $|B(\\{a\\}) \\cap [1,N]| = \\lfloor N/a \\rfloor$ via bijection, monotonicity of `multiplesCount` in $N$, and monotonicity in $A$ (adding elements increases the count)."
     },
     {
       "id": "davenport-density",
@@ -105,17 +105,13 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Finset.Card",
-      "Mathlib.Data.Rat.Basic",
-      "Mathlib.Tactic"
+      "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 92,
-    "axiomCount": 5,
-    "theoremCount": 0,
+    "lineCount": 140,
+    "axiomCount": 2,
+    "theoremCount": 3,
     "definitionCount": 4
   },
   "references": [

--- a/src/data/research/problems/erdos-488.json
+++ b/src/data/research/problems/erdos-488.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-13T03:37:39.479Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination complete for routine results",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "AXIOM HUNT: Eliminated 3 of 5 axioms. Proved singleton count formula, monotonicity, and subset monotonicity. Remaining 2 axioms are deep results.",
+    "builtItems": [
+      "theorem singleton_multiplesCount (bijection proof, ~25 lines)",
+      "theorem multiplesCount_mono (4 lines)",
+      "theorem multiplesCount_subset (5 lines)"
+    ],
+    "insights": [
+      "singleton_multiplesCount proved via bijection: Finset.range (N/a) → (Icc 1 N).filter (a∣·) via k↦(k+1)*a",
+      "multiplesCount_mono proved: filter subset from Icc monotonicity",
+      "multiplesCount_subset proved: predicate weakening on existential",
+      "Axiom count reduced 5→2: remaining are constant_2_optimal and Davenport density theorem"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "constant_2_optimal provable using singleton_multiplesCount + rational arithmetic",
+      "multiplesSet_density_exists is Davenport 1933 - needs significant infrastructure"
+    ],
     "markdown": "# Erdős #488 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A$ be a finite set and\\[B=\\{ n \\geq 1 : a\\mid n\\textrm{ for some }a\\in A\\}.\\]Is it true that, for every $m>n\\geq \\max(A)$,\\[\\frac{\\lvert B\\cap [1,m]\\rvert }{m}< 2\\frac{\\lvert B\\cap [1,n]\\rvert}{n}?\\]\n\n\n\nThe constant $2$ would be the best possible here, as witnessed by taking $A=\\{a\\}$, $n=2a-1$, and $m=2a$.\n\nThis problem is also discussed in problem E5 of Guy's collection \\cite{Gu04}.\n\nIn \\cite{Er61} this problem is as stated above, but with $a\\mid n$ in the definition of $B$ replaced by $a\\nmid n$. This is most likely a typo (especially since the problem is also given as stated above in \\cite{Er66}). There have been several counterexamples given for this alternate problem. Cambie has observed that, if $A$ is the set of primes bounded above by $n$, and $m=2n$, then\\[\\frac{\\lvert B\\cap [1,m]\\rvert }{m}=\\frac{\\pi(2n)-\\pi(n)+1}{2n}\\sim \\frac{1}{2\\log n}\\]while\\[\\frac{\\lvert B\\cap [1,n]\\rvert}{n}=\\frac{1}{n}.\\]Further concrete counterexamples, found by Alexeev and Aristotle, are given in the comments section.\n\n\n\n\nReferences\n\n\n[Er61] Erd\\H{o}s, Paul, Some unsolved problems. Magyar Tud. Akad. Mat. Kutat\\'{o} Int. K\\\"{o}zl. (1961), 221-254.\n\n[Er66] Erd\\H{o}s, P\\'al, Remarks on number theory. {V}. {E}xtremal problems in number\ntheory. {II}. Mat. Lapok (1966), 135--155.\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #487\n- Problem #489\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n- Er61\n- Er66\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Prove `singleton_multiplesCount` via bijection (`Finset.range (N/a)` ↔ multiples of `a` in `[1,N]`)
- Prove `multiplesCount_mono` from `Finset.Icc` subset monotonicity
- Prove `multiplesCount_subset` from predicate weakening on bounded existential
- **Axiom count reduced 5 → 2** (remaining: `constant_2_optimal`, `multiplesSet_density_exists`)

## Fixes Applied
- Replace stale `import Mathlib.Data.Rat.Basic` → `import Mathlib`
- Fix invalid `A.nonempty` → named hypothesis `hA` in `ErdosProblem488` definition

## Status
**Outcome**: Significant axiom elimination
**Next Steps**: `constant_2_optimal` is provable via ℚ arithmetic (ratio = 2 - 1/a); `multiplesSet_density_exists` (Davenport 1933) needs substantial infrastructure

🤖 Generated by researcher-1