### PR TITLE
Research: erdos-960 - Fix compilation, prove symmetry + ordinary_gives_pair

### DIFF
--- a/proofs/Proofs/Erdos960Problem.lean
+++ b/proofs/Proofs/Erdos960Problem.lean
@@ -26,6 +26,8 @@ Source: [Er84]
 
 namespace Erdos960
 
+open Classical
+
 /-- A point configuration is a finite set of points (represented abstractly). -/
 structure PointConfig where
   n : ℕ
@@ -36,7 +38,7 @@ structure PointConfig where
 def NoKCollinear (P : PointConfig) (k : ℕ) : Prop :=
   ∀ (S : Finset (ℕ × ℕ)), S ⊆ P.points → S.card = k →
     ¬∃ (a b c : ℤ), (a, b, c) ≠ (0, 0, 0) ∧
-      ∀ p ∈ S, a * p.1 + b * p.2 + c = 0
+      ∀ p ∈ S, a * (p.1 : ℤ) + b * (p.2 : ℤ) + c = 0
 
 -- ## Part II: Ordinary Lines
 
@@ -44,12 +46,13 @@ def NoKCollinear (P : PointConfig) (k : ℕ) : Prop :=
 def IsOrdinaryLine (P : PointConfig) (p q : ℕ × ℕ) : Prop :=
   p ∈ P.points ∧ q ∈ P.points ∧ p ≠ q ∧
     ∀ r ∈ P.points, r ≠ p → r ≠ q →
-      ¬∃ (t : ℚ), (r.1 : ℚ) = (1 - t) * p.1 + t * q.1 ∧
-                   (r.2 : ℚ) = (1 - t) * p.2 + t * q.2
+      ¬∃ (t : ℚ), (r.1 : ℚ) = (1 - t) * (p.1 : ℚ) + t * (q.1 : ℚ) ∧
+                   (r.2 : ℚ) = (1 - t) * (p.2 : ℚ) + t * (q.2 : ℚ)
 
 /-- Count of ordinary lines (simplified: count of unordered pairs). -/
 noncomputable def ordinaryLineCount (P : PointConfig) : ℕ :=
-  (P.points.offDiag.filter fun pq => IsOrdinaryLine P pq.1 pq.2).card / 2
+  (P.points.offDiag.filter
+    (fun (pq : (ℕ × ℕ) × (ℕ × ℕ)) => IsOrdinaryLine P pq.1 pq.2)).card / 2
 
 -- ## Part III: All-Ordinary Subsets
 
@@ -59,11 +62,14 @@ def AllOrdinary (P : PointConfig) (S : Finset (ℕ × ℕ)) : Prop :=
   S ⊆ P.points ∧ ∀ p ∈ S, ∀ q ∈ S, p ≠ q → IsOrdinaryLine P p q
 
 /-- IsOrdinaryLine is symmetric: if the line through p,q is ordinary,
-    then so is the line through q,p. -/
+    then so is the line through q,p. Uses the substitution t ↦ 1-t
+    to transform the parametric representation. -/
 theorem isOrdinaryLine_symm (P : PointConfig) (p q : ℕ × ℕ)
     (h : IsOrdinaryLine P p q) : IsOrdinaryLine P q p := by
   obtain ⟨hp, hq, hne, hord⟩ := h
-  exact ⟨hq, hp, hne.symm, fun r hr hrq hrp => hord r hr hrp hrq⟩
+  refine ⟨hq, hp, hne.symm, fun r hr hrq hrp => ?_⟩
+  intro ⟨t, ht1, ht2⟩
+  exact hord r hr hrp hrq ⟨1 - t, by linarith, by linarith⟩
 
 -- ## Part IV: The Threshold Function
 
@@ -78,10 +84,11 @@ noncomputable def threshold (r k n : ℕ) : ℕ :=
 -- ## Part V: The Main Conjecture
 
 /-- Erdős Problem #960: Is f_{r,k}(n) = o(n²)?
-    That is, for every ε > 0, f_{r,k}(n) < ε · n² for large n. -/
+    That is, for every ε > 0, f_{r,k}(n) < ε · n² for large n.
+    Stated with ℚ cast to avoid floor/ceil dependencies. -/
 def ErdosConjecture960_littleo (r k : ℕ) : Prop :=
   ∀ ε : ℚ, ε > 0 → ∃ N₀ : ℕ, ∀ n ≥ N₀,
-    threshold r k n < (ε * n * n).toNat
+    (threshold r k n : ℚ) < ε * ↑n * ↑n
 
 /-- Stronger form: Is f_{r,k}(n) ≪ n? -/
 def ErdosConjecture960_linear (r k : ℕ) : Prop :=
@@ -99,16 +106,53 @@ axiom erdos_960_littleo_conjecture : ∀ r k : ℕ, r ≥ 2 → k ≥ 2 →
 theorem turan_upper_bound (r k n : ℕ) (hr : r ≥ 2) (hk : k ≥ 2) :
   (threshold r k n : ℚ) ≤ (1 - 1 / (r - 1 : ℚ)) * n^2 / 2 + 1 := by sorry
 
-/-- The trivial upper bound: at most C(n,2) ordinary lines total. -/
+/-- The trivial upper bound: at most C(n,2) ordinary lines total.
+    Follows from: filtered offDiag ⊆ offDiag, and |offDiag| = n(n-1). -/
 theorem trivial_bound (P : PointConfig) :
-  ordinaryLineCount P ≤ P.n * (P.n - 1) / 2 := by sorry
+  ordinaryLineCount P ≤ P.n * (P.n - 1) / 2 := by
+  unfold ordinaryLineCount
+  apply Nat.div_le_div_right
+  calc (P.points.offDiag.filter
+        (fun (pq : (ℕ × ℕ) × (ℕ × ℕ)) => IsOrdinaryLine P pq.1 pq.2)).card
+      ≤ P.points.offDiag.card := Finset.card_filter_le _ _
+    _ = P.n * (P.n - 1) := by sorry -- Finset.card_offDiag not available; need: offDiag.card = n*(n-1)
 
 -- ## Part VII: Known Cases and Connections
 
-/-- For r = 2: any two points determine a line, so f_{2,k}(n) = 1.
-    One ordinary line trivially gives a 2-point all-ordinary subset. -/
+/-- Any ordinary line gives a 2-point all-ordinary subset:
+    if the line through p,q is ordinary, then {p,q} is a 2-element
+    subset where all C(2,2) = 1 connecting lines are ordinary. -/
+theorem ordinary_gives_pair (P : PointConfig) (p q : ℕ × ℕ)
+    (h : IsOrdinaryLine P p q) :
+    ∃ S : Finset (ℕ × ℕ), S.card = 2 ∧ AllOrdinary P S := by
+  have hsymm := isOrdinaryLine_symm P p q h
+  obtain ⟨hp, hq, hne, hord⟩ := h
+  use {p, q}
+  refine ⟨?_, ?_, ?_⟩
+  · -- card {p, q} = 2
+    have hmem : p ∉ ({q} : Finset _) := Finset.notMem_singleton.mpr hne
+    simp [Finset.card_insert_of_notMem hmem]
+  · -- {p, q} ⊆ P.points
+    intro x hx
+    simp at hx
+    rcases hx with rfl | rfl <;> assumption
+  · -- all pairs ordinary
+    intro a ha b hb hab
+    simp at ha hb
+    rcases ha with rfl | rfl <;> rcases hb with rfl | rfl
+    · exact absurd rfl hab
+    · exact ⟨hp, hq, hne, hord⟩
+    · exact hsymm
+    · exact absurd rfl hab
+
+/-- For r = 2: f_{2,k}(n) = 0.
+    Any ordinary line gives a 2-point all-ordinary subset (by ordinary_gives_pair),
+    so no configuration can have ≥ 1 ordinary lines without having a 2-point
+    all-ordinary subset. The threshold set is ⊆ {0}, so sSup = 0.
+    (Previously claimed = 1, corrected: the threshold is the max number of ordinary
+    lines a config can have WITHOUT an all-ordinary r-subset.) -/
 theorem threshold_r2 (k n : ℕ) (hk : k ≥ 2) (hn : n ≥ 2) :
-  threshold 2 k n = 1 := by sorry
+  threshold 2 k n = 0 := by sorry
 
 /-- The Sylvester-Gallai theorem: any finite non-collinear point set
     in ℝ² has at least one ordinary line. For n points with no 3
@@ -123,17 +167,19 @@ theorem ordinary_pairs_count (r : ℕ) (hr : r ≥ 2) :
     ∀ P : PointConfig, ∀ S : Finset (ℕ × ℕ), S.card = r → AllOrdinary P S →
       S.offDiag.card = r * (r - 1) := by
   intro P S hcard _hord
-  rw [Finset.card_offDiag, hcard]
+  sorry -- Finset.card_offDiag not available; need: offDiag.card = n*(n-1)
 
-/-- The linear conjecture implies the little-o conjecture. -/
+/-- The linear conjecture implies the little-o conjecture.
+    For large enough n (n > C/ε), C·n < ε·n², so threshold ≤ C·n < ε·n².
+    N₀ = C · ε.den + 1 ensures n > C/ε since ε ≥ 1/ε.den. -/
 theorem linear_implies_littleo (r k : ℕ) (hr : r ≥ 2) (hk : k ≥ 2) :
     ErdosConjecture960_linear r k → ErdosConjecture960_littleo r k := by
   intro ⟨C, hC⟩ ε hε
-  -- For large enough n, C*n < ε*n²
-  use C + 1
+  -- Need n > C/ε so that C*n < ε*n². Since ε ≥ 1/ε.den, C/ε ≤ C*ε.den.
+  use C * ε.den + 1
   intro n hn
-  calc threshold r k n ≤ C * n := hC n
-    _ < (ε * n * n).toNat := by sorry
+  calc (threshold r k n : ℚ) ≤ ↑C * ↑n := by exact_mod_cast hC n
+    _ < ε * ↑n * ↑n := by sorry
 
 -- ## Summary
 
@@ -142,7 +188,7 @@ theorem linear_implies_littleo (r k : ℕ) (hr : r ≥ 2) (hk : k ≥ 2) :
     and the Sylvester-Gallai/Green-Tao ordinary line result. -/
 theorem erdos_960_summary :
     (∀ r k : ℕ, r ≥ 2 → k ≥ 2 → ErdosConjecture960_littleo r k) ∧
-    (∀ k n : ℕ, k ≥ 2 → n ≥ 2 → threshold 2 k n = 1) :=
+    (∀ k n : ℕ, k ≥ 2 → n ≥ 2 → threshold 2 k n = 0) :=
   ⟨erdos_960_littleo_conjecture, fun k n hk hn => threshold_r2 k n hk hn⟩
 
 end Erdos960

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 6,
     "erdosNumber": 960,
     "erdosUrl": "https://erdosproblems.com/960",
     "erdosProblemStatus": "open",
@@ -30,13 +30,15 @@
       "ErdosConjecture960_littleo: f = o(n²) formal statement",
       "ErdosConjecture960_linear: f ≪ n stronger form",
       "turan_upper_bound (axiom): Turán bound over ℚ",
-      "threshold_r2 (axiom): f_{2,k}(n) = 1",
-      "green_tao_ordinary_lines (axiom): ≥ n/2 for general position",
+      "isOrdinaryLine_symm (proved): symmetry via t ↦ 1-t parametric substitution",
+      "ordinary_gives_pair (proved): any ordinary line yields a 2-pt all-ordinary subset",
+      "threshold_r2 (sorry): f_{2,k}(n) = 0 (corrected from incorrect = 1)",
+      "green_tao_ordinary_lines (sorry): ≥ n/2 for general position",
       "erdos_960_summary (proved): combines conjecture with r=2 case"
     ],
     "axiomCount": 1,
     "lineCount": 148,
-    "assumptions": "1 axiom(s) and 5 sorry(s). See the Lean source for details.",
+    "assumptions": "1 axiom(s) and 6 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Fixed 3 pre-existing compilation bugs in Erdős #960 formalization
- Proved `isOrdinaryLine_symm` (parametric t↦1-t substitution) and `ordinary_gives_pair` (new theorem)
- Corrected `threshold_r2` from incorrect `= 1` to correct `= 0`
- Fixed `ErdosConjecture960_littleo` definition and `linear_implies_littleo` N₀ choice
- File now compiles successfully (6 sorries, was previously non-compiling)

## Progress
- **Proved**: `isOrdinaryLine_symm` — symmetry via t↦1-t substitution in parametric line representation
- **Proved**: `ordinary_gives_pair` — any ordinary line yields a 2-point all-ordinary subset
- **Fixed**: `threshold_r2` statement corrected from `= 1` to `= 0` (mathematical bug)
- **Fixed**: `ErdosConjecture960_littleo` — replaced non-existent `Rat.toNat` with ℚ cast comparison
- **Fixed**: `linear_implies_littleo` N₀ from `C + 1` to `C * ε.den + 1` for correct C/ε bound
- **Fixed**: Added `open Classical` for `DecidablePred` synthesis with `Finset.filter`
- **Fixed**: Type annotations for `NoKCollinear` and `IsOrdinaryLine` coercions

## Findings
- `Finset.card_offDiag` is not available in Mathlib 4.26.0 with current imports — blocks `trivial_bound` and `ordinary_pairs_count` (sorry'd)
- `isOrdinaryLine_symm` cannot be proved by simple argument swapping — the parametric formula `(1-t)·p + t·q` requires the substitution `t ↦ 1-t`

## Status
**Outcome**: progress
**Next Steps**: Find correct Mathlib import for `card_offDiag`, prove `threshold_r2 = 0` from sSup properties

🤖 Generated by researcher-7