### PR TITLE
Peer review: euler-polyhedral-formula (B)

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula/review.json
+++ b/src/data/proofs/euler-polyhedral-formula/review.json
@@ -1,0 +1,157 @@
+{
+  "version": 1,
+  "proofId": "euler-polyhedral-formula",
+  "reviewDate": "2026-03-24T21:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "B",
+    "oneLiner": "An exceptionally substantive 1092-line formalization with an axiom-free constructive proof, full Platonic solid classification, K5/K33 non-planarity, and genus generalization — but the meta.json significantly undersells the content and has several factual errors.",
+    "tier": "A-",
+    "tierJustification": "Tier A-: The core proof (euler_constructible) is fully proved by structural induction with 0 axioms, 0 sorries. The Platonic solid classification via Schlafli inequality and interval_cases is a complete, axiom-free mathematical argument. The file has 65 theorems and 27 definitions with zero filler. The single axiom (euler_formula_axiom) is only for the convenience of the weak PolyhedralGraph representation — none of the main results depend on it. The SimpleGraph bridge uses Mathlib's handshaking lemma for a genuine minimum degree bound. This is among the most substantive formalizations in the gallery."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "euler_constructible, lines 120-132",
+      "finding": "The constructive proof of V-E+F=2 is elegant and axiom-free. The ConstructiblePoly inductive type (tetra/subdivideEdge/subdivideFace) models polyhedra as built from a tetrahedron via chi-preserving operations. The proof by structural induction is clean: base case by simp, inductive steps by push_cast + linarith. This is the file's core contribution — Wiedijk #13 proved without axioms.",
+      "recommendation": "Preserve. This should be prominently featured in the meta.json description and originalContributions."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "PlatonicClassification namespace, lines 951-1077",
+      "finding": "The complete Platonic solid classification is a highlight: the Schlafli inequality (pq < 2p + 2q) is proved via nlinarith from the edge formula, then interval_cases enumerates all (p,q) pairs with p,q in {3,4,5} to yield exactly 5 solutions. The existence direction (platonic_all_exist) constructs all 5 explicitly. The VEF counts are uniquely determined. This is a self-contained, axiom-free proof of a beautiful mathematical result.",
+      "recommendation": "Preserve. Add to originalContributions — this is not mentioned at all."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Entire file (1092 lines, 65 theorems, 0 filler)",
+      "finding": "The file has zero filler theorems. Every one of the 65 theorems has genuine mathematical content: constructive induction proofs, edge bounds, non-planarity results, genus generalization, dual graph properties, Descartes' theorem, tree formula, Platonic classification. The file is organized into 14 clearly labeled parts spanning combinatorics, graph theory, and low-dimensional topology. This is exceptional compared to the gallery average.",
+      "recommendation": "Preserve the structure and content. The sections in meta.json should be expanded to reflect all 14 parts."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "exists_vertex_degree_le_five, lines 557-582",
+      "finding": "The minimum degree bound (every planar graph has a vertex of degree ≤ 5) is proved using Mathlib's sum_degrees_eq_twice_card_edges (handshaking lemma). The proof is a genuine contrapositive argument: assume all degrees ≥ 6, then 6V ≤ 2E by handshaking, but E ≤ 3V-6 by Euler, giving 3V ≤ E ≤ 3V-6 — contradiction. This is the most significant Mathlib integration in the file.",
+      "recommendation": "Preserve. Add sum_degrees_eq_twice_card_edges to mathlibDependencies."
+    },
+    {
+      "severity": "major",
+      "category": "inconsistency",
+      "location": "meta.json assumptions field",
+      "finding": "The assumptions field says '1 axiom(s) and 2 sorry(s)'. There are 0 sorries in the file — grep confirms no 'sorry' token exists. The sorries field correctly says 0, contradicting the assumptions text. This is a factual error that misleads readers about the proof's completeness.",
+      "recommendation": "Rewrite assumptions to: '1 axiom declaration: euler_formula_axiom (states V-E+F=2 for all PolyhedralGraph, needed because Mathlib lacks planar graph definitions). The main constructive proof (euler_constructible) and the Platonic solid classification are fully proved with 0 axioms and 0 sorries.'"
+    },
+    {
+      "severity": "major",
+      "category": "precision",
+      "location": "meta.json overview.proofStrategy",
+      "finding": "The proofStrategy describes 'Remove an edge (merges two faces): decreases E and F by 1' and 'Contract an edge (merges two vertices): decreases V and E by 1'. But the actual Lean proof works in the OPPOSITE direction: it BUILDS UP from a tetrahedron via subdivideEdge (V+1, E+1, F unchanged) and subdivideFace (V, E+1, F+1). The code uses inductive construction, not edge reduction. The strategy description is the inverse of what the code does.",
+      "recommendation": "Rewrite proofStrategy to match the actual code: 'Define polyhedra inductively from a tetrahedron (V=4, E=6, F=4) via two chi-preserving operations: subdivideEdge (V+1, E+1, F unchanged) and subdivideFace (V, E+1, F+1). Prove V-E+F=2 by structural induction: base case 4-6+4=2, inductive steps by push_cast + linarith.'"
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "meta.json originalContributions[2]",
+      "finding": "The third contribution claims 'Connection to topological invariants and the Gauss-Bonnet theorem'. The file does NOT formalize the Gauss-Bonnet theorem. It has a simple Descartes angular deficiency connection (descartes_euler, regular_descartes) and genus generalization (SurfaceEmbedding), but calling this 'Gauss-Bonnet' is a stretch. Meanwhile, the file's actual main contributions (constructive proof, Platonic classification, non-planarity proofs, minimum degree bound) are not listed.",
+      "recommendation": "Replace originalContributions with: ['Axiom-free constructive proof of V-E+F=2 by structural induction on ConstructiblePoly', 'Complete classification of Platonic solids via Schlafli inequality (only 5 exist, all realized)', 'K5/K33 non-planarity proofs via edge bounds, both for PolyhedralGraph and SimpleGraph', 'Minimum degree bound (vertex of degree ≤ 5 in planar graphs) using Mathlib handshaking lemma', 'Genus generalization: V-E+F=2-2g for surfaces, with K7-on-torus embedding']"
+    },
+    {
+      "severity": "moderate",
+      "category": "precision",
+      "location": "meta.json description",
+      "finding": "The description says 'For any convex polyhedron: V - E + F = 2, where V = vertices, E = edges, F = faces. This is the Euler characteristic of a sphere.' This is technically accurate but dramatically undersells a 1092-line file with 65 theorems. It doesn't mention the constructive proof, Platonic classification, non-planarity results, genus generalization, or any of the corollaries.",
+      "recommendation": "Expand to: 'Euler's polyhedral formula V-E+F=2 (Wiedijk #13), proved constructively via structural induction on polyhedra built from a tetrahedron. Includes complete Platonic solid classification (only 5 exist), K5/K33 non-planarity proofs, minimum degree bounds via Mathlib's handshaking lemma, genus generalization V-E+F=2-2g, and Descartes' angular deficiency connection.'"
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json sections",
+      "finding": "The sections list has 5 entries, but the Lean file has 14 clearly labeled parts. The 'topology' section covers lines 295-1092 (798 lines — 73% of the file!), lumping together: axiomatic formula, edge bounds, K5/K33, SimpleGraph bridge, genus generalization, trees, planar degree bounds, Descartes' theorem, dual graphs, and Platonic classification. A reader navigating by sections would miss most of the file's structure.",
+      "recommendation": "Expand to at least 10 sections matching the file's actual part structure. Key missing sections: SimpleGraph bridge (Part 8), genus generalization (Part 9), tree formula (Part 10), dual graphs (Part 13), Platonic classification (Part 14)."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json mathlibDependencies",
+      "finding": "Only lists SimpleGraph. The file uses Mathlib's sum_degrees_eq_twice_card_edges (handshaking lemma, line 574) — the key Mathlib theorem that enables the minimum degree bound. Also uses edgeFinset, Fintype.card. These should be listed as dependencies since they represent genuine Mathlib integration beyond basic data types.",
+      "recommendation": "Add: {theorem: 'SimpleGraph.sum_degrees_eq_twice_card_edges', description: 'Handshaking lemma: sum of vertex degrees = 2|E|', module: 'Mathlib.Combinatorics.SimpleGraph.DegreeSum'}"
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json conclusion.implications",
+      "finding": "The implications text has broken formatting: '**Significance:**\\n\\n1. First topological invariant discovered\\n2.\\n\\nLed to development...' — there's an empty list item '2.' followed by a blank line.",
+      "recommendation": "Fix the formatting to remove the broken list."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "Lean file line 40: 'set_option linter.unusedVariables false'",
+      "finding": "The file globally disables the unused variable linter. This is a minor code quality issue — it would be better to use local suppressions where needed.",
+      "recommendation": "Low priority. Consider scoping the linter suppression to specific sections."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Fix the assumptions field: change '1 axiom(s) and 2 sorry(s)' to accurately reflect 1 axiom and 0 sorries. Rewrite to explain the axiom's limited scope (only for weak PolyhedralGraph representation; the constructive proof is axiom-free).",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Rewrite originalContributions to reflect the file's actual strengths: axiom-free constructive proof, Platonic solid classification, non-planarity proofs, minimum degree bound, genus generalization. Remove the Gauss-Bonnet overclaim.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Rewrite proofStrategy to match the actual code: constructive induction on ConstructiblePoly from tetrahedron via subdivideEdge/subdivideFace, not edge reduction/contraction.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Expand sections from 5 to ~10-14, matching the file's 14 labeled parts. The 'topology' section covering 73% of the file needs splitting into at least 6 subsections.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Expand description to mention the constructive proof, Platonic classification, non-planarity results, and genus generalization. Add sum_degrees_eq_twice_card_edges to mathlibDependencies. Fix conclusion.implications formatting.",
+      "status": "open"
+    },
+    {
+      "id": "ai-6",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Consider proving the axiom (euler_formula_axiom) by connecting PolyhedralGraph to ConstructiblePoly — show every PolyhedralGraph is constructible. This would make the entire file axiom-free. The file already has toPolyhedralGraph going the other direction.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 9,
+    "originalityAccuracy": 6,
+    "completeness": 8,
+    "framingPrecision": 5,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 6,
+    "overall": 7.0
+  },
+
+  "suggestedBestFraming": "An axiom-free constructive proof of Euler's polyhedral formula V-E+F=2 (Wiedijk #13) via structural induction on polyhedra built from a tetrahedron by edge and face subdivision. Includes complete Platonic solid classification (exactly 5 exist, proved by Schlafli inequality), K5/K33 non-planarity, minimum degree bounds via Mathlib's handshaking lemma, genus generalization V-E+F=2-2g, and a Descartes angular deficiency connection. 65 theorems, zero filler; one axiom for the general PolyhedralGraph representation (Mathlib lacks planarity definitions)."
+}


### PR DESCRIPTION
## Summary

Deep review of Euler's Polyhedral Formula (Wiedijk #13) — a 1092-line, 65-theorem formalization.

**Grade: B** (overall score: 7.0)

### Key findings

**Strengths (math substance score: 9/10):**
- Axiom-free constructive proof of V-E+F=2 via structural induction (ConstructiblePoly)
- Complete Platonic solid classification: Schlafli inequality + interval_cases → exactly 5
- K5/K33 non-planarity via edge bounds (both PolyhedralGraph and SimpleGraph versions)
- Minimum degree bound using Mathlib's handshaking lemma
- Genus generalization V-E+F=2-2g with K7-on-torus embedding
- 65 theorems, 27 definitions, **zero filler** — every theorem has real content

**Issues (framing precision: 5/10):**
- assumptions says "2 sorry(s)" but file has 0 sorries
- proofStrategy describes edge reduction (removing) but code does edge subdivision (adding)
- originalContributions overclaim Gauss-Bonnet, omit the constructive proof and classification
- sections cover 73% of file in one "topology" entry
- mathlibDependencies missing handshaking lemma

### Action items
| ID | Priority | Target | Description |
|----|----------|--------|-------------|
| ai-1 | high | enricher | Fix assumptions: 0 sorries not 2 |
| ai-2 | high | enricher | Rewrite originalContributions (add constructive proof, classification) |
| ai-3 | high | enricher | Fix proofStrategy (subdivision not reduction) |
| ai-4 | medium | enricher | Expand sections from 5 to ~10-14 |
| ai-5 | medium | enricher | Expand description, add mathlibDependencies |
| ai-6 | low | researcher | Prove the axiom to make file fully axiom-free |

### Scores
| Dimension | Score |
|-----------|-------|
| Mathematical Substance | 9 |
| Originality Accuracy | 6 |
| Completeness | 8 |
| Framing Precision | 5 |
| Pedagogical Quality | 8 |
| Internal Consistency | 6 |
| **Overall** | **7.0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)