### PR TITLE
Fix: triangle-inequality-oq-03 axiomCount 1→0

### DIFF
--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -20,7 +20,7 @@
     "proofRepoPath": "Proofs/TriangleInequalityOQ03.lean",
     "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 255,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in triangle-inequality-oq-03 meta.json.

## Evidence

**Before**: `axiomCount: 1` — but the only "axiom" in the Lean file is in a docstring ("axiom of metric spaces")
**After**: `axiomCount: 0` — matches reality (0 code-level axiom declarations, 0 structure-encoded assumptions)

Status correctly remains `verified` (0 sorries, 0 axioms).

---
Automated fix by lean-mechanic agent.