### PR TITLE
Audit batch 7a: fix axiomCount in 9 proofs

### DIFF
--- a/src/data/proofs/erdos-1087/meta.json
+++ b/src/data/proofs/erdos-1087/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos-Purdy (1971 bounds)",
     "sourceUrl": "https://erdosproblems.com/1087",
     "date": "1971",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1087Problem.lean",
     "tags": [
       "erdos",
@@ -64,9 +64,9 @@
       "Connection to unit distances and Guth-Katz theorem",
       "erdos_1087 theorem: combining known bounds"
     ],
-    "axiomCount": 7,
+    "axiomCount": 6,
     "lineCount": 330,
-    "assumptions": "7 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "6 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #1087**\n\nThis problem was posed by Paul Erdos and George Purdy in their 1971 paper \"Some extremal problems in geometry\" (J. Combinatorial Theory Ser. A, 246-252). It belongs to the rich tradition of combinatorial geometry problems that Erdos pioneered.\n\n**The Setting:**\nGiven n points in the plane, consider all C(n,4) = n(n-1)(n-2)(n-3)/24 subsets of 4 points (quadruples). A quadruple is called \"degenerate\" if at least two of its 6 pairwise distances are equal. Let f(n) be the maximum number of degenerate quadruples over all n-point configurations.\n\n**Historical Progress:**\nErdos and Purdy proved bounds n^3 log n << f(n) << n^{7/2} in 1971. The problem asks whether the upper bound can be improved to n^{3+o(1)}, which would nearly match the lower bound. This remains open as of 2025, representing a gap in our understanding of distance geometry.",
@@ -288,7 +288,7 @@
     ],
     "namespace": "Erdos1087",
     "lineCount": 330,
-    "axiomCount": 7,
+    "axiomCount": 6,
     "theoremCount": 5,
     "definitionCount": 12
   }

--- a/src/data/proofs/erdos-219/meta.json
+++ b/src/data/proofs/erdos-219/meta.json
@@ -47,9 +47,9 @@
       "Record of longest known AP (k=23)",
       "Statement of open consecutive prime AP question"
     ],
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 143,
-    "assumptions": "6 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "This is one of the oldest and most natural questions about prime numbers: can we find arbitrarily long sequences of primes in arithmetic progression? The question appears as Problem A5 in Richard Guy's 'Unsolved Problems in Number Theory'.\n\nThe Green-Tao theorem (2008) provides a resounding YES. Ben Green and Terence Tao proved that for every k, there exists an arithmetic progression of k primes. Their proof, published in the Annals of Mathematics, is a landmark of 21st century mathematics, combining techniques from ergodic theory, combinatorics, and analytic number theory.\n\nThe result earned Tao and Green numerous accolades and opened new research directions in additive combinatorics.",
@@ -133,7 +133,7 @@
     ],
     "namespace": "Erdos219",
     "lineCount": 143,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-228/meta.json
+++ b/src/data/proofs/erdos-228/meta.json
@@ -53,9 +53,9 @@
       "Related Hayman question on maximum magnitude",
       "Proved √n > 0 for n ≥ 1 as basic heuristic"
     ],
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 161,
-    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "3 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "This problem originates from J.E. Littlewood's 1966 work on polynomials with ±1 coefficients (Littlewood polynomials). He conjectured that 'flat' examples exist—polynomials where |P(z)| stays close to √n uniformly on the unit circle.\n\nThe conjecture remained open for over 50 years. In 2019, Balister, Bollobás, Morris, Sahasrabudhe, and Tiba proved that flat Littlewood polynomials exist, resolving the conjecture. Their paper 'Flat Littlewood Polynomials Exist' appeared in the Annals of Mathematics (2020).\n\nThe result is remarkable: despite the severe constraint of ±1 coefficients, the magnitude can be controlled to stay within constant factors of √n everywhere on the unit circle. This matches the 'random' behavior predicted by the central limit theorem.",
@@ -147,7 +147,7 @@
     ],
     "namespace": "Erdos228",
     "lineCount": 161,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-233/meta.json
+++ b/src/data/proofs/erdos-233/meta.json
@@ -44,9 +44,9 @@
       "Clear exposition of the relationship between prime gaps and the Riemann Hypothesis",
       "Connection to Cramér's conjecture on individual prime gaps"
     ],
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 160,
-    "assumptions": "6 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "This problem concerns the distribution of prime gaps dₙ = pₙ₊₁ - pₙ. The prime number theorem tells us that the average gap near x is approximately log x, but individual gaps can be much larger or smaller.\n\nThe conjecture that Σ dₙ² ≪ N(log N)² is sometimes attributed to Heath-Brown. It says that, on average, prime gaps are 'typically' of size log p - the squares don't accumulate faster than expected.\n\nCramér (1936) proved that, assuming the Riemann Hypothesis, Σ dₙ² = O(N(log N)⁴). Selberg (1943) improved this to Σ dₙ²/n = O((log N)⁴). The prime number theorem immediately gives the matching lower bound N(log N)², so the gap between lower and upper bounds is (log N)².\n\nThis problem is intimately connected to Cramér's famous conjecture that dₙ = O((log pₙ)²), which remains one of the most important open problems about prime gaps.",
@@ -143,7 +143,7 @@
     ],
     "namespace": "Erdos233",
     "lineCount": 160,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 1,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-242/meta.json
+++ b/src/data/proofs/erdos-242/meta.json
@@ -47,9 +47,9 @@
       "Connection to Schinzel's generalization",
       "Summary of computational verification status"
     ],
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 186,
-    "assumptions": "6 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "The Erdős-Straus conjecture was posed by Paul Erdős and Ernst Straus in 1948. It asks whether every fraction 4/n with n > 2 can be written as a sum of exactly three unit fractions with distinct denominators.\n\nThis is one of the most famous unsolved problems in elementary number theory. Despite its simple statement, it has resisted proof for over 75 years. The conjecture has been verified computationally for all n up to 10^17 (over 100 quadrillion values), yet no general proof exists.\n\nThe problem is related to ancient Egyptian mathematics, where fractions were always written as sums of distinct unit fractions. The conjecture essentially asks: can the Egyptians always express 4/n using exactly three unit fractions?",
@@ -146,7 +146,7 @@
     ],
     "namespace": "Erdos242",
     "lineCount": 186,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-334/meta.json
+++ b/src/data/proofs/erdos-334/meta.json
@@ -43,7 +43,7 @@
       "Concrete examples: example_10, example_100",
       "smoothCount (ψ function) and Goldbach connection"
     ],
-    "axiomCount": 5,
+    "axiomCount": 4,
     "prerequisites": [
       "Prime numbers and prime factorization",
       "Divisibility and Euclid's lemma",
@@ -53,7 +53,7 @@
       "Asymptotic notation (o(1), big-O)"
     ],
     "lineCount": 300,
-    "assumptions": "5 axiom(s) and 3 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "4 axiom(s) and 3 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -181,7 +181,7 @@
     ],
     "namespace": "Erdos334",
     "lineCount": 300,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 9,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos (1977)",
     "sourceUrl": "https://erdosproblems.com/358",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos358Problem.lean",
     "tags": [
       "erdos",
@@ -57,9 +57,9 @@
       "PositiveDensityConjecture definition: positive upper density",
       "Classical characterization: n = sum of >=2 consecutive iff n != 2^k"
     ],
-    "axiomCount": 7,
+    "axiomCount": 5,
     "lineCount": 183,
-    "assumptions": "7 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "5 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdos Problem #358 was posed in 1977 [Er77c] and revisited in Erdos-Graham (1980). It asks a deceptively simple question about how many ways an integer can be written as a sum of consecutive terms from a fixed sequence.\n\nErdos himself remarked: \"This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me.\"\n\nThe problem connects to classical results about sums of consecutive integers (which relate to odd divisors) and to the Erdos-Moser conjecture (1963) about consecutive prime sums.",
@@ -160,7 +160,7 @@
     ],
     "namespace": "Erdos358",
     "lineCount": 183,
-    "axiomCount": 7,
+    "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-375/meta.json
+++ b/src/data/proofs/erdos-375/meta.json
@@ -7,7 +7,7 @@
     "author": "Grimm (1969 conjecture), Ramachandra-Shorey-Tijdeman (1975 partial)",
     "sourceUrl": "https://erdosproblems.com/375",
     "date": "1969",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos375Problem.lean",
     "tags": [
       "erdos",
@@ -58,9 +58,9 @@
       "Connection to prime gaps and Legendre's conjecture",
       "Hall's marriage theorem formulation"
     ],
-    "axiomCount": 8,
+    "axiomCount": 7,
     "lineCount": 336,
-    "assumptions": "8 axiom(s) and 5 sorry(s). See the Lean source for details."
+    "assumptions": "7 axiom(s) and 5 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #375: Grimm's Conjecture**\n\nThis conjecture was originally posed by C.A. Grimm in 1969 in the American Mathematical Monthly. It connects prime factorization with combinatorial matching theory.\n\n**The Core Question:**\nGiven any interval of k consecutive composite numbers (a 'prime gap'), can we always assign a distinct prime divisor to each composite?\n\n**Historical Progress:**\n- 1969: Grimm poses conjecture, proves k << log n / log log n\n- 1970s: Erdos-Selfridge extend to k <= (1+o(1)) log n\n- 1975: Ramachandra-Shorey-Tijdeman prove k << (log n / log log n)^3\n\n**Significance:**\nThis is listed as problem B32 in Guy's Unsolved Problems in Number Theory. It remains one of the most intriguing open problems connecting prime gaps to matching theory.",
@@ -171,7 +171,7 @@
     ],
     "namespace": "Erdos375",
     "lineCount": 336,
-    "axiomCount": 8,
+    "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-38/meta.json
+++ b/src/data/proofs/erdos-38/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": 38,
     "erdosUrl": "https://erdosproblems.com/38",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 139,
     "prerequisites": [
       "Essential components in additive number theory",
@@ -29,7 +29,7 @@
       "Schnirelmann density",
       "Freiman's theorem"
     ],
-    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -108,7 +108,7 @@
     ],
     "namespace": "Erdos38",
     "lineCount": 139,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 0,
     "definitionCount": 8
   },


### PR DESCRIPTION
## Summary

- Fix axiomCount overcounting in 9 gallery proofs (all verified against `grep -c "^axiom "` on Lean source)
- Fix status field for 3 proofs: erdos-358, erdos-375, erdos-1087 (formalized→axiomatized, since they have axiom declarations)
- Audited pythagorean-triples: CLEAN (Tier B Mathlib bridge, properly documented)

### Axiom count fixes

| Proof | Old | New | Delta |
|-------|-----|-----|-------|
| erdos-38 | 5 | 4 | -1 |
| erdos-219 | 6 | 5 | -1 |
| erdos-228 | 4 | 3 | -1 |
| erdos-233 | 6 | 5 | -1 |
| erdos-242 | 6 | 5 | -1 |
| erdos-334 | 5 | 4 | -1 |
| erdos-358 | 7 | 5 | -2 |
| erdos-375 | 8 | 7 | -1 |
| erdos-1087 | 7 | 6 | -1 |

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Spot-check that axiomCount matches `grep -c "^axiom " proofs/Proofs/ErdosNProblem.lean` for each fixed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)