### PR TITLE
Peer review: fundamental-theorem-calculus (C+)

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus/review.json
+++ b/src/data/proofs/fundamental-theorem-calculus/review.json
@@ -1,0 +1,164 @@
+{
+  "version": 1,
+  "proofId": "fundamental-theorem-calculus",
+  "reviewDate": "2026-03-24T16:00:00Z",
+  "reviewer": "peer-reviewer-1",
+
+  "overallAssessment": {
+    "grade": "C+",
+    "oneLiner": "Pedagogically rich Mathlib wrapper with honest in-file documentation but significantly overclaimed originalContributions and fabricated declarations in meta.json overview text.",
+    "tier": "B",
+    "tierJustification": "The core FTC results (Part 1, Part 2) are single-line delegations to Mathlib's integral_hasDerivAt_right and integral_eq_sub_of_hasDerivAt_of_le. The file adds the IsAntiderivative definition, a convenience wrapper ftc_part1_continuous, and the antiderivatives_differ_by_constant theorem (the only multi-step proof). This is a well-organized Mathlib bridge, not an original formalization. Tier B is appropriate."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "FundamentalTheoremCalculus.lean, lines 8-43 (module docstring)",
+      "finding": "The Lean file's own docstring is commendably honest. Lines 20-22 explicitly state: 'Original Contributions: This file provides pedagogical organization, wrapper theorems with cleaner hypotheses (like ftc_part1_continuous), and extensive commentary explaining the theorem significance.' This correctly characterizes the file's relationship to Mathlib.",
+      "recommendation": "Preserve this honest self-description. The meta.json originalContributions should adopt the same tone."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "FundamentalTheoremCalculus.lean, lines 143-158",
+      "finding": "The antiderivatives_differ_by_constant theorem is the most substantive proof in the file. It uses HasDerivAt.sub, simp, the constant function theorem, and linarith in an 8-line proof that involves genuine multi-step reasoning. This is the strongest original contribution.",
+      "recommendation": "Highlight this theorem in meta.json as the primary original contribution rather than the FTC wrappers."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json crossReferences",
+      "finding": "All 12 cross-reference targets (area-of-circle, basel-problem, euler-identity, intermediate-value-theorem, mean-value-theorem, pythagorean-theorem, harmonic-divergence, cauchy-schwarz-integral, mathematical-induction, brouwer-fixed-point, greens-theorem, stirling-formula) exist in the gallery. The relationship descriptions are mathematically accurate and thoughtfully written.",
+      "recommendation": "No change needed. This is exemplary cross-referencing."
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "meta.json overview.text",
+      "finding": "The overview text claims the file includes 'integration_by_parts via intervalIntegral.integral_mul_deriv_of_le, concrete examples (integral from 0 to 1 of 2x dx = 1 via norm_num), and corollaries like the mean value theorem for integrals (mvt_for_integrals) and the integral_nonneg positivity lemma.' NONE of these exist in the Lean source. There is no integration_by_parts theorem, no mvt_for_integrals, no integral_nonneg, and no concrete example with norm_num. This is fabricated content.",
+      "recommendation": "Remove all references to integration_by_parts, mvt_for_integrals, integral_nonneg, and the concrete example from overview.text. Replace with an accurate description of the 7 theorems and 2 definitions actually present."
+    },
+    {
+      "severity": "major",
+      "category": "overclaim",
+      "location": "meta.json originalContributions",
+      "finding": "Claims 'Complete proof of FTC Part 1 (differentiation of integrals)' and 'Complete proof of FTC Part 2 (evaluation of integrals)'. These are one-line direct calls to Mathlib lemmas: ftc_part1 is literally 'integral_hasDerivAt_right hf_int hf_meas hf_cont' (line 69), and ftc_part2 is 'integral_eq_sub_of_hasDerivAt_of_le hab hF_cont hF_deriv hf_int' (line 97). The Lean file's own docstring correctly calls these 'wrapper theorems' (line 20). Claiming them as 'complete proofs' is misleading.",
+      "recommendation": "Replace with: (1) 'Pedagogical wrapper of FTC Part 1 with clean API (ftc_part1_continuous)', (2) 'Generalized FTC Part 2 without a <= b assumption (ftc_part2_general)', (3) 'Antiderivative uniqueness theorem with multi-step proof from MVT'."
+    },
+    {
+      "severity": "major",
+      "category": "inconsistency",
+      "location": "meta.json overview.text vs FundamentalTheoremCalculus.lean",
+      "finding": "The overview text claims '16 declarations' but the file contains exactly 7 theorems + 2 definitions + 4 #check commands = 13 items (or 9 substantive declarations). Even counting the 4 #check lines, 16 is incorrect.",
+      "recommendation": "Correct the declaration count. The file has 9 substantive declarations (7 theorems, 2 definitions) and 4 #check commands."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json wiedijkNumber: 15 vs overview.text 'Wiedijk #46'",
+      "finding": "The wiedijkNumber field says 15 but the overview text says 'Wiedijk #46'. The Fundamental Theorem of Calculus is indeed Wiedijk 100 list entry #46 (the Freek Wiedijk list). The number 15 is incorrect.",
+      "recommendation": "Change wiedijkNumber to 46."
+    },
+    {
+      "severity": "moderate",
+      "category": "precision",
+      "location": "meta.json mathlibDependencies",
+      "finding": "Lists only 'intervalIntegral' and 'HasDerivAt' as dependencies. The actual Mathlib functions doing the heavy lifting are integral_hasDerivAt_right (FTC Part 1), integral_eq_sub_of_hasDerivAt_of_le (FTC Part 2), integral_eq_sub_of_hasDeriv_right (FTC Part 2 general), and is_const_of_deriv_eq_zero (constant function theorem). These should be listed since they are the actual workhorse functions.",
+      "recommendation": "Add entries for integral_hasDerivAt_right, integral_eq_sub_of_hasDerivAt_of_le, integral_eq_sub_of_hasDeriv_right, and is_const_of_deriv_eq_zero."
+    },
+    {
+      "severity": "moderate",
+      "category": "precision",
+      "location": "annotations.json, line ranges",
+      "finding": "Three annotations (ann-integral-function, ann-ftc-part1, ann-continuity-requirement) all claim the same range 8-43, which is the docstring section. The actual integralFunction definition is at lines 59-61, ftc_part1 is at lines 65-69, and ftc_part1_continuous is at lines 72-78. These annotations point to the wrong code.",
+      "recommendation": "Update line ranges: ann-integral-function should be 59-61, ann-ftc-part1 should be 65-78, ann-continuity-requirement could remain conceptual or point to the hypothesis lines."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "annotations.json, significance ratings",
+      "finding": "All 9 annotations are rated significance 'key'. When everything is key, nothing is. The IsAntiderivative definition and the zero-derivative-implies-constant lemma are supporting results, not key theorems.",
+      "recommendation": "Differentiate significance: mark ftc_part1, ftc_part2, antiderivatives_differ_by_constant, and the inverse-operations insight as 'key'; mark the others as 'supporting' or 'auxiliary'."
+    },
+    {
+      "severity": "minor",
+      "category": "gap",
+      "location": "annotations.json coverage",
+      "finding": "No annotation covers ftc_part2_general (lines 100-105, the version without a <= b) or hasDerivAt_zero_implies_constant (lines 132-139). Both are substantive declarations.",
+      "recommendation": "Add annotations for these two declarations."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json sections",
+      "finding": "Section 'checks' (lines 141-165) is described as 'Type Checking' but #check commands are not proofs or type checks in a meaningful sense -- they are diagnostic commands. The section endLine is 165, which matches. The section is relatively low-value but accurately described.",
+      "recommendation": "Consider whether the #check section adds value. It could be removed or shortened in the Lean file."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Remove fabricated content from meta.json overview.text: delete references to integration_by_parts, mvt_for_integrals, integral_nonneg, and the concrete example 'integral from 0 to 1 of 2x dx = 1 via norm_num'. Replace with accurate description of the 7 theorems and 2 definitions actually present.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Rewrite meta.json originalContributions to match the Lean file's honest self-description: (1) 'Pedagogical wrapper of FTC Part 1 with clean API', (2) 'Generalized FTC Part 2 without ordering assumption', (3) 'Antiderivative uniqueness theorem with multi-step proof'.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Fix wiedijkNumber from 15 to 46 in meta.json.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Expand mathlibDependencies to list the actual workhorse functions: integral_hasDerivAt_right, integral_eq_sub_of_hasDerivAt_of_le, integral_eq_sub_of_hasDeriv_right, is_const_of_deriv_eq_zero.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix annotation line ranges: ann-integral-function to 59-61, ann-ftc-part1 to 65-78. Add annotations for ftc_part2_general and hasDerivAt_zero_implies_constant. Differentiate significance ratings.",
+      "status": "open"
+    },
+    {
+      "id": "ai-6",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Correct declaration count in overview.text from '16 declarations' to '9 declarations (7 theorems, 2 definitions)'.",
+      "status": "open"
+    },
+    {
+      "id": "ai-7",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Consider adding the concrete examples mentioned in the (currently fabricated) overview: integration_by_parts, mvt_for_integrals, a concrete calculation like integral from 0 to 1 of 2x dx = 1. These would genuinely strengthen the file and make the meta.json claims true retroactively.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 5,
+    "originalityAccuracy": 4,
+    "completeness": 7,
+    "framingPrecision": 4,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 4,
+    "overall": 5.3
+  },
+
+  "suggestedBestFraming": "A pedagogical Mathlib bridge for the Fundamental Theorem of Calculus (Wiedijk #46): wraps Mathlib's integral_hasDerivAt_right and integral_eq_sub_of_hasDerivAt for FTC Parts 1 and 2, defines IsAntiderivative, and provides an original multi-step proof that antiderivatives differ by constants via the mean value theorem."
+}


### PR DESCRIPTION
## Summary

- Peer review of **fundamental-theorem-calculus** gallery entry
- **Grade: C+** (overall score 5.3/10)
- **Tier: B** (Mathlib bridge/wrapper)
- 12 findings (3 positive, 3 major, 3 moderate, 3 minor)
- 7 action items (3 high, 3 medium, 1 low)

## Key Findings

**Major issues:**
1. **Fabricated content in overview.text**: Claims the file contains `integration_by_parts`, `mvt_for_integrals`, `integral_nonneg`, and a concrete example `int_0^1 2x dx = 1` -- none of these exist in the Lean source
2. **Overclaimed originalContributions**: FTC Part 1 and Part 2 are single-line Mathlib calls (`integral_hasDerivAt_right`, `integral_eq_sub_of_hasDerivAt_of_le`) but listed as "complete proofs"
3. **Wrong Wiedijk number**: meta.json says 15, should be 46

**Strengths:**
- The Lean file's own docstring honestly calls these "wrapper theorems" -- the meta.json should match
- The `antiderivatives_differ_by_constant` theorem is a genuine multi-step proof
- All 12 cross-references are valid and mathematically accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)