### PR TITLE
Create Aristotle companion file for Erdős Problem #798

### DIFF
--- a/proofs/Proofs/Erdos798Aristotle.lean
+++ b/proofs/Proofs/Erdos798Aristotle.lean
@@ -1,0 +1,87 @@
+/-
+  Aristotle targets for Erdős Problem #798
+  Routine supporting lemmas for automated proof search.
+  See Erdos798Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main bounds (Erdős-Purdy lower, Alon upper) which are axiomatized
+  - Known results provable from Mathlib (cardinality, combinatorics, analysis)
+  - Clean theorem statements with no definition sorries
+  - No axioms
+
+  The main file formalizes: t(n) = min points in {1,...,n}^2 whose
+  lines cover all lattice points. Result: t(n) = Theta(n^{2/3} log n).
+-/
+import Mathlib
+
+namespace Erdos798Aristotle
+
+open Set Real Finset
+
+/- ## Definitions (mirrored from Erdos798Problem.lean) -/
+
+/-- The lattice grid {1,...,n}^2. -/
+def latticeGrid (n : ℕ) : Set (ℤ × ℤ) :=
+  {p | 1 ≤ p.1 ∧ p.1 ≤ n ∧ 1 ≤ p.2 ∧ p.2 ≤ n}
+
+/-- Line through two distinct points. -/
+def lineThroughPoints (p q : ℤ × ℤ) : Set (ℤ × ℤ) :=
+  if p = q then {p}
+  else {r : ℤ × ℤ | ∃ t : ℚ, r.1 = p.1 + t * (q.1 - p.1) ∧
+                             r.2 = p.2 + t * (q.2 - p.2)}
+
+/-- A set S covers the grid if every lattice point lies on a line from S. -/
+def pointsCoversGrid (S : Set (ℤ × ℤ)) (n : ℕ) : Prop :=
+  ∀ r ∈ latticeGrid n, ∃ p q : ℤ × ℤ, p ∈ S ∧ q ∈ S ∧ p ≠ q ∧
+    r ∈ lineThroughPoints p q
+
+/-- t(n): minimum covering points. -/
+noncomputable def t (n : ℕ) : ℕ :=
+  sInf {k : ℕ | ∃ S : Finset (ℤ × ℤ), S.card = k ∧
+    (↑S : Set (ℤ × ℤ)) ⊆ latticeGrid n ∧
+    pointsCoversGrid (↑S) n}
+
+/- ## Routine Lemmas -/
+
+-- Lattice grid properties
+/-- The lattice grid {1,...,n}^2 has n^2 points. -/
+theorem latticeGrid_card (n : ℕ) (hn : n ≥ 1) :
+    (latticeGrid n).ncard = n ^ 2 := by sorry
+
+/-- The lattice grid is finite. -/
+theorem latticeGrid_finite (n : ℕ) :
+    (latticeGrid n).Finite := by sorry
+
+/-- A point (i,j) with 1 ≤ i,j ≤ n is in the lattice grid. -/
+theorem mem_latticeGrid (n : ℕ) (i j : ℤ)
+    (hi1 : 1 ≤ i) (hi2 : i ≤ n) (hj1 : 1 ≤ j) (hj2 : j ≤ n) :
+    (i, j) ∈ latticeGrid n := by sorry
+
+-- Line properties
+/-- A point lies on the line through it and any other point. -/
+theorem mem_lineThroughPoints_left (p q : ℤ × ℤ) :
+    p ∈ lineThroughPoints p q := by sorry
+
+/-- The second point also lies on the line. -/
+theorem mem_lineThroughPoints_right (p q : ℤ × ℤ) :
+    q ∈ lineThroughPoints p q := by sorry
+
+/-- Lines are symmetric: the line through p,q equals the line through q,p. -/
+theorem lineThroughPoints_symm (p q : ℤ × ℤ) :
+    lineThroughPoints p q = lineThroughPoints q p := by sorry
+
+-- Combinatorial bound
+/-- k points determine at most k*(k-1)/2 lines. -/
+theorem lines_from_points (S : Finset (ℤ × ℤ)) :
+    ∃ L : Finset (Set (ℤ × ℤ)), L.card ≤ S.card.choose 2 ∧
+    ∀ p q : ℤ × ℤ, p ∈ S → q ∈ S → p ≠ q →
+    lineThroughPoints p q ∈ L := by sorry
+
+-- Asymptotic (with hypothesis instead of axiom)
+/-- If t(n) ≤ C·n^{2/3}·log n, then t(n) = o(n). -/
+theorem t_is_o_n
+    (C : ℝ) (hC : C > 0)
+    (hbound : ∀ n : ℕ, n ≥ 2 → (t n : ℝ) ≤ C * n ^ (2/3 : ℝ) * Real.log n) :
+    ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N, (t n : ℝ) < ε * n := by sorry
+
+end Erdos798Aristotle


### PR DESCRIPTION
## Fix

Create Aristotle companion file with 9 routine lemmas for Erdos798Problem.lean (covering lattice points with lines).

## Evidence

**Before**: erdos-798 had 7 sorries and 3 axioms with no Aristotle companion file
**After**: `Erdos798Aristotle.lean` provides 9 clean theorem sorries:
- `latticeGrid_card` — grid has n^2 points
- `latticeGrid_finite` — grid is finite
- `mem_latticeGrid` — membership criterion
- `mem_lineThroughPoints_left/right` — endpoints lie on the line
- `lineThroughPoints_symm` — line symmetry
- `lines_from_points` — k points determine ≤ C(k,2) lines
- `t_is_o_n` — asymptotic result (with hypothesis, not axiom)

Validated: no definition sorries, no axioms, no placeholder theorems, no `/-!` sections.

---
Automated fix by lean-mechanic agent.