### PR TITLE
Gallery audit: fix stale cayley-hamilton-minpoly-oq-03 metadata

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2,8 +2,8 @@
   "version": 1,
   "entries": {
     "pythagorean-triples": {
-      "auditCount": 7,
-      "lastAudited": "2026-03-24T11:54:24Z",
+      "auditCount": 8,
+      "lastAudited": "2026-03-24T13:54:17Z",
       "result": "clean",
       "issues": []
     },
@@ -453,8 +453,8 @@
       "issues": []
     },
     "chinese-remainder-non-coprime-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:02:41Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T13:57:28Z",
       "result": "clean",
       "issues": []
     },
@@ -465,8 +465,8 @@
       "issues": []
     },
     "cramers-rule-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:02:41Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T13:57:27Z",
       "result": "clean",
       "issues": []
     },
@@ -501,8 +501,8 @@
       "issues": []
     },
     "derangements-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:02:42Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T13:57:29Z",
       "result": "clean",
       "issues": []
     },
@@ -543,8 +543,8 @@
       "issues": []
     },
     "pascals-hexagon": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T13:58:14Z",
       "result": "clean",
       "issues": []
     },
@@ -561,14 +561,14 @@
       "issues": []
     },
     "poincare-conjecture": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T13:58:14Z",
       "result": "clean",
       "issues": []
     },
     "taylor-sincos-convergence": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T13:58:14Z",
       "result": "clean",
       "issues": []
     },
@@ -9139,6 +9139,18 @@
       "auditCount": 1,
       "result": "clean",
       "agentId": "auditor-cycle-20-batch"
+    },
+    "cayley-hamilton-minpoly-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T13:57:20Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-1007-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T13:57:26Z",
+      "result": "clean",
+      "issues": []
     }
   }
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(linear_algebra)#Computation",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
     "tags": [
       "linear-algebra",
@@ -18,8 +18,8 @@
       "computational-complexity",
       "research"
     ],
-    "badge": "formalized",
-    "sorries": 3,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.monic",
@@ -79,8 +79,8 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 326,
-    "assumptions": "3 sorries: aeval_mulVec_eq_krylov_sum (polynomial-Krylov expansion), krylov_dependent_at_minpoly_degree (termination), nonderogatory_krylov_optimal (cyclic vector independence). No axioms.",
+    "lineCount": 368,
+    "assumptions": "0 axioms, 0 sorries. All 12 theorems fully proved. Uses Mathlib's minpoly infrastructure (monic, aeval, dvd_charpoly) as foundation for original Krylov theory.",
     "mathlib_version": "4.26.0"
   },
   "leanFile": {
@@ -88,8 +88,8 @@
     "theoremCount": 12,
     "defCount": 1,
     "axiomCount": 0,
-    "sorryCount": 3,
-    "lineCount": 326
+    "sorryCount": 0,
+    "lineCount": 368
   },
   "sections": [
     {
@@ -104,7 +104,7 @@
       "title": "Polynomial Evaluation via Krylov Vectors",
       "startLine": 89,
       "endLine": 107,
-      "summary": "States the key structural theorem: evaluating polynomial p at matrix M and applying to v gives a linear combination of Krylov vectors with p's coefficients. (1 sorry)"
+      "summary": "States the key structural theorem: evaluating polynomial p at matrix M and applying to v gives a linear combination of Krylov vectors with p's coefficients."
     },
     {
       "id": "krylov-annihilation",
@@ -118,7 +118,7 @@
       "title": "Krylov Termination Theorem",
       "startLine": 128,
       "endLine": 157,
-      "summary": "States that the first deg(minpoly)+1 Krylov vectors are linearly dependent, since the monic minimal polynomial provides a nontrivial relation. (1 sorry)"
+      "summary": "States that the first deg(minpoly)+1 Krylov vectors are linearly dependent, since the monic minimal polynomial provides a nontrivial relation."
     },
     {
       "id": "krylov-dimension",
@@ -139,7 +139,7 @@
       "title": "Nonderogatory Optimality",
       "startLine": 226,
       "endLine": 250,
-      "summary": "States that for nonderogatory matrices with a cyclic vector, exactly n Krylov vectors are linearly independent -- the method is optimal. (1 sorry)"
+      "summary": "States that for nonderogatory matrices with a cyclic vector, exactly n Krylov vectors are linearly independent -- the method is optimal."
     },
     {
       "id": "invariance-recurrence",
@@ -150,7 +150,7 @@
     }
   ],
   "overview": "The minimal polynomial of an n\u00d7n matrix M over a field K can be computed in O(n\u00b3) field operations using the Krylov method. Starting from any vector v, compute the sequence v, Mv, M\u00b2v, ...; when M^d\u00b7v first becomes a linear combination of the previous vectors, d equals the degree of v's annihilating polynomial (which divides \u03bc_M). Since d \u2264 deg(\u03bc_M) \u2264 n, at most n matrix-vector products (each O(n\u00b2)) suffice. This formalization defines Krylov sequences, proves the recurrence relation enabling efficient computation, establishes termination via the minimal polynomial, and bounds the iteration count. For nonderogatory matrices (\u03bc_M = \u03c7_M), a single cyclic vector's Krylov sequence extracts the full minimal polynomial.",
-  "conclusion": "The Krylov method provides an O(n\u00b3) algorithm for computing the minimal polynomial, with the key structural insight that polynomial evaluation at a matrix distributes through the Krylov sequence. The formalization establishes 9 proved results including the recurrence, annihilation, and dimension bounds, with 3 sorries in the polynomial-to-Krylov expansion chain suitable for Aristotle proof search.",
+  "conclusion": "The Krylov method provides an O(n\u00b3) algorithm for computing the minimal polynomial, with the key structural insight that polynomial evaluation at a matrix distributes through the Krylov sequence. The formalization establishes 12 fully proved theorems including the recurrence, annihilation, dimension bounds, and nonderogatory optimality. All sorries have been resolved.",
   "references": [
     {
       "type": "paper",


### PR DESCRIPTION
## Summary

- **cayley-hamilton-minpoly-oq-03**: All 3 sorries have been resolved in the Lean source but meta.json was stale. Fixed: status `formalized`→`verified`, badge `formalized`→`original`, sorries `3`→`0`, lineCount `326`→`368`, removed "(1 sorry)" annotations from section summaries
- Audited 8 proofs total this cycle, including 7 scanner false positives (verified as clean)

## Audit Results

| Proof | Result | Notes |
|-------|--------|-------|
| pythagorean-triples | clean | 3 `example : True` are pedagogical, not proof claims |
| cayley-hamilton-minpoly-oq-03 | **fixed** | Stale metadata: 3 sorries resolved |
| erdos-1007-oq-01-oq-01 | clean | Mathlib utils (Nat.choose), not core result |
| cramers-rule-oq-02 | clean | Mathlib utils (factorial), not core result |
| chinese-remainder-non-coprime-oq-04 | clean | Pigeonhole is tool, not core result |
| derangements-oq-03 | clean | Uses Mathlib infra, original convergence proof |
| taylor-sincos-convergence | clean | Scanner axiom detection broken (reports 0, actual 2) |
| poincare-conjecture | clean | Scanner axiom detection broken (reports 0, actual 32) |
| pascals-hexagon | clean | Scanner axiom detection broken (reports 0, actual 1) |

## Scanner Issues Noted

The `find-targets.ts` scanner has two systematic false positive patterns:
1. **"directly calls major Mathlib theorem"**: Flags any proof listing `mathlibDependencies`, even when deps are basic utilities
2. **Axiom count "actual 0"**: Scanner regex fails to find `axiom` declarations in several files

## Test plan

- [x] Verified Lean source has 0 sorries: `grep -c sorry proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean` → 0
- [x] Verified 0 axioms: `grep -c "^axiom " proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean` → 0
- [x] Verified 368 lines: `wc -l` → 368
- [x] meta.json fields consistent with Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)