### PR TITLE
Fix: 209 proofs status formalized→axiomatized (axiomCount > 0)

### DIFF
--- a/src/data/proofs/basel-problem-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Open (Apéry 1978, Rivoal 2000, Zudilin 2001 for partial results)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_theorem",
     "date": "1978",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ZetaFiveIrrationality.lean",
     "tags": [
       "analysis",
@@ -19,7 +19,7 @@
       "number-theory",
       "research"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 1,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Open (Hermite 1873, Lindemann 1882 for components; Nesterenko 1996 for related results)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Transcendental_number",
     "date": "1873",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ETranscendentalOQ01.lean",
     "tags": [
       "transcendental-numbers",
@@ -20,7 +20,7 @@
       "schanuel",
       "nesterenko"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 3,
     "theoremCount": 13,
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -7,7 +7,7 @@
     "author": "Kostochka-Pyber (1988)",
     "sourceUrl": "https://erdosproblems.com/1018",
     "date": "1988",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos1018Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "topological-graph-theory",
       "extremal-combinatorics"
     ],
-    "badge": "pending",
+    "badge": "axiom",
     "sorries": 7,
     "erdosNumber": 1018,
     "erdosUrl": "https://erdosproblems.com/1018",

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -7,7 +7,7 @@
     "author": "Miklós Simonovits (PhD thesis, supervised by Turán)",
     "sourceUrl": "https://erdosproblems.com/1019",
     "date": "1970s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1019Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "extremal-combinatorics",
       "turan-theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 1019,
     "erdosUrl": "https://erdosproblems.com/1019",

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1020",
     "date": "1965",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1020Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "turan-type",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 1020,
     "erdosUrl": "https://erdosproblems.com/1020",

--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Simonovits",
     "sourceUrl": "https://erdosproblems.com/1021",
     "date": "1971",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1021Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "turan-type",
       "bipartite-graphs"
     ],
-    "badge": "pending",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 1021,
     "erdosUrl": "https://erdosproblems.com/1021",

--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/103",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos103Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1030/meta.json
+++ b/src/data/proofs/erdos-1030/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Sós (problem), Burr-Erdős-Faudree-Schelp (1989 solution)",
     "sourceUrl": "https://erdosproblems.com/1030",
     "date": "1989",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1030Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "combinatorics",
       "growth-rates"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 1030,
     "erdosUrl": "https://erdosproblems.com/1030",

--- a/src/data/proofs/erdos-1031/meta.json
+++ b/src/data/proofs/erdos-1031/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Fajtlowicz-Staton, Prömel-Rödl (1999)",
     "sourceUrl": "https://erdosproblems.com/1031",
     "date": "1999",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1031Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "regular-graphs",
       "universality"
     ],
-    "badge": "pending",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 1031,
     "erdosUrl": "https://erdosproblems.com/1031",

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Laskar (1985), Fan (1988)",
     "sourceUrl": "https://erdosproblems.com/1033",
     "date": "1985",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1033Problem.lean",
     "tags": [
       "graph-theory",

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Faudree (conjecture), Ma-Tang (disproof)",
     "sourceUrl": "https://erdosproblems.com/1034",
     "date": "2020",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1034Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "triangles",
       "counterexample"
     ],
-    "badge": "pending",
+    "badge": "axiom",
     "sorries": 12,
     "erdosNumber": 1034,
     "erdosUrl": "https://erdosproblems.com/1034",

--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -7,7 +7,7 @@
     "author": "Chen-Erdős (conjecture), Cambie-Chan-Hunter (disproof)",
     "sourceUrl": "https://erdosproblems.com/1037",
     "date": "2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1037Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "ramsey-theory",
       "counterexample"
     ],
-    "badge": "pending",
+    "badge": "axiom",
     "sorries": 9,
     "erdosNumber": 1037,
     "erdosUrl": "https://erdosproblems.com/1037",

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Herzog-Piranian (problem), Pommerenke (1961), KLR (2025)",
     "sourceUrl": "https://erdosproblems.com/1039",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos1039Problem.lean",
     "tags": [
       "complex-analysis",
@@ -16,7 +16,7 @@
       "lemniscates",
       "open-problem"
     ],
-    "badge": "pending",
+    "badge": "axiom",
     "sorries": 9,
     "erdosNumber": 1039,
     "erdosUrl": "https://erdosproblems.com/1039",

--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1975)",
     "sourceUrl": "https://erdosproblems.com/104",
     "date": "1975",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos104Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "unit-circles",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 104,
     "erdosUrl": "https://erdosproblems.com/104",

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Herzog-Piranian (1958), Erdős-Netanyahu (1973)",
     "sourceUrl": "https://erdosproblems.com/1040",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1040Problem.lean",
     "tags": [
       "complex-analysis",
@@ -16,7 +16,7 @@
       "potential-theory",
       "open-problem"
     ],
-    "badge": "pending",
+    "badge": "axiom",
     "sorries": 7,
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",

--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Herzog, Piranian (1958); Pommerenke (1961)",
     "sourceUrl": "https://erdosproblems.com/1043",
     "date": "1958-1961",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1043Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "measure-theory",
       "geometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 8,
     "erdosNumber": 1043,
     "erdosUrl": "https://erdosproblems.com/1043",

--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Herzog-Piranian (1958), Pommerenke (1961)",
     "sourceUrl": "https://erdosproblems.com/1048",
     "date": "1961",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1048Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "lemniscates",
       "disproved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 10,
     "erdosNumber": 1048,
     "erdosUrl": "https://erdosproblems.com/1048",

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1948), Chowla (conjecture)",
     "sourceUrl": "https://erdosproblems.com/1049",
     "date": "1948",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1049Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1054-oq-01/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (via Guy's 'Unsolved Problems in Number Theory')",
     "sourceUrl": "https://erdosproblems.com/1054",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1054AlmostAllOQ01.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "open-problem",
       "research"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 1054,
     "erdosUrl": "https://erdosproblems.com/1054",

--- a/src/data/proofs/erdos-106/meta.json
+++ b/src/data/proofs/erdos-106/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/106",
     "date": "1930s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos106Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "optimization",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 106,
     "erdosUrl": "https://erdosproblems.com/106",

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, documented in Guy [Gu04] Problem B11",
     "sourceUrl": "https://erdosproblems.com/1060",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1060Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos-Szekeres",
     "sourceUrl": "https://erdosproblems.com/107",
     "date": "1935",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos107Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "convex-geometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 107,
     "erdosUrl": "https://erdosproblems.com/107",

--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Larman-Rogers, Croft, ACMVZ",
     "sourceUrl": "https://erdosproblems.com/1070",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1070Problem.lean",
     "tags": [
       "combinatorics",
@@ -17,7 +17,7 @@
       "independence-number",
       "hadwiger-nelson"
     ],
-    "badge": "open",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 1070,
     "erdosUrl": "https://erdosproblems.com/1070",

--- a/src/data/proofs/erdos-1080/meta.json
+++ b/src/data/proofs/erdos-1080/meta.json
@@ -7,7 +7,7 @@
     "author": "De Caen-Székely (1992 disproof), Lazebnik-Ustimenko-Woldar (1994 improved bounds)",
     "sourceUrl": "https://erdosproblems.com/1080",
     "date": "1992",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1080Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -7,7 +7,7 @@
     "author": "Graham-Selfridge (k=3), Hunter (general k via Hales-Jewett)",
     "sourceUrl": "https://erdosproblems.com/1090",
     "date": "1975",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1090Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -7,7 +7,7 @@
     "author": "Ecklund-Erdős-Selfridge (1974)",
     "sourceUrl": "https://erdosproblems.com/1095",
     "date": "1974",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos1095Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "smooth-numbers",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/1100",
     "date": "1978",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos1100Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1104/meta.json
+++ b/src/data/proofs/erdos-1104/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1104",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1104Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1129/meta.json
+++ b/src/data/proofs/erdos-1129/meta.json
@@ -7,7 +7,7 @@
     "author": "Kilgore-Cheney (1976), Kilgore (1977), de Boor-Pinkus (1978)",
     "sourceUrl": "https://erdosproblems.com/1129",
     "date": "1978",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1129Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1143/meta.json
+++ b/src/data/proofs/erdos-1143/meta.json
@@ -7,7 +7,7 @@
     "author": "researcher-5",
     "sourceUrl": "https://erdosproblems.com/1143",
     "date": "2026-03-11",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1143Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1144/meta.json
+++ b/src/data/proofs/erdos-1144/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1144",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1144Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1150/meta.json
+++ b/src/data/proofs/erdos-1150/meta.json
@@ -7,7 +7,7 @@
     "author": "researcher-5",
     "sourceUrl": "https://erdosproblems.com/1150",
     "date": "2026-03-11",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1150Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1166",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1166Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1176/meta.json
+++ b/src/data/proofs/erdos-1176/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1176",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1176Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Gyárfás",
     "sourceUrl": "https://erdosproblems.com/135",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos135Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "distinct-distances",
       "disproved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 6,
     "erdosNumber": 135,
     "erdosUrl": "https://erdosproblems.com/135",

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -7,7 +7,7 @@
     "author": "Roth (1953), Kelley-Meka (2023)",
     "sourceUrl": "https://erdosproblems.com/140",
     "date": "2023",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos140Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "roth-number",
       "kelley-meka"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 140,
     "erdosUrl": "https://erdosproblems.com/140",

--- a/src/data/proofs/erdos-150/meta.json
+++ b/src/data/proofs/erdos-150/meta.json
@@ -7,7 +7,7 @@
     "author": "Bradac (2024 proof), Erdos-Nesetril (problem), Seymour (construction)",
     "sourceUrl": "https://erdosproblems.com/150",
     "date": "2024",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos150Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -7,7 +7,7 @@
     "author": "Pilatte (2023), Erdős-Turán (1941)",
     "sourceUrl": "https://erdosproblems.com/157",
     "date": "2023",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos157Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "additive-combinatorics",
       "density"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 157,
     "erdosUrl": "https://erdosproblems.com/157",

--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős & Freud",
     "erdosNumber": 160,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos160Problem.lean",
     "sourceUrl": "https://erdosproblems.com/160",
     "erdosUrl": "https://erdosproblems.com/160",

--- a/src/data/proofs/erdos-162/meta.json
+++ b/src/data/proofs/erdos-162/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1990)",
     "sourceUrl": "https://erdosproblems.com/162",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos162Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "discrepancy",
       "graph-colouring"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 162,
     "erdosUrl": "https://erdosproblems.com/162",

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -7,7 +7,7 @@
     "author": "Kim (1995 breakthrough), Shearer (1983 upper), Hefty-Horn-King-Pfender (2025 lower)",
     "sourceUrl": "https://erdosproblems.com/165",
     "date": "2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos165Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -7,7 +7,7 @@
     "author": "Nelson (1950), Isbell (1950), de Grey (2018)",
     "sourceUrl": "https://erdosproblems.com/171",
     "date": "2018",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos171Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "unit-distance",
       "hadwiger-nelson"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 171,
     "erdosUrl": "https://erdosproblems.com/171",

--- a/src/data/proofs/erdos-175/meta.json
+++ b/src/data/proofs/erdos-175/meta.json
@@ -7,7 +7,7 @@
     "author": "Granville-Ramaré (1996), Sárközy (1985), Sander, Erdős-Kolesnik",
     "sourceUrl": "https://erdosproblems.com/175",
     "date": "1996",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos175Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-176/meta.json
+++ b/src/data/proofs/erdos-176/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham (1980), Spencer (1973), Erdős (1963)",
     "sourceUrl": "https://erdosproblems.com/176",
     "date": "1963",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos176Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-179/meta.json
+++ b/src/data/proofs/erdos-179/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/179",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos179Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/183",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos183Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-191/meta.json
+++ b/src/data/proofs/erdos-191/meta.json
@@ -7,7 +7,7 @@
     "author": "Rödl (2003), Conlon-Fox-Sudakov (2013)",
     "sourceUrl": "https://erdosproblems.com/191",
     "date": "2003",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos191Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-195/meta.json
+++ b/src/data/proofs/erdos-195/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham [ErGr79, ErGr80]",
     "sourceUrl": "https://erdosproblems.com/195",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos195Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-204/meta.json
+++ b/src/data/proofs/erdos-204/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham (conjecture), Adenwalla (2025 proof)",
     "sourceUrl": "https://erdosproblems.com/204",
     "date": "2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos204Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "divisors",
       "solved"
     ],
-    "badge": "solved",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 204,
     "erdosUrl": "https://erdosproblems.com/204",

--- a/src/data/proofs/erdos-207/meta.json
+++ b/src/data/proofs/erdos-207/meta.json
@@ -7,7 +7,7 @@
     "author": "Kwan-Sah-Sawhney-Simkin (2022 proof)",
     "sourceUrl": "https://erdosproblems.com/207",
     "date": "2022",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos207Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-211/meta.json
+++ b/src/data/proofs/erdos-211/meta.json
@@ -7,7 +7,7 @@
     "author": "Beck (1983), Szemerédi-Trotter (1983)",
     "sourceUrl": "https://erdosproblems.com/211",
     "date": "1983",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos211Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -7,7 +7,7 @@
     "author": "Juhász",
     "sourceUrl": "https://erdosproblems.com/214",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos214Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "unit-distance",
       "combinatorial-geometry"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 214,
     "erdosUrl": "https://erdosproblems.com/214",

--- a/src/data/proofs/erdos-224/meta.json
+++ b/src/data/proofs/erdos-224/meta.json
@@ -7,7 +7,7 @@
     "author": "Danzer-Grünbaum (1962), Kuiper-Boerdijk (d=3)",
     "sourceUrl": "https://erdosproblems.com/224",
     "date": "1962",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos224Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-227/meta.json
+++ b/src/data/proofs/erdos-227/meta.json
@@ -7,7 +7,7 @@
     "author": "Clunie-Hayman (1964)",
     "sourceUrl": "https://erdosproblems.com/227",
     "date": "1964",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos227Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -7,7 +7,7 @@
     "author": "Moser (1966), Ambrus et al. (2023)",
     "sourceUrl": "https://erdosproblems.com/232",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos232Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-235/meta.json
+++ b/src/data/proofs/erdos-235/meta.json
@@ -7,7 +7,7 @@
     "author": "Hooley (1965)",
     "sourceUrl": "https://erdosproblems.com/235",
     "date": "1965",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos235Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-237/meta.json
+++ b/src/data/proofs/erdos-237/meta.json
@@ -7,7 +7,7 @@
     "author": "Chen and Ding (2022 solution), Erdős (1950 special case)",
     "sourceUrl": "https://erdosproblems.com/237",
     "date": "2022",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos237Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1974)",
     "sourceUrl": "https://erdosproblems.com/260",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos260Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "sequences",
       "number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 260,
     "erdosUrl": "https://erdosproblems.com/260",

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Vjekoslav Kovač, Terence Tao",
     "sourceUrl": "https://erdosproblems.com/268",
     "date": "1950s-2024",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos268Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "number-theory",
       "Egyptian-fractions"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 12,
     "erdosNumber": 268,
     "erdosUrl": "https://erdosproblems.com/268",

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -7,7 +7,7 @@
     "author": "Haight (1979 solution)",
     "sourceUrl": "https://erdosproblems.com/277",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos277Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -7,7 +7,7 @@
     "author": "Sidon, Erdős",
     "sourceUrl": "https://erdosproblems.com/29",
     "date": "1932",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos29Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "additive-basis",
       "explicit-construction"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 29,
     "erdosUrl": "https://erdosproblems.com/29",

--- a/src/data/proofs/erdos-290/meta.json
+++ b/src/data/proofs/erdos-290/meta.json
@@ -7,7 +7,7 @@
     "author": "van Doorn (2024 solution)",
     "sourceUrl": "https://erdosproblems.com/290",
     "date": "2024",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos290Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -7,7 +7,7 @@
     "author": "Bloom (2021)",
     "sourceUrl": "https://erdosproblems.com/299",
     "date": "2021",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos299Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos",
     "sourceUrl": "https://erdosproblems.com/3",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos3Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "arithmetic-progressions",
       "szemeredi"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 3,
     "erdosUrl": "https://erdosproblems.com/3",

--- a/src/data/proofs/erdos-302/meta.json
+++ b/src/data/proofs/erdos-302/meta.json
@@ -7,7 +7,7 @@
     "author": "Stijn Cambie, Wouter van Doorn",
     "sourceUrl": "https://erdosproblems.com/302",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos302Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "sum-free-sets",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 9,
     "erdosNumber": 302,
     "erdosUrl": "https://erdosproblems.com/302",

--- a/src/data/proofs/erdos-305/meta.json
+++ b/src/data/proofs/erdos-305/meta.json
@@ -7,7 +7,7 @@
     "author": "Yokota, Liu-Sawhney",
     "sourceUrl": "https://erdosproblems.com/305",
     "date": "1988",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos305Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "unit-fractions",
       "greedy-algorithm"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 305,
     "erdosUrl": "https://erdosproblems.com/305",

--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbeau (1976), Cambie",
     "sourceUrl": "https://erdosproblems.com/307",
     "date": "1976",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos307Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "egyptian-fractions",
       "reciprocals"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 6,
     "erdosNumber": 307,
     "erdosUrl": "https://erdosproblems.com/307",

--- a/src/data/proofs/erdos-308/meta.json
+++ b/src/data/proofs/erdos-308/meta.json
@@ -7,7 +7,7 @@
     "author": "Croot (1999)",
     "sourceUrl": "https://erdosproblems.com/308",
     "date": "1999",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos308Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -7,7 +7,7 @@
     "author": "Yokota (1997, 2002), Croot (1999)",
     "sourceUrl": "https://erdosproblems.com/309",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos309Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-314/meta.json
+++ b/src/data/proofs/erdos-314/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/314",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos314Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-318/meta.json
+++ b/src/data/proofs/erdos-318/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Straus (1975), Sattler (1975, 1982)",
     "sourceUrl": "https://erdosproblems.com/318",
     "date": "1982",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos318Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-32/meta.json
+++ b/src/data/proofs/erdos-32/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1954), Kolountzakis (1996), Ruzsa (1998)",
     "sourceUrl": "https://erdosproblems.com/32",
     "date": "1954-1998",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos32Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "prime-number-theory",
       "density-bounds"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 32,
     "erdosUrl": "https://erdosproblems.com/32",

--- a/src/data/proofs/erdos-320/meta.json
+++ b/src/data/proofs/erdos-320/meta.json
@@ -7,7 +7,7 @@
     "author": "Bleicher-Erdős (1975-76), Bettin-Grenié-Molteni-Sanna (2025)",
     "sourceUrl": "https://erdosproblems.com/320",
     "date": "1975-2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos320Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-338/meta.json
+++ b/src/data/proofs/erdos-338/meta.json
@@ -7,7 +7,7 @@
     "author": "Kelly, Hennecart, Hegyvári, Plagne",
     "sourceUrl": "https://erdosproblems.com/338",
     "date": "1957-2007",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos338Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "restricted-order",
       "combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 338,
     "erdosUrl": "https://erdosproblems.com/338",

--- a/src/data/proofs/erdos-34/meta.json
+++ b/src/data/proofs/erdos-34/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos (1977); Disproved by Hegyvari (1986), Konieczny (2015)",
     "sourceUrl": "https://erdosproblems.com/34",
     "date": "1977",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos34Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "permutations",
       "disproved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 34,
     "erdosUrl": "https://erdosproblems.com/34",

--- a/src/data/proofs/erdos-352/meta.json
+++ b/src/data/proofs/erdos-352/meta.json
@@ -7,7 +7,7 @@
     "author": "Freiling-Mauldin (2002 partial), Erdős (unpublished special cases)",
     "sourceUrl": "https://erdosproblems.com/352",
     "date": "1978-present",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos352Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "lebesgue-measure",
       "convexity"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 352,
     "erdosUrl": "https://erdosproblems.com/352",

--- a/src/data/proofs/erdos-353/meta.json
+++ b/src/data/proofs/erdos-353/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Mauldin, Kovač (2023), Koizumi (2025)",
     "sourceUrl": "https://erdosproblems.com/353",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos353Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Harzheim, Hegyvári, Weisenberg",
     "sourceUrl": "https://erdosproblems.com/357",
     "date": "1977-1986",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos357Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "sequences",
       "distinct-sums"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 16,
     "erdosNumber": 357,
     "erdosUrl": "https://erdosproblems.com/357",

--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -7,7 +7,7 @@
     "author": "Conlon-Fox-Pham (2021 solution), Alon-Erdős (1996 bounds)",
     "sourceUrl": "https://erdosproblems.com/360",
     "date": "2021",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos360Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-363/meta.json
+++ b/src/data/proofs/erdos-363/meta.json
@@ -7,7 +7,7 @@
     "author": "Ulas (2005), Bauer-Bennett (2007), Bennett-Van Luijk (2012)",
     "sourceUrl": "https://erdosproblems.com/363",
     "date": "2005-2012",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos363Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-371/meta.json
+++ b/src/data/proofs/erdos-371/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Carl Pomerance, Joni Teräväinen, Terence Tao, Zhiwei Wang",
     "sourceUrl": "https://erdosproblems.com/371",
     "date": "1978-2021",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos371Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "density",
       "analytic-number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 371,
     "erdosUrl": "https://erdosproblems.com/371",

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -7,7 +7,7 @@
     "author": "Granville-Ramare (1996), Aggarwal-Cambie (observation)",
     "sourceUrl": "https://erdosproblems.com/378",
     "date": "1996",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos378Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-381/meta.json
+++ b/src/data/proofs/erdos-381/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (question), Nicolas (disproof)",
     "sourceUrl": "https://erdosproblems.com/381",
     "date": "1971",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos381Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-39/meta.json
+++ b/src/data/proofs/erdos-39/meta.json
@@ -7,7 +7,7 @@
     "author": "Open Problem ($500 prize)",
     "sourceUrl": "https://erdosproblems.com/39",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos39Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "infinite-sequences",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 39,
     "erdosUrl": "https://erdosproblems.com/39",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -7,7 +7,7 @@
     "author": "Cambie (2020s)",
     "sourceUrl": "https://erdosproblems.com/392",
     "date": "2020",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos392Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "asymptotics",
       "number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",

--- a/src/data/proofs/erdos-408/meta.json
+++ b/src/data/proofs/erdos-408/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Granville-Pomerance-Spiro (1990)",
     "sourceUrl": "https://erdosproblems.com/408",
     "date": "1990",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos408Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-415/meta.json
+++ b/src/data/proofs/erdos-415/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1936)",
     "sourceUrl": "https://erdosproblems.com/415",
     "date": "1936",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos415Problem.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "permutation-patterns",
       "arithmetic-functions"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "sorries": 14,
     "erdosNumber": 415,
     "erdosUrl": "https://erdosproblems.com/415",

--- a/src/data/proofs/erdos-417/meta.json
+++ b/src/data/proofs/erdos-417/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1979, 1998)",
     "sourceUrl": "https://erdosproblems.com/417",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos417Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-43/meta.json
+++ b/src/data/proofs/erdos-43/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/43",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos43Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-433/meta.json
+++ b/src/data/proofs/erdos-433/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham (1972), Dixmier (1990)",
     "sourceUrl": "https://erdosproblems.com/433",
     "date": "1972",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos433Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-434/meta.json
+++ b/src/data/proofs/erdos-434/meta.json
@@ -7,7 +7,7 @@
     "author": "Kiss (2002)",
     "sourceUrl": "https://erdosproblems.com/434",
     "date": "2002",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos434Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "extremal-combinatorics",
       "coin-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 8,
     "erdosNumber": 434,
     "erdosUrl": "https://erdosproblems.com/434",

--- a/src/data/proofs/erdos-437/meta.json
+++ b/src/data/proofs/erdos-437/meta.json
@@ -7,7 +7,7 @@
     "author": "Bui-Pratt-Zaharescu (2024), Tao (bounds)",
     "sourceUrl": "https://erdosproblems.com/437",
     "date": "2024",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos437Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-441/meta.json
+++ b/src/data/proofs/erdos-441/meta.json
@@ -7,7 +7,7 @@
     "author": "Chen-Dai",
     "sourceUrl": "https://erdosproblems.com/441",
     "date": "2006-2007",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos441Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "lcm",
       "extremal-combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 441,
     "erdosUrl": "https://erdosproblems.com/441",

--- a/src/data/proofs/erdos-448/meta.json
+++ b/src/data/proofs/erdos-448/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Tenenbaum (1981 disproof), Ford (2008 asymptotic)",
     "sourceUrl": "https://erdosproblems.com/448",
     "date": "1981",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos448Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Paul Erdős, Ernest Croot, Mehtaab Sawhney",
     "erdosNumber": 45,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -17,7 +17,7 @@
       "divisor-function",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "sourceUrl": "https://erdosproblems.com/45",
     "erdosUrl": "https://erdosproblems.com/45",

--- a/src/data/proofs/erdos-453/meta.json
+++ b/src/data/proofs/erdos-453/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Ernst Straus",
     "sourceUrl": "https://erdosproblems.com/453",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos453Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "convex-geometry",
       "prime-number-graph"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 453,
     "erdosUrl": "https://erdosproblems.com/453",

--- a/src/data/proofs/erdos-454/meta.json
+++ b/src/data/proofs/erdos-454/meta.json
@@ -7,7 +7,7 @@
     "author": "Carl Pomerance (1979 partial result)",
     "sourceUrl": "https://erdosproblems.com/454",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos454Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "limsup",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 7,
     "erdosNumber": 454,
     "erdosUrl": "https://erdosproblems.com/454",

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/456",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos456Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "natural-density",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 456,
     "erdosUrl": "https://erdosproblems.com/456",

--- a/src/data/proofs/erdos-465/meta.json
+++ b/src/data/proofs/erdos-465/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/465",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos465Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "distances",
       "solved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 465,
     "erdosUrl": "https://erdosproblems.com/465",

--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -7,7 +7,7 @@
     "author": "da Silva-Hamidoune (1994)",
     "sourceUrl": "https://erdosproblems.com/476",
     "date": "1994",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos476Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -7,7 +7,7 @@
     "author": "Szemerédi (1976 solution), Erdős (1972 original)",
     "sourceUrl": "https://erdosproblems.com/490",
     "date": "1976",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos490Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-492/meta.json
+++ b/src/data/proofs/erdos-492/meta.json
@@ -7,7 +7,7 @@
     "author": "Schmidt (1969 counterexample)",
     "sourceUrl": "https://erdosproblems.com/492",
     "date": "1969",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos492Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-499/meta.json
+++ b/src/data/proofs/erdos-499/meta.json
@@ -7,7 +7,7 @@
     "author": "Marcus-Minc (1962 proof), Erdős (problem)",
     "sourceUrl": "https://erdosproblems.com/499",
     "date": "1962",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos499Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, András Hajnal",
     "sourceUrl": "https://erdosproblems.com/501",
     "date": "1960",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos501Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "combinatorics",
       "independence"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 501,
     "erdosUrl": "https://erdosproblems.com/501",

--- a/src/data/proofs/erdos-511/meta.json
+++ b/src/data/proofs/erdos-511/meta.json
@@ -7,7 +7,7 @@
     "author": "Pommerenke (1961 disproof), Pólya (1928 upper bound)",
     "sourceUrl": "https://erdosproblems.com/511",
     "date": "1961",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos511Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -7,7 +7,7 @@
     "author": "Konyagin (1981), McGehee-Pigno-Smith (1981)",
     "sourceUrl": "https://erdosproblems.com/512",
     "date": "1981",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos512Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-516/meta.json
+++ b/src/data/proofs/erdos-516/meta.json
@@ -7,7 +7,7 @@
     "author": "Fuchs (1963), Kovári (1965)",
     "sourceUrl": "https://erdosproblems.com/516",
     "date": "1963",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos516Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-531/meta.json
+++ b/src/data/proofs/erdos-531/meta.json
@@ -7,7 +7,7 @@
     "author": "Balogh-Eberhard-Narayanan-Treglown-Wagner (2017 lower bound), Folkman (existence)",
     "sourceUrl": "https://erdosproblems.com/531",
     "date": "2017",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos531Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-537/meta.json
+++ b/src/data/proofs/erdos-537/meta.json
@@ -7,7 +7,7 @@
     "author": "Ruzsa (counterexample), described by Erdős",
     "sourceUrl": "https://erdosproblems.com/537",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos537Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-545/meta.json
+++ b/src/data/proofs/erdos-545/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham",
     "sourceUrl": "https://erdosproblems.com/545",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos545Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "Ramsey theory",
       "combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 12,
     "erdosNumber": 545,
     "erdosUrl": "https://erdosproblems.com/545",

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Sós (1963), partial: Brandt-Dobson (1996), Saclé-Wozniak (1997)",
     "sourceUrl": "https://erdosproblems.com/548",
     "date": "1963",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos548Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "erdos-sos",
       "erdos"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 6,
     "erdosNumber": 548,
     "erdosUrl": "https://erdosproblems.com/548",

--- a/src/data/proofs/erdos-564/meta.json
+++ b/src/data/proofs/erdos-564/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Hajnal, and Rado (1965)",
     "sourceUrl": "https://erdosproblems.com/564",
     "date": "1965",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos564Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "combinatorics",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 564,
     "erdosUrl": "https://erdosproblems.com/564",

--- a/src/data/proofs/erdos-565/meta.json
+++ b/src/data/proofs/erdos-565/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Rödl (proposed), Aragão et al. (solved)",
     "sourceUrl": "https://erdosproblems.com/565",
     "date": "2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos565Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-57/meta.json
+++ b/src/data/proofs/erdos-57/meta.json
@@ -7,7 +7,7 @@
     "author": "Liu-Montgomery",
     "sourceUrl": "https://erdosproblems.com/57",
     "date": "2020",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos57Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "combinatorics",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 57,
     "erdosUrl": "https://erdosproblems.com/57",

--- a/src/data/proofs/erdos-572/meta.json
+++ b/src/data/proofs/erdos-572/meta.json
@@ -7,7 +7,7 @@
     "author": "Benson (1966 for k=3,5), Lazebnik-Ustimenko-Woldar (1995 general)",
     "sourceUrl": "https://erdosproblems.com/572",
     "date": "1966",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos572Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-589/meta.json
+++ b/src/data/proofs/erdos-589/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (origin), Füredi (1991), Furstenberg-Katznelson (1991), Balogh-Solymosi (2018)",
     "sourceUrl": "https://erdosproblems.com/589",
     "date": "~1980s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos589Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-59/meta.json
+++ b/src/data/proofs/erdos-59/meta.json
@@ -7,7 +7,7 @@
     "author": "Morris-Saxton",
     "sourceUrl": "https://erdosproblems.com/59",
     "date": "2016",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos59Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "combinatorics",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 59,
     "erdosUrl": "https://erdosproblems.com/59",

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, András Hajnal, Eric Milner, Jean Larson",
     "sourceUrl": "https://erdosproblems.com/601",
     "date": "1970",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos601Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "ordinals",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 14,
     "erdosNumber": 601,
     "erdosUrl": "https://erdosproblems.com/601",

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1985), Erdős-Salamon (1988)",
     "sourceUrl": "https://erdosproblems.com/606",
     "date": "1988",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos606Problem.lean",
     "tags": [
       "discrete-geometry",
@@ -15,7 +15,7 @@
       "combinatorial-geometry",
       "erdos"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 11,
     "erdosNumber": 606,
     "erdosUrl": "https://erdosproblems.com/606",

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -7,7 +7,7 @@
     "author": "Szemerédi-Trotter (1983)",
     "sourceUrl": "https://erdosproblems.com/607",
     "date": "1983",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos607Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "counting",
       "asymptotics"
     ],
-    "badge": "solved",
+    "badge": "axiom",
     "sorries": 20,
     "erdosNumber": 607,
     "erdosUrl": "https://erdosproblems.com/607",

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Gallai-Tuza",
     "sourceUrl": "https://erdosproblems.com/610",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos610Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "independent-sets",
       "open-problem"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "sorries": 17,
     "erdosNumber": 610,
     "erdosUrl": "https://erdosproblems.com/610",

--- a/src/data/proofs/erdos-611/meta.json
+++ b/src/data/proofs/erdos-611/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Gallai-Tuza, Bollobás-Erdős",
     "sourceUrl": "https://erdosproblems.com/611",
     "date": "1992",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos611Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "threshold-functions",
       "open"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "sorries": 13,
     "erdosNumber": 611,
     "erdosUrl": "https://erdosproblems.com/611",

--- a/src/data/proofs/erdos-612/meta.json
+++ b/src/data/proofs/erdos-612/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Pach-Pollack-Tuza (1989), counterexamples by Czabarka-Singgih-Székely (2021)",
     "sourceUrl": "https://erdosproblems.com/612",
     "date": "1989",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos612Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "counterexample",
       "open-problem"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "sorries": 16,
     "erdosNumber": 612,
     "erdosUrl": "https://erdosproblems.com/612",

--- a/src/data/proofs/erdos-613/meta.json
+++ b/src/data/proofs/erdos-613/meta.json
@@ -7,7 +7,7 @@
     "author": "Pikhurko (disproof), Tao (Lean verification), Faudree (partial)",
     "sourceUrl": "https://erdosproblems.com/613",
     "date": "2000s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos613Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "counterexample",
       "lean-verified"
     ],
-    "badge": "solved",
+    "badge": "axiom",
     "sorries": 12,
     "erdosNumber": 613,
     "erdosUrl": "https://erdosproblems.com/613",

--- a/src/data/proofs/erdos-620/meta.json
+++ b/src/data/proofs/erdos-620/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Rogers (1962), bounds: Bollobás-Hind, Krivelevich, Mubayi-Verstraete",
     "sourceUrl": "https://erdosproblems.com/620",
     "date": "1962",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos620Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "extremal-graph-theory",
       "erdos"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 620,
     "erdosUrl": "https://erdosproblems.com/620",

--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Hajnal (1958)",
     "sourceUrl": "https://erdosproblems.com/623",
     "date": "1958",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos623Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "combinatorics",
       "independence"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "mathlib_version": "4.26.0",
     "sorries": 6,
     "erdosNumber": 623,

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (upper bound), Kostochka (lower bound)",
     "sourceUrl": "https://erdosproblems.com/626",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos626Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "asymptotics",
       "open-problem"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "mathlib_version": "4.26.0",
     "sorries": 15,
     "erdosNumber": 626,

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (asymptotics), Tutte-Zykov (constructions)",
     "sourceUrl": "https://erdosproblems.com/627",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos627Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "asymptotics",
       "open-problem"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "sorries": 16,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Lovász (conjecture), Brown-Jung (a=b=3), Balogh-Kostochka-Prince-Stiebitz (special cases)",
     "sourceUrl": "https://erdosproblems.com/628",
     "date": "1968",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos628Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "clique-free",
       "open-problem"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Rubin-Taylor (problem), Alon-Tarsi (solution 1992)",
     "sourceUrl": "https://erdosproblems.com/630",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos630Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "bipartite-graphs",
       "solved"
     ],
-    "badge": "solved",
+    "badge": "axiom",
     "sorries": 15,
     "erdosNumber": 630,
     "erdosUrl": "https://erdosproblems.com/630",

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Rubin-Taylor (problem), Thomassen (upper bound), Voigt (lower bound)",
     "sourceUrl": "https://erdosproblems.com/631",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos631Problem.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "choosability",
       "topological-graph-theory"
     ],
-    "badge": "solved",
+    "badge": "axiom",
     "sorries": 10,
     "erdosNumber": 631,
     "erdosUrl": "https://erdosproblems.com/631",

--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Rubin-Taylor (1980 conjecture), Dvořák-Hu-Sereni (2019 disproof)",
     "sourceUrl": "https://erdosproblems.com/632",
     "date": "2019",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos632Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "counterexample",
       "disproved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 632,
     "erdosUrl": "https://erdosproblems.com/632",

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (problem), Beeson (negative results), Soifer (similar case), Snover-Waiveris-Williams, Zhang (2025)",
     "sourceUrl": "https://erdosproblems.com/634",
     "date": "ongoing",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos634Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "congruent-triangles",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 7,
     "erdosNumber": 634,
     "erdosUrl": "https://erdosproblems.com/634",

--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Faudree-Sós (problem), Kwan-Sudakov (2021 solution)",
     "sourceUrl": "https://erdosproblems.com/636",
     "date": "2021",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos636Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "induced-subgraphs",
       "counting"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 4,
     "erdosNumber": 636,
     "erdosUrl": "https://erdosproblems.com/636",

--- a/src/data/proofs/erdos-641/meta.json
+++ b/src/data/proofs/erdos-641/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Hajnal (problem), Janzer-Steiner-Sudakov (2024 disproof)",
     "sourceUrl": "https://erdosproblems.com/641",
     "date": "2024",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos641Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "counterexample",
       "disproved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 641,
     "erdosUrl": "https://erdosproblems.com/641",

--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -7,7 +7,7 @@
     "author": "Hamburger-Szegedy (problem), Chen-Erdős-Staton (1996), Draganić-Methuku-Munhá Correia-Sudakov (2024)",
     "sourceUrl": "https://erdosproblems.com/642",
     "date": "ongoing",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos642Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "diagonals",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 7,
     "erdosNumber": 642,
     "erdosUrl": "https://erdosproblems.com/642",

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -7,7 +7,7 @@
     "author": "Open Problem (bounds by Füredi, Pikhurko-Verstraëte)",
     "sourceUrl": "https://erdosproblems.com/643",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos643Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "extremal-combinatorics",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 4,
     "erdosNumber": 643,
     "erdosUrl": "https://erdosproblems.com/643",

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -7,7 +7,7 @@
     "author": "Open Problem (n=24 case verified computationally)",
     "sourceUrl": "https://erdosproblems.com/647",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos647Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "highly-composite",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 647,
     "erdosUrl": "https://erdosproblems.com/647",

--- a/src/data/proofs/erdos-648/meta.json
+++ b/src/data/proofs/erdos-648/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (problem), Stijn Cambie (2025 solution)",
     "sourceUrl": "https://erdosproblems.com/648",
     "date": "2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos648Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -7,7 +7,7 @@
     "author": "Moree-Osburn (2006), Lund-Sheffer",
     "sourceUrl": "https://erdosproblems.com/659",
     "date": "2006",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos659Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "distance-problems",
       "lattices"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 659,
     "erdosUrl": "https://erdosproblems.com/659",

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -5,7 +5,7 @@
   "description": "For 1-separated points in ℝ², is the number of pairs at distance ≤ t maximized by the triangular lattice? f(1)=6, f(√3)=12, f(3)=18. Erdős–Lovász–Vesztergombi. Open.",
   "meta": {
     "erdosNumber": 662,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -15,7 +15,7 @@
       "open"
     ],
     "sorries": 3,
-    "badge": "wip",
+    "badge": "axiom",
     "sourceUrl": "https://erdosproblems.com/662",
     "erdosUrl": "https://erdosproblems.com/662",
     "axiomCount": 3,

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -7,7 +7,7 @@
     "author": "Chung (1992 disproof), Brouwer-Dejter-Thomassen (1993), Conder (1993)",
     "sourceUrl": "https://erdosproblems.com/666",
     "date": "1992",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos666Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos",
     "sourceUrl": "https://erdosproblems.com/668",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos668Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-682/meta.json
+++ b/src/data/proofs/erdos-682/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (problem), Gafni-Tao (solution, 2025)",
     "sourceUrl": "https://erdosproblems.com/682",
     "date": "2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos682Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/684",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos684Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/695",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos695Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-698/meta.json
+++ b/src/data/proofs/erdos-698/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Szekeres (problem, 1978), Bergman (solution, 2011)",
     "sourceUrl": "https://erdosproblems.com/698",
     "date": "2011",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos698Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (problem), Frankl-Rödl (solved, 1987)",
     "sourceUrl": "https://erdosproblems.com/703",
     "date": "1987",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos703Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "extremal",
       "intersection-problems"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 703,
     "erdosUrl": "https://erdosproblems.com/703",

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Sauer (1981)",
     "sourceUrl": "https://erdosproblems.com/719",
     "date": "1981",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos719Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-72/meta.json
+++ b/src/data/proofs/erdos-72/meta.json
@@ -7,7 +7,7 @@
     "author": "Verstraëte (2005), Liu & Montgomery (2020)",
     "sourceUrl": "https://erdosproblems.com/72",
     "date": "2020",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos72Problem.lean",
     "tags": [
       "graph-theory",
@@ -18,7 +18,7 @@
       "solved",
       "regularity-method"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 72,
     "erdosUrl": "https://erdosproblems.com/72",

--- a/src/data/proofs/erdos-727/meta.json
+++ b/src/data/proofs/erdos-727/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Graham, Ruzsa, Straus",
     "sourceUrl": "https://erdosproblems.com/727",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos727Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "open-problem",
       "partially-solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 727,
     "erdosUrl": "https://erdosproblems.com/727",

--- a/src/data/proofs/erdos-728/meta.json
+++ b/src/data/proofs/erdos-728/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos, Graham, Ruzsa, Straus (1975)",
     "sourceUrl": "https://erdosproblems.com/728",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos728Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -7,7 +7,7 @@
     "author": "Barreto-Leeham (solution), Erdős (1968)",
     "sourceUrl": "https://erdosproblems.com/729",
     "date": "2020s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos729Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-73/meta.json
+++ b/src/data/proofs/erdos-73/meta.json
@@ -7,7 +7,7 @@
     "author": "Bruce Reed (1999)",
     "sourceUrl": "https://erdosproblems.com/73",
     "date": "1999",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos73Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "erdos",
       "structural-graph-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 73,
     "erdosUrl": "https://erdosproblems.com/73",

--- a/src/data/proofs/erdos-733/meta.json
+++ b/src/data/proofs/erdos-733/meta.json
@@ -7,7 +7,7 @@
     "author": "Szemeredi-Trotter (1983 solution), Erdos (problem and lower bound)",
     "sourceUrl": "https://erdosproblems.com/733",
     "date": "1983",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos733Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-740/meta.json
+++ b/src/data/proofs/erdos-740/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Hajnal (conjecture), Rödl (partial result)",
     "sourceUrl": "https://erdosproblems.com/740",
     "date": "1981",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos740Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Rödl-Tuza (1985 disproof), Erdős-Hajnal-Szemerédi (1982 conjecture)",
     "sourceUrl": "https://erdosproblems.com/744",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos744Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Rényi (1966), Pósa (1976), Korshunov (1977), Komlós-Szemerédi (1983)",
     "sourceUrl": "https://erdosproblems.com/746",
     "date": "1966",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos746Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -7,7 +7,7 @@
     "author": "Green (2004), Sapozhenko (2003)",
     "sourceUrl": "https://erdosproblems.com/748",
     "date": "2004",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos748Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -7,7 +7,7 @@
     "author": "Bondy-Vince (1998)",
     "sourceUrl": "https://erdosproblems.com/751",
     "date": "1998",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos751Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-753/meta.json
+++ b/src/data/proofs/erdos-753/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Rubin, and Taylor",
     "sourceUrl": "https://erdosproblems.com/753",
     "date": "1992",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos753Problem.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "solved",
       "disproved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 753,
     "erdosUrl": "https://erdosproblems.com/753",

--- a/src/data/proofs/erdos-755/meta.json
+++ b/src/data/proofs/erdos-755/meta.json
@@ -7,7 +7,7 @@
     "author": "Clemen-Dumitrescu-Liu (2025 solution), Lenz/Erdős-Purdy (1975 construction)",
     "sourceUrl": "https://erdosproblems.com/755",
     "date": "2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos755Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -7,7 +7,7 @@
     "author": "Bhowmick (2024 solution), Clemen-Dumitrescu-Liu (2025 grid results)",
     "sourceUrl": "https://erdosproblems.com/756",
     "date": "2024",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos756Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-757/meta.json
+++ b/src/data/proofs/erdos-757/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Sós (lower bound); Gyárfás-Lehel (1995, bounds)",
     "sourceUrl": "https://erdosproblems.com/757",
     "date": "1995",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos757Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "additive-combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 757,
     "erdosUrl": "https://erdosproblems.com/757",

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -7,7 +7,7 @@
     "author": "Gruslys & Letzter (2020)",
     "sourceUrl": "https://erdosproblems.com/76",
     "date": "2020",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos76Problem.lean",
     "tags": [
       "graph-theory",

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -5,7 +5,7 @@
   "description": "Must a graph with large chromatic number have large dichromatic number? Must a graph with large cochromatic number contain a subgraph with large dichromatic number? The dichromatic number is the minimum k such that every orientation admits an acyclic k-coloring. Status: OPEN.",
   "meta": {
     "erdosNumber": 761,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos761Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos-Graham (lower bound), Alon-Freiman (1988, upper bound)",
     "sourceUrl": "https://erdosproblems.com/771",
     "date": "1988",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos771Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-773/meta.json
+++ b/src/data/proofs/erdos-773/meta.json
@@ -7,7 +7,7 @@
     "author": "Alon-Erdős (1985), Lefmann-Thiele (1995)",
     "sourceUrl": "https://erdosproblems.com/773",
     "date": "1985",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos773Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "additive-combinatorics",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 773,
     "erdosUrl": "https://erdosproblems.com/773",

--- a/src/data/proofs/erdos-79/meta.json
+++ b/src/data/proofs/erdos-79/meta.json
@@ -7,7 +7,7 @@
     "author": "Wigderson (2024)",
     "sourceUrl": "https://erdosproblems.com/79",
     "date": "2024",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos79Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "ramsey-numbers",
       "extremal-graphs"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 79,
     "erdosUrl": "https://erdosproblems.com/79",

--- a/src/data/proofs/erdos-793/meta.json
+++ b/src/data/proofs/erdos-793/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1938)",
     "sourceUrl": "https://erdosproblems.com/793",
     "date": "1938",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos793Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "primes",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 793,
     "erdosUrl": "https://erdosproblems.com/793",

--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -7,7 +7,7 @@
     "author": "Alon (1991 solution), Erdos-Purdy (problem and lower bound)",
     "sourceUrl": "https://erdosproblems.com/798",
     "date": "1991",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos798Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-815/meta.json
+++ b/src/data/proofs/erdos-815/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős & Hajnal (conjecture), Narins-Pokrovskiy-Szabó (disproof)",
     "sourceUrl": "https://erdosproblems.com/815",
     "date": "2017",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos815Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "counterexample",
       "disproved"
     ],
-    "badge": "disproved",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 815,
     "erdosUrl": "https://erdosproblems.com/815",

--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős and Sárközy; Partial result proved",
     "sourceUrl": "https://erdosproblems.com/817",
     "date": "1991",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos817Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "subset-sums",
       "extremal-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 4,
     "erdosNumber": 817,
     "erdosUrl": "https://erdosproblems.com/817",

--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -7,7 +7,7 @@
     "author": "Solymosi (2009)",
     "sourceUrl": "https://erdosproblems.com/818",
     "date": "2009",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos818Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1974 partial), van Doorn (improvement)",
     "sourceUrl": "https://erdosproblems.com/820",
     "date": "1974",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos820Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-83/meta.json
+++ b/src/data/proofs/erdos-83/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Ko-Rado (1961 conjecture), Ahlswede-Khachatrian (1997 proof)",
     "sourceUrl": "https://erdosproblems.com/83",
     "date": "1997",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos83Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/831",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos831Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-835/meta.json
+++ b/src/data/proofs/erdos-835/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Rosenfeld",
     "sourceUrl": "https://erdosproblems.com/835",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos835Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-858/meta.json
+++ b/src/data/proofs/erdos-858/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/858",
     "date": "1966",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos858Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "multiplicative-structure",
       "density"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 858,
     "erdosUrl": "https://erdosproblems.com/858",

--- a/src/data/proofs/erdos-859/meta.json
+++ b/src/data/proofs/erdos-859/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1970)",
     "sourceUrl": "https://erdosproblems.com/859",
     "date": "1970",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos859Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "density",
       "asymptotics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 7,
     "erdosNumber": 859,
     "erdosUrl": "https://erdosproblems.com/859",

--- a/src/data/proofs/erdos-860/meta.json
+++ b/src/data/proofs/erdos-860/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Pomerance, Selfridge, Ruzsa",
     "sourceUrl": "https://erdosproblems.com/860",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos860Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/866",
     "date": "1975",
     "mathlib_version": "4.26.0",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos866Problem.lean",
     "tags": [
       "additive-combinatorics",

--- a/src/data/proofs/erdos-868/meta.json
+++ b/src/data/proofs/erdos-868/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős & Nathanson (1979, 1989)",
     "sourceUrl": "https://erdosproblems.com/868",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos868Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "bases",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 868,
     "erdosUrl": "https://erdosproblems.com/868",

--- a/src/data/proofs/erdos-869/meta.json
+++ b/src/data/proofs/erdos-869/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős and Nathanson (1988 question)",
     "sourceUrl": "https://erdosproblems.com/869",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos869Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-870/meta.json
+++ b/src/data/proofs/erdos-870/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Nathanson (1979), Härtter (1956)",
     "sourceUrl": "https://erdosproblems.com/870",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos870Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Deshouillers, Erdős",
     "sourceUrl": "https://erdosproblems.com/875",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos875Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "binary-representation",
       "popcount"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 875,
     "erdosUrl": "https://erdosproblems.com/875",

--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Graham, Łuczak-Schoen, Deshouillers-Erdős-Melfi",
     "sourceUrl": "https://erdosproblems.com/876",
     "date": "2000",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos876Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -7,7 +7,7 @@
     "author": "Cameron-Erdős (problem), Łuczak-Schoen (solved), BLST (sharp bounds)",
     "sourceUrl": "https://erdosproblems.com/877",
     "date": "2001",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos877Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "counting",
       "asymptotics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 5,
     "erdosNumber": 877,
     "erdosUrl": "https://erdosproblems.com/877",

--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1935), Mordell (1937)",
     "sourceUrl": "https://erdosproblems.com/898",
     "date": "1935",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos898Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "triangles",
       "classical"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 8,
     "erdosNumber": 898,
     "erdosUrl": "https://erdosproblems.com/898",

--- a/src/data/proofs/erdos-900/meta.json
+++ b/src/data/proofs/erdos-900/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (problem), Ajtai-Komlós-Szemerédi (1981 solution)",
     "sourceUrl": "https://erdosproblems.com/900",
     "date": "1981",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos900Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "probabilistic-method",
       "phase-transition"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 900,
     "erdosUrl": "https://erdosproblems.com/900",

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/919",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos919Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-933/meta.json
+++ b/src/data/proofs/erdos-933/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1976), Steinerberger",
     "sourceUrl": "https://erdosproblems.com/933",
     "date": "1976",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos933Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-934/meta.json
+++ b/src/data/proofs/erdos-934/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Nešetřil",
     "sourceUrl": "https://erdosproblems.com/934",
     "date": "1988",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos934Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-940/meta.json
+++ b/src/data/proofs/erdos-940/meta.json
@@ -7,7 +7,7 @@
     "author": "Baker-Brüdern (1994), Heath-Brown (1988)",
     "sourceUrl": "https://erdosproblems.com/940",
     "date": "1976",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos940Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "density",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 940,
     "erdosUrl": "https://erdosproblems.com/940",

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Ivić (1986, problem), Heath-Brown (1988, proof)",
     "sourceUrl": "https://erdosproblems.com/941",
     "date": "1988",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos941Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-95/meta.json
+++ b/src/data/proofs/erdos-95/meta.json
@@ -7,7 +7,7 @@
     "author": "Guth & Katz (2015)",
     "sourceUrl": "https://erdosproblems.com/95",
     "date": "2015",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos95Problem.lean",
     "tags": [
       "discrete-geometry",

--- a/src/data/proofs/erdos-951/meta.json
+++ b/src/data/proofs/erdos-951/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (problem), Beurling (generalized primes theory)",
     "sourceUrl": "https://erdosproblems.com/951",
     "date": "1937-present",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos951Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Motzkin, Gordon, et al. (1963) - misattributed to Erdős",
     "sourceUrl": "https://erdosproblems.com/952",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos952Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-956/meta.json
+++ b/src/data/proofs/erdos-956/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Pach (problem and 1990 bounds)",
     "sourceUrl": "https://erdosproblems.com/956",
     "date": "ongoing",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos956Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "convex-sets",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 11,
     "erdosNumber": 956,
     "erdosUrl": "https://erdosproblems.com/956",

--- a/src/data/proofs/erdos-957/meta.json
+++ b/src/data/proofs/erdos-957/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos-Pach (1990), Dumitrescu (2019)",
     "sourceUrl": "https://erdosproblems.com/957",
     "date": "2019",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos957Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/960",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos960Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-961/meta.json
+++ b/src/data/proofs/erdos-961/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Sylvester, Schur, Erdős, Jutila, Ramachandra, Shorey (1934-1974)",
     "sourceUrl": "https://erdosproblems.com/961",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos961Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "prime-factors",
       "analytic-number-theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 961,
     "erdosUrl": "https://erdosproblems.com/961",

--- a/src/data/proofs/erdos-964/meta.json
+++ b/src/data/proofs/erdos-964/meta.json
@@ -7,7 +7,7 @@
     "author": "Eberhard (2025)",
     "sourceUrl": "https://erdosproblems.com/964",
     "date": "2025",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos964Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-97/meta.json
+++ b/src/data/proofs/erdos-97/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1946); Danzer counterexample (1987); Fishburn-Reeds (1992)",
     "sourceUrl": "https://erdosproblems.com/97",
     "date": "1946",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos97Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "unit-distance",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 97,
     "erdosUrl": "https://erdosproblems.com/97",

--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos (1946), Moser (1952), Erdos-Fishburn (1994), Dumitrescu (2006), Nivasch-Pach-Pinchasi-Zerbib (2013)",
     "sourceUrl": "https://erdosproblems.com/982",
     "date": "1946",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos982Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-986/meta.json
+++ b/src/data/proofs/erdos-986/meta.json
@@ -7,7 +7,7 @@
     "author": "Spencer (1977, k=3), Mattheus-Verstraete (2023, k=4)",
     "sourceUrl": "https://erdosproblems.com/986",
     "date": "1977-2023",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos986Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-991/meta.json
+++ b/src/data/proofs/erdos-991/meta.json
@@ -7,7 +7,7 @@
     "author": "Brauchart (2008 bound), Marzo-Mas (2021 improvement)",
     "sourceUrl": "https://erdosproblems.com/991",
     "date": "2008",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos991Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-996/meta.json
+++ b/src/data/proofs/erdos-996/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1949), Matsuyama (1966)",
     "sourceUrl": "https://erdosproblems.com/996",
     "date": "1949-1966",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos996Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "lacunary-sequences",
       "fourier-series"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 996,
     "erdosUrl": "https://erdosproblems.com/996",

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "fundamental-theorem-calculus-oq-01",
   "description": "Formalizes the Lebesgue generalization of the Fundamental Theorem of Calculus. Defines absolutely continuous functions (not yet in Mathlib), states the Lebesgue FTC (AC → a.e. differentiable, integral of derivative = net change), and connects to Mathlib's Vitali covering theorem, Lebesgue density theorem, and monotone a.e. differentiability.",
   "meta": {
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "analysis",
       "measure-theory",


### PR DESCRIPTION
## Fix

Updated 209 meta.json files where `status` was `"formalized"` but `axiomCount > 0`. Per the axiom integrity policy, these should be `"axiomatized"` with badge `"axiom"`.

## Evidence

**Before**: 209 proofs had `status: "formalized"` with `axiomCount > 0` (ranging from 1 to 23 axioms)
**After**: All 209 now have `status: "axiomatized"` and `badge: "axiom"`

Also fixed 102 badge mismatches (wip→axiom: 52, mathlib→axiom: 21, pending→axiom: 7, conjecture→axiom: 7, solved→axiom: 5, formalized→axiom: 5, open→axiom: 4, disproved→axiom: 1).

Build validated: `pnpm build` succeeds.

---
Automated fix by lean-mechanic agent.