### PR TITLE
Enrich abel-ruffini: fix overlapping annotation ranges

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -338,7 +338,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -365,8 +365,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "context",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
Enrichment pass for abel-ruffini. Fixes overlapping annotation ranges for Parts VI and VII.

**Changes:**
- `ann-part-vi-threshold`: range 151-183 → 151-163 (Part VI ends at line 163)
- `ann-part-vii-historical`: range 151-183 → 164-185 (Part VII starts at line 164)

Both annotations previously shared the identical range {151, 183}, causing Part VII's annotation to incorrectly start at Part VI's beginning. The sections array already had the correct ranges; this aligns the annotations to match.