### PR TITLE
Enrich: annotation coverage for 5 proof entries

### DIFF
--- a/src/data/proofs/erdos-1065/annotations.json
+++ b/src/data/proofs/erdos-1065/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-1065",
     "range": {
       "startLine": 1,
-      "endLine": 4
+      "endLine": 5
     },
     "type": "concept",
     "title": "Imports and Dependencies",
@@ -30,7 +30,7 @@
     },
     "type": "concept",
     "title": "Problem Statement and Historical Context",
-    "content": "Module docstring describing Erdős Problem #1065 (Guy's B46): are there infinitely many primes $p$ with $p - 1 = 2^k q$ ($q$ prime)? Lists known examples, connections to safe primes and Artin's conjecture, and the more general $2^k 3^l q + 1$ variant. References OEIS A074781 (safe primes) and A339465.",
+    "content": "Module docstring describing Erd\u0151s Problem #1065 (Guy's B46): are there infinitely many primes $p$ with $p - 1 = 2^k q$ ($q$ prime)? Lists known examples, connections to safe primes and Artin's conjecture, and the more general $2^k 3^l q + 1$ variant. References OEIS A074781 (safe primes) and A339465.",
     "mathContext": "The problem asks about the density of primes whose predecessor $p-1$ has restricted factorization. Connected to Hardy-Littlewood Conjecture F (1923) on the density of safe primes: $\\pi_{\\text{safe}}(x) \\sim 2C_2 x/(\\log x)^2$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -47,7 +47,7 @@
     "id": "two-time-prime",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 27,
+      "startLine": 24,
       "endLine": 29
     },
     "type": "definition",
@@ -94,12 +94,12 @@
     "id": "conjecture-a",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 37,
+      "startLine": 34,
       "endLine": 39
     },
     "type": "concept",
     "title": "Conjecture A: Infinitely Many $2^k q + 1$ Primes",
-    "content": "The stronger variant of Erdős Problem #1065: the set $\\{p \\text{ prime} : p - 1 = 2^k q,\\; q \\text{ prime}\\}$ is infinite. This implies the safe primes conjecture as a special case ($k = 1$). The conjecture relates to the distribution of prime values of the polynomial $2^k q + 1$ as $q$ ranges over primes and $k$ over non-negative integers.",
+    "content": "The stronger variant of Erd\u0151s Problem #1065: the set $\\{p \\text{ prime} : p - 1 = 2^k q,\\; q \\text{ prime}\\}$ is infinite. This implies the safe primes conjecture as a special case ($k = 1$). The conjecture relates to the distribution of prime values of the polynomial $2^k q + 1$ as $q$ ranges over primes and $k$ over non-negative integers.",
     "mathContext": "$|\\{p \\in \\mathbb{P} : \\exists q \\in \\mathbb{P},\\, k \\in \\mathbb{N}: p = 2^k q + 1\\}| = \\infty$.",
     "significance": "key",
     "relatedConcepts": [
@@ -122,7 +122,7 @@
     },
     "type": "concept",
     "title": "Conjecture B: Infinitely Many $2^k 3^l q + 1$ Primes",
-    "content": "The weaker variant of Problem #1065: the set of primes $p$ with $p - 1 = 2^k \\cdot 3^l \\cdot q$ ($q$ prime) is infinite. This is implied by Conjecture A (set $l = 0$). The extra factor of $3^l$ significantly enlarges the candidate set — for example, $p = 61$ satisfies Form B ($60 = 2^2 \\cdot 3 \\cdot 5$) but not Form A.\n\n**Why 3 is special:** The choice of 3 as the additional smooth factor is natural: the $\\{2,3\\}$-smooth numbers (regular numbers, studied since Babylonian mathematics) are the densest smooth number set after powers of 2. Requiring $p - 1$ to be $\\{2,3\\}$-smooth times a prime is the mildest relaxation of Form A's $2$-smooth condition, and the density of Form B primes among all primes is predicted to exceed Form A's by a factor reflecting the additional ways to factor $p - 1$ via powers of 3.",
+    "content": "The weaker variant of Problem #1065: the set of primes $p$ with $p - 1 = 2^k \\cdot 3^l \\cdot q$ ($q$ prime) is infinite. This is implied by Conjecture A (set $l = 0$). The extra factor of $3^l$ significantly enlarges the candidate set \u2014 for example, $p = 61$ satisfies Form B ($60 = 2^2 \\cdot 3 \\cdot 5$) but not Form A.\n\n**Why 3 is special:** The choice of 3 as the additional smooth factor is natural: the $\\{2,3\\}$-smooth numbers (regular numbers, studied since Babylonian mathematics) are the densest smooth number set after powers of 2. Requiring $p - 1$ to be $\\{2,3\\}$-smooth times a prime is the mildest relaxation of Form A's $2$-smooth condition.",
     "mathContext": "$|\\{p \\in \\mathbb{P} : \\exists q \\in \\mathbb{P},\\, k, l \\in \\mathbb{N}: p = 2^k \\cdot 3^l \\cdot q + 1\\}| = \\infty$.",
     "significance": "key",
     "relatedConcepts": [
@@ -139,13 +139,13 @@
     "id": "verified-examples",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 47,
-      "endLine": 87
+      "startLine": 44,
+      "endLine": 129
     },
     "type": "concept",
     "title": "Computationally Verified Form A Examples",
-    "content": "Proves seven Form A primes: $3 = 2^0 \\cdot 2 + 1$, $5 = 2^1 \\cdot 2 + 1$, $7 = 2^1 \\cdot 3 + 1$, $13 = 2^2 \\cdot 3 + 1$, $11 = 2^1 \\cdot 5 + 1$, $29 = 2^2 \\cdot 7 + 1$, $41 = 2^3 \\cdot 5 + 1$ (the eighth, $97 = 2^5 \\cdot 3 + 1$, appears after the Form B example due to file ordering). Each proof constructs the witness $(q, k)$ and checks primality of both $p$ and $q$ using `decide` and `norm_num`.\n\nThe pattern is uniform: `constructor` splits the conjunction into a primality check (`decide`) and an existence witness. The witness is provided as `⟨q, k, by decide, by norm_num⟩`, where `by decide` verifies primality of $q$ and `by norm_num` checks the arithmetic equation $p = 2^k \\cdot q + 1$ computationally. This reflects Lean 4's strength in verified finite computation: despite the conjecture being open, the individual instances are decidable and machine-checkable in milliseconds.",
-    "mathContext": "Form A decompositions: $(p, k, q) \\in \\{(3,0,2), (5,1,2), (7,1,3), (11,1,5), (13,2,3), (29,2,7), (41,3,5)\\}$. Note the non-monotone ordering: $p = 13$ appears before $p = 11$ in the file (likely written in discovery order). All 16 primes between 3 and 41 not in this list either have $p - 1$ completely $\\{2,3\\}$-smooth (e.g., $19 - 1 = 18 = 2 \\cdot 3^2$) or have an odd composite factor (e.g., $23 - 1 = 22 = 2 \\cdot 11$, which is Form A since $11$ is prime — so $23$ should actually be Form A!).",
+    "content": "Proves all 14 Form A primes up to 100: $3, 5, 7, 11, 13, 23, 29, 41, 47, 53, 59, 83, 89, 97$. Each proof constructs the witness $(q, k)$ and checks primality of both $p$ and $q$ using `decide` and `norm_num`.\n\nThe pattern is uniform: `constructor` splits the conjunction into a primality check (`decide`) and an existence witness. The witness is provided as `\u27e8q, k, by decide, by norm_num\u27e9`, where `by decide` verifies primality of $q$ and `by norm_num` checks the arithmetic equation $p = 2^k \\cdot q + 1$ computationally. This reflects Lean 4's strength in verified finite computation: despite the conjecture being open, the individual instances are decidable and machine-checkable in milliseconds.",
+    "mathContext": "Form A decompositions: $(p, k, q) \\in \\{(3,0,2), (5,1,2), (7,1,3), (11,1,5), (13,2,3), (23,1,11), (29,2,7), (41,3,5), (47,1,23), (53,2,13), (59,1,29), (83,1,41), (89,3,11), (97,5,3)\\}$. Among the 25 primes $\\leq 100$, 14 are Form A \u2014 a density of 56%.",
     "significance": "supporting",
     "relatedConcepts": [
       "computational number theory",
@@ -160,40 +160,108 @@
     ]
   },
   {
-    "id": "form-b-separating-example",
+    "id": "form-b-examples",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 88,
-      "endLine": 104
+      "startLine": 130,
+      "endLine": 146
     },
     "type": "insight",
-    "title": "Separating Example ($p = 61$) and Non-Example ($p = 37$)",
-    "content": "This section establishes that Forms A and B are genuinely distinct, via two carefully chosen boundary cases.\n\n**Separating example $p = 61$** (Form B but not Form A): $60 = 2^2 \\cdot 3 \\cdot 5$. Since the factorizations $60/1 = 60$, $60/2 = 30$, $60/4 = 15$ are all composite (or have composite quotients after removing 2-powers), no Form A witness exists. But $60 = 4 \\cdot 3 \\cdot 5 = 2^2 \\cdot 3^1 \\cdot 5$, so $(q, k, l) = (5, 2, 1)$ is a valid Form B witness. The theorem `example_61_extended` proves this via the same `decide`/`norm_num` pattern.\n\n**Non-example $p = 37$** (neither form, as a comment): $36 = 2^2 \\cdot 3^2$ is a perfect $\\{2, 3\\}$-smooth number — after removing all powers of 2 and 3, nothing remains but 1, which is not prime. Hence $p = 37$ satisfies neither $p - 1 = 2^k q$ nor $p - 1 = 2^k \\cdot 3^l \\cdot q$ for any prime $q$. This also appears later (line 96-100) where $p = 97 = 2^5 \\cdot 3 + 1$ confirms the eighth Form A prime.\n\nThe juxtaposition of $61$ (Form B, not A) and $37$ (neither form) precisely demonstrates the three-level hierarchy: {safe primes} ⊂ {Form A} ⊂ {Form B} ⊂ {all primes}.",
-    "mathContext": "$61 - 1 = 60 = 2^2 \\cdot 3 \\cdot 5$: Form B witness $(q,k,l) = (5,2,1)$; Form A requires $60/2^k$ prime for some $k$, but $60, 30, 15$ are all composite. $37 - 1 = 36 = 2^2 \\cdot 3^2$: $\\omega(36) = 2$, $\\text{rad}(36) = 6 = 2 \\cdot 3$, so $36/(2^k 3^l) \\in \\{1, 2, 3, 4, 9, 12, 18, 36\\} \\setminus \\{\\text{primes}\\} = \\emptyset$ for valid $k, l$. $97 - 1 = 96 = 2^5 \\cdot 3$: Form A witness $(q,k) = (3,5)$.",
+    "title": "Form B Separating Examples ($p = 37$ and $p = 61$)",
+    "content": "This section proves that $37$ and $61$ are Form B primes, establishing them as separating examples for the strict inclusion Form A $\\subsetneq$ Form B.\n\n**$p = 37$**: $36 = 2 \\cdot 3^2 \\cdot 2$, so $(q, k, l) = (2, 1, 2)$ is a valid Form B witness. Note that $36 = 2^2 \\cdot 9$ and 9 is not prime, so 37 is not Form A.\n\n**$p = 61$**: $60 = 2^2 \\cdot 3 \\cdot 5$, so $(q, k, l) = (5, 2, 1)$ is a valid Form B witness. Since $60/1 = 60$, $60/2 = 30$, $60/4 = 15$ are all composite, 61 is not Form A.\n\nThe juxtaposition of these two examples demonstrates the three-level hierarchy: {safe primes} $\\subset$ {Form A} $\\subset$ {Form B} $\\subset$ {all primes}.",
+    "mathContext": "$37 - 1 = 36 = 2 \\cdot 3^2 \\cdot 2$: Form B witness $(q,k,l) = (2,1,2)$. $61 - 1 = 60 = 2^2 \\cdot 3 \\cdot 5$: Form B witness $(q,k,l) = (5,2,1)$.",
     "significance": "key",
     "relatedConcepts": [
       "separating example",
       "smooth number",
-      "radical of an integer",
       "three-level prime hierarchy",
       "Form A vs Form B distinction"
     ],
     "prerequisites": [
-      "IsTwoTimePrimePlusOne",
       "IsTwoThreeTimePrimePlusOne",
       "smooth number factorization"
+    ]
+  },
+  {
+    "id": "non-example-37",
+    "proofId": "erdos-1065",
+    "range": {
+      "startLine": 147,
+      "endLine": 166
+    },
+    "type": "technique",
+    "title": "Non-Form-A Proof: $p = 37$",
+    "content": "Proves $37$ is not Form A by exhaustive case analysis. Since $36 = 2^k \\cdot q$, bounding $k \\leq 4$ (as $2^5 = 32 > 36/2$) and using `interval_cases` to enumerate $k = 0, \\ldots, 4$: the quotients $36, 18, 9$ are all composite, and for $k \\geq 3$ the arithmetic fails via `omega`. The `not_form_a_37` section heading and docstring are included in this range.",
+    "mathContext": "$37 - 1 = 36 = 2^2 \\cdot 3^2$. For $k = 0$: $q = 36$ (not prime). For $k = 1$: $q = 18$ (not prime). For $k = 2$: $q = 9$ (not prime). For $k \\geq 3$: $2^k \\cdot q = 36$ has no solution with $q \\geq 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "interval_cases",
+      "bounded exhaustion",
+      "primality refutation"
+    ],
+    "prerequisites": [
+      "IsTwoTimePrimePlusOne",
+      "interval_cases tactic"
+    ]
+  },
+  {
+    "id": "non-example-61-71",
+    "proofId": "erdos-1065",
+    "range": {
+      "startLine": 167,
+      "endLine": 220
+    },
+    "type": "technique",
+    "title": "Non-Form-A and Non-Form-B Proofs: $p = 61$ and $p = 71$",
+    "content": "Three non-membership proofs using bounded exhaustion:\n\n`not_form_a_61`: $60 = 2^k q$ for $k = 0,1,2$ gives $q \\in \\{60, 30, 15\\}$, all composite. For $k \\geq 3$, $2^k > 60$.\n\n`not_form_a_71`: $70 = 2^k q$ gives $q \\in \\{70, 35\\}$ (composite), then $2^k > 70$ for $k \\geq 2$.\n\n`not_form_b_71`: $70 = 2^k \\cdot 3^l \\cdot q$ is exhaustively checked over $k \\leq 5, l \\leq 3$ using `interval_cases k <;> interval_cases l <;> simp_all`. Since $3 \\nmid 70$, only $l = 0$ cases are non-vacuous, reducing to `not_form_a_71`.",
+    "mathContext": "The bounding strategy: $2^k \\leq p - 1$ forces $k \\leq \\lfloor \\log_2(p-1) \\rfloor$, and $3^l \\leq p - 1$ forces $l \\leq \\lfloor \\log_3(p-1) \\rfloor$. For $p = 71$: $70 = 2 \\cdot 5 \\cdot 7$ is $3$-free, so no factorization $2^k \\cdot 3^l \\cdot q$ with $q$ prime and $l > 0$ exists.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "interval_cases",
+      "bounded exhaustion",
+      "primality refutation",
+      "factorization analysis"
+    ],
+    "prerequisites": [
+      "Nat.pow_le_pow_right",
+      "interval_cases",
+      "decide"
+    ]
+  },
+  {
+    "id": "strict-inclusion",
+    "proofId": "erdos-1065",
+    "range": {
+      "startLine": 221,
+      "endLine": 232
+    },
+    "type": "insight",
+    "title": "Strict Inclusion: Form A $\\subsetneq$ Form B via Witnesses",
+    "content": "`strict_inclusion_37` and `strict_inclusion_61` combine positive Form B membership with negative Form A membership to witness $\\{\\text{Form A}\\} \\subsetneq \\{\\text{Form B}\\}$. These are the two smallest separating examples: $37 = 2 \\cdot 3^2 \\cdot 2 + 1$ and $61 = 2^2 \\cdot 3 \\cdot 5 + 1$.",
+    "mathContext": "$\\text{Form A} \\subsetneq \\text{Form B}$ is witnessed by: $37 \\in \\text{Form B} \\setminus \\text{Form A}$ (via `example_37_extended` and `not_form_a_37`) and $61 \\in \\text{Form B} \\setminus \\text{Form A}$ (via `example_61_extended` and `not_form_a_61`).",
+    "significance": "key",
+    "relatedConcepts": [
+      "strict set inclusion",
+      "separating examples",
+      "witness construction"
+    ],
+    "prerequisites": [
+      "example_37_extended",
+      "not_form_a_37",
+      "example_61_extended",
+      "not_form_a_61"
     ]
   },
   {
     "id": "form-a-implies-b",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 109,
-      "endLine": 112
+      "startLine": 233,
+      "endLine": 240
     },
     "type": "concept",
     "title": "Form A Implies Form B",
-    "content": "Proves that every prime of the $2^k q + 1$ form is also of the $2^k 3^l q + 1$ form, by taking $l = 0$ (so $3^0 = 1$). The proof destructures the Form A hypothesis and applies the trivial embedding. This establishes a set inclusion $\\{\\text{Form A primes}\\} \\subseteq \\{\\text{Form B primes}\\}$.",
+    "content": "Proves that every prime of the $2^k q + 1$ form is also of the $2^k 3^l q + 1$ form, by taking $l = 0$ (so $3^0 = 1$). The proof destructures the Form A hypothesis and applies the trivial embedding. This establishes the set inclusion $\\{\\text{Form A primes}\\} \\subseteq \\{\\text{Form B primes}\\}$.",
     "mathContext": "$p = 2^k q + 1 \\implies p = 2^k \\cdot 3^0 \\cdot q + 1$, so $\\text{IsTwoTimePrimePlusOne}(p) \\implies \\text{IsTwoThreeTimePrimePlusOne}(p)$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -209,18 +277,18 @@
     "id": "sophie-germain",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 114,
-      "endLine": 121
+      "startLine": 241,
+      "endLine": 254
     },
     "type": "technique",
     "title": "Connection to Sophie Germain / Safe Primes",
-    "content": "Proves that the infinitude of safe primes ($p = 2q + 1$ with $q$ prime, see `sophie-germain`) would imply Conjecture A. A safe prime $p = 2q + 1$ is exactly a Form A prime with $k = 1$. The safe primes conjecture is itself wide open — heuristically, Hardy-Littlewood Conjecture F predicts $\\sim 2C_2 \\cdot x / (\\log x)^2$ safe primes up to $x$ where $C_2 \\approx 0.66$ is the twin primes constant.\n\nThe connection to Dirichlet's theorem (see `dirichlets-theorem`) is instructive: Dirichlet proved infinitely many primes in $a + nd$ (arithmetic progressions), while this conjecture asks about primes in $2^k q + 1$ where $q$ varies over primes — a much more restrictive structured set requiring two simultaneous primality conditions ($p$ and $q$ both prime).",
-    "mathContext": "$\\{p \\in \\mathbb{P} : \\exists q \\in \\mathbb{P},\\, p = 2q+1\\} \\subseteq \\{p : \\text{IsTwoTimePrimePlusOne}(p)\\}$ via $k = 1$. Hardy–Littlewood predict $\\pi_{\\text{safe}}(x) \\sim 2C_2 x/(\\ln x)^2$.",
+    "content": "Two theorems connecting safe primes to Form A. `sophie_germain_case` proves that the infinitude of safe primes ($p = 2q + 1$ with $q$ prime) would imply Conjecture A: a safe prime is a Form A prime with $k = 1$. `safe_prime_is_form_a` provides the direct embedding. The safe primes conjecture is itself wide open \u2014 heuristically, Hardy-Littlewood Conjecture F predicts $\\sim 2C_2 \\cdot x / (\\log x)^2$ safe primes up to $x$ where $C_2 \\approx 0.66$ is the twin primes constant.\n\nThe connection to Dirichlet's theorem (see `dirichlets-theorem`) is instructive: Dirichlet proved infinitely many primes in $a + nd$ (arithmetic progressions), while this conjecture asks about primes in $2^k q + 1$ where $q$ varies over primes \u2014 a much more restrictive structured set requiring two simultaneous primality conditions.",
+    "mathContext": "$\\{p \\in \\mathbb{P} : \\exists q \\in \\mathbb{P},\\, p = 2q+1\\} \\subseteq \\{p : \\text{IsTwoTimePrimePlusOne}(p)\\}$ via $k = 1$. Hardy\u2013Littlewood predict $\\pi_{\\text{safe}}(x) \\sim 2C_2 x/(\\ln x)^2$.",
     "significance": "key",
     "relatedConcepts": [
       "Sophie Germain prime",
       "safe prime",
-      "Hardy–Littlewood conjecture",
+      "Hardy\u2013Littlewood conjecture",
       "twin primes constant"
     ],
     "prerequisites": [
@@ -232,8 +300,8 @@
     "id": "smooth-structure",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 123,
-      "endLine": 127
+      "startLine": 255,
+      "endLine": 260
     },
     "type": "technique",
     "title": "Smooth Structure of $p - 1$",
@@ -254,13 +322,13 @@
     "id": "conjecture-implication",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 129,
-      "endLine": 136
+      "startLine": 261,
+      "endLine": 269
     },
     "type": "technique",
     "title": "Conjecture A Implies Conjecture B",
-    "content": "Proves that if the set of Form A primes is infinite, then the set of Form B primes is infinite. Uses `Set.Infinite.mono` with `form_a_implies_b` to lift the set inclusion to an infinitude implication. This formalizes the complete logical hierarchy: safe primes $\\Rightarrow$ Conjecture A $\\Rightarrow$ Conjecture B.\n\nThe key Mathlib lemma is `Set.Infinite.mono`: if $S \\subseteq T$ and $S$ is infinite, then $T$ is infinite. This is the standard monotonicity principle for infinite sets. The proof is essentially two lines: apply `h.mono` (where `h : Set.Infinite {Form A}`) and dispatch the subset obligation to `form_a_implies_b`. This clean two-step structure — `Set.Infinite.mono` composed with `form_a_implies_b` — is characteristic of how Mathlib formalizes logical hierarchies between infinitude conjectures: prove the inclusion once, then transport infinitude freely.",
-    "mathContext": "$|\\{\\text{Form A}\\}| = \\infty \\implies |\\{\\text{Form B}\\}| = \\infty$ since $\\{\\text{Form A}\\} \\subseteq \\{\\text{Form B}\\}$ by `form_a_implies_b`. Formally: `h.mono (fun p hp => form_a_implies_b p hp)`. Compare with `sophie_germain_case` at line 115, which uses the same pattern to show safe primes $\\Rightarrow$ Form A infinitude.",
+    "content": "Proves that if the set of Form A primes is infinite, then the set of Form B primes is infinite. Uses `Set.Infinite.mono` with `form_a_implies_b` to lift the set inclusion to an infinitude implication. This formalizes the complete logical hierarchy: safe primes $\\Rightarrow$ Conjecture A $\\Rightarrow$ Conjecture B.\n\nThe key Mathlib lemma is `Set.Infinite.mono`: if $S \\subseteq T$ and $S$ is infinite, then $T$ is infinite. The proof is essentially two lines: apply `h.mono` (where `h : Set.Infinite {Form A}`) and dispatch the subset obligation to `form_a_implies_b`.",
+    "mathContext": "$|\\{\\text{Form A}\\}| = \\infty \\implies |\\{\\text{Form B}\\}| = \\infty$ since $\\{\\text{Form A}\\} \\subseteq \\{\\text{Form B}\\}$ by `form_a_implies_b`. Formally: `h.mono (fun p hp => form_a_implies_b p hp)`.",
     "significance": "key",
     "relatedConcepts": [
       "Set.Infinite.mono",
@@ -278,8 +346,8 @@
     "id": "decidable-check",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 141,
-      "endLine": 148
+      "startLine": 270,
+      "endLine": 279
     },
     "type": "definition",
     "title": "Decidable Check Function",
@@ -297,120 +365,26 @@
     ]
   },
   {
-    "id": "collective-verification",
+    "id": "fourteen-examples",
     "proofId": "erdos-1065",
     "range": {
-      "startLine": 149,
-      "endLine": 162
+      "startLine": 280,
+      "endLine": 301
     },
     "type": "concept",
-    "title": "Collective Verification of Eight Examples",
-    "content": "Proves that all eight identified primes $\\leq 100$ satisfy `IsTwoTimePrimePlusOne`, packaging the individual examples into a single universally quantified statement over a list. Uses `List.mem_cons` and case splitting to dispatch each element to its previously proved instance.",
-    "mathContext": "$\\forall p \\in \\{3, 5, 7, 11, 13, 29, 41, 97\\}: \\text{IsTwoTimePrimePlusOne}(p)$. These are all Form A primes $\\leq 100$; note 17, 19, 23, 31, 37, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89 are excluded.",
+    "title": "Collective Verification: All 14 Form A Primes $\\leq 100$",
+    "content": "Proves that all 14 identified Form A primes $\\leq 100$ satisfy `IsTwoTimePrimePlusOne`, packaging the individual examples into a single universally quantified statement over a list. Uses `simp [List.mem_cons]` and case splitting (`rcases`) to dispatch each element to its previously proved instance.\n\nThis is the computational evidence supporting Conjecture A: among the 25 primes up to 100, a majority (56%) have the Form A property.",
+    "mathContext": "$\\forall p \\in \\{3, 5, 7, 11, 13, 23, 29, 41, 47, 53, 59, 83, 89, 97\\}: \\text{IsTwoTimePrimePlusOne}(p)$. Decompositions: $(3,0,2), (5,1,2), (7,1,3), (11,1,5), (13,2,3), (23,1,11), (29,2,7), (41,3,5), (47,1,23), (53,2,13), (59,1,29), (83,1,41), (89,3,11), (97,5,3)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "list membership proof",
       "case analysis",
-      "exhaustive verification"
+      "exhaustive verification",
+      "prime density"
     ],
     "prerequisites": [
       "individual example theorems",
       "List.mem_cons"
-    ]
-  },
-  {
-    "id": "ann-e1065-non-examples",
-    "proofId": "erdos-1065",
-    "range": {
-      "startLine": 167,
-      "endLine": 219
-    },
-    "type": "technique",
-    "title": "Non-Form-A and Non-Form-B Proofs by Exhaustion",
-    "content": "Three non-membership proofs using bounded exhaustion:\n\n`not_form_a_61`: $60 = 2^k q$ for $k = 0,1,2$ gives $q \\in \\{60, 30, 15\\}$, all composite. For $k \\geq 3$, $2^k > 60$.\n\n`not_form_a_71`: $70 = 2^k q$ gives $q \\in \\{70, 35\\}$ (composite), then $2^k > 70$ for $k \\geq 2$.\n\n`not_form_b_71`: $70 = 2^k \\cdot 3^l \\cdot q$ is exhaustively checked over $k \\leq 5, l \\leq 3$ using `interval_cases k <;> interval_cases l <;> simp_all`. Since $3 \\nmid 70$, only $l = 0$ cases are non-vacuous, reducing to `not_form_a_71`.",
-    "mathContext": "The bounding strategy: $2^k \\leq p - 1$ forces $k \\leq \\lfloor \\log_2(p-1) \\rfloor$, and $3^l \\leq p - 1$ forces $l \\leq \\lfloor \\log_3(p-1) \\rfloor$. The `interval_cases` tactic enumerates all values in these ranges, and `decide` refutes primality of each candidate $q$.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "interval_cases",
-      "bounded exhaustion",
-      "primality refutation",
-      "factorization analysis"
-    ],
-    "prerequisites": [
-      "Nat.pow_le_pow_right",
-      "interval_cases",
-      "decide"
-    ]
-  },
-  {
-    "id": "ann-e1065-strict-inclusion",
-    "proofId": "erdos-1065",
-    "range": {
-      "startLine": 221,
-      "endLine": 231
-    },
-    "type": "insight",
-    "title": "Strict Inclusion: Form A ⊊ Form B via Witnesses",
-    "content": "`strict_inclusion_37` and `strict_inclusion_61` combine positive Form B membership with negative Form A membership to witness $\\{\\text{Form A}\\} \\subsetneq \\{\\text{Form B}\\}$. These are the two smallest separating examples: $37 = 2^2 \\cdot 3^2 + 1$ and $61 = 2^2 \\cdot 3 \\cdot 5 + 1$.",
-    "mathContext": "$\\text{Form A} \\subsetneq \\text{Form B}$ is witnessed by primes $p$ where $p - 1 = 2^k \\cdot 3^l \\cdot q$ with $q$ prime and $l > 0$ (so no Form A decomposition exists). $37 - 1 = 36 = 2^2 \\cdot 3^2$ has $q = 1$ (not prime in Form A), but $q = 1$ with $l = 2$ works for Form B via $36 = 4 \\cdot 9 \\cdot 1$... actually $37 = 2^2 \\cdot 3^2 \\cdot 1 + 1$, which requires $q = 1$ not prime. The actual Form B witness for 37 uses a different decomposition.",
-    "significance": "key",
-    "relatedConcepts": [
-      "strict set inclusion",
-      "separating examples",
-      "witness construction"
-    ],
-    "prerequisites": [
-      "example_37_extended",
-      "not_form_a_37",
-      "example_61_extended",
-      "not_form_a_61"
-    ]
-  },
-  {
-    "id": "ann-e1065-structural-2",
-    "proofId": "erdos-1065",
-    "range": {
-      "startLine": 235,
-      "endLine": 268
-    },
-    "type": "theorem",
-    "title": "Structural Implications: Inclusion Chain and Safe Primes",
-    "content": "Five theorems establishing the inclusion structure:\n\n1. `form_a_implies_b`: Form A $\\subseteq$ Form B via $l = 0$ specialization\n2. `sophie_germain_case`: If infinitely many safe primes exist, then Conjecture A holds (since safe primes are Form A with $k = 1$)\n3. `safe_prime_is_form_a`: Direct safe prime $\\to$ Form A embedding\n4. `smooth_structure`: Extracts $p - 1 = 2^k q$ from Form A membership\n5. `conjecture_a_implies_b`: Uses `Set.Infinite.mono` to lift the inclusion to infinitude\n\nThe Sophie Germain connection is notable: the infinitude of safe primes (widely believed but unproven) would immediately resolve Conjecture A.",
-    "mathContext": "The inclusion chain $\\{2q+1 : q \\text{ prime}\\} \\subseteq \\{p : p = 2^k q + 1\\} \\subseteq \\{p : p = 2^k 3^l q + 1\\}$ gives $\\text{Sophie Germain} \\Rightarrow \\text{Conj A} \\Rightarrow \\text{Conj B}$. The smoothness of $p-1$: Form A primes have $\\omega(p-1) \\leq 2$ (at most the primes 2 and $q$).",
-    "significance": "key",
-    "relatedConcepts": [
-      "safe primes",
-      "Sophie Germain primes",
-      "Set.Infinite.mono",
-      "smooth numbers"
-    ],
-    "prerequisites": [
-      "Set.Infinite",
-      "form_a_implies_b",
-      "IsTwoTimePrimePlusOne"
-    ]
-  },
-  {
-    "id": "ann-e1065-bulk-verify",
-    "proofId": "erdos-1065",
-    "range": {
-      "startLine": 272,
-      "endLine": 301
-    },
-    "type": "technique",
-    "title": "Decidable Check and 14 Form A Primes ≤ 100",
-    "content": "`checkTwoTimePrime` provides a decidable Boolean check for Form A membership by iterating over possible exponents $k$ in `List.range p`. For each $k$, it verifies $2^k \\mid (p-1)$ and checks primality of $(p-1)/2^k$.\n\n`fourteen_examples_le_100` collects all 14 Form A primes $\\leq 100$: $3, 5, 7, 11, 13, 23, 29, 41, 47, 53, 59, 83, 89, 97$. The proof destructures list membership via `simp [List.mem_cons]` and applies the individual example theorems. This is the computational evidence supporting Conjecture A.",
-    "mathContext": "The 14 Form A primes $\\leq 100$ with their decompositions $(p, k, q)$: $(3,0,2), (5,1,2), (7,1,3), (11,1,5), (13,2,3), (23,1,11), (29,2,7), (41,3,5), (47,1,23), (53,2,13), (59,1,29), (83,1,41), (89,3,11), (97,5,3)$. Among the 25 primes $\\leq 100$, 14 are Form A — a density of 56%.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "decidable predicates",
-      "List.range",
-      "computational verification",
-      "prime density"
-    ],
-    "prerequisites": [
-      "checkTwoTimePrime",
-      "individual example theorems"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -73,7 +73,7 @@
       "title": "Imports and Setup",
       "startLine": 1,
       "endLine": 5,
-      "summary": "Imports Mathlib prime basics, finite set infrastructure, natural number arithmetic, and tactic framework.",
+      "summary": "Imports Mathlib's prime number basics, finite set infrastructure, natural number foundations, and tactic framework.",
       "mathContext": "Uses `Nat.Prime`, `Set.Infinite`, `Set.Finite`, `Finset`, and decision procedures (`decide`, `norm_num`) from Mathlib."
     },
     {
@@ -81,15 +81,15 @@
       "title": "Module Documentation",
       "startLine": 6,
       "endLine": 23,
-      "summary": "Problem statement referencing Guy's B46, OEIS A074781 (safe primes) and A339465. Describes both conjecture variants, lists known Form A examples (3, 5, 7, 11, 13, 29, 41, 97) and the separating example p = 61, and notes connections to safe primes, Artin's conjecture, and Cunningham chains.",
-      "mathContext": "Form A: $p = 2^k q + 1$ ($q$ prime). Form B: $p = 2^k 3^l q + 1$. Known Form A primes $\\leq 100$: $3, 5, 7, 11, 13, 29, 41, 97$. Separating example: $61 = 2^2 \\cdot 3 \\cdot 5 + 1$ (Form B only)."
+      "summary": "Problem statement referencing Guy's B46, OEIS A074781 (safe primes) and A339465. Describes both conjecture variants and notes connections to safe primes, Artin's conjecture, and Cunningham chains.",
+      "mathContext": "Form A: $p = 2^k q + 1$ ($q$ prime). Form B: $p = 2^k 3^l q + 1$. Separating example: $61 = 2^2 \\cdot 3 \\cdot 5 + 1$ (Form B only)."
     },
     {
       "id": "definitions",
       "title": "Form Definitions",
       "startLine": 24,
       "endLine": 33,
-      "summary": "Defines IsTwoTimePrimePlusOne (p = 2^k · q + 1) and IsTwoThreeTimePrimePlusOne (p = 2^k · 3^l · q + 1) predicates.",
+      "summary": "Defines IsTwoTimePrimePlusOne (p = 2^k * q + 1) and IsTwoThreeTimePrimePlusOne (p = 2^k * 3^l * q + 1) predicates.",
       "mathContext": "$\\text{Form A}: p \\text{ prime} \\wedge \\exists q \\in \\mathbb{P}, k \\in \\mathbb{N}: p = 2^k q + 1$. $\\text{Form B}: p \\text{ prime} \\wedge \\exists q \\in \\mathbb{P}, k, l \\in \\mathbb{N}: p = 2^k \\cdot 3^l \\cdot q + 1$."
     },
     {
@@ -104,65 +104,49 @@
       "id": "form-a-examples",
       "title": "Form A Verified Examples",
       "startLine": 44,
-      "endLine": 87,
-      "summary": "Seven Form A primes verified via `decide` + `norm_num` in this section: $3, 5, 7, 13, 11, 29, 41$. Each proof constructs the witness $(q, k)$ and checks primality of both $p$ and $q$. Proofs follow the pattern: `constructor` (split primality and existence), `decide` (verify $p$ prime), `exact ⟨q, k, by decide, by norm_num⟩`. (The eighth, $p = 97$, appears after the Form B example due to file ordering.)",
-      "mathContext": "$(p, k, q)$: $(3,0,2), (5,1,2), (7,1,3), (11,1,5), (13,2,3), (29,2,7), (41,3,5), (97,5,3)$. These are all Form A primes $\\leq 100$; the 16 primes $17, 19, 23, 31, 37, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89$ are excluded."
+      "endLine": 129,
+      "summary": "All 14 Form A primes up to 100 verified via `decide` + `norm_num`: $3, 5, 7, 11, 13, 23, 29, 41, 47, 53, 59, 83, 89, 97$. Each proof constructs the witness $(q, k)$ and checks primality of both $p$ and $q$.",
+      "mathContext": "$(p, k, q)$: $(3,0,2), (5,1,2), (7,1,3), (11,1,5), (13,2,3), (23,1,11), (29,2,7), (41,3,5), (47,1,23), (53,2,13), (59,1,29), (83,1,41), (89,3,11), (97,5,3)$."
     },
     {
-      "id": "form-b-and-nonexample",
-      "title": "Form B Separating Example and Non-Example",
-      "startLine": 88,
-      "endLine": 105,
-      "summary": "Proves $61 = 2^2 \\cdot 3^1 \\cdot 5 + 1$ is Form B but not Form A (since $60 = 4 \\cdot 15$ and $15$ is not prime). Also includes $97 = 2^5 \\cdot 3 + 1$ (Form A, out of numerical order in the file). Comments document the non-example $p = 37$: $36 = 2^2 \\cdot 3^2$ is $\\{2,3\\}$-smooth with no additional prime factor, so $37$ satisfies neither form.",
-      "mathContext": "$61 - 1 = 60 = 2^2 \\cdot 3 \\cdot 5$: Form B witness $(q,k,l) = (5,2,1)$ but no Form A decomposition exists since $60/2^k$ for $k=0,1,2$ gives $60, 30, 15$ (all composite). $37 - 1 = 36 = 2^2 \\cdot 3^2$: completely $\\{2,3\\}$-smooth."
-    },
-    {
-      "id": "structural-theorems",
-      "title": "Structural Theorems and Implications",
-      "startLine": 106,
-      "endLine": 137,
-      "summary": "Proves Form A ⊆ Form B, safe primes ⊆ Form A, smooth structure of p−1, and Conjecture A ⇒ Conjecture B.",
-      "mathContext": "$\\{\\text{safe primes}\\} \\subseteq \\{\\text{Form A}\\} \\subseteq \\{\\text{Form B}\\}$ via $k=1$ and $l=0$ specializations. Form A implies $\\omega(p-1) \\leq 2$. Uses `Set.Infinite.mono` for infinitude lifting."
-    },
-    {
-      "id": "computational",
-      "title": "Computational Verification (Part 1)",
-      "startLine": 138,
-      "endLine": 166,
-      "summary": "Verified examples and non-examples via `interval_cases` + `decide`. Includes the exhaustive case analysis showing $37$ is not Form A ($36 = 2^k \\cdot q$ for $k = 0,\\ldots,4$ gives non-prime $q$)."
+      "id": "form-b-examples",
+      "title": "Form B Examples (Not Form A)",
+      "startLine": 130,
+      "endLine": 146,
+      "summary": "Proves $37 = 2^1 \\cdot 3^2 \\cdot 2 + 1$ and $61 = 2^2 \\cdot 3^1 \\cdot 5 + 1$ are Form B primes. Both are Form B but not Form A, serving as separating examples for the strict inclusion.",
+      "mathContext": "$37 - 1 = 36 = 2 \\cdot 3^2 \\cdot 2$: Form B witness $(q,k,l) = (2,1,2)$. $61 - 1 = 60 = 2^2 \\cdot 3 \\cdot 5$: Form B witness $(q,k,l) = (5,2,1)$."
     },
     {
       "id": "non-examples",
       "title": "Non-Form-A and Non-Form-B Proofs",
-      "startLine": 167,
-      "endLine": 219,
-      "summary": "Proves $61$ and $71$ are not Form A ($60 = 2^2 \\cdot 15$, $70 = 2 \\cdot 35$ have composite odd parts). Proves $71$ is not Form B either ($3 \\nmid 70$, so no factorization $2^k \\cdot 3^l \\cdot q$ with $q$ prime). Uses `interval_cases` on bounded exponents with primality refutation by `decide`.",
-      "mathContext": "For $p = 61$: $60 = 2^k \\cdot q$ gives $q \\in \\{60, 30, 15\\}$ (all composite) for $k \\leq 2$, and $2^k > 60$ for $k \\geq 6$. For $p = 71$: $70 = 2 \\cdot 5 \\cdot 7$ is $3$-free, so no factorization $2^k \\cdot 3^l \\cdot q$ with $q$ prime and $l > 0$ exists."
+      "startLine": 147,
+      "endLine": 220,
+      "summary": "Proves $37$, $61$, and $71$ are not Form A via exhaustive case analysis on exponents. Proves $71$ is not Form B either ($70 = 2 \\cdot 5 \\cdot 7$ is $3$-free). Uses `interval_cases` on bounded exponents with primality refutation by `decide`.",
+      "mathContext": "For $p = 37$: $36 = 2^k q$ for $k = 0,\\ldots,4$ gives non-prime $q$. For $p = 61$: $60/2^k \\in \\{60, 30, 15\\}$ all composite. For $p = 71$: $70 = 2 \\cdot 5 \\cdot 7$ is $3$-free, so no $2^k \\cdot 3^l \\cdot q$ factorization with $q$ prime exists."
     },
     {
       "id": "strict-inclusion",
       "title": "Strict Inclusion: Form A ⊊ Form B",
       "startLine": 221,
-      "endLine": 231,
+      "endLine": 232,
       "summary": "Combines verified examples to give two witnesses for the strict inclusion Form A $\\subsetneq$ Form B: $37$ and $61$ are each Form B but not Form A.",
-      "mathContext": "$\\{p : \\texttt{IsTwoTimePrimePlusOne}\\, p\\} \\subsetneq \\{p : \\texttt{IsTwoThreeTimePrimePlusOne}\\, p\\}$ witnessed by $37 = 2^2 \\cdot 3^2 + 1$ and $61 = 2^2 \\cdot 3 \\cdot 5 + 1$."
+      "mathContext": "$\\{p : \\texttt{IsTwoTimePrimePlusOne}\\, p\\} \\subsetneq \\{p : \\texttt{IsTwoThreeTimePrimePlusOne}\\, p\\}$ witnessed by $37$ and $61$."
     },
     {
-      "id": "structural-2",
-      "title": "Structural Theorems (Extended)",
+      "id": "structural-theorems",
+      "title": "Structural Theorems and Implications",
       "startLine": 233,
-      "endLine": 268,
+      "endLine": 269,
       "summary": "Five structural results: `form_a_implies_b` ($l = 0$ specialization), `sophie_germain_case` (safe primes embed into Form A via $k = 1$), `safe_prime_is_form_a`, `smooth_structure` ($p - 1 = 2^k q$), and `conjecture_a_implies_b` (Set.Infinite monotonicity).",
-      "mathContext": "The inclusion chain $\\{\\text{safe primes}\\} \\xrightarrow{k=1} \\{\\text{Form A}\\} \\xrightarrow{l=0} \\{\\text{Form B}\\}$ gives $\\text{Conj A} \\Rightarrow \\text{Conj B}$. `smooth_structure` extracts $p - 1 = 2^k q$ from the Form A predicate, exposing the $\\{2, q\\}$-smooth factorization of $p - 1$."
+      "mathContext": "The inclusion chain $\\{\\text{safe primes}\\} \\xrightarrow{k=1} \\{\\text{Form A}\\} \\xrightarrow{l=0} \\{\\text{Form B}\\}$ gives $\\text{Conj A} \\Rightarrow \\text{Conj B}$. `smooth_structure` extracts $p - 1 = 2^k q$ from the Form A predicate."
     },
     {
-      "id": "computational-2",
+      "id": "computational",
       "title": "Decidable Check and Bulk Verification",
       "startLine": 270,
       "endLine": 301,
-      "summary": "Defines `checkTwoTimePrime` as a decidable Bool check via `List.range` over possible exponents $k$. Proves `fourteen_examples_le_100`: all 14 Form A primes $\\leq 100$ ($3, 5, 7, 11, 13, 23, 29, 41, 47, 53, 59, 83, 89, 97$) satisfy `IsTwoTimePrimePlusOne`, collecting the individual verified examples.",
-      "mathContext": "The 14 Form A primes $\\leq 100$ are verified by case analysis on the list membership. The decidable check iterates $k$ from $0$ to $p-1$, computing $2^k$ and testing whether $(p-1)/2^k$ is prime. Six additional examples beyond the earlier eight: $23 = 2 \\cdot 11 + 1$, $47 = 2 \\cdot 23 + 1$, $53 = 2^2 \\cdot 13 + 1$, $59 = 2 \\cdot 29 + 1$, $83 = 2 \\cdot 41 + 1$, $89 = 2^3 \\cdot 11 + 1$.",
-      "mathContext": "Algorithm: for each $k = 0, \\ldots, p-1$, check if $2^k \\mid (p-1)$ and $(p-1)/2^k$ is prime. Collectively verifies $\\forall p \\in \\{3,5,7,11,13,29,41,97\\}: \\text{IsTwoTimePrimePlusOne}(p)$."
+      "summary": "Defines `checkTwoTimePrime` as a decidable Bool check via `List.range` over possible exponents $k$. Proves `fourteen_examples_le_100`: all 14 Form A primes $\\leq 100$ satisfy `IsTwoTimePrimePlusOne`, collecting the individual verified examples.",
+      "mathContext": "Algorithm: for each $k = 0, \\ldots, p-1$, check if $2^k \\mid (p-1)$ and $(p-1)/2^k$ is prime. Among the 25 primes $\\leq 100$, 14 are Form A -- a density of 56%."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-1089/annotations.json
+++ b/src/data/proofs/erdos-1089/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-1089-header",
     "proofId": "erdos-1089",
-    "range": { "startLine": 1, "endLine": 36 },
+    "range": { "startLine": 1, "endLine": 37 },
     "type": "context",
     "title": "Problem Statement and Imports",
     "content": "The header documents Erdős Problem #1089: estimating the threshold function $g_d(n)$ that guarantees $n$ distinct distances in $\\mathbb{R}^d$. Known small values ($g_1(3)=4$, $g_2(3)=6$, $g_3(3)=7$) and the central bounds ($d^{n-1} \\ll g_d(n) \\leq c^{d^{1-b_n}}$) are summarized. The single `import Mathlib` pulls in EuclideanSpace, Filter, Finset, and all required tactics. The `open Set Finset` declaration makes set and finite set operations available without prefixes.",
@@ -14,7 +14,7 @@
   {
     "id": "ann-1089-point",
     "proofId": "erdos-1089",
-    "range": { "startLine": 44, "endLine": 49 },
+    "range": { "startLine": 38, "endLine": 50 },
     "type": "definition",
     "title": "Point Type and Distance Function",
     "content": "**Point d** abbreviates `EuclideanSpace ℝ (Fin d)` — the type of functions `Fin d → ℝ` equipped with the $\\ell^2$ inner product. The **dist** function computes $\\|p - q\\| = \\sqrt{\\sum_{i=0}^{d-1} (p_i - q_i)^2}$ using Mathlib's norm. The `noncomputable` annotation reflects that real-valued computation is non-constructive in Lean's type theory.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-1089-distinctdist",
     "proofId": "erdos-1089",
-    "range": { "startLine": 51, "endLine": 57 },
+    "range": { "startLine": 51, "endLine": 58 },
     "type": "definition",
     "title": "Distinct Distances Set and Count",
     "content": "**distinctDistances P** computes all positive pairwise distances in a point set, and **numDistinctDistances** returns its cardinality. These are the central quantities: the problem asks how many points guarantee n distinct values.\n\nThe number of pairwise distances is at most $\\binom{|P|}{2}$ (see `combinations-formula`), so $|\\Delta(P)| \\leq \\binom{|P|}{2}$. The Guth-Katz breakthrough (2015) proved $|\\Delta(P)| \\geq c|P|/\\sqrt{\\log |P|}$ in the plane — the near-tight answer to the 2D distinct distances problem. Problem #1089 asks the orthogonal question: fixing the number of distinct distances $n$ and varying dimension $d$.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-1089-gdef",
     "proofId": "erdos-1089",
-    "range": { "startLine": 59, "endLine": 75 },
+    "range": { "startLine": 59, "endLine": 76 },
     "type": "definition",
     "title": "The Threshold Function g_d(n): Definition and Well-Definedness",
     "content": "This section introduces the two core definitions of the formalization.\n\n**determinesNDistances P n** is the predicate that a finite point set $P$ realizes at least $n$ distinct pairwise distances. It serves as the Boolean criterion inside the infimum defining $g$.\n\n**g d n** is the infimum of all $m$ such that every $m$-point set in $\\mathbb{R}^d$ determines at least $n$ distinct distances — the central threshold function of Erdős Problem #1089. The `noncomputable` annotation reflects that both $g$ and `determinesNDistances` depend on real-valued distances, which are non-constructive in Lean.\n\n**g_well_defined** axiomatizes the finiteness of $g_d(n)$ for $n \\geq 1$: it asserts that for each $n \\geq 1$, there exists some $m$ such that every $m$-point set determines $n$ distances. Without this, `sInf` of an empty set would equal 0, giving the wrong value. This well-definedness is geometrically clear (for any $n$, $m = n$ points in general position suffice) but non-trivial to formalize in Lean.",
@@ -62,7 +62,7 @@
   {
     "id": "ann-1089-cube",
     "proofId": "erdos-1089",
-    "range": { "startLine": 99, "endLine": 118 },
+    "range": { "startLine": 99, "endLine": 119 },
     "type": "context",
     "title": "Cube Construction: The Key Extremal Example",
     "content": "The $d$-dimensional unit cube $\\{0,1\\}^d$ is the fundamental extremal construction in this problem. This section axiomatizes it and derives a lower bound.\n\n**cubeVertices(d)** is axiomatized as a `Finset (Point d)` — a finite subset of $\\mathbb{R}^d$. The embedding $\\{0,1\\}^d \\hookrightarrow \\mathbb{R}^d$ is straightforward conceptually (map each bitstring to its coordinate vector) but would require substantial Lean infrastructure to formalize (building the $2^d$ elements of `EuclideanSpace ℝ (Fin d)` as a `Finset`), so it is axiomatized instead.\n\n**cube_card** axiomatizes $|\\text{cubeVertices}(d)| = 2^d$ — the cube has $2^d$ vertices.\n\n**cube_distances** axiomatizes $|\\Delta(\\text{cubeVertices}(d))| \\leq d$ — the cube vertices determine at most $d$ distinct distances: vertices differing in exactly $k$ coordinates have squared distance $k$, giving distances $\\sqrt{1}, \\sqrt{2}, \\ldots, \\sqrt{d}$. Exactly $d$ distinct distances, not $2^d$.\n\n**cube_lower_bound** ($g_d(d+1) > 2^d$) is sorry'd. The proof idea: since the $2^d$-vertex cube has only $d < d+1$ distinct distances, the $2^d$-point set does NOT witness that $2^d$ points guarantee $d+1$ distances. Hence $g_d(d+1) > 2^d$. Completing this proof from the axioms requires working through the sInf characterization of $g$.",
@@ -74,7 +74,7 @@
   {
     "id": "ann-1089-erdoslower",
     "proofId": "erdos-1089",
-    "range": { "startLine": 120, "endLine": 122 },
+    "range": { "startLine": 120, "endLine": 123 },
     "type": "context",
     "title": "Erdős Lower Bound: g_d(n) ≥ c·d^{n-1} (Polynomial Growth)",
     "content": "**erdos_lower_bound** axiomatizes Erdős's 1975 polynomial lower bound: for each $n \\geq 2$, there exists a constant $c > 0$ such that $g_d(n) \\geq c \\cdot d^{n-1}$ for all $d \\geq 1$.\n\nErdős called this 'easy' — the argument goes: fix $n \\geq 2$ and consider the points $\\{1, 2, \\ldots, m\\}^{n-1} \\subset \\mathbb{R}^{n-1}$ (a discrete grid). By a counting argument, one can show that $m^{n-1}$ points in $\\mathbb{R}^{d}$ cannot guarantee $n$ distinct distances unless $m \\gtrsim d$, giving $g_d(n) \\gtrsim d^{n-1}$. The key observation is that polynomial families of points can be arranged with controlled distance repetitions.\n\nIn the Lean formalization, `erdos_lower_bound` is axiomatized because the full counting argument requires constructing explicit low-distance configurations in high-dimensional Euclidean space — a substantial Lean formalization effort. The axiom states the conclusion in the natural form for the subsequent theorem `ratio_bounded_below`.\n\nThe `(n - 1 : ℕ)` exponent uses natural number subtraction: since $n \\geq 2$, this equals $n - 1$ as expected. The cast `(g d n : ℝ)` is needed because $g$ has type `ℕ → ℕ → ℕ`.",
@@ -86,7 +86,7 @@
   {
     "id": "ann-1089-upper",
     "proofId": "erdos-1089",
-    "range": { "startLine": 130, "endLine": 133 },
+    "range": { "startLine": 124, "endLine": 134 },
     "type": "context",
     "title": "Erdős-Straus Upper Bound",
     "content": "**erdos_straus_upper_bound** axiomatizes that $g_d(n) \\le c^{d^{1-b_n}}$ for constants $c > 1$ and $b_n > 0$. This stretched-exponential upper bound is vastly larger than the polynomial lower bound $d^{n-1}$.",
@@ -98,7 +98,7 @@
   {
     "id": "ann-1089-ratio",
     "proofId": "erdos-1089",
-    "range": { "startLine": 141, "endLine": 147 },
+    "range": { "startLine": 135, "endLine": 149 },
     "type": "definition",
     "title": "Normalized Ratio and Main Conjecture",
     "content": "**gRatio d n** = $g_d(n)/d^{n-1}$ is the normalized threshold. **erdos1089Conjecture n** asks whether this ratio converges as $d \\to \\infty$ for fixed $n$. Convergence would determine the exact polynomial growth rate.",
@@ -110,7 +110,7 @@
   {
     "id": "ann-1089-bounded-below",
     "proofId": "erdos-1089",
-    "range": { "startLine": 153, "endLine": 157 },
+    "range": { "startLine": 153, "endLine": 158 },
     "type": "technique",
     "title": "ratio_bounded_below: The One Genuinely Proved Theorem",
     "content": "**ratio_bounded_below** is the one theorem in this file with a genuine Lean proof (not an axiom or sorry). It derives that $g_d(n)/d^{n-1} \\geq c > 0$ directly from the `erdos_lower_bound` axiom.\n\nThe Lean proof is a two-step `obtain`/`exact`:\n1. `obtain ⟨c, hc, h⟩ := erdos_lower_bound n hn` — destructs the existential in `erdos_lower_bound` to get a witness $c > 0$ and the bound $g_d(n) \\geq c \\cdot d^{n-1}$.\n2. `exact ⟨c, hc, fun d hd => by simp only [gRatio]; linarith [h d hd]⟩` — constructs the output existential, then proves `gRatio d n ≥ c` by unfolding the definition and applying `linarith` to `h d hd : g d n ≥ c * d^(n-1)`.\n\nThe `simp only [gRatio]` unfolds the definition `gRatio d n = (g d n : ℝ) / d^(n-1)`. Then `linarith` finishes: $g_d(n) \\geq c \\cdot d^{n-1}$ implies $g_d(n)/d^{n-1} \\geq c$ (for $d \\geq 1$, $d^{n-1} > 0$).\n\nThis theorem establishes that the ratio $\\text{gRatio}(d, n)$ is bounded away from 0 — meaning $g_d(n)$ genuinely grows at least polynomially as $d \\to \\infty$. Combined with `ratioIsBounded` (which remains open), this would place the ratio in a positive interval $[c, C]$.",
@@ -122,7 +122,7 @@
   {
     "id": "ann-1089-bounded-question",
     "proofId": "erdos-1089",
-    "range": { "startLine": 150, "endLine": 151 },
+    "range": { "startLine": 150, "endLine": 152 },
     "type": "definition",
     "title": "Weaker Question: Is the Ratio Bounded?",
     "content": "**ratioIsBounded** asks whether $g_d(n)/d^{n-1} \\leq C$ for some constant $C$ and all $d \\geq 1$. This is strictly weaker than limit existence (erdos1089Conjecture): boundedness would follow from convergence but not vice versa. Combined with ratio_bounded_below, an upper bound would sandwich the ratio in $[c, C]$. If the ratio is unbounded, then $g_d(n)$ grows super-polynomially in $d$, closer to the Erdős-Straus stretched-exponential upper bound.",
@@ -146,7 +146,7 @@
   {
     "id": "ann-1089-monotonicity",
     "proofId": "erdos-1089",
-    "range": { "startLine": 165, "endLine": 171 },
+    "range": { "startLine": 159, "endLine": 172 },
     "type": "concept",
     "title": "Monotonicity of g_d(n) in Both Arguments",
     "content": "Two natural monotonicity properties are axiomatized: **g_mono_n** ($n_1 \\leq n_2 \\implies g_d(n_1) \\leq g_d(n_2)$) says requiring more distinct distances can only increase the threshold. **g_mono_d** ($d_1 \\leq d_2 \\implies g_{d_1}(n) \\leq g_{d_2}(n)$ for $n \\geq 2$) says higher dimensions allow larger few-distance configurations, so more points are needed. The $n \\geq 2$ condition in g_mono_d excludes the trivial case $g_d(1) = 2$ for all $d$.",
@@ -158,7 +158,7 @@
   {
     "id": "ann-1089-openproblem",
     "proofId": "erdos-1089",
-    "range": { "startLine": 193, "endLine": 201 },
+    "range": { "startLine": 186, "endLine": 201 },
     "type": "context",
     "title": "Open Problem Statement and Type Verification",
     "content": "**erdos1089OpenProblem** bundles the open conjecture for all $n \\geq 2$ simultaneously: $\\forall n \\geq 2,\\; \\text{erdos1089Conjecture}(n)$. This is the statement of Erdős Problem #1089 as a single Lean `Prop`.\n\nThe five trailing `#check` commands serve as type-level unit tests — they confirm that the central definitions and theorems have the expected types and compile without errors. In Lean 4, `#check` elaborates and type-checks its argument, so these verify that:\n- `g : ℕ → ℕ → ℕ` (the threshold function)\n- `gRatio : ℕ → ℕ → ℝ` (the normalized ratio)\n- `erdos1089Conjecture : ℕ → Prop` (the limit existence predicate)\n- `erdos_lower_bound` and `erdos_straus_upper_bound` have their correct axiom types\n\n**Why the problem remains open**: The difficulty of proving `erdos1089OpenProblem` lies in simultaneously establishing convergence for all $n \\geq 2$. Even for $n = 2$ (where $g_d(2) = 3$ for all $d$, so the ratio $3/d^1 \\to 0$), the limit is known trivially. For $n = 3$, the ratio $g_d(3)/d^2$ is bounded below by the Erdős lower bound but its convergence is open. The problem is hardest for large $n$, where the gap between $d^{n-1}$ and $c^{d^{1-b_n}}$ is widest.",

--- a/src/data/proofs/erdos-1097/annotations.json
+++ b/src/data/proofs/erdos-1097/annotations.json
@@ -335,7 +335,7 @@
     "id": "erdos-1097-ann-restricted-ops",
     "proofId": "erdos-1097",
     "range": {
-      "startLine": 340,
+      "startLine": 337,
       "endLine": 347
     },
     "type": "definition",

--- a/src/data/proofs/erdos-36/annotations.json
+++ b/src/data/proofs/erdos-36/annotations.json
@@ -264,7 +264,10 @@
       "expository comments",
       "module documentation"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "erdos_36_limit_exists",
+      "known bounds axioms"
+    ],
     "mathContext": "Three key results about the constant $c = \\lim_{N \\to \\infty} M(N)/N$: (1) Erdős conjectured $c = 1/2$ (disproved), (2) the Fourier approach gives $c \\geq 1 - 1/\\sqrt{2}$, (3) connections to additive combinatorics discrepancy theory."
   },
   {

--- a/src/data/proofs/erdos-369/annotations.json
+++ b/src/data/proofs/erdos-369/annotations.json
@@ -28,7 +28,7 @@
     "id": "ann-e369-imports",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 30,
+      "startLine": 29,
       "endLine": 35
     },
     "type": "concept",
@@ -50,7 +50,7 @@
     "id": "ann-e369-is-smooth",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 39,
+      "startLine": 36,
       "endLine": 43
     },
     "type": "definition",
@@ -73,7 +73,7 @@
     "id": "ann-e369-largest-prime-factor",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 45,
+      "startLine": 44,
       "endLine": 48
     },
     "type": "definition",
@@ -96,7 +96,7 @@
     "id": "ann-e369-consecutive-run",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 52,
+      "startLine": 49,
       "endLine": 56
     },
     "type": "definition",
@@ -118,7 +118,7 @@
     "id": "ann-e369-has-run",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 58,
+      "startLine": 57,
       "endLine": 67
     },
     "type": "definition",
@@ -140,7 +140,7 @@
     "id": "ann-e369-conjecture",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 71,
+      "startLine": 68,
       "endLine": 87
     },
     "type": "concept",
@@ -162,7 +162,7 @@
     "id": "ann-e369-k2",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 91,
+      "startLine": 88,
       "endLine": 105
     },
     "type": "concept",
@@ -185,7 +185,7 @@
     "id": "ann-e369-balog-wooley",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 109,
+      "startLine": 106,
       "endLine": 120
     },
     "type": "concept",
@@ -208,7 +208,7 @@
     "id": "ann-e369-summary",
     "proofId": "erdos-369",
     "range": {
-      "startLine": 122,
+      "startLine": 121,
       "endLine": 131
     },
     "type": "context",

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -133,7 +133,7 @@
     {
       "id": "smooth-numbers",
       "title": "Part I: Smooth Numbers",
-      "startLine": 37,
+      "startLine": 36,
       "endLine": 48,
       "summary": "Defines **IsSmooth m B** (line 42–43: $m \\geq 1$ and all prime factors $\\leq B$) and axiomatizes **largestPrimeFactor** (line 48: `noncomputable axiom`). The Dickman-de Bruijn function governs the density of $B$-smooth numbers: $\\Psi(x, x^{1/u}) \\sim x\\rho(u)$.",
       "mathContext": "$\\text{IsSmooth}(m, B) \\iff m \\geq 1 \\wedge \\forall p \\mid m,\\, p\\text{ prime} \\implies p \\leq B$. Density: $\\Psi(x, x^{1/u}) \\sim x\\rho(u)$ where $\\rho$ satisfies $u\\rho'(u) = -\\rho(u-1)$, $\\rho(u) = 1$ for $u \\in [0,1]$. Note: `largestPrimeFactor` is a definitional axiom — `IsSmooth` does not depend on it."
@@ -141,7 +141,7 @@
     {
       "id": "consecutive-runs",
       "title": "Part II: Consecutive Smooth Runs",
-      "startLine": 50,
+      "startLine": 49,
       "endLine": 67,
       "summary": "Defines **ConsecutiveSmoothRun m k B** (line 55–56: $k \\geq 2$ consecutive $B$-smooth integers from $m$) and **HasConsecutiveSmoothRun** (line 66–67: existence within $\\{1,\\ldots,n\\}$). Coprimality of consecutive integers makes joint smoothness a multiplicatively independent condition.",
       "mathContext": "$\\text{ConsecutiveSmoothRun}(m, k, B) \\iff k \\geq 2 \\wedge \\forall i < k: \\text{IsSmooth}(m+i, B)$. $\\text{HasConsecutiveSmoothRun}(n,k,B) \\iff \\exists m \\geq 1: m+k-1 \\leq n \\wedge \\text{ConsecutiveSmoothRun}(m,k,B)$. Key difficulty: $\\gcd(m, m+1) = 1$ makes their smoothness multiplicatively independent."
@@ -149,7 +149,7 @@
     {
       "id": "conjecture",
       "title": "Part III: The Erdős-Graham Conjecture",
-      "startLine": 69,
+      "startLine": 68,
       "endLine": 87,
       "summary": "**ErdosConjecture369** (lines 79–87): parametrized by `smoothBound : ℕ → ℕ` (divergent, $\\leq n$), asserts $\\forall k \\geq 2, \\exists N_0, \\forall n \\geq N_0$, a $k$-run of smooth integers exists. Elegantly avoids real exponentiation. Important subtlety: as stated for $\\{1,\\ldots,n\\}$, the small integers $\\{1,\\ldots,k\\}$ would trivially form a smooth run — the non-trivial interpretation requires each $m$ to lie in $[n/2,n]$ or be $m^\\varepsilon$-smooth.",
       "mathContext": "Parametrized: given $B : \\mathbb{N} \\to \\mathbb{N}$ with $B(n) \\to \\infty$ and $B(n) \\leq n$: $\\forall k \\geq 2, \\exists N_0, \\forall n \\geq N_0: \\text{HasConsecutiveSmoothRun}(n,k,B(n))$. The two conditions on `smoothBound` ensure it captures $n^\\varepsilon$ for any fixed $\\varepsilon > 0$ without using real arithmetic."
@@ -157,7 +157,7 @@
     {
       "id": "k2-case",
       "title": "Part IV: The k = 2 Case",
-      "startLine": 89,
+      "startLine": 88,
       "endLine": 105,
       "summary": "**ErdosConjecture369_k2** (lines 99–105): the simplest open instance, fixing $k = 2$ in the general conjecture. Even two consecutive smooth numbers for all large $n$ is unresolved. Erdős-Graham: 'the answer should be affirmative but the problem seems very hard.' The k=2 case is equivalent to: for all large $n$, $\\{1,\\ldots,n\\}$ contains a pair $(m, m+1)$ both $B(n)$-smooth.",
       "mathContext": "$k = 2$: $\\exists N_0, \\forall n \\geq N_0, \\exists m \\leq n: \\text{IsSmooth}(m, B(n)) \\wedge \\text{IsSmooth}(m+1, B(n))$. Note: `ErdosConjecture369_k2` is strictly weaker than `ErdosConjecture369` (the latter implies the former by taking $k=2$), so any proof of `ErdosConjecture369` automatically proves this."
@@ -165,7 +165,7 @@
     {
       "id": "balog-wooley",
       "title": "Part V: Balog-Wooley Partial Result (1998)",
-      "startLine": 107,
+      "startLine": 106,
       "endLine": 120,
       "summary": "Axiomatizes **balog_wooley_infinitely_many** (lines 116–120): for any divergent smoothness bound, infinitely many $n$ have both $n$ and $n+1$ smooth. Uses sieve methods and exponential sums. Falls short of 'all sufficiently large $n$.' This is the `axiom` that encodes a deep mathematical theorem as a Lean assumption.",
       "mathContext": "Balog-Wooley (1998): $\\forall B: \\mathbb{N}\\to\\mathbb{N}$ diverging, $\\forall N_0, \\exists n \\geq N_0: \\text{IsSmooth}(n, B(n)) \\wedge \\text{IsSmooth}(n+1, B(n+1))$. This is the $\\exists^\\infty$ statement, not the $\\forall^\\infty$ conjecture. The proof uses Type I/II exponential sum estimates and the Selberg sieve on arithmetic progressions."
@@ -173,7 +173,7 @@
     {
       "id": "summary",
       "title": "Part VI: Summary",
-      "startLine": 122,
+      "startLine": 121,
       "endLine": 131,
       "summary": "Closing comment (lines 124–129) summarizing the formalization structure: definitions of smooth numbers and consecutive runs, the parametrized conjecture statement, and the Balog-Wooley axiom as the strongest known partial result. Status: OPEN even for $k = 2$.",
       "mathContext": "Current state: $\\exists^\\infty n: \\text{IsSmooth}(n, B(n)) \\wedge \\text{IsSmooth}(n+1, B(n+1))$ (proved, Balog-Wooley) vs. $\\forall^\\infty n: \\text{HasConsecutiveSmoothRun}(n,k,B(n))$ (open for all $k \\geq 2$). Difficulty hierarchy: infinitely many < positive density < all large $n$ — each step requires fundamentally new tools."


### PR DESCRIPTION
## Summary

Enrichment pass 2 for 5 gallery entries, focusing on annotation coverage and alignment.

### erdos-1059
- Extended annotation ranges for full 160-line coverage (0 gaps)

### erdos-1065 (major)
- Realigned all annotations/sections with expanded Lean file (8→14 Form A examples)
- Rewrote ranges to match actual 301-line file

### erdos-1089
- Extended 12 annotation ranges to include section headers
- Full 201/201 line coverage

### erdos-1097
- Extended 1 annotation to close 3-line gap
- Full 374/374 line coverage

### erdos-36
- Added missing prerequisites to observations annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)