### PR TITLE
Fix: lineCount metadata in 8 gallery entries

### DIFF
--- a/src/data/proofs/erdos-1105/meta.json
+++ b/src/data/proofs/erdos-1105/meta.json
@@ -60,7 +60,7 @@
       "turan definition: extremal graph theory connection"
     ],
     "axiomCount": 8,
-    "lineCount": 275,
+    "lineCount": 291,
     "assumptions": "8 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -323,7 +323,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos1105",
-    "lineCount": 275,
+    "lineCount": 291,
     "axiomCount": 8,
     "theoremCount": 3,
     "definitionCount": 25

--- a/src/data/proofs/erdos-1140/meta.json
+++ b/src/data/proofs/erdos-1140/meta.json
@@ -71,7 +71,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 219,
+    "lineCount": 227,
     "assumptions": "2 axiom(s): epure_gica_mod_1 (mod 1 classification), epure_gica_mod_3 (mod 3 finiteness). erdos_1140_finite now proved from these two axioms."
   },
   "overview": {
@@ -252,7 +252,7 @@
     ],
     "opens": [],
     "namespace": "Erdos1140",
-    "lineCount": 219,
+    "lineCount": 227,
     "axiomCount": 2,
     "theoremCount": 19,
     "definitionCount": 2

--- a/src/data/proofs/erdos-197/meta.json
+++ b/src/data/proofs/erdos-197/meta.json
@@ -55,7 +55,7 @@
       "erdos_197_open_question theorem: the main conjecture"
     ],
     "axiomCount": 2,
-    "lineCount": 295,
+    "lineCount": 307,
     "assumptions": "2 axioms: erdos_graham_three_sets (deep combinatorial result), stanley_avoids_3AP (greedy construction). Previously 5 axioms; 3 eliminated by proving powers_of_2_avoid_3AP, erdos_197_conjecture (from classical logic), and removing malformed erdos_197_not_finite_checkable."
   },
   "overview": {
@@ -183,7 +183,7 @@
       "Function"
     ],
     "namespace": "Erdos197",
-    "lineCount": 295,
+    "lineCount": 307,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 10

--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -38,7 +38,7 @@
       "Formal statement of irrationality threshold at β = 2"
     ],
     "axiomCount": 8,
-    "lineCount": 205,
+    "lineCount": 217,
     "assumptions": "9 axioms: cantorSeq_rational_sum, cantorSeq_shifted_rational, erdos_265_singleExp_achievable, and 6 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -148,7 +148,7 @@
     ],
     "opens": [],
     "namespace": "Erdos265",
-    "lineCount": 205,
+    "lineCount": 217,
     "axiomCount": 8,
     "theoremCount": 2,
     "definitionCount": 11

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 428,
+    "lineCount": 446,
     "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), merikoski_bounded_gaps (S has bounded gaps, 2020). 0 sorries. Proves 19 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_unbounded, westzynthius_implies_frequently_large. Gallery metadata now points to main formalization (Erdos5PrimeGaps.lean) instead of legacy stub.",
     "mathlib_version": "4.26.0"
   },
@@ -189,7 +189,7 @@
       "Topology"
     ],
     "namespace": "Erdos5",
-    "lineCount": 428,
+    "lineCount": 446,
     "axiomCount": 3,
     "theoremCount": 19,
     "definitionCount": 9

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/638",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 95,
+    "lineCount": 107,
     "assumptions": "1 axiom: ramsey_triangle (classical Ramsey theorem for triangles). complete_graphs_ramsey proved from ramsey_triangle. triangle_ramsey_mono proved via Fin.castLE injection.",
     "mathlib_version": "4.26.0"
   },
@@ -106,7 +106,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 95,
+    "lineCount": 107,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 5

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",
     "axiomCount": 6,
-    "lineCount": 128,
+    "lineCount": 175,
     "assumptions": "6 axioms: f_upper_bound, f_lower_bound, f_semiprime, f_30, erdos_700_question2, erdos_700_question3. fBinom now defined (not axiomatized). f_prime_square proved from f_lower_bound.",
     "mathlib_version": "4.26.0"
   },
@@ -148,7 +148,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 128,
+    "lineCount": 175,
     "axiomCount": 6,
     "theoremCount": 2,
     "definitionCount": 3

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -35,7 +35,7 @@
       "erdos_960_summary (proved): combines conjecture with r=2 case"
     ],
     "axiomCount": 1,
-    "lineCount": 153,
+    "lineCount": 164,
     "assumptions": "1 axiom(s) and 5 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
@@ -143,7 +143,7 @@
     ],
     "opens": [],
     "namespace": "Erdos960",
-    "lineCount": 153,
+    "lineCount": 164,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 7


### PR DESCRIPTION
## Fix

Update stale `lineCount` values in 8 gallery meta.json files to match actual Lean source file lengths.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| erdos-1105 | 275 | 291 |
| erdos-1140 | 219 | 227 |
| erdos-197 | 295 | 307 |
| erdos-265 | 205 | 217 |
| erdos-5 | 428 | 446 |
| erdos-638 | 95 | 107 |
| erdos-700 | 128 | 175 |
| erdos-960 | 153 | 164 |

All mismatches verified by `wc -l` on the actual `.lean` files. `pnpm build` passes.

---
Automated fix by lean-mechanic agent.