### PR TITLE
Research: erdos-536 + erdos-1117 - Eliminate 7 axioms

### DIFF
--- a/proofs/Proofs/Erdos1117Problem.lean
+++ b/proofs/Proofs/Erdos1117Problem.lean
@@ -19,39 +19,45 @@ The question is how ν(r) can grow.
 Reference: https://erdosproblems.com/1117
 -/
 
-import Mathlib.Analysis.Complex.Basic
-import Mathlib.Topology.Basic
-import Mathlib.Tactic
+import Mathlib
 
 /- ## Core Definitions -/
 
-/-- An entire function: a function ℂ → ℂ that is holomorphic on all of ℂ. -/
-axiom IsEntire (f : ℂ → ℂ) : Prop
+/-- An entire function: holomorphic (ℂ-differentiable) on all of ℂ.
+    Previously an axiom; now a proper definition using Mathlib's Differentiable. -/
+def IsEntire (f : ℂ → ℂ) : Prop := Differentiable ℂ f
 
 /-- f is a monomial: f(z) = c·z^n for some c ∈ ℂ and n ∈ ℕ. -/
 def IsMonomial (f : ℂ → ℂ) : Prop :=
   ∃ (c : ℂ) (n : ℕ), ∀ z : ℂ, f z = c * z ^ n
 
-/-- The maximum modulus M(r): max_{|z|=r} |f(z)|. -/
-axiom maxModulus (f : ℂ → ℂ) (r : ℝ) : ℝ
+/-- The maximum modulus M(r): sup_{|z|=r} |f(z)|.
+    Previously an axiom; now a proper definition. -/
+noncomputable def maxModulus (f : ℂ → ℂ) (r : ℝ) : ℝ :=
+  sSup {x : ℝ | ∃ z : ℂ, ‖z‖ = r ∧ x = ‖f z‖}
 
-/-- M(r) is the supremum of |f(z)| on |z| = r. -/
-axiom maxModulus_def (f : ℂ → ℂ) (r : ℝ) (hr : r > 0) :
-    maxModulus f r = sSup {x : ℝ | ∃ z : ℂ, Complex.abs z = r ∧ x = Complex.abs (f z)}
+/-- M(r) is the supremum of |f(z)| on |z| = r. Proved by definition. -/
+theorem maxModulus_def (f : ℂ → ℂ) (r : ℝ) (_hr : r > 0) :
+    maxModulus f r = sSup {x : ℝ | ∃ z : ℂ, ‖z‖ = r ∧ x = ‖f z‖} :=
+  rfl
 
 /-- ν(r): the number of points on |z| = r where |f(z)| = M(r).
-    For non-monomials, this is always finite (for each r). -/
-axiom nu (f : ℂ → ℂ) (r : ℝ) : ℕ
+    Previously an axiom; now a proper definition using Nat.card. -/
+noncomputable def nu (f : ℂ → ℂ) (r : ℝ) : ℕ :=
+  Nat.card {z : ℂ | ‖z‖ = r ∧ ‖f z‖ = maxModulus f r}
 
-/-- ν(r) counts the maximum modulus points on the circle of radius r. -/
-axiom nu_def (f : ℂ → ℂ) (r : ℝ) (hr : r > 0) :
-    nu f r = Nat.card {z : ℂ | Complex.abs z = r ∧ Complex.abs (f z) = maxModulus f r}
+/-- ν(r) counts the maximum modulus points on the circle of radius r. Proved by definition. -/
+theorem nu_def (f : ℂ → ℂ) (r : ℝ) (_hr : r > 0) :
+    nu f r = Nat.card {z : ℂ | ‖z‖ = r ∧ ‖f z‖ = maxModulus f r} :=
+  rfl
 
 /- ## Basic Properties -/
 
-/-- For a non-monomial entire function, ν(r) is finite for each r > 0. -/
-axiom nu_finite (f : ℂ → ℂ) (hent : IsEntire f) (hnm : ¬ IsMonomial f) (r : ℝ)
-    (hr : r > 0) : nu f r < ⊤
+/-- For a non-monomial entire function, ν(r) is finite for each r > 0.
+    Now trivially true since nu returns ℕ. Previously an axiom. -/
+theorem nu_finite (f : ℂ → ℂ) (_hent : IsEntire f) (_hnm : ¬ IsMonomial f) (r : ℝ)
+    (_hr : r > 0) : (nu f r : ℕ∞) < ⊤ :=
+  WithTop.coe_lt_top _
 
 /-- For a non-monomial entire function, ν(r) ≥ 1 for all r > 0
     (the maximum is always achieved on a compact set). -/
@@ -88,8 +94,8 @@ axiom glucksam_pardo_simon_approximate :
     ∃ f : ℂ → ℂ, IsEntire f ∧ ¬ IsMonomial f ∧
       ∀ ε : ℝ, ε > 0 → ∀ N : ℕ, ∃ R : ℝ, ∀ r : ℝ, r > R →
         ∃ (S : Finset ℂ), S.card ≥ N ∧
-          ∀ z ∈ S, Complex.abs z = r ∧
-            Complex.abs (f z) ≥ (1 - ε) * maxModulus f r
+          ∀ z ∈ S, ‖z‖ = r ∧
+            ‖f z‖ ≥ (1 - ε) * maxModulus f r
 
 /- ## Hadamard Three-Circles Context -/
 

--- a/proofs/Proofs/Erdos536Problem.lean
+++ b/proofs/Proofs/Erdos536Problem.lean
@@ -76,12 +76,20 @@ axiom weisenberg_construction :
 
 /- ## Observations -/
 
-/-- **LCM Structure**: [a,b] = [b,c] = [a,c] = L means a, b, c are all
-    divisors of L that pairwise have LCM exactly L. Each pair covers all
-    prime factors of L. -/
-axiom lcm_structure (a b c L : ℕ) :
-  HasEqualPairwiseLCM a b c → a.lcm b = L →
-    a ∣ L ∧ b ∣ L ∧ c ∣ L
+/--
+**Proved: LCM Structure** — if [a,b] = [b,c] = [a,c] = L, then a, b, c all divide L.
+
+Since a ∣ lcm(a,b) and b ∣ lcm(a,b) by Nat.dvd_lcm_left/right, and
+c ∣ lcm(b,c) = lcm(a,b) = L by the equal-LCM hypothesis. Previously an axiom.
+-/
+theorem lcm_structure (a b c L : ℕ) :
+    HasEqualPairwiseLCM a b c → a.lcm b = L →
+      a ∣ L ∧ b ∣ L ∧ c ∣ L := by
+  intro ⟨_, _, _, hab_eq_bc, _⟩ hL
+  refine ⟨?_, ?_, ?_⟩
+  · exact hL ▸ Nat.dvd_lcm_left a b
+  · exact hL ▸ Nat.dvd_lcm_right a b
+  · rw [← hL, hab_eq_bc]; exact Nat.dvd_lcm_right b c
 
 /- **Related Problems**: #535, #537, #856, #857 concern similar questions
     about GCD/LCM patterns in dense sets. -/

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -20,9 +20,9 @@
     "erdosUrl": "https://erdosproblems.com/1117",
     "erdosProblemStatus": "open",
     "badge": "axiom",
-    "axiomCount": 11,
-    "lineCount": 100,
-    "assumptions": "11 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "axiomCount": 5,
+    "lineCount": 106,
+    "assumptions": "5 axiom(s): nu_ge_one, herzog_piranian, erdos_1117_open, glucksam_pardo_simon_approximate, maxModulus_nondecreasing. Converted IsEntire/maxModulus/nu from axioms to defs; proved maxModulus_def, nu_def, nu_finite.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -203,9 +203,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 100,
-    "axiomCount": 11,
-    "theoremCount": 0,
+    "lineCount": 106,
+    "axiomCount": 5,
+    "theoremCount": 3,
     "definitionCount": 1
   }
 }


### PR DESCRIPTION
## Summary
Two axiom elimination sessions:

### erdos-536: LCM Structure (5→4 axioms)
- Proved `lcm_structure` from Mathlib LCM divisibility lemmas

### erdos-1117: Maximum Modulus Points (11→5 axioms)
- Converted `IsEntire`, `maxModulus`, `nu` from axioms to proper defs
- Proved `maxModulus_def`, `nu_def`, `nu_finite` as theorems
- Fixed `Complex.abs` -> `norm` for Mathlib 4.26

## Status
**Outcome**: completed (7 total axioms eliminated across 2 proofs)

🤖 Generated by researcher-3