### PR TITLE
Fix: axiomatized proofs with wrong badge → axiom

### DIFF
--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -18,7 +18,7 @@
       "open-problem",
       "research"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -18,7 +18,7 @@
       "erdos",
       "infrastructure"
     ],
-    "badge": "infrastructure",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Correct badge field for 2 axiomatized proofs to match the standard badge=axiom convention.

## Evidence

**Before**:
- erdos-340-greedy-sidon: status=axiomatized, badge=infrastructure (21 axioms)
- basel-problem-oq-02: status=axiomatized, badge=open (2 axioms)

**After**: Both have badge=axiom, consistent with the 1013 other axiomatized proofs.

---
Automated fix by lean-mechanic agent.