### PR TITLE
Fix: navier-stokes axiomCount 0 → 5, lineCount 21111 → 21110

### DIFF
--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -54,8 +54,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 Lean axiom declarations, but the 3D regularity theorem is conditional on the NSAxioms structure (5 fields encoding physical hypotheses: Type II exponent, spectral gap, theta dynamics, blowup rate, and BKM criterion). These structure fields are mathematically equivalent to axiom declarations -- the assumptions were reorganized, not eliminated. The 2D global existence theorem (Ladyzhenskaya 1969) is genuinely unconditional. The Millennium Prize problem remains unsolved.",
+    "axiomCount": 5,
+    "assumptions": "5 structure-encoded assumptions in NSAxioms (Type II exponent, spectral gap, theta dynamics, blowup rate, BKM criterion). 0 Lean axiom declarations, but the 3D regularity theorem is conditional on the NSAxioms structure (5 fields encoding physical hypotheses: Type II exponent, spectral gap, theta dynamics, blowup rate, and BKM criterion). These structure fields are mathematically equivalent to axiom declarations -- the assumptions were reorganized, not eliminated. The 2D global existence theorem (Ladyzhenskaya 1969) is genuinely unconditional. The Millennium Prize problem remains unsolved.",
     "mathlibDependencies": [
       {
         "theorem": "Real",
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21111
+    "lineCount": 21110
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",
@@ -362,9 +362,9 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21111,
+    "lineCount": 21110,
     "structureCount": 249,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "theoremCount": 832,
     "lemmaCount": 14,
     "defCount": 101,


### PR DESCRIPTION
## Summary
- Same issue as #6078 (navier-stokes-existence): `axiomCount` was 0 but `NSAxioms` has 5 structure-encoded assumptions
- Also fixed lineCount off-by-1 (21111 → 21110)
- This is the parent `navier-stokes` entry (separate meta.json from the `-existence` variant)

## Test plan
- [x] Verified NSAxioms structure fields in Lean source (lines 895-917)
- [x] `wc -l proofs/Proofs/NavierStokes.lean` = 21110

🤖 Generated with [Claude Code](https://claude.com/claude-code)