### PR TITLE
fix: batch fix CrossReference type assertions and missing relationship fields

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02/index.ts
+++ b/src/data/proofs/arithmetic-series-oq-02/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/ArithmeticSeriesOQ02.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const arithmeticSeriesOQ02Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const arithmeticSeriesOQ02Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const arithmeticSeriesOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const arithmeticSeriesOQ02Data: ProofData = { proof: arithmeticSeriesOQ02Proof, annotations: arithmeticSeriesOQ02Annotations }

--- a/src/data/proofs/bezout-identity-oq-02-oq-01/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ02OQ01.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const bezoutIdentityOQ02OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const bezoutIdentityOQ02OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const bezoutIdentityOQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const bezoutIdentityOQ02OQ01Data: ProofData = { proof: bezoutIdentityOQ02OQ01Proof, annotations: bezoutIdentityOQ02OQ01Annotations }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ02OQ02OQ01.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const bezoutIdentityOQ02OQ02OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const bezoutIdentityOQ02OQ02OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const bezoutIdentityOQ02OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const bezoutIdentityOQ02OQ02OQ01Data: ProofData = { proof: bezoutIdentityOQ02OQ02OQ01Proof, annotations: bezoutIdentityOQ02OQ02OQ01Annotations }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ02OQ02.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const bezoutIdentityOQ02OQ02Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const bezoutIdentityOQ02OQ02Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const bezoutIdentityOQ02OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const bezoutIdentityOQ02OQ02Data: ProofData = { proof: bezoutIdentityOQ02OQ02Proof, annotations: bezoutIdentityOQ02OQ02Annotations }

--- a/src/data/proofs/bezout-identity-oq-02/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ02.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const bezoutIdentityOQ02Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const bezoutIdentityOQ02Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const bezoutIdentityOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const bezoutIdentityOQ02Data: ProofData = { proof: bezoutIdentityOQ02Proof, annotations: bezoutIdentityOQ02Annotations }

--- a/src/data/proofs/bezout-identity-oq-03-oq-01/index.ts
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ03OQ01.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const bezoutIdentityOQ03OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const bezoutIdentityOQ03OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const bezoutIdentityOQ03OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const bezoutIdentityOQ03OQ01Data: ProofData = { proof: bezoutIdentityOQ03OQ01Proof, annotations: bezoutIdentityOQ03OQ01Annotations }

--- a/src/data/proofs/bezout-identity-oq-03/index.ts
+++ b/src/data/proofs/bezout-identity-oq-03/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ03.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const bezoutIdentityOQ03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const bezoutIdentityOQ03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const bezoutIdentityOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const bezoutIdentityOQ03Data: ProofData = { proof: bezoutIdentityOQ03Proof, annotations: bezoutIdentityOQ03Annotations }

--- a/src/data/proofs/bezout-identity-oq-04/index.ts
+++ b/src/data/proofs/bezout-identity-oq-04/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ04.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const bezoutIdentityOQ04Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const bezoutIdentityOQ04Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const bezoutIdentityOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const bezoutIdentityOQ04Data: ProofData = { proof: bezoutIdentityOQ04Proof, annotations: bezoutIdentityOQ04Annotations }

--- a/src/data/proofs/bezout-identity/index.ts
+++ b/src/data/proofs/bezout-identity/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentity.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const bezoutIdentityProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const bezoutIdentityProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const bezoutIdentityAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const bezoutIdentityData: ProofData = { proof: bezoutIdentityProof, annotations: bezoutIdentityAnnotations }

--- a/src/data/proofs/binomial-theorem/index.ts
+++ b/src/data/proofs/binomial-theorem/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BinomialTheorem.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const binomialTheoremProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const binomialTheoremProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const binomialTheoremAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const binomialTheoremData: ProofData = { proof: binomialTheoremProof, annotations: binomialTheoremAnnotations }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const cauchySchwarzIntegralOQ01OQ01OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const cauchySchwarzIntegralOQ01OQ01OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const cauchySchwarzIntegralOQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const cauchySchwarzIntegralOQ01OQ01OQ01Data: ProofData = { proof: cauchySchwarzIntegralOQ01OQ01OQ01Proof, annotations: cauchySchwarzIntegralOQ01OQ01OQ01Annotations }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const cauchySchwarzIntegralOQ01OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const cauchySchwarzIntegralOQ01OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const cauchySchwarzIntegralOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const cauchySchwarzIntegralOQ01OQ01Data: ProofData = { proof: cauchySchwarzIntegralOQ01OQ01Proof, annotations: cauchySchwarzIntegralOQ01OQ01Annotations }

--- a/src/data/proofs/cauchy-schwarz-integral/index.ts
+++ b/src/data/proofs/cauchy-schwarz-integral/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzIntegral.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const cauchySchwarzIntegralProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const cauchySchwarzIntegralProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const cauchySchwarzIntegralAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const cauchySchwarzIntegralData: ProofData = { proof: cauchySchwarzIntegralProof, annotations: cauchySchwarzIntegralAnnotations }

--- a/src/data/proofs/cauchy-schwarz/index.ts
+++ b/src/data/proofs/cauchy-schwarz/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CauchySchwarz.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const cauchySchwarzProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const cauchySchwarzProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const cauchySchwarzAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const cauchySchwarzData: ProofData = { proof: cauchySchwarzProof, annotations: cauchySchwarzAnnotations }

--- a/src/data/proofs/cramers-rule/index.ts
+++ b/src/data/proofs/cramers-rule/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CramersRule.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const cramersRuleProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const cramersRuleProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const cramersRuleAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const cramersRuleData: ProofData = { proof: cramersRuleProof, annotations: cramersRuleAnnotations }

--- a/src/data/proofs/derangements/index.ts
+++ b/src/data/proofs/derangements/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/Derangements.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const derangementsProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const derangementsProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const derangementsAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const derangementsData: ProofData = { proof: derangementsProof, annotations: derangementsAnnotations }

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -156,31 +156,38 @@
   "crossReferences": [
     {
       "relation": "Triangle Supersaturation — the direct predecessor in the same supersaturation program. #1010 counts how many triangles are forced when edge count exceeds ⌊n²/4⌋; #1019 asks which *topological* structures (saturated planar subgraphs) are forced at ⌊n²/4⌋ + ⌊(n+1)/2⌋.",
-      "targetId": "erdos-1010"
+      "targetId": "erdos-1010",
+      "relationship": "related"
     },
     {
       "relation": "Triangles in Graphs with High Chromatic Number — shares the Turán threshold ⌊n²/4⌋ as the baseline. Both problems study what happens just above this threshold, with #1011 focusing on chromatic-structural consequences and #1019 on planarity-structural ones.",
-      "targetId": "erdos-1011"
+      "targetId": "erdos-1011",
+      "relationship": "related"
     },
     {
       "relation": "Long Cycles in Dense Graphs — Woodall's result that dense graphs are pancyclic (contain cycles of every length up to n-k) is thematically parallel: both problems show that exceeding a Turán-type threshold forces rich substructure (long cycles or saturated planar subgraphs). Both use stability-style arguments.",
-      "targetId": "erdos-1012"
+      "targetId": "erdos-1012",
+      "relationship": "related"
     },
     {
       "relation": "Ramsey Number Ratio Convergence — tangentially related via the extremal/Ramsey duality: the K₄ forced by Simonovits's theorem connects to Ramsey multiplicity questions. Both are part of the Erdős extremal graph theory cluster.",
-      "targetId": "erdos-1014"
+      "targetId": "erdos-1014",
+      "relationship": "related"
     },
     {
       "relation": "Non-Planar Subgraphs in Dense Graphs — the most direct companion problem. #1018 asks when graphs force non-planar subgraphs on O(1) vertices (Kostochka-Pyber, K₅ subdivisions); #1019 asks when they force *saturated planar* subgraphs on >3 vertices. Together they bracket planarity from both sides.",
-      "targetId": "erdos-1018"
+      "targetId": "erdos-1018",
+      "relationship": "related"
     },
     {
       "relation": "The Erdős Matching Conjecture — neighboring problem in the Erdős catalogue sharing the extremal-combinatorics tag and the Turán-type threshold framework. Both ask for the precise edge/structure threshold in the hypergraph/graph setting.",
-      "targetId": "erdos-1020"
+      "targetId": "erdos-1020",
+      "relationship": "related"
     },
     {
       "relation": "Four Color Theorem — the deepest result about planar graph structure. Problem #1019 forces saturated planar subgraphs (maximal planar graphs / triangulations), which are exactly the graphs for which the Four Color Theorem is hardest. The `isPlanar` definition left as `sorry` in this formalization connects to the broader challenge of formalizing planarity that the Four Color Theorem also requires.",
-      "targetId": "four-color-theorem"
+      "targetId": "four-color-theorem",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -144,32 +144,38 @@
     {
       "relation": "direct-generalization",
       "note": "Problem 926 asks for ex(n, H_k) ≪ n^(3/2) where H_k = G_k + x (one extra central vertex). Since G_k ⊆ H_k, the H_k bound implies the G_k bound; problem 1021 is the harder question of beating the n^(3/2) threshold.",
-      "targetId": "erdos-926"
+      "targetId": "erdos-926",
+      "relationship": "related"
     },
     {
       "relation": "solved-base-case",
       "note": "Problem 572 asks for ex(n, C_{2k}) ≫ n^{1+1/k}. The k=3 case gives the lower bound matching the C_6 upper bound n^{7/6}, resolving the k=3 instance of problem 1021 (since G_3 ≅ C_6).",
-      "targetId": "erdos-572"
+      "targetId": "erdos-572",
+      "relationship": "related"
     },
     {
       "relation": "related-question",
       "note": "Problem 113 concerns the Erdős-Simonovits conjecture that ex(n,G) ≪ n^{3/2} iff G is 2-degenerate (disproved by Janzer 2023). G_k is 2-degenerate for all k, making this directly relevant to understanding when KST-type bounds hold.",
-      "targetId": "erdos-113"
+      "targetId": "erdos-113",
+      "relationship": "related"
     },
     {
       "relation": "related-problem",
       "note": "Problem 1080 concerns C_6 in sparse bipartite graphs with parts of size n^{2/3}. The disproof by Dellamonica et al. uses constructions related to algebraic/projective-plane methods that also bear on ex(n, C_6) = ex(n, G_3).",
-      "targetId": "erdos-1080"
+      "targetId": "erdos-1080",
+      "relationship": "related"
     },
     {
       "relation": "related-technique",
       "note": "Problem 1008 (C_4-free subgraphs) uses Zarankiewicz-type arguments central to the KST theorem. The 2/3 exponent there mirrors the 3/2 barrier for bipartite graphs with K_{2,t} as a subgraph.",
-      "targetId": "erdos-1008"
+      "targetId": "erdos-1008",
+      "relationship": "related"
     },
     {
       "relation": "related-question",
       "note": "Problem 1011 on triangles in high-chromatic-number graphs uses Turán-type extremal methods. The interplay between chromatic structure and edge density is analogous to how G_k's bipartite structure should force sub-KST bounds.",
-      "targetId": "erdos-1011"
+      "targetId": "erdos-1011",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1029/meta.json
+++ b/src/data/proofs/erdos-1029/meta.json
@@ -104,27 +104,32 @@
     {
       "slug": "ramseys-theorem",
       "relation": "foundation",
-      "note": "Ramsey's theorem establishes that R(k) is finite for all k, providing the fundamental existence result that this problem refines into a quantitative growth-rate question."
+      "note": "Ramsey's theorem establishes that R(k) is finite for all k, providing the fundamental existence result that this problem refines into a quantitative growth-rate question.",
+      "relationship": "related"
     },
     {
       "slug": "erdos-1015",
       "relation": "closely-related",
-      "note": "Erdős Problem #1015 concerns partitioning 2-colored complete graphs using monochromatic cliques and directly involves the off-diagonal Ramsey number R(t, t-1), sharing the same extremal graph-theoretic setting."
+      "note": "Erdős Problem #1015 concerns partitioning 2-colored complete graphs using monochromatic cliques and directly involves the off-diagonal Ramsey number R(t, t-1), sharing the same extremal graph-theoretic setting.",
+      "relationship": "related"
     },
     {
       "slug": "erdos-1",
       "relation": "thematic",
-      "note": "Erdős Problem #1 (distinct subset sums) is another of Erdős's oldest open problems carrying a prize, illustrating his broader program of quantitative combinatorics where probabilistic lower bounds are expected to be far from tight."
+      "note": "Erdős Problem #1 (distinct subset sums) is another of Erdős's oldest open problems carrying a prize, illustrating his broader program of quantitative combinatorics where probabilistic lower bounds are expected to be far from tight.",
+      "relationship": "related"
     },
     {
       "slug": "erdos-500",
       "relation": "thematic",
-      "note": "Turán density for hypergraphs is a parallel open problem in extremal combinatorics where the gap between probabilistic and algebraic bounds is also enormous and unresolved."
+      "note": "Turán density for hypergraphs is a parallel open problem in extremal combinatorics where the gap between probabilistic and algebraic bounds is also enormous and unresolved.",
+      "relationship": "related"
     },
     {
       "slug": "szemeredi-regularity",
       "relation": "technique",
-      "note": "The Szemerédi Regularity Lemma is a key structural tool in extremal graph theory; progress on Ramsey upper bounds often passes through regularity-type arguments and graph decompositions."
+      "note": "The Szemerédi Regularity Lemma is a key structural tool in extremal graph theory; progress on Ramsey upper bounds often passes through regularity-type arguments and graph decompositions.",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1067/meta.json
+++ b/src/data/proofs/erdos-1067/meta.json
@@ -160,32 +160,38 @@
     {
       "relation": "companion",
       "description": "Erdős Problem #62 asks whether two graphs with χ = ℵ₁ must share a common subgraph with χ = 4, also concerning structural properties of uncountable chromatic graphs",
-      "targetId": "erdos-62"
+      "targetId": "erdos-62",
+      "relationship": "related"
     },
     {
       "relation": "related",
       "description": "Erdős Problem #57 studies odd cycle lengths in graphs with infinite chromatic number, connecting chromatic structure to cycle properties in infinite graphs",
-      "targetId": "erdos-57"
+      "targetId": "erdos-57",
+      "relationship": "related"
     },
     {
       "relation": "related",
       "description": "Erdős Problem #63 (solved by Liu-Montgomery 2020) characterizes which cycle lengths must appear in graphs with infinite chromatic number, a parallel structural question",
-      "targetId": "erdos-63"
+      "targetId": "erdos-63",
+      "relationship": "related"
     },
     {
       "relation": "companion",
       "description": "Erdős Problem #1068 asks the countable variant: does every graph with χ = ℵ₁ contain a countable infinitely vertex-connected subgraph? Related open question from the same 2015 paper",
-      "targetId": "erdos-1068"
+      "targetId": "erdos-1068",
+      "relationship": "related"
     },
     {
       "relation": "related",
       "description": "Erdős Problem #58 (Gyárfás 1992) bounds chromatic number by distinct odd cycle lengths, showing the deep interplay between χ and local graph structure",
-      "targetId": "erdos-58"
+      "targetId": "erdos-58",
+      "relationship": "related"
     },
     {
       "relation": "background",
       "description": "Ramsey's Theorem provides the finite combinatorial foundation for Ramsey-type questions about cliques and colorings that motivate infinite chromatic number theory",
-      "targetId": "ramseys-theorem"
+      "targetId": "ramseys-theorem",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-110/meta.json
+++ b/src/data/proofs/erdos-110/meta.json
@@ -170,37 +170,43 @@
       "slug": "erdos-62",
       "title": "Erdős Problem #62: Common Subgraphs of Graphs with Chromatic Number ℵ₁",
       "relation": "sibling-problem",
-      "description": "Directly related: asks whether any two ℵ₁-chromatic graphs share a common finite subgraph, another question about finite structure inside uncountably chromatic graphs"
+      "description": "Directly related: asks whether any two ℵ₁-chromatic graphs share a common finite subgraph, another question about finite structure inside uncountably chromatic graphs",
+      "relationship": "related"
     },
     {
       "slug": "erdos-111",
       "title": "Erdős Problem #111: Edge Deletion to Bipartiteness for Large Chromatic Graphs",
       "relation": "sibling-problem",
-      "description": "Companion problem in the series: studies how many edges must be deleted to make ℵ₁-chromatic graphs bipartite, related structure theory"
+      "description": "Companion problem in the series: studies how many edges must be deleted to make ℵ₁-chromatic graphs bipartite, related structure theory",
+      "relationship": "related"
     },
     {
       "slug": "erdos-736",
       "title": "Chromatic Numbers and Finite Subgraph Inheritance",
       "relation": "foundational-theorem",
-      "description": "Directly relevant: concerns the inheritance of chromatic properties by finite subgraphs of infinite graphs — the central theme of Problem #110"
+      "description": "Directly relevant: concerns the inheritance of chromatic properties by finite subgraphs of infinite graphs — the central theme of Problem #110",
+      "relationship": "related"
     },
     {
       "slug": "erdos-593",
       "title": "Erdős Problem #593: Finite Subhypergraphs of Uncountably Chromatic 3-Uniform Hypergraphs",
       "relation": "generalization",
-      "description": "Hypergraph analogue of Problem #110: asks the same question about bounded finite subhypergraphs in the uncountably chromatic setting"
+      "description": "Hypergraph analogue of Problem #110: asks the same question about bounded finite subhypergraphs in the uncountably chromatic setting",
+      "relationship": "related"
     },
     {
       "slug": "erdos-918",
       "title": "Erdős Problem #918: Chromatic Numbers of Infinite Graphs",
       "relation": "sibling-problem",
-      "description": "Broadly related: studies chromatic number behavior and structure theory for infinite graphs, overlapping themes of ℵ₀ vs ℵ₁ chromatic behavior"
+      "description": "Broadly related: studies chromatic number behavior and structure theory for infinite graphs, overlapping themes of ℵ₀ vs ℵ₁ chromatic behavior",
+      "relationship": "related"
     },
     {
       "slug": "continuum-hypothesis",
       "title": "Independence of the Continuum Hypothesis",
       "relation": "set-theory-context",
-      "description": "Set-theoretic backdrop: Shelah's consistency result for Problem #110 uses forcing and independence techniques analogous to those used to prove CH independence"
+      "description": "Set-theoretic backdrop: Shelah's consistency result for Problem #110 uses forcing and independence techniques analogous to those used to prove CH independence",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-1106/meta.json
+++ b/src/data/proofs/erdos-1106/meta.json
@@ -131,32 +131,38 @@
     {
       "relation": "uses-result",
       "note": "Euler's Partition Theorem establishes the foundational properties of p(n) via generating functions; Erdős #1106 studies the prime factorization of the product ∏p(k) built from these same partition numbers.",
-      "targetId": "partition-theorem"
+      "targetId": "partition-theorem",
+      "relationship": "related"
     },
     {
       "relation": "related-topic",
       "note": "Rogers-Ramanujan partition identities and Ramanujan's congruences p(5n+4) ≡ 0 (mod 5), p(7n+5) ≡ 0 (mod 7), p(11n+6) ≡ 0 (mod 11) are the arithmetic heart of why every prime eventually divides some p(n), as proved by Ono (2000).",
-      "targetId": "partition-theorem-oq-01"
+      "targetId": "partition-theorem-oq-01",
+      "relationship": "related"
     },
     {
       "relation": "related-topic",
       "note": "Both problems study the omega function ω(n) counting distinct prime factors: Erdős #679 asks about ω(n-k) being small simultaneously, while #1106 asks whether ω(∏p(k)) grows without bound.",
-      "targetId": "erdos-679"
+      "targetId": "erdos-679",
+      "relationship": "related"
     },
     {
       "relation": "related-topic",
       "note": "Erdős #890 concerns the sum ∑ω over consecutive integers, exploiting the same Erdős-Kac normal order log log n that underlies the heuristic for the growth rate of F(n) in #1106.",
-      "targetId": "erdos-890"
+      "targetId": "erdos-890",
+      "relationship": "related"
     },
     {
       "relation": "related-topic",
       "note": "Erdős #126 asks about distinct prime factors of products of pairwise sums; both problems track how prime factors accumulate in products defined by combinatorial sequences, a common theme in Erdős's multiplicative number theory.",
-      "targetId": "erdos-126"
+      "targetId": "erdos-126",
+      "relationship": "related"
     },
     {
       "relation": "related-topic",
       "note": "Bertrand's Postulate guarantees a prime between n and 2n; Erdős's elementary proof technique and Tijdeman's 1973 result on prime factors of fast-growing sequences (used in resolving Part 1 of #1106) both build on such prime gap estimates.",
-      "targetId": "bertrands-postulate"
+      "targetId": "bertrands-postulate",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-578/meta.json
+++ b/src/data/proofs/erdos-578/meta.json
@@ -177,7 +177,8 @@
   "crossReferences": [
     {
       "targetId": "ramseys-theorem",
-      "description": "Both concern guaranteed substructures: Ramsey theory guarantees monochromatic complete graphs, #578 guarantees hypercube subgraphs in random graphs"
+      "description": "Both concern guaranteed substructures: Ramsey theory guarantees monochromatic complete graphs, #578 guarantees hypercube subgraphs in random graphs",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-603/meta.json
+++ b/src/data/proofs/erdos-603/meta.json
@@ -186,7 +186,8 @@
   "crossReferences": [
     {
       "targetId": "ramseys-theorem",
-      "description": "Both concern coloring/partition problems: Ramsey theory partitions edges, #603 partitions hypergraph vertices (set families) avoiding intersection conditions"
+      "description": "Both concern coloring/partition problems: Ramsey theory partitions edges, #603 partitions hypergraph vertices (set families) avoiding intersection conditions",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-65/meta.json
+++ b/src/data/proofs/erdos-65/meta.json
@@ -126,27 +126,33 @@
   "crossReferences": [
     {
       "relevance": "Companion problem on cycle lengths in graphs with minimum degree 3; both problems study how graph structure forces specific cycle lengths.",
-      "targetId": "erdos-64"
+      "targetId": "erdos-64",
+      "relationship": "related"
     },
     {
       "relevance": "Directly related: asks which cycle lengths are unavoidable in dense graphs, complementing the reciprocal-sum question of Problem 65.",
-      "targetId": "erdos-72"
+      "targetId": "erdos-72",
+      "relationship": "related"
     },
     {
       "relevance": "Concerns almost-bipartite graphs, connecting to the role of complete bipartite graphs as extremal examples in Problem 65.",
-      "targetId": "erdos-73"
+      "targetId": "erdos-73",
+      "relationship": "related"
     },
     {
       "relevance": "Asks about long cycles in dense graphs; shares the edge-density vs cycle-structure theme and uses overlapping techniques.",
-      "targetId": "erdos-1012"
+      "targetId": "erdos-1012",
+      "relationship": "related"
     },
     {
       "relevance": "The Szemerédi Regularity Lemma is a key tool in proving cycle-structure results for dense graphs, including the GKS theorem approach.",
-      "targetId": "szemeredi-regularity"
+      "targetId": "szemeredi-regularity",
+      "relationship": "related"
     },
     {
       "relevance": "Ramsey theory underlies extremal combinatorics; forbidden-subgraph methods used in the Zarankiewicz connection appear here.",
-      "targetId": "ramseys-theorem"
+      "targetId": "ramseys-theorem",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -186,7 +186,8 @@
   "crossReferences": [
     {
       "targetId": "erdos-678",
-      "description": "Both concern products of consecutive integers: #678 studies LCM, #686 studies ratios of products"
+      "description": "Both concern products of consecutive integers: #678 studies LCM, #686 studies ratios of products",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-71/meta.json
+++ b/src/data/proofs/erdos-71/meta.json
@@ -166,7 +166,8 @@
   "crossReferences": [
     {
       "targetId": "erdos-219",
-      "description": "Both concern arithmetic progressions in combinatorial structures: #219 studies APs of primes, #71 studies cycle lengths from APs"
+      "description": "Both concern arithmetic progressions in combinatorial structures: #219 studies APs of primes, #71 studies cycle lengths from APs",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-759/meta.json
+++ b/src/data/proofs/erdos-759/meta.json
@@ -209,7 +209,8 @@
   "crossReferences": [
     {
       "targetId": "erdos-760",
-      "description": "Consecutive Erdős problems — both concern graph parameters on surfaces"
+      "description": "Consecutive Erdős problems — both concern graph parameters on surfaces",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-784/meta.json
+++ b/src/data/proofs/erdos-784/meta.json
@@ -220,7 +220,8 @@
   "crossReferences": [
     {
       "targetId": "erdos-760",
-      "description": "Both are Erdős combinatorics problems from the ErGr80 collection"
+      "description": "Both are Erdős combinatorics problems from the ErGr80 collection",
+      "relationship": "related"
     }
   ],
   "relatedProofs": [

--- a/src/data/proofs/erdos-801/meta.json
+++ b/src/data/proofs/erdos-801/meta.json
@@ -152,11 +152,13 @@
   "crossReferences": [
     {
       "targetId": "ramseys-theorem",
-      "description": "The independence/clique duality underlying Alon's proof — α(G) ≤ √n is a Ramsey-type constraint"
+      "description": "The independence/clique duality underlying Alon's proof — α(G) ≤ √n is a Ramsey-type constraint",
+      "relationship": "related"
     },
     {
       "targetId": "erdos-806",
-      "description": "Both are Erdős problems about structural graph-theoretic properties"
+      "description": "Both are Erdős problems about structural graph-theoretic properties",
+      "relationship": "related"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/fundamental-arithmetic/index.ts
+++ b/src/data/proofs/fundamental-arithmetic/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/FundamentalArithmetic.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const fundamentalArithmeticProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const fundamentalArithmeticProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const fundamentalArithmeticAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const fundamentalArithmeticData: ProofData = { proof: fundamentalArithmeticProof, annotations: fundamentalArithmeticAnnotations }

--- a/src/data/proofs/greens-theorem-oq-01/index.ts
+++ b/src/data/proofs/greens-theorem-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/GreensTheoremOQ01.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const greensTheoremOQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const greensTheoremOQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const greensTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const greensTheoremOQ01Data: ProofData = { proof: greensTheoremOQ01Proof, annotations: greensTheoremOQ01Annotations }

--- a/src/data/proofs/greens-theorem-oq-03/index.ts
+++ b/src/data/proofs/greens-theorem-oq-03/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/GreensTheoremOQ03.lean?raw'
-const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const greensTheoremOQ03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const greensTheoremOQ03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const greensTheoremOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const greensTheoremOQ03Data: ProofData = { proof: greensTheoremOQ03Proof, annotations: greensTheoremOQ03Annotations }

--- a/src/data/proofs/herons-formula/index.ts
+++ b/src/data/proofs/herons-formula/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/HeronsFormula.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const heronsFormulaProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const heronsFormulaProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const heronsFormulaAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const heronsFormulaData: ProofData = { proof: heronsFormulaProof, annotations: heronsFormulaAnnotations }

--- a/src/data/proofs/intermediate-value-theorem-oq-01/index.ts
+++ b/src/data/proofs/intermediate-value-theorem-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/IntermediateValueTheoremOQ01.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const intermediateValueTheoremOQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const intermediateValueTheoremOQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const intermediateValueTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const intermediateValueTheoremOQ01Data: ProofData = { proof: intermediateValueTheoremOQ01Proof, annotations: intermediateValueTheoremOQ01Annotations }

--- a/src/data/proofs/isosceles-triangle/index.ts
+++ b/src/data/proofs/isosceles-triangle/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/IsoscelesTriangle.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const isoscelesTriangleProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const isoscelesTriangleProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const isoscelesTriangleAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const isoscelesTriangleData: ProofData = { proof: isoscelesTriangleProof, annotations: isoscelesTriangleAnnotations }

--- a/src/data/proofs/lagrange-theorem/index.ts
+++ b/src/data/proofs/lagrange-theorem/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/LagrangeTheorem.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const lagrangeTheoremProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const lagrangeTheoremProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const lagrangeTheoremAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const lagrangeTheoremData: ProofData = { proof: lagrangeTheoremProof, annotations: lagrangeTheoremAnnotations }

--- a/src/data/proofs/mean-value-theorem/index.ts
+++ b/src/data/proofs/mean-value-theorem/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/MeanValueTheorem.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const meanValueTheoremProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const meanValueTheoremProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const meanValueTheoremAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const meanValueTheoremData: ProofData = { proof: meanValueTheoremProof, annotations: meanValueTheoremAnnotations }

--- a/src/data/proofs/navier-stokes-existence/index.ts
+++ b/src/data/proofs/navier-stokes-existence/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/NavierStokes.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const navierStokesExistenceProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const navierStokesExistenceProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const navierStokesExistenceAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const navierStokesExistenceData: ProofData = { proof: navierStokesExistenceProof, annotations: navierStokesExistenceAnnotations }

--- a/src/data/proofs/navier-stokes/index.ts
+++ b/src/data/proofs/navier-stokes/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, ProofVersionInfo, VersionHistoryEntry, VersionContent } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, ProofVersionInfo, VersionHistoryEntry, VersionContent, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/NavierStokes.lean?raw'
@@ -7,7 +7,7 @@ import v2Json from './versions/v2.json'
 
 // Version content mapping
 // Note: v1 doesn't have objection field, v2 does
-const v1 = v1Json as { description: string; overview: ProofOverview; conclusion: ProofConclusion, CrossReference }
+const v1 = v1Json as { description: string; overview: ProofOverview; conclusion: ProofConclusion; crossReferences?: CrossReference[] }
 const v2 = v2Json as { description: string; overview: ProofOverview; conclusion: ProofConclusion; objection?: { verdict: string; summary: string; coreIssue?: string } }
 
 const versionContent: Record<string, VersionContent> = {

--- a/src/data/proofs/pell-equation/index.ts
+++ b/src/data/proofs/pell-equation/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/PellEquation.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const pellEquationProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const pellEquationProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const pellEquationAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const pellEquationData: ProofData = { proof: pellEquationProof, annotations: pellEquationAnnotations }

--- a/src/data/proofs/perfect-numbers/index.ts
+++ b/src/data/proofs/perfect-numbers/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/PerfectNumbers.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const perfectNumbersProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const perfectNumbersProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const perfectNumbersAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const perfectNumbersData: ProofData = { proof: perfectNumbersProof, annotations: perfectNumbersAnnotations }

--- a/src/data/proofs/ptolemys-theorem/index.ts
+++ b/src/data/proofs/ptolemys-theorem/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/PtolemysTheorem.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const ptolemysTheoremProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const ptolemysTheoremProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const ptolemysTheoremAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const ptolemysTheoremData: ProofData = { proof: ptolemysTheoremProof, annotations: ptolemysTheoremAnnotations }

--- a/src/data/proofs/triangle-inequality-oq-03/index.ts
+++ b/src/data/proofs/triangle-inequality-oq-03/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/TriangleInequalityOQ03.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const triangleInequalityOq03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const triangleInequalityOq03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const triangleInequalityOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const triangleInequalityOq03Data: ProofData = { proof: triangleInequalityOq03Proof, annotations: triangleInequalityOq03Annotations }

--- a/src/data/proofs/triangular-reciprocals-oq-03/index.ts
+++ b/src/data/proofs/triangular-reciprocals-oq-03/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/TriangularReciprocalAlternatingOQ03.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion, CrossReference }
-export const triangularReciprocalAlternatingOq03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const triangularReciprocalAlternatingOq03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const triangularReciprocalAlternatingOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const triangularReciprocalAlternatingOq03Data: ProofData = { proof: triangularReciprocalAlternatingOq03Proof, annotations: triangularReciprocalAlternatingOq03Annotations }


### PR DESCRIPTION
## Summary
- Fix malformed `CrossReference` property in 1374 index.ts type casts → `crossReferences?: CrossReference[]`
- Wire `crossReferences: meta.crossReferences` in 30 proof exports that were missing it
- Fix navier-stokes/index.ts missing CrossReference import
- Add missing `relationship: "related"` to 50 crossReference entries in meta.json

This was causing build failures (TS6196, TS2352, TS7008).

## Test plan
- `pnpm build` passes successfully