### PR TITLE
Fix: stale leanFile metadata in 10 gallery proofs (batch 4)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -50,7 +50,7 @@
       }
     ],
     "leanFile": {
-      "lineCount": 7446,
+      "lineCount": 7437,
       "structureCount": 92,
       "axiomCount": 21,
       "theoremCount": 254,

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -84,7 +84,7 @@
         "Metric"
       ],
       "namespace": "Brouwer",
-      "lineCount": 250,
+      "lineCount": 249,
       "axiomCount": 2,
       "theoremCount": 5,
       "definitionCount": 6

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -59,7 +59,7 @@
       "erdos_1091_summary: verified combined result"
     ],
     "leanFile": {
-      "lineCount": 209,
+      "lineCount": 208,
       "structureCount": 2,
       "axiomCount": 7,
       "theoremCount": 4,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -36,11 +36,11 @@
     ],
     "assumptions": "2 axiom(s) and 2 sorry(s).",
     "leanFile": {
-      "lineCount": 5735,
-      "theoremCount": 374,
+      "lineCount": 1881,
+      "theoremCount": 107,
       "lemmaCount": 1,
-      "defCount": 9,
-      "axiomCount": 3,
+      "defCount": 1,
+      "axiomCount": 2,
       "sorryCount": 2,
       "imports": [
         "Mathlib.NumberTheory.Cyclotomic.Basic",

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -51,7 +51,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 353,
+      "lineCount": 352,
       "structures": 2,
       "axioms": 2,
       "theorems": 6,

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 322,
+      "lineCount": 321,
       "structures": 1,
       "axioms": 1,
       "theorems": 1,

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -64,7 +64,7 @@
     ],
     "dateAdded": "2026-03-06",
     "leanFile": {
-      "lineCount": 721,
+      "lineCount": 710,
       "structures": 2,
       "axioms": 3,
       "theorems": 34,

--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 490,
+      "lineCount": 489,
       "structures": 1,
       "axioms": 2,
       "theorems": 12,

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -75,13 +75,13 @@
       "590 theorems proved, 137 structures defined, 218 definitions, 82 parts across 11574 lines"
     ],
     "leanFile": {
-      "lineCount": 17302,
-      "theoremCount": 922,
+      "lineCount": 17668,
+      "theoremCount": 897,
       "lemmaCount": 0,
-      "defCount": 382,
-      "axiomCount": 36,
+      "defCount": 365,
+      "axiomCount": 32,
       "sorryCount": 0,
-      "structureCount": 229,
+      "structureCount": 183,
       "instanceCount": 21,
       "parts": 100,
       "note": "Single file formalization. 100 parts covering: topology of S³ and S^n, closed manifolds, simple connectivity, Perelman's proof strategy, counterexamples, geometrization, connected sum theory, covering spaces, Hopf fibration, knot surgery, JSJ decomposition, foliations, Papakyriakopoulos results, Heegaard Floer homology, L-space conjecture, contact structures, Virtual Haken conjecture, Gordon-Luecke theorem, Chern-Simons theory, h-cobordism, TQFT axioms, κ-solutions, surgery algorithm, Kneser-Milnor, finite extinction, proof architecture, generalized Poincaré, open problems, legacy."

--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -57,7 +57,7 @@
         "Subgroup"
       ],
       "namespace": "SylowTheorems",
-      "lineCount": 247,
+      "lineCount": 246,
       "axiomCount": 0,
       "theoremCount": 10,
       "definitionCount": 1


### PR DESCRIPTION
## Fix

Update stale `leanFile` metadata (lineCount, theoremCount, defCount, axiomCount, structureCount) in 10 gallery proofs to match current Lean source files.

## Evidence

**Proofs fixed (lineCount only):**
- birch-swinnerton-dyer: 7446 → 7437
- brouwer-fixed-point: 250 → 249
- erdos-1091: 209 → 208
- morleys-theorem: 353 → 352
- pascals-hexagon: 322 → 321
- picks-theorem-oq-03: 721 → 710
- picks-theorem: 490 → 489
- sylow-theorems: 247 → 246

**Proofs fixed (multiple fields):**
- inverse-galois: lineCount 5735→1881, theoremCount 374→107, defCount 9→1, axiomCount 3→2 (file was significantly refactored into multi-file structure)
- poincare-conjecture: lineCount 17302→17668, theoremCount 922→897, defCount 382→365, axiomCount 36→32, structureCount 229→183

---
Automated fix by lean-mechanic agent.