### PR TITLE
Enrich: bertrands-postulate, bezout-identity, cauchy-schwarz (peer review fixes)

### DIFF
--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -33,10 +33,25 @@
         "theorem": "sq_nonneg",
         "description": "Non-negativity of squares",
         "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "real_inner_self_eq_norm_sq",
+        "description": "⟨v, v⟩ = ‖v‖² for real inner product spaces",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_inner_eq_norm_iff",
+        "description": "Equality characterization: |⟨u,v⟩| = ‖u‖·‖v‖ iff linearly dependent",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_add_sq_real",
+        "description": "‖u + v‖² = ‖u‖² + 2⟨u,v⟩ + ‖v‖² expansion",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
       }
     ],
     "originalContributions": [
-      "Inner product form via abs_real_inner_le_norm",
+      "Pedagogical wrapper of Mathlib's abs_real_inner_le_norm for the inner product form",
       "Squared form via sq_le_sq' and real_inner_self_eq_norm_sq",
       "Two-variable algebraic proof via Lagrange identity",
       "Two-variable equality characterization via sq_eq_zero_iff",
@@ -79,7 +94,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Origins and Multiple Discoverers**\n\nThe Cauchy-Schwarz inequality has been independently discovered at least three times. **Augustin-Louis Cauchy** first proved the discrete (finite sum) version in his 1821 *Cours d'Analyse*, establishing $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ for real sequences. **Viktor Bunyakovsky** extended this to integrals in 1859, proving $\\left(\\int fg\\right)^2 \\leq \\int f^2 \\int g^2$. **Hermann Amandus Schwarz** independently proved the integral version in 1888 for the specific context of Fourier analysis.\n\n**Modern Significance**\n\nThe inequality is arguably the single most important inequality in mathematics. It underpins the triangle inequality in normed spaces, the definition of angle between vectors, the Pearson correlation coefficient in statistics, the Heisenberg uncertainty principle in quantum mechanics, and concentration inequalities in probability theory. It appears as #78 on **Freek Wiedijk**'s list of 100 theorems formalized in proof assistants.\n\n**The Quadratic Argument**\n\nThe standard modern proof considers $0 \\leq \\|u - tv\\|^2 = \\|u\\|^2 - 2t\\langle u,v\\rangle + t^2\\|v\\|^2$ as a quadratic in $t$, whose non-negative discriminant yields $\\langle u,v\\rangle^2 \\leq \\|u\\|^2\\|v\\|^2$. The elementary two-variable proof uses the **Lagrange identity**: $(a_1^2+a_2^2)(b_1^2+b_2^2) - (a_1b_1+a_2b_2)^2 = (a_1b_2-a_2b_1)^2 \\geq 0$.",
+    "historicalContext": "**Origins and Multiple Discoverers**\n\nThe Cauchy-Schwarz inequality has been independently discovered at least three times. **Augustin-Louis Cauchy** first proved the discrete (finite sum) version in his 1821 *Cours d'Analyse*, establishing $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ for real sequences. **Viktor Bunyakovsky** extended this to integrals in 1859, proving $\\left(\\int fg\\right)^2 \\leq \\int f^2 \\int g^2$. **Hermann Amandus Schwarz** independently proved the integral version in 1885 for the specific context of surface area minimization.\n\n**Modern Significance**\n\nThe inequality is arguably the single most important inequality in mathematics. It underpins the triangle inequality in normed spaces, the definition of angle between vectors, the Pearson correlation coefficient in statistics, the Heisenberg uncertainty principle in quantum mechanics, and concentration inequalities in probability theory. It appears as #78 on **Freek Wiedijk**'s list of 100 theorems formalized in proof assistants.\n\n**The Quadratic Argument**\n\nThe standard modern proof considers $0 \\leq \\|u - tv\\|^2 = \\|u\\|^2 - 2t\\langle u,v\\rangle + t^2\\|v\\|^2$ as a quadratic in $t$, whose non-negative discriminant yields $\\langle u,v\\rangle^2 \\leq \\|u\\|^2\\|v\\|^2$. The elementary two-variable proof uses the **Lagrange identity**: $(a_1^2+a_2^2)(b_1^2+b_2^2) - (a_1b_1+a_2b_2)^2 = (a_1b_2-a_2b_1)^2 \\geq 0$.",
     "problemStatement": "**Cauchy-Schwarz Inequality**\n\nFor vectors $u, v$ in a real inner product space:\n$$|\\langle u, v \\rangle| \\leq \\|u\\| \\cdot \\|v\\|$$\n\nFor sequences $a, b : \\text{Fin}\\,n \\to \\mathbb{R}$:\n$$(\\sum_i a_i b_i)^2 \\leq (\\sum_i a_i^2)(\\sum_i b_i^2)$$\n\nEquality holds if and only if $u$ and $v$ are linearly dependent.",
     "text": "The Lean formalization presents Cauchy-Schwarz in three complementary forms. The abstract inner product version applies Mathlib's abs_real_inner_le_norm directly. The two-variable algebraic form gives an independent proof via the Lagrange identity, using sq_nonneg and nlinarith to show (a1*b2 - a2*b1)^2 >= 0. The finite sum form embeds sequences into EuclideanSpace via inner_eq_star_dotProduct, bridging abstract and concrete representations. Equality is characterized as linear dependence using norm_inner_eq_norm_iff. Two applications are derived as corollaries: the triangle inequality (via norm_add_sq_real expansion) and the correlation coefficient bound |rho| <= 1 (via div_le_one). All 9 theorems are fully verified with zero axioms across 231 lines.",
     "proofStrategy": "**Formalization Strategy**\n\n1. **Abstract form:** Apply Mathlib's `abs_real_inner_le_norm` for $|\\langle u,v\\rangle| \\leq \\|u\\|\\|v\\|$.\n2. **Squared form:** Derive $\\langle u,v\\rangle^2 \\leq \\langle u,u\\rangle\\langle v,v\\rangle$ via `sq_le_sq'` and `real_inner_self_eq_norm_sq`.\n3. **Two-variable case:** Direct algebraic proof using the Lagrange identity $(a_1b_2-a_2b_1)^2 \\geq 0$ via `sq_nonneg` and `nlinarith`.\n4. **Finite sum form:** Embed sequences into `EuclideanSpace \\mathbb{R} (\\text{Fin}\\,n)` and apply the squared inner product form.\n5. **Equality:** Characterize equality as linear dependence using `norm_inner_eq_norm_iff`.\n6. **Applications:** Derive triangle inequality and correlation bound as corollaries.",
@@ -178,12 +193,12 @@
     },
     {
       "targetId": "hurwitz-theorem",
-      "relationship": "foundational",
+      "relationship": "related",
       "description": "Hurwitz's theorem on normed division algebras (ℝ, ℂ, ℍ, 𝕆) relies on the inner product space structure where Cauchy-Schwarz is the fundamental inequality."
     },
     {
       "targetId": "yang-mills",
-      "relationship": "foundational",
+      "relationship": "related",
       "description": "The Yang-Mills formalization uses Hilbert spaces and inner products (Wightman axioms) where Cauchy-Schwarz underpins the spectral theory and mass gap definition."
     },
     {
@@ -218,7 +233,7 @@
     },
     {
       "targetId": "central-limit-theorem",
-      "relationship": "foundational",
+      "relationship": "related",
       "description": "Cauchy-Schwarz underpins key steps in proving the Central Limit Theorem: bounding characteristic function differences $|\\varphi_n(t) - e^{-t^2/2}|$ uses $|\\mathbb{E}[XY]| \\leq \\sqrt{\\mathbb{E}[X^2]\\mathbb{E}[Y^2]}$, and the variance decomposition $\\text{Var}(S_n/\\sqrt{n}) = 1$ relies on the inner product structure of $L^2$. The CLT's normal limit $\\mathcal{N}(0,1)$ has density proportional to $e^{-x^2/2}$, whose normalization $\\int e^{-x^2} dx = \\sqrt{\\pi}$ connects to the Gaussian integral"
     }
   ],
@@ -270,12 +285,12 @@
     },
     {
       "id": "hurwitz-theorem",
-      "relationship": "foundational",
+      "relationship": "related",
       "description": "Hurwitz's theorem on normed division algebras (ℝ, ℂ, ℍ, 𝕆) relies on the inner product space structure where Cauchy-Schwarz is the fundamental inequality."
     },
     {
       "id": "yang-mills",
-      "relationship": "foundational",
+      "relationship": "related",
       "description": "The Yang-Mills formalization uses Hilbert spaces and inner products (Wightman axioms) where Cauchy-Schwarz underpins the spectral theory and mass gap definition."
     },
     {
@@ -300,7 +315,7 @@
     },
     {
       "id": "central-limit-theorem",
-      "relationship": "foundational",
+      "relationship": "related",
       "description": "Cauchy-Schwarz underpins key steps in proving the Central Limit Theorem: bounding characteristic function differences $|\\varphi_n(t) - e^{-t^2/2}|$ uses $|\\mathbb{E}[XY]| \\leq \\sqrt{\\mathbb{E}[X^2]\\mathbb{E}[Y^2]}$, and the variance decomposition $\\text{Var}(S_n/\\sqrt{n}) = 1$ relies on the inner product structure of $L^2$. The CLT's normal limit $\\mathcal{N}(0,1)$ has density proportional to $e^{-x^2/2}$, whose normalization $\\int e^{-x^2} dx = \\sqrt{\\pi}$ connects to the Gaussian integral"
     }
   ],

--- a/src/data/proofs/cauchy-schwarz/review.json
+++ b/src/data/proofs/cauchy-schwarz/review.json
@@ -3,14 +3,12 @@
   "proofId": "cauchy-schwarz",
   "reviewDate": "2026-03-24T16:00:00Z",
   "reviewer": "peer-reviewer-1",
-
   "overallAssessment": {
     "grade": "B+",
     "oneLiner": "A well-structured, fully verified formalization of Cauchy-Schwarz in three forms, with genuine proof content in most theorems and honest Mathlib attribution, marred only by one overclaimed wrapper and minor metadata inconsistencies.",
     "tier": "B",
     "tierJustification": "The core abstract inequality (cauchy_schwarz_inner) is a single Mathlib call to abs_real_inner_le_norm, placing the proof in Tier B. However, the file adds substantial value beyond the wrapper: an independent two-variable proof via Lagrange identity, a non-trivial EuclideanSpace bridge for finite sums, equality characterization, and two derived applications. The badge 'mathlib' is honest about this dependency."
   },
-
   "findings": [
     {
       "severity": "positive",
@@ -69,38 +67,40 @@
       "recommendation": "No change needed. This is the correct badge for a Mathlib-based verified proof."
     }
   ],
-
   "actionItems": [
     {
       "id": "ai-1",
       "priority": "medium",
       "target": "enricher",
       "description": "Remove 'Inner product form via abs_real_inner_le_norm' from originalContributions or rephrase to acknowledge it is a Mathlib wrapper/restatement. The current framing overstates originality for a single-line Mathlib call.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Rephrased originalContributions[0] from \"Inner product form via abs_real_inner_le_norm\" to \"Pedagogical wrapper of Mathlib's abs_real_inner_le_norm for the inner product form\"."
     },
     {
       "id": "ai-2",
       "priority": "low",
       "target": "enricher",
       "description": "Fix Schwarz date in overview.historicalContext from '1888' to '1885' to match the references section and historical record.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Fixed Schwarz date from 1888 to 1885 in overview.historicalContext."
     },
     {
       "id": "ai-3",
       "priority": "low",
       "target": "enricher",
       "description": "Add real_inner_self_eq_norm_sq, norm_inner_eq_norm_iff, and norm_add_sq_real to the mathlibDependencies list, as these are key Mathlib lemmas used in multiple proofs.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Added real_inner_self_eq_norm_sq, norm_inner_eq_norm_iff, and norm_add_sq_real to mathlibDependencies."
     },
     {
       "id": "ai-4",
       "priority": "low",
       "target": "enricher",
       "description": "Soften the 'foundational' cross-reference relationship for hurwitz-theorem, yang-mills, and central-limit-theorem to 'related', since this Lean file is not imported by those formalizations.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Softened hurwitz-theorem, yang-mills, and central-limit-theorem cross-references from \"foundational\" to \"related\" in both crossReferences and relatedProofs arrays."
     }
   ],
-
   "qualityScores": {
     "mathematicalSubstance": 7,
     "originalityAccuracy": 7,
@@ -110,6 +110,5 @@
     "internalConsistency": 8,
     "overall": 7.8
   },
-
   "suggestedBestFraming": "A fully verified Lean 4 formalization of the Cauchy-Schwarz inequality in three forms (abstract inner product, two-variable algebraic via Lagrange identity, finite sums via EuclideanSpace), with equality characterization and two corollaries (triangle inequality, correlation bound). The abstract form applies Mathlib's abs_real_inner_le_norm directly; the two-variable form provides an independent elementary proof; the finite sum form bridges abstract and concrete via EuclideanSpace embedding."
 }


### PR DESCRIPTION
Enrichment pass addressing peer review action items for three proofs.

## bertrands-postulate (4 items: ai-1, ai-2, ai-3, ai-5)
- Fixed `wiedijkNumber` from 98 → 43 (Bertrand's Postulate is Wiedijk #43)
- Fixed `overview.text`: "13 declarations" → "7 theorems", "prime_gap_bound" → "prime_gap_bounded"
- Removed false "concrete verifications" claim
- Fixed `description`: "n > 1" → "positive integer n"
- Removed incorrect "opens Nat" from sections[0]
- Restructured `originalContributions`

## bezout-identity (5 items: ai-1 through ai-5)
- Removed fabricated Euclid's lemma claim from `overview.text`
- Reframed `originalContributions`: wrappers vs substantive proofs
- Fixed `conclusion.summary` line count: 238 → 237
- Downgraded `ann-bezout-nat`/`ann-bezout-int` significance: key → supporting
- Labeled documentation item as expository

## cauchy-schwarz (4 items: ai-1 through ai-4)
- Rephrased originalContributions[0] as Mathlib wrapper
- Fixed Schwarz date: 1888 → 1885
- Added 3 missing mathlibDependencies
- Softened 3 cross-references from "foundational" to "related"