### PR TITLE
Audit: fix sorry count mismatches in ballot-problem-oq-03-oq-02, erdos-960

### DIFF
--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -29,14 +29,17 @@
       "threshold(r,k,n) via sSup over configurations",
       "ErdosConjecture960_littleo: f = o(n²) formal statement",
       "ErdosConjecture960_linear: f ≪ n stronger form",
-      "turan_upper_bound (axiom): Turán bound over ℚ",
-      "threshold_r2 (axiom): f_{2,k}(n) = 1",
+      "turan_upper_bound (sorry): Turán bound over ℚ",
+      "threshold_r2 (sorry): f_{2,k}(n) = 0",
+      "trivial_bound (proved): at most C(n,2) ordinary lines",
+      "linear_implies_littleo (proved): linear bound implies o(n²)",
+      "ordinary_pairs_count (proved): r*(r-1) ordered ordinary pairs",
       "green_tao_ordinary_lines (axiom): ≥ n/2 for general position",
       "erdos_960_summary (proved): combines conjecture with r=2 case"
     ],
     "axiomCount": 2,
-    "lineCount": 164,
-    "assumptions": "2 axioms: erdos_960_littleo_conjecture (the open o(n²) conjecture), green_tao_ordinary_lines (Green-Tao 2013 ordinary lines bound). 4 sorries in turan_upper_bound, trivial_bound, threshold_r2, linear_implies_littleo.",
+    "lineCount": 192,
+    "assumptions": "2 axioms: erdos_960_littleo_conjecture (the open o(n²) conjecture), green_tao_ordinary_lines (Green-Tao 2013 ordinary lines bound). 2 sorries in turan_upper_bound, threshold_r2.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -143,10 +146,10 @@
     ],
     "opens": [],
     "namespace": "Erdos960",
-    "lineCount": 164,
+    "lineCount": 192,
     "axiomCount": 2,
-    "theoremCount": 8,
-    "definitionCount": 7
+    "theoremCount": 7,
+    "definitionCount": 8
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

- **ballot-problem-oq-03-oq-02**: sorry count 2→1 (gvCanon_membership now proved), updated stale claims that gv_involution_cancellation was an axiom (now a theorem), corrected line/theorem/definition counts to match actual Lean source
- **erdos-960**: sorry count 4→2 (trivial_bound and linear_implies_littleo now proved), corrected line count, updated originalContributions

## Test plan

- [ ] Verify `pnpm build` passes with updated meta.json files
- [ ] Confirm sorry counts match: `grep -c sorry proofs/Proofs/BallotProblemOQ03OQ02.lean` = 2 (1 in comment, 1 in code)
- [ ] Confirm sorry counts match: `grep -c sorry proofs/Proofs/Erdos960Problem.lean` = 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)