### PR TITLE
Fix erdos-668 metadata: sorry count and axiom count

### DIFF
--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 668,
     "erdosUrl": "https://erdosproblems.com/668",
     "erdosProblemStatus": "open",
@@ -60,9 +60,9 @@
         "relationship": "Erdős Problem #90 (maximum unit distances u(n)) is the prerequisite problem — #668 studies uniqueness of configurations achieving u(n)"
       }
     ],
-    "axiomCount": 8,
+    "axiomCount": 7,
     "lineCount": 228,
-    "assumptions": "8 axiom declarations, 0 sorries. Axioms: f_four, four_config_unique, u_four, computational_evidence, extremalConfigs_nonempty, u_lower_bound, u_upper_bound, extremalQuotient_finite."
+    "assumptions": "7 axiom declarations, 1 sorry. Axioms: f_four, four_config_unique, u_four, computational_evidence, extremalConfigs_nonempty, u_lower_bound, u_upper_bound. Sorry: f_pos (f(n)≥1 requires finiteness of extremalConfigs)."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #668**\n\nThis problem explores the structure of extremal configurations for the classical unit distance problem in the plane.\n\n**Background:**\nThe unit distance problem (Erdos Problem #90) asks: what is the maximum number u(n) of unit distances among n points in the plane? Problem #668 goes further, asking about the UNIQUENESS of configurations achieving this maximum.\n\n**Historical Development:**\n- The unit distance problem was posed by Erdos in 1946\n- The case n=4 is fully understood: exactly one configuration (the double triangle)\n- Computational work by Engel, Hammond-Lee, Su, Varga, Zsamboki [EHSVZ25] and Alexeev, Mixon, Parshall [AMP25] suggests uniqueness for 5 <= n <= 21\n\n**Status:** OPEN",


### PR DESCRIPTION
## Fix

Correct erdos-668 meta.json: sorry count 0→1, axiom count 8→7, remove phantom axiom from assumptions.

## Evidence

**Before**: meta.json claimed 0 sorries, 8 axioms (including nonexistent `extremalQuotient_finite`)
**After**: meta.json correctly reports 1 sorry (`f_pos` at line 214), 7 axioms matching the Lean source

Verified: `pnpm build` succeeds.

---
Automated fix by lean-mechanic agent.