### PR TITLE
Enrich erdos-922 + erdos-924: add annotation depth

### DIFF
--- a/src/data/proofs/erdos-924/annotations.json
+++ b/src/data/proofs/erdos-924/annotations.json
@@ -32,10 +32,17 @@
     "type": "definition",
     "title": "IsCliqueOfSize",
     "content": "A graph G contains a clique of size n if there exists a set S of n vertices where every pair is adjacent (G.IsClique S). This builds on Mathlib's `SimpleGraph.IsClique`.",
-    "mathContext": "The definition `∃ S : Finset V, S.card = n ∧ G.IsClique S` packages the standard notion. Mathlib's `IsClique` checks that S is pairwise adjacent: `∀ a ∈ S, ∀ b ∈ S, a ≠ b → G.Adj a b`. Note this uses `Finset` (not `Set`), ensuring decidable cardinality. The clique number ω(G) = max n such that IsCliqueOfSize G n.",
+    "mathContext": "The definition $\\text{IsCliqueOfSize}(G, n) \\;\\triangleq\\; \\exists S : \\text{Finset}\\, V,\\; |S| = n \\land G.\\text{IsClique}\\, S$ packages the standard notion. Mathlib's `IsClique` checks pairwise adjacency: $\\forall a, b \\in S,\\; a \\neq b \\implies G.\\text{Adj}\\, a\\, b$. Using `Finset` rather than `Set` ensures decidable cardinality. The clique number $\\omega(G) = \\max\\{n : \\text{IsCliqueOfSize}(G, n)\\}$.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "clique number",
+      "pairwise adjacency",
+      "Finset cardinality"
+    ],
+    "prerequisites": [
+      "SimpleGraph.IsClique",
+      "Finset"
+    ]
   },
   {
     "id": "ann-e924-clique-free",
@@ -47,7 +54,7 @@
     "type": "definition",
     "title": "IsCliqueFree",
     "content": "A graph G is K_n-free if it contains no clique of size n: `¬IsCliqueOfSize G n`. For the Folkman graph problem, we require K_{l+1}-freeness while forcing monochromatic K_l.",
-    "mathContext": "The K_{l+1}-freeness constraint is what makes the problem non-trivial. Without it, any sufficiently large complete graph would work. The Ramsey number R(l, l; k) gives the threshold for K_n with k colors, but K_n contains K_{l+1} for n ≥ l+1. The challenge is to maintain Ramsey forcing while keeping ω(G) ≤ l. By Ramsey's theorem, such graphs must have many vertices (far more than R(l,l;k)), but they need not have large clique number.",
+    "mathContext": "The $K_{l+1}$-freeness constraint $\\omega(G) \\le l$ is what makes the problem non-trivial. Without it, any sufficiently large complete graph would work. The Ramsey number $R(l, l; k)$ gives the threshold for $K_n$ with $k$ colors, but $K_n$ contains $K_{l+1}$ for $n \\ge l+1$. The challenge is to maintain Ramsey forcing while keeping $\\omega(G) \\le l$. By Ramsey's theorem, such graphs must have many vertices (far more than $R(l,l;k)$), but they need not have large clique number.",
     "significance": "key",
     "crossReferences": [
       {
@@ -56,8 +63,15 @@
         "description": "Erdős #920 studies the maximum chromatic number among K_k-free graphs on n vertices"
       }
     ],
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Turán number",
+      "forbidden subgraph",
+      "clique number bound"
+    ],
+    "prerequisites": [
+      "IsCliqueOfSize",
+      "SimpleGraph"
+    ]
   },
   {
     "id": "ann-e924-contains-clique",
@@ -115,10 +129,19 @@
     "type": "definition",
     "title": "MonochromaticSubgraph",
     "content": "For a coloring χ and color c, the subgraph consisting of all edges colored c. Formally a `SimpleGraph V` where `Adj u v` holds iff `G.Adj u v ∧ χ(edge(u,v)) = c`. The `symm` and `loopless` proofs verify the SimpleGraph axioms.",
-    "mathContext": "Each monochromatic subgraph is a *color class* — the induced subgraph on edges of one color. The union of all k color classes gives back G. The Ramsey property asks that at least one color class contains K_l. The symmetry proof uses `Sym2.eq_swap` to handle the unordered edge representation. This is a concrete instance of the partition regularity principle: for any finite partition of edges, at least one part must contain a prescribed structure.",
+    "mathContext": "Each monochromatic subgraph is a *color class*: $G_c = (V,\\; \\{uv \\in E(G) : \\chi(uv) = c\\})$. The union $\\bigcup_{c=0}^{k-1} E(G_c) = E(G)$ partitions the edge set. The Ramsey property asks that $\\exists c,\\; K_l \\subseteq G_c$. The symmetry proof uses `Sym2.eq_swap` to handle unordered edges $\\{u,v\\} = \\{v,u\\}$. This is a concrete instance of partition regularity: for any finite partition of edges, at least one part must contain the prescribed structure.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "color class",
+      "Sym2.eq_swap",
+      "SimpleGraph axioms",
+      "partition regularity"
+    ],
+    "prerequisites": [
+      "EdgeColoring",
+      "SimpleGraph",
+      "Sym2"
+    ]
   },
   {
     "id": "ann-e924-has-mono-clique",
@@ -154,10 +177,17 @@
     "type": "definition",
     "title": "HasRamseyProperty",
     "content": "G has the k-Ramsey property for K_l if **every** k-coloring of G's edges contains a monochromatic K_l. The universal quantification over all colorings is what makes this a strong structural property of G.",
-    "mathContext": "This definition captures the arrow notation from Ramsey theory: G → (K_l)^k_2 means every k-coloring of G's edges yields a monochromatic K_l. The classical Ramsey theorem says K_n → (K_l)^k_2 for sufficiently large n. The Folkman-Nešetřil-Rödl theorem strengthens this: there exists G with ω(G) ≤ l such that G → (K_l)^k_2. The Ramsey property is a *partition property* — it says G is 'partition regular' with respect to K_l in k colors.",
+    "mathContext": "This definition captures the arrow notation from Ramsey theory: $G \\to (K_l)^k_2$ means every $k$-coloring of $G$'s edges yields a monochromatic $K_l$. Formally, $\\forall \\chi : E(G) \\to [k],\\; \\exists c \\in [k],\\; K_l \\subseteq G_c$. The classical Ramsey theorem says $K_n \\to (K_l)^k_2$ for $n \\ge R(l,\\ldots,l;k)$. The Folkman-Nesetril-Rodl theorem strengthens this: $\\exists G$ with $\\omega(G) \\le l$ such that $G \\to (K_l)^k_2$.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Ramsey arrow notation",
+      "universal quantification over colorings",
+      "partition property"
+    ],
+    "prerequisites": [
+      "EdgeColoring",
+      "HasMonochromaticClique"
+    ]
   },
   {
     "id": "ann-e924-erdos-hajnal",
@@ -169,10 +199,19 @@
     "type": "definition",
     "title": "ErdosHajnalQuestion",
     "content": "The core problem: does there exist a K_{l+1}-free graph with the k-Ramsey property for K_l? Formalized as an existential over types V with Fintype and DecidableEq instances, a SimpleGraph G, and the two properties.",
-    "mathContext": "The existential quantification `∃ (V : Type) (_ : Fintype V) ...` is necessary because Folkman graphs exist at different sizes for different parameter pairs (l, k). The Lean formalization quantifies over all possible vertex types, not just `Fin n`, to maintain generality. The DecidableRel constraint on G.Adj ensures computability of the adjacency relation, needed for constructing MonochromaticSubgraph. This question was posed by Erdős and Hajnal in the broader context of structural Ramsey theory.",
+    "mathContext": "The existential $\\exists (V : \\text{Type})\\, (G : \\text{SimpleGraph}\\, V),\\; \\omega(G) \\le l \\;\\land\\; G \\to (K_l)^k_2$ quantifies over all possible vertex types, not just $\\text{Fin}\\, n$, to maintain generality. The `DecidableRel` constraint on $G.\\text{Adj}$ ensures computability, needed for constructing `MonochromaticSubgraph`. This question was posed by Erdos and Hajnal in the broader context of structural Ramsey theory.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "structural Ramsey theory",
+      "Fintype",
+      "DecidableRel",
+      "existential quantification"
+    ],
+    "prerequisites": [
+      "IsCliqueFree",
+      "HasRamseyProperty",
+      "SimpleGraph"
+    ]
   },
   {
     "id": "ann-e924-folkman-graph",
@@ -184,10 +223,17 @@
     "type": "definition",
     "title": "IsFolkmanGraph",
     "content": "A Folkman graph for parameters (l, k) is a graph that is K_{l+1}-free AND has the k-Ramsey property for K_l. Named after Jon Folkman (1938-1969), who proved existence for k = 2 shortly before his death.",
-    "mathContext": "Jon Folkman proved the k = 2 case and the paper was published posthumously in 1970 (SIAM J. Appl. Math.). Folkman graphs are central objects in structural Ramsey theory. Their study reveals that Ramsey-type phenomena don't require dense substructures — they can emerge from carefully controlled sparse graphs. The definition is the conjunction `IsCliqueFree G (l + 1) ∧ HasRamseyProperty G k l`, capturing both the forbidden subgraph constraint and the Ramsey forcing property.",
+    "mathContext": "The definition is the conjunction $\\text{IsCliqueFree}\\, G\\, (l+1) \\;\\land\\; \\text{HasRamseyProperty}\\, G\\, k\\, l$, i.e., $\\omega(G) \\le l$ and $G \\to (K_l)^k_2$. Folkman graphs are central objects in structural Ramsey theory. Their study reveals that Ramsey-type phenomena do not require dense substructures --- they can emerge from carefully controlled sparse graphs with bounded clique number.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "structural Ramsey theory",
+      "forbidden subgraph",
+      "Ramsey forcing"
+    ],
+    "prerequisites": [
+      "IsCliqueFree",
+      "HasRamseyProperty"
+    ]
   },
   {
     "id": "ann-e924-folkman-number",
@@ -199,10 +245,17 @@
     "type": "definition",
     "title": "FolkmanNumber",
     "content": "f(l; k) is the minimum number of vertices in a Folkman graph for parameters (l, k). Defined via `Nat.find` using the existence guarantee from the Nešetřil-Rödl theorem.",
-    "mathContext": "Computing Folkman numbers is extremely challenging. Known values and bounds include: f(3; 2) = 786 (the minimum vertices for a K_4-free graph where every 2-coloring of edges yields a monochromatic triangle). The original bounds were astronomical — Folkman's construction gave f(3; 2) ≤ 10^10^10, and even the Nešetřil-Rödl construction gives tower-type bounds. Reductions to f(3; 2) = 786 required decades of work by Spencer, Graham, Frankl-Rödl, Dudek-Rödl, and others. The `Nat.find` definition requires a decidability instance to search for the minimum.",
+    "mathContext": "$f(l;\\, k) = \\min\\{|V(G)| : G \\text{ is } K_{l+1}\\text{-free and } G \\to (K_l)^k_2\\}$. The `Nat.find` definition searches for the minimum $n$ such that `ErdosHajnalQuestion k l` holds with a graph on $n$ vertices. Computing Folkman numbers is extremely challenging: $f(3;\\,2) = 786$, while Folkman's original construction gave $f(3;\\,2) \\le 10^{10^{10}}$. The Nesetril-Rodl construction gives tower-type bounds. Reductions to $f(3;\\,2) = 786$ required decades of work.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Nat.find",
+      "extremal graph theory",
+      "minimum vertex count"
+    ],
+    "prerequisites": [
+      "IsFolkmanGraph",
+      "ErdosHajnalQuestion"
+    ]
   },
   {
     "id": "ann-e924-folkman-1970",
@@ -214,7 +267,7 @@
     "type": "concept",
     "title": "Folkman's Theorem (1970)",
     "content": "For k = 2 and any l ≥ 3, Folkman graphs exist: there is a K_{l+1}-free graph G such that every 2-coloring of G's edges contains a monochromatic K_l. Published posthumously in SIAM J. Appl. Math.",
-    "mathContext": "Folkman's proof used *shift graphs* (also called Kneser-like graphs). The construction works as follows: take vertices to be all l-element subsets of a large set, with edges determined by an interlacing condition. The shift structure ensures triangle-freeness (or more generally, K_{l+1}-freeness) while the high-dimensional structure forces monochromatic K_l. The construction gives bounds of tower type, far from the now-known values. Folkman's original paper also introduced the concept of *vertex-Folkman numbers*, though these remain less studied.",
+    "mathContext": "Folkman's proof used *shift graphs*: vertices are all $l$-element subsets of a large set $[N]$, with adjacency from an interlacing condition $\\{a_1 < \\cdots < a_l\\} \\sim \\{b_1 < \\cdots < b_l\\}$ iff $a_1 < b_1 < a_2 < b_2 < \\cdots$. The shift structure ensures $K_{l+1}$-freeness while the high-dimensional combinatorial structure forces monochromatic $K_l$. The construction gives bounds of tower type, far from the now-known values.",
     "significance": "key",
     "crossReferences": [
       {
@@ -223,8 +276,15 @@
         "description": "Erdős #922 is another result by Jon Folkman (1970) on chromatic number bounds via independent sets"
       }
     ],
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "shift graphs",
+      "Kneser-like constructions",
+      "posthumous publication"
+    ],
+    "prerequisites": [
+      "ErdosHajnalQuestion",
+      "Ramsey theory"
+    ]
   },
   {
     "id": "ann-e924-nesetril-rodl",
@@ -236,7 +296,7 @@
     "type": "concept",
     "title": "Nešetřil-Rödl Theorem (1976)",
     "content": "For ANY k ≥ 2 and l ≥ 3, Folkman graphs exist. This completely solves the Erdős-Hajnal question. Published in J. Combinatorial Theory Ser. B (1976).",
-    "mathContext": "The Nešetřil-Rödl proof uses the *partite construction* combined with the *Hales-Jewett theorem*. The key idea: (1) Start with a sufficiently high-dimensional combinatorial cube [m]^n, (2) Apply Hales-Jewett to guarantee combinatorial lines in any coloring, (3) Embed K_l into combinatorial lines, (4) Control the clique number via the partite structure. The bounds are of Ackermann/tower type. Later work by Conlon-Gowers and Schacht connected this to hypergraph regularity methods. The theorem is a cornerstone of *structural Ramsey theory* — the study of which structures are Ramsey.",
+    "mathContext": "The proof uses the *partite construction* combined with the *Hales-Jewett theorem*: (1) embed the problem in a high-dimensional combinatorial cube $[m]^n$, (2) apply Hales-Jewett to guarantee combinatorial lines $\\{x \\in [m]^n : x_i \\text{ varies over } [m] \\text{ for } i \\in I,\\; x_j = c_j \\text{ for } j \\notin I\\}$ in any $k$-coloring, (3) embed $K_l$ into combinatorial lines, (4) control $\\omega(G)$ via the partite structure. The bounds are of Ackermann/tower type.",
     "significance": "key",
     "crossReferences": [
       {
@@ -250,8 +310,16 @@
         "description": "Erdős #923 is another result by Rödl (1977) on triangle-free subgraphs with high chromatic number"
       }
     ],
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Hales-Jewett theorem",
+      "partite construction",
+      "structural Ramsey theory"
+    ],
+    "prerequisites": [
+      "ErdosHajnalQuestion",
+      "Hales-Jewett theorem",
+      "Ramsey theory"
+    ]
   },
   {
     "id": "ann-e924-f32",
@@ -263,10 +331,17 @@
     "type": "definition",
     "title": "The Simplest Case: f(3; 2)",
     "content": "f(3; 2) is the minimum vertices for a K_4-free graph where every 2-coloring of edges contains a monochromatic triangle. The exact value is f(3; 2) = 786, determined through decades of incremental improvements.",
-    "mathContext": "The history of f(3; 2) bounds: Folkman (1970): f(3;2) exists, bounds astronomical. Graham (1993): f(3;2) ≤ 941 (via an explicit construction with 941 vertices). Frankl-Rödl (1986): improved general bounds using hypergraph regularity. Lu (2007): f(3;2) ≤ 9697. Dudek-Rödl (2008): f(3;2) ≤ 941 by different method. Lange-Radziszowski-Xu (2014): f(3;2) ≤ 786. Exact determination f(3;2) = 786 combines upper bound (explicit graph construction) with lower bound (exhaustive or algebraic elimination). The graph achieving 786 vertices is based on a Cayley graph construction over a carefully chosen group.",
+    "mathContext": "$f(3;\\,2) = \\min\\{|V(G)| : \\omega(G) \\le 3 \\;\\land\\; G \\to (K_3)^2_2\\} = 786$. History of bounds: Folkman (1970): existence, bounds astronomical ($\\le 10^{10^{10}}$). Graham (1968): $f(3;2) \\le 941$. Frankl-Rodl (1986): improved via hypergraph regularity. Dudek-Rodl (2008): $\\le 941$ by different method. Lange-Radziszowski-Xu (2014): $\\le 786$. The graph achieving 786 vertices is based on a Cayley graph construction over a carefully chosen group.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Cayley graph construction",
+      "Graham upper bound",
+      "extremal combinatorics"
+    ],
+    "prerequisites": [
+      "FolkmanNumber",
+      "IsFolkmanGraph"
+    ]
   },
   {
     "id": "ann-e924-ramsey-compare",
@@ -278,10 +353,17 @@
     "type": "definition",
     "title": "Comparison with Classical Ramsey Numbers",
     "content": "Complete graphs K_n trivially have the Ramsey property for n ≥ R(l,l;k). Folkman graphs achieve the same forcing while keeping the clique number at most l — no K_{l+1}. This demonstrates that Ramsey phenomena are not artifacts of density.",
-    "mathContext": "The Ramsey number R(3,3) = 6 means K_6 forces a monochromatic triangle in every 2-coloring. But K_6 contains K_4, K_5, and K_6 — far from K_4-free. Folkman graphs achieve the same forcing with ω(G) ≤ 3 (no K_4), at the cost of needing 786 vertices instead of 6. The gap between R(l,l) and f(l;2) reveals the 'price of avoiding large cliques'. For higher k, the Folkman number f(l;k) grows even faster. This comparison motivates the study of *Ramsey multiplicity* — how many copies of the monochromatic structure are forced.",
+    "mathContext": "$R(3,3) = 6$: $K_6$ forces a monochromatic triangle in every 2-coloring, but $\\omega(K_6) = 6$. Folkman graphs achieve the same forcing with $\\omega(G) \\le 3$ (no $K_4$), at the cost of needing $f(3;2) = 786$ vertices instead of 6. The ratio $f(l;\\,2) / R(l,l)$ quantifies the 'price of avoiding $K_{l+1}$'. For larger $k$, $f(l;\\,k)$ grows as towers of exponentials. This comparison motivates the study of *Ramsey multiplicity*: how many copies of the monochromatic structure are forced.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "Ramsey numbers",
+      "clique number vs vertex count tradeoff",
+      "Ramsey multiplicity"
+    ],
+    "prerequisites": [
+      "FolkmanNumber",
+      "Ramsey number R(l,l)"
+    ]
   },
   {
     "id": "ann-e924-generalized",
@@ -293,10 +375,18 @@
     "type": "definition",
     "title": "GeneralizedFolkmanNumber",
     "content": "f(l₁, ..., l_k; r) generalizes to asymmetric parameters: an r-clique-free graph where any k-coloring forces a monochromatic K_{l_i} in color i for some i.",
-    "mathContext": "The generalized Folkman number accommodates different clique sizes in different colors, analogous to asymmetric Ramsey numbers R(l₁, ..., l_k). The formalization uses `List ℕ` for the parameter sequence and `Fin ls.length` for colors. The existence is guaranteed by a generalization of the Nešetřil-Rödl theorem. When all l_i = l and r = l+1, this reduces to the standard f(l; k). The most studied asymmetric case is f(3, 3; 4) — K_4-free graphs forcing monochromatic triangles in both colors.",
+    "mathContext": "$f(l_1, \\ldots, l_k;\\, r) = \\min\\{|V(G)| : \\omega(G) < r \\;\\land\\; \\forall \\chi : E(G) \\to [k],\\; \\exists i \\in [k],\\; K_{l_i} \\subseteq G_{\\chi,i}\\}$. This is analogous to asymmetric Ramsey numbers $R(l_1, \\ldots, l_k)$. The formalization uses `List \\mathbb{N}` for the parameter sequence and `Fin ls.length` for colors. When all $l_i = l$ and $r = l+1$, this reduces to the standard $f(l;\\, k)$. The most studied asymmetric case is $f(3, 3;\\, 4)$.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "asymmetric Ramsey numbers",
+      "List-indexed parameters",
+      "hypergraph Folkman numbers"
+    ],
+    "prerequisites": [
+      "IsFolkmanGraph",
+      "EdgeColoring",
+      "MonochromaticSubgraph"
+    ]
   },
   {
     "id": "ann-e924-summary",
@@ -308,10 +398,17 @@
     "type": "concept",
     "title": "erdos_924_summary (Proved)",
     "content": "The summary theorem combines three results: (1) Nešetřil-Rödl: general existence for all k ≥ 2, l ≥ 3, (2) Folkman: the original k = 2 case, (3) specific case f(3; 2) exists. All proved from the axioms.",
-    "mathContext": "The proof uses `constructor` to split the conjunction. The first conjunct is `nesetril_rodl_1976` directly. The second is `folkman_1970`. The third applies `nesetril_rodl_1976 2 3` with `norm_num` to discharge k ≥ 2 and l ≥ 3. This structure demonstrates how the general theorem (Nešetřil-Rödl) subsumes both Folkman's special case and the most-studied Folkman number f(3; 2).",
+    "mathContext": "The conjunction $(\\forall k \\ge 2,\\, l \\ge 3,\\; \\text{EHQ}(k,l)) \\;\\land\\; (\\forall l \\ge 3,\\; \\text{EHQ}(2,l)) \\;\\land\\; \\text{EHQ}(2,3)$ is split by `constructor`. The first conjunct is `nesetril_rodl_1976` directly. The second is `folkman_1970`. The third applies `nesetril_rodl_1976 2 3` with `norm_num` to discharge $k \\ge 2$ and $l \\ge 3$. This demonstrates how the general theorem subsumes both Folkman's special case and $f(3;\\,2)$.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "conjunction splitting",
+      "theorem subsumption",
+      "norm_num tactic"
+    ],
+    "prerequisites": [
+      "nesetril_rodl_1976",
+      "folkman_1970"
+    ]
   },
   {
     "id": "ann-e924-main",
@@ -323,10 +420,17 @@
     "type": "concept",
     "title": "erdos_924 (Proved)",
     "content": "The main theorem: `∀ k l : ℕ, k ≥ 2 → l ≥ 3 → ErdosHajnalQuestion k l`. Defined directly as `nesetril_rodl_1976`, showing the complete solution is precisely the Nešetřil-Rödl theorem.",
-    "mathContext": "This one-line proof `erdos_924 = nesetril_rodl_1976` is a clean demonstration that the Erdős-Hajnal question is exactly answered by the Nešetřil-Rödl theorem. The identification `erdos_924 := nesetril_rodl_1976` makes the mathematical point explicit: Problem #924 *is* the Nešetřil-Rödl theorem. The axiomatized proof delegates to the deep combinatorial content of the original 1976 paper.",
+    "mathContext": "The one-line definition $\\texttt{erdos\\_924} := \\texttt{nesetril\\_rodl\\_1976}$ identifies Problem \\#924 with the Nesetril-Rodl theorem: $\\forall k \\ge 2,\\, l \\ge 3,\\; \\exists G,\\; \\omega(G) \\le l \\;\\land\\; G \\to (K_l)^k_2$. The axiomatized proof delegates to the deep combinatorial content of the original 1976 paper.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "definitional equality",
+      "axiom forwarding",
+      "Erdos-Hajnal question"
+    ],
+    "prerequisites": [
+      "nesetril_rodl_1976",
+      "ErdosHajnalQuestion"
+    ]
   },
   {
     "id": "ann-e924-answer",
@@ -338,9 +442,16 @@
     "type": "concept",
     "title": "erdos_924_answer (Proved)",
     "content": "Unpacks the existential: for any k ≥ 2, l ≥ 3, there exists a finite graph G that is K_{l+1}-free and has the k-Ramsey property for K_l. A direct application of `nesetril_rodl_1976`.",
-    "mathContext": "This theorem makes the existential content explicit by unfolding `ErdosHajnalQuestion` into its constituent parts: existence of a type V with Fintype, a SimpleGraph G, and the conjunction `IsCliqueFree G (l+1) ∧ HasRamseyProperty G k l`. The proof is again a direct forwarding to the axiom, serving as a readable 'interface' to the main result for downstream use.",
+    "mathContext": "This theorem unfolds `ErdosHajnalQuestion` into its constituent parts: $\\exists (V : \\text{Type})\\, [\\text{Fintype}\\, V]\\, (G : \\text{SimpleGraph}\\, V),\\; \\text{IsCliqueFree}\\, G\\, (l+1) \\;\\land\\; \\text{HasRamseyProperty}\\, G\\, k\\, l$. The proof forwards to `nesetril_rodl_1976`, serving as a readable interface to the main result for downstream use.",
     "significance": "key",
-    "relatedConcepts": [],
-    "prerequisites": []
+    "relatedConcepts": [
+      "existential unpacking",
+      "API theorem",
+      "ErdosHajnalQuestion"
+    ],
+    "prerequisites": [
+      "nesetril_rodl_1976",
+      "ErdosHajnalQuestion"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment passes for erdos-922 and erdos-924.

## erdos-922 (Graph Independence and Chromatic Number)
- Replaced 11 placeholder mathContext with LaTeX formulas
- Filled 12 empty relatedConcepts, 16 empty prerequisites
- Fixed 4 type mismatches

## erdos-924 (Ramsey-Type Graphs Without Large Cliques)
- Replaced generic mathContext with LaTeX across 14 annotations
- Filled 15 empty relatedConcepts, 15 empty prerequisites

Quality: enriched (pass 1 each)