### PR TITLE
Fix: lineCount and axiomCount metadata in 3 gallery entries

### DIFF
--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -247,11 +247,11 @@
     }
   ],
   "leanFile": {
-    "lineCount": 143,
+    "lineCount": 159,
     "namespace": null,
     "opens": [],
     "structureCount": 0,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 8,
     "lemmaCount": 0,
     "defCount": 1,

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -54,7 +54,7 @@
     ],
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: erdos_1065a (Set.Infinite for primes of the form 2^k·q + 1), erdos_1065b (Set.Infinite for primes of the form 2^k·3^l·q + 1). Both encode the open conjectures themselves.",
-    "lineCount": 162,
+    "lineCount": 301,
     "relatedProblems": [
       {
         "id": "erdos-1057",

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1095",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
-    "lineCount": 148,
+    "lineCount": 154,
     "assumptions": "4 axiom(s): gFunc definition and its 3 properties (existence, specification, minimality). 0 sorries."
   },
   "overview": {
@@ -99,7 +99,7 @@
       "Nat"
     ],
     "namespace": "Erdos1095OQ01",
-    "lineCount": 148,
+    "lineCount": 154,
     "axiomCount": 4,
     "theoremCount": 10,
     "definitionCount": 2


### PR DESCRIPTION
Fixes metadata discrepancies found by comparing `wc -l` and `grep -c '^axiom '` against meta.json values.

**erdos-1095-oq-01** (Asymptotics of g(k)):
- lineCount 148→154 (both `meta.lineCount` and `leanFile.lineCount`)

**erdos-1059** (Primes Minus Factorials):
- `leanFile.axiomCount` 3→2 (`factorial_count_bound` is a proved theorem, not an axiom)
- `leanFile.lineCount` 143→159

**erdos-1065** (Primes of Form 2^k·q+1):
- `meta.lineCount` 162→301 (file was expanded with 14 examples, non-examples, strict inclusions)