### PR TITLE
Audit fix: 2 proofs with hidden structure-encoded axioms

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Descartes/Euler/Gauss/Bonnet (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gauss%E2%80%93Bonnet_theorem#For_polyhedra",
     "date": "1630-1848",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "topology",
       "geometry",
@@ -19,7 +19,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/EulerPolyhedralOQ02.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -36,9 +36,9 @@
       "Classification of regular polyhedra from Schläfli curvature constraint"
     ],
     "dateAdded": "2026-03-05",
-    "axiomCount": 0,
+    "axiomCount": 4,
     "lineCount": 507,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 sorries but 4 structure-encoded assumptions: PolyhedralSurface.euler (V-E+F=χ), PolyhedralSurface.angle_sum_identity, PolyhedralSurface.deficiency_sum, OrientableSurface.chi_genus (χ=2-2g). All 37+ consequence theorems are fully proved from these axiomatized foundations.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -120,7 +120,7 @@
     ],
     "namespace": "DiscreteGaussBonnet",
     "lineCount": 507,
-    "axiomCount": 0,
+    "axiomCount": 4,
     "theoremCount": 52,
     "definitionCount": 7
   },

--- a/src/data/proofs/pythagorean-theorem-oq-03/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lobachevsky & Bolyai (1830s), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hyperbolic_law_of_cosines",
     "date": "c. 1830",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PythagoreanTheoremOQ03.lean",
     "tags": [
       "geometry",
@@ -17,7 +17,7 @@
       "pythagorean-theorem",
       "generalization"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -62,9 +62,9 @@
         "relationship": "The original Euclidean Pythagorean theorem proof that posed the open question answered by this formalization"
       }
     ],
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 1431,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 sorries but 3 structure-encoded assumptions: HyperbolicRightTriangle.law (cosh c = cosh a · cosh b), SphericalRightTriangle.law (cos c = cos a · cos b), SphericalRightTriangleR.law (cos(c/R) = cos(a/R) · cos(b/R)). These metric laws are axiomatized as structure fields; all 50+ consequence theorems are fully proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -254,7 +254,7 @@
     ],
     "namespace": "PythagoreanNonEuclidean",
     "lineCount": 1431,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 105,
     "definitionCount": 18
   }


### PR DESCRIPTION
## Summary

Two proofs claimed `axiomCount: 0` with badge `"verified"`/`"original"` but have mathematical theorems axiomatized as structure fields:

### pythagorean-theorem-oq-03 (axiomCount 0→3)
The hyperbolic, spherical, and spherical-with-radius Pythagorean laws are structure fields, not proved from first principles.

### euler-polyhedral-formula-oq-02 (axiomCount 0→4)
Euler's formula (V-E+F=χ), the angle sum identity, deficiency sum, and chi-genus formula are all structure fields.

Both files have extensive consequence theorems fully proved from these axioms. The issue is only with the metadata overclaiming "verified" status.

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery pages render with `axiom` badge

---
Discovered during gallery integrity audit (Auditor cycle 8).