### PR TITLE
Research: erdos-345 + erdos-963 + erdos-1051 - Prove 8 axioms, fix builds

### DIFF
--- a/proofs/Proofs/Erdos345Problem.lean
+++ b/proofs/Proofs/Erdos345Problem.lean
@@ -18,6 +18,8 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Basic
 import Mathlib.Tactic
 
+namespace Erdos345
+
 /- ## Subset sums and completeness -/
 
 /-- The set of finite subset sums of `A ⊆ ℕ`. -/
@@ -26,7 +28,7 @@ def subsetSums (A : Set ℕ) : Set ℕ :=
 
 /-- A sequence `A` is complete if all sufficiently large integers are
 in `P(A)`. -/
-def IsComplete (A : Set ℕ) : Prop :=
+def IsCompleteSeq (A : Set ℕ) : Prop :=
     ∃ m : ℕ, ∀ n : ℕ, m ≤ n → n ∈ subsetSums A
 
 /- ## Completeness threshold -/
@@ -37,12 +39,12 @@ minimum requires decidability. -/
 axiom threshold : Set ℕ → ℕ
 
 /-- `threshold A` is correct: all `n ≥ T(A)` are in `P(A)`. -/
-axiom threshold_spec (A : Set ℕ) (hA : IsComplete A) :
+axiom threshold_spec (A : Set ℕ) (hA : IsCompleteSeq A) :
     ∀ n : ℕ, threshold A ≤ n → n ∈ subsetSums A
 
 /-- `threshold A` is minimal: some `n < T(A)` is not in `P(A)`,
 unless `T(A) = 0`. -/
-axiom threshold_minimal (A : Set ℕ) (hA : IsComplete A)
+axiom threshold_minimal (A : Set ℕ) (hA : IsCompleteSeq A)
     (ht : 0 < threshold A) :
     ∃ n : ℕ, n < threshold A ∧ n ∉ subsetSums A
 
@@ -52,8 +54,15 @@ axiom threshold_minimal (A : Set ℕ) (hA : IsComplete A)
 def powerSeq (k : ℕ) : Set ℕ :=
     { m | ∃ n : ℕ, 1 ≤ n ∧ m = n ^ k }
 
-/-- The sequence of natural numbers is complete with `T(n) = 1`. -/
-axiom powerSeq_1_complete : IsComplete (powerSeq 1)
+/-- The sequence of natural numbers is complete with `T(n) = 1`.
+    Every n ≥ 1 is a subset sum of {1^1, 2^1, 3^1, ...} via the singleton {n}. -/
+theorem powerSeq_1_complete : IsCompleteSeq (powerSeq 1) := by
+  refine ⟨1, fun n hn => ?_⟩
+  refine ⟨{n}, ?_, ?_⟩
+  · simp only [Finset.coe_singleton, Set.singleton_subset_iff]
+    exact ⟨n, hn, (pow_one n).symm⟩
+  · simp
+
 axiom threshold_powerSeq_1 : threshold (powerSeq 1) = 1
 
 /- ## Known threshold values -/
@@ -75,7 +84,7 @@ axiom threshold_fifth : threshold (powerSeq 5) = 67898771
 /-- Power sequences `{n^k}` are complete for all `k ≥ 1`
 (Waring's problem guarantees this). -/
 axiom powerSeq_complete (k : ℕ) (hk : 1 ≤ k) :
-    IsComplete (powerSeq k)
+    IsCompleteSeq (powerSeq k)
 
 /- ## Main conjecture -/
 
@@ -87,10 +96,15 @@ def ErdosProblem345 : Prop :=
 
 /- ## Monotonicity observations -/
 
-/-- The known values suggest `T(n^k)` is rapidly increasing, but the
-conjecture asks whether the sequence ever decreases. -/
-axiom threshold_mono_small :
+/-- The known values show `T(n^k)` is rapidly increasing for small k:
+    1 < 128 < 12758 < 5134240 < 67898771. -/
+theorem threshold_mono_small :
     threshold (powerSeq 1) < threshold (powerSeq 2) ∧
     threshold (powerSeq 2) < threshold (powerSeq 3) ∧
     threshold (powerSeq 3) < threshold (powerSeq 4) ∧
-    threshold (powerSeq 4) < threshold (powerSeq 5)
+    threshold (powerSeq 4) < threshold (powerSeq 5) := by
+  rw [threshold_powerSeq_1, threshold_squares, threshold_cubes,
+      threshold_fourth, threshold_fifth]
+  omega
+
+end Erdos345

--- a/proofs/Proofs/Erdos963Problem.lean
+++ b/proofs/Proofs/Erdos963Problem.lean
@@ -13,7 +13,7 @@ f(n) ≥ ⌊log₂ n⌋.
 - A dissociated set of size k has 2^k distinct subset sums
 - Powers of 2 form a dissociated set (binary representation)
 
-Axiom count: 6 (was 7; proved log_base_gap)
+Axiom count: 5 (was 7; proved log_base_gap, dissociated_subset_sum_count)
 Sorry count: 0
 
 ## References
@@ -23,9 +23,10 @@ Sorry count: 0
 - <https://erdosproblems.com/963>
 -/
 
-import Mathlib.Combinatorics.Additive.Dissociated
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Real.Basic
+import Mathlib.Data.Nat.Log
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Tactic
 
@@ -44,10 +45,16 @@ noncomputable def maxDissociatedSize (n : ℕ) : ℕ :=
 
 /- ## Subset Sum Counting -/
 
-/-- A dissociated set of size k has exactly 2^k distinct subset sums. -/
-axiom dissociated_subset_sum_count :
+/-- **PROVED** (was axiom): A dissociated set of size k has exactly 2^k
+    distinct subset sums. The dissociated condition means the sum map is
+    injective on the powerset, so the image has cardinality 2^|B|. -/
+theorem dissociated_subset_sum_count :
   ∀ (B : Finset ℝ), (∀ S T : Finset ℝ, S ⊆ B → T ⊆ B → S.sum id = T.sum id → S = T) →
-    (Finset.image (fun S => S.sum id) B.powerset).card = 2 ^ B.card
+    (Finset.image (fun S => S.sum id) B.powerset).card = 2 ^ B.card := by
+  intro B hdiss
+  rw [Finset.card_image_of_injOn, Finset.card_powerset]
+  intro S hS T hT heq
+  exact hdiss S T (Finset.mem_powerset.mp hS) (Finset.mem_powerset.mp hT) heq
 
 /- ## Main Conjecture -/
 
@@ -85,45 +92,19 @@ theorem empty_dissociated (A : Finset ℝ) : IsDissociatedSubset A ∅ := by
     rw [Finset.subset_empty] at hS hT
     rw [hS, hT]
 
-/-- Any singleton subset is dissociated. -/
-theorem singleton_dissociated (A : Finset ℝ) (a : ℝ) (ha : a ∈ A) :
+/-- Any singleton {a} with a ≠ 0 is dissociated (subsets ∅ and {a}
+    have distinct sums 0 and a). -/
+theorem singleton_dissociated (A : Finset ℝ) (a : ℝ) (ha : a ∈ A) (ha0 : a ≠ 0) :
     IsDissociatedSubset A {a} := by
   constructor
   · exact Finset.singleton_subset_iff.mpr ha
   · intro S T hS hT hsum
-    ext x
-    simp only [Finset.mem_singleton] at hS hT ⊢
-    constructor
-    · intro hx
-      have := hS hx
-      rw [this] at hx ⊢
-      by_contra h
-      have hT_empty : T = ∅ := by
-        ext y
-        simp only [Finset.mem_empty, iff_false]
-        intro hy
-        exact h (hT hy)
-      rw [hT_empty] at hsum
-      simp [Finset.sum_singleton] at hsum
-      rw [Finset.subset_singleton_iff] at hS
-      cases hS with
-      | inl h_empty => rw [h_empty] at hx; exact (Finset.not_mem_empty x) hx
-      | inr h_eq => rw [h_eq] at hsum; simp at hsum
-    · intro hx
-      have := hT hx
-      rw [this] at hx ⊢
-      by_contra h
-      have hS_empty : S = ∅ := by
-        ext y
-        simp only [Finset.mem_empty, iff_false]
-        intro hy
-        exact h (hS hy)
-      rw [hS_empty] at hsum
-      simp [Finset.sum_singleton] at hsum
-      rw [Finset.subset_singleton_iff] at hT
-      cases hT with
-      | inl h_empty => rw [h_empty] at hx; exact (Finset.not_mem_empty x) hx
-      | inr h_eq => rw [h_eq] at hsum; simp at hsum
+    rw [Finset.subset_singleton_iff] at hS hT
+    rcases hS with rfl | rfl <;> rcases hT with rfl | rfl
+    · rfl
+    · simp at hsum; exfalso; exact ha0 hsum.symm
+    · simp at hsum; exfalso; exact ha0 hsum
+    · rfl
 
 /-- Powers of 2 form a dissociated set (binary representation uniqueness). -/
 axiom powers_of_two_dissociated :
@@ -135,8 +116,9 @@ axiom powers_of_two_dissociated :
 axiom maxDissociatedSize_mono :
   ∀ m n : ℕ, m ≤ n → maxDissociatedSize m ≤ maxDissociatedSize n
 
-/-- **PROVED** (was axiom): The gap between the greedy bound and the conjecture: log₂ vs log₃.
-    Since 2 ≤ 3, log₃ n ≤ log₂ n for all n. -/
+/-- **PROVED** (was axiom): The gap between the greedy bound and the
+    conjecture: log₂ vs log₃. Since 2 ≤ 3, log₃ n ≤ log₂ n for all n. -/
 theorem log_base_gap :
-    ∀ n : ℕ, n ≥ 2 → Nat.log 3 n ≤ Nat.log 2 n :=
-  fun n _ => Nat.log_anti_left (by omega) n
+    ∀ n : ℕ, n ≥ 2 → Nat.log 3 n ≤ Nat.log 2 n := by
+  intro n _
+  apply Nat.log_anti_left <;> omega

--- a/src/data/proofs/erdos-345/meta.json
+++ b/src/data/proofs/erdos-345/meta.json
@@ -52,8 +52,8 @@
       "threshold_mono_small axiom"
     ],
     "axiomCount": 9,
-    "lineCount": 96,
-    "assumptions": "9 axioms: threshold, threshold_spec, threshold_minimal, threshold_powerSeq_1, threshold_squares, threshold_cubes, threshold_fourth, threshold_fifth, powerSeq_complete."
+    "lineCount": 112,
+    "assumptions": "9 axioms: threshold (function), threshold_spec, threshold_minimal, threshold_powerSeq_1, threshold_squares, threshold_cubes, threshold_fourth, threshold_fifth, powerSeq_complete. 2 proved: powerSeq_1_complete, threshold_mono_small."
   },
   "overview": {
     "historicalContext": "The notion of **complete sequences** — sets whose subset sums eventually cover all integers — was systematically studied by Erdős and Graham in their 1980 monograph. The **completeness threshold** $T(A)$ measures the onset of full representability. For the sequence of positive integers, $T(\\{n\\}) = 1$ trivially (binary representation). For squares, Sprague (1948) showed completeness, and the exact value $T(n^2) = 128$ was computed by Wright (1960s). Hilbert's resolution of **Waring's problem** (1909) guarantees that $k$-th power sequences are complete for all $k$, but the threshold $T(n^k)$ measures representability by **distinct** $k$-th powers, a finer and harder question. The exact values $T(n^3) = 12758$, $T(n^4) = 5134240$, $T(n^5) = 67898771$ were determined by exhaustive computation. Despite the rapid growth, Erdős and Graham conjectured that the sequence $T(n^k)$ is **not eventually monotone** — that threshold reversals $T(n^k) > T(n^{k+1})$ occur infinitely often, perhaps at $k = 2^t$ for large $t$.",
@@ -178,7 +178,7 @@
     "namespace": null,
     "lineCount": 96,
     "axiomCount": 9,
-    "theoremCount": 0,
+    "theoremCount": 2,
     "definitionCount": 4
   },
   "relatedProofs": [

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 963,
     "erdosUrl": "https://erdosproblems.com/963",
     "erdosProblemStatus": "open",
-    "axiomCount": 6,
-    "lineCount": 140,
-    "assumptions": "6 axioms: dissociated_subset_sum_count, erdos_963_conjecture, greedy_lower_bound, trivial_upper_bound, powers_of_two_dissociated, maxDissociatedSize_mono. log_base_gap proved.",
+    "axiomCount": 5,
+    "lineCount": 124,
+    "assumptions": "5 axioms: erdos_963_conjecture, greedy_lower_bound, trivial_upper_bound, powers_of_two_dissociated, maxDissociatedSize_mono. Proved: dissociated_subset_sum_count (card_image_of_injOn), log_base_gap (Nat.log_anti_left).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-345.json
+++ b/src/data/research/problems/erdos-345.json
@@ -29,9 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Reduced axiom count from 11 to 9. Proved completeness of linear powers and monotonicity of thresholds.",
+    "builtItems": [
+      "Proved powerSeq_1_complete in Erdos345Problem.lean",
+      "Proved threshold_mono_small in Erdos345Problem.lean"
+    ],
+    "insights": [
+      "Proved powerSeq_1_complete: {n^1 : n ≥ 1} is complete (every n ≥ 1 = sum of {n})",
+      "Proved threshold_mono_small from concrete values via omega",
+      "Renamed IsComplete → IsCompleteSeq to avoid Mathlib conflict, added Erdos345 namespace"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #345 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A\\subseteq \\mathbb{N}$ be a complete sequence, and define the threshold of completeness $T(A)$ to be the least integer $m$ such that all $n\\geq m$ are in\\[P(A) = \\left\\{\\sum_{n\\in B}n : B\\subseteq A\\textrm{ finite }\\right\\}\\](the existence of $T(A)$ is guaranteed by completeness).\n\nIs it true that there are infinitely many $k$ such that $T(n^k)>T(n^{k+1})$?\n\n\n\nErd\\H{o}s and Graham \\cite{ErGr80} remark that very little is known about $T(A)$ in general. It is known that\\[T(n)=1, T(n^2)=128, T(n^3)=12758,\\]\\[T(n^4)=5134240,\\textrm{ and }T(n^5)=67898771.\\]Erd\\H{o}s and Graham remark that a good candidate for the $n$ in the question are $k=2^t$ for large $t$, perhaps even $t=3$, because of the highly restricted values of $n^{2^t}$ modulo $2^{t+1}$.\n\n\n\n\nReferences\n\n\n[ErGr80] Erd\\H{o}s, P. and Graham, R., Old and new problems and results in combinatorial number theory. Monographies de L'Enseignement Mathematique (1980).\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #344\n- Problem #346\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
@@ -58,8 +65,8 @@
       "path": "Proofs/Erdos345Problem.lean",
       "filename": "Erdos345Problem.lean",
       "lineCount": 97,
-      "theoremCount": 0,
-      "axiomCount": 11,
+      "theoremCount": 2,
+      "axiomCount": 9,
       "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
Research session proving axioms and fixing build issues across three problems.

## erdos-345: Completeness Thresholds (11→9 axioms)
- **powerSeq_1_complete**: proved {n^1} is complete via singleton subset sums
- **threshold_mono_small**: proved from value axioms via omega
- Added namespace, renamed IsComplete to avoid Mathlib conflict

## erdos-963: Dissociated Subsets (7→5 axioms, fixed broken build)
- **dissociated_subset_sum_count**: proved via Finset.card_image_of_injOn
- **log_base_gap**: proved via Nat.log_anti_left
- Fixed broken import (Mathlib.Combinatorics.Additive.Dissociated doesn't exist)
- Fixed singleton_dissociated proof (added a ≠ 0 hypothesis)
- File was previously unbuildable; now compiles clean

## erdos-1051: Irrationality Series (5→4 axioms)
- **series_positive**: proved from series_converges via tsum_pos
- Fixed deprecated import

## Build
Docker build passes for all three files.

Generated by researcher-2