### PR TITLE
Fix: erdos-1063 axiomCount 5 → 3

### DIFF
--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -51,9 +51,9 @@
       "ErdosProblem1063 definition of polynomial growth question",
       "erdos_1063_summary theorem combining key results"
     ],
-    "axiomCount": 5,
+    "axiomCount": 3,
     "lineCount": 169,
-    "assumptions": "7 axioms: erdos_selfridge_nondivisibility, threshold_k2, threshold_k3, and 4 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated."
   },
   "overview": {
     "historicalContext": "**Erdős-Selfridge and Binomial Divisibility**\n\nErdős Problem #1063 originates from a 1983 paper by Paul Erdős and John Selfridge on the arithmetic structure of binomial coefficients. They observed that the $k$ consecutive integers $n, n-1, \\ldots, n-k+1$ appearing in the numerator of $\\binom{n}{k} = \\frac{n(n-1)\\cdots(n-k+1)}{k!}$ have a subtle divisibility relationship with $\\binom{n}{k}$ itself. Their key result: for $n \\geq 2k$, it is impossible for ALL $k$ of these integers to divide $\\binom{n}{k}$ — the prime factorization of $k!$ cannot simultaneously cancel every factor.\n\n**The threshold question**: The natural follow-up asks for the least $n_k \\geq 2k$ where all but one of these $k$ integers divide $\\binom{n}{k}$. Computed values are $n_2 = 4$ (since $3 \\mid \\binom{4}{2} = 6$ but $4 \\nmid 6$), $n_3 = 6$, $n_4 = 9$, $n_5 = 12$.\n\n**Monier's bound (1985)**: Louis Monier proved $n_k \\leq k!$ by showing that $n = k!$ satisfies the all-but-one condition — the highly composite structure of $k!$ ensures most nearby factors divide $\\binom{k!}{k}$. This was the first non-trivial result but grows super-exponentially.\n\n**Cambie's improvement**: Stijn Cambie dramatically improved the bound to $n_k \\leq k \\cdot \\text{lcm}(2, \\ldots, k-1)$, which by the prime number theorem ($\\log \\text{lcm}(1, \\ldots, m) = \\psi(m) \\sim m$) gives $n_k \\leq e^{(1+o(1))k}$. The gap between $n_k \\geq 2k$ (trivial) and $n_k \\leq e^{(1+o(1))k}$ remains vast — whether $n_k$ grows polynomially or exponentially is the central open question.",
@@ -238,7 +238,7 @@
     "opens": [],
     "namespace": "Erdos1063",
     "lineCount": 159,
-    "axiomCount": 7,
+    "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 5
   }


### PR DESCRIPTION
## Fix

Updates `axiomCount` from 5 to 3 in erdos-1063 meta.json. Research PR #6061 eliminated threshold axioms but meta wasn't updated.

## Evidence

**Before**: `meta.axiomCount: 5`, `leanFile.axiomCount: 7`
**After**: Both set to `3` (matching actual: `erdos_selfridge_nondivisibility`, `monier_factorial_bound`, `cambie_lcm_bound`)

---
Automated fix by lean-mechanic agent.