### PR TITLE
Enrich: batch fix theoremCount in 19 entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -266,7 +266,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 17,
+    "theoremCount": 16,
     "lemmaCount": 0,
     "defCount": 3
   },

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -90,7 +90,7 @@
     "lineCount": 383,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 23,
     "lemmaCount": 0,
     "defCount": 4,
     "definitionCount": 4

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -64,7 +64,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 1885,
-    "theoremCount": 76,
+    "theoremCount": 28,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
       "Binomial coefficients (Mathlib)",

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -265,7 +265,7 @@
     "namespace": "BallotProblem",
     "lineCount": 251,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 1
   },
   "relatedProofs": [

--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 4,
     "assumptions": "4 axiom declarations: infinitely_many_in_each_class (infinitely many primes per class), erdos_growth_conjecture (p_r^(1/r) tends to infinity), selfridge_bounded_conjecture (p_r^(1/r) is bounded), class_density_subpolynomial (class-r primes have n^o(1) density)",
     "lineCount": 222,
-    "theoremCount": 36,
+    "theoremCount": 31,
     "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -178,7 +178,7 @@
     "namespace": "Erdos1060",
     "lineCount": 268,
     "axiomCount": 2,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 5
   }
 }

--- a/src/data/proofs/erdos-247/meta.json
+++ b/src/data/proofs/erdos-247/meta.json
@@ -135,7 +135,7 @@
     "namespace": "Erdos247",
     "lineCount": 506,
     "axiomCount": 1,
-    "theoremCount": 27,
+    "theoremCount": 22,
     "definitionCount": 7
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -166,7 +166,7 @@
     "namespace": null,
     "lineCount": 182,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 6
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -263,7 +263,7 @@
     "namespace": "",
     "lineCount": 497,
     "axiomCount": 4,
-    "theoremCount": 18,
+    "theoremCount": 13,
     "definitionCount": 10
   }
 }

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -111,7 +111,7 @@
     "lineCount": 137,
     "structureCount": 0,
     "axiomCount": 3,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "lemmaCount": 0,
     "defCount": 2,
     "imports": [

--- a/src/data/proofs/erdos-324/meta.json
+++ b/src/data/proofs/erdos-324/meta.json
@@ -193,7 +193,7 @@
     "namespace": null,
     "lineCount": 139,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 7
   },
   "relatedProofs": [

--- a/src/data/proofs/erdos-361/meta.json
+++ b/src/data/proofs/erdos-361/meta.json
@@ -153,7 +153,7 @@
     "namespace": null,
     "lineCount": 146,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 6,
     "definitionCount": 5
   },
   "references": [

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -114,7 +114,7 @@
     "namespace": null,
     "lineCount": 98,
     "axiomCount": 2,
-    "theoremCount": 1,
+    "theoremCount": 4,
     "definitionCount": 3
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -139,7 +139,7 @@
     "namespace": null,
     "lineCount": 172,
     "axiomCount": 4,
-    "theoremCount": 0,
+    "theoremCount": 2,
     "definitionCount": 7
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-436/meta.json
+++ b/src/data/proofs/erdos-436/meta.json
@@ -168,7 +168,7 @@
     "namespace": "Erdos436",
     "lineCount": 634,
     "axiomCount": 15,
-    "theoremCount": 44,
+    "theoremCount": 43,
     "definitionCount": 8
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-848/meta.json
+++ b/src/data/proofs/erdos-848/meta.json
@@ -151,7 +151,7 @@
     "namespace": "Erdos848",
     "lineCount": 255,
     "axiomCount": 3,
-    "theoremCount": 8,
+    "theoremCount": 13,
     "definitionCount": 4
   },
   "references": [

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -259,7 +259,7 @@
     "lineCount": 467,
     "structureCount": 1,
     "axiomCount": 2,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "lemmaCount": 0,
     "defCount": 12,
     "imports": [

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -196,7 +196,7 @@
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
     "axiomCount": 0,
-    "theoremCount": 1009,
+    "theoremCount": 846,
     "definitionCount": 104
   },
   "references": [

--- a/src/data/proofs/wolstenholme-theorem/meta.json
+++ b/src/data/proofs/wolstenholme-theorem/meta.json
@@ -127,7 +127,7 @@
     "namespace": "WolstenholmeTheorem",
     "lineCount": 220,
     "axiomCount": 2,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 6
   },
   "crossReferences": [


### PR DESCRIPTION
## Data integrity: theorem count fixes

Corrected `leanFile.theoremCount` in 19 entries to match actual `grep -c "^theorem\|^lemma"` counts from the Lean source files.

| Entry | Old | New | Diff |
|-------|-----|-----|------|
| navier-stokes-oq-02 | 1009 | 846 | -163 |
| ballot-problem-oq-03-oq-02 | 76 | 28 | -48 |
| erdos-28 | 18 | 13 | -5 |
| erdos-1055 | 36 | 31 | -5 |
| erdos-247 | 27 | 22 | -5 |
| erdos-848 | 8 | 13 | +5 |
| angle-trisection | 18 | 23 | +5 |
| erdos-389 | 1 | 4 | +3 |
| erdos-430 | 0 | 2 | +2 |
| erdos-361 | 8 | 6 | -2 |
| erdos-1060 | 10 | 12 | +2 |
| erdos-436 | 44 | 43 | -1 |
| erdos-321 | 5 | 6 | +1 |
| erdos-273 | 8 | 9 | +1 |
| erdos-324 | 7 | 6 | -1 |
| ballot-problem | 8 | 7 | -1 |
| wolstenholme-theorem | 16 | 17 | +1 |
| amgm-inequality-oq-02 | 17 | 16 | -1 |
| godel-incompleteness | 14 | 15 | +1 |