### PR TITLE
Add Aristotle companion file for Erdős #1034

### DIFF
--- a/proofs/Proofs/Erdos1034Aristotle.lean
+++ b/proofs/Proofs/Erdos1034Aristotle.lean
@@ -1,0 +1,85 @@
+/-
+  Aristotle targets for Erdős Problem #1034
+  Routine supporting lemmas for automated proof search.
+  See Erdos1034Problem.lean for the main formalization.
+
+  Note: The main file has Aristotle parser issues with the Triangle structure.
+  This companion file uses self-contained definitions to avoid those issues.
+
+  Criteria for inclusion:
+  - NOT the main Ma-Tang counterexample or deep extremal results
+  - Basic graph/finset properties provable from Mathlib
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos1034Aristotle
+
+open Finset SimpleGraph
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Section 1: Triangle Basics
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Three distinct vertices. -/
+structure TripleDistinct (V : Type*) where
+  v1 : V
+  v2 : V
+  v3 : V
+  distinct12 : v1 ≠ v2
+  distinct23 : v2 ≠ v3
+  distinct13 : v1 ≠ v3
+
+/-- The finset of vertices of a triple. -/
+def TripleDistinct.toFinset (T : TripleDistinct V) : Finset V :=
+  {T.v1, T.v2, T.v3}
+
+/-- A triple of distinct elements has cardinality 3. -/
+theorem triple_card (T : TripleDistinct V) : T.toFinset.card = 3 := by sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Section 2: Adjacency Counting
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Count how many elements of a finset S are adjacent to y. -/
+def adjCount (G : SimpleGraph V) [DecidableRel G.Adj] (S : Finset V) (y : V) : ℕ :=
+  (S.filter (fun v => G.Adj y v)).card
+
+/-- If y is adjacent to all elements of S, adjCount = |S|. -/
+theorem adjCount_eq_card_of_all_adj (G : SimpleGraph V) [DecidableRel G.Adj]
+    (S : Finset V) (y : V)
+    (h : ∀ v ∈ S, G.Adj y v) : adjCount G S y = S.card := by sorry
+
+/-- adjCount is at most |S|. -/
+theorem adjCount_le_card (G : SimpleGraph V) [DecidableRel G.Adj]
+    (S : Finset V) (y : V) : adjCount G S y ≤ S.card := by sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Section 3: Numerical Constants
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The Ma-Tang constant: 2 - √(5/2). -/
+noncomputable def maTangConstant : ℝ := 2 - Real.sqrt (5/2)
+
+/-- The K₄-free constant: 2√3 - 3. -/
+noncomputable def k4FreeConstant : ℝ := 2 * Real.sqrt 3 - 3
+
+/-- Ma-Tang constant is positive. -/
+theorem maTangConstant_pos : maTangConstant > 0 := by sorry
+
+/-- K₄-free constant is positive. -/
+theorem k4FreeConstant_pos : k4FreeConstant > 0 := by sorry
+
+/-- K₄-free bound is worse (higher) than general bound. -/
+theorem k4free_gt_maTang : k4FreeConstant > maTangConstant := by sorry
+
+/-- Both constants are less than 1/2. -/
+theorem maTangConstant_lt_half : maTangConstant < 1/2 := by sorry
+
+/-- The gap between 1/6 and the Ma-Tang constant. -/
+theorem gap_bounds : maTangConstant - 1/6 > 1/4 ∧ maTangConstant - 1/6 < 3/10 := by sorry
+
+end Erdos1034Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #1034 (Triangle Neighbors in Dense Graphs). The main file had Aristotle parser issues with the `Triangle` structure, so this companion uses clean self-contained definitions.

## Evidence

**Before**: No companion file; Aristotle previously failed to load the main file due to type inference issues with `Triangle G`
**After**: Self-contained companion file with 8 provable lemmas:
- `triple_card`: finset of 3 distinct elements has card 3
- `adjCount_eq_card_of_all_adj`, `adjCount_le_card`: adjacency counting bounds
- `maTangConstant_pos`, `k4FreeConstant_pos`: positivity via nlinarith/sqrt bounds
- `k4free_gt_maTang`: ordering of constants (nlinarith)
- `maTangConstant_lt_half`: numerical comparison
- `gap_bounds`: bounds on 2 - √(5/2) - 1/6

Pre-submission checklist verified:
- No definition sorries
- No axiom declarations
- No True placeholders
- No `/-!` docstrings

---
Automated fix by lean-mechanic agent.