### PR TITLE
Fix: revert inverse-galois sorry count 14→2

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -26,7 +26,7 @@
       "Proofs/AbelRuffini.lean"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 2,
     "axiomCount": 2,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
@@ -34,14 +34,14 @@
       "Group theory (symmetric and alternating groups, Sylow theorems, solvability)",
       "Algebraic number theory (Eisenstein criterion, Dedekind's theorem)"
     ],
-    "assumptions": "2 axiom(s) and 14 sorry(s).",
+    "assumptions": "2 axiom(s) and 2 sorry(s).",
     "leanFile": {
       "lineCount": 1881,
       "theoremCount": 107,
       "lemmaCount": 1,
       "defCount": 1,
       "axiomCount": 2,
-      "sorryCount": 14,
+      "sorryCount": 2,
       "imports": [
         "Mathlib.NumberTheory.Cyclotomic.Basic",
         "Mathlib.NumberTheory.Cyclotomic.Gal",


### PR DESCRIPTION
## Fix

Reverts the incorrect change from PR #6135 which changed `sorries` from 2 to 14.

## Evidence

**Root cause**: `grep -cw "sorry"` counted 14 occurrences, but 12 are in comments/documentation (e.g., "sorry-free proofs", "was sorry"). Only 2 actual code sorries exist:
- Line 77: `sorry -- OPEN: No proof known for general finite group G`
- Line 364: `sorry -- Classical: Hilbert's irreducibility theorem (not yet in Mathlib)`

**Before (incorrect)**: `sorries: 14`, `sorryCount: 14`
**After (correct)**: `sorries: 2`, `sorryCount: 2`

---
Automated fix by lean-mechanic agent.