### PR TITLE
Fix: remove unreliable Mathlib wrapper detection from scanner

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -117,25 +117,11 @@ function stripLeanComments(content: string): string {
   return result
 }
 
-/** Namespaces whose members should not trigger "major Mathlib dependency" flag */
-const BASIC_MATHLIB_NAMES = new Set([
-  'Function', 'Set', 'Finset', 'Nat', 'Int', 'Real', 'Complex',
-  'List', 'Array', 'Option', 'Bool', 'Prod', 'Sum', 'Equiv',
-  'Order', 'Filter', 'Topology', 'Metric', 'Norm', 'Subtype',
-  'Classical', 'Decidable',
-  // Common standalone utilities
-  'congr_fun', 'congr_arg', 'funext', 'rfl', 'Iff',
-])
-
-/** Check whether a Mathlib dependency represents a major named result */
-function isMajorMathlibDep(theorem: string, module: string): boolean {
-  if (!theorem) return false
-  if (module === 'Lean core' || module.startsWith('Init.')) return false
-  const topNamespace = theorem.split('.')[0]
-  if (BASIC_MATHLIB_NAMES.has(topNamespace)) return false
-  if (BASIC_MATHLIB_NAMES.has(theorem)) return false
-  return true
-}
+// NOTE: Automated Mathlib wrapper detection was removed because regex-based
+// heuristics cannot reliably distinguish "using Mathlib lemmas as building blocks"
+// (normal, expected in original proofs) from "directly wrapping a Mathlib theorem
+// as the main result." The hasMajorMathlibDep field is retained in AuditTarget
+// for manual auditor review but is always false for automated scanning.
 
 function countInFile(filePath: string, pattern: RegExp): number {
   if (!fs.existsSync(filePath)) return 0
@@ -215,16 +201,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
       }
     }
 
-    // Mathlib dependency check: only flag genuinely major named results (Issue #6130)
-    const deps = proofMeta.mathlibDependencies || []
-    for (const dep of deps) {
-      const theorem = dep.theorem || ''
-      const module = dep.module || ''
-      if (isMajorMathlibDep(theorem, module) && rawContent.includes(theorem)) {
-        hasMajorMathlibDep = true
-        break
-      }
-    }
+    // hasMajorMathlibDep left as false -- automated detection removed (unreliable)
   }
 
   const trackerEntry = tracker.entries[id]


### PR DESCRIPTION
## Fix

Removes the automated Mathlib wrapper detection from the auditor scanner. Follow-up to #6181.

## Evidence

**Before**: Scanner flagged 10 proofs for using Mathlib dependencies (all false positives — basic lemmas like `div_pos`, tactics like `field_simp`, definitions like `Real.sqrt`)
**After**: Scanner surfaces 14 genuine issues (sorry count mismatches, axiom undercounts) instead of Mathlib false positives

The `hasMajorMathlibDep` field is retained in the `AuditTarget` interface for manual auditor use, but automated detection is disabled because regex heuristics cannot distinguish:
- `:= div_pos mp.hC mp.hBC` (basic lemma usage, normal in original proofs)
- `:= Mathlib.MajorTheorem` (genuine Mathlib wrapper)

---
Automated fix by lean-mechanic agent.