### PR TITLE
Peer review: herons-formula (B)

### DIFF
--- a/src/data/proofs/herons-formula/review.json
+++ b/src/data/proofs/herons-formula/review.json
@@ -1,0 +1,129 @@
+{
+  "version": 1,
+  "proofId": "herons-formula",
+  "reviewDate": "2026-03-24T16:00:00Z",
+  "reviewer": "peer-reviewer-1",
+
+  "overallAssessment": {
+    "grade": "B",
+    "oneLiner": "Honest Mathlib wrapper with well-structured pedagogical content, but originalContributions are overstated and a phantom 'law of cosines connection' is claimed but never formalized.",
+    "tier": "B",
+    "tierJustification": "The main theorem (heron_formula, line 91) is a single direct call to Theorems100.heron from the Mathlib Archive. The file adds definitions, algebraic expansions proved by ring, numerical verifications by norm_num, and one substantive helper lemma (heron_product_nonneg). This is a well-organized Mathlib bridge with genuine supporting content, but the core mathematical work is imported."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "badge field in meta.json (line 20); docstring lines 19-21 of Lean file",
+      "finding": "The badge is honestly set to 'mathlib' and the Lean file docstring explicitly states 'Foundation (from Mathlib): We use Theorems100.heron from the Mathlib Archive.' This is exemplary transparency about the provenance of the main result.",
+      "recommendation": "Preserve this honest framing. It sets a good standard for other Mathlib-based entries."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "heron_product_nonneg, lines 226-238 of Lean file",
+      "finding": "The non-negativity proof is the most substantive original theorem in the file. It takes the triangle inequality hypotheses and deduces positivity of each factor via linarith, then chains mul_nonneg. This is a genuine multi-step proof with mathematical content, not a one-liner tactic call.",
+      "recommendation": "Highlight this theorem more prominently in the meta.json originalContributions as the main original proof in the file."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Lean file lines 152-211 (worked examples section)",
+      "finding": "The three worked examples (3-4-5, equilateral-2, 5-12-13) are well-chosen and pedagogically valuable. They demonstrate the formula on the most recognizable Pythagorean triples and the equilateral case, and the docstrings show the manual computation step by step.",
+      "recommendation": "Keep these examples. They serve the pedagogical goal well."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions (line 29): 'Connection to law of cosines'",
+      "finding": "No theorem in the Lean file connects Heron's formula to the law of cosines. The phrase appears in the meta.json overview.proofStrategy ('the trigonometric area formula (1/2 ab sin C) equals the Heron formula') but this is the statement of Theorems100.heron itself, which is imported, not an original contribution. The law of cosines is a separate identity (c^2 = a^2 + b^2 - 2ab cos C) that is not formalized or referenced in the file.",
+      "recommendation": "Remove 'Connection to law of cosines' from originalContributions. Replace with something accurate like 'Non-negativity proof connecting Heron product to triangle inequality' or 'Algebraic expansion of Heron product proved by ring'."
+    },
+    {
+      "severity": "minor",
+      "category": "overclaim",
+      "location": "meta.json originalContributions (line 28): 'Multiple formulations'",
+      "finding": "There is exactly one formulation of the main theorem (heron_formula, line 91), which is a direct restatement of Theorems100.heron. The definitions (semiperimeter, heron_product, triangle_area) and the algebraic expansions provide alternate ways to express the Heron product, but these are definitions and identities, not multiple formulations of the theorem. Calling definitions 'multiple formulations' stretches the term.",
+      "recommendation": "Reword to 'Computable definitions and algebraic expansions' or similar phrasing that accurately describes the contribution."
+    },
+    {
+      "severity": "minor",
+      "category": "filler",
+      "location": "heron_product_expand_alt, lines 142-146 of Lean file",
+      "finding": "This theorem proves the same algebraic identity as heron_product_expand (line 135) but with the four factors in a different order. Since multiplication is commutative, this is mathematically trivial and adds no new content. The annotation correctly calls this 'purely cosmetic.'",
+      "recommendation": "Either remove heron_product_expand_alt or explicitly note in the docstring that it is a reordering for convenience. Do not count it as a distinct contribution."
+    },
+    {
+      "severity": "minor",
+      "category": "filler",
+      "location": "triangle_area_nonneg, lines 261-266 of Lean file",
+      "finding": "This theorem's proof body is exactly 'sqrt_nonneg _'. It does not use the triangle inequality hypotheses at all -- sqrt_nonneg holds for any real number. The six hypotheses (ha, hb, hc, hab, hbc, hca) are unused, making this a misleadingly parameterized trivial fact. The theorem is true but vacuously so: it holds even for negative or zero side lengths by Mathlib's sqrt convention.",
+      "recommendation": "Either (a) remove the unnecessary triangle inequality hypotheses and note that sqrt_nonneg is unconditional, or (b) strengthen the theorem to prove triangle_area > 0 (strictly positive) for valid triangles, which would actually use the hypotheses."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "relatedProofs in meta.json: cayley-hamilton entry (lines 155-158)",
+      "finding": "The cross-reference to cayley-hamilton is listed as 'Related gallery proof' with no meaningful description. The Cayley-Hamilton theorem (about characteristic polynomials of matrices) has no mathematical relationship to Heron's formula (triangle area from side lengths). This appears to be an auto-generated placeholder.",
+      "recommendation": "Remove the cayley-hamilton entry from relatedProofs. The other cross-references (pythagorean-theorem, triangle-angle-sum, triangle-inequality, ptolemys-theorem) are all reasonable."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json overview.proofStrategy, line 43",
+      "finding": "The proofStrategy mentions 'connection to law of cosines' as part of the original contributions, but the Lean file never mentions or proves anything about the law of cosines. The 'sine area formula' used by Theorems100.heron is not the law of cosines -- they are distinct identities. This conflates two different classical results.",
+      "recommendation": "Remove the law of cosines reference from proofStrategy. The strategy should accurately describe what the file does: restate Mathlib's theorem, provide definitions, prove algebraic expansions, verify examples, and prove non-negativity."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix originalContributions in meta.json: replace 'Connection to law of cosines' (not in the Lean file) with 'Non-negativity proof via triangle inequality (heron_product_nonneg)'. Reword 'Multiple formulations' to 'Computable definitions and algebraic expansions'.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Remove the cayley-hamilton entry from relatedProofs in meta.json. It is a spurious cross-reference with no mathematical basis.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Remove the 'law of cosines' reference from overview.proofStrategy. The sine area formula is distinct from the law of cosines.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Consider strengthening triangle_area_nonneg to prove strict positivity (triangle_area > 0) for valid triangles, which would actually use the triangle inequality hypotheses. Currently the proof is sqrt_nonneg which ignores all six hypotheses.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Consider removing heron_product_expand_alt (commutative reordering of heron_product_expand) or replacing it with a genuinely different algebraic form, such as the expanded polynomial form 2a^2b^2 + 2b^2c^2 + 2c^2a^2 - a^4 - b^4 - c^4.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 5,
+    "originalityAccuracy": 6,
+    "completeness": 8,
+    "framingPrecision": 7,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 7,
+    "overall": 6.8
+  },
+
+  "suggestedBestFraming": "A pedagogical Mathlib wrapper presenting Heron's formula (Wiedijk #57) from the Mathlib Archive, with computable definitions of the semi-perimeter and Heron product, algebraic expansions proved by ring, three worked numerical examples, and an original non-negativity proof via the triangle inequality."
+}


### PR DESCRIPTION
## Summary
- Peer review of the **herons-formula** gallery entry
- **Grade: B** (overall score 6.8/10)
- **Tier: B** -- Mathlib wrapper with bridge/infrastructure content

## Key Findings
- **Positive**: Honest `mathlib` badge and transparent docstring about Mathlib provenance
- **Positive**: `heron_product_nonneg` is a genuine multi-step original proof
- **Positive**: Three well-chosen worked examples with pedagogically useful docstrings
- **Moderate**: `originalContributions` claims "Connection to law of cosines" which is not formalized in the Lean file
- **Minor**: Spurious cross-reference to cayley-hamilton (no mathematical relationship)
- **Minor**: `triangle_area_nonneg` has six unused hypotheses (proof is just `sqrt_nonneg`)
- **Minor**: `heron_product_expand_alt` is a cosmetic reordering of `heron_product_expand`

## Action Items
- 3 enricher tasks (fix originalContributions, remove spurious cross-reference, fix proofStrategy)
- 2 researcher tasks (strengthen `triangle_area_nonneg`, replace filler `heron_product_expand_alt`)

## Scores
| Dimension | Score |
|-----------|-------|
| Mathematical Substance | 5 |
| Originality Accuracy | 6 |
| Completeness | 8 |
| Framing Precision | 7 |
| Pedagogical Quality | 8 |
| Internal Consistency | 7 |
| **Overall** | **6.8** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)