### PR TITLE
Fix: euler-polyhedral-formula metadata per peer review

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula/meta.json
@@ -24,24 +24,30 @@
         "theorem": "SimpleGraph",
         "description": "Graph structure for modeling polyhedra",
         "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "Sum_degrees_eq_twice_card_edges",
+        "description": "Handshaking lemma: sum of degrees = 2|E|",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
       }
     ],
     "originalContributions": [
-      "Verification of Euler's formula for all five Platonic solids",
-      "Proof that edge operations preserve the Euler characteristic",
-      "Connection to topological invariants and the Gauss-Bonnet theorem"
+      "Axiom-free constructive proof of V-E+F=2 via ConstructiblePoly structural induction",
+      "Complete Platonic solid classification from Schläfli inequality (exactly 5 solutions)",
+      "K₅ and K₃,₃ non-planarity via edge bounds (both PolyhedralGraph and SimpleGraph versions)",
+      "Minimum degree bound using Mathlib's handshaking lemma"
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 1,
     "lineCount": 1092,
-    "assumptions": "1 axiom(s) and 2 sorry(s). See the Lean source for details.",
+    "assumptions": "1 axiom (euler_formula_axiom: V-E+F=2 for PolyhedralGraph, needed because Mathlib lacks planarity). The constructive ConstructiblePoly proof is axiom-free.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Euler discovered this formula in 1758 while studying polyhedra, though René Descartes had noticed a closely related result in 1639 (remaining unpublished until 1860). The formula V - E + F = 2 is one of the most beautiful results in mathematics, connecting three apparently unrelated counts — vertices, edges, and faces — through a single universal constant.\n\nCauchy provided the first rigorous proof in 1813 using triangulation, reducing a general polyhedron to the sphere. Legendre gave an independent spherical geometry proof the same year. The formula is equivalent to the topological statement that every convex polyhedron is homeomorphic to a sphere, whose Euler characteristic χ = 2. Poincaré generalized this in 1895 to all compact orientable surfaces: χ = 2 − 2g for genus g, founding algebraic topology. The Euler characteristic became the first example of a topological invariant preserved under continuous deformation.",
     "problemStatement": "**Theorem (Euler, 1758)**: For any convex polyhedron with V vertices, E edges, and F faces:\n\n$$V - E + F = 2$$\n\nThis is Wiedijk's 100 Theorems #13 and represents a fundamental topological invariant.",
     "text": "For any convex polyhedron: V - E + F = 2, where V = vertices, E = edges, F = faces. This is the Euler characteristic of a sphere.",
-    "proofStrategy": "**Proof by Edge Reduction**:\n\n1. **Base Case**: The tetrahedron has V=4, E=6, F=4, so 4 - 6 + 4 = 2\n2. **Inductive Step**: For any polyhedron with E > 6 edges:\n   - Remove an edge (merges two faces): decreases E and F by 1\n   - Contract an edge (merges two vertices): decreases V and E by 1\n3. Both operations preserve V - E + F\n4. By reduction to tetrahedron, all polyhedra have V - E + F = 2",
+    "proofStrategy": "**Proof by Constructive Induction (Edge/Face Subdivision)**:\n\n1. **Base Case**: The tetrahedron has V=4, E=6, F=4, so 4 - 6 + 4 = 2\n2. **Inductive Step**: Build all polyhedra from the tetrahedron via two operations:\n   - `subdivideEdge`: Insert a vertex on an edge, splitting it in two (V+1, E+1, F unchanged)\n   - `subdivideFace`: Insert an edge across a face, splitting it in two (V unchanged, E+1, F+1)\n3. Both operations preserve V - E + F\n4. By structural induction on ConstructiblePoly, all constructible polyhedra have V - E + F = 2",
     "keyInsights": [
       "**Topological Invariant:** $\\chi = V - E + F$ depends only on the surface type, not the triangulation. Any two triangulations of the sphere give $\\chi = 2$. This is the simplest example of a topological invariant — a quantity unchanged by continuous deformation.",
       "**Genus Generalization:** $V - E + F = 2 - 2g$ for compact orientable surfaces of genus $g$. Sphere ($g=0$): $\\chi = 2$. Torus ($g=1$): $\\chi = 0$. Double torus ($g=2$): $\\chi = -2$. The genus counts 'handles' on the surface.",
@@ -74,7 +80,7 @@
       "title": "General Proof Strategy",
       "startLine": 174,
       "endLine": 218,
-      "summary": "Proof by edge reduction preserving the Euler characteristic."
+      "summary": "Proof by constructive induction via edge/face subdivision preserving the Euler characteristic."
     },
     {
       "id": "main-formula",


### PR DESCRIPTION
## Fix

Addresses high-priority findings from peer review #5868 for euler-polyhedral-formula (Wiedijk #13).

## Evidence

**Before**:
- `assumptions` claimed "2 sorry(s)" — file has 0 sorries
- `proofStrategy` described edge reduction (removing) — code does subdivision (adding)
- `originalContributions` overclaimed Gauss-Bonnet, omitted constructive proof and classification
- `mathlibDependencies` missing handshaking lemma

**After**:
- `assumptions` correctly describes 1 axiom with 0 sorries
- `proofStrategy` accurately describes ConstructiblePoly subdivision induction
- `originalContributions` lists actual contributions (constructive proof, Platonic classification, K₅/K₃,₃)
- `mathlibDependencies` includes handshaking lemma (DegreeSum)

Addresses findings ai-1, ai-2, ai-3, ai-5 from PR #5868.

---
Automated fix by lean-mechanic agent.