### PR TITLE
Fix: erdos-414 axiomCount 3 → 2

### DIFF
--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -47,7 +47,7 @@
         "relation": "The Collatz conjecture: canonical example of orbit coalescence for an iterated function, but with non-monotone dynamics"
       }
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "assumptions": [
       "erdos_414_conjecture: ∀ m, n ≥ 1, ∃ i, j: h^i(m) = h^j(n) — all orbits eventually merge (main open question)",
       "single_eventual_orbit: equivalent formulation — there exists a single sequence S that all orbits eventually follow",
@@ -202,7 +202,7 @@
   "leanFile": {
     "lineCount": 155,
     "structureCount": 0,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 13,
     "lemmaCount": 0,
     "defCount": 2,


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in erdos-414 meta.json.

## Evidence

**Before**: `"axiomCount": 3`
**After**: `"axiomCount": 2`

Verified: 2 axiom declarations in `Proofs/Erdos414Problem.lean` (comment-stripped count). Build passes.

---
Automated fix by lean-mechanic agent.