### PR TITLE
Fix: inverse-galois sorry count 14→2 (revert incorrect #6135)

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -26,7 +26,7 @@
       "Proofs/AbelRuffini.lean"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 2,
     "axiomCount": 2,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
@@ -34,7 +34,7 @@
       "Group theory (symmetric and alternating groups, Sylow theorems, solvability)",
       "Algebraic number theory (Eisenstein criterion, Dedekind's theorem)"
     ],
-    "assumptions": "2 axiom(s) and 14 sorry(s).",
+    "assumptions": "2 axiom(s) and 2 sorry(s). The 2 sorries are: (1) the main IGP conjecture (open problem, no proof known), (2) Hilbert's irreducibility theorem (classical, not yet in Mathlib).",
     "leanFile": {
       "lineCount": 1881,
       "theoremCount": 107,


### PR DESCRIPTION
## Summary

- Reverts the incorrect sorry count change from PR #6135 (2→14 was wrong)
- The file has only **2 actual sorry tactics** (lines 77 and 364)
- The other 12 occurrences of "sorry" are in comments describing proofs as "sorry-free"
- Verified across all 6 listed files: total actual sorries = 2

## Evidence

```bash
$ grep -cE '^\s+sorry' proofs/Proofs/InverseGalois.lean
2

$ grep -n '^\s+sorry' proofs/Proofs/InverseGalois.lean
77:  sorry -- OPEN: No proof known for general finite group G
364:  sorry -- Classical: Hilbert's irreducibility theorem (not yet in Mathlib)
```

Additional files (InverseGaloisA5, D4, F20, AbelRuffini, AbelRuffiniGaloisExtensions): 0 sorries each.

## Test plan

- [x] Verify sorry count matches Lean source
- [x] Verify assumptions field is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)