### PR TITLE
Enrich 9 entries: complete relatedProofs coverage

### DIFF
--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -95,7 +95,9 @@
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Nat"],
+    "opens": [
+      "Nat"
+    ],
     "namespace": "Erdos1095OQ01",
     "lineCount": 148,
     "axiomCount": 4,
@@ -109,5 +111,21 @@
       "description": "Open question derived from Erdős #1095 on g(k)"
     }
   ],
-  "relatedProofs": []
+  "relatedProofs": [
+    {
+      "id": "erdos-1095",
+      "title": "Erdős Problem #1095: The Erdős-Selfridge Function",
+      "relationship": "parent problem — this is an open question about the growth rate of g(k)"
+    },
+    {
+      "id": "kummer-theorem",
+      "title": "Kummer's Theorem on Binomial Coefficients",
+      "relationship": "foundational — Kummer's theorem characterizes p-adic valuations of C(n,k)"
+    },
+    {
+      "id": "binomial-theorem",
+      "title": "The Binomial Theorem",
+      "relationship": "background — provides the algebraic framework for binomial coefficients"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -165,5 +165,27 @@
       "relationship": "related",
       "description": "The Abel–Ruffini theorem connects to group theory through the non-solvability of the symmetric group S₅. The distinction between solvable and non-solvable groups is relevant to Pantelidakis's approach, which exploits solvability of odd-order groups."
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "sylow-theorems",
+      "title": "Sylow's Theorems",
+      "relationship": "foundation — Sylow theorems provide the structural decomposition underpinning group enumeration"
+    },
+    {
+      "id": "lagrange-theorem",
+      "title": "Lagrange's Theorem",
+      "relationship": "foundation — subgroup order divides group order, basic ingredient in group enumeration"
+    },
+    {
+      "id": "inverse-galois",
+      "title": "The Inverse Galois Problem",
+      "relationship": "related — both concern the structure and diversity of finite groups"
+    },
+    {
+      "id": "abel-ruffini",
+      "title": "Abel-Ruffini Theorem",
+      "relationship": "related — the solvable/non-solvable distinction is relevant to Pantelidakis's approach"
+    }
   ]
 }

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -101,7 +101,9 @@
   },
   "references": [
     {
-      "authors": ["Bálint Tóth"],
+      "authors": [
+        "Bálint Tóth"
+      ],
       "title": "No more than three favourite sites for simple random walk",
       "journal": "Annals of Probability",
       "volume": "29",
@@ -111,13 +113,21 @@
       "note": "Proves P(|F(n)| = r i.o.) = 0 for r ≥ 4 in the 2D random walk, establishing the upper bound of 3 favourite sites."
     },
     {
-      "authors": ["Zhonghao Hao", "Yifan Li", "Ryo Okada", "Chen Zheng"],
+      "authors": [
+        "Zhonghao Hao",
+        "Yifan Li",
+        "Ryo Okada",
+        "Chen Zheng"
+      ],
       "title": "Three favourite sites occurs infinitely often for one-dimensional simple random walk",
       "year": 2024,
       "note": "Proves P(|F(n)| = 3 i.o.) = 1, matching Tóth's upper bound and completely resolving Erdős Problem #1165."
     },
     {
-      "authors": ["Richard F. Bass", "Philip S. Griffin"],
+      "authors": [
+        "Richard F. Bass",
+        "Philip S. Griffin"
+      ],
       "title": "The most visited site of Brownian motion and simple random walk",
       "journal": "Zeitschrift für Wahrscheinlichkeitstheorie und verwandte Gebiete",
       "volume": "70",
@@ -132,12 +142,26 @@
       "Mathlib.Data.Int.Basic",
       "Mathlib.Data.Finset.Card"
     ],
-    "opens": ["MeasureTheory"],
+    "opens": [
+      "MeasureTheory"
+    ],
     "namespace": "Erdos1165",
     "lineCount": 175,
     "axiomCount": 8,
     "theoremCount": 5,
     "definitionCount": 2,
     "sorryCount": 0
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "central-limit-theorem",
+      "title": "Central Limit Theorem",
+      "relationship": "background — CLT gives the Gaussian scaling of the 2D walk"
+    },
+    {
+      "id": "erdos-1144",
+      "title": "Erdős Problem #1144: Partial Sums of Random Multiplicative Functions",
+      "relationship": "sibling Erdős problem involving probabilistic analysis"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-176/meta.json
+++ b/src/data/proofs/erdos-176/meta.json
@@ -214,5 +214,22 @@
       "relationship": "Szemerédi's theorem on APs in dense sets is a fundamental companion result; the discrepancy problem #176 asks about ±1 balance on APs rather than AP existence",
       "targetId": "szemeredi-theorem"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-177",
+      "title": "Erdős Problem #177",
+      "relationship": "sibling — both concern discrepancy and arithmetic structure"
+    },
+    {
+      "id": "erdos-178",
+      "title": "Erdős Problem #178: Balancing Infinite Collections",
+      "relationship": "sibling — both study discrepancy-type balancing problems"
+    },
+    {
+      "id": "szemeredi-theorem",
+      "title": "Szemerédi's Theorem",
+      "relationship": "foundation — guarantees arithmetic progressions whose discrepancy is studied here"
+    }
   ]
 }

--- a/src/data/proofs/erdos-178/meta.json
+++ b/src/data/proofs/erdos-178/meta.json
@@ -219,5 +219,22 @@
       "relationship": "Both concern discrepancy in combinatorial structures — #162 studies graph colorings while #178 studies sequence balancing",
       "targetId": "erdos-162"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-176",
+      "title": "Erdős Problem #176: Discrepancy of Arithmetic Progressions",
+      "relationship": "sibling — both study discrepancy-type balancing problems"
+    },
+    {
+      "id": "erdos-177",
+      "title": "Erdős Problem #177",
+      "relationship": "sibling — related discrepancy problem"
+    },
+    {
+      "id": "erdos-162",
+      "title": "Erdős Problem #162",
+      "relationship": "related — both concern infinite sequences with combinatorial constraints"
+    }
   ]
 }

--- a/src/data/proofs/erdos-180/meta.json
+++ b/src/data/proofs/erdos-180/meta.json
@@ -195,5 +195,22 @@
       "relationship": "Both concern extremal properties of graph families — Tuza's conjecture relates triangle covering to packing, while #180 asks about Turán number domination",
       "targetId": "erdos-167"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-182",
+      "title": "Erdős Problem #182: Maximum Edges Avoiding k-Regular Subgraphs",
+      "relationship": "sibling — both concern extremal graph theory and subgraph density"
+    },
+    {
+      "id": "szemeredi-regularity",
+      "title": "Szemerédi Regularity Lemma",
+      "relationship": "technique — the regularity lemma is a key tool in extremal graph theory"
+    },
+    {
+      "id": "erdos-167",
+      "title": "Erdős Problem #167",
+      "relationship": "related extremal graph theory problem"
+    }
   ]
 }

--- a/src/data/proofs/erdos-182/meta.json
+++ b/src/data/proofs/erdos-182/meta.json
@@ -205,5 +205,22 @@
       "relationship": "The regularity lemma is a standard tool in extremal graph theory; the iterative argument in Janzer-Sudakov's resolution uses regularity-type structural decompositions",
       "targetId": "szemeredi-regularity"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-180",
+      "title": "Erdős Problem #180: Turán Numbers for Graph Families",
+      "relationship": "sibling — both study extremal graph theory and forbidden subgraph density"
+    },
+    {
+      "id": "erdos-181",
+      "title": "Erdős Problem #181",
+      "relationship": "sibling — related extremal graph problem"
+    },
+    {
+      "id": "szemeredi-regularity",
+      "title": "Szemerédi Regularity Lemma",
+      "relationship": "technique — central to extremal graph theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -189,5 +189,22 @@
       "relationship": "Ramsey's theorem guarantees the finiteness of R(3;k); the multicolor generalization of Ramsey's theorem is the starting point for #183",
       "targetId": "ramseys-theorem"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-165",
+      "title": "Erdős Problem #165",
+      "relationship": "related — both concern Ramsey-type problems"
+    },
+    {
+      "id": "erdos-166",
+      "title": "Erdős Problem #166",
+      "relationship": "related — both concern Ramsey numbers and graph coloring"
+    },
+    {
+      "id": "ramseys-theorem",
+      "title": "Ramsey's Theorem",
+      "relationship": "foundation — the classical result that multicolor triangle Ramsey numbers generalize"
+    }
   ]
 }

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -161,5 +161,17 @@
       "venue": "Rocky Mountain Journal of Mathematics, vol. 29, pp. 1387–1411",
       "note": "Extended the Erdős-Graham framework to study factorial products within specific integer sequences, providing structural results on the distribution of Dₖ"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "infinitude-primes",
+      "title": "Infinitude of Prime Numbers",
+      "relationship": "foundation — prime factorization structure determines when factorial products are perfect squares"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "title": "Fundamental Theorem of Arithmetic",
+      "relationship": "foundation — unique prime factorization is the key tool for analyzing factorial products"
+    }
   ]
 }


### PR DESCRIPTION
Complete relatedProofs coverage for all remaining entries without cross-references.

- **erdos-1095-oq-01**: erdos-1095, kummer-theorem, binomial-theorem
- **erdos-1160**: sylow-theorems, lagrange-theorem, inverse-galois, abel-ruffini
- **erdos-1165**: central-limit-theorem, erdos-1144
- **erdos-176**: erdos-177, erdos-178, szemeredi-theorem
- **erdos-178**: erdos-176, erdos-177, erdos-162
- **erdos-180**: erdos-182, szemeredi-regularity, erdos-167
- **erdos-182**: erdos-180, erdos-181, szemeredi-regularity
- **erdos-183**: erdos-165, erdos-166, ramseys-theorem
- **erdos-374**: infinitude-primes, fundamental-arithmetic

After this PR, all 1529 gallery entries will have relatedProofs populated.