### PR TITLE
Enrich 10 entries: annotations, cross-references, depth

### DIFF
--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -149,6 +149,28 @@
       "targetId": "prob-method-alteration"
     }
   ],
+  "relatedProofs": [
+    {
+      "id": "erdos-156",
+      "title": "Erdős Problem #156: Minimum Size of Maximal Sidon Sets",
+      "relationship": "sibling — both study Sidon sets; #156 asks about maximality while #157 asks about basis properties"
+    },
+    {
+      "id": "erdos-158",
+      "title": "Erdős Problem #158: B₂[g] Sets",
+      "relationship": "generalization — B₂[g] sets allow g representations per sum; the density constraints change as g grows"
+    },
+    {
+      "id": "erdos-1",
+      "title": "Erdős Problem #1: Distinct Subset Sums",
+      "relationship": "related additive combinatorics — another problem about how sums interact with set structure"
+    },
+    {
+      "id": "prob-method-alteration",
+      "title": "Probabilistic Method: Alteration",
+      "relationship": "technique — Pilatte's proof uses the Lovász Local Lemma, a key tool in the probabilistic method"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-170/meta.json
+++ b/src/data/proofs/erdos-170/meta.json
@@ -182,5 +182,22 @@
       "relationship": "Both involve arithmetic structure and optimal covering/balancing of integer ranges; difference bases cover all residues while discrepancy bounds measure uniformity",
       "targetId": "erdos-176"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-340-greedy-sidon",
+      "title": "Greedy Sidon Sequence Infrastructure (Erdős Problem #340)",
+      "relationship": "both study difference-based combinatorial structures — Sidon sets require distinct pairwise differences, rulers require all differences 1..N"
+    },
+    {
+      "id": "erdos-169",
+      "title": "Erdős Problem #169: Harmonic Sum of AP-Free Sets",
+      "relationship": "both concern extremal problems on integer sets with additive structure constraints"
+    },
+    {
+      "id": "erdos-176",
+      "title": "Erdős Problem #176: Discrepancy of Arithmetic Progressions",
+      "relationship": "both involve arithmetic structure and optimal covering/balancing of integer ranges"
+    }
   ]
 }

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -207,5 +207,22 @@
       "relationship": "The Lovász Local Lemma is a key tool in chromatic number bounds for geometric graphs, including approaches to the Hadwiger-Nelson problem",
       "targetId": "prob-method-lovasz-local"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-173",
+      "title": "Erdős Problem #173: Monochromatic Triangles in Plane Colorings",
+      "relationship": "both concern chromatic properties of the Euclidean plane from different angles"
+    },
+    {
+      "id": "erdos-174",
+      "title": "Erdős Problem #174: Euclidean Ramsey Sets",
+      "relationship": "both involve geometric Ramsey theory — unavoidable monochromatic configurations in Euclidean space"
+    },
+    {
+      "id": "prob-method-lovasz-local",
+      "title": "Lovász Local Lemma",
+      "relationship": "technique — LLL is a key tool in chromatic number bounds for geometric graphs"
+    }
   ]
 }

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -176,5 +176,22 @@
       "relationship": "Both are Ramsey-type problems asking for unavoidable monochromatic configurations — #172 in arithmetic, #174 in geometry",
       "targetId": "erdos-174"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-160",
+      "title": "Erdős Problem #160",
+      "relationship": "related — both study Ramsey-type phenomena in number theory with monochromatic configurations"
+    },
+    {
+      "id": "ramseys-theorem",
+      "title": "Ramsey's Theorem",
+      "relationship": "foundation — the original combinatorial result guaranteeing monochromatic structures in colorings"
+    },
+    {
+      "id": "erdos-174",
+      "title": "Erdős Problem #174: Euclidean Ramsey Sets",
+      "relationship": "sibling — #172 studies arithmetic Ramsey (sums/products), #174 studies geometric Ramsey"
+    }
   ]
 }

--- a/src/data/proofs/erdos-174/meta.json
+++ b/src/data/proofs/erdos-174/meta.json
@@ -207,5 +207,22 @@
       "relationship": "Both ask about unavoidable monochromatic geometric configurations in colored Euclidean space",
       "targetId": "erdos-173"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-171",
+      "title": "Erdős Problem #171: Unit Distance Chromatic Number",
+      "relationship": "both study chromatic/Ramsey properties of Euclidean space from different angles"
+    },
+    {
+      "id": "ramseys-theorem",
+      "title": "Ramsey's Theorem",
+      "relationship": "foundation — Euclidean Ramsey theory extends classical Ramsey theory to geometric settings"
+    },
+    {
+      "id": "erdos-173",
+      "title": "Erdős Problem #173: Monochromatic Triangles in Plane Colorings",
+      "relationship": "sibling — both ask about unavoidable monochromatic geometric configurations"
+    }
   ]
 }

--- a/src/data/proofs/erdos-175/meta.json
+++ b/src/data/proofs/erdos-175/meta.json
@@ -203,5 +203,22 @@
       "relationship": "The binomial theorem provides the algebraic foundation for binomial coefficients whose squarefreeness is studied in this problem",
       "targetId": "binomial-theorem"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "kummer-theorem",
+      "title": "Kummer's Theorem on Binomial Coefficients",
+      "relationship": "central tool — Kummer's theorem governs the p-adic valuations that determine squarefreeness of C(2n,n)"
+    },
+    {
+      "id": "erdos-728-factorial-divisibility",
+      "title": "Erdős Problem #728: Factorial Divisibility",
+      "relationship": "sibling — both study p-adic valuations of combinatorial quantities"
+    },
+    {
+      "id": "binomial-theorem",
+      "title": "The Binomial Theorem",
+      "relationship": "foundation — provides the algebraic framework for binomial coefficients"
+    }
   ]
 }


### PR DESCRIPTION
Batch enrichment pass across 10 gallery entries.

## Deep enrichments (annotations created/expanded, history deepened)

### erdos-1139 (Gaps in the Almost-Prime Sequence) — quality 34 → high
- Created annotations.json from scratch (10 annotations)
- Expanded historicalContext, keyInsights (3→5), sections (3→8)
- Added relatedProofs: prime-number-theorem, bounded-prime-gaps, infinitude-primes

### erdos-1165 (Favourite Sites of Random Walks in ℤ²)
- Added 2 keyInsights (Green's function, zero-one dichotomy), fixed lineCount, sections
- Added relatedProofs: central-limit-theorem, erdos-1144

## relatedProofs additions (entries had crossReferences but no relatedProofs)

- **erdos-1160**: sylow-theorems, lagrange-theorem, inverse-galois, abel-ruffini
- **erdos-157**: erdos-156, erdos-158, erdos-1, prob-method-alteration
- **erdos-170**: erdos-340-greedy-sidon, erdos-169, erdos-176
- **erdos-171**: erdos-173, erdos-174, prob-method-lovasz-local
- **erdos-172**: erdos-160, ramseys-theorem, erdos-174
- **erdos-174**: erdos-171, ramseys-theorem, erdos-173
- **erdos-175**: kummer-theorem, erdos-728-factorial-divisibility, binomial-theorem

Also includes erdos-1095-oq-01 enrichment (history, annotations, sections, lineCount fix).