### PR TITLE
Fix: triangle-inequality-oq-03 assumptions text

### DIFF
--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
-    "assumptions": "1 axiom, 0 sorries. See the Lean source for details."
+    "assumptions": "No axioms, no sorries. Fully machine-checked."
   },
   "overview": {
     "historicalContext": "The study of non-Archimedean analysis began with Kurt Hensel's invention of p-adic numbers in 1897, motivated by analogies between number fields and function fields. Alexander Ostrowski (1916) classified all absolute values on the rationals: they are either the usual absolute value, a p-adic absolute value, or the trivial absolute value. This classification theorem shows that the ultrametric inequality is not an exotic curiosity but governs half of all possible notions of 'distance' on the rationals.\n\nThe ultrametric inequality d(x,z) ≤ max(d(x,y), d(y,z)) — strictly stronger than the usual d(x,z) ≤ d(x,y) + d(y,z) — was studied systematically by Marc Krasner (1940s) who developed the theory of ultrametric spaces and their striking topological properties: every point inside a ball is its center, balls are clopen (both open and closed), and distinct balls of equal radius are disjoint.\n\nThese 'strange' properties have profound consequences in number theory: the p-adic integers form a compact open subring (impossible over ℝ), p-adic analysis has no Archimedean property (|n|_p ≤ 1 for all integers), and Hensel's lemma provides a p-adic Newton's method with guaranteed convergence. Today, p-adic geometry underlies the Langlands program, perfectoid spaces (Scholze, Fields Medal 2018), and modern arithmetic geometry.",


### PR DESCRIPTION
## Fix

Correct contradictory assumptions text in triangle-inequality-oq-03 meta.json.

## Evidence

**Before**: `"assumptions": "1 axiom, 0 sorries. See the Lean source for details."` (contradicts `axiomCount: 0` and `status: "verified"`)
**After**: `"assumptions": "No axioms, no sorries. Fully machine-checked."`

The word "axiom" in the Lean file appears only in a block comment ("the defining axiom of metric spaces") discussing the mathematical concept, not as a Lean `axiom` declaration. The proof has 0 axioms, 0 sorries, and is correctly marked verified.

---
Automated fix by lean-mechanic agent.