### PR TITLE
Fix: erdos-1068 metadata (0 sorries, axiomatized)

### DIFF
--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -16,13 +16,13 @@
       "infinite-connectivity"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1068,
     "erdosUrl": "https://erdosproblems.com/1068",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
     "lineCount": 205,
-    "assumptions": "3 axioms: erdos_1068 (OPEN conjecture), soukup_uncountable_not_inf_connected (research result), problem_1067_disproved (research result). 2 sorries in proof of inf_connected_no_finite_separator.",
+    "assumptions": "3 axioms: erdos_1068 (OPEN conjecture), soukup_uncountable_not_inf_connected (research result), problem_1067_disproved (research result). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update erdos-1068 meta.json sorry count to match actual Lean source.

## Evidence

**Before**: sorries=2, axiomCount=3, status=axiomatized
**After**: sorries=0, axiomCount=3, status=axiomatized

The 2 sorries in `inf_connected_no_finite_separator` were proved. The 3 axioms
(open conjecture + 2 research results) remain, so status stays axiomatized.

---
Automated fix by lean-mechanic agent.