### PR TITLE
Peer review: cramers-rule (B-)

### DIFF
--- a/src/data/proofs/cramers-rule/review.json
+++ b/src/data/proofs/cramers-rule/review.json
@@ -1,0 +1,143 @@
+{
+  "version": 1,
+  "proofId": "cramers-rule",
+  "reviewDate": "2026-03-24T16:00:00Z",
+  "reviewer": "peer-reviewer-1",
+
+  "overallAssessment": {
+    "grade": "B-",
+    "oneLiner": "A well-organized pedagogical exposition of Cramer's Rule built almost entirely on Mathlib wrappers, with several factual errors in the overview narrative that must be corrected.",
+    "tier": "B",
+    "tierJustification": "The core theorem (cramers_rule) is a direct call to Matrix.mulVec_cramer. The file adds the invertible-determinant solution formula and a 2x2 field example, but the heavy lifting is done by Mathlib's adjugate infrastructure. This is a Mathlib-backed formalization, not an original proof."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "CramersRule.lean, overall structure",
+      "finding": "The file is exceptionally well-organized with clear section headers, accurate docstrings on each theorem, and a logical progression from the component formula through the main identity, adjugate connection, transpose form, linearity properties, and a concrete 2x2 example. The choice to work over CommRing rather than Field, and to use the Invertible typeclass for the solution formula, demonstrates genuine mathematical sophistication in the formalization design.",
+      "recommendation": "Preserve this structure. It is a model for how pedagogical Mathlib-wrapper proofs should be organized."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "CramersRule.lean, cramers_rule_solution (line 94-96)",
+      "finding": "The solution formula cramers_rule_solution is the most original content in the file: it derives A * (det(A)^{-1} * cramer(A,b)) = b from the main identity via a 4-step rewrite. While short, this is a genuine (if minor) composition not directly available in Mathlib as a single lemma.",
+      "recommendation": "Highlight this as the primary original contribution rather than listing the Mathlib wrappers."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "OQ companion files (CramersRuleOQ01.lean, OQ02, OQ04)",
+      "finding": "The companion OQ files are substantially more original than the main proof: OQ01 gives an explicit step-by-step derivation of Cayley-Hamilton from the adjugate identity (not just calling aeval_self_charpoly), OQ02 formalizes the complexity comparison with factorial growth lemmas and an asymptotic theorem, and OQ04 develops generalized inverse properties. These represent genuine mathematical work.",
+      "recommendation": "Consider mentioning the OQ files in the gallery entry's conclusion or as related extensions, since they demonstrate the mathematical depth that the main file's framing implies."
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "meta.json, overview.text (line 61)",
+      "finding": "The overview text claims 'Explicit examples for 2x2 and 3x3 systems are verified by native_decide and norm_num.' This is factually false: (1) there is no 3x3 example in CramersRule.lean, (2) native_decide is never used in the file, (3) norm_num is never used in the file. The 2x2 example uses a rewrite chain (mulVec_smul, cramers_rule, smul_smul, inv_mul_cancel, one_smul), not decision procedures.",
+      "recommendation": "Remove the claim about 3x3 examples and native_decide/norm_num. Replace with: 'A 2x2 field example demonstrates the classical formula via algebraic rewriting.'"
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "meta.json, overview.text (line 61)",
+      "finding": "The overview text claims the formalization 'covers the existence and uniqueness of solutions.' No uniqueness theorem is proved in the file. The word 'unique' appears only in docstring comments (lines 25, 85), never in a theorem statement. Existence is implicit (the Cramer vector exists), but there is no formal proof that it is THE unique solution when det(A) is invertible.",
+      "recommendation": "Either (a) add a uniqueness theorem (e.g., if A.mulVec x = b and Invertible A.det, then x = det(A)^{-1} * cramer(A,b)) or (b) remove the uniqueness claim from the overview."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json, overview.text (line 61) vs wiedijkNumber (line 53)",
+      "finding": "The overview text says 'Wiedijk #100' but the wiedijkNumber field correctly states 97, and the Lean file header correctly says 'Wiedijk #97'. This is a simple numbering error in the prose.",
+      "recommendation": "Change 'Wiedijk #100' to 'Wiedijk #97' in overview.text."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json, originalContributions (lines 44-49)",
+      "finding": "Of the 6 listed 'original contributions,' 5 are direct one-line Mathlib wrappers: (1) 'General form' is Matrix.mulVec_cramer, (3) 'Connection to adjugate' is Matrix.cramer_eq_adjugate_mulVec, (4) 'Transpose form' is Matrix.cramer_transpose_apply, (5) 'Linearity properties' are map_add/map_smul/map_zero, (6) '2x2 example' is a 3-step rewrite. Only item (2) 'Solution formula with Invertible typeclass' has a multi-step proof body. Calling one-line Mathlib calls 'original contributions' misrepresents the nature of the work.",
+      "recommendation": "Reframe as 'pedagogical contributions' or 'curated Mathlib results.' Reserve 'original contributions' for cramers_rule_solution and the 2x2 example. Alternatively, describe these as 'results assembled from Mathlib' with the solution formula as the original bridge."
+    },
+    {
+      "severity": "moderate",
+      "category": "precision",
+      "location": "meta.json, badge field (line 19)",
+      "finding": "The badge is 'mathlib' which is accurate for this proof -- it correctly signals Mathlib dependency. However, the status is 'verified' (line 10) which in combination with 'mathlib' creates a slightly misleading impression. 'Verified' typically implies the proof was independently constructed and checked. Here, the core theorems are Mathlib lemmas re-exported under new names. The badge/status combination is technically correct per project definitions but could be more informative.",
+      "recommendation": "The badge 'mathlib' is the right choice and should be preserved. No change needed -- this is a minor observation, not a required fix."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json, leanFile.theoremCount (line 224)",
+      "finding": "The theoremCount is listed as 9 but the file contains 9 named theorems plus 1 unnamed example (line 149), totaling 10 theorem-level items. The example has a substantive proof body and should arguably be counted.",
+      "recommendation": "Either count the example (making it 10) or add a note that the example is excluded from the count. Minor issue."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json, crossReferences: cauchy-schwarz and fundamental-arithmetic",
+      "finding": "The cross-references to cauchy-schwarz and fundamental-arithmetic are vague and tenuous. The stated relationship for cauchy-schwarz is 'Both are foundational linear algebra results' -- Cauchy-Schwarz is an inner product space result, not a linear algebra result in the same sense as Cramer's Rule. The fundamental-arithmetic connection ('both work over abstract algebraic structures') is even more generic. By contrast, the cayley-hamilton cross-reference is excellent and mathematically substantive.",
+      "recommendation": "Remove or strengthen the weak cross-references. The cayley-hamilton and cayley-hamilton-minpoly references are the ones with real mathematical content."
+    },
+    {
+      "severity": "minor",
+      "category": "filler",
+      "location": "CramersRule.lean, cramer_zero (line 137-139)",
+      "finding": "cramer_zero proves A.cramer 0 = 0, which is an automatic consequence of cramer being a LinearMap (map_zero). While not harmful, it is the most trivially-deducible fact in the file and adds no insight.",
+      "recommendation": "Low priority. Could be removed to tighten the file, but it does complete the 'linearity properties' section. Acceptable as-is for pedagogical completeness."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Fix factual errors in overview.text: (1) change 'Wiedijk #100' to 'Wiedijk #97', (2) remove false claims about 3x3 examples, native_decide, and norm_num, (3) remove false claim about existence and uniqueness coverage.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Reframe originalContributions to distinguish 'curated Mathlib results' from genuinely original work. The solution formula (cramers_rule_solution) and 2x2 example are the primary original items; the rest are pedagogical restatements of Mathlib lemmas.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "medium",
+      "target": "researcher",
+      "description": "Add a uniqueness theorem: if Invertible A.det and A.mulVec x = b, then x = det(A)^{-1} * A.cramer b. This would make the 'existence and uniqueness' claim true and add genuine mathematical substance.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Strengthen or remove weak cross-references (cauchy-schwarz, fundamental-arithmetic). The cayley-hamilton references are excellent and should be preserved.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Fix theoremCount from 9 to 10 (to include the unnamed 2x2 example) or add clarifying note.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 4,
+    "originalityAccuracy": 5,
+    "completeness": 7,
+    "framingPrecision": 5,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 5,
+    "overall": 5.7
+  },
+
+  "suggestedBestFraming": "A pedagogical exposition of Cramer's Rule (Wiedijk #97) in Lean 4, assembling Mathlib's Matrix.cramer and adjugate infrastructure into a readable 161-line walkthrough of the component formula, main identity, adjugate connection, and transpose form, with an original bridge theorem deriving the explicit solution formula when det(A) is invertible."
+}


### PR DESCRIPTION
## Summary

- Peer review of the cramers-rule gallery entry
- Grade: **B-** (overall score 5.7/10)
- 12 findings (3 positive, 2 major, 3 moderate, 4 minor)
- 5 action items (2 high, 2 medium, 1 low)

## Key Findings

**Strengths**: Exceptionally well-organized pedagogical exposition with clear section structure. The OQ companion files (OQ01, OQ02, OQ04) contain substantially more original mathematical work than the main file.

**Major Issues**:
1. The overview text contains multiple factual errors: claims 3x3 examples that don't exist, claims native_decide/norm_num usage that doesn't occur, says "Wiedijk #100" when it should be #97
2. Claims "existence and uniqueness" coverage but no uniqueness theorem is proved
3. 5 of 6 listed "original contributions" are single-line Mathlib wrappers

## Tier

**Tier B** (Mathlib-backed formalization): The core theorems are direct Mathlib calls. The file's value is pedagogical curation, not original proof work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)