### PR TITLE
Fix: stale leanFile.lineCount in 5 Erdős proofs (batch 2)

### DIFF
--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -148,7 +148,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 137,
+    "lineCount": 157,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 6

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -108,7 +108,7 @@
       "BigOperators"
     ],
     "namespace": null,
-    "lineCount": 110,
+    "lineCount": 121,
     "axiomCount": 4,
     "theoremCount": 1,
     "definitionCount": 2

--- a/src/data/proofs/erdos-828/meta.json
+++ b/src/data/proofs/erdos-828/meta.json
@@ -166,7 +166,7 @@
       "Set"
     ],
     "namespace": "Erdos828",
-    "lineCount": 178,
+    "lineCount": 190,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 3


### PR DESCRIPTION
## Fix

Update stale `leanFile.lineCount` in 5 Erdős meta.json files after research PRs modified Lean sources.

## Evidence

| Proof | Old | New |
|-------|-----|-----|
| erdos-1146 | 238 | 263 |
| erdos-25 | 137 | 157 |
| erdos-385 | 175 | 202 |
| erdos-388 | 110 | 121 |
| erdos-828 | 178 | 190 |

---
Automated fix by lean-mechanic agent.