### PR TITLE
Enrich: address peer review findings for 3 gallery entries

### DIFF
--- a/proofs/Proofs/BertrandsPostulate.lean
+++ b/proofs/Proofs/BertrandsPostulate.lean
@@ -44,7 +44,7 @@ Bertrand's Postulate has numerous applications:
 - Foundation for stronger results like the Prime Number Theorem
 - Applications in combinatorics and algorithms requiring "nearby" primes
 
-## Wiedijk's 100 Theorems: #98
+## Wiedijk's 100 Theorems: #43
 -/
 
 namespace BertrandsPostulate

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -2,7 +2,7 @@
   "id": "bertrands-postulate",
   "title": "Bertrand's Postulate",
   "slug": "bertrands-postulate",
-  "description": "For every integer n > 1, there exists a prime p such that n < p ≤ 2n. Conjectured by Bertrand (1845), first proved by Chebyshev (1852), with an elegant elementary proof by Erdős (1932).",
+  "description": "For every positive integer n, there exists a prime p such that n < p ≤ 2n. Conjectured by Bertrand (1845), first proved by Chebyshev (1852), with an elegant elementary proof by Erdős (1932).",
   "meta": {
     "author": "Chebyshev (1852), Erdős (1932)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/Bertrand.html",
@@ -32,12 +32,13 @@
       }
     ],
     "originalContributions": [
-      "Pedagogical wrapper with clear documentation",
-      "Corollaries: prime gaps are bounded, infinitude of primes via Bertrand",
-      "Connection to Prime Number Theorem explained"
+      "Pedagogical wrapper with clear documentation and historical exposition",
+      "Original derivations: infinitude of primes via Bertrand (primes_infinite_via_bertrand), no largest prime (no_largest_prime_via_bertrand)",
+      "Pedagogical restatements: prime gap bound (prime_gap_bounded), interval existence (exists_prime_between)",
+      "Expository connection to the Prime Number Theorem (commentary, not formalized)"
     ],
     "dateAdded": "2025-12-26",
-    "wiedijkNumber": 98,
+    "wiedijkNumber": 43,
     "axiomCount": 0,
     "lineCount": 165,
     "relatedProblems": [
@@ -52,7 +53,7 @@
   "overview": {
     "historicalContext": "Joseph Bertrand conjectured this result in 1845 after verifying it for all integers up to 3,000,000. He stated the conjecture in his *Traité d'Algèbre* without proof, noting that a prime always appears between $n$ and $2n-2$ for every $n$ he checked.\n\nPafnuty Chebyshev provided the first proof in 1852 using analytic methods involving what are now called the Chebyshev functions $\\theta(x) = \\sum_{p \\leq x} \\log p$ and $\\psi(x) = \\sum_{p^k \\leq x} \\log p$. He proved the stronger result that $(1 - \\epsilon)x/\\log x < \\pi(x) < (1 + \\epsilon)x/\\log x$ for large $x$ and specific constants, from which Bertrand's postulate follows.\n\nIn 1932, the 19-year-old Paul Erdős published an elegant elementary proof in *Acta Litt. Sci. Szeged* that avoided complex analysis entirely, relying instead on clever analysis of the prime factorization of $\\binom{2n}{n}$. This became his first published paper and launched his legendary mathematical career — Erdős later called it his favorite proof. The key insight: $\\binom{2n}{n} \\geq 4^n/(2n)$ (from $(1+1)^{2n} = \\sum \\binom{2n}{k}$), but if no prime lies in $(n, 2n]$, all prime power factors of $\\binom{2n}{n}$ are $\\leq n$, making the product too small to match $4^n/(2n)$ for $n \\geq 512$.\n\nThe theorem is sometimes called the 'Bertrand-Chebyshev theorem' in honor of both the conjecturer and first prover. Srinivasa Ramanujan gave another proof in his first published paper (1919), using the gamma function. Bertrand's Postulate is a stepping stone toward the Prime Number Theorem: while Bertrand guarantees at least one prime in $(n, 2n]$, the PNT (proved independently by Hadamard and de la Vallée Poussin in 1896) gives the asymptotic density $\\pi(x) \\sim x/\\log x$.",
     "problemStatement": "**Bertrand's Postulate**: For every positive integer $n$, there exists a prime $p$ such that:\n\n$$n < p \\leq 2n$$\n\nEquivalently: between any positive integer and its double, there is always at least one prime number.\n\nThis gives an explicit upper bound on prime gaps: if $p$ is prime, the next prime is at most $2p$.",
-    "text": "A 165-line formalization of Bertrand's Postulate (Wiedijk #43) with 13 declarations, 0 sorries, 0 axioms. Delegates to Mathlib's `Nat.exists_prime_lt_and_le_two_mul` which follows Erdos's elementary proof: the central binomial coefficient $\\binom{2n}{n} \\geq 4^n/(2n)$ has a prime factorization too small if no prime lies in $(n,2n]$, giving a contradiction for $n \\geq 512$. Small cases use an explicit descending chain: 983, 491, 241, ..., 3, 2. Provides `bertrand_postulate` as a clean restatement, `prime_gap_bound` ($p_{k+1} < 2p_k$), and concrete verifications (e.g., prime 7 between 4 and 8). Commentary connects to the Prime Number Theorem ($\\pi(x) \\sim x/\\log x$) and Erdos's first published paper (age 19).",
+    "text": "A 165-line formalization of Bertrand's Postulate (Wiedijk #43) with 7 theorems, 0 sorries, 0 axioms. Delegates to Mathlib's `Nat.exists_prime_lt_and_le_two_mul` which follows Erdos's elementary proof: the central binomial coefficient $\\binom{2n}{n} \\geq 4^n/(2n)$ has a prime factorization too small if no prime lies in $(n,2n]$, giving a contradiction for $n \\geq 512$. Small cases use an explicit descending chain: 983, 491, 241, ..., 3, 2. Provides `bertrand_postulate` as a clean restatement, `prime_gap_bounded` ($p_{k+1} < 2p_k$), and illustrative commentary on concrete instances (e.g., prime 7 between 4 and 8, though these are not machine-checked). Commentary connects to the Prime Number Theorem ($\\pi(x) \\sim x/\\log x$) and Erdos's first published paper (age 19).",
     "proofStrategy": "The Mathlib proof follows Erdős's elementary approach:\n\n1. **Central Binomial Coefficient**: Analyze $\\binom{2n}{n} = \\frac{(2n)!}{(n!)^2}$\n\n2. **Prime Factorization**: Examine which primes divide $\\binom{2n}{n}$ and with what multiplicity\n\n3. **Upper Bound**: Show that if no prime exists in $(n, 2n]$, then the prime factorization of $\\binom{2n}{n}$ is \"too small\"\n\n4. **Lower Bound**: Use the inequality $4^n / (2n) < \\binom{2n}{n}$\n\n5. **Contradiction**: For large $n$ (specifically $n \\geq 512$), these bounds conflict\n\n6. **Small Cases**: Handle $n < 512$ by exhibiting an explicit descending chain of primes:\n   983, 491, 241, 127, 61, 31, 17, 11, 7, 5, 3, 2\n   where each prime is more than half but at most double the next.",
     "keyInsights": [
       "The central binomial coefficient $\\binom{2n}{n}$ encodes information about primes in $(n, 2n]$",
@@ -73,7 +74,7 @@
       "title": "Imports and Historical Context",
       "startLine": 1,
       "endLine": 51,
-      "summary": "Import of `Mathlib.NumberTheory.Bertrand` and `Mathlib.Tactic`. Comprehensive docstring covering the problem statement, historical development (Bertrand 1845, Chebyshev 1852, Erdős 1932), proof approach via Mathlib delegation, and connections to prime gap theory. Namespace `BertrandsPostulate` opens `Nat`.",
+      "summary": "Import of `Mathlib.NumberTheory.Bertrand` and `Mathlib.Tactic`. Comprehensive docstring covering the problem statement, historical development (Bertrand 1845, Chebyshev 1852, Erdős 1932), proof approach via Mathlib delegation, and connections to prime gap theory. Namespace `BertrandsPostulate` is opened (no `open Nat`).",
       "mathContext": "Three key historical proofs: Bertrand conjectured $\\forall n, \\exists p \\in (n, 2n]$ prime after checking $n \\leq 3{,}000{,}000$; Chebyshev proved it analytically via $\\vartheta(x) = \\sum_{p \\leq x} \\log p$; Erdős gave an elementary proof using $\\binom{2n}{n}$ and the central binomial coefficient."
     },
     {
@@ -121,8 +122,8 @@
       "title": "Key Theorems Summary",
       "startLine": 156,
       "endLine": 165,
-      "summary": "Type-checks all six theorems via #check and closes the BertrandsPostulate namespace.",
-      "mathContext": "Verifies: `bertrand_postulate`, `bertrand`, `exists_prime_between`, `prime_gap_bounded`, `primes_infinite_via_bertrand`, `no_largest_prime_via_bertrand`."
+      "summary": "Type-checks six of the seven theorems via #check (bertrand_large is omitted) and closes the BertrandsPostulate namespace.",
+      "mathContext": "Verifies: `bertrand_postulate`, `bertrand`, `exists_prime_between`, `prime_gap_bounded`, `primes_infinite_via_bertrand`, `no_largest_prime_via_bertrand`. The seventh theorem `bertrand_large` is not #checked here."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/bertrands-postulate/review.json
+++ b/src/data/proofs/bertrands-postulate/review.json
@@ -111,21 +111,21 @@
       "priority": "high",
       "target": "enricher",
       "description": "Fix wiedijkNumber from 98 to 43 in meta.json. Update Lean file docstring line 47 from '#98' to '#43'. Bertrand's Postulate is Wiedijk #43, not #98.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",
       "priority": "high",
       "target": "enricher",
       "description": "Fix overview.text: change '13 declarations' to '7 theorems'. Fix 'prime_gap_bound' to 'prime_gap_bounded'. Remove or qualify the claim about 'concrete verifications' since the examples section is comments-only.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-3",
       "priority": "medium",
       "target": "enricher",
       "description": "Remove 'opens Nat' from sections[0].summary. Fix sections[5] description to note 6 of 7 theorems are #checked (bertrand_large is omitted).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",
@@ -139,7 +139,7 @@
       "priority": "medium",
       "target": "enricher",
       "description": "Reframe originalContributions to distinguish genuine derivations (primes_infinite_via_bertrand, no_largest_prime_via_bertrand) from trivial restatements (exists_prime_between, prime_gap_bounded) and commentary (PNT connection). Fix description 'n > 1' to 'n >= 1' to match Lean.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-6",


### PR DESCRIPTION
## Summary

Addresses open enricher action items from peer reviews of three gallery entries:

### fundamental-arithmetic (5 items)
- Rewrite originalContributions to reflect actual content
- Reframe proofStrategy to clarify Mathlib vs original content
- Downgrade nat_is_ufm annotation to 'supporting'
- Remove duplicate relatedProofs array
- Add 6 missing mathlibDependencies

### cramers-rule (4 items)
- Fix 3 factual errors in overview.text: Wiedijk number, false 3x3/native_decide claims
- Separate genuine contributions from Mathlib wrappers
- Remove weak cross-references
- Fix theoremCount

### bertrands-postulate (4 items)
- Fix Wiedijk number from 98 to 43
- Fix declaration count, theorem name, qualify commentary examples
- Fix section metadata (false 'open Nat' claim, missing #check note)
- Reframe originalContributions

All 13 enricher review action items marked resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)