### PR TITLE
Research: erdos-367 + erdos-1051 - Prove 5 axioms total

### DIFF
--- a/proofs/Proofs/Erdos1051Problem.lean
+++ b/proofs/Proofs/Erdos1051Problem.lean
@@ -13,7 +13,7 @@ integers with lim inf aₙ^{1/2ⁿ} > 1, then Σ 1/(aₙ · aₙ₊₁) is irrat
 
 import Mathlib.Data.Int.Basic
 import Mathlib.Data.Real.Basic
-import Mathlib.Data.Real.Irrational
+import Mathlib.NumberTheory.Real.Irrational
 import Mathlib.Order.Filter.Basic
 import Mathlib.Topology.Algebra.InfiniteSum.Basic
 import Mathlib.Tactic
@@ -71,10 +71,24 @@ axiom series_converges (a : ℕ → ℤ) (h_mono : StrictMono a)
     (h_growth : GrowthCondition a) :
     Summable (fun n => (1 : ℝ) / ((a n : ℝ) * (a (n + 1) : ℝ)))
 
-/-- The series is positive when all aₙ > 0. -/
-axiom series_positive (a : ℕ → ℤ) (h_mono : StrictMono a)
+/-- The series is positive when all aₙ > 0.
+
+Each term 1/(aₙ · aₙ₊₁) > 0 since aₙ > 0, and the sum of positive
+summable terms is positive. Uses series_converges for summability. -/
+theorem series_positive (a : ℕ → ℤ) (h_mono : StrictMono a)
     (h_pos : ∀ n, a n > 0) (h_growth : GrowthCondition a) :
-    erdosSeries a > 0
+    erdosSeries a > 0 := by
+  unfold erdosSeries
+  have h_summable := series_converges a h_mono h_growth
+  apply tsum_pos h_summable
+  · intro n
+    apply le_of_lt
+    apply div_pos one_pos
+    apply mul_pos
+    · exact Int.cast_pos.mpr (h_pos n)
+    · exact Int.cast_pos.mpr (h_pos (n + 1))
+  · exact ⟨0, div_pos one_pos (mul_pos
+      (Int.cast_pos.mpr (h_pos 0)) (Int.cast_pos.mpr (h_pos 1)))⟩
 
 /-
 ## Section VI: Related Series

--- a/proofs/Proofs/Erdos367Problem.lean
+++ b/proofs/Proofs/Erdos367Problem.lean
@@ -184,19 +184,83 @@ The 2-full part is trivial exactly when n has no repeated prime factors.
 axiom twoFullPart_eq_one_iff (n : ℕ) (hn : n ≥ 1) :
     twoFullPart n = 1 ↔ Squarefree n
 
+/- Helper: For a prime p, p.primeFactors = {p} -/
+private lemma primeFactors_prime_eq (p : ℕ) (hp : p.Prime) :
+    p.primeFactors = {p} := by
+  ext q
+  simp only [Nat.mem_primeFactors, Finset.mem_singleton]
+  constructor
+  · rintro ⟨hq, hqp, -⟩
+    exact (hp.eq_one_or_self_of_dvd q hqp).resolve_left hq.one_lt.ne'
+  · rintro rfl
+    exact ⟨hp, dvd_refl p, hp.ne_zero⟩
+
+/- Helper: For a prime p, (p^2).primeFactors = {p} -/
+private lemma primeFactors_prime_sq_eq (p : ℕ) (hp : p.Prime) :
+    (p ^ 2).primeFactors = {p} := by
+  ext q
+  simp only [Nat.mem_primeFactors, Finset.mem_singleton]
+  constructor
+  · rintro ⟨hq, hqp2, -⟩
+    exact (hp.eq_one_or_self_of_dvd q (hq.dvd_of_dvd_pow hqp2)).resolve_left hq.one_lt.ne'
+  · rintro rfl
+    exact ⟨hp, dvd_pow_self p (by omega), pow_ne_zero 2 hp.ne_zero⟩
+
+/- Helper: squarefreePart of a prime equals the prime itself -/
+private lemma squarefreePart_prime_eq (p : ℕ) (hp : p.Prime) :
+    squarefreePart p = p := by
+  unfold squarefreePart
+  rw [primeFactors_prime_eq p hp]
+  have hfilt : ({p} : Finset ℕ).filter (fun q => p.factorization q = 1) = {p} := by
+    apply Finset.filter_true_of_mem
+    intro q hq
+    rw [Finset.mem_singleton.mp hq]
+    simp [Nat.factorization_prime hp, Finsupp.single_eq_same]
+  rw [hfilt]
+  exact Finset.prod_singleton
+
+/- Helper: squarefreePart of p² is 1 (no primes with exponent exactly 1) -/
+private lemma squarefreePart_prime_sq_eq (p : ℕ) (hp : p.Prime) :
+    squarefreePart (p ^ 2) = 1 := by
+  unfold squarefreePart
+  rw [primeFactors_prime_sq_eq p hp]
+  have hfilt : ({p} : Finset ℕ).filter
+      (fun q => (p ^ 2).factorization q = 1) = ∅ := by
+    rw [Finset.filter_eq_empty]
+    intro q hq
+    rw [Finset.mem_singleton.mp hq]
+    simp [Nat.factorization_prime_pow hp, Finsupp.single_eq_same]
+  rw [hfilt]
+  exact Finset.prod_empty
+
 /--
 **B₂(p) = 1 for Primes**
 
 Primes are squarefree, so their 2-full part is 1.
 -/
-axiom twoFullPart_prime (p : ℕ) (hp : p.Prime) : twoFullPart p = 1
+theorem twoFullPart_prime (p : ℕ) (hp : p.Prime) : twoFullPart p = 1 := by
+  have hsf := squarefreePart_prime_eq p hp
+  unfold twoFullPart
+  have h : squarefreePart p ∣ p ∧ squarefreePart p ≠ 0 := by
+    constructor
+    · rw [hsf]
+    · rw [hsf]; exact hp.ne_zero
+  rw [dif_pos h, hsf, Nat.div_self hp.pos]
 
 /--
 **B₂(p²) = p² for Primes**
 
 Perfect squares of primes are entirely 2-full.
 -/
-axiom twoFullPart_prime_sq (p : ℕ) (hp : p.Prime) : twoFullPart (p ^ 2) = p ^ 2
+theorem twoFullPart_prime_sq (p : ℕ) (hp : p.Prime) :
+    twoFullPart (p ^ 2) = p ^ 2 := by
+  have hsf := squarefreePart_prime_sq_eq p hp
+  unfold twoFullPart
+  have h : squarefreePart (p ^ 2) ∣ p ^ 2 ∧ squarefreePart (p ^ 2) ≠ 0 := by
+    constructor
+    · rw [hsf]; exact one_dvd _
+    · rw [hsf]; exact one_ne_zero
+  rw [dif_pos h, hsf, Nat.div_one]
 
 /--
 **Multiplicativity on Coprime Arguments**
@@ -211,14 +275,22 @@ axiom twoFullPart_mul_coprime (m n : ℕ) (h : Nat.Coprime m n) :
 
 The 2-full part never exceeds n itself.
 -/
-axiom twoFullPart_le (n : ℕ) : twoFullPart n ≤ n
+theorem twoFullPart_le (n : ℕ) : twoFullPart n ≤ n := by
+  unfold twoFullPart
+  split
+  next _ => exact Nat.div_le_self n _
+  next _ => exact le_refl n
 
 /--
 **Divisibility: B₂(n) | n**
 
 The 2-full part always divides n.
 -/
-axiom twoFullPart_dvd (n : ℕ) : twoFullPart n ∣ n
+theorem twoFullPart_dvd (n : ℕ) : twoFullPart n ∣ n := by
+  unfold twoFullPart
+  split
+  next h => exact Nat.div_dvd_of_dvd h.1
+  next _ => exact dvd_refl n
 
 /-
 # Part 8: Generalization to r-Full Parts

--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 1051,
     "erdosUrl": "https://erdosproblems.com/1051",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 98,
-    "assumptions": "5 axioms: rapid_growth_irrational, series_converges, series_positive, and 2 more. See Lean source for complete statements.",
+    "axiomCount": 4,
+    "lineCount": 106,
+    "assumptions": "4 axioms: rapid_growth_irrational, series_converges, simple_series_question, sylvester_fibonacci_example. series_positive proved from series_converges via tsum_pos.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -227,9 +227,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 98,
-    "axiomCount": 5,
-    "theoremCount": 0,
+    "lineCount": 106,
+    "axiomCount": 4,
+    "theoremCount": 1,
     "definitionCount": 4
   }
 }

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -54,9 +54,13 @@
       "rFullPart: generalization to r-full parts",
       "twoFullPart_eq_rFullPart: proved consistency by rfl",
       "generalizedConjecture: r-full version",
-      "erdos_367_summary: proved conjunction of known results"
+      "erdos_367_summary: proved conjunction of known results",
+      "twoFullPart_le: proved B₂(n) ≤ n from definition",
+      "twoFullPart_dvd: proved B₂(n) | n from definition",
+      "twoFullPart_prime: proved B₂(p) = 1 via squarefreePart computation",
+      "twoFullPart_prime_sq: proved B₂(p²) = p² via squarefreePart computation"
     ],
-    "axiomCount": 11,
+    "axiomCount": 7,
     "prerequisites": [
       "Prime factorization and p-adic valuations",
       "Squarefree numbers and powerful (k-full) numbers",
@@ -65,14 +69,14 @@
       "Basic real analysis (logarithms, limits, sequences)"
     ],
     "date": "1980",
-    "lineCount": 295,
-    "assumptions": "11 axioms: strong_bound_k1, strong_bound_k2, strong_bound_fails_k3, and 8 more. See Lean source for complete statements."
+    "lineCount": 367,
+    "assumptions": "7 axioms: strong_bound_k1, strong_bound_k2, strong_bound_fails_k3, van_doorn_lower_bound, twoFullPart_eq_one_iff, twoFullPart_mul_coprime, average_twoFullPart_bounded. 4 former axioms proved: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #367: Products of 2-Full Parts**\n\nThis problem connects two classical themes in multiplicative number theory: the distribution of powerful numbers and the multiplicative structure of consecutive integers.\n\n**Background:** The 2-full (or squareful) part $B_2(n)$ captures the 'square content' of $n$'s prime factorization. Golomb (1970) introduced powerful numbers (where every prime divides with exponent $\\geq 2$) and studied their distribution. The function $B_2$ generalizes this: $B_2(n) = \\prod_{v_p(n) \\geq 2} p^{v_p(n)}$ extracts the powerful component from any integer.\n\n**The problem:** Erdős asked whether $\\prod_{n \\leq m < n+k} B_2(m) \\ll n^{2+o(1)}$ for every fixed $k$. The exponent 2 is natural: since $B_2(n) \\leq n$, the product of $k$ terms is at most $n^k$, but heuristically most $B_2(m)$ are small, so the 'effective' exponent should be much less than $k$.\n\n**Progress:**\n- For $k \\leq 2$: the strong bound $\\ll n^2$ holds trivially ($B_2(n) \\leq n$).\n- **van Doorn (2023):** Proved the strong bound **fails** for $k \\geq 3$. Specifically, there exist infinitely many $n$ with $\\prod_{m=n}^{n+2} B_2(m) \\gg n^2 \\log n$. The construction uses the Chinese Remainder Theorem to find $n$ where multiple consecutive integers have large square factors.\n- The **weak bound** $n^{2+o(1)}$ (with the logarithmic slack) remains open for all $k \\geq 3$.",
     "problemStatement": "Let B₂(n) = n/squarefreePart(n) denote the 2-full part. For every fixed k ≥ 1, is it true that ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)}? Or perhaps even ≪_k n²?",
     "text": "For fixed k ≥ 1, is ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)}? The strong bound ≪ n² holds for k ≤ 2 but fails for k ≥ 3 (van Doorn). OPEN.",
-    "proofStrategy": "The formalization defines squarefreePart, twoFullPart, and productTwoFullParts. Weak and strong bounds are defined as propositions. Known results (k ≤ 2 strong bound, k ≥ 3 failure, van Doorn lower bound) are axioms. Properties of B₂ (squarefree characterization, multiplicativity, divisibility) are axioms. The r-full generalization is defined with a proved consistency theorem. A summary theorem combines the known results.",
+    "proofStrategy": "The formalization defines squarefreePart, twoFullPart, and productTwoFullParts. Weak and strong bounds are defined as propositions. Known results (k ≤ 2 strong bound, k ≥ 3 failure, van Doorn lower bound) are axioms. Four key properties of B₂ are proved from the definition: B₂(n) ≤ n, B₂(n) | n, B₂(p) = 1 for primes, B₂(p²) = p² for primes. Remaining properties (squarefree characterization, multiplicativity, average bound) are axioms. The r-full generalization is defined with a proved consistency theorem. A summary theorem combines the known results.",
     "keyInsights": [
       "B₂(n) = 1 when n is squarefree; B₂(n) = n when n is a perfect power",
       "For k ≤ 2, ∏B₂(m) ≤ n² holds trivially since B₂(n) ≤ n",
@@ -142,7 +146,7 @@
       "title": "Part 7: Properties of B₂",
       "startLine": 173,
       "endLine": 222,
-      "summary": "Six axiomatized properties: B₂=1 iff squarefree, B₂(p)=1, B₂(p²)=p², multiplicativity on coprime, B₂≤n, B₂|n.",
+      "summary": "Four proved theorems (B₂(p)=1, B₂(p²)=p², B₂≤n, B₂|n) and three axioms (B₂=1 iff squarefree, multiplicativity on coprime).",
       "mathContext": "$B_2(n) = 1 \\iff n$ squarefree; $B_2$ is multiplicative on coprime arguments; $B_2(n) \\mid n$"
     },
     {
@@ -233,9 +237,9 @@
       "Finset"
     ],
     "namespace": "Erdos367",
-    "lineCount": 295,
-    "axiomCount": 11,
-    "theoremCount": 2,
+    "lineCount": 367,
+    "axiomCount": 7,
+    "theoremCount": 6,
     "definitionCount": 10
   }
 }

--- a/src/data/research/problems/erdos-1051.json
+++ b/src/data/research/problems/erdos-1051.json
@@ -29,11 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Reduced axiom count from 5 to 4. Proved positivity of the series.",
+    "builtItems": [
+      "Proved series_positive theorem in Erdos1051Problem.lean"
+    ],
+    "insights": [
+      "Proved series_positive from series_converges using tsum_pos. Each term 1/(a_n*a_{n+1}) > 0 since a_n > 0."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Remaining axioms are deep (Erdős 1988 result, open questions, Fibonacci example)"
+    ],
     "markdown": "# Erdős #1051 - Knowledge Base\n\n## Problem Statement\n\nIs it true that if a1&lt;a2&lt;&#x22EF;\" role=\"presentation\" style=\"position: relative;\">a1a2⋯a1a2⋯a_1 is a sequence of integers withlim&#x2006;infan1/2n&gt;1\" role=\"presentation\" style=\"text-align: center; position: relative;\">liminfa1/2nn>1lim infan1/2n>1\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #1050\n- Problem #1052\n- Problem #39\n- Problem #1\n\n## References\n\n- Er88c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -58,9 +64,9 @@
     {
       "path": "Proofs/Erdos1051Problem.lean",
       "filename": "Erdos1051Problem.lean",
-      "lineCount": 99,
-      "theoremCount": 0,
-      "axiomCount": 5,
+      "lineCount": 106,
+      "theoremCount": 1,
+      "axiomCount": 4,
       "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/erdos-367.json
+++ b/src/data/research/problems/erdos-367.json
@@ -29,11 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Reduced axiom count from 11 to 7. Proved 4 properties of B₂ from definitions using Mathlib factorization API.",
+    "builtItems": [
+      "Proved twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq in Erdos367Problem.lean"
+    ],
+    "insights": [
+      "4 axioms proved from Mathlib: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove strong_bound_k1/k2 from twoFullPart_le",
+      "Prove twoFullPart_eq_one_iff via squarefreePart analysis"
+    ],
     "markdown": "# Erdős #367 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $B_2(n)$ be the 2-full part of $n$ (that is, $B_2(n)=n/n'$ where $n'$ is the product of all primes that divide $n$ exactly once). Is it true that, for every fixed $k\\geq 1$,\\[\\prod_{n\\leq m<n+k}B_2(m) \\ll n^{2+o(1)}?\\]Or perhaps even $\\ll_k n^2$?\n\n\n\nIt would also be interesting to find upper and lower bounds for the analogous product with $B_r$ for $r\\geq 3$, where $B_r(n)$ is the $r$-full part of $n$ (that is, the product of prime powers $p^a \\mid n$ such that $p^{a+1}\\nmid n$ and $a\\geq r$). Is it true that, for every fixed $r,k\\geq 2$ and $\\epsilon>0$,\\[\\limsup \\frac{\\prod_{n\\leq m<n+k}B_r(m) }{n^{1+\\epsilon}}\\to\\infty?\\]van Doorn notes in the comments that for $k\\leq 2$ we trivially have\\[\\prod_{n\\leq m<n+k}B_2(m) \\ll n^{2},\\]but that this fails for all $k\\geq 3$, and in fact\\[\\prod_{n\\leq m<n+3}B_2(m) \\gg n^{2}\\log n\\]infinitely often.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #366\n- Problem #368\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -57,9 +64,9 @@
     {
       "path": "Proofs/Erdos367Problem.lean",
       "filename": "Erdos367Problem.lean",
-      "lineCount": 296,
-      "theoremCount": 2,
-      "axiomCount": 11,
+      "lineCount": 367,
+      "theoremCount": 6,
+      "axiomCount": 7,
       "defCount": 10,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
Research session proving axioms across two Erdős problems.

## erdos-367: Products of 2-Full Parts (11→7 axioms)
- **twoFullPart_le**: B₂(n) ≤ n via Nat.div_le_self
- **twoFullPart_dvd**: B₂(n) | n via Nat.div_dvd_of_dvd
- **twoFullPart_prime**: B₂(p) = 1 via primeFactors/factorization API
- **twoFullPart_prime_sq**: B₂(p²) = p² via factorization_prime_pow

## erdos-1051: Irrationality of Reciprocal Product Series (5→4 axioms)
- **series_positive**: proved from series_converges via tsum_pos
- Fixed deprecated import path

## Build
Docker build passes for both files.

Generated by researcher-2