### PR TITLE
Audit batch 6j: 29 proofs audited, re-fix erdos-1072

### DIFF
--- a/src/data/proofs/erdos-1072/meta.json
+++ b/src/data/proofs/erdos-1072/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 1072,
     "erdosUrl": "https://erdosproblems.com/1072",
     "erdosProblemStatus": "open",
-    "axiomCount": 9,
+    "axiomCount": 8,
     "lineCount": 125,
-    "assumptions": "9 axiom(s). Proved: wilson_theorem (from Mathlib ZMod.wilsons_lemma) and f_le_pred (from Wilson). Removed wilson_prime_distinction (dubious claim). Remaining: 3 open conjectures + 4 small values + f_pos."
+    "assumptions": "8 axiom declarations. Proved: wilson_theorem (from Mathlib ZMod.wilsons_lemma) and f_le_pred (from Wilson). Remaining: 2 open conjectures (erdos_1072a, erdos_1072b) + hardy_subbarao_belief + 4 small values (f_of_2/3/5/7) + f_pos."
   },
   "overview": {
     "historicalContext": "Erdős, Hardy, and Subbarao posed this problem in their 2002 American Mathematical Monthly paper on problems involving factorials. The question builds directly on Wilson's theorem—proved by Lagrange in 1771 and named after John Wilson—which guarantees that $(p-1)! \\equiv -1 \\pmod{p}$ for every prime $p$. The natural follow-up is: can this congruence be achieved earlier? The function $f(p) = \\min\\{n \\geq 1 : n! \\equiv -1 \\pmod{p}\\}$ measures how early the Wilson congruence first appears. Computational evidence (OEIS A154554) shows that $f(p)$ is often much smaller than $p-1$: for instance $f(7) = 3$ since $3! + 1 = 7$, and $f(23) = 14$. Hardy and Subbarao conjectured that Wilson-maximal primes (where $f(p) = p-1$) have density zero among all primes, paralleling the sparsity conjectures for twin primes and Wilson primes. The problem also connects to Guy's *Unsolved Problems in Number Theory* (Problem A2) and to the broader Erdős program of understanding the arithmetic of factorials. The question about Wilson primes—primes $p$ with $p^2 \\mid (p-1)! + 1$—is a related but much harder condition; only three Wilson primes ($5, 13, 563$) are known despite searches to $5 \\times 10^{17}$.",
@@ -222,7 +222,7 @@
     ],
     "namespace": null,
     "lineCount": 125,
-    "axiomCount": 9,
+    "axiomCount": 8,
     "theoremCount": 2,
     "definitionCount": 2
   }


### PR DESCRIPTION
## Summary
- Audited 29 gallery proofs — all clean
- Re-fixed erdos-1072 axiomCount 9→8 (enricher had overwritten previous fix)

## erdos-1072 fix
The Lean file has 8 axiom declarations (1 `noncomputable axiom` + 7 `axiom`), not 9. The previous fix in PR #5704 was overwritten by an enricher pass.

## Proofs audited (all clean)
borsuk-ulam, brouwer-fixed-point, cayley-hamilton, e-transcendental-oq-01, elementary-quadratic-reciprocity-oq-03, erdos-103, erdos-1088, erdos-1103, erdos-1171, erdos-172, erdos-185, erdos-189, erdos-300, erdos-338, erdos-360, erdos-39, erdos-492, erdos-544, erdos-559, erdos-599, erdos-612, erdos-620, erdos-668, erdos-706, erdos-724, erdos-759, erdos-803, erdos-89, erdos-962

🤖 Generated with [Claude Code](https://claude.com/claude-code)