### PR TITLE
Fix: stale lineCount in 16 meta.json files

### DIFF
--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -54,7 +54,7 @@
     ],
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: erdos_1065a (Set.Infinite for primes of the form 2^k·q + 1), erdos_1065b (Set.Infinite for primes of the form 2^k·3^l·q + 1). Both encode the open conjectures themselves.",
-    "lineCount": 163,
+    "lineCount": 162,
     "relatedProblems": [
       {
         "id": "erdos-1057",

--- a/src/data/proofs/erdos-1108/meta.json
+++ b/src/data/proofs/erdos-1108/meta.json
@@ -51,7 +51,7 @@
       "Proved 1 is both a square factorial sum and powerful"
     ],
     "axiomCount": 5,
-    "lineCount": 193,
+    "lineCount": 195,
     "assumptions": "7 axiom(s) encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -89,7 +89,7 @@
       "Bounds on pi (Real.pi_pos, Real.pi_gt_three)",
       "Divisibility and powers (dvd_pow_self)"
     ],
-    "lineCount": 218,
+    "lineCount": 320,
     "assumptions": "2 axioms (bergelson_richter, random_coprime_density). The main density theorem is axiomatized (deep ergodic theory); all supporting lemmas are fully proved including Möbius inversion identity, card_multiples, and pairs_with_common_factor."
   },
   "overview": {

--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -25,7 +25,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-24",
     "mathlib_version": "4.26.0",
-    "lineCount": 157,
+    "lineCount": 205,
     "mathlibDependencies": [
       {
         "theorem": "Nat.Prime",

--- a/src/data/proofs/erdos-1170/meta.json
+++ b/src/data/proofs/erdos-1170/meta.json
@@ -60,7 +60,7 @@
       "erdos1170_implies_laver_special"
     ],
     "axiomCount": 1,
-    "lineCount": 155,
+    "lineCount": 186,
     "assumptions": "1 axiom: laver_consistency (Laver's 1982 forcing result — consistency of ω₂ → (ω₁² + 1, α)² for all α < ω₂). This is a deep independence result requiring large cardinals and iterated forcing."
   },
   "overview": {

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/25",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 158,
+    "lineCount": 157,
     "assumptions": "2 axioms: finite_sieve_density_exists, sieve_density_positive. Previously 6: logDensity/logDensity_mem_unit/logDensity_unique proved via constructive HasLogDensity; sieved_set_nonempty proved with corrected hypothesis (seq_n 0 ≥ 2).",
     "mathlib_version": "4.26.0"
   },
@@ -143,7 +143,10 @@
       "Proofs.Erdos25LogDensity",
       "Mathlib.Tactic"
     ],
-    "opens": ["Erdos25", "Filter"],
+    "opens": [
+      "Erdos25",
+      "Filter"
+    ],
     "namespace": null,
     "lineCount": 137,
     "axiomCount": 3,

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 2,
     "assumptions": "4 axiom declarations: selfridge_example (p>=3 covering exists), covering_reciprocal_sum (reciprocal sum >= 1 necessary), difficulty_even_coverage (no modulus 2 obstacle), min_modulus_ge_4 (all moduli >= 4 for p>=5)",
-    "lineCount": 185,
+    "lineCount": 182,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: simpson_theorem (minimum with equal residues — deep 1986 result), max_density_coprime_case (CRT coprime maximum). Previously axiomatized equal_residues_minimize, single_modulus_density, and erdos_278_density_le_one are now fully proved.",
-    "lineCount": 359,
+    "lineCount": 411,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 12,
     "assumptions": "12 axiom declarations: iteration_terminates (orbit reaches a prime), iterate_decreasing (strict decrease on composites), erdos_409_upper_bound (F(n) = o(n) bound), erdos_409_same_prime (infinite basin existence), erdos_409_density (basin natural density), prime_zero_iterations (F(p) = 0 for primes), one_iteration_criterion (F(n) = 1 condition), totient_plus_one_odd (parity of phi+1), sigma_variant_question (sigma variant termination), sigma_growing (sigma non-decreasing), four_to_three (phi(4)+1 = 3), one_iteration_infinite (infinitely many F=1)",
-    "lineCount": 127,
+    "lineCount": 128,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 380,
+    "lineCount": 428,
     "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), merikoski_bounded_gaps (S has bounded gaps, 2020). 0 sorries. Proves 19 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_unbounded, westzynthius_implies_frequently_large. Gallery metadata now points to main formalization (Erdos5PrimeGaps.lean) instead of legacy stub.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/530",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 164,
+    "lineCount": 270,
     "assumptions": "4 axiom(s): erdos_lower_bound (N^{1/3}), komlos_sulyok_szemeredi (N^{1/2} lower bound), alon_erdos_partition_conjecture, sidon_sum_count (k(k+1)/2 distinct sums).",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/638",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 98,
+    "lineCount": 95,
     "assumptions": "1 axiom: ramsey_triangle (classical Ramsey theorem for triangles). complete_graphs_ramsey proved from ramsey_triangle. triangle_ramsey_mono proved via Fin.castLE injection.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-680/meta.json
+++ b/src/data/proofs/erdos-680/meta.json
@@ -90,7 +90,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 194,
+    "lineCount": 233,
     "assumptions": "1 axiom: cramer_implies_large_lpf (Cramér's conjecture implies the existence of large LPF offsets). quadratic_weaker_than_exponential is a proved theorem, not an axiom."
   },
   "overview": {

--- a/src/data/proofs/erdos-828/meta.json
+++ b/src/data/proofs/erdos-828/meta.json
@@ -79,7 +79,7 @@
       "erdos_828_summary theorem"
     ],
     "axiomCount": 0,
-    "lineCount": 178,
+    "lineCount": 190,
     "assumptions": "0 axioms. totient_dvd_self_iff backward direction proved. Forward direction (1 sorry): if φ(n)|n then n=2^a·3^b (proof sketch documented)."
   },
   "overview": {

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/931",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 300,
+    "lineCount": 330,
     "assumptions": "2 axioms: stronger_implies_main (Størmer-type smooth number argument), exists_prime_between_blocks (partially proved via Bertrand for k₁ ≥ n₁ case). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 1577,
+    "lineCount": 1596,
     "assumptions": "No axioms. 1 sorry: density_increment_iter N=1 hard case (delta ∈ (0.99, 1]) — requires Dirichlet approximation to prevent descent reaching N=1 with high density. DirichletApproximation.lean is already proved.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Update lineCount field in 16 meta.json files to match actual Lean source file lengths (via `wc -l`).

## Evidence

**Before**: lineCount values set at enrichment time but not updated after researcher edits
**After**: All 16 values match current Lean source files

| Proof | Old | New |
|-------|-----|-----|
| erdos-530 | 164 | 270 |
| erdos-1149 | 218 | 320 |
| erdos-278 | 359 | 411 |
| erdos-1160 | 157 | 205 |
| erdos-5 | 380 | 428 |
| erdos-680 | 194 | 233 |
| erdos-1170 | 155 | 186 |
| erdos-931 | 300 | 330 |
| roth-theorem-k3 | 1577 | 1596 |
| erdos-828 | 178 | 190 |
| erdos-273 | 185 | 182 |
| erdos-638 | 98 | 95 |
| erdos-1108 | 193 | 195 |
| erdos-1065 | 163 | 162 |
| erdos-25 | 158 | 157 |
| erdos-409 | 127 | 128 |

---
Automated fix by lean-mechanic agent.