### PR TITLE
Fix: remove #check debug lines from 4 gallery proofs

### DIFF
--- a/proofs/Proofs/ArithmeticSeries.lean
+++ b/proofs/Proofs/ArithmeticSeries.lean
@@ -177,11 +177,4 @@ theorem triangular_mul_two (n : ℕ) : triangular n * 2 = n * (n + 1) := by
   · rw [hk]
     exact ⟨(2 * k + 1) * (k + 1), by ring⟩
 
-#check gauss_sum
-#check gauss_sum_zero_indexed
-#check arithmetic_series_sum
-#check sum_odd_numbers
-#check triangular
-#check triangular_recurrence
-
 end ArithmeticSeries

--- a/proofs/Proofs/BallotProblem.lean
+++ b/proofs/Proofs/BallotProblem.lean
@@ -248,8 +248,4 @@ P(good) = [C(p+q,p) - C(p+q,q)] / C(p+q,p)
 This elegant simplification is the heart of the ballot problem!
 -/
 
-#check ballot_theorem
-#check ballot_unanimous
-#check ballot_tie
-
 end BallotProblem

--- a/proofs/Proofs/CevasTheorem.lean
+++ b/proofs/Proofs/CevasTheorem.lean
@@ -261,9 +261,3 @@ concurrence results:
 - **Mass point geometry**: Physical interpretation using lever principles
 -/
 
--- Export main results
-#check @cevas_theorem
-#check @medians_satisfy_ceva
-#check @equal_params_ceva_iff
-#check @ceva_product_implies_param
-#check @ceva_param_implies_product

--- a/proofs/Proofs/DissectionOfCubesOQ01.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ01.lean
@@ -272,8 +272,3 @@ perfectly squared), this question has been studied but may not be fully resolved
 -/
 
 end DissectionOfCubesOQ01
-
--- Check key results compile
-#check DissectionOfCubesOQ01.every_dissection_has_collision
-#check DissectionOfCubesOQ01.at_least_two_colliding_cubes
-#check DissectionOfCubesOQ01.collision_class_at_least_two

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -41,7 +41,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 68,
     "axiomCount": 0,
-    "lineCount": 187,
+    "lineCount": 180,
     "relatedProblems": [
       {
         "id": "arithmetic-series-oq-02",
@@ -144,7 +144,7 @@
       "BigOperators"
     ],
     "namespace": "ArithmeticSeries",
-    "lineCount": 187,
+    "lineCount": 180,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1

--- a/src/data/proofs/arithmetic-series/review.json
+++ b/src/data/proofs/arithmetic-series/review.json
@@ -73,7 +73,7 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove the six #check debug commands at lines 180-185 of ArithmeticSeries.lean. These are development artifacts.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -61,7 +61,7 @@
       "Finset and Nat operations from Mathlib"
     ],
     "axiomCount": 0,
-    "lineCount": 255,
+    "lineCount": 251,
     "relatedProblems": [
       {
         "id": "ballot-problem-oq-01",
@@ -279,7 +279,7 @@
       "MeasureTheory"
     ],
     "namespace": "BallotProblem",
-    "lineCount": 255,
+    "lineCount": 251,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1

--- a/src/data/proofs/ballot-problem/review.json
+++ b/src/data/proofs/ballot-problem/review.json
@@ -136,7 +136,7 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove #check debug lines at end of file (lines 251-253).",
-      "status": "open"
+      "status": "resolved"
     }
   ],
   "qualityScores": {

--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -34,7 +34,7 @@
     "dateAdded": "2025-12-27",
     "wiedijkNumber": 61,
     "axiomCount": 0,
-    "lineCount": 269,
+    "lineCount": 263,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -140,7 +140,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 269,
+    "lineCount": 263,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 3

--- a/src/data/proofs/cevas-theorem/review.json
+++ b/src/data/proofs/cevas-theorem/review.json
@@ -94,7 +94,7 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove #check debug lines at end of file (lines 265-269).",
-      "status": "open"
+      "status": "resolved"
     }
   ],
   "qualityScores": {

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-02-23",
     "axiomCount": 0,
-    "lineCount": 279,
+    "lineCount": 274,
     "assumptions": "2 axioms (inherited from DissectionOfCubes.lean): axioms for 3D geometric properties used in the descent argument. This file has 0 direct axioms and 0 sorries, but all theorems depend transitively on the parent file's 2 axioms. Note: the covering constraint (covers_unit_cube) is a placeholder (covers_unit_cube : True), so results technically apply to disjoint cube arrangements, not necessarily actual dissections of the unit cube."
   },
   "overview": {
@@ -138,7 +138,7 @@
       "DissectionOfCubes"
     ],
     "namespace": "DissectionOfCubesOQ01",
-    "lineCount": 279,
+    "lineCount": 274,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 4

--- a/src/data/proofs/dissection-of-cubes-oq-01/review.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/review.json
@@ -94,7 +94,7 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove #check debug lines at end of file (lines 276-279).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-5",


### PR DESCRIPTION
## Fix

Remove trailing #check debug commands from 4 gallery Lean proof files, flagged by peer reviewers as development artifacts.

## Evidence

**Before**: ArithmeticSeries.lean (6 #check), BallotProblem.lean (3 #check), CevasTheorem.lean (5 #check + comment), DissectionOfCubesOQ01.lean (3 #check + comment) all had trailing debug lines.

**After**: Debug lines removed. lineCount updated in corresponding meta.json files. Peer review action items marked as resolved.

**Files changed**: 4 Lean files, 4 meta.json files, 4 review.json files.

---
Automated fix by lean-mechanic agent.