### PR TITLE
Fix: axiomCount metadata in 13 gallery entries

### DIFF
--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -77,7 +77,7 @@
       "mem_mostVisitedSet",
       "mostVisitedSet_nonempty"
     ],
-    "axiomCount": 23,
+    "axiomCount": 19,
     "lineCount": 283,
     "assumptions": "19 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
@@ -208,7 +208,7 @@
     ],
     "namespace": "Erdos1166",
     "lineCount": 283,
-    "axiomCount": 23,
+    "axiomCount": 19,
     "theoremCount": 8,
     "definitionCount": 1
   },

--- a/src/data/proofs/erdos-1177/meta.json
+++ b/src/data/proofs/erdos-1177/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 1177,
     "erdosUrl": "https://erdosproblems.com/1177",
     "erdosProblemStatus": "open",
-    "axiomCount": 18,
+    "axiomCount": 7,
     "lineCount": 206,
-    "assumptions": "18 axioms: Card, Card.le, Card.lt, and 15 more. See Lean source for complete statements.",
+    "assumptions": "7 axioms. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -142,7 +142,7 @@
     "opens": [],
     "namespace": "Erdos1177",
     "lineCount": 206,
-    "axiomCount": 18,
+    "axiomCount": 7,
     "theoremCount": 4,
     "definitionCount": 6
   }

--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -37,9 +37,9 @@
       "Formal statement of Kovač-Tao (2024) doubly exponential result",
       "Formal statement of irrationality threshold at β = 2"
     ],
-    "axiomCount": 8,
+    "axiomCount": 7,
     "lineCount": 217,
-    "assumptions": "9 axioms: cantorSeq_rational_sum, cantorSeq_shifted_rational, erdos_265_singleExp_achievable, and 6 more. See Lean source for complete statements.",
+    "assumptions": "7 axioms. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -149,7 +149,7 @@
     "opens": [],
     "namespace": "Erdos265",
     "lineCount": 217,
-    "axiomCount": 8,
+    "axiomCount": 7,
     "theoremCount": 2,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -27,9 +27,9 @@
         "module": "Mathlib.Data.Nat.Prime.Basic"
       }
     ],
-    "axiomCount": 4,
+    "axiomCount": 2,
     "lineCount": 86,
-    "assumptions": "4 axioms: small_k_covers, ErdosProblem279, ErdosProblem279_k3, and 1 more. See Lean source for complete statements.",
+    "assumptions": "2 axioms. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -108,7 +108,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 86,
-    "axiomCount": 4,
+    "axiomCount": 2,
     "theoremCount": 0,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -34,7 +34,7 @@
         "relation": "Erdős #143 studies dilation-avoiding sets, another problem where prime factorization structure controls set density"
       }
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "assumptions": "2 axiom declarations: `largestPrimeFactor` (definitional convenience, not a mathematical assumption — adds no mathematical content) and `balog_wooley_infinitely_many` (encodes the Balog-Wooley theorem, a deep mathematical result). No sorries.",
     "author": "Erdős-Graham (1980), Balog-Wooley (1998)",
     "mathlibDependencies": [
@@ -215,7 +215,7 @@
   "leanFile": {
     "lineCount": 131,
     "structureCount": 0,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 0,
     "lemmaCount": 0,
     "defCount": 5,

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -20,8 +20,8 @@
     "erdosNumber": 389,
     "erdosUrl": "https://erdosproblems.com/389",
     "erdosProblemStatus": "open",
-    "axiomCount": 3,
-    "assumptions": "7 axiom declarations: erdos_389 (main open conjecture), erdos_389_n2 (n=2 k=5 case), erdos_389_n3 (n=3 k=4 case), mehta_n4_minimal (minimalK(4) = 207), mehta_n4_minimality (207 is minimal), ratio_identity (product ratio formulation), consecutiveProd_binomial (binomial coefficient identity)",
+    "axiomCount": 2,
+    "assumptions": "2 axiom declarations: erdos_389 (main open conjecture), erdos_389_n2 (n=2 k=5 case). Previously axiomatized results now proved.",
     "lineCount": 98,
     "mathlib_version": "4.26.0"
   },
@@ -113,7 +113,7 @@
     ],
     "namespace": null,
     "lineCount": 98,
-    "axiomCount": 7,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -16,7 +16,7 @@
     ],
     "namespace": "Erdos504",
     "lineCount": 255,
-    "axiomCount": 16,
+    "axiomCount": 15,
     "theoremCount": 1,
     "definitionCount": 5
   },
@@ -37,9 +37,9 @@
     "erdosNumber": 504,
     "erdosUrl": "https://erdosproblems.com/504",
     "erdosProblemStatus": "solved",
-    "axiomCount": 16,
+    "axiomCount": 15,
     "lineCount": 255,
-    "assumptions": "16 axiom(s). No sorries.",
+    "assumptions": "15 axiom(s). No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -106,9 +106,9 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 15,
+    "axiomCount": 13,
     "lineCount": 328,
-    "assumptions": "15 axioms encoding mathematical hypotheses. See the Lean source for details."
+    "assumptions": "13 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #529: Self-Avoiding Walks**\n\nSelf-avoiding walks (SAWs) were first studied systematically by the chemist Paul Flory in 1949 as models for linear polymers in good solvents. Flory's mean-field prediction $\\nu = 3/(d+2)$ for the end-to-end distance exponent was remarkably accurate, setting the stage for decades of rigorous mathematical work.\n\nThe first rigorous high-dimensional result came from **Gordon Slade** (1987), who used the **lace expansion** — a perturbative technique introduced by Brydges and Spencer (1985) — to prove $d_k(n) \\sim D\\sqrt{n}$ for sufficiently large $k$. **Takashi Hara** and Slade (1991-92) refined this to all $k \\ge 5$, using computer-assisted bounds on the lace expansion coefficients. Their work established that mean-field behavior ($\\nu = 1/2$) holds above the upper critical dimension $d_c = 4$.\n\nThe low-dimensional case proved far more resistant. **Bernard Nienhuis** (1982) predicted $\\nu = 3/4$ in 2D using the exact solution of an O(n) loop model on the honeycomb lattice, and conformal field theory arguments connect 2D SAW to the SLE$_{8/3}$ process (Lawler, Schramm, Werner). The landmark result of **Hugo Duminil-Copin** and **Alan Hammond** (2013) proved $d_2(n) = o(n)$ (sub-ballistic growth) using a bridge decomposition argument, but the full Question 1 ($d_2(n)/\\sqrt{n} \\to \\infty$) remains open.\n\nThe definitive reference is the monograph *The Self-Avoiding Walk* by Madras and Slade (1993, 2nd ed. 2013). **Nathan Clisby** (2010) provided the most precise numerical estimates: $\\nu_3 \\approx 0.5876 \\pm 0.0002$.",
@@ -225,7 +225,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 328,
-    "axiomCount": 15,
+    "axiomCount": 13,
     "theoremCount": 6,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -22,7 +22,7 @@
     "erdosNumber": 686,
     "erdosUrl": "https://erdosproblems.com/686",
     "erdosProblemStatus": "open",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "prerequisites": [
       "Nat.factorial",
       "Nat.choose",
@@ -206,7 +206,7 @@
     ],
     "namespace": "Erdos686",
     "lineCount": 292,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 8
   }

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -19,9 +19,9 @@
     "sourceUrl": "https://erdosproblems.com/700",
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 175,
-    "assumptions": "6 axioms: f_upper_bound, f_lower_bound, f_semiprime, f_30, erdos_700_question2, erdos_700_question3. fBinom now defined (not axiomatized). f_prime_square proved from f_lower_bound.",
+    "assumptions": "5 axioms: f_upper_bound, f_lower_bound, f_semiprime, erdos_700_question2, erdos_700_question3. fBinom now defined (not axiomatized). f_prime_square proved from f_lower_bound.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -132,7 +132,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 175,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -76,7 +76,7 @@
       "multiplicity_trivial_upper theorem: multiplicity ≤ n²",
       "erdos_756 theorem: main result"
     ],
-    "axiomCount": 10,
+    "axiomCount": 7,
     "lineCount": 293,
     "assumptions": "10 axioms: (1) hopf_pannwitz — largest distance multiplicity ≤ n, (2) bhowmick_construction — existence of point set with rich distances, (3) bhowmick_main — ⌊n/4⌋ rich distances for large n, (4) bhowmick_general — ⌊n/(2(m+1))⌋ distances with multiplicity ≥ n+m, (5) clemen_dumitrescu_liu — superpolynomial grid richness, (6-10) supporting axioms for distance counting, grid construction, and asymptotic bounds. 1 sorry in construction details."
   },
@@ -223,7 +223,7 @@
     ],
     "namespace": "Erdos756",
     "lineCount": 293,
-    "axiomCount": 10,
+    "axiomCount": 7,
     "theoremCount": 8,
     "definitionCount": 15
   },

--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 929,
     "erdosUrl": "https://erdosproblems.com/929",
     "erdosProblemStatus": "open",
-    "axiomCount": 7,
+    "axiomCount": 6,
     "lineCount": 110,
-    "assumptions": "7 axiom(s) and 0 sorry(s). See the Lean source for details.",
+    "assumptions": "6 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -133,7 +133,7 @@
     ],
     "namespace": null,
     "lineCount": 110,
-    "axiomCount": 7,
+    "axiomCount": 6,
     "theoremCount": 1,
     "definitionCount": 5
   }

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -55,9 +55,9 @@
       "erdos_96_summary: proved conjunction of bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 294,
-    "assumptions": "5 axiom(s). No sorries."
+    "assumptions": "4 axiom(s). No sorries."
   },
   "overview": {
     "historicalContext": "Erdős and Moser conjectured that a convex n-gon has O(n) unit distance pairs. Despite progress from O(n log n) bounds (Füredi 1990, Aggarwal 2015), the conjecture remains open. The Edelsbrunner-Hajnal (1991) lower bound of 2n - 7 suggests the Erdős-Fishburn conjecture of exactly 2n may be tight. The unit distance problem for general point sets (Erdős Problem #89, 1946) asks for the maximum number of unit distance pairs among n points in the plane, with best known bounds Ω(n^{1+c/log log n}) and O(n^{4/3}). The convex restriction dramatically simplifies the problem: in a convex polygon, each distance can appear at most twice on each side, giving much sharper bounds.",
@@ -149,7 +149,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 294,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 2,
     "definitionCount": 10
   },


### PR DESCRIPTION
## Fix

Update stale `axiomCount` values in 13 gallery meta.json files to match actual `axiom` declarations in Lean source.

## Evidence

| Proof | Before | After | Delta |
|-------|--------|-------|-------|
| erdos-1177 | 18 | 7 | -11 |
| erdos-1166 | 23 | 19 | -4 |
| erdos-756 | 10 | 7 | -3 |
| erdos-279 | 4 | 2 | -2 |
| erdos-529 | 15 | 13 | -2 |
| erdos-265 | 8 | 7 | -1 |
| erdos-369 | 2 | 1 | -1 |
| erdos-389 | 3/7 | 2 | -1/-5 |
| erdos-504 | 16 | 15 | -1 |
| erdos-686 | 1 | 0 | -1 |
| erdos-700 | 6 | 5 | -1 |
| erdos-929 | 7 | 6 | -1 |
| erdos-96 | 5 | 4 | -1 |

All verified by `grep -c '^axiom ' <lean-file>`. All were overcounts caused by axioms being proved/removed without updating meta.json. No structure-encoded axioms found in any of these files.

`pnpm build` passes.

---
Automated fix by lean-mechanic agent.