### PR TITLE
Fix: stale assumptions text in 8 gallery proofs

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
@@ -61,7 +61,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
     "lineCount": 1162,
-    "assumptions": "2 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom (Tucker's lemma in 2D and n-D axiomatized). No sorries."
   },
   "overview": {
     "historicalContext": "**Quantitative Borsuk-Ulam and Tucker's Lemma**\n\nThe parent file (borsuk-ulam-oq-03) proved the 1D Borsuk-Ulam theorem constructively via IVT. This extension explores the quantitative and computational aspects: How fast can we locate antipodal pairs? What bounds does Lipschitz continuity impose? How does the modulus of continuity control the deviation |f(x) - f(-x)|?\n\nTucker's lemma (1946) is the combinatorial analog of Borsuk-Ulam: any signed labeling of a triangulated interval with antipodal boundary condition (f(0) = -f(last)) must have a complementary edge (adjacent vertices with opposite labels). In 1D, Tucker's lemma and BU are equivalent.\n\nThe higher-dimensional generalization of Tucker's lemma (to triangulated disks B^n with labels from {+-1,...,+-n}) implies the full n-dimensional Borsuk-Ulam theorem. The 2D and n-D cases are axiomized here, awaiting simplicial complex infrastructure in Mathlib.",

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -47,7 +47,7 @@
     "dateAdded": "2026-02-22",
     "axiomCount": 2,
     "lineCount": 442,
-    "assumptions": "2 axiom(s) and 1 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -59,7 +59,7 @@
       "7 concrete verification examples for first 3 tree levels"
     ],
     "lineCount": 618,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms. 4 sorries remaining (surjectivity, completeness proofs).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -59,7 +59,7 @@
       "Combinatorial arguments in discrete geometry",
       "Basic real analysis (volume decomposition)"
     ],
-    "assumptions": "2 axiom(s) and 2 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
@@ -16,7 +16,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 2,
-    "assumptions": "2 axioms: Lebesgue FTC Part 1 (AC → a.e. differentiable) and Part 2 (integral of a.e. derivative = net change). 2 sorries: Lipschitz→AC arithmetic detail, Cantor function construction.",
+    "assumptions": "2 axioms: Lebesgue FTC Part 1 (AC → a.e. differentiable) and Part 2 (integral of a.e. derivative = net change). 1 sorry remaining.",
     "mathlibDependencies": [
       {
         "theorem": "Monotone.ae_differentiableAt",

--- a/src/data/proofs/hilbert-19-oq-03/meta.json
+++ b/src/data/proofs/hilbert-19-oq-03/meta.json
@@ -64,7 +64,7 @@
     "axioms": 2,
     "axiomCount": 4,
     "lineCount": 462,
-    "assumptions": "9 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "4 axioms (Evans-Krylov theorem, Schauder estimates, comparison principle, ABP estimate). No sorries."
   },
   "overview": {
     "historicalContext": "Hilbert's 19th problem (1900) asked whether minimizers of variational integrals are always analytic. De Giorgi (1957) and Nash (1958) independently resolved this for divergence-form (quasilinear) equations by proving Holder continuity of weak solutions. The natural extension to fully nonlinear equations $F(D^2 u) = 0$ required entirely new techniques: the classical energy methods fail because the equation cannot be written in divergence form. Alexandrov (1960s) introduced the ABP maximum principle using contact sets and convex envelopes. Krylov and Safonov (1980) proved the Harnack inequality for nondivergence-form equations, establishing $C^\\alpha$ regularity without convexity. The breakthrough came in 1982 when Evans and Krylov independently proved $C^{2,\\alpha}$ regularity for convex (or concave) uniformly elliptic $F$, using the Ishii-Lions method and Krylov-Safonov theory. Caffarelli and Cabre (1995) systematized the theory in their monograph. Nadirashvili and Vladut (2008) showed that convexity is essential: they constructed non-convex uniformly elliptic operators in dimension $\\geq 5$ with solutions failing $C^{1,1}$ regularity. Crandall and Lions (1983) introduced viscosity solutions as the correct weak solution framework for fully nonlinear PDEs.",

--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -45,7 +45,7 @@
     "dateAdded": "2025-12-26",
     "axiomCount": 2,
     "lineCount": 1679,
-    "assumptions": "2 axiom(s) and 2 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/ramanujan-sum-fallacy/meta.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/meta.json
@@ -50,7 +50,7 @@
     "dateAdded": "2025-12-21",
     "axiomCount": 2,
     "lineCount": 282,
-    "assumptions": "2 axiom(s) and 9 sorry(s). See the Lean source for details."
+    "assumptions": "2 axioms. No sorries."
   },
   "overview": {
     "historicalContext": "The claim that $1+2+3+4+\\cdots = -\\frac{1}{12}$ gained widespread attention through a 2014 Numberphile video that has over 10 million views. The result has legitimate origins in the work of Ramanujan and the theory of the Riemann zeta function, where $\\zeta(-1) = -\\frac{1}{12}$. However, the video's 'elementary proof' using series manipulation is fundamentally flawed.\n\nThe actual -1/12 result comes from analytic continuation of the Riemann zeta function. For $\\text{Re}(s) > 1$, the zeta function is defined as $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$. This series diverges for $s = -1$, but the zeta function can be uniquely extended to a meromorphic function on the complex plane, and $\\zeta(-1) = -\\frac{1}{12}$.\n\nThis is NOT the same as saying the sum converges to $-\\frac{1}{12}$. The result appears in string theory and physics through a technique called zeta function regularization, which is a specific mathematical procedure - not ordinary summation.",


### PR DESCRIPTION
## Fix

The `assumptions` text field in meta.json was out of sync with the actual `sorries` field for 8 proofs. The `sorries` numeric field was already correct; only the human-readable text was stale.

## Evidence

| Proof | Before (text) | After (matches sorries field) |
|-------|--------------|-------------------------------|
| borsuk-ulam-oq-03-oq-01 | "1 sorry" | 0 sorries |
| cantor-diagonalization-oq-01 | "1 sorry" | 0 sorries |
| dissection-of-cubes | "2 sorries" | 0 sorries |
| hurwitz-theorem | "2 sorries" | 0 sorries |
| ramanujan-sum-fallacy | "9 sorries" | 0 sorries |
| hilbert-19-oq-03 | "9 axioms, 1 sorry" | 4 axioms, 0 sorries |
| fundamental-theorem-calculus-oq-01 | "2 sorries" | 1 sorry |
| denumerability-rationals-oq-03 | "0 sorries" | 4 sorries (was overclaiming) |

---
Automated fix by lean-mechanic agent.