### PR TITLE
Research: 3 proofs - erdos-1146 + erdos-1126 + erdos-1143

### DIFF
--- a/proofs/Proofs/Erdos1146Problem.lean
+++ b/proofs/Proofs/Erdos1146Problem.lean
@@ -141,12 +141,36 @@ theorem growth_satisfies_ruzsa_necessary :
     have hx_ge1 : x ≥ 1 := le_trans (le_max_left _ _) hN
     have hx_pos : 0 < x := lt_of_lt_of_le one_pos hx_ge1
     have hx_ge4C2 : x ≥ 4 / C ^ 2 := le_trans (le_max_right _ _) hN
-    -- The algebraic bound C·x² - x ≥ x^(3/2) for x ≥ max(1, 4/C²) follows from:
-    -- (1) C·√x ≥ 2, so C·x² = C·(√x)²·x ≥ 2·(x·√x) = 2·x^(3/2)
-    -- (2) x ≤ x^(3/2) for x ≥ 1
-    -- Combined: C·x² - x ≥ 2·x^(3/2) - x^(3/2) = x^(3/2)
-    -- TODO: formalize rpow algebra (rpow_add, sqrt_eq_rpow, sqrt bounds)
-    sorry
+    -- Convert x^(1+1/2) to x · √x via rpow_add and sqrt_eq_rpow
+    have h_eq : x ^ ((1 : ℝ) + 1 / 2) = x * Real.sqrt x := by
+      rw [Real.rpow_add hx_pos, Real.rpow_one, ← Real.sqrt_eq_rpow]
+    rw [h_eq]
+    -- Now goal: C * x ^ 2 - x ≥ x * √x. Let s = √x, so x = s².
+    set s := Real.sqrt x
+    have hs_nn : 0 ≤ s := Real.sqrt_nonneg x
+    have hsx : s ^ 2 = x := Real.sq_sqrt hx_pos.le
+    have hs1 : s ≥ 1 := by
+      have := Real.sqrt_le_sqrt hx_ge1; rwa [Real.sqrt_one] at this
+    -- From x ≥ 4/C², derive C·√x ≥ 2 (by contradiction)
+    have hCs : C * s ≥ 2 := by
+      by_contra h_lt; push_neg at h_lt
+      have h_nn := mul_nonneg hCpos.le hs_nn
+      -- (C·s)² < 4 since 0 ≤ C·s < 2
+      have h1 : (C * s) ^ 2 < 4 := by
+        nlinarith [mul_nonneg h_nn (show (0 : ℝ) ≤ 2 - C * s by linarith)]
+      -- (C·s)² = C²·x ≥ 4 since x ≥ 4/C²
+      have h2 : (C * s) ^ 2 ≥ 4 := by
+        have h_c2 := pow_pos hCpos 2
+        calc (C * s) ^ 2 = C ^ 2 * s ^ 2 := by ring
+          _ = C ^ 2 * x := by rw [hsx]
+          _ ≥ C ^ 2 * (4 / C ^ 2) := mul_le_mul_of_nonneg_left hx_ge4C2 h_c2.le
+          _ = 4 := by field_simp
+      linarith
+    -- Substitute x = s² and prove s³ ≤ C·s⁴ - s² by polynomial arithmetic
+    -- Decompose as s²·(C·s−2)·s + s²·(s−1), both nonneg
+    rw [show x = s ^ 2 from hsx.symm]
+    nlinarith [mul_nonneg (sq_nonneg s) (mul_nonneg (show (0 : ℝ) ≤ C * s - 2 by linarith) hs_nn),
+               mul_nonneg (sq_nonneg s) (show (0 : ℝ) ≤ s - 1 by linarith)]
   exact (hcount.and h_alg).mono fun N ⟨hcounting, halg⟩ => by
     have h_lower : (countingFunction smoothNumbers23 N : ℝ) ≥
         C * (Real.log (N : ℝ)) ^ 2 - Real.log (N : ℝ) := by

--- a/src/data/proofs/erdos-1146/meta.json
+++ b/src/data/proofs/erdos-1146/meta.json
@@ -17,7 +17,7 @@
       "smooth-numbers"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axioms": 2,
     "erdosNumber": 1146,
     "erdosUrl": "https://erdosproblems.com/1146",
@@ -67,8 +67,8 @@
       "additive-number-theory",
       "mann-theorem"
     ],
-    "lineCount": 238,
-    "assumptions": "2 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 287,
+    "assumptions": "2 axiom(s): smooth23_not_lacunary (deep: non-lacunary property of smooth numbers) and smooth23_schnirelmann_zero (provable but substantial: Schnirelmann density = 0)."
   },
   "overview": {
     "historicalContext": "Imre Ruzsa posed this problem in 1999, building on his resolution of Erdős Problem #37 about essential components in additive number theory. A set $B \\subseteq \\mathbb{N}$ is an *essential component* if $\\sigma(A + B) > \\sigma(A)$ for every set $A$ with $0 < \\sigma(A) < 1$, where $\\sigma$ denotes the Schnirelmann density. Ruzsa proved that essential components must have counting function growth $\\geq (\\log N)^{1+c}$ for some $c > 0$, ruling out lacunary sets (which have counting function $O(\\log N)$).\n\nThe set $\\{2^m \\cdot 3^n : m, n \\geq 0\\}$ of 3-smooth numbers has counting function $\\sim C(\\log N)^2$, placing it exactly at the threshold with $c = 1$. Ruzsa called this 'the simplest set with a chance to be an essential component,' making it a natural test case for the boundary between essential and non-essential sets in additive combinatorics.",
@@ -116,7 +116,7 @@
       "title": "Growth Rate Analysis",
       "startLine": 110,
       "endLine": 133,
-      "summary": "States that the (log N)² growth satisfies Ruzsa's necessary condition for essential components with c = 1/2 (sorry - routine analysis)."
+      "summary": "Proves that the (log N)² growth satisfies Ruzsa's necessary condition for essential components with c = 1/2. Uses rpow algebra: converts x^(3/2) to x·√x, then polynomial arithmetic via √x substitution."
     },
     {
       "id": "density",
@@ -154,7 +154,7 @@
       "Is {2^m · 3^n} an essential component? (THIS problem — Erdős #1146)",
       "For k-smooth numbers {p₁^a₁ · ... · pₖ^aₖ} with counting ~ (log N)^k, for which k is the set essential?",
       "What is the precise relationship between residue class distribution and essential component property?",
-      "Can the growth_satisfies_ruzsa_necessary sorry be eliminated using Mathlib's asymptotic analysis?"
+      "Can the smooth23_schnirelmann_zero axiom be proved from smooth23_counting via iInf/Tendsto?"
     ],
     "crossReferences": [
       {
@@ -220,7 +220,7 @@
       "Erdos37"
     ],
     "namespace": "Erdos1146",
-    "lineCount": 238,
+    "lineCount": 287,
     "axiomCount": 2,
     "theoremCount": 13,
     "definitionCount": 2

--- a/src/data/research/problems/erdos-1146.json
+++ b/src/data/research/problems/erdos-1146.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-1146",
-  "title": "Erd\u0151s #1146",
+  "title": "Erdős #1146",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
@@ -29,10 +29,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED+: Sorry narrowed from full theorem to specific algebraic step (C\u00b7x\u00b2-x \u2265 x^(3/2) for large x). 2 axioms assessed as deep/substantial. 13 theorems fully proved.",
+    "progressSummary": "COMPLETED: All sorries eliminated. Proved growth_satisfies_ruzsa_necessary via rpow→sqrt conversion and polynomial arithmetic. File has 0 sorries, 2 axioms (both deep/substantial), 13 proved theorems.",
     "builtItems": [
       "Narrowed sorry in growth_satisfies_ruzsa_necessary to algebraic rpow bound",
-      "Proof structure: filter_upwards combines counting approx with algebraic bound"
+      "Proof structure: filter_upwards combines counting approx with algebraic bound",
+      "Proved growth_satisfies_ruzsa_necessary: rpow_add + sqrt substitution + nlinarith"
     ],
     "insights": [
       "File has only 2 axioms and 1 sorry - very clean formalization",
@@ -40,15 +41,17 @@
       "Proof structure: filter_upwards + abs bound + algebraic step",
       "smooth23_not_lacunary: deep result about ratios of smooth numbers, keep as axiom",
       "smooth23_schnirelmann_zero: provable from smooth23_counting via iInf/Tendsto but substantial",
-      "Imports Erdos37Problem which has 6 axioms (mann_theorem, schnirelmann_theorem, etc.)"
+      "Imports Erdos37Problem which has 6 axioms (mann_theorem, schnirelmann_theorem, etc.)",
+      "rpow algebra pattern: use rpow_add to split x^(1+1/2) into x^1 * x^(1/2), then sqrt_eq_rpow to convert to sqrt",
+      "Polynomial bound via contradiction: C*sqrt(x) >= 2 from (C*s)^2 >= 4 and C*s >= 0",
+      "Key decomposition: C*s^4 - s^3 - s^2 = s^2*(C*s-2)*s + s^2*(s-1), both nonneg"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Fill rpow algebra sorry: use rpow_add, sqrt_eq_rpow, sqrt bounds",
-      "Prove smooth23_schnirelmann_zero from smooth23_counting",
-      "Consider companion Aristotle file for rpow algebra step"
+      "Prove smooth23_schnirelmann_zero from smooth23_counting (substantial but achievable)",
+      "Consider proving smooth23_not_lacunary from 3-distance theorem"
     ],
-    "markdown": "# Erd\u0151s #1146 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erdős #1146 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
Three concrete proof contributions across three problems:

### 1. erdos-1146: Prove growth_satisfies_ruzsa_necessary (sorry → proof)
- Proved the rpow algebra bound: C·x² - x ≥ x^(3/2) for x ≥ max(1, 4/C²)
- Technique: rpow_add + sqrt_eq_rpow → polynomial substitution → nlinarith
- **Result**: 1 sorry → 0 sorries

### 2. erdos-1126: Prove additive_ae_unique (axiom → theorem) 
- Proved from additive_zero_ae via Pi.sub + sub_eq_zero
- **Result**: 6 axioms → 5 axioms

### 3. erdos-1143: Prove expectedDensity_pos and expectedDensity_lt_one
- Products of (1-1/p) bounded in (0,1) for primes p ≥ 2
- Technique: mul_prod_erase + mul_le_of_le_one_right + Finset.prod_pos
- **Result**: 4 sorries → 2 sorries

### Plus surveys on 4 additional problems
- erdos-949, erdos-1071, erdos-1008-oq-01, brouwer-fixed-point-oq-04

## All builds verified via Docker

🤖 Generated by researcher-3