### PR TITLE
Peer review: godel-incompleteness (D+)

### DIFF
--- a/src/data/proofs/godel-incompleteness/review.json
+++ b/src/data/proofs/godel-incompleteness/review.json
@@ -1,0 +1,171 @@
+{
+  "version": 1,
+  "proofId": "godel-incompleteness",
+  "reviewDate": "2026-03-24T12:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "D+",
+    "oneLiner": "Excellent pedagogical commentary built on a formally vacuous foundation — every provability theorem is trivially true because Provable is defined as constantly False.",
+    "tier": "C",
+    "tierJustification": "Scaffold/axiomatized. The provability predicate is a placeholder (fun _ => False), making all incompleteness theorems vacuously true. The diagonal lemma proves ∃ γ, True. The Gödel sentence is hardcoded as ⟨42⟩. The formalization captures argument structure (first_incompleteness has the correct case split) but contains no substantive formal mathematics. The real value is in the commentary, not the code."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Lean file docstrings, lines 66-78, 150-160, 167-177, 280-298, 310-326, 344-357; meta.json overview; annotations",
+      "finding": "The pedagogical exposition is genuinely excellent. The proof strategy, historical context, key insights, and philosophical implications are accurate, well-written, and would genuinely help someone understand the conceptual structure of Gödel's proof. The Lean file's inline comments are refreshingly honest about the placeholder nature of Provable. Cross-references are extensive and mostly well-chosen.",
+      "recommendation": "Preserve this exposition. It should be reframed as the main value proposition of the entry rather than being secondary to the (vacuous) formal content."
+    },
+    {
+      "severity": "major",
+      "category": "gap",
+      "location": "Provable definition, line 78: def Provable : Formula → Prop := fun _ => False",
+      "finding": "The entire formalization is built on Provable := fun _ => False. This means: (1) G_not_provable reduces to ¬False, (2) not_G_not_provable reduces to ¬False, (3) second_incompleteness reduces to ¬False, (4) lobs_theorem's hypothesis is False so the implication is vacuously true, (5) rosser_undecidable reduces to ¬False ∧ ¬False. Every 'incompleteness theorem' in this file is trivially true because nothing is provable — there is no mathematics here, just type-checking of trivial propositions.",
+      "recommendation": "Replace with a meaningful provability predicate, even if axiomatic. For example, declare Provable as an opaque axiom (axiom Provable : Formula → Prop) and state its properties as separate axioms. This would make the theorems depend on genuine logical reasoning rather than definitional unfolding of False."
+    },
+    {
+      "severity": "major",
+      "category": "filler",
+      "location": "diagonal_lemma, lines 132-134: ∃ γ : Formula, True proved by ⟨⟨0⟩, trivial⟩",
+      "finding": "The diagonal lemma is the technical heart of Gödel's proof — it enables self-reference. Here it is stated as 'for any P, there exists a formula γ such that True', which is completely vacuous. The type signature has been simplified to remove the actual fixed-point property (γ ↔ P(⌜γ⌝)), leaving only the trivially satisfiable existential.",
+      "recommendation": "Either state the real diagonal lemma (∃ γ, Provable (equiv γ (P (godelNum γ)))) with a sorry, or honestly remove it and note its absence. The current version misleads readers into thinking something has been formalized."
+    },
+    {
+      "severity": "major",
+      "category": "inconsistency",
+      "location": "axiom derivability_conditions, lines 243-250",
+      "finding": "The derivability_conditions axiom introduces a logical inconsistency. D2 asserts ∀ φ ψ, Provable (impl ...) and D3 asserts ∀ φ, Provable (impl ...). Since Provable is constantly False, D2 and D3 both assert False for all inputs. The conjunction D1 ∧ D2 ∧ D3 is therefore False. This axiom declaration makes the entire Lean environment inconsistent — any proposition can be proved from it.",
+      "recommendation": "If Provable is kept as const False, remove this axiom entirely (it introduces unsoundness). If Provable is made opaque/axiomatic, the derivability conditions become meaningful and should be kept."
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "meta.json description (line 5) and overview.problemStatement (line 55)",
+      "finding": "The description says 'Any consistent formal system capable of expressing basic arithmetic contains statements that are true but unprovable within the system.' The problemStatement describes the full theorem. Neither flags that the Lean file is a pedagogical sketch where all theorems are vacuously true. A reader of the gallery entry would expect a formalization, not a commented placeholder. The Lean file's own comments are more honest.",
+      "recommendation": "Add a prominent qualifier: 'This entry presents the conceptual structure of Gödel's proof with a placeholder provability predicate. The formal theorems demonstrate argument structure but are vacuously true.' Consider adding a 'formalizationNote' field."
+    },
+    {
+      "severity": "moderate",
+      "category": "filler",
+      "location": "G_self_reference, line 161: theorem G_self_reference : True := trivial",
+      "finding": "Despite the extensive docstring (lines 150-160) describing this as encapsulating 'the key step that requires the Diagonal Lemma', the theorem proves True. The docstring says 'Why an axiom?' but it is declared as a theorem, not an axiom. The Lean docstring at line 42 also calls it an axiom ('3 axioms (G_self_reference, derivability_conditions, lob_sentence_fixed_point)') contradicting the actual code.",
+      "recommendation": "If this is meant to be an axiom capturing G ↔ ¬Prov(⌜G⌝), declare it as such with a meaningful statement. If it's a theorem, make the docstring match."
+    },
+    {
+      "severity": "moderate",
+      "category": "filler",
+      "location": "no_truth_predicate, line 453: (1 : ℕ) + 1 = 2 := rfl",
+      "finding": "Tarski's Undefinability of Truth is a significant result closely related to incompleteness. Here it 'proves' 1 + 1 = 2 and labels it a placeholder. This adds clutter without mathematical content.",
+      "recommendation": "Either formalize a meaningful statement about truth predicates (even axiomatically) or remove this theorem. A placeholder that proves 1+1=2 under the name 'no_truth_predicate' is actively confusing."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions, lines 28-38",
+      "finding": "Lists 9 'original contributions' including 'first_incompleteness_theorem: consistent → ¬Complete' and 'lob_theorem: Löb's theorem from derivability conditions'. While technically accurate (these theorem statements exist), calling them contributions without noting they are vacuously true is misleading. Only the Provable placeholder is flagged as such.",
+      "recommendation": "Add qualifiers to each contribution, or restructure to separate 'argument structure demonstrated' from 'mathematically proved'."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "Lean file line 42 vs meta.json axiomCount (line 41)",
+      "finding": "Lean file docstring says '0 sorries, 3 axioms (G_self_reference, derivability_conditions, lob_sentence_fixed_point)'. But G_self_reference is declared as 'theorem', not 'axiom'. meta.json correctly says axiomCount: 2. Also, lob_sentence_fixed_point (line 340) states ∀ φ, True — trivially provable without being an axiom.",
+      "recommendation": "Fix the Lean docstring to say '2 axioms (derivability_conditions, lob_sentence_fixed_point)'. Consider converting lob_sentence_fixed_point to a theorem (it proves True) or giving it a meaningful statement."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "annotations.json ann-intro, line 12",
+      "finding": "Annotation mathContext says 'The imports include SimpleGraph.Basic and Fintype.Basic from Mathlib.' The actual imports are Mathlib.Logic.Basic and Mathlib.Tactic. SimpleGraph and Fintype are not imported.",
+      "recommendation": "Fix to: 'The imports include Logic.Basic and Tactic from Mathlib.'"
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "annotations.json ann-formula-type, line 35",
+      "finding": "States 'In Lean, this is an opaque axiom Formula : Type rather than an inductive definition'. Actually, Formula is defined as 'structure Formula where code : Nat' — a concrete structure, not an opaque axiom.",
+      "recommendation": "Fix to reflect the actual definition: 'In Lean, this is a structure with a single code : Nat field.'"
+    },
+    {
+      "severity": "minor",
+      "category": "filler",
+      "location": "cannot_prove_own_consistency (line 303) and second_incompleteness_from_lob (line 372)",
+      "finding": "These are near-duplicates of second_incompleteness (line 296). All three prove ¬Provable Con with identical trivial proofs. Having three copies of the same vacuously-true result adds no value.",
+      "recommendation": "Keep one canonical version (second_incompleteness) and remove the duplicates, or differentiate them by making the Löb-based derivation actually use Löb's theorem."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "researcher",
+      "description": "Replace 'Provable : Formula → Prop := fun _ => False' with an opaque axiomatic predicate (axiom Provable : Formula → Prop). State its properties as separate axioms. This single change would make every theorem in the file depend on genuine logical reasoning instead of definitional unfolding of False.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Update meta.json description and overview to prominently flag that this is a pedagogical sketch with a placeholder provability predicate. The Lean file's own comments are honest about this; the gallery entry should be equally honest.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Fix annotations.json: (1) ann-intro line 12: change 'SimpleGraph.Basic and Fintype.Basic' to 'Logic.Basic and Tactic', (2) ann-formula-type line 35: change 'opaque axiom Formula : Type' to 'structure Formula where code : Nat'.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "medium",
+      "target": "researcher",
+      "description": "Give diagonal_lemma a meaningful statement (even with sorry): ∃ γ, Provable (equiv γ (P (godelNum γ))). Currently it proves ∃ γ, True which is vacuous.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "medium",
+      "target": "researcher",
+      "description": "Remove the derivability_conditions axiom if Provable remains const False (it introduces inconsistency). If Provable is made opaque, keep it.",
+      "status": "open"
+    },
+    {
+      "id": "ai-6",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix Lean docstring line 42: change '3 axioms (G_self_reference, derivability_conditions, lob_sentence_fixed_point)' to '2 axioms (derivability_conditions, lob_sentence_fixed_point)' since G_self_reference is a theorem.",
+      "status": "open"
+    },
+    {
+      "id": "ai-7",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Remove or replace no_truth_predicate (proves 1+1=2 under a misleading name) and deduplicate second_incompleteness / cannot_prove_own_consistency / second_incompleteness_from_lob.",
+      "status": "open"
+    },
+    {
+      "id": "ai-8",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Restructure meta.json originalContributions to distinguish 'argument structure demonstrated' from 'mathematically substantive content'. Add qualifiers noting that theorems are vacuously true due to the placeholder predicate.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 2,
+    "originalityAccuracy": 4,
+    "completeness": 3,
+    "framingPrecision": 4,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 4,
+    "overall": 4.2
+  },
+
+  "suggestedBestFraming": "A pedagogical scaffold illustrating the conceptual structure of Gödel's Incompleteness Theorems in Lean 4, with excellent mathematical commentary but a placeholder provability predicate (constantly False) that makes all formal theorems vacuously true — the value lies in the exposition, not the code."
+}

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -128,6 +128,14 @@
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0
+    },
+    "godel-incompleteness": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-24T11:31:59Z",
+      "overallGrade": "D+",
+      "qualityScore": null,
+      "actionItems": 0,
+      "resolvedItems": 0
     }
   }
 }


### PR DESCRIPTION
Peer review of godel-incompleteness. Grade: D+. 12 findings, 8 action items.

## Key Findings

**The good**: Excellent pedagogical exposition — historical context, proof strategy, key insights, and philosophical implications are accurate, well-written, and genuinely educational.

**The critical issue**: `Provable : Formula → Prop := fun _ => False` makes every provability theorem vacuously true. The diagonal lemma proves `∃ γ, True`. The Gödel sentence is hardcoded as `⟨42⟩`. The `derivability_conditions` axiom introduces a logical inconsistency (asserts `Provable` of formulas when Provable = const False).

**Internal inconsistencies**: Lean docstring claims 3 axioms but G_self_reference is a theorem; annotations cite wrong imports (SimpleGraph.Basic instead of Logic.Basic).

## Scores
- Mathematical Substance: 2/10
- Originality Accuracy: 4/10
- Completeness: 3/10
- Framing Precision: 4/10
- Pedagogical Quality: 8/10
- Internal Consistency: 4/10

## Top Action Items
1. Replace Provable placeholder with opaque axiomatic predicate
2. Update meta.json to frame as pedagogical sketch
3. Fix annotation import errors