### PR TITLE
Research: erdos-667 - Prove conjecture for p=3

### DIFF
--- a/proofs/Proofs/Erdos667Problem.lean
+++ b/proofs/Proofs/Erdos667Problem.lean
@@ -250,6 +250,26 @@ theorem p5_ramsey_upper : cpq 5 1 ≤ (1 : ℚ) / 3 := by
   norm_num at h ⊢
   exact h
 
+/-- For p = 4: Ramsey bounds give c(4,1) ∈ [1/3, 2/5]. -/
+theorem p4_ramsey_lower : (1 : ℚ) / 3 ≤ cpq 4 1 := by
+  have h := cpq_lower_ramsey 4 (by omega)
+  norm_num at h ⊢; exact h
+
+theorem p4_ramsey_upper : cpq 4 1 ≤ (2 : ℚ) / 5 := by
+  have h := cpq_upper_ramsey 4 (by omega)
+  norm_num at h ⊢; exact h
+
+/-- For p = 3: cpq_strict already proves the FULL conjecture for p=3
+    (there is only one step: q goes from 1 to 2). -/
+theorem erdos667_holds_for_p3 :
+    ∀ q, 1 ≤ q → q < Nat.choose 2 2 + 1 → cpq 3 q < cpq 3 (q + 1) := by
+  intro q hq1 hq_lt
+  have hq_eq : q = 1 := by
+    have : Nat.choose 2 2 + 1 = 2 := by native_decide
+    omega
+  subst hq_eq
+  exact p3_strict
+
 /-
 ## Part VIII: The Main Conjecture (Erdos Problem 667)
 -/

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/667",
     "erdosProblemStatus": "open",
     "axiomCount": 14,
-    "lineCount": 323,
+    "lineCount": 343,
     "dateAdded": "2026-02-10",
     "mathlibDependencies": [
       {

--- a/src/data/research/problems/erdos-667.json
+++ b/src/data/research/problems/erdos-667.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-667",
-  "title": "Erdős #667",
+  "title": "Erd\u0151s #667",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -29,14 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 1 axiom (cliqueGuarantee_pos), added 10 new theorems including p=5 analysis and gap structure. Fixed stale Mathlib import. 14 axioms remain.",
+    "progressSummary": "STRUCTURAL: Proved full conjecture for p=3, added p=4 Ramsey bounds. 14 axioms remain (all deep function definitions or known results).",
     "builtItems": [
       "Proved cliqueGuarantee_pos from other axioms (axiom elimination: 15->14)",
       "Added cliqueGuarantee_mono_q_general: extended monotonicity for H",
       "Added p5_max, p5_efrs, p5_strict_at_top, p5_ramsey_lower, p5_ramsey_upper",
       "Added cpq_total_gap, cpq_gap_pos, erdos667_at_least_one_strict_step",
       "Fixed import: Mathlib.Data.Rat.Basic -> Mathlib.Data.Rat.Defs",
-      "Fixed edgeCount: Finset.product pipe syntax -> explicit parenthesization"
+      "Fixed edgeCount: Finset.product pipe syntax -> explicit parenthesization",
+      "erdos667_holds_for_p3: proved (complete conjecture for p=3)",
+      "p4_ramsey_lower: proved (c(4,1) \u2265 1/3)",
+      "p4_ramsey_upper: proved (c(4,1) \u2264 2/5)"
     ],
     "insights": [
       "cliqueGuarantee_pos is derivable from cliqueGuarantee_zero + cliqueGuarantee_mono_q by induction on q",
@@ -44,7 +47,10 @@
       "The total gap c(p,q_max)-c(p,1) >= 1-2/(p+1) grows with p, approaching 1",
       "At least one strict step exists for all p>=3 (at q=C(p-1,2) via EFRS)",
       "Mathlib.Data.Rat.Basic renamed to Mathlib.Data.Rat.Defs in current Mathlib",
-      "Finset.product pipe syntax |>.card broken in Lean 4.26.0; use explicit parenthesization"
+      "Finset.product pipe syntax |>.card broken in Lean 4.26.0; use explicit parenthesization",
+      "Proved erdos667_holds_for_p3: the FULL conjecture holds for p=3 (only 1 step: c(3,1) < c(3,2))",
+      "Added p4 Ramsey bounds: c(4,1) \u2208 [1/3, 2/5]",
+      "p=3 is the only case where the conjecture is fully resolved (q ranges over {1,2})"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -53,7 +59,7 @@
       "Investigate whether cpq_mono_q can be derived from the definition of cpq + cliqueGuarantee_mono_q",
       "Create Aristotle companion file with routine lemmas for automated proof search"
     ],
-    "markdown": "# Erdős #667 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $p,q\\geq 1$ be fixed integers. We define $H(n)=H(N;p,q)$ to be the largest $m$ such that any graph on $n$ vertices where every set of $p$ vertices spans at least $q$ edges must contain a complete graph on $m$ vertices.\nIs\\[c(p,q)=\\liminf \\frac{\\log H(n)}{\\log n}\\]a strictly increasing function of $q$ for $1\\leq q\\leq \\binom{p-1}{2}+1$?\n\n\n\nA problem of Erd\\H{o}s, Faudree, Rousseau, and Schelp.\n\nWhen $q=1$ this corresponds exactly to the classical Ramsey problem, and hence for example\\[\\frac{1}{p-1}\\leq c(p,1) \\leq \\frac{2}{p+1}.\\]It is easy to see that if $q=\\binom{p-1}{2}+1$ then $c(p,q)=1$. Erd\\H{o}s, Faudree, Rousseau, and Schelp have shown that $c(p,\\binom{p-1}{2})\\leq 1/2$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #666\n- Problem #668\n- Problem #39\n- Problem #1\n\n## References\n\n- Er97f\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erd\u0151s #667 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $p,q\\geq 1$ be fixed integers. We define $H(n)=H(N;p,q)$ to be the largest $m$ such that any graph on $n$ vertices where every set of $p$ vertices spans at least $q$ edges must contain a complete graph on $m$ vertices.\nIs\\[c(p,q)=\\liminf \\frac{\\log H(n)}{\\log n}\\]a strictly increasing function of $q$ for $1\\leq q\\leq \\binom{p-1}{2}+1$?\n\n\n\nA problem of Erd\\H{o}s, Faudree, Rousseau, and Schelp.\n\nWhen $q=1$ this corresponds exactly to the classical Ramsey problem, and hence for example\\[\\frac{1}{p-1}\\leq c(p,1) \\leq \\frac{2}{p+1}.\\]It is easy to see that if $q=\\binom{p-1}{2}+1$ then $c(p,q)=1$. Erd\\H{o}s, Faudree, Rousseau, and Schelp have shown that $c(p,\\binom{p-1}{2})\\leq 1/2$.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #666\n- Problem #668\n- Problem #39\n- Problem #1\n\n## References\n\n- Er97f\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- Prove the full Erdős Problem #667 conjecture for p=3
- Add p=4 Ramsey bounds: c(4,1) ∈ [1/3, 2/5]

## Progress
- **erdos667_holds_for_p3**: Complete resolution for p=3 — the conjecture reduces to c(3,1) < c(3,2), which follows from the Ramsey upper bound c(3,1) ≤ 1/2 < 1 = c(3,2)
- **p4_ramsey_lower/upper**: Explicit Ramsey interval for p=4

## Status
**Outcome**: completed
**Axioms**: 14 (unchanged — all deep results)
**Sorries**: 0

🤖 Generated by researcher-1