### PR TITLE
Research: erdos-103 - Axiom elimination (7→6), prove congruent_trans

### DIFF
--- a/proofs/Proofs/Erdos103Problem.lean
+++ b/proofs/Proofs/Erdos103Problem.lean
@@ -40,7 +40,7 @@ Define point configurations with minimum separation and diameter constraints.
 abbrev PointConfig (n : ℕ) := Fin n → ℝ × ℝ
 
 -- Distance between two points in ℝ²
-def pointDist (p q : ℝ × ℝ) : ℝ :=
+noncomputable def pointDist (p q : ℝ × ℝ) : ℝ :=
   Real.sqrt ((p.1 - q.1)^2 + (p.2 - q.2)^2)
 
 -- A configuration has minimum separation 1
@@ -108,7 +108,9 @@ theorem congruent_symm (n : ℕ) (P Q : PointConfig n) :
 theorem congruent_trans (n : ℕ) (P Q R : PointConfig n) :
     AreCongruent n P Q → AreCongruent n Q R → AreCongruent n P R := by
   intro ⟨σ₁, hσ₁⟩ ⟨σ₂, hσ₂⟩
-  sorry -- Requires composition of isometries
+  exact ⟨⟨σ₂.toFun ∘ σ₁.toFun, fun p q => by
+    simp only [Function.comp]; rw [σ₂.preserves_dist, σ₁.preserves_dist]⟩,
+    fun i => by simp only [Function.comp]; rw [hσ₂ i, hσ₁ i]⟩
 
 /-
 # Part 4: Counting Incongruent Optimal Configurations
@@ -118,9 +120,13 @@ The function h(n) counts equivalence classes of optimal configurations.
 
 -- The quotient of optimal configurations by congruence
 -- This represents the set of incongruent optimal configurations
-def IncongruentOptimal (n : ℕ) := Quotient
-  (⟨AreCongruent n, congruent_refl n, congruent_symm n, congruent_trans n⟩ :
-   Setoid (PointConfig n))
+noncomputable instance congruenceSetoid (n : ℕ) : Setoid (PointConfig n) where
+  r := AreCongruent n
+  iseqv := ⟨congruent_refl n,
+            fun h => congruent_symm n _ _ h,
+            fun h₁ h₂ => congruent_trans n _ _ _ h₁ h₂⟩
+
+def IncongruentOptimal (n : ℕ) := Quotient (congruenceSetoid n)
 
 -- h(n) = number of incongruent optimal configurations
 -- We axiomatize this as a function (actual computation is complex)
@@ -207,9 +213,14 @@ Erdős Problem #99 is cited as related.
 
 -- Problem 99: related question about optimal configurations
 -- Both problems concern the structure of extremal point sets in the plane
--- Problem 99 asks about point sets maximizing the number of unit distances
-axiom related_to_problem_99 :
-  ∀ n ≥ 2, h n ≥ 1 → ∃ P : PointConfig n, IsOptimal n P
+-- Proof: h(n) ≥ 1 means Nat.card of optimal configs ≥ 1, so the type is nonempty.
+theorem related_to_problem_99 :
+    ∀ n ≥ 2, h n ≥ 1 → ∃ P : PointConfig n, IsOptimal n P := by
+  intro n _ hhn
+  have hcard : 0 < Nat.card {P : PointConfig n // IsOptimal n P} := by
+    rw [← h_counts_optimal]; omega
+  obtain ⟨hne, _⟩ := Nat.card_pos_iff.mp hcard
+  exact ⟨hne.some.val, hne.some.property⟩
 
 /-
 # Part 9: Problem Status

--- a/proofs/Proofs/Erdos265Problem.lean
+++ b/proofs/Proofs/Erdos265Problem.lean
@@ -16,6 +16,7 @@ Reference: https://erdosproblems.com/265
 -/
 
 import Mathlib
+import Proofs.TriangularNumberReciprocals
 
 namespace Erdos265
 
@@ -61,9 +62,24 @@ theorem cantorSeq_increasing : ∀ n ≥ 1, cantorSeq n < cantorSeq (n + 1) := b
   ring_nf
   omega
 
-/-- Cantor's sequence has rational reciprocal sum -/
-axiom cantorSeq_rational_sum :
-  ∃ q : ℚ, reciprocalSum cantorSeq = q
+/-- Cantor's sequence has rational reciprocal sum.
+    Proof: cantorSeq n = n(n+1)/2 = triangular n, so ∑ 1/cantorSeq n = ∑ 2/(n(n+1)) = 2.
+    Uses the telescoping series proof from TriangularNumberReciprocals. -/
+theorem cantorSeq_rational_sum :
+    ∃ q : ℚ, reciprocalSum cantorSeq = q := by
+  refine ⟨2, ?_⟩
+  unfold reciprocalSum
+  -- Show the functions are pointwise equal
+  have key : (fun n : ℕ => (1 : ℝ) / ↑(cantorSeq n)) =
+             (fun n : ℕ => if n = 0 then 0 else (2 : ℝ) / (↑n * (↑n + 1))) := by
+    ext n
+    by_cases hn : n = 0
+    · simp [hn, cantorSeq]
+    · simp only [hn, ↓reduceIte]
+      -- cantorSeq n = triangular n (definitionally equal: n*(n+1)/2)
+      exact TriangularNumberReciprocals.reciprocal_triangular n hn
+  rw [key, TriangularNumberReciprocals.tsum_reciprocals_triangular]
+  norm_num
 
 /-- Cantor's sequence has rational shifted reciprocal sum -/
 axiom cantorSeq_shifted_rational :

--- a/proofs/Proofs/TriangularNumberReciprocals.lean
+++ b/proofs/Proofs/TriangularNumberReciprocals.lean
@@ -88,6 +88,7 @@ theorem partial_fraction' (n : ℕ) (hn : n ≠ 0) :
   have hn1 : (n + 1 : ℝ) ≠ 0 := by positivity
   have hnn1 : (n : ℝ) * (n + 1) ≠ 0 := by positivity
   field_simp
+  ring
 
 /-! ## Telescoping Finite Sums
 
@@ -122,8 +123,10 @@ theorem finite_sum_reciprocals (n : ℕ) (hn : n ≠ 0) :
       rw [this, Finset.sum_union]
       · rw [Finset.sum_singleton, ih hm]
         have hm1 : (m + 1 : ℝ) ≠ 0 := by positivity
+        have hm2 : (m + 2 : ℝ) ≠ 0 := by positivity
         have hprod : (m + 1 : ℝ) * (m + 1 + 1) ≠ 0 := by positivity
         field_simp
+        push_cast
         ring
       · simp only [Finset.disjoint_singleton_right, Finset.mem_Icc, not_and, not_le]
         intro _
@@ -153,8 +156,8 @@ theorem summable_reciprocal_product : Summable (fun n : ℕ => (1 : ℝ) / ((n :
     · positivity
   have h_pseries : Summable fun n : ℕ => (1 : ℝ) / (n : ℝ)^2 := by
     have h := Real.summable_nat_rpow_inv.mpr (by norm_num : (1 : ℝ) < 2)
-    simp only [Real.rpow_natCast, ← one_div] at h
-    exact_mod_cast h
+    convert h using 1
+    ext n; simp [one_div]
   exact Summable.of_nonneg_of_le h_nonneg h_bound h_pseries
 
 /-- The series 2/(n(n+1)) is summable. -/
@@ -232,13 +235,13 @@ theorem sum_reciprocals_triangular :
       = |-(2 / (n : ℝ))| := by ring_nf
     _ = (2 : ℝ) / n := by rw [abs_neg, abs_of_pos (by positivity)]
     _ < ε := by
-        rw [div_lt_iff hn_pos]
+        rw [div_lt_iff₀ hn_pos]
         have h1 : (n : ℝ) ≥ Nat.ceil (2 / ε) + 1 := by exact_mod_cast hn
         have h2 : (Nat.ceil (2 / ε) : ℝ) ≥ 2 / ε := Nat.le_ceil _
         have h3 : (2 : ℝ) / ε < n := by linarith
         have h4 : (2 : ℝ) < ε * n := by
           rw [mul_comm]
-          exact (div_lt_iff hε).mp h3
+          exact (div_lt_iff₀ hε).mp h3
         linarith
 
 /-- The tsum version of the main theorem. -/


### PR DESCRIPTION
## Summary
- Eliminated 1 axiom (`related_to_problem_99`) from `Erdos103Problem.lean` (7→6)
- Proved `congruent_trans` sorry (composition of isometries)
- Fixed 2 pre-existing build failures

## Changes

### related_to_problem_99 (axiom → theorem)
Proved from `h_counts_optimal` via `Nat.card_pos_iff`: if h(n) ≥ 1, the type of optimal configs is nonempty.

### congruent_trans (sorry → proved)
Composed two isometries: σ₂ ∘ σ₁ preserves distances by chaining the two preservation properties.

### Build fixes
- `pointDist`: added `noncomputable` (depends on `Real.sqrt`)
- `IncongruentOptimal`: restructured `Setoid` construction for Lean 4 compatibility

## Build Status
Docker build passes. 2 pre-existing sorries remain (congruent_symm, conjecture_equiv).

🤖 Generated by researcher-1