### PR TITLE
Enrich erdos-1126-oq-01: add 10 annotations

### DIFF
--- a/src/data/proofs/erdos-1126-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1126-oq-01/annotations.json
@@ -1,1 +1,221 @@
-[]
+[
+  {
+    "id": "ann-e1126-oq01-header",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 28
+    },
+    "type": "context",
+    "title": "Extending de Bruijn-Jurkat to Other Functional Equations",
+    "content": "The de Bruijn-Jurkat theorem (1965-66) says that if $f(x+y) = f(x) + f(y)$ holds for almost all pairs $(x,y)$, then $f$ agrees a.e. with a truly additive function. This open question asks: does the same stability phenomenon hold for other functional equations — multiplicative ($f(xy) = f(x)f(y)$), Jensen ($f((x+y)/2) = (f(x)+f(y))/2$), and Leibniz/derivation ($d(xy) = xd(y) + yd(x)$)?",
+    "mathContext": "De Bruijn-Jurkat: $f(x+y) = f(x) + f(y)$ a.e. $\\implies \\exists g$ additive with $f = g$ a.e. Question: does the same hold for $f(xy) = f(x)f(y)$, $f(\\frac{x+y}{2}) = \\frac{f(x)+f(y)}{2}$, and $d(xy) = xd(y) + yd(x)$?",
+    "significance": "key",
+    "relatedConcepts": [
+      "functional equations",
+      "almost everywhere stability",
+      "Cauchy equation",
+      "homomorphisms"
+    ],
+    "prerequisites": [
+      "measure theory",
+      "Lebesgue measure",
+      "null sets"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-isadditive",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 43
+    },
+    "type": "definition",
+    "title": "Cauchy's Additive Functional Equation",
+    "content": "Cauchy's equation $f(x+y) = f(x) + f(y)$ for all $x, y \\in \\mathbb{R}$. Solutions include $f(x) = cx$ (linear) but also pathological non-measurable solutions constructed using the axiom of choice and a Hamel basis for $\\mathbb{R}$ over $\\mathbb{Q}$. The de Bruijn-Jurkat theorem concerns the a.e. version of this equation.",
+    "mathContext": "$\\text{IsAdditive}(f) \\iff \\forall x, y \\in \\mathbb{R},\\; f(x+y) = f(x) + f(y)$. Continuous solutions: $f(x) = cx$. Discontinuous solutions require AC.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Cauchy equation",
+      "Hamel basis",
+      "additive functions"
+    ],
+    "prerequisites": [
+      "real analysis"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-isjensen",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 67,
+      "endLine": 68
+    },
+    "type": "definition",
+    "title": "Jensen's Functional Equation (Midpoint Affinity)",
+    "content": "Jensen's equation $f((x+y)/2) = (f(x)+f(y))/2$ says $f$ preserves midpoints: the value at the midpoint equals the average of endpoint values. This is the defining property of affine functions. The formalization proves that Jensen's equation is equivalent to additivity up to a constant shift.",
+    "mathContext": "$\\text{IsJensen}(f) \\iff \\forall x, y,\\; f\\!\\left(\\frac{x+y}{2}\\right) = \\frac{f(x) + f(y)}{2}$. Equivalently, $g(x) = f(x) - f(0)$ is additive.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Jensen's inequality",
+      "midpoint convexity",
+      "affine functions"
+    ],
+    "prerequisites": [
+      "IsAdditive"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-jensen-additive",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 103
+    },
+    "type": "concept",
+    "title": "Jensen Implies Shifted Additivity",
+    "content": "If $f$ satisfies Jensen's equation, then $g(x) = f(x) - f(0)$ is additive. The proof uses the doubling trick: from Jensen with $(x,x)$ we get $f(x) = (f(2x) + f(0))/2$, hence $f(2x) = 2f(x) - f(0)$. Then Jensen with $(2a, 2b)$ gives $f(a+b) = (f(2a) + f(2b))/2 = f(a) + f(b) - f(0)$, which is exactly $g(a+b) = g(a) + g(b)$.",
+    "mathContext": "$f$ Jensen $\\implies g(x) = f(x) - f(0)$ additive. Key step: $f(2z) = 2f(z) - f(0)$ from $f(z) = \\frac{f(0) + f(2z)}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "doubling trick",
+      "functional equation reduction"
+    ],
+    "prerequisites": [
+      "IsJensen",
+      "IsAdditive",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-jensen-iff",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 128,
+      "endLine": 174
+    },
+    "type": "concept",
+    "title": "Jensen and Additivity Are Equivalent Modulo Constants",
+    "content": "The full equivalence: $f$ is Jensen if and only if $g(x) = f(x) - f(0)$ is additive. The forward direction uses the doubling trick. The backward direction shows that if $g$ is additive and $f(x) = g(x) + c$, then $f$ satisfies Jensen. This algebraic equivalence is the key to reducing Jensen stability to additive stability (de Bruijn-Jurkat).",
+    "mathContext": "$\\text{IsJensen}(f) \\iff \\text{IsAdditive}(x \\mapsto f(x) - f(0))$",
+    "significance": "key",
+    "relatedConcepts": [
+      "iff characterization",
+      "functional equation equivalence"
+    ],
+    "prerequisites": [
+      "jensen_implies_shifted_additive",
+      "additive_plus_const_is_jensen"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-ismultiplicative",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 193,
+      "endLine": 194
+    },
+    "type": "definition",
+    "title": "Multiplicative Functional Equation (Cauchy Exponential)",
+    "content": "The multiplicative Cauchy equation $f(xy) = f(x)f(y)$ for $x, y \\neq 0$. Continuous solutions on $(0, \\infty)$ are power functions $f(x) = x^c$. The logarithmic reduction $g = \\log \\circ f \\circ \\exp$ converts this to the additive equation, enabling transfer of de Bruijn-Jurkat results.",
+    "mathContext": "$\\text{IsMultiplicative}(f) \\iff \\forall x, y \\neq 0,\\; f(xy) = f(x)f(y)$. If $f > 0$: setting $g = \\log f$, $g(xy) = g(x) + g(y)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "exponential Cauchy equation",
+      "power functions",
+      "logarithmic conjugation"
+    ],
+    "prerequisites": [
+      "Real.log",
+      "Real.exp"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-mul-one",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 202,
+      "endLine": 215
+    },
+    "type": "concept",
+    "title": "Multiplicative Functions: f(1) = 1",
+    "content": "For a non-trivial multiplicative function ($\\exists a \\neq 0$ with $f(a) \\neq 0$), we have $f(1) = 1$. From $f(a) = f(a \\cdot 1) = f(a) \\cdot f(1)$, dividing by $f(a) \\neq 0$ gives $f(1) = 1$. The proof uses `mul_eq_zero` to split the factored equation.",
+    "mathContext": "$f$ multiplicative, $f \\not\\equiv 0 \\implies f(1) = 1$. Proof: $f(a) = f(a)f(1) \\implies f(a)(f(1) - 1) = 0 \\implies f(1) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "identity element",
+      "group homomorphism"
+    ],
+    "prerequisites": [
+      "mul_eq_zero",
+      "IsMultiplicative"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-isderivation",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 279,
+      "endLine": 280
+    },
+    "type": "definition",
+    "title": "Derivation (Leibniz Rule) Functional Equation",
+    "content": "The Leibniz rule $d(xy) = xd(y) + yd(x)$ defines a derivation on $\\mathbb{R}$. This generalizes the familiar product rule from calculus. Unlike additive and multiplicative functions, the only continuous derivation on $\\mathbb{R}$ is identically zero (because $\\mathbb{R}$ is a complete valued field). Discontinuous derivations exist via AC.",
+    "mathContext": "$\\text{IsDerivation}(d) \\iff \\forall x, y,\\; d(xy) = xd(y) + yd(x)$. The product rule for differentiation is the prototypical example.",
+    "significance": "key",
+    "relatedConcepts": [
+      "product rule",
+      "derivation",
+      "Leibniz rule",
+      "differential algebra"
+    ],
+    "prerequisites": [
+      "ring theory",
+      "continuous derivations"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-power-rule",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 305,
+      "endLine": 328
+    },
+    "type": "concept",
+    "title": "The Power Rule for Derivations",
+    "content": "Proves $d(x^n) = nx^{n-1}d(x)$ for all $n \\geq 1$ by induction on $n$. The base case $d(x) = 1 \\cdot x^0 \\cdot d(x)$ is trivial. The inductive step uses $d(x^{n+1}) = d(x \\cdot x^n) = xd(x^n) + x^n d(x)$ and the induction hypothesis. This confirms derivations generalize the familiar power rule from calculus.",
+    "mathContext": "$d(x^n) = nx^{n-1}d(x)$ for $n \\geq 1$. Inductive step: $d(x^{n+1}) = xd(x^n) + x^n d(x) = x \\cdot nx^{n-1}d(x) + x^n d(x) = (n+1)x^n d(x)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "power rule",
+      "mathematical induction",
+      "polynomial derivations"
+    ],
+    "prerequisites": [
+      "IsDerivation",
+      "induction"
+    ]
+  },
+  {
+    "id": "ann-e1126-oq01-paradigm",
+    "proofId": "erdos-1126-oq-01",
+    "range": {
+      "startLine": 362,
+      "endLine": 368
+    },
+    "type": "concept",
+    "title": "The Stability Paradigm: Almost-Homomorphisms Can Be Repaired",
+    "content": "The combined stability result: for each of the four functional equations (additive, Jensen, multiplicative, derivation), almost-everywhere satisfaction implies a.e. agreement with an exact solution. The unifying theme is that algebraic homomorphism properties are 'rigid' — they cannot be slightly violated without being violated nowhere. This pattern generalizes to locally compact groups (Jarai 2005).",
+    "mathContext": "Stability paradigm: for $\\mathcal{E} \\in \\{\\text{additive, Jensen, multiplicative, derivation}\\}$: $f$ satisfies $\\mathcal{E}$ a.e. $\\implies \\exists g$ satisfying $\\mathcal{E}$ exactly with $f = g$ a.e.",
+    "significance": "key",
+    "relatedConcepts": [
+      "rigidity",
+      "Ulam stability",
+      "automatic continuity"
+    ],
+    "prerequisites": [
+      "almost_jensen_stability",
+      "almost_derivation_stability"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Created 10 annotations for "Extending de Bruijn-Jurkat to Other Functional Equations" (was empty)
- Covers: Jensen↔Additive equivalence, multiplicative Cauchy equation, derivation/Leibniz rule, stability paradigm
- Documented the doubling trick proof for Jensen→Additive, log reduction for multiplicative, power rule induction
- All annotations have mathContext, significance, relatedConcepts, prerequisites
- 0 annotation build warnings