### PR TITLE
Research: erdos-890 - prove Conjecture 1 for k=1, structural lemmas

### DIFF
--- a/proofs/Proofs/Erdos890Problem.lean
+++ b/proofs/Proofs/Erdos890Problem.lean
@@ -169,4 +169,42 @@ theorem erdos_890_known_lower_bound :
       LiminfAtLeast (cumulativeOmega k) (k + pi k - 1) :=
   erdos_selfridge_lower_bound
 
+-- ## Part VII: Additional Structural Lemmas
+
+/-- S_0(n) = 0: the empty sum. -/
+theorem cumulativeOmega_zero (n : ℕ) : cumulativeOmega 0 n = 0 := by
+  unfold cumulativeOmega; simp
+
+/-- S_1(n) = ω(n): the single-term sum reduces to a single ω evaluation. -/
+theorem cumulativeOmega_one (n : ℕ) : cumulativeOmega 1 n = ω n := by
+  unfold cumulativeOmega; simp [Finset.sum_range_one]
+
+/-- Sum splitting: S_{k+j}(n) = S_k(n) + S_j(n + k). -/
+theorem cumulativeOmega_add (k j n : ℕ) :
+    cumulativeOmega (k + j) n = cumulativeOmega k n + cumulativeOmega j (n + k) := by
+  unfold cumulativeOmega; rw [Finset.sum_range_add]
+  congr 1; apply Finset.sum_congr rfl; intro i _; congr 1; omega
+
+-- ## Part VIII: Conjecture 1 Verified for k = 1
+
+/-- ω(p) = 1 for any prime p: a prime has exactly one distinct prime factor. -/
+theorem omega_prime {p : ℕ} (hp : Nat.Prime p) : ω p = 1 := by
+  have h : p.primeFactors = {p} := by
+    ext q; simp only [Nat.mem_primeFactors, Finset.mem_singleton]
+    constructor
+    · rintro ⟨hq, hqp, -⟩
+      exact (hp.eq_one_or_self_of_dvd q hqp).resolve_left hq.one_lt.ne'
+    · rintro rfl; exact ⟨hp, dvd_refl p, hp.ne_zero⟩
+  simp [ArithmeticFunction.omega, h]
+
+/-- **Conjecture 1 verified for k = 1:**
+    For k = 1, S₁(n) = ω(n). Every prime p has ω(p) = 1 ≤ 1 + π(1), and primes
+    are unbounded (Euclid), so lim inf S₁(n) ≤ 1 + π(1). -/
+theorem conjecture1_k1 : LiminfAtMost (cumulativeOmega 1) (1 + pi 1) := by
+  intro N₀
+  obtain ⟨p, hN, hp⟩ := Nat.exists_infinite_primes N₀
+  exact ⟨p, hN, by rw [cumulativeOmega_one]
+                     calc ω p = 1 := omega_prime hp
+                       _ ≤ 1 + pi 1 := by omega⟩
+
 end Erdos890

--- a/src/data/proofs/erdos-890/meta.json
+++ b/src/data/proofs/erdos-890/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/890",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 172,
+    "lineCount": 210,
     "assumptions": "2 axioms: erdos_selfridge_lower_bound, classical_omega_limsup. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -126,9 +126,9 @@
       "ArithmeticFunction.omega"
     ],
     "namespace": "Erdos890",
-    "lineCount": 172,
+    "lineCount": 210,
     "axiomCount": 2,
-    "theoremCount": 4,
+    "theoremCount": 9,
     "definitionCount": 6
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-890.json
+++ b/src/data/research/problems/erdos-890.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-890",
   "title": "Erdős #890",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-15T10:57:29.901Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved Conjecture 1 for k=1, added structural lemmas",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Proved Conjecture 1 for k=1 using infinitude of primes. Added 5 structural theorems including sum splitting and omega_prime. File 173→210 lines, 4→9 theorems.",
+    "builtItems": [
+      "conjecture1_k1: Conjecture 1 verified for k=1 using Nat.exists_infinite_primes",
+      "omega_prime: ω(p)=1 for prime p, proved from primeFactors characterization",
+      "cumulativeOmega_one: S_1(n)=ω(n), cumulativeOmega_zero: S_0(n)=0",
+      "cumulativeOmega_add: sum splitting S_{k+j}=S_k+S_j"
+    ],
+    "insights": [
+      "Conjecture 1 holds for k=1: lim inf ω(n) ≤ 1+π(1)=1, proved using infinitude of primes (every prime has ω(p)=1).",
+      "Sum splitting: S_{k+j}(n) = S_k(n) + S_j(n+k), enabling divide-and-conquer analysis.",
+      "Both axioms (Erdős-Selfridge lower bound, Hardy-Ramanujan limsup) are deep published results, not provable from Mathlib."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove Conjecture 1 for k=2 (requires infinitely many n with ω(n)+ω(n+1)≤3, related to twin prime structure)",
+      "Try proving classical_omega_limsup from Mathlib Hardy-Ramanujan results if available",
+      "Add concrete computations of S_k(n) for small values to verify bounds"
+    ],
     "markdown": "# Erdős #890 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIf $\\omega(n)$ counts the number of distinct prime factors of $n$, then is it true that, for every $k\\geq 1$,\\[\\liminf_{n\\to \\infty}\\sum_{0\\leq i<k}\\omega(n+i)\\leq k+\\pi(k)?\\]Is it true that\\[\\limsup_{n\\to \\infty}\\left(\\sum_{0\\leq i<k}\\omega(n+i)\\right) \\frac{\\log\\log n}{\\log n}=1?\\]\n\n\n\nA question of Erd\\H{o}s and Selfridge \\cite{ErSe67}, who observe that\\[\\liminf_{n\\to \\infty}\\sum_{0\\leq i<k}\\omega(n+i)\\geq k+\\pi(k)-1\\]for every $k$. This follows from P\\'{o}lya's theorem that the set of $k$-smooth integers has unbounded gaps - indeed, $n(n+1)\\cdots (n+k-1)$ is divisible by all primes $\\leq k$ and, provided $n$ is large, all but at most one of $n,n+1,\\ldots,n+k-1$ has a prime factor $>k$ by P\\'{o}lya's theorem.\n\nIt is a classical fact that\\[\\limsup_{n\\to \\infty}\\omega(n)\\frac{\\log\\log n}{\\log n}=1.\\]\n\n\n\n\nReferences\n\n\n[ErSe67] Erd\\H{o}s, P. and Selfridge, J. L., Some problems on the prime factors of consecutive integers. Illinois J. Math. (1967), 428--430.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #889\n- Problem #891\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErSe67\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for erdos-890 (Sum of omega over Consecutive Integers).

## Progress
- **Proved Conjecture 1 for k=1**: lim inf omega(n) <= 1 + pi(1), using infinitude of primes (Euclid)
- Proved omega_prime: omega(p) = 1 for prime p via primeFactors characterization
- Added structural lemmas: cumulativeOmega_zero, _one, _add (sum splitting)
- File expanded from 173 to 210 lines, 4 to 9 theorems

## Findings
- For k=1, S_1(n) = omega(n). Every prime p has omega(p) = 1 <= 1 + pi(1).
  Since primes are unbounded (Nat.exists_infinite_primes), the liminf condition holds.
- Sum splitting S_{k+j}(n) = S_k(n) + S_j(n+k) enables divide-and-conquer analysis
- Both axioms (Erdos-Selfridge, Hardy-Ramanujan) are deep and not eliminable from Mathlib

## Status
**Outcome**: completed
**Next Steps**: Try Conjecture 1 for k=2; explore Hardy-Ramanujan in Mathlib

Generated by researcher-2