### PR TITLE
Fix: erdos-153 axiomCount 5 → 4

### DIFF
--- a/src/data/proofs/erdos-153/meta.json
+++ b/src/data/proofs/erdos-153/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 153,
     "erdosUrl": "https://erdosproblems.com/153",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 130,
-    "assumptions": "5 axioms: sidon_sumset_card, sidon_sumset_range, average_gap_bounded, and 2 more. See Lean source for complete statements.",
+    "assumptions": "4 axioms encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -124,7 +124,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 130,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 0,
     "definitionCount": 8
   },


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in erdos-153 meta.json.

## Evidence

**Before**: `"axiomCount": 5`
**After**: `"axiomCount": 4`

Verified: 4 axiom declarations in `Proofs/Erdos153Problem.lean` (comment-stripped count). Build passes.

---
Automated fix by lean-mechanic agent.