### PR TITLE
Research: erdos-321 — prove pair_hasDistinctReciprocalSums, eliminate last sorry

### DIFF
--- a/proofs/Proofs/Erdos321Problem.lean
+++ b/proofs/Proofs/Erdos321Problem.lean
@@ -82,13 +82,46 @@ theorem singleton_hasDistinctReciprocalSums (n : ℕ) (hn : n ≥ 1) :
   · simp [Finset.sum_singleton]; positivity
   · exact absurd rfl hne
 
+/-- Subsets of a two-element set {a, b} are: ∅, {a}, {b}, {a, b}. -/
+private lemma subset_pair_cases {a b : ℕ} (_hab : a ≠ b) {S : Finset ℕ}
+    (hS : S ⊆ {a, b}) : S = ∅ ∨ S = {a} ∨ S = {b} ∨ S = {a, b} := by
+  have hmem : ∀ x ∈ S, x = a ∨ x = b := fun x hx =>
+    (Finset.mem_insert.mp (hS hx)).imp_right Finset.mem_singleton.mp
+  by_cases ha : a ∈ S <;> by_cases hb : b ∈ S
+  · right; right; right
+    exact Finset.Subset.antisymm hS (fun x hx =>
+      ((Finset.mem_insert.mp hx).imp_right Finset.mem_singleton.mp).elim
+        (fun h => h ▸ ha) (fun h => h ▸ hb))
+  · right; left
+    exact Finset.Subset.antisymm
+      (fun x hx => Finset.mem_singleton.mpr
+        ((hmem x hx).resolve_right (fun h => hb (h ▸ hx))))
+      (Finset.singleton_subset_iff.mpr ha)
+  · right; right; left
+    exact Finset.Subset.antisymm
+      (fun x hx => Finset.mem_singleton.mpr
+        ((hmem x hx).resolve_left (fun h => ha (h ▸ hx))))
+      (Finset.singleton_subset_iff.mpr hb)
+  · left
+    exact Finset.eq_empty_of_forall_notMem fun x hx =>
+      (hmem x hx).elim (fun h => ha (h ▸ hx)) (fun h => hb (h ▸ hx))
+
 /-- Pair {m, n} with m < n has distinct reciprocal sums.
-    Since m < n and both ≥ 1, we have 1/m ≠ 1/n, so the 4 subsets
-    ∅, {m}, {n}, {m,n} all have distinct sums 0, 1/m, 1/n, 1/m+1/n. -/
+    Since m < n and both ≥ 1, we have 0 < 1/n < 1/m < 1/m + 1/n,
+    so all 4 subset sums are distinct. -/
 theorem pair_hasDistinctReciprocalSums (m n : ℕ) (hm : m ≥ 1) (hn : n ≥ 1)
     (hmn : m < n) : HasDistinctReciprocalSums {m, n} := by
-  intro S T hS hT hne
-  sorry
+  have hmn_ne : m ≠ n := Nat.ne_of_lt hmn
+  have hm_pos : (0 : ℚ) < 1 / (m : ℚ) := by positivity
+  have hn_pos : (0 : ℚ) < 1 / (n : ℚ) := by positivity
+  have hmn_lt : (1 : ℚ) / n < 1 / m :=
+    div_lt_div_of_pos_left one_pos (by positivity : (0 : ℚ) < m)
+      (by exact_mod_cast hmn : (m : ℚ) < n)
+  intro S T hS hT hne heq
+  rcases subset_pair_cases hmn_ne hS with rfl | rfl | rfl | rfl <;>
+  rcases subset_pair_cases hmn_ne hT with rfl | rfl | rfl | rfl <;>
+  simp only [Finset.sum_empty, Finset.sum_singleton, Finset.sum_pair hmn_ne] at heq <;>
+  first | exact hne rfl | linarith
 
 /- ## R(N) Definition -/
 

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -14,7 +14,7 @@
       "egyptian-fractions",
       "open"
     ],
-    "sorries": 1,
+    "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/321",
     "erdosUrl": "https://erdosproblems.com/321",
     "axiomCount": 3,
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos321Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 137
+    "lineCount": 170
   },
   "sections": [
     {
@@ -133,7 +133,7 @@
     "https://erdosproblems.com/321"
   ],
   "leanFile": {
-    "lineCount": 137,
+    "lineCount": 170,
     "structureCount": 0,
     "axiomCount": 3,
     "theoremCount": 5,

--- a/src/data/research/problems/erdos-321.json
+++ b/src/data/research/problems/erdos-321.json
@@ -29,19 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved erdos_321_asymptotics (tautological axiom). Axioms 4→3.",
+    "progressSummary": "COMPLETE: 0 sorries, 3 axioms (published bounds), 6 theorems. Proved pair_hasDistinctReciprocalSums via exhaustive 4×4 case analysis on subsets of {m,n}.",
     "builtItems": [
-      "erdos_321_asymptotics: proved by taking f = maxDistinctReciprocal"
+      "erdos_321_asymptotics: proved by taking f = maxDistinctReciprocal",
+      "subset_pair_cases: helper classifying S ⊆ {a,b} into 4 cases",
+      "pair_hasDistinctReciprocalSums: proved (4 subset sums are strictly ordered: 0 < 1/n < 1/m < 1/m+1/n)"
     ],
     "insights": [
       "erdos_321_asymptotics was tautological — take f = the function itself",
       "pair_hasDistinctReciprocalSums has a sorry — needs Finset case analysis on subsets of {m,n}",
-      "main_term_n_over_log_n could potentially be derived from bleicher_erdos_lower + bleicher_erdos_upper"
+      "main_term_n_over_log_n could potentially be derived from bleicher_erdos_lower + bleicher_erdos_upper",
+      "For {m,n} with m < n: 0 < 1/n < 1/m < 1/m + 1/n gives all 4 subset sums distinct",
+      "Finset.sum_pair hmn_ne + linarith handles all 12 non-trivial cross-cases",
+      "div_lt_div_of_pos_left is the correct Mathlib v4.26.0 name for reciprocal ordering"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Complete pair_hasDistinctReciprocalSums sorry (enumerate 4 subsets of {m,n})",
-      "Derive main_term_n_over_log_n from the two Bleicher-Erdős bounds"
+      "Prove triple case {m,n,k} has distinct reciprocal sums (more challenging: 8 subsets)",
+      "Connect pair/triple results to lower bounds on R(N)"
     ],
     "markdown": "# Erdős #321 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nWhat is the size of the largest $A\\subseteq \\{1,\\ldots,N\\}$ such that all sums $\\sum_{n\\in S}\\frac{1}{n}$ are distinct for $S\\subseteq A$?\n\n\n\nLet $R(N)$ be the maximal such size. Results of Bleicher and Erd\\H{o}s from \\cite{BlEr75} and \\cite{BlEr76b} imply that\\[\\frac{N}{\\log N}\\prod_{i=3}^k\\log_iN\\leq R(N)\\leq \\frac{1}{\\log 2}\\log_r N\\left(\\frac{N}{\\log N} \\prod_{i=3}^r \\log_iN\\right),\\]valid for any $k\\geq 4$ with $\\log_kN\\geq k$ and any $r\\geq 1$ with $\\log_{2r}N\\geq 1$. (In these bounds $\\log_in$ denotes the $i$-fold iterated logarithm.)\n\nSee also [320].\n\n\n\n\n\n\nReferences\n\n\n[BlEr75] Bleicher, M. N. and Erd\\H{o}s, P., The number of distinct subsums of $\\sum \\sb{1}\\spN\\,1/i$. Math. Comp. (1975), 29-42.\n\n[BlEr76b] Bleicher, Michael N. and Erd\\H{o}s, Paul, Denominators of Egyptian fractions. II. Illinois J. Math. (1976), 598-613.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #320\n- Problem #322\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- BlEr75\n- BlEr76b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },


### PR DESCRIPTION
## Summary

- Prove `pair_hasDistinctReciprocalSums`: {m, n} with m < n has distinct reciprocal subset sums
- Add `subset_pair_cases` helper: classifies S ⊆ {a, b} into ∅, {a}, {b}, {a, b}
- The 4 subset sums 0, 1/n, 1/m, 1/m+1/n are strictly ordered, so 4×4 case analysis + `linarith` closes all cases

**Before**: 6 theorems, 3 axioms, 1 sorry
**After**: 6 theorems, 3 axioms, 0 sorries

## Test plan

- [x] Docker build passes (`Proofs.Erdos321Problem`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)