### PR TITLE
Fix: erdos-960 sorry count 5→4, axiom count 1→2

### DIFF
--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 960,
     "erdosUrl": "https://erdosproblems.com/960",
     "erdosProblemStatus": "open",
@@ -34,9 +34,9 @@
       "green_tao_ordinary_lines (axiom): ≥ n/2 for general position",
       "erdos_960_summary (proved): combines conjecture with r=2 case"
     ],
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 164,
-    "assumptions": "1 axiom(s) and 5 sorry(s). See the Lean source for details.",
+    "assumptions": "2 axioms: erdos_960_littleo_conjecture (the open o(n²) conjecture), green_tao_ordinary_lines (Green-Tao 2013 ordinary lines bound). 4 sorries in turan_upper_bound, trivial_bound, threshold_r2, linear_implies_littleo.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -144,7 +144,7 @@
     "opens": [],
     "namespace": "Erdos960",
     "lineCount": 164,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Fix

Correct metadata for erdos-960 (Ordinary Lines and Collinear Ramsey Thresholds).

## Evidence

**Sorry count**:
- **Before**: `"sorries": 5`
- **After**: `"sorries": 4`
- Actual sorries: `turan_upper_bound` (L104), `trivial_bound` (L109), `threshold_r2` (L120), `linear_implies_littleo` (L154)

**Axiom count**:
- **Before**: `"axiomCount": 1`
- **After**: `"axiomCount": 2`
- Actual axioms: `erdos_960_littleo_conjecture` (L95), `green_tao_ordinary_lines` (L127)

**Assumptions text** updated to enumerate all axioms and sorries.

---
Automated fix by lean-mechanic agent.