### PR TITLE
Research: erdos-428 - Prove finite_set_zero_density (1 axiom eliminated)

### DIFF
--- a/proofs/Proofs/Erdos428Problem.lean
+++ b/proofs/Proofs/Erdos428Problem.lean
@@ -55,11 +55,12 @@ def ErdosProblem428Limsup : Prop :=
     Filter.limsup (fun n => primeDensityRatio A n) Filter.atTop > 0
 
 /-- The liminf version implies the limsup version.
-    Proof: liminf ≤ limsup, so liminf > 0 implies limsup > 0. -/
+    Note: Filter.liminf_le_limsup requires IsBoundedUnder (bounded above)
+    which needs a PNT-like argument for the density ratio. -/
 theorem liminf_implies_limsup :
     ErdosProblem428 → ErdosProblem428Limsup := by
   intro ⟨A, hfreq, hliminf⟩
-  exact ⟨A, hfreq, lt_of_lt_of_le hliminf (Filter.liminf_le_limsup)⟩
+  exact ⟨A, hfreq, lt_of_lt_of_le hliminf (by sorry)⟩
 
 -- ## Prime k-Tuple Conjecture
 
@@ -81,8 +82,7 @@ theorem primeCounting_pos (n : ℕ) (hn : 2 ≤ n) :
     0 < primeCounting n := by
   unfold primeCounting
   apply Finset.card_pos.mpr
-  exact ⟨2, Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega),
-    Nat.prime_iff.mpr ⟨by omega, fun m hm => by omega⟩⟩⟩
+  exact ⟨2, Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), by decide⟩⟩
 
 /-- Singleton sets always satisfy AllOffsetsPrime for appropriate n. -/
 theorem singleton_offset (a : ℕ) (n : ℕ) (ha : 0 < a) (han : a < n)
@@ -96,7 +96,7 @@ theorem singleton_offset (a : ℕ) (n : ℕ) (ha : 0 < a) (han : a < n)
 /-- The empty set trivially satisfies AllOffsetsPrime but has zero density. -/
 theorem empty_trivial (n : ℕ) : AllOffsetsPrime ∅ n := by
   intro a ha
-  exact absurd ha (Set.not_mem_empty a)
+  exact absurd ha (Set.notMem_empty a)
 
 /-- Subsets preserve the AllOffsetsPrime property. -/
 theorem allOffsetsPrime_mono {A B : Set ℕ} {n : ℕ}
@@ -109,13 +109,79 @@ theorem allOffsetsPrime_mono {A B : Set ℕ} {n : ℕ}
 theorem primeDensityRatio_nonneg (A : Set ℕ) (n : ℕ) :
     0 ≤ primeDensityRatio A n := by
   unfold primeDensityRatio
-  apply div_nonneg
-  · exact Nat.cast_nonneg'
-  · exact Nat.cast_nonneg'
+  exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
 
-/-- Finite sets have zero liminf prime density. -/
-axiom finite_set_zero_density (A : Set ℕ) (hA : A.Finite) :
-    Filter.liminf (fun n => primeDensityRatio A n) Filter.atTop = 0
+-- ## Finite Set Density Proof
+
+/-- primeCounting is monotone: more primes counted up to larger n. -/
+private lemma primeCounting_mono : Monotone primeCounting := by
+  intro m n hmn
+  unfold primeCounting
+  apply Finset.card_le_card
+  apply Finset.filter_subset_filter
+  exact Finset.range_mono (by omega)
+
+/-- Strictly more primes are counted up to a prime p than up to any smaller N. -/
+private lemma primeCounting_lt_of_prime {N p : ℕ} (hp : p.Prime) (hpN : N < p) :
+    primeCounting N < primeCounting p := by
+  unfold primeCounting
+  apply Finset.card_lt_card
+  constructor
+  · exact Finset.filter_subset_filter _ (Finset.range_mono (by omega))
+  · intro h
+    have hp_in : p ∈ Finset.filter Nat.Prime (Finset.range (p + 1)) :=
+      Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), hp⟩
+    exact absurd (h hp_in) (by
+      simp only [Finset.mem_filter, Finset.mem_range, not_and]
+      intro h; omega)
+
+/-- The prime counting function grows without bound (ℕ-valued). -/
+private lemma primeCounting_tendsto_nat :
+    Filter.Tendsto primeCounting Filter.atTop Filter.atTop := by
+  apply Filter.tendsto_atTop_atTop_of_monotone primeCounting_mono
+  intro M
+  induction M with
+  | zero => exact ⟨0, Nat.zero_le _⟩
+  | succ k ih =>
+    obtain ⟨N, hN⟩ := ih
+    obtain ⟨p, hp_ge, hp_prime⟩ := Nat.exists_infinite_primes (N + 1)
+    have hNp : N < p := by omega
+    have h_lt := primeCounting_lt_of_prime hp_prime hNp
+    exact ⟨p, by omega⟩
+
+/-- The real-valued prime counting function grows without bound. -/
+private lemma primeCounting_real_tendsto :
+    Filter.Tendsto (fun n => (primeCounting n : ℝ)) Filter.atTop Filter.atTop := by
+  rw [Filter.tendsto_atTop_atTop]
+  intro b
+  obtain ⟨N, hN⟩ := (Filter.tendsto_atTop_atTop.mp primeCounting_tendsto_nat) ⌈max b 0⌉₊
+  exact ⟨N, fun n hn => le_trans (le_trans (le_max_left b 0) (Nat.le_ceil _))
+    (by exact_mod_cast hN n hn)⟩
+
+/-- Finite sets have zero liminf prime density.
+
+Proof: For finite A with |A| = M, the intersection (A ∩ [1,n]) has at most M elements,
+so primeDensityRatio A n ≤ M / π(n). Since π(n) → ∞ by the infinitude of primes,
+this ratio is squeezed to 0. -/
+theorem finite_set_zero_density (A : Set ℕ) (hA : A.Finite) :
+    Filter.liminf (fun n => primeDensityRatio A n) Filter.atTop = 0 := by
+  -- Step 1: Show the density ratio tends to 0
+  suffices h_tendsto : Filter.Tendsto (fun n => primeDensityRatio A n) Filter.atTop (nhds 0) by
+    exact h_tendsto.liminf_eq
+  -- Step 2: Squeeze between 0 and A.ncard / π(n)
+  apply squeeze_zero (primeDensityRatio_nonneg A)
+  · -- Upper bound: primeDensityRatio A n ≤ A.ncard / π(n)
+    intro n
+    show (↑(A ∩ Set.Icc 1 n).ncard : ℝ) / ↑(primeCounting n) ≤ ↑A.ncard / ↑(primeCounting n)
+    apply div_le_div_of_nonneg_right
+    · exact_mod_cast Set.ncard_le_ncard Set.inter_subset_left hA
+    · exact Nat.cast_nonneg _
+  · -- A.ncard / π(n) → 0 since π(n) → ∞
+    have h_inv : Filter.Tendsto (fun n => ((primeCounting n : ℝ))⁻¹)
+        Filter.atTop (nhds 0) :=
+      tendsto_inv_atTop_zero.comp primeCounting_real_tendsto
+    have h_mul := tendsto_const_nhds (x := (A.ncard : ℝ)) |>.mul h_inv
+    rwa [mul_zero] at h_mul
 
 /-- Any solution to Problem 428 must use an infinite set. -/
 theorem erdos428_requires_infinite :

--- a/src/data/proofs/erdos-428/meta.json
+++ b/src/data/proofs/erdos-428/meta.json
@@ -68,13 +68,14 @@
       "Proved erdos428_requires_infinite via finite_set_zero_density",
       "Proved allOffsetsPrime_mono (subset monotonicity)"
     ],
-    "axiomCount": 2,
-    "lineCount": 130,
-    "assumptions": "2 axioms: erdos_graham_limsup, finite_set_zero_density. See Lean source for complete statements."
+    "axiomCount": 1,
+    "lineCount": 196,
+    "sorries": 1,
+    "assumptions": "1 axiom: erdos_graham_limsup (k-tuple conjecture implies limsup variant). 1 sorry in liminf_implies_limsup (needs IsBoundedUnder for Mathlib's Filter.liminf_le_limsup)."
   },
   "leanFile": {
     "path": "Proofs/Erdos428Problem.lean",
-    "lineCount": 130,
+    "lineCount": 196,
     "namespace": "root",
     "imports": [
       "Mathlib.Data.Nat.Prime.Basic",
@@ -100,9 +101,9 @@
       "ErdosProblem428Limsup",
       "PrimeKTupleConjecture"
     ],
-    "axiomCount": 2,
-    "theoremCount": 7,
-    "sorryCount": 0
+    "axiomCount": 1,
+    "theoremCount": 12,
+    "sorryCount": 1
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in their influential 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (L'Enseignement Mathématique, Monograph No. 28). It asks whether a set of 'prime-generating offsets' can have positive density relative to the prime counting function $\\pi(x)$. Informally: can you find a substantial set $A$ of natural numbers such that for infinitely many $n$, subtracting any element of $A$ from $n$ always yields a prime?\n\nThe problem connects to the Hardy-Littlewood prime $k$-tuple conjecture (1923), one of the central open problems in analytic number theory. Hardy and Littlewood conjectured that any admissible pattern of primes occurs infinitely often; the twin prime conjecture is the simplest special case ($H = \\{0, 2\\}$). Erdős and Graham showed that the weaker limsup variant of Problem #428 holds assuming the $k$-tuple conjecture, using a greedy construction of admissible tuples combined with the Prime Number Theorem.\n\nThe essential difficulty is strengthening limsup to liminf: the offset set must maintain its density consistently, not just along a subsequence. Major progress toward the $k$-tuple conjecture came from Yitang Zhang (2014), who proved bounded gaps between primes ($\\liminf p_{n+1} - p_n \\leq 7 \\times 10^7$), and James Maynard (2015), who improved this dramatically and proved that for any $m$, infinitely many intervals of bounded length contain $m$ primes. Despite this progress, the full $k$-tuple conjecture remains open, and Problem #428 in its liminf form is wide open.\n\nThe problem sits at the intersection of analytic number theory (prime counting, sieve theory) and additive combinatorics (density of structured sets). A positive answer would demonstrate remarkable regularity in the distribution of prime-generating translations.",

--- a/src/data/research/problems/erdos-428.json
+++ b/src/data/research/problems/erdos-428.json
@@ -29,16 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 2 axioms, 7 proved theorems. finite_set_zero_density is most tractable: finite A => |A∩[1,n]|/pi(n) -> 0 since numerator bounded, denominator -> infinity.",
-    "builtItems": [],
+    "progressSummary": "COMPLETED: Proved finite_set_zero_density theorem (was axiom). Reduced axioms from 2 to 1. Also fixed existing Mathlib API breakage (Nat.prime_iff, Set.not_mem_empty, Nat.cast_nonneg).",
+    "builtItems": [
+      "Proved primeCounting_mono (monotonicity)",
+      "Proved primeCounting_lt_of_prime (strict monotonicity at primes)",
+      "Proved primeCounting_tendsto_nat (π(n) → ∞ as ℕ)",
+      "Proved primeCounting_real_tendsto (π(n) → ∞ as ℝ)",
+      "Proved finite_set_zero_density (eliminated axiom)"
+    ],
     "insights": [
       "Only 2 axioms - well-developed file",
       "finite_set_zero_density provable: finite A has bounded intersection, pi(n)->inf by infinitude of primes",
-      "erdos_graham_limsup is conditional on prime k-tuple conjecture - deep result"
+      "erdos_graham_limsup is conditional on prime k-tuple conjecture - deep result",
+      "Proved finite_set_zero_density: finite A has bounded |A∩[1,n]| while π(n)→∞, so density→0 by squeeze theorem",
+      "primeCounting unboundedness proved via Nat.exists_infinite_primes + monotonicity",
+      "Filter.liminf_le_limsup in current Mathlib requires IsBoundedUnder (bounded above) which fails for general density ratios",
+      "squeeze_zero in current Mathlib takes ∀ (not ∀ᶠ) - API change from earlier versions"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove finite_set_zero_density via: |A∩[1,n]| <= |A| (constant) and primeCounting n -> infinity (from Nat.exists_infinite_primes)"
+      "Fix liminf_implies_limsup sorry (needs IsBoundedUnder for general density ratio, may require PNT or EReal)"
     ],
     "markdown": "# Erdős #428 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a set $A\\subseteq \\mathbb{N}$ such that, for infinitely many $n$, all of $n-a$ are prime for all $a\\in A$ with $0<a<n$ and\\[\\liminf\\frac{\\lvert A\\cap [1,x]\\rvert}{\\pi(x)}>0?\\]\n\n\n\nErd\\H{o}s and Graham could show this is true (assuming the prime $k$-tuple conjecture) if we replace $\\liminf$ by $\\limsup$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #427\n- Problem #429\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },


### PR DESCRIPTION
## Summary
- **Proved `finite_set_zero_density`**: converted axiom → theorem, eliminating 1 of 2 axioms
- Added 4 supporting lemmas proving π(n) is monotone and unbounded
- Fixed 4 Mathlib API breakages in existing code (Nat.prime_iff, Set.not_mem_empty, etc.)

## Proof Strategy
For finite A with |A| = M:
1. `primeCounting` is monotone and unbounded (via `Nat.exists_infinite_primes`)
2. `primeDensityRatio A n ≤ M / π(n)` (intersection bounded by |A|)
3. `M / π(n) → 0` as `π(n) → ∞` (via `tendsto_inv_atTop_zero`)
4. Squeeze theorem → `Tendsto 0` → `liminf = 0`

## Status
- **Axioms**: 2 → 1 (only `erdos_graham_limsup` remains - deep conditional result)
- **Sorries**: 0 → 1 (`liminf_implies_limsup` - pre-existing Mathlib API breakage, needs `IsBoundedUnder` for `Filter.liminf_le_limsup`)
- **Theorems**: 7 → 12

## Files Modified
- `proofs/Proofs/Erdos428Problem.lean` - main proof changes
- `src/data/proofs/erdos-428/meta.json` - updated counts
- `src/data/research/problems/erdos-428.json` - updated knowledge

🤖 Generated by researcher-2