### PR TITLE
Research: erdos-1150 - Fix IsUltraflat definition and eliminate sorry

### DIFF
--- a/proofs/Proofs/Erdos1150Problem.lean
+++ b/proofs/Proofs/Erdos1150Problem.lean
@@ -41,9 +41,12 @@ namespace Erdos1150
 def IsLittlewoodPolynomial (p : Polynomial ℂ) : Prop :=
   ∀ i ≤ p.natDegree, p.coeff i = 1 ∨ p.coeff i = -1
 
-/-- The supremum of |P(z)| over the unit circle. -/
+/-- The supremum of |P(z)| over the unit circle.
+    Defined over the unit circle subtype for clean `ciSup_le` interaction. -/
 noncomputable def supNorm (p : Polynomial ℂ) : ℝ :=
-  ⨆ (z : ℂ) (_ : ‖z‖ = 1), ‖p.eval z‖
+  ⨆ (z : {z : ℂ // ‖z‖ = 1}), ‖p.eval z.1‖
+
+instance : Nonempty {z : ℂ // ‖z‖ = 1} := ⟨⟨1, norm_one⟩⟩
 
 /-
 ## The Main Conjecture
@@ -84,50 +87,66 @@ theorem parseval_bound_pos (n : ℕ) (hn : n ≥ 1) :
 ## Equivalent Formulation: No Ultraflat Littlewood Polynomials
 -/
 
-/-- A sequence of Littlewood polynomials is **ultraflat** if the ratio
-    max_{|z|=1}|P_n(z)| / √n → 1 as n → ∞. -/
+/-- A sequence of Littlewood polynomials is **ultraflat** if their degrees
+    tend to infinity and the ratio max_{|z|=1}|P_n(z)| / √(deg P_n) → 1.
+
+    Note: The degrees need not be exactly n — this allows subsequences,
+    which is the standard mathematical definition. The old definition
+    requiring `(P n).natDegree = n` for all n was too restrictive:
+    ¬Conjecture gives witnesses for infinitely many n (not all n),
+    making the backward direction of the equivalence unprovable. -/
 def IsUltraflat (P : ℕ → Polynomial ℂ) : Prop :=
   (∀ n, IsLittlewoodPolynomial (P n)) ∧
-  (∀ n, (P n).natDegree = n) ∧
-  Filter.Tendsto (fun n => supNorm (P n) / Real.sqrt n) atTop (nhds 1)
+  (Filter.Tendsto (fun n => (P n).natDegree) atTop atTop) ∧
+  Filter.Tendsto (fun n => supNorm (P n) / Real.sqrt ↑((P n).natDegree)) atTop (nhds 1)
 
 /-- **Forward direction (proved):**
-    If the conjecture holds (∃ c > 0 with max|P| > (1+c)√n eventually),
-    then no ultraflat Littlewood sequence exists.
+    If the conjecture holds, then no ultraflat Littlewood sequence exists.
 
-    Proof: If supNorm(P_n) > (1+c)√n eventually, then
-    supNorm(P_n)/√n > 1+c eventually, which contradicts
-    supNorm(P_n)/√n → 1. -/
+    Proof: The conjecture gives a lower bound (1+c)√(degree) for all Littlewood
+    polynomials of large degree. Since degrees → ∞ in an ultraflat sequence,
+    the bound eventually applies, giving ratio > 1+c. But the ultraflat condition
+    says ratio → 1, so eventually ratio < 1+c. Contradiction. -/
 theorem conjecture_implies_no_ultraflat :
     Erdos1150Conjecture → ∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P := by
-  intro ⟨c, hc, hev⟩ P ⟨hlit, hdeg, htend⟩
-  -- From the conjecture: eventually supNorm(P n) > (1+c)√n
-  -- Since P n has degree n and is Littlewood, eventually ratio > 1+c
-  have hev' : ∀ᶠ n in atTop, supNorm (P n) / Real.sqrt n > 1 + c := by
-    apply (hev.and (Filter.eventually_atTop.mpr ⟨1, fun n hn => hn⟩)).mono
-    intro n ⟨hn, hn_pos⟩
-    have hspecial := hn (P n) (hdeg n) (hlit n)
-    have hsqrt_pos : (0 : ℝ) < Real.sqrt n := by
-      apply Real.sqrt_pos_of_pos; exact_mod_cast (show 0 < n by omega)
-    exact lt_div_iff₀ hsqrt_pos |>.mpr (by linarith)
-  -- From ultraflat: supNorm(P n)/√n → 1, so eventually < 1 + c
-  have hlt : ∀ᶠ n in atTop, supNorm (P n) / Real.sqrt n < 1 + c := by
+  intro ⟨c, hc, hev⟩ P ⟨hlit, hdeg_tend, htend⟩
+  -- Pull back the conjecture bound through the degree sequence
+  have hpull : ∀ᶠ n in atTop,
+      supNorm (P n) > (1 + c) * Real.sqrt ↑((P n).natDegree) :=
+    (hdeg_tend.eventually hev).mono fun n hn => hn (P n) rfl (hlit n)
+  -- Eventually degree > 0, so √degree > 0
+  have hdeg_pos : ∀ᶠ n in atTop, 0 < (P n).natDegree :=
+    hdeg_tend.eventually (Filter.eventually_atTop.mpr ⟨1, fun m hm => by omega⟩)
+  -- Therefore ratio > 1+c eventually
+  have hev' : ∀ᶠ n in atTop,
+      supNorm (P n) / Real.sqrt ↑((P n).natDegree) > 1 + c := by
+    apply (hpull.and hdeg_pos).mono
+    intro n ⟨hgt, hpos⟩
+    have hsqrt_pos : (0 : ℝ) < Real.sqrt ↑((P n).natDegree) :=
+      Real.sqrt_pos_of_pos (Nat.cast_pos.mpr hpos)
+    exact (lt_div_iff₀ hsqrt_pos).mpr (by linarith)
+  -- From ultraflat: ratio → 1, so eventually < 1+c
+  have hlt : ∀ᶠ n in atTop,
+      supNorm (P n) / Real.sqrt ↑((P n).natDegree) < 1 + c := by
     have hmem : Set.Iio (1 + c) ∈ nhds (1 : ℝ) := Iio_mem_nhds (by linarith)
-    exact Filter.Eventually.mono (htend hmem) fun n hn => hn
+    exact htend hmem
   -- Contradiction: eventually > 1+c AND eventually < 1+c
-  have hboth := hev'.and hlt
-  obtain ⟨n, hgt, hlt'⟩ := hboth.exists
+  obtain ⟨n, hgt, hlt'⟩ := (hev'.and hlt).exists
   linarith
 
 /-- **Backward direction (axiomatized):**
     If no ultraflat Littlewood sequence exists, then the conjecture holds.
 
-    Proof sketch: By contrapositive. If no c works, then for each k,
-    there exists n_k and a Littlewood P_k of degree n_k with
-    supNorm(P_k) ≤ (1+1/k)√n_k. Taking k → ∞ yields an ultraflat
-    sequence, contradicting the hypothesis.
+    Proof sketch (contrapositive): Assume ¬Conjecture. For each k ≥ 1,
+    the negation gives arbitrarily large n with a degree-n Littlewood P
+    satisfying supNorm(P) ≤ (1+1/k)√n. By dependent choice, extract a
+    strictly increasing sequence n₁ < n₂ < ... with corresponding
+    Littlewood P_k of degree n_k and supNorm(P_k)/√n_k ≤ 1+1/k.
+    Combined with Parseval (ratio ≥ √((n+1)/n) → 1), the squeeze theorem
+    gives ratio → 1, yielding an ultraflat sequence.
 
-    This requires countable choice and a careful diagonal argument. -/
+    This proof requires dependent choice, Filter.Frequently ↔ ¬Eventually,
+    and the squeeze theorem for Tendsto. -/
 axiom no_ultraflat_implies_conjecture :
     (∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P) → Erdos1150Conjecture
 
@@ -174,9 +193,8 @@ theorem bbmst_upper_bound_exists :
       supNorm p ≤ c₂ * Real.sqrt n := by
   obtain ⟨_, c₂, _, hc₂, hflat⟩ := bbmst_flat
   refine ⟨c₂, hc₂, hflat.mono fun n ⟨p, hdeg, hlit, hbound⟩ => ⟨p, hdeg, hlit, ?_⟩⟩
-  -- supNorm p = ⨆ z on unit circle of ‖p.eval z‖ ≤ c₂ * √n
-  -- since hbound z hz gives ‖p.eval z‖ ≤ c₂ * √n for each z on the unit circle
-  sorry -- supNorm p ≤ c₂√n from pointwise bound (ciSup API issue with ConditionallyCompleteLattice)
+  -- supNorm is iSup over unit circle subtype, so ciSup_le applies directly
+  exact ciSup_le fun z => (hbound z.1 z.2).2
 
 /-
 ## The Gap Between Flat and Ultraflat
@@ -231,7 +249,9 @@ ultraflat ±1 polynomials exist. Erdős conjectured they don't.
 
 **Proved in this file**:
 5. Conjecture ↔ no ultraflat ±1 sequences (forward direction proved,
-   backward direction axiomatized)
+   backward direction axiomatized). Uses subsequence-based ultraflat
+   definition (degrees → ∞, ratio → 1) for mathematical correctness.
+6. BBMST implies supNorm bound (proved from pointwise bound)
 -/
 theorem erdos_1150_summary :
     -- Parseval lower bound holds

--- a/src/data/proofs/erdos-1150/meta.json
+++ b/src/data/proofs/erdos-1150/meta.json
@@ -17,7 +17,7 @@
       "unit-circle"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axioms": 5,
     "erdosNumber": 1150,
     "erdosUrl": "https://erdosproblems.com/1150",
@@ -39,8 +39,8 @@
       "Axiom rudin_shapiro_bound (concrete ≤ √(2n) family)"
     ],
     "axiomCount": 5,
-    "lineCount": 250,
-    "assumptions": "5 axiom(s) and 1 sorry(s). Forward direction of equivalence (conjecture → no ultraflat) is proved; backward direction axiomatized."
+    "lineCount": 270,
+    "assumptions": "5 axiom(s) and 0 sorry(s). Forward direction of equivalence proved. Backward direction axiomatized. IsUltraflat uses subsequence-based definition for mathematical correctness."
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #1150 as part of his investigations into extremal properties of polynomials with restricted coefficients. The study of Littlewood polynomials — polynomials with all coefficients ±1 — dates to J.E. Littlewood's 1966 monograph, where he asked about the minimal sup norm on the unit circle. By Parseval's identity, every degree-$n$ Littlewood polynomial satisfies $\\max_{|z|=1}|P(z)| \\ge \\sqrt{n+1}$, since the $L^2$ norm equals $\\sqrt{n+1}$. The question is whether this can be improved by a multiplicative constant. Kahane's 1980 breakthrough showed that for general unimodular coefficients ($|a_k| = 1$, complex phases allowed), ultraflat polynomials exist — the sup norm can be made $(1+o(1))\\sqrt{n}$. This made the ±1 restriction the essential barrier. The problem gained renewed attention after Balister, Bollobás, Morris, Sahasrabudhe, and Tiba (BBMST, 2019) proved flat Littlewood polynomials exist ($c_1\\sqrt{n} \\le |P(z)| \\le c_2\\sqrt{n}$), resolving Erdős Problem #228. But flat is weaker than ultraflat: the gap between 'bounded ratio' and 'ratio converging to 1' is precisely what Problem #1150 asks about. The Rudin-Shapiro polynomials, constructed recursively since the 1950s, provide the best explicit examples with sup norm at most $\\sqrt{2(n+1)}$.",
@@ -99,8 +99,8 @@
       "title": "Known Results",
       "startLine": 142,
       "endLine": 183,
-      "summary": "Axiomatizes three landmark results: BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), and derives the BBMST upper bound consequence (contains 1 sorry for the supremum step).",
-      "mathContext": "Axiomatizes three landmark results: BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), and derives the BBMST upper bound consequence (contains 1 sorry for the supremum step)."
+      "summary": "Axiomatizes three landmark results: BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), and proves the BBMST upper bound consequence from pointwise bound via ciSup_le.",
+      "mathContext": "Axiomatizes three landmark results: BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), and proves the BBMST upper bound consequence from pointwise bound via ciSup_le."
     },
     {
       "id": "gap-analysis",
@@ -128,7 +128,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1150, an open question in extremal polynomial theory. The conjecture asks whether the sup norm of degree-$n$ Littlewood polynomials on the unit circle must exceed $(1+c)\\sqrt{n}$ for some universal $c > 0$ — equivalently, whether ultraflat Littlewood polynomials do not exist. All major known results are axiomatized: Parseval lower bound, BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), Rudin-Shapiro explicit bounds, and the equivalence with non-existence of ultraflat sequences. Three theorems are proved: positivity of the Parseval bound, logical non-implication of flat → ultraflat, and a combined summary of known results. Contains 1 sorry (routine supremum bound) and 5 axioms encoding deep results.",
+    "summary": "This formalization captures Erdős Problem #1150, an open question in extremal polynomial theory. The conjecture asks whether the sup norm of degree-$n$ Littlewood polynomials on the unit circle must exceed $(1+c)\\sqrt{n}$ for some universal $c > 0$ — equivalently, whether ultraflat Littlewood polynomials do not exist. All major known results are axiomatized: Parseval lower bound, BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), Rudin-Shapiro explicit bounds, and the equivalence with non-existence of ultraflat sequences. Key theorems proved: forward direction of the ultraflat equivalence, BBMST sup norm bound from pointwise bound (via ciSup_le), and a combined summary. Contains 0 sorries and 5 axioms encoding deep results. Uses subsequence-based IsUltraflat definition for mathematical correctness.",
     "implications": "**Theoretical Significance**: A positive resolution (confirming the conjecture) would establish that the discrete structure of {-1,+1} coefficients imposes a fundamental rigidity on polynomial behavior on the unit circle — a qualitative separation from the continuous case |$a_k$| = 1.\n\nThis would connect to concentration of measure phenomena and Boolean function analysis. A negative resolution (constructing ultraflat ±1 polynomials) would be equally striking, requiring new techniques beyond BBMST's probabilistic approach.",
     "openQuestions": [
       "Does the conjecture hold: is $\\inf_{P \\in \\mathcal{L}_n} \\|P\\|_\\infty / \\sqrt{n} > 1$ for all large $n$?",
@@ -165,7 +165,7 @@
       "Filter"
     ],
     "namespace": "Erdos1150",
-    "lineCount": 250,
+    "lineCount": 270,
     "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 4

--- a/src/data/research/problems/erdos-1150.json
+++ b/src/data/research/problems/erdos-1150.json
@@ -29,25 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved forward direction of equivalence (conjecture → no ultraflat). Reduced axiom conjecture_equiv_no_ultraflat to only the backward direction. File now has 253 lines, 5 axioms, 7 theorems, 1 sorry.",
+    "progressSummary": "PROGRESS: Fixed mathematical bug in IsUltraflat definition (subsequences, not all-n). Eliminated sorry in bbmst_upper_bound_exists via supNorm subtype redesign + ciSup_le. File now has 270 lines, 5 axioms, 7 theorems, 0 sorries.",
     "builtItems": [
       "conjecture_implies_no_ultraflat theorem: forward direction proved via filter contradiction",
-      "conjecture_equiv_no_ultraflat theorem: full equivalence from proved forward + axiom backward"
+      "conjecture_equiv_no_ultraflat theorem: full equivalence from proved forward + axiom backward",
+      "supNorm redesigned to use unit circle subtype for clean ciSup_le interaction",
+      "bbmst_upper_bound_exists: eliminated sorry via ciSup_le on subtype",
+      "IsUltraflat corrected: subsequence-based (Tendsto degree atTop atTop) instead of all-n"
     ],
     "insights": [
       "Forward direction is clean: supNorm/√n > 1+c eventually contradicts Tendsto ... (nhds 1)",
       "Backward direction needs countable choice: extract witnesses for 1/k, build ultraflat sequence",
-      "The bbmst_upper_bound_exists sorry requires ciSup handling for conditional supremum",
+      "Old IsUltraflat requiring degree=n for ALL n was mathematically incorrect: ¬Conjecture gives witnesses for infinitely many n only, so backward direction was unprovable",
+      "supNorm defined over subtype {z : ℂ // ‖z‖ = 1} avoids ciSup empty-index issues entirely",
       "Parseval axiom potentially provable if Mathlib has circle integration theory"
     ],
     "mathlibGaps": [
-      "ciSup over conditional types in ConditionallyCompleteLattice",
       "Integration on unit circle (for Parseval)"
     ],
     "nextSteps": [
-      "Fix bbmst_upper_bound_exists sorry",
-      "Prove no_ultraflat_implies_conjecture (diagonal argument)",
-      "Explore whether parseval_lower_bound is provable from Mathlib"
+      "Prove no_ultraflat_implies_conjecture (diagonal argument with dependent choice)",
+      "Explore whether parseval_lower_bound is provable from Mathlib",
+      "Consider proving rudin_shapiro_bound constructively"
     ],
     "markdown": "# Erdős #1150 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -73,11 +76,11 @@
     {
       "path": "Proofs/Erdos1150Problem.lean",
       "filename": "Erdos1150Problem.lean",
-      "lineCount": 208,
-      "theoremCount": 4,
+      "lineCount": 270,
+      "theoremCount": 7,
       "axiomCount": 5,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1150Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Fix mathematical bug in `IsUltraflat` definition: use subsequences (degrees → ∞) instead of requiring degree = n for all n
- Eliminate sorry in `bbmst_upper_bound_exists` by redesigning `supNorm` to use unit circle subtype
- Rewrite forward direction proof for new definitions

## Changes
**Mathematical correctness fix**: The old `IsUltraflat` required `(P n).natDegree = n` for ALL n, but the standard definition allows subsequences. The backward direction axiom (`no_ultraflat_implies_conjecture`) was unprovable with the old definition because ¬Conjecture only provides witnesses for infinitely many n, not all n.

**Sorry elimination**: Redesigned `supNorm` from `⨆ (z : ℂ) (_ : ‖z‖ = 1), ‖p.eval z‖` to `⨆ (z : {z : ℂ // ‖z‖ = 1}), ‖p.eval z.1‖`. This makes the unit circle nonempty by instance, enabling `ciSup_le` to close the sorry directly.

**Stats**: 270 lines, 5 axioms, 7 theorems, 0 sorries (was 1)

## Test plan
- [x] Docker build passes (`docker-build.sh Proofs.Erdos1150Problem`)
- [x] All existing theorems still compile
- [x] meta.json and problem JSON updated

🤖 Generated by researcher-3