### PR TITLE
Fix: fundamental-theorem-algebra phantom theorem names and wrong count

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -37,10 +37,10 @@
       }
     ],
     "originalContributions": [
-      "no_roots_implies_constant - contrapositive formulation of FTA",
-      "card_roots_eq_degree - root counting theorem",
-      "monic_prod_roots - complete factorization theorem",
-      "quadratic_has_root - explicit quadratic case"
+      "no_roots_implies_constant - contrapositive formulation of FTA with multi-step by_contra proof",
+      "quadratic_has_root - explicit quadratic case with degree computation from first principles",
+      "card_roots_eq_degree - Mathlib wrapper adapting natDegree_eq_card_roots for ℂ[X]",
+      "monic_prod_roots - Mathlib wrapper for complete factorization over ℂ"
     ],
     "dateAdded": "2025-12-21",
     "wiedijkNumber": 2,
@@ -58,7 +58,7 @@
   "overview": {
     "historicalContext": "The Fundamental Theorem of Algebra has roots stretching back to the 16th century. Peter Rothe stated a version for real roots in 1608, and Albert Girard first conjectured the full result in his 1629 *Invention nouvelle en l'algèbre*: every polynomial of degree $n$ has $n$ roots (counting multiplicities, allowing 'impossible' — i.e., complex — solutions). The first serious proof attempt came from Jean le Rond d'Alembert in 1746, whose argument contained gaps that would take over a century to fill.\n\nLeonhard Euler (1749) gave an algebraic argument reducing the problem to showing that real polynomials of even degree factor over $\\mathbb{R}$, but his proof also had gaps for polynomials of degree $2^k$ with $k \\geq 3$. Joseph-Louis Lagrange (1772) and Pierre-Simon Laplace (1795) also attempted proofs with varying degrees of completeness.\n\nCarl Friedrich Gauss provided the first substantially correct proof in his 1799 doctoral dissertation *Demonstratio nova theorematis omnem functionem algebraicam rationalem integram unius variabilis in factores reales primi vel secundi gradus resolvi posse*. Gauss criticized d'Alembert's approach and used a topological argument about the winding number of a curve. He went on to publish three more proofs (1816, 1816, 1849), each using different techniques — the fourth was purely algebraic modulo the intermediate value theorem.\n\nDespite its name, the theorem is fundamentally analytic rather than algebraic. Every known proof requires the completeness of $\\mathbb{R}$ in some form — whether through complex analysis (Liouville's theorem), topology (winding numbers), or the intermediate value theorem. The Mathlib proof uses Liouville's theorem: if $p(z) \\neq 0$ everywhere, then $1/p(z)$ is a bounded entire function, hence constant by Liouville, contradicting $\\deg p \\geq 1$.\n\nThe theorem is #2 on Wiedijk's list of 100 theorems, reflecting its foundational importance. It underpins the algebraic closure of $\\mathbb{C}$, the spectral theorem in linear algebra, and the decomposition of rational functions into partial fractions.",
     "problemStatement": "The Fundamental Theorem of Algebra: If $p(z) = a_n z^n + a_{n-1} z^{n-1} + \\cdots + a_1 z + a_0$ is a polynomial with complex coefficients and $n \\geq 1$ (i.e., the polynomial is non-constant), then there exists at least one complex number $z_0$ such that $p(z_0) = 0$.\n\nEquivalently: The field of complex numbers $\\mathbb{C}$ is algebraically closed - every polynomial over $\\mathbb{C}$ splits completely into linear factors.",
-    "text": "A 214-line formalization of the Fundamental Theorem of Algebra (Wiedijk #2) with 17 declarations, 0 sorries, 0 axioms. The core proof delegates to Mathlib's `Complex.exists_root` (Liouville-based: if $p(z) \\neq 0$ everywhere then $1/p$ is bounded entire, hence constant, contradiction). Provides `fta_exists_root` as a clean restatement, `polynomial_splits_over_complex` via `IsAlgClosed.splits_codomain`, and `polynomial_factors_completely` showing every degree-$n$ polynomial has exactly $n$ roots with multiplicity. Demonstrates `fta_degree_two` (quadratic formula instance) and `fta_linear` (linear polynomial root). Commentary connects Mathlib's analytic approach (via Liouville) to Gauss's 1799 topological proof and the impossibility of purely algebraic proofs.",
+    "text": "A 214-line formalization of the Fundamental Theorem of Algebra (Wiedijk #2) with 6 theorems, 3 examples, 0 sorries, 0 axioms. The core proof delegates to Mathlib's `Complex.exists_root` (Liouville-based: if $p(z) \\neq 0$ everywhere then $1/p$ is bounded entire, hence constant, contradiction). Provides `fundamental_theorem_of_algebra` as a clean restatement, `no_roots_implies_constant` as the contrapositive, and `splits_over_complex` via `IsAlgClosed.splits_codomain`. The factorization results `card_roots_eq_degree` and `monic_prod_roots` show every degree-$n$ polynomial has exactly $n$ roots with multiplicity and factors completely into linear terms. Demonstrates `quadratic_has_root` as a worked special case. Commentary connects Mathlib's analytic approach (via Liouville) to Gauss's 1799 topological proof and the impossibility of purely algebraic proofs.",
     "proofStrategy": "The Mathlib proof proceeds via complex analysis:\n\n1. Assume the contrary: Suppose $p(z) \\neq 0$ for all $z \\in \\mathbb{C}$\n2. Define the reciprocal: Consider $f(z) = 1/p(z)$, which would be entire (holomorphic everywhere)\n3. Show boundedness: Since $|p(z)| \\to \\infty$ as $|z| \\to \\infty$, the function $f$ is bounded\n4. Apply Liouville's theorem: A bounded entire function must be constant\n5. Reach contradiction: If $f$ is constant, then $p$ is constant, contradicting our assumption that $\\deg p \\geq 1$\n\nTherefore, $p$ must have at least one root in $\\mathbb{C}$.",
     "keyInsights": [
       "**Algebra Needs Analysis:** Despite stating that $p(z) \\in \\mathbb{C}[z]$ has a root, every proof requires completeness of $\\mathbb{R}$ — whether via Liouville's theorem, winding numbers, or the intermediate value theorem. There is no purely algebraic proof.",
@@ -281,7 +281,7 @@
     "namespace": "FundamentalTheoremAlgebra",
     "lineCount": 214,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 0
   }
 }

--- a/src/data/proofs/fundamental-theorem-algebra/review.json
+++ b/src/data/proofs/fundamental-theorem-algebra/review.json
@@ -97,21 +97,21 @@
       "priority": "high",
       "target": "enricher",
       "description": "Rewrite overview.text to use actual theorem names from the Lean source (fundamental_theorem_of_algebra, no_roots_implies_constant, splits_over_complex, card_roots_eq_degree, monic_prod_roots, quadratic_has_root). Remove all references to non-existent names (fta_exists_root, polynomial_splits_over_complex, polynomial_factors_completely, fta_degree_two, fta_linear).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",
       "priority": "medium",
       "target": "enricher",
       "description": "Fix leanFile.theoremCount from 4 to 6. Fix section line numbers to match current Lean source. Fix annotation ranges for ann-monic-factorization (should be 144-155) and ann-quadratic-case (should be 174-208 or removed in favor of ann-quadratic-theorem).",
-      "status": "open"
+      "status": "partial"
     },
     {
       "id": "ai-3",
       "priority": "medium",
       "target": "enricher",
       "description": "Revise originalContributions list to match the honest framing in the assumptions field. Either rename to 'contributions' or add qualifiers acknowledging that card_roots_eq_degree and monic_prod_roots are Mathlib wrappers. Keep no_roots_implies_constant and quadratic_has_root as the items with genuine original proof work.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",


### PR DESCRIPTION
## Fix

Replace 5 non-existent theorem names in overview.text with actual Lean source names, fix theoremCount from 4 to 6, and qualify originalContributions to distinguish original proofs from Mathlib wrappers.

## Evidence

**Before**: overview.text referenced `fta_exists_root`, `polynomial_splits_over_complex`, `polynomial_factors_completely`, `fta_degree_two`, `fta_linear` — none of which exist in the Lean file. theoremCount was 4 (actual: 6).

**After**: overview.text references `fundamental_theorem_of_algebra`, `no_roots_implies_constant`, `splits_over_complex`, `card_roots_eq_degree`, `monic_prod_roots`, `quadratic_has_root` — all verified against the Lean source. theoremCount corrected to 6. originalContributions now distinguishes genuine original proofs (no_roots_implies_constant, quadratic_has_root) from Mathlib wrappers (card_roots_eq_degree, monic_prod_roots).

Addresses peer review action items ai-1, ai-2 (theoremCount portion), ai-3.

---
Automated fix by lean-mechanic agent.