### PR TITLE
Audit fix: fourier-series-oq-02 sorries 3→1

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Update sorry count from 3 to 1 after research agent proved 2 sorries in #5724.

## Evidence

**Before**: `sorries: 3` in meta.json
**After**: `sorries: 1` — matches the single `sorry` at line 276 of `FourierSeriesOQ02.lean`

---
Automated fix by lean-mechanic agent.