### PR TITLE
Research: erdos-1144 + erdos-1068 — eliminate sorries, fix bugs

### DIFF
--- a/proofs/Proofs/Erdos1068Problem.lean
+++ b/proofs/Proofs/Erdos1068Problem.lean
@@ -35,6 +35,7 @@ import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.Data.Set.Countable
+import Mathlib.Tactic
 
 open Cardinal SimpleGraph
 
@@ -155,9 +156,16 @@ theorem inf_connected_no_finite_separator :
   -- (by pairwise internal disjointness). So `bad` is finite (bounded by |S|).
   -- We use a sorry here as the finiteness argument requires careful set theory.
   have hbad_finite : Set.Finite bad := by
-    -- Each s ∈ S contributes at most one bad path (by internal disjointness)
-    -- |bad| ≤ |S| < ∞
-    sorry
+    -- bad ⊆ ⋃ s ∈ S, {p ∈ paths | s internal to p}
+    -- Each fiber has ≤ 1 element (by pairwise internal disjointness), S is finite
+    have hunion : Set.Finite (⋃ s ∈ (↑S : Set V),
+        {p ∈ paths | s ∈ p.vertices.drop 1 ∧ s ∈ p.vertices.dropLast}) :=
+      Set.Finite.biUnion S.finite_toSet fun s _ =>
+        Set.Subsingleton.finite fun p₁ ⟨hp₁, hs_p₁⟩ p₂ ⟨hp₂, hs_p₂⟩ => by
+          by_contra hneq; exact hdisj p₁ hp₁ p₂ hp₂ hneq s hs_p₁ hs_p₂
+    exact hunion.subset fun p hp => by
+      obtain ⟨hp_mem, w, hwS, hw_d, hw_dl⟩ := hp
+      exact Set.mem_biUnion hwS (Set.mem_sep hp_mem ⟨hw_d, hw_dl⟩)
   -- Since paths is infinite and bad is finite, there exists a good path
   have hgood : ∃ p ∈ paths, p ∉ bad := by
     by_contra h
@@ -167,14 +175,33 @@ theorem inf_connected_no_finite_separator :
   obtain ⟨p, hp, hpgood⟩ := hgood
   refine ⟨p, (hpath p hp).1, (hpath p hp).2, ?_⟩
   -- Show all vertices of p avoid S
-  intro w hw
-  -- Case analysis: w is either an endpoint or internal
-  simp only [bad, Set.mem_sep_iff, not_and, not_exists] at hpgood
-  intro hw_in_S
-  -- Since p ∉ bad, no internal vertex of p is in S
-  -- We need: w is the head (= u) or tail (= v), hence not in S by hypothesis,
-  -- OR w is internal, hence not in S by the good path property
-  sorry
+  intro w hw hw_in_S
+  -- Since p ∉ bad, no vertex in S is internal to p
+  have h_not_internal : ¬(w ∈ p.vertices.drop 1 ∧ w ∈ p.vertices.dropLast) := by
+    intro ⟨hd, hdl⟩
+    exact hpgood ⟨hp, w, hw_in_S, hd, hdl⟩
+  -- So w ∉ drop 1 or w ∉ dropLast. Either way w is an endpoint = u or v.
+  rcases not_and_or.mp h_not_internal with h_not_drop | h_not_last
+  · -- w ∉ drop 1 = tail → w is the head = u → u ∈ S, contradiction
+    have hhead : p.vertices.head? = some w := by
+      cases hpv : p.vertices with
+      | nil => simp [hpv] at hw
+      | cons a t =>
+        rw [hpv] at h_not_drop hw
+        simp only [List.drop_succ_cons, List.drop_zero] at h_not_drop
+        simp only [List.head?_cons]
+        exact congr_arg some ((List.mem_cons.mp hw).resolve_right h_not_drop).symm
+    rw [(hpath p hp).1] at hhead
+    exact hu (Option.some.inj hhead ▸ hw_in_S)
+  · -- w ∉ dropLast → w is the last = v → v ∈ S, contradiction
+    have hlast : p.vertices.getLast? = some w := by
+      have hne : p.vertices ≠ [] := List.ne_nil_of_mem hw
+      rw [← List.dropLast_append_getLast hne] at hw
+      rcases List.mem_append.mp hw with h1 | h2
+      · exact absurd h1 h_not_last
+      · rw [List.mem_singleton.mp h2]; exact List.getLast?_eq_some_getLast hne
+    rw [(hpath p hp).2] at hlast
+    exact hv (Option.some.inj hlast ▸ hw_in_S)
 
 /-- **Set-theoretic sensitivity**: Problems about uncountable chromatic
     numbers and infinite connectivity often depend on set-theoretic axioms

--- a/src/data/research/problems/erdos-1068.json
+++ b/src/data/research/problems/erdos-1068.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-1068",
-  "title": "Erdős #1068",
+  "title": "Erd\u0151s #1068",
   "phase": "ACT",
   "status": "in-progress",
   "tier": "A",
@@ -19,7 +19,7 @@
     "phase": "ACT",
     "since": "2026-01-15T14:38:41.571Z",
     "iteration": 1,
-    "focus": "Axiom elimination: reduced 6→3 axioms",
+    "focus": "Axiom elimination: reduced 6\u21923 axioms",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,16 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axiom count from 6 to 3. Proved set_theoretic_sensitivity and bowler_pikhurko (True placeholders). Converted inf_connected_no_finite_separator from axiom to theorem with proof sketch (2 sorries: finiteness of bad paths set, vertex classification).",
+    "progressSummary": "COMPLETED: All sorries eliminated. Proved finiteness of bad paths (via biUnion + subsingleton fibers) and vertex classification (head/tail endpoints avoid separator). 3 deep axioms remain (open conjecture, Soukup, Prob 1067).",
     "builtItems": [
-      "Proved set_theoretic_sensitivity (was axiom True → theorem trivial)",
-      "Proved bowler_pikhurko_simplified_construction (was axiom True → theorem trivial)",
-      "Partial proof of inf_connected_no_finite_separator (axiom→theorem with 2 sorries)"
+      "Proved set_theoretic_sensitivity (was axiom True \u2192 theorem trivial)",
+      "Proved bowler_pikhurko_simplified_construction (was axiom True \u2192 theorem trivial)",
+      "Partial proof of inf_connected_no_finite_separator (axiom\u2192theorem with 2 sorries)",
+      "Proved hbad_finite: Set.Finite bad via biUnion over S with subsingleton fibers",
+      "Proved vertex classification: head?=some w via mem_cons + resolve_right, getLast?=some w via dropLast_append_getLast"
     ],
     "insights": [
       "inf_connected_no_finite_separator is provable from definitions via pigeonhole: infinitely many disjoint paths, finite separator blocks at most finitely many, so one path avoids S",
       "Two axioms (set_theoretic_sensitivity, bowler_pikhurko) were documentation placeholders (axiom foo : True), safely eliminated",
-      "Remaining 3 axioms are genuinely deep: the open conjecture, Soukup 2015, and problem 1067 disproof"
+      "Remaining 3 axioms are genuinely deep: the open conjecture, Soukup 2015, and problem 1067 disproof",
+      "Set.Finite.biUnion + Set.Subsingleton.finite pattern works for bounding path sets by separator size",
+      "List.dropLast_append_getLast is key for proving vertex is endpoint when not in dropLast",
+      "need Mathlib.Tactic import for Set.Finite.biUnion (not transitively imported by Set.Countable)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -46,7 +51,7 @@
       "Prove vertex classification (list element is endpoint or internal)",
       "Consider Aristotle companion file for the 2 remaining sorries"
     ],
-    "markdown": "# Erdős #1068 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nDoes every graph with chromatic number $\\aleph_1$ contain a countable subgraph which is infinitely connected?\n\n\n\nA question of Erd\\H{o}s and Hajnal. We say a graph is infinitely connected if any two vertices are connected by infinitely many pairwise disjoint paths.\n\nSee also [1067].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1067\n- Problem #1069\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErHa66\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erd\u0151s #1068 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nDoes every graph with chromatic number $\\aleph_1$ contain a countable subgraph which is infinitely connected?\n\n\n\nA question of Erd\\H{o}s and Hajnal. We say a graph is infinitely connected if any two vertices are connected by infinitely many pairwise disjoint paths.\n\nSee also [1067].\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1067\n- Problem #1069\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErHa66\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -70,10 +75,10 @@
     {
       "path": "Proofs/Erdos1068Problem.lean",
       "filename": "Erdos1068Problem.lean",
-      "lineCount": 206,
-      "theoremCount": 2,
-      "axiomCount": 6,
-      "defCount": 6,
+      "lineCount": 268,
+      "theoremCount": 5,
+      "axiomCount": 3,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1068Problem.lean"


### PR DESCRIPTION
## Summary
Two research sessions completing erdos-1144 and erdos-1068.

### erdos-1144: Partial Sums of Random Multiplicative Functions
- **Eliminated false theorem** `atherfold_implies_subpolynomial` (provably wrong for f≡1)
- **Fixed mathematical error** `completely_mult_zero` → `completely_mult_zero_or_one`
- **Added counterexample**: `const_one_completely_mult`, `const_one_rademacher`, `partialSum_const_one_eq`
- **Rewrote** `partialSum_trivial_bound` (fixes Mathlib v4.26 API)
- **Result**: 10 theorems, 1 axiom, **0 sorries** (was 1)

### erdos-1068: Countable Infinitely-Connected Subgraphs
- **Proved `hbad_finite`**: finiteness of bad paths via `Set.Finite.biUnion` + subsingleton fibers
- **Proved vertex classification**: w ∈ path ∩ S → w is endpoint (head/getLast) → contradiction
- **Result**: 5 theorems, 3 axioms, **0 sorries** (was 2)

## Build
Both proofs pass Docker build clean (0 errors).

🤖 Generated by researcher-5