### PR TITLE
Audit fix: 4 overclaiming proofs (True stubs, sorry mismatch)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1345,6 +1345,30 @@
       "lastAudited": "2026-03-24T09:02:30Z",
       "result": "clean",
       "issues": []
+    },
+    "pac-learning-bounds": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T09:12:59Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-1149": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T09:12:59Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "prob-method-alteration": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T09:14:03Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "prob-method-applications": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T09:14:03Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   }
 }

--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -19,7 +19,7 @@
       "zeta-function"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 3,
     "axioms": 2,
     "erdosNumber": 1149,
     "erdosUrl": "https://erdosproblems.com/1149",
@@ -87,10 +87,10 @@
       "Divisibility and powers (dvd_pow_self)"
     ],
     "lineCount": 218,
-    "assumptions": "2 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "2 axioms (bergelson_richter, random_coprime_density) and 3 sorries (routine Finset counting lemmas). The main density theorem is axiomatized; the sorries are in supporting coprime pair counting infrastructure."
   },
   "overview": {
-    "summary": "Formalizes Erdős Problem #1149, solved by Bergelson and Richter (2017): for non-integer α > 0, the natural density of integers n with gcd(n, ⌊n^α⌋) = 1 is exactly 6/π². The main theorem is axiomatized (deep ergodic theory), with 13 proved theorems: density bounds, coprime set properties (nonemptiness, n=1 membership, floor=1 criterion), HasNaturalDensity reformulation, coprime pair counting infrastructure, and integer exponent exclusion. 218 lines, 0 sorries, 2 axioms.",
+    "summary": "Formalizes Erdős Problem #1149, solved by Bergelson and Richter (2017): for non-integer α > 0, the natural density of integers n with gcd(n, ⌊n^α⌋) = 1 is exactly 6/π². The main theorem is axiomatized (deep ergodic theory), with 13 proved theorems: density bounds, coprime set properties (nonemptiness, n=1 membership, floor=1 criterion), HasNaturalDensity reformulation, coprime pair counting infrastructure, and integer exponent exclusion. 218 lines, 3 sorries, 2 axioms.",
     "keyIdea": "The value 6/π² = 1/ζ(2) is the probability that two 'random' integers are coprime. The Bergelson-Richter theorem shows that n and ⌊n^α⌋ achieve exactly this coprime density despite being deterministically related — the floor-power function acts as a 'pseudorandom' generator for coprimality. The integer case is degenerate (gcd(n, n^k) = n), making the non-integer hypothesis essential.",
     "historicalContext": "Erdős asked whether $n$ and $\\lfloor n^\\alpha \\rfloor$ (for irrational $\\alpha > 1$) are coprime with natural density $6/\\pi^2 = 1/\\zeta(2) \\approx 0.6079$. This value is the classical probability that two uniformly random integers are coprime, first computed by Cesàro (1881) and Sylvester using Euler's product formula $\\prod_p (1 - 1/p^2) = 6/\\pi^2$.\n\nThe difficulty lies in the deterministic structure of the sequence $\\lfloor n^\\alpha \\rfloor$: unlike random integers, it has specific arithmetic properties that could bias coprimality. Vitaly Bergelson and Florian K. Richter (2017) proved Erdős's conjecture affirmatively, showing that the coprimality density is indeed $6/\\pi^2$ for any irrational $\\alpha > 1$. Their proof uses the theory of multiplicative functions along polynomial sequences and results from ergodic theory, establishing that the 'randomness' expectation holds for this structured sequence.",
     "problemStatement": "**Erdős Problem #1149** (SOLVED): Let $\\alpha > 0$ be a non-integer. Then\n$$\\lim_{N \\to \\infty} \\frac{|\\{n \\leq N : \\gcd(n, \\lfloor n^\\alpha \\rfloor) = 1\\}|}{N} = \\frac{6}{\\pi^2}.$$",

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -7,7 +7,7 @@
     "author": "Vapnik-Chervonenkis (1971), Valiant (1984), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
     "date": "1984",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/PACLearning.lean",
     "tags": [
       "learning-theory",
@@ -16,7 +16,7 @@
       "cs-math-bridge",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -36,11 +36,11 @@
       }
     ],
     "originalContributions": [
-      "VC dimension definition and shattering formalization",
-      "Sauer-Shelah lemma with polynomial growth bound",
-      "PAC learning framework with sample complexity",
-      "Fundamental theorem of statistical learning",
-      "Connection between combinatorial dimension and learnability"
+      "choose_le_pow: C(n,k) ≤ n^k via descFactorial",
+      "sauer_shelah_bound: ∑ C(n,i) ≤ (n+1)^d via binomial theorem",
+      "pac_sample_complexity: sample size bound statement (trivial existence witness)",
+      "NOTE: growthFunction is a placeholder (returns 0), making sauer_shelah trivially true",
+      "NOTE: fundamental_theorem_stat_learning is a True stub placeholder"
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
@@ -52,7 +52,7 @@
       "Concentration inequalities (Hoeffding, Chernoff)",
       "Uniform convergence and generalization bounds"
     ],
-    "assumptions": "1 axiom(s) and 3 sorry(s). See the Lean source for details.",
+    "assumptions": "0 axioms, 0 sorries. However, key results are placeholders: growthFunction returns 0 (making sauer_shelah trivially true), pac_sample_complexity has a trivial existence witness, and fundamental_theorem_stat_learning is a True stub. Only choose_le_pow and sauer_shelah_bound are substantive proofs.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdos, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1960",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ProbMethodAlteration.lean",
     "tags": [
       "probabilistic-method",
@@ -15,7 +15,7 @@
       "graph-theory",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -35,9 +35,9 @@
       }
     ],
     "originalContributions": [
-      "Alteration principle formalization for finite structures",
-      "Independent set lower bound via vertex deletion",
-      "Property B existence proof via hypergraph coloring"
+      "alteration_principle: genuine proof by contradiction via Finset.sum_le_sum",
+      "independent_set_bound: trivial existence witness (max, not graph-theoretic)",
+      "property_b_bound: True stub placeholder (needs hypergraph type)"
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos and collaborators, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1947",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ProbMethodApplications.lean",
     "tags": [
       "probabilistic-method",
@@ -16,7 +16,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -41,11 +41,12 @@
       }
     ],
     "originalContributions": [
-      "Unified probabilistic method application suite",
-      "Ramsey number lower bounds via multiple techniques",
-      "Chromatic number bounds via expectation and alteration",
-      "Property B results for uniform hypergraphs",
-      "Independent set bounds connecting all four probabilistic methods"
+      "crossing_number_bound: genuine proof that e³/(64n²) > 0 via nlinarith",
+      "property_b_lower: proves 2^(k-1) > 0 (basic positivity)",
+      "ramsey_lower_bound: trivial existence witness (le_refl)",
+      "tournament_domination: trivial existence witness",
+      "unbalancing_lights: trivial existence witness",
+      "high_girth_high_chromatic: True stub placeholder"
     ],
     "dateAdded": "2026-03-21",
     "prerequisites": [


### PR DESCRIPTION
## Summary

- Fixed 3 proofs falsely claiming `"verified"` status despite containing True stubs / trivial witnesses
- Fixed 1 proof with sorry count mismatch (claimed 0, actual 3)

## CRITICAL Fixes

| Proof | Issue | Fix |
|-------|-------|-----|
| pac-learning-bounds | `fundamental_theorem_stat_learning: True := trivial`, `growthFunction` returns 0 | status: verified→formalized, badge: verified→wip |
| prob-method-alteration | `property_b_bound: True := trivial` | status: verified→formalized, badge: verified→wip |
| prob-method-applications | `high_girth_high_chromatic: True := trivial` + trivial witnesses | status: verified→formalized, badge: verified→wip |

## HIGH Fix

| Proof | Issue | Fix |
|-------|-------|-----|
| erdos-1149 | `sorries: 0` but 3 actual sorry keywords in Lean file | sorries: 0→3, updated assumptions text |

## Test plan

- [x] Verified sorry/axiom counts match actual Lean source files
- [x] Updated originalContributions to honestly describe proof content
- [ ] Verify gallery build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)