### PR TITLE
Peer review: bezout-identity (B)

### DIFF
--- a/src/data/proofs/bezout-identity/review.json
+++ b/src/data/proofs/bezout-identity/review.json
@@ -1,0 +1,136 @@
+{
+  "version": 1,
+  "proofId": "bezout-identity",
+  "reviewDate": "2026-03-24T16:00:00Z",
+  "reviewer": "peer-reviewer-1",
+
+  "overallAssessment": {
+    "grade": "B",
+    "oneLiner": "A well-structured pedagogical entry with three genuinely substantive corollaries built on Mathlib wrappers, marred by overcounting wrappers as original contributions and a fabricated claim about Euclid's lemma.",
+    "tier": "B",
+    "tierJustification": "The core Bezout identity is a direct Mathlib application (Nat.gcd_eq_gcd_ab / Int.gcd_eq_gcd_ab), but the file adds real value through the coprimality characterization (22-line iff proof), Diophantine solvability criterion (15-line iff proof with calc block), and modular inverse existence. This qualifies as Tier B: formalized using Mathlib with genuine bridge/infrastructure theorems."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "coprime_iff_linear_combination, lines 125-148",
+      "finding": "The coprimality characterization is a genuinely substantive proof. The reverse direction (lines 134-148) constructs a multi-step divisibility argument: gcd divides a and b, therefore divides ax + by = 1, convert through natAbs, conclude gcd = 1 via Nat.eq_one_of_dvd_one. This is the kind of non-trivial reasoning that adds real value over a raw Mathlib import.",
+      "recommendation": "Preserve this as the centerpiece of the entry. It demonstrates real proof engineering."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "diophantine_solvable, lines 176-191",
+      "finding": "The Diophantine solvability criterion is another substantive proof with genuine bidirectional reasoning. The reverse direction (lines 184-191) uses a calc chain to scale Bezout coefficients by k = c/gcd, with ring for the algebraic steps. This is a meaningful mathematical result that goes beyond Mathlib wrapping.",
+      "recommendation": "Highlight this alongside the coprimality proof as the two main contributions."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json badge field",
+      "finding": "The badge is honestly set to 'mathlib' rather than 'original', correctly acknowledging the Mathlib foundation. The status 'verified' with 0 sorries and 0 axioms is also accurate.",
+      "recommendation": "No change needed. This is the right level of honesty."
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "overview.text, paragraph 1",
+      "finding": "The overview text claims '(4) Euclid's lemma (p | ab => p | a or p | b for primes)' as a formalized result. There is no Euclid's lemma theorem anywhere in BezoutIdentity.lean. The file only contains a prose comment about Euclid's lemma in the 'Connection to Other Theorems' section (lines 218-220). This is a fabricated claim -- commentary about a theorem is not a formalization of it.",
+      "recommendation": "Remove the Euclid's lemma claim from overview.text. If desired, note that the coprimality characterization provides the key ingredient for Euclid's lemma, but do not claim it is proved in this file."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions, items 1-3",
+      "finding": "Three of eight listed 'original contributions' are trivial Mathlib wrappers: (1) 'Bezout's identity for N with explicit existential witnesses via gcdA and gcdB' is the single line '<Nat.gcdA a b, Nat.gcdB a b, Nat.gcd_eq_gcd_ab a b>' (line 81). (2) 'Bezout's identity for Z extending the natural number version' is the identical pattern with Int variants (line 96). (3) 'Extended GCD components theorem packaging gcdA, gcdB, and gcd together' has proof body 'Nat.gcd_eq_gcd_ab a b' (line 116), the same single Mathlib call with let-bindings for cosmetic naming. Calling these 'original contributions' overstates what is essentially three renamings of the same Mathlib theorem.",
+      "recommendation": "Reframe items 1-3 as 'Pedagogical wrappers providing explicit witnesses and named components around Mathlib's gcd_eq_gcd_ab'. Reserve 'original contribution' language for the coprimality, modular inverse, and Diophantine proofs."
+    },
+    {
+      "severity": "moderate",
+      "category": "filler",
+      "location": "bezout_nat_explicit (line 85) and extended_gcd_components (line 111)",
+      "finding": "bezout_nat_explicit has proof body 'Nat.gcd_eq_gcd_ab a b' -- it is a literal synonym. extended_gcd_components has the same proof body with let-bindings that do not change the mathematical content. Together with bezout_nat, this is three theorems for the same fact, and bezout_int_explicit makes four if counting both the nat and int versions. The file has 5 Mathlib-synonym theorems out of 8 total named theorems.",
+      "recommendation": "Consider consolidating into 2 theorems (bezout_nat and bezout_int) for the core identity, and acknowledging the explicit/components forms as pedagogical restatements rather than independent results. Alternatively, if the pedagogical purpose is valued, clearly label them as such in the meta.json."
+    },
+    {
+      "severity": "moderate",
+      "category": "precision",
+      "location": "overview.text and overview.proofStrategy",
+      "finding": "The overview text says 'The file's substantial original contributions build on this foundation' (emphasis on 'substantial') when 5 of 8 theorems are one-line Mathlib calls. The proofStrategy section correctly describes the three substantive proofs but does not mention that the first five theorems are trivial wrappers, creating an asymmetric picture that emphasizes the additions while omitting the wrapper nature of the base theorems.",
+      "recommendation": "Add a sentence acknowledging that the core identity theorems are direct applications of Mathlib, with the file's value coming from the three application theorems. This is already partially done ('one-line applications of Mathlib's gcd_eq_gcd_ab') but should be more prominent."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json originalContributions, item 8",
+      "finding": "Item 8 lists 'Documentation connecting Bezout to Euclid's lemma, unique factorization, CRT, and RSA' as an original contribution. Documentation is valuable but listing it alongside proof contributions without distinction conflates expository writing with formal mathematics.",
+      "recommendation": "Move documentation to a separate category (e.g., 'pedagogicalContributions') or label it explicitly as 'Expository documentation' rather than placing it in the same list as proved theorems."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json lineCount vs overview.text",
+      "finding": "meta.json states lineCount 237, overview.text states '237-line formalization', but the conclusion says '238-line formalization'. The actual file is 237 lines (confirmed by wc -l). The conclusion has a minor off-by-one error.",
+      "recommendation": "Change conclusion summary from '238-line' to '237-line'."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "annotations.json ann-bezout-nat significance",
+      "finding": "ann-bezout-nat and ann-bezout-int are marked with significance 'key' but both theorems are one-line Mathlib wrappers. The genuinely key annotations (ann-coprimality, ann-diophantine) are also marked 'key', which dilutes the signal. The ann-extended-gcd is correctly marked 'supporting'.",
+      "recommendation": "Change ann-bezout-nat and ann-bezout-int significance from 'key' to 'supporting' to better distinguish the wrapper theorems from the substantive results."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Remove the fabricated Euclid's lemma claim from overview.text. The file does not contain a theorem proving Euclid's lemma. Replace with a note that coprime_iff_linear_combination provides a key ingredient that could be used to prove Euclid's lemma (and point to bezout-identity-oq-02 which actually proves it).",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Reframe originalContributions items 1-3 as pedagogical wrappers rather than original contributions. Suggested replacement: 'Pedagogical wrapper theorems (bezout_nat, bezout_int, bezout_nat_explicit, bezout_int_explicit, extended_gcd_components) providing accessible entry points to Mathlib's gcd_eq_gcd_ab with explicit witnesses and named components.'",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix the off-by-one line count in conclusion.summary: change '238-line' to '237-line'.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Downgrade annotations ann-bezout-nat and ann-bezout-int significance from 'key' to 'supporting' to properly distinguish wrapper theorems from the substantive coprimality, modular inverse, and Diophantine proofs.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Move item 8 of originalContributions ('Documentation connecting Bezout to Euclid's lemma...') to a separate pedagogical contributions category or explicitly label it as expository rather than mathematical.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 6,
+    "originalityAccuracy": 5,
+    "completeness": 8,
+    "framingPrecision": 6,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 7,
+    "overall": 6.7
+  },
+
+  "suggestedBestFraming": "A pedagogical formalization of Bezout's identity (Wiedijk #60) that wraps Mathlib's gcd_eq_gcd_ab for accessibility, then builds three substantive corollaries: a full coprimality characterization (gcd = 1 iff linear combination equals 1), modular inverse existence via Bezout coefficients, and a complete Diophantine solvability criterion (ax + by = c iff gcd | c), all with 0 sorries."
+}


### PR DESCRIPTION
## Summary

- Peer review of the bezout-identity gallery entry (Wiedijk #60, Bezout's Identity)
- **Grade: B** (overall score 6.7/10)
- **Tier: B** -- Core identity from Mathlib, with three substantive corollary proofs
- 10 findings (3 positive, 1 major, 3 moderate, 3 minor)
- 5 action items (1 high, 2 medium, 2 low), all targeting the enricher

## Key Findings

**Strengths**: coprime_iff_linear_combination (22-line iff proof) and diophantine_solvable (15-line iff with calc block) are genuinely substantive. Badge honestly set to "mathlib".

**Major issue**: overview.text fabricates a claim that Euclid's lemma is formalized in this file -- it is only discussed in prose comments, not proved.

**Moderate issues**: 3 of 8 "original contributions" are one-line Mathlib wrappers (bezout_nat, bezout_int, extended_gcd_components all have proof body `Nat.gcd_eq_gcd_ab a b`). 5 of 8 named theorems are Mathlib synonyms.

## Test plan

- [ ] Verify review.json is valid JSON and follows schema
- [ ] Verify review-tracker.json has bezout-identity entry with grade B
- [ ] Enricher should act on the 5 action items (especially ai-1: remove Euclid's lemma fabrication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)