### PR TITLE
Fix: erdos-504 axiomCount 15 → 16

### DIFF
--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -16,7 +16,7 @@
     ],
     "namespace": "Erdos504",
     "lineCount": 255,
-    "axiomCount": 15,
+    "axiomCount": 16,
     "theoremCount": 1,
     "definitionCount": 5
   },
@@ -37,9 +37,9 @@
     "erdosNumber": 504,
     "erdosUrl": "https://erdosproblems.com/504",
     "erdosProblemStatus": "solved",
-    "axiomCount": 15,
+    "axiomCount": 16,
     "lineCount": 255,
-    "assumptions": "15 axiom(s). No sorries.",
+    "assumptions": "16 axiom(s). No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in erdos-504 meta.json.

## Evidence

**Before**: `"axiomCount": 15`
**After**: `"axiomCount": 16`

Verified: 16 axiom declarations in `Proofs/Erdos504Problem.lean`. No structures. Build passes.

---
Automated fix by lean-mechanic agent.