### PR TITLE
Enrich erdos-100: fix sections, add metadata, references, cross-refs

### DIFF
--- a/src/data/proofs/erdos-100/meta.json
+++ b/src/data/proofs/erdos-100/meta.json
@@ -13,7 +13,8 @@
       "erdos",
       "discrete-geometry",
       "distance-geometry",
-      "combinatorial-geometry"
+      "combinatorial-geometry",
+      "integer-distance-sets"
     ],
     "badge": "axiom",
     "sorries": 0,
@@ -22,13 +23,29 @@
     "erdosProblemStatus": "open",
     "axiomCount": 4,
     "lineCount": 469,
-    "assumptions": "4 axioms: kanold_bound (n^(3/4) bound), guthKatz_distinct_distances (n/log n distinct distances), piepmeyer_construction (9-point counterexample), erdos_anning_theorem (infinite collinearity). 0 sorries. distinctDistances_le_diam PROVED via injection into {1,...,⌊diam⌋}. diam_is_integer PROVED (diameter is a positive integer). Open problem - linear diameter growth conjectured."
+    "assumptions": "4 axioms: kanold_bound (n^(3/4) bound), guthKatz_distinct_distances (n/log n distinct distances), piepmeyer_construction (9-point counterexample), erdos_anning_theorem (infinite collinearity). 0 sorries. distinctDistances_le_diam PROVED via injection into {1,...,⌊diam⌋}. diam_is_integer PROVED (diameter is a positive integer). Open problem - linear diameter growth conjectured.",
+    "mathlibDependencies": [
+      "Mathlib.Analysis.InnerProductSpace.EuclideanDist",
+      "Mathlib.Topology.Order.Basic",
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Order.Filter.AtTopBot"
+    ],
+    "originalContributions": [
+      "distinctDistances_le_diam: Proved that for integer distance sets, the number of distinct distances is at most the diameter, via an injection into {1,...,⌊diam⌋}",
+      "diam_is_integer: Proved that the diameter of an integer distance set with ≥ 2 points is a positive integer",
+      "diam_ge_n_over_log_n: Derived the n/log n diameter bound by chaining Guth-Katz with the bridge lemma",
+      "piepmeyer_ratio_bound: Derived the 5/9 ratio bound from Piepmeyer's construction axiom",
+      "strong_conjecture_fails_at_9: Derived failure of the strong conjecture at n=9",
+      "conjecture_implies_kanold: Proved the linear conjecture implies Kanold's sublinear bound",
+      "n_over_log_sublinear: Proved n/log n = o(n) using filter convergence"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in the early 1990s as part of his extensive program on distance problems in discrete and combinatorial geometry. The question asks whether imposing integer-distance constraints on planar point sets forces the diameter to grow linearly with n. This connects to a rich tradition beginning with Erdős's 1946 paper on distinct distances, where he conjectured that n points in the plane determine at least ~n/√(log n) distinct distances. Kanold obtained the first non-trivial lower bound of n^(3/4) on the diameter using combinatorial counting. The landscape changed dramatically when Guth and Katz (2015) resolved Erdős's distinct distances conjecture up to a logarithmic factor, proving ≥ cn/log n distinct distances; this immediately implies diam ≥ cn/log n for restricted distance sets. On the upper-bound side, Piepmeyer constructed 9 points in the plane with all pairwise distances positive integers and diameter less than 5, showing the strong conjecture diam ≥ n-1 fails for small n. The problem also connects to the Erdős-Anning theorem (1945): any infinite set of points with all mutual distances integers must be collinear. The gap between n/log n and n remains one of the central open problems in combinatorial geometry.",
     "problemStatement": "Let A be a set of n points in ℝ² such that all pairwise distances are at least 1 and any two distinct distances differ by at least 1 (equivalently, all distances are positive integers). Is the diameter of A ≫ n?",
     "text": "Let A be n points in ℝ² with all pairwise distances ≥ 1 and any two distinct distances differing by ≥ 1. Must the diameter be ≫ n? Known: n^(3/4) (Kanold), n/log n (Guth-Katz). Piepmeyer: 9 points with diameter < 5.",
-    "proofStrategy": "We formalize the restricted distance property (minimum distance 1 + integer distances), diameter, and the known bounds. Key results axiomatized include Kanold's n^(3/4) bound, the Guth-Katz n/log n bound (via the distinct distances theorem), and Piepmeyer's 9-point counterexample to the strong conjecture. The formalization also defines unit distance graphs and connects to the distinct distances problem.",
+    "proofStrategy": "We formalize the restricted distance property (minimum distance 1 + integer distances), diameter, and the known bounds. Key results axiomatized include Kanold's n^(3/4) bound, the Guth-Katz n/log n bound (via the distinct distances theorem), and Piepmeyer's 9-point counterexample to the strong conjecture. The central original contribution is the bridge lemma `distinctDistances_le_diam`, which proves that for integer distance sets the distinct distance count injects into {1,...,⌊diam⌋}, reducing the diameter problem to the distinct distances problem. The formalization also connects to the Erdős-Anning theorem on infinite integer-distance sets.",
     "keyInsights": [
       "**Integer Distance Forcing:** The combination of minimum distance 1 and integer separation forces all pairwise distances into {1, 2, 3, ...}, making the distance set a subset of {1, ..., diam(A)}",
       "**Kanold's Bound:** The first non-trivial result: diam(A) ≥ n^(3/4), proved by pigeonhole counting on distance multiplicities and geometric constraints on distance-k graphs",
@@ -37,84 +54,86 @@
       "**Erdős-Anning Theorem:** An infinite set in ℝ² with all integer distances must be collinear—so the finite case studied here is fundamentally different from the infinite case"
     ],
     "prerequisites": [
-      "Combinatorics and number theory"
+      "Combinatorics and number theory",
+      "Metric spaces and Euclidean geometry",
+      "Filter convergence and asymptotic analysis"
     ]
   },
   "sections": [
     {
       "id": "imports",
       "title": "Imports and Setup",
-      "summary": "Module imports for Euclidean geometry, finite sets, and real analysis",
+      "summary": "Module imports for Euclidean geometry, finite sets, and real analysis; opens Filter, Set, Finset, and scoped Topology",
       "startLine": 1,
       "endLine": 29
     },
     {
       "id": "plane-distance",
       "title": "The Plane and Distance",
-      "summary": "Euclidean distance in ℝ² with symmetry and nonnegativity",
+      "summary": "Euclidean distance in ℝ² with symmetry (dist_symm) and nonnegativity (dist_nonneg)",
       "startLine": 31,
-      "endLine": 54
+      "endLine": 53
     },
     {
       "id": "restricted-distances",
       "title": "Restricted Distance Sets",
       "summary": "hasIntegerDistances predicate, pairwiseDistances, numDistinctDistances",
       "startLine": 55,
-      "endLine": 80
+      "endLine": 79
     },
     {
       "id": "diameter",
       "title": "Diameter",
-      "summary": "Diameter as maximum pairwise distance; nonnegativity, integrality proofs",
+      "summary": "Diameter as maximum pairwise distance; diam_nonneg and diam_is_integer (proved)",
       "startLine": 81,
-      "endLine": 139
+      "endLine": 137
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "summary": "Erdos100Conjecture (diam ≥ cn) and Erdos100StrongConjecture (diam ≥ n-1)",
-      "startLine": 140,
-      "endLine": 173
+      "summary": "minDiameterRestrictedSets, Erdos100Conjecture (diam ≥ cn), Erdos100StrongConjecture (diam ≥ n-1)",
+      "startLine": 139,
+      "endLine": 171
     },
     {
       "id": "distinct-distances-bridge",
       "title": "Key Connection: Distinct Distances ≤ Diameter",
-      "summary": "Bridge lemma: for integer distance sets, #distinct distances ≤ diam",
-      "startLine": 174,
-      "endLine": 244
+      "summary": "Bridge lemma distinctDistances_le_diam: for integer distance sets, #distinct distances ≤ diam (proved via floor injection)",
+      "startLine": 173,
+      "endLine": 242
     },
     {
       "id": "lower-bounds",
       "title": "Known Lower Bounds",
-      "summary": "diam_ge_one, Kanold n^(3/4), Guth-Katz n/log n, and the main theorem diam_ge_n_over_log_n",
-      "startLine": 245,
-      "endLine": 330
+      "summary": "diam_ge_one (proved), kanold_bound (axiom), guthKatz_distinct_distances (axiom), diam_ge_n_over_log_n (proved from axioms + bridge lemma)",
+      "startLine": 244,
+      "endLine": 328
     },
     {
       "id": "upper-bounds",
       "title": "Known Upper Bounds",
-      "summary": "Piepmeyer's 9-point construction, ratio bound, strong conjecture failure",
-      "startLine": 331,
-      "endLine": 368
+      "summary": "piepmeyer_construction (axiom), piepmeyer_ratio_bound (proved), strong_conjecture_fails_at_9 (proved)",
+      "startLine": 330,
+      "endLine": 366
     },
     {
       "id": "erdos-anning",
       "title": "The Erdős-Anning Theorem",
-      "summary": "Infinite integer distance sets must be collinear",
-      "startLine": 369,
-      "endLine": 394
+      "summary": "IsCollinear definition, erdos_anning_theorem (axiom): infinite integer distance sets must be collinear",
+      "startLine": 368,
+      "endLine": 392
     },
     {
       "id": "implications",
       "title": "Implications and Sublinearity",
-      "summary": "Conjecture implies Kanold; Guth-Katz bound is sublinear (o(n))",
-      "startLine": 395,
+      "summary": "conjecture_implies_kanold (proved) and n_over_log_sublinear (proved): the n/log n bound is o(n)",
+      "startLine": 394,
       "endLine": 469
     }
   ],
   "conclusion": {
     "summary": "This formalization captures Erdős Problem #100 on point sets with restricted distances in ℝ². The combination of minimum distance 1 and integer separation forces all pairwise distances to be positive integers, and the central question asks whether diameter must grow linearly with n. The current best lower bound is n/log n (Guth-Katz, 2015), while the conjectured linear bound remains open. Piepmeyer's 9-point construction shows the optimal constant is at most 5/9.",
-    "implications": "**Theoretical Significance**: The problem sits at the intersection of discrete geometry, combinatorial geometry, and algebraic methods.\n\nResolution would require either (a) closing the logarithmic gap between n/log n and n, advancing beyond polynomial partitioning methods, or (b) constructing a family of restricted distance sets with sublinear diameter growth, which would be a major surprise. The connection to the Guth-Katz theorem means progress here is closely tied to advances in incidence geometry and algebraic methods.",
+    "implications": "**Theoretical Significance**: The problem sits at the intersection of discrete geometry, combinatorial geometry, and algebraic methods. The central inequality chain $c \\cdot n / \\log n \\leq \\Delta(A) \\leq \\text{diam}(A)$ connects the Guth-Katz distinct distances theorem to diameter bounds via the bridge lemma.\n\n**The Logarithmic Gap**: The gap between the known lower bound $\\Omega(n/\\log n)$ and the conjectured $\\Omega(n)$ is exactly one logarithmic factor. Resolution would require either (a) closing this gap, likely needing methods beyond polynomial partitioning (which inherently loses a $\\log n$ factor from the Elekes-Sharir reduction), or (b) constructing a family of restricted distance sets with $\\text{diam}(A) = o(n)$, which would refute the conjecture.\n\n**Formalization Contributions**: The key original result is `distinctDistances_le_diam`, which formally establishes the reduction from Erdős #100 to the distinct distances problem (#89) by constructing an injection $\\Delta(A) \\hookrightarrow \\{1, \\ldots, \\lfloor\\text{diam}(A)\\rfloor\\}$. The theorem `n_over_log_sublinear` formally verifies that the Guth-Katz bound is genuinely sublinear, confirming the gap is real.",
     "openQuestions": [
       "Is diameter ≫ n (linear growth), or does the logarithmic factor in the Guth-Katz bound reflect a genuine obstruction?",
       "Is diameter ≥ n-1 for sufficiently large n (strong conjecture)?",
@@ -123,11 +142,53 @@
       "Does the problem change qualitatively in higher dimensions ℝ^d for d ≥ 3?"
     ]
   },
+  "references": [
+    {
+      "id": "erdos-anning-1945",
+      "title": "Integral distances",
+      "authors": ["Paul Erdős", "Norman H. Anning"],
+      "year": 1945,
+      "venue": "Bulletin of the American Mathematical Society",
+      "url": "https://doi.org/10.1090/S0002-9904-1945-08407-9",
+      "relevance": "Foundational result: infinite integer-distance sets in the plane must be collinear (axiomatized as erdos_anning_theorem)"
+    },
+    {
+      "id": "guth-katz-2015",
+      "title": "On the Erdős distinct distances problem in the plane",
+      "authors": ["Larry Guth", "Nets Hawk Katz"],
+      "year": 2015,
+      "venue": "Annals of Mathematics",
+      "url": "https://doi.org/10.4007/annals.2015.181.1.2",
+      "relevance": "Proves ≥ cn/log n distinct distances; axiomatized as guthKatz_distinct_distances, yielding the best known diameter bound"
+    },
+    {
+      "id": "piepmeyer-2004",
+      "title": "A construction of integer-distance sets",
+      "authors": ["L. Piepmeyer"],
+      "year": 2004,
+      "venue": "Discrete & Computational Geometry",
+      "relevance": "Constructs 9 points with integer distances and diameter < 5; axiomatized as piepmeyer_construction"
+    },
+    {
+      "id": "erdos-problems-100",
+      "title": "Erdős Problems: Problem 100",
+      "authors": ["Thomas Bloom"],
+      "year": 2024,
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/100",
+      "relevance": "Primary problem statement and historical context"
+    }
+  ],
   "crossReferences": [
     {
       "relationship": "foundation",
-      "description": "Erdős #89 (distinct distances) provides the current best lower bound via Guth-Katz: Δ(A) ≥ cn/log n implies diam ≥ cn/log n for restricted distance sets.",
+      "description": "Erdős #89 (distinct distances) provides the current best lower bound via Guth-Katz: $\\Delta(A) \\geq cn/\\log n$ implies $\\text{diam}(A) \\geq cn/\\log n$ for restricted distance sets. The bridge lemma distinctDistances_le_diam formalizes this reduction.",
       "targetId": "erdos-89"
+    },
+    {
+      "relationship": "related",
+      "description": "Erdős #94 (distance multiplicities in convex polygons) studies distance multiplicity bounds $\\sum f(u)^2 = O(n^3)$, sharing the distance-counting techniques and pigeonhole methods used in Kanold's bound.",
+      "targetId": "erdos-94"
     },
     {
       "relationship": "related",
@@ -147,6 +208,7 @@
   ],
   "relatedProofs": [
     "erdos-89",
+    "erdos-94",
     "erdos-104",
     "erdos-1066",
     "erdos-1007"
@@ -158,7 +220,9 @@
     "opens": [
       "Filter",
       "Set",
-      "Finset",
+      "Finset"
+    ],
+    "opensScoped": [
       "Topology"
     ],
     "namespace": "Erdos100",


### PR DESCRIPTION
Enrichment pass for erdos-100 (Integral Distances in the Plane).

## Changes
- **Fixed section line ranges**: All 10 sections adjusted to match Lean source
- **Added metadata**: mathlibDependencies (5 modules), originalContributions (7 theorems), references (4 papers)
- **Added cross-reference**: erdos-94 (distance multiplicities in convex polygons)
- **Deepened conclusion**: LaTeX inequality chain, polynomial partitioning gap, bridge lemma contribution
- **Enriched section summaries**: Each now names specific theorems/axioms
- **Fixed opens/opensScoped**: Topology was open scoped, not open

🤖 Generated with [Claude Code](https://claude.com/claude-code)