### PR TITLE
Enrich 11 entries: add relatedProofs cross-references

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-03/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-03/meta.json
@@ -190,5 +190,27 @@
     "opens": [
       "Function"
     ]
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "cantors-theorem",
+      "title": "Cantor's Theorem",
+      "relationship": "parent — this is an open question derived from Cantor's theorem"
+    },
+    {
+      "id": "cantor-diagonalization",
+      "title": "Cantor's Diagonalization",
+      "relationship": "technique — diagonalization is the key proof method for cardinality results"
+    },
+    {
+      "id": "cantors-theorem-oq-01",
+      "title": "Cantor's Theorem OQ01",
+      "relationship": "sibling open question from the same theorem"
+    },
+    {
+      "id": "cantors-theorem-oq-02",
+      "title": "Cantor's Theorem OQ02",
+      "relationship": "sibling open question from the same theorem"
+    }
+  ]
 }

--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -171,5 +171,22 @@
       "Mathlib.Tactic"
     ],
     "opens": []
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "collatz-structured",
+      "title": "Collatz Conjecture (Structured)",
+      "relationship": "parent — this is an open question about Collatz dynamics"
+    },
+    {
+      "id": "dirichlets-theorem",
+      "title": "Dirichlet's Theorem",
+      "relationship": "related — distribution of primes in arithmetic progressions connects to residue classes in Collatz dynamics"
+    },
+    {
+      "id": "fermat-two-squares",
+      "title": "Fermat's Two Squares Theorem",
+      "relationship": "related — both involve arithmetic structure of integers modulo primes"
+    }
+  ]
 }

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -178,5 +178,17 @@
       "citation": "Jessen, B., The algebra of polyhedra and the Dehn-Sydler theorem, Math. Scand. 22 (1968), 241-256.",
       "type": "paper"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "dissection-of-cubes",
+      "title": "Dissection of Cubes",
+      "relationship": "parent — this is an open question derived from cube dissection"
+    },
+    {
+      "id": "dissection-of-cubes-oq-01",
+      "title": "Dissection of Cubes OQ01",
+      "relationship": "sibling open question about cube dissections"
+    }
   ]
 }

--- a/src/data/proofs/schroeder-bernstein-oq-04/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-04/meta.json
@@ -165,5 +165,12 @@
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 3
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "schroeder-bernstein",
+      "title": "Schröder-Bernstein Theorem",
+      "relationship": "parent — this is an open question derived from the Schröder-Bernstein theorem"
+    }
+  ]
 }

--- a/src/data/proofs/solution-of-cubic-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03/meta.json
@@ -236,5 +236,32 @@
       "citation": "Stillwell, J., Mathematics and Its History, 3rd ed., Springer Undergraduate Texts in Mathematics (2010), Chapters 6–7: cubic and quartic equations.",
       "type": "book"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "solution-of-cubic",
+      "title": "Solution of the Cubic",
+      "relationship": "parent — this is an open question derived from cubic equation theory"
+    },
+    {
+      "id": "abel-ruffini",
+      "title": "Abel-Ruffini Theorem",
+      "relationship": "related — both concern the solvability of polynomial equations by radicals"
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "title": "Fundamental Theorem of Algebra",
+      "relationship": "foundation — guarantees existence of roots whose structure is studied here"
+    },
+    {
+      "id": "general-quartic",
+      "title": "General Quartic",
+      "relationship": "sibling — extends cubic solutions to quartic equations"
+    },
+    {
+      "id": "vietas-formulas",
+      "title": "Vieta's Formulas",
+      "relationship": "technique — connects coefficients to roots, essential for cubic analysis"
+    }
   ]
 }


### PR DESCRIPTION
Add relatedProofs arrays to 11 entries that had crossReferences but no relatedProofs field.

## Batch 1 (6 entries)
- **erdos-176**: erdos-177, erdos-178, szemeredi-theorem
- **erdos-178**: erdos-176, erdos-177, erdos-162
- **erdos-180**: erdos-182, szemeredi-regularity, erdos-167
- **erdos-182**: erdos-180, erdos-181, szemeredi-regularity
- **erdos-183**: erdos-165, erdos-166, ramseys-theorem
- **erdos-374**: infinitude-primes, fundamental-arithmetic

## Batch 2 (5 entries)
- **cantors-theorem-oq-03**: cantors-theorem, cantor-diagonalization, oq-01, oq-02
- **collatz-structured-oq-02**: collatz-structured, dirichlets-theorem, fermat-two-squares
- **dissection-of-cubes-oq-02**: dissection-of-cubes, oq-01
- **schroeder-bernstein-oq-04**: schroeder-bernstein
- **solution-of-cubic-oq-03**: solution-of-cubic, abel-ruffini, FTA, general-quartic, vietas-formulas