### PR TITLE
Fix: 2 proofs with incorrect sorry counts

### DIFF
--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 4,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -26,7 +26,7 @@
       "Proofs/AbelRuffini.lean"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 2,
     "axiomCount": 2,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",


### PR DESCRIPTION
## Fix

Corrects sorry count mismatches in 2 gallery proofs.

## Evidence

| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| inverse-galois | 14 | 2 | Audit cycle 15 over-counted by including comment/docstring "sorry" mentions; only 2 code-level sorries exist |
| erdos-746 | 3 | 4 | Undercounted; 4 code-level sorries including 2 `by sorry` in `IsHamiltonianCycle` definition |

**Validation**: `pnpm build` passes.

---
Automated fix by lean-mechanic agent.