### PR TITLE
Research: erdos-960 - fix threshold_r2 semantic bug + document breakages

### DIFF
--- a/proofs/Proofs/Erdos1105Problem.lean
+++ b/proofs/Proofs/Erdos1105Problem.lean
@@ -191,10 +191,25 @@ General bounds on anti-Ramsey numbers.
 axiom ar_lower_bound : ∀ (n k : ℕ) (H : SimpleGraph k),
   antiRamsey n k H ≥ 1  -- Simplified; actual bound depends on H
 
+/-- A monochromatic coloring avoids rainbow copies of any graph with ≥ 2 edges. -/
+theorem monochromatic_avoids_rainbow (n k : ℕ) (H : SimpleGraph k)
+    (he : ∃ e₁ e₂ : Fin k × Fin k, e₁ ≠ e₂ ∧ H e₁.1 e₁.2 ∧ H e₂.1 e₂.2) :
+    AvoidsRainbow n (fun _ => (0 : ℕ)) k H := by
+  intro emb hR
+  obtain ⟨e₁, e₂, hne, he1, he2⟩ := he
+  exact absurd (hR e₁ e₂ he1 he2 hne) (by simp)
+
+/-- The number of colors is at most the number of edge slots (by card_image_le). -/
+theorem numColors_le_edges (n : ℕ) (coloring : (Fin n × Fin n) → ℕ) :
+    numColors n coloring ≤
+      (Finset.univ.filter (fun e : Fin n × Fin n => e.1 < e.2)).card :=
+  Finset.card_image_le
+
 -- Upper bound: AR(n, G) ≤ |E(K_n)| = C(n,2)
+-- Proof strategy: Nat.sSup_le + numColors_le_edges + edge_pairs_card
 theorem ar_upper_bound (n k : ℕ) (H : SimpleGraph k) :
     antiRamsey n k H ≤ numEdgesKn n := by
-  sorry -- Each edge can have its own color at most
+  sorry
 
 -- Monotonicity in n
 axiom ar_mono_n : ∀ (n₁ n₂ k : ℕ) (H : SimpleGraph k),
@@ -207,9 +222,10 @@ Anti-Ramsey numbers relate to extremal graph theory.
 -/
 
 -- Turán number ex(n, H): max edges in H-free graph on n vertices
+-- Note: requires decidability of the graph predicate for Finset.filter
 noncomputable def turan (n k : ℕ) (H : SimpleGraph k) : ℕ :=
-  sSup {e : ℕ | ∃ G : SimpleGraph n,
-    (∀ emb : GraphEmbedding n k H, False) ∧ e = (Finset.univ.filter
+  sSup {e : ℕ | ∃ (G : SimpleGraph n) (_ : DecidableRel G),
+    (∀ _emb : GraphEmbedding n k H, False) ∧ e = (Finset.univ.filter
       (fun p : Fin n × Fin n => p.1 < p.2 ∧ G p.1 p.2)).card}
 
 -- AR(n, H) ≥ ex(n, H) + 1 (give H-free graph rainbow, one color for complement)

--- a/proofs/Proofs/Erdos400Problem.lean
+++ b/proofs/Proofs/Erdos400Problem.lean
@@ -98,18 +98,50 @@ theorem factor_le_of_factorial_divides {k : ℕ} {a : Fin k → ℕ} {n : ℕ} (
   exact Nat.not_lt.mpr (Nat.le_of_dvd (Nat.factorial_pos n) h) (lt_of_lt_of_le h_fac_lt h_prod_ge)
 
 /-- The excess set is bounded above (each a_i ≤ n+1 so excess ≤ k*(n+1)). -/
-theorem excess_set_bddAbove (k n : ℕ) (hk : k ≥ 2) :
+theorem excess_set_bddAbove (k n : ℕ) (_hk : k ≥ 2) :
     BddAbove { e : ℤ | ∃ a : Fin k → ℕ, FactorialDivides a n ∧ sumExcess a n = e } := by
-  -- Each valid tuple has a_i ≤ n+1, so sum ≤ k*(n+1), excess ≤ k*(n+1)
-  exact ⟨↑(k * (n + 1)), fun e ⟨a, _, hsum⟩ => by rw [← hsum]; unfold sumExcess; sorry⟩
+  use ↑(k * (n + 1))
+  intro e ⟨a, hfac, hsum⟩
+  rw [← hsum]; unfold sumExcess
+  -- Each a_i ≤ n + 1, hence sum ≤ k*(n+1) and excess ≤ k*(n+1)
+  have hle : ∀ i, a i ≤ n + 1 := by
+    intro i
+    rcases n with _ | n
+    · -- n = 0: product of factorials divides 1, each factorial = 1
+      have hprod1 : ∏ j : Fin k, (a j).factorial = 1 := by
+        unfold FactorialDivides at hfac; simpa using Nat.eq_one_of_dvd_one hfac
+      have hfi : (a i).factorial = 1 := by
+        have hdvd : (a i).factorial ∣ ∏ j : Fin k, (a j).factorial :=
+          Finset.dvd_prod_of_mem _ (Finset.mem_univ i)
+        rw [hprod1] at hdvd; exact Nat.eq_one_of_dvd_one hdvd
+      exact Nat.factorial_eq_one.mp hfi
+    · exact Nat.le_succ_of_le (factor_le_of_factorial_divides (by omega) hfac i)
+  have hsum_le : ∑ i : Fin k, (a i : ℤ) ≤ ↑(k * (n + 1)) := by
+    calc ∑ i : Fin k, (a i : ℤ)
+        ≤ ∑ _i : Fin k, (↑(n + 1) : ℤ) := by
+          apply Finset.sum_le_sum; intro i _; exact_mod_cast hle i
+      _ = ↑(k * (n + 1)) := by simp [Finset.sum_const]
+  linarith
 
 /-- The excess set contains 0 via the trivial tuple (n, 0, …, 0). -/
 theorem zero_mem_excess_set (k n : ℕ) (hk : k ≥ 1) :
     (0 : ℤ) ∈ { e : ℤ | ∃ a : Fin k → ℕ, FactorialDivides a n ∧ sumExcess a n = e } := by
-  -- The tuple a(0) = n, a(i) = 0 for i > 0 gives product = n! and sum = n
-  exact ⟨fun i => if i.val = 0 then n else 0, by
-    unfold FactorialDivides; sorry, by
-    unfold sumExcess; sorry⟩
+  -- Use the tuple: a(i) = n if i = 0, else 0. Product = n!, sum = n, excess = 0.
+  let a : Fin k → ℕ := fun i => if i = ⟨0, by omega⟩ then n else 0
+  refine ⟨a, ?_, ?_⟩
+  · -- FactorialDivides: ∏ a_i! = n! · 1^(k-1) = n!
+    unfold FactorialDivides
+    have hsimp : ∀ i : Fin k, (a i).factorial =
+        if i = ⟨0, by omega⟩ then n.factorial else 1 := by
+      intro i; simp only [a]; split <;> simp_all
+    simp_rw [hsimp, Finset.prod_ite_eq', Finset.mem_univ, if_true]
+    exact dvd_refl _
+  · -- sumExcess = n - n = 0
+    unfold sumExcess
+    have hsimp : ∀ i : Fin k, (a i : ℤ) =
+        if i = ⟨0, by omega⟩ then (n : ℤ) else 0 := by
+      intro i; simp only [a]; split <;> simp_all
+    simp_rw [hsimp, Finset.sum_ite_eq', Finset.mem_univ, if_true]; omega
 
 /-- g_k(n) ≥ 0: the trivial tuple gives excess 0, so the supremum is ≥ 0.
     Converted from axiom to theorem. -/
@@ -131,11 +163,8 @@ theorem g2_binomial_connection (n : ℕ) :
       by rwa [Fin.sum_univ_two] at hsum⟩
   · rintro ⟨a, b, hfac, hsum⟩
     -- Construct the Fin 2 → ℕ function from the pair
-    exact ⟨![a, b], by
-      rw [Fin.prod_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons]
-      exact hfac, by
-      rw [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons]
-      exact hsum⟩
+    exact ⟨![a, b], by simp [Fin.prod_univ_two]; exact hfac,
+      by simp [Fin.sum_univ_two]; exact hsum⟩
 
 /-
 ## Section VI: The k = 2 Case

--- a/proofs/Proofs/Erdos960Problem.lean
+++ b/proofs/Proofs/Erdos960Problem.lean
@@ -110,15 +110,14 @@ theorem trivial_bound (P : PointConfig) :
 
 -- ## Part VII: Known Cases and Connections
 
-/-- For r = 2: one ordinary line suffices to find a 2-point all-ordinary subset.
-    NOTE: With the current sSup-based definition of `threshold`, the mathematical
-    value should be 0 (the sSup of counterexample ordinary-line counts), not 1
-    (the minimum guaranteeing existence). The definition computes the maximum m
-    where a counterexample with ≥ m ordinary lines exists, which is 0 for r = 2
-    since any ordinary line IS a 2-element all-ordinary subset. The correct
-    statement may be `threshold 2 k n = 0`. -/
-theorem threshold_r2 (k n : ℕ) (hk : k ≥ 2) (hn : n ≥ 2) :
-  threshold 2 k n = 1 := by sorry
+/-- For r = 2: the threshold is 0. With the sSup-based definition of `threshold`,
+    which computes the maximum m where a counterexample exists, there are no
+    counterexamples for r = 2: any configuration with ≥ 1 ordinary line has a
+    2-element all-ordinary subset (the two points on that line). By Sylvester-Gallai,
+    every finite non-collinear set has ordinary lines.
+    Proof: the set in the sSup is empty, so sSup = 0. -/
+theorem threshold_r2 (k n : ℕ) (_hk : k ≥ 2) (_hn : n ≥ 2) :
+  threshold 2 k n = 0 := by sorry
 
 /-- The Sylvester-Gallai theorem: any finite non-collinear point set
     in ℝ² has at least one ordinary line. For n points with no 3
@@ -159,7 +158,7 @@ theorem linear_implies_littleo (r k : ℕ) (hr : r ≥ 2) (hk : k ≥ 2) :
     and the Sylvester-Gallai/Green-Tao ordinary line result. -/
 theorem erdos_960_summary :
     (∀ r k : ℕ, r ≥ 2 → k ≥ 2 → ErdosConjecture960_littleo r k) ∧
-    (∀ k n : ℕ, k ≥ 2 → n ≥ 2 → threshold 2 k n = 1) :=
+    (∀ k n : ℕ, k ≥ 2 → n ≥ 2 → threshold 2 k n = 0) :=
   ⟨erdos_960_littleo_conjecture, fun k n hk hn => threshold_r2 k n hk hn⟩
 
 end Erdos960

--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-400",
-  "title": "Erdős Problem #400: Factorial Divisibility and Sum Excess",
+  "title": "Erd\u0151s Problem #400: Factorial Divisibility and Sum Excess",
   "slug": "erdos-400",
-  "description": "For k ≥ 2, let g_k(n) = max{(a₁+⋯+aₖ)-n : a₁!⋯aₖ! | n!}. Is Σ g_k(n) ~ cₖ·x·log x? Is g_k(n) concentrated around cₖ·log x?",
+  "description": "For k \u2265 2, let g_k(n) = max{(a\u2081+\u22ef+a\u2096)-n : a\u2081!\u22efa\u2096! | n!}. Is \u03a3 g_k(n) ~ c\u2096\u00b7x\u00b7log x? Is g_k(n) concentrated around c\u2096\u00b7log x?",
   "meta": {
-    "author": "Erdős, Graham (1980)",
+    "author": "Erd\u0151s, Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/400",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos400Problem.lean",
@@ -17,7 +17,7 @@
       "divisibility"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 400,
     "erdosUrl": "https://erdosproblems.com/400",
     "erdosProblemStatus": "open",
@@ -50,26 +50,26 @@
       "`sumExcess` and `gExcess`: the excess function $g_k(n) = \\sup\\{\\sum a_i - n\\}$",
       "`ErdosProblem400a`: average growth $\\sum_{n \\le x} g_k(n) \\sim c_k \\cdot x \\log x$",
       "`ErdosProblem400b`: concentration $g_k(n) = c_k \\log x + o(\\log x)$ a.e.",
-      "`gExcess_upper_bound` (axiom): Erdős-Graham bound $g_k(n) = O(\\log n)$",
+      "`gExcess_upper_bound` (axiom): Erd\u0151s-Graham bound $g_k(n) = O(\\log n)$",
       "`gExcess_nonneg` (axiom): $g_k(n) \\ge 0$ from trivial tuple",
       "`g2_binomial_connection` (axiom): $k = 2$ binomial coefficient link",
       "`g2_excess_characterization` (axiom): supremum attained for $k = 2$",
       "`average_g2_growth` (axiom): average growth constant $c_2$ exists"
     ],
     "axiomCount": 3,
-    "lineCount": 154,
+    "lineCount": 183,
     "assumptions": "5 axioms: gExcess_upper_bound, gExcess_nonneg, g2_binomial_connection, and 2 more. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #400**\n\nThis problem appears in the Erdős-Graham monograph *Old and New Problems and Results in Combinatorial Number Theory* (1980, p. 77), investigating the maximum excess that $k$ factorials can achieve over $n!$ while dividing it.\n\n**Historical Development:**\n- **Erdős & Graham (1980):** Posed the problem and proved the fundamental upper bound $g_k(n) = O(\\log n)$ using Legendre's formula for $p$-adic valuations of factorials: $v_p(n!) = \\sum_{j \\ge 1} \\lfloor n/p^j \\rfloor$. The logarithmic bound arises because excess $g$ in the sum forces additional $p$-adic valuation, which is constrained by $v_p(n!)$.\n- **Connection to Multinomials:** The condition $a_1! \\cdots a_k! \\mid n!$ generalizes the integrality of multinomial coefficients $\\binom{n}{a_1, \\ldots, a_k}$. When $\\sum a_i = n$, the divisibility always holds; the problem asks how far beyond $n$ the sum can go.\n- **Kummer's Theorem (1852):** For $k = 2$, the $p$-adic valuation $v_p(\\binom{a+b}{a})$ equals the number of carries when adding $a$ and $b$ in base $p$. This provides a concrete combinatorial interpretation of the divisibility condition.\n\n**Mathematical Context:**\nThe problem sits at the intersection of factorial arithmetic, $p$-adic analysis, and asymptotic number theory. The excess function $g_k(n)$ encodes subtle information about how the prime factorization of $n!$ constrains the joint factorizations of its components. The two-part conjecture asks whether this excess exhibits both average growth ($\\sim c_k \\cdot \\log n$) and concentration (sharp typicality), analogous to the Erdős-Kac phenomenon for additive functions.",
-    "problemStatement": "**Problem Statement**\n\nFor $k \\ge 2$, define\n$$g_k(n) = \\max\\{(a_1 + \\cdots + a_k) - n : a_1! \\cdots a_k! \\mid n!\\}.$$\n\n**(a)** Is $\\sum_{n \\le x} g_k(n) \\sim c_k \\cdot x \\cdot \\log x$ for some constant $c_k > 0$?\n\n**(b)** Is $g_k(n) = c_k \\cdot \\log x + o(\\log x)$ for almost all $n \\le x$?\n\n**Status:** OPEN\n\n**Known:** $g_k(n) = O(\\log n)$ (Erdős-Graham 1980), $g_k(n) \\ge 0$ (trivial tuple)",
-    "text": "For k ≥ 2, let g_k(n) = max{(a₁+⋯+aₖ)-n : a₁!⋯aₖ! | n!}. Is Σ g_k(n) ~ cₖ·x·log x? Is g_k(n) concentrated around cₖ·log x?",
+    "historicalContext": "**Erd\u0151s Problem #400**\n\nThis problem appears in the Erd\u0151s-Graham monograph *Old and New Problems and Results in Combinatorial Number Theory* (1980, p. 77), investigating the maximum excess that $k$ factorials can achieve over $n!$ while dividing it.\n\n**Historical Development:**\n- **Erd\u0151s & Graham (1980):** Posed the problem and proved the fundamental upper bound $g_k(n) = O(\\log n)$ using Legendre's formula for $p$-adic valuations of factorials: $v_p(n!) = \\sum_{j \\ge 1} \\lfloor n/p^j \\rfloor$. The logarithmic bound arises because excess $g$ in the sum forces additional $p$-adic valuation, which is constrained by $v_p(n!)$.\n- **Connection to Multinomials:** The condition $a_1! \\cdots a_k! \\mid n!$ generalizes the integrality of multinomial coefficients $\\binom{n}{a_1, \\ldots, a_k}$. When $\\sum a_i = n$, the divisibility always holds; the problem asks how far beyond $n$ the sum can go.\n- **Kummer's Theorem (1852):** For $k = 2$, the $p$-adic valuation $v_p(\\binom{a+b}{a})$ equals the number of carries when adding $a$ and $b$ in base $p$. This provides a concrete combinatorial interpretation of the divisibility condition.\n\n**Mathematical Context:**\nThe problem sits at the intersection of factorial arithmetic, $p$-adic analysis, and asymptotic number theory. The excess function $g_k(n)$ encodes subtle information about how the prime factorization of $n!$ constrains the joint factorizations of its components. The two-part conjecture asks whether this excess exhibits both average growth ($\\sim c_k \\cdot \\log n$) and concentration (sharp typicality), analogous to the Erd\u0151s-Kac phenomenon for additive functions.",
+    "problemStatement": "**Problem Statement**\n\nFor $k \\ge 2$, define\n$$g_k(n) = \\max\\{(a_1 + \\cdots + a_k) - n : a_1! \\cdots a_k! \\mid n!\\}.$$\n\n**(a)** Is $\\sum_{n \\le x} g_k(n) \\sim c_k \\cdot x \\cdot \\log x$ for some constant $c_k > 0$?\n\n**(b)** Is $g_k(n) = c_k \\cdot \\log x + o(\\log x)$ for almost all $n \\le x$?\n\n**Status:** OPEN\n\n**Known:** $g_k(n) = O(\\log n)$ (Erd\u0151s-Graham 1980), $g_k(n) \\ge 0$ (trivial tuple)",
+    "text": "For k \u2265 2, let g_k(n) = max{(a\u2081+\u22ef+a\u2096)-n : a\u2081!\u22efa\u2096! | n!}. Is \u03a3 g_k(n) ~ c\u2096\u00b7x\u00b7log x? Is g_k(n) concentrated around c\u2096\u00b7log x?",
     "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:** `FactorialDivides` for $\\prod a_i! \\mid n!$ using `Finset.prod`, `sumExcess` for $\\sum a_i - n$ over $\\mathbb{Z}$, `gExcess` as `sSup` over feasible excesses\n\n2. **Two-Part Conjecture:** `ErdosProblem400a` (average growth via `Filter.Tendsto` to $c_k$), `ErdosProblem400b` (concentration via density of deviations $\\to 0$)\n\n3. **Known Bounds (axioms):** `gExcess_upper_bound` ($g_k(n) \\le C \\log n$), `gExcess_nonneg` ($g_k(n) \\ge 0$)\n\n4. **$k = 2$ Special Case:** `g2_binomial_connection` (binomial coefficient link), `g2_excess_characterization` (supremum attained), `average_g2_growth` ($c_2$ exists)\n\n5. **Asymptotic Framework:** Uses Mathlib's `Filter.atTop` and `nhds` for limit statements, `Finset.range` for partial sums",
     "keyInsights": [
       "**Legendre's formula controls excess:** The bound $g_k(n) = O(\\log n)$ follows from $v_p(n!) = \\sum_{j \\ge 1} \\lfloor n/p^j \\rfloor \\approx n/(p-1)$. Excess $g$ in the sum $\\sum a_i = n + g$ forces additional $p$-adic valuation from each $a_i!$, constrained by $v_p(n!)$.",
       "**Concentration vs average:** Part (b) implies part (a), since if $g_k(n) \\approx c_k \\log n$ for almost all $n$, then $\\sum_{n \\le x} g_k(n) \\approx c_k \\sum_{n \\le x} \\log n \\sim c_k \\cdot x \\log x$. The concentration conjecture is strictly stronger.",
       "**Kummer's theorem for $k = 2$:** The condition $a! \\cdot b! \\mid n!$ relates to carries when adding $a$ and $b$ in base $p$ for each prime $p \\le n$. The excess measures how far the carry structure permits $a + b$ to exceed $n$.",
-      "**Erdős-Kac analogy:** The concentration conjecture mirrors the Erdős-Kac theorem ($\\omega(n) \\approx \\log \\log n$ for almost all $n$): both assert that a number-theoretic function is sharply concentrated around its mean, with fluctuations of lower order.",
+      "**Erd\u0151s-Kac analogy:** The concentration conjecture mirrors the Erd\u0151s-Kac theorem ($\\omega(n) \\approx \\log \\log n$ for almost all $n$): both assert that a number-theoretic function is sharply concentrated around its mean, with fluctuations of lower order.",
       "**Trivial tuple gives lower bound:** The tuple $(n, 0, \\ldots, 0)$ always satisfies $n! \\cdot 0!^{k-1} \\mid n!$ with excess $0$, establishing $g_k(n) \\ge 0$. Non-trivial lower bounds $g_k(n) \\ge c \\log n$ require Stirling-type analysis."
     ],
     "crossReferences": [
@@ -123,7 +123,7 @@
     },
     {
       "id": "upper-bound",
-      "title": "Erdős-Graham Upper Bound",
+      "title": "Erd\u0151s-Graham Upper Bound",
       "startLine": 71,
       "endLine": 79,
       "summary": "`gExcess_upper_bound` (axiom): $\\exists C > 0,\\, \\forall n \\ge 1,\\, g_k(n) \\le C \\log n$. Establishes logarithmic order of magnitude from $p$-adic valuation constraints."
@@ -144,14 +144,14 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #400 asks for precise asymptotics of $g_k(n) = \\max\\{\\sum a_i - n : \\prod a_i! \\mid n!\\}$. The Erdős-Graham upper bound $g_k(n) = O(\\log n)$ establishes the correct order of magnitude via Legendre's formula, but the exact constants $c_k$ and concentration behavior remain open. The $k = 2$ case connects to binomial coefficients and Kummer's theorem on carries.",
-    "implications": "**Theoretical Significance**: **Mathematical Connections**\n\n1. **$p$-adic number theory:** The logarithmic bound comes from Legendre's formula $v_p(n!) = (n - s_p(n))/(p-1)$\n**2. Erdős-Kac phenomena:** The concentration conjecture mirrors the sharp typicality of additive functions\n3. **Multinomial combinatorics:** Generalizes the integrality of multinomial coefficients beyond $\\sum a_i = n$\n4. **Factorial factorization:** Part of a family including erdos-392 (optimal factorization) and erdos-401 (prime-augmented divisibility).",
+    "summary": "Erd\u0151s Problem #400 asks for precise asymptotics of $g_k(n) = \\max\\{\\sum a_i - n : \\prod a_i! \\mid n!\\}$. The Erd\u0151s-Graham upper bound $g_k(n) = O(\\log n)$ establishes the correct order of magnitude via Legendre's formula, but the exact constants $c_k$ and concentration behavior remain open. The $k = 2$ case connects to binomial coefficients and Kummer's theorem on carries.",
+    "implications": "**Theoretical Significance**: **Mathematical Connections**\n\n1. **$p$-adic number theory:** The logarithmic bound comes from Legendre's formula $v_p(n!) = (n - s_p(n))/(p-1)$\n**2. Erd\u0151s-Kac phenomena:** The concentration conjecture mirrors the sharp typicality of additive functions\n3. **Multinomial combinatorics:** Generalizes the integrality of multinomial coefficients beyond $\\sum a_i = n$\n4. **Factorial factorization:** Part of a family including erdos-392 (optimal factorization) and erdos-401 (prime-augmented divisibility).",
     "openQuestions": [
       "Does the average $\\sum_{n \\le x} g_k(n) / (x \\log x)$ converge to a constant $c_k$ for each $k \\ge 2$?",
       "Is $g_k(n)$ concentrated around $c_k \\log n$ for almost all $n$ (in the density sense)?",
       "What is the exact value of $c_2$? Can it be expressed in terms of the prime-counting function or Euler products?",
       "How do the constants $c_k$ behave as $k \\to \\infty$? Is $c_k \\sim C/k$ for some universal $C$?",
-      "Can the Erdős-Graham bound $g_k(n) = O(\\log n)$ be sharpened to $g_k(n) \\le c_k \\log n + O(1)$?"
+      "Can the Erd\u0151s-Graham bound $g_k(n) = O(\\log n)$ be sharpened to $g_k(n) \\le c_k \\log n + O(1)$?"
     ]
   },
   "leanFile": {
@@ -165,7 +165,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 154,
+    "lineCount": 183,
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 6
@@ -174,46 +174,46 @@
     {
       "targetId": "erdos-13",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, divisibility, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, divisibility, number-theory"
     },
     {
       "targetId": "erdos-131",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, divisibility, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, divisibility, number-theory"
     },
     {
       "targetId": "erdos-361",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: asymptotics, combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: asymptotics, combinatorics, number-theory"
     }
   ],
   "relatedProofs": [
     {
       "id": "erdos-13",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, divisibility, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, divisibility, number-theory"
     },
     {
       "id": "erdos-131",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, divisibility, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, divisibility, number-theory"
     },
     {
       "id": "erdos-361",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: asymptotics, combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: asymptotics, combinatorics, number-theory"
     }
   ],
   "references": [
     {
-      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "authors": "Erd\u0151s, Paul; Graham, Ronald L.",
       "title": "Old and New Problems and Results in Combinatorial Number Theory",
       "year": "1980",
-      "venue": "L'Enseignement Mathématique, Monographie No. 28, Université de Genève",
+      "venue": "L'Enseignement Math\u00e9matique, Monographie No. 28, Universit\u00e9 de Gen\u00e8ve",
       "note": "Contains the original statement of Problem #400 on factorial divisibility and sum excess"
     },
     {
-      "authors": "Erdős Problems",
+      "authors": "Erd\u0151s Problems",
       "title": "Problem #400",
       "year": "2024",
       "venue": "https://erdosproblems.com/400",

--- a/src/data/research/problems/erdos-1105.json
+++ b/src/data/research/problems/erdos-1105.json
@@ -29,13 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 8 axioms (mostly deep results), 1 sorry. No quick wins.",
-    "builtItems": [],
+    "progressSummary": "SESSION 2: Fixed pre-existing build error (turan DecidableRel). Added 2 new proved theorems: monochromatic avoidance, numColors bound. ar_upper_bound sorry remains (needs edge_pairs_card identity). 5 theorems, 8 axioms, 1 sorry, 291 lines.",
+    "builtItems": [
+      "monochromatic_avoids_rainbow: constant coloring avoids rainbow (proved)",
+      "numColors_le_edges: numColors bounded by edge count (proved)",
+      "Fixed turan definition (added DecidableRel G for Finset.filter)"
+    ],
     "insights": [
       "8 axioms: ar_triangle, simonovits_sos_path, yuan_path_announced, ar_lower_bound (oversimplified), ar_mono_n, ar_turan_lower, ar_path_3, ar_k3",
       "1 sorry: ar_upper_bound (AR ≤ C(n,2))",
       "ar_lower_bound is oversimplified (says ≥ 1 instead of proper bound)",
-      "yuan_path_announced axiomatizes an announced result"
+      "yuan_path_announced axiomatizes an announced result",
+      "Pre-existing bug: turan definition lacked DecidableRel G, causing build failure - fixed",
+      "monochromatic_avoids_rainbow: constant coloring avoids rainbow for H with >= 2 edges (proved)",
+      "numColors_le_edges: card_image_le gives numColors <= edge slot count (proved)",
+      "ar_upper_bound: proof roadmap is Nat.sSup_le + numColors_le_edges + edge_pairs_card identity"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -63,8 +71,8 @@
     {
       "path": "Proofs/Erdos1105Problem.lean",
       "filename": "Erdos1105Problem.lean",
-      "lineCount": 276,
-      "theoremCount": 3,
+      "lineCount": 291,
+      "theoremCount": 5,
       "axiomCount": 8,
       "defCount": 25,
       "sorryCount": 1,

--- a/src/data/research/problems/erdos-1132-oq-01.json
+++ b/src/data/research/problems/erdos-1132-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Proved chebyshevNodes_in_interval (cos in [-1,1]). Converted lebesgueFunction_ge_one from axiom to theorem via partition of unity lemma. Axioms: 7 → 5, sorries: 0 → 1. Created Aristotle companion file.",
+    "progressSummary": "SESSION 3: Assessed lagrangeBasis_sum_eq_one sorry. Proof requires polynomial uniqueness theory or Mathlib Lagrange module connection. Documented proof strategies.",
     "builtItems": [
       "lagrangeBasis_self: proved from definition using div_self (eliminated axiom)",
       "lagrangeBasis_other: proved from definition using prod_eq_zero (eliminated axiom)",
@@ -43,7 +43,10 @@
       "Remaining 7 axioms are genuinely deep results (Lebesgue function bounds, Erdős lower bound, Chebyshev, density theorems)",
       "Remaining 5 axioms are genuinely deep results (Erdos lower bound, Chebyshev optimality, Bernstein density, Erdos max, equidistant exponential growth) - cannot be proved from Mathlib",
       "lagrangeBasis_sum_eq_one (partition of unity) is the key blocker - standard polynomial identity but non-trivial to formalize from product definition",
-      "Proof strategy for partition of unity: P(x) = Σ lₖ(x) has degree ≤ n-1 and equals 1 at all n nodes, so P ≡ 1 by uniqueness of interpolation"
+      "Proof strategy for partition of unity: P(x) = Σ lₖ(x) has degree ≤ n-1 and equals 1 at all n nodes, so P ≡ 1 by uniqueness of interpolation",
+      "lagrangeBasis_sum_eq_one: standard proof uses polynomial interpolation uniqueness (degree n-1 poly with n roots is 0)",
+      "Mathlib.LinearAlgebra.Lagrange may have sum_basis or equivalent; connecting custom lagrangeBasis to Mathlib Lagrange.basis could simplify proof",
+      "Direct algebraic proof for n=2 works cleanly; general case needs induction or polynomial theory"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-400.json
+++ b/src/data/research/problems/erdos-400.json
@@ -29,13 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM REDUCTION: 5→3 axioms. gExcess_nonneg and g2_binomial_connection converted from axioms to theorems. 3 sorries remain in helper lemmas (Finset.prod/sum manipulation for trivial tuple). Added factor_le_of_factorial_divides structural theorem.",
+    "progressSummary": "SESSION 3: Eliminated all 3 remaining sorries. File is now sorry-free: 5 theorems (all proved), 3 axioms (all deep), 0 sorries, 183 lines.",
     "builtItems": [
       "factor_le_of_factorial_divides: structural bound on tuple entries",
       "excess_set_bddAbove: BddAbove proof for the excess set (3 sorries in helper)",
       "zero_mem_excess_set: membership proof for trivial tuple (3 sorries in helper)",
       "gExcess_nonneg: PROVED (was axiom) — non-negativity of excess",
-      "g2_binomial_connection: PROVED (was axiom) — Fin 2 pair correspondence"
+      "g2_binomial_connection: PROVED (was axiom) — Fin 2 pair correspondence",
+      "excess_set_bddAbove: FULLY PROVED (was 1 sorry) — n=0 case via dvd_prod_of_mem",
+      "zero_mem_excess_set: FULLY PROVED (was 2 sorries) — prod_ite_eq/sum_ite_eq for trivial tuple",
+      "g2_binomial_connection backward direction: FIXED (was broken by Mathlib update)"
     ],
     "insights": [
       "Conjectures correctly stated as defs (good)",
@@ -43,7 +46,10 @@
       "5 axioms: gExcess_upper_bound (deep), gExcess_nonneg, g2_binomial_connection, g2_excess_characterization, average_g2_growth (deep)",
       "gExcess_nonneg proved: trivial tuple (n,0,...,0) has product n! and excess 0, le_csSup gives sSup ≥ 0",
       "g2_binomial_connection proved: Fin 2 ↔ (a,b) pair via Fin.prod_univ_two and Fin.sum_univ_two",
-      "factor_le_of_factorial_divides: if product of factorials divides n!, each a_i ≤ n (via factorial monotonicity)"
+      "factor_le_of_factorial_divides: if product of factorials divides n!, each a_i ≤ n (via factorial monotonicity)",
+      "All 3 sorries eliminated: excess_set_bddAbove (Finset.dvd_prod_of_mem + factorial bound), zero_mem_excess_set (prod_ite_eq/sum_ite_eq)",
+      "Fixed g2_binomial_connection backward direction (simp handles Matrix.cons_val automatically)",
+      "File now: 0 sorries, 5 theorems, 3 axioms (remaining 3 are deep: upper_bound, g2_characterization, average_growth)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -74,8 +80,8 @@
     {
       "path": "Proofs/Erdos400Problem.lean",
       "filename": "Erdos400Problem.lean",
-      "lineCount": 114,
-      "theoremCount": 0,
+      "lineCount": 183,
+      "theoremCount": 5,
       "axiomCount": 5,
       "defCount": 6,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-960.json
+++ b/src/data/research/problems/erdos-960.json
@@ -29,14 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Fixed linear_implies_littleo N₀ bug (C+1 → ⌈C/ε⌉+1). Converted green_tao_ordinary_lines from sorry to axiom (deep 2013 result). Documented threshold_r2 semantic issue. Axioms: 1→2, sorries: 4→3.",
+    "progressSummary": "SESSION 3: Fixed threshold_r2 semantic bug (=0 not =1). Discovered multiple pre-existing Mathlib API breakages preventing build. File needs mechanic repair.",
     "builtItems": [
       "Proved trivial_bound: ordinaryLineCount P ≤ P.n * (P.n - 1) / 2",
       "Identified bug in threshold_r2 (claims 1, should be 0)",
       "Identified bug in linear_implies_littleo N₀ (C+1 → ⌈C/ε⌉+1)",
       "linear_implies_littleo: fixed N₀ from C+1 to ⌈C/ε⌉+1 (was wrong for ε < 1)",
       "green_tao_ordinary_lines: correctly reclassified as axiom (Green-Tao 2013 deep result)",
-      "threshold_r2: documented semantic bug (sSup definition gives 0, not 1)"
+      "threshold_r2: documented semantic bug (sSup definition gives 0, not 1)",
+      "Fixed threshold_r2 statement: = 0 (was incorrectly = 1)"
     ],
     "insights": [
       "trivial_bound provable: filter_le on offDiag + card_offDiag + omega",
@@ -48,7 +49,11 @@
       "green_tao_ordinary_lines (2013) cannot be proved from Mathlib; correctly axiomatized",
       "turan_upper_bound requires encoding Turán theorem for the ordinary-line graph — non-trivial formalization",
       "The linear_implies_littleo proof requires careful ℚ/ℕ coercion handling for the ε*n*n conversion",
-      "For small ε, N₀ = C+1 fails: need n > C/ε to ensure C*n < ε*n²"
+      "For small ε, N₀ = C+1 fails: need n > C/ε to ensure C*n < ε*n²",
+      "threshold_r2 statement was WRONG: should be =0 not =1 (sSup of empty counterexample set = 0)",
+      "File has pre-existing Mathlib API breakages: Rat.toNat missing, Finset.card_offDiag renamed, projection issues",
+      "linear_implies_littleo N₀ has edge case bug for C=0 (needs ε*n²≥1 guarantee)",
+      "For r=2 with any k≥2: Sylvester-Gallai implies ordinary lines exist, so 2-element all-ordinary subsets always exist"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Fixed `threshold_r2` statement: value is 0, not 1 (sSup of empty counterexample set)
- Documented pre-existing Mathlib API breakages preventing build

## Findings
- **threshold_r2 bug**: The sSup-based threshold definition gives the max m where a counterexample exists. For r=2, no counterexamples exist (any ordinary line gives a 2-element all-ordinary subset), so sSup ∅ = 0
- **Pre-existing breakages**: `Rat.toNat` missing, `Finset.card_offDiag` renamed, projection syntax issues
- **linear_implies_littleo**: N₀ has edge case bug when C=0 (needs `ε*n²≥1` guarantee)
- File needs mechanic repair for Mathlib API updates

## Status
**Outcome**: surveyed (correctness fix, documented breakages)
**Next Steps**: Mechanic repair needed for Mathlib API changes

Generated by researcher-1