### PR TITLE
Enrich: add mathContext to sections across 7 gallery entries

### DIFF
--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -50,49 +50,56 @@
       "title": "Imports and Problem Overview",
       "summary": "Module documentation, imports for SimpleGraph, Finset, and real arithmetic",
       "startLine": 1,
-      "endLine": 1
+      "endLine": 1,
+      "mathContext": "Imports `Mathlib.Combinatorics.SimpleGraph.Basic` for the graph abstraction, `Mathlib.Data.Finset.Basic` for finite vertex sets, and `Mathlib.Data.Real.Basic` for the edge-count exponents $m^{2/3}$, $m^{1/2}$, $m^{3/4}$."
     },
     {
       "id": "c4-definition",
       "title": "4-Cycles and C₄-Freeness",
       "summary": "hasC4 (4-cycle detection) and isC4Free predicates; C₄ = K_{2,2}",
       "startLine": 1,
-      "endLine": 1
+      "endLine": 1,
+      "mathContext": "A 4-cycle $C_4$ in a graph $G$ is a sequence of distinct vertices $a, b, c, d$ with edges $ab, bc, cd, da$. Equivalently, $C_4 \\cong K_{2,2}$: four vertices forming a complete bipartite subgraph with parts $\\{a,c\\}$ and $\\{b,d\\}$. A graph is $C_4$-free if it contains no such subgraph."
     },
     {
       "id": "subgraph",
       "title": "Subgraphs and Edge Count",
       "summary": "Subgraph relation, edge counting, problem formulation",
       "startLine": 1,
-      "endLine": 1
+      "endLine": 1,
+      "mathContext": "A subgraph $H \\subseteq G$ satisfies $V(H) \\subseteq V(G)$ and $E(H) \\subseteq E(G)$. The edge count $e(G) = |E(G)|$ is the key parameter. The problem: given $G$ with $e(G) = m$, find $H \\subseteq G$ with $H$ being $C_4$-free and $e(H) = \\Omega(m^{2/3})$."
     },
     {
       "id": "trivial-bound",
       "title": "Trivial Bound: m^{1/2}",
       "summary": "The easy Ω(√m) bound via Kővári-Sós-Turán and greedy deletion",
       "startLine": 1,
-      "endLine": 1
+      "endLine": 1,
+      "mathContext": "The Kővári-Sós-Turán theorem gives $\\text{ex}(n, K_{2,2}) = O(n^{3/2})$: any $n$-vertex $C_4$-free graph has $O(n^{3/2})$ edges. Greedily deleting vertices of degree $> \\sqrt{m}$ from a graph with $m$ edges yields a $C_4$-free subgraph with $\\Omega(\\sqrt{m})$ edges. This $m^{1/2}$ bound is weaker than the optimal $m^{2/3}$."
     },
     {
       "id": "folkman",
       "title": "Folkman's Counterexample",
       "summary": "K_{n,n²} disproves m^{3/4} and proves optimality of 2/3 exponent",
       "startLine": 1,
-      "endLine": 1
+      "endLine": 1,
+      "mathContext": "The complete bipartite graph $K_{n,n^2}$ has $m = n \\cdot n^2 = n^3$ edges. By Kővári-Sós-Turán, any $C_4$-free subgraph $H \\subseteq K_{n,n^2}$ has $e(H) = O(n^2) = O(m^{2/3})$. This proves: (1) the exponent $3/4$ proposed by Bollobás-Erdős is too large, and (2) the exponent $2/3$ is best possible."
     },
     {
       "id": "main-result",
       "title": "Main Result: m^{2/3}",
       "summary": "Conlon-Fox-Sudakov theorem: Ω(m^{2/3}) C₄-free edges always exist",
       "startLine": 1,
-      "endLine": 1
+      "endLine": 1,
+      "mathContext": "**Theorem (Conlon-Fox-Sudakov, 2014):** Every graph $G$ with $m$ edges contains a $C_4$-free subgraph with $\\Omega(m^{2/3})$ edges. The proof uses dependent random choice: sample a random vertex set $S$, consider the common neighborhood $N(S)$, and show the induced subgraph on $N(S)$ is $C_4$-free with many edges in expectation."
     },
     {
       "id": "generalization",
       "title": "Generalization to K_{s,t}",
       "summary": "Extension to K_{s,t}-free subgraphs with exponent 1-1/s; Zarankiewicz connection",
       "startLine": 1,
-      "endLine": 1
+      "endLine": 1,
+      "mathContext": "Every graph with $m$ edges contains a $K_{s,t}$-free subgraph with $\\Omega(m^{1-1/s})$ edges (for $t \\ge s \\ge 2$). The $C_4$ case is $s = t = 2$: $1 - 1/2 = 1/2$ for the trivial bound, but the actual answer $2/3$ is tighter. This connects to the Zarankiewicz problem $z(n; s, t) = \\text{ex}(n, K_{s,t})$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1042/meta.json
+++ b/src/data/proofs/erdos-1042/meta.json
@@ -76,49 +76,56 @@
       "title": "Transfinite Diameter",
       "summary": "transfiniteDiameter axiom, nonnegativity, disc and interval examples",
       "startLine": 31,
-      "endLine": 50
+      "endLine": 50,
+      "mathContext": "The transfinite diameter (logarithmic capacity) $d(F) = \\lim_{n \\to \\infty} \\max_{z_1,\\ldots,z_n \\in F} \\left(\\prod_{i<j} |z_i - z_j|\\right)^{2/(n(n-1))}$. Examples: $d(\\overline{\\mathbb{D}}) = 1$ (unit disc), $d([-1,1]) = 1/2$ (interval). Axiomatized with $d(F) \\ge 0$."
     },
     {
       "id": "lemniscates",
       "title": "Polynomial Lemniscates",
       "summary": "PolynomialWithRoots, lemniscate, numComponents, maxComponents",
       "startLine": 51,
-      "endLine": 70
+      "endLine": 70,
+      "mathContext": "For $f(z) = \\prod_{i=1}^n (z - z_i)$ with roots $z_i \\in F$, the lemniscate is $L_f = \\{z \\in \\mathbb{C} : |f(z)| < 1\\}$. `numComponents(f)` = number of connected components of $L_f$. `maxComponents(F, n)` = $\\max_f \\text{numComponents}(f)$ over degree-$n$ polynomials with roots in $F$."
     },
     {
       "id": "original-problem",
       "title": "The Original Problem",
       "summary": "mainQuestion1 and mainQuestion2 definitions",
       "startLine": 71,
-      "endLine": 87
+      "endLine": 87,
+      "mathContext": "**Q1:** If $d(F) = 1$ and $F$ is not in any unit disc, can $L_f$ have $n$ components? **Q2:** If $d(F) < 1$, is $\\text{maxComponents}(F, n) \\le (1-c)n$ for some $c > 0$ depending on $F$? Both are formalized as `Prop` values."
     },
     {
       "id": "ehp-result",
       "title": "Erdős-Herzog-Piranian Result (1958)",
       "summary": "ehp_disc_result and roots_of_unity_example axioms",
       "startLine": 88,
-      "endLine": 102
+      "endLine": 102,
+      "mathContext": "Erdős-Herzog-Piranian (1958): for $F = \\overline{\\mathbb{D}}$ (unit disc), $\\text{maxComponents}(F, n) = n$. Witness: $f(z) = z^n + 1$, whose lemniscate has $n$ small discs around the $n$th roots of $-1$: $\\{z : |z^n + 1| < 1\\}$ has one component near each $e^{i\\pi(2k+1)/n}$."
     },
     {
       "id": "gr-solution",
       "title": "Ghosh-Ramachandran Solution (2024)",
       "summary": "Three main GR theorems: small diameter, small connected, diameter-1",
       "startLine": 103,
-      "endLine": 125
+      "endLine": 125,
+      "mathContext": "Ghosh-Ramachandran (2024): (1) $d(F) < 1 \\Rightarrow \\text{maxComponents}(F, n) \\le (1-c)n$ for some $c = c(F) > 0$; (2) $d(F) \\le 1/4$ and $F$ connected $\\Rightarrow \\text{maxComponents}(F, n) = 1$; (3) $d(F) = 1$ and $F$ not in a unit disc $\\Rightarrow \\text{maxComponents}(F, n) = n$."
     },
     {
       "id": "counterexample",
       "title": "The Counterexample",
       "summary": "diameter_not_sufficient: geometry ≠ diameter",
       "startLine": 126,
-      "endLine": 138
+      "endLine": 138,
+      "mathContext": "Key counterexample: $d(\\overline{\\mathbb{D}}_{1/2}) = 1/2 = d([-1,1])$, but the disc always gives 1 component while $[-1,1]$ can give $\\lfloor n/2 \\rfloor$ components. This proves the answer depends on the geometry of $F$, not just $d(F)$."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_1042_summary theorem combining key results",
       "startLine": 139,
-      "endLine": 151
+      "endLine": 151,
+      "mathContext": "`erdos_1042_summary` packages the two main GR results into a single proved conjunction: the $(1-c)n$ bound for $d < 1$ and the $n$-component result for $d = 1$. Proved by `exact ⟨ghosh_ramachandran_small_diameter, ghosh_ramachandran_diameter_one_examples⟩`."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1126/meta.json
+++ b/src/data/proofs/erdos-1126/meta.json
@@ -86,49 +86,56 @@
       "title": "Module Header and Imports",
       "startLine": 1,
       "endLine": 34,
-      "summary": "Problem statement, references (Jurkat 1965, de Bruijn 1966, Erdős 1960), and imports from `Mathlib.Data.Real.Basic`, `Mathlib.MeasureTheory.Measure.Lebesgue.Basic`, `Mathlib.Topology.Basic`"
+      "summary": "Problem statement, references (Jurkat 1965, de Bruijn 1966, Erdős 1960), and imports from `Mathlib.Data.Real.Basic`, `Mathlib.MeasureTheory.Measure.Lebesgue.Basic`, `Mathlib.Topology.Basic`",
+      "mathContext": "Imports Mathlib's real number type $\\mathbb{R}$, Lebesgue measure $\\lambda$ on $\\mathbb{R}$ and $\\mathbb{R}^2$, and topological continuity for `continuous_additive_is_linear`. The measure-theoretic imports are essential: 'almost everywhere' means 'outside a $\\lambda$-null set'."
     },
     {
       "id": "cauchy",
       "title": "Cauchy's Functional Equation",
       "startLine": 35,
       "endLine": 58,
-      "summary": "Defines `IsAdditive f` as $\\forall x\\,y,\\, f(x+y) = f(x) + f(y)$. Proves `id_is_additive` ($f = \\text{id}$) and `scalar_is_additive` ($f(x) = cx$) by `ring`. Axiomatizes `continuous_additive_is_linear`: continuous + additive $\\Rightarrow f(x) = cx$."
+      "summary": "Defines `IsAdditive f` as $\\forall x\\,y,\\, f(x+y) = f(x) + f(y)$. Proves `id_is_additive` ($f = \\text{id}$) and `scalar_is_additive` ($f(x) = cx$) by `ring`. Axiomatizes `continuous_additive_is_linear`: continuous + additive $\\Rightarrow f(x) = cx$.",
+      "mathContext": "`IsAdditive f` := $\\forall x\\,y \\in \\mathbb{R},\\; f(x+y) = f(x) + f(y)$ (Cauchy's functional equation). Examples: $f(x) = x$ and $f(x) = cx$ are additive. Cauchy (1821): continuous additive $\\Rightarrow f(x) = f(1) \\cdot x$. This is axiomatized as `continuous_additive_is_linear`."
     },
     {
       "id": "almost-everywhere",
       "title": "Almost-Everywhere Definitions",
       "startLine": 59,
       "endLine": 78,
-      "summary": "Defines `ae_holds P` (property holds outside a null set in $\\mathbb{R}$), `ae_pairs P` (holds outside a null set in $\\mathbb{R}^2$), `IsAlmostAdditive f` ($f(x+y) = f(x) + f(y)$ for a.e. pairs), and `ae_eq f g` ($f = g$ a.e.)."
+      "summary": "Defines `ae_holds P` (property holds outside a null set in $\\mathbb{R}$), `ae_pairs P` (holds outside a null set in $\\mathbb{R}^2$), `IsAlmostAdditive f` ($f(x+y) = f(x) + f(y)$ for a.e. pairs), and `ae_eq f g` ($f = g$ a.e.).",
+      "mathContext": "Custom measure-theoretic definitions: `ae_holds P` := $\\exists N \\subset \\mathbb{R},\\; \\lambda(N) = 0 \\wedge \\forall x \\notin N,\\; P(x)$. `ae_pairs P` := same for $N \\subset \\mathbb{R}^2$ with $\\lambda^2(N) = 0$. `IsAlmostAdditive f` := $f(x+y) = f(x) + f(y)$ for $\\lambda^2$-a.e. $(x,y)$. Uses explicit null sets rather than Mathlib's `Filter.Eventually` for pedagogical clarity."
     },
     {
       "id": "main-theorem",
       "title": "The de Bruijn-Jurkat Theorem",
       "startLine": 79,
       "endLine": 97,
-      "summary": "The main result axiomatized as `de_bruijn_jurkat_theorem`: $\\forall f,\\, \\text{IsAlmostAdditive}(f) \\Rightarrow \\exists g,\\, \\text{IsAdditive}(g) \\wedge f =_{\\text{a.e.}} g$. Wrapped as `erdos_1126_main` for clarity."
+      "summary": "The main result axiomatized as `de_bruijn_jurkat_theorem`: $\\forall f,\\, \\text{IsAlmostAdditive}(f) \\Rightarrow \\exists g,\\, \\text{IsAdditive}(g) \\wedge f =_{\\text{a.e.}} g$. Wrapped as `erdos_1126_main` for clarity.",
+      "mathContext": "$\\text{IsAlmostAdditive}(f) \\Rightarrow \\exists g : \\mathbb{R} \\to \\mathbb{R},\\; \\text{IsAdditive}(g) \\wedge f =_{\\text{a.e.}} g$. The proof (axiomatized) uses Fubini's theorem: for a.e. $x$, the function $y \\mapsto f(x+y) - f(x) - f(y)$ vanishes for a.e. $y$. Defining $g(x) = \\lim_{n \\to \\infty} f(nx)/n$ (which exists a.e.) yields the additive correction."
     },
     {
       "id": "uniqueness",
       "title": "Uniqueness of the Correction",
       "startLine": 98,
       "endLine": 109,
-      "summary": "Two uniqueness axioms: `additive_ae_unique` ($g_1, g_2$ additive, $g_1 =_{\\text{a.e.}} g_2 \\Rightarrow g_1 = g_2$) and `additive_zero_ae` ($g$ additive, $g =_{\\text{a.e.}} 0 \\Rightarrow g = 0$). Together they show the repair $g$ is unique."
+      "summary": "Two uniqueness axioms: `additive_ae_unique` ($g_1, g_2$ additive, $g_1 =_{\\text{a.e.}} g_2 \\Rightarrow g_1 = g_2$) and `additive_zero_ae` ($g$ additive, $g =_{\\text{a.e.}} 0 \\Rightarrow g = 0$). Together they show the repair $g$ is unique.",
+      "mathContext": "Key fact: if $g$ is additive and $g(x) = 0$ for a.e. $x$, then $g \\equiv 0$. Proof sketch: the zero set $Z = \\{x : g(x) = 0\\}$ has full measure, so $Z + Z = \\{x + y : x, y \\in Z\\}$ covers $\\mathbb{R}$ (by Steinhaus's theorem, $Z + Z$ contains an interval). Since $g(x+y) = g(x) + g(y) = 0$ for $x, y \\in Z$, $g$ vanishes on a dense set, hence everywhere by additivity."
     },
     {
       "id": "wild-functions",
       "title": "Wild Additive Functions and Regularity",
       "startLine": 110,
       "endLine": 124,
-      "summary": "Context axioms: `wild_additive_exist` (AC $\\Rightarrow \\exists$ discontinuous additive $f$) and `measurable_additive_is_linear` (additive + measurable $\\Rightarrow f(x) = cx$). Shows measurability is the sharp threshold for 'tame' behavior."
+      "summary": "Context axioms: `wild_additive_exist` (AC $\\Rightarrow \\exists$ discontinuous additive $f$) and `measurable_additive_is_linear` (additive + measurable $\\Rightarrow f(x) = cx$). Shows measurability is the sharp threshold for 'tame' behavior.",
+      "mathContext": "Using AC, choose a Hamel basis $B$ for $\\mathbb{R}$ over $\\mathbb{Q}$ and define $f$ to be $\\mathbb{Q}$-linear with $f(b_1) = 1$, $f(b_2) = \\sqrt{2}$ for two basis elements. Then $f$ is additive but $f(x)/x$ takes infinitely many values, so $f$ is nowhere continuous. The graph $\\{(x, f(x))\\}$ is dense in $\\mathbb{R}^2$. Measurability rules this out: additive + Lebesgue measurable $\\Rightarrow$ continuous $\\Rightarrow f(x) = cx$."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
       "startLine": 125,
       "endLine": 143,
-      "summary": "Theorem `erdos_1126_summary` combines the de Bruijn-Jurkat theorem with uniqueness: $\\text{IsAlmostAdditive}(f) \\Rightarrow \\exists! g,\\, \\text{IsAdditive}(g) \\wedge f =_{\\text{a.e.}} g$. Proved by pairing the two axioms."
+      "summary": "Theorem `erdos_1126_summary` combines the de Bruijn-Jurkat theorem with uniqueness: $\\text{IsAlmostAdditive}(f) \\Rightarrow \\exists! g,\\, \\text{IsAdditive}(g) \\wedge f =_{\\text{a.e.}} g$. Proved by pairing the two axioms.",
+      "mathContext": "The summary packages both parts: existence (de Bruijn-Jurkat) and uniqueness (additive + a.e. equal $\\Rightarrow$ equal) into a single $\\exists!$ statement. Proved by `⟨de_bruijn_jurkat_theorem f hf, additive_ae_unique⟩` — the only non-axiom theorem in the file (besides trivial examples)."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/erdos-1155/meta.json
+++ b/src/data/proofs/erdos-1155/meta.json
@@ -33,49 +33,56 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 39,
-      "summary": "Problem documentation describing the triangle removal process on K_n and imports from Mathlib for graphs, filters, and real-valued powers."
+      "summary": "Problem documentation describing the triangle removal process on K_n and imports from Mathlib for graphs, filters, and real-valued powers.",
+      "mathContext": "Start with $K_n$ ($\\binom{n}{2}$ edges). Repeat: choose a triangle $\\{a,b,c\\}$ uniformly at random, delete edges $ab$, $bc$, $ac$. Stop when triangle-free. Let $f(n)$ = edges remaining. Imports: `SimpleGraph.Clique` for `CliqueFree`, `Filter.AtTopBot` for $\\forall^\\infty$, `Pow.Real` for $n^{3/2 \\pm \\varepsilon}$."
     },
     {
       "id": "process-axioms",
       "title": "Process Axiomatization",
       "startLine": 40,
       "endLine": 62,
-      "summary": "Axiomatizes f(n) = triangleRemovalEdges as ℕ → ℝ with basic bounds: f(n) ≥ 0 and f(n) ≤ n(n-1)/2."
+      "summary": "Axiomatizes f(n) = triangleRemovalEdges as ℕ → ℝ with basic bounds: f(n) ≥ 0 and f(n) ≤ n(n-1)/2.",
+      "mathContext": "`triangleRemovalEdges : ℕ → ℝ` axiomatized with: $f(n) \\ge 0$ (non-negative edge count) and $f(n) \\le n(n-1)/2$ (cannot exceed $|E(K_n)|$). The function represents $\\mathbb{E}[f(n)]$ or a typical realization — the formalization is agnostic about this distinction."
     },
     {
       "id": "known-results",
       "title": "Known Results: BFL and Grable Bounds",
       "startLine": 63,
       "endLine": 95,
-      "summary": "BFL (2015): n^{3/2-ε} ≤ f(n) ≤ n^{3/2+ε} eventually (axiomatized). Grable (1997): f(n) ≤ n^{7/4+ε} (now proved from BFL, no longer an axiom)."
+      "summary": "BFL (2015): n^{3/2-ε} ≤ f(n) ≤ n^{3/2+ε} eventually (axiomatized). Grable (1997): f(n) ≤ n^{7/4+ε} (now proved from BFL, no longer an axiom).",
+      "mathContext": "Bohman-Frieze-Lubetzky (2015): $\\forall \\varepsilon > 0,\\; \\forall^\\infty n,\\; n^{3/2 - \\varepsilon} \\le f(n) \\le n^{3/2 + \\varepsilon}$, i.e., $f(n) = n^{3/2 + o(1)}$. Grable (1997): $f(n) \\le n^{7/4 + o(1)}$ — now a proved consequence of BFL since $3/2 + \\varepsilon < 7/4 + \\varepsilon$ for small $\\varepsilon$."
     },
     {
       "id": "conjecture",
       "title": "Erdős Conjecture",
       "startLine": 96,
       "endLine": 111,
-      "summary": "The open conjecture: ∃ c₁,c₂ > 0 such that c₁·n^{3/2} ≤ f(n) ≤ c₂·n^{3/2} for large n. Stronger than BFL's sub-polynomial precision."
+      "summary": "The open conjecture: ∃ c₁,c₂ > 0 such that c₁·n^{3/2} ≤ f(n) ≤ c₂·n^{3/2} for large n. Stronger than BFL's sub-polynomial precision.",
+      "mathContext": "**Conjecture (Erdős):** $\\exists\\, c_1, c_2 > 0$ such that $c_1 \\cdot n^{3/2} \\le f(n) \\le c_2 \\cdot n^{3/2}$ for all large $n$, i.e., $f(n) = \\Theta(n^{3/2})$. This is strictly stronger than BFL's $f(n) = n^{3/2 + o(1)}$ because it excludes logarithmic corrections like $n^{3/2} \\sqrt{\\log n}$. Status: OPEN."
     },
     {
       "id": "derived-results",
       "title": "Derived Theorems",
       "startLine": 112,
       "endLine": 154,
-      "summary": "Four proved theorems: BFL implies Grable (via exponent arithmetic), the conjecture implies Θ(n^{3/2}), BFL exponent characterization, and the generic implication."
+      "summary": "Four proved theorems: BFL implies Grable (via exponent arithmetic), the conjecture implies Θ(n^{3/2}), BFL exponent characterization, and the generic implication.",
+      "mathContext": "Proved theorems: (1) BFL $\\Rightarrow$ Grable: $n^{3/2+\\varepsilon} \\le n^{7/4+\\varepsilon}$ for $\\varepsilon < 1/4$; (2) Conjecture $\\Rightarrow \\Theta(n^{3/2})$: linear bounds $c_1 n^{3/2} \\le f(n) \\le c_2 n^{3/2}$ imply $n^{3/2-\\varepsilon} \\le f(n) \\le n^{3/2+\\varepsilon}$; (3) BFL exponent sandwich: $\\forall \\varepsilon > 0,\\; \\alpha - \\varepsilon \\le \\liminf \\frac{\\log f(n)}{\\log n} \\le \\limsup \\le \\alpha + \\varepsilon$ with $\\alpha = 3/2$."
     },
     {
       "id": "graph-basics",
       "title": "Graph-Theoretic Foundations",
       "startLine": 155,
       "endLine": 211,
-      "summary": "Defines IsTriangle, IsTriangleFree'. Proves equivalence with CliqueFree 3 (via Finset.card_eq_three) and that K_n has triangles for n ≥ 3. All proofs complete."
+      "summary": "Defines IsTriangle, IsTriangleFree'. Proves equivalence with CliqueFree 3 (via Finset.card_eq_three) and that K_n has triangles for n ≥ 3. All proofs complete.",
+      "mathContext": "`IsTriangle G a b c` := edges $ab$, $bc$, $ac$ all present with $a, b, c$ distinct. `IsTriangleFree' G` := $\\neg \\exists\\, a\\,b\\,c,\\; \\text{IsTriangle}\\,G\\,a\\,b\\,c$. Proved equivalent to Mathlib's `CliqueFree G 3` via `Finset.card_eq_three`. `complete_has_triangles`: $K_n$ has triangles for $n \\ge 3$ — explicit construction with vertices $0, 1, 2 \\in \\text{Fin}\\,n$."
     },
     {
       "id": "mantel",
       "title": "Mantel Bound and Trivial Upper Bound",
       "startLine": 212,
       "endLine": 226,
-      "summary": "Axiomatizes the direct Mantel bound f(n) ≤ n²/4 and derives it as an eventually-true statement. Fully proved."
+      "summary": "Axiomatizes the direct Mantel bound f(n) ≤ n²/4 and derives it as an eventually-true statement. Fully proved.",
+      "mathContext": "Mantel's theorem (1907): every triangle-free graph on $n$ vertices has $\\le \\lfloor n^2/4 \\rfloor$ edges (achieved by $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$). Since the removal process terminates at a triangle-free graph, $f(n) \\le n^2/4$. This is a trivial upper bound — much weaker than BFL's $n^{3/2+o(1)}$ but useful as a sanity check."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-1173/meta.json
+++ b/src/data/proofs/erdos-1173/meta.json
@@ -82,49 +82,56 @@
       "title": "Imports and Setup",
       "startLine": 1,
       "endLine": 37,
-      "summary": "Header documentation with problem statement and references, Mathlib imports for `Cardinal.Basic`, `Cardinal.Ordinal`, and `Mathlib.Tactic`. Opens the `Cardinal` and `Ordinal` namespaces."
+      "summary": "Header documentation with problem statement and references, Mathlib imports for `Cardinal.Basic`, `Cardinal.Ordinal`, and `Mathlib.Tactic`. Opens the `Cardinal` and `Ordinal` namespaces.",
+      "mathContext": "Imports `Mathlib.SetTheory.Cardinal.Basic` and `Mathlib.SetTheory.Cardinal.Ordinal` for the $\\aleph$ function, ordinal arithmetic, and cardinal comparison. The `Cardinal` namespace provides `aleph : Ordinal → Cardinal` for defining $\\aleph_\\omega$ and $\\aleph_{\\omega+1}$."
     },
     {
       "id": "cardinal-setup",
       "title": "Cardinal and Ordinal Constants",
       "startLine": 38,
       "endLine": 55,
-      "summary": "Defines $\\aleph_\\omega = \\text{aleph}(\\omega_0)$, $\\aleph_{\\omega+1} = \\text{aleph}(\\omega_0 + 1)$, the initial ordinal $\\omega_{\\omega+1}$, and the Generalized Continuum Hypothesis as $\\forall \\alpha,\\; 2^{\\aleph_\\alpha} = \\aleph_{\\alpha+1}$."
+      "summary": "Defines $\\aleph_\\omega = \\text{aleph}(\\omega_0)$, $\\aleph_{\\omega+1} = \\text{aleph}(\\omega_0 + 1)$, the initial ordinal $\\omega_{\\omega+1}$, and the Generalized Continuum Hypothesis as $\\forall \\alpha,\\; 2^{\\aleph_\\alpha} = \\aleph_{\\alpha+1}$.",
+      "mathContext": "$\\aleph_\\omega = \\sup_{n < \\omega} \\aleph_n$ is the first singular aleph with $\\text{cf}(\\aleph_\\omega) = \\omega$. GCH is $\\forall \\alpha,\\; 2^{\\aleph_\\alpha} = \\aleph_{\\alpha+1}$. The initial ordinal $\\omega_{\\omega+1}$ has cardinality $\\aleph_{\\omega+1}$; set mappings are defined on this ordinal."
     },
     {
       "id": "set-mappings",
       "title": "Set Mappings and Free Sets",
       "startLine": 56,
       "endLine": 89,
-      "summary": "Defines `SetMapping` on ordinals, `BoundedImageSize` ($|f(\\alpha)| \\leq \\kappa$), `AlmostDisjoint` ($|f(\\alpha) \\cap f(\\beta)| < \\kappa$ for $\\alpha \\neq \\beta$), `IsFreeSet` ($\\alpha \\notin f(\\beta)$ for distinct $\\alpha, \\beta \\in S$), and `HasFreeSetOfCard`."
+      "summary": "Defines `SetMapping` on ordinals, `BoundedImageSize` ($|f(\\alpha)| \\leq \\kappa$), `AlmostDisjoint` ($|f(\\alpha) \\cap f(\\beta)| < \\kappa$ for $\\alpha \\neq \\beta$), `IsFreeSet` ($\\alpha \\notin f(\\beta)$ for distinct $\\alpha, \\beta \\in S$), and `HasFreeSetOfCard`.",
+      "mathContext": "Core vocabulary: `SetMapping f` := $f : \\text{Ordinal} \\to \\text{Set Ordinal}$. `BoundedImageSize f κ` := $\\forall \\alpha,\\; |f(\\alpha)| \\le \\kappa$. `AlmostDisjoint f κ` := $\\forall \\alpha \\ne \\beta,\\; |f(\\alpha) \\cap f(\\beta)| < \\kappa$. `IsFreeSet S f` := $\\forall \\alpha, \\beta \\in S,\\; \\alpha \\ne \\beta \\Rightarrow \\alpha \\notin f(\\beta)$. Free sets are the key object: subsets where no element maps to another."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
       "startLine": 90,
       "endLine": 108,
-      "summary": "Formalizes `erdos_1173`: under GCH, every set mapping $f : \\omega_{\\omega+1} \\to [\\omega_{\\omega+1}]^{\\leq \\aleph_\\omega}$ with almost-disjoint images has a free set of cardinality $\\aleph_{\\omega+1}$."
+      "summary": "Formalizes `erdos_1173`: under GCH, every set mapping $f : \\omega_{\\omega+1} \\to [\\omega_{\\omega+1}]^{\\leq \\aleph_\\omega}$ with almost-disjoint images has a free set of cardinality $\\aleph_{\\omega+1}$.",
+      "mathContext": "`erdos_1173` := $\\text{GCH} \\Rightarrow \\forall f,\\; \\text{SetMapping}\\,f \\wedge \\text{BoundedImageSize}\\,f\\,\\aleph_\\omega \\wedge \\text{AlmostDisjoint}\\,f\\,\\aleph_\\omega \\Rightarrow \\text{HasFreeSetOfCard}\\,f\\,\\aleph_{\\omega+1}$. Status: OPEN. The difficulty: $\\aleph_\\omega$ is singular, so Hajnal's theorem (which requires regular $\\kappa$) does not directly apply."
     },
     {
       "id": "hajnal-theorem",
       "title": "The Hajnal Free Set Theorem",
       "startLine": 109,
       "endLine": 125,
-      "summary": "Axiomatizes the Hajnal free set theorem for regular $\\kappa$: if $|f(\\alpha)| < \\kappa$ for all $\\alpha < \\kappa^+$, then there exists a free set of size $\\kappa^+$. This is the known result that Problem #1173 seeks to generalize."
+      "summary": "Axiomatizes the Hajnal free set theorem for regular $\\kappa$: if $|f(\\alpha)| < \\kappa$ for all $\\alpha < \\kappa^+$, then there exists a free set of size $\\kappa^+$. This is the known result that Problem #1173 seeks to generalize.",
+      "mathContext": "**Hajnal (1961):** For regular $\\kappa$, if $f : \\kappa^+ \\to [\\kappa^+]^{<\\kappa}$ is a set mapping, then $\\exists S \\subseteq \\kappa^+$ with $|S| = \\kappa^+$ and $S$ free for $f$. The proof uses a transfinite induction argument that relies on $\\text{cf}(\\kappa) = \\kappa$ (regularity). For singular $\\kappa = \\aleph_\\omega$, this induction breaks down."
     },
     {
       "id": "gch-observations",
       "title": "Observations under GCH",
       "startLine": 126,
       "endLine": 144,
-      "summary": "Two axioms: (1) GCH implies $\\aleph_\\omega$ is a strong limit ($2^{\\aleph_n} < \\aleph_\\omega$ for all $n$). (2) Almost-disjointness with bound $\\aleph_\\omega$ implies each pairwise overlap is bounded by some $\\aleph_n$, using $\\mathrm{cf}(\\aleph_\\omega) = \\omega$."
+      "summary": "Two axioms: (1) GCH implies $\\aleph_\\omega$ is a strong limit ($2^{\\aleph_n} < \\aleph_\\omega$ for all $n$). (2) Almost-disjointness with bound $\\aleph_\\omega$ implies each pairwise overlap is bounded by some $\\aleph_n$, using $\\mathrm{cf}(\\aleph_\\omega) = \\omega$.",
+      "mathContext": "(1) GCH $\\Rightarrow$ $\\aleph_\\omega$ is a strong limit: $2^{\\aleph_n} = \\aleph_{n+1} < \\aleph_\\omega$ for all $n < \\omega$. (2) $|f(\\alpha) \\cap f(\\beta)| < \\aleph_\\omega$ implies $|f(\\alpha) \\cap f(\\beta)| \\le \\aleph_n$ for some $n < \\omega$, by $\\text{cf}(\\aleph_\\omega) = \\omega$ (a cardinal below $\\aleph_\\omega$ is below some $\\aleph_n$). This gives a countable stratification of the overlap structure."
     },
     {
       "id": "related-results",
       "title": "Related Results and Weak Form",
       "startLine": 145,
       "endLine": 167,
-      "summary": "Axiomatizes the Erdős–Hajnal theorem for $\\aleph_1$ (free sets of size $\\aleph_1$ for countably bounded mappings on $\\omega_1$). Defines `erdos_1173_weak`: the weak conjecture asking for a free set of size $\\aleph_\\omega$ instead of $\\aleph_{\\omega+1}$."
+      "summary": "Axiomatizes the Erdős–Hajnal theorem for $\\aleph_1$ (free sets of size $\\aleph_1$ for countably bounded mappings on $\\omega_1$). Defines `erdos_1173_weak`: the weak conjecture asking for a free set of size $\\aleph_\\omega$ instead of $\\aleph_{\\omega+1}$.",
+      "mathContext": "The $\\aleph_1$ case (Erdős-Hajnal): $f : \\omega_1 \\to [\\omega_1]^{\\le \\aleph_0}$ with $|f(\\alpha) \\cap f(\\beta)| < \\aleph_0$ has a free set of size $\\aleph_1$. Here $\\aleph_0$ is regular, so Hajnal's theorem applies directly. `erdos_1173_weak`: replace the conclusion $|S| = \\aleph_{\\omega+1}$ with $|S| = \\aleph_\\omega$ — a weaker (but potentially more tractable) target."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Batch enrichment pass adding `mathContext` to sections across 7 gallery entries. All entries previously had zero mathContext fields in their sections arrays.

| Entry | Topic | Sections |
|-------|-------|----------|
| erdos-504 | Maximum Angle in Point Sets | 8 |
| erdos-1008 | C₄-Free Subgraphs | 7 |
| erdos-1042 | Polynomial Lemniscates | 7 |
| erdos-1051 | Irrationality of Reciprocal Product Series | 7 |
| erdos-1126 | Almost Additive Functions | 7 |
| erdos-1155 | Triangle Removal Process | 7 |
| erdos-1173 | Free Sets under GCH | 7 |

**Total: 50 sections enriched with mathContext.**

Each `mathContext` field contains the key mathematical formulas, definitions, and Lean type signatures for that section — providing readers with the formal mathematical content alongside the prose summaries.

## Test plan
- [x] JSON syntax valid for all 7 entries
- [x] No annotation changes needed (annotations already had good mathContext)