### PR TITLE
Add Aristotle companion file for Erdős #956 (8 sorries)

### DIFF
--- a/proofs/Proofs/Erdos956Aristotle.lean
+++ b/proofs/Proofs/Erdos956Aristotle.lean
@@ -1,0 +1,68 @@
+/-
+  Aristotle targets for Erdős Problem #956
+  Routine supporting lemmas for automated proof search.
+  See Erdos956Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (h(n) > n^(1+c))
+  - Known results from Mathlib: set distance properties, convexity/compactness
+    preservation under translation, basic analysis inequalities
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos956Aristotle
+
+open Set Metric Finset
+
+/-- The distance between two sets in a metric space. -/
+noncomputable def setDistance {X : Type*} [PseudoMetricSpace X] (C D : Set X) : ℝ :=
+  sInf { dist c d | (c : X) (d : X) (_ : c ∈ C) (_ : d ∈ D) }
+
+/-- A translate C + x of a set. -/
+def translate (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2)) :
+    Set (EuclideanSpace ℝ (Fin 2)) :=
+  { c + x | c ∈ C }
+
+-- Routine: Symmetry of set distance (follows from dist_comm)
+theorem setDistance_symm {X : Type*} [PseudoMetricSpace X] (C D : Set X) :
+    setDistance C D = setDistance D C := by
+  sorry
+
+-- Routine: Non-negativity of set distance (dist is non-negative, so is its infimum)
+theorem setDistance_nonneg {X : Type*} [PseudoMetricSpace X] (C D : Set X) :
+    setDistance C D ≥ 0 := by
+  sorry
+
+-- Routine: Translates preserve convexity
+theorem translate_convex (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2))
+    (hC : Convex ℝ C) : Convex ℝ (translate C x) := by
+  sorry
+
+-- Routine: Translates preserve compactness
+theorem translate_compact (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2))
+    (hC : IsCompact C) : IsCompact (translate C x) := by
+  sorry
+
+-- Routine: Translation preserves nonemptiness
+theorem translate_nonempty (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2))
+    (hC : C.Nonempty) : (translate C x).Nonempty := by
+  sorry
+
+-- Routine: Distance between translated sets equals distance between translation vectors
+-- when sets are singletons
+theorem setDistance_singletons {X : Type*} [PseudoMetricSpace X] (a b : X) :
+    setDistance {a} {b} = dist a b := by
+  sorry
+
+-- Routine: The general convex set exponent 7/5 exceeds the translate exponent 4/3
+theorem general_exponent_larger : (7 : ℝ) / 5 > 4 / 3 := by
+  sorry
+
+-- Routine: For large n, n^(4/3) > n * log n / log log n
+theorem power_dominates_log_ratio (n : ℕ) (hn : n ≥ 100) :
+    (n : ℝ) ^ ((4 : ℝ) / 3) > n * Real.log n / Real.log (Real.log n) := by
+  sorry
+
+end Erdos956Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #956 (Unit Distances Between Convex Translates) with 8 routine supporting lemmas for automated proof search.

## Evidence

**Before**: No Aristotle companion file; 11 sorries in main file with no automated proof pipeline
**After**: 8 routine sorries extracted into `Erdos956Aristotle.lean` for Aristotle to attempt:
- `setDistance_symm` — symmetry of set distance (from `dist_comm`)
- `setDistance_nonneg` — non-negativity of set distance
- `translate_convex` — convexity preserved under translation
- `translate_compact` — compactness preserved under translation
- `translate_nonempty` — nonemptiness preserved under translation
- `setDistance_singletons` — singleton set distance equals point distance
- `general_exponent_larger` — 7/5 > 4/3 (norm_num)
- `power_dominates_log_ratio` — n^(4/3) > n log n / log log n for n ≥ 100

All checklist items pass: no definition sorries, no axioms, no True placeholders, no `/-!` sections.

---
Automated fix by lean-mechanic agent.