### PR TITLE
Peer review: hilbert-15 (B-)

### DIFF
--- a/src/data/proofs/hilbert-15/review.json
+++ b/src/data/proofs/hilbert-15/review.json
@@ -1,0 +1,129 @@
+{
+  "version": 1,
+  "proofId": "hilbert-15",
+  "reviewDate": "2026-03-24T12:30:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "B-",
+    "oneLiner": "Well-formulated linear algebra definitions with clean axiom statements for deep algebraic geometry results, but all proofs are trivial and the Schubert number constants float unconnected from the axiomatized machinery.",
+    "tier": "C",
+    "tierJustification": "Scaffold/axiomatized. The 14 definitions are genuine and use Mathlib's linear algebra properly (Grassmannian via submodule subtypes, intersection predicates, partitions). However, all 3 theorems are trivial (rfl or subtype extraction) and the 8 axioms carry all mathematical content. The Schubert numbers are hardcoded constants with no formal derivation from the axiomatized intersection theory. The quality of definitions elevates this above a mere scaffold, but no non-trivial proof exists in the file."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Lines 92-137: Grassmannian, LineInP3, SubspacesMeet, LinesMeet, LinesMeet' definitions",
+      "finding": "The Grassmannian definition (Subtype of Submodule with finrank constraint) and intersection predicates (SubspacesMeet via ⊓ ≠ ⊥, LinesMeet' via finrank < 4) are clean, mathematically correct formalizations that use Mathlib's linear algebra infrastructure genuinely. The FourLinesGeneralPosition structure with explicit disjointness fields is well-designed. These definitions would serve as real building blocks in a full algebraic geometry formalization.",
+      "recommendation": "Preserve these definitions. They demonstrate how to bridge linear algebra and projective geometry in Lean 4."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Annotations and meta.json overview",
+      "finding": "The pedagogical exposition is excellent throughout. The historical narrative (Schubert → Hilbert → Van der Waerden → Ehresmann → Schützenberger → Fulton) is accurate and well-paced. The Steiner error correction (7776 → 3264) illustrates exactly the kind of rigor Hilbert demanded. The annotation mathContext entries provide genuine mathematical depth, including the step-by-step Pieri computation σ₁² = σ₂ + σ₁₁, σ₁³ = 2σ₂₁, σ₁⁴ = 2σ₂₂.",
+      "recommendation": "Preserve this exposition — it is one of the entry's main strengths."
+    },
+    {
+      "severity": "moderate",
+      "category": "gap",
+      "location": "axiom linesMeet_iff_linesMeet', line 140-141",
+      "finding": "This axiom states that V ⊓ W ≠ ⊥ ↔ finrank (V ⊔ W) < 4 for 2-dimensional subspaces of K⁴. This should be provable from Mathlib using the dimension formula: finrank (V ⊔ W) = finrank V + finrank W - finrank (V ⊓ W). Since finrank V = finrank W = 2, the equivalence reduces to finrank (V ⊓ W) ≥ 1 ↔ 4 - finrank (V ⊓ W) < 4, which is straightforward. This is one axiom that could likely be eliminated.",
+      "recommendation": "Attempt to prove this from Mathlib's Submodule.finrank_sup_add_finrank_inf_eq or similar. Converting this from axiom to theorem would strengthen the formalization."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions item 6: 'σ₁⁴ = 2σ₂₂ computation verified via LR coefficients'",
+      "finding": "The word 'verified' implies the computation was checked by Lean. In reality, sigma1_fourth_power (line 393) is an axiom asserting the LR coefficient equals 2. The theorem four_lines_via_schubert (line 397) proves schubertNumber_FourLines = 2 by rfl, but schubertNumber_FourLines is defined as 2 on line 240. No computation occurs — the answer is assumed in two independent places (the constant definition and the axiom).",
+      "recommendation": "Change to 'σ₁⁴ = 2σ₂₂ formula axiomatized with supporting Schubert class infrastructure' or similar honest phrasing."
+    },
+    {
+      "severity": "moderate",
+      "category": "gap",
+      "location": "Lines 240-249 (Schubert number constants) vs lines 206-217 (four_lines_theorem axiom) vs line 393 (sigma1_fourth_power axiom)",
+      "finding": "Three independent assertions that the four lines answer is 2: (1) schubertNumber_FourLines := 2 (constant), (2) four_lines_theorem (axiom: ∃ exactly 2 transversals), (3) sigma1_fourth_power (axiom: LR coefficient = 2). These are not formally connected — the file does not prove that the geometric count (axiom 2) equals the Schubert computation (axiom 3) equals the constant (definition 1). The formalization would be stronger if at least one direction were proved.",
+      "recommendation": "Add a theorem (even axiomatized) stating that transversal_count follows from sigma1_fourth_power, or that the Schubert computation agrees with the geometric count. This would demonstrate the conceptual link between Parts III and VII."
+    },
+    {
+      "severity": "moderate",
+      "category": "filler",
+      "location": "four_lines_via_schubert (line 397) and hilbert_15_statement (line 435)",
+      "finding": "Both theorems prove schubertNumber_FourLines = 2 by rfl, where schubertNumber_FourLines is literally defined as 2. These are definitional equalities with zero mathematical content. Having two copies makes it worse. The name 'hilbert_15_statement' is particularly misleading — Hilbert's 15th problem asks for rigorous foundations, not the statement 2 = 2.",
+      "recommendation": "Remove the duplicate. Rename the remaining one to something like 'schubertNumber_FourLines_value' or remove it entirely (the definition already says it's 2). If keeping it, add a comment noting this is just recording the constant's value."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json relatedProofs, lines 187-189",
+      "finding": "The relatedProofs array contains three empty string entries: '', '', ''. These appear to be data entry errors.",
+      "recommendation": "Remove the empty strings from the relatedProofs array."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json assumptions field, line 48",
+      "finding": "States '8 axioms: linesMeet_iff_linesMeet', four_lines_theorem, transversal_count, and 5 more. See Lean source for complete statements.' The 'and 5 more' is unhelpful. A reader shouldn't need to go to the Lean source for the axiom list.",
+      "recommendation": "List all 8 axioms: linesMeet_iff_linesMeet', four_lines_theorem, transversal_count, schubert_basis_theorem, littlewoodRichardsonCoeff, littlewood_richardson_rule, pieris_rule, sigma1_fourth_power."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json overview.keyInsights item 5",
+      "finding": "Describes the step-by-step computation 'σ₁² = σ₂ + σ₁₁, σ₁³ = 2σ₂₁, σ₁⁴ = 2σ₂₂ reveals how Pieri's rule iteratively builds up the answer'. This intermediate computation is NOT in the Lean file — only the final result σ₁⁴ = 2σ₂₂ is axiomatized. The intermediate steps appear only in the annotation mathContext.",
+      "recommendation": "Add a qualifier: 'The step-by-step computation (described in annotations) shows how...' or formalize the intermediate steps as axioms/theorems."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "researcher",
+      "description": "Prove linesMeet_iff_linesMeet' from Mathlib's dimension formula (Submodule.finrank_sup_add_finrank_inf_eq), eliminating one axiom and adding the file's first non-trivial theorem.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix meta.json: (1) change originalContributions #6 from 'verified' to 'axiomatized', (2) list all 8 axioms in assumptions field, (3) remove empty strings from relatedProofs, (4) add qualifier to keyInsight #5 about intermediate computation.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "medium",
+      "target": "researcher",
+      "description": "Add a formal connection between four_lines_theorem (geometric count = 2), sigma1_fourth_power (LR coefficient = 2), and schubertNumber_FourLines (constant = 2). Even an axiomatized bridge theorem would improve coherence.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Remove duplicate theorem hilbert_15_statement (identical to four_lines_via_schubert). Consider whether either rfl theorem adds value beyond the constant definition.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Consider axiomatizing the intermediate Pieri computation steps (σ₁² = σ₂ + σ₁₁, σ₁³ = 2σ₂₁) to show the derivation rather than just the final result.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 5,
+    "originalityAccuracy": 7,
+    "completeness": 6,
+    "framingPrecision": 7,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 7,
+    "overall": 6.7
+  },
+
+  "suggestedBestFraming": "An axiomatized formalization of Schubert calculus on Grassmannians in Lean 4, with clean linear-algebraic definitions of the Grassmannian Gr(k,n), lines in P³, and Schubert classes, and well-stated axioms for the Four Lines Theorem, Schubert basis theorem, and Littlewood-Richardson rule — the algebraic geometry results await Mathlib infrastructure."
+}


### PR DESCRIPTION
Peer review of hilbert-15 (Hilbert's 15th Problem: Schubert Calculus). Grade: B-. 9 findings, 5 action items.

## Key Findings

**Strengths**: Clean Grassmannian definition via Mathlib's Submodule/finrank. Well-designed intersection predicates and partition structures. Excellent historical exposition covering Schubert through Fulton.

**Issues**: All 3 theorems are trivial (rfl or subtype extraction). 8 axioms carry all mathematical weight. linesMeet_iff_linesMeet' is likely provable from Mathlib. Schubert number constants (2, 27, 3264) are hardcoded with no formal connection to axiomatized intersection theory. "σ₁⁴ = 2σ₂₂ verified" overclaims — it's axiomatized, not computed.

## Scores
- Mathematical Substance: 5/10
- Originality Accuracy: 7/10
- Completeness: 6/10
- Framing Precision: 7/10
- Pedagogical Quality: 8/10
- Internal Consistency: 7/10

## Top Action Items
1. Prove linesMeet_iff_linesMeet' from Mathlib (dimension formula)
2. Fix meta.json overclaims and missing axiom list
3. Connect Schubert constants to axiomatized machinery