### PR TITLE
Enrich navier-stokes-oq-02, erdos-279, erdos-1165

### DIFF
--- a/src/data/proofs/erdos-1165/annotations.json
+++ b/src/data/proofs/erdos-1165/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-e1165-z2-infrastructure",
+    "proofId": "erdos-1165",
+    "range": { "startLine": 49, "endLine": 60 },
+    "type": "definition",
+    "title": "Random Walk Infrastructure: Z², Visit Counts, Maximum",
+    "content": "Defines the state space $\\mathbb{Z}^2$ as `Z2 := ℤ × ℤ` and axiomatizes `VisitCount n x` — the number of times the walk visits position $x$ in its first $n$ steps. The maximum visit count `MaxVisitCount n` is defined as a placeholder using the origin; a full formalization would take the supremum over all $x \\in \\mathbb{Z}^2$. The axiomatization is necessary because Mathlib lacks built-in 2D random walk infrastructure.",
+    "mathContext": "$f_n(x) = |\\{k \\le n : s_k = x\\}|$ (visit count). $M_n = \\max_{x \\in \\mathbb{Z}^2} f_n(x)$ (maximum visit count).",
+    "significance": "supporting",
+    "relatedConcepts": ["random walk", "local time", "visit count", "lattice random walk"],
+    "prerequisites": ["ℤ × ℤ as lattice", "Nat.card"]
+  },
+  {
+    "id": "ann-e1165-favourite-sites",
+    "proofId": "erdos-1165",
+    "range": { "startLine": 68, "endLine": 77 },
+    "type": "definition",
+    "title": "Favourite Sites: Positions with Maximum Visit Count",
+    "content": "Axiomatizes `FavouriteSites n` as a `Finset Z2` — the set of positions achieving the maximum visit count at time $n$. The cardinality `numFavouriteSites n = |F(n)|` is the number of favourite sites. In a full formalization, $F(n) = \\{x \\in \\mathbb{Z}^2 : f_n(x) = \\max_y f_n(y)\\}$. The finiteness (as a `Finset`) is justified because the walk has visited at most $n+1$ distinct positions by time $n$.",
+    "mathContext": "$F(n) = \\{x \\in \\mathbb{Z}^2 : f_n(x) = M_n\\}$. Since the walk visits $\\le n+1$ distinct sites, $F(n)$ is finite.",
+    "significance": "key",
+    "relatedConcepts": ["argmax", "Finset", "favourite site", "mode of distribution"],
+    "prerequisites": ["VisitCount", "Finset.card"]
+  },
+  {
+    "id": "ann-e1165-probability-io",
+    "proofId": "erdos-1165",
+    "range": { "startLine": 85, "endLine": 96 },
+    "type": "definition",
+    "title": "Infinitely-Often Probability Axioms",
+    "content": "Axiomatizes `prob_favourite_count_io r` as the probability $\\mathbb{P}(|F(n)| = r \\text{ i.o.})$. In measure theory, 'infinitely often' means the limsup event: $\\bigcap_{N=1}^\\infty \\bigcup_{n \\ge N} \\{|F(n)| = r\\}$. Two basic bounds are axiomatized: $0 \\le \\mathbb{P} \\le 1$. By the Borel-Cantelli lemma, if $\\sum_n \\mathbb{P}(|F(n)| = r) < \\infty$ then the i.o. probability is 0; the converse requires independence (second Borel-Cantelli).",
+    "mathContext": "$\\mathbb{P}(|F(n)| = r \\text{ i.o.}) = \\mathbb{P}\\bigl(\\bigcap_{N=1}^\\infty \\bigcup_{n \\ge N} \\{|F(n)| = r\\}\\bigr) \\in [0, 1]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["limsup of events", "Borel-Cantelli lemma", "zero-one law", "infinitely often"],
+    "prerequisites": ["Measure theory", "probability bounds"]
+  },
+  {
+    "id": "ann-e1165-toth",
+    "proofId": "erdos-1165",
+    "range": { "startLine": 104, "endLine": 115 },
+    "type": "context",
+    "title": "Tóth's Upper Bound: At Most 3 Favourite Sites (2001)",
+    "content": "Axiomatizes Tóth's 2001 theorem: for $r \\ge 4$, $\\mathbb{P}(|F(n)| = r \\text{ i.o.}) = 0$. This means that four or more sites cannot simultaneously achieve the maximum visit count infinitely often. Tóth's proof uses a delicate analysis of the local time profile of the 2D random walk, exploiting Green's function estimates and the fact that in $\\mathbb{Z}^2$ the Green's function grows logarithmically: $G(x) \\sim (2/\\pi) \\log |x|$.",
+    "mathContext": "$\\forall r \\ge 4: \\mathbb{P}(|F(n)| = r \\text{ i.o.}) = 0$. Tóth (2001), Annals of Probability.",
+    "significance": "key",
+    "relatedConcepts": ["local time analysis", "Green's function for ℤ²", "logarithmic potential theory"],
+    "prerequisites": ["prob_favourite_count_io", "2D random walk recurrence"]
+  },
+  {
+    "id": "ann-e1165-hloz",
+    "proofId": "erdos-1165",
+    "range": { "startLine": 117, "endLine": 128 },
+    "type": "context",
+    "title": "Hao-Li-Okada-Zheng: Exactly 3 Favourite Sites (2024)",
+    "content": "Axiomatizes the 2024 breakthrough: $\\mathbb{P}(|F(n)| = 3 \\text{ i.o.}) = 1$. Combined with Tóth's result, this completely resolves Erdős Problem #1165: the maximum visit count is shared by exactly 3 sites infinitely often, almost surely. The 23-year gap between the upper bound (2001) and matching lower bound (2024) reflects the extreme technical difficulty of proving that three-way ties persist.",
+    "mathContext": "$\\mathbb{P}(|F(n)| = 3 \\text{ i.o.}) = 1$. Hao, Li, Okada, Zheng (2024).",
+    "significance": "key",
+    "relatedConcepts": ["matching lower bound", "almost sure events", "random walk local time"],
+    "prerequisites": ["prob_favourite_count_io", "toth_favourite_sites_geq_4"]
+  },
+  {
+    "id": "ann-e1165-resolution",
+    "proofId": "erdos-1165",
+    "range": { "startLine": 132, "endLine": 149 },
+    "type": "technique",
+    "title": "Complete Resolution and Corollaries",
+    "content": "Three proved theorems combining the axiomatized results. `erdos_1165_resolved` packages both directions: $r = 3 \\Rightarrow \\mathbb{P} = 1$ and $r \\ge 4 \\Rightarrow \\mathbb{P} = 0$. `finitely_many_r_favourites` is a direct consequence of Tóth's theorem. `three_favourites_io` restates the Hao et al. result. These are simple wrappers providing a clean API for the complete resolution.",
+    "mathContext": "Complete answer: $\\mathbb{P}(|F(n)| = r \\text{ i.o.}) = \\begin{cases} 1 & r = 3 \\\\ 0 & r \\ge 4 \\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["problem resolution", "clean API", "conjunction packaging"],
+    "prerequisites": ["toth_favourite_sites_geq_4", "hao_li_okada_zheng_three_favourite_sites"]
+  },
+  {
+    "id": "ann-e1165-bass-griffin",
+    "proofId": "erdos-1165",
+    "range": { "startLine": 157, "endLine": 164 },
+    "type": "context",
+    "title": "Bass-Griffin 1D Context: Unique Favourite Site",
+    "content": "Axiomatizes the 1D background result by Bass and Griffin (1985): in one dimension, the favourite site is unique for large $n$ almost surely. This is stated as `True` (placeholder) to provide motivating context. The contrast between 1D (unique favourite) and 2D (exactly 3 favourites) reveals how the marginal recurrence of $\\mathbb{Z}^2$ creates a fundamentally richer structure of visit frequencies compared to the strongly recurrent $\\mathbb{Z}^1$.",
+    "mathContext": "1D: $\\mathbb{P}(|F_{1D}(n)| = 1 \\text{ for all large } n) = 1$ (Bass-Griffin 1985). Contrast with 2D: $|F_{2D}(n)| = 3$ i.o. a.s.",
+    "significance": "supporting",
+    "relatedConcepts": ["dimensional dichotomy", "1D recurrence", "strong vs marginal recurrence"],
+    "prerequisites": ["1D random walk theory"]
+  }
+]

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -46,42 +46,48 @@
       "title": "Problem Statement and Context",
       "startLine": 1,
       "endLine": 36,
-      "summary": "Module docstring: the problem statement about favourite sites of 2D random walks, the complete resolution by Tóth (2001) and Hao-Li-Okada-Zheng (2024), and background on dimensional differences in favourite site behaviour."
+      "summary": "Module docstring: the problem statement about favourite sites of 2D random walks, the complete resolution by Tóth (2001) and Hao-Li-Okada-Zheng (2024), and background on dimensional differences in favourite site behaviour.",
+      "mathContext": "Find $\\mathbb{P}(|F(n)| = r \\text{ i.o.})$ for $r \\ge 3$, where $F(n) = \\{x : f_n(x) = \\max_y f_n(y)\\}$."
     },
     {
       "id": "infrastructure",
       "title": "Random Walk Infrastructure",
       "startLine": 37,
       "endLine": 70,
-      "summary": "Axiomatizes the core objects: ℤ² lattice, visit count function, maximum visit count, and favourite sites as a Finset. These form the interface needed to state the problem."
+      "summary": "Axiomatizes the core objects: ℤ² lattice, visit count function, maximum visit count, and favourite sites as a Finset. These form the interface needed to state the problem.",
+      "mathContext": "$f_n(x) = |\\{k \\le n : s_k = x\\}|$, $M_n = \\max_x f_n(x)$, $F(n) = \\{x : f_n(x) = M_n\\}$ as `Finset Z2`."
     },
     {
       "id": "probability-events",
       "title": "Probability Events",
       "startLine": 71,
       "endLine": 95,
-      "summary": "Axiomatizes the probability of the infinitely-often event for favourite site counts, with basic probability bounds (non-negative, at most 1)."
+      "summary": "Axiomatizes the probability of the infinitely-often event for favourite site counts, with basic probability bounds (non-negative, at most 1).",
+      "mathContext": "$\\mathbb{P}(|F(n)| = r \\text{ i.o.}) \\in [0, 1]$. Limsup event: $\\bigcap_N \\bigcup_{n \\ge N} \\{|F(n)| = r\\}$."
     },
     {
       "id": "main-results",
       "title": "Main Results (SOLVED)",
       "startLine": 96,
       "endLine": 128,
-      "summary": "States the two axioms that resolve the problem: Tóth (2001) proves P = 0 for r ≥ 4, Hao-Li-Okada-Zheng (2024) proves P = 1 for r = 3."
+      "summary": "States the two axioms that resolve the problem: Tóth (2001) proves P = 0 for r ≥ 4, Hao-Li-Okada-Zheng (2024) proves P = 1 for r = 3.",
+      "mathContext": "Tóth: $r \\ge 4 \\Rightarrow \\mathbb{P} = 0$. Hao-Li-Okada-Zheng: $r = 3 \\Rightarrow \\mathbb{P} = 1$."
     },
     {
       "id": "consequences",
       "title": "Derived Consequences",
       "startLine": 129,
       "endLine": 147,
-      "summary": "Three proved theorems: the complete resolution combining both results, the finite occurrence corollary for r ≥ 4, and the almost-sure three-favourite-sites theorem."
+      "summary": "Three proved theorems: the complete resolution combining both results, the finite occurrence corollary for r ≥ 4, and the almost-sure three-favourite-sites theorem.",
+      "mathContext": "$\\mathbb{P}(|F(n)| = r \\text{ i.o.}) = \\begin{cases} 1 & r = 3 \\\\ 0 & r \\ge 4 \\end{cases}$. All proved from axioms."
     },
     {
       "id": "background",
       "title": "Background Results",
       "startLine": 148,
       "endLine": 157,
-      "summary": "Bass-Griffin (1985) 1D uniqueness result, providing context for why the 2D case is fundamentally different."
+      "summary": "Bass-Griffin (1985) 1D uniqueness result, providing context for why the 2D case is fundamentally different.",
+      "mathContext": "1D: $|F(n)| = 1$ for large $n$ a.s. (Bass-Griffin 1985). Contrast: 2D has $|F(n)| = 3$ i.o. a.s."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Three enrichments:

### navier-stokes-oq-02
- Added `mathContext` to all 5 sections

### erdos-279
- Added `mathContext` to all 5 sections

### erdos-1165
- Created 7 annotations from scratch (was the last proof with empty annotations)
- Added `mathContext` to all 6 sections
- Covers: random walk infrastructure, favourite sites, probability axioms, Tóth/HLOZ results, Bass-Griffin context