### PR TITLE
Enrich 5 proofs: PNT, bertrands-postulate, fourier-series, taylor-theorem + earlier

### DIFF
--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -78,7 +78,8 @@
       "Open and closed disks have the same area because the boundary circle has Lebesgue measure zero — a fundamental property of lower-dimensional manifolds in measure theory",
       "The general $n$-dimensional ball volume formula $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2 + 1)$ specializes to $\\pi r^2$ for $n = 2$ via $\\Gamma(2) = 1$",
       "Archimedes' method of exhaustion — approximating the disk by inscribed/circumscribed polygons — is the historical precursor to the Riemann integral, which in turn is subsumed by the Lebesgue integral used in this formalization",
-      "The area formula explains why $\\pi$ appears in the Gaussian integral $\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}$: squaring and converting to polar coordinates gives $\\iint e^{-(x^2+y^2)} dx\\,dy = \\int_0^{2\\pi}\\int_0^{\\infty} e^{-r^2} r\\,dr\\,d\\theta = \\pi$, where the Jacobian factor $r$ is exactly $dA/dr\\,d\\theta = r$ from the polar form of $A = \\pi r^2$"
+      "The area formula explains why $\\pi$ appears in the Gaussian integral $\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}$: squaring and converting to polar coordinates gives $\\iint e^{-(x^2+y^2)} dx\\,dy = \\int_0^{2\\pi}\\int_0^{\\infty} e^{-r^2} r\\,dr\\,d\\theta = \\pi$, where the Jacobian factor $r$ is exactly $dA/dr\\,d\\theta = r$ from the polar form of $A = \\pi r^2$",
+      "**Scaling and dimensional analysis**: $A = \\pi r^2$ encodes the fact that area scales quadratically with length. Under a dilation $z \\mapsto cz$, the Lebesgue measure transforms as $\\lambda^2(cS) = c^2 \\lambda^2(S)$ (since $\\lambda^2$ is the product measure $\\lambda \\otimes \\lambda$ and each factor scales linearly). The formula $A = \\pi r^2 = \\pi \\cdot (\\text{radius})^2$ thus separates into a shape factor ($\\pi$, encoding the specific geometry of a circle vs a square) and a scale factor ($r^2$, universal for any 2D shape). In Lean, this separation is implicit: `ENNReal.ofReal r ^ 2` captures the scale and `NNReal.pi` captures the shape"
     ],
     "prerequisites": [
       "Real analysis (integration, limits)",
@@ -220,6 +221,11 @@
       "targetId": "e-transcendental",
       "relationship": "related",
       "description": "The transcendence of $e$ connects to the circle area formula through the Gaussian integral: $\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}$, proved by squaring and converting to polar coordinates where the area element $r\\, dr\\, d\\theta$ derives from $A = \\pi r^2$. The appearance of both $e$ and $\\pi$ in this integral reflects their deep algebraic independence (both transcendental) and analytic interconnection via the complex exponential $e^{i\\theta}$"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} = -1$ connects to the circle area formula through the complex plane: this formalization uses $\\mathbb{C}$ as its ambient space precisely because the unit circle $\\{z : |z| = 1\\}$ is parameterized by $e^{i\\theta}$ for $\\theta \\in [0, 2\\pi)$. The area enclosed by this exponential curve is $\\pi \\cdot 1^2 = \\pi$ (the `area_unit_disk` corollary). More deeply, $e^{i\\pi} = -1$ encodes the half-turn symmetry of the circle, and the appearance of $\\pi$ in both the area formula and the exponential reflects $\\pi$'s dual role as a geometric constant (area-to-radius-squared ratio) and an analytic period (half-period of $e^{i\\theta}$)"
     }
   ],
   "relatedProofs": [
@@ -238,7 +244,8 @@
     "lebesgue-measure",
     "fundamental-theorem-calculus",
     "stirling-formula",
-    "e-transcendental"
+    "e-transcendental",
+    "euler-identity"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -273,6 +273,16 @@
       "targetId": "dirichlets-theorem",
       "relationship": "extends",
       "description": "Dirichlet's theorem on primes in arithmetic progressions (1837) uses Dirichlet $L$-functions $L(s, \\chi) = \\sum \\chi(n) n^{-s}$, which generalize the Riemann zeta function $\\zeta(s) = \\sum n^{-s}$ whose simplest non-trivial value is the Basel identity $\\zeta(2) = \\pi^2/6$. Euler's product formula for $\\zeta$ inspired Dirichlet's product formula for $L$-functions, extending the connection between arithmetic and analysis that the Basel problem first revealed"
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "The area formula $A = \\pi r^2$ and the Basel identity $\\zeta(2) = \\pi^2/6$ both reveal $\\pi$ in seemingly unrelated contexts. The connection runs deep: the Gaussian integral $\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$ (proved via the area formula's polar coordinate change of variables) is closely related to the functional equation of $\\zeta(s)$, which maps $\\zeta(2) = \\pi^2/6$ to the behavior of $\\zeta$ at negative integers via $\\Gamma(s/2)\\pi^{-s/2}\\zeta(s)$"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The Central Limit Theorem's Gaussian density $\\frac{1}{\\sqrt{2\\pi}} e^{-x^2/2}$ contains $\\pi$ for the same deep reason as the Basel identity: the Fourier transform of the Gaussian is itself Gaussian, and $\\zeta(2) = \\pi^2/6$ emerges from Parseval's theorem applied to periodic functions — both results flow from the self-duality of the Gaussian under Fourier analysis"
     }
   ],
   "relatedProofs": [
@@ -290,7 +300,9 @@
     "prime-number-theorem",
     "e-transcendental",
     "stirling-formula",
-    "dirichlets-theorem"
+    "dirichlets-theorem",
+    "area-of-circle",
+    "central-limit-theorem"
   ],
   "leanFile": {
     "imports": [

--- a/src/data/proofs/bertrands-postulate/annotations.json
+++ b/src/data/proofs/bertrands-postulate/annotations.json
@@ -127,6 +127,49 @@
     "prerequisites": []
   },
   {
+    "id": "ann-corollaries-section",
+    "proofId": "bertrands-postulate",
+    "range": {
+      "startLine": 63,
+      "endLine": 76
+    },
+    "type": "technique",
+    "title": "Alternative Name and Existence Corollary",
+    "content": "`bertrand` provides an alias using Mathlib's `Nat.bertrand` (vs `Nat.exists_prime_lt_and_le_two_mul` in the main theorem). `exists_prime_between` is a trivial corollary repackaging the main theorem for the common use case $n \\geq 1$.\n\nHistorically, Bertrand conjectured this in 1845 based on checking primes up to 6,000,000. Chebyshev gave the first proof in 1852 using bounds on $\\theta(x) = \\sum_{p \\leq x} \\ln p$. Erdős gave a celebrated elementary proof in 1932 (at age 19) using properties of $\\binom{2n}{n}$.",
+    "mathContext": "Bertrand's postulate: $\\forall n \\geq 1, \\exists p \\text{ prime}, n < p \\leq 2n$. The PNT strengthens this: $\\pi(2n) - \\pi(n) \\sim n/\\ln n$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "bertrand_postulate"
+    ],
+    "relatedConcepts": [
+      "Chebyshev's theorem",
+      "Erdős's proof",
+      "central binomial coefficient"
+    ]
+  },
+  {
+    "id": "ann-no-largest-bertrand",
+    "proofId": "bertrands-postulate",
+    "range": {
+      "startLine": 99,
+      "endLine": 113
+    },
+    "type": "insight",
+    "title": "No Largest Prime via Bertrand and Proof Architecture",
+    "content": "`no_largest_prime_via_bertrand` derives prime infinitude from Bertrand — much stronger than Euclid's theorem.\n\nThe commentary explains Erdős's proof architecture: large $n$ ($\\geq 512$) uses $\\binom{2n}{n}$ analysis (primes in $(n,2n]$ divide $\\binom{2n}{n}$, and growth bounds force their existence), while small $n$ ($< 512$) is verified computationally via a descending chain of known primes.",
+    "mathContext": "Erdős's key bound: $\\binom{2n}{n} \\geq 4^n/(2n+1)$ grows exponentially, but if no prime existed in $(n,2n]$, $\\binom{2n}{n}$ would be bounded by $\\prod_{p \\leq n} p^{\\lfloor \\log_p(2n) \\rfloor}$ — polynomial growth, yielding a contradiction for large $n$.",
+    "significance": "key",
+    "prerequisites": [
+      "primes_infinite_via_bertrand",
+      "central binomial coefficient"
+    ],
+    "relatedConcepts": [
+      "Erdős's proof style",
+      "central binomial coefficient",
+      "prime factorization bounds"
+    ]
+  },
+  {
     "id": "ann-pnt-connection",
     "proofId": "bertrands-postulate",
     "range": {

--- a/src/data/proofs/fourier-series/annotations.json
+++ b/src/data/proofs/fourier-series/annotations.json
@@ -23,6 +23,56 @@
     ]
   },
   {
+    "id": "ann-fs-docstring",
+    "proofId": "fourier-series",
+    "range": {
+      "startLine": 8,
+      "endLine": 102
+    },
+    "type": "concept",
+    "title": "Module Overview: Fourier Series Theory (Wiedijk #76)",
+    "content": "A comprehensive 95-line docstring covering the full scope of Fourier series:\n\n**Classical statement**: Every periodic function $f$ with period $2\\pi$ can be represented as $f(x) = \\frac{a_0}{2} + \\sum_{n=1}^{\\infty}(a_n \\cos nx + b_n \\sin nx)$. The **complex exponential form** $f(x) = \\sum_{n=-\\infty}^{\\infty} c_n e^{inx}$ is more elegant.\n\n**Three convergence modes**: (1) $L^2$ convergence for all square-integrable functions (Parseval), (2) pointwise convergence under Dirichlet conditions (piecewise smooth), (3) uniform convergence with continuity + bounded variation.\n\n**Mathlib approach**: Fourier series are formalized on the additive circle $\\mathbb{R}/T\\mathbb{Z}$ (not just $[-\\pi,\\pi]$), using Haar measure as the canonical probability measure. The basis functions $e_n(x) = e^{2\\pi inx/T}$ are orthonormal in $L^2$.\n\n**Applications listed**: heat equation (Fourier's original motivation, 1807), signal processing (Shannon-Nyquist), quantum mechanics (wavefunctions), music theory (overtone series), image compression (JPEG via DCT).",
+    "mathContext": "Classical: $c_n = \\frac{1}{2\\pi}\\int_{-\\pi}^{\\pi} f(x)e^{-inx}\\,dx$. Parseval: $\\sum|c_n|^2 = \\frac{1}{2\\pi}\\int|f|^2\\,dx$. Mathlib: $c_n = \\text{fourierCoeff}(f, n) = \\int_{\\mathbb{R}/T\\mathbb{Z}} f(x)\\overline{e_n(x)}\\,d\\mu_{\\text{Haar}}(x)$.",
+    "significance": "key",
+    "prerequisites": [
+      "periodic functions",
+      "trigonometric series",
+      "L2 space",
+      "complex exponentials"
+    ],
+    "relatedConcepts": [
+      "Fourier transform",
+      "harmonic analysis",
+      "heat equation",
+      "signal processing",
+      "Dirichlet conditions"
+    ]
+  },
+  {
+    "id": "ann-fs-setup",
+    "proofId": "fourier-series",
+    "range": {
+      "startLine": 104,
+      "endLine": 126
+    },
+    "type": "context",
+    "title": "Setup: Noncomputable Section and Additive Circle",
+    "content": "The `noncomputable section` declares all definitions as noncomputable — necessary because Fourier coefficients involve integrals (which are not algorithmically computable in general). `maxHeartbeats 400000` extends the type-checker's computation budget for this file's heavier proofs.\n\nPart I introduces the **additive circle** $\\text{AddCircle}\\,T = \\mathbb{R}/T\\mathbb{Z}$ for positive period $T$. The normalized **Haar measure** `haarAddCircle` is the unique translation-invariant probability measure — the analog of uniform distribution on the circle. `IsProbabilityMeasure` ensures $\\mu(\\mathbb{R}/T\\mathbb{Z}) = 1$, which is why Fourier coefficients automatically normalize.",
+    "mathContext": "The additive circle $\\mathbb{R}/T\\mathbb{Z}$ is a compact abelian group. By Haar's theorem (1933), it admits a unique translation-invariant probability measure $\\mu$. For $T = 2\\pi$: $\\int_{\\mathbb{R}/2\\pi\\mathbb{Z}} 1\\,d\\mu = 1$, so $d\\mu = dx/(2\\pi)$ in classical notation.",
+    "significance": "supporting",
+    "prerequisites": [
+      "quotient groups",
+      "Haar measure",
+      "compact groups"
+    ],
+    "relatedConcepts": [
+      "additive circle",
+      "Haar measure",
+      "compact abelian group",
+      "noncomputable"
+    ]
+  },
+  {
     "id": "ann-fs-haar",
     "proofId": "fourier-series",
     "range": {

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -214,6 +214,21 @@
       "targetId": "isoperimetric-theorem",
       "relationship": "related",
       "description": "The isoperimetric inequality ($4\\pi A \\leq L^2$) can be proved using Fourier series: parametrize the curve, expand in Fourier series, and the constraint becomes an inequality on Fourier coefficients via Parseval"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "foundational",
+      "description": "Euler's formula $e^{ix} = \\cos x + i\\sin x$ is the foundation of the complex exponential form of Fourier series: the basis functions $e_n(x) = e^{2\\pi inx/T}$ are powers of the complex exponential. Every Fourier coefficient $c_n = \\int f(x) e^{-2\\pi inx/T}\\,dx$ uses this formula"
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "The Fourier basis functions $e^{in\\theta}$ parameterize circles in $\\mathbb{C}$ — each $e^{in\\theta}$ traces the unit circle $n$ times. The $L^2$ inner product on $\\mathbb{R}/2\\pi\\mathbb{Z}$ is integration over the circle, connecting Fourier analysis to the geometry of circles and the area formula $A = \\pi r^2$"
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "FTC underpins the computation of Fourier coefficients $c_n = \\int f e^{-inx}\\,dx$ and integration by parts, which shows that smoothness of $f$ implies faster decay of $c_n$: $f \\in C^k \\Rightarrow c_n = O(n^{-k})$"
     }
   ],
   "conclusion": {
@@ -246,6 +261,9 @@
     "prime-number-theorem",
     "basel-problem",
     "cauchy-schwarz",
-    "isoperimetric-theorem"
+    "isoperimetric-theorem",
+    "euler-identity",
+    "area-of-circle",
+    "fundamental-theorem-calculus"
   ]
 }

--- a/src/data/proofs/fundamental-theorem-algebra/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra/annotations.json
@@ -160,5 +160,102 @@
       "discriminant",
       "complex square roots"
     ]
+  },
+  {
+    "id": "ann-namespace-examples",
+    "proofId": "fundamental-theorem-algebra",
+    "range": {
+      "startLine": 42,
+      "endLine": 64
+    },
+    "type": "context",
+    "title": "Namespace Setup and Concrete Examples",
+    "content": "The `open Polynomial Complex` brings Mathlib's polynomial notation (`X`, `C`, `degree`, `IsRoot`) and complex number operations into scope. Two concrete examples ground the abstraction:\n\n1. **Degree computation**: `degree (X ^ 2 + 1 : ℂ[X]) = 2`, discharged by `simp` with `degree_add_eq_left_of_degree_lt` — the degree of a sum equals the degree of its highest-degree summand when the other terms are strictly lower.\n\n2. **Root verification**: `IsRoot (X ^ 2 + 1 : ℂ[X]) Complex.I`, proving that $i$ is a root of $z^2 + 1$. The proof evaluates: $i^2 + 1 = -1 + 1 = 0$, using `Complex.I_sq : I^2 = -1` and `norm_num`. This is the simplest instance of FTA: over $\\mathbb{R}$, $z^2 + 1$ has no roots, but over $\\mathbb{C}$ it factors as $(z-i)(z+i)$.",
+    "mathContext": "$z^2 + 1 = (z - i)(z + i)$ over $\\mathbb{C}$. The root $i = \\sqrt{-1}$ is the fundamental reason $\\mathbb{C}$ was invented: Cardano and Bombelli (c. 1545-1572) encountered $\\sqrt{-1}$ while solving cubics via the Cardano-Tartaglia formula, even when the final answers were real. The algebraic closure of $\\mathbb{R}$ requires only adjoining $i$: $\\mathbb{C} = \\mathbb{R}[i]/(i^2+1)$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Complex.I_sq",
+      "degree_add_eq_left_of_degree_lt",
+      "IsRoot definition"
+    ],
+    "relatedConcepts": [
+      "polynomial evaluation",
+      "degree computation",
+      "complex unit i",
+      "algebraic closure"
+    ]
+  },
+  {
+    "id": "ann-monic-prod-roots",
+    "proofId": "fundamental-theorem-algebra",
+    "range": {
+      "startLine": 142,
+      "endLine": 155
+    },
+    "type": "technique",
+    "title": "Complete Factorization: Monic Product of Root Factors",
+    "content": "`monic_prod_roots` proves the complete factorization theorem: every monic polynomial over $\\mathbb{C}$ equals the product of its root factors $(X - r)$, taken over the multiset of roots with multiplicity.\n\nThe proof:\n1. Obtain `Splits (RingHom.id ℂ) p` from `IsAlgClosed.splits_codomain` — every polynomial splits over $\\mathbb{C}$\n2. Show the root count equals the degree via `natDegree_eq_card_roots`\n3. Apply `prod_multiset_X_sub_C_of_monic_of_roots_card_eq` — Mathlib's factorization theorem for monic polynomials whose root count equals their degree\n\nThis is the constructive content of FTA: not just that roots *exist*, but that the polynomial *factors completely* into linear terms. Combined with `card_roots_eq_degree`, this gives the full picture: every degree-$n$ monic polynomial has exactly $n$ roots and factors as $\\prod_{i=1}^n (X - r_i)$.",
+    "mathContext": "For monic $p \\in \\mathbb{C}[X]$: $p = \\prod_{r \\in \\text{roots}(p)} (X - r)$, where $\\text{roots}(p)$ is a multiset of cardinality $\\deg(p)$. Comparing coefficients yields **Vieta's formulas**: $e_k(r_1, \\ldots, r_n) = (-1)^k a_{n-k}$, where $e_k$ is the $k$-th elementary symmetric polynomial.",
+    "significance": "key",
+    "prerequisites": [
+      "prod_multiset_X_sub_C_of_monic_of_roots_card_eq",
+      "IsAlgClosed.splits_codomain",
+      "natDegree_eq_card_roots"
+    ],
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "multiset of roots",
+      "complete factorization",
+      "monic polynomial"
+    ]
+  },
+  {
+    "id": "ann-why-this-matters",
+    "proofId": "fundamental-theorem-algebra",
+    "range": {
+      "startLine": 157,
+      "endLine": 172
+    },
+    "type": "insight",
+    "title": "Why FTA Matters: Algebraic Completeness of ℂ",
+    "content": "The commentary section explains four consequences of FTA:\n\n1. **Algebraic completeness**: $\\mathbb{C}$ is the *terminal* number system for algebra — no further extension is needed to solve polynomial equations. Compare: $\\mathbb{R}$ fails ($x^2+1=0$ has no solution), $\\mathbb{Q}$ fails ($x^2-2=0$), even the algebraic numbers $\\overline{\\mathbb{Q}}$ are algebraically closed but $\\mathbb{C}$ is the canonical completion of $\\mathbb{R}$.\n\n2. **Linear algebra**: Every complex matrix has an eigenvalue (eigenvalues are roots of the characteristic polynomial), so every complex linear map has Jordan normal form — a complete structural decomposition.\n\n3. **Field hierarchy**: $\\mathbb{C}$ is the algebraic closure of both $\\mathbb{R}$ (adjoining $i$) and $\\mathbb{Q}$ (countably many algebraic extensions).\n\n4. **Analysis-algebra bridge**: Despite its algebraic statement, every proof of FTA uses the completeness and/or connectedness of $\\mathbb{C}$ — topological properties unavailable in purely algebraic settings.",
+    "mathContext": "The Artin-Schreier theorem characterizes algebraically closed fields: a field $K$ is algebraically closed iff it has no proper algebraic extension. For $\\mathbb{C}$: the extension degree $[\\mathbb{C}:\\mathbb{R}] = 2$ is the unique case where a real closed field has algebraic closure of degree 2 (via adjoining $\\sqrt{-1}$). No field of positive characteristic has this property.",
+    "significance": "key",
+    "prerequisites": [
+      "algebraic closure",
+      "eigenvalues",
+      "Jordan normal form"
+    ],
+    "relatedConcepts": [
+      "algebraic closure",
+      "eigenvalue",
+      "Jordan normal form",
+      "Artin-Schreier theorem",
+      "real closed field"
+    ]
+  },
+  {
+    "id": "ann-quadratic-theorem",
+    "proofId": "fundamental-theorem-algebra",
+    "range": {
+      "startLine": 174,
+      "endLine": 209
+    },
+    "type": "technique",
+    "title": "Quadratic Case: FTA Applied to Degree-2 Polynomials",
+    "content": "`quadratic_has_root` proves that every quadratic $az^2 + bz + c$ with $a \\neq 0$ has a complex root, deriving this from the general FTA rather than the quadratic formula.\n\nThe proof is the longest in the file (36 lines) because it must:\n1. **Construct** the polynomial $p = C(a) \\cdot X^2 + C(b) \\cdot X + C(c)$ from scalar coefficients\n2. **Compute degree**: Show $\\deg(p) = 2$ by proving the leading term $C(a) \\cdot X^2$ dominates — requires `degree_C ha` (nonzero constant has degree 0), `degree_X_pow`, and `degree_add_eq_left_of_degree_lt`\n3. **Apply FTA**: `Complex.exists_root` with `0 < 2`\n4. **Translate back**: Convert `IsRoot p z` (polynomial evaluation) to the scalar equation $az^2 + bz + c = 0$\n\nThe degree computation takes 20 lines — a typical pattern in formalized mathematics where 'obvious' facts require careful bookkeeping. The classical quadratic formula $z = (-b \\pm \\sqrt{b^2-4ac})/(2a)$ would be shorter but less general: this proof works uniformly for all characteristics.",
+    "mathContext": "For $a \\neq 0$: $\\deg(aX^2 + bX + c) = 2$ since $\\deg(aX^2) = 2$ and $\\deg(bX + c) \\leq 1 < 2$. FTA gives $\\exists z, az^2 + bz + c = 0$. The classical quadratic formula identifies the roots explicitly, but FTA guarantees existence without computation.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Complex.exists_root",
+      "degree_add_eq_left_of_degree_lt",
+      "polynomial evaluation"
+    ],
+    "relatedConcepts": [
+      "quadratic formula",
+      "degree computation",
+      "polynomial construction",
+      "IsRoot translation"
+    ]
   }
 ]

--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -201,6 +201,21 @@
       "targetId": "brouwer-fixed-point",
       "relationship": "related",
       "description": "Both FTA and Brouwer's fixed point theorem are topological results about continuous maps on compact sets. The topological proof of FTA via winding numbers (the degree of $p(z)/|p(z)|$ on a large circle is $n$) uses the same homotopy-theoretic tools that prove Brouwer's theorem — both are consequences of the non-triviality of $\\pi_1(S^1) \\cong \\mathbb{Z}$"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} = -1$ reveals the structure of $\\mathbb{C}$ that makes FTA true: the complex exponential $e^{i\\theta}$ parameterizes the unit circle, giving $\\mathbb{C}^*$ a connected compact subgroup. The winding number proof of FTA uses this parameterization: $p(Re^{i\\theta})/|p(Re^{i\\theta})|$ winds $n$ times around the origin for large $R$, and this winding cannot unwind to 0 by continuity"
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "complementary",
+      "description": "FTA guarantees that all polynomial roots exist in $\\mathbb{C}$, while the area-of-circle formalization uses $\\mathbb{C} \\cong \\mathbb{R}^2$ as its ambient space for computing Lebesgue measure. Both entries exploit the identification of $\\mathbb{C}$ with $\\mathbb{R}^2$: FTA for the topology (completeness, connectedness) and area-of-circle for the measure theory (product Lebesgue measure)"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley-Hamilton theorem ($p_A(A) = 0$ for the characteristic polynomial $p_A$) combined with FTA guarantees every complex matrix has an eigenvalue: FTA gives a root $\\lambda$ of $p_A$, making $A - \\lambda I$ singular. This is why linear algebra over $\\mathbb{C}$ admits Jordan normal form — a direct consequence of algebraic closure"
     }
   ],
   "relatedProofs": [
@@ -213,7 +228,10 @@
     "lagrange-theorem",
     "vietas-formulas",
     "intermediate-value-theorem",
-    "brouwer-fixed-point"
+    "brouwer-fixed-point",
+    "euler-identity",
+    "area-of-circle",
+    "cayley-hamilton"
   ],
   "references": [
     {

--- a/src/data/proofs/infinitude-primes/annotations.json
+++ b/src/data/proofs/infinitude-primes/annotations.json
@@ -244,5 +244,71 @@
       "proof by contradiction"
     ],
     "prerequisites": []
+  },
+  {
+    "id": "ann-dvd-factorial",
+    "proofId": "infinitude-primes",
+    "range": {
+      "startLine": 44,
+      "endLine": 49
+    },
+    "type": "technique",
+    "title": "Divisibility by Factorials: The Crucial Property",
+    "content": "`dvd_factorial` proves that any positive $k \\leq n$ divides $n!$. This is the property that makes Euclid's proof work: if we list primes $p_1, \\ldots, p_m \\leq n$, then each $p_i$ divides $n!$. So if $p_i$ also divided $n! + 1$, it would divide $(n!+1) - n! = 1$, contradicting $p_i \\geq 2$. Therefore $n! + 1$ has a prime factor not among $p_1, \\ldots, p_m$.\n\nThe proof delegates to Mathlib's `Nat.dvd_factorial`, which proves $k \\mid n!$ by induction: $k \\mid k \\cdot (k-1) \\cdots 1 \\mid n \\cdot (n-1) \\cdots 1 = n!$ when $k \\leq n$.",
+    "mathContext": "$k! \\mid n!$ for $k \\leq n$, and $k \\mid k!$ since $k$ is one of the factors. Combined: $0 < k \\leq n \\Rightarrow k \\mid n!$. This is the foundation of Euclid's argument: primes up to $n$ divide $n!$ but cannot divide $n! + 1$.",
+    "significance": "key",
+    "prerequisites": [
+      "Nat.dvd_factorial",
+      "factorial definition"
+    ],
+    "relatedConcepts": [
+      "factorial",
+      "divisibility",
+      "Euclid's proof structure"
+    ]
+  },
+  {
+    "id": "ann-dvd-add-one",
+    "proofId": "infinitude-primes",
+    "range": {
+      "startLine": 56,
+      "endLine": 64
+    },
+    "type": "technique",
+    "title": "The Key Lemma: Dividing Consecutive Numbers Forces Dividing 1",
+    "content": "`dvd_of_dvd_add_one` proves: if $p \\mid a$ and $p \\mid (a+1)$, then $p \\mid 1$. The proof subtracts: $p \\mid (a+1) - a = 1$ via `Nat.dvd_sub'`.\n\nThis is the logical core of Euclid's proof. Since every prime $p_i \\leq n$ divides $n!$, and any prime factor $q$ of $n! + 1$ divides $n! + 1$, if $q$ were among the $p_i$ then $q \\mid n!$ AND $q \\mid n! + 1$, giving $q \\mid 1$ — impossible since $q \\geq 2$. Therefore $q > n$.\n\nThe elegance of this argument has made it the standard proof of Euclid's theorem for over two millennia.",
+    "mathContext": "If $p \\mid a$ and $p \\mid (a+1)$, then $p \\mid \\gcd(a, a+1) = 1$, so $p = 1$. More generally, $\\gcd(n!, n!+1) = 1$ since consecutive integers are always coprime. This coprimality is the mechanism that forces new primes into existence.",
+    "significance": "key",
+    "prerequisites": [
+      "Nat.dvd_sub'",
+      "coprimality of consecutive integers"
+    ],
+    "relatedConcepts": [
+      "coprime",
+      "consecutive integers",
+      "divisibility subtraction"
+    ]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "infinitude-primes",
+    "range": {
+      "startLine": 108,
+      "endLine": 127
+    },
+    "type": "insight",
+    "title": "Equivalent Formulations and Corollaries",
+    "content": "Three equivalent statements of prime infinitude:\n\n1. **`primes_infinite`** (= `unbounded_primes`): $\\forall n, \\exists p > n$ prime — the quantitative form\n2. **`exists_prime_gt_prime`**: Given any prime $p$, there exists a larger prime $q$ — primes are unbounded within primes\n3. **`no_largest_prime`**: $\\neg \\exists$ largest prime — the classical qualitative form\n\nThe proof of `no_largest_prime` is by contradiction: assume largest prime $p$ exists, apply `unbounded_primes p` to find $q > p$ prime, then $q \\leq p$ (by assumption) contradicts $q > p$ via `omega`.\n\nThese formulations differ in logical form (universal vs existential, positive vs negative) but are trivially equivalent. The `#check` commands at the end verify the theorems are accessible.",
+    "mathContext": "The three forms are logically equivalent:\n$(\\forall n, \\exists p > n, \\text{prime}(p)) \\iff (\\forall p, \\text{prime}(p) \\Rightarrow \\exists q > p, \\text{prime}(q)) \\iff \\neg(\\exists p, \\text{prime}(p) \\wedge \\forall q, \\text{prime}(q) \\Rightarrow q \\leq p)$\n\nIn cardinality terms: $|\\{p : p \\text{ prime}\\}| = \\aleph_0$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "unbounded_primes",
+      "omega tactic"
+    ],
+    "relatedConcepts": [
+      "logical equivalence",
+      "proof by contradiction",
+      "cardinality of primes"
+    ]
   }
 ]

--- a/src/data/proofs/prime-number-theorem/annotations.json
+++ b/src/data/proofs/prime-number-theorem/annotations.json
@@ -444,5 +444,52 @@
       "approximation quality"
     ],
     "prerequisites": []
+  },
+  {
+    "id": "ann-prime-counting-axiom",
+    "proofId": "prime-number-theorem",
+    "range": {
+      "startLine": 382,
+      "endLine": 402
+    },
+    "type": "context",
+    "title": "Axiom: Prime Counting Tends to Infinity",
+    "content": "`prime_counting_tendsto_top_axiom` axiomatizes that $\\pi(x) \\to \\infty$ as $x \\to \\infty$. This is a weak consequence of Euclid's theorem (infinitude of primes) but stated here as an axiom rather than proved from Mathlib's `Nat.infinite_setOf_prime` because converting between the set-theoretic infinitude and the analytic limit requires bridging Mathlib's `Finset`-based counting with the `Filter.Tendsto` framework.\n\n`prime_counting_tendsto_top` wraps the axiom for downstream use. This is a common formalization pattern: axiomatize a 'morally obvious' fact that requires significant infrastructure to prove formally, marking it for future replacement when the bridge lemmas are available.",
+    "mathContext": "$\\pi(x) \\to \\infty$ as $x \\to \\infty$. Quantitatively: $\\pi(x) \\geq \\ln\\ln x$ (Euler, 1737) and $\\pi(x) \\geq x/(2\\ln x)$ for $x \\geq 59$ (Chebyshev bound). PNT gives $\\pi(x) \\sim x/\\ln x$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Tendsto",
+      "atTop filter",
+      "primePi"
+    ],
+    "relatedConcepts": [
+      "axiom usage",
+      "formalization gap",
+      "prime counting function",
+      "Euclid's theorem"
+    ]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "prime-number-theorem",
+    "range": {
+      "startLine": 430,
+      "endLine": 463
+    },
+    "type": "context",
+    "title": "Summary and API Surface",
+    "content": "The summary doc-comment recaps the six key aspects of PNT:\n1. **Statement**: $\\pi(x) \\sim x/\\ln x$\n2. **Meaning**: fraction $\\sim 1/\\ln x$ of integers up to $x$ are prime\n3. **Better approximation**: $\\pi(x) \\sim \\text{Li}(x) = \\int_2^x dt/\\ln t$\n4. **Error terms**: unconditional $O(x e^{-c\\sqrt{\\ln x}})$ vs conditional (RH) $O(\\sqrt{x} \\ln x)$\n5. **Proof techniques**: complex analysis of $\\zeta(s)$, zero-free region, Tauberian theorems\n6. **History**: Gauss/Legendre conjecture (~1800), Hadamard/de la Vallée Poussin proof (1896)\n\n`pnt_summary` is a trivial placeholder theorem ($1 + 1 = 2$) anchoring the doc-comment. The four `#check` commands verify the API: `primeNumberTheorem`, `prime_asymptotic`, `prime_density_tends_to_zero`, `nth_prime_asymptotic`.",
+    "mathContext": "Error term hierarchy:\n- Trivial: $\\pi(x) = x/\\ln x + O(x/\\ln^2 x)$ (from PNT)\n- Best unconditional: $\\pi(x) = \\text{Li}(x) + O(x \\exp(-c(\\ln x)^{3/5}(\\ln\\ln x)^{-1/5}))$ (Korobov-Vinogradov, 1958)\n- Under RH: $\\pi(x) = \\text{Li}(x) + O(\\sqrt{x} \\ln x)$ (von Koch, 1901)",
+    "significance": "supporting",
+    "prerequisites": [
+      "PNT statement",
+      "Li(x) function"
+    ],
+    "relatedConcepts": [
+      "logarithmic integral",
+      "error terms",
+      "zero-free region",
+      "Tauberian theorem"
+    ]
   }
 ]

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -146,13 +146,48 @@
       "targetId": "basel-problem",
       "relationship": "related",
       "description": "Both concern the distribution of primes. The Basel problem ζ(2) = π²/6 is an early evaluation of the Riemann zeta function whose zeros control prime distribution."
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate ($\\exists$ prime in $(n, 2n]$) is an elementary consequence of PNT: $\\pi(2n) - \\pi(n) \\sim n/\\ln n \\to \\infty$. Historically, Chebyshev's 1852 proof of Bertrand's postulate used proto-PNT techniques (bounds on $\\theta(x)$), and Erdős's 1932 elementary proof foreshadowed the Erdős-Selberg elementary proof of PNT (1949)"
+    },
+    {
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "Euler's proof that $\\sum 1/p$ diverges (1737) was the first quantitative result on prime distribution. PNT refines this: $\\sum_{p \\leq x} 1/p \\sim \\ln\\ln x$, a consequence of $\\pi(x) \\sim x/\\ln x$ via partial summation"
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "extends",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions ($\\exists$ infinitely many primes $\\equiv a \\pmod{q}$ when $\\gcd(a,q)=1$) is strengthened by PNT in arithmetic progressions: $\\pi(x; q, a) \\sim x/(\\varphi(q) \\ln x)$, proving primes are equidistributed among residue classes"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function $\\varphi(n)$ appears in PNT for arithmetic progressions: $\\pi(x; q, a) \\sim x/(\\varphi(q) \\ln x)$. The totient also connects to prime distribution through the formula $\\varphi(n)/n = \\prod_{p | n}(1 - 1/p)$"
+    },
+    {
+      "targetId": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\sim \\sqrt{2\\pi n}(n/e)^n$ and PNT are both asymptotic results about discrete sequences with continuous approximations. The prime-counting analog of Stirling is $\\pi(x) \\sim \\text{Li}(x) = \\int_2^x dt/\\ln t$. Both involve the logarithm as the bridge between multiplicative and additive structure"
+    },
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Both are landmark achievements in number theory. Wiles's proof of FLT (1995) uses the modularity of elliptic curves and Galois representations — the same analytic number theory toolkit (L-functions, complex analysis) that underpins PNT. The connection between primes and modular forms runs deep through the Langlands program"
     }
   ],
   "relatedProofs": [
     "infinitude-primes",
     "riemann-hypothesis",
     "basel-problem",
-    "prime-reciprocal-divergence"
+    "prime-reciprocal-divergence",
+    "bertrands-postulate",
+    "dirichlets-theorem",
+    "euler-totient",
+    "stirling-formula",
+    "fermats-last-theorem"
   ],
   "references": [
     {

--- a/src/data/proofs/pythagorean-theorem/annotations.json
+++ b/src/data/proofs/pythagorean-theorem/annotations.json
@@ -196,6 +196,30 @@
     ]
   },
   {
+    "id": "ann-triple-examples",
+    "proofId": "pythagorean-theorem",
+    "range": {
+      "startLine": 123,
+      "endLine": 131
+    },
+    "type": "example",
+    "title": "Classic Pythagorean Triples: (3,4,5), (5,12,13), (8,15,17)",
+    "content": "Three classic Pythagorean triples verified by `norm_num`: $(3,4,5)$, $(5,12,13)$, and $(8,15,17)$. All three are **primitive** triples ($\\gcd(a,b,c) = 1$).\n\nEvery primitive triple has the form $(m^2 - n^2,\\, 2mn,\\, m^2 + n^2)$ for coprime integers $m > n > 0$ with $m - n$ odd (Euclid, *Elements* X.28). The examples: $(3,4,5)$ from $(m,n) = (2,1)$, $(5,12,13)$ from $(3,2)$, $(8,15,17)$ from $(4,1)$. The proof that this parameterization is complete uses unique factorization in $\\mathbb{Z}[i]$: $a^2 + b^2 = c^2$ factors as $(a+bi)(a-bi) = c^2$ in the Gaussian integers.",
+    "mathContext": "Euclid's parameterization: primitive triples $(a,b,c)$ with $2 | b$ are exactly $a = m^2 - n^2$, $b = 2mn$, $c = m^2 + n^2$ for $m > n > 0$, $\\gcd(m,n) = 1$, $m \\not\\equiv n \\pmod{2}$. Verify: $a^2 + b^2 = (m^2-n^2)^2 + (2mn)^2 = m^4 + n^4 - 2m^2n^2 + 4m^2n^2 = (m^2+n^2)^2 = c^2$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "norm_num tactic",
+      "Pythagorean triple",
+      "Gaussian integers"
+    ],
+    "relatedConcepts": [
+      "Euclid's parameterization",
+      "primitive triple",
+      "Gaussian integers",
+      "unique factorization"
+    ]
+  },
+  {
     "id": "ann-right-triangle",
     "proofId": "pythagorean-theorem",
     "range": {

--- a/src/data/proofs/taylor-theorem/meta.json
+++ b/src/data/proofs/taylor-theorem/meta.json
@@ -169,6 +169,21 @@
       "targetId": "basel-problem",
       "relationship": "related",
       "description": "Euler's evaluation $\\zeta(2) = \\pi^2/6$ can be proved via the Taylor series $\\sin(x)/x = \\prod(1 - x^2/(n\\pi)^2)$ — comparing Taylor coefficients yields the Basel sum."
+    },
+    {
+      "targetId": "fourier-series",
+      "relationship": "related",
+      "description": "Taylor series expand functions in powers of $(x-a)$ (local, polynomial basis), while Fourier series expand in $e^{inx}$ (global, trigonometric basis). Both are instances of expanding functions in orthogonal bases — Taylor in the monomial basis for analytic functions, Fourier in the exponential basis for $L^2$ functions. The Taylor coefficients $f^{(n)}(a)/n!$ are local (depend on derivatives at $a$), while Fourier coefficients $c_n = \\int f e^{-inx}\\,dx$ are global (depend on the entire function)"
+    },
+    {
+      "targetId": "pi-transcendental",
+      "relationship": "related",
+      "description": "The Taylor series $\\arctan(x) = x - x^3/3 + x^5/5 - \\cdots$ evaluated at $x = 1$ gives Leibniz's formula $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$. Lindemann's proof that $\\pi$ is transcendental (1882) uses the convergence properties of Taylor series for $e^x$ and the Lindemann-Weierstrass theorem"
+    },
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "IVT guarantees the existence of the intermediate point $c$ in the Lagrange remainder: $R_n = f^{(n+1)}(c)(x-a)^{n+1}/(n+1)!$ for some $c$ between $a$ and $x$. Without IVT (or the completeness of $\\mathbb{R}$), this intermediate value might not exist"
     }
   ],
   "relatedProofs": [
@@ -176,7 +191,10 @@
     "fundamental-theorem-calculus",
     "binomial-theorem",
     "e-transcendental",
-    "basel-problem"
+    "basel-problem",
+    "fourier-series",
+    "pi-transcendental",
+    "intermediate-value-theorem"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary
- **prime-number-theorem**: 6 cross-refs + 2 annotations (3→9 refs, 19→21 anns)
- **bertrands-postulate**: 2 annotations for corollaries and proof architecture (8→10, 69%→82%)
- **fourier-series**: 2 annotations + 3 cross-refs (17%→43% coverage, 4→7 refs)
- **taylor-theorem**: 3 cross-references (fourier-series, pi-transcendental, IVT; 5→8 refs)

## Test plan
- [x] All JSON validated
- [x] All cross-reference targets verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)