### PR TITLE
Fix: erdos-5 sorry count 0→1 in meta.json

### DIFF
--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -16,13 +16,13 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 5,
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
     "lineCount": 446,
-    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), merikoski_bounded_gaps (S has bounded gaps, 2020). 0 sorries. Proves 19 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_unbounded, westzynthius_implies_frequently_large. Gallery metadata now points to main formalization (Erdos5PrimeGaps.lean) instead of legacy stub.",
+    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), merikoski_bounded_gaps (S has bounded gaps, 2020). 1 sorry in limitPointSet_isClosed (closedness of limit point set). Proves 19 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_unbounded, westzynthius_implies_frequently_large.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -109,7 +109,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 19 theorems from 3 axioms with 0 sorries. The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Structural results include: S is nonempty, S is unbounded (from Merikoski), and normalized gaps exceed any bound infinitely often. The conjecture reduces to showing all C ≥ 0 are limit points.",
+    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 19 theorems from 3 axioms with 1 sorry (limitPointSet_isClosed). The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Structural results include: S is nonempty, S is unbounded (from Merikoski), and normalized gaps exceed any bound infinitely often. The conjecture reduces to showing all C ≥ 0 are limit points.",
     "implications": "Resolution would provide a complete understanding of prime gap fluctuations at the logarithmic scale, confirming the prediction of Cramér's probabilistic model. It connects to the Hardy-Littlewood prime k-tuples conjecture (which would imply S = [0, ∞)), sieve methods (the GPY-Maynard-Tao framework), and the distribution of primes in short intervals.",
     "openQuestions": [
       "Is every C ≥ 0 a limit point of (p_{n+1} - p_n)/log(p_n)?",


### PR DESCRIPTION
## Fix

Update erdos-5 meta.json sorry count from 0 to 1 to match the actual sorry in `limitPointSet_isClosed` (line 433 of Erdos5PrimeGaps.lean).

## Evidence

**Before**: `"sorries": 0`, assumptions text says "0 sorries"
**After**: `"sorries": 1`, assumptions text mentions the sorry in `limitPointSet_isClosed`

Closes #6217

---
Automated fix by lean-mechanic agent.