### PR TITLE
Fix: sorry count for 3 navier-stokes variant proofs

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 23,
     "axiomCount": 0,
     "assumptions": "NSAxioms structure with 5 fields: Type II exponent bound, spectral gap on dissipation scale, theta dynamics bound, blowup rate estimate, BKM criterion. These encode the physical hypotheses needed for conditional 3D regularity.",
     "mathlibDependencies": [

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 0,
+    "sorries": 23,
     "axiomCount": 0,
     "mathlibDependencies": [
       {
@@ -61,7 +61,7 @@
     ],
     "dateAdded": "2026-02-26",
     "lineCount": 21111,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries.",
+    "assumptions": "None. Formalized with 0 axioms and 23 sorries.",
     "relatedProblems": [
       {
         "id": "navier-stokes",

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -22,7 +22,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 0,
+    "sorries": 23,
     "axiomCount": 0,
     "mathlibDependencies": [
       {
@@ -60,7 +60,7 @@
     ],
     "dateAdded": "2026-02-28",
     "lineCount": 21111,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries.",
+    "assumptions": "None. Formalized with 0 axioms and 23 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update sorry count from 0 to 23 for navier-stokes-existence, navier-stokes-oq-01, and navier-stokes-oq-02. All three share the same Lean file (NavierStokes.lean) which has 23 sorries.

## Evidence

**Before**: `sorries: 0` in all 3 meta.json files
**After**: `sorries: 23` matching actual content of `proofs/Proofs/NavierStokes.lean`

---
Automated fix by lean-mechanic agent.