### PR TITLE
Fix: contradictory assumptions text in 5 verified proofs

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "assumptions": "0 axioms, 1 sorry. Core π bounds derived from Mathlib's pi_gt_d4 and pi_lt_d4.",
+    "assumptions": "No axioms, no sorries. Fully machine-checked. Core π bounds derived from Mathlib's pi_gt_d4 and pi_lt_d4.",
     "lineCount": 102,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -33,7 +33,7 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 182,
-    "assumptions": "0 axioms, 1 sorry. See the Lean source for details.",
+    "assumptions": "No axioms, no sorries. Fully machine-checked.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -78,7 +78,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 270,
-    "assumptions": "0 axioms, 1 sorry. Uses Classical.propDecidable as a local instance for decidability of propositions.",
+    "assumptions": "No axioms, no sorries. Fully machine-checked. Uses Classical.propDecidable as a local instance for decidability of propositions.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -68,7 +68,7 @@
     "dateAdded": "2026-02-25",
     "axiomCount": 0,
     "lineCount": 357,
-    "assumptions": "0 axioms, 1 sorry. Core cardinality result uses Mathlib's card_derangements_eq_numDerangements.",
+    "assumptions": "No axioms, no sorries. Fully machine-checked. Core cardinality result uses Mathlib's card_derangements_eq_numDerangements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -65,7 +65,7 @@
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
     "lineCount": 247,
-    "assumptions": "0 axioms, 1 sorry. See the Lean source for details.",
+    "assumptions": "No axioms, no sorries. Fully machine-checked.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

5 verified proofs (axiomCount=0, sorries=0) had assumptions text incorrectly claiming "1 sorry." In each case, the word "sorry" appears only in Lean comments (e.g., "sorry-free proofs", "Resolves the sorry in..."), not in actual code.

## Affected entries

| Proof | Old assumptions | Issue |
|-------|----------------|-------|
| area-of-circle-oq-03-oq-02 | "0 axioms, 1 sorry..." | "sorry" only in comment line 75 |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | "0 axioms, 1 sorry..." | "sorry" only in comment line 141 |
| cayley-hamilton-minpoly-oq-05-oq-01 | "0 axioms, 1 sorry..." | "sorry" only in comment line 4 |
| derangements-oq-02 | "0 axioms, 1 sorry..." | "sorry" only in comment line 340 |
| erdos-1006-oq-02-oq-03 | "0 axioms, 1 sorry..." | "sorry" only in comment line 235 |

## Evidence

Each Lean file verified: `grep -nw "sorry" <file>` shows only comment occurrences. No `sorry` in actual Lean tactic blocks. Build passes.

---
Automated fix by lean-mechanic agent.