### PR TITLE
Research: erdos-1060 - Eliminate all 3 sorries (3→0)

### DIFF
--- a/proofs/Proofs/Erdos1060Problem.lean
+++ b/proofs/Proofs/Erdos1060Problem.lean
@@ -46,14 +46,21 @@ For prime p, σ(p) = p + 1
 theorem sigma_prime (p : ℕ) (hp : p.Prime) : sigma p = p + 1 := by
   unfold sigma
   rw [Nat.Prime.divisors hp]
-  simp
+  have h1p : (1 : ℕ) ∉ ({p} : Finset ℕ) := by
+    rw [Finset.mem_singleton]; exact hp.one_lt.ne
+  rw [Finset.sum_insert h1p, Finset.sum_singleton]
+  simp only [id]; omega
 
 /--
 σ is multiplicative on coprime arguments.
 -/
-theorem sigma_mul_coprime (m n : ℕ) (hmn : m.Coprime n) (hm : m ≠ 0) (hn : n ≠ 0) :
+theorem sigma_mul_coprime (m n : ℕ) (hmn : m.Coprime n) (_hm : m ≠ 0) (_hn : n ≠ 0) :
     sigma (m * n) = sigma m * sigma n := by
-  sorry
+  -- Bridge to Mathlib's ArithmeticFunction.sigma 1, which is proved multiplicative
+  have bridge : ∀ k : ℕ, sigma k = (ArithmeticFunction.sigma 1) k := by
+    intro k; simp only [sigma, ArithmeticFunction.sigma_apply, pow_one, id]
+  rw [bridge, bridge, bridge]
+  exact ArithmeticFunction.isMultiplicative_sigma.map_mul_of_coprime hmn
 
 /-
 ## Part II: The Product k·σ(k)
@@ -137,7 +144,23 @@ noncomputable def f' (n : ℕ) : ℕ :=
 f and f' agree for n > 0.
 -/
 theorem f_eq_f' (n : ℕ) (hn : n > 0) : f n = f' n := by
-  sorry
+  unfold f f'
+  -- Key: solutionSet n = ↑((Icc 1 n).filter (fun k => g k = n)) as sets
+  have h_eq : solutionSet n = ↑((Finset.Icc 1 n).filter (fun k => g k = n)) := by
+    ext k
+    simp only [solutionSet, Set.mem_setOf_eq, Finset.coe_filter, Set.mem_setOf_eq,
+               Finset.mem_coe, Finset.mem_filter, Finset.mem_Icc]
+    constructor
+    · intro hk
+      refine ⟨⟨?_, ?_⟩, hk⟩
+      · -- k ≥ 1: if k = 0 then g 0 = 0 ≠ n since n > 0
+        by_contra hle; push_neg at hle; interval_cases k; simp [g] at hk; omega
+      · -- k ≤ n: since k ≤ g(k) = n
+        have hk_pos : 0 < k := by
+          by_contra hle; push_neg at hle; interval_cases k; simp [g] at hk; omega
+        linarith [k_le_g k hk_pos]
+    · exact fun ⟨_, hk⟩ => hk
+  rw [h_eq, Set.ncard_coe_finset]
 
 /-
 ## Part IV: Basic Values
@@ -221,11 +244,24 @@ The sequence of n for which f(n) > 0 (i.e., k·σ(k) = n has a solution).
 def oeis_A327153 : Set ℕ := {n : ℕ | f n > 0}
 
 /--
-Membership in A327153.
+Membership in A327153 for positive n.
+
+Note: For n = 0, f(0) = 1 > 0 (via k = 0), but no k > 0 satisfies g(k) = 0,
+so the k > 0 condition requires n > 0.
 -/
-theorem mem_A327153_iff (n : ℕ) :
+theorem mem_A327153_iff (n : ℕ) (hn : n > 0) :
     n ∈ oeis_A327153 ↔ ∃ k > 0, g k = n := by
-  sorry
+  -- Use show to keep f n visible for rewriting
+  show f n > 0 ↔ ∃ k > 0, g k = n
+  rw [f_eq_f' n hn]
+  simp only [f', Finset.card_pos, Finset.Nonempty]
+  constructor
+  · rintro ⟨k, hk⟩
+    rw [Finset.mem_filter, Finset.mem_Icc] at hk
+    exact ⟨k, hk.1.1, hk.2⟩
+  · rintro ⟨k, hk_pos, hgk⟩
+    exact ⟨k, Finset.mem_filter.mpr ⟨Finset.mem_Icc.mpr
+      ⟨hk_pos, hgk ▸ k_le_g k hk_pos⟩, hgk⟩⟩
 
 /-
 ## Part VII: Examples and Computations

--- a/research/problems/erdos-1060/knowledge.md
+++ b/research/problems/erdos-1060/knowledge.md
@@ -58,7 +58,30 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-03-24 (Session 1) - Eliminate All Sorries
+
+**Mode**: FRESH
+**Outcome**: progress (3 sorries → 0 sorries)
+
+#### What I Did
+- Proved `sigma_mul_coprime`: σ is multiplicative on coprime arguments. Bridge to Mathlib's `ArithmeticFunction.isMultiplicative_sigma` via showing our local `sigma k = (ArithmeticFunction.sigma 1) k`.
+- Proved `f_eq_f'`: Bridge between `Set.ncard` and `Finset.card` characterizations of f(n). Key: showed `solutionSet n = ↑((Icc 1 n).filter (fun k => g k = n))` then used `Set.ncard_coe_finset`.
+- Proved `mem_A327153_iff`: Characterized OEIS A327153 membership for n > 0. Added hypothesis `n > 0` (original statement was unprovable for n=0). Uses `f_eq_f'` bridge and `Finset.card_pos`.
+- Fixed pre-existing `sigma_prime` proof that relied on `simp` which couldn't close `∑ x ∈ {1, p}, x = p + 1`. Used explicit `Finset.sum_insert` + `Finset.sum_singleton` + `omega`.
+
+#### Key Findings
+- `Nat.Coprime.divisors_mul` was removed/renamed in Mathlib v4.26.0 - need to use ArithmeticFunction bridge instead
+- `sigma_isMultiplicative` → now `ArithmeticFunction.isMultiplicative_sigma`
+- `Set.ncard_coe_Finset` → deprecated, use `Set.ncard_coe_finset`
+- `Set.Finite` is now `Finite` on the subtype in recent Mathlib
+
+#### Files Modified
+- `proofs/Proofs/Erdos1060Problem.lean` (3 sorries → 0, also fixed sigma_prime)
+
+#### Next Steps
+- 2 axioms remain (OPEN conjectures - cannot be proved)
+- File is now in good shape: 0 sorries, well-structured
+- Consider adding more supporting lemmas (e.g., bounds on f for specific n)
 
 ---
 

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -16,7 +16,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 1060,
     "erdosUrl": "https://erdosproblems.com/1060",
     "erdosProblemStatus": "open",
@@ -51,11 +51,14 @@
       "erdos_1060_weak_conjecture axiom: f(n) ≤ n^{o(1/log log n)}",
       "erdos_1060_strong_conjecture axiom: f(n) ≤ (log n)^C",
       "oeis_A327153 definition: values with solutions",
-      "Concrete examples: g(2)=6, g(3)=12, g(5)=30, g(6)=72, g(7)=56"
+      "Concrete examples: g(2)=6, g(3)=12, g(5)=30, g(6)=72, g(7)=56",
+      "sigma_mul_coprime theorem: σ multiplicativity via ArithmeticFunction bridge",
+      "f_eq_f theorem: Set.ncard = Finset.card characterization",
+      "mem_A327153_iff theorem: OEIS A327153 membership for n > 0"
     ],
     "axiomCount": 2,
-    "lineCount": 268,
-    "assumptions": "2 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "lineCount": 282,
+    "assumptions": "2 axiom(s) (open conjectures). All supporting lemmas fully proved."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1060**\n\nThis problem appears as B11 in Richard Guy's collection 'Unsolved Problems in Number Theory' [Gu04], attributed to Erdős.\n\n**Key History:**\n- The problem concerns the multiplicative Diophantine equation k·σ(k) = n\n- Related to understanding the structure of the divisor function σ\n- Connected to OEIS sequence A327153\n\n**Mathematical Setting:**\nThe sum of divisors function σ(k) = Σ_{d|k} d is one of the most fundamental arithmetic functions. The product k·σ(k) combines multiplicative and additive structure in a subtle way.",

--- a/src/data/research/problems/erdos-1060.json
+++ b/src/data/research/problems/erdos-1060.json
@@ -29,9 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: All 3 sorries eliminated (3→0). 2 axioms remain (OPEN conjectures).",
+    "builtItems": [
+      "sigma_mul_coprime (Erdos1060Problem.lean:57): σ multiplicativity via ArithmeticFunction bridge",
+      "f_eq_f (Erdos1060Problem.lean:142): Set.ncard = Finset.card for f(n)",
+      "mem_A327153_iff (Erdos1060Problem.lean:247): OEIS A327153 membership for n>0",
+      "sigma_prime fix (Erdos1060Problem.lean:46): explicit sum_insert proof"
+    ],
+    "insights": [
+      "sigma_mul_coprime proved via bridge to ArithmeticFunction.isMultiplicative_sigma",
+      "f_eq_f bridges Set.ncard and Finset.card via Set.ncard_coe_finset",
+      "mem_A327153_iff requires n > 0 (unprovable for n=0 since f(0)=1 but no k>0 with g(k)=0)",
+      "Mathlib v4.26: Nat.Coprime.divisors_mul removed, sigma_isMultiplicative renamed"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #1060 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $f(n)$ count the number of solutions to $k\\sigma(k)=n$, where $\\sigma(k)$ is the sum of divisors of $k$. Is it true that $f(n)\\leq n^{o(\\frac{1}{\\log\\log n})}$? Perhaps even $\\leq (\\log n)^{O(1)}$?\n\n\n\nThis is discussed in problem B11 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1059\n- Problem #1061\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"


### PR DESCRIPTION
## Summary
- Proved all 3 supporting lemmas for Erdős Problem #1060 (counting solutions to k·σ(k) = n)
- `sigma_mul_coprime`: σ multiplicativity via bridge to Mathlib's `ArithmeticFunction.isMultiplicative_sigma`
- `f_eq_f'`: Bridge `Set.ncard` ↔ `Finset.card` using `Set.ncard_coe_finset`
- `mem_A327153_iff`: OEIS A327153 membership characterization (added `n > 0` hypothesis — original was unprovable for n = 0)
- Fixed pre-existing `sigma_prime` proof (`simp` couldn't close goal)

2 axioms remain (open conjectures, cannot be proved).

## Test plan
- [x] Docker build succeeds for `Proofs.Erdos1060Problem`
- [x] 0 sorries, 2 axioms (both are open conjectures)
- [x] Knowledge and meta.json updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)