### PR TITLE
Fix: axiom counting in scanner ignores comments

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -205,7 +205,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     const content = stripLeanComments(rawContent)
 
     sorryCount = (content.match(/\bsorry\b/g) || []).length
-    axiomCount = (rawContent.match(/^axiom /gm) || []).length
+    axiomCount = (content.match(/^axiom /gm) || []).length
 
     // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
     for (const line of content.split('\n')) {


### PR DESCRIPTION
## Fix

Use comment-stripped content for axiom declaration counting in the auditor scanner.

## Evidence

**Before**: `axiomCount = (rawContent.match(/^axiom /gm) || []).length` counted `axiom` in block comments
**After**: `axiomCount = (content.match(/^axiom /gm) || []).length` uses stripped content

Two false positives eliminated:
- `buffons-needle-oq-01-oq-01`: `axiom` inside a Lean code example in a block comment
- `borsuk-ulam-oq-03`: prose "axiom from Section XXIII redundant" at start of comment line

---
Automated fix by lean-mechanic agent.