### PR TITLE
Research: erdos-269 - Prove smoothSeq_zero + Mathlib fixes

### DIFF
--- a/proofs/Proofs/Erdos269Problem.lean
+++ b/proofs/Proofs/Erdos269Problem.lean
@@ -27,13 +27,7 @@ References:
 - [Er88c, p.106]
 -/
 
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.Finset.Lattice
-import Mathlib.Algebra.Order.LatticeGroup
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Real.Irrational
-import Mathlib.Data.Nat.Order.Lemmas
-import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib
 
 open Nat BigOperators Finset
 
@@ -55,13 +49,10 @@ Examples for P = {2, 3}:
 def IsPSmooth (P : Set ℕ) (n : ℕ) : Prop :=
   n > 0 ∧ ∀ p, p.Prime → p ∣ n → p ∈ P
 
-/-- 1 is P-smooth for any P. -/
-theorem one_isPSmooth (P : Set ℕ) : IsPSmooth P 1 := by
-  constructor
-  · exact Nat.one_pos
-  · intro p hp hdiv
-    have : p = 1 := Nat.eq_one_of_pos_of_self_mul_self_le hp.pos (Nat.le_of_dvd Nat.one_pos hdiv)
-    exact absurd this (Nat.Prime.ne_one hp)
+/-- 1 is P-smooth for any P (vacuously: 1 has no prime divisors). -/
+theorem one_isPSmooth (P : Set ℕ) : IsPSmooth P 1 :=
+  ⟨Nat.one_pos, fun p hp hdiv =>
+    absurd (Nat.le_of_dvd Nat.one_pos hdiv) (not_le_of_lt hp.one_lt)⟩
 
 /-- If p ∈ P and p is prime, then p is P-smooth. -/
 theorem prime_isPSmooth {P : Set ℕ} {p : ℕ} (hp : p.Prime) (hpP : p ∈ P) :
@@ -96,8 +87,20 @@ For P = {2, 3}: a = [1, 2, 3, 4, 6, 8, 9, 12, 16, 18, ...]
 noncomputable def smoothSeq (P : Set ℕ) : ℕ → ℕ :=
   Nat.nth (IsPSmooth P)
 
-/-- smoothSeq P 0 = 1 for any nonempty P. -/
-axiom smoothSeq_zero (P : Set ℕ) (hP : P.Nonempty) : smoothSeq P 0 = 1
+/-- smoothSeq P 0 = 1 for any nonempty P.
+The 0-th P-smooth number is 1, since 1 is vacuously P-smooth (has no prime divisors)
+and 0 is not P-smooth (fails the positivity requirement). -/
+theorem smoothSeq_zero (P : Set ℕ) (hP : P.Nonempty) : smoothSeq P 0 = 1 := by
+  classical
+  unfold smoothSeq
+  -- Use Nat.nth_count: if p n, then nth p (count p n) = n
+  have h_smooth : IsPSmooth P 1 := one_isPSmooth P
+  have h_count : Nat.count (IsPSmooth P) 1 = 0 := by
+    change Nat.count (IsPSmooth P) (0 + 1) = 0
+    rw [Nat.count_succ, Nat.count_zero, zero_add,
+        if_neg (show ¬ IsPSmooth P 0 from fun h => absurd h.1 (by omega))]
+  rw [show (0 : ℕ) = Nat.count (IsPSmooth P) 1 from h_count.symm]
+  exact Nat.nth_count h_smooth
 
 /- ## Part III: Partial LCM -/
 
@@ -122,9 +125,8 @@ theorem partialLcm_one (P : Set ℕ) (hP : P.Nonempty) : partialLcm P 1 = 1 := b
 /-- L_{n+1} = lcm(L_n, a_n). -/
 theorem partialLcm_succ (P : Set ℕ) (n : ℕ) :
     partialLcm P (n + 1) = Nat.lcm (partialLcm P n) (smoothSeq P n) := by
-  simp only [partialLcm, Finset.range_succ]
-  rw [Finset.lcm_insert (Finset.not_mem_range_self n)]
-  ring
+  simp only [partialLcm, Finset.range_add_one, Finset.lcm_insert]
+  exact _root_.lcm_comm _ _
 
 /- ## Part IV: The Series -/
 
@@ -159,7 +161,7 @@ def isSeriesRational (P : Set ℕ) : Prop :=
 
 theorem erdos_269_equivalent (P : Finset ℕ) (hPrime : ∀ p ∈ P, p.Prime) (hCard : P.card ≥ 2) :
     ¬ isSeriesRational (P : Set ℕ) ↔ Irrational (lcmSeries (P : Set ℕ)) := by
-  simp [isSeriesRational, irrational_iff_ne_rational]
+  simp [isSeriesRational, Irrational]
 
 /- ## Part VI: The Infinite Case (SOLVED) -/
 
@@ -193,7 +195,7 @@ theorem twoThreeSmooth_prime : ∀ p ∈ ({2, 3} : Finset ℕ), p.Prime := by
 
 /- ## Part VIII: Structural Properties -/
 
-/--
+/-
 **P-adic Valuation**
 
 For understanding the series, the key is the p-adic valuation v_p(L_n).
@@ -203,11 +205,11 @@ power of p enters the sequence.
 
 /-- The p-adic valuation of L_n. -/
 noncomputable def lcmPadicVal (p n : ℕ) (P : Set ℕ) : ℕ :=
-  Nat.padicValNat p (partialLcm P n)
+  padicValNat p (partialLcm P n)
 
 /- ## Part IX: Why It's Hard -/
 
-/--
+/-
 **The Difficulty**
 
 For finite P, the series S(P) = Σ 1/L_n has a "finite structure" in some sense.

--- a/src/data/proofs/erdos-269/meta.json
+++ b/src/data/proofs/erdos-269/meta.json
@@ -65,9 +65,9 @@
       "partialLcm_eventually_periodic theorem: L_n stabilizes mod M",
       "distinctLcmSeries definition: series without duplicate terms"
     ],
-    "axiomCount": 4,
-    "lineCount": 273,
-    "assumptions": "25 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 3,
+    "lineCount": 275,
+    "assumptions": "3 axiom(s): erdos_269 (main conjecture, OPEN), erdos_269_infinite (infinite P case), erdos_269_distinct (distinct LCM case). Former axiom smoothSeq_zero now proved."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #269: LCM Series Irrationality**\n\nThis problem was posed by Erdos in a letter to the editor of the Fibonacci Quarterly (January 1, 1973), published in Vol. 12 (1974), p. 335.\n\n**Key History:**\n- Erdos (1973): Original problem statement\n- [ErGr80, p.65]: Referenced in Erdos-Graham collaboration\n- [Er88c, p.106]: Further discussion\n\n**The Setting:**\nP-smooth numbers (or P-friable numbers) are integers whose prime factors all come from a fixed set P. When P = {2,3}, these are the 3-smooth numbers: 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, 27, ...\n\nThe series sums reciprocals of successive LCMs of these numbers.",
@@ -180,13 +180,7 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Data.Finset.Lattice",
-      "Mathlib.Algebra.Order.LatticeGroup",
-      "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Real.Irrational",
-      "Mathlib.Data.Nat.Order.Lemmas",
-      "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      "Mathlib"
     ],
     "opens": [
       "Nat",
@@ -194,9 +188,9 @@
       "Finset"
     ],
     "namespace": "Erdos269",
-    "lineCount": 273,
-    "axiomCount": 4,
-    "theoremCount": 11,
+    "lineCount": 275,
+    "axiomCount": 3,
+    "theoremCount": 12,
     "definitionCount": 9
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-269.json
+++ b/src/data/research/problems/erdos-269.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-12T22:30:27.389Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination + Mathlib compatibility fixes",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,18 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: File well-structured (11 thm, 4 ax). smoothSeq_zero axiom provable via Nat.nth_count.",
-    "builtItems": [],
+    "progressSummary": "AXIOM HUNT: Eliminated 1 of 4 axioms (smoothSeq_zero). Fixed 5 pre-existing Mathlib compatibility issues. Remaining 3 axioms are deep open/known results.",
+    "builtItems": [
+      "theorem smoothSeq_zero (Nat.nth_count proof, 8 lines)",
+      "Fixed one_isPSmooth (2 lines, simpler proof)",
+      "Fixed partialLcm_succ, erdos_269_equivalent, lcmPadicVal"
+    ],
     "insights": [
       "smoothSeq_zero provable: 1 is min P-smooth number (count 1 = 0 since IsPSmooth P 0 fails)",
       "Need infinite set proof: P contains prime p → p^k are all P-smooth",
-      "partialLcm_succ may need Nat.lcm_comm instead of ring"
+      "partialLcm_succ may need Nat.lcm_comm instead of ring",
+      "smoothSeq_zero proved via Nat.nth_count + Nat.count_succ: count at 1 is 0 since IsPSmooth P 0 is false (0>0 fails)",
+      "one_isPSmooth simplified: absurd (Nat.le_of_dvd) (not_le_of_lt hp.one_lt)",
+      "partialLcm_succ fixed: lcm_insert now unconditional in Mathlib, use _root_.lcm_comm",
+      "Multiple pre-existing Mathlib API breakages fixed (deprecated range_succ, padicValNat, docstring syntax)"
     ],
     "mathlibGaps": [
       "Nat.nth computation for noncomputable predicates requires count/nth reasoning"
     ],
     "nextSteps": [
-      "Prove smoothSeq_zero via Nat.nth_count"
+      "erdos_269_infinite (infinite P case) described as simple exercise - might be provable with effort",
+      "erdos_269 and erdos_269_distinct are deep results - leave as axioms"
     ],
     "markdown": "# Erdős #269 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $P$ be a finite set of primes with $\\lvert P\\rvert \\geq 2$ and let $\\{a_1<a_2<\\cdots\\}=\\{ n\\in \\mathbb{N} : \\textrm{if }p\\mid n\\textrm{ then }p\\in P\\}$. Is the sum\\[\\sum_{n=1}^\\infty \\frac{1}{[a_1,\\ldots,a_n]},\\]where $[a_1,\\ldots,a_n]$ is the lowest common multiple of $a_1,\\ldots,a_n$, irrational?\n\n\n\nIf $P$ is infinite this sum is always irrational (in \\cite{Er88c} Erd\\H{o}s says this is a 'simple exercise').\n\nThis problem was asked by Erd\\H{o}s in a letter to the editor written January 1st 1973 in issue 12 of the Fibonacci Quarterly, 1974, p. 335. In that letter he says that he can prove the sum is irrational if duplicate summands are removed.\n\n\n\n\nReferences\n\n\n[Er88c] Erd\\\"{o}s, P., On the irrationality of certain series: problems and results. New advances in transcendence theory (Durham, 1986) (1988), 102-109.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #268\n- Problem #270\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er88c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },


### PR DESCRIPTION
## Summary
- Prove `smoothSeq_zero` (axiom → theorem) via `Nat.nth_count` + `Nat.count_succ`
- Fix 5 pre-existing Mathlib compatibility issues across the file
- **Axiom count 4 → 3**

## Fixes
- `one_isPSmooth`: replace removed `Nat.eq_one_of_pos_of_self_mul_self_le` with `not_le_of_lt hp.one_lt`
- `partialLcm_succ`: `lcm_insert` no longer takes `∉` arg; use `_root_.lcm_comm`
- `erdos_269_equivalent`: `irrational_iff_ne_rational` → `Irrational`
- `lcmPadicVal`: `Nat.padicValNat` → `padicValNat`
- Docstring syntax: `/--` → `/-` for non-lemma sections

## Status
**Outcome**: Axiom elimination + compatibility repair
**Remaining axioms**: `erdos_269` (main, OPEN), `erdos_269_infinite` (infinite P, "simple exercise"), `erdos_269_distinct`

🤖 Generated by researcher-1