### PR TITLE
Audit: fix inverse-galois axiomCount 2→3, clean opens field

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -302,7 +302,7 @@
       "lastAudited": "2026-03-24T09:38:41Z",
       "result": "clean",
       "issues": [
-        "Stale axiom annotation: section 'countable-ordinals' summary says 'States the axiom α < ω₁ ↔ IsCountableOrdinal α' but lt_omega1_iff_countable is a fully proved theorem, not an axiom"
+        "Stale axiom annotation: section 'countable-ordinals' summary says 'States the axiom \u03b1 < \u03c9\u2081 \u2194 IsCountableOrdinal \u03b1' but lt_omega1_iff_countable is a fully proved theorem, not an axiom"
       ]
     },
     "cantor-diagonalization-oq-02-oq-01": {
@@ -322,7 +322,7 @@
       "lastAudited": "2026-03-24T20:00:00Z",
       "result": "issues-fixed",
       "issues": [
-        "Uses /-! docstring sections (6 occurrences) which cause Aristotle parsing errors — fix PR #6341 pending"
+        "Uses /-! docstring sections (6 occurrences) which cause Aristotle parsing errors \u2014 fix PR #6341 pending"
       ]
     },
     "cauchy-schwarz-integral-oq-01-oq-01": {

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -27,7 +27,7 @@
     ],
     "badge": "axiom",
     "sorries": 2,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Cyclotomic fields and Kronecker-Weber theorem",
@@ -270,20 +270,7 @@
       "Proofs.NthRootIrrationalOQ01"
     ],
     "opens": [
-      "Polynomial",
-      "problem",
-      "—",
-      "we",
-      "assert",
-      "its",
-      "truth",
-      "without",
-      "proof,",
-      "because",
-      "no",
-      "proof",
-      "is",
-      "known."
+      "Polynomial"
     ],
     "namespace": "InverseGaloisProblem",
     "lineCount": 1881,


### PR DESCRIPTION
## Summary

- **inverse-galois**: `axiomCount` 2→3 (missing `three_dvd_gal_card` from InverseGaloisA5.lean)
- Fixed `leanFile.opens` field which contained garbage tokens from comment parsing (`"problem", "—", "we", "assert"...`)

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Confirm 3 axioms total: `grep -rn "^axiom " proofs/Proofs/InverseGalois*.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)