### PR TITLE
Fix: erdos-1007-oq-01 status axiomatized → verified

### DIFF
--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/1007",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1007OQ01.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "extension",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

erdos-1007-oq-01 had `"status": "axiomatized"` with `"badge": "axiom"`, but the proof has 0 sorries, 0 axiom declarations, and 0 structure-encoded assumptions. Its own assumptions field already says "0 axioms. Fully verified." — former axioms were replaced with concrete proofs.

## Evidence

**Before**: status=axiomatized, badge=axiom
**After**: status=verified, badge=verified

Verified: `grep -c "^axiom " proofs/Proofs/Erdos1007OQ01.lean` → 0, sorry count → 0.

`pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.