### PR TITLE
Update descartes-rule-of-signs-oq-02 metadata (7→4 sorries)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.derivative",
@@ -56,13 +56,20 @@
       "n_roots_derivative_roots: n+1 ordered roots → n derivative roots (fully proved)",
       "descartes_from_budan: Descartes' rule as special case of Budan (a=0, b→∞)",
       "iterDeriv_eq_zero: iterated derivative beyond degree is zero (fully proved)",
+      "iterDeriv_coeff: general coefficient formula (p^(k)).coeff j = descFactorial(j+k,k) * p.coeff(j+k) (fully proved)",
+      "iterDeriv_eval_zero: p^(k)(0) = k! * coeff k (fully proved via iterDeriv_coeff)",
+      "poly_eval_at_zero: polynomial evaluation at 0 equals constant coefficient (fully proved)",
+      "budanCount_le_natDegree: V_p(x) ≤ deg(p) structural bound (fully proved)",
+      "rootsInInterval_split: root count additivity over interval splits (fully proved)",
+      "iterDeriv_C_mul: scalar multiplication commutes with iterated derivative (fully proved)",
+      "countAdjacentDiffs_le: sign changes bounded by list length - 1 (fully proved)",
       "budanCount_diff_split: V(a)-V(b) = (V(a)-V(c)) + (V(c)-V(b)) additivity"
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 3,
-    "lineCount": 491,
-    "theoremCount": 33,
-    "defCount": 9,
+    "lineCount": 502,
+    "theoremCount": 45,
+    "defCount": 8,
     "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02.json
@@ -29,17 +29,17 @@
     "phase": "ACT",
     "since": "2026-03-24T20:00:00Z",
     "iteration": 2,
-    "focus": "Proving infrastructure sorries: iterDeriv_eval_zero, budanCount_le_natDegree, rootsInInterval_split",
+    "focus": "Proved key infrastructure: iterDeriv_eval_zero, budanCount_le_natDegree, rootsInInterval_split (7→4 sorries)",
     "blockers": [],
-    "nextAction": "Prove 4 remaining sorries: descartes_from_budan, budanCount_smul, budanCount_zero_eq_coeff_sign_changes, chainVariation_budanChain",
+    "nextAction": "Prove 4 remaining sorries: descartes_from_budan (needs root containment), budanCount_zero_eq_coeff_sign_changes (needs positive scaling preserves signs), budanCount_smul (needs sign change preservation under scaling), chainVariation_budanChain (finRange↔range conversion)",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: DescartesRuleOfSignsOQ02.lean — 502 lines, 45 theorems, 9 definitions, 3 axioms, 4 sorries (down from 7). Session 2 proved: iterDeriv_eval_zero, budanCount_le_natDegree, rootsInInterval_split, plus infrastructure (iterDeriv_coeff, countAdjacentDiffs_le, poly_eval_at_zero, iterDeriv_C_mul, iterDeriv_eq_iterate).",
+    "progressSummary": "ACT: 502 lines, 45 theorems, 8 definitions, 3 axioms, 4 sorries (was 7). Session 2 proved 3 key sorries + 6 infrastructure lemmas. Key: iterDeriv_coeff (general coefficient formula via descFactorial induction), iterDeriv_eval_zero (Taylor coefficient extraction), budanCount_le_natDegree (structural bound via countAdjacentDiffs_le).",
     "builtItems": [
       "iterDeriv: k-th iterated derivative with degree bounds (DescartesRuleOfSignsOQ02.lean:68-108)",
       "budanSequence: [p(x), p'(x), ..., p^(n)(x)] evaluation list (DescartesRuleOfSignsOQ02.lean:110-117)",


### PR DESCRIPTION
## Summary
- Update gallery meta.json: sorries 5→4, lineCount 491→502, theoremCount 33→45
- Add 7 new original contributions to meta.json
- Update problem JSON currentState and progressSummary

Follow-up to #6358 which proved the actual Lean sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)