### PR TITLE
Fix erdos-1160 sections: wrong field names break build

### DIFF
--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -57,44 +57,44 @@
     {
       "id": "group-counting",
       "title": "The Group Counting Function",
-      "lineStart": 30,
-      "lineEnd": 60,
-      "description": "Axiomatization of numGroups and known values"
+      "startLine": 30,
+      "endLine": 60,
+      "summary": "Axiomatization of numGroups and known values"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "lineStart": 62,
-      "lineEnd": 77,
-      "description": "Positivity and monotonicity for prime powers"
+      "startLine": 62,
+      "endLine": 77,
+      "summary": "Positivity and monotonicity for prime powers"
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
-      "lineStart": 79,
-      "lineEnd": 97,
-      "description": "Formal statement and equivalent formulations"
+      "startLine": 79,
+      "endLine": 97,
+      "summary": "Formal statement and equivalent formulations"
     },
     {
       "id": "stronger-conjecture",
       "title": "Stronger Conjecture",
-      "lineStart": 99,
-      "lineEnd": 114,
-      "description": "BNV07 stronger form and implication"
+      "startLine": 99,
+      "endLine": 114,
+      "summary": "BNV07 stronger form and implication"
     },
     {
       "id": "partial-results",
       "title": "Known Partial Results",
-      "lineStart": 116,
-      "lineEnd": 138,
-      "description": "Proved cases: n=1, prime n, odd n (Pantelidakis)"
+      "startLine": 116,
+      "endLine": 138,
+      "summary": "Proved cases: n=1, prime n, odd n (Pantelidakis)"
     },
     {
       "id": "asymptotics",
       "title": "Asymptotic Growth",
-      "lineStart": 140,
-      "lineEnd": 152,
-      "description": "Super-exponential growth of g(2^m)"
+      "startLine": 140,
+      "endLine": 152,
+      "summary": "Super-exponential growth of g(2^m)"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix `erdos-1160/meta.json` sections to use correct `ProofSection` field names
- `lineStart`→`startLine`, `lineEnd`→`endLine`, `description`→`summary`
- Build was broken by PR #5762 which introduced these incorrect field names

## Test plan
- [x] Verified field names match `ProofSection` interface in `src/types/proof.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)