### PR TITLE
Revert false verified promotions

### DIFF
--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -7,7 +7,7 @@
     "author": "Vapnik-Chervonenkis (1971), Valiant (1984), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
     "date": "1984",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/PACLearning.lean",
     "tags": [
       "learning-theory",
@@ -16,7 +16,7 @@
       "cs-math-bridge",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdos, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1960",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ProbMethodAlteration.lean",
     "tags": [
       "probabilistic-method",
@@ -15,7 +15,7 @@
       "graph-theory",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos and collaborators, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1947",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ProbMethodApplications.lean",
     "tags": [
       "probabilistic-method",
@@ -16,7 +16,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
Reverts #6294 promotions. All three proofs contain True stub theorems disqualifying verified status. Demoting to formalized/wip.