### PR TITLE
Enrich erdos-2: fix section mathContext

### DIFF
--- a/src/data/proofs/erdos-2/meta.json
+++ b/src/data/proofs/erdos-2/meta.json
@@ -67,7 +67,7 @@
       "summary": "Imports Mathlib and opens `Set`/`Finset` namespaces for the `Erdos2` namespace.",
       "startLine": 28,
       "endLine": 33,
-      "mathContext": "Imports Mathlib and opens `Set`/`Finset` namespaces for the `Erdos2` namespace."
+      "mathContext": "The proof relies on `Mathlib.Data.Int.ModCast` and `Mathlib.Data.Finset.Basic` for congruence arithmetic over $\\mathbb{Z}$. Opening `Set` and `Finset` namespaces gives convenient access to $\\{x \\mid P\\, x\\}$ set-builder notation and finite collection operations used throughout the covering system definitions."
     },
     {
       "id": "basic-definitions",
@@ -75,7 +75,7 @@
       "summary": "Defines **ArithmeticProgression** $\\{x \\mid x \\equiv a \\pmod{n}\\}$ and the **CongruenceClass** structure bundling residue with modulus $n \\geq 2$.",
       "startLine": 34,
       "endLine": 49,
-      "mathContext": "Defines **ArithmeticProgression** $\\{x \\mid x \\equiv a \\pmod{n}\\}$ and the **CongruenceClass** structure bundling residue with modulus $n \\geq 2$."
+      "mathContext": "An arithmetic progression modulo $n$ with residue $a$ is the set $\\{x \\in \\mathbb{Z} \\mid x \\equiv a \\pmod{n}\\}$. The `CongruenceClass` structure bundles a residue $a : \\mathbb{Z}$ with a modulus $n : \\mathbb{N}$ satisfying $n \\geq 2$. The condition $n \\geq 2$ excludes the trivial modulus $n = 1$, which would cover all of $\\mathbb{Z}$ alone."
     },
     {
       "id": "covering-systems",
@@ -83,7 +83,7 @@
       "summary": "Defines **CoveringSystem** as a nonempty list of congruence classes covering $\\mathbb{Z}$, with **hasDistinctModuli**, **moduli**, **minModulus**, and **hasMinModulusAtLeast** properties.",
       "startLine": 50,
       "endLine": 74,
-      "mathContext": "Defines **CoveringSystem** as a nonempty list of congruence classes covering $\\mathbb{Z}$, with **hasDistinctModuli**, **moduli**, **minModulus**, and **hasMinModulusAtLeast** properties."
+      "mathContext": "A **covering system** is a finite collection $\\{a_1 \\bmod n_1, \\ldots, a_k \\bmod n_k\\}$ satisfying: (1) $\\forall x \\in \\mathbb{Z},\\, \\exists i: x \\equiv a_i \\pmod{n_i}$ (covers all integers); (2) the moduli $n_1, \\ldots, n_k$ are distinct; (3) each $n_i \\geq 2$. The **minModulus** is $\\min_i n_i$, and **hasMinModulusAtLeast** $N$ means $\\min_i n_i \\geq N$."
     },
     {
       "id": "original-conjecture",
@@ -91,7 +91,7 @@
       "summary": "States **erdos_original_conjecture**: $\\forall N,\\, \\exists$ a covering system with min modulus $\\geq N$. Erdős expected YES and offered \\$1000.",
       "startLine": 75,
       "endLine": 85,
-      "mathContext": "States **erdos_original_conjecture**: $\\forall N,\\, \\exists$ a covering system with min modulus $\\geq N$. Erdős expected YES and offered \\$1000."
+      "mathContext": "Erdős conjectured: $\\forall N \\in \\mathbb{N},\\, \\exists$ a covering system $C$ with $\\mathrm{minModulus}(C) \\geq N$. Constructions pushing the minimum modulus upward — reaching 42 by Owens (2014) — supported this belief. The conjecture was stated as an axiom here with status DISPROVED: Hough (2015) showed it is FALSE, and this conjecture cannot be proved from the other axioms."
     },
     {
       "id": "main-result",
@@ -99,7 +99,7 @@
       "summary": "States **erdos_2_solution** ($\\exists N$ bounding all systems) and proves **solution_implies_not_conjecture** via contradiction with `omega`.",
       "startLine": 86,
       "endLine": 104,
-      "mathContext": "States **erdos_2_solution** ($\\exists N$ bounding all systems) and proves **solution_implies_not_conjecture** via contradiction with `omega`."
+      "mathContext": "The main result is: $\\exists N \\in \\mathbb{N},\\, \\forall$ covering systems $C,\\, \\mathrm{minModulus}(C) \\leq N$. The theorem **solution_implies_not_conjecture** deduces $\\lnot \\mathrm{ErdősConjecture}$ from this: if such a universal bound $N$ exists, then no covering system can have min modulus $\\geq N+1$, contradicting the conjecture. The proof uses `omega` to close the arithmetic inequality $\\mathrm{minModulus}(C) \\leq N < N+1$."
     },
     {
       "id": "hough-theorem",
@@ -107,7 +107,7 @@
       "summary": "Axiomatizes **hough_bound** ($\\leq 10^{16}$) and proves **hough_implies_solution**: the existential witness $N = 10^{16}$ resolves the problem.",
       "startLine": 105,
       "endLine": 122,
-      "mathContext": "Axiomatizes **hough_bound** ($\\leq 10^{16}$) and proves **hough_implies_solution**: the existential witness $N = 10^{16}$ resolves the problem."
+      "mathContext": "Hough's theorem (2015): every covering system $C$ satisfies $\\mathrm{minModulus}(C) \\leq 10^{16}$. The proof uses the **Lovász Local Lemma** in a probabilistic sieving argument, building on Filaseta–Ford–Konyagin–Pomerance–Yu (2007). The theorem **hough_implies_solution** instantiates the main result with the explicit witness $N := 10^{16}$, confirming the universal bound exists."
     },
     {
       "id": "balister-theorem",
@@ -115,7 +115,7 @@
       "summary": "Axiomatizes **balister_bound** ($\\leq 616{,}000$), a dramatic $10^{10}$-fold improvement using the **distortion method**.",
       "startLine": 123,
       "endLine": 138,
-      "mathContext": "Axiomatizes **balister_bound** ($\\leq 616{,}000$), a dramatic $10^{10}$-fold improvement using the **distortion method**."
+      "mathContext": "Balister, Bollobás, Morris, Sahasrabudhe, and Tiba (2022) proved: every covering system $C$ satisfies $\\mathrm{minModulus}(C) \\leq 616{,}000$. This $\\approx 10^{10}$-fold improvement over Hough's $10^{16}$ bound uses the **distortion method** — a new technique deforming a probability measure to analyze the sieve — published in the Annals of Mathematics. The current best bounds are $42 \\leq M \\leq 616{,}000$."
     },
     {
       "id": "owens-construction",
@@ -123,7 +123,7 @@
       "summary": "Axiomatizes **owens_construction** (min modulus $\\geq 42$) and proves **bounds_summary**: $42 \\leq M \\leq 616{,}000$.",
       "startLine": 139,
       "endLine": 158,
-      "mathContext": "Axiomatizes **owens_construction** (min modulus $\\geq 42$) and proves **bounds_summary**: $42 \\leq M \\leq 616{,}000$."
+      "mathContext": "Owens (2014) constructed an explicit covering system with $\\mathrm{minModulus} = 42$, establishing the lower bound $M \\geq 42$ where $M$ is the maximum achievable minimum modulus. This construction uses 40 congruence classes. Combined with Balister et al.'s upper bound, the theorem **bounds_summary** gives the sharp inequality $42 \\leq M \\leq 616{,}000$. Determining the exact value of $M$ is an open problem."
     },
     {
       "id": "simple-examples",
@@ -131,7 +131,7 @@
       "summary": "Constructs $\\{0 \\bmod 2, 1 \\bmod 2\\}$, proves **even_odd_cover** and **trivial_cover_min_modulus** — the simplest covering system with min modulus $2$.",
       "startLine": 159,
       "endLine": 188,
-      "mathContext": "Constructs $\\{0 \\bmod 2, 1 \\bmod 2\\}$, proves **even_odd_cover** and **trivial_cover_min_modulus** — the simplest covering system with min modulus $2$."
+      "mathContext": "The simplest covering system is $\\{0 \\bmod 2,\\, 1 \\bmod 2\\}$: every integer is either even ($\\equiv 0 \\pmod 2$) or odd ($\\equiv 1 \\pmod 2$). A richer example is $\\{0 \\bmod 2,\\, 0 \\bmod 3,\\, 1 \\bmod 6\\}$: multiples of 2 or 3 cover $5/6$ of integers, and $1 \\bmod 6$ covers those $\\equiv 1 \\pmod{6}$ (the remaining $1/6$). Both have $\\mathrm{minModulus} = 2$, the smallest possible."
     },
     {
       "id": "properties",
@@ -139,7 +139,7 @@
       "summary": "Proves basic structural lemmas: **covering_distinct_moduli**, **covering_nonempty**, and **covering_complete** — extracting structure fields as standalone theorems.",
       "startLine": 189,
       "endLine": 204,
-      "mathContext": "Proves basic structural lemmas: **covering_distinct_moduli**, **covering_nonempty**, and **covering_complete** — extracting structure fields as standalone theorems."
+      "mathContext": "Structural properties of covering systems: (1) **Distinct moduli**: if $i \\neq j$ then $n_i \\neq n_j$; (2) **Nonemptiness**: $k \\geq 1$ (no empty covering); (3) **Completeness**: $\\bigcup_{i=1}^k \\{x \\mid x \\equiv a_i \\pmod{n_i}\\} = \\mathbb{Z}$; (4) **Minimum modulus $\\geq 2$**: each $n_i \\geq 2$. These are derived directly from the `CoveringSystem` structure definition as standalone Lean lemmas."
     },
     {
       "id": "density-argument",
@@ -147,7 +147,7 @@
       "summary": "Defines **reciprocalSum** $= \\sum 1/n_i$ over $\\mathbb{Q}$ and axiomatizes **reciprocal_sum_ge_one**: every covering system has reciprocal sum $\\geq 1$, providing the key density constraint.",
       "startLine": 205,
       "endLine": 220,
-      "mathContext": "Defines **reciprocalSum** $= \\sum 1/n_i$ over $\\mathbb{Q}$ and axiomatizes **reciprocal_sum_ge_one**: every covering system has reciprocal sum $\\geq 1$, providing the key density constraint."
+      "mathContext": "Each congruence class $a_i \\bmod n_i$ covers exactly $1/n_i$ of all integers (by periodicity). Since the classes cover all of $\\mathbb{Z}$, we need $\\sum_{i=1}^k 1/n_i \\geq 1$. This **density constraint** forces: if $\\min n_i = N$, then $k \\geq N$ and $\\sum 1/n_i \\leq k/N$, so $k \\geq N$. As $N$ grows, the required number of classes grows too, making large-minimum-modulus systems harder to construct."
     },
     {
       "id": "related-problems",
@@ -155,7 +155,7 @@
       "summary": "States **exact_maximum_min_modulus** (the sharp bound problem, currently $42 \\leq M \\leq 616{,}000$) and the **Erdős-Selfridge conjecture** (every covering system has an even modulus).",
       "startLine": 221,
       "endLine": 264,
-      "mathContext": "States **exact_maximum_min_modulus** (the sharp bound problem, currently $42 \\leq M \\leq 616{,}000$) and the **Erdős-Selfridge conjecture** (every covering system has an even modulus)."
+      "mathContext": "Two major open problems remain. (1) **Sharp bound**: Let $M = \\sup\\{\\mathrm{minModulus}(C) \\mid C \\text{ is a covering system}\\}$. Currently $42 \\leq M \\leq 616{,}000$; finding $M$ exactly is open. (2) **Erdős-Selfridge conjecture** (Erdős Problem #7): every covering system with distinct moduli $\\geq 2$ must contain an even modulus. Equivalently, there is no covering system using only odd moduli. This is related to: for any finite set $S$ of odd integers $\\geq 3$, $\\sum_{n \\in S} 1/n < 1$ would suffice, but the conjecture is unproved."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
First enrichment pass for erdos-2 (Covering Systems).

- Replaced all 12 section `mathContext` fields with real LaTeX: covering system definition, Hough bound, Balister bound, Owens construction, density argument