### PR TITLE
fix: triangular-reciprocals index.ts type assertion

### DIFF
--- a/src/data/proofs/triangular-reciprocals/index.ts
+++ b/src/data/proofs/triangular-reciprocals/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/TriangularNumberReciprocals.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const triangularReciprocalsProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const triangularReciprocalsProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const triangularReciprocalsAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const triangularReciprocalsData: ProofData = { proof: triangularReciprocalsProof, annotations: triangularReciprocalsAnnotations }


### PR DESCRIPTION
## Summary
- Fix malformed `CrossReference` property in type cast — should be `crossReferences?: CrossReference[]`
- This was causing build failures (`TS6196` unused import + `TS2352` type mismatch)

## Test plan
- Build should pass after this fix