### PR TITLE
Enrich abel-ruffini + cramers-rule-oq-03

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -338,7 +338,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 163
+      "endLine": 183
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -365,8 +365,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 164,
-      "endLine": 185
+      "startLine": 151,
+      "endLine": 183
     },
     "type": "context",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -2,7 +2,7 @@
   "id": "abel-ruffini",
   "title": "Abel-Ruffini Theorem",
   "slug": "abel-ruffini",
-  "description": "The Abel-Ruffini theorem: there is no general algebraic solution in radicals to polynomial equations of degree five or higher. First proved by Abel (1824), building on Ruffini's incomplete 1799 attempt, and later recast by Galois (1832) via the profound connection between field theory and group theory — the symmetric group S₅ is not solvable because A₅ is simple. Wiedijk 100 theorem #16, formalized in Lean 4 via Mathlib's Galois theory infrastructure.",
+  "description": "The Abel-Ruffini theorem: there is no general algebraic solution in radicals to polynomial equations of degree five or higher. First proved by Abel (1824), building on Ruffini's incomplete 1799 attempt, and later recast by Galois (1832) via the profound connection between field theory and group theory — the symmetric group S₅ is not solvable because A₅ is simple. Wiedijk 100 theorem #16, presented as a pedagogical walkthrough composing Mathlib's Galois theory infrastructure (solvableByRad.isSolvable', Equiv.Perm.not_solvable, alternatingGroup.isSimpleGroup_five) into an accessible seven-part development.",
   "meta": {
     "author": "Niels Henrik Abel (1824), Evariste Galois (1832)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/AbelRuffini.html",


### PR DESCRIPTION
## Summary

Two enrichment passes on feature/enricher-1:

### 1. abel-ruffini (quality: 100, passes: 3 → 4)
- Recalibrated ann-exists-quintic per peer review: replaced overstated "structural role" with honest placeholder characterization
- Refined description to foreground Mathlib wrapper nature
- Restructured overview.text per suggestedBestFraming
- Sharpened conclusion.summary precision

### 2. cramers-rule-oq-03 (quality: 97, passes: 0 → 1)
- Expanded historicalContext from 3 sentences to full narrative (Hamilton 1843, Schur 1917, Dieudonné 1943, Gelfand-Retakh 1991/1997)
- Expanded overview.text from 1 sentence to substantive proof summary
- Added imports-header section (lines 1-27); added mathContext to all 7 sections
- Added cramers-rule-oq-02 cross-reference
- Added keyInsight on two invertibility conditions vs. one determinant

## Test plan
- [x] JSON validated with Python json parser
- [x] Annotation builds pass for both entries (no errors)
- [x] All cross-reference targets verified to exist