### PR TITLE
Research: descartes-rule-of-signs-oq-02 - Budan's Theorem formalization

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ02.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ02.lean
@@ -1,0 +1,418 @@
+import Mathlib.Algebra.Polynomial.Basic
+import Mathlib.Algebra.Polynomial.Degree.Definitions
+import Mathlib.Algebra.Polynomial.Eval.Defs
+import Mathlib.Algebra.Polynomial.Coeff
+import Mathlib.Algebra.Polynomial.RuleOfSigns
+import Mathlib.Algebra.Polynomial.Derivative
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+import Mathlib.Analysis.Calculus.LocalExtr.Rolle
+
+set_option maxHeartbeats 800000
+
+/-
+# Budan's Theorem — Generalization of Descartes' Rule (OQ-02)
+
+## What This Proves
+
+Budan's theorem (1807) generalizes Descartes' Rule of Signs from counting
+positive roots to counting roots in any half-open interval (a, b].
+
+For a polynomial p of degree n, define the **Budan-Fourier sequence** at x:
+  [p(x), p'(x), p''(x), ..., p⁽ⁿ⁾(x)]
+
+Let V_p(x) = number of sign changes in this sequence (ignoring zeros).
+
+**Budan's Theorem**: The number of roots of p in (a, b], counted with
+multiplicity, satisfies:
+  #roots(a,b] ≤ V_p(a) - V_p(b)
+and the difference V_p(a) - V_p(b) - #roots(a,b] is an even non-negative number.
+
+## Historical Context
+
+François Budan de Boislaurent published this result in 1807. Joseph Fourier
+independently rediscovered it around 1820, leading to the name
+"Budan-Fourier theorem." It is strictly more powerful than Descartes' rule,
+which is the special case a = 0, b → ∞.
+
+The theorem is a key ingredient in:
+- Vincent's theorem for real root isolation (1834)
+- The VAS (Vincent-Akritas-Strzeboński) algorithm
+- Modern real algebraic geometry computations
+
+## Key Results
+
+1. **Derivative sequence**: Iterated derivatives [p, p', p'', ..., p⁽ⁿ⁾]
+2. **Budan-Fourier count V_p(x)**: Sign changes in the derivative sequence at x
+3. **Main theorem**: #roots in (a,b] ≤ V_p(a) - V_p(b) (with parity)
+4. **Descartes recovery**: Budan at (0, +∞) gives Descartes' rule
+5. **Root isolation**: V_p(a) - V_p(b) = 1 implies exactly one root in (a,b]
+6. **Special cases**: Constant, linear, quadratic polynomials
+
+## Axiom Budget: 3 axioms (budan_upper_bound, budan_parity, budanCount_large)
+
+Original formalization for Lean Genius.
+-/
+
+namespace BudanTheorem
+
+open Polynomial
+
+/-
+## Part I: The Derivative Sequence
+
+The Budan-Fourier sequence of a polynomial p of degree n at point x is:
+  [p(x), p'(x), p''(x), ..., p⁽ⁿ⁾(x)]
+-/
+
+/-- The k-th iterated derivative of a polynomial.
+    iterDeriv p 0 = p, iterDeriv p 1 = p', iterDeriv p k = p⁽ᵏ⁾ -/
+noncomputable def iterDeriv (p : ℝ[X]) : ℕ → ℝ[X]
+  | 0 => p
+  | k + 1 => derivative (iterDeriv p k)
+
+@[simp]
+theorem iterDeriv_zero (p : ℝ[X]) : iterDeriv p 0 = p := rfl
+
+@[simp]
+theorem iterDeriv_succ (p : ℝ[X]) (k : ℕ) :
+    iterDeriv p (k + 1) = derivative (iterDeriv p k) := rfl
+
+/-- iterDeriv of a derivative commutes. -/
+theorem iterDeriv_derivative (p : ℝ[X]) (k : ℕ) :
+    iterDeriv (derivative p) k = iterDeriv p (k + 1) := by
+  induction k with
+  | zero => simp
+  | succ k ih => simp [ih]
+
+/-- Degree of the k-th iterated derivative is bounded. -/
+theorem natDegree_iterDeriv_le (p : ℝ[X]) (k : ℕ) :
+    (iterDeriv p k).natDegree ≤ p.natDegree - k := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    simp only [iterDeriv_succ]
+    have hd := Polynomial.natDegree_derivative_le (iterDeriv p k)
+    omega
+
+/-- Iterated derivative beyond the degree is zero. -/
+theorem iterDeriv_eq_zero (p : ℝ[X]) (k : ℕ) (hk : p.natDegree < k) :
+    iterDeriv p k = 0 := by
+  induction k with
+  | zero => omega
+  | succ k ih =>
+    simp only [iterDeriv_succ]
+    by_cases hk' : p.natDegree < k
+    · rw [ih hk']; simp
+    · push_neg at hk'
+      have hkeq : k = p.natDegree := by omega
+      subst hkeq
+      have hdeg : (iterDeriv p p.natDegree).natDegree = 0 := by
+        have := natDegree_iterDeriv_le p p.natDegree; omega
+      have hconst := Polynomial.eq_C_of_natDegree_eq_zero hdeg
+      rw [hconst]; simp
+
+/-- The Budan-Fourier evaluation sequence at a point x.
+    Returns [p(x), p'(x), ..., p⁽ⁿ⁾(x)] as a list of reals. -/
+noncomputable def budanSequence (p : ℝ[X]) (n : ℕ) (x : ℝ) : List ℝ :=
+  (List.range (n + 1)).map (fun k => (iterDeriv p k).eval x)
+
+@[simp]
+theorem budanSequence_length (p : ℝ[X]) (n : ℕ) (x : ℝ) :
+    (budanSequence p n x).length = n + 1 := by
+  simp [budanSequence]
+
+/-
+## Part II: Sign Variation Count
+-/
+
+/-- Count adjacent pairs that differ in a list of ±1 values. -/
+def countAdjacentDiffs : List ℤ → ℕ
+  | [] => 0
+  | [_] => 0
+  | a :: b :: rest =>
+    (if a ≠ b then 1 else 0) + countAdjacentDiffs (b :: rest)
+
+@[simp] theorem countAdjacentDiffs_nil : countAdjacentDiffs [] = 0 := rfl
+@[simp] theorem countAdjacentDiffs_singleton (a : ℤ) : countAdjacentDiffs [a] = 0 := rfl
+
+/-- Count sign changes in a list of reals, ignoring zeros.
+    Filters out zeros, maps remaining to ±1, counts adjacent differences. -/
+noncomputable def signChangesInList (l : List ℝ) : ℕ :=
+  let nonzero := l.filter (· ≠ 0)
+  let signs := nonzero.map (fun x => if x > 0 then (1 : ℤ) else -1)
+  countAdjacentDiffs signs
+
+@[simp]
+theorem signChangesInList_nil : signChangesInList [] = 0 := by
+  simp [signChangesInList, countAdjacentDiffs]
+
+/-
+## Part III: The Budan-Fourier Count V_p(x)
+-/
+
+/-- The Budan-Fourier sign variation count V_p(x).
+    Counts sign changes in the derivative evaluation sequence at x. -/
+noncomputable def budanCount (p : ℝ[X]) (x : ℝ) : ℕ :=
+  signChangesInList (budanSequence p p.natDegree x)
+
+@[simp]
+theorem budanCount_zero (x : ℝ) : budanCount (0 : ℝ[X]) x = 0 := by
+  unfold budanCount budanSequence
+  simp [signChangesInList, countAdjacentDiffs]
+
+/-- V_p(x) for a constant polynomial is 0 (one entry, no sign changes). -/
+theorem budanCount_C (c : ℝ) (x : ℝ) : budanCount (C c) x = 0 := by
+  unfold budanCount budanSequence
+  simp only [Polynomial.natDegree_C, List.range_succ, List.range_zero, List.nil_append,
+    List.map_cons, List.map_nil]
+  unfold signChangesInList
+  simp only [List.filter_cons, List.filter_nil]
+  split <;> simp [countAdjacentDiffs]
+
+/-
+## Part IV: Count of Roots in Intervals
+-/
+
+/-- Count of roots of p in the half-open interval (a, b], with multiplicity. -/
+noncomputable def rootsInInterval (p : ℝ[X]) (a b : ℝ) : ℕ :=
+  if p = 0 then 0
+  else Multiset.card (p.roots.filter (fun r => a < r ∧ r ≤ b))
+
+@[simp]
+theorem rootsInInterval_zero (a b : ℝ) : rootsInInterval (0 : ℝ[X]) a b = 0 := by
+  simp [rootsInInterval]
+
+/-- A nonzero constant has 0 roots in any interval. -/
+theorem rootsInInterval_C (c : ℝ) (hc : c ≠ 0) (a b : ℝ) :
+    rootsInInterval (C c) a b = 0 := by
+  simp only [rootsInInterval, C_eq_zero.not.mpr hc, ↓reduceIte]
+  rw [Multiset.card_eq_zero, Multiset.filter_eq_nil]
+  intro r hr
+  exfalso
+  have hmem := (mem_roots (C_ne_zero.mpr hc)).mp hr
+  rw [Polynomial.IsRoot, eval_C] at hmem
+  exact hc hmem
+
+/-
+## Part V: Budan's Theorem — Main Results
+-/
+
+/-- **Axiom: Budan's Theorem (Upper Bound)**
+
+The number of roots of p in (a, b], counted with multiplicity, is at most
+V_p(a) - V_p(b). The proof proceeds by strong induction on the degree,
+using Rolle's theorem: between consecutive roots of p, the derivative p'
+has a root, and sign changes decrease accordingly at each derivative level. -/
+axiom budan_upper_bound_axiom (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ) (hab : a < b) :
+    rootsInInterval p a b ≤ budanCount p a - budanCount p b
+
+theorem budan_upper_bound (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ) (hab : a < b) :
+    rootsInInterval p a b ≤ budanCount p a - budanCount p b :=
+  budan_upper_bound_axiom p hp a b hab
+
+/-- **Axiom: Budan's Theorem (Parity)**
+
+V_p(a) - V_p(b) and the number of roots in (a,b] differ by an even number.
+This follows from complex roots coming in conjugate pairs: each pair of
+non-real roots contributes 0 or 2 to the variation difference. -/
+axiom budan_parity_axiom (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ) (hab : a < b) :
+    Even (budanCount p a - budanCount p b - rootsInInterval p a b)
+
+theorem budan_parity (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ) (hab : a < b) :
+    Even (budanCount p a - budanCount p b - rootsInInterval p a b) :=
+  budan_parity_axiom p hp a b hab
+
+/-- **Budan's Theorem (Combined)**
+
+The number of roots in (a, b] equals V_p(a) - V_p(b) minus some non-negative
+even number 2k. -/
+theorem budan_theorem (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ) (hab : a < b) :
+    ∃ k : ℕ, rootsInInterval p a b + 2 * k = budanCount p a - budanCount p b := by
+  have hbound := budan_upper_bound p hp a b hab
+  have hparity := budan_parity p hp a b hab
+  obtain ⟨m, hm⟩ := hparity
+  exact ⟨m, by omega⟩
+
+/-
+## Part VI: Root Isolation Certificates
+-/
+
+/-- **Root-free certificate**: If V_p(a) = V_p(b), then p has no roots in (a,b]. -/
+theorem no_roots_of_equal_budanCount (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ) (hab : a < b)
+    (heq : budanCount p a = budanCount p b) :
+    rootsInInterval p a b = 0 := by
+  have := budan_upper_bound p hp a b hab; omega
+
+/-- **Unique root certificate**: If V_p(a) - V_p(b) = 1, then p has exactly
+    one root in (a,b].
+
+    Proof: rootsInInterval ≤ 1 from the bound, and (1 - rootsInInterval) must
+    be even by parity. Since 1 - 0 = 1 is odd, rootsInInterval ≠ 0. -/
+theorem unique_root_of_budanCount_diff_one (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ)
+    (hab : a < b) (hdiff : budanCount p a = budanCount p b + 1) :
+    rootsInInterval p a b = 1 := by
+  have hbound := budan_upper_bound p hp a b hab
+  have hparity := budan_parity p hp a b hab
+  have h1 : budanCount p a - budanCount p b = 1 := by omega
+  rw [h1] at hbound hparity
+  by_contra hne1
+  have h0 : rootsInInterval p a b = 0 := by omega
+  rw [h0] at hparity; simp at hparity
+
+/-- **Two-or-zero certificate**: If V_p(a) - V_p(b) = 2, then p has 0 or 2
+    roots in (a,b]. -/
+theorem zero_or_two_roots_of_budanCount_diff_two (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ)
+    (hab : a < b) (hdiff : budanCount p a = budanCount p b + 2) :
+    rootsInInterval p a b = 0 ∨ rootsInInterval p a b = 2 := by
+  have hbound := budan_upper_bound p hp a b hab
+  have hparity := budan_parity p hp a b hab
+  have h2 : budanCount p a - budanCount p b = 2 := by omega
+  rw [h2] at hbound hparity
+  interval_cases (rootsInInterval p a b) <;> simp_all
+
+/-
+## Part VII: Descartes' Rule as Special Case
+-/
+
+/-- **Axiom: For large x, V_p(x) = 0.**
+
+    For x sufficiently large, each derivative p⁽ᵏ⁾(x) is dominated by its
+    leading term, which has the same sign as the leading coefficient times
+    a positive factorial. So all entries of the Budan-Fourier sequence share
+    the same sign, giving 0 sign changes. -/
+axiom budanCount_large_axiom (p : ℝ[X]) (hp : p ≠ 0) :
+    ∃ M : ℝ, ∀ x, x > M → budanCount p x = 0
+
+theorem budanCount_eventually_zero (p : ℝ[X]) (hp : p ≠ 0) :
+    ∃ M : ℝ, ∀ x, x > M → budanCount p x = 0 :=
+  budanCount_large_axiom p hp
+
+/-- **Descartes' Rule from Budan's Theorem**
+
+Taking a = 0 and b large enough that V_p(b) = 0 and all positive roots
+are in (0, b], Budan gives: #positive_roots ≤ V_p(0). -/
+theorem descartes_from_budan (p : ℝ[X]) (hp : p ≠ 0) :
+    ∃ B : ℝ, 0 < B ∧
+      Multiset.card (p.roots.filter (0 < ·)) ≤ budanCount p 0 := by
+  obtain ⟨M, hM⟩ := budanCount_eventually_zero p hp
+  -- Take B large enough for all positive roots and for V(B) = 0
+  use max 1 (M + 1)
+  refine ⟨by positivity, ?_⟩
+  -- The number of positive roots ≤ rootsInInterval p 0 B' for large B'
+  -- and rootsInInterval p 0 B' ≤ V(0) - V(B') = V(0) - 0 = V(0)
+  sorry
+
+/-
+## Part VIII: Connection to Coefficient Sign Variations
+
+V_p(0) relates to the coefficient sign variation count because
+p⁽ᵏ⁾(0) = k! · aₖ, and k! > 0 preserves signs.
+-/
+
+/-- p⁽ᵏ⁾(0) = k! · (coefficient k of p).
+
+    The k-th derivative at 0 extracts the k-th coefficient up to factorial. -/
+theorem iterDeriv_eval_zero (p : ℝ[X]) (k : ℕ) :
+    (iterDeriv p k).eval 0 = (k.factorial : ℝ) * p.coeff k := by
+  sorry
+
+/-- Since k! > 0, the sign of p⁽ᵏ⁾(0) equals the sign of aₖ.
+    Therefore V_p(0) = signVariations of the coefficient sequence. -/
+theorem budanCount_zero_eq_coeff_sign_changes (p : ℝ[X]) (hp : p ≠ 0) :
+    budanCount p 0 = signChangesInList
+      ((List.range (p.natDegree + 1)).map p.coeff) := by
+  sorry
+
+/-
+## Part IX: Structural Theorems
+-/
+
+/-- V_p(x) is bounded by the degree of p.
+    (A list of n+1 entries has at most n sign changes.) -/
+theorem budanCount_le_natDegree (p : ℝ[X]) (x : ℝ) :
+    budanCount p x ≤ p.natDegree := by
+  sorry
+
+/-- Scaling by a nonzero constant preserves the Budan count.
+    Since (c·p)⁽ᵏ⁾ = c·p⁽ᵏ⁾ and c ≠ 0 preserves all signs. -/
+theorem budanCount_smul (p : ℝ[X]) (c : ℝ) (hc : c ≠ 0) (x : ℝ) :
+    budanCount (C c * p) x = budanCount p x := by
+  sorry
+
+/-
+## Part X: Root Count Additivity
+-/
+
+/-- Root counts are additive when splitting an interval at a point. -/
+theorem rootsInInterval_split (p : ℝ[X]) (hp : p ≠ 0) (a c b : ℝ)
+    (_hac : a < c) (hcb : c < b) :
+    rootsInInterval p a b = rootsInInterval p a c + rootsInInterval p c b := by
+  sorry
+
+/-- Budan count differences are additive: V(a) - V(b) = (V(a) - V(c)) + (V(c) - V(b)).
+    This is just arithmetic: the V(c) terms cancel. -/
+theorem budanCount_diff_split (p : ℝ[X]) (a c b : ℝ)
+    (h1 : budanCount p c ≤ budanCount p a)
+    (h2 : budanCount p b ≤ budanCount p c) :
+    budanCount p a - budanCount p b =
+    (budanCount p a - budanCount p c) + (budanCount p c - budanCount p b) := by
+  omega
+
+/-
+## Part XI: Rolle's Theorem Connection
+
+Rolle's theorem is the key ingredient in the inductive proof of Budan's theorem.
+We prove it here as a bridge between calculus and algebra.
+-/
+
+/-- Between two distinct roots of p, the derivative has a root.
+    This is the polynomial version of Rolle's theorem. -/
+theorem rolle_polynomial (p : ℝ[X]) (a b : ℝ) (hab : a < b)
+    (ha : p.eval a = 0) (hb : p.eval b = 0) :
+    ∃ c, a < c ∧ c < b ∧ (derivative p).eval c = 0 := by
+  have hcont : ContinuousOn (fun x => p.eval x) (Set.Icc a b) :=
+    p.continuous.continuousOn
+  have heq : p.eval a = p.eval b := ha.trans hb.symm
+  obtain ⟨c, ⟨hac, hcb⟩, hderiv⟩ := exists_deriv_eq_zero hab hcont heq
+  exact ⟨c, hac, hcb, by simp only [Polynomial.deriv] at hderiv; exact hderiv⟩
+
+/-- Between n+1 distinct ordered roots of p, the derivative has at least n roots
+    (one between each consecutive pair). -/
+theorem n_roots_derivative_roots (p : ℝ[X]) (n : ℕ)
+    (rootsF : Fin (n + 1) → ℝ)
+    (hstrict : StrictMono rootsF)
+    (heval : ∀ i, p.eval (rootsF i) = 0) :
+    ∀ i : Fin n, ∃ c, rootsF i.castSucc < c ∧ c < rootsF i.succ ∧
+      (derivative p).eval c = 0 := by
+  intro i
+  have hlt : i.castSucc < i.succ := i.castSucc_lt_succ
+  exact rolle_polynomial p _ _ (hstrict hlt) (heval i.castSucc) (heval i.succ)
+
+/-
+## Part XII: Sturm Chains (Framework)
+
+Budan's theorem gives bounds with a parity gap; Sturm's theorem gives
+exact counts by replacing the derivative sequence with a pseudo-remainder
+sequence. We define the framework for future formalization.
+-/
+
+/-- A chain of polynomials for root counting. -/
+structure PolyChain (m : ℕ) where
+  polys : Fin (m + 1) → ℝ[X]
+
+/-- The sign variation count for a polynomial chain at a point x. -/
+noncomputable def chainVariation {m : ℕ} (sc : PolyChain m) (x : ℝ) : ℕ :=
+  signChangesInList ((List.finRange (m + 1)).map (fun k =>
+    (sc.polys k).eval x))
+
+/-- The Budan-Fourier chain: [p, p', p'', ..., p⁽ⁿ⁾]. -/
+noncomputable def budanChain (p : ℝ[X]) : PolyChain p.natDegree where
+  polys k := iterDeriv p k
+
+/-- The Budan chain's variation equals budanCount. -/
+theorem chainVariation_budanChain (p : ℝ[X]) (x : ℝ) :
+    chainVariation (budanChain p) x = budanCount p x := by
+  sorry
+
+end BudanTheorem

--- a/research/problems/descartes-rule-of-signs-oq-02/knowledge.md
+++ b/research/problems/descartes-rule-of-signs-oq-02/knowledge.md
@@ -1,0 +1,45 @@
+# Budan's Theorem (descartes-rule-of-signs-oq-02)
+
+## Problem Summary
+
+Budan's theorem (1807) generalizes Descartes' Rule of Signs to count roots in
+any interval (a,b], using the sign variation count V_p(x) of the derivative
+evaluation sequence [p(x), p'(x), ..., p^(n)(x)].
+
+**Main result**: #roots in (a,b] ≤ V_p(a) - V_p(b), with even parity gap.
+
+## Session 2026-03-24 (Session 1) — Initial Formalization
+
+**Mode**: FRESH
+**Outcome**: progress (substantial infrastructure + key results)
+
+### What I Did
+- Created `proofs/Proofs/DescartesRuleOfSignsOQ02.lean` (418 lines)
+- Defined iterated derivative (`iterDeriv`), Budan-Fourier sequence, sign changes
+- Proved Rolle's theorem for polynomials (fully proved)
+- Proved root isolation certificates (0-root, 1-root, 2-root) from axioms
+- Proved n+1 roots → n derivative roots (fully proved)
+- Set up Descartes recovery framework (from Budan a=0, b→∞)
+- Created gallery entry with full metadata
+
+### Key Findings
+- `iterDeriv_eq_zero` beyond degree follows from `eq_C_of_natDegree_eq_zero`
+- Root isolation certificates use parity elegantly: V(a)-V(b)=1 + parity → exactly 1 root
+- `Fin.castSucc_lt_succ` is a proof term in current Lean, use `i.castSucc_lt_succ`
+- Mathlib has no Budan-Fourier infrastructure at all — everything is original
+
+### Files Modified
+- `proofs/Proofs/DescartesRuleOfSignsOQ02.lean` (new, 418 lines)
+- `src/data/proofs/descartes-rule-of-signs-oq-02/` (new gallery entry)
+- `src/data/research/problems/descartes-rule-of-signs-oq-02.json`
+
+### Stats
+- 28 theorems, 9 definitions, 3 axioms, 7 sorries
+- Key proved: rolle_polynomial, n_roots_derivative_roots, root isolation certificates
+- Key axiomized: budan_upper_bound, budan_parity, budanCount_large
+
+### Next Steps
+- Prove `iterDeriv_eval_zero` (p^(k)(0) = k! * coeff k)
+- Prove `rootsInInterval_split` (interval additivity)
+- Prove `budanCount_le_natDegree` (sign changes ≤ degree)
+- Submit remaining sorries to Aristotle

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/index.ts
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/index.ts
@@ -1,0 +1,37 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import sourceRaw from '../../../../proofs/Proofs/DescartesRuleOfSignsOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const descartesRuleOfSignsOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const descartesRuleOfSignsOQ02Annotations: Annotation[] = []
+
+export const descartesRuleOfSignsOQ02Data: ProofData = {
+  proof: descartesRuleOfSignsOQ02Proof,
+  annotations: descartesRuleOfSignsOQ02Annotations,
+}
+
+export default descartesRuleOfSignsOQ02Data

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "descartes-rule-of-signs-oq-02",
+  "title": "Budan's Theorem: Generalization of Descartes' Rule to Intervals",
+  "slug": "descartes-rule-of-signs-oq-02",
+  "description": "Budan's theorem (1807) generalizes Descartes' Rule of Signs from counting positive roots to counting roots in any half-open interval (a, b]. For a polynomial p of degree n, the Budan-Fourier sequence at x is [p(x), p'(x), ..., p^(n)(x)]. The sign variation count V_p(x) gives: #roots in (a,b] ≤ V_p(a) - V_p(b), with the difference being even. This is the foundation of modern polynomial root isolation algorithms.",
+  "meta": {
+    "author": "François Budan de Boislaurent (1807); Joseph Fourier (~1820)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Budan%27s_theorem",
+    "date": "1807",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ02.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "roots",
+      "real-analysis",
+      "sign-variations",
+      "root-isolation",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 7,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.derivative",
+        "description": "Formal derivative of polynomials",
+        "module": "Mathlib.Algebra.Polynomial.Derivative"
+      },
+      {
+        "theorem": "Polynomial.natDegree_derivative_le",
+        "description": "Degree of derivative ≤ degree - 1",
+        "module": "Mathlib.Algebra.Polynomial.Derivative"
+      },
+      {
+        "theorem": "exists_deriv_eq_zero",
+        "description": "Rolle's theorem: continuous function equal at endpoints has critical point",
+        "module": "Mathlib.Analysis.Calculus.LocalExtr.Rolle"
+      },
+      {
+        "theorem": "Polynomial.continuous",
+        "description": "Polynomial evaluation is continuous",
+        "module": "Mathlib.Topology.Algebra.Polynomial"
+      }
+    ],
+    "originalContributions": [
+      "iterDeriv: k-th iterated derivative definition with commutativity and degree bounds",
+      "budanSequence: Budan-Fourier evaluation sequence [p(x), p'(x), ..., p^(n)(x)]",
+      "signChangesInList: sign change counter for real-valued lists (filters zeros, maps to ±1)",
+      "budanCount: V_p(x) = sign changes in the Budan-Fourier sequence at x",
+      "rootsInInterval: root count in half-open interval (a,b] with multiplicity",
+      "budan_theorem: combined upper bound + parity (∃ k, roots + 2k = V(a) - V(b))",
+      "no_roots_of_equal_budanCount: V(a) = V(b) → no roots in (a,b] (root-free certificate)",
+      "unique_root_of_budanCount_diff_one: V(a) - V(b) = 1 → exactly 1 root (unique root certificate)",
+      "zero_or_two_roots: V(a) - V(b) = 2 → 0 or 2 roots (parity constraint)",
+      "rolle_polynomial: between two roots of p, derivative has a root (fully proved)",
+      "n_roots_derivative_roots: n+1 ordered roots → n derivative roots (fully proved)",
+      "descartes_from_budan: Descartes' rule as special case of Budan (a=0, b→∞)",
+      "iterDeriv_eq_zero: iterated derivative beyond degree is zero (fully proved)",
+      "budanCount_diff_split: V(a)-V(b) = (V(a)-V(c)) + (V(c)-V(b)) additivity"
+    ],
+    "dateAdded": "2026-03-24",
+    "axiomCount": 3,
+    "lineCount": 418,
+    "theoremCount": 28,
+    "defCount": 9,
+    "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "François Budan de Boislaurent published this generalization of Descartes' rule in 1807. Joseph Fourier independently discovered the same result around 1820, leading to the name 'Budan-Fourier theorem.' Where Descartes' rule counts positive roots (the interval (0, ∞)), Budan's theorem counts roots in any interval (a, b] using the derivative sequence evaluated at the endpoints.\n\nThe theorem is fundamental to computational algebra: Vincent's theorem (1834) for root isolation, the VAS algorithm (Vincent-Akritas-Strzeboński), and modern implementations in computer algebra systems all rely on Budan-Fourier counts for efficient polynomial root finding.\n\nSturm's theorem (1829) later provided exact counts by replacing derivatives with pseudo-remainder sequences, eliminating the parity gap. However, Budan's theorem remains practically important because derivative sequences are much cheaper to compute than Sturm chains.",
+    "problemStatement": "**Open Question (descartes-rule-of-signs-oq-02)**: Can Budan's theorem be formalized in Lean 4 as a strict generalization of Descartes' rule?\n\n**The theorem**: For a polynomial p of degree n, let V_p(x) = sign changes in [p(x), p'(x), ..., p^(n)(x)]. Then:\n1. #roots in (a,b] ≤ V_p(a) - V_p(b)\n2. V_p(a) - V_p(b) - #roots is even and non-negative\n\n**Recovery of Descartes**: Taking a = 0 and b → +∞ gives V_p(0) (coefficient sign changes) as the upper bound on positive roots.",
+    "text": "This formalization defines the Budan-Fourier sequence, the sign variation count V_p(x), and states the main theorem with its root isolation applications. The key deep results (upper bound via Rolle induction, parity via conjugate pairs, large-x vanishing) are axiomatized. The root isolation certificates — which are the main algorithmic applications — are fully proved from the axioms.",
+    "proofStrategy": "**Infrastructure (fully proved)**: iterDeriv (iterated derivative), budanSequence, signChangesInList, budanCount, rootsInInterval definitions. iterDeriv commutes with derivative, degree bounds, vanishing beyond degree.\n\n**Root Isolation (fully proved from axioms)**: The practical heart of Budan's theorem — given V_p(a) and V_p(b), we can certify root counts. unique_root_of_budanCount_diff_one uses the parity axiom elegantly: if V(a)-V(b)=1, then roots ≤ 1 (from bound) and 1-roots must be even (from parity), so roots = 1.\n\n**Rolle's Theorem Bridge (fully proved)**: rolle_polynomial and n_roots_derivative_roots provide the calculus foundation that would be used in a full proof of the upper bound axiom.\n\n**Descartes Recovery**: descartes_from_budan shows how Budan's theorem specializes to Descartes' rule at a=0, b→∞, using the budanCount_large axiom.",
+    "keyInsights": [
+      "The Budan-Fourier count V_p(x) = sign changes in [p(x), p'(x), ..., p^(n)(x)] is a non-increasing step function: it can only decrease at roots of p.",
+      "For large x, all derivatives are dominated by their leading terms, which share the same sign. So V_p(x) = 0 for x >> 0, making V_p(0) the total count (recovering Descartes).",
+      "The root isolation certificates are the key algorithmic application: V(a) - V(b) = 0 means root-free, = 1 means unique root. These drive bisection-based root finders.",
+      "Budan's parity gap (roots may be 0 or 2 when V(a)-V(b)=2) is precisely what Sturm's theorem eliminates by using pseudo-remainder sequences instead of derivatives."
+    ],
+    "prerequisites": [
+      "Polynomial algebra",
+      "Real analysis (Rolle's theorem)",
+      "Complex analysis (conjugate pairs, for parity)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "derivative-sequence",
+      "title": "Part I: The Derivative Sequence",
+      "startLine": 1,
+      "endLine": 110,
+      "summary": "iterDeriv definition and properties: commutativity with derivative, degree bounds, vanishing beyond degree. budanSequence: evaluation sequence [p(x), p'(x), ..., p^(n)(x)]."
+    },
+    {
+      "id": "sign-variation",
+      "title": "Part II-III: Sign Variation Count and Budan-Fourier Count",
+      "startLine": 111,
+      "endLine": 170,
+      "summary": "countAdjacentDiffs, signChangesInList (filters zeros, maps to ±1, counts differences). budanCount V_p(x) = signChangesInList(budanSequence). Constants have V = 0."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Part IV-V: Budan's Theorem and Root Intervals",
+      "startLine": 171,
+      "endLine": 260,
+      "summary": "rootsInInterval definition. Three axioms (upper bound, parity, large-x vanishing). budan_theorem combined: ∃ k, roots + 2k = V(a) - V(b)."
+    },
+    {
+      "id": "root-isolation",
+      "title": "Part VI: Root Isolation Certificates",
+      "startLine": 261,
+      "endLine": 290,
+      "summary": "no_roots_of_equal_budanCount (0-root certificate), unique_root_of_budanCount_diff_one (1-root certificate), zero_or_two_roots (2-root certificate). All fully proved from axioms."
+    },
+    {
+      "id": "descartes-recovery",
+      "title": "Part VII-VIII: Descartes Recovery and Coefficient Connection",
+      "startLine": 291,
+      "endLine": 345,
+      "summary": "descartes_from_budan: Descartes' rule as special case (a=0, b→∞). iterDeriv_eval_zero: p^(k)(0) = k! · a_k (Taylor connection). budanCount_zero_eq_coeff_sign_changes."
+    },
+    {
+      "id": "rolle-bridge",
+      "title": "Part IX-XII: Rolle's Theorem, Additivity, and Sturm Framework",
+      "startLine": 346,
+      "endLine": 418,
+      "summary": "rolle_polynomial (fully proved). n_roots_derivative_roots (fully proved). rootsInInterval_split. PolyChain structure for generalization to Sturm chains."
+    }
+  ],
+  "relatedProofs": [
+    "descartes-rule-of-signs",
+    "descartes-rule-of-signs-oq-01",
+    "descartes-rule-of-signs-oq-03"
+  ]
+}

--- a/src/data/research/problems/descartes-rule-of-signs-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02.json
@@ -1,94 +1,119 @@
 {
   "slug": "descartes-rule-of-signs-oq-02",
-  "title": "Budan's theorem (1807) generalizes Descartes's rule: the number of roots in a...",
-  "phase": "NEW",
-  "status": "active",
+  "title": "Budan's Theorem (1807): Generalization of Descartes' Rule to Intervals",
+  "phase": "ACT",
+  "status": "in-progress",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in algebra: Budan's theorem (1807) generalizes Descartes's rule: the number of roots in a....",
-    "whyMatters": []
+    "formal": "For polynomial p of degree n, let V_p(x) = sign changes in [p(x), p'(x), ..., p^(n)(x)]. Then #roots in (a,b] ≤ V_p(a) - V_p(b), and the difference is even.",
+    "plain": "Budan's theorem generalizes Descartes' Rule: the number of roots in any interval (a,b] is bounded by the decrease in sign variation count of the derivative evaluation sequence between the endpoints.",
+    "whyMatters": [
+      "Foundation of modern polynomial root isolation algorithms (Vincent, VAS)",
+      "Strict generalization of Descartes' Rule of Signs",
+      "Computationally cheaper than Sturm chains for practical root finding"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Descartes' upper bound (Mathlib: roots_countP_pos_le_signVariations)",
+      "Rolle's theorem for polynomials (ContinuousOn + exists_deriv_eq_zero)"
+    ],
+    "open": [
+      "Full proof of Budan's upper bound (requires careful Rolle induction)",
+      "Parity result (requires complex conjugate pair analysis)"
+    ],
+    "goal": "Complete formalization of Budan's theorem with root isolation certificates"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-24T00:48:59.817Z",
+    "phase": "ACT",
+    "since": "2026-03-24T20:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Initial formalization: definitions, root isolation certificates, Rolle bridge",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Prove remaining sorries (iterDeriv_eval_zero, rootsInInterval_split, budanCount bounds)",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "ACT: Created DescartesRuleOfSignsOQ02.lean — 418 lines, 28 theorems, 9 definitions, 3 axioms, 7 sorries. Key results: root isolation certificates (0,1,2-root), Rolle polynomial bridge, Descartes recovery framework.",
+    "builtItems": [
+      "iterDeriv: k-th iterated derivative with degree bounds (DescartesRuleOfSignsOQ02.lean:68-108)",
+      "budanSequence: [p(x), p'(x), ..., p^(n)(x)] evaluation list (DescartesRuleOfSignsOQ02.lean:110-117)",
+      "signChangesInList: sign change counter (filter zeros, map ±1, count diffs) (DescartesRuleOfSignsOQ02.lean:123-143)",
+      "budanCount: V_p(x) = sign changes in Budan-Fourier sequence (DescartesRuleOfSignsOQ02.lean:149-152)",
+      "rootsInInterval: root count in (a,b] with multiplicity (DescartesRuleOfSignsOQ02.lean:173-176)",
+      "budan_theorem: combined bound + parity (∃ k, roots + 2k = V(a) - V(b)) (DescartesRuleOfSignsOQ02.lean:217-222)",
+      "no_roots_of_equal_budanCount: root-free certificate (DescartesRuleOfSignsOQ02.lean:230-232)",
+      "unique_root_of_budanCount_diff_one: unique root certificate (DescartesRuleOfSignsOQ02.lean:239-247)",
+      "zero_or_two_roots: parity-constrained certificate (DescartesRuleOfSignsOQ02.lean:252-260)",
+      "rolle_polynomial: between two roots, derivative has root (DescartesRuleOfSignsOQ02.lean:371-378)",
+      "n_roots_derivative_roots: n+1 roots → n derivative roots (DescartesRuleOfSignsOQ02.lean:382-391)"
+    ],
+    "insights": [
+      "Budan-Fourier count V_p(x) generalizes Descartes' coefficient sign changes: V_p(0) = signChanges(coefficients) because p^(k)(0) = k! * a_k and k! > 0 preserves signs",
+      "Root isolation certificates (0-root, 1-root) are elegant applications of the parity axiom — the parity constraint eliminates impossible root counts",
+      "Rolle's theorem for polynomials follows cleanly from Mathlib's exists_deriv_eq_zero + Polynomial.deriv + Polynomial.continuous",
+      "iterDeriv_eq_zero (beyond degree) uses eq_C_of_natDegree_eq_zero to show the n-th derivative is constant, then derivative of constant is 0"
+    ],
+    "mathlibGaps": [
+      "No Budan-Fourier theorem in Mathlib — derivative sequence sign change analysis is absent",
+      "No polynomial root count in intervals (only positive root count via roots.filter)",
+      "Fin.castSucc_lt_succ API is a proof term not a function — need dot notation i.castSucc_lt_succ"
+    ],
+    "nextSteps": [
+      "Prove iterDeriv_eval_zero (p^(k)(0) = k! * coeff k) via induction on derivative coefficients",
+      "Prove rootsInInterval_split (interval additivity) via Multiset.ext",
+      "Prove budanCount_le_natDegree (sign changes ≤ list length - 1)",
+      "Submit remaining sorries to Aristotle for automated proof search"
+    ]
   },
   "tags": [
     "polynomials",
     "algebra",
     "real-analysis",
     "root-counting",
+    "root-isolation",
     "wiedijk-100",
     "seeker-selected"
   ],
   "relatedProofs": [
     "descartes-rule-of-signs",
-    "descartes-rule-of-signs-oq-01"
+    "descartes-rule-of-signs-oq-01",
+    "descartes-rule-of-signs-oq-03"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Budan de Boislaurent (1807): Nouvelle méthode pour la résolution des équations numériques",
+      "Fourier (~1820): Sur l'usage du théorème de Descartes (published posthumously 1831)",
+      "Akritas (1986): There is no 'Uspensky's method'"
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Budan%27s_theorem"
+    ],
+    "mathlib": [
+      "Mathlib.Algebra.Polynomial.Derivative",
+      "Mathlib.Algebra.Polynomial.RuleOfSigns",
+      "Mathlib.Analysis.Calculus.LocalExtr.Rolle"
+    ]
   },
   "started": "2026-03-24T00:48:59.817Z",
-  "lastUpdate": "2026-03-24T00:48:59.817Z",
+  "lastUpdate": "2026-03-24T20:00:00.000Z",
   "significance": 8,
   "tractability": 6,
   "leanFiles": [
     {
-      "path": "Proofs/DescartesRuleOfSigns.lean",
-      "filename": "DescartesRuleOfSigns.lean",
-      "lineCount": 577,
-      "theoremCount": 35,
-      "axiomCount": 8,
-      "defCount": 11,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSigns.lean"
-    },
-    {
-      "path": "Proofs/DescartesRuleOfSignsOQ01.lean",
-      "filename": "DescartesRuleOfSignsOQ01.lean",
-      "lineCount": 1075,
-      "theoremCount": 30,
-      "axiomCount": 1,
-      "defCount": 1,
-      "sorryCount": 1,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
-    },
-    {
-      "path": "Proofs/DescartesRuleOfSignsOQ03.lean",
-      "filename": "DescartesRuleOfSignsOQ03.lean",
-      "lineCount": 441,
-      "theoremCount": 24,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ03.lean"
+      "path": "Proofs/DescartesRuleOfSignsOQ02.lean",
+      "filename": "DescartesRuleOfSignsOQ02.lean",
+      "lineCount": 418,
+      "theoremCount": 28,
+      "axiomCount": 3,
+      "defCount": 9,
+      "sorryCount": 7,
+      "isAristotle": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Formalize **Budan's theorem (1807)**, which generalizes Descartes' Rule of Signs to count roots in any half-open interval (a, b] using the Budan-Fourier derivative evaluation sequence.

**Stats**: 418 lines, 28 theorems, 9 definitions, 3 axioms, 7 sorries

### Key Results (Fully Proved)
- `rolle_polynomial`: Between two roots of p, p' has a root
- `n_roots_derivative_roots`: n+1 ordered roots → n derivative roots
- `no_roots_of_equal_budanCount`: V(a) = V(b) → no roots in (a,b]
- `unique_root_of_budanCount_diff_one`: V(a) - V(b) = 1 → exactly 1 root
- `zero_or_two_roots`: V(a) - V(b) = 2 → 0 or 2 roots (parity)
- `budan_theorem`: ∃ k, roots + 2k = V(a) - V(b) (combined bound + parity)

### Axiomatized (Deep Results)
- `budan_upper_bound_axiom`: Rolle-based induction proof
- `budan_parity_axiom`: Complex conjugate pair analysis
- `budanCount_large_axiom`: Leading coefficient dominance for large x

### New Infrastructure
- `iterDeriv`: k-th iterated derivative with degree bounds
- `budanSequence`: Evaluation sequence [p(x), p'(x), ..., p^(n)(x)]
- `signChangesInList`: Sign change counter for real-valued lists
- `budanCount`: Budan-Fourier sign variation count V_p(x)
- `rootsInInterval`: Root count in (a, b] with multiplicity

## Test plan
- [x] Docker build succeeds
- [x] Gallery metadata created
- [x] Research knowledge documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)