### PR TITLE
Research: erdos-1035 - Prove all 3 axioms (0 sorries remaining)

### DIFF
--- a/proofs/Proofs/Erdos1035Problem.lean
+++ b/proofs/Proofs/Erdos1035Problem.lean
@@ -84,16 +84,28 @@ def ErdosProblem1035_alt2 : Prop :=
 
 /- ## Basic properties -/
 
-/-- The hypercube `Q_n` is a subgraph of itself. -/
-axiom hypercube_self_subgraph (n : ℕ) :
-    ContainsAsSubgraph (hypercubeGraph n) (hypercubeGraph n)
+/-- The hypercube `Q_n` is a subgraph of itself (via the identity embedding). -/
+theorem hypercube_self_subgraph (n : ℕ) :
+    ContainsAsSubgraph (hypercubeGraph n) (hypercubeGraph n) :=
+  ⟨id, Function.injective_id, fun _ _ h => h⟩
 
-/-- The complete graph on `2^n` vertices contains `Q_n`. -/
-axiom complete_contains_hypercube (n : ℕ) :
+/-- The complete graph on `2^n` vertices contains `Q_n` (via the identity map,
+    since every non-diagonal pair is adjacent in a complete graph). -/
+theorem complete_contains_hypercube (n : ℕ) :
     ∀ (G : SimpleGraph (Fin (2 ^ n))),
       (∀ u v : Fin (2 ^ n), u ≠ v → G.Adj u v) →
-        ContainsAsSubgraph G (hypercubeGraph n)
+        ContainsAsSubgraph G (hypercubeGraph n) := by
+  intro G hG
+  exact ⟨id, Function.injective_id, fun u v huv => hG u v huv.1⟩
 
-/-- `Q_1` is the single edge graph on 2 vertices. -/
-axiom hypercube_one_is_edge :
-    ∀ u v : Fin (2 ^ 1), (hypercubeGraph 1).Adj u v ↔ u ≠ v
+/-- `Q_1` is the complete graph on `Fin 2`: two vertices are adjacent iff distinct.
+    Proved by case analysis on `Fin 2`. -/
+theorem hypercube_one_is_edge :
+    ∀ u v : Fin (2 ^ 1), (hypercubeGraph 1).Adj u v ↔ u ≠ v := by
+  intro u v
+  constructor
+  · exact fun h => h.1
+  · intro hne
+    refine ⟨hne, ⟨0, by omega⟩, ?_⟩
+    simp [Pow.pow]
+    fin_cases u <;> fin_cases v <;> simp_all

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1035",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1035Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "extremal-graph-theory",
       "minimum-degree"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 1035,
     "erdosUrl": "https://erdosproblems.com/1035",
@@ -27,9 +27,9 @@
       "Graph density and extremal graph theory",
       "Turán-type bounds"
     ],
-    "axiomCount": 3,
-    "lineCount": 99,
-    "assumptions": "3 axiom(s): hypercube_self_subgraph, complete_contains_hypercube, hypercube_one_is_edge. See Lean source for complete statements.",
+    "axiomCount": 0,
+    "lineCount": 106,
+    "assumptions": "None. All auxiliary theorems proved: hypercube_self_subgraph (identity embedding), complete_contains_hypercube (identity on complete graph), hypercube_one_is_edge (case analysis on Fin 2). Main conjecture stated as Prop definition (open problem).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -220,9 +220,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 99,
-    "axiomCount": 3,
-    "theoremCount": 0,
+    "lineCount": 106,
+    "axiomCount": 0,
+    "theoremCount": 3,
     "definitionCount": 7
   }
 }

--- a/src/data/research/problems/erdos-1035.json
+++ b/src/data/research/problems/erdos-1035.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-1035",
-  "title": "Erdős #1035",
+  "title": "Erd\u0151s #1035",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -29,12 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved all 3 axioms. File is now axiom-free (verified). hypercube_self_subgraph via identity, complete_contains_hypercube via identity + adj condition, hypercube_one_is_edge via fin_cases.",
+    "builtItems": [
+      "Proved hypercube_self_subgraph via identity embedding",
+      "Proved complete_contains_hypercube via identity + adjacency condition",
+      "Proved hypercube_one_is_edge via fin_cases on Fin 2"
+    ],
+    "insights": [
+      "ContainsAsSubgraph with id embedding trivially proves self-containment",
+      "For complete graphs, adjacency of H implies adjacency in G since all distinct pairs are adjacent",
+      "fin_cases tactic handles Fin 2 exhaustively for Q_1 characterization",
+      "XOR adjacency definition works cleanly with native_decide/simp for small cases"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #1035 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a constant $c>0$ such that every graph on $2^n$ vertices with minimum degree $>(1-c)2^n$ contains the $n$-dimensional hypercube $Q_n$?\n\n\n\nErd\\H{o}s \\cite{Er93} says 'if the conjecture is false, two related problems could be asked':\n{UL}\n{LI}Determine or estimate the smallest $m>2^n$ such that every graph on $m$ vertices with minimum degree $>(1-c)2^n$ contains a $Q_n$, and {/LI}\n{LI}For which $u_n$ is it true that every graph on $2^n$ vertices with minimum degree $>2^n-u_n$ contains a $Q_n$.{/LI}\n{/UL}\n\nSee also [576] for the extremal number of edges that guarantee a $Q_n$.\n\n\n\n\nReferences\n\n\n[Er93] Erd\\H{o}s, Paul, Some of my favorite solved and unsolved problems in graph\ntheory. Quaestiones Math. (1993), 333-350.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #576\n- Problem #1034\n- Problem #1036\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #6\n\n## References\n\n- Er93\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Main conjecture ErdosProblem1035 is genuinely open - no further axiom elimination possible",
+      "Could add more small-case verifications (Q_2, Q_3) as native_decide theorems"
+    ],
+    "markdown": "# Erd\u0151s #1035 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a constant $c>0$ such that every graph on $2^n$ vertices with minimum degree $>(1-c)2^n$ contains the $n$-dimensional hypercube $Q_n$?\n\n\n\nErd\\H{o}s \\cite{Er93} says 'if the conjecture is false, two related problems could be asked':\n{UL}\n{LI}Determine or estimate the smallest $m>2^n$ such that every graph on $m$ vertices with minimum degree $>(1-c)2^n$ contains a $Q_n$, and {/LI}\n{LI}For which $u_n$ is it true that every graph on $2^n$ vertices with minimum degree $>2^n-u_n$ contains a $Q_n$.{/LI}\n{/UL}\n\nSee also [576] for the extremal number of edges that guarantee a $Q_n$.\n\n\n\n\nReferences\n\n\n[Er93] Erd\\H{o}s, Paul, Some of my favorite solved and unsolved problems in graph\ntheory. Quaestiones Math. (1993), 333-350.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #576\n- Problem #1034\n- Problem #1036\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #6\n\n## References\n\n- Er93\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -58,9 +70,9 @@
     {
       "path": "Proofs/Erdos1035Problem.lean",
       "filename": "Erdos1035Problem.lean",
-      "lineCount": 100,
-      "theoremCount": 0,
-      "axiomCount": 3,
+      "lineCount": 106,
+      "theoremCount": 3,
+      "axiomCount": 0,
       "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Prove `hypercube_self_subgraph` via identity embedding (trivial: `⟨id, injective_id, fun _ _ h => h⟩`)
- Prove `complete_contains_hypercube` via identity map + adjacency condition
- Prove `hypercube_one_is_edge` via `fin_cases` on `Fin 2`
- File is now **axiom-free**: status upgraded from axiomatized to verified

## Axiom Count
**Before**: 3 axioms
**After**: 0 axioms, 3 theorems

## Test Plan
- [x] Docker build passes: `Proofs.Erdos1035Problem` builds successfully
- [x] No sorries, no axioms
- [x] meta.json updated (status: verified, axiomCount: 0)

🤖 Generated by researcher-6