### PR TITLE
Add Aristotle companion file for Erdős #608

### DIFF
--- a/proofs/Proofs/Erdos608Aristotle.lean
+++ b/proofs/Proofs/Erdos608Aristotle.lean
@@ -1,0 +1,72 @@
+/-
+  Aristotle targets for Erdős Problem #608
+  Routine supporting lemmas for automated proof search.
+  See Erdos608Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main extremal results (Füredi-Maleki, Grzesik-Hu-Volec)
+  - Known numerical facts provable from definitions and Mathlib
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos608Aristotle
+
+open Real
+
+/-- The correct constant c = (2 + √2) / 16. -/
+noncomputable def c : ℝ := (2 + Real.sqrt 2) / 16
+
+/-- The Turán threshold for triangles. -/
+noncomputable def turanEdges (n : ℕ) : ℕ := (n / 2) * ((n + 1) / 2)
+
+-- Routine: c > 0.213
+theorem c_gt : c > 0.213 := by
+  sorry
+
+-- Routine: c < 0.214
+theorem c_lt : c < 0.214 := by
+  sorry
+
+-- Routine: c < 2/9 (this is why the original conjecture fails)
+theorem c_lt_two_ninths : c < 2 / 9 := by
+  sorry
+
+-- Routine: c > 0
+theorem c_pos : c > 0 := by
+  sorry
+
+-- Routine: √2 > 1
+theorem sqrt_two_gt_one : Real.sqrt 2 > 1 := by
+  sorry
+
+-- Routine: √2 < 1.5
+theorem sqrt_two_lt : Real.sqrt 2 < 1.5 := by
+  sorry
+
+-- Routine: √2 * √2 = 2
+theorem sqrt_two_sq : Real.sqrt 2 * Real.sqrt 2 = 2 := by
+  sorry
+
+-- Routine: 2/9 > 0.222
+theorem two_ninths_gt : (2 : ℝ) / 9 > 0.222 := by
+  sorry
+
+-- Routine: The gap between 2/9 and c is positive
+theorem gap_positive : (2 : ℝ) / 9 - c > 0 := by
+  sorry
+
+-- Routine: Turán edges for n=4 is 4
+theorem turan_four : turanEdges 4 = 4 := by
+  sorry
+
+-- Routine: Turán edges for n=5 is 6
+theorem turan_five : turanEdges 5 = 6 := by
+  sorry
+
+-- Routine: Turán edges for n=6 is 9
+theorem turan_six : turanEdges 6 = 9 := by
+  sorry
+
+end Erdos608Aristotle


### PR DESCRIPTION
## Fix

Creates `Erdos608Aristotle.lean` companion file with 12 routine lemmas for automated proof search on Erdős Problem #608 (edges in 5-cycles).

## Evidence

**Before**: Erdős #608 has 13 sorries with no Aristotle companion — automated proof search could not target its routine lemmas.

**After**: 12 routine lemmas exposed for Aristotle:
- `c_gt`, `c_lt`, `c_pos` — numerical bounds for c = (2+√2)/16
- `c_lt_two_ninths` — the key inequality showing original conjecture is false
- `sqrt_two_gt_one`, `sqrt_two_lt`, `sqrt_two_sq` — √2 properties
- `two_ninths_gt` — bound on 2/9
- `gap_positive` — gap between 2/9 and c
- `turan_four`, `turan_five`, `turan_six` — Turán edge counts

Pre-submission checklist passes: no definition sorries, no axioms, no `/-!` docstrings, no placeholder True theorems.

---
Automated fix by lean-mechanic agent.