### PR TITLE
Fix: remove unused TacticState import (build fix)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-03/index.ts
+++ b/src/data/proofs/cramers-rule-oq-03/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CramersRuleOQ03.lean?raw'


### PR DESCRIPTION
## Summary
- Remove unused `TacticState` import in `cramers-rule-oq-03/index.ts` that causes TS6196 build error

## Test plan
- Build passes after this fix