### PR TITLE
Audit cycle 20: fix 3 proofs, verify 4 clean

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01/meta.json
@@ -19,7 +19,7 @@
       "extension",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -58,7 +58,7 @@
     "dateAdded": "2026-02-23",
     "axiomCount": 0,
     "lineCount": 304,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Core reduction and nilpotency results rely on Mathlib's Cayley-Hamilton theorem (Matrix.aeval_self_charpoly). Original contributions include diagonal power induction proofs and degree bound arguments.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02/meta.json
@@ -17,7 +17,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -57,7 +57,7 @@
     "dateAdded": "2026-03-22",
     "axiomCount": 0,
     "lineCount": 160,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. Core divisibility and reduction results derived from Mathlib's minpoly.dvd, Matrix.aeval_self_charpoly (Cayley-Hamilton), and minpoly.aeval. Original contributions include the reduction comparison theorem and scalar matrix derogatory example.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -103,18 +103,18 @@
       "title": "Part III: Non-Derogatory Matrices",
       "startLine": 76,
       "endLine": 101,
-      "summary": "Defines IsNonDerogatory via degree equality, states that non-derogatory matrices have equally efficient reductions (sorry), and claims companion matrices are non-derogatory (sorry)."
+      "summary": "Defines IsNonDerogatory via degree equality, proves the scalar matrix derogatory example (minpoly degree ≤ 1 while charpoly degree = n)."
     },
     {
       "id": "summary",
       "title": "Summary and Status",
       "startLine": 102,
       "endLine": 160,
-      "summary": "Lists all 6 theorems with proof status: 4 fully proved, 2 with sorries (nonderogatory equivalence and companion matrix existence)."
+      "summary": "Lists all 10 theorems with proof status: all fully proved (0 sorries, 0 axioms)."
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the fundamental relationship between the minimal and characteristic polynomials of a matrix. Four of six theorems are fully proved: the divisibility μ_M | χ_M, the degree comparison, the reduction degree bound, and the evaluation equivalence. The two remaining sorries concern non-derogatory matrices: proving that minpoly and charpoly reductions have equal degree for non-derogatory matrices, and constructing non-derogatory companion matrices.",
+    "summary": "This formalization establishes the fundamental relationship between the minimal and characteristic polynomials of a matrix. All 10 theorems are fully proved (0 sorries): the divisibility μ_M | χ_M, the degree comparison, the reduction degree bound, evaluation equivalence, comparison showing minpoly reduction is always at least as efficient as charpoly reduction, and the scalar matrix derogatory example. Core results derived from Mathlib's Cayley-Hamilton and minpoly modules.",
     "implications": "**Theoretical Significance**: 1. **Efficient matrix computation**: When computing f(M) for large matrices, reducing f modulo μ_M rather than χ_M can significantly reduce the degree of the polynomial to evaluate, especially for derogatory matrices where deg(μ_M) ≪ n.\n**2. Rational canonical form**: The non-derogatory characterization connects to the rational canonical form — a matrix is non-derogatory iff its RCF has a single companion block, which determines the structure of its centralizer.\n3. **Matrix function theory**: The evaluation equivalence theorem is foundational for matrix function computation via polynomial interpolation: one can work modulo μ_M rather than χ_M without changing the result.\n4. **Connection to Cayley-Hamilton**: Builds directly on the parent formalization, showing that Cayley-Hamilton is not just a theoretical result but has immediate computational consequences.",
     "openQuestions": [
       "Can the rational canonical form (Frobenius normal form) be fully formalized in Lean 4, decomposing any matrix into companion blocks corresponding to the invariant factors?",


### PR DESCRIPTION
## Summary

- **erdos-409**: axiomCount 12→10 (2 listed axioms are now theorems), theoremCount 1→3
- **cayley-hamilton-reduction-oq-01**: badge verified→mathlib (core results rely on Mathlib Cayley-Hamilton)
- **cayley-hamilton-reduction-oq-02**: badge verified→mathlib, fixed stale conclusion claiming sorries exist when file has 0

Verified clean (false positives from automated detection):
- pythagorean-triples, chinese-remainder-non-coprime-oq-01, cevas-theorem-oq-02-oq-02, cramers-rule-oq-02

## Test plan

- [ ] Gallery builds successfully (`pnpm build`)
- [ ] No badge/status regressions on affected proof pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)