### PR TITLE
Add Aristotle companion file for Erdős #1048 (8 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1048Aristotle.lean
+++ b/proofs/Proofs/Erdos1048Aristotle.lean
@@ -1,0 +1,58 @@
+/-
+  Aristotle targets for Erdős Problem #1048
+  Routine supporting lemmas for automated proof search.
+  See Erdos1048Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main conjecture (EHP disproved) or deep counterexample analysis
+  - Routine complex analysis facts: continuity, openness, polynomial properties
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos1048Aristotle
+
+open Complex Polynomial Set Metric
+
+-- Routine: Sublevel set of |f(z)| is open (preimage of open set under continuous map)
+theorem polynomial_sublevel_isOpen (f : ℂ[X]) (c : ℝ) (hc : c > 0) :
+    IsOpen { z : ℂ | Complex.abs (f.eval z) < c } := by
+  sorry
+
+-- Routine: X^n - C a is monic for n ≥ 1
+theorem xpow_sub_const_monic (a : ℂ) (n : ℕ) (hn : n ≥ 1) :
+    (X ^ n - C a : ℂ[X]).leadingCoeff = 1 := by
+  sorry
+
+-- Routine: Degree of X^n - C a is n for n ≥ 1
+theorem xpow_sub_const_degree (a : ℂ) (n : ℕ) (hn : n ≥ 1) :
+    (X ^ n - C a : ℂ[X]).degree = n := by
+  sorry
+
+-- Routine: |r * exp(iθ)| = |r| for r : ℝ
+theorem abs_mul_exp (r : ℝ) (θ : ℝ) :
+    Complex.abs (r * Complex.exp (θ * Complex.I)) = |r| := by
+  sorry
+
+-- Routine: If z^n = r^n for r > 0, then |z| = r
+theorem abs_root_of_pow_eq (z : ℂ) (r : ℝ) (n : ℕ) (hr : r > 0) (hn : n ≥ 1)
+    (h : z ^ n = (r : ℂ) ^ n) : Complex.abs z = r := by
+  sorry
+
+-- Routine: Polynomial evaluation is continuous
+theorem polynomial_eval_continuous (f : ℂ[X]) : Continuous f.eval := by
+  sorry
+
+-- Routine: The golden ratio satisfies φ² = φ + 1
+theorem golden_ratio_sq :
+    let φ := (Real.sqrt 5 + 1) / 2
+    φ ^ 2 = φ + 1 := by
+  sorry
+
+-- Routine: (√5 - 1)/2 is positive and less than 1
+theorem golden_minus_one_bounds :
+    (Real.sqrt 5 - 1) / 2 > 0 ∧ (Real.sqrt 5 - 1) / 2 < 1 := by
+  sorry
+
+end Erdos1048Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #1048 (Polynomial Lemniscate Diameter) with 8 routine supporting lemmas for automated proof search.

## Evidence

**Before**: No Aristotle companion file; 10 sorries in main file
**After**: 8 routine sorries in `Erdos1048Aristotle.lean` for Aristotle to attempt:
- `polynomial_sublevel_isOpen` — {z : |f(z)| < c} is open
- `xpow_sub_const_monic` — X^n - C a has leading coeff 1
- `xpow_sub_const_degree` — degree of X^n - C a is n
- `abs_mul_exp` — |r * exp(iθ)| = |r|
- `abs_root_of_pow_eq` — z^n = r^n implies |z| = r
- `polynomial_eval_continuous` — f.eval is continuous
- `golden_ratio_sq` — φ² = φ + 1
- `golden_minus_one_bounds` — (√5-1)/2 ∈ (0, 1)

All checklist items pass: no definition sorries, no axioms, no True placeholders, no `/-!` sections.

---
Automated fix by lean-mechanic agent.