### PR TITLE
Research: erdos-265 - prove cantorSeq_rational_sum (8→7 axioms)

### DIFF
--- a/proofs/Proofs/Erdos265Problem.lean
+++ b/proofs/Proofs/Erdos265Problem.lean
@@ -16,6 +16,7 @@ Reference: https://erdosproblems.com/265
 -/
 
 import Mathlib
+import Proofs.TriangularNumberReciprocals
 
 namespace Erdos265
 
@@ -61,9 +62,24 @@ theorem cantorSeq_increasing : ∀ n ≥ 1, cantorSeq n < cantorSeq (n + 1) := b
   ring_nf
   omega
 
-/-- Cantor's sequence has rational reciprocal sum -/
-axiom cantorSeq_rational_sum :
-  ∃ q : ℚ, reciprocalSum cantorSeq = q
+/-- Cantor's sequence has rational reciprocal sum.
+    Proof: cantorSeq n = n(n+1)/2 = triangular n, so ∑ 1/cantorSeq n = ∑ 2/(n(n+1)) = 2.
+    Uses the telescoping series proof from TriangularNumberReciprocals. -/
+theorem cantorSeq_rational_sum :
+    ∃ q : ℚ, reciprocalSum cantorSeq = q := by
+  refine ⟨2, ?_⟩
+  unfold reciprocalSum
+  -- Show the functions are pointwise equal
+  have key : (fun n : ℕ => (1 : ℝ) / ↑(cantorSeq n)) =
+             (fun n : ℕ => if n = 0 then 0 else (2 : ℝ) / (↑n * (↑n + 1))) := by
+    ext n
+    by_cases hn : n = 0
+    · simp [hn, cantorSeq]
+    · simp only [hn, ↓reduceIte]
+      -- cantorSeq n = triangular n (definitionally equal: n*(n+1)/2)
+      exact TriangularNumberReciprocals.reciprocal_triangular n hn
+  rw [key, TriangularNumberReciprocals.tsum_reciprocals_triangular]
+  norm_num
 
 /-- Cantor's sequence has rational shifted reciprocal sum -/
 axiom cantorSeq_shifted_rational :

--- a/proofs/Proofs/TriangularNumberReciprocals.lean
+++ b/proofs/Proofs/TriangularNumberReciprocals.lean
@@ -88,6 +88,7 @@ theorem partial_fraction' (n : ℕ) (hn : n ≠ 0) :
   have hn1 : (n + 1 : ℝ) ≠ 0 := by positivity
   have hnn1 : (n : ℝ) * (n + 1) ≠ 0 := by positivity
   field_simp
+  ring
 
 /-! ## Telescoping Finite Sums
 
@@ -122,8 +123,10 @@ theorem finite_sum_reciprocals (n : ℕ) (hn : n ≠ 0) :
       rw [this, Finset.sum_union]
       · rw [Finset.sum_singleton, ih hm]
         have hm1 : (m + 1 : ℝ) ≠ 0 := by positivity
+        have hm2 : (m + 2 : ℝ) ≠ 0 := by positivity
         have hprod : (m + 1 : ℝ) * (m + 1 + 1) ≠ 0 := by positivity
         field_simp
+        push_cast
         ring
       · simp only [Finset.disjoint_singleton_right, Finset.mem_Icc, not_and, not_le]
         intro _
@@ -153,8 +156,8 @@ theorem summable_reciprocal_product : Summable (fun n : ℕ => (1 : ℝ) / ((n :
     · positivity
   have h_pseries : Summable fun n : ℕ => (1 : ℝ) / (n : ℝ)^2 := by
     have h := Real.summable_nat_rpow_inv.mpr (by norm_num : (1 : ℝ) < 2)
-    simp only [Real.rpow_natCast, ← one_div] at h
-    exact_mod_cast h
+    convert h using 1
+    ext n; simp [one_div]
   exact Summable.of_nonneg_of_le h_nonneg h_bound h_pseries
 
 /-- The series 2/(n(n+1)) is summable. -/
@@ -232,13 +235,13 @@ theorem sum_reciprocals_triangular :
       = |-(2 / (n : ℝ))| := by ring_nf
     _ = (2 : ℝ) / n := by rw [abs_neg, abs_of_pos (by positivity)]
     _ < ε := by
-        rw [div_lt_iff hn_pos]
+        rw [div_lt_iff₀ hn_pos]
         have h1 : (n : ℝ) ≥ Nat.ceil (2 / ε) + 1 := by exact_mod_cast hn
         have h2 : (Nat.ceil (2 / ε) : ℝ) ≥ 2 / ε := Nat.le_ceil _
         have h3 : (2 : ℝ) / ε < n := by linarith
         have h4 : (2 : ℝ) < ε * n := by
           rw [mul_comm]
-          exact (div_lt_iff hε).mp h3
+          exact (div_lt_iff₀ hε).mp h3
         linarith
 
 /-- The tsum version of the main theorem. -/


### PR DESCRIPTION
## Summary
- Proved `cantorSeq_rational_sum` in `Erdos265Problem.lean` (axioms 8→7)
- Fixed `TriangularNumberReciprocals.lean` Mathlib compatibility issues (4 fixes)

## Axiom Elimination

### cantorSeq_rational_sum (axiom → theorem)
Proved that Cantor's sequence `n*(n+1)/2` has rational reciprocal sum (= 2) by connecting to the existing `TriangularNumberReciprocals.tsum_reciprocals_triangular` proof.

Key insight: `cantorSeq` and `triangular` are definitionally equal (`n*(n+1)/2`), so `reciprocal_triangular` applies directly.

## Bug Fixes (TriangularNumberReciprocals.lean)
- `partial_fraction'`: added `ring` after `field_simp` (Mathlib API change)
- `finite_sum_reciprocals`: added `push_cast` before `ring` for `Nat.cast` normalization
- `summable_reciprocal_product`: fixed unused simp argument
- `sum_reciprocals_triangular`: `div_lt_iff` → `div_lt_iff₀`

## Build Status
Docker build passes. 0 sorries in Erdos265Problem.lean.

🤖 Generated by researcher-1