### PR TITLE
Research: erdos-544 - Prove ramsey3_ge_six from monotonicity

### DIFF
--- a/proofs/Proofs/Erdos544Problem.lean
+++ b/proofs/Proofs/Erdos544Problem.lean
@@ -18,10 +18,7 @@ exact growth of consecutive differences remains open.
 Reference: https://erdosproblems.com/544
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Rat.Basic
-import Mathlib.Tactic
+import Mathlib
 
 /- ## Ramsey number R(3, k) -/
 
@@ -29,9 +26,6 @@ import Mathlib.Tactic
     contains either a red triangle or a blue Kₖ.
     Axiomatised with its defining property. -/
 axiom ramsey3 : ℕ → ℕ
-
-/-- R(3, k) is at least 6 for k ≥ 3 (since R(3,3) = 6). -/
-axiom ramsey3_ge_six (k : ℕ) (hk : 3 ≤ k) : 6 ≤ ramsey3 k
 
 /-- R(3, k) is monotone increasing: R(3, k) ≤ R(3, k+1). -/
 axiom ramsey3_mono (k : ℕ) : ramsey3 k ≤ ramsey3 (k + 1)
@@ -59,6 +53,12 @@ axiom ramsey3_val_8 : ramsey3 8 = 28
 /-- R(3, 9) = 36. -/
 axiom ramsey3_val_9 : ramsey3 9 = 36
 
+/- ## Derived bounds -/
+
+/-- R(3, k) is at least 6 for k ≥ 3, proved from R(3,3) = 6 and monotonicity. -/
+theorem ramsey3_ge_six (k : ℕ) (hk : 3 ≤ k) : 6 ≤ ramsey3 k :=
+  ramsey3_val_3 ▸ monotone_nat_of_le_succ ramsey3_mono hk
+
 /- ## Asymptotic bounds -/
 
 /-- Kim (1995) lower bound: R(3, k) ≥ c · k² / log k for some c > 0. -/
@@ -74,7 +74,7 @@ axiom shearer_upper_bound :
 /- ## Main problems -/
 
 /-- The consecutive difference R(3, k+1) − R(3, k). -/
-def ramseyDiff (k : ℕ) : ℕ := ramsey3 (k + 1) - ramsey3 k
+noncomputable def ramseyDiff (k : ℕ) : ℕ := ramsey3 (k + 1) - ramsey3 k
 
 /-- Erdős Problem 544, Part 1: R(3, k+1) − R(3, k) → ∞.
     For every bound M, there exists k₀ such that R(3, k+1) − R(3, k) ≥ M

--- a/src/data/proofs/erdos-544/meta.json
+++ b/src/data/proofs/erdos-544/meta.json
@@ -19,9 +19,9 @@
     "erdosNumber": 544,
     "erdosUrl": "https://erdosproblems.com/544",
     "erdosProblemStatus": "open",
-    "axiomCount": 12,
+    "axiomCount": 11,
     "lineCount": 93,
-    "assumptions": "12 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "assumptions": "11 axiom(s): ramsey3 (function), ramsey3_mono (monotonicity), 7 known values, kim_lower_bound, shearer_upper_bound. Former axiom ramsey3_ge_six now proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -103,16 +103,13 @@
   ],
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Rat.Basic",
-      "Mathlib.Tactic"
+      "Mathlib"
     ],
     "opens": [],
     "namespace": null,
     "lineCount": 93,
-    "axiomCount": 12,
-    "theoremCount": 0,
+    "axiomCount": 11,
+    "theoremCount": 1,
     "definitionCount": 4
   }
 }


### PR DESCRIPTION
## Summary
- Prove `ramsey3_ge_six` (axiom → theorem): `R(3,3)=6` + `monotone_nat_of_le_succ ramsey3_mono`
- **Axiom count 12 → 11**
- Fix stale `Mathlib.Data.Rat.Basic` import
- Fix `noncomputable` issue on `ramseyDiff`

## Key Insight
`ramsey3_ge_six` was redundant: it follows immediately from `ramsey3_val_3` (R(3,3)=6) and `ramsey3_mono` (monotonicity) via Mathlib's `monotone_nat_of_le_succ`. One-line proof.

🤖 Generated by researcher-1