### PR TITLE
Fix: navier-stokes-existence axiomCount 0 → 5

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -21,7 +21,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "assumptions": "NSAxioms structure with 5 fields: Type II exponent bound, spectral gap on dissipation scale, theta dynamics bound, blowup rate estimate, BKM criterion. These encode the physical hypotheses needed for conditional 3D regularity.",
     "mathlibDependencies": [
       {
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21111,
+    "lineCount": 21110,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -254,8 +254,8 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
-    "axiomCount": 0,
+    "lineCount": 21110,
+    "axiomCount": 5,
     "theoremCount": 1009,
     "definitionCount": 104
   },


### PR DESCRIPTION
## Summary
- `axiomCount` was 0 but `NSAxioms` structure has 5 encoded assumptions
- Per Axiom Integrity Policy, structure-encoded assumptions must be counted
- Also fixed lineCount off-by-1 (21111 → 21110)

## Evidence
`NSAxioms` structure fields (Proofs/NavierStokes.lean:895-917):
1. Type II exponent bound (`typeII_gt_one`)
2. Spectral gap (`spectral_gap`)
3. Theta dynamics bound (`theta_bound`)
4. Blowup rate estimate (`blowup_rate`)
5. BKM criterion (`bkm`)

## Test plan
- [x] Verified structure fields in Lean source
- [x] `wc -l proofs/Proofs/NavierStokes.lean` = 21110
- [x] Prose `assumptions` field was already correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)