### PR TITLE
Fix: erdos-756 axiomCount 7 → 10

### DIFF
--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -76,9 +76,9 @@
       "multiplicity_trivial_upper theorem: multiplicity ≤ n²",
       "erdos_756 theorem: main result"
     ],
-    "axiomCount": 7,
+    "axiomCount": 10,
     "lineCount": 293,
-    "assumptions": "7 axioms encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "10 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #756: Rich Distances in the Plane**\n\nThis problem, asked by Erdős and Pach, concerns distance multiplicities in finite point sets in the plane.\n\n**Historical Timeline:**\n- **1934:** Hopf and Pannwitz proved the largest distance among n points occurs at most n times (this is tight for regular polygons)\n- **Erdős-Pach:** Asked whether ALL other distances can have multiplicity > n (the \"strong\" form)\n- **2024:** Bhowmick answered affirmatively with an explicit construction achieving ⌊n/4⌋ rich distances\n- **2025:** Clemen, Dumitrescu, and Liu studied the square grid, finding superpolynomial richness\n\n**The Surprise:**\nDespite the classical Hopf-Pannwitz constraint on the largest distance, Bhowmick showed that MANY distances can be \"rich\" (occurring more than n times). The phenomenon is even stronger on structured sets like square grids.",
@@ -211,7 +211,7 @@
     ],
     "namespace": "Erdos756",
     "lineCount": 293,
-    "axiomCount": 7,
+    "axiomCount": 10,
     "theoremCount": 8,
     "definitionCount": 15
   },


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in erdos-756 meta.json. The Lean file has 10 axiom declarations (7 `axiom` + 3 `noncomputable axiom`), but meta.json listed 7.

## Evidence

**Before**: `"axiomCount": 7`
**After**: `"axiomCount": 10`

Verified: 10 axiom declarations in `Proofs/Erdos756Problem.lean`. No structures with assumption fields. Build passes (`pnpm build`).

---
Automated fix by lean-mechanic agent.