### PR TITLE
Research: erdos-667 - eliminate cliqueGuarantee_pos axiom, add p=5 analysis

### DIFF
--- a/proofs/Proofs/Erdos667Problem.lean
+++ b/proofs/Proofs/Erdos667Problem.lean
@@ -25,7 +25,7 @@ Adapted from erdosproblems.com (Apache 2.0 License)
 
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Choose.Basic
-import Mathlib.Data.Rat.Basic
+import Mathlib.Data.Rat.Defs
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Clique
 import Mathlib.Tactic
@@ -43,7 +43,7 @@ We formalize the edge density condition: every p-subset spans at least q edges.
 /-- The number of edges a graph G induces on a subset S of vertices. -/
 def edgeCount {V : Type*} [Fintype V] [DecidableEq V]
     (G : SimpleGraph V) [DecidableRel G.Adj] (S : Finset V) : ℕ :=
-  (S.product S).filter (fun p => p.1 ≠ p.2 ∧ G.Adj p.1 p.2) |>.card / 2
+  ((S ×ˢ S).filter (fun p => p.1 ≠ p.2 ∧ G.Adj p.1 p.2)).card / 2
 
 /-- A graph satisfies the (p,q)-density condition if every p-element subset
     spans at least q edges. -/
@@ -64,10 +64,6 @@ H(n; p, q) is the largest m such that every n-vertex graph with the
 axiom cliqueGuarantee : ℕ → ℕ → ℕ → ℕ
 
 -- Notation: H(n; p, q) = cliqueGuarantee n p q
-
-/-- H(n; p, q) ≥ 1 for any non-empty graph. -/
-axiom cliqueGuarantee_pos (n p q : ℕ) (hn : 1 ≤ n) :
-    1 ≤ cliqueGuarantee n p q
 
 /-- H is monotone in n: more vertices can only help. -/
 axiom cliqueGuarantee_mono_n (p q n : ℕ) :
@@ -96,6 +92,22 @@ axiom cliqueGuarantee_max (n p : ℕ) (hp : 2 ≤ p) :
     (every graph has at least one vertex, forming a trivial clique). -/
 axiom cliqueGuarantee_zero (n p : ℕ) (hn : 1 ≤ n) :
     cliqueGuarantee n p 0 = 1
+
+/-- Extended monotonicity: H(n; p, q1) ≤ H(n; p, q2) for q1 ≤ q2. -/
+theorem cliqueGuarantee_mono_q_general (n p q1 q2 : ℕ) (h : q1 ≤ q2) :
+    cliqueGuarantee n p q1 ≤ cliqueGuarantee n p q2 := by
+  induction h with
+  | refl => exact le_refl _
+  | step _ ih => exact le_trans ih (cliqueGuarantee_mono_q n p _)
+
+/-- H(n; p, q) ≥ 1 for any non-empty graph.
+    Proved: H(n,p,0) = 1 and H is monotone in q, so H(n,p,q) ≥ 1 for all q.
+    (Previously axiomatized; now derived from cliqueGuarantee_zero + monotonicity.) -/
+theorem cliqueGuarantee_pos (n p q : ℕ) (hn : 1 ≤ n) :
+    1 ≤ cliqueGuarantee n p q := by
+  have h0 : cliqueGuarantee n p 0 = 1 := cliqueGuarantee_zero n p hn
+  have hmono := cliqueGuarantee_mono_q_general n p 0 q (Nat.zero_le q)
+  linarith
 
 /-
 ## Part IV: The Exponent c(p, q)
@@ -174,7 +186,7 @@ theorem cpq_pos_at_one (p : ℕ) (hp : 3 ≤ p) : (0 : ℚ) < cpq p 1 := by
 theorem cpq_mono_q_general (p q1 q2 : ℕ) (h : q1 ≤ q2) :
     cpq p q1 ≤ cpq p q2 := by
   induction h with
-  | refl => le_refl _
+  | refl => exact le_refl _
   | step _ ih => exact le_trans ih (cpq_mono_q p _)
 
 /-- The Ramsey bound interval: for p ≥ 2, c(p,1) lies in [1/(p-1), 2/(p+1)]. -/
@@ -214,6 +226,30 @@ theorem p4_efrs : cpq 4 (Nat.choose 3 2) ≤ (1 : ℚ) / 2 :=
 theorem p4_strict_at_top : cpq 4 (Nat.choose 3 2) < cpq 4 (Nat.choose 3 2 + 1) :=
   cpq_strict_at_top 4 (by omega)
 
+/-- For p = 5: C(4,2) + 1 = 7. So q ranges over {1, 2, 3, 4, 5, 6, 7}.
+    c(5,7) = 1. -/
+theorem p5_max : cpq 5 (Nat.choose 4 2 + 1) = 1 := cpq_at_max 5 (by omega)
+
+/-- For p = 5: EFRS gives c(5,6) ≤ 1/2. -/
+theorem p5_efrs : cpq 5 (Nat.choose 4 2) ≤ (1 : ℚ) / 2 :=
+  efrs_bound 5 (by omega)
+
+/-- For p = 5: strict increase at the top: c(5,6) < c(5,7) = 1. -/
+theorem p5_strict_at_top : cpq 5 (Nat.choose 4 2) < cpq 5 (Nat.choose 4 2 + 1) :=
+  cpq_strict_at_top 5 (by omega)
+
+/-- For p = 5: the Ramsey lower bound gives c(5,1) ≥ 1/4. -/
+theorem p5_ramsey_lower : (1 : ℚ) / 4 ≤ cpq 5 1 := by
+  have h := cpq_lower_ramsey 5 (by omega)
+  norm_num at h ⊢
+  exact h
+
+/-- For p = 5: the Ramsey upper bound gives c(5,1) ≤ 1/3. -/
+theorem p5_ramsey_upper : cpq 5 1 ≤ (1 : ℚ) / 3 := by
+  have h := cpq_upper_ramsey 5 (by omega)
+  norm_num at h ⊢
+  exact h
+
 /-
 ## Part VIII: The Main Conjecture (Erdos Problem 667)
 -/
@@ -221,7 +257,7 @@ theorem p4_strict_at_top : cpq 4 (Nat.choose 3 2) < cpq 4 (Nat.choose 3 2 + 1) :
 /-- Erdos Problem 667 (OPEN): c(p, q) is strictly increasing in q for
     1 ≤ q ≤ C(p-1, 2) + 1. -/
 def ErdosProblem667 : Prop :=
-    ∀ (p : ℕ) (hp : 3 ≤ p),
+    ∀ (p : ℕ) (_ : 3 ≤ p),
       ∀ (q : ℕ), 1 ≤ q → q < Nat.choose (p - 1) 2 + 1 →
         cpq p q < cpq p (q + 1)
 
@@ -236,6 +272,38 @@ theorem erdos667_weak_evidence (p : ℕ) (hp : 3 ≤ p) :
     rw [div_lt_one (by linarith : (0 : ℚ) < (p : ℚ) + 1)]
     linarith
   linarith
+
+/-
+## Part IX: Structural Consequences
+
+General results about the gap structure of c(p,q).
+-/
+
+/-- The total gap: for p ≥ 3, c(p,1) is bounded away from c(p,q_max) = 1.
+    Specifically, c(p,q_max) - c(p,1) ≥ 1 - 2/(p+1). -/
+theorem cpq_total_gap (p : ℕ) (hp : 3 ≤ p) :
+    1 - (2 : ℚ) / ((p : ℚ) + 1) ≤
+    cpq p (Nat.choose (p - 1) 2 + 1) - cpq p 1 := by
+  have h1 := cpq_at_max p (le_trans (by omega : 2 ≤ 3) hp)
+  have h2 := cpq_upper_ramsey p (le_trans (by omega : 2 ≤ 3) hp)
+  linarith
+
+/-- The gap is positive: c(p,q_max) - c(p,1) > 0 for p ≥ 3. -/
+theorem cpq_gap_pos (p : ℕ) (hp : 3 ≤ p) :
+    (0 : ℚ) < cpq p (Nat.choose (p - 1) 2 + 1) - cpq p 1 := by
+  linarith [erdos667_weak_evidence p hp]
+
+/-- For p ≥ 3, there exists at least one strict step in c(p,·).
+    The EFRS bound ensures c(p, C(p-1,2)) < c(p, C(p-1,2)+1) = 1. -/
+theorem erdos667_at_least_one_strict_step (p : ℕ) (hp : 3 ≤ p) :
+    ∃ q, 1 ≤ q ∧ q ≤ Nat.choose (p - 1) 2 ∧ cpq p q < cpq p (q + 1) := by
+  exact ⟨Nat.choose (p - 1) 2,
+    Nat.one_le_iff_ne_zero.mpr (by
+      intro h
+      have := Nat.choose_pos (by omega : 2 ≤ p - 1)
+      simp [h] at this),
+    le_refl _,
+    cpq_strict_at_top p hp⟩
 
 /-- Summary of known results for c(p,q). -/
 theorem erdos667_summary (p : ℕ) (hp : 3 ≤ p) :

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -20,8 +20,8 @@
     "erdosNumber": 667,
     "erdosUrl": "https://erdosproblems.com/667",
     "erdosProblemStatus": "open",
-    "axiomCount": 15,
-    "lineCount": 255,
+    "axiomCount": 14,
+    "lineCount": 323,
     "dateAdded": "2026-02-10",
     "mathlibDependencies": [
       {
@@ -38,10 +38,17 @@
     "originalContributions": [
       "edgeCount: definition of induced edge count via filtered ordered pairs",
       "HasDensity: formal (p,q)-density condition on simple graphs",
+      "cliqueGuarantee_pos: PROVED from cliqueGuarantee_zero + mono_q (previously axiom, eliminated 1 axiom)",
+      "cliqueGuarantee_mono_q_general: extended monotonicity H(n;p,q1) ≤ H(n;p,q2) for q1 ≤ q2",
       "cpq_strict_at_top: strict increase at last step via EFRS bound + boundary value",
       "cpq_pos_at_one: positivity c(p,1) > 0 via Ramsey lower bound for p ≥ 3",
       "cpq_mono_q_general: extended weak monotonicity by induction on Nat.le",
       "p3_strict: complete resolution of the p=3 case (c(3,1) < c(3,2)=1)",
+      "p5_max, p5_efrs, p5_strict_at_top: p=5 case analysis (C(4,2)+1=7, EFRS at top)",
+      "p5_ramsey_lower, p5_ramsey_upper: Ramsey bounds for c(5,1) ∈ [1/4, 1/3]",
+      "cpq_total_gap: lower bound on gap c(p,q_max) - c(p,1) ≥ 1 - 2/(p+1)",
+      "cpq_gap_pos: the gap is strictly positive",
+      "erdos667_at_least_one_strict_step: existence of strict increase in c(p,·)",
       "erdos667_weak_evidence: c(p,1) < 1 = c(p,q_max) from Ramsey upper bound",
       "erdos667_summary: packaging of all known structural results"
     ],
@@ -51,7 +58,7 @@
       "Extremal graph theory: Turán-type density conditions",
       "Combinatorics: binomial coefficients C(n,k)"
     ],
-    "assumptions": "15 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "assumptions": "14 axiom(s) encoding mathematical hypotheses (reduced from 15 by proving cliqueGuarantee_pos). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "crossReferences": [
@@ -150,7 +157,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem 667 in 255 lines with 15 axioms encoding the extremal function H(n;p,q) and its exponent c(p,q), and 12 proved theorems deriving structural consequences. The key proved result is strict increase at the top step (via EFRS + boundary value), and the p=3 case is fully resolved. The main conjecture — strict monotonicity of c(p,q) in q — remains open.",
+    "summary": "This formalization captures Erdős Problem 667 in 323 lines with 14 axioms (reduced from 15 by proving cliqueGuarantee_pos) encoding the extremal function H(n;p,q) and its exponent c(p,q), and 22 proved theorems. Key results: axiom elimination via induction, strict increase at top step (EFRS + boundary), small cases (p=3 fully resolved, p=4 and p=5 at top), and structural gap analysis. The main conjecture — strict monotonicity of c(p,q) in q — remains open.",
     "implications": "Strict monotonicity would establish that every additional edge per p-set produces a measurably larger polynomial clique guarantee, ruling out 'plateaus' in the density-to-structure transfer function. This would provide a fine-grained understanding of how local graph density translates to global clique structure, connecting Ramsey theory (q=1) to Turán-type extremal problems (q near maximum) through a monotone interpolation.",
     "openQuestions": [
       "Is c(p,q) strictly increasing in q for all 1 ≤ q < C(p-1,2)+1? The formalization proves this at the top step and for p=3, but the general case remains open",
@@ -163,7 +170,7 @@
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Nat.Choose.Basic",
-      "Mathlib.Data.Rat.Basic",
+      "Mathlib.Data.Rat.Defs",
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Combinatorics.SimpleGraph.Clique",
       "Mathlib.Tactic"
@@ -174,8 +181,8 @@
     ],
     "namespace": "Erdos667",
     "lineCount": 255,
-    "axiomCount": 15,
-    "theoremCount": 12,
+    "axiomCount": 14,
+    "theoremCount": 22,
     "definitionCount": 3
   },
   "references": [

--- a/src/data/research/problems/erdos-667.json
+++ b/src/data/research/problems/erdos-667.json
@@ -16,24 +16,43 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-13T18:22:04.305Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination and structural theorems",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Eliminated 1 axiom (cliqueGuarantee_pos), added 10 new theorems including p=5 analysis and gap structure. Fixed stale Mathlib import. 14 axioms remain.",
+    "builtItems": [
+      "Proved cliqueGuarantee_pos from other axioms (axiom elimination: 15->14)",
+      "Added cliqueGuarantee_mono_q_general: extended monotonicity for H",
+      "Added p5_max, p5_efrs, p5_strict_at_top, p5_ramsey_lower, p5_ramsey_upper",
+      "Added cpq_total_gap, cpq_gap_pos, erdos667_at_least_one_strict_step",
+      "Fixed import: Mathlib.Data.Rat.Basic -> Mathlib.Data.Rat.Defs",
+      "Fixed edgeCount: Finset.product pipe syntax -> explicit parenthesization"
+    ],
+    "insights": [
+      "cliqueGuarantee_pos is derivable from cliqueGuarantee_zero + cliqueGuarantee_mono_q by induction on q",
+      "For p=5: C(4,2)+1=7, so q ranges over {1,...,7}; Ramsey bounds give c(5,1) in [1/4, 1/3]",
+      "The total gap c(p,q_max)-c(p,1) >= 1-2/(p+1) grows with p, approaching 1",
+      "At least one strict step exists for all p>=3 (at q=C(p-1,2) via EFRS)",
+      "Mathlib.Data.Rat.Basic renamed to Mathlib.Data.Rat.Defs in current Mathlib",
+      "Finset.product pipe syntax |>.card broken in Lean 4.26.0; use explicit parenthesization"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Define cliqueGuarantee as proper Lean definition to eliminate more axioms (cliqueGuarantee itself, mono_q, le_n, zero, mono_n)",
+      "Define cpq using liminf from Mathlib.Topology.Algebra.Order.LiminfLimsup to eliminate cpq axioms",
+      "Investigate whether cpq_mono_q can be derived from the definition of cpq + cliqueGuarantee_mono_q",
+      "Create Aristotle companion file with routine lemmas for automated proof search"
+    ],
     "markdown": "# Erdős #667 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $p,q\\geq 1$ be fixed integers. We define $H(n)=H(N;p,q)$ to be the largest $m$ such that any graph on $n$ vertices where every set of $p$ vertices spans at least $q$ edges must contain a complete graph on $m$ vertices.\nIs\\[c(p,q)=\\liminf \\frac{\\log H(n)}{\\log n}\\]a strictly increasing function of $q$ for $1\\leq q\\leq \\binom{p-1}{2}+1$?\n\n\n\nA problem of Erd\\H{o}s, Faudree, Rousseau, and Schelp.\n\nWhen $q=1$ this corresponds exactly to the classical Ramsey problem, and hence for example\\[\\frac{1}{p-1}\\leq c(p,1) \\leq \\frac{2}{p+1}.\\]It is easy to see that if $q=\\binom{p-1}{2}+1$ then $c(p,q)=1$. Erd\\H{o}s, Faudree, Rousseau, and Schelp have shown that $c(p,\\binom{p-1}{2})\\leq 1/2$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #666\n- Problem #668\n- Problem #39\n- Problem #1\n\n## References\n\n- Er97f\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -50,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T18:22:04.305Z",
-  "lastUpdate": "2026-03-13T07:52:17.050Z",
+  "lastUpdate": "2026-03-24T07:20:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- **Axiom elimination**: Proved `cliqueGuarantee_pos` from `cliqueGuarantee_zero` + `cliqueGuarantee_mono_q` by induction on q (15→14 axioms)
- **New theorems**: Added 10 new proved theorems including p=5 case analysis and structural gap analysis
- **Bug fixes**: Fixed stale Mathlib import (`Rat.Basic` → `Rat.Defs`) and `edgeCount` syntax for Lean 4.26.0

## Progress
- Eliminated 1 axiom by deriving `cliqueGuarantee_pos` from other axioms
- Added `cliqueGuarantee_mono_q_general`: extended monotonicity H(n;p,q1) ≤ H(n;p,q2) for q1 ≤ q2
- Added p=5 analysis: `p5_max`, `p5_efrs`, `p5_strict_at_top`, `p5_ramsey_lower`, `p5_ramsey_upper`
- Added structural gap theorems: `cpq_total_gap`, `cpq_gap_pos`, `erdos667_at_least_one_strict_step`
- Updated meta.json with new counts (14 axioms, 22 theorems, 323 lines)

## Findings
- `cliqueGuarantee_pos` follows trivially from the zero case + monotonicity in q
- For p=5: C(4,2)+1=7, Ramsey bounds give c(5,1) ∈ [1/4, 1/3], EFRS gives strict increase at top
- The total gap c(p,q_max)-c(p,1) ≥ 1-2/(p+1) grows with p, approaching 1

## Status
**Outcome**: progress
**Next Steps**: Define `cliqueGuarantee` as proper Lean definition to eliminate 4+ more axioms; create Aristotle companion file

🤖 Generated by researcher-2