### PR TITLE
Enrich Erdős #1160: overview, conclusion, cross-refs, deep annotations

### DIFF
--- a/src/data/proofs/erdos-1160/annotations.json
+++ b/src/data/proofs/erdos-1160/annotations.json
@@ -1,58 +1,146 @@
 [
   {
-    "id": "numGroups-axiom",
-    "lineStart": 37,
-    "lineEnd": 40,
+    "id": "ann-numgroups-axiom",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 37, "endLine": 40 },
     "type": "definition",
     "title": "The Group Counting Function",
-    "content": "We axiomatize g(n) = numGroups(n), the number of non-isomorphic groups of order n (OEIS A000001). This function is not computable in Lean/Mathlib since it requires enumerating all group structures of a given order up to isomorphism. The function grows erratically: g(p) = 1 for any prime p, but g(2^m) grows super-exponentially."
+    "content": "We axiomatize $g(n) = \\texttt{numGroups}(n)$, the number of non-isomorphic groups of order $n$ (OEIS A000001). This function is not computable in Lean/Mathlib since it requires enumerating all group structures of a given order up to isomorphism. The function grows erratically: $g(p) = 1$ for any prime $p$, but $g(2^m)$ grows super-exponentially.",
+    "mathContext": "$g : \\mathbb{N} \\to \\mathbb{N}$, where $g(n) = |\\{G : |G| = n\\} / {\\cong}|$. Axiomatized because group isomorphism testing is not decidable in Lean's type theory without additional computational content.",
+    "significance": "key",
+    "relatedConcepts": ["group isomorphism", "OEIS A000001", "classification of finite groups", "Hölder's program"],
+    "prerequisites": ["finite group theory", "isomorphism classes"]
   },
   {
-    "id": "known-values",
-    "lineStart": 42,
-    "lineEnd": 55,
+    "id": "ann-known-values",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 42, "endLine": 56 },
     "type": "context",
     "title": "Known Values of g(n) at Powers of 2",
-    "content": "The sequence g(2^m) for m = 0, 1, 2, ... is: 1, 1, 2, 5, 14, 51, 267, 2328, 56092, 10494213, ... This explosive growth reflects the combinatorial richness of 2-groups. The dominant contribution comes from groups whose commutator structure can be encoded by nilpotent Lie algebras over GF(2), giving the asymptotic g(2^m) ~ 2^{(2/27)m³}."
+    "content": "The sequence $g(2^m)$ for $m = 0, 1, 2, \\ldots$ is: 1, 1, 2, 5, 14, 51, 267, 2328, 56092, 10494213, $\\ldots$ This explosive growth reflects the combinatorial richness of 2-groups. The dominant contribution comes from groups whose commutator structure can be encoded by nilpotent Lie algebras over $\\mathbb{F}_2$, giving the asymptotic $g(2^m) \\sim 2^{(2/27)m^3}$.",
+    "mathContext": "$g(2^0)=1,\\; g(2^1)=1,\\; g(2^2)=2,\\; g(2^3)=5,\\; g(2^4)=14,\\; g(2^5)=51$. The ratio $g(2^{m+1})/g(2^m)$ grows rapidly, reaching $g(256)/g(128) \\approx 24$ and accelerating.",
+    "significance": "key",
+    "relatedConcepts": ["p-groups", "nilpotent Lie algebras", "Lazard correspondence", "OEIS A000679"],
+    "prerequisites": ["group classification", "exponential growth"]
   },
   {
-    "id": "erdos-1160-statement",
-    "lineStart": 83,
-    "lineEnd": 86,
+    "id": "ann-numgroups-prime",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 48, "endLine": 49 },
+    "type": "concept",
+    "title": "Uniqueness of Groups of Prime Order",
+    "content": "For any prime $p$, there is exactly one group of order $p$: the cyclic group $\\mathbb{Z}/p\\mathbb{Z}$. This follows from Lagrange's theorem — every non-identity element generates the entire group. The extreme contrast between $g(p) = 1$ and the explosive growth of $g(2^m)$ is the heart of the conjecture.",
+    "mathContext": "$g(p) = 1$ for all primes $p$, since the only group of prime order is $\\mathbb{Z}/p\\mathbb{Z}$",
+    "significance": "supporting",
+    "relatedConcepts": ["cyclic groups", "Lagrange's theorem", "simple groups of prime order"],
+    "prerequisites": ["prime numbers", "cyclic group structure"]
+  },
+  {
+    "id": "ann-numgroups-pos",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 62, "endLine": 64 },
+    "type": "concept",
+    "title": "Positivity of the Group Counting Function",
+    "content": "Every positive integer $n$ is the order of at least one group, namely the cyclic group $\\mathbb{Z}/n\\mathbb{Z}$. This axiom ($g(n) > 0$ for $n \\geq 1$) is used as a lower bound in proving the conjecture for base cases: since $g(2^m) \\geq 1$, any $n$ with $g(n) = 1$ automatically satisfies the conjecture.",
+    "mathContext": "$\\forall n \\geq 1,\\; g(n) \\geq 1$ since $\\mathbb{Z}/n\\mathbb{Z}$ is always a group of order $n$",
+    "significance": "supporting",
+    "relatedConcepts": ["cyclic groups", "existence of groups", "lower bounds"],
+    "prerequisites": ["cyclic group construction"]
+  },
+  {
+    "id": "ann-prime-power-mono",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 66, "endLine": 69 },
+    "type": "concept",
+    "title": "Monotonicity for Prime Powers",
+    "content": "For a fixed prime $p$, the function $k \\mapsto g(p^k)$ is monotonically non-decreasing. Intuitively, every group of order $p^{k_1}$ can be extended (e.g., by direct product with $\\mathbb{Z}/p^{k_2-k_1}\\mathbb{Z}$) to produce distinct groups of order $p^{k_2}$, and many additional groups arise from non-trivial extensions. This monotonicity is a key structural fact that supports the conjecture.",
+    "mathContext": "$k_1 \\leq k_2 \\implies g(p^{k_1}) \\leq g(p^{k_2})$ for any prime $p$ and positive exponents $k_1, k_2$",
+    "significance": "supporting",
+    "relatedConcepts": ["p-group structure", "group extensions", "direct products"],
+    "prerequisites": ["prime power orders", "group extensions"]
+  },
+  {
+    "id": "ann-erdos-1160-statement",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 75, "endLine": 81 },
     "type": "conjecture",
     "title": "Erdős Problem #1160: Powers of 2 Maximize g(n)",
-    "content": "The conjecture states that for any n ≤ 2^m, the number of groups of order n is at most the number of groups of order 2^m. Intuitively, 2-groups are by far the most numerous among groups of comparable size. This is because p-groups (for p = 2) have the most flexible internal structure: every possible pattern of commutativity relations gives a distinct group."
+    "content": "The conjecture states that for any $n \\leq 2^m$, the number of groups of order $n$ is at most the number of groups of order $2^m$. Intuitively, 2-groups are by far the most numerous among groups of comparable size. This is because $p$-groups (for $p = 2$) have the most flexible internal structure: every possible pattern of commutativity relations gives a distinct group.",
+    "mathContext": "$\\texttt{erdos\\_1160} :\\equiv \\forall m\\, n \\in \\mathbb{N},\\; n \\leq 2^m \\implies g(n) \\leq g(2^m)$",
+    "significance": "key",
+    "relatedConcepts": ["2-groups", "p-group dominance", "group diversity", "extremal group theory"],
+    "prerequisites": ["group counting function", "power of 2 orders"]
   },
   {
-    "id": "equiv-proof",
-    "lineStart": 88,
-    "lineEnd": 96,
-    "type": "proof",
+    "id": "ann-equiv-proof",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 83, "endLine": 95 },
+    "type": "technique",
     "title": "Equivalence of Two Formulations",
-    "content": "We prove that the universally quantified form (∀ m n, n ≤ 2^m → g(n) ≤ g(2^m)) is equivalent to the Finset-based form (∀ m, ∀ n ∈ range(2^m + 1), g(n) ≤ g(2^m)). This is straightforward but establishes that the conjecture can be checked computationally for any fixed m."
+    "content": "The proof establishes that the universally quantified form ($\\forall m\\, n,\\; n \\leq 2^m \\to g(n) \\leq g(2^m)$) is equivalent to the Finset-based form ($\\forall m,\\; \\forall n \\in \\texttt{range}(2^m+1),\\; g(n) \\leq g(2^m)$). This is straightforward via `Finset.mem_range` and `omega`, but establishes that the conjecture can be checked computationally for any fixed $m$.",
+    "mathContext": "$\\texttt{erdos\\_1160} \\iff \\texttt{erdos\\_1160\\_alt}$, proved by converting between $n \\leq 2^m$ and $n \\in \\{0, \\ldots, 2^m\\}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.range", "computational verification", "propositional equivalence"],
+    "prerequisites": ["Finset membership", "omega tactic"]
   },
   {
-    "id": "strong-conjecture",
-    "lineStart": 103,
-    "lineEnd": 107,
+    "id": "ann-strong-conjecture",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 101, "endLine": 106 },
     "type": "conjecture",
     "title": "BNV07 Stronger Conjecture",
-    "content": "Blackburn, Neumann, and Venkataraman (2007) proposed the stronger conjecture that the total number of groups of ALL orders below 2^m is still at most g(2^m). This dramatically strengthens the original: not just each individual g(n), but their entire sum is dominated by g(2^m). The sum is expected to be dominated for m ≥ 7."
+    "content": "Blackburn, Neumann, and Venkataraman (2007) proposed the dramatically stronger conjecture that the total number of groups of ALL orders below $2^m$ is still at most $g(2^m)$. Not just each individual $g(n)$, but their entire sum is dominated by $g(2^m)$. The sum is expected to be dominated for $m \\geq 7$, reflecting the overwhelming dominance of 2-groups in finite group theory.",
+    "mathContext": "$\\exists M,\\; \\forall m \\geq M:\\; \\sum_{n=0}^{2^m - 1} g(n) \\leq g(2^m)$",
+    "significance": "key",
+    "relatedConcepts": ["summation bounds", "asymptotic dominance", "BNV enumeration survey"],
+    "prerequisites": ["Finset.sum", "asymptotic growth rates"]
   },
   {
-    "id": "pantelidakis",
-    "lineStart": 120,
-    "lineEnd": 123,
+    "id": "ann-strong-implies",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 108, "endLine": 114 },
+    "type": "technique",
+    "title": "Stronger Conjecture Implies Original",
+    "content": "The proof that the BNV stronger conjecture implies the original uses `Finset.single_le_sum`: if all summands are nonneg and $n$ is in the range, then $g(n) \\leq \\sum_{i < 2^m} g(i) \\leq g(2^m)$. This is a clean application of summation monotonicity, and illustrates how aggregate dominance (the sum is small) implies pointwise dominance (each term is small).",
+    "mathContext": "$g(n) \\leq \\sum_{i < 2^m} g(i) \\leq g(2^m)$ via $\\texttt{Finset.single\\_le\\_sum}$ and the BNV hypothesis",
+    "significance": "key",
+    "relatedConcepts": ["Finset.single_le_sum", "summation inequalities", "pointwise vs aggregate bounds"],
+    "prerequisites": ["nonnegativity of g", "Finset summation lemmas"]
+  },
+  {
+    "id": "ann-pantelidakis",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 120, "endLine": 123 },
     "type": "context",
     "title": "Pantelidakis's Result for Odd Orders",
-    "content": "Pantelidakis (2003) proved that when n is odd and m ≥ 3619, then g(n) ≤ g(2^m). The key insight is that odd-order groups are all solvable (Feit-Thompson theorem) and their enumeration is controlled by Sylow theory, which provides much tighter bounds than for 2-groups. The threshold m ≥ 3619 is likely not optimal."
+    "content": "Pantelidakis (2003) proved that when $n$ is odd and $m \\geq 3619$, then $g(n) \\leq g(2^m)$. The key insight is that odd-order groups are all solvable (Feit–Thompson theorem, 1963) and their enumeration is controlled by Sylow theory and Hall's theorem, which provides much tighter bounds than are available for 2-groups. The threshold $m \\geq 3619$ is likely far from optimal.",
+    "mathContext": "Pantelidakis: $n$ odd, $n \\leq 2^m$, $m \\geq 3619 \\implies g(n) \\leq g(2^m)$. Uses Feit–Thompson ($|G|$ odd $\\Rightarrow G$ solvable) and Hall subgroup theory.",
+    "significance": "key",
+    "relatedConcepts": ["Feit-Thompson theorem", "solvable groups", "Hall subgroups", "odd-order theorem"],
+    "prerequisites": ["Sylow theorems", "solvable group theory", "ann-erdos-1160-statement"]
   },
   {
-    "id": "growth-rate",
-    "lineStart": 141,
-    "lineEnd": 149,
+    "id": "ann-base-cases",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 125, "endLine": 137 },
+    "type": "technique",
+    "title": "Verified Base Cases",
+    "content": "Two base cases are fully proved: (1) $g(1) = 1 \\leq g(2^m)$ using positivity of $g$, and (2) $g(p) = 1 \\leq g(2^m)$ for any prime $p$ using `numGroups_prime`. Both proofs reduce to showing $1 \\leq g(2^m)$, which follows from `numGroups_pos` and `positivity`/`omega`. These are the only cases where the conjecture is proved without additional axioms.",
+    "mathContext": "$g(1) = 1 \\leq g(2^m)$ and $g(p) = 1 \\leq g(2^m)$ for prime $p$, both using $g(2^m) \\geq 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["base case verification", "positivity", "omega tactic"],
+    "prerequisites": ["ann-numgroups-pos", "ann-numgroups-prime"]
+  },
+  {
+    "id": "ann-growth-rate",
+    "proofId": "erdos-1160",
+    "range": { "startLine": 143, "endLine": 150 },
     "type": "context",
-    "title": "The (2/27)m³ Growth Rate",
-    "content": "The asymptotic formula log₂(g(2^m)) ~ (2/27)m³ was established by Sims (1965). The constant 2/27 arises from counting nilpotent Lie algebras over GF(2): the number of such algebras of dimension m grows as 2^{(2/27)m³}, and most 2-groups of order 2^m correspond to such algebras via the Lazard correspondence. This super-exponential growth is why powers of 2 are conjectured to maximize g(n)."
+    "title": "The Higman–Sims (2/27)m³ Growth Rate",
+    "content": "The asymptotic formula $\\log_2(g(2^m)) \\sim \\frac{2}{27}m^3$ was established by Higman (1960) and Sims (1965). The constant $\\frac{2}{27}$ arises from counting nilpotent Lie algebras over $\\mathbb{F}_2$: most 2-groups of order $2^m$ correspond to such algebras of dimension $m$ via the Lazard correspondence, and the enumeration reduces to counting antisymmetric bilinear forms on an $m$-dimensional space modulo linear equivalence. This super-exponential growth is the fundamental reason that powers of 2 are conjectured to maximize $g(n)$.",
+    "mathContext": "$\\lim_{m \\to \\infty} \\frac{\\log_2 g(2^m)}{m^3} = \\frac{2}{27}$, formalized as $\\forall \\varepsilon > 0,\\; \\exists M,\\; \\forall m \\geq M:\\; \\frac{2}{27} - \\varepsilon < \\frac{\\log g(2^m)}{m^3 \\log 2} < \\frac{2}{27} + \\varepsilon$",
+    "significance": "key",
+    "relatedConcepts": ["Higman-Sims formula", "Lazard correspondence", "nilpotent Lie algebras", "asymptotic group theory"],
+    "prerequisites": ["real analysis", "limit definition", "Lie algebra basics"]
   }
 ]

--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -13,7 +13,9 @@
       "erdos",
       "group-theory",
       "enumeration",
-      "open-problem"
+      "open-problem",
+      "p-groups",
+      "asymptotic-analysis"
     ],
     "badge": "axiom",
     "sorries": 0,
@@ -23,6 +25,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-24",
     "mathlib_version": "4.26.0",
+    "lineCount": 157,
     "mathlibDependencies": [
       {
         "theorem": "Nat.Prime",
@@ -33,6 +36,16 @@
         "theorem": "Finset.sum",
         "description": "Sum over finite sets",
         "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.range",
+        "description": "Finite range of natural numbers",
+        "module": "Mathlib.Data.Finset.Range"
+      },
+      {
+        "theorem": "Finset.single_le_sum",
+        "description": "Single element bounded by sum of nonneg terms",
+        "module": "Mathlib.Algebra.BigOperators.Order"
       }
     ],
     "originalContributions": [
@@ -50,8 +63,26 @@
       "Known values g(1)=1, g(2)=1, g(4)=2, g(8)=5, g(16)=14, g(32)=51 are axiomatized",
       "Pantelidakis's result for odd n (m ≥ 3619) is axiomatized",
       "Asymptotic growth formula log₂(g(2^m)) ~ (2/27)m³ is axiomatized"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The problem of which integer orders maximize the group counting function has been studied since at least the 1960s. The conjecture that powers of 2 are the maximizers is attributed variously to Erdős, Higman, and others. The super-exponential growth of $g(2^m) \\approx 2^{(2/27)m^3}$ arises from the rich structure of $p$-groups: as the exponent $m$ grows, the number of non-isomorphic 2-groups explodes due to the combinatorial explosion of possible commutator structures.\n\nThe group counting function $g(n)$ (OEIS A000001) was studied systematically from the late 19th century, starting with Hölder's classification of groups of small order. Higman (1960) and Sims (1965) independently established the fundamental asymptotic formula $\\log_2 g(2^m) \\sim \\frac{2}{27}m^3$, showing that the number of groups of order $2^m$ dwarfs those of any comparable non-prime-power order.\n\nPantelidakis (2003) made the first major progress by proving the conjecture for odd $n$ when $m$ is sufficiently large ($m \\geq 3619$). The key tool is the Feit–Thompson theorem (odd-order groups are solvable), which gives tight control over the enumeration of odd-order groups via Hall's theorem. The stronger conjecture of Blackburn, Neumann, and Venkataraman (2007, Question 22.18) asserts that $\\sum_{n < 2^m} g(n) \\leq g(2^m)$ for all sufficiently large $m$, reflecting how overwhelmingly 2-groups dominate the landscape of finite group theory.\n\nThe constant $\\frac{2}{27}$ arises from counting nilpotent Lie algebras over $\\mathbb{F}_2$: via the Lazard correspondence, most 2-groups of order $2^m$ are in bijection with such algebras of dimension $m$, and the enumeration reduces to counting certain antisymmetric bilinear forms modulo equivalence.",
+    "problemStatement": "Let $g(n)$ denote the number of non-isomorphic groups of order $n$. Conjecture: for all $m \\in \\mathbb{N}$ and all $n \\leq 2^m$, we have $g(n) \\leq g(2^m)$. That is, powers of 2 maximize the group counting function among all integers up to a given bound.",
+    "proofStrategy": "The formalization axiomatizes $g(n)$ since Lean/Mathlib has no computable group enumeration function, then states the conjecture in two equivalent forms (universally quantified and Finset-based). The proof establishes the equivalence of these formulations, proves the conjecture for the base cases $n = 1$ and $n$ prime (where $g(n) = 1$), and axiomatizes Pantelidakis's deeper result for odd $n$. The stronger BNV conjecture ($\\sum_{n < 2^m} g(n) \\leq g(2^m)$) is also formalized, with a proof that it implies the original via `Finset.single_le_sum`. The asymptotic growth rate is captured as an $\\varepsilon$-$N$ statement about $\\log_2 g(2^m) / m^3 \\to 2/27$.",
+    "keyInsights": [
+      "The group counting function $g(n)$ is wildly erratic: $g(p) = 1$ for every prime $p$, but $g(2^m)$ grows super-exponentially as $2^{(2/27)m^3}$, making 2-groups by far the dominant source of finite group diversity.",
+      "The Lazard correspondence between $p$-groups of class less than $p$ and nilpotent Lie algebras over $\\mathbb{F}_p$ explains the constant $\\frac{2}{27}$: it reduces group enumeration to counting antisymmetric bilinear maps modulo linear equivalence.",
+      "The formalization proves the stronger BNV conjecture implies the original via a single-element-to-sum bound (`Finset.single_le_sum`), a clean example of how summation inequalities connect pointwise and aggregate forms of dominance.",
+      "Pantelidakis's restriction to odd $n$ exploits the Feit–Thompson theorem (all odd-order groups are solvable), which combined with Hall's theorem gives tight enumeration bounds — a strategy that fails for even orders where non-solvable groups appear.",
+      "The equivalence proof between universally quantified and Finset-range formulations demonstrates that the conjecture is computationally verifiable for any fixed $m$, though exponential growth of $2^m$ makes direct verification infeasible beyond small cases."
     ],
-    "historicalContext": "The problem of which integer orders maximize the group counting function has been studied since at least the 1960s. The conjecture that powers of 2 are the maximizers is attributed variously to Erdős, Higman, and others. The super-exponential growth of g(2^m), approximately 2^{(2/27)m³}, arises from the rich structure of p-groups: as the exponent m grows, the number of non-isomorphic 2-groups explodes due to the combinatorial explosion of possible commutator structures.\n\nPantelidakis (2003) made the first major progress by proving the conjecture for odd n when m is sufficiently large (m ≥ 3619). The stronger conjecture of Blackburn-Neumann-Venkataraman (2007) asserts that the sum of g(n) for all n < 2^m is dominated by g(2^m) alone, reflecting how overwhelmingly 2-groups dominate the landscape of finite group theory.\n\nThe asymptotic formula g(2^m) ~ 2^{(2/27)m³ + O(m^{8/3})} was established by Sims (1965) and refined by others. By contrast, g(n) for non-prime-power n grows much more slowly, governed by Sylow theory constraints."
+    "prerequisites": [
+      "Finite group theory",
+      "Sylow theorems",
+      "p-group classification",
+      "Asymptotic analysis",
+      "Nilpotent Lie algebras"
+    ]
   },
   "sections": [
     {
@@ -59,42 +90,80 @@
       "title": "The Group Counting Function",
       "startLine": 30,
       "endLine": 60,
-      "summary": "Axiomatization of numGroups and known values"
+      "summary": "Axiomatization of the group counting function numGroups : ℕ → ℕ (OEIS A000001) along with known values for small powers of 2. Since Lean/Mathlib has no computable group enumeration, these are declared as axioms.",
+      "mathContext": "$g(n) = |\\{G : |G| = n\\}/\\cong|$, with known values $g(1)=1$, $g(4)=2$, $g(8)=5$, $g(16)=14$, $g(32)=51$"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 62,
       "endLine": 77,
-      "summary": "Positivity and monotonicity for prime powers"
+      "summary": "Fundamental properties: positivity of g(n) for n ≥ 1 (every positive integer is the order of at least ℤ/nℤ) and monotonicity of g(p^k) in k for fixed prime p.",
+      "mathContext": "$g(n) > 0$ for $n \\geq 1$ and $g(p^{k_1}) \\leq g(p^{k_2})$ for $k_1 \\leq k_2$"
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
       "startLine": 79,
       "endLine": 97,
-      "summary": "Formal statement and equivalent formulations"
+      "summary": "States the main conjecture in two equivalent forms and proves their equivalence. The universally quantified form (∀ m n, n ≤ 2^m → g(n) ≤ g(2^m)) is equivalent to the Finset-range form, enabling computational verification for fixed m.",
+      "mathContext": "$\\forall m, n \\in \\mathbb{N},\\; n \\leq 2^m \\implies g(n) \\leq g(2^m)$"
     },
     {
       "id": "stronger-conjecture",
-      "title": "Stronger Conjecture",
+      "title": "Stronger Conjecture (BNV07)",
       "startLine": 99,
       "endLine": 114,
-      "summary": "BNV07 stronger form and implication"
+      "summary": "Formalizes the dramatically stronger conjecture of Blackburn–Neumann–Venkataraman: the sum of g(n) over all n < 2^m is dominated by g(2^m) alone for sufficiently large m. Proves this implies the original conjecture via Finset.single_le_sum.",
+      "mathContext": "$\\exists M,\\; \\forall m \\geq M: \\sum_{n=0}^{2^m-1} g(n) \\leq g(2^m)$"
     },
     {
       "id": "partial-results",
       "title": "Known Partial Results",
       "startLine": 116,
       "endLine": 138,
-      "summary": "Proved cases: n=1, prime n, odd n (Pantelidakis)"
+      "summary": "Verifies the conjecture for base cases: n = 1 (trivially g(1) = 1 ≤ g(2^m)), prime n (g(p) = 1), and axiomatizes Pantelidakis's 2003 result for odd n when m ≥ 3619.",
+      "mathContext": "$g(1) = 1 \\leq g(2^m)$; $g(p) = 1$ for prime $p$; Pantelidakis: odd $n \\leq 2^m,\\, m \\geq 3619 \\implies g(n) \\leq g(2^m)$"
     },
     {
       "id": "asymptotics",
       "title": "Asymptotic Growth",
       "startLine": 140,
-      "endLine": 152,
-      "summary": "Super-exponential growth of g(2^m)"
+      "endLine": 156,
+      "summary": "Axiomatizes the Higman–Sims asymptotic formula: log₂(g(2^m)) / m³ → 2/27 as m → ∞. This super-exponential growth is the fundamental reason powers of 2 are conjectured to maximize the group counting function.",
+      "mathContext": "$\\lim_{m \\to \\infty} \\frac{\\log_2 g(2^m)}{m^3} = \\frac{2}{27}$"
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization captures Erdős Problem #1160 and its strengthened BNV form, proves the equivalence of two conjecture formulations, verifies base cases (n = 1, prime n), and axiomatizes the key known partial result (Pantelidakis for odd n) and the Higman–Sims asymptotic formula. The 11 axioms encode the group counting function and its known properties, since group enumeration is not available in Lean/Mathlib.",
+    "implications": "A proof of the full conjecture would establish that 2-groups are the dominant source of finite group diversity at every scale — a fundamental structural fact about finite group theory. The BNV stronger form would imply that the diversity of 2-groups grows so fast that a single order $2^m$ harbors more non-isomorphic groups than all smaller orders combined. Progress on this conjecture is closely tied to advances in $p$-group enumeration and nilpotent Lie algebra classification.",
+    "openQuestions": [
+      "Can the Pantelidakis threshold of $m \\geq 3619$ for odd $n$ be significantly lowered, perhaps to $m \\geq 10$ or smaller?",
+      "Is the BNV stronger conjecture ($\\sum_{n<2^m} g(n) \\leq g(2^m)$) true for all $m \\geq 7$, and can this threshold be determined computationally?",
+      "Can the conjecture be extended to other primes: does $g(p^m)$ dominate $g(n)$ for all $n \\leq p^m$ when $p$ is fixed?",
+      "What is the correct error term in the Higman–Sims formula — is $\\log_2 g(2^m) = \\frac{2}{27}m^3 + O(m^{8/3})$ sharp?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sylow-theorems",
+      "relationship": "foundation",
+      "description": "The Sylow theorems provide the structural decomposition of finite groups into p-subgroups that underpins group enumeration. Pantelidakis's partial result for odd n relies on Sylow-theoretic bounds."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "foundation",
+      "description": "Lagrange's theorem (subgroup order divides group order) constrains which orders can appear as subgroup orders, a basic ingredient in group enumeration."
+    },
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "Both problems concern the structure and diversity of finite groups. The inverse Galois problem asks which groups arise as Galois groups, while Erdős #1160 asks which orders maximize the group counting function."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "The Abel–Ruffini theorem connects to group theory through the non-solvability of the symmetric group S₅. The distinction between solvable and non-solvable groups is relevant to Pantelidakis's approach, which exploits solvability of odd-order groups."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for erdos-1160 (Group Counting Function Maximized at Powers of 2).

**Quality improvements:**
- Added `overview` with rich historicalContext (Hölder, Higman, Sims, Feit-Thompson, Pantelidakis), LaTeX problemStatement, proofStrategy, 5 deep keyInsights
- Added `conclusion` with mathematical implications and 4 genuine open questions
- Added 4 cross-references: sylow-theorems, lagrange-theorem, inverse-galois, abel-ruffini
- All 12 annotations now have `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`
- Fixed annotation schema: `lineStart`/`lineEnd` → `range: {startLine, endLine}`, added `proofId`
- All 6 sections now have `mathContext` and expanded summaries
- Added `lineCount`, additional mathlibDependencies, new tags

**Axiom integrity:** Verified — 11 axioms correctly counted, status `axiomatized`, badge `axiom`. No structure-encoded assumptions.