### PR TITLE
Enrich erdos-36: add mathContext to all annotations

### DIFF
--- a/src/data/proofs/erdos-36/annotations.json
+++ b/src/data/proofs/erdos-36/annotations.json
@@ -264,7 +264,8 @@
       "expository comments",
       "module documentation"
     ],
-    "prerequisites": []
+    "prerequisites": [],
+    "mathContext": "Three key results about the constant $c = \\lim_{N \\to \\infty} M(N)/N$: (1) Erdős conjectured $c = 1/2$ (disproved), (2) the Fourier approach gives $c \\geq 1 - 1/\\sqrt{2}$, (3) connections to additive combinatorics discrepancy theory."
   },
   {
     "id": "ann-e36-conjecture-disproved",


### PR DESCRIPTION
## Summary
- Added `mathContext` to the one annotation missing it (ann-e36-observations)
- All 15/15 annotations now have complete LaTeX mathematical context
- 0 annotation build warnings