### PR TITLE
Audit: fix theorem/def counts in ballot-problem-oq-01, amgm-inequality-oq-02

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -266,7 +266,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 16,
+    "theoremCount": 25,
     "lemmaCount": 0,
     "defCount": 3
   },

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -282,7 +282,7 @@
     "namespace": "GeneralizedBallot",
     "lineCount": 789,
     "axiomCount": 0,
-    "theoremCount": 67,
-    "definitionCount": 8
+    "theoremCount": 57,
+    "definitionCount": 9
   }
 }


### PR DESCRIPTION
## Summary

- **ballot-problem-oq-01**: theoremCount 67→57, definitionCount 8→9
- **amgm-inequality-oq-02**: theoremCount 16→25 (prior batch fix in #6346 used incorrect count)

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)