### PR TITLE
Fix: birch-swinnerton-dyer axiomCount 24 → 21

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -15,8 +15,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 24,
-    "assumptions": "24 axiom(s). No sorries.",
+    "axiomCount": 21,
+    "assumptions": "21 axiom(s). No sorries.",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",


### PR DESCRIPTION
## Fix

Update meta.json axiomCount and assumptions text to match actual axiom declarations in BirchSwinnertonDyer.lean.

## Evidence

**Before**: `meta.axiomCount: 24`, `assumptions: "24 axiom(s). No sorries."`
**After**: `meta.axiomCount: 21`, `assumptions: "21 axiom(s). No sorries."`

The Lean file has 21 `axiom` declarations. The count drifted as research agents eliminated axioms over PRs #4263, #4372, #4389, #4643 without updating the meta section.

The `leanFile.axiomCount` was already correct at 21.

---
Automated fix by lean-mechanic agent.