### PR TITLE
Research: erdos-347 - Eliminate 3 axioms (4→1), fix incorrect axiom

### DIFF
--- a/proofs/Proofs/Erdos347Problem.lean
+++ b/proofs/Proofs/Erdos347Problem.lean
@@ -80,14 +80,23 @@ axiom erdos347_affirmative : ErdosProblem347
 /- ## Basic properties -/
 
 /-- The empty subset sum is 0: `0 ∈ P(A)` for any `A`. -/
-axiom zero_mem_subsetSums (A : Set ℕ) :
-    0 ∈ subsetSums A
+theorem zero_mem_subsetSums (A : Set ℕ) :
+    0 ∈ subsetSums A :=
+  ⟨∅, by simp, by simp⟩
 
-/-- Subset sums are closed under adding elements of `A`. -/
-axiom subsetSums_add (A : Set ℕ) (s : ℕ) (a : ℕ) :
-    s ∈ subsetSums A → a ∈ A →
-      s + a ∈ subsetSums A
+/-- Subset sums grow when adding a new element not already in the witness.
+    NOTE: The original `subsetSums_add` axiom (s ∈ P(A) → a ∈ A → s+a ∈ P(A))
+    was INCORRECT — it fails when a is already in the witness finset S
+    (e.g., A = {2,3}, s = 5, a = 2: 7 ∉ P({2,3}) = {0,2,3,5}).
+    This correct version requires a fresh witness where a ∉ S. -/
+theorem subsetSums_insert (A : Set ℕ) (S : Finset ℕ) (a : ℕ)
+    (hS : (↑S : Set ℕ) ⊆ A) (ha : a ∈ A) (hna : a ∉ S) :
+    S.sum id + a ∈ subsetSums A :=
+  ⟨insert a S, by simpa [Set.insert_subset_iff] using ⟨ha, hS⟩,
+   by rw [Finset.sum_insert hna]; ring⟩
 
 /-- If `A ⊆ B`, then `P(A) ⊆ P(B)`. -/
-axiom subsetSums_mono (A B : Set ℕ) (h : A ⊆ B) :
-    subsetSums A ⊆ subsetSums B
+theorem subsetSums_mono (A B : Set ℕ) (h : A ⊆ B) :
+    subsetSums A ⊆ subsetSums B := by
+  intro s ⟨S, hS, hs⟩
+  exact ⟨S, Set.Subset.trans hS h, hs⟩

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 347,
     "erdosUrl": "https://erdosproblems.com/347",
     "erdosProblemStatus": "proved",
-    "axiomCount": 4,
+    "axiomCount": 1,
     "assumptions": "4 axiom declarations: erdos347_affirmative (positive answer exists), zero_mem_subsetSums (empty sum is zero), subsetSums_add (closure under element addition), subsetSums_mono (monotonicity under inclusion)",
     "lineCount": 93,
     "mathlib_version": "4.26.0"
@@ -118,8 +118,8 @@
     ],
     "namespace": null,
     "lineCount": 93,
-    "axiomCount": 4,
-    "theoremCount": 0,
+    "axiomCount": 1,
+    "theoremCount": 3,
     "definitionCount": 8
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-347.json
+++ b/src/data/research/problems/erdos-347.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-13T00:53:52.153Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Axiom elimination + bug fix complete",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "AXIOM ELIMINATION + BUG FIX: Proved zero_mem_subsetSums and subsetSums_mono. Fixed incorrect subsetSums_add axiom (was false: fails when a already in witness finset). Axioms 4→1.",
+    "builtItems": [
+      "Proved zero_mem_subsetSums: empty finset witnesses 0 ∈ P(A)",
+      "Proved subsetSums_mono: A⊆B → P(A)⊆P(B) via witness subset transitivity",
+      "Fixed subsetSums_add → subsetSums_insert: requires a∉S as precondition",
+      "Identified bug: old subsetSums_add was FALSE (counterexample: A={2,3}, s=5, a=2)"
+    ],
+    "insights": [
+      "subsetSums_add was UNSOUND: for A={2,3}, s=5∈P(A), a=2∈A, but 7∉P(A)={0,2,3,5}",
+      "Correct version needs a∉S precondition: can only add elements not already in witness",
+      "CoveringSystem formalization uses Set ℕ (no repeats) — fine for this problem",
+      "Problem is SOLVED (Tao + van Doorn ideas), axiom erdos347_affirmative records this"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "erdos347_affirmative is the only remaining axiom — records the solved result",
+      "Could construct explicit witness sequence satisfying ErdosProblem347 to eliminate last axiom"
+    ],
     "markdown": "# Erdős #347 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a sequence $A=\\{a_1\\leq a_2\\leq \\cdots\\}$ of integers with\\[\\lim \\frac{a_{n+1}}{a_n}=2\\]such that\\[P(A')= \\left\\{\\sum_{n\\in B}n : B\\subseteq A'\\textrm{ finite }\\right\\}\\]has density $1$ for every cofinite subsequence $A'$ of $A$?\n\n\n\n\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #346\n- Problem #348\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -50,20 +63,19 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:53:52.153Z",
-  "lastUpdate": "2026-03-13T07:52:17.046Z",
+  "lastUpdate": "2026-03-24T08:15:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos347Problem.lean",
       "filename": "Erdos347Problem.lean",
-      "lineCount": 94,
-      "theoremCount": 0,
-      "axiomCount": 4,
+      "lineCount": 100,
+      "theoremCount": 3,
+      "axiomCount": 1,
       "defCount": 8,
       "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos347Problem.lean"
+      "isAristotle": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Eliminated 3 axioms from `Erdos347Problem.lean` (4→1)
- **Bug fix**: `subsetSums_add` axiom was FALSE

## Axiom Eliminations

| Axiom | Proof | Notes |
|-------|-------|-------|
| `zero_mem_subsetSums` | `⟨∅, by simp, by simp⟩` | Empty finset witnesses 0 |
| `subsetSums_mono` | `Set.Subset.trans` | Witness subset transitivity |
| `subsetSums_add` | **REMOVED (FALSE)** | See bug fix below |

## Bug Fix: subsetSums_add was unsound

The axiom `subsetSums_add : s ∈ P(A) → a ∈ A → s + a ∈ P(A)` is **false**.

**Counterexample**: A = {2,3}, s = 5 (from B = {2,3}), a = 2.
Then s + a = 7, but P({2,3}) = {0, 2, 3, 5} — 7 is not achievable.

The issue: if `a` is already in the witness finset S, `insert a S = S` so the sum doesn't increase.

**Fix**: Replaced with `subsetSums_insert` which requires `a ∉ S` as precondition.

🤖 Generated by researcher-2