### PR TITLE
Research: erdos-963 - Prove log_base_gap axiom (7→6 axioms)

### DIFF
--- a/proofs/Proofs/Erdos963Problem.lean
+++ b/proofs/Proofs/Erdos963Problem.lean
@@ -13,6 +13,9 @@ f(n) ≥ ⌊log₂ n⌋.
 - A dissociated set of size k has 2^k distinct subset sums
 - Powers of 2 form a dissociated set (binary representation)
 
+Axiom count: 6 (was 7; proved log_base_gap)
+Sorry count: 0
+
 ## References
 
 - [Er65] Erdős original formulation
@@ -132,6 +135,8 @@ axiom powers_of_two_dissociated :
 axiom maxDissociatedSize_mono :
   ∀ m n : ℕ, m ≤ n → maxDissociatedSize m ≤ maxDissociatedSize n
 
-/-- The gap between the greedy bound and the conjecture: log₂ vs log₃. -/
-axiom log_base_gap :
-  ∀ n : ℕ, n ≥ 2 → Nat.log 3 n ≤ Nat.log 2 n
+/-- **PROVED** (was axiom): The gap between the greedy bound and the conjecture: log₂ vs log₃.
+    Since 2 ≤ 3, log₃ n ≤ log₂ n for all n. -/
+theorem log_base_gap :
+    ∀ n : ℕ, n ≥ 2 → Nat.log 3 n ≤ Nat.log 2 n :=
+  fun n _ => Nat.log_anti_left (by omega) n

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 963,
     "erdosUrl": "https://erdosproblems.com/963",
     "erdosProblemStatus": "open",
-    "axiomCount": 7,
-    "lineCount": 137,
-    "assumptions": "7 axioms: dissociated_subset_sum_count, erdos_963_conjecture, greedy_lower_bound, and 4 more. See Lean source for complete statements.",
+    "axiomCount": 6,
+    "lineCount": 140,
+    "assumptions": "6 axioms: dissociated_subset_sum_count, erdos_963_conjecture, greedy_lower_bound, trivial_upper_bound, powers_of_two_dissociated, maxDissociatedSize_mono. log_base_gap proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-963.json
+++ b/src/data/research/problems/erdos-963.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-963",
   "title": "Erdős #963",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-15T12:36:36.408Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,9 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved log_base_gap axiom (7→6 axioms remaining)",
+    "builtItems": [
+      "Proved log_base_gap: Nat.log 3 n <= Nat.log 2 n"
+    ],
+    "insights": [
+      "Nat.log_anti_left provides log base monotonicity"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #963 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $f(n)$ be the maximal $k$ such that in any set $A\\subset \\mathbb{R}$ of size $n$ there is a subset $B\\subseteq A$ of size $\\lvert B\\rvert\\geq k$ which is dissociated that is, the sums $\\sum_{b\\in S}b$ are distinct for all $S\\subseteq B$. Estimate $f(n)$ - in particular, is it true that\\[f(n)\\geq \\lfloor \\log_2 n\\rfloor?\\]\n\n\n\nErd\\H{o}s noted that the greedy algorithm showed $f(n)\\geq \\lfloor \\log_3 n\\rfloor$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #962\n- Problem #964\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #7\n\n## References\n\n- Er65\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
@@ -57,9 +61,9 @@
     {
       "path": "Proofs/Erdos963Problem.lean",
       "filename": "Erdos963Problem.lean",
-      "lineCount": 138,
-      "theoremCount": 2,
-      "axiomCount": 7,
+      "lineCount": 140,
+      "theoremCount": 3,
+      "axiomCount": 6,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Prove `log_base_gap` axiom: Nat.log 3 n ≤ Nat.log 2 n
- Axiom count reduced from 7 to 6

## Changes
- Replaced `axiom log_base_gap` with `theorem log_base_gap` using `Nat.log_anti_left`
- Updated meta.json axiom count
- Updated problem knowledge

🤖 Generated by researcher-4