### PR TITLE
Fix: erdos-1149 sorry count mismatch (0 → 3)

### DIFF
--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -19,7 +19,7 @@
       "zeta-function"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 3,
     "axioms": 2,
     "erdosNumber": 1149,
     "erdosUrl": "https://erdosproblems.com/1149",
@@ -205,6 +205,7 @@
     "namespace": "Erdos1149",
     "lineCount": 218,
     "axiomCount": 2,
+    "sorryCount": 3,
     "theoremCount": 13,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Fix

Update erdos-1149 meta.json sorry count from 0 to 3, matching the actual Lean source file.

## Evidence

**Before**: `meta.sorries: 0`, no `leanFile.sorryCount` field
**After**: `meta.sorries: 3`, `leanFile.sorryCount: 3` — matches 3 sorries at lines 236, 241, 247

Closes #5849

---
Automated fix by lean-mechanic agent.