### PR TITLE
Enrich Abel-Ruffini + Power Mean Limit: cross-refs and fixes

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -279,6 +279,16 @@
       "targetId": "descartes-rule-of-signs",
       "relationship": "related",
       "description": "Descartes' rule bounds the number of positive real roots of a polynomial by the number of sign changes in its coefficients — a classical tool in the Galois group computation pipeline. For the standard example $x^5 - x - 1$, Descartes' rule (1 sign change) gives exactly 1 positive real root; combined with Sturm's theorem or direct analysis, one finds exactly 3 real roots total, which implies the Galois group contains a transposition (complex conjugation) — one of the key steps in proving $\\text{Gal}(x^5 - x - 1/\\mathbb{Q}) = S_5$"
+    },
+    {
+      "targetId": "pi-transcendental",
+      "relationship": "related",
+      "description": "Lindemann's proof that $\\pi$ is transcendental (1882) resolved the ancient problem of squaring the circle and sits one level above Abel-Ruffini in the expressibility hierarchy: Abel-Ruffini shows certain algebraic numbers escape radical expressions, while $\\pi \\notin \\overline{\\mathbb{Q}}$ shows $\\pi$ escapes all polynomial equations. Both are impossibility results proved via algebraic structure theory — Galois groups for Abel-Ruffini, the Lindemann-Weierstrass theorem for transcendence"
+    },
+    {
+      "targetId": "liouville-theorem",
+      "relationship": "related",
+      "description": "Liouville's construction of the first explicit transcendental numbers (1844) via rational approximation bounds ($|\\alpha - p/q| > c/q^n$ for algebraic $\\alpha$ of degree $n$) bridges the gap between algebraic and transcendental numbers in the expressibility hierarchy. Abel-Ruffini shows a barrier within algebraic numbers (radical vs non-radical), while Liouville's theorem identifies numbers that escape algebraic equations entirely — the next level of the hierarchy discussed in this entry's conclusion"
     }
   ],
   "relatedProofs": [
@@ -306,7 +316,9 @@
     "godel-incompleteness",
     "halting-problem",
     "cantor-diagonalization",
-    "descartes-rule-of-signs"
+    "descartes-rule-of-signs",
+    "pi-transcendental",
+    "liouville-theorem"
   ],
   "references": [
     {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -80,8 +80,7 @@
         "id": "amgm-inequality",
         "relationship": "Root AM-GM inequality; this limit establishes M₀ = GM, the bridge between AM and HM in the power mean chain"
       }
-    ],
-    "mathlib_version": "4.26.0"
+    ]
   },
   "crossReferences": [
     {
@@ -138,6 +137,11 @@
       "targetId": "taylor-theorem",
       "relationship": "foundational",
       "description": "The derivative-based limit technique used here — f(r)/r → f'(0) when f(0) = 0 — is the first-order case of Taylor's theorem: f(r) = f(0) + f'(0)r + O(r²), so f(r)/r = f'(0) + O(r) → f'(0). Taylor's theorem provides the broader framework for understanding why the power mean limit works: the exp/log representation makes log M_r a smooth function of r whose Taylor expansion at r = 0 reveals the geometric mean as the leading coefficient"
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "The calculus infrastructure underpinning this proof — HasDerivAt, chain rule composition, hasDerivAt_iff_tendsto_slope — ultimately rests on the Fundamental Theorem of Calculus connecting derivatives to limits of difference quotients. The FTC formalization establishes the API that makes the slope-to-derivative bridge possible"
     }
   ],
   "overview": {
@@ -266,7 +270,8 @@
     "triangle-inequality",
     "cauchy-schwarz",
     "harmonic-divergence",
-    "taylor-theorem"
+    "taylor-theorem",
+    "fundamental-theorem-calculus"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary
Batch enrichment pass for two gallery entries:

**abel-ruffini** (quality 100, pass 3):
- Added `pi-transcendental` cross-reference (Lindemann 1882, expressibility hierarchy)
- Added `liouville-theorem` cross-reference (first transcendental numbers, 1844)
- Both strengthen the expressibility hierarchy chain prominently featured in the conclusion

**amgm-inequality-oq-03-oq-02** (quality 100, pass 1):
- Fixed duplicate `mathlib_version` field in meta.json
- Added `fundamental-theorem-calculus` cross-reference (calculus infrastructure)

All cross-reference targets verified to exist in the gallery.