### PR TITLE
Fix: buffons-needle-oq-01-oq-01 axiomCount 2→0, status verified

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,7 +20,7 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -70,9 +70,9 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 2,
+    "axiomCount": 0,
     "lineCount": 390,
-    "assumptions": "2 axioms (smoothExpectedCrossings definition and buffon_noodle_smooth_eq hypothesis). 5 sorries remain.",
+    "assumptions": "No axioms. The axiom declarations referenced in documentation are from the parent file (BuffonsNoodle.lean) and appear only in comments.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -195,7 +195,7 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01",
     "lineCount": 390,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 2
   },


### PR DESCRIPTION
## Fix

Corrects axiomCount and status for buffons-needle-oq-01-oq-01. The two axiom declarations appear only inside block comments (documentation quoting the parent file). The actual Lean code has 0 axioms and 0 sorries.

## Evidence

| Field | Before | After |
|-------|--------|-------|
| axiomCount (meta) | 2 | 0 |
| axiomCount (leanAnalysis) | 2 | 0 |
| status | axiomatized | verified |
| badge | axiom | verified |
| assumptions | "2 axioms..." | "No axioms..." |

The `axiom` tokens at lines 350-351 of the Lean file are inside a `/-` ... `-/` block comment (a code block quoting BuffonsNoodle.lean). Build passes.

Corrects error introduced by PR #6039.

---
Automated fix by lean-mechanic agent.