### PR TITLE
Enrich erdos-490-oq-01: add annotations, deepen context

### DIFF
--- a/src/data/proofs/erdos-490-oq-01/annotations.json
+++ b/src/data/proofs/erdos-490-oq-01/annotations.json
@@ -1,1 +1,204 @@
-[]
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 1, "endLine": 26 },
+    "type": "context",
+    "title": "Module Overview: The Limit Question for Distinct Products",
+    "content": "This module formalizes a specific open question from Erdős Problem #490: given pairs $A, B \\subseteq \\{1,\\ldots,N\\}$ with all products $ab$ distinct, does the normalized maximum $\\max |A||B| \\cdot \\log N / N^2$ converge as $N \\to \\infty$?\n\nSzemerédi (1976) proved the upper bound $|A||B| \\leq C \\cdot N^2/\\log N$, while the construction $A = \\{1,\\ldots,\\lfloor N/2 \\rfloor\\}$, $B = \\{p \\in (N/2, N] : p \\text{ prime}\\}$ achieves $\\sim N^2/(2\\log N)$ by the prime number theorem. The ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$ is thus bounded between positive constants. But does it converge?\n\nThe formalization axiomatizes the deep bounds (Szemerédi's theorem and the optimal construction) and derives from them that the product ratio sequence is sandwiched and that any limit must lie in $[c, C]$. Three axioms, five definitions, nine theorems, zero sorries.",
+    "mathContext": "Define $f(N) = \\max\\{|A| \\cdot |B| : A, B \\subseteq \\{1,\\ldots,N\\},\\; ab \\neq a'b' \\text{ for } (a,b) \\neq (a',b')\\}$. Szemerédi: $f(N) \\leq C \\cdot N^2/\\log N$. Optimal: $f(N) \\geq c \\cdot N^2/\\log N$. Question: does $\\lim_{N \\to \\infty} f(N) \\cdot \\log N / N^2$ exist?",
+    "significance": "key",
+    "prerequisites": [
+      "Erdős Problem #490",
+      "Szemerédi's multiplicative theorem",
+      "prime number theorem"
+    ],
+    "relatedConcepts": [
+      "distinct products",
+      "multiplicative combinatorics",
+      "Szemerédi's theorem",
+      "limit existence"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 28, "endLine": 39 },
+    "type": "definition",
+    "title": "Core Combinatorial Setup: Subsets and Distinct Products",
+    "content": "`IsSubsetUpTo' A N` encodes $A \\subseteq \\{1,\\ldots,N\\}$ by requiring $1 \\leq a \\leq N$ for all $a \\in A$.\n\n`HasDistinctProducts' A B` encodes the constraint that the product map $(a, b) \\mapsto ab$ is injective on $A \\times B$: if $a_1 b_1 = a_2 b_2$ with $a_i \\in A$, $b_i \\in B$, then $a_1 = a_2$ and $b_1 = b_2$. This is stronger than requiring all products to be distinct as multiset elements — it demands the factorization is unique.\n\nNote: distinct products over $\\{1,\\ldots,N\\}$ connects to unique factorization in $\\mathbb{Z}$. If $A$ and $B$ consist of integers with disjoint prime support, distinctness is automatic. The constraint becomes interesting when $A$ and $B$ share prime factors, forcing a tension between size and multiplicative independence.",
+    "mathContext": "$A \\subseteq \\{1,\\ldots,N\\}$: $\\forall a \\in A,\\; 1 \\leq a \\leq N$.\n\nDistinct products: the map $\\phi: A \\times B \\to \\mathbb{N}$, $\\phi(a,b) = ab$ is injective. Equivalently, $|\\{ab : a \\in A, b \\in B\\}| = |A| \\cdot |B|$.",
+    "significance": "key",
+    "prerequisites": [
+      "Finset membership",
+      "injectivity",
+      "product map"
+    ],
+    "relatedConcepts": [
+      "Sidon sets",
+      "B_h sets",
+      "sum-product phenomenon",
+      "multiplicative energy"
+    ]
+  },
+  {
+    "id": "ann-maxprod-axiom",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 41, "endLine": 65 },
+    "type": "concept",
+    "title": "Axiomatizing the Maximum: maxProd Existence and Extraction",
+    "content": "The axiom `maxProd_exists` asserts that for each $N \\geq 2$, the maximum of $|A| \\cdot |B|$ over valid pairs exists and is achieved. This is mathematically clear (finite optimization over a finite domain) but axiomatized because formalizing the finiteness argument fully would require constructing the search space explicitly.\n\n`maxProd N hN` extracts the maximum value via `Exists.choose`, and two extraction theorems provide the interface:\n- `maxProd_is_upper`: for any valid pair, $|A||B| \\leq \\operatorname{maxProd}(N)$\n- `maxProd_is_achieved`: there exists a valid pair achieving equality\n\nThis axiomatization pattern — assert existence, extract via `choose`, provide upper and achieved interfaces — is a clean way to work with extremal combinatorial quantities in Lean without building the full optimization machinery.",
+    "mathContext": "$\\operatorname{maxProd}(N) = \\max\\{|A| \\cdot |B| : A, B \\subseteq \\{1,\\ldots,N\\},\\; \\phi_{A,B} \\text{ injective}\\}$.\n\nThe maximum exists because the domain $\\{(A,B) : A, B \\subseteq \\{1,\\ldots,N\\}\\}$ is finite and non-empty (take $A = B = \\{1\\}$).",
+    "significance": "supporting",
+    "prerequisites": [
+      "Exists.choose",
+      "finite optimization",
+      "noncomputable definitions"
+    ],
+    "relatedConcepts": [
+      "axiomatization pattern",
+      "extremal combinatorics",
+      "noncomputable extraction"
+    ]
+  },
+  {
+    "id": "ann-szemeredi-axiom",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 67, "endLine": 77 },
+    "type": "concept",
+    "title": "The Key Bounds: Szemerédi Upper and Optimal Lower",
+    "content": "Two axioms encode the deep number-theoretic results that bound the product ratio:\n\n**Szemerédi upper bound** (`szemeredi_upper`): $\\exists C > 0$ such that $\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$ for all $N \\geq 2$. Szemerédi (1976) proved this using a combinatorial double-counting argument involving the multiplicative structure of $\\{1,\\ldots,N\\}$.\n\n**Optimal lower bound** (`optimal_lower`): $\\exists c > 0$ such that $\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$ for all $N \\geq 2$. The witness construction takes $A = \\{1,\\ldots,\\lfloor N/2 \\rfloor\\}$ and $B = \\{p \\text{ prime} : N/2 < p \\leq N\\}$. Since the primes in $B$ are all $> N/2$, each product $ab$ has a unique factorization into $a \\cdot p$, ensuring distinctness. By the prime number theorem, $|B| \\sim N/(2\\log N)$ and $|A| \\sim N/2$, giving $|A||B| \\sim N^2/(4\\log N)$.\n\nThese bounds together pin $\\operatorname{maxProd}(N)$ to the order $\\Theta(N^2/\\log N)$.",
+    "mathContext": "Upper: $\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$ (Szemerédi 1976).\nLower: $\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$ (prime construction).\n\nCombined: $\\operatorname{maxProd}(N) = \\Theta(N^2/\\log N)$, so $\\operatorname{productRatio}(N) = \\Theta(1)$.",
+    "significance": "key",
+    "prerequisites": [
+      "Szemerédi's multiplicative bound",
+      "prime number theorem",
+      "asymptotic notation"
+    ],
+    "relatedConcepts": [
+      "Szemerédi's theorem",
+      "prime counting function",
+      "Theta notation",
+      "extremal number theory"
+    ]
+  },
+  {
+    "id": "ann-product-ratio",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 79, "endLine": 86 },
+    "type": "definition",
+    "title": "The Product Ratio: The Normalized Sequence Under Study",
+    "content": "The product ratio $\\operatorname{productRatio}'(N) = \\operatorname{maxProd}(N) \\cdot \\log N / N^2$ normalizes the maximum product size by the expected order of growth. If this sequence converges, the limit $L$ is a fundamental constant of multiplicative combinatorics — analogous to how the prime counting function $\\pi(N) \\sim N/\\log N$ has the implicit constant 1 (the prime number theorem).\n\nThe definition is `noncomputable` because `maxProd` itself is noncomputable (extracted via `Exists.choose`). The ratio is well-defined for $N \\geq 2$ since $\\log N > 0$ and $N^2 > 0$.",
+    "mathContext": "$\\operatorname{productRatio}'(N) = \\frac{\\operatorname{maxProd}(N) \\cdot \\log N}{N^2}$.\n\nIf $\\operatorname{maxProd}(N) = (L + o(1)) \\cdot N^2/\\log N$, then $\\operatorname{productRatio}'(N) \\to L$.",
+    "significance": "key",
+    "prerequisites": [
+      "Real.log",
+      "noncomputable definitions"
+    ],
+    "relatedConcepts": [
+      "normalization",
+      "asymptotic constant",
+      "prime number theorem"
+    ]
+  },
+  {
+    "id": "ann-bounded-above",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 88, "endLine": 101 },
+    "type": "technique",
+    "title": "Product Ratio Bounded Above from Szemerédi",
+    "content": "Derives $\\operatorname{productRatio}'(N) \\leq C$ from the Szemerédi upper bound. The proof unfolds `productRatio'`, establishes positivity of $\\log N$ and $N^2$, then rewrites $\\operatorname{maxProd}(N) \\cdot \\log N / N^2 \\leq C$ as $\\operatorname{maxProd}(N) \\cdot \\log N \\leq C \\cdot N^2$.\n\nThe key step is the `calc` block: multiply both sides of Szemerédi's bound by $\\log N$ and simplify using `field_simp` to cancel the $\\log N$ denominator. The monotonicity lemma `mul_le_mul_of_nonneg_left` handles the multiplication by $\\log N \\geq 0$.",
+    "mathContext": "$\\operatorname{productRatio}'(N) = \\frac{\\operatorname{maxProd}(N) \\cdot \\log N}{N^2} \\leq \\frac{C \\cdot N^2/\\log N \\cdot \\log N}{N^2} = C$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "div_le_iff",
+      "mul_le_mul_of_nonneg_left",
+      "field_simp"
+    ],
+    "relatedConcepts": [
+      "algebraic manipulation",
+      "positivity tactic",
+      "calc blocks"
+    ]
+  },
+  {
+    "id": "ann-bounded-below",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 103, "endLine": 116 },
+    "type": "technique",
+    "title": "Product Ratio Bounded Below from Optimal Construction",
+    "content": "Derives $c \\leq \\operatorname{productRatio}'(N)$ from the optimal lower bound, using the same algebraic technique as the upper bound proof but in the reverse direction. The `calc` block multiplies the lower bound by $\\log N$ and uses `field_simp` to cancel, then `ring` reorders the product.\n\nTogether with `productRatio_bounded_above`, this establishes the sandwich: $c \\leq \\operatorname{productRatio}'(N) \\leq C$ for all $N \\geq 2$.",
+    "mathContext": "$\\operatorname{productRatio}'(N) = \\frac{\\operatorname{maxProd}(N) \\cdot \\log N}{N^2} \\geq \\frac{c \\cdot N^2/\\log N \\cdot \\log N}{N^2} = c$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "le_div_iff",
+      "field_simp",
+      "ring"
+    ],
+    "relatedConcepts": [
+      "sandwich inequality",
+      "lower bound",
+      "symmetric argument"
+    ]
+  },
+  {
+    "id": "ann-limit-sandwich",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 118, "endLine": 156 },
+    "type": "technique",
+    "title": "The Limit Question and Sandwich Theorem",
+    "content": "`LimitExists'` defines convergence via the standard $\\varepsilon$-$\\delta$ formulation: $\\exists L,\\; \\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0,\\; |\\operatorname{productRatio}'(N) - L| < \\varepsilon$.\n\n`limit_in_sandwich` is the main theorem: if the limit exists, it lies in $[c, C]$. The proof uses contradiction twice:\n1. **Lower bound**: Assume $L < c$. Set $\\varepsilon = c - L > 0$. For large $N$, $|\\operatorname{productRatio}'(N) - L| < c - L$, so $\\operatorname{productRatio}'(N) < c$. But $\\operatorname{productRatio}'(N) \\geq c$ by the lower bound — contradiction.\n2. **Upper bound**: Assume $L > C$. Set $\\varepsilon = L - C > 0$. For large $N$, $\\operatorname{productRatio}'(N) > C$. But $\\operatorname{productRatio}'(N) \\leq C$ — contradiction.\n\nThis is a standard real analysis argument, but the formalization handles the dependent hypotheses ($hN : 2 \\leq N$) carefully, using `max N₀ 2` to satisfy both the convergence threshold and the $N \\geq 2$ requirement.",
+    "mathContext": "If $a_n \\to L$ and $c \\leq a_n \\leq C$ for all $n$, then $c \\leq L \\leq C$.\n\nProof: If $L < c$, take $\\varepsilon = c - L$. Then $|a_n - L| < c - L$ for large $n$, so $a_n < c$ — contradicting $a_n \\geq c$. Similarly for $L > C$.",
+    "significance": "key",
+    "prerequisites": [
+      "epsilon-delta definition",
+      "abs_lt",
+      "by_contra",
+      "linarith"
+    ],
+    "relatedConcepts": [
+      "squeeze theorem",
+      "limit of bounded sequence",
+      "proof by contradiction",
+      "max trick for dependent hypotheses"
+    ]
+  },
+  {
+    "id": "ann-structural",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 158, "endLine": 201 },
+    "type": "technique",
+    "title": "Structural Analysis: Nonnegativity, Cardinality, and Full Sandwich",
+    "content": "Three supporting results and the capstone theorem:\n\n**`productRatio_nonneg`**: The product ratio is nonneg because $\\operatorname{maxProd}(N) \\geq 0$ (as a natural number cast to $\\mathbb{R}$), $\\log N > 0$ for $N \\geq 2$, and $N^2 > 0$. Uses `div_nonneg` and `mul_nonneg`.\n\n**`card_le_of_subset_upto`**: If $A \\subseteq \\{1,\\ldots,N\\}$, then $|A| \\leq N$. Proved by inclusion $A \\hookrightarrow [1, N]$ via `Finset.card_le_card`, then `Finset.card_Icc` computes $|[1,N]| = N$.\n\n**`maxProd_le_sq`**: The trivial bound $\\operatorname{maxProd}(N) \\leq N^2$ follows from $|A| \\leq N$ and $|B| \\leq N$ applied to an achieving pair.\n\n**`productRatio_sandwich`**: The capstone: $\\exists c, C$ with $0 < c \\leq C$ such that $c \\leq \\operatorname{productRatio}'(N) \\leq C$ for all $N \\geq 2$. Combines the bounded above/below results and verifies $c \\leq C$ by evaluating at $N = 2$.",
+    "mathContext": "$|A| \\leq N$ for $A \\subseteq \\{1,\\ldots,N\\}$, so $|A||B| \\leq N^2$.\n\nFull sandwich: $\\exists\\, 0 < c \\leq C$ with $c \\leq \\operatorname{productRatio}'(N) \\leq C$ for all $N \\geq 2$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Finset.card_le_card",
+      "Finset.card_Icc",
+      "Nat.mul_le_mul"
+    ],
+    "relatedConcepts": [
+      "trivial bound",
+      "cardinality argument",
+      "sandwich inequality"
+    ]
+  },
+  {
+    "id": "ann-summary-checks",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 203, "endLine": 215 },
+    "type": "context",
+    "title": "Summary: Nine Theorems, Zero Sorries",
+    "content": "The `#check` block lists all nine proved theorems as a verification summary. The development forms a complete logical chain:\n\n1. **Infrastructure**: `maxProd_is_upper`, `maxProd_is_achieved` (from axiom)\n2. **Bounds**: `productRatio_bounded_above`, `productRatio_bounded_below` (from Szemerédi/optimal axioms)\n3. **Limit theory**: `limit_in_sandwich` (the main result)\n4. **Structural**: `productRatio_nonneg`, `card_le_of_subset_upto`, `maxProd_le_sq`, `productRatio_sandwich`\n\nThe three axioms are clearly separated from the nine theorems, and all theorems are proved without sorry. The open question — does the limit exist? — remains formally stated but unresolved.",
+    "mathContext": "9 theorems proved, 0 sorries, 3 axioms (encoding deep results). The limit question $\\exists L,\\; \\operatorname{productRatio}'(N) \\to L$ is stated but not resolved.",
+    "significance": "supporting",
+    "prerequisites": [
+      "#check command"
+    ],
+    "relatedConcepts": [
+      "verification summary",
+      "proof inventory",
+      "open questions"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-490-oq-01/meta.json
+++ b/src/data/proofs/erdos-490-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-490-oq-01",
   "title": "Does lim max|A||B|·log N/N² Exist?",
   "slug": "erdos-490-oq-01",
-  "description": "Investigates whether the limit of the normalized maximum product size exists. Proves the product ratio sequence is sandwiched between positive constants, establishes that any limit must lie in this interval, and provides structural bounds.",
+  "description": "Formalizes the open question from Erdős Problem #490: does lim max|A||B|·log N/N² exist, where the maximum is over pairs with distinct products in {1,...,N}? Proves the product ratio is sandwiched between positive constants (Szemerédi upper bound and prime construction lower bound) and that any limit must lie in [c, C]. Three axioms encoding deep number-theoretic bounds, nine theorems, zero sorries.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/490",
@@ -50,44 +50,50 @@
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Basic Definitions",
-      "summary": "Defines `IsSubsetUpTo'` (A ⊆ {1,...,N}), `HasDistinctProducts'` (product map injective), `maxProd` (maximum product size), and `productRatio'` (normalized ratio maxProd·log N/N²).",
-      "startLine": 30,
-      "endLine": 80
+      "id": "header-and-definitions",
+      "title": "Module Header, Definitions, and maxProd Axiom",
+      "summary": "Module docstring, imports, and the core combinatorial setup: `IsSubsetUpTo'` ($A \\subseteq \\{1,\\ldots,N\\}$), `HasDistinctProducts'` (product map injective), `maxProd` (maximum $|A||B|$ over valid pairs), and `productRatio'` (normalized ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$). The `maxProd_exists` axiom asserts existence and achievability of the maximum.",
+      "startLine": 1,
+      "endLine": 86,
+      "mathContext": "Five definitions formalize the optimization problem: $f(N) = \\max\\{|A||B| : A, B \\subseteq \\{1,\\ldots,N\\},\\; \\phi_{A,B} \\text{ injective}\\}$ and $r(N) = f(N) \\cdot \\log N / N^2$. The axiom `maxProd_exists` provides the existential witness for $f(N)$."
     },
     {
       "id": "bounds",
       "title": "Bounds on the Product Ratio",
-      "summary": "Proves the product ratio is bounded above (from Szemerédi's theorem) and below (from the optimal prime example), establishing it stays in a fixed interval [c, C] for all N ≥ 2.",
-      "startLine": 84,
-      "endLine": 125
+      "summary": "Two axioms encode deep bounds: Szemerédi's $\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$ and the optimal construction's $\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$. Two theorems derive $c \\leq \\operatorname{productRatio}'(N) \\leq C$ by algebraic manipulation: multiply by $\\log N$, divide by $N^2$, use `field_simp` to cancel.",
+      "startLine": 88,
+      "endLine": 116,
+      "mathContext": "$c \\leq \\frac{\\operatorname{maxProd}(N) \\cdot \\log N}{N^2} \\leq C$ for all $N \\geq 2$. The proofs are symmetric `calc` blocks using $\\log N > 0$ for $N \\geq 2$."
     },
     {
       "id": "limit-question",
-      "title": "The Limit Question",
-      "summary": "States the open question (does the limit exist?) and proves that if it does, the limit value L satisfies c ≤ L ≤ C. Uses ε-δ characterization with contradiction arguments.",
-      "startLine": 129,
-      "endLine": 165
+      "title": "The Limit Question and Sandwich Theorem",
+      "summary": "Defines `LimitExists'` (standard $\\varepsilon$-$\\delta$ convergence) and proves `limit_in_sandwich`: if the limit $L$ exists, then $c \\leq L \\leq C$. Each bound is proved by contradiction — assuming $L < c$ (or $L > C$) and choosing $\\varepsilon = c - L$ (or $L - C$) yields a value simultaneously above and below the bound.",
+      "startLine": 118,
+      "endLine": 156,
+      "mathContext": "If $a_n \\to L$ and $c \\leq a_n \\leq C$ for all $n$, then $c \\leq L \\leq C$. This is the squeeze theorem for limits of bounded sequences, proved here via $\\varepsilon$-$\\delta$ contradiction."
     },
     {
       "id": "structural",
-      "title": "Structural Analysis",
-      "summary": "Proves nonnegativity of the product ratio, the cardinality bound |A| ≤ N for subsets of {1,...,N}, and the trivial bound maxProd(N) ≤ N². Establishes the full sandwich theorem.",
-      "startLine": 168,
-      "endLine": 229
+      "title": "Structural Analysis and Full Sandwich",
+      "summary": "Proves `productRatio_nonneg` (nonnegativity from component signs), `card_le_of_subset_upto` ($|A| \\leq N$ via inclusion into $[1, N]$), `maxProd_le_sq` (trivial bound $\\operatorname{maxProd}(N) \\leq N^2$), and the capstone `productRatio_sandwich` (combining all bounds with $c \\leq C$ verified at $N = 2$). Summary `#check` block lists all nine theorems.",
+      "startLine": 158,
+      "endLine": 215,
+      "mathContext": "$|A| \\leq |[1,N]| = N$ for $A \\subseteq \\{1,\\ldots,N\\}$, so $\\operatorname{maxProd}(N) \\leq N^2$. The full sandwich combines all bounds into a single statement with explicit $c \\leq C$."
     }
   ],
   "overview": {
-    "historicalContext": "Szemerédi (1976) proved that if A, B ⊆ {1,...,N} have all products ab distinct, then |A||B| ≤ C·N²/log N. The optimal example (A = [1,N/2], B = primes in (N/2,N]) achieves ~N²/(2 log N). Erdős (1972) asked whether the ratio max|A||B|·log N/N² has a limit as N→∞.",
+    "historicalContext": "Erdős Problem #490 belongs to extremal multiplicative combinatorics, a field Erdős helped create. The question concerns pairs $A, B \\subseteq \\{1,\\ldots,N\\}$ where the product map $(a,b) \\mapsto ab$ is injective — all products are distinct. How large can $|A| \\cdot |B|$ be?\n\nThe upper bound is due to Szemerédi (1976), who proved $|A||B| \\leq C \\cdot N^2/\\log N$ by a combinatorial argument exploiting the multiplicative structure of $\\{1,\\ldots,N\\}$. The logarithmic factor arises because large subsets of $\\{1,\\ldots,N\\}$ inevitably share multiplicative structure: numbers with many small prime factors create product collisions $ab = a'b'$, so achieving distinct products requires either small sets or sets whose elements have disjoint prime factorizations.\n\nThe matching lower bound comes from a natural construction: take $A = \\{1,\\ldots,\\lfloor N/2 \\rfloor\\}$ and $B = \\{p \\text{ prime} : N/2 < p \\leq N\\}$. Since every $b \\in B$ is prime and $> N/2$, each product $ab = a \\cdot p$ has a unique factorization with prime part $p$, ensuring distinctness. By the prime number theorem, $|B| \\sim N/(2\\log N)$ and $|A| \\sim N/2$, giving $|A||B| \\sim N^2/(4\\log N)$.\n\nErdős (1972) asked the natural follow-up: since $\\operatorname{maxProd}(N) = \\Theta(N^2/\\log N)$, does the normalized ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$ converge to a definite constant? If so, this constant would be a fundamental quantity in multiplicative combinatorics, analogous to the constant 1 in the prime number theorem ($\\pi(N) \\sim N/\\log N$). The question remains open.",
     "problemStatement": "Does the limit L = lim_{N→∞} max_{A,B} |A||B|·log N/N² exist, where the maximum is over pairs (A,B) ⊆ {1,...,N}² with all products ab distinct? If so, what is L?",
-    "text": "Formalizes the limit question for the normalized maximum product size, proving the sequence is bounded in a positive interval.",
-    "proofStrategy": "We axiomatize the key bounds (Szemerédi upper, optimal lower) and derive consequences for the product ratio sequence. The sandwich theorem is proved by contradiction: if the limit violates a bound, the ε-δ definition yields a contradictory inequality.",
+    "text": "A formalization of the limit question for Erdős Problem #490 in 229 lines with 3 axioms and 0 sorries. The two deep bounds — Szemerédi's upper bound $\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$ and the prime construction's lower bound $\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$ — are axiomatized. From these, nine theorems derive: the product ratio $\\operatorname{productRatio}'(N) = \\operatorname{maxProd}(N) \\cdot \\log N / N^2$ is sandwiched between positive constants $c$ and $C$; if the limit exists, it lies in $[c, C]$; and structural properties including nonnegativity, cardinality bounds, and the trivial bound $\\operatorname{maxProd}(N) \\leq N^2$. The central open question — does the sequence converge or oscillate? — is formally stated but unresolved.",
+    "proofStrategy": "The proof follows a three-layer strategy:\n\n1. **AXIOMATIZE**: Three axioms encode results whose proofs require deep number theory: `maxProd_exists` (the finite optimization has an achiever), `szemeredi_upper` ($\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$), and `optimal_lower` ($\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$). These are treated as black boxes.\n\n2. **ALGEBRAIC MANIPULATION**: The bounded-above and bounded-below theorems convert the axioms into bounds on the product ratio by multiplying by $\\log N / N^2$ and simplifying. The key technique is `calc` blocks with `field_simp` to cancel the $\\log N$ denominator, using `mul_le_mul_of_nonneg_left` for monotonicity.\n\n3. **REAL ANALYSIS**: The `limit_in_sandwich` theorem uses $\\varepsilon$-$\\delta$ contradiction: if $L < c$, choose $\\varepsilon = c - L$ and derive $\\operatorname{productRatio}'(N) < c$ for large $N$, contradicting the lower bound. The `max N_0 2` trick simultaneously satisfies the convergence threshold and the $N \\geq 2$ requirement.\n\nThe development separates the 'hard' mathematics (axiomatized) from the 'soft' analysis (proved), allowing the formal verification to focus on the logical structure of the limit argument.",
     "keyInsights": [
-      "The product ratio is **bounded between positive constants**: 0 < c ≤ productRatio(N) ≤ C for all N ≥ 2.",
-      "The **limit, if it exists, is unique** and lies in [c, C] — proved via ε-δ contradiction.",
-      "The **trivial bound** maxProd(N) ≤ N² follows from |A| ≤ N and |B| ≤ N for subsets of {1,...,N}.",
-      "The **critical question** is whether the sequence oscillates or converges — boundedness alone doesn't settle this."
+      "**Sandwich between positive constants**: $0 < c \\leq \\operatorname{productRatio}'(N) \\leq C$ for all $N \\geq 2$. The lower bound $c$ comes from the prime construction ($A = [1, N/2]$, $B = $ primes in $(N/2, N]$), and the upper bound $C$ from Szemerédi's theorem. This pins the sequence to a bounded positive interval.",
+      "**Limit constrained to $[c, C]$**: If $\\lim \\operatorname{productRatio}'(N) = L$ exists, then $c \\leq L \\leq C$. Proved by $\\varepsilon$-$\\delta$ contradiction — the squeeze theorem for bounded convergent sequences.",
+      "**Convergence vs. oscillation**: Boundedness does not imply convergence. The Bolzano-Weierstrass theorem guarantees convergent subsequences, but the full sequence could oscillate between $c$ and $C$. Resolving whether it converges likely requires understanding the fine arithmetic structure of optimal pairs $(A, B)$ as $N$ varies.",
+      "**The logarithmic factor is forced**: The $\\log N$ in Szemerédi's bound arises because dense subsets of $\\{1,\\ldots,N\\}$ share multiplicative structure. Numbers with many small prime factors create product collisions, so achieving distinct products forces either small sets or multiplicatively independent elements (like primes, which have density $\\sim 1/\\log N$).",
+      "**Axiomatization separates depth from logic**: The three axioms isolate the 'hard' mathematics (Szemerédi's combinatorial argument, the prime number theorem for the lower bound, finite optimization) from the 'soft' real analysis (sandwich, limit bounds). This design lets Lean verify the logical structure without requiring the full number-theoretic proofs.",
+      "**Possible limit value $1/2$**: If the limit exists, the prime construction suggests $L \\approx 1/4$ to $1/2$ (from $|A||B| \\approx N^2/(4\\log N)$ giving ratio $\\approx 1/4$). Whether the prime construction is asymptotically optimal — or whether cleverer constructions beat it — is part of the open question."
     ],
     "prerequisites": [
       "Number theory (primes, unique factorization)",
@@ -96,12 +102,14 @@
     ]
   },
   "conclusion": {
-    "summary": "We formalize the limit question for Erdős #490's product ratio and prove the sequence is sandwiched between positive constants. The limit (if it exists) must lie in [c, C]. All 9 theorems proved with 0 sorries.",
-    "implications": "The bounded sandwich establishes the limit question as genuinely about oscillation vs. convergence, not about divergence.\nA proof that the sequence is eventually monotone would resolve the question positively.",
+    "summary": "This formalization establishes the foundational framework for Erdős's limit question: the product ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$ is sandwiched between positive constants, so it neither diverges to $\\infty$ nor decays to 0. Any limit must lie in $[c, C]$. The nine theorems with zero sorries provide a rigorous starting point for investigating convergence.",
+    "implications": "**Theoretical significance**: The sandwich theorem reduces the limit question to a question about oscillation vs. convergence of a bounded positive sequence. Since the Bolzano-Weierstrass theorem guarantees convergent subsequences, the key question is whether the limsup and liminf coincide.\n\n**Connections to additive combinatorics**: The distinct products condition is the multiplicative analogue of Sidon sets (where all pairwise sums are distinct). The Erdős-Turán conjecture on Sidon sets ($|A| \\leq \\sqrt{N} + O(N^{1/4})$) and the Cilleruelo-Vinuesa improvements have multiplicative counterparts that constrain the structure of optimal pairs.\n\n**Sum-product phenomenon**: Erdős and Szemerédi (1983) showed that finite sets cannot simultaneously have small sumset and small product set ($|A+A| + |A \\cdot A| \\geq |A|^{1+\\varepsilon}$). The distinct products constraint in Problem #490 forces $|A \\cdot B| = |A||B|$ (maximal product set), which limits $|A|$ and $|B|$ and connects to this broader theme.\n\n**Monotonicity approach**: If $\\operatorname{productRatio}'(N)$ were eventually monotone (increasing or decreasing), convergence would follow immediately from boundedness. Understanding whether optimal pairs $(A_N, B_N)$ vary smoothly or erratically with $N$ is the crux of the problem.",
     "openQuestions": [
-      "Does lim max|A||B|·log N/N² exist?",
-      "If the limit exists, is it 1/2 (matching the prime example)?",
-      "Is the productRatio sequence eventually monotone?"
+      "Does $\\lim_{N \\to \\infty} \\operatorname{maxProd}(N) \\cdot \\log N / N^2$ exist? This is Erdős's original question — completely open.",
+      "If the limit exists, what is its value? The prime construction suggests $L \\leq 1/2$, but the exact value (if well-defined) is unknown.",
+      "Is the product ratio sequence eventually monotone? Monotonicity plus boundedness would immediately give convergence.",
+      "Can the Szemerédi constant $C$ and optimal constant $c$ be made explicit? Currently they are existential — computing tight values would narrow the interval $[c, C]$ and potentially resolve the limit question.",
+      "What is the structure of optimal pairs $(A_N, B_N)$ for large $N$? Are they always close to the prime construction, or do fundamentally different configurations achieve the maximum for certain $N$?"
     ]
   },
   "leanFile": {
@@ -121,27 +129,51 @@
   },
   "crossReferences": [
     {
-      "relationship": "Parent formalization of Erdős Problem #490; this OQ investigates the limit question",
-      "targetId": "erdos-490"
+      "targetId": "erdos-490",
+      "relationship": "Parent formalization of Erdős Problem #490; this OQ investigates the limit question for the normalized maximum product size"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "The prime construction for the lower bound uses primes in (N/2, N], whose density comes from the prime number theorem — a consequence of the infinitude of primes"
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "The divergence of the harmonic series is related to the density of primes (Euler's proof uses $\\sum 1/p = \\infty$), which underlies the $\\log N$ factor in Szemerédi's bound"
     }
   ],
   "references": [
     {
-      "authors": "E. Szemerédi",
+      "authors": "Szemerédi, Endre",
       "title": "On a problem of P. Erdős",
       "year": "1976",
-      "venue": "J. Number Theory",
-      "note": "Proved |A||B| ≤ C·N²/log N for distinct products"
+      "venue": "Journal of Number Theory, vol. 8, pp. 264–270",
+      "note": "Proved the upper bound |A||B| ≤ C·N²/log N for pairs with distinct products in {1,...,N}. The combinatorial argument exploits the multiplicative structure of integers to bound the number of valid pairs"
     },
     {
-      "authors": "P. Erdős",
+      "authors": "Erdős, Paul",
       "title": "Extremal problems in number theory",
       "year": "1972",
-      "venue": "Proceedings of the 1972 Number Theory Conference",
-      "note": "Posed the limit question"
+      "venue": "Proceedings of the 1972 Number Theory Conference, Boulder, CO",
+      "note": "Posed the problem of maximizing |A||B| with distinct products and asked whether the normalized ratio has a limit"
+    },
+    {
+      "authors": "Erdős, Paul; Szemerédi, Endre",
+      "title": "On sums and products of integers",
+      "year": "1983",
+      "venue": "Studies in Pure Mathematics, Birkhäuser, pp. 213–218",
+      "note": "Proved the sum-product inequality |A+A| + |A·A| ≥ |A|^{1+ε}, initiating the sum-product phenomenon that provides broader context for distinct product problems"
+    },
+    {
+      "authors": "Tao, Terence; Vu, Van",
+      "title": "Additive Combinatorics",
+      "year": "2006",
+      "venue": "Cambridge University Press",
+      "note": "Comprehensive reference for the sum-product phenomenon, Sidon sets, and extremal problems in additive and multiplicative combinatorics"
     }
   ],
   "relatedProofs": [
-    "erdos-490"
+    "erdos-490",
+    "infinitude-primes",
+    "harmonic-divergence"
   ]
 }


### PR DESCRIPTION
Enrichment pass for erdos-490-oq-01 (pass 1, quality 38 → significantly improved).

## Changes
- Created 10 annotations (from 0) covering all code sections with mathContext, significance, relatedConcepts, prerequisites
- Expanded historicalContext from 1 sentence to comprehensive narrative covering Szemerédi's argument, prime construction, and multiplicative combinatorics context
- Deepened proofStrategy with three-layer breakdown
- Added 6 keyInsights (from 4), including logarithmic factor motivation and axiomatization design
- Expanded conclusion with connections to Sidon sets and sum-product phenomenon
- Added mathContext to all 4 sections
- Added cross-references and 2 new references