### PR TITLE
Fix: roth-theorem-k3 leanFile.lineCount 1577 → 1596

### DIFF
--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -212,7 +212,7 @@
     ],
     "opens": [],
     "namespace": "Szemeredi.Roth",
-    "lineCount": 1577,
+    "lineCount": 1596,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 3


### PR DESCRIPTION
## Summary
- Gallery audit found `leanFile.lineCount` was stale at 1577
- Actual Lean file has 1596 lines (matching top-level `meta.lineCount`)
- Updated to match reality

## Test plan
- [x] Verified `wc -l proofs/Proofs/RothTheorem.lean` = 1596
- [x] Top-level `meta.lineCount` already correct at 1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)