### PR TITLE
Fix: correct axiom/sorry counts in 5 gallery metadata files

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axioms": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -64,7 +64,7 @@
       "erdos_382_summary: combined known results theorem",
       "Concrete example: prodInterval 2 4 = 24 via native_decide"
     ],
-    "axiomCount": 13,
+    "axiomCount": 12,
     "lineCount": 266,
     "assumptions": "13 axioms: prodInterval_factorial, largestPrimeDivisor_dvd, largestPrimeDivisor_prime, and 10 more. See Lean source for complete statements."
   },
@@ -196,7 +196,7 @@
     ],
     "namespace": "Erdos382",
     "lineCount": 266,
-    "axiomCount": 13,
+    "axiomCount": 12,
     "theoremCount": 3,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "erdosNumber": 960,
     "erdosUrl": "https://erdosproblems.com/960",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -190,7 +190,7 @@
     ],
     "namespace": "GreensTheoremOQ03",
     "lineCount": 557,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 31,
     "definitionCount": 12
   }

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -27,7 +27,7 @@
     ],
     "badge": "axiom",
     "sorries": 2,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Cyclotomic fields and Kronecker-Weber theorem",


### PR DESCRIPTION
## Fix

Corrects metadata counts that drifted from actual Lean source content in 5 gallery entries.

## Evidence

| Entry | Field | Before | After | Verification |
|-------|-------|--------|-------|-------------|
| erdos-382 | axiomCount | 13 | 12 | 12 `^axiom` declarations in source, 0 structures |
| erdos-960 | sorries | 4 | 2 | 2 code sorries (lines 104, 135); 2 others in comments |
| ballot-problem-oq-03-oq-02 | sorries | 2 | 1 | 1 code sorry (line 1912); 1 other in doc comment |
| inverse-galois | meta.axiomCount | 3 | 2 | 2 axioms (abelian_realizable, shafarevich_theorem); leanFile.axiomCount was already 2 |
| greens-theorem-oq-03 | leanFile.axiomCount | 2 | 3 | 3 axioms in source; meta.axiomCount was already 3 |

All counts verified by stripping Lean block/line comments before counting.

Also closed #6327 (auditor false positive — all 16 reported sorry mismatches were in comments).

---
Automated fix by lean-mechanic agent.