### PR TITLE
Add Aristotle companion file for Erdős #302 (8 sorries)

### DIFF
--- a/proofs/Proofs/Erdos302Aristotle.lean
+++ b/proofs/Proofs/Erdos302Aristotle.lean
@@ -1,0 +1,59 @@
+/-
+  Aristotle targets for Erdős Problem #302
+  Routine supporting lemmas for automated proof search.
+  See Erdos302Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (asymptotic density of f(N))
+  - Routine rational algebra identities and cardinality bounds
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos302Aristotle
+
+open Finset
+
+-- Routine: The unit fraction identity 1/a = 1/b + 1/c ↔ bc = a(b+c)
+-- Pure rational field manipulation (field_simp + ring)
+theorem unit_fraction_equiv (a b c : ℕ) (ha : a > 0) (hb : b > 0) (hc : c > 0) :
+    (1 : ℚ) / a = (1 : ℚ) / b + (1 : ℚ) / c ↔ b * c = a * (b + c) := by
+  sorry
+
+-- Routine: Equivalent algebraic form bc = ab + ac
+theorem unit_fraction_algebraic (a b c : ℕ) (ha : a > 0) (hb : b > 0) (hc : c > 0) :
+    (1 : ℚ) / a = (1 : ℚ) / b + (1 : ℚ) / c ↔ (b : ℚ) * c = a * b + a * c := by
+  sorry
+
+-- Routine: Standard decomposition pattern 1/n = 1/(n+1) + 1/(n(n+1))
+-- This is a well-known identity provable by field_simp + ring
+theorem standard_decomposition (n : ℕ) (hn : n > 0) :
+    (1 : ℚ) / n = 1 / (n + 1) + 1 / (n * (n + 1)) := by
+  sorry
+
+-- Routine: If A ⊆ Finset.range (N+1), then A.card ≤ N+1
+theorem subset_range_card_bound (A : Finset ℕ) (N : ℕ) (h : A ⊆ Finset.range (N + 1)) :
+    A.card ≤ N + 1 := by
+  sorry
+
+-- Routine: Odd integers in [1,N] have cardinality approximately N/2
+theorem odd_count_bound (N : ℕ) :
+    ((Finset.range (N + 1)).filter (fun n => n > 0 ∧ n % 2 = 1)).card ≤ (N + 1) / 2 := by
+  sorry
+
+-- Routine: The product of two odd numbers is odd
+theorem odd_mul_odd (a b : ℕ) (ha : a % 2 = 1) (hb : b % 2 = 1) :
+    (a * b) % 2 = 1 := by
+  sorry
+
+-- Routine: The sum of two odd numbers is even
+theorem odd_add_odd (a b : ℕ) (ha : a % 2 = 1) (hb : b % 2 = 1) :
+    (a + b) % 2 = 0 := by
+  sorry
+
+-- Routine: 5/8 > 1/2 (lower bound improvement)
+theorem cambie_improves : (5 : ℚ) / 8 > 1 / 2 := by
+  sorry
+
+end Erdos302Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #302 (Unit Fraction Sum-Free Sets) with 8 routine supporting lemmas for automated proof search.

## Evidence

**Before**: No Aristotle companion file; 9 sorries in main file
**After**: 8 routine sorries in `Erdos302Aristotle.lean` for Aristotle to attempt:
- `unit_fraction_equiv` — 1/a = 1/b + 1/c ↔ bc = a(b+c) (field_simp + ring)
- `unit_fraction_algebraic` — equivalent form bc = ab + ac
- `standard_decomposition` — 1/n = 1/(n+1) + 1/(n(n+1))
- `subset_range_card_bound` — cardinality bound for subsets
- `odd_count_bound` — count of odd integers ≤ (N+1)/2
- `odd_mul_odd` — product of two odd numbers is odd
- `odd_add_odd` — sum of two odd numbers is even
- `cambie_improves` — 5/8 > 1/2 (norm_num)

All checklist items pass: no definition sorries, no axioms, no True placeholders, no `/-!` sections.

---
Automated fix by lean-mechanic agent.