### PR TITLE
Audit cycle 19: 6 proofs audited, all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -290,17 +290,17 @@
       "issues": []
     },
     "buffons-needle-oq-02-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-24T04:37:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-03-24T09:38:41Z",
+      "result": "clean",
       "issues": [
         "Stale sorry annotation: section 7 summary says 'States (with sorry)' and conclusion says '1 sorry' but the Lean file has 0 sorries (the asymptotic theorem crossingFactor_tendsto_zero is now fully proved)"
       ]
     },
     "cantor-diagonalization-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-24T04:37:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-03-24T09:38:41Z",
+      "result": "clean",
       "issues": [
         "Stale axiom annotation: section 'countable-ordinals' summary says 'States the axiom \u03b1 < \u03c9\u2081 \u2194 IsCountableOrdinal \u03b1' but lt_omega1_iff_countable is a fully proved theorem, not an axiom"
       ]
@@ -363,8 +363,8 @@
       "issues": []
     },
     "cauchy-schwarz-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T04:53:29Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T09:38:41Z",
       "result": "clean",
       "issues": []
     },
@@ -375,8 +375,8 @@
       "issues": []
     },
     "cauchy-schwarz-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T04:59:09Z",
+      "auditCount": 3,
+      "lastAudited": "2026-03-24T09:38:42Z",
       "result": "clean",
       "issues": []
     },
@@ -411,8 +411,8 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:00:36Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T09:38:42Z",
       "result": "clean",
       "issues": []
     },
@@ -429,8 +429,8 @@
       "issues": []
     },
     "cevas-theorem-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:01:54Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T09:38:42Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

- 6 proofs audited, all clean
- All were scanner false positives on badge check (flagged for calling Mathlib theorems)

## Audited Proofs

| Proof | Badge | Result |
|-------|-------|--------|
| cantor-diagonalization-oq-02 | verified | clean |
| buffons-needle-oq-02-oq-01 | verified | clean |
| cauchy-schwarz-oq-01-oq-01 | original | clean |
| cauchy-schwarz-oq-03-oq-01 | verified | clean |
| cayley-hamilton-minpoly-oq-05 | verified | clean |
| cevas-theorem-oq-02-oq-01 | verified | clean |

## Test plan

- [x] Audit tracker updated
- [ ] Verify gallery build

🤖 Generated with [Claude Code](https://claude.com/claude-code)