### PR TITLE
Audit fix: 4 axiomCount mismatches + badge verifications

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -88,7 +88,7 @@
     "namespace": "AngleTrisection",
     "lineCount": 389,
     "structureCount": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 18,
     "lemmaCount": 0,
     "defCount": 4,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8,8 +8,8 @@
       "issues": []
     },
     "amgm-inequality-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:48:05Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T07:20:55Z",
       "result": "clean",
       "issues": []
     },

--- a/src/data/proofs/erdos-536/meta.json
+++ b/src/data/proofs/erdos-536/meta.json
@@ -49,8 +49,8 @@
       "Stated lcm_structure: equal pairwise LCMs imply common divisibility"
     ],
     "lineCount": 88,
-    "axiomCount": 5,
-    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 4,
+    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős posed versions of this problem from the 1960s through the 1990s, culminating in a discussion at the 1991 West Coast Number Theory session. The question asks whether positive-density subsets of $\\{1,\\ldots,N\\}$ must contain three distinct elements with equal pairwise LCMs: $[a,b] = [b,c] = [a,c]$. This means $a, b, c$ are all divisors of a common value $L = [a,b]$, and each pair covers all prime factors of $L$.\n\nWeisenberg proved the conjecture for density $\\varepsilon > 221/225 \\approx 0.982$, an impressively tight partial result. Weisenberg also constructed sets of size $\\gg (\\log\\log N)^{f(N)} \\cdot N / \\log N$ (where $f(N) \\to \\infty$) that avoid the LCM triple property, showing that if a density threshold exists, triple-free sets can be surprisingly large.\n\nErdős showed that the analogous statement for four elements is false: there exist sets of density $\\geq 1/2$ in $\\{1,\\ldots,N\\}$ with no four elements having all pairwise LCMs equal. This sharp contrast between triples and quadruples is characteristic of extremal combinatorics problems.\n\nThe problem sits within a family of Erdős problems (#535, #537, #856, #857) on GCD/LCM patterns in dense sets, connecting density Ramsey theory to multiplicative number theory. The condition $[a,b] = [b,c] = [a,c] = L$ forces a very rigid multiplicative structure: each pair must jointly account for every prime power in the factorization of $L$.\n\n**Status**: OPEN — The conjecture is proved only for $\\varepsilon > 221/225$.",
@@ -134,7 +134,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 87,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 0,
     "definitionCount": 2
   },


### PR DESCRIPTION
## Summary

- Fixed axiomCount in 4 proofs:
  - erdos-1166: 23→19 (overcounted by 4)
  - erdos-5: 2→8 (undercounted by 6)
  - erdos-536: 5→4 (overcounted by 1)
  - angle-trisection: leanFile.axiomCount 1→0 (meta section was correct)
- Verified badges on 3 proofs flagged as "original but calls Mathlib" — all justified
- False positive: area-of-circle-oq-01-oq-03 sorry count is correct (5th match is comment)

## Test plan

- [x] Verified axiom counts by grepping `^axiom ` in Lean source files
- [x] Manually reviewed Mathlib usage in flagged badge proofs
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)