### PR TITLE
Enrich 35 entries: add relatedProofs field (gallery convention)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -201,5 +201,32 @@
       "venue": "Comptes Rendus de l'Académie des Sciences (Paris)",
       "note": "Early version of the cycle lemma approach, preceding the 1947 joint paper with Motzkin"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "ballot-problem-oq-01",
+      "relationship": "parent",
+      "description": "Parent proof containing the full Dvoretzky-Motzkin Cycle Lemma (cycle_lemma: |goodRotations l| = a - k*b) that uses this discrete IVT as a key ingredient"
+    },
+    {
+      "id": "ballot-problem",
+      "relationship": "ancestor",
+      "description": "Classical Bertrand ballot theorem: setting k=1 in the cycle lemma recovers the ballot problem probability (a-b)/(a+b)"
+    },
+    {
+      "id": "intermediate-value-theorem",
+      "relationship": "related",
+      "description": "This file proves a discrete analog of the IVT: for {+1,-k}-sequences, prefix sums that start below and end above a target value v must achieve exactly v at some intermediate position — the same 'crossing' principle as the continuous IVT"
+    },
+    {
+      "id": "ballot-problem-oq-02",
+      "relationship": "sibling",
+      "description": "Continuous-time analog via Brownian motion — while this file uses discrete IVT for the cycle lemma, the sibling extends ballot counting to the continuous setting where random walks become Brownian bridges and the cycle lemma becomes the reflection principle"
+    },
+    {
+      "id": "ballot-problem-oq-03",
+      "relationship": "sibling",
+      "description": "The Lindström-Gessel-Viennot lemma via 2D reflection — a different combinatorial approach to ballot-type counting. While this file uses cyclic rotation (Dvoretzky-Motzkin), LGV uses lattice path non-intersection, providing a dual perspective on the same counting problems"
+    }
   ]
 }

--- a/src/data/proofs/ballot-problem-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02/meta.json
@@ -208,5 +208,32 @@
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 3
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "ballot-problem-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling open question addressing the ballot problem from a different angle — both extend the base ballot problem formalization in complementary directions"
+    },
+    {
+      "id": "birthday-problem",
+      "relationship": "related",
+      "description": "Both are classic probability results with elegant formulas. The ballot problem's (p-q)/(p+q) and the birthday paradox's threshold at √(365) both demonstrate how probability defies naive intuition."
+    },
+    {
+      "id": "ballot-problem",
+      "relationship": "extends",
+      "description": "The classical discrete ballot problem (Bertrand 1887) — this file extends it to continuous time via Brownian motion, replacing discrete vote counts with a continuous diffusion process"
+    },
+    {
+      "id": "ballot-problem-oq-01",
+      "relationship": "extends",
+      "description": "The generalized k-fold ballot problem — this file provides the continuous analog via the reflection principle for Brownian motion, recovering the same probabilities in the scaling limit"
+    },
+    {
+      "id": "ballot-problem-oq-03",
+      "relationship": "sibling",
+      "description": "The LGV lemma via 2D reflection provides a discrete determinantal approach to ballot counting, complementing this file's continuous-time Brownian motion formulation. Both generalize the original ballot problem: this file to continuous time via stochastic processes, LGV to multiple non-crossing paths via linear algebra"
+    }
+  ]
 }

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -214,5 +214,27 @@
     "axiomCount": 0,
     "theoremCount": 31,
     "definitionCount": 16
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "ballot-problem-oq-03",
+      "relationship": "extends",
+      "description": "Extends the 2×2 LGV lemma to the full r×r case using permutations and Matrix.det"
+    },
+    {
+      "id": "ballot-problem",
+      "relationship": "ancestor",
+      "description": "The ballot problem's reflection principle is the 1D precursor to the LGV lemma's crossing argument"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The path matrix entries C(m+bⱼ-aᵢ, m) are binomial coefficients counting lattice paths between grid points"
+    },
+    {
+      "id": "ballot-problem-oq-02",
+      "relationship": "related",
+      "description": "The continuous-time ballot problem via Brownian motion provides the probabilistic counterpart to the general LGV determinant: where this file computes determinants of path-count matrices for r non-crossing discrete paths, the Brownian motion approach computes analogous crossing probabilities in continuous time using the Karlin-McGregor theorem"
+    }
+  ]
 }

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -298,5 +298,37 @@
     "axiomCount": 0,
     "theoremCount": 138,
     "definitionCount": 31
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "ballot-problem",
+      "relationship": "extends",
+      "description": "Extends the classical ballot problem's 1D reflection principle to 2D lattice path pairs, providing the combinatorial foundation for the LGV lemma"
+    },
+    {
+      "id": "ballot-problem-oq-01",
+      "relationship": "extends",
+      "description": "The generalized k-fold ballot problem — this file extends the lattice path framework from 1D to 2D pairs with the Lindström involution"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundational",
+      "description": "Path counts use C(m+n, m) for the number of monotone lattice paths from (0,0) to (m,n) — the binomial coefficient is the fundamental building block"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "related",
+      "description": "The Vandermonde identity C(m+n,r) = ∑C(m,j)C(n,r-j) proved here via lattice path decomposition has a natural connection to the binomial expansion (x+y)^n"
+    },
+    {
+      "id": "ballot-problem-oq-03-oq-02",
+      "relationship": "extended-by",
+      "description": "Extends the 2×2 LGV determinant to the general r×r case, computing determinants of path-count matrices for r non-crossing lattice paths — the full generalization of the reflection principle used in this file's 2D case"
+    },
+    {
+      "id": "ballot-problem-oq-02",
+      "relationship": "sibling",
+      "description": "Continuous-time ballot problem via Brownian motion — the stochastic complement to this file's discrete lattice path approach. Both generalize ballot counting: this file via non-crossing determinants, the sibling via stochastic processes and the reflection principle in continuous time"
+    }
+  ]
 }

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -267,5 +267,77 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "fair-games-theorem",
+      "relationship": "related",
+      "description": "Both use conditional probability over finite sample spaces; the ballot problem's staysPositive predicate connects to fair game stopping conditions"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "uses",
+      "description": "The ballot formula relies on binomial coefficients C(p+q,p) and C(p+q,q) for counting lattice paths"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "co-listed",
+      "description": "Both appear in Wiedijk's 100 Theorems list; infinitude of primes is #11, ballot problem is #30"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "uses",
+      "description": "The ballot probability is a ratio of binomial coefficients C(p+q,p); the counting argument relies on the combinations formula"
+    },
+    {
+      "id": "birthday-problem",
+      "relationship": "related",
+      "description": "Both are classic probability problems solved by counting arguments over finite sample spaces — the birthday problem counts collisions in random assignments, the ballot problem counts lattice paths staying positive"
+    },
+    {
+      "id": "ballot-problem-oq-01",
+      "relationship": "extended-by",
+      "description": "Sub-entry extending the ballot problem with generalizations and additional analysis"
+    },
+    {
+      "id": "ballot-problem-oq-02",
+      "relationship": "extended-by",
+      "description": "Sub-entry exploring further connections of the ballot problem"
+    },
+    {
+      "id": "ballot-problem-oq-03",
+      "relationship": "extended-by",
+      "description": "Sub-entry with additional ballot problem variants and applications"
+    },
+    {
+      "id": "derangements",
+      "relationship": "related",
+      "description": "Both are classical combinatorics problems solved by bijective counting: the ballot problem uses the reflection principle while derangements use inclusion-exclusion — both transform a counting constraint into a simpler enumeration"
+    },
+    {
+      "id": "inclusion-exclusion",
+      "relationship": "related",
+      "description": "Inclusion-exclusion is a complementary counting technique to the ballot problem's reflection principle — both reduce constrained counting to simpler enumerations, and some ballot problem proofs use inclusion-exclusion directly"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The ballot problem concerns random walks with a bias (p > q votes), which in the limit connects to the central limit theorem: the vote-counting sequence is a biased random walk, and CLT describes its asymptotic distribution"
+    },
+    {
+      "id": "erdos-szekeres",
+      "relationship": "related",
+      "description": "Both are combinatorial results solved by elegant counting arguments: the Erdős-Szekeres theorem (every sequence of length mn+1 has a monotone subsequence of length m+1 or n+1) uses the pigeonhole principle on lattice paths, while the ballot problem uses the reflection principle on lattice paths — both involve path-counting in grid diagrams"
+    },
+    {
+      "id": "ballot-problem-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Formalizes the Discrete Intermediate Value Theorem for the Dvoretzky-Motzkin cycle lemma — a deeper combinatorial tool that generalizes the ballot problem's reflection principle to cyclic sequences"
+    },
+    {
+      "id": "ballot-problem-oq-03-oq-02",
+      "relationship": "extended-by",
+      "description": "Extends ballot problem lattice path counting to the general $r \\times r$ Lindström-Gessel-Viennot determinant formula — the ballot problem is the $1 \\times 1$ case of the LGV lemma for non-intersecting lattice paths"
+    }
+  ]
 }

--- a/src/data/proofs/basel-problem-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01/meta.json
@@ -222,5 +222,42 @@
       "citation": "Fischler, S. and Nesterenko, Y., Arithmetic properties of values of the Riemann zeta function at odd integers, Bulletin of the London Mathematical Society 42(3) (2010), 457–470.",
       "type": "paper"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "basel-problem",
+      "relationship": "extends",
+      "description": "Parent entry proving ζ(2) = π²/6 — this file explores the deeper question of ζ(5) irrationality, extending from even zeta values (known closed forms) to odd zeta values (largely mysterious)"
+    },
+    {
+      "id": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "Both concern the Riemann zeta function ζ(s): RH addresses the zeros of ζ in the critical strip, while this file addresses the arithmetic nature of ζ at odd positive integers"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "Both are questions about the arithmetic nature of fundamental constants — e's transcendence is proved, while ζ(5)'s irrationality remains open despite strong numerical evidence"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "foundational",
+      "description": "The harmonic series $\\sum 1/n$ diverges, while $\\zeta(2) = \\sum 1/n^2 = \\pi^2/6$ converges (Basel problem). The question of whether $\\zeta(5) = \\sum 1/n^5$ is irrational probes the arithmetic nature of these convergent sums — the divergence/convergence boundary at $s = 1$ is foundational, and the irrationality question asks about the deeper algebraic structure of the convergent values"
+    },
+    {
+      "id": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{i\\pi} + 1 = 0$ connects the constants $e$, $\\pi$, and $i$. The zeta values $\\zeta(2k) = (-1)^{k+1}(2\\pi)^{2k}B_{2k}/(2(2k)!)$ involve $\\pi$, linking even zeta values to the same transcendental constant in Euler's identity. The irrationality of odd zeta values like $\\zeta(5)$ remains open precisely because they lack such clean $\\pi$-based formulas"
+    },
+    {
+      "id": "basel-problem-oq-02",
+      "relationship": "related",
+      "description": "Sibling open question focusing on the transcendence of ALL odd zeta values and the full implication hierarchy (transcendence => irrationality => Apery + Rivoal + Zudilin); this entry focuses specifically on ζ(5) irrationality"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "related",
+      "description": "Lindemann's theorem (π transcendental) is the key ingredient for even zeta transcendence (ζ(2k) = rational * π^(2k)); contrasts with the open status of odd zeta irrationality explored here"
+    }
   ]
 }

--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -224,5 +224,32 @@
       "citation": "Zudilin, W., One of the numbers ζ(5), ζ(7), ζ(9), ζ(11) is irrational, Russian Mathematical Surveys 56(4) (2001), 774–776.",
       "type": "paper"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "basel-problem",
+      "relationship": "extends",
+      "description": "Parent entry proving ζ(2) = π²/6 — this file explores the transcendence landscape of all zeta values at positive integers"
+    },
+    {
+      "id": "basel-problem-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question focusing specifically on ζ(5) irrationality; this entry takes the broader view of ALL odd zeta values"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "Both concern transcendence of fundamental constants — e's transcendence is proved while odd zeta transcendence remains open"
+    },
+    {
+      "id": "pi-transcendental",
+      "relationship": "uses",
+      "description": "Lindemann's theorem (π transcendental) is axiomatized here as the key ingredient for even-zeta transcendence"
+    },
+    {
+      "id": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "Irrationality of √2 is the classical prototype for irrationality proofs — Apéry's proof of ζ(3) irrationality uses a far more sophisticated descendant of the same diophantine approximation tradition"
+    }
   ]
 }

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -233,5 +233,47 @@
       "venue": "Proceedings of the Japan Academy 28(4), 177–181",
       "note": "Strengthened Bertrand: for n > 25, there is always a prime between n and 6n/5, reducing the gap ratio from 2 to 1.2"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "infinitude-primes",
+      "relationship": "implied-by",
+      "description": "Bertrand's Postulate immediately implies infinitude of primes (for any n, there's a prime > n), giving an alternative to Euclid's proof via a much stronger quantitative result"
+    },
+    {
+      "id": "bounded-prime-gaps",
+      "relationship": "related",
+      "description": "Both concern prime gaps: Bertrand gives gaps < p (elementary), while Zhang-Maynard-Tao show infinitely many gaps ≤ 246 (deep analytic methods)"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "technique",
+      "description": "Erdős's proof hinges on analyzing the central binomial coefficient C(2n,n), using properties of binomial coefficients and their prime factorizations"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "related",
+      "description": "PNT gives π(n) ~ n/ln(n), which implies Bertrand's postulate for sufficiently large n. Bertrand's postulate is an elementary precursor: always a prime between n and 2n, without asymptotics"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization underpins Erdős's proof: the prime factorization of C(2n,n) is analyzed to show large primes must appear"
+    },
+    {
+      "id": "bertrands-postulate-oq-03",
+      "relationship": "extended-by",
+      "description": "Explores the precise density of primes in short intervals — refining Bertrand's guarantee of at least one prime in $(n, 2n)$ to questions about how many primes exist in shorter intervals like $(n, n + n^\\theta)$"
+    },
+    {
+      "id": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "RH implies the strongest form of the prime gap bound: $p_{n+1} - p_n = O(\\sqrt{p_n} \\log p_n)$, far stronger than Bertrand's $p_{n+1} < 2p_n$. Both concern the regularity of prime distribution but at different scales — Bertrand is elementary, RH is deep"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "Both quantify prime density: Bertrand's postulate gives a local guarantee ($\\exists$ prime in $(n, 2n]$), while $\\sum 1/p = \\infty$ gives a global measure (primes are collectively dense enough for their reciprocals to diverge). Together they establish that primes are both locally frequent and globally ubiquitous"
+    }
   ]
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01/meta.json
@@ -205,5 +205,27 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "bezout-identity-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry proving Euclid's lemma from Bézout — this file completes the chain by deriving the Fundamental Theorem of Arithmetic from Euclid's lemma"
+    },
+    {
+      "id": "bezout-identity",
+      "relationship": "ancestor",
+      "description": "The original Bézout identity gcd(a,b) = ax + by — the start of the chain Bézout → Euclid's Lemma → FTA that this file completes"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "Both formalize unique prime factorization, but via different proof architectures: this file derives FTA explicitly from Euclid's lemma, while the gallery FTA entry may use Mathlib's UFD infrastructure"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "extended-by",
+      "description": "The infinity of primes (no_finite_list_contains_all_primes) is proved here as a corollary of FTA, complementing Euclid's original proof"
+    }
+  ]
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -165,5 +165,37 @@
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 2
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "bezout-identity",
+      "relationship": "ancestor",
+      "description": "The root formalization of Bézout's identity, which establishes the extended Euclidean algorithm used here"
+    },
+    {
+      "id": "bezout-identity-oq-02",
+      "relationship": "ancestor",
+      "description": "Euclid's lemma via coprimality — the classical (noncomputable) version that this entry makes computable"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "The direct parent: constructive divisibility via Bézout coefficients using classical choice (`hdvd.choose`)"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Euclid's lemma in Bézout domains and PIDs — the abstract algebraic generalization"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-01",
+      "relationship": "related",
+      "description": "The Fundamental Theorem of Arithmetic from Euclid's lemma — a key application of the divisibility result made computable here"
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "related",
+      "description": "The Chinese Remainder Theorem uses similar coprimality and Bézout coefficient techniques"
+    }
+  ]
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
@@ -324,5 +324,67 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 2
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "bezout-identity",
+      "relationship": "extends",
+      "description": "Root formalization of Bézout's identity; this entry extends it with a constructive divisibility algorithm using the Bézout coefficients"
+    },
+    {
+      "id": "bezout-identity-oq-02",
+      "relationship": "extends",
+      "description": "Parent open question about Euclid's lemma; this entry resolves the sub-question about constructive quotient computation"
+    },
+    {
+      "id": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "Both use the extended Euclidean algorithm constructively: CRT for simultaneous congruences, this for explicit quotient extraction"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Direct parent in the open question chain: generalizes Euclid's lemma to commutative rings. This entry adds the constructive quotient computation"
+    },
+    {
+      "id": "gcd-algorithm",
+      "relationship": "related",
+      "description": "Standard Euclidean algorithm for GCD computation. This entry implements the extended version that additionally returns Bézout coefficients"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "Unique prime factorization relies on Euclid's lemma (if p | ab and p prime, then p | a or p | b) — the constructive version here gives the explicit quotient"
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "complementary",
+      "description": "Extends CRT to non-coprime moduli, where Bézout's identity gives $\\gcd(m,n) = um + vn$ rather than $1 = um + vn$. The extended GCD from this file computes the same coefficients but the quotient formula requires the coprimality normalization $\\gcd = 1$"
+    },
+    {
+      "id": "bezout-identity-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling open question from the Bézout identity chain, exploring different extensions of the core identity — together these entries map the space of constructive number-theoretic algorithms derivable from the extended Euclidean algorithm"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Child entry that resolves the first open question: removes the noncomputable annotation from constructive_div by replacing classical choice (hdvd.choose) with computable integer division, making the full algorithm executable"
+    },
+    {
+      "id": "bezout-identity-oq-04",
+      "relationship": "sibling",
+      "description": "Complete parametric solution set of linear Diophantine equations ax + by = c: solutions form a 1D lattice {(x₀ + (b/d)t, y₀ - (a/d)t) : t ∈ ℤ}. Extends the single-solution Bézout computation here to the full solution family, using the same extended GCD infrastructure"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Proves the Fundamental Theorem of Arithmetic from Euclid's lemma — a direct consumer of the constructive Euclid's lemma developed here. The proof chain Bézout → Euclid's lemma → unique factorization shows that the constructive quotient extraction formalized in this entry is a building block for the most fundamental theorem in number theory"
+    },
+    {
+      "id": "bezout-identity-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "The CRT ring isomorphism $\\mathbb{Z}/mn\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ is constructed from the same Bézout coefficients computed by the extended Euclidean algorithm. The isomorphism maps $x \\mapsto (x \\bmod m, x \\bmod n)$ with inverse $a \\mapsto a_1 vn + a_2 um$ where $um + vn = 1$ — directly using the output of extGcd"
+    }
+  ]
 }

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
@@ -202,5 +202,37 @@
       "venue": "Springer Graduate Texts in Mathematics",
       "note": "Chapter 3: the CRT as a ring isomorphism, with applications to Euler's totient"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "bezout-identity",
+      "relationship": "extends",
+      "description": "The root formalization: Bézout's identity ($\\gcd(a,b) = ax + by$). The CRT builds on coprimality ($\\gcd = 1$), which is the Bézout case yielding $1 = ax + by$."
+    },
+    {
+      "id": "bezout-identity-oq-03",
+      "relationship": "extends",
+      "description": "Direct grandparent: explores the 2-fold CRT and its ring-theoretic formulation. This entry generalizes to arbitrary $k$-fold products."
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) provides the canonical pairwise coprime decomposition $n = p_1^{a_1} \\cdots p_k^{a_k}$, making the $k$-fold CRT applicable to any modulus."
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "related",
+      "description": "The Euler totient function $\\varphi(n)$. This file proves the $k$-fold multiplicativity $\\varphi(\\prod n_i) = \\prod \\varphi(n_i)$ as a CRT corollary, extending Euler's classical result."
+    },
+    {
+      "id": "primitive-roots",
+      "relationship": "related",
+      "description": "Primitive roots modulo primes: $(\\mathbb{Z}/p\\mathbb{Z})^*$ is cyclic. The CRT decomposes $(\\mathbb{Z}/n\\mathbb{Z})^* \\cong \\prod (\\mathbb{Z}/p_i^{a_i}\\mathbb{Z})^*$, reducing unit group structure to prime power components."
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "related",
+      "description": "Generalizes the CRT to non-coprime moduli: when $\\gcd(m,n) > 1$, the system $x \\equiv a \\pmod{m}$, $x \\equiv b \\pmod{n}$ has a solution iff $a \\equiv b \\pmod{\\gcd(m,n)}$. The coprime k-fold CRT here is the clean isomorphism case; the non-coprime version shows what happens when the coprimality hypothesis is dropped."
+    }
   ]
 }

--- a/src/data/proofs/bezout-identity/meta.json
+++ b/src/data/proofs/bezout-identity/meta.json
@@ -272,5 +272,42 @@
       "venue": "Oxford University Press, 6th edition",
       "note": "Standard reference with multiple proofs of Bézout's identity via the Euclidean algorithm"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Bézout's identity is a key ingredient in proving unique prime factorization: from gcd(a,b) = ax + by, one derives Euclid's lemma (p|ab → p|a or p|b), which gives uniqueness"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "related",
+      "description": "Euclid's proof of infinite primes uses coprimality — Bézout provides the algebraic characterization gcd = 1 ⟺ ax + by = 1 that underpins coprimality arguments"
+    },
+    {
+      "id": "chinese-remainder-constructive",
+      "relationship": "extended-by",
+      "description": "The Chinese Remainder Theorem uses Bézout coefficients to construct simultaneous solutions: from gcd(m,n) = 1 and mx + ny = 1, the CRT solution is built by scaling"
+    },
+    {
+      "id": "lagrange-theorem",
+      "relationship": "related",
+      "description": "Both are foundational to group/number theory: Lagrange's theorem constrains subgroup orders, while Bézout characterizes when elements generate the full group ℤ/nℤ"
+    },
+    {
+      "id": "bezout-identity-oq-02",
+      "relationship": "extended-by",
+      "description": "Proves Euclid's lemma ($p \\mid ab \\Rightarrow p \\mid a$ or $p \\mid b$) using the coprime_iff_linear_combination characterization from Bézout — answering one of this file's open questions"
+    },
+    {
+      "id": "bezout-identity-oq-03",
+      "relationship": "extended-by",
+      "description": "Constructs the Chinese Remainder Theorem via Bézout's identity for integers — from $\\gcd(m,n) = 1$ and $mx + ny = 1$, builds simultaneous solutions to systems of congruences"
+    },
+    {
+      "id": "bezout-identity-oq-04",
+      "relationship": "extended-by",
+      "description": "Characterizes the complete solution set of linear Diophantine equations $ax + by = c$: a particular solution (from Bézout) plus the homogeneous solutions $(b/g)t, -(a/g)t$ where $g = \\gcd(a,b)$"
+    }
   ]
 }

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01/meta.json
@@ -182,5 +182,27 @@
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 1
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "binomial-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Develops the analytic function theory perspective on Newton's theorem, complementing the algebraic approach in the parent proof"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "generalizes",
+      "description": "The standard binomial theorem for natural exponents is a special case where the generalized binomial series terminates (C(n,k)=0 for k>n when n∈ℕ)"
+    },
+    {
+      "id": "geometric-series",
+      "relationship": "related",
+      "description": "The geometric series 1/(1+x) = Σ(-x)^k is the α=-1 case of Newton's generalized binomial theorem, since C(-1,k)=(-1)^k"
+    },
+    {
+      "id": "fundamental-theorem-calculus",
+      "relationship": "related",
+      "description": "The absorption identity α·C(α-1,k)=(k+1)·C(α,k+1) is the coefficient-level version of d/dx[(1+x)^α]=α(1+x)^(α-1), connecting power series differentiation to the FTC"
+    }
+  ]
 }

--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -326,5 +326,82 @@
     "lemmaCount": 0,
     "defCount": 0,
     "definitionCount": 0
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "binomial-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Sub-entry extending the binomial theorem to further identities or applications."
+    },
+    {
+      "id": "binomial-theorem-oq-04",
+      "relationship": "parent",
+      "description": "Sub-entry on advanced binomial coefficient properties."
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The binomial coefficient $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$ is precisely the combinations formula. The binomial theorem gives the algebraic identity that these coefficients satisfy."
+    },
+    {
+      "id": "inclusion-exclusion",
+      "relationship": "related",
+      "description": "The alternating sum identity $\\sum (-1)^k \\binom{n}{k} = 0$ for $n \\geq 1$, proved here as a corollary of the binomial theorem, is the simplest instance of inclusion-exclusion. Both use the same signed summation machinery."
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "extends",
+      "description": "The binomial distribution $P(X = k) = \\binom{n}{k} p^k (1-p)^{n-k}$ arises directly from the binomial theorem. The Central Limit Theorem shows this distribution converges to a Gaussian as $n \\to \\infty$."
+    },
+    {
+      "id": "binomial-theorem-oq-02",
+      "relationship": "extended-by",
+      "description": "Generalizes $(x+y)^n = \\sum \\binom{n}{k} x^k y^{n-k}$ to the multinomial theorem $(x_1 + \\cdots + x_m)^n = \\sum \\frac{n!}{k_1! \\cdots k_m!} \\prod x_i^{k_i}$ — the binomial theorem is the $m=2$ case"
+    },
+    {
+      "id": "binomial-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "Derives the binomial distribution $P(X = k) = \\binom{n}{k} p^k (1-p)^{n-k}$ as a probabilistic interpretation of the binomial theorem with $x = p$, $y = 1-p$"
+    },
+    {
+      "id": "binomial-theorem-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Newton's generalized binomial theorem extends to non-integer exponents: $(1+x)^\\alpha = \\sum_{k=0}^\\infty \\binom{\\alpha}{k} x^k$ for $|x| < 1$, using the generalized binomial coefficient $\\binom{\\alpha}{k} = \\frac{\\alpha(\\alpha-1)\\cdots(\\alpha-k+1)}{k!}$"
+    },
+    {
+      "id": "binomial-theorem-oq-04-oq-02",
+      "relationship": "extended-by",
+      "description": "Proves the Vandermonde identity $\\binom{m+n}{r} = \\sum_{k=0}^r \\binom{m}{k}\\binom{n}{r-k}$ via algebraic coefficient comparison in the product $(1+x)^m(1+x)^n = (1+x)^{m+n}$"
+    },
+    {
+      "id": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "Mathematical induction is the standard proof technique for the binomial theorem: the inductive step uses Pascal's identity $\\binom{n+1}{k+1} = \\binom{n}{k} + \\binom{n}{k+1}$ to derive row $n+1$ of Pascal's triangle from row $n$. Mathlib's `add_pow` is proved by induction internally, making induction the logical backbone of this formalization"
+    },
+    {
+      "id": "geometric-series",
+      "relationship": "foundational",
+      "description": "The geometric series $\\sum_{k=0}^n r^k = (1-r^{n+1})/(1-r)$ is the $y = 1$ special case of the binomial theorem when $x = r$ and we track only powers of $x$. More deeply, Newton's generalized binomial series $(1+x)^\\alpha = \\sum \\binom{\\alpha}{k} x^k$ for $|x| < 1$ reduces to the geometric series when $\\alpha = -1$: $(1+x)^{-1} = 1 - x + x^2 - \\cdots$"
+    },
+    {
+      "id": "taylor-theorem",
+      "relationship": "extends",
+      "description": "Taylor's theorem provides the framework for Newton's generalized binomial series: $(1+x)^\\alpha = \\sum_{k=0}^\\infty \\frac{f^{(k)}(0)}{k!} x^k$ where $f^{(k)}(0) = \\alpha(\\alpha-1)\\cdots(\\alpha-k+1)$, giving the generalized binomial coefficient $\\binom{\\alpha}{k}$. The finite binomial theorem (proved here) is the special case where $\\alpha = n \\in \\mathbb{N}$ and the Taylor series terminates after $n+1$ terms"
+    },
+    {
+      "id": "birthday-problem",
+      "relationship": "related",
+      "description": "The birthday problem's exact probability $1 - \\frac{365!}{365^n (365-n)!}$ involves the same factorial and combinatorial counting that underlies binomial coefficients. The binomial approximation $(1-1/365)^{\\binom{n}{2}} \\approx e^{-n(n-1)/730}$ directly uses binomial coefficients to count collision pairs"
+    },
+    {
+      "id": "derangements",
+      "relationship": "related",
+      "description": "The derangement formula $D_n = n! \\sum_{k=0}^n \\frac{(-1)^k}{k!}$ uses inclusion-exclusion with binomial coefficients $\\binom{n}{k}$ to count permutations fixing exactly $k$ points. The alternating sum identity proved here ($\\sum (-1)^k \\binom{n}{k} = 0$) is the simplest instance of this alternation pattern"
+    },
+    {
+      "id": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Faulhaber's formulas for $\\sum_{i=1}^n i^k$ use the binomial theorem in their derivation via the telescoping identity $(i+1)^{k+1} - i^{k+1} = \\sum_{j=0}^k \\binom{k+1}{j} i^j$, which expands the left side using the binomial theorem and rearranges to solve for $\\sum i^k$ in terms of lower power sums"
+    }
+  ]
 }

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -701,5 +701,67 @@
       "venue": "Springer GTM 106, 2nd edition",
       "note": "Standard graduate text covering the BSD conjecture and its partial results"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "Both concern deep connections between algebraic and analytic properties: FTA proves polynomial roots exist in $\\mathbb{C}$, while BSD connects rational points on elliptic curves (algebra) with the analytic behavior of L-functions at $s = 1$"
+    },
+    {
+      "id": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "The Hasse bound $|\\#E(\\mathbb{F}_p) - p - 1| \\leq 2\\sqrt{p}$ (axiomatized in this file) is equivalent to the Riemann Hypothesis for the zeta function of $E$ over $\\mathbb{F}_p$, proved by Hasse (1936). The full RH for the Riemann zeta function is a Millennium Prize sibling of BSD, and the Generalized RH for Dirichlet L-functions is intimately connected to BSD via the Langlands program"
+    },
+    {
+      "id": "p-vs-np",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem — both remain open and carry a $1,000,000 prize from the Clay Mathematics Institute. While P vs NP concerns computational complexity, BSD concerns the arithmetic of elliptic curves — two very different mathematical domains united by the Clay Prize's recognition of their fundamental importance"
+    },
+    {
+      "id": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "Both are famous mathematical problems whose resolution has required fundamentally new ideas. CH was proved independent of ZFC by Gödel (consistency, 1940) and Cohen (independence, 1963), while BSD remains open with only partial results (ranks 0 and 1 proved by Kolyvagin and Gross-Zagier)"
+    },
+    {
+      "id": "e-transcendental",
+      "relationship": "related",
+      "description": "Transcendence theory connects to BSD via the Schneider-Lang theorem and periods of elliptic curves. The real period $\\Omega_E$ appearing in the BSD formula is a transcendental number (by Schneider's theorem on elliptic integrals), and its arithmetic significance is a key ingredient in the exact BSD formula"
+    },
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Wiles's proof of FLT (1995) established the modularity of semistable elliptic curves over $\\mathbb{Q}$ — the same modularity that is essential for BSD. The Taniyama-Shimura-Weil conjecture (now the modularity theorem, proved in full by Breuil-Conrad-Diamond-Taylor 2001) ensures that the L-function $L(E,s)$ in BSD has the analytic properties needed for the conjecture to make sense. FLT and BSD are thus siblings in the modularity framework"
+    },
+    {
+      "id": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "Quadratic reciprocity is the simplest case of Artin reciprocity, which in turn is the abelian case of the Langlands program. The L-function $L(E,s)$ in BSD is a degree-2 automorphic L-function, and the Langlands program predicts deep connections between such L-functions and automorphic forms — generalizing the quadratic reciprocity law from $\\text{GL}_1$ to $\\text{GL}_2$"
+    },
+    {
+      "id": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The congruent number problem — which integers are areas of right triangles with rational sides? — provides the most classical bridge from Pythagorean triples to BSD. A positive integer $n$ is congruent iff the elliptic curve $y^2 = x^3 - n^2 x$ has positive rank. This file formalizes the congruent number curve $E_{37}: y^2 = x^3 - 37^2 x$ and the Koblitz correspondence between rational right triangles and rational points on $E_n$"
+    },
+    {
+      "id": "hodge-conjecture",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning algebraic geometry. The Hodge conjecture and BSD both involve deep connections between algebraic and analytic/topological structures: Hodge asks when cohomology classes are algebraic, while BSD asks when the analytic rank equals the algebraic rank. Both are manifestations of the general principle that algebraic and analytic invariants of varieties should be closely related"
+    },
+    {
+      "id": "poincare-conjecture",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem, uniquely among the seven to have been solved (by Perelman, 2003). The Poincaré conjecture (every simply connected closed 3-manifold is homeomorphic to $S^3$) was proved using Ricci flow, a geometric analysis technique — illustrating how the deepest problems in different areas of mathematics require fundamentally different approaches"
+    },
+    {
+      "id": "navier-stokes",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning the existence and smoothness of solutions to the Navier-Stokes equations. Both BSD and Navier-Stokes involve proving that analytic objects (L-functions / fluid velocity fields) have specific regularity properties, though the mathematical tools are entirely different (algebraic number theory vs PDE analysis)"
+    },
+    {
+      "id": "yang-mills",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem concerning the existence of a mass gap in quantum Yang-Mills theory. Both BSD and Yang-Mills involve non-perturbative phenomena in their respective domains (arithmetic geometry / quantum field theory) that resist existing proof techniques"
+    }
   ]
 }

--- a/src/data/proofs/birthday-problem-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03/meta.json
@@ -241,5 +241,27 @@
       "Mathlib"
     ],
     "opens": []
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "birthday-problem",
+      "relationship": "generalizes",
+      "description": "Generalizes from 2-way to k-way coincidences. The classical birthday problem is exactly the k=2 case, and this formalization proves that equivalence via `hasKWay_two_iff_not_injective`"
+    },
+    {
+      "id": "birthday-problem-oq-02",
+      "relationship": "related",
+      "description": "The asymptotic bound formalization complements this combinatorial approach — OQ-02 provides the $\\sqrt{2d \\ln 2} \\approx 22.5$ threshold formula, while this entry provides the exact pigeonhole bound and extends to $k > 2$"
+    },
+    {
+      "id": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Both are results about forced structure in combinatorial configurations: the pigeonhole principle (this entry) forces a k-way coincidence, while Ramsey theory forces monochromatic substructures. The generalized pigeonhole is sometimes viewed as the simplest case of Ramsey-type results"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "technique",
+      "description": "Both use counting/contradiction arguments: the generalized pigeonhole bounds fiber sizes, while Euclid's proof bounds the number of primes. The proof structure — assume a bound, sum over components, derive a contradiction — is shared"
+    }
+  ]
 }

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -291,5 +291,67 @@
       "venue": "Prentice Hall, Chapter 15",
       "note": "Historical context: traces the birthday problem from von Mises (1939) through its popularization by mathematical recreationists and its unexpected applications in cryptography and DNA forensics"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "birthday-problem-oq-03",
+      "relationship": "extended-by",
+      "description": "Extended with more sophisticated probability bounds and approximations."
+    },
+    {
+      "id": "ballot-problem",
+      "relationship": "related",
+      "description": "Fellow combinatorial probability problem: both use counting arguments over structured finite sample spaces — the ballot problem counts lattice paths, the birthday problem counts injective functions"
+    },
+    {
+      "id": "buffons-needle",
+      "relationship": "related",
+      "description": "Fellow classic probability problem: Buffon's needle involves geometric probability with π, while the birthday problem uses discrete counting and produces the surprising 23-person threshold"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "uses",
+      "description": "Binomial coefficients C(n,2) = n(n-1)/2 count the number of pairs, which is why 23 people have 253 pairs — the quadratic growth of pairs is the key to the birthday 'paradox'"
+    },
+    {
+      "id": "arithmetic-series",
+      "relationship": "related",
+      "description": "The number of pairs C(n,2) = n(n-1)/2 is a triangular number — the same formula as the arithmetic series sum, connecting the birthday problem to elementary number theory"
+    },
+    {
+      "id": "birthday-problem-oq-02",
+      "relationship": "extended-by",
+      "description": "Sub-entry exploring further birthday problem variants and generalizations"
+    },
+    {
+      "id": "derangements",
+      "relationship": "related",
+      "description": "Both are classic combinatorial problems counting structured functions: the birthday problem counts injective functions (all-distinct assignments) while derangements count fixed-point-free permutations. Both use complement counting — $P(\\text{match}) = 1 - P(\\text{all distinct})$ parallels the inclusion-exclusion for derangement count $D_n = n! \\sum_{k=0}^{n} (-1)^k/k!$"
+    },
+    {
+      "id": "inclusion-exclusion",
+      "relationship": "uses",
+      "description": "The birthday formula $P(n) = 1 - \\prod_{i=0}^{n-1}(1 - i/365)$ is a complement-counting argument, the simplest form of inclusion-exclusion. For the generalized birthday problem (counting exact number of collisions), full inclusion-exclusion over overlapping pair events is needed"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation $n! \\approx \\sqrt{2\\pi n}(n/e)^n$ enables the Poisson approximation $P(n) \\approx 1 - e^{-n^2/(2 \\cdot 365)}$, which gives the asymptotic threshold $n \\approx \\sqrt{2 \\cdot 365 \\cdot \\ln 2} \\approx 22.5$ for the 50% crossover — explaining why 23 is the exact threshold"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "uses",
+      "description": "The binomial coefficient $\\binom{n}{2} = n(n-1)/2$ counts the number of person-pairs, which is the key to the birthday 'paradox': 23 people yield 253 pairs, and each pair has probability $1/365$ of matching. The expected number of matching pairs is $\\binom{n}{2}/365$"
+    },
+    {
+      "id": "prob-method-expectation",
+      "relationship": "related",
+      "description": "The probabilistic method uses expectation to prove existence: in the birthday problem, the expected number of matching pairs is $\\binom{n}{2}/365 > 1$ for $n \\geq 28$, guaranteeing a match exists in expectation. The birthday bound is a key ingredient in probabilistic method arguments for hash collisions and random graph coloring"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The number of birthday collisions among $n$ people follows a distribution that converges to Poisson (and thence to Gaussian via CLT) as $n$ grows. The Poisson approximation $P \\approx 1 - e^{-n^2/(2m)}$ for $m$ buckets is the CLT-style limit that explains the $\\sqrt{m}$ scaling of the birthday threshold"
+    }
   ]
 }

--- a/src/data/proofs/borsuk-ulam-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02/meta.json
@@ -223,5 +223,27 @@
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Tucker 2D Lemma via Graph-Theoretic Path-Following"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "borsuk-ulam",
+      "relationship": "extends",
+      "description": "Parent formalization; this entry extends it with further exploration"
+    },
+    {
+      "id": "borsuk-ulam-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling open question from the same parent: Constructive Borsuk-Ulam Theorem and Equivalences"
+    },
+    {
+      "id": "borsuk-ulam-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling open question from the same parent: Quantitative Borsuk-Ulam and Tucker's Lemma in 1D"
+    },
+    {
+      "id": "borsuk-ulam-oq-03-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling open question from the same parent: Tucker 2D Lemma via Graph-Theoretic Path-Following"
+    }
   ]
 }

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -258,5 +258,52 @@
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 6
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "brouwer-fixed-point",
+      "relationship": "implication",
+      "description": "Borsuk-Ulam implies Brouwer's Fixed Point Theorem: the retraction proof shows that a continuous map without a fixed point would yield an antipode-preserving map, contradicting Borsuk-Ulam"
+    },
+    {
+      "id": "intermediate-value-theorem",
+      "relationship": "related",
+      "description": "The n=1 case of Borsuk-Ulam (every continuous f: S¹ → ℝ has f(x) = f(-x)) is equivalent to the intermediate value theorem applied to g(θ) = f(θ) - f(θ+π) on the circle — Borsuk-Ulam is the higher-dimensional generalization of IVT"
+    },
+    {
+      "id": "prob-method-lovasz-local",
+      "relationship": "related",
+      "description": "Lovász's 1978 proof of Kneser's conjecture used Borsuk-Ulam as the key topological ingredient, connecting the chromatic number of Kneser graphs to sphere connectivity. This launched the field of topological combinatorics that bridges Lovász's probabilistic/algebraic methods with topological fixed-point theory."
+    },
+    {
+      "id": "schauder-fixed-point",
+      "relationship": "related",
+      "description": "Schauder's theorem generalizes Brouwer's fixed point theorem to infinite dimensions. Since Borsuk-Ulam implies Brouwer, the chain Borsuk-Ulam → Brouwer → Schauder traces the progression from finite-dimensional topology to functional analysis."
+    },
+    {
+      "id": "borsuk-ulam-oq-02",
+      "relationship": "extended-by",
+      "description": "Explores equivariant extensions of Borsuk-Ulam to group actions beyond the $\\mathbb{Z}/2\\mathbb{Z}$ antipodal action — answering the open question about which group actions preserve the Borsuk-Ulam property"
+    },
+    {
+      "id": "borsuk-ulam-oq-03",
+      "relationship": "extended-by",
+      "description": "Develops constructive versions of the Borsuk-Ulam theorem and equivalent formulations (Tucker's lemma, Lusternik-Schnirelman) — addressing the open question about intuitionistic proofs"
+    },
+    {
+      "id": "poincare-conjecture",
+      "relationship": "thematic",
+      "description": "Both are landmark results in the topology of spheres. Borsuk-Ulam concerns the symmetry structure of $S^n$ (no odd map $S^n \\to S^{n-1}$), while the Poincaré conjecture characterizes $S^3$ among 3-manifolds by its fundamental group. Both rely on homotopy-theoretic invariants ($\\pi_1$ for Borsuk-Ulam's covering space argument, the full homotopy type for Poincaré) and both were solved using deep analytic/topological methods"
+    },
+    {
+      "id": "four-color-theorem",
+      "relationship": "thematic",
+      "description": "Both connect topology to combinatorics. Borsuk-Ulam implies Kneser's conjecture on graph chromatic numbers via Lovász's 1978 proof, founding topological combinatorics. The four-color theorem concerns the chromatic number of planar graphs. Together they illustrate how topology constrains coloring: Borsuk-Ulam provides lower bounds ($\\chi(K(n,k)) \\geq n - 2k + 2$) while the four-color theorem provides an upper bound ($\\chi(G) \\leq 4$ for planar $G$)"
+    },
+    {
+      "id": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "Both use topological arguments about continuous maps on spheres. FTA can be proved via the winding number (degree theory on $S^1$), while Borsuk-Ulam uses degree theory on $S^n$. Both show that topological constraints (non-contractibility of spheres) force the existence of special points (roots, antipodal pairs)"
+    }
+  ]
 }


### PR DESCRIPTION
Batch enrichment adding `relatedProofs` arrays matching `crossReferences` for 35 gallery entries.

## Batch 1 (15 entries)
abel-ruffini, abel-ruffini-oq-04, amgm-inequality, amgm-inequality-oq-02, amgm-inequality-oq-03, amgm-inequality-oq-03-oq-01, amgm-inequality-oq-03-oq-02, angle-trisection, angle-trisection-oq-02, angle-trisection-oq-02-oq-03-oq-01, area-of-circle-oq-03, area-of-circle-oq-03-oq-02, arithmetic-series, arithmetic-series-oq-02, arithmetic-series-oq-02-oq-02

## Batch 2 (20 entries)
ballot-problem, ballot-problem-oq-01-oq-01, ballot-problem-oq-02, ballot-problem-oq-03, ballot-problem-oq-03-oq-02, basel-problem-oq-01, basel-problem-oq-02, bertrands-postulate, bezout-identity, bezout-identity-oq-02-oq-01, bezout-identity-oq-02-oq-02-oq-01, bezout-identity-oq-02-oq-02-oq-01-oq-01, bezout-identity-oq-03-oq-01-oq-01, binomial-theorem, binomial-theorem-oq-01-oq-01, birch-swinnerton-dyer, birthday-problem, birthday-problem-oq-03, borsuk-ulam, borsuk-ulam-oq-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)