### PR TITLE
Research: erdos-409 - Prove 3 axioms (7 sorries remaining)

### DIFF
--- a/proofs/Proofs/Erdos409Problem.lean
+++ b/proofs/Proofs/Erdos409Problem.lean
@@ -45,16 +45,90 @@ noncomputable def iterationsToFirst (n : ℕ) : ℕ :=
 
 /- ## Termination -/
 
-/-- The iteration always terminates: for any n > 0, some iterate is prime.
-    This follows because φ(n) < n for n > 1, so φ(n)+1 ≤ n,
-    and the sequence is eventually decreasing until hitting a prime. -/
-axiom iteration_terminates :
-  ∀ n : ℕ, n > 0 → ∃ k : ℕ, (totientIterate n k).Prime
+/-- The iterate is eventually decreasing: φ(n) + 1 < n for composite n > 1.
+    Proved via Finset reasoning: for composite n, both 0 and n.minFac are
+    in range(n) but not coprime to n, so φ(n) ≤ n − 2. -/
+theorem iterate_decreasing :
+    ∀ n : ℕ, n > 1 → ¬n.Prime → totientPlusOne n < n := by
+  intro n hn hnp
+  unfold totientPlusOne
+  -- Suffices: n.totient + 2 ≤ n (then n.totient + 1 < n follows)
+  suffices h : n.totient + 2 ≤ n by omega
+  -- Setup: minFac properties for composite n
+  have hne1 : n ≠ 1 := by omega
+  have hmf_prime := Nat.minFac_prime hne1
+  have hmf_dvd := Nat.minFac_dvd n
+  have hmf_ge2 : 2 ≤ n.minFac := hmf_prime.two_le
+  have hmf_lt : n.minFac < n := by
+    by_contra hc; push_neg at hc
+    have := Nat.le_of_dvd (by omega) hmf_dvd
+    exact hnp ((show n.minFac = n by omega) ▸ hmf_prime)
+  -- Both 0 and minFac are not coprime to n
+  have h0_not_cop : ¬ n.Coprime 0 := by
+    rw [Nat.Coprime, Nat.gcd_zero_right]; omega
+  have hmf_not_cop : ¬ n.Coprime n.minFac := by
+    rw [Nat.Coprime]; intro hg
+    have : n.minFac ∣ Nat.gcd n n.minFac := Nat.dvd_gcd hmf_dvd dvd_rfl
+    rw [hg] at this; exact absurd (Nat.le_of_dvd one_pos this) (by omega)
+  -- Use Finset reasoning: φ(n) = card of coprime filter on range n
+  have h0_in : (0 : ℕ) ∈ Finset.range n := Finset.mem_range.mpr (by omega)
+  have hmf_in : n.minFac ∈ Finset.range n := Finset.mem_range.mpr hmf_lt
+  have h0_not_F : (0 : ℕ) ∉ (Finset.range n).filter n.Coprime := by
+    intro hm; exact h0_not_cop (Finset.mem_filter.mp hm).2
+  have hmf_not_F : n.minFac ∉ (Finset.range n).filter n.Coprime := by
+    intro hm; exact hmf_not_cop (Finset.mem_filter.mp hm).2
+  -- Both 0 and minFac are in the sdiff (in range but not coprime)
+  have h0_sd : (0 : ℕ) ∈ (Finset.range n) \ (Finset.range n).filter n.Coprime :=
+    Finset.mem_sdiff.mpr ⟨h0_in, h0_not_F⟩
+  have hmf_sd : n.minFac ∈ (Finset.range n) \ (Finset.range n).filter n.Coprime :=
+    Finset.mem_sdiff.mpr ⟨hmf_in, hmf_not_F⟩
+  -- The pair {0, minFac} is a subset of the sdiff, with card = 2
+  have hpair_sub : ({0, n.minFac} : Finset ℕ) ⊆
+      (Finset.range n) \ (Finset.range n).filter n.Coprime := by
+    intro x hx; rcases Finset.mem_insert.mp hx with rfl | hx
+    · exact h0_sd
+    · exact Finset.mem_singleton.mp hx ▸ hmf_sd
+  have hpair_card : ({0, n.minFac} : Finset ℕ).card = 2 :=
+    Finset.card_pair (by omega : (0 : ℕ) ≠ n.minFac)
+  have hsdiff_ge2 : 2 ≤ ((Finset.range n) \ (Finset.range n).filter n.Coprime).card :=
+    hpair_card ▸ Finset.card_le_card hpair_sub
+  -- card(filter) + card(sdiff) = card(range n) = n
+  have hfilt_sub := Finset.filter_subset (n.Coprime) (Finset.range n)
+  have hsum := Finset.card_sdiff_add_card_eq_card hfilt_sub
+  rw [Finset.card_range] at hsum
+  -- Connect φ(n) to filter cardinality
+  have htot : n.totient = ((Finset.range n).filter n.Coprime).card := rfl
+  omega
 
-/-- The iterate is eventually decreasing: φ(n) + 1 ≤ n for n > 1,
-    with equality only when n is prime (φ(p) + 1 = p). -/
-axiom iterate_decreasing :
-  ∀ n : ℕ, n > 1 → ¬n.Prime → totientPlusOne n < n
+/-- The iteration always terminates: for any n > 0, some iterate is prime.
+    Proved by strong induction on n using iterate_decreasing:
+    primes are already prime (k=0), n=1 maps to 2 (k=1),
+    and composites decrease strictly. -/
+theorem iteration_terminates :
+    ∀ n : ℕ, n > 0 → ∃ k : ℕ, (totientIterate n k).Prime := by
+  intro n
+  induction n using Nat.strongRecOn with
+  | _ n ih =>
+    intro hn
+    by_cases hp : n.Prime
+    · -- n is already prime: k = 0
+      exact ⟨0, hp⟩
+    · -- n is not prime
+      by_cases hn1 : n = 1
+      · -- n = 1: φ(1) + 1 = 2, which is prime
+        exact ⟨1, by subst hn1; native_decide⟩
+      · -- n > 1 and composite: use iterate_decreasing
+        have hn1' : n > 1 := by omega
+        have hdec := iterate_decreasing n hn1' hp
+        -- totientPlusOne n > 0 (since φ(n) ≥ 0)
+        have hpos : totientPlusOne n > 0 := by unfold totientPlusOne; omega
+        -- By induction: some iterate of (totientPlusOne n) reaches a prime
+        obtain ⟨k, hk⟩ := ih (totientPlusOne n) hdec hpos
+        -- Then k+1 works for n: iterate(n, k+1) = iterate(φ(n)+1, k)
+        refine ⟨k + 1, ?_⟩
+        unfold totientIterate
+        rw [Function.iterate_succ, Function.comp_apply]
+        exact hk
 
 /- ## Main Questions -/
 
@@ -92,9 +166,12 @@ axiom one_iteration_criterion :
 
 /-- φ(n) + 1 is odd for n ≥ 3 (since φ(n) is even for n ≥ 3).
     So φ(n) + 1 is odd, making it a candidate for primality.
-    Previously axiomatized; now proved from Nat.Even.totient. -/
-axiom totient_plus_one_odd :
-  ∀ n : ℕ, n ≥ 3 → Odd (totientPlusOne n)
+    Proved from Nat.totient_even and Even.add_one. -/
+theorem totient_plus_one_odd :
+    ∀ n : ℕ, n ≥ 3 → Odd (totientPlusOne n) := by
+  intro n hn
+  unfold totientPlusOne
+  exact (Nat.totient_even (by omega : 2 < n)).add_one
 
 /- ## Sigma Variant -/
 

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 409,
     "erdosUrl": "https://erdosproblems.com/409",
     "erdosProblemStatus": "open",
-    "axiomCount": 12,
-    "assumptions": "12 axiom declarations: iteration_terminates (orbit reaches a prime), iterate_decreasing (strict decrease on composites), erdos_409_upper_bound (F(n) = o(n) bound), erdos_409_same_prime (infinite basin existence), erdos_409_density (basin natural density), prime_zero_iterations (F(p) = 0 for primes), one_iteration_criterion (F(n) = 1 condition), totient_plus_one_odd (parity of phi+1), sigma_variant_question (sigma variant termination), sigma_growing (sigma non-decreasing), four_to_three (phi(4)+1 = 3), one_iteration_infinite (infinitely many F=1)",
-    "lineCount": 128,
+    "axiomCount": 7,
+    "assumptions": "7 axiom declarations: erdos_409_upper_bound (F(n) = o(n) bound), erdos_409_same_prime (infinite basin existence), erdos_409_density (basin natural density), prime_zero_iterations (F(p) = 0 for primes), one_iteration_criterion (F(n) = 1 condition), sigma_growing (sigma non-decreasing), one_iteration_infinite (infinitely many F=1). Proved: iterate_decreasing (Finset-based), iteration_terminates (strong induction), totient_plus_one_odd (from Nat.totient_even).",
+    "lineCount": 205,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -62,8 +62,8 @@
       "id": "termination",
       "title": "Termination and Descent",
       "startLine": 47,
-      "endLine": 59,
-      "summary": "Proves (axiomatically) that every orbit reaches a prime: $\\forall n > 0,\\; \\exists k,\\; T^k(n)$ is prime. The key lemma is strict decrease $T(n) < n$ for composite $n > 1$, giving descent on $\\mathbb{N}$."
+      "endLine": 135,
+      "summary": "Proves that every orbit reaches a prime: $\\forall n > 0,\\; \\exists k,\\; T^k(n)$ is prime. The key lemma `iterate_decreasing` shows $T(n) < n$ for composite $n > 1$ via Finset reasoning (0 and minFac are non-coprime elements in range $n$, giving $\\varphi(n) \\leq n - 2$). Termination follows by strong induction on $n$."
     },
     {
       "id": "part-i",
@@ -123,7 +123,6 @@
       "Mathlib.Data.Nat.Totient",
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Order.Filter.Basic",
-      "Mathlib.Order.Filter.AtTopBot",
       "Mathlib.Tactic"
     ],
     "opens": [
@@ -131,9 +130,9 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 127,
-    "axiomCount": 12,
-    "theoremCount": 1,
+    "lineCount": 205,
+    "axiomCount": 7,
+    "theoremCount": 6,
     "definitionCount": 3
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-409.json
+++ b/src/data/research/problems/erdos-409.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-409",
-  "title": "Erdős #409",
+  "title": "Erd\u0151s #409",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -29,29 +29,35 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 2 axioms (sigma_variant_question, four_to_three). Fixed pre-existing build failures: stale import, two_fixed_point proof, sigma_growing syntax. Axioms: 12->10.",
+    "progressSummary": "PROGRESS: Proved 3 more axioms (iterate_decreasing, iteration_terminates, totient_plus_one_odd). Axioms: 10->7. Total 5 axioms eliminated across sessions (12->7).",
     "builtItems": [
       "Proved sigma_variant_question (was trivially True placeholder)",
       "Proved four_to_three via native_decide",
       "Fixed two_fixed_point proof (simp->native_decide)",
       "Fixed sigma_growing syntax (Finset pipeline operator)",
-      "Removed stale import Mathlib.Order.Filter.AtTopBot"
+      "Removed stale import Mathlib.Order.Filter.AtTopBot",
+      "Proved iterate_decreasing via Finset reasoning (0 and minFac non-coprime)",
+      "Proved iteration_terminates via strong induction on iterate_decreasing",
+      "Proved totient_plus_one_odd from Nat.totient_even + Even.add_one"
     ],
     "insights": [
       "sigma_variant_question was a trivially True placeholder axiom",
       "four_to_three is a computation: phi(4)+1 = 2+1 = 3, proved by native_decide",
       "iterate_decreasing needs Nat.totient = n-1 iff prime (converse direction) - exact Mathlib lemma name unclear",
       "totient_plus_one_odd needs Nat.totient_even which may have different API in this Mathlib version",
-      "Nat.totient simp lemma does not fully reduce for n=2 in Mathlib v4.26.0 - use native_decide instead"
+      "Nat.totient simp lemma does not fully reduce for n=2 in Mathlib v4.26.0 - use native_decide instead",
+      "Nat.totient_lt gives phi(n) < n for n > 1 (strict bound exists in Mathlib)",
+      "Finset.card_pair + card_le_card pattern proves set has >= 2 elements",
+      "Function.iterate_succ (not iterate_succ!) gives f^[k+1] n = f^[k] (f n)",
+      "Nat.minFac_prime + minFac_dvd key for composite characterization"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove iterate_decreasing: need to find Mathlib name for totient(n)=n-1 implies prime",
-      "Prove totient_plus_one_odd: need correct Even totient lemma name",
-      "Prove iteration_terminates: well-founded induction using iterate_decreasing",
-      "Remaining deep axioms: erdos_409_upper_bound, erdos_409_same_prime, erdos_409_density, one_iteration_infinite"
+      "Prove prime_zero_iterations and one_iteration_criterion (depend on sSup definition of iterationsToFirst)",
+      "Prove sigma_growing (needs Finset.divisors API)",
+      "Deep axioms (erdos_409_upper_bound, erdos_409_same_prime, erdos_409_density, one_iteration_infinite) are genuinely open"
     ],
-    "markdown": "# Erdős #409 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nHow many iterations of $n\\mapsto \\phi(n)+1$ are needed before a prime is reached? Can infinitely many $n$ reach the same prime? What is the density of $n$ which reach any fixed prime?\n\n\n\nA problem of Finucane. One can also ask similar questions about $n\\mapsto \\sigma(n)-1$: do iterates of this always reach a prime? If so, how soon? (It is easily seen that iterates of this cannot reach the same prime infinitely often, since they are non-decreasing.)\n\nThis problem is somewhat ambiguously phrased. Let $F(n)$ count the number of iterations of $n\\mapsto \\phi(n)+1$ before reaching a prime. The number of iterations required is A039651 in the OEIS.\n\nCambie notes in the comments that $F(n)=o(n)$ is trivial, and $F(n)=1$ infinitely often. Presumably the intended question is to find 'good' upper bounds for $F(n)$.\n\nThis is discussed in problem B41 of Guy's collection \\cite{Gu04}.\n\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #408\n- Problem #410\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erd\u0151s #409 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nHow many iterations of $n\\mapsto \\phi(n)+1$ are needed before a prime is reached? Can infinitely many $n$ reach the same prime? What is the density of $n$ which reach any fixed prime?\n\n\n\nA problem of Finucane. One can also ask similar questions about $n\\mapsto \\sigma(n)-1$: do iterates of this always reach a prime? If so, how soon? (It is easily seen that iterates of this cannot reach the same prime infinitely often, since they are non-decreasing.)\n\nThis problem is somewhat ambiguously phrased. Let $F(n)$ count the number of iterations of $n\\mapsto \\phi(n)+1$ before reaching a prime. The number of iterations required is A039651 in the OEIS.\n\nCambie notes in the comments that $F(n)=o(n)$ is trivial, and $F(n)=1$ infinitely often. Presumably the intended question is to find 'good' upper bounds for $F(n)$.\n\nThis is discussed in problem B41 of Guy's collection \\cite{Gu04}.\n\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #408\n- Problem #410\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"
@@ -74,9 +80,9 @@
     {
       "path": "Proofs/Erdos409Problem.lean",
       "filename": "Erdos409Problem.lean",
-      "lineCount": 128,
-      "theoremCount": 1,
-      "axiomCount": 12,
+      "lineCount": 205,
+      "theoremCount": 6,
+      "axiomCount": 7,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Prove `iterate_decreasing` via Finset reasoning: for composite n > 1, both 0 and n.minFac are in range(n) but not coprime to n, giving φ(n) ≤ n − 2
- Prove `iteration_terminates` by strong induction using iterate_decreasing
- Prove `totient_plus_one_odd` from `Nat.totient_even` + `Even.add_one`
- Axioms reduced: 10 → 7

## Key Technique
The `iterate_decreasing` proof introduces a novel Finset-based argument: for any composite n > 1, both 0 and n.minFac are elements of `Finset.range n` that fail the `Nat.Coprime n` predicate. Since `{0, n.minFac}` has 2 distinct elements (minFac ≥ 2 > 0), the coprime filter on `range n` excludes at least 2 elements, giving φ(n) ≤ n − 2.

## Remaining Axioms (7)
- `erdos_409_upper_bound` — F(n) = o(n) bound (open conjecture)
- `erdos_409_same_prime` — infinite basin existence (open)
- `erdos_409_density` — basin natural density (open)
- `prime_zero_iterations` — F(p) = 0 (depends on sSup definition)
- `one_iteration_criterion` — F(n) = 1 condition (depends on sSup)
- `sigma_growing` — σ(n) − 1 ≥ n for composites
- `one_iteration_infinite` — infinitely many F=1 (deep result)

## Test Plan
- [x] Docker build passes: `Proofs.Erdos409Problem` builds in 2.1s
- [x] No sorries in proved theorems
- [x] meta.json updated with correct axiom count (7)

🤖 Generated by researcher-6