### PR TITLE
Research: erdos-884 - prove 3 axioms (nonneg sums + multiplicative τ)

### DIFF
--- a/proofs/Proofs/Erdos884Problem.lean
+++ b/proofs/Proofs/Erdos884Problem.lean
@@ -104,11 +104,21 @@ axiom erdos_884 : ErdosConjecture884
 
 /- ## Basic Properties -/
 
-/-- The all-pairs sum is non-negative. -/
-axiom allPairsSum_nonneg (n : ℕ) : allPairsSum n ≥ 0
+/-- The all-pairs sum is non-negative (sum of 1/gap ≥ 0). -/
+theorem allPairsSum_nonneg (n : ℕ) : allPairsSum n ≥ 0 := by
+  unfold allPairsSum
+  apply Finset.sum_nonneg
+  intro i _
+  apply Finset.sum_nonneg
+  intro j _
+  exact div_nonneg one_pos.le (Nat.cast_nonneg _)
 
-/-- The consecutive-pairs sum is non-negative. -/
-axiom consecutivePairsSum_nonneg (n : ℕ) : consecutivePairsSum n ≥ 0
+/-- The consecutive-pairs sum is non-negative (sum of 1/gap ≥ 0). -/
+theorem consecutivePairsSum_nonneg (n : ℕ) : consecutivePairsSum n ≥ 0 := by
+  unfold consecutivePairsSum
+  apply Finset.sum_nonneg
+  intro i _
+  exact div_nonneg one_pos.le (Nat.cast_nonneg _)
 
 /-- Number of terms in consecutive-pairs sum: τ(n) - 1. -/
 theorem consecutivePairsSum_num_terms (n : ℕ) (hn : n > 0) :
@@ -136,10 +146,13 @@ axiom gap_lower_bound (n i j : ℕ) (hij : i < j) :
     generalGap n i j ≥ consecutiveGap n i
 
 /-- For coprime m, n: τ(mn) = τ(m) · τ(n).
-    This multiplicativity of the divisor count affects gap patterns. -/
-axiom numDivisors_mul_coprime (m n : ℕ) (hm : m > 0) (hn : n > 0)
+    Proved from Mathlib's Nat.Coprime.divisors_mul and Finset.card_product. -/
+theorem numDivisors_mul_coprime (m n : ℕ) (hm : m > 0) (hn : n > 0)
     (hcop : Nat.Coprime m n) :
-    numDivisors (m * n) = numDivisors m * numDivisors n
+    numDivisors (m * n) = numDivisors m * numDivisors n := by
+  unfold numDivisors
+  rw [Nat.Coprime.divisors_mul hcop]
+  exact Finset.card_map _
 
 /- ## Connections -/
 

--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -60,9 +60,9 @@
       "divisorHarmonicSum definition: σ_{-1}(n)",
       "Examples: divisors of 6, prime divisors, prime case equality"
     ],
-    "axiomCount": 12,
-    "assumptions": "12 axiom declarations: divisor list properties (sorted, membership, positive gaps), the main conjecture (∃ C, allPairsSum ≤ C(1 + consecutivePairsSum)), nonnegativity of both sums, gap lower bound (general gaps ≥ consecutive gaps), multiplicativity of τ, and concrete examples (divisors of 6, prime divisors). Most encode basic divisor arithmetic properties.",
-    "lineCount": 155
+    "axiomCount": 9,
+    "assumptions": "9 axioms: divisorList_sorted, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, erdos_884 (main conjecture), divisors_6, divisors_prime, prime_case_equality, gap_lower_bound. 3 proved: allPairsSum_nonneg (sum_nonneg), consecutivePairsSum_nonneg (sum_nonneg), numDivisors_mul_coprime (Mathlib).",
+    "lineCount": 168
   },
   "overview": {
     "historicalContext": "Erdős Problem #884 appears in [Er98] and asks about the relationship between two sums over divisor gaps. Given the divisors d₁ < d₂ < ··· < d_t of a positive integer n, one can form either the all-pairs sum (summing 1/(d_j - d_i) over all i < j) or the consecutive-pairs sum (summing only over adjacent divisors). The question is whether the all-pairs sum is controlled by the consecutive-pairs sum up to an absolute constant.\n\nThe problem is related to Erdős Problem #144 on divisor arithmetic. Terence Tao has indicated that this problem appears tractable, suggesting it may be amenable to combinatorial or analytic arguments about divisor distributions.\n\nThe trivial observation is that for primes p, both sums equal 1/(p-1) since there is only one pair of divisors {1, p}. For composite numbers with many divisors, the all-pairs sum has O(τ²) terms while the consecutive-pairs sum has only O(τ) terms, making the conjectured bound non-trivial.",
@@ -214,9 +214,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos884",
-    "lineCount": 155,
-    "axiomCount": 12,
-    "theoremCount": 2,
+    "lineCount": 168,
+    "axiomCount": 9,
+    "theoremCount": 5,
     "definitionCount": 9
   }
 }

--- a/src/data/research/problems/erdos-884.json
+++ b/src/data/research/problems/erdos-884.json
@@ -16,9 +16,9 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-15T10:46:46.306Z",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,12 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 12 axioms, divisorList is noncomputable so no native_decide. Most axioms are structural or the open conjecture.",
-    "builtItems": [],
+    "progressSummary": "AXIOM CLEANUP: Proved 3 axioms (allPairsSum_nonneg, consecutivePairsSum_nonneg, numDivisors_mul_coprime). Axioms: 12→9.",
+    "builtItems": [
+      "theorem allPairsSum_nonneg: sum_nonneg + div_nonneg",
+      "theorem consecutivePairsSum_nonneg: sum_nonneg + div_nonneg",
+      "theorem numDivisors_mul_coprime: from Nat.Coprime.divisors_mul"
+    ],
     "insights": [
       "divisorList is noncomputable (prevents native_decide for concrete values like divisors_6)",
       "allPairsSum_nonneg and consecutivePairsSum_nonneg could be provable if sums over positive terms are proved to be non-negative",
-      "Main conjecture erdos_884 is open (though Tao considers it tractable)"
+      "Main conjecture erdos_884 is open (though Tao considers it tractable)",
+      "allPairsSum_nonneg and consecutivePairsSum_nonneg: trivially sums of 1/gap ≥ 0 terms",
+      "numDivisors_mul_coprime: in Mathlib as Nat.Coprime.divisors_mul + Finset.card_map"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -61,9 +67,9 @@
     {
       "path": "Proofs/Erdos884Problem.lean",
       "filename": "Erdos884Problem.lean",
-      "lineCount": 156,
-      "theoremCount": 2,
-      "axiomCount": 12,
+      "lineCount": 168,
+      "theoremCount": 5,
+      "axiomCount": 9,
       "defCount": 9,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- **Prove** `allPairsSum_nonneg` and `consecutivePairsSum_nonneg` via `Finset.sum_nonneg`
- **Prove** `numDivisors_mul_coprime` from `Nat.Coprime.divisors_mul` + `Finset.card_map`
- **Reduce axiom count** from 12 to 9

## Remaining Axioms (9)
The main conjecture `erdos_884` (OPEN), divisor list properties, gap positivity, examples, and structural lemmas.

🤖 Generated by researcher-7