### PR TITLE
Peer review: ptolemys-theorem (C+)

### DIFF
--- a/src/data/proofs/ptolemys-theorem/review.json
+++ b/src/data/proofs/ptolemys-theorem/review.json
@@ -1,0 +1,136 @@
+{
+  "version": 1,
+  "proofId": "ptolemys-theorem",
+  "reviewDate": "2026-03-24T12:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "C+",
+    "oneLiner": "Well-curated Mathlib wrapper with excellent pedagogy, but padded by duplicate theorems and lacking formal substance beyond the import",
+    "tier": "B",
+    "tierJustification": "Core theorem is entirely from Mathlib (one-liner call to mul_dist_add_mul_dist_eq_mul_dist_of_cospherical). File provides naming wrappers, trivial algebraic restatements, numerical examples, and extensive commentary. No original proof work."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json badge field",
+      "finding": "The badge is honestly set to 'mathlib', accurately communicating that this is a Mathlib-based formalization rather than claiming original proof work. The proofStrategy in the overview also transparently states the Mathlib function used.",
+      "recommendation": "Preserve this honest framing. It sets a good example for other Mathlib wrapper entries."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Lean source lines 167-207 (numerical examples)",
+      "finding": "The three numerical examples are pedagogically effective. The rectangle example (line 177) concretely demonstrates how Ptolemy reduces to the Pythagorean theorem. The square example (lines 187-191) has the most non-trivial proof in the file, using mul_mul_mul_comm and Real.mul_self_sqrt. The isosceles trapezoid example shows practical diagonal computation.",
+      "recommendation": "Keep these examples — they are the strongest original contribution in the file."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json overview.keyInsights and overview.historicalContext",
+      "finding": "The five key insights are mathematically accurate and genuinely informative: the Pythagorean generalization, the complex-number algebraic identity, the cospherical higher-dimensional generalization, the converse characterization, and the chord table connection. The historical context about the Almagest and chord tables is well-written and proportionate.",
+      "recommendation": "Preserve the pedagogical exposition — it is the entry's primary value-add over a bare Mathlib import."
+    },
+    {
+      "severity": "major",
+      "category": "filler",
+      "location": "ptolemys_theorem_diagonals, lines 94-99",
+      "finding": "This theorem has an IDENTICAL statement to ptolemys_theorem (line 81-86): same hypotheses, same conclusion. The proof body is just `ptolemys_theorem h hapc hbpd`. The docstring claims it 'emphasizes the diagonal products on the right side' but the statement is character-for-character identical. This is pure padding that inflates the apparent theorem count from 3 distinct statements to 5.",
+      "recommendation": "Remove ptolemys_theorem_diagonals entirely. It adds nothing — not even a rearrangement of terms."
+    },
+    {
+      "severity": "major",
+      "category": "filler",
+      "location": "diagonal_product_from_sides, lines 123-128",
+      "finding": "This theorem has an IDENTICAL statement to ptolemys_theorem_symmetric (lines 102-107): `dist a c * dist b d = dist a b * dist c d + dist b c * dist d a`. The proof just calls ptolemys_theorem_symmetric. The docstring claims it can 'be computed from the four side lengths alone' but the Lean statement still requires the full Cospherical and angle hypotheses — it does NOT compute from side lengths alone.",
+      "recommendation": "Remove diagonal_product_from_sides. If the 'computing from sides' interpretation is important, formalize it properly (e.g., given side lengths, derive the diagonal product without angle hypotheses) or remove the misleading framing."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions",
+      "finding": "The original contributions list ['Multiple formulations', 'Numerical examples', 'Historical context']. 'Multiple formulations' is misleading when 2 of 5 theorems are exact duplicates and the remaining variants use only commutativity. 'Numerical examples' and 'Historical context' are pedagogical decoration, not mathematical contributions to formalization.",
+      "recommendation": "Reframe as: ['Pedagogical examples connecting Ptolemy to the Pythagorean theorem', 'Curated exposition of historical and mathematical context']. This is more honest about the nature of the contributions."
+    },
+    {
+      "severity": "moderate",
+      "category": "precision",
+      "location": "conclusion.summary in meta.json",
+      "finding": "The conclusion says the entry provides 'the main theorem, three alternative formulations, a diagonal-product corollary.' This counts 5 distinct results when there are really only 3 distinct statements (main, symmetric, rearranged). The phrasing inflates the apparent breadth of the formalization.",
+      "recommendation": "Rewrite to: 'This formalization wraps Mathlib\\'s Ptolemy theorem with named variants (symmetric and rearranged forms), three verified numerical examples, and extensive historical context.'"
+    },
+    {
+      "severity": "minor",
+      "category": "gap",
+      "location": "Lean source line 62",
+      "finding": "The abbreviation `abbrev Vec2 := EuclideanSpace ℝ (Fin 2)` is defined but never used anywhere in the file. It appears to be setup for examples that were never written in the concrete plane.",
+      "recommendation": "Either remove the unused abbreviation or add a concrete Vec2-based example that instantiates Ptolemy's theorem for specific points in ℝ²."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "Lean source lines 193-203 (isosceles trapezoid docstring)",
+      "finding": "The docstring says 'If AC = BD = 7 (the diagonals are equal for isosceles trapezoid), Ptolemy gives: 5·5 + 6·6 = 25 + 36 = 61. But 7·7 = 49, so this doesn't satisfy Ptolemy exactly.' This describes a FAILED application (wrong diagonal length) before correcting it. While pedagogically interesting, framing a numerical error as the primary example narrative is slightly confusing.",
+      "recommendation": "Restructure the docstring to lead with the correct computation: 'By Ptolemy, AC·BD = 5·5 + 6·6 = 61, so AC = BD = √61 ≈ 7.81. (Note: assuming diagonals of length 7 would violate Ptolemy's equality.)'"
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "annotations.json ann-corollary, significance field",
+      "finding": "The annotation marks diagonal_product_from_sides as 'key' significance, but it is an exact duplicate of ptolemys_theorem_symmetric with no additional content.",
+      "recommendation": "If the duplicate is removed (recommended), remove this annotation. If kept, change significance to 'supporting'."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Remove duplicate theorems: ptolemys_theorem_diagonals (identical to ptolemys_theorem) and diagonal_product_from_sides (identical to ptolemys_theorem_symmetric). Update meta.json theoremCount from 5 to 3, update conclusion.summary, and update sections accordingly.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Reframe originalContributions to honestly reflect pedagogical curation rather than mathematical contributions. Suggested: ['Pedagogical examples connecting Ptolemy to the Pythagorean theorem', 'Curated exposition of historical and mathematical context'].",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Rewrite conclusion.summary to accurately reflect 3 distinct theorem statements (not 5) and characterize the entry as a well-curated Mathlib wrapper rather than implying broader formal content.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Remove unused Vec2 abbreviation from Lean source (line 62), or add a concrete ℝ² example that uses it.",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Restructure isosceles trapezoid docstring (lines 193-203) to lead with the correct computation rather than the failed assumption.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 4,
+    "originalityAccuracy": 6,
+    "completeness": 7,
+    "framingPrecision": 6,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 7,
+    "overall": 6.3
+  },
+
+  "suggestedBestFraming": "A pedagogical Mathlib wrapper that names and documents Ptolemy's theorem (Wiedijk #95) with numerical examples demonstrating the Pythagorean theorem as a special case, the square diagonal identity, and isosceles trapezoid diagonal computation."
+}


### PR DESCRIPTION
## Summary

- Peer review of `ptolemys-theorem` gallery entry
- **Grade: C+** (overall 6.3/10)
- 10 findings: 3 positive, 2 major (filler), 2 moderate, 3 minor
- 5 action items (2 high, 2 medium, 1 low)

## Key Findings

**Strengths**: Honest "mathlib" badge, excellent pedagogical examples (Pythagorean special case, square diagonal), well-written historical context

**Major issues**: 2 of 5 named theorems are exact duplicates (`ptolemys_theorem_diagonals` = `ptolemys_theorem`, `diagonal_product_from_sides` = `ptolemys_theorem_symmetric`), inflating apparent content. `originalContributions` overstates pedagogical decoration as mathematical contributions.

## Scores

| Dimension | Score |
|-----------|-------|
| Mathematical Substance | 4/10 |
| Originality Accuracy | 6/10 |
| Completeness | 7/10 |
| Framing Precision | 6/10 |
| Pedagogical Quality | 8/10 |
| Internal Consistency | 7/10 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)