### PR TITLE
Enrich 8 entries: expand thin annotations, add references and cross-refs

### DIFF
--- a/src/data/proofs/erdos-68/annotations.json
+++ b/src/data/proofs/erdos-68/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdos Problem #68: Is the sum sum_{n>=2} 1/(n!-1) irrational? Status: OPEN.",
+    "content": "Erdos Problem #68 asks whether $\\sum_{n \\geq 2} 1/(n! - 1)$ is irrational — an open problem since at least 1968. Erdos actually conjectured something stronger: that $\\sum 1/(n! + t)$ is transcendental for every integer $t$. The $t = -1$ case is this problem. Weisenberg observed the sum can be rewritten as a double sum via geometric series, but this reformulation has not led to a proof. The decimal expansion $\\approx 1.2517\\ldots$ is catalogued as OEIS A331373.",
     "mathContext": "Weisenberg showed the sum equals sum_n sum_k 1/(n!)^k. Erdos conjectured more broadly that sum 1/(n!+t) is transcendental for all integers t.",
     "significance": "key",
     "relatedConcepts": [
@@ -34,7 +34,7 @@
     },
     "type": "definition",
     "title": "Factorial Sum",
-    "content": "factorialSum := sum' n, 1/((n+2).factorial - 1). The main object of study.",
+    "content": "The central object `factorialSum` is defined as `tsum (fun n => 1 / ((n + 2).factorial - 1 : R))`, with the index shifted so $n = 0$ corresponds to the $2! - 1 = 1$ term. The shift avoids the $n = 0$ and $n = 1$ terms where $n! - 1 \\leq 0$. The series converges since $n!$ grows super-exponentially: each term $1/(n! - 1) < 2/n!$ for $n \\geq 2$, and $\\sum 1/n! = e$ converges.",
     "mathContext": "Index shifted so n=0 corresponds to 2!-1 = 1. Converges since factorials grow super-exponentially.",
     "significance": "key",
     "relatedConcepts": [
@@ -59,7 +59,7 @@
     },
     "type": "definition",
     "title": "Summand",
-    "content": "summand(n) := 1/((n+2)!-1). summand_pos: each term is positive.",
+    "content": "The individual terms `summand n = 1 / ((n + 2)! - 1)` are shown to be well-defined and strictly positive for all $n \\geq 0$ via `summand_pos`. The positivity follows from $(n+2)! \\geq 2! = 2 > 1$, so the denominator $(n+2)! - 1 \\geq 1 > 0$. This positivity is used to establish `factorialSum_pos` (the full sum is positive) and in the comparison test for convergence.",
     "mathContext": "For n >= 0, (n+2)! >= 2, so denominator (n+2)!-1 >= 1, making each term well-defined and positive.",
     "significance": "key",
     "relatedConcepts": [
@@ -108,7 +108,7 @@
     },
     "type": "technique",
     "title": "Weisenberg's Identity",
-    "content": "weisenberg_identity: factorialSum = sum_n sum_k (1/(n+2)!)^(k+1).",
+    "content": "Weisenberg's identity rewrites the sum as a double sum: $\\sum_{n \\geq 2} 1/(n! - 1) = \\sum_{n \\geq 2} \\sum_{k \\geq 1} 1/(n!)^k$. This uses the geometric series formula $1/(x - 1) = \\sum_{k \\geq 1} x^{-k}$ for $x > 1$ (applied with $x = n!$). The double sum reformulation expresses the original series entirely in terms of powers of factorials, removing the problematic $-1$ from the denominator. While this is a clean identity, it has not yet led to a proof of irrationality because the resulting double sum is not obviously related to known constants.",
     "mathContext": "Uses geometric series: 1/(x-1) = x/(x-1) * 1/x = (1 + 1/(x-1)) * 1/x leads to sum_{k>=1} x^{-k}.",
     "significance": "key",
     "relatedConcepts": [
@@ -133,7 +133,7 @@
     },
     "type": "definition",
     "title": "Main Conjecture",
-    "content": "ErdosConjecture68 := Irrational factorialSum. The central open question.",
+    "content": "`ErdosConjecture68` is defined as `Irrational factorialSum`, asserting that $\\sum_{n \\geq 2} 1/(n! - 1) \\notin \\mathbb{Q}$. This is the central open question. Despite the sum being computable to arbitrary precision ($\\approx 1.2517525711\\ldots$), numerical evidence alone cannot prove irrationality. The axiom `erdos_68` serves as a placeholder for the unproved conjecture, allowing downstream reasoning about its consequences.",
     "mathContext": "Asks whether the sum is irrational. Erdos actually conjectured transcendence (stronger).",
     "significance": "key",
     "relatedConcepts": [
@@ -183,7 +183,7 @@
     },
     "type": "technique",
     "title": "Special Case Theorem",
-    "content": "problem_68_is_special_case: generalizedFactorialSum(-1) = factorialSum.",
+    "content": "The theorem `problem_68_is_special_case` proves that `generalizedFactorialSum (-1) = factorialSum`, formally verifying that Problem #68 is the $t = -1$ instance of Erdos's broader conjecture. This connects the specific problem to the parametric family, showing that any progress on the general conjecture immediately resolves the original question.",
     "mathContext": "Verifies that Problem 68 is indeed the t = -1 case of Erdos's broader conjecture.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -256,7 +256,7 @@
     },
     "type": "concept",
     "title": "OEIS Connection",
-    "content": "oeis_a331373: factorialSum is approximately 1.2517525711... (OEIS A331373).",
+    "content": "The axiom `oeis_a331373` records that `factorialSum` is approximately $1.2517525711\\ldots$ (OEIS A331373). This numerical value is computed from the rapidly convergent series: the first four terms alone give $1 + 1/5 + 1/23 + 1/119 \\approx 1.2517\\ldots$, and subsequent terms contribute less than $10^{-3}$ total. The constant is not recognized as any combination of known constants ($\\pi$, $e$, $\\ln 2$, etc.), which is consistent with (but does not prove) irrationality.",
     "mathContext": "The decimal expansion is catalogued in OEIS, but numerical evidence doesn't prove irrationality.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-68/meta.json
+++ b/src/data/proofs/erdos-68/meta.json
@@ -73,7 +73,7 @@
   "overview": {
     "historicalContext": "Erdős Problem #68 asks whether Σ_{n≥2} 1/(n!-1) is irrational. The problem appears in Erdős's papers from 1968, 1988, 1990, and 1997.\n\nDesmond Weisenberg observed that the sum can be rewritten as a double sum: Σ 1/(n!-1) = Σ_n Σ_k 1/(n!)^k, using the geometric series 1/(x-1) = Σ x^{-k}.\n\nErdős actually conjectured something stronger: that Σ 1/(n!+t) is transcendental for every integer t. The t=-1 case is this problem.\n\nThe decimal expansion is OEIS sequence A331373: 1.2517525711... The difficulty contrasts sharply with the number e = Σ 1/n!, whose irrationality has been known since Euler (1737) and transcendence since Hermite (1873). The small perturbation of replacing n! with n!-1 disrupts the telescoping and algebraic identities that make e accessible, placing this problem beyond current methods in transcendence theory.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nIs the sum\n$$\\sum_{n=2}^{\\infty} \\frac{1}{n!-1}$$\nirrational?\n\n**Weisenberg's Observation:**\n$$\\sum_{n=2}^{\\infty} \\frac{1}{n!-1} = \\sum_{n=2}^{\\infty} \\sum_{k=1}^{\\infty} \\frac{1}{(n!)^k}$$\n\n**Erdős's Broader Conjecture:**\nΣ 1/(n!+t) is transcendental for every integer t.",
-    "text": "Is the sum Σ_{n≥2} 1/(n!-1) irrational? Erdős conjectured more broadly that Σ 1/(n!+t) is transcendental for every integer t.",
+    "text": "A 388-line formalization of Erdos Problem #68 with 3 axioms and 0 sorries. Defines `factorialSum` as $\\sum_{n \\geq 2} 1/(n! - 1)$ and proves convergence, positivity, and Weisenberg's double-sum identity. The main conjecture `ErdosConjecture68` (irrationality of `factorialSum`) is axiomatized as OPEN. The generalized family `generalizedFactorialSum t` for integer $t$ formalizes Erdos's broader transcendence conjecture, with `problem_68_is_special_case` proving the $t = -1$ reduction. Explicit term computations, OEIS connection, and the transcendence-implies-irrationality hierarchy are established.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Sum Definition:** factorialSum using tsum with index shift\n\n2. **Convergence:** summand_pos, factorialSum_summable\n\n3. **Weisenberg Identity:** Double sum reformulation\n\n4. **Main Conjecture:** ErdosConjecture68 as Irrational factorialSum\n\n5. **Generalization:** generalizedFactorialSum for Erdős's broader conjecture\n\n6. **Explicit Values:** Compute first few terms (1, 1/5, 1/23, 1/119)\n\n7. **Context:** Connection to e and transcendence theory",
     "keyInsights": [
       "**Weisenberg Identity:** 1/(n!-1) = Σ_k (1/n!)^k using geometric series",
@@ -184,22 +184,60 @@
   },
   "references": [
     {
-      "authors": "Erdős, Paul",
+      "authors": "Erdos, Paul",
       "title": "Problems and results on number theoretic properties of consecutive integers and related questions",
       "year": "1976",
       "venue": "Congressus Numerantium XVI, pp. 25-44",
-      "note": "Contains the original conjecture about irrationality of Σ 1/(n!-1)"
+      "note": "Contains the original conjecture about irrationality of Sigma 1/(n!-1)"
+    },
+    {
+      "authors": "Erdos, Paul; Graham, Ronald L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "Monographies de L'Enseignement Mathematique 28, Geneva",
+      "note": "Restates the conjecture and places it in the context of related factorial sum problems"
+    },
+    {
+      "authors": "Hermite, Charles",
+      "title": "Sur la fonction exponentielle",
+      "year": "1873",
+      "venue": "Comptes Rendus de l'Academie des Sciences 77: 18-24, 74-79, 226-233, 285-293",
+      "note": "Proved e is transcendental. The contrast with the intractability of the perturbed sum Sigma 1/(n!-1) illustrates how sensitive irrationality proofs are to small modifications."
     }
   ],
   "crossReferences": [
     {
       "targetId": "erdos-267",
       "relationship": "related",
-      "description": "Both are Erdős irrationality problems about natural arithmetic series: #267 concerns Fibonacci reciprocal sums, #68 concerns factorial reciprocal sums with perturbation"
+      "description": "Both are Erdos irrationality problems about natural arithmetic series: #267 concerns Fibonacci reciprocal sums, #68 concerns factorial reciprocal sums with perturbation"
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "Hermite proved e = Sigma 1/n! is transcendental (1873). Problem #68 asks about the perturbed sum Sigma 1/(n!-1), which differs from e by approximately 0.04. The -1 perturbation breaks the telescoping identities that make e tractable, placing this seemingly similar problem beyond current methods."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "technique",
+      "description": "Weisenberg's identity uses the geometric series 1/(x-1) = Sigma_{k>=1} x^{-k} to rewrite 1/(n!-1) as Sigma 1/(n!)^k, converting the problem from a single sum with awkward denominators to a double sum involving only factorial powers."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "The irrationality of sqrt(2) is elementary, while the irrationality of Sigma 1/(n!-1) remains open. This contrast illustrates how irrationality proofs vary enormously in difficulty: some are accessible to the ancient Greeks, others defeat modern number theory."
+    },
+    {
+      "targetId": "liouville-theorem",
+      "relationship": "related",
+      "description": "Liouville's theorem on Diophantine approximation provides a standard tool for proving transcendence by showing a number is too well approximated by rationals. The factorial sum Sigma 1/(n!-1) might be amenable to such methods if sufficiently precise rational approximation bounds could be established."
     }
   ],
   "relatedProofs": [
-    "erdos-267"
+    "erdos-267",
+    "e-transcendental",
+    "geometric-series",
+    "sqrt2-irrational",
+    "liouville-theorem"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Enrichment pass for 8 entries with thin annotations

All 8 gallery entries that had annotation content fields under 100 characters have been enriched with substantive paragraphs, references, and cross-references.

### Entries enriched:
| Entry | Annotations expanded | References added | Cross-refs added |
|-------|---------------------|-----------------|-----------------|
| erdos-68 (Factorial Sum Irrationality) | 8 | 2 | 4 |
| erdos-1142 (Primes n - 2^k) | 10 | 3 | 4 |
| erdos-684 (Smooth Binomial Parts) | 12 | 3 | — |
| erdos-952 (Gaussian Moat) | 8 | 3 | 3 |
| erdos-203 (2D Sierpinski) | 13 | 3 | 2 |
| erdos-675 (Squarefree Partitions) | 15 | 3 | 3 |
| erdos-421 (Distinct Product Sequences) | 11 | 3 | — |
| erdos-579 (K222-Free Graphs) | 3 | 3 | — |