### PR TITLE
Research: roth-theorem-k3 - Fix build errors in density_increment_dirichlet

### DIFF
--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -1411,31 +1411,15 @@ private theorem density_increment_dirichlet {N : ℕ} (hN : 4 ≤ N)
       _ ≥ (delta + delta ^ 2 / 100) * (↑N / ↑g) := by
           apply mul_le_mul_of_nonneg_right _ (by positivity)
           nlinarith [sq_nonneg delta]
-  · -- N ≤ 1: with 0 < N, N = 1.
-    have hN1 : N = 1 := by omega
-    subst hN1
-    -- In ZMod 1 (singleton type), every element is 0, so delta ≤ |A| ≤ 1
-    have hdelta_le : delta ≤ 1 := by
-      have h1 := card_le_nat_real A
-      simp only [Nat.cast_one] at hdensity h1
-      linarith
-    by_cases hle : delta + delta ^ 2 / 100 ≤ 1
-    · -- Output density ≤ 1: witnessed by the unique element of ZMod 1
-      refine ⟨1, Finset.univ, one_pos, ?_, ?_⟩
-      · -- APFree is vacuous on ZMod 1 (no nonzero d exists in the singleton type)
-        intro a d hd
-        exact absurd (Subsingleton.elim d 0) hd
-      · simp only [Finset.card_univ, ZMod.card, Nat.cast_one, mul_one]
-        linarith
-    · -- ARCHITECTURAL GAP: delta + delta²/100 > 1 (requires delta > ~0.99)
-      -- with N = 1. The conclusion needs |B| > M for any (M, B), which
-      -- is impossible for finite sets. This case arises in the density
-      -- iteration when the coset decomposition reduces the universe to
-      -- size 1 (e.g., for prime N where gcd(val(r), N) = 1).
-      -- Resolution requires Dirichlet approximation or Bohr sets to
-      -- guarantee subprogression length ≥ √N at each step, ensuring
-      -- M ≥ 2 throughout the iteration.
-      sorry
+  · -- CASE 2: gcd(val(r), N) < √N → coset partition gives M = d < √N,
+    -- which does not satisfy the conclusion Nat.sqrt N ≤ M.
+    -- This case requires Dirichlet approximation: apply DirichletApproximation
+    -- to α = val(r)/N with Q = Nat.sqrt N to get q ≤ √N with |qα - p| < 1/√N.
+    -- Then partition ZMod N into APs of step q, each of length ⌊N/q⌋ ≥ √N.
+    -- The large Fourier coefficient provides a density increment on the
+    -- densest AP. (Not implemented — main theorem roth_density_bound uses
+    -- Mathlib's corners-based proof instead.)
+    sorry
 
 /-- Tower-of-squares threshold for Roth's theorem.
     roth_threshold 0 = 4, roth_threshold (k+1) = (roth_threshold k)².

--- a/research/problems/roth-theorem-k3/knowledge.md
+++ b/research/problems/roth-theorem-k3/knowledge.md
@@ -300,3 +300,27 @@ Attempted to fix the Mathlib breakages but could not verify without interactive 
 - `push_cast; linarith` → explicit `Nat.cast_sub` + `linarith`
 - `linarith` on ℂ → `linear_combination`
 Reverted these changes as the full fix requires an interactive Lean session.
+
+## Session 17 (2026-03-24, researcher-4)
+
+**Mode**: REVISIT
+**Outcome**: progress (build fix)
+
+### What I Did
+1. **Identified build errors**: `density_increment_dirichlet` else branch had `have hN1 : N = 1 := by omega` which fails because `hN : 4 ≤ N` is in scope. The branch was written when the hypothesis was weaker (`0 < N` or `1 < N`), and when it was strengthened to `4 ≤ N`, the else case (d < √N) became reachable for prime N but the N=1 argument became unsound.
+2. **Fixed build errors**: Replaced broken else branch (failed omega + downstream type errors) with a clean sorry + accurate documentation of what's needed (Dirichlet-based subprogression partition).
+3. **Verified build**: Docker build succeeds. 0 axioms, 1 sorry (dead code), 1580 lines, 3 linter warnings.
+4. **Updated metadata**: meta.json assumptions and lineCount updated.
+
+### Key Findings
+- The main theorem `roth_density_bound` is fully proved via Mathlib's `roth_3ap_theorem_nat` (corners theorem chain). The 1 sorry is in `density_increment_dirichlet`, a private helper used only by `density_chain`, which is itself never called.
+- The sorry is in Case 2: when `gcd(val(r), N) < Nat.sqrt N`, the coset partition gives M = d < √N, which doesn't satisfy the conclusion `Nat.sqrt N ≤ M`. This case genuinely needs Dirichlet approximation.
+- `DirichletApproximation.lean` is fully proved and available, but integrating it into the density increment argument requires ~100-200 lines of Lean (approximate character constancy on subprogressions, error bounds, density boost).
+
+### Files Modified
+- `proofs/Proofs/RothTheorem.lean` (lines 1414-1422: replaced broken else branch)
+- `src/data/proofs/roth-theorem-k3/meta.json` (lineCount, assumptions)
+
+### Next Steps
+- To eliminate the sorry: implement Dirichlet-based density increment in Case 2 using `DirichletApproximation.dirichlet_approximation`
+- This is optional since the main theorem is fully proved via Mathlib

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -43,8 +43,8 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 1596,
-    "assumptions": "No axioms. 1 sorry: density_increment_iter N=1 hard case (delta ∈ (0.99, 1]) — requires Dirichlet approximation to prevent descent reaching N=1 with high density. DirichletApproximation.lean is already proved.",
+    "lineCount": 1580,
+    "assumptions": "No axioms. 1 sorry in dead code: density_increment_dirichlet Case 2 (gcd < sqrt(N), requires Dirichlet-based subprogression partition). Main theorem roth_density_bound is fully proved via Mathlib's corners-theorem chain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -201,7 +201,7 @@
     ],
     "opens": [],
     "namespace": "Szemeredi.Roth",
-    "lineCount": 1596,
+    "lineCount": 1580,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 3

--- a/src/data/research/problems/roth-theorem-k3.json
+++ b/src/data/research/problems/roth-theorem-k3.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 16 reduced density_increment_large_M sorry to coprime case only. When gcd(val(r),N)≥2, the existing density_increment_lemma provides M≥2 directly. Remaining sorry only fires when r is coprime to N (all primes, some composites). File: 0 axioms, 2 sorries (both reduced), 1526 lines.",
+    "progressSummary": "PROGRESS: Fixed build errors in density_increment_dirichlet (omega N=1 failure with hN:4≤N). Else branch replaced with clean sorry+docs. File compiles: 0 axioms, 1 sorry (dead code), 1580 lines. Main theorem roth_density_bound fully proved via Mathlib.",
     "builtItems": [
       "Fixed apFree_singleton proof, Complex.abs -> norm, added apFree_subset, removed incorrect apFree_pair",
       "Build now succeeds: 0 axioms, 3 sorries",
@@ -70,7 +70,8 @@
       "Fixed 4 linter warnings: unused simp args (true_and, Finset.mem_univ), unused vars (_hg, _hAP, _hdelta1, _hdelta)",
       "density_increment_large_M: TRUE sorry for Dirichlet-based density increment (M>=2, M<N) in RothTheorem.lean",
       "Comprehensive documentation of elimination strategy for FALSE sorry in density_increment_iter",
-      "Partial proof of density_increment_large_M: M≥2 case via density_increment_lemma (sorry only for coprime/M=1 case)"
+      "Partial proof of density_increment_large_M: M≥2 case via density_increment_lemma (sorry only for coprime/M=1 case)",
+      "Fixed build errors in density_increment_dirichlet: replaced broken omega N=1 proof + downstream type errors with clean sorry"
     ],
     "insights": [
       "RothTheorem.lean had 3 build errors: deprecated Finset.not_mem_empty, broken apFree_singleton, non-existent Complex.abs",
@@ -122,7 +123,9 @@
       "density_increment_iter sorry (N=1, delta>0.99) is FALSE: conclusion requires |B|>M, impossible. Standard fix: Dirichlet approximation ensures M>=2",
       "density_increment_large_M (TRUE sorry): For N>=4, Dirichlet gives APs of length >=sqrt(N)>=2. Approximate Fourier analysis on APs gives density boost.",
       "To eliminate FALSE sorry: restructure roth_density_bound with N0=4^{2^K} so chain stays at M>=4. Requires density_increment_large_M proved.",
-      "For prime N: coset approach gives M=gcd(val(r),N)=1. AP-based (Dirichlet) approach gives M=floor(N/q)>=sqrt(N) instead."
+      "For prime N: coset approach gives M=gcd(val(r),N)=1. AP-based (Dirichlet) approach gives M=floor(N/q)>=sqrt(N) instead.",
+      "density_increment_dirichlet else branch had build error: omega tried N=1 with hN:4≤N hypothesis. Case 2 (d<sqrt(N)) is genuinely reachable for prime N. Fixed by replacing broken N=1 argument with clean sorry.",
+      "File compiles with 1 sorry (dead code only) + 0 axioms. Main theorem uses Mathlib roth_3ap_theorem_nat, not the Fourier-based density_increment_dirichlet."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Fix build errors in `density_increment_dirichlet` else branch: `omega` tried to prove `N = 1` with `hN : 4 ≤ N` in scope (broken since hypothesis was strengthened)
- Replaced broken proof (failed omega + downstream type errors) with clean sorry + documentation
- Main theorem `roth_density_bound` is fully proved via Mathlib's `roth_3ap_theorem_nat` — the sorry is in dead code (private helper never called)
- Docker build verified: 0 axioms, 1 sorry (dead code), 1580 lines

## Test plan
- [x] Docker build succeeds (`./proofs/scripts/docker-build.sh Proofs.RothTheorem`)
- [x] 0 axioms, 1 sorry (in unused `density_increment_dirichlet`)
- [x] Main theorem `roth_density_bound` has no sorry dependencies
- [x] Gallery metadata updated (lineCount, assumptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)