### PR TITLE
Enrich bertrands-postulate-oq-03: expand history, fix mathContext

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/meta.json
@@ -69,7 +69,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "Bertrand conjectured in 1845 that every interval (n, 2n] contains at least one prime. Chebyshev verified this in 1852, and Erdős gave an elegant elementary proof in 1932 using central binomial coefficients. But the deeper question is: how precisely are primes distributed in much shorter intervals? The Prime Number Theorem (PNT) gives π(x) ~ x/ln(x), predicting ~h/ln(x) primes in [x, x+h] for 'large' h. The question of how small h can be while guaranteeing a prime is one of the central problems in analytic number theory.",
+    "historicalContext": "Bertrand conjectured in 1845 that every interval $(n, 2n]$ contains at least one prime — a result he verified empirically up to $n = 3{,}000{,}000$. Chebyshev gave the first proof in 1852 using bounds on the Chebyshev functions $\\theta(x) = \\sum_{p \\leq x} \\log p$ and $\\psi(x) = \\sum_{p^k \\leq x} \\log p$. In 1932, the 19-year-old Paul Erdős gave an elegant elementary proof using properties of central binomial coefficients $\\binom{2n}{n}$ — his first published paper, which launched a legendary career.\n\nThe deeper question — how short an interval $[x, x+h]$ can be guaranteed to contain a prime — has driven analytic number theory since Riemann's 1859 memoir. The Prime Number Theorem (PNT), proved independently by Hadamard and de la Vallée Poussin in 1896, gives $\\pi(x) \\sim x/\\ln x$, predicting $\\sim h/\\ln x$ primes in $[x, x+h]$ for large $h$. Hoheisel (1930) first proved a prime exists in $[x, x + x^{1-1/33000}]$ for large $x$, and successive improvements by Ingham (1937, $\\theta = 5/8$), Heath-Brown (1988, $\\theta = 7/12$), and Baker-Harman-Pintz (2001, $\\theta = 0.525$) have pushed the exponent steadily downward. Cramér conjectured in 1936 — based on a probabilistic model of primes — that the maximal prime gap near $p$ is $O((\\log p)^2)$, which would give $\\theta \\to 0$ with polylogarithmic correction. Legendre's older conjecture (c. 1808) that every interval $[n^2, (n+1)^2]$ contains a prime remains open after more than two centuries. Both conjectures are far beyond current proof techniques, which rely on zero-free regions of the Riemann zeta function.",
     "problemStatement": "**Open Question**: What is the smallest θ such that every interval [x, x+x^θ] contains a prime for all sufficiently large x?\n\n**Known**: Baker-Harman-Pintz (2001) proved θ = 0.525 works.\n**Open**: Does θ < 1/2 work? Does θ → 0 work with a poly-log correction (Cramér's conjecture)? Does every [n², (n+1)²] contain a prime (Legendre's conjecture)?",
     "text": "A 308-line formalization exploring prime density in short intervals beyond Bertrand's postulate. Defines `primeCountInInterval lo hi` as $\\pi(hi) - \\pi(lo)$ and proves $\\pi(2^m) \\geq m$ by iterating Bertrand (each doubling contributes at least one prime). This yields the logarithmic lower bound $\\pi(n) \\geq \\log_2(n)$ for $n \\geq 2$. Introduces `PrimeGapConjecture(\\theta)` — the assertion that every interval $[x, x + x^\\theta]$ contains a prime for $x \\geq 2$ — and proves it is monotone in $\\theta$. Three axioms capture deep results: Bertrand as $\\text{PrimeGapConjecture}(1)$, Baker-Harman-Pintz (2001) as $\\text{PrimeGapConjecture}(0.525)$, and Cramér's conjecture. Legendre's conjecture (prime between consecutive squares) follows from $\\text{PrimeGapConjecture}(1/2)$, which remains open.",
     "proofStrategy": "Start with Bertrand's Postulate (prime in (n, 2n]) and iterate: if π(n) counts primes up to n, then π(2n) ≥ π(n) + 1 by Bertrand. Iterating k times gives π(2^k * n) ≥ π(n) + k. Setting n=1 gives π(2^m) ≥ m. Since 2^(log₂ n) ≤ n, this yields the logarithmic bound π(n) ≥ log₂(n). The short-interval question (the open part) is then captured via axioms for Baker-Harman-Pintz, Cramér, and Legendre.",
@@ -92,7 +92,7 @@
       "startLine": 1,
       "endLine": 66,
       "summary": "Imports, the density hierarchy table (from x^(log x)² to 2n), and the key new result π(2^m) ≥ m.",
-      "mathContext": "Imports, the density hierarchy table (from x^(log x)² to 2n), and the key new result π(2^m) ≥ m."
+      "mathContext": "The density hierarchy: $\\text{Cramér}: [x, x + (\\log x)^2] \\subset \\text{Legendre}: [n^2, (n+1)^2] \\subset \\text{BHP}: [x, x + x^{0.525}] \\subset \\text{Bertrand}: (n, 2n]$. Each level guarantees a prime in progressively shorter intervals."
     },
     {
       "id": "definitions",
@@ -100,7 +100,7 @@
       "startLine": 67,
       "endLine": 89,
       "summary": "primeCountInInterval as π(hi) - π(lo), with monotonicity and the key conversion lemma.",
-      "mathContext": "primeCountInInterval as π(hi) - π(lo), with monotonicity and the key conversion lemma."
+      "mathContext": "$\\text{primeCountInInterval}(\\text{lo}, \\text{hi}) = \\pi(\\text{hi}) - \\pi(\\text{lo}) = |\\{p \\text{ prime} : \\text{lo} < p \\leq \\text{hi}\\}|$. Monotonicity: $\\text{lo} \\leq \\text{lo}' \\Rightarrow \\pi(\\text{lo}') \\geq \\pi(\\text{lo})$."
     },
     {
       "id": "bertrand-bounds",
@@ -108,7 +108,7 @@
       "startLine": 90,
       "endLine": 124,
       "summary": "bertrand_interval_nonempty (every (n,2n] has ≥1 prime), π(2^m) ≥ m, and iterated Bertrand giving π(2^k*n) ≥ π(n)+k.",
-      "mathContext": "bertrand_interval_nonempty (every (n,2n] has ≥1 prime), π(2^m) ≥ m, and iterated Bertrand giving π(2^k*n) ≥ π(n)+k."
+      "mathContext": "Bertrand: $\\forall n \\geq 1, \\exists p \\text{ prime}: n < p \\leq 2n$. Iterated $k$ times: $\\pi(2^k \\cdot n) \\geq \\pi(n) + k$. Setting $n = 1$: $\\pi(2^m) \\geq m$."
     },
     {
       "id": "log-lower-bound",
@@ -116,7 +116,7 @@
       "startLine": 125,
       "endLine": 148,
       "summary": "From π(2^m) ≥ m and 2^(log₂ n) ≤ n, proved: π(n) ≥ log₂(n) for all n ≥ 2.",
-      "mathContext": "From π(2^m) ≥ m and 2^(log₂ n) ≤ n, proved: π(n) ≥ log₂(n) for all n ≥ 2."
+      "mathContext": "Since $2^{\\lfloor \\log_2 n \\rfloor} \\leq n$, monotonicity gives $\\pi(n) \\geq \\pi(2^{\\lfloor \\log_2 n \\rfloor}) \\geq \\lfloor \\log_2 n \\rfloor$. This is weaker than PNT's $\\pi(n) \\sim n/\\ln n$ but proved from Bertrand alone, without complex analysis."
     },
     {
       "id": "pnt-axioms",
@@ -124,7 +124,7 @@
       "startLine": 149,
       "endLine": 173,
       "summary": "pnt_ratio_form (π(x) ~ x/ln x) and pnt_medium_interval_density — PNT-derived results axiomatized since PNT is not in base Mathlib.",
-      "mathContext": "pnt_ratio_form (π(x) ~ x/ln x) and pnt_medium_interval_density — PNT-derived results axiomatized since PNT is not in base Mathlib."
+      "mathContext": "$\\pi(x) \\sim x/\\ln x$ (PNT, Hadamard and de la Vallée Poussin, 1896). For intervals: $\\pi(x+h) - \\pi(x) \\sim h/\\ln x$ when $h = x^\\theta$ with $\\theta > 1/2$ (conditional on RH) or $\\theta > 0.525$ (unconditional, BHP)."
     },
     {
       "id": "bhp-theorem",
@@ -132,7 +132,7 @@
       "startLine": 174,
       "endLine": 192,
       "summary": "bhp_short_interval axiom: for x ≥ 1 and h ≥ x^0.525, the interval [x, x+h] contains a prime. The current best proved bound.",
-      "mathContext": "bhp_short_interval axiom: for x ≥ 1 and h ≥ x^0.525, the interval [x, x+h] contains a prime. The current best proved bound."
+      "mathContext": "Baker-Harman-Pintz (2001): $\\forall x \\geq x_0,\\; \\exists p \\text{ prime} \\in [x, x + x^{0.525}]$. The exponent $0.525 = 21/40$ improves on Heath-Brown's $7/12 \\approx 0.583$ using Harman's sieve method with trilinear exponential sums."
     },
     {
       "id": "open-conjectures",
@@ -140,7 +140,7 @@
       "startLine": 193,
       "endLine": 227,
       "summary": "cramer_conjecture (max prime gap O((log p)²)) and legendre_conjecture (prime in [n²,(n+1)²]) — both open since the 19th century.",
-      "mathContext": "cramer_conjecture (max prime gap O((log p)²)) and legendre_conjecture (prime in [n²,(n+1)²]) — both open since the 19th century."
+      "mathContext": "Cramér (1936): $p_{n+1} - p_n = O((\\log p_n)^2)$, i.e., maximal prime gaps grow as $(\\log p)^2$. Legendre (c. 1808): $\\forall n \\geq 1, \\exists p \\text{ prime}: n^2 < p < (n+1)^2$. Both imply $\\text{PrimeGapConjecture}(\\theta)$ for $\\theta$ near 0 and $\\theta = 1/2$ respectively."
     },
     {
       "id": "prime-gap-conjecture",
@@ -148,7 +148,7 @@
       "startLine": 228,
       "endLine": 308,
       "summary": "PrimeGapConjecture(θ) defined formally, monotonicity proved, BHP gives θ=0.525, density_question_status summarizes the full landscape.",
-      "mathContext": "PrimeGapConjecture(θ) defined formally, monotonicity proved, BHP gives θ=0.525, density_question_status summarizes the full landscape."
+      "mathContext": "$\\text{PrimeGapConjecture}(\\theta) :\\equiv \\forall x \\geq 2, \\exists p \\text{ prime} \\in [x, x + x^\\theta]$. Monotonicity: $\\theta_1 \\leq \\theta_2 \\Rightarrow \\text{PGC}(\\theta_1) \\Rightarrow \\text{PGC}(\\theta_2)$. Known: $\\text{PGC}(1)$ (Bertrand), $\\text{PGC}(0.525)$ (BHP). Open: $\\text{PGC}(1/2)$ (implies Legendre)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Enrichment pass for bertrands-postulate-oq-03 (quality: 100, passes: 0 → 1).

- **historicalContext**: Expanded from ~525 to ~1500 chars — added Hoheisel (1930), Ingham (1937), Heath-Brown (1988) progression, Chebyshev function details, Erdős's age context, zero-free region connection
- **sections.mathContext**: Fixed all 8 sections — were exact duplicates of the `summary` field (a quality gap), now contain proper LaTeX mathematical formulations with formulas and notation

## Test plan
- [x] JSON validated with Python json parser