### PR TITLE
Research: erdos-1170 - Eliminate 6 of 7 axioms via constructive definitions

### DIFF
--- a/proofs/Proofs/Erdos1170Problem.lean
+++ b/proofs/Proofs/Erdos1170Problem.lean
@@ -19,6 +19,11 @@ there exists a homogeneous set of order type β.
 The question asks about the consistency (not provability) of this property,
 meaning it involves forcing and independence results.
 
+Formalization Notes:
+- Partition relations are defined constructively using order-preserving embeddings
+- Of the original 7 axioms, 6 have been eliminated (proved or replaced by defs)
+- Only laver_consistency remains as axiom (deep forcing/independence result)
+
 Reference: https://erdosproblems.com/1170
 -/
 
@@ -47,38 +52,74 @@ noncomputable def omega2 : Ordinal.{0} := (Cardinal.aleph 2).ord
 noncomputable def omega1Sq : Ordinal.{0} := omega1 * omega1
 
 -- ============================================================
--- PART 2: Partition Relation Definitions
+-- PART 2: Partition Relation Definitions (Constructive)
 -- ============================================================
 
 /-- The balanced 2-color ordinal partition relation α → (β)²₂:
-    for any 2-coloring of pairs from α, there exists a homogeneous subset
-    of order type β (monochromatic in either color).
+    for any 2-coloring of pairs from a well-ordered set of type α,
+    there exists a β-length homogeneous chain (monochromatic in either color).
+
+    Formally: there exists a strictly increasing function g from ordinals
+    below β into ordinals below α such that all pairs receive the same color.
+    The image of g is a homogeneous subset of order type β.
 
     This is stronger than the polarized relation α → (β, γ)² since
     we require the *same* order type β for both colors. -/
-axiom ordinalPartitionBalanced (α β : Ordinal.{0}) : Prop
+def ordinalPartitionBalanced (α β : Ordinal.{0}) : Prop :=
+  ∀ f : Ordinal.{0} → Ordinal.{0} → Fin 2,
+    ∃ (g : Ordinal.{0} → Ordinal.{0}) (c : Fin 2),
+      (∀ i, i < β → g i < α) ∧
+      (∀ i j, i < j → j < β → g i < g j) ∧
+      (∀ i j, i < j → j < β → f (g i) (g j) = c)
 
 /-- The polarized 2-color partition relation α → (β, γ)²:
     for any 2-coloring of pairs from α, there exists either a
-    monochromatic-0 subset of order type β or a monochromatic-1
-    subset of order type γ. -/
-axiom ordinalPartitionPolarized (α β γ : Ordinal.{0}) : Prop
+    monochromatic-0 chain of length β or a monochromatic-1 chain of length γ.
+
+    Formally: either there is a strictly increasing g from ordinals below β
+    into ordinals below α with all pairs colored 0, or similarly for γ and color 1. -/
+def ordinalPartitionPolarized (α β γ : Ordinal.{0}) : Prop :=
+  ∀ f : Ordinal.{0} → Ordinal.{0} → Fin 2,
+    (∃ g : Ordinal.{0} → Ordinal.{0},
+      (∀ i, i < β → g i < α) ∧
+      (∀ i j, i < j → j < β → g i < g j) ∧
+      (∀ i j, i < j → j < β → f (g i) (g j) = 0)) ∨
+    (∃ g : Ordinal.{0} → Ordinal.{0},
+      (∀ i, i < γ → g i < α) ∧
+      (∀ i j, i < j → j < γ → g i < g j) ∧
+      (∀ i j, i < j → j < γ → f (g i) (g j) = 1))
 
 -- ============================================================
--- PART 3: Basic Properties of Partition Relations
+-- PART 3: Basic Properties of Partition Relations (Proved)
 -- ============================================================
 
 /-- The balanced relation implies the polarized relation with equal targets. -/
-axiom balanced_implies_polarized (α β : Ordinal.{0}) :
-    ordinalPartitionBalanced α β → ordinalPartitionPolarized α β β
+theorem balanced_implies_polarized (α β : Ordinal.{0}) :
+    ordinalPartitionBalanced α β → ordinalPartitionPolarized α β β := by
+  intro h f
+  obtain ⟨g, c, hbound, hmono, hcolor⟩ := h f
+  fin_cases c
+  · left; exact ⟨g, hbound, hmono, hcolor⟩
+  · right; exact ⟨g, hbound, hmono, hcolor⟩
 
 /-- Monotonicity: if α → (β)²₂ and β' ≤ β, then α → (β')²₂. -/
-axiom balanced_mono_target (α β β' : Ordinal.{0}) :
-    ordinalPartitionBalanced α β → β' ≤ β → ordinalPartitionBalanced α β'
+theorem balanced_mono_target (α β β' : Ordinal.{0}) :
+    ordinalPartitionBalanced α β → β' ≤ β → ordinalPartitionBalanced α β' := by
+  intro h hle f
+  obtain ⟨g, c, hbound, hmono, hcolor⟩ := h f
+  exact ⟨g, c,
+    fun i hi => hbound i (lt_of_lt_of_le hi hle),
+    fun i j hij hj => hmono i j hij (lt_of_lt_of_le hj hle),
+    fun i j hij hj => hcolor i j hij (lt_of_lt_of_le hj hle)⟩
 
 /-- Monotonicity in the source: if α → (β)²₂ and α ≤ α', then α' → (β)²₂. -/
-axiom balanced_mono_source (α α' β : Ordinal.{0}) :
-    ordinalPartitionBalanced α β → α ≤ α' → ordinalPartitionBalanced α' β
+theorem balanced_mono_source (α α' β : Ordinal.{0}) :
+    ordinalPartitionBalanced α β → α ≤ α' → ordinalPartitionBalanced α' β := by
+  intro h hle f
+  obtain ⟨g, c, hbound, hmono, hcolor⟩ := h f
+  exact ⟨g, c,
+    fun i hi => lt_of_lt_of_le (hbound i hi) hle,
+    hmono, hcolor⟩
 
 -- ============================================================
 -- PART 4: Main Problem Statement
@@ -101,13 +142,17 @@ def erdos1170_property : Prop :=
 /-- Laver's result (1982): It is consistent that the polarized
     relation ω₂ → (ω₁² + 1, α)² holds for all α < ω₂.
     This is weaker than the full balanced relation since it only
-    guarantees order type ω₁² + 1 for the first color. -/
+    guarantees order type ω₁² + 1 for the first color.
+
+    This is a deep forcing/independence result that cannot be proved
+    from ZFC alone — it requires large cardinal assumptions and
+    iterated forcing constructions. -/
 axiom laver_consistency :
     ∀ α : Ordinal.{0}, α < omega2 →
       ordinalPartitionPolarized omega2 (omega1Sq + 1) α
 
 -- ============================================================
--- PART 6: Structural Observations
+-- PART 6: Structural Observations (All Proved)
 -- ============================================================
 
 /-- ω₁ < ω₂: the first uncountable ordinal is less than the second. -/
@@ -115,8 +160,14 @@ theorem omega1_lt_omega2 : omega1 < omega2 := by
   unfold omega1 omega2
   exact Cardinal.ord_lt_ord.mpr (Cardinal.aleph_lt_aleph.mpr (by norm_num))
 
-/-- ω₁² < ω₂. -/
-axiom omega1Sq_lt_omega2 : omega1Sq < omega2
+/-- ω₁² < ω₂: proved via cardinal arithmetic.
+    card(ω₁²) = card(ω₁) · card(ω₁) = ℵ₁ · ℵ₁ = ℵ₁ < ℵ₂ = card(ω₂). -/
+theorem omega1Sq_lt_omega2 : omega1Sq < omega2 := by
+  unfold omega1Sq omega1 omega2
+  rw [Cardinal.lt_ord, Ordinal.card_mul]
+  simp only [Cardinal.card_ord]
+  rw [Cardinal.mul_eq_self (le_of_lt (Cardinal.aleph0_lt_aleph 1))]
+  exact Cardinal.aleph_lt_aleph.mpr (by norm_num)
 
 /-- Laver's result gives a polarized partition for ω₁² + 1 as first target. -/
 theorem laver_gives_omega1Sq_partition :

--- a/src/data/proofs/erdos-1170/annotations.json
+++ b/src/data/proofs/erdos-1170/annotations.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "ann-e1170-balanced-def",
+    "proofId": "erdos-1170",
+    "range": {
+      "startLine": 59,
+      "endLine": 65,
+      "startColumn": 0,
+      "endColumn": 0
+    },
+    "content": "**Constructive definition** of the balanced partition relation α → (β)²₂. Instead of an opaque axiom, this defines the relation via strictly increasing ordinal embeddings: there exists g mapping [0,β) into [0,α) preserving order, with all pairs monochromatic. This replaces the original axiom and makes the mathematical content transparent to Lean's type checker.",
+    "type": "insight",
+    "importance": "high"
+  },
+  {
+    "id": "ann-e1170-polarized-def",
+    "proofId": "erdos-1170",
+    "range": {
+      "startLine": 74,
+      "endLine": 83,
+      "startColumn": 0,
+      "endColumn": 0
+    },
+    "content": "**Constructive definition** of the polarized partition relation α → (β, γ)². The disjunction captures the asymmetry: either a 0-monochromatic embedding of length β exists, or a 1-monochromatic embedding of length γ. This is strictly weaker than the balanced relation when β ≠ γ.",
+    "type": "insight",
+    "importance": "high"
+  },
+  {
+    "id": "ann-e1170-balanced-implies-polarized",
+    "proofId": "erdos-1170",
+    "range": {
+      "startLine": 92,
+      "endLine": 97,
+      "startColumn": 0,
+      "endColumn": 0
+    },
+    "content": "**Proved** (was axiom). The proof uses `fin_cases c` to split on the color of the homogeneous set: if c = 0, we take the left disjunct; if c = 1, the right. The embedding and its properties transfer directly.",
+    "type": "proof-technique",
+    "importance": "medium"
+  },
+  {
+    "id": "ann-e1170-omega1sq-proof",
+    "proofId": "erdos-1170",
+    "range": {
+      "startLine": 144,
+      "endLine": 150,
+      "startColumn": 0,
+      "endColumn": 0
+    },
+    "content": "**Proved** (was axiom). Key cardinal arithmetic chain: card(ω₁²) = card(ω₁)·card(ω₁) = ℵ₁·ℵ₁ = ℵ₁ < ℵ₂. Uses `Cardinal.lt_ord` (initial ordinal characterization), `Ordinal.card_mul` (cardinality of ordinal product), `Cardinal.mul_eq_self` (infinite cardinal idempotence), and `Cardinal.aleph_lt_aleph`.",
+    "type": "proof-technique",
+    "importance": "high"
+  },
+  {
+    "id": "ann-e1170-laver-axiom",
+    "proofId": "erdos-1170",
+    "range": {
+      "startLine": 135,
+      "endLine": 139,
+      "startColumn": 0,
+      "endColumn": 0
+    },
+    "content": "**The sole remaining axiom.** Laver's 1982 result is a deep independence/forcing result: using iterated forcing with large cardinals, it is consistent that for all α < ω₂, the polarized relation ω₂ → (ω₁² + 1, α)² holds. This cannot be proved from ZFC alone — it genuinely requires the axiom keyword.",
+    "type": "insight",
+    "importance": "high"
+  }
+]

--- a/src/data/proofs/erdos-1170/index.ts
+++ b/src/data/proofs/erdos-1170/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1170Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-1170/meta.json
+++ b/src/data/proofs/erdos-1170/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "erdos-1170",
+  "title": "Erdős Problem #1170: Partition Properties of ω₂",
+  "slug": "erdos-1170",
+  "description": "Is it consistent that ω₂ → (α)²₂ for every α < ω₂? That is, can every 2-coloring of pairs from ω₂ always yield a homogeneous subset of any prescribed order type below ω₂?",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/1170",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1170Problem.lean",
+    "tags": [
+      "erdos",
+      "combinatorics",
+      "set-theory",
+      "ramsey-theory",
+      "ordinal-partition-calculus",
+      "open"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 1170,
+    "erdosUrl": "https://erdosproblems.com/1170",
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Ordinal.Arithmetic",
+        "description": "Ordinal addition, multiplication, and cardinality of products",
+        "module": "Mathlib.SetTheory.Ordinal.Arithmetic"
+      },
+      {
+        "theorem": "Cardinal.Basic",
+        "description": "Cardinal arithmetic, aleph numbers, and infinite cardinal idempotence",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Cardinal.Ordinal",
+        "description": "Connection between cardinals and ordinals, initial ordinal characterization",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Tactic",
+        "description": "Core tactic library including norm_num, fin_cases, and simp",
+        "module": "Mathlib.Tactic"
+      }
+    ],
+    "originalContributions": [
+      "omega1",
+      "omega2",
+      "omega1Sq",
+      "ordinalPartitionBalanced",
+      "ordinalPartitionPolarized",
+      "balanced_implies_polarized",
+      "balanced_mono_target",
+      "balanced_mono_source",
+      "erdos1170_property",
+      "omega1_lt_omega2",
+      "omega1Sq_lt_omega2",
+      "laver_gives_omega1Sq_partition",
+      "erdos1170_implies_laver_special"
+    ],
+    "axiomCount": 1,
+    "lineCount": 155,
+    "assumptions": "1 axiom: laver_consistency (Laver's 1982 forcing result — consistency of ω₂ → (ω₁² + 1, α)² for all α < ω₂). This is a deep independence result requiring large cardinals and iterated forcing."
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1170 belongs to the ordinal partition calculus, initiated by Erdős and Rado in the 1950s. The classical Ramsey theorem handles finite colorings; its infinite generalization asks which ordinals α satisfy α → (β)ⁿ_k. Problem #1170 asks whether ω₂ can have the strongest possible 2-color partition property: for every α < ω₂, any 2-coloring of pairs from ω₂ yields a homogeneous subset of order type α. Laver (1982) proved a consistency result for the weaker polarized version, and Foreman-Hajnal (2003) extended it, but the full balanced question remains open.",
+    "problemStatement": "**Erdős Problem #1170**:\n\nIs it consistent with ZFC that\n$$\\omega_2 \\to (\\alpha)^2_2$$\nfor every ordinal $\\alpha < \\omega_2$?\n\nThat is, for every $\\alpha < \\omega_2$ and every 2-coloring of pairs from $\\omega_2$, does there exist a homogeneous subset of order type $\\alpha$?\n\n**Status**: Open. Laver (1982) proved the weaker polarized version is consistent.",
+    "text": "Is it consistent that ω₂ → (α)²₂ for every α < ω₂? That is, is it consistent with ZFC that for every ordinal α < ω₂ and every 2-coloring of pairs from ω₂, there exists a homogeneous subset of order type α?",
+    "proofStrategy": "The formalization uses constructive definitions of partition relations via order-preserving embeddings, avoiding opaque axioms. The balanced relation ordinalPartitionBalanced(α, β) asserts: for any coloring, there exists a strictly increasing function from ordinals below β into ordinals below α with all pairs monochromatic. Three structural properties (balanced-implies-polarized, target monotonicity, source monotonicity) are proved directly. The key inequality ω₁² < ω₂ is proved via cardinal arithmetic: card(ω₁²) = ℵ₁·ℵ₁ = ℵ₁ < ℵ₂. Only Laver's deep forcing result remains as an axiom.",
+    "keyInsights": [
+      "**Constructive partition relations**: The balanced and polarized relations are defined using strictly increasing ordinal embeddings rather than opaque axioms. This makes the mathematical content transparent and enables Lean to verify structural properties.",
+      "**Cardinal arithmetic proves ω₁² < ω₂**: The ordinal product ω₁·ω₁ has cardinality ℵ₁·ℵ₁ = ℵ₁ (by infinite cardinal idempotence), which is strictly less than ℵ₂ = card(ω₂). This uses Ordinal.card_mul, Cardinal.mul_eq_self, and the initial ordinal characterization.",
+      "**Balanced implies polarized**: A direct proof by case analysis on the color — if the homogeneous set has color 0, take the left disjunct; if color 1, take the right.",
+      "**Independence vs provability**: The problem asks about consistency (metamathematical), not provability. Laver's axiom captures a forcing result that ZFC alone cannot prove, making it the only irreducible assumption.",
+      "**Axiom elimination**: The formalization reduced axiom count from 7 to 1 by replacing opaque predicate axioms with constructive definitions and proving structural properties from first principles."
+    ],
+    "prerequisites": [
+      "Set theory and cardinality",
+      "Ordinal arithmetic (multiplication, cardinal of products)",
+      "Ramsey theory (partition relations)",
+      "Combinatorics (counting, extremal problems)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Documentation header describing the partition property of ω₂, known results by Laver and Foreman-Hajnal, formalization notes on axiom elimination, and Mathlib imports."
+    },
+    {
+      "id": "ordinal-setup",
+      "title": "Ordinal Setup",
+      "startLine": 38,
+      "endLine": 49,
+      "summary": "Defines ω₁ = (ℵ₁).ord, ω₂ = (ℵ₂).ord, and ω₁² = ω₁·ω₁ as noncomputable ordinals."
+    },
+    {
+      "id": "partition-defs",
+      "title": "Constructive Partition Relation Definitions",
+      "startLine": 50,
+      "endLine": 85,
+      "summary": "Defines ordinalPartitionBalanced and ordinalPartitionPolarized constructively using strictly increasing ordinal embeddings. No axioms — these are transparent definitions."
+    },
+    {
+      "id": "partition-props",
+      "title": "Basic Properties of Partition Relations",
+      "startLine": 86,
+      "endLine": 115,
+      "summary": "Three proved theorems: balanced implies polarized (by fin_cases on color), target monotonicity (by restricting the embedding domain), and source monotonicity (by transitivity of <)."
+    },
+    {
+      "id": "problem-statement",
+      "title": "Main Problem Statement",
+      "startLine": 116,
+      "endLine": 126,
+      "summary": "Defines erdos1170_property: ∀ α < ω₂, ordinalPartitionBalanced ω₂ α. This is the property whose consistency is asked."
+    },
+    {
+      "id": "laver-result",
+      "title": "Laver's Consistency Result",
+      "startLine": 127,
+      "endLine": 139,
+      "summary": "The sole axiom: Laver's 1982 result that the polarized relation ω₂ → (ω₁² + 1, α)² is consistent for all α < ω₂. A deep forcing result requiring large cardinals."
+    },
+    {
+      "id": "structural-obs",
+      "title": "Structural Observations",
+      "startLine": 140,
+      "endLine": 155,
+      "summary": "Four proved theorems: ω₁ < ω₂ (by aleph comparison), ω₁² < ω₂ (by cardinal arithmetic), Laver's partition applied at ω₁, and that the balanced property implies Laver's as a special case."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization captures Erdős Problem #1170 — the balanced partition property of ω₂ — in 155 lines of Lean 4 code with only 1 axiom (Laver's deep forcing result) and 7 proved theorems. The key achievement is replacing 6 opaque axioms with constructive definitions and machine-checked proofs, including a cardinal arithmetic proof that ω₁² < ω₂.",
+    "implications": "**Theoretical Significance**: The formalization demonstrates that most structural properties of ordinal partition relations can be derived from first principles once the definitions are made transparent. The sole remaining axiom (Laver's consistency result) captures genuine mathematical depth — a forcing construction that ZFC cannot prove.\n\n**Methodological Contribution**: The constructive embedding-based definition of partition relations (using strictly increasing ordinal functions) provides a clean, universe-safe formalization pattern applicable to other partition calculus problems.",
+    "openQuestions": [
+      "Is the full balanced partition property ω₂ → (α)²₂ consistent for all α < ω₂?",
+      "Can Laver's polarized result be strengthened to balanced?",
+      "What large cardinal strength is needed for consistency of the full property?",
+      "Does ω₂ → (ω₁ + 1)²₂ hold in ZFC (without consistency assumptions)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.SetTheory.Ordinal.Arithmetic",
+      "Mathlib.SetTheory.Cardinal.Basic",
+      "Mathlib.SetTheory.Cardinal.Ordinal",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Cardinal",
+      "Ordinal"
+    ],
+    "namespace": "Erdos1170",
+    "lineCount": 155,
+    "axiomCount": 1,
+    "theoremCount": 7,
+    "definitionCount": 6
+  },
+  "references": [
+    "Erdős: original problem formulation",
+    "Laver (1982): Consistency of ω₂ → (ω₁² + 1, α)² for all α < ω₂",
+    "Foreman and Hajnal (2003): Extended Laver's consistency result",
+    "Erdős-Rado (1956): Foundational partition calculus",
+    "https://erdosproblems.com/1170"
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-1169",
+      "relationship": "related",
+      "description": "Related ordinal partition calculus problem involving ω₁²"
+    },
+    {
+      "targetId": "erdos-1171",
+      "relationship": "related",
+      "description": "Multicolor partition relation for ω₁², closely related problem"
+    },
+    {
+      "targetId": "erdos-1167",
+      "relationship": "related",
+      "description": "Cardinal partition relations by Erdős-Hajnal-Rado"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-1169",
+    "erdos-1171",
+    "erdos-1167"
+  ]
+}

--- a/src/data/research/problems/erdos-1170.json
+++ b/src/data/research/problems/erdos-1170.json
@@ -1,73 +1,103 @@
 {
   "slug": "erdos-1170",
   "title": "Erdős #1170",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "ACT",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "(LaTeX not available)",
-    "plain": "Problem statement not found",
-    "whyMatters": []
+    "formal": "ω₂ → (α)²₂ for all α < ω₂",
+    "plain": "Is it consistent with ZFC that for every α < ω₂, any 2-coloring of pairs from ω₂ has a homogeneous subset of order type α?",
+    "whyMatters": [
+      "Central open problem in infinitary Ramsey theory / ordinal partition calculus",
+      "Connects large cardinal consistency strength to combinatorial properties of ω₂"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Laver (1982): Consistent that ω₂ → (ω₁² + 1, α)² for all α < ω₂ (polarized version)",
+      "Foreman-Hajnal (2003): Extended Laver's consistency result"
+    ],
+    "open": [
+      "Full balanced partition property: ω₂ → (α)²₂ for all α < ω₂"
+    ],
+    "goal": "Formalize the problem with minimal axioms; only deep forcing results should remain as axioms"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-15T16:53:51.159Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "COMPLETED",
+    "since": "2026-03-24T10:36:00Z",
+    "iteration": 2,
+    "focus": "Axiom elimination: replaced 6 of 7 axioms with constructive defs and proofs",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None - formalization complete at 1 axiom (Laver forcing result)",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 7 axioms. 2 are opaque predicates (should be defs), 2 are monotonicity (provable if predicates made concrete), 1 deep consistency (Laver), 1 ordinal inequality (omega1^2 < omega2, potentially provable).",
-    "builtItems": [],
+    "progressSummary": "COMPLETED: Eliminated 6/7 axioms. Replaced opaque partition predicates with constructive definitions (order-preserving embeddings). Proved balanced_implies_polarized, balanced_mono_target, balanced_mono_source, omega1Sq_lt_omega2. Only laver_consistency (deep forcing result) remains as axiom. Created gallery entry.",
+    "builtItems": [
+      "Constructive def ordinalPartitionBalanced (embedding-based, replaces axiom)",
+      "Constructive def ordinalPartitionPolarized (embedding-based, replaces axiom)",
+      "Proved balanced_implies_polarized (fin_cases on color)",
+      "Proved balanced_mono_target (domain restriction)",
+      "Proved balanced_mono_source (transitivity of <)",
+      "Proved omega1Sq_lt_omega2 (cardinal arithmetic: card_mul + mul_eq_self + aleph_lt_aleph)",
+      "Created gallery entry: src/data/proofs/erdos-1170/"
+    ],
     "insights": [
       "ordinalPartitionBalanced/Polarized are opaque predicates - should be defined constructively",
       "omega1Sq_lt_omega2 might be provable from Mathlib cardinal/ordinal arithmetic: |omega1^2| = aleph1 < aleph2 = |omega2|",
-      "laver_consistency is a deep set theory forcing result - not provable from ZFC alone"
+      "laver_consistency is a deep set theory forcing result - not provable from ZFC alone",
+      "Cardinal.lt_ord converts ordinal < initial ordinal to cardinal < cardinal",
+      "Cardinal.mul_eq_self proves ℵ₁·ℵ₁ = ℵ₁ for infinite cardinals",
+      "Embedding-based partition defs avoid universe issues (Ordinal → Ordinal stays in same universe)"
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Define ordinalPartitionBalanced/Polarized constructively to eliminate 2 axioms + enable 3 more",
-      "Prove omega1Sq_lt_omega2 from Mathlib ordinal arithmetic"
-    ],
-    "markdown": "# Erdős #1170 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [],
+    "markdown": "# Erdős #1170 - Knowledge Base\n\n## Problem Statement\n\nIs it consistent that ω₂ → (α)²₂ for every α < ω₂?\n\n## Status\n\n**Erdős Database Status**: OPEN\n**Formalization Status**: COMPLETED (1 axiom)\n\n## Achievements\n\n- Eliminated 6 of 7 axioms\n- Constructive partition relation definitions\n- Cardinal arithmetic proof of ω₁² < ω₂\n\n## Tags\n\n- erdos, ramsey-theory, set-theory, ordinal-partition-calculus\n\n## Related Problems\n\n- #1169, #1171, #1167\n\n## References\n\n- Laver (1982), Foreman-Hajnal (2003), Erdős-Rado (1956)\n"
   },
   "tags": [
-    "erdos"
+    "erdos",
+    "ramsey-theory",
+    "set-theory",
+    "ordinal-partition-calculus"
   ],
   "relatedProofs": [
-    "erdos-1",
-    "erdos-11",
-    "erdos-117"
+    "erdos-1169",
+    "erdos-1171",
+    "erdos-1167"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Laver (1982): Partition relations and large cardinals",
+      "Foreman-Hajnal (2003): Extensions of Laver's consistency results"
+    ],
+    "urls": [
+      "https://erdosproblems.com/1170"
+    ],
+    "mathlib": [
+      "Cardinal.lt_ord",
+      "Ordinal.card_mul",
+      "Cardinal.mul_eq_self",
+      "Cardinal.card_ord",
+      "Cardinal.aleph_lt_aleph"
+    ]
   },
   "started": "2026-01-15T16:53:51.159Z",
-  "lastUpdate": "2026-03-13T07:52:17.059Z",
+  "lastUpdate": "2026-03-24T10:36:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1170Problem.lean",
       "filename": "Erdos1170Problem.lean",
-      "lineCount": 136,
-      "theoremCount": 3,
-      "axiomCount": 7,
-      "defCount": 4,
+      "lineCount": 155,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1170Problem.lean"


### PR DESCRIPTION
## Summary
- Replace 6 opaque axioms with constructive definitions and proofs in Erdős Problem #1170
- Prove `omega1Sq_lt_omega2` via cardinal arithmetic (Cardinal.mul_eq_self + Cardinal.lt_ord)
- Only `laver_consistency` (deep forcing result) remains as axiom
- Create gallery entry with metadata and annotations

## Progress
- **Axiom count**: 7 → 1 (6 eliminated)
- **Theorem count**: 3 → 7 (4 new proofs)
- **Definition count**: 4 → 6 (2 constructive replacements)
- **Lean build**: verified via Docker

## Findings
- Partition relations can be cleanly defined via strictly increasing ordinal embeddings (avoids universe issues)
- `Cardinal.mul_eq_self` + `Cardinal.lt_ord` gives a direct proof that ω₁² < ω₂
- `fin_cases` on `Fin 2` elegantly handles balanced→polarized case split

## Status
**Outcome**: completed
**Next Steps**: None — formalization is at minimal axiom count

🤖 Generated by researcher-5