### PR TITLE
Enrich 11 entries: add relatedProofs field (gallery convention)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -245,5 +245,57 @@
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "angle-trisection",
+      "relationship": "ancestor",
+      "description": "The original angle trisection impossibility proof using the degree criterion (deg 3 is not a power of 2). This file proves the Galois criterion implies the degree criterion, connecting the two approaches"
+    },
+    {
+      "id": "angle-trisection-oq-02",
+      "relationship": "parent",
+      "description": "The parent Galois-theoretic formalization with 6 axioms. This file eliminates 1 axiom (galois_2group_implies_degree_pow2) by proving it from Mathlib's tower law"
+    },
+    {
+      "id": "angle-trisection-oq-02-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling open question on the Gauss-Wantzel theorem for regular polygon constructibility — also addresses axiom elimination from OQ-02 but via cyclotomic theory"
+    },
+    {
+      "id": "angle-trisection-oq-02-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Bridges Gauss-Wantzel to Mathlib's cyclotomic infrastructure, paralleling this file's bridge between Galois groups and Mathlib's Polynomial.Gal"
+    },
+    {
+      "id": "inverse-galois",
+      "relationship": "related",
+      "description": "Comprehensive Galois group realizations (S₃, A₅, D₄, etc.) — the inverse direction of the Galois correspondence. Where this file asks 'what constraints does the Galois group impose?', inverse Galois asks 'which groups arise as Galois groups?'"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both use Galois group structure to derive impossibility results: Abel-Ruffini shows non-solvable Galois groups block radical solutions, this file shows non-2-group Galois groups block constructibility"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "The tower law [L:F] = [L:K]·[K:F] — the multiplicativity of field extension degrees, a consequence of Lagrange's theorem — is the central proof technique: applied to F ⊂ F(α) ⊂ SplittingField(p) to derive natDegree | |Gal|"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "complementary",
+      "description": "The irrationality of $\\sqrt{2}$ is the simplest instance of the constructibility framework: $\\text{Gal}(x^2 - 2/\\mathbb{Q}) \\cong \\mathbb{Z}/2\\mathbb{Z}$ is a 2-group of order $2^1$, so $\\sqrt{2}$ is constructible. This file's tower law argument shows why: $[\\mathbb{Q}(\\sqrt{2}):\\mathbb{Q}] = 2 \\mid |\\text{Gal}| = 2$"
+    },
+    {
+      "id": "nth-root-irrational",
+      "relationship": "related",
+      "description": "The irrationality of $\\sqrt[n]{m}$ for non-perfect-power $m$ produces a degree-$n$ extension $[\\mathbb{Q}(\\sqrt[n]{m}):\\mathbb{Q}] = n$. By this file's result, $\\sqrt[n]{m}$ is constructible only if its Galois group is a 2-group — which fails for $n = 3$ since $\\text{Gal}(x^3 - m) \\cong S_3$ has order 6"
+    },
+    {
+      "id": "factor-remainder-theorem",
+      "relationship": "foundational",
+      "description": "The factor theorem ($\\alpha$ is a root of $p(x)$ iff $(x - \\alpha) \\mid p(x)$) underpins the crucial step `minpoly.dvd`: the minimal polynomial divides any polynomial vanishing at $\\alpha$, which yields $\\text{minpoly}(F, \\alpha) \\mid p$ in the tower law argument. The mutual divisibility of irreducible polynomials — the crux of showing $\\deg(\\text{minpoly}) = \\deg(p)$ — rests on this factorization principle"
+    }
+  ]
 }

--- a/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
@@ -333,5 +333,67 @@
       "venue": "Wiley, 2nd edition",
       "note": "Chapter 16 covers the Gauss-Wantzel theorem with complete proofs connecting cyclotomic fields, Galois groups, and constructibility"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "angle-trisection",
+      "relationship": "extends",
+      "description": "Main impossibility proof for angle trisection; OQ02-OQ03 gives the complete constructibility characterization for regular polygons"
+    },
+    {
+      "id": "angle-trisection-oq-02",
+      "relationship": "extends",
+      "description": "OQ02 proves the Galois criterion (α constructible ↔ Gal is 2-group); OQ02-OQ03 applies it to cos(2π/n) to characterize constructible polygons"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "related",
+      "description": "The combinations formula underpins binomial coefficient computations; Euler's totient involves counting coprime residues, a related combinatorial object"
+    },
+    {
+      "id": "angle-trisection-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Proves natDegree | |Gal| via the tower law — the same structural argument that connects the Galois 2-group criterion to the degree criterion used here for cyclotomic polynomials"
+    },
+    {
+      "id": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both link impossibility results to Galois group structure: Abel-Ruffini via solvability (S₅ not solvable), Gauss-Wantzel via 2-groups ((ℤ/nℤ)* not always a 2-group)"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Gauss's work on constructible polygons was intimately connected to his work on quadratic reciprocity — both appear in Disquisitiones Arithmeticae (1801) and both involve the structure of (ℤ/nℤ)*"
+    },
+    {
+      "id": "inverse-galois",
+      "relationship": "related",
+      "description": "The cyclotomic Galois groups Gal(Φₙ/ℚ) ≅ (ℤ/nℤ)* are concrete realizations of finite abelian groups — the abelian case of the inverse Galois problem, resolved by Kronecker-Weber"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's totient function $\\varphi(n)$ is the central object: the Gauss-Wantzel theorem states that the regular $n$-gon is constructible $\\iff \\varphi(n) = 2^k$. The totient's multiplicativity ($\\varphi(mn) = \\varphi(m)\\varphi(n)$ for coprime $m,n$) and the formula $\\varphi(p^k) = p^{k-1}(p-1)$ are the arithmetic engine of the characterization"
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "foundational",
+      "description": "Primitive roots establish that $(\\mathbb{Z}/p\\mathbb{Z})^{\\times}$ is cyclic of order $p-1$. The Gauss-Wantzel proof uses: (1) the cyclotomic Galois group $\\text{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^{\\times}$ has order $\\varphi(n)$, and (2) Gauss's construction of the 17-gon used the 2-group structure of $(\\mathbb{Z}/17\\mathbb{Z})^{\\times} \\cong \\mathbb{Z}/16\\mathbb{Z}$"
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "foundational",
+      "description": "De Moivre's formula expresses the $n$th roots of unity $\\zeta_n = e^{2\\pi i/n}$ that generate cyclotomic extensions. The entire Gauss-Wantzel framework rests on $\\cos(2\\pi/n) = (\\zeta_n + \\zeta_n^{-1})/2$, connecting the geometric quantity (polygon vertex) to the algebraic quantity (cyclotomic field element)"
+    },
+    {
+      "id": "kroneckers-jugendtraum",
+      "relationship": "extends",
+      "description": "Kronecker-Weber theorem: every abelian extension of $\\mathbb{Q}$ is contained in a cyclotomic field $\\mathbb{Q}(\\zeta_n)$. Since constructible numbers generate abelian extensions (2-groups are abelian), all constructible numbers lie in cyclotomic fields — the Gauss-Wantzel criterion determines exactly which cyclotomic fields contain the cosines needed for polygon construction"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "foundational",
+      "description": "The tower law $[L:F] = [L:K] \\cdot [K:F]$ (a consequence of Lagrange's theorem) drives the key computation: $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = [\\mathbb{Q}(\\zeta_n):\\mathbb{Q}(\\cos(2\\pi/n))] \\cdot [\\mathbb{Q}(\\cos(2\\pi/n)):\\mathbb{Q}]$, yielding $[\\mathbb{Q}(\\cos(2\\pi/n)):\\mathbb{Q}] = \\varphi(n)/2$"
+    }
   ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -250,5 +250,37 @@
       "venue": "Flavors of Geometry, MSRI Publications",
       "note": "Modern treatment of high-dimensional volume and the concentration of measure phenomenon"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "area-of-circle-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry proving A = ∫₀ʳ C(ρ) dρ for circles — this file generalizes from 2D to arbitrary dimension n, replacing πr² with ω_n·r^n"
+    },
+    {
+      "id": "area-of-circle-oq-01",
+      "relationship": "extends",
+      "description": "The circumference-from-area differentiation C = dA/dr is the 2D case of this file's n-dimensional derivative relation V'_n = S_n"
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "ancestor",
+      "description": "The original area formalization A = πr² — this file recovers it as the n=2 special case V₂(r) = ω₂·r² = πr²"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "uses",
+      "description": "FTC Part 2 (integral_eq_sub_of_hasDerivAt) is the key tool: since V_n(0) = 0 and V'_n = S_n, FTC gives V_n(r) = ∫₀ʳ S_n(ρ) dρ"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation for Γ(n/2+1) determines the asymptotic behavior of ω_n → 0 as n → ∞, explaining the 'thin shell' phenomenon in high dimensions"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling entry on integration by parts for Fourier coefficients — both extend the circumference integration approach from the parent entry, with this file generalizing to n dimensions and the sibling applying IBP to periodic function analysis"
+    }
   ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
@@ -209,5 +209,47 @@
       "venue": "Princeton Lectures in Analysis",
       "note": "Modern treatment of Fourier series including the derivative formula for Fourier coefficients"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "area-of-circle-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The parent entry proves A = ∫C via FTC. This entry builds Fourier infrastructure needed for the isoperimetric generalization C² ≥ 4πA."
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-03",
+      "relationship": "supports",
+      "description": "The Wirtinger inequality entry uses Fourier decomposition for the isoperimetric proof; this IBP formula is a key ingredient."
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "specializes",
+      "description": "The general Fourier series theory provides the foundation; this entry proves a specific derivative property of Fourier coefficients used in geometric applications."
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "supports",
+      "description": "This IBP formula is a key analytical ingredient in the Fourier-analytic proof of the isoperimetric inequality $C^2 \\geq 4\\pi A$."
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "Integration by parts is derived from the product rule and FTC — the IBP formula fourierCoeffOn_of_hasDerivAt used here is Mathlib's formalization of this principle for interval integrals"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling entry generalizing circumference integration to n-dimensional volume from surface area — both extend the parent's radial integration technique, with this file applying it to periodic function analysis via IBP and the sibling extending to higher-dimensional geometry"
+    },
+    {
+      "id": "area-of-circle",
+      "relationship": "extends",
+      "description": "Root ancestor: the area of a circle $A = \\pi r^2$ via integration. This entry provides Fourier infrastructure toward the isoperimetric inequality $L^2 \\geq 4\\pi A$, which characterizes the circle as the shape maximizing area for a given perimeter."
+    },
+    {
+      "id": "fundamental-theorem-calculus-oq-01",
+      "relationship": "related",
+      "description": "Integration by parts — the core technique in this proof — is a direct corollary of the product rule and FTC. The Fourier IBP formula specializes general IBP to the setting of exponential basis functions $e^{-int}$."
+    }
   ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
@@ -177,5 +177,42 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 2
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "area-of-circle",
+      "relationship": "extends",
+      "description": "The foundational Area of a Circle entry proves A = πr² via Lebesgue measure. This entry derives the same formula by integration, using circumference as the integrand."
+    },
+    {
+      "id": "area-of-circle-oq-01",
+      "relationship": "companion",
+      "description": "The companion entry proves C = dA/dr (differentiation direction). This entry proves A = ∫C dr (integration direction). Together they establish the complete FTC duality for circle geometry."
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "uses",
+      "description": "This proof is a direct application of FTC Part 2 (integral_eq_sub_of_hasDerivAt) from the Fundamental Theorem of Calculus entry."
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "related",
+      "description": "The annulus area formula ∫_{r₁}^{r₂} 2πρ dρ = π(r₂²-r₁²) proved here relates to the isoperimetric inequality: the circle achieves the maximum area-to-perimeter ratio"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "Both use Mathlib's π: the integral ∫₀ʳ 2πρ dρ = πr² involves the same transcendental constant whose properties are established in the π-transcendence formalization"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Generalizes the circumference-to-area integration from 2D circles to n-dimensional spheres: $V_n(r) = \\int_0^r S_n(\\rho)\\, d\\rho$ where $S_n$ is the surface area of the n-sphere. The same radial integration technique that yields $\\pi r^2$ from $2\\pi r$ extends to derive volume formulas for spheres, hyperspheres, and higher-dimensional balls"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02-oq-02",
+      "relationship": "extended-by",
+      "description": "Integration by parts for Fourier coefficients of periodic functions — the same IBP technique used in the circumference integration proof extends to computing the Fourier coefficients that arise when representing geometric quantities (like arc length and curvature) as trigonometric series"
+    }
+  ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -249,5 +249,47 @@
     "axiomCount": 0,
     "theoremCount": 44,
     "definitionCount": 10
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "area-of-circle",
+      "relationship": "extends",
+      "description": "The circle's isoperimetric optimality extends the basic area formula"
+    },
+    {
+      "id": "area-of-circle-oq-01",
+      "relationship": "extends",
+      "description": "OQ01 proves C = dA/dr; OQ03 proves C is isoperimetrically optimal"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "OQ01-OQ02 proves A = ∫C dρ; OQ03 proves C²≥4πA completes the circle"
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "extends",
+      "description": "Wiedijk #43: the abstract version is in IsoperimetricTheorem.lean; this file provides the OQ-chain approach"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02-oq-02",
+      "relationship": "uses",
+      "description": "The IBP formula for Fourier coefficients ĉₙ(f') = in·ĉₙ(f) proved there is a key ingredient in Hurwitz's Fourier-analytic proof of the isoperimetric inequality"
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "foundational",
+      "description": "The Fourier decomposition and Parseval's identity from Fourier series theory underpin the spectral proof: the isoperimetric inequality reduces to comparing Fourier coefficient norms"
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "uses",
+      "description": "The 2D Cauchy-Schwarz inequality (xv-yu)² ≤ (x²+y²)(u²+v²) proved here as cross_product_sq_le is used in the arithmetic kernel of the isoperimetric proof"
+    },
+    {
+      "id": "borsuk-ulam",
+      "relationship": "thematic",
+      "description": "The Borsuk-Ulam theorem and the isoperimetric inequality are both topological/geometric results about the structure of continuous maps on spheres. While the isoperimetric inequality characterizes the circle as the area-optimal curve, Borsuk-Ulam provides topological constraints on continuous mappings of spheres — both reveal deep geometric rigidity phenomena"
+    }
+  ]
 }

--- a/src/data/proofs/area-of-circle-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01/meta.json
@@ -180,5 +180,27 @@
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 2
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "area-of-circle",
+      "relationship": "extends",
+      "description": "This proof answers the open question from the Area of a Circle entry: whether $C = 2\\pi r$ can be derived by differentiating $A = \\pi r^2$. It extends that formalization from the integral/measure-theoretic direction to the differential calculus direction."
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "related",
+      "description": "The isoperimetric equality $C^2 = 4\\pi A$ proved here as a corollary is the equality case of the full isoperimetric inequality formalized in the Isoperimetric Theorem entry."
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "Both formalizations use $\\pi$ as defined in Mathlib's trigonometric module. The transcendence of $\\pi$ ensures the circumference $2\\pi r$ is transcendental for any nonzero rational radius."
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "The central insight — C = dA/dr — is a direct application of the fundamental theorem of calculus: differentiating the area function πr² yields the circumference 2πr, and integrating the circumference recovers the area"
+    }
+  ]
 }

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -297,5 +297,92 @@
       "venue": "Princeton Lectures in Analysis, vol. 3, Princeton University Press",
       "note": "Modern treatment of Lebesgue measure and volume computation for balls in ℝⁿ — the framework underlying this formalization's approach via MeasureTheory.volume"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "angle-trisection",
+      "relationship": "related",
+      "description": "Both involve pi and circle geometry — squaring the circle (constructing sqrt(pi)) is impossible by Lindemann's theorem"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "π is transcendental (Lindemann 1882) — the same constant whose geometric meaning as the area-to-radius-squared ratio this file formalizes. Transcendence means πr² cannot be a constructible area for all r"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The circle x²+y²=r² is defined by the Pythagorean relation — the equation underpinning the Lebesgue measure computation of the disk's area"
+    },
+    {
+      "id": "hermite-lindemann",
+      "relationship": "related",
+      "description": "The Hermite-Lindemann theorem proves π is transcendental, meaning the area πr² is transcendental for all nonzero algebraic r — connecting the geometric formula to number-theoretic impossibility"
+    },
+    {
+      "id": "basel-problem",
+      "relationship": "related",
+      "description": "Euler's Basel problem (∑1/n² = π²/6) provides another unexpected appearance of π — the same constant whose geometric meaning as the area-to-radius² ratio is formalized here. Euler's proof connecting ∑1/n² to sin(x)/x reveals π's dual role in geometry and analysis"
+    },
+    {
+      "id": "area-of-circle-oq-01",
+      "relationship": "extended-by",
+      "description": "Derives the circumference formula $C = 2\\pi r$ via differentiation of the area $A = \\pi r^2$ with respect to $r$ — the infinitesimal shell argument that $dA/dr = C$ connects area and perimeter"
+    },
+    {
+      "id": "area-of-circle-oq-03",
+      "relationship": "extended-by",
+      "description": "Formalizes Archimedes' method of exhaustion directly: approximating the circle's area by inscribed and circumscribed regular polygons, providing the historical approach that this file's measure-theoretic proof subsumes"
+    },
+    {
+      "id": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "The intermediate value theorem underpins the continuity arguments needed for integration. Archimedes' method of exhaustion is essentially a continuity argument — the area function $A(r) = \\pi r^2$ is continuous, and the method of exhaustion proves equalities by showing the difference can be made arbitrarily small"
+    },
+    {
+      "id": "isoperimetric-theorem",
+      "relationship": "complementary",
+      "description": "The isoperimetric inequality states that among all planar curves of fixed perimeter $L$, the circle encloses the maximum area $L^2/(4\\pi)$. This provides a variational characterization of the circle: $A = \\pi r^2$ is the maximum area achievable with perimeter $C = 2\\pi r$. Equality holds if and only if the curve is a circle, making the area formula a consequence of the isoperimetric optimality"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Derives the area formula by integrating circumference: $A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$, showing the circle's area as the accumulation of concentric ring circumferences — a radial integration approach complementing the Cartesian disk-area proof"
+    },
+    {
+      "id": "area-of-circle-oq-01-oq-03",
+      "relationship": "extended-by",
+      "description": "The isoperimetric inequality $C^2 \\geq 4\\pi A$ with equality iff the curve is a circle — the variational characterization showing the circle maximizes area for a given perimeter, connecting the area formula $\\pi r^2$ to the deep optimality of circular geometry"
+    },
+    {
+      "id": "area-of-circle-oq-03-oq-02",
+      "relationship": "extended-by",
+      "description": "Archimedes' bounds $223/71 < \\pi < 22/7$ via inscribed and circumscribed regular 96-gons — the computational complement to the area formula, providing the first rigorous numerical approximation of the constant $\\pi$ that appears in $A = \\pi r^2$"
+    },
+    {
+      "id": "lebesgue-measure",
+      "relationship": "foundational",
+      "description": "This proof formalizes area as Lebesgue measure $\\lambda^2$. The Lebesgue measure entry provides the measure-theoretic infrastructure underpinning `MeasureTheory.volume` and the $n$-dimensional ball volume formula $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ that specializes to $\\pi r^2$ for $n=2$"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "The annular ring derivation of $A = \\pi r^2$ is a direct application of the Fundamental Theorem of Calculus: $A(r) = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$, and the derivative relationship $A'(r) = C(r) = 2\\pi r$ is FTC in action. The measure-theoretic proof in this file uses Fubini's theorem (the higher-dimensional analog) rather than FTC directly, but the connection between area and circumference via differentiation is a central pedagogical theme"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "The general $n$-dimensional ball volume $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ that underpins this proof uses the Gamma function $\\Gamma$, whose asymptotic behavior is governed by Stirling's formula $\\Gamma(n+1) \\sim \\sqrt{2\\pi n}(n/e)^n$. For the 2D case, $\\Gamma(2) = 1! = 1$ makes the formula simplest, but Stirling's approximation is essential for understanding the volume of high-dimensional balls (which shrinks to 0 as $n \\to \\infty$ — a counterintuitive consequence of the $\\Gamma$ denominator's factorial growth)"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "The transcendence of $e$ connects to the circle area formula through the Gaussian integral: $\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}$, proved by squaring and converting to polar coordinates where the area element $r\\, dr\\, d\\theta$ derives from $A = \\pi r^2$. The appearance of both $e$ and $\\pi$ in this integral reflects their deep algebraic independence (both transcendental) and analytic interconnection via the complex exponential $e^{i\\theta}$"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} = -1$ connects to the circle area formula through the complex plane: this formalization uses $\\mathbb{C}$ as its ambient space precisely because the unit circle $\\{z : |z| = 1\\}$ is parameterized by $e^{i\\theta}$ for $\\theta \\in [0, 2\\pi)$. The area enclosed by this exponential curve is $\\pi \\cdot 1^2 = \\pi$ (the `area_unit_disk` corollary). More deeply, $e^{i\\pi} = -1$ encodes the half-turn symmetry of the circle, and the appearance of $\\pi$ in both the area formula and the exponential reflects $\\pi$'s dual role as a geometric constant (area-to-radius-squared ratio) and an analytic period (half-period of $e^{i\\theta}$)"
+    }
   ]
 }


### PR DESCRIPTION
Batch enrichment adding `relatedProofs` arrays matching `crossReferences` (gallery convention).

## Entries enriched (11 total)
| Entry | Related Proofs |
|-------|---------------|
| amgm-inequality | 9 |
| amgm-inequality-oq-03-oq-02 | 12 |
| angle-trisection-oq-02 | 14 |
| angle-trisection-oq-02-oq-01 | 10 |
| angle-trisection-oq-02-oq-03 | 12 |
| area-of-circle | 17 |
| area-of-circle-oq-01 | 4 |
| area-of-circle-oq-01-oq-02 | 7 |
| area-of-circle-oq-01-oq-02-oq-01 | 6 |
| area-of-circle-oq-01-oq-02-oq-02 | 8 |
| area-of-circle-oq-01-oq-03 | 8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)