### PR TITLE
Fix: erdos-1172 axiomCount 10 → 8

### DIFF
--- a/src/data/proofs/erdos-1172/meta.json
+++ b/src/data/proofs/erdos-1172/meta.json
@@ -65,9 +65,9 @@
       "omega1_lt_omega2",
       "omega2_lt_omega3"
     ],
-    "axiomCount": 10,
+    "axiomCount": 8,
     "lineCount": 204,
-    "assumptions": "10 axioms: OrdPartitionRel, partition_mono_source, partition_mono_target, and 7 more. See Lean source for complete statements."
+    "assumptions": "8 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős Problem #1172 originates from the Erdős-Hajnal partition calculus program, a systematic study of ordinal partition relations launched by Paul Erdős and András Hajnal in the 1960s. The specific questions appear as problem 7.87 in Väänänen's 1999 survey (Va99), attributed to Erdős and Hajnal.\n\nThe partition calculus grew out of Ramsey's theorem (1930) and its infinitary extensions by Erdős and Rado (1956). The Erdős-Dushnik-Miller theorem (1941) established the foundational result λ → (λ, ω)² for all infinite λ. By the 1960s, Erdős and Hajnal had developed a comprehensive program to determine which ordinal partition relations hold under various set-theoretic hypotheses.\n\nA key turning point came with Todorcevic's work in 1989, which revealed that many partition relations at ω₁ are independent of ZFC. Under the Proper Forcing Axiom (PFA), ω₁ → (ω₁, α)² holds for all countable α, while under b = ω₁, the relation ω₁ → (ω₁, ω + 2)² fails. This independence phenomenon makes the questions at ω₂ and ω₃ particularly subtle, as GCH or CH may be needed to resolve them.\n\nThe four questions in Problem 1172 probe the boundary between what is provable under GCH/CH and what remains open, involving delicate interactions between ordinal arithmetic, cofinality, and coloring arguments.",
@@ -191,7 +191,7 @@
     ],
     "namespace": "Erdos1172",
     "lineCount": 204,
-    "axiomCount": 10,
+    "axiomCount": 8,
     "theoremCount": 16,
     "definitionCount": 12
   },


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in erdos-1172 meta.json. Two axioms were eliminated by research PRs.

## Evidence

**Before**: `"axiomCount": 10`
**After**: `"axiomCount": 8`

Verified: 8 axiom declarations in `Proofs/Erdos1172Problem.lean` (comment-stripped count). Build passes.

---
Automated fix by lean-mechanic agent.