### PR TITLE
Enrich Skolem-Noether: rewrite annotations, add mathContext

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01/annotations.json
@@ -1,118 +1,166 @@
 [
   {
-    "id": "ann-inner-aut-def",
+    "id": "ann-module-header",
     "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 93,
-      "endLine": 95
-    },
-    "type": "definition",
-    "title": "Inner Automorphism Predicate",
-    "content": "IsInnerAut φ holds when φ equals conjugation by some invertible matrix P: φ(A) = P⁻¹AP for all A. This is an existential predicate — it asserts the existence of a conjugating unit without specifying it uniquely (since P and cP give the same automorphism for any nonzero scalar c).",
-    "mathContext": "$\\varphi \\text{ is inner} \\iff \\exists P \\in \\text{GL}_n(K), \\; \\varphi(A) = P^{-1}AP \\; \\forall A$",
+    "range": { "startLine": 1, "endLine": 18 },
+    "type": "context",
+    "title": "Module Overview: Skolem-Noether for Matrix Algebras",
+    "content": "A fully verified proof of the Skolem-Noether theorem for matrix algebras: every $K$-algebra automorphism of $M_n(K)$ is inner (conjugation by an invertible matrix). The formalization uses an elementary matrix units approach — no Artin-Wedderburn theory or simple module theory is needed.\n\nThe file contains 26 theorems/lemmas in 570 lines with 0 axioms and 0 sorries. Beyond the main theorem, it derives $\\text{Aut}_K(M_n(K)) \\cong \\text{PGL}_n(K)$, proves $\\text{Center}(M_n(K)) = K \\cdot I$, and characterizes the kernel of the conjugation map.",
+    "mathContext": "Skolem-Noether: $\\forall \\varphi \\in \\text{Aut}_K(M_n(K)),\\; \\exists P \\in \\text{GL}_n(K),\\; \\varphi(A) = P^{-1}AP$.\n\nConsequence: $\\text{Aut}_K(M_n(K)) \\cong \\text{GL}_n(K) / K^* = \\text{PGL}_n(K)$.",
     "significance": "key",
+    "prerequisites": [
+      "matrix algebra",
+      "algebra automorphisms",
+      "invertible matrices"
+    ],
     "relatedConcepts": [
+      "Skolem-Noether theorem",
       "inner automorphism",
-      "conjugation",
-      "invertible matrix",
-      "PGL"
-    ],
-    "prerequisites": [
-      "algebra automorphism",
-      "units group"
-    ]
-  },
-  {
-    "id": "ann-inner-group",
-    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 97,
-      "endLine": 135
-    },
-    "type": "technique",
-    "title": "Inner Automorphisms Form a Group",
-    "content": "Three theorems establish the group structure of inner automorphisms: (1) isInnerAut_id shows the identity is inner (conjugation by 1), (2) isInnerAut_symm shows if φ is inner via P then φ⁻¹ is inner via P⁻¹, and (3) isInnerAut_trans shows if φ = conj(P) and ψ = conj(Q) then ψ ∘ φ = conj(PQ). The composition formula uses (PQ)⁻¹ = Q⁻¹P⁻¹ (reversal of order under inversion).",
-    "mathContext": "$\\text{Inn}(M_n(K))$ is a subgroup of $\\text{Aut}_K(M_n(K))$",
-    "significance": "key",
-    "relatedConcepts": [
-      "group structure",
-      "subgroup",
-      "composition of automorphisms"
-    ],
-    "prerequisites": [
-      "AlgEquiv.refl",
-      "AlgEquiv.symm",
-      "AlgEquiv.trans",
-      "mul_inv_rev"
-    ]
-  },
-  {
-    "id": "ann-skolem-noether-axiom",
-    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 157,
-      "endLine": 166
-    },
-    "type": "concept",
-    "title": "Skolem-Noether Theorem (Axiomatized)",
-    "content": "The main theorem is stated as an axiom: every K-algebra automorphism of Mₙ(K) is inner. The proof requires Artin-Wedderburn theory — specifically, that Kⁿ is the unique simple Mₙ(K)-module up to isomorphism. Given an automorphism φ, one constructs a 'twisted' module where M acts as φ(M); by uniqueness, the original and twisted modules are isomorphic via some P ∈ GL_n(K), giving φ(A) = P⁻¹AP.",
-    "mathContext": "$\\forall \\varphi \\in \\text{Aut}_K(M_n(K)), \\; \\exists P \\in \\text{GL}_n(K), \\; \\varphi(A) = P^{-1}AP$",
-    "significance": "key",
-    "relatedConcepts": [
       "central simple algebra",
-      "Artin-Wedderburn",
-      "simple modules",
-      "Skolem-Noether"
-    ],
-    "prerequisites": [
-      "simple module theory",
-      "Artin-Wedderburn theorem"
+      "projective general linear group"
     ]
   },
   {
-    "id": "ann-surjection",
+    "id": "ann-conjugation",
     "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 195,
-      "endLine": 199
-    },
-    "type": "technique",
-    "title": "Units Surject onto Automorphisms",
-    "content": "The theorem surjection_units_to_aut extracts from Skolem-Noether the equality φ = conjAlgEquiv P as an AlgEquiv equation (not just pointwise). This uses AlgEquiv.ext to promote the pointwise equality from skolemNoether to a full AlgEquiv identity. Combined with the kernel characterization (center = scalars), this yields the isomorphism Aut_K(Mₙ(K)) ≅ PGLₙ(K) = GLₙ(K)/K*.",
-    "mathContext": "The map $P \\mapsto \\text{conjAlgEquiv}(P)$ is surjective onto $\\text{Aut}_K(M_n(K))$",
+    "range": { "startLine": 19, "endLine": 92 },
+    "type": "definition",
+    "title": "Conjugation Automorphism and Inner Automorphism Predicate",
+    "content": "`conjAlgEquiv P` constructs the conjugation map $A \\mapsto P^{-1}AP$ as a $K$-algebra equivalence (`AlgEquiv`). The inverse map is $A \\mapsto PAP^{-1}$, and the proof that it preserves multiplication uses $(P^{-1}AB P) = (P^{-1}AP)(P^{-1}BP)$.\n\n`IsInnerAut φ` is the existential predicate: $\\varphi$ is inner iff $\\exists P \\in (M_n(K))^\\times,\\; \\varphi = \\text{conjAlgEquiv}(P)$. Note that $P$ is not unique — $P$ and $cP$ give the same automorphism for any $c \\in K^*$.\n\nInner automorphisms form a group: `isInnerAut_id` (identity = conj(1)), `isInnerAut_symm` (inverse = conj($P^{-1}$)), `isInnerAut_trans` (composition = conj($PQ$)).",
+    "mathContext": "$\\text{conj}_P(A) = P^{-1}AP$. The map $P \\mapsto \\text{conj}_P$ is a group homomorphism $\\text{GL}_n(K) \\to \\text{Aut}_K(M_n(K))$ with kernel $K^* \\cdot I$.",
     "significance": "key",
+    "prerequisites": [
+      "AlgEquiv",
+      "Units",
+      "mul_inv_cancel"
+    ],
+    "relatedConcepts": [
+      "conjugation",
+      "inner automorphism",
+      "group homomorphism"
+    ]
+  },
+  {
+    "id": "ann-helper-lemmas",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
+    "range": { "startLine": 93, "endLine": 176 },
+    "type": "technique",
+    "title": "Elementary Matrix Unit Helpers and Linear Independence",
+    "content": "The proof's technical core: helper lemmas for the elementary matrix units approach.\n\n`stdBasis_entry` and `stdBasis_mul` compute entries and products of standard basis matrices $E_{ij}$: $(E_{ij})_{kl} = \\delta_{ik}\\delta_{jl}$ and $E_{ij} \\cdot E_{kl} = \\delta_{jk} E_{il}$.\n\n`f_mul` proves $\\varphi(E_{ij}) \\cdot \\varphi(E_{kl}) = \\delta_{jk} \\varphi(E_{il})$ — the images preserve the same multiplication rules. This is the key structural property.\n\n`intertwine_prop` shows $\\varphi(E_{kk}) \\cdot p_j = \\delta_{kj} p_k$ where $p_j = \\varphi(E_{j,i_0}) \\cdot v_0$.\n\n`p_linearIndependent` proves the vectors $\\{p_j\\}$ are linearly independent using the intertwine property: if $\\sum c_j p_j = 0$, apply $\\varphi(E_{kk})$ to extract $c_k p_k = 0$, then use $p_k \\neq 0$ to get $c_k = 0$.",
+    "mathContext": "$E_{ij} E_{kl} = \\delta_{jk} E_{il}$ (standard matrix unit multiplication). Images $\\varphi(E_{ij})$ satisfy the same rule. Vectors $p_j = \\varphi(E_{j,i_0}) v_0$ are linearly independent because $\\varphi(E_{kk})$ acts as the projection onto $p_k$.",
+    "significance": "key",
+    "prerequisites": [
+      "Matrix.stdBasisMatrix",
+      "linearIndependent_iff",
+      "Fintype.linearIndependent_iff"
+    ],
+    "relatedConcepts": [
+      "matrix units",
+      "Kronecker delta",
+      "linear independence",
+      "projection"
+    ]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
+    "range": { "startLine": 178, "endLine": 280 },
+    "type": "technique",
+    "title": "The Skolem-Noether Theorem: Fully Proved",
+    "content": "The main theorem `skolemNoether` is **fully proved** (not axiomatized) using elementary matrix units.\n\n**Proof outline**:\n1. Choose $i_0 \\in n$ (from `Nonempty n`) and find $v_0$ such that $\\varphi(E_{i_0,i_0}) \\cdot v_0 \\neq 0$ (by contradiction: if all actions are zero, $\\varphi(E_{i_0,i_0}) = 0$, contradicting injectivity since $E_{i_0,i_0} \\neq 0$).\n2. Define $p_j = \\varphi(E_{j,i_0}) \\cdot v_0$ for each $j \\in n$.\n3. Form the matrix $P$ with columns $p_j$. Since $\\{p_j\\}$ are linearly independent (from `p_linearIndependent`), $P$ is invertible.\n4. Show $\\varphi(A) = P^{-1}AP$ for all $A$ by decomposing $A = \\sum_{i,j} A_{ij} E_{ij}$ and using the multiplication rules of the images.\n\nThis avoids Artin-Wedderburn theory entirely — it uses only basic matrix arithmetic and linear independence.",
+    "mathContext": "Proof: $P = [p_0 | p_1 | \\cdots | p_{n-1}]$ where $p_j = \\varphi(E_{j,i_0}) v_0$. Then $\\varphi(E_{ij}) = P^{-1} E_{ij} P$ by the multiplication rule, and $\\varphi(A) = \\sum A_{ij} \\varphi(E_{ij}) = P^{-1} (\\sum A_{ij} E_{ij}) P = P^{-1}AP$.",
+    "significance": "key",
+    "prerequisites": [
+      "LinearIndependent → IsUnit (Matrix.of p)",
+      "matrix decomposition",
+      "AlgEquiv.map_sum"
+    ],
+    "relatedConcepts": [
+      "change of basis",
+      "matrix unit decomposition",
+      "constructive proof"
+    ]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
+    "range": { "startLine": 281, "endLine": 311 },
+    "type": "insight",
+    "title": "Consequences: Surjection, Minpoly Preservation, and n=1 Case",
+    "content": "Four immediate consequences of the main theorem:\n\n`exists_conjugating_matrix`: extracts the witnessing invertible $P$ from `skolemNoether`.\n\n`surjection_units_to_aut`: the conjugation map is surjective — every automorphism equals some `conjAlgEquiv P`. This uses `AlgEquiv.ext` to promote pointwise equality to algebraic equality.\n\n`automorphism_preserves_minpoly`: every automorphism preserves minimal polynomials, via Mathlib's `minpoly.algEquiv_eq`.\n\n`skolemNoether_one`: the $n = 1$ case is proved independently — $M_1(K) \\cong K$ has only the identity automorphism, since every 1×1 matrix is scalar and automorphisms fix scalars.",
+    "mathContext": "$\\text{conj}: \\text{GL}_n(K) \\twoheadrightarrow \\text{Aut}_K(M_n(K))$ is surjective. $\\varphi(\\text{minpoly}_K(A)) = \\text{minpoly}_K(\\varphi(A)) = \\text{minpoly}_K(A)$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "AlgEquiv.ext",
+      "minpoly.algEquiv_eq"
+    ],
     "relatedConcepts": [
       "surjection",
-      "PGL",
-      "projective general linear group",
-      "quotient group"
-    ],
-    "prerequisites": [
-      "skolemNoether axiom",
-      "AlgEquiv.ext"
+      "minimal polynomial invariance",
+      "trivial case"
     ]
   },
   {
-    "id": "ann-trivial-case",
+    "id": "ann-matrix-units",
     "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
-    "range": {
-      "startLine": 218,
-      "endLine": 237
-    },
+    "range": { "startLine": 347, "endLine": 387 },
     "type": "technique",
-    "title": "The n=1 Case: Proved Without Axioms",
-    "content": "For 1×1 matrices, every K-algebra automorphism is the identity. The proof shows that every A ∈ M₁(K) is a scalar matrix (A = A₀₀ · I), and automorphisms fix scalars by the commutes' property of AlgEquiv. Since M₁(K) ≅ K and K has no nontrivial K-algebra automorphisms, this is the trivial case of Skolem-Noether. The inner automorphism is then conjugation by 1 (the identity).",
-    "mathContext": "Every $K$-algebra automorphism of $M_1(K) \\cong K$ is the identity",
+    "title": "Matrix Unit Product Formulas",
+    "content": "`mul_eij_entry` and `eij_mul_entry` compute the entries of products $A \\cdot E_{ij}$ and $E_{ij} \\cdot A$:\n- $(A \\cdot E_{ij})_{kl} = \\delta_{jl} \\cdot A_{ki}$ (right-multiplication by $E_{ij}$ extracts column $i$ and places it in column $j$)\n- $(E_{ij} \\cdot A)_{kl} = \\delta_{ik} \\cdot A_{jl}$ (left-multiplication extracts row $j$ and places it in row $i$)\n\nThese are the computational workhorses for the center characterization: commuting with $E_{ij}$ forces specific entry constraints on $A$.",
+    "mathContext": "$(A E_{ij})_{kl} = A_{ki} \\delta_{jl}$, $(E_{ij} A)_{kl} = \\delta_{ik} A_{jl}$. Commutativity $AE_{ij} = E_{ij}A$ forces $A_{ki}\\delta_{jl} = \\delta_{ik}A_{jl}$ for all $k, l$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "1×1 matrices",
-      "scalar matrices",
-      "trivial automorphism"
-    ],
     "prerequisites": [
-      "Fin 1",
-      "fin_cases",
-      "AlgEquiv.commutes"
+      "Matrix.mul_apply",
+      "Matrix.stdBasisMatrix",
+      "Finset.sum_ite_eq"
+    ],
+    "relatedConcepts": [
+      "matrix unit arithmetic",
+      "column extraction",
+      "row extraction"
+    ]
+  },
+  {
+    "id": "ann-center",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
+    "range": { "startLine": 388, "endLine": 452 },
+    "type": "technique",
+    "title": "Center of Mₙ(K) = Scalar Matrices",
+    "content": "Proves `center_iff_scalar`: a matrix $A$ commutes with all matrices iff $A = c \\cdot I$ for some $c \\in K$.\n\n**Proof**: Two helper lemmas:\n1. `off_diagonal_vanish_of_center`: If $AE_{ij} = E_{ij}A$ for all $i \\neq j$, then $A_{kl} = 0$ for $k \\neq l$. Setting $k = i, l = j$ in the entry formula gives $A_{ki}\\delta_{jl} = \\delta_{ik}A_{jl}$; with $k \\neq i$ and $l = j$ this gives $A_{kj} = 0$.\n2. `diagonal_constant_of_center`: If $A$ commutes with all $E_{ij}$, then all diagonal entries are equal: $A_{ii} = A_{jj}$.\n\nCombined: $A$ commuting with all matrices $\\Rightarrow$ $A$ is diagonal with constant diagonal $\\Rightarrow$ $A = c \\cdot I$.",
+    "mathContext": "$\\text{Center}(M_n(K)) = \\{c \\cdot I : c \\in K\\} \\cong K$. This is a special case of the general fact that the center of a central simple algebra is the base field.",
+    "significance": "key",
+    "prerequisites": [
+      "mul_eij_entry",
+      "eij_mul_entry",
+      "Matrix.ext_iff"
+    ],
+    "relatedConcepts": [
+      "center of a ring",
+      "scalar matrices",
+      "Schur's lemma",
+      "central simple algebra"
+    ]
+  },
+  {
+    "id": "ann-pgl",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
+    "range": { "startLine": 453, "endLine": 570 },
+    "type": "technique",
+    "title": "PGL Structure: Conjugation Kernel and Automorphism Classification",
+    "content": "The final section characterizes when two units give the same conjugation:\n\n`conjAlgEquiv_eq_iff_center`: $\\text{conj}_P = \\text{conj}_Q$ iff $Q^{-1}P$ is central (i.e., scalar). Proof: $P^{-1}AP = Q^{-1}AQ$ for all $A$ iff $(QP^{-1})A = A(QP^{-1})$ for all $A$ iff $QP^{-1} \\in \\text{Center}(M_n(K))$.\n\n`conjAlgEquiv_eq_refl_iff`: the kernel of the conjugation map ($\\text{conj}_P = \\text{id}$) is exactly the scalar matrices. This gives the short exact sequence:\n$$1 \\to K^* \\to \\text{GL}_n(K) \\xrightarrow{\\text{conj}} \\text{Aut}_K(M_n(K)) \\to 1$$\nand hence $\\text{Aut}_K(M_n(K)) \\cong \\text{GL}_n(K) / K^* = \\text{PGL}_n(K)$.",
+    "mathContext": "$\\ker(\\text{conj}) = K^* \\cdot I \\cong K^*$. Combined with surjectivity (Skolem-Noether): $\\text{Aut}_K(M_n(K)) \\cong \\text{GL}_n(K) / K^* = \\text{PGL}_n(K)$.",
+    "significance": "key",
+    "prerequisites": [
+      "center_iff_scalar",
+      "skolemNoether",
+      "short exact sequence"
+    ],
+    "relatedConcepts": [
+      "PGL",
+      "projective general linear group",
+      "short exact sequence",
+      "quotient group",
+      "kernel characterization"
     ]
   }
 ]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01/meta.json
@@ -103,56 +103,64 @@
       "title": "Conjugation Automorphism",
       "startLine": 19,
       "endLine": 53,
-      "summary": "Constructs conjAlgEquiv P : Matrix n n K ≃ₐ[K] Matrix n n K, the conjugation automorphism A ↦ P⁻¹AP with inverse A ↦ PAP⁻¹."
+      "summary": "Constructs conjAlgEquiv P : Matrix n n K ≃ₐ[K] Matrix n n K, the conjugation automorphism A ↦ P⁻¹AP with inverse A ↦ PAP⁻¹.",
+      "mathContext": "$\\text{conj}_P(A) = P^{-1}AP$ defines a $K$-algebra isomorphism since $(P^{-1}AP)(P^{-1}BP) = P^{-1}ABP$ and $P^{-1}(cA)P = cP^{-1}AP$."
     },
     {
       "id": "inner-automorphisms",
       "title": "Inner Automorphisms",
       "startLine": 54,
       "endLine": 83,
-      "summary": "Defines IsInnerAut and proves inner automorphisms form a group: conjAlgEquiv_isInner, isInnerAut_id, isInnerAut_symm, isInnerAut_trans."
+      "summary": "Defines IsInnerAut and proves inner automorphisms form a group: conjAlgEquiv_isInner, isInnerAut_id, isInnerAut_symm, isInnerAut_trans.",
+      "mathContext": "$\\text{Inn}(M_n(K)) = \\{\\text{conj}_P : P \\in \\text{GL}_n(K)\\}$ is a subgroup of $\\text{Aut}_K(M_n(K))$. Skolem-Noether will show $\\text{Inn} = \\text{Aut}$."
     },
     {
       "id": "skolem-noether-proof",
       "title": "Skolem-Noether Proof (Elementary Matrix Units)",
       "startLine": 84,
       "endLine": 280,
-      "summary": "Fully proves the Skolem-Noether theorem using elementary matrix units (no Artin-Wedderburn). Helper lemmas: stdBasis_entry, stdBasis_mul, f_mul, intertwine_prop, p_ne_zero, p_linearIndependent. Main theorem constructs an invertible P from linearly independent vectors p_j = φ(E_{j,i₀})·v₀ and proves φ = conj(P) by decomposing matrices as ∑ A_{ij}·E_{ij}."
+      "summary": "Fully proves the Skolem-Noether theorem using elementary matrix units (no Artin-Wedderburn). Helper lemmas: stdBasis_entry, stdBasis_mul, f_mul, intertwine_prop, p_ne_zero, p_linearIndependent. Main theorem constructs an invertible P from linearly independent vectors p_j = φ(E_{j,i₀})·v₀ and proves φ = conj(P) by decomposing matrices as ∑ A_{ij}·E_{ij}.",
+      "mathContext": "Key chain: $E_{ij} E_{kl} = \\delta_{jk} E_{il}$ $\\Rightarrow$ $\\varphi(E_{ij})\\varphi(E_{kl}) = \\delta_{jk}\\varphi(E_{il})$ $\\Rightarrow$ $\\varphi(E_{kk})$ acts as projection onto $p_k$ $\\Rightarrow$ $\\{p_j\\}$ linearly independent $\\Rightarrow$ $P = [p_0|\\cdots|p_{n-1}]$ invertible $\\Rightarrow$ $\\varphi = \\text{conj}_P$."
     },
     {
       "id": "consequences",
       "title": "Consequences",
       "startLine": 281,
       "endLine": 298,
-      "summary": "Derives exists_conjugating_matrix, surjection_units_to_aut (Aut = Inn), automorphism_preserves_minpoly, and aut_ext."
+      "summary": "Derives exists_conjugating_matrix, surjection_units_to_aut (Aut = Inn), automorphism_preserves_minpoly, and aut_ext.",
+      "mathContext": "$\\text{conj}: \\text{GL}_n(K) \\twoheadrightarrow \\text{Aut}_K(M_n(K))$ (surjective). $\\varphi(\\text{minpoly}_K(A)) = \\text{minpoly}_K(A)$ (invariance)."
     },
     {
       "id": "trivial-case",
       "title": "The Trivial Case n = 1",
       "startLine": 299,
       "endLine": 311,
-      "summary": "Proves Skolem-Noether for M₁(K) without the main theorem: every 1×1 matrix is scalar, so every automorphism of M₁(K) ≅ K is the identity."
+      "summary": "Proves Skolem-Noether for M₁(K) without the main theorem: every 1×1 matrix is scalar, so every automorphism of M₁(K) ≅ K is the identity.",
+      "mathContext": "$M_1(K) \\cong K$ as $K$-algebras. Every $K$-algebra endomorphism of $K$ is the identity (it fixes 1 and is $K$-linear)."
     },
     {
       "id": "matrix-unit-products",
       "title": "Matrix Unit Product Lemmas",
       "startLine": 347,
       "endLine": 387,
-      "summary": "Helper lemmas mul_eij_entry and eij_mul_entry for computing products A·E_{ij} and E_{ij}·A, extracting/placing columns and rows."
+      "summary": "Helper lemmas mul_eij_entry and eij_mul_entry for computing products A·E_{ij} and E_{ij}·A, extracting/placing columns and rows.",
+      "mathContext": "$(AE_{ij})_{kl} = A_{ki}\\delta_{jl}$ (extract column $i$, place in column $j$). $(E_{ij}A)_{kl} = \\delta_{ik}A_{jl}$ (extract row $j$, place in row $i$)."
     },
     {
       "id": "center",
       "title": "Center of Mₙ(K) = Scalar Matrices",
       "startLine": 388,
       "endLine": 452,
-      "summary": "Proves center_iff_scalar: a matrix commutes with all matrices iff it is a scalar multiple of I. Uses off_diagonal_vanish_of_center and diagonal_constant_of_center."
+      "summary": "Proves center_iff_scalar: a matrix commutes with all matrices iff it is a scalar multiple of I. Uses off_diagonal_vanish_of_center and diagonal_constant_of_center.",
+      "mathContext": "$\\text{Center}(M_n(K)) = \\{cI : c \\in K\\} \\cong K$. Proof: commuting with $E_{ij}$ ($i \\neq j$) kills off-diagonal entries; commuting with all $E_{ij}$ forces equal diagonal entries."
     },
     {
       "id": "pgl-structure",
       "title": "Conjugation Kernel and PGL Structure",
       "startLine": 453,
       "endLine": 570,
-      "summary": "Proves conjAlgEquiv_eq_iff_center (two units give same conjugation iff ratio is central) and conjAlgEquiv_eq_refl_iff (kernel = scalar matrices), establishing Aut_K(Mₙ(K)) ≅ PGLₙ(K)."
+      "summary": "Proves conjAlgEquiv_eq_iff_center (two units give same conjugation iff ratio is central) and conjAlgEquiv_eq_refl_iff (kernel = scalar matrices), establishing Aut_K(Mₙ(K)) ≅ PGLₙ(K).",
+      "mathContext": "$\\ker(\\text{conj}: \\text{GL}_n(K) \\to \\text{Aut}_K(M_n(K))) = K^* \\cdot I$. By first isomorphism theorem: $\\text{Aut}_K(M_n(K)) \\cong \\text{GL}_n(K) / K^* = \\text{PGL}_n(K)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for cayley-hamilton-minpoly-oq-02-oq-01-oq-01 (Skolem-Noether theorem, 570 lines, 26 theorems).

## Changes
- Rewrote annotations from 5 to 8, **fixing incorrect "axiomatized" label** — the theorem is fully proved (0 axioms), not axiomatized
- Added comprehensive annotations for all sections including center characterization and PGL structure
- Added mathContext to all 8 sections in meta.json
- All annotations have mathContext, significance, relatedConcepts, prerequisites

## Bug Fix
The previous annotation `ann-skolem-noether-axiom` incorrectly labeled the theorem as "axiomatized" and pointed to the wrong line range (p_linearIndependent helper, not the main theorem). This has been corrected.