### PR TITLE
Research: erdos-1105 + erdos-1177 + erdos-279 - Axiom elimination (8→7, 18→7, 4→2)

### DIFF
--- a/proofs/Proofs/Erdos1105Problem.lean
+++ b/proofs/Proofs/Erdos1105Problem.lean
@@ -187,29 +187,135 @@ axiom yuan_path_announced : PathConjecture
 General bounds on anti-Ramsey numbers.
 -/
 
--- Lower bound: AR(n, G) ≥ |E(G)| - 1 (need |E(G)| - 1 edges same color)
-axiom ar_lower_bound : ∀ (n k : ℕ) (H : SimpleGraph k),
-  antiRamsey n k H ≥ 1  -- Simplified; actual bound depends on H
+-- Constant coloring uses exactly 1 color when n ≥ 2
+private lemma numColors_const_one (n : ℕ) (hn : n ≥ 2) :
+    numColors n (fun _ => (0 : ℕ)) = 1 := by
+  unfold numColors
+  set S := Finset.univ.filter (fun e : Fin n × Fin n => e.1 < e.2) with hS_def
+  have hne : S.Nonempty := by
+    use (⟨0, by omega⟩, ⟨1, by omega⟩)
+    simp only [hS_def, Finset.mem_filter, Finset.mem_univ, true_and, Fin.mk_lt_mk]
+    omega
+  have himg : S.image (fun _ => (0 : ℕ)) = {0} := by
+    ext x
+    simp only [Finset.mem_image, Finset.mem_singleton]
+    exact ⟨fun ⟨_, _, h⟩ => h.symm, fun h => ⟨hne.choose, hne.choose_spec, h.symm⟩⟩
+  rw [himg, Finset.card_singleton]
 
-/-- A monochromatic coloring avoids rainbow copies of any graph with ≥ 2 edges. -/
-theorem monochromatic_avoids_rainbow (n k : ℕ) (H : SimpleGraph k)
-    (he : ∃ e₁ e₂ : Fin k × Fin k, e₁ ≠ e₂ ∧ H e₁.1 e₁.2 ∧ H e₂.1 e₂.2) :
+-- Constant coloring avoids rainbow for graphs with ≥ 2 directed edge pairs
+private lemma const_avoids_rainbow (n k : ℕ) (H : SimpleGraph k)
+    (hedge : ∃ i j : Fin k, H i j ∧ H j i ∧ i ≠ j) :
     AvoidsRainbow n (fun _ => (0 : ℕ)) k H := by
-  intro emb hR
-  obtain ⟨e₁, e₂, hne, he1, he2⟩ := he
-  exact absurd (hR e₁ e₂ he1 he2 hne) (by simp)
+  intro emb h_rainbow
+  obtain ⟨i, j, hij, hji, hne⟩ := hedge
+  exact absurd rfl (h_rainbow (i, j) (j, i) hij hji (fun h => hne (congr_arg Prod.fst h)))
 
-/-- The number of colors is at most the number of edge slots (by card_image_le). -/
-theorem numColors_le_edges (n : ℕ) (coloring : (Fin n × Fin n) → ℕ) :
-    numColors n coloring ≤
-      (Finset.univ.filter (fun e : Fin n × Fin n => e.1 < e.2)).card :=
-  Finset.card_image_le
+-- Lower bound: AR(n, H) ≥ 1 for n ≥ 2 and H with symmetric edges
+-- (Eliminates oversimplified ar_lower_bound axiom which was false for n < 2)
+theorem ar_lower_bound (n k : ℕ) (H : SimpleGraph k)
+    (hn : n ≥ 2)
+    (hedge : ∃ i j : Fin k, H i j ∧ H j i ∧ i ≠ j) :
+    antiRamsey n k H ≥ 1 := by
+  unfold antiRamsey
+  have hmem : 1 ∈ {c : ℕ | ∃ coloring : (Fin n × Fin n) → ℕ,
+    numColors n coloring = c ∧ AvoidsRainbow n coloring k H} :=
+    ⟨fun _ => 0, numColors_const_one n hn, const_avoids_rainbow n k H hedge⟩
+  have hbdd : BddAbove {c : ℕ | ∃ coloring : (Fin n × Fin n) → ℕ,
+    numColors n coloring = c ∧ AvoidsRainbow n coloring k H} :=
+    ⟨n * n, fun c ⟨coloring, hc_eq, _⟩ => by
+      rw [← hc_eq]; unfold numColors
+      calc (Finset.image coloring _).card
+          ≤ (Finset.univ.filter _).card := Finset.card_image_le
+        _ ≤ Finset.univ.card := Finset.card_filter_le _ _
+        _ = n * n := by simp [Finset.card_univ, Fintype.card_prod, Fintype.card_fin]⟩
+  exact le_csSup hbdd hmem
+
+-- Helper: n.choose 2 * 2 + n = n * n (subtraction-free form)
+private lemma choose_two_add_eq (n : ℕ) : n.choose 2 * 2 + n = n * n := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [Nat.choose_succ_succ, Nat.choose_one_right, add_mul,
+        show m * 2 + m.choose 2 * 2 + (m + 1) =
+             (m.choose 2 * 2 + m) + (m * 2 + 1) from by ring, ih]
+    ring
+
+-- Helper: |{(i,j) : Fin n × Fin n | i < j}| = C(n,2)
+-- Proof via trichotomy: every pair is in exactly one of {i<j}, {i=j}, {i>j}
+private lemma card_edges_eq_choose (n : ℕ) :
+    (Finset.univ.filter (fun e : Fin n × Fin n => e.1 < e.2)).card = n.choose 2 := by
+  set S_lt := Finset.univ.filter (fun e : Fin n × Fin n => e.1 < e.2)
+  set S_gt := Finset.univ.filter (fun e : Fin n × Fin n => e.2 < e.1)
+  set S_eq := Finset.univ.filter (fun e : Fin n × Fin n => e.1 = e.2)
+  -- Pairwise disjointness
+  have hdisj_lt_eq : Disjoint S_lt S_eq := by
+    rw [Finset.disjoint_left]; intro ⟨a, b⟩ h1 h2
+    simp only [S_lt, S_eq, Finset.mem_filter] at h1 h2; exact absurd h2.2 (ne_of_lt h1.2)
+  have hdisj_lt_gt : Disjoint S_lt S_gt := by
+    rw [Finset.disjoint_left]; intro ⟨a, b⟩ h1 h2
+    simp only [S_lt, S_gt, Finset.mem_filter] at h1 h2
+    exact absurd (lt_trans h1.2 h2.2) (lt_irrefl _)
+  have hdisj_eq_gt : Disjoint S_eq S_gt := by
+    rw [Finset.disjoint_left]; intro ⟨a, b⟩ h1 h2
+    simp only [S_eq, S_gt, Finset.mem_filter] at h1 h2; exact absurd h1.2 (ne_of_gt h2.2)
+  -- Union = Finset.univ (trichotomy)
+  have hunion : S_lt ∪ S_eq ∪ S_gt = Finset.univ := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_union, S_lt, S_eq, S_gt, Finset.mem_filter, Finset.mem_univ, true_and,
+               iff_true]
+    rcases lt_trichotomy a b with h | h | h
+    · exact Or.inl (Or.inl h)
+    · exact Or.inl (Or.inr h)
+    · exact Or.inr h
+  -- |S_lt| = |S_gt| via Prod.swap bijection
+  have hswap : S_lt.card = S_gt.card := by
+    apply Finset.card_bij (fun e _ => (e.2, e.1))
+    · intro ⟨a, b⟩ ha
+      simp only [S_lt, S_gt, Finset.mem_filter, Finset.mem_univ, true_and] at ha ⊢; exact ha
+    · intro ⟨a₁, b₁⟩ _ ⟨a₂, b₂⟩ _ h
+      simp only [Prod.mk.injEq] at h; exact Prod.ext h.2 h.1
+    · intro ⟨a, b⟩ hb
+      exact ⟨(b, a), by
+        simp only [S_lt, S_gt, Finset.mem_filter, Finset.mem_univ, true_and] at hb ⊢
+        exact hb, rfl⟩
+  -- |S_eq| = n (diagonal)
+  have hdiag : S_eq.card = n := by
+    suffices h : S_eq = Finset.univ.image (fun x : Fin n => (x, x)) by
+      rw [h, Finset.card_image_of_injective _ (fun a b h => (Prod.mk.inj h).1), Finset.card_fin]
+    ext ⟨a, b⟩; simp [S_eq, Finset.mem_image, Prod.mk.injEq, eq_comm]
+  -- |Fin n × Fin n| = n²
+  have htotal : (Finset.univ : Finset (Fin n × Fin n)).card = n * n := by
+    simp [Finset.card_univ, Fintype.card_prod, Fintype.card_fin]
+  -- Combine: 2 * |S_lt| + n = n * n
+  have h_count : S_lt.card * 2 + n = n * n := by
+    have hdisj_outer : Disjoint (S_lt ∪ S_eq) S_gt := by
+      rw [Finset.disjoint_left]; intro x hx hgt
+      rcases Finset.mem_union.mp hx with hlt | heq
+      · exact (Finset.disjoint_left.mp hdisj_lt_gt) hlt hgt
+      · exact (Finset.disjoint_left.mp hdisj_eq_gt) heq hgt
+    have h3 : (S_lt ∪ S_eq ∪ S_gt).card = S_lt.card + S_eq.card + S_gt.card := by
+      rw [Finset.card_union_of_disjoint hdisj_outer,
+          Finset.card_union_of_disjoint hdisj_lt_eq]
+    rw [hunion, htotal] at h3; linarith [hdiag, hswap]
+  -- n.choose 2 * 2 + n = n * n, so S_lt.card = n.choose 2
+  linarith [choose_two_add_eq n]
+
+-- Helper: numColors ≤ numEdgesKn
+private lemma numColors_le_edges (n : ℕ) (coloring : (Fin n × Fin n) → ℕ) :
+    numColors n coloring ≤ numEdgesKn n := by
+  unfold numColors numEdgesKn
+  exact le_trans Finset.card_image_le (le_of_eq (card_edges_eq_choose n))
 
 -- Upper bound: AR(n, G) ≤ |E(K_n)| = C(n,2)
--- Proof strategy: Nat.sSup_le + numColors_le_edges + edge_pairs_card
 theorem ar_upper_bound (n k : ℕ) (H : SimpleGraph k) :
     antiRamsey n k H ≤ numEdgesKn n := by
-  sorry
+  unfold antiRamsey
+  rcases Set.eq_empty_or_nonempty {c : ℕ | ∃ coloring : (Fin n × Fin n) → ℕ,
+    numColors n coloring = c ∧ AvoidsRainbow n coloring k H} with h | h
+  · -- Empty set: sSup ∅ = 0 ≤ numEdgesKn n
+    rw [h]; simp
+  · -- Nonempty: each element ≤ numEdgesKn n, so sSup ≤ numEdgesKn n
+    exact csSup_le h (fun c ⟨coloring, hc, _⟩ => hc ▸ numColors_le_edges n coloring)
 
 -- Monotonicity in n
 axiom ar_mono_n : ∀ (n₁ n₂ k : ℕ) (H : SimpleGraph k),
@@ -222,10 +328,10 @@ Anti-Ramsey numbers relate to extremal graph theory.
 -/
 
 -- Turán number ex(n, H): max edges in H-free graph on n vertices
--- Note: requires decidability of the graph predicate for Finset.filter
+open Classical in
 noncomputable def turan (n k : ℕ) (H : SimpleGraph k) : ℕ :=
-  sSup {e : ℕ | ∃ (G : SimpleGraph n) (_ : DecidableRel G),
-    (∀ _emb : GraphEmbedding n k H, False) ∧ e = (Finset.univ.filter
+  sSup {e : ℕ | ∃ G : SimpleGraph n,
+    (∀ emb : GraphEmbedding n k H, False) ∧ e = (Finset.univ.filter
       (fun p : Fin n × Fin n => p.1 < p.2 ∧ G p.1 p.2)).card}
 
 -- AR(n, H) ≥ ex(n, H) + 1 (give H-free graph rainbow, one color for complement)

--- a/proofs/Proofs/Erdos1177Problem.lean
+++ b/proofs/Proofs/Erdos1177Problem.lean
@@ -18,51 +18,58 @@ References:
 - Erdős, Galvin, Hajnal (original)
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Set.Basic
-import Mathlib.Order.Basic
-import Mathlib.Tactic
+import Mathlib
 
 namespace Erdos1177
 
-/-
-## Part I: Abstract Framework
+open Cardinal
 
-We work with an abstract cardinal type and hypergraph type to avoid heavy
-SetTheory imports. This allows clean formalization of the problem structure
-while staying within reasonable build constraints.
+/-
+## Part I: Cardinals from Mathlib
+
+The original formalization axiomatized an abstract cardinal type with 10 axioms
+(Card, Card.le, Card.lt, aleph0, aleph1, beth2, Card.isUncountable, and 3 properties).
+Using Mathlib's Cardinal type eliminates all of them.
 -/
 
--- We axiomatize an abstract cardinal type with the needed properties
-axiom Card : Type
-axiom Card.le : Card → Card → Prop
-axiom Card.lt : Card → Card → Prop
-instance : LE Card := ⟨Card.le⟩
-instance : LT Card := ⟨Card.lt⟩
+-- ℵ₀ < ℵ₁ (proved from Mathlib; was axiom)
+theorem aleph0_lt_aleph1 : Cardinal.aleph0 < Cardinal.aleph 1 := by
+  rw [← Cardinal.aleph_zero]
+  exact Cardinal.aleph_lt_aleph.mpr (by norm_num)
 
--- Key cardinals used in the problem
-axiom aleph0 : Card          -- ℵ₀
-axiom aleph1 : Card          -- ℵ₁
-axiom beth2 : Card           -- 2^(2^ℵ₀)
-axiom Card.isUncountable : Card → Prop
+-- ℵ₁ is uncountable (proved; was axiom)
+theorem aleph1_uncountable : Cardinal.aleph0 < Cardinal.aleph 1 := aleph0_lt_aleph1
 
-axiom aleph0_lt_aleph1 : aleph0 < aleph1
-axiom aleph1_uncountable : Card.isUncountable aleph1
-axiom aleph1_le_beth2 : aleph1 ≤ beth2
+-- ℵ₁ ≤ 2^(2^ℵ₀) (proved; was axiom)
+-- Proof: ℵ₁ = succ(ℵ₀) ≤ 2^ℵ₀ (Cantor) ≤ 2^(2^ℵ₀) (monotone power)
+theorem aleph1_le_beth2 :
+    Cardinal.aleph 1 ≤ (2 : Cardinal) ^ ((2 : Cardinal) ^ Cardinal.aleph0) := by
+  have h_cantor := Cardinal.cantor Cardinal.aleph0
+  -- Step 1: ℵ₁ ≤ 2^ℵ₀
+  have h1 : Cardinal.aleph 1 ≤ (2 : Cardinal) ^ Cardinal.aleph0 := by
+    -- ℵ₁ = aleph(succ 0) = succ(aleph 0) = succ(ℵ₀)
+    have hsuc : Cardinal.aleph 1 = Order.succ Cardinal.aleph0 := by
+      rw [← Cardinal.aleph_zero, ← Cardinal.aleph_succ]
+      congr 1; exact Ordinal.succ_zero.symm
+    rw [hsuc]
+    exact Order.succ_le_of_lt h_cantor
+  -- Step 2: 2^ℵ₀ ≤ 2^(2^ℵ₀)
+  exact le_trans h1 (Cardinal.power_le_power_left
+    (by norm_num : (2 : Cardinal) ≠ 0) (le_of_lt h_cantor))
 
 /-
 ## Part II: 3-Uniform Hypergraphs
 
 A 3-uniform hypergraph on a vertex type V is specified by its edge set,
 where each edge is an unordered triple of vertices.
+We axiomatize the abstract type and its key operations.
 -/
 
-/-- Abstract type of 3-uniform hypergraphs. We parametrize by a "size" cardinal
-    to handle both finite and infinite vertex sets. -/
+/-- Abstract type of 3-uniform hypergraphs. -/
 axiom Hypergraph3 : Type
 
 /-- The cardinality (number of vertices) of a 3-uniform hypergraph. -/
-axiom Hypergraph3.vertexCard : Hypergraph3 → Card
+axiom Hypergraph3.vertexCard : Hypergraph3 → Cardinal.{0}
 
 /-- Whether one 3-uniform hypergraph contains another as a subhypergraph. -/
 axiom Hypergraph3.ContainsSubgraph : Hypergraph3 → Hypergraph3 → Prop
@@ -73,7 +80,7 @@ axiom Hypergraph3.IsFinite : Hypergraph3 → Prop
 /-- The chromatic number of a 3-uniform hypergraph.
     This is the minimum cardinal κ such that the vertices can be colored
     with κ colors so that no edge is monochromatic. -/
-axiom Hypergraph3.chromaticNumber : Hypergraph3 → Card
+axiom Hypergraph3.chromaticNumber : Hypergraph3 → Cardinal.{0}
 
 /-
 ## Part III: The Forbidden Subgraph Family F_G(κ)
@@ -84,12 +91,12 @@ of all 3-uniform hypergraphs with chromatic number κ that do not contain G.
 
 /-- F_G(κ): the family of 3-uniform hypergraphs with chromatic number κ
     that do not contain G as a subhypergraph. -/
-def forbiddenFamily (G : Hypergraph3) (kappa : Card) : Set Hypergraph3 :=
+def forbiddenFamily (G : Hypergraph3) (kappa : Cardinal.{0}) : Set Hypergraph3 :=
   { H | H.chromaticNumber = kappa ∧ ¬ H.ContainsSubgraph G }
 
 /-- F_G(κ) is nonempty if there exists a hypergraph with chromatic number κ
     avoiding G. -/
-def forbiddenFamilyNonempty (G : Hypergraph3) (kappa : Card) : Prop :=
+def forbiddenFamilyNonempty (G : Hypergraph3) (kappa : Cardinal.{0}) : Prop :=
   ∃ H : Hypergraph3, H ∈ forbiddenFamily G kappa
 
 /-
@@ -103,8 +110,9 @@ These are the three conjectures from Erdős, Galvin, and Hajnal.
     with at most 2^(2^ℵ₀) vertices. -/
 def Conjecture1 : Prop :=
   ∀ G : Hypergraph3, G.IsFinite →
-    forbiddenFamilyNonempty G aleph1 →
-    ∃ X : Hypergraph3, X ∈ forbiddenFamily G aleph1 ∧ X.vertexCard ≤ beth2
+    forbiddenFamilyNonempty G (Cardinal.aleph 1) →
+    ∃ X : Hypergraph3, X ∈ forbiddenFamily G (Cardinal.aleph 1) ∧
+      X.vertexCard ≤ (2 : Cardinal) ^ ((2 : Cardinal) ^ Cardinal.aleph0)
 
 /-- **Conjecture 2** (Intersection Property):
     If F_G(ℵ₁) and F_H(ℵ₁) are both nonempty, their intersection is nonempty.
@@ -112,9 +120,10 @@ def Conjecture1 : Prop :=
     that avoids both G and H. -/
 def Conjecture2 : Prop :=
   ∀ G H : Hypergraph3, G.IsFinite → H.IsFinite →
-    forbiddenFamilyNonempty G aleph1 →
-    forbiddenFamilyNonempty H aleph1 →
-    ∃ X : Hypergraph3, X ∈ forbiddenFamily G aleph1 ∧ X ∈ forbiddenFamily H aleph1
+    forbiddenFamilyNonempty G (Cardinal.aleph 1) →
+    forbiddenFamilyNonempty H (Cardinal.aleph 1) →
+    ∃ X : Hypergraph3, X ∈ forbiddenFamily G (Cardinal.aleph 1) ∧
+      X ∈ forbiddenFamily H (Cardinal.aleph 1)
 
 /-- **Conjecture 3** (Cardinal Transfer):
     If κ and μ are uncountable and F_G(κ) is nonempty, then F_G(μ) is nonempty.
@@ -122,7 +131,7 @@ def Conjecture2 : Prop :=
     between uncountable cardinals. -/
 def Conjecture3 : Prop :=
   ∀ G : Hypergraph3, G.IsFinite →
-    ∀ kappa mu : Card, Card.isUncountable kappa → Card.isUncountable mu →
+    ∀ kappa mu : Cardinal.{0}, Cardinal.aleph0 < kappa → Cardinal.aleph0 < mu →
       forbiddenFamilyNonempty G kappa → forbiddenFamilyNonempty G mu
 
 /-
@@ -136,19 +145,19 @@ def Conjecture3 : Prop :=
     but shows the families are simultaneously rich.) -/
 theorem conj3_implies_simultaneous_nonempty (h3 : Conjecture3) :
     ∀ G H : Hypergraph3, G.IsFinite → H.IsFinite →
-      forbiddenFamilyNonempty G aleph1 →
-      forbiddenFamilyNonempty H aleph1 →
-      ∀ kappa : Card, Card.isUncountable kappa →
+      forbiddenFamilyNonempty G (Cardinal.aleph 1) →
+      forbiddenFamilyNonempty H (Cardinal.aleph 1) →
+      ∀ kappa : Cardinal.{0}, Cardinal.aleph0 < kappa →
         forbiddenFamilyNonempty G kappa ∧ forbiddenFamilyNonempty H kappa := by
   intro G H hGfin hHfin hG hH kappa hkappa
-  unfold Conjecture3 at h3
-  exact ⟨h3 G hGfin aleph1 kappa aleph1_uncountable hkappa hG,
-         h3 H hHfin aleph1 kappa aleph1_uncountable hkappa hH⟩
+  exact ⟨h3 G hGfin (Cardinal.aleph 1) kappa aleph0_lt_aleph1 hkappa hG,
+         h3 H hHfin (Cardinal.aleph 1) kappa aleph0_lt_aleph1 hkappa hH⟩
 
 /-- Conjecture 2 applied to identical forbidden graphs is trivially true. -/
 theorem conj2_trivial_case (G : Hypergraph3) (_hfin : G.IsFinite)
-    (hne : forbiddenFamilyNonempty G aleph1) :
-    ∃ X : Hypergraph3, X ∈ forbiddenFamily G aleph1 ∧ X ∈ forbiddenFamily G aleph1 := by
+    (hne : forbiddenFamilyNonempty G (Cardinal.aleph 1)) :
+    ∃ X : Hypergraph3, X ∈ forbiddenFamily G (Cardinal.aleph 1) ∧
+      X ∈ forbiddenFamily G (Cardinal.aleph 1) := by
   obtain ⟨X, hX⟩ := hne
   exact ⟨X, hX, hX⟩
 
@@ -163,36 +172,21 @@ axiom containsSubgraph_trans {H₁ H₂ H₃ : Hypergraph3} :
 /-- The forbidden family is anti-monotone in G: if G is a subgraph of G'
     (i.e., any graph containing G' also contains G), then avoiding G is
     harder than avoiding G', so F_G(κ) ⊆ F_{G'}(κ). -/
-theorem forbiddenFamily_antimonotone {G G' : Hypergraph3} {kappa : Card}
+theorem forbiddenFamily_antimonotone {G G' : Hypergraph3} {kappa : Cardinal.{0}}
     (hsub : ∀ H : Hypergraph3, H.ContainsSubgraph G' → H.ContainsSubgraph G) :
     forbiddenFamily G kappa ⊆ forbiddenFamily G' kappa := by
   intro H ⟨hchrom, hfree⟩
   exact ⟨hchrom, fun hG'H => hfree (hsub H hG'H)⟩
 
 /-- Anti-monotonicity extends to nonemptiness. -/
-theorem forbiddenFamilyNonempty_antimonotone {G G' : Hypergraph3} {kappa : Card}
+theorem forbiddenFamilyNonempty_antimonotone {G G' : Hypergraph3} {kappa : Cardinal.{0}}
     (hsub : ∀ H : Hypergraph3, H.ContainsSubgraph G' → H.ContainsSubgraph G) :
     forbiddenFamilyNonempty G kappa → forbiddenFamilyNonempty G' kappa := by
   intro ⟨H, hH⟩
   exact ⟨H, forbiddenFamily_antimonotone hsub hH⟩
 
 /-
-## Part VII: Connection to Graph Coloring Theory
-
-For ordinary graphs (2-uniform), the problem of G-free graphs with high
-chromatic number is well-understood thanks to Erdős's probabilistic method
-(1959) and later constructive results.
--/
-
-/-- Erdős's theorem (1959): For any k, l ∈ ℕ, there exists a graph with
-    chromatic number ≥ k and girth ≥ l. In particular, for any finite graph G,
-    F_G(κ) is nonempty for all finite κ when G contains a cycle.
-    This is the 2-uniform analogue of the phenomena studied in Problem #1177. -/
-axiom erdos_1959_high_chromatic_girth :
-  ∀ _k : ℕ, ∀ _l : ℕ, ∃ H : Hypergraph3, H.IsFinite ∧ True
-
-/-
-## Part VIII: The Erdős Problem #1177 Statement
+## Part VII: The Erdős Problem #1177 Statement
 -/
 
 /-- **Erdős Problem #1177:**
@@ -202,5 +196,16 @@ def erdos_1177 : Prop := Conjecture1 ∧ Conjecture2 ∧ Conjecture3
 
 /-- Problem #1177 is OPEN. We state it without proof. -/
 axiom erdos_1177_open : erdos_1177
+
+/-
+## Summary
+
+**Axiom reduction**: 18 → 7
+- Eliminated 10 cardinal axioms by using Mathlib's Cardinal type
+- Eliminated 1 meaningless placeholder axiom (erdos_1959_high_chromatic_girth)
+- Retained 5 Hypergraph3 axioms (abstract type), 1 transitivity, 1 open conjecture
+
+**Proved from Mathlib**: aleph0_lt_aleph1, aleph1_uncountable, aleph1_le_beth2
+-/
 
 end Erdos1177

--- a/proofs/Proofs/Erdos279Problem.lean
+++ b/proofs/Proofs/Erdos279Problem.lean
@@ -18,7 +18,6 @@ Reference: https://erdosproblems.com/279
 
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.Rat.Basic
 import Mathlib.Tactic
 
 /- ## Covering by Shifted Progressions -/
@@ -39,11 +38,10 @@ def CoversEventually (a : ResidueChoice) (k : ℕ) : Prop :=
 /- ## Known Results for Small k -/
 
 /-- For k = 1 or k = 2: any set A with divergent Σ 1/n can cover
-    all sufficiently large integers -/
-axiom small_k_covers :
-  ∀ k : ℕ, k ≤ 2 →
-    -- A set with divergent reciprocal sum suffices
-    True
+    all sufficiently large integers (placeholder — conclusion is True) -/
+theorem small_k_covers :
+  ∀ k : ℕ, k ≤ 2 → True := by
+  intros; trivial
 
 /- ## Density Conditions for Generalization -/
 
@@ -65,9 +63,10 @@ def HasLogLogDivergence (A : Set ℕ) : Prop :=
 axiom ErdosProblem279 (k : ℕ) (hk : 3 ≤ k) :
   ∃ a : ResidueChoice, CoversEventually a k
 
-/-- The case k = 3: already difficult -/
-axiom ErdosProblem279_k3 :
-  ∃ a : ResidueChoice, CoversEventually a 3
+/-- The case k = 3: follows from the general conjecture -/
+theorem ErdosProblem279_k3 :
+  ∃ a : ResidueChoice, CoversEventually a 3 :=
+  ErdosProblem279 3 (le_refl 3)
 
 /- ## Generalization to Dense Sets -/
 


### PR DESCRIPTION
## Summary
Three research sessions: axiom elimination across three Erdős problems.

### erdos-1105: Anti-Ramsey Numbers (8→7 axioms)
- Proved `ar_upper_bound`: AR(n,H) ≤ C(n,2) via `csSup_le` + trichotomy counting
- Eliminated `ar_lower_bound` axiom: constant coloring argument with correct hypotheses

### erdos-1177: Hypergraph Forbidden Subgraphs (18→7 axioms)
- Replaced axiomatized `Card` type with Mathlib `Cardinal` (eliminates 10 axioms)
- Proved `aleph0_lt_aleph1`, `aleph1_uncountable`, `aleph1_le_beth2` from Mathlib
- Removed meaningless placeholder axiom

### erdos-279: Covering with Shifted Prime Progressions (4→2 axioms)
- Proved `small_k_covers` (conclusion was `True`)
- Derived `ErdosProblem279_k3` from `ErdosProblem279`
- Fixed bad import (`Mathlib.Data.Rat.Basic` removed)

## Combined Impact
- **14 axioms eliminated** across three files
- **7 new proved theorems** added
- **0 sorries** in all files
- All builds verified via Docker

🤖 Generated by researcher-4