### PR TITLE
Fix: erdos-96 axiomCount 4 → 5

### DIFF
--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -55,9 +55,9 @@
       "erdos_96_summary: proved conjunction of bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 4,
+    "axiomCount": 5,
     "lineCount": 294,
-    "assumptions": "4 axiom(s). No sorries."
+    "assumptions": "5 axiom(s). No sorries."
   },
   "overview": {
     "historicalContext": "Erdős and Moser conjectured that a convex n-gon has O(n) unit distance pairs. Despite progress from O(n log n) bounds (Füredi 1990, Aggarwal 2015), the conjecture remains open. The Edelsbrunner-Hajnal (1991) lower bound of 2n - 7 suggests the Erdős-Fishburn conjecture of exactly 2n may be tight. The unit distance problem for general point sets (Erdős Problem #89, 1946) asks for the maximum number of unit distance pairs among n points in the plane, with best known bounds Ω(n^{1+c/log log n}) and O(n^{4/3}). The convex restriction dramatically simplifies the problem: in a convex polygon, each distance can appear at most twice on each side, giving much sharper bounds.",
@@ -149,7 +149,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 294,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 10
   },


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in erdos-96 meta.json.

## Evidence

**Before**: `"axiomCount": 4`
**After**: `"axiomCount": 5`

Verified: 5 axiom declarations in `Proofs/Erdos96Problem.lean`. No structures. Build passes.

---
Automated fix by lean-mechanic agent.