### PR TITLE
Audit: fix angle-trisection transitive axiom overclaim

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -2,12 +2,12 @@
   "id": "angle-trisection",
   "title": "Impossibility of Trisecting an Angle",
   "slug": "angle-trisection",
-  "description": "The three classical Greek impossibility problems resolved in one file (Wiedijk #8): angle trisection, cube doubling, and circle squaring. Wantzel's 1837 algebraic criterion ($\\cos(20°)$ satisfies an irreducible cubic $8x^3-6x-1$, degree 3 $\\neq 2^n$) settles the first two; Lindemann's transcendence of $\\pi$ (1882, axiomatized in companion file) settles the third. 389 lines, 0 sorries; circle squaring depends on 1 axiom (pi_transcendental) from PiTranscendental.lean.",
+  "description": "The three classical Greek impossibility problems resolved in one file (Wiedijk #8): angle trisection, cube doubling, and circle squaring. Wantzel's 1837 algebraic criterion ($\\cos(20°)$ satisfies an irreducible cubic $8x^3-6x-1$, degree 3 $\\neq 2^n$) settles the first two; Lindemann's transcendence of $\\pi$ (1882, axiomatized in companion file) settles the third. 383 lines, 0 sorries; circle squaring depends on 1 axiom (pi_transcendental) from PiTranscendental.lean.",
   "meta": {
     "author": "Pierre Wantzel (1837)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Angle_trisection",
     "date": "1837",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "geometry",
       "galois-theory",
@@ -17,7 +17,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/AngleTrisection.lean",
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 8,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Field extensions and algebraic degree",
       "Polynomial rings and irreducibility over Q",
@@ -71,7 +71,7 @@
         "relationship": "Further extensions of the constructibility framework"
       }
     ],
-    "assumptions": "Fully verified. 0 axioms, 0 sorries.",
+    "assumptions": "Angle trisection and cube doubling: fully verified (0 axioms, 0 sorries). Circle squaring: depends on 1 axiom (pi_transcendental from PiTranscendental.lean).",
     "mathlib_version": "4.26.0"
   },
   "leanFile": {
@@ -88,7 +88,7 @@
     "namespace": "AngleTrisection",
     "lineCount": 383,
     "structureCount": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 18,
     "lemmaCount": 0,
     "defCount": 4,
@@ -164,7 +164,7 @@
   "overview": {
     "historicalContext": "The problem of trisecting an arbitrary angle using only compass and straightedge is one of the three famous classical Greek problems, alongside doubling the cube and squaring the circle. These problems appear to have been formulated by the 5th century BCE. Hippocrates of Chios (c. 470–410 BCE) made the first recorded attempt at cube doubling by reducing it to finding two mean proportionals between 1 and 2. The Delian problem — doubling the altar of Apollo — is attributed by Eratosthenes to an oracle's demand during a plague on Delos (c. 430 BCE), though this may be apocryphal.\n\nGreek mathematicians found solutions using curves beyond compass and straightedge: Hippias's quadratrix (c. 420 BCE) could trisect angles, Menaechmus (c. 350 BCE) solved cube doubling using conic sections, and Archimedes (c. 250 BCE) demonstrated angle trisection by *neusis* (a marked ruler slid between two constraints). Nicomedes' conchoid (c. 200 BCE) could also trisect angles. These solutions were considered legitimate but geometrically 'impure' — the restriction to compass and straightedge was a philosophical choice, not a practical one.\n\nThe impossibility question remained open for two millennia until Pierre Laurent Wantzel published his proof in 1837 in the *Journal de Mathématiques Pures et Appliquées*. Wantzel, only 23 at the time, showed that compass-and-straightedge constructions correspond to towers of quadratic field extensions, so constructible numbers have degree $2^n$ over the rationals. Since $\\cos(20°)$ satisfies an irreducible cubic, its degree is 3 (not a power of 2), and the trisection of 60° is impossible. Wantzel's paper — barely 7 pages — was largely overlooked for decades; he died in 1848 at age 33 from overwork and stimulant abuse, and his priority was not fully recognized until the 20th century.\n\nThe squaring of the circle was proven impossible by Ferdinand von Lindemann in 1882, when he showed that $\\pi$ is transcendental. This was a strictly stronger result: constructibility requires algebraic degree $2^n$, but $\\pi$ has no algebraic degree at all. Lindemann's proof, building on Hermite's 1873 proof that $e$ is transcendental, completed the resolution of all three classical problems.\n\nRemarkably, angle trisection 'cranks' — amateur mathematicians claiming to have trisected the angle — persisted well into the 20th century. Augustus De Morgan catalogued such claims in his *Budget of Paradoxes* (1872), and mathematics departments continued receiving purported constructions long after Wantzel's proof.",
     "problemStatement": "Given an arbitrary angle θ, can it be divided into three equal parts using only a compass and unmarked straightedge?\n\nThe answer is NO for a general angle. In particular, a 60° angle cannot be trisected.\n\nTo trisect 60°, we would need to construct a 20° angle, which is equivalent to constructing the number cos(20°). Using the triple angle formula:\n$$\\cos(60°) = 4\\cos^3(20°) - 3\\cos(20°)$$\n$$\\frac{1}{2} = 4x^3 - 3x$$\n$$8x^3 - 6x - 1 = 0$$\n\nSo cos(20°) satisfies an irreducible cubic polynomial over ℚ.",
-    "text": "A 389-line Lean 4 formalization of the impossibility of angle trisection, doubling the cube, and squaring the circle with 37 declarations and 0 sorries. Imports `AngleTrisectionCos20Gal` (Galois group computation) and `PiTranscendental` (π transcendence, axiomatized). Angle trisection and cube doubling are fully verified; circle squaring depends on 1 axiom (pi_transcendental). The core argument: `trisectionPolynomial` ($8x^3 - 6x - 1$) is shown irreducible by exhaustive rational root checking, `cos_20_satisfies_cubic` connects it to $\\cos(20°)$ via the triple-angle formula, and `three_not_power_of_two` establishes that degree 3 is incompatible with Wantzel's constructibility criterion.",
+    "text": "A 383-line Lean 4 formalization of the impossibility of angle trisection, doubling the cube, and squaring the circle with 37 declarations and 0 sorries. Imports `AngleTrisectionCos20Gal` (Galois group computation) and `PiTranscendental` (π transcendence, axiomatized). Angle trisection and cube doubling are fully verified; circle squaring depends on 1 axiom (pi_transcendental). The core argument: `trisectionPolynomial` ($8x^3 - 6x - 1$) is shown irreducible by exhaustive rational root checking, `cos_20_satisfies_cubic` connects it to $\\cos(20°)$ via the triple-angle formula, and `three_not_power_of_two` establishes that degree 3 is incompatible with Wantzel's constructibility criterion.",
     "proofStrategy": "The proof proceeds in several stages:\n\n1. **Algebraic Translation**: Show that trisecting 60° requires constructing cos(20°).\n\n2. **Find the Minimal Polynomial**: Use the triple angle formula to derive that cos(20°) satisfies 8x³ - 6x - 1 = 0.\n\n3. **Prove Irreducibility**: By the rational root theorem, check that ±1, ±1/2, ±1/4, ±1/8 are not roots. For cubics, no rational roots means irreducible over ℚ.\n\n4. **Degree Argument**: Since the polynomial is irreducible of degree 3, we have [ℚ(cos 20°) : ℚ] = 3.\n\n5. **Constructibility Criterion**: Wantzel's theorem: constructible numbers have degree 2^n over ℚ.\n\n6. **Contradiction**: 3 is not a power of 2, so cos(20°) is not constructible.",
     "keyInsights": [
       "Compass and straightedge constructions correspond to quadratic field extensions - each new point requires solving at most a quadratic equation",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2,8 +2,8 @@
   "version": 1,
   "entries": {
     "pythagorean-triples": {
-      "auditCount": 4,
-      "lastAudited": "2026-03-24T06:54:07Z",
+      "auditCount": 5,
+      "lastAudited": "2026-03-24T07:54:26Z",
       "result": "clean",
       "issues": []
     },
@@ -14,9 +14,9 @@
       "issues": []
     },
     "angle-trisection": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:49:48Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T07:58:08Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "angle-trisection-oq-02": {
@@ -44,32 +44,32 @@
       "issues": []
     },
     "angle-trisection-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:53:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T07:59:29Z",
       "result": "clean",
       "issues": []
     },
     "angle-trisection-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:53:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T08:00:04Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:53:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T07:58:55Z",
       "result": "clean",
       "issues": []
     },
     "angle-trisection-oq-02-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:53:49Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T08:01:42Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:53:49Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T08:01:15Z",
       "result": "clean",
       "issues": []
     },
@@ -80,8 +80,8 @@
       "issues": []
     },
     "arithmetic-series-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T02:53:49Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T08:00:27Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

- **angle-trisection**: Fixed overclaiming `verified` status. The file imports `PiTranscendental.lean` (7 axioms) and defines `lindemann_pi_transcendental` which depends on the `pi_transcendental` axiom. Changes: status `verified`→`axiomatized`, badge `verified`→`axiom`, axiomCount `0`→`1`, line count `389`→`383`, assumptions field updated to reflect the transitive axiom dependency.
- Updated audit tracker with 8 newly audited proofs

## Audited proofs (8 total)

| Proof | Result | Notes |
|-------|--------|-------|
| pythagorean-triples | CLEAN | True stubs are documentation examples, not claims |
| **angle-trisection** | **FIXED** | Transitive axiom from PiTranscendental.lean |
| area-of-circle-oq-03 | CLEAN | Mathlib used for building blocks, not delegation |
| angle-trisection-oq-02-oq-01 | CLEAN | Original theorems extending Mathlib |
| angle-trisection-oq-02-oq-03 | CLEAN | 1799-line proof with 150+ original theorems |
| arithmetic-series-oq-02 | CLEAN | Hockey stick identity, original work |
| area-of-circle-oq-01-oq-02 | CLEAN | FTC used as tool, not delegation |
| angle-trisection-oq-02-oq-03-oq-01 | CLEAN | Cyclotomic infrastructure bridge |

## Test plan

- [ ] Verify `pnpm build` succeeds with updated meta.json
- [ ] Verify angle-trisection gallery page renders with axiom badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)