### PR TITLE
Research: cayley-hamilton-minpoly-oq-03 - Prove all 3 sorries (0 remaining)

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean
@@ -99,11 +99,32 @@ theorem krylovVec_succ (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K) (k : ℕ
     This connects the algebraic operation (polynomial evaluation at a matrix)
     to the iterative operation (Krylov sequence). It is the theoretical
     foundation of Krylov subspace methods. -/
+-- Helper: mulVec distributes over finite sums of matrices
+private theorem sum_mulVec {ι : Type*} [DecidableEq ι] (s : Finset ι)
+    (f : ι → Matrix (Fin n) (Fin n) K) (v : Fin n → K) :
+    (∑ i ∈ s, f i).mulVec v = ∑ i ∈ s, (f i).mulVec v := by
+  induction s using Finset.induction_on with
+  | empty => simp [Matrix.zero_mulVec]
+  | insert has ih =>
+    rw [Finset.sum_insert has, Matrix.add_mulVec, ih, Finset.sum_insert has]
+
 theorem aeval_mulVec_eq_krylov_sum (M : Matrix (Fin n) (Fin n) K)
     (v : Fin n → K) (p : K[X]) :
     (aeval M p).mulVec v =
       ∑ i ∈ range (p.natDegree + 1), p.coeff i • krylovVec M v i := by
-  sorry
+  have haeval_expand : aeval M p =
+      ∑ i ∈ range (p.natDegree + 1), p.coeff i • M ^ i := by
+    simp only [aeval_def, Polynomial.eval₂_eq_sum, Polynomial.sum_def]
+    have hsub : p.support ⊆ range (p.natDegree + 1) := by
+      intro i hi
+      exact Finset.mem_range.mpr (Nat.lt_succ_of_le (Polynomial.le_natDegree_of_mem_supp _ hi))
+    rw [Finset.sum_subset hsub]
+    · congr 1; ext i
+      rw [Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
+    · intro i _ hi
+      rw [Polynomial.not_mem_support_iff.mp hi, map_zero, zero_mul]
+  rw [haeval_expand, sum_mulVec]
+  simp only [Matrix.smul_mulVec, krylovVec]
 
 -- ============================================================
 -- PART III: Krylov Annihilation by Minimal Polynomial
@@ -143,16 +164,17 @@ theorem krylov_dependent_at_minpoly_degree [hn : NeZero n]
     ¬ LinearIndependent K
       (fun i : Fin ((minpoly K M).natDegree + 1) => krylovVec M v i) := by
   intro hli
-  -- The minimal polynomial is monic and annihilates M
   have hmonic := minpoly.monic (isIntegral M)
-  -- μ_M(M)·v = 0
   have hann := minpoly_annihilates_vec M v
-  -- Expand using the Krylov sum representation
-  -- The sum ∑ (minpoly.coeff i) • krylovVec M v i = 0
-  -- with the leading coefficient being 1 (monic), this gives
-  -- a nontrivial linear combination equal to zero,
-  -- contradicting linear independence
-  sorry
+  rw [aeval_mulVec_eq_krylov_sum] at hann
+  rw [← Fin.sum_univ_eq_sum_range] at hann
+  have hzero := (Fintype.linearIndependent_iff.mp hli)
+    (fun i => (minpoly K M).coeff ↑i) hann
+  have h0 := hzero ⟨(minpoly K M).natDegree, Nat.lt_succ_of_le le_rfl⟩
+  dsimp at h0
+  have h1 : (minpoly K M).leadingCoeff = 1 := hmonic.leadingCoeff
+  rw [Polynomial.leadingCoeff] at h1
+  linarith
 
 -- ============================================================
 -- PART V: Krylov Dimension Bound
@@ -239,12 +261,34 @@ theorem nonderogatory_krylov_optimal
     (hcyclic : ∀ p : K[X], p.natDegree < n → (aeval M p).mulVec v = 0 → p = 0)
     (hnond : minpoly K M = M.charpoly) :
     LinearIndependent K (fun i : Fin n => krylovVec M v i) := by
-  -- A cyclic vector means: if p(M)v = 0 and deg(p) < n, then p = 0
-  -- We need: the Krylov vectors are linearly independent
-  -- Suppose ∑ cᵢ M^i v = 0 for some coefficients c : Fin n → K
-  -- Define p = ∑ cᵢ Xⁱ. Then p(M)v = 0 and deg(p) < n
-  -- By the cyclic vector property, p = 0, hence all cᵢ = 0
-  sorry
+  by_cases hn : n = 0
+  · subst hn; exact linearIndependent_empty_type
+  · rw [Fintype.linearIndependent_iff]
+    intro g hg
+    set p := ∑ i : Fin n, Polynomial.C (g i) * Polynomial.X ^ (i : ℕ) with hp_def
+    have hpv : (aeval M p).mulVec v = 0 := by
+      rw [hp_def, map_sum, sum_mulVec]
+      simp only [map_mul, map_pow, aeval_C, aeval_X,
+        Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, Matrix.smul_mulVec]
+      exact hg
+    have hpd : p.natDegree < n := by
+      calc p.natDegree
+          ≤ Finset.univ.sup (fun i : Fin n =>
+              (Polynomial.C (g i) * Polynomial.X ^ (i : ℕ)).natDegree) :=
+            Polynomial.natDegree_sum_le _ _
+        _ < n := by
+            rw [Finset.sup_lt_iff (Nat.pos_of_ne_zero hn)]
+            intro i _
+            exact (Polynomial.natDegree_C_mul_X_pow_le (g i) i).trans_lt i.isLt
+    have hp0 := hcyclic p hpd hpv
+    intro i
+    have hpc : p.coeff ↑i = 0 := by simp [hp0]
+    rw [hp_def, Polynomial.finset_sum_coeff] at hpc
+    simp only [Polynomial.coeff_C_mul_X_pow] at hpc
+    rw [Finset.sum_eq_single i] at hpc
+    · simpa using hpc
+    · intro j _ hji; exact if_neg (Ne.symm (Fin.val_ne_of_ne hji))
+    · intro h; exact absurd (Finset.mem_univ i) h
 
 -- ============================================================
 -- PART VIII: Krylov Subspace is M-invariant
@@ -314,13 +358,13 @@ theorem krylov_recurrence (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K)
   - minpoly_degree_le_dim: ✓ (proved)
   - krylov_subspace_invariant: ✓ (proved)
   - krylov_recurrence: ✓ (proved)
-  - aeval_mulVec_eq_krylov_sum: sorry (needs polynomial coefficient expansion)
-  - krylov_dependent_at_minpoly_degree: sorry (depends on above)
-  - krylov_independent_card_le_minpoly_degree: sorry (depends on above)
-  - krylov_iteration_bound: sorry (depends on above, but proof complete modulo above)
-  - nonderogatory_krylov_optimal: sorry (needs cyclic vector → LI argument)
+  - aeval_mulVec_eq_krylov_sum: ✓ (proved via sum_mulVec + eval₂ expansion)
+  - krylov_dependent_at_minpoly_degree: ✓ (proved via monic leading coeff)
+  - krylov_independent_card_le_minpoly_degree: ✓ (proved)
+  - krylov_iteration_bound: ✓ (proved)
+  - nonderogatory_krylov_optimal: ✓ (proved via polynomial construction)
 
-  **Key sorries**: 4 (all in the dependency chain from aeval_mulVec_eq_krylov_sum)
+  **All theorems proved**: 0 sorries remaining
 -/
 
 end MinpolyComplexity

--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean
@@ -105,7 +105,7 @@ private theorem sum_mulVec {ι : Type*} [DecidableEq ι] (s : Finset ι)
     (∑ i ∈ s, f i).mulVec v = ∑ i ∈ s, (f i).mulVec v := by
   induction s using Finset.induction_on with
   | empty => simp [Matrix.zero_mulVec]
-  | insert has ih =>
+  | @insert a s' has ih =>
     rw [Finset.sum_insert has, Matrix.add_mulVec, ih, Finset.sum_insert has]
 
 theorem aeval_mulVec_eq_krylov_sum (M : Matrix (Fin n) (Fin n) K)
@@ -122,7 +122,7 @@ theorem aeval_mulVec_eq_krylov_sum (M : Matrix (Fin n) (Fin n) K)
     · congr 1; ext i
       rw [Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
     · intro i _ hi
-      rw [Polynomial.not_mem_support_iff.mp hi, map_zero, zero_mul]
+      rw [Polynomial.notMem_support_iff.mp hi, map_zero, zero_mul]
   rw [haeval_expand, sum_mulVec]
   simp only [Matrix.smul_mulVec, krylovVec]
 
@@ -170,11 +170,9 @@ theorem krylov_dependent_at_minpoly_degree [hn : NeZero n]
   rw [← Fin.sum_univ_eq_sum_range] at hann
   have hzero := (Fintype.linearIndependent_iff.mp hli)
     (fun i => (minpoly K M).coeff ↑i) hann
-  have h0 := hzero ⟨(minpoly K M).natDegree, Nat.lt_succ_of_le le_rfl⟩
-  dsimp at h0
-  have h1 : (minpoly K M).leadingCoeff = 1 := hmonic.leadingCoeff
-  rw [Polynomial.leadingCoeff] at h1
-  linarith
+  have h0 : (minpoly K M).leadingCoeff = 0 :=
+    hzero ⟨(minpoly K M).natDegree, Nat.lt_succ_of_le le_rfl⟩
+  exact one_ne_zero (hmonic.leadingCoeff.symm.trans h0)
 
 -- ============================================================
 -- PART V: Krylov Dimension Bound


### PR DESCRIPTION
## Summary
- Prove all 3 remaining sorries in the Krylov method formalization
- File goes from 3 sorries to 0, completing the full formal proof of O(n³) complexity

## Proofs Added

### 1. `aeval_mulVec_eq_krylov_sum` (core structural theorem)
Polynomial evaluation at a matrix distributes through mulVec:
`(aeval M p).mulVec v = ∑ (p.coeff i) • krylovVec M v i`

Proof via: helper `sum_mulVec` (distributes mulVec over finite sums), eval₂ expansion over polynomial support, and `smul_mulVec` for scalar-matrix-vector simplification.

### 2. `krylov_dependent_at_minpoly_degree` (termination theorem)
The Krylov vectors {v, Mv, ..., M^d·v} are linearly dependent at d = deg(μ_M).

Proof: expand μ(M)·v = 0 via the Krylov sum, use linear independence to force all coefficients to 0, then derive contradiction from monic leading coefficient = 1.

### 3. `nonderogatory_krylov_optimal` (optimality)
For nonderogatory matrices with a cyclic vector, exactly n Krylov vectors are linearly independent.

Proof: construct polynomial p from coefficients, show p(M)·v = 0 with deg(p) < n, apply cyclic vector property to get p = 0, extract all coefficients = 0.

## Verification
Docker build verified: 0 sorries, 0 axioms, all 12+ theorems proved.

🤖 Generated by researcher-7