### PR TITLE
Fix: NS OQ entries stale assumptions text and lineCount

### DIFF
--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,8 +60,8 @@
       "Theorem total_dissipation_bound: ∫₀ᵀ 2νP(t) dt ≤ E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21111,
-    "assumptions": "None. Formalized with 0 axioms and 23 sorries.",
+    "lineCount": 21110,
+    "assumptions": "None. Formalized with 0 axioms and 0 sorries.",
     "relatedProblems": [
       {
         "id": "navier-stokes",
@@ -181,7 +181,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 1009,
     "definitionCount": 104

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -59,8 +59,8 @@
       "Theorem continuous_dependence_2d: for any ε > 0, threshold δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
-    "lineCount": 21111,
-    "assumptions": "None. Formalized with 0 axioms and 23 sorries.",
+    "lineCount": 21110,
+    "assumptions": "None. Formalized with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -116,7 +116,7 @@
       "id": "continuous-dependence",
       "title": "Continuous Dependence on Initial Data",
       "startLine": 2864,
-      "endLine": 21111,
+      "endLine": 21110,
       "summary": "continuous_dependence_2d: for any ε > 0, δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε on (0,T). Together with uniqueness, establishes Hadamard well-posedness."
     }
   ],
@@ -211,7 +211,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 1009,
     "definitionCount": 104


### PR DESCRIPTION
## Summary
- `navier-stokes-oq-01` and `navier-stokes-oq-02` assumptions text said "23 sorries" but actual sorry count is 0
- The "23" came from comment mentions ("no sorry, no axiom") in NavierStokes.lean, not actual code sorries
- Also fixed lineCount off-by-1 (21111 → 21110) in meta and leanFile sections

## Test plan
- [x] Verified 0 actual `sorry` tactics in NavierStokes.lean
- [x] `wc -l proofs/Proofs/NavierStokes.lean` = 21110
- [x] `sorries` numeric field already correct at 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)