### PR TITLE
Research: erdos-1096-oq-01 + erdos-1063-oq-01 — golden ratio proofs + threshold axiom elimination

### DIFF
--- a/proofs/Proofs/Erdos1063Problem.lean
+++ b/proofs/Proofs/Erdos1063Problem.lean
@@ -45,13 +45,13 @@ def DividesChoose (n k i : ℕ) : Prop :=
 /--
 The count of values 0 ≤ i < k for which (n - i) | C(n, k).
 -/
-noncomputable def divisibilityCount (n k : ℕ) : ℕ :=
+def divisibilityCount (n k : ℕ) : ℕ :=
   ((Finset.range k).filter (fun i => (n - i) ∣ Nat.choose n k)).card
 
 /--
 All but one of {n, n-1, ..., n-k+1} divide C(n, k).
 -/
-def AllButOneDivide (n k : ℕ) : Prop :=
+@[reducible] def AllButOneDivide (n k : ℕ) : Prop :=
   n ≥ 2 * k ∧ divisibilityCount n k ≥ k - 1
 
 /- ## Part II: The Threshold n_k -/
@@ -82,25 +82,35 @@ axiom erdos_selfridge_nondivisibility :
 /- ## Part IV: Known Small Values -/
 
 /--
-n_2 = 4: C(4,2) = 6, and 4 | 6 is false but 3 | 6 is true.
+n_2 = 4: C(4,2) = 6, and 4 ∤ 6 but 3 | 6.
 So all but one (i.e., 1 out of 2) of {4,3} divides C(4,2).
--/
-axiom threshold_k2 : IsThreshold 4 2
+Minimality is vacuous since 2·2 = 4. -/
+theorem threshold_k2 : IsThreshold 4 2 := by
+  refine ⟨⟨by norm_num, by native_decide⟩, fun m hm hge => by omega⟩
 
 /--
-n_3 = 6.
--/
-axiom threshold_k3 : IsThreshold 6 3
+n_3 = 6: C(6,3) = 20, and 5 | 20, 4 | 20, but 6 ∤ 20.
+Minimality is vacuous since 2·3 = 6. -/
+theorem threshold_k3 : IsThreshold 6 3 := by
+  refine ⟨⟨by norm_num, by native_decide⟩, fun m hm hge => by omega⟩
 
 /--
-n_4 = 9.
--/
-axiom threshold_k4 : IsThreshold 9 4
+n_4 = 9: C(9,4) = 126, and 9 | 126, 7 | 126, 6 | 126, but 8 ∤ 126.
+Minimality checked at m = 8: C(8,4) = 70 has only 2 divisors from {8,7,6,5}. -/
+theorem threshold_k4 : IsThreshold 9 4 := by
+  refine ⟨⟨by norm_num, by native_decide⟩, ?_⟩
+  intro m hm hge
+  have : m = 8 := by omega
+  subst this; native_decide
 
 /--
-n_5 = 12.
--/
-axiom threshold_k5 : IsThreshold 12 5
+n_5 = 12: C(12,5) = 792, and 12 | 792, 11 | 792, 9 | 792, 8 | 792, but 10 ∤ 792.
+Minimality checked at m ∈ {10, 11}: neither achieves 4 divisors. -/
+theorem threshold_k5 : IsThreshold 12 5 := by
+  refine ⟨⟨by norm_num, by native_decide⟩, ?_⟩
+  intro m hm hge
+  have : m = 10 ∨ m = 11 := by omega
+  rcases this with rfl | rfl <;> native_decide
 
 /- ## Part V: Upper Bounds -/
 

--- a/proofs/Proofs/Erdos1096Problem.lean
+++ b/proofs/Proofs/Erdos1096Problem.lean
@@ -28,9 +28,9 @@ References:
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Set.Basic
-import Mathlib.Data.Set.Finite
 import Mathlib.Data.Finset.Basic
 import Mathlib.Topology.MetricSpace.Basic
+import Mathlib.Tactic
 
 open Set Nat Real
 
@@ -84,7 +84,7 @@ axiom qSequence_initial (q : ℝ) (hq : 1 < q) (hq2 : q < 2) :
     qSequence q 1 = 0 ∧ qSequence q 2 = 1 ∧ qSequence q 3 = q
 
 /-- The gap between consecutive terms: x_{k+1} - x_k -/
-def gap (q : ℝ) (k : ℕ) : ℝ := qSequence q (k + 1) - qSequence q k
+noncomputable def gap (q : ℝ) (k : ℕ) : ℝ := qSequence q (k + 1) - qSequence q k
 
 /- ## Part III: Pisot-Vijayaraghavan Numbers
 
@@ -112,6 +112,22 @@ axiom smallestPisot_minimal :
 noncomputable def goldenRatio : ℝ := (1 + Real.sqrt 5) / 2
 
 axiom goldenRatio_is_pisot : IsPisot goldenRatio
+
+/-- The golden ratio satisfies φ > 1. -/
+theorem goldenRatio_gt_one : 1 < goldenRatio := by
+  unfold goldenRatio
+  have h : (1 : ℝ) < Real.sqrt 5 := by
+    rw [show (1:ℝ) = Real.sqrt 1 from Real.sqrt_one.symm]
+    exact Real.sqrt_lt_sqrt (by norm_num) (by norm_num)
+  linarith
+
+/-- The golden ratio satisfies φ < 2. -/
+theorem goldenRatio_lt_two : goldenRatio < 2 := by
+  unfold goldenRatio
+  have h : Real.sqrt 5 < 3 := by
+    have hsq : Real.sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num)
+    nlinarith [sq_nonneg (Real.sqrt 5 - 3)]
+  linarith
 
 /- ## Part IV: The Erdős-Joó-Komornik Results (1990)
 -/
@@ -158,7 +174,7 @@ def QRepresentableM (q : ℝ) (m : ℕ) : Set ℝ :=
 /-- The k-th element of the m-digit ordered sequence. -/
 axiom qSequenceM (q : ℝ) (m : ℕ) (k : ℕ) : ℝ
 
-def gapM (q : ℝ) (m : ℕ) (k : ℕ) : ℝ :=
+noncomputable def gapM (q : ℝ) (m : ℕ) (k : ℕ) : ℝ :=
   qSequenceM q m (k + 1) - qSequenceM q m k
 
 /-- Bugeaud's Characterization (1996):
@@ -194,5 +210,23 @@ theorem erdos_1096_summary :
     -- The smallest Pisot doesn't have the property
     (¬HasGapProperty smallestPisot) := by
   exact ⟨pisot_no_gap_property, gap_universal_bound, conjecture_second_part⟩
+
+/- ## Part IX: Consequences for the Golden Ratio -/
+
+/-- The golden ratio does not have the gap property
+    (it is a Pisot number, so gaps persist at all scales). -/
+theorem goldenRatio_no_gap_property : ¬HasGapProperty goldenRatio :=
+  pisot_no_gap_property goldenRatio goldenRatio_is_pisot
+
+/-- Gaps in the golden ratio q-expansion are bounded by 1. -/
+theorem goldenRatio_gap_bound (k : ℕ) : gap goldenRatio k ≤ 1 :=
+  gap_universal_bound goldenRatio goldenRatio_gt_one (le_of_lt goldenRatio_lt_two) k
+
+/-- Bugeaud characterization applied to the golden ratio:
+    since φ is Pisot, for every m ≥ 1, the m-digit gaps have positive liminf. -/
+theorem goldenRatio_persistent_gaps :
+    ∀ m : ℕ, m ≥ 1 → ∃ δ : ℝ, δ > 0 ∧ ∀ᶠ k in Filter.atTop, gapM goldenRatio m k ≥ δ :=
+  (bugeaud_characterization goldenRatio goldenRatio_gt_one (le_of_lt goldenRatio_lt_two)).mp
+    goldenRatio_is_pisot
 
 end Erdos1096

--- a/src/data/research/problems/erdos-1063-oq-01.json
+++ b/src/data/research/problems/erdos-1063-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1063-oq-01",
   "title": "Is $n_k$ polynomial in $k$",
   "phase": "NEW",
-  "status": "active",
+  "status": "in-progress",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-24T00:48:59.904Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination via computational verification",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Eliminated 4 of 7 axioms by computational verification. Made divisibilityCount computable, proved all known threshold values (n_2=4, n_3=6, n_4=9, n_5=12) using native_decide.",
+    "builtItems": [
+      "threshold_k2 theorem (proved by native_decide + omega)",
+      "threshold_k3 theorem (proved by native_decide + omega)",
+      "threshold_k4 theorem (proved by native_decide + omega, m=8 check)",
+      "threshold_k5 theorem (proved by native_decide + omega, m\u2208{10,11} check)"
+    ],
+    "insights": [
+      "Threshold axioms (k=2,3,4,5) are computationally verifiable using native_decide",
+      "Key: remove noncomputable from divisibilityCount and mark AllButOneDivide as @[reducible]",
+      "For k=2,3 minimality is vacuous (2k = nk). For k=4 check m=8, k=5 check m\u2208{10,11}",
+      "Remaining 3 axioms are deep results: Erd\u0151s-Selfridge nondivisibility, Monier factorial bound, Cambie lcm bound"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Could compute threshold values for k=6,7,... by extending the pattern",
+      "Erd\u0151s-Selfridge nondivisibility result might be provable for small k values",
+      "Consider proving Monier bound for specific small k values"
+    ]
   },
   "tags": [
     "erdos",

--- a/src/data/research/problems/erdos-1096-oq-01.json
+++ b/src/data/research/problems/erdos-1096-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1096-oq-01",
-  "title": "Does every 1 < q < q₀ have the gap property (gaps → 0)",
+  "title": "Does every 1 < q < q\u2080 have the gap property (gaps \u2192 0)",
   "phase": "NEW",
-  "status": "active",
+  "status": "in-progress",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-24T00:48:59.905Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Golden ratio infrastructure + import/noncomputable fixes",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Added 5 proved theorems (golden ratio bounds + consequences), fixed broken import and noncomputable issues. 14 axioms are all necessary.",
+    "builtItems": [
+      "goldenRatio_gt_one theorem in Erdos1096Problem.lean (proved: phi > 1)",
+      "goldenRatio_lt_two theorem in Erdos1096Problem.lean (proved: phi < 2)",
+      "goldenRatio_no_gap_property theorem (derived from axioms)",
+      "goldenRatio_gap_bound theorem (derived from axioms + bounds)",
+      "goldenRatio_persistent_gaps theorem (Bugeaud characterization applied to phi)"
+    ],
+    "insights": [
+      "All 14 axioms are necessary: function definitions (qSequence, IsPisot, smallestPisot, qSequenceM) + deep results (EJK1990, Bugeaud1996, EJS1996)",
+      "Golden ratio bounds (1 < phi < 2) enable applying gap_universal_bound and bugeaud_characterization axioms",
+      "Import Mathlib.Data.Set.Finite is broken in current Mathlib 4.26.0 - replaced with Mathlib.Tactic",
+      "gap and gapM definitions need noncomputable annotation since they use axiomatized qSequence/qSequenceM"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Consider replacing qSequence axiom with constructive definition using Set.enumerateCountable",
+      "Could define IsPisot concretely if Mathlib has MinimalPolynomial + algebraic conjugate infrastructure",
+      "Potential to prove density_near_one from QRepresentable definition for q near 1"
+    ]
   },
   "tags": [
     "erdos",


### PR DESCRIPTION
## Summary

### erdos-1096-oq-01 (q-expansion gaps)
- Proved `goldenRatio_gt_one` (φ > 1) and `goldenRatio_lt_two` (φ < 2) 
- Derived 3 consequences: `goldenRatio_no_gap_property`, `goldenRatio_gap_bound`, `goldenRatio_persistent_gaps`
- Fixed broken import (`Mathlib.Data.Set.Finite` → `Mathlib.Tactic`) and `noncomputable` issues

### erdos-1063-oq-01 (binomial coefficient divisibility)
- **Proved all 4 threshold axioms** (`n₂=4`, `n₃=6`, `n₄=9`, `n₅=12`) using `native_decide`
- **Axiom count: 7 → 3** — remaining axioms are deep results (Erdős-Selfridge, Monier, Cambie)
- Made `divisibilityCount` computable, `AllButOneDivide` `@[reducible]`

## Build
Both Docker builds pass ✓

🤖 Generated by researcher-5