### PR TITLE
Audit cycle 14b: fix leanFile.axiomCount in 22 proofs

### DIFF
--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -140,7 +140,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 104,
-    "axiomCount": 16,
+    "axiomCount": 14,
     "theoremCount": 0,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -86,7 +86,7 @@
     "opens": [],
     "namespace": "Erdos1052",
     "lineCount": 196,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "theoremCount": 8,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-1103/meta.json
+++ b/src/data/proofs/erdos-1103/meta.json
@@ -165,7 +165,7 @@
     ],
     "namespace": null,
     "lineCount": 92,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 3,
     "definitionCount": 2
   },

--- a/src/data/proofs/erdos-134/meta.json
+++ b/src/data/proofs/erdos-134/meta.json
@@ -95,7 +95,7 @@
     ],
     "namespace": "Erdos134",
     "lineCount": 295,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -169,7 +169,7 @@
     ],
     "namespace": "Erdos183",
     "lineCount": 241,
-    "axiomCount": 13,
+    "axiomCount": 12,
     "theoremCount": 5,
     "definitionCount": 13
   },

--- a/src/data/proofs/erdos-252/meta.json
+++ b/src/data/proofs/erdos-252/meta.json
@@ -75,7 +75,7 @@
       "SchinzelHypothesisH",
       "PrimeKTuplesConjecture"
     ],
-    "axiomCount": 8,
+    "axiomCount": 10,
     "theoremCount": 6,
     "opens": [
       "scoped",

--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -108,7 +108,7 @@
     ],
     "namespace": null,
     "lineCount": 86,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -111,7 +111,7 @@
   "leanFile": {
     "lineCount": 137,
     "structureCount": 0,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 5,
     "lemmaCount": 0,
     "defCount": 2,

--- a/src/data/proofs/erdos-327/meta.json
+++ b/src/data/proofs/erdos-327/meta.json
@@ -146,7 +146,7 @@
     ],
     "namespace": null,
     "lineCount": 198,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 7,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -166,7 +166,7 @@
     "opens": [],
     "namespace": "Erdos348",
     "lineCount": 265,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 14
   },

--- a/src/data/proofs/erdos-406/meta.json
+++ b/src/data/proofs/erdos-406/meta.json
@@ -81,7 +81,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 82,
-    "axiomCount": 5,
+    "axiomCount": 6,
     "theoremCount": 0,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-413/meta.json
+++ b/src/data/proofs/erdos-413/meta.json
@@ -215,7 +215,7 @@
     "opens": [],
     "namespace": "Erdos413",
     "lineCount": 1047,
-    "axiomCount": 6,
+    "axiomCount": 4,
     "theoremCount": 116,
     "definitionCount": 17
   },

--- a/src/data/proofs/erdos-44/meta.json
+++ b/src/data/proofs/erdos-44/meta.json
@@ -132,7 +132,7 @@
     ],
     "namespace": "Erdos44",
     "lineCount": 346,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-828/meta.json
+++ b/src/data/proofs/erdos-828/meta.json
@@ -167,7 +167,7 @@
     ],
     "namespace": "Erdos828",
     "lineCount": 178,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -137,7 +137,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 113,
-    "axiomCount": 21,
+    "axiomCount": 9,
     "theoremCount": 0,
     "definitionCount": 2
   },

--- a/src/data/proofs/erdos-896/meta.json
+++ b/src/data/proofs/erdos-896/meta.json
@@ -128,7 +128,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 182,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-932/meta.json
+++ b/src/data/proofs/erdos-932/meta.json
@@ -139,7 +139,7 @@
     ],
     "namespace": "Erdos932",
     "lineCount": 336,
-    "axiomCount": 12,
+    "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-950/meta.json
+++ b/src/data/proofs/erdos-950/meta.json
@@ -150,7 +150,7 @@
     ],
     "namespace": "Erdos950",
     "lineCount": 244,
-    "axiomCount": 12,
+    "axiomCount": 9,
     "theoremCount": 4,
     "definitionCount": 10
   }

--- a/src/data/proofs/erdos-987/meta.json
+++ b/src/data/proofs/erdos-987/meta.json
@@ -92,7 +92,7 @@
     ],
     "namespace": "Erdos987",
     "lineCount": 258,
-    "axiomCount": 10,
+    "axiomCount": 12,
     "theoremCount": 2,
     "definitionCount": 6
   },

--- a/src/data/proofs/taylor-theorem-oq-03/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-03/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "TaylorExpConvergence",
     "lineCount": 268,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 20,
     "definitionCount": 2
   }

--- a/src/data/proofs/wolstenholme-theorem/meta.json
+++ b/src/data/proofs/wolstenholme-theorem/meta.json
@@ -126,7 +126,7 @@
     ],
     "namespace": "WolstenholmeTheorem",
     "lineCount": 220,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 6
   },

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -305,7 +305,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 16,
+    "axiomCount": 0,
     "theoremCount": 1818,
     "definitionCount": 260
   },


### PR DESCRIPTION
## Fix

Syncs stale `leanFile.axiomCount` values in meta.json to match actual axiom declaration counts in Lean source files. All 22 proofs had correct `meta.axiomCount` but outdated `leanFile.axiomCount`.

## Evidence

| Proof | Before | After | Delta |
|-------|--------|-------|-------|
| erdos-854 | 21 | 9 | -12 |
| erdos-932 | 12 | 4 | -8 |
| yang-mills | 16 | 0 | -16 |
| erdos-1014 | 16 | 14 | -2 |
| erdos-252 | 8 | 10 | +2 |
| erdos-987 | 10 | 12 | +2 |
| erdos-950 | 12 | 9 | -3 |
| erdos-413 | 6 | 4 | -2 |
| taylor-theorem-oq-03 | 2 | 0 | -2 |
| + 13 more erdos proofs | off by 1 | corrected | ±1 |

**Method**: Counted `axiom` declarations in Lean source (outside comments), verified against existing `meta.axiomCount` values.

**Not fixed** (need structure-encoded assumption analysis): birch-swinnerton-dyer, borsuk-ulam-oq-03, buffons-needle-oq-01-oq-01, dissection-of-cubes-oq-01, greens-theorem-oq-03, riemann-hypothesis.

---
Automated fix by lean-mechanic agent.