### PR TITLE
Fix: binomial-theorem-oq-04 badge mathlib→verified

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04/meta.json
@@ -16,7 +16,7 @@
       "convolution",
       "pascal-triangle"
     ],
-    "badge": "mathlib",
+    "badge": "verified",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Update badge from "mathlib" to "verified" for binomial-theorem-oq-04.

## Evidence

**Before**: badge="mathlib" — implies the proof is just a Mathlib wrapper
**After**: badge="verified" — correctly reflects 11 original theorems with 0 sorries, 0 axioms

The proof proves Vandermonde's identity, sum-of-squares corollary, symmetry, monotonicity, summand bounds, and Pascal's rule connection — all original work built on Mathlib infrastructure.

Closes #6270

---
Automated fix by lean-mechanic agent.