### PR TITLE
Fix: stale metadata for erdos-953, erdos-731, erdos-1051

### DIFF
--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/1051",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
-    "lineCount": 106,
+    "lineCount": 112,
     "assumptions": "4 axioms: rapid_growth_irrational, series_converges, simple_series_question, sylvester_fibonacci_example. series_positive proved from series_converges via tsum_pos.",
     "mathlib_version": "4.26.0"
   },
@@ -227,7 +227,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 106,
+    "lineCount": 112,
     "axiomCount": 4,
     "theoremCount": 1,
     "definitionCount": 4

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/731",
     "erdosProblemStatus": "open",
     "axiomCount": 7,
-    "lineCount": 115,
+    "lineCount": 105,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",
@@ -136,7 +136,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 115,
+    "lineCount": 105,
     "axiomCount": 7,
     "theoremCount": 5,
     "definitionCount": 3

--- a/src/data/proofs/erdos-953/meta.json
+++ b/src/data/proofs/erdos-953/meta.json
@@ -60,8 +60,8 @@
       "singleton_avoids and pair_half_avoids verified examples"
     ],
     "axiomCount": 8,
-    "lineCount": 318,
-    "assumptions": "8 axioms: trivial_upper_bound, circle_separation, kovac_lower_bound, thin_annulus_property, erdos_465_upper, erdos_466_lower, erdos_953_asymptotic, erdos_953. (sarkozy_exponent_exists is a theorem, not an axiom.)"
+    "lineCount": 319,
+    "assumptions": "8 axioms: trivial_upper_bound, circle_separation, kovac_lower_bound, thin_annulus_property, erdos_465_upper, erdos_466_lower, erdos_953_asymptotic, erdos_953."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #953** is a joint problem of Paul Erdős and András Sárközi from around 1980, addressing a natural geometric-measure-theoretic question: how large (in Lebesgue measure) can a subset of a disk be if no two of its points are at integer distance? Erdős himself remarked that 'Sárközi has the sharpest results, but nothing has been published yet,' highlighting how this problem circulated informally among Hungarian combinatorialists before appearing in print.\n\n**Origins and Context:**\nThe problem sits at the intersection of combinatorial geometry and measure theory, extending classical Erdős distance problems to a continuous setting. While Erdős's famous 1946 distinct distances problem (with Gallai) concerns finite point sets, Problem #953 shifts the focus to measurable sets in the plane, asking how metric constraints on pairwise distances limit the 'size' of a set in the Lebesgue sense.\n\n**Key Contributors:**\n- **András Sárközi** (1936–2024): Hungarian mathematician known for foundational results in additive combinatorics, including the Szemerédi–Sárközi theorem on difference sets containing perfect squares. His unpublished methods on this problem informed later work.\n- **Vjekoslav Kovač**: Croatian mathematician who adapted Sárközy's methods from Erdős Problem #466 to obtain the current best lower bound of $r^{0.26}$ for the maximum measure.\n- The problem is closely related to Erdős Problems #465 and #466, which treat the unit distance case and represent the 'one forbidden distance' variant of this 'all integer distances forbidden' problem.\n\n**Mathematical Landscape:**\nThe $O(r)$ upper bound follows from a geometric slicing argument: a set avoiding integer distances cannot intersect too many concentric circles whose radii differ by integers. The lower bound $r^{0.26}$ uses deep ideas from additive combinatorics—specifically, constructions related to sum-free sets and difference sets that avoid prescribed residues. The enormous gap between these bounds reveals how poorly understood the geometry of integer-distance-avoiding sets remains.",
@@ -194,9 +194,9 @@
       "Real"
     ],
     "namespace": "Erdos953",
-    "lineCount": 318,
+    "lineCount": 319,
     "axiomCount": 8,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 5
   }
 }


### PR DESCRIPTION
## Fix

Update meta.json for 3 proofs with stale metadata after recent research PRs.

## Changes

**erdos-953** (after research PR #5975 - proved sarkozy_exponent_exists):
- axiomCount: 9 → 8
- lineCount: 318 → 319
- theoremCount: 12 → 13 (leanFile section)
- assumptions: removed sarkozy_exponent_exists from axiom list

**erdos-731** (after research PR #5973):
- lineCount: 115 → 105

**erdos-1051** (after research PR #5979):
- lineCount: 106 → 112

## Evidence

Verified by `grep -c "^axiom "` and `wc -l` against Lean source files.

---
Automated fix by lean-mechanic agent.