### PR TITLE
Fix: navier-stokes sorry counts (23→0 for 3 entries)

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "NSAxioms structure with 5 fields: Type II exponent bound, spectral gap on dissipation scale, theta dynamics bound, blowup rate estimate, BKM criterion. These encode the physical hypotheses needed for conditional 3D regularity.",
     "mathlibDependencies": [

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -22,7 +22,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Update sorry counts for 3 Navier-Stokes gallery entries that all reference NavierStokes.lean.

## Evidence

**NavierStokes.lean**: 0 sorries (verified by stripping comments and counting)

**Before**:
- navier-stokes-existence: sorries=23
- navier-stokes-oq-01: sorries=23
- navier-stokes-oq-02: sorries=23

**After**: All updated to sorries=0

Note: The parent `navier-stokes` entry already had sorries=0 (correct).

---
Automated fix by lean-mechanic agent.