### PR TITLE
Research: erdos-892 - complete erdos_1935_necessary proof (0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos892Problem.lean
+++ b/proofs/Proofs/Erdos892Problem.lean
@@ -215,12 +215,60 @@ theorem erdos_1935_necessary (b : ℕ → ℕ) :
     by_contra hlt; push_neg at hlt
     have h1 : C * b n < C * C := mul_lt_mul_of_pos_left hlt hCpos
     linarith [hdom n, hN₀ n hn]
-  -- Bound: head ≤ N₀/(2·log 2), tail ≤ 2C · Sa
-  use ↑N₀ * (1 / (2 * Real.log 2)) + 2 * ↑C * Sa
+  -- Head bound: use actual finite sum of first N₀ terms (independent of N)
+  use (∑ n ∈ Finset.range N₀,
+    (if b n ≥ 2 then (1 : ℝ) / ((b n : ℝ) * Real.log (b n : ℝ)) else 0))
+    + 2 * ↑C * Sa
   intro N
-  -- TODO: Split sum at min N N₀, bound head terms by 1/(2·log 2),
-  -- bound tail terms using reciprocal_log_comparison
-  sorry
+  -- Non-negativity of original sum terms
+  have hf_nonneg : ∀ n, 0 ≤
+      (if b n ≥ 2 then (1 : ℝ) / ((b n : ℝ) * Real.log (b n : ℝ)) else 0) := by
+    intro n; split_ifs with hbn
+    · exact div_nonneg zero_le_one (mul_nonneg (Nat.cast_nonneg _)
+        (Real.log_nonneg (by exact_mod_cast (show 1 ≤ b n by omega))))
+    · norm_num
+  -- Non-negativity of comparison bound terms
+  have hg_nonneg : ∀ n, 0 ≤
+      2 * (C : ℝ) * ((1 : ℝ) / ((a n : ℝ) * Real.log (a n : ℝ))) := by
+    intro n
+    apply mul_nonneg (mul_nonneg (by norm_num) (Nat.cast_nonneg _))
+    exact div_nonneg zero_le_one (mul_nonneg (Nat.cast_nonneg _)
+      (Real.log_nonneg (by exact_mod_cast (show 1 ≤ a n by have := hge n; omega))))
+  -- Split sum at N₀ using filter decomposition
+  have hsplit := (Finset.sum_filter_add_sum_filter_not (Finset.range N) (· < N₀)
+    (fun n => if b n ≥ 2 then (1 : ℝ) / ((b n : ℝ) * Real.log (b n : ℝ)) else 0)).symm
+  rw [hsplit]
+  apply add_le_add
+  -- Part 1 (Head): filter (· < N₀) ⊆ range N₀, all terms non-negative
+  · apply Finset.sum_le_sum_of_subset_of_nonneg
+    · intro n hn
+      simp only [Finset.mem_filter, Finset.mem_range] at hn ⊢
+      exact hn.2
+    · intro n _ _; exact hf_nonneg n
+  -- Part 2 (Tail): termwise comparison, then factor out 2C and bound by Sa
+  · calc ∑ n ∈ (Finset.range N).filter (fun n => ¬(n < N₀)),
+          (if b n ≥ 2 then (1 : ℝ) / ((b n : ℝ) * Real.log (b n : ℝ)) else 0)
+        ≤ ∑ n ∈ (Finset.range N).filter (fun n => ¬(n < N₀)),
+          (2 * (C : ℝ) * ((1 : ℝ) / ((a n : ℝ) * Real.log (a n : ℝ)))) := by
+          apply Finset.sum_le_sum
+          intro n hn
+          simp only [Finset.mem_filter, Finset.mem_range] at hn
+          have hn_ge : n ≥ N₀ := by omega
+          split_ifs with hbn
+          · rw [mul_one_div]
+            exact reciprocal_log_comparison (a n) (b n) C (hdom n) (hge n) hbn (hb_large n hn_ge)
+          · exact hg_nonneg n
+      _ ≤ ∑ n ∈ Finset.range N,
+          (2 * (C : ℝ) * ((1 : ℝ) / ((a n : ℝ) * Real.log (a n : ℝ)))) := by
+          apply Finset.sum_le_sum_of_subset_of_nonneg
+          · exact Finset.filter_subset _ _
+          · intro n _ _; exact hg_nonneg n
+      _ = 2 * ↑C * ∑ n ∈ Finset.range N,
+          ((1 : ℝ) / ((a n : ℝ) * Real.log (a n : ℝ))) := by
+          rw [← Finset.mul_sum]
+      _ ≤ 2 * ↑C * Sa := by
+          exact mul_le_mul_of_nonneg_left (hSa N)
+            (mul_nonneg (by norm_num) (Nat.cast_nonneg _))
 
 /-
 ## Section VII: GCD Condition

--- a/src/data/proofs/erdos-892/meta.json
+++ b/src/data/proofs/erdos-892/meta.json
@@ -16,7 +16,7 @@
       "sequences"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 892,
     "erdosUrl": "https://erdosproblems.com/892",
     "erdosProblemStatus": "open",
@@ -55,11 +55,12 @@
       "Proved strict_inc_eventually_ge: such sequences eventually exceed any bound M",
       "Proved product_log_comparison: a·log(a) ≤ 2C·(b·log(b)) under domination with b ≥ C",
       "Proved reciprocal_log_comparison: 1/(b·log b) ≤ 2C/(a·log a) via cross-multiplication",
-      "Converted erdos_1935_necessary from axiom to theorem with structured proof outline"
+      "Converted erdos_1935_necessary from axiom to theorem with structured proof outline",
+      "Fully proved erdos_1935_necessary: sum splitting at threshold N₀, head bounded by finite sum, tail bounded via reciprocal_log_comparison and primitive convergence axiom"
     ],
     "axiomCount": 3,
-    "lineCount": 242,
-    "assumptions": "3 axioms: ess_1967_necessary, primitive_counting_bound, primitive_reciprocal_log_convergent. 1 sorry: erdos_1935_necessary (Finset sum splitting for convergence). See Lean source.",
+    "lineCount": 290,
+    "assumptions": "3 axioms: ess_1967_necessary, primitive_counting_bound, primitive_reciprocal_log_convergent. All theorem sorries eliminated. See Lean source.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -102,14 +103,14 @@
       "id": "main-theorem",
       "title": "Main Theorem",
       "startLine": 179,
-      "endLine": 204,
-      "summary": "`erdos_1935_necessary`: proves $\\sum 1/(b_n \\log b_n) < \\infty$ is necessary for primitive domination. Uses comparison test via `reciprocal_log_comparison`. One sorry remaining for Finset sum splitting."
+      "endLine": 271,
+      "summary": "`erdos_1935_necessary`: fully proves $\\sum 1/(b_n \\log b_n) < \\infty$ is necessary for primitive domination. Splits sum at threshold $N_0$ where $a(n) \\geq C^2$; head bounded by finite sum, tail bounded via `reciprocal_log_comparison` and primitive convergence axiom."
     },
     {
       "id": "gcd-condition",
       "title": "GCD-Free Condition",
-      "startLine": 205,
-      "endLine": 242,
+      "startLine": 273,
+      "endLine": 290,
       "summary": "Defines `IsGCDFree b` and formulates `ErdosProblem892GCDFree`: is the GCD-free condition sufficient for the existence of a primitive dominator?"
     }
   ],
@@ -117,7 +118,7 @@
     "historicalContext": "Primitive sets (antichains in the divisibility poset) have been central to combinatorial number theory since Behrend (1935) and Erdős (1935). Erdős proved in 1935 that for any primitive sequence $a_1 < a_2 < \\cdots$ with $a_n \\geq 2$, the series $\\sum 1/(a_n \\log a_n)$ converges — a remarkable density constraint showing primitive sequences are 'thin.' Problem 892, posed by Erdős, Sárközy, and Szemerédi in 1968, asks: given a target growth rate $b$, when can we find a primitive sequence growing at rate $\\ll b$? The convergence result gives a necessary condition: $\\sum 1/(b_n \\log b_n) < \\infty$. Erdős, Sárközy, and Szemerédi (1967) strengthened this to a partial sum growth condition: $\\sum_{b_n < x} 1/b_n = o(\\log x / \\sqrt{\\log\\log x})$. A sufficient condition remains elusive. The GCD-free variant asks whether the condition $\\gcd(b_i, b_j) \\neq b_k$ (which prevents divisibility obstructions) suffices.",
     "problemStatement": "Given $b_1 < b_2 < \\cdots$, find necessary and sufficient conditions for the existence of a primitive sequence $a_1 < a_2 < \\cdots$ (no $a_i \\mid a_j$) with $a_n \\ll b_n$.",
     "text": "Characterize integer sequences b such that a primitive sequence a (no element divides another) exists with aₙ ≪ bₙ. Known: Σ 1/(bₙ log bₙ) < ∞ is necessary. OPEN.",
-    "proofStrategy": "The formalization models sequences as functions $\\mathbb{N} \\to \\mathbb{N}$, defines primitivity via pairwise non-divisibility, and domination via an explicit constant. Five supporting lemmas are fully proved, including the key comparison bound $a \\cdot \\log a \\leq 2C \\cdot (b \\cdot \\log b)$. The Erdős 1935 necessary condition $\\sum 1/(b_n \\log b_n) < \\infty$ is being proved from axiomatized convergence of $\\sum 1/(a_n \\log a_n)$ via comparison test. Three deep results remain as axioms.",
+    "proofStrategy": "The formalization models sequences as functions $\\mathbb{N} \\to \\mathbb{N}$, defines primitivity via pairwise non-divisibility, and domination via an explicit constant. Six theorems are fully proved, including the key comparison bound and the Erdős 1935 necessary condition. The proof of `erdos_1935_necessary` splits the sum at threshold $N_0$ where $a(n) \\geq C^2$: the head is bounded by a finite constant, the tail uses `reciprocal_log_comparison` to reduce to the convergent series $\\sum 1/(a_n \\log a_n)$. Three deep results remain as axioms.",
     "keyInsights": [
       "Primitive sequences are antichains in the divisibility partial order: $a_i \\nmid a_j$ for $i \\neq j$. They are sparse — the primes form the densest primitive sequence",
       "Erdős (1935) convergence: $\\sum 1/(a_n \\log a_n) < \\infty$ for any primitive $a$ with $a_n \\geq 2$. This is an analog of the prime harmonic series divergence, showing primitive sets are even thinner than primes in the $1/(n \\log n)$ metric",
@@ -131,7 +132,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem 892 is formalized with 6 definitions, 5 fully proved theorems, and 1 theorem with sorry. The key comparison lemma (product_log_comparison) is fully proved, establishing $a \\cdot \\log a \\leq 2C \\cdot (b \\cdot \\log b)$ under domination. The Erdős 1935 necessary condition is being proved from 3 axiomatized deep results, with one sorry remaining for Finset sum splitting.",
+    "summary": "Erdős Problem 892 is formalized with 6 definitions, 6 fully proved theorems, and 0 sorries. All theorem proofs are complete. The Erdős 1935 necessary condition ($\\sum 1/(b_n \\log b_n) < \\infty$) is fully proved from 3 axiomatized deep results via comparison test with Finset sum splitting.",
     "implications": "A full characterization would provide a fundamental understanding of how the 'thinness' of primitive sequences constrains their growth rates. This connects to Behrend's theorem, the distribution of primes (the densest primitive sequence), and the structure of the divisibility lattice on natural numbers.",
     "openQuestions": [
       "What are necessary and sufficient conditions for a sequence b to admit a primitive dominator?",
@@ -170,7 +171,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 242,
+    "lineCount": 290,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 6

--- a/src/data/research/problems/erdos-892.json
+++ b/src/data/research/problems/erdos-892.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Proved reciprocal_log_comparison (cross-multiplication from product_log_comparison). Added 3 helper theorems (strict_inc_lower_bound, strict_inc_eventually_ge, product_log_comparison). Axioms: 3, sorries: 1 (was 2), theorems: 6 (was 2). erdos_1935_necessary proof structured with threshold and bound.",
+    "progressSummary": "COMPLETED: erdos_1935_necessary fully proved (Finset sum splitting at threshold, comparison lemma). File: 0 sorries, 3 axioms (deep results), 6 proved theorems. All theorem bodies complete.",
     "builtItems": [
       "primitive_elements_ge_two: proved from primitivity (0 divides everything, 1 divides everything)",
       "erdos_1935_necessary: converted from axiom to theorem (Steps 1-2 complete, Step 3 sorry for comparison arithmetic)",
@@ -38,7 +38,8 @@
       "product_log_comparison: proved a·log(a) ≤ 2C·(b·log(b)) via log monotonicity",
       "strict_inc_lower_bound: proved a(n) ≥ n+2 by induction",
       "strict_inc_eventually_ge: proved sequence eventually exceeds any bound M",
-      "reciprocal_log_comparison: PROVED from product_log_comparison via div_le_div_iff₀"
+      "reciprocal_log_comparison: PROVED from product_log_comparison via div_le_div_iff₀",
+      "erdos_1935_necessary: FULLY PROVED - sum splitting at N₀, head bounded by finite sum, tail by comparison+convergence"
     ],
     "insights": [
       "erdos_1935_necessary is logically derivable from primitive_reciprocal_log_convergent: if a ≤ C*b, then 1/(b·log b) ≤ 2C/(a·log a) for large n, so convergence transfers",
@@ -50,7 +51,8 @@
       "The comparison test from primitive_reciprocal_log_convergent to erdos_1935_necessary requires careful handling of ℕ/ℝ coercions and log monotonicity",
       "Key step: split sum at threshold where a(n) ≥ 2C. Finitely many terms below threshold (by strict increase), comparison above.",
       "div_le_div_iff₀ (not div_le_div_iff) is the correct Mathlib name for cross-multiplication of fraction inequalities",
-      "The threshold b(n) ≥ C (instead of a(n) ≥ 2C) is more natural for the comparison lemma"
+      "The threshold b(n) ≥ C (instead of a(n) ≥ 2C) is more natural for the comparison lemma",
+      "Finset.sum_filter_add_sum_filter_not cleanly splits sums by predicate; Finset.sum_le_sum_of_subset_of_nonneg handles subset monotonicity with non-negative terms"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -80,8 +82,8 @@
     {
       "path": "Proofs/Erdos892Problem.lean",
       "filename": "Erdos892Problem.lean",
-      "lineCount": 122,
-      "theoremCount": 0,
+      "lineCount": 290,
+      "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- Fully proved `erdos_1935_necessary`: Erdős 1935 necessary condition for primitive sequence domination (Σ 1/(bₙ log bₙ) < ∞)
- Eliminated the last sorry in Erdos892Problem.lean (was 1, now 0)
- File: 6 proved theorems, 3 deep axioms, 0 sorries

## Proof Strategy
Split sum at threshold N₀ where a(n) ≥ C² using `Finset.sum_filter_add_sum_filter_not`:
- **Head** (n < N₀): bounded by finite sum over range N₀ via `Finset.sum_le_sum_of_subset_of_nonneg`
- **Tail** (n ≥ N₀): each term bounded by 2C/(aₙ·log aₙ) via `reciprocal_log_comparison`, total ≤ 2C·Sa via `Finset.mul_sum` and the primitive convergence axiom

## Files Modified
- `proofs/Proofs/Erdos892Problem.lean` — proof completion (+48 lines)
- `src/data/proofs/erdos-892/meta.json` — updated sorries, line count, summaries
- `src/data/research/problems/erdos-892.json` — updated knowledge and progress

## Build
Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos892Problem` ✓

🤖 Generated by researcher-6