### PR TITLE
Enrich erdos-503: add section mathContext, references

### DIFF
--- a/src/data/proofs/erdos-503/meta.json
+++ b/src/data/proofs/erdos-503/meta.json
@@ -69,7 +69,9 @@
       "**Neither bound tight for $n = 3$:** Since $f(3) = 8$ while the bounds give $[7, 10]$, neither Blokhuis nor Weisenberg is tight, suggesting the true answer may require dimension-specific constructions"
     ],
     "prerequisites": [
-      "Combinatorics and number theory"
+      "Discrete geometry (distance sets, isosceles configurations)",
+      "Combinatorics (binomial coefficients, extremal counting)",
+      "Linear algebra (dimension arguments for polynomial spaces)"
     ]
   },
   "sections": [
@@ -78,49 +80,56 @@
       "title": "Imports and Namespace",
       "startLine": 26,
       "endLine": 32,
-      "summary": "Imports $\\texttt{Nat.Choose.Basic}$ for binomial coefficients $\\binom{n}{k}$, $\\texttt{Finset.Basic}$ for finite point sets, and $\\texttt{Tactic}$ for $\\texttt{norm\\_num}$. Opens the $\\texttt{Erdos503}$ namespace."
+      "summary": "Imports $\\texttt{Nat.Choose.Basic}$ for binomial coefficients $\\binom{n}{k}$, $\\texttt{Finset.Basic}$ for finite point sets, and $\\texttt{Tactic}$ for $\\texttt{norm\\_num}$. Opens the $\\texttt{Erdos503}$ namespace.",
+      "mathContext": "Uses `Nat.choose` for $\\binom{n}{k}$, `Finset` for finite subsets of metric spaces, and `norm_num` for verifying concrete binomial coefficient computations."
     },
     {
       "id": "isosceles-sets",
       "title": "Isosceles Set Definitions",
       "startLine": 33,
       "endLine": 49,
-      "summary": "Defines $\\texttt{IsIsoscelesSet}(A)$: every triple $\\{x,y,z\\} \\subset A$ satisfies $d(x,y) = d(y,z) \\lor d(y,z) = d(x,z) \\lor d(x,y) = d(x,z)$. Axiomatizes $\\texttt{maxIsoscelesSize}(n) = f(n)$."
+      "summary": "Defines $\\texttt{IsIsoscelesSet}(A)$: every triple $\\{x,y,z\\} \\subset A$ satisfies $d(x,y) = d(y,z) \\lor d(y,z) = d(x,z) \\lor d(x,y) = d(x,z)$. Axiomatizes $\\texttt{maxIsoscelesSize}(n) = f(n)$.",
+      "mathContext": "$A$ is an **isosceles set** if $\\forall x,y,z \\in A$, the multiset $\\{d(x,y), d(y,z), d(x,z)\\}$ has a repeated element. Equivalently, every triangle formed by points in $A$ is isosceles. $f(n) = \\max\\{|A| : A \\subseteq \\mathbb{R}^n, A \\text{ isosceles}\\}$."
     },
     {
       "id": "small-dimensions",
       "title": "Exact Results: $f(2) = 6$, $f(3) = 8$",
       "startLine": 50,
       "endLine": 64,
-      "summary": "Axiomatizes Kelly's $f(2) = 6$ [1947] and Croft's $f(3) = 8$ [1962]—the only known exact values of the isosceles extremal function."
+      "summary": "Axiomatizes Kelly's $f(2) = 6$ [1947] and Croft's $f(3) = 8$ [1962]—the only known exact values of the isosceles extremal function.",
+      "mathContext": "$f(2) = 6$: the regular hexagon is the unique extremal configuration in $\\mathbb{R}^2$. $f(3) = 8$: Croft's 3D construction uses a carefully chosen 8-point set. Both are axiomatized; the proofs require case analysis and geometric arguments not in Mathlib."
     },
     {
       "id": "upper-bound",
       "title": "Blokhuis Upper Bound $\\binom{n+2}{2}$",
       "startLine": 65,
       "endLine": 73,
-      "summary": "Axiomatizes Blokhuis's 1984 result: $f(n) \\leq \\binom{n+2}{2} = \\frac{(n+2)(n+1)}{2}$ via a linear algebra dimension argument on distance polynomials."
+      "summary": "Axiomatizes Blokhuis's 1984 result: $f(n) \\leq \\binom{n+2}{2} = \\frac{(n+2)(n+1)}{2}$ via a linear algebra dimension argument on distance polynomials.",
+      "mathContext": "Blokhuis (1984): $f(n) \\leq \\binom{n+2}{2}$. The proof: for each pair $\\{x_i, x_j\\}$, the isosceles condition $d(x_i, x_k) = d(x_j, x_k)$ defines a hyperplane in $\\mathbb{R}^n$. The $\\binom{|A|}{2}$ resulting constraints live in a space of dimension $\\binom{n+2}{2}$ (squared-distance polynomials)."
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds: Alweiss and Weisenberg",
       "startLine": 74,
       "endLine": 89,
-      "summary": "Axiomatizes $f(n) \\geq \\binom{n+1}{2}$ (Alweiss, via $\\{e_i + e_j\\}$ vectors) and $f(n) \\geq \\binom{n+1}{2} + 1$ (Weisenberg, adding one more point)."
+      "summary": "Axiomatizes $f(n) \\geq \\binom{n+1}{2}$ (Alweiss, via $\\{e_i + e_j\\}$ vectors) and $f(n) \\geq \\binom{n+1}{2} + 1$ (Weisenberg, adding one more point).",
+      "mathContext": "Alweiss: $A = \\{e_i + e_j : 1 \\leq i < j \\leq n+1\\} \\subset \\mathbb{R}^{n+1}$, $|A| = \\binom{n+1}{2}$. For any triple, $\\|e_i+e_j - e_k-e_l\\|^2 \\in \\{2,4\\}$, so at least two distances coincide. Weisenberg adds one more point for $\\binom{n+1}{2}+1$."
     },
     {
       "id": "combined-bounds",
       "title": "Combined Bounds and Consistency",
       "startLine": 90,
       "endLine": 114,
-      "summary": "Proves $\\binom{n+1}{2}+1 \\leq f(n) \\leq \\binom{n+2}{2}$ from the axioms. Verifies consistency for $n = 2$ ($4 \\leq 6 \\leq 6$) and $n = 3$ ($7 \\leq 8 \\leq 10$) via $\\texttt{norm\\_num}$."
+      "summary": "Proves $\\binom{n+1}{2}+1 \\leq f(n) \\leq \\binom{n+2}{2}$ from the axioms. Verifies consistency for $n = 2$ ($4 \\leq 6 \\leq 6$) and $n = 3$ ($7 \\leq 8 \\leq 10$) via $\\texttt{norm\\_num}$.",
+      "mathContext": "Combined: $\\binom{n+1}{2}+1 \\leq f(n) \\leq \\binom{n+2}{2}$. Gap $= \\binom{n+2}{2} - \\binom{n+1}{2} - 1 = n$. Consistency: $f(2) = 6 \\in [4,6]$; $f(3) = 8 \\in [7,10]$. Both verified by `norm_num` on concrete binomial values."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
       "startLine": 115,
       "endLine": 127,
-      "summary": "Proves $\\texttt{erdos\\_503\\_summary} : f(2) = 6 \\wedge f(3) = 8$ from Kelly and Croft axioms. The problem remains open for $n \\geq 4$."
+      "summary": "Proves $\\texttt{erdos\\_503\\_summary} : f(2) = 6 \\wedge f(3) = 8$ from Kelly and Croft axioms. The problem remains open for $n \\geq 4$.",
+      "mathContext": "$f(2) = 6 \\wedge f(3) = 8$: the complete known data. For $n \\geq 4$, only bounds are known: $11 \\leq f(4) \\leq 15$, $16 \\leq f(5) \\leq 21$, etc. The gap grows as $n$."
     }
   ],
   "conclusion": {
@@ -163,6 +172,22 @@
       "targetId": "erdos-662",
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: combinatorial-geometry, distances, open"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Blokhuis, Aart",
+      "title": "Few-distance sets",
+      "year": "1984",
+      "venue": "CWI Tract 7, Centrum voor Wiskunde en Informatica, Amsterdam",
+      "note": "Proved the upper bound f(n) ≤ C(n+2,2) using the linear algebra method on squared-distance polynomials"
+    },
+    {
+      "authors": "Croft, Hallard T.",
+      "title": "9-point and 7-point configurations in 3-space",
+      "year": "1962",
+      "venue": "Proceedings of the London Mathematical Society 12, 400–424",
+      "note": "Proved f(3) = 8 by constructing an 8-point isosceles set and showing no 9-point set exists"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for erdos-503 (Maximum Isosceles Sets).

- Added mathematical context with LaTeX formulas to all 7 sections
- Added 2 references: Blokhuis 1984, Croft 1962
- Deepened prerequisites from 1 generic item to 3 specific topics