### PR TITLE
Research: erdos-1149 - add proved theorems and coprime pair infrastructure

### DIFF
--- a/proofs/Proofs/Erdos1149Problem.lean
+++ b/proofs/Proofs/Erdos1149Problem.lean
@@ -48,6 +48,30 @@ def HasNaturalDensity (S : Set ℕ) (d : ℝ) : Prop :=
     atTop (nhds d)
 
 /-
+## Properties of the Coprime Floor-Power Set
+-/
+
+/-- n = 1 is always coprime to any floor power, since gcd(1, m) = 1. -/
+theorem one_isFloorPowerCoprime (α : ℝ) : IsFloorPowerCoprime α 1 :=
+  Nat.coprime_one_left _
+
+/-- 1 is always in the coprime floor-power set. -/
+theorem one_mem_coprimeFloorPowerSet (α : ℝ) : 1 ∈ coprimeFloorPowerSet α :=
+  ⟨Nat.one_pos, one_isFloorPowerCoprime α⟩
+
+/-- The coprime floor-power set is always nonempty (contains 1). -/
+theorem coprimeFloorPowerSet_nonempty (α : ℝ) : (coprimeFloorPowerSet α).Nonempty :=
+  ⟨1, one_mem_coprimeFloorPowerSet α⟩
+
+/-- If ⌊n^α⌋ = 1, then n is coprime to ⌊n^α⌋. This covers
+    the regime 1 < n^α < 2 (e.g., small α or small n). -/
+theorem coprime_of_floor_eq_one (α : ℝ) (n : ℕ)
+    (h : Nat.floor ((n : ℝ) ^ α) = 1) : IsFloorPowerCoprime α n := by
+  unfold IsFloorPowerCoprime
+  rw [h]
+  exact Nat.coprime_one_right n
+
+/-
 ## The Main Theorem
 -/
 
@@ -109,6 +133,17 @@ theorem integer_alpha_trivial (k : ℕ) (hk : 0 < k) :
   rw [hcop] at this
   exact Nat.not_lt.mpr (Nat.le_of_dvd one_pos this) hn
 
+/-- The density 6/π² lies strictly in the open interval (0, 1). -/
+theorem density_mem_Ioo : 6 / Real.pi ^ 2 ∈ Set.Ioo (0 : ℝ) 1 :=
+  ⟨density_pos, density_lt_one⟩
+
+/-- The Bergelson-Richter theorem restated using HasNaturalDensity:
+    the coprime floor-power set has natural density 6/π². -/
+theorem bergelson_richter_density (α : ℝ) (hα_pos : 0 < α)
+    (hα_nonint : ∀ k : ℤ, (k : ℝ) ≠ α) :
+    HasNaturalDensity (coprimeFloorPowerSet α) (6 / Real.pi ^ 2) :=
+  bergelson_richter α hα_pos hα_nonint
+
 /-
 ## Connection to Coprime Probability
 
@@ -129,6 +164,21 @@ axiom random_coprime_density :
         Nat.Coprime p.1 p.2} : ℝ) / (N : ℝ) ^ 2)
       Filter.atTop
       (nhds (6 / Real.pi ^ 2))
+
+/-- Coprime pair counting via Finset (decidable/computable).
+    Counts |{(a,b) ∈ [1,N]² : gcd(a,b) = 1}| using a finite computation. -/
+def countCoprimePairs (N : ℕ) : ℕ :=
+  ((Finset.Icc 1 N ×ˢ Finset.Icc 1 N).filter
+    (fun p => Nat.Coprime p.1 p.2)).card
+
+/-- Coprime pair symmetry: (a,b) coprime iff (b,a) coprime.
+    Hence countCoprimePairs counts each pair's contribution equally. -/
+theorem coprime_pair_symm (a b : ℕ) : Nat.Coprime a b ↔ Nat.Coprime b a :=
+  ⟨Nat.Coprime.symm, Nat.Coprime.symm⟩
+
+/-- The coprime pair count at N = 1 is exactly 1: only (1,1). -/
+theorem countCoprimePairs_one : countCoprimePairs 1 = 1 := by
+  native_decide
 
 /-
 ## Computational Verification (small cases)

--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -25,14 +25,19 @@
     "erdosUrl": "https://erdosproblems.com/1149",
     "erdosProblemStatus": "solved",
     "dateAdded": "2026-03-11",
-    "dateUpdated": "2026-03-11",
+    "dateUpdated": "2026-03-23",
     "mathlib_version": "4.26.0",
     "originalContributions": [
-      "Definition IsFloorPowerCoprime, coprimeFloorPowerSet, countCoprime, HasNaturalDensity",
+      "Definition IsFloorPowerCoprime, coprimeFloorPowerSet, countCoprime, HasNaturalDensity, countCoprimePairs",
       "Proved density_equals_inv_zeta2 (algebraic identity)",
       "Proved density_pos (6/π² > 0)",
       "Proved density_lt_one (6/π² < 1, using π > 3)",
       "Proved integer_alpha_trivial (integer exponents give density 0)",
+      "Proved one_isFloorPowerCoprime, one_mem_coprimeFloorPowerSet, coprimeFloorPowerSet_nonempty",
+      "Proved coprime_of_floor_eq_one (floor = 1 implies coprime)",
+      "Proved density_mem_Ioo (6/π² ∈ (0, 1))",
+      "Proved bergelson_richter_density (HasNaturalDensity reformulation)",
+      "Proved coprime_pair_symm, countCoprimePairs_one (coprime pair infrastructure)",
       "Axiom bergelson_richter (main theorem)",
       "Axiom random_coprime_density (classical 6/π² coprime probability)"
     ],
@@ -81,16 +86,16 @@
       "Bounds on pi (Real.pi_pos, Real.pi_gt_three)",
       "Divisibility and powers (dvd_pow_self)"
     ],
-    "lineCount": 168,
+    "lineCount": 218,
     "assumptions": "2 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
-    "summary": "Formalizes Erdős Problem #1149, solved by Bergelson and Richter (2017): for non-integer α > 0, the natural density of integers n with gcd(n, ⌊n^α⌋) = 1 is exactly 6/π². The main theorem is axiomatized (deep ergodic theory), with supporting results proved: density bounds 0 < 6/π² < 1, integer exponent exclusion, and the connection to classical coprime probability. 168 lines, 0 sorries, 2 axioms.",
+    "summary": "Formalizes Erdős Problem #1149, solved by Bergelson and Richter (2017): for non-integer α > 0, the natural density of integers n with gcd(n, ⌊n^α⌋) = 1 is exactly 6/π². The main theorem is axiomatized (deep ergodic theory), with 13 proved theorems: density bounds, coprime set properties (nonemptiness, n=1 membership, floor=1 criterion), HasNaturalDensity reformulation, coprime pair counting infrastructure, and integer exponent exclusion. 218 lines, 0 sorries, 2 axioms.",
     "keyIdea": "The value 6/π² = 1/ζ(2) is the probability that two 'random' integers are coprime. The Bergelson-Richter theorem shows that n and ⌊n^α⌋ achieve exactly this coprime density despite being deterministically related — the floor-power function acts as a 'pseudorandom' generator for coprimality. The integer case is degenerate (gcd(n, n^k) = n), making the non-integer hypothesis essential.",
     "historicalContext": "Erdős asked whether $n$ and $\\lfloor n^\\alpha \\rfloor$ (for irrational $\\alpha > 1$) are coprime with natural density $6/\\pi^2 = 1/\\zeta(2) \\approx 0.6079$. This value is the classical probability that two uniformly random integers are coprime, first computed by Cesàro (1881) and Sylvester using Euler's product formula $\\prod_p (1 - 1/p^2) = 6/\\pi^2$.\n\nThe difficulty lies in the deterministic structure of the sequence $\\lfloor n^\\alpha \\rfloor$: unlike random integers, it has specific arithmetic properties that could bias coprimality. Vitaly Bergelson and Florian K. Richter (2017) proved Erdős's conjecture affirmatively, showing that the coprimality density is indeed $6/\\pi^2$ for any irrational $\\alpha > 1$. Their proof uses the theory of multiplicative functions along polynomial sequences and results from ergodic theory, establishing that the 'randomness' expectation holds for this structured sequence.",
     "problemStatement": "**Erdős Problem #1149** (SOLVED): Let $\\alpha > 0$ be a non-integer. Then\n$$\\lim_{N \\to \\infty} \\frac{|\\{n \\leq N : \\gcd(n, \\lfloor n^\\alpha \\rfloor) = 1\\}|}{N} = \\frac{6}{\\pi^2}.$$",
     "text": "The density of integers n where gcd(n, ⌊n^α⌋) = 1 is 6/π² for non-integer α > 0. This shows n and ⌊n^α⌋ behave as 'independent random integers' for coprimality.",
-    "proofStrategy": "The formalization has five layers:\n\n1. **Definitions**: IsFloorPowerCoprime α n via Nat.Coprime, coprimeFloorPowerSet as the set of positive coprime n, countCoprime as the finite counting function via Set.ncard, and HasNaturalDensity via Filter.Tendsto\n2. **Main Theorem (axiom)**: bergelson_richter axiomatizes the Bergelson-Richter result; erdos_1149_solved wraps it\n3. **Algebraic Identity**: density_equals_inv_zeta2 proves 6/π² = 1/(π²/6) by ring, connecting to ζ(2)\n4. **Density Bounds**: density_pos from π² > 0; density_lt_one from π > 3 ⟹ π² > 9 > 6 via nlinarith\n5. **Integer Exclusion**: integer_alpha_trivial shows gcd(n, n^k) ≠ 1 for n > 1 via dvd_pow_self and Nat.dvd_gcd\n6. **Classical Context**: random_coprime_density (axiom) states the classical coprime pair density is 6/π²",
+    "proofStrategy": "The formalization has seven layers:\n\n1. **Definitions**: IsFloorPowerCoprime α n via Nat.Coprime, coprimeFloorPowerSet, countCoprime (Set.ncard), HasNaturalDensity (Filter.Tendsto), countCoprimePairs (Finset, computable)\n2. **Coprime Set Properties**: one_isFloorPowerCoprime (n=1 always coprime), one_mem_coprimeFloorPowerSet, coprimeFloorPowerSet_nonempty, coprime_of_floor_eq_one\n3. **Main Theorem (axiom)**: bergelson_richter axiomatizes the Bergelson-Richter result; erdos_1149_solved and bergelson_richter_density (HasNaturalDensity form) wrap it\n4. **Algebraic Identity**: density_equals_inv_zeta2 proves 6/π² = 1/(π²/6) by ring\n5. **Density Bounds**: density_pos, density_lt_one, density_mem_Ioo (6/π² ∈ (0,1))\n6. **Integer Exclusion**: integer_alpha_trivial shows gcd(n, n^k) ≠ 1 for n > 1\n7. **Coprime Pair Infrastructure**: countCoprimePairs (decidable counting), coprime_pair_symm, countCoprimePairs_one — infrastructure toward proving random_coprime_density",
     "keyInsights": [
       "The independence phenomenon: n and ⌊n^α⌋ achieve exactly the coprime density 6/π² of random integers, despite being deterministically related — the non-integer exponent destroys arithmetic correlations",
       "6/π² = 1/ζ(2) = ∏_p(1-1/p²): the Euler product connects coprimality to the Riemann zeta function at s=2",
@@ -198,10 +203,10 @@
       "Set"
     ],
     "namespace": "Erdos1149",
-    "lineCount": 168,
+    "lineCount": 218,
     "axiomCount": 2,
-    "theoremCount": 5,
-    "definitionCount": 4
+    "theoremCount": 13,
+    "definitionCount": 5
   },
   "references": [
     {

--- a/src/data/research/problems/erdos-1149.json
+++ b/src/data/research/problems/erdos-1149.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1149",
   "title": "Erdős #1149",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-15T16:24:55.487Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Proving random_coprime_density axiom from Mathlib tools",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Added 8 proved theorems and 1 computable definition. Set up coprime pair counting infrastructure (countCoprimePairs via Finset). Path to proving random_coprime_density identified: Möbius inversion + hasSum_zeta_two.",
+    "builtItems": [
+      "one_isFloorPowerCoprime: n=1 always coprime (Erdos1149Problem.lean:55)",
+      "one_mem_coprimeFloorPowerSet: 1 ∈ coprime set (Erdos1149Problem.lean:59)",
+      "coprimeFloorPowerSet_nonempty: set nonempty (Erdos1149Problem.lean:63)",
+      "coprime_of_floor_eq_one: floor=1 criterion (Erdos1149Problem.lean:68)",
+      "density_mem_Ioo: 6/π² ∈ (0,1) (Erdos1149Problem.lean:137)",
+      "bergelson_richter_density: HasNaturalDensity reformulation (Erdos1149Problem.lean:142)",
+      "countCoprimePairs: Finset-based coprime pair counter (Erdos1149Problem.lean:170)",
+      "coprime_pair_symm: coprimality symmetry (Erdos1149Problem.lean:176)",
+      "countCoprimePairs_one: verified N=1 case (Erdos1149Problem.lean:180)"
+    ],
+    "insights": [
+      "Mathlib has hasSum_zeta_two (Basel problem: ∑1/n² = π²/6) — key ingredient for proving random_coprime_density",
+      "Mathlib has ArithmeticFunction.moebius — needed for Möbius inversion in coprime pair counting",
+      "random_coprime_density could potentially be proved: needs Möbius inversion + hasSum_zeta_two + asymptotic analysis",
+      "bergelson_richter axiom is NOT provable from Mathlib (requires deep ergodic theory)",
+      "n=1 is always coprime (Nat.coprime_one_left), floor=1 implies coprime (Nat.coprime_one_right)",
+      "countCoprimePairs provides computable Finset-based infrastructure for future work on random_coprime_density"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove random_coprime_density from hasSum_zeta_two via Möbius inversion (eliminate 1 axiom)",
+      "Step 1: Prove ∑_{d=1}^N μ(d)⌊N/d⌋² = countCoprimePairs N (Möbius counting identity)",
+      "Step 2: Show countCoprimePairs N / N² → ∑_{d=1}^∞ μ(d)/d² (asymptotic analysis)",
+      "Step 3: Prove ∑_{d=1}^∞ μ(d)/d² = 6/π² using Euler product + hasSum_zeta_two"
+    ],
     "markdown": "# Erdős #1149 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Added 8 proved theorems to Erdős #1149 formalization (coprimality of n and ⌊n^α⌋)
- Introduced computable coprime pair counting function (countCoprimePairs via Finset)
- All new code builds successfully with 0 sorries, 0 new axioms

## Progress
- **Coprime set properties**: `one_isFloorPowerCoprime`, `one_mem_coprimeFloorPowerSet`, `coprimeFloorPowerSet_nonempty`, `coprime_of_floor_eq_one`
- **Density bounds**: `density_mem_Ioo` (6/π² ∈ (0,1))
- **HasNaturalDensity reformulation**: `bergelson_richter_density`
- **Coprime pair infrastructure**: `countCoprimePairs` (Finset-based, decidable), `coprime_pair_symm`, `countCoprimePairs_one` (verified via native_decide)

## Findings
- Mathlib has `hasSum_zeta_two` (Basel problem) and `ArithmeticFunction.moebius` — both needed to prove `random_coprime_density`
- Path to eliminating 1 axiom identified: Möbius inversion + Basel problem + asymptotic analysis
- `bergelson_richter` axiom is NOT provable from Mathlib (requires deep ergodic theory)

## Status
**Outcome**: progress
**Next Steps**: Prove `random_coprime_density` from Mathlib tools (3-step plan documented in knowledge)

🤖 Generated by researcher-5