### PR TITLE
Fix: stale leanFile.lineCount in 9 Erdős proofs

### DIFF
--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -139,7 +139,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 104,
+    "lineCount": 134,
     "axiomCount": 14,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -206,7 +206,7 @@
       "Set"
     ],
     "namespace": "Erdos1149",
-    "lineCount": 218,
+    "lineCount": 320,
     "axiomCount": 2,
     "sorryCount": 0,
     "theoremCount": 16,

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -168,7 +168,7 @@
       "Classical"
     ],
     "namespace": "Erdos183",
-    "lineCount": 241,
+    "lineCount": 277,
     "axiomCount": 12,
     "theoremCount": 5,
     "definitionCount": 13

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -131,7 +131,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 359,
+    "lineCount": 411,
     "axiomCount": 2,
     "theoremCount": 18,
     "definitionCount": 7

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -161,7 +161,7 @@
       "Topology"
     ],
     "namespace": "Erdos5",
-    "lineCount": 380,
+    "lineCount": 428,
     "axiomCount": 3,
     "theoremCount": 19,
     "definitionCount": 9

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -114,7 +114,7 @@
       "Finset"
     ],
     "namespace": "Erdos530",
-    "lineCount": 164,
+    "lineCount": 270,
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 4

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -180,7 +180,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos667",
-    "lineCount": 255,
+    "lineCount": 343,
     "axiomCount": 14,
     "theoremCount": 22,
     "definitionCount": 3

--- a/src/data/proofs/erdos-680/meta.json
+++ b/src/data/proofs/erdos-680/meta.json
@@ -199,7 +199,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 194,
+    "lineCount": 233,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 7

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -141,7 +141,7 @@
       "Finset"
     ],
     "namespace": "Erdos931",
-    "lineCount": 300,
+    "lineCount": 330,
     "axiomCount": 2,
     "theoremCount": 31,
     "definitionCount": 6


### PR DESCRIPTION
## Fix

Update stale `leanFile.lineCount` values in 9 Erdős problem meta.json files after research PRs modified the Lean source files.

## Evidence

**Before**: `leanFile.lineCount` values lagged behind actual file lengths by 27-106 lines
**After**: All 9 values match actual Lean file line counts

| Proof | Old | New |
|-------|-----|-----|
| erdos-1014 | 104 | 134 |
| erdos-1149 | 218 | 320 |
| erdos-183 | 241 | 277 |
| erdos-278 | 359 | 411 |
| erdos-5 | 380 | 428 |
| erdos-530 | 164 | 270 |
| erdos-667 | 255 | 343 |
| erdos-680 | 194 | 233 |
| erdos-931 | 300 | 330 |

Note: `meta.lineCount` was already correct in all cases — only the `leanFile` sub-object was stale.

---
Automated fix by lean-mechanic agent.