### PR TITLE
Audit: erdos-103 fix sorry and axiom counts

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -723,9 +723,9 @@
       "issues": []
     },
     "erdos-103": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:17:38Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T18:42:39Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1030": {

--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 103,
     "erdosUrl": "https://erdosproblems.com/103",
     "erdosProblemStatus": "open",
@@ -57,9 +57,9 @@
       "optimalPackingDensity definition: π/(2√3)",
       "diameter_asymptotic axiom: relation to packing"
     ],
-    "axiomCount": 7,
+    "axiomCount": 6,
     "lineCount": 248,
-    "assumptions": "7 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "6 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in [Er94b] (1994). The question concerns the diversity of optimal point configurations in the plane.\n\nGiven n points with minimum pairwise separation 1, we seek configurations minimizing the diameter (largest distance). h(n) counts how many 'essentially different' (incongruent) optimal configurations exist.\n\nThe problem connects to classical circle packing - placing n non-overlapping unit circles in the smallest possible containing circle. The hexagonal lattice is optimal for large n (Thue-Minkowski).\n\nRelated to Erdős Problem #99. Even very weak versions of the conjecture remain open.",
@@ -261,7 +261,7 @@
     ],
     "namespace": "Erdos103",
     "lineCount": 248,
-    "axiomCount": 7,
+    "axiomCount": 6,
     "theoremCount": 5,
     "definitionCount": 17
   }


### PR DESCRIPTION
## Summary
- Sorries: 3→**2** (1 proved by research)
- Axioms: 7→**6** (1 eliminated)

## Test plan
- [ ] Verify `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)