### PR TITLE
Research: erdos-382 - Prove 3 largestPrimeDivisor axioms (12→9)

### DIFF
--- a/proofs/Proofs/Erdos382Problem.lean
+++ b/proofs/Proofs/Erdos382Problem.lean
@@ -82,17 +82,77 @@ noncomputable def largestPrimeDivisor (n : ℕ) : ℕ :=
     n.primeFactorsList.foldl max 0
   else 0
 
+/-- Helper: foldl max is ≥ init. -/
+private lemma foldl_max_ge_init : ∀ (l : List ℕ) (init : ℕ),
+    l.foldl max init ≥ init
+  | [], init => le_refl init
+  | _ :: as, init => le_trans (le_max_left init _) (foldl_max_ge_init as _)
+
+/-- Helper: foldl max is ≥ any member. -/
+private lemma foldl_max_ge_of_mem : ∀ {l : List ℕ} {x : ℕ}, x ∈ l →
+    ∀ (init : ℕ), l.foldl max init ≥ x
+  | _ :: _, _, List.Mem.head _, init =>
+    le_trans (le_max_right init _) (foldl_max_ge_init _ _)
+  | _ :: _, _, List.Mem.tail _ hx, init =>
+    foldl_max_ge_of_mem hx _
+
+/-- Helper: foldl max result equals init or is a member of the list. -/
+private lemma foldl_max_eq_init_or_mem : ∀ (l : List ℕ) (init : ℕ),
+    l.foldl max init = init ∨ l.foldl max init ∈ l
+  | [], init => Or.inl rfl
+  | a :: as, init => by
+    simp only [List.foldl_cons]
+    rcases foldl_max_eq_init_or_mem as (max init a) with h | h
+    · rw [h]
+      rcases le_or_lt a init with hle | hlt
+      · left; exact max_eq_left hle
+      · right; rw [max_eq_right (le_of_lt hlt)]; exact List.mem_cons_self a as
+    · right; exact List.mem_cons_of_mem a h
+
+/-- primeFactorsList is nonempty for n > 1. -/
+private lemma primeFactorsList_ne_nil (n : ℕ) (hn : n > 1) :
+    n.primeFactorsList ≠ [] := by
+  intro h
+  have := Nat.prod_primeFactorsList (show n ≠ 0 by omega)
+  rw [h, List.prod_nil] at this
+  omega
+
+/-- The foldl max 0 of primeFactorsList is a member for n > 1. -/
+private lemma foldl_max_mem_primeFactorsList (n : ℕ) (hn : n > 1) :
+    n.primeFactorsList.foldl max 0 ∈ n.primeFactorsList := by
+  have hne := primeFactorsList_ne_nil n hn
+  rcases foldl_max_eq_init_or_mem n.primeFactorsList 0 with h | h
+  · exfalso
+    obtain ⟨x, hx⟩ : ∃ a, a ∈ n.primeFactorsList := by
+      cases hl : n.primeFactorsList with
+      | nil => exact absurd hl hne
+      | cons a l => exact ⟨a, List.mem_cons_self a l⟩
+    have h1 := foldl_max_ge_of_mem hx 0
+    rw [h] at h1
+    have h2 := (Nat.prime_of_mem_primeFactorsList hx).two_le
+    omega
+  · exact h
+
 /-- The largest prime divisor divides n. -/
-axiom largestPrimeDivisor_dvd (n : ℕ) (hn : n > 1) :
-    largestPrimeDivisor n ∣ n
+theorem largestPrimeDivisor_dvd (n : ℕ) (hn : n > 1) :
+    largestPrimeDivisor n ∣ n := by
+  simp only [largestPrimeDivisor, dif_pos hn]
+  exact Nat.dvd_of_mem_primeFactorsList (foldl_max_mem_primeFactorsList n hn)
 
 /-- The largest prime divisor is prime (if n > 1). -/
-axiom largestPrimeDivisor_prime (n : ℕ) (hn : n > 1) :
-    (largestPrimeDivisor n).Prime
+theorem largestPrimeDivisor_prime (n : ℕ) (hn : n > 1) :
+    (largestPrimeDivisor n).Prime := by
+  simp only [largestPrimeDivisor, dif_pos hn]
+  exact Nat.prime_of_mem_primeFactorsList (foldl_max_mem_primeFactorsList n hn)
 
 /-- Any prime divisor is ≤ the largest. -/
-axiom prime_le_largestPrimeDivisor (n p : ℕ) (hn : n > 1) (hp : p.Prime) (hdiv : p ∣ n) :
-    p ≤ largestPrimeDivisor n
+theorem prime_le_largestPrimeDivisor (n p : ℕ) (hn : n > 1) (hp : p.Prime) (hdiv : p ∣ n) :
+    p ≤ largestPrimeDivisor n := by
+  simp only [largestPrimeDivisor, dif_pos hn]
+  have hmem : p ∈ n.primeFactorsList := by
+    rw [Nat.mem_primeFactorsList (show n ≠ 0 by omega)]
+    exact ⟨hp, hdiv⟩
+  exact foldl_max_ge_of_mem hmem 0
 
 /- ## Part III: Exponent of Prime in Product -/
 

--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -64,9 +64,9 @@
       "erdos_382_summary: combined known results theorem",
       "Concrete example: prodInterval 2 4 = 24 via native_decide"
     ],
-    "axiomCount": 12,
-    "lineCount": 266,
-    "assumptions": "12 axioms: largestPrimeDivisor_dvd, largestPrimeDivisor_prime, prime_le_largestPrimeDivisor, exponentInProduct_sum, largest_prime_exp_one, exp_ge_two_needs_square, erdos_382_q1, erdos_382_q2_heuristic, ramachandra_bound, cramer_implies_q1, no_prime_in_upper_half, condition_iff_no_large_prime."
+    "axiomCount": 9,
+    "lineCount": 330,
+    "assumptions": "9 axioms: exponentInProduct_sum, largest_prime_exp_one, exp_ge_two_needs_square, erdos_382_q1, erdos_382_q2_heuristic, ramachandra_bound, cramer_implies_q1, no_prime_in_upper_half, condition_iff_no_large_prime. Previously proved: largestPrimeDivisor_dvd, largestPrimeDivisor_prime, prime_le_largestPrimeDivisor (via primeFactorsList + foldl max membership)."
   },
   "overview": {
     "historicalContext": "Erdős Problem #382 originates from the 1980 monograph by Erdős and Graham [ErGr80], which systematically cataloged open problems in combinatorial number theory. The problem studies the factorization structure of products of consecutive integers u·(u+1)·...·v, specifically asking about the exponent of the largest prime divisor.\n\nThe key constraint is that the largest prime p dividing the product must appear with exponent ≥ 2. Since p² must divide some integer in [u,v], this forces p ≤ √v, meaning the interval [u,v] is 'prime-free' above √v. The problem asks two questions: whether v−u grows subpolynomially in v, and whether v−u can be arbitrarily large.\n\nRamachandra established the best known upper bound v−u ≤ v^{1/2+o(1)}, using techniques from the distribution of primes in short intervals. Cramér's famous conjecture on prime gaps would imply the stronger result that v−u = v^o(1). Cambie's heuristic analysis suggests that v−u can indeed be arbitrarily large, but both questions remain open.",
@@ -99,8 +99,8 @@
       "title": "Part II: Largest Prime Divisor",
       "startLine": 65,
       "endLine": 88,
-      "summary": "largestPrimeDivisor via primeFactorsList maximum. Axioms: divides n, is prime, is maximal.",
-      "mathContext": "largestPrimeDivisor via primeFactorsList maximum. Axioms: divides n, is prime, is maximal."
+      "summary": "largestPrimeDivisor via primeFactorsList foldl max. All three properties PROVED: divides n, is prime, is maximal — via helper lemmas establishing foldl max membership in nonempty lists of primes.",
+      "mathContext": "largestPrimeDivisor via primeFactorsList foldl max. Proved largestPrimeDivisor_dvd, largestPrimeDivisor_prime, prime_le_largestPrimeDivisor using foldl_max_mem_primeFactorsList and Nat.dvd_of_mem_primeFactorsList / Nat.prime_of_mem_primeFactorsList / Nat.mem_primeFactorsList."
     },
     {
       "id": "exponent",
@@ -195,9 +195,9 @@
       "Real"
     ],
     "namespace": "Erdos382",
-    "lineCount": 266,
-    "axiomCount": 12,
-    "theoremCount": 3,
+    "lineCount": 330,
+    "axiomCount": 9,
+    "theoremCount": 6,
     "definitionCount": 9
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-382.json
+++ b/src/data/research/problems/erdos-382.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-13T00:59:36.242Z",
+    "phase": "ACT",
+    "since": "2026-03-24T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved 3 largestPrimeDivisor axioms. Axioms 12→9.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,23 +29,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved prodInterval_factorial (axiom→theorem). Fixed 3 pre-existing build errors. Axioms 13→12.",
+    "progressSummary": "PROGRESS: Proved 3 largestPrimeDivisor axioms (dvd, prime, le). Axioms 12→9. All via primeFactorsList foldl max membership.",
     "builtItems": [
       "Proved prodInterval_factorial by induction with Finset.prod_insert",
       "Fixed largestPrimeDivisor: List.foldl max 0 replaces removed List.maximum?",
       "Fixed cramersConjecture: consecutive prime formulation replaces removed Nat.nth",
-      "Removed orphaned docstring causing parse error"
+      "Removed orphaned docstring causing parse error",
+      "Proved largestPrimeDivisor_dvd via foldl_max_mem_primeFactorsList + Nat.dvd_of_mem_primeFactorsList",
+      "Proved largestPrimeDivisor_prime via foldl_max_mem_primeFactorsList + Nat.prime_of_mem_primeFactorsList",
+      "Proved prime_le_largestPrimeDivisor via Nat.mem_primeFactorsList + foldl_max_ge_of_mem",
+      "Helper lemmas: foldl_max_ge_init, foldl_max_ge_of_mem, foldl_max_eq_init_or_mem, primeFactorsList_ne_nil, foldl_max_mem_primeFactorsList"
     ],
     "insights": [
       "12 axioms remain (was 13). prodInterval_factorial proved by induction",
       "largestPrimeDivisor_dvd/prime/le axioms likely provable from primeFactorsList + foldl max API",
       "exponentInProduct_sum likely provable from Nat.factorization multiplicativity",
-      "Pre-existing API breakage: List.maximum? and Nat.nth removed from Lean/Mathlib"
+      "Pre-existing API breakage: List.maximum? and Nat.nth removed from Lean/Mathlib",
+      "foldl max 0 of primeFactorsList is a member when n > 1: proved via induction (foldl_max_eq_init_or_mem) + primeFactorsList nonempty + all elements ≥ 2",
+      "exponentInProduct_sum axiom has pre-existing bug: wrong when u=0 (product is 0 but sum of valuations is positive)",
+      "exp_ge_two_needs_square axiom is also incorrect: exponent ≥ 2 can come from two separate multiples of p, not requiring p²|k"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove largestPrimeDivisor_dvd/prime/le from primeFactorsList properties",
-      "Prove exponentInProduct_sum from Nat.factorization_prod"
+      "Fix exponentInProduct_sum: add u > 0 precondition, prove via Nat.factorization_prod + Finsupp.finset_sum_apply",
+      "Fix exp_ge_two_needs_square: statement is too strong",
+      "Remaining 9 axioms: 2 OPEN conjectures (q1, q2), 3 deep results (ramachandra, cramer_implies_q1, condition_iff_no_large_prime), 4 structural"
     ],
     "markdown": "# Erdős #382 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $u\\leq v$ be such that the largest prime dividing $\\prod_{u\\leq m\\leq v}m$ appears with exponent at least $2$. Is it true that $v-u=v^{o(1)}$? Can $v-u$ be arbitrarily large?\n\n\n\nErd\\H{o}s and Graham report it follows from results of Ramachandra that $v-u\\leq v^{1/2+o(1)}$.\n\nCambie has observed that the first question boils down to some old conjectures on prime gaps.\nBy Cram\\'{er's conjecture}, for every $\\epsilon>0,$ for every $u$ sufficiently large there is a prime between $u$ and $u+u^\\epsilon$.\nThus for $u+u^\\epsilon<v$, the largest prime divisor of \\( \\prod_{u \\leq m \\leq v} m \\) appears with exponent $1$.\nSince this is not the case in the question, \\( v - u = v^{o(1)} \\).\n\nCambie also gives the following heuristic for the second question. The 'probability' that the largest prime divisor of $n$ is $<n^{1/2}$ is $1-\\log 2>0$. For any fixed $k$, there is therefore a positive 'probability' that there are $k$ consecutive integers around $q^2$ (for a prime $q$) all of whose prime divisors are bounded above by $q$, when $v-u\\geq k$. See [383] for a conjecture along these lines. A similar argument applies if we replace multiplicity $2$ with multiplicity $r$, for any fixed $r\\geq 2$.\n\nSee also [380].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #383\n- Problem #380\n- Problem #381\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },


### PR DESCRIPTION
## Summary

- Convert `largestPrimeDivisor_dvd`, `largestPrimeDivisor_prime`, and `prime_le_largestPrimeDivisor` from axioms to proved theorems
- Added 5 helper lemmas for `List.foldl max` membership and bounds over `primeFactorsList`
- Axiom count reduced from 12 to 9
- Build passes (0 sorries, 9 axioms remaining)

## Proof Strategy

The `largestPrimeDivisor` is defined as `n.primeFactorsList.foldl max 0`. Key insight: for `n > 1`, the list is nonempty (since `n` has prime factors) and all elements are ≥ 2 (since they're primes). The `foldl max 0` result is therefore a member of the list, giving access to `Nat.dvd_of_mem_primeFactorsList`, `Nat.prime_of_mem_primeFactorsList`, and `foldl_max_ge_of_mem`.

## Remaining Axioms (9)

- 2 OPEN conjectures: `erdos_382_q1`, `erdos_382_q2_heuristic`
- 3 deep results: `ramachandra_bound`, `cramer_implies_q1`, `condition_iff_no_large_prime`
- 4 structural: `exponentInProduct_sum`, `largest_prime_exp_one`, `exp_ge_two_needs_square`, `no_prime_in_upper_half`

## Test plan
- [x] Docker build passes for `Proofs.Erdos382Problem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)