### PR TITLE
Enrich BSD Conjecture: fix cross-references and add Millennium Prize connections

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -137,24 +137,64 @@
   },
   "crossReferences": [
     {
-      "targetProofId": "fundamental-theorem-algebra",
-      "relationship": "Both concern deep connections between algebraic and analytic properties -- BSD connects rational points (algebra) with L-functions (analysis)"
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "Both concern deep connections between algebraic and analytic properties: FTA proves polynomial roots exist in $\\mathbb{C}$, while BSD connects rational points on elliptic curves (algebra) with the analytic behavior of L-functions at $s = 1$"
     },
     {
-      "targetProofId": "riemann-hypothesis",
-      "relationship": "The Hasse bound (axiomatized in this file) is the Riemann Hypothesis for curves over finite fields; the full RH for the Riemann zeta function is a Millennium Prize sibling"
+      "targetId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "The Hasse bound $|\\#E(\\mathbb{F}_p) - p - 1| \\leq 2\\sqrt{p}$ (axiomatized in this file) is equivalent to the Riemann Hypothesis for the zeta function of $E$ over $\\mathbb{F}_p$, proved by Hasse (1936). The full RH for the Riemann zeta function is a Millennium Prize sibling of BSD, and the Generalized RH for Dirichlet L-functions is intimately connected to BSD via the Langlands program"
     },
     {
-      "targetProofId": "p-vs-np",
-      "relationship": "Fellow Millennium Prize Problem -- both remain open and carry a $1,000,000 prize from the Clay Mathematics Institute"
+      "targetId": "p-vs-np",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem — both remain open and carry a $1,000,000 prize from the Clay Mathematics Institute. While P vs NP concerns computational complexity, BSD concerns the arithmetic of elliptic curves — two very different mathematical domains united by the Clay Prize's recognition of their fundamental importance"
     },
     {
-      "targetProofId": "continuum-hypothesis",
-      "relationship": "Both are famous mathematical statements whose resolution required fundamentally new ideas -- CH was proved independent by Cohen, while BSD remains open"
+      "targetId": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "Both are famous mathematical problems whose resolution has required fundamentally new ideas. CH was proved independent of ZFC by Gödel (consistency, 1940) and Cohen (independence, 1963), while BSD remains open with only partial results (ranks 0 and 1 proved by Kolyvagin and Gross-Zagier)"
     },
     {
-      "targetProofId": "e-transcendental",
-      "relationship": "Transcendence theory connects to BSD via the Schneider-Lang theorem and periods of elliptic curves"
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "Transcendence theory connects to BSD via the Schneider-Lang theorem and periods of elliptic curves. The real period $\\Omega_E$ appearing in the BSD formula is a transcendental number (by Schneider's theorem on elliptic integrals), and its arithmetic significance is a key ingredient in the exact BSD formula"
+    },
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Wiles's proof of FLT (1995) established the modularity of semistable elliptic curves over $\\mathbb{Q}$ — the same modularity that is essential for BSD. The Taniyama-Shimura-Weil conjecture (now the modularity theorem, proved in full by Breuil-Conrad-Diamond-Taylor 2001) ensures that the L-function $L(E,s)$ in BSD has the analytic properties needed for the conjecture to make sense. FLT and BSD are thus siblings in the modularity framework"
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "Quadratic reciprocity is the simplest case of Artin reciprocity, which in turn is the abelian case of the Langlands program. The L-function $L(E,s)$ in BSD is a degree-2 automorphic L-function, and the Langlands program predicts deep connections between such L-functions and automorphic forms — generalizing the quadratic reciprocity law from $\\text{GL}_1$ to $\\text{GL}_2$"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The congruent number problem — which integers are areas of right triangles with rational sides? — provides the most classical bridge from Pythagorean triples to BSD. A positive integer $n$ is congruent iff the elliptic curve $y^2 = x^3 - n^2 x$ has positive rank. This file formalizes the congruent number curve $E_{37}: y^2 = x^3 - 37^2 x$ and the Koblitz correspondence between rational right triangles and rational points on $E_n$"
+    },
+    {
+      "targetId": "hodge-conjecture",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning algebraic geometry. The Hodge conjecture and BSD both involve deep connections between algebraic and analytic/topological structures: Hodge asks when cohomology classes are algebraic, while BSD asks when the analytic rank equals the algebraic rank. Both are manifestations of the general principle that algebraic and analytic invariants of varieties should be closely related"
+    },
+    {
+      "targetId": "poincare-conjecture",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem, uniquely among the seven to have been solved (by Perelman, 2003). The Poincaré conjecture (every simply connected closed 3-manifold is homeomorphic to $S^3$) was proved using Ricci flow, a geometric analysis technique — illustrating how the deepest problems in different areas of mathematics require fundamentally different approaches"
+    },
+    {
+      "targetId": "navier-stokes",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning the existence and smoothness of solutions to the Navier-Stokes equations. Both BSD and Navier-Stokes involve proving that analytic objects (L-functions / fluid velocity fields) have specific regularity properties, though the mathematical tools are entirely different (algebraic number theory vs PDE analysis)"
+    },
+    {
+      "targetId": "yang-mills",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning the existence of a mass gap in quantum Yang-Mills theory. Both BSD and Yang-Mills involve non-perturbative phenomena in their respective domains (arithmetic geometry / quantum field theory) that resist existing proof techniques"
     }
   ],
   "sections": [
@@ -640,11 +680,18 @@
     "definitionCount": 143
   },
   "relatedProofs": [
-    "",
-    "",
-    "",
-    "",
-    ""
+    "fundamental-theorem-algebra",
+    "riemann-hypothesis",
+    "p-vs-np",
+    "continuum-hypothesis",
+    "e-transcendental",
+    "fermats-last-theorem",
+    "quadratic-reciprocity",
+    "pythagorean-theorem",
+    "hodge-conjecture",
+    "poincare-conjecture",
+    "navier-stokes",
+    "yang-mills"
   ],
   "references": [
     {


### PR DESCRIPTION
Enrichment pass 1 for birch-swinnerton-dyer (quality: 100, passes: 0).

## Changes
- **Fixed cross-reference schema**: `targetProofId` → `targetId`, added proper `relationship` and `description` fields
- **Fixed broken `relatedProofs`**: was 5 empty strings, now 12 valid IDs
- **Added 7 new cross-references**:
  - `fermats-last-theorem`: Wiles's modularity theorem connects FLT and BSD
  - `quadratic-reciprocity`: Artin reciprocity → Langlands program → BSD L-functions
  - `pythagorean-theorem`: Congruent number problem bridges Pythagorean triples to BSD
  - `hodge-conjecture`: Millennium Prize sibling (algebraic geometry)
  - `poincare-conjecture`: Millennium Prize sibling (solved by Perelman)
  - `navier-stokes`: Millennium Prize sibling (PDE analysis)
  - `yang-mills`: Millennium Prize sibling (QFT)

Cross-references: 5 → 12