### PR TITLE
Add Aristotle companion file for Erdős #601 (8 sorries)

### DIFF
--- a/proofs/Proofs/Erdos601Aristotle.lean
+++ b/proofs/Proofs/Erdos601Aristotle.lean
@@ -1,0 +1,59 @@
+/-
+  Aristotle targets for Erdős Problem #601
+  Routine supporting lemmas for automated proof search.
+  See Erdos601Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (P(α) for general limit ordinals)
+  - Known results from Mathlib: ordinal arithmetic, transfinite induction,
+    logical equivalences
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos601Aristotle
+
+open Ordinal Cardinal
+
+/-- Transfinite induction on ordinals.
+    This is a well-known principle, available in Mathlib as Ordinal.induction. -/
+theorem transfinite_induction (P : Ordinal → Prop)
+    (h0 : P 0)
+    (hS : ∀ α, P α → P (α + 1))
+    (hL : ∀ α, α.IsLimit → (∀ β < α, P β) → P α) :
+    ∀ α, P α := by
+  sorry
+
+/-- The ordinal hierarchy: ω < ω₁. -/
+theorem omega_lt_omega1 : ω < Ordinal.omega1 := by
+  sorry
+
+/-- ω₁ < ω₁ ^ ω (ordinal exponentiation). -/
+theorem omega1_lt_omega1_pow_omega : Ordinal.omega1 < Ordinal.omega1 ^ ω := by
+  sorry
+
+/-- ω₁ ^ ω < ω₁ ^ (ω + 1). -/
+theorem omega1_pow_omega_lt_succ : Ordinal.omega1 ^ ω < Ordinal.omega1 ^ (ω + 1) := by
+  sorry
+
+/-- ω₁ ^ (ω + 1) < ω₁ ^ (ω + 2). -/
+theorem omega1_pow_succ_lt : Ordinal.omega1 ^ (ω + 1) < Ordinal.omega1 ^ (ω + 2) := by
+  sorry
+
+/-- A disjunction P ∨ Q is equivalent to (¬P → Q) when decidable. -/
+theorem or_iff_not_imp {P Q : Prop} : (P ∨ Q) ↔ (¬P → Q) := by
+  sorry
+
+/-- If a set is finite, it has no injective map from ℕ. -/
+theorem Finite.no_injective_nat {V : Type*} [Finite V] :
+    ¬∃ f : ℕ → V, Function.Injective f := by
+  sorry
+
+/-- No infinite path in a graph on a finite vertex set.
+    An "infinite path" is an injective ℕ-indexed sequence of adjacent vertices. -/
+theorem finite_no_infinite_path {V : Type*} [Finite V] (G : SimpleGraph V) :
+    ¬∃ f : ℕ → V, Function.Injective f ∧ ∀ n, G.Adj (f n) (f (n + 1)) := by
+  sorry
+
+end Erdos601Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #601 (Infinite Paths and Independent Sets in Ordinal Graphs) with 8 routine supporting lemmas for automated proof search.

## Evidence

**Before**: No Aristotle companion file; 14 sorries in main file with deep ordinal theory
**After**: 8 routine sorries extracted into `Erdos601Aristotle.lean` for Aristotle to attempt:
- `transfinite_induction` — well-known, matches `Ordinal.induction` in Mathlib
- `omega_lt_omega1` — ω < ω₁
- `omega1_lt_omega1_pow_omega` — ω₁ < ω₁^ω
- `omega1_pow_omega_lt_succ` — ω₁^ω < ω₁^(ω+1)
- `omega1_pow_succ_lt` — ω₁^(ω+1) < ω₁^(ω+2)
- `or_iff_not_imp` — disjunction equivalence
- `Finite.no_injective_nat` — no injection ℕ → V for finite V
- `finite_no_infinite_path` — no infinite path in finite graph

All checklist items pass: no definition sorries, no axioms, no True placeholders, no `/-!` sections.

---
Automated fix by lean-mechanic agent.