### PR TITLE
Fix: erdos-1166 axiomCount 19 → 23

### DIFF
--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -77,7 +77,7 @@
       "mem_mostVisitedSet",
       "mostVisitedSet_nonempty"
     ],
-    "axiomCount": 19,
+    "axiomCount": 23,
     "lineCount": 283,
     "assumptions": "19 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
@@ -198,7 +198,7 @@
     ],
     "namespace": "Erdos1166",
     "lineCount": 283,
-    "axiomCount": 19,
+    "axiomCount": 23,
     "theoremCount": 8,
     "definitionCount": 1
   },


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in erdos-1166 meta.json. The Lean file has 23 `axiom` declarations (no structure-encoded assumptions), but meta.json listed 19.

## Evidence

**Before**: `"axiomCount": 19`
**After**: `"axiomCount": 23`

Verified: `grep -c` of axiom declarations in `Proofs/Erdos1166Problem.lean` = 23. No structures or typeclasses with assumption fields. Build passes (`pnpm build`).

---
Automated fix by lean-mechanic agent.