### PR TITLE
Audit batch 7c: fix erdos-5 axiom undercounting + 2 more

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
       "isoperimetric"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 5,
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",

--- a/src/data/proofs/area-of-circle-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01/meta.json
@@ -16,7 +16,7 @@
       "differentiation",
       "extension"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -52,7 +52,7 @@
       "Chain rule and power rule for derivatives",
       "Pi and trigonometric function properties"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Main result is a direct application of Mathlib hasDerivAt_pow.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

**CRITICAL fix**: erdos-5 axiomCount was 2 but file has 8 axiom declarations (undercounting).

### Fixes

| Proof | Field | Old | New | Severity |
|-------|-------|-----|-----|----------|
| erdos-5 | axiomCount | 2 | 8 | CRITICAL (undercounting) |
| area-of-circle-oq-01 | badge | original | mathlib | MEDIUM (Tier B wrapper) |
| area-of-circle-oq-01-oq-03 | sorries | 4 | 5 | LOW |

### Clean audits (6 proofs, no fixes)

- erdos-1166: axiomCount 23 correct (scanner undercounted noncomputable axioms)
- angle-trisection, area-of-circle-oq-03, angle-trisection-oq-02-oq-01, angle-trisection-oq-02-oq-03: Tier A original work, badges correct

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)