### PR TITLE
Enrich: erdos-379, erdos-851, cauchy-schwarz-oq-03, de-moivre-oq-02

### DIFF
--- a/src/data/proofs/erdos-6/annotations.json
+++ b/src/data/proofs/erdos-6/annotations.json
@@ -15,7 +15,12 @@
       "prime enumeration",
       "Nat.nth"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.nth",
+      "Nat.Prime",
+      "Set.Infinite",
+      "Nat.infinite_setOf_prime"
+    ]
   },
   {
     "id": "ann-e6-prime-gap",
@@ -34,7 +39,12 @@
       "twin primes",
       "bounded gaps"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "nthPrime (Erdos6.nthPrime)",
+      "Nat.nth Nat.Prime",
+      "Nat.sub (natural number subtraction)",
+      "prime enumeration via Nat.nth"
+    ]
   },
   {
     "id": "ann-e6-primes-infinite",
@@ -52,7 +62,12 @@
       "infinitude of primes"
     ],
     "mathContext": "See annotation content for formal details of primes are infinite",
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.infinite_setOf_prime",
+      "Set.Infinite",
+      "Nat.Prime",
+      "Euclid's theorem on the infinitude of primes"
+    ]
   },
   {
     "id": "ann-e6-strict-mono",
@@ -70,7 +85,12 @@
       "StrictMono"
     ],
     "mathContext": "See annotation content for formal details of strict monotonicity",
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.nth_strictMono",
+      "StrictMono",
+      "Set.Infinite",
+      "Nat.infinite_setOf_prime"
+    ]
   },
   {
     "id": "ann-e6-gap-pos",
@@ -88,7 +108,12 @@
       "omega tactic"
     ],
     "mathContext": "See annotation content for formal details of prime gaps are positive",
-    "prerequisites": []
+    "prerequisites": [
+      "nthPrime_strictMono",
+      "Nat.nth_strictMono",
+      "omega (Lean 4 linear arithmetic tactic)",
+      "Nat.sub_pos_of_lt"
+    ]
   },
   {
     "id": "ann-e6-first-gaps",
@@ -106,7 +131,12 @@
       "simp"
     ],
     "mathContext": "See annotation content for formal details of first prime gaps",
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.nth_prime_zero_eq_two",
+      "Nat.nth_prime_one_eq_three",
+      "Nat.nth_prime_two_eq_five",
+      "simp (Lean 4 simplification tactic)"
+    ]
   },
   {
     "id": "ann-e6-increasing-gaps",
@@ -124,7 +154,12 @@
       "monotone sequences",
       "prime gap patterns"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "primeGap (Erdos6.primeGap)",
+      "StrictMono",
+      "Finset.range (for universal quantification over indices)",
+      "strict inequality on natural numbers"
+    ]
   },
   {
     "id": "ann-e6-decreasing-gaps",
@@ -141,7 +176,12 @@
       "monotone sequences"
     ],
     "mathContext": "See annotation content for formal details of decreasing gap sequences",
-    "prerequisites": []
+    "prerequisites": [
+      "primeGap (Erdos6.primeGap)",
+      "HasIncreasingGaps (symmetric definition)",
+      "strict inequality on natural numbers",
+      "StrictAntiMono"
+    ]
   },
   {
     "id": "ann-e6-infinitely-many",
@@ -159,7 +199,12 @@
       "infinite sets",
       "cofinality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "HasIncreasingGaps (Erdos6.HasIncreasingGaps)",
+      "HasDecreasingGaps (Erdos6.HasDecreasingGaps)",
+      "existential quantifier over unbounded naturals",
+      "Set.Infinite (standard 'infinitely many' encoding)"
+    ]
   },
   {
     "id": "ann-e6-conjecture",
@@ -177,7 +222,12 @@
       "Erdős problems",
       "prime gap conjecture"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "InfinitelyManyIncreasing (Erdos6.InfinitelyManyIncreasing)",
+      "primeGap (Erdos6.primeGap)",
+      "Erdős-Turán conjecture on prime gap monotonicity (1948)",
+      "bounded gaps between primes (Maynard-Tao-Zhang)"
+    ]
   },
   {
     "id": "ann-e6-bftb-theorem",
@@ -196,7 +246,12 @@
       "sieve methods",
       "bounded gaps"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "InfinitelyManyIncreasing (Erdos6.InfinitelyManyIncreasing)",
+      "maynard_tao_bounded_gaps (axiom)",
+      "Maynard-Tao multidimensional sieve (GPY method)",
+      "Zhang's bounded gaps theorem (2013)"
+    ]
   },
   {
     "id": "ann-e6-decreasing-axiom",
@@ -214,7 +269,12 @@
       "gap patterns"
     ],
     "mathContext": "See annotation content for formal details of decreasing version",
-    "prerequisites": []
+    "prerequisites": [
+      "InfinitelyManyDecreasing (Erdos6.InfinitelyManyDecreasing)",
+      "banks_freiberg_turnage_butterbaugh (axiom, increasing version)",
+      "Maynard-Tao sieve (symmetric argument for decreasing patterns)",
+      "prime gap oscillation"
+    ]
   },
   {
     "id": "ann-e6-solved",
@@ -231,7 +291,12 @@
     "relatedConcepts": [
       "theorem derivation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "banks_freiberg_turnage_butterbaugh (axiom)",
+      "erdos_6_conjecture (Erdos6.erdos_6_conjecture)",
+      "norm_num (Lean 4 numeric normalization tactic)",
+      "InfinitelyManyIncreasing 2"
+    ]
   },
   {
     "id": "ann-e6-maynard-tao",
@@ -250,7 +315,12 @@
       "prime clusters",
       "GPY method"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Finset.filter Nat.Prime (counting primes in intervals)",
+      "Finset.Icc (closed integer intervals)",
+      "Finset.card (cardinality)",
+      "Goldston-Pintz-Yıldırım (GPY) sieve method"
+    ]
   },
   {
     "id": "ann-e6-zhang",
@@ -269,7 +339,12 @@
       "bounded gaps",
       "polymath project"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.Prime (primality predicate)",
+      "lim inf of prime gaps (analytic number theory concept)",
+      "Bombieri-Vinogradov theorem (used in Zhang's proof)",
+      "admissible tuples and Hardy-Littlewood conjecture"
+    ]
   },
   {
     "id": "ann-e6-long-runs",
@@ -287,7 +362,12 @@
       "prime gap patterns"
     ],
     "mathContext": "See annotation content for formal details of arbitrarily long monotone runs",
-    "prerequisites": []
+    "prerequisites": [
+      "banks_freiberg_turnage_butterbaugh (axiom)",
+      "banks_freiberg_turnage_butterbaugh_decreasing (axiom)",
+      "InfinitelyManyIncreasing (Erdos6.InfinitelyManyIncreasing)",
+      "universal quantification over run length m"
+    ]
   },
   {
     "id": "ann-e6-oscillation",
@@ -305,6 +385,11 @@
       "oscillation theorems",
       "prime randomness"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "banks_freiberg_turnage_butterbaugh (axiom, m = 1)",
+      "banks_freiberg_turnage_butterbaugh_decreasing (axiom, m = 1)",
+      "And.intro (Lean 4 conjunction introduction)",
+      "norm_num (proves 1 ≥ 1 numerically)"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-6/meta.json
+++ b/src/data/proofs/erdos-6/meta.json
@@ -79,6 +79,7 @@
       "id": "prime-gap",
       "title": "Prime Gap Definition",
       "summary": "Definition of d_n = p_{n+1} - p_n using Mathlib's prime enumeration",
+      "mathContext": "$d_n = p_{n+1} - p_n$, where $p_n$ denotes the $n$-th prime (0-indexed via `Nat.nth Nat.Prime`)",
       "startLine": 32,
       "endLine": 56
     },
@@ -86,6 +87,7 @@
       "id": "monotone",
       "title": "Monotone Sequences",
       "summary": "HasIncreasingGaps, HasDecreasingGaps, InfinitelyMany predicates",
+      "mathContext": "`HasIncreasingGaps n m` $\\iff$ $\\forall i < m,\\; d_{n+i} < d_{n+i+1}$; similarly for decreasing",
       "startLine": 57,
       "endLine": 74
     },
@@ -93,6 +95,7 @@
       "id": "conjecture",
       "title": "Original Conjecture",
       "summary": "Erdős Problem 6 as InfinitelyManyIncreasing 2",
+      "mathContext": "$\\exists^\\infty n,\\; d_n < d_{n+1} < d_{n+2}$, i.e., `InfinitelyManyIncreasing 2`",
       "startLine": 75,
       "endLine": 85
     },
@@ -100,6 +103,7 @@
       "id": "main-theorem",
       "title": "Main Theorem",
       "summary": "Banks-Freiberg-Turnage-Butterbaugh (2015) resolution",
+      "mathContext": "$\\forall m \\geq 1,\\; \\forall N,\\; \\exists n > N,\\; d_n < d_{n+1} < \\cdots < d_{n+m}$",
       "startLine": 86,
       "endLine": 113
     },
@@ -107,6 +111,7 @@
       "id": "machinery",
       "title": "Maynard-Tao Machinery",
       "summary": "Key ingredients: bounded gaps theorems of Maynard-Tao and Zhang",
+      "mathContext": "$\\exists H,\\; \\forall N,\\; \\exists n > N,\\; |\\{p \\text{ prime} : p \\in [n, n+H]\\}| \\geq m$",
       "startLine": 114,
       "endLine": 136
     },
@@ -114,6 +119,7 @@
       "id": "generalizations",
       "title": "Generalizations",
       "summary": "Arbitrarily long runs and oscillation theorems",
+      "mathContext": "$\\forall m \\geq 1$, both `InfinitelyManyIncreasing m` and `InfinitelyManyDecreasing m` hold; prime gaps oscillate without eventual monotonicity",
       "startLine": 148,
       "endLine": 204
     }

--- a/src/data/proofs/erdos-851/annotations.json
+++ b/src/data/proofs/erdos-851/annotations.json
@@ -16,7 +16,12 @@
       "prime factors",
       "additive number theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "asymptotic density and liminf",
+      "Nat.primeFactors and the ω function",
+      "additive representations of integers",
+      "sieve methods in analytic number theory"
+    ]
   },
   {
     "id": "ann-e851-twopowaddset",
@@ -35,7 +40,12 @@
       "omega function",
       "set-builder notation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.primeFactors (Mathlib.Data.Nat.Prime)",
+      "Finset.card for cardinality of prime factor sets",
+      "Set comprehension and existential witnesses in Lean 4",
+      "distinction between ω(n) (distinct primes) and Ω(n) (prime factors with multiplicity)"
+    ]
   },
   {
     "id": "ann-e851-lowerdensity",
@@ -54,7 +64,12 @@
       "asymptotic density",
       "axiomatization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Filter.liminf and liminf in ordered topological spaces (Mathlib.Order.LiminfLimsup)",
+      "decidability requirements for constructive set membership",
+      "natural density of subsets of ℕ",
+      "axiom declarations in Lean 4 as trusted hypotheses"
+    ]
   },
   {
     "id": "ann-e851-twopow-add-one",
@@ -72,7 +87,12 @@
       "Fermat numbers",
       "empty set cardinality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.primeFactors_one : Nat.primeFactors 1 = ∅",
+      "Finset.card_empty : Finset.card ∅ = 0",
+      "Fermat numbers F_n = 2^(2^n) + 1",
+      "simp lemmas for Nat.primeFactors in Mathlib"
+    ]
   },
   {
     "id": "ann-e851-monotone",
@@ -90,7 +110,12 @@
       "monotonicity"
     ],
     "mathContext": "See annotation content for formal details of monotonicity of twopowaddset",
-    "prerequisites": []
+    "prerequisites": [
+      "le_trans for transitivity of ≤ on ℕ",
+      "Set.subset_def and intro-pattern destructuring in Lean 4",
+      "monotone functions and order-preserving maps",
+      "Nat.le_refl and Nat.le_of_lt_succ"
+    ]
   },
   {
     "id": "ann-e851-covers",
@@ -108,7 +133,12 @@
       "covering",
       "omega tactic"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "omega tactic for linear arithmetic over ℕ and ℤ",
+      "Nat.sub_add_cancel : n - 1 + 1 = n when 1 ≤ n",
+      "existential introduction with ⟨witness, proof⟩ syntax",
+      "Nat.primeFactors.card as a witness for the r parameter"
+    ]
   },
   {
     "id": "ann-e851-romanoff",
@@ -126,7 +156,12 @@
       "analytic number theory",
       "sieve methods"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Romanoff (1934): 'Über einige Sätze der additiven Zahlentheorie'",
+      "lower density of subsets of ℕ",
+      "Selberg sieve and related inclusion-exclusion methods",
+      "Nat.Prime and primality in Mathlib"
+    ]
   },
   {
     "id": "ann-e851-density-value",
@@ -144,7 +179,12 @@
       "numerical bounds"
     ],
     "mathContext": "See annotation content for formal details of romanoff density bounds",
-    "prerequisites": []
+    "prerequisites": [
+      "Romanoff's Theorem establishing positivity of lowerDensity (TwoPowAddSet 1)",
+      "real number arithmetic and comparison in Lean 4 (norm_num)",
+      "Erdős-Odlyzko (1979) sieve refinement",
+      "interval arithmetic for density bounds"
+    ]
   },
   {
     "id": "ann-e851-conjecture",
@@ -162,7 +202,12 @@
       "open problem",
       "density limit"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "lower density definition and monotonicity in r (twoPowAddSet_mono)",
+      "ε–∃ quantifier structure for limits (filter convergence)",
+      "Romanoff's Theorem as the r = 1 base case",
+      "open problems in additive number theory and covering congruences"
+    ]
   },
   {
     "id": "ann-e851-density-mono",
@@ -180,7 +225,12 @@
       "convergence"
     ],
     "mathContext": "See annotation content for formal details of density monotonicity",
-    "prerequisites": []
+    "prerequisites": [
+      "twoPowAddSet_mono: set monotonicity as the structural foundation",
+      "monotone sequences of reals and their convergence (Mathlib.Order.Monotone.Basic)",
+      "density_le_one: upper bound needed to apply monotone convergence",
+      "axiom density_mono as an assumed property of the axiomatized lowerDensity"
+    ]
   },
   {
     "id": "ann-e851-limit-equiv",
@@ -198,7 +248,12 @@
       "epsilon-delta"
     ],
     "mathContext": "See annotation content for formal details of conjecture equivalence",
-    "prerequisites": []
+    "prerequisites": [
+      "ε–δ (ε–N) definition of limits of sequences",
+      "density_mono: monotonicity implies the two directions of the equivalence",
+      "Filter.Tendsto and sequence limits in Mathlib",
+      "biconditional (Iff) proofs using constructor with mp and mpr"
+    ]
   },
   {
     "id": "ann-e851-uncovered",
@@ -216,7 +271,12 @@
       "uncovered integers"
     ],
     "mathContext": "See annotation content for formal details of uncovered by primes",
-    "prerequisites": []
+    "prerequisites": [
+      "Set.compl and complement density in ℕ",
+      "density_le_one: lowerDensity S ≤ 1 for any S",
+      "romanoff_density_value: density of TwoPowAddSet 1 is < 0.10",
+      "sub_pos.mpr and real number arithmetic to derive 1 - 0.10 > 0"
+    ]
   },
   {
     "id": "ann-e851-erdos-odlyzko",
@@ -234,7 +294,12 @@
       "sieve methods"
     ],
     "mathContext": "See annotation content for formal details of erdős-odlyzko (1979)",
-    "prerequisites": []
+    "prerequisites": [
+      "romanoff_theorem: positivity of lowerDensity (TwoPowAddSet 1) as prerequisite",
+      "Selberg sieve and Brun sieve for summing over prime-related sets",
+      "numerical lower bound proofs using interval arithmetic",
+      "Erdős-Odlyzko (1979) paper on density of odd integers of the form (p-1)/2^n"
+    ]
   },
   {
     "id": "ann-e851-examples",
@@ -252,7 +317,12 @@
       "Fermat numbers",
       "constructive proofs"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "rfl tactic for definitional equality (e.g. 3 = 2^1 + 1)",
+      "Nat.primeFactors_one = ∅ and simp lemmas for small primeFactors",
+      "anonymous constructor ⟨k, n, hm, hr⟩ syntax for existential witnesses",
+      "twoPow_add_one_mem as the general case for this family"
+    ]
   },
   {
     "id": "ann-e851-covering-congruences",
@@ -270,7 +340,12 @@
       "covering systems",
       "modular arithmetic"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "covering systems of congruences (Erdős, 1950)",
+      "Nat.ModEq and modular arithmetic in Mathlib",
+      "covering_problem_open axiom: the dichotomy between full coverage and permanent gaps",
+      "2-adic valuation and v_2(m) in relation to representability"
+    ]
   },
   {
     "id": "ann-e851-history",
@@ -289,6 +364,11 @@
       "Odlyzko"
     ],
     "mathContext": "See annotation content for formal details of historical context",
-    "prerequisites": []
+    "prerequisites": [
+      "Romanoff (1934) foundational theorem on additive representations with primes",
+      "Erdős-Odlyzko (1979) refined sieve estimates for Romanoff density",
+      "additive number theory: sumsets and representations",
+      "density of arithmetically defined subsets of ℕ"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-851/meta.json
+++ b/src/data/proofs/erdos-851/meta.json
@@ -78,49 +78,56 @@
       "title": "Core Definitions",
       "startLine": 23,
       "endLine": 42,
-      "summary": "TwoPowAddSet and lowerDensity definitions capturing the representability condition."
+      "summary": "TwoPowAddSet and lowerDensity definitions capturing the representability condition.",
+      "mathContext": "$\\mathrm{TwoPowAddSet}(r) = \\{m \\mid \\exists\\, k,n,\\; m = 2^k + n,\\; \\omega(n) \\leq r\\}$"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 43,
       "endLine": 63,
-      "summary": "Powers of 2 plus 1 are always representable; TwoPowAddSet is monotone; union covers all m ≥ 2."
+      "summary": "Powers of 2 plus 1 are always representable; TwoPowAddSet is monotone; union covers all m ≥ 2.",
+      "mathContext": "$r \\leq s \\Rightarrow \\mathrm{TwoPowAddSet}(r) \\subseteq \\mathrm{TwoPowAddSet}(s)$; $\\bigcup_{r \\geq 0} \\mathrm{TwoPowAddSet}(r) \\supseteq \\{m \\in \\mathbb{N} \\mid m \\geq 2\\}$"
     },
     {
       "id": "romanoff",
       "title": "Romanoff's Theorem (1934)",
       "startLine": 64,
       "endLine": 77,
-      "summary": "The foundational result: 2^k + p has positive lower density, approximately 0.0868."
+      "summary": "The foundational result: 2^k + p has positive lower density, approximately 0.0868.",
+      "mathContext": "$\\liminf_{N \\to \\infty} \\frac{|\\mathrm{TwoPowAddSet}(1) \\cap [1,N]|}{N} \\approx 0.0868 > 0$"
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture (OPEN)",
       "startLine": 78,
       "endLine": 92,
-      "summary": "Erdős's question about achieving density arbitrarily close to 1."
+      "summary": "Erdős's question about achieving density arbitrarily close to 1.",
+      "mathContext": "$\\forall \\varepsilon > 0,\\; \\exists r \\in \\mathbb{N},\\; \\liminf_{N \\to \\infty} \\frac{|\\mathrm{TwoPowAddSet}(r) \\cap [1,N]|}{N} \\geq 1 - \\varepsilon$"
     },
     {
       "id": "density-properties",
       "title": "Density Properties",
       "startLine": 93,
       "endLine": 117,
-      "summary": "Monotonicity of density in r, upper bound of 1, and equivalence to limit being 1."
+      "summary": "Monotonicity of density in r, upper bound of 1, and equivalence to limit being 1.",
+      "mathContext": "$r \\leq s \\Rightarrow d^-(\\mathrm{TwoPowAddSet}(r)) \\leq d^-(\\mathrm{TwoPowAddSet}(s)) \\leq 1$; conjecture $\\Leftrightarrow \\lim_{r \\to \\infty} d^-(\\mathrm{TwoPowAddSet}(r)) = 1$"
     },
     {
       "id": "related-results",
       "title": "Related Results",
       "startLine": 118,
       "endLine": 130,
-      "summary": "Uncovered integers, Erdős-Odlyzko bounds, and covering problem status."
+      "summary": "Uncovered integers, Erdős-Odlyzko bounds, and covering problem status.",
+      "mathContext": "$d^-(\\mathrm{TwoPowAddSet}(1)^c) > 0$; Erdős–Odlyzko (1979): $d^-(\\mathrm{TwoPowAddSet}(1)) > 0.0868$"
     },
     {
       "id": "examples",
       "title": "Verified Examples",
       "startLine": 131,
       "endLine": 195,
-      "summary": "Specific integers 3, 5, 9, 17 verified to be in TwoPowAddSet 0."
+      "summary": "Specific integers 3, 5, 9, 17 verified to be in TwoPowAddSet 0.",
+      "mathContext": "$3 = 2^1 + 1,\\; 5 = 2^2 + 1,\\; 9 = 2^3 + 1,\\; 17 = 2^4 + 1$; Fermat numbers $F_n = 2^{2^n} + 1 \\in \\mathrm{TwoPowAddSet}(0)$"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enrichment pass adding missing `mathContext` and `prerequisites` fields to gallery entries.

### cauchy-schwarz-oq-03
- Added `mathContext` to all 7 sections, `prerequisites` to 6 annotations, 2 new annotations

### de-moivre-oq-02
- Added `mathContext` to all 6 sections, overview `prerequisites`

### erdos-379
- Added `mathContext` to all 7 sections, `prerequisites` to all 17 annotations

### erdos-851
- Added `mathContext` to all 7 sections, `prerequisites` to all 16 annotations