### PR TITLE
Enrich erdos-414: fix lineCount (155 → 171)

### DIFF
--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -229,7 +229,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This 155-line formalization captures the OPEN Erdős Problem #414: do all orbits of the iteration $h(n) = n + \\tau(n)$ eventually merge, where $\\tau(n)$ is the divisor count function? The formalization defines the orbit structure, proves basic properties (e.g., $h(n) > n$ so orbits are strictly increasing), axiomatizes the coalescence conjecture, and verifies small-case mergers computationally. The problem's difficulty is irreducibility: the divisor function $\\tau(n) = \\prod(e_i + 1)$ fluctuates wildly with the prime factorization of $n$, and proving two trajectories $h^i(m), h^j(n)$ eventually collide requires controlling cumulative irregularities across arbitrarily many steps. The heuristic that $\\tau(n)$ averages $\\ln n$ suggests orbits grow like $n + c \\cdot n\\ln n$ and should merge, but the gap between average behavior and pointwise control of specific trajectories remains unbridged.",
+    "summary": "This 171-line formalization captures the OPEN Erdős Problem #414: do all orbits of the iteration $h(n) = n + \\tau(n)$ eventually merge, where $\\tau(n)$ is the divisor count function? The formalization defines the orbit structure, proves basic properties (e.g., $h(n) > n$ so orbits are strictly increasing), axiomatizes the coalescence conjecture, and verifies small-case mergers computationally. The problem's difficulty is irreducibility: the divisor function $\\tau(n) = \\prod(e_i + 1)$ fluctuates wildly with the prime factorization of $n$, and proving two trajectories $h^i(m), h^j(n)$ eventually collide requires controlling cumulative irregularities across arbitrarily many steps. The heuristic that $\\tau(n)$ averages $\\ln n$ suggests orbits grow like $n + c \\cdot n\\ln n$ and should merge, but the gap between average behavior and pointwise control of specific trajectories remains unbridged.",
     "implications": "A resolution would advance the theory of arithmetic dynamics — understanding when simple number-theoretic iterations have universal limiting behavior. The problem connects divisor function regularity (Dirichlet divisor problem), additive combinatorics (collision conditions), and discrete dynamical systems (orbit coalescence). Techniques developed for this problem could apply to the broader family of 'n + f(n)' iterations for multiplicative arithmetic functions f. The collision mechanism h(a) = h(b) when τ(a) - τ(b) = b - a connects to the distribution of values of τ, a classical topic in multiplicative number theory",
     "openQuestions": [
       "Does the merging conjecture hold? Can any pair of orbits be shown to collide?",
@@ -240,7 +240,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 155,
+    "lineCount": 171,
     "structureCount": 0,
     "axiomCount": 2,
     "theoremCount": 13,


### PR DESCRIPTION
Enrichment pass for erdos-414 (Merging Orbits of h(n) = n + τ(n)).

## Changes
- Fixed `lineCount` in both `meta` and `leanFile` sections: 155 → 171 (verified via `wc -l`)
- Fixed "155-line" → "171-line" in conclusion summary

## Axiom integrity
Verified: 2 axioms (erdos_414_conjecture, orbits_get_close), status "axiomatized", badge "axiom" — correct.