### PR TITLE
Enrich erdos-848: fix lineCount (176 → 255)

### DIFF
--- a/src/data/proofs/erdos-848/meta.json
+++ b/src/data/proofs/erdos-848/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 3,
     "assumptions": "3 axiom declarations: vanDoorn_upper_bound (0.108N upper bound via prime density), sawhney_solution (exact answer N/25 for large N), sawhney_structure (extremal set uniqueness). Previously axiomatized maxNonSqfreeSet, maxNonSqfreeSet_le, and lower_bound are now proved.",
-    "lineCount": 176,
+    "lineCount": 255,
     "dateAdded": "2026-02-10",
     "mathlibDependencies": [
       {
@@ -149,7 +149,7 @@
     ],
     "opens": [],
     "namespace": "Erdos848",
-    "lineCount": 176,
+    "lineCount": 255,
     "axiomCount": 3,
     "theoremCount": 8,
     "definitionCount": 4


### PR DESCRIPTION
Enrichment pass for erdos-848 (Squarefree Products and Extremal Sets).

## Changes
- Fixed `lineCount` in both `meta` and `leanFile` sections: 176 → 255 (verified via `wc -l`)

## Axiom integrity
Verified: 3 axioms, lineCount 255, status "axiomatized", badge "axiom" — all correct.