### PR TITLE
Research: erdos-684 - Axiom elimination (8→7) + sorry elimination (3→2)

### DIFF
--- a/proofs/Proofs/Erdos684Problem.lean
+++ b/proofs/Proofs/Erdos684Problem.lean
@@ -29,14 +29,7 @@ Question: What are the bounds on f(n)?
 Adapted from formal-conjectures (Apache 2.0 License)
 -/
 
-import Mathlib.Data.Nat.Choose.Factorization
-import Mathlib.Data.Nat.Choose.Dvd
-import Mathlib.Data.Nat.Factorization.Basic
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Algebra.BigOperators.Group.Finset
-import Mathlib.Algebra.Order.Ring.Lemmas
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Order.Filter.AtTopBot
+import Mathlib
 
 open Nat BigOperators Finset
 
@@ -57,10 +50,44 @@ noncomputable def smoothPart (k m : ℕ) : ℕ :=
 noncomputable def roughPart (k m : ℕ) : ℕ :=
   m / smoothPart k m
 
+-- Helper: product of p^(factorization p) over a set of primes divides m
+private theorem prod_pow_factorization_dvd {m : ℕ} (hm : m ≠ 0) (S : Finset ℕ)
+    (hS : ∀ p ∈ S, p.Prime) :
+    ∏ p ∈ S, p ^ (m.factorization p) ∣ m := by
+  induction S using Finset.induction_on with
+  | empty => simp
+  | @insert a s ha IH =>
+    rw [Finset.prod_insert ha]
+    have ha_prime : a.Prime := hS a (Finset.mem_insert_self a s)
+    have IH' := IH (fun q hq => hS q (Finset.mem_insert_of_mem hq))
+    apply Nat.Coprime.mul_dvd_of_dvd_of_dvd
+    · -- Coprimality: a^e coprime to ∏ q ∈ s, q^e
+      apply Nat.Coprime.prod_right
+      intro q hq
+      have hq_prime : q.Prime := hS q (Finset.mem_insert_of_mem hq)
+      have hne : a ≠ q := fun h => ha (h ▸ hq)
+      apply (Nat.Coprime.pow_left _ (Nat.Coprime.pow_right _ _))
+      rwa [Nat.coprime_comm, hq_prime.coprime_iff_not_dvd,
+        ha_prime.dvd_iff_eq hq_prime.one_lt.ne']
+    · -- a^(m.factorization a) ∣ m: use factorization_le_iff_dvd
+      rw [← Nat.factorization_le_iff_dvd (pow_pos ha_prime.pos _).ne' hm]
+      intro q
+      simp only [Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul,
+        ha_prime.factorization, Finsupp.single_apply]
+      split_ifs with h
+      · subst h; omega
+      · simp
+    · exact IH'
+
 -- The smooth part divides the original number
 -- Each p^(factorization p) divides m for prime p, and distinct prime powers are coprime
 theorem smoothPart_dvd (k m : ℕ) : smoothPart k m ∣ m := by
-  sorry
+  by_cases hm : m = 0
+  · subst hm
+    simp only [smoothPart, Nat.factorization_zero, Finsupp.zero_apply, pow_zero,
+      Finset.prod_const_one]
+    exact one_dvd 0
+  · exact prod_pow_factorization_dvd hm _ (fun p hp => (Finset.mem_filter.mp hp).2)
 
 -- Decomposition: m = smoothPart * roughPart (follows from smoothPart_dvd)
 theorem smooth_rough_decomposition (k m : ℕ) (hm : m > 0) :
@@ -100,10 +127,12 @@ axiom below_f_small (n k : ℕ) (hn : n ≥ 2) (hk : k < f n) :
 The smooth part is bounded by n^{1+ε} for large n.
 -/
 
--- Mahler's theorem (ineffective): smooth part bounded
--- For any ε > 0, ∃ N such that ∀ n ≥ N, k ≤ n, smoothPart(C(n,k)) ≤ n^{1+ε}
-axiom mahler_ineffective : ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N, ∀ k ≤ n,
-    (binomialSmoothPart n k : ℝ) ≤ n^(1 + ε)
+-- Mahler's theorem (ineffective): for FIXED k, smooth part bounded
+-- NOTE: The original axiom stated ∀ k ≤ n, which is inconsistent with f_property
+-- (it would imply the smooth part is always < n² for large n, contradicting f's existence).
+-- Correct statement: for any fixed k₀ and ε > 0, eventually smoothPart(C(n,k₀)) ≤ n^{1+ε}.
+axiom mahler_ineffective : ∀ (k₀ : ℕ), ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N,
+    (binomialSmoothPart n k₀ : ℝ) ≤ (n : ℝ)^(1 + ε)
 
 -- Mahler implies f(n) → ∞
 theorem f_tendsto_infty_weak : ∀ C : ℕ, ∃ N : ℕ, ∀ n ≥ N, f n > C := by
@@ -118,13 +147,13 @@ Recent results by Tang & ChatGPT on explicit bounds for f(n).
 
 -- Tang-ChatGPT bound: f(n) ≤ n^{30/43 + o(1)}
 -- The exponent 30/43 ≈ 0.698
-def tang_exponent : ℝ := 30 / 43
+noncomputable def tang_exponent : ℝ := 30 / 43
 
 axiom tang_bound : ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N,
     (f n : ℝ) ≤ n^(tang_exponent + ε)
 
 -- Under Riemann Hypothesis: f(n) ≤ n^{2/3 + o(1)}
-def rh_exponent : ℝ := 2 / 3
+noncomputable def rh_exponent : ℝ := 2 / 3
 
 axiom rh_conditional_bound : ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N,
     -- Assuming RH
@@ -138,13 +167,15 @@ The heuristic suggests f(n) ~ 2 log n for most n.
 
 -- Sothanaphan-ChatGPT heuristic: f(n) ~ 2 log n for "most" n
 -- This is much smaller than the proven bounds!
-def heuristic_bound (n : ℕ) : ℝ := 2 * Real.log n
+noncomputable def heuristic_bound (n : ℕ) : ℝ := 2 * Real.log n
 
 -- The heuristic (not proven)
+-- Informal: for "most" n, f(n) ≈ 2 log n
+-- Formal statement uses natural density of a decidable subset
 axiom heuristic_conjecture : ∀ ε : ℝ, ε > 0 →
-    -- For density 1 set of n
-    ∃ S : Set ℕ, (∀ N, (↑(Finset.filter (· ∈ S) (Finset.range N)).card / N : ℝ) > 1 - ε) ∧
-    (∀ n ∈ S, |((f n : ℝ) - heuristic_bound n) / heuristic_bound n| < ε)
+    ∃ S : ℕ → Prop, ∃ _ : DecidablePred S,
+    (∀ N : ℕ, (↑(Finset.filter S (Finset.range N)).card / (N : ℝ)) > 1 - ε) ∧
+    (∀ n, S n → |((f n : ℝ) - heuristic_bound n) / heuristic_bound n| < ε)
 
 /-
 # Part 6: Structure of Smooth Part
@@ -162,6 +193,9 @@ noncomputable def legendreExponent (n p : ℕ) : ℕ :=
 
 -- Kummer's theorem: v_p(C(n,k)) = number of carries when adding k + (n-k) in base p
 -- Equivalently: v_p(C(n,k)) = v_p(n!) - v_p(k!) - v_p((n-k)!)
+-- NOTE: Mathlib has Nat.Prime.multiplicity_choose which expresses this via carries.
+-- Converting between multiplicity and factorization uses Nat.multiplicity_eq_factorization.
+-- TODO: Replace this axiom with Mathlib's version.
 axiom kummer_theorem (n k p : ℕ) (hp : p.Prime) (hk : k ≤ n) :
     (Nat.choose n k).factorization p =
     legendreExponent n p - legendreExponent k p - legendreExponent (n - k) p
@@ -173,13 +207,46 @@ Examine f(n) for small n and special values.
 -/
 
 -- f(n) ≥ 2 for n ≥ 4 (otherwise smooth part too small)
-axiom f_lower_bound : ∀ n ≥ 4, f n ≥ 2
+-- Proved from f_property: for k ∈ {0,1}, no primes ≤ k exist, so smoothPart = 1 ≤ n²
+-- Hence every element of {k | binomialSmoothPart n k > n²} is ≥ 2.
+theorem f_lower_bound : ∀ n ≥ 4, f n ≥ 2 := by
+  intro n hn
+  -- f n = sInf {k | binomialSmoothPart n k > n^2}
+  -- Show every element of the set is ≥ 2
+  unfold f
+  apply le_csInf
+  · -- Set is nonempty (from f_property)
+    exact ⟨_, f_property n (by omega)⟩
+  · -- Every element is ≥ 2
+    intro x hx
+    simp only [Set.mem_setOf_eq] at hx
+    by_contra h
+    push_neg at h
+    -- x < 2, so x = 0 or x = 1
+    interval_cases x
+    · -- x = 0: smoothPart 0 (choose n 0) = 1 since no primes ≤ 0
+      simp only [binomialSmoothPart, Nat.choose_zero_right, smoothPart] at hx
+      have : (Finset.range 1).filter Nat.Prime = ∅ := by
+        ext p; simp only [Finset.mem_filter, Finset.mem_range, Finset.notMem_empty, iff_false,
+          not_and]
+        intro hp; exact fun hprime => absurd hprime.two_le (by omega)
+      rw [this, Finset.prod_empty] at hx
+      -- 1 > n^2 contradicts n ≥ 4
+      nlinarith [sq_nonneg n]
+    · -- x = 1: smoothPart 1 (choose n 1) = 1 since no primes ≤ 1
+      simp only [binomialSmoothPart, smoothPart] at hx
+      have : (Finset.range 2).filter Nat.Prime = ∅ := by
+        ext p; simp only [Finset.mem_filter, Finset.mem_range, Finset.notMem_empty, iff_false,
+          not_and]
+        intro hp; exact fun hprime => absurd hprime.two_le (by omega)
+      rw [this, Finset.prod_empty] at hx
+      nlinarith [sq_nonneg n]
 
 -- For prime n, behavior may differ
 -- C(p, k) for prime p has special structure
 theorem prime_binomial_structure (p : ℕ) (hp : p.Prime) (k : ℕ) (hk : 1 ≤ k ∧ k ≤ p - 1) :
     p ∣ Nat.choose p k := by
-  exact Nat.Prime.dvd_choose hp hk.1 hk.2
+  apply hp.dvd_choose <;> omega
 
 /-
 # Part 8: The Generalized Problem
@@ -197,7 +264,7 @@ theorem f_is_fGeneral_0 (n : ℕ) : f n = fGeneral n 0 := by
   simp only [f, fGeneral]
   congr 1
   ext k
-  simp [Nat.zero_le]
+  simp
 
 /-
 # Part 9: OEIS Sequence

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 684,
     "erdosUrl": "https://erdosproblems.com/684",
     "erdosProblemStatus": "open",
@@ -57,9 +57,9 @@
       "prime_binomial_structure theorem: p divides C(p,k)",
       "fGeneral definition: generalized problem"
     ],
-    "axiomCount": 8,
-    "lineCount": 245,
-    "assumptions": "8 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "axiomCount": 7,
+    "lineCount": 312,
+    "assumptions": "7 axiom(s) and 2 sorry(s). Proved smoothPart_dvd and f_lower_bound. Fixed mahler_ineffective inconsistency."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in [Er79d]. For binomial coefficient C(n,k), we decompose it as u·v where u is the k-smooth part (primes ≤ k) and v is the k-rough part (primes > k).\n\nThe function f(n) asks: how small can k be while still having the smooth part exceed n²?\n\nMahler's classical theorem gives an ineffective bound. Recent work by Tang & ChatGPT (2026) proved f(n) ≤ n^{30/43+o(1)}, with n^{2/3+o(1)} conditional on the Riemann Hypothesis.\n\nRemarkably, heuristic arguments by Sothanaphan & ChatGPT suggest f(n) ~ 2 log n for most n - vastly smaller than proven bounds!\n\nThe sequence f(n) is recorded in OEIS A392019.",
@@ -165,14 +165,7 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Choose.Factorization",
-      "Mathlib.Data.Nat.Choose.Dvd",
-      "Mathlib.Data.Nat.Factorization.Basic",
-      "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Algebra.BigOperators.Group.Finset",
-      "Mathlib.Algebra.Order.Ring.Lemmas",
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-      "Mathlib.Order.Filter.AtTopBot"
+      "Mathlib"
     ],
     "opens": [
       "Nat",
@@ -180,9 +173,9 @@
       "Finset"
     ],
     "namespace": "Erdos684",
-    "lineCount": 245,
-    "axiomCount": 8,
-    "theoremCount": 6,
+    "lineCount": 312,
+    "axiomCount": 7,
+    "theoremCount": 8,
     "definitionCount": 10
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-684.json
+++ b/src/data/research/problems/erdos-684.json
@@ -29,11 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Axiom elimination (8→7) + sorry elimination (3→2). Proved smoothPart_dvd and f_lower_bound. Fixed mahler_ineffective inconsistency and 4 pre-existing build issues. File now builds cleanly.",
+    "builtItems": [
+      "Proved smoothPart_dvd via prod_pow_factorization_dvd helper (Finset induction + coprimality)",
+      "Proved f_lower_bound theorem from f_property axiom",
+      "Fixed mahler_ineffective axiom (∀ k ≤ n → ∀ k₀ fixed)",
+      "Fixed noncomputable defs: tang_exponent, rh_exponent, heuristic_bound",
+      "Fixed prime_binomial_structure to use current Mathlib API",
+      "Fixed heuristic_conjecture to use DecidablePred"
+    ],
+    "insights": [
+      "smoothPart_dvd proved: product of p^(factorization p) for primes p ≤ k divides m, via coprimality of distinct prime powers and Finset induction",
+      "f_lower_bound converted from axiom to theorem: no primes exist ≤ 0 or ≤ 1, so smoothPart 0 and smoothPart 1 both equal 1, which is ≤ n² for n ≥ 4",
+      "mahler_ineffective axiom was INCONSISTENT (∀ k ≤ n would contradict f_property). Fixed to correct statement: for fixed k₀ and ε>0",
+      "kummer_theorem has a Mathlib equivalent via Nat.Prime.multiplicity_choose — convertible but requires bridging multiplicity vs factorization APIs",
+      "4 pre-existing build issues fixed: noncomputable defs, deprecated API names, heuristic_conjecture decidability issue"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove kummer_theorem by bridging Nat.Prime.multiplicity_choose to factorization API",
+      "Prove f_tendsto_infty_weak from corrected mahler_ineffective + f_property (complex ℝ/ℕ proof)",
+      "Create Aristotle companion file for remaining routine lemmas"
+    ],
     "markdown": "# Erdős #684 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor $0\\leq k\\leq n$ write\\[\\binom{n}{k} = uv\\]where the only primes dividing $u$ are in $[2,k]$ and the only primes dividing $v$ are in $(k,n]$.\n\nLet $f(n)$ be the smallest $k$ such that $u>n^2$. Give bounds for $f(n)$.\n\n\n\nA classical theorem of Mahler states that for any $\\epsilon>0$ and integers $k$ and $l$ then, writing\\[(n+1)\\cdots (n+k) = ab\\]where the only primes dividing $a$ are $\\leq l$ and the only primes dividing $b$ are $>l$, we have $a < n^{1+\\epsilon}$ for all sufficiently large (depending on $\\epsilon,k,l$) $n$.\n\nMahler's theorem implies $f(n)\\to \\infty$ as $n\\to \\infty$, but is ineffective, and so gives no bounds on the growth of $f(n)$.\n\nOne can similarly ask for estimates on the smallest integer $f(n,k)$ such that if $m$ is the factor of $\\binom{n}{k}$ containing all primes $\\leq f(n,k)$ then $m > n^2$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #683\n- Problem #685\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Proved `smoothPart_dvd` theorem (was sorry): product of p^(factorization p) for primes ≤ k divides m
- Converted `f_lower_bound` from axiom to theorem (8→7 axioms)
- Fixed `mahler_ineffective` axiom inconsistency (∀ k ≤ n contradicts f_property)
- Fixed 4 pre-existing build issues (noncomputable defs, deprecated APIs, decidability, API changes)
- Docker build verified: all changes compile cleanly against Mathlib v4.26.0

## Progress
**Axioms**: 8 → 7 (proved f_lower_bound from f_property)
**Sorries**: 3 → 2 (proved smoothPart_dvd via coprime product induction)
**Build**: Fixed — file now compiles cleanly (previously had 3 import errors + 4 other issues)

## Findings
- `mahler_ineffective` was inconsistent: stated ∀ k ≤ n (uniform), which combined with f_property leads to contradiction. Corrected to ∀ k₀ fixed (Mahler's theorem for fixed parameters)
- `kummer_theorem` has Mathlib equivalent via `Nat.Prime.multiplicity_choose` — conversion requires bridging multiplicity ↔ factorization APIs (documented as TODO)
- `smoothPart_dvd` proof uses Finset.induction_on with coprimality of distinct prime powers

## Status
**Outcome**: progress
**Next Steps**: Prove kummer_theorem from Mathlib, prove f_tendsto_infty_weak from corrected Mahler + f_property

🤖 Generated by researcher-6