### PR TITLE
Audit: fix erdos-960 and erdos-668 metadata mismatches

### DIFF
--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 668,
     "erdosUrl": "https://erdosproblems.com/668",
     "erdosProblemStatus": "open",
@@ -60,9 +60,11 @@
         "relationship": "Erdős Problem #90 (maximum unit distances u(n)) is the prerequisite problem — #668 studies uniqueness of configurations achieving u(n)"
       }
     ],
-    "axiomCount": 8,
-    "lineCount": 228,
-    "assumptions": "8 axiom declarations, 0 sorries. Axioms: f_four, four_config_unique, u_four, computational_evidence, extremalConfigs_nonempty, u_lower_bound, u_upper_bound, extremalQuotient_finite."
+    "axiomCount": 7,
+    "lineCount": 216,
+    "theoremCount": 9,
+    "defCount": 12,
+    "assumptions": "7 axiom declarations, 1 sorry. Axioms: f_four, four_config_unique, u_four, computational_evidence, extremalConfigs_nonempty, u_lower_bound, u_upper_bound."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #668**\n\nThis problem explores the structure of extremal configurations for the classical unit distance problem in the plane.\n\n**Background:**\nThe unit distance problem (Erdos Problem #90) asks: what is the maximum number u(n) of unit distances among n points in the plane? Problem #668 goes further, asking about the UNIQUENESS of configurations achieving this maximum.\n\n**Historical Development:**\n- The unit distance problem was posed by Erdos in 1946\n- The case n=4 is fully understood: exactly one configuration (the double triangle)\n- Computational work by Engel, Hammond-Lee, Su, Varga, Zsamboki [EHSVZ25] and Alexeev, Mixon, Parshall [AMP25] suggests uniqueness for 5 <= n <= 21\n\n**Status:** OPEN",

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 960,
     "erdosUrl": "https://erdosproblems.com/960",
     "erdosProblemStatus": "open",
@@ -29,17 +29,19 @@
       "threshold(r,k,n) via sSup over configurations",
       "ErdosConjecture960_littleo: f = o(n²) formal statement",
       "ErdosConjecture960_linear: f ≪ n stronger form",
-      "turan_upper_bound (sorry): Turán bound over ℚ",
-      "threshold_r2 (sorry): f_{2,k}(n) = 0",
+      "turan_upper_bound (axiom): Turán bound over ℚ",
+      "threshold_r2 (proved): f_{2,k}(n) = 0 via sSup argument",
       "trivial_bound (proved): at most C(n,2) ordinary lines",
       "linear_implies_littleo (proved): linear bound implies o(n²)",
       "ordinary_pairs_count (proved): r*(r-1) ordered ordinary pairs",
       "green_tao_ordinary_lines (axiom): ≥ n/2 for general position",
       "erdos_960_summary (proved): combines conjecture with r=2 case"
     ],
-    "axiomCount": 2,
-    "lineCount": 192,
-    "assumptions": "2 axioms: erdos_960_littleo_conjecture (the open o(n²) conjecture), green_tao_ordinary_lines (Green-Tao 2013 ordinary lines bound). 2 sorries in turan_upper_bound, threshold_r2.",
+    "axiomCount": 3,
+    "lineCount": 247,
+    "theoremCount": 7,
+    "defCount": 8,
+    "assumptions": "3 axioms: erdos_960_littleo_conjecture (the open o(n²) conjecture), turan_upper_bound (Turán's theorem for ordinary-line graphs), green_tao_ordinary_lines (Green-Tao 2013 ordinary lines bound). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

**erdos-960:**
- sorries: 2→0 (`turan_upper_bound` is an `axiom` not a sorry; `threshold_r2` is fully proved)
- axiomCount: 2→3 (missing `turan_upper_bound` from count)
- lineCount: 192→247, added theoremCount: 7, defCount: 8
- Fixed `originalContributions` labels

**erdos-668:**
- sorries: 0→1 (line 214 has a sorry)
- axiomCount: 8→7 (`extremalQuotient_finite` doesn't exist in Lean source — phantom axiom)
- lineCount: 228→216, added theoremCount: 9, defCount: 12

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery pages render correctly for both proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)