### PR TITLE
Research: erdos-1139 - prove sorry lemmas (3→1 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1139Problem.lean
+++ b/proofs/Proofs/Erdos1139Problem.lean
@@ -102,7 +102,10 @@ theorem semiprime_isAlmostPrime {p q : ℕ} (hp : Nat.Prime p) (hq : Nat.Prime q
   constructor
   · exact le_trans (by norm_num : 2 ≤ 4) (semiprime_ge_four hp hq)
   · unfold bigOmega
-    sorry -- Ω(p*q) = Ω(p) + Ω(q) = 1 + 1 = 2
+    rw [Nat.factorization_mul hp.ne_zero hq.ne_zero]
+    rw [Finsupp.sum_add_index (fun _ _ => rfl) (fun _ _ _ _ => rfl)]
+    rw [Nat.Prime.factorization hp, Nat.Prime.factorization hq]
+    simp [Finsupp.sum_single_index]
 
 -- ## Part 5: Counting
 
@@ -135,10 +138,15 @@ theorem cube_gap_obstruction (n : ℕ) (hn : 2 ≤ n)
     (m : ℕ) (hm1 : n ^ 3 < m) (hm2 : m < (n + 1) ^ 3)
     (hdiv : 8 ∣ m) : ¬IsAlmostPrime m := by
   intro ⟨_, hΩ⟩
-  unfold bigOmega at hΩ
   obtain ⟨k, rfl⟩ := hdiv
-  -- Ω(8k) ≥ Ω(8) = 3 > 2, contradiction
-  sorry
+  have hk_ne : k ≠ 0 := by nlinarith [show n ^ 3 ≥ 8 from by nlinarith]
+  -- Ω(8k) = Ω(8) + Ω(k) ≥ 3 > 2, contradicting hΩ
+  have h_split : bigOmega (8 * k) = bigOmega 8 + bigOmega k := by
+    unfold bigOmega
+    rw [Nat.factorization_mul (by norm_num : (8 : ℕ) ≠ 0) hk_ne]
+    exact Finsupp.sum_add_index (fun _ _ => rfl) (fun _ _ _ _ => rfl)
+  have h8 : bigOmega 8 = 3 := by unfold bigOmega; native_decide
+  linarith
 
 -- ## Part 8: Density and Asymptotic Counting
 

--- a/proofs/Proofs/Erdos197Problem.lean
+++ b/proofs/Proofs/Erdos197Problem.lean
@@ -230,6 +230,13 @@ theorem powers_of_2_avoid_3AP :
   have hi : 0 < 2 ^ i := pow_pos (by omega : (0 : ℕ) < 2) i
   linarith
 
+/-- A subsequence of a 3-AP-free sequence is 3-AP-free.
+    Key implication: if a set has a 3-AP-free enumeration, any infinite subset does too. -/
+theorem avoids3AP_of_comp {f g : ℕ → ℕ} (hf : avoids3AP f) (hg : StrictMono g) :
+    avoids3AP (f ∘ g) := by
+  intro ⟨i, j, k, hij, hjk, hap⟩
+  exact hf ⟨g i, g j, g k, hg hij, hg hjk, hap⟩
+
 /-
 ## Part VIII: Computational Intractability
 
@@ -263,6 +270,11 @@ By construction.
 -/
 axiom stanley_avoids_3AP :
     ∃ f : ℕ → ℕ, isStanleySequence f ∧ avoids3AP f
+
+/-- The Stanley sequence property already implies 3-AP avoidance.
+    The `∧ avoids3AP f` in stanley_avoids_3AP is redundant. -/
+theorem stanley_implies_avoids3AP {f : ℕ → ℕ} (h : isStanleySequence f) : avoids3AP f :=
+  h.2.2.1
 
 /-
 ## Part X: Main Results Summary

--- a/proofs/Proofs/Erdos5PrimeGaps.lean
+++ b/proofs/Proofs/Erdos5PrimeGaps.lean
@@ -382,7 +382,7 @@ theorem normalizedGap_pos {n : ℕ} (hn : 2 ≤ n) : 0 < normalizedGap n := by
     Since normalizedGap n ≥ 0 for all n, any subsequential limit is ≥ 0. -/
 theorem limitPoint_nonneg {C : ℝ} (hC : IsLimitPoint C) : 0 ≤ C := by
   obtain ⟨f, _, hf_lim⟩ := hC
-  exact le_of_tendsto' hf_lim (Eventually.of_forall fun i => normalizedGap_nonneg (f i))
+  exact ge_of_tendsto hf_lim (Eventually.of_forall fun i => normalizedGap_nonneg (f i))
 
 /-- The set S of limit points is contained in [0, ∞). -/
 theorem limitPointSet_subset_nonneg : limitPointSet ⊆ Set.Ici 0 :=
@@ -414,7 +414,25 @@ theorem limitPointSet_unbounded_above (M : ℝ) (hM : M > 0) :
   obtain ⟨C, hCM, hCLP⟩ := hildebrand_maier_large_limit_points M hM
   exact ⟨C, hCLP, hCM⟩
 
-/- ## Part X: The Conjecture as Set Equality -/
+/- ## Part X: Closedness of S -/
+
+/-- **The set S of limit points is closed.**
+    Proof outline: the complement is open. If C is not a limit point, then
+    no subsequence of normalizedGap converges to C. Equivalently (in ℝ),
+    ∃ ε > 0 such that only finitely many n have normalizedGap(n) ∈ ball(C, ε).
+    For any C' ∈ ball(C, ε/2), by triangle inequality only finitely many n have
+    normalizedGap(n) ∈ ball(C', ε/2), so C' is also not a limit point.
+    The diagonalization: if ∀ ε > 0, infinitely many terms within ε of C,
+    pick n_k with normalizedGap(n_k) within 1/(k+1) of C and n_k > n_{k-1}. -/
+theorem limitPointSet_isClosed : IsClosed limitPointSet := by
+  rw [← isOpen_compl_iff, Metric.isOpen_iff]
+  intro C hC
+  -- C is not a limit point → ∃ ε > 0, eventually normalizedGap stays away from C
+  -- (contrapositive of diagonalization argument above)
+  -- Then ball C (ε/2) ⊆ limitPointSetᶜ by triangle inequality
+  sorry
+
+/- ## Part XI: The Conjecture as Set Equality -/
 
 /-- Erdős Problem #5 is equivalent to: S = [0, ∞) and ∞ is a limit point.
     The forward direction: if erdos_5 holds, then limitPointSet = Set.Ici 0. -/

--- a/proofs/Proofs/Erdos638Problem.lean
+++ b/proofs/Proofs/Erdos638Problem.lean
@@ -75,12 +75,25 @@ axiom ramsey_triangle (n : ℕ) (hn : 1 ≤ n) :
 /-- The family of complete graphs is a Ramsey family.
     Proved from ramsey_triangle: for each n, it provides an N with K_N Ramsey. -/
 theorem complete_graphs_ramsey :
-    IsRamseyFamily (fun m => {⊤ : SimpleGraph (Fin m)}) := by
+    IsRamseyFamily (fun m => ({⊤} : Set (SimpleGraph (Fin m)))) := by
   intro n hn
   obtain ⟨N, hN⟩ := ramsey_triangle n hn
   exact ⟨N, ⊤, Set.mem_singleton _, hN⟩
 
 /- ## Basic observations -/
+
+/-- For 1 colour, K_3 has the triangle Ramsey property: every 1-colouring
+    trivially yields a monochromatic triangle (Fin 1 is a subsingleton). -/
+theorem ramsey_triangle_base :
+    HasTriangleRamsey (⊤ : SimpleGraph (Fin 3)) 1 := by
+  intro c
+  refine ⟨0, 1, 2, by decide, by decide, by decide, ?_, ?_, ?_, ?_, ?_⟩
+  all_goals first | simp [SimpleGraph.top_adj] | exact Subsingleton.elim _ _
+
+/-- The n = 1 case of ramsey_triangle, proved without using the axiom. -/
+theorem ramsey_triangle_one_proved :
+    ∃ N : ℕ, HasTriangleRamsey (⊤ : SimpleGraph (Fin N)) 1 :=
+  ⟨3, ramsey_triangle_base⟩
 
 /-- Monotonicity: if `G` has the `n`-colour property and `m ≤ n`, then
 `G` also has the `m`-colour property. Proved by embedding Fin m into
@@ -90,6 +103,5 @@ theorem triangle_ramsey_mono {V : Type*} (G : SimpleGraph V) (m n : ℕ)
   intro c
   obtain ⟨a, b, d, hab, hbd, had, eab, ebd, ead, hc1, hc2⟩ :=
     h (fun v w => (c v w).castLE hmn)
-  have hInj : Function.Injective (Fin.castLE hmn) := by
-    intro x y hxy; ext; exact congrArg Fin.val hxy
+  have hInj : Function.Injective (Fin.castLE hmn) := Fin.castLE_injective hmn
   exact ⟨a, b, d, hab, hbd, had, eab, ebd, ead, hInj hc1, hInj hc2⟩

--- a/proofs/Proofs/Erdos700Problem.lean
+++ b/proofs/Proofs/Erdos700Problem.lean
@@ -57,6 +57,28 @@ theorem minFac_prime_sq (p : ℕ) (hp : p.Prime) : Nat.minFac (p * p) = p := by
     exact hpf.dvd_of_dvd_pow h2
   exact (hp.eq_one_or_self_of_dvd _ hdvdp).resolve_left (by have := hpf.one_lt; omega)
 
+/-- minFac(p * q) = p for primes p ≤ q. -/
+theorem minFac_mul_prime {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≤ q) :
+    Nat.minFac (p * q) = p := by
+  have hpq_ne1 : p * q ≠ 1 := by have := hp.two_le; nlinarith
+  have hpf := Nat.minFac_prime hpq_ne1
+  have hdvd := Nat.minFac_dvd (p * q)
+  rcases hpf.dvd_mul.mp hdvd with hp_dvd | hq_dvd
+  · exact (hp.eq_one_or_self_of_dvd _ hp_dvd).resolve_left hpf.one_lt.ne'
+  · have heq := (hq.eq_one_or_self_of_dvd _ hq_dvd).resolve_left hpf.one_lt.ne'
+    have hle : Nat.minFac (p * q) ≤ p :=
+      Nat.minFac_le_of_dvd hp.two_le (dvd_mul_right p q)
+    omega
+
+/-- Any prime factor of n is ≤ largestPrimeFactor(n). -/
+theorem le_largestPrimeFactor {n r : ℕ} (hr : r.Prime) (hdvd : r ∣ n) (hn : 2 ≤ n) :
+    r ≤ largestPrimeFactor n := by
+  unfold largestPrimeFactor
+  simp only [hn, dite_true]
+  have hr_le_n : r ≤ n := Nat.le_of_dvd (by omega) hdvd
+  exact Finset.le_sup (f := id)
+    (Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), hr, hdvd⟩)
+
 /- ## Basic Bounds -/
 
 /-- f(n) ≤ n/P(n) for all composite n.
@@ -76,11 +98,36 @@ axiom f_lower_bound (n : ℕ) (hn : 2 ≤ n) :
 /- ## Known Equalities -/
 
 /-- When n = pq is a product of two primes with p ≤ q, f(n) = p.
-    The sandwich argument: p = minFac(pq) ≤ f(pq) ≤ pq/q = p.
-    Axiomatized because proving largestPrimeFactor(pq) = q requires
-    nontrivial work with the Finset.sup definition. -/
-axiom f_semiprime (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hpq : p ≤ q) :
-  fBinom (p * q) = p
+    Sandwich: p = minFac(pq) ≤ f(pq) ≤ pq/largestPrimeFactor(pq) ≤ pq/q = p. -/
+theorem f_semiprime (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hpq : p ≤ q) :
+    fBinom (p * q) = p := by
+  have h2 : 2 ≤ p * q := by have := hp.two_le; nlinarith
+  have hcomp : ¬(p * q).Prime := by
+    intro hprime
+    rcases hprime.eq_one_or_self_of_dvd p (dvd_mul_right p q) with h1 | h2
+    · exact hp.one_lt.ne' h1
+    · have : q = 1 := by nlinarith [hp.one_lt]
+      exact absurd this (by omega)
+  -- Lower bound: p ≤ f(pq)
+  have hlower : p ≤ fBinom (p * q) := by
+    have hmin := f_lower_bound (p * q) h2
+    rw [show smallestPrimeFactor (p * q) = Nat.minFac (p * q) from rfl,
+        minFac_mul_prime hp hq hpq] at hmin
+    exact hmin
+  -- Upper bound: f(pq) ≤ p
+  have hupper : fBinom (p * q) ≤ p := by
+    have hup := f_upper_bound (p * q) hcomp h2
+    have hq_le : q ≤ largestPrimeFactor (p * q) :=
+      le_largestPrimeFactor hq (dvd_mul_left q p) h2
+    have hlpf_pos : 0 < largestPrimeFactor (p * q) := by
+      have := hq.two_le; linarith
+    have hpq_le : p * q / largestPrimeFactor (p * q) ≤ p :=
+      calc p * q / largestPrimeFactor (p * q)
+          ≤ p * largestPrimeFactor (p * q) / largestPrimeFactor (p * q) :=
+            Nat.div_le_div_right (Nat.mul_le_mul_left p hq_le)
+        _ = p := Nat.mul_div_cancel p hlpf_pos
+    linarith
+  omega
 
 /-- f(30) = 30/5 = 6. One verifies gcd(30, C(30,k)) ≥ 6 for all
     1 < k ≤ 15, with equality at k = 5 where C(30,5) = 142506

--- a/proofs/Proofs/Erdos848Problem.lean
+++ b/proofs/Proofs/Erdos848Problem.lean
@@ -17,6 +17,7 @@ Reference: https://erdosproblems.com/848
 import Mathlib.Tactic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.NumberTheory.SumTwoSquares
 
 /- ## Definitions -/
 
@@ -46,12 +47,15 @@ theorem maxNonSqfreeSet_le (N : ℕ) : maxNonSqfreeSet N ≤ N := by
   simp only [Finset.mem_filter, Finset.mem_powerset] at hA
   -- |A| ≤ |Icc 1 N| ≤ N via injection x ↦ x - 1 from Icc 1 N to range N
   have hIcc_le : (Finset.Icc 1 N).card ≤ N := by
-    calc (Finset.Icc 1 N).card
-        ≤ (Finset.range N).card := Finset.card_le_card_of_injOn (· - 1)
-          (fun x hx => by simp only [Finset.mem_Icc] at hx; simp only [Finset.mem_range]; omega)
-          (fun a ha b hb h => by
-            simp only [Finset.coe_Icc, Set.mem_Icc] at ha hb; omega)
-      _ = N := Finset.card_range N
+    have hle : (Finset.Icc 1 N).card ≤ (Finset.range N).card := by
+      apply Finset.card_le_card_of_injOn (fun x => x - 1)
+      · intro x hx
+        simp only [Finset.mem_coe] at hx ⊢
+        rw [Finset.mem_Icc] at hx; rw [Finset.mem_range]; omega
+      · intro a ha b hb hab
+        simp only [Finset.mem_coe, Finset.mem_Icc] at ha hb
+        dsimp only at hab; omega
+    linarith [Finset.card_range N]
   linarith [Finset.card_le_card hA.1]
 
 /- ## Known Results -/
@@ -152,6 +156,81 @@ theorem lower_bound (N : ℕ) (hN : 25 ≤ N) :
     exact ⟨Finset.mem_powerset.mpr (mod7Set_sub N), mod7Set_prop N⟩
   calc N / 25 ≤ (mod7Set N).card := mod7Set_card_ge N hN
     _ ≤ _ := Finset.le_sup hmem
+
+/- ## Van Doorn's Argument: Key Intermediate Steps
+
+Van Doorn's density bound proceeds by showing every a ∈ A must satisfy
+a² ≡ -1 (mod p²) for some prime p ≡ 1 (mod 4), then applying a union bound
+over such primes. We formalize the key constraint here. -/
+
+/-- Diagonal constraint: the product property implies every element satisfies
+    ∃ p prime, p² | a² + 1. This is the starting point for Van Doorn's argument. -/
+theorem diagonal_constraint (A : Finset ℕ) (hA : HasNonSqfreeProductProp A)
+    (a : ℕ) (ha : a ∈ A) :
+    ∃ p : ℕ, p.Prime ∧ p * p ∣ a * a + 1 := by
+  have h := hA a ha a ha
+  unfold IsSquarefree at h
+  push_neg at h
+  exact h
+
+/-- 4 never divides a² + 1: since a² mod 4 ∈ {0, 1}, we have a² + 1 mod 4 ∈ {1, 2}. -/
+theorem not_four_dvd_sq_succ (a : ℕ) : ¬(2 * 2 ∣ a * a + 1) := by
+  intro ⟨k, hk⟩
+  rcases Nat.even_or_odd a with ⟨m, rfl⟩ | ⟨m, rfl⟩
+  · -- a = m+m: (m+m)² + 1 = 4m² + 1 = 4k is impossible (1 ≢ 0 mod 4)
+    have : (m + m) * (m + m) + 1 = 4 * (m * m) + 1 := by ring
+    rw [this] at hk; set n := m * m; omega
+  · -- a = 2m+1: (2m+1)² + 1 = 4m²+4m+2 = 4k is impossible (2 ≢ 0 mod 4)
+    have : (2 * m + 1) * (2 * m + 1) + 1 = 4 * (m * m + m) + 2 := by ring
+    rw [this] at hk; set n := m * m + m; omega
+
+/-- If p is prime and p² | a² + 1, then p ≠ 2. -/
+theorem prime_sq_dvd_sq_succ_ne_two {p a : ℕ} (hp : p.Prime)
+    (hdvd : p * p ∣ a * a + 1) : p ≠ 2 := by
+  intro heq; rw [heq] at hdvd; exact not_four_dvd_sq_succ a hdvd
+
+/-- If p is prime and p² | a² + 1, then p ≡ 1 (mod 4).
+    This is the key step in Van Doorn's density argument: -1 must be a quadratic
+    residue mod p, which by the first supplement forces p ≡ 1 (mod 4). -/
+theorem prime_sq_dvd_sq_succ_mod_four {p a : ℕ} (hp : p.Prime)
+    (hdvd : p * p ∣ a * a + 1) : p % 4 = 1 := by
+  have hp2 : p ≠ 2 := prime_sq_dvd_sq_succ_ne_two hp hdvd
+  -- p | a² + 1 since p² | a² + 1
+  have hpdvd : p ∣ a * a + 1 := dvd_trans ⟨p, rfl⟩ hdvd
+  -- Construct: -1 is a square mod p (since a² ≡ -1 mod p)
+  haveI : Fact (Nat.Prime p) := ⟨hp⟩
+  have hsq : IsSquare (-1 : ZMod p) := by
+    use (a : ZMod p)
+    -- Cast a * a + 1 to ZMod p and show it equals 0
+    have hpdvd' : p ∣ a ^ 2 + 1 := by rwa [sq]
+    have hzero : ((a ^ 2 + 1 : ℕ) : ZMod p) = 0 := by
+      rw [ZMod.natCast_zmod_eq_zero_iff_dvd]; exact hpdvd'
+    simp only [Nat.cast_add, Nat.cast_pow, Nat.cast_one] at hzero
+    have h : (a : ZMod p) ^ 2 = -1 := by
+      have h0 : (a : ZMod p) ^ 2 + 1 = 0 := hzero
+      calc (a : ZMod p) ^ 2 = (a : ZMod p) ^ 2 + 1 - 1 := by ring
+        _ = 0 - 1 := by rw [h0]
+        _ = -1 := by ring
+    rw [sq] at h; exact h.symm
+  -- Apply first supplement to quadratic reciprocity: IsSquare (-1) ↔ p % 4 ≠ 3
+  have hne3 : p % 4 ≠ 3 := ZMod.exists_sq_eq_neg_one_iff.mp hsq
+  -- p is odd prime, so p % 4 ∈ {1, 3}; exclude 3
+  have hodd : Odd p := hp.odd_of_ne_two hp2
+  have hmod : p % 4 = 1 ∨ p % 4 = 3 := by
+    obtain ⟨m, hm⟩ := hodd
+    have : p ≥ 3 := by have := hp.two_le; omega
+    omega
+  exact hmod.resolve_right hne3
+
+/-- Van Doorn's key constraint: for any set with the non-squarefree product property,
+    every element a must satisfy a² ≡ -1 (mod p²) for some prime p ≡ 1 (mod 4).
+    The full density bound follows from a union bound: each such p contributes ≤ 2/p²
+    density, giving |A|/N ≤ 2·Σ_{p≡1(4)} 1/p² ≈ 0.108. -/
+theorem vanDoorn_constraint (A : Finset ℕ) (hA : HasNonSqfreeProductProp A)
+    (a : ℕ) (ha : a ∈ A) :
+    ∃ p : ℕ, p.Prime ∧ p % 4 = 1 ∧ p * p ∣ a * a + 1 := by
+  obtain ⟨p, hp, hdvd⟩ := diagonal_constraint A hA a ha
+  exact ⟨p, hp, prime_sq_dvd_sq_succ_mod_four hp hdvd, hdvd⟩
 
 /- ## Deep Results (Axiomatized) -/
 

--- a/src/data/research/problems/erdos-1139.json
+++ b/src/data/research/problems/erdos-1139.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-02-08T00:55:03.568Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Initial formalization of almost-prime gap problem",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,11 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: New formalization created. 11 proved theorems, 2 axioms (open conjecture + Hardy-Ramanujan), 3 sorries in supporting lemmas. Builds clean.",
+    "progressSummary": "PROGRESS: Session 3 eliminated 2/3 sorries. Proved semiprime_isAlmostPrime (Ω additivity) and cube_gap_obstruction (Ω(8k) ≥ 3). Only almostPrimeGap definition sorry remains.",
     "builtItems": [
       "Created Erdos1139Problem.lean (157 lines, 11 theorems, 2 axioms, 3 sorries)",
       "Proved prime_isAlmostPrime, four_isAlmostPrime, eight_not_almostPrime",
-      "Proved almostPrimes_contain_primes (primes ⊆ almost-primes)"
+      "Proved almostPrimes_contain_primes (primes ⊆ almost-primes)",
+      "Proved semiprime_isAlmostPrime: Ω(pq) = Ω(p) + Ω(q) = 2 via factorization_mul + sum_add_index",
+      "Proved cube_gap_obstruction: Ω(8k) = Ω(8) + Ω(k) ≥ 3 > 2 via bigOmega additivity"
     ],
     "insights": [
       "Ω(n) available via n.factorization.sum in Mathlib",
@@ -61,5 +63,11 @@
   "started": "2026-02-08T00:55:03.569Z",
   "lastUpdate": "2026-03-13T07:52:17.061Z",
   "significance": 7,
-  "tractability": 5
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "sorryCount": 1,
+      "theoremCount": 11
+    }
+  ]
 }

--- a/src/data/research/problems/erdos-197.json
+++ b/src/data/research/problems/erdos-197.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-197",
-  "title": "Erd\u0151s #197",
+  "title": "Erdős #197",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-12T16:01:50.837Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Axiom elimination: 5 -> 2 axioms",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,25 +29,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM HUNT: Reduced from 5 axioms to 2. Proved powers_of_2_avoid_3AP, erdos_197_conjecture (from classical logic), removed malformed erdos_197_not_finite_checkable. Fixed false constant_avoids_3AP theorem. Fixed broken Mathlib imports.",
+    "progressSummary": "PROGRESS: Session 3 added 2 structural theorems. avoids3AP_of_comp proves subsequences preserve 3-AP freedom. stanley_implies_avoids3AP documents axiom redundancy. File now has 9 proved theorems, 2 axioms, 0 sorries.",
     "builtItems": [
       "Proved powers_of_2_avoid_3AP: 2^n avoids 3-APs (since j<k => 2^k >= 2*2^j)",
       "Proved erdos_197_conjecture from Classical.em + De Morgan",
       "Fixed constant_has_3AP (was incorrectly claiming constant sequences avoid 3-APs)",
-      "Fixed isStanleySequence definition (Nat.find API change)"
+      "Fixed isStanleySequence definition (Nat.find API change)",
+      "Proved avoids3AP_of_comp: subsequence of 3-AP-free sequence is 3-AP-free",
+      "Proved stanley_implies_avoids3AP: documents redundancy in stanley_avoids_3AP axiom"
     ],
     "insights": [
       "2^i + 2^k = 2*2^j is impossible for i<j<k because 2^k >= 2*2^j and 2^i >= 1",
       "erdos_197_conjecture (P or not-P) is just excluded middle, not a real axiom",
       "erdos_197_not_finite_checkable had a placeholder True making it malformed",
-      "constant_avoids_3AP was a false theorem: constant sequences DO have 3-APs"
+      "constant_avoids_3AP was a false theorem: constant sequences DO have 3-APs",
+      "avoids3AP_of_comp: subsequences of 3-AP-free sequences are 3-AP-free (key structural property)",
+      "stanley_avoids_3AP axiom has redundant conjunction: isStanleySequence already includes avoids3AP",
+      "fast_growing_avoids_3AP is FALSE: e.g. f=(1,3,5) has 2^n ≤ f(n) but 1+5=2*3 is an AP"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Could try to prove stanley_avoids_3AP (greedy construction argument)",
       "erdos_graham_three_sets is the remaining deep axiom - needs serious combinatorics"
     ],
-    "markdown": "# Erd\u0151s #197 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nCan $\\mathbb{N}$ be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions?\n\n\n\nIf three sets are allowed then this is possible.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #196\n- Problem #198\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr79\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "markdown": "# Erdős #197 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nCan $\\mathbb{N}$ be partitioned into two sets, each of which can be permuted to avoid monotone 3-term arithmetic progressions?\n\n\n\nIf three sets are allowed then this is possible.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #196\n- Problem #198\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr79\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
     "erdos"

--- a/src/data/research/problems/erdos-5.json
+++ b/src/data/research/problems/erdos-5.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-12T03:37:20.406Z",
-    "iteration": 2,
-    "focus": "Session 2: Replaced True placeholders with proper Merikoski axiom, proved 5 structural theorems, updated gallery to main file",
+    "iteration": 3,
+    "focus": "Fixed build failure, added limitPointSet_isClosed outline",
     "blockers": [],
-    "nextAction": "Prove limitPointSet_isClosed (S is closed). Consider proving Hildebrand-Maier from westzynthius+merikoski.",
+    "nextAction": "Prove limitPointSet_isClosed: implement diagonalization (cluster_implies_limitPoint) + triangle inequality for complement openness",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 2 replaced 2 dishonest True-placeholder theorems with proper Merikoski bounded-gaps axiom. Proved 5 new structural theorems: westzynthius_implies_frequently_large, limitPointSet_nonempty, limitPointSet_unbounded, erdos5_from_full, erdos5_known_partial. Updated gallery metadata to point to main file (Erdos5PrimeGaps.lean, 3 axioms) instead of legacy stub (Erdos5Problem.lean, 8 axioms).",
+    "progressSummary": "PROGRESS: Session 3 fixed pre-existing build failure (Mathlib API change) and added limitPointSet_isClosed statement with documented proof strategy. Proof reduces to diagonalization + triangle inequality.",
     "builtItems": [
       "Proved goldston_pintz_yildirim_small_gaps: derived from zhang_implies_zero_limit (already proved from zhang_bounded_gaps axiom)",
       "Proved erdos_ricci_positive_measure: trivially True placeholder (needs measure theory for real content)",
@@ -42,7 +42,9 @@
       "Added merikoski_bounded_gaps axiom: proper formalization of S having bounded gaps",
       "Removed erdos_ricci_positive_measure True placeholder (was ∃ ε > 0, True)",
       "Removed merikoski_density True placeholder (was ∃ d ≥ 1/3, True)",
-      "Updated gallery meta.json: proofRepoPath → Erdos5PrimeGaps.lean, axiomCount 8→3"
+      "Updated gallery meta.json: proofRepoPath → Erdos5PrimeGaps.lean, axiomCount 8→3",
+      "Fixed limitPoint_nonneg: le_of_tendsto → ge_of_tendsto (Mathlib API change)",
+      "Added limitPointSet_isClosed statement with proof outline (sorry, 1 remaining)"
     ],
     "insights": [
       "Erdos5PrimeGaps.lean is the main file (343L, well-structured); Erdos5Problem.lean is legacy (81L, all axiomatized)",
@@ -54,7 +56,9 @@
       "erdos_ricci_positive_measure and merikoski_density were vacuous: they proved ∃ x, P(x) ∧ True which says nothing about the mathematical content",
       "Merikoski bounded gaps axiom enables proving S unbounded (for any M, limit point > M exists)",
       "westzynthius_large_gaps + filter API gives infinitely-often large gaps via Tendsto.atTop decomposition",
-      "Gallery was pointing to legacy Erdos5Problem.lean (8 axioms, 80 lines) instead of main Erdos5PrimeGaps.lean (3 axioms, 380 lines, 19 theorems)"
+      "Gallery was pointing to legacy Erdos5Problem.lean (8 axioms, 80 lines) instead of main Erdos5PrimeGaps.lean (3 axioms, 380 lines, 19 theorems)",
+      "limitPoint_nonneg was broken by Mathlib API change: le_of_tendsto renamed to ge_of_tendsto",
+      "limitPointSet_isClosed proof strategy documented: show complement is open via cluster point characterization + triangle inequality"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-638.json
+++ b/src/data/research/problems/erdos-638.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-13T17:14:37.756Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Axiom elimination",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,15 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION: Proved 2 of 3 axioms (complete_graphs_ramsey, triangle_ramsey_mono). Only ramsey_triangle remains. Axiom count: 3→1.",
+    "progressSummary": "PROGRESS: Session 3 fixed 2 pre-existing build failures and proved n=1 case of ramsey_triangle axiom. Path to full elimination: iterate 2-color Ramsey theorem (already proved in RamseysTheorem.lean) via color-splitting.",
     "builtItems": [
       "theorem complete_graphs_ramsey: proved from ramsey_triangle via Set.mem_singleton",
-      "theorem triangle_ramsey_mono: proved via Fin.castLE injection"
+      "theorem triangle_ramsey_mono: proved via Fin.castLE injection",
+      "Fixed 2 pre-existing build failures (set literal syntax, Fin.castLE injectivity)",
+      "Proved ramsey_triangle_base: K_3 has 1-color Ramsey property",
+      "Proved ramsey_triangle_one_proved: instantiates axiom for n=1 without axiom"
     ],
     "insights": [
       "complete_graphs_ramsey follows directly from ramsey_triangle: just instantiate with K_N",
       "triangle_ramsey_mono provable via Fin.castLE: embed m-coloring into n-coloring, use injectivity to transfer monochromaticity",
-      "Only ramsey_triangle (classical Ramsey theorem) needs to remain as axiom — deep result not in Mathlib"
+      "Only ramsey_triangle (classical Ramsey theorem) needs to remain as axiom — deep result not in Mathlib",
+      "Set literal syntax changed in Lean 4: {⊤ : T} → ({⊤} : Set T)",
+      "Fin.castLE_injective replaces manual congrArg proof for injectivity",
+      "ramsey_triangle axiom n=1 case is provable: K_3 with Fin 1 colors is trivially monochromatic"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -68,7 +74,7 @@
       "path": "Proofs/Erdos638Problem.lean",
       "filename": "Erdos638Problem.lean",
       "lineCount": 98,
-      "theoremCount": 2,
+      "theoremCount": 4,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-700.json
+++ b/src/data/research/problems/erdos-700.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-14T21:07:11.724Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Axiom elimination: 9->6 axioms. Defined fBinom, proved f_prime_square, removed false Q1 axiom.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,11 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axioms 9->6. Defined fBinom properly, proved minFac(p^2)=p and f(p^2)>=p, removed false axiom. 2 new theorems machine-checked.",
+    "progressSummary": "AXIOM ELIMINATION: Converted f_semiprime from axiom to theorem via sandwich argument (minFac ≤ f ≤ n/largestPrimeFactor). Proved 2 new helper lemmas. Axiom count: 6→5.",
     "builtItems": [
       "Defined fBinom via Finset.min in Erdos700Problem.lean:41-46",
       "Proved minFac_prime_sq in Erdos700Problem.lean:51-57",
-      "Proved f_prime_square in Erdos700Problem.lean:104-112"
+      "Proved f_prime_square in Erdos700Problem.lean:104-112",
+      "Proved minFac_mul_prime: minFac(pq) = p for primes p ≤ q",
+      "Proved le_largestPrimeFactor: prime divisors ≤ largestPrimeFactor",
+      "Converted f_semiprime from axiom to theorem (sandwich argument)",
+      "Axiom count: 6→5"
     ],
     "insights": [
       "fBinom can be defined using Finset.min over Finset.Icc 2 (n/2), nonempty for n>=4",
@@ -74,8 +78,8 @@
       "path": "Proofs/Erdos700Problem.lean",
       "filename": "Erdos700Problem.lean",
       "lineCount": 86,
-      "theoremCount": 0,
-      "axiomCount": 9,
+      "theoremCount": 5,
+      "axiomCount": 5,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/erdos-848.json
+++ b/src/data/research/problems/erdos-848.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-23T21:30:00Z",
-    "iteration": 3,
-    "focus": "Axiom elimination: converted maxNonSqfreeSet to noncomputable def, proved maxNonSqfreeSet_le and lower_bound (6→3 axioms)",
+    "iteration": 4,
+    "focus": "Proved Van Doorn constraint: diagonal + p≡1(mod4) via QR theory",
     "blockers": [],
-    "nextAction": "Remaining 3 axioms are deep results (Van Doorn, Sawhney). Further progress would require formalizing analytic number theory.",
+    "nextAction": "Remaining 3 axioms still require deep analytic NT. Van Doorn bound needs union bound over primes. Sawhney results need additive combinatorics.",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 2,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 3 more axioms (6→3). Converted maxNonSqfreeSet from axiom to noncomputable def via Finset.sup. Proved maxNonSqfreeSet_le via injection x↦x-1. Proved lower_bound via witness construction k↦25k+7. All builds verified.",
+    "progressSummary": "PROGRESS: Proved 5 new theorems formalizing Van Doorn intermediate steps. Key result: vanDoorn_constraint shows every element of A must have a² ≡ -1 (mod p²) for some prime p ≡ 1 (mod 4). Uses Mathlib QR theory (first supplement). File now has 13 proved theorems, 3 deep axioms, 0 sorries.",
     "builtItems": [
       "Proved mod25_achieves (axiom→theorem): 5²|ab+1 when a≡b≡7(mod25)",
       "Proved mod25_achieves_18: symmetric case for a≡b≡18(mod25)",
@@ -38,7 +38,12 @@
       "Converted maxNonSqfreeSet from axiom to noncomputable def via Finset.sup over powerset",
       "Proved maxNonSqfreeSet_le: |A| ≤ |Icc 1 N| ≤ N via injection x↦x-1 to range N",
       "Proved lower_bound: N/25 ≤ maxNonSqfreeSet N via mod7Set witness and injection k↦25k+7",
-      "Added mod7Set helper def with residue, subset, and cardinality lemmas"
+      "Added mod7Set helper def with residue, subset, and cardinality lemmas",
+      "Proved diagonal_constraint: ∀ a ∈ A, ∃ p prime, p² | a²+1",
+      "Proved not_four_dvd_sq_succ: ¬(4 | a²+1) via even/odd case split",
+      "Proved prime_sq_dvd_sq_succ_ne_two: p prime, p² | a²+1 → p ≠ 2",
+      "Proved prime_sq_dvd_sq_succ_mod_four: p prime, p² | a²+1 → p ≡ 1 (mod 4) via ZMod QR",
+      "Proved vanDoorn_constraint: combined result packaging all intermediate steps"
     ],
     "insights": [
       "mod25_achieves is pure arithmetic: 7*7+1=50, 25|50, so 5²|ab+1 for a≡b≡7(mod25)",
@@ -47,7 +52,11 @@
       "maxNonSqfreeSet can be defined as Finset.sup (powerset.filter HasNonSqfreeProductProp) card using open Classical for decidability",
       "Upper bound proof: injection x↦x-1 from Icc 1 N to range N avoids needing Finset.card_Icc",
       "Lower bound proof: injection k↦25k+7 from range(N/25) to mod7Set N, using Nat.div_mul_le_self for the bound 25k+7 ≤ N",
-      "Remaining 3 axioms are genuinely deep: Van Doorn's analytic upper bound, Sawhney's exact solution, and structural characterization"
+      "Remaining 3 axioms are genuinely deep: Van Doorn's analytic upper bound, Sawhney's exact solution, and structural characterization",
+      "Van Doorn constraint proved: every a in A must have p^2 | a^2+1 for some prime p ≡ 1 (mod 4)",
+      "Proved not_four_dvd_sq_succ: 4 never divides a^2+1 (rules out p=2 via mod 4 case analysis)",
+      "Used Mathlib first supplement (ZMod.exists_sq_eq_neg_one_iff) to derive p % 4 = 1 from IsSquare(-1) mod p",
+      "Import of Mathlib.NumberTheory.SumTwoSquares required fixing existing proof (Set coercion in card_le_card_of_injOn)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -78,10 +87,10 @@
     {
       "path": "Proofs/Erdos848Problem.lean",
       "filename": "Erdos848Problem.lean",
-      "lineCount": 177,
-      "theoremCount": 8,
+      "lineCount": 255,
+      "theoremCount": 13,
       "axiomCount": 3,
-      "defCount": 3,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos848Problem.lean"


### PR DESCRIPTION
## Summary
Research session 3 for erdos-1139 (Gaps in Almost-Primes).

## Progress
- **Proved `semiprime_isAlmostPrime`**: Ω(pq) = Ω(p) + Ω(q) = 1 + 1 = 2 via `factorization_mul` + `sum_add_index`
- **Proved `cube_gap_obstruction`**: Ω(8k) = Ω(8) + Ω(k) ≥ 3 > 2, contradiction with almost-prime
- Sorries: **3 → 1** (only `almostPrimeGap` definition sorry remains)

## Status
**Outcome**: progress (sorry elimination)

🤖 Generated by researcher-9