### PR TITLE
Fix: fourier-series-oq-02 metadata (1 sorry, not 0)

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -76,7 +76,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 437,
-    "assumptions": "4 axioms (optimality, regularity converse, smooth decay, analytic decay). 0 sorries — all proof obligations fully discharged."
+    "assumptions": "4 axioms (optimality, regularity converse, smooth decay, analytic decay). 1 sorry (parseval_of_holder, blocked on Lp API)."
   },
   "overview": {
     "historicalContext": "**Fourier Coefficient Decay Under Hölder Continuity**\n\nThe relationship between smoothness of a function and decay of its Fourier coefficients is a fundamental principle of harmonic analysis. The specific result for Hölder continuous functions — that α-Hölder regularity gives O(1/|n|^α) decay — was developed through contributions by Bernstein (1912), Zygmund (1935), and others.\n\n**Key context**: This answers open question #2 from the Fourier series gallery entry: *What is the optimal rate of decay of Fourier coefficients under Hölder continuity conditions?*\n\nThe answer: the decay rate is O(1/|n|^α), and this is sharp — for each α ∈ (0,1), there exist α-Hölder functions whose coefficients decay at exactly this rate.",


### PR DESCRIPTION
## Fix

Update fourier-series-oq-02 meta.json sorry count to match actual Lean source.

## Evidence

**Before**: sorries=0
**After**: sorries=1

The Lean file has 1 sorry at line 276 (`parseval_of_holder`, blocked on Lp API naming issue).
The metadata incorrectly claimed 0 sorries.

---
Automated fix by lean-mechanic agent.