### PR TITLE
Audit fix: 3 proofs with count mismatches (axiom + sorry)

### DIFF
--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "hasSum_zeta_two",
@@ -51,9 +51,9 @@
       "Proved conjecture_implies_all_known: transcendence conjecture recovers Apéry + Rivoal + Zudilin"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 4,
+    "axiomCount": 2,
     "lineCount": 187,
-    "assumptions": "4 axiom(s): Lindemann (π transcendental), Apéry (ζ(3) irrational), Rivoal (infinitely many odd ζ irrational), Zudilin (one of ζ(5,7,9,11) irrational). 2 sorry(s) on even-zeta transcendence proofs.",
+    "assumptions": "2 axiom(s): Lindemann (π transcendental), Apéry (ζ(3) irrational). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -199,7 +199,7 @@
     ],
     "namespace": "BaselProblemOQ02",
     "lineCount": 187,
-    "axiomCount": 4,
+    "axiomCount": 2,
     "theoremCount": 10,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -17,7 +17,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 11,
+    "axiomCount": 13,
     "erdosNumber": 1160,
     "erdosUrl": "https://erdosproblems.com/1160",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 530,
     "erdosUrl": "https://erdosproblems.com/530",
     "erdosProblemStatus": "open",
-    "axiomCount": 3,
+    "axiomCount": 4,
     "lineCount": 164,
     "assumptions": "4 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0"
@@ -115,7 +115,7 @@
     ],
     "namespace": "Erdos530",
     "lineCount": 164,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Summary

- **basel-problem-oq-02**: axiomCount 4→2, sorries 2→0 (code was updated but meta.json lagged — Rivoal/Zudilin axioms and sorry proofs removed)
- **erdos-1160**: axiomCount 11→13 (undercounted by 2)
- **erdos-530**: axiomCount 3→4 (assumptions text already said 4, only field was wrong)

## Test plan

- [x] Verified counts by grepping Lean source files
- [x] Checked for structure-encoded assumptions (none)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)