### PR TITLE
Fix: stale metadata for erdos-853 and erdos-430 after research PRs

### DIFF
--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -17,13 +17,13 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 430,
     "erdosUrl": "https://erdosproblems.com/430",
     "erdosProblemStatus": "open",
-    "axiomCount": 3,
-    "assumptions": "3 axioms: erdos_385_equivalence (equivalence with Problem 385), erdos_430_conjecture (composites appear for large n), small_n_all_prime (small n can be all-prime). example_n8 now proved by native_decide.",
-    "lineCount": 114,
+    "axiomCount": 2,
+    "assumptions": "2 axioms: erdos_430_conjecture (composites appear for large n), small_n_all_prime (small n can be all-prime). 1 sorry remaining in greedy sequence containment proof.",
+    "lineCount": 172,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-853/meta.json
+++ b/src/data/proofs/erdos-853/meta.json
@@ -60,9 +60,9 @@
       "erdos_853_weak: weak conjecture r(x) → ∞",
       "erdos_853_strong: strong conjecture r(x)/log x → ∞"
     ],
-    "axiomCount": 9,
-    "lineCount": 237,
-    "assumptions": "9 axioms: r, r_even_pos, r_not_gap, and 6 more. See Lean source for complete statements."
+    "axiomCount": 5,
+    "lineCount": 282,
+    "assumptions": "5 axioms: r_upper_bound, erdos_853_weak, erdos_853_strong, maynard_tao_bounded_gaps, cramer_conjecture_bound."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #853: Completeness of the Prime Gap Census**\n\nErdős posed this problem in 1985 [Er85c], asking about the completeness of prime gap sizes. For primes up to $x$, we observe a finite set of gap values $d_n = p_{n+1} - p_n$. The function $r(x)$ measures how far this set is from containing all even integers: it is the smallest even number $\\ge 2$ not appearing as any gap.\n\n**Historical Timeline:**\n- 1849: Polignac conjectured every even number is a prime gap infinitely often\n- 1936: Cramér proposed his probabilistic model for prime gaps, predicting maximal gap $\\sim (\\log x)^2$\n- 1985: Erdős formulated Problem 853, asking whether $r(x) \\to \\infty$\n- 1995: Granville refined Cramér's constant to $2e^{-\\gamma} \\approx 1.119$\n- 2013: Zhang proved bounded gaps ($\\liminf d_n \\le 7 \\times 10^7$), the first finite bound\n- 2014: Maynard and Tao independently improved to $\\liminf d_n \\le 246$\n- 2014: Polymath8b project achieved the current bound of 246\n\n**The Key Tension:** The Maynard-Tao theorem guarantees some small gap appears infinitely often, confirming that at least some entries of the gap census grow without bound. But this says nothing about whether ALL even gaps eventually appear. The problem asks about the **completeness** of the gap set $G(x) = \\{d_n : p_n \\le x\\}$, which is a fundamentally different question from the existence of small gaps.\n\n**Notably rich formalization:** This file proves 14 theorems directly from Mathlib (no sorries), including the crucial `primeGap_even` (all gaps after $d_0$ are even), `r_monotone` (the smallest missing gap is weakly increasing), and `weak_implies_all_even_gaps` (the weak conjecture implies gap completeness).",


### PR DESCRIPTION
## Fix

Update meta.json for two proofs whose Lean source files were changed by recent research PRs without corresponding metadata updates.

## Changes

**erdos-853** (after research PR #5964 - defined r(x) via Nat.find, eliminated 4 axioms):
- axiomCount: 9 → 5
- lineCount: 237 → 282
- assumptions: listed all 5 remaining axioms (was "and 6 more")

**erdos-430** (after research PRs - proved erdos_385_equivalence, expanded file):
- sorries: 0 → 1 (sorry in greedy containment proof)
- axiomCount: 3 → 2
- lineCount: 114 → 172
- assumptions: listed 2 remaining axioms, noted 1 sorry

## Evidence

Verified by `grep -c "^axiom "` and `grep -n "sorry"` against Lean source files.

---
Automated fix by lean-mechanic agent.