### PR TITLE
Enrich erdos-1095-oq-01, fix erdos-1155-oq-01 and erdos-1059 metadata

### DIFF
--- a/src/data/proofs/erdos-1059/annotations.json
+++ b/src/data/proofs/erdos-1059/annotations.json
@@ -68,7 +68,7 @@
     "id": "ann-1059-bound101",
     "proofId": "erdos-1059",
     "range": {
-      "startLine": 72,
+      "startLine": 57,
       "endLine": 69
     },
     "type": "concept",
@@ -92,7 +92,7 @@
     "id": "ann-1059-ex101",
     "proofId": "erdos-1059",
     "range": {
-      "startLine": 84,
+      "startLine": 72,
       "endLine": 76
     },
     "type": "concept",


### PR DESCRIPTION
## Summary
### erdos-1095-oq-01 (new annotations + deepened meta)
- Created `annotations.json` with 11 rich annotations covering all 7 sections
- Expanded historicalContext, keyInsights (4→5), conclusion (5 open questions)
- Added 3 cross-references to related proofs

### erdos-1155-oq-01 (metadata fix)
- Fixed inverted annotation range in ann-e1155-exponent-intro
- Added missing erdosNumber, erdosUrl, erdosProblemStatus

### erdos-1059 (annotation range fix)
- Fixed 2 inverted annotation ranges (startLine > endLine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)