### PR TITLE
Enrich: batch cleanup (130 entries) + deep enrichment (7 notable entries)

### DIFF
--- a/src/data/proofs/central-limit-theorem/meta.json
+++ b/src/data/proofs/central-limit-theorem/meta.json
@@ -52,7 +52,12 @@
     ],
     "assumptions": "13 axioms encoding measure-theoretic infrastructure not yet available in Mathlib: (1) stdGaussian — standard Gaussian measure on ℝ, (2) stdGaussian_isProbabilityMeasure — probability measure instance, (3) gaussian_fourier_identity — Gaussian Fourier transform $\\int e^{itx} dN = e^{-t^2/2}$, (4) charFun_deriv_interchange — differentiation under the integral for characteristic functions, (5) integral_ofReal_eq_ofReal_integral — complex/real integral coercion, (6) charFun_taylor_remainder — Taylor expansion remainder bound $O(|t|^3)$, (7) charFun_normalized_sum_limit — core CLT convergence $[\\varphi(t/\\sqrt{n})]^n \\to e^{-t^2/2}$, (8) measureWeakTopology — weak-* topology on measures, (9) levy_continuity_axiom — Lévy continuity theorem, (10) clt_general_case_axiom — CLT for non-standardized distributions, (11) renormalization_measure — n-fold convolution and scaling, (12) gaussian_fixed_point_axiom — Gaussian fixed point under renormalization, (13) gaussian_attractor_axiom — Gaussian as attractor of renormalization flow. The substantive original proofs are charFun_zero, charFun_deriv_mean, limit_one_plus_x_over_n, and gaussian_charFun.",
     "proofRepoPath": "Proofs/CentralLimitTheorem.lean",
-    "lineCount": 618
+    "lineCount": 618,
+    "prerequisites": [
+      "Probability theory (random variables, expectation, variance)",
+      "Measure theory (convergence in distribution)",
+      "Characteristic functions and Fourier analysis"
+    ]
   },
   "overview": {
     "historicalContext": "The Central Limit Theorem (CLT) stands as one of the most remarkable results in probability theory. Its origins trace back to Abraham de Moivre's 1733 analysis of coin flips, but the theorem took nearly two centuries to reach its modern form.\n\nPierre-Simon Laplace generalized de Moivre's result in 1812, showing that sums of many independent random variables tend toward a bell curve. However, the first rigorous proof came from Aleksandr Lyapunov in 1901, using characteristic functions.\n\nThe algebraic topological perspective—viewing the Gaussian as a fixed point of a renormalization flow on the space of distributions—emerged in the late 20th century, connecting probability theory to dynamical systems, information geometry, and category theory.\n\nThis dual perspective reveals not just *that* the Gaussian appears universally, but *why*: it is an attractor in the space of probability distributions under the operation of convolution and rescaling.",

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -5,6 +5,7 @@
   "description": "Fermat's Last Theorem: no positive integers $a, b, c$ satisfy $a^n + b^n = c^n$ for $n > 2$. Proved by Andrew Wiles (1995) via the modularity of semistable elliptic curves, settling a 358-year conjecture. Formalized in Lean 4 with 5 axioms encoding the key steps of the Frey-Ribet-Wiles proof chain (modularity theorem, level-lowering, Frey curve, Mazur torsion). Status: axiomatized.",
   "meta": {
     "author": "Andrew Wiles (1995), with Richard Taylor",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_Last_Theorem",
     "date": "1995",
     "status": "axiomatized",
     "tags": [
@@ -241,6 +242,27 @@
       "year": "1847",
       "venue": "Monatsberichte der Königlichen Preussischen Akademie der Wissenschaften zu Berlin, 132–141",
       "note": "Proof of FLT for regular primes using ideal factorization in cyclotomic fields — the deepest 19th-century progress, which introduced ideal theory and motivated Dedekind's algebraic number theory"
+    },
+    {
+      "authors": "Ribet, Kenneth A.",
+      "title": "On modular representations of Gal(Q̄/Q) arising from modular forms",
+      "year": "1990",
+      "venue": "Inventiones Mathematicae 100(2): 431-476",
+      "note": "Proves the epsilon conjecture (now Ribet's theorem): if the Frey curve is modular, level-lowering forces it to correspond to a weight-2 form of level 2, which does not exist — the key link between modularity and FLT"
+    },
+    {
+      "authors": "Frey, Gerhard",
+      "title": "Links between stable elliptic curves and certain Diophantine equations",
+      "year": "1986",
+      "venue": "Annales Universitatis Saraviensis 1: 1-40",
+      "note": "Proposes the Frey curve construction: a counterexample to FLT yields a semistable elliptic curve whose properties would violate the Taniyama-Shimura-Weil conjecture"
+    },
+    {
+      "authors": "Breuil, Christophe; Conrad, Brian; Diamond, Fred; Taylor, Richard",
+      "title": "On the modularity of elliptic curves over Q: wild 3-adic exercises",
+      "year": "2001",
+      "venue": "Journal of the AMS 14(4): 843-939",
+      "note": "Completes the full modularity theorem: every elliptic curve over Q is modular, extending Wiles's result from semistable curves to all curves"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -35,7 +35,12 @@
     "assumptions": "2 axiom(s). No sorries.",
     "proofRepoPath": "Proofs/FourColorTheorem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 294
+    "lineCount": 294,
+    "prerequisites": [
+      "Graph theory (planar graphs, coloring)",
+      "Combinatorics (discharging method, reducibility)",
+      "Topology (Jordan curve theorem, planar embeddings)"
+    ]
   },
   "overview": {
     "historicalContext": "The Four Color Problem captivated mathematicians for over a century. First posed in 1852 by Francis Guthrie while coloring a map of England, it asked: can every map be colored with just four colors so that no two adjacent regions share the same color?\n\nMany attempted proofs failed. Alfred Kempe published a 'proof' in 1879 that stood for 11 years before Percy Heawood found a fatal flaw. In 1976, Kenneth Appel and Wolfgang Haken finally proved the theorem—but their proof required a computer to check 1,936 reducible configurations. This was the first major theorem proved with essential computer assistance, sparking philosophical debates: Is a proof humans cannot verify still a 'proof'?\n\nIn 2005, Georges Gonthier formalized the complete proof in Coq, providing a machine-verified certificate that settled remaining doubts about the computer calculations.",

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -52,7 +52,13 @@
     "axiomCount": 13,
     "lineCount": 463,
     "assumptions": "13 axioms: ratio_iff_equiv_axiom, equiv_iff_error_axiom, li_equiv_approx_axiom, and 10 more. See Lean source for complete statements.",
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "Real analysis (limits, integrals, asymptotic analysis)",
+      "Complex analysis (contour integration, analytic functions)",
+      "Number theory (prime counting function, arithmetic functions)",
+      "Logarithmic integral and asymptotic notation"
+    ]
   },
   "overview": {
     "historicalContext": "The Prime Number Theorem was conjectured by Legendre (1798) and Gauss (1849, in the form π(x) ~ Li(x)), then proved independently by Hadamard and de la Vallée Poussin in 1896 using the non-vanishing of ζ(1+it). Erdős and Selberg gave an elementary proof in 1949. Avigad et al. provided the first formal proof in Isabelle (2004), and Kontorovich, Tao, et al. completed a full Lean 4 formalization (2024) in the PrimeNumberTheoremAnd project. The theorem was a major landmark in analytic number theory: Riemann's 1859 memoir introduced the zeta function and sketched the connection between its zeros and prime distribution, but the proof required controlling ζ on the entire critical strip Re(s) = 1, achieved by Hadamard's product formula and de la Vallée Poussin's zero-free region.",

--- a/src/data/proofs/pythagorean-theorem/meta.json
+++ b/src/data/proofs/pythagorean-theorem/meta.json
@@ -243,78 +243,11 @@
       "targetId": "binomial-theorem",
       "relationship": "related",
       "description": "The expansion $\\|u+v\\|^2 = \\|u\\|^2 + 2\\langle u,v \\rangle + \\|v\\|^2$ used in the proof is the inner product analog of the binomial expansion $(a+b)^2 = a^2 + 2ab + b^2$. The Pythagorean theorem says the cross term vanishes when $\\langle u,v \\rangle = 0$"
-    }
-  ],
-  "relatedProofs": [
+    },
     {
-      "id": "area-of-circle",
+      "targetId": "pythagorean-theorem-oq-03",
       "relationship": "related",
-      "description": "Both are fundamental results in Euclidean geometry. The Pythagorean theorem relates side lengths; the area formula uses πr² which depends on the same metric structure"
-    },
-    {
-      "id": "angle-trisection",
-      "relationship": "related",
-      "description": "The Pythagorean theorem underpins compass-and-straightedge constructions — every constructible length arises from iterated application of the theorem via circle-line intersections"
-    },
-    {
-      "id": "fermats-last-theorem",
-      "relationship": "foundational",
-      "description": "FLT generalizes the Pythagorean equation: while a²+b²=c² has infinitely many integer solutions, aⁿ+bⁿ=cⁿ has none for n≥"
-    },
-    {
-      "id": "cauchy-schwarz",
-      "relationship": "related",
-      "description": "Both are consequences of inner product space structure: Pythagorean theorem uses orthogonality (⟨v,w⟩=0), Cauchy-Schwarz bounds the general case (|⟨v,w⟩| ≤ ‖v‖‖w‖)"
-    },
-    {
-      "id": "pythagorean-theorem-oq-03",
-      "relationship": "related",
-      "description": "Related gallery proof"
-    },
-    {
-      "id": "sqrt2-irrational",
-      "relationship": "foundational",
-      "description": "The irrationality of $\\sqrt{2}$ follows directly from the Pythagorean theorem: the diagonal of a unit square has length $\\sqrt{1^2 + 1^2} = \\sqrt{2}$, and the Pythagoreans' discovery that this is irrational was a foundational crisis in Greek mathematics. The Pythagorean theorem creates the very quantity whose irrationality had to be confronted"
-    },
-    {
-      "id": "law-of-cosines",
-      "relationship": "extended-by",
-      "description": "The law of cosines generalizes the Pythagorean theorem: $c^2 = a^2 + b^2 - 2ab\\cos(C)$. When $C = 90°$, $\\cos(C) = 0$ and this reduces to $c^2 = a^2 + b^2$. In inner product form: $\\|u-v\\|^2 = \\|u\\|^2 + \\|v\\|^2 - 2\\langle u,v \\rangle$"
-    },
-    {
-      "id": "euler-identity",
-      "relationship": "related",
-      "description": "Euler's identity $e^{i\\pi} + 1 = 0$ connects to the Pythagorean theorem via $|e^{i\\theta}|^2 = \\cos^2\\theta + \\sin^2\\theta = 1$ — the Pythagorean identity on the unit circle. The modulus of complex numbers is defined via $|z|^2 = (\\text{Re}\\,z)^2 + (\\text{Im}\\,z)^2$, which is the Pythagorean theorem applied to the Argand plane"
-    },
-    {
-      "id": "cauchy-schwarz-integral",
-      "relationship": "related",
-      "description": "The integral Cauchy-Schwarz inequality $|\\int fg|^2 \\leq \\int f^2 \\cdot \\int g^2$ is the infinite-dimensional generalization of the same inner product framework. The Pythagorean theorem for $L^2$ functions — $\\|f+g\\|^2 = \\|f\\|^2 + \\|g\\|^2$ when $\\int fg = 0$ — is Parseval's identity in Fourier analysis"
-    },
-    {
-      "id": "triangle-inequality",
-      "relationship": "related",
-      "description": "The triangle inequality $\\|u + v\\| \\leq \\|u\\| + \\|v\\|$ and the Pythagorean theorem $\\|u + v\\|^2 = \\|u\\|^2 + \\|v\\|^2$ (when $u \\perp v$) are complementary: the Pythagorean theorem gives equality in the squared norm when vectors are orthogonal, while the triangle inequality gives the bound for general vectors. Both are fundamental properties of inner product norms"
-    },
-    {
-      "id": "amgm-inequality",
-      "relationship": "related",
-      "description": "Both AM-GM and the Pythagorean theorem arise from inner product/norm inequalities. The AM-GM inequality $\\sqrt{ab} \\leq (a+b)/2$ can be proved via the Cauchy-Schwarz inequality, which itself is a direct consequence of the Pythagorean decomposition $v = \\text{proj}_w v + (v - \\text{proj}_w v)$"
-    },
-    {
-      "id": "mathematical-induction",
-      "relationship": "foundational",
-      "description": "The generalized Pythagorean theorem (`pythagorean_sum`) for $n$ mutually orthogonal vectors is proved by induction on the number of vectors using `Finset.induction_on` — a direct application of mathematical induction in the formalization"
-    },
-    {
-      "id": "fundamental-theorem-calculus",
-      "relationship": "related",
-      "description": "The FTC connects to the Pythagorean theorem through arc length: the length of a curve $\\gamma$ is $\\int \\sqrt{dx^2 + dy^2}$, where $dx^2 + dy^2$ is the Pythagorean theorem applied infinitesimally. The Pythagorean theorem is the local, infinitesimal form of the metric that the FTC integrates globally"
-    },
-    {
-      "id": "binomial-theorem",
-      "relationship": "related",
-      "description": "The expansion $\\|u+v\\|^2 = \\|u\\|^2 + 2\\langle u,v \\rangle + \\|v\\|^2$ used in the proof is the inner product analog of the binomial expansion $(a+b)^2 = a^2 + 2ab + b^2$. The Pythagorean theorem says the cross term vanishes when $\\langle u,v \\rangle = 0$"
+      "description": "Sub-entry exploring extensions or open questions about the Pythagorean theorem"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -4,6 +4,8 @@
   "slug": "riemann-hypothesis",
   "description": "A comprehensive formalization of the Riemann Hypothesis (6594 lines, 540+ proved theorems, 32 axioms, 0 sorries). States RH using Mathlib's zeta function, proves GRH→RH, establishes 14 equivalent formulations (K₁₀ network + BSY, Riesz, Báez-Duarte, Volchkov integral criteria) with 91 pairwise equivalences, shows ¬RH forces 4 distinct off-line zeros, moment growth rates, Selberg class, de Bruijn-Newman constant, random matrix theory, and arithmetic consequences.",
   "meta": {
+    "author": "Bernhard Riemann (1859); formalized by Lean Genius contributors",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Riemann_hypothesis",
     "status": "axiomatized",
     "tags": [
       "number-theory",
@@ -56,6 +58,12 @@
     "hilbertNumber": 8,
     "millenniumProblem": "riemann",
     "proofRepoPath": "Proofs/RiemannHypothesis.lean",
+    "prerequisites": [
+      "Complex analysis (meromorphic functions, analytic continuation)",
+      "Analytic number theory (Dirichlet series, prime counting function)",
+      "Functional analysis (Hilbert spaces, operator theory for Nyman-Beurling)",
+      "Algebraic number theory (L-functions, Galois representations for GRH)"
+    ],
     "mathlib_version": "4.26.0",
     "lineCount": 6594
   },
@@ -167,6 +175,27 @@
       "year": "1989",
       "venue": "Journal für die reine und angewandte Mathematik 399, 1–26",
       "note": "Best known proportion (41.28%) of zeros proved to lie on the critical line"
+    },
+    {
+      "authors": "Iwaniec, Henryk; Kowalski, Emmanuel",
+      "title": "Analytic Number Theory",
+      "year": "2004",
+      "venue": "AMS Colloquium Publications vol. 53",
+      "note": "Modern comprehensive treatment of the zeta function, L-functions, zero-free regions, and the connections between RH and prime distribution"
+    },
+    {
+      "authors": "Hardy, G.H.",
+      "title": "Sur les zéros de la fonction ζ(s) de Riemann",
+      "year": "1914",
+      "venue": "Comptes Rendus de l'Académie des Sciences 158: 1012-1014",
+      "note": "First proof that infinitely many zeros lie on the critical line Re(s) = 1/2"
+    },
+    {
+      "authors": "Bombieri, Enrico",
+      "title": "The Riemann Hypothesis",
+      "year": "2000",
+      "venue": "Clay Mathematics Institute Millennium Prize Problems",
+      "note": "Official problem statement for the $1 million Clay Millennium Prize, surveying the current state of knowledge and key equivalent formulations"
     }
   ],
   "conclusion": {
@@ -200,33 +229,11 @@
       "targetId": "euler-identity",
       "relationship": "related",
       "description": "Euler's identity connects e, i, π — the same constants that appear in the functional equation ξ(s) = ξ(1-s) of the completed zeta function"
-    }
-  ],
-  "relatedProofs": [
-    {
-      "id": "infinitude-primes",
-      "relationship": "extends",
-      "description": "RH quantifies the distribution of primes beyond mere infinitude — it gives the optimal error term π(x) = Li(x) + O(√x log x), the sharpest form of the Prime Number Theorem"
     },
     {
-      "id": "basel-problem",
-      "relationship": "foundational",
-      "description": "The Basel identity ζ(2) = π²/6 is the first non-trivial value of the Riemann zeta function whose zeros are the subject of RH"
-    },
-    {
-      "id": "prime-number-theorem",
-      "relationship": "extends",
-      "description": "RH implies the strongest form of PNT: π(x) = Li(x) + O(√x log x). PNT is equivalent to ζ(s) ≠ 0 on Re(s) = 1, while RH is the much stronger ζ(s) ≠ 0 for Re(s) > 1/2"
-    },
-    {
-      "id": "euler-identity",
+      "targetId": "prime-reciprocal-divergence",
       "relationship": "related",
-      "description": "Euler's identity connects e, i, π — the same constants that appear in the functional equation ξ(s) = ξ(1-s) of the completed zeta function"
-    },
-    {
-      "id": "prime-reciprocal-divergence",
-      "relationship": "related",
-      "description": "Related gallery proof"
+      "description": "The divergence of $\\sum 1/p$ (Euler, 1737) was the first result using the Euler product $\\zeta(s) = \\prod (1-p^{-s})^{-1}$, establishing the analytic approach to prime distribution that RH completes"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary
Batch structural cleanup + deep enrichment of notable gallery entries.

### Batch fix: Remove duplicate relatedProofs (130 entries)
- Removed `relatedProofs` top-level field duplicating `crossReferences` in 130 meta.json files
- **3066 lines of redundant JSON removed**

### Deep enrichment: individual entries
| Entry | Changes |
|-------|---------|
| **fermats-last-theorem** | Added sourceUrl, 3 references (Ribet, Frey, BCDT) |
| **riemann-hypothesis** | Added sourceUrl, author, prerequisites, 3 references (Iwaniec-Kowalski, Hardy, Bombieri), fixed relatedProofs |
| **prime-number-theorem** | Added 4 prerequisites |
| **four-color-theorem** | Added 3 prerequisites |
| **central-limit-theorem** | Added 3 prerequisites |
| **pythagorean-theorem** | Moved missing cross-ref, removed duplicate relatedProofs |
| **binomial-theorem** | Removed duplicate relatedProofs (separate PR #6320) |

## Test plan
- [x] All modified meta.json files parse as valid JSON
- [x] crossReferences preserved in all entries
- [x] New references are historically accurate
- [x] Prerequisites are appropriate for each entry's mathematical content