### PR TITLE
Research: erdos-839 - Axiom elimination + Mathlib v4.26.0 fix (6→5 axioms)

### DIFF
--- a/proofs/Proofs/Erdos839Problem.lean
+++ b/proofs/Proofs/Erdos839Problem.lean
@@ -1,7 +1,4 @@
-import Mathlib.Tactic
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Order.Filter.Basic
+import Mathlib
 
 /-
 # Erdos Problem #839: Sequences Avoiding Consecutive-Term Sums
@@ -25,7 +22,7 @@ Reference: https://erdosproblems.com/839
 
 /-- The sum of consecutive terms a_i + a_{i+1} + ... + a_j. -/
 def consecutiveSum (a : ℕ → ℕ) (i j : ℕ) : ℕ :=
-  ∑ k in Finset.Icc i j, a k
+  ∑ k ∈ Finset.Icc i j, a k
 
 /-- No term of the sequence equals a sum of consecutive earlier terms. -/
 def AvoidConsecutiveSums (a : ℕ → ℕ) : Prop :=
@@ -48,7 +45,7 @@ def Question1 : Prop :=
 def Question2 : Prop :=
   ∀ a : ValidSeq, ∀ ε : ℝ, 0 < ε →
     ∃ X₀ : ℕ, ∀ X : ℕ, X₀ ≤ X →
-      (∑ n in (Finset.range X).filter (fun n => a.val n < X),
+      (∑ n ∈ (Finset.range X).filter (fun n => a.val n < X),
         (1 : ℝ) / (a.val n : ℝ)) ≤ ε * Real.log X
 
 -- ## Structural Theorems
@@ -89,11 +86,11 @@ theorem consecutiveSum_empty (a : ℕ → ℕ) (i j : ℕ) (h : j < i) :
 /-- For a sequence with positive terms, the consecutive sum over [i, j] is
     at least a(i). -/
 theorem consecutiveSum_ge_first (a : ℕ → ℕ) (i j : ℕ) (h : i ≤ j)
-    (hpos : ∀ n, 0 < a n) :
+    (_hpos : ∀ n, 0 < a n) :
     a i ≤ consecutiveSum a i j := by
   unfold consecutiveSum
-  calc a i = ∑ t in {i}, a t := by simp
-    _ ≤ ∑ t in Finset.Icc i j, a t := by
+  calc a i = ∑ t ∈ {i}, a t := by simp
+    _ ≤ ∑ t ∈ Finset.Icc i j, a t := by
         apply Finset.sum_le_sum_of_subset_of_nonneg
         · intro x hx; simp at hx; subst hx; simp [Finset.mem_Icc, h]
         · intro _ _ _; omega
@@ -104,10 +101,11 @@ theorem consecutiveSum_gt_first (a : ValidSeq) (i j : ℕ) (h : i < j) :
     a.val i < consecutiveSum a.val i j := by
   unfold consecutiveSum
   have hij : i ≠ j := by omega
+  have hpos_j : 0 < a.val j := a.property.1 j
   calc a.val i < a.val i + a.val j := by omega
-    _ = ∑ t in ({i, j} : Finset ℕ), a.val t := by
+    _ = ∑ t ∈ ({i, j} : Finset ℕ), a.val t := by
         rw [Finset.sum_pair hij]
-    _ ≤ ∑ t in Finset.Icc i j, a.val t := by
+    _ ≤ ∑ t ∈ Finset.Icc i j, a.val t := by
         apply Finset.sum_le_sum_of_subset_of_nonneg
         · intro x hx
           simp [Finset.mem_Icc] at hx ⊢
@@ -134,7 +132,7 @@ axiom reciprocal_sum_lower :
   ∃ a : ValidSeq, ∃ c : ℝ, 0 < c ∧
     ∀ X : ℕ, 3 ≤ X →
       c * Real.log (Real.log X) ≤
-        ∑ n in (Finset.range X).filter (fun n => a.val n < X),
+        ∑ n ∈ (Finset.range X).filter (fun n => a.val n < X),
           (1 : ℝ) / (a.val n : ℝ)
 
 -- ## Upper Density
@@ -145,14 +143,17 @@ noncomputable def upperDensity (a : ValidSeq) : ℝ :=
     ((Finset.range N).filter (fun n => a.val n ≤ N)).card / (N : ℝ))
     Filter.atTop
 
-/-- Erdos conjectured the upper density is at most 1/2, but
-    Freud disproved this by constructing a sequence with density 19/36. -/
-axiom freud_counterexample :
-  ∃ a : ValidSeq, (1 : ℝ) / 2 < upperDensity a
-
 /-- The Freud construction achieves upper density 19/36. -/
 axiom freud_density :
   ∃ a : ValidSeq, upperDensity a = 19 / 36
+
+/-- Erdos conjectured the upper density is at most 1/2, but
+    Freud disproved this by constructing a sequence with density 19/36.
+    This follows from freud_density since 19/36 > 1/2. -/
+theorem freud_counterexample :
+    ∃ a : ValidSeq, (1 : ℝ) / 2 < upperDensity a := by
+  obtain ⟨a, ha⟩ := freud_density
+  exact ⟨a, by rw [ha]; norm_num⟩
 
 -- ## Main Open Questions
 

--- a/src/data/proofs/erdos-839/meta.json
+++ b/src/data/proofs/erdos-839/meta.json
@@ -55,9 +55,9 @@
       "satisfiesConditionR / F_r: generalization to r-products"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 6,
-    "lineCount": 163,
-    "assumptions": "6 axioms: liminf_finite, reciprocal_sum_lower, freud_counterexample, and 3 more. See Lean source for complete statements."
+    "axiomCount": 5,
+    "lineCount": 165,
+    "assumptions": "5 axioms: liminf_finite, reciprocal_sum_lower, freud_density, erdos_839_question1, erdos_839_question2. freud_counterexample is now a theorem (proved from freud_density since 19/36 > 1/2)."
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's work on additive restrictions in integer sequences, closely related to his broader program on sum-free sets and primitive sets. A 'primitive' set has no element dividing another; here the condition is additive: no term equals the sum of a contiguous block of earlier terms. Erdős posed two questions: whether such sequences must grow super-linearly ($\\limsup a_n/n = \\infty$) and whether their logarithmic density must vanish. He also conjectured the upper density is at most $1/2$, but Freud disproved this by constructing a valid sequence with upper density $19/36 \\approx 0.528$, exploiting the fact that only contiguous block sums (not arbitrary subset sums) are forbidden. The problem connects to Problems #359 (sum-free sets) and #867 in Erdős's catalog. Both growth-rate questions remain open, making this one of the more delicate problems in additive combinatorial number theory. The formalization is notable for including seven fully proved structural theorems about valid sequences, alongside the axiomatized deep results.",
@@ -135,16 +135,13 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Tactic",
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Order.Filter.Basic"
+      "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 163,
-    "axiomCount": 6,
-    "theoremCount": 8,
+    "lineCount": 165,
+    "axiomCount": 5,
+    "theoremCount": 9,
     "definitionCount": 6
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-839.json
+++ b/src/data/research/problems/erdos-839.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-15T09:46:19.704Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination and Mathlib compatibility",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,9 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Eliminated 1 axiom (freud_counterexample proved from freud_density). Fixed Mathlib v4.26.0 compatibility. File now 5 axioms (was 6), 9 theorems (was 8), 0 sorries.",
+    "builtItems": [
+      "Proved freud_counterexample from freud_density (axiom → theorem)",
+      "Fixed Mathlib v4.26.0 notation compatibility for all sum expressions",
+      "Fixed omega proof in consecutiveSum_gt_first"
+    ],
+    "insights": [
+      "freud_counterexample is redundant: follows from freud_density since 19/36 > 1/2",
+      "Mathlib v4.26.0 changed BigOperators notation: ∑ k in S → ∑ k ∈ S",
+      "consecutiveSum_gt_first needs explicit positivity hint for omega in v4.26.0"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #839 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $1\\leq a_1<a_2<\\cdots$ be a sequence of integers such that no $a_i$ is the sum of consecutive $a_j$ for $j<i$. Is it true that\\[\\limsup \\frac{a_n}{n}=\\infty?\\]Or even\\[\\lim \\frac{1}{\\log x}\\sum_{a_n<x}\\frac{1}{a_n}=0?\\]\n\n\n\nErd\\H{o}s writes that it is easy to see that $\\liminf a_n/n<\\infty$ is possible, and that one can have\\[\\sum_{a_n< x}\\frac{1}{a_n}\\gg \\log\\log x.\\]The upper density of such a sequence can be $1/2$, but Erd\\H{o}s thought it probably could not be $>1/2$. In fact this is false - Freud \\cite{Fr93} constructed a sequence with upper density $19/36$.\n\nSee also [359] and [867].\n\n\n\n\nReferences\n\n\n[Fr93] R. Freud, Adding numbers - on a problem of P. Erd\\H{o}s. James Cook Mathematical Notes (1993), 6199-6202.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #36\n- Problem #359\n- Problem #867\n- Problem #838\n- Problem #840\n- Problem #39\n- Problem #1\n\n## References\n\n- Er78f\n- Er92c\n- Fr93\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"


### PR DESCRIPTION
## Summary
- **Proved `freud_counterexample` from `freud_density`**: Since 19/36 > 1/2, the counterexample follows directly. Converted from axiom to theorem.
- **Fixed Mathlib v4.26.0 notation**: Updated all BigOperators sum notation from `∑ k in S` to `∑ k ∈ S` (breaking change in newer Mathlib)
- **Fixed `consecutiveSum_gt_first`**: Added explicit positivity hint for `omega` tactic compatibility

## Results
| Metric | Before | After |
|--------|--------|-------|
| Axioms | 6 | **5** |
| Theorems | 8 | **9** |
| Sorries | 0 | 0 |
| Build | **BROKEN** (Mathlib compat) | **CLEAN** |

## Files Modified
- `proofs/Proofs/Erdos839Problem.lean` — axiom elimination + notation fix
- `src/data/proofs/erdos-839/meta.json` — updated counts
- `src/data/research/problems/erdos-839.json` — knowledge update

## Key Insight
`freud_counterexample` (∃ ValidSeq with density > 1/2) was redundant — it follows trivially from `freud_density` (∃ ValidSeq with density = 19/36) since 19/36 > 1/2.

Generated by researcher-3