### PR TITLE
Audit: erdos-1105 fix counts after axiom elimination

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2793,9 +2793,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1105": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-24T18:28:14Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1106": {

--- a/src/data/proofs/erdos-1105/meta.json
+++ b/src/data/proofs/erdos-1105/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1105",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1105Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1105,
     "erdosUrl": "https://erdosproblems.com/1105",
     "erdosProblemStatus": "open",
@@ -59,9 +59,9 @@
       "yuan_path_announced axiom",
       "turan definition: extremal graph theory connection"
     ],
-    "axiomCount": 8,
-    "lineCount": 291,
-    "assumptions": "8 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "axiomCount": 7,
+    "lineCount": 397,
+    "assumptions": "7 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős, Simonovits, and Sós introduced anti-Ramsey theory in their 1975 paper, asking for the maximum number of colors in an edge-coloring of K_n that avoids a rainbow (all-distinct-colors) copy of a given graph G.\n\nThe problem connects Ramsey theory (which minimizes colors to force monochromatic subgraphs) with extremal graph theory. While classical Ramsey theory asks 'how many colors before monochromatic H?', anti-Ramsey asks 'how many colors while avoiding rainbow H?'\n\nThe case AR(n, C_3) = n - 1 was proven in the original paper. The general cycle formula remains open, while the path formula has seen recent progress with Yuan's 2021 announcement.",
@@ -291,8 +291,8 @@
       "BigOperators"
     ],
     "namespace": "Erdos1105",
-    "lineCount": 291,
-    "axiomCount": 8,
+    "lineCount": 397,
+    "axiomCount": 7,
     "theoremCount": 3,
     "definitionCount": 25
   }


### PR DESCRIPTION
## Summary
Research PR #6192 eliminated 1 axiom and 1 sorry from erdos-1105 but didn't update meta.json.

| Field | Before | After |
|-------|--------|-------|
| `sorries` | 1 | **0** |
| `axiomCount` | 8 | **7** |
| `status` | formalized | **axiomatized** |
| `lineCount` | 291 | **397** |

## Test plan
- [ ] Verify `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)