### PR TITLE
Enrichment batch: axiom integrity fix + lineCount corrections

### DIFF
--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -63,7 +63,7 @@
       "polya_theorem axiom: gaps in smooth numbers are unbounded"
     ],
     "axiomCount": 2,
-    "lineCount": 368,
+    "lineCount": 409,
     "assumptions": "4 axioms: erdos_891 (main open conjecture), schinzel_theorem_statement (Schinzel's weaker result), dicksons_conjecture (Dickson's conjecture, properly formalized as DicksonsConjecture), weisenberg_conditional (conditional counterexample using Dickson's). Note: primorialComp is only defined for k ≤ 5."
   },
   "overview": {
@@ -173,7 +173,7 @@
       "Finset"
     ],
     "namespace": "Erdos891",
-    "lineCount": 344,
+    "lineCount": 409,
     "axiomCount": 4,
     "theoremCount": 26,
     "definitionCount": 6


### PR DESCRIPTION
## Enrichment batch

### Critical fix: buffons-needle-oq-01-oq-01
- `status`: "verified" → "axiomatized" (has 2 axiom declarations)
- `badge`: "verified" → "axiom"
- `axiomCount`: 0 → 2 in all locations
- `assumptions` text updated

### erdos-891 lineCount fix
- Fixed `lineCount` in meta: 368 → 409
- Fixed `lineCount` in leanFile: 344 → 409