### PR TITLE
Enrich 6 proofs: cross-references and annotations (#5785)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -159,6 +159,21 @@
       "targetId": "fundamental-theorem-calculus",
       "relationship": "related",
       "description": "FTC connects differentiation and integration — the same Lebesgue integral framework that defines the $L^2$ inner product $\\langle f, g \\rangle = \\int fg\\,d\\mu$. Both theorems rely on Mathlib's Bochner integration infrastructure"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01",
+      "relationship": "extended-by",
+      "description": "Hölder's inequality $\\|fg\\|_1 \\leq \\|f\\|_p \\cdot \\|g\\|_q$ (for $1/p + 1/q = 1$) generalizes the integral Cauchy-Schwarz from $p = q = 2$ to arbitrary conjugate exponents. The $p = 2$ case recovers Cauchy-Schwarz exactly: $\\int |fg| \\leq (\\int |f|^2)^{1/2}(\\int |g|^2)^{1/2}$"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-02",
+      "relationship": "extended-by",
+      "description": "The Minkowski integral inequality $\\|f+g\\|_p \\leq \\|f\\|_p + \\|g\\|_p$ is the $L^p$ triangle inequality. For $p = 2$, it follows directly from the integral Cauchy-Schwarz via expanding $\\|f+g\\|_2^2 = \\|f\\|_2^2 + 2\\langle f,g \\rangle + \\|g\\|_2^2 \\leq (\\|f\\|_2 + \\|g\\|_2)^2$"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-03",
+      "relationship": "extended-by",
+      "description": "Extends the integral Cauchy-Schwarz to complex-valued $L^2$ functions via a bridge theorem connecting the real and complex inner product space formulations. Completes the Cauchy-Schwarz development across real, complex, and abstract $\\text{RCLike}$ fields"
     }
   ],
   "relatedProofs": [
@@ -169,7 +184,10 @@
     "basel-problem",
     "triangle-inequality",
     "amgm-inequality-oq-03",
-    "fundamental-theorem-calculus"
+    "fundamental-theorem-calculus",
+    "cauchy-schwarz-integral-oq-01",
+    "cauchy-schwarz-integral-oq-02",
+    "cauchy-schwarz-integral-oq-03"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary

Six enrichment passes adding cross-references, annotations, and references across major gallery entries:

### Abel-Ruffini (pass 3) — 2 cross-refs added
`nth-root-irrational`, `euler-totient`

### Erdős #1160 (pass 4) — major enrichment
- Rewrote all 7 annotations with proper format and full enrichment fields
- Added 4 cross-references, 3 references, 6th keyInsight

### Basel Problem (pass 1) — 3 cross-refs added
`basel-problem-oq-02`, `hermite-lindemann`, `area-of-circle`

### Brouwer Fixed Point (pass 1) — 2 cross-refs added
`borsuk-ulam-oq-03`, `schauder-fixed-point-oq-01`

### Cantor's Theorem (pass 1) — 2 cross-refs added
`denumerability-rationals`, `subset-count`

### Cauchy-Schwarz Integral (pass 1) — 3 cross-refs added
`cauchy-schwarz-integral-oq-01` (Hölder), `cauchy-schwarz-integral-oq-02` (Minkowski), `cauchy-schwarz-integral-oq-03` (complex L2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)