### PR TITLE
Audit batch 7d: fix 8 proofs incl. CRITICAL buffons-needle axiom masking

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -27,7 +27,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "assumptions": "1 axiom declaration: borsuk_ulam_general (Borsuk-Ulam theorem for n>=1, INDEPENDENT). Three former axioms (no_retraction, brouwer_fixed_point, lusternik_schnirelmann) are REDUNDANT — proved from BU. Two former axioms (ham_sandwich_general, odd_map_odd_degree) converted to theorems.",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,7 +20,7 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -70,9 +70,9 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 390,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "1 axiom: buffon_noodle_smooth_eq (smooth Buffon noodle expectation). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -195,7 +195,7 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01",
     "lineCount": 390,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 2
   },

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -34,7 +34,7 @@
         "relation": "Erdős #143 studies dilation-avoiding sets, another problem where prime factorization structure controls set density"
       }
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "assumptions": "2 axiom declarations: (1) largestPrimeFactor — definitional axiom positing existence of the largest prime factor function (trivially realizable, used for convenience), (2) balog_wooley_infinitely_many — mathematical assumption encoding the Balog-Wooley 1998 theorem (infinitely many consecutive smooth pairs)",
     "author": "Erdős-Graham (1980), Balog-Wooley (1998)",
     "mathlibDependencies": [
@@ -227,7 +227,7 @@
   "leanFile": {
     "lineCount": 131,
     "structureCount": 0,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 0,
     "lemmaCount": 0,
     "defCount": 5,

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 530,
     "erdosUrl": "https://erdosproblems.com/530",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 164,
     "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0"
@@ -115,7 +115,7 @@
     ],
     "namespace": "Erdos530",
     "lineCount": 164,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-536/meta.json
+++ b/src/data/proofs/erdos-536/meta.json
@@ -49,8 +49,8 @@
       "Stated lcm_structure: equal pairwise LCMs imply common divisibility"
     ],
     "lineCount": 88,
-    "axiomCount": 5,
-    "assumptions": "5 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "axiomCount": 4,
+    "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős posed versions of this problem from the 1960s through the 1990s, culminating in a discussion at the 1991 West Coast Number Theory session. The question asks whether positive-density subsets of $\\{1,\\ldots,N\\}$ must contain three distinct elements with equal pairwise LCMs: $[a,b] = [b,c] = [a,c]$. This means $a, b, c$ are all divisors of a common value $L = [a,b]$, and each pair covers all prime factors of $L$.\n\nWeisenberg proved the conjecture for density $\\varepsilon > 221/225 \\approx 0.982$, an impressively tight partial result. Weisenberg also constructed sets of size $\\gg (\\log\\log N)^{f(N)} \\cdot N / \\log N$ (where $f(N) \\to \\infty$) that avoid the LCM triple property, showing that if a density threshold exists, triple-free sets can be surprisingly large.\n\nErdős showed that the analogous statement for four elements is false: there exist sets of density $\\geq 1/2$ in $\\{1,\\ldots,N\\}$ with no four elements having all pairwise LCMs equal. This sharp contrast between triples and quadruples is characteristic of extremal combinatorics problems.\n\nThe problem sits within a family of Erdős problems (#535, #537, #856, #857) on GCD/LCM patterns in dense sets, connecting density Ramsey theory to multiplicative number theory. The condition $[a,b] = [b,c] = [a,c] = L$ forces a very rigid multiplicative structure: each pair must jointly account for every prime power in the factorization of $L$.\n\n**Status**: OPEN — The conjecture is proved only for $\\varepsilon > 221/225$.",
@@ -134,7 +134,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 87,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 0,
     "definitionCount": 2
   },

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -55,7 +55,7 @@
       "erdos_96_summary: proved conjunction of bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 294,
     "assumptions": "5 axioms: cyclicOrder (convex polygon vertex ordering), furedi_bound (O(n log n) upper bound), aggarwal_bound (n log₂n + 4n best upper bound), edelsbrunner_hajnal_construction (2n-7 lower bound), sum_lower_bound (equidistant count near 4n)."
   },
@@ -149,7 +149,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 294,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 2,
     "definitionCount": 10
   },

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -72,7 +72,7 @@
       "green-theorem",
       "research"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 557,
     "prerequisites": [
       "Green's theorem: line integral to double integral",

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 21,
-    "axiomCount": 7,
+    "axiomCount": 6,
     "lineCount": 387,
     "assumptions": "7 axioms: fuchsian_has_regular_singularities, computeMonodromy, plemelj_theorem_irreducible, bolibrukh_counterexample, birkhoff_theorem, realization_criterion, riemann_hilbert_correspondence.",
     "mathlib_version": "4.26.0"
@@ -155,7 +155,7 @@
     "opens": [],
     "namespace": "Hilbert21",
     "lineCount": 387,
-    "axiomCount": 7,
+    "axiomCount": 6,
     "theoremCount": 3,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Summary

**CRITICAL**: buffons-needle-oq-01-oq-01 claimed "verified" (0 axioms) but has `axiom buffon_noodle_smooth_eq` at line 351. This is Narrative Failure Mode #2 (axiom masking). Fixed: status→axiomatized, badge→axiom, axiomCount→1.

### All fixes

| Proof | Field | Old | New | Type |
|-------|-------|-----|-----|------|
| buffons-needle-oq-01-oq-01 | status/badge/axiomCount | verified/0 | axiomatized/axiom/1 | CRITICAL |
| erdos-536 | axiomCount | 5 | 4 | overcounting |
| erdos-530 | axiomCount | 4 | 3 | overcounting |
| erdos-96 | axiomCount | 5 | 4 | overcounting |
| erdos-369 | axiomCount | 2 | 1 | overcounting |
| hilbert-21 | axiomCount | 7 | 6 | overcounting |
| borsuk-ulam-oq-03 | axiomCount | 1 | 2 | undercounting |
| greens-theorem-oq-03 | axiomCount | 2 | 3 | undercounting |

### Clean audits (3 proofs)

- riemann-hypothesis: 38 = 32 decls + 6 SelbergClassAxioms structure fields ✓
- birch-swinnerton-dyer: 24 = 21 decls + 3 structure fields ✓
- triangle-inequality-oq-03: 0 axioms ✓

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)