### PR TITLE
Enrich erdos-28, erdos-1095-oq-01: fix sections, add annotations

### DIFF
--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -31,68 +31,84 @@
   },
   "sections": [
     {
-      "id": "header-imports",
+      "id": "header",
       "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 29,
-      "summary": "Module docstring stating the conjecture and its $500 bounty, followed by Mathlib imports for additive combinatorics (`SumConv`), Finset operations, filter convergence (`atTop`, `Tendsto`), and real analysis (`Real.log`, `Real.sqrt`). Opens `Filter` and `Set` namespaces with `Pointwise` scoping for $A + A$ notation.",
-      "mathContext": "Imports: `SumConv` for Minkowski sum $A + A$, `Filter.atTop` for $\\lim_{N \\to \\infty}$, `Pointwise` for set addition notation."
+      "endLine": 44,
+      "summary": "Module docstring stating the conjecture and its $500 bounty, Mathlib imports, namespace opens."
     },
     {
-      "id": "core-definitions",
-      "title": "Core Definitions",
-      "startLine": 31,
-      "endLine": 45,
-      "summary": "Three foundational definitions: the **representation function** $r_A(n) = |\\{(a,b) : a+b=n, a \\leq b, a,b \\in A\\}|$, the **asymptotic basis** condition $(A+A)^c$ finite, and the **counting function** $A(N) = |A \\cap [1,N]|$. These encode the core objects of the Erdős–Turán conjecture in Lean 4.",
-      "mathContext": "$r_A(n) = |\\{(a,b) : a+b=n,\\, a \\leq b,\\, a,b \\in A\\}|$; $A$ basis iff $(A+A)^c$ finite; $A(N) = |A \\cap [1,N]|$."
+      "id": "representation-function",
+      "title": "Part I: Representation Function",
+      "startLine": 45,
+      "endLine": 60,
+      "summary": "Ordered and unordered representation functions: r_A(n) counts pairs (a,b) in A×A with a+b=n.",
+      "mathContext": "$r_A(n) = |\\{(a,b) \\in A^2 : a+b=n\\}|$, $r_A^{\\leq}(n) = |\\{(a,b) : a+b=n, a \\leq b\\}|$."
+    },
+    {
+      "id": "sumset-basis",
+      "title": "Part II: Sumset and Asymptotic Basis",
+      "startLine": 61,
+      "endLine": 108,
+      "summary": "Sumset definition, Sidon set predicate (IsSidon), asymptotic basis of order 2 (IsAsymptoticBasis), and finiteness lemmas."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Part III: Basic Properties",
+      "startLine": 109,
+      "endLine": 200,
+      "summary": "Proved lemmas: Sidon representation bound (r_A(n) ≤ 2), exact computation of r_ℕ(n), and helper lemmas."
     },
     {
       "id": "main-conjecture",
-      "title": "The Main Conjecture",
-      "startLine": 47,
-      "endLine": 56,
-      "summary": "The Erdős–Turán conjecture (1941): $\\forall B, \\exists n: r_A(n) \\geq B$ whenever $A$ is an asymptotic basis of order 2. Stated as an axiom since the problem remains **OPEN** with a \\$500 bounty. Equivalent to $\\limsup r_A(n) = \\infty$.",
-      "mathContext": "$\\text{IsAsymptoticBasis2}(A) \\Rightarrow \\limsup_{n \\to \\infty} r_A(n) = \\infty$. Axiom: open conjecture with \\$500 bounty."
-    },
-    {
-      "id": "stronger-forms",
-      "title": "Stronger Forms of the Conjecture",
-      "startLine": 58,
-      "endLine": 70,
-      "summary": "Two strengthenings: (1) the **logarithmic form** $\\limsup r_A(n)/\\log n > 0$, motivated by probabilistic heuristics showing $\\mathbb{E}[r_A(n)] \\sim \\log n$ for random sets of density $\\sqrt{N}$; (2) the **density version** replacing the basis hypothesis with $A(N) \\geq c\\sqrt{N}$, which is strictly weaker than being a basis.",
-      "mathContext": "Strong form: $\\limsup r_A(n)/\\log n > 0$. Density version: $A(N) \\geq c\\sqrt{N} \\Rightarrow \\limsup r_A(n) = \\infty$."
-    },
-    {
-      "id": "counting-bounds",
-      "title": "Counting Lower Bounds",
-      "startLine": 72,
-      "endLine": 77,
-      "summary": "Necessary density condition: any basis of order 2 has $A(N) \\gg \\sqrt{N}$ by a pigeonhole/counting argument. Since $|A+A| \\leq \\binom{A(N)+1}{2}$ and $A+A$ must cover $\\sim N$ integers, we get $A(N) \\geq \\sqrt{2N} - 1$.",
-      "mathContext": "$N \\leq \\binom{A(N)+1}{2} \\Rightarrow A(N) \\geq \\sqrt{2N} - 1$. Tight for Sidon sets."
-    },
-    {
-      "id": "sidon-sets",
-      "title": "Sidon Sets and Extremal Case",
-      "startLine": 79,
-      "endLine": 84,
-      "summary": "Sidon sets ($B_2$ sets) have $r_A(n) \\leq 1$, making them too sparse ($A(N) \\leq \\sqrt{N} + O(N^{1/4})$) to be bases. This confirms the conjecture vacuously for the extremal case $r \\leq 1$.",
-      "mathContext": "Sidon: $r_A(n) \\leq 1 \\Rightarrow A(N) \\leq \\sqrt{N} + O(N^{1/4})$, too sparse for basis."
-    },
-    {
-      "id": "problem-40-connection",
-      "title": "Connection to Problem #40",
-      "startLine": 86,
-      "endLine": 93,
-      "summary": "Problem #40 generalizes the Sidon observation: can any $B_2[g]$ set (with $r_A(n) \\leq g$) be a basis? The Erdős–Turán conjecture implies the answer is **no** for every finite $g$. This formalizes the implication #28 $\\Rightarrow$ #40.",
-      "mathContext": "#28 $\\Rightarrow$ #40: $\\limsup r_A(n) = \\infty$ implies no $B_2[g]$ set can be a basis for any finite $g$."
+      "title": "Part IV: The Main Conjecture",
+      "startLine": 201,
+      "endLine": 224,
+      "summary": "Weak form (limsup r_A(n) = ∞) and strong form (limsup r_A(n)/log n > 0), plus the official Problem #28 definition.",
+      "mathContext": "Weak: $\\forall k,\\; \\exists n: r_A(n) > k$. Strong: $\\exists c > 0,\\; \\forall M,\\; \\exists n > M: r_A(n) > c \\log n$."
     },
     {
       "id": "partial-results",
-      "title": "Partial Results: Erdős–Fuchs and Averages",
-      "startLine": 95,
-      "endLine": 112,
-      "summary": "Two key partial results: (1) the **Erdős–Fuchs theorem** (1956) showing $\\sum_{n \\leq N} r_A(n) \\neq cN + o(N^{1/4}/\\sqrt{\\log N})$ — representations must oscillate, but this doesn't imply individual unboundedness; (2) **Halberstam–Roth** showing the average $\\frac{1}{N}\\sum r_A(n) \\to \\infty$, which also falls short of proving the conjecture.",
-      "mathContext": "Erdős–Fuchs: $\\sum_{n \\leq N} r_A(n) - cN = \\Omega(N^{1/4}/\\sqrt{\\log N})$. Halberstam–Roth: $\\frac{1}{N}\\sum r_A(n) \\to \\infty$."
+      "title": "Part V: Known Partial Results",
+      "startLine": 225,
+      "endLine": 234,
+      "summary": "Grekos et al. (2003): r_A(n) ≥ 6 i.o. Borwein et al.: r_A(n) ≥ 8 i.o."
+    },
+    {
+      "id": "examples",
+      "title": "Part VI: Examples",
+      "startLine": 235,
+      "endLine": 347,
+      "summary": "ℕ as a basis, computation of r_ℕ(n) = n/2+1 or (n+1)/2, Finset-to-Set conversion lemmas."
+    },
+    {
+      "id": "sidon-connection",
+      "title": "Part VII: Connection to Sidon Sets",
+      "startLine": 348,
+      "endLine": 412,
+      "summary": "Sidon density bound and proof outline for why infinite Sidon sets cannot be asymptotic bases."
+    },
+    {
+      "id": "ordered-vs-unordered",
+      "title": "Part VIII: Ordered vs Unordered Representations",
+      "startLine": 413,
+      "endLine": 425,
+      "summary": "Proved: r_A(n) ≥ r_A^≤(n) since unordered pairs are a subset of ordered pairs."
+    },
+    {
+      "id": "conjecture-for-nat",
+      "title": "Part IX: Conjecture Holds for ℕ",
+      "startLine": 426,
+      "endLine": 446,
+      "summary": "Proved: the Erdős-Turán conjecture holds trivially for A = ℕ, since r_ℕ(2k+2) = k+2 > k."
+    },
+    {
+      "id": "basis-density",
+      "title": "Part X: Basis Density Lower Bound",
+      "startLine": 447,
+      "endLine": 497,
+      "summary": "Proved: any basis A satisfies |A ∩ [0,N]|² ≥ N - N₀ + 1, giving |A ∩ [0,N]| ≥ c√N.",
+      "mathContext": "$|A \\cap [0,N]|^2 \\geq N - N_0 + 1$ via $[N_0,N] \\subseteq A+A$ and $|A+A| \\leq |A|^2$."
     }
   ],
   "overview": {


### PR DESCRIPTION
## erdos-28 (Erdős-Turán Conjecture on Additive Bases)
- **Major fix**: sections referenced wrong file (Erdos28Problem.lean, 117 lines) instead of actual proof file (Erdos28AdditiveBases.lean, 497 lines)
- Replaced 8 stale sections with 11 sections covering all 10 parts of the actual Lean file
- Section coverage improved from 21% to ~95%

## erdos-1095-oq-01 (Asymptotics of g(k))
- Added 5th keyInsight on negation witness technique
- Added 2 annotations: not_allPrimesExceed_of_prime_dvd, choose_eq_zero_of_lt
- Fixed lineCount 148 → 154