### PR TITLE
Gallery audit cycle 12: audit 8 proofs, fix 3 issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -831,15 +831,15 @@
       "issues": []
     },
     "navier-stokes-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:02:23Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "navier-stokes-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:02:23Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "roth-theorem-k3": {
@@ -861,20 +861,20 @@
       "issues": []
     },
     "yang-mills-2d": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:02:48Z",
       "result": "clean",
       "issues": []
     },
     "yang-mills-lattice": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:02:48Z",
       "result": "clean",
       "issues": []
     },
     "yang-mills-transfer-matrix": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:02:48Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary
- Audited 8 gallery proofs in this cycle
- Found and fixed 3 issues via separate PRs
- Identified automated scanner false positives (comment mentions of "sorry")

## Proofs Audited
| Proof | Result | Details |
|-------|--------|---------|
| pythagorean-triples | Clean | True stubs are documentation markers, not claims |
| riemann-hypothesis | Clean | "sorry" only in comments ("no sorry, no axiom") |
| roth-theorem-k3 | Fixed | leanFile.lineCount 1577→1596 (#6076) |
| schauder-fixed-point | Clean | "sorry" only in comments |
| navier-stokes-existence | Fixed | axiomCount 0→5 (NSAxioms structure), lineCount (#6078) |
| navier-stokes-oq-01 | Fixed | assumptions text "23 sorries" → "0 sorries" (#6081) |
| navier-stokes-oq-02 | Fixed | Same as oq-01 (#6081) |
| yang-mills-* (3 entries) | Clean | 58 code sorries correct, 1 comment mention |

## Test plan
- [x] All fixes verified against Lean source files
- [x] Tracker updated with audit results

🤖 Generated with [Claude Code](https://claude.com/claude-code)