### PR TITLE
Audit: fix badge verified→mathlib for 5 proofs

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02/meta.json
@@ -20,7 +20,7 @@
       "foundations",
       "infinity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -84,7 +84,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 272,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "0 axioms, 0 sorries. Core diagonal argument is original; infrastructure relies on Mathlib's Cardinal.isRegular_aleph_one (regularity of ℵ₁) and Cardinal.lt_ord (ordinal/cardinal correspondence)."
   },
   "overview": {
     "historicalContext": "**The First Uncountable Ordinal**\n\nCantor's development of transfinite ordinals in 1883 culminated in the definition of ω₁ — the first ordinal that cannot be put in bijection with ℕ. The collection of all countable ordinals {α | α.card ≤ ℵ₀} forms a well-ordered set of extraordinary richness: it contains ω, ω², ω^ω, ε₀, and all other 'small' infinite ordinals.\n\n**Why ℵ₁?**\n\nThe cardinality of this collection is ℵ₁, the first uncountable cardinal. This is not a coincidence: ω₁ is defined as the initial ordinal of ℵ₁, meaning it is the smallest ordinal of cardinality ℵ₁. The set of ordinals below ω₁ (i.e., the countable ordinals) then has exactly ℵ₁ many elements.\n\n**The Diagonal Argument Connection**\n\nThe uncountability of the countable ordinals admits a beautiful diagonal proof: if f : ℕ → Ordinal claimed to enumerate all countable ordinals, we could form β = sSup(range f) + 1. Since ω₁ is regular (a countable union of countable sets is countable), β < ω₁. But β > f(n) for all n, contradicting surjectivity.",

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -75,7 +75,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 835,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Lagrange identity and Hölder equality characterization are original; inner product space equality case uses Mathlib's norm_inner_eq_norm_iff, Hölder inequality via NNReal.inner_le_Lp_mul_Lq.",
     "mathlib_version": "4.26.0"
   },
   "sections": [

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "skolem-noether",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -74,7 +74,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 570,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Uses Mathlib's minpoly.algEquiv_eq for minimal polynomial invariance under algebra equivalences.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02/meta.json
@@ -19,7 +19,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -79,7 +79,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 131,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Uses Mathlib's minpoly.unique for minimal polynomial characterization and wraps Matrix.minpoly_dvd_charpoly.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
@@ -17,7 +17,7 @@
       "scalar-tower",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -96,7 +96,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 232,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Built on Mathlib's minimal polynomial infrastructure (minpoly.monic, minpoly.aeval, minpoly.dvd, minpoly.irreducible).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculus.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,7 +39,7 @@
     "wiedijkNumber": 15,
     "axiomCount": 0,
     "lineCount": 165,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Core FTC results (integral_hasDerivAt_right, integral_eq_sub_of_hasDerivAt) derived from Mathlib's measure-theoretic integration framework.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- Fix badge `verified`/`original` → `mathlib` for 6 proofs that rely on deep Mathlib theorems
- Update assumptions fields to accurately describe Mathlib dependencies
- 21 proofs audited total: 6 fixed, 15 confirmed clean

### Proofs fixed (badge → mathlib)

| Proof | Key Mathlib dependency |
|-------|----------------------|
| cantor-diagonalization-oq-02 | Cardinal.isRegular_aleph_one |
| cauchy-schwarz-oq-03-oq-01 | norm_inner_eq_norm_iff |
| cayley-hamilton-minpoly-oq-02 | Matrix.minpoly_dvd_charpoly |
| cayley-hamilton-minpoly-oq-02-oq-01-oq-01 | minpoly.algEquiv_eq |
| cayley-hamilton-minpoly-oq-05 | minpoly infrastructure |
| fundamental-theorem-calculus | integral_hasDerivAt_right |

### Proofs confirmed clean (no changes needed)

- pythagorean-triples, buffons-needle-oq-02-oq-01, cauchy-schwarz-oq-01-oq-01, cauchy-schwarz-oq-04, cevas-theorem-oq-02-oq-01
- abel-ruffini, amgm-inequality, area-of-circle, angle-trisection
- ballot-problem, cantor-diagonalization, e-transcendental, factor-remainder-theorem, gcd-algorithm, halting-problem
- binomial-theorem, fermats-last-theorem, fundamental-theorem-algebra, prime-number-theorem, sqrt2-irrational

## Test plan

- [x] Verify badge changes match Tier B classification
- [x] Verify assumptions fields accurately describe Mathlib reliance
- [ ] `pnpm build` passes (metadata-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)