### PR TITLE
Research: erdos-25 - prove logDensity_odds by complementation

### DIFF
--- a/proofs/Proofs/Erdos25LogDensity.lean
+++ b/proofs/Proofs/Erdos25LogDensity.lean
@@ -344,12 +344,79 @@ Ratio: (1/2) · H_{N/2} / log(N) → 1/2 since H_{N/2} ~ log(N/2) ~ log(N).
 **Proof status**: HARD (~60 lines) - requires harmonic sum asymptotics. -/
 axiom logDensity_evens : HasLogDensity {n : ℕ | Even n ∧ n ≠ 0} (1/2)
 
-/-- **Axiom: Odd numbers have log density 1/2**.
+/-- Splitting: logWeightedCount of a disjoint union equals the sum of parts. -/
+theorem logWeightedCount_union_disjoint {A B : Set ℕ} (h : Disjoint A B) (N : ℕ) :
+    logWeightedCount (A ∪ B) N = logWeightedCount A N + logWeightedCount B N := by
+  unfold logWeightedCount
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro n _
+  by_cases hn : n = 0
+  · subst hn; simp
+  · by_cases hA : n ∈ A
+    · have hB : n ∉ B := fun hb => Set.disjoint_left.mp h hA hb
+      rw [if_pos ⟨Set.mem_union_left B hA, hn⟩, if_pos ⟨hA, hn⟩,
+          if_neg (show ¬(n ∈ B ∧ n ≠ 0) from fun ⟨hb, _⟩ => hB hb)]
+      ring
+    · by_cases hB : n ∈ B
+      · rw [if_pos ⟨Set.mem_union_right A hB, hn⟩,
+            if_neg (show ¬(n ∈ A ∧ n ≠ 0) from fun ⟨ha, _⟩ => hA ha),
+            if_pos ⟨hB, hn⟩]
+        ring
+      · rw [if_neg (show ¬(n ∈ (A ∪ B) ∧ n ≠ 0) from fun ⟨hab, _⟩ => hab.elim hA hB),
+            if_neg (show ¬(n ∈ A ∧ n ≠ 0) from fun ⟨ha, _⟩ => hA ha),
+            if_neg (show ¬(n ∈ B ∧ n ≠ 0) from fun ⟨hb, _⟩ => hB hb)]
+        ring
 
-Follows from logDensity_full and logDensity_evens via complementation.
+/-- Every positive natural number is either even or odd. -/
+private theorem even_odd_partition :
+    (Set.univ : Set ℕ) \ {0} = {n : ℕ | Even n ∧ n ≠ 0} ∪ {n : ℕ | Odd n} := by
+  ext n
+  simp only [Set.mem_diff, Set.mem_univ, Set.mem_singleton_iff, true_and,
+    Set.mem_union, Set.mem_setOf_eq]
+  constructor
+  · intro hne
+    rcases Nat.even_or_odd n with he | ho
+    · exact Or.inl ⟨he, hne⟩
+    · exact Or.inr ho
+  · rintro (⟨_, hne⟩ | ho)
+    · exact hne
+    · obtain ⟨k, hk⟩ := ho; omega
 
-**Proof status**: HARD (~40 lines) - requires density complementation lemma. -/
-axiom logDensity_odds : HasLogDensity {n : ℕ | Odd n} (1/2)
+/-- Even and odd positive numbers are disjoint. -/
+private theorem even_odd_disjoint :
+    Disjoint {n : ℕ | Even n ∧ n ≠ 0} {n : ℕ | Odd n} := by
+  rw [Set.disjoint_left]
+  intro n ⟨he, _⟩ ho
+  obtain ⟨k, hk⟩ := he; obtain ⟨j, hj⟩ := ho; omega
+
+/-- Odd numbers have log density 1/2.
+    Proved from logDensity_full and logDensity_evens via complementation:
+    {evens⁺} ∪ {odds} = ℕ⁺, so density(odds) = 1 - 1/2 = 1/2.
+    (Previously axiomatized; now derived.) -/
+theorem logDensity_odds : HasLogDensity {n : ℕ | Odd n} (1/2) := by
+  -- Strategy: show odds = ℕ⁺ \ evens⁺, then use density subtraction
+  have hfull := logDensity_full
+  have hevens := logDensity_evens
+  have hunion := even_odd_partition
+  have hdisj := even_odd_disjoint
+  -- logDensityRatio of odds = logDensityRatio of ℕ⁺ - logDensityRatio of evens⁺
+  -- because logDensityRatio of (A ∪ B) = logDensityRatio A + logDensityRatio B (for N > 1)
+  suffices h : HasLogDensity {n : ℕ | Odd n} (1 - 1/2) by
+    norm_num at h; exact h
+  unfold HasLogDensity at *
+  -- Eventually, the ratios split
+  have hev_split : ∀ᶠ N in atTop,
+      logDensityRatio {n : ℕ | Odd n} N =
+      logDensityRatio (Set.univ \ {0}) N - logDensityRatio {n | Even n ∧ n ≠ 0} N := by
+    filter_upwards [eventually_gt_atTop 1] with N hN
+    have h1 : ¬(N ≤ 1) := by omega
+    unfold logDensityRatio
+    simp only [h1, ↓reduceIte]
+    rw [hunion, logWeightedCount_union_disjoint hdisj N, add_div]
+    ring
+  refine Filter.Tendsto.congr' ?_ (Tendsto.sub hfull hevens)
+  exact hev_split.mono (fun N hN => hN.symm)
 
 /-- **Axiom: Numbers ≢ 0 (mod m) have log density (m-1)/m**.
 

--- a/src/data/research/problems/erdos-25.json
+++ b/src/data/research/problems/erdos-25.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 3 axioms from Erdos25LogDensity.lean (hasLogDensity_iff_eq, logDensityRatio_bounded→fixed+proved, upperLogDensity_mono). Added 10 new proved theorems including logWeightedCount_nonneg, logWeightedCount_mono, logDensityRatio_nonneg, logDensityRatio_mono, and more. Fixed incorrect axiom (logDensityRatio_bounded upper bound was provably false).",
+    "progressSummary": "PROGRESS: Proved logDensity_odds by complementation (evens+full→odds). LogDensity.lean now has 5 axioms (down from 6). Total: 5 axioms in LogDensity + 6 in Problem = 11. Combined with prior session: eliminated 4 axioms total across sessions.",
     "builtItems": [
       "Proved logWeightedCount_nonneg in Erdos25LogDensity.lean",
       "Proved logWeightedCount_mono in Erdos25LogDensity.lean",
@@ -43,13 +43,21 @@
       "Proved logDensityRatio_isBoundedUnder_ge in Erdos25LogDensity.lean",
       "Converted upperLogDensity_mono from axiom to theorem in Erdos25LogDensity.lean",
       "Converted hasLogDensity_iff_eq from axiom to theorem in Erdos25LogDensity.lean",
-      "Fixed incorrect logDensityRatio_bounded axiom (upper bound ≤1 was false for H_N/log N > 1)"
+      "Fixed incorrect logDensityRatio_bounded axiom (upper bound ≤1 was false for H_N/log N > 1)",
+      "Proved logDensity_odds from logDensity_evens + logDensity_full (axiom: 6→5 in LogDensity.lean)",
+      "Added logWeightedCount_union_disjoint: splitting lemma for disjoint unions",
+      "Added even_odd_partition: ℕ⁺ = evens⁺ ∪ odds",
+      "Added even_odd_disjoint: evens and odds are disjoint"
     ],
     "insights": [
       "The axiom logDensityRatio_bounded claiming ratio ≤ 1 for N ≥ 2 is mathematically incorrect since H_N/log N > 1 for all finite N (converges to 1 from above due to Euler-Mascheroni constant)",
       "Filter.IsCoboundedUnder (· ≤ ·) and Filter.IsBoundedUnder (· ≥ ·) are different types in Mathlib despite both representing lower bounds conceptually",
       "tendsto_of_le_liminf_of_limsup_le needs IsBoundedUnder (· ≤ ·) and IsBoundedUnder (· ≥ ·), not IsCoboundedUnder",
-      "div_le_div_right and div_le_div_iff are not available in current Mathlib; use div_eq_mul_inv + mul_le_mul_of_nonneg_right instead"
+      "div_le_div_right and div_le_div_iff are not available in current Mathlib; use div_eq_mul_inv + mul_le_mul_of_nonneg_right instead",
+      "logDensity_odds is derivable from logDensity_evens + logDensity_full via complementation",
+      "logWeightedCount splits additively over disjoint unions",
+      "Even/odd exclusivity proved by omega on Nat existential forms",
+      "Tendsto.congr requires EventuallyEq direction matching; use .mono with eq.symm"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -82,7 +90,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T04:34:21.348Z",
-  "lastUpdate": "2026-03-13T07:52:17.042Z",
+  "lastUpdate": "2026-03-24T08:10:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- **Axiom elimination**: Proved `logDensity_odds` from `logDensity_evens` + `logDensity_full` via complementation (6→5 axioms in Erdos25LogDensity.lean)
- **New infrastructure**: `logWeightedCount_union_disjoint` splitting lemma, `even_odd_partition` and `even_odd_disjoint` helpers

## Progress
- Proved that odd numbers have log density 1/2 by showing: {evens⁺} ∪ {odds} = ℕ⁺ (partition), density(ℕ⁺) = 1, density(evens⁺) = 1/2, so density(odds) = 1 - 1/2 = 1/2
- The `logWeightedCount_union_disjoint` lemma enables further density proofs by complementation
- LogDensity.lean: 5 axioms (down from 6), 34 definitions/theorems, 473 lines

## Findings
- `logWeightedCount` splits additively over disjoint unions — this is a general tool
- The `Tendsto.congr'` direction matters: need `EventuallyEq.mono` with `Eq.symm` for the right direction
- Even/odd exclusivity best proved by destructing into existentials and using `omega`

## Status
**Outcome**: progress
**Next Steps**: Prove `logDensity_evens` (harmonic sum of even numbers = (1/2)·H_{N/2}), then all three example axioms become theorems

🤖 Generated by researcher-2