### PR TITLE
Research: erdos-1008-oq-01 - Eliminate both sorries (2→0)

### DIFF
--- a/proofs/Proofs/Erdos1008OQ01.lean
+++ b/proofs/Proofs/Erdos1008OQ01.lean
@@ -229,7 +229,26 @@ axiom cfs_admissible_exists : ∃ c : ℝ, IsAdmissibleConstant c
 
 /-- The optimal constant is positive (follows from CFS admissibility) -/
 theorem optimal_constant_pos : optimalConstant > 0 := by
-  sorry -- Requires showing sSup is positive given cfs_admissible_exists
+  obtain ⟨c₀, hc₀⟩ := cfs_admissible_exists
+  -- Show the set of admissible constants is bounded above by 1
+  have hbdd : BddAbove {c : ℝ | IsAdmissibleConstant c} := by
+    refine ⟨1, fun c hc => ?_⟩
+    -- Specialize to Fin 2, completeGraph (which has exactly 1 edge)
+    obtain ⟨H, hdr, hsub, _, hge⟩ := hc.2 (Fin 2) (completeGraph (Fin 2))
+    letI := hdr
+    -- completeGraph (Fin 2) has 1 edge
+    have hone : (completeGraph (Fin 2)).edgeFinset.card = 1 := by native_decide
+    -- H is a subgraph, so H has ≤ 1 edge
+    have hle : H ≤ completeGraph (Fin 2) := hsub
+    have hH_sub : H.edgeFinset ⊆ (completeGraph (Fin 2)).edgeFinset := by
+      intro e he; rw [SimpleGraph.mem_edgeFinset] at he ⊢
+      exact SimpleGraph.edgeSet_mono hle he
+    have hH_card : H.edgeFinset.card ≤ 1 := by linarith [Finset.card_le_card hH_sub]
+    -- From hge: (H.edgeFinset.card : ℝ) ≥ c * (1 : ℝ) ^ (2/3) = c
+    simp only [hone, Nat.cast_one, Real.one_rpow, mul_one] at hge
+    linarith [show (H.edgeFinset.card : ℝ) ≤ 1 from by exact_mod_cast hH_card]
+  -- c₀ is in the set and is positive; sSup ≥ c₀ > 0
+  exact lt_of_lt_of_le hc₀.1 (le_csSup hbdd hc₀)
 
 /-
 ## Part VI: The Open Question
@@ -260,7 +279,47 @@ theorem c4free_mono {G H : SimpleGraph V} (hle : H ≤ G) (hG : IsC4Free G) : Is
 /-- A graph with at most 3 edges is C₄-free -/
 theorem c4free_of_few_edges (G : SimpleGraph V) [DecidableRel G.Adj]
     (h : G.edgeFinset.card ≤ 3) : IsC4Free G := by
-  sorry -- A C₄ requires at least 4 edges
+  intro ⟨a, b, c, d, hab, hbc, hcd, hda, hac, hbd, e_ab, e_bc, e_cd, e_da⟩
+  -- The 4 cycle edges are in G.edgeFinset
+  have m1 : s(a, b) ∈ G.edgeFinset := G.mem_edgeFinset.mpr e_ab
+  have m2 : s(b, c) ∈ G.edgeFinset := G.mem_edgeFinset.mpr e_bc
+  have m3 : s(c, d) ∈ G.edgeFinset := G.mem_edgeFinset.mpr e_cd
+  have m4 : s(d, a) ∈ G.edgeFinset := G.mem_edgeFinset.mpr e_da
+  -- The 4 edges are pairwise distinct (via Sym2.eq_iff)
+  have ne12 : s(a, b) ≠ s(b, c) := by
+    intro heq; rcases Sym2.eq_iff.mp heq with ⟨rfl, _⟩ | ⟨rfl, _⟩ <;> contradiction
+  have ne13 : s(a, b) ≠ s(c, d) := by
+    intro heq; rcases Sym2.eq_iff.mp heq with ⟨rfl, _⟩ | ⟨h1, _⟩
+    · exact hac rfl
+    · exact hda h1.symm
+  have ne14 : s(a, b) ≠ s(d, a) := by
+    intro heq; rcases Sym2.eq_iff.mp heq with ⟨h1, _⟩ | ⟨_, h2⟩
+    · exact hda h1.symm
+    · exact hbd h2
+  have ne23 : s(b, c) ≠ s(c, d) := by
+    intro heq; rcases Sym2.eq_iff.mp heq with ⟨rfl, _⟩ | ⟨rfl, _⟩ <;> contradiction
+  have ne24 : s(b, c) ≠ s(d, a) := by
+    intro heq; rcases Sym2.eq_iff.mp heq with ⟨rfl, _⟩ | ⟨h1, _⟩
+    · exact hbd rfl
+    · exact hab h1.symm
+  have ne34 : s(c, d) ≠ s(d, a) := by
+    intro heq; rcases Sym2.eq_iff.mp heq with ⟨rfl, _⟩ | ⟨h1, _⟩
+    · exact hcd rfl
+    · exact hac h1.symm
+  -- 4 distinct elements in G.edgeFinset ⟹ card ≥ 4
+  have hsub : ({s(a, b), s(b, c), s(c, d), s(d, a)} : Finset (Sym2 V)) ⊆ G.edgeFinset := by
+    intro e he
+    simp only [Finset.mem_insert, Finset.mem_singleton] at he
+    rcases he with rfl | rfl | rfl | rfl <;> assumption
+  have nm3 : s(c, d) ∉ ({s(d, a)} : Finset (Sym2 V)) := Finset.notMem_singleton.mpr ne34
+  have nm2 : s(b, c) ∉ insert s(c, d) ({s(d, a)} : Finset (Sym2 V)) := by
+    simp only [Finset.mem_insert, Finset.mem_singleton, not_or]; exact ⟨ne23, ne24⟩
+  have nm1 : s(a, b) ∉ insert s(b, c) (insert s(c, d) ({s(d, a)} : Finset (Sym2 V))) := by
+    simp only [Finset.mem_insert, Finset.mem_singleton, not_or]; exact ⟨ne12, ne13, ne14⟩
+  have hcard : ({s(a, b), s(b, c), s(c, d), s(d, a)} : Finset (Sym2 V)).card = 4 := by
+    simp only [Finset.card_insert_of_notMem nm1, Finset.card_insert_of_notMem nm2,
+      Finset.card_insert_of_notMem nm3, Finset.card_singleton]
+  linarith [Finset.card_le_card hsub]
 
 omit [Fintype V] [DecidableEq V] in
 /-- In a C₄-free graph, any two vertices have at most one common neighbor -/

--- a/src/data/proofs/erdos-1008-oq-01/meta.json
+++ b/src/data/proofs/erdos-1008-oq-01/meta.json
@@ -20,13 +20,13 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1008,
     "erdosUrl": "https://erdosproblems.com/1008",
     "erdosProblemStatus": "open-question",
     "axiomCount": 2,
-    "lineCount": 296,
-    "assumptions": "Two axioms: folkman_upper_bound (c* \u2264 1, requires full KST formalization) and cfs_admissible_exists (Conlon-Fox-Sudakov main theorem). 15 theorems fully proved including K_{2,2}=C\u2084 equivalence and common neighbor uniqueness.",
+    "lineCount": 355,
+    "assumptions": "Two axioms: folkman_upper_bound (c* \u2264 1, requires full KST formalization) and cfs_admissible_exists (Conlon-Fox-Sudakov main theorem). 17 theorems fully proved including K_{2,2}=C\u2084 equivalence, common neighbor uniqueness, c4free_of_few_edges, and optimal_constant_pos.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -106,7 +106,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the open question about optimal constants in the $C_4$-free subgraph bound. Of 17 theorems, 15 are fully proved including the $K_{2,2} = C_4$ equivalence, common neighbor uniqueness, hereditary $C_4$-freeness, and the Folkman ratio $(n^3)^{2/3} = n^2$. Two axioms encode the deep results: Folkman's upper bound $c^* \\leq 1$ (requiring full KST formalization) and the CFS existence theorem $c^* > 0$.",
+    "summary": "Formalizes the open question about optimal constants in the $C_4$-free subgraph bound. All 17 theorems fully proved (0 sorries) including the $K_{2,2} = C_4$ equivalence, common neighbor uniqueness, c4free_of_few_edges, optimal_constant_pos, hereditary $C_4$-freeness, and the Folkman ratio $(n^3)^{2/3} = n^2$. Two axioms encode the deep results: Folkman's upper bound $c^* \\leq 1$ (requiring full KST formalization) and the CFS existence theorem.",
     "implications": "The common neighbor uniqueness theorem ($|N(a) \\cap N(b)| \\leq 1$ in $C_4$-free graphs) is the combinatorial engine behind all density bounds for $C_4$-free graphs, from the original Kővári-Sós-Turán proof to modern dependent random choice arguments. The optimal constant framework via `IsAdmissibleConstant` and `optimalConstant = sSup` provides a clean formalization target: resolving the value of $c^*$ would complete a quantitative picture of $C_4$-free subgraph extraction that has been open since the 1960s. The techniques here connect to graph sparsification in theoretical computer science and to the broader Zarankiewicz problem in combinatorics.",
     "openQuestions": [
       "Determine the exact value of the optimal constant c* in (0, 1]",
@@ -152,7 +152,7 @@
     "imports": ["Mathlib"],
     "opens": ["SimpleGraph", "Finset"],
     "namespace": "Erdos1008OQ01",
-    "lineCount": 296,
+    "lineCount": 355,
     "axiomCount": 2,
     "theoremCount": 17,
     "definitionCount": 8

--- a/src/data/research/problems/erdos-1008-oq-01.json
+++ b/src/data/research/problems/erdos-1008-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1008-oq-01",
   "title": "What are the optimal constants in the Ω(m^{2/3}) bound",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Erdos1008OQ01.lean (296 lines). Proved 15 theorems including K_{2,2}=C₄ equivalence, common neighbor uniqueness, Folkman ratio. 2 axioms (CFS theorem, Folkman upper bound), 2 sorries remaining.",
+    "progressSummary": "COMPLETED: Eliminated both sorries. c4free_of_few_edges (edge counting via Sym2 distinctness) and optimal_constant_pos (BddAbove via Fin 2 specialization + le_csSup). File: 355 lines, 17 theorems, 2 axioms (deep results), 0 sorries.",
     "builtItems": [
       "Created proofs/Proofs/Erdos1008OQ01.lean (296 lines, 15 proved theorems)",
       "Proved k22_implies_c4: K_{2,2} → C₄ direction",
@@ -38,25 +38,24 @@
       "Proved folkman_ratio_rpow: (n³)^{2/3} = n²",
       "Proved c4free_of_subgraph, c4free_mono, empty_isC4Free",
       "Defined IsAdmissibleConstant framework and optimalConstant",
-      "Created gallery metadata src/data/proofs/erdos-1008-oq-01/meta.json"
+      "Created gallery metadata src/data/proofs/erdos-1008-oq-01/meta.json",
+      "c4free_of_few_edges: graph with ≤3 edges has no C₄ (Erdos1008OQ01.lean:261-322)",
+      "optimal_constant_pos: optimalConstant > 0 from cfs_admissible_exists (Erdos1008OQ01.lean:231-250)"
     ],
     "insights": [
       "K_{2,2}=C₄ equivalence proved via Finset.card_eq_two destructuring",
       "Common neighbor uniqueness is key structural constraint driving KST bounds",
       "The optimal constant c* ∈ (0,1] -- upper bound from Folkman, lower from CFS",
       "rpow_mul + norm_num sufficient for real power arithmetic (n³)^{2/3}=n²",
-      "SimpleGraph.ne_of_adj gives distinctness from adjacency (for irreflexive graphs)"
+      "SimpleGraph.ne_of_adj gives distinctness from adjacency (for irreflexive graphs)",
+      "c4free_of_few_edges proof uses Sym2.eq_iff to show 4 edges of a C₄ are distinct, giving card≥4 contradiction",
+      "optimal_constant_pos proved by specializing admissibility to completeGraph (Fin 2) to establish BddAbove, then le_csSup"
     ],
     "mathlibGaps": [
       "No Kővári-Sós-Turán theorem in Mathlib -- would need custom formalization",
       "No dependent random choice lemma -- needed for CFS proof"
     ],
-    "nextSteps": [
-      "Prove optimal_constant_pos from cfs_admissible_exists (sSup argument)",
-      "Prove c4free_of_few_edges (edge counting argument with Sym2)",
-      "Create Aristotle companion file for routine lemmas",
-      "Investigate whether c* = 1/2 matching KST coefficient"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "erdos",
@@ -81,15 +80,15 @@
     "mathlib": []
   },
   "started": "2026-03-24T00:48:59.901Z",
-  "lastUpdate": "2026-03-24T17:30:00Z",
+  "lastUpdate": "2026-03-24T19:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1008Problem.lean",
       "filename": "Erdos1008Problem.lean",
-      "lineCount": 1,
-      "theoremCount": 0,
+      "lineCount": 355,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

- Proves `c4free_of_few_edges`: graph with ≤3 edges is C₄-free (edge counting via Sym2 distinctness)
- Proves `optimal_constant_pos`: optimal constant c* > 0 (BddAbove via Fin 2 specialization + le_csSup)

File now: 355 lines, 17 theorems, 2 axioms (deep results), **0 sorries**.

## Test plan

- [x] `docker-build.sh Proofs.Erdos1008OQ01` passes
- [x] 0 sorry count verified
- [x] Gallery metadata updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)