### PR TITLE
Peer review: fair-games-theorem (C-)

### DIFF
--- a/src/data/proofs/fair-games-theorem/review.json
+++ b/src/data/proofs/fair-games-theorem/review.json
@@ -1,0 +1,157 @@
+{
+  "version": 1,
+  "proofId": "fair-games-theorem",
+  "reviewDate": "2026-03-24T12:30:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "C-",
+    "oneLiner": "Contains a genuine Optional Stopping Theorem proof, but the meta.json describes a completely different theorem (gambler's ruin), 5 of 11 theorems are filler proving 1+1=2, and the status/badge are wrong for a file whose main result is actually proved.",
+    "tier": "B",
+    "tierJustification": "Tier B: The core Optional Stopping Theorem is formalized using Mathlib, with a genuine ~20-line proof combining sub- and supermartingale inequalities via le_antisymm. However, the surrounding content is heavily padded with filler theorems, thin definition wrappers, and one supplementary axiom. The low grade reflects catastrophic framing (description describes a different theorem) rather than lack of mathematical substance."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "fair_games_theorem, lines 195-227",
+      "finding": "The main theorem is a genuine, substantive proof. It uses le_antisymm to combine Mathlib's submartingale inequality (E[f_τ] ≤ E[f_π]) with the supermartingale inequality (obtained by negating f and using Submartingale.neg + integral_neg + linarith). This is a clever sandwich argument that constitutes real formal reasoning, not just a Mathlib wrapper. The proof works with Mathlib's deep measure theory API at a non-trivial level.",
+      "recommendation": "Preserve. This is the file's core value."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Lean file docstring (lines 8-84) and meta.json overview.historicalContext",
+      "finding": "The exposition of martingale history is well-researched and well-written: Bachelier (1900/1906), Lévy (1930s), Ville (1939 coining 'martingale'), Doob (1953). The intuitive explanations of why stopping strategies fail in fair games are clear and accessible. The Lean file comments explaining the proof strategy (sub/supermartingale sandwich) are accurate and helpful.",
+      "recommendation": "Preserve the historical and intuitive exposition. It just needs to describe the correct theorem."
+    },
+    {
+      "severity": "critical",
+      "category": "precision",
+      "location": "meta.json description, overview.problemStatement, overview.text, sourceUrl",
+      "finding": "The description says: 'a gambler with finite wealth playing against an infinitely wealthy opponent will eventually go bankrupt with probability 1.' The problemStatement says: 'will eventually go bankrupt with probability 1. The expected time to ruin is infinite, but ruin is certain.' This is GAMBLER'S RUIN — a theorem about random walk recurrence and hitting times. The Lean file proves the OPTIONAL STOPPING THEOREM: E[X_τ] = E[X_0] for bounded stopping times, which is a different result (about expectations, not probabilities of ruin). The sourceUrl links to Wikipedia's Gambler's Ruin page, reinforcing the confusion. A mathematician reading the gallery entry would expect to find a formalization of P(ruin)=1 and instead find E[X_τ]=E[X_0].",
+      "recommendation": "Rewrite description to: 'The Optional Stopping Theorem (Wiedijk #62): for a martingale (fair game) and bounded stopping times τ ≤ π, E[X_τ] = E[X_π]. No betting strategy can change the expected outcome of a fair game.' Change sourceUrl to the Optional Stopping Theorem Wikipedia page. Rewrite problemStatement accordingly."
+    },
+    {
+      "severity": "major",
+      "category": "filler",
+      "location": "gamblers_ruin_fair_game (line 373), betting_systems_fail (line 392), option_pricing_martingale (line 408), doobs_inequality_statement (line 422), fair_games_summary (line 469)",
+      "finding": "Five theorems each prove `(1 : ℕ) + 1 = 2 := rfl`. Their docstrings discuss substantive mathematics (gambler's ruin probabilities, betting system analysis, Black-Scholes pricing, Doob's maximal inequality) but the formal content is completely vacuous. These inflate the theorem count from 6 to 11 and create a misleading impression of formal coverage. A reader browsing the gallery would think gambler's ruin, option pricing, and Doob's inequality are formalized when they are not.",
+      "recommendation": "Remove all filler theorems entirely, or replace them with honest placeholder comments. If the goal is to sketch future directions, use Lean comments rather than theorems. Do not count these in theoremCount."
+    },
+    {
+      "severity": "major",
+      "category": "filler",
+      "location": "fair_coin_flip_martingale_property, line 111-114",
+      "finding": "This theorem proves `True := by trivial`. Its docstring promises an example about fair coin flips forming a martingale. The theorem statement and body have zero mathematical content. This is the most egregious form of filler — a True theorem dressed as a mathematical result.",
+      "recommendation": "Either formalize the actual claim (construct a simple random walk martingale) or remove entirely."
+    },
+    {
+      "severity": "major",
+      "category": "inconsistency",
+      "location": "meta.json status: 'axiomatized', badge: 'axiom'",
+      "finding": "The main theorem (fair_games_theorem / Optional Stopping Theorem) IS proved — it is not axiomatized. The single axiom (submartingale_of_stoppedValue_mono) is for a supplementary characterization theorem, not the main result. Marking the file as 'axiomatized' with badge 'axiom' is incorrect. The file should be 'verified' with badge 'mathlib' (the proof relies on Mathlib's submartingale API), with a note that one supplementary characterization uses an axiom.",
+      "recommendation": "Change status to 'verified', badge to 'mathlib'. Update assumptions to clarify the axiom is for the supplementary characterization, not the main result."
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "meta.json originalContributions",
+      "finding": "The three listed contributions are all overclaimed: (1) 'Framework for fair games and random walks' — isFairGame is literally `= Martingale`, not a framework. (2) 'Ruin probability calculations' — the 'calculation' proves 1+1=2. (3) 'Connection to martingale stopping theorems' — the proof IS the stopping theorem; calling it a 'connection' is circular. The actual original contribution is the le_antisymm sandwich proof combining sub/supermartingale inequalities.",
+      "recommendation": "Replace with: ['Proof of Optional Stopping Theorem equality via submartingale/supermartingale sandwich argument (le_antisymm)', 'E[X_τ]=E[X_0] corollary for bounded stopping times', 'Submartingale characterization via stopped values (forward direction from Mathlib, converse axiomatized)']."
+    },
+    {
+      "severity": "major",
+      "category": "precision",
+      "location": "meta.json overview.proofStrategy",
+      "finding": "The proofStrategy says: 'Model the game as a random walk on integers. The player's wealth is a martingale. By the martingale convergence theorem and recurrence properties of 1D random walks, the walk will hit 0 with probability 1.' This describes a proof of gambler's ruin via random walk recurrence, NOT the Optional Stopping Theorem. The actual proof strategy is: use le_antisymm with the submartingale inequality E[f_τ] ≤ E[f_π] and the supermartingale inequality (obtained by negating f), yielding equality.",
+      "recommendation": "Rewrite to describe the actual proof: 'A martingale is both a submartingale and supermartingale. The submartingale property gives E[f_τ] ≤ E[f_π], while negating to get a supermartingale gives E[f_τ] ≥ E[f_π]. By le_antisymm, E[f_τ] = E[f_π].'"
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json overview.keyInsights",
+      "finding": "4 of 5 keyInsights describe content not formalized in the Lean file: gambler's ruin probability (P=1), Pólya's random walk recurrence, expected time to ruin (E[τ]=∞), and Harrison-Pliska/Black-Scholes. Only insight #4 ('Optional Stopping Theorem says E[X_τ]=E[X_0]') describes what is actually proved.",
+      "recommendation": "Rewrite insights to focus on the formalized content: the sandwich proof technique, the role of boundedness, the sub/supermartingale duality."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "crossReferences: infinitude-primes",
+      "finding": "The cross-reference to infinitude-primes claims both are 'inevitability results: infinitely many primes exist (Euclid) and ruin is certain in a fair game (Doob).' This is purely metaphorical — there is no mathematical connection between the infinitude of primes and the Optional Stopping Theorem. Additionally, gambler's ruin is NOT what this file proves.",
+      "recommendation": "Remove this cross-reference. Replace with a connection to a proof that has a genuine mathematical relationship (e.g., central-limit-theorem, or another probability result)."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json leanFile.theoremCount: 11",
+      "finding": "Of the 11 theorems: 5 prove `1+1=2`, 1 proves `True`, so only 5 contain any mathematical content. The count of 11 creates a false impression of substantive coverage.",
+      "recommendation": "Update to 5 (actual content theorems) after removing filler, or note that 6 are placeholder theorems."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "Lean file line 8: '/-!' docstring",
+      "finding": "The file uses `/-!` (module docstring syntax) at line 8. Per Aristotle compatibility notes, `/-!` can cause parsing errors. Additionally, `/-!` appears again at lines 88, 118, 163, 269, 350, 429.",
+      "recommendation": "Replace `/-!` with `/-` for compatibility, unless the file is not intended for Aristotle submission."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Critical reframing: rewrite meta.json description, overview.problemStatement, overview.text, and overview.proofStrategy to describe the Optional Stopping Theorem (what the file proves) instead of gambler's ruin (what it doesn't prove). Change sourceUrl from Gambler's Ruin to Optional Stopping Theorem. This is the single most important fix.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Fix status and badge: change status from 'axiomatized' to 'verified', badge from 'axiom' to 'mathlib'. The main theorem IS proved; the single axiom is for a supplementary characterization, not the main result. Update assumptions to clarify.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "high",
+      "target": "researcher",
+      "description": "Remove or replace the 6 filler theorems: 5 that prove (1:ℕ)+1=2 and 1 that proves True. Either delete them entirely (preferred), replace with comments sketching future directions, or formalize at least one application (e.g., construct a simple random walk and show it's a martingale).",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Rewrite originalContributions to reflect the actual proof: le_antisymm sandwich argument, E[X_τ]=E[X_0] corollary, partial submartingale characterization. Remove claims about 'framework' and 'ruin probability calculations'.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Rewrite keyInsights to focus on formalized content (sandwich proof technique, bounded stopping time requirement, sub/supermartingale duality). Remove insights about gambler's ruin, Pólya's theorem, and Harrison-Pliska that are not formalized.",
+      "status": "open"
+    },
+    {
+      "id": "ai-6",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Remove spurious cross-reference to infinitude-primes. Update mathlibDependencies to list specific API used (expected_stoppedValue_mono, Submartingale.neg, etc.) instead of just the general module. Fix theoremCount after filler removal.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 5,
+    "originalityAccuracy": 3,
+    "completeness": 5,
+    "framingPrecision": 3,
+    "pedagogicalQuality": 6,
+    "internalConsistency": 3,
+    "overall": 4.2
+  },
+
+  "suggestedBestFraming": "A Lean 4 proof of the Optional Stopping Theorem (Wiedijk #62): for a martingale and bounded stopping times τ ≤ π, E[X_τ] = E[X_π], proved via a sub/supermartingale sandwich argument using Mathlib's measure-theoretic probability API."
+}


### PR DESCRIPTION
## Summary

- Peer review of `fair-games-theorem` gallery entry (Optional Stopping Theorem, Wiedijk #62)
- **Grade: C-** (Tier B mathematical content, severely undermined by framing)
- 12 findings (2 positive, 1 critical, 5 major, 2 moderate, 1 minor)
- 6 action items (3 high, 2 medium, 1 low)

## Key Findings

- **Critical framing mismatch**: meta.json description/problemStatement describe **gambler's ruin** (P(bankruptcy)=1) but the Lean file proves the **Optional Stopping Theorem** (E[X_τ]=E[X_0]) — completely different results
- **Filler epidemic**: 5 of 11 theorems prove `(1:ℕ)+1=2`, 1 proves `True` — elaborate docstrings with zero formal content
- **Wrong status/badge**: Main theorem IS proved (not axiomatized); the single axiom is for a supplementary characterization
- **Genuine proof**: `fair_games_theorem` (lines 195-227) is a substantive le_antisymm sandwich proof combining sub/supermartingale inequalities
- **Good exposition**: Historical context (Bachelier→Lévy→Ville→Doob) is well-written, just describes the wrong theorem

🤖 Generated with [Claude Code](https://claude.com/claude-code)