### PR TITLE
Fix: erdos-884 sorry count mismatch

### DIFF
--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 884,
     "erdosUrl": "https://erdosproblems.com/884",
     "erdosProblemStatus": "open",
@@ -61,7 +61,7 @@
       "Examples: divisors of 6, prime divisors, prime case equality"
     ],
     "axiomCount": 9,
-    "assumptions": "9 axioms: divisorList_sorted, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, erdos_884 (main conjecture), divisors_6, divisors_prime, prime_case_equality, gap_lower_bound. 3 proved: allPairsSum_nonneg (sum_nonneg), consecutivePairsSum_nonneg (sum_nonneg), numDivisors_mul_coprime (Mathlib).",
+    "assumptions": "9 axioms: divisorList_sorted, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, erdos_884 (main conjecture), divisors_6, divisors_prime, prime_case_equality, gap_lower_bound. 2 proved: allPairsSum_nonneg (sum_nonneg), consecutivePairsSum_nonneg (sum_nonneg). 1 sorry: numDivisors_mul_coprime (Mathlib API breakage in v4.26.0).",
     "lineCount": 168
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update erdos-884 meta.json sorry count from 0 to 1 to match actual Lean source.

## Evidence

**Before**: `"sorries": 0` — overclaims; `numDivisors_mul_coprime` at line 217 has a sorry from Mathlib v4.26.0 API breakage
**After**: `"sorries": 1` — matches reality; assumptions field updated

`pnpm build` passes.

Closes #6295

---
Automated fix by lean-mechanic agent.