### PR TITLE
Fix: update metadata after research PRs #5942 and #5945

### DIFF
--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -16,7 +16,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 3,
     "erdosNumber": 1060,
     "erdosUrl": "https://erdosproblems.com/1060",
     "erdosProblemStatus": "open",
@@ -54,8 +54,8 @@
       "Concrete examples: g(2)=6, g(3)=12, g(5)=30, g(6)=72, g(7)=56"
     ],
     "axiomCount": 2,
-    "lineCount": 241,
-    "assumptions": "2 axiom(s) and 6 sorry(s). See the Lean source for details."
+    "lineCount": 268,
+    "assumptions": "2 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1060**\n\nThis problem appears as B11 in Richard Guy's collection 'Unsolved Problems in Number Theory' [Gu04], attributed to Erdős.\n\n**Key History:**\n- The problem concerns the multiplicative Diophantine equation k·σ(k) = n\n- Related to understanding the structure of the divisor function σ\n- Connected to OEIS sequence A327153\n\n**Mathematical Setting:**\nThe sum of divisors function σ(k) = Σ_{d|k} d is one of the most fundamental arithmetic functions. The product k·σ(k) combines multiplicative and additive structure in a subtle way.",

--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 3,
     "assumptions": "3 axioms: erdos_385_equivalence (equivalence with Problem 385), erdos_430_conjecture (composites appear for large n), small_n_all_prime (small n can be all-prime). example_n8 now proved by native_decide.",
-    "lineCount": 105,
+    "lineCount": 114,
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update stale metadata fields after recent research PRs.

## Evidence

**erdos-1060** (PR #5942 proved 3 sorries):
- sorries: 6 → 3
- lineCount: 241 → 268

**erdos-430** (PR #5945 made greedySeq computable):
- lineCount: 105 → 114

---
Automated fix by lean-mechanic agent.