### PR TITLE
Research: erdos-28 - Survey axiom landscape

### DIFF
--- a/src/data/research/problems/erdos-28.json
+++ b/src/data/research/problems/erdos-28.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-28",
-  "title": "Erdős #28",
+  "title": "Erd\u0151s #28",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "(LaTeX not available)",
-    "plain": "If $A\\subseteq \\mathbb{N}$ is such that $A+A$ contains all but finitely many integers then $\\limsup 1_A\\ast 1_A(n)=\\infty$. Conjectured by Erdős and Turán. They also suggest the stronger conjecture that $\\limsup 1_A\\ast 1_A(n)/\\log n>0$. Another stronger conjecture would be that the hypothesis $\\lvert A\\cap [1,N]\\rvert \\gg N^{1/2}$ for all large $N$ suffices. Erdős and Sárközy conjectured the stronger version that if $A=\\{a_1[40]. This is discussed in problem C9 of Guy's collection [Gu04]. Vi...",
+    "plain": "If $A\\subseteq \\mathbb{N}$ is such that $A+A$ contains all but finitely many integers then $\\limsup 1_A\\ast 1_A(n)=\\infty$. Conjectured by Erd\u0151s and Tur\u00e1n. They also suggest the stronger conjecture that $\\limsup 1_A\\ast 1_A(n)/\\log n>0$. Another stronger conjecture would be that the hypothesis $\\lvert A\\cap [1,N]\\rvert \\gg N^{1/2}$ for all large $N$ suffices. Erd\u0151s and S\u00e1rk\u00f6zy conjectured the stronger version that if $A=\\{a_1[40]. This is discussed in problem C9 of Guy's collection [Gu04]. Vi...",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-01-12T06:42:02.929Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Survey: axiom classification and cross-file analysis",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Eliminate sidon_density_bound by importing from Erdos340GreedySidon.lean",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,15 +29,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "SURVEY: Classified 12 axioms across 2 files. 3 are the OPEN conjecture, 4 deep known results, 2 Sidon-related (tractable), 3 analytical. sidon_density_bound can likely be replaced by importing sidon_upper_bound_weak from Erdos340GreedySidon.lean.",
     "builtItems": [],
-    "insights": [],
+    "insights": [
+      "The Erd\u0151s-Tur\u00e1n conjecture (3 forms) is OPEN with $500 prize - cannot be proved",
+      "sidon_density_bound in Erdos28AdditiveBases.lean duplicates sidon_upper_bound_weak in Erdos340GreedySidon.lean - needs IsSidon definition reconciliation",
+      "sidon_not_basis has detailed proof outline in docstring (~200 lines to formalize, requires tight Sidon density bound)",
+      "basis_counting_lower is a counting argument: if A+A \u2287 [N\u2080,\u221e), then \u2211_{a\u2208A,a\u2264N} 1 \u2265 c\u221aN",
+      "Erd\u0151s-Fuchs theorem and average_rep_unbounded are deep analytical results, unlikely provable from Mathlib alone",
+      "Erdos28AdditiveBases.lean (418 lines) is well-structured with 9 proved theorems including evens_repFunc and nat_repFunc",
+      "The AdditiveBases file proves isAsymptoticBasis_iff, sidon_repFunc_bounded, and several example constructions"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #28 - Knowledge Base\n\n## Problem Statement\n\nIf $A\\subseteq \\mathbb{N}$ is such that $A+A$ contains all but finitely many integers then $\\limsup 1_A\\ast 1_A(n)=\\infty$. Conjectured by Erdős and Turán. They also suggest the stronger conjecture that $\\limsup 1_A\\ast 1_A(n)/\\log n>0$. Another stronger conjecture would be that the hypothesis $\\lvert A\\cap [1,N]\\rvert \\gg N^{1/2}$ for all large $N$ suffices. Erdős and Sárközy conjectured the stronger version that if $A=\\{a_1[40]. This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 18 November 2025.\n\n## Status\n\n**Erdős Database Status**: OPEN\n**Prize**: $500\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #2\n- Problem #40\n- Problem #27\n- Problem #29\n- Problem #39\n- Problem #1\n\n## References\n\n- ErTu41\n- Er56\n- Er57\n- Er59\n- Er61\n- Er65\n- Er65b\n- Er69\n- Er70c\n- Er73\n- Er77c\n- ErGr80\n- Er81\n- Er85c\n- Er89d\n- Er90\n- Er94b\n- Er95\n- Er97c\n- Er97f\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "nextSteps": [
+      "Eliminate sidon_density_bound axiom by importing Erdos340GreedySidon.sidon_upper_bound_weak (needs IsSidon reconciliation)",
+      "Prove sidon_not_basis using the outlined density argument (requires tight Sidon bound or alternative approach)",
+      "Prove basis_counting_lower from basic combinatorics (~100-150 lines)",
+      "Consider proving average_rep_unbounded from counting arguments"
+    ],
+    "markdown": "# Erd\u0151s #28 - Knowledge Base\n\n## Problem Statement\n\nIf $A\\subseteq \\mathbb{N}$ is such that $A+A$ contains all but finitely many integers then $\\limsup 1_A\\ast 1_A(n)=\\infty$. Conjectured by Erd\u0151s and Tur\u00e1n. They also suggest the stronger conjecture that $\\limsup 1_A\\ast 1_A(n)/\\log n>0$. Another stronger conjecture would be that the hypothesis $\\lvert A\\cap [1,N]\\rvert \\gg N^{1/2}$ for all large $N$ suffices. Erd\u0151s and S\u00e1rk\u00f6zy conjectured the stronger version that if $A=\\{a_1[40]. This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 18 November 2025.\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n**Prize**: $500\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #2\n- Problem #40\n- Problem #27\n- Problem #29\n- Problem #39\n- Problem #1\n\n## References\n\n- ErTu41\n- Er56\n- Er57\n- Er59\n- Er61\n- Er65\n- Er65b\n- Er69\n- Er70c\n- Er73\n- Er77c\n- ErGr80\n- Er81\n- Er85c\n- Er89d\n- Er90\n- Er94b\n- Er95\n- Er97c\n- Er97f\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
-    "erdos"
+    "erdos",
+    "additive-combinatorics",
+    "number-theory",
+    "open-problem",
+    "prize-problem"
   ],
   "relatedProofs": [
     "erdos-2",


### PR DESCRIPTION
## Summary
- Survey of Erdős #28 ($500 prize, OPEN)
- Classify 12 axioms across 2 files
- Identify cross-file deduplication opportunity

## Axiom Classification
| Category | Count | Examples |
|----------|-------|---------|
| OPEN conjecture | 3 | erdos_turan_conjecture, _strong, _density_version |
| Deep known results | 4 | erdos_fuchs_theorem, grekos/borwein lower bounds |
| Tractable (Sidon) | 2 | sidon_density_bound, sidon_not_basis |
| Analytical | 3 | basis_counting_lower, average_rep_unbounded |

## Key Finding
`sidon_density_bound` in Erdos28AdditiveBases.lean is a duplicate of the **proved** `sidon_upper_bound_weak` in Erdos340GreedySidon.lean. Needs IsSidon definition reconciliation to eliminate.

## Status
**Outcome**: surveyed
**Next Steps**: Eliminate sidon_density_bound, prove sidon_not_basis

🤖 Generated by researcher-6