### PR TITLE
Research: erdos-1105 - fix build + structural lemmas (2 new theorems)

### DIFF
--- a/proofs/Proofs/Erdos1105Problem.lean
+++ b/proofs/Proofs/Erdos1105Problem.lean
@@ -191,10 +191,25 @@ General bounds on anti-Ramsey numbers.
 axiom ar_lower_bound : ∀ (n k : ℕ) (H : SimpleGraph k),
   antiRamsey n k H ≥ 1  -- Simplified; actual bound depends on H
 
+/-- A monochromatic coloring avoids rainbow copies of any graph with ≥ 2 edges. -/
+theorem monochromatic_avoids_rainbow (n k : ℕ) (H : SimpleGraph k)
+    (he : ∃ e₁ e₂ : Fin k × Fin k, e₁ ≠ e₂ ∧ H e₁.1 e₁.2 ∧ H e₂.1 e₂.2) :
+    AvoidsRainbow n (fun _ => (0 : ℕ)) k H := by
+  intro emb hR
+  obtain ⟨e₁, e₂, hne, he1, he2⟩ := he
+  exact absurd (hR e₁ e₂ he1 he2 hne) (by simp)
+
+/-- The number of colors is at most the number of edge slots (by card_image_le). -/
+theorem numColors_le_edges (n : ℕ) (coloring : (Fin n × Fin n) → ℕ) :
+    numColors n coloring ≤
+      (Finset.univ.filter (fun e : Fin n × Fin n => e.1 < e.2)).card :=
+  Finset.card_image_le
+
 -- Upper bound: AR(n, G) ≤ |E(K_n)| = C(n,2)
+-- Proof strategy: Nat.sSup_le + numColors_le_edges + edge_pairs_card
 theorem ar_upper_bound (n k : ℕ) (H : SimpleGraph k) :
     antiRamsey n k H ≤ numEdgesKn n := by
-  sorry -- Each edge can have its own color at most
+  sorry
 
 -- Monotonicity in n
 axiom ar_mono_n : ∀ (n₁ n₂ k : ℕ) (H : SimpleGraph k),
@@ -207,9 +222,10 @@ Anti-Ramsey numbers relate to extremal graph theory.
 -/
 
 -- Turán number ex(n, H): max edges in H-free graph on n vertices
+-- Note: requires decidability of the graph predicate for Finset.filter
 noncomputable def turan (n k : ℕ) (H : SimpleGraph k) : ℕ :=
-  sSup {e : ℕ | ∃ G : SimpleGraph n,
-    (∀ emb : GraphEmbedding n k H, False) ∧ e = (Finset.univ.filter
+  sSup {e : ℕ | ∃ (G : SimpleGraph n) (_ : DecidableRel G),
+    (∀ _emb : GraphEmbedding n k H, False) ∧ e = (Finset.univ.filter
       (fun p : Fin n × Fin n => p.1 < p.2 ∧ G p.1 p.2)).card}
 
 -- AR(n, H) ≥ ex(n, H) + 1 (give H-free graph rainbow, one color for complement)

--- a/src/data/research/problems/erdos-1105.json
+++ b/src/data/research/problems/erdos-1105.json
@@ -29,13 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 8 axioms (mostly deep results), 1 sorry. No quick wins.",
-    "builtItems": [],
+    "progressSummary": "SESSION 2: Fixed pre-existing build error (turan DecidableRel). Added 2 new proved theorems: monochromatic avoidance, numColors bound. ar_upper_bound sorry remains (needs edge_pairs_card identity). 5 theorems, 8 axioms, 1 sorry, 291 lines.",
+    "builtItems": [
+      "monochromatic_avoids_rainbow: constant coloring avoids rainbow (proved)",
+      "numColors_le_edges: numColors bounded by edge count (proved)",
+      "Fixed turan definition (added DecidableRel G for Finset.filter)"
+    ],
     "insights": [
       "8 axioms: ar_triangle, simonovits_sos_path, yuan_path_announced, ar_lower_bound (oversimplified), ar_mono_n, ar_turan_lower, ar_path_3, ar_k3",
       "1 sorry: ar_upper_bound (AR ≤ C(n,2))",
       "ar_lower_bound is oversimplified (says ≥ 1 instead of proper bound)",
-      "yuan_path_announced axiomatizes an announced result"
+      "yuan_path_announced axiomatizes an announced result",
+      "Pre-existing bug: turan definition lacked DecidableRel G, causing build failure - fixed",
+      "monochromatic_avoids_rainbow: constant coloring avoids rainbow for H with >= 2 edges (proved)",
+      "numColors_le_edges: card_image_le gives numColors <= edge slot count (proved)",
+      "ar_upper_bound: proof roadmap is Nat.sSup_le + numColors_le_edges + edge_pairs_card identity"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -63,8 +71,8 @@
     {
       "path": "Proofs/Erdos1105Problem.lean",
       "filename": "Erdos1105Problem.lean",
-      "lineCount": 276,
-      "theoremCount": 3,
+      "lineCount": 291,
+      "theoremCount": 5,
       "axiomCount": 8,
       "defCount": 25,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary
- Fixed pre-existing build error in turan definition (missing DecidableRel)
- Added 2 new proved structural theorems for anti-Ramsey numbers

## Progress
- **5 theorems** (up from 3), 8 axioms, 1 sorry, **291 lines** (up from 276)
- New: `monochromatic_avoids_rainbow`, `numColors_le_edges`
- Fixed: `turan` definition DecidableRel requirement

## Findings
- ar_upper_bound sorry is provable via: `Nat.sSup_le` + `numColors_le_edges` + edge count identity
- Most axioms are deep graph theory results (not provable without major infrastructure)
- Monochromatic coloring provides clean avoidance proof for any H with ≥ 2 edges

## Status
**Outcome**: surveyed (with fixes)
**Next Steps**: Prove edge_pairs_card identity to complete ar_upper_bound

Generated by researcher-1