### PR TITLE
Peer review: continuum-hypothesis (C)

### DIFF
--- a/src/data/proofs/continuum-hypothesis/review.json
+++ b/src/data/proofs/continuum-hypothesis/review.json
@@ -1,93 +1,100 @@
 {
   "version": 1,
   "proofId": "continuum-hypothesis",
-  "reviewDate": "2026-03-23T19:30:00Z",
+  "reviewDate": "2026-03-23T22:00:00Z",
   "reviewer": "peer-reviewer",
 
   "overallAssessment": {
-    "grade": "C-",
-    "oneLiner": "Excellent pedagogical commentary on a landmark independence result, but the formal content is hollow — holds_CH and holds_notCH are both defined as True, making the main theorem vacuously satisfied, and 'Easton's Theorem' proves 1+1=2.",
+    "grade": "C",
+    "oneLiner": "Excellent pedagogy on a landmark result, but the formal independence proof is vacuous — holds_CH and holds_notCH are both True, making the main theorem trivially (∃ M, True) ∧ (∃ M, True), with one egregious filler theorem (Easton's Theorem proving 1+1=2).",
     "tier": "C",
-    "tierJustification": "Tier C: Scaffold/axiomatized. The central independence theorem is vacuously true because holds_CH and holds_notCH are placeholder definitions (fun _ => True). The 6 axiom declarations partially capture the proof structure, but 2 of them (L_satisfies_CH, forcing_violates_CH) have type True. The only genuinely proved result is gch_implies_ch. The file is an illustrative scaffold, not a real axiomatization."
+    "tierJustification": "Tier C: Scaffold/axiomatized. The core independence theorem is vacuously true because holds_CH and holds_notCH are both placeholder definitions returning True for any model. Two genuine Mathlib-based proofs exist (gch_implies_ch, cantor_theorem) and the CH/GCH definitions are correctly formalized, but the central claim of the file — CH independence — has no formal content."
   },
 
   "findings": [
     {
       "severity": "positive",
       "category": "strength",
-      "location": "BallotProblem.lean lines 300-356 (Part 8: Consequences and Philosophy)",
-      "finding": "The philosophical commentary is genuinely thoughtful and well-sourced. It covers four distinct perspectives (Platonism, Formalism, Multiverse view, Pragmatism), names specific researchers (Hamkins, Woodin), and describes active research programs (inner model theory, forcing axioms, Ultimate L). The L and forcing explanations in Parts 4-5 (lines 147-220) are clear and mathematically accurate. The historical narrative (Cantor 1878 → Hilbert 1900 → Gödel 1940 → Cohen 1963) is precise and well-structured.",
-      "recommendation": "Preserve. This commentary is the file's primary value and is genuinely educational."
+      "location": "ContinuumHypothesis.lean lines 106-112 (gch_implies_ch)",
+      "finding": "The proof that GCH implies CH is the most substantive formal result in the file. It unfolds CH, continuum, aleph_one, applies GCH at α=0, simplifies with zero_add, and converts using Cardinal.aleph_zero. This is genuine multi-step Lean proof work — not a wrapper or placeholder.",
+      "recommendation": "Preserve and highlight as the file's main formal contribution."
     },
     {
       "severity": "positive",
       "category": "strength",
-      "location": "ContinuumHypothesis.lean lines 106-112 (gch_implies_ch)",
-      "finding": "The proof that GCH implies CH is the only genuinely substantive formal result in the file. It unfolds definitions, applies the GCH at α=0, and uses Mathlib's cardinal arithmetic (Cardinal.aleph_zero). This is real Lean proof work, not a wrapper or placeholder.",
-      "recommendation": "Preserve and highlight. This should be prominently featured as the file's main formal contribution."
+      "location": "ContinuumHypothesis.lean lines 6-43, 300-356; annotations.json (all entries)",
+      "finding": "The pedagogical exposition is the file's primary strength. The historical narrative (Cantor 1878 → Hilbert 1900 → Gödel 1940 → Cohen 1963 → Fields Medal 1966) is precise and well-sourced. The docstrings explaining why L and forcing are axiomatized are honest and educational. The philosophical discussion covers four perspectives with specific researcher citations (Hamkins, Woodin). Annotations provide accurate mathematical context with proper LaTeX notation.",
+      "recommendation": "Preserve. This commentary is genuinely educational and could serve as a model for other gallery entries."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "ContinuumHypothesis.lean lines 59-103 (definitions)",
+      "finding": "The formal definitions of continuum (2^ℵ₀), aleph_one (Cardinal.aleph 1), CH (continuum = aleph_one), CH_alt (no intermediate cardinal), and GCH (∀α, 2^ℵ_α = ℵ_{α+1}) are mathematically correct and cleanly stated using Mathlib's cardinal arithmetic. These definitions have genuine mathematical content.",
+      "recommendation": "Preserve. These are the solid formal foundation of the file."
     },
     {
       "severity": "critical",
       "category": "gap",
       "location": "ContinuumHypothesis.lean lines 138, 141 (holds_CH, holds_notCH)",
-      "finding": "holds_CH and holds_notCH are both defined as `fun (_ : ZFCModel) => True`. This means holds_CH M = True and holds_notCH M = True for ALL models M, simultaneously. Consequence: the main theorem `continuum_hypothesis_independent` (line 269) asserts (∃ M, True) ∧ (∃ M, True), which is trivially true without any axioms. The axioms L_satisfies_CH and forcing_violates_CH both have type True. The entire independence 'proof' structure is vacuous — it does not distinguish models where CH holds from models where CH fails.",
-      "recommendation": "Replace holds_CH with a definition that actually references the CH proposition in the model. For example: `def holds_CH (M : ZFCModel) : Prop := sorry` would at least leave the connection as an explicit gap. Better: define a satisfaction relation so that holds_CH and holds_notCH are genuinely contradictory predicates. The current definitions make the file's central theorem mathematically meaningless."
+      "finding": "holds_CH and holds_notCH are both defined as `fun (_ : ZFCModel) => True`. This means holds_CH M = True AND holds_notCH M = True for ALL models simultaneously. The main theorem continuum_hypothesis_independent (line 269) therefore asserts (∃ M, True) ∧ (∃ M, True), which is trivially true without any axioms at all. The axioms L_satisfies_CH (line 181) and forcing_violates_CH (line 220) both have type `True`, contributing no mathematical content. The entire independence proof structure is vacuous.",
+      "recommendation": "Replace with meaningful predicates. At minimum: `def holds_CH (M : ZFCModel) : Prop := sorry` and `def holds_notCH (M : ZFCModel) : Prop := sorry` to leave the connection as an explicit gap. Better: define a satisfaction predicate so holds_CH and holds_notCH are genuinely contradictory for any given model."
     },
     {
       "severity": "major",
       "category": "filler",
       "location": "ContinuumHypothesis.lean line 294 (easton_flexibility)",
-      "finding": "The theorem is named 'easton_flexibility' with docstring 'Easton's Theorem (1970): For regular cardinals, the function κ ↦ 2^κ can be almost anything consistent with König's theorem.' But the Lean statement is: `theorem easton_flexibility : (1 : ℕ) + 1 = 2 := rfl`. This is egregious filler — attaching a famous theorem's name and description to a completely unrelated trivial identity. A reader seeing 'Easton's Theorem' in the declaration list would be actively misled about the file's content.",
-      "recommendation": "Either remove entirely, or rename to something honest like `trivial_arithmetic` with a comment 'Easton's theorem is not formalized here.' If Easton's theorem is desired, it should be a genuine axiom or sorry'd statement about cardinal exponentiation."
+      "finding": "The theorem is named 'easton_flexibility' with a docstring describing Easton's Theorem (1970) about cardinal exponentiation flexibility. The actual Lean statement is: `theorem easton_flexibility : (1 : ℕ) + 1 = 2 := rfl`. This is textbook filler — attaching a famous theorem's name and description to a completely unrelated trivial identity. A reader seeing 'Easton's Theorem' in the theorem list would be actively misled about the file's content.",
+      "recommendation": "Remove entirely or replace with a genuine axiomatization: `axiom easton_flexibility (κ : Cardinal) (hκ : κ.IsRegular) (c : Cardinal) (hc : κ < Cardinal.cof c) : ∃ M : ZFCModel, True` (even as a sorry'd statement it would be more honest)."
     },
     {
       "severity": "major",
       "category": "overclaim",
       "location": "meta.json originalContributions",
-      "finding": "The three listed contributions — 'Framework for ZFC models and relative consistency', 'Godel's constructible universe L axiomatized', 'Cohen's forcing approach outlined' — significantly overclaim. The 'framework' has all predicates defined as True. The 'axiomatization' of L is a structure with True fields (V_eq_L: True, L_satisfies_CH: True). The forcing 'approach' is similarly hollow. These are prose descriptions of mathematical ideas, not formal axiomatizations.",
-      "recommendation": "Reframe honestly: 'Illustrative scaffold showing the logical structure of the Gödel-Cohen independence proof, with key metamathematical facts as axioms and placeholder model definitions.'"
+      "finding": "Three contributions are listed: 'Framework for ZFC models and relative consistency' (structures have all-True fields), 'Godel's constructible universe L axiomatized' (L_satisfies_CH asserts True), 'Cohen's forcing approach outlined' (forcing_violates_CH asserts True). These describe the pedagogical intent accurately but overclaim the formal content — the 'framework' doesn't distinguish models, the 'axiomatization' doesn't capture L's properties, and the 'outline' doesn't represent forcing.",
+      "recommendation": "Reframe as: ['Pedagogical scaffold illustrating the Gödel-Cohen independence proof structure', 'Genuine proof that GCH implies CH using Mathlib cardinal arithmetic', 'Correct formal definitions of CH, CH_alt, and GCH using Mathlib cardinals']."
     },
     {
       "severity": "major",
       "category": "gap",
       "location": "ContinuumHypothesis.lean lines 226-230 (RelativelyConsistent)",
-      "finding": "RelativelyConsistent is defined as `fun _ => ZFCModel → ∃ M : ZFCModel, True`. This definition ignores the proposition it's supposed to be relative to (the parameter is unused). Any ZFCModel witness trivially satisfies this. The 'consistency' theorems ch_consistent_with_zfc and not_ch_consistent_with_zfc are therefore vacuously true — they don't actually assert that specific models satisfy CH or ¬CH.",
-      "recommendation": "Either make RelativelyConsistent actually use its proposition parameter (e.g., via a satisfaction predicate), or honestly mark it as a placeholder with a sorry."
+      "finding": "RelativelyConsistent is defined as `fun _ => ZFCModel → ∃ M : ZFCModel, True`. The proposition parameter is completely ignored — the definition says 'given any model, there exists some model', regardless of what property φ is. The consistency theorems ch_consistent_with_zfc and not_ch_consistent_with_zfc therefore don't actually assert that specific models satisfy CH or ¬CH.",
+      "recommendation": "Either make RelativelyConsistent use its proposition parameter via a satisfaction predicate, or honestly mark it as a placeholder: `def RelativelyConsistent (φ : Prop) : Prop := sorry`."
     },
     {
       "severity": "moderate",
       "category": "inconsistency",
-      "location": "ContinuumHypothesis.lean lines 23-28 (docstring status)",
-      "finding": "The file's status checklist says '[x] Incomplete (has sorries)' but there are no sorry declarations in the file (meta.json correctly says sorries: 0). The file has axioms, not sorries. These are semantically different: axioms are explicit assumptions, sorries are proof gaps.",
-      "recommendation": "Change to '[x] Axiomatized (has axiom declarations)' to accurately describe the file's status."
+      "location": "ContinuumHypothesis.lean line 35 (docstring)",
+      "finding": "The file header says '2 sorries, 5 axioms capturing key metamathematical facts'. The file actually contains 0 sorries and 6 axioms. The meta.json correctly states sorries: 0 and axiomCount: 6, contradicting the header. This suggests the header was written for an earlier version and not updated.",
+      "recommendation": "Update to '0 sorries, 6 axioms capturing key metamathematical facts'."
     },
     {
       "severity": "moderate",
       "category": "inconsistency",
-      "location": "meta.json axiomCount: 6 and assumptions field",
-      "finding": "The assumptions field describes real mathematical content for L_satisfies_CH ('L satisfies CH') and forcing_violates_CH ('forcing model violates CH'). But these axioms actually have type True due to the placeholder definitions. The assumptions field implies these axioms carry mathematical weight they don't actually have. Additionally, axiomCount: 6 is numerically correct but doesn't distinguish genuine axioms (ch_implies_no_intermediate, no_intermediate_implies_ch) from trivially-True ones.",
-      "recommendation": "Either fix the placeholder definitions so the axioms carry real content, or note in assumptions that L_satisfies_CH and forcing_violates_CH are trivially True due to placeholder model predicates."
+      "location": "annotations.json ann-gch (line 101 of content field)",
+      "finding": "The annotation says 'Göran proved GCH holds in L' — this should be 'Gödel'. Göran is a Swedish first name unrelated to Kurt Gödel. This is a factual error in a pedagogical annotation.",
+      "recommendation": "Fix to 'Gödel proved GCH holds in L'."
     },
     {
       "severity": "moderate",
       "category": "inconsistency",
-      "location": "annotations.json ann-gch line 101",
-      "finding": "The annotation says 'Göran proved GCH holds in L' — this should be 'Gödel.' 'Göran' is a Swedish first name, not the mathematician who proved this result. Kurt Gödel proved GCH holds in L in his 1940 monograph.",
-      "recommendation": "Fix: 'Gödel proved GCH holds in L'."
+      "location": "meta.json assumptions field",
+      "finding": "The assumptions field describes L_satisfies_CH as 'L satisfies CH' and forcing_violates_CH as 'forcing model violates CH', implying these axioms carry genuine mathematical content. In reality both have type True due to the placeholder definitions of holds_CH/holds_notCH. The description is accurate to the intent but misleading about the implementation.",
+      "recommendation": "If the placeholder definitions aren't fixed, add a note: '(Note: holds_CH and holds_notCH are currently placeholder definitions returning True; these axioms are formally vacuous until the predicates are implemented)'."
     },
     {
       "severity": "minor",
       "category": "inconsistency",
       "location": "meta.json sections",
-      "finding": "Sections overlap at line 185 (godel ends at 185, cohen starts at 185) and miss several file parts: Part 3 (ZFC Set Theory, lines 114-141), Part 7 (Related Results, lines 280-295), Part 8 (Philosophy, lines 296-356).",
+      "finding": "Section boundaries overlap (godel endLine 185, cohen startLine 185) and three file parts are missing from sections: Part 3 ZFC Set Theory (lines 114-141), Part 7 Related Results (lines 280-295), Part 8 Philosophy (lines 296-356).",
       "recommendation": "Fix overlap and add missing sections."
     },
     {
       "severity": "minor",
       "category": "precision",
-      "location": "ContinuumHypothesis.lean lines 361-366 (#check commands)",
-      "finding": "Six #check debug commands left in production code.",
-      "recommendation": "Remove."
+      "location": "ContinuumHypothesis.lean lines 361-366",
+      "finding": "Six #check debug commands left in production code. While harmless, they add clutter.",
+      "recommendation": "Remove or move to a test file."
     }
   ],
 
@@ -96,49 +103,49 @@
       "id": "ai-1",
       "priority": "high",
       "target": "researcher",
-      "description": "Fix holds_CH and holds_notCH definitions to be non-trivial predicates that actually distinguish models. At minimum, replace `True` with `sorry` placeholders. Ideally, define a satisfaction relation that connects ZFCModel to the CH proposition. This is the most critical issue — it makes the entire independence 'proof' vacuous.",
+      "description": "Replace trivial holds_CH/holds_notCH definitions (both return True) with meaningful predicates that actually distinguish models where CH holds from models where it fails. This is the single most important fix — it makes the independence theorem, the two consistency theorems, and 2 of the 6 axioms all formally meaningful instead of vacuous.",
       "status": "open"
     },
     {
       "id": "ai-2",
       "priority": "high",
       "target": "researcher",
-      "description": "Remove or replace easton_flexibility. Currently proves 1+1=2 while claiming to be 'Easton's Theorem'. Either remove entirely or replace with a genuine axiomatization of Easton's result about cardinal exponentiation.",
+      "description": "Remove or replace easton_flexibility (currently proves 1+1=2 while claiming to be Easton's Theorem). Either delete the theorem entirely, or replace with a genuine axiomatization of Easton's result about cardinal exponentiation.",
       "status": "open"
     },
     {
       "id": "ai-3",
       "priority": "high",
       "target": "researcher",
-      "description": "Fix RelativelyConsistent to actually use its proposition parameter. Current definition ignores the input proposition, making consistency theorems vacuous.",
+      "description": "Fix RelativelyConsistent definition to actually use its proposition parameter. Current definition ignores the input proposition entirely, making the consistency theorems vacuous.",
       "status": "open"
     },
     {
       "id": "ai-4",
       "priority": "medium",
       "target": "enricher",
-      "description": "Reframe originalContributions to honestly describe placeholder scaffold rather than claiming 'framework' and 'axiomatization'. Suggested: 'Illustrative scaffold showing the logical structure of the Gödel-Cohen independence proof.'",
+      "description": "Reframe originalContributions in meta.json to honestly describe the pedagogical scaffold nature: ['Pedagogical scaffold illustrating Gödel-Cohen independence proof structure', 'Genuine proof that GCH implies CH using Mathlib cardinal arithmetic', 'Correct formal definitions of CH, CH_alt, and GCH'].",
       "status": "open"
     },
     {
       "id": "ai-5",
       "priority": "medium",
       "target": "enricher",
-      "description": "Fix Göran → Gödel typo in annotations.json ann-gch.",
+      "description": "Fix factual errors: (1) Göran → Gödel in annotations.json ann-gch, (2) '2 sorries, 5 axioms' → '0 sorries, 6 axioms' in file header docstring.",
       "status": "open"
     },
     {
       "id": "ai-6",
       "priority": "medium",
       "target": "enricher",
-      "description": "Fix docstring status checklist: change '[x] Incomplete (has sorries)' to '[x] Axiomatized (has axiom declarations)'. Also update assumptions field to note which axioms are trivially True.",
+      "description": "Update assumptions field in meta.json to note that L_satisfies_CH and forcing_violates_CH are formally vacuous due to placeholder model predicate definitions.",
       "status": "open"
     },
     {
       "id": "ai-7",
       "priority": "low",
       "target": "enricher",
-      "description": "Fix section overlaps and add missing sections for ZFC Set Theory (lines 114-141), Related Results (lines 280-295), and Philosophy (lines 296-356).",
+      "description": "Fix section boundaries in meta.json: resolve overlap at line 185, add missing sections for ZFC Set Theory (114-141), Related Results (280-295), Philosophy (296-356).",
       "status": "open"
     },
     {
@@ -151,14 +158,14 @@
   ],
 
   "qualityScores": {
-    "mathematicalSubstance": 4,
-    "originalityAccuracy": 4,
-    "completeness": 4,
-    "framingPrecision": 4,
+    "mathematicalSubstance": 5,
+    "originalityAccuracy": 5,
+    "completeness": 5,
+    "framingPrecision": 5,
     "pedagogicalQuality": 8,
-    "internalConsistency": 4,
-    "overall": 4.7
+    "internalConsistency": 5,
+    "overall": 5.5
   },
 
-  "suggestedBestFraming": "A pedagogical scaffold illustrating the logical structure of the Gödel-Cohen independence proof for CH, with genuine Lean definitions for CH, GCH, and ℵ₁ using Mathlib's cardinal arithmetic, one substantive proof (GCH → CH), and axiomatized placeholder models for the constructible universe and forcing extension — the central independence theorem is illustrative rather than formally meaningful due to placeholder model predicates."
+  "suggestedBestFraming": "A pedagogical scaffold illustrating the logical architecture of the Gödel-Cohen independence proof for the Continuum Hypothesis, featuring correct Lean 4 definitions of CH, GCH, and ℵ₁ using Mathlib's cardinal arithmetic, one genuine proof (GCH implies CH), and placeholder model structures whose predicates need implementation to give the independence theorem formal content."
 }

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -81,10 +81,10 @@
       "actionItems": 0,
       "resolvedItems": 0
     },
-    "denumerability-rationals": {
+    "continuum-hypothesis": {
       "reviewCount": 1,
-      "lastReviewed": "2026-03-24T06:35:19Z",
-      "overallGrade": "B",
+      "lastReviewed": "2026-03-24T06:31:41Z",
+      "overallGrade": "C",
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0


### PR DESCRIPTION
## Summary

- Deep review of the continuum-hypothesis gallery entry (Wiedijk #24 / Hilbert #1)
- **Grade: C** — excellent pedagogy undermined by vacuous formal content
- 12 findings (1 critical, 3 major, 4 moderate, 2 minor, 3 positive)
- 8 action items (3 high priority for researcher, 5 for enricher)

## Key Findings

**Critical**: `holds_CH` and `holds_notCH` are both defined as `True`, making the independence theorem trivially `(∃ M, True) ∧ (∃ M, True)`

**Strengths**: Excellent pedagogical docstrings (8/10), correct CH/GCH definitions, genuine `gch_implies_ch` proof using Mathlib

**Filler**: `easton_flexibility` proves `1 + 1 = 2` while claiming to be Easton's Theorem

## Test plan
- [x] review.json written with proper schema
- [x] review-tracker.json updated
- [x] No code files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)