### PR TITLE
Research: erdos-1139 — define almostPrimeGap, eliminate last sorry

### DIFF
--- a/proofs/Proofs/Erdos1139Problem.lean
+++ b/proofs/Proofs/Erdos1139Problem.lean
@@ -79,9 +79,36 @@ theorem eight_not_almostPrime : ¬IsAlmostPrime 8 := by
 def almostPrimesUpTo (N : ℕ) : Finset ℕ :=
   (Finset.range (N + 1)).filter (fun n => checkAlmostPrime n)
 
-/-- The gap between the k-th and (k+1)-th almost-prime. Defined via the
-    enumeration of the almost-prime sequence. -/
-noncomputable def almostPrimeGap : ℕ → ℕ := sorry
+/-- The set of almost-primes is infinite (it contains all primes). -/
+theorem infinite_almostPrimes : (setOf IsAlmostPrime).Infinite :=
+  Nat.infinite_setOf_prime.mono (fun _ hn => prime_isAlmostPrime hn)
+
+noncomputable instance : DecidablePred IsAlmostPrime := Classical.decPred _
+
+/-- The k-th almost-prime (0-indexed): u₀ = 2, u₁ = 3, u₂ = 4, u₃ = 5, ... -/
+noncomputable def nthAlmostPrime (k : ℕ) : ℕ := Nat.nth IsAlmostPrime k
+
+/-- nthAlmostPrime is strictly increasing. -/
+theorem nthAlmostPrime_strictMono : StrictMono nthAlmostPrime :=
+  Nat.nth_strictMono infinite_almostPrimes
+
+/-- Every value of nthAlmostPrime is an almost-prime. -/
+theorem nthAlmostPrime_isAlmostPrime (k : ℕ) : IsAlmostPrime (nthAlmostPrime k) :=
+  Nat.nth_mem_of_infinite infinite_almostPrimes k
+
+/-- Every almost-prime appears in the enumeration. -/
+theorem nthAlmostPrime_surj (m : ℕ) (hm : IsAlmostPrime m) :
+    ∃ k, nthAlmostPrime k = m :=
+  ⟨Nat.count IsAlmostPrime m, Nat.nth_count hm⟩
+
+/-- The gap between consecutive almost-primes:
+    g(k) = u_{k+1} - u_k where u_k is the k-th almost-prime. -/
+noncomputable def almostPrimeGap (k : ℕ) : ℕ :=
+  nthAlmostPrime (k + 1) - nthAlmostPrime k
+
+/-- The gap is always positive (consecutive almost-primes are distinct). -/
+theorem almostPrimeGap_pos (k : ℕ) : 0 < almostPrimeGap k :=
+  Nat.sub_pos_of_lt (nthAlmostPrime_strictMono (by omega))
 
 -- ## Part 4: Structural Results
 

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1139",
   "title": "Erdős Problem #1139: Gaps in the Almost-Prime Sequence",
   "slug": "erdos-1139",
-  "description": "For the sequence of integers with at most 2 prime factors (primes and semiprimes), do the gaps grow faster than log k? Formalization with 11 proved theorems including prime membership, small cases, and counting bounds.",
+  "description": "For the sequence of integers with at most 2 prime factors (primes and semiprimes), do the gaps grow faster than log k? Formalization with 16 proved theorems including enumeration via Nat.nth, gap function, structural properties, and counting bounds.",
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1139",
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1139,
     "erdosUrl": "https://erdosproblems.com/1139",
     "erdosProblemStatus": "open",
@@ -51,7 +51,7 @@
     "dateAdded": "2026-03-24",
     "axiomCount": 2,
     "lineCount": 157,
-    "assumptions": "2 axioms: erdos_1139 (the open conjecture), hardy_ramanujan_asymptotic (density estimate). 3 sorries in supporting lemmas."
+    "assumptions": "2 axioms: erdos_1139 (the open conjecture), hardy_ramanujan_asymptotic (density estimate). 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős #1139 asks about the distribution of gaps in the sequence of integers with at most 2 prime factors (primes and semiprimes). The study of almost-primes dates to Viggo Brun's 1915 sieve work, which first established that the sum of reciprocals of twin primes converges — in contrast to the divergent sum over primes. The counting function for integers with at most $k$ prime factors was studied by Landau (1900) and refined by Ramanujan, Sathe (1953), and Selberg (1954), giving the asymptotic $\\pi_2(N) \\sim cN \\log \\log N / \\log N$. Despite the almost-primes being denser than the primes by a factor of $\\log \\log N$, Erdős conjectured that their gaps still grow faster than $\\log k$. This is surprising: for primes, Cramér's conjecture predicts gaps of order $(\\log p)^2$, and one might expect the denser almost-prime sequence to have comparatively tamer gaps. The problem connects to Maier's 1985 theorem showing irregularities in prime distribution that defeat simple probabilistic models, and to the Jacobsthal function measuring maximal gaps in sieved sequences.",
@@ -91,9 +91,9 @@
       "id": "enumeration",
       "title": "Enumeration and Gap Definition",
       "startLine": 76,
-      "endLine": 84,
-      "summary": "Defines the finite set of almost-primes up to N via Finset.filter and the gap function between consecutive terms (sorry — requires well-ordering).",
-      "mathContext": "$\\pi_2(N) = |\\{n \\leq N : \\Omega(n) \\leq 2\\}|$; $g_k = u_{k+1} - u_k$"
+      "endLine": 111,
+      "summary": "Proves the set of almost-primes is infinite (contains all primes), defines the k-th almost-prime via Mathlib's Nat.nth enumeration, and defines the gap function g(k) = u_{k+1} - u_k. Derives strict monotonicity, membership, surjectivity, and positivity of gaps.",
+      "mathContext": "$\\pi_2(N) = |\\{n \\leq N : \\Omega(n) \\leq 2\\}|$; $u_k = \\text{nth}(\\text{IsAlmostPrime}, k)$; $g_k = u_{k+1} - u_k > 0$"
     },
     {
       "id": "structural-results",
@@ -137,23 +137,23 @@
     }
   ],
   "conclusion": {
-    "summary": "A new formalization of Erdős #1139 with 11 proved theorems establishing the basic theory of almost-primes via Mathlib's factorization API. The formalization covers definitions, small case verification, enumeration, semiprime inclusion, and a structural gap obstruction from divisibility by 8. The main conjecture (lim sup gₖ/log k = ∞) and the Hardy-Ramanujan density asymptotic remain axiomatized.",
+    "summary": "A formalization of Erdős #1139 with 16 proved theorems and 0 sorries. The almost-prime sequence is enumerated via Mathlib's Nat.nth on the infinite set of IsAlmostPrime numbers, with the gap function defined as g(k) = u_{k+1} - u_k. Key structural results include strict monotonicity, membership, surjectivity, gap positivity, semiprime inclusion, and a gap obstruction from divisibility by 8. The main conjecture (lim sup gₖ/log k = ∞) and the Hardy-Ramanujan density asymptotic remain axiomatized.",
     "implications": "Resolution would illuminate the fine structure of almost-prime distribution and complement the extensive body of results on prime gaps (Cramér, Maier, Maynard-Tao). A positive answer would demonstrate that even in sequences much denser than the primes, irregular gaps persist — a phenomenon related to the failure of naive probabilistic models in analytic number theory. The formalization also contributes reusable definitions (bigOmega, IsAlmostPrime) that could support formalizations of other problems involving k-almost primes.",
     "openQuestions": [
       "Does lim sup (u_{k+1} - u_k) / log k = ∞? (the main open conjecture)",
       "What is the correct order of growth for maximal almost-prime gaps — is it closer to (log k)² as in Cramér's conjecture for primes?",
       "Can the cube_gap_obstruction approach be extended to produce explicit gap lower bounds of order log k?",
-      "Is Ω(p·q) = Ω(p) + Ω(q) = 2 provable from Mathlib's factorization_mul without native_decide?"
+      "Can the nthAlmostPrime enumeration be connected to the counting function almostPrimesUpTo to bound gaps?"
     ]
   },
   "leanFile": {
     "imports": ["Mathlib"],
     "opens": [],
     "namespace": "Erdos1139",
-    "lineCount": 157,
+    "lineCount": 192,
     "axiomCount": 2,
-    "theoremCount": 11,
-    "definitionCount": 5
+    "theoremCount": 16,
+    "definitionCount": 7
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-1139.json
+++ b/src/data/research/problems/erdos-1139.json
@@ -29,22 +29,36 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 3 eliminated 2/3 sorries. Proved semiprime_isAlmostPrime (Ω additivity) and cube_gap_obstruction (Ω(8k) ≥ 3). Only almostPrimeGap definition sorry remains.",
+    "progressSummary": "COMPLETE: 0 sorries, 2 axioms (open conjecture + density asymptotic), 16 theorems. Defined almostPrimeGap via Nat.nth on infinite almost-prime set.",
     "builtItems": [
       "Created Erdos1139Problem.lean (157 lines, 11 theorems, 2 axioms, 3 sorries)",
       "Proved prime_isAlmostPrime, four_isAlmostPrime, eight_not_almostPrime",
       "Proved almostPrimes_contain_primes (primes ⊆ almost-primes)",
       "Proved semiprime_isAlmostPrime: Ω(pq) = Ω(p) + Ω(q) = 2 via factorization_mul + sum_add_index",
-      "Proved cube_gap_obstruction: Ω(8k) = Ω(8) + Ω(k) ≥ 3 > 2 via bigOmega additivity"
+      "Proved cube_gap_obstruction: Ω(8k) = Ω(8) + Ω(k) ≥ 3 > 2 via bigOmega additivity",
+      "infinite_almostPrimes: proved set is infinite (superset of primes)",
+      "nthAlmostPrime: defined k-th almost-prime via Nat.nth",
+      "nthAlmostPrime_strictMono: strict monotonicity (proved)",
+      "nthAlmostPrime_isAlmostPrime: membership (proved)",
+      "nthAlmostPrime_surj: surjectivity (proved)",
+      "almostPrimeGap: defined as nthAlmostPrime(k+1) - nthAlmostPrime(k)",
+      "almostPrimeGap_pos: gap is positive (proved)"
     ],
     "insights": [
       "Ω(n) available via n.factorization.sum in Mathlib",
       "Nat.Prime.factorization gives clean single-index sum for primes",
       "native_decide works for small Ω computations (4, 8)",
-      "Nat.primeFactorsList is the modern API for factor lists"
+      "Nat.primeFactorsList is the modern API for factor lists",
+      "Set.Infinite.mono applied to Nat.infinite_setOf_prime gives infinite_almostPrimes",
+      "Nat.nth provides 0-indexed enumeration with strictMono, mem_of_infinite, nth_count API",
+      "Classical.decPred needed since bigOmega is noncomputable (uses Finsupp.sum)"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Connect nthAlmostPrime enumeration to almostPrimesUpTo counting function",
+      "Prove almost-prime gaps are unbounded (weaker than main conjecture but provable)",
+      "Explore connections to Jacobsthal function for gap lower bounds"
+    ],
     "markdown": "# Erdős #1139 - Knowledge Base\n\n## Problem Statement\n\nLet 1&#x2264;u1&lt;u2&lt;&#x22EF;\" role=\"presentation\" style=\"position: relative;\">1≤u1u2⋯1≤u1u2⋯1\\leq u_1 be the sequence of integers with at most 2\" role=\"presentation\" style=\"position: relative;\">222 prime factors. Is it true thatlim&#x2006;supuk+1&#x2212;uklog&#x2061;k=&#x221E;?\" role=\"presentation\" style=\"text-align: center; position: relative;\">limsupuk+1−uklogk=∞?lim supuk+1−uklog⁡k=∞? View the LaTeX source This page was last edited 23 January 2026.\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1138\n- Problem #1140\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #7\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-02-08*\n"
   },
   "tags": [
@@ -66,8 +80,8 @@
   "tractability": 5,
   "leanFiles": [
     {
-      "sorryCount": 1,
-      "theoremCount": 11
+      "sorryCount": 0,
+      "theoremCount": 16
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Define `almostPrimeGap` via Mathlib's `Nat.nth` enumeration, eliminating the last sorry
- Prove `infinite_almostPrimes` (superset of primes via `Set.Infinite.mono`)
- Define `nthAlmostPrime` with full structural API: `strictMono`, `isAlmostPrime`, `surj`
- Prove `almostPrimeGap_pos` (consecutive almost-primes are distinct)

**Before**: 11 theorems, 2 axioms, 1 sorry
**After**: 16 theorems, 2 axioms, 0 sorries

## Test plan

- [x] Docker build passes (`Proofs.Erdos1139Problem`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)