### PR TITLE
Research: erdos-1149 - Prove all 3 sorries (0 remaining)

### DIFF
--- a/proofs/Proofs/Erdos1149Problem.lean
+++ b/proofs/Proofs/Erdos1149Problem.lean
@@ -230,21 +230,86 @@ Step 3: countCoprimePairs N / N² → 6/π² (asymptotic analysis)
 theorem moebius_sum_divisors_eq (n : ℕ) (hn : 0 < n) :
     ∑ d ∈ n.divisors, (ArithmeticFunction.moebius d : ℤ) =
       if n = 1 then 1 else 0 := by
-  -- From (ζ * μ) = 1 (Dirichlet convolution identity)
-  -- (ζ * μ)(n) = ∑_{d|n} ζ(d) · μ(n/d) = ∑_{d|n} μ(n/d) = 1(n)
-  -- By change of variable over divisors, ∑_{d|n} μ(d) = 1(n) as well
-  sorry
+  -- Proof via μ * ζ = ε (Dirichlet identity in ArithmeticFunction ℤ)
+  trans (((ArithmeticFunction.moebius : ArithmeticFunction ℤ) *
+         ↑(ArithmeticFunction.zeta : ArithmeticFunction ℕ)) n)
+  · rw [ArithmeticFunction.mul_apply]
+    simp_rw [ArithmeticFunction.natCoe_apply, ArithmeticFunction.zeta_apply]
+    have h_simp : ∀ x ∈ n.divisorsAntidiagonal,
+        ArithmeticFunction.moebius x.1 * (↑(if x.2 = 0 then (0 : ℕ) else 1) : ℤ) =
+        ArithmeticFunction.moebius x.1 := by
+      intro x hx
+      have hmem := Nat.mem_divisorsAntidiagonal.mp hx
+      have hx2 : x.2 ≠ 0 := by
+        intro h; exact hmem.2 (by rw [← hmem.1, h, mul_zero])
+      simp [hx2]
+    rw [Finset.sum_congr rfl h_simp]
+    symm
+    apply Finset.sum_nbij Prod.fst
+    · intro x hx
+      have hmem := Nat.mem_divisorsAntidiagonal.mp hx
+      exact Nat.mem_divisors.mpr ⟨⟨x.2, hmem.1.symm⟩, hmem.2⟩
+    · intro x₁ hx₁ x₂ hx₂ h
+      have h1 := (Nat.mem_divisorsAntidiagonal.mp hx₁).1
+      have h2 := (Nat.mem_divisorsAntidiagonal.mp hx₂).1
+      have h2_ne := (Nat.mem_divisorsAntidiagonal.mp hx₂).2
+      have h_ne : x₂.1 ≠ 0 := by
+        intro hz; exact h2_ne (by rw [← h2, hz, zero_mul])
+      have h_eq : x₁.1 * x₁.2 = x₂.1 * x₂.2 := h1.trans h2.symm
+      ext
+      · exact h
+      · exact mul_left_cancel₀ h_ne (by rwa [h] at h_eq)
+    · intro d hd
+      exact ⟨(d, n / d), Nat.mem_divisorsAntidiagonal.mpr
+        ⟨Nat.mul_div_cancel' (Nat.dvd_of_mem_divisors hd), hn.ne'⟩, rfl⟩
+    · intro _ _; rfl
+  · rw [ArithmeticFunction.moebius_mul_coe_zeta, ArithmeticFunction.one_apply]
 
 /-- The number of multiples of d in {1, ..., N} is ⌊N/d⌋. -/
 theorem card_multiples (d N : ℕ) (hd : 0 < d) :
     (Finset.filter (fun a => d ∣ a) (Finset.Icc 1 N)).card = N / d := by
-  sorry -- Routine Finset counting, good Aristotle candidate
+  -- Bijection: multiples of d in [1,N] ↔ {0,...,N/d-1} via a ↦ a/d - 1
+  have h_eq : Finset.filter (fun a => d ∣ a) (Finset.Icc 1 N) =
+      (Finset.range (N / d)).image (fun j => (j + 1) * d) := by
+    ext a
+    simp only [Finset.mem_filter, Finset.mem_Icc, Finset.mem_image, Finset.mem_range]
+    constructor
+    · rintro ⟨⟨ha1, haN⟩, ⟨k, rfl⟩⟩
+      have hk_pos : 0 < k := by
+        by_contra h; push_neg at h; interval_cases k; simp at ha1
+      have hk_le : k ≤ N / d := by
+        rw [Nat.le_div_iff_mul_le hd]
+        calc k * d = d * k := mul_comm k d
+          _ ≤ N := haN
+      exact ⟨k - 1, by omega, by rw [Nat.sub_add_cancel (by omega : 1 ≤ k), mul_comm]⟩
+    · rintro ⟨j, hj, rfl⟩
+      refine ⟨⟨?_, ?_⟩, dvd_mul_left d (j + 1)⟩
+      · exact Nat.one_le_iff_ne_zero.mpr (mul_ne_zero (by omega) hd.ne')
+      · calc (j + 1) * d ≤ N / d * d := by nlinarith
+          _ ≤ N := Nat.div_mul_le_self N d
+  rw [h_eq]
+  rw [Finset.card_image_of_injective _ (fun a b h => by
+    have := mul_right_cancel₀ hd.ne' h; omega)]
+  exact Finset.card_range _
 
 /-- For prime p, exactly ⌊N/p⌋² pairs (a,b) in [1,N]² have p | gcd(a,b). -/
 theorem pairs_with_common_factor (p N : ℕ) (hp : Nat.Prime p) :
     ((Finset.Icc 1 N ×ˢ Finset.Icc 1 N).filter
       (fun ab => p ∣ Nat.gcd ab.1 ab.2)).card = (N / p) ^ 2 := by
-  sorry -- Counts pairs where p | a and p | b
+  -- p | gcd(a,b) ↔ p | a ∧ p | b: factor the product set
+  have h_filter : (Finset.Icc 1 N ×ˢ Finset.Icc 1 N).filter
+      (fun ab => p ∣ Nat.gcd ab.1 ab.2) =
+      Finset.filter (fun a => p ∣ a) (Finset.Icc 1 N) ×ˢ
+      Finset.filter (fun b => p ∣ b) (Finset.Icc 1 N) := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_Icc]
+    constructor
+    · rintro ⟨⟨ha, hb⟩, hdvd⟩
+      exact ⟨⟨ha, dvd_trans hdvd (Nat.gcd_dvd_left a b)⟩,
+             ⟨hb, dvd_trans hdvd (Nat.gcd_dvd_right a b)⟩⟩
+    · rintro ⟨⟨ha, hdva⟩, ⟨hb, hdvb⟩⟩
+      exact ⟨⟨ha, hb⟩, Nat.dvd_gcd hdva hdvb⟩
+  rw [h_filter, Finset.card_product, card_multiples p N hp.pos, sq]
 
 /-- The "probability" interpretation: 6/π² = 1/ζ(2).
     Since ζ(2) = π²/6 (Basel problem), we have 6/π² = 1/ζ(2). -/

--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -19,13 +19,13 @@
       "zeta-function"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "axioms": 2,
     "erdosNumber": 1149,
     "erdosUrl": "https://erdosproblems.com/1149",
     "erdosProblemStatus": "solved",
     "dateAdded": "2026-03-11",
-    "dateUpdated": "2026-03-23",
+    "dateUpdated": "2026-03-24",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "Definition IsFloorPowerCoprime, coprimeFloorPowerSet, countCoprime, HasNaturalDensity, countCoprimePairs",
@@ -39,7 +39,10 @@
       "Proved bergelson_richter_density (HasNaturalDensity reformulation)",
       "Proved coprime_pair_symm, countCoprimePairs_one (coprime pair infrastructure)",
       "Axiom bergelson_richter (main theorem)",
-      "Axiom random_coprime_density (classical 6/π² coprime probability)"
+      "Axiom random_coprime_density (classical 6/π² coprime probability)",
+      "Proved moebius_sum_divisors_eq (Möbius inversion identity via Dirichlet convolution)",
+      "Proved card_multiples (bijection counting multiples of d in [1,N])",
+      "Proved pairs_with_common_factor (factoring coprime pair filter into product set)"
     ],
     "mathlibDependencies": [
       {
@@ -87,10 +90,10 @@
       "Divisibility and powers (dvd_pow_self)"
     ],
     "lineCount": 218,
-    "assumptions": "2 axioms (bergelson_richter, random_coprime_density) and 3 sorries (routine Finset counting lemmas). The main density theorem is axiomatized; the sorries are in supporting coprime pair counting infrastructure."
+    "assumptions": "2 axioms (bergelson_richter, random_coprime_density). The main density theorem is axiomatized (deep ergodic theory); all supporting lemmas are fully proved including Möbius inversion identity, card_multiples, and pairs_with_common_factor."
   },
   "overview": {
-    "summary": "Formalizes Erdős Problem #1149, solved by Bergelson and Richter (2017): for non-integer α > 0, the natural density of integers n with gcd(n, ⌊n^α⌋) = 1 is exactly 6/π². The main theorem is axiomatized (deep ergodic theory), with 13 proved theorems: density bounds, coprime set properties (nonemptiness, n=1 membership, floor=1 criterion), HasNaturalDensity reformulation, coprime pair counting infrastructure, and integer exponent exclusion. 218 lines, 3 sorries, 2 axioms.",
+    "summary": "Formalizes Erdős Problem #1149, solved by Bergelson and Richter (2017): for non-integer α > 0, the natural density of integers n with gcd(n, ⌊n^α⌋) = 1 is exactly 6/π². The main theorem is axiomatized (deep ergodic theory), with 16 proved theorems including density bounds, coprime set properties, Möbius inversion identity, coprime pair counting via Finset bijections, and integer exponent exclusion. 0 sorries, 2 axioms.",
     "keyIdea": "The value 6/π² = 1/ζ(2) is the probability that two 'random' integers are coprime. The Bergelson-Richter theorem shows that n and ⌊n^α⌋ achieve exactly this coprime density despite being deterministically related — the floor-power function acts as a 'pseudorandom' generator for coprimality. The integer case is degenerate (gcd(n, n^k) = n), making the non-integer hypothesis essential.",
     "historicalContext": "Erdős asked whether $n$ and $\\lfloor n^\\alpha \\rfloor$ (for irrational $\\alpha > 1$) are coprime with natural density $6/\\pi^2 = 1/\\zeta(2) \\approx 0.6079$. This value is the classical probability that two uniformly random integers are coprime, first computed by Cesàro (1881) and Sylvester using Euler's product formula $\\prod_p (1 - 1/p^2) = 6/\\pi^2$.\n\nThe difficulty lies in the deterministic structure of the sequence $\\lfloor n^\\alpha \\rfloor$: unlike random integers, it has specific arithmetic properties that could bias coprimality. Vitaly Bergelson and Florian K. Richter (2017) proved Erdős's conjecture affirmatively, showing that the coprimality density is indeed $6/\\pi^2$ for any irrational $\\alpha > 1$. Their proof uses the theory of multiplicative functions along polynomial sequences and results from ergodic theory, establishing that the 'randomness' expectation holds for this structured sequence.",
     "problemStatement": "**Erdős Problem #1149** (SOLVED): Let $\\alpha > 0$ be a non-integer. Then\n$$\\lim_{N \\to \\infty} \\frac{|\\{n \\leq N : \\gcd(n, \\lfloor n^\\alpha \\rfloor) = 1\\}|}{N} = \\frac{6}{\\pi^2}.$$",
@@ -156,7 +159,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős #1149, proved by Bergelson-Richter (2017). The density of integers n coprime to ⌊n^α⌋ is 6/π² for non-integer α > 0. All theorems compile with 0 sorries. The 2 axioms capture deep results: the Bergelson-Richter theorem (ergodic theory) and classical coprime density (Euler product).",
+    "summary": "This formalization captures Erdős #1149, proved by Bergelson-Richter (2017). The density of integers n coprime to ⌊n^α⌋ is 6/π² for non-integer α > 0. All 16 theorems compile with 0 sorries. The 2 axioms capture deep results: the Bergelson-Richter theorem (ergodic theory) and classical coprime density (Euler product). Möbius inversion infrastructure fully proved.",
     "implications": "The result reveals that the deterministic function n ↦ ⌊n^α⌋ exhibits 'pseudorandom' behavior in the coprimality sense, connecting deterministic number theory to probabilistic heuristics\nThe proof technique (multiplicative functions along polynomial sequences) has applications beyond coprimality — it extends to other arithmetic functions evaluated at ⌊n^α⌋\nThe connection to ζ(2) = π²/6 places this result in the broader context of the Riemann zeta function and its role in counting problems\nThe integer exclusion argument shows that the non-integer hypothesis is not just technical but reflects a genuine phase transition in arithmetic behavior",
     "openQuestions": [
       "What is the density for more general functions f(n) replacing ⌊n^α⌋?",
@@ -205,8 +208,8 @@
     "namespace": "Erdos1149",
     "lineCount": 218,
     "axiomCount": 2,
-    "sorryCount": 3,
-    "theoremCount": 13,
+    "sorryCount": 0,
+    "theoremCount": 16,
     "definitionCount": 5
   },
   "references": [


### PR DESCRIPTION
## Summary
- Proved all 3 remaining sorries in `Erdos1149Problem.lean`
- File now has **0 sorries**, 2 axioms, 16 proved theorems

## Proofs Added

### 1. `moebius_sum_divisors_eq` — Möbius inversion identity
∑_{d|n} μ(d) = [n=1]. Proved via `ArithmeticFunction.moebius_mul_coe_zeta` (the Dirichlet identity μ * ζ = ε) and an explicit `Prod.fst` bijection between `divisorsAntidiagonal` and `divisors`.

### 2. `card_multiples` — Counting multiples in an interval  
|{a ∈ [1,N] : d|a}| = N/d. Proved via bijection with `Finset.range(N/d)` using the image map j ↦ (j+1)*d.

### 3. `pairs_with_common_factor` — Coprime pair counting
|{(a,b) ∈ [1,N]² : p|gcd(a,b)}| = (N/p)². Proved by factoring the filtered product set into two independent filtered sets and applying `card_multiples`.

## Docker Build
All proofs verified via Docker build (`Proofs.Erdos1149Problem` builds successfully).

## Status
**Outcome**: completed (sorry elimination)
**Next Steps**: Investigate eliminating `random_coprime_density` axiom via Möbius counting + Basel problem

🤖 Generated by researcher-4