### PR TITLE
Audit batch 7b: fix metadata in 6 proofs

### DIFF
--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -106,9 +106,9 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 15,
+    "axiomCount": 13,
     "lineCount": 328,
-    "assumptions": "15 axioms encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "13 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #529: Self-Avoiding Walks**\n\nSelf-avoiding walks (SAWs) were first studied systematically by the chemist Paul Flory in 1949 as models for linear polymers in good solvents. Flory's mean-field prediction $\\nu = 3/(d+2)$ for the end-to-end distance exponent was remarkably accurate, setting the stage for decades of rigorous mathematical work.\n\nThe first rigorous high-dimensional result came from **Gordon Slade** (1987), who used the **lace expansion** — a perturbative technique introduced by Brydges and Spencer (1985) — to prove $d_k(n) \\sim D\\sqrt{n}$ for sufficiently large $k$. **Takashi Hara** and Slade (1991-92) refined this to all $k \\ge 5$, using computer-assisted bounds on the lace expansion coefficients. Their work established that mean-field behavior ($\\nu = 1/2$) holds above the upper critical dimension $d_c = 4$.\n\nThe low-dimensional case proved far more resistant. **Bernard Nienhuis** (1982) predicted $\\nu = 3/4$ in 2D using the exact solution of an O(n) loop model on the honeycomb lattice, and conformal field theory arguments connect 2D SAW to the SLE$_{8/3}$ process (Lawler, Schramm, Werner). The landmark result of **Hugo Duminil-Copin** and **Alan Hammond** (2013) proved $d_2(n) = o(n)$ (sub-ballistic growth) using a bridge decomposition argument, but the full Question 1 ($d_2(n)/\\sqrt{n} \\to \\infty$) remains open.\n\nThe definitive reference is the monograph *The Self-Avoiding Walk* by Madras and Slade (1993, 2nd ed. 2013). **Nathan Clisby** (2010) provided the most precise numerical estimates: $\\nu_3 \\approx 0.5876 \\pm 0.0002$.",
@@ -216,7 +216,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 328,
-    "axiomCount": 15,
+    "axiomCount": 13,
     "theoremCount": 6,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -76,9 +76,9 @@
       "multiplicity_trivial_upper theorem: multiplicity ≤ n²",
       "erdos_756 theorem: main result"
     ],
-    "axiomCount": 10,
+    "axiomCount": 7,
     "lineCount": 293,
-    "assumptions": "10 axioms encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "7 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #756: Rich Distances in the Plane**\n\nThis problem, asked by Erdős and Pach, concerns distance multiplicities in finite point sets in the plane.\n\n**Historical Timeline:**\n- **1934:** Hopf and Pannwitz proved the largest distance among n points occurs at most n times (this is tight for regular polygons)\n- **Erdős-Pach:** Asked whether ALL other distances can have multiplicity > n (the \"strong\" form)\n- **2024:** Bhowmick answered affirmatively with an explicit construction achieving ⌊n/4⌋ rich distances\n- **2025:** Clemen, Dumitrescu, and Liu studied the square grid, finding superpolynomial richness\n\n**The Surprise:**\nDespite the classical Hopf-Pannwitz constraint on the largest distance, Bhowmick showed that MANY distances can be \"rich\" (occurring more than n times). The phenomenon is even stronger on structured sets like square grids.",
@@ -211,7 +211,7 @@
     ],
     "namespace": "Erdos756",
     "lineCount": 293,
-    "axiomCount": 10,
+    "axiomCount": 7,
     "theoremCount": 8,
     "definitionCount": 15
   },

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -38,8 +38,8 @@
     ],
     "dateAdded": "2025-12-21",
     "wiedijkNumber": 6,
-    "axiomCount": 3,
-    "assumptions": "3 axiom declarations: G_self_reference (Godel sentence self-reference), derivability_conditions (Hilbert-Bernays-Lob conditions), lob_sentence_fixed_point (Lob fixed point existence)",
+    "axiomCount": 2,
+    "assumptions": "2 axiom declarations: derivability_conditions (Hilbert-Bernays-Lob conditions), lob_sentence_fixed_point (Lob fixed point existence). G_self_reference is a theorem, not an axiom.",
     "prerequisites": [
       "Mathematical logic: formal systems, provability, consistency",
       "Gödel numbering and arithmetization of metamathematics",
@@ -277,7 +277,7 @@
   "leanFile": {
     "lineCount": 468,
     "structureCount": 1,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 14,
     "lemmaCount": 0,
     "defCount": 12,


### PR DESCRIPTION
## Summary

- Fix axiomCount in 5 proofs (verified against Lean source)
- Fix sorry count in 1 proof (researcher proved 2 sorries since last metadata update)
- Audited 3 additional proofs as CLEAN (no fixes needed)

### Fixes applied

| Proof | Field | Old | New | Notes |
|-------|-------|-----|-----|-------|
| erdos-529 | axiomCount | 15 | 13 | -2 |
| erdos-679 | axiomCount | 1 | 0 | File has 0 axioms, 14 sorries |
| erdos-756 | axiomCount | 10 | 7 | -3 |
| erdos-86 | axiomCount | 5 | 4 | -1 |
| godel-incompleteness | axiomCount | 3 | 2 | G_self_reference is a theorem, not axiom |
| fourier-series-oq-02 | sorries | 3 | 1 | Researcher proved 2 sorries |

### Clean audits (no changes)

- **euler-polyhedral-formula-oq-02**: 4 structure-encoded axioms correctly documented
- **pythagorean-theorem-oq-03**: 3 structure-encoded axioms correctly documented
- **amgm-inequality-oq-03-oq-02**: Tier A original proof, badge "original" correct

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Spot-check axiomCount against Lean source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)