### PR TITLE
Add Aristotle companion file for Erdős #1037 (8 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1037Aristotle.lean
+++ b/proofs/Proofs/Erdos1037Aristotle.lean
@@ -1,0 +1,66 @@
+/-
+  Aristotle targets for Erdős Problem #1037
+  Routine supporting lemmas for automated proof search.
+  See Erdos1037Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main conjecture (Chen-Erdős, disproved)
+  - Routine graph theory facts: handshake lemma, degree bounds, pigeonhole
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos1037Aristotle
+
+open SimpleGraph Finset
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+variable (G : SimpleGraph V) [DecidableRel G.Adj]
+
+-- Routine: Handshake lemma — sum of degrees equals twice the number of edges
+-- This is a fundamental result, likely in Mathlib as sum_degrees_eq_twice_card_edges
+theorem degree_sum_eq_twice_edges :
+    (Finset.univ.sum (fun v => G.degree v)) = 2 * G.edgeFinset.card := by
+  sorry
+
+-- Routine: Maximum degree in a simple graph is at most n-1
+theorem degree_le_card_sub_one (v : V) :
+    G.degree v ≤ Fintype.card V - 1 := by
+  sorry
+
+-- Routine: Number of distinct degree values is at most n
+-- (at most n vertices, so at most n distinct degrees)
+theorem distinctDegrees_le_card :
+    (Finset.univ.image (fun v => G.degree v)).card ≤ Fintype.card V := by
+  sorry
+
+-- Routine: If every value appears at most k times among n elements,
+-- then there are at least ⌈n/k⌉ distinct values (pigeonhole)
+theorem pigeonhole_distinct_count (f : V → ℕ) (k : ℕ) (hk : k ≥ 1)
+    (h : ∀ d : ℕ, (Finset.univ.filter (fun v => f v = d)).card ≤ k) :
+    (Finset.univ.image f).card ≥ Fintype.card V / k := by
+  sorry
+
+-- Routine: Degree values range in {0, ..., n-1}, so at most n distinct values
+theorem degree_range :
+    Finset.univ.image (fun v => G.degree v) ⊆ Finset.range (Fintype.card V) := by
+  sorry
+
+-- Routine: The complement graph G^c has degree (n-1) - deg_G(v)
+theorem complement_degree (v : V) :
+    Gᶜ.degree v = Fintype.card V - 1 - G.degree v := by
+  sorry
+
+-- Routine: If every degree appears at most twice and degrees ∈ {0,...,n-1},
+-- then the number of distinct degrees ≤ n, and n ≤ 2 * distinctDegrees
+theorem limited_mult_bound_from_pigeonhole
+    (h : ∀ d : ℕ, (Finset.univ.filter (fun v => G.degree v = d)).card ≤ 2) :
+    Fintype.card V ≤ 2 * (Finset.univ.image (fun v => G.degree v)).card := by
+  sorry
+
+-- Routine: 3/4 > 2/3 (comparing optimal bounds)
+theorem three_fourths_gt_two_thirds : (3 : ℝ) / 4 > 2 / 3 := by
+  sorry
+
+end Erdos1037Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #1037 (Degree Diversity and Ramsey Properties) with 8 routine graph theory lemmas for automated proof search.

## Evidence

**Before**: No Aristotle companion file; 9 sorries in main file
**After**: 8 routine sorries in `Erdos1037Aristotle.lean` for Aristotle to attempt:
- `degree_sum_eq_twice_edges` — handshake lemma (sum degrees = 2|E|)
- `degree_le_card_sub_one` — degree ≤ n-1 in simple graph
- `distinctDegrees_le_card` — at most n distinct degrees
- `pigeonhole_distinct_count` — pigeonhole for distinct values
- `degree_range` — degrees ⊆ {0,...,n-1}
- `complement_degree` — Gᶜ degree = (n-1) - G degree
- `limited_mult_bound_from_pigeonhole` — n ≤ 2 * distinctDegrees when multiplicity ≤ 2
- `three_fourths_gt_two_thirds` — 3/4 > 2/3 (norm_num)

All checklist items pass: no definition sorries, no axioms, no True placeholders, no `/-!` sections.

---
Automated fix by lean-mechanic agent.