### PR TITLE
Audit: fix descartes-rule-of-signs-oq-02 metadata

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -68,8 +68,8 @@
     "dateAdded": "2026-03-24",
     "axiomCount": 3,
     "lineCount": 502,
-    "theoremCount": 45,
-    "defCount": 8,
+    "theoremCount": 36,
+    "defCount": 9,
     "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -129,21 +129,21 @@
       "id": "descartes-recovery",
       "title": "Part VII-VIII: Descartes Recovery and Coefficient Connection",
       "startLine": 274,
-      "endLine": 341,
+      "endLine": 393,
       "summary": "`descartes_from_budan`: Descartes' rule as special case ($a=0$, $b \\to \\infty$). `iterDeriv_eval_zero`: $p^{(k)}(0) = k! \\cdot a_k$. `budanCount_zero_eq_coeff_sign_changes`.",
       "mathContext": "The chain: $V_p(0) = V(p(0), p'(0), \\ldots, p^{(n)}(0)) = V(a_0, 1!a_1, 2!a_2, \\ldots, n!a_n)$. Since $k! > 0$, this equals $V(a_0, a_1, \\ldots, a_n)$ — exactly Descartes' coefficient sign variation count. Taking $b \\to \\infty$ with $V_p(b) = 0$ gives Descartes' rule: $\\#\\{\\text{positive roots}\\} \\leq V(a_0, \\ldots, a_n)$."
     },
     {
       "id": "rolle-bridge",
       "title": "Part IX-XII: Rolle's Theorem, Additivity, and Sturm Framework",
-      "startLine": 327,
-      "endLine": 418,
+      "startLine": 395,
+      "endLine": 502,
       "summary": "`rolle_polynomial` (fully proved via Mathlib's Rolle). `n_roots_derivative_roots` ($n+1$ roots of $p$ give $n$ roots of $p'$, fully proved). `rootsInInterval_split` (interval additivity). `PolyChain` structure for generalization to Sturm chains.",
       "mathContext": "Rolle's theorem gives the calculus foundation: between consecutive roots of $p$, $p'$ has a zero. By induction, $n+1$ roots of $p$ produce $\\geq n$ roots of $p'$, $\\geq n-1$ of $p''$, etc. This 'Rolle ladder' is the inductive engine for the `budan_upper_bound` axiom. The `PolyChain` abstraction prepares for Sturm's theorem, where pseudo-remainder chains replace derivative chains for exact (not just bounded) root counts."
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes Budan's theorem (1807) as a strict generalization of Descartes' Rule of Signs, extending root counting from positive reals to arbitrary half-open intervals. The 418-line development provides 9 original definitions, 28 theorems, and 3 carefully scoped axioms. The root isolation certificates — the main algorithmic application — are fully proved, while the deeper analytical results (Rolle induction, conjugate pair parity, asymptotic leading term dominance) are axiomatized with detailed proof sketches.",
+    "summary": "This formalization establishes Budan's theorem (1807) as a strict generalization of Descartes' Rule of Signs, extending root counting from positive reals to arbitrary half-open intervals. The 502-line development provides 9 original definitions, 36 theorems, and 3 carefully scoped axioms. The root isolation certificates — the main algorithmic application — are fully proved, while the deeper analytical results (Rolle induction, conjugate pair parity, asymptotic leading term dominance) are axiomatized with detailed proof sketches.",
     "implications": "**Computational algebra**: Budan-Fourier counts are the foundation of modern polynomial root isolation. The VAS algorithm (Vincent-Akritas-Strzeboński) uses recursive bisection guided by Budan counts to isolate all real roots of a polynomial in $O(n^4)$ arithmetic operations (improved bounds by Sagraloff-Mehlhorn achieve $\\tilde{O}(n^3)$). This formalization provides verified certificates for the key bisection steps.\n\n**Formal verification of numerical algorithms**: The root isolation certificates (`no_roots_of_equal_budanCount`, `unique_root_of_budanCount_diff_one`) are exactly the predicates that a verified root finder would need. A certified implementation could call `budanCount` at interval endpoints and use these certificates to guarantee correctness of isolated roots.\n\n**Sturm's theorem**: The `PolyChain` framework anticipates formalizing Sturm's theorem (1829), which eliminates the parity gap by using pseudo-remainder sequences instead of derivatives. Sturm gives exact root counts: $\\#\\text{roots in } (a,b] = V_{\\text{Sturm}}(a) - V_{\\text{Sturm}}(b)$ with equality rather than an upper bound.",
     "openQuestions": [
       "Can the `budan_upper_bound` axiom be fully proved in Lean? The proof requires strong induction on degree with Rolle's theorem at each step — the `rolle_polynomial` and `n_roots_derivative_roots` bridges are already in place, but the sign-change accounting across derivative levels needs careful Lean formalization.",


### PR DESCRIPTION
## Summary

- **sorries**: 5→4 (actual `sorry` count in Lean source is 4, not 5)
- **theoremCount**: 33→36 (includes `@[simp] theorem` on same line and private theorems)
- **lineCount**: 491→502 (actual file length)
- **defCount**: resolved merge conflict, corrected to 9 (upstream had incorrectly changed to 8)
- **section endLines**: fixed Part VII-VIII (341→393) and Part IX-XII (327-418→395-502) to match actual Lean source
- **conclusion text**: updated "418-line, 28 theorems" → "502-line, 36 theorems"

No issues with status/badge/axiomCount — `axiomatized`/`axiom`/3 are all correct.

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly for descartes-rule-of-signs-oq-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)