### PR TITLE
Research: erdos-25 - Eliminate sieved_set_nonempty axiom, prove structural lemmas

### DIFF
--- a/proofs/Proofs/Erdos25Problem.lean
+++ b/proofs/Proofs/Erdos25Problem.lean
@@ -16,8 +16,7 @@ m < nᵢ or m ≢ aᵢ (mod nᵢ). Must the logarithmic density of A exist?
 import Mathlib.Data.Nat.Basic
 import Mathlib.Order.Filter.Basic
 import Mathlib.Topology.Basic
-import Mathlib.Data.Int.ModCast
-import Mathlib.Data.Int.Lemmas
+import Mathlib.Data.Int.ModEq
 import Mathlib.Tactic
 
 /-
@@ -89,13 +88,33 @@ axiom finite_sieve_density_exists (σ : CongruenceSieve) (N : ℕ)
 def erdos_486_implies_25 (h486 : ErdosProblem25) : ErdosProblem25 := h486
 
 /-
-## Section V: Density Bounds
+## Section V: Basic Membership and Density Bounds
 -/
 
-/-- The sieved set is nonempty: small integers pass all conditions
-since they are less than the first modulus. -/
-axiom sieved_set_nonempty (σ : CongruenceSieve) :
-  ∃ m : ℕ, m ∈ sievedSet σ ∧ m > 0
+/-- Zero is always in the sieved set: 0 < every modulus (from moduli_pos). -/
+theorem zero_in_sieved (σ : CongruenceSieve) : 0 ∈ sievedSet σ := by
+  intro i
+  left
+  exact_mod_cast σ.moduli_pos i
+
+/-- Any m less than the first modulus is in the sieved set, since
+    strict monotonicity gives m < seq_n 0 ≤ seq_n i for all i. -/
+theorem small_in_sieved (σ : CongruenceSieve) (m : ℕ) (hm : (m : ℤ) < σ.seq_n 0) :
+    m ∈ sievedSet σ := by
+  intro i
+  left
+  calc (m : ℤ) < σ.seq_n 0 := hm
+    _ ≤ σ.seq_n i := by exact_mod_cast σ.strictly_mono.monotone (Nat.zero_le i)
+
+/-- The sieved set contains a positive element when the first modulus is ≥ 2.
+    Note: if seq_n 0 = 1, the sieved set contains only 0 among non-negative integers,
+    since mod 1 every integer is congruent, so no m ≥ 1 can avoid the first sieve.
+    (Previously axiomatized without the seq_n 0 ≥ 2 hypothesis, which was unsound.) -/
+theorem sieved_set_nonempty (σ : CongruenceSieve) (h : σ.seq_n 0 ≥ 2) :
+    ∃ m : ℕ, m ∈ sievedSet σ ∧ m > 0 := by
+  refine ⟨1, small_in_sieved σ 1 ?_, Nat.one_pos⟩
+  have : (1 : ℕ) < σ.seq_n 0 := by omega
+  exact_mod_cast this
 
 /-- Each individual congruence class excludes at most a 1/nᵢ fraction.
 The sieved set has positive logarithmic density when it exists. -/

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 25,
     "erdosUrl": "https://erdosproblems.com/25",
     "erdosProblemStatus": "open",
-    "axiomCount": 6,
-    "lineCount": 118,
-    "assumptions": "6 axioms: logDensity, logDensity_mem_unit, logDensity_unique, and 3 more. See Lean source for complete statements.",
+    "axiomCount": 5,
+    "lineCount": 137,
+    "assumptions": "5 axioms: logDensity (opaque predicate), logDensity_mem_unit, logDensity_unique, finite_sieve_density_exists, sieve_density_positive. Previously 6: sieved_set_nonempty eliminated (proved as theorem with corrected hypothesis).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-25.json
+++ b/src/data/research/problems/erdos-25.json
@@ -19,7 +19,7 @@
     "phase": "ACT",
     "since": "2026-01-12T04:34:21.348Z",
     "iteration": 2,
-    "focus": "Axiom elimination in log density formalization",
+    "focus": "Axiom elimination: proved sieved_set_nonempty (was buggy axiom)",
     "blockers": [],
     "nextAction": "Continue proving remaining axioms (logDensity_evens, naturalDensity_implies_logDensity)",
     "attemptCounts": {
@@ -29,41 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved logDensity_odds by complementation (evens+full→odds). LogDensity.lean now has 5 axioms (down from 6). Total: 5 axioms in LogDensity + 6 in Problem = 11. Combined with prior session: eliminated 4 axioms total across sessions.",
+    "progressSummary": "PROGRESS: Eliminated sieved_set_nonempty axiom (was unsound, proved with corrected hypothesis). Added zero_in_sieved and small_in_sieved theorems. Fixed stale import. Axioms: 6→5, Theorems: 1→4.",
     "builtItems": [
-      "Proved logWeightedCount_nonneg in Erdos25LogDensity.lean",
-      "Proved logWeightedCount_mono in Erdos25LogDensity.lean",
-      "Proved logWeightedCount_le_harmonicSum in Erdos25LogDensity.lean",
-      "Proved logDensityRatio_nonneg in Erdos25LogDensity.lean",
-      "Proved logDensityRatio_mono in Erdos25LogDensity.lean",
-      "Proved logDensityRatio_le_harmonic_ratio in Erdos25LogDensity.lean",
-      "Proved logDensityRatio_eventually_le_two in Erdos25LogDensity.lean",
-      "Proved logDensityRatio_isBoundedUnder in Erdos25LogDensity.lean",
-      "Proved logDensityRatio_isCoboundedUnder in Erdos25LogDensity.lean",
-      "Proved logDensityRatio_isBoundedUnder_ge in Erdos25LogDensity.lean",
-      "Converted upperLogDensity_mono from axiom to theorem in Erdos25LogDensity.lean",
-      "Converted hasLogDensity_iff_eq from axiom to theorem in Erdos25LogDensity.lean",
-      "Fixed incorrect logDensityRatio_bounded axiom (upper bound ≤1 was false for H_N/log N > 1)",
-      "Proved logDensity_odds from logDensity_evens + logDensity_full (axiom: 6→5 in LogDensity.lean)",
-      "Added logWeightedCount_union_disjoint: splitting lemma for disjoint unions",
-      "Added even_odd_partition: ℕ⁺ = evens⁺ ∪ odds",
-      "Added even_odd_disjoint: evens and odds are disjoint"
+      "zero_in_sieved: proved 0 ∈ sievedSet σ always (Erdos25Problem.lean:95)",
+      "small_in_sieved: proved m < seq_n 0 → m ∈ sievedSet σ (Erdos25Problem.lean:102)",
+      "sieved_set_nonempty: PROVED (was axiom, added hypothesis seq_n 0 ≥ 2) (Erdos25Problem.lean:113)",
+      "Fixed stale import: Mathlib.Data.Int.ModCast → Mathlib.Data.Int.ModEq"
     ],
     "insights": [
-      "The axiom logDensityRatio_bounded claiming ratio ≤ 1 for N ≥ 2 is mathematically incorrect since H_N/log N > 1 for all finite N (converges to 1 from above due to Euler-Mascheroni constant)",
-      "Filter.IsCoboundedUnder (· ≤ ·) and Filter.IsBoundedUnder (· ≥ ·) are different types in Mathlib despite both representing lower bounds conceptually",
-      "tendsto_of_le_liminf_of_limsup_le needs IsBoundedUnder (· ≤ ·) and IsBoundedUnder (· ≥ ·), not IsCoboundedUnder",
-      "div_le_div_right and div_le_div_iff are not available in current Mathlib; use div_eq_mul_inv + mul_le_mul_of_nonneg_right instead",
-      "logDensity_odds is derivable from logDensity_evens + logDensity_full via complementation",
-      "logWeightedCount splits additively over disjoint unions",
-      "Even/odd exclusivity proved by omega on Nat existential forms",
-      "Tendsto.congr requires EventuallyEq direction matching; use .mono with eq.symm"
+      "sieved_set_nonempty axiom was unsound: false when seq_n 0 = 1 (mod 1 excludes everything)",
+      "Fixed: added hypothesis seq_n 0 ≥ 2, proved via small_in_sieved with m=1",
+      "zero_in_sieved is trivially true: 0 < every modulus (from moduli_pos)",
+      "small_in_sieved proved: any m < seq_n 0 passes all sieve conditions (strict mono)",
+      "Import Mathlib.Data.Int.ModCast was stale — replaced with Mathlib.Data.Int.ModEq",
+      "Remaining 5 axioms: 3 are opaque predicate properties (logDensity), 1 is deep (finite_sieve), 1 is deep (density_positive)",
+      "LogDensity companion file (Erdos25LogDensity.lean) has proper definitions + many proved theorems — much richer formalization"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove logDensity_evens: even numbers have log density 1/2 (requires harmonic sum splitting)",
-      "Prove naturalDensity_implies_logDensity via summation by parts",
-      "Reduce axiom count in Erdos25Problem.lean (6 axioms, some overlap with LogDensity file)"
+      "Consider defining logDensity concretely (using LogDensity files HasLogDensity) to eliminate opaque predicate axioms",
+      "finite_sieve_density_exists could be proved if logDensity was concrete (periodicity argument)",
+      "Merge insights from Erdos25LogDensity.lean into main file for unified formalization"
     ],
     "markdown": "# Erdős #25 - Knowledge Base\n\n## Problem Statement\n\nLet $n_1 View the LaTeX source\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #486\n- Problem #24\n- Problem #26\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er95\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },


### PR DESCRIPTION
## Summary
- **Eliminated axiom**: `sieved_set_nonempty` was unsound (false when `seq_n 0 = 1`, since mod 1 excludes everything). Replaced with theorem requiring `seq_n 0 ≥ 2`.
- **Proved 3 new theorems**: `zero_in_sieved`, `small_in_sieved`, `sieved_set_nonempty` (corrected)
- **Fixed stale import**: `Mathlib.Data.Int.ModCast` → `Mathlib.Data.Int.ModEq` (build was broken)
- Axioms: 6→5, Theorems: 1→4

## Files Modified
- `proofs/Proofs/Erdos25Problem.lean` - axiom elimination + new theorems + import fix
- `src/data/proofs/erdos-25/meta.json` - Updated stats
- `src/data/research/problems/erdos-25.json` - Knowledge update

## Status
**Outcome**: completed
**Docker build**: passed

🤖 Generated by researcher-2