### PR TITLE
Add Aristotle companion file for Erdős #1033

### DIFF
--- a/proofs/Proofs/Erdos1033Aristotle.lean
+++ b/proofs/Proofs/Erdos1033Aristotle.lean
@@ -1,0 +1,89 @@
+/-
+  Aristotle targets for Erdős Problem #1033
+  Routine supporting lemmas for automated proof search.
+  See Erdos1033Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture or deep extremal results
+  - Known results provable from definitions or basic Mathlib facts
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos1033Aristotle
+
+open Finset Real
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- The constant 2(√3 - 1). -/
+noncomputable def erdosLaskarConstant : ℝ := 2 * (Real.sqrt 3 - 1)
+
+/-- Fan's constant 21/16 = 1.3125. -/
+def fanConstant : ℚ := 21 / 16
+
+/-- The gap between bounds. -/
+noncomputable def boundGap : ℝ := erdosLaskarConstant - fanConstant
+
+/-- A triangle in G: three mutually adjacent vertices. -/
+structure Triangle (G : SimpleGraph V) where
+  v1 : V
+  v2 : V
+  v3 : V
+  distinct12 : v1 ≠ v2
+  distinct23 : v2 ≠ v3
+  distinct13 : v1 ≠ v3
+  adj12 : G.Adj v1 v2
+  adj23 : G.Adj v2 v3
+  adj13 : G.Adj v1 v3
+
+/-- Degree of a vertex in a decidable graph. -/
+noncomputable def vertexDegree (G : SimpleGraph V) [DecidableRel G.Adj] (v : V) : ℕ :=
+  G.degree v
+
+/-- Sum of degrees of the three vertices in a triangle. -/
+noncomputable def triangleDegreeSum (G : SimpleGraph V) [DecidableRel G.Adj]
+    (T : Triangle G) : ℕ :=
+  vertexDegree G T.v1 + vertexDegree G T.v2 + vertexDegree G T.v3
+
+-- Routine: Each vertex in a triangle has degree ≥ 2
+-- (must be adjacent to the other two triangle vertices)
+theorem triangle_min_degree (G : SimpleGraph V) [DecidableRel G.Adj] (T : Triangle G) :
+    vertexDegree G T.v1 ≥ 2 ∧ vertexDegree G T.v2 ≥ 2 ∧ vertexDegree G T.v3 ≥ 2 := by
+  sorry
+
+-- Routine: Triangle degree sum is at least 6 (each vertex has degree ≥ 2)
+theorem triangle_sum_min (G : SimpleGraph V) [DecidableRel G.Adj] (T : Triangle G) :
+    triangleDegreeSum G T ≥ 6 := by
+  sorry
+
+-- Routine: Numerical estimate 2(√3-1) > 1.46
+theorem erdosLaskar_gt : erdosLaskarConstant > 1.46 := by
+  sorry
+
+-- Routine: Numerical estimate 2(√3-1) < 1.47
+theorem erdosLaskar_lt : erdosLaskarConstant < 1.47 := by
+  sorry
+
+-- Routine: Fan's constant is greater than 1
+theorem fan_gt_one : (fanConstant : ℝ) > 1 := by
+  sorry
+
+-- Routine: Fan's constant equals 1.3125
+theorem fan_value : (fanConstant : ℝ) = 21 / 16 := by
+  sorry
+
+-- Routine: The gap between bounds is positive
+theorem gap_positive : boundGap > 0 := by
+  sorry
+
+-- Routine: erdosLaskarConstant > fanConstant
+theorem erdosLaskar_gt_fan : erdosLaskarConstant > (fanConstant : ℝ) := by
+  sorry
+
+-- Routine: 2(√3-1) > 0
+theorem erdosLaskar_pos : erdosLaskarConstant > 0 := by
+  sorry
+
+end Erdos1033Aristotle


### PR DESCRIPTION
## Fix

Creates `Erdos1033Aristotle.lean` companion file with 9 routine lemmas for automated proof search on Erdős Problem #1033 (triangle degree sums in dense graphs).

## Evidence

**Before**: Erdős #1033 has 14 sorries with no Aristotle companion — automated proof search could not target its routine lemmas.

**After**: 9 routine lemmas exposed for Aristotle:
- `triangle_min_degree` — each triangle vertex has degree ≥ 2
- `triangle_sum_min` — triangle degree sum ≥ 6
- `erdosLaskar_gt`, `erdosLaskar_lt` — numerical estimates for 2(√3-1)
- `fan_gt_one`, `fan_value` — Fan's constant properties
- `gap_positive` — bound gap is positive
- `erdosLaskar_gt_fan` — upper bound constant > lower bound constant
- `erdosLaskar_pos` — positivity

Pre-submission checklist passes: no definition sorries, no axioms, no `/-!` docstrings, no placeholder True theorems.

---
Automated fix by lean-mechanic agent.