### PR TITLE
Enrich erdos-969 + erdos-197: add annotation depth

### DIFF
--- a/src/data/proofs/erdos-197/annotations.json
+++ b/src/data/proofs/erdos-197/annotations.json
@@ -16,7 +16,10 @@
       "Set partitions",
       "Ramsey theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Basic set theory (unions, intersections, complements)",
+      "Bijections and enumerations of infinite sets"
+    ]
   },
   {
     "id": "ann-e197-ap-def",
@@ -33,8 +36,11 @@
       "Common difference",
       "Arithmetic sequences"
     ],
-    "mathContext": "See annotation content for formal details of arithmetic progression predicate",
-    "prerequisites": []
+    "mathContext": "Three values $a, b, c$ satisfy $a + c = 2b$ iff they form an arithmetic progression with common difference $d = b - a = c - b$. Equivalently, $b$ is the arithmetic mean of $a$ and $c$.",
+    "prerequisites": [
+      "Natural number arithmetic",
+      "Equality of sums in $\\mathbb{N}$"
+    ]
   },
   {
     "id": "ann-e197-has-3ap",
@@ -46,10 +52,17 @@
     "type": "definition",
     "title": "Monotone 3-AP Detection",
     "content": "**hasMonotone3AP:**\n\nA sequence f : N -> N contains a monotone 3-AP if there exist indices i < j < k such that f(i), f(j), f(k) form an arithmetic progression.\n\n```lean\ndef hasMonotone3AP (f : N -> N) : Prop :=\n  exists i j k, i < j and j < k and isArithmeticProgression (f i) (f j) (f k)\n```\n\nThe ordering constraint i < j < k is crucial - we care about the sequential structure.",
-    "mathContext": "This captures the 'monotone' aspect: the indices must be increasing. A set might contain APs without having monotone APs in any enumeration.",
+    "mathContext": "The predicate $\\exists\\, i < j < k,\\; f(i) + f(k) = 2f(j)$ detects arithmetic progressions that respect the index ordering. This is strictly stronger than the set $\\{f(n)\\}$ containing a 3-AP, because rearranging terms can break the monotone condition.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Monotone subsequences",
+      "Arithmetic progressions in sequences",
+      "Ramsey-type index constraints"
+    ],
+    "prerequisites": [
+      "Natural number ordering ($i < j < k$)",
+      "Existential quantification over triples"
+    ]
   },
   {
     "id": "ann-e197-avoids-3ap",
@@ -62,9 +75,16 @@
     "title": "3-AP Free Sequence",
     "content": "**avoids3AP:**\n\nA sequence avoids monotone 3-APs if it has no such triple.\n\n```lean\ndef avoids3AP (f : N -> N) : Prop := not hasMonotone3AP f\n```\n\nThis is the property we want for each partition part.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of 3-ap free sequence",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "A sequence $f : \\mathbb{N} \\to \\mathbb{N}$ is 3-AP-free when $\\nexists\\, i < j < k,\\; f(i) + f(k) = 2f(j)$. By Roth's theorem, any 3-AP-free subset of $\\{1, \\ldots, N\\}$ has density $o(1)$, so such sequences must be sparse.",
+    "relatedConcepts": [
+      "Roth's theorem on 3-AP-free sets",
+      "Salem-Spencer sets",
+      "Sequence density"
+    ],
+    "prerequisites": [
+      "Negation of existential quantifiers",
+      "isArithmeticProgression predicate"
+    ]
   },
   {
     "id": "ann-e197-enumeration",
@@ -77,9 +97,16 @@
     "title": "Enumeration of a Set",
     "content": "**isEnumeration:**\n\nAn enumeration of a set S is a bijection from N to S.\n\n```lean\ndef isEnumeration (S : Set N) (f : N -> N) : Prop :=\n  Function.Bijective f and forall n, f n in S\n```\n\nThis allows us to 'order' the elements of S.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of enumeration of a set",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "An enumeration $f : \\mathbb{N} \\twoheadrightarrow S$ is a bijection with $\\operatorname{ran}(f) = S$. Since $S \\subseteq \\mathbb{N}$ is infinite, such an $f$ exists by the Cantor-Bernstein theorem; the question is whether one can be chosen to avoid monotone 3-APs.",
+    "relatedConcepts": [
+      "Bijections between countable sets",
+      "Permutations of infinite sets",
+      "Function.Bijective in Mathlib"
+    ],
+    "prerequisites": [
+      "Bijective functions (injective + surjective)",
+      "Set membership predicates"
+    ]
   },
   {
     "id": "ann-e197-permute-3ap-free",
@@ -92,9 +119,16 @@
     "title": "Set Permutable to 3-AP-Free",
     "content": "**canPermuteTo3APFree:**\n\nA set S can be permuted to avoid 3-APs if there exists an enumeration of S that has no monotone 3-AP.\n\n```lean\ndef canPermuteTo3APFree (S : Set N) : Prop :=\n  exists f, isEnumeration S f and avoids3AP f\n```\n\nThis is the key property each partition part must have.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of set permutable to 3-ap-free",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "The predicate $\\exists\\, f : \\mathbb{N} \\xrightarrow{\\sim} S,\\; \\text{avoids3AP}(f)$ asks whether the elements of $S$ can be listed as $s_0, s_1, s_2, \\ldots$ with no $i < j < k$ satisfying $s_i + s_k = 2s_j$. This is an existential statement over all possible orderings.",
+    "relatedConcepts": [
+      "Permutation avoidance",
+      "Sequence rearrangement theorems",
+      "Existential choice of enumerations"
+    ],
+    "prerequisites": [
+      "isEnumeration definition",
+      "avoids3AP predicate"
+    ]
   },
   {
     "id": "ann-e197-two-partition",
@@ -107,9 +141,16 @@
     "title": "Two-Set Partition of N",
     "content": "**isTwoPartition:**\n\nA and B form a partition of N if they are disjoint and their union is N.\n\n```lean\ndef isTwoPartition (A B : Set N) : Prop :=\n  Disjoint A B and A union B = Set.univ\n```\n\nThis captures the classical notion of a partition into two parts.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of two-set partition of n",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "A 2-coloring of $\\mathbb{N}$: $A \\cap B = \\varnothing$ and $A \\cup B = \\mathbb{N}$. Equivalently, $B = A^c$. Every element belongs to exactly one of the two parts.",
+    "relatedConcepts": [
+      "Set.Disjoint in Mathlib",
+      "Set.univ (the universal set)",
+      "Complement partitions"
+    ],
+    "prerequisites": [
+      "Disjoint sets predicate",
+      "Set union and universal set"
+    ]
   },
   {
     "id": "ann-e197-partition-mem",
@@ -118,13 +159,20 @@
       "startLine": 104,
       "endLine": 121
     },
-    "type": "technique",
+    "type": "concept",
     "title": "Partition Membership",
     "content": "**partition_mem_iff:**\n\nIn a two-partition, each element belongs to exactly one part.\n\n```lean\ntheorem partition_mem_iff (A B : Set N) (h : isTwoPartition A B) (n : N) :\n    (n in A and n not in B) or (n not in A and n in B)\n```\n\nThis is a basic but important property of partitions.",
     "significance": "supporting",
-    "mathContext": "See annotation content for formal details of partition membership",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "From $A \\cap B = \\varnothing$ and $A \\cup B = \\mathbb{N}$, for each $n \\in \\mathbb{N}$ exactly one of $n \\in A$ or $n \\in B$ holds. The proof proceeds by case analysis on $n \\in A \\cup B$, using disjointness to rule out joint membership.",
+    "relatedConcepts": [
+      "Exclusive disjunction",
+      "Disjoint union decomposition",
+      "Set membership decidability"
+    ],
+    "prerequisites": [
+      "isTwoPartition definition",
+      "Disjointness implies non-overlap"
+    ]
   },
   {
     "id": "ann-e197-conjecture",
@@ -138,23 +186,37 @@
     "content": "**erdos_197_conjecture:**\n\nThe main open question: Does there exist a partition of N into two sets A and B such that both can be permuted to avoid monotone 3-APs?\n\n```lean\naxiom erdos_197_conjecture :\n    (exists A B, isTwoPartition A B and\n      canPermuteTo3APFree A and canPermuteTo3APFree B) or\n    (forall A B, isTwoPartition A B ->\n      not canPermuteTo3APFree A or not canPermuteTo3APFree B)\n```\n\nAxiomatized as the disjunction of the two possible answers (yes or no).",
     "mathContext": "This formulation captures that the problem is open - we assert one of the two answers holds without knowing which.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Law of excluded middle",
+      "Open problems in combinatorial number theory",
+      "Erdos-Graham conjecture family"
+    ],
+    "prerequisites": [
+      "isTwoPartition and canPermuteTo3APFree definitions",
+      "Classical logic (excluded middle)"
+    ]
   },
   {
     "id": "ann-e197-three-partition",
     "proofId": "erdos-197",
     "range": {
-      "startLine": 149,
-      "endLine": 154
+      "startLine": 158,
+      "endLine": 163
     },
     "type": "definition",
     "title": "Three-Set Partition of N",
     "content": "**isThreePartition:**\n\nA, B, C form a partition of N if they are pairwise disjoint and cover N.\n\n```lean\ndef isThreePartition (A B C : Set N) : Prop :=\n  Disjoint A B and Disjoint B C and Disjoint A C and A union B union C = Set.univ\n```",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of three-set partition of n",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "A 3-coloring of $\\mathbb{N}$: three pairwise disjoint sets $A \\cap B = B \\cap C = A \\cap C = \\varnothing$ with $A \\cup B \\cup C = \\mathbb{N}$. This is the setting where Erdos-Graham proved that 3-AP avoidance is achievable.",
+    "relatedConcepts": [
+      "Pairwise disjoint sets",
+      "3-colorings in Ramsey theory",
+      "Set covers"
+    ],
+    "prerequisites": [
+      "Disjoint sets predicate (three pairs)",
+      "Set.univ and union associativity"
+    ]
   },
   {
     "id": "ann-e197-erdos-graham",
@@ -168,23 +230,37 @@
     "content": "**erdos_graham_three_sets:**\n\nN CAN be partitioned into THREE sets, each permutable to avoid monotone 3-APs.\n\n```lean\naxiom erdos_graham_three_sets :\n    exists A B C, isThreePartition A B C and\n      canPermuteTo3APFree A and canPermuteTo3APFree B and canPermuteTo3APFree C\n```\n\nThis proves the threshold is at most 3. The open question is whether it's 2 or 3.",
     "mathContext": "The construction uses sophisticated combinatorial techniques. The jump from 2 to 3 represents a fundamental structural change.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Threshold phenomena in combinatorics",
+      "Erdos-Graham partition constructions",
+      "Axiomatized deep results"
+    ],
+    "prerequisites": [
+      "isThreePartition definition",
+      "canPermuteTo3APFree predicate"
+    ]
   },
   {
     "id": "ann-e197-identity-3ap",
     "proofId": "erdos-197",
     "range": {
-      "startLine": 196,
-      "endLine": 206
+      "startLine": 201,
+      "endLine": 211
     },
-    "type": "technique",
+    "type": "concept",
     "title": "Identity Has 3-APs",
     "content": "**identity_has_3AP:**\n\nThe sequence 0, 1, 2, 3, ... has a 3-AP at any three consecutive terms.\n\n```lean\ntheorem identity_has_3AP : hasMonotone3AP id := by\n  use 0, 1, 2\n  ...\n```\n\n**Verification:** 0 + 2 = 2 = 2 * 1.\n\nThe natural ordering fails spectacularly!",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of identity has 3-aps",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "The identity $f(n) = n$ witnesses $(0, 1, 2)$ as a monotone 3-AP since $f(0) + f(2) = 0 + 2 = 2 = 2 \\cdot 1 = 2 f(1)$. In fact any three consecutive values $n, n+1, n+2$ form a 3-AP, so the natural ordering is maximally bad.",
+    "relatedConcepts": [
+      "Identity function as trivial enumeration",
+      "Witness-based existence proofs",
+      "Consecutive arithmetic progressions"
+    ],
+    "prerequisites": [
+      "hasMonotone3AP definition",
+      "isArithmeticProgression predicate"
+    ]
   },
   {
     "id": "ann-e197-powers-2",
@@ -200,9 +276,13 @@
     "significance": "key",
     "relatedConcepts": [
       "Binary representation",
-      "Geometric sequences"
+      "Geometric sequences",
+      "Lacunary sequences"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "avoids3AP definition",
+      "Properties of exponential functions ($2^n$)"
+    ]
   },
   {
     "id": "ann-e197-not-finite",
@@ -216,8 +296,15 @@
     "content": "**erdos_197_not_finite_checkable:**\n\nThe two-set version cannot be resolved by finite computation.\n\nAny finite portion of N can be partitioned to avoid 3-APs in both parts, but this doesn't guarantee a solution for all of N.\n\nThis is why the problem remains open despite decades of study.",
     "mathContext": "Compactness arguments fail here. Local solutions don't compose into global solutions.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Compactness failure for infinite partitions",
+      "Finite vs. infinite combinatorics",
+      "Undecidability of partition problems"
+    ],
+    "prerequisites": [
+      "Distinction between finite and infinite verification",
+      "Compactness principle in combinatorics"
+    ]
   },
   {
     "id": "ann-e197-stanley",
@@ -233,9 +320,13 @@
     "significance": "key",
     "relatedConcepts": [
       "Greedy algorithms",
-      "3-AP-free sets"
+      "3-AP-free sets",
+      "OEIS A005836"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "avoids3AP and StrictlyIncreasing definitions",
+      "Greedy set construction principles"
+    ]
   },
   {
     "id": "ann-e197-status",
@@ -244,13 +335,20 @@
       "startLine": 260,
       "endLine": 274
     },
-    "type": "technique",
+    "type": "concept",
     "title": "Problem Status",
     "content": "**erdos_197_status:**\n\nSummary of what we know:\n1. The three-set version is solvable (erdos_graham_three_sets)\n2. Individual 3-AP-free sequences exist (powers_of_2_avoid_3AP)\n\n```lean\ntheorem erdos_197_status :\n    (exists A B C, isThreePartition A B C and ...) and\n    (exists f, avoids3AP f)\n```\n\nThe open question is whether two sets suffice.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of problem status",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "The conjunction $(\\exists\\, A,B,C,\\; \\text{isThreePartition}(A,B,C) \\wedge \\ldots) \\wedge (\\exists\\, f,\\; \\text{avoids3AP}(f))$ encapsulates two known facts: the Erdos-Graham three-set result and the existence of 3-AP-free sequences such as $2^n$.",
+    "relatedConcepts": [
+      "Conjunction of known results",
+      "Partial progress on open problems",
+      "Summary theorems in formalization"
+    ],
+    "prerequisites": [
+      "erdos_graham_three_sets axiom",
+      "powers_of_2_avoid_3AP theorem"
+    ]
   },
   {
     "id": "ann-e197-open-question",
@@ -259,12 +357,19 @@
       "startLine": 276,
       "endLine": 285
     },
-    "type": "technique",
+    "type": "concept",
     "title": "The Main Open Question",
     "content": "**erdos_197_open_question:**\n\nWhether two sets suffice remains unknown.\n\n```lean\ntheorem erdos_197_open_question :\n    (exists A B, isTwoPartition A B and\n      canPermuteTo3APFree A and canPermuteTo3APFree B) or\n    (forall A B, isTwoPartition A B ->\n      not canPermuteTo3APFree A or not canPermuteTo3APFree B) :=\n  erdos_197_conjecture\n```\n\nThis directly exposes the open nature of the problem.",
     "significance": "key",
-    "mathContext": "See annotation content for formal details of the main open question",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "mathContext": "This theorem is a direct application of erdos_197_conjecture (proved via excluded middle). It restates the open problem: either $\\exists$ a valid 2-partition, or $\\forall$ 2-partitions at least one part cannot be permuted to avoid 3-APs.",
+    "relatedConcepts": [
+      "Open problem formalization patterns",
+      "Excluded middle in constructive vs. classical logic",
+      "Erdos problem hierarchy"
+    ],
+    "prerequisites": [
+      "erdos_197_conjecture theorem",
+      "isTwoPartition and canPermuteTo3APFree definitions"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment passes for erdos-969 and erdos-197.

## erdos-969 (Squarefree Number Error Term)
- Replaced 8 placeholder mathContext with LaTeX formulas
- Filled 14 empty relatedConcepts, all 20 empty prerequisites

## erdos-197 (3-AP Free Permutations)
- Replaced 10 placeholder mathContext with LaTeX formulas
- Filled 13 empty relatedConcepts, 15 empty prerequisites
- Fixed 2 line range errors and 4 type mismatches

Quality: enriched (pass 1 each)