### PR TITLE
Fix: remove #check debug lines from ContinuumHypothesis.lean

### DIFF
--- a/proofs/Proofs/ContinuumHypothesis.lean
+++ b/proofs/Proofs/ContinuumHypothesis.lean
@@ -394,11 +394,3 @@ The independence of CH didn't end the story:
 -/
 
 end ContinuumHypothesis
-
--- Export main theorems
-#check ContinuumHypothesis.CH
-#check ContinuumHypothesis.GCH
-#check ContinuumHypothesis.continuum_hypothesis_independent
-#check ContinuumHypothesis.cantor_theorem
-#check ContinuumHypothesis.ch_consistent_with_zfc
-#check ContinuumHypothesis.not_ch_consistent_with_zfc

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2025-12-29",
     "axiomCount": 4,
     "assumptions": "4 axiom declarations: L_exists (constructible universe L exists as ZFC model), L_satisfies_CH (L satisfies CH), forcing_extension_exists (Cohen forcing extension exists), forcing_violates_CH (forcing model violates CH). Previously 6 axioms; ch_implies_no_intermediate and no_intermediate_implies_ch are now proved from Mathlib cardinal arithmetic.",
-    "lineCount": 404,
+    "lineCount": 396,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -116,7 +116,7 @@
       "Cardinal"
     ],
     "namespace": "ContinuumHypothesis",
-    "lineCount": 404,
+    "lineCount": 396,
     "axiomCount": 4,
     "theoremCount": 9,
     "definitionCount": 8

--- a/src/data/proofs/continuum-hypothesis/review.json
+++ b/src/data/proofs/continuum-hypothesis/review.json
@@ -149,8 +149,8 @@
       "id": "ai-8",
       "priority": "low",
       "target": "researcher",
-      "description": "Remove #check debug lines at end of file (lines 361-366).",
-      "status": "open"
+      "description": "Remove #check debug lines at end of file (lines 399-404).",
+      "status": "resolved"
     }
   ],
   "qualityScores": {


### PR DESCRIPTION
## Fix

Remove 6 trailing #check debug commands from ContinuumHypothesis.lean.

## Evidence

**Before**: Lines 398-404 had #check commands for CH, GCH, continuum_hypothesis_independent, cantor_theorem, ch_consistent_with_zfc, not_ch_consistent_with_zfc.

**After**: Debug lines removed. lineCount updated from 404 to 396.

Addresses peer review action item ai-8.

---
Automated fix by lean-mechanic agent.