### PR TITLE
Audit cycle 14: fix sorry counts across 12 proofs, upgrade 4 to verified

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -19,7 +19,7 @@
       "elementary-symmetric-polynomials"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
       "isoperimetric"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Ballot.countedSequence",

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 2,
     "axioms": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,8 +17,8 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,10 +7,10 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "tags": [
       "combinatorics",
       "permutations",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "conjecture",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -15,8 +15,8 @@
       "convex-analysis",
       "open-question"
     ],
-    "badge": "wip",
-    "sorries": 3,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",


### PR DESCRIPTION
## Fix

Corrects sorry count mismatches in 12 proofs where meta.json `sorries` field did not match the actual sorry count in Lean source files. Upgrades 4 proofs from `formalized` to `verified` status (0 sorries, 0 axioms).

## Evidence

**Sorry count corrections** (meta.json `sorries` vs actual Lean source, properly excluding comments):

| Proof | Before | After |
|-------|--------|-------|
| amgm-inequality-oq-02 | 1 | 0 |
| area-of-circle-oq-01-oq-03 | 5 | 4 |
| ballot-problem-oq-01 | 2 | 1 |
| ballot-problem-oq-03-oq-02 | 4 | 2 |
| cayley-hamilton-minpoly-oq-05-oq-01 | 1 | 0 |
| derangements-oq-02 | 1 | 0 |
| erdos-1006-oq-02-oq-03 | 1 | 0 |
| erdos-138 | 5 | 4 |
| erdos-392 | 3 | 2 |
| erdos-628 | 12 | 11 |
| erdos-746 | 4 | 3 |
| schauder-fixed-point-oq-01 | 3 | 0 |

**Status upgrades** (formalized → verified, badge wip → verified):
- cayley-hamilton-minpoly-oq-05-oq-01
- derangements-oq-02
- erdos-1006-oq-02-oq-03
- schauder-fixed-point-oq-01

All 4 upgraded proofs have 0 sorries AND 0 axiom declarations in their Lean source.

---
Automated fix by lean-mechanic agent.