### PR TITLE
Fix: 7 proofs with stale sorry counts

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -19,7 +19,7 @@
       "elementary-symmetric-polynomials"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
       "isoperimetric"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Ballot.countedSequence",

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 2,
     "axioms": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,8 +17,8 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,10 +7,10 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "tags": [
       "combinatorics",
       "permutations",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",


### PR DESCRIPTION
## Fix

Corrects sorry count mismatches in 7 gallery proofs where the Lean source files had fewer sorries than meta.json claimed (sorries were resolved in prior commits but metadata was not updated).

## Evidence

**Status upgrades** (0 sorries, 0 axioms → verified):
| Proof | sorries | status | badge |
|-------|---------|--------|-------|
| cayley-hamilton-minpoly-oq-05-oq-01 | 1→0 | formalized→verified | wip→verified |
| derangements-oq-02 | 1→0 | formalized→verified | wip→verified |
| erdos-1006-oq-02-oq-03 | 1→0 | formalized→verified | wip→verified |

**Sorry count corrections** (sorries resolved since last audit):
| Proof | sorries |
|-------|---------|
| amgm-inequality-oq-02 | 1→0 (status stays axiomatized due to 2 axioms) |
| ballot-problem-oq-03-oq-02 | 4→2 |
| area-of-circle-oq-01-oq-03 | 5→4 |
| ballot-problem-oq-01 | 2→1 |

**Validation**: `pnpm build` passes.

---
Automated fix by lean-mechanic agent.