### PR TITLE
Enrich ballot-problem-oq-02: fix axiom counts, align line ranges

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-02/annotations.json
@@ -4,11 +4,11 @@
     "proofId": "ballot-problem-oq-02",
     "range": {
       "startLine": 3,
-      "endLine": 66
+      "endLine": 55
     },
     "type": "context",
     "title": "Ballot Problem: From Bertrand's Discrete Result to Levy's Brownian Motion",
-    "content": "The module preamble frames the continuous-time ballot problem. The classical discrete ballot theorem (Bertrand 1887, Wiedijk #30) asks: if A gets p votes and B gets q votes with p>q, what is the probability A leads throughout? Answer: (p-q)/(p+q). The continuous generalization connects to Brownian motion via three key results: the Reflection Principle (P(max W >= a) = 2P(W_T >= a)), the First Passage Time Distribution (P(tau_a <= T) = 2(1-Phi(a/sqrt(T)))), and Levy's Arcsine Law (fraction of time BM spends positive has arcsine distribution). The file achieves 0 sorries with 3 axioms for deep results (reflection principle, first passage characterization, arcsine law), while proving all derived results including the discrete ballot formula.",
+    "content": "The module preamble frames the continuous-time ballot problem. The classical discrete ballot theorem (Bertrand 1887, Wiedijk #30) asks: if A gets p votes and B gets q votes with p>q, what is the probability A leads throughout? Answer: (p-q)/(p+q). The continuous generalization connects to Brownian motion via three key results: the Reflection Principle (P(max W >= a) = 2P(W_T >= a)), the First Passage Time Distribution (P(tau_a <= T) = 2(1-Phi(a/sqrt(T)))), and Levy's Arcsine Law (fraction of time BM spends positive has arcsine distribution). The file achieves 0 sorries with 2 axioms for deep results (reflection principle and first passage characterization), while proving all derived results including the discrete ballot formula. The arcsine law is discussed and its definition (`positiveTime`) is provided, but the arcsine distribution formula itself is not axiomatized in the Lean code.",
     "mathContext": "Reflection Principle (Levy): $P(\\max_{0\\leq s\\leq T} W_s \\geq a) = 2P(W_T \\geq a)$ for $a,T>0$. First passage: $P(\\tau_a \\leq T) = 2(1-\\Phi(a/\\sqrt{T}))$. Arcsine Law: $P(L_T/T \\leq r) = (2/\\pi)\\arcsin(\\sqrt{r})$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -29,8 +29,8 @@
     "id": "ann-ballot-oq02-02-bm-structure",
     "proofId": "ballot-problem-oq-02",
     "range": {
-      "startLine": 67,
-      "endLine": 100
+      "startLine": 61,
+      "endLine": 93
     },
     "type": "definition",
     "title": "BrownianMotion Structure: Axiomatic Framework with Key Properties",
@@ -55,8 +55,8 @@
     "id": "ann-ballot-oq02-03-symmetry",
     "proofId": "ballot-problem-oq-02",
     "range": {
-      "startLine": 101,
-      "endLine": 128
+      "startLine": 95,
+      "endLine": 130
     },
     "type": "technique",
     "title": "Symmetry: P(W_t > 0) = P(W_t < 0) from Gaussian Structure",
@@ -80,7 +80,7 @@
     "proofId": "ballot-problem-oq-02",
     "range": {
       "startLine": 145,
-      "endLine": 171
+      "endLine": 170
     },
     "type": "definition",
     "title": "First Passage Time and Max Event Definitions",
@@ -153,11 +153,11 @@
     "proofId": "ballot-problem-oq-02",
     "range": {
       "startLine": 228,
-      "endLine": 306
+      "endLine": 305
     },
     "type": "concept",
     "title": "Arcsine Law, Donsker Connection, and Main Ballot Theorem",
-    "content": "positiveTime defines the time BM spends positive in [0,T] via Lebesgue measure. levy_arcsine_law is axiomatized: P(L_T/T <= r) = (2/pi)*arcsin(sqrt(r)), characterizing the arcsine distribution -- the fraction of positive time is NOT uniform but heavily concentrated near 0 and 1. The Donsker invariance principle (1951) is discussed informally: the scaled random walk S_{floor(nt)}/sqrt(n) converges to Brownian motion, connecting discrete and continuous ballot theorems. continuous_ballot_theorem packages the complete continuous ballot picture as a conjunction: reflection principle, first passage = max event, and positive passage probability.",
+    "content": "positiveTime defines the time BM spends positive in [0,T] via Lebesgue measure. The arcsine law P(L_T/T <= r) = (2/pi)*arcsin(sqrt(r)) is described mathematically but NOT axiomatized as a Lean axiom -- only the `positiveTime` definition is formalized. The Donsker invariance principle (1951) is discussed informally: the scaled random walk S_{floor(nt)}/sqrt(n) converges to Brownian motion, connecting discrete and continuous ballot theorems. continuous_ballot_theorem packages the complete continuous ballot picture as a conjunction: reflection principle, first passage = max event, and positive passage probability.",
     "mathContext": "Arcsine law: $P(L_T/T \\leq r) = (2/\\pi)\\arcsin(\\sqrt{r})$. Density $f(x) = 1/(\\pi\\sqrt{x(1-x)})$ is infinite at 0 and 1 -- most time is spent near 0 (all negative) or $T$ (all positive). Main theorem: conjunction of reflection principle, first passage characterization, and positivity.",
     "significance": "key",
     "relatedConcepts": [
@@ -178,7 +178,7 @@
     "proofId": "ballot-problem-oq-02",
     "range": {
       "startLine": 308,
-      "endLine": 340
+      "endLine": 339
     },
     "type": "insight",
     "title": "Discrete Ballot Theorem: (p-q)/(p+q) via Bertrand-Cycle Lemma",

--- a/src/data/proofs/ballot-problem-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02/meta.json
@@ -5,7 +5,7 @@
   "description": "Continuous-time versions of the ballot problem, connecting to Brownian motion and the reflection principle. Formalizes the reflection principle, first passage time distributions, and Lévy's Arcsine Law.",
   "meta": {
     "author": "Lévy (1939), Donsker (1951)",
-    "sourceUrl": "",
+    "sourceUrl": "http://www.numdam.org/item/CM_1940__7__283_0/",
     "date": "1939",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/BallotProblemOQ02.lean",
@@ -37,7 +37,7 @@
       "firstPassageTime_eq_maxEvent axiom: {τ_a ≤ T} = maxEvent (from path continuity)",
       "First passage CDF: P(τ_a ≤ T) = 2·P(W_T ≥ a) proved without sorry",
       "First passage time monotonicity: higher levels take longer to reach",
-      "Lévy Arcsine Law axiom: fraction of positive time has arcsine distribution",
+      "positiveTime definition: Lebesgue measure of time BM spends positive, supporting the arcsine law description",
       "Main continuous ballot theorem combining all components (0 sorries)"
     ],
     "dateAdded": "2026-02-24",
@@ -56,7 +56,7 @@
   "overview": {
     "historicalContext": "The classical ballot problem was posed by Joseph Bertrand in 1887 in the *Comptes Rendus*: if candidate A receives $p$ votes and B receives $q$ votes with $p > q$, the probability A leads throughout counting is $(p-q)/(p+q)$. Désiré André gave the first proof using the reflection principle for lattice paths. The continuous-time version emerged from Louis Bachelier's 1900 thesis on stock price fluctuations — the first mathematical treatment of Brownian motion, predating Einstein's 1905 paper. Paul Lévy (1939) rigorously developed the reflection principle for Brownian motion, proving $P(\\max_{s \\leq T} W_s \\geq a) = 2P(W_T \\geq a)$, and discovered the arcsine law for the fraction of time BM spends positive. Monroe Donsker's 1951 invariance principle (functional CLT) formally connected discrete and continuous ballot theorems: the rescaled random walk converges in distribution to Brownian motion, making the discrete formula $(p-q)/(p+q)$ a finite approximation of the continuous reflection principle.",
     "problemStatement": "**Continuous Ballot Problem**: For standard Brownian motion W on [0,T]:\n\n1. **Reflection Principle** (Lévy 1939): P(max_{s≤T} W_s ≥ a) = 2·P(W_T ≥ a)\n2. **First Passage CDF**: P(τ_a ≤ T) = 2·P(W_T ≥ a) = 2(1 - Φ(a/√T))\n3. **Arcsine Law**: The fraction of [0,T] where W > 0 has the arcsine distribution\n\nThese give the complete probabilistic description of Brownian motion relative to a level.",
-    "text": "A 339-line axiomatic formalization of the continuous-time ballot problem via Brownian motion. The file defines a `BrownianMotion` structure with Gaussian marginals ($W_t \\sim N(0,t)$), symmetry, measurability, and continuous paths. Symmetry theorems ($P(W_t > 0) = P(W_t < 0)$) are proved from the structure axioms. The reflection principle $P(\\max_{s \\leq T} W_s \\geq a) = 2P(W_T \\geq a)$ is axiomatized (requires the strong Markov property, unavailable in Mathlib 4.26.0), and the first passage CDF $P(\\tau_a \\leq T) = 2P(W_T \\geq a)$ is derived via the linking axiom `firstPassageTime_eq_maxEvent`. First passage time monotonicity ($a' > a \\Rightarrow P(\\tau_{a'} \\leq T) \\leq P(\\tau_a \\leq T)$) is proved directly. Lévy's arcsine law ($P(L_T/T \\leq r) = (2/\\pi)\\arcsin(\\sqrt{r})$) is axiomatized. The `continuous_ballot_theorem` packages all results into a single conjunction. A final section connects to the discrete ballot probability $(p-q)/(p+q) \\in [0,1]$. Total: 2 axioms, 0 sorries.",
+    "text": "A 339-line axiomatic formalization of the continuous-time ballot problem via Brownian motion. The file defines a `BrownianMotion` structure with Gaussian marginals ($W_t \\sim N(0,t)$), symmetry, measurability, and continuous paths. Symmetry theorems ($P(W_t > 0) = P(W_t < 0)$) are proved from the structure axioms. The reflection principle $P(\\max_{s \\leq T} W_s \\geq a) = 2P(W_T \\geq a)$ is axiomatized (requires the strong Markov property, unavailable in Mathlib 4.26.0), and the first passage CDF $P(\\tau_a \\leq T) = 2P(W_T \\geq a)$ is derived via the linking axiom `firstPassageTime_eq_maxEvent`. First passage time monotonicity ($a' > a \\Rightarrow P(\\tau_{a'} \\leq T) \\leq P(\\tau_a \\leq T)$) is proved directly. Lévy's arcsine law ($P(L_T/T \\leq r) = (2/\\pi)\\arcsin(\\sqrt{r})$) is described and the `positiveTime` definition is formalized, though the arcsine distribution formula is not declared as a Lean axiom. The `continuous_ballot_theorem` packages all results into a single conjunction. A final section connects to the discrete ballot probability $(p-q)/(p+q) \\in [0,1]$. Total: 2 axioms, 0 sorries.",
     "proofStrategy": "**Axiomatic Approach**: Since Mathlib 4.26.0 lacks full Brownian motion formalization, we axiomatize the key properties:\n\n1. Define BrownianMotion structure with measurability, Gaussian marginals, and symmetry\n2. Prove symmetry theorems from the structure axioms\n3. Take the reflection principle as an axiom (requires strong Markov property)\n4. Derive the first passage CDF from the reflection principle\n5. Axiomatize the Arcsine Law (requires deep analysis)\n6. Connect to the classical discrete ballot theorem via explicit arithmetic",
     "keyInsights": [
       "The reflection principle $P(\\max_{s \\leq T} W_s \\geq a) = 2P(W_T \\geq a)$ is the continuous analog of André's lattice path reflection",
@@ -79,62 +79,62 @@
       "id": "bm-structure",
       "title": "Brownian Motion Structure",
       "startLine": 75,
-      "endLine": 92,
+      "endLine": 93,
       "summary": "BrownianMotion structure with process W : ℝ → Ω → ℝ, measurability, zero start, Gaussian marginals, symmetry, and positive probability field.",
       "mathContext": "$W : \\mathbb{R} \\to \\Omega \\to \\mathbb{R}$ with $W_t \\sim N(0,t)$, $W_0 = 0$, and continuous paths"
     },
     {
       "id": "symmetry",
       "title": "Symmetry Properties",
-      "startLine": 93,
-      "endLine": 129,
+      "startLine": 95,
+      "endLine": 130,
       "summary": "P(W_t > 0) = P(W_t < 0) proved from the symmetry field. Both positive and negative outcomes have positive probability for t > 0.",
       "mathContext": "$P(W_t > 0) = P(W_t < 0) > 0$ for $t > 0$, from the `symmetric` field of `BrownianMotion`"
     },
     {
       "id": "reflection-principle",
       "title": "The Reflection Principle",
-      "startLine": 130,
-      "endLine": 166,
+      "startLine": 132,
+      "endLine": 186,
       "summary": "maxEvent definition and reflection_principle axiom: P(max W ≥ a in [0,T]) = 2·P(W_T ≥ a). Deep result requiring strong Markov property.",
       "mathContext": "$P(\\max_{s \\leq T} W_s \\geq a) = 2 \\cdot P(W_T \\geq a)$ (axiom, requires strong Markov property)"
     },
     {
       "id": "first-passage",
       "title": "First Passage Time Distribution",
-      "startLine": 167,
-      "endLine": 251,
+      "startLine": 188,
+      "endLine": 227,
       "summary": "firstPassageTime as sInf, first_passage_cdf (P(τ_a ≤ T) = 2P(W_T ≥ a)), monotonicity, and positivity of passage probability.",
       "mathContext": "$\\tau_a = \\inf\\{t : W_t \\geq a\\}$; $P(\\tau_a \\leq T) = 2P(W_T \\geq a) = 2(1 - \\Phi(a/\\sqrt{T}))$"
     },
     {
       "id": "arcsine-law",
       "title": "Lévy's Arcsine Law",
-      "startLine": 252,
-      "endLine": 260,
-      "summary": "positiveTime definition and levy_arcsine_law axiom: fraction of positive time has distribution (2/π)·arcsin(√r).",
+      "startLine": 228,
+      "endLine": 246,
+      "summary": "positiveTime definition: the Lebesgue measure of time BM spends positive in [0,T]. The arcsine distribution P(L_T/T <= r) = (2/pi)*arcsin(sqrt(r)) is described mathematically but not axiomatized in Lean.",
       "mathContext": "$P(L_T / T \\leq r) = (2/\\pi) \\arcsin(\\sqrt{r})$ where $L_T = \\text{Leb}\\{s \\leq T : W_s > 0\\}$"
     },
     {
       "id": "donsker-connection",
       "title": "Donsker's Functional CLT and Discrete-Continuous Bridge",
-      "startLine": 258,
-      "endLine": 276,
+      "startLine": 248,
+      "endLine": 269,
       "summary": "Commentary on Donsker's invariance principle (1951): the scaled random walk $S_{\\lfloor nt \\rfloor}/\\sqrt{n}$ converges to Brownian motion in distribution, making the discrete ballot formula $(p-q)/(p+q)$ a finite approximation of the continuous reflection principle.",
       "mathContext": "Donsker's theorem: $S_{\\lfloor nt \\rfloor}/\\sqrt{n} \\Rightarrow W_t$ in $C[0,1]$. Under this convergence, the maximum of the random walk scales to the maximum of Brownian motion, so discrete ballot probabilities converge to the continuous reflection principle formula."
     },
     {
       "id": "main-theorem",
       "title": "Main Continuous Ballot Theorem",
-      "startLine": 278,
-      "endLine": 315,
+      "startLine": 271,
+      "endLine": 306,
       "summary": "continuous_ballot_theorem combining reflection principle, first passage CDF, and positive probability in one package.",
       "mathContext": "Main theorem: conjunction of reflection principle ($P(\\max W \\geq a) = 2P(W_T \\geq a)$), first passage characterization ($\\{\\tau_a \\leq T\\} = \\text{maxEvent}$), and positive passage probability ($P(\\tau_a \\leq T) > 0$)"
     },
     {
       "id": "discrete-connection",
       "title": "Connection to Discrete Ballot",
-      "startLine": 327,
+      "startLine": 308,
       "endLine": 339,
       "summary": "discrete_ballot_probability: the value (p-q)/(p+q) is a valid probability in [0,1], connecting discrete and continuous formulations.",
       "mathContext": "$P(\\text{A leads throughout}) = (p-q)/(p+q) \\in [0, 1]$ for $p > q$ (Bertrand 1887)"
@@ -192,11 +192,12 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization provides a complete axiomatic framework for the continuous-time ballot problem via Brownian motion. The key results — reflection principle, first passage distributions, and arcsine law — are stated as axioms since Mathlib 4.26.0 lacks full BM formalization. All theorems now build without sorry: the firstPassageTime_eq_maxEvent axiom captures the path-continuity argument cleanly, and path_continuous was added as a BrownianMotion structure field.",
+    "summary": "This formalization provides a complete axiomatic framework for the continuous-time ballot problem via Brownian motion. Two axioms are used: `reflection_principle` (requires the strong Markov property) and `firstPassageTime_eq_maxEvent` (requires csInf theory for closed sets). The arcsine law is discussed mathematically and `positiveTime` is defined, but no axiom is declared for the arcsine distribution formula. All theorems build without sorry, and path_continuous is included as a BrownianMotion structure field.",
     "implications": "**Theoretical Significance**: This formalization isolates the precise axiomatic requirements for continuous-time ballot theory: Gaussian marginals and symmetry for the reflection principle, path continuity for the first passage time characterization, and the strong Markov property (the deepest ingredient, still axiomatized). The axiomatic approach serves as a roadmap for future Mathlib development of Brownian motion.\n\n**Applications**:\n\n1. **Mathematical finance**: Barrier option pricing (knock-in/knock-out options) uses the first passage CDF $P(\\tau_a \\leq T) = 2(1 - \\Phi(a/\\sqrt{T}))$ directly — the Black-Scholes barrier formula is a corollary\n2. **Physics**: First passage times model 1D diffusion hitting times, relevant to particle transport and chemical kinetics\n3. **Statistics**: Sequential analysis and CUSUM stopping rules are continuous-time ballot problems in disguise — the reflection principle gives exact boundary-crossing probabilities\n4. **Probability**: The arcsine law reveals counterintuitive behavior — Brownian motion spends most of its time entirely above or entirely below zero, not oscillating symmetrically",
     "openQuestions": [
       "Prove the reflection principle from the strong Markov property (requires full BM Markov theory)",
       "Prove firstPassageTime_eq_maxEvent from path_continuous (requires csInf theory for closed sets)",
+      "Axiomatize the arcsine law as a formal Lean axiom: P(positiveTime/T <= r) = (2/pi)*arcsin(sqrt(r))",
       "Formal proof of the Arcsine Law via BM local times",
       "Formal proof of Donsker's functional CLT connecting discrete and continuous ballot"
     ]
@@ -241,9 +242,7 @@
       "MeasureTheory",
       "ProbabilityTheory",
       "Set",
-      "Real",
-      "ProbabilityTheory",
-      "MeasureTheory"
+      "Real"
     ],
     "namespace": "ContinuousBallot",
     "lineCount": 339,
@@ -276,6 +275,11 @@
       "id": "ballot-problem-oq-03",
       "relationship": "sibling",
       "description": "The LGV lemma via 2D reflection provides a discrete determinantal approach to ballot counting, complementing this file's continuous-time Brownian motion formulation. Both generalize the original ballot problem: this file to continuous time via stochastic processes, LGV to multiple non-crossing paths via linear algebra"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relationship": "foundational",
+      "description": "Donsker's functional CLT bridges discrete and continuous ballot theorems: the rescaled random walk converges to Brownian motion, making the discrete ballot formula (p-q)/(p+q) a finite approximation of the continuous reflection principle"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for ballot-problem-oq-02 (passes: 0 → 1).

- **Fixed axiom count claims**: Lean file has 2 axioms (not 3 as claimed) — the arcsine law is described but not axiomatized. Corrected across meta.json and annotations.json
- **Aligned all 8 section line ranges** to match actual Lean file boundaries
- **Aligned 5 annotation line ranges** to match Lean source
- **Removed duplicate opens** in leanFile section
- **Added sourceUrl** (Lévy 1939 paper)
- **Synced relatedProofs** with crossReferences
- **Added open question** about formalizing arcsine law axiom

## Test plan
- [x] JSON validated
- [x] All 6 cross-reference targets verified