### PR TITLE
Research: erdos-5 — prove limitPointSet_isClosed (0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos5PrimeGaps.lean
+++ b/proofs/Proofs/Erdos5PrimeGaps.lean
@@ -427,10 +427,65 @@ theorem limitPointSet_unbounded_above (M : ℝ) (hM : M > 0) :
 theorem limitPointSet_isClosed : IsClosed limitPointSet := by
   rw [← isOpen_compl_iff, Metric.isOpen_iff]
   intro C hC
-  -- C is not a limit point → ∃ ε > 0, eventually normalizedGap stays away from C
-  -- (contrapositive of diagonalization argument above)
-  -- Then ball C (ε/2) ⊆ limitPointSetᶜ by triangle inequality
-  sorry
+  -- Step 1: ¬IsLimitPoint C → ∃ ε > 0, only finitely many n within ε of C
+  -- (by contrapositive: if infinitely many for all ε, extract converging subsequence)
+  have key : ∃ ε > 0, ({n : ℕ | dist (normalizedGap n) C < ε}).Finite := by
+    by_contra h_all_inf
+    push_neg at h_all_inf
+    apply hC
+    -- For each k, the set {n | dist ... < 1/(k+1)} is infinite
+    have hS : ∀ k : ℕ, ({n : ℕ | dist (normalizedGap n) C < 1 / (↑k + 1)}).Infinite :=
+      fun k => h_all_inf _ (by positivity)
+    -- From infinite subset of ℕ, find elements beyond any bound
+    have inf_gt : ∀ (s : Set ℕ), s.Infinite → ∀ N : ℕ, ∃ n ∈ s, N < n := by
+      intro s hs N
+      by_contra hc; push_neg at hc
+      exact hs ((Set.finite_Iic N).subset fun n hn => hc n hn)
+    -- For each k, N: get n > N with dist < 1/(k+1)
+    have step : ∀ k N : ℕ, ∃ n, N < n ∧ dist (normalizedGap n) C < 1 / (↑k + 1) := by
+      intro k N; obtain ⟨n, hm, hg⟩ := inf_gt _ (hS k) N; exact ⟨n, hg, hm⟩
+    choose g hg_gt hg_dist using step
+    -- Build sequence: f 0 = g 0 0, f (k+1) = g (k+1) (f k)
+    let f : ℕ → ℕ := fun n => Nat.rec (g 0 0) (fun k fk => g (k + 1) fk) n
+    have hf_step : ∀ n, f n < f (n + 1) := fun n => hg_gt (n + 1) (f n)
+    have hf_dist : ∀ k, dist (normalizedGap (f k)) C < 1 / (↑k + 1) := by
+      intro k; cases k with
+      | zero => exact hg_dist 0 0
+      | succ n => exact hg_dist (n + 1) (f n)
+    refine ⟨f, strictMono_nat_of_lt_succ hf_step, ?_⟩
+    rw [Metric.tendsto_atTop]
+    intro ε hε
+    obtain ⟨K, hK⟩ := exists_nat_gt (1 / ε)
+    use K
+    intro k hk
+    simp only [Function.comp_apply]
+    calc dist (normalizedGap (f k)) C
+        < 1 / (↑k + 1) := hf_dist k
+      _ < ε := by
+          have hk_pos : (0 : ℝ) < ↑k + 1 := by positivity
+          rw [div_lt_iff₀ hk_pos]
+          have h1 : 1 < (↑K : ℝ) * ε := (div_lt_iff₀ hε).mp hK
+          have h2 : (↑K : ℝ) ≤ ↑k := by exact_mod_cast hk
+          nlinarith
+  -- Step 2: Ball of radius ε/2 around C avoids all limit points
+  obtain ⟨ε, hε, hfin⟩ := key
+  refine ⟨ε / 2, by linarith, ?_⟩
+  intro C' hC' ⟨f, hf_mono, hf_lim⟩
+  rw [Metric.tendsto_atTop] at hf_lim
+  obtain ⟨K, hK⟩ := hf_lim (ε / 2) (by linarith)
+  -- For k ≥ K: normalizedGap(f k) within ε/2 of C', and C' within ε/2 of C
+  -- So normalizedGap(f k) within ε of C by triangle inequality
+  have h_in : ∀ k, K ≤ k → f k ∈ {n : ℕ | dist (normalizedGap n) C < ε} := by
+    intro k hk
+    have h1 := hK k hk; simp only [Function.comp_apply] at h1
+    simp only [Set.mem_setOf_eq]
+    linarith [dist_triangle (normalizedGap (f k)) C' C, Metric.mem_ball.mp hC']
+  -- But only finitely many n are within ε of C, while f is unbounded → contradiction
+  obtain ⟨M, hM⟩ := hfin.bddAbove
+  obtain ⟨K', hK'⟩ := (Filter.tendsto_atTop_atTop.mp hf_mono.tendsto_atTop) (M + 1)
+  have h_le := hM (h_in (max K K') (le_max_left _ _))
+  have h_ge := hK' (max K K') (le_max_right _ _)
+  omega
 
 /- ## Part XI: The Conjecture as Set Equality -/
 

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -16,13 +16,13 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 5,
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 446,
-    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), merikoski_bounded_gaps (S has bounded gaps, 2020). 1 sorry in limitPointSet_isClosed (closedness of limit point set). Proves 19 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_unbounded, westzynthius_implies_frequently_large.",
+    "lineCount": 501,
+    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 20 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, westzynthius_implies_frequently_large.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -109,7 +109,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 19 theorems from 3 axioms with 1 sorry (limitPointSet_isClosed). The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Structural results include: S is nonempty, S is unbounded (from Merikoski), and normalized gaps exceed any bound infinitely often. The conjecture reduces to showing all C ≥ 0 are limit points.",
+    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 20 theorems from 3 axioms with 0 sorries. The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Key structural results: S is nonempty, S is closed (proved via diagonal extraction + triangle inequality), S is unbounded, and normalized gaps exceed any bound infinitely often. The conjecture reduces to showing all C ≥ 0 are limit points.",
     "implications": "Resolution would provide a complete understanding of prime gap fluctuations at the logarithmic scale, confirming the prediction of Cramér's probabilistic model. It connects to the Hardy-Littlewood prime k-tuples conjecture (which would imply S = [0, ∞)), sieve methods (the GPY-Maynard-Tao framework), and the distribution of primes in short intervals.",
     "openQuestions": [
       "Is every C ≥ 0 a limit point of (p_{n+1} - p_n)/log(p_n)?",
@@ -162,9 +162,9 @@
       "Topology"
     ],
     "namespace": "Erdos5",
-    "lineCount": 446,
+    "lineCount": 501,
     "axiomCount": 3,
-    "theoremCount": 19,
+    "theoremCount": 20,
     "definitionCount": 9
   },
   "references": [

--- a/src/data/research/problems/erdos-5.json
+++ b/src/data/research/problems/erdos-5.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-5",
   "title": "Erdős #5",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 3 fixed pre-existing build failure (Mathlib API change) and added limitPointSet_isClosed statement with documented proof strategy. Proof reduces to diagonalization + triangle inequality.",
+    "progressSummary": "COMPLETED: All sorries eliminated. 20 theorems, 3 axioms (deep results), 0 sorries. limitPointSet_isClosed proved via diagonal extraction + triangle inequality.",
     "builtItems": [
       "Proved goldston_pintz_yildirim_small_gaps: derived from zhang_implies_zero_limit (already proved from zhang_bounded_gaps axiom)",
       "Proved erdos_ricci_positive_measure: trivially True placeholder (needs measure theory for real content)",
@@ -44,7 +44,8 @@
       "Removed merikoski_density True placeholder (was ∃ d ≥ 1/3, True)",
       "Updated gallery meta.json: proofRepoPath → Erdos5PrimeGaps.lean, axiomCount 8→3",
       "Fixed limitPoint_nonneg: le_of_tendsto → ge_of_tendsto (Mathlib API change)",
-      "Added limitPointSet_isClosed statement with proof outline (sorry, 1 remaining)"
+      "Added limitPointSet_isClosed statement with proof outline (sorry, 1 remaining)",
+      "PROVED limitPointSet_isClosed: S is closed as subset of ℝ (Erdos5PrimeGaps.lean:427)"
     ],
     "insights": [
       "Erdos5PrimeGaps.lean is the main file (343L, well-structured); Erdos5Problem.lean is legacy (81L, all axiomatized)",
@@ -58,11 +59,11 @@
       "westzynthius_large_gaps + filter API gives infinitely-often large gaps via Tendsto.atTop decomposition",
       "Gallery was pointing to legacy Erdos5Problem.lean (8 axioms, 80 lines) instead of main Erdos5PrimeGaps.lean (3 axioms, 380 lines, 19 theorems)",
       "limitPoint_nonneg was broken by Mathlib API change: le_of_tendsto renamed to ge_of_tendsto",
-      "limitPointSet_isClosed proof strategy documented: show complement is open via cluster point characterization + triangle inequality"
+      "limitPointSet_isClosed proof strategy documented: show complement is open via cluster point characterization + triangle inequality",
+      "limitPointSet_isClosed proved: complement is open via contrapositive diagonal extraction (build strictly increasing subsequence from infinite ε-neighborhoods) + triangle inequality (ε/2-ball argument)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove limitPointSet_isClosed: S is closed (diagonal argument on subsequential limits)",
       "Consider proving Hildebrand-Maier from westzynthius + merikoski (large finite limit points)",
       "Consider if merikoski_bounded_gaps can derive erdos_ricci (infinitely many distinct limit points)",
       "Deprecate Erdos5Problem.lean or add note pointing to Erdos5PrimeGaps.lean"


### PR DESCRIPTION
## Summary
- **Prove `limitPointSet_isClosed`**: The set S of limit points of normalized prime gaps is closed as a subset of ℝ. This was the last remaining sorry in the erdos-5 formalization.
- **Proof technique**: Contrapositive diagonal extraction (build strictly increasing subsequence from infinite ε-neighborhoods) + triangle inequality (ε/2-ball argument excludes all limit points near a non-limit-point).
- **File now**: 20 theorems, 3 axioms (Westzynthius, Zhang, Hildebrand-Maier), **0 sorries**, 501 lines.

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos5PrimeGaps`
- [x] Zero sorries confirmed: `grep sorry proofs/Proofs/Erdos5PrimeGaps.lean` returns empty
- [x] Gallery metadata updated (sorries: 1→0, theoremCount: 19→20, lineCount: 446→501)

🤖 Generated with [Claude Code](https://claude.com/claude-code)