### PR TITLE
chore: sync enrichment tracker and metadata corrections

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -658,8 +658,8 @@
       "quality": 100
     },
     "abel-ruffini-oq-04": {
-      "passes": 3,
-      "lastEnriched": "2026-03-24T00:49:31Z",
+      "passes": 4,
+      "lastEnriched": "2026-03-24T16:18:21Z",
       "quality": 100
     },
     "amgm-inequality-oq-02": {
@@ -735,6 +735,11 @@
     "hilbert-15": {
       "passes": 1,
       "lastEnriched": "2026-03-24T00:16:28Z",
+      "quality": 100
+    },
+    "erdos-362": {
+      "passes": 1,
+      "lastEnriched": "2026-03-24T16:17:26Z",
       "quality": 100
     }
   }

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -18,13 +18,13 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 1020,
     "erdosUrl": "https://erdosproblems.com/1020",
     "erdosProblemStatus": "open",
     "axiomCount": 11,
     "lineCount": 247,
-    "assumptions": "11 axiom(s) and 3 sorry(s). See the Lean source for details.",
+    "assumptions": "11 axiom(s) and 2 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 409,
-    "assumptions": "4 axioms: erdos_891 (main open conjecture), schinzel_theorem_statement (Schinzel's weaker result), dicksons_conjecture (Dickson's conjecture, properly formalized as DicksonsConjecture), weisenberg_conditional (conditional counterexample using Dickson's). Note: primorialComp is only defined for k ≤ 5."
+    "assumptions": "2 axioms: schinzel_theorem_statement (Schinzel's weaker result), weisenberg_conditional (conditional counterexample using Dickson's conjecture). The main conjecture ErdosProblem891 and DicksonsConjecture are defs, not axioms."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #891**\n\nThis problem was posed by Erdős and Selfridge in 1967 [ErSe67, p.430] and connects the distribution of prime factors to the structure of short intervals.\n\n**Key History:**\n- Erdős-Selfridge (1967): Original problem formulation\n- Schinzel: Proved a weaker version using Pólya's theorem on smooth numbers\n- Weisenberg: Showed conditional counterexample with interval length p₁···pₖ - 1\n\n**Mathematical Setting:**\nThe primorial p₁···pₖ (product of first k primes) gives natural interval lengths: 2, 6, 30, 210, 2310, ...\nThe question asks whether these specific lengths guarantee finding integers with many prime factors.\n\nThe problem remains open even for k = 2, asking whether every interval of 6 consecutive integers (for large n) contains a number with at least 3 prime factors.",
@@ -174,7 +174,7 @@
     ],
     "namespace": "Erdos891",
     "lineCount": 409,
-    "axiomCount": 4,
+    "axiomCount": 2,
     "theoremCount": 26,
     "definitionCount": 6
   },


### PR DESCRIPTION
## Summary
- Add erdos-362 to enrichment tracker (new enrichment pass)
- Fix erdos-891 axiom count: 4→2 (2 axioms are actually defs, not axioms)
- Fix erdos-1020 sorry count: 3→2

Automated sync from deployer agent.