### PR TITLE
Enrichment batch: 5 proofs (JSON fixes, add text/refs)

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-02/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-02/meta.json
@@ -158,6 +158,7 @@
   "overview": {
     "historicalContext": "Johann Faulhaber (1631) published closed-form expressions for sums of consecutive kth powers, extending work by al-Haytham (c. 1000) and Bernoulli. The reciprocal series sum 1/n^2 was posed as the Basel Problem by Pietro Mengoli in 1644 and resisted solution for 90 years. Euler's breakthrough in 1734, showing zeta(2) = pi^2/6, stunned contemporary mathematicians by linking a discrete arithmetic sum to the circle constant. Euler subsequently computed zeta(2k) for all positive integers k using Bernoulli numbers and powers of pi. The convergence dichotomy at s = 1 — the harmonic series diverges while sum 1/n^s converges for any s > 1 — was first observed by Nicole Oresme (c. 1360) and later connected to the prime number theorem via the Euler product zeta(s) = prod (1 - p^{-s})^{-1}. Riemann's 1859 memoir extended zeta(s) to complex s via analytic continuation, transforming number theory forever.",
     "problemStatement": "Extend Faulhaber integer power sums to real exponents via zeta(s) = sum 1/n^s.",
+    "text": "A 175-line formalization extending Faulhaber's integer power sum formulas to real exponents via the Riemann zeta function $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$. The proof establishes the convergence dichotomy (the $p$-series converges iff $s > 1$), recovers the Basel problem $\\zeta(2) = \\pi^2/6$ and $\\zeta(4) = \\pi^4/90$ from Mathlib, proves term-wise and sum-wise antitonicity of $\\zeta(s)$ in $s$, derives bounds $1 \\leq \\zeta(s) \\leq \\pi^2/6$ for $s \\geq 2$, shows partial sum convergence and monotonicity, and bridges real-exponent theory back to integer power sums via `rpow_natCast`. All 14 theorems are fully verified with 0 sorries and 0 axioms, building on Mathlib's `summable_nat_rpow_inv`, `hasSum_zeta_two`, and `hasSum_zeta_four`.",
     "proofStrategy": "Eight parts: convergence dichotomy, known values, term monotonicity, zeta monotonicity, bounds, partial sums, bridge to integers. Fully verified.",
     "keyInsights": [
       "P-series threshold at s=1 separates convergent from divergent power-law decay",
@@ -202,6 +203,36 @@
       "targetId": "riemann-hypothesis",
       "relationship": "foundational",
       "description": "Basic properties of zeta(s) for real s > 1"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "De summis serierum reciprocarum",
+      "year": "1734",
+      "venue": "Commentarii academiae scientiarum Petropolitanae 7, pp. 123-134 (published 1740)",
+      "note": "First proof that ζ(2) = π²/6 (the Basel problem), using the product formula for sin(x)/x — one of the most celebrated results in analysis"
+    },
+    {
+      "authors": "Hardy, G.H.; Wright, E.M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "Standard reference for the zeta function, Bernoulli numbers, and their connection to power sums (Chapter XVII)"
+    },
+    {
+      "authors": "Titchmarsh, E.C.",
+      "title": "The Theory of the Riemann Zeta-Function",
+      "year": "1986",
+      "venue": "Oxford University Press, 2nd edition (revised by D.R. Heath-Brown)",
+      "note": "Definitive monograph on ζ(s) including convergence, analytic continuation, functional equation, and the Euler product"
+    },
+    {
+      "authors": "Knuth, Donald E.",
+      "title": "Johann Faulhaber and sums of powers",
+      "year": "1993",
+      "venue": "Mathematics of Computation 61(203), pp. 277-294",
+      "note": "Historical analysis of Faulhaber's 1631 formulas for power sums, establishing his priority and mathematical sophistication"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **abel-ruffini**: Merged duplicate `leanFile` keys, recovering `mainTheorems` (3 entries)
- **erdos-428**: Removed duplicate `sorries` key (incorrect `0` → correct `1`)
- **chinese-remainder-constructive-oq-04**: Added `overview.text`, 4 cross-references, 5 references
- **erdos-1160**: Added `overview.text`, 5 scholarly references, `relatedProofs` array
- **sum-of-kth-powers-oq-02**: Added `overview.text`, 4 top-level references

Scanned all 1522 gallery entries for duplicate JSON keys; abel-ruffini and erdos-428 were the only two with same-level duplicate keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)