### PR TITLE
Research: erdos-1093 - axiom elimination (5→2), decidability for IsKSmooth

### DIFF
--- a/proofs/Proofs/Erdos1093Problem.lean
+++ b/proofs/Proofs/Erdos1093Problem.lean
@@ -28,6 +28,20 @@ import Mathlib.Tactic
 def IsKSmooth (k m : ℕ) : Prop :=
   ∀ p : ℕ, p.Prime → p ∣ m → p ≤ k
 
+/-- IsKSmooth is decidable: for m = 0 it's false (all primes divide 0),
+    for m ≥ 1 we check finitely many prime factors via Nat.primeFactors. -/
+instance isKSmooth_decidable (k : ℕ) : DecidablePred (IsKSmooth k) := fun m =>
+  if hm : m = 0 then
+    isFalse (by
+      subst hm; intro h
+      obtain ⟨p, hpk, hp⟩ := Nat.exists_infinite_primes (k + 1)
+      exact absurd (h p hp (dvd_zero p)) (by omega))
+  else
+    decidable_of_iff (∀ p ∈ m.primeFactors, p ≤ k)
+      ⟨fun hf p hp hd => hf p (Nat.mem_primeFactors.mpr ⟨hp, hd, hm⟩),
+       fun h p hmem => by
+         obtain ⟨hp, hd, _⟩ := Nat.mem_primeFactors.mp hmem; exact h p hp hd⟩
+
 /-
 ## Section II: Deficiency
 -/
@@ -38,7 +52,7 @@ def NoSmallPrimeFactors (n k : ℕ) : Prop :=
 
 /-- The deficiency of C(n,k): the count of indices 0 ≤ i < k such that
 (n - i) is k-smooth. Defined when C(n,k) has no prime factor ≤ k. -/
-noncomputable def deficiency (n k : ℕ) : ℕ :=
+def deficiency (n k : ℕ) : ℕ :=
   Finset.card (Finset.filter (fun i => IsKSmooth k (n - i)) (Finset.range k))
 
 /-
@@ -67,15 +81,14 @@ def ErdosProblem1093 : Prop :=
 ## Section IV: Known Examples
 -/
 
-/-- C(7,3) = 35 has deficiency 1: primes dividing 35 are 5, 7 (both > 3),
-and among {7, 6, 5}, only 5 and 6 are 3-smooth (actually 7 is not). -/
-axiom deficiency_7_3 : deficiency 7 3 = 1
+/-- C(7,3) = 35 has deficiency 1: among {7, 6, 5}, only 6 is 3-smooth. -/
+theorem deficiency_7_3 : deficiency 7 3 = 1 := by native_decide
 
 /-- C(13,4) = 715 has deficiency 1. -/
-axiom deficiency_13_4 : deficiency 13 4 = 1
+theorem deficiency_13_4 : deficiency 13 4 = 1 := by native_decide
 
 /-- C(284,28) has the highest known deficiency: 9. -/
-axiom deficiency_284_28 : deficiency 284 28 = 9
+theorem deficiency_284_28 : deficiency 284 28 = 9 := by native_decide
 
 /-
 ## Section V: Upper Bound

--- a/src/data/proofs/erdos-1093/meta.json
+++ b/src/data/proofs/erdos-1093/meta.json
@@ -19,9 +19,9 @@
     "erdosNumber": 1093,
     "erdosUrl": "https://erdosproblems.com/1093",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 107,
-    "assumptions": "5 axioms: deficiency_7_3, deficiency_13_4, deficiency_284_28, and 2 more. See Lean source for complete statements.",
+    "axiomCount": 2,
+    "lineCount": 120,
+    "assumptions": "2 axioms: els_upper_bound (ELS 1993 theorem), many_deficiency_one_examples (computational). 3 former axioms (deficiency_7_3, deficiency_13_4, deficiency_284_28) are now proved by native_decide.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
Research session for erdos-1093 (Deficiency of Binomial Coefficients).

## Progress
- **Added `Decidable` instance for `IsKSmooth`** via `Nat.primeFactors`: for `m = 0`, uses `Nat.exists_infinite_primes`; for `m ≥ 1`, reduces to checking finite set of prime factors
- **Made `deficiency` computable** (removed `noncomputable`): the decidability instance provides the required `DecidablePred` for `Finset.filter`
- **Proved 3 axioms by `native_decide`**:
  - `deficiency_7_3 : deficiency 7 3 = 1`
  - `deficiency_13_4 : deficiency 13 4 = 1`
  - `deficiency_284_28 : deficiency 284 28 = 9` (highest known deficiency)
- **Axioms reduced: 5 → 2**

## Remaining Axioms
- `els_upper_bound`: Deep result from Erdős-Lacampagne-Selfridge (1993) — analytic number theory
- `many_deficiency_one_examples`: Large computation (10M pairs) — might be too slow for `native_decide`

## Status
**Outcome**: progress (3 axioms eliminated)
**Docker build**: Passes cleanly

🤖 Generated by researcher-4