### PR TITLE
Enrich fundamental-theorem-calculus: address peer review findings

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.json
@@ -1,165 +1,122 @@
 [
   {
+    "id": "ann-header-docstring",
+    "proofId": "fundamental-theorem-calculus",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "Module Overview and Imports",
+    "content": "Imports six Mathlib modules providing the calculus infrastructure: FDeriv, Deriv, IntervalIntegral, FundThmCalculus, MeanValue, and Topology. The module docstring honestly describes the file as providing 'pedagogical organization, wrapper theorems with cleaner hypotheses (like ftc_part1_continuous), and extensive commentary.' Opens MeasureTheory, Set, Filter, Topology, and intervalIntegral namespaces.",
+    "mathContext": "Mathlib dependencies: `integral_hasDerivAt_right` (FTC Part 1), `integral_eq_sub_of_hasDerivAt_of_le` (FTC Part 2), `is_const_of_deriv_eq_zero` (constant function theorem).",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib imports", "measure theory", "interval integration"],
+    "prerequisites": ["Lean 4 module system", "Mathlib library structure"]
+  },
+  {
     "id": "ann-integral-function",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 8,
-      "endLine": 43
-    },
+    "range": { "startLine": 59, "endLine": 61 },
     "type": "definition",
-    "title": "The Integral Function F(x)",
-    "content": "We define **F(x) = ∫ₐˣ f(t) dt**, the cumulative integral from a fixed starting point $a$ to a variable endpoint $x$.\n\nThis function measures the 'accumulated area' under $f$ from $a$ to $x$. As $x$ increases, more area is accumulated (if $f$ is positive).\n\nThe key insight: F is constructed from f via integration, and we'll prove F' = f.",
-    "mathContext": "$F : \\mathbb{R} \\to \\mathbb{R}$\n\n$F(x) = \\int_a^x f(t)\\,dt$\n\nF(a) = 0 (integral over an empty interval)",
+    "title": "The Integral Function F(x) = int_a^x f(t) dt",
+    "content": "Defines the cumulative integral function `integralFunction f a : R -> R` as `fun x => int t in a..x, f t`. This is the function whose derivative FTC Part 1 will show equals f. The definition uses Mathlib's interval integral notation. As `noncomputable`, it relies on classical choice for the measure-theoretic integral.",
+    "mathContext": "$F(x) = \\int_a^x f(t)\\,dt$ defines a function $F : \\mathbb{R} \\to \\mathbb{R}$ with $F(a) = 0$.",
     "significance": "key",
-    "relatedConcepts": [
-      "definite integral",
-      "area under curve",
-      "accumulation function"
-    ]
+    "relatedConcepts": ["interval integral", "accumulation function", "noncomputable definition"],
+    "prerequisites": ["measure-theoretic integration", "interval integral notation"]
   },
   {
     "id": "ann-ftc-part1",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 8,
-      "endLine": 43
-    },
-    "type": "theorem",
+    "range": { "startLine": 65, "endLine": 78 },
+    "type": "technique",
     "title": "FTC Part 1: Derivative of an Integral",
-    "content": "**The derivative of the integral function equals the integrand.**\n\nIf $F(x) = \\int_a^x f(t)\\,dt$, then $F'(x) = f(x)$.\n\nThis is profound: integration 'builds' an antiderivative of any continuous function. Even if we can't write ∫f in closed form, the integral function exists and has f as its derivative.",
-    "mathContext": "$\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$\n\nIn Leibniz notation: $\\frac{d}{dx}F(x) = f(x)$",
+    "content": "Two theorems implementing FTC Part 1. `ftc_part1` (lines 65-69) is a direct delegation to Mathlib's `integral_hasDerivAt_right`, requiring explicit hypotheses: ContinuousAt, IntervalIntegrable, StronglyMeasurableAtFilter. `ftc_part1_continuous` (lines 72-78) is the convenience wrapper deriving all three from a single `Continuous f` — the file's main API contribution for Part 1.",
+    "mathContext": "$\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$ for $f$ continuous. Lean type: `HasDerivAt (integralFunction f a) (f x) x`.",
     "significance": "key",
-    "relatedConcepts": [
-      "antiderivative",
-      "HasDerivAt",
-      "differentiability"
-    ]
-  },
-  {
-    "id": "ann-continuity-requirement",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 8,
-      "endLine": 43
-    },
-    "type": "concept",
-    "title": "Continuity is Essential",
-    "content": "The theorem requires **continuity at x** (for the pointwise statement) or **continuity on [a,b]** (for the global statement).\n\nWhy? The proof relies on limits: as the integration interval shrinks, the average value approaches f(x). This requires continuity.\n\nFor discontinuous functions, we need the more sophisticated Lebesgue-Stieltjes integral and almost-everywhere differentiability.",
-    "mathContext": "$f$ continuous at $x$ means:\n\n$\\lim_{h \\to 0} f(x+h) = f(x)$\n\nThis ensures $\\lim_{h \\to 0} \\frac{1}{h}\\int_x^{x+h} f(t)\\,dt = f(x)$",
-    "significance": "key",
-    "relatedConcepts": [
-      "continuity",
-      "ContinuousAt",
-      "limit definition"
-    ]
+    "relatedConcepts": ["HasDerivAt", "integral_hasDerivAt_right", "ContinuousAt", "IntervalIntegrable"],
+    "prerequisites": ["measure-theoretic integrals", "Mathlib FTC infrastructure"]
   },
   {
     "id": "ann-ftc-part2",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 65,
-      "endLine": 69
-    },
-    "type": "theorem",
+    "range": { "startLine": 91, "endLine": 97 },
+    "type": "technique",
     "title": "FTC Part 2: Evaluation Theorem",
-    "content": "**The integral of a derivative equals the net change.**\n\n$\\int_a^b F'(x)\\,dx = F(b) - F(a)$\n\nThis is the 'computational' part of FTC: it reduces the problem of integration (infinite sums) to simple evaluation at two points.\n\nEvery integral table and integration technique is ultimately about finding antiderivatives to apply this theorem.",
-    "mathContext": "$\\int_a^b f(x)\\,dx = F(b) - F(a)$\n\nwhere $F' = f$ on $[a, b]$\n\nOften written: $\\left[F(x)\\right]_a^b = F(b) - F(a)$",
+    "content": "`ftc_part2` delegates to Mathlib's `integral_eq_sub_of_hasDerivAt_of_le` with four hypotheses: `a <= b`, `ContinuousOn F (Icc a b)`, `HasDerivAt F (f x) x` on the open interval, and `IntervalIntegrable f`. One-line delegation providing a clean namespace-scoped API.",
+    "mathContext": "$\\int_a^b f(x)\\,dx = F(b) - F(a)$ when $F$ is continuous on $[a,b]$, differentiable on $(a,b)$, and $F' = f$.",
     "significance": "key",
-    "relatedConcepts": [
-      "antiderivative",
-      "evaluation",
-      "net change"
-    ]
+    "relatedConcepts": ["evaluation formula", "net change", "integral_eq_sub_of_hasDerivAt_of_le"],
+    "prerequisites": ["ContinuousOn", "HasDerivAt", "IntervalIntegrable"]
   },
   {
-    "id": "ann-ftc-part2-conditions",
+    "id": "ann-ftc-part2-general",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 65,
-      "endLine": 69
-    },
-    "type": "concept",
-    "title": "Conditions for FTC Part 2",
-    "content": "The theorem requires:\n\n1. **F is differentiable** on [a, b]\n2. **F' is continuous** on [a, b] (or at least integrable)\n3. **a ≤ b** (the integration bounds are in order)\n\nThe continuity of F' is crucial: if F' has 'bad' discontinuities, the integral may not equal F(b) - F(a).\n\nCounterexamples exist for merely differentiable F with discontinuous derivative.",
-    "mathContext": "We need:\n- $\\forall x \\in [a,b], \\text{HasDerivAt } F (F'(x)) x$\n- $F' \\in C([a,b])$ (continuous on closed interval)",
-    "significance": "key",
-    "relatedConcepts": [
-      "differentiability",
-      "ContinuousOn",
-      "interval conditions"
-    ]
-  },
-  {
-    "id": "ann-antiderivative-def",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 91,
-      "endLine": 97
-    },
-    "type": "definition",
-    "title": "Antiderivative Definition",
-    "content": "**F is an antiderivative of f** if $F'(x) = f(x)$ for all $x$.\n\nAlso called a **primitive** or **indefinite integral** of f.\n\nThe key property: if F is an antiderivative of f, then so is F + C for any constant C. This is why indefinite integrals always have the '+C'.",
-    "mathContext": "$F$ is an antiderivative of $f$ means:\n\n$\\forall x, \\frac{d}{dx}F(x) = f(x)$\n\nNotation: $\\int f(x)\\,dx = F(x) + C$",
-    "significance": "key",
-    "relatedConcepts": [
-      "derivative",
-      "indefinite integral",
-      "primitive function"
-    ]
-  },
-  {
-    "id": "ann-uniqueness",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 107,
-      "endLine": 117
-    },
-    "type": "theorem",
-    "title": "Antiderivatives Differ by Constants",
-    "content": "**If F and G are both antiderivatives of f, then F - G is constant.**\n\nThis explains the '+C' in indefinite integrals:\n- F and G both satisfy F' = f and G' = f\n- So (F - G)' = 0\n- A function with zero derivative is constant (by MVT)\n- Therefore F = G + C\n\nThis means antiderivatives are 'unique up to a constant'.",
-    "mathContext": "$F' = G' = f \\Rightarrow (F - G)' = 0$\n\n$\\Rightarrow F - G = C$ (constant)\n\nSo $\\int f\\,dx$ represents a *family* of functions differing by constants.",
-    "significance": "key",
-    "relatedConcepts": [
-      "mean value theorem",
-      "constant function",
-      "uniqueness"
-    ]
-  },
-  {
-    "id": "ann-zero-derivative",
-    "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 124,
-      "endLine": 128
-    },
-    "type": "lemma",
-    "title": "Zero Derivative Implies Constant",
-    "content": "**If F'(x) = 0 for all x, then F is constant.**\n\nThis is a consequence of the Mean Value Theorem:\n\nFor any two points x and y, there exists c between them with\n$F(y) - F(x) = F'(c)(y - x) = 0 \\cdot (y - x) = 0$\n\nSo F(y) = F(x) for all x, y.\n\nThis lemma is essential for proving uniqueness of antiderivatives.",
-    "mathContext": "Mean Value Theorem: $F(y) - F(x) = F'(c)(y - x)$ for some $c \\in (x, y)$\n\nIf $F' \\equiv 0$, then $F(y) = F(x)$ for all $x, y$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "mean value theorem",
-      "constant function",
-      "convexity"
-    ]
+    "range": { "startLine": 100, "endLine": 105 },
+    "type": "technique",
+    "title": "FTC Part 2 General: No Ordering Assumption",
+    "content": "`ftc_part2_general` removes the `a <= b` requirement by using `uIcc a b` (unordered interval) and `HasDerivWithinAt` on `Ioi x` (right derivatives). Delegates to `integral_eq_sub_of_hasDeriv_right`. Useful when the integral direction matters or ordering is unknown.",
+    "mathContext": "$\\int_a^b f(x)\\,dx = F(b) - F(a)$ for any $a, b \\in \\mathbb{R}$, using the unordered closed interval.",
+    "significance": "supporting",
+    "relatedConcepts": ["uIcc", "HasDerivWithinAt", "unordered interval"],
+    "prerequisites": ["interval integral conventions", "right derivatives"]
   },
   {
     "id": "ann-inverse-operations",
     "proofId": "fundamental-theorem-calculus",
-    "range": {
-      "startLine": 80,
-      "endLine": 88
-    },
+    "range": { "startLine": 107, "endLine": 121 },
     "type": "insight",
-    "title": "The Unity of Calculus",
-    "content": "**Differentiation and integration are inverse operations.**\n\nIntegrate then differentiate: $\\frac{d}{dx}\\int_a^x f = f$ (FTC Part 1)\n\nDifferentiate then integrate: $\\int_a^x F' = F - F(a)$ (FTC Part 2)\n\nThis 'almost inverse' relationship (up to the constant F(a)) unifies the two branches of calculus that Newton and Leibniz developed from completely different perspectives.\n\nNewton saw derivatives as velocities and integrals as areas. Leibniz saw both through infinitesimals. FTC shows they were studying the same thing.",
-    "mathContext": "$D$ = differentiation, $I_a$ = integration from $a$\n\n$D \\circ I_a = \\text{id}$ (FTC Part 1)\n\n$I_a \\circ D = \\text{id} + \\text{const}$ (FTC Part 2, roughly)",
+    "title": "The Unity of Calculus: Inverse Operations",
+    "content": "Commentary explaining that FTC Parts 1 and 2 together establish differentiation and integration as inverse operations. The 'up to constants' discrepancy (F(a) in Part 2) motivates the IsAntiderivative definition and uniqueness theorem.",
+    "mathContext": "$D \\circ I_a = \\text{id}$ (Part 1), $I_a \\circ D = \\text{id} - \\text{eval}_a$ (Part 2). Kernel of $D$ is constants.",
     "significance": "key",
-    "relatedConcepts": [
-      "inverse functions",
-      "Newton",
-      "Leibniz",
-      "calculus unification"
-    ]
+    "relatedConcepts": ["inverse operations", "antiderivative", "kernel of differentiation"],
+    "prerequisites": ["FTC Parts 1 and 2"]
+  },
+  {
+    "id": "ann-antiderivative-def",
+    "proofId": "fundamental-theorem-calculus",
+    "range": { "startLine": 119, "endLine": 128 },
+    "type": "definition",
+    "title": "IsAntiderivative: F' = f Everywhere",
+    "content": "`IsAntiderivative F f` is defined as `forall x, HasDerivAt F (f x) x`. `integral_is_antiderivative` proves the integral function is an antiderivative of any continuous f.",
+    "mathContext": "$F$ is an antiderivative of $f$ iff $\\forall x,\\, F'(x) = f(x)$. By FTC Part 1: $\\int_a^x f(t)\\,dt$ is an antiderivative when $f$ is continuous.",
+    "significance": "supporting",
+    "relatedConcepts": ["antiderivative", "HasDerivAt", "indefinite integral"],
+    "prerequisites": ["ftc_part1_continuous"]
+  },
+  {
+    "id": "ann-zero-derivative-constant",
+    "proofId": "fundamental-theorem-calculus",
+    "range": { "startLine": 132, "endLine": 139 },
+    "type": "technique",
+    "title": "Zero Derivative Implies Constant (via MVT)",
+    "content": "`hasDerivAt_zero_implies_constant` proves that if F'(x) = 0 for all x, then F(x) = F(y) for all x, y. Uses `is_const_of_deriv_eq_zero` from Mathlib (which internally uses the Mean Value Theorem). Supporting lemma for antiderivative uniqueness.",
+    "mathContext": "By MVT: $F(y) - F(x) = F'(c)(y - x) = 0$ for some $c$ between $x$ and $y$. Hence $F(x) = F(y)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["mean value theorem", "is_const_of_deriv_eq_zero", "Differentiable"],
+    "prerequisites": ["mean value theorem", "HasDerivAt.deriv"]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "fundamental-theorem-calculus",
+    "range": { "startLine": 143, "endLine": 158 },
+    "type": "technique",
+    "title": "Antiderivatives Differ by Constants",
+    "content": "`antiderivatives_differ_by_constant` is the file's most substantive original proof. Given `IsAntiderivative F f` and `IsAntiderivative G f`, proves `exists c, forall x, F x - G x = c`. Proof: (1) show (F-G)' = 0 via HasDerivAt.sub and simp; (2) apply hasDerivAt_zero_implies_constant; (3) witness c = F 0 - G 0 and close with linarith. This explains the '+C' in indefinite integrals.",
+    "mathContext": "$F' = G' = f \\Rightarrow (F-G)' = 0 \\Rightarrow F - G = c$. Antiderivatives form an affine subspace $F + \\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": ["antiderivative uniqueness", "HasDerivAt.sub", "constant function theorem"],
+    "prerequisites": ["hasDerivAt_zero_implies_constant", "IsAntiderivative"]
+  },
+  {
+    "id": "ann-verification",
+    "proofId": "fundamental-theorem-calculus",
+    "range": { "startLine": 160, "endLine": 165 },
+    "type": "context",
+    "title": "Type-Check Verification",
+    "content": "Four #check commands verify the types of ftc_part1, ftc_part2, integral_is_antiderivative, and antiderivatives_differ_by_constant.",
+    "mathContext": "Verified types: FTC Part 1, FTC Part 2, integral-is-antiderivative, and antiderivative uniqueness.",
+    "significance": "technical",
+    "relatedConcepts": ["#check command", "API summary"],
+    "prerequisites": ["Lean 4 commands"]
   }
 ]

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -21,23 +21,43 @@
     "sorries": 0,
     "mathlibDependencies": [
       {
-        "theorem": "intervalIntegral",
-        "description": "Interval integration definitions",
-        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
+        "theorem": "integral_hasDerivAt_right",
+        "description": "FTC Part 1: HasDerivAt for the integral function at a point",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus"
+      },
+      {
+        "theorem": "integral_eq_sub_of_hasDerivAt_of_le",
+        "description": "FTC Part 2: integral of derivative equals net change when a <= b",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus"
+      },
+      {
+        "theorem": "integral_eq_sub_of_hasDeriv_right",
+        "description": "FTC Part 2 general: works without ordering assumption",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus"
+      },
+      {
+        "theorem": "is_const_of_deriv_eq_zero",
+        "description": "Constant function theorem: zero derivative implies constant",
+        "module": "Mathlib.Analysis.Calculus.MeanValue"
       },
       {
         "theorem": "HasDerivAt",
         "description": "Derivative definitions and properties",
         "module": "Mathlib.Analysis.Calculus.Deriv.Basic"
+      },
+      {
+        "theorem": "IntervalIntegrable",
+        "description": "Integrability on intervals",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
       }
     ],
     "originalContributions": [
-      "Complete proof of FTC Part 1 (differentiation of integrals)",
-      "Complete proof of FTC Part 2 (evaluation of integrals)",
-      "Antiderivative uniqueness up to constants"
+      "Pedagogical wrapper of FTC Part 1 with clean API (ftc_part1_continuous simplifies hypotheses)",
+      "Generalized FTC Part 2 without ordering assumption (ftc_part2_general via uIcc)",
+      "Antiderivative uniqueness theorem with multi-step proof via mean value theorem (antiderivatives_differ_by_constant)"
     ],
     "dateAdded": "2025-12-21",
-    "wiedijkNumber": 15,
+    "wiedijkNumber": 46,
     "axiomCount": 0,
     "lineCount": 165,
     "assumptions": "0 axioms, 0 sorries. Core FTC results (integral_hasDerivAt_right, integral_eq_sub_of_hasDerivAt) derived from Mathlib's measure-theoretic integration framework.",
@@ -46,7 +66,7 @@
   "overview": {
     "historicalContext": "The Fundamental Theorem of Calculus (FTC) represents one of mathematics' greatest unifications. Its origins predate Newton and Leibniz: Isaac Barrow, Newton's teacher at Cambridge, proved a geometric version in his *Lectiones Geometricae* (1670), showing that the tangent to an area curve gives the height of the original curve — essentially FTC Part 1 in geometric language. But Barrow did not recognize the full computational significance.\n\nIsaac Newton developed his 'method of fluxions' while avoiding the plague at Woolsthorpe Manor (1665-1666), making FTC the centerpiece: he systematically used antidifferentiation to compute areas, volumes, and arc lengths. Leibniz independently created his differential calculus in the 1670s, with superior notation (dx, dy, ∫) that we still use today. Their bitter priority dispute dominated European mathematics for decades.\n\nWhile Newton and Leibniz grasped the theorem intuitively, rigorous proof required the epsilon-delta foundations developed by Cauchy in his *Résumé des leçons* (1823) and perfected by Weierstrass (1860s). Bernhard Riemann's 1854 Habilitationsschrift gave the first rigorous definition of the integral, making FTC a theorem rather than a heuristic. The modern Lebesgue integral (1902) and its generalization by Henstock-Kurzweil further extended FTC to broader classes of functions.",
     "problemStatement": "The Fundamental Theorem of Calculus has two parts:\n\nPart 1 (Differentiation of Integrals):\nIf $f$ is continuous on $[a, b]$ and we define\n$$F(x) = \\int_a^x f(t)\\,dt$$\nthen $F$ is differentiable and $F'(x) = f(x)$.\n\nPart 2 (Evaluation of Integrals):\nIf $F$ is an antiderivative of $f$ on $[a, b]$ (meaning $F' = f$), then\n$$\\int_a^b f(x)\\,dx = F(b) - F(a)$$\n\nTogether, these say that differentiation and integration are inverse operations.",
-    "text": "A 165-line formalization of the Fundamental Theorem of Calculus (Wiedijk #46) with 16 declarations, 0 sorries, 0 axioms. Part 1 (`ftc_part1`): delegates to Mathlib's `intervalIntegral.integral_hasStrictDerivAt` showing $F(x) = \\int_a^x f(t)\\,dt$ has $F'(x) = f(x)$ for continuous $f$. Part 2 (`ftc_part2`): delegates to `intervalIntegral.integral_eq_sub_of_hasDerivAt`, giving $\\int_a^b f = F(b) - F(a)$. Includes `integration_by_parts` via `intervalIntegral.integral_mul_deriv_of_le`, concrete examples ($\\int_0^1 2x\\,dx = 1$ via `norm_num`), and corollaries like the mean value theorem for integrals (`mvt_for_integrals`) and the `integral_nonneg` positivity lemma.",
+    "text": "A 165-line pedagogical Mathlib bridge for the Fundamental Theorem of Calculus (Wiedijk #46) with 9 declarations (7 theorems, 2 definitions), 0 sorries, 0 axioms. Part 1 (`ftc_part1`): delegates to Mathlib's `integral_hasDerivAt_right` showing $F(x) = \\int_a^x f(t)\\,dt$ has $F'(x) = f(x)$, with a convenience wrapper `ftc_part1_continuous` for continuous $f$. Part 2 (`ftc_part2`): delegates to `integral_eq_sub_of_hasDerivAt_of_le` giving $\\int_a^b f = F(b) - F(a)$, plus a generalized version `ftc_part2_general` without the $a \\leq b$ assumption. Defines `IsAntiderivative` and proves `antiderivatives_differ_by_constant` via the mean value theorem — the file's most substantive original proof.",
     "proofStrategy": "Part 1 Strategy:\n\n1. Consider the difference quotient of $F$:\n   $$\\frac{F(x+h) - F(x)}{h} = \\frac{1}{h}\\int_x^{x+h} f(t)\\,dt$$\n\n2. By the Mean Value Theorem for integrals, this equals $f(c)$ for some $c$ between $x$ and $x+h$\n\n3. As $h \\to 0$, we have $c \\to x$, and by continuity of $f$, $f(c) \\to f(x)$\n\n4. Therefore $F'(x) = \\lim_{h \\to 0} \\frac{F(x+h) - F(x)}{h} = f(x)$\n\nPart 2 Strategy:\n\n1. Define $G(x) = \\int_a^x f(t)\\,dt$\n\n2. By Part 1, $G'(x) = f(x) = F'(x)$\n\n3. Since $G' = F'$, we have $(F - G)' = 0$, so $F - G = C$ (constant)\n\n4. At $x = a$: $G(a) = 0$, so $C = F(a)$, meaning $G(x) = F(x) - F(a)$\n\n5. At $x = b$: $\\int_a^b f = G(b) = F(b) - F(a)$",
     "keyInsights": [
       "**Inverse Operations:** Differentiation and integration are inverse: $\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$ (Part 1) and $\\int_a^b F'(x)\\,dx = F(b) - F(a)$ (Part 2). This duality is the central insight of calculus.",

--- a/src/data/proofs/fundamental-theorem-calculus/review.json
+++ b/src/data/proofs/fundamental-theorem-calculus/review.json
@@ -3,14 +3,12 @@
   "proofId": "fundamental-theorem-calculus",
   "reviewDate": "2026-03-24T16:00:00Z",
   "reviewer": "peer-reviewer-1",
-
   "overallAssessment": {
     "grade": "C+",
     "oneLiner": "Pedagogically rich Mathlib wrapper with honest in-file documentation but significantly overclaimed originalContributions and fabricated declarations in meta.json overview text.",
     "tier": "B",
     "tierJustification": "The core FTC results (Part 1, Part 2) are single-line delegations to Mathlib's integral_hasDerivAt_right and integral_eq_sub_of_hasDerivAt_of_le. The file adds the IsAntiderivative definition, a convenience wrapper ftc_part1_continuous, and the antiderivatives_differ_by_constant theorem (the only multi-step proof). This is a well-organized Mathlib bridge, not an original formalization. Tier B is appropriate."
   },
-
   "findings": [
     {
       "severity": "positive",
@@ -97,49 +95,48 @@
       "recommendation": "Consider whether the #check section adds value. It could be removed or shortened in the Lean file."
     }
   ],
-
   "actionItems": [
     {
       "id": "ai-1",
       "priority": "high",
       "target": "enricher",
       "description": "Remove fabricated content from meta.json overview.text: delete references to integration_by_parts, mvt_for_integrals, integral_nonneg, and the concrete example 'integral from 0 to 1 of 2x dx = 1 via norm_num'. Replace with accurate description of the 7 theorems and 2 definitions actually present.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",
       "priority": "high",
       "target": "enricher",
       "description": "Rewrite meta.json originalContributions to match the Lean file's honest self-description: (1) 'Pedagogical wrapper of FTC Part 1 with clean API', (2) 'Generalized FTC Part 2 without ordering assumption', (3) 'Antiderivative uniqueness theorem with multi-step proof'.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-3",
       "priority": "high",
       "target": "enricher",
       "description": "Fix wiedijkNumber from 15 to 46 in meta.json.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",
       "priority": "medium",
       "target": "enricher",
       "description": "Expand mathlibDependencies to list the actual workhorse functions: integral_hasDerivAt_right, integral_eq_sub_of_hasDerivAt_of_le, integral_eq_sub_of_hasDeriv_right, is_const_of_deriv_eq_zero.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-5",
       "priority": "medium",
       "target": "enricher",
       "description": "Fix annotation line ranges: ann-integral-function to 59-61, ann-ftc-part1 to 65-78. Add annotations for ftc_part2_general and hasDerivAt_zero_implies_constant. Differentiate significance ratings.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-6",
       "priority": "medium",
       "target": "enricher",
       "description": "Correct declaration count in overview.text from '16 declarations' to '9 declarations (7 theorems, 2 definitions)'.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-7",
@@ -149,7 +146,6 @@
       "status": "open"
     }
   ],
-
   "qualityScores": {
     "mathematicalSubstance": 5,
     "originalityAccuracy": 4,
@@ -159,6 +155,5 @@
     "internalConsistency": 4,
     "overall": 5.3
   },
-
   "suggestedBestFraming": "A pedagogical Mathlib bridge for the Fundamental Theorem of Calculus (Wiedijk #46): wraps Mathlib's integral_hasDerivAt_right and integral_eq_sub_of_hasDerivAt for FTC Parts 1 and 2, defines IsAntiderivative, and provides an original multi-step proof that antiderivatives differ by constants via the mean value theorem."
 }


### PR DESCRIPTION
Address 6 peer review findings for fundamental-theorem-calculus:

- **ai-1** (HIGH): Remove fabricated content from overview.text (integration_by_parts, mvt_for_integrals, integral_nonneg don't exist in Lean file)
- **ai-2** (HIGH): Rewrite originalContributions to honestly describe Mathlib wrappers
- **ai-3** (HIGH): Fix wiedijkNumber from 15 to 46
- **ai-4** (MED): Expand mathlibDependencies with actual workhorse functions
- **ai-5** (MED): Fix annotation line ranges, add missing annotations, differentiate significance
- **ai-6** (MED): Correct declaration count from 16 to 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)