### PR TITLE
Enrich: add mathContext to sections across 23 gallery entries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -80,35 +80,40 @@
       "title": "Documentation and Context",
       "summary": "Module documentation describing the open question, proof strategies for both bounds (half-angle refinement and Niven integral), and references.",
       "startLine": 1,
-      "endLine": 27
+      "endLine": 27,
+      "mathContext": "Archimedes (~250 BCE) bounded $\\pi$ by inscribing and circumscribing regular 96-gons: $\\frac{223}{71} < \\pi < \\frac{22}{7}$. This gives $\\pi \\approx 3.14$ with an error less than $1/497 \\approx 0.002$. The bounds stood as the best known for over 400 years."
     },
     {
       "id": "bounds",
       "title": "Archimedes' Bounds (Fully Verified)",
       "summary": "Both bounds proved as theorems from Mathlib's pi_gt_d4 and pi_lt_d4: 223/71 < 3.1415 < π and π < 3.1416 < 22/7.",
       "startLine": 27,
-      "endLine": 46
+      "endLine": 46,
+      "mathContext": "Lower bound: $223/71 \\approx 3.14084 < 3.1415 < \\pi$ (via `pi_gt_d4`). Upper bound: $\\pi < 3.1416 < 22/7 \\approx 3.14286$ (via `pi_lt_d4`). Mathlib provides 4-decimal bounds on $\\pi$, which are more than sufficient for Archimedes' 3-decimal result."
     },
     {
       "id": "derived",
       "title": "Derived Results",
       "summary": "Six theorems: combined bounds, traditional formulations (3+10/71 and 3+1/7), exact gap computation (1/497), error bounds, and the 22/7 overestimate quantification (<3/1000).",
       "startLine": 47,
-      "endLine": 73
+      "endLine": 73,
+      "mathContext": "The gap between bounds: $22/7 - 223/71 = (22 \\cdot 71 - 223 \\cdot 7)/(7 \\cdot 71) = (1562 - 1561)/497 = 1/497 \\approx 0.00201$. Traditional forms: $3 + 10/71 < \\pi < 3 + 1/7$. The upper bound overestimates: $22/7 - \\pi < 3/1000$."
     },
     {
       "id": "polygon",
       "title": "General Inscribed Polygon Bound",
       "summary": "The fully formal theorem that n·sin(π/n) < π for all n ≥ 1, proved using Real.sin_lt and field_simp. Formalizes the geometric core of Archimedes' method.",
       "startLine": 74,
-      "endLine": 90
+      "endLine": 90,
+      "mathContext": "A regular $n$-gon inscribed in a unit circle has perimeter $2n \\sin(\\pi/n)$, so the circle's circumference $2\\pi$ exceeds $2n \\sin(\\pi/n)$, giving $n \\sin(\\pi/n) < \\pi$. As $n \\to \\infty$, $n \\sin(\\pi/n) \\to \\pi$ (since $\\sin(x)/x \\to 1$). Archimedes used $n = 96$ to get his lower bound."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
       "summary": "Packaging theorem bundling all three main results (bounds, gap, polygon bound) into a single statement for downstream use.",
       "startLine": 91,
-      "endLine": 102
+      "endLine": 102,
+      "mathContext": "The bundled theorem: $223/71 < \\pi < 22/7$ $\\wedge$ $22/7 - 223/71 = 1/497$ $\\wedge$ $\\forall n \\geq 1,\\, n \\sin(\\pi/n) < \\pi$. This provides a single import point for downstream proofs needing Archimedes' bounds."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
@@ -73,42 +73,48 @@
       "title": "Module Documentation",
       "startLine": 1,
       "endLine": 17,
-      "summary": "States the open question (generalizing the hockey stick to multi-dimensional sums), and outlines the three main results: 1D hockey stick, parallel Vandermonde, and 2D hockey stick."
+      "summary": "States the open question (generalizing the hockey stick to multi-dimensional sums), and outlines the three main results: 1D hockey stick, parallel Vandermonde, and 2D hockey stick.",
+      "mathContext": "Introduces the generalization program: from the 1D hockey stick $\\sum_{i=0}^{n} \\binom{i+k}{k} = \\binom{n+k+1}{k+1}$ to the 2D identity $\\sum_{i+j \\leq n} \\binom{i+a}{a}\\binom{j+b}{b} = \\binom{n+a+b+2}{a+b+2}$, with the parallel Vandermonde convolution $\\sum_{i+j=n} \\binom{i+a}{a}\\binom{j+b}{b} = \\binom{n+a+b+1}{a+b+1}$ as the key intermediate identity."
     },
     {
       "id": "simplicial",
       "title": "Simplicial Numbers",
       "startLine": 18,
       "endLine": 48,
-      "summary": "Self-contained definitions: simplicial k n = C(n+k, k), base cases (simp lemmas), Pascal recurrence, and the 1D hockey stick identity. All proved by straightforward induction."
+      "summary": "Self-contained definitions: simplicial k n = C(n+k, k), base cases (simp lemmas), Pascal recurrence, and the 1D hockey stick identity. All proved by straightforward induction.",
+      "mathContext": "Defines $S_k(n) = \\binom{n+k}{k}$, the $k$-th simplicial number sequence. Establishes Pascal's recurrence $S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1)$ and the 1D hockey stick $\\sum_{i=0}^{n} S_k(i) = S_{k+1}(n)$. These are the figurate numbers: $S_0(n) = 1$, $S_1(n) = n+1$ (counting), $S_2(n) = \\binom{n+2}{2}$ (triangular), $S_3(n) = \\binom{n+3}{3}$ (tetrahedral)."
     },
     {
       "id": "parallel-vandermonde",
       "title": "Parallel Vandermonde Identity",
       "startLine": 49,
       "endLine": 99,
-      "summary": "The main result: Σ_{i+j=n} S_a(i)·S_b(j) = S_{a+b+1}(n). Proved by nested induction on (b, n) with Pascal decomposition of S_{b+1}(n+1-i) into two terms, each resolved by a different induction hypothesis."
+      "summary": "The main result: Σ_{i+j=n} S_a(i)·S_b(j) = S_{a+b+1}(n). Proved by nested induction on (b, n) with Pascal decomposition of S_{b+1}(n+1-i) into two terms, each resolved by a different induction hypothesis.",
+      "mathContext": "Proves the parallel Vandermonde convolution: $\\sum_{i+j=n} \\binom{i+a}{a}\\binom{j+b}{b} = \\binom{n+a+b+1}{a+b+1}$. The nested induction uses Pascal's identity $\\binom{j+b+1}{b+1} = \\binom{j+b}{b+1} + \\binom{j+b}{b}$ to split each summand, yielding two sums resolved by the inner hypothesis (on $n$) and outer hypothesis (on $b$). This is equivalent to the Cauchy product of generating functions $(1-x)^{-(a+1)} \\cdot (1-x)^{-(b+1)} = (1-x)^{-(a+b+2)}$."
     },
     {
       "id": "2d-hockey-stick",
       "title": "2D Hockey Stick Identity",
       "startLine": 100,
       "endLine": 114,
-      "summary": "hockey_stick_2d: Σ_{i+j≤n} S_a(i)·S_b(j) = S_{a+b+2}(n). Elegant two-line proof composing parallel_vandermonde with hockey_stick via simp_rw."
+      "summary": "hockey_stick_2d: Σ_{i+j≤n} S_a(i)·S_b(j) = S_{a+b+2}(n). Elegant two-line proof composing parallel_vandermonde with hockey_stick via simp_rw.",
+      "mathContext": "The 2D hockey stick: $\\sum_{i+j \\leq n} \\binom{i+a}{a}\\binom{j+b}{b} = \\binom{n+a+b+2}{a+b+2}$. The proof rewrites the triangular sum $\\sum_{m=0}^{n} \\left(\\sum_{i+j=m} S_a(i) S_b(j)\\right)$ using the parallel Vandermonde to get $\\sum_{m=0}^{n} S_{a+b+1}(m)$, then applies the 1D hockey stick. This two-line composition demonstrates that the 2D identity is simply $\\texttt{hockey\\_stick} \\circ \\texttt{parallel\\_vandermonde}$."
     },
     {
       "id": "special-cases",
       "title": "Special Cases and Verification",
       "startLine": 115,
       "endLine": 131,
-      "summary": "parallel_vandermonde_left (a=0 reduces to hockey stick), plus concrete native_decide checks: S_2(2) = 6 and S_3(2) = 10."
+      "summary": "parallel_vandermonde_left (a=0 reduces to hockey stick), plus concrete native_decide checks: S_2(2) = 6 and S_3(2) = 10.",
+      "mathContext": "Verifies degenerate cases: when $a = 0$, the parallel Vandermonde reduces to $\\sum_{i+j=n} \\binom{j+b}{b} = \\binom{n+b+1}{b+1}$, recovering the 1D hockey stick. Concrete checks: $S_2(2) = \\binom{4}{2} = 6$ (the 2nd triangular number) and $S_3(2) = \\binom{5}{3} = 10$ (the 2nd tetrahedral number), verified by $\\texttt{native\\_decide}$."
     },
     {
       "id": "summary",
       "title": "Summary",
       "startLine": 132,
       "endLine": 154,
-      "summary": "Recapitulates all 12 theorems with 0 sorries and 0 axioms, highlighting the nested induction strategy and the compositional proof of the 2D identity."
+      "summary": "Recapitulates all 12 theorems with 0 sorries and 0 axioms, highlighting the nested induction strategy and the compositional proof of the 2D identity.",
+      "mathContext": "Summarizes the complete chain: $S_k(n) = \\binom{n+k}{k}$ (definition) $\\to$ Pascal's recurrence $\\to$ 1D hockey stick $\\sum S_k(i) = S_{k+1}(n)$ $\\to$ parallel Vandermonde $\\sum_{i+j=n} S_a(i) S_b(j) = S_{a+b+1}(n)$ $\\to$ 2D hockey stick $\\sum_{i+j \\leq n} S_a(i) S_b(j) = S_{a+b+2}(n)$. All 12 theorems verified with 0 sorries and 0 axioms."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -71,7 +71,8 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 60,
-      "summary": "Module docstring establishing the generalized ballot problem for $k$-fold dominance, imports from `Archive.Wiedijk100Theorems.BallotProblem` and `Mathlib.Tactic`"
+      "summary": "Module docstring establishing the generalized ballot problem for $k$-fold dominance, imports from `Archive.Wiedijk100Theorems.BallotProblem` and `Mathlib.Tactic`",
+      "mathContext": "Imports Mathlib's Wiedijk #30 (Ballot Problem) for the classical $k=1$ case and validation. The generalization: probability of $k$-fold dominance is $(a - kb)/(a + b)$ rather than $(p-q)/(p+q)$."
     },
     {
       "id": "definitions",
@@ -94,28 +95,32 @@
       "title": "Part III: Basic Properties",
       "startLine": 103,
       "endLine": 149,
-      "summary": "Derives sum $= a - kb$, length $= a + b$, permutation characterization $l \\sim \\text{replicate}(a,1) \\mathbin{\\|} \\text{replicate}(b,-k)$, finiteness, and nonemptiness"
+      "summary": "Derives sum $= a - kb$, length $= a + b$, permutation characterization $l \\sim \\text{replicate}(a,1) \\mathbin{\\|} \\text{replicate}(b,-k)$, finiteness, and nonemptiness",
+      "mathContext": "A $k$-ballot sequence $l$ is fully determined by its permutation class: $l \\sim [\\underbrace{1,\\ldots,1}_{a}, \\underbrace{-k,\\ldots,-k}_{b}]$. The finiteness proof uses the permutation characterization to bound the set size by $\\binom{a+b}{a}$ (the multinomial coefficient)."
     },
     {
       "id": "classical-connection",
       "title": "Part IV: Connection to Classical Ballot Problem",
       "startLine": 150,
       "endLine": 159,
-      "summary": "Shows $\\text{kCountedSequence}(1, a, b) = \\text{Ballot.countedSequence}(a, b)$ via `simpa`, validating against Wiedijk #30"
+      "summary": "Shows $\\text{kCountedSequence}(1, a, b) = \\text{Ballot.countedSequence}(a, b)$ via `simpa`, validating against Wiedijk #30",
+      "mathContext": "When $k = 1$: a $+1/-1$ lattice path with $a$ up-steps and $b$ down-steps reduces to the classical ballot sequence. The formula $(a - 1 \\cdot b)/(a+b) = (p-q)/(p+q)$ recovers Bertrand's 1887 result."
     },
     {
       "id": "ballot-theorem",
       "title": "Part V: The Generalized Ballot Theorem",
       "startLine": 160,
       "endLine": 182,
-      "summary": "States the counting formula (1 sorry: double counting) and proves $P = (a - kb)/(a + b) > 0$; verified examples with `norm_num`"
+      "summary": "States the counting formula (1 sorry: double counting) and proves $P = (a - kb)/(a + b) > 0$; verified examples with `norm_num`",
+      "mathContext": "The counting formula: $|\\{l \\in \\text{kCountedSequence} : \\text{kStaysPositive}(l)\\}| = \\frac{a - kb}{a + b} \\cdot |\\text{kCountedSequence}|$. One sorry remains on the double-counting step that connects cycle lemma good rotations to favorable ballot orderings."
     },
     {
       "id": "cyclic-rotations",
       "title": "Part VII: Cyclic Rotation Infrastructure",
       "startLine": 183,
       "endLine": 236,
-      "summary": "Defines $\\text{rotate}(l, i) = l[i:] \\mathbin{\\|} l[:i]$ and proves sum/length preservation, identity, membership in kCountedSequence, and composition"
+      "summary": "Defines $\\text{rotate}(l, i) = l[i:] \\mathbin{\\|} l[:i]$ and proves sum/length preservation, identity, membership in kCountedSequence, and composition",
+      "mathContext": "The cyclic rotation $\\text{rot}(l, i) = l[i:] \\mathbin{\\|} l[:i]$ is the key symmetry operation. Invariant: $\\text{rot}(l, i)$ has the same multiset of values as $l$, so it remains in $\\text{kCountedSequence}(k, a, b)$. The $n$ rotations of $l$ partition into 'good' (all prefix sums positive) and 'bad' — the cycle lemma counts exactly $S = a - kb$ good ones."
     },
     {
       "id": "prefix-sums",
@@ -130,7 +135,8 @@
       "title": "Rightmost Minimum Infrastructure",
       "startLine": 335,
       "endLine": 420,
-      "summary": "Defines `rightmostMinPos` as the last position achieving $\\min(\\sigma)$; proves it is a good rotation when $S > 0$, giving $|\\text{goodRotations}| \\geq 1$"
+      "summary": "Defines `rightmostMinPos` as the last position achieving $\\min(\\sigma)$; proves it is a good rotation when $S > 0$, giving $|\\text{goodRotations}| \\geq 1$",
+      "mathContext": "The rightmost minimum $i^* = \\max\\{i : \\sigma(i) = \\min_j \\sigma(j)\\}$ is always a good rotation: rotating to start after $i^*$ places the minimum at the beginning, so all subsequent prefix sums exceed it. This existence argument bootstraps the cycle lemma's lower bound."
     },
     {
       "id": "upper-bound",
@@ -153,7 +159,8 @@
       "title": "Part VIII: Lattice Path Interpretation",
       "startLine": 702,
       "endLine": 710,
-      "summary": "Interprets prefix sums as lattice path heights: A-vote $= (+1)$ step, B-vote $= (-k)$ step; path stays above $x$-axis iff all prefix sums are positive"
+      "summary": "Interprets prefix sums as lattice path heights: A-vote $= (+1)$ step, B-vote $= (-k)$ step; path stays above $x$-axis iff all prefix sums are positive",
+      "mathContext": "The lattice path interpretation: a ballot sequence $l = [l_1, \\ldots, l_n]$ defines a path in $\\mathbb{Z}^2$ from $(0,0)$ to $(n, a-kb)$, with height at time $j$ equal to $\\sigma(j) = \\sum_{i=1}^{j} l_i$. The $k$-fold dominance condition 'A always has > k times B's votes' translates to $\\sigma(j) > 0$ for all $j$, i.e., the path stays strictly above the $x$-axis."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/basel-problem-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01/meta.json
@@ -89,49 +89,56 @@
       "title": "Problem Statement and Context",
       "startLine": 1,
       "endLine": 45,
-      "summary": "Overview of the ζ(5) irrationality question, known results, and mathematical context."
+      "summary": "Overview of the ζ(5) irrationality question, known results, and mathematical context.",
+      "mathContext": "The Riemann zeta function $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$. The irrationality of $\\zeta(5)$ is a major open problem in analytic number theory, sitting between the solved $\\zeta(3)$ case (Apery 1978) and the general conjecture that all odd zeta values are irrational."
     },
     {
       "id": "definition-convergence",
       "title": "Definition and Convergence",
       "startLine": 49,
       "endLine": 66,
-      "summary": "zetaFive defined as ∑ 1/n^5 with summability proved via p-series criterion (p=5 > 1)."
+      "summary": "zetaFive defined as ∑ 1/n^5 with summability proved via p-series criterion (p=5 > 1).",
+      "mathContext": "$\\zeta(5) = \\sum_{n=1}^{\\infty} \\frac{1}{n^5} \\approx 1.0369277551$. Convergence follows from the $p$-series test: $\\sum 1/n^p$ converges for $p > 1$. In Lean: `Real.summable_nat_rpow_inv` with $p = 5$."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 67,
       "endLine": 95,
-      "summary": "zetaFive ≥ 1 (from n=1 term), zetaFive > 0, zetaFive ≠ 0. The lower bound uses hasSum_ite_eq + hasSum_le."
+      "summary": "zetaFive ≥ 1 (from n=1 term), zetaFive > 0, zetaFive ≠ 0. The lower bound uses hasSum_ite_eq + hasSum_le.",
+      "mathContext": "$\\zeta(5) \\geq 1/1^5 = 1$ since the first term alone contributes 1. The proof uses `hasSum_ite_eq` (sum of indicator at $n=1$) compared with `hasSum_le` (term-by-term comparison). The strict positivity $\\zeta(5) > 0$ follows immediately."
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
       "startLine": 96,
       "endLine": 135,
-      "summary": "ζ(5) ≤ π⁴/90 = ζ(4) and ζ(5) ≤ π²/6 = ζ(2) by term-by-term comparison using 1/n^5 ≤ 1/n^k for k ≤ 5."
+      "summary": "ζ(5) ≤ π⁴/90 = ζ(4) and ζ(5) ≤ π²/6 = ζ(2) by term-by-term comparison using 1/n^5 ≤ 1/n^k for k ≤ 5.",
+      "mathContext": "For $n \\geq 1$: $1/n^5 \\leq 1/n^4 \\leq 1/n^2$, so $\\zeta(5) \\leq \\zeta(4) = \\pi^4/90 \\approx 1.0823$ and $\\zeta(5) \\leq \\zeta(2) = \\pi^2/6 \\approx 1.6449$. Combined with the lower bound: $1 \\leq \\zeta(5) \\leq \\pi^4/90$."
     },
     {
       "id": "open-conjecture",
       "title": "The Open Conjecture",
       "startLine": 136,
       "endLine": 153,
-      "summary": "zeta_five_irrational is stated with sorry — this is a genuine open problem, unknown as of 2026."
+      "summary": "zeta_five_irrational is stated with sorry — this is a genuine open problem, unknown as of 2026.",
+      "mathContext": "Conjecture: $\\zeta(5) \\notin \\mathbb{Q}$. This is expected to be true (all evidence suggests odd zeta values are irrational and transcendental), but no proof exists. The `sorry` here represents genuine mathematical ignorance, not a formalization gap."
     },
     {
       "id": "partial-results",
-      "title": "Known Partial Results (Apéry, Rivoal, Zudilin)",
+      "title": "Known Partial Results (Apery, Rivoal, Zudilin)",
       "startLine": 153,
       "endLine": 191,
-      "summary": "Three landmark theorems axiomatized: Apéry (ζ(3) irrational), Rivoal (infinitely many irrational odd zetas), Zudilin (at least one of four consecutive odd zetas irrational)."
+      "summary": "Three landmark theorems axiomatized: Apéry (ζ(3) irrational), Rivoal (infinitely many irrational odd zetas), Zudilin (at least one of four consecutive odd zetas irrational).",
+      "mathContext": "Apery (1978): $\\zeta(3) \\notin \\mathbb{Q}$. Rivoal (2000): $\\dim_{\\mathbb{Q}} \\text{span}\\{1, \\zeta(3), \\zeta(5), \\ldots, \\zeta(2n+1)\\} \\geq \\frac{1+o(1)}{1+\\log 2} \\log n$. Zudilin (2001): at least one of $\\zeta(5), \\zeta(7), \\zeta(9), \\zeta(11)$ is irrational. All three are axiomatized since their proofs (involving Pade approximants and hypergeometric series) are far beyond current Mathlib."
     },
     {
       "id": "consequences",
       "title": "Consequences of Partial Results",
       "startLine": 192,
       "endLine": 244,
-      "summary": "Derived results from Rivoal and Zudilin: infinitely many irrational odd zeta values exist; not all of ζ(5), ζ(7), ζ(9), ζ(11) are rational; zudilin_witness locates an irrational in the set {5,7,9,11}."
+      "summary": "Derived results from Rivoal and Zudilin: infinitely many irrational odd zeta values exist; not all of ζ(5), ζ(7), ζ(9), ζ(11) are rational; zudilin_witness locates an irrational in the set {5,7,9,11}.",
+      "mathContext": "From Zudilin's axiom: $\\exists k \\in \\{5,7,9,11\\},\\, \\zeta(k) \\notin \\mathbb{Q}$. The proof derives this from the axiomatized statement by contradiction: if all four were rational, the axiom's conclusion would fail. This is a non-constructive existence proof — we know one of the four is irrational, but not which one."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/bezout-identity-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02/meta.json
@@ -81,49 +81,56 @@
       "title": "Imports",
       "startLine": 1,
       "endLine": 6,
-      "summary": "Imports GCD basics for naturals, GCD for integers (Bézout coefficients), coprime ring theory (IsCoprime), prime number basics, and Tactic (linear_combination, exact_mod_cast)."
+      "summary": "Imports GCD basics for naturals, GCD for integers (Bézout coefficients), coprime ring theory (IsCoprime), prime number basics, and Tactic (linear_combination, exact_mod_cast).",
+      "mathContext": "Imports the Mathlib modules needed to work with $\\gcd(a,b)$ in $\\mathbb{N}$, Bezout coefficients $x, y \\in \\mathbb{Z}$ satisfying $ax + by = \\gcd(a,b)$, the $\\text{IsCoprime}$ typeclass ($\\exists u\\, v,\\; ua + vb = 1$), and the $\\texttt{linear\\_combination}$ tactic for closing ring-arithmetic goals."
     },
     {
       "id": "module-docstring",
       "title": "Module Documentation",
       "startLine": 7,
       "endLine": 39,
-      "summary": "Documents the open question (can coprime_iff_linear_combination prove Euclid's lemma?), the answer (yes!), the key proof idea with the explicit witness x*c + y*k, and proof status (0 sorries)."
+      "summary": "Documents the open question (can coprime_iff_linear_combination prove Euclid's lemma?), the answer (yes!), the key proof idea with the explicit witness x*c + y*k, and proof status (0 sorries).",
+      "mathContext": "Frames the open question: given the equivalence $\\gcd(a,b) = 1 \\iff \\exists x,y \\in \\mathbb{Z},\\; ax + by = 1$, can we derive Euclid's lemma ($\\gcd(a,b) = 1 \\land a \\mid bc \\Rightarrow a \\mid c$) by constructing the explicit witness $c = a(xc + yk)$ where $bc = ak$?"
     },
     {
       "id": "coprime-iff",
       "title": "coprime_iff_linear_combination (Core Tool)",
       "startLine": 42,
       "endLine": 78,
-      "summary": "Re-proves coprime_iff_linear_combination: Nat.Coprime a b ↔ ∃ x y : ℤ, a*x + b*y = 1. Forward direction uses Nat.gcdA/gcdB and push_cast/linarith. Backward direction shows gcd | 1 via exact_mod_cast and Nat.eq_one_of_dvd_one."
+      "summary": "Re-proves coprime_iff_linear_combination: Nat.Coprime a b ↔ ∃ x y : ℤ, a*x + b*y = 1. Forward direction uses Nat.gcdA/gcdB and push_cast/linarith. Backward direction shows gcd | 1 via exact_mod_cast and Nat.eq_one_of_dvd_one.",
+      "mathContext": "Establishes the equivalence $\\text{Nat.Coprime}\\; a\\; b \\iff \\exists x, y \\in \\mathbb{Z},\\; ax + by = 1$. The forward direction extracts the extended Euclidean algorithm witnesses $\\texttt{gcdA}(a,b)$ and $\\texttt{gcdB}(a,b)$ satisfying $\\gcd(a,b) = a \\cdot \\texttt{gcdA} + b \\cdot \\texttt{gcdB}$ and uses $\\gcd(a,b) = 1$. The backward direction shows $\\gcd(a,b) \\mid 1$ in $\\mathbb{N}$, forcing $\\gcd(a,b) = 1$."
     },
     {
       "id": "euclids-int",
       "title": "Euclid's Lemma for Integers",
       "startLine": 81,
       "endLine": 102,
-      "summary": "euclids_lemma_int: IsCoprime version. Unpacks IsCoprime to get u, v with u*a + v*b = 1. Gets k with b*c = a*k. Witness u*c + v*k, proved by linear_combination v * hk - c * huv."
+      "summary": "euclids_lemma_int: IsCoprime version. Unpacks IsCoprime to get u, v with u*a + v*b = 1. Gets k with b*c = a*k. Witness u*c + v*k, proved by linear_combination v * hk - c * huv.",
+      "mathContext": "Proves Euclid's lemma over $\\mathbb{Z}$: if $\\text{IsCoprime}(a,b)$ (i.e., $\\exists u,v,\\; ua + vb = 1$) and $a \\mid bc$, then $a \\mid c$. From $bc = ak$ and $ua + vb = 1$, the witness is $c = a(uc + vk)$, verified by the ring identity $v(bc - ak) - c(ua + vb - 1) = 0$."
     },
     {
       "id": "euclids-nat",
       "title": "Euclid's Lemma for Naturals (Main Result)",
       "startLine": 103,
       "endLine": 131,
-      "summary": "euclids_lemma_nat: the main answer to the OQ. Uses coprime_iff_linear_combination to get Bézout coefficients x, y over ℤ. Casts divisibility to ℤ with exact_mod_cast. Constructs witness x*c + y*k by linear_combination y * hk - c * hbez."
+      "summary": "euclids_lemma_nat: the main answer to the OQ. Uses coprime_iff_linear_combination to get Bézout coefficients x, y over ℤ. Casts divisibility to ℤ with exact_mod_cast. Constructs witness x*c + y*k by linear_combination y * hk - c * hbez.",
+      "mathContext": "The main result: $\\gcd(a,b) = 1 \\land a \\mid bc \\Rightarrow a \\mid c$ over $\\mathbb{N}$. The proof lifts to $\\mathbb{Z}$ to access Bezout coefficients $x, y$ with $ax + by = 1$, constructs $c = a(xc + yk)$ using $bc = ak$, and casts back via $\\texttt{Int.natCast\\_dvd\\_natCast}$. The key step avoids $\\mathbb{N}$ subtraction pitfalls since $x, y$ may be negative."
     },
     {
       "id": "euclids-prime",
       "title": "Prime Version of Euclid's Lemma",
       "startLine": 132,
       "endLine": 153,
-      "summary": "euclids_lemma_prime: if p prime and p | a*b then p|a or p|b. Case splits on p | a. If p ∤ a, uses Nat.Prime.coprime_iff_not_dvd to get Nat.Coprime p a, then applies euclids_lemma_nat."
+      "summary": "euclids_lemma_prime: if p prime and p | a*b then p|a or p|b. Case splits on p | a. If p ∤ a, uses Nat.Prime.coprime_iff_not_dvd to get Nat.Coprime p a, then applies euclids_lemma_nat.",
+      "mathContext": "The classical form of Euclid's lemma: if $p$ is prime and $p \\mid ab$, then $p \\mid a$ or $p \\mid b$. Uses the equivalence $p \\nmid a \\iff \\gcd(p, a) = 1$ (since $p$ is prime, its only divisors are $1$ and $p$), then applies $\\texttt{euclids\\_lemma\\_nat}$. This is Proposition VII.30 of Euclid's *Elements* and the essential ingredient for unique prime factorization."
     },
     {
       "id": "examples",
       "title": "Worked Examples",
       "startLine": 154,
       "endLine": 192,
-      "summary": "Four examples: (3,7,6), (5,8,15), prime 7|14*3, and direct witness verification 3*(5*6+(-2)*14) = 6."
+      "summary": "Four examples: (3,7,6), (5,8,15), prime 7|14*3, and direct witness verification 3*(5*6+(-2)*14) = 6.",
+      "mathContext": "Concrete verifications: $\\gcd(3,7)=1$ and $3 \\mid 42$ gives $3 \\mid 6$; $\\gcd(5,8)=1$ and $5 \\mid 120$ gives $5 \\mid 15$; prime $7 \\mid 14 \\cdot 3 = 42$ gives $7 \\mid 14$ or $7 \\mid 3$. The witness check $3 \\cdot (5 \\cdot 6 + (-2) \\cdot 14) = 3 \\cdot 2 = 6$ demonstrates the explicit Bezout construction: $x = 5$, $y = -2$ from $3 \\cdot 5 + 7 \\cdot (-2) = 1$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/bezout-identity-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04/meta.json
@@ -100,42 +100,48 @@
       "title": "GCD Divides All Linear Combinations",
       "startLine": 50,
       "endLine": 55,
-      "summary": "gcd_divides_linear_combination: (Int.gcd a b : ℤ) ∣ a*x + b*y for any x, y. One-line proof: gcd | a and gcd | b, so gcd | a*x + b*y by dvd_add and dvd_mul_of_dvd_left. This is the structural fact that the ideal {ax+by} ⊆ gcd(a,b)·ℤ."
+      "summary": "gcd_divides_linear_combination: (Int.gcd a b : ℤ) ∣ a*x + b*y for any x, y. One-line proof: gcd | a and gcd | b, so gcd | a*x + b*y by dvd_add and dvd_mul_of_dvd_left. This is the structural fact that the ideal {ax+by} ⊆ gcd(a,b)·ℤ.",
+      "mathContext": "For any $x, y \\in \\mathbb{Z}$: $\\gcd(a,b) \\mid a$ and $\\gcd(a,b) \\mid b$ implies $\\gcd(a,b) \\mid (ax + by)$. In ideal notation: $(a,b) \\subseteq (\\gcd(a,b))$. Combined with Bézout ($\\gcd(a,b) \\in (a,b)$), this gives $(a,b) = (\\gcd(a,b))$."
     },
     {
       "id": "null-space",
       "title": "The Null Space: ax + by = 0 when gcd = 1",
       "startLine": 63,
       "endLine": 107,
-      "summary": "coprime_linear_null_space: when gcd(a,b)=1, ax+by=0 ↔ ∃t, x=bt ∧ y=-at. Proof: build IsCoprime from Bezout coefficients. Case b=0: isCoprime_zero_right gives IsUnit a (a=±1), so x=0, take t=-a*y. Case b≠0: Bezout witnesses give b∣x directly (x = u*(a*x)+v*b*x = u*(b*m)+v*b*x = b*(u*m+v*x)), then a*t+y=0 from b*(a*t+y)=0."
+      "summary": "coprime_linear_null_space: when gcd(a,b)=1, ax+by=0 ↔ ∃t, x=bt ∧ y=-at. Proof: build IsCoprime from Bezout coefficients. Case b=0: isCoprime_zero_right gives IsUnit a (a=±1), so x=0, take t=-a*y. Case b≠0: Bezout witnesses give b∣x directly (x = u*(a*x)+v*b*x = u*(b*m)+v*b*x = b*(u*m+v*x)), then a*t+y=0 from b*(a*t+y)=0.",
+      "mathContext": "The null space $\\ker(\\phi) = \\{(x,y) : ax + by = 0\\}$ of the linear form $\\phi(x,y) = ax + by$ is a rank-1 free $\\mathbb{Z}$-module when $\\gcd(a,b) = 1$: $\\ker(\\phi) = \\mathbb{Z} \\cdot (b, -a)$. The generator $(b, -a)$ is perpendicular to $(a, b)$ in the lattice $\\mathbb{Z}^2$."
     },
     {
       "id": "complete-param",
       "title": "Complete Parametrization of All Solutions",
       "startLine": 112,
       "endLine": 184,
-      "summary": "diophantine_complete_parameterization: with d=gcd(a,b)>0 and one solution (x₀,y₀), all solutions are (x₀+(b/d)t, y₀-(a/d)t). Key steps: gcd(a/d, b/d)=1 proved via Nat.dvd_one (gcd divides Bezout combination = 1); reduce to null space of coprime equation; backward direction uses linear_combination h₀ + key*t where key: a*(b/d) = b*(a/d)."
+      "summary": "diophantine_complete_parameterization: with d=gcd(a,b)>0 and one solution (x₀,y₀), all solutions are (x₀+(b/d)t, y₀-(a/d)t). Key steps: gcd(a/d, b/d)=1 proved via Nat.dvd_one (gcd divides Bezout combination = 1); reduce to null space of coprime equation; backward direction uses linear_combination h₀ + key*t where key: a*(b/d) = b*(a/d).",
+      "mathContext": "The solution set of $ax + by = c$ is an affine lattice (coset of the null space): $\\{(x_0, y_0) + t(b/d, -a/d) : t \\in \\mathbb{Z}\\}$ where $d = \\gcd(a,b)$. Geometrically, solutions lie on the line $ax + by = c$ in $\\mathbb{R}^2$, spaced at intervals of $\\|(b/d, -a/d)\\| = \\sqrt{(a^2+b^2)}/d$. The step vector $(b/d, -a/d)$ is the primitive lattice vector in the null space direction."
     },
     {
       "id": "three-variable",
       "title": "Three-Variable Diophantine Criterion",
       "startLine": 185,
       "endLine": 232,
-      "summary": "bezout_three: ∃x,y,z: ax+by+cz = gcd(gcd(a,b),c). Proof applies Bezout twice: get x₀,y₀ with gcd(a,b)=ax₀+by₀, then u,v with gcd(gcd(a,b),c)=gcd(a,b)*u+c*v. Solution: x=x₀*u, y=y₀*u, z=v. diophantine_three_solvable: ax+by+cz=k has solutions ↔ gcd(gcd(a,b),c) | k. Proves the criterion extends inductively to three variables."
+      "summary": "bezout_three: ∃x,y,z: ax+by+cz = gcd(gcd(a,b),c). Proof applies Bezout twice: get x₀,y₀ with gcd(a,b)=ax₀+by₀, then u,v with gcd(gcd(a,b),c)=gcd(a,b)*u+c*v. Solution: x=x₀*u, y=y₀*u, z=v. diophantine_three_solvable: ax+by+cz=k has solutions ↔ gcd(gcd(a,b),c) | k. Proves the criterion extends inductively to three variables.",
+      "mathContext": "Three-variable Bézout: $\\gcd(\\gcd(a,b), c) = ax + by + cz$ for some $x, y, z \\in \\mathbb{Z}$. The solvability criterion: $a_1 x_1 + \\cdots + a_n x_n = k$ has integer solutions $\\Leftrightarrow$ $\\gcd(a_1, \\ldots, a_n) \\mid k$. This extends inductively since $\\gcd(a_1, \\ldots, a_n) = \\gcd(\\gcd(a_1, \\ldots, a_{n-1}), a_n)$."
     },
     {
       "id": "gcd-minimality",
       "title": "GCD as Minimum Positive Linear Combination",
       "startLine": 235,
       "endLine": 262,
-      "summary": "gcd_eq_min_pos_linear_comb: gcd(a,b) ≤ c for any positive c achievable as a*x+b*y (since gcd ∣ c and c > 0). gcd_achievable: gcd(a,b) is itself achievable via Nat.gcdA, Nat.gcdB and Nat.gcd_eq_gcd_ab. Together: gcd(a,b) is the minimum element of the positive linear combinations."
+      "summary": "gcd_eq_min_pos_linear_comb: gcd(a,b) ≤ c for any positive c achievable as a*x+b*y (since gcd ∣ c and c > 0). gcd_achievable: gcd(a,b) is itself achievable via Nat.gcdA, Nat.gcdB and Nat.gcd_eq_gcd_ab. Together: gcd(a,b) is the minimum element of the positive linear combinations.",
+      "mathContext": "The GCD admits an alternative characterization: $\\gcd(a,b) = \\min\\{ax + by : x, y \\in \\mathbb{Z},\\, ax + by > 0\\}$. This is equivalent to saying the ideal $(a,b) \\cap \\mathbb{N}_{>0}$ has minimum $\\gcd(a,b)$. The proof uses $d \\mid c$ and $c > 0$ to conclude $d \\leq c$ via `Nat.le_of_dvd`."
     },
     {
       "id": "ideal-characterization",
       "title": "Complete GCD Ideal Characterization",
       "startLine": 265,
       "endLine": 349,
-      "summary": "gcd_complete_characterization: d = gcd(a,b) ↔ (d is achievable as ax+by) AND (d divides all achievable values). Forward: d | gcd (d divides Nat.gcdA,gcdB combination = gcd) and gcd | d (gcd divides the achieving combination = d), so d = gcd by Nat.dvd_antisymm. Backward: gcd_achievable and gcd divides all ax+by by gcd_divides_linear_combination."
+      "summary": "gcd_complete_characterization: d = gcd(a,b) ↔ (d is achievable as ax+by) AND (d divides all achievable values). Forward: d | gcd (d divides Nat.gcdA,gcdB combination = gcd) and gcd | d (gcd divides the achieving combination = d), so d = gcd by Nat.dvd_antisymm. Backward: gcd_achievable and gcd divides all ax+by by gcd_divides_linear_combination.",
+      "mathContext": "The ideal characterization: $d = \\gcd(a,b)$ iff $(a,b) = (d)$ as ideals in $\\mathbb{Z}$. Equivalently: $d \\in (a,b)$ (achievability) AND $(a,b) \\subseteq (d)$ (divisibility). The proof uses double divisibility: $\\gcd \\mid d$ (from achievability of $d$) and $d \\mid \\gcd$ (from divisibility of Bézout witnesses), hence $d = \\gcd$ by `Nat.dvd_antisymm`."
     }
   ],
   "conclusion": {
@@ -204,5 +210,35 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0
-  }
+  },
+  "references": [
+    {
+      "authors": "Bézout, Étienne",
+      "title": "Théorie générale des équations algébriques",
+      "year": "1779",
+      "venue": "Paris: Ph.-D. Pierres",
+      "note": "Contains the original statement of Bézout's identity for polynomials and integers, establishing that gcd(a,b) is expressible as a linear combination ax + by"
+    },
+    {
+      "authors": "Hardy, G.H.; Wright, E.M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "venue": "Oxford University Press (6th edition 2008)",
+      "note": "Chapter 2 covers the Euclidean algorithm, Bézout's identity, and the complete parametrization of solutions to linear Diophantine equations ax + by = c"
+    },
+    {
+      "authors": "Niven, Ivan; Zuckerman, Herbert S.; Montgomery, Hugh L.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1991",
+      "venue": "John Wiley & Sons, 5th edition",
+      "note": "Section 1.3: complete treatment of linear Diophantine equations, including the solution lattice structure and the GCD ideal characterization"
+    },
+    {
+      "authors": "Ireland, Kenneth; Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer GTM 84, 2nd edition",
+      "note": "Chapter 1 presents the ideal-theoretic characterization of GCD in ℤ and its connection to the principal ideal domain structure"
+    }
+  ]
 }

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
@@ -76,42 +76,48 @@
       "title": "Module Documentation",
       "summary": "States the open question (can the algebraic coefficient-comparison proof be formalized?), outlines the four components, and lists references.",
       "startLine": 1,
-      "endLine": 24
+      "endLine": 24,
+      "mathContext": "The algebraic proof of Vandermonde's identity: extract $[X^r]$ from both sides of $(1+X)^{m+n} = (1+X)^m \\cdot (1+X)^n$ to get $\\binom{m+n}{r} = \\sum_{i+j=r} \\binom{m}{i}\\binom{n}{j}$. This is the generating function approach to combinatorial identities."
     },
     {
       "id": "exponent-law",
       "title": "Exponent Law",
       "summary": "The polynomial identity (1+X)^(m+n) = (1+X)^m · (1+X)^n, proved in one line via pow_add — the monoid exponent law applied to ℕ[X].",
       "startLine": 28,
-      "endLine": 37
+      "endLine": 37,
+      "mathContext": "$(1+X)^{m+n} = (1+X)^m \\cdot (1+X)^n$ in $\\mathbb{N}[X]$. This is the monoid law $a^{m+n} = a^m \\cdot a^n$ applied to the commutative monoid $(\\mathbb{N}[X], \\cdot)$. The one-line proof `pow_add` encapsulates the algebraic foundation of the entire file."
     },
     {
       "id": "vandermonde",
       "title": "Vandermonde's Identity",
       "summary": "The antidiagonal convolution formula C(m+n,r) = Σ_{i+j=r} C(m,i)·C(n,j) via Nat.add_choose_eq, plus the symmetry theorem.",
       "startLine": 38,
-      "endLine": 55
+      "endLine": 55,
+      "mathContext": "Vandermonde's identity: $\\binom{m+n}{r} = \\sum_{k=0}^{r} \\binom{m}{k}\\binom{n}{r-k} = \\sum_{i+j=r} \\binom{m}{i}\\binom{n}{j}$. The sum runs over the antidiagonal $\\{(i,j) : i+j=r\\}$ of the grid $[0,m] \\times [0,n]$. Combinatorially: choosing $r$ items from $m+n$ is equivalent to choosing $i$ from the first $m$ and $j = r-i$ from the last $n$."
     },
     {
       "id": "cauchy",
       "title": "Cauchy Product Structure",
       "summary": "The Cauchy product formula, coefficient comparison principle, and the algebraic proof structure connecting all three layers.",
       "startLine": 56,
-      "endLine": 78
+      "endLine": 78,
+      "mathContext": "The Cauchy product: if $f(X) = \\sum a_n X^n$ and $g(X) = \\sum b_n X^n$, then $(fg)(X) = \\sum_r (\\sum_{i+j=r} a_i b_j) X^r$. Applying this to $(1+X)^m \\cdot (1+X)^n$ with $a_i = \\binom{m}{i}$ and $b_j = \\binom{n}{j}$, the $r$th coefficient is $\\sum_{i+j=r} \\binom{m}{i}\\binom{n}{j}$, which must equal $[X^r](1+X)^{m+n} = \\binom{m+n}{r}$."
     },
     {
       "id": "corollaries",
       "title": "Corollaries",
       "summary": "Equal parameters case C(2n,r) = Σ C(n,i)·C(n,j) and Pascal's rule as the m=1 specialization of Vandermonde.",
       "startLine": 79,
-      "endLine": 93
+      "endLine": 93,
+      "mathContext": "Setting $m = n$: $\\binom{2n}{r} = \\sum_{i+j=r} \\binom{n}{i}\\binom{n}{j}$. The central case $r = n$ gives $\\binom{2n}{n} = \\sum_{k=0}^{n} \\binom{n}{k}^2$ (Chu-Vandermonde). Setting $m = 1$: $\\binom{1+n}{r} = \\binom{n}{r-1} + \\binom{n}{r}$, which is Pascal's rule."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Packaging theorem bundling the exponent law, Vandermonde identity, and Cauchy product into a single conjunction.",
       "startLine": 94,
-      "endLine": 111
+      "endLine": 111,
+      "mathContext": "The bundled result: $(1+X)^{m+n} = (1+X)^m(1+X)^n$ $\\wedge$ $\\binom{m+n}{r} = \\sum_{i+j=r} \\binom{m}{i}\\binom{n}{j}$ $\\wedge$ Cauchy product structure. Provides a single import point for downstream proofs needing generating function techniques."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Enrichment pass adding `mathContext` fields to sections across 19 gallery entries. Total: ~88 section `mathContext` fields added, 4 references added.

### Entries enriched:
| Entry | Changes |
|-------|---------|
| bezout-identity-oq-04 | 6 sections + 4 references |
| ballot-problem-oq-01 | 7 sections |
| basel-problem-oq-01 | 7 sections |
| area-of-circle-oq-03-oq-02 | 5 sections |
| binomial-theorem-oq-04-oq-02 | 6 sections |
| arithmetic-series-oq-02-oq-02 | 6 sections |
| bezout-identity-oq-02 | 7 sections |
| bezout-identity-oq-02-oq-01 | 7 sections |
| bezout-identity-oq-03-oq-01 | 7 sections |
| area-of-circle-oq-03 | 6 sections |
| area-of-circle-oq-01-oq-02 | 5 sections |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | 5 sections |
| bezout-identity-oq-03-oq-01-oq-01 | 7 sections |
| bezout-identity-oq-03-oq-01-oq-01-oq-01 | 5 sections |
| ballot-problem-oq-01-oq-01 | 2 sections |
| cantor-diagonalization-oq-01 | 7 sections |
| cantors-theorem-oq-01 | 7 sections |
| buffons-needle-oq-01 | 5 sections |
| buffons-needle-oq-02 | 7 sections |

🤖 Generated with [Claude Code](https://claude.com/claude-code)