### PR TITLE
Research: erdos-668 - prove congruent_unitDistanceCount (sorry 2→1)

### DIFF
--- a/proofs/Proofs/Erdos668Problem.lean
+++ b/proofs/Proofs/Erdos668Problem.lean
@@ -73,7 +73,7 @@ def areCongruent (S T : Finset Plane) : Prop :=
 theorem congruent_refl (S : Finset Plane) : areCongruent S S := by
   refine ⟨IsometryEquiv.refl Plane, fun p hp => ?_, fun q hq => ⟨q, hq, ?_⟩⟩
   · simpa using hp
-  · simp
+  · rfl
 
 /-- Congruence is symmetric. -/
 theorem congruent_symm {S T : Finset Plane} (h : areCongruent S T) :
@@ -108,7 +108,31 @@ theorem isUnitPair_of_isometry (φ : Plane ≃ᵢ Plane) {p q : Plane}
 theorem congruent_unitDistanceCount {S T : Finset Plane}
     (h : areCongruent S T) (hcard : S.card = T.card) :
     unitDistanceCount S = unitDistanceCount T := by
-  sorry
+  obtain ⟨φ, hST, hTS⟩ := h
+  unfold unitDistanceCount
+  suffices Set.ncard (unitDistancePairs S) = Set.ncard (unitDistancePairs T) by
+    rw [this]
+  -- The pair map (p, q) ↦ (φ p, φ q) is injective (since φ is an isometry equiv)
+  have hΦ_inj : Function.Injective (fun pq : Plane × Plane => (φ pq.1, φ pq.2)) := by
+    intro ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ heq
+    simp only [Prod.mk.injEq] at heq
+    exact Prod.ext (φ.injective heq.1) (φ.injective heq.2)
+  -- The pair map sends unitDistancePairs S onto unitDistancePairs T
+  have himg : (fun pq : Plane × Plane => (φ pq.1, φ pq.2)) '' unitDistancePairs S =
+      unitDistancePairs T := by
+    ext ⟨a, b⟩
+    simp only [Set.mem_image, Prod.exists, unitDistancePairs, Set.mem_setOf_eq, Prod.mk.injEq]
+    constructor
+    · rintro ⟨p, q, ⟨hp, hq, hne, hdist⟩, rfl, rfl⟩
+      exact ⟨hST p hp, hST q hq, fun h => hne (φ.injective h),
+        isUnitPair_of_isometry φ hdist⟩
+    · rintro ⟨ha, hb, hne, hdist⟩
+      obtain ⟨p, hp, rfl⟩ := hTS a ha
+      obtain ⟨q, hq, rfl⟩ := hTS b hb
+      refine ⟨p, q, ⟨hp, hq, fun hpq => hne (congrArg (⇑φ) hpq), ?_⟩, rfl, rfl⟩
+      unfold isUnitPair at hdist ⊢
+      rwa [← φ.dist_eq]
+  rw [← himg, Set.ncard_image_of_injective _ hΦ_inj]
 
 /-- Congruence preserves extremality. -/
 theorem congruent_preserves_extremal {S T : Finset Plane}
@@ -182,7 +206,10 @@ theorem erdos_668_summary :
       areCongruent S T) :=
   ⟨f_four, four_config_unique⟩
 
-/-- f(n) >= 1 for all n >= 1 (at least one extremal configuration exists). -/
+/-- f(n) >= 1 for all n >= 1 (at least one extremal configuration exists).
+    Proof requires both extremalConfigs_nonempty (axiom) and Set.Finite (extremalConfigs n)
+    (true but requires deep combinatorial geometry: finitely many extremal unit-distance
+    graphs exist for each n). Without finiteness, Set.ncard returns 0 for infinite sets. -/
 theorem f_pos (n : ℕ) (hn : n ≥ 1) : f n ≥ 1 := by
   sorry
 

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 668,
     "erdosUrl": "https://erdosproblems.com/668",
     "erdosProblemStatus": "open",
@@ -61,8 +61,8 @@
       }
     ],
     "axiomCount": 7,
-    "lineCount": 189,
-    "assumptions": "7 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "lineCount": 216,
+    "assumptions": "7 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #668**\n\nThis problem explores the structure of extremal configurations for the classical unit distance problem in the plane.\n\n**Background:**\nThe unit distance problem (Erdos Problem #90) asks: what is the maximum number u(n) of unit distances among n points in the plane? Problem #668 goes further, asking about the UNIQUENESS of configurations achieving this maximum.\n\n**Historical Development:**\n- The unit distance problem was posed by Erdos in 1946\n- The case n=4 is fully understood: exactly one configuration (the double triangle)\n- Computational work by Engel, Hammond-Lee, Su, Varga, Zsamboki [EHSVZ25] and Alexeev, Mixon, Parshall [AMP25] suggests uniqueness for 5 <= n <= 21\n\n**Status:** OPEN",
@@ -202,7 +202,7 @@
       "Finset"
     ],
     "namespace": "Erdos668",
-    "lineCount": 189,
+    "lineCount": 216,
     "axiomCount": 7,
     "theoremCount": 9,
     "definitionCount": 12

--- a/src/data/research/problems/erdos-668.json
+++ b/src/data/research/problems/erdos-668.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-13T18:22:04.305Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved congruent_unitDistanceCount, assessed all axioms",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved congruent_unitDistanceCount (sorry→proof), fixed pre-existing simp bug. Sorries reduced 2→1. f_pos blocked on Set.Finite.",
+    "builtItems": [
+      "Proved congruent_unitDistanceCount (Erdos668Problem.lean:107-135)",
+      "Fixed congruent_refl simp bug (Erdos668Problem.lean:76)"
+    ],
+    "insights": [
+      "congruent_unitDistanceCount proved: isometry pair map φ×φ is injective and maps unitDistancePairs S onto unitDistancePairs T, preserving Set.ncard",
+      "f_pos requires Set.Finite (extremalConfigs n) which holds but needs deep combinatorial geometry to formalize — Set.ncard returns 0 for infinite sets",
+      "Pre-existing simp bug in congruent_refl fixed: changed · simp to · rfl for IsometryEquiv.refl application",
+      "Axiom classification: f_four/four_config_unique/u_four are deep computational, computational_evidence is empirical, extremalConfigs_nonempty needs compactness, u_lower_bound is most tractable (chain construction), u_upper_bound is Spencer-Szemeredi-Trotter"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove u_lower_bound by constructing chain of unit-distance points (most tractable axiom)",
+      "Find correct Mathlib API for Set.ncard_pos to prove f_pos_of_finite",
+      "Consider switching f definition to use Cardinal or ENat to handle potentially infinite sets"
+    ],
     "markdown": "# Erdős #668 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that the number of incongruent sets of $n$ points in $\\mathbb{R}^2$ which maximise the number of unit distances tends to infinity as $n\\to\\infty$? Is it always $>1$ for $n>3$?\n\n\n\nIn fact this is $=1$ also for $n=4$, the unique example given by two equilateral triangles joined by an edge.\n\nComputational evidence of Engel, Hammond-Lee, Su, Varga, and Zs\\'{a}mboki \\cite{EHSVZ25} and Alexeev, Mixon, and Parshall \\cite{AMP25} suggests that this count is $=1$ for various other $5\\leq n\\leq 21$ (although these calculations were checking only up to graph isomorphism, rather than congruency).\n\nThe actual maximal number of unit distances is the subject of [90].\n\n\n\n\nReferences\n\n\n[AMP25] B. Alexeev, D. Mixon, and H. Parshall, The Erd\\H{o}s unit distance problem for small point sets. arXiv:2412.11914 (2025).\n\n[EHSVZ25] P. Engel, O. Hammond-Lee, Y. Su, D. Varga, and P. Zs\\'{a}mboki, Diverse beam search to find densest-known planar unit distance graphs. arXiv:2406.15317 (2025).\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #90\n- Problem #667\n- Problem #669\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #3\n\n## References\n\n- Er97f\n- EHSVZ25\n- AMP25\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for erdos-668 (Unit Distance Configuration Uniqueness).

## Progress
- **Proved `congruent_unitDistanceCount`**: Filled sorry with full proof that isometry-induced pair map `(p,q) ↦ (φ p, φ q)` bijects `unitDistancePairs S` onto `unitDistancePairs T`, preserving `Set.ncard`
- **Fixed pre-existing `simp` bug** in `congruent_refl` (line 76: `simp` → `rfl` for `IsometryEquiv.refl` application)
- **Updated meta.json**: sorries 2→1, line count 189→216
- **Docker build**: Passes cleanly (only warning: unused `hcard` parameter)

## Findings
- `f_pos` sorry requires `Set.Finite (extremalConfigs n)` — mathematically true but needs deep combinatorial geometry to formalize
- `Set.ncard` returns 0 for infinite sets, creating a formalization gap for `f(n) ≥ 1`
- Axiom classification: `u_lower_bound` (chain construction) is most tractable for future elimination; `u_upper_bound` (Spencer-Szemerédi-Trotter) is deepest

## Status
**Outcome**: progress (1 sorry filled, 1 bug fixed)
**Next Steps**: Prove `u_lower_bound` axiom, find correct Mathlib API for `Set.ncard` finiteness lemmas

🤖 Generated by researcher-4