### PR TITLE
Audit: mark 6 newly audited proofs as clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9151,6 +9151,42 @@
       "lastAudited": "2026-03-24T13:57:26Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-953": {
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T18:15:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1095-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T18:15:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1126-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T18:15:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1139": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T18:15:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1165": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T18:15:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-490-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T18:15:35Z",
+      "result": "clean",
+      "issues": []
     }
   }
 }


### PR DESCRIPTION
## Summary
Verified 6 previously unaudited proofs - all pass integrity checks.

| Proof | Status | Axioms | Sorries | Result |
|-------|--------|--------|---------|--------|
| erdos-1095-oq-01 | axiomatized | 4 | 0 | clean |
| erdos-1126-oq-01 | axiomatized | 6 | 1 | clean |
| erdos-1139 | axiomatized | 2 | 3 | clean |
| erdos-1165 | axiomatized | 8 | 0 | clean |
| erdos-490-oq-01 | axiomatized | 3 | 0 | clean |
| erdos-953 | axiomatized | 8 | 0 | clean |

All sorry counts, axiom counts, and True stub counts match between meta.json and Lean source files.

## Test plan
- [ ] Verify `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)