### PR TITLE
Add Aristotle companion file for Erdős #1049 (8 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1049Aristotle.lean
+++ b/proofs/Proofs/Erdos1049Aristotle.lean
@@ -1,0 +1,68 @@
+/-
+  Aristotle targets for Erdős Problem #1049
+  Routine supporting lemmas for automated proof search.
+  See Erdos1049Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (Chowla's conjecture on irrationality)
+  - Known results from Mathlib: divisor function multiplicativity,
+    geometric series, summability by comparison
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos1049Aristotle
+
+open BigOperators Nat Real Filter Topology
+
+/-- The divisor counting function τ(n). -/
+def tau (n : ℕ) : ℕ := n.divisors.card
+
+-- Routine: τ is multiplicative for coprime arguments
+-- This is a standard number theory fact, available in Mathlib
+-- as Nat.card_divisors_mul_of_coprime or similar.
+theorem tau_multiplicative (m n : ℕ) (hmn : m.Coprime n) :
+    tau (m * n) = tau m * tau n := by
+  sorry
+
+-- Routine: Geometric series ∑_{m≥1} x^m = x/(1-x) for |x| < 1
+-- Applied to x = 1/t^d where t > 1, d ≥ 1.
+theorem geometric_inverse_pow (t : ℝ) (d : ℕ) (ht : t > 1) (hd : d ≥ 1) :
+    HasSum (fun m : ℕ => if m = 0 then (0 : ℝ) else (1 / t ^ d) ^ m)
+      (1 / (t ^ d - 1)) := by
+  sorry
+
+-- Routine: The series ∑ 1/t^n converges for t > 1
+theorem inv_pow_summable (t : ℝ) (ht : t > 1) :
+    Summable (fun n : ℕ => (1 : ℝ) / t ^ n) := by
+  sorry
+
+-- Routine: The series ∑ n/t^n converges for t > 1
+-- (derivative of geometric series)
+theorem n_div_pow_summable (t : ℝ) (ht : t > 1) :
+    Summable (fun n : ℕ => (n : ℝ) / t ^ n) := by
+  sorry
+
+-- Routine: t^n - 1 > 0 for t > 1, n ≥ 1
+theorem pow_sub_one_pos (t : ℝ) (n : ℕ) (ht : t > 1) (hn : n ≥ 1) :
+    t ^ n - 1 > 0 := by
+  sorry
+
+-- Routine: 1/(t^n - 1) ≤ 2/t^n for t ≥ 2, n ≥ 1
+-- (since t^n - 1 ≥ t^n / 2)
+theorem inv_pow_sub_one_bound (t : ℝ) (n : ℕ) (ht : t ≥ 2) (hn : n ≥ 1) :
+    1 / (t ^ n - 1) ≤ 2 / t ^ n := by
+  sorry
+
+-- Routine: τ(n) ≤ n (number of divisors bounded by n)
+theorem tau_le_self (n : ℕ) : tau n ≤ n := by
+  sorry
+
+-- Routine: If transcendental, then irrational
+-- (transcendental numbers are not algebraic, rational numbers are algebraic)
+theorem transcendental_implies_irrational (x : ℝ) (h : ¬IsAlgebraic ℚ x) :
+    Irrational x := by
+  sorry
+
+end Erdos1049Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #1049 (Irrationality of Divisor Sums) with 8 routine supporting lemmas for automated proof search.

## Evidence

**Before**: No Aristotle companion file; 12 sorries in main file with no automated proof pipeline
**After**: 8 routine sorries extracted into `Erdos1049Aristotle.lean` for Aristotle to attempt:
- `tau_multiplicative` — multiplicativity of divisor function for coprime arguments
- `geometric_inverse_pow` — geometric series for 1/t^d terms
- `inv_pow_summable` — summability of 1/t^n for t > 1
- `n_div_pow_summable` — summability of n/t^n for t > 1
- `pow_sub_one_pos` — t^n - 1 > 0 for t > 1, n ≥ 1
- `inv_pow_sub_one_bound` — 1/(t^n - 1) ≤ 2/t^n for t ≥ 2
- `tau_le_self` — τ(n) ≤ n
- `transcendental_implies_irrational` — not algebraic → irrational

All checklist items pass: no definition sorries, no axioms, no True placeholders, no `/-!` sections.

---
Automated fix by lean-mechanic agent.