### PR TITLE
Fix: fair-games-theorem date errors

### DIFF
--- a/proofs/Proofs/FairGamesTheorem.lean
+++ b/proofs/Proofs/FairGamesTheorem.lean
@@ -74,7 +74,7 @@ We use Mathlib's comprehensive martingale theory:
 
 ## Historical Notes
 
-- **1906**: Louis Bachelier applies fair game concepts to financial markets
+- **1900**: Louis Bachelier applies fair game concepts to financial markets
 - **1934**: Paul Lévy develops martingale theory
 - **1939**: Jean Ville coins the term "martingale"
 - **1953**: Joseph Doob proves the optional stopping theorem

--- a/src/data/proofs/fair-games-theorem/meta.json
+++ b/src/data/proofs/fair-games-theorem/meta.json
@@ -7,7 +7,7 @@
     "wiedijkNumber": 62,
     "author": "Classical probability theory",
     "sourceUrl": "https://en.wikipedia.org/wiki/Optional_stopping_theorem",
-    "date": "1700s",
+    "date": "1953",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/FairGamesTheorem.lean",
     "tags": [

--- a/src/data/proofs/fair-games-theorem/review.json
+++ b/src/data/proofs/fair-games-theorem/review.json
@@ -128,7 +128,7 @@
       "priority": "low",
       "target": "enricher",
       "description": "Fix date field from '1700s' to '1953' (Doob's proof). Fix Lean file line 77 Bachelier date from '1906' to '1900'.",
-      "status": "open"
+      "status": "resolved"
     }
   ],
 


### PR DESCRIPTION
## Fix

Correct two date errors in the fair-games-theorem gallery entry.

## Evidence

**Before**: meta.json date was '1700s' (18th-century gambling origin, not the theorem date). Lean file docstring line 77 said Bachelier's work was '1906'.

**After**: meta.json date corrected to '1953' (Doob's Optional Stopping Theorem proof). Lean file docstring corrected to '1900' (Bachelier's actual thesis date, matching the overview.historicalContext).

Addresses peer review action item ai-7.

---
Automated fix by lean-mechanic agent.