### PR TITLE
Gallery audit cycle 2: fix erdos-107 axiomCount, audit 9 proofs clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -513,32 +513,32 @@
       "issues": []
     },
     "erdos-107": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:11:13Z",
       "result": "clean",
       "issues": []
     },
     "erdos-1091": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:11:13Z",
       "result": "clean",
       "issues": []
     },
     "erdos-1113": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:11:12Z",
       "result": "clean",
       "issues": []
     },
     "inverse-galois": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:11:12Z",
       "result": "clean",
       "issues": []
     },
     "morleys-theorem": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:11:12Z",
       "result": "clean",
       "issues": []
     },
@@ -549,14 +549,14 @@
       "issues": []
     },
     "picks-theorem": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:11:12Z",
       "result": "clean",
       "issues": []
     },
     "picks-theorem-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:11:12Z",
       "result": "clean",
       "issues": []
     },
@@ -573,14 +573,14 @@
       "issues": []
     },
     "descartes-rule-of-signs-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:10:12Z",
       "result": "clean",
       "issues": []
     },
     "erdos-1006-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:11:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T14:10:12Z",
       "result": "clean",
       "issues": []
     },

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -60,7 +60,7 @@
     "leanFile": {
       "lineCount": 188,
       "structureCount": 0,
-      "axiomCount": 5,
+      "axiomCount": 6,
       "theoremCount": 5,
       "defCount": 6,
       "imports": [


### PR DESCRIPTION
## Summary

- **erdos-107**: Fixed stale `leanFile.axiomCount` (5→6) to match the 6 `axiom` declarations in the Lean file
- Audited 9 additional proofs, all confirmed clean (scanner false positives)

## Audit Results

| Proof | Result | Notes |
|-------|--------|-------|
| picks-theorem | clean | Scanner axiom detection broken (reports 0, actual 2) |
| picks-theorem-oq-03 | clean | Scanner axiom detection broken |
| morleys-theorem | clean | Scanner axiom detection broken (reports 0, actual 2) |
| inverse-galois | clean | Scanner axiom/sorry detection broken |
| erdos-1113 | clean | Scanner axiom detection broken (reports 0, actual 9) |
| erdos-1091 | clean | Scanner axiom detection broken (reports 0, actual 7) |
| erdos-107 | **fixed** | `leanFile.axiomCount` 5→6 |
| erdos-1006-oq-02 | clean | "sorry" appears in comment, not code |
| descartes-rule-of-signs-oq-01 | clean | "sorry" appears in comment, not code |

## Test plan

- [x] `grep -c "^axiom " proofs/Proofs/Stubs/Erdos107Problem.lean` → 6 (matches fix)
- [x] All other proofs verified: meta.json claims match Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)