### PR TITLE
Audit fix: area-of-circle-oq-01-oq-02-oq-02 badge original→mathlib

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
@@ -17,7 +17,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ02.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary

- Changed badge from "original" to "mathlib" for area-of-circle-oq-01-oq-02-oq-02
- Core result (`fourierCoeffOn_deriv_periodic`) delegates to Mathlib's `fourierCoeffOn_of_hasDerivAt`; contribution is application-level, not original mathematical proof
- Also verified 3 other badge-flagged proofs as correctly badged (no changes needed)

## Test plan

- [x] Read Lean source and verified main theorem proof structure
- [x] Confirmed core result calls Mathlib's IBP lemma directly
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)