### PR TITLE
Enrich dissection-of-cubes: expand cross-references

### DIFF
--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -165,6 +165,16 @@
       "targetId": "angle-trisection",
       "relationship": "thematic",
       "description": "Both are impossibility results in geometry: angle trisection shows certain constructions are impossible with compass and straightedge, while cube dissection shows certain geometric decompositions are impossible"
+    },
+    {
+      "targetId": "dissection-of-cubes-oq-01",
+      "relationship": "extended-by",
+      "description": "OQ-01 explores extensions and variations of the cube dissection impossibility, including higher-dimensional analogues and related open problems in combinatorial geometry"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Both are structural impossibility results: Abel-Ruffini reduces quintic unsolvability to the non-solvability of $S_5$, while cube dissection reduces geometric impossibility to infinite descent on the smallest cube — each identifies a fundamental structural obstruction"
     }
   ],
   "references": [
@@ -206,6 +216,8 @@
   ],
   "relatedProofs": [
     "hilbert-10",
-    "angle-trisection"
+    "angle-trisection",
+    "dissection-of-cubes-oq-01",
+    "abel-ruffini"
   ]
 }


### PR DESCRIPTION
Enrichment pass 1 for dissection-of-cubes (Dissection of Cubes, Wiedijk #82).

**Changes:**
- Added 2 cross-references: dissection-of-cubes-oq-01 (extension), abel-ruffini (structural impossibility theme)
- Updated relatedProofs array (2 → 4 entries)