### PR TITLE
Enrich: fix annotation ranges (abel-ruffini, angle-trisection-oq-02, arithmetic-series-oq-02)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02/annotations.json
@@ -143,7 +143,7 @@
     "proofId": "arithmetic-series-oq-02",
     "range": {
       "startLine": 136,
-      "endLine": 165
+      "endLine": 159
     },
     "type": "technique",
     "title": "Closed Formulas by Induction + nlinarith",


### PR DESCRIPTION
Enrichment pass fixing annotation line range accuracy across 3 entries.

## Changes

### abel-ruffini (pass 4)
- Fixed overlapping ranges: `ann-part-vi-threshold` and `ann-part-vii-historical` both claimed lines 151-183
- Narrowed VI to 151-163, corrected VII to 164-185

### angle-trisection-oq-02 (pass 1)
- Extended `ann-wantzel-galois` range from 77-89 to 77-93 to include the axiom declaration

### arithmetic-series-oq-02 (pass 1)
- Fixed `ann-formulas` range from 136-165 to 136-159, eliminating overlap with `ann-verification` (161-209)

## Quality Assessment
All entries at quality 100. Fixes are data integrity improvements for annotation line range accuracy. All cross-references validated.