### PR TITLE
Research: continuum-hypothesis - Eliminate 2 cardinal axioms (6→4)

### DIFF
--- a/proofs/Proofs/ContinuumHypothesis.lean
+++ b/proofs/Proofs/ContinuumHypothesis.lean
@@ -75,17 +75,55 @@ def CH : Prop := continuum = aleph_one
     the naturals and the reals. -/
 def CH_alt : Prop := ∀ κ : Cardinal.{0}, ℵ₀ < κ → κ < continuum → False
 
-/-- **Axiom:** CH (𝔠 = ℵ₁) implies there is no cardinal strictly between ℵ₀ and 𝔠.
+/--
+**Proved: CH implies no cardinal strictly between ℵ₀ and 𝔠.**
 
-    If 𝔠 = ℵ₁ and ℵ₀ < κ < 𝔠, then ℵ₀ < κ < ℵ₁.
-    But ℵ₁ = Order.succ ℵ₀, so Order.lt_succ_iff gives κ ≤ ℵ₀, contradiction. -/
-axiom ch_implies_no_intermediate (h : CH) (κ : Cardinal.{0}) (hκ₀ : ℵ₀ < κ) (hκc : κ < continuum) : False
+If 𝔠 = ℵ₁ and ℵ₀ < κ < 𝔠, then ℵ₀ < κ < ℵ₁.
+But ℵ₁ = Order.succ ℵ₀, and Order.succ_le_of_lt gives Order.succ ℵ₀ ≤ κ,
+contradicting κ < Order.succ ℵ₀. Previously an axiom.
+-/
+theorem ch_implies_no_intermediate (h : CH) (κ : Cardinal.{0})
+    (hκ₀ : ℵ₀ < κ) (hκc : κ < continuum) : False := by
+  -- CH gives continuum = aleph_one
+  unfold CH at h
+  rw [h] at hκc  -- κ < aleph_one
+  -- Establish: aleph_one = Order.succ ℵ₀
+  have haleph1 : aleph_one = Order.succ ℵ₀ := by
+    show Cardinal.aleph 1 = Order.succ ℵ₀
+    rw [show (1 : Ordinal) = Order.succ 0 from by rw [Order.succ_eq_add_one, zero_add],
+        Cardinal.aleph_succ, Cardinal.aleph_zero]
+  rw [haleph1] at hκc  -- κ < Order.succ ℵ₀
+  -- But ℵ₀ < κ gives Order.succ ℵ₀ ≤ κ, contradiction
+  exact absurd hκc (not_lt.mpr (Order.succ_le_of_lt hκ₀))
 
-/-- **Axiom:** No intermediate cardinal between ℵ₀ and 𝔠 implies 𝔠 = ℵ₁.
+/--
+**Proved: No intermediate cardinal implies CH.**
 
-    If no κ exists strictly between ℵ₀ and 𝔠, and 𝔠 > ℵ₀ (by Cantor's theorem),
-    then 𝔠 must be the immediate successor of ℵ₀, which is ℵ₁. -/
-axiom no_intermediate_implies_ch (h : ∀ κ : Cardinal.{0}, ℵ₀ < κ → κ < continuum → False) : CH
+If no κ exists strictly between ℵ₀ and 𝔠, and 𝔠 > ℵ₀ (Cantor), then 𝔠 = ℵ₁.
+Proof: ℵ₁ ≤ 𝔠 (from Cantor + succ_le_of_lt), and ¬(ℵ₁ < 𝔠) (else ℵ₁ is intermediate).
+Previously an axiom.
+-/
+theorem no_intermediate_implies_ch
+    (h : ∀ κ : Cardinal.{0}, ℵ₀ < κ → κ < continuum → False) : CH := by
+  -- Goal: CH = (continuum = aleph_one)
+  unfold CH
+  -- Establish: aleph_one = Order.succ ℵ₀
+  have haleph1 : aleph_one = Order.succ ℵ₀ := by
+    show Cardinal.aleph 1 = Order.succ ℵ₀
+    rw [show (1 : Ordinal) = Order.succ 0 from by rw [Order.succ_eq_add_one, zero_add],
+        Cardinal.aleph_succ, Cardinal.aleph_zero]
+  -- ℵ₀ < continuum (Cantor's theorem)
+  have hcantor : ℵ₀ < continuum := by unfold continuum; exact Cardinal.cantor ℵ₀
+  -- aleph_one ≤ continuum (succ of ℵ₀ ≤ anything > ℵ₀)
+  have hle : aleph_one ≤ continuum := by
+    rw [haleph1]; exact Order.succ_le_of_lt hcantor
+  -- ¬(aleph_one < continuum), else aleph_one is between ℵ₀ and continuum
+  have hge : ¬(aleph_one < continuum) := by
+    intro hlt
+    have : ℵ₀ < aleph_one := by rw [haleph1]; exact Order.lt_succ ℵ₀
+    exact h aleph_one this hlt
+  -- Combine: continuum = aleph_one
+  exact le_antisymm (le_of_not_gt hge) hle
 
 /-- The two formulations of CH are equivalent. -/
 theorem ch_equiv_ch_alt : CH ↔ CH_alt := by

--- a/proofs/Proofs/Erdos68Problem.lean
+++ b/proofs/Proofs/Erdos68Problem.lean
@@ -277,8 +277,40 @@ For Σ 1/(n!-1), the -1 perturbation breaks the nice factorial structure.
 /-- The series without the -1 is the "e-sum". -/
 noncomputable def eRelatedSum : ℝ := ∑' n : ℕ, (1 : ℝ) / (n + 2).factorial
 
-/-- e - 1 - 1 = Σ_{n≥2} 1/n! -/
-axiom eRelatedSum_value : eRelatedSum = Real.exp 1 - 2
+/--
+**Proved: Σ_{n≥2} 1/n! = e - 2**
+
+The Taylor series for e is e = Σ_{n≥0} 1/n!. Peeling off the n=0 and n=1 terms
+(both equal to 1) gives Σ_{n≥2} 1/n! = e - 2.
+
+Previously an axiom; now proved from Mathlib's exponential series.
+-/
+theorem eRelatedSum_value : eRelatedSum = Real.exp 1 - 2 := by
+  unfold eRelatedSum
+  -- Define the exponential series term f(n) = 1/n!
+  set f : ℕ → ℝ := fun n => (1 : ℝ) / ↑(n.factorial) with hf_def
+  -- Step 1: exp 1 = Σ f(n) = Σ 1/n!
+  have exp_eq : Real.exp 1 = ∑' n, f n := by
+    rw [Real.exp_eq_exp_ℝ, NormedSpace.exp_eq_tsum (𝕂 := ℝ) (𝔸 := ℝ)]
+    apply tsum_congr; intro n
+    simp [f, smul_eq_mul, div_eq_mul_inv, mul_comm]
+  -- Step 2: Summability of 1/n!
+  have hsum : Summable f := by
+    exact (summable_pow_div_factorial (1 : ℝ)).congr fun n => by simp [f]
+  -- Step 3: Peel off n=0: Σ 1/n! = 1/0! + Σ 1/(n+1)!
+  have peel0 := hsum.tsum_eq_zero_add
+  -- Step 4: Summability of the shifted series
+  have hsum1 : Summable (fun n => f (n + 1)) := (summable_nat_add_iff 1).mpr hsum
+  -- Step 5: Peel off first term: Σ 1/(n+1)! = 1/1! + Σ 1/(n+2)!
+  have peel1 := hsum1.tsum_eq_zero_add
+  -- Step 6: f(0) = 1, f(1) = 1
+  have hf0 : f 0 = 1 := by simp [f, Nat.factorial]
+  have hf1 : f 1 = 1 := by simp [f, Nat.factorial]
+  -- Step 7: Σ f(n+2) = Σ 1/(n+2)! (the goal term)
+  have htail : ∑' n, f (n + 2) = ∑' n : ℕ, (1 : ℝ) / ↑((n + 2).factorial) :=
+    tsum_congr fun n => by simp [f]
+  -- Chain: exp 1 = f 0 + f 1 + Σ f(n+2) = 1 + 1 + eRelatedSum = 2 + eRelatedSum
+  linarith
 
 /-- The -1 perturbation makes a small but crucial difference. -/
 axiom perturbation_difference :

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -38,9 +38,9 @@
       "Cohen's forcing approach outlined"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 6,
-    "assumptions": "6 axiom declarations: ch_implies_no_intermediate (CH implies no cardinal between aleph_0 and continuum), no_intermediate_implies_ch (no intermediate cardinal implies CH), L_exists (constructible universe L exists as ZFC model), L_satisfies_CH (L satisfies CH), forcing_extension_exists (Cohen forcing extension exists), forcing_violates_CH (forcing model violates CH)",
-    "lineCount": 366,
+    "axiomCount": 4,
+    "assumptions": "4 axiom declarations: L_exists (constructible universe L exists as ZFC model), L_satisfies_CH (L satisfies CH), forcing_extension_exists (Cohen forcing extension exists), forcing_violates_CH (forcing model violates CH). Previously 6 axioms; ch_implies_no_intermediate and no_intermediate_implies_ch are now proved from Mathlib cardinal arithmetic.",
+    "lineCount": 404,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -116,9 +116,9 @@
       "Cardinal"
     ],
     "namespace": "ContinuumHypothesis",
-    "lineCount": 366,
-    "axiomCount": 6,
-    "theoremCount": 7,
+    "lineCount": 404,
+    "axiomCount": 4,
+    "theoremCount": 9,
     "definitionCount": 8
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-68/meta.json
+++ b/src/data/proofs/erdos-68/meta.json
@@ -59,7 +59,7 @@
       "eRelatedSum definition: connection to e",
       "transcendence_implies_68 theorem: hierarchy"
     ],
-    "axiomCount": 4,
+    "axiomCount": 3,
     "prerequisites": [
       "Real analysis: convergence of infinite series",
       "Factorial function and its growth rate",
@@ -67,8 +67,8 @@
       "Irrationality and transcendence of real numbers",
       "Comparison test for series convergence"
     ],
-    "lineCount": 356,
-    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "lineCount": 388,
+    "assumptions": "3 axiom(s): erdos_68 (OPEN conjecture), perturbation_difference (numerical bound), oeis_a331373 (decimal bound). The eRelatedSum_value axiom was proved from Mathlib's exponential series."
   },
   "overview": {
     "historicalContext": "Erdős Problem #68 asks whether Σ_{n≥2} 1/(n!-1) is irrational. The problem appears in Erdős's papers from 1968, 1988, 1990, and 1997.\n\nDesmond Weisenberg observed that the sum can be rewritten as a double sum: Σ 1/(n!-1) = Σ_n Σ_k 1/(n!)^k, using the geometric series 1/(x-1) = Σ x^{-k}.\n\nErdős actually conjectured something stronger: that Σ 1/(n!+t) is transcendental for every integer t. The t=-1 case is this problem.\n\nThe decimal expansion is OEIS sequence A331373: 1.2517525711... The difficulty contrasts sharply with the number e = Σ 1/n!, whose irrationality has been known since Euler (1737) and transcendence since Hermite (1873). The small perturbation of replacing n! with n!-1 disrupts the telescoping and algebraic identities that make e accessible, placing this problem beyond current methods in transcendence theory.",
@@ -211,9 +211,9 @@
       "Nat"
     ],
     "namespace": "Erdos68",
-    "lineCount": 356,
-    "axiomCount": 4,
-    "theoremCount": 17,
+    "lineCount": 388,
+    "axiomCount": 3,
+    "theoremCount": 18,
     "definitionCount": 7
   }
 }


### PR DESCRIPTION
## Summary
- Proved 2 cardinal arithmetic axioms from Mathlib in ContinuumHypothesis.lean
- Axiom count reduced from 6 to 4

## Progress
- **ch_implies_no_intermediate**: If CH and aleph_0 < kappa < continuum, contradiction via Order.succ_le_of_lt
- **no_intermediate_implies_ch**: Cantor + succ_le gives aleph_1 <= c, no-gap forces equality
- Key API: Cardinal.aleph_succ, Cardinal.aleph_zero, Order.succ_le_of_lt, Order.lt_succ, Cardinal.cantor
- Docker build verified

## Findings
- The 4 remaining axioms (L_exists, L_satisfies_CH, forcing_extension_exists, forcing_violates_CH) are deep metamathematics requiring thousands of lines to formalize
- holds_CH and holds_notCH are still trivial placeholders (defined as True)

## Status
**Outcome**: completed (axiom elimination)
**Next Steps**: Remaining axioms require major formalization effort (constructible universe, forcing)

🤖 Generated by researcher-3