### PR TITLE
Research: erdos-324 - eliminate 5 of 7 axioms via counterexamples

### DIFF
--- a/proofs/Proofs/Erdos324Problem.lean
+++ b/proofs/Proofs/Erdos324Problem.lean
@@ -70,29 +70,55 @@ aⁿ + bⁿ = cⁿ + dⁿ with a < b and c < d implies (a,b) = (c,d). -/
 def PowerPairSumDistinct (n : ℕ) : Prop :=
   HasDistinctPairSums (X ^ n : ℤ[X])
 
-/-- The Lander-Parkin-Selfridge conjecture implies that xⁿ works
-for all n ≥ 5. -/
-axiom lps_implies_power_distinct :
-  (∀ n : ℕ, n ≥ 5 → PowerPairSumDistinct n) → ErdosProblem324
+/-- The Lander-Parkin-Selfridge conjecture implies xⁿ works for all n ≥ 5.
+    Taking n = 5 trivially gives a solution. -/
+theorem lps_implies_power_distinct :
+    (∀ n : ℕ, n ≥ 5 → PowerPairSumDistinct n) → ErdosProblem324 :=
+  fun h => ⟨X ^ 5, h 5 (by omega)⟩
 
 /-- For n = 2, the property fails: 1² + 8² = 4² + 7² = 65. -/
-axiom squares_not_distinct : ¬PowerPairSumDistinct 2
+theorem squares_not_distinct : ¬PowerPairSumDistinct 2 := by
+  intro h
+  have hp1 : ((1 : ℕ), (8 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have hp2 : ((4 : ℕ), (7 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have heq : pairSumFn (X ^ 2 : ℤ[X]) (1, 8) = pairSumFn (X ^ 2 : ℤ[X]) (4, 7) := by
+    simp [pairSumFn, eval_pow, eval_X]; norm_num
+  exact absurd (h hp1 hp2 heq) (by decide)
 
-/-- For n = 3, the property fails: the Hardy-Ramanujan taxicab
-numbers give counterexamples (1³ + 12³ = 9³ + 10³ = 1729). -/
-axiom cubes_not_distinct : ¬PowerPairSumDistinct 3
+/-- For n = 3, the property fails: the Hardy–Ramanujan taxicab number
+    1³ + 12³ = 9³ + 10³ = 1729. -/
+theorem cubes_not_distinct : ¬PowerPairSumDistinct 3 := by
+  intro h
+  have hp1 : ((1 : ℕ), (12 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have hp2 : ((9 : ℕ), (10 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have heq : pairSumFn (X ^ 3 : ℤ[X]) (1, 12) = pairSumFn (X ^ 3 : ℤ[X]) (9, 10) := by
+    simp [pairSumFn, eval_pow, eval_X]; norm_num
+  exact absurd (h hp1 hp2 heq) (by decide)
 
-/-- For n = 4, the property fails: there exist equal sums of
-two fourth powers (Euler 1772). -/
-axiom quartics_not_distinct : ¬PowerPairSumDistinct 4
+/-- For n = 4, the property fails: 59⁴ + 158⁴ = 133⁴ + 134⁴ = 635318657
+    (Euler 1772). -/
+theorem quartics_not_distinct : ¬PowerPairSumDistinct 4 := by
+  intro h
+  have hp1 : ((59 : ℕ), (158 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have hp2 : ((133 : ℕ), (134 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have heq : pairSumFn (X ^ 4 : ℤ[X]) (59, 158) = pairSumFn (X ^ 4 : ℤ[X]) (133, 134) := by
+    simp [pairSumFn, eval_pow, eval_X]; norm_num
+  exact absurd (h hp1 hp2 heq) (by decide)
 
 /-
 ## Section V: Lower Degree Impossibility
 -/
 
-/-- Linear polynomials cannot have distinct pair sums. -/
-axiom linear_not_distinct (a b : ℤ) (ha : a ≠ 0) :
-  ¬HasDistinctPairSums (C a * X + C b)
+/-- Linear polynomials cannot have distinct pair sums:
+    for f(x) = ax + b, f(0) + f(3) = f(1) + f(2) = 3a + 2b. -/
+theorem linear_not_distinct (a b : ℤ) (ha : a ≠ 0) :
+    ¬HasDistinctPairSums (C a * X + C b) := by
+  intro h
+  have hp1 : ((0 : ℕ), (3 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have hp2 : ((1 : ℕ), (2 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have heq : pairSumFn (C a * X + C b) (0, 3) = pairSumFn (C a * X + C b) (1, 2) := by
+    simp [pairSumFn, eval_add, eval_mul, eval_C, eval_X]; push_cast; ring
+  exact absurd (h hp1 hp2 heq) (by decide)
 
 /-- The degree of any polynomial with distinct pair sums must be ≥ 5. -/
 axiom min_degree_for_distinct :

--- a/src/data/proofs/erdos-324/meta.json
+++ b/src/data/proofs/erdos-324/meta.json
@@ -21,9 +21,9 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2025-01-01",
     "mathlib_version": "4.26.0",
-    "axiomCount": 7,
-    "assumptions": "7 axiom declarations: lps_implies_power_distinct (LPS implies distinct sums), squares_not_distinct (x^2 fails), cubes_not_distinct (x^3 fails via 1729), quartics_not_distinct (x^4 fails via Euler), linear_not_distinct (linear polynomials fail), min_degree_for_distinct (degree at least 5), distinct_count_eq_binomial (count equals binomial)",
-    "lineCount": 113
+    "axiomCount": 2,
+    "assumptions": "2 axioms: min_degree_for_distinct (any polynomial with distinct pair sums has degree ≥ 5), distinct_count_eq_binomial (count of distinct pair sums equals C(N+1,2)). Five former axioms now proved: lps_implies_power_distinct (trivial), squares/cubes/quartics_not_distinct (via counterexamples 65/1729/635318657), linear_not_distinct (f(0)+f(3)=f(1)+f(2)).",
+    "lineCount": 139
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed Problem #324 in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p. 53), describing it as 'very annoying.' The question asks whether any polynomial $f \\in \\mathbb{Z}[X]$ can make all sums $f(a) + f(b)$ with $a < b$ nonnegative integers distinct.\n\nThe problem connects to a rich history of equal-sums-of-powers questions. Diophantus studied representations of numbers as sums of squares. Fermat (1640s) characterized which integers are sums of two squares. The failure of $x^2$: $65 = 1^2 + 8^2 = 4^2 + 7^2$ follows from 65 having prime factors 5 and 13, both $\\equiv 1 \\pmod{4}$. The iconic failure of $x^3$ is the Hardy-Ramanujan taxicab number $1729 = 1^3 + 12^3 = 9^3 + 10^3$, discovered by Ramanujan in 1919 during Hardy's hospital visit. Euler (1772) found $59^4 + 158^4 = 133^4 + 134^4$, showing $x^4$ fails.\n\nThe Lander-Parkin-Selfridge (LPS) conjecture (1967) predicts that $x_1^n + x_2^n = y_1^n + y_2^n$ has no nontrivial solutions for $n \\geq 5$, generalizing Fermat's Last Theorem (the $k = 1$ case, proved by Wiles 1995). LPS would immediately resolve Problem #324 via $f(x) = x^5$. Despite extensive computational searches, no counterexample to $a^5 + b^5 = c^5 + d^5$ has been found, making the quintic the natural candidate.",
@@ -191,9 +191,9 @@
       "Polynomial"
     ],
     "namespace": null,
-    "lineCount": 113,
-    "axiomCount": 7,
-    "theoremCount": 1,
+    "lineCount": 139,
+    "axiomCount": 2,
+    "theoremCount": 7,
     "definitionCount": 7
   },
   "relatedProofs": [

--- a/src/data/research/problems/erdos-324.json
+++ b/src/data/research/problems/erdos-324.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-324",
   "title": "Erdős #324",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-12T23:55:09.604Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Eliminated 5 of 7 axioms via counterexamples and trivial arguments",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Eliminated 5 of 7 axioms. Proved non-distinctness for n=2,3,4 via counterexamples and for linear polynomials via algebra. Remaining 2 axioms require deeper mathematical arguments.",
+    "builtItems": [
+      "lps_implies_power_distinct: trivial proof (take n=5)",
+      "squares_not_distinct: counterexample (1,8) vs (4,7)",
+      "cubes_not_distinct: counterexample (1,12) vs (9,10) — Hardy-Ramanujan taxicab 1729",
+      "quartics_not_distinct: counterexample (59,158) vs (133,134) — Euler 1772",
+      "linear_not_distinct: f(0)+f(3)=f(1)+f(2) for any linear f"
+    ],
+    "insights": [
+      "5 of 7 axioms eliminated: lps_implies_power_distinct (trivial), squares/cubes/quartics_not_distinct (counterexamples), linear_not_distinct (algebra).",
+      "Key counterexamples: 1²+8²=4²+7²=65, 1³+12³=9³+10³=1729, 59⁴+158⁴=133⁴+134⁴=635318657.",
+      "Remaining axioms (min_degree_for_distinct, distinct_count_eq_binomial) require deeper arguments about general polynomials."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove distinct_count_eq_binomial using Finset.card_image_of_injOn",
+      "The min_degree_for_distinct axiom requires showing ALL polynomials of degree≤4 fail, not just x^n"
+    ],
     "markdown": "# Erdős #324 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nDoes there exist a polynomial $f(x)\\in\\mathbb{Z}[x]$ such that all the sums $f(a)+f(b)$ with $a<b$ nonnegative integers are distinct?\n\n\n\nErd\\H{o}s and Graham describe this problem as 'very annoying'. Probably $f(x)=x^5$ should work. The Lander, Parkin, and Selfridge conjecture would imply that $f(x)=x^n$ has this property for all $n\\geq 5$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #323\n- Problem #325\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Axiom elimination for erdos-324 (Distinct Polynomial Pair Sums).

## Progress
- **5 of 7 axioms eliminated** — axiom count reduced from 7 to 2
- `lps_implies_power_distinct`: trivially proved (take n=5)
- `squares_not_distinct`: 1^2 + 8^2 = 4^2 + 7^2 = 65
- `cubes_not_distinct`: 1^3 + 12^3 = 9^3 + 10^3 = 1729 (taxicab)
- `quartics_not_distinct`: 59^4 + 158^4 = 133^4 + 134^4 (Euler 1772)
- `linear_not_distinct`: f(0)+f(3) = f(1)+f(2) for any linear f (ring identity)

## Remaining Axioms
- `min_degree_for_distinct`: ANY poly of degree <= 4 fails (not just x^n)
- `distinct_count_eq_binomial`: count equals C(N+1,2) (provable but involved)

## Status
**Outcome**: completed
**Next Steps**: Try proving distinct_count_eq_binomial from Finset.card_image_of_injOn

Generated by researcher-2