### PR TITLE
Enrich: add wiedijk-100 tag to 44 Wiedijk proofs

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -14,7 +14,8 @@
       "field-theory",
       "classic",
       "impossibility",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/AngleTrisection.lean",
     "badge": "verified",

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -12,7 +12,8 @@
       "geometry",
       "measure-theory",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/AreaOfCircle.lean",
     "badge": "mathlib",

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -14,7 +14,8 @@
       "primes",
       "prime-gaps",
       "classic",
-      "erdos"
+      "erdos",
+      "wiedijk-100"
     ],
     "badge": "mathlib",
     "sorries": 0,

--- a/src/data/proofs/bezout-identity/meta.json
+++ b/src/data/proofs/bezout-identity/meta.json
@@ -12,7 +12,8 @@
       "number-theory",
       "algorithms",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/BezoutIdentity.lean",
     "badge": "mathlib",

--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -12,7 +12,8 @@
       "algebra",
       "combinatorics",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/BinomialTheorem.lean",
     "badge": "mathlib",

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -13,7 +13,8 @@
       "combinatorics",
       "counting",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/BirthdayProblem.lean",
     "badge": "mathlib",

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -12,7 +12,8 @@
       "analysis",
       "linear-algebra",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/CauchySchwarz.lean",
     "badge": "mathlib",

--- a/src/data/proofs/cayley-hamilton/meta.json
+++ b/src/data/proofs/cayley-hamilton/meta.json
@@ -12,7 +12,8 @@
       "linear-algebra",
       "matrices",
       "polynomials",
-      "eigenvalues"
+      "eigenvalues",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/CayleyHamilton.lean",
     "badge": "mathlib",

--- a/src/data/proofs/central-limit-theorem/meta.json
+++ b/src/data/proofs/central-limit-theorem/meta.json
@@ -13,7 +13,8 @@
       "topology",
       "analysis",
       "advanced",
-      "characteristic-functions"
+      "characteristic-functions",
+      "wiedijk-100"
     ],
     "badge": "axiom",
     "sorries": 0,

--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -13,7 +13,8 @@
       "triangle",
       "concurrency",
       "signed-ratios",
-      "classic"
+      "classic",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/CevasTheorem.lean",
     "badge": "original",

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -12,7 +12,8 @@
       "linear-algebra",
       "matrices",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/CramersRule.lean",
     "badge": "mathlib",

--- a/src/data/proofs/de-moivre/meta.json
+++ b/src/data/proofs/de-moivre/meta.json
@@ -13,7 +13,8 @@
       "trigonometry",
       "classic",
       "intermediate",
-      "wiedijk"
+      "wiedijk",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/DeMoivre.lean",
     "badge": "mathlib",

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -12,7 +12,8 @@
       "combinatorics",
       "probability",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/Derangements.lean",
     "badge": "mathlib",

--- a/src/data/proofs/desargues-theorem/meta.json
+++ b/src/data/proofs/desargues-theorem/meta.json
@@ -14,7 +14,8 @@
       "perspective",
       "collinearity",
       "concurrence",
-      "classic"
+      "classic",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/DesarguesTheorem.lean",
     "badge": "mathlib",

--- a/src/data/proofs/dirichlets-theorem/meta.json
+++ b/src/data/proofs/dirichlets-theorem/meta.json
@@ -17,7 +17,8 @@
       "dirichlet",
       "analytic-number-theory",
       "l-functions",
-      "arithmetic-progressions"
+      "arithmetic-progressions",
+      "wiedijk-100"
     ],
     "badge": "mathlib",
     "sorries": 0,

--- a/src/data/proofs/divisibility-by-3/meta.json
+++ b/src/data/proofs/divisibility-by-3/meta.json
@@ -13,7 +13,8 @@
       "divisibility",
       "modular-arithmetic",
       "classic",
-      "easy"
+      "easy",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/DivisibilityBy3.lean",
     "badge": "mathlib",

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -13,7 +13,8 @@
       "modular-arithmetic",
       "primes",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/EulerTotient.lean",
     "badge": "mathlib",

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -13,7 +13,8 @@
       "elliptic-curves",
       "modular-forms",
       "advanced",
-      "milestone"
+      "milestone",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/FermatsLastTheorem.lean",
     "badge": "axiom",

--- a/src/data/proofs/feuerbachs-theorem-defs/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs/meta.json
@@ -17,7 +17,8 @@
       "triangle",
       "circumcenter",
       "incircle",
-      "infrastructure"
+      "infrastructure",
+      "wiedijk-100"
     ],
     "badge": "infrastructure",
     "sorries": 0,

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -12,7 +12,8 @@
       "graph-theory",
       "combinatorics",
       "computer-assisted-proof",
-      "advanced"
+      "advanced",
+      "wiedijk-100"
     ],
     "badge": "axiom",
     "sorries": 0,

--- a/src/data/proofs/friendship-theorem/meta.json
+++ b/src/data/proofs/friendship-theorem/meta.json
@@ -12,7 +12,8 @@
       "graph-theory",
       "combinatorics",
       "spectral-methods",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/FriendshipTheorem.lean",
     "badge": "verified",

--- a/src/data/proofs/fundamental-arithmetic/meta.json
+++ b/src/data/proofs/fundamental-arithmetic/meta.json
@@ -12,7 +12,8 @@
       "number-theory",
       "primes",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/FundamentalArithmetic.lean",
     "badge": "mathlib",

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -13,7 +13,8 @@
       "integration",
       "differentiation",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculus.lean",
     "badge": "mathlib",

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -12,7 +12,8 @@
       "algebra",
       "polynomial",
       "classic",
-      "hard"
+      "hard",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/GeneralQuartic.lean",
     "badge": "axiom",

--- a/src/data/proofs/herons-formula/meta.json
+++ b/src/data/proofs/herons-formula/meta.json
@@ -12,7 +12,8 @@
       "geometry",
       "trigonometry",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/HeronsFormula.lean",
     "badge": "mathlib",

--- a/src/data/proofs/infinitude-primes/meta.json
+++ b/src/data/proofs/infinitude-primes/meta.json
@@ -14,7 +14,8 @@
       "primes",
       "classic",
       "euclid",
-      "beginner-friendly"
+      "beginner-friendly",
+      "wiedijk-100"
     ],
     "badge": "original",
     "sorries": 0,

--- a/src/data/proofs/intermediate-value-theorem/meta.json
+++ b/src/data/proofs/intermediate-value-theorem/meta.json
@@ -13,7 +13,8 @@
       "continuity",
       "connectedness",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/IntermediateValueTheorem.lean",
     "badge": "mathlib",

--- a/src/data/proofs/isosceles-triangle/meta.json
+++ b/src/data/proofs/isosceles-triangle/meta.json
@@ -13,7 +13,8 @@
       "euclidean",
       "classic",
       "beginner",
-      "wiedijk"
+      "wiedijk",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/IsoscelesTriangle.lean",
     "badge": "mathlib",

--- a/src/data/proofs/konigsberg/meta.json
+++ b/src/data/proofs/konigsberg/meta.json
@@ -12,7 +12,8 @@
       "graph-theory",
       "combinatorics",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/Konigsberg.lean",
     "badge": "mathlib",

--- a/src/data/proofs/lagrange-theorem/meta.json
+++ b/src/data/proofs/lagrange-theorem/meta.json
@@ -12,7 +12,8 @@
       "group-theory",
       "algebra",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/LagrangeTheorem.lean",
     "badge": "mathlib",

--- a/src/data/proofs/laws-of-large-numbers/meta.json
+++ b/src/data/proofs/laws-of-large-numbers/meta.json
@@ -12,7 +12,8 @@
       "probability",
       "statistics",
       "analysis",
-      "convergence"
+      "convergence",
+      "wiedijk-100"
     ],
     "badge": "axiom",
     "sorries": 0,

--- a/src/data/proofs/lhopital/meta.json
+++ b/src/data/proofs/lhopital/meta.json
@@ -13,7 +13,8 @@
       "limits",
       "derivatives",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/LHopital.lean",
     "badge": "mathlib",

--- a/src/data/proofs/mean-value-theorem/meta.json
+++ b/src/data/proofs/mean-value-theorem/meta.json
@@ -12,7 +12,8 @@
       "calculus",
       "analysis",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/MeanValueTheorem.lean",
     "badge": "mathlib",

--- a/src/data/proofs/pell-equation/meta.json
+++ b/src/data/proofs/pell-equation/meta.json
@@ -12,7 +12,8 @@
       "number-theory",
       "diophantine-equations",
       "continued-fractions",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/PellEquation.lean",
     "badge": "mathlib",

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -12,7 +12,8 @@
       "geometry",
       "circles",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/ProductOfSegmentsOfChords.lean",
     "badge": "axiom",

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -12,7 +12,8 @@
       "geometry",
       "circle",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/PtolemysTheorem.lean",
     "badge": "mathlib",

--- a/src/data/proofs/pythagorean-theorem/meta.json
+++ b/src/data/proofs/pythagorean-theorem/meta.json
@@ -12,7 +12,8 @@
       "geometry",
       "inner-product",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/PythagoreanTheorem.lean",
     "badge": "original",

--- a/src/data/proofs/pythagorean-triples/meta.json
+++ b/src/data/proofs/pythagorean-triples/meta.json
@@ -12,7 +12,8 @@
       "number-theory",
       "geometry",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/PythagoreanTriples.lean",
     "badge": "mathlib",

--- a/src/data/proofs/ramseys-theorem/meta.json
+++ b/src/data/proofs/ramseys-theorem/meta.json
@@ -14,7 +14,8 @@
       "graph-theory",
       "ramsey-theory",
       "pigeonhole",
-      "classic"
+      "classic",
+      "wiedijk-100"
     ],
     "badge": "axiom",
     "sorries": 0,

--- a/src/data/proofs/sqrt2-irrational/meta.json
+++ b/src/data/proofs/sqrt2-irrational/meta.json
@@ -9,7 +9,8 @@
       "number-theory",
       "classic",
       "irrationality",
-      "generalization"
+      "generalization",
+      "wiedijk-100"
     ],
     "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/Sqrt2Irrational.lean",

--- a/src/data/proofs/subset-count/meta.json
+++ b/src/data/proofs/subset-count/meta.json
@@ -13,7 +13,8 @@
       "combinatorics",
       "counting",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/SubsetCount.lean",
     "badge": "mathlib",

--- a/src/data/proofs/taylor-theorem/meta.json
+++ b/src/data/proofs/taylor-theorem/meta.json
@@ -13,7 +13,8 @@
       "analysis",
       "approximation",
       "classic",
-      "intermediate"
+      "intermediate",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/TaylorTheorem.lean",
     "badge": "mathlib",

--- a/src/data/proofs/triangle-angle-sum/meta.json
+++ b/src/data/proofs/triangle-angle-sum/meta.json
@@ -12,7 +12,8 @@
       "geometry",
       "euclidean",
       "classic",
-      "beginner"
+      "beginner",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/TriangleAngleSum.lean",
     "badge": "mathlib",

--- a/src/data/proofs/triangular-reciprocals/meta.json
+++ b/src/data/proofs/triangular-reciprocals/meta.json
@@ -14,7 +14,8 @@
       "combinatorics",
       "classic",
       "intermediate",
-      "wiedijk"
+      "wiedijk",
+      "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/TriangularNumberReciprocals.lean",
     "badge": "mathlib",


### PR DESCRIPTION
## Summary
- Added missing `wiedijk-100` tag to 44 gallery entries that have `wiedijkNumber` set but were missing the tag
- Covers Wiedijk #1 (sqrt2-irrational) through #98 (bertrands-postulate)
- This enables tag-based filtering to correctly show all Wiedijk 100 theorems on the gallery page

Found systematically while enriching `area-of-circle` (Wiedijk #9).