### PR TITLE
Research: erdos-14 - Prove non_unique_monotone (7→6 axioms)

### DIFF
--- a/proofs/Proofs/Erdos14Problem.lean
+++ b/proofs/Proofs/Erdos14Problem.lean
@@ -21,7 +21,7 @@ with a ≤ b, a, b ∈ A}. Two questions:
 - <https://erdosproblems.com/14>
 -/
 
-import Mathlib.Analysis.Asymptotics.Asymptotics
+import Mathlib.Analysis.Asymptotics.Defs
 import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic
 
@@ -99,5 +99,10 @@ axiom sidon_set_non_unique (A : Set ℕ) :
   ∀ᶠ N in atTop, (nonUniqueSumCountInf A N : ℝ) ≥ (N : ℝ) / 2
 
 /-- The non-unique count is monotonically non-decreasing in N. -/
-axiom non_unique_monotone (A : Set ℕ) :
-  ∀ M N : ℕ, M ≤ N → nonUniqueSumCountInf A M ≤ nonUniqueSumCountInf A N
+theorem non_unique_monotone (A : Set ℕ) :
+    ∀ M N : ℕ, M ≤ N → nonUniqueSumCountInf A M ≤ nonUniqueSumCountInf A N := by
+  intro M N hMN
+  unfold nonUniqueSumCountInf
+  apply Set.ncard_le_ncard
+  · exact Set.diff_subset_diff_left (Set.Icc_subset_Icc_right hMN)
+  · exact (Set.finite_Icc 1 N).subset Set.diff_subset

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-14",
   "title": "Unique Sums and Non-Unique Representation",
   "slug": "erdos-14",
-  "description": "For A ⊆ ℕ, let B be integers with exactly one representation as a+b (a≤b, a,b∈A). (a) Is |{1,...,N}\\B| ≫ N^{1/2−ε}? (b) Can |{1,...,N}\\B| = o(√N)? ESS: ≪ N^{1/2+ε} achievable, ≫ N^{1/3−ε} infinitely often.",
+  "description": "For A \u2286 \u2115, let B be integers with exactly one representation as a+b (a\u2264b, a,b\u2208A). (a) Is |{1,...,N}\\B| \u226b N^{1/2\u2212\u03b5}? (b) Can |{1,...,N}\\B| = o(\u221aN)? ESS: \u226a N^{1/2+\u03b5} achievable, \u226b N^{1/3\u2212\u03b5} infinitely often.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/14",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos14Problem.lean",
@@ -20,27 +20,27 @@
     "erdosNumber": 14,
     "erdosUrl": "https://erdosproblems.com/14",
     "erdosProblemStatus": "open",
-    "axiomCount": 7,
-    "lineCount": 103,
+    "axiomCount": 6,
+    "lineCount": 108,
     "prerequisites": [
       "Additive combinatorics (sumsets and representation functions)",
       "Finite set theory",
       "Extremal combinatorics",
       "Probabilistic method"
     ],
-    "assumptions": "7 axioms: erdos_14a_conjecture, erdos_14b_conjecture, ess_upper_bound, and 4 more. See Lean source for complete statements.",
+    "assumptions": "6 axioms: erdos_14a_conjecture, erdos_14b_conjecture, ess_upper_bound, ess_lower_bound, erdos_freud_finite, sidon_set_non_unique. non_unique_monotone was proved from definitions.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "This problem was originally considered by Erdős and Nathanson, and later attributed by Erdős to joint work with Sárközy and Szemerédi (references [Er92c], [Er97], [Er97e]). It asks a fundamental question about the trade-off between uniqueness and coverage in additive representation: given $A \\subseteq \\mathbb{N}$, the set $B$ of integers with exactly one representation as $a + b$ ($a \\leq b$, $a, b \\in A$) captures the 'well-represented' sums. The complementary set $\\{1, \\ldots, N\\} \\setminus B$ consists of integers that are either unrepresented or multiply represented.\n\nThe key tension is that making $A$ larger increases coverage (fewer unrepresented integers) but also increases collisions (more multiply represented integers). Sidon sets, where all sums are distinct, achieve perfect uniqueness but are too sparse ($|A| \\leq \\sqrt{N} + O(N^{1/4})$) to cover even half of $\\{1, \\ldots, N\\}$. At the other extreme, dense sets cover everything but have massive collision counts.\n\nThe main quantitative results are by Erdős, Sárközy, and Szemerédi: they constructed $A \\subseteq \\mathbb{N}$ achieving $f_A(N) = O_{\\varepsilon}(N^{1/2+\\varepsilon})$ for all $\\varepsilon > 0$, showing the non-unique count can be brought very close to $\\sqrt{N}$ from above. However, they also proved that for this same set, $f_A(N) \\gg_{\\varepsilon} N^{1/3-\\varepsilon}$ for infinitely many $N$. Erdős and Freud (1991) proved a finite analogue: for $A \\subseteq \\{1, \\ldots, N\\}$, there exists a choice with non-unique count $< 2^{3/2}\\sqrt{N}$, and the constant $2^{3/2}$ may be optimal.",
+    "historicalContext": "This problem was originally considered by Erd\u0151s and Nathanson, and later attributed by Erd\u0151s to joint work with S\u00e1rk\u00f6zy and Szemer\u00e9di (references [Er92c], [Er97], [Er97e]). It asks a fundamental question about the trade-off between uniqueness and coverage in additive representation: given $A \\subseteq \\mathbb{N}$, the set $B$ of integers with exactly one representation as $a + b$ ($a \\leq b$, $a, b \\in A$) captures the 'well-represented' sums. The complementary set $\\{1, \\ldots, N\\} \\setminus B$ consists of integers that are either unrepresented or multiply represented.\n\nThe key tension is that making $A$ larger increases coverage (fewer unrepresented integers) but also increases collisions (more multiply represented integers). Sidon sets, where all sums are distinct, achieve perfect uniqueness but are too sparse ($|A| \\leq \\sqrt{N} + O(N^{1/4})$) to cover even half of $\\{1, \\ldots, N\\}$. At the other extreme, dense sets cover everything but have massive collision counts.\n\nThe main quantitative results are by Erd\u0151s, S\u00e1rk\u00f6zy, and Szemer\u00e9di: they constructed $A \\subseteq \\mathbb{N}$ achieving $f_A(N) = O_{\\varepsilon}(N^{1/2+\\varepsilon})$ for all $\\varepsilon > 0$, showing the non-unique count can be brought very close to $\\sqrt{N}$ from above. However, they also proved that for this same set, $f_A(N) \\gg_{\\varepsilon} N^{1/3-\\varepsilon}$ for infinitely many $N$. Erd\u0151s and Freud (1991) proved a finite analogue: for $A \\subseteq \\{1, \\ldots, N\\}$, there exists a choice with non-unique count $< 2^{3/2}\\sqrt{N}$, and the constant $2^{3/2}$ may be optimal.",
     "problemStatement": "(a) Must $|\\{1, \\ldots, N\\} \\setminus B| \\gg_{\\varepsilon} N^{1/2-\\varepsilon}$ for all $A \\subseteq \\mathbb{N}$ and $\\varepsilon > 0$? (b) Can $|\\{1, \\ldots, N\\} \\setminus B| = o(\\sqrt{N})$ for some $A$?",
-    "text": "For A ⊆ ℕ, let B be integers with exactly one representation as a+b (a≤b, a,b∈A). (a) Is |{1,...,N}\\B| ≫ N^{1/2−ε}? (b) Can |{1,...,N}\\B| = o(√N)? ESS: ≪ N^{1/2+ε} achievable, ≫ N^{1/3−ε} infinitely often.",
-    "proofStrategy": "The formalization defines `uniqueSums` for finite sets (filtering for representation count $= 1$), `uniqueSumsInf` for infinite sets (using `∃!` for unique existence), and `nonUniqueSumCount`/`nonUniqueSumCountInf` as the complementary counting functions. Both conjectures are stated using Lean's `Filter.atTop` for asymptotic quantifiers. The ESS bounds use `∀ᶠ` (eventually) and `∃ᶠ` (frequently) to distinguish 'for all large $N$' from 'for infinitely many $N$'. Structural results about Sidon sets and monotonicity are included.",
+    "text": "For A \u2286 \u2115, let B be integers with exactly one representation as a+b (a\u2264b, a,b\u2208A). (a) Is |{1,...,N}\\B| \u226b N^{1/2\u2212\u03b5}? (b) Can |{1,...,N}\\B| = o(\u221aN)? ESS: \u226a N^{1/2+\u03b5} achievable, \u226b N^{1/3\u2212\u03b5} infinitely often.",
+    "proofStrategy": "The formalization defines `uniqueSums` for finite sets (filtering for representation count $= 1$), `uniqueSumsInf` for infinite sets (using `\u2203!` for unique existence), and `nonUniqueSumCount`/`nonUniqueSumCountInf` as the complementary counting functions. Both conjectures are stated using Lean's `Filter.atTop` for asymptotic quantifiers. The ESS bounds use `\u2200\u1da0` (eventually) and `\u2203\u1da0` (frequently) to distinguish 'for all large $N$' from 'for infinitely many $N$'. Structural results about Sidon sets and monotonicity are included.",
     "keyInsights": [
       "The problem encodes a fundamental uniqueness-coverage trade-off: Sidon sets give perfect uniqueness ($B = A+A$) but miss $\\sim N/2$ integers, while dense sets cover everything but have $\\sim N$ collisions. The question is whether any intermediate construction can reduce the non-unique count below $\\sqrt{N}$.",
       "The ESS exponent gap $1/3 < ? < 1/2$ is the open territory. The upper bound $O(N^{1/2+\\varepsilon})$ and the lower bound $\\Omega(N^{1/3-\\varepsilon})$ leave a wide range for the true threshold. Conjecture (a) predicts the answer is $\\sim N^{1/2}$, matching the Sidon set barrier.",
-      "The distinction between `∀ᶠ` (eventually: for all $N \\geq N_0$) and `∃ᶠ` (frequently: for infinitely many $N$) is mathematically crucial. The ESS lower bound $N^{1/3-\\varepsilon}$ holds only frequently, while conjecture (a) requires an eventual lower bound — a much stronger statement.",
-      "The Erdős-Freud constant $2^{3/2} = 2\\sqrt{2} \\approx 2.83$ in the finite analogue provides a concrete target. If it is optimal, it suggests that the non-unique count cannot be made smaller than $\\sim \\sqrt{N}$ even with the best finite constructions.",
+      "The distinction between `\u2200\u1da0` (eventually: for all $N \\geq N_0$) and `\u2203\u1da0` (frequently: for infinitely many $N$) is mathematically crucial. The ESS lower bound $N^{1/3-\\varepsilon}$ holds only frequently, while conjecture (a) requires an eventual lower bound \u2014 a much stronger statement.",
+      "The Erd\u0151s-Freud constant $2^{3/2} = 2\\sqrt{2} \\approx 2.83$ in the finite analogue provides a concrete target. If it is optimal, it suggests that the non-unique count cannot be made smaller than $\\sim \\sqrt{N}$ even with the best finite constructions.",
       "The problem cannot be resolved by finite computation (as noted on erdosproblems.com), since it asks about the behavior of $f_A(N)$ as $N \\to \\infty$ for all infinite sets $A$. This is fundamentally an asymptotic question requiring analytical or structural methods."
     ],
     "prerequisites": [
@@ -56,14 +56,14 @@
       "title": "Problem Statement and References",
       "startLine": 1,
       "endLine": 22,
-      "summary": "Documents the two-part problem, references to Erdős [Er92c, Er97, Er97e], Erdős-Freud [ErFr91], and OEIS A143824."
+      "summary": "Documents the two-part problem, references to Erd\u0151s [Er92c, Er97, Er97e], Erd\u0151s-Freud [ErFr91], and OEIS A143824."
     },
     {
       "id": "imports",
       "title": "Imports and Setup",
       "startLine": 23,
       "endLine": 29,
-      "summary": "Imports Mathlib's asymptotics library and finset basics. Opens `Finset`, `Filter`, `Asymptotics` for `atTop`, `∀ᶠ`, `∃ᶠ`."
+      "summary": "Imports Mathlib's asymptotics library and finset basics. Opens `Finset`, `Filter`, `Asymptotics` for `atTop`, `\u2200\u1da0`, `\u2203\u1da0`."
     },
     {
       "id": "unique-sums",
@@ -77,25 +77,25 @@
       "title": "Non-Unique Sum Counting Functions",
       "startLine": 40,
       "endLine": 51,
-      "summary": "Defines `nonUniqueSumCount` (finite) and `nonUniqueSumCountInf` (infinite via `Set.ncard`) — the quantity $f_A(N) = |\\{1,\\ldots,N\\} \\setminus B|$."
+      "summary": "Defines `nonUniqueSumCount` (finite) and `nonUniqueSumCountInf` (infinite via `Set.ncard`) \u2014 the quantity $f_A(N) = |\\{1,\\ldots,N\\} \\setminus B|$."
     },
     {
       "id": "conjectures",
       "title": "Main Conjectures (14a and 14b)",
       "startLine": 52,
       "endLine": 66,
-      "summary": "States (a) $f_A(N) \\gg N^{1/2-\\varepsilon}$ eventually and (b) $\\exists A$ with $f_A(N) = o(\\sqrt{N})$, using `∀ᶠ` and filter quantifiers."
+      "summary": "States (a) $f_A(N) \\gg N^{1/2-\\varepsilon}$ eventually and (b) $\\exists A$ with $f_A(N) = o(\\sqrt{N})$, using `\u2200\u1da0` and filter quantifiers."
     },
     {
       "id": "ess-bounds",
-      "title": "Erdős-Sárközy-Szemerédi Bounds",
+      "title": "Erd\u0151s-S\u00e1rk\u00f6zy-Szemer\u00e9di Bounds",
       "startLine": 67,
       "endLine": 82,
       "summary": "Upper: $\\exists A$ with $f_A(N) \\leq CN^{1/2+\\varepsilon}$ eventually. Lower: same $A$ has $f_A(N) \\geq CN^{1/3-\\varepsilon}$ frequently."
     },
     {
       "id": "erdos-freud",
-      "title": "Erdős-Freud Finite Analogue",
+      "title": "Erd\u0151s-Freud Finite Analogue",
       "startLine": 83,
       "endLine": 89,
       "summary": "For $A \\subseteq \\{1,\\ldots,N\\}$, $\\exists A$ with $f_A(N) < 2^{3/2}\\sqrt{N}$. The constant $2\\sqrt{2}$ may be optimal."
@@ -109,13 +109,13 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #14 in 104 lines of Lean 4, encoding the unique-sum representation problem with both finite and infinite versions, the two open conjectures, ESS bounds ($O(N^{1/2+\\varepsilon})$ eventually, $\\Omega(N^{1/3-\\varepsilon})$ frequently), the Erdős-Freud finite analogue, and structural observations about Sidon sets. Zero sorries; all deep results axiomatized.",
-    "implications": "**Theoretical Significance**: Resolution would clarify the fundamental limits of unique representation in additive combinatorics.\n\nIf conjecture (a) holds, it establishes $\\sqrt{N}$ as a universal barrier — no set can achieve better than $\\sim \\sqrt{N}$ non-unique sums. This connects to the broader theory of additive bases, Sidon sets, and the probabilistic method in combinatorial number theory.",
+    "summary": "This formalization captures Erd\u0151s Problem #14 in 104 lines of Lean 4, encoding the unique-sum representation problem with both finite and infinite versions, the two open conjectures, ESS bounds ($O(N^{1/2+\\varepsilon})$ eventually, $\\Omega(N^{1/3-\\varepsilon})$ frequently), the Erd\u0151s-Freud finite analogue, and structural observations about Sidon sets. Zero sorries; all deep results axiomatized.",
+    "implications": "**Theoretical Significance**: Resolution would clarify the fundamental limits of unique representation in additive combinatorics.\n\nIf conjecture (a) holds, it establishes $\\sqrt{N}$ as a universal barrier \u2014 no set can achieve better than $\\sim \\sqrt{N}$ non-unique sums. This connects to the broader theory of additive bases, Sidon sets, and the probabilistic method in combinatorial number theory.",
     "openQuestions": [
       "Is $f_A(N) \\gg N^{1/2-\\varepsilon}$ for all $A$ and all large $N$? This is conjecture (a), the main open question.",
       "Can $f_A(N) = o(\\sqrt{N})$ for some $A$? This is conjecture (b), which if true would refute (a).",
       "What is the true exponent in the lower bound? The gap between the ESS bounds ($1/3$ from below, $1/2$ from above) leaves room for the answer to lie anywhere in $(1/3, 1/2]$.",
-      "Is the Erdős-Freud constant $2^{3/2}$ optimal for the finite analogue? What is the extremal set achieving this bound?"
+      "Is the Erd\u0151s-Freud constant $2^{3/2}$ optimal for the finite analogue? What is the extremal set achieving this bound?"
     ]
   },
   "leanFile": {
@@ -139,7 +139,7 @@
     {
       "targetId": "erdos-28",
       "relationship": "related",
-      "description": "Problem #28 (Erdős-Turán on additive bases) concerns unbounded representation. Problem #14 studies unique sums vs. non-unique representation, the complementary question of when representations can be controlled"
+      "description": "Problem #28 (Erd\u0151s-Tur\u00e1n on additive bases) concerns unbounded representation. Problem #14 studies unique sums vs. non-unique representation, the complementary question of when representations can be controlled"
     },
     {
       "targetId": "erdos-1",
@@ -149,10 +149,10 @@
   ],
   "references": [
     {
-      "authors": "Erdős, Paul; Freiman, Gregory",
+      "authors": "Erd\u0151s, Paul; Freiman, Gregory",
       "title": "On two additive problems",
       "year": "1990",
-      "venue": "Journal of Number Theory, vol. 34, no. 1, pp. 1–12",
+      "venue": "Journal of Number Theory, vol. 34, no. 1, pp. 1\u201312",
       "note": "Studied unique and non-unique representation in additive settings"
     },
     {

--- a/src/data/research/problems/erdos-14.json
+++ b/src/data/research/problems/erdos-14.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-14",
-  "title": "Erdős #14",
+  "title": "Erd\u0151s #14",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "(LaTeX not available)",
-    "plain": "Let $A\\subseteq \\mathbb{N}$. Let $B\\subseteq \\mathbb{N}$ be the set of integers which are representable in exactly one way as the sum of two elements from $A$. Is it true that for all $\\epsilon>0$ and large $N$\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert \\gg_\\epsilon N^{1/2-\\epsilon}?\\]Is it possible that\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert =o(N^{1/2})?\\] Apparently originally considered by Erdős and Nathanson, although later Erdős attributes this to Erdős, Sárközy, and Szemerédi (but gives...",
+    "plain": "Let $A\\subseteq \\mathbb{N}$. Let $B\\subseteq \\mathbb{N}$ be the set of integers which are representable in exactly one way as the sum of two elements from $A$. Is it true that for all $\\epsilon>0$ and large $N$\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert \\gg_\\epsilon N^{1/2-\\epsilon}?\\]Is it possible that\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert =o(N^{1/2})?\\] Apparently originally considered by Erd\u0151s and Nathanson, although later Erd\u0151s attributes this to Erd\u0151s, S\u00e1rk\u00f6zy, and Szemer\u00e9di (but gives...",
     "whyMatters": []
   },
   "knownResults": {
@@ -29,16 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 12 Lean files with total ~86 axioms, 3 sorries. Main file has 7 axioms. Too many files for efficient single-session work.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: Eliminated 1 axiom (non_unique_monotone). Fixed broken import. 6 axioms remain in Erdos14Problem (all deep/open). 4 axioms in Erdos14UniqueSums (sidon_size_bound potentially provable).",
+    "builtItems": [
+      "Proved non_unique_monotone in Erdos14Problem.lean:102 (3-line proof)",
+      "Fixed import: Asymptotics.Asymptotics -> Asymptotics.Defs in Erdos14Problem.lean:24"
+    ],
     "insights": [
       "12 associated Lean files - largest problem family encountered",
       "Erdos140Problem has 3 sorries worth investigating",
-      "Most axioms are deep number-theoretic results"
+      "Most axioms are deep number-theoretic results",
+      "non_unique_monotone axiom proved: monotonicity follows from Set.ncard_le_ncard + Icc subset",
+      "Import Mathlib.Analysis.Asymptotics.Asymptotics renamed to Mathlib.Analysis.Asymptotics.Defs in Mathlib v4.26",
+      "sidon_size_bound (UniqueSums) could be proved from Erdos340GreedySidon sidon_upper_bound_weak but needs Set/Finset conversion",
+      "Most axioms in Erdos14Problem.lean are deep results (open conjectures, deep theorems) that must stay as axioms",
+      "erdos_freud_finite duplicated between Erdos14Problem.lean and Erdos14UniqueSums.lean"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #14 - Knowledge Base\n\n## Problem Statement\n\nLet $A\\subseteq \\mathbb{N}$. Let $B\\subseteq \\mathbb{N}$ be the set of integers which are representable in exactly one way as the sum of two elements from $A$. Is it true that for all $\\epsilon>0$ and large $N$\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert \\gg_\\epsilon N^{1/2-\\epsilon}?\\]Is it possible that\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert =o(N^{1/2})?\\] Apparently originally considered by Erdős and Nathanson, although later Erdős attributes this to Erdős, Sárközy, and Szemerédi (but gives no reference), and claims a construction of an $A$ such that for all $\\epsilon>0$ and all large $N$\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert \\ll_\\epsilon N^{1/2+\\epsilon},\\]and yet there for all $\\epsilon>0$ there exist infinitely many $N$ where\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert \\gg_\\epsilon N^{1/3-\\epsilon}.\\]Erdös and Freud investigated the finite analogue in [ErFr91], proving that there exists $A\\subseteq \\{1,\\ldots,N\\}$ such that the number of integers not representable in exactly one w\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #3\n- Problem #13\n- Problem #15\n- Problem #39\n- Problem #1\n\n## References\n\n- Er92c\n- Er97\n- Er97e\n- ErFr91\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "nextSteps": [
+      "Prove sidon_size_bound from Erdos340GreedySidon.sidon_upper_bound_weak (Set/Finset bridge needed)",
+      "Consider proving sidon_set_non_unique using sidon_size_bound + counting argument",
+      "erdos_freud_finite deduplication between the two files"
+    ],
+    "markdown": "# Erd\u0151s #14 - Knowledge Base\n\n## Problem Statement\n\nLet $A\\subseteq \\mathbb{N}$. Let $B\\subseteq \\mathbb{N}$ be the set of integers which are representable in exactly one way as the sum of two elements from $A$. Is it true that for all $\\epsilon>0$ and large $N$\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert \\gg_\\epsilon N^{1/2-\\epsilon}?\\]Is it possible that\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert =o(N^{1/2})?\\] Apparently originally considered by Erd\u0151s and Nathanson, although later Erd\u0151s attributes this to Erd\u0151s, S\u00e1rk\u00f6zy, and Szemer\u00e9di (but gives no reference), and claims a construction of an $A$ such that for all $\\epsilon>0$ and all large $N$\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert \\ll_\\epsilon N^{1/2+\\epsilon},\\]and yet there for all $\\epsilon>0$ there exist infinitely many $N$ where\\[\\lvert \\{1,\\ldots,N\\}\\backslash B\\rvert \\gg_\\epsilon N^{1/3-\\epsilon}.\\]Erd\u00f6s and Freud investigated the finite analogue in [ErFr91], proving that there exists $A\\subseteq \\{1,\\ldots,N\\}$ such that the number of integers not representable in exactly one w\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #3\n- Problem #13\n- Problem #15\n- Problem #39\n- Problem #1\n\n## References\n\n- Er92c\n- Er97\n- Er97e\n- ErFr91\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- Prove `non_unique_monotone` axiom from definitions, eliminating 1 axiom (7 → 6)
- Fix broken import: `Mathlib.Analysis.Asymptotics.Asymptotics` → `Mathlib.Analysis.Asymptotics.Defs` (Mathlib v4.26 rename)
- Update gallery metadata and problem knowledge

## Progress
The monotonicity proof is a clean 3-line tactic proof:
```lean
theorem non_unique_monotone (A : Set ℕ) :
    ∀ M N : ℕ, M ≤ N → nonUniqueSumCountInf A M ≤ nonUniqueSumCountInf A N := by
  intro M N hMN
  unfold nonUniqueSumCountInf
  apply Set.ncard_le_ncard
  · exact Set.diff_subset_diff_left (Set.Icc_subset_Icc_right hMN)
  · exact (Set.finite_Icc 1 N).subset Set.diff_subset
```

## Findings
- Remaining 6 axioms in Erdos14Problem.lean are all deep results or open conjectures
- `sidon_size_bound` in Erdos14UniqueSums.lean could potentially be proved from existing `sidon_upper_bound_weak` in Erdos340GreedySidon.lean (requires Set/Finset bridge)
- `erdos_freud_finite` is duplicated between both files

## Status
**Outcome**: progress
**Next Steps**: Prove `sidon_size_bound` via Erdos340 bridge; consider `sidon_set_non_unique` counting argument

🤖 Generated by researcher-3