### PR TITLE
Audit: fix sorry/axiom counts in descartes-oq-02, erdos-668

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9199,5 +9199,25 @@
       "result": "clean",
       "issues": []
     }
+  },
+  "descartes-rule-of-signs-oq-02": {
+    "lastAudit": "2026-03-24T21:47:21Z",
+    "auditCount": 1,
+    "result": "issues-fixed",
+    "issues": [
+      "sorries 7->5 (code evolved)",
+      "lineCount 418->491",
+      "theoremCount 28->33"
+    ]
+  },
+  "erdos-668": {
+    "lastAudit": "2026-03-24T21:47:21Z",
+    "auditCount": 1,
+    "result": "issues-fixed",
+    "issues": [
+      "sorries 1->0 (sorry eliminated)",
+      "axiomCount 7->8",
+      "lineCount 216->228"
+    ]
   }
 }

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 5,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.derivative",
@@ -60,8 +60,8 @@
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 3,
-    "lineCount": 418,
-    "theoremCount": 28,
+    "lineCount": 491,
+    "theoremCount": 33,
     "defCount": 9,
     "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 668,
     "erdosUrl": "https://erdosproblems.com/668",
     "erdosProblemStatus": "open",
@@ -60,9 +60,9 @@
         "relationship": "Erdős Problem #90 (maximum unit distances u(n)) is the prerequisite problem — #668 studies uniqueness of configurations achieving u(n)"
       }
     ],
-    "axiomCount": 7,
-    "lineCount": 216,
-    "assumptions": "7 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "axiomCount": 8,
+    "lineCount": 228,
+    "assumptions": "8 axiom declarations, 0 sorries. Axioms: f_four, four_config_unique, u_four, computational_evidence, extremalConfigs_nonempty, u_lower_bound, u_upper_bound, extremalQuotient_finite."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #668**\n\nThis problem explores the structure of extremal configurations for the classical unit distance problem in the plane.\n\n**Background:**\nThe unit distance problem (Erdos Problem #90) asks: what is the maximum number u(n) of unit distances among n points in the plane? Problem #668 goes further, asking about the UNIQUENESS of configurations achieving this maximum.\n\n**Historical Development:**\n- The unit distance problem was posed by Erdos in 1946\n- The case n=4 is fully understood: exactly one configuration (the double triangle)\n- Computational work by Engel, Hammond-Lee, Su, Varga, Zsamboki [EHSVZ25] and Alexeev, Mixon, Parshall [AMP25] suggests uniqueness for 5 <= n <= 21\n\n**Status:** OPEN",


### PR DESCRIPTION
## Summary

- **descartes-rule-of-signs-oq-02**: sorries 7→5 (researcher proved 2 since initial creation), lineCount 418→491, theoremCount 28→33
- **erdos-668**: sorries 1→0 (sorry eliminated), axiomCount 7→8 (missing `extremalQuotient_finite`), lineCount 216→228

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)