### PR TITLE
Peer review: isosceles-triangle (B-)

### DIFF
--- a/src/data/proofs/isosceles-triangle/review.json
+++ b/src/data/proofs/isosceles-triangle/review.json
@@ -1,0 +1,122 @@
+{
+  "version": 1,
+  "proofId": "isosceles-triangle",
+  "reviewDate": "2026-03-24T16:00:00Z",
+  "reviewer": "peer-reviewer-1",
+
+  "overallAssessment": {
+    "grade": "B-",
+    "oneLiner": "A clean, well-documented Mathlib wrapper for the isosceles triangle theorem with excellent pedagogy but overstated originality claims.",
+    "tier": "B",
+    "tierJustification": "All four theorems delegate directly to Mathlib lemmas. The biconditional combines two Mathlib calls into an Iff pair. No original proof reasoning exists. This is Tier B: formalized using Mathlib, with the file providing pedagogical curation and API naming rather than original mathematics."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "annotations.json (all 7 annotations)",
+      "finding": "The annotations are consistently accurate, mathematically informative, and well-targeted. The explanation of the torsor/affine space setup (ann-namespace), the connection to Pappus's self-congruence argument (ann-forward), and the geometric interpretation of the vector form (ann-vector) all add genuine pedagogical value beyond what the Lean code alone communicates.",
+      "recommendation": "Preserve these annotations. They represent the strongest part of the entry."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json overview.historicalContext",
+      "finding": "The historical context covering Euclid I.5, the medieval Pons Asinorum naming, Pappus's simplification, and Proclus's commentary is accurate, well-written, and proportionate. It correctly connects the formalization to mathematical history without overclaiming.",
+      "recommendation": "Preserve. This is good mathematical exposition."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json badge field",
+      "finding": "The badge is honestly set to 'mathlib' rather than 'original' or 'verified', correctly signaling that the proof content comes from Mathlib. This is the right classification for a wrapper entry.",
+      "recommendation": "Preserve this honest badge classification."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions[1]: 'Vector space formulation via inner product geometry'",
+      "finding": "The 'vector space formulation' (angle_eq_of_norm_eq, line 118-120) is a direct one-line call to InnerProductGeometry.angle_sub_eq_angle_sub_rev_of_norm_eq. The file provides a renamed identifier and docstring, not a new formulation. Calling this an 'original contribution' misrepresents what was done.",
+      "recommendation": "Reframe as 'Pedagogical restatement of Mathlib's vector-form theorem with geometric interpretation' or remove from originalContributions and acknowledge it as a Mathlib re-export."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions[2]: 'Non-degeneracy analysis for the converse'",
+      "finding": "There is no 'analysis' of non-degeneracy in the file. The converse theorem (sides_equal_of_base_angles_equal, line 87-91) simply passes the hypothesis hnd : angle BAC != pi to Mathlib's dist_eq_of_angle_eq_angle_of_angle_ne_pi. The non-degeneracy condition is part of Mathlib's API signature, not something this file discovered or analyzed.",
+      "recommendation": "Remove from originalContributions. If desired, note in the annotations that the non-degeneracy condition is worth discussing pedagogically, but do not claim it as an original contribution."
+    },
+    {
+      "severity": "minor",
+      "category": "overclaim",
+      "location": "meta.json originalContributions[0]: 'Forward and converse directions combined into biconditional'",
+      "finding": "The biconditional (isosceles_triangle_iff, line 103-106) constructs an Iff pair from two existing theorems via the anonymous constructor. This is a legitimate, if trivial, compositional step. Calling it an 'original contribution' is a stretch but not unreasonable for a wrapper entry.",
+      "recommendation": "Acceptable as stated, but consider softening to 'Combines forward and converse into a single biconditional for downstream use' to avoid implying non-trivial proof work."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json conclusion.implications",
+      "finding": "The claim that the formalization 'connects elementary geometry to functional analysis (Hilbert spaces) and physics (quantum state spaces)' overstates the entry's contribution. The generality to arbitrary inner product spaces is inherited from Mathlib's polymorphic types, not from any design choice in this file. Any Lean theorem using these type variables automatically works in infinite-dimensional spaces.",
+      "recommendation": "Reframe to acknowledge that the generality is inherited: 'Thanks to Mathlib's formulation in arbitrary inner product spaces, the theorem automatically applies in Hilbert spaces and other infinite-dimensional settings.'"
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "IsoscelesTriangle.lean lines 124-127 (#check statements)",
+      "finding": "The four #check commands at the end serve as a verification block. While not harmful, #check does not verify proof correctness -- it only confirms the terms type-check. The section header 'Verification' (line 122) could mislead readers into thinking additional verification is happening.",
+      "recommendation": "Rename the section to 'Exports' or 'API Summary' to avoid suggesting additional verification beyond what Lean's kernel already provides."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json crossReferences vs relatedProofs",
+      "finding": "The crossReferences array (lines 118-138) and relatedProofs array (lines 149-170) contain identical content. This is redundant data that could drift out of sync during future edits.",
+      "recommendation": "Remove one of the two arrays, or document which is canonical. The crossReferences field appears to be the standard one."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Rewrite originalContributions to be honest about the Mathlib wrapper nature. Replace 'Vector space formulation via inner product geometry' with a description acknowledging the re-export. Remove 'Non-degeneracy analysis for the converse'. Soften the biconditional claim.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Reframe conclusion.implications to acknowledge that inner product space generality is inherited from Mathlib's type-polymorphic formulation, not an original design choice of this entry.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Remove the duplicate relatedProofs array (lines 149-170 of meta.json) since it is identical to crossReferences (lines 118-138).",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Rename the 'Verification' section header in the Lean file docstring and corresponding annotations to 'Exports' or 'API Summary' to avoid implying additional verification beyond Lean's kernel.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 4,
+    "originalityAccuracy": 5,
+    "completeness": 8,
+    "framingPrecision": 6,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 7,
+    "overall": 6.3
+  },
+
+  "suggestedBestFraming": "A pedagogical Mathlib wrapper that re-exports the isosceles triangle theorem (Pons Asinorum, Wiedijk #65) in four forms -- forward, converse, biconditional, and vector -- with rich historical context and careful documentation, but no original proof work beyond combining Mathlib lemmas into an Iff pair."
+}


### PR DESCRIPTION
## Summary

- Peer review of the **isosceles-triangle** gallery entry (Pons Asinorum, Wiedijk #65)
- **Grade: B-** (overall quality score: 6.3/10)
- **Tier: B** -- Mathlib wrapper with pedagogical curation
- 9 findings (3 positive, 2 moderate, 4 minor), 4 action items

## Key Findings

**Strengths**: Excellent annotations and historical context. Honest `mathlib` badge. Well-structured cross-references to 4 related gallery entries.

**Issues**: Two of three `originalContributions` are overclaims -- the "vector space formulation" is a direct Mathlib re-export, and the "non-degeneracy analysis" is just passing through a Mathlib API parameter. All four theorems are one-line Mathlib calls (the biconditional being the only one with even a trivial compositional step). The `conclusion.implications` overstates the entry's contribution to generality that is actually inherited from Mathlib's polymorphic types.

## Action Items (4)

1. **[medium]** Rewrite `originalContributions` to honestly reflect Mathlib wrapper nature (enricher)
2. **[low]** Reframe `conclusion.implications` re: inherited generality (enricher)
3. **[low]** Remove duplicate `relatedProofs` array (enricher)
4. **[low]** Rename "Verification" section to "Exports" (enricher)

## Test plan

- [ ] Verify `review.json` is valid JSON and follows the schema
- [ ] Verify `review-tracker.json` entry is consistent with review

🤖 Generated with [Claude Code](https://claude.com/claude-code)