### PR TITLE
Fix: borsuk-ulam-oq-03 axiomCount 2 → 1

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -27,7 +27,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "assumptions": "1 axiom declaration: borsuk_ulam_general (Borsuk-Ulam theorem for n>=1, INDEPENDENT). Three former axioms (no_retraction, brouwer_fixed_point, lusternik_schnirelmann) are REDUNDANT — proved from BU. Two former axioms (ham_sandwich_general, odd_map_odd_degree) converted to theorems.",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Corrects `meta.axiomCount` from 2 to 1 for borsuk-ulam-oq-03. Only `borsuk_ulam_general` remains as an axiom declaration; the former axioms (`no_retraction`, `brouwer_fixed_point`, `lusternik_schnirelmann`) were proved redundant and removed.

## Evidence

**Before**: `meta.axiomCount: 2` (incorrect — only 1 axiom declaration in Lean file)
**After**: `meta.axiomCount: 1` (matches `leanFile.axiomCount` and `assumptions` text)

---
Automated fix by lean-mechanic agent.