### PR TITLE
Enrich erdos-820 + erdos-572 + erdos-714: add annotation depth

### DIFF
--- a/src/data/proofs/erdos-714/annotations.json
+++ b/src/data/proofs/erdos-714/annotations.json
@@ -9,14 +9,17 @@
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdos Problem #714: The Zarankiewicz Problem**\n\nIs ex(n; K_{r,r}) >> n^{2-1/r}?\n\nThis asks if the Kovari-Sos-Turan upper bound is tight.\n\n**Status:** Proved for r=2,3; OPEN for r >= 4.",
-    "mathContext": "One of the most famous open problems in extremal graph theory.",
+    "mathContext": "$\\mathrm{ex}(n; K_{r,r})$ denotes the maximum number of edges in an $n$-vertex graph containing no $K_{r,r}$. The KST theorem gives $\\mathrm{ex}(n; K_{r,r}) = O(n^{2-1/r})$; this problem asks whether $\\mathrm{ex}(n; K_{r,r}) = \\Omega(n^{2-1/r})$.",
     "significance": "key",
     "relatedConcepts": [
       "Extremal graph theory",
       "Bipartite graphs",
       "Turan-type problems"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Graph theory fundamentals",
+      "Asymptotic notation"
+    ]
   },
   {
     "id": "ann-e714-bipartite",
@@ -29,9 +32,16 @@
     "title": "Complete Bipartite Subgraph",
     "content": "**containsCompleteBipartite:**\n\nG contains K_{r,s} if there exist disjoint sets A, B with |A|=r, |B|=s, and all edges between A and B present.\n\n```lean\ndef containsCompleteBipartite (G : SimpleGraph V) [Fintype V] (r s : N) : Prop :=\n  exists (A B : Finset V), A.card = r and B.card = s and Disjoint A B and\n    forall a in A, forall b in B, G.Adj a b\n```",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of complete bipartite subgraph",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "$G \\supseteq K_{r,s}$ iff $\\exists\\, A, B \\subseteq V(G)$ with $|A|=r$, $|B|=s$, $A \\cap B = \\emptyset$, and $\\forall a \\in A,\\, b \\in B,\\; \\{a,b\\} \\in E(G)$.",
+    "relatedConcepts": [
+      "Complete bipartite graph $K_{r,s}$",
+      "Subgraph containment",
+      "Disjoint vertex sets"
+    ],
+    "prerequisites": [
+      "SimpleGraph and adjacency in Lean/Mathlib",
+      "Finset operations"
+    ]
   },
   {
     "id": "ann-e714-krr-free",
@@ -44,9 +54,15 @@
     "title": "K_{r,r}-Free Property",
     "content": "**isKrrFree:**\n\nA graph is K_{r,r}-free if it contains no complete bipartite K_{r,r}.\n\n```lean\ndef isKrrFree (G : SimpleGraph V) [Fintype V] (r : N) : Prop :=\n  not containsCompleteBipartite G r r\n```",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of k_{r,r}-free property",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "$G$ is $K_{r,r}$-free iff $\\neg\\,\\texttt{containsCompleteBipartite}\\;G\\;r\\;r$, i.e., no pair of disjoint $r$-element sets spans a complete bipartite subgraph.",
+    "relatedConcepts": [
+      "Forbidden subgraph property",
+      "Turan-type extremal conditions",
+      "Bipartite Ramsey theory"
+    ],
+    "prerequisites": [
+      "containsCompleteBipartite definition"
+    ]
   },
   {
     "id": "ann-e714-extremal",
@@ -58,10 +74,18 @@
     "type": "definition",
     "title": "Extremal Function for K_{r,r}",
     "content": "**exKrr:**\n\nex(n; K_{r,r}) = max{|E(G)| : G has n vertices, no K_{r,r}}\n\n```lean\nnoncomputable def exKrr (n r : N) : N :=\n  sSup {m : N | exists V G, card V = n and isKrrFree G r and edgeCount G = m}\n```\n\nThis is the central object in the Zarankiewicz problem.",
-    "mathContext": "The extremal function measures the maximum edge density avoiding K_{r,r}.",
+    "mathContext": "$\\mathrm{ex}(n; K_{r,r}) = \\max\\{|E(G)| : |V(G)| = n,\\; G \\text{ is } K_{r,r}\\text{-free}\\}$. Defined via $\\mathrm{sSup}$ over the set of achievable edge counts.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Extremal function",
+      "Supremum over natural numbers",
+      "Turan number"
+    ],
+    "prerequisites": [
+      "isKrrFree definition",
+      "edgeCount definition",
+      "Lattice supremum (sSup)"
+    ]
   },
   {
     "id": "ann-e714-kst",
@@ -73,13 +97,17 @@
     "type": "concept",
     "title": "Kovari-Sos-Turan Upper Bound",
     "content": "**kovari_sos_turan:**\n\nFor all r >= 2: ex(n; K_{r,r}) <= c * n^{2-1/r}\n\nMore precisely: ex(n; K_{r,r}) <= (1/2)(r-1)^{1/r} * n^{2-1/r} + O(n)\n\nThis 1954 theorem is the fundamental upper bound.",
-    "mathContext": "Proved by double counting: count pairs (v, S) where S is an r-subset of neighbors of v.",
+    "mathContext": "$\\forall\\, r \\ge 2,\\; \\exists\\, c > 0 : \\mathrm{ex}(n; K_{r,r}) \\le c \\cdot n^{2 - 1/r}$. Proved by double counting pairs $(v, S)$ where $S$ is an $r$-subset of $N(v)$, yielding $\\mathrm{ex}(n; K_{r,r}) \\le \\tfrac{1}{2}(r-1)^{1/r} n^{2-1/r} + \\tfrac{r-1}{2}n$.",
     "significance": "key",
     "relatedConcepts": [
       "Double counting",
-      "Counting arguments"
+      "Counting arguments",
+      "Convexity inequality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Extremal function exKrr",
+      "Combinatorial double counting"
+    ]
   },
   {
     "id": "ann-e714-exponent",
@@ -92,9 +120,15 @@
     "title": "The KST Exponent",
     "content": "**kstExponent:**\n\nThe exponent 2 - 1/r:\n- r=2: 3/2 = 1.5\n- r=3: 5/3 = 1.667\n- r=4: 7/4 = 1.75\n- As r -> infinity: exponent -> 2",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of the kst exponent",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "$\\texttt{kstExponent}(r) = 2 - \\frac{1}{r}$. Key values: $\\frac{3}{2}$ for $r=2$, $\\frac{5}{3}$ for $r=3$, $\\frac{7}{4}$ for $r=4$. As $r \\to \\infty$, the exponent approaches $2$, reflecting that dense graphs eventually contain large $K_{r,r}$.",
+    "relatedConcepts": [
+      "Turan exponent",
+      "Rational exponents in extremal problems",
+      "Density threshold"
+    ],
+    "prerequisites": [
+      "Real-valued arithmetic in Lean"
+    ]
   },
   {
     "id": "ann-e714-conjecture",
@@ -107,9 +141,16 @@
     "title": "The Erdos Conjecture",
     "content": "**erdosConjectureLowerBound:**\n\nFor all r >= 2: ex(n; K_{r,r}) >> n^{2-1/r}\n\n```lean\ndef erdosConjectureLowerBound (r : N) : Prop :=\n  exists c > 0, forall n >= 1, exKrr n r >= c * n^{2-1/r}\n```\n\nThis asks if the KST upper bound is tight.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of the erdos conjecture",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "$\\texttt{erdosConjectureLowerBound}(r) :\\equiv \\exists\\, c > 0,\\; \\forall\\, n \\ge 1,\\; \\mathrm{ex}(n; K_{r,r}) \\ge c \\cdot n^{2-1/r}$. Together with the KST upper bound, a positive answer would give $\\mathrm{ex}(n; K_{r,r}) = \\Theta(n^{2-1/r})$.",
+    "relatedConcepts": [
+      "Asymptotic tightness",
+      "Lower bound constructions",
+      "Extremal graph conjectures"
+    ],
+    "prerequisites": [
+      "exKrr definition",
+      "kstExponent definition"
+    ]
   },
   {
     "id": "ann-e714-r2",
@@ -121,14 +162,17 @@
     "type": "concept",
     "title": "Complete Solution for r=2",
     "content": "**zarankiewicz_r2:**\n\nex(n; K_{2,2}) = (1/2 + o(1)) * n^{3/2}\n\nSince K_{2,2} = C_4 (the 4-cycle), this follows from the Erdos-Klein-Reiman theorem.\n\nExtremal graphs come from incidence graphs of projective planes.",
-    "mathContext": "The Petersen graph and friends achieve the bound.",
+    "mathContext": "$\\exists\\, c_1, c_2 > 0$ with $c_1 \\le c_2$ such that $c_1 n^{3/2} \\le \\mathrm{ex}(n; K_{2,2}) \\le c_2 n^{3/2}$ for all $n \\ge 1$. The exact leading constant is $\\tfrac{1}{2} + o(1)$, achieved by incidence graphs of $\\mathrm{PG}(2,q)$.",
     "significance": "key",
     "relatedConcepts": [
       "Projective planes",
       "C_4-free graphs",
       "Problem #768"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "exKrr definition",
+      "Projective plane incidence graphs"
+    ]
   },
   {
     "id": "ann-e714-r3",
@@ -140,10 +184,17 @@
     "type": "concept",
     "title": "Brown's Theorem for r=3",
     "content": "**brown_theorem:**\n\nex(n; K_{3,3}) >= c * n^{5/3}\n\nBrown (1966) and independently Erdos-Renyi-Sos (1966) proved this.\n\nThe construction uses generalized hexagons from incidence geometry.",
-    "mathContext": "Uses algebraic constructions over finite fields.",
+    "mathContext": "$\\exists\\, c > 0 : \\mathrm{ex}(n; K_{3,3}) \\ge c \\cdot n^{5/3}$ for all $n \\ge 1$. The exponent $\\frac{5}{3} = 2 - \\frac{1}{3}$ matches the KST upper bound, so $\\mathrm{ex}(n; K_{3,3}) = \\Theta(n^{5/3})$.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Generalized hexagons",
+      "Incidence geometry",
+      "Algebraic constructions over finite fields"
+    ],
+    "prerequisites": [
+      "exKrr definition",
+      "Generalized polygons"
+    ]
   },
   {
     "id": "ann-e714-r2-proof",
@@ -152,13 +203,20 @@
       "startLine": 145,
       "endLine": 159
     },
-    "type": "technique",
+    "type": "concept",
     "title": "Conjecture Proved for r=2",
     "content": "**erdos_714_r2:**\n\n```lean\ntheorem erdos_714_r2 : erdosConjectureLowerBound 2 := by\n  unfold erdosConjectureLowerBound\n  obtain (c1, c2, hc1, _, hbounds) := zarankiewicz_r2\n  use c1\n  ...\n```\n\nFollows from zarankiewicz_r2 since 3/2 = 2 - 1/2.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of conjecture proved for r=2",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "From $\\texttt{zarankiewicz\\_r2}$ we obtain $c_1 > 0$ with $\\mathrm{ex}(n;K_{2,2}) \\ge c_1 n^{3/2}$. Since $\\frac{3}{2} = 2 - \\frac{1}{2}$, this is exactly $\\texttt{erdosConjectureLowerBound}\\;2$. The proof uses \\texttt{norm\\_num} to verify the exponent equality.",
+    "relatedConcepts": [
+      "Exponent normalization",
+      "Unfolding definitions in Lean",
+      "norm_num tactic"
+    ],
+    "prerequisites": [
+      "zarankiewicz_r2 axiom",
+      "erdosConjectureLowerBound definition"
+    ]
   },
   {
     "id": "ann-e714-r3-proof",
@@ -167,13 +225,20 @@
       "startLine": 160,
       "endLine": 171
     },
-    "type": "technique",
+    "type": "concept",
     "title": "Conjecture Proved for r=3",
     "content": "**erdos_714_r3:**\n\nFollows from Brown's theorem since 5/3 = 2 - 1/3.\n\nThe construction uses generalized hexagons.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of conjecture proved for r=3",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "From $\\texttt{brown\\_theorem}$, $\\exists\\,c>0 : \\mathrm{ex}(n;K_{3,3}) \\ge c\\,n^{5/3}$. Since $\\frac{5}{3} = 2 - \\frac{1}{3}$, this yields $\\texttt{erdosConjectureLowerBound}\\;3$. Again closed by \\texttt{norm\\_num}.",
+    "relatedConcepts": [
+      "Brown's theorem (1966)",
+      "Erdos-Renyi-Sos theorem",
+      "Generalized hexagon construction"
+    ],
+    "prerequisites": [
+      "brown_theorem axiom",
+      "erdosConjectureLowerBound definition"
+    ]
   },
   {
     "id": "ann-e714-r4-open",
@@ -186,9 +251,16 @@
     "title": "r=4 Case: OPEN",
     "content": "**best_known_lower_bound_r4:**\n\nNo construction achieving ex(n; K_{4,4}) >> n^{7/4} is known.\n\nThe best known lower bound gives only n^{3/2}, strictly weaker than the conjectured n^{7/4}.\n\nThis is one of the most famous open problems in extremal combinatorics.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of r=4 case: open",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "The axiom states $\\exists\\,c>0 : \\mathrm{ex}(n;K_{4,4}) \\ge c\\,n^{3/2}$, but the conjecture asks for $\\Omega(n^{7/4})$. The gap $\\frac{3}{2} < \\frac{7}{4}$ means current constructions fall short by a polynomial factor $n^{1/4}$.",
+    "relatedConcepts": [
+      "Open problems in extremal combinatorics",
+      "Polynomial gap in exponents",
+      "Algebraic vs probabilistic constructions"
+    ],
+    "prerequisites": [
+      "exKrr definition",
+      "Kovari-Sos-Turan upper bound"
+    ]
   },
   {
     "id": "ann-e714-projective",
@@ -200,13 +272,17 @@
     "type": "concept",
     "title": "Projective Plane Construction",
     "content": "**projective_plane_construction:**\n\nFor r=2, extremal graphs come from incidence graphs of projective planes PG(2,q).\n\nIf q is prime, the incidence graph has:\n- q^2 + q + 1 vertices\n- (q+1)(q^2+q+1) edges\n- No K_{2,2} subgraph",
-    "mathContext": "Projective planes over finite fields provide optimal K_{2,2}-free graphs.",
+    "mathContext": "For prime $q$, the incidence graph of $\\mathrm{PG}(2,q)$ has $q^2+q+1$ vertices, $(q+1)(q^2+q+1)$ edges, and is $K_{2,2}$-free. This gives $\\mathrm{ex}(n;K_{2,2}) \\ge \\frac{1}{2}n^{3/2}$ for infinitely many $n$.",
     "significance": "key",
     "relatedConcepts": [
       "Finite geometry",
-      "Projective planes"
+      "Projective planes",
+      "Incidence graphs"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Projective planes over finite fields",
+      "isKrrFree definition"
+    ]
   },
   {
     "id": "ann-e714-hexagon",
@@ -219,9 +295,16 @@
     "title": "Generalized Hexagons",
     "content": "**generalized_hexagon_construction:**\n\nFor r=3, constructions use generalized hexagons (girth-12 cages from incidence geometry).\n\nWhen q is a prime power, these give K_{3,3}-free graphs on O(q^3) vertices with O(q^5) edges, matching the n^{5/3} bound.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of generalized hexagons",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "A generalized hexagon of order $q$ yields a $K_{3,3}$-free graph on $q^3+q^2+q+1$ vertices. With $\\Theta(q^5)$ edges and $n = \\Theta(q^3)$, the edge count is $\\Theta(n^{5/3})$, matching the KST bound for $r=3$.",
+    "relatedConcepts": [
+      "Generalized polygons",
+      "Girth and cage graphs",
+      "Tits buildings"
+    ],
+    "prerequisites": [
+      "Incidence geometry",
+      "isKrrFree definition"
+    ]
   },
   {
     "id": "ann-e714-norm-graph",
@@ -233,13 +316,17 @@
     "type": "concept",
     "title": "Norm Graphs (KRS 1996)",
     "content": "**norm_graph_lower_bound:**\n\nKollar-Ronyai-Szabo (1996) used algebraic constructions via norms over finite fields to give K_{r,r}-free graphs with Omega(n^{2-2/(r+1)}) edges.\n\nFor r >= 4, this is weaker than the conjectured n^{2-1/r}, showing a genuine gap.",
-    "mathContext": "Best known algebraic construction for r >= 4.",
+    "mathContext": "$\\exists\\,c>0 : \\mathrm{ex}(n;K_{r,r}) \\ge c\\,n^{2-2/(r+1)}$ for $r \\ge 4$. Since $\\frac{2}{r+1} > \\frac{1}{r}$ for $r \\ge 4$, the exponent $2 - \\frac{2}{r+1} < 2 - \\frac{1}{r}$, leaving a gap from the conjectured bound.",
     "significance": "key",
     "relatedConcepts": [
       "Algebraic graph theory",
-      "Finite fields"
+      "Finite fields",
+      "Norm forms in algebraic geometry"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "exKrr definition",
+      "Field norms and algebraic geometry basics"
+    ]
   },
   {
     "id": "ann-e714-c4",
@@ -251,10 +338,17 @@
     "type": "concept",
     "title": "K_{2,2} = C_4",
     "content": "**k22_equals_c4:**\n\nK_{2,2} is exactly the 4-cycle C_4. A graph is K_{2,2}-free iff it contains no complete bipartite K_{2,2}.\n\nSo ex(n; K_{2,2}) = ex(n; C_4), connecting this problem to Problem #768.",
-    "mathContext": "Both ask for maximum edges in a graph with no 4-cycle.",
+    "mathContext": "$K_{2,2} \\cong C_4$: two vertices on each side with all four edges form a $4$-cycle. Hence $\\texttt{isKrrFree}\\;G\\;2 \\iff \\neg\\,\\texttt{containsCompleteBipartite}\\;G\\;2\\;2$, and $\\mathrm{ex}(n;K_{2,2}) = \\mathrm{ex}(n;C_4)$.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Graph isomorphism",
+      "Cycle-free graphs",
+      "Erdos Problem #768"
+    ],
+    "prerequisites": [
+      "containsCompleteBipartite definition",
+      "isKrrFree definition"
+    ]
   },
   {
     "id": "ann-e714-matrix",
@@ -267,9 +361,16 @@
     "title": "Matrix Formulation",
     "content": "**zarankiewicz_matrix_connection:**\n\nThe Zarankiewicz problem z(m,n;r,s) asks for the maximum 1s in an m x n 0-1 matrix with no all-1s r x s submatrix.\n\nThe connection: ex(n; K_{r,r}) <= c * n^{2-1/r} + r*n/2, matching the KST bound.",
     "significance": "supporting",
-    "mathContext": "See annotation content for formal details of matrix formulation",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "$z(n,n;r,r)$ is the maximum ones in an $n \\times n$ $\\{0,1\\}$-matrix with no all-ones $r \\times r$ submatrix. The bound $\\mathrm{ex}(n;K_{r,r}) \\le c\\,n^{2-1/r} + \\frac{r\\,n}{2}$ connects the graph and matrix formulations via the bipartite double cover.",
+    "relatedConcepts": [
+      "0-1 matrices",
+      "Bipartite double cover",
+      "Zarankiewicz matrix problem"
+    ],
+    "prerequisites": [
+      "exKrr definition",
+      "Kovari-Sos-Turan theorem"
+    ]
   },
   {
     "id": "ann-e714-summary",
@@ -278,13 +379,20 @@
       "startLine": 249,
       "endLine": 263
     },
-    "type": "technique",
+    "type": "concept",
     "title": "Summary Theorem",
     "content": "**erdos_714_summary:**\n\n```lean\ntheorem erdos_714_summary :\n    erdosConjectureLowerBound 2 and\n    erdosConjectureLowerBound 3\n```\n\n1. r=2: SOLVED (exact asymptotics)\n2. r=3: SOLVED (Brown 1966)\n3. r>=4: OPEN",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of summary theorem",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "The theorem packages both partial results: $\\texttt{erdosConjectureLowerBound}\\;2 \\wedge \\texttt{erdosConjectureLowerBound}\\;3$. Proved by $\\langle\\texttt{erdos\\_714\\_r2},\\, \\texttt{erdos\\_714\\_r3}\\rangle$.",
+    "relatedConcepts": [
+      "Conjunction of partial results",
+      "Proof packaging",
+      "Erdos Problem #714 status"
+    ],
+    "prerequisites": [
+      "erdos_714_r2 theorem",
+      "erdos_714_r3 theorem"
+    ]
   },
   {
     "id": "ann-e714-status",
@@ -293,12 +401,19 @@
       "startLine": 265,
       "endLine": 285
     },
-    "type": "technique",
+    "type": "concept",
     "title": "Zarankiewicz Problem Status",
     "content": "**zarankiewicz_status:**\n\nCombines all results:\n1. KST upper bound for all r >= 2\n2. Lower bound matching upper bound for r=2,3\n3. Gap remains for r >= 4\n\nOne of the most famous open problems in extremal combinatorics.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of zarankiewicz problem status",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "The combined theorem states: $(\\forall\\,r \\ge 2,\\; \\mathrm{ex}(n;K_{r,r}) \\le c\\,n^{2-1/r}) \\;\\wedge\\; (\\texttt{erdosConjectureLowerBound}\\;2 \\wedge \\texttt{erdosConjectureLowerBound}\\;3)$. Uses $\\texttt{kovari\\_sos\\_turan}$ for the upper bound and $\\texttt{erdos\\_714\\_summary}$ for the lower bounds.",
+    "relatedConcepts": [
+      "Extremal graph theory survey results",
+      "Upper and lower bound synthesis",
+      "Open problem classification"
+    ],
+    "prerequisites": [
+      "kovari_sos_turan axiom",
+      "erdos_714_summary theorem"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment passes for erdos-820, erdos-572, and erdos-714.

## erdos-820 (GCD of Powers Minus One)
- Replaced 8 placeholder mathContext with LaTeX formulas
- Filled 14 empty relatedConcepts, 12 empty prerequisites

## erdos-572 (Even Cycle Extremal Numbers)
- Replaced 10 placeholder mathContext with LaTeX formulas
- Filled all empty relatedConcepts and prerequisites

## erdos-714 (Zarankiewicz Problem)
- Replaced 9 placeholder mathContext with LaTeX formulas
- Filled 14 empty relatedConcepts, 17 empty prerequisites

Quality: enriched (pass 1 each)