### PR TITLE
Gallery audit cycle 15: audit 5 proofs, all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -753,26 +753,26 @@
       "issues": []
     },
     "erdos-1137": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:41:48Z",
       "result": "clean",
       "issues": []
     },
     "erdos-1138-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:41:48Z",
       "result": "clean",
       "issues": []
     },
     "erdos-131": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:41:48Z",
       "result": "clean",
       "issues": []
     },
     "erdos-402": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:25:07Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:41:48Z",
       "result": "clean",
       "issues": []
     },
@@ -897,8 +897,8 @@
       "issues": []
     },
     "cantors-theorem-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:57:03Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T15:41:48Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary
- Audited 5 proofs, all clean (scanner false positives)
- Sorry count mismatches: all from block comment mentions of "sorry"
- cantors-theorem-oq-02: badge "verified" correct (basic Mathlib deps, original proofs)

## Proofs Audited
| Proof | Claimed | Actual | Result |
|-------|---------|--------|--------|
| erdos-402 | 2 sorries | 2 | Clean |
| erdos-131 | 4 sorries | 4 | Clean |
| erdos-1137 | 0 sorries | 0 | Clean |
| erdos-1138-oq-03 | 0 sorries | 0 | Clean |
| cantors-theorem-oq-02 | 0 sorries, verified | 0, Tier A | Clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)