### PR TITLE
Research: erdos-685 - Axiom elimination + 3 proved theorems (6 theorems, 0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos685Problem.lean
+++ b/proofs/Proofs/Erdos685Problem.lean
@@ -69,4 +69,38 @@ theorem omega_choose_one (n : ℕ) : omega (n.choose 1) = omega n := by
   rw [Nat.choose_one_right]
 
 /-- `ω(n) = 0` iff `n ≤ 1`. -/
-axiom omega_eq_zero_iff (n : ℕ) : omega n = 0 ↔ n ≤ 1
+theorem omega_eq_zero_iff (n : ℕ) : omega n = 0 ↔ n ≤ 1 := by
+  simp only [omega, Finset.card_eq_zero]
+  constructor
+  · intro h
+    by_contra hn
+    push_neg at hn
+    -- n ≥ 2, so n has at least one prime factor
+    have hn2 : 2 ≤ n := hn
+    have := Nat.exists_prime_and_dvd (by omega : n ≠ 1)
+    obtain ⟨p, hp, hpn⟩ := this
+    have : p ∈ n.primeFactors := Nat.mem_primeFactors.mpr ⟨hp, hpn, by omega⟩
+    rw [h] at this
+    exact Finset.notMem_empty p this
+  · intro h
+    interval_cases n <;> simp [Nat.primeFactors]
+
+/-- `ω(n) > 0` for `n ≥ 2`. -/
+theorem omega_pos_of_one_lt (n : ℕ) (hn : 1 < n) : 0 < omega n := by
+  by_contra h
+  push_neg at h
+  have := (omega_eq_zero_iff n).mp (Nat.le_zero.mp h)
+  omega
+
+/-- `ω(p) = 1` for a prime `p`. -/
+theorem omega_prime (p : ℕ) (hp : p.Prime) : omega p = 1 := by
+  unfold omega
+  have : p.primeFactors = {p} := by
+    ext q
+    simp only [Nat.mem_primeFactors, Finset.mem_singleton]
+    constructor
+    · intro ⟨hq, hqp, _⟩
+      exact (hp.eq_one_or_self_of_dvd q hqp).resolve_left (Nat.Prime.one_lt hq).ne'
+    · intro heq; rw [heq]
+      exact ⟨hp, dvd_refl p, hp.pos.ne'⟩
+  rw [this, Finset.card_singleton]

--- a/src/data/proofs/erdos-685/meta.json
+++ b/src/data/proofs/erdos-685/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-685",
-  "title": "Erdős Problem #685: Prime Divisors of Binomial Coefficients",
+  "title": "Erd\u0151s Problem #685: Prime Divisors of Binomial Coefficients",
   "slug": "erdos-685",
-  "description": "For n^ε < k ≤ n^{1-ε}, is ω(C(n,k)) = (1+o(1))·k·Σ_{k<p<n} 1/p? Trivial lower bound: log C(n,k)/log n, tight when k > n^{1-o(1)}.",
+  "description": "For n^\u03b5 < k \u2264 n^{1-\u03b5}, is \u03c9(C(n,k)) = (1+o(1))\u00b7k\u00b7\u03a3_{k<p<n} 1/p? Trivial lower bound: log C(n,k)/log n, tight when k > n^{1-o(1)}.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/685",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos685Problem.lean",
@@ -47,27 +47,30 @@
     "originalContributions": [
       "Defined omega (distinct prime divisor count) using Nat.primeFactors",
       "Defined primeSumInRange for the prime reciprocal sum over (k,n)",
-      "Stated ErdosProblem685 as an asymptotic equality for ω(C(n,k))",
-      "Stated trivial lower bound ω(C(n,k)) ≥ log C(n,k)/log n",
+      "Stated ErdosProblem685 as an asymptotic equality for \u03c9(C(n,k))",
+      "Stated trivial lower bound \u03c9(C(n,k)) \u2265 log C(n,k)/log n",
       "Stated tightness of the lower bound for k near n",
       "Proved omega_one, omega_choose_zero, omega_choose_one",
-      "Stated omega_eq_zero_iff as characterization"
+      "Stated omega_eq_zero_iff as characterization",
+      "omega_eq_zero_iff: \u03c9(n) = 0 \u2194 n \u2264 1 (PROVED, was axiom)",
+      "omega_pos_of_one_lt: \u03c9(n) > 0 for n \u2265 2 (PROVED)",
+      "omega_prime: \u03c9(p) = 1 for prime p (PROVED)"
     ],
-    "axiomCount": 3,
-    "lineCount": 72,
+    "axiomCount": 2,
+    "lineCount": 106,
     "assumptions": "3 axiom(s): omega_choose_lower, omega_choose_tight_near_n, omega_eq_zero_iff. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "Erdős studied the prime factorization structure of binomial coefficients throughout his career. The function ω(n), counting distinct prime divisors, is a fundamental quantity in analytic number theory. For binomial coefficients C(n,k), Kummer's theorem relates the p-adic valuation to carries in base-p addition, but counting the number of distinct primes dividing C(n,k) is a subtler question.\n\nThe conjecture gives a precise asymptotic formula: ω(C(n,k)) ~ k · Σ_{k<p<n} 1/p, where the sum runs over primes in the interval (k,n). By Mertens' theorem, this prime reciprocal sum is approximately log(log n/log k), so the formula predicts ω(C(n,k)) ~ k · log(log n/log k). The result should hold in the 'middle range' n^ε < k ≤ n^{1-ε}, where both k and n/k grow polynomially.\n\nThe trivial lower bound ω(C(n,k)) ≥ log C(n,k)/log n comes from the fact that each prime factor of C(n,k) is at most n. This bound is tight when k is near n (specifically for k > n^{1-o(1)}), since then C(n,k) is small and its prime factors are constrained. Erdős speculated that the conjecture might extend to k as small as (log n)^c.",
-    "problemStatement": "For n^ε < k ≤ n^{1-ε}, is ω(C(n,k)) = (1+o(1))·k·Σ_{k<p<n} 1/p?",
-    "text": "For n^ε < k ≤ n^{1-ε}, is ω(C(n,k)) = (1+o(1))·k·Σ_{k<p<n} 1/p? Trivial lower bound: log C(n,k)/log n, tight when k > n^{1-o(1)}.",
+    "historicalContext": "Erd\u0151s studied the prime factorization structure of binomial coefficients throughout his career. The function \u03c9(n), counting distinct prime divisors, is a fundamental quantity in analytic number theory. For binomial coefficients C(n,k), Kummer's theorem relates the p-adic valuation to carries in base-p addition, but counting the number of distinct primes dividing C(n,k) is a subtler question.\n\nThe conjecture gives a precise asymptotic formula: \u03c9(C(n,k)) ~ k \u00b7 \u03a3_{k<p<n} 1/p, where the sum runs over primes in the interval (k,n). By Mertens' theorem, this prime reciprocal sum is approximately log(log n/log k), so the formula predicts \u03c9(C(n,k)) ~ k \u00b7 log(log n/log k). The result should hold in the 'middle range' n^\u03b5 < k \u2264 n^{1-\u03b5}, where both k and n/k grow polynomially.\n\nThe trivial lower bound \u03c9(C(n,k)) \u2265 log C(n,k)/log n comes from the fact that each prime factor of C(n,k) is at most n. This bound is tight when k is near n (specifically for k > n^{1-o(1)}), since then C(n,k) is small and its prime factors are constrained. Erd\u0151s speculated that the conjecture might extend to k as small as (log n)^c.",
+    "problemStatement": "For n^\u03b5 < k \u2264 n^{1-\u03b5}, is \u03c9(C(n,k)) = (1+o(1))\u00b7k\u00b7\u03a3_{k<p<n} 1/p?",
+    "text": "For n^\u03b5 < k \u2264 n^{1-\u03b5}, is \u03c9(C(n,k)) = (1+o(1))\u00b7k\u00b7\u03a3_{k<p<n} 1/p? Trivial lower bound: log C(n,k)/log n, tight when k > n^{1-o(1)}.",
     "proofStrategy": "We define omega as the prime factors count using Nat.primeFactors, and primeSumInRange for the prime reciprocal sum. The main conjecture ErdosProblem685 is stated as an asymptotic equality with explicit error terms. The trivial lower bound and its tightness for k near n are axioms. Basic properties omega_one, omega_choose_zero, and omega_choose_one are proved.",
     "keyInsights": [
-      "**Asymptotic Formula**: ω(C(n,k)) ~ k · Σ 1/p over primes in (k,n), combining the prime counting function with the structure of binomial coefficients",
-      "**Mertens Connection**: By Mertens' theorem, the prime sum is ≈ log(log n/log k), giving ω(C(n,k)) ~ k · log(log n/log k) in the middle range",
-      "**Kummer's Theorem**: The p-adic valuation of C(n,k) equals the number of carries when adding k and n-k in base p — this underlies the divisibility structure",
-      "**Trivial Bound Tightness**: The bound ω ≥ log C(n,k)/log n is tight only when k > n^{1-o(1)}, where the binomial coefficient is small",
-      "**Extended Range**: The conjecture may hold for k ≥ (log n)^c, well below the polynomial threshold n^ε"
+      "**Asymptotic Formula**: \u03c9(C(n,k)) ~ k \u00b7 \u03a3 1/p over primes in (k,n), combining the prime counting function with the structure of binomial coefficients",
+      "**Mertens Connection**: By Mertens' theorem, the prime sum is \u2248 log(log n/log k), giving \u03c9(C(n,k)) ~ k \u00b7 log(log n/log k) in the middle range",
+      "**Kummer's Theorem**: The p-adic valuation of C(n,k) equals the number of carries when adding k and n-k in base p \u2014 this underlies the divisibility structure",
+      "**Trivial Bound Tightness**: The bound \u03c9 \u2265 log C(n,k)/log n is tight only when k > n^{1-o(1)}, where the binomial coefficient is small",
+      "**Extended Range**: The conjecture may hold for k \u2265 (log n)^c, well below the polynomial threshold n^\u03b5"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -80,7 +83,7 @@
       "title": "Module Header and Problem Context",
       "startLine": 1,
       "endLine": 20,
-      "summary": "Documents Erdős Problem #685: the number of distinct prime divisors of C(n,k) is asymptotically k·Σ_{k<p≤n} 1/p for n^ε < k ≤ n^{1-ε}. This connects the prime factorization of binomial coefficients to Mertens' theorem. Status: OPEN. Imports Mathlib."
+      "summary": "Documents Erd\u0151s Problem #685: the number of distinct prime divisors of C(n,k) is asymptotically k\u00b7\u03a3_{k<p\u2264n} 1/p for n^\u03b5 < k \u2264 n^{1-\u03b5}. This connects the prime factorization of binomial coefficients to Mertens' theorem. Status: OPEN. Imports Mathlib."
     },
     {
       "id": "omega",
@@ -94,14 +97,14 @@
       "title": "Main Conjecture",
       "startLine": 31,
       "endLine": 42,
-      "summary": "States ErdosProblem685: ω(C(n,k)) = (1±δ)·k·Σ 1/p for n^ε < k ≤ n^{1-ε}, with explicit quantifiers over ε and δ."
+      "summary": "States ErdosProblem685: \u03c9(C(n,k)) = (1\u00b1\u03b4)\u00b7k\u00b7\u03a3 1/p for n^\u03b5 < k \u2264 n^{1-\u03b5}, with explicit quantifiers over \u03b5 and \u03b4."
     },
     {
       "id": "lower",
       "title": "Trivial Lower Bound",
       "startLine": 43,
       "endLine": 56,
-      "summary": "Trivial bound ω(C(n,k)) ≥ log C(n,k)/log n and tightness for k > n^{1-ε}."
+      "summary": "Trivial bound \u03c9(C(n,k)) \u2265 log C(n,k)/log n and tightness for k > n^{1-\u03b5}."
     },
     {
       "id": "basic",
@@ -112,11 +115,11 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 685 on distinct prime divisors of binomial coefficients, the trivial lower bound, and its tightness near k = n. Three theorems are proved directly; two bounds and one characterization are axiomatized.",
+    "summary": "The formalization captures Erd\u0151s Problem 685 on distinct prime divisors of binomial coefficients, the trivial lower bound, and its tightness near k = n. Three theorems are proved directly; two bounds and one characterization are axiomatized.",
     "implications": "A resolution would quantify the prime factor structure of binomial coefficients across the full range of k, connecting Kummer's theorem to asymptotic prime counting and extending Mertens' theorem to combinatorial settings.",
     "openQuestions": [
-      "Is ω(C(n,k)) = (1+o(1))·k·Σ 1/p for n^ε < k ≤ n^{1-ε}?",
-      "Does the asymptotic hold for k ≥ (log n)^c?",
+      "Is \u03c9(C(n,k)) = (1+o(1))\u00b7k\u00b7\u03a3 1/p for n^\u03b5 < k \u2264 n^{1-\u03b5}?",
+      "Does the asymptotic hold for k \u2265 (log n)^c?",
       "What is the error term in the asymptotic formula?",
       "How does the distribution of prime factors of C(n,k) compare to that of a 'random' integer of similar size?"
     ]
@@ -143,17 +146,17 @@
     {
       "targetId": "erdos-1095",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory, prime-factors"
+      "description": "Related Erd\u0151s problem sharing themes: binomial-coefficients, number-theory, prime-factors"
     },
     {
       "targetId": "erdos-683",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory, primes"
+      "description": "Related Erd\u0151s problem sharing themes: binomial-coefficients, number-theory, primes"
     },
     {
       "targetId": "erdos-684",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory, primes"
+      "description": "Related Erd\u0151s problem sharing themes: binomial-coefficients, number-theory, primes"
     }
   ],
   "relatedProofs": [

--- a/src/data/research/problems/erdos-685.json
+++ b/src/data/research/problems/erdos-685.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-685",
-  "title": "Erdős #685",
-  "phase": "OBSERVE",
+  "title": "Erd\u0151s #685",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-01-14T19:46:33.195Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,12 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Eliminated omega_eq_zero_iff axiom (now proved). Added omega_pos_of_one_lt and omega_prime theorems. File now has 6 theorems, 2 axioms, 0 sorries.",
+    "builtItems": [
+      "Proved omega_eq_zero_iff (eliminated axiom)",
+      "Proved omega_pos_of_one_lt",
+      "Proved omega_prime (\u03c9(p) = 1 for prime p)"
+    ],
+    "insights": [
+      "omega_eq_zero_iff is provable from Nat.primeFactors + Nat.exists_prime_and_dvd",
+      "omega_prime proved via primeFactors singleton characterization for primes",
+      "Remaining 2 axioms (omega_choose_lower, omega_choose_tight_near_n) are asymptotic estimates requiring analytic number theory"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #685 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $\\epsilon>0$ and $n$ be large depending on $\\epsilon$. Is it true that for all $n^\\epsilon<k\\leq n^{1-\\epsilon}$ the number of distinct prime divisors of $\\binom{n}{k}$ is\\[(1+o(1))k\\sum_{k<p<n}\\frac{1}{p}?\\]Or perhaps even when $k \\geq (\\log n)^c$?\n\n\n\nIt is trivial that the number of prime factors is\\[>\\frac{\\log \\binom{n}{k}}{\\log n},\\]and this inequality becomes (asymptotic) equality if $k>n^{1-o(1)}$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #684\n- Problem #686\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
+    "nextSteps": [
+      "The 2 remaining axioms require analytic number theory (prime counting, asymptotics)",
+      "Could add: omega_prime_power (\u03c9(p^k) = 1), omega multiplicativity bounds"
+    ],
+    "markdown": "# Erd\u0151s #685 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $\\epsilon>0$ and $n$ be large depending on $\\epsilon$. Is it true that for all $n^\\epsilon<k\\leq n^{1-\\epsilon}$ the number of distinct prime divisors of $\\binom{n}{k}$ is\\[(1+o(1))k\\sum_{k<p<n}\\frac{1}{p}?\\]Or perhaps even when $k \\geq (\\log n)^c$?\n\n\n\nIt is trivial that the number of prime factors is\\[>\\frac{\\log \\binom{n}{k}}{\\log n},\\]and this inequality becomes (asymptotic) equality if $k>n^{1-o(1)}$.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #684\n- Problem #686\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [
     "erdos"
@@ -50,7 +61,7 @@
     "mathlib": []
   },
   "started": "2026-01-14T19:46:33.201Z",
-  "lastUpdate": "2026-03-13T07:52:17.051Z",
+  "lastUpdate": "2026-03-24T08:10:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Eliminate the `omega_eq_zero_iff` axiom and add structural theorems for Erdős #685 (prime divisors of binomial coefficients).

## Progress
- **Proved `omega_eq_zero_iff`**: ω(n) = 0 ↔ n ≤ 1 (was axiom, now theorem using `Nat.primeFactors`)
- **Added `omega_pos_of_one_lt`**: ω(n) > 0 for n ≥ 2 (proved)
- **Added `omega_prime`**: ω(p) = 1 for prime p (proved via primeFactors singleton)
- Axiom count: 3 → 2
- Sorry count: 0

## Remaining Axioms (genuinely deep)
- `omega_choose_lower`: asymptotic lower bound requiring analytic number theory
- `omega_choose_tight_near_n`: tightness result for k near n

## Status
**Outcome**: completed
**File**: 106 lines, 6 theorems, 2 axioms, 0 sorries

🤖 Generated by researcher-6