### PR TITLE
Research: erdos-273 - Add moduli_even theorem and easyPrimes facts

### DIFF
--- a/proofs/Proofs/Erdos273Problem.lean
+++ b/proofs/Proofs/Erdos273Problem.lean
@@ -120,3 +120,34 @@ theorem min_modulus_ge_4 :
   intro cs h i
   obtain ⟨p, _, h5, hm⟩ := h i
   omega
+
+/-- All moduli in a p-1 covering (p ≥ 5) are even.
+    Since p ≥ 5 implies p is odd, p - 1 is even. -/
+theorem moduli_even :
+    ∀ cs : CoveringSystem, AllModuliPrimeMinusOne 5 cs →
+      ∀ i, Even (cs.moduli i) := by
+  intro cs h i
+  obtain ⟨p, hp, h5, hm⟩ := h i
+  have hodd : Odd p := by
+    rcases Nat.Prime.eq_two_or_odd hp with h2 | hodd
+    · omega
+    · exact hodd
+  rw [hm]
+  exact Nat.Odd.sub_odd hodd odd_one
+
+
+/-
+## Section VIII: Computational Verifications
+-/
+
+/-- All elements of easyPrimes are indeed prime. -/
+theorem easyPrimes_all_prime : ∀ p ∈ easyPrimes, Nat.Prime p := by
+  decide
+
+/-- All elements of easyPrimes are ≥ 5. -/
+theorem easyPrimes_ge_five : ∀ p ∈ easyPrimes, 5 ≤ p := by
+  decide
+
+/-- For each p in easyPrimes, (p - 1) divides 360. -/
+theorem easyPrimes_mod_divides_360 : ∀ p ∈ easyPrimes, (p - 1) ∣ 360 := by
+  decide

--- a/src/data/research/problems/erdos-273.json
+++ b/src/data/research/problems/erdos-273.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-12T22:33:22.718Z",
-    "iteration": 1,
+    "iteration": 3,
     "focus": "Axiom elimination complete (4→2)",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,23 +29,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION: Proved difficulty_even_coverage and min_modulus_ge_4 (trivial: p≥5 ⟹ p-1≥4>2). Axioms 4→2. CoveringSystem structure well-formalized.",
+    "progressSummary": "PROGRESS: Added moduli_even theorem (all p-1 moduli for p≥5 are even) and 3 computational verifications for easyPrimes. covering_reciprocal_sum remains axiomatized (deep result requiring formal counting argument).",
     "builtItems": [
       "Proved difficulty_even_coverage: all moduli > 2 when using primes ≥ 5 (omega)",
-      "Proved min_modulus_ge_4: all moduli ≥ 4 when using primes ≥ 5 (omega)"
+      "Proved min_modulus_ge_4: all moduli ≥ 4 when using primes ≥ 5 (omega)",
+      "Proved moduli_even: all moduli in p-1 covering (p≥5) are even",
+      "Proved easyPrimes_all_prime: all 7 primes verified by decide",
+      "Proved easyPrimes_ge_five: all ≥ 5 by decide",
+      "Proved easyPrimes_mod_divides_360: (p-1)|360 for all by decide"
     ],
     "insights": [
       "CoveringSystem structure is well-designed: uses Fin n for indices, ℤ for residues, covers all integers",
       "IsPrimeMinusOne and AllModuliPrimeMinusOne definitions are clean and correct",
       "The key constraint: excluding p=3 removes modulus 2, so all moduli ≥ 4 — very restrictive for covering",
       "Selfridge example (p≥3) uses divisors of 360 = 2³·3²·5 as moduli",
-      "easyPrimes {5,7,13,19,37,61,181} are primes p≥5 with (p-1)|360"
+      "easyPrimes {5,7,13,19,37,61,181} are primes p≥5 with (p-1)|360",
+      "All p-1 moduli for p≥5 are even because p≥5 implies p is odd",
+      "Nat.Odd.sub_odd used to show p-1 is even when p is odd",
+      "covering_reciprocal_sum proof requires counting residue class elements in ranges - doable but ~50 lines"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "covering_reciprocal_sum is mathematically provable from the covering property (pigeonhole)",
-      "selfridge_example requires explicit construction of ~20 residue classes — tedious but feasible",
-      "Could add theorem: sum of 1/(p-1) over easyPrimes = computatible rational — check if ≥ 1"
+      "Prove covering_reciprocal_sum via LCM counting argument (~50 lines)",
+      "Prove easyPrimes_reciprocal_sum_lt_one: ∑1/(p-1) = 109/180 < 1 (needs norm_num on rationals)",
+      "Explore whether larger prime sets can achieve ∑1/(p-1) ≥ 1"
     ],
     "markdown": "# Erdős #273 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a covering system all of whose moduli are of the form $p-1$ for some primes $p\\geq 5$?\n\n\n\nSelfridge has found an example using divisors of $360$ if $p=3$ is allowed.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #272\n- Problem #274\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },


### PR DESCRIPTION
## Summary
- Prove 4 new theorems for Erdős #273 (covering systems with p-1 moduli)
- Theorem count: 2 → 6 (axiom count unchanged at 2)

## Progress
- **moduli_even**: all moduli in a p-1 covering (p ≥ 5) are even, since p ≥ 5 implies p is odd
- **easyPrimes_all_prime**: all 7 elements of easyPrimes are prime (by `decide`)
- **easyPrimes_ge_five**: all ≥ 5 (by `decide`)
- **easyPrimes_mod_divides_360**: (p-1) | 360 for all easyPrimes (by `decide`)

## Status
**Outcome**: progress
**Next Steps**: Prove covering_reciprocal_sum, compute ∑1/(p-1) for easyPrimes

🤖 Generated by researcher-7