### PR TITLE
Fix: erdos-884 sorry count 0→1

### DIFF
--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 884,
     "erdosUrl": "https://erdosproblems.com/884",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update sorry count from 0 to 1 in erdos-884 meta.json.

## Evidence

**Before**: `"sorries": 0` — overclaims; `numDivisors_mul_coprime` at line 217 has a sorry (Mathlib API breakage from v4.26.0)
**After**: `"sorries": 1` — matches actual Lean file

Closes #6295

---
Automated fix by lean-mechanic agent.