### PR TITLE
Research: erdos-68 - Eliminate eRelatedSum_value axiom (4→3)

### DIFF
--- a/proofs/Proofs/Erdos68Problem.lean
+++ b/proofs/Proofs/Erdos68Problem.lean
@@ -277,8 +277,40 @@ For Σ 1/(n!-1), the -1 perturbation breaks the nice factorial structure.
 /-- The series without the -1 is the "e-sum". -/
 noncomputable def eRelatedSum : ℝ := ∑' n : ℕ, (1 : ℝ) / (n + 2).factorial
 
-/-- e - 1 - 1 = Σ_{n≥2} 1/n! -/
-axiom eRelatedSum_value : eRelatedSum = Real.exp 1 - 2
+/--
+**Proved: Σ_{n≥2} 1/n! = e - 2**
+
+The Taylor series for e is e = Σ_{n≥0} 1/n!. Peeling off the n=0 and n=1 terms
+(both equal to 1) gives Σ_{n≥2} 1/n! = e - 2.
+
+Previously an axiom; now proved from Mathlib's exponential series.
+-/
+theorem eRelatedSum_value : eRelatedSum = Real.exp 1 - 2 := by
+  unfold eRelatedSum
+  -- Define the exponential series term f(n) = 1/n!
+  set f : ℕ → ℝ := fun n => (1 : ℝ) / ↑(n.factorial) with hf_def
+  -- Step 1: exp 1 = Σ f(n) = Σ 1/n!
+  have exp_eq : Real.exp 1 = ∑' n, f n := by
+    rw [Real.exp_eq_exp_ℝ, NormedSpace.exp_eq_tsum (𝕂 := ℝ) (𝔸 := ℝ)]
+    apply tsum_congr; intro n
+    simp [f, smul_eq_mul, div_eq_mul_inv, mul_comm]
+  -- Step 2: Summability of 1/n!
+  have hsum : Summable f := by
+    exact (summable_pow_div_factorial (1 : ℝ)).congr fun n => by simp [f]
+  -- Step 3: Peel off n=0: Σ 1/n! = 1/0! + Σ 1/(n+1)!
+  have peel0 := hsum.tsum_eq_zero_add
+  -- Step 4: Summability of the shifted series
+  have hsum1 : Summable (fun n => f (n + 1)) := (summable_nat_add_iff 1).mpr hsum
+  -- Step 5: Peel off first term: Σ 1/(n+1)! = 1/1! + Σ 1/(n+2)!
+  have peel1 := hsum1.tsum_eq_zero_add
+  -- Step 6: f(0) = 1, f(1) = 1
+  have hf0 : f 0 = 1 := by simp [f, Nat.factorial]
+  have hf1 : f 1 = 1 := by simp [f, Nat.factorial]
+  -- Step 7: Σ f(n+2) = Σ 1/(n+2)! (the goal term)
+  have htail : ∑' n, f (n + 2) = ∑' n : ℕ, (1 : ℝ) / ↑((n + 2).factorial) :=
+    tsum_congr fun n => by simp [f]
+  -- Chain: exp 1 = f 0 + f 1 + Σ f(n+2) = 1 + 1 + eRelatedSum = 2 + eRelatedSum
+  linarith
 
 /-- The -1 perturbation makes a small but crucial difference. -/
 axiom perturbation_difference :

--- a/src/data/proofs/erdos-68/meta.json
+++ b/src/data/proofs/erdos-68/meta.json
@@ -59,7 +59,7 @@
       "eRelatedSum definition: connection to e",
       "transcendence_implies_68 theorem: hierarchy"
     ],
-    "axiomCount": 4,
+    "axiomCount": 3,
     "prerequisites": [
       "Real analysis: convergence of infinite series",
       "Factorial function and its growth rate",
@@ -67,8 +67,8 @@
       "Irrationality and transcendence of real numbers",
       "Comparison test for series convergence"
     ],
-    "lineCount": 356,
-    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "lineCount": 388,
+    "assumptions": "3 axiom(s): erdos_68 (OPEN conjecture), perturbation_difference (numerical bound), oeis_a331373 (decimal bound). The eRelatedSum_value axiom was proved from Mathlib's exponential series."
   },
   "overview": {
     "historicalContext": "Erdős Problem #68 asks whether Σ_{n≥2} 1/(n!-1) is irrational. The problem appears in Erdős's papers from 1968, 1988, 1990, and 1997.\n\nDesmond Weisenberg observed that the sum can be rewritten as a double sum: Σ 1/(n!-1) = Σ_n Σ_k 1/(n!)^k, using the geometric series 1/(x-1) = Σ x^{-k}.\n\nErdős actually conjectured something stronger: that Σ 1/(n!+t) is transcendental for every integer t. The t=-1 case is this problem.\n\nThe decimal expansion is OEIS sequence A331373: 1.2517525711... The difficulty contrasts sharply with the number e = Σ 1/n!, whose irrationality has been known since Euler (1737) and transcendence since Hermite (1873). The small perturbation of replacing n! with n!-1 disrupts the telescoping and algebraic identities that make e accessible, placing this problem beyond current methods in transcendence theory.",
@@ -211,9 +211,9 @@
       "Nat"
     ],
     "namespace": "Erdos68",
-    "lineCount": 356,
-    "axiomCount": 4,
-    "theoremCount": 17,
+    "lineCount": 388,
+    "axiomCount": 3,
+    "theoremCount": 18,
     "definitionCount": 7
   }
 }


### PR DESCRIPTION
## Summary
- Proved `eRelatedSum_value` axiom: Σ_{n≥2} 1/n! = e - 2, using Mathlib's exponential Taylor series
- Axiom count reduced from 4 to 3 in Erdos68Problem.lean
- Docker build verified successfully

## Progress
- **Axiom eliminated**: `eRelatedSum_value` — was an axiom, now a 30-line theorem
- **Proof technique**: `Real.exp_eq_exp_ℝ` → `NormedSpace.exp_eq_tsum` → `tsum_eq_zero_add` (peel n=0,1 terms)
- **Remaining axioms**: `erdos_68` (OPEN conjecture), `perturbation_difference`, `oeis_a331373`

## Findings
- The proof uses standard Mathlib infrastructure: `summable_pow_div_factorial`, `summable_nat_add_iff`, `tsum_eq_zero_add`
- The numerical axioms (`perturbation_difference`, `oeis_a331373`) may have incorrect bounds — flagged for future investigation

## Status
**Outcome**: completed (axiom elimination)
**Next Steps**: Investigate correctness of remaining numerical axioms

🤖 Generated by researcher-3