### PR TITLE
Fix: 9 proofs falsely claiming verified status

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "area-of-circle-oq-03-oq-02",
   "title": "Archimedes Pi Bounds: 223/71 < π < 22/7",
   "slug": "area-of-circle-oq-03-oq-02",
-  "description": "Archimedes' classical bounds on π from inscribed and circumscribed 96-gons: 223/71 < π < 22/7. Fully verified — both bounds proved from Mathlib's pi_gt_d4/pi_lt_d4, 0 axioms, 0 sorries.",
+  "description": "Archimedes' classical bounds on π from inscribed and circumscribed 96-gons: 223/71 < π < 22/7. Both bounds proved from Mathlib's pi_gt_d4/pi_lt_d4, 0 axioms, 1 sorry remaining.",
   "meta": {
     "author": "Archimedes (c. 250 BCE), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Archimedes",
     "date": "-250",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "geometry",
       "analysis",
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Core π bounds derived from Mathlib's pi_gt_d4 and pi_lt_d4.",
+    "assumptions": "0 axioms, 1 sorry. Core π bounds derived from Mathlib's pi_gt_d4 and pi_lt_d4.",
     "lineCount": 102,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cycle_lemma",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,8 +18,8 @@
       "finset",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 130,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 2 sorries. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid; formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euclid%27s_lemma",
     "date": "~300 BCE",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -16,7 +16,7 @@
       "research"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Int.mul_ediv_cancel'",
@@ -33,7 +33,7 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 182,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 1 sorry. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,8 +20,8 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 5,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_comp_add_right",
@@ -70,9 +70,9 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 390,
-    "assumptions": "No axioms or sorries.",
+    "assumptions": "1 axiom, 5 sorries. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -195,7 +195,7 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01",
     "lineCount": 390,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 2
   },

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,8 +17,8 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",
@@ -78,7 +78,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 270,
-    "assumptions": "None. Fully verified with 0 axioms, 0 sorries. Uses Classical.propDecidable as a local instance for decidability of propositions. All 5 theorems and 2 definitions are proved from Mathlib's UniqueFactorizationMonoid, EuclideanDomain, and linear algebra infrastructure.",
+    "assumptions": "0 axioms, 1 sorry. Uses Classical.propDecidable as a local instance for decidability of propositions.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,10 +7,10 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 1,
     "tags": [
       "combinatorics",
       "permutations",
@@ -68,7 +68,7 @@
     "dateAdded": "2026-02-25",
     "axiomCount": 0,
     "lineCount": 357,
-    "assumptions": "0 axioms, 0 sorries. Core cardinality result uses Mathlib's card_derangements_eq_numDerangements.",
+    "assumptions": "0 axioms, 1 sorry. Core cardinality result uses Mathlib's card_derangements_eq_numDerangements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",
@@ -65,7 +65,7 @@
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
     "lineCount": 247,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 1 sorry. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -15,8 +15,8 @@
       "convex-analysis",
       "open-question"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-03-06",
     "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 3 sorries. See the Lean source for details.",
     "proofRepoPath": "Proofs/SchauderFixedPointOQ01.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 315

--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical / Krasner / Ostrowski (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Ultra/Basic.html",
     "date": "1913 / 1946",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "geometry",
       "analysis",
@@ -18,9 +18,9 @@
       "topology"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ03.lean",
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 255,
     "mathlibDependencies": [
       {
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "1 axiom, 0 sorries. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "The study of non-Archimedean analysis began with Kurt Hensel's invention of p-adic numbers in 1897, motivated by analogies between number fields and function fields. Alexander Ostrowski (1916) classified all absolute values on the rationals: they are either the usual absolute value, a p-adic absolute value, or the trivial absolute value. This classification theorem shows that the ultrametric inequality is not an exotic curiosity but governs half of all possible notions of 'distance' on the rationals.\n\nThe ultrametric inequality d(x,z) ≤ max(d(x,y), d(y,z)) — strictly stronger than the usual d(x,z) ≤ d(x,y) + d(y,z) — was studied systematically by Marc Krasner (1940s) who developed the theory of ultrametric spaces and their striking topological properties: every point inside a ball is its center, balls are clopen (both open and closed), and distinct balls of equal radius are disjoint.\n\nThese 'strange' properties have profound consequences in number theory: the p-adic integers form a compact open subring (impossible over ℝ), p-adic analysis has no Archimedean property (|n|_p ≤ 1 for all integers), and Hensel's lemma provides a p-adic Newton's method with guaranteed convergence. Today, p-adic geometry underlies the Langlands program, perfectoid spaces (Scholze, Fields Medal 2018), and modern arithmetic geometry.",
@@ -172,7 +172,7 @@
   "leanFile": {
     "lineCount": 256,
     "structureCount": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 15,
     "lemmaCount": 0,
     "defCount": 0,


### PR DESCRIPTION
## Fix

Correct metadata for 9 gallery proofs where status was "verified" but Lean source contains sorries or axioms.

## Evidence

**Before**: 9 proofs claimed `status: "verified"` with `sorries: 0` / `axiomCount: 0` in meta.json, but their Lean source files contain `sorry` or `axiom` declarations.

**After**: Each proof's status, badge, sorry count, axiom count, and assumptions text now match the actual Lean source:

| Proof | Status | Sorries | Axioms |
|-------|--------|---------|--------|
| area-of-circle-oq-03-oq-02 | formalized | 0→1 | 0 |
| ballot-problem-oq-01-oq-01 | formalized | 0→2 | 0 |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | formalized | 0→1 | 0 |
| buffons-needle-oq-01-oq-01 | formalized | 0→5 | 0→1 |
| cayley-hamilton-minpoly-oq-05-oq-01 | formalized | 0→1 | 0 |
| derangements-oq-02 | formalized | 0→1 | 0 |
| erdos-1006-oq-02-oq-03 | formalized | 0→1 | 0 |
| schauder-fixed-point-oq-01 | formalized | 0→3 | 0 |
| triangle-inequality-oq-03 | axiomatized | 0 | 0→1 |

---
Automated fix by lean-mechanic agent.