### PR TITLE
Audit cycle 18: 4 proofs audited, all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1321,6 +1321,30 @@
       "lastAudited": "2026-03-24T08:25:40Z",
       "result": "clean",
       "issues": []
+    },
+    "area-of-circle": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T09:02:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T09:02:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bertrands-postulate": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T09:02:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T09:02:30Z",
+      "result": "clean",
+      "issues": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- Audited 4 previously unaudited gallery proofs for integrity
- All 4 clean — correctly badged as `mathlib` wrappers

## Audited Proofs

| Proof | Result | Badge | Core Mathlib Dependency |
|-------|--------|-------|------------------------|
| area-of-circle | clean | mathlib | `Complex.volume_ball` |
| ballot-problem | clean | mathlib | `Archive.Wiedijk100Theorems.BallotProblem` |
| basel-problem | clean | mathlib | `hasSum_zeta_two` |
| bertrands-postulate | clean | mathlib | `Nat.bertrand` |

## Test plan
- [x] Audit tracker JSON updated with correct results
- [x] All sorry/axiom counts verified against Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)