### PR TITLE
Enrich 4 proofs: Basel OQ-02, Cauchy-Schwarz OQ-01, Dissection of Cubes, Shannon Source Coding

### DIFF
--- a/src/data/proofs/shannon-source-coding/meta.json
+++ b/src/data/proofs/shannon-source-coding/meta.json
@@ -63,7 +63,8 @@
       "Typical sequences have probability approximately 2^(-nH) each, and there are approximately 2^(nH) of them -- a tiny fraction of all |X|^n possible sequences",
       "The achievability proof is constructive: encode typical sequences with fixed-length codes and flag atypical ones",
       "The converse uses a counting argument: too few codewords cannot cover enough probability mass",
-      "Block coding (encoding sequences rather than individual symbols) is essential: per-symbol optimal codes exist (Huffman) but block coding achieves the limit"
+      "Block coding (encoding sequences rather than individual symbols) is essential: per-symbol optimal codes exist (Huffman) but block coding achieves the limit",
+      "The formalization is currently placeholder stubs (all theorems prove True) — a genuine proof would require Mathlib's probability measure framework, i.i.d. product measures, and the weak law of large numbers applied to log-probability"
     ],
     "prerequisites": [
       "Shannon entropy as information content",
@@ -119,7 +120,7 @@
     {
       "targetId": "shannon-entropy",
       "relationship": "depends-on",
-      "description": "The source coding theorem characterizes entropy H(X) operationally as the compression limit"
+      "description": "The source coding theorem characterizes entropy H(X) operationally as the compression limit — giving entropy its concrete meaning as 'minimum bits per symbol'"
     },
     {
       "targetId": "shannon-channel-coding",
@@ -130,6 +131,16 @@
       "targetId": "shannon-source-coding-oq-02",
       "relationship": "extended-by",
       "description": "Extends the source coding theorem to explore connections with Kolmogorov complexity and algorithmic information theory"
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "related",
+      "description": "Both use probabilistic counting arguments: the birthday problem counts collisions in random mappings, while source coding counts typical sequences — in both cases, the exponential growth of combinatorial possibilities is the core phenomenon"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "foundational",
+      "description": "The AEP (information-theoretic law of large numbers) that underlies source coding is closely related to the CLT: both describe concentration of averages of i.i.d. random variables, but the AEP concerns log-probability while the CLT concerns sums"
     }
   ],
   "conclusion": {
@@ -144,7 +155,9 @@
   "relatedProofs": [
     "shannon-entropy",
     "shannon-channel-coding",
-    "shannon-source-coding-oq-02"
+    "shannon-source-coding-oq-02",
+    "birthday-problem",
+    "central-limit-theorem"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary

Enrichment pass for 4 gallery entries in a single PR.

### basel-problem-oq-02 (quality: 43 → enriched)
- Added 18 detailed annotations covering all sections of the 187-line proof
- Each annotation includes mathContext, significance, relatedConcepts, prerequisites
- Added 5th keyInsight on Zudilin's 4-way disjunction
- Added 3 new cross-references: pi-transcendental, riemann-hypothesis, sqrt2-irrational

### cauchy-schwarz-oq-01 (untracked → enriched)
- Added 4 new annotations: real CS, self-inner product, Im=0, triangle inequality
- Enriched 6 existing annotations with prerequisites
- Added 4 cross-references and mathContext to all 6 sections

### dissection-of-cubes (untracked → enriched)
- Expanded conclusion.implications with electrical network connection
- Added 2 cross-references: sqrt2-irrational, infinitude-primes

### shannon-source-coding (untracked → enriched)
- Added 2 cross-references: birthday-problem, central-limit-theorem
- Added 6th keyInsight noting placeholder status

🤖 Generated with [Claude Code](https://claude.com/claude-code)