### PR TITLE
Enrich: annotation coverage for 5 proof entries

### DIFF
--- a/src/data/proofs/erdos-124-complete-sequences/annotations.json
+++ b/src/data/proofs/erdos-124-complete-sequences/annotations.json
@@ -16,7 +16,12 @@
       "formal verification"
     ],
     "mathContext": "See annotation content for formal details of the first ai-solved open problem",
-    "prerequisites": []
+    "prerequisites": [
+      "Finset.sum (finite sums over indexed families)",
+      "Nat.digits (digit representation in arbitrary bases)",
+      "subset sum representation",
+      "Erdős conjecture framework"
+    ]
   },
   {
     "id": "ann-problem-statement",
@@ -35,7 +40,12 @@
       "bases",
       "complete sequences"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.digits (positional notation in arbitrary bases)",
+      "Finset.sum (summation over finite index sets)",
+      "Nat.pow (integer powers dᵢ^eᵢ)",
+      "complete sequences (every natural number is a subset sum)"
+    ]
   },
   {
     "id": "ann-two-versions",
@@ -54,7 +64,12 @@
       "ambiguity",
       "strong conjecture"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.Coprime / Nat.gcd (greatest common divisor for strong version)",
+      "Nat.digits (base-d digit representation)",
+      "Brown's criterion for complete sequences",
+      "Baker's theorem (transcendence theory, needed for strong version)"
+    ]
   },
   {
     "id": "ann-ai-story",
@@ -73,7 +88,12 @@
       "AI mathematics"
     ],
     "mathContext": "See annotation content for formal details of the ai story",
-    "prerequisites": []
+    "prerequisites": [
+      "Lean 4 formal verification system",
+      "Brown's criterion for complete sequences",
+      "greedy algorithm for sequence construction",
+      "automated theorem proving"
+    ]
   },
   {
     "id": "ann-proof-strategy",
@@ -92,7 +112,12 @@
       "Brown's criterion",
       "greedy algorithm"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Brown's criterion (gap condition implies completeness)",
+      "greedy algorithm analysis",
+      "Finset.sum / Finset.range (partial sums)",
+      "Nat.digits (digit decomposition)"
+    ]
   },
   {
     "id": "ann-namespace",
@@ -111,7 +136,12 @@
       "Mathlib imports",
       "namespaces"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean 4 namespace and open syntax",
+      "Mathlib.Data.Nat.Digits (Nat.digits)",
+      "Mathlib.Algebra.BigOperators.Group.Finset (Finset.sum)",
+      "Mathlib.Order.Filter.Basic (Filter.Eventually, atTop)"
+    ]
   },
   {
     "id": "ann-algebraic-gap",
@@ -130,7 +160,12 @@
       "reciprocal condition",
       "gap bound"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Finset.sum_le_sum (monotonicity of sums)",
+      "div_le_div_of_nonneg_right (division preserves inequality with nonneg denominator)",
+      "mul_le_mul_of_nonneg_left (scaling inequalities)",
+      "Rat / ℚ arithmetic (rational number calculations)"
+    ]
   },
   {
     "id": "ann-reciprocal-condition",
@@ -149,7 +184,12 @@
       "gap control",
       "necessity"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "harmonic series and partial sums (∑ 1/(dᵢ-1) convergence)",
+      "Finset.sum over Fin k (indexed finite summation)",
+      "Nat.cast to ℚ (embedding naturals into rationals)",
+      "geometric series identity: ∑ dⁱ = (d^n - 1)/(d-1)"
+    ]
   },
   {
     "id": "ann-browns-criterion",
@@ -168,7 +208,12 @@
       "complete sequences",
       "gap condition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Monotone (order-preserving functions in Mathlib)",
+      "Finset.range (finite initial segments {0, …, n})",
+      "Finset.sum (partial sums of a sequence)",
+      "strong induction on ℕ (induction' tactic)"
+    ]
   },
   {
     "id": "ann-browns-proof-structure",
@@ -187,7 +232,12 @@
       "partial sums",
       "case analysis"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Finset.sum_range_succ (unfolding one step of a partial sum)",
+      "Finset.Subset.trans (subset transitivity for extending the answer set)",
+      "Nat.le_succ (n ≤ n+1 used to grow the range)",
+      "tactic: by_cases (classical case split on a decidable proposition)"
+    ]
   },
   {
     "id": "ann-min-index",
@@ -206,7 +256,12 @@
       "Classical.choose",
       "noncomputable"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Finset.exists_min_image (existence of argmin over a nonempty finset)",
+      "Classical.choose / Classical.choose_spec (noncomputable witness extraction)",
+      "Finset.univ for Fin k (the complete finite index set)",
+      "Fin.pos_iff_nonempty (Fin k is nonempty iff k > 0)"
+    ]
   },
   {
     "id": "ann-next-e",
@@ -225,7 +280,12 @@
       "exponent tracking",
       "state update"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Function.update (point-wise function modification)",
+      "Function.update_apply (evaluation of Function.update at a point)",
+      "dite / decidable if-then-else (dependent if for k = 0 guard)",
+      "min_index (choosing which base to increment)"
+    ]
   },
   {
     "id": "ann-e-seq",
@@ -244,7 +304,12 @@
       "state sequence",
       "exponent tracking"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "structural recursion on ℕ (Lean pattern matching on Nat.zero / Nat.succ)",
+      "next_e (single-step exponent update)",
+      "Fin k → ℕ (functions from a finite index type)",
+      "e_seq_succ / e_seq_zero (key lemmas about the sequence)"
+    ]
   },
   {
     "id": "ann-u-seq",
@@ -263,7 +328,12 @@
       "power selection",
       "Brown's criterion input"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "e_seq (exponent state at step n)",
+      "min_index (argmin of current powers)",
+      "Nat.pow (integer exponentiation dᵢ^eᵢ)",
+      "u_seq_monotone and u_seq_gap (the two key properties)"
+    ]
   },
   {
     "id": "ann-greedy-construction",
@@ -282,7 +352,12 @@
       "sequence construction",
       "power selection"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "min_index (selecting the base with the smallest current power)",
+      "next_e (advancing the chosen base's exponent)",
+      "e_seq (tracking the full exponent state over time)",
+      "greedy algorithm correctness (locally optimal choices yield global completeness)"
+    ]
   },
   {
     "id": "ann-u-seq-monotone",
@@ -301,7 +376,12 @@
       "Brown's criterion",
       "greedy property"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Monotone (order-preserving predicate in Mathlib)",
+      "pow_le_pow_right₀ (monotonicity of exponentiation in the exponent)",
+      "Finset.min' and Finset.image (computing the minimum over a finite image set)",
+      "e_seq_succ (how exponents change at each step)"
+    ]
   },
   {
     "id": "ann-u-seq-gap",
@@ -320,7 +400,12 @@
       "reciprocal sum",
       "bound propagation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "algebraic_gap (core inequality: m ≤ 1 + ∑(yᵢ-1)/(dᵢ-1))",
+      "sum_u_seq_eq_geom (∑ u_seq j = ∑ (dⱼ^eⱼ-1)/(dⱼ-1) geometric identity)",
+      "Nat.cast_le (comparing ℕ and ℚ inequalities)",
+      "geom_sum_mul (geometric series factorization: (d^n-1) = (d-1)·∑dⁱ)"
+    ]
   },
   {
     "id": "ann-chosen-index-exponent",
@@ -339,7 +424,12 @@
       "exponent recording",
       "provenance"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "min_index (argmin selection from the current exponent state)",
+      "e_seq (exponent state at step n)",
+      "chosen_pair_injective (injectivity of the (index, exponent) map)",
+      "u_seq_eq_power (connecting u_seq to the (index, exponent) pair)"
+    ]
   },
   {
     "id": "ann-u-seq-eq-power",
@@ -357,7 +447,12 @@
       "definitional equality",
       "power representation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "u_seq (definition as min power over all bases)",
+      "chosen_index / chosen_exponent (definitions wrapping min_index and e_seq)",
+      "Nat.pow (dᵢ^eᵢ exponentiation)",
+      "definitional unfolding (aesop / unfold tactics)"
+    ]
   },
   {
     "id": "ann-chosen-pair-injective",
@@ -376,7 +471,12 @@
       "uniqueness",
       "digit constraint"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Function.Injective (injectivity of a function between types)",
+      "chosen_exponent_strict_mono (exponent strictly increases when same base is chosen again)",
+      "lt_or_gt_of_ne (trichotomy for ordering natural numbers)",
+      "Prod.ext_iff (equality of pairs iff both components equal)"
+    ]
   },
   {
     "id": "ann-digit-decomposition",
@@ -395,7 +495,12 @@
       "unique exponents",
       "base decomposition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.digits and Nat.ofDigits (positional representation and its inverse)",
+      "Finset.image (mapping exponents to the index-filtered subset)",
+      "chosen_pair_injective (each (base, exponent) pair used exactly once)",
+      "Nat.digits_ofDigits (round-trip identity for digit representation)"
+    ]
   },
   {
     "id": "ann-u-seq-zero",
@@ -414,7 +519,12 @@
       "Brown's criterion",
       "d^0 = 1"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "pow_zero (d^0 = 1 for any d)",
+      "e_seq_zero (all exponents start at 0)",
+      "u_seq (definition in terms of e_seq and min_index)",
+      "Nat.one_le_pow (d^n ≥ 1 for d ≥ 1)"
+    ]
   },
   {
     "id": "ann-k-nonzero",
@@ -433,7 +543,12 @@
       "bound tactic",
       "hypothesis derivation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Finset.sum_empty (empty sum equals zero)",
+      "Fin 0 is empty (vacuous quantification over Fin 0)",
+      "linarith / bound tactic (automated numerical reasoning)",
+      "Nat.pos_of_ne_zero (k ≠ 0 ↔ 0 < k)"
+    ]
   },
   {
     "id": "ann-main-theorem-structure",
@@ -452,7 +567,12 @@
       "proof assembly",
       "Brown's criterion"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "browns_criterion (complete sequence from gap condition)",
+      "digits_of_subset_sum_u_seq (subset sum → 0/1 digit representation)",
+      "u_seq_monotone, u_seq_gap, u_seq_zero (the three Brown criterion hypotheses)",
+      "k_ne_zero_of_sum_eq_one (deriving k > 0 from the reciprocal condition)"
+    ]
   },
   {
     "id": "ann-erdos-124-strengthened",
@@ -471,7 +591,12 @@
       "unnecessary hypotheses",
       "clean statement"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "erdos_conjecture_true (the assembled main theorem it wraps)",
+      "Nat.digits and List.toFinset (digit extraction and set conversion)",
+      "Finset.subset_insert / Finset.mem_insert (subset reasoning for {0, 1})",
+      "formal conjecture minimality (removing redundant hypotheses)"
+    ]
   },
   {
     "id": "ann-formal-conjectures",
@@ -491,7 +616,12 @@
       "DeepMind",
       "filters"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Filter.Eventually (∀ᶠ n in atTop, P n means P holds for all sufficiently large n)",
+      "Filter.atTop (the cofinite filter on ℕ, capturing 'eventually')",
+      "erdos_124 / erdos_conjecture_true (the theorems being repackaged)",
+      "Finset.sum over Fin k with ℚ coercion (rational reciprocal sums)"
+    ]
   },
   {
     "id": "ann-worked-example",
@@ -510,6 +640,11 @@
       "representation",
       "digit check"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.digits 2 7 = [1, 1, 1] (binary digit extraction)",
+      "Nat.digits 3 3 = [0, 1] (ternary digit extraction)",
+      "subset sum selection from u_seq (which subset covers the target n)",
+      "digit decomposition (converting subset sums to per-base 0/1 representations)"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-31/annotations.json
+++ b/src/data/proofs/erdos-31/annotations.json
@@ -16,7 +16,12 @@
       "sumsets",
       "lorentz-1954"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Asymptotic density of subsets of ℕ",
+      "Sumset (Minkowski sum) of two sets",
+      "Cofinite subsets of ℕ",
+      "Set.Infinite (Mathlib predicate)"
+    ]
   },
   {
     "id": "ann-e31-density",
@@ -35,7 +40,12 @@
       "counting-function",
       "limsup"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Filter.Tendsto (limit along a filter)",
+      "Filter.atTop (cofinite filter on ℕ)",
+      "Set.ncard (cardinality of a set)",
+      "Filter.limsup (limit superior along a filter)"
+    ]
   },
   {
     "id": "ann-e31-sumsets",
@@ -54,7 +64,12 @@
       "cofinite",
       "coverage"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Set.Finite (finiteness of sets in Mathlib)",
+      "Set.Icc (closed interval in an ordered type)",
+      "Minkowski sum / additive combinatorics sumset",
+      "Cofinite topology / cofinite filter on ℕ"
+    ]
   },
   {
     "id": "ann-e31-primes-axiom",
@@ -73,7 +88,12 @@
       "density-zero",
       "primes"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Prime Number Theorem: π(N) ~ N / log N",
+      "Nat.Prime (primality predicate in Mathlib)",
+      "Nat.primeCounting (prime-counting function π(N))",
+      "HasDensityZero definition (this file)"
+    ]
   },
   {
     "id": "ann-e31-powers2-bijection",
@@ -92,7 +112,12 @@
       "logarithm",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.log (binary logarithm in Mathlib)",
+      "Finset.image (image of a function on a Finset)",
+      "Nat.pow_le_iff_le_log (Nat.log characterization)",
+      "Set.Icc (closed interval [a,b])"
+    ]
   },
   {
     "id": "ann-e31-powers2-count",
@@ -111,7 +136,12 @@
       "logarithmic-growth",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "powers_of_2_in_Icc_eq (bijection lemma, this file)",
+      "Finset.card_image_of_injective (injectivity gives equality of cardinalities)",
+      "Nat.card_Icc (cardinality of Nat.Icc a b)",
+      "Nat.log (binary logarithm)"
+    ]
   },
   {
     "id": "ann-e31-log-limit",
@@ -130,7 +160,12 @@
       "tendsto",
       "logarithm"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Filter.Tendsto.squeeze (squeeze theorem for limits)",
+      "Real.log (natural logarithm in Mathlib)",
+      "tendsto_pow_log_div_mul_add_atTop (log N / N → 0 in Mathlib)",
+      "Nat.log_le_clog (Nat.log bounded by Real.log)"
+    ]
   },
   {
     "id": "ann-e31-powers2-density",
@@ -149,7 +184,12 @@
       "density-zero",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "powers_of_2_count_bound (this file)",
+      "tendsto_log_add_one_div (this file)",
+      "Filter.Tendsto.congr (changing the function in a limit)",
+      "HasDensityZero / HasDensity definitions (this file)"
+    ]
   },
   {
     "id": "ann-e31-squares-bijection",
@@ -168,7 +208,12 @@
       "bijection",
       "sqrt"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.sqrt (integer square root in Mathlib)",
+      "Nat.le_sqrt (characterization: k ≤ √N ↔ k² ≤ N)",
+      "Finset.image (image of a function on a Finset)",
+      "Set.Icc (closed interval)"
+    ]
   },
   {
     "id": "ann-e31-squares-count",
@@ -187,7 +232,12 @@
       "square-root-growth",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "squares_in_Icc_eq (bijection lemma, this file)",
+      "Finset.card_image_of_injective",
+      "Nat.card_Icc (cardinality of integer interval)",
+      "Nat.sqrt (integer square root)"
+    ]
   },
   {
     "id": "ann-e31-sqrt-limit",
@@ -206,7 +256,12 @@
       "tendsto",
       "sqrt"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Real.sqrt (real square root in Mathlib)",
+      "tendsto_rpow_atTop (x^r → ∞ for r > 0)",
+      "Filter.Tendsto.squeeze / tendsto_of_tendsto_of_tendsto_of_le_of_le",
+      "Real.sqrt_le_sqrt (monotonicity of sqrt)"
+    ]
   },
   {
     "id": "ann-e31-squares-density",
@@ -225,7 +280,12 @@
       "density-zero",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "squares_count_bound (this file)",
+      "tendsto_sqrt_inv (this file)",
+      "Filter.Tendsto.congr (rewriting the function in a limit)",
+      "HasDensityZero / HasDensity definitions (this file)"
+    ]
   },
   {
     "id": "ann-e31-main-statement",
@@ -244,7 +304,12 @@
       "additive-complements",
       "axiom"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "HasDensityZero definition (this file)",
+      "CoversAllButFinitely definition (this file)",
+      "Set.Infinite (Mathlib predicate for infinite sets)",
+      "Lorentz (1954): constructive proof via greedy gap-filling"
+    ]
   },
   {
     "id": "ann-e31-lorentz-bound",
@@ -263,7 +328,12 @@
       "optimal",
       "density"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "lorentz_theorem axiom (this file)",
+      "countingFn definition (this file)",
+      "O(N / log N) growth rate (analytic number theory)",
+      "Real.log (natural logarithm in Mathlib)"
+    ]
   },
   {
     "id": "ann-e31-powers2-example",
@@ -282,7 +352,12 @@
       "example",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "lorentz_theorem axiom (this file)",
+      "Set.infinite_of_injective_forall_mem (showing a set is infinite via injection)",
+      "powers_of_2_density_zero (this file)",
+      "CoversAllButFinitely definition (this file)"
+    ]
   },
   {
     "id": "ann-e31-optimal",
@@ -301,7 +376,12 @@
       "infimum",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Real.sInf (infimum of a set of reals in Mathlib)",
+      "le_antisymm (antisymmetry of ≤ to prove equality)",
+      "lorentz_theorem axiom (this file)",
+      "HasDensity / density non-negativity"
+    ]
   },
   {
     "id": "ann-e31-coverage-theorem",
@@ -320,7 +400,12 @@
       "coverage",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Set.Finite.image (image of a finite set is finite)",
+      "Set.Finite.prod (product of finite sets is finite)",
+      "Set.infinite_of_not_bddAbove (unbounded subsets of ℕ are infinite)",
+      "CoversAllButFinitely / CoversCofinite definitions (this file)"
+    ]
   },
   {
     "id": "ann-e31-basis",
@@ -339,7 +424,12 @@
       "order-2",
       "verified"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "lorentz_theorem axiom (this file)",
+      "IsAsymptoticBasis definition (this file)",
+      "Sumset / sumset notation +ₛ (this file)",
+      "Set.union_subset (union of sets)"
+    ]
   },
   {
     "id": "ann-e31-strengthened",
@@ -358,7 +448,12 @@
       "strengthened",
       "lorentz"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "lorentz_theorem axiom (this file)",
+      "lorentz_B_bound axiom (this file)",
+      "countingFn definition (this file)",
+      "Real.log (logarithm for the N/log N bound)"
+    ]
   },
   {
     "id": "ann-e31-summary",
@@ -377,6 +472,11 @@
       "solved",
       "verified-proofs"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Additive combinatorics (sumsets, density, bases)",
+      "Lorentz (1954): constructive gap-filling proof",
+      "Asymptotic density and density-zero sets",
+      "Asymptotic additive bases of order 2"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-31/meta.json
+++ b/src/data/proofs/erdos-31/meta.json
@@ -89,42 +89,48 @@
       "title": "Density Definitions",
       "startLine": 28,
       "endLine": 48,
-      "summary": "Define counting function, HasDensity, HasDensityZero, and upperDensity."
+      "summary": "Define counting function, HasDensity, HasDensityZero, and upperDensity.",
+      "mathContext": "$d(A) = \\lim_{N\\to\\infty} \\frac{|A \\cap \\{1,\\ldots,N\\}|}{N}$"
     },
     {
       "id": "sumsets",
       "title": "Sumsets",
       "startLine": 49,
       "endLine": 61,
-      "summary": "Define sumsets A +ₛ B and CoversAllButFinitely predicate."
+      "summary": "Define sumsets A +ₛ B and CoversAllButFinitely predicate.",
+      "mathContext": "$A +_s B = \\{a + b \\mid a \\in A,\\, b \\in B\\} \\subseteq \\mathbb{N}$"
     },
     {
       "id": "main-theorem",
       "title": "The Main Theorem",
       "startLine": 79,
       "endLine": 107,
-      "summary": "State Erdős Problem #31 and axiomatize Lorentz's theorem with the strengthened bound."
+      "summary": "State Erdős Problem #31 and axiomatize Lorentz's theorem with the strengthened bound.",
+      "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\, A \\text{ infinite} \\Rightarrow \\exists B,\\, d(B)=0 \\wedge (\\mathbb{N} \\setminus (A+B) \\text{ finite})$"
     },
     {
       "id": "optimal-density",
       "title": "Optimal Density",
       "startLine": 132,
       "endLine": 165,
-      "summary": "Define OptimalBDensity and prove it equals 0 for infinite A."
+      "summary": "Define OptimalBDensity and prove it equals 0 for infinite A.",
+      "mathContext": "$\\text{OptimalBDensity}(A) = \\inf\\{d(B) \\mid B \\text{ covers cofinitely}\\} = 0$"
     },
     {
       "id": "coverage-requirements",
       "title": "Coverage Requirements",
       "startLine": 172,
       "endLine": 219,
-      "summary": "Prove that finite A and finite B cannot achieve cofinite coverage."
+      "summary": "Prove that finite A and finite B cannot achieve cofinite coverage.",
+      "mathContext": "$A, B \\text{ finite} \\Rightarrow |A +_s B| \\leq |A| \\cdot |B| < \\infty$, so $A +_s B$ cannot be cofinite"
     },
     {
       "id": "additive-bases",
       "title": "Connection to Additive Bases",
       "startLine": 220,
       "endLine": 726,
-      "summary": "Show that the result implies A ∪ B is an asymptotic basis of order 2."
+      "summary": "Show that the result implies A ∪ B is an asymptotic basis of order 2.",
+      "mathContext": "$A \\cup B$ is an asymptotic basis of order 2: $\\forall n \\gg 1,\\, n \\in (A \\cup B) + (A \\cup B)$"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-572/annotations.json
+++ b/src/data/proofs/erdos-572/annotations.json
@@ -16,7 +16,12 @@
       "Turan's theorem",
       "Forbidden subgraphs"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Turán-type extremal problems",
+      "SimpleGraph in Mathlib",
+      "Forbidden subgraph problems",
+      "Kővári–Sós–Turán theorem"
+    ]
   },
   {
     "id": "ann-e572-cycle-def",
@@ -34,7 +39,12 @@
       "formal definition",
       "graph theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Mathlib.Combinatorics.SimpleGraph.Basic",
+      "Function.Injective",
+      "Fin k indexing in Lean 4",
+      "SimpleGraph.Adj"
+    ]
   },
   {
     "id": "ann-e572-cycle-free",
@@ -52,7 +62,12 @@
       "formal definition",
       "graph theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "hasCycleOfLength definition",
+      "Proposition negation in Lean 4",
+      "Girth of a graph",
+      "Bipartite graphs and even cycles"
+    ]
   },
   {
     "id": "ann-e572-edge-count",
@@ -70,7 +85,12 @@
       "formal definition",
       "graph theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Mathlib.Combinatorics.SimpleGraph.Finite",
+      "SimpleGraph.edgeFinset",
+      "Finset.card",
+      "DecidableRel"
+    ]
   },
   {
     "id": "ann-e572-extremal-func",
@@ -88,7 +108,12 @@
       "formal definition",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Set.sSup in Lean 4",
+      "isCycleFree definition",
+      "edgeCount definition",
+      "Fintype.card for vertex set size"
+    ]
   },
   {
     "id": "ann-e572-bondy-simonovits",
@@ -106,7 +131,12 @@
       "Random graph methods",
       "Cycle counting"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "exCycle definition",
+      "Real.rpow for fractional exponents",
+      "Bondy–Simonovits theorem (1974)",
+      "Even cycle counting in graphs"
+    ]
   },
   {
     "id": "ann-e572-benson-k3",
@@ -124,7 +154,12 @@
       "graph theory",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Generalized hexagons (incidence geometry)",
+      "exCycle n 3 for C_6-free graphs",
+      "Real.rpow with exponent 4/3",
+      "Benson (1966) construction"
+    ]
   },
   {
     "id": "ann-e572-benson-k5",
@@ -142,7 +177,12 @@
       "Lean 4 formalization",
       "mathematical proof"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Generalized decagons (incidence geometry)",
+      "exCycle n 5 for C_10-free graphs",
+      "Real.rpow with exponent 6/5",
+      "Benson (1966) construction"
+    ]
   },
   {
     "id": "ann-e572-luw",
@@ -160,7 +200,12 @@
       "Algebraic graphs",
       "Finite fields"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "luwExponent definition",
+      "Algebraic graph constructions over GF(q)",
+      "Parity condition ν = [2 | k]",
+      "Lazebnik–Ustimenko–Woldar (1995)"
+    ]
   },
   {
     "id": "ann-e572-conjecture",
@@ -178,7 +223,12 @@
       "formal definition",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "exCycle definition",
+      "Real.rpow for n^{1+1/k}",
+      "Asymptotic big-Omega notation",
+      "Bondy–Simonovits upper bound"
+    ]
   },
   {
     "id": "ann-e572-k3-proof",
@@ -196,7 +246,12 @@
       "proof technique",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "erdosConjectureLowerBound definition",
+      "benson_k3 axiom",
+      "norm_num tactic for 4/3 = 1+1/3",
+      "Lean 4 obtain pattern matching"
+    ]
   },
   {
     "id": "ann-e572-k5-proof",
@@ -214,7 +269,12 @@
       "Lean 4 formalization",
       "mathematical proof"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "erdosConjectureLowerBound definition",
+      "benson_k5 axiom",
+      "norm_num tactic for 6/5 = 1+1/5",
+      "Lean 4 convert tactic"
+    ]
   },
   {
     "id": "ann-e572-exponents",
@@ -232,7 +292,12 @@
       "formal definition",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "luwExponent definition",
+      "Real division in Lean 4",
+      "Asymptotic growth rates of power functions",
+      "Relationship between LUW and Benson exponents"
+    ]
   },
   {
     "id": "ann-e572-luw-matches-k3",
@@ -250,7 +315,12 @@
       "proof technique",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "luwExponent definition",
+      "conjecturedExponent definition",
+      "norm_num tactic for numeric equality",
+      "k odd parity: ν = 0 for k=3"
+    ]
   },
   {
     "id": "ann-e572-gap-k4",
@@ -268,7 +338,12 @@
       "proof technique",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "luwExponent definition",
+      "conjecturedExponent definition",
+      "norm_num tactic for numeric inequality",
+      "k even parity: ν = 1 for k=4"
+    ]
   },
   {
     "id": "ann-e572-erdos-klein",
@@ -286,7 +361,12 @@
       "Zarankiewicz problem",
       "Projective planes"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Zarankiewicz problem Z(n; 2,2)",
+      "Finite projective planes of order q",
+      "exCycle n 2 for C_4-free graphs",
+      "Kővári–Sós–Turán theorem"
+    ]
   },
   {
     "id": "ann-e572-odd-cycles",
@@ -304,7 +384,12 @@
       "graph theory",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Turán's theorem for bipartite extremal graphs",
+      "Complete bipartite graphs K_{n/2, n/2}",
+      "Bipartite graphs contain no odd cycles",
+      "Floor function n²/4 in Lean 4"
+    ]
   },
   {
     "id": "ann-e572-summary",
@@ -322,7 +407,12 @@
       "proof technique",
       "combinatorics"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "erdos_572_k3 and erdos_572_k5 theorems",
+      "luw_matches_k3 theorem",
+      "And.intro in Lean 4",
+      "Partial solutions to open problems"
+    ]
   },
   {
     "id": "ann-e572-best-bounds",
@@ -340,6 +430,11 @@
       "proof technique",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "benson_k3 and benson_k5 axioms",
+      "lazebnik_ustimenko_woldar axiom",
+      "luwExponent vs conjecturedExponent gap",
+      "Asymptotics of extremal graph densities"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-572/meta.json
+++ b/src/data/proofs/erdos-572/meta.json
@@ -81,49 +81,56 @@
       "title": "Graph-Theoretic Definitions",
       "summary": "hasCycleOfLength, isCycleFree, edgeCount definitions",
       "startLine": 43,
-      "endLine": 74
+      "endLine": 74,
+      "mathContext": "G \\text{ has a } C_k \\iff \\exists\\, v_0,\\dots,v_{k-1}\\text{ distinct}: v_i \\sim v_{(i+1)\\bmod k}"
     },
     {
       "id": "extremal-function",
       "title": "The Extremal Function",
       "summary": "exCycle definition: ex(n; C_{2k})",
       "startLine": 75,
-      "endLine": 89
+      "endLine": 89,
+      "mathContext": "\\mathrm{ex}(n; C_{2k}) = \\max\\{|E(G)| : |V(G)| = n,\\, G \\text{ is } C_{2k}\\text{-free}\\}"
     },
     {
       "id": "known-results",
       "title": "Known Results",
       "summary": "bondy_simonovits_upper, benson_k3, benson_k5, lazebnik_ustimenko_woldar axioms",
       "startLine": 90,
-      "endLine": 143
+      "endLine": 143,
+      "mathContext": "c_1 n^{1+2/(3k-3+\\nu)} \\leq \\mathrm{ex}(n; C_{2k}) \\leq c_2 k n^{1+1/k},\\quad \\nu = [2 \\mid k]"
     },
     {
       "id": "the-conjecture",
       "title": "The Conjecture",
       "summary": "erdosConjectureLowerBound, erdos_572_k3, erdos_572_k5 theorems",
       "startLine": 144,
-      "endLine": 191
+      "endLine": 191,
+      "mathContext": "\\exists c > 0: \\mathrm{ex}(n; C_{2k}) \\geq c\\, n^{1+1/k} \\text{ for all } n \\geq 1"
     },
     {
       "id": "exponent-comparison",
       "title": "Comparison of Exponents",
       "summary": "luwExponent, conjecturedExponent, comparison theorems",
       "startLine": 192,
-      "endLine": 232
+      "endLine": 232,
+      "mathContext": "\\alpha_{\\mathrm{LUW}}(k) = 1 + \\frac{2}{3k-3+\\nu} \\leq 1 + \\frac{1}{k} = \\alpha_{\\mathrm{conj}}(k),\\quad \\text{with equality iff } k=3"
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "summary": "erdos_klein_c4 for C_4, odd_cycle_extremal for odd cycles",
       "startLine": 233,
-      "endLine": 272
+      "endLine": 272,
+      "mathContext": "\\mathrm{ex}(n; C_4) \\sim \\tfrac{1}{2}n^{3/2};\\quad \\mathrm{ex}(n; C_{2k+1}) = \\lfloor n^2/4 \\rfloor"
     },
     {
       "id": "summary",
       "title": "Main Results Summary",
       "summary": "erdos_572_summary, best_known_lower_bounds theorems",
       "startLine": 273,
-      "endLine": 305
+      "endLine": 305,
+      "mathContext": "\\mathrm{ex}(n; C_6) \\geq c n^{4/3},\\; \\mathrm{ex}(n; C_{10}) \\geq c n^{6/5},\\; \\mathrm{ex}(n; C_{2k}) \\geq c n^{1+2/(3k-3+\\nu)}"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-891/annotations.json
+++ b/src/data/proofs/erdos-891/annotations.json
@@ -16,7 +16,12 @@
       "Prime factorization",
       "Short intervals"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.Prime",
+      "Nat.factorization",
+      "Prime factorization with multiplicity (Ω function)",
+      "Primorial: product of first k primes"
+    ]
   },
   {
     "id": "ann-e891-big-omega",
@@ -35,7 +40,12 @@
       "Arithmetic functions",
       "Little omega"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.factorization",
+      "Finsupp.sum",
+      "Nat.Prime",
+      "p-adic valuation (Nat.factorization applied to a prime)"
+    ]
   },
   {
     "id": "ann-e891-little-omega",
@@ -53,7 +63,12 @@
       "formal definition",
       "prime numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.factorization",
+      "Finsupp.support",
+      "Finset.card",
+      "Squarefree numbers (ω(n) = Ω(n) iff n is squarefree)"
+    ]
   },
   {
     "id": "ann-e891-nth-prime",
@@ -71,7 +86,12 @@
       "formal definition",
       "prime numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.nth",
+      "Nat.infinite_setOf_prime",
+      "Nat.nth_strictMono",
+      "Nat.nth_mem_of_infinite"
+    ]
   },
   {
     "id": "ann-e891-primorial",
@@ -90,7 +110,12 @@
       "Product of primes",
       "Smooth numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Finset.prod",
+      "Finset.range",
+      "nthPrime (Nat.nth applied to the set of primes)",
+      "Finset.prod_pos"
+    ]
   },
   {
     "id": "ann-e891-has-many-factors",
@@ -108,7 +133,12 @@
       "prime numbers",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "bigOmega (Ω function counting prime factors with multiplicity)",
+      "primorial (product of first k primes)",
+      "Existential quantifier over a bounded interval",
+      "Nat.lt and Nat.le for interval membership"
+    ]
   },
   {
     "id": "ann-e891-conjecture",
@@ -126,7 +156,12 @@
       "prime numbers",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "HasManyFactors predicate",
+      "primorial (product of first k primes)",
+      "Eventually (Filter.Eventually) / sufficiently large n",
+      "bigOmega (Ω function)"
+    ]
   },
   {
     "id": "ann-e891-k-equals-2",
@@ -144,7 +179,12 @@
       "prime numbers",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "primorialComp 2 = 6 (computable primorial)",
+      "bigOmega (Ω function)",
+      "HasManyFactorsComp predicate",
+      "native_decide for decidable computation over finite ranges"
+    ]
   },
   {
     "id": "ann-e891-examples",
@@ -162,7 +202,12 @@
       "prime numbers",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "native_decide tactic for decidable propositions",
+      "bigOmega_eight / bigOmega_twelve (specific Ω value theorems)",
+      "HasManyFactorsComp with primorialComp",
+      "Nat.factorization and prime power decomposition"
+    ]
   },
   {
     "id": "ann-e891-schinzel",
@@ -180,7 +225,12 @@
       "prime numbers",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Pólya's theorem on unbounded gaps in k-smooth numbers",
+      "k-smooth numbers (isSmoothComp predicate)",
+      "bigOmega (Ω function counting prime factors with multiplicity)",
+      "schinzel_theorem_statement axiom (skipped-primorial interval)"
+    ]
   },
   {
     "id": "ann-e891-dicksons",
@@ -199,7 +249,12 @@
       "Prime constellations",
       "Hardy-Littlewood conjecture"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.Prime and linear forms aᵢn + bᵢ",
+      "Set.Infinite for infinitely many simultaneous primes",
+      "No fixed prime divisor condition (admissibility of k-tuples)",
+      "Twin prime conjecture as the k=2 special case"
+    ]
   },
   {
     "id": "ann-e891-weisenberg",
@@ -217,7 +272,12 @@
       "prime numbers",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "DicksonsConjecture definition",
+      "primorial (product of first k primes)",
+      "Set.Infinite for infinitely many counterexample starting points",
+      "weisenberg_conditional axiom (conditional on Dickson's conjecture)"
+    ]
   },
   {
     "id": "ann-e891-smooth",
@@ -236,7 +296,12 @@
       "Prime distribution"
     ],
     "mathContext": "See annotation content for formal details of smooth numbers and pólya's theorem",
-    "prerequisites": []
+    "prerequisites": [
+      "isSmoothComp predicate (all prime factors ≤ bound)",
+      "Nat.Prime and divisibility",
+      "Pólya's theorem: limsup of gaps in k-smooth sequence is infinite",
+      "Nat.primeFactors and Finset membership"
+    ]
   },
   {
     "id": "ann-e891-summary",
@@ -254,6 +319,11 @@
       "proof technique",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "ErdosProblem891 definition (main open conjecture)",
+      "schinzel_theorem_statement axiom (skipped-primorial weaker result)",
+      "weisenberg_conditional axiom (conditional sharpness of primorial threshold)",
+      "k2_verified_range (computational evidence for k = 2 case)"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -89,6 +89,7 @@
       "id": "prime-counting",
       "title": "Prime Factor Counting",
       "summary": "Definitions of bigOmega and littleOmega functions",
+      "mathContext": "$\\Omega(n) = \\sum_{p \\text{ prime}} v_p(n)$, where $v_p(n)$ is the $p$-adic valuation of $n$; $\\omega(n) = |\\{p \\text{ prime} : p \\mid n\\}|$",
       "startLine": 40,
       "endLine": 85
     },
@@ -96,6 +97,7 @@
       "id": "nth-prime",
       "title": "The k-th Prime",
       "summary": "Definition of nthPrime and basic axioms",
+      "mathContext": "$p_k$ denotes the $k$-th prime (1-indexed): $p_1 = 2,\\ p_2 = 3,\\ p_3 = 5,\\ p_4 = 7,\\ \\ldots$",
       "startLine": 86,
       "endLine": 109
     },
@@ -103,6 +105,7 @@
       "id": "primorial",
       "title": "Primorial",
       "summary": "Product of first k primes",
+      "mathContext": "$p_k\\# = \\prod_{i=1}^{k} p_i$; values: $2, 6, 30, 210, 2310, \\ldots$",
       "startLine": 110,
       "endLine": 139
     },
@@ -110,6 +113,7 @@
       "id": "main-conjecture",
       "title": "The Main Conjecture",
       "summary": "HasManyFactors predicate and erdos891_conjecture",
+      "mathContext": "$\\forall k \\geq 2,\\ \\exists N,\\ \\forall n \\geq N,\\ \\exists m \\in [n, n + p_k\\#),\\ \\Omega(m) > k$",
       "startLine": 140,
       "endLine": 160
     },
@@ -117,6 +121,7 @@
       "id": "k-equals-2",
       "title": "The k = 2 Case",
       "summary": "Simplest open case with intervals of length 6",
+      "mathContext": "$\\exists N,\\ \\forall n \\geq N,\\ \\exists m \\in [n, n+6),\\ \\Omega(m) \\geq 3$; computationally verified for $n \\in [3, 1002]$",
       "startLine": 161,
       "endLine": 207
     },
@@ -124,6 +129,7 @@
       "id": "schinzel",
       "title": "Schinzel's Weaker Result",
       "summary": "Modified primorial version that is provable",
+      "mathContext": "Holds with skipped primorial $Q_k = p_1 \\cdots p_{k-1} \\cdot p_{k+1}$; e.g., $Q_2 = 10,\\ Q_3 = 42$, proved via Pólya's smooth-number gap theorem",
       "startLine": 208,
       "endLine": 229
     },
@@ -131,6 +137,7 @@
       "id": "weisenberg",
       "title": "Weisenberg's Conditional Counterexample",
       "summary": "p₁···pₖ - 1 fails under Dickson's conjecture",
+      "mathContext": "Under Dickson's conjecture: $\\exists^{\\infty} n,\\ \\forall m \\in [n, n + p_k\\# - 1),\\ \\Omega(m) \\leq k$; interval length $p_k\\# - 1$ is sub-threshold",
       "startLine": 230,
       "endLine": 257
     },
@@ -138,6 +145,7 @@
       "id": "smooth-numbers",
       "title": "Smooth Numbers Connection",
       "summary": "k-smooth numbers and Pólya's theorem",
+      "mathContext": "$n$ is $k$-smooth if $\\forall p \\mid n,\\ p \\leq p_k$; Pólya: $\\limsup_{n \\to \\infty} (s_{n+1} - s_n) = \\infty$ for the sequence $(s_n)$ of $k$-smooth numbers",
       "startLine": 258,
       "endLine": 280
     },
@@ -145,6 +153,7 @@
       "id": "summary",
       "title": "Summary and Status",
       "summary": "Main results and open status",
+      "mathContext": "Threshold: $p_k\\# - 1$ fails (conditional), $p_k\\#$ conjectured, $Q_k > p_k\\#$ proven; open for all $k \\geq 2$",
       "startLine": 281,
       "endLine": 344
     }

--- a/src/data/proofs/prime-number-theorem/annotations.json
+++ b/src/data/proofs/prime-number-theorem/annotations.json
@@ -27,7 +27,12 @@
         "relationship": "RH would sharpen PNT's error term from O(x·exp(-c√ln x)) to O(√x·ln x) — the zeros of ζ(s) control prime distribution"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime counting function π(x)",
+      "Riemann zeta function ζ(s)",
+      "asymptotic notation (big-O, little-o, ~)",
+      "Filter.Tendsto in Mathlib"
+    ]
   },
   {
     "id": "ann-prime-pi",
@@ -47,7 +52,12 @@
       "Chebyshev functions",
       "Mathlib.NumberTheory.PrimeCounting"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.primeCounting (Mathlib.NumberTheory.PrimeCounting)",
+      "Nat.floor (⌊·⌋₊)",
+      "prime numbers",
+      "Finset.card"
+    ]
   },
   {
     "id": "ann-prime-approx",
@@ -66,7 +76,11 @@
       "logarithm",
       "partial function"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Real.log (Mathlib.Analysis.SpecialFunctions.Log.Basic)",
+      "conditional expression (if/then/else) in Lean 4",
+      "natural logarithm ln x"
+    ]
   },
   {
     "id": "ann-li",
@@ -92,7 +106,12 @@
         "relationship": "The divergence of Σ 1/p (Euler) is a consequence of Li(x) → ∞; both reflect the logarithmic density of primes"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "intervalIntegral (Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic)",
+      "Real.log",
+      "asymptotic expansion via integration by parts",
+      "measure theory (MeasureTheory.Measure)"
+    ]
   },
   {
     "id": "ann-pnt-ratio",
@@ -112,7 +131,12 @@
       "atTop filter",
       "neighborhood filter"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Filter.Tendsto (Mathlib.Order.Filter.Basic)",
+      "Filter.atTop",
+      "nhds / 𝓝 (neighborhood filter)",
+      "Real.log"
+    ]
   },
   {
     "id": "ann-pnt-equiv",
@@ -132,7 +156,12 @@
       "big-O notation",
       "little-o notation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Asymptotics.IsEquivalent (Mathlib.Analysis.Asymptotics.Defs)",
+      "Filter.atTop",
+      "asymptotic equivalence f ~ g",
+      "Asymptotics.IsLittleO"
+    ]
   },
   {
     "id": "ann-pnt-error",
@@ -152,7 +181,12 @@
       "Vinogradov",
       "Korobov"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Asymptotics.IsLittleO (Mathlib.Analysis.Asymptotics.Defs)",
+      "Asymptotics.IsEquivalent",
+      "little-o notation f = o(g)",
+      "Vinogradov-Korobov zero-free region"
+    ]
   },
   {
     "id": "ann-pnt-li",
@@ -172,7 +206,12 @@
       "asymptotic expansion",
       "transitivity"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Asymptotics.IsEquivalent",
+      "logIntegral (Li function)",
+      "transitivity of asymptotic equivalence",
+      "li_equiv_approx: Li(x) ~ x/ln x"
+    ]
   },
   {
     "id": "ann-equivalences",
@@ -192,7 +231,12 @@
       "von Mangoldt function",
       "Tauberian theorems"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "ratio_iff_equiv: PNT_Ratio ↔ PNT_Equiv",
+      "equiv_iff_error: PNT_Equiv ↔ PNT_Error",
+      "li_iff_equiv: PNT_Li ↔ PNT_Equiv",
+      "Chebyshev ψ-function ψ(x) ~ x"
+    ]
   },
   {
     "id": "ann-main-axiom",
@@ -218,7 +262,12 @@
         "relationship": "PNT uses the weakest form of zeta zero information (no zeros on Re(s)=1); RH asserts all zeros lie on Re(s)=1/2"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "axiom primeNumberTheorem (PNT_Ratio)",
+      "complex analysis: Riemann zeta function ζ(s)",
+      "zero-free region: ζ(1+it) ≠ 0",
+      "Wiener-Ikehara / Newman Tauberian theorem"
+    ]
   },
   {
     "id": "ann-density",
@@ -243,7 +292,12 @@
         "relationship": "Euclid proved primes are infinite; this corollary shows their density nonetheless vanishes — they become ever sparser"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime_asymptotic: π(x) ~ x/ln x",
+      "Filter.Tendsto atTop (𝓝 0)",
+      "natural density",
+      "Real.log_tendsto_atTop"
+    ]
   },
   {
     "id": "ann-nth-prime",
@@ -269,7 +323,12 @@
         "relationship": "Bertrand's postulate (pₙ₊₁ < 2pₙ) gives a crude bound; PNT's inverse gives the precise asymptotics pₙ ~ n ln n"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.nth Nat.Prime (nth prime in Mathlib)",
+      "primeNumberTheorem (PNT ratio form)",
+      "asymptotic inversion",
+      "Rosser's theorem: pₙ > n ln n"
+    ]
   },
   {
     "id": "ann-mertens",
@@ -295,7 +354,12 @@
         "relationship": "Euler (1737) proved Σ 1/p diverges; Mertens (1874) quantified the rate as ln ln x + M"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime_asymptotic: π(x) ~ x/ln x",
+      "partial summation (Abel summation)",
+      "Real.log_log_tendsto",
+      "Finset.sum over primes"
+    ]
   },
   {
     "id": "ann-gaps",
@@ -321,7 +385,12 @@
         "relationship": "Bertrand's postulate gives gap < p (i.e., ε=1); PNT improves this to gap = o(p) for any ε>0"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "primeNumberTheorem (PNT ratio form)",
+      "prime counting estimates: π(x) ~ x/ln x",
+      "average prime gap: x/π(x) ~ ln x",
+      "Baker-Harman-Pintz theorem"
+    ]
   },
   {
     "id": "ann-rh",
@@ -347,7 +416,12 @@
         "relationship": "The gallery's dedicated RH entry formalizes equivalent forms (Robin's inequality, explicit formula) and partial results"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Riemann zeta function ζ(s) for complex s",
+      "analytic continuation of ζ to ℂ \\ {1}",
+      "non-trivial zeros of ζ(s)",
+      "Millennium Prize Problems"
+    ]
   },
   {
     "id": "ann-von-koch",
@@ -367,7 +441,12 @@
       "Riemann Hypothesis",
       "square root cancellation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "RiemannHypothesis (axiom Prop)",
+      "logIntegral Li(x)",
+      "Riemann explicit formula: π(x) = Li(x) − Σ_ρ Li(x^ρ) + …",
+      "Real.sqrt"
+    ]
   },
   {
     "id": "ann-chebyshev",
@@ -393,7 +472,12 @@
         "relationship": "Erdős's 1932 proof of Bertrand's postulate uses Chebyshev-style analysis of binomial coefficient prime factorizations"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.centralBinom (central binomial coefficient)",
+      "Nat.factorization / multiplicity (p-adic valuation)",
+      "Legendre's formula: vₚ(n!) = Σ_{k≥1} ⌊n/pᵏ⌋",
+      "elementary number theory (no complex analysis)"
+    ]
   },
   {
     "id": "ann-euler-product",
@@ -423,7 +507,12 @@
         "relationship": "Euler's product at s=1 diverges (ζ has a pole), directly yielding Σ 1/p = ∞"
       }
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Dirichlet series: Σ aₙ/nˢ",
+      "Euler product formula ζ(s) = Π_p(1−p⁻ˢ)⁻¹",
+      "von Mangoldt function Λ(n)",
+      "Nat.Prime.prime_def_minFac"
+    ]
   },
   {
     "id": "ann-numerical",
@@ -443,7 +532,12 @@
       "Littlewood's theorem",
       "approximation quality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "primePi(x) values at powers of 10",
+      "primeApprox(x) = x/ln x",
+      "logIntegral Li(x)",
+      "Littlewood's oscillation theorem"
+    ]
   },
   {
     "id": "ann-prime-counting-axiom",

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -77,49 +77,56 @@
       "title": "Basic Definitions",
       "startLine": 66,
       "endLine": 91,
-      "summary": "Defines primePi (via Mathlib's Nat.primeCounting), primeApprox (x/ln x), and logIntegral Li(x) = ∫₂ˣ dt/ln t."
+      "summary": "Defines primePi (via Mathlib's Nat.primeCounting), primeApprox (x/ln x), and logIntegral Li(x) = ∫₂ˣ dt/ln t.",
+      "mathContext": "\\(\\pi(x) = \\#\\{p \\leq x : p \\text{ prime}\\}\\), \\(\\text{primeApprox}(x) = x/\\ln x\\), \\(\\text{Li}(x) = \\int_2^x \\frac{dt}{\\ln t}\\)"
     },
     {
       "id": "main-theorem",
       "title": "The Prime Number Theorem",
       "startLine": 92,
       "endLine": 130,
-      "summary": "Four equivalent formulations: ratio (π·ln x/x → 1), asymptotic (π ~ x/ln x), error (π − x/ln x = o(x/ln x)), and Li form (π ~ Li)."
+      "summary": "Four equivalent formulations: ratio (π·ln x/x → 1), asymptotic (π ~ x/ln x), error (π − x/ln x = o(x/ln x)), and Li form (π ~ Li).",
+      "mathContext": "\\(\\lim_{x\\to\\infty}\\frac{\\pi(x)\\ln x}{x} = 1\\); equivalently \\(\\pi(x) \\sim x/\\ln x\\), \\(\\pi(x) - x/\\ln x = o(x/\\ln x)\\), and \\(\\pi(x) \\sim \\mathrm{Li}(x)\\)"
     },
     {
       "id": "equivalences",
       "title": "Equivalence of Formulations",
       "startLine": 127,
       "endLine": 189,
-      "summary": "Axiomatized equivalences between all four PNT formulations, including Li(x) ~ x/ln(x) via asymptotic expansion."
+      "summary": "Axiomatized equivalences between all four PNT formulations, including Li(x) ~ x/ln(x) via asymptotic expansion.",
+      "mathContext": "\\(f \\sim g \\iff f - g = o(g)\\); transitivity: \\(\\pi \\sim x/\\ln x \\sim \\mathrm{Li}(x)\\) because \\(\\mathrm{Li}(x) = x/\\ln x + x/\\ln^2 x + \\cdots\\)"
     },
     {
       "id": "main-axiom",
       "title": "The Main Theorem (Axiomatized)",
       "startLine": 190,
       "endLine": 217,
-      "summary": "PNT axiomatized based on PrimeNumberTheoremAnd project; corollaries derive asymptotic and Li forms."
+      "summary": "PNT axiomatized based on PrimeNumberTheoremAnd project; corollaries derive asymptotic and Li forms.",
+      "mathContext": "\\(\\texttt{axiom primeNumberTheorem}\\colon \\text{Tendsto}(\\lambda x,\\, \\pi(x)\\ln x/x)\\;\\texttt{atTop}\\;(\\mathcal{N}\\,1)\\); key step: \\(\\zeta(1+it)\\neq 0\\) via \\(3+4\\cos\\theta+\\cos 2\\theta\\geq 0\\)"
     },
     {
       "id": "consequences",
       "title": "Consequences of PNT",
       "startLine": 218,
       "endLine": 310,
-      "summary": "Prime density → 0, nth prime ~ n ln n, Mertens' sum of reciprocals ~ ln ln x, and prime gaps are sublinear."
+      "summary": "Prime density → 0, nth prime ~ n ln n, Mertens' sum of reciprocals ~ ln ln x, and prime gaps are sublinear.",
+      "mathContext": "\\(\\pi(x)/x \\to 0\\); \\(p_n \\sim n\\ln n\\); \\(\\sum_{p\\leq x}1/p = \\ln\\ln x + M + o(1)\\) where \\(M\\approx 0.2615\\); prime gaps \\(= o(x)\\)"
     },
     {
       "id": "rh-connection",
       "title": "Stronger Versions (Conditional on RH)",
       "startLine": 308,
       "endLine": 352,
-      "summary": "Riemann Hypothesis stated; von Koch's theorem gives |π(x)−Li(x)| = O(√x ln x) conditionally."
+      "summary": "Riemann Hypothesis stated; von Koch's theorem gives |π(x)−Li(x)| = O(√x ln x) conditionally.",
+      "mathContext": "RH: all non-trivial zeros of \\(\\zeta(s)\\) satisfy \\(\\operatorname{Re}(s)=1/2\\). Von Koch (1901): RH \\(\\Rightarrow |\\pi(x)-\\mathrm{Li}(x)| = O(\\sqrt{x}\\ln x)\\)"
     },
     {
       "id": "elementary-bounds",
       "title": "Elementary Bounds",
       "startLine": 353,
       "endLine": 463,
-      "summary": "Chebyshev's pre-PNT bounds (0.92 < π·ln x/x < 1.11), infinitude of primes, and Euler product connection."
+      "summary": "Chebyshev's pre-PNT bounds (0.92 < π·ln x/x < 1.11), infinitude of primes, and Euler product connection.",
+      "mathContext": "Chebyshev (1852): \\(0.92 < \\pi(x)\\ln x/x < 1.11\\) for large \\(x\\). Euler product: \\(\\zeta(s) = \\prod_p (1-p^{-s})^{-1}\\) for \\(\\operatorname{Re}(s)>1\\)"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enrichment pass adding missing `mathContext` and `prerequisites` fields to 5 gallery entries.

### erdos-572 (305 lines, even cycle extremal numbers)
- Added `mathContext` to all 7 sections, `prerequisites` to all 19 annotations

### erdos-31 (726 lines, additive complements)
- Added `mathContext` to all 6 sections, `prerequisites` to all 20 annotations

### erdos-124-complete-sequences (507 lines, complete sequences)
- Filled in `prerequisites` on all 27 annotations (sections already had mathContext)

### prime-number-theorem (463 lines)
- Added `mathContext` to all 7 sections, `prerequisites` to all 19 annotations

### erdos-891 (409 lines, primorial conjecture) — in earlier commit
- Added `mathContext` to all 9 sections, `prerequisites` to all 14 annotations