### PR TITLE
Fix: greens-theorem-oq-03 axiomCount 3 → 2

### DIFF
--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -72,7 +72,7 @@
       "green-theorem",
       "research"
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 557,
     "prerequisites": [
       "Green's theorem: line integral to double integral",
@@ -151,7 +151,7 @@
     ]
   },
   "conclusion": {
-    "summary": "OQ-03 is answered YES with substantial proof content: 31 theorems, 3 axioms, 0 sorries. The abstract GreenRegion is replaced by both TypeI and TypeII concrete region structures. The Inner FTC is proved for both region types — the P contribution (TypeI) and Q contribution (TypeII) — which are the two halves of the standard Green's theorem proof. Disk and semicircle are concrete examples with full membership characterization.",
+    "summary": "OQ-03 is answered YES with substantial proof content: 31 theorems, 2 axioms, 0 sorries. The abstract GreenRegion is replaced by both TypeI and TypeII concrete region structures. The Inner FTC is proved for both region types — the P contribution (TypeI) and Q contribution (TypeII) — which are the two halves of the standard Green's theorem proof. Disk and semicircle are concrete examples with full membership characterization.",
     "significance": "Proves the two FTC halves of Green's theorem (the P and Q contributions) completely, with zero axioms. The remaining axiom is only for combining them (requires Fubini for variable limits). Demonstrates Lean 4 can model the Apostol/Rudin textbook proof structure.",
     "implications": "**Theoretical Significance**: Enables formalization of vector calculus on curved-boundary domains.\n\nTypeI+TypeII framework covers rectangles, disks, and convex regions. The inner FTC results are reusable infrastructure for any Green's theorem application.",
     "openQuestions": [


### PR DESCRIPTION
## Fix

Correct axiomCount from 3 to 2 in greens-theorem-oq-03 meta.json. The text `axiom greens_theorem_general` on line 12 of the Lean file is inside a block comment quoting the original placeholder code — not an actual axiom declaration.

## Evidence

**Before**: meta.axiomCount = 3, conclusion says "3 axioms"
**After**: meta.axiomCount = 2, conclusion says "2 axioms" (matches leanFile.axiomCount which was already correct at 2)

The 2 actual axioms are: `greens_theorem_typeI` (line 205) and `disk_area_eq_pi` (line 440).

---
Automated fix by lean-mechanic agent.