### PR TITLE
Audit: batch fix sorry counts for 4 proofs

### DIFF
--- a/src/data/proofs/erdos-417/meta.json
+++ b/src/data/proofs/erdos-417/meta.json
@@ -15,8 +15,8 @@
       "counting-functions",
       "asymptotic-analysis"
     ],
-    "badge": "formalized",
-    "sorries": 4,
+    "badge": "axiom",
+    "sorries": 2,
     "erdosNumber": 417,
     "erdosUrl": "https://erdosproblems.com/417",
     "erdosProblemStatus": "open",
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 220,
-    "assumptions": "3 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős first posed this problem in [Er79e], asking about two natural counting functions for Euler's totient values. Given the set of all totient values, one can count how many appear among outputs of small inputs ($V'(x)$) versus how many totient values exist up to $x$ regardless of input size ($V(x)$). The question is whether these two counts grow at comparable rates.\n\nThe problem was revisited in Erdős and Graham [ErGr80] in their influential monograph on combinatorial number theory. In [Er98], Erdős went further and conjectured that $V(x)/V'(x)$ may actually tend to infinity, suggesting that the vast majority of totient values at most $x$ come from inputs much larger than $x$. This would be a striking statement about the structure of the totient function's range.\n\nThe problem connects to deep results on totient value density. Pillai (1929) first showed $V(x) = o(x)$. Erdős (1935) proved $V(x) \\sim cx/\\log x$. Ford (1998) determined the precise asymptotics: $V(x) = \\frac{x}{\\log x} \\exp(C_1(\\log_3 x)^2 + C_2 \\log_3 x + C_3)$. However, the relationship between $V(x)$ and $V'(x)$ remains open, as it requires understanding the **smallest preimage function** $m^*(n) = \\min\\{m : \\varphi(m) = n\\}$. Related questions appear in Problem #416, which concerns the structure of the totient range more directly.",

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 695,
     "erdosUrl": "https://erdosproblems.com/695",
     "erdosProblemStatus": "open",
@@ -67,7 +67,7 @@
       "Lean 4 / Mathlib (Filter.Tendsto, Asymptotics.IsLittleO, Nat.Prime)"
     ],
     "lineCount": 203,
-    "assumptions": "6 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "assumptions": "6 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1979 [Er79e]. Prime chains arise from the multiplicative structure of cyclic groups: if p_{i+1} ≡ 1 (mod p_i), then Z/p_{i+1}Z contains a cyclic subgroup of order p_i.\n\nFord, Konyagin, and Luca [FKL10] conducted an extensive study of prime chain growth, establishing various bounds. The problem connects to Linnik's theorem on the least prime in arithmetic progressions.\n\nRelated: OEIS A061092, Cunningham chains. Cunningham chains, studied by A.J.C. Cunningham in 1881, are special prime chains of the form p, 2p+1, 4p+3, ... where each term is 2·(previous term)+1; these satisfy the divisibility condition and are the subject of longstanding conjectures about their unbounded length. Linnik's theorem (1944) guarantees the existence of primes in arithmetic progressions, and its quantitative form (Linnik's constant L, conjectured to equal 2) directly controls the greedy construction of prime chains.",

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -18,13 +18,13 @@
       "coprime-residues"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 854,
     "erdosUrl": "https://erdosproblems.com/854",
     "erdosProblemStatus": "open",
     "axiomCount": 9,
     "lineCount": 113,
-    "assumptions": "9 axiom declarations: nthPrime (k-th prime), nthPrime_prime, nthPrime_mono, nthPrime_vals, gaps_even, maxGap_bound, lacampagne_selfridge_counterexample, ErdosProblem854_missing_gap_growth, ErdosProblem854_many_gaps",
+    "assumptions": "9 axiom(s) and 4 sorry(s). Axioms: nthPrime, nthPrime_prime, nthPrime_mono, nthPrime_vals, gaps_even, maxGap_bound, lacampagne_selfridge_counterexample, ErdosProblem854_missing_gap_growth, ErdosProblem854_many_gaps.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
Batch audit fixes for sorry count mismatches and badge corrections.

| Proof | sorries (before→after) | Other fixes |
|-------|----------------------|-------------|
| erdos-854 | 5→**4** | — |
| erdos-695 | 4→**3** | — |
| erdos-5 | 0→**1** | Fix axiom name (merikoski→hildebrand_maier) |
| erdos-417 | 4→**2** | Badge: formalized→axiom (has 3 axioms) |

All counts verified against Lean source files.

## Test plan
- [ ] Verify `pnpm build` succeeds
- [ ] Confirm all meta.json files are valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)