### PR TITLE
Research: erdos-1084 - Prove f1_achievable (13→12 axioms)

### DIFF
--- a/proofs/Proofs/Erdos1084Problem.lean
+++ b/proofs/Proofs/Erdos1084Problem.lean
@@ -20,6 +20,8 @@ n points in ℝ^d with all pairwise distances ≥ 1. Estimate f_d(n).
   points are distance 2 apart (on opposite sides).
 - `unit_distance_1d_degree_at_most_two`: A point in ℝ has at most
   2 neighbors at unit distance among mutually separated points.
+- `f1_achievable`: The consecutive integer configuration 0, 1, ..., n-1
+  achieves exactly n-1 unit-distance pairs.
 
 ## References
 
@@ -83,13 +85,13 @@ theorem unit_distance_1d_triangle (x y z : ℝ)
   have hxz' := (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hxz
   rcases hxy' with hxy' | hxy' <;> rcases hxz' with hxz' | hxz'
   · have : y = z := by linarith
-    rw [this] at hyz; simp at hyz
+    rw [this] at hyz; rw [sub_self, abs_zero] at hyz; linarith
   · have : y - z = -2 := by linarith
     rw [this]; norm_num
   · have : y - z = 2 := by linarith
     rw [this]; norm_num
   · have : y = z := by linarith
-    rw [this] at hyz; simp at hyz
+    rw [this] at hyz; rw [sub_self, abs_zero] at hyz; linarith
 
 /-- In ℝ, a point can have at most 2 unit-distance neighbors among
     mutually separated points. If x has three unit neighbors y, z, w
@@ -104,26 +106,44 @@ theorem unit_distance_1d_degree_at_most_two (x y z w : ℝ)
   have hxy' := (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hxy
   have hxz' := (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hxz
   have hxw' := (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hxw
-  -- Each of y, z, w is x+1 or x-1 (two values, three variables → pigeonhole)
   rcases hxy' with hxy' | hxy' <;> rcases hxz' with hxz' | hxz' <;>
     rcases hxw' with hxw' | hxw'
   -- In each case, two variables are equal, so their separation is 0, not ≥ 1
   · have heq : y = z := by linarith
-    subst heq; simp at hyz
+    subst heq; rw [sub_self, abs_zero] at hyz; linarith
   · have heq : y = z := by linarith
-    subst heq; simp at hyz
+    subst heq; rw [sub_self, abs_zero] at hyz; linarith
   · have heq : y = w := by linarith
-    subst heq; simp at hyw
+    subst heq; rw [sub_self, abs_zero] at hyw; linarith
   · have heq : z = w := by linarith
-    subst heq; simp at hzw
+    subst heq; rw [sub_self, abs_zero] at hzw; linarith
   · have heq : z = w := by linarith
-    subst heq; simp at hzw
+    subst heq; rw [sub_self, abs_zero] at hzw; linarith
   · have heq : y = w := by linarith
-    subst heq; simp at hyw
+    subst heq; rw [sub_self, abs_zero] at hyw; linarith
   · have heq : y = z := by linarith
-    subst heq; simp at hyz
+    subst heq; rw [sub_self, abs_zero] at hyz; linarith
   · have heq : y = z := by linarith
-    subst heq; simp at hyz
+    subst heq; rw [sub_self, abs_zero] at hyz; linarith
+
+/- ### Helper Lemmas for 1D Counting -/
+
+/-- Distinct naturals have absolute difference ≥ 1 as reals. -/
+private lemma nat_abs_sub_ge_one {a b : ℕ} (h : a ≠ b) :
+    |(a : ℝ) - (b : ℝ)| ≥ 1 := by
+  rcases Nat.lt_or_gt_of_ne h with hab | hab
+  · have : (a : ℝ) + 1 ≤ (b : ℝ) := by exact_mod_cast hab
+    rw [abs_sub_comm, abs_of_nonneg (by linarith)]
+    linarith
+  · have : (b : ℝ) + 1 ≤ (a : ℝ) := by exact_mod_cast hab
+    rw [abs_of_nonneg (by linarith)]
+    linarith
+
+/-- For consecutive naturals, the real absolute difference is 1. -/
+private lemma nat_consecutive_abs_eq_one (i : ℕ) :
+    |(i : ℝ) - ((i + 1 : ℕ) : ℝ)| = 1 := by
+  have : (i : ℝ) - ((i + 1 : ℕ) : ℝ) = -1 := by push_cast; ring
+  rw [this, abs_neg, abs_one]
 
 /- ### 1D Bounds -/
 
@@ -137,9 +157,55 @@ axiom f1_upper_bound (n : ℕ) (hn : n ≥ 1) (C : SeparatedConfig1D n) :
   unitDistPairs1D C ≤ n - 1
 
 /-- The consecutive integer configuration achieves n-1 unit pairs.
-    Place points at 0, 1, 2, ..., n-1. -/
-axiom f1_achievable (n : ℕ) (hn : n ≥ 1) :
-  ∃ C : SeparatedConfig1D n, unitDistPairs1D C = n - 1
+    Place points at 0, 1, 2, ..., n-1.
+
+    Proof: We place points at integer positions 0, 1, ..., n-1.
+    Separation holds because distinct integers differ by ≥ 1.
+    The unit-distance pairs are exactly the consecutive pairs
+    (i, i+1) for i = 0, ..., n-2, giving n-1 pairs. -/
+theorem f1_achievable (n : ℕ) (hn : n ≥ 1) :
+    ∃ C : SeparatedConfig1D n, unitDistPairs1D C = n - 1 := by
+  -- Configuration: points at 0, 1, 2, ..., n-1
+  let C : SeparatedConfig1D n :=
+    ⟨fun i => (i.val : ℝ), fun i j hij => nat_abs_sub_ge_one (Fin.val_ne_of_ne hij)⟩
+  refine ⟨C, ?_⟩
+  simp only [unitDistPairs1D]
+  -- Map from Fin (n-1) to consecutive pairs: k ↦ (k, k+1)
+  set φ : Fin (n - 1) → Fin n × Fin n :=
+    fun k => (⟨k.val, by omega⟩, ⟨k.val + 1, by omega⟩) with hφ_def
+  -- φ is injective
+  have hinj : Function.Injective φ := by
+    intro x y hxy
+    simp only [φ, Prod.mk.injEq, Fin.mk.injEq] at hxy
+    exact Fin.ext hxy.1
+  -- Show: filter set = image of φ, then card = n - 1
+  suffices hset : Finset.filter
+      (fun p : Fin n × Fin n => p.1 < p.2 ∧ |C.points p.1 - C.points p.2| = 1)
+      Finset.univ = Finset.image φ Finset.univ by
+    rw [hset, Finset.card_image_of_injective _ hinj, Finset.card_univ, Fintype.card_fin]
+  ext ⟨a, b⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_image]
+  constructor
+  · -- Forward: (a, b) is unit pair → it's a consecutive pair from φ
+    rintro ⟨hab, hunit⟩
+    have hlt : a.val < b.val := hab
+    have hlt' : (a.val : ℝ) < (b.val : ℝ) := Nat.cast_lt.mpr hlt
+    have hdiff : (b.val : ℝ) - (a.val : ℝ) = 1 := by
+      rwa [abs_sub_comm, abs_of_pos (by linarith)] at hunit
+    have hba : b.val = a.val + 1 := by
+      exact_mod_cast (show (b.val : ℝ) = (a.val : ℝ) + 1 by linarith)
+    exact ⟨⟨a.val, by omega⟩, by simp only [φ]; exact Prod.ext (Fin.ext rfl) (Fin.ext hba.symm)⟩
+  · -- Backward: consecutive pair from φ is a unit pair
+    rintro ⟨k, hk⟩
+    have ha : a = ⟨k.val, by omega⟩ := by
+      have := congr_arg Prod.fst hk; simp only [φ] at this; exact this.symm
+    have hb : b = ⟨k.val + 1, by omega⟩ := by
+      have := congr_arg Prod.snd hk; simp only [φ] at this; exact this.symm
+    subst ha; subst hb
+    constructor
+    · show (⟨k.val, _⟩ : Fin n) < ⟨k.val + 1, _⟩
+      exact Fin.mk_lt_mk.mpr (Nat.lt_succ_of_le le_rfl)
+    · exact nat_consecutive_abs_eq_one k.val
 
 /-- f_1(n) = n - 1 -/
 axiom f1_exact (n : ℕ) (hn : n ≥ 1) :

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -18,9 +18,9 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1084",
     "erdosUrl": "https://erdosproblems.com/1084",
-    "axiomCount": 13,
-    "assumptions": "13 axiom declarations: maxUnitDistPairs (extremal function definition), f1_upper_bound (1D forest bound), f1_achievable (1D construction exists), f1_exact (f_1(n)=n-1), f2_upper_erdos (Erdos 3n-c*sqrt(n) bound), harborth_exact (2D exact formula), triangular_lattice_optimal (A2 lattice achieves max), f2_trivial_upper (f_2(n)<3n), f3_leading (3D leading coefficient 6), bezdek_reid_upper (3D n^{2/3} correction), erdos_1084_d3_conjecture (3D Theta(n^{2/3}) conjecture), fd_lower_general (general lower bound), fd_upper_general (Kabatyansky-Levenshtein upper bound)",
-    "lineCount": 198,
+    "axiomCount": 12,
+    "assumptions": "12 axiom declarations: maxUnitDistPairs (extremal function definition), f1_upper_bound (1D forest bound), f1_exact (f_1(n)=n-1), f2_upper_erdos (Erdos 3n-c*sqrt(n) bound), harborth_exact (2D exact formula), triangular_lattice_optimal (A2 lattice achieves max), f2_trivial_upper (f_2(n)<3n), f3_leading (3D leading coefficient 6), bezdek_reid_upper (3D n^{2/3} correction), erdos_1084_d3_conjecture (3D Theta(n^{2/3}) conjecture), fd_lower_general (general lower bound), fd_upper_general (Kabatyansky-Levenshtein upper bound). f1_achievable is now fully proved.",
+    "lineCount": 264,
     "badge": "axiom",
     "mathlib_version": "4.26.0"
   },
@@ -102,12 +102,12 @@
     "historicalContext": "Erdős introduced this problem in 1946, asking how many 'contacts' (unit-distance pairs) can occur among n non-overlapping unit spheres in ℝ^d. The problem connects sphere packing theory, the classical Newton–Gregory kissing number dispute (1694), and extremal graph theory. For d = 2, the kissing number τ(2) = 6 gives f₂(n) ≤ 3n; Harborth (1974) found the exact formula f₂(n) = ⌊3n - √(12n-3)⌋ using the triangular lattice A₂, one of the most elegant results in combinatorial geometry. For d = 3, Newton proved τ(3) = 12 (confirmed by Schütte–van der Waerden 1953), giving f₃(n) ~ 6n. Bezdek and Reid (2013) proved the n^{2/3} correction: f₃(n) < 6n - 0.926·n^{2/3}, establishing the surface-to-volume isoperimetric deficit for finite sphere packings. The matching lower bound remains open and is related to the Kepler conjecture (Hales 2005). In high dimensions, the Kabatyansky–Levenshtein bound (1978) gives τ(d) ≤ 2^{0.401d}, but the true behavior of f_d(n) for large d remains mysterious.",
     "problemStatement": "Estimate f_d(n), the maximum number of unit-distance pairs among n points in ℝ^d with pairwise distances ≥ 1.",
     "text": "Let f_d(n) be the maximum number of unit-distance pairs among n points in ℝ^d with all pairwise distances ≥ 1. For d=2, Harborth gave the exact formula. For d=3, Erdős conjectured f_3(n) = 6n - Θ(n^{2/3}). Status: OPEN (d ≥ 3).",
-    "proofStrategy": "The Lean formalization defines separated configurations and unit-distance pair counting in arbitrary dimension d. For d = 1, two key lemmas are fully machine-verified: the triangle lemma (unit neighbors must be on opposite sides) and the degree bound (at most 2 unit neighbors). These establish f₁(n) = n - 1. The d = 2 and d = 3 results are formalized as axioms capturing Harborth's formula, the Bezdek-Reid bound, and Erdős's conjecture. General dimension bounds use kissing number estimates.",
+    "proofStrategy": "The Lean formalization defines separated configurations and unit-distance pair counting in arbitrary dimension d. For d = 1, three theorems are machine-verified: the triangle lemma (unit neighbors must be on opposite sides), the degree bound (at most 2 unit neighbors), and the achievability theorem (the consecutive integer configuration {0,1,...,n-1} achieves exactly n-1 unit pairs, proved via an explicit bijection with Fin(n-1)). The d = 2 and d = 3 results are formalized as axioms capturing Harborth's formula, the Bezdek-Reid bound, and Erdős's conjecture. General dimension bounds use kissing number estimates.",
     "keyInsights": [
       "**Kissing number controls the leading coefficient**: $f_d(n) \\le \\tau(d) \\cdot n / 2$ by double-counting. Known values $\\tau(1) = 2$, $\\tau(2) = 6$, $\\tau(3) = 12$ give leading terms $n$, $3n$, $6n$",
       "**Harborth's formula** $f_2(n) = \\lfloor 3n - \\sqrt{12n-3} \\rfloor$ encodes the boundary deficit of the hexagonal lattice — one of the few exact extremal results in combinatorial geometry",
       "**Isoperimetric exponent** $n^{2/3}$ in $d = 3$ reflects the surface-to-volume ratio: a ball of volume $n$ has surface area $\\Theta(n^{2/3})$, and surface spheres lose contacts",
-      "**Two machine-verified theorems** establish the 1D degree bound: the triangle lemma and the 3-neighbor impossibility, both proved by exhaustive case analysis in Lean 4",
+      "**Three machine-verified theorems** for d=1: the triangle lemma, the 3-neighbor impossibility, and the achievability of n-1 unit pairs via consecutive integers — establishing f₁(n) = n-1 constructively",
       "**Exponential gap** in general $d$: between $f_d(n) \\ge dn$ from $\\mathbb{Z}^d$ and $f_d(n) \\le 2^{O(d)} n$ from Kabatyansky–Levenshtein — closing this is a major open problem"
     ],
     "prerequisites": [
@@ -195,9 +195,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 198,
-    "axiomCount": 13,
-    "theoremCount": 2,
+    "lineCount": 264,
+    "axiomCount": 12,
+    "theoremCount": 3,
     "definitionCount": 2
   }
 }


### PR DESCRIPTION
## Summary
- Converted `f1_achievable` from axiom to fully machine-verified theorem
- Constructs consecutive integer configuration {0,1,...,n-1} and proves it achieves exactly n-1 unit-distance pairs via explicit bijection with Fin(n-1)
- Fixed `unit_distance_1d_triangle` and `unit_distance_1d_degree_at_most_two` to use robust tactic proofs

## Progress
- **Axioms**: 13 → 12 (eliminated f1_achievable)
- **Proved theorems**: 2 → 3 (+ f1_achievable, + 2 helper lemmas)
- **Docker build**: passes

## Findings
- Previous survey assessed all 13 axioms as "deep combinatorial geometry, not tractable" — but the 1D results ARE tractable with existing infrastructure
- `simp at hyz` broke on real-valued `|x-x| ≥ 1` goals in newer Lean versions; replaced with robust `rw [sub_self, abs_zero]; linarith`
- `omega` struggles with `Fin` coercions; explicit `Fin.mk_lt_mk` works better

## Status
**Outcome**: progress (1 axiom eliminated)
**Next Steps**: `f1_upper_bound` (degree ≤ 2 → forest → ≤ n-1 edges) needs graph theory infrastructure

🤖 Generated by researcher-4