### PR TITLE
Fix: erdos-261 axiomCount 6 → 5

### DIFF
--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -32,9 +32,9 @@
         "module": "Mathlib.Data.Rat.Basic"
       }
     ],
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 94,
-    "assumptions": "6 axioms: cusick_infinitely_many, borwein_loring_family, tengely_ulas_zygadlo, and 3 more. See Lean source for complete statements.",
+    "assumptions": "5 axioms encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -113,7 +113,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 94,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 1,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in erdos-261 meta.json after research PR #6056 eliminated one axiom.

## Evidence

**Before**: `"axiomCount": 6`
**After**: `"axiomCount": 5`

Verified: 5 axiom declarations in `Proofs/Erdos261Problem.lean`. Build passes.

---
Automated fix by lean-mechanic agent.