### PR TITLE
Enrich 2 proofs: section mathContext (erdos-10, erdos-1002)

### DIFF
--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -60,56 +60,64 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 35,
-      "summary": "Header documenting Erdős Problem #10 with references to Gallagher (1975), Granville-Soundararajan (1998), Grechuk, Romanoff (1934), and covering congruence arguments. Imports `Tactic`, `Nat.Prime.Basic`, `InfiniteSum.Real`, `AtTopBot.Group`. Opens `Set` and `Filter` namespaces."
+      "summary": "Header documenting Erdős Problem #10 with references to Gallagher (1975), Granville-Soundararajan (1998), Grechuk, Romanoff (1934), and covering congruence arguments. Imports `Tactic`, `Nat.Prime.Basic`, `InfiniteSum.Real`, `AtTopBot.Group`. Opens `Set` and `Filter` namespaces.",
+      "mathContext": "Establishes foundational framework for studying representations $n = p + \\sum 2^{a_i}$ where $p$ is prime and the exponent multiset has bounded cardinality."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 36,
       "endLine": 49,
-      "summary": "Defines `sumPrimeAndTwoPows k : Set \\mathbb{N}` as $\\{n : \\exists p \\text{ prime},\\, \\exists \\text{pows} : \\text{Multiset}\\,\\mathbb{N},\\, |\\text{pows}| \\leq k \\land n = p + \\sum 2^{a_i}\\}$. Defines `Set.lowerDensity S = \\liminf_{n \\to \\infty} |S \\cap [0,n]| / (n+1)$ via `Filter.liminf` along `atTop`."
+      "summary": "Defines `sumPrimeAndTwoPows k : Set \\mathbb{N}` as $\\{n : \\exists p \\text{ prime},\\, \\exists \\text{pows} : \\text{Multiset}\\,\\mathbb{N},\\, |\\text{pows}| \\leq k \\land n = p + \\sum 2^{a_i}\\}$. Defines `Set.lowerDensity S = \\liminf_{n \\to \\infty} |S \\cap [0,n]| / (n+1)$ via `Filter.liminf` along `atTop`.",
+      "mathContext": "$S_k = \\{n : n = p + \\sum_{i=1}^j 2^{a_i},\\; p \\text{ prime},\\; j \\leq k\\}$. Lower density $\\underline{d}(S_k) = \\liminf_{N \\to \\infty} |S_k \\cap [1,N]|/N$."
     },
     {
       "id": "main-conjecture",
       "title": "Erdős-Graham Conjecture",
       "startLine": 50,
       "endLine": 60,
-      "summary": "Axiomatizes `erdos_10_conjecture`: $\\neg \\exists k,\\, \\{n > 1\\} \\subseteq S_k$. The Erdős-Graham conjecture that no finite $k$ suffices for all integers. Equivalently: $\\forall k,\\, \\{n > 1\\} \\setminus S_k \\neq \\emptyset$."
+      "summary": "Axiomatizes `erdos_10_conjecture`: $\\neg \\exists k,\\, \\{n > 1\\} \\subseteq S_k$. The Erdős-Graham conjecture that no finite $k$ suffices for all integers. Equivalently: $\\forall k,\\, \\{n > 1\\} \\setminus S_k \\neq \\emptyset$.",
+      "mathContext": "$\\forall k \\in \\mathbb{N},\\; \\exists n > 1,\\; n \\notin S_k$: no finite number of powers of 2 added to a prime can represent all integers."
     },
     {
       "id": "gallagher",
       "title": "Gallagher's Density Theorem",
       "startLine": 61,
       "endLine": 68,
-      "summary": "Axiomatizes `gallagher_density`: $\\forall \\varepsilon > 0,\\, \\exists k: \\underline{d}(S_k) \\geq 1 - \\varepsilon$. The strongest unconditional result — 'almost all' integers are representable for large enough $k$. Proved via the large sieve (1975)."
+      "summary": "Axiomatizes `gallagher_density`: $\\forall \\varepsilon > 0,\\, \\exists k: \\underline{d}(S_k) \\geq 1 - \\varepsilon$. The strongest unconditional result — 'almost all' integers are representable for large enough $k$. Proved via the large sieve (1975).",
+      "mathContext": "Gallagher (1975): $\\underline{d}(S_k) \\to 1$ as $k \\to \\infty$, proved via the large sieve inequality and Bombieri-Vinogradov theorem."
     },
     {
       "id": "granville-soundararajan",
       "title": "Granville-Soundararajan Conjectures",
       "startLine": 69,
       "endLine": 80,
-      "summary": "Axiomatizes `granville_soundararajan_odd`: $\\{n \\text{ odd},\\, n > 1\\} \\subseteq S_3$, and `granville_soundararajan_even`: $\\{n \\text{ even},\\, n \\neq 0\\} \\subseteq S_4$. Conjectured 1998; computationally verified for large ranges."
+      "summary": "Axiomatizes `granville_soundararajan_odd`: $\\{n \\text{ odd},\\, n > 1\\} \\subseteq S_3$, and `granville_soundararajan_even`: $\\{n \\text{ even},\\, n \\neq 0\\} \\subseteq S_4$. Conjectured 1998; computationally verified for large ranges.",
+      "mathContext": "Conjectured: every odd $n > 1$ is $p + 2^a + 2^b + 2^c$ ($k=3$) and every even $n > 0$ is $p + 2^a + 2^b + 2^c + 2^d$ ($k=4$)."
     },
     {
       "id": "counterexample",
       "title": "Grechuk's Counterexample",
       "startLine": 81,
       "endLine": 87,
-      "summary": "Axiomatizes `grechuk_counterexample`: $1117175146 \\notin S_3$. Since $1117175146$ is even, this is consistent with $S_3 \\supseteq \\{n \\text{ odd},\\, n > 1\\}$ but shows $k = 3$ fails for even integers."
+      "summary": "Axiomatizes `grechuk_counterexample`: $1117175146 \\notin S_3$. Since $1117175146$ is even, this is consistent with $S_3 \\supseteq \\{n \\text{ odd},\\, n > 1\\}$ but shows $k = 3$ fails for even integers.",
+      "mathContext": "$1117175146 \\notin S_3$: this even number cannot be $p + 2^a + 2^b + 2^c$ for any prime $p$, establishing the parity barrier for $k = 3$."
     },
     {
       "id": "exceptions",
       "title": "Infinitely Many Exceptions",
       "startLine": 88,
       "endLine": 102,
-      "summary": "Axiomatizes `infinitely_many_exceptions_k2`: $\\{n \\text{ even}\\} \\setminus S_2$ is infinite (proved via covering congruences), and `infinitely_many_exceptions_k3`: $\\{n \\text{ even}\\} \\setminus S_3$ is infinite (conjectured)."
+      "summary": "Axiomatizes `infinitely_many_exceptions_k2`: $\\{n \\text{ even}\\} \\setminus S_2$ is infinite (proved via covering congruences), and `infinitely_many_exceptions_k3`: $\\{n \\text{ even}\\} \\setminus S_3$ is infinite (conjectured).",
+      "mathContext": "Erdős's covering congruence argument: infinitely many even integers are not in $S_2 = \\{p + 2^a + 2^b\\}$. Extension to $S_3$ remains open."
     },
     {
       "id": "romanoff",
       "title": "Romanoff's Theorem",
       "startLine": 103,
       "endLine": 109,
-      "summary": "Axiomatizes `romanoff_positive_density`: $\\underline{d}(S_1) > 0$. Romanoff (1934) showed a positive proportion of integers are $p + 2^a$, using sieve methods. One of the earliest results on prime-plus-lacunary bases."
+      "summary": "Axiomatizes `romanoff_positive_density`: $\\underline{d}(S_1) > 0$. Romanoff (1934) showed a positive proportion of integers are $p + 2^a$, using sieve methods. One of the earliest results on prime-plus-lacunary bases.",
+      "mathContext": "Romanoff (1934): $\\underline{d}(S_1) > 0$ via sieve methods — a positive proportion of integers have the form $p + 2^a$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -49,70 +49,80 @@
       "title": "Fractional Part",
       "summary": "$\\{x\\} = x - \\lfloor x \\rfloor$ fractional part definition and deviation from midpoint",
       "startLine": 34,
-      "endLine": 41
+      "endLine": 41,
+      "mathContext": "$\\{x\\} = x - \\lfloor x \\rfloor \\in [0,1)$. The deviation $1/2 - \\{x\\}$ measures distance from the midpoint; its sum over $k$ captures the asymmetry of the orbit $\\{\\alpha k\\}_{k=1}^n$."
     },
     {
       "id": "weighted-sum",
       "title": "The Weighted Sum f(α, n)",
       "summary": "$S(\\alpha, n) = \\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\})$ and $f(\\alpha, n) = S(\\alpha, n)/\\log n$",
       "startLine": 43,
-      "endLine": 57
+      "endLine": 57,
+      "mathContext": "$f(\\alpha, n) = \\frac{1}{\\log n}\\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\})$. The $\\log n$ normalization is set by Weyl equidistribution: for irrational $\\alpha$, partial sums grow at most logarithmically."
     },
     {
       "id": "distribution-functions",
       "title": "Distribution Functions",
       "summary": "$g : \\mathbb{R} \\to [0,1]$ non-decreasing with $g(-\\infty) = 0$, $g(+\\infty) = 1$",
       "startLine": 59,
-      "endLine": 70
+      "endLine": 70,
+      "mathContext": "A distribution function $g: \\mathbb{R} \\to [0,1]$ with $g(-\\infty) = 0$, $g(+\\infty) = 1$ represents the limiting CDF of $f(\\alpha,n)$ as $n \\to \\infty$."
     },
     {
       "id": "asymptotic-distribution",
       "title": "Asymptotic Distribution",
       "summary": "Level set $L(n,c) = \\{\\alpha : f(\\alpha,n) \\le c\\}$ and $\\mu(L(n,c)) \\to g(c)$ convergence",
       "startLine": 72,
-      "endLine": 90
+      "endLine": 90,
+      "mathContext": "$L(n,c) = \\{\\alpha \\in (0,1) : f(\\alpha,n) \\leq c\\}$. The conjecture: $\\mu(L(n,c)) \\to g(c)$ for some distribution function $g$, where $\\mu$ is Lebesgue measure."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture (OPEN)",
       "summary": "OPEN: $\\exists\\, g,\\; \\mu(\\{\\alpha : f(\\alpha,n) \\le c\\}) \\to g(c)$ as $n \\to \\infty$",
       "startLine": 92,
-      "endLine": 99
+      "endLine": 99,
+      "mathContext": "Main conjecture: $\\exists g,\\; \\forall c \\in \\mathbb{R},\\; \\lim_{n \\to \\infty} \\mu(\\{\\alpha : f(\\alpha,n) \\leq c\\}) = g(c)$. Neither existence nor form of $g$ is known."
     },
     {
       "id": "kesten-theorem",
       "title": "Kesten's Theorem (1960)",
       "summary": "Kesten (1960): Two-parameter variant has Cauchy limit $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$",
       "startLine": 101,
-      "endLine": 140
+      "endLine": 140,
+      "mathContext": "Kesten (1960): the two-parameter variant $f(\\alpha,\\beta,n) = \\frac{1}{\\log n}\\sum(1/2 - \\{\\beta + \\alpha k\\})$ converges in distribution to a Cauchy CDF $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$. The shift $\\beta$ provides ergodic independence; fixing $\\beta = 0$ destroys this."
     },
     {
       "id": "relationship",
       "title": "Relationship Between Problems",
       "summary": "$f(\\alpha, n) = f(\\alpha, 0, n)$: one-parameter case is $\\beta = 0$ specialization (proved)",
       "startLine": 142,
-      "endLine": 152
+      "endLine": 152,
+      "mathContext": "$f(\\alpha,n) = f(\\alpha, 0, n)$: the one-parameter problem is the $\\beta = 0$ specialization. Understanding why $\\beta = 0$ breaks Kesten's proof is the central difficulty."
     },
     {
       "id": "difficulty",
       "title": "Why the Problem is Difficult",
       "summary": "Boundedness of $f$ for irrational $\\alpha$ and $|S(\\alpha, n)| \\le C \\log n$ bound",
       "startLine": 154,
-      "endLine": 167
+      "endLine": 167,
+      "mathContext": "For irrational $\\alpha$: $|S(\\alpha,n)| \\leq C\\log n$ (so $f = O(1)$), but the distribution of values across different $\\alpha$ remains intractable without Kesten's parameter-averaging."
     },
     {
       "id": "partial-results",
       "title": "Partial Results",
       "summary": "Weyl equidistribution implies sublinear growth; rational periodicity of inner sum",
       "startLine": 169,
-      "endLine": 183
+      "endLine": 183,
+      "mathContext": "Weyl: $\\{\\alpha k\\}$ equidistributed for irrational $\\alpha$, so $S(\\alpha,n) = o(n)$. For rational $\\alpha = p/q$: $\\{\\alpha k\\}$ is periodic with period $q$, giving exact closed forms."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Complete formalization: 7 axioms, 0 sorries, 2 theorems; main conjecture OPEN (mathematical gap, not formalization gap)",
       "startLine": 185,
-      "endLine": 211
+      "endLine": 211,
+      "mathContext": "7 axioms encoding Kesten's theorem, Weyl equidistribution, and the main conjecture. 2 proved theorems: $f(\\alpha,n) = f(\\alpha,0,n)$ and rational periodicity. The open mathematical problem cannot be resolved by formal methods alone."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Section mathContext enrichment for 2 gallery entries (batch 2):

- **erdos-10**: Added mathContext to all 8 sections (prime-plus-powers representations, Gallagher density, Granville-Soundararajan, covering congruences, Romanoff)
- **erdos-1002**: Added mathContext to all 10 sections (weighted fractional sums, distribution functions, Kesten's Cauchy theorem, Weyl equidistribution)

Note: First batch (abel-ruffini, erdos-1170, erdos-1000, erdos-1001, erdos-100) was lost during branch reset. Those enrichments will need to be redone.

## Test plan

- [ ] JSON validation passes
- [ ] No new annotation build errors for enriched entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)