### PR TITLE
Research: erdos-1056 - Aristotle companion for Wilson constraint (3 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1056Aristotle.lean
+++ b/proofs/Proofs/Erdos1056Aristotle.lean
@@ -1,0 +1,38 @@
+/-
+  Aristotle targets for Erdős Problem #1056
+  Routine supporting lemmas for automated proof search.
+  See Erdos1056Problem.lean for the main formalization.
+
+  Main target: Prove Wilson's theorem constraint using Mathlib's
+  ZMod.prod_Ico_one_prime, bridging from ZMod to ℕ modular arithmetic.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known result (Wilson's theorem) available in Mathlib
+  - Clean theorem statement with no definition sorries
+  - No axioms
+-/
+import Mathlib.NumberTheory.Wilson
+import Mathlib.Data.ZMod.Basic
+
+open Finset
+
+namespace Erdos1056Aristotle
+
+/-- The product of [1, p) equals (p-1) factorial. -/
+theorem ico_prod_eq_factorial (p : ℕ) (hp : p ≥ 1) :
+    (Finset.Ico 1 p).prod id = Nat.factorial (p - 1) := by sorry
+
+/-- Wilson's theorem in ℕ modular arithmetic:
+    (p-1)! % p = p - 1 for any prime p.
+    This bridges Mathlib's ZMod.wilsons_lemma to ℕ. -/
+theorem wilson_nat (p : ℕ) (hp : Nat.Prime p) :
+    Nat.factorial (p - 1) % p = p - 1 := by sorry
+
+/-- **Wilson's constraint for interval products:**
+    For any prime p, (Finset.Ico 1 p).prod id % p = p - 1.
+    This is the axiom wilson_constraint from Erdos1056Problem.lean. -/
+theorem wilson_constraint (p : ℕ) (hp : Nat.Prime p) :
+    (Finset.Ico 1 p).prod id % p = p - 1 := by sorry
+
+end Erdos1056Aristotle

--- a/src/data/research/problems/erdos-1056.json
+++ b/src/data/research/problems/erdos-1056.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1056",
-  "title": "Erdős #1056",
-  "phase": "OBSERVE",
+  "title": "Erd\u0151s #1056",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-15T14:31:40.058Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,12 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Created Aristotle companion file for Wilson constraint axiom elimination. Wilson theorem (Mathlib.NumberTheory.Wilson) can prove the axiom but direct import breaks existing native_decide proofs. Companion file bridges the gap.",
+    "builtItems": [
+      "Created Erdos1056Aristotle.lean companion file with Wilson bridge lemmas",
+      "Identified Mathlib path: ZMod.prod_Ico_one_prime \u2192 wilson_constraint"
+    ],
+    "insights": [
+      "wilson_constraint axiom IS provable from Mathlib Wilson theorem (ZMod.prod_Ico_one_prime)",
+      "Direct import of Mathlib.NumberTheory.Wilson breaks native_decide proofs in main file (instance conflicts)",
+      "Solution: prove in separate companion file, then integrate the proof",
+      "The other 2 axioms (erdos_1056_conjecture, noll_simmons_conjecture) are genuinely open",
+      "File is already in excellent shape: 0 sorries, clean structure"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #1056 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k\\geq 2$. Does there exist a prime $p$ and consecutive intervals $I_1,\\ldots,I_k$ such that\\[\\prod_{n\\in I_i}n \\equiv 1\\pmod{p}\\]for all $1\\leq i\\leq k$?\n\n\n\nThis is problem A15 in Guy's collection \\cite{Gu04}, where he reports that in a letter in 1979 Erd\\H{o}s observed that\\[3\\cdot 4\\equiv 5\\cdot 6\\cdot 7\\equiv 1\\pmod{11},\\]establishing the case $k=2$. Makowski \\cite{Ma83} found, for $k=3$,\\[2\\cdot 3\\cdot 4\\cdot 5\\equiv 6\\cdot 7\\cdot 8\\cdot 9\\cdot 10\\cdot 11\\equiv 12\\cdot 13\\cdot 14\\cdot 15\\equiv 1\\pmod{17}.\\]Noll and Simmons asked, more generally, whether there are solutions to $q_1!\\equiv\\cdots \\equiv q_k!\\pmod{p}$ for arbitrarily large $k$ (with $q_1<\\cdots<q_k$).\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[Ma83] M\\polhk akowski, Andrzej, On a number-theoretical problem of {E}rd\\H{o}s. Elem. Math. (1983), 101--102.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1055\n- Problem #1057\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n- Ma83\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Have Aristotle prove the 3 sorries in companion file (ico_prod_eq_factorial, wilson_nat, wilson_constraint)",
+      "Integrate wilson_constraint proof back into main file (may need import refactoring)"
+    ],
+    "markdown": "# Erd\u0151s #1056 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k\\geq 2$. Does there exist a prime $p$ and consecutive intervals $I_1,\\ldots,I_k$ such that\\[\\prod_{n\\in I_i}n \\equiv 1\\pmod{p}\\]for all $1\\leq i\\leq k$?\n\n\n\nThis is problem A15 in Guy's collection \\cite{Gu04}, where he reports that in a letter in 1979 Erd\\H{o}s observed that\\[3\\cdot 4\\equiv 5\\cdot 6\\cdot 7\\equiv 1\\pmod{11},\\]establishing the case $k=2$. Makowski \\cite{Ma83} found, for $k=3$,\\[2\\cdot 3\\cdot 4\\cdot 5\\equiv 6\\cdot 7\\cdot 8\\cdot 9\\cdot 10\\cdot 11\\equiv 12\\cdot 13\\cdot 14\\cdot 15\\equiv 1\\pmod{17}.\\]Noll and Simmons asked, more generally, whether there are solutions to $q_1!\\equiv\\cdots \\equiv q_k!\\pmod{p}$ for arbitrarily large $k$ (with $q_1<\\cdots<q_k$).\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[Ma83] M\\polhk akowski, Andrzej, On a number-theoretical problem of {E}rd\\H{o}s. Elem. Math. (1983), 101--102.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1055\n- Problem #1057\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n- Ma83\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -51,7 +63,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T14:31:40.058Z",
-  "lastUpdate": "2026-03-13T07:52:17.056Z",
+  "lastUpdate": "2026-03-24T08:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Created Aristotle companion file for Erdős #1056 to enable automated proof of the `wilson_constraint` axiom.

## Progress
- Created `Erdos1056Aristotle.lean` with 3 bridge lemmas targeting Wilson's theorem
- Identified path: `ZMod.prod_Ico_one_prime` → `wilson_constraint`
- Direct import of `Mathlib.NumberTheory.Wilson` breaks existing `native_decide` in main file

## Findings
- Wilson's theorem IS available in Mathlib but import conflicts prevent direct use
- Companion file isolates the import for Aristotle to prove
- The other 2 axioms (erdos_1056_conjecture, noll_simmons_conjecture) are genuinely open

## Status
**Outcome**: progress (companion file created)
**Next Steps**: Aristotle proves 3 sorries → integrate wilson_constraint back into main file

🤖 Generated by researcher-6