### PR TITLE
Enrich erdos-528, erdos-774, erdos-7: fix section mathContext

### DIFF
--- a/src/data/proofs/erdos-528/meta.json
+++ b/src/data/proofs/erdos-528/meta.json
@@ -98,7 +98,7 @@
       "summary": "LatticePoint, areNeighbors, Walk, startsAtOrigin, isConnected, isSelfAvoiding, isSAW",
       "startLine": 37,
       "endLine": 68,
-      "mathContext": "LatticePoint, areNeighbors, Walk, startsAtOrigin, isConnected, isSelfAvoiding, isSAW"
+      "mathContext": "A SAW in $\\mathbb{Z}^k$ is a sequence $(w_0, w_1, \\ldots, w_n)$ with $w_0 = 0$, $\\|w_{i+1} - w_i\\|_1 = 1$ (nearest-neighbor steps), and $w_i \\neq w_j$ for all $i \\neq j$ (self-avoidance). Here $\\mathbb{Z}^k$ is the integer lattice with $2k$ neighbors per vertex."
     },
     {
       "id": "counting",
@@ -106,7 +106,7 @@
       "summary": "sawCount axiom, f_zero, f_one base cases",
       "startLine": 69,
       "endLine": 85,
-      "mathContext": "sawCount axiom, f_zero, f_one base cases"
+      "mathContext": "The counting function $f(n,k) = |\\{\\text{SAWs of length } n \\text{ in } \\mathbb{Z}^k\\}|$. Base cases: $f(0,k) = 1$ (the trivial walk at the origin) and $f(1,k) = 2k$ (one step in each of $2k$ directions)."
     },
     {
       "id": "limit-existence",
@@ -114,7 +114,7 @@
       "summary": "submultiplicativity, limit_exists (Hammersley-Morton), connectiveConstant definition",
       "startLine": 86,
       "endLine": 106,
-      "mathContext": "submultiplicativity, limit_exists (Hammersley-Morton), connectiveConstant definition"
+      "mathContext": "Submultiplicativity: $f(m+n, k) \\leq f(m,k) \\cdot f(n,k)$ (concatenating two SAWs may create self-intersections, so the count can only decrease). By Fekete's lemma applied to $\\log f(n,k)$, this implies $C_k = \\lim_{n \\to \\infty} f(n,k)^{1/n}$ exists (Hammersley–Morton 1954)."
     },
     {
       "id": "trivial-bounds",
@@ -122,7 +122,7 @@
       "summary": "connective_lower_bound, connective_upper_bound, trivial_bounds theorem",
       "startLine": 107,
       "endLine": 124,
-      "mathContext": "connective_lower_bound, connective_upper_bound, trivial_bounds theorem"
+      "mathContext": "Trivial bounds: $k \\leq C_k \\leq 2k-1$. Lower bound: at each step one can always extend in one of $k$ independent directions. Upper bound: after the first step, at most $2k-1$ choices remain (cannot backtrack), so $f(n,k) \\leq 2k \\cdot (2k-1)^{n-1}$, giving $C_k \\leq 2k-1$."
     },
     {
       "id": "kesten",
@@ -130,7 +130,7 @@
       "summary": "kesten_asymptotic, kesten_first_order",
       "startLine": 125,
       "endLine": 140,
-      "mathContext": "kesten_asymptotic, kesten_first_order"
+      "mathContext": "Kesten's asymptotic (1963): $C_k = 2k - 1 - \\frac{1}{2k} + O(k^{-2})$ as $k \\to \\infty$. The leading correction $-1/(2k)$ comes from counting walks that attempt to backtrack; $|C_k - (2k-1)| \\leq 1/k$ provides a rigorous first-order bound."
     },
     {
       "id": "two-dimensional",
@@ -138,7 +138,7 @@
       "summary": "mu2_value, conway_guttmann_lower, alm_upper, jsg_computation, two_d_bounds",
       "startLine": 141,
       "endLine": 162,
-      "mathContext": "mu2_value, conway_guttmann_lower, alm_upper, jsg_computation, two_d_bounds"
+      "mathContext": "For $k=2$: rigorous bounds $2.62 \\leq C_2 \\leq 2.696$ (Conway–Guttmann 1993, Alm 1993), and the high-precision value $C_2 = 2.6381585303279\\ldots$ (Jacobsen–Scullard–Guttmann 2016, 12+ decimal places). No closed form is known."
     },
     {
       "id": "higher-dimensions",
@@ -146,7 +146,7 @@
       "summary": "mu3_estimate, large_k_limit, normalized_limit",
       "startLine": 163,
       "endLine": 178,
-      "mathContext": "mu3_estimate, large_k_limit, normalized_limit"
+      "mathContext": "For $k=3$: $C_3 \\approx 4.684$ (numerical). Asymptotically, $\\lim_{k \\to \\infty} C_k / (2k) = 1$, confirming that in high dimensions the self-avoidance constraint becomes negligible and $C_k$ approaches the non-backtracking constant $2k-1 \\sim 2k$."
     },
     {
       "id": "honeycomb",
@@ -154,7 +154,7 @@
       "summary": "mu_honeycomb definition, mu_honeycomb_approx, honeycomb_exact",
       "startLine": 179,
       "endLine": 199,
-      "mathContext": "mu_honeycomb definition, mu_honeycomb_approx, honeycomb_exact"
+      "mathContext": "The honeycomb lattice connective constant satisfies $\\mu_{\\text{hex}} = \\sqrt{2 + \\sqrt{2}} \\approx 1.8478$, proved exactly by Duminil-Copin and Smirnov (2012) using discrete holomorphicity (parafermionic observables). This is the only lattice for which an exact closed form is known; the proof contributed to Smirnov's Fields Medal work."
     },
     {
       "id": "conjectures",
@@ -162,7 +162,7 @@
       "summary": "mu2_closed_form_conjecture, irrationality_conjecture, mu2_irrationality_open_status",
       "startLine": 200,
       "endLine": 217,
-      "mathContext": "mu2_closed_form_conjecture, irrationality_conjecture, mu2_irrationality_open_status"
+      "mathContext": "Open questions: (1) Is $C_2$ algebraic, or does it have a closed form in terms of known constants? (2) Is $C_k$ irrational for $k \\geq 2$? Neither question is resolved for any $k$. The algebraic nature of $C_2$ is considered one of the most tantalizing open problems in combinatorics."
     },
     {
       "id": "enumeration",
@@ -170,7 +170,7 @@
       "summary": "saw_counts_2d (n ≤ 5), ratio_convergence",
       "startLine": 218,
       "endLine": 235,
-      "mathContext": "saw_counts_2d (n ≤ 5), ratio_convergence"
+      "mathContext": "Exact 2D SAW counts: $f(0,2)=1$, $f(1,2)=4$, $f(2,2)=12$, $f(3,2)=36$, $f(4,2)=100$, $f(5,2)=284$. The ratios $f(n+1,2)/f(n,2)$ converge to $C_2 \\approx 2.638$; e.g.\\ $284/100 = 2.84$, still converging from above."
     },
     {
       "id": "applications",
@@ -178,7 +178,7 @@
       "summary": "critical_exponent_exists, gamma_2d_conjecture_value",
       "startLine": 236,
       "endLine": 253,
-      "mathContext": "critical_exponent_exists, gamma_2d_conjecture_value"
+      "mathContext": "Beyond exponential growth, SAW counts satisfy $f(n,k) \\sim A_k \\, C_k^n \\, n^{\\gamma_k - 1}$ for a critical exponent $\\gamma_k$. In 2D, conformal field theory predicts $\\gamma_2 = 43/32$ (unproved rigorously). SAWs model linear polymer chains in a good solvent; $C_k$ determines entropic elasticity and $\\gamma_k$ governs end-to-end distance scaling."
     },
     {
       "id": "summary",
@@ -186,7 +186,7 @@
       "summary": "erdos_528_summary: limit existence, bounds, 2D results",
       "startLine": 254,
       "endLine": 272,
-      "mathContext": "erdos_528_summary: limit existence, bounds, 2D results"
+      "mathContext": "Summary of main results: $C_k = \\lim_{n\\to\\infty} f(n,k)^{1/n}$ exists for all $k \\geq 1$ (Hammersley–Morton 1954); $k \\leq C_k \\leq 2k-1$ (trivial bounds); $C_k = 2k-1-\\frac{1}{2k}+O(k^{-2})$ (Kesten 1963); $2.62 \\leq C_2 \\leq 2.696$, $C_2 = 2.6381585\\ldots$ (numerical); $\\mu_{\\text{hex}} = \\sqrt{2+\\sqrt{2}}$ (exact). Exact closed forms for $C_k$ on square lattices remain open."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-7/meta.json
+++ b/src/data/proofs/erdos-7/meta.json
@@ -93,7 +93,7 @@
       "summary": "CongruenceClass and CoveringSystem structures",
       "startLine": 31,
       "endLine": 56,
-      "mathContext": "CongruenceClass and CoveringSystem structures"
+      "mathContext": "A covering system $\\{a_i \\pmod{n_i}\\}_{i=1}^k$ covers $\\mathbb{Z}$: $\\forall x \\in \\mathbb{Z},\\, \\exists i: x \\equiv a_i \\pmod{n_i}$, with distinct $n_i \\geq 2$."
     },
     {
       "id": "odd-moduli",
@@ -101,7 +101,7 @@
       "summary": "Predicates for odd and even moduli",
       "startLine": 57,
       "endLine": 70,
-      "mathContext": "Predicates for odd and even moduli"
+      "mathContext": "All moduli odd: $2 \\nmid n_i$ for all $i$. The Erdős-Selfridge conjecture: no such covering exists."
     },
     {
       "id": "erdos-selfridge",
@@ -109,7 +109,7 @@
       "summary": "Main conjecture in two equivalent forms",
       "startLine": 71,
       "endLine": 101,
-      "mathContext": "Main conjecture in two equivalent forms"
+      "mathContext": "Conjecture: $\\nexists$ covering with all $n_i$ odd and distinct. Equivalently: every covering uses some even modulus."
     },
     {
       "id": "squarefree",
@@ -117,7 +117,7 @@
       "summary": "Definitions for squarefree covering systems",
       "startLine": 102,
       "endLine": 118,
-      "mathContext": "Definitions for squarefree covering systems"
+      "mathContext": "Squarefree: $\\forall p$ prime, $p^2 \\nmid n_i$. Combined with odd: all moduli are odd squarefree integers."
     },
     {
       "id": "balister",
@@ -125,7 +125,7 @@
       "summary": "No odd squarefree covering exists",
       "startLine": 119,
       "endLine": 140,
-      "mathContext": "No odd squarefree covering exists"
+      "mathContext": "Balister et al. (2022): $\\nexists$ odd squarefree covering system — proved for the squarefree case."
     },
     {
       "id": "hough-nielsen",
@@ -133,7 +133,7 @@
       "summary": "Some modulus must be divisible by 2 or 3",
       "startLine": 141,
       "endLine": 159,
-      "mathContext": "Some modulus must be divisible by 2 or 3"
+      "mathContext": "Hough-Nielsen (2019): in any covering, $\\exists n_i$ with $2 \\mid n_i$ or $3 \\mid n_i$. Any odd covering must use a multiple of 3."
     },
     {
       "id": "lcm-constraint",
@@ -141,7 +141,7 @@
       "summary": "If odd covering exists, LCM divisible by 9 or 15",
       "startLine": 160,
       "endLine": 173,
-      "mathContext": "If odd covering exists, LCM divisible by 9 or 15"
+      "mathContext": "If odd covering exists, $9 \\mid \\text{lcm}(n_1,\\ldots,n_k)$ or $15 \\mid \\text{lcm}(n_1,\\ldots,n_k)$."
     },
     {
       "id": "properties",
@@ -149,7 +149,7 @@
       "summary": "Basic facts about odd moduli",
       "startLine": 174,
       "endLine": 188,
-      "mathContext": "Basic facts about odd moduli"
+      "mathContext": "Basic: if all $n_i$ odd, smallest $n_i \\geq 3$. Reciprocal sum: $\\sum 1/n_i \\geq 1$ (covering condition)."
     },
     {
       "id": "gap",
@@ -157,7 +157,7 @@
       "summary": "Summary of what is known vs unknown",
       "startLine": 189,
       "endLine": 207,
-      "mathContext": "Summary of what is known vs unknown"
+      "mathContext": "Known: no odd squarefree covering; any covering needs modulus divisible by 2 or 3. Open: odd non-squarefree coverings."
     },
     {
       "id": "selfridge",
@@ -165,7 +165,7 @@
       "summary": "$2000 for explicit odd covering construction",
       "startLine": 208,
       "endLine": 219,
-      "mathContext": "$2000 for explicit odd covering construction"
+      "mathContext": "Selfridge prize: $2000 for explicit construction of a covering with all $n_i$ odd and distinct (if one exists)."
     },
     {
       "id": "covering-properties",
@@ -173,7 +173,7 @@
       "summary": "Min odd modulus definitions",
       "startLine": 220,
       "endLine": 234,
-      "mathContext": "Min odd modulus definitions"
+      "mathContext": "$m^*(\\mathcal{C}) = \\min\\{n_i : n_i \\text{ odd}\\}$; bounds on the smallest modulus of any hypothetical odd covering."
     },
     {
       "id": "summary-theorem",
@@ -181,7 +181,7 @@
       "summary": "erdos_7_summary combining Hough-Nielsen, Balister, and LCM constraint",
       "startLine": 235,
       "endLine": 274,
-      "mathContext": "erdos_7_summary combining Hough-Nielsen, Balister, and LCM constraint"
+      "mathContext": "Main theorem: Hough-Nielsen ($\\exists n_i$ with $6 \\mid n_i$ or $2 \\mid n_i$) + Balister (no odd squarefree covering) + LCM constraint ($9 \\mid \\text{lcm}$ or $15 \\mid \\text{lcm}$)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-774/meta.json
+++ b/src/data/proofs/erdos-774/meta.json
@@ -83,7 +83,7 @@
       "summary": "IsDissociated, IsDissociatedSet, HasUniqueSubsetSums, equivalence theorem",
       "startLine": 41,
       "endLine": 70,
-      "mathContext": "IsDissociated, IsDissociatedSet, HasUniqueSubsetSums, equivalence theorem"
+      "mathContext": "$A \\subset \\mathbb{N}$ is **dissociated** if $\\sum_{n \\in X} n \\neq \\sum_{m \\in Y} m$ for all finite $X, Y \\subseteq A$ with $X \\neq Y$. Equivalently: no nontrivial signed subset sums to zero."
     },
     {
       "id": "examples",
@@ -91,7 +91,7 @@
       "summary": "Powers of 2, powers of any base, lacunary sequences",
       "startLine": 71,
       "endLine": 96,
-      "mathContext": "Powers of 2, powers of any base, lacunary sequences"
+      "mathContext": "$\\{2^k : k \\geq 0\\}$ is dissociated (binary representation uniqueness). More generally, $\\{b^k\\}$ for $b \\geq 2$ and lacunary sequences $a_{n+1}/a_n \\geq 2$ are dissociated."
     },
     {
       "id": "proportionately-dissociated",
@@ -99,7 +99,7 @@
       "summary": "IsProportionatelyDissociated definition, dissociated implies proportionately",
       "startLine": 97,
       "endLine": 123,
-      "mathContext": "IsProportionatelyDissociated definition, dissociated implies proportionately"
+      "mathContext": "$A$ is **proportionately dissociated** if $\\exists c > 0$: every finite $B \\subseteq A$ contains a dissociated subset of size $\\geq c|B|$."
     },
     {
       "id": "sidon-harmonic",
@@ -107,7 +107,7 @@
       "summary": "IsSidonHarmonic, Pisier's theorem connecting to proportionately dissociated",
       "startLine": 124,
       "endLine": 141,
-      "mathContext": "IsSidonHarmonic, Pisier's theorem connecting to proportionately dissociated"
+      "mathContext": "Pisier (1983): $\\Lambda$ is Sidon (harmonic) $\\Leftrightarrow$ $\\Lambda$ is proportionately dissociated."
     },
     {
       "id": "sidon-additive",
@@ -115,7 +115,7 @@
       "summary": "IsSidonAdditive, relationship to dissociated sets",
       "startLine": 142,
       "endLine": 159,
-      "mathContext": "IsSidonAdditive, relationship to dissociated sets"
+      "mathContext": "$A$ is Sidon (additive) if $a+b=c+d$ implies $\\{a,b\\}=\\{c,d\\}$. Sidon (additive) $\\Rightarrow$ dissociated."
     },
     {
       "id": "union-decomposition",
@@ -123,7 +123,7 @@
       "summary": "IsFiniteUnionDissociated, finite_union_is_proportionately",
       "startLine": 160,
       "endLine": 172,
-      "mathContext": "IsFiniteUnionDissociated, finite_union_is_proportionately"
+      "mathContext": "$A = D_1 \\cup \\cdots \\cup D_k$ with each $D_i$ dissociated $\\Rightarrow$ $A$ proportionately dissociated (pigeonhole)."
     },
     {
       "id": "main-conjecture",
@@ -131,7 +131,7 @@
       "summary": "ErdosConjecture774 formal statement, Alon-Erdős conjecture",
       "startLine": 173,
       "endLine": 185,
-      "mathContext": "ErdosConjecture774 formal statement, Alon-Erdős conjecture"
+      "mathContext": "**Erdős #774 (OPEN)**: Does proportionately dissociated $\\Rightarrow$ finite union of dissociated? Alon-Erdős conjecture: NO."
     },
     {
       "id": "sidon-analogue",
@@ -139,7 +139,7 @@
       "summary": "IsProportionatelySidon, SidonAnalogue, Nešetřil-Rödl-Sales theorem, NRS construction",
       "startLine": 186,
       "endLine": 218,
-      "mathContext": "IsProportionatelySidon, SidonAnalogue, Nešetřil-Rödl-Sales theorem, NRS construction"
+      "mathContext": "NRS (2024): $\\exists$ proportionately Sidon set that is NOT a finite union of Sidon sets. Strong evidence #774 also has answer NO."
     },
     {
       "id": "connections",
@@ -147,7 +147,7 @@
       "summary": "Implications between Sidon and dissociated notions",
       "startLine": 219,
       "endLine": 231,
-      "mathContext": "Implications between Sidon and dissociated notions"
+      "mathContext": "Chain: Sidon (additive) $\\Rightarrow$ dissociated $\\Rightarrow$ prop. dissociated $\\Leftrightarrow$ Sidon (harmonic). Question: does the second arrow reverse under finite unions?"
     },
     {
       "id": "bounds",
@@ -155,7 +155,7 @@
       "summary": "maxDissociatedSize, Θ(log n) bound",
       "startLine": 232,
       "endLine": 246,
-      "mathContext": "maxDissociatedSize, Θ(log n) bound"
+      "mathContext": "Max dissociated subset of $\\{1,\\ldots,n\\}$ has size $\\Theta(\\log n)$: powers of 2 give $\\lfloor \\log_2 n \\rfloor + 1$ elements."
     },
     {
       "id": "summary",
@@ -163,7 +163,7 @@
       "summary": "erdos_774_summary theorem combining finite_union_is_proportionately and NRS",
       "startLine": 247,
       "endLine": 260,
-      "mathContext": "erdos_774_summary theorem combining finite_union_is_proportionately and NRS"
+      "mathContext": "Main: finite union of dissociated $\\Rightarrow$ proportionately dissociated (proved), converse OPEN (conjectured false by Alon-Erdős). NRS resolving Sidon analogue negatively is strongest evidence."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass fixing section `mathContext` fields across 3 entries:

**erdos-528** (Connective Constant for Self-Avoiding Walks):
- 12 sections: SAW definition, submultiplicativity/Fekete's lemma, Kesten asymptotic, honeycomb constant, critical exponents

**erdos-774** (Dissociated and Proportionately Dissociated Sets):
- 11 sections: dissociated set definition, Pisier's theorem, NRS result, implication chains

**erdos-7** (Odd Covering Systems):
- 12 sections: covering system definition, Erdős-Selfridge conjecture, Hough-Nielsen, Balister squarefree result, LCM constraints