### PR TITLE
Enrich: address peer review findings for 7 gallery entries

### DIFF
--- a/proofs/Proofs/Hilbert17SumOfSquares.lean
+++ b/proofs/Proofs/Hilbert17SumOfSquares.lean
@@ -61,7 +61,7 @@ Allowing rational functions g²/h² = (g/h)² provides more flexibility.
 - [x] Connection to real closed fields
 - [x] Explanation of why rational functions are needed
 - [x] Pedagogical example
-- [ ] Incomplete (has sorries - full proof requires substantial model theory)
+- [ ] Incomplete (10 axioms - full proof requires model theory and real algebraic geometry)
 
 ## Mathlib Dependencies
 

--- a/src/data/proofs/euler-totient/annotations.json
+++ b/src/data/proofs/euler-totient/annotations.json
@@ -152,7 +152,7 @@
     "title": "Totient of a Prime",
     "content": "$\\varphi(p) = p - 1$ for prime $p$: every element $1, 2, \\ldots, p-1$ is coprime to $p$. Direct application of `Nat.totient_prime`.",
     "mathContext": "This is the bridge from Euler's theorem to Fermat's: substituting $\\varphi(p) = p-1$ into $a^{\\varphi(n)} = 1$ gives $a^{p-1} = 1$. More generally, $\\mathbb{Z}/p\\mathbb{Z}$ is a field for prime $p$, so $(\\mathbb{Z}/p\\mathbb{Z})^\\times = \\mathbb{Z}/p\\mathbb{Z} \\setminus \\{0\\}$ has order $p - 1$.",
-    "significance": "key",
+    "significance": "supporting",
     "relatedConcepts": [
       "Nat.totient_prime",
       "prime fields",
@@ -174,7 +174,7 @@
     "title": "Totient of a Prime Power",
     "content": "$\\varphi(p^k) = p^{k-1}(p-1)$ for prime $p$ and $k > 0$. Among $1, \\ldots, p^k$, exactly $p^{k-1}$ are divisible by $p$, so $\\varphi(p^k) = p^k - p^{k-1} = p^{k-1}(p-1)$.",
     "mathContext": "This, combined with the multiplicative property $\\varphi(mn) = \\varphi(m)\\varphi(n)$ for coprime $m, n$, gives the product formula: $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$. For example, $\\varphi(12) = \\varphi(4)\\varphi(3) = 2 \\cdot 2 = 4$. The identity $n = \\sum_{d \\mid n} \\varphi(d)$ (counting elements of $\\mathbb{Z}/n\\mathbb{Z}$ by their order) is a deep consequence.",
-    "significance": "key",
+    "significance": "supporting",
     "relatedConcepts": [
       "Nat.totient_prime_pow",
       "prime powers",

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -42,13 +42,15 @@
       }
     ],
     "originalContributions": [
-      "Euler's theorem via ZMod.pow_totient",
-      "Fermat's Little Theorem as corollary via totient_prime",
-      "Fermat's full form a^p = a via ZMod.pow_card",
-      "Totient value examples verified by rfl",
-      "Euler's theorem examples verified by native_decide",
-      "Non-coprime counterexample (2^φ(4) ≠ 1 mod 4)",
-      "Totient of prime power formula"
+      "Derives Fermat's Little Theorem as a 3-line corollary of Euler's theorem via totient_prime substitution"
+    ],
+    "pedagogicalCuration": [
+      "Curates Mathlib's ZMod.pow_totient as a one-line proof of Euler's theorem",
+      "Applies ZMod.pow_card for the unconditional form a^p = a",
+      "Verifies totient values φ(1)–φ(6) by rfl computation",
+      "Confirms Euler's theorem for small cases via native_decide",
+      "Demonstrates necessity of coprimality with 2^φ(4) ≠ 1 (mod 4) counterexample",
+      "Provides totient formulas for primes and prime powers from Mathlib"
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 10,
@@ -79,7 +81,7 @@
       "title": "Imports and Documentation",
       "summary": "Imports `ZMod.Basic`, `Nat.Totient`, `RingTheory.Int.Basic`, and `Tactic`. Docstring with $a^{\\varphi(n)} \\equiv 1$, approach via Lagrange's theorem, and historical note (Euler 1763, Wiedijk #10).",
       "startLine": 1,
-      "endLine": 53
+      "endLine": 43
     },
     {
       "id": "main-theorem",

--- a/src/data/proofs/euler-totient/review.json
+++ b/src/data/proofs/euler-totient/review.json
@@ -69,21 +69,21 @@
       "priority": "medium",
       "target": "enricher",
       "description": "Rewrite originalContributions in meta.json to distinguish genuine proof steps from pedagogical curation. Keep 'Derives Fermat's Little Theorem as corollary' as a contribution; reframe Mathlib wrappers and rfl/native_decide examples as 'pedagogical curation' rather than 'original contributions.'",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",
       "priority": "low",
       "target": "enricher",
       "description": "Downgrade significance of et-totient-prime and et-totient-prime-pow annotations from 'key' to 'supporting,' since both are single-line Mathlib re-exports.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-3",
       "priority": "low",
       "target": "enricher",
       "description": "Fix section line-range overlap: imports section endLine should be ~41 and main-theorem startLine should be ~42 to avoid the 10-line overlap at lines 44-53.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",

--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -35,7 +35,7 @@
     ],
     "originalContributions": [
       "Statement of Artin's theorem for multivariate polynomials over ℝ",
-      "Motzkin polynomial counterexample with non-negativity and non-SOS proofs",
+      "Motzkin polynomial definition with axiomatized non-negativity and non-SOS properties",
       "Robinson and Choi-Lam additional counterexamples",
       "Hilbert's 1888 classification of when PSD = polynomial-SOS",
       "Pfister's and Cassels' quantitative bounds on number of squares",
@@ -45,13 +45,24 @@
     "hilbertNumber": 17,
     "axiomCount": 10,
     "lineCount": 572,
-    "assumptions": "10 axioms: artin_hilbert17, artin_univariate_aux, motzkin_nonneg_aux, and 7 more. See Lean source for complete statements.",
+    "assumptions": [
+      "artin_hilbert17: Every PSD multivariate polynomial over R is a sum of squares of rational functions (Artin's theorem)",
+      "artin_univariate_aux: Every PSD univariate polynomial is a sum of squares of rational functions",
+      "motzkin_nonneg_aux: The Motzkin polynomial M(x,y) = x^4y^2 + x^2y^4 - 3x^2y^2 + 1 is non-negative everywhere (AM-GM)",
+      "motzkin_not_sos_polynomial_aux: The Motzkin polynomial is not a sum of squares of polynomials (degree analysis)",
+      "univariate_psd_is_sos_aux: Every PSD univariate polynomial is a sum of squares of polynomials (complex factorization)",
+      "quadratic_psd_is_sos_aux: Every PSD quadratic form is a sum of squares of polynomials (Gram matrix / Cholesky)",
+      "pfister_bound_aux: At most 2^n rational function squares needed for n-variable PSD polynomials (Pfister forms)",
+      "cassels_bound_bivariate_aux: At most 4 rational function squares needed for bivariate PSD polynomials",
+      "robinson_nonneg_aux: Robinson's polynomial is non-negative everywhere (Schur's inequality)",
+      "robinson_not_sos_aux: Robinson's polynomial is not a sum of squares of polynomials (homogeneous form analysis)"
+    ],
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Hilbert's 17th Problem emerged from a long investigation into the relationship between non-negativity and sums of squares. In 1888, Hilbert proved a remarkable non-constructive result: there exist non-negative polynomials that are not sums of squares of polynomials. He showed this happens in all but three exceptional cases — univariate polynomials, quadratic forms, and bivariate quartics — but gave no explicit example.\n\nIn his famous 1900 Paris lecture, Hilbert posed Problem 17: even if polynomial squares don't suffice, can every non-negative polynomial be written as a sum of squares of rational functions (quotients of polynomials)? This seemingly modest weakening turns out to be exactly right.\n\nEmil Artin resolved the problem affirmatively in 1927, as an application of his theory of formally real fields and real closures. The proof is a triumph of abstract algebra: if a non-negative polynomial were not a sum of squares of rational functions, one could construct an ordering of the function field making it negative, which contradicts non-negativity via the transfer principle for real closed fields.\n\nNearly 40 years after Hilbert's non-constructive existence proof, Theodore Motzkin (1967) gave the first explicit counterexample to polynomial SOS: M(x,y) = x⁴y² + x²y⁴ - 3x²y² + 1 is non-negative everywhere (by AM-GM) but cannot be decomposed as a sum of squared polynomials (by degree analysis). In the same year, Albrecht Pfister proved that at most 2^n rational function squares are needed for n-variable polynomials.",
     "problemStatement": "**Question:** If f is a polynomial with f(x) >= 0 for all x, is f a sum of squares?\n\n**Answer (Artin):** Yes, but as a sum of squares of rational functions. Motzkin's polynomial shows polynomials don't suffice.",
-    "text": "Artin's theorem: every non-negative polynomial is a sum of squares of rational functions, but not necessarily polynomials (Motzkin's counterexample).",
+    "text": "Artin's theorem: every non-negative polynomial is a sum of squares of rational functions, but not necessarily polynomials (Motzkin's counterexample). Note: of 11 proved theorems, 9 are one-line wrappers around axioms (e.g., theorem foo := foo_aux); the single genuine deduction is motzkin_sos_ratfunc, which combines motzkin_nonneg with artin_hilbert17.",
     "proofStrategy": "The formalization is structured in nine parts mirroring the mathematical landscape. Part I defines SOS and PSD predicates for univariate, multivariate, and rational function settings. Part II axiomatizes Artin's theorem using algebraMap to embed polynomials into rational function fields. Part III constructs the Motzkin polynomial as an MvPolynomial and axiomatizes its non-negativity and non-SOS properties, then derives its rational-SOS representation by applying Artin's theorem — the key deduction. Part IV axiomatizes Hilbert's 1888 classification (univariate and quadratic cases). Part V gives Pfister's 2^n bound and Cassels' bivariate specialization. Part VI discusses real closed fields. Parts VII-IX cover applications, additional counterexamples (Robinson, Choi-Lam), and a summary.",
     "keyInsights": [
       "The gap between non-negativity and being a sum of polynomial squares is fundamental: Hilbert proved it exists (1888), Motzkin exhibited it (1967), and Artin showed rational functions bridge it (1927)",
@@ -193,18 +204,18 @@
   "relatedProofs": [
     {
       "id": "fundamental-theorem-algebra",
-      "relationship": "The univariate case of Hilbert 17 relies on complex root factorization, which is a consequence of the fundamental theorem of algebra",
-      "description": ""
+      "relationship": "technical",
+      "description": "The univariate case of Hilbert 17 relies on complex root factorization, which is a consequence of the fundamental theorem of algebra"
     },
     {
       "id": "hilbert-10",
-      "relationship": "Fellow Hilbert problem — Problem 10 (Diophantine equations) involves polynomial decidability, while Problem 17 involves polynomial positivity",
-      "description": ""
+      "relationship": "thematic",
+      "description": "Fellow Hilbert problem — Problem 10 (Diophantine equations) involves polynomial decidability, while Problem 17 involves polynomial positivity"
     },
     {
       "id": "hilbert-16",
-      "relationship": "Adjacent Hilbert problem — Problem 16 (limit cycles) also concerns real polynomial geometry, specifically the topology of real algebraic curves",
-      "description": ""
+      "relationship": "thematic",
+      "description": "Adjacent Hilbert problem — Problem 16 (limit cycles) also concerns real polynomial geometry, specifically the topology of real algebraic curves"
     }
   ],
   "references": [
@@ -221,6 +232,20 @@
       "year": "1927",
       "venue": "Abhandlungen aus dem mathematischen Seminar der Universität Hamburg 5, 100–115",
       "note": "Proved every positive semidefinite rational function is a sum of squares of rational functions — solving Hilbert's 17th problem"
+    },
+    {
+      "authors": "Motzkin, Theodore S.",
+      "title": "The arithmetic-geometric inequality",
+      "year": "1967",
+      "venue": "Inequalities (Proceedings of a Symposium, Wright-Patterson AFB), Academic Press, 205–224",
+      "note": "First explicit example of a non-negative polynomial that is not a sum of squares of polynomials"
+    },
+    {
+      "authors": "Pfister, Albrecht",
+      "title": "Zur Darstellung definiter Funktionen als Summe von Quadraten",
+      "year": "1967",
+      "venue": "Inventiones Mathematicae 4, 229–237",
+      "note": "Proved that at most 2^n rational function squares suffice for n-variable PSD polynomials"
     }
   ]
 }

--- a/src/data/proofs/hilbert-17/review.json
+++ b/src/data/proofs/hilbert-17/review.json
@@ -118,14 +118,14 @@
       "priority": "medium",
       "target": "enricher",
       "description": "Fix meta.json: list all 10 axioms in assumptions field, remove 3 empty relatedProofs entries, fix field swaps in populated relatedProofs, add Motzkin and Pfister references, fix originalContributions 'proofs' → 'axiomatized properties'.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",
       "priority": "medium",
       "target": "enricher",
       "description": "Fix docstring status checklist: change 'has sorries' to 'has axioms'. Note the axiom-wrapper pattern in meta.json (9 of 11 theorems are wrappers).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-5",


### PR DESCRIPTION
## Summary

Addresses open enricher action items from peer reviews of seven gallery entries (24 items total):

### bezout-identity (5 items)
- Remove fabricated Euclid's lemma claim, consolidate wrappers, fix line count, downgrade wrapper annotations, add pedagogicalContributions

### derangements (5 items)  
- Remove phantom derangement_probability_limit, reframe contributions, fix declaration count, downgrade commentary annotations, fix cross-reference

### lagrange-four-squares (3 items)
- Split monolithic section into Parts II-V, update contributions with genuine proofs, note placeholder True axioms, add 5 annotations, fix misanchored line ranges

### hilbert-10 (3 items)
- Fix overclaim language, distinguish load-bearing vs contextual axioms, qualify axiomatized reduction step

### hilbert-4 (3 items)
- Fix sorry count, mark geodesics as axiomatized, fix mathlibDependencies, qualify vacuous contributions, expand sections, annotate placeholder axioms

### hilbert-17 (2 items)
- Expand assumptions to list all 10 axioms, fix relatedProofs structure, qualify axiomatized properties, fix docstring

### euler-totient (3 items)
- Separate genuine contribution from pedagogical curation, downgrade Mathlib wrapper annotations, fix section overlap

All 24 enricher review action items marked resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)