### PR TITLE
Research: erdos-731 - Prove 5 placeholder axioms, fix build bug (7 sorries remaining)

### DIFF
--- a/proofs/Proofs/Erdos731Problem.lean
+++ b/proofs/Proofs/Erdos731Problem.lean
@@ -29,8 +29,10 @@ def centralBinom (n : ℕ) : ℕ := Nat.choose (2 * n) n
 
 /-- The least positive integer that does not divide m. -/
 noncomputable def leastNonDivisor (m : ℕ) : ℕ :=
-  if m = 0 then 1
-  else Nat.find (⟨m + 1, by omega⟩ : ∃ k : ℕ, k > 0 ∧ ¬(k ∣ m))
+  if hm : m = 0 then 1
+  else Nat.find (⟨m + 1, ⟨by omega, fun h =>
+    absurd (Nat.le_of_dvd (Nat.pos_of_ne_zero hm) h) (by omega)⟩⟩ :
+    ∃ k : ℕ, k > 0 ∧ ¬(k ∣ m))
 
 /-- The least non-divisor of C(2n, n). -/
 noncomputable def leastNonDivCentral (n : ℕ) : ℕ :=
@@ -39,19 +41,16 @@ noncomputable def leastNonDivCentral (n : ℕ) : ℕ :=
 /- ## Main Conjecture -/
 
 /-- **Erdős Problem #731** (OPEN): For almost all n, the least m with
-    m ∤ C(2n, n) satisfies m = exp((log n)^{1/2 + o(1)}). -/
-axiom erdos_731_conjecture :
-  -- For all ε > 0, the density of n where the least non-divisor deviates
-  -- from exp((log n)^{1/2}) by more than (log n)^ε is zero.
-  True  -- Precise formulation requires asymptotic density and real analysis
+    m ∤ C(2n, n) satisfies m = exp((log n)^{1/2 + o(1)}).
+    Placeholder: precise formulation requires asymptotic density. -/
+theorem erdos_731_conjecture : True := trivial
 
 /- ## Divisibility Properties of Central Binomials -/
 
 /-- **Kummer's Theorem**: The p-adic valuation of C(m+n, m) equals the
-    number of carries when adding m and n in base p. -/
-axiom kummer_carries (p m n : ℕ) (hp : Nat.Prime p) :
-  -- v_p(C(m+n, m)) = number of carries in base-p addition of m and n
-  True
+    number of carries when adding m and n in base p.
+    Placeholder: full formalization needs p-adic valuations. -/
+theorem kummer_carries (p m n : ℕ) (hp : Nat.Prime p) : True := trivial
 
 /-- For prime p ≤ 2n, we have p | C(2n, n) iff there is at least one
     carry when adding n to itself in base p. -/
@@ -67,10 +66,9 @@ axiom small_primes_divide (p : ℕ) (hp : Nat.Prime p) :
 /-- C(2n, n) is always even for n ≥ 1. -/
 axiom two_divides_central (n : ℕ) (hn : n ≥ 1) : 2 ∣ centralBinom n
 
-/-- The product of all primes ≤ x is roughly e^x (prime number theorem). -/
-axiom primorial_asymptotic :
-  -- ∏_{p ≤ x} p = e^{x(1+o(1))} as x → ∞
-  True
+/-- The product of all primes ≤ x is roughly e^x (prime number theorem).
+    Placeholder: full formalization needs Chebyshev functions. -/
+theorem primorial_asymptotic : True := trivial
 
 /- ## Asymptotic Analysis -/
 
@@ -81,24 +79,16 @@ axiom least_nondiv_is_prime (n : ℕ) (hn : centralBinom n > 0) :
 
 /-- **EGRS (1975)**: The typical behavior is
     log(leastNonDivCentral n) ~ (log n)^{1/2}.
-    Heuristic: a prime p divides C(2n,n) unless all log_p(n) digits of n
-    are small. The probability of this is roughly (1/2)^{log n / log p},
-    which becomes significant when log p ~ (log n)^{1/2}. -/
-axiom egrs_typical_behavior :
-  -- For density-1 set of n:
-  -- (log n)^{1/2 - ε} ≤ log(leastNonDivCentral n) ≤ (log n)^{1/2 + ε}
-  True
+    Placeholder: full formalization needs probabilistic number theory. -/
+theorem egrs_typical_behavior : True := trivial
 
 /- ## Bounds -/
 
-/-- Lower bound: the least non-divisor is at least 2 for n ≥ 1 (since
-    2 | C(2n, n) for n ≥ 1). More generally, all primes up to a threshold
-    divide C(2n, n) for most n. -/
-axiom lower_bound_most_n :
-  ∀ (P : ℕ), ∃ (D : ℕ), D > 0 ∧
-    -- For at least (1 - 1/D) fraction of n ≤ N:
-    -- leastNonDivCentral n > P
-    True
+/-- Lower bound: for any P, there exists a density threshold.
+    Placeholder: the actual density claim requires measure theory. -/
+theorem lower_bound_most_n :
+    ∀ (P : ℕ), ∃ (D : ℕ), D > 0 ∧ True :=
+  fun _ => ⟨1, by omega, trivial⟩
 
 /-- Upper bound: there always exists a prime p ≤ 2n+1 not dividing C(2n, n),
     namely p = 2n+1 when it is prime and n+1 < p. -/

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-731",
   "title": "Least Non-Divisor of Central Binomial Coefficients",
   "slug": "erdos-731",
-  "description": "Find f(n) such that for almost all n, the least m with m ∤ C(2n,n) satisfies m ~ f(n). EGRS (1975): m = exp((log n)^{1/2+o(1)}) for almost all n.",
+  "description": "Find f(n) such that for almost all n, the least m with m \u2224 C(2n,n) satisfies m ~ f(n). EGRS (1975): m = exp((log n)^{1/2+o(1)}) for almost all n.",
   "meta": {
-    "author": "Erdős, Graham, Ruzsa, Straus",
+    "author": "Erd\u0151s, Graham, Ruzsa, Straus",
     "sourceUrl": "https://erdosproblems.com/731",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos731Problem.lean",
@@ -20,7 +20,7 @@
     "erdosNumber": 731,
     "erdosUrl": "https://erdosproblems.com/731",
     "erdosProblemStatus": "open",
-    "axiomCount": 12,
+    "axiomCount": 7,
     "lineCount": 115,
     "mathlibDependencies": [
       {
@@ -39,13 +39,13 @@
         "module": "Mathlib.Order.WellFounded"
       }
     ],
-    "assumptions": "12 axioms: erdos_731_conjecture, kummer_carries, prime_divides_central_iff, and 9 more. See Lean source for complete statements.",
+    "assumptions": "7 axiom declarations: prime_divides_central_iff, small_primes_divide, two_divides_central, least_nondiv_is_prime, upper_bound_trivial, bertrand_central, central_binom_lower. Proved 5 placeholder axioms (erdos_731_conjecture, kummer_carries, primorial_asymptotic, egrs_typical_behavior, lower_bound_most_n) that had True conclusions.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős, Graham, Ruzsa, and Straus (1975) studied the divisibility properties of central binomial coefficients $\\binom{2n}{n}$ and observed that the least integer not dividing $\\binom{2n}{n}$ is typically $\\exp((\\log n)^{1/2+o(1)})$. This observation connects deeply to Kummer's theorem (1852), which states that $v_p(\\binom{m+n}{m})$ equals the number of carries in base-$p$ addition of $m$ and $n$. For $\\binom{2n}{n}$, the carries arise when doubling $n$ in base $p$, which happens precisely when some base-$p$ digit of $n$ is $\\geq \\lceil p/2 \\rceil$. The heuristic is that a random $n$ has each base-$p$ digit independently uniform, so the probability of no carry (and hence $p \\nmid \\binom{2n}{n}$) is approximately $(1/2)^{\\log n/\\log p}$, which transitions from negligible to significant when $\\log p \\approx (\\log n)^{1/2}$. The sequence of least non-divisors appears as OEIS A006197.",
+    "historicalContext": "Erd\u0151s, Graham, Ruzsa, and Straus (1975) studied the divisibility properties of central binomial coefficients $\\binom{2n}{n}$ and observed that the least integer not dividing $\\binom{2n}{n}$ is typically $\\exp((\\log n)^{1/2+o(1)})$. This observation connects deeply to Kummer's theorem (1852), which states that $v_p(\\binom{m+n}{m})$ equals the number of carries in base-$p$ addition of $m$ and $n$. For $\\binom{2n}{n}$, the carries arise when doubling $n$ in base $p$, which happens precisely when some base-$p$ digit of $n$ is $\\geq \\lceil p/2 \\rceil$. The heuristic is that a random $n$ has each base-$p$ digit independently uniform, so the probability of no carry (and hence $p \\nmid \\binom{2n}{n}$) is approximately $(1/2)^{\\log n/\\log p}$, which transitions from negligible to significant when $\\log p \\approx (\\log n)^{1/2}$. The sequence of least non-divisors appears as OEIS A006197.",
     "problemStatement": "Find a reasonable function $f(n)$ such that for almost all $n$, the least integer $m$ with $m \\nmid \\binom{2n}{n}$ satisfies $m \\sim f(n)$.",
-    "text": "Find f(n) such that for almost all n, the least m with m ∤ C(2n,n) satisfies m ~ f(n). EGRS (1975): m = exp((log n)^{1/2+o(1)}) for almost all n.",
+    "text": "Find f(n) such that for almost all n, the least m with m \u2224 C(2n,n) satisfies m ~ f(n). EGRS (1975): m = exp((log n)^{1/2+o(1)}) for almost all n.",
     "proofStrategy": "The formalization defines `centralBinom n` via `Nat.choose (2*n) n`, constructs `leastNonDivisor` using `Nat.find`, and specializes to `leastNonDivCentral`. Kummer's theorem and the prime divisibility criterion are axiomatized, connecting divisibility to base-$p$ digit structure. The EGRS asymptotic, Bertrand's postulate application, and exponential lower bounds for $\\binom{2n}{n}$ are stated as supporting results.",
     "keyInsights": [
       "$p \\mid \\binom{2n}{n}$ iff some base-$p$ digit of $n$ is $\\geq \\lceil p/2 \\rceil$, by Kummer's theorem applied to the carries in $n + n$ in base $p$",
@@ -65,7 +65,7 @@
       "title": "Preamble: Problem Context and Imports",
       "startLine": 1,
       "endLine": 24,
-      "summary": "File docstring establishing the problem: find f(n) approximating the least m with m ∤ C(2n,n). Cites the EGRS (1975) result m = exp((log n)^{1/2+o(1)}), Kummer's theorem on carries, and OEIS A006197. Imports Mathlib.Data.Nat.Choose.Central for central binomial coefficients, Mathlib.Data.Nat.Prime.Basic for primality, and Mathlib.Tactic for proof automation."
+      "summary": "File docstring establishing the problem: find f(n) approximating the least m with m \u2224 C(2n,n). Cites the EGRS (1975) result m = exp((log n)^{1/2+o(1)}), Kummer's theorem on carries, and OEIS A006197. Imports Mathlib.Data.Nat.Choose.Central for central binomial coefficients, Mathlib.Data.Nat.Prime.Basic for primality, and Mathlib.Tactic for proof automation."
     },
     {
       "id": "definitions",
@@ -97,7 +97,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erdős Problem 731 on the least non-divisor of central binomial coefficients. The EGRS heuristic $\\exp((\\log n)^{1/2+o(1)})$ is driven by Kummer's theorem and the digit structure of $n$ in various bases. The formalization includes the core definitions, the divisibility criterion, supporting bounds, and the Bertrand connection, with all structural properties axiomatized.",
+    "summary": "Formalizes Erd\u0151s Problem 731 on the least non-divisor of central binomial coefficients. The EGRS heuristic $\\exp((\\log n)^{1/2+o(1)})$ is driven by Kummer's theorem and the digit structure of $n$ in various bases. The formalization includes the core definitions, the divisibility criterion, supporting bounds, and the Bertrand connection, with all structural properties axiomatized.",
     "implications": "A precise asymptotic for $f(n)$ would unify the digit-theoretic and probabilistic perspectives on central binomial divisibility. It would connect to the distribution of smooth numbers (via the $\\exp((\\log n)^{1/2})$ threshold), to Dickman's function in the theory of friable integers, and to the more general study of arithmetic functions along special sequences.",
     "openQuestions": [
       "What is the precise function $f(n)$ with $\\text{leastNonDivCentral}(n) \\sim f(n)$ for almost all $n$? Is it $\\exp(c(\\log n)^{1/2})$ for a specific constant $c$?",
@@ -137,13 +137,13 @@
     "opens": [],
     "namespace": null,
     "lineCount": 115,
-    "axiomCount": 12,
-    "theoremCount": 0,
+    "axiomCount": 7,
+    "theoremCount": 5,
     "definitionCount": 3
   },
   "references": [
     {
-      "authors": "P. Erdős, R. L. Graham, I. Z. Ruzsa, E. G. Straus",
+      "authors": "P. Erd\u0151s, R. L. Graham, I. Z. Ruzsa, E. G. Straus",
       "title": "On the prime factors of $\\binom{2n}{n}$",
       "year": "1975",
       "venue": "Mathematische Zeitschrift, 148(3), pp. 287-295",
@@ -151,9 +151,9 @@
     },
     {
       "authors": "E. E. Kummer",
-      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "title": "\u00dcber die Erg\u00e4nzungss\u00e4tze zu den allgemeinen Reciprocit\u00e4tsgesetzen",
       "year": "1852",
-      "venue": "Journal für die reine und angewandte Mathematik, 44, pp. 93-146",
+      "venue": "Journal f\u00fcr die reine und angewandte Mathematik, 44, pp. 93-146",
       "note": "Proves that v_p(C(m+n,m)) equals the number of carries in base-p addition of m and n"
     }
   ]

--- a/src/data/research/problems/erdos-731.json
+++ b/src/data/research/problems/erdos-731.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-731",
-  "title": "Erdős #731",
+  "title": "Erd\u0151s #731",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -29,12 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved 5 placeholder axioms (True conclusions), fixed pre-existing build bug in leastNonDivisor definition. Axioms: 12->7.",
+    "builtItems": [
+      "Proved erdos_731_conjecture (True placeholder)",
+      "Proved kummer_carries (True placeholder)",
+      "Proved primorial_asymptotic (True placeholder)",
+      "Proved egrs_typical_behavior (True placeholder)",
+      "Proved lower_bound_most_n (True with existential)",
+      "Fixed leastNonDivisor definition (omega -> Nat.pos_of_ne_zero)"
+    ],
+    "insights": [
+      "File had pre-existing build failure: omega cannot prove non-divisibility (m+1 does not divide m)",
+      "Fix: use dite pattern (if hm : m = 0 then ... else ...) to access m != 0 hypothesis",
+      "5 of 12 axioms were placeholders with True conclusions - trivially provable",
+      "Remaining 7 axioms are mathematically substantive (Kummer characterization, Bertrand, bounds)"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #731 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFind some reasonable function $f(n)$ such that, for almost all integers $n$, the least integer $m$ such that $m\\nmid \\binom{2n}{n}$ satisfies\\[m\\sim f(n).\\]\n\n\n\nA problem of Erd\\H{o}s, Graham, Ruzsa, and Straus \\cite{EGRS75}, who say it is 'not hard to show that', for almost all $n$, the minimal such $m$ satisfies\\[m=\\exp((\\log n)^{1/2+o(1)}).\\]\n\n\n\n\nReferences\n\n\n[EGRS75] Erd\\H{o}s, P. and Graham, R. L. and Ruzsa, I. Z. and Straus, E. G., On the prime factors of $(\\sp{2n}\\sb{n})$. Math. Comp. (1975), 83-92.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #730\n- Problem #732\n- Problem #39\n- Problem #1\n\n## References\n\n- EGRS75\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
+    "nextSteps": [
+      "Prove two_divides_central via Pascal rule + choose_symm (C(2n,n) = 2*C(2n-1,n-1))",
+      "Prove central_binom_lower if Mathlib has 4^n bound",
+      "Deep axioms: prime_divides_central_iff, small_primes_divide, least_nondiv_is_prime, upper_bound_trivial, bertrand_central"
+    ],
+    "markdown": "# Erd\u0151s #731 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFind some reasonable function $f(n)$ such that, for almost all integers $n$, the least integer $m$ such that $m\\nmid \\binom{2n}{n}$ satisfies\\[m\\sim f(n).\\]\n\n\n\nA problem of Erd\\H{o}s, Graham, Ruzsa, and Straus \\cite{EGRS75}, who say it is 'not hard to show that', for almost all $n$, the minimal such $m$ satisfies\\[m=\\exp((\\log n)^{1/2+o(1)}).\\]\n\n\n\n\nReferences\n\n\n[EGRS75] Erd\\H{o}s, P. and Graham, R. L. and Ruzsa, I. Z. and Straus, E. G., On the prime factors of $(\\sp{2n}\\sb{n})$. Math. Comp. (1975), 83-92.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #730\n- Problem #732\n- Problem #39\n- Problem #1\n\n## References\n\n- EGRS75\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [
     "erdos"
@@ -58,8 +74,8 @@
       "path": "Proofs/Erdos731Problem.lean",
       "filename": "Erdos731Problem.lean",
       "lineCount": 116,
-      "theoremCount": 0,
-      "axiomCount": 12,
+      "theoremCount": 5,
+      "axiomCount": 7,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Fix pre-existing build failure in `leastNonDivisor` definition (omega can't prove non-divisibility; fixed with dite pattern)
- Prove 5 placeholder axioms that had `True` conclusions: `erdos_731_conjecture`, `kummer_carries`, `primorial_asymptotic`, `egrs_typical_behavior`, `lower_bound_most_n`
- Axioms reduced: 12 → 7

## Test Plan
- [x] Docker build passes (was previously broken due to omega bug in leastNonDivisor)
- [x] No sorries in proved theorems
- [x] meta.json updated with correct axiom count (7)

🤖 Generated by researcher-6