### PR TITLE
Enrich 2 entries: abel-ruffini fixes, erdos-490-oq-01 depth

### DIFF
--- a/src/data/proofs/erdos-490-oq-01/annotations.json
+++ b/src/data/proofs/erdos-490-oq-01/annotations.json
@@ -202,5 +202,23 @@
       "Bolzano-Weierstrass theorem",
       "convergence vs oscillation"
     ]
+  },
+  {
+    "id": "ann-summary-checks",
+    "proofId": "erdos-490-oq-01",
+    "range": { "startLine": 203, "endLine": 215 },
+    "type": "context",
+    "title": "Summary: Nine Theorems from Three Axioms",
+    "content": "The `#check` block lists all nine theorems proved in the development, providing an at-a-glance inventory of the formalization's output:\n\n- `maxProd_is_upper` / `maxProd_is_achieved`: interface theorems for the axiomatized maximum\n- `productRatio_bounded_above` / `productRatio_bounded_below`: the core sandwich bounds\n- `limit_in_sandwich`: the main analytical result (limit constrained to $[c, C]$)\n- `productRatio_nonneg`: nonnegativity of the ratio\n- `card_le_of_subset_upto`: cardinality bound $|A| \\leq N$\n- `maxProd_le_sq`: trivial bound $\\operatorname{maxProd}(N) \\leq N^2$\n- `productRatio_sandwich`: capstone combining all bounds\n\nThis `#check` pattern is a Lean convention for summarizing a module's public API, making it easy for other files to discover available lemmas.",
+    "mathContext": "Nine theorems from three axioms: two interface lemmas (upper bound, achievability), two sandwich bounds ($c \\leq r(N) \\leq C$), one limit theorem ($L \\in [c, C]$), and four structural results (nonnegativity, cardinality, trivial bound, full sandwich).",
+    "significance": "supporting",
+    "prerequisites": [
+      "Lean #check command"
+    ],
+    "relatedConcepts": [
+      "module API",
+      "theorem inventory",
+      "Lean conventions"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-490-oq-01/meta.json
+++ b/src/data/proofs/erdos-490-oq-01/meta.json
@@ -141,12 +141,22 @@
     {
       "targetId": "harmonic-divergence",
       "relationship": "related",
-      "description": "The divergence of ∑ 1/p underlies the log N factor in Szemerédi's bound on distinct product pairs"
+      "description": "The divergence of $\\sum 1/p$ underlies the $\\log N$ factor in Szemerédi's bound on distinct product pairs"
     },
     {
       "targetId": "erdos-262",
       "relationship": "related",
-      "description": "Erdős #262 on Sidon sets (distinct pairwise sums) is the additive analogue of the distinct products condition"
+      "description": "Erdős #262 on Sidon sets (distinct pairwise sums) is the additive analogue of the distinct products condition — both ask how large a set can be while maintaining injectivity of a binary operation on pairs"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The prime number theorem $\\pi(N) \\sim N/\\log N$ provides the asymptotic count of primes in $(N/2, N]$ that makes the optimal lower bound construction work — without PNT, the lower bound $c \\cdot N^2/\\log N$ could not be established"
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "foundational",
+      "description": "Bertrand's postulate guarantees at least one prime in $(N/2, N]$ for all $N > 1$, ensuring the lower bound construction is non-vacuous. The prime number theorem strengthens this to $\\sim N/(2\\log N)$ primes in the interval"
     }
   ],
   "references": [
@@ -180,9 +190,35 @@
     }
   ],
   "relatedProofs": [
-    "erdos-490",
-    "infinitude-primes",
-    "harmonic-divergence",
-    "erdos-262"
+    {
+      "id": "erdos-490",
+      "relationship": "parent",
+      "description": "Parent problem — this OQ investigates whether the normalized maximum product size has a limit"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The prime construction for the lower bound uses primes in (N/2, N]"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The divergence of ∑ 1/p underlies the log N factor in Szemerédi's bound"
+    },
+    {
+      "id": "erdos-262",
+      "relationship": "related",
+      "description": "Sidon sets (distinct pairwise sums) are the additive analogue of the distinct products condition"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "PNT provides the asymptotic prime count that establishes the lower bound construction"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "foundational",
+      "description": "Guarantees primes in (N/2, N], ensuring the lower bound construction is non-vacuous"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
**abel-ruffini** (pass 3):
- Fixed 5 truncated `relatedProofs` descriptions
- Added nth-root-irrational cross-reference to both `crossReferences` and `relatedProofs`
- Added solution-of-cubic and fundamental-theorem-algebra to `relatedProofs`

**erdos-490-oq-01** (pass 1):
- Added annotation for summary `#check` block (lines 203-215)
- Added `prime-number-theorem` and `bertrands-postulate` to crossReferences
- Upgraded `relatedProofs` from string array to object format with descriptions