### PR TITLE
Research: erdos-530 - eliminate axiom, fix compilation (5→4 axioms)

### DIFF
--- a/proofs/Proofs/Erdos530Problem.lean
+++ b/proofs/Proofs/Erdos530Problem.lean
@@ -30,7 +30,7 @@ implies `{a,b} = {c,d}`.
 
 namespace Erdos530
 
-open Finset
+open Finset Classical
 
 /-- A Finset of integers is Sidon if all pairwise sums are distinct:
     a + b = c + d with a ≤ b, c ≤ d implies a = c and b = d. -/
@@ -41,7 +41,7 @@ def IsSidon (S : Finset ℤ) : Prop :=
 /-- The empty set is Sidon. -/
 theorem isSidon_empty : IsSidon ∅ := by
   intro a ha
-  exact absurd ha (Finset.not_mem_empty a)
+  exact absurd ha (Finset.notMem_empty a)
 
 /-- Any singleton is Sidon. -/
 theorem isSidon_singleton (x : ℤ) : IsSidon {x} := by
@@ -83,12 +83,20 @@ axiom komlos_sulyok_szemeredi :
     ∀ A : Finset ℤ, A.card ≥ 4 →
       maxSidonSize A * maxSidonSize A ≥ c * A.card
 
-/-- Upper bound: the maximum Sidon subset of any set of size N
-    has size at most (1 + o(1)) · N^{1/2}. For {1,...,N}, the
-    Sidon set construction gives at most ~ N^{1/2} elements. -/
-axiom sidon_upper_bound :
+/-- Every Sidon subset of A is a subset, hence has cardinality ≤ |A|. -/
+theorem maxSidonSize_le_card (A : Finset ℤ) : maxSidonSize A ≤ A.card := by
+  unfold maxSidonSize
+  apply Finset.sup_le (fun S hS => ?_)
+  exact Finset.card_le_card (Finset.mem_powerset.mp (Finset.mem_filter.mp hS).1)
+
+/-- Trivial upper bound: (maxSidonSize A)² ≤ |A|². Since any Sidon subset
+    of A has at most |A| elements, squaring preserves the inequality.
+    Note: the actual conjecture is the much stronger maxSidonSize A ≤ (1+o(1))√|A|. -/
+theorem sidon_upper_bound :
   ∀ A : Finset ℤ,
-    maxSidonSize A * maxSidonSize A ≤ A.card * A.card
+    maxSidonSize A * maxSidonSize A ≤ A.card * A.card := by
+  intro A
+  exact Nat.mul_le_mul (maxSidonSize_le_card A) (maxSidonSize_le_card A)
 
 /-
 ## Section 4: The main conjecture
@@ -134,10 +142,23 @@ The study of maximum Sidon subsets connects to the broader theory of
 sum-free sets, Szemerédi's theorem, and additive number theory.
 -/
 
+/-- The sum function is injective on sorted pairs of a Sidon set.
+    This is the core property of Sidon sets: distinct pairs give distinct sums. -/
+theorem sidon_sum_injective (S : Finset ℤ) (hS : IsSidon S) :
+    Set.InjOn (fun p : ℤ × ℤ => p.1 + p.2)
+      ((S ×ˢ S).filter (fun p => p.1 ≤ p.2) : Set (ℤ × ℤ)) := by
+  intro ⟨a, b⟩ hab ⟨c, d⟩ hcd heq
+  simp only [Finset.coe_filter, Set.mem_setOf_eq,
+    Finset.mem_product] at hab hcd
+  obtain ⟨⟨haS, hbS⟩, hab_le⟩ := hab
+  obtain ⟨⟨hcS, hdS⟩, hcd_le⟩ := hcd
+  have := hS a haS b hbS c hcS d hdS hab_le hcd_le heq
+  exact Prod.ext this.1 this.2
+
 /-- The number of distinct pairwise sums from a Sidon set S of size k
     is exactly k(k+1)/2 (all sums are distinct). -/
 axiom sidon_sum_count (S : Finset ℤ) (hS : IsSidon S) :
-  ((S ×ˢ S).filter (fun p => p.1 ≤ p.2)).image (fun p => p.1 + p.2)
-    |>.card = S.card * (S.card + 1) / 2
+  (((S ×ˢ S).filter (fun p => p.1 ≤ p.2)).image (fun p => p.1 + p.2)).card =
+    S.card * (S.card + 1) / 2
 
 end Erdos530

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 530,
     "erdosUrl": "https://erdosproblems.com/530",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 143,
-    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "axiomCount": 4,
+    "lineCount": 164,
+    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -114,9 +114,9 @@
       "Finset"
     ],
     "namespace": "Erdos530",
-    "lineCount": 143,
-    "axiomCount": 5,
-    "theoremCount": 2,
+    "lineCount": 164,
+    "axiomCount": 4,
+    "theoremCount": 5,
     "definitionCount": 4
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-530.json
+++ b/src/data/research/problems/erdos-530.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-530",
   "title": "Erdős #530",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-13T04:39:49.623Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination — proved sidon_upper_bound, partially proved sidon_sum_count",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Eliminated 1 axiom (sidon_upper_bound 5→4), proved 3 new theorems, fixed 2 pre-existing issues (compilation error, deprecation).",
+    "builtItems": [
+      "maxSidonSize_le_card: proved maxSidonSize A ≤ A.card (Erdos530Problem.lean:87)",
+      "sidon_upper_bound: PROVED (was axiom) — trivial bound from subset property (Erdos530Problem.lean:95)",
+      "sidon_sum_injective: proved injectivity of sum map on sorted pairs of Sidon sets (Erdos530Problem.lean:147)",
+      "Fixed compilation: added open Classical for DecidablePred IsSidon (Erdos530Problem.lean:34)",
+      "Fixed deprecated: Finset.not_mem_empty → Finset.notMem_empty (Erdos530Problem.lean:44)"
+    ],
+    "insights": [
+      "sidon_upper_bound was trivially true (maxSidonSize A ≤ A.card, squared) — eliminated as axiom",
+      "Pre-existing compilation error: IsSidon needed Classical decidability for Finset.filter — fixed with open Classical",
+      "sidon_sum_count partially proved: injectivity (sidon_sum_injective) follows directly from IsSidon definition; pair counting identity k(k+1)/2 remains as axiom",
+      "erdos_lower_bound and komlos_sulyok_szemeredi are deep combinatorial results — not provable from Mathlib",
+      "alon_erdos_partition_conjecture is an open conjecture — not provable",
+      "Remaining axiom sidon_sum_count could potentially be eliminated: need to prove |(S×S filtered a≤b)| = |S|*(|S|+1)/2 for Finset"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove sidon_sum_count: need Finset pair counting identity |{(a,b) ∈ S×S : a ≤ b}| = |S|*(|S|+1)/2",
+      "Investigate if sidon_sum_injective can be used with Finset.card_image_of_injOn to get partial progress",
+      "Note: sidon_upper_bound as stated was very weak (just subset bound). The ACTUAL upper bound ℓ(N) ≤ (1+o(1))√N is much stronger"
+    ],
     "markdown": "# Erdős #530 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $\\ell(N)$ be maximal such that in any finite set $A\\subset \\mathbb{R}$ of size $N$ there exists a Sidon subset $S$ of size $\\ell(N)$ (i.e. the only solutions to $a+b=c+d$ in $S$ are the trivial ones). Determine the order of $\\ell(N)$.\n\n\nIn particular, is it true that $\\ell(N)\\sim N^{1/2}$?\n\n\n\nOriginally asked by Riddell \\cite{Ri69}. Erd\\H{o}s noted the bounds\\[N^{1/3} \\ll \\ell(N) \\leq (1+o(1))N^{1/2}\\](the upper bound following from the case $A=\\{1,\\ldots,N\\}$). The lower bound was improved to $N^{1/2}\\ll \\ell(N)$ by Koml\\'{o}s, Sulyok, and Szemer\\'{e}di \\cite{KSS75}. The correct constant is unknown, but it is likely that the upper bound is true, so that $\\ell(N)\\sim N^{1/2}$.\n\nIn \\cite{AlEr85} Alon and Erd\\H{o}s make the stronger conjecture that perhaps $A$ can always be written as the union of at most $(1+o(1))N^{1/2}$ many Sidon sets. (This is easily verified for $A=\\{1,\\ldots,N\\}$ using standard constructions of Sidon sets.)\n\nThis is discussed in problem C9 of Guy's collection \\cite{Gu04}.\n\nSee also [1088] for a higher-dimensional generalisation.\n\n\n\n\nReferences\n\n\n[AlEr85] Alon, Noga and Erd\\H{o}s, P., An application of graph theory to additive number theory. European J. Combin. (1985), 201-203.\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[KSS75] Koml\\'{o}s, J. and Sulyok, M. and Szemeredi, E., Linear problems in combinatorial number theory. Acta Math. Acad. Sci. Hungar. (1975), 113-121.\n\n[Ri69] Riddell, J., On sets of numbers containing no $l$ terms in arithmetic progression. Nieuw Arch. Wisk. (3) (1969), 204-209.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #3\n- Problem #1088\n- Problem #529\n- Problem #531\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80e\n- Ri69\n- KSS75\n- AlEr85\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Eliminated 1 axiom (`sidon_upper_bound`: trivially true subset bound) from Erdős #530
- Proved 3 new theorems: `maxSidonSize_le_card`, `sidon_upper_bound` (now proved), `sidon_sum_injective`
- Fixed 2 pre-existing issues: compilation error (`DecidablePred IsSidon`) and deprecated API

## Progress
- **Axiom eliminated**: `sidon_upper_bound` was just `maxSidonSize A ≤ A.card` squared — proved via `Finset.sup_le`
- **New theorem**: `sidon_sum_injective` — the sum function is injective on sorted pairs of Sidon sets (core Sidon property)
- **Bug fix**: Added `open Classical` to resolve `DecidablePred IsSidon` synthesis failure
- **Deprecation fix**: `Finset.not_mem_empty` → `Finset.notMem_empty`

## Findings
- `sidon_upper_bound` as stated was a very weak bound (subset bound, not the actual √N upper bound)
- 4 remaining axioms: 2 deep results (Erdős, KSS), 1 open conjecture (Alon-Erdős), 1 identity (sum counting)
- `sidon_sum_count` could potentially be fully proved: injectivity done, needs pair counting identity

## Status
**Outcome**: progress (1 axiom eliminated, 2 pre-existing bugs fixed)
**Next Steps**: Prove `sidon_sum_count` to eliminate another axiom

🤖 Generated by researcher-5