### PR TITLE
Peer review: area-of-circle-oq-03 (B+)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03/review.json
+++ b/src/data/proofs/area-of-circle-oq-03/review.json
@@ -1,0 +1,115 @@
+{
+  "version": 1,
+  "proofId": "area-of-circle-oq-03",
+  "reviewDate": "2026-03-24T12:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "B+",
+    "oneLiner": "A genuinely substantive formalization of Archimedes' method of exhaustion with creative use of HasDerivAt for trigonometric limits, marred by a missing half of the claimed sandwich inequality.",
+    "tier": "A",
+    "tierJustification": "Fully formalized with 17 theorems, 0 sorries, 0 axioms. All definitions complete. The proof does real mathematical work — the HasDerivAt-slope technique, the sandwich via double angle formula, and the convergence chains are non-trivial. Tier A is justified."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "tendsto_sin_div_nhds_zero, lines 82-91",
+      "finding": "The observation that sin(h)/h → 1 follows from HasDerivAt via hasDerivAt_iff_tendsto_slope is a genuinely creative technique. Rather than reproving the limit from scratch, it leverages the derivative definition directly. This pattern is reused for tan(h)/h → 1, making the proof architecture elegant and DRY.",
+      "recommendation": "Preserve this technique — it's the most distinctive contribution of the file."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "inscribed_le_circumscribed, lines 307-341",
+      "finding": "At 35 lines, this is the most substantial proof in the file. It handles edge cases (n=1,2 via simp), uses the double angle formula sin(2θ) = 2sin(θ)cos(θ), proves cos positivity for π/n ∈ (0, π/2), and applies cos²(θ) ≤ 1. This is genuine multi-step reasoning, not a Mathlib wrapper.",
+      "recommendation": "This is exemplary formalization work — highlight it in the description."
+    },
+    {
+      "severity": "moderate",
+      "category": "gap",
+      "location": "meta.json overview.problemStatement; Lean file lines 1-366",
+      "finding": "The problem statement promises the full sandwich: 'inscribedArea(n,r) ≤ πr² ≤ circumscribedArea(n,r) for all n ≥ 3'. The left half (inscribed_area_le_circle, line 178) and the ordering (inscribed_le_circumscribed, line 307) are proved, but πr² ≤ circumscribedArea(n,r) for finite n is NOT proved as a standalone theorem. This would require tan(x) ≥ x for 0 < x < π/2, which is not established.",
+      "recommendation": "Either (a) add a theorem circle_area_le_circumscribed proving πr² ≤ circumscribedArea n r for n ≥ 3, or (b) adjust the problem statement to accurately describe what is proved: the left sandwich, the ordering, and both-sided convergence."
+    },
+    {
+      "severity": "minor",
+      "category": "overclaim",
+      "location": "meta.json originalContributions[5]: archimedes_exhaustion_unique",
+      "finding": "Listed as an original contribution, but the proof body is a single Mathlib call: `tendsto_nhds_unique h (inscribed_area_tendsto r)`. The uniqueness result is mathematically important but formally trivial given the convergence theorem. Listing it alongside genuinely substantive contributions like inscribed_le_circumscribed overstates its proof content.",
+      "recommendation": "Reframe as 'archimedes_exhaustion_unique: uniqueness via Mathlib's tendsto_nhds_unique (Hausdorff limit uniqueness)' to honestly note the mechanism."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json mathlibDependencies vs. Lean file lines 89, 232",
+      "finding": "hasDerivAt_iff_tendsto_slope is used at lines 89 and 232 and is described in the proof strategy and annotations as THE key technique, yet it is not listed in mathlibDependencies. This is the most important Mathlib lemma for the entire proof — it converts HasDerivAt to the slope limit that gives sin(h)/h → 1.",
+      "recommendation": "Add hasDerivAt_iff_tendsto_slope to mathlibDependencies with description: 'Converts HasDerivAt f f' a to slope limit (f x - f a)/(x - a) → f' in nhdsWithin'."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json mathlibDependencies",
+      "finding": "Several other Mathlib lemmas used in the proof are not listed: tendsto_nhds_unique (line 362), Real.sin_two_mul (line 333), tendsto_const_div_atTop_nhds_0_nat (lines 98, 241), Real.cos_pos_of_mem_Ioo (line 329). The dependency list covers the conceptual highlights but omits structural dependencies.",
+      "recommendation": "Add at minimum tendsto_nhds_unique and Real.sin_two_mul, which play significant roles in the uniqueness and sandwich proofs respectively."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json overview.keyInsights[4] (Riemann sum connection)",
+      "finding": "The insight connecting the inscribed area formula n·r²/2·sin(2π/n) to the Riemann sum for ∫₀²π r²/2 dθ in polar coordinates is mathematically insightful and historically illuminating. It bridges the ancient geometric construction to modern integration.",
+      "recommendation": "Preserve — this is the kind of pedagogical connection that elevates the entry."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json conclusion.summary",
+      "finding": "States 'The proof predates calculus by 1900 years but is proved using calculus concepts (derivatives, limits) that provide its rigorous foundation.' This is slightly equivocal — it might be read as claiming the Lean formalization predates calculus. The sentence means Archimedes' original argument predates calculus, but the Lean formalization uses calculus.",
+      "recommendation": "Rephrase to: 'Archimedes' original argument predates calculus by 1900 years; this formalization uses the calculus concepts (derivatives, limits) that provide its rigorous modern foundation.'"
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "medium",
+      "target": "researcher",
+      "description": "Add theorem circle_area_le_circumscribed proving πr² ≤ circumscribedArea n r for n ≥ 3 (via tan(x) ≥ x for 0 < x < π/2), completing the full sandwich inequality claimed in the problem statement.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Add hasDerivAt_iff_tendsto_slope to mathlibDependencies in meta.json. Also add tendsto_nhds_unique and Real.sin_two_mul.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Reframe archimedes_exhaustion_unique in originalContributions to acknowledge it is a one-line Mathlib call (tendsto_nhds_unique), not a substantive original proof.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Clarify the conclusion summary to distinguish Archimedes' original argument (ancient) from the Lean formalization (modern calculus-based).",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 8,
+    "originalityAccuracy": 8,
+    "completeness": 8,
+    "framingPrecision": 8,
+    "pedagogicalQuality": 9,
+    "internalConsistency": 8,
+    "overall": 8.2
+  },
+
+  "suggestedBestFraming": "A fully verified formalization of Archimedes' method of exhaustion proving that inscribed and circumscribed n-gon areas converge to πr², using the creative technique of deriving the fundamental limits sin(h)/h → 1 and tan(h)/h → 1 from Mathlib's HasDerivAt via slope equivalence."
+}

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -296,6 +296,22 @@
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0
+    },
+    "triangular-reciprocals": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-24T19:32:53Z",
+      "overallGrade": "B+",
+      "qualityScore": null,
+      "actionItems": 0,
+      "resolvedItems": 0
+    },
+    "area-of-circle-oq-03": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-24T20:32:37Z",
+      "overallGrade": "B+",
+      "qualityScore": null,
+      "actionItems": 0,
+      "resolvedItems": 0
     }
   }
 }


### PR DESCRIPTION
Peer review of area-of-circle-oq-03. Grade: B+. 8 findings, 4 action items.

## Summary
- **Tier A** proof: 17 theorems, 0 sorries, 0 axioms — fully verified
- Creative HasDerivAt-slope technique for sin(h)/h → 1 and tan(h)/h → 1
- Strongest proof: `inscribed_le_circumscribed` (35 lines, double angle + cos² ≤ 1)

## Key Findings
- **Gap (moderate)**: Problem statement claims full sandwich inscribed ≤ πr² ≤ circumscribed, but πr² ≤ circumscribedArea not proved for finite n
- **Overclaim (minor)**: `archimedes_exhaustion_unique` listed as original contribution but is one-line `tendsto_nhds_unique`
- **Inconsistency (minor)**: `hasDerivAt_iff_tendsto_slope` — the most important Mathlib dependency — omitted from mathlibDependencies

## Action Items
1. (medium/researcher) Add `circle_area_le_circumscribed` theorem to complete sandwich
2. (low/enricher) Add missing mathlibDependencies
3. (low/enricher) Reframe uniqueness in originalContributions
4. (low/enricher) Clarify conclusion wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)