### PR TITLE
Enrich: sync relatedProofs with crossReferences across gallery

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -383,6 +383,51 @@
       "id": "lagrange-theorem",
       "relationship": "foundational",
       "description": "Lagrange's theorem on subgroup orders is used throughout: |Aₙ| = n!/2, and the derived series quotients have predictable orders"
+    },
+    {
+      "id": "sylow-theorems",
+      "relationship": "related",
+      "description": "Sylow theorems provide structural information about A₅: its Sylow subgroups witness the 60 = 4·3·5 factorization and hel"
+    },
+    {
+      "id": "solution-of-cubic",
+      "relationship": "complementary",
+      "description": "Cardano's formula (1545) gives explicit radical solutions for cubics — the highest odd degree where a general radical fo"
+    },
+    {
+      "id": "general-quartic",
+      "relationship": "complementary",
+      "description": "Ferrari's quartic formula (1540) is the highest-degree general radical solution. S₄ is solvable (derived series {e} ◁ V₄"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Gauss's quadratic reciprocity (1801) concerns the multiplicative structure of (ℤ/pℤ)*, foreshadowing the group-theoretic"
+    },
+    {
+      "id": "vietas-formulas",
+      "relationship": "foundational",
+      "description": "Vieta's formulas are the fundamental Sₙ-invariant polynomials. The Abel-Ruffini theorem can be restated as: the elementa"
+    },
+    {
+      "id": "puiseux-theorem",
+      "relationship": "complementary",
+      "description": "Puiseux series always solve polynomial equations, contrasting with Abel-Ruffini: radicals cannot solve the generic quint"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "foundational",
+      "description": "Primitive roots of unity are essential to Kummer theory, which underlies Step 4 (the Galois bridge): each radical extrac"
+    },
+    {
+      "id": "kummer-theorem",
+      "relationship": "foundational",
+      "description": "Kummer theory provides the mechanism for Step 4: radical extensions are towers of Kummer (cyclic) extensions, so their G"
+    },
+    {
+      "id": "hilbert-13",
+      "relationship": "related",
+      "description": "Hilbert's 13th problem (1900) asked whether degree-7 polynomial roots require genuinely trivariate functions. Abel-Ruffi"
     }
   ]
 }

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -362,6 +362,126 @@
       "id": "angle-trisection",
       "relationship": "related",
       "description": "Both are impossibility results proved via Galois theory: Abel-Ruffini shows quintics are unsolvable by radicals, angle trisection shows the general angle cannot be trisected by compass and straightedge"
+    },
+    {
+      "id": "abel-ruffini-oq-04",
+      "relationship": "extended-by",
+      "description": "OQ-04 exposes the internal proof chain from A₅ simplicity to Abel-Ruffini as individually named theorems with pedagogica"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "Lagrange's theorem on subgroup orders underpins the group-theoretic machinery: the derived series, composition factors, "
+    },
+    {
+      "id": "puiseux-theorem",
+      "relationship": "complementary",
+      "description": "Puiseux's theorem shows the field of fractional power series (Puiseux series) is algebraically closed — polynomial roots"
+    },
+    {
+      "id": "vietas-formulas",
+      "relationship": "foundational",
+      "description": "Vieta's formulas express polynomial coefficients as elementary symmetric functions of roots — this is precisely why the "
+    },
+    {
+      "id": "solution-of-cubic",
+      "relationship": "complementary",
+      "description": "Cardano's cubic formula (1545) is the degree-3 case where radicals succeed — Abel-Ruffini proves this pattern breaks at "
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "complementary",
+      "description": "FTA guarantees every polynomial has roots in C. Abel-Ruffini shows those roots cannot always be expressed by radicals — "
+    },
+    {
+      "id": "kroneckers-jugendtraum",
+      "relationship": "extends",
+      "description": "Kronecker-Weber (every abelian extension of Q is contained in a cyclotomic field) is the positive counterpart to Abel-Ru"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "Hermite's proof that $e$ is transcendental (1873) sits one level above Abel-Ruffini in the expressibility hierarchy: Abe"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "foundational",
+      "description": "Primitive roots and cyclotomic extensions supply the abelian Galois groups $(\\mathbb{Z}/n\\mathbb{Z})^{\\times}$ that form"
+    },
+    {
+      "id": "kummer-theorem",
+      "relationship": "foundational",
+      "description": "Kummer theory provides the mechanism underlying the Galois bridge (galois_bridge): each radical extraction creates a Kum"
+    },
+    {
+      "id": "hilbert-13",
+      "relationship": "extended-by",
+      "description": "Hilbert's 13th problem (1900) was directly motivated by Abel-Ruffini: since polynomials of degree $\\geq 5$ cannot be sol"
+    },
+    {
+      "id": "hilbert-10",
+      "relationship": "related",
+      "description": "Matiyasevich's negative resolution of Hilbert's 10th problem (MRDP theorem, 1970) extends the impossibility paradigm ina"
+    },
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Both are landmark impossibility/nonexistence results in algebra: Abel-Ruffini proves no radical formula exists for gener"
+    },
+    {
+      "id": "hermite-lindemann",
+      "relationship": "related",
+      "description": "Sits one level above Abel-Ruffini in the expressibility hierarchy: Abel-Ruffini shows certain algebraic numbers escape r"
+    },
+    {
+      "id": "gelfond-schneider",
+      "relationship": "related",
+      "description": "Extends the transcendence hierarchy beyond Hermite-Lindemann: Gelfond-Schneider proves $\\alpha^\\beta$ is transcendental "
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "foundational",
+      "description": "The irrationality of $\\sqrt{2}$ ($\\sqrt{2} \\notin \\mathbb{Q}$, c. 500 BCE) is the first level of the expressibility hier"
+    },
+    {
+      "id": "godel-incompleteness",
+      "relationship": "related",
+      "description": "Abel-Ruffini (1824) and Gödel's incompleteness (1931) are both impossibility results showing that natural questions ('fi"
+    },
+    {
+      "id": "halting-problem",
+      "relationship": "related",
+      "description": "Turing's halting problem (1936) extends the impossibility paradigm to computation: no algorithm can decide whether an ar"
+    },
+    {
+      "id": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "Cantor's diagonal argument (1891) is the set-theoretic impossibility result that bridges Abel-Ruffini and Gödel in the i"
+    },
+    {
+      "id": "descartes-rule-of-signs",
+      "relationship": "related",
+      "description": "Descartes' rule bounds the number of positive real roots of a polynomial by the number of sign changes in its coefficien"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "Lindemann's proof that $\\pi$ is transcendental (1882) resolved the ancient problem of squaring the circle and sits one l"
+    },
+    {
+      "id": "liouville-theorem",
+      "relationship": "related",
+      "description": "Liouville's construction of the first explicit transcendental numbers (1844) via rational approximation bounds ($|\\alpha"
+    },
+    {
+      "id": "lagrange-theorem-oq-03",
+      "relationship": "related",
+      "description": "Hall's theorem (1928) is the partial converse of Lagrange's theorem for solvable groups: every Hall divisor of a solvabl"
+    },
+    {
+      "id": "angle-trisection-oq-02",
+      "relationship": "related",
+      "description": "The Wantzel-Galois theorem — an algebraic number $\\alpha$ is constructible by compass and straightedge iff $\\text{Gal}(\\"
     }
   ],
   "references": [

--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -295,6 +295,41 @@
       "id": "triangle-inequality",
       "relationship": "related",
       "description": "Both are fundamental inequalities formalized from first principles — the triangle inequality controls absolute sums while Maclaurin's chain controls symmetric polynomial means"
+    },
+    {
+      "id": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Power sums p_k = ∑ xᵢᵏ are related to elementary symmetric polynomials via Newton's identities (Newton-Girard formulas):"
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "FTA guarantees that elementary symmetric polynomials e_k(x₁,...,xₙ) equal the coefficients (up to sign) of ∏(t - xᵢ) — t"
+    },
+    {
+      "id": "amgm-inequality-oq-03-oq-02",
+      "relationship": "complementary",
+      "description": "Power mean limit: lim_{r→0} M_r = GM shows the geometric mean as a continuous limit of power means M_r = (∑ wᵢxᵢʳ)^{1/r}"
+    },
+    {
+      "id": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The integral Cauchy-Schwarz inequality (∫fg)² ≤ (∫f²)(∫g²) is the continuous analog of the finite Cauchy-Schwarz sum n·∑"
+    },
+    {
+      "id": "amgm-inequality-oq-03-oq-01",
+      "relationship": "complementary",
+      "description": "Negative power mean monotonicity M_r ≤ M_s for r ≤ s < 0 completes the power mean picture: OQ-02 studies Maclaurin means"
+    },
+    {
+      "id": "vietas-formulas",
+      "relationship": "foundational",
+      "description": "Vieta's formulas $e_k(x_1,\\ldots,x_n) = (-1)^k a_{n-k}/a_n$ express elementary symmetric polynomials as polynomial coeff"
+    },
+    {
+      "id": "inclusion-exclusion",
+      "relationship": "related",
+      "description": "The powersetCard decomposition in elemSymm (summing over all $k$-element subsets) is a combinatorial cousin of inclusion"
     }
   ],
   "references": [

--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -229,6 +229,31 @@
       "id": "cauchy-schwarz",
       "relationship": "related",
       "description": "Both are fundamental inequalities in analysis; Cauchy-Schwarz can be derived from the r=2 power mean"
+    },
+    {
+      "id": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The Bunyakovsky-Schwarz integral inequality is the continuous/L² analog of the discrete M₁ ≤ M₂ power mean inequality"
+    },
+    {
+      "id": "triangle-inequality",
+      "relationship": "related",
+      "description": "For p ≥ 1, power mean monotonicity M₁ ≤ M_p implies Minkowski's inequality (the L^p triangle inequality), connecting the"
+    },
+    {
+      "id": "shannon-entropy",
+      "relationship": "related",
+      "description": "Shannon entropy H(X) = -∑ pᵢ log pᵢ is the α→1 limit of Rényi entropy H_α = (1/(1-α))·log ∑ pᵢ^α. Since H_α ∝ log M_{α-1"
+    },
+    {
+      "id": "mean-value-theorem",
+      "relationship": "related",
+      "description": "The mean value theorem underpins the r→0 limit case: proving lim_{r→0} M_r = GM requires L'Hôpital's rule (which depends"
+    },
+    {
+      "id": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Power sums p_k = ∑ xᵢ^k are the unnormalized building blocks of power means: M_k = (p_k/n)^(1/k) for equal weights. The "
     }
   ],
   "references": [

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -146,7 +146,7 @@
   ],
   "overview": {
     "historicalContext": "The power mean $M_r(z,w) = (\\sum w_i z_i^r)^{1/r}$ is undefined at $r = 0$, but the limit exists and equals the geometric mean $\\text{GM} = \\prod z_i^{w_i}$. This was established by Hardy, Littlewood, and Pólya (*Inequalities*, 1934, §2.9) and makes the power mean a continuous interpolation between min ($r \\to -\\infty$), HM ($r=-1$), GM ($r=0$), AM ($r=1$), and max ($r \\to +\\infty$).\n\nThe result has deep connections to information theory. The expression $\\sum w_i \\log z_i$ appearing in the limit is exactly the negative of the Kullback-Leibler divergence $D_{KL}(w \\| \\text{uniform})$ applied to $\\log z$, and more broadly, the Rényi entropy $H_\\alpha = \\frac{1}{1-\\alpha}\\log\\sum p_i^\\alpha$ (Rényi, 1961) satisfies $\\lim_{\\alpha \\to 1} H_\\alpha = H_1 = -\\sum p_i \\log p_i$ (Shannon entropy) by the same derivative-at-zero technique used here. The power mean limit is thus a special case of the Rényi-to-Shannon entropy limit.\n\nIn 1930, Kolmogorov and Nagumo independently proved that the power mean family is (essentially) the unique class of quasi-arithmetic means satisfying continuity, strict monotonicity, and homogeneity. The r→0 limit is the continuity condition at the singular point that makes the power mean a smooth one-parameter interpolation. Without it, the family would have a gap at r=0, and the Kolmogorov-Nagumo characterization would not hold.\n\nThe proof uses the definition of derivative: $f(r) = \\log(\\sum w_i z_i^r)$ satisfies $f(0) = 0$ and $f'(0) = \\sum w_i \\log z_i$. Therefore $f(r)/r \\to f'(0)$ by the definition of derivative, and $M_r = \\exp(f(r)/r) \\to \\exp(\\sum w_i \\log z_i) = \\text{GM}$ by continuity of exp. The Lean 4 formalization uses `hasDerivAt_iff_tendsto_slope` as the key bridge, avoiding explicit L'Hôpital machinery.",
-    "problemStatement": "**Open Question (amgm-inequality-oq-03-oq-02)**: Formalize the limit lim_{r→0} M_r(z,w) = GM(z,w) in Lean 4.\n\n**Definitions**:\n- M_r(z,w) = (∑ wᵢzᵢ^r)^(1/r)  for r ≠ 0, wᵢ ≥ 0, ∑ wᵢ = 1, zᵢ > 0\n- GM(z,w) = ∏ zᵢ^wᵢ (weighted geometric mean)\n\n**The Limit**: Filter.Tendsto (fun r => (∑ wᵢzᵢ^r)^(1/r)) (nhdsWithin 0 {0}ᶜ) (nhds (∏ zᵢ^wᵢ))\n\n**Proof sketch**: f(r) = log(∑ wᵢzᵢ^r), f(0) = 0, f'(0) = ∑ wᵢ log zᵢ, so M_r = exp(f(r)/r) → exp(∑ wᵢ log zᵢ) = GM.",
+    "problemStatement": "**Power Mean Limit Theorem**: For weights $w_i \\geq 0$ with $\\sum w_i = 1$ and positive values $z_i > 0$:\n$$\\lim_{r \\to 0} M_r(\\mathbf{z}, \\mathbf{w}) = \\lim_{r \\to 0} \\left(\\sum_i w_i z_i^r\\right)^{1/r} = \\prod_i z_i^{w_i} = \\text{GM}(\\mathbf{z}, \\mathbf{w})$$\n\n**Proof via derivative**: Let $f(r) = \\log(\\sum_i w_i z_i^r)$. Then $f(0) = 0$, $f'(0) = \\sum_i w_i \\log z_i$, so $M_r = \\exp(f(r)/r) \\to \\exp(f'(0)) = \\exp(\\sum_i w_i \\log z_i) = \\text{GM}$.",
     "text": "This formalization resolves the singularity of the weighted power mean $M_r = (\\sum w_i z_i^r)^{1/r}$ at $r = 0$ by proving $\\lim_{r \\to 0} M_r = \\prod z_i^{w_i} = \\text{GM}$. The proof is a clean 5-step chain through Mathlib's calculus API: (1) establish $\\sum w_i z_i^r > 0$ for the domain; (2) differentiate under the sum to get $f'(0) = \\sum w_i \\log z_i$; (3) compose with $\\log$ via the chain rule; (4) convert the derivative to a slope limit via `hasDerivAt_iff_tendsto_slope`; (5) pass through $\\exp$ by continuity. The key Lean insight is that `hasDerivAt_iff_tendsto_slope` directly gives $f(r)/r \\to f'(0)$ when $f(0) = 0$, avoiding explicit L'Hôpital machinery. As a corollary, the file also proves $\\text{HM} \\leq \\text{GM} \\leq \\text{AM}$ via an inversion trick (apply AM-GM to $z^{-1}$). All 10 theorems are fully verified with 0 sorries.",
     "proofStrategy": "**Step 1**: Establish M_r = exp((1/r)·log(∑ wᵢzᵢ^r)) for zᵢ > 0 via Real.rpow_def_of_pos.\n\n**Step 2**: Prove d/dr[∑ wᵢzᵢ^r]|_{r=0} = ∑ wᵢ log zᵢ:\n- Each term: HasDerivAt (fun r => zᵢ^r) (log zᵢ) 0 via Real.hasStrictDerivAt_const_rpow + rpow_zero\n- Apply HasDerivAt.const_mul and HasDerivAt.sum\n\n**Step 3**: Establish g(r) = log(∑ wᵢzᵢ^r) has g(0) = 0 and g'(0) = ∑ wᵢ log zᵢ:\n- Chain rule: Real.hasDerivAt_log composed with step 2\n- g(0) = log(1) = 0 since ∑ wᵢzᵢ^0 = ∑ wᵢ = 1\n\n**Step 4**: Conclude g(r)/r → g'(0) via hasDerivAt_iff_tendsto_slope (congr on slope formula).\n\n**Step 5**: Apply Real.continuous_exp.continuousAt to get M_r = exp(g(r)/r) → exp(∑ wᵢ log zᵢ) = GM.",
     "keyInsights": [
@@ -263,27 +263,62 @@
     {
       "id": "amgm-inequality-oq-03",
       "relationship": "extends",
-      "description": "Parent file containing power mean definitions and positive/negative monotonicity — this file establishes the r=0 limit completing the continuous chain"
+      "description": "Parent file with power mean definitions and monotonicity — this limit completes the continuous chain"
     },
     {
       "id": "amgm-inequality-oq-03-oq-01",
       "relationship": "related",
-      "description": "Negative power mean monotonicity — together with this limit, only the mixed-sign crossing (r < 0 < s) remains"
+      "description": "Negative power mean monotonicity — together with this limit, only the mixed-sign crossing remains"
     },
     {
       "id": "amgm-inequality",
       "relationship": "related",
-      "description": "AM-GM is the coarsest case M₁ ≥ M₀: the limit here shows M₀ = GM, giving AM ≥ GM"
+      "description": "AM-GM is the M₁ ≥ M₀ case; this limit shows M₀ = GM, giving AM ≥ GM"
     },
     {
       "id": "amgm-inequality-oq-02",
       "relationship": "related",
-      "description": "Maclaurin's inequalities via elementary symmetric polynomials give an alternative chain between AM and GM — this limit result shows M₀ = GM, the same GM that Maclaurin's chain bounds from a different direction"
+      "description": "Maclaurin's inequalities give an alternative AM-GM chain via elementary symmetric polynomials"
     },
     {
       "id": "lhopital",
       "relationship": "related",
-      "description": "The limit uses the same derivative-based approach as L'Hopital's rule: f(r)/r → f'(0) when f(0) = 0, formalized via hasDerivAt_iff_tendsto_slope"
+      "description": "Uses the same derivative-based approach: f(r)/r → f'(0) when f(0) = 0"
+    },
+    {
+      "id": "shannon-entropy",
+      "relationship": "related",
+      "description": "GM = exp(∑ wᵢ log zᵢ) involves the same weighted log-sum as Shannon entropy; Rényi entropy generalizes both via power means"
+    },
+    {
+      "id": "mean-value-theorem",
+      "relationship": "foundational",
+      "description": "MVT underpins hasDerivAt_iff_tendsto_slope, the slope-to-derivative bridge central to this proof"
+    },
+    {
+      "id": "triangle-inequality",
+      "relationship": "related",
+      "description": "Power mean monotonicity (completed by this limit) implies Minkowski's inequality (L^p triangle inequality)"
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Cauchy-Schwarz is the M₁ ≤ M₂ case of power mean monotonicity"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "HM = M_{-1} uses reciprocal arithmetic; this limit bridges HM and AM via GM = M₀"
+    },
+    {
+      "id": "taylor-theorem",
+      "relationship": "foundational",
+      "description": "The f(r)/r → f'(0) technique is the first-order case of Taylor's theorem"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "FTC establishes the HasDerivAt API connecting derivatives to difference quotient limits"
     }
   ],
   "references": [

--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -241,6 +241,31 @@
       "id": "amgm-inequality-oq-03-oq-02",
       "relationship": "extended-by",
       "description": "Proves lim_{r→0} M_r = GM — the missing r=0 case that would bridge the positive and negative exponent monotonicity results"
+    },
+    {
+      "id": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The Bunyakovsky-Schwarz integral inequality is the continuous analog of the M₁ ≤ M₂ case: for equal weights, (∑wᵢzᵢ)² ≤ "
+    },
+    {
+      "id": "mean-value-theorem",
+      "relationship": "related",
+      "description": "MVT is foundational for proving the r=0 limit case: lim_{r→0} M_r = GM requires L'Hôpital's rule, which itself depends o"
+    },
+    {
+      "id": "triangle-inequality",
+      "relationship": "related",
+      "description": "For p ≥ 1, the power mean inequality M₁ ≤ M_p implies (via Minkowski) the L^p triangle inequality — connecting discrete "
+    },
+    {
+      "id": "shannon-entropy",
+      "relationship": "related",
+      "description": "Shannon entropy H(X) = -∑ pᵢ log pᵢ is the α→1 limit of Rényi entropy H_α = (1/(1-α))·log ∑ pᵢ^α, which is essentially l"
+    },
+    {
+      "id": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Power sums p_k = ∑ xᵢ^k are the unnormalized building blocks of power means: M_k = (∑ wᵢzᵢ^k)^(1/k) = (p_k/n)^(1/k) for "
     }
   ],
   "references": [

--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -174,6 +174,26 @@
       "id": "triangle-inequality",
       "relationship": "related",
       "description": "Both AM-GM and the triangle inequality are fundamental non-negativity results: AM-GM exploits $(\\sqrt{a}-\\sqrt{b})^2 \\geq 0$ while the triangle inequality exploits $|x+y| \\leq |x|+|y|$. Together they form the backbone of analytic estimation."
+    },
+    {
+      "id": "amgm-inequality-oq-02",
+      "relationship": "parent",
+      "description": "Sub-entry exploring extensions or open questions arising from the AM-GM inequality."
+    },
+    {
+      "id": "amgm-inequality-oq-03",
+      "relationship": "parent",
+      "description": "Sub-entry exploring further generalizations or applications of AM-GM."
+    },
+    {
+      "id": "amgm-inequality-oq-03-oq-01",
+      "relationship": "parent",
+      "description": "Proves negative-exponent power mean monotonicity $M_r \\leq M_s$ for $r \\leq s < 0$, extending the AM-GM chain to the ful"
+    },
+    {
+      "id": "amgm-inequality-oq-03-oq-02",
+      "relationship": "parent",
+      "description": "Proves $\\lim_{r \\to 0} M_r = \\text{GM}$: the geometric mean arises as the continuous limit of power means at $r=0$, comp"
     }
   ],
   "sections": [

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -257,6 +257,31 @@
       "id": "inverse-galois",
       "relationship": "related",
       "description": "Comprehensive Galois group realizations (S₃, A₅, D₄, etc.) — the inverse direction of the Galois correspondence. Where this file asks 'what constraints does the Galois group impose?', inverse Galois asks 'which groups arise as Galois groups?'"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both use Galois group structure to derive impossibility results: Abel-Ruffini shows non-solvable Galois groups block rad"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "The tower law [L:F] = [L:K]·[K:F] — the multiplicativity of field extension degrees, a consequence of Lagrange's theorem"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "complementary",
+      "description": "The irrationality of $\\sqrt{2}$ is the simplest instance of the constructibility framework: $\\text{Gal}(x^2 - 2/\\mathbb{"
+    },
+    {
+      "id": "nth-root-irrational",
+      "relationship": "related",
+      "description": "The irrationality of $\\sqrt[n]{m}$ for non-perfect-power $m$ produces a degree-$n$ extension $[\\mathbb{Q}(\\sqrt[n]{m}):\\"
+    },
+    {
+      "id": "factor-remainder-theorem",
+      "relationship": "foundational",
+      "description": "The factor theorem ($\\alpha$ is a root of $p(x)$ iff $(x - \\alpha) \\mid p(x)$) underpins the crucial step `minpoly.dvd`:"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
@@ -225,6 +225,26 @@
       "id": "inverse-galois",
       "relationship": "related",
       "description": "The cyclotomic Galois group Gal(Φₙ/ℚ) ≅ (ℤ/nℤ)* realizes concrete abelian groups — the simplest case of the inverse Galois problem, proved here via galCyclotomicEquivUnitsZMod"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "The roots of unity ζₙ = exp(2πi/n) involve π — this file uses cyclotomic properties of ζₙ, while π's transcendence (prov"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's totient function $\\phi(n) = |(\\mathbb{Z}/n\\mathbb{Z})^{\\times}|$ gives the degree $[\\mathbb{Q}(\\zeta_n):\\mathbb{"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "foundational",
+      "description": "Primitive roots modulo primes establish that $(\\mathbb{Z}/p\\mathbb{Z})^{\\times}$ is cyclic of order $p-1$. The cyclotomi"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "foundational",
+      "description": "Euler's identity $e^{i\\pi} + 1 = 0$ is the $n = 2$ case of $\\zeta_n = e^{2\\pi i/n}$. This file's proof that $\\zeta_n = \\"
     }
   ],
   "references": [

--- a/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
@@ -321,6 +321,41 @@
       "id": "abel-ruffini",
       "relationship": "related",
       "description": "Both link impossibility results to Galois group structure: Abel-Ruffini via solvability (S₅ not solvable), Gauss-Wantzel via 2-groups ((ℤ/nℤ)* not always a 2-group)"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Gauss's work on constructible polygons was intimately connected to his work on quadratic reciprocity — both appear in Di"
+    },
+    {
+      "id": "inverse-galois",
+      "relationship": "related",
+      "description": "The cyclotomic Galois groups Gal(Φₙ/ℚ) ≅ (ℤ/nℤ)* are concrete realizations of finite abelian groups — the abelian case o"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's totient function $\\varphi(n)$ is the central object: the Gauss-Wantzel theorem states that the regular $n$-gon i"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "foundational",
+      "description": "Primitive roots establish that $(\\mathbb{Z}/p\\mathbb{Z})^{\\times}$ is cyclic of order $p-1$. The Gauss-Wantzel proof use"
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "foundational",
+      "description": "De Moivre's formula expresses the $n$th roots of unity $\\zeta_n = e^{2\\pi i/n}$ that generate cyclotomic extensions. The"
+    },
+    {
+      "id": "kroneckers-jugendtraum",
+      "relationship": "extends",
+      "description": "Kronecker-Weber theorem: every abelian extension of $\\mathbb{Q}$ is contained in a cyclotomic field $\\mathbb{Q}(\\zeta_n)"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "The tower law $[L:F] = [L:K] \\cdot [K:F]$ (a consequence of Lagrange's theorem) drives the key computation: $[\\mathbb{Q}"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -284,27 +284,72 @@
     {
       "id": "angle-trisection",
       "relationship": "extends",
-      "description": "Parent file with the degree criterion (necessary condition) — this file upgrades it to a biconditional via Galois groups"
+      "description": "Parent file with the degree criterion — this file upgrades it to a biconditional via Galois groups"
     },
     {
       "id": "abel-ruffini",
       "relationship": "related",
-      "description": "Both use Galois groups to prove impossibility: Abel-Ruffini via solvable groups, constructibility via 2-groups"
+      "description": "Both use Galois groups for impossibility: Abel-Ruffini via solvable groups, constructibility via 2-groups"
     },
     {
       "id": "inverse-galois",
       "relationship": "related",
-      "description": "The Galois group realizations (S₃ for x³-2, D₄ for x⁴-2) are concrete instances of the inverse Galois problem"
+      "description": "S₃ and D₄ realizations are concrete instances of the inverse Galois problem"
     },
     {
       "id": "lagrange-theorem",
       "relationship": "foundational",
-      "description": "The tower law [K:ℚ] = ∏[Kᵢ₊₁:Kᵢ] — a consequence of Lagrange's theorem — underpins galois_2group_implies_degree_pow2: the minimal polynomial degree divides |Gal| = 2^k"
+      "description": "Tower law underpins galois_2group_implies_degree_pow2"
     },
     {
       "id": "sqrt2-irrational",
       "relationship": "complementary",
-      "description": "√2 is the canonical constructible irrational: |Gal(x²-2/ℚ)| = 2 = 2¹, proved here by divisibility squeeze. Its irrationality is the first step beyond ℚ in the constructible tower"
+      "description": "√2 is the canonical constructible irrational with |Gal(x²-2/ℚ)| = 2 = 2¹"
+    },
+    {
+      "id": "angle-trisection-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry extending the 2-group characterization with additional constructibility examples"
+    },
+    {
+      "id": "angle-trisection-oq-02-oq-03",
+      "relationship": "extended-by",
+      "description": "Connects to the Gauss-Wantzel theorem for regular polygon constructibility"
+    },
+    {
+      "id": "angle-trisection-oq-02-oq-03-oq-01",
+      "relationship": "extended-by",
+      "description": "Bridges Gauss-Wantzel to Mathlib's cyclotomic field infrastructure"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "foundational",
+      "description": "(ℤ/pℤ)× is cyclic of order p-1; regular p-gon constructible iff p-1 = 2^k (Fermat prime)"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "foundational",
+      "description": "φ(n) bridges number theory and constructibility: n-gon constructible iff φ(n) = 2^k"
+    },
+    {
+      "id": "nth-root-irrational",
+      "relationship": "foundational",
+      "description": "ⁿ√m constructible iff Gal(xⁿ-m/ℚ) is a 2-group: √m always, ∛m never"
+    },
+    {
+      "id": "solution-of-cubic",
+      "relationship": "complementary",
+      "description": "S₃ is solvable but not a 2-group: cos(20°) is solvable by radicals but not constructible"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "complementary",
+      "description": "Squaring the circle fails by transcendence, not the 2-group criterion — a different impossibility mechanism"
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "complementary",
+      "description": "FTA guarantees roots exist in ℂ; constructibility is about which geometric operations can produce them"
     }
   ],
   "references": [

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -276,6 +276,46 @@
       "id": "pi-transcendental",
       "relationship": "uses",
       "description": "This file directly imports the pi transcendence proof to establish that squaring the circle is impossible — Lindemann's "
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "The tower law for field extensions (a consequence of Lagrange's theorem on subgroup indices) underpins the degree divisi"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "Lindemann's proof that e is transcendental uses the same Lindemann-Weierstrass framework that proves π transcendental — "
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "complementary",
+      "description": "√2 IS constructible (as the diagonal of a unit square, a basic compass-and-straightedge construction) because its minima"
+    },
+    {
+      "id": "solution-of-cubic",
+      "relationship": "complementary",
+      "description": "Cardano's formula solves the general cubic by radicals — the trisection polynomial 8x³-6x-1 is a specific cubic whose ro"
+    },
+    {
+      "id": "angle-trisection-oq-02",
+      "relationship": "extended-by",
+      "description": "OQ-02 extends the degree argument to a complete Galois characterization: α is constructible iff Gal(minpoly(α)/ℚ) is a 2"
+    },
+    {
+      "id": "angle-trisection-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Proves the Wantzel-Galois characterization connecting Polynomial.Gal to constructibility — strengthening the degree crit"
+    },
+    {
+      "id": "nth-root-irrational",
+      "relationship": "foundational",
+      "description": "The irrationality of $\\sqrt[3]{2}$ (a special case of the $n$-th root irrationality) is the simplest instance of the deg"
+    },
+    {
+      "id": "angle-trisection-oq-02-oq-03",
+      "relationship": "extended-by",
+      "description": "Extends the constructibility framework to the Gauss-Wantzel theorem for regular polygons: the regular $n$-gon is constru"
     }
   ],
   "references": [

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -231,6 +231,11 @@
       "id": "stirling-formula",
       "relationship": "related",
       "description": "Stirling's approximation for Γ(n/2+1) determines the asymptotic behavior of ω_n → 0 as n → ∞, explaining the 'thin shell' phenomenon in high dimensions"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling entry on integration by parts for Fourier coefficients — both extend the circumference integration approach from"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
@@ -202,6 +202,21 @@
       "id": "fourier-series",
       "relationship": "specializes",
       "description": "The general Fourier series theory provides the foundation; this entry proves a specific derivative property of Fourier coefficients used in geometric applications."
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "supports",
+      "description": "This IBP formula is a key analytical ingredient in the Fourier-analytic proof of the isoperimetric inequality $C^2 \\geq "
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "Integration by parts is derived from the product rule and FTC — the IBP formula fourierCoeffOn_of_hasDerivAt used here i"
+    },
+    {
+      "id": "fundamental-theorem-calculus-oq-01",
+      "relationship": "related",
+      "description": "Integration by parts — the core technique in this proof — is a direct corollary of the product rule and FTC. The Fourier"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
@@ -182,6 +182,16 @@
       "id": "pi-transcendental",
       "relationship": "related",
       "description": "Both use Mathlib's π: the integral ∫₀ʳ 2πρ dρ = πr² involves the same transcendental constant whose properties are established in the π-transcendence formalization"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Generalizes the circumference-to-area integration from 2D circles to n-dimensional spheres: $V_n(r) = \\int_0^r S_n(\\rho)"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02-oq-02",
+      "relationship": "extended-by",
+      "description": "Integration by parts for Fourier coefficients of periodic functions — the same IBP technique used in the circumference i"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -221,6 +221,21 @@
       "id": "isoperimetric-theorem",
       "relationship": "extends",
       "description": "Wiedijk #43: the abstract version is in IsoperimetricTheorem.lean; this file provides the OQ-chain approach"
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "foundational",
+      "description": "Fourier decomposition and Parseval's identity underpin the spectral proof of the isoperimetric inequality"
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "uses",
+      "description": "2D Cauchy-Schwarz (xv-yu)² ≤ (x²+y²)(u²+v²) used in the arithmetic kernel of the proof"
+    },
+    {
+      "id": "borsuk-ulam",
+      "relationship": "thematic",
+      "description": "Both reveal geometric rigidity: isoperimetric characterizes the circle as area-optimal, Borsuk-Ulam constrains continuous sphere maps"
     }
   ],
   "references": [

--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -180,7 +180,17 @@
     {
       "id": "area-of-circle-oq-01",
       "relationship": "sibling",
-      "description": "Derives the circumference formula $C = 2\\pi r$ from the area formula by differentiation — the computational counterpart "
+      "description": "Derives the circumference formula $C = 2\\pi r$ from the area formula by differentiation"
+    },
+    {
+      "id": "basel-problem",
+      "relationship": "related",
+      "description": "Euler's ∑ 1/n² = π²/6 provides another exact formula involving π — Archimedes' bounds bracket the same constant"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "Hermite proved e transcendental (1873), paving the way for Lindemann's proof that π is transcendental (1882)"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -253,6 +253,66 @@
       "id": "basel-problem",
       "relationship": "related",
       "description": "Euler's Basel problem (∑1/n² = π²/6) provides another unexpected appearance of π — the same constant whose geometric meaning as the area-to-radius² ratio is formalized here. Euler's proof connecting ∑1/n² to sin(x)/x reveals π's dual role in geometry and analysis"
+    },
+    {
+      "id": "area-of-circle-oq-01",
+      "relationship": "extended-by",
+      "description": "Derives the circumference formula $C = 2\\pi r$ via differentiation of the area $A = \\pi r^2$ with respect to $r$ — the i"
+    },
+    {
+      "id": "area-of-circle-oq-03",
+      "relationship": "extended-by",
+      "description": "Formalizes Archimedes' method of exhaustion directly: approximating the circle's area by inscribed and circumscribed reg"
+    },
+    {
+      "id": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "The intermediate value theorem underpins the continuity arguments needed for integration. Archimedes' method of exhausti"
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "complementary",
+      "description": "The isoperimetric inequality states that among all planar curves of fixed perimeter $L$, the circle encloses the maximum"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Derives the area formula by integrating circumference: $A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$, showing the circle's a"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-03",
+      "relationship": "extended-by",
+      "description": "The isoperimetric inequality $C^2 \\geq 4\\pi A$ with equality iff the curve is a circle — the variational characterizatio"
+    },
+    {
+      "id": "area-of-circle-oq-03-oq-02",
+      "relationship": "extended-by",
+      "description": "Archimedes' bounds $223/71 < \\pi < 22/7$ via inscribed and circumscribed regular 96-gons — the computational complement "
+    },
+    {
+      "id": "lebesgue-measure",
+      "relationship": "foundational",
+      "description": "This proof formalizes area as Lebesgue measure $\\lambda^2$. The Lebesgue measure entry provides the measure-theoretic in"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "The annular ring derivation of $A = \\pi r^2$ is a direct application of the Fundamental Theorem of Calculus: $A(r) = \\in"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "The general $n$-dimensional ball volume $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ that underpins this proof uses the Gamm"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "The transcendence of $e$ connects to the circle area formula through the Gaussian integral: $\\int_{-\\infty}^{\\infty} e^{"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} = -1$ connects to the circle area formula through the complex plane: this formalization uses "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
@@ -178,6 +178,11 @@
       "id": "ballot-problem",
       "relationship": "related",
       "description": "The ballot problem counts monotone lattice paths — exactly the combinatorial objects that the parallel Vandermonde identity decomposes. The ballot problem's reflection argument and this file's Vandermonde convolution are complementary lattice path counting techniques"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The nested induction pattern (outer on $b$, inner on $n$) used in the parallel Vandermonde proof is a sophisticated inst"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/arithmetic-series-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02/meta.json
@@ -209,6 +209,11 @@
       "id": "arithmetic-series-oq-02-oq-02",
       "relationship": "extended-by",
       "description": "Sub-entry extending the simplicial number framework with additional results or applications"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The Hockey Stick Identity is proved by induction on n, using Pascal's recurrence C(n+1,k+1) = C(n,k) + C(n,k+1) as the inductive step"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -231,6 +231,36 @@
       "id": "sum-of-kth-powers",
       "relationship": "extended-by",
       "description": "Faulhaber's formulas generalize the arithmetic series from $\\sum k$ (degree 1) to $\\sum k^p$ for arbitrary $p$ — the arithmetic series formula $n(n+1)/2$ is the $p=1$ case of Faulhaber's general result"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "complementary",
+      "description": "The harmonic series $\\sum 1/k$ diverges while the arithmetic series $\\sum k$ grows quadratically — contrasting behaviors"
+    },
+    {
+      "id": "triangular-reciprocals",
+      "relationship": "related",
+      "description": "The reciprocals of triangular numbers $T_n = n(n+1)/2$ telescope to give $\\sum 1/T_n = 2(1 - 1/(n+1))$ — connecting the "
+    },
+    {
+      "id": "basel-problem",
+      "relationship": "related",
+      "description": "Euler's solution $\\sum 1/k^2 = \\pi^2/6$ extends the idea of summing natural number expressions from $\\sum k$ (polynomial"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The sum-of-odd-numbers identity $1+3+5+\\cdots+(2n-1) = n^2$ was known to the Pythagoreans as the gnomon construction — e"
+    },
+    {
+      "id": "perfect-numbers",
+      "relationship": "related",
+      "description": "Triangular numbers $T(n) = n(n+1)/2$ connect to perfect numbers via Euler's theorem: every even perfect number has the f"
+    },
+    {
+      "id": "arithmetic-series-oq-02-oq-02",
+      "relationship": "extended-by",
+      "description": "The 2D hockey stick identity generalizes the arithmetic series sum to two-dimensional lattice sums, extending the one-di"
     }
   ],
   "references": [

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -213,6 +213,11 @@
       "id": "erdos-szekeres",
       "relationship": "related",
       "description": "Both are combinatorial results on sequences: Erdős-Szekeres guarantees monotone subsequences, the generalized ballot problem counts sequences satisfying a dominance constraint"
+    },
+    {
+      "id": "ballot-problem-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Applies the Dvoretzky-Motzkin cycle lemma with a discrete intermediate value theorem to analyze ballot sequences — exten"
     }
   ],
   "references": [

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -259,6 +259,11 @@
       "id": "ballot-problem-oq-03-oq-02",
       "relationship": "extended-by",
       "description": "Extends the 2×2 LGV determinant to the general r×r case, computing determinants of path-count matrices for r non-crossing lattice paths — the full generalization of the reflection principle used in this file's 2D case"
+    },
+    {
+      "id": "ballot-problem-oq-02",
+      "relationship": "sibling",
+      "description": "Continuous-time ballot problem via Brownian motion — the stochastic complement to this file's discrete lattice path appr"
     }
   ],
   "references": [

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -246,6 +246,51 @@
       "id": "birthday-problem",
       "relationship": "related",
       "description": "Both are classic probability problems solved by counting arguments over finite sample spaces — the birthday problem counts collisions in random assignments, the ballot problem counts lattice paths staying positive"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "co-listed",
+      "description": "Both appear in Wiedijk's 100 Theorems list; infinitude of primes is #11, ballot problem is #30"
+    },
+    {
+      "id": "ballot-problem-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry extending the ballot problem with generalizations and additional analysis"
+    },
+    {
+      "id": "ballot-problem-oq-02",
+      "relationship": "extended-by",
+      "description": "Sub-entry exploring further connections of the ballot problem"
+    },
+    {
+      "id": "ballot-problem-oq-03",
+      "relationship": "extended-by",
+      "description": "Sub-entry with additional ballot problem variants and applications"
+    },
+    {
+      "id": "derangements",
+      "relationship": "related",
+      "description": "Both are classical combinatorics problems solved by bijective counting: the ballot problem uses the reflection principle"
+    },
+    {
+      "id": "inclusion-exclusion",
+      "relationship": "related",
+      "description": "Inclusion-exclusion is a complementary counting technique to the ballot problem's reflection principle — both reduce con"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The ballot problem concerns random walks with a bias (p > q votes), which in the limit connects to the central limit the"
+    },
+    {
+      "id": "ballot-problem-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Formalizes the Discrete Intermediate Value Theorem for the Dvoretzky-Motzkin cycle lemma — a deeper combinatorial tool t"
+    },
+    {
+      "id": "ballot-problem-oq-03-oq-02",
+      "relationship": "extended-by",
+      "description": "Extends ballot problem lattice path counting to the general $r \\times r$ Lindström-Gessel-Viennot determinant formula — "
     }
   ],
   "references": [

--- a/src/data/proofs/basel-problem-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01/meta.json
@@ -207,6 +207,16 @@
       "id": "harmonic-divergence",
       "relationship": "foundational",
       "description": "The harmonic series $\\sum 1/n$ diverges, while $\\zeta(2) = \\sum 1/n^2 = \\pi^2/6$ converges (Basel problem). The question of whether $\\zeta(5) = \\sum 1/n^5$ is irrational probes the arithmetic nature of these convergent sums — the divergence/convergence boundary at $s = 1$ is foundational, and the irrationality question asks about the deeper algebraic structure of the convergent values"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} + 1 = 0$ connects the constants $e$, $\\pi$, and $i$. The zeta values $\\zeta(2k) = (-1)^{k+1}("
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "Lindemann's theorem (π transcendental) is the key ingredient for even zeta transcendence (ζ(2k) = rational * π^(2k)); co"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -310,6 +310,66 @@
       "id": "prime-reciprocal-divergence",
       "relationship": "related",
       "description": "Euler proved ∑ 1/p diverges using the Euler product ζ(s) = ∏(1-p⁻ˢ)⁻¹ — the same zeta function framework. The divergence of ∑ 1/p contrasts with the convergence of ∑ 1/n² = π²/6, highlighting how prime density differs from integer density"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "Basel's answer ζ(2) = π²/6 involves the same transcendental π — Lindemann's transcendence proof (1882) implies that ζ(2)"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "related",
+      "description": "Euler's proof of the infinitude of primes uses the Euler product ζ(s) = ∏(1-p⁻ˢ)⁻¹ — the same zeta function whose value "
+    },
+    {
+      "id": "basel-problem-oq-01",
+      "relationship": "extended-by",
+      "description": "Explores the open question of whether $\\zeta(5)$ is irrational — extending the Basel problem's $\\zeta(2) = \\pi^2/6$ to o"
+    },
+    {
+      "id": "leibniz-pi",
+      "relationship": "complementary",
+      "description": "Leibniz's formula $\\pi/4 = 1 - 1/3 + 1/5 - 1/7 + \\cdots$ and Basel's $\\sum 1/n^2 = \\pi^2/6$ are both series evaluations "
+    },
+    {
+      "id": "geometric-series",
+      "relationship": "foundational",
+      "description": "The geometric series $\\sum r^n = 1/(1-r)$ for $|r| < 1$ is the simplest convergent series with closed form. The Basel se"
+    },
+    {
+      "id": "taylor-theorem",
+      "relationship": "technique",
+      "description": "Euler's original proof compares the Taylor expansion $\\sin(x)/x = 1 - x^2/6 + x^4/120 - \\cdots$ with the infinite produc"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "extends",
+      "description": "The Prime Number Theorem ($\\pi(x) \\sim x/\\ln x$) is proved by analyzing the Riemann zeta function $\\zeta(s)$ in the comp"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "The Bernoulli numbers that produce $\\zeta(2) = \\pi^2/6$ are defined by the exponential generating function $t/(e^t - 1) "
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\approx \\sqrt{2\\pi n}(n/e)^n$ is another instance where $\\pi$ emerges from a purely integer"
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "extends",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions (1837) uses Dirichlet $L$-functions $L(s, \\chi) = \\sum \\chi(n) "
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "related",
+      "description": "The area formula $A = \\pi r^2$ and the Basel identity $\\zeta(2) = \\pi^2/6$ both reveal $\\pi$ in seemingly unrelated cont"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The Central Limit Theorem's Gaussian density $\\frac{1}{\\sqrt{2\\pi}} e^{-x^2/2}$ contains $\\pi$ for the same deep reason "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bertrands-postulate-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/meta.json
@@ -219,6 +219,31 @@
       "id": "riemann-hypothesis",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "twin-primes-special",
+      "relationship": "related",
+      "description": "Both address fine-grained prime distribution: twin primes concern gaps of exactly 2 between consecutive primes, while th"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's totient $\\varphi(n) = n \\prod_{p|n}(1-1/p)$ encodes the local prime structure that determines prime density. The"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\approx \\sqrt{2\\pi n}(n/e)^n$ is needed for asymptotic estimates in prime counting: Chebysh"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Quadratic reciprocity governs the splitting behavior of primes in quadratic fields, connecting to the Chebotarev density"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "The divergence of $\\sum 1/p$ (over primes) establishes that primes are 'dense enough' that their reciprocals diverge. Th"
     }
   ],
   "references": [

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -201,6 +201,21 @@
       "id": "fundamental-arithmetic",
       "relationship": "foundational",
       "description": "Unique prime factorization underpins Erdős's proof: the prime factorization of C(2n,n) is analyzed to show large primes "
+    },
+    {
+      "id": "bertrands-postulate-oq-03",
+      "relationship": "extended-by",
+      "description": "Explores the precise density of primes in short intervals — refining Bertrand's guarantee of at least one prime in $(n, "
+    },
+    {
+      "id": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "RH implies the strongest form of the prime gap bound: $p_{n+1} - p_n = O(\\sqrt{p_n} \\log p_n)$, far stronger than Bertra"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "Both quantify prime density: Bertrand's postulate gives a local guarantee ($\\exists$ prime in $(n, 2n]$), while $\\sum 1/"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -178,6 +178,11 @@
       "id": "bezout-identity-oq-02-oq-01",
       "relationship": "related",
       "description": "The Fundamental Theorem of Arithmetic from Euclid's lemma — a key application of the divisibility result made computable here"
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "related",
+      "description": "The Chinese Remainder Theorem uses similar coprimality and Bézout coefficient techniques"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
@@ -279,6 +279,41 @@
       "id": "chinese-remainder-constructive",
       "relationship": "related",
       "description": "Both use the extended Euclidean algorithm constructively: CRT for simultaneous congruences, this for explicit quotient extraction"
+    },
+    {
+      "id": "gcd-algorithm",
+      "relationship": "related",
+      "description": "Standard Euclidean algorithm for GCD computation. This entry implements the extended version that additionally returns B"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "Unique prime factorization relies on Euclid's lemma (if p | ab and p prime, then p | a or p | b) — the constructive vers"
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "complementary",
+      "description": "Extends CRT to non-coprime moduli, where Bézout's identity gives $\\gcd(m,n) = um + vn$ rather than $1 = um + vn$. The ex"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Child entry that resolves the first open question: removes the noncomputable annotation from constructive_div by replaci"
+    },
+    {
+      "id": "bezout-identity-oq-04",
+      "relationship": "sibling",
+      "description": "Complete parametric solution set of linear Diophantine equations ax + by = c: solutions form a 1D lattice {(x₀ + (b/d)t,"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Proves the Fundamental Theorem of Arithmetic from Euclid's lemma — a direct consumer of the constructive Euclid's lemma "
+    },
+    {
+      "id": "bezout-identity-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "The CRT ring isomorphism $\\mathbb{Z}/mn\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ is constru"
     }
   ],
   "references": [

--- a/src/data/proofs/bezout-identity-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02/meta.json
@@ -193,6 +193,16 @@
       "id": "bezout-identity-oq-02-oq-01",
       "relationship": "extended-by",
       "description": "Sub-entry: Fundamental Theorem of Arithmetic from Euclid's Lemma"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry: Constructive Divisibility Algorithm via Bézout Coefficients"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry: Constructive Divisibility: Removing the Noncomputable Annota"
     }
   ],
   "references": [

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -188,6 +188,21 @@
       "id": "chinese-remainder-non-coprime-oq-02",
       "relationship": "related",
       "description": "The non-coprime CRT for Euclidean domains with the ideal bridge IsCoprime ↔ Ideal.span coprime."
+    },
+    {
+      "id": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "Constructive CRT providing an explicit solution algorithm for simultaneous congruences, complementing the abstract isomo"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function $\\varphi(mn) = \\varphi(m)\\varphi(n)$ for coprime $m,n$ is a direct corollary of the integer CRT"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The CRT underlies the proof of quadratic reciprocity via Gauss sums: decomposing $\\mathbb{Z}/p\\mathbb{Z}$-computations t"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
@@ -189,6 +189,11 @@
       "id": "primitive-roots",
       "relationship": "related",
       "description": "Primitive roots modulo primes: $(\\mathbb{Z}/p\\mathbb{Z})^*$ is cyclic. The CRT decomposes $(\\mathbb{Z}/n\\mathbb{Z})^* \\cong \\prod (\\mathbb{Z}/p_i^{a_i}\\mathbb{Z})^*$, reducing unit group structure to prime power components."
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "related",
+      "description": "Generalizes the CRT to non-coprime moduli: when $\\gcd(m,n) > 1$, the system $x \\equiv a \\pmod{m}$, $x \\equiv b \\pmod{n}$"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bezout-identity-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03/meta.json
@@ -224,6 +224,21 @@
       "id": "fundamental-arithmetic",
       "relationship": "related",
       "description": "CRT and FTA are both consequences of Bézout's identity: FTA uses Euclid's lemma (from Bézout), while CRT uses Bézout coefficients as selectors"
+    },
+    {
+      "id": "bezout-identity-oq-03-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry: CRT Ring Isomorphism ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ"
+    },
+    {
+      "id": "bezout-identity-oq-03-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry: k-fold Chinese Remainder Theorem: ℤ/(n₁···nₖ)ℤ ≅ ∏ᵢ ℤ/nᵢℤ"
+    },
+    {
+      "id": "bezout-identity-oq-03-oq-01-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry: Ideal-theoretic CRT: R/∏Iᵢ ≅ ∏ R/Iᵢ"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bezout-identity/meta.json
+++ b/src/data/proofs/bezout-identity/meta.json
@@ -281,6 +281,16 @@
       "id": "bezout-identity-oq-02",
       "relationship": "extended-by",
       "description": "Proves Euclid's lemma ($p \\mid ab \\Rightarrow p \\mid a$ or $p \\mid b$) using the coprime_iff_linear_combination characterization from Bézout — answering one of this file's open questions"
+    },
+    {
+      "id": "bezout-identity-oq-03",
+      "relationship": "extended-by",
+      "description": "Constructs the Chinese Remainder Theorem via Bézout's identity for integers — from $\\gcd(m,n) = 1$ and $mx + ny = 1$, bu"
+    },
+    {
+      "id": "bezout-identity-oq-04",
+      "relationship": "extended-by",
+      "description": "Characterizes the complete solution set of linear Diophantine equations $ax + by = c$: a particular solution (from Bézou"
     }
   ],
   "references": [

--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -284,6 +284,56 @@
       "id": "binomial-theorem-oq-02",
       "relationship": "extended-by",
       "description": "Generalizes $(x+y)^n = \\sum \\binom{n}{k} x^k y^{n-k}$ to the multinomial theorem $(x_1 + \\cdots + x_m)^n = \\sum \\frac{n!"
+    },
+    {
+      "id": "binomial-theorem-oq-04",
+      "relationship": "parent",
+      "description": "Sub-entry on advanced binomial coefficient properties."
+    },
+    {
+      "id": "binomial-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "Derives the binomial distribution $P(X = k) = \\binom{n}{k} p^k (1-p)^{n-k}$ as a probabilistic interpretation of the bin"
+    },
+    {
+      "id": "binomial-theorem-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Newton's generalized binomial theorem extends to non-integer exponents: $(1+x)^\\alpha = \\sum_{k=0}^\\infty \\binom{\\alpha}"
+    },
+    {
+      "id": "binomial-theorem-oq-04-oq-02",
+      "relationship": "extended-by",
+      "description": "Proves the Vandermonde identity $\\binom{m+n}{r} = \\sum_{k=0}^r \\binom{m}{k}\\binom{n}{r-k}$ via algebraic coefficient com"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "Mathematical induction is the standard proof technique for the binomial theorem: the inductive step uses Pascal's identi"
+    },
+    {
+      "id": "geometric-series",
+      "relationship": "foundational",
+      "description": "The geometric series $\\sum_{k=0}^n r^k = (1-r^{n+1})/(1-r)$ is the $y = 1$ special case of the binomial theorem when $x "
+    },
+    {
+      "id": "taylor-theorem",
+      "relationship": "extends",
+      "description": "Taylor's theorem provides the framework for Newton's generalized binomial series: $(1+x)^\\alpha = \\sum_{k=0}^\\infty \\fra"
+    },
+    {
+      "id": "birthday-problem",
+      "relationship": "related",
+      "description": "The birthday problem's exact probability $1 - \\frac{365!}{365^n (365-n)!}$ involves the same factorial and combinatorial"
+    },
+    {
+      "id": "derangements",
+      "relationship": "related",
+      "description": "The derangement formula $D_n = n! \\sum_{k=0}^n \\frac{(-1)^k}{k!}$ uses inclusion-exclusion with binomial coefficients $\\"
+    },
+    {
+      "id": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Faulhaber's formulas for $\\sum_{i=1}^n i^k$ use the binomial theorem in their derivation via the telescoping identity $("
     }
   ],
   "references": [

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -704,6 +704,41 @@
       "id": "e-transcendental",
       "relationship": "related",
       "description": "Transcendence theory connects to BSD via the Schneider-Lang theorem and periods of elliptic curves. The real period $\\Omega_E$ appearing in the BSD formula is a transcendental number (by Schneider's theorem on elliptic integrals), and its arithmetic significance is a key ingredient in the exact BSD formula"
+    },
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Wiles's proof of FLT (1995) established the modularity of semistable elliptic curves over $\\mathbb{Q}$ — the same modula"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "Quadratic reciprocity is the simplest case of Artin reciprocity, which in turn is the abelian case of the Langlands prog"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The congruent number problem — which integers are areas of right triangles with rational sides? — provides the most clas"
+    },
+    {
+      "id": "hodge-conjecture",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning algebraic geometry. The Hodge conjecture and BSD both involve deep connection"
+    },
+    {
+      "id": "poincare-conjecture",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem, uniquely among the seven to have been solved (by Perelman, 2003). The Poincaré conjectu"
+    },
+    {
+      "id": "navier-stokes",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning the existence and smoothness of solutions to the Navier-Stokes equations. Bot"
+    },
+    {
+      "id": "yang-mills",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning the existence of a mass gap in quantum Yang-Mills theory. Both BSD and Yang-M"
     }
   ],
   "references": [

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -259,6 +259,41 @@
       "id": "binomial-theorem",
       "relationship": "uses",
       "description": "Binomial coefficients C(n,2) = n(n-1)/2 count the number of pairs, which is why 23 people have 253 pairs — the quadratic growth of pairs is the key to the birthday 'paradox'"
+    },
+    {
+      "id": "arithmetic-series",
+      "relationship": "related",
+      "description": "The number of pairs C(n,2) = n(n-1)/2 is a triangular number — the same formula as the arithmetic series sum, connecting"
+    },
+    {
+      "id": "derangements",
+      "relationship": "related",
+      "description": "Both are classic combinatorial problems counting structured functions: the birthday problem counts injective functions ("
+    },
+    {
+      "id": "inclusion-exclusion",
+      "relationship": "uses",
+      "description": "The birthday formula $P(n) = 1 - \\prod_{i=0}^{n-1}(1 - i/365)$ is a complement-counting argument, the simplest form of i"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\approx \\sqrt{2\\pi n}(n/e)^n$ enables the Poisson approximation $P(n) \\approx 1 - e^{-n^2/("
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "uses",
+      "description": "The binomial coefficient $\\binom{n}{2} = n(n-1)/2$ counts the number of person-pairs, which is the key to the birthday '"
+    },
+    {
+      "id": "prob-method-expectation",
+      "relationship": "related",
+      "description": "The probabilistic method uses expectation to prove existence: in the birthday problem, the expected number of matching p"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The number of birthday collisions among $n$ people follows a distribution that converges to Poisson (and thence to Gauss"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -213,6 +213,11 @@
       "id": "intermediate-value-theorem",
       "relationship": "uses",
       "description": "The IVT is the fundamental engine for the constructive 1D proof: applied to the antisymmetric difference g(x) = f(x) - f(-x) to find a zero"
+    },
+    {
+      "id": "schauder-fixed-point",
+      "relationship": "related",
+      "description": "Schauder's fixed-point theorem extends Brouwer's to infinite dimensions — the BU → Brouwer FP chain in this file is the "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -265,6 +265,26 @@
       "id": "borsuk-ulam-oq-02",
       "relationship": "extended-by",
       "description": "Explores equivariant extensions of Borsuk-Ulam to group actions beyond the $\\mathbb{Z}/2\\mathbb{Z}$ antipodal action — answering the open question about which group actions preserve the Borsuk-Ulam property"
+    },
+    {
+      "id": "borsuk-ulam-oq-03",
+      "relationship": "extended-by",
+      "description": "Develops constructive versions of the Borsuk-Ulam theorem and equivalent formulations (Tucker's lemma, Lusternik-Schnire"
+    },
+    {
+      "id": "poincare-conjecture",
+      "relationship": "thematic",
+      "description": "Both are landmark results in the topology of spheres. Borsuk-Ulam concerns the symmetry structure of $S^n$ (no odd map $"
+    },
+    {
+      "id": "four-color-theorem",
+      "relationship": "thematic",
+      "description": "Both connect topology to combinatorics. Borsuk-Ulam implies Kneser's conjecture on graph chromatic numbers via Lovász's "
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "Both use topological arguments about continuous maps on spheres. FTA can be proved via the winding number (degree theory"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bounded-prime-gaps/meta.json
+++ b/src/data/proofs/bounded-prime-gaps/meta.json
@@ -288,6 +288,36 @@
       "id": "prime-number-theorem",
       "relationship": "related",
       "description": "PNT gives the average prime gap as log p, but bounded prime gaps shows the minimum gap is finite — primes are much more "
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "The divergence of ∑1/p (proved by Euler) shows primes have positive density in a logarithmic sense — bounded prime gaps "
+    },
+    {
+      "id": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "RH implies much stronger prime gap bounds (Cramér's conjecture: gaps O(log²p)) but remains unproved. Zhang's result is u"
+    },
+    {
+      "id": "twin-primes-special",
+      "relationship": "related",
+      "description": "The twin prime conjecture ($\\liminf g_n = 2$) is the ultimate target. This formalization shows $\\liminf g_n \\leq 246$ (P"
+    },
+    {
+      "id": "bounded-prime-gaps-oq-03",
+      "relationship": "extended-by",
+      "description": "Sub-entry exploring extensions, further admissible tuple computations, or refined gap bounds"
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "foundational",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions is a prerequisite for the Bombieri-Vinogradov theorem, which is"
+    },
+    {
+      "id": "bounded-prime-gaps-oq-03-oq-01",
+      "relationship": "extended-by",
+      "description": "Analyzes how the $k$-tuple size parameter affects the gap bound: the Polymath 8b bound 246 comes from optimizing over 50"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -355,6 +355,51 @@
       "id": "schauder-fixed-point",
       "relationship": "extended-by",
       "description": "Schauder's fixed point theorem (1930) generalizes Brouwer from finite-dimensional balls to compact convex subsets of Banach spaces: every continuous self-map of a compact convex set in a Banach space has a fixed point. This infinite-dimensional extension is essential for differential equations (Leray-Schauder degree theory) and functional analysis"
+    },
+    {
+      "id": "poincare-conjecture",
+      "relationship": "thematic",
+      "description": "Both are landmark results in topology requiring sophisticated machinery: Brouwer uses homology (or degree theory) to pro"
+    },
+    {
+      "id": "mean-value-theorem",
+      "relationship": "related",
+      "description": "Both guarantee existence of special points for continuous functions. The 1D Brouwer theorem follows from IVT (which also"
+    },
+    {
+      "id": "brouwer-fixed-point-oq-02",
+      "relationship": "extended-by",
+      "description": "Explores the computational complexity of finding approximate fixed points (PPAD-completeness) — the constructive dimensi"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem defines the Euclidean metric $\\|x\\|^2 = x_1^2 + \\cdots + x_n^2$ that determines the closed ball "
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "related",
+      "description": "The area formula $A = \\pi r^2$ gives the measure of the 2-disk $B^2$ where the 2-dimensional Brouwer theorem applies. Th"
+    },
+    {
+      "id": "halting-problem",
+      "relationship": "thematic",
+      "description": "Both are non-constructive existence/impossibility results: Brouwer proves a fixed point exists without exhibiting it, wh"
+    },
+    {
+      "id": "konigsberg",
+      "relationship": "thematic",
+      "description": "Both are pioneering results in topology: Euler's solution of the Königsberg bridge problem (1736) launched graph theory "
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "Cauchy-Schwarz provides the triangle inequality $\\|u+v\\| \\leq \\|u\\| + \\|v\\|$ that makes the closed ball $B^n = \\{x : \\|x"
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "thematic",
+      "description": "Both characterize fundamental properties of the ball/sphere: the isoperimetric theorem shows the ball maximizes volume f"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cantor-diagonalization/meta.json
+++ b/src/data/proofs/cantor-diagonalization/meta.json
@@ -262,6 +262,41 @@
       "id": "schroeder-bernstein",
       "relationship": "complementary",
       "description": "The Schröder-Bernstein theorem (injections in both directions imply bijection) provides the positive tool for establishing cardinality equalities, while Cantor's diagonal argument provides the negative tool for establishing strict inequalities. Together they form the complete toolkit for comparing infinite cardinalities."
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "thematic",
+      "description": "Both are existence proofs via contradiction: Euclid shows no finite list contains all primes (construct p₁···pₙ + 1), Ca"
+    },
+    {
+      "id": "cantor-diagonalization-oq-01",
+      "relationship": "extended-by",
+      "description": "Explores the Continuum Hypothesis — whether there exists a cardinality strictly between $|\\mathbb{N}|$ and $|\\mathbb{R}|"
+    },
+    {
+      "id": "cantor-diagonalization-oq-02",
+      "relationship": "extended-by",
+      "description": "Establishes the cardinality of the set of countable ordinals $\\omega_1$, extending the diagonal argument's study of card"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Both belong to the impossibility proof tradition: Cantor proves no enumeration captures all reals (1891), Abel-Ruffini p"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "thematic",
+      "description": "Both prove existence of 'unreachable' quantities: $\\sqrt{2} \\notin \\mathbb{Q}$ (irrationals exist) is the earliest impos"
+    },
+    {
+      "id": "hilbert-10",
+      "relationship": "related",
+      "description": "Matiyasevich's theorem uses the diagonal argument's undecidability legacy: the halting problem (proved undecidable via d"
+    },
+    {
+      "id": "russell-1-plus-1",
+      "relationship": "related",
+      "description": "Russell's paradox ($R = \\{x : x \\notin x\\}$) and Cantor's diagonal argument share the same logical structure: define an "
     }
   ],
   "alternativeInterpretation": {

--- a/src/data/proofs/cantors-theorem-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01/meta.json
@@ -194,6 +194,11 @@
       "id": "schroeder-bernstein",
       "relationship": "foundational",
       "description": "Schröder-Bernstein theorem enables cardinal arithmetic comparisons: injections both ways give bijection, establishing the well-ordering of cardinals used throughout this file"
+    },
+    {
+      "id": "godel-incompleteness",
+      "relationship": "thematic",
+      "description": "Gödel's work on CH consistency (1940) and Cohen's forcing independence proof (1963) show that the exact value of |P(ℝ)| "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cantors-theorem-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-02/meta.json
@@ -204,6 +204,11 @@
       "id": "brouwer-fixed-point",
       "relationship": "contrast",
       "description": "Brouwer's fixed-point theorem guarantees fixed points for continuous maps on compact convex sets — a topological analog,"
+    },
+    {
+      "id": "schauder-fixed-point",
+      "relationship": "contrast",
+      "description": "Schauder's fixed-point theorem extends Brouwer to infinite dimensions; both contrast with Lawvere's algebraic/categorica"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cantors-theorem-oq-03/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-03/meta.json
@@ -211,6 +211,11 @@
       "id": "cantors-theorem-oq-02",
       "title": "Cantor's Theorem OQ02",
       "relationship": "sibling open question from the same theorem"
+    },
+    {
+      "id": "cantor-diagonalization-oq-01",
+      "relationship": "related",
+      "description": "The Continuum Hypothesis asks what lies between ℵ₀ and 2^ℵ₀ — König's inequality Σκᵢ < Πλᵢ constrains possible answers"
     }
   ]
 }

--- a/src/data/proofs/cantors-theorem/meta.json
+++ b/src/data/proofs/cantors-theorem/meta.json
@@ -222,6 +222,31 @@
       "id": "cantors-theorem-oq-01",
       "relationship": "extended-by",
       "description": "Investigates the cardinality of $\\mathcal{P}(\\mathbb{R})$ — iterated application of Cantor's theorem gives the tower $|\\"
+    },
+    {
+      "id": "cantors-theorem-oq-02",
+      "relationship": "extended-by",
+      "description": "Lawvere's fixed-point theorem provides a categorical generalization of Cantor's diagonal argument: in any cartesian clos"
+    },
+    {
+      "id": "godel-incompleteness",
+      "relationship": "thematic",
+      "description": "Godel's incompleteness theorem uses a self-referential construction structurally identical to Cantor's diagonal argument"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Both are impossibility results proved by structural obstruction: Cantor shows no surjection to the power set via diagona"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "related",
+      "description": "Both establish fundamental structural properties of infinite mathematical objects. Euclid's proof that primes are infini"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The well-ordering principle (equivalent to induction, as formalized in mathematical-induction) provides the foundation f"
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01/meta.json
@@ -186,6 +186,11 @@
       "id": "cauchy-schwarz-integral-oq-02",
       "relationship": "related",
       "description": "The Cauchy-Schwarz equality case (⟪f,g⟫ = ‖f‖·‖g‖ iff proportional) — Hölder's equality case similarly requires f^p and "
+    },
+    {
+      "id": "cauchy-schwarz-integral-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Strict Minkowski inequality characterization — extends the equality case analysis that this file's Hölder result enables"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -201,6 +201,36 @@
       "id": "basel-problem",
       "relationship": "related",
       "description": "The Basel identity ζ(2) = π²/6 can be derived using Parseval's theorem applied to f(x) = x on [-π,π], which is a direct "
+    },
+    {
+      "id": "triangle-inequality",
+      "relationship": "implication",
+      "description": "The Minkowski inequality (L^p triangle inequality) ‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p for p=2 follows directly from the integral Ca"
+    },
+    {
+      "id": "amgm-inequality-oq-03",
+      "relationship": "related",
+      "description": "Power mean monotonicity M₁ ≤ M₂ is the discrete Cauchy-Schwarz for equal weights; the integral analog extends this to co"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "related",
+      "description": "FTC connects differentiation and integration — the same Lebesgue integral framework that defines the $L^2$ inner product"
+    },
+    {
+      "id": "cauchy-schwarz-integral-oq-01",
+      "relationship": "extended-by",
+      "description": "Hölder's inequality $\\|fg\\|_1 \\leq \\|f\\|_p \\cdot \\|g\\|_q$ (for $1/p + 1/q = 1$) generalizes the integral Cauchy-Schwarz "
+    },
+    {
+      "id": "cauchy-schwarz-integral-oq-02",
+      "relationship": "extended-by",
+      "description": "The Minkowski integral inequality $\\|f+g\\|_p \\leq \\|f\\|_p + \\|g\\|_p$ is the $L^p$ triangle inequality. For $p = 2$, it f"
+    },
+    {
+      "id": "cauchy-schwarz-integral-oq-03",
+      "relationship": "extended-by",
+      "description": "Extends the integral Cauchy-Schwarz to complex-valued $L^2$ functions via a bridge theorem connecting the real and compl"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cauchy-schwarz-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01/meta.json
@@ -265,6 +265,21 @@
       "id": "cauchy-schwarz-oq-01-oq-01",
       "relationship": "extended-by",
       "description": "Further exploration building on this entry's complex Cauchy-Schwarz result"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The classical Pythagorean theorem $a^2 + b^2 = c^2$ is a special case of the abstract Pythagorean theorem proved here: o"
+    },
+    {
+      "id": "triangle-inequality",
+      "relationship": "related",
+      "description": "The triangle inequality $\\|u+v\\| \\leq \\|u\\| + \\|v\\|$ for normed spaces is proved using Cauchy-Schwarz in inner product s"
+    },
+    {
+      "id": "amgm-inequality",
+      "relationship": "related",
+      "description": "AM-GM and Cauchy-Schwarz are both fundamental inequalities in analysis. Cauchy-Schwarz can be derived from AM-GM applied"
     }
   ]
 }

--- a/src/data/proofs/cauchy-schwarz-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03/meta.json
@@ -232,6 +232,11 @@
       "id": "triangle-inequality",
       "relationship": "related",
       "description": "Hölder's inequality implies Minkowski's inequality (the triangle inequality for $L^p$ spaces): $\\|f+g\\|_p \\leq \\|f\\|_p +"
+    },
+    {
+      "id": "cauchy-schwarz-oq-03-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry further exploring consequences or refinements of the Hölder generalization established here."
     }
   ]
 }

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -256,6 +256,51 @@
       "id": "cauchy-schwarz-oq-03-oq-01",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "triangle-inequality",
+      "relationship": "proves",
+      "description": "The triangle inequality ‖u+v‖ ≤ ‖u‖+‖v‖ is derived as a direct corollary of Cauchy-Schwarz in both formalizations, demon"
+    },
+    {
+      "id": "amgm-inequality",
+      "relationship": "related",
+      "description": "AM-GM and Cauchy-Schwarz are the two most fundamental inequalities in analysis. Cauchy-Schwarz for n=2 can be derived fr"
+    },
+    {
+      "id": "hurwitz-theorem",
+      "relationship": "foundational",
+      "description": "Hurwitz's theorem on normed division algebras (ℝ, ℂ, ℍ, 𝕆) relies on the inner product space structure where Cauchy-Schw"
+    },
+    {
+      "id": "yang-mills",
+      "relationship": "foundational",
+      "description": "The Yang-Mills formalization uses Hilbert spaces and inner products (Wightman axioms) where Cauchy-Schwarz underpins the"
+    },
+    {
+      "id": "amgm-inequality-oq-03",
+      "relationship": "related",
+      "description": "For equal weights, the power mean inequality M₁ ≤ M₂ is equivalent to Cauchy-Schwarz: (∑wᵢzᵢ)² ≤ ∑wᵢzᵢ². Cauchy-Schwarz "
+    },
+    {
+      "id": "amgm-inequality-oq-02",
+      "relationship": "related",
+      "description": "The Cauchy-Schwarz sum n·∑xᵢ² ≥ (∑xᵢ)² is the key engine in the Maclaurin M₁²≥M₂ proof — directly connecting Cauchy-Schw"
+    },
+    {
+      "id": "cauchy-schwarz-oq-04",
+      "relationship": "extended-by",
+      "description": "Strengthens the equality characterization to give the exact proportionality constant $c = \\langle u,v\\rangle/\\|v\\|^2$ wh"
+    },
+    {
+      "id": "randomized-maxcut",
+      "relationship": "related",
+      "description": "The randomized MAX-CUT approximation algorithm uses semidefinite programming relaxations where Cauchy-Schwarz bounds con"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "foundational",
+      "description": "Cauchy-Schwarz underpins key steps in proving the Central Limit Theorem: bounding characteristic function differences $|"
     }
   ],
   "references": [

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -263,6 +263,21 @@
       "id": "cayley-hamilton-reduction",
       "relationship": "related",
       "description": "Both extend the Cayley-Hamilton theorem in different directions: reduction develops computational aspects, while this proof develops the structural characterization via cyclic vectors"
+    },
+    {
+      "id": "gcd-algorithm",
+      "relationship": "uses-concept",
+      "description": "The Euclidean algorithm for polynomial GCD is the computational backbone of the Bezout identity used in the GCD annihila"
+    },
+    {
+      "id": "cayley-hamilton-minpoly-oq-05",
+      "relationship": "extends",
+      "description": "Parent entry on minimal polynomial reduction in K-algebras. This OQ-01 entry specializes the theory to matrices and prov"
+    },
+    {
+      "id": "cayley-hamilton-minpoly-oq-02",
+      "relationship": "related",
+      "description": "Similar matrices share the same minimal polynomial. Combined with the nonderogatory characterization, this shows the cyc"
     }
   ],
   "references": [

--- a/src/data/proofs/cayley-hamilton-reduction/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction/meta.json
@@ -200,6 +200,11 @@
       "id": "cramers-rule",
       "relationship": "related",
       "description": "Cramer's rule uses determinants of matrices; the characteristic polynomial involves det(A - λI), connecting determinant "
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "Matrix power expansion and polynomial evaluation at matrices use binomial-type identities for the algebraic manipulation"
     }
   ],
   "references": [

--- a/src/data/proofs/central-limit-theorem/meta.json
+++ b/src/data/proofs/central-limit-theorem/meta.json
@@ -274,6 +274,36 @@
       "id": "central-limit-theorem-oq-01",
       "relationship": "extended-by",
       "description": "Explores what happens when variance is infinite — leading to stable distributions (Lévy $\\alpha$-stable) with heavier tails than the Gaussian, answering the first open question"
+    },
+    {
+      "id": "central-limit-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "Investigates the categorical structure of probability distributions under convolution, connecting CLT to operad theory a"
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "Cauchy-Schwarz bounds $|\\mathbb{E}[XY]| \\leq \\sqrt{\\mathbb{E}[X^2]\\mathbb{E}[Y^2]}$ are used throughout the CLT proof: b"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "The binomial distribution $P(X = k) = \\binom{n}{k}p^k(1-p)^{n-k}$ arises directly from the binomial theorem with $x = p,"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "The CLT proof via characteristic functions uses $\\varphi_X(t) = \\mathbb{E}[e^{itX}]$, where $e^{itX} = \\cos(tX) + i\\sin("
+    },
+    {
+      "id": "central-limit-theorem-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "The Gnedenko-Kolmogorov domain of attraction theorem: classifies which distributions converge to each stable law $S_\\alp"
+    },
+    {
+      "id": "central-limit-theorem-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "The Lévy-Khintchine representation: every infinitely divisible distribution has a unique triplet $(b, \\sigma^2, \\nu)$ de"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
@@ -192,6 +192,11 @@
       "id": "law-of-cosines",
       "relationship": "foundational",
       "description": "The spherical law of cosines $\\cos c = \\cos a \\cos b + \\sin a \\sin b \\cos C$ is the fundamental identity relating angles and sides on the sphere. This entry's inner product computation $\\langle B, D \\rangle = (\\alpha + \\beta m)/n$ is the unit-vector version of the same geometric relationship."
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The Pythagorean theorem and Ceva's theorem are both fundamental results about triangles that admit deep generalizations:"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -218,6 +218,11 @@
       "id": "feuerbachs-theorem",
       "relationship": "related",
       "description": "Both are classical triangle geometry results: Ceva's theorem concerns cevian concurrency, while Feuerbach's theorem concerns the tangency of the nine-point circle and incircle — both reveal deep structure in triangle configurations"
+    },
+    {
+      "id": "isosceles-triangle",
+      "relationship": "foundational",
+      "description": "The isosceles triangle theorem is the simplest symmetry result in triangle geometry, while Ceva's theorem handles the ge"
     }
   ]
 }

--- a/src/data/proofs/chinese-remainder-constructive/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive/meta.json
@@ -262,6 +262,31 @@
       "id": "wilsons-theorem",
       "relationship": "related",
       "description": "Wilson's theorem $(p-1)! \\equiv -1 \\pmod{p}$ uses the structure of $(\\mathbb{Z}/p\\mathbb{Z})^*$, while CRT decomposes $("
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "CRT is used in proofs of quadratic reciprocity: the Jacobi symbol $(a/mn) = (a/m)(a/n)$ follows from the CRT decompositi"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "The CRT decomposition $\\mathbb{Z}/n\\mathbb{Z} \\cong \\prod \\mathbb{Z}/p_i^{a_i}\\mathbb{Z}$ (where $n = \\prod p_i^{a_i}$) "
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "extended-by",
+      "description": "The non-coprime CRT generalizes: $x \\equiv a \\pmod{m}, x \\equiv b \\pmod{n}$ has a solution iff $\\gcd(m,n) \\mid (a-b)$, a"
+    },
+    {
+      "id": "fermat-two-squares",
+      "relationship": "related",
+      "description": "CRT is used in Cornacchia's algorithm for finding the two-square representation $p = a^2+b^2$: compute $r \\equiv \\sqrt{-"
+    },
+    {
+      "id": "perfect-numbers",
+      "relationship": "related",
+      "description": "CRT's multiplicativity result $\\phi(mn) = \\phi(m)\\phi(n)$ (for coprime $m,n$) generalizes to all multiplicative function"
     }
   ],
   "references": [

--- a/src/data/proofs/de-moivre-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02/meta.json
@@ -234,6 +234,11 @@
       "id": "fourier-series",
       "relationship": "related",
       "description": "The product-to-sum identity 2·T_m(x)·T_n(x) = T_{m+n}(x) + T_{m-n}(x) is the Chebyshev analogue of the trigonometric product-to-sum formula central to Fourier analysis. Chebyshev expansions are discrete cosine transforms."
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "related",
+      "description": "The roots of T_n are cos((2k+1)π/(2n)), closely related to primitive roots of unity. The Chebyshev nodes are projections"
     }
   ]
 }

--- a/src/data/proofs/derangements-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-01/meta.json
@@ -191,6 +191,16 @@
       "id": "binomial-theorem",
       "relationship": "related",
       "description": "Binomial coefficients C(n,k) appear as the 'choose the fixed points' factor in S(n,k) = C(n,k)·D(n-k). The binomial theorem provides the algebraic framework for manipulating these coefficients"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The combinations formula C(n,k) = n!/(k!(n-k)!) is used directly in the partial derangement formula S(n,k) = C(n,k)·D(n-"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient φ(n) counts elements of (ℤ/nℤ)* coprime to n, paralleling how derangements count fixed-point-free permut"
     }
   ],
   "references": [

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -261,6 +261,21 @@
       "id": "e-transcendental",
       "relationship": "related",
       "description": "The derangement probability D_n/n! = ∑(-1)^k/k! converges to 1/e as n→∞ — the Taylor series of e^{-1} truncated at the n-th term. The transcendence of e means D_n/n! is never exactly 1/e for finite n"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation n! ≈ √(2πn)(n/e)^n combined with D_n ≈ n!/e gives D_n ≈ √(2πn)(n/e)^n/e — an asymptotic formula"
+    },
+    {
+      "id": "buffons-needle",
+      "relationship": "related",
+      "description": "Both are classic probability problems where fundamental constants appear unexpectedly: Buffon's needle yields $2/\\pi$ fr"
+    },
+    {
+      "id": "birthday-problem",
+      "relationship": "related",
+      "description": "Both are celebrated combinatorial probability problems with counterintuitive answers. The birthday problem counts collis"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/dirichlets-theorem/meta.json
+++ b/src/data/proofs/dirichlets-theorem/meta.json
@@ -207,6 +207,31 @@
       "id": "prime-number-theorem",
       "relationship": "extended-by",
       "description": "PNT ($\\pi(x) \\sim x/\\ln x$) is the quantitative refinement of the infinitude of primes. Dirichlet's theorem is the equidistribution refinement: primes are not only infinite but spread uniformly across coprime residue classes. PNT for arithmetic progressions ($\\pi(x; q, a) \\sim x/(\\varphi(q) \\ln x)$) combines both, proved via Dirichlet L-functions"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Both are foundational results in algebraic number theory. Dirichlet's theorem uses characters mod $q$ to detect primes i"
+    },
+    {
+      "id": "bounded-prime-gaps",
+      "relationship": "related",
+      "description": "Zhang's bounded prime gaps proof requires the Bombieri-Vinogradov theorem, which is a mean-value estimate for the error "
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "Euler's proof that $\\sum 1/p$ diverges was the prototype for Dirichlet's method: Dirichlet showed $\\sum_{p \\equiv a \\pmo"
+    },
+    {
+      "id": "kroneckers-jugendtraum",
+      "relationship": "extends",
+      "description": "Kronecker-Weber (every abelian extension of $\\mathbb{Q}$ is contained in a cyclotomic field) provides the class field th"
+    },
+    {
+      "id": "hilbert-9-reciprocity",
+      "relationship": "extends",
+      "description": "Hilbert's 9th problem asks for the most general reciprocity law in algebraic number fields. Dirichlet's theorem is the f"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -277,6 +277,21 @@
       "id": "abel-ruffini",
       "relationship": "thematic",
       "description": "Both are structural impossibility results where the proof identifies a fundamental obstruction: Abel-Ruffini's obstruction is the non-solvability of $S_5$ (group theory), while cube dissection's obstruction is the infinite descent forced by the surrounding geometry (combinatorics). Both reduce impossibility to a structural property that cannot be circumvented"
+    },
+    {
+      "id": "erdos-szekeres",
+      "relationship": "related",
+      "description": "The Erdős-Szekeres theorem (every sequence of length $mn+1$ has a monotone subsequence of length $m+1$ or $n+1$) uses th"
+    },
+    {
+      "id": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey theory and cube dissection share the infinite descent / pigeonhole methodology: both prove that sufficiently larg"
+    },
+    {
+      "id": "hilbert-3",
+      "relationship": "related",
+      "description": "Hilbert's 3rd problem (Dehn's theorem): not all polyhedra of equal volume are equidecomposable — the Dehn invariant prov"
     }
   ]
 }

--- a/src/data/proofs/divisibility-truncation-general-oq-01/meta.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-01/meta.json
@@ -192,6 +192,11 @@
       "id": "euler-totient",
       "relationship": "related",
       "description": "Euler's totient function $\\varphi(d)$ counts invertible elements in $\\mathbb{Z}/d\\mathbb{Z}$. The osculator $c$ is the multiplicative inverse of 10 mod $d$, which exists iff $\\gcd(10, d) = 1$ — a condition guaranteed by Euler's theorem: $10^{\\varphi(d)} \\equiv 1 \\pmod{d}$"
+    },
+    {
+      "id": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "CRT provides an alternative approach to osculator construction: for composite $d = d_1 d_2$ with $\\gcd(d_1, d_2) = 1$, t"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -195,6 +195,11 @@
       "id": "sqrt2-irrational",
       "relationship": "foundational",
       "description": "The irrationality of √2 is the simplest impossibility result about number expressibility. Transcendence of e is strictly stronger: irrational → algebraically irrational → transcendental"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both are impossibility results about algebraic expressibility: Abel-Ruffini shows certain roots can't be expressed by ra"
     }
   ],
   "references": [

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
@@ -180,6 +180,16 @@
       "id": "primitive-roots",
       "relationship": "foundational",
       "description": "Primitive roots establish that (ℤ/pℤ)* is cyclic, fundamental to the Legendre symbol: a is a QR mod p iff a^((p-1)/2) ≡ "
+    },
+    {
+      "id": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem (p-1)! ≡ -1 (mod p) connects to the first supplement of QR: (-1/p) = (-1)^((p-1)/2). Both characterize "
+    },
+    {
+      "id": "fermat-two-squares",
+      "relationship": "related",
+      "description": "Fermat's two-squares theorem (p = a² + b² iff p ≡ 1 mod 4) follows from (-1/p) = 1 iff p ≡ 1 mod 4, the first supplement"
     }
   ],
   "references": [

--- a/src/data/proofs/elementary-quadratic-reciprocity/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity/meta.json
@@ -228,6 +228,11 @@
       "id": "primitive-roots",
       "relationship": "foundational",
       "description": "Primitive roots establish that $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is cyclic of order $p-1$. The quadratic residues are precisely the even powers of a primitive root, forming the unique subgroup of index 2. This group structure is what makes the Legendre symbol a group homomorphism"
+    },
+    {
+      "id": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem ($(p-1)! \\equiv -1 \\pmod{p}$) is closely related to quadratic residues: pairing each residue with its i"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -236,6 +236,26 @@
       "id": "erdos-347",
       "relationship": "related",
       "description": "Complete sequences with ratio tending to 2 concern sets whose subset sums cover all sufficiently large integers. Problem #1 asks when subset sums are all different; Problem #347 asks when they cover everything. The powers of 2 are extremal for both: they give distinct sums with maximum N, and their subset sums cover exactly $\\{0, 1, \\ldots, 2^n - 1\\}$"
+    },
+    {
+      "id": "erdos-867",
+      "relationship": "related",
+      "description": "Consecutive sum-free sets concern sets avoiding the equation $a + b = c$. While Problem #1 requires all subset sums to b"
+    },
+    {
+      "id": "erdos-1179",
+      "relationship": "extends",
+      "description": "Uniform subset sum representations in abelian groups generalizes the distinct subset sums problem from $\\mathbb{Z}$ to a"
+    },
+    {
+      "id": "erdos-340-greedy-sidon",
+      "relationship": "related",
+      "description": "Sidon sets ($B_2$ sequences) require all pairwise sums $a + b$ to be distinct. Distinct subset sums is the much stronger"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "The binomial theorem gives $|\\mathcal{P}(A)| = 2^{|A|}$ (the number of subsets of an $n$-element set). This cardinality "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -212,6 +212,11 @@
       "id": "erdos-1",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes is a basic prerequisite. Romanoff's theorem ($\\underline{d}(S_1) > 0$) relies on the prime numb"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -182,6 +182,36 @@
     {
       "id": "erdos-1",
       "description": "Erdős Problem 1 is a canonical example of an Erdős conjecture with elementary statement and deep analytic content, sharing with Problem 1004 the feature that birthday-paradox and probabilistic heuristics strongly support the conjecture while rigorous proof remains elusive."
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "foundation",
+      "description": "The Euler totient function $\\varphi(n)$ is the central object in Problem 1004. The euler-totient proof establishes its c"
+    },
+    {
+      "id": "erdos-1003",
+      "relationship": "sibling",
+      "description": "Erdős Problem 1003 studies locally repeated values of arithmetic functions, the direct predecessor of Problem 1004 in th"
+    },
+    {
+      "id": "erdos-1005",
+      "relationship": "sibling",
+      "description": "Erdős Problem 1005 is the next problem in the EPS series on locally repeated values, studying further properties of toti"
+    },
+    {
+      "id": "erdos-1049",
+      "relationship": "analogy",
+      "description": "Erdős Problem 1049 concerns the divisor function $\\tau(n)$, which appears explicitly in the Problem 1004 formalization a"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "dependency",
+      "description": "The EPS upper bound on distinct totient runs relies on smooth number estimates, which in turn depend on the distribution"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "dependency",
+      "description": "The unique factorization theorem is essential for totient calculations: $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$ uses "
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1006/meta.json
+++ b/src/data/proofs/erdos-1006/meta.json
@@ -155,6 +155,11 @@
       "id": "erdos-1011",
       "relationship": "related",
       "description": "Both connect chromatic number to structural graph properties: #1006 shows high chromatic number obstructs robust orientability; #1011 studies triangles forced by high chromatic number, exploring the same chromatic-extremal theme."
+    },
+    {
+      "id": "randomized-maxcut",
+      "relationship": "related",
+      "description": "Both use probabilistic arguments in graph theory: the Nešetřil-Rödl disproof relies on the probabilistic method (random "
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -194,6 +194,11 @@
       "id": "szemeredi-regularity",
       "relationship": "complementary",
       "description": "Szemerédi's Regularity Lemma is the primary modern tool for analyzing triangle structure in dense graphs. Györi's proof "
+    },
+    {
+      "id": "erdos-1",
+      "relationship": "thematic",
+      "description": "Erdős Problem #1 is a central problem in Erdős's extremal combinatorics program. Like #1009, it exemplifies Erdős's appr"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1011/meta.json
+++ b/src/data/proofs/erdos-1011/meta.json
@@ -186,6 +186,11 @@
       "id": "erdos-500",
       "relationship": "related",
       "description": "Erdős Problem #500 on chromatic number and subgraph structure shares the core tension between local sparsity (triangle-free) and global complexity (high chromatic number)."
+    },
+    {
+      "id": "szemeredi-regularity",
+      "relationship": "uses",
+      "description": "Szemerédi's Regularity Lemma is the principal tool in proving asymptotic Turán-type results; the Simonovits asymptotic f"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -184,6 +184,11 @@
       "id": "szemeredi-regularity",
       "relationship": "complementary",
       "description": "The Szemerédi Regularity Lemma is a key tool in modern extremal graph theory for problems about dense graphs. Approaches to the general case of Problem #1017 beyond the K₄-free regime are expected to require regularity-based techniques."
+    },
+    {
+      "id": "erdos-500",
+      "relationship": "thematic",
+      "description": "Erdős #500 studies Turán-type density questions for hypergraphs. The EGP bound ⌊n²/4⌋ equals the Turán number ex(n,K₃), "
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -187,6 +187,11 @@
       "id": "erdos-1017",
       "relationship": "sibling",
       "description": "Erdős Problem #1017 is a neighboring problem in the Erdős problem collection sharing the extremal combinatorics and density-forcing theme."
+    },
+    {
+      "id": "szemeredi-regularity",
+      "relationship": "technique",
+      "description": "Szemerédi's Regularity Lemma is a fundamental tool in extremal graph theory; the density regime n^(1+ε) studied in Probl"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -192,6 +192,11 @@
       "id": "szemeredi-theorem",
       "relationship": "thematic",
       "description": "Szemerédi's theorem (on arithmetic progressions) and the Szemerédi–Trotter incidence theorem are distinct results by the same author. The incidence theorem is the key upper bound tool for Problem #102; the regularity lemma underlying both results connects discrete geometry to combinatorics."
+    },
+    {
+      "id": "erdos-100",
+      "relationship": "related",
+      "description": "Problem #100 on point sets with restricted distances and Problem #102 on rich lines both belong to Erdős's combinatorial"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -167,6 +167,11 @@
       "id": "erdos-1078",
       "relationship": "related",
       "description": "Erdős #1078 determines the minimum-degree threshold that forces K_r in r-partite graphs (solved by Haxell 2001). Both #1"
+    },
+    {
+      "id": "erdos-1077",
+      "relationship": "related",
+      "description": "Erdős #1077 (Balanced Subgraphs in Dense Graphs, Jiang-Longbrake 2025) asks for large balanced subgraphs in dense graphs"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -212,6 +212,11 @@
       "id": "lebesgue-measure",
       "relationship": "foundational",
       "description": "The definition of μ(F) as the Lebesgue measure of sublevel sets in the complex plane relies directly on MeasureTheory.volume, the Lebesgue measure formalized in Mathlib."
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "foundational",
+      "description": "The Fundamental Theorem of Algebra underpins the polynomial infrastructure, ensuring that monic polynomials with roots i"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -246,6 +246,21 @@
       "id": "erdos-1041",
       "relationship": "related",
       "description": "Erdős #1041 studies path lengths within lemniscate components connecting roots, complementing #1048's diameter analysis "
+    },
+    {
+      "id": "erdos-1038",
+      "relationship": "related",
+      "description": "Erdős #1038 studies the Lebesgue measure of polynomial sublevel sets {x : |f(x)| < 1} on the real line (solved: supremum"
+    },
+    {
+      "id": "erdos-1040",
+      "relationship": "related",
+      "description": "Erdős #1040 asks whether the measure of L(f,1) is determined by the transfinite diameter of the root set — connecting to"
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "foundational",
+      "description": "The Fundamental Theorem of Algebra guarantees that a degree-n monic polynomial has exactly n roots in ℂ (with multiplici"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -244,6 +244,11 @@
       "id": "erdos-1003",
       "relationship": "sibling",
       "description": "Erdős Problem #1003 is another number-theoretic problem from the Erdős collection involving divisibility and arithmetic "
+    },
+    {
+      "id": "erdos-1051",
+      "relationship": "sibling",
+      "description": "Erdős Problem #1051 sits in the same cluster of problems concerning arithmetic properties of series and sums, closely ne"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -159,6 +159,11 @@
       "id": "erdos-1003",
       "relationship": "related",
       "description": "Erdős Problem #1003 concerns the distribution of the abundancy index σ(n)/n over integers, studying when large values occur. The k-perfect numbers — where σ(n)/n is exactly an integer — are a special discrete sub-problem within this continuous distribution question."
+    },
+    {
+      "id": "erdos-1004",
+      "relationship": "related",
+      "description": "Erdős Problem #1004 studies the sum ∑ σ(n)/n over structured sets, connecting the local behavior of σ(n)/n at k-perfect "
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1057/meta.json
+++ b/src/data/proofs/erdos-1057/meta.json
@@ -234,6 +234,16 @@
       "id": "dirichlets-theorem",
       "relationship": "key construction tool",
       "description": "Dirichlet's theorem on primes in arithmetic progressions is used in the AGP construction; finding sufficiently many primes $p$ with $(p-1) \\mid L$ for a suitable $L$ is the core step in building large sets of Carmichael numbers."
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "structural prerequisite",
+      "description": "The Fundamental Theorem of Arithmetic underpins both Korselt's criterion and the squarefreeness requirement: Carmichael "
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "sieve-method context",
+      "description": "Bertrand's postulate (a prime between $n$ and $2n$) and the AGP Carmichael lower bound both use sieve-theoretic and anal"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -244,6 +244,31 @@
       "id": "erdos-1058",
       "relationship": "sibling",
       "description": "Both problems concern the interplay between primes and factorials: #1058 studies prime divisors of $n!+1$ between consecutive primes, while #1059 studies primality of $p - k!$. Both exploit the super-exponential growth of factorials to reduce infinite problems to finite case analysis"
+    },
+    {
+      "id": "erdos-728-factorial-divisibility",
+      "relationship": "related",
+      "description": "Both concern factorial-prime interactions: #728 studies factorial divisibility patterns while #1059 studies factorial su"
+    },
+    {
+      "id": "erdos-68",
+      "relationship": "related",
+      "description": "Both involve interactions between primes and factorials: #68 asks about irrationality of $\\sum 1/(n!-1)$ while #1059 ask"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "supports",
+      "description": "Unique prime factorization underlies the compositeness checks: verifying $n - k!$ is composite requires exhibiting a non"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The probabilistic heuristic for this problem relies on the PNT: the probability that a random integer near $p$ is prime "
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "foundational",
+      "description": "Stirling's approximation $k! \\sim \\sqrt{2\\pi k}(k/e)^k$ quantifies the super-exponential growth of factorials that makes"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -131,6 +131,31 @@
       "id": "erdos-131",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "divisibility-by-3",
+      "relationship": "related",
+      "description": "Divisibility is the core relation: this problem restricts sets based on the divisibility partial order on {1,...,n}. Und"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization underlies the divisibility poset structure: a | b iff every prime power in a's factorization "
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes shapes the structure of the divisibility poset on {1,...,n}. Primes contribute to the valid set"
+    },
+    {
+      "id": "partition-theorem",
+      "relationship": "related",
+      "description": "The problem connects to partition theory through the structure of the divisibility lattice: Dilworth's theorem relates m"
+    },
+    {
+      "id": "derangements",
+      "relationship": "thematic",
+      "description": "Both are extremal counting problems: derangements count permutations avoiding fixed points, while this problem maximizes"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -237,6 +237,26 @@
       "id": "prime-number-theorem",
       "relationship": "foundational",
       "description": "The prime number theorem $\\pi(x) \\sim x/\\ln x$ underlies the density heuristic: the probability that $2^k q + 1$ is prime is $\\sim 1/\\ln(2^k q)$, and summing over valid $(k, q)$ pairs predicts the count of Form A primes up to $x$"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "related",
+      "description": "Artin's primitive root conjecture depends on the factorization of p-1 — exactly the structure constrained by Form A"
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions is the prototype for prime distribution in structured sets; Erd"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient $\\varphi(p) = p - 1$ connects directly: Form A primes have $\\varphi(p) = 2^k q$ with $\\omega(\\varphi(p))"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate guarantees primes in every interval $(n, 2n)$; similar density arguments underlie the heuristic pre"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1075/meta.json
+++ b/src/data/proofs/erdos-1075/meta.json
@@ -205,6 +205,11 @@
       "id": "erdos-1078",
       "relationship": "thematic",
       "description": "Erdős #1078 (minimum degree for K_r in r-partite graphs, solved by Haxell 2001) uses threshold conditions on edge or degree density to force complete subgraphs. The structural threshold machinery — showing a density condition forces a specific substructure — is the same paradigm as Problem #1075, and the r-partite setting provides explicit constructions that could inform extremal examples."
+    },
+    {
+      "id": "szemeredi-regularity",
+      "relationship": "methodological",
+      "description": "The Szemerédi Regularity Lemma provides a structural decomposition of dense graphs and hypergraphs into quasi-random pie"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1076/meta.json
+++ b/src/data/proofs/erdos-1076/meta.json
@@ -227,6 +227,11 @@
       "id": "ramseys-theorem",
       "relationship": "related",
       "description": "Ramsey's theorem is the foundational extremal combinatorics result guaranteeing monochromatic cliques; the Brown-Erdős-Sós conjecture belongs to the broader program of quantifying how dense a hypergraph must be before a particular configuration is forced"
+    },
+    {
+      "id": "erdos-340",
+      "relationship": "related",
+      "description": "Problem #340 (Greedy Sidon Sequence) also concerns asymptotic extremal counts (Sidon sets) where the exact growth rate i"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1085/meta.json
+++ b/src/data/proofs/erdos-1085/meta.json
@@ -215,6 +215,11 @@
       "id": "erdos-95",
       "relationship": "related",
       "description": "Sum of squared distance multiplicities (#95) provides an algebraic complement: bounding Σ_d f_d(P)² relates to the energy of distance multisets and connects to the polynomial method used in Guth-Katz."
+    },
+    {
+      "id": "erdos-1007",
+      "relationship": "related",
+      "description": "Graph dimension (#1007) asks for the minimum number of edges in a graph realizable in ℝ^d with prescribed edge lengths, "
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -267,6 +267,26 @@
       "id": "ramseys-theorem",
       "relationship": "related",
       "description": "The distinct distances threshold $g_d(n)$ is a Ramsey-type quantity: it asks for the minimum set size guaranteeing a structured subset (many distinct distances). The polynomial lower bound $g_d(n) \\gg d^{n-1}$ parallels Ramsey-type tower growth phenomena in combinatorics"
+    },
+    {
+      "id": "szemeredi-regularity",
+      "relationship": "related",
+      "description": "Both are central results in combinatorial geometry/graph theory. Szemerédi's regularity lemma provides pseudorandom part"
+    },
+    {
+      "id": "borsuk-ulam",
+      "relationship": "related",
+      "description": "The Borsuk-Ulam theorem is a key topological tool in combinatorial geometry: it implies that any continuous map $S^n \\to"
+    },
+    {
+      "id": "minkowski-theorem",
+      "relationship": "related",
+      "description": "Minkowski's theorem on convex bodies and lattice points provides geometric constraints in Euclidean space relevant to di"
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "thematic",
+      "description": "Both concern fundamental geometric constraints in Euclidean space. The isoperimetric inequality (the sphere minimizes su"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -180,6 +180,11 @@
       "id": "bertrands-postulate",
       "relationship": "foundation",
       "description": "Bertrand's postulate guarantees primes in [n, 2n], relevant to bounding prime factors in the central binomial coefficient"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundation",
+      "description": "The combinatorial formula C(n,k) = n!/(k!(n-k)!) underlies all prime factor analysis of binomial coefficients"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -188,6 +188,11 @@
       "id": "prime-number-theorem",
       "relationship": "related",
       "description": "The Prime Number Theorem via Chebyshev's ψ-function gives log L_k = ψ(k) ~ k, establishing the asymptotic log L_k / k → "
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "The binomial coefficients C(n,k) are the central object of study: g(k) is the smallest n > k+1 where C(n,k) is k-rough. "
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -211,6 +211,31 @@
       "id": "prob-method-expectation",
       "relationship": "related",
       "description": "The first moment method underlies the $\\Omega(n^{3/2})$ lower bound on common differences: a random subset of $\\{1,\\ldots,N\\}$ of size $n$ has expected $\\sim cn^3/N$ three-term APs, distributed over $\\sim N$ possible common differences. The pigeonhole principle then shows at least $\\sim n^3/N^2$ distinct common differences occur, which for optimal $N \\sim n^2$ gives $\\Omega(n)$ — but more sophisticated counting via the second moment or Cauchy-Schwarz improves this to $\\Omega(n^{3/2})$"
+    },
+    {
+      "id": "arithmetic-series",
+      "relationship": "foundational",
+      "description": "Basic arithmetic series formulas underlie the counting of arithmetic progressions in intervals"
+    },
+    {
+      "id": "szemeredi-regularity",
+      "relationship": "related",
+      "description": "The regularity lemma provides pseudorandom decompositions used in counting arithmetic progressions. The 3-AP counting ap"
+    },
+    {
+      "id": "szemeredi-counting",
+      "relationship": "related",
+      "description": "The counting lemma quantifies substructure (including APs) in regular pairs. Counting 3-APs by common difference is the "
+    },
+    {
+      "id": "szemeredi-full",
+      "relationship": "related",
+      "description": "The full Szemerédi theorem guarantees $k$-term APs in dense sets for all $k$. This problem specializes to $k = 3$ but st"
+    },
+    {
+      "id": "prob-method-second-moment",
+      "relationship": "related",
+      "description": "The second moment method (Chebyshev/Paley-Zygmund inequalities) provides the concentration bounds needed to convert the "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-11/meta.json
+++ b/src/data/proofs/erdos-11/meta.json
@@ -203,6 +203,21 @@
       "id": "infinitude-primes",
       "relationship": "foundation",
       "description": "Euclid's infinitude of primes is a prerequisite; the Wieferich prime connection requires understanding prime distribution"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "The divergence of $\\sum 1/p$ relates to squarefree density: the density of squarefree numbers is $\\prod_p (1 - 1/p^2) = "
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate ensures primes in $(n, 2n]$; Erdős gave elementary proofs of both this and the density result for P"
+    },
+    {
+      "id": "erdos-1",
+      "relationship": "sibling",
+      "description": "Another Erdős problem formalization; Problem #1 concerns infinite Sidon sets, also connecting combinatorics with number "
     }
   ]
 }

--- a/src/data/proofs/erdos-1102/meta.json
+++ b/src/data/proofs/erdos-1102/meta.json
@@ -171,6 +171,11 @@
       "id": "erdos-11",
       "relationship": "related",
       "description": "Squarefree + Power of 2 (Erdős #11) studies whether every integer can be written as the sum of a squarefree number and a power of 2, another instance of Erdős's recurring interest in squarefree translates"
+    },
+    {
+      "id": "basel-problem",
+      "relationship": "foundational",
+      "description": "The Basel Problem establishes ζ(2) = π²/6, hence 1/ζ(2) = 6/π² is the density of squarefree integers — exactly the optim"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1109/meta.json
+++ b/src/data/proofs/erdos-1109/meta.json
@@ -240,6 +240,11 @@
       "id": "bertrands-postulate",
       "relationship": "related",
       "description": "Bertrand's postulate guarantees a prime in every interval [n, 2n], providing the density information about prime distribution that underpins sieve estimates for squarefree numbers used in the Erdős-Sárközy and Konyagin bounds."
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The prime number theorem governs the asymptotic density of primes and, via Euler's product formula, determines that the "
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1116/meta.json
+++ b/src/data/proofs/erdos-1116/meta.json
@@ -215,6 +215,11 @@
       "id": "erdos-516",
       "relationship": "foundational",
       "description": "Erdős #516 on gap series and the minimum modulus problem (Fabry gaps, solved by Fuchs 1963) establishes that lacunary power series have tightly controlled minimum modulus. The Weierstrass products and lacunary series used to construct the Gol'dberg–Toppila example in #1116 rely on this same structural theory."
+    },
+    {
+      "id": "erdos-514",
+      "relationship": "related",
+      "description": "Erdős #514 on growth of entire functions along paths (Boas) studies how fast f(z) can grow along curves to infinity. The"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1120/meta.json
+++ b/src/data/proofs/erdos-1120/meta.json
@@ -194,6 +194,11 @@
       "id": "erdos-1115",
       "relationship": "analogous",
       "description": "Problem #1115 asks for the growth rate of paths to infinity along which an entire function of finite order grows slowly "
+    },
+    {
+      "id": "erdos-509",
+      "relationship": "related",
+      "description": "Problem #509 asks whether the sublevel set {|f(z)| ≤ 1} of a degree-n monic polynomial can always be covered by discs wi"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1121/meta.json
+++ b/src/data/proofs/erdos-1121/meta.json
@@ -180,6 +180,11 @@
       "id": "kepler-conjecture",
       "relationship": "related",
       "description": "The Kepler Conjecture (Hales 1998) determines the densest sphere packing in ℝ³. While sphere packing asks how efficiently spheres can fill space, circle covering asks how efficiently a single sphere can cover a connected configuration. Both problems concern the geometry of spherical/circular configurations in ℝⁿ and extend naturally to higher dimensions, where the Goodman-Goodman theorem also holds for balls."
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "foundational",
+      "description": "The Area of a Circle formalizes basic circle geometry (radius, area, circumference) in Lean. The Goodman-Goodman theorem"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1125/meta.json
+++ b/src/data/proofs/erdos-1125/meta.json
@@ -196,6 +196,11 @@
       "id": "lebesgue-measure",
       "relationship": "foundational",
       "description": "Lebesgue measure is the foundation for Kemperman's 1969 partial result: measurability of f (in the Lebesgue sense) was the original hypothesis required to conclude monotonicity. Laczkovich's 1984 theorem removes this assumption, but understanding why measurability suffices — and why it is not necessary — requires the theory of Lebesgue null sets and the existence of non-measurable functions via the Axiom of Choice."
+    },
+    {
+      "id": "erdos-1124",
+      "relationship": "related",
+      "description": "Erdős #1124 (Tarski's Circle-Squaring Problem) was also resolved by Laczkovich — his 1990 theorem proving that a disk an"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1127/meta.json
+++ b/src/data/proofs/erdos-1127/meta.json
@@ -199,6 +199,11 @@
       "id": "cantor-diagonalization",
       "relationship": "foundational",
       "description": "Cantor's diagonal argument establishes that ℝ is uncountable (|ℝ| = 2^ℵ₀ > ℵ₀). This is the reason the decomposition in "
+    },
+    {
+      "id": "erdos-100",
+      "relationship": "thematic",
+      "description": "Erdős #100 studies finite planar point sets with all pairwise distances being integers (restricted distance sets), while"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-113/meta.json
+++ b/src/data/proofs/erdos-113/meta.json
@@ -209,6 +209,11 @@
       "id": "erdos-133",
       "relationship": "thematic",
       "description": "Problem #133 studies maximum degree in triangle-free diameter-2 graphs, with answer f(n) = Θ(√n). The Kővári-Sós-Turán bound ex(n; K_{2,2}) = O(n^{3/2}) that anchors #113's threshold is also fundamental to degree/diameter trade-offs studied in #133."
+    },
+    {
+      "id": "ramseys-theorem",
+      "relationship": "foundational",
+      "description": "Ramsey's theorem provides the foundational framework for forbidden subgraph problems. The extremal number ex(n;H) studie"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1141/meta.json
+++ b/src/data/proofs/erdos-1141/meta.json
@@ -222,6 +222,11 @@
     {
       "id": "erdos-680",
       "relationship": "Shares the quadratic–primality boundary theme; squares and prime factors interact in analogous ways"
+    },
+    {
+      "id": "erdos-17",
+      "relationship": "thematic",
+      "description": "Erdős #17 on cluster primes asks whether every even n ≤ p − 3 is a difference of two primes ≤ p. The structural idea of "
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -397,6 +397,41 @@
       "id": "erdos-1010",
       "relationship": "related",
       "description": "Triangle supersaturation counts triangles in graphs with more than Turán-many edges. The triangle removal process starts from the complete graph (maximum supersaturation) and greedily reduces triangles to zero — the edge count at termination is governed by the rate of triangle depletion, connecting supersaturation bounds to the removal process dynamics"
+    },
+    {
+      "id": "erdos-1104",
+      "relationship": "related",
+      "description": "Maximum chromatic number of triangle-free graphs: the terminal graph of the triangle removal process is triangle-free, s"
+    },
+    {
+      "id": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemerédi's theorem on arithmetic progressions in dense sets is a cornerstone of additive combinatorics. The triangle re"
+    },
+    {
+      "id": "roth-theorem-k3",
+      "relationship": "related",
+      "description": "The triangle removal lemma — a key consequence of Szemerédi regularity — states that graphs with o(n³) triangles can be "
+    },
+    {
+      "id": "szemeredi-counting",
+      "relationship": "related",
+      "description": "Szemerédi's counting lemma quantifies triangle density in ε-regular triples: if (A, B, C) are pairwise ε-regular with ed"
+    },
+    {
+      "id": "prob-method-alteration",
+      "relationship": "related",
+      "description": "The alteration method (Erdős 1963) constructs combinatorial objects by starting with a random structure and modifying it"
+    },
+    {
+      "id": "prob-method-lovasz-local",
+      "relationship": "related",
+      "description": "The Lovász Local Lemma provides bounds on the probability that no 'bad event' occurs when events have limited dependency"
+    },
+    {
+      "id": "prob-method-second-moment",
+      "relationship": "related",
+      "description": "The second moment method bounds P(X > 0) via E[X]²/E[X²], providing concentration for the triangle count during the remo"
     }
   ]
 }

--- a/src/data/proofs/erdos-1157/meta.json
+++ b/src/data/proofs/erdos-1157/meta.json
@@ -180,6 +180,11 @@
       "id": "erdos-1155",
       "relationship": "technique",
       "description": "Problem #1155 (triangle removal process) involves the Triangle Removal Lemma, which is the key technique for the (6,3)-case of the BES conjecture"
+    },
+    {
+      "id": "erdos-1078",
+      "relationship": "related",
+      "description": "Problem #1078 (minimum degree for K_r in r-partite graphs) studies BES-type thresholds in the multipartite setting, solv"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1170/meta.json
+++ b/src/data/proofs/erdos-1170/meta.json
@@ -242,6 +242,26 @@
       "id": "cantor-diagonalization-oq-02-oq-01",
       "relationship": "prerequisite",
       "description": "Properties of ω₁ (aleph hierarchy, regularity, cofinality) used in the ordinal setup and cardinal arithmetic"
+    },
+    {
+      "id": "erdos-1014",
+      "relationship": "thematic",
+      "description": "Ramsey number ratio convergence — finite counterpart to the infinite partition calculus studied here"
+    },
+    {
+      "id": "ramseys-theorem",
+      "relationship": "prerequisite",
+      "description": "Ramsey's theorem is the finite foundation of partition calculus; Problem #1170 asks about its transfinite generalization"
+    },
+    {
+      "id": "erdos-szekeres",
+      "relationship": "thematic",
+      "description": "The Erdős-Szekeres theorem on monotone subsequences is a classical application of Ramsey theory — the same combinatorial"
+    },
+    {
+      "id": "partition-theorem",
+      "relationship": "prerequisite",
+      "description": "General partition theorem formalization — the finite partition calculus that Problem #1170 generalizes to uncountable or"
     }
   ]
 }

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -204,6 +204,31 @@
       "id": "erdos-4",
       "relationship": "related",
       "description": "Erdős #4 concerns the additive structure of sets with constraints on sums and differences. Like #143, it asks how algebraic constraints (here dilation-avoidance, there sum-free conditions) force sparseness of the underlying set"
+    },
+    {
+      "id": "erdos-36",
+      "relationship": "related",
+      "description": "Both are Erdős problems about density constraints on number-theoretic sets. #36 concerns sets avoiding arithmetic progre"
+    },
+    {
+      "id": "roth-theorem-k3",
+      "relationship": "related",
+      "description": "Roth's theorem bounds the density of sets avoiding 3-term arithmetic progressions. Like #143, it shows that a combinator"
+    },
+    {
+      "id": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemerédi's theorem (sets of positive upper density contain arbitrarily long arithmetic progressions) provides the parad"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate (there is always a prime between $n$ and $2n$) implies that primes have positive lower density in l"
+    },
+    {
+      "id": "erdos-25",
+      "relationship": "related",
+      "description": "Erdős #25 concerns the distribution of prime gaps. Both #25 and #143 study how number-theoretic constraints affect the s"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-17/meta.json
+++ b/src/data/proofs/erdos-17/meta.json
@@ -214,6 +214,16 @@
       "id": "dirichlets-theorem",
       "relationship": "related",
       "description": "Dirichlet's theorem guarantees primes in arithmetic progressions have positive relative density $1/\\varphi(d)$; the formalization proves cluster primes are rarer than primes in any fixed AP, highlighting how extreme the cluster sparsity condition is"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "uses",
+      "description": "The prime number theorem $\\pi(x) \\sim x/\\log x$ is needed to interpret the Blecksmith-Erdős-Selfridge and Elsholtz upper"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate guarantees a prime in $(n, 2n)$, bounding prime gaps from above. Small prime gaps help the cluster "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-205/meta.json
+++ b/src/data/proofs/erdos-205/meta.json
@@ -217,6 +217,16 @@
       "id": "erdos-9",
       "relationship": "related",
       "description": "Both concern representations involving powers of 2: #9 asks about p + 2^k + 2^l, #205 asks about 2^k + m with Ω constraints"
+    },
+    {
+      "id": "chinese-remainder-constructive",
+      "relationship": "uses",
+      "description": "The Chinese Remainder Theorem underlies the covering system construction: simultaneous congruences mod {3,5,7,13,17,241}"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The Erdős-Kac theorem (axiomatized here) is a number-theoretic analogue of the CLT: Ω(n) is asymptotically Gaussian, par"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -259,6 +259,16 @@
       "id": "erdos-100",
       "relationship": "related",
       "description": "Point sets with restricted distances: n points in ℝ² with distance constraints, sharing the distance geometry framework"
+    },
+    {
+      "id": "erdos-107",
+      "relationship": "related",
+      "description": "The Happy Ending problem: convex n-gons in point sets, related Ramsey-type existence of geometric configurations"
+    },
+    {
+      "id": "erdos-705",
+      "relationship": "related",
+      "description": "Unit distance graphs with large girth: chromatic number of unit distance graphs under girth constraints"
     }
   ]
 }

--- a/src/data/proofs/erdos-235/meta.json
+++ b/src/data/proofs/erdos-235/meta.json
@@ -191,6 +191,11 @@
       "id": "",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "foundation",
+      "description": "The sum Σ(1/log x) ~ n/log n asymptotic and average gap growth both depend on the prime number theorem and Mertens' theo"
     }
   ]
 }

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -229,6 +229,11 @@
       "id": "erdos-41",
       "relationship": "extends",
       "description": "Problem #41 on $B_h$ sequence density bounds generalizes Sidon sets to higher-order representation constraints. The Erdős-Turán conjecture on bases of order 2 connects directly to whether $B_2[g]$ sets can be bases — Problem #28 implies they cannot"
+    },
+    {
+      "id": "erdos-42",
+      "relationship": "related",
+      "description": "Problem #42 on Sidon sets with disjoint difference sets explores the structure theory of $B_2$ sets, the same objects wh"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-305/meta.json
+++ b/src/data/proofs/erdos-305/meta.json
@@ -204,6 +204,21 @@
       "id": "erdos-309",
       "relationship": "related",
       "description": "Counting representable integers from unit fractions, F(N) = Θ(log N) via Yokota-Croot"
+    },
+    {
+      "id": "erdos-300",
+      "relationship": "related",
+      "description": "Maximum subsets avoiding unit fraction sum equal to 1 (Liu-Sawhney 2024)"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "Foundational result H_n ~ log n explaining why logarithms appear in D(b) bounds"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "Euler's theorem ∑1/p = ∞, underlying the prime structure in Egyptian fraction bounds"
     }
   ]
 }

--- a/src/data/proofs/erdos-331/meta.json
+++ b/src/data/proofs/erdos-331/meta.json
@@ -253,6 +253,26 @@
       "id": "arithmetic-series",
       "relationship": "foundational",
       "description": "Arithmetic progressions and their common differences are the central objects. The difference set $A - A$ is precisely the set of common differences of 2-term APs in $A$"
+    },
+    {
+      "id": "roth-theorem-k3",
+      "relationship": "related",
+      "description": "Both study density thresholds for additive structure. Roth's theorem shows density $\\gg N/\\log\\log N$ forces 3-term APs;"
+    },
+    {
+      "id": "erdos-30",
+      "relationship": "related",
+      "description": "Ruzsa's counterexample sets have Sidon-like properties ($|A - A| \\sim |A|$), connecting to Erdős #30 on $B_2$ sequences "
+    },
+    {
+      "id": "erdos-1145",
+      "relationship": "related",
+      "description": "Problem #1145 (Erdős–Sárközy conjecture) cites Ruzsa's counterexample from #331 to show the ratio condition $a_n/b_n \\to"
+    },
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "Problem #28 (Erdős–Turán conjecture on additive bases) is the $A = B$ case of the two-set conjecture #1145. Ruzsa's coun"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -277,6 +277,21 @@
       "id": "szemeredi-theorem",
       "relationship": "related",
       "description": "Szemeredi's theorem (dense sets contain arbitrarily long APs) and Sidon theory represent dual aspects of additive combinatorics: Szemeredi limits how unstructured a dense set can be, while Sidon theory limits how dense an unstructured set can be"
+    },
+    {
+      "id": "prob-method-expectation",
+      "relationship": "related",
+      "description": "The probabilistic method shows random Sidon sets achieve density N^(1/2), near-optimal. This provides the comparison ben"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The bijection orderedPairsLt_card_via_choose uses C(n,2) = n(n-1)/2 via Finset.card_powersetCard. This binomial coeffici"
+    },
+    {
+      "id": "partition-theorem",
+      "relationship": "related",
+      "description": "Each element of the sumset A+A of a Sidon set has a unique representation a+b with a <= b — a partition-like uniqueness "
     }
   ]
 }

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -257,6 +257,31 @@
       "id": "roth-theorem-k3",
       "relationship": "related",
       "description": "Both use Fourier-analytic methods on finite sets of integers. Roth's theorem counts 3-term APs via the Fourier transform; the minimum overlap problem reduces to convex optimization over Fourier coefficients. The same machinery (Parseval's identity, energy bounds) drives both results"
+    },
+    {
+      "id": "erdos-1",
+      "relationship": "related",
+      "description": "Both are extremal problems on subsets of integers: #1 asks for maximum-size sets with distinct subset sums, #36 asks for"
+    },
+    {
+      "id": "erdos-35",
+      "relationship": "related",
+      "description": "Both concern additive structure in integer subsets: #35 studies Schnirelmann density and when sets form additive bases ("
+    },
+    {
+      "id": "erdos-37",
+      "relationship": "related",
+      "description": "Neighboring Erdős problem on essential components and lacunary sets in additive number theory. Both #36 and #37 probe th"
+    },
+    {
+      "id": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemerédi's theorem on arithmetic progressions in dense sets and the regularity lemma underpin potential approaches to t"
+    },
+    {
+      "id": "prob-method-expectation",
+      "relationship": "related",
+      "description": "The first moment method provides the baseline lower bound on the minimum overlap: a random equal partition of $\\{1,\\ldot"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -237,6 +237,31 @@
       "id": "fundamental-arithmetic",
       "relationship": "foundational",
       "description": "Unique prime factorization is the foundation of smooth number theory: P⁺(n) (the largest prime factor) is well-defined by FTA, and smoothness is defined in terms of the factorization structure that FTA guarantees"
+    },
+    {
+      "id": "erdos-143",
+      "relationship": "related",
+      "description": "Erdős #143 studies dilation-avoiding sets, another problem where prime factorization structure controls combinatorial de"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate guarantees a prime in (n, 2n). Erdős #369 asks a complementary question: are there consecutive comp"
+    },
+    {
+      "id": "erdos-371",
+      "relationship": "related",
+      "description": "Erdős #371 studies the density of integers where $P^+(n) < P^+(n+1)$ (the largest prime factor increases). Both #369 and"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes is foundational: smooth numbers are defined by having all prime factors below a threshold, and "
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "foundational",
+      "description": "Stirling's approximation $k! \\sim \\sqrt{2\\pi k}(k/e)^k$ is essential to the Dickman function analysis: the differential-"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-386/meta.json
+++ b/src/data/proofs/erdos-386/meta.json
@@ -170,6 +170,11 @@
       "id": "bertrands-postulate",
       "relationship": "related",
       "description": "Bertrand's postulate ($\\exists$ prime in $(n, 2n)$) constrains prime gaps and hence the spacing of consecutive prime products. For large $n$, the gap between consecutive primes ensures primorial quotients grow rapidly"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization is the basis for asking whether $\\binom{n}{k}$ equals a product of consecutive primes — witho"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-4/meta.json
+++ b/src/data/proofs/erdos-4/meta.json
@@ -316,6 +316,31 @@
       "id": "dirichlets-theorem",
       "relationship": "related",
       "description": "Dirichlet's theorem on primes in arithmetic progressions is used in Rankin's construction: to create large prime-free intervals, one exploits that primes in specific residue classes can be avoided, requiring control over how primes distribute in progressions"
+    },
+    {
+      "id": "erdos-1",
+      "relationship": "complement",
+      "description": "Erdős #1 concerns small gaps between primes (Bertrand's postulate), the complementary question to the large gaps studied"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate gives p_{n+1} < 2p_n, a weak upper bound on prime gaps that contrasts with the large gaps studied h"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes is a prerequisite for studying prime gaps — the problem only makes sense because there are infi"
+    },
+    {
+      "id": "erdos-6",
+      "relationship": "related",
+      "description": "Erdős #6 studies related questions about prime gap statistics. Together #4, #5, and #6 form a cluster of Erdős problems "
+    },
+    {
+      "id": "bounded-prime-gaps-oq-03",
+      "relationship": "complementary",
+      "description": "Large gaps (this entry) and bounded gaps (OQ-03 on Engelsma's optimal 246 bound) are dual perspectives on prime gap dist"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -160,6 +160,16 @@
       "id": "erdos-1",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "szemeredi-regularity",
+      "relationship": "foundational",
+      "description": "The Szemerédi regularity lemma is a fundamental tool in additive combinatorics that provides structural decompositions o"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "The binomial theorem underlies the probabilistic random-set heuristic in Problem #40: the expected number of representat"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -201,6 +201,31 @@
       "id": "prime-number-theorem",
       "relationship": "foundational",
       "description": "The PNT controls prime distribution governing tau(n); the Dirichlet divisor problem provides the average-case behavior of h(n) = n + tau(n)"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "Both involve fundamental multiplicative arithmetic functions: $\\tau(n)$ counts all divisors while Euler's $\\phi(n)$ coun"
+    },
+    {
+      "id": "erdos-415",
+      "relationship": "related",
+      "description": "Erdős #415 studies ordering patterns in $\\varphi(n)$. Both $\\tau$ and $\\varphi$ are multiplicative functions whose local"
+    },
+    {
+      "id": "perfect-numbers",
+      "relationship": "related",
+      "description": "Perfect numbers satisfy $\\sigma(n) = 2n$, making them fixed points of the iteration $n \\mapsto \\sigma(n) - n$. The open "
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The average of $\\tau(n)$ over $[1, N]$ is $\\sim \\log N$ (Dirichlet's divisor problem), so the iteration $h(n) = n + \\tau"
+    },
+    {
+      "id": "riemann-hypothesis",
+      "relationship": "thematic",
+      "description": "The Riemann Hypothesis controls the error term in the Dirichlet divisor problem ($\\sum_{n \\leq N} \\tau(n) = N\\log N + O("
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -279,6 +279,21 @@
       "id": "stirling-formula",
       "relationship": "related-problem",
       "description": "Stirling gives log(n!) ~ n log n; the asymptotics log τ(n!) ~ n log n / log log n involve an extra log log n factor from the prime structure of n!."
+    },
+    {
+      "id": "erdos-400",
+      "relationship": "related-problem",
+      "description": "Both study divisibility and growth properties of factorial-related quantities, exploring how the rich prime factorizatio"
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "uses-result",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions guarantees infinitely many n+1 = pk for each fixed k, ensuring "
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "related-problem",
+      "description": "The prime number theorem underlies the density estimates for primes p with n+1 = pk, and Mertens' theorem (a consequence"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-432/meta.json
+++ b/src/data/proofs/erdos-432/meta.json
@@ -232,6 +232,21 @@
       "id": "fundamental-arithmetic",
       "relationship": "foundational",
       "description": "Unique prime factorization is the key structural tool: pairwise coprimality of sumset elements forces their prime factorizations to be disjoint, and the counting argument relies on the unique factorization to bound the number of primes available"
+    },
+    {
+      "id": "gcd-algorithm",
+      "relationship": "supports",
+      "description": "The GCD algorithm is the computational tool for checking pairwise coprimality $\\gcd(x,y) = 1$, the central constraint in"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient $\\varphi(n)$ counts integers coprime to $n$, the same coprimality concept central to #432. The density o"
+    },
+    {
+      "id": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "CRT constructs integers with prescribed remainders modulo coprime moduli — the same coprimality machinery. Building pair"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-441/meta.json
+++ b/src/data/proofs/erdos-441/meta.json
@@ -260,6 +260,21 @@
       "id": "erdos-534",
       "relationship": "related",
       "description": "Ahlswede-Khachatrian characterization of sets with pairwise gcd > 1; dual problem via the GCD-LCM identity lcm(a,b) = ab/gcd(a,b)"
+    },
+    {
+      "id": "erdos-487",
+      "relationship": "related",
+      "description": "Kleitman's 1971 theorem: dense sets must contain a,b,c with lcm(a,b)=c; connects LCM constraints to density-Ramsey theor"
+    },
+    {
+      "id": "erdos-402",
+      "relationship": "related",
+      "description": "Graham's GCD conjecture (solved): for any set A, ∃a,b with gcd(a,b) ≤ a/|A|; uses divisibility structure underlying LCM "
+    },
+    {
+      "id": "gcd-algorithm",
+      "relationship": "related",
+      "description": "Fundamental Euclidean algorithm for computing gcd; the core operation underlying the LCM constraint lcm(a,b) = ab/gcd(a,"
     }
   ]
 }

--- a/src/data/proofs/erdos-444/meta.json
+++ b/src/data/proofs/erdos-444/meta.json
@@ -217,6 +217,21 @@
       "id": "euler-totient",
       "relationship": "related",
       "description": "Both involve fundamental multiplicative arithmetic functions: $\\tau(n)$ and its generalizations $d_A(n)$ count divisors, while $\\phi(n)$ counts coprime residues. The multiplicativity property $f(mn) = f(m)f(n)$ for $\\gcd(m,n)=1$ is key to both"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The extremal construction uses products of primes from A with optimized exponents. The infinitude of primes guarantees a"
+    },
+    {
+      "id": "perfect-numbers",
+      "relationship": "related",
+      "description": "Perfect numbers are extremal for the sum-of-divisors function $\\sigma(n) = 2n$. The generalized divisor function $\\tau_A"
+    },
+    {
+      "id": "erdos-413",
+      "relationship": "related",
+      "description": "Erdős #413 studies barriers for $\\omega(n)$ (distinct prime factor count). The generalized divisor function $\\tau_A(n)$ "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-465/meta.json
+++ b/src/data/proofs/erdos-465/meta.json
@@ -250,6 +250,16 @@
       "id": "erdos-254",
       "relationship": "related",
       "description": "Connects additive combinatorics with Diophantine approximation: subset sum representation involving fractional parts {θn}"
+    },
+    {
+      "id": "erdos-1127",
+      "relationship": "related",
+      "description": "Set-theoretic variant on distance constraints: decomposing ℝⁿ into countably many sets with distinct pairwise distances,"
+    },
+    {
+      "id": "erdos-1000",
+      "relationship": "related",
+      "description": "Uses Diophantine approximation techniques: generalized totient φ_A with Cesàro averages and fraction denominators, solve"
     }
   ]
 }

--- a/src/data/proofs/erdos-500/meta.json
+++ b/src/data/proofs/erdos-500/meta.json
@@ -207,6 +207,16 @@
       "id": "szemeredi-regularity",
       "relationship": "related",
       "description": "Szemerédi's regularity lemma is the key structural tool in extremal graph theory. While it applies to graphs (2-uniform)"
+    },
+    {
+      "id": "erdos-1",
+      "relationship": "related",
+      "description": "Erdős #1 (distinct subset sums) is another flagship Erdős problem in combinatorics. Both exemplify the characteristic Er"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "The binomial coefficient C(n,3) normalizes the Turán density π(K₄³) = lim ex₃(n)/C(n,3). The combinatorial identity C(n,"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -201,6 +201,16 @@
       "id": "law-of-cosines",
       "relationship": "foundational",
       "description": "The law of cosines $c^2 = a^2 + b^2 - 2ab\\cos C$ provides the algebraic foundation for computing angles between points via the dot product formula used to define $\\angle(x,y,z)$"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem underpins the Euclidean norm $\\|v\\| = \\sqrt{v_1^2 + v_2^2}$ used in the angle definition $\\angle"
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "thematic",
+      "description": "The inscribed angle theorem — central to proving regular polygon optimality for $\\alpha_{2^n}$ — is intimately connected"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-596/meta.json
+++ b/src/data/proofs/erdos-596/meta.json
@@ -268,6 +268,31 @@
       "id": "erdos-544",
       "relationship": "related",
       "description": "Problem #544 studies consecutive Ramsey number differences, another question about the fine structure of Ramsey theory. "
+    },
+    {
+      "id": "erdos-1009",
+      "relationship": "related",
+      "description": "Problem #1009 concerns edge-disjoint triangles beyond the Turán threshold, connecting to the extremal graph theory that "
+    },
+    {
+      "id": "erdos-1010",
+      "relationship": "related",
+      "description": "Triangle supersaturation (#1010) is the quantitative backbone of Ramsey-type forcing: once edge density exceeds the Turá"
+    },
+    {
+      "id": "erdos-637",
+      "relationship": "related",
+      "description": "Problem #637 studies distinct degrees in induced subgraphs, a Ramsey-theoretic question about structural properties forc"
+    },
+    {
+      "id": "erdos-905",
+      "relationship": "related",
+      "description": "Edge-triangle multiplicity above the Turán threshold (#905) quantifies how many triangles share edges in dense graphs. T"
+    },
+    {
+      "id": "prob-method-lovasz-local",
+      "relationship": "technique",
+      "description": "The Lovász Local Lemma is a key probabilistic tool for constructing colorings that avoid forbidden monochromatic subgrap"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -261,6 +261,16 @@
       "id": "erdos-108",
       "relationship": "related",
       "description": "High chromatic subgraphs with large girth: chromatic number and clique/color structure, related to the interplay between cliques and independent sets"
+    },
+    {
+      "id": "erdos-612",
+      "relationship": "related",
+      "description": "Sister problem: diameter bounds for K_r-free graphs, extending clique-free constraints to diameter properties of graphs"
+    },
+    {
+      "id": "erdos-54",
+      "relationship": "related",
+      "description": "Foundational Ramsey theory (2-complete sets): the Ramsey-theoretic framework underpinning Kim's theorem R(3,k) = Θ(k²/lo"
     }
   ]
 }

--- a/src/data/proofs/erdos-648/meta.json
+++ b/src/data/proofs/erdos-648/meta.json
@@ -302,6 +302,11 @@
       "id": "erdos-4",
       "relationship": "related",
       "description": "Both are solved Erdős problems involving prime distribution asymptotics. Erdős #4 (large prime gaps, solved by Maynard 2"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "The divergence $\\sum_{p} 1/p = \\infty$ (Euler, 1737) implies the set of primes is dense enough to support arbitrarily lo"
     }
   ]
 }

--- a/src/data/proofs/erdos-680/meta.json
+++ b/src/data/proofs/erdos-680/meta.json
@@ -283,6 +283,11 @@
       "id": "erdos-648",
       "relationship": "related",
       "description": "Erdős #648 studies the greatest prime factor $P(n)$ while #680 studies the least prime factor $p(n)$. They are dual perspectives on the same arithmetic function: the prime factorization structure of integers near $n$."
+    },
+    {
+      "id": "erdos-1055",
+      "relationship": "related",
+      "description": "Erdős #1055 classifies primes by smoothness of $p+1$, connecting to the least prime factor of $p + 1$. Both problems rel"
     }
   ]
 }

--- a/src/data/proofs/erdos-683/meta.json
+++ b/src/data/proofs/erdos-683/meta.json
@@ -294,6 +294,11 @@
       "id": "bertrands-postulate",
       "relationship": "related",
       "description": "foundation"
+    },
+    {
+      "id": "erdos-961",
+      "relationship": "related",
+      "description": "equivalent"
     }
   ]
 }

--- a/src/data/proofs/erdos-737/meta.json
+++ b/src/data/proofs/erdos-737/meta.json
@@ -155,6 +155,11 @@
       "id": "four-color-theorem",
       "relationship": "thematic",
       "description": "The four-color theorem ($\\chi(G) \\leq 4$ for planar graphs) concerns finite chromatic bounds, while Erdős #737 concerns "
+    },
+    {
+      "id": "ramanujan-sum-fallacy",
+      "relationship": "thematic",
+      "description": "Both results involve infinite structures producing surprising finite-like behavior: Ramanujan's sum assigns finite value"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-766/meta.json
+++ b/src/data/proofs/erdos-766/meta.json
@@ -238,6 +238,11 @@
       "id": "erdos-765",
       "relationship": "related",
       "description": "Adjacent Erdős problem studying related extremal graph theory questions about edge density thresholds"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The binomial coefficient C(n,2) = n(n-1)/2 counts the maximum possible edges in an n-vertex graph and appears throughout"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-794/meta.json
+++ b/src/data/proofs/erdos-794/meta.json
@@ -249,6 +249,16 @@
       "id": "erdos-1008",
       "relationship": "related",
       "description": "C₄-free subgraphs via dependent random choice (Conlon-Fox-Sudakov 2014): extremal graph theory using probabilistic methods for forbidden subgraph problems"
+    },
+    {
+      "id": "erdos-1021",
+      "relationship": "related",
+      "description": "Extremal numbers for bipartite pair graphs: Turán-type bounds beyond Kővári-Sós-Turán, sharing the forbidden subgraph de"
+    },
+    {
+      "id": "erdos-1017",
+      "relationship": "related",
+      "description": "Clique partition of graph edges (Erdős-Goodman-Pósa 1966): minimum cliques to partition edges, with K₄-free case by Győr"
     }
   ]
 }

--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -272,6 +272,31 @@
       "id": "roth-theorem-k3",
       "relationship": "technique",
       "description": "Roth's theorem on 3-term arithmetic progressions shares additive combinatorics foundations; Fourier-analytic and energy "
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "context",
+      "description": "The Erdős multiplication table problem (which proves the log factor in Problem #818 is tight) uses the prime number theo"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "context",
+      "description": "The logarithmic factor in Solymosi's bound reflects the same log-growth that appears in the harmonic series; the multipl"
+    },
+    {
+      "id": "prob-method-second-moment",
+      "relationship": "technique",
+      "description": "The energy method in Problem #818 is analogous to second-moment arguments: multiplicative energy counts pair collisions,"
+    },
+    {
+      "id": "erdos-801",
+      "relationship": "related",
+      "description": "Both are Erdős problems in combinatorial number theory concerning expansion properties of finite sets"
+    },
+    {
+      "id": "erdos-4",
+      "relationship": "context",
+      "description": "Problem #4 on prime gaps uses analytic number theory tools; the multiplication table problem connecting to Problem #818'"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-987/meta.json
+++ b/src/data/proofs/erdos-987/meta.json
@@ -222,6 +222,11 @@
       "id": "erdos-995",
       "relationship": "related-problem",
       "description": "Lacunary sequences and fractional parts: the quasi-independence from exponential gaps prevents accumulation, relating to how #987's bounds depend on sequence structure."
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "foundation",
+      "description": "Fourier series convergence via Parseval's theorem provides the foundational harmonic analysis on which all exponential s"
     }
   ]
 }

--- a/src/data/proofs/erdos-989/meta.json
+++ b/src/data/proofs/erdos-989/meta.json
@@ -266,6 +266,11 @@
       "id": "fourier-series",
       "relationship": "related",
       "description": "Foundational Fourier series theory underpinning Beck's Fourier-analytic lower bound proof"
+    },
+    {
+      "id": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Roth's theorem (k=3 case) connects to Roth's earlier rectangle discrepancy lower bound (1954)"
     }
   ]
 }

--- a/src/data/proofs/erdos-996/meta.json
+++ b/src/data/proofs/erdos-996/meta.json
@@ -280,6 +280,16 @@
       "id": "fourier-series",
       "relationship": "related",
       "description": "Foundational Fourier series theory: partial sums, Parseval's identity, L² approximation"
+    },
+    {
+      "id": "laws-of-large-numbers",
+      "relationship": "related",
+      "description": "Core probability foundation: the weak and strong laws of large numbers that this problem generalizes to lacunary samplin"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "related",
+      "description": "Related limit theorem; the exponent c > 1/2 in Matsuyama's result is reminiscent of CLT variance scaling"
     }
   ]
 }

--- a/src/data/proofs/euler-identity/meta.json
+++ b/src/data/proofs/euler-identity/meta.json
@@ -301,6 +301,61 @@
       "id": "fundamental-theorem-algebra",
       "relationship": "related",
       "description": "Euler's formula $e^{2\\pi ik/n}$ generates the $n$th roots of unity — the roots of $z^n - 1$. FTA guarantees these $n$ roots exist in $\\mathbb{C}$, and Euler's formula provides them explicitly, giving the cleanest demonstration that $\\mathbb{C}$ is algebraically closed for cyclotomic polynomials"
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "related",
+      "description": "The same $\\pi$ that appears in Euler's identity as the half-period of $e^{i\\theta}$ also appears in $A = \\pi r^2$. The d"
+    },
+    {
+      "id": "hermite-lindemann",
+      "relationship": "related",
+      "description": "The Hermite-Lindemann theorem ($e^\\alpha$ is transcendental for nonzero algebraic $\\alpha$) means $e^{i\\pi}$ is transcen"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "related",
+      "description": "Primitive $n$th roots of unity $\\zeta_n = e^{2\\pi i/n}$ are the fundamental building blocks of cyclotomic fields. Euler'"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Both concern the exponential function and polynomial roots: Euler's formula expresses roots of unity $e^{2\\pi ik/n}$ as "
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "Euler's formula $e^{ix} = \\cos x + i\\sin x$ is derived by integrating the ODE $f'(x) = if(x)$ with $f(0) = 1$ — a direct"
+    },
+    {
+      "id": "gelfond-schneider",
+      "relationship": "related",
+      "description": "The Gelfond-Schneider theorem proves $\\alpha^\\beta$ is transcendental for algebraic $\\alpha \\neq 0,1$ and irrational alg"
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "foundational",
+      "description": "De Moivre's theorem $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$ is an immediate corollary of Euler's"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Gauss sums $g(\\chi) = \\sum_{a=0}^{p-1} \\chi(a) e^{2\\pi i a/p}$ — defined using Euler's formula — are the key tool in pro"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's formula $n! \\sim \\sqrt{2\\pi n}(n/e)^n$ contains both $e$ and $\\pi$ — the same constants in Euler's identity $"
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "foundational",
+      "description": "Fourier series $f(x) = \\sum_{n=-\\infty}^{\\infty} c_n e^{inx}$ are built entirely on Euler's formula $e^{ix} = \\cos x + i"
+    },
+    {
+      "id": "de-moivre-oq-01",
+      "relationship": "extended-by",
+      "description": "Extends de Moivre's theorem to Chebyshev polynomials: $\\cos(n\\theta) = T_n(\\cos\\theta)$ and $\\sin(n\\theta) = \\sin\\theta "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -200,6 +200,21 @@
       "id": "wilsons-theorem",
       "relationship": "related",
       "description": "Wilson's theorem $(p-1)! \\equiv -1 \\pmod{p}$ and Euler's theorem $a^{\\varphi(n)} \\equiv 1$ both describe the multiplicative group $(\\mathbb{Z}/n\\mathbb{Z})^*$. Wilson gives the product of all elements; Euler gives the exponent of any single element. For $n = p$ prime, $\\varphi(p) = p-1$, recovering Fermat's little theorem"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The Legendre symbol $(a/p)$ and quadratic residues are studied via $a^{(p-1)/2}$ (Euler's criterion), a direct consequen"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "related",
+      "description": "A primitive root mod $n$ is a generator of $(\\mathbb{Z}/n\\mathbb{Z})^*$, which has order $\\varphi(n)$. The existence of "
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "related",
+      "description": "The average order of $\\varphi(n)$ is $\\frac{6}{\\pi^2} n$ (a consequence of PNT and the Euler product $\\varphi(n)/n = \\pr"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/factor-remainder-theorem/meta.json
+++ b/src/data/proofs/factor-remainder-theorem/meta.json
@@ -235,6 +235,41 @@
       "id": "gcd-algorithm",
       "relationship": "related",
       "description": "The Euclidean algorithm for polynomial GCD computes $\\gcd(p,q)$ by repeated division with remainder — each step applies "
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "related",
+      "description": "The binomial theorem expands $(x-a)^n$ and provides the standard form for polynomial powers. Combined with the Factor Th"
+    },
+    {
+      "id": "solution-of-cubic",
+      "relationship": "extends",
+      "description": "Cardano's cubic formula finds one root; the Factor Theorem then reduces the cubic to a quadratic by dividing out $(x - \\"
+    },
+    {
+      "id": "general-quartic",
+      "relationship": "extends",
+      "description": "Ferrari's quartic solution, like Cardano's cubic, uses root-finding followed by factoring out linear terms via the Facto"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "analogous",
+      "description": "Unique factorization of polynomials into irreducible factors over a field ($F[x]$ is a UFD) parallels unique prime facto"
+    },
+    {
+      "id": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "The Chinese Remainder Theorem for polynomials says $R[x]/(f_1 \\cdots f_k) \\cong \\prod R[x]/(f_i)$ when the $f_i$ are pai"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "related",
+      "description": "The proof that a degree-$n$ polynomial has at most $n$ roots uses strong induction on degree, with the Factor Theorem as"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "related",
+      "description": "Lagrange's theorem on subgroup orders and the Factor Theorem both concern divisibility structures. More directly, Lagran"
     }
   ],
   "references": [

--- a/src/data/proofs/fermat-two-squares/meta.json
+++ b/src/data/proofs/fermat-two-squares/meta.json
@@ -241,6 +241,31 @@
       "id": "euler-totient",
       "relationship": "related",
       "description": "Euler's criterion ($a^{(p-1)/2} \\equiv \\left(\\frac{a}{p}\\right) \\pmod{p}$) determines whether $-1$ is a QR mod $p$: $(-1"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique factorization in $\\mathbb{Z}[i]$ (the Gaussian integers form a UFD) implies the uniqueness of the two-square repr"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "related",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions (generalizing the infinitude of primes) guarantees infinitely m"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "Pythagorean triples $(a,b,c)$ with $a^2+b^2 = c^2$ are intimately connected to the two-squares theorem: a prime $p$ divi"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Both theorems concern the arithmetic of algebraic number rings: Fermat's theorem uses $\\mathbb{Z}[i]$ (norm $a^2+b^2$), "
+    },
+    {
+      "id": "elementary-quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Elementary QR provides the criterion $\\left(\\frac{-1}{p}\\right) = (-1)^{(p-1)/2}$ which directly determines whether $p$ "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -230,6 +230,51 @@
       "id": "pythagorean-theorem",
       "relationship": "foundational",
       "description": "The Pythagorean theorem establishes $a^2 + b^2 = c^2$ — Fermat's Last Theorem generalizes this from $n=2$ (infinitely many solutions: Pythagorean triples) to $n \\geq 3$ (no solutions). The contrast between richness at $n=2$ and emptiness at $n \\geq 3$ is the core mystery"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both are landmark results where Galois theory plays a central role: Abel-Ruffini uses non-solvability of $S_5$ to block "
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "Lagrange's theorem constrains group structure throughout the proof: the order of Galois groups, the structure of decompo"
+    },
+    {
+      "id": "pythagorean-triples",
+      "relationship": "complementary",
+      "description": "Pythagorean triples $(a,b,c)$ with $a^2+b^2=c^2$ are completely classified: $a = m^2-n^2$, $b=2mn$, $c=m^2+n^2$. FLT sho"
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "FTA guarantees all algebraic numbers embed in $\\mathbb{C}$, providing the complex-analytic tools for Wiles's proof. Modu"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "Gauss's quadratic reciprocity (1801) is the starting point of the class field theory that Wiles's proof generalizes: Art"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "The failure of unique factorization in $\\mathbb{Z}[\\zeta_p]$ for irregular primes blocked Kummer's 1847 approach to FLT."
+    },
+    {
+      "id": "godel-incompleteness",
+      "relationship": "thematic",
+      "description": "FLT was once conjectured to be unprovable in PA or even ZFC. Wiles's proof shows it is provable in ZFC, but the question"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Wiles's proof uses modular forms with $q$-expansions $f(\\tau) = \\sum a_n e^{2\\pi i n \\tau}$ — directly using Euler's for"
+    },
+    {
+      "id": "hilbert-10",
+      "relationship": "related",
+      "description": "Both concern integer solutions of polynomial equations: FLT proves $x^n + y^n = z^n$ has none for $n > 2$, while Hilbert"
     }
   ],
   "references": [

--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -194,6 +194,11 @@
       "id": "law-of-cosines",
       "relationship": "foundational",
       "description": "The law of cosines provides the computational foundation for establishing the nine-point circle's properties, including "
+    },
+    {
+      "id": "triangle-angle-sum",
+      "relationship": "foundational",
+      "description": "The angle sum property is the most basic constraint on triangle geometry, while Feuerbach's theorem is one of the deepes"
     }
   ]
 }

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -282,6 +282,16 @@
       "id": "euler-identity",
       "relationship": "foundational",
       "description": "Euler's formula $e^{ix} = \\cos x + i\\sin x$ is the foundation of the complex exponential form of Fourier series: the basis functions $e_n(x) = e^{2\\pi inx/T}$ are powers of the complex exponential. Every Fourier coefficient $c_n = \\int f(x) e^{-2\\pi inx/T}\\,dx$ uses this formula"
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "related",
+      "description": "The Fourier basis functions $e^{in\\theta}$ parameterize circles in $\\mathbb{C}$ — each $e^{in\\theta}$ traces the unit ci"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "FTC underpins the computation of Fourier coefficients $c_n = \\int f e^{-inx}\\,dx$ and integration by parts, which shows "
     }
   ]
 }

--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -248,6 +248,46 @@
       "id": "liouville-theorem",
       "relationship": "uses",
       "description": "The Mathlib proof of FTA relies on Liouville's theorem (bounded entire function is constant): if p(z) ≠ 0 everywhere, then 1/p is bounded entire, hence constant — contradiction"
+    },
+    {
+      "id": "general-quartic",
+      "relationship": "specializes",
+      "description": "Ferrari's quartic formula provides explicit complex roots for degree-4 polynomials; FTA guarantees such roots exist for "
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "Lagrange's theorem on subgroup orders underpins the group-theoretic proof of FTA via Sylow theory: the non-existence of "
+    },
+    {
+      "id": "vietas-formulas",
+      "relationship": "complementary",
+      "description": "Vieta's formulas express polynomial coefficients as elementary symmetric functions of roots: $a_{n-k}/a_n = (-1)^k e_k(r"
+    },
+    {
+      "id": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "Gauss's algebraic proof of FTA (1849) reduces to IVT: every odd-degree real polynomial has a real root (by IVT, since it"
+    },
+    {
+      "id": "brouwer-fixed-point",
+      "relationship": "related",
+      "description": "Both FTA and Brouwer's fixed point theorem are topological results about continuous maps on compact sets. The topologica"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} = -1$ reveals the structure of $\\mathbb{C}$ that makes FTA true: the complex exponential $e^{"
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "complementary",
+      "description": "FTA guarantees that all polynomial roots exist in $\\mathbb{C}$, while the area-of-circle formalization uses $\\mathbb{C} "
+    },
+    {
+      "id": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley-Hamilton theorem ($p_A(A) = 0$ for the characteristic polynomial $p_A$) combined with FTA guarantees every co"
     }
   ],
   "references": [

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -206,6 +206,41 @@
       "id": "mean-value-theorem",
       "relationship": "related",
       "description": "MVT is the key tool in proving FTC Part II: $F(b) - F(a) = \\int_a^b F'(x)\\,dx$ uses $F(x_{i+1}) - F(x_i) = F'(c_i)(x_{i+"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "FTC connects to the Pythagorean theorem through arc length: $L = \\int_a^b \\sqrt{1 + (f'(x))^2}\\,dx$ where $\\sqrt{1 + (f'"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The divergence of the harmonic series $\\sum 1/n$ can be proved via FTC by comparison with $\\int_1^N 1/x\\,dx = \\ln N \\to "
+    },
+    {
+      "id": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The integral Cauchy-Schwarz inequality $(\\int fg)^2 \\leq (\\int f^2)(\\int g^2)$ uses the Lebesgue integral, which is the "
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "related",
+      "description": "Repeated application of FTC gives the Taylor series: $f(x) = \\sum_{k=0}^n f^{(k)}(a)(x-a)^k/k! + R_n(x)$ where $R_n = \\i"
+    },
+    {
+      "id": "brouwer-fixed-point",
+      "relationship": "related",
+      "description": "The 1D Brouwer fixed point theorem follows directly from IVT, which is closely tied to FTC. For $f:[0,1] \\to [0,1]$ cont"
+    },
+    {
+      "id": "greens-theorem",
+      "relationship": "extends",
+      "description": "Green's theorem $\\oint_C (P\\,dx + Q\\,dy) = \\iint_D (\\partial Q/\\partial x - \\partial P/\\partial y)\\,dA$ is the 2D genera"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\sim \\sqrt{2\\pi n}(n/e)^n$ is derived using FTC applied to $\\ln(n!) = \\sum \\ln k \\approx \\i"
     }
   ],
   "references": [

--- a/src/data/proofs/gcd-algorithm/meta.json
+++ b/src/data/proofs/gcd-algorithm/meta.json
@@ -252,6 +252,31 @@
       "id": "chinese-remainder-constructive",
       "relationship": "extends",
       "description": "The Chinese Remainder Theorem uses the extended Euclidean algorithm to construct solutions: given $\\gcd(m,n) = 1$, find "
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient $\\phi(n) = |\\{k \\leq n : \\gcd(k,n) = 1\\}|$ counts coprime residues, directly using the GCD. The Euclidea"
+    },
+    {
+      "id": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem's pairing argument pairs each $a \\in \\{2,\\ldots,p-2\\}$ with its inverse $a^{-1}$, where the inverse exi"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The Euclidean algorithm's termination is proved by well-founded induction on the second argument: $a \\bmod b < b$ for $b"
+    },
+    {
+      "id": "perfect-numbers",
+      "relationship": "related",
+      "description": "The Euclid-Euler theorem for perfect numbers uses $\\gcd(2^k, 2^{k+1}-1) = 1$ (since $2^{k+1}-1$ is odd) to invoke multip"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "The Euclidean algorithm in the polynomial ring $F[x]$ computes $\\gcd(p,q)$, which determines the splitting behavior of p"
     }
   ],
   "references": [

--- a/src/data/proofs/gelfond-schneider/meta.json
+++ b/src/data/proofs/gelfond-schneider/meta.json
@@ -208,6 +208,16 @@
       "id": "pi-transcendental",
       "relationship": "related",
       "description": "Gelfond-Schneider proves $e^\\pi = (-1)^{-i}$ is transcendental ($\\alpha = -1$, $\\beta = -i$), an elegant alternative to "
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "The irrationality of $\\sqrt{2}$ is the first level of the expressibility hierarchy. Gelfond-Schneider operates at the al"
+    },
+    {
+      "id": "liouville-theorem",
+      "relationship": "foundational",
+      "description": "Liouville's Diophantine approximation theorem (1844) gave the first transcendence results. Gelfond-Schneider uses a diff"
     }
   ],
   "references": [

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -184,6 +184,16 @@
       "id": "angle-trisection",
       "relationship": "related",
       "description": "Both connect to constructibility: quartic roots with degree 4 = 2² ARE constructible (4 divides 2²), while the cubic case (degree 3) is the obstruction for trisection"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "Lagrange's theorem underpins the Galois-theoretic explanation: S₄ has order 24 and its solvable derived series S₄ ▷ A₄ ▷"
+    },
+    {
+      "id": "sylow-theorems",
+      "relationship": "related",
+      "description": "Sylow theory reveals the subgroup structure of S₄ (Sylow 2-subgroups of order 8, Sylow 3-subgroups of order 3) that enab"
     }
   ],
   "references": [

--- a/src/data/proofs/geometric-series/meta.json
+++ b/src/data/proofs/geometric-series/meta.json
@@ -275,6 +275,26 @@
       "id": "taylor-theorem",
       "relationship": "foundational",
       "description": "The geometric series $\\sum r^k = 1/(1-r)$ is the Taylor expansion of $f(r) = (1-r)^{-1}$ at $r = 0$. Taylor's theorem guarantees that any analytic function has a power series expansion, with the geometric series being the prototypical example — its radius of convergence $|r| < 1$ is determined by the nearest singularity at $r = 1$"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} + 1 = 0$ connects the exponential series $e^z = \\sum z^k/k!$ (which converges for all $z$) to"
+    },
+    {
+      "id": "leibniz-pi",
+      "relationship": "related",
+      "description": "The Leibniz formula $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$ arises from integrating the geometric series: $\\int_0^1 \\frac{1}{1+"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "The exponential function $e^x = \\sum x^k/k!$ and the geometric series $1/(1-x) = \\sum x^k$ are the two most fundamental "
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "extends",
+      "description": "Euler's proof that $\\sum 1/p$ diverges over primes uses the Euler product $\\zeta(s) = \\prod_p (1 - p^{-s})^{-1}$, where "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -250,6 +250,46 @@
       "id": "hilbert-10",
       "relationship": "extends",
       "description": "Matiyasevich's theorem (1970) shows no algorithm decides Diophantine solvability. This extends Gödel's impossibility from provability to decidability: the set of true Diophantine statements is not recursively enumerable"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "Induction over natural numbers is the core reasoning principle that Gödel's system must be able to express. The incomple"
+    },
+    {
+      "id": "parallel-postulate-independence",
+      "relationship": "related",
+      "description": "The independence of the parallel postulate from Euclid's other axioms (via non-Euclidean geometries) was an early exampl"
+    },
+    {
+      "id": "russell-1-plus-1",
+      "relationship": "related",
+      "description": "Russell and Whitehead's Principia Mathematica (1910-1913) attempted to derive all of mathematics from logical axioms — H"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Gödel numbering — the encoding of formulas as natural numbers — relies critically on the fundamental theorem of arithmet"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes ensures Gödel numbering never runs out: each position in a formula requires a new prime, so enc"
+    },
+    {
+      "id": "angle-trisection",
+      "relationship": "thematic",
+      "description": "Both are impossibility results that resolved long-standing programs: Wantzel (1837) showed compass-straightedge cannot t"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "thematic",
+      "description": "The irrationality of $\\sqrt{2}$ and Gödel's incompleteness are both proved by contradiction and both reveal fundamental "
+    },
+    {
+      "id": "cantors-theorem",
+      "relationship": "foundational",
+      "description": "Cantor's theorem ($|A| < |\\mathcal{P}(A)|$) uses the same diagonal construction that Gödel adapted for incompleteness. G"
     }
   ],
   "references": [

--- a/src/data/proofs/greens-theorem/meta.json
+++ b/src/data/proofs/greens-theorem/meta.json
@@ -212,6 +212,21 @@
       "id": "euler-identity",
       "relationship": "related",
       "description": "Cauchy's integral theorem — every holomorphic function satisfies $\\oint_C f(z)\\,dz = 0$ — is a direct consequence of Green's theorem applied to the real and imaginary parts of $f$. Euler's formula $e^{ix} = \\cos x + i\\sin x$ defines the key holomorphic function $e^z$, and the residue theorem (generalization of Cauchy's theorem) evaluates contour integrals by analyzing singularities of $e^z$-related functions"
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "related",
+      "description": "The isoperimetric inequality $4\\pi A \\leq L^2$ can be proved using Green's theorem: the area $A = \\frac{1}{2}\\oint (x\\,d"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem defines the Euclidean metric $ds^2 = dx^2 + dy^2$ underlying Green's theorem. The area element $"
+    },
+    {
+      "id": "mean-value-theorem",
+      "relationship": "foundational",
+      "description": "The mean value theorem is used in the proof of Green's theorem for rectangles: the Fubini + FTC approach applies MVT to "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -188,6 +188,36 @@
       "id": "angle-trisection",
       "relationship": "thematic",
       "description": "Both prove that a natural class of problems has no universal solution within a given framework: compass-straightedge cannot trisect all angles, algorithms cannot decide all halting questions. Both disprove the existence of a universal method by exhibiting specific unsolvable instances"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The proof that the halting problem is undecidable uses proof by contradiction (assume a halting oracle exists, then cons"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "Gödel numbering — encoding programs as natural numbers — relies on unique prime factorization to make the encoding injec"
+    },
+    {
+      "id": "russell-1-plus-1",
+      "relationship": "related",
+      "description": "Russell's paradox ($R = \\{x : x \\notin x\\}$) and the halting problem use the same self-referential trick: construct an e"
+    },
+    {
+      "id": "continuum-hypothesis",
+      "relationship": "thematic",
+      "description": "Both illustrate fundamental limits of formal methods: the halting problem shows some questions about programs are algori"
+    },
+    {
+      "id": "cantors-theorem",
+      "relationship": "foundational",
+      "description": "Cantor's theorem ($|A| < |\\mathcal{P}(A)|$) is the prototype of the diagonal argument that Turing adapted for the haltin"
+    },
+    {
+      "id": "p-vs-np",
+      "relationship": "related",
+      "description": "The halting problem proves absolute undecidability (no algorithm decides all instances), while P vs NP asks about effici"
     }
   ],
   "references": [

--- a/src/data/proofs/harmonic-divergence/meta.json
+++ b/src/data/proofs/harmonic-divergence/meta.json
@@ -211,6 +211,16 @@
       "id": "prime-number-theorem",
       "relationship": "related",
       "description": "PNT explains WHY the harmonic series diverges logarithmically: the integral test gives $H_n \\sim \\int_1^n dx/x = \\ln n$."
+    },
+    {
+      "id": "geometric-series",
+      "relationship": "contrasts",
+      "description": "Geometric $\\sum r^n$ converges (exponential decay) vs harmonic $\\sum 1/n$ diverges (polynomial decay). The boundary betw"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Both $H_n = \\ln n + \\gamma + O(1/n)$ and $\\ln(n!) = n\\ln n - n + O(\\ln n)$ are logarithmic estimates proved by Euler-Mac"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -202,6 +202,16 @@
       "id": "fermat-two-squares",
       "relationship": "related",
       "description": "Fermat's two squares theorem characterizes which primes are represented by the binary form x^2 + y^2, a special case of "
+    },
+    {
+      "id": "pell-equation",
+      "relationship": "related",
+      "description": "Pell's equation x^2 - Dy^2 = 1 concerns the indefinite binary quadratic form x^2 - Dy^2, with solutions governed by unit"
+    },
+    {
+      "id": "kroneckers-jugendtraum",
+      "relationship": "related",
+      "description": "Hilbert's 12th Problem (Kronecker's Jugendtraum) seeks explicit class field theory, connecting to the reciprocity phenom"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -161,6 +161,11 @@
       "id": "hilbert-19",
       "relationship": "thematic",
       "description": "Hilbert's 19th (regularity of solutions of variational problems) and 21st both concern differential equations: the 19th "
+    },
+    {
+      "id": "hilbert-22",
+      "relationship": "thematic",
+      "description": "Hilbert's 22nd (uniformization of analytic relations) and 21st both concern complex analysis and Riemann surfaces: unifo"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/hilbert-6/meta.json
+++ b/src/data/proofs/hilbert-6/meta.json
@@ -210,6 +210,11 @@
       "id": "navier-stokes-existence",
       "relationship": "related",
       "description": "The Navier-Stokes equations are one of the key examples in Hilbert's program: axiomatizing fluid mechanics requires understanding existence and regularity — the open Millennium Prize problem shows how far this program remains from completion"
+    },
+    {
+      "id": "shannon-entropy",
+      "relationship": "related",
+      "description": "Shannon entropy axiomatizes information-theoretic aspects that connect to Hilbert's 6th through statistical mechanics: t"
     }
   ]
 }

--- a/src/data/proofs/hilbert-9-reciprocity/meta.json
+++ b/src/data/proofs/hilbert-9-reciprocity/meta.json
@@ -190,6 +190,11 @@
       "id": "abel-ruffini",
       "relationship": "related",
       "description": "Abel-Ruffini uses non-solvability of S_5 to block radical solutions. The 9th problem's reciprocity laws describe when and how Galois groups control arithmetic — both connect Galois theory to fundamental algebraic questions"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's totient function phi(n) gives the degree of cyclotomic extensions [Q(zeta_n):Q] = phi(n), with Galois group (Z/n"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/inclusion-exclusion/meta.json
+++ b/src/data/proofs/inclusion-exclusion/meta.json
@@ -204,6 +204,21 @@
       "id": "subset-count",
       "relationship": "related",
       "description": "The number of subsets of a finite set connects to inclusion-exclusion through the power set structure"
+    },
+    {
+      "id": "birthday-problem",
+      "relationship": "applies",
+      "description": "The birthday problem can be solved via inclusion-exclusion: P(at least one shared birthday) = 1 - P(all distinct), where"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "related",
+      "description": "The sieve of Eratosthenes is an inclusion-exclusion argument: count integers not divisible by any prime up to √n by alte"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization enables inclusion-exclusion over prime divisors: φ(n) = n·∏(1-1/p) uses I-E with sets A_p = {"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/infinitude-primes/meta.json
+++ b/src/data/proofs/infinitude-primes/meta.json
@@ -247,6 +247,51 @@
       "id": "prime-reciprocal-divergence",
       "relationship": "extends",
       "description": "Euler's proof that Σ 1/p diverges gives an analytic proof of infinitely many primes and shows primes are 'denser' than perfect squares"
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "extends",
+      "description": "Dirichlet's theorem shows infinitely many primes in arithmetic progressions a, a+d, a+2d, ... when gcd(a,d)=1 — a vast g"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function φ(n) counts integers coprime to n; its relationship to primes via φ(p) = p-1 connects to the in"
+    },
+    {
+      "id": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem — $(p-1)! \\equiv -1 \\pmod{p}$ iff $p$ is prime — is the factorial-based primality criterion. Both resul"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "thematic",
+      "description": "Both are foundational proofs by contradiction from ancient Greek mathematics: the irrationality of $\\sqrt{2}$ (attribute"
+    },
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "thematic",
+      "description": "Primes play a central role in FLT: Kummer's proof for regular primes (1847) was the deepest 19th-century progress, and W"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Gauss's quadratic reciprocity law governs which primes are squares modulo other primes: $(p/q)(q/p) = (-1)^{(p-1)(q-1)/4"
+    },
+    {
+      "id": "basel-problem",
+      "relationship": "related",
+      "description": "Euler connected the Basel problem ($\\sum 1/n^2 = \\pi^2/6$) to primes via his product formula: $\\zeta(s) = \\sum 1/n^s = \\"
+    },
+    {
+      "id": "gcd-algorithm",
+      "relationship": "foundational",
+      "description": "The GCD algorithm (Euclid's algorithm) is the computational tool underlying the proof: the key step $\\gcd(n!+1, p) = 1$ "
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "Euclid's proof uses a form of infinite descent: given any finite list of primes, construct a number not divisible by any"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/intermediate-value-theorem/meta.json
+++ b/src/data/proofs/intermediate-value-theorem/meta.json
@@ -218,6 +218,31 @@
       "id": "sqrt2-irrational",
       "relationship": "related",
       "description": "The failure of IVT over $\\mathbb{Q}$ is witnessed by $f(x) = x^2 - 2$: $f(1) < 0 < f(2)$ but $\\sqrt{2} \\notin \\mathbb{Q}"
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "foundational",
+      "description": "Gauss's algebraic proof of FTA (1849) reduces to IVT: every odd-degree real polynomial has a real root because $\\lim_{x "
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "related",
+      "description": "Archimedes' method of exhaustion — the ancient precursor to IVT — proved $A = \\pi r^2$ by showing the difference between"
+    },
+    {
+      "id": "angle-trisection",
+      "relationship": "related",
+      "description": "IVT guarantees that $\\cos(\\theta/3)$ exists for any angle $\\theta$ (as a real value between -1 and 1). The impossibility"
+    },
+    {
+      "id": "schroeder-bernstein",
+      "relationship": "thematic",
+      "description": "Both establish existence of 'intermediate' objects: IVT proves a continuous function attains all values between $f(a)$ a"
+    },
+    {
+      "id": "cantor-diagonalization",
+      "relationship": "thematic",
+      "description": "IVT relies on the completeness of $\\mathbb{R}$ (which has uncountably many points, by Cantor's argument). Over $\\mathbb{"
     }
   ],
   "references": [

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -339,6 +339,11 @@
       "id": "fundamental-theorem-algebra",
       "relationship": "related",
       "description": "FTA guarantees polynomial roots exist over C; the Inverse Galois Problem asks about the symmetry structure of those roots over Q"
+    },
+    {
+      "id": "nth-root-irrational-oq-01",
+      "relationship": "depends-on",
+      "description": "Imports Eisenstein irreducibility and nth root irrationality infrastructure used for proving polynomial irreducibility i"
     }
   ],
   "references": [

--- a/src/data/proofs/isoperimetric-theorem/meta.json
+++ b/src/data/proofs/isoperimetric-theorem/meta.json
@@ -198,6 +198,36 @@
       "id": "area-of-circle-oq-01-oq-03",
       "relationship": "supports",
       "description": "The Wirtinger inequality and Fourier framework entry provides the other key ingredient for the Fourier-analytic proof."
+    },
+    {
+      "id": "picks-theorem",
+      "relationship": "related",
+      "description": "Pick's theorem relates area to lattice points for polygons. Both results connect perimeter/boundary information to enclo"
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "foundational",
+      "description": "Fourier series provide the analytical machinery for Hurwitz's proof: the curve is decomposed into Fourier modes, and the"
+    },
+    {
+      "id": "amgm-inequality",
+      "relationship": "related",
+      "description": "The product-sum corollary of AM-GM (ab ≤ ((a+b)/2)²) proves the isoperimetric inequality for rectangles; the full theore"
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "The Cauchy-Schwarz inequality is used in the parametric proof of the isoperimetric theorem: for a curve $(x(t), y(t))$ w"
+    },
+    {
+      "id": "greens-theorem",
+      "relationship": "foundational",
+      "description": "Green's theorem converts the isoperimetric problem from a double integral (area) to a line integral: $A = \\frac{1}{2}\\oi"
+    },
+    {
+      "id": "brouwer-fixed-point",
+      "relationship": "thematic",
+      "description": "Both are fundamental results about convex bodies: the isoperimetric theorem characterizes the optimal shape (circle/sphe"
     }
   ],
   "references": [

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -228,6 +228,26 @@
       "id": "euler-totient",
       "relationship": "Cyclotomic Fields",
       "description": "Euler's totient function φ(n) gives the degree [ℚ(ζₙ):ℚ] = φ(n) and the order of the Galois group (ℤ/nℤ)×, both proved in the formalization."
+    },
+    {
+      "id": "inverse-galois",
+      "relationship": "Galois Theory",
+      "description": "The Inverse Galois Problem asks which groups appear as Galois groups over ℚ. Kronecker-Weber completely answers this for"
+    },
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "Cyclotomic Fields",
+      "description": "Kummer's approach to Fermat's Last Theorem used cyclotomic fields ℚ(ζₚ) and their arithmetic, the same fields that are c"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "Galois Theory",
+      "description": "Abel-Ruffini uses the non-solvability of S₅ to show general quintics are not solvable by radicals. Kronecker-Weber uses "
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "Cyclotomic Fields",
+      "description": "Primitive roots modulo primes are closely related to generators of cyclic Galois groups Gal(ℚ(ζₚ)/ℚ) ≅ (ℤ/pℤ)×, which is"
     }
   ],
   "references": [

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -186,6 +186,16 @@
       "id": "perfect-numbers",
       "relationship": "related",
       "description": "Both results connect to the multiplicative structure of $\\mathbb{N}$: Lagrange shows every $n$ decomposes as $a^2 + b^2 "
+    },
+    {
+      "id": "pythagorean-triples",
+      "relationship": "complementary",
+      "description": "Pythagorean triples solve $a^2 + b^2 = c^2$ — the two-variable sum-of-squares equation. Lagrange's theorem concerns the "
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "foundational",
+      "description": "The Chinese Remainder Theorem allows the four-squares problem to be decomposed by prime powers: proving $p = a^2+b^2+c^2"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/lagrange-theorem/meta.json
+++ b/src/data/proofs/lagrange-theorem/meta.json
@@ -239,6 +239,31 @@
       "id": "euler-totient",
       "relationship": "extends",
       "description": "Euler's theorem (a^φ(n) ≡ 1 mod n) is a direct corollary of Lagrange applied to (Z/nZ)× of order φ(n). The formalization derives Fermat's little theorem (the prime case); Euler's theorem is the general case"
+    },
+    {
+      "id": "angle-trisection",
+      "relationship": "foundational",
+      "description": "The tower law for field extension degrees ([F_n:Q] = ∏[F_{i+1}:F_i] = 2^n) is a consequence of Lagrange's theorem on sub"
+    },
+    {
+      "id": "inverse-galois",
+      "relationship": "related",
+      "description": "Lagrange's original 1771 work on permutations of polynomial roots was the direct precursor to Galois theory. The Inverse"
+    },
+    {
+      "id": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem ($(p-1)! \\equiv -1 \\pmod{p}$) can be proved via Lagrange's theorem: in $(\\mathbb{Z}/p\\mathbb{Z})^\\times"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Quadratic reciprocity concerns the structure of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$, specifically whether elements are qua"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "related",
+      "description": "The existence of primitive roots modulo $p$ — generators of the cyclic group $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ — is a co"
     }
   ],
   "references": [

--- a/src/data/proofs/law-of-cosines/meta.json
+++ b/src/data/proofs/law-of-cosines/meta.json
@@ -190,6 +190,16 @@
       "id": "angle-trisection",
       "relationship": "related",
       "description": "Both concern angle measurement in Euclidean geometry. The Law of Cosines recovers angles from side lengths ($\\cos C = (a^2+b^2-c^2)/(2ab)$), while the angle trisection impossibility shows certain angles cannot be constructed — the cosine formula connects the algebraic and geometric perspectives on angles"
+    },
+    {
+      "id": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Both are foundational results in linear algebra. The inner product form of the Law of Cosines uses the same bilinear str"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's formula $e^{i\\theta} = \\cos\\theta + i\\sin\\theta$ provides the connection between the inner product $\\langle v, w"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/lebesgue-measure-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01/meta.json
@@ -197,6 +197,21 @@
       "id": "harmonic-divergence",
       "relationship": "related",
       "description": "Both proofs use measure-theoretic or analytic techniques to resolve questions about integration: harmonic divergence shows ∑1/n diverges (related to the integral test), while this proof shows ∫𝟙_ℚ = 0 via measure-theoretic methods unavailable to classical analysis"
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Named after the same mathematician (Dirichlet): his theorem on primes in arithmetic progressions uses Dirichlet characte"
+    },
+    {
+      "id": "schroeder-bernstein",
+      "relationship": "foundational",
+      "description": "Schröder-Bernstein establishes that injections in both directions yield a bijection, underpinning the cardinality argume"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "foundational",
+      "description": "The irrationality of √2 establishes the existence of irrational numbers — the points where 𝟙_ℚ = 0. The density of irrat"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/legendre-partial/meta.json
+++ b/src/data/proofs/legendre-partial/meta.json
@@ -183,6 +183,11 @@
       "id": "dirichlets-theorem",
       "relationship": "related",
       "description": "Dirichlet's theorem (1837) proves primes exist in every arithmetic progression $a + nd$ with $\\gcd(a,d) = 1$. Both results concern the distribution of primes in structured subsets of the integers — Dirichlet in arithmetic progressions, Legendre in intervals between squares"
+    },
+    {
+      "id": "twin-primes-special",
+      "relationship": "thematic",
+      "description": "The twin prime conjecture (infinitely many primes $p$ with $p+2$ also prime) and Legendre's conjecture are both long-sta"
     }
   ],
   "references": [

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
@@ -228,6 +228,16 @@
       "id": "geometric-series",
       "relationship": "related",
       "description": "The arctan Taylor series arctan(x) = x - x^3/3 + x^5/5 - ... is a variant of the geometric series identity; Machin's formula exploits its rapid convergence at small arguments"
+    },
+    {
+      "id": "taylor-theorem",
+      "relationship": "uses-concept",
+      "description": "The arctan series $\\arctan(x) = x - x^3/3 + x^5/5 - \\cdots$ that Machin's formula accelerates is a special case of Taylo"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Both results connect pi to analytic function identities; Euler's identity uses $e^{i\\pi}$ while Machin uses arctan compo"
     }
   ]
 }

--- a/src/data/proofs/leibniz-pi/meta.json
+++ b/src/data/proofs/leibniz-pi/meta.json
@@ -210,6 +210,16 @@
       "id": "taylor-theorem",
       "relationship": "foundational",
       "description": "The Leibniz series is the Taylor expansion of $\\arctan(x)$ at $x = 0$ evaluated at $x = 1$: $\\arctan(x) = x - x^3/3 + x^"
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "related",
+      "description": "The Leibniz series $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$ is the value $L(1, \\chi_4)$ of the Dirichlet $L$-function for the no"
+    },
+    {
+      "id": "geometric-series",
+      "relationship": "foundational",
+      "description": "The derivation of $\\arctan(x) = \\int_0^x 1/(1+t^2)\\,dt$ starts from the geometric series $1/(1+t^2) = 1 - t^2 + t^4 - \\c"
     }
   ],
   "references": [

--- a/src/data/proofs/liouville-theorem/meta.json
+++ b/src/data/proofs/liouville-theorem/meta.json
@@ -246,6 +246,21 @@
       "id": "sqrt2-irrational",
       "relationship": "specializes",
       "description": "Irrationality of √2 is the simplest case of the algebraic-transcendental hierarchy: √2 is algebraic of degree 2, hence not Liouville, while Liouville numbers go further and are transcendental"
+    },
+    {
+      "id": "denumerability-rationals",
+      "relationship": "related",
+      "description": "Countability of rationals contextualizes Liouville's result: algebraic numbers are countable while transcendentals (incl"
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "FTA (every polynomial has complex roots) establishes that algebraic numbers form a field. Liouville's theorem shows this"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "Abel-Ruffini shows some algebraic numbers can't be expressed by radicals; Liouville goes further, exhibiting numbers tha"
     }
   ],
   "references": [

--- a/src/data/proofs/mathematical-induction/meta.json
+++ b/src/data/proofs/mathematical-induction/meta.json
@@ -249,6 +249,41 @@
       "id": "arithmetic-series",
       "relationship": "related",
       "description": "The sum formula $\\sum_{k=1}^n k = n(n+1)/2$ is the classic first example of proof by induction, attributed to Gauss. This formalization includes this example, connecting induction to combinatorial identities"
+    },
+    {
+      "id": "godel-incompleteness",
+      "relationship": "related",
+      "description": "Godel's incompleteness theorems concern the limits of Peano arithmetic, whose induction axiom schema is precisely the pr"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "related",
+      "description": "Lagrange's theorem on subgroup orders is proved by induction on the index of the subgroup, using the coset decomposition"
+    },
+    {
+      "id": "gcd-algorithm",
+      "relationship": "related",
+      "description": "The Euclidean algorithm's correctness and termination are proved by strong induction on the pair (a, b) ordered by the s"
+    },
+    {
+      "id": "factor-remainder-theorem",
+      "relationship": "related",
+      "description": "The factor theorem connects to induction through polynomial division: proving that a degree-n polynomial has at most n r"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "While the Pythagorean theorem itself does not use induction, many of its extensions do: counting Pythagorean triples, pr"
+    },
+    {
+      "id": "subset-count",
+      "relationship": "related",
+      "description": "The proof that a set with n elements has 2^n subsets is a textbook application of weak induction: removing one element s"
+    },
+    {
+      "id": "schroeder-bernstein",
+      "relationship": "related",
+      "description": "The Schroeder-Bernstein theorem uses a chain of iterated function applications that terminates by well-ordering — the sa"
     }
   ]
 }

--- a/src/data/proofs/mean-value-theorem/meta.json
+++ b/src/data/proofs/mean-value-theorem/meta.json
@@ -231,6 +231,21 @@
       "id": "cauchy-schwarz",
       "relationship": "related",
       "description": "The Cauchy form of MVT ($\\frac{f(b)-f(a)}{g(b)-g(a)} = \\frac{f'(c)}{g'(c)}$) is used in L'Hôpital's rule, which evaluates indeterminate forms. Cauchy-Schwarz and Cauchy's MVT both bear Cauchy's name and both provide bounds on ratios — Cauchy-Schwarz on $\\langle u,v\\rangle/(\\|u\\|\\|v\\|)$ and Cauchy's MVT on $\\Delta f/\\Delta g$"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The integral test for series convergence uses MVT: comparing $\\sum_{k=1}^n f(k)$ with $\\int_1^n f(x)\\,dx$ requires bound"
+    },
+    {
+      "id": "taylor-theorem",
+      "relationship": "extended-by",
+      "description": "Taylor's theorem is the $n$th-order generalization of MVT: MVT is the $n=0$ case ($f(b) = f(a) + f'(c)(b-a)$), while Tay"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "MVT bounds $|e^x - 1 - x| \\leq (e^c/2)x^2$ — the kind of estimate used in Hermite's transcendence proof, where controlli"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -332,6 +332,11 @@
       "id": "hilbert-20",
       "relationship": "related",
       "description": "Hilbert's 20th (boundary value problem existence) was resolved via Lax-Milgram for elliptic PDEs. Navier-Stokes existence is the analogous question for incompressible fluid equations — Leray's weak solutions exist but global regularity is unknown"
+    },
+    {
+      "id": "birch-swinnerton-dyer",
+      "relationship": "thematic",
+      "description": "Both are unsolved Clay Millennium Prize problems: BSD concerns L-functions of elliptic curves, while Navier-Stokes conce"
     }
   ]
 }

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -243,6 +243,16 @@
       "id": "fundamental-theorem-calculus-oq-01",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "cauchy-schwarz-integral",
+      "relationship": "foundational",
+      "description": "The Cauchy-Schwarz inequality for integrals underlies many estimates in PDE regularity theory, including bounding enstro"
+    },
+    {
+      "id": "lebesgue-measure",
+      "relationship": "foundational",
+      "description": "The integral identities are formulated using Lebesgue integration (MeasureTheory.Integral.IntervalIntegral), with Interv"
     }
   ],
   "references": [

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -359,6 +359,26 @@
       "id": "schauder-fixed-point",
       "relationship": "foundational",
       "description": "Schauder's fixed point theorem is used in PDE existence proofs: weak solutions to Navier-Stokes are constructed via Galerkin approximation and compactness arguments, where Schauder-type fixed points guarantee existence of approximate solutions"
+    },
+    {
+      "id": "navier-stokes-oq-01",
+      "relationship": "extended-by",
+      "description": "Extension exploring additional aspects of the Navier-Stokes regularity theory"
+    },
+    {
+      "id": "navier-stokes-oq-02",
+      "relationship": "extended-by",
+      "description": "Extension exploring further directions in the Navier-Stokes formalization"
+    },
+    {
+      "id": "lebesgue-measure",
+      "relationship": "foundational",
+      "description": "The Lebesgue integral underlies all energy estimates in the Navier-Stokes analysis: enstrophy $E = \\int|\\omega|^2$, pali"
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "foundational",
+      "description": "Fourier analysis is central to the spectral gap arguments: the Faber-Krahn inequality $\\lambda_1 \\geq \\pi^2/(4R^2)$ rela"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/nth-root-irrational-oq-01/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-01/meta.json
@@ -231,6 +231,16 @@
       "id": "hermite-lindemann",
       "relationship": "related",
       "description": "Hermite-Lindemann proves e^alpha is transcendental for algebraic alpha != 0, a strictly stronger result than irrationality. Both sit in the hierarchy: algebraic irrationality (this module) < transcendence (Hermite-Lindemann)"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "Abel-Ruffini uses the irreducibility of the generic polynomial to prove radical unsolvability. This module's Eisenstein "
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "The transcendence of e implies e is not a root of any polynomial over Q, a strictly stronger statement than irrationalit"
     }
   ]
 }

--- a/src/data/proofs/perfect-numbers/meta.json
+++ b/src/data/proofs/perfect-numbers/meta.json
@@ -269,6 +269,31 @@
       "id": "lagrange-four-squares",
       "relationship": "related",
       "description": "Both concern representation problems in number theory: which numbers are sums of squares (Lagrange) vs which satisfy $\\sigma(n) = 2n$ (perfect numbers). The sigma function $\\sigma_k$ for different $k$ connects both: $\\sigma_0(n)$ counts divisors, $\\sigma_1(n)$ sums divisors (perfect numbers), and $r_4(n) = 8\\sigma_1(n) - 32\\sigma_1(n/4)$ counts four-square representations (Jacobi)"
+    },
+    {
+      "id": "fermat-two-squares",
+      "relationship": "related",
+      "description": "Both rely on the multiplicativity of arithmetic functions: Fermat's theorem uses the multiplicativity of the Gaussian in"
+    },
+    {
+      "id": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Both are characterizations of primes — Wilson's theorem characterizes primes via factorial congruence, while the Euclid-"
+    },
+    {
+      "id": "arithmetic-series",
+      "relationship": "related",
+      "description": "The formula $\\sigma_1(2^k) = 2^{k+1} - 1$ used in Euclid's proof is the sum of a geometric series $1 + 2 + 4 + \\cdots + "
+    },
+    {
+      "id": "gcd-algorithm",
+      "relationship": "foundational",
+      "description": "The proof uses $\\gcd(2^k, 2^{k+1}-1) = 1$ repeatedly to invoke multiplicativity of $\\sigma_1$. Computing GCDs via the Eu"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "related",
+      "description": "The Mersenne number $M_p = 2^p - 1$ factors as $(2-1)(2^{p-1} + 2^{p-2} + \\cdots + 1)$ when $p$ is composite (via the fa"
     }
   ]
 }

--- a/src/data/proofs/pi-transcendental/meta.json
+++ b/src/data/proofs/pi-transcendental/meta.json
@@ -226,6 +226,36 @@
       "id": "",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "hermite-lindemann",
+      "relationship": "generalizes",
+      "description": "The Hermite-Lindemann theorem ($e^\\alpha$ transcendental for algebraic $\\alpha \\neq 0$) is the key lemma axiomatized her"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "Hermite's 1873 proof of $e$'s transcendence introduced the auxiliary polynomial method that Lindemann extended to prove "
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "uses",
+      "description": "Euler's identity $e^{i\\pi} = -1$ is the critical bridge: it converts the transcendence of exponentials into a statement "
+    },
+    {
+      "id": "gelfond-schneider",
+      "relationship": "related",
+      "description": "The Gelfond-Schneider theorem (1934) extended transcendence theory beyond exponentials to $\\alpha^\\beta$, resolving Hilb"
+    },
+    {
+      "id": "angle-trisection",
+      "relationship": "parallel",
+      "description": "Another classical impossibility result using field-theoretic arguments; angle trisection fails because some angles requi"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "foundation",
+      "description": "Irrationality of $\\sqrt{2}$ is the simplest case of showing a number is not rational; transcendence of $\\pi$ is the much"
     }
   ]
 }

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -354,6 +354,11 @@
       "id": "hodge-conjecture",
       "relationship": "thematic",
       "description": "Another Clay Millennium Prize Problem — the Hodge conjecture concerns the algebraic topology of complex manifolds, complementing the Poincaré conjecture's classification of topological manifolds"
+    },
+    {
+      "id": "godel-incompleteness",
+      "relationship": "thematic",
+      "description": "Gödel's incompleteness theorems constrain what formal systems can prove — Perelman's proof of the Poincaré conjecture wa"
     }
   ],
   "references": [

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -203,6 +203,26 @@
       "id": "bertrands-postulate",
       "relationship": "related",
       "description": "Bertrand's postulate ($\\exists$ prime in $(n, 2n]$) is an elementary consequence of PNT: $\\pi(2n) - \\pi(n) \\sim n/\\ln n "
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "extends",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions ($\\exists$ infinitely many primes $\\equiv a \\pmod{q}$ when $\\gc"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function $\\varphi(n)$ appears in PNT for arithmetic progressions: $\\pi(x; q, a) \\sim x/(\\varphi(q) \\ln x"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\sim \\sqrt{2\\pi n}(n/e)^n$ and PNT are both asymptotic results about discrete sequences wit"
+    },
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Both are landmark achievements in number theory. Wiles's proof of FLT (1995) uses the modularity of elliptic curves and "
     }
   ],
   "references": [

--- a/src/data/proofs/prime-reciprocal-divergence/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence/meta.json
@@ -197,6 +197,36 @@
       "id": "",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "strengthens",
+      "description": "The divergence of $\\sum 1/p$ is a quantitative strengthening of Euclid's theorem: not only infinitely many primes, but d"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The prime reciprocal sum is a sparse sub-sum of the harmonic series; both diverge but $\\sum 1/p \\sim \\ln \\ln n$ grows fa"
+    },
+    {
+      "id": "basel-problem",
+      "relationship": "related",
+      "description": "The Basel problem ($\\sum 1/n^2 = \\pi^2/6$) connects to the prime zeta function $P(2) = \\sum 1/p^2 \\approx 0.4522$; both "
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "related",
+      "description": "The PNT ($\\pi(n) \\sim n/\\ln n$) is equivalent to Mertens-type estimates; prime reciprocal divergence is a weaker consequ"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate ($\\exists$ prime in $(n, 2n]$) and prime reciprocal divergence both quantify how dense primes are; "
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions uses similar analytic techniques; the divergence of $\\sum 1/p$ "
     }
   ],
   "references": [

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -185,6 +185,16 @@
       "id": "ramseys-theorem",
       "relationship": "related",
       "description": "Ramsey-type problems are a primary motivation for the alteration method — the probabilistic lower bound on Ramsey numbers uses an alteration argument to handle edge colorings"
+    },
+    {
+      "id": "friendship-theorem",
+      "relationship": "related",
+      "description": "The friendship theorem is a graph-theoretic existence/uniqueness result that, like the independent set bound here, conne"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "Binomial coefficients underpin the probability calculations in the alteration method: random subset selection with proba"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/prob-method-second-moment/meta.json
+++ b/src/data/proofs/prob-method-second-moment/meta.json
@@ -182,6 +182,11 @@
       "id": "prob-method-alteration",
       "relationship": "related",
       "description": "The alteration method often combines with second moment bounds: first prove a structure exists with high probability, then alter it to achieve additional properties"
+    },
+    {
+      "id": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey number lower bounds via the second moment method sharpen the first moment bounds: where E[X] > 0 gives existence,"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/pythagorean-theorem/meta.json
+++ b/src/data/proofs/pythagorean-theorem/meta.json
@@ -269,6 +269,51 @@
       "id": "pythagorean-theorem-oq-03",
       "relationship": "related",
       "description": "Related gallery proof"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "foundational",
+      "description": "The irrationality of $\\sqrt{2}$ follows directly from the Pythagorean theorem: the diagonal of a unit square has length "
+    },
+    {
+      "id": "law-of-cosines",
+      "relationship": "extended-by",
+      "description": "The law of cosines generalizes the Pythagorean theorem: $c^2 = a^2 + b^2 - 2ab\\cos(C)$. When $C = 90°$, $\\cos(C) = 0$ an"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} + 1 = 0$ connects to the Pythagorean theorem via $|e^{i\\theta}|^2 = \\cos^2\\theta + \\sin^2\\the"
+    },
+    {
+      "id": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The integral Cauchy-Schwarz inequality $|\\int fg|^2 \\leq \\int f^2 \\cdot \\int g^2$ is the infinite-dimensional generaliza"
+    },
+    {
+      "id": "triangle-inequality",
+      "relationship": "related",
+      "description": "The triangle inequality $\\|u + v\\| \\leq \\|u\\| + \\|v\\|$ and the Pythagorean theorem $\\|u + v\\|^2 = \\|u\\|^2 + \\|v\\|^2$ (wh"
+    },
+    {
+      "id": "amgm-inequality",
+      "relationship": "related",
+      "description": "Both AM-GM and the Pythagorean theorem arise from inner product/norm inequalities. The AM-GM inequality $\\sqrt{ab} \\leq "
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The generalized Pythagorean theorem (`pythagorean_sum`) for $n$ mutually orthogonal vectors is proved by induction on th"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "related",
+      "description": "The FTC connects to the Pythagorean theorem through arc length: the length of a curve $\\gamma$ is $\\int \\sqrt{dx^2 + dy^"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "related",
+      "description": "The expansion $\\|u+v\\|^2 = \\|u\\|^2 + 2\\langle u,v \\rangle + \\|v\\|^2$ used in the proof is the inner product analog of th"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/quadratic-reciprocity/meta.json
+++ b/src/data/proofs/quadratic-reciprocity/meta.json
@@ -211,6 +211,41 @@
       "id": "abel-ruffini",
       "relationship": "related",
       "description": "Both are landmarks of 19th-century algebra: Abel-Ruffini uses Galois groups to prove quintic unsolvability, while quadratic reciprocity reveals deep structure in $\\mathbb{Z}/p\\mathbb{Z}$. Artin reciprocity law unifies both into class field theory."
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "The quadratic residues modulo $p$ form a subgroup of index 2 in $(\\mathbb{Z}/p\\mathbb{Z})^\\times$, with order $(p-1)/2$ "
+    },
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "foundational",
+      "description": "Quadratic reciprocity is the $n = 2$ case of Artin reciprocity, which Wiles's modularity theorem generalizes to 2-dimens"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization underpins the Legendre symbol: $(a/p)$ depends on $a$ only through its residue mod $p$, and t"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "foundational",
+      "description": "The existence of primitive roots modulo $p$ proves $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is cyclic of order $p-1$. Quadratic"
+    },
+    {
+      "id": "kroneckers-jugendtraum",
+      "relationship": "extends",
+      "description": "Kronecker-Weber (every abelian extension of $\\mathbb{Q}$ is cyclotomic) generalizes quadratic reciprocity: QR determines"
+    },
+    {
+      "id": "fermat-two-squares",
+      "relationship": "related",
+      "description": "Fermat's two-squares theorem ($p = a^2 + b^2$ iff $p \\equiv 1 \\pmod{4}$) is a direct application of quadratic reciprocit"
+    },
+    {
+      "id": "hilbert-9-reciprocity",
+      "relationship": "extends",
+      "description": "Hilbert's 9th problem asks for the most general reciprocity law in algebraic number fields. Quadratic reciprocity is the"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/ramseys-theorem/meta.json
+++ b/src/data/proofs/ramseys-theorem/meta.json
@@ -216,6 +216,11 @@
       "id": "mathematical-induction",
       "relationship": "foundational",
       "description": "Ramsey's theorem is proved by strong induction on $r + s$, the same principle formalized in mathematical-induction. The "
+    },
+    {
+      "id": "erdos-szekeres",
+      "relationship": "related",
+      "description": "The Erdos-Szekeres theorem (every sequence of length $rs+1$ contains a monotone subsequence of length $r+1$ or $s+1$) ca"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -220,6 +220,26 @@
       "id": "szemeredi-theorem",
       "relationship": "extends",
       "description": "Roth's theorem is the k=3 base case of Szemerédi's theorem (1975): every set of positive upper density contains arithmetic progressions of every length. The density increment strategy introduced by Roth was a precursor to Szemerédi's far more complex regularity-based proof"
+    },
+    {
+      "id": "prob-method-expectation",
+      "relationship": "related",
+      "description": "Both use counting arguments over structured combinatorial objects"
+    },
+    {
+      "id": "erdos-1155-oq-01",
+      "relationship": "related",
+      "description": "The triangle removal process (Erdős #1155) is connected through the triangle removal lemma: Ruzsa-Szemerédi (1978) showe"
+    },
+    {
+      "id": "erdos-1155",
+      "relationship": "related",
+      "description": "Parent formalization of the triangle removal process — connected via the triangle removal lemma which provides an altern"
+    },
+    {
+      "id": "bounded-prime-gaps",
+      "relationship": "thematic",
+      "description": "Both are landmark results in analytic/additive number theory about structure in the integers. The Green-Tao theorem (200"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/schroeder-bernstein/meta.json
+++ b/src/data/proofs/schroeder-bernstein/meta.json
@@ -253,6 +253,21 @@
       "id": "mathematical-induction",
       "relationship": "related",
       "description": "The Knaster-Tarski fixed point $S^* = \\bigcup_n T^n(\\emptyset)$ is constructed by iterated application of the monotone operator, using transfinite induction."
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Both are Wiedijk 100 theorems formalized as pedagogical wrappers over Mathlib, demonstrating the pattern of exposing Mat"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "related",
+      "description": "Both are foundational results establishing structural properties of infinite sets."
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "SB establishes $|\\mathbb{C}| = |\\mathbb{R}|$: $\\mathbb{R} \\hookrightarrow \\mathbb{C}$ (inclusion) and $\\mathbb{C} \\hookr"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/shannon-source-coding/meta.json
+++ b/src/data/proofs/shannon-source-coding/meta.json
@@ -197,6 +197,21 @@
       "id": "birthday-problem",
       "relationship": "related",
       "description": "Both use probabilistic counting arguments involving exponential growth: the birthday problem counts collisions among $2^"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "foundational",
+      "description": "The AEP that underlies source coding is an information-theoretic law of large numbers: $-\\frac{1}{n}\\log p(X_1^n) \\to H("
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $\\log n! \\approx n\\log n - n$ underpins the typical set counting argument: the number of sequen"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The multinomial coefficient $\\binom{n}{k_1, \\ldots, k_m}$ counts sequences of a given type — the method of types (Csiszá"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/solution-of-cubic-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03/meta.json
@@ -262,6 +262,21 @@
       "id": "vietas-formulas",
       "title": "Vieta's Formulas",
       "relationship": "technique — connects coefficients to roots, essential for cubic analysis"
+    },
+    {
+      "id": "vietas-formulas-oq-03",
+      "relationship": "related",
+      "description": "Newton's identities express power sums p_k = Σxᵢᵏ recursively in terms of elementary symmetric polynomials eⱼ, generaliz"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "foundational",
+      "description": "The primitive cube root of unity ω = e^{2πi/3} is a primitive root of the cyclotomic polynomial Φ₃(x) = x² + x + 1. The "
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "related",
+      "description": "The binomial theorem underlies the expansion of (ωu + ω²v)³ and similar expressions needed in the Vieta proofs. The mult"
     }
   ]
 }

--- a/src/data/proofs/solution-of-cubic/meta.json
+++ b/src/data/proofs/solution-of-cubic/meta.json
@@ -226,6 +226,11 @@
       "id": "de-moivre",
       "relationship": "uses-same-technique",
       "description": "De Moivre's theorem connects complex exponentials to trigonometry. The cube roots of unity ω = e^(2πi/3) central to expressing all three cubic roots are a direct application."
+    },
+    {
+      "id": "angle-trisection",
+      "relationship": "related-problem",
+      "description": "The impossibility of angle trisection reduces to showing cos(20°) satisfies an irreducible cubic — the same cubic equati"
     }
   ],
   "references": [

--- a/src/data/proofs/sqrt2-examples/meta.json
+++ b/src/data/proofs/sqrt2-examples/meta.json
@@ -189,6 +189,11 @@
       "id": "sqrt2-from-axioms",
       "relationship": "related",
       "description": "Alternative sqrt(2) formalization built from first principles rather than Mathlib"
+    },
+    {
+      "id": "amgm-inequality",
+      "relationship": "related",
+      "description": "AM-GM inequality relies on non-negativity of squares as a building block"
     }
   ],
   "references": [

--- a/src/data/proofs/sqrt2-irrational/meta.json
+++ b/src/data/proofs/sqrt2-irrational/meta.json
@@ -203,6 +203,41 @@
       "id": "abel-ruffini",
       "relationship": "foundational",
       "description": "The irrationality of $\\sqrt{2}$ is the earliest impossibility result in mathematics — showing $\\sqrt{2} \\notin \\mathbb{Q}$. Abel-Ruffini extends this paradigm: certain quantities cannot be expressed within given algebraic frameworks (radicals rather than rationals). Both prove that 'simple' descriptions fail to capture certain numbers"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "Both are landmark results about the nature of specific numbers: $\\sqrt{2} \\notin \\mathbb{Q}$ (irrational) is the weakest"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "The irrationality of $\\sqrt{2}$ and the transcendence of $\\pi$ bracket the expressibility hierarchy: $\\sqrt{2}$ is algeb"
+    },
+    {
+      "id": "hermite-lindemann",
+      "relationship": "extends",
+      "description": "Hermite-Lindemann ($e^\\alpha$ transcendental for algebraic $\\alpha \\neq 0$) is a vast generalization: it proves transcen"
+    },
+    {
+      "id": "angle-trisection",
+      "relationship": "complementary",
+      "description": "$\\sqrt{2}$ IS constructible (diagonal of a unit square) because $[\\mathbb{Q}(\\sqrt{2}):\\mathbb{Q}] = 2 = 2^1$. This cont"
+    },
+    {
+      "id": "cantor-diagonalization",
+      "relationship": "thematic",
+      "description": "Both prove that certain sets are 'too large' for a given description: $\\sqrt{2} \\notin \\mathbb{Q}$ shows irrationals exi"
+    },
+    {
+      "id": "gelfond-schneider",
+      "relationship": "extends",
+      "description": "Gelfond-Schneider proves $\\alpha^\\beta$ is transcendental for algebraic $\\alpha \\neq 0,1$ and irrational algebraic $\\bet"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "The proof by infinite descent (showing no smallest counterexample exists) is closely related to strong induction — both "
     }
   ],
   "references": [

--- a/src/data/proofs/stirling-formula/meta.json
+++ b/src/data/proofs/stirling-formula/meta.json
@@ -223,6 +223,26 @@
       "id": "euler-identity",
       "relationship": "related",
       "description": "Euler's formula e^{iπ} + 1 = 0 connects the same constants (e, π) that appear in Stirling's formula. Both reveal deep relationships between exponential growth and circular geometry"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "Stirling's formula is derived by approximating $\\ln(n!) = \\sum_{k=1}^n \\ln k \\approx \\int_1^n \\ln x\\,dx = n\\ln n - n + 1"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "Both results compare discrete sums with continuous integrals: the harmonic series $\\sum 1/n$ diverges like $\\ln n$ (by c"
+    },
+    {
+      "id": "derangements",
+      "relationship": "related",
+      "description": "The number of derangements $D_n \\sim n!/e$ uses both the factorial (approximated by Stirling) and $e$ (the base of the n"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate (there exists a prime between $n$ and $2n$) was first proved by Chebyshev using bounds on $\\binom{2"
     }
   ]
 }

--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -294,6 +294,41 @@
       "id": "euler-totient",
       "relationship": "related",
       "description": "Euler's totient $\\phi(n)$ determines the structure of $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, whose Sylow $p$-subgroups are cyclic of order $p^{v_p(\\phi(n))}$. The Sylow decomposition of this group underlies the Chinese Remainder Theorem structure of $\\mathbb{Z}/n\\mathbb{Z}$"
+    },
+    {
+      "id": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley-Hamilton theorem connects to Sylow theory through the Jordan canonical form: the primary decomposition of a l"
+    },
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Wiles's proof uses the structure of Galois representations $\\text{Gal}(\\overline{\\mathbb{Q}}/\\mathbb{Q}) \\to GL_2(\\mathb"
+    },
+    {
+      "id": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem — (p−1)! ≡ −1 (mod p) — is a statement about the group (ℤ/pℤ)* of order p−1. The Sylow p-subgroups of ("
+    },
+    {
+      "id": "derangements",
+      "relationship": "related",
+      "description": "Derangements are fixed-point-free permutations in Sₙ. The Sylow p-subgroups of Sₙ have a recursive wreath product struct"
+    },
+    {
+      "id": "partition-theorem",
+      "relationship": "related",
+      "description": "Integer partitions of n index the conjugacy classes of Sₙ by cycle type. Sylow counting in Sₙ depends on the prime facto"
+    },
+    {
+      "id": "inverse-galois",
+      "relationship": "related",
+      "description": "The inverse Galois problem asks which groups occur as Galois groups over ℚ. Sylow subgroups constrain realizability: if "
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Quadratic reciprocity governs the structure of (ℤ/pℤ)*, whose Sylow 2-subgroup determines the quadratic residue structur"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/szemeredi-core/meta.json
+++ b/src/data/proofs/szemeredi-core/meta.json
@@ -222,6 +222,11 @@
       "id": "roth-theorem-k3",
       "relationship": "related",
       "description": "Roth's theorem (1953) on 3-term arithmetic progressions was the first major application of regularity-type ideas. While "
+    },
+    {
+      "id": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey's theorem guarantees monochromatic complete subgraphs in edge-colorings. The regularity lemma generalizes this pe"
     }
   ]
 }

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -237,6 +237,16 @@
       "id": "roth-theorem-k3",
       "relationship": "related",
       "description": "Roth's theorem (1953) on 3-term APs can be proved via regularity + triangle removal — the regularity lemma provides the "
+    },
+    {
+      "id": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey theory and regularity are complementary tools: Ramsey guarantees monochromatic complete subgraphs, while regulari"
+    },
+    {
+      "id": "prob-method-alteration",
+      "relationship": "related",
+      "description": "Regularity captures pseudo-randomness: epsilon-regular pairs behave like random bipartite graphs for counting purposes, "
     }
   ]
 }

--- a/src/data/proofs/taylor-theorem/meta.json
+++ b/src/data/proofs/taylor-theorem/meta.json
@@ -211,6 +211,21 @@
       "id": "basel-problem",
       "relationship": "related",
       "description": "Euler's evaluation $\\zeta(2) = \\pi^2/6$ can be proved via the Taylor series $\\sin(x)/x = \\prod(1 - x^2/(n\\pi)^2)$ — comparing Taylor coefficients yields the Basel sum."
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "related",
+      "description": "Taylor series expand functions in powers of $(x-a)$ (local, polynomial basis), while Fourier series expand in $e^{inx}$ "
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "The Taylor series $\\arctan(x) = x - x^3/3 + x^5/5 - \\cdots$ evaluated at $x = 1$ gives Leibniz's formula $\\pi/4 = 1 - 1/"
+    },
+    {
+      "id": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "IVT guarantees the existence of the intermediate point $c$ in the Lagrange remainder: $R_n = f^{(n+1)}(c)(x-a)^{n+1}/(n+"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/three-place-identity/meta.json
+++ b/src/data/proofs/three-place-identity/meta.json
@@ -207,6 +207,11 @@
       "id": "schroeder-bernstein",
       "relationship": "thematic",
       "description": "The Schröder-Bernstein theorem on set bijections relies on the membership relation that Etter's D1 bridge derives from identity — showing how classical set-theoretic results emerge from the identity-first perspective"
+    },
+    {
+      "id": "halting-problem",
+      "relationship": "thematic",
+      "description": "The halting problem's undecidability constrains what any foundational system can prove — Etter's identity theory, being "
     }
   ],
   "leanFile": {

--- a/src/data/proofs/triangle-inequality/meta.json
+++ b/src/data/proofs/triangle-inequality/meta.json
@@ -205,6 +205,31 @@
       "id": "intermediate-value-theorem",
       "relationship": "related",
       "description": "The intermediate value theorem and the triangle inequality are both foundational results for real analysis. The triangle inequality is used in proofs of uniform continuity and the IVT's generalization to metric spaces"
+    },
+    {
+      "id": "mean-value-theorem",
+      "relationship": "related",
+      "description": "The mean value theorem combined with the triangle inequality yields key estimates: $|f(x) - f(y)| \\leq M|x - y|$ where $"
+    },
+    {
+      "id": "brouwer-fixed-point",
+      "relationship": "related",
+      "description": "The Brouwer fixed-point theorem's proof via Schauder's theorem relies on the triangle inequality in normed spaces to est"
+    },
+    {
+      "id": "schauder-fixed-point",
+      "relationship": "related",
+      "description": "Schauder's fixed-point theorem operates in Banach spaces where the triangle inequality axiom provides the metric structu"
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "thematic",
+      "description": "Both the triangle inequality and the isoperimetric theorem concern optimal geometric configurations: the triangle inequa"
+    },
+    {
+      "id": "cauchy-schwarz-integral",
+      "relationship": "complementary",
+      "description": "The integral Cauchy-Schwarz inequality $|\\int fg| \\leq (\\int f^2)^{1/2}(\\int g^2)^{1/2}$ implies the triangle inequality"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/vietas-formulas-oq-03/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03/meta.json
@@ -227,6 +227,21 @@
       "id": "solution-of-cubic",
       "relationship": "complementary",
       "description": "Cardano's cubic formula explicitly uses Newton's identity p₃ = e₁³ − 3e₁e₂ + 3e₃ via the sum-of-cubes factorization: the resolvent cubic in Cardano's method involves expressing root combinations as symmetric functions, exactly the bridge Newton's identities provide"
+    },
+    {
+      "id": "general-quartic",
+      "relationship": "complementary",
+      "description": "Ferrari's quartic formula uses the resolvent cubic, whose discriminant is expressed via elementary symmetric polynomials"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization in Z[x₁,...,xₙ] guarantees that the polynomial identities proved by `ring` are valid — the ri"
+    },
+    {
+      "id": "lagrange-four-squares",
+      "relationship": "thematic",
+      "description": "Lagrange's four-squares theorem (every positive integer is a sum of four squares) is historically connected to Waring's "
     }
   ],
   "references": [

--- a/src/data/proofs/vietas-formulas/meta.json
+++ b/src/data/proofs/vietas-formulas/meta.json
@@ -181,6 +181,11 @@
       "id": "general-quartic",
       "relationship": "related",
       "description": "Ferrari's quartic resolution uses Vieta's formulas for the resolvent cubic — relating quartic root sums/products to the "
+    },
+    {
+      "id": "inverse-galois",
+      "relationship": "related",
+      "description": "Vieta's formulas show that polynomial coefficients are symmetric functions of roots, so the Galois group permutes roots "
     }
   ],
   "references": [

--- a/src/data/proofs/wilsons-theorem/meta.json
+++ b/src/data/proofs/wilsons-theorem/meta.json
@@ -219,6 +219,41 @@
       "id": "fermat-two-squares",
       "relationship": "related",
       "description": "Wilson's theorem and Fermat's two-squares theorem both concern primes modulo 4. Wilson's theorem shows $(p-1)! \\equiv -1"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "extends",
+      "description": "The existence of primitive roots (generators of $(\\mathbb{Z}/p\\mathbb{Z})^*$) is closely related to Wilson's theorem. If"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Both concern the distribution of primes. Bertrand's postulate (a prime exists between $n$ and $2n$) and Wilson's theorem"
+    },
+    {
+      "id": "factor-remainder-theorem",
+      "relationship": "related",
+      "description": "The Factor Theorem's polynomial-root connection parallels Wilson's arithmetic-root connection: the Factor Theorem says $"
+    },
+    {
+      "id": "bezout-identity",
+      "relationship": "foundational",
+      "description": "Bézout's identity ($\\gcd(a,n) = 1 \\Rightarrow \\exists a^{-1}$ with $a \\cdot a^{-1} \\equiv 1 \\pmod{n}$) provides the mult"
+    },
+    {
+      "id": "sylow-theorems",
+      "relationship": "related",
+      "description": "Sylow's theorems describe subgroup structure of finite groups. Applied to $(\\mathbb{Z}/p\\mathbb{Z})^*$ (cyclic of order "
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "Unique prime factorization connects to Wilson's backward direction: if $n$ is composite with smallest prime factor $p \\l"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both Wilson's theorem and Abel-Ruffini analyze the structure of symmetric/cyclic groups. Wilson's theorem shows $(\\mathb"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -291,6 +291,16 @@
       "id": "yang-mills-transfer-matrix",
       "relationship": "has-submodule",
       "description": "Proven finite-volume mass gap via transfer matrix / Perron-Frobenius — the strongest rigorous result in this formalization"
+    },
+    {
+      "id": "yang-mills-lattice",
+      "relationship": "has-submodule",
+      "description": "Lattice gauge theory with proven plaquette gauge invariance and action bounds"
+    },
+    {
+      "id": "yang-mills-2d",
+      "relationship": "has-submodule",
+      "description": "Exact 2D Yang-Mills solution via Migdal formula with proven area law and mass gap"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary
Comprehensive enrichment pass syncing `relatedProofs` arrays with `crossReferences` across the entire gallery. Many entries had detailed `crossReferences` but truncated `relatedProofs` — this PR brings them into alignment.

**Scope:**
- 1446 / 1529 gallery entries now have fully synced `relatedProofs` matching `crossReferences`
- ~200 entries updated across multiple batches
- 83 entries remain unsyncable due to non-standard JSON structure (missing `id` or `targetId` fields)

**Additional improvements (first 2 entries):**
- **amgm-inequality-oq-03-oq-02**: LaTeX `problemStatement` formatting
- **Multiple entries**: Expanded `mathlibDependencies`

## Test plan
- [x] JSON validation passes for all modified files
- [x] All changes are metadata-only (no Lean code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)