### PR TITLE
Research: erdos-1137, erdos-1143 - Axiom/sorry elimination

### DIFF
--- a/proofs/Proofs/Erdos1137Problem.lean
+++ b/proofs/Proofs/Erdos1137Problem.lean
@@ -231,12 +231,54 @@ theorem erdosRatio_le_one (x : ℕ) (hx : x ≥ 2) : erdosRatio x ≤ 1 := by
       have := Finset.mem_range.mp hn; omega))
   exact Nat.mul_le_mul h1 h2
 
+/-- Prime gaps are unbounded: for any B, there exists n with primeGap n ≥ B.
+    Uses the factorial argument: (B+2)!+2, ..., (B+2)!+(B+2) are all composite,
+    giving B+1 consecutive composites, hence a prime gap of size ≥ B.
+    Proof follows the Galois connection between Nat.nth and Nat.count. -/
+private theorem primeGap_unbounded (B : ℕ) : ∃ n, B ≤ primeGap n := by
+  -- (B+2)!+2, ..., (B+2)!+(B+2) are all composite
+  set a := (B + 2)! + 2 with ha_def
+  have hcomp : ∀ j ≤ B, ¬ Nat.Prime (a + j) := by
+    intro j hj
+    have h_eq : a + j = (B + 2)! + (j + 2) := by rw [ha_def]; omega
+    rw [h_eq]; exact not_prime_factorial_add (B + 2) (j + 2) (by omega) (by omega)
+  -- c = #{primes < a}; c ≥ 1 since 2 < a
+  set c := Nat.count Nat.Prime a with hc_def
+  have hc_pos : 0 < c := by
+    rw [hc_def, Nat.lt_nth_iff_count_lt Nat.infinite_setOf_prime]
+    rw [Nat.nth_prime_zero_eq_two, ha_def]
+    have := Nat.factorial_pos (B + 2); omega
+  -- The (c-1)-th prime is below a (Galois connection: c-1 < count → nth(c-1) < a)
+  have h1 : nth Nat.Prime (c - 1) < a :=
+    (Nat.lt_nth_iff_count_lt Nat.infinite_setOf_prime).mp (by rw [← hc_def]; omega)
+  -- The c-th prime is ≥ a (Galois connection: count ≤ c → a ≤ nth c)
+  have h2 : a ≤ nth Nat.Prime c := by
+    rw [← Nat.count_le_iff_le_nth Nat.infinite_setOf_prime]
+  -- The c-th prime must skip the entire composite run [a, a+B]
+  have h3 : a + B + 1 ≤ nth Nat.Prime c := by
+    by_contra hlt
+    push_neg at hlt
+    -- If nth(c) < a + B + 1, then nth(c) ∈ [a, a+B] — but all of those are composite
+    set j := nth Nat.Prime c - a with hj_def
+    have hj_le : j ≤ B := by omega
+    have hj_eq : a + j = nth Nat.Prime c := by omega
+    exact hcomp j hj_le (hj_eq ▸ nth_prime_is_prime c)
+  -- primeGap(c-1) = nth(c) - nth(c-1) ≥ (a+B+1) - a = B+1 ≥ B
+  exact ⟨c - 1, by unfold primeGap; rw [show c - 1 + 1 = c from by omega]; omega⟩
+
 /-- The maximal prime gap tends to infinity.
-    Proof outline: For any B, the B-1 consecutive composites B!+2, ..., B!+B
-    (proved composite by not_prime_factorial_add) witness a prime gap ≥ B.
-    Full proof requires connecting the factorial composites to the nth-prime
-    enumeration (available via Nat.nth_surjective). -/
-axiom maxGap_tendsto_atTop : Tendsto (fun x => (maxGap x : ℝ)) atTop atTop
+    Proved from primeGap_unbounded: for any bound B, eventually maxGap x ≥ B. -/
+theorem maxGap_tendsto_atTop : Tendsto (fun x => (maxGap x : ℝ)) atTop atTop := by
+  rw [Filter.tendsto_atTop_atTop]
+  intro b
+  obtain ⟨B, hB⟩ := exists_nat_gt b
+  obtain ⟨n, hn⟩ := primeGap_unbounded B
+  exact ⟨n + 1, fun x hx => by
+    have h1 : primeGap n ≤ maxGap x :=
+      Finset.le_sup (f := primeGap) (Finset.mem_range.mpr (by omega))
+    calc b ≤ (B : ℝ) := le_of_lt hB
+      _ ≤ ((primeGap n : ℕ) : ℝ) := Nat.cast_le.mpr hn
+      _ ≤ ((maxGap x : ℕ) : ℝ) := Nat.cast_le.mpr h1⟩
 
 /-
 ## Summary
@@ -251,10 +293,11 @@ of consecutive prime gaps to the square of the maximum gap tends to 0.
 - dvd_factorial: k divides n! when 1 ≤ k ≤ n
 - not_prime_factorial_add: n!+k is composite for 2 ≤ k ≤ n
 - erdosRatio_le_one: ratio ≤ 1 (previously axiom, now PROVED)
+- primeGap_unbounded: ∀ B, ∃ n, primeGap n ≥ B (factorial + Galois connection)
+- maxGap_tendsto_atTop: max gap → ∞ (previously axiom, now PROVED)
 
-**Axioms (2)**:
+**Axioms (1)**:
 - erdos_1137: the main open conjecture (ratio → 0)
-- maxGap_tendsto_atTop: max gap → ∞ (provable via factorial, see doc)
 
 **Key Insights**:
 1. The unique odd prime gap is d_0 = 1 (between 2 and 3)

--- a/research/problems/erdos-1137/state.md
+++ b/research/problems/erdos-1137/state.md
@@ -1,7 +1,7 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T15:52:59.263Z
+**Phase**: ACT
+**Since**: 2026-03-24T12:00:16-07:00
 **Iteration**: 1
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -2563,11 +2563,11 @@
     },
     {
       "slug": "erdos-1137",
-      "phase": "COMPLETED",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-01-15T15:52:59.263Z",
       "status": "graduated",
-      "lastUpdate": "2026-03-24T05:17:00.048Z",
+      "lastUpdate": "2026-03-24T12:00:16-07:00",
       "completed": "2026-03-24T05:17:00.048Z"
     },
     {

--- a/src/data/proofs/erdos-1137/meta.json
+++ b/src/data/proofs/erdos-1137/meta.json
@@ -58,16 +58,18 @@
       "primeGap_zero/one/two/three: computed d_0=1, d_1=2, d_2=2, d_3=4",
       "nth_prime_not_even: for n ≥ 1, p_n is odd (via primality + ≥ 3)",
       "primeGap_even: for n ≥ 1, d_n is even (odd − odd)",
-      "primeGap_ge_two: for n ≥ 1, d_n ≥ 2 (even + positive)"
+      "primeGap_ge_two: for n ≥ 1, d_n ≥ 2 (even + positive)",
+      "primeGap_unbounded: for any B, ∃ n with primeGap n ≥ B (factorial argument + Nat.nth/count Galois connection)",
+      "maxGap_tendsto_atTop: max prime gap → ∞ (previously axiom, now PROVED from primeGap_unbounded)"
     ],
     "dateAdded": "2026-03-23",
-    "axiomCount": 2,
-    "lineCount": 271,
-    "assumptions": "2 axioms: erdos_1137 (the main open conjecture, ratio → 0), maxGap_tendsto_atTop (max gap → ∞, provable via factorial argument). erdosRatio_le_one PROVED from Finset.sup properties. Infrastructure: dvd_factorial, not_prime_factorial_add for future axiom elimination."
+    "axiomCount": 1,
+    "lineCount": 314,
+    "assumptions": "1 axiom: erdos_1137 (the main open conjecture, ratio → 0). All other results fully proved: maxGap_tendsto_atTop proved via factorial composites + Galois connection (Nat.nth/Nat.count), erdosRatio_le_one proved from Finset.sup properties."
   },
   "leanFile": {
     "path": "Proofs/Erdos1137Problem.lean",
-    "lineCount": 271,
+    "lineCount": 314,
     "namespace": "Erdos1137",
     "imports": [
       "Mathlib"
@@ -88,8 +90,8 @@
       "maxGap",
       "erdosRatio"
     ],
-    "axiomCount": 2,
-    "theoremCount": 20
+    "axiomCount": 1,
+    "theoremCount": 22
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-1137.json
+++ b/src/data/research/problems/erdos-1137.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 2 eliminated erdosRatio_le_one axiom (3→2). Proved it from Finset.sup_le + Nat.mul_le_mul. Added dvd_factorial and not_prime_factorial_add infrastructure for future maxGap_tendsto_atTop proof.",
+    "progressSummary": "AXIOM ELIMINATION: maxGap_tendsto_atTop proved (2->1 axioms). File: 22 theorems, 1 axiom (open conjecture), 0 sorries, 314 lines.",
     "builtItems": [
       "proofs/Proofs/Erdos1137Problem.lean - 210 lines, 17 theorems, 3 axioms",
       "src/data/proofs/erdos-1137/ - complete gallery entry",
@@ -51,7 +51,9 @@
       "PROVED erdosRatio_le_one: ratio ≤ 1 (axiom → theorem via Finset.sup properties)",
       "PROVED dvd_factorial: k | n! for 1 ≤ k ≤ n (by induction on n)",
       "PROVED not_prime_factorial_add: n!+k is composite for 2 ≤ k ≤ n",
-      "Updated gallery metadata: axiomCount 3→2, theoremCount 17→20"
+      "Updated gallery metadata: axiomCount 3→2, theoremCount 17→20",
+      "PROVED primeGap_unbounded: for all B, exists n with primeGap n >= B",
+      "PROVED maxGap_tendsto_atTop: Tendsto maxGap atTop atTop (from primeGap_unbounded)"
     ],
     "insights": [
       "d_0 = 1 is the unique odd prime gap (transition from even prime 2 to odd prime 3)",
@@ -63,16 +65,15 @@
       "erdosRatio_le_one proof: key is Finset.sup_le + both factors ≤ maxGap x since n-1 < x when n < x",
       "dvd_factorial proved by induction: if k = n+1 use dvd_mul_right, if k ≤ n use IH + dvd_mul_of_dvd_right",
       "not_prime_factorial_add: k | (n!+k) and 2 ≤ k < n!+k contradicts primality via eq_one_or_self_of_dvd",
-      "Finset.le_sup needs explicit (f := primeGap) annotation when function is ambiguous in context"
+      "Finset.le_sup needs explicit (f := primeGap) annotation when function is ambiguous in context",
+      "maxGap_tendsto_atTop PROVED via factorial composites and Galois connection Nat.nth/Nat.count"
     ],
     "mathlibGaps": [
       "No direct nth_prime_one theorem in Mathlib (proved via Nat.nth_count + decide)",
       "Nat.even_sub signature should be verified against current Mathlib version"
     ],
     "nextSteps": [
-      "Prove maxGap_tendsto_atTop: connect factorial composites to primeGap enumeration via Nat.nth properties",
-      "Need: exists_large_primeGap B ≥ 2 : ∃ n, primeGap n ≥ B (factorial composites → gap witness)",
-      "Key missing step: finding n such that nth Prime n ≤ B!+1 < nth Prime (n+1)"
+      "Only erdos_1137 (open conjecture) remains as axiom"
     ],
     "markdown": "# Erdős #1137 - Knowledge Base\n\n## Problem Statement\n\nLet $d_n = p_{n+1} - p_n$, where $p_n$ is the $n$th prime. Is it true that\n$$\\frac{\\max_{n<x} d_n d_{n-1}}{(\\max_{n<x} d_n)^2} \\to 0$$\nas $x \\to \\infty$?\n\n## Status\n\n**Erdős Database Status**: OPEN\n**Reference**: [Va99, §1.2]\n\n**Tractability Score**: 6/10 (open conjecture, but basic properties provable)\n**Aristotle Suitable**: Partially (basic lemmas yes, main conjecture no)\n\n## Session 1 (2026-03-23, researcher-5)\n\n**Decision**: DEEP DIVE\n**Outcome**: Created complete formalization with 17 theorems proved\n\nKey results:\n- Defined primeGap, maxGap, erdosRatio\n- Proved gap positivity, parity, and specific values\n- Stated main conjecture as axiom\n- Created gallery entry\n\n## Tags\n\n- erdos\n- number-theory\n- prime-gaps\n- analytic-number-theory\n\n## Related Problems\n\n- Erdős #6 (Cramér's conjecture on maximal prime gaps)\n- PrimeGapBounds.lean (Bertrand postulate infrastructure)\n\n## References\n\n- [Va99] Varga (1999), Survey §1.2\n- Cramér, H. (1936). On the order of magnitude of the difference between consecutive prime numbers.\n- Google DeepMind formal-conjectures: FormalConjectures/ErdosProblems/1137.lean\n"
   },


### PR DESCRIPTION
## Summary
Two proof improvements in a single branch:

### erdos-1137: Prove maxGap_tendsto_atTop (axiom 2→1)
- Proved `primeGap_unbounded`: for any B, ∃ n with primeGap n ≥ B (factorial composites + Nat.nth/count Galois connection)
- Proved `maxGap_tendsto_atTop`: max prime gap → ∞
- File now: 22 theorems, 1 axiom (open conjecture only), 0 sorries, 314 lines

### erdos-1143: Prove single_prime_lower (sorry 1→0)
- Proved `single_prime_lower`: coveringFunction {p} k ≥ k/p via injection i ↦ (⌈a/p⌉ + i) * p
- File now: 0 sorries, 3 axioms (all open conjectures)

## Test plan
- [x] Docker build verified for both files
- [x] meta.json updated for both problems
- [x] Knowledge bases updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)