### PR TITLE
Enrich 9 proofs: sections mathContext, cross-refs, references

### DIFF
--- a/src/data/proofs/erdos-149/meta.json
+++ b/src/data/proofs/erdos-149/meta.json
@@ -95,63 +95,72 @@
       "title": "Header, Imports, and Namespace",
       "startLine": 1,
       "endLine": 30,
-      "summary": "Module documentation with problem statement and progress timeline; imports SimpleGraph.Basic, Nat.Basic, Finset.Basic, and Tactic; opens SimpleGraph namespace"
+      "summary": "Module documentation with problem statement and progress timeline; imports SimpleGraph.Basic, Nat.Basic, Finset.Basic, and Tactic; opens SimpleGraph namespace",
+      "mathContext": "Strong chromatic index $\\chi'_s(G)$: minimum colors for edges so that edges within distance 2 get different colors. Conjecture: $\\chi'_s(G) \\leq \\frac{5}{4}\\Delta^2$."
     },
     {
       "id": "definitions",
       "title": "Part 1: Basic Definitions",
       "startLine": 31,
       "endLine": 58,
-      "summary": "Defines maxDegree (Finset.sup over degrees), edgesAtDistance2, StrongEdgeColoring structure, strongChromaticIndex via sInf, and notation χ'_s"
+      "summary": "Defines maxDegree (Finset.sup over degrees), edgesAtDistance2, StrongEdgeColoring structure, strongChromaticIndex via sInf, and notation χ'_s",
+      "mathContext": "$\\Delta(G) = \\max_v \\deg(v)$. Two edges are at distance $\\leq 2$ if they share a vertex or their endpoints are adjacent. $\\chi'_s(G) = \\inf\\{k : \\text{strong } k\\text{-edge-coloring exists}\\}$."
     },
     {
       "id": "conjecture",
       "title": "Part 2: The Erdős-Nešetřil Conjecture (1985)",
       "startLine": 59,
       "endLine": 83,
-      "summary": "ErdosNesetrilConjecture: χ'_s(G) ≤ (5/4)Δ²; conjecture_is_tight: achievable for Δ ≥ 2; c5_blowup_construction: explicit extremal graph for even Δ"
+      "summary": "ErdosNesetrilConjecture: χ'_s(G) ≤ (5/4)Δ²; conjecture_is_tight: achievable for Δ ≥ 2; c5_blowup_construction: explicit extremal graph for even Δ",
+      "mathContext": "Conjecture: $\\chi'_s(G) \\leq \\frac{5}{4}\\Delta^2$. Tight: the $C_5$-blowup achieves equality for even $\\Delta$."
     },
     {
       "id": "bounds",
       "title": "Part 3: Upper Bounds Progress History",
       "startLine": 84,
       "endLine": 123,
-      "summary": "Five bounds from trivial 2Δ² through Hurley et al. 1.772Δ²; current_gap theorem proved by norm_num: 1.772 - 5/4 = 0.522"
+      "summary": "Five bounds from trivial 2Δ² through Hurley et al. 1.772Δ²; current_gap theorem proved by norm_num: 1.772 - 5/4 = 0.522",
+      "mathContext": "$2\\Delta^2 \\to 1.998\\Delta^2 \\to 1.835\\Delta^2 \\to 1.772\\Delta^2$ (Hurley et al. 2022). Gap: $1.772 - 1.25 = 0.522$."
     },
     {
       "id": "special",
       "title": "Part 4: Special Graph Classes",
       "startLine": 124,
       "endLine": 145,
-      "summary": "Mahdian's C₄-free bound O(Δ²/log Δ) and bipartite bound with constant < 5/4"
+      "summary": "Mahdian's C₄-free bound O(Δ²/log Δ) and bipartite bound with constant < 5/4",
+      "mathContext": "$C_4$-free: $\\chi'_s = O(\\Delta^2/\\log\\Delta)$. Bipartite: strict improvement over $5/4$."
     },
     {
       "id": "clique",
       "title": "Part 5: Clique Number of L(G)²",
       "startLine": 146,
       "endLine": 167,
-      "summary": "cliqueNumber_LineSquare axiom, clique_le_chromatic relationship, Śleszyńska-Nowak (3/2)Δ² and Faron-Postle (4/3)Δ² bounds"
+      "summary": "cliqueNumber_LineSquare axiom, clique_le_chromatic relationship, Śleszyńska-Nowak (3/2)Δ² and Faron-Postle (4/3)Δ² bounds",
+      "mathContext": "$\\omega(L(G)^2) \\leq \\chi'_s(G)$. Best: $\\omega(L(G)^2) \\leq \\frac{4}{3}\\Delta^2$ (Faron-Postle)."
     },
     {
       "id": "pairs",
       "title": "Part 6: Strongly Independent Edge Pairs",
       "startLine": 168,
       "endLine": 184,
-      "summary": "StronglyIndependentEdges definition and Chung-Gyárfás-Tuza-Trotter 1990 result on edge density threshold"
+      "summary": "StronglyIndependentEdges definition and Chung-Gyárfás-Tuza-Trotter 1990 result on edge density threshold",
+      "mathContext": "Edges $e_1, e_2$ are strongly independent if no endpoint of $e_1$ is adjacent to any endpoint of $e_2$."
     },
     {
       "id": "matchings",
       "title": "Part 7: Induced Matchings",
       "startLine": 185,
       "endLine": 200,
-      "summary": "IsInducedMatching definition and strong_chromatic_eq_induced_matchings: χ'_s equals minimum induced matching partition number"
+      "summary": "IsInducedMatching definition and strong_chromatic_eq_induced_matchings: χ'_s equals minimum induced matching partition number",
+      "mathContext": "$\\chi'_s(G) = \\min\\{k : E(G) = M_1 \\cup \\cdots \\cup M_k\\}$ where each $M_i$ is an induced matching."
     },
     {
       "id": "summary",
       "title": "Part 8: Summary Theorem",
       "startLine": 201,
       "endLine": 217,
-      "summary": "erdos_149_summary combines hurley_joannis_kang_2022 (1.772Δ²) and conjecture_is_tight ((5/4)Δ² achievable), proved by exact tuple"
+      "summary": "erdos_149_summary combines hurley_joannis_kang_2022 (1.772Δ²) and conjecture_is_tight ((5/4)Δ² achievable), proved by exact tuple",
+      "mathContext": "Summary: $\\frac{5}{4}\\Delta^2 \\leq \\chi'_s(G) \\leq 1.772\\Delta^2$. The conjecture is that the lower bound is tight."
     }
   ],
   "conclusion": {
@@ -185,10 +194,39 @@
     {
       "targetId": "erdos-132",
       "relationship": "related",
-      "description": "Both are Erdős distance/combinatorial geometry problems involving point configurations and extremal bounds"
+      "description": "Both are Erdős problems on extremal combinatorial bounds in graph/geometric settings"
+    },
+    {
+      "targetId": "four-color-theorem",
+      "relationship": "conceptual",
+      "description": "Both concern graph coloring bounds: 4CT gives χ ≤ 4 for planar graphs, while #149 conjectures χ'_s ≤ (5/4)Δ² for all graphs"
+    },
+    {
+      "targetId": "erdos-762",
+      "relationship": "thematic",
+      "description": "Both are Erdős graph coloring conjectures: #762 on chromatic vs cochromatic number, #149 on strong chromatic index"
     }
   ],
   "relatedProofs": [
-    "erdos-132"
+    "erdos-132",
+    "four-color-theorem",
+    "erdos-762"
+  ],
+  "references": [
+    {
+      "authors": "Hurley, Eoin; de Joannis de Verclos, Rémi; Kang, Ross J.",
+      "title": "An improved procedure for colouring graphs of bounded local density",
+      "year": "2022",
+      "venue": "Advances in Combinatorics",
+      "note": "Current best upper bound 1.772Δ² using the cluster expansion method from statistical physics"
+    },
+    {
+      "authors": "Molloy, Michael; Reed, Bruce",
+      "title": "A bound on the strong chromatic index of a graph",
+      "year": "1997",
+      "venue": "Journal of Combinatorial Theory, Series B, vol. 69, pp. 103–109",
+      "note": "First sub-2Δ² bound via the Lovász Local Lemma: χ'_s ≤ 2Δ² - 2Δ + 1"
+    },
+    "https://erdosproblems.com/149"
   ]
 }

--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -55,56 +55,64 @@
       "title": "Arithmetic Progression Definitions",
       "startLine": 33,
       "endLine": 42,
-      "summary": "Defines IsAP3, IsAP4, IsAP5 via constant differences $b - a = c - b = \\cdots$ with strict ordering $a < b < c < \\cdots$."
+      "summary": "Defines IsAP3, IsAP4, IsAP5 via constant differences $b - a = c - b = \\cdots$ with strict ordering $a < b < c < \\cdots$.",
+      "mathContext": "A $k$-term arithmetic progression: $a, a+d, a+2d, \\ldots, a+(k-1)d$ with common difference $d > 0$. Here $a < b < c$ and $b - a = c - b$."
     },
     {
       "id": "monotone-aps",
       "title": "Monotone APs in Permutations",
       "startLine": 47,
       "endLine": 60,
-      "summary": "HasMonotone$k$AP$(\\pi)$: $\\exists$ monotone indices with values forming a $k$-AP. Covers 3, 4, and 5-term variants."
+      "summary": "HasMonotone$k$AP$(\\pi)$: $\\exists$ monotone indices with values forming a $k$-AP. Covers 3, 4, and 5-term variants.",
+      "mathContext": "$\\text{HasMonotone4AP}(\\pi) \\iff \\exists i_1 < i_2 < i_3 < i_4$ with $\\pi(i_1), \\pi(i_2), \\pi(i_3), \\pi(i_4)$ forming an AP (either increasing or decreasing)."
     },
     {
       "id": "conjecture",
       "title": "The Open Conjecture ($k = 4$)",
       "startLine": 64,
       "endLine": 67,
-      "summary": "ErdosProblem196: $\\forall \\pi: \\mathbb{N} \\equiv \\mathbb{N},$ HasMonotone4AP$(\\pi)$. The critical threshold question."
+      "summary": "ErdosProblem196: $\\forall \\pi: \\mathbb{N} \\equiv \\mathbb{N},$ HasMonotone4AP$(\\pi)$. The critical threshold question.",
+      "mathContext": "Conjecture: every permutation $\\pi : \\mathbb{N} \\to \\mathbb{N}$ contains a monotone 4-term AP. OPEN."
     },
     {
       "id": "degs-results",
       "title": "DEGS Results ($k = 3$ and $k = 5$)",
       "startLine": 72,
       "endLine": 77,
-      "summary": "DEGS (1977): $k = 3$ always exists (axiom), $k = 5$ can be avoided (axiom). Establishes the $k = 4$ threshold."
+      "summary": "DEGS (1977): $k = 3$ always exists (axiom), $k = 5$ can be avoided (axiom). Establishes the $k = 4$ threshold.",
+      "mathContext": "DEGS (1977): $k = 3$ — every permutation has a monotone 3-AP. $k = 5$ — there exists a permutation avoiding all monotone 5-APs. So $k = 4$ is the threshold candidate."
     },
     {
       "id": "implication",
       "title": "4-AP Implies 3-AP (Proved)",
       "startLine": 80,
       "endLine": 89,
-      "summary": "Lean proof that the 4-AP conjecture implies the 3-AP theorem by extracting three terms and using `omega`."
+      "summary": "Lean proof that the 4-AP conjecture implies the 3-AP theorem by extracting three terms and using `omega`.",
+      "mathContext": "If $\\pi$ has a monotone 4-AP $(a, a+d, a+2d, a+3d)$, then $(a, a+d, a+2d)$ is a monotone 3-AP. Proved in Lean via index extraction and `omega`."
     },
     {
       "id": "parity",
       "title": "Common Difference Parity Analysis",
       "startLine": 94,
       "endLine": 114,
-      "summary": "Odd/even CD definitions, LeSaulnier–Vijay odd-CD avoidance (2011), parity dichotomy (proved), and the structural equivalence to even-CD forcing."
+      "summary": "Odd/even CD definitions, LeSaulnier–Vijay odd-CD avoidance (2011), parity dichotomy (proved), and the structural equivalence to even-CD forcing.",
+      "mathContext": "LeSaulnier-Vijay (2011): odd-CD monotone 4-APs can be avoided. So the conjecture reduces to: can *even-CD* monotone 4-APs be avoided? Parity dichotomy proved in Lean."
     },
     {
       "id": "non-extendability",
       "title": "Non-Extendability Constraints",
       "startLine": 128,
       "endLine": 134,
-      "summary": "If no 4-AP exists, each 3-AP forbids a value at all later monotone positions — accumulating constraints toward a contradiction."
+      "summary": "If no 4-AP exists, each 3-AP forbids a value at all later monotone positions — accumulating constraints toward a contradiction.",
+      "mathContext": "If $(a, a+d, a+2d)$ is a monotone 3-AP in $\\pi$, then $a+3d$ cannot appear at a monotone position — a forbidden value constraint."
     },
     {
       "id": "erdos-szekeres",
       "title": "Erdős–Szekeres Connection",
       "startLine": 138,
       "endLine": 145,
-      "summary": "Erdős–Szekeres (1935): $n > (r-1)(s-1) \\implies$ monotone subsequence of length $r$ or $s$. Gives long monotone subsequences but not APs."
+      "summary": "Erdős–Szekeres (1935): $n > (r-1)(s-1) \\implies$ monotone subsequence of length $r$ or $s$. Gives long monotone subsequences but not APs.",
+      "mathContext": "Erdős-Szekeres: every sequence of $> (r-1)(s-1)$ distinct reals has an increasing subsequence of length $r$ or decreasing of length $s$. Gives structure but not AP structure."
     }
   ],
   "conclusion": {
@@ -136,10 +144,39 @@
     {
       "targetId": "erdos-34",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, permutations"
+      "description": "Related Erdős combinatorial problem involving permutation structure"
+    },
+    {
+      "targetId": "arithmetic-series",
+      "relationship": "foundational",
+      "description": "Arithmetic progressions are the core object: this problem asks which k-term APs are unavoidable in permutations of ℕ"
+    },
+    {
+      "targetId": "erdos-szekeres",
+      "relationship": "foundational",
+      "description": "The Erdős-Szekeres theorem (monotone subsequences in sequences) is a structural cousin — both guarantee structured subsequences, but Erdős-Szekeres gives monotone subsequences while #196 asks about monotone APs"
     }
   ],
   "relatedProofs": [
-    "erdos-34"
+    "erdos-34",
+    "arithmetic-series",
+    "erdos-szekeres"
+  ],
+  "references": [
+    {
+      "authors": "Davis, J.A.; Entringer, R.C.; Graham, R.L.; Simmons, G.J.",
+      "title": "On permutations containing no long arithmetic progressions",
+      "year": "1977",
+      "venue": "Acta Arithmetica, vol. 34, pp. 81–90",
+      "note": "Proved k=3 always exists and k=5 can be avoided; left k=4 as the critical open case"
+    },
+    {
+      "authors": "LeSaulnier, T.D.; Vijay, S.",
+      "title": "Monotone arithmetic progressions in permutations",
+      "year": "2011",
+      "venue": "Preprint",
+      "note": "Showed odd common-difference 4-APs can be avoided, reducing the conjecture to the even-CD case"
+    },
+    "https://erdosproblems.com/196"
   ]
 }


### PR DESCRIPTION
## Summary
Enrichment batch for 8 entries with sparse cross-references, missing section mathContext, and short/incorrect references.

### Common improvements across all 8 entries:
- Added `mathContext` with LaTeX to all sections (6-12 per entry, was 0 in each)
- Added 2-4 meaningful cross-references (was 1 generic in each)
- Fixed incorrect references (several cited wrong source papers)
- Deepened `historicalContext` where short (~600 → ~1100 chars)
- Added `references` arrays with scholarly citations

### Entries enriched:
1. **erdos-1060** - Counting Solutions to k·σ(k) = n (annotation rewrite + 4 cross-refs)
2. **erdos-191** - Monochromatic Sets with Large 1/log Sum (12 section mathContext)
3. **erdos-97** - Equidistant Vertices in Convex Polygons (7 section mathContext)
4. **erdos-353** - Geometric Configurations in Infinite-Measure Sets (10 section mathContext)
5. **erdos-762** - Chromatic vs Cochromatic Number (8 section mathContext, fixed ref)
6. **erdos-883** - Cycles in the Coprime Graph (8 section mathContext, fixed ref)
7. **continuum-hypothesis-oq-01** - Should We Adopt Axioms That Decide CH? (8 section mathContext)
8. **erdos-149** - Strong Chromatic Index Conjecture (9 section mathContext)

### Total changes:
- ~75 sections with new `mathContext` LaTeX
- ~20 new cross-references
- ~16 new scholarly references
- 5 incorrect references fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)