### PR TITLE
Enrich erdos-1095-oq-01 and feuerbachs-theorem

### DIFF
--- a/src/data/proofs/feuerbachs-theorem/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-feuer-assembly",
+    "proofId": "feuerbachs-theorem",
+    "range": {"startLine": 1, "endLine": 23},
+    "type": "context",
+    "title": "Assembly Module: Importing the Computational Core",
+    "content": "This file imports `FeuerbachsTheoremOQ01`, which contains the heavy coordinate computations. The assembly module re-exports the distance relations as clean theorem statements and combines them into the full Feuerbach theorem. This separation is a common Lean pattern: keep the computational proofs (with `field_simp`, `ring`, `nlinarith`) in one file and the clean mathematical statements in another. The `noncomputable section` is needed because the triangle center computations involve real number division.",
+    "mathContext": "The proof architecture splits into: (1) FeuerbachsTheoremDefs.lean (definitions), (2) FeuerbachsTheoremOQ01.lean (coordinate computation proofs), (3) FeuerbachsTheorem.lean (assembly and statement of the complete theorem).",
+    "significance": "supporting",
+    "relatedConcepts": ["modular proof architecture", "noncomputable section", "proof delegation"],
+    "prerequisites": ["Lean 4 imports", "noncomputable keyword"]
+  },
+  {
     "id": "ann-feuer-intro",
     "proofId": "feuerbachs-theorem",
     "range": {"startLine": 3, "endLine": 15},
@@ -58,5 +70,17 @@
     "significance": "supporting",
     "relatedConcepts": ["equilateral triangle", "coincident circles", "R = 2r", "degenerate tangency"],
     "prerequisites": ["Real.sqrt", "positivity tactic"]
+  },
+  {
+    "id": "ann-feuer-exports",
+    "proofId": "feuerbachs-theorem",
+    "range": {"startLine": 155, "endLine": 164},
+    "type": "context",
+    "title": "Export Summary and Verification",
+    "content": "The `#check` block verifies the key exports: `feuerbachs_theorem` (the complete 4-part conjunction), `feuerbach_incircle_tangent` (incircle tangency), `feuerbach_excircle_a_tangent` (excircle A tangency), `ninePointRadius_eq_half_circumradius` ($R_9 = R/2$), and `euler_line_relation` (the Euler line $N = (O+H)/2$). Together these provide a complete API for triangle geometry work downstream.",
+    "mathContext": "Exports: $d(N,I) = |R/2 - r|$, $d(N, I_k) = R/2 + r_k$, $R_9 = R/2$, $N = (O+H)/2$. All fully proved with 0 axioms.",
+    "significance": "technical",
+    "relatedConcepts": ["#check command", "proof inventory", "API surface"],
+    "prerequisites": ["feuerbachs_theorem"]
   }
 ]

--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -75,7 +75,7 @@
     {
       "id": "main-theorem",
       "title": "Feuerbach's Theorem: Complete Statement",
-      "startLine": 112,
+      "startLine": 98,
       "endLine": 120,
       "summary": "Combines the four proved distance relations into the full theorem: internal tangency with incircle and external tangency with all three excircles. Fully proved, Wiedijk #29.",
       "mathContext": "**Feuerbach's Theorem (1822)**: The nine-point circle of any triangle is internally tangent to the incircle and externally tangent to all three excircles. Formally: $d(N,I) = |R/2 - r|$ and $d(N,I_k) = R/2 + r_k$ for $k = a, b, c$. The tangent point with the incircle is the **Feuerbach point** $X(11)$ in Kimberling's notation."
@@ -87,6 +87,14 @@
       "endLine": 153,
       "summary": "Proves R = 2r for equilateral triangles via coordinate computation, implying the nine-point circle and incircle coincide (degenerate tangency).",
       "mathContext": "For equilateral triangles: $R = 2r$ (circumradius = twice inradius), so $d(N, I) = |R/2 - r| = |r - r| = 0$, meaning the nine-point circle and incircle coincide. This is the degenerate case where internal tangency becomes coincidence. Also $O = H = I = G = N$ (all centers coincide)."
+    },
+    {
+      "id": "exports",
+      "title": "Export Summary",
+      "startLine": 155,
+      "endLine": 164,
+      "summary": "Verification `#check` block listing the five key exports: `feuerbachs_theorem`, `feuerbach_incircle_tangent`, `feuerbach_excircle_a_tangent`, `ninePointRadius_eq_half_circumradius`, and `euler_line_relation`.",
+      "mathContext": "Complete API: the main theorem, individual tangency theorems, nine-point radius identity, and Euler line relation."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Two enrichments in this PR:

### erdos-1095-oq-01
- Added `id` and `mathContext` fields to all 7 sections
- Added missing "Structural Properties" section
- Expanded `historicalContext` with Ecklund-Erdős-Selfridge, Konyagin, CRT heuristic, Mertens' theorem
- Deepened conclusion with primorial/Kummer connections
- Added 2 references

### feuerbachs-theorem
- Added 2 new annotations (assembly module, export summary)
- Extended main-theorem section coverage
- Added exports section
- Annotations: 5 → 7