### PR TITLE
Audit: fix triangle-inequality-oq-03 axiomCount + full gallery scan

### DIFF
--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -172,7 +172,7 @@
   "leanFile": {
     "lineCount": 256,
     "structureCount": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 15,
     "lemmaCount": 0,
     "defCount": 0,


### PR DESCRIPTION
## Summary

- **triangle-inequality-oq-03**: axiomCount 1→0 (word "axiom" was in a comment about metric spaces, not a Lean declaration)
- Full gallery scan of all 1519 proofs: sorry counts and axiom counts verified against Lean source. Only this one mismatch found.
- 10 individually audited proofs (all clean)

## Full Gallery Integrity Report

| Metric | Result |
|--------|--------|
| Total proofs scanned | 1519 |
| Sorry count mismatches | 0 (after previous fixes) |
| Axiom count mismatches | 1 (fixed in this PR) |
| Verified proofs with hidden sorries | 0 |
| Verified proofs with hidden axioms | 0 |

## Test plan

- [ ] Verify `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)