### PR TITLE
Research: erdos-884 — eliminate remaining axioms (3→1, 0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos884Problem.lean
+++ b/proofs/Proofs/Erdos884Problem.lean
@@ -188,12 +188,69 @@ theorem consecutivePairsSum_num_terms (n : ℕ) (_hn : n > 0) :
 theorem divisors_6 : divisorList 6 = [1, 2, 3, 6] := by native_decide
 
 /-- For prime p, divisors are [1, p]. -/
-axiom divisors_prime (p : ℕ) (hp : p.Prime) :
-    divisorList p = [1, p]
+theorem divisors_prime (p : ℕ) (hp : p.Prime) :
+    divisorList p = [1, p] := by
+  unfold divisorList
+  rw [Nat.Prime.divisors hp]
+  -- Use pairwise_getD_lt from divisorList_pairwise_lt to characterize the sorted list
+  -- Alternative: use the length-2 sorted list characterization
+  have hlt : (1 : ℕ) < p := hp.one_lt
+  have hne : (1 : ℕ) ≠ p := Nat.ne_of_lt hlt
+  -- The sorted list has length 2 and contains exactly 1 and p
+  -- Use properties: mem_sort, length_sort, sort_nodup, sort_sorted
+  -- Extract as a length-2 list
+  have hlen : (({1, p} : Finset ℕ).sort (· ≤ ·)).length = 2 := by
+    rw [Finset.length_sort]; exact Finset.card_pair hne
+  obtain ⟨a, b, hab⟩ := List.length_eq_two.mp hlen
+  -- a and b are in {1, p}
+  have ha : a ∈ ({1, p} : Finset ℕ) := by
+    rw [← Finset.mem_sort (r := (· ≤ ·)), hab]; simp
+  have hb : b ∈ ({1, p} : Finset ℕ) := by
+    rw [← Finset.mem_sort (r := (· ≤ ·)), hab]; simp
+  simp only [Finset.mem_insert, Finset.mem_singleton] at ha hb
+  -- No duplicates
+  have hnd : a ≠ b := by
+    have hnodup := (({1, p} : Finset ℕ).sort_nodup (· ≤ ·))
+    rw [hab] at hnodup
+    simp [List.nodup_cons, List.not_mem_nil] at hnodup
+    exact hnodup
+  -- Sorted: a ≤ b
+  have _hle : a ≤ b := by
+    have hs := (({1, p} : Finset ℕ).sort_sorted (· ≤ ·))
+    rw [hab] at hs
+    simp [List.Sorted, List.Pairwise] at hs
+    exact hs
+  rw [hab]
+  rcases ha with rfl | rfl <;> rcases hb with rfl | rfl
+  · exact absurd rfl hnd
+  · rfl
+  · exfalso; omega
+  · exact absurd rfl hnd
+
+/-- For primes, numDivisors p = 2. -/
+theorem numDivisors_prime (p : ℕ) (hp : p.Prime) : numDivisors p = 2 := by
+  unfold numDivisors
+  rw [Nat.Prime.divisors hp]
+  exact Finset.card_pair (Nat.ne_of_lt hp.one_lt)
+
+/-- generalGap n 0 1 = consecutiveGap n 0 by definition. -/
+private theorem generalGap_zero_one (n : ℕ) :
+    generalGap n 0 1 = consecutiveGap n 0 := by
+  unfold generalGap consecutiveGap
+  rfl
 
 /-- For primes, allPairsSum = consecutivePairsSum (trivially: only one pair). -/
-axiom prime_case_equality (p : ℕ) (hp : p.Prime) :
-    allPairsSum p = consecutivePairsSum p
+theorem prime_case_equality (p : ℕ) (hp : p.Prime) :
+    allPairsSum p = consecutivePairsSum p := by
+  unfold allPairsSum consecutivePairsSum
+  rw [numDivisors_prime p hp]
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add]
+  -- LHS: 0 + (∑ j ∈ Ioo 0 2, 1/generalGap p 0 j) + (∑ j ∈ Ioo 1 2, 1/generalGap p 1 j)
+  -- Ioo 1 2 = ∅, Ioo 0 2 = {1}
+  have h1 : Finset.Ioo 1 2 = (∅ : Finset ℕ) := by decide
+  have h2 : Finset.Ioo 0 2 = ({1} : Finset ℕ) := by decide
+  rw [h1, h2, Finset.sum_empty, add_zero, Finset.sum_singleton]
+  rw [generalGap_zero_one]
 
 /- ## Structural Lemmas -/
 
@@ -208,13 +265,19 @@ theorem gap_lower_bound (n i j : ℕ) (hij : i < j) (hj : j < numDivisors n) :
   have hj' : j < (divisorList n).length := by omega
   exact pairwise_getD_le (divisorList_pairwise_lt n) (by omega : i + 1 ≤ j) hj'
 
+/-- σ₀(n) = τ(n) = n.divisors.card. -/
+private theorem sigma_zero_eq_card (n : ℕ) :
+    ArithmeticFunction.sigma 0 n = numDivisors n := by
+  unfold numDivisors
+  simp [ArithmeticFunction.sigma_apply]
+
 /-- For coprime m, n: τ(mn) = τ(m) · τ(n). -/
-/- Note: Nat.Coprime.divisors_mul was removed/renamed in Mathlib v4.26.0.
-   This theorem was proved in the original file but needs API update. -/
+/- Proved via σ₀ multiplicativity after Nat.Coprime.divisors_mul was renamed. -/
 theorem numDivisors_mul_coprime (m n : ℕ) (_hm : m > 0) (_hn : n > 0)
-    (_hcop : Nat.Coprime m n) :
+    (hcop : Nat.Coprime m n) :
     numDivisors (m * n) = numDivisors m * numDivisors n := by
-  sorry
+  rw [← sigma_zero_eq_card, ← sigma_zero_eq_card, ← sigma_zero_eq_card]
+  exact ArithmeticFunction.isMultiplicative_sigma.map_mul_of_coprime hcop
 
 /- ## Connections -/
 

--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 884,
     "erdosUrl": "https://erdosproblems.com/884",
     "erdosProblemStatus": "open",
@@ -60,9 +60,9 @@
       "divisorHarmonicSum definition: σ_{-1}(n)",
       "Examples: divisors of 6, prime divisors, prime case equality"
     ],
-    "axiomCount": 9,
-    "assumptions": "9 axioms: divisorList_sorted, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, erdos_884 (main conjecture), divisors_6, divisors_prime, prime_case_equality, gap_lower_bound. 2 proved: allPairsSum_nonneg (sum_nonneg), consecutivePairsSum_nonneg (sum_nonneg). 1 sorry: numDivisors_mul_coprime (Mathlib API breakage in v4.26.0).",
-    "lineCount": 168
+    "axiomCount": 1,
+    "assumptions": "1 axiom: erdos_884 (the OPEN main conjecture). All 8 supporting axioms eliminated: divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, divisors_prime, prime_case_equality, gap_lower_bound — all proved. numDivisors_mul_coprime sorry also proved via σ₀ multiplicativity.",
+    "lineCount": 293
   },
   "overview": {
     "historicalContext": "Erdős Problem #884 appears in [Er98] and asks about the relationship between two sums over divisor gaps. Given the divisors d₁ < d₂ < ··· < d_t of a positive integer n, one can form either the all-pairs sum (summing 1/(d_j - d_i) over all i < j) or the consecutive-pairs sum (summing only over adjacent divisors). The question is whether the all-pairs sum is controlled by the consecutive-pairs sum up to an absolute constant.\n\nThe problem is related to Erdős Problem #144 on divisor arithmetic. Terence Tao has indicated that this problem appears tractable, suggesting it may be amenable to combinatorial or analytic arguments about divisor distributions.\n\nThe trivial observation is that for primes p, both sums equal 1/(p-1) since there is only one pair of divisors {1, p}. For composite numbers with many divisors, the all-pairs sum has O(τ²) terms while the consecutive-pairs sum has only O(τ) terms, making the conjectured bound non-trivial.",
@@ -211,9 +211,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos884",
-    "lineCount": 168,
-    "axiomCount": 9,
-    "theoremCount": 5,
+    "lineCount": 293,
+    "axiomCount": 1,
+    "theoremCount": 20,
     "definitionCount": 9
   }
 }

--- a/src/data/research/problems/erdos-884.json
+++ b/src/data/research/problems/erdos-884.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 6 axioms (9→3). Proved divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, gap_lower_bound. Made definitions computable. Only OPEN conjecture + 2 example axioms remain.",
+    "progressSummary": "PROGRESS: Eliminated 8 of 9 axioms (9→1) and 1 sorry. Only the OPEN conjecture axiom erdos_884 remains. Proved divisors_prime (Finset.sort uniqueness), prime_case_equality (single-pair reduction), numDivisors_mul_coprime (via σ₀ multiplicativity), plus 6 earlier axiom eliminations.",
     "builtItems": [
       "theorem allPairsSum_nonneg: sum_nonneg + div_nonneg",
       "theorem consecutivePairsSum_nonneg: sum_nonneg + div_nonneg",
@@ -41,7 +41,13 @@
       "theorem divisors_6: by native_decide (computable divisorList)",
       "theorem gap_lower_bound: from pairwise_getD_le + Nat.sub_le_sub_right (added hj hypothesis)",
       "helper getD_zero_eq_getElem: by induction on list + cases on index",
-      "helper pairwise_getD_lt/le: getD ordering from pairwise and getD_zero_eq_getElem"
+      "helper pairwise_getD_lt/le: getD ordering from pairwise and getD_zero_eq_getElem",
+      "theorem divisors_prime: Finset.sort uniqueness proof via length-2 extraction + case analysis",
+      "theorem numDivisors_prime: card_pair via Nat.Prime.divisors",
+      "theorem prime_case_equality: Ioo reduction (Ioo 0 2 = {1}, Ioo 1 2 = ∅)",
+      "helper generalGap_zero_one: definitional rfl",
+      "theorem sigma_zero_eq_card: σ₀ = divisors.card via ArithmeticFunction.sigma_apply",
+      "theorem numDivisors_mul_coprime: via σ₀ multiplicativity (isMultiplicative_sigma)"
     ],
     "insights": [
       "divisorList is noncomputable (prevents native_decide for concrete values like divisors_6)",
@@ -54,13 +60,17 @@
       "divisorList is computable (Finset.sort is computable for ℕ), noncomputable was unnecessary",
       "gap_lower_bound was FALSE as stated (missing j < numDivisors n hypothesis for out-of-bounds getD=0 case)",
       "Nat.Coprime.divisors_mul removed/renamed in Mathlib v4.26.0, causes sorry in numDivisors_mul_coprime",
-      "Key technique: getD_zero_eq_getElem helper proved by induction bridges getD and getElem APIs"
+      "Key technique: getD_zero_eq_getElem helper proved by induction bridges getD and getElem APIs",
+      "Finset.sort_pair does NOT exist in Mathlib v4.26.0 - must prove sort uniqueness manually",
+      "For 2-element finset sort: use length_sort + List.length_eq_two to extract elements, then case analysis with mem_sort + sort_nodup + sort_sorted",
+      "σ₀(n) = n.divisors.card proved via ArithmeticFunction.sigma_apply + Finset.card_eq_sum_ones",
+      "ArithmeticFunction.isMultiplicative_sigma gives τ multiplicativity for free (σ₀ is σ at k=0)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove divisors_prime using Nat.Prime.divisors + Finset.sort uniqueness for 2-element sets",
-      "Prove prime_case_equality by reducing both sums to single term via divisors_prime",
-      "Fix numDivisors_mul_coprime sorry by finding correct Mathlib v4.26.0 API name"
+      "All provable axioms and sorries eliminated — only the OPEN conjecture remains",
+      "Consider creating Aristotle companion file for potential supporting lemmas",
+      "Explore Tao's approach (he indicated tractability) for potential proof strategy"
     ],
     "markdown": "# Erdős #884 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that, for any $n$, if $d_1<\\cdots <d_t$ are the divisors of $n$, then\\[\\sum_{1\\leq i<j\\leq t}\\frac{1}{d_j-d_i} \\ll 1+\\sum_{1\\leq i<t}\\frac{1}{d_{i+1}-d_i},\\]where the implied constant is absolute?\n\n\n\nSee also [144].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #144\n- Problem #883\n- Problem #885\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er98\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -85,11 +95,11 @@
     {
       "path": "Proofs/Erdos884Problem.lean",
       "filename": "Erdos884Problem.lean",
-      "lineCount": 230,
-      "theoremCount": 12,
-      "axiomCount": 3,
+      "lineCount": 293,
+      "theoremCount": 20,
+      "axiomCount": 1,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos884Problem.lean"
     }


### PR DESCRIPTION
## Summary

- Eliminates the **last 2 example axioms** and **1 sorry** from erdos-884
- Total across sessions: **9 → 1 axioms**, **1 → 0 sorries**
- Only remaining axiom: `erdos_884 : ErdosConjecture884` (the OPEN conjecture)

### Axioms/sorries eliminated this PR

| Item | Technique |
|------|-----------|
| `divisors_prime` axiom | Finset.sort uniqueness: length-2 extraction + case analysis with sort_nodup + sort_sorted |
| `prime_case_equality` axiom | Ioo reduction: `Ioo 0 2 = {1}`, `Ioo 1 2 = ∅` gives single-term equality |
| `numDivisors_mul_coprime` sorry | σ₀ multiplicativity via `ArithmeticFunction.isMultiplicative_sigma` |

### New helper theorems

- `numDivisors_prime`: `card_pair` via `Nat.Prime.divisors`
- `generalGap_zero_one`: definitional `rfl`
- `sigma_zero_eq_card`: bridges `σ₀(n)` and `n.divisors.card`

### Build verification

Docker build passes with 0 errors, 0 sorries, 1 axiom (the open conjecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)