### PR TITLE
Research: erdos-931 - fix consecutive product computation bug

### DIFF
--- a/proofs/Proofs/Erdos931Problem.lean
+++ b/proofs/Proofs/Erdos931Problem.lean
@@ -60,8 +60,8 @@ theorem consecutiveProduct_13_3 : consecutiveProduct 13 3 = 3360 := by native_de
 /-- 19·20·21·22 = 175560. -/
 theorem consecutiveProduct_18_4 : consecutiveProduct 18 4 = 175560 := by native_decide
 
-/-- 54·55·56·57 = 9459360. -/
-theorem consecutiveProduct_53_4 : consecutiveProduct 53 4 = 9459360 := by native_decide
+/-- 54·55·56·57 = 9480240. -/
+theorem consecutiveProduct_53_4 : consecutiveProduct 53 4 = 9480240 := by native_decide
 
 /-- For k = 0, the product is 1 (empty product). -/
 theorem consecutiveProduct_zero (n : ℕ) : consecutiveProduct n 0 = 1 := by

--- a/src/data/research/problems/erdos-931.json
+++ b/src/data/research/problems/erdos-931.json
@@ -16,9 +16,9 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "OBSERVE",
     "since": "2026-01-15T11:43:50.650Z",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,11 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEYED: Fixed compilation bug. 2 axioms remain, both non-trivial (deep result + open question). File in good shape.",
+    "builtItems": [
+      "Fixed consecutive product computation bug (9459360 → 9480240)"
+    ],
+    "insights": [
+      "Only 2 axioms, both deep: stronger_implies_main (requires Bertrand-type argument), exists_prime_between_blocks (open question)",
+      "Fixed pre-existing bug: consecutiveProduct 53 4 was 9459360 (should be 9480240 = 54*55*56*57)",
+      "Bertrand postulate available in Mathlib (Nat.exists_prime_lt_and_le) — could help with stronger_implies_main",
+      "File well-structured with verified counterexamples via native_decide"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Try proving stronger_implies_main using Bertrand postulate from Mathlib",
+      "Add more verified examples via native_decide",
+      "exists_prime_between_blocks is an open question - cannot be eliminated"
+    ],
     "markdown": "# Erdős #931 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k_1\\geq k_2\\geq 3$. Are there only finitely many $n_2\\geq n_1+k_1$ such that\\[\\prod_{1\\leq i\\leq k_1}(n_1+i)\\textrm{ and }\\prod_{1\\leq j\\leq k_2}(n_2+j)\\]have the same prime factors?\n\n\n\nTijdeman gave the example\\[19,20,21,22\\textrm{ and }54,55,56,57.\\]Erd\\H{o}s \\cite{Er76d} was unsure of this conjecture, and thought perhaps if the two products have the same prime factors then $n_2>2(n_1+k_1)$. It is not clear but it is possible that he meant to ask this question also permitting finitely many counterexamples. Indeed, without this caveat it is false - AlphaProof has found the counterexample\\[10! = 2^8\\cdot 3^4\\cdot 5^2\\cdot 7\\]and\\[14\\cdot 15\\cdot 16 = 2^5\\cdot 3\\cdot 5\\cdot 7,\\]so that $n_1=0$, $k_1=10$, $n_2=13$, and $k_2=3$.\n\nSee also [388].\n\nThis is discussed in problem B35 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Er76d] Erd\\H{o}s, P., Problems and results on number theoretic properties of consecutive integers and related questions. Proceedings of the Fifth Manitoba Conference on Numerical Mathematics (Univ. Manitoba, Winnipeg, Man., 1975) (1976), 25-44.\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #388\n- Problem #930\n- Problem #932\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -50,7 +61,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:43:50.650Z",
-  "lastUpdate": "2026-03-13T07:52:17.054Z",
+  "lastUpdate": "2026-03-24T09:15:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- Fixed pre-existing compilation bug: `consecutiveProduct_53_4` had wrong value (9459360 → 9480240)
- 54·55·56·57 = 9480240, not 9459360

## Status
**Outcome**: surveyed (bug fix)
**Axioms**: 2 (both non-trivial: one deep result, one open question)

🤖 Generated by researcher-2