### PR TITLE
Enrich 3 proofs: erdos-1013, erdos-10, erdos-1019

### DIFF
--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -4,7 +4,7 @@
   "slug": "erdos-1019",
   "description": "Does every graph on n vertices with ⌊n²/4⌋ + ⌊(n+1)/2⌋ edges contain a saturated planar graph with more than 3 vertices? Simonovits proved yes: such graphs must contain K₄ or C_l + 2K₁.",
   "meta": {
-    "author": "Simonovits (PhD thesis)",
+    "author": "Miklós Simonovits (PhD thesis, supervised by Turán)",
     "sourceUrl": "https://erdosproblems.com/1019",
     "date": "1970s",
     "status": "formalized",
@@ -16,7 +16,7 @@
       "extremal-combinatorics",
       "turan-theory"
     ],
-    "badge": "pending",
+    "badge": "formalized",
     "sorries": 5,
     "erdosNumber": 1019,
     "erdosUrl": "https://erdosproblems.com/1019",
@@ -132,7 +132,7 @@
   ],
   "conclusion": {
     "summary": "This formalization captures Erdős Problem #1019 on saturated planar subgraphs in dense graphs in a ~290-line Lean file spanning 12 sections. The framework defines saturated planarity ($|E| = 3|V| - 6$), the edge density threshold $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor$, and the two forced structures ($K_4$ and $C_\\ell + 2K_1$). Simonovits's theorem is axiomatized and used to derive the affirmative answer. The threshold is proved tight within 1 edge, with 5 sorries and several axioms encoding deep results.",
-    "implications": "**Theoretical Significance**: This result connects several major themes in graph theory:\n\n1. **Supersaturation in extremal graph theory**: Beyond the Turán threshold, not only do forbidden subgraphs appear, but *topologically rich* (saturated planar) subgraphs are forced. This is a bridge between extremal combinatorics and topological graph theory.\n\n2. **Simonovits stability program**: The result is an early example of the structure-theoretic approach to extremal problems: rather than just counting edges, it characterizes *which* structures must appear.\n\nThis anticipates the Szemerédi regularity lemma (1975) and the graph removal lemma.\n\n3. **Threshold phenomena**: The 1-edge gap between construction and forcing is a sharp threshold phenomenon, analogous to phase transitions in random graph theory (Erdős-Rényi model). Such precise thresholds are rare and mathematically significant.\n\n4. **Formalization challenges**: The `isPlanar` definition as `sorry` highlights a concrete gap in Mathlib: topological planarity (via Kuratowski's theorem or planar embeddings) is not yet formalized. This is an active target for the formalization community.",
+    "implications": "**Theoretical Significance**: This result connects several major themes in graph theory:\n\n1. **Supersaturation in extremal graph theory**: Beyond the Turán threshold $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$, not only do forbidden subgraphs appear, but *topologically rich* (saturated planar) subgraphs are forced. The critical threshold is $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor$, and the quantitative bound shows forced subgraphs on $\\Omega(k/n)$ vertices when the graph has $\\lfloor n^2/4 \\rfloor + k$ edges. This bridges extremal combinatorics and topological graph theory.\n\n2. **Simonovits stability program**: The $K_4 \\lor C_\\ell + 2K_1$ dichotomy is an early example of the structure-theoretic approach to extremal problems. Rather than just counting edges, it characterizes *which* structures must appear. Both forced structures satisfy $|E| = 3|V| - 6$ exactly: $K_4$ with $6 = 3(4) - 6$ and $C_\\ell + 2K_1$ with $3\\ell = 3(\\ell + 2) - 6$. This anticipates the Szemerédi regularity lemma (1975) and the graph removal lemma.\n\n3. **Threshold phenomena**: The identity $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor = \\lfloor n^2/4 \\rfloor + \\lfloor(n-1)/2\\rfloor + 1$ (proved by `omega`) establishes a 1-edge gap between construction and forcing. This is a sharp threshold phenomenon analogous to phase transitions in the Erdős-Rényi model $G(n,p)$. Such precise thresholds are rare and mathematically significant.\n\n4. **Formalization challenges**: The `isPlanar` definition as `sorry` highlights a concrete gap in Mathlib: topological planarity (via Kuratowski's theorem — $G$ is planar iff it has no $K_5$ or $K_{3,3}$ subdivision) is not yet formalized. The Four Color Theorem, which implies $\\chi(G) \\le 4$ for planar $G$, is another deep result awaiting formalization. These are active targets for the formalization community.",
     "openQuestions": [
       "Can Simonovits's proof be made fully constructive, yielding a polynomial-time algorithm to find $K_4$ or $C_\\ell + 2K_1$ in dense graphs?",
       "What is the analogous threshold for forcing saturated graphs on other surfaces (torus: $|E| \\le 3|V| + 3$; projective plane: $|E| \\le 3|V| - 3$)?",
@@ -165,6 +165,10 @@
     {
       "relation": "The Erdős Matching Conjecture — neighboring problem in the Erdős catalogue sharing the extremal-combinatorics tag and the Turán-type threshold framework. Both ask for the precise edge/structure threshold in the hypergraph/graph setting.",
       "targetId": "erdos-1020"
+    },
+    {
+      "relation": "Four Color Theorem — the deepest result about planar graph structure. Problem #1019 forces saturated planar subgraphs (maximal planar graphs / triangulations), which are exactly the graphs for which the Four Color Theorem is hardest. The `isPlanar` definition left as `sorry` in this formalization connects to the broader challenge of formalizing planarity that the Four Color Theorem also requires.",
+      "targetId": "four-color-theorem"
     }
   ],
   "relatedProofs": [
@@ -232,6 +236,18 @@
       "year": 1978,
       "publisher": "Academic Press",
       "note": "Comprehensive treatment of Turán-type and supersaturation problems; includes the Erdős-Simonovits stability results and the supersaturation regime directly relevant to Problem #1019."
+    },
+    {
+      "authors": [
+        "P. Erdős",
+        "M. Simonovits"
+      ],
+      "title": "Supersaturated graphs and hypergraphs",
+      "venue": "Combinatorica",
+      "year": 1983,
+      "volume": 3,
+      "pages": "181–192",
+      "note": "General supersaturation framework: if ex(n, H) is exceeded by cn² edges, then the number of copies of H is Ω(n^{|V(H)|}). The supersaturation regime studied in Problem #1019 is a topological variant of this principle."
     }
   ],
   "leanFile": {
@@ -248,6 +264,20 @@
     "lineCount": 316,
     "axiomCount": 8,
     "theoremCount": 8,
-    "definitionCount": 18
-  }
+    "definitionCount": 19
+  },
+  "mathlibDependencies": [
+    "Mathlib.Combinatorics.SimpleGraph.Basic",
+    "Mathlib.Combinatorics.SimpleGraph.Subgraph",
+    "Mathlib.Data.Real.Basic",
+    "Mathlib.Data.Fintype.Basic"
+  ],
+  "originalContributions": [
+    "Framework for saturated planarity: defines `isSaturatedPlanar` and derives basic properties",
+    "Complete encoding of the edge density threshold $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor$",
+    "Formal statement of the $K_4$ vs $C_\\ell + 2K_1$ dichotomy (Simonovits's theorem)",
+    "Machine-checked derivation of `erdos_1019_solved` from the axiomatized dichotomy",
+    "Proof of the 1-edge threshold gap via `omega`",
+    "Definition of `completeBipartite` on `Fin m ⊕ Fin n` with adjacency between parts"
+  ]
 }


### PR DESCRIPTION
Enrichment batch for erdos-1013, erdos-10, and erdos-1019.

## erdos-1013 (Triangle-Free Graphs and Chromatic Number)
- Expanded assumptions to list all 11 axioms
- Added mathlibDependencies, originalContributions
- Added Kim (1995) reference, deepened conclusion

## erdos-10 (Representations as p + 2^k)
- Added mathlibDependencies, originalContributions
- Added cross-references: PNT, Dirichlet's theorem
- Added references: Habsieger-Roblot, Pintz-Ruzsa

## erdos-1019 (Saturated Planar Subgraphs)
- Fixed badge "pending"→"formalized", definitionCount 18→19
- Added mathlibDependencies, originalContributions
- Added four-color-theorem cross-reference
- Deepened conclusion with extremal bounds and planarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)