### PR TITLE
Fix: upgrade 12 proofs from formalized to verified status

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Archimedes (c. 250 BCE), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Archimedes",
     "date": "-250",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "geometry",
       "analysis",

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cycle_lemma",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,7 +18,7 @@
       "finset",
       "research"
     ],
-    "badge": "formalized",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid; formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euclid%27s_lemma",
     "date": "~300 BCE",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
     "tags": [
       "number-theory",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(linear_algebra)#Computation",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
     "tags": [
       "linear-algebra",
@@ -18,7 +18,7 @@
       "computational-complexity",
       "research"
     ],
-    "badge": "formalized",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,7 +17,7 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "formalized",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lévy (1934), Khintchine (1937); formalized 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%C3%A9vy%E2%80%93Khintchine_representation",
     "date": "1937",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
     "tags": [
       "probability",
@@ -19,7 +19,7 @@
       "gaussian",
       "stable-distributions"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
     "badge": "mathlib",
     "sorries": 0,

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "coloring",
       "research"
     ],
-    "badge": "formalized",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -7,7 +7,7 @@
     "author": "Vapnik-Chervonenkis (1971), Valiant (1984), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
     "date": "1984",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/PACLearning.lean",
     "tags": [
       "learning-theory",
@@ -16,7 +16,7 @@
       "cs-math-bridge",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdos, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1960",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ProbMethodAlteration.lean",
     "tags": [
       "probabilistic-method",
@@ -15,7 +15,7 @@
       "graph-theory",
       "intermediate"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos and collaborators, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1947",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ProbMethodApplications.lean",
     "tags": [
       "probabilistic-method",
@@ -16,7 +16,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -15,7 +15,7 @@
       "convex-analysis",
       "open-question"
     ],
-    "badge": "formalized",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

12 gallery proofs had `"status": "formalized"` but actually have 0 sorries and 0 axioms, meeting the criteria for `"verified"` status. Updated status and badge fields.

## Evidence

**Before**: All 12 proofs had `"status": "formalized"` (implies sorries remain)
**After**: All 12 proofs have `"status": "verified"` (0 sorries, 0 axioms confirmed)

### Proofs upgraded

| Proof | Badge Change |
|-------|-------------|
| area-of-circle-oq-03-oq-02 | mathlib (kept) |
| ballot-problem-oq-01-oq-01 | formalized → verified |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | original (kept) |
| cayley-hamilton-minpoly-oq-03 | formalized → verified |
| cayley-hamilton-minpoly-oq-05-oq-01 | formalized → verified |
| central-limit-theorem-oq-01-oq-02 | wip → verified |
| derangements-oq-02 | mathlib (kept) |
| erdos-1006-oq-02-oq-03 | formalized → verified |
| pac-learning-bounds | wip → verified |
| prob-method-alteration | wip → verified |
| prob-method-applications | wip → verified |
| schauder-fixed-point-oq-01 | formalized → verified |

### Verification method

Each proof's Lean source was checked for sorry occurrences (excluding comments/block comments), axiom declarations, and structure-encoded assumptions. All 12 confirmed to have 0 sorries and 0 axioms.

`pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.