### PR TITLE
Enrich Cauchy-Schwarz OQ-01: annotations, cross-refs, context

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01/annotations.json
@@ -1,5 +1,73 @@
 [
   {
+    "id": "ann-module-doc",
+    "proofId": "cauchy-schwarz-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "context",
+    "title": "Module Documentation and Setup",
+    "content": "The module docstring frames this entry as an answer to an open question from the parent `cauchy-schwarz` formalization: whether Mathlib's inner product machinery extends to complex spaces.\n\nFour Mathlib imports provide the complete infrastructure:\n- `InnerProductSpace.Basic`: Core definitions including `norm_inner_le_norm`, `inner_self_eq_norm_sq_to_K`, and `norm_add_sq` (the polarization identity)\n- `InnerProductSpace.PiL2`: `EuclideanSpace` for concrete instantiations\n- `RCLike.Basic`: The typeclass abstracting $\\mathbb{R}$ and $\\mathbb{C}$, providing `RCLike.norm_re_le_norm`\n- `Tactic`: Provides `nlinarith` and `ring` for the derived results\n\nThe `open scoped InnerProductSpace` line activates the `⟪·,·⟫_𝕜` notation, which desugars to `@inner 𝕜 E _ u v` — the inner product on `E` over the scalar field `𝕜`.",
+    "mathContext": "The namespace `CauchySchwarzOQ01` scopes 10 theorems covering: three Cauchy-Schwarz forms ($\\mathbb{C}$, $\\mathbb{R}$, RCLike), two derived inequalities (real part bound, squared form), two identities (self-inner product, imaginary part zero), and three applications (triangle inequality, Pythagoras, summary conjunction).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Mathlib imports",
+      "InnerProductSpace",
+      "RCLike typeclass",
+      "notation scoping"
+    ],
+    "prerequisites": [
+      "Lean 4 import system",
+      "inner product space axioms"
+    ]
+  },
+  {
+    "id": "ann-self-inner-product",
+    "proofId": "cauchy-schwarz-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 101
+    },
+    "type": "technique",
+    "title": "Self-Inner Product and Imaginary Part",
+    "content": "Two theorems establishing the relationship between self-inner products and norms in complex spaces:\n\n**`inner_self_eq_norm_sq_complex`**: $\\langle u, u \\rangle_\\mathbb{C} = (\\|u\\|^2 : \\mathbb{C})$. The proof delegates to Mathlib's `inner_self_eq_norm_sq_to_K` with explicit scalar field annotation `(𝕜 := ℂ)`. The coercion $(\\|u\\|^2 : \\mathbb{C})$ embeds the real number $\\|u\\|^2$ into $\\mathbb{C}$ via `Complex.ofReal`.\n\n**`im_inner_self_zero`**: $(\\langle u, u \\rangle_\\mathbb{C}).\\text{im} = 0$. Since $\\langle u, u \\rangle_\\mathbb{C} = \\|u\\|^2 \\in \\mathbb{R} \\hookrightarrow \\mathbb{C}$, its imaginary part is zero. The `simp` call uses `Complex.mul_im` and `Complex.ofReal_im` to reduce the goal.\n\nTogether these confirm a defining property of inner product spaces: $\\langle u, u \\rangle$ is always a non-negative real number, even in complex spaces where $\\langle u, v \\rangle$ can be complex.",
+    "mathContext": "$\\langle u, u \\rangle_\\mathbb{C} = \\|u\\|^2 + 0i \\in \\mathbb{R}_{\\geq 0} \\hookrightarrow \\mathbb{C}$. This is a consequence of the sesquilinearity axiom: $\\langle u, u \\rangle = \\overline{\\langle u, u \\rangle}$ (by conjugate symmetry), so $\\langle u, u \\rangle \\in \\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "self-inner product",
+      "positive definiteness",
+      "Complex.ofReal",
+      "sesquilinearity"
+    ],
+    "prerequisites": [
+      "inner_self_eq_norm_sq_to_K",
+      "complex number structure"
+    ]
+  },
+  {
+    "id": "ann-inner-triangle",
+    "proofId": "cauchy-schwarz-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 115
+    },
+    "type": "technique",
+    "title": "Triangle Inequality for Inner Products",
+    "content": "**Theorem** `inner_triangle`: $\\|\\langle u, v \\rangle_\\mathbb{K} + \\langle v, w \\rangle_\\mathbb{K}\\| \\leq \\|u\\| \\cdot \\|v\\| + \\|v\\| \\cdot \\|w\\|$.\n\nThe proof chains two steps via `calc`:\n1. `norm_add_le`: the norm triangle inequality $\\|a + b\\| \\leq \\|a\\| + \\|b\\|$ applied to inner products\n2. `add_le_add` with two applications of `norm_inner_le_norm`: bounding each inner product term\n\nThis result is stated for general `RCLike` fields, so it applies to both real and complex inner product spaces simultaneously.",
+    "mathContext": "$\\|\\langle u, v \\rangle + \\langle v, w \\rangle\\| \\leq \\|\\langle u, v \\rangle\\| + \\|\\langle v, w \\rangle\\| \\leq \\|u\\|\\|v\\| + \\|v\\|\\|w\\|$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangle inequality",
+      "norm_add_le",
+      "Cauchy-Schwarz application"
+    ],
+    "prerequisites": [
+      "norm_inner_le_norm",
+      "norm_add_le"
+    ]
+  },
+  {
     "id": "ann-core-complex-cs",
     "proofId": "cauchy-schwarz-oq-01",
     "range": {
@@ -17,7 +85,11 @@
       "norm_inner_le_norm",
       "RCLike"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "complex inner product spaces",
+      "SeminormedAddCommGroup",
+      "norm_inner_le_norm"
+    ]
   },
   {
     "id": "ann-rclike-uniform",
@@ -37,7 +109,11 @@
       "inner product space",
       "Hilbert space"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "RCLike typeclass",
+      "InnerProductSpace typeclass",
+      "typeclass polymorphism"
+    ]
   },
   {
     "id": "ann-re-bound",
@@ -57,7 +133,11 @@
       "complex modulus",
       "chain of inequalities"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "le_abs_self",
+      "RCLike.norm_re_le_norm",
+      "cauchy_schwarz_complex"
+    ]
   },
   {
     "id": "ann-squared-form",
@@ -77,7 +157,11 @@
       "quadratic witness",
       "Cauchy-Schwarz"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "cauchy_schwarz_complex",
+      "norm_nonneg",
+      "nlinarith tactic"
+    ]
   },
   {
     "id": "ann-pythagoras",
@@ -97,7 +181,11 @@
       "norm_add_sq",
       "polarization identity"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "norm_add_sq (polarization identity)",
+      "map_zero",
+      "ring tactic"
+    ]
   },
   {
     "id": "ann-summary",
@@ -117,6 +205,9 @@
       "norm_inner_le_norm",
       "formalization answer"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "norm_inner_le_norm",
+      "conjunction introduction"
+    ]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01/meta.json
@@ -58,7 +58,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**From Real to Complex: Extending Cauchy-Schwarz**\n\nThe classical Cauchy-Schwarz inequality for real inner product spaces states:\n$$|\\langle u, v \\rangle| \\leq \\|u\\| \\cdot \\|v\\|$$\n\nFor complex inner product spaces, the inner product $\\langle u, v \\rangle_\\mathbb{C}$ is **sesquilinear**: conjugate-linear in the first argument, linear in the second. The generalization requires the complex modulus:\n$$\\|\\langle u, v \\rangle_\\mathbb{C}\\| \\leq \\|u\\| \\cdot \\|v\\|$$\n\n**The Open Question**: Can the existing real Cauchy-Schwarz formalization be extended to complex inner product spaces using Mathlib's `inner_mul_le_norm_mul_norm`?\n\n**The Answer**: YES — and even more is true. Mathlib's `norm_inner_le_norm` works uniformly for any field `𝕜` satisfying `[RCLike 𝕜]`, which includes both `ℝ` and `ℂ`. The complex case requires no additional work beyond what Mathlib already provides.",
+    "historicalContext": "**From Real to Complex: The Extension of Cauchy-Schwarz**\n\nThe Cauchy-Schwarz inequality originated in Augustin-Louis Cauchy's *Cours d'Analyse* (1821) as a finite-sum inequality: $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ for real sequences. Viktor Bunyakovsky independently established the integral form in 1859, and Hermann Amandus Schwarz proved it for square-integrable functions in 1885 while studying minimal surfaces — hence the inequality is also called the Cauchy-Bunyakovsky-Schwarz inequality.\n\nThe extension to complex inner product spaces was driven by the development of functional analysis in the early 20th century. John von Neumann's axiomatization of quantum mechanics (*Mathematische Grundlagen der Quantenmechanik*, 1932) placed complex Hilbert spaces at the foundation of physics, making the complex Cauchy-Schwarz inequality $\\|\\langle u, v \\rangle_\\mathbb{C}\\| \\leq \\|u\\| \\cdot \\|v\\|$ a cornerstone result. The key subtlety is sesquilinearity: the complex inner product $\\langle u, v \\rangle_\\mathbb{C}$ is conjugate-linear in the first argument and linear in the second (by Mathlib convention), so one bounds the complex modulus $\\|\\langle u, v \\rangle_\\mathbb{C}\\|$ rather than the absolute value.\n\nMathlib's formalization achieves remarkable generality via the `RCLike` typeclass, which abstracts over $\\mathbb{R}$ and $\\mathbb{C}$ simultaneously. The single theorem `norm_inner_le_norm` subsumes both the real and complex cases, answering the open question affirmatively: no separate formalization is needed for complex inner product spaces.",
     "problemStatement": "**Cauchy-Schwarz for Complex Inner Products (OQ-01)**\n\nFor vectors $u, v$ in a complex inner product space $H$:\n$$\\|\\langle u, v \\rangle_{\\mathbb{C}}\\| \\leq \\|u\\| \\cdot \\|v\\|$$\n\nwhere $\\|\\langle u, v \\rangle_{\\mathbb{C}}\\|$ denotes the complex modulus of the inner product.\n\n**Key extension**: The real case `|⟪u,v⟫_ℝ| ≤ ‖u‖·‖v‖` is a special case. For complex spaces, conjugate-linearity means $\\langle u, v \\rangle_\\mathbb{C} \\in \\mathbb{C}$, and we bound its complex modulus rather than its real absolute value.",
     "text": "Extension of Cauchy-Schwarz to complex inner product spaces: ‖⟪u,v⟫_ℂ‖ ≤ ‖u‖·‖v‖. Mathlib's norm_inner_le_norm works uniformly for all RCLike fields, answering yes to the open question.",
     "proofStrategy": "**Formalization Strategy**\n\nThe core insight is that Mathlib's `norm_inner_le_norm` is already parameterized by an `[RCLike 𝕜]` field:\n\n```lean\ntheorem norm_inner_le_norm {𝕜 : Type*} [RCLike 𝕜] {E : Type*}\n    [SeminormedAddCommGroup E] [InnerProductSpace 𝕜 E] (x y : E) :\n    ‖⟪x, y⟫_𝕜‖ ≤ ‖x‖ * ‖y‖\n```\n\nThis covers both `ℝ` and `ℂ` (and any other `RCLike` field) in one statement. The derived results follow:\n\n1. **Real part bound**: `Re(⟪u,v⟫_ℂ) ≤ ‖u‖·‖v‖` via `le_abs_self` + `RCLike.norm_re_le_norm` + Cauchy-Schwarz\n2. **Squared form**: `‖⟪u,v⟫_ℂ‖² ≤ ‖u‖²·‖v‖²` via `nlinarith` with the linear form as a hypothesis\n3. **Pythagoras**: `⟪u,v⟫=0 → ‖u+v‖²=‖u‖²+‖v‖²` via `norm_add_sq` + `ring`\n4. **Self-inner product**: `⟪u,u⟫_ℂ = (↑‖u‖)²` via `inner_self_eq_norm_sq_to_K`",
@@ -67,7 +67,9 @@
       "**No Extra Proof**: The complex case requires zero additional mathematical work. The `open scoped InnerProductSpace` notation opens `⟪·,·⟫_𝕜` and `norm_inner_le_norm` does the rest.",
       "**Conjugate-linearity is handled**: In Mathlib, complex inner products are built with conjugate-linearity in the first argument by convention. The `norm_inner_le_norm` inequality correctly bounds the complex modulus, handling the conjugation automatically.",
       "**Self-inner product elaboration**: `inner_self_eq_norm_sq_to_K` gives `⟪u,u⟫_𝕜 = (↑‖u‖)^2` where the coercion is `‖u‖ : ℝ → 𝕜`. For `𝕜 = ℂ`, this is `(↑‖u‖ : ℂ)^2 = (Complex.ofReal ‖u‖)^2`, whose imaginary part is 0 by `Complex.mul_im` and `Complex.ofReal_im`.",
-      "**Concrete instantiation**: The EuclideanSpace ℝ n specialization demonstrates that abstract inner product theorems apply to $\\mathbb{R}^n$ with the standard dot product, bridging abstract and concrete linear algebra"
+      "**Concrete instantiation**: The EuclideanSpace ℝ n specialization demonstrates that abstract inner product theorems apply to $\\mathbb{R}^n$ with the standard dot product, bridging abstract and concrete linear algebra",
+      "**Sesquilinearity vs bilinearity**: The complex case requires bounding $\\|\\langle u, v \\rangle_\\mathbb{C}\\|$ (complex modulus) rather than $|\\langle u, v \\rangle|$ (absolute value). This is because $\\langle u, v \\rangle_\\mathbb{C} \\in \\mathbb{C}$ can have nonzero imaginary part, unlike the real case. Mathlib's `norm_inner_le_norm` uses the norm $\\|\\cdot\\|$ on the scalar field, which automatically handles both cases.",
+      "**Pythagorean theorem as a consequence**: The orthogonality condition $\\langle u, v \\rangle_\\mathbb{K} = 0$ implies $\\|u+v\\|^2 = \\|u\\|^2 + \\|v\\|^2$ via the polarization identity. This generalizes the classical Pythagorean theorem from Euclidean geometry to arbitrary inner product spaces — real or complex — showing that orthogonality is the abstract essence of right angles."
     ],
     "prerequisites": [
       "Mathematical analysis",
@@ -81,42 +83,48 @@
       "title": "Imports and Setup",
       "summary": "Imports Mathlib's InnerProductSpace.Basic (which provides norm_inner_le_norm), PiL2 (EuclideanSpace), RCLike.Basic, and Tactic. Opens InnerProductSpace scope for ⟪·,·⟫_𝕜 notation.",
       "startLine": 1,
-      "endLine": 34
+      "endLine": 34,
+      "mathContext": "The four imports supply the mathematical foundation: `InnerProductSpace.Basic` provides $\\|\\langle x, y \\rangle_\\mathbb{K}\\| \\leq \\|x\\| \\cdot \\|y\\|$ and `inner_self_eq_norm_sq_to_K`; `PiL2` provides `EuclideanSpace`; `RCLike.Basic` provides the typeclass abstracting $\\mathbb{R}$ and $\\mathbb{C}$; `Tactic` provides `nlinarith` and `ring`."
     },
     {
       "id": "core-cs",
       "title": "Core Cauchy-Schwarz Theorems",
       "summary": "Three forms of Cauchy-Schwarz: (1) complex ‖⟪u,v⟫_ℂ‖ ≤ ‖u‖·‖v‖, (2) real ‖⟪u,v⟫_ℝ‖ ≤ ‖u‖·‖v‖, (3) uniform RCLike ‖⟪u,v⟫_𝕜‖ ≤ ‖u‖·‖v‖. All are one-line applications of norm_inner_le_norm.",
       "startLine": 37,
-      "endLine": 63
+      "endLine": 63,
+      "mathContext": "Three specializations of the same underlying inequality $\\|\\langle u, v \\rangle_\\mathbb{K}\\| \\leq \\|u\\| \\cdot \\|v\\|$: for $\\mathbb{K} = \\mathbb{C}$ (sesquilinear), $\\mathbb{K} = \\mathbb{R}$ (bilinear), and general `RCLike` $\\mathbb{K}$. Each is a direct application of `norm_inner_le_norm`."
     },
     {
       "id": "derived",
       "title": "Derived Inequalities",
       "summary": "Re(⟪u,v⟫_ℂ) ≤ ‖u‖·‖v‖ via RCLike.norm_re_le_norm chained with Cauchy-Schwarz. Squared form ‖⟪u,v⟫_ℂ‖² ≤ ‖u‖²·‖v‖² via nlinarith from the linear bound.",
       "startLine": 64,
-      "endLine": 89
+      "endLine": 89,
+      "mathContext": "Two derived forms: (1) $\\text{Re}\\langle u, v \\rangle_\\mathbb{C} \\leq |\\text{Re}\\langle u, v \\rangle_\\mathbb{C}| \\leq \\|\\langle u, v \\rangle_\\mathbb{C}\\| \\leq \\|u\\| \\cdot \\|v\\|$ via a three-step `calc` chain; (2) $\\|\\langle u, v \\rangle_\\mathbb{C}\\|^2 \\leq \\|u\\|^2 \\cdot \\|v\\|^2$ by squaring with `nlinarith`."
     },
     {
       "id": "self-inner",
       "title": "Self-Inner Product Identity",
       "summary": "inner_self_eq_norm_sq_to_K gives ⟪u,u⟫_ℂ = (↑‖u‖)² in ℂ. The imaginary part zero follows from Complex.mul_im and Complex.ofReal_im.",
       "startLine": 90,
-      "endLine": 108
+      "endLine": 108,
+      "mathContext": "$\\langle u, u \\rangle_\\mathbb{C} = \\|u\\|^2 \\in \\mathbb{R}_{\\geq 0} \\hookrightarrow \\mathbb{C}$. This identity connects the abstract inner product to the concrete norm, and establishes that self-inner products are always real and non-negative — a defining property of inner product spaces."
     },
     {
       "id": "consequences",
       "title": "Triangle Inequality and Pythagoras",
       "summary": "Triangle inequality for inner products via norm_add_le applied to ⟪u,v⟫+⟪v,w⟫. Pythagorean theorem from orthogonality via norm_add_sq and ring.",
       "startLine": 109,
-      "endLine": 130
+      "endLine": 130,
+      "mathContext": "Two applications: (1) $\\|\\langle u, v \\rangle + \\langle v, w \\rangle\\| \\leq \\|u\\| \\cdot \\|v\\| + \\|v\\| \\cdot \\|w\\|$ combines norm triangle inequality with Cauchy-Schwarz; (2) $\\langle u, v \\rangle = 0 \\implies \\|u+v\\|^2 = \\|u\\|^2 + \\|v\\|^2$ via the polarization identity $\\|u+v\\|^2 = \\|u\\|^2 + 2\\text{Re}\\langle u,v\\rangle + \\|v\\|^2$."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
       "summary": "A single ∧-statement asserting that norm_inner_le_norm gives complex Cauchy-Schwarz both as a ℂ-specific result and as the uniform RCLike result.",
       "startLine": 131,
-      "endLine": 138
+      "endLine": 138,
+      "mathContext": "A formal conjunction: $(\\forall E, \\forall u\\,v \\in E,\\; \\|\\langle u,v\\rangle_\\mathbb{C}\\| \\leq \\|u\\| \\cdot \\|v\\|) \\;\\wedge\\; (\\forall \\mathbb{K}\\;(\\text{RCLike}),\\; \\forall E, \\forall u\\,v \\in E,\\; \\|\\langle u,v\\rangle_\\mathbb{K}\\| \\leq \\|u\\| \\cdot \\|v\\|)$."
     }
   ],
   "conclusion": {
@@ -125,7 +133,9 @@
     "openQuestions": [
       "Can the equality characterization (‖⟪u,v⟫_ℂ‖ = ‖u‖·‖v‖ ↔ u and v are linearly dependent) be stated and proved for complex inner product spaces?",
       "Can the complex Gram-Schmidt process be formalized using this Cauchy-Schwarz bound?",
-      "Can the Heisenberg uncertainty principle be derived from this complex Cauchy-Schwarz in Lean 4?"
+      "Can the Heisenberg uncertainty principle be derived from this complex Cauchy-Schwarz in Lean 4?",
+      "Can the Bessel inequality $\\sum_k |\\langle u, e_k \\rangle|^2 \\leq \\|u\\|^2$ for orthonormal systems be formalized as a consequence of iterated Cauchy-Schwarz and Pythagoras?",
+      "The Riesz representation theorem states that every bounded linear functional on a Hilbert space has the form $f \\mapsto \\langle v, f \\rangle$ for some $v$, with operator norm $\\|v\\|$. Can this be derived using the complex Cauchy-Schwarz bound as the key estimate?"
     ]
   },
   "leanFile": {
@@ -165,16 +175,79 @@
       "year": "1859",
       "venue": "Memoires de l'Academie Imperiale des Sciences de St.-Petersbourg",
       "note": "Independent discovery of the integral form"
+    },
+    {
+      "authors": "J. von Neumann",
+      "title": "Mathematische Grundlagen der Quantenmechanik",
+      "year": "1932",
+      "venue": "Springer",
+      "note": "Axiomatized quantum mechanics on complex Hilbert spaces, making complex Cauchy-Schwarz a foundational result in physics"
+    },
+    {
+      "authors": "P. R. Halmos",
+      "title": "Introduction to Hilbert Space and the Theory of Spectral Multiplicity",
+      "year": "1951",
+      "venue": "Chelsea Publishing",
+      "note": "Standard reference for inner product space theory; presents Cauchy-Schwarz as the key inequality from which the triangle inequality and continuity of the inner product follow"
+    },
+    {
+      "authors": "M. Reed; B. Simon",
+      "title": "Methods of Modern Mathematical Physics I: Functional Analysis",
+      "year": "1980",
+      "venue": "Academic Press, revised edition",
+      "note": "Develops Cauchy-Schwarz in the context of complex Hilbert spaces and operator theory, with applications to quantum mechanics"
     }
   ],
   "crossReferences": [
     {
       "targetId": "cauchy-schwarz",
       "relationship": "extends",
-      "description": "Parent formalization; this entry extends it with further exploration"
+      "description": "Parent formalization proving the real Cauchy-Schwarz inequality |⟪u,v⟫_ℝ| ≤ ‖u‖·‖v‖. This entry extends it to complex inner product spaces and the uniform RCLike framework"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03",
+      "relationship": "related",
+      "description": "Sibling open question exploring further aspects of Cauchy-Schwarz — together these entries form a comprehensive treatment of the inequality across different formulations"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-04",
+      "relationship": "related",
+      "description": "Sibling open question investigating additional consequences and extensions of the Cauchy-Schwarz inequality"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "complementary",
+      "description": "The integral form of Cauchy-Schwarz: $(\\int fg)^2 \\leq (\\int f^2)(\\int g^2)$. This entry proves the abstract inner product space version; the integral entry proves the $L^2$ specialization via Hölder's inequality"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Further exploration building on this entry's complex Cauchy-Schwarz result"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The classical Pythagorean theorem $a^2 + b^2 = c^2$ is a special case of the abstract Pythagorean theorem proved here: orthogonality ($\\langle u,v \\rangle = 0$) implies $\\|u+v\\|^2 = \\|u\\|^2 + \\|v\\|^2$ in any inner product space"
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "related",
+      "description": "The triangle inequality $\\|u+v\\| \\leq \\|u\\| + \\|v\\|$ for normed spaces is proved using Cauchy-Schwarz in inner product spaces: expand $\\|u+v\\|^2$ and apply Re⟪u,v⟫ ≤ ‖u‖·‖v‖ (proved in this entry as re_inner_le_norm_mul)"
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "AM-GM and Cauchy-Schwarz are both fundamental inequalities in analysis. Cauchy-Schwarz can be derived from AM-GM applied to the quadratic $\\|u - tv\\|^2 \\geq 0$, optimized over $t$"
     }
   ],
   "relatedProofs": [
-    "cauchy-schwarz"
+    "cauchy-schwarz",
+    "cauchy-schwarz-oq-03",
+    "cauchy-schwarz-oq-04",
+    "cauchy-schwarz-integral",
+    "cauchy-schwarz-oq-01-oq-01",
+    "pythagorean-theorem",
+    "triangle-inequality",
+    "amgm-inequality"
   ]
 }


### PR DESCRIPTION
Enrichment pass for cauchy-schwarz-oq-01 (Complex Inner Product Spaces).

**Improvements:**
- Annotations: 6 → 9 (added coverage for imports/setup, self-inner product, triangle inequality)
- Cross-references: 1 → 8 (linked to cauchy-schwarz family, pythagorean-theorem, triangle-inequality, amgm-inequality)
- Historical context: 878 → 1575 chars (added Bunyakovsky, von Neumann, RCLike significance)
- Key insights: 5 → 7 (sesquilinearity vs bilinearity, Pythagorean consequence)
- Sections: all 6 now have mathContext fields
- All 9 annotations now have non-empty prerequisites
- Open questions: 3 → 5 (Bessel inequality, Riesz representation)
- References: 3 → 6 (von Neumann, Halmos, Reed & Simon)