### PR TITLE
Peer review: hilbert-17 (C+)

### DIFF
--- a/src/data/proofs/hilbert-17/review.json
+++ b/src/data/proofs/hilbert-17/review.json
@@ -1,0 +1,150 @@
+{
+  "version": 1,
+  "proofId": "hilbert-17",
+  "reviewDate": "2026-03-24T13:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "C+",
+    "oneLiner": "Comprehensive scaffold covering Artin's theorem, Motzkin's counterexample, Hilbert's 1888 classification, and Pfister's bounds with excellent pedagogy, but mathematically thin — 10 axioms and only 1 genuine deduction among 11 'theorems'.",
+    "tier": "C",
+    "tierJustification": "All 10 mathematical results are axiomatized. Of 11 proved theorems, 9 are one-line wrappers (theorem foo := foo_aux), 1 is filler (real_is_real_closed : True), and only 1 (motzkin_sos_ratfunc) is a genuine deduction combining two axioms. The definitions are well-typed and the mathematical landscape is broad, but no significant mathematical reasoning is formalized."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "annotations.json, all entries; overview.historicalContext",
+      "finding": "The pedagogical exposition is exceptional. The historical narrative from Hilbert 1888 through Artin 1927 to Motzkin 1967 is accurate and proportionate. The annotations explain the AM-GM proof for Motzkin, the Gram matrix approach for quadratics, and the connection to Pfister forms. The distinction between polynomial-SOS and rational-SOS is clearly articulated throughout. The overview.keyInsights are genuinely insightful.",
+      "recommendation": "Preserve the exposition quality. This is the file's strongest asset."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Hilbert17SumOfSquares.lean, lines 107-132",
+      "finding": "The SOS and PSD definitions (IsSumOfSquaresPolynomial, IsSumOfSquaresMvPolynomial, IsSumOfSquaresRatFunc, IsPositiveSemidefinite, IsPositiveSemidefiniteMv) are well-designed using Lean's type system. The three-way SOS distinction (polynomial, multivariate polynomial, rational function) correctly captures the mathematical landscape.",
+      "recommendation": "Preserve these definitions — they could serve as a foundation for substantive proofs."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "motzkin_sos_ratfunc, lines 263-267",
+      "finding": "The one genuine deduction in the file: combining motzkin_nonneg (axiomatized PSD) with artin_hilbert17 to derive that the Motzkin polynomial is rational-SOS despite not being polynomial-SOS. This exemplifies exactly the theorem's content. The annotation correctly identifies this as 'the only non-trivial deduction in the file.'",
+      "recommendation": "Highlight this as the proof's key contribution in originalContributions."
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "All 'theorem' declarations except motzkin_sos_ratfunc",
+      "finding": "Of 11 proved theorems, 9 are one-line wrappers around axioms (e.g., theorem motzkin_nonneg := motzkin_nonneg_aux). This creates the appearance of 11 proved results when there is effectively 1 genuine deduction. The pattern of pairing every axiom with a wrapper theorem inflates the theoremCount without adding mathematical content.",
+      "recommendation": "Enricher: Note in meta.json that 9 of 11 theorems are axiom wrappers. Consider whether the wrapper pattern is necessary — the axioms could be named directly (motzkin_nonneg instead of motzkin_nonneg_aux) to eliminate the redundancy."
+    },
+    {
+      "severity": "major",
+      "category": "filler",
+      "location": "real_is_real_closed, line 425",
+      "finding": "Proves True with comment 'In full Mathlib, this would be: IsRealClosed ℝ'. This is a filler theorem that proves nothing. Unlike the motzkin_sos_ratfunc deduction, this doesn't even combine axioms — it's just trivial.",
+      "recommendation": "Researcher: Either replace with an actual statement using Mathlib's IsRealClosed (if available) or remove the theorem entirely. The comments documenting the aspiration are fine without a vacuous proof."
+    },
+    {
+      "severity": "moderate",
+      "category": "gap",
+      "location": "artin_univariate_aux (line 176); cassels_bound_bivariate_aux (line 386)",
+      "finding": "Two axioms are redundant with others: artin_univariate_aux is a special case of artin_hilbert17 (n=1), and cassels_bound_bivariate_aux is a special case of pfister_bound_aux (n=2, Fin 4 = Fin (2^2)). These could be derived rather than axiomatized, reducing the axiom count from 10 to 8 without losing any content.",
+      "recommendation": "Researcher: Derive artin_univariate from artin_hilbert17 and cassels_bound_bivariate from pfister_bound. This would add 2 genuine deductions and reduce the axiom count."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "Hilbert17SumOfSquares.lean, docstring line 64",
+      "finding": "The status checklist says '[ ] Incomplete (has sorries - full proof requires substantial model theory)'. The file has 0 sorries; it uses axioms instead. This contradicts the 0-sorry claim in meta.json and mischaracterizes the incompleteness.",
+      "recommendation": "Enricher: Change to '[ ] Incomplete (10 axioms - full proof requires model theory and real algebraic geometry)' to accurately describe the axiom-based approach."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions, 'Motzkin polynomial counterexample with non-negativity and non-SOS proofs'",
+      "finding": "Both motzkin_nonneg and motzkin_not_sos_polynomial are axiomatized, not proved. The word 'proofs' is inaccurate.",
+      "recommendation": "Enricher: Change to 'Motzkin polynomial definition with axiomatized non-negativity and non-SOS properties' or similar."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json assumptions field",
+      "finding": "The assumptions field says '10 axioms: artin_hilbert17, artin_univariate_aux, motzkin_nonneg_aux, and 7 more. See Lean source for complete statements.' Other Hilbert problem entries list all axioms by name. This is incomplete and unhelpful for readers who want to understand the assumptions without reading the source.",
+      "recommendation": "Enricher: List all 10 axioms with one-line descriptions, consistent with the hilbert-4 and hilbert-10 entries."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json relatedProofs",
+      "finding": "Contains 3 entries with empty id ('') and generic description ('Related gallery proof'). The 2 populated entries (fundamental-theorem-algebra, hilbert-10) have the relationship and description fields swapped compared to the crossReferences format.",
+      "recommendation": "Enricher: Remove the 3 empty entries. Fix the field values for the populated entries."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json references",
+      "finding": "Only lists Hilbert (1900) and Artin (1927). Missing Motzkin (1967) and Pfister (1967) who are both prominently discussed in the file and have results axiomatized.",
+      "recommendation": "Enricher: Add references for Motzkin (1967) 'The arithmetic-geometric inequality' and Pfister (1967) 'Zur Darstellung definiter Funktionen als Summe von Quadraten'."
+    },
+    {
+      "severity": "minor",
+      "category": "gap",
+      "location": "choi_lam definition, line 530",
+      "finding": "The Choi-Lam polynomial is defined but has no properties axiomatized (unlike Motzkin and Robinson which have nonneg and not-SOS axioms). It's an incomplete addition — present but not characterized.",
+      "recommendation": "Researcher: Either add axiomatized non-negativity and non-SOS properties for Choi-Lam (consistent with the other counterexamples), or note in the docstring that it is a definition-only entry."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "researcher",
+      "description": "Derive artin_univariate from artin_hilbert17 (n=1 case) and cassels_bound_bivariate from pfister_bound (n=2 case), converting 2 axioms into genuine deductions. This reduces axiom count from 10 to 8 and adds real proof content.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "medium",
+      "target": "researcher",
+      "description": "Remove filler theorem real_is_real_closed (proves True). Either replace with actual IsRealClosed ℝ from Mathlib or remove entirely.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix meta.json: list all 10 axioms in assumptions field, remove 3 empty relatedProofs entries, fix field swaps in populated relatedProofs, add Motzkin and Pfister references, fix originalContributions 'proofs' → 'axiomatized properties'.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix docstring status checklist: change 'has sorries' to 'has axioms'. Note the axiom-wrapper pattern in meta.json (9 of 11 theorems are wrappers).",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Consider proving motzkin_nonneg_aux from AM-GM (Mathlib may have the necessary ingredients). This would convert the most accessible axiom into a genuine proof and demonstrate the AM-GM argument described in the annotations.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 4,
+    "originalityAccuracy": 5,
+    "completeness": 5,
+    "framingPrecision": 7,
+    "pedagogicalQuality": 9,
+    "internalConsistency": 6,
+    "overall": 6.0
+  },
+
+  "suggestedBestFraming": "A pedagogical scaffold for Hilbert's 17th Problem that defines SOS and PSD predicates, axiomatizes Artin's theorem, Motzkin's counterexample properties, Hilbert's 1888 classification, and Pfister's quantitative bounds, with one genuine deduction (deriving Motzkin is rational-SOS from Artin's theorem and non-negativity) as the central mathematical argument."
+}

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -152,6 +152,14 @@
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0
+    },
+    "hilbert-17": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-24T15:41:27Z",
+      "overallGrade": "C+",
+      "qualityScore": null,
+      "actionItems": 0,
+      "resolvedItems": 0
     }
   }
 }


### PR DESCRIPTION
## Summary

- Deep peer review of hilbert-17 (Hilbert's 17th Problem: Sum of Squares)
- Grade: **C+** (6.0/10) — broad scaffold with excellent pedagogy but thin mathematics
- 12 findings: 3 positive, 2 major, 4 moderate, 3 minor
- 5 action items (2 for researcher, 3 for enricher)

## Key Findings

**Major**: Of 11 "proved" theorems, 9 are one-line wrappers around axioms (`theorem foo := foo_aux`). Only `motzkin_sos_ratfunc` (combining Artin + non-negativity) is a genuine deduction. `real_is_real_closed` proves `True`.

**Redundancy**: 2 axioms are special cases of others (artin_univariate_aux of artin_hilbert17, cassels_bound of pfister_bound) — could be derived instead.

**Strengths**: Exceptional pedagogical exposition, well-designed SOS/PSD type definitions, broad mathematical landscape coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)