### PR TITLE
Enrich 1331 entries (relatedProofs) + fix fundamental-theorem-calculus peer review

### DIFF
--- a/src/data/proofs/erdos-302/meta.json
+++ b/src/data/proofs/erdos-302/meta.json
@@ -261,5 +261,27 @@
       "venue": "arXiv preprint",
       "note": "Proved upper bound f(N) ≤ (9/10+o(1))N"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-23",
+      "relationship": "related",
+      "description": "Both are Erdős extremal combinatorics problems about maximum/minimum sizes of sets satisfying structural constraints"
+    },
+    {
+      "id": "erdos-285",
+      "relationship": "related",
+      "description": "Both concern Egyptian fraction / unit fraction structure: #285 studies asymptotics of Egyptian fraction representations, #302 studies maximum sets avoiding unit fraction equations"
+    },
+    {
+      "id": "erdos-288",
+      "relationship": "related",
+      "description": "Both concern unit fraction sums and finiteness: #288 asks about finitely many interval pairs with integer harmonic sums, #302 asks about maximum sets avoiding 1/a = 1/b + 1/c"
+    },
+    {
+      "id": "erdos-303",
+      "relationship": "related",
+      "description": "The coloring version of #302: can {1,...,N} be 2-colored with no monochromatic solution to 1/a = 1/b + 1/c? Solved by Brown-Rödl (1991)"
+    }
   ]
 }

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -165,5 +165,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-46",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: colouring, number-theory, ramsey-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-242",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-304/meta.json
+++ b/src/data/proofs/erdos-304/meta.json
@@ -198,5 +198,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+    },
+    {
+      "id": "erdos-206",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+    },
+    {
+      "id": "erdos-242",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-305/meta.json
+++ b/src/data/proofs/erdos-305/meta.json
@@ -178,5 +178,47 @@
       "relationship": "related",
       "description": "Euler's theorem ∑1/p = ∞, underlying the prime structure in Egyptian fraction bounds"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-304",
+      "relationship": "related",
+      "description": "Sibling problem on the minimum number of terms N(b) in Egyptian fractions (complexity rather than max denominator)"
+    },
+    {
+      "id": "erdos-306",
+      "relationship": "related",
+      "description": "Sibling problem on Egyptian fractions with semiprime denominator constraints"
+    },
+    {
+      "id": "erdos-307",
+      "relationship": "related",
+      "description": "Prime reciprocal products ∑1/p · ∑1/q = 1, extending Egyptian fraction structure to primes"
+    },
+    {
+      "id": "erdos-308",
+      "relationship": "related",
+      "description": "Bounded denominator representability: smallest integer not expressible as unit fraction sum from {1,...,N}"
+    },
+    {
+      "id": "erdos-309",
+      "relationship": "related",
+      "description": "Counting representable integers from unit fractions, F(N) = Θ(log N) via Yokota-Croot"
+    },
+    {
+      "id": "erdos-300",
+      "relationship": "related",
+      "description": "Maximum subsets avoiding unit fraction sum equal to 1 (Liu-Sawhney 2024)"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "related",
+      "description": "Foundational result H_n ~ log n explaining why logarithms appear in D(b) bounds"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "Euler's theorem ∑1/p = ∞, underlying the prime structure in Egyptian fraction bounds"
+    }
   ]
 }

--- a/src/data/proofs/erdos-306/meta.json
+++ b/src/data/proofs/erdos-306/meta.json
@@ -173,5 +173,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: number-theory, prime-factorization"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-318",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, partially-solved"
+    },
+    {
+      "id": "erdos-1094",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, prime-factorization"
+    },
+    {
+      "id": "erdos-137",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, prime-factorization"
+    }
   ]
 }

--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -273,5 +273,31 @@
     "axiomCount": 5,
     "theoremCount": 19,
     "definitionCount": 15
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-300",
+      "relationship": "Maximum subsets avoiding unit fraction sum 1 — the avoidance analogue of the Egyptian fraction connection in #307"
+    },
+    {
+      "id": "erdos-304",
+      "relationship": "Egyptian fractions complexity — directly related to the unit fraction decomposition theory underlying #307"
+    },
+    {
+      "id": "erdos-306",
+      "relationship": "Egyptian fractions with semiprime denominators — intermediate constraint between coprime and prime conditions in #307"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "Euler's proof that ∑1/p diverges — the key analytic fact behind the |P ∪ Q| ≥ 60 bound in #307"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "Prime factorization underpins both the p-adic valuation argument for P ∩ Q = ∅ and the LCD formulation"
+    },
+    {
+      "id": "bezout-identity",
+      "relationship": "Bézout's identity underlies coprimality verification in Cambie's examples and the modular arithmetic of reciprocal sums"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-308/meta.json
+++ b/src/data/proofs/erdos-308/meta.json
@@ -203,5 +203,27 @@
     "axiomCount": 19,
     "theoremCount": 3,
     "definitionCount": 9
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "harmonic-divergence",
+      "relationship": "The harmonic series $H_N = \\sum_{k=1}^N 1/k$ is the key quantity bounding representability; harmonic-divergence proves $H_N \\to \\infty$, which implies $f(N) \\to \\infty$"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "Both study sums of reciprocals: prime-reciprocal-divergence shows $\\sum 1/p$ diverges, while #308 studies which integers arise as subset sums of $\\{1/k : k \\leq N\\}$"
+    },
+    {
+      "id": "basel-problem",
+      "relationship": "The Basel problem computes $\\sum_{k=1}^\\infty 1/k^2 = \\pi^2/6$; both results concern sums of reciprocals, and the harmonic number $H_N$ is the degree-1 analogue of the Basel sum"
+    },
+    {
+      "id": "erdos-306",
+      "relationship": "Adjacent Erdős–Graham Egyptian fraction problem: #306 concerns decompositions of rationals into distinct unit fractions, complementing #308's bounded-denominator representability question"
+    },
+    {
+      "id": "erdos-124-complete-sequences",
+      "relationship": "Both study completeness of integer sequences: #124 asks when a sequence is complete (every large integer is a subset sum), while #308 asks which integers are subset sums of $\\{1/k\\}$ mapped to $\\mathbb{Z}$"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -242,5 +242,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-314",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: asymptotic-analysis, harmonic-numbers, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-242",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-31/meta.json
+++ b/src/data/proofs/erdos-31/meta.json
@@ -185,5 +185,22 @@
       "venue": "Archiv der Mathematik, vol. 15, pp. 210–214",
       "note": "Early results on density of additive complements"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-32",
+      "relationship": "related",
+      "description": "Problem #32 asks specifically about additive complements of primes, a special case of Problem #31's general question about additive complements"
+    },
+    {
+      "id": "erdos-33",
+      "relationship": "related",
+      "description": "Problem #33 asks about additive complements of squares, another special case. Problems #31, #32, #33 form a trio studying additive complements of different structured sets"
+    },
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "Additive bases (Problem #28) and additive complements (Problem #31) are dual concepts: a complement B of A satisfies A + B ⊇ all large integers, making A ∪ B a basis-like structure"
+    }
   ]
 }

--- a/src/data/proofs/erdos-310/meta.json
+++ b/src/data/proofs/erdos-310/meta.json
@@ -213,5 +213,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, solved, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-286",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, solved, unit-fractions"
+    },
+    {
+      "id": "erdos-292",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: density, egyptian-fractions, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-296",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, solved, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -165,5 +165,17 @@
       "authors": "Kovac",
       "note": "Showed the variant asking about exact representation of 1 is equivalent"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-316",
+      "relationship": "related-problem",
+      "description": "Both involve unit fraction sums: #311 asks about approximating 1, while #316 asks about partitioning sets with reciprocal sum < 2"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "uses-result",
+      "description": "The lower bound δ(N) ≥ 1/lcm(1,...,N) uses lcm(1,...,N) = e^{ψ(N)} where ψ(N) ~ N by PNT"
+    }
   ]
 }

--- a/src/data/proofs/erdos-312/meta.json
+++ b/src/data/proofs/erdos-312/meta.json
@@ -166,5 +166,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-242",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-284",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-313/meta.json
+++ b/src/data/proofs/erdos-313/meta.json
@@ -172,5 +172,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
+    },
+    {
+      "id": "erdos-320",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
+    },
+    {
+      "id": "erdos-321",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-314/meta.json
+++ b/src/data/proofs/erdos-314/meta.json
@@ -180,5 +180,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: number-theory, solved, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-309",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: asymptotic-analysis, harmonic-numbers, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-286",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, solved, unit-fractions"
+    },
+    {
+      "id": "erdos-296",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, solved, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-315/meta.json
+++ b/src/data/proofs/erdos-315/meta.json
@@ -242,5 +242,22 @@
       "venue": "arXiv preprints",
       "note": "Independently proved that Sylvester's sequence has maximal growth rate among Egyptian sequences"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-288",
+      "relationship": "related",
+      "description": "Both concern integer properties of sums of unit fractions — #288 asks when harmonic sums are integers, #315 asks about growth rates of sequences summing to 1"
+    },
+    {
+      "id": "erdos-267",
+      "relationship": "related",
+      "description": "Both involve irrationality/transcendence of sums related to number-theoretic sequences (Fibonacci vs Sylvester)"
+    },
+    {
+      "id": "erdos-285",
+      "relationship": "related",
+      "description": "Both concern Egyptian fraction structure: #285 studies asymptotics of Egyptian fraction representations, #315 characterizes the optimal growth rate among all Egyptian sequences for 1"
+    }
   ]
 }

--- a/src/data/proofs/erdos-316/meta.json
+++ b/src/data/proofs/erdos-316/meta.json
@@ -193,5 +193,37 @@
       "venue": "L'Enseignement Mathématique, Monographie No. 28, Geneva",
       "note": "Original source of the conjecture — an influential monograph collecting hundreds of open problems in combinatorial number theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-191",
+      "relationship": "related",
+      "description": "Both involve reciprocal sums of natural numbers; #191 studies monochromatic sets with large $1/\\log$ sum while #316 studies partition constraints on $\\sum 1/n$ sums"
+    },
+    {
+      "id": "erdos-315",
+      "relationship": "related",
+      "description": "Adjacent problem in the Erdős unit fractions series — #315 and #316 both concern partitioning constraints on sets of unit fractions"
+    },
+    {
+      "id": "erdos-317",
+      "relationship": "related",
+      "description": "Adjacent problem in the Erdős conjecture series — #317 explores related partitioning questions for sets with reciprocal sum constraints"
+    },
+    {
+      "id": "harmonic-divergence",
+      "relationship": "foundational",
+      "description": "The divergence of $\\sum 1/n$ implies that large finite sets of natural numbers have arbitrarily large reciprocal sums. The threshold $\\sum 1/n < 2$ in Erdős #316 is a finite-set constraint within this divergent series"
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "The divergence of $\\sum 1/p$ over primes shows that even prime-restricted reciprocal sums grow without bound. The counterexample set $\\{2,3,5,7,11,13\\}$ uses primes because their reciprocals are the 'largest' unit fractions for their size, creating tighter partition constraints"
+    },
+    {
+      "id": "erdos-305",
+      "relationship": "related",
+      "description": "Another Erdős problem on arithmetic structure of natural number subsets — both concern how combinatorial properties interact with the additive/multiplicative structure of finite subsets of $\\mathbb{N}$"
+    }
   ]
 }

--- a/src/data/proofs/erdos-317/meta.json
+++ b/src/data/proofs/erdos-317/meta.json
@@ -165,5 +165,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: diophantine-approximation, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1000",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: diophantine-approximation, number-theory"
+    },
+    {
+      "id": "erdos-1001",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: diophantine-approximation, number-theory"
+    },
+    {
+      "id": "erdos-1147",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: diophantine-approximation, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-318/meta.json
+++ b/src/data/proofs/erdos-318/meta.json
@@ -197,5 +197,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-242",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-284",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-319/meta.json
+++ b/src/data/proofs/erdos-319/meta.json
@@ -162,5 +162,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-300",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-310",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-1005",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-32/meta.json
+++ b/src/data/proofs/erdos-32/meta.json
@@ -220,5 +220,22 @@
       "venue": "Doklady Akademii Nauk SSSR, vol. 15, pp. 291–294",
       "note": "Goldbach-type results showing primes are nearly self-complementary"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-31",
+      "relationship": "specializes",
+      "description": "Problem #31 asks about additive complements in general; Problem #32 specializes to additive complements of the primes"
+    },
+    {
+      "id": "erdos-33",
+      "relationship": "related",
+      "description": "Problem #33 (complements of squares) is the parallel question for a different structured set. Both ask: how thin can a complement of a natural sequence be?"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The distribution of primes (density ~1/log N) determines the minimum density of their additive complements"
+    }
   ]
 }

--- a/src/data/proofs/erdos-320/meta.json
+++ b/src/data/proofs/erdos-320/meta.json
@@ -228,5 +228,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: counting, egyptian-fractions, number-theory, open, unit-fractions"
+    },
+    {
+      "id": "erdos-313",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
+    },
+    {
+      "id": "erdos-321",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -167,5 +167,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
+    },
+    {
+      "id": "erdos-300",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, subset-sums, unit-fractions"
+    },
+    {
+      "id": "erdos-313",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, open, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-322/meta.json
+++ b/src/data/proofs/erdos-322/meta.json
@@ -186,5 +186,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-11",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-1103",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-1107",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-323/meta.json
+++ b/src/data/proofs/erdos-323/meta.json
@@ -170,5 +170,22 @@
       "authors": "Erdős–Graham 1980",
       "note": "Original source of both conjectures"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-362",
+      "relationship": "related-problem",
+      "description": "Both involve counting integers with specific additive representations: #323 counts sums of k-th powers, #362 counts subsets with a given sum"
+    },
+    {
+      "id": "fermat-two-squares",
+      "relationship": "foundation",
+      "description": "Fermat's theorem on sums of two squares provides the multiplicative criterion underlying Landau's asymptotic for f_{2,2}(x)"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "technique",
+      "description": "The prime number theorem underlies the analytic number theory techniques used in Landau's proof of f_{2,2}(x) ~ c·x/√(log x)"
+    }
   ]
 }

--- a/src/data/proofs/erdos-324/meta.json
+++ b/src/data/proofs/erdos-324/meta.json
@@ -195,5 +195,27 @@
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 7
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-321",
+      "relationship": "Both from Erdős-Graham (1980) on polynomial additive combinatorics"
+    },
+    {
+      "id": "erdos-325",
+      "relationship": "Adjacent Erdős problem on polynomial representations"
+    },
+    {
+      "id": "erdos-332",
+      "relationship": "Both involve additive structure of polynomial images"
+    },
+    {
+      "id": "lagrange-four-squares",
+      "relationship": "Lagrange's theorem gives representation bounds; pair sums of squares relate to this"
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "Cauchy-Schwarz bounds additive energy, connected to distinct pair sum counting"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-325/meta.json
+++ b/src/data/proofs/erdos-325/meta.json
@@ -153,5 +153,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-423",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, asymptotics, number-theory"
+    },
+    {
+      "id": "erdos-1054",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: asymptotics, number-theory"
+    },
+    {
+      "id": "erdos-11",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-326/meta.json
+++ b/src/data/proofs/erdos-326/meta.json
@@ -152,5 +152,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, bases, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1103",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, growth-rates, number-theory"
+    },
+    {
+      "id": "erdos-336",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, bases, number-theory"
+    },
+    {
+      "id": "erdos-868",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, bases, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-327/meta.json
+++ b/src/data/proofs/erdos-327/meta.json
@@ -166,5 +166,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: extremal-combinatorics, number-theory, unit-fractions"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1062",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: divisibility, extremal-combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-301",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: extremal-combinatorics, number-theory, unit-fractions"
+    },
+    {
+      "id": "erdos-302",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: extremal-combinatorics, number-theory, unit-fractions"
+    }
   ]
 }

--- a/src/data/proofs/erdos-328/meta.json
+++ b/src/data/proofs/erdos-328/meta.json
@@ -221,5 +221,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, sidon-sets"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-360",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, partition, ramsey-theory"
+    },
+    {
+      "id": "erdos-14",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sidon-sets"
+    },
+    {
+      "id": "erdos-152",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sidon-sets"
+    }
   ]
 }

--- a/src/data/proofs/erdos-329/meta.json
+++ b/src/data/proofs/erdos-329/meta.json
@@ -203,5 +203,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: combinatorics, density"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1075",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, density"
+    },
+    {
+      "id": "erdos-109",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, density"
+    },
+    {
+      "id": "erdos-139",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, density"
+    }
   ]
 }

--- a/src/data/proofs/erdos-33/meta.json
+++ b/src/data/proofs/erdos-33/meta.json
@@ -141,5 +141,17 @@
       "venue": "Nouveaux Mémoires de l'Académie royale des Sciences de Berlin",
       "note": "Proved every positive integer is a sum of four squares — the classical result on squares as an additive basis"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-31",
+      "relationship": "specializes",
+      "description": "Problem #31 asks about additive complements in general; Problem #33 specializes to complements of the sequence of perfect squares"
+    },
+    {
+      "id": "erdos-32",
+      "relationship": "related",
+      "description": "Problem #32 asks about complements of primes. Problems #31-33 form a trio: general complements, complements of primes, complements of squares"
+    }
   ]
 }

--- a/src/data/proofs/erdos-330/meta.json
+++ b/src/data/proofs/erdos-330/meta.json
@@ -158,5 +158,22 @@
       "venue": "Springer GTM 164",
       "note": "Standard reference for additive basis theory including Waring's problem, minimal bases, and the Erdős-Nathanson program"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-38",
+      "relationship": "related",
+      "description": "Both concern additive bases and density: #38 studies essential components and density boosting via Schnirelmann's method, while #330 asks about minimal bases where each element's removal creates positive-density gaps"
+    },
+    {
+      "id": "erdos-469",
+      "relationship": "related",
+      "description": "Both ask about density/convergence properties of number-theoretic sets defined by divisor/representability conditions"
+    },
+    {
+      "id": "lagrange-four-squares",
+      "relationship": "foundational",
+      "description": "Lagrange's four-square theorem proves that the squares form an additive basis of order 4. This is the classical example motivating additive basis theory — Problem #330 asks about the minimality structure of general bases, not just classical ones like squares"
+    }
   ]
 }

--- a/src/data/proofs/erdos-331/meta.json
+++ b/src/data/proofs/erdos-331/meta.json
@@ -293,5 +293,52 @@
       "venue": "Cambridge University Press",
       "note": "Standard reference; Chapter 2 covers sumset estimates and density conditions for additive structure"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Both concern arithmetic structure in dense sets. Szemerédi's theorem guarantees APs in dense sets; Problem #331 asks about common differences between two sets of density $\\sim \\sqrt{N}$"
+    },
+    {
+      "id": "erdos-1097",
+      "relationship": "related",
+      "description": "Both study common differences and additive structure: #1097 asks about the number of common differences in 3-term APs within a single set, while #331 asks about common differences between two distinct sets"
+    },
+    {
+      "id": "roth-theorem-k3",
+      "relationship": "related",
+      "description": "Both study density thresholds for additive structure. Roth's theorem shows density $\\gg N/\\log\\log N$ forces 3-term APs; Problem #331 shows density $\\sim \\sqrt{N}$ does NOT force common differences between two sets — a sharp contrast in the 'density implies structure' paradigm"
+    },
+    {
+      "id": "erdos-30",
+      "relationship": "related",
+      "description": "Ruzsa's counterexample sets have Sidon-like properties ($|A - A| \\sim |A|$), connecting to Erdős #30 on $B_2$ sequences (sets with distinct pairwise sums). Both exploit extremal additive structure to achieve unusual combinatorial properties"
+    },
+    {
+      "id": "erdos-3",
+      "relationship": "related",
+      "description": "Erdős #3 asks about arithmetic progressions in the primes (a density condition on a specific set). Both #3 and #331 ask when density forces structured arithmetic patterns, but #331's negative answer shows the forcing depends sensitively on the structure of the set, not just its density"
+    },
+    {
+      "id": "szemeredi-counting",
+      "relationship": "related",
+      "description": "The counting lemma quantifies how many structured subpatterns exist in dense sets. The density threshold $\\sqrt{N}$ in #331 is precisely where counting arguments via Plünnecke-Ruzsa fail to guarantee common differences"
+    },
+    {
+      "id": "arithmetic-series",
+      "relationship": "foundational",
+      "description": "Arithmetic progressions and their common differences are the central objects. The difference set $A - A$ is precisely the set of common differences of 2-term APs in $A$"
+    },
+    {
+      "id": "erdos-1145",
+      "relationship": "related",
+      "description": "Problem #1145 (Erdős–Sárközy conjecture) cites Ruzsa's counterexample from #331 to show the ratio condition $a_n/b_n \\to 1$ is necessary: without it, one can have $A + B = \\mathbb{N}$ with $r_{A,B}(n) = 1$ for all $n$"
+    },
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "Problem #28 (Erdős–Turán conjecture on additive bases) is the $A = B$ case of the two-set conjecture #1145. Ruzsa's counterexample (#331) shows the two-set generalization requires the additional ratio condition"
+    }
   ]
 }

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -213,5 +213,27 @@
       "venue": "Oxford University Press",
       "note": "Classical reference for difference sets, density conditions, and additive bases; includes the average representation divergence result"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-23",
+      "relationship": "related",
+      "description": "Both study how density forces combinatorial structure: #23 concerns covering congruences and minimum modulus, #332 concerns difference sets and syndeticity — both ask 'what density threshold forces a specific pattern?'"
+    },
+    {
+      "id": "erdos-331",
+      "relationship": "related",
+      "description": "Consecutive Erdős problem on additive structure of dense sets. Both #331 and #332 study how arithmetic properties of A propagate to derived sets (sumsets vs difference sets)"
+    },
+    {
+      "id": "erdos-333",
+      "relationship": "related",
+      "description": "Consecutive Erdős problem. Both #332 and #333 concern structural consequences of density conditions on subsets of ℕ in the additive combinatorics setting"
+    },
+    {
+      "id": "erdos-340",
+      "relationship": "related",
+      "description": "Both involve density and extremal problems in additive combinatorics: #340 studies sum-free sets and their maximum density, #332 studies difference sets and syndeticity thresholds"
+    }
   ]
 }

--- a/src/data/proofs/erdos-333/meta.json
+++ b/src/data/proofs/erdos-333/meta.json
@@ -214,5 +214,17 @@
       "venue": "Monographies de L'Enseignement Mathématique 28",
       "note": "[ErGr80] where Problem 333 appears, apparently overlooking the implicit negative answer in Erdős-Newman 1977"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-302",
+      "relationship": "related",
+      "description": "Both are Erdős combinatorial density problems about extremal sizes of structured subsets of integers"
+    },
+    {
+      "id": "erdos-806",
+      "relationship": "related",
+      "description": "Directly related: #806 asks about small bases for sumsets (B+B covering). Both explore the minimum size of B needed so that A ⊆ B+B"
+    }
   ]
 }

--- a/src/data/proofs/erdos-334/meta.json
+++ b/src/data/proofs/erdos-334/meta.json
@@ -210,5 +210,22 @@
       "venue": "Indag. Math. 13, pp. 50-60",
       "note": "Foundational work on the Dickman function ρ(u) governing smooth number density"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "prime-number-theorem",
+      "relationship": "uses",
+      "description": "PNT underpins the distribution of smooth numbers via the Dickman function and Selberg-Delange method"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "related",
+      "description": "Smooth numbers are defined by their largest prime factor; infinitude of primes ensures the problem is nontrivial"
+    },
+    {
+      "id": "erdos-333",
+      "relationship": "related",
+      "description": "Both concern additive representations of integers: #333 asks about sumset covering A ⊆ B+B, #334 asks about representing n = a + b with smooth summands"
+    }
   ]
 }

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -172,5 +172,12 @@
     "Weyl (1916): 'Über die Gleichverteilung von Zahlen mod. Eins', Math. Annalen 77, 313–352",
     "Nathanson (1996): 'Additive Number Theory: Inverse Problems and the Geometry of Sumsets', Graduate Texts in Mathematics 165",
     "https://erdosproblems.com/335"
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-36",
+      "relationship": "related",
+      "description": "Both study density/overlap in partition and sumset problems; #36 concerns overlap in partitions while #335 characterizes density-additive sumsets"
+    }
   ]
 }

--- a/src/data/proofs/erdos-336/meta.json
+++ b/src/data/proofs/erdos-336/meta.json
@@ -180,5 +180,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-326",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, bases, number-theory"
+    },
+    {
+      "id": "erdos-868",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, bases, number-theory"
+    },
+    {
+      "id": "erdos-11",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-337/meta.json
+++ b/src/data/proofs/erdos-337/meta.json
@@ -241,5 +241,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-bases, additive-combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1103",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, sumsets"
+    },
+    {
+      "id": "erdos-1109",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, sumsets"
+    },
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-bases, additive-combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-338/meta.json
+++ b/src/data/proofs/erdos-338/meta.json
@@ -201,5 +201,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1005",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-1138",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-1161",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-339/meta.json
+++ b/src/data/proofs/erdos-339/meta.json
@@ -208,5 +208,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-bases, additive-combinatorics, density, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-35",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-bases, additive-combinatorics, density, number-theory, solved"
+    },
+    {
+      "id": "erdos-1136",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, density, number-theory, solved"
+    },
+    {
+      "id": "erdos-330",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-bases, additive-combinatorics, density, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-34/meta.json
+++ b/src/data/proofs/erdos-34/meta.json
@@ -166,5 +166,17 @@
       "venue": "Bulletin of the Research Council of Israel, Section F, vol. 10F, pp. 41–43",
       "note": "The Erdős-Ginzburg-Ziv theorem on zero-sum subsequences, related to consecutive sum properties in permutations"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1",
+      "relationship": "related",
+      "description": "Problem #1 (distinct subset sums) and Problem #34 (consecutive sums in permutations) both concern how sums of structured subsets behave. Both ask when additive properties can be simultaneously satisfied"
+    },
+    {
+      "id": "erdos-867",
+      "relationship": "related",
+      "description": "Problem #867 on sum-free sets and Problem #34 on consecutive sums both concern constraints on sums of elements in a set/permutation"
+    }
   ]
 }

--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -251,5 +251,47 @@
       "citation": "Tao, T. and Vu, V. (2006). Additive Combinatorics. Cambridge University Press, Chapter 6.",
       "type": "book"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-340",
+      "relationship": "extends",
+      "description": "This infrastructure module provides the full Sidon set library (definitions, closure, counting, bounds) for the main Erdos #340 problem entry"
+    },
+    {
+      "id": "erdos-44",
+      "relationship": "foundational",
+      "description": "Erdos #44 concerns Sidon sets (B2 sequences) — this module's IsSidon definition, subset closure, and counting infrastructure directly support that formalization"
+    },
+    {
+      "id": "erdos-1",
+      "relationship": "thematic",
+      "description": "Both are foundational results in additive combinatorics: Erdos #1 (Erdos-Ginzburg-Ziv, zero-sum subsequences) constrains sums modulo n, while Sidon sets constrain pairwise sum distinctness"
+    },
+    {
+      "id": "roth-theorem-k3",
+      "relationship": "related",
+      "description": "Roth's theorem (dense sets contain 3-term APs) is complementary: Sidon sets constrain pairwise sums (additive energy zero), while AP-free sets constrain arithmetic structure. Both use density/counting arguments to derive upper bounds on set size"
+    },
+    {
+      "id": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemeredi's theorem (dense sets contain arbitrarily long APs) and Sidon theory represent dual aspects of additive combinatorics: Szemeredi limits how unstructured a dense set can be, while Sidon theory limits how dense an unstructured set can be"
+    },
+    {
+      "id": "prob-method-expectation",
+      "relationship": "related",
+      "description": "The probabilistic method shows random Sidon sets achieve density N^(1/2), near-optimal. This provides the comparison benchmark: Erdos conjectured the deterministic greedy achieves nearly the same N^(1/2-epsilon) density as random"
+    },
+    {
+      "id": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The bijection orderedPairsLt_card_via_choose uses C(n,2) = n(n-1)/2 via Finset.card_powersetCard. This binomial coefficient is the core counting tool for all Sidon set bounds in this module"
+    },
+    {
+      "id": "partition-theorem",
+      "relationship": "related",
+      "description": "Each element of the sumset A+A of a Sidon set has a unique representation a+b with a <= b — a partition-like uniqueness constraint that parallels the distinct-parts condition in partition theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -177,5 +177,37 @@
     "axiomCount": 8,
     "theoremCount": 0,
     "definitionCount": 4
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-30",
+      "relationship": "related",
+      "description": "Problem #30 asks whether h(N) = N^{1/2} + O_ε(N^ε) for general Sidon sets — the theoretical ceiling that constrains Problem #340. Resolving #340 would show the greedy construction approaches this ceiling"
+    },
+    {
+      "id": "erdos-156",
+      "relationship": "related",
+      "description": "Problem #156 concerns maximal Sidon subsets and their density. Both study how construction methods affect Sidon set growth, with #340 focusing on the specific greedy algorithm"
+    },
+    {
+      "id": "prob-method-expectation",
+      "relationship": "technique",
+      "description": "The random Sidon set benchmark (expected size ~N^{1/3} by the birthday paradox) is the baseline comparison: the greedy construction empirically outperforms randomness by achieving ~N^{0.497} instead of ~N^{1/3}"
+    },
+    {
+      "id": "prob-method-alteration",
+      "relationship": "technique",
+      "description": "The alteration method could potentially construct near-optimal Sidon sets by starting with a random set and removing colliding pairs. This approach gives ~N^{1/3} which matches the known lower bound, suggesting the greedy algorithm uses structural information that randomness misses"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "technique",
+      "description": "Singer's construction of Sidon sets from perfect difference sets in Z_p uses primes, achieving size ~√N for specific N. The PNT ensures these constructions exist for arbitrarily large N, providing the existence proof that the Erdős-Turán upper bound is tight (at least for non-greedy constructions)"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes guarantees that Singer-type Sidon set constructions (using Z_p for primes p) exist for all large N, establishing the theoretical maximum density against which the greedy sequence is compared"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-341/meta.json
+++ b/src/data/proofs/erdos-341/meta.json
@@ -157,5 +157,32 @@
     "axiomCount": 9,
     "theoremCount": 0,
     "definitionCount": 5
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-340",
+      "relationship": "specialization",
+      "description": "Problem #340 concerns the greedy Sidon (Mian-Chowla) sequence, which is the Dickson extension starting from {1}. Problem #341 generalizes to arbitrary starting sets."
+    },
+    {
+      "id": "erdos-302",
+      "relationship": "related",
+      "description": "Both concern sum-free set theory: #302 studies unit fraction sum-free sets, #341 extends Dickson's sum-free construction — both explore extremal properties of sets avoiding additive structure."
+    },
+    {
+      "id": "erdos-421",
+      "relationship": "related",
+      "description": "Both study dense sequences with restricted arithmetic structure: #421 concerns distinct products in dense sequences, #341 concerns sum-free extensions — different facets of additive vs multiplicative extremal combinatorics."
+    },
+    {
+      "id": "erdos-349",
+      "relationship": "related",
+      "description": "Both involve sequence completeness and density conditions: #349 studies completeness of exponential floor sequences, #341 studies periodic structure in sum-free extensions — both address how structural constraints shape sequence behavior."
+    },
+    {
+      "id": "erdos-276",
+      "relationship": "related",
+      "description": "Both involve sequences with restricted additive/multiplicative properties and periodicity: #276 studies composite Lucas sequences, #341 studies periodic sum-free extensions."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-342/meta.json
+++ b/src/data/proofs/erdos-342/meta.json
@@ -169,5 +169,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-423",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, sequences"
+    },
+    {
+      "id": "erdos-839",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, sequences"
+    },
+    {
+      "id": "erdos-11",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-343/meta.json
+++ b/src/data/proofs/erdos-343/meta.json
@@ -160,5 +160,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, density, sumsets"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-109",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, density, sumsets"
+    },
+    {
+      "id": "erdos-245",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, density, sumsets"
+    },
+    {
+      "id": "erdos-31",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, density, sumsets"
+    }
   ]
 }

--- a/src/data/proofs/erdos-344/meta.json
+++ b/src/data/proofs/erdos-344/meta.json
@@ -212,5 +212,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: complete-sequences, number-theory, subset-sums"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-253",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: arithmetic-progressions, number-theory, subset-sums"
+    },
+    {
+      "id": "erdos-345",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: complete-sequences, number-theory, subset-sums"
+    },
+    {
+      "id": "erdos-347",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: complete-sequences, number-theory, subset-sums"
+    }
   ]
 }

--- a/src/data/proofs/erdos-346/meta.json
+++ b/src/data/proofs/erdos-346/meta.json
@@ -140,5 +140,12 @@
       "relationship": "related",
       "description": "Both concern additive representation properties of sequences: #38 on essential components, #346 on completeness and fragility under removal"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-38",
+      "relationship": "related",
+      "description": "Both concern additive representation properties of sequences: #38 on essential components, #346 on completeness and fragility under removal"
+    }
   ]
 }

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -154,5 +154,22 @@
       "venue": "Canadian Journal of Mathematics, vol. 18, pp. 643–655",
       "note": "Classical results on complete sequences and the relationship between growth rate and completeness"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1",
+      "relationship": "related",
+      "description": "Both concern subset sum structure: #1 asks when all subset sums are distinct (minimizing representations), while #347 asks when subset sums achieve density 1 robustly (maximizing coverage). They sit at opposite ends of the subset sum complexity spectrum"
+    },
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "Both concern additive completeness: #28 asks whether representation functions of additive bases must be unbounded, while #347 asks whether a sequence growing at rate 2 can maintain density-1 subset sums under deletions. Both explore the boundary between thin and thick additive structure"
+    },
+    {
+      "id": "erdos-40",
+      "relationship": "related",
+      "description": "Both involve additive structure at critical thresholds: #40 studies B_2[g] sets that cannot be bases, while #347 studies sequences at the critical ratio 2 that can be robustly complete. Both concern how growth rate constraints interact with additive coverage"
+    }
   ]
 }

--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -209,5 +209,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, complete-sequences, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-124",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, complete-sequences, number-theory"
+    },
+    {
+      "id": "erdos-246",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, complete-sequences, number-theory"
+    },
+    {
+      "id": "erdos-54",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, complete-sequences, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -183,5 +183,27 @@
       "What is the Hausdorff dimension of the boundary of the completeness region in (t,α)-space?",
       "Is there a topological or measure-theoretic characterization of the completeness set for fixed t?"
     ]
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-345",
+      "relationship": "related",
+      "description": "Studies completeness thresholds for power sequences — a closely related completeness problem sharing the additive combinatorics framework"
+    },
+    {
+      "id": "erdos-346",
+      "relationship": "related",
+      "description": "Studies lacunary complete sequences with golden ratio limit, sharing the $\\varphi$ threshold that is central to Problem #349"
+    },
+    {
+      "id": "erdos-322",
+      "relationship": "related",
+      "description": "Waring's problem for sums of $k$-th powers, connected through the Ideal Waring formula $g(k) = 2^k + \\lfloor (3/2)^k \\rfloor - 2$"
+    },
+    {
+      "id": "erdos-267",
+      "relationship": "related",
+      "description": "Irrationality of Fibonacci reciprocal sums, connecting Fibonacci sequences and the golden ratio that appears as the critical threshold"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-35/meta.json
+++ b/src/data/proofs/erdos-35/meta.json
@@ -177,5 +177,22 @@
       "venue": "Oxford University Press",
       "note": "Standard reference for Schnirelmann density theory and additive bases"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "Problem #28 (Erdős-Turán on bases) and Problem #35 both concern additive bases. Schnirelmann density provides the foundation: positive Schnirelmann density implies basis, but Problem #28 asks about the representation function"
+    },
+    {
+      "id": "erdos-29",
+      "relationship": "related",
+      "description": "Problem #29 asks for explicit economical bases. Schnirelmann's theorem (Problem #35) guarantees existence; Problem #29 demands constructive versions"
+    },
+    {
+      "id": "erdos-31",
+      "relationship": "related",
+      "description": "Additive complements (Problem #31) and Schnirelmann density (Problem #35) are closely related: a set with positive Schnirelmann density is automatically an additive basis"
+    }
   ]
 }

--- a/src/data/proofs/erdos-350/meta.json
+++ b/src/data/proofs/erdos-350/meta.json
@@ -205,5 +205,22 @@
       "venue": "https://erdosproblems.com/350",
       "note": "Online catalog entry with current status and related problems"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-30",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, sidon-sets"
+    },
+    {
+      "id": "erdos-340",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, sidon-sets"
+    },
+    {
+      "id": "erdos-41",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, sidon-sets"
+    }
   ]
 }

--- a/src/data/proofs/erdos-351/meta.json
+++ b/src/data/proofs/erdos-351/meta.json
@@ -147,5 +147,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-283",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, polynomials"
+    },
+    {
+      "id": "erdos-11",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-1103",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-352/meta.json
+++ b/src/data/proofs/erdos-352/meta.json
@@ -195,5 +195,17 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: number-neighbor"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-351",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-neighbor"
+    },
+    {
+      "id": "erdos-353",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-neighbor"
+    }
   ]
 }

--- a/src/data/proofs/erdos-353/meta.json
+++ b/src/data/proofs/erdos-353/meta.json
@@ -186,5 +186,12 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: geometric-measure-theory, solved"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-988",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: geometric-measure-theory, solved"
+    }
   ]
 }

--- a/src/data/proofs/erdos-354/meta.json
+++ b/src/data/proofs/erdos-354/meta.json
@@ -202,5 +202,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-11",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-1103",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-1107",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -168,5 +168,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-148",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+    },
+    {
+      "id": "erdos-206",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+    },
+    {
+      "id": "erdos-242",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-356/meta.json
+++ b/src/data/proofs/erdos-356/meta.json
@@ -202,5 +202,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, combinatorics, solved"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1179",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, combinatorics, solved"
+    },
+    {
+      "id": "erdos-185",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, combinatorics, solved"
+    },
+    {
+      "id": "erdos-748",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, combinatorics, solved"
+    }
   ]
 }

--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -257,5 +257,27 @@
     "axiomCount": 4,
     "theoremCount": 16,
     "definitionCount": 16
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-867",
+      "relationship": "Problem #867 on subsequences with distinct sums; both study extremal sequence properties"
+    },
+    {
+      "id": "erdos-321",
+      "relationship": "Both involve extremal problems on integer sequences with distinctness constraints"
+    },
+    {
+      "id": "erdos-332",
+      "relationship": "Related sequence extremal problems from Erdős-Graham"
+    },
+    {
+      "id": "erdos-324",
+      "relationship": "Problem #324 asks about distinct pair sums of polynomial values; both involve distinctness of sums"
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "Cauchy-Schwarz bounds additive energy, connected to B₂ sequence theory underlying Weisenberg's bound"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -188,5 +188,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: number-theory, open, primes"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1113",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, open, primes"
+    },
+    {
+      "id": "erdos-1141",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, open, primes"
+    },
+    {
+      "id": "erdos-200",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, open, primes"
+    }
   ]
 }

--- a/src/data/proofs/erdos-359/meta.json
+++ b/src/data/proofs/erdos-359/meta.json
@@ -166,5 +166,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: density, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-421",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: density, number-theory, sequences"
+    },
+    {
+      "id": "erdos-424",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: density, number-theory, sequences"
+    },
+    {
+      "id": "erdos-1054",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: density, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -282,5 +282,57 @@
       "venue": "Unpublished manuscript",
       "note": "Refined exponential sum estimates for upper bounds on c"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-335",
+      "relationship": "related",
+      "description": "Erdős #335 studies density additivity in sumsets, a closely related partition-structure question in additive combinatorics"
+    },
+    {
+      "id": "erdos-66",
+      "relationship": "related",
+      "description": "Erdős #66 studies the representation function r_A(n) asymptotics, the same counting machinery underlying the overlap function"
+    },
+    {
+      "id": "erdos-30",
+      "relationship": "complement",
+      "description": "Erdős #30 on Sidon sets (B₂ sequences with unique pairwise sums) represents the opposite extreme — maximizing distinctness of differences"
+    },
+    {
+      "id": "fourier-series",
+      "relationship": "supports",
+      "description": "Scherk's 1955 lower bound and White's 2022 breakthrough both use Fourier analysis. The overlap function equals the autocorrelation of the partition indicator, and Parseval's identity provides the key constraint in the convex optimization formulation"
+    },
+    {
+      "id": "erdos-1",
+      "relationship": "related",
+      "description": "Both are extremal problems on subsets of integers: #1 asks for maximum-size sets with distinct subset sums, #36 asks for minimum-overlap equal partitions. Both probe the combinatorial structure of difference and sum sets in $\\{1, \\ldots, N\\}$"
+    },
+    {
+      "id": "roth-theorem-k3",
+      "relationship": "related",
+      "description": "Both use Fourier-analytic methods on finite sets of integers. Roth's theorem counts 3-term APs via the Fourier transform; the minimum overlap problem reduces to convex optimization over Fourier coefficients. The same machinery (Parseval's identity, energy bounds) drives both results"
+    },
+    {
+      "id": "erdos-35",
+      "relationship": "related",
+      "description": "Both concern additive structure in integer subsets: #35 studies Schnirelmann density and when sets form additive bases (sumsets cover all integers), while #36 studies the unavoidable overlap in equal partitions. Both use density and counting arguments on $\\{1,\\ldots,N\\}$"
+    },
+    {
+      "id": "erdos-37",
+      "relationship": "related",
+      "description": "Neighboring Erdős problem on essential components and lacunary sets in additive number theory. Both #36 and #37 probe the structural constraints that additive combinatorics imposes on subsets of integers"
+    },
+    {
+      "id": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemerédi's theorem on arithmetic progressions in dense sets and the regularity lemma underpin potential approaches to the minimum overlap problem. The open question of whether regularity methods can provide an alternative lower bound connects directly to this machinery — both problems concern the unavoidable additive structure in dense subsets of integers"
+    },
+    {
+      "id": "prob-method-expectation",
+      "relationship": "related",
+      "description": "The first moment method provides the baseline lower bound on the minimum overlap: a random equal partition of $\\{1,\\ldots,2N\\}$ has expected overlap $\\sim N/2$ at each shift, and the maximum over $O(N)$ shifts is at least the average. Carefully optimizing the partition reduces the overlap from $N/2$ to $\\sim 0.380 N$, but the probabilistic baseline shows that random partitions already achieve overlap $\\sim N/2$ — the problem asks how much better structured partitions can do"
+    }
   ]
 }

--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -189,5 +189,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive-combinatorics, partition, ramsey-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1136",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, solved, sum-free-sets"
+    },
+    {
+      "id": "erdos-179",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, ramsey-theory, solved"
+    },
+    {
+      "id": "erdos-328",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, partition, ramsey-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-361/meta.json
+++ b/src/data/proofs/erdos-361/meta.json
@@ -179,5 +179,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: asymptotics, combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-253",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, subset-sums"
+    },
+    {
+      "id": "erdos-300",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, subset-sums"
+    },
+    {
+      "id": "erdos-400",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: asymptotics, combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-362/meta.json
+++ b/src/data/proofs/erdos-362/meta.json
@@ -203,5 +203,12 @@
       "authors": "Erdős–Graham 1980",
       "note": "Original source of the problem"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-254",
+      "relationship": "related-problem",
+      "description": "Both concern subset sum properties: #254 asks when all sufficiently large integers are representable as subset sums, while #362 bounds how many subsets can sum to a fixed value"
+    }
   ]
 }

--- a/src/data/proofs/erdos-363/meta.json
+++ b/src/data/proofs/erdos-363/meta.json
@@ -211,5 +211,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-443",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, diophantine-equations, number-theory"
+    },
+    {
+      "id": "erdos-1005",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
+    },
+    {
+      "id": "erdos-1138",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-364/meta.json
+++ b/src/data/proofs/erdos-364/meta.json
@@ -189,5 +189,17 @@
       "relationship": "related",
       "description": "Fellow Erdős problem"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Related extremal combinatorics result"
+    },
+    {
+      "id": "erdos-1001",
+      "relationship": "related",
+      "description": "Fellow Erdős problem"
+    }
   ]
 }

--- a/src/data/proofs/erdos-365/meta.json
+++ b/src/data/proofs/erdos-365/meta.json
@@ -133,5 +133,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-137",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+    },
+    {
+      "id": "erdos-366",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+    },
+    {
+      "id": "erdos-367",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+    }
   ]
 }

--- a/src/data/proofs/erdos-366/meta.json
+++ b/src/data/proofs/erdos-366/meta.json
@@ -185,5 +185,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-137",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+    },
+    {
+      "id": "erdos-365",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+    },
+    {
+      "id": "erdos-367",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+    }
   ]
 }

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -236,5 +236,22 @@
     "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 10
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-366",
+      "relationship": "related",
+      "description": "Directly related: #366 concerns consecutive k-full numbers (B_k(n) = n case), while #367 studies the product of 2-full parts B₂ over consecutive integers"
+    },
+    {
+      "id": "erdos-369",
+      "relationship": "related",
+      "description": "Both concern multiplicative structure of consecutive integers: #369 studies consecutive smooth numbers, #367 studies products of powerful parts"
+    },
+    {
+      "id": "erdos-368",
+      "relationship": "related",
+      "description": "Both study prime factor structure of consecutive integers: #368 asks about the largest prime factor of n(n+1), while #367 concerns the 2-full part"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-368/meta.json
+++ b/src/data/proofs/erdos-368/meta.json
@@ -217,5 +217,17 @@
       "relationship": "related",
       "description": "Fellow Erdős problem"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Related extremal combinatorics result"
+    },
+    {
+      "id": "erdos-1001",
+      "relationship": "related",
+      "description": "Fellow Erdős problem"
+    }
   ]
 }

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -264,5 +264,57 @@
       "venue": "Springer, Problem Books in Mathematics (3rd edition)",
       "note": "Section B33 discusses smooth numbers and consecutive factorization problems"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-370",
+      "relationship": "related",
+      "description": "Erdős #370 asks about smooth numbers in short intervals — a closely related distributional question about how smooth numbers cluster"
+    },
+    {
+      "id": "erdos-143",
+      "relationship": "related",
+      "description": "Erdős #143 studies dilation-avoiding sets, another problem where prime factorization structure controls combinatorial density"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "PNT gives the density of primes as π(x) ~ x/log x. The smooth number counting function Ψ(x,y) is the multiplicative analog — both concern the distribution of numbers with restricted prime factorization. The Dickman function ρ(u) governing smooth number density is derived from PNT-like analytic methods"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate guarantees a prime in (n, 2n). Erdős #369 asks a complementary question: are there consecutive composite-like (smooth) numbers near n? Both concern the local distribution of numbers with extreme factorization properties"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization is the foundation of smooth number theory: P⁺(n) (the largest prime factor) is well-defined by FTA, and smoothness is defined in terms of the factorization structure that FTA guarantees"
+    },
+    {
+      "id": "erdos-368",
+      "relationship": "related",
+      "description": "Erdős #368 studies the largest prime factor of $n(n+1)$, directly related to the smoothness of consecutive integers. If $P^+(n(n+1)) \\leq n^\\varepsilon$, then both $n$ and $n+1$ are $n^\\varepsilon$-smooth — exactly the $k=2$ case of #369"
+    },
+    {
+      "id": "erdos-371",
+      "relationship": "related",
+      "description": "Erdős #371 studies the density of integers where $P^+(n) < P^+(n+1)$ (the largest prime factor increases). Both #369 and #371 probe the multiplicative structure of consecutive integers: #369 asks for simultaneous smoothness, #371 asks for relative prime factor ordering"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes is foundational: smooth numbers are defined by having all prime factors below a threshold, and the distribution of primes (via PNT) governs the Dickman function $\\rho(u)$ that predicts smooth number density"
+    },
+    {
+      "id": "erdos-4",
+      "relationship": "related",
+      "description": "Both problems connect smooth numbers to prime gaps. Problem #4 (large prime gaps) uses smooth number constructions (products of small primes create long prime-free intervals), while #369 directly studies consecutive smooth numbers. Rankin's large gap construction exploits the same smooth number density estimates"
+    },
+    {
+      "id": "stirling-formula",
+      "relationship": "foundational",
+      "description": "Stirling's approximation $k! \\sim \\sqrt{2\\pi k}(k/e)^k$ is essential to the Dickman function analysis: the differential-delay equation $u\\rho'(u) = -\\rho(u-1)$ governing smooth number density requires precise factorial/gamma function asymptotics for its saddle-point analysis. The asymptotic $\\rho(u) \\sim u^{-u(1+o(1))}$ — which determines the density of $n^\\varepsilon$-smooth numbers — is derived via Laplace-type estimates that depend on Stirling's formula"
+    }
   ]
 }

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -257,5 +257,17 @@
       "venue": "Matematicheskii Sbornik, vol. 52, pp. 661–700",
       "note": "Used essential component ideas in additive prime number theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-38",
+      "relationship": "related",
+      "description": "Problem #38 on essential components and density boosting is the companion problem. Both concern how adding a set A can boost the Schnirelmann density of another set B"
+    },
+    {
+      "id": "erdos-35",
+      "relationship": "related",
+      "description": "Problem #35 on Schnirelmann density provides the foundational framework. Essential components (Problems #37-38) study which sets can boost density of others"
+    }
   ]
 }

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -200,5 +200,27 @@
       "Can the main infinitude theorem be proved in Lean by showing infinitely many $m = 2^k$ yield $\\operatorname{gpf}((2^k-1)(2^k+1)) < 2^k$?",
       "What is the exact critical exponent below which the Erdős-Graham problem requires constructive rather than density-based proofs?"
     ]
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-1136",
+      "relationship": "related-problem",
+      "description": "Both are Erdős problems about sets of integers satisfying arithmetic constraints, resolved by clever constructions. Erdős #1136 uses binary structure; #370 uses difference of squares."
+    },
+    {
+      "id": "erdos-984",
+      "relationship": "related-problem",
+      "description": "Both are Erdős problems in combinatorial number theory where extremal constructions play a central role in resolving density/existence questions."
+    },
+    {
+      "id": "erdos-527",
+      "relationship": "thematic",
+      "description": "Both involve density and structure questions where the answer depends on a critical threshold parameter (the exponent $1/\\sqrt{e}$ in #370, analogous thresholds in #527)."
+    },
+    {
+      "id": "prime-reciprocal-divergence",
+      "relationship": "foundational",
+      "description": "Prime distribution underlies smooth number theory. The density of smooth numbers is governed by the Dickman function, which depends on the distribution of prime factors."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-371/meta.json
+++ b/src/data/proofs/erdos-371/meta.json
@@ -220,5 +220,32 @@
     "axiomCount": 12,
     "theoremCount": 18,
     "definitionCount": 17
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-372",
+      "relationship": "related",
+      "description": "Companion problem: #372 asks for infinitely many n with P(n) > P(n+1) > P(n+2) (descending chains). Proved by Balog (2001). Both problems study consecutive behavior of P(n)"
+    },
+    {
+      "id": "erdos-928",
+      "relationship": "related",
+      "description": "Related problem on consecutive smooth numbers with density involving the same Dickman function framework and conditional results under Elliott-Halberstam"
+    },
+    {
+      "id": "erdos-369",
+      "relationship": "related",
+      "description": "Asks for consecutive smooth numbers in {1,...,n}: finding k consecutive integers all with small largest prime factor. Uses similar sieve and smooth number machinery"
+    },
+    {
+      "id": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The Prime Number Theorem provides the foundational asymptotic π(x) ~ x/ln x underlying all density arguments about prime-related sets in this formalization"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes ensures P(n) is well-defined for all n ≥ 2 and that the density questions are nontrivial — the set of primes dividing consecutive integers is always infinite"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-372/meta.json
+++ b/src/data/proofs/erdos-372/meta.json
@@ -194,5 +194,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, prime-factors"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1106",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, prime-factors"
+    },
+    {
+      "id": "erdos-368",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, prime-factors"
+    },
+    {
+      "id": "erdos-371",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, prime-factors"
+    }
   ]
 }

--- a/src/data/proofs/erdos-373/meta.json
+++ b/src/data/proofs/erdos-373/meta.json
@@ -182,5 +182,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: diophantine-equations, factorials, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-388",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: diophantine-equations, factorials, number-theory"
+    },
+    {
+      "id": "erdos-393",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: diophantine-equations, factorials, number-theory"
+    },
+    {
+      "id": "erdos-399",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: diophantine-equations, factorials, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -161,5 +161,17 @@
       "venue": "Rocky Mountain Journal of Mathematics, vol. 29, pp. 1387–1411",
       "note": "Extended the Erdős-Graham framework to study factorial products within specific integer sequences, providing structural results on the distribution of Dₖ"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The structure of Dₖ depends on prime factorizations of factorials. Legendre's formula v_p(n!) = ∑⌊n/pⁱ⌋ determines which factorial products can be perfect squares"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization is the foundation for analyzing when a product a₁!···aₖ! is a perfect square: each prime's total exponent must be even"
+    }
   ]
 }

--- a/src/data/proofs/erdos-375/meta.json
+++ b/src/data/proofs/erdos-375/meta.json
@@ -200,5 +200,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: composite-numbers, number-theory, open"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1055",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, open, prime-gaps"
+    },
+    {
+      "id": "erdos-1137",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, open, prime-gaps"
+    },
+    {
+      "id": "erdos-276",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: composite-numbers, number-theory, open"
+    }
   ]
 }

--- a/src/data/proofs/erdos-376/meta.json
+++ b/src/data/proofs/erdos-376/meta.json
@@ -183,5 +183,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1063",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory"
+    },
+    {
+      "id": "erdos-1093",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory"
+    },
+    {
+      "id": "erdos-1094",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-377/meta.json
+++ b/src/data/proofs/erdos-377/meta.json
@@ -156,5 +156,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1004",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory"
+    },
+    {
+      "id": "erdos-1102",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory"
+    },
+    {
+      "id": "erdos-1106",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -203,5 +203,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: density, number-theory, solved"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1102",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: density, number-theory, squarefree"
+    },
+    {
+      "id": "erdos-1136",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: density, number-theory, solved"
+    },
+    {
+      "id": "erdos-144",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: density, number-theory, solved"
+    }
   ]
 }

--- a/src/data/proofs/erdos-379/meta.json
+++ b/src/data/proofs/erdos-379/meta.json
@@ -176,5 +176,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-175",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory, prime-powers"
+    },
+    {
+      "id": "erdos-1063",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory"
+    },
+    {
+      "id": "erdos-1093",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: binomial-coefficients, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-38/meta.json
+++ b/src/data/proofs/erdos-38/meta.json
@@ -144,5 +144,22 @@
       "venue": "Scientia, Series A: Mathematics, vol. 3, pp. 97–109",
       "note": "Simplified Plünnecke's approach, providing the modern framework for density boosting"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-37",
+      "relationship": "related",
+      "description": "Problem #37 on essential components and lacunary sets is the companion problem. Both concern the density-boosting properties of specific sets in additive combinatorics"
+    },
+    {
+      "id": "erdos-35",
+      "relationship": "related",
+      "description": "Problem #35 on Schnirelmann density is the foundation. Essential components (Problems #37-38) study which sets can boost the Schnirelmann density of any set with positive density"
+    },
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "Additive bases (Problem #28) and essential components (Problem #38) are related: an essential component can convert any set with positive density into a basis"
+    }
   ]
 }

--- a/src/data/proofs/erdos-380/meta.json
+++ b/src/data/proofs/erdos-380/meta.json
@@ -162,5 +162,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, prime-factors"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-452",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, intervals, number-theory, prime-factors"
+    },
+    {
+      "id": "erdos-1106",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, prime-factors"
+    },
+    {
+      "id": "erdos-368",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, prime-factors"
+    }
   ]
 }

--- a/src/data/proofs/erdos-381/meta.json
+++ b/src/data/proofs/erdos-381/meta.json
@@ -194,5 +194,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: divisor-functions, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1081",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: counting-functions, disproved, number-theory"
+    },
+    {
+      "id": "erdos-1057",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: counting-functions, number-theory"
+    },
+    {
+      "id": "erdos-1060",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: divisor-functions, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -216,5 +216,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: number-theory, prime-gaps, prime-numbers"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-238",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, prime-gaps, prime-numbers"
+    },
+    {
+      "id": "erdos-680",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, prime-gaps, prime-numbers"
+    },
+    {
+      "id": "erdos-950",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, prime-gaps, prime-numbers"
+    }
   ]
 }

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -212,5 +212,22 @@
     "axiomCount": 3,
     "theoremCount": 13,
     "definitionCount": 12
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-382",
+      "relationship": "related",
+      "description": "Directly related: #382 concerns prime powers in factorial products, and a positive answer to #383 would resolve part of #382"
+    },
+    {
+      "id": "erdos-334",
+      "relationship": "related",
+      "description": "Both involve smooth numbers: #334 asks about sums of smooth numbers, #383 asks about smooth numbers near prime squares"
+    },
+    {
+      "id": "erdos-368",
+      "relationship": "related",
+      "description": "Both concern the largest prime factor of products of consecutive integers: #368 studies P(n(n+1)), #383 studies P(∏(p²+i))"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-384/meta.json
+++ b/src/data/proofs/erdos-384/meta.json
@@ -204,5 +204,17 @@
     "axiomCount": 13,
     "theoremCount": 12,
     "definitionCount": 8
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-382",
+      "relationship": "related",
+      "description": "Both concern prime factorization of combinatorial/factorial products: #382 studies prime powers in factorial products, #384 studies prime divisors of binomial coefficients"
+    },
+    {
+      "id": "erdos-383",
+      "relationship": "related",
+      "description": "Both concern largest prime divisors of number-theoretic products: #383 studies P(∏(p²+i)), #384 studies small primes dividing C(n,k)"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-385/meta.json
+++ b/src/data/proofs/erdos-385/meta.json
@@ -216,5 +216,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: number-theory, open, prime-divisors"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-276",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: composite-numbers, number-theory, open"
+    },
+    {
+      "id": "erdos-375",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: composite-numbers, number-theory, open"
+    },
+    {
+      "id": "erdos-383",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: number-theory, open, prime-divisors"
+    }
   ]
 }

--- a/src/data/proofs/erdos-386/meta.json
+++ b/src/data/proofs/erdos-386/meta.json
@@ -192,5 +192,37 @@
       "venue": "Mathematika, vol. 43, pp. 73–107",
       "note": "Showed that C(n,k) is squarefree for most pairs (n,k), with explicit bounds on exceptions. Since consecutive prime products are squarefree, this provides necessary conditions for Problem 386 instances"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-384",
+      "relationship": "related",
+      "description": "Problem #384 (Sylvester-Schur: the largest prime dividing $\\binom{n}{k}$ exceeds $n/2$ for $k \\ge 2$) studies the same prime factorization structure of binomial coefficients. The axiom `choose_largest_prime_le` in this file is a weaker form of that bound"
+    },
+    {
+      "id": "erdos-385",
+      "relationship": "related",
+      "description": "Problem #385 concerns smooth numbers in products of consecutive integers — closely related since $\\binom{n}{k} = \\prod_{i=1}^{k} (n-k+i)/i$ and the 'consecutive prime product' condition is a strong form of smoothness"
+    },
+    {
+      "id": "erdos-387",
+      "relationship": "related",
+      "description": "Problem #387 asks about divisors of $\\binom{n}{k}$ in the interval $(cn, n]$. Together with Problems 384-386, these form a cluster in Erdős-Graham (1980) studying the prime structure of binomial coefficients"
+    },
+    {
+      "id": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "The binomial theorem provides the algebraic context for $\\binom{n}{k}$. Problem 386 asks when these coefficients have the maximally structured factorization of being a product of consecutive primes"
+    },
+    {
+      "id": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate ($\\exists$ prime in $(n, 2n)$) constrains prime gaps and hence the spacing of consecutive prime products. For large $n$, the gap between consecutive primes ensures primorial quotients grow rapidly"
+    },
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique prime factorization is the basis for asking whether $\\binom{n}{k}$ equals a product of consecutive primes — without FTA, the question is not well-defined"
+    }
   ]
 }

--- a/src/data/proofs/erdos-387/meta.json
+++ b/src/data/proofs/erdos-387/meta.json
@@ -141,5 +141,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: combinatorics, divisibility, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1063",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: binomial-coefficients, divisibility, number-theory"
+    },
+    {
+      "id": "erdos-13",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, divisibility, number-theory"
+    },
+    {
+      "id": "erdos-131",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, divisibility, number-theory"
+    }
   ]
 }

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -137,5 +137,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, open"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1056",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: factorials, number-theory, open"
+    },
+    {
+      "id": "erdos-1072",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: factorials, number-theory, open"
+    },
+    {
+      "id": "erdos-369",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, open"
+    }
   ]
 }

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -139,5 +139,12 @@
       "venue": "L'Enseignement Mathématique, Monograph no. 28, Geneva",
       "note": "Lists Problem #389 and discusses the minimal k values for small n"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "Both concern multiplicative structure of consecutive integer products: #389 asks about divisibility of falling factorials, #28 concerns additive representations. Both sit in Erdős's program on the fine structure of integer sequences"
+    }
   ]
 }

--- a/src/data/proofs/erdos-39/meta.json
+++ b/src/data/proofs/erdos-39/meta.json
@@ -225,5 +225,32 @@
     "axiomCount": 5,
     "theoremCount": 6,
     "definitionCount": 3
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-28",
+      "relationship": "related",
+      "description": "The Erdős-Turán conjecture on additive bases (Problem #28) asks whether bases must have unbounded representation. Sidon sets have minimal representation ($r \\leq 1$) and are too sparse to be bases — Problem #39 asks exactly how sparse they must be"
+    },
+    {
+      "id": "erdos-1",
+      "relationship": "related",
+      "description": "Problem #1 (distinct subset sums) generalizes the Sidon condition from pairwise sums to all subset sums. Both concern the fundamental question of how density forces additive collisions"
+    },
+    {
+      "id": "erdos-41",
+      "relationship": "extends",
+      "description": "Problem #41 on $B_h$ sequence density bounds generalizes Sidon sets ($B_2$) to higher-order representation constraints. The growth rate question of Problem #39 has natural analogs for $B_h$ sets"
+    },
+    {
+      "id": "erdos-42",
+      "relationship": "related",
+      "description": "Problem #42 asks about Sidon sets with disjoint difference sets, exploring structural constraints beyond density. Both concern the fine structure of Sidon sets"
+    },
+    {
+      "id": "erdos-44",
+      "relationship": "related",
+      "description": "Problem #44 on extending Sidon sets asks whether finite Sidon sets can always be extended. The infinite Sidon set growth question of Problem #39 is the asymptotic version of this extensibility question"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-390/meta.json
+++ b/src/data/proofs/erdos-390/meta.json
@@ -133,5 +133,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: factorials, number-theory, open"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-1056",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: factorials, number-theory, open"
+    },
+    {
+      "id": "erdos-1072",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: factorials, number-theory, open"
+    },
+    {
+      "id": "erdos-374",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: factorials, number-theory, open"
+    }
   ]
 }

--- a/src/data/proofs/erdos-391/meta.json
+++ b/src/data/proofs/erdos-391/meta.json
@@ -200,5 +200,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: factorization, number-theory, solved"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-392",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: asymptotics, factorial, factorization, number-theory"
+    },
+    {
+      "id": "erdos-419",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: factorial, number-theory, solved"
+    },
+    {
+      "id": "erdos-933",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: factorization, number-theory, solved"
+    }
   ]
 }

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -197,5 +197,22 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: factorial, number-theory"
     }
+  ],
+  "relatedProofs": [
+    {
+      "id": "erdos-391",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: asymptotics, factorial, factorization, number-theory"
+    },
+    {
+      "id": "erdos-1054",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: asymptotics, number-theory"
+    },
+    {
+      "id": "erdos-1073",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: factorial, number-theory"
+    }
   ]
 }


### PR DESCRIPTION
## 1. Gallery-wide enrichment: add relatedProofs field (1331 entries)
Complete enrichment pass adding `relatedProofs` arrays to all gallery entries missing them.

## 2. Fix fundamental-theorem-calculus peer review findings (6 items)
- **ai-1**: Removed fabricated content (integration_by_parts, mvt_for_integrals, etc.)
- **ai-2**: Rewrote originalContributions to honestly describe Mathlib wrappers
- **ai-3**: Fixed wiedijkNumber from 15 to 46
- **ai-4**: Expanded mathlibDependencies with actual workhorse functions
- **ai-5**: Rewrote annotations with correct line ranges and significance ratings
- **ai-6**: Corrected declaration count from 16 to 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)