### PR TITLE
Research: erdos-884 — eliminate 6 of 9 axioms

### DIFF
--- a/proofs/Proofs/Erdos884Problem.lean
+++ b/proofs/Proofs/Erdos884Problem.lean
@@ -17,11 +17,7 @@ by the consecutive-pairs sum (plus 1) up to a universal constant.
 Terence Tao has indicated this problem appears tractable.
 -/
 
-import Mathlib.Data.Nat.Divisors
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Algebra.BigOperators.Group.Finset
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.List.Sort
+import Mathlib
 
 open Nat Finset BigOperators
 
@@ -40,40 +36,101 @@ the sum over all pairs 1/(d_j - d_i) is bounded by an absolute constant times
 /- ## Divisor Lists -/
 
 /-- The divisors of n as a sorted list. -/
-noncomputable def divisorList (n : ℕ) : List ℕ :=
+def divisorList (n : ℕ) : List ℕ :=
   (n.divisors.sort (· ≤ ·))
 
 /-- Number of divisors τ(n). -/
 def numDivisors (n : ℕ) : ℕ := n.divisors.card
 
 /-- Access the i-th divisor (0-indexed). -/
-noncomputable def divisor (n i : ℕ) : ℕ :=
+def divisor (n i : ℕ) : ℕ :=
   (divisorList n).getD i 0
 
-/-- The divisor list is strictly sorted. -/
-axiom divisorList_sorted (n : ℕ) : (divisorList n).Sorted (· < ·)
+/- ## Helper Lemmas -/
+
+/-- Length of divisorList equals numDivisors. -/
+theorem divisorList_length (n : ℕ) : (divisorList n).length = numDivisors n := by
+  unfold divisorList numDivisors
+  exact Finset.length_sort (· ≤ ·)
+
+/-- Convert getD to getElem when index is in bounds. -/
+private theorem getD_zero_eq_getElem (l : List ℕ) (k : ℕ) (h : k < l.length) :
+    l.getD k 0 = l[k] := by
+  induction l generalizing k with
+  | nil => simp at h
+  | cons a t ih =>
+    cases k with
+    | zero => rfl
+    | succ k' => exact ih k' (by simpa using h)
+
+/-- The divisor list is pairwise strictly increasing. -/
+theorem divisorList_pairwise_lt (n : ℕ) : (divisorList n).Pairwise (· < ·) := by
+  unfold divisorList
+  have hle := Finset.pairwise_sort n.divisors (· ≤ ·)
+  have hnd := n.divisors.sort_nodup (· ≤ ·)
+  rw [List.pairwise_iff_getElem] at hle ⊢
+  intro i j hi hj hij
+  have hle' := hle i j hi hj hij
+  have hne := (List.pairwise_iff_getElem.mp hnd) i j hi hj hij
+  omega
 
 /-- The divisor list contains exactly the positive divisors. -/
-axiom mem_divisorList_iff (n d : ℕ) (hn : n > 0) :
-    d ∈ divisorList n ↔ d ∣ n ∧ d > 0
+theorem mem_divisorList_iff (n d : ℕ) (hn : n > 0) :
+    d ∈ divisorList n ↔ d ∣ n ∧ d > 0 := by
+  unfold divisorList
+  rw [Finset.mem_sort, Nat.mem_divisors]
+  constructor
+  · rintro ⟨hdvd, hne⟩
+    refine ⟨hdvd, ?_⟩
+    rcases Nat.eq_zero_or_pos d with h | h
+    · subst h; simp at hdvd; exact absurd hdvd hne
+    · exact h
+  · rintro ⟨hdvd, _⟩
+    exact ⟨hdvd, by omega⟩
+
+/-- In a pairwise (· < ·) ℕ list, getD respects the strict order. -/
+private theorem pairwise_getD_lt {l : List ℕ} (hs : l.Pairwise (· < ·))
+    {i j : ℕ} (hij : i < j) (hj : j < l.length) :
+    l.getD i 0 < l.getD j 0 := by
+  have hi : i < l.length := Nat.lt_trans hij hj
+  rw [getD_zero_eq_getElem l i hi, getD_zero_eq_getElem l j hj]
+  exact (List.pairwise_iff_getElem.mp hs) i j hi hj hij
+
+/-- In a pairwise (· < ·) ℕ list, getD respects the weak order. -/
+private theorem pairwise_getD_le {l : List ℕ} (hs : l.Pairwise (· < ·))
+    {i j : ℕ} (hij : i ≤ j) (hj : j < l.length) :
+    l.getD i 0 ≤ l.getD j 0 := by
+  rcases eq_or_lt_of_le hij with h | h
+  · subst h; exact le_refl _
+  · exact le_of_lt (pairwise_getD_lt hs h hj)
 
 /- ## Divisor Gaps -/
 
 /-- Consecutive divisor gap: d_{i+1} - d_i. -/
-noncomputable def consecutiveGap (n i : ℕ) : ℕ :=
+def consecutiveGap (n i : ℕ) : ℕ :=
   divisor n (i + 1) - divisor n i
 
 /-- General divisor gap: d_j - d_i for any pair. -/
-noncomputable def generalGap (n i j : ℕ) : ℕ :=
+def generalGap (n i j : ℕ) : ℕ :=
   divisor n j - divisor n i
 
 /-- Consecutive gaps are positive for sorted divisors. -/
-axiom consecutiveGap_pos (n i : ℕ) (hn : n > 1) (hi : i + 1 < numDivisors n) :
-    consecutiveGap n i > 0
+theorem consecutiveGap_pos (n i : ℕ) (_hn : n > 1) (hi : i + 1 < numDivisors n) :
+    consecutiveGap n i > 0 := by
+  unfold consecutiveGap divisor
+  have hlen := divisorList_length n
+  have hi1 : i + 1 < (divisorList n).length := by omega
+  have hlt := pairwise_getD_lt (divisorList_pairwise_lt n) (by omega : i < i + 1) hi1
+  omega
 
 /-- General gaps with i < j are positive. -/
-axiom generalGap_pos (n i j : ℕ) (hn : n > 1) (hij : i < j) (hj : j < numDivisors n) :
-    generalGap n i j > 0
+theorem generalGap_pos (n i j : ℕ) (_hn : n > 1) (hij : i < j) (hj : j < numDivisors n) :
+    generalGap n i j > 0 := by
+  unfold generalGap divisor
+  have hlen := divisorList_length n
+  have hj' : j < (divisorList n).length := by omega
+  have hlt := pairwise_getD_lt (divisorList_pairwise_lt n) hij hj'
+  omega
 
 /- ## The Two Sums -/
 
@@ -121,14 +178,14 @@ theorem consecutivePairsSum_nonneg (n : ℕ) : consecutivePairsSum n ≥ 0 := by
   exact div_nonneg one_pos.le (Nat.cast_nonneg _)
 
 /-- Number of terms in consecutive-pairs sum: τ(n) - 1. -/
-theorem consecutivePairsSum_num_terms (n : ℕ) (hn : n > 0) :
+theorem consecutivePairsSum_num_terms (n : ℕ) (_hn : n > 0) :
     (Finset.range (numDivisors n - 1)).card = numDivisors n - 1 := by
   simp
 
 /- ## Examples -/
 
 /-- For n = 6, divisors are [1, 2, 3, 6]. -/
-axiom divisors_6 : divisorList 6 = [1, 2, 3, 6]
+theorem divisors_6 : divisorList 6 = [1, 2, 3, 6] := by native_decide
 
 /-- For prime p, divisors are [1, p]. -/
 axiom divisors_prime (p : ℕ) (hp : p.Prime) :
@@ -140,19 +197,24 @@ axiom prime_case_equality (p : ℕ) (hp : p.Prime) :
 
 /- ## Structural Lemmas -/
 
-/-- Any general gap is at least the first consecutive gap involved.
-    d_j - d_i ≥ d_{i+1} - d_i since divisors are increasing. -/
-axiom gap_lower_bound (n i j : ℕ) (hij : i < j) :
-    generalGap n i j ≥ consecutiveGap n i
+/-- Any general gap is at least the corresponding consecutive gap.
+    d_j - d_i ≥ d_{i+1} - d_i since divisors are increasing.
+    Requires j to be in range (otherwise getD returns 0 and the inequality fails). -/
+theorem gap_lower_bound (n i j : ℕ) (hij : i < j) (hj : j < numDivisors n) :
+    generalGap n i j ≥ consecutiveGap n i := by
+  unfold generalGap consecutiveGap divisor
+  apply Nat.sub_le_sub_right
+  have hlen := divisorList_length n
+  have hj' : j < (divisorList n).length := by omega
+  exact pairwise_getD_le (divisorList_pairwise_lt n) (by omega : i + 1 ≤ j) hj'
 
-/-- For coprime m, n: τ(mn) = τ(m) · τ(n).
-    Proved from Mathlib's Nat.Coprime.divisors_mul and Finset.card_product. -/
-theorem numDivisors_mul_coprime (m n : ℕ) (hm : m > 0) (hn : n > 0)
-    (hcop : Nat.Coprime m n) :
+/-- For coprime m, n: τ(mn) = τ(m) · τ(n). -/
+/- Note: Nat.Coprime.divisors_mul was removed/renamed in Mathlib v4.26.0.
+   This theorem was proved in the original file but needs API update. -/
+theorem numDivisors_mul_coprime (m n : ℕ) (_hm : m > 0) (_hn : n > 0)
+    (_hcop : Nat.Coprime m n) :
     numDivisors (m * n) = numDivisors m * numDivisors n := by
-  unfold numDivisors
-  rw [Nat.Coprime.divisors_mul hcop]
-  exact Finset.card_map _
+  sorry
 
 /- ## Connections -/
 

--- a/src/data/research/problems/erdos-884.json
+++ b/src/data/research/problems/erdos-884.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-884",
   "title": "Erdős #884",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-15T10:46:46.306Z",
-    "iteration": 2,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 3,
+    "focus": "Axiom elimination on structural properties",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,21 +29,39 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM CLEANUP: Proved 3 axioms (allPairsSum_nonneg, consecutivePairsSum_nonneg, numDivisors_mul_coprime). Axioms: 12→9.",
+    "progressSummary": "PROGRESS: Eliminated 6 axioms (9→3). Proved divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, gap_lower_bound. Made definitions computable. Only OPEN conjecture + 2 example axioms remain.",
     "builtItems": [
       "theorem allPairsSum_nonneg: sum_nonneg + div_nonneg",
       "theorem consecutivePairsSum_nonneg: sum_nonneg + div_nonneg",
-      "theorem numDivisors_mul_coprime: from Nat.Coprime.divisors_mul"
+      "theorem numDivisors_mul_coprime: from Nat.Coprime.divisors_mul",
+      "theorem divisorList_pairwise_lt: from Finset.pairwise_sort + sort_nodup + pairwise_iff_getElem",
+      "theorem mem_divisorList_iff: from Finset.mem_sort + Nat.mem_divisors",
+      "theorem consecutiveGap_pos: from pairwise_getD_lt",
+      "theorem generalGap_pos: from pairwise_getD_lt",
+      "theorem divisors_6: by native_decide (computable divisorList)",
+      "theorem gap_lower_bound: from pairwise_getD_le + Nat.sub_le_sub_right (added hj hypothesis)",
+      "helper getD_zero_eq_getElem: by induction on list + cases on index",
+      "helper pairwise_getD_lt/le: getD ordering from pairwise and getD_zero_eq_getElem"
     ],
     "insights": [
       "divisorList is noncomputable (prevents native_decide for concrete values like divisors_6)",
       "allPairsSum_nonneg and consecutivePairsSum_nonneg could be provable if sums over positive terms are proved to be non-negative",
       "Main conjecture erdos_884 is open (though Tao considers it tractable)",
       "allPairsSum_nonneg and consecutivePairsSum_nonneg: trivially sums of 1/gap ≥ 0 terms",
-      "numDivisors_mul_coprime: in Mathlib as Nat.Coprime.divisors_mul + Finset.card_map"
+      "numDivisors_mul_coprime: in Mathlib as Nat.Coprime.divisors_mul + Finset.card_map",
+      "List.Sorted deprecated in Mathlib v4.26.0, use List.Pairwise instead",
+      "Finset.sort_sorted deprecated, use Finset.pairwise_sort instead",
+      "divisorList is computable (Finset.sort is computable for ℕ), noncomputable was unnecessary",
+      "gap_lower_bound was FALSE as stated (missing j < numDivisors n hypothesis for out-of-bounds getD=0 case)",
+      "Nat.Coprime.divisors_mul removed/renamed in Mathlib v4.26.0, causes sorry in numDivisors_mul_coprime",
+      "Key technique: getD_zero_eq_getElem helper proved by induction bridges getD and getElem APIs"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove divisors_prime using Nat.Prime.divisors + Finset.sort uniqueness for 2-element sets",
+      "Prove prime_case_equality by reducing both sums to single term via divisors_prime",
+      "Fix numDivisors_mul_coprime sorry by finding correct Mathlib v4.26.0 API name"
+    ],
     "markdown": "# Erdős #884 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that, for any $n$, if $d_1<\\cdots <d_t$ are the divisors of $n$, then\\[\\sum_{1\\leq i<j\\leq t}\\frac{1}{d_j-d_i} \\ll 1+\\sum_{1\\leq i<t}\\frac{1}{d_{i+1}-d_i},\\]where the implied constant is absolute?\n\n\n\nSee also [144].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #144\n- Problem #883\n- Problem #885\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er98\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -67,11 +85,11 @@
     {
       "path": "Proofs/Erdos884Problem.lean",
       "filename": "Erdos884Problem.lean",
-      "lineCount": 168,
-      "theoremCount": 5,
-      "axiomCount": 9,
+      "lineCount": 230,
+      "theoremCount": 12,
+      "axiomCount": 3,
       "defCount": 9,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos884Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Proved 6 structural axioms from Finset.sort / List.Pairwise properties
- Made divisorList, divisor, consecutiveGap, generalGap computable (removed noncomputable)
- Added helper lemmas: divisorList_length, getD_zero_eq_getElem, pairwise_getD_lt/le

## Axioms eliminated (6)
| Axiom | Proof technique |
|-------|----------------|
| `divisorList_sorted` → `divisorList_pairwise_lt` | pairwise_sort + sort_nodup + omega |
| `mem_divisorList_iff` | Finset.mem_sort + Nat.mem_divisors |
| `consecutiveGap_pos` | pairwise ordering on getD |
| `generalGap_pos` | pairwise ordering on getD |
| `divisors_6` | native_decide (now computable) |
| `gap_lower_bound` | pairwise_getD_le + Nat.sub_le_sub_right |

## Remaining axioms (3)
- `erdos_884`: OPEN conjecture (must stay)
- `divisors_prime`: universally quantified, not native_decide-able
- `prime_case_equality`: depends on divisors_prime

## Notes
- `gap_lower_bound` signature changed: added `hj : j < numDivisors n` (old statement was false for out-of-bounds j)
- `numDivisors_mul_coprime` has sorry due to `Nat.Coprime.divisors_mul` API rename in Mathlib v4.26.0
- `List.Sorted` deprecated in v4.26.0 → migrated to `List.Pairwise`

## Test plan
- [x] Docker build passes (`Proofs.Erdos884Problem`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)