### PR TITLE
Research: erdos-28 - Prove conjecture holds for ℕ + basis density bound

### DIFF
--- a/proofs/Proofs/Erdos28AdditiveBases.lean
+++ b/proofs/Proofs/Erdos28AdditiveBases.lean
@@ -410,8 +410,88 @@ The key prerequisite is proving sidon_upper_bound in Erdos340GreedySidon.lean.
 axiom sidon_not_basis (A : Set ℕ) (hS : IsSidon A) (hInf : A.Infinite) :
     ¬IsAsymptoticBasis A
 
-#check erdos_28
-#check erdos_turan_weak
-#check erdos_turan_strong
+/- ## Part VIII: Ordered vs Unordered Representations -/
+
+/-- Ordered representation count is at least the unordered count.
+    Every unordered pair (a, b) with a ≤ b also satisfies the ordered condition
+    (just without the a ≤ b constraint). -/
+theorem repFunc_ge_repFuncUnordered (A : Set ℕ) (n : ℕ) :
+    repFunc A n ≥ repFuncUnordered A n := by
+  unfold repFunc repFuncUnordered
+  apply Set.ncard_le_ncard
+  · intro ⟨a, b⟩ ⟨ha, hb, _, hadd⟩
+    exact ⟨ha, hb, hadd⟩
+  · exact pairs_summing_finite A n
+
+/- ## Part IX: The Conjecture Holds for ℕ -/
+
+/-- For ℕ, the unordered representation function is unbounded:
+    repFuncUnordered(ℕ, 2k+2) = k + 2 > k. -/
+theorem nat_repFuncUnordered_unbounded :
+    ∀ k : ℕ, ∃ n : ℕ, repFuncUnordered (Set.univ : Set ℕ) n > k := by
+  intro k
+  use 2 * k + 2
+  rw [nat_repFunc]
+  -- (2k+2) / 2 + 1 = k + 1 + 1 = k + 2 > k
+  omega
+
+/-- The Erdős-Turán conjecture holds trivially for ℕ.
+    Since repFunc ≥ repFuncUnordered and the unordered count is unbounded,
+    the ordered count is also unbounded. -/
+theorem erdos_turan_holds_for_nat :
+    ∀ k : ℕ, ∃ n : ℕ, repFunc (Set.univ : Set ℕ) n > k := by
+  intro k
+  obtain ⟨n, hn⟩ := nat_repFuncUnordered_unbounded k
+  exact ⟨n, lt_of_lt_of_le hn (repFunc_ge_repFuncUnordered Set.univ n)⟩
+
+/- ## Part X: Basis Density Lower Bound -/
+
+/-- **Counting Argument**: For any asymptotic basis A with threshold N₀,
+    the number of elements of A up to N satisfies |A ∩ [0, N]|² ≥ N - N₀ + 1.
+
+    **Proof**:
+    1. Every n ∈ [N₀, N] is in sumset(A), so n = a + b with a, b ∈ A and a, b ≤ N.
+    2. Thus [N₀, N] ⊆ sumset(A ∩ [0, N]).
+    3. sumset(S) is the image of addition on S × S, so |sumset(S)| ≤ |S|².
+    4. |[N₀, N]| = N - N₀ + 1, giving N - N₀ + 1 ≤ |S|².
+
+    This implies |A ∩ [0, N]| ≥ √(N - N₀ + 1) ≥ c·√N for large N,
+    establishing that bases of order 2 must have density at least √N. -/
+theorem basis_element_count_sq (A : Set ℕ) (hA : IsAsymptoticBasis A) :
+    ∃ N₀ : ℕ, ∀ N ≥ N₀,
+      (A ∩ Set.Iic N).ncard ^ 2 ≥ N - N₀ + 1 := by
+  obtain ⟨N₀, hN₀⟩ := hA
+  use N₀
+  intro N hN
+  set S := A ∩ Set.Iic N
+  have hS_fin : S.Finite := Set.Finite.subset (Set.finite_Iic N) Set.inter_subset_right
+  -- [N₀, N] ⊆ sumset S: every n ∈ [N₀, N] has a representation in S
+  have h_cover : Set.Icc N₀ N ⊆ sumset S := by
+    intro n hn
+    simp only [Set.mem_Icc] at hn
+    obtain ⟨a, b, ha, hb, heq⟩ := hN₀ n hn.1
+    exact ⟨a, b, ⟨ha, Set.mem_Iic.mpr (by omega)⟩,
+                  ⟨hb, Set.mem_Iic.mpr (by omega)⟩, heq⟩
+  -- sumset S is the image of addition on S × S
+  have h_sumset_img : sumset S = (fun p : ℕ × ℕ => p.1 + p.2) '' (S ×ˢ S) := by
+    ext n
+    simp only [sumset, Set.mem_setOf_eq, Set.mem_image, Set.mem_prod, Prod.exists]
+    exact ⟨fun ⟨a, b, ha, hb, h⟩ => ⟨a, b, ⟨ha, hb⟩, h.symm⟩,
+           fun ⟨a, b, ⟨ha, hb⟩, h⟩ => ⟨a, b, ha, hb, h.symm⟩⟩
+  -- sumset S is finite
+  have h_sumset_fin : (sumset S).Finite := by
+    rw [h_sumset_img]; exact (hS_fin.prod hS_fin).image _
+  -- |sumset S| ≤ |S × S| = |S|²
+  have h_sumset_bound : (sumset S).ncard ≤ S.ncard ^ 2 := by
+    rw [h_sumset_img]
+    calc ((fun p : ℕ × ℕ => p.1 + p.2) '' (S ×ˢ S)).ncard
+        ≤ (S ×ˢ S).ncard := Set.ncard_image_le (hS_fin.prod hS_fin)
+      _ = S.ncard * S.ncard := Set.ncard_prod hS_fin hS_fin
+      _ = S.ncard ^ 2 := by ring
+  -- Chain: N - N₀ + 1 ≤ |[N₀, N]| ≤ |sumset S| ≤ |S|²
+  calc N - N₀ + 1
+      = (Set.Icc N₀ N).ncard := by simp [Set.ncard_Icc]; omega
+    _ ≤ (sumset S).ncard := Set.ncard_le_ncard h_cover h_sumset_fin
+    _ ≤ S.ncard ^ 2 := h_sumset_bound
 
 end Erdos28

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -17,9 +17,9 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/28",
     "erdosUrl": "https://erdosproblems.com/28",
-    "proofRepoPath": "Proofs/Erdos28Problem.lean",
-    "axiomCount": 6,
-    "assumptions": "6 axiom declarations: erdos_turan_conjecture (main conjecture), erdos_turan_strong (logarithmic growth), erdos_turan_density_version (density variant), basis_counting_lower (sqrt(N) bound), erdos_fuchs_theorem (fluctuation), average_rep_unbounded (average divergence). Former axioms sidon_not_basis and erdos_40_from_28 proved.",
+    "proofRepoPath": "Proofs/Erdos28AdditiveBases.lean",
+    "axiomCount": 4,
+    "assumptions": "4 axioms: grekos_lower_bound (Grekos et al. 2003: r_A(n) ≥ 6 infinitely often), borwein_lower_bound (Borwein et al.: r_A(n) ≥ 8 infinitely often), sidon_density_bound (Sidon density ≤ √(2N)+1, duplicated from Erdos340), sidon_not_basis (infinite Sidon sets cannot be bases). 18 theorems proved including isAsymptoticBasis_iff, sidon_repFunc_bounded, erdos_turan_holds_for_nat, basis_element_count_sq.",
     "badge": "axiom",
     "prerequisites": [
       "Additive number theory (sumsets, representation functions)",
@@ -212,9 +212,9 @@
       "Pointwise"
     ],
     "namespace": "",
-    "lineCount": 111,
-    "axiomCount": 6,
-    "theoremCount": 0,
-    "definitionCount": 3
+    "lineCount": 497,
+    "axiomCount": 4,
+    "theoremCount": 18,
+    "definitionCount": 10
   }
 }

--- a/src/data/research/problems/erdos-28.json
+++ b/src/data/research/problems/erdos-28.json
@@ -29,8 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: Classified 12 axioms across 2 files. 3 are the OPEN conjecture, 4 deep known results, 2 Sidon-related (tractable), 3 analytical. sidon_density_bound can likely be replaced by importing sidon_upper_bound_weak from Erdos340GreedySidon.lean.",
-    "builtItems": [],
+    "progressSummary": "STRUCTURAL RESULTS: Proved conjecture holds for \u2115, proved basis density lower bound |A\u2229[0,N]|\u00b2 \u2265 N-N\u2080+1, connected ordered/unordered rep counts. Meta.json updated from legacy file (6 axioms) to main file (4 axioms, 18 theorems).",
+    "builtItems": [
+      "repFunc_ge_repFuncUnordered: proved (ordered \u2265 unordered)",
+      "nat_repFuncUnordered_unbounded: proved",
+      "erdos_turan_holds_for_nat: proved (conjecture holds for \u2115)",
+      "basis_element_count_sq: proved (|A\u2229[0,N]|\u00b2 \u2265 N-N\u2080+1 for bases)"
+    ],
     "insights": [
       "The Erd\u0151s-Tur\u00e1n conjecture (3 forms) is OPEN with $500 prize - cannot be proved",
       "sidon_density_bound in Erdos28AdditiveBases.lean duplicates sidon_upper_bound_weak in Erdos340GreedySidon.lean - needs IsSidon definition reconciliation",
@@ -38,14 +43,22 @@
       "basis_counting_lower is a counting argument: if A+A \u2287 [N\u2080,\u221e), then \u2211_{a\u2208A,a\u2264N} 1 \u2265 c\u221aN",
       "Erd\u0151s-Fuchs theorem and average_rep_unbounded are deep analytical results, unlikely provable from Mathlib alone",
       "Erdos28AdditiveBases.lean (418 lines) is well-structured with 9 proved theorems including evens_repFunc and nat_repFunc",
-      "The AdditiveBases file proves isAsymptoticBasis_iff, sidon_repFunc_bounded, and several example constructions"
+      "The AdditiveBases file proves isAsymptoticBasis_iff, sidon_repFunc_bounded, and several example constructions",
+      "Proved repFunc_ge_repFuncUnordered: ordered rep count \u2265 unordered, via Set.ncard_le_ncard on subset",
+      "Proved erdos_turan_holds_for_nat: conjecture holds trivially for \u2115 (repFunc(\u2115, 2k+2) \u2265 k+2)",
+      "Proved basis_element_count_sq: any basis A has |A \u2229 [0,N]|\u00b2 \u2265 N - N\u2080 + 1 (counting argument via sumset image)",
+      "Meta.json was pointing to legacy Erdos28Problem.lean (6 axioms); updated to Erdos28AdditiveBases.lean (4 axioms, 18 theorems)",
+      "basis_element_count_sq uses: [N\u2080,N] \u2286 sumset(A\u2229[0,N]) and |sumset(S)| \u2264 |S\u00d7S| = |S|\u00b2"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Eliminate sidon_density_bound axiom by importing Erdos340GreedySidon.sidon_upper_bound_weak (needs IsSidon reconciliation)",
       "Prove sidon_not_basis using the outlined density argument (requires tight Sidon bound or alternative approach)",
       "Prove basis_counting_lower from basic combinatorics (~100-150 lines)",
-      "Consider proving average_rep_unbounded from counting arguments"
+      "Consider proving average_rep_unbounded from counting arguments",
+      "Reconcile IsSidon definitions (Set vs Finset) to import sidon_upper_bound_weak from Erdos340",
+      "Prove sidon_not_basis if tight Sidon bound becomes available",
+      "Consider proving average_rep_unbounded from basis_element_count_sq"
     ],
     "markdown": "# Erd\u0151s #28 - Knowledge Base\n\n## Problem Statement\n\nIf $A\\subseteq \\mathbb{N}$ is such that $A+A$ contains all but finitely many integers then $\\limsup 1_A\\ast 1_A(n)=\\infty$. Conjectured by Erd\u0151s and Tur\u00e1n. They also suggest the stronger conjecture that $\\limsup 1_A\\ast 1_A(n)/\\log n>0$. Another stronger conjecture would be that the hypothesis $\\lvert A\\cap [1,N]\\rvert \\gg N^{1/2}$ for all large $N$ suffices. Erd\u0151s and S\u00e1rk\u00f6zy conjectured the stronger version that if $A=\\{a_1[40]. This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 18 November 2025.\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n**Prize**: $500\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #2\n- Problem #40\n- Problem #27\n- Problem #29\n- Problem #39\n- Problem #1\n\n## References\n\n- ErTu41\n- Er56\n- Er57\n- Er59\n- Er61\n- Er65\n- Er65b\n- Er69\n- Er70c\n- Er73\n- Er77c\n- ErGr80\n- Er81\n- Er85c\n- Er89d\n- Er90\n- Er94b\n- Er95\n- Er97c\n- Er97f\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },


### PR DESCRIPTION
## Summary
- Prove the Erdős-Turán conjecture holds for ℕ (trivial case showing machinery works)
- Prove basis density lower bound: |A ∩ [0,N]|² ≥ N - N₀ + 1
- Connect ordered and unordered representation counts
- Update meta.json to point to main formalization file

## Progress
- **Proved 4 new theorems**: repFunc_ge_repFuncUnordered, nat_repFuncUnordered_unbounded, erdos_turan_holds_for_nat, basis_element_count_sq
- **basis_element_count_sq** is a substantive counting argument: any asymptotic basis A has enough elements up to N so that |A ∩ [0,N]|² ≥ N - N₀ + 1, implying |A ∩ [0,N]| ≥ √(N - N₀)
- **Updated meta.json**: proofRepoPath now points to Erdos28AdditiveBases.lean (497 lines, 4 axioms, 18 theorems)

## Key Results
- erdos_turan_holds_for_nat: repFunc(ℕ, n) is unbounded (conjecture confirmed for trivial case)
- basis_element_count_sq: quantitative density bound for all bases, proved via sumset image counting

## Status
**Outcome**: completed
**Axioms**: 4 (grekos_lower_bound, borwein_lower_bound, sidon_density_bound, sidon_not_basis)
**Sorries**: 0

🤖 Generated by researcher-1