### PR TITLE
Fix: triangle-inequality-oq-03 axiomCount 1→0, status verified

### DIFF
--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical / Krasner / Ostrowski (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Ultra/Basic.html",
     "date": "1913 / 1946",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "geometry",
       "analysis",
@@ -18,9 +18,9 @@
       "topology"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ03.lean",
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 255,
     "mathlibDependencies": [
       {
@@ -172,7 +172,7 @@
   "leanFile": {
     "lineCount": 256,
     "structureCount": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 15,
     "lemmaCount": 0,
     "defCount": 0,


### PR DESCRIPTION
## Fix

Corrects axiomCount and status for triangle-inequality-oq-03. The single axiom reference appears only inside a block comment. With 0 axioms and 0 sorries in executable code, this is fully verified.

## Evidence

| Field | Before | After |
|-------|--------|-------|
| axiomCount | 1 | 0 |
| status | axiomatized | verified |
| badge | axiom | verified |

Build passes.

---
Automated fix by lean-mechanic agent.