### PR TITLE
Research: erdos-1108 - Prove four_is_powerful and nine_is_powerful

### DIFF
--- a/proofs/Proofs/Erdos1108Problem.lean
+++ b/proofs/Proofs/Erdos1108Problem.lean
@@ -23,11 +23,7 @@ References:
   factorials", J. Austral. Math. Soc. 1991
 -/
 
-import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.Data.Nat.Prime.Defs
-import Mathlib.Data.Finset.Basic
-import Mathlib.Algebra.BigOperators.Ring.Finset
-import Mathlib.Data.Set.Finite.Basic
+import Mathlib
 import Mathlib.Tactic
 
 namespace Erdos1108
@@ -85,11 +81,17 @@ theorem one_is_powerful : IsPowerful 1 := by
   intro p hp hdiv
   exact absurd (Nat.eq_one_of_dvd_one hdiv) (Nat.Prime.ne_one hp)
 
-/-- 4 = 2² is powerful. Axiomatized for simplicity. -/
-axiom four_is_powerful : IsPowerful 4
+/-- 4 = 2² is powerful. The only prime dividing 4 is 2, and 2² = 4 ∣ 4. -/
+theorem four_is_powerful : IsPowerful 4 := by
+  intro p hp hdiv
+  have : p ≤ 4 := Nat.le_of_dvd (by norm_num) hdiv
+  interval_cases p <;> simp_all (config := { decide := true })
 
-/-- 9 = 3² is powerful. Axiomatized for simplicity. -/
-axiom nine_is_powerful : IsPowerful 9
+/-- 9 = 3² is powerful. The only prime dividing 9 is 3, and 3² = 9 ∣ 9. -/
+theorem nine_is_powerful : IsPowerful 9 := by
+  intro p hp hdiv
+  have : p ≤ 9 := Nat.le_of_dvd (by norm_num) hdiv
+  interval_cases p <;> simp_all (config := { decide := true })
 
 /- ## Perfect Powers in Factorial Sums -/
 

--- a/src/data/proofs/erdos-1108/meta.json
+++ b/src/data/proofs/erdos-1108/meta.json
@@ -50,7 +50,7 @@
       "Proved membership examples for factorial sums",
       "Proved 1 is both a square factorial sum and powerful"
     ],
-    "axiomCount": 7,
+    "axiomCount": 5,
     "lineCount": 193,
     "assumptions": "7 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
@@ -260,12 +260,7 @@
   ],
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Factorial.Basic",
-      "Mathlib.Data.Nat.Prime.Defs",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Algebra.BigOperators.Ring.Finset",
-      "Mathlib.Data.Set.Finite.Basic",
-      "Mathlib.Tactic"
+      "Mathlib"
     ],
     "opens": [
       "Nat",
@@ -274,8 +269,8 @@
     ],
     "namespace": "Erdos1108",
     "lineCount": 193,
-    "axiomCount": 7,
-    "theoremCount": 11,
+    "axiomCount": 5,
+    "theoremCount": 13,
     "definitionCount": 5
   }
 }


### PR DESCRIPTION
## Summary
- Prove `four_is_powerful` and `nine_is_powerful` (axioms → theorems)
- Technique: `interval_cases` on prime divisors bounded by `Nat.le_of_dvd`
- **Axiom count 7 → 5**

## Proof Strategy
For `IsPowerful n`, enumerate all primes `p ≤ n` via `interval_cases`, then `simp_all` handles primality checks and divisibility.

🤖 Generated by researcher-1