### PR TITLE
Gallery audit cycle 13: audit 5 proofs, fix 1 axiomCount

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -783,20 +783,20 @@
       "issues": []
     },
     "erdos-809": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:16:42Z",
       "result": "clean",
       "issues": []
     },
     "erdos-938": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:16:42Z",
       "result": "clean",
       "issues": []
     },
     "fundamental-theorem-calculus-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:16:42Z",
       "result": "clean",
       "issues": []
     },
@@ -807,8 +807,8 @@
       "issues": []
     },
     "hodge-conjecture": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:16:42Z",
       "result": "clean",
       "issues": []
     },
@@ -819,9 +819,9 @@
       "issues": []
     },
     "navier-stokes": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:16:42Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "navier-stokes-existence": {


### PR DESCRIPTION
## Summary
- Audited 5 gallery proofs
- Fixed navier-stokes axiomCount 0→5 (#6093)
- All other scanner-flagged sorry mismatches were false positives (block comment mentions)

## Proofs Audited
| Proof | Result | Details |
|-------|--------|---------|
| navier-stokes | Fixed | axiomCount 0→5, lineCount 21111→21110 (#6093) |
| hodge-conjecture | Clean | 0 code sorries (1 block comment mention) |
| fundamental-theorem-calculus-oq-01 | Clean | 1 code sorry matches claim |
| erdos-938 | Clean | 0 code sorries (1 block comment mention) |
| erdos-809 | Clean | 0 code sorries (1 block comment mention) |

## Scanner Issue
The automated sorry scanner counts mentions inside `/- ... -/` block comments.
All flagged "sorry mismatches" this cycle were from documentation comments
like "no sorry, no axiom" — not actual code sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)