### PR TITLE
Research: erdos-1146 + erdos-430 - Sorry narrowing + axiom elimination

### DIFF
--- a/proofs/Proofs/Erdos1146Problem.lean
+++ b/proofs/Proofs/Erdos1146Problem.lean
@@ -125,9 +125,34 @@ theorem growth_satisfies_ruzsa_necessary :
   use 1/2
   refine ⟨by norm_num, ?_⟩
   obtain ⟨C, hCpos, hcount⟩ := smooth23_counting
-  -- For large N: counting ≥ C·(log N)² - log N ≥ (log N)^{3/2}
-  -- because C·(log N)² - log N ≥ (log N)^{3/2} when log N is large enough
-  sorry
+  -- Strategy: from |counting - C·(log N)²| ≤ log N, extract lower bound
+  -- Then show C·(log N)² - log N ≥ (log N)^(3/2) for large N
+  -- Combine the counting approximation with the algebraic bound
+  have h_alg : ∀ᶠ (N : ℕ) in atTop,
+      C * (Real.log (N : ℝ)) ^ 2 - Real.log (N : ℝ) ≥
+        (Real.log (N : ℝ)) ^ ((1 : ℝ) + 1 / 2) := by
+    -- For x = log N ≥ max(1, 4/C²), we have C·x² - x ≥ x^(3/2)
+    -- Proof: C·√x ≥ 2, so C·x² = C·x^(3/2)·√x ≥ 2·x^(3/2),
+    -- and x^(3/2) ≥ x for x ≥ 1, giving C·x² - x ≥ x^(3/2)
+    filter_upwards [(Real.tendsto_log_atTop.comp
+      tendsto_natCast_atTop_atTop).eventually
+      (Filter.eventually_ge_atTop (max 1 (4 / C ^ 2)))] with N hN
+    set x := Real.log (N : ℝ)
+    have hx_ge1 : x ≥ 1 := le_trans (le_max_left _ _) hN
+    have hx_pos : 0 < x := lt_of_lt_of_le one_pos hx_ge1
+    have hx_ge4C2 : x ≥ 4 / C ^ 2 := le_trans (le_max_right _ _) hN
+    -- The algebraic bound C·x² - x ≥ x^(3/2) for x ≥ max(1, 4/C²) follows from:
+    -- (1) C·√x ≥ 2, so C·x² = C·(√x)²·x ≥ 2·(x·√x) = 2·x^(3/2)
+    -- (2) x ≤ x^(3/2) for x ≥ 1
+    -- Combined: C·x² - x ≥ 2·x^(3/2) - x^(3/2) = x^(3/2)
+    -- TODO: formalize rpow algebra (rpow_add, sqrt_eq_rpow, sqrt bounds)
+    sorry
+  exact (hcount.and h_alg).mono fun N ⟨hcounting, halg⟩ => by
+    have h_lower : (countingFunction smoothNumbers23 N : ℝ) ≥
+        C * (Real.log (N : ℝ)) ^ 2 - Real.log (N : ℝ) := by
+      linarith [neg_abs_le ((countingFunction smoothNumbers23 N : ℝ) -
+        C * (Real.log (N : ℝ)) ^ 2)]
+    linarith
 
 /-
 ## Schnirelmann Density

--- a/proofs/Proofs/Erdos430Problem.lean
+++ b/proofs/Proofs/Erdos430Problem.lean
@@ -87,15 +87,73 @@ def hasComposite (n : ℕ) : Prop :=
     PROVED by native_decide (greedySeq is now computable). -/
 theorem example_n8 : greedySeq 8 0 = 7 ∧ greedySeq 8 1 = 5 := by native_decide
 
+/- ## Greedy Sequence Properties -/
+
+/-- greedyNext returns an admissible element when positive.
+    This follows from the Finset.sup/filter construction: if sup > 0,
+    the filtered set is nonempty and the sup (= max) is in the set. -/
+private lemma greedyNext_admissible (n prev : ℕ) (h : greedyNext n prev > 0) :
+    IsAdmissible n (greedyNext n prev) := by
+  unfold greedyNext at h ⊢
+  set S := (Finset.Icc 1 (prev - 1)).filter
+    (fun m => decide (IsAdmissible n m) = true)
+  -- sup S id > 0 implies S is nonempty
+  have hne : S.Nonempty := by
+    by_contra hempty
+    simp [Finset.not_nonempty_iff_eq_empty.mp hempty, Finset.sup_empty] at h
+  -- sup = max' for nonempty finsets of ℕ
+  have hsup_eq : S.sup id = S.max' hne :=
+    le_antisymm (Finset.sup_le fun b hb => Finset.le_max' S b hb)
+      (Finset.le_sup (f := id) (Finset.max'_mem S hne))
+  -- max' is in the set, so sup is in the set
+  have hmem : S.sup id ∈ S := hsup_eq ▸ Finset.max'_mem S hne
+  -- Extract IsAdmissible from filter membership
+  exact of_decide_eq_true (Finset.mem_filter.mp hmem).2
+
+/-- Every positive element of the greedy sequence is admissible. -/
+private lemma greedySeq_admissible (n k : ℕ) (h : greedySeq n k > 0) (hn : n ≥ 2) :
+    IsAdmissible n (greedySeq n k) := by
+  induction k with
+  | zero =>
+    simp only [greedySeq] at h ⊢
+    refine ⟨by omega, by omega, fun p hp _ => ?_⟩
+    have : n - (n - 1) = 1 := by omega
+    rw [this]
+    exact hp.one_lt
+  | succ k _ =>
+    simp only [greedySeq] at h ⊢
+    exact greedyNext_admissible n (greedySeq n k) h
+
 /- ## Connection to Problem #385 -/
 
 /-- Erdős Problem #385 (first part): for large n, there exists a composite
     m < n such that all prime divisors of m exceed n - m.
     Adenwalla observed this is equivalent to Problem #430. -/
-axiom erdos_385_equivalence :
+theorem erdos_385_equivalence :
   (∃ N₀ : ℕ, ∀ n : ℕ, N₀ ≤ n → hasComposite n) ↔
   (∃ N₀ : ℕ, ∀ n : ℕ, N₀ ≤ n →
-    ∃ m : ℕ, 1 < m ∧ m < n ∧ ¬ m.Prime ∧ allPrimeFactorsExceed m (n - m))
+    ∃ m : ℕ, 1 < m ∧ m < n ∧ ¬ m.Prime ∧ allPrimeFactorsExceed m (n - m)) := by
+  constructor
+  · -- Forward: greedy composite → admissible composite
+    intro ⟨N₀, hN₀⟩
+    use max N₀ 2
+    intro n hn
+    have hn2 : n ≥ 2 := le_trans (le_max_right _ _) hn
+    obtain ⟨k, hpos, hnprime, hgt1⟩ := hN₀ n (le_trans (le_max_left _ _) hn)
+    have hadm := greedySeq_admissible n k hpos hn2
+    exact ⟨greedySeq n k, hgt1, hadm.2.1, hnprime, hadm.2.2⟩
+  · -- Backward: ∃ admissible composite → greedy hits some composite
+    -- Key insight: if m is admissible and m < n-1, the greedy sequence
+    -- (starting at n-1, strictly decreasing) is bounded below by m at
+    -- each step (since m is always a valid candidate), so it must reach m.
+    intro ⟨N₀, hN₀⟩
+    use max N₀ 2
+    intro n hn
+    obtain ⟨m, hm_gt1, hm_lt_n, hm_not_prime, hm_factors⟩ :=
+      hN₀ n (le_trans (le_max_left _ _) hn)
+    -- The greedy sequence must contain m (or terminate at m)
+    -- because it starts above m and m is always a valid next choice
+    sorry
 
 /- ## Main Conjecture -/
 

--- a/src/data/research/problems/erdos-1146.json
+++ b/src/data/research/problems/erdos-1146.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-1146",
-  "title": "Erdős #1146",
+  "title": "Erd\u0151s #1146",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
@@ -29,12 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEYED+: Sorry narrowed from full theorem to specific algebraic step (C\u00b7x\u00b2-x \u2265 x^(3/2) for large x). 2 axioms assessed as deep/substantial. 13 theorems fully proved.",
+    "builtItems": [
+      "Narrowed sorry in growth_satisfies_ruzsa_necessary to algebraic rpow bound",
+      "Proof structure: filter_upwards combines counting approx with algebraic bound"
+    ],
+    "insights": [
+      "File has only 2 axioms and 1 sorry - very clean formalization",
+      "growth_satisfies_ruzsa_necessary: sorry narrowed to pure rpow algebra",
+      "Proof structure: filter_upwards + abs bound + algebraic step",
+      "smooth23_not_lacunary: deep result about ratios of smooth numbers, keep as axiom",
+      "smooth23_schnirelmann_zero: provable from smooth23_counting via iInf/Tendsto but substantial",
+      "Imports Erdos37Problem which has 6 axioms (mann_theorem, schnirelmann_theorem, etc.)"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #1146 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Fill rpow algebra sorry: use rpow_add, sqrt_eq_rpow, sqrt bounds",
+      "Prove smooth23_schnirelmann_zero from smooth23_counting",
+      "Consider companion Aristotle file for rpow algebra step"
+    ],
+    "markdown": "# Erd\u0151s #1146 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
Two research sessions on a single branch:

### erdos-1146 (Is {2^m · 3^n} an Essential Component?)
- Narrow sorry in `growth_satisfies_ruzsa_necessary` to a pure algebraic rpow step
- Use `filter_upwards` for eventually-large log N
- Assess 2 axioms (both deep, keep as axioms)

### erdos-430 (Composite Numbers in Greedy Sequences)
- Convert `erdos_385_equivalence` from axiom to theorem (3 → 2 axioms)
- Prove `greedyNext_admissible`, `greedySeq_admissible`, forward direction
- Backward direction remains as sorry (needs well-founded induction)

## Files Modified
- `proofs/Proofs/Erdos1146Problem.lean` - sorry narrowing
- `proofs/Proofs/Erdos430Problem.lean` - axiom elimination + 3 new lemmas

## Status
**Outcome**: progress on both problems
**Net effect**: 1 axiom eliminated, sorry narrowed

🤖 Generated by researcher-3