### PR TITLE
Research: erdos-1047 - Axiom elimination (17→14 axioms, prove polynomial properties)

### DIFF
--- a/proofs/Proofs/Erdos1047Problem.lean
+++ b/proofs/Proofs/Erdos1047Problem.lean
@@ -149,8 +149,12 @@ theorem pommerenkePolynomial_monic (k : ℕ) (a : ℂ) :
   exact Monic.mul (monic_X_pow k) (monic_X_sub_C a)
 
 /-- Pommerenke's polynomial has degree k+1 -/
-axiom pommerenkePolynomial_degree (k : ℕ) (a : ℂ) (ha : a ≠ 0) :
-    (pommerenkePolynomial k a).natDegree = k + 1
+theorem pommerenkePolynomial_degree (k : ℕ) (a : ℂ) (ha : a ≠ 0) :
+    (pommerenkePolynomial k a).natDegree = k + 1 := by
+  unfold pommerenkePolynomial
+  rw [Polynomial.natDegree_mul (pow_ne_zero k X_ne_zero) (X_sub_C_ne_zero a),
+      Polynomial.natDegree_pow, Polynomial.natDegree_X, Polynomial.natDegree_X_sub_C,
+      mul_one]
 
 /-- For large k and specific a, Pommerenke's polynomial gives a non-convex component.
     This is the first counterexample to Grunsky's conjecture. -/
@@ -176,7 +180,10 @@ noncomputable def goodmanPolynomial : ℂ[X] :=
   (X ^ 2 + 1) * (X - 2) ^ 2
 
 /-- Goodman's polynomial is monic of degree 4 -/
-axiom goodmanPolynomial_monic : goodmanPolynomial.Monic
+theorem goodmanPolynomial_monic : goodmanPolynomial.Monic := by
+  unfold goodmanPolynomial
+  exact Monic.mul (monic_X_pow_add_C 1 (by norm_num : (2 : ℕ) ≠ 0))
+    ((monic_X_sub_C (2 : ℂ)).pow 2)
 
 /-- Goodman's critical value: c = 5^(3/2)/4 ≈ 2.795 -/
 noncomputable def goodmanCriticalValue : ℝ :=
@@ -206,7 +213,9 @@ noncomputable def refereePolynomial : ℂ[X] :=
   X * (X ^ 5 - 1)
 
 /-- Referee's polynomial is monic of degree 6 -/
-axiom refereePolynomial_monic : refereePolynomial.Monic
+theorem refereePolynomial_monic : refereePolynomial.Monic := by
+  unfold refereePolynomial
+  exact monic_X.mul (monic_X_pow_sub_C 1 (by norm_num : (5 : ℕ) ≠ 0))
 
 /-- Referee's critical value: 5.6^(-6/5) -/
 noncomputable def refereeCriticalValue : ℝ :=

--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -57,9 +57,9 @@
       "Framework for studying lemniscate convexity and component geometry",
       "Positive results: single-root lemniscates are convex disks"
     ],
-    "axiomCount": 17,
-    "lineCount": 278,
-    "assumptions": "17 axioms: lemniscate_isClosed, lemniscate_isBounded, lemniscate_isCompact, and 14 more. See Lean source for complete statements.",
+    "axiomCount": 14,
+    "lineCount": 286,
+    "assumptions": "14 axioms: lemniscate_isClosed, lemniscate_isBounded, lemniscate_isCompact, and 11 more. Proved: pommerenkePolynomial_degree, goodmanPolynomial_monic, refereePolynomial_monic.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -298,9 +298,9 @@
       "Set"
     ],
     "namespace": "Erdos1047",
-    "lineCount": 278,
-    "axiomCount": 17,
-    "theoremCount": 4,
+    "lineCount": 286,
+    "axiomCount": 14,
+    "theoremCount": 7,
     "definitionCount": 13
   }
 }

--- a/src/data/research/problems/erdos-1047-oq-01.json
+++ b/src/data/research/problems/erdos-1047-oq-01.json
@@ -29,9 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Eliminated 3 axioms (17→14). Proved polynomial degree and monicity from Mathlib. Clean build.",
+    "builtItems": [
+      "Proved pommerenkePolynomial_degree: deg(X^k(X-a)) = k+1",
+      "Proved goodmanPolynomial_monic: (X²+1)(X-2)² is monic",
+      "Proved refereePolynomial_monic: X(X⁵-1) is monic"
+    ],
+    "insights": [
+      "pommerenkePolynomial_degree provable via natDegree_mul + natDegree_pow",
+      "Monic for product polynomials via Monic.mul and monic_X_pow_add_C/monic_X_sub_C",
+      "monic_X_pow_sub_C needs the exponent ≠ 0 proof",
+      "goodmanPolynomial_degree_pos harder: Monic.natDegree_pos needs p ≠ 1 which requires eval-based contradiction"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary
Eliminated 3 axioms from Erdős #1047 (Convexity of Polynomial Lemniscates) by proving polynomial properties from Mathlib.

| Metric | Before | After |
|--------|--------|-------|
| Axioms | 17 | **14** |
| Theorems | 4 | **7** |
| Sorries | 0 | 0 |

## Axioms Eliminated
- `pommerenkePolynomial_degree` → theorem via `natDegree_mul`, `natDegree_pow`, `natDegree_X_sub_C`
- `goodmanPolynomial_monic` → theorem via `monic_X_pow_add_C`, `Monic.mul`, `Monic.pow`
- `refereePolynomial_monic` → theorem via `monic_X.mul`, `monic_X_pow_sub_C`

## Files Modified
- `proofs/Proofs/Erdos1047Problem.lean`
- `src/data/proofs/erdos-1047/meta.json`
- `src/data/research/problems/erdos-1047-oq-01.json`

Generated by researcher-3