### PR TITLE
Audit fix: erdos-1166 and erdos-5 axiomCount mismatches

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -38,8 +38,8 @@
       "issues": []
     },
     "area-of-circle-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:52:33Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T07:08:58Z",
       "result": "clean",
       "issues": []
     },

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -77,9 +77,9 @@
       "mem_mostVisitedSet",
       "mostVisitedSet_nonempty"
     ],
-    "axiomCount": 23,
+    "axiomCount": 19,
     "lineCount": 259,
-    "assumptions": "23 axioms encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "19 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős Problem #1166 was posed by Paul Erdős and Pál Révész in their study of the fine structure of planar random walks. The problem belongs to a cluster of questions (#1165, #1166) about 'favorite points' — the sites most frequently visited by a random walk on $\\mathbb{Z}^2$. The study of favorite points connects to deep results in probability theory going back to Pólya's 1921 recurrence theorem: a simple random walk on $\\mathbb{Z}^2$ returns to its starting point infinitely often, but only barely — the expected number of returns diverges logarithmically, making two dimensions the critical case between recurrence (1D, 2D) and transience (3D+).\n\nThe key breakthrough came from the Erdős–Taylor theorem (1960), which established that the maximum local time $T_n$ (the largest number of visits to any single point through $n$ steps) satisfies $T_n / (\\log n)^2 \\to 1/\\pi$ almost surely. The appearance of $\\pi$ here is remarkable: it arises from the connection between 2D random walks and planar Brownian motion via Donsker's invariance principle, and ultimately from the Green's function of the 2D lattice.\n\nThe answer to Problem #1166 is YES: almost surely $|\\bigcup_{k \\leq n} F(k)| = O((\\log n)^2)$. The proof combines two ingredients: (1) $|F(n)| \\leq 3$ a.s. for large $n$ (Erdős–Révész, related to #1165), and (2) the Erdős–Taylor bound on $T_n$. Since $T_n$ is integer-valued and bounded by $C(\\log n)^2$, there are at most $O((\\log n)^2)$ distinct 'regimes' of most-visited points, each contributing at most 3 new points. This problem is catalogued at erdosproblems.com/1166 and referenced in Révész's monograph [Va99, 6.78].",
@@ -198,7 +198,7 @@
     ],
     "namespace": "Erdos1166",
     "lineCount": 259,
-    "axiomCount": 23,
+    "axiomCount": 19,
     "theoremCount": 8,
     "definitionCount": 1
   },

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 5,
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
+    "axiomCount": 8,
     "lineCount": 80,
     "assumptions": "8 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0"
@@ -148,7 +148,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 80,
-    "axiomCount": 2,
+    "axiomCount": 8,
     "theoremCount": 21,
     "definitionCount": 2
   },


### PR DESCRIPTION
## Summary

- Fixed axiomCount in 2 erdos meta.json files:
  - erdos-1166: 23→19 (overcounted by 4, no structure-encoded assumptions)
  - erdos-5: 2→8 (undercounted by 6 — assumptions text already correct, only axiomCount field was wrong)
- Also audited area-of-circle-oq-01-oq-03 — sorry mismatch was false positive (5th match is in a comment)

## Test plan

- [x] Verified axiom counts by grepping `^axiom ` in Lean source files
- [x] Checked for structure/class fields encoding assumptions (none found)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)