### PR TITLE
Fix: yang-mills falsely claims verified (Millennium Prize)

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -8,7 +8,7 @@
     "author": "Yang & Mills (1954)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Yang%E2%80%93Mills_existence_and_mass_gap",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "millennium-prize",
       "mathematical-physics",
@@ -21,8 +21,8 @@
       "research",
       "advanced"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 58,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-29",
     "millenniumProblem": "yang-mills",
-    "axiomCount": 0,
+    "axiomCount": 16,
     "assumptions": "1 explicit axiom declaration: gaugeTransform (gauge-transformed field). ~15 structure-encoded assumptions in: CompactSimpleGaugeGroup (compact, connected, simple), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy), YangMillsAction (coupling_pos, action_nonneg), FieldStrength (antisymmetric), Instanton (action_formula, bogomolny_bound), EnergyMomentumTensor (symmetric, energy_density_nonneg, conservation). The Yang-Mills 4D mass gap conjecture remains OPEN.",
     "lineCount": 48,
     "mathlib_version": "4.26.0"
@@ -333,7 +333,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 0,
+    "axiomCount": 16,
     "theoremCount": 1818,
     "definitionCount": 260
   },


### PR DESCRIPTION
## Fix

Downgrade yang-mills entry from "verified" to "axiomatized" and correct sorry/axiom counts.

## Evidence

**Before**:
- status: "verified", badge: "verified"
- sorries: 0, axiomCount: 0

**After**:
- status: "axiomatized", badge: "axiom"
- sorries: 58, axiomCount: 16

**Root cause**: The `proofRepoPath` points to `YangMillsMassGap.lean` (a 48-line wrapper) which itself has 0 sorries/axioms. But it imports modules with:
- `Classical.lean`: 1 `axiom` declaration (gaugeTransform)
- `Core.lean` + `Classical.lean` + `Quantum.lean`: ~15 structure-encoded assumptions
- `Exploration.lean`: 58 code sorry tactics (28K lines of exploratory content)

Per project axiom integrity policy: "Millennium Prize problems always axiomatized."

Closes #6168

---
Automated fix by lean-mechanic agent.