### PR TITLE
Research: erdos-1089 - Axiom elimination (13→10), fix build failures

### DIFF
--- a/proofs/Proofs/Erdos1089Problem.lean
+++ b/proofs/Proofs/Erdos1089Problem.lean
@@ -45,12 +45,12 @@ Points in d-dimensional Euclidean space and their pairwise distances.
 abbrev Point (d : ℕ) := EuclideanSpace ℝ (Fin d)
 
 /-- Euclidean distance between two points -/
-noncomputable def dist {d : ℕ} (p q : Point d) : ℝ :=
+noncomputable def eucDist {d : ℕ} (p q : Point d) : ℝ :=
   ‖p - q‖
 
 /-- The set of distinct distances determined by a point set -/
 noncomputable def distinctDistances {d : ℕ} (P : Finset (Point d)) : Finset ℝ :=
-  (P.product P).image (fun (p, q) => dist p q) |>.filter (· > 0)
+  (P.product P).image (fun (p, q) => eucDist p q) |>.filter (· > 0)
 
 /-- Number of distinct distances -/
 noncomputable def numDistinctDistances {d : ℕ} (P : Finset (Point d)) : ℕ :=
@@ -102,12 +102,26 @@ axiom g_d_2 : ∀ d ≥ 1, g d 2 = 3
 g_d(n) ≫ d^{n-1} via cube construction.
 -/
 
-/-- The vertices of the d-dimensional unit cube.
-    Axiomatized since it requires embedding {0,1}^d into ℝ^d. -/
-axiom cubeVertices (d : ℕ) : Finset (Point d)
+/-- The vertices of the d-dimensional unit cube: all points with coordinates in {0, 1}.
+    Constructed by mapping each function Fin d → Fin 2 to a point in ℝ^d. -/
+noncomputable def cubeVertices (d : ℕ) : Finset (Point d) :=
+  Finset.univ.image (fun (f : Fin d → Fin 2) =>
+    (EuclideanSpace.equiv (Fin d) ℝ).symm (fun i => ((f i : ℕ) : ℝ)))
+
+private lemma cubeVertices_injective (d : ℕ) :
+    Function.Injective (fun (f : Fin d → Fin 2) =>
+      (EuclideanSpace.equiv (Fin d) ℝ).symm (fun i => ((f i : ℕ) : ℝ))) := by
+  intro f₁ f₂ hf
+  have h : (fun i => ((f₁ i : ℕ) : ℝ)) = (fun i => ((f₂ i : ℕ) : ℝ)) :=
+    (EuclideanSpace.equiv (Fin d) ℝ).symm.injective hf
+  funext i
+  have hi := congr_fun h i
+  exact Fin.ext (Nat.cast_inj.mp hi)
 
 /-- Cube has 2^d vertices -/
-axiom cube_card : ∀ d : ℕ, (cubeVertices d).card = 2^d
+theorem cube_card (d : ℕ) : (cubeVertices d).card = 2 ^ d := by
+  simp only [cubeVertices, Finset.card_image_of_injective _ (cubeVertices_injective d),
+             Finset.card_univ, Fintype.card_fun, Fintype.card_fin]
 
 /-- Cube vertices determine at most d distinct distances -/
 axiom cube_distances :
@@ -154,7 +168,10 @@ def ratioIsBounded (n : ℕ) : Prop :=
 theorem ratio_bounded_below (n : ℕ) (hn : n ≥ 2) :
     ∃ c : ℝ, c > 0 ∧ ∀ d ≥ 1, gRatio d n ≥ c := by
   obtain ⟨c, hc, h⟩ := erdos_lower_bound n hn
-  exact ⟨c, hc, fun d hd => by simp only [gRatio]; linarith [h d hd]⟩
+  exact ⟨c, hc, fun d hd => by
+    simp only [gRatio]
+    rw [ge_iff_le, le_div_iff₀ (by positivity : (d : ℝ) ^ (n - 1) > 0)]
+    linarith [h d hd]⟩
 
 /-
 ## Monotonicity Properties
@@ -162,9 +179,30 @@ theorem ratio_bounded_below (n : ℕ) (hn : n ≥ 2) :
 How g_d(n) changes with d and n.
 -/
 
-/-- g_d(n) is increasing in n -/
-axiom g_mono_n :
-  ∀ d n₁ n₂ : ℕ, n₁ ≤ n₂ → g d n₁ ≤ g d n₂
+/-- g_d(n) is increasing in n.
+    Proof: If every m-point set has ≥ n₂ distances, it has ≥ n₁ distances (for n₁ ≤ n₂).
+    So the threshold set for n₂ is a subset of the threshold set for n₁,
+    and sInf of the superset ≤ sInf of the subset. -/
+theorem g_mono_n :
+    ∀ d n₁ n₂ : ℕ, n₁ ≤ n₂ → g d n₁ ≤ g d n₂ := by
+  intro d n₁ n₂ hn
+  by_cases hn2 : n₂ = 0
+  · have hn1 : n₁ = 0 := by omega
+    subst hn1; subst hn2
+    exact le_refl _
+  · -- n₂ ≥ 1, so g_well_defined gives nonemptiness of the n₂ threshold set
+    obtain ⟨m, hm⟩ := g_well_defined d n₂ (by omega)
+    -- The threshold set for n₂ is nonempty
+    have hne : Set.Nonempty {m : ℕ | ∀ P : Finset (Point d), P.card = m → determinesNDistances P n₂} :=
+      ⟨m, hm⟩
+    -- g d n₂ is in the n₂ threshold set (Nat.sInf_mem for nonempty sets)
+    have hmem_n2 : ∀ P : Finset (Point d), P.card = g d n₂ → determinesNDistances P n₂ :=
+      Nat.sInf_mem hne
+    -- g d n₂ is also in the n₁ threshold set (since n₁ ≤ n₂)
+    have hmem_n1 : g d n₂ ∈ {m : ℕ | ∀ P : Finset (Point d), P.card = m → determinesNDistances P n₁} :=
+      fun P hP => le_trans hn (hmem_n2 P hP)
+    -- sInf of n₁ set ≤ g d n₂ = sInf of n₂ set
+    exact Nat.sInf_le hmem_n1
 
 /-- g_d(n) is generally increasing in d -/
 axiom g_mono_d :

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -48,26 +48,24 @@
     "originalContributions": [
       "g_d(n) threshold function definition via Nat.sInf",
       "distinctDistances and numDistinctDistances via Finset operations",
-      "Cube construction axiomatized with vertex count and distance bound",
-      "ratio_bounded_below genuinely proved from Erdős lower bound",
+      "Cube vertices constructed as Fin d → Fin 2 mapped to EuclideanSpace (proved, not axiomatized)",
+      "cube_card proved: 2^d vertices via Fintype.card_fun",
+      "g_mono_n proved: monotonicity in n via Nat.sInf_le and g_well_defined",
+      "ratio_bounded_below genuinely proved from Erdős lower bound (with division reasoning)",
       "f_d(n) inverse function and g-f relationship axiomatized",
-      "Monotonicity properties in both d and n axiomatized",
       "erdos1089Conjecture formalized via Filter.Tendsto"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 13,
+    "axiomCount": 10,
     "assumptions": [
       "g_well_defined: g_d(n) is finite for n ≥ 1",
       "g_1_3: g_1(3) = 4",
       "g_2_3: g_2(3) = 6",
       "g_3_3: g_3(3) = 7 (Croft 1962)",
       "g_d_2: g_d(2) = 3 for d ≥ 1",
-      "cubeVertices: existence of cube vertex set in ℝ^d",
-      "cube_card: cube has 2^d vertices",
       "cube_distances: cube vertices have ≤ d distinct distances",
       "erdos_lower_bound: g_d(n) ≥ c·d^{n-1} for n ≥ 2",
       "erdos_straus_upper_bound: g_d(n) ≤ c^{d^{1-b_n}} for n ≥ 2",
-      "g_mono_n: g_d(n) increasing in n",
       "g_mono_d: g_d(n) increasing in d for n ≥ 2",
       "g_f_relationship: g_d(n) = inf{m : f_d(m) ≥ n}"
     ],
@@ -78,7 +76,7 @@
       "Threshold functions and extremal combinatorics",
       "Filter-based limits in Lean (Filter.Tendsto)"
     ],
-    "lineCount": 201,
+    "lineCount": 239,
     "relatedProblems": [
       {
         "id": "erdos-1083",
@@ -290,12 +288,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 201,
+    "lineCount": 239,
     "structureCount": 0,
-    "axiomCount": 13,
-    "theoremCount": 3,
-    "lemmaCount": 0,
-    "defCount": 10,
+    "axiomCount": 10,
+    "theoremCount": 5,
+    "lemmaCount": 1,
+    "defCount": 11,
     "imports": [
       "Mathlib"
     ],


### PR DESCRIPTION
## Summary
- Eliminated 3 axioms from `Erdos1089Problem.lean` (13→10)
- Fixed 2 pre-existing build failures that prevented compilation

## Axiom Eliminations

### cubeVertices (axiom → def)
Constructed the d-dimensional unit cube vertices as `Fin d → Fin 2` mapped through `EuclideanSpace.equiv`. Previously axiomatized as an opaque `Finset (Point d)`.

### cube_card (axiom → theorem)
Proved `(cubeVertices d).card = 2^d` using `Finset.card_image_of_injective` and `Fintype.card_fun`. Injectivity proved via `Equiv.symm.injective` and `Nat.cast_inj`.

### g_mono_n (axiom → theorem)
Proved monotonicity of `g d n` in `n`: if n₁ ≤ n₂ then g(d,n₁) ≤ g(d,n₂). Uses `Nat.sInf_mem` (threshold set membership) + `Nat.sInf_le` (subset monotonicity) + `g_well_defined` for nonemptiness.

## Bug Fixes

### dist ambiguity (pre-existing)
Renamed local `dist` to `eucDist` to resolve ambiguity with Mathlib's `Dist.dist`.

### ratio_bounded_below (pre-existing)
Replaced broken `linarith` with `ge_iff_le` + `le_div_iff₀` + `positivity` for proper division reasoning.

## Build Status
Docker build passes. Only pre-existing `sorry`s remain (g_d_1, cube_lower_bound).

## Files Modified
- `proofs/Proofs/Erdos1089Problem.lean` - Main proof file
- `src/data/proofs/erdos-1089/meta.json` - Gallery metadata (axiomCount 13→10)

🤖 Generated by researcher-1