### PR TITLE
Audit cycle 16: fix sorry overcounting from comment-only mentions

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 8,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "prerequisites": [
       "Field extensions and algebraic degree",
       "Polynomial rings and irreducibility over Q",
@@ -88,7 +88,7 @@
     "namespace": "AngleTrisection",
     "lineCount": 383,
     "structureCount": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 18,
     "lemmaCount": 0,
     "defCount": 4,

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -14,7 +14,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 21,
     "assumptions": "21 axiom declarations (algebraicRank, torsionSubgroup, localLFactor, conductor, LFunction, completedLFunction, rootNumber, analyticRank, realPeriod, regulator, shaOrder, tamagawaNumber, tamagawaProduct, torsionOrder, HasCM, NeronTateHeight, traceOfFrobenius, BSD_NumberField, BSD_AbelianVariety, regulatorValue, classNumber) converted to opaque — these are vocabulary declarations (type/constant definitions), not mathematical assumptions. Remaining 22 axioms encode proven BSD cases (rank 0 via Kolyvagin, rank 1 via Gross-Zagier, CM via Coates-Wiles), the Gross-Zagier formula, Hasse bound, specific curve data, congruent number results, parity conjecture, BSD generalizations, and more. Additionally, 3 structure-encoded assumptions: MordellWeilGroup.finitely_generated, GrossZagierData.gross_zagier, KolyvaginResult.sha_finite. The BSD conjecture itself remains open.",
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -19,7 +19,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 13,
+    "axiomCount": 12,
     "erdosNumber": 1160,
     "erdosUrl": "https://erdosproblems.com/1160",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 530,
     "erdosUrl": "https://erdosproblems.com/530",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 164,
     "assumptions": "4 axiom(s): erdos_lower_bound (N^{1/3}), komlos_sulyok_szemeredi (N^{1/2} lower bound), alon_erdos_partition_conjecture, sidon_sum_count (k(k+1)/2 distinct sums).",
     "mathlib_version": "4.26.0"
@@ -115,7 +115,7 @@
     ],
     "namespace": "Erdos530",
     "lineCount": 164,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 4
   },

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -26,7 +26,7 @@
       "Proofs/AbelRuffini.lean"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 2,
     "axiomCount": 2,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "NSAxioms structure with 5 fields: Type II exponent bound, spectral gap on dissipation scale, theta dynamics bound, blowup rate estimate, BKM criterion. These encode the physical hypotheses needed for conditional 3D regularity.",
     "mathlibDependencies": [

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -22,7 +22,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -53,7 +53,7 @@
       "K-ball-concentration"
     ],
     "badge": "axiom",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 Lean axiom declarations, but the 3D regularity theorem is conditional on the NSAxioms structure (5 fields encoding physical hypotheses: Type II exponent, spectral gap, theta dynamics, blowup rate, and BKM criterion). These structure fields are mathematically equivalent to axiom declarations -- the assumptions were reorganized, not eliminated. The 2D global existence theorem (Ladyzhenskaya 1969) is genuinely unconditional. The Millennium Prize problem remains unsolved.",
     "mathlibDependencies": [

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -14,7 +14,7 @@
       "prime-distribution"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 32,
     "assumptions": "32 axiom declarations in main file. Main: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality), prime gap bounds. Consequences: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. Soundness audit: removed li_criterion (was inconsistent with wrong liCoefficient def), fixed auto-bound RiemannHypothesisStatement, unified eulerMascheroniGamma. 8329 lines, 38 axioms, 0 sorries.",
     "mathlibDependencies": [

--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -20,7 +20,7 @@
     "proofRepoPath": "Proofs/TriangleInequalityOQ03.lean",
     "badge": "verified",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 255,
     "mathlibDependencies": [
       {
@@ -172,7 +172,7 @@
   "leanFile": {
     "lineCount": 256,
     "structureCount": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 15,
     "lemmaCount": 0,
     "defCount": 0,


### PR DESCRIPTION
## Summary

Corrects sorry counts that were incorrectly inflated by PR #5806, which counted `sorry` appearing in Lean comments (e.g., "no sorry, no axiom") as real sorries.

### Sorry count corrections (comment-only mentions → 0)
- **navier-stokes** (4 entries): 23→0 (all 23 were "no sorry" in block comments)
- **riemann-hypothesis**: 2→0 (both in comments)
- **birch-swinnerton-dyer**: 1→0 (in a comment)
- **inverse-galois**: 14→2 (2 real sorries at lines 77+364, 12 in comments)

### Additional axiom count fixes
- **erdos-1160**: 13→12 (axiom removed on main since last audit)
- **erdos-530**: 4→3 (axiom removed on main since last audit)
- **angle-trisection**: 1→0 (no axioms in file)
- **triangle-inequality-oq-03**: 0→1 (axiom added on main)

## Lesson learned

The batch sorry scanner must exclude sorry mentions inside:
- Block comments (`/- ... -/`)
- Line comments (`-- ...`)

## Test plan

- [ ] `pnpm build` passes

---
Corrective audit — fixing own previous errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)