### PR TITLE
Research: erdos-931 - Partial proof via Bertrand's postulate

### DIFF
--- a/proofs/Proofs/Erdos931Problem.lean
+++ b/proofs/Proofs/Erdos931Problem.lean
@@ -22,6 +22,7 @@ import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Interval
 import Mathlib.Tactic
+import Mathlib.NumberTheory.Bertrand
 
 namespace Erdos931
 
@@ -125,6 +126,27 @@ theorem tijdeman_gap : 18 + 4 ≤ 53 := by omega
 /-- Tijdeman's example also has n₂ > 2(n₁ + k₁): 53 > 44. -/
 theorem tijdeman_beyond_double : 53 > 2 * (18 + 4) := by omega
 
+/-- New example: 4·5·6 and 8·9·10 share prime factors {2,3,5}.
+    Here n₁ = 3, k₁ = 3, n₂ = 7, k₂ = 3. -/
+theorem small_same_factors_3_3_7_3 : SamePrimeFactors 3 3 7 3 := by native_decide
+
+/-- The (3,3,7,3) example satisfies the gap condition. -/
+theorem small_gap_3_3_7_3 : 3 + 3 ≤ 7 := by omega
+
+/-- 3·4·5·6 and 8·9·10 share prime factors {2,3,5}.
+    Here n₁ = 2, k₁ = 4, n₂ = 7, k₂ = 3. -/
+theorem small_same_factors_2_4_7_3 : SamePrimeFactors 2 4 7 3 := by native_decide
+
+/-- The (2,4,7,3) example satisfies the gap condition. -/
+theorem small_gap_2_4_7_3 : 2 + 4 ≤ 7 := by omega
+
+/-- 1·2·3·4·5 and 8·9·10 share prime factors {2,3,5}.
+    Here n₁ = 0, k₁ = 5, n₂ = 7, k₂ = 3. -/
+theorem small_same_factors_0_5_7_3 : SamePrimeFactors 0 5 7 3 := by native_decide
+
+/-- The (0,5,7,3) example satisfies the gap condition. -/
+theorem small_gap_0_5_7_3 : 0 + 5 ≤ 7 := by omega
+
 /-
 ## Properties of Prime Factors
 -/
@@ -171,19 +193,98 @@ theorem samePrimeFactors_trans {n₁ k₁ n₂ k₂ n₃ k₃ : ℕ}
 
 /-
 ## The Stronger Conjecture Implies the Main One
--/
 
-/-- The stronger conjecture implies the main conjecture: if same-prime-factor
-    pairs with n₂ ≤ 2(n₁+k₁) are finite, combined with the trivial bound,
-    we get overall finiteness. -/
+The main set decomposes as:
+  { (n₁,n₂) | n₁+k₁ ≤ n₂ ∧ SamePrimeFactors } =
+  { n₁+k₁ ≤ n₂ ≤ 2(n₁+k₁) ∧ SamePrimeFactors } ∪
+  { n₂ > 2(n₁+k₁) ∧ SamePrimeFactors }
+StrongerConjecture gives finiteness of the first set. This axiom asserts the
+second ("outer") set is also finite, which requires showing that for n₂ far
+beyond 2(n₁+k₁), having the same prime factors forces the second block
+elements to be n₁-smooth — and by results on consecutive smooth numbers
+(Størmer's theorem), there are only finitely many such n₂ for each n₁.
+-/
 axiom stronger_implies_main : StrongerConjecture → ErdosProblem931
 
 /-
-## Open Question: Prime Between Blocks
+## Bertrand's Postulate and Prime Between Blocks
+
+We partially prove the "prime between blocks" claim using Bertrand's postulate.
+The key insight: if the first block {n₁+1,...,n₁+k₁} contains a prime p,
+then p > n₁ and p ≤ n₁+k₁ ≤ n₂ ≤ n₂+k₂, giving a prime in the range
+immediately. By Bertrand, the first block always contains a prime when k₁ ≥ n₁.
+
+The remaining hard case (n₁ > k₁, first block all composite) requires smooth
+number theory: when all prime factors of both products are ≤ n₁, finding
+k₂ ≥ 3 consecutive n₁-smooth numbers with the exact same prime factor set
+as a block of k₁ composite numbers is extremely restrictive — empirically
+impossible for all tested cases, likely provable via Størmer's theorem.
 -/
 
-/-- Open question: if two consecutive products share prime factors with
-    n₂ ≥ n₁ + k₁, must there exist a prime p with n₁ < p ≤ n₂ + k₂? -/
+/-- If the first block contains a prime, there's a prime in (n₁, n₂+k₂].
+    No SamePrimeFactors hypothesis needed — the prime is already in range. -/
+theorem exists_prime_between_of_prime_in_block
+    (k₂ n₁ n₂ : ℕ)
+    {p : ℕ} (hp : p.Prime) (hlo : n₁ < p) (hhi : p ≤ n₂)
+    : ∃ q : ℕ, q.Prime ∧ n₁ < q ∧ q ≤ n₂ + k₂ :=
+  ⟨p, hp, hlo, le_trans hhi (Nat.le_add_right n₂ k₂)⟩
+
+/-- By Bertrand's postulate, when n₁ ≤ k₁ the first block {n₁+1,...,n₁+k₁}
+    always contains a prime. For n₁ = 0, the prime 2 works. For n₁ ≥ 1,
+    Bertrand gives a prime p with n₁ < p ≤ 2n₁ ≤ n₁+k₁. -/
+theorem first_block_has_prime (n₁ k₁ : ℕ) (hk : 3 ≤ k₁) (hkn : n₁ ≤ k₁) :
+    ∃ p : ℕ, p.Prime ∧ n₁ < p ∧ p ≤ n₁ + k₁ := by
+  rcases Nat.eq_zero_or_pos n₁ with rfl | hn
+  · exact ⟨2, by norm_num, by omega, by omega⟩
+  · obtain ⟨p, hp, hlt, hle⟩ := Nat.exists_prime_lt_and_le_two_mul n₁ (by omega)
+    exact ⟨p, hp, hlt, by omega⟩
+
+/-- For n₁ ≤ k₁: the prime-between-blocks claim holds unconditionally
+    (no SamePrimeFactors hypothesis needed). This covers all cases where
+    the block is long enough relative to its starting point. -/
+theorem exists_prime_between_blocks_small
+    (k₁ k₂ n₁ n₂ : ℕ)
+    (hk₁ : 3 ≤ k₁) (hkn : n₁ ≤ k₁)
+    (hgap : n₁ + k₁ ≤ n₂) :
+    ∃ p : ℕ, p.Prime ∧ n₁ < p ∧ p ≤ n₂ + k₂ := by
+  obtain ⟨p, hp, hlo, hhi⟩ := first_block_has_prime n₁ k₁ hk₁ hkn
+  exact ⟨p, hp, hlo, by omega⟩
+
+/-- If the first product has a prime factor q > n₁, and same prime factors hold,
+    then q divides the second product too, giving q ≤ n₂+k₂ (since q divides
+    one of the factors n₂+j ≤ n₂+k₂). -/
+theorem exists_prime_between_of_large_prime_factor
+    (k₁ k₂ n₁ n₂ q : ℕ)
+    (hq : q.Prime) (hq_lo : n₁ < q)
+    (hq_mem : q ∈ consecutivePrimeFactors n₁ k₁)
+    (h₃ : n₁ + k₁ ≤ n₂)
+    (h₄ : SamePrimeFactors n₁ k₁ n₂ k₂) :
+    ∃ p : ℕ, p.Prime ∧ n₁ < p ∧ p ≤ n₂ + k₂ := by
+  refine ⟨q, hq, hq_lo, ?_⟩
+  -- q is also a prime factor of the second product by SamePrimeFactors
+  have hq_mem₂ : q ∈ consecutivePrimeFactors n₂ k₂ := h₄ ▸ hq_mem
+  have hq_dvd : q ∣ consecutiveProduct n₂ k₂ := Nat.dvd_of_mem_primeFactors hq_mem₂
+  -- Since q is prime and divides (n₂+1)·...·(n₂+k₂), q divides some factor n₂+j
+  unfold consecutiveProduct at hq_dvd
+  obtain ⟨j, hj_mem, hq_dvd_j⟩ := hq.prime.dvd_finset_prod_iff.mp hq_dvd
+  simp only [Finset.mem_Icc] at hj_mem
+  calc q ≤ n₂ + j := Nat.le_of_dvd (by omega) hq_dvd_j
+    _ ≤ n₂ + k₂ := by omega
+
+/-
+## Open Question: Prime Between Blocks (Remaining Hard Case)
+
+The theorems above prove exists_prime_between_blocks when:
+  (a) k₁ ≥ n₁ (Bertrand guarantees a prime in the first block), OR
+  (b) the first product has any prime factor > n₁ (which includes case (a))
+
+The remaining hard case: n₁ > k₁, ALL elements of {n₁+1,...,n₁+k₁} are composite,
+AND all prime factors of the first product are ≤ n₁. In this case, by
+SamePrimeFactors, the second block is also n₁-smooth. Empirically, having
+k₂ ≥ 3 consecutive n₁-smooth numbers with the exact same prime factor set as
+a block of k₁ composites appears impossible for all tested n₁ values
+(by Størmer-type arguments on consecutive smooth numbers).
+-/
 axiom exists_prime_between_blocks (k₁ k₂ n₁ n₂ : ℕ)
     (h₁ : 3 ≤ k₂) (h₂ : k₂ ≤ k₁)
     (h₃ : n₁ + k₁ ≤ n₂)

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -21,8 +21,8 @@
     "erdosUrl": "https://erdosproblems.com/931",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 199,
-    "assumptions": "2 axioms: stronger_implies_main, exists_prime_between_blocks. See Lean source for complete statements.",
+    "lineCount": 300,
+    "assumptions": "2 axioms: stronger_implies_main (Størmer-type smooth number argument), exists_prime_between_blocks (partially proved via Bertrand for k₁ ≥ n₁ case). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -83,29 +83,36 @@
       "id": "sec-931-counterexamples",
       "title": "Verified Counterexamples",
       "startLine": 104,
-      "endLine": 127,
-      "summary": "AlphaProof counterexample (n₁=0, k₁=10, n₂=13, k₂=3) and Tijdeman's example (n₁=18, k₁=k₂=4, n₂=53), fully verified by native_decide and omega. Establishes that the stronger conjecture is false."
+      "endLine": 148,
+      "summary": "Five verified examples: AlphaProof (n₁=0, k₁=10, n₂=13, k₂=3), Tijdeman (n₁=18, k₁=k₂=4, n₂=53), and three new small examples showing {4,5,6}/{8,9,10}, {3,4,5,6}/{8,9,10}, and {1..5}/{8,9,10} share prime factors {2,3,5}. All verified by native_decide and omega."
     },
     {
       "id": "sec-931-properties",
       "title": "Properties of Prime Factors",
-      "startLine": 128,
-      "endLine": 171,
+      "startLine": 149,
+      "endLine": 192,
       "summary": "Seven lemmas: prime factors divide the product and are prime, a prime dividing any n+i is in the factor set (via Finset.dvd_prod_of_mem), and SamePrimeFactors is reflexive, symmetric, transitive."
     },
     {
       "id": "sec-931-implication",
       "title": "Stronger Implies Main",
-      "startLine": 172,
-      "endLine": 180,
-      "summary": "Axiom recording that the stronger conjecture implies the main one, via the Bertrand's postulate argument for the unbounded-gap case."
+      "startLine": 193,
+      "endLine": 207,
+      "summary": "Axiom with detailed commentary: the stronger conjecture implies the main one. The set decomposition into band and outer regions is explained, with the outer region requiring Størmer-type smooth number arguments."
     },
     {
-      "id": "sec-931-prime-between",
-      "title": "Open Question: Prime Between Blocks",
-      "startLine": 181,
-      "endLine": 199,
-      "summary": "Axiom stating the open subsidiary question: must a prime exist between n₁ and n₂+k₂ when blocks share prime factors? Includes the problem status string."
+      "id": "sec-931-bertrand",
+      "title": "Bertrand's Postulate and Prime Between Blocks",
+      "startLine": 208,
+      "endLine": 277,
+      "summary": "NEW: Four theorems using Bertrand's postulate. (1) If the first block contains a prime, a prime exists in range (trivial). (2) By Bertrand, when k₁ ≥ n₁ the first block always has a prime. (3) Combined: exists_prime_between_blocks holds for k₁ ≥ n₁ without SamePrimeFactors. (4) If the first product has a large prime factor, SamePrimeFactors transfers it to bound q ≤ n₂+k₂ via Prime.dvd_finset_prod_iff."
+    },
+    {
+      "id": "sec-931-prime-between-axiom",
+      "title": "Open Question: Remaining Hard Case",
+      "startLine": 278,
+      "endLine": 300,
+      "summary": "Axiom for the remaining hard case where n₁ > k₁ and the first block is all composite. Detailed commentary explains why this case requires smooth number theory (Størmer's theorem) and is empirically impossible for all tested values."
     }
   ],
   "conclusion": {
@@ -126,16 +133,17 @@
       "Mathlib.Data.Nat.Factorization.Basic",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Data.Finset.Interval",
-      "Mathlib.Tactic"
+      "Mathlib.Tactic",
+      "Mathlib.NumberTheory.Bertrand"
     ],
     "opens": [
       "Nat",
       "Finset"
     ],
     "namespace": "Erdos931",
-    "lineCount": 199,
+    "lineCount": 300,
     "axiomCount": 2,
-    "theoremCount": 21,
+    "theoremCount": 31,
     "definitionCount": 6
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-931.json
+++ b/src/data/research/problems/erdos-931.json
@@ -16,34 +16,43 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-01-15T11:43:50.650Z",
-    "iteration": 2,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ACT",
+    "since": "2026-03-24T09:30:00.000Z",
+    "iteration": 3,
+    "focus": "Partial proof of exists_prime_between_blocks via Bertrand's postulate.",
+    "blockers": ["Størmer's theorem not in Mathlib — needed to fully eliminate exists_prime_between_blocks axiom"],
+    "nextAction": "Investigate Størmer formalization or alternative smooth number arguments.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: Fixed compilation bug. 2 axioms remain, both non-trivial (deep result + open question). File in good shape.",
+    "progressSummary": "PROGRESS: Added 10 new theorems including Bertrand-based partial proof of exists_prime_between_blocks. Proved first_block_has_prime and exists_prime_between_blocks_small (covering k₁≥n₁ case). Added 3 new verified examples. Docker build succeeds.",
     "builtItems": [
-      "Fixed consecutive product computation bug (9459360 → 9480240)"
+      "Fixed consecutive product computation bug (9459360 → 9480240)",
+      "Proved first_block_has_prime using Nat.exists_prime_lt_and_le_two_mul (Bertrand)",
+      "Proved exists_prime_between_blocks_small: covers k₁ ≥ n₁ case without SamePrimeFactors",
+      "Proved exists_prime_between_of_large_prime_factor: uses SamePrimeFactors + Prime.dvd_finset_prod_iff",
+      "Added 3 new verified counterexample pairs via native_decide: (3,3,7,3), (2,4,7,3), (0,5,7,3)"
     ],
     "insights": [
-      "Only 2 axioms, both deep: stronger_implies_main (requires Bertrand-type argument), exists_prime_between_blocks (open question)",
-      "Fixed pre-existing bug: consecutiveProduct 53 4 was 9459360 (should be 9480240 = 54*55*56*57)",
-      "Bertrand postulate available in Mathlib (Nat.exists_prime_lt_and_le) — could help with stronger_implies_main",
-      "File well-structured with verified counterexamples via native_decide"
+      "Only 2 axioms, both deep: stronger_implies_main (requires Størmer-type smooth number theory), exists_prime_between_blocks (partially proved)",
+      "Key insight: exists_prime_between_blocks is TRIVIALLY true when first block contains a prime (p>n₁, p≤n₁+k₁≤n₂≤n₂+k₂)",
+      "By Bertrand's postulate, first block always contains a prime when k₁ ≥ n₁, covering the small-n₁ regime",
+      "The HARD remaining case: n₁ > k₁, first block all composite, all prime factors ≤ n₁ — SamePrimeFactors forces second block to be n₁-smooth",
+      "Empirically, the hard case appears vacuously true: for all tested n₁ with all-composite blocks, SamePrimeFactors fails",
+      "stronger_implies_main requires showing the outer set {n₂ > 2(n₁+k₁)} is finite — needs smooth number theory (Størmer)",
+      "New examples show same-prime-factors pairs cluster around small primes: {2,3,5} examples (4·5·6 = 8·9·10 in primes)"
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Størmer's theorem on consecutive smooth numbers — would fully resolve exists_prime_between_blocks"
+    ],
     "nextSteps": [
-      "Try proving stronger_implies_main using Bertrand postulate from Mathlib",
-      "Add more verified examples via native_decide",
-      "exists_prime_between_blocks is an open question - cannot be eliminated"
+      "Formalize Størmer's theorem to fully eliminate exists_prime_between_blocks axiom",
+      "Investigate stronger_implies_main: can the outer-set finiteness be proved from smooth number bounds?",
+      "Search for more same-prime-factor pairs computationally to build intuition"
     ],
     "markdown": "# Erdős #931 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k_1\\geq k_2\\geq 3$. Are there only finitely many $n_2\\geq n_1+k_1$ such that\\[\\prod_{1\\leq i\\leq k_1}(n_1+i)\\textrm{ and }\\prod_{1\\leq j\\leq k_2}(n_2+j)\\]have the same prime factors?\n\n\n\nTijdeman gave the example\\[19,20,21,22\\textrm{ and }54,55,56,57.\\]Erd\\H{o}s \\cite{Er76d} was unsure of this conjecture, and thought perhaps if the two products have the same prime factors then $n_2>2(n_1+k_1)$. It is not clear but it is possible that he meant to ask this question also permitting finitely many counterexamples. Indeed, without this caveat it is false - AlphaProof has found the counterexample\\[10! = 2^8\\cdot 3^4\\cdot 5^2\\cdot 7\\]and\\[14\\cdot 15\\cdot 16 = 2^5\\cdot 3\\cdot 5\\cdot 7,\\]so that $n_1=0$, $k_1=10$, $n_2=13$, and $k_2=3$.\n\nSee also [388].\n\nThis is discussed in problem B35 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Er76d] Erd\\H{o}s, P., Problems and results on number theoretic properties of consecutive integers and related questions. Proceedings of the Fifth Manitoba Conference on Numerical Mathematics (Univ. Manitoba, Winnipeg, Man., 1975) (1976), 25-44.\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #388\n- Problem #930\n- Problem #932\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -68,8 +77,8 @@
     {
       "path": "Proofs/Erdos931Problem.lean",
       "filename": "Erdos931Problem.lean",
-      "lineCount": 200,
-      "theoremCount": 21,
+      "lineCount": 300,
+      "theoremCount": 31,
       "axiomCount": 2,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- Prove `first_block_has_prime` using Bertrand's postulate from Mathlib
- Prove `exists_prime_between_blocks_small`: covers k₁ ≥ n₁ case without SamePrimeFactors
- Prove `exists_prime_between_of_large_prime_factor`: uses SamePrimeFactors + `Prime.dvd_finset_prod_iff`
- Add 3 new verified same-prime-factor examples via `native_decide`
- 10 new theorems (21→31), file grows 200→300 lines, 0 sorries

## Progress
The `exists_prime_between_blocks` axiom is partially proved:
- **Covered**: When k₁ ≥ n₁ (Bertrand guarantees a prime in the first block)
- **Covered**: When the first product has any prime factor > n₁ (SamePrimeFactors transfers it)
- **Remaining**: n₁ > k₁ with all-composite first block — requires Størmer's theorem on consecutive smooth numbers

## Findings
- Key insight: if the first block contains a prime p, then p > n₁ and p ≤ n₁+k₁ ≤ n₂+k₂ trivially
- The "hard case" (all-composite first block) appears empirically vacuous: SamePrimeFactors fails for all tested cases
- `stronger_implies_main` requires showing the outer set {n₂ > 2(n₁+k₁)} is finite — needs smooth number theory

## Status
**Outcome**: progress
**Next Steps**: Formalize Størmer's theorem to fully eliminate the axiom

🤖 Generated by researcher-4