### PR TITLE
Research: FTA-OQ04 + Lawvere-Cantor - Two verified proofs

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ03.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ03.lean
@@ -1,0 +1,149 @@
+import Mathlib.Logic.Function.Basic
+import Mathlib.Order.BooleanAlgebra
+
+/-
+# Lawvere Fixed-Point Theorem and Cantor's Theorem
+
+## What This Proves
+The Lawvere fixed-point theorem: if there exists a surjection e : A → (A → B),
+then every endomorphism f : B → B has a fixed point. As a corollary, Cantor's
+theorem follows: there is no surjection from any type to its power type (A → Prop),
+because negation (not) has no fixed point in Prop.
+
+This unifies Cantor's diagonal argument, Russell's paradox, the halting problem,
+and Gödel's incompleteness theorem as instances of a single categorical principle.
+
+## Approach
+- **Foundation**: Pure type theory — no Mathlib dependencies beyond basic logic
+- **Key idea**: The diagonal g(a) = f(e(a)(a)) must equal some e(a₀) by surjectivity
+- **Cantor**: Instantiate with B = Prop, f = not; no fixed point → no surjection
+
+## Proof Techniques
+- Diagonal construction (Lawvere's categorical trick)
+- Proof by contradiction (Cantor from Lawvere)
+- Functional extensionality argument
+
+Historical Note: F. William Lawvere (1969) showed that Cantor's diagonal argument
+is an instance of a general fixed-point theorem in cartesian closed categories.
+This formalization presents the type-theoretic version.
+-/
+
+namespace LawvereCantor
+
+/-
+  Part 1: The Lawvere Fixed-Point Theorem
+
+  If e : A → (A → B) is surjective, then every f : B → B has a fixed point.
+  The proof constructs the diagonal function g(a) = f(e(a)(a)) and uses
+  surjectivity to find a₀ with e(a₀) = g, giving f(g(a₀)) = g(a₀).
+-/
+
+-- The Lawvere fixed-point theorem
+theorem lawvere_fixpoint {A B : Type*} (e : A → A → B)
+    (he : Function.Surjective e) (f : B → B) :
+    ∃ b : B, f b = b := by
+  -- Define the diagonal: g(a) = f(e(a)(a))
+  obtain ⟨a₀, ha₀⟩ := he (fun a => f (e a a))
+  -- a₀ satisfies e(a₀) = g, so e(a₀)(a₀) = g(a₀) = f(e(a₀)(a₀))
+  exact ⟨e a₀ a₀, by rw [← congr_fun ha₀ a₀]⟩
+
+/-
+  Part 2: No Fixed-Point-Free Endomorphism Corollary
+
+  Contrapositive: if some f : B → B has no fixed point, then no
+  e : A → (A → B) can be surjective.
+-/
+
+-- If f has no fixed point, there is no surjection A → (A → B)
+theorem no_surjection_if_no_fixpoint {A B : Type*} (f : B → B)
+    (hf : ∀ b, f b ≠ b) : ¬ ∃ e : A → A → B, Function.Surjective e := by
+  rintro ⟨e, he⟩
+  obtain ⟨b, hb⟩ := lawvere_fixpoint e he f
+  exact hf b hb
+
+/-
+  Part 3: Cantor's Theorem via Lawvere
+
+  There is no surjection from A to (A → Prop), because negation
+  (not : Prop → Prop) has no fixed point: ¬p = p is impossible.
+-/
+
+-- Negation has no fixed point in Prop
+theorem not_has_no_fixpoint : ∀ p : Prop, (¬p) ≠ p := by
+  intro p h
+  -- Transport along the equality ¬p = p
+  have to_np : p → ¬p := cast h.symm
+  have to_p : ¬p → p := cast h
+  -- Construct ¬p by self-application (the Russell-like trick)
+  have np : ¬p := fun hp => to_np hp hp
+  -- Derive contradiction
+  exact np (to_p np)
+
+-- Cantor's theorem: no surjection A → (A → Prop)
+theorem cantor {A : Type*} (e : A → A → Prop) :
+    ¬ Function.Surjective e := by
+  intro he
+  obtain ⟨b, hb⟩ := lawvere_fixpoint e he Not
+  exact not_has_no_fixpoint b hb
+
+-- Alternative statement: the power type has strictly larger cardinality
+theorem cantor_no_surjection (A : Type*) :
+    ¬ ∃ e : A → A → Prop, Function.Surjective e :=
+  no_surjection_if_no_fixpoint Not not_has_no_fixpoint
+
+/-
+  Part 4: Cantor's Theorem for Bool (Decidable Version)
+
+  The same argument works with Bool instead of Prop: boolean negation
+  has no fixed point, so there is no surjection A → (A → Bool).
+-/
+
+-- Boolean negation has no fixed point
+theorem bnot_has_no_fixpoint : ∀ b : Bool, (!b) ≠ b := by
+  intro b
+  cases b <;> decide
+
+-- Cantor's theorem for Bool: no surjection A → (A → Bool)
+theorem cantor_bool {A : Type*} (e : A → A → Bool) :
+    ¬ Function.Surjective e := by
+  intro he
+  obtain ⟨b, hb⟩ := lawvere_fixpoint e he (! ·)
+  exact bnot_has_no_fixpoint b hb
+
+/-
+  Part 5: Russell's Paradox as a Lawvere Instance
+
+  If we could form the set of all sets, we would have a surjection
+  from the universe to its power set. Lawvere prevents this.
+  We formalize this as: no type can enumerate all its subtypes.
+-/
+
+-- Russell's paradox: no type can classify all predicates on itself
+-- (This is exactly Cantor's theorem restated)
+theorem russell (A : Type*) :
+    ¬ ∃ e : A → A → Prop, ∀ S : A → Prop, ∃ a, e a = S :=
+  cantor_no_surjection A
+
+/-
+  Part 6: The Diagonal Lemma (Explicit Construction)
+
+  Makes the diagonal construction explicit: given any e : A → (A → B),
+  the function g(a) = f(e(a)(a)) is not in the range of e when f has
+  no fixed point.
+-/
+
+-- The diagonal function is not in the range of e
+theorem diagonal_not_in_range {A B : Type*} (e : A → A → B)
+    (f : B → B) (hf : ∀ b, f b ≠ b) :
+    (fun a => f (e a a)) ∉ Set.range e := by
+  rintro ⟨a₀, ha₀⟩
+  exact hf (e a₀ a₀) (congr_fun ha₀ a₀).symm
+
+end LawvereCantor
+
+-- Verification
+#check LawvereCantor.lawvere_fixpoint
+#check LawvereCantor.cantor
+#check LawvereCantor.cantor_bool
+#check LawvereCantor.russell
+#check LawvereCantor.diagonal_not_in_range

--- a/proofs/Proofs/FundamentalTheoremAlgebraOQ04.lean
+++ b/proofs/Proofs/FundamentalTheoremAlgebraOQ04.lean
@@ -1,10 +1,6 @@
-import Mathlib.FieldTheory.IsAlgClosed.Basic
-import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
-import Mathlib.Analysis.Complex.Polynomial.Basic
-import Mathlib.Analysis.SpecialFunctions.Complex.Circle
-import Mathlib.LinearAlgebra.Dimension.Finrank
+import Mathlib
 
-/-!
+/-
 # ℂ is the Unique Algebraic Closure of ℝ
 
 ## What This Proves
@@ -107,11 +103,11 @@ theorem no_real_root_of_x_sq_plus_one (x : ℝ) : x ^ 2 + 1 ≠ 0 := by
 theorem reals_not_alg_closed : ¬ IsAlgClosed ℝ := by
   intro h
   -- If ℝ were algebraically closed, X² + 1 would have a real root
-  have hp : (0 : WithBot ℕ) < degree (X ^ 2 + 1 : ℝ[X]) := by
+  have hp : degree (X ^ 2 + 1 : ℝ[X]) ≠ 0 := by
     simp [degree_add_eq_left_of_degree_lt, degree_X_pow]
   obtain ⟨r, hr⟩ := h.exists_root _ hp
   -- But x² + 1 > 0 for all real x
-  simp only [IsRoot, eval_add, eval_pow, eval_X, eval_one] at hr
+  rw [IsRoot, eval_add, eval_pow, eval_X, eval_one] at hr
   exact no_real_root_of_x_sq_plus_one r hr
 
 /-
@@ -128,24 +124,23 @@ noncomputable def charQuad (z : ℂ) : ℝ[X] :=
 -- z is a root of its characteristic quadratic
 theorem is_root_charQuad (z : ℂ) :
     (charQuad z).eval₂ (algebraMap ℝ ℂ) z = 0 := by
-  simp only [charQuad, eval₂_add, eval₂_sub, eval₂_mul, eval₂_pow, eval₂_X,
-    eval₂_C, map_ofNat, map_mul, map_add, map_pow]
-  ext
-  · -- Real part
-    simp [mul_comm, mul_assoc]
+  have halg : algebraMap ℝ ℂ = Complex.ofReal := rfl
+  simp only [charQuad, eval₂_add, eval₂_sub, eval₂_mul, eval₂_pow, eval₂_X, eval₂_C, halg]
+  apply Complex.ext
+  · simp only [Complex.ofReal_re, Complex.ofReal_im, Complex.add_re, Complex.sub_re,
+      Complex.mul_re, Complex.zero_re, sq]
     ring
-  · -- Imaginary part
-    simp [mul_comm, mul_assoc]
+  · simp only [Complex.ofReal_re, Complex.ofReal_im, Complex.add_im, Complex.sub_im,
+      Complex.mul_im, Complex.zero_im, sq]
     ring
 
 -- The conjugate z̄ is also a root
 theorem is_root_charQuad_conj (z : ℂ) :
-    (charQuad z).eval₂ (algebraMap ℝ ℂ) (conj z) = 0 := by
-  have : charQuad z = charQuad (conj z) := by
+    (charQuad z).eval₂ (algebraMap ℝ ℂ) (starRingEnd ℂ z) = 0 := by
+  have : charQuad z = charQuad (starRingEnd ℂ z) := by
     simp [charQuad, Complex.conj_re, Complex.conj_im]
-    ring
   rw [this]
-  exact is_root_charQuad (conj z)
+  exact is_root_charQuad (starRingEnd ℂ z)
 
 /-
   Part 7: Minimality — ℂ is the Smallest Algebraically Closed Extension of ℝ
@@ -161,16 +156,21 @@ theorem is_root_charQuad_conj (z : ℂ) :
 theorem no_intermediate_field (K : IntermediateField ℝ ℂ)
     (hK : Module.Finite ℝ K) :
     Module.finrank ℝ K = 1 ∨ Module.finrank ℝ K = 2 := by
-  -- [ℂ:ℝ] = [ℂ:K] * [K:ℝ] and [ℂ:ℝ] = 2
+  -- [ℂ:ℝ] = [ℂ:K] · [K:ℝ] and [ℂ:ℝ] = 2
   have h2 := finrank_complex_over_reals
-  have htower := IntermediateField.finrank_mul_finrank K (⊤ : IntermediateField ℝ ℂ)
-  rw [IntermediateField.finrank_top] at htower
+  have htower := Module.finrank_mul_finrank ℝ (↥K) ℂ
+  -- htower : finrank ℝ ↥K * finrank ↥K ℂ = finrank ℝ ℂ
   rw [h2] at htower
-  -- [ℂ:K] * [K:ℝ] = 2, and both factors are positive
-  have hK_pos : 0 < Module.finrank ℝ K := Module.finrank_pos
-  have hCK_pos : 0 < Module.finrank K (⊤ : IntermediateField ℝ ℂ) := Module.finrank_pos
-  -- 2 = a * b with a, b > 0 implies (a,b) = (1,2) or (2,1)
-  interval_cases (Module.finrank ℝ K) <;> omega
+  -- finrank ℝ ↥K * finrank ↥K ℂ = 2, and both factors are positive
+  have hK_pos : 0 < Module.finrank ℝ ↥K := Module.finrank_pos
+  have hCK_pos : 0 < Module.finrank (↥K) ℂ := Module.finrank_pos
+  -- a * b = 2 with b > 0 implies a ≤ 2
+  have hle : Module.finrank ℝ ↥K ≤ 2 := by
+    calc Module.finrank ℝ ↥K
+        ≤ Module.finrank ℝ ↥K * Module.finrank (↥K) ℂ :=
+          le_mul_of_one_le_right (Nat.zero_le _) hCK_pos
+        _ = 2 := htower
+  interval_cases (Module.finrank ℝ ↥K) <;> omega
 
 /-
   Part 8: The Quadratic Extension is Necessary and Sufficient

--- a/src/data/proofs/cantor-diagonalization-oq-03/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/annotations.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "ann-lawvere-main",
+    "proofId": "cantor-diagonalization-oq-03",
+    "range": { "startLine": 39, "endLine": 45 },
+    "type": "key-step",
+    "title": "Lawvere Fixed-Point Theorem",
+    "content": "The core 3-line proof: given surjective $e$ and any $f$, obtain $a_0$ with $e(a_0) = \\lambda a. f(e(a)(a))$ by surjectivity, then $e(a_0)(a_0)$ is the fixed point. The diagonal construction $g(a) = f(e(a)(a))$ is the categorical essence of all diagonal arguments.",
+    "significance": "major"
+  },
+  {
+    "id": "ann-lawvere-negation",
+    "proofId": "cantor-diagonalization-oq-03",
+    "range": { "startLine": 71, "endLine": 78 },
+    "type": "key-step",
+    "title": "Negation Has No Fixed Point",
+    "content": "If $\\neg p = p$, cast along this equality to get $p \\to \\neg p$ and $\\neg p \\to p$. Define $\\neg p := \\lambda h. (\\mathrm{cast}\\,h^{-1}\\,h)\\,h$ (self-application), then apply to get $p$, yielding contradiction. This uses the same self-referential trick as Russell's paradox.",
+    "significance": "major"
+  },
+  {
+    "id": "ann-lawvere-cantor",
+    "proofId": "cantor-diagonalization-oq-03",
+    "range": { "startLine": 80, "endLine": 85 },
+    "type": "key-step",
+    "title": "Cantor from Lawvere",
+    "content": "Cantor's theorem in 3 lines: assume surjective $e : A \\to (A \\to \\mathrm{Prop})$, apply Lawvere with $f = \\mathrm{Not}$, get fixed point $b$ with $\\neg b = b$, contradicting `not_has_no_fixpoint`.",
+    "significance": "major"
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-03/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-03/index.ts
@@ -1,0 +1,39 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CantorDiagonalizationOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cantorDiagonalizationOQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cantorDiagonalizationOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cantorDiagonalizationOQ03Data: ProofData = {
+  proof: cantorDiagonalizationOQ03Proof,
+  annotations: cantorDiagonalizationOQ03Annotations,
+  tacticStates: [],
+}
+
+export default cantorDiagonalizationOQ03Data

--- a/src/data/proofs/cantor-diagonalization-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "cantor-diagonalization-oq-03",
+  "title": "Lawvere Fixed-Point Theorem and Cantor's Theorem",
+  "slug": "cantor-diagonalization-oq-03",
+  "description": "The Lawvere fixed-point theorem: if there exists a surjection e : A -> (A -> B), then every endomorphism f : B -> B has a fixed point. Cantor's theorem follows as a corollary by noting that negation (Not) has no fixed point in Prop, so no surjection A -> (A -> Prop) can exist. This unifies Cantor's diagonal argument, Russell's paradox, and the halting problem as instances of a single principle.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ03.lean",
+    "tags": [
+      "set-theory",
+      "logic",
+      "category-theory",
+      "lawvere",
+      "cantor",
+      "diagonal-argument",
+      "fixed-point",
+      "wiedijk-100"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 149,
+    "assumptions": "None. Fully verified with 0 axioms, 0 sorries. Uses only basic logic and function theory from Mathlib.",
+    "originalContributions": [
+      "lawvere_fixpoint: the general Lawvere fixed-point theorem for surjections A -> (A -> B)",
+      "not_has_no_fixpoint: negation has no fixed point in Prop (via cast and self-application)",
+      "cantor: Cantor's theorem as a direct corollary of Lawvere",
+      "cantor_bool: decidable version with Bool instead of Prop",
+      "russell: Russell's paradox as Cantor's theorem restated",
+      "diagonal_not_in_range: explicit diagonal construction showing non-membership in range"
+    ],
+    "dateAdded": "2026-03-24"
+  },
+  "overview": {
+    "problemStatement": "Prove the Lawvere fixed-point theorem as a categorical generalization of Cantor's diagonal argument: if a surjection $e : A \\to (A \\to B)$ exists, then every endomorphism $f : B \\to B$ has a fixed point. Derive Cantor's theorem as a corollary.",
+    "text": "A 149-line verified formalization of the Lawvere fixed-point theorem (1969) with 0 sorries and 0 axioms. The main theorem states: if $e : A \\to (A \\to B)$ is surjective, then every $f : B \\to B$ has a fixed point. The proof constructs the diagonal function $g(a) = f(e(a)(a))$ and uses surjectivity to find $a_0$ with $e(a_0) = g$, yielding $f(g(a_0)) = g(a_0)$. Five corollaries follow: Cantor's theorem for Prop, Cantor's theorem for Bool, Russell's paradox, the contrapositive (no fixed-point-free endomorphism implies no surjection), and an explicit diagonal non-membership result.",
+    "proofStrategy": "1. **Lawvere's diagonal trick**: Given surjective $e : A \\to (A \\to B)$ and $f : B \\to B$, define $g(a) = f(e(a)(a))$. By surjectivity, $\\exists a_0$ with $e(a_0) = g$. Then $e(a_0)(a_0) = g(a_0) = f(e(a_0)(a_0))$, so $e(a_0)(a_0)$ is a fixed point of $f$.\n\n2. **Cantor from Lawvere**: Take $B = \\mathrm{Prop}$ and $f = \\neg$. Since $\\neg$ has no fixed point ($\\neg p = p$ leads to contradiction via self-application), Lawvere implies no surjection $A \\to (A \\to \\mathrm{Prop})$ exists.\n\n3. **Negation has no fixed point**: If $\\neg p = p$, cast along this equality to get $p \\to \\neg p$ and $\\neg p \\to p$. Define $\\neg p$ by $\\lambda h. (\\mathrm{cast}\\, h^{-1}\\, h)\\, h$, then derive contradiction.",
+    "keyInsights": [
+      "**One Proof, Many Theorems**: Lawvere's fixed-point theorem unifies Cantor's diagonal argument, Russell's paradox, the halting problem, and Godel's incompleteness theorem. Each is an instance with different B and f.",
+      "**The Diagonal is Universal**: The construction g(a) = f(e(a)(a)) is the categorical essence of all diagonal arguments. It extracts the common pattern from seemingly different impossibility proofs.",
+      "**Self-Application is the Key**: The proof of not_has_no_fixpoint uses the same self-application trick as Russell's paradox: if we can apply something to itself, contradiction follows. This is the type-theoretic core of all diagonal arguments.",
+      "**Surjectivity is the Barrier**: Cantor's theorem is not about size per se — it's about the impossibility of a certain surjection. This formulation makes the logical content precise without appealing to cardinal arithmetic."
+    ]
+  },
+  "sections": [
+    {
+      "id": "lawvere",
+      "title": "Lawvere Fixed-Point Theorem",
+      "startLine": 33,
+      "endLine": 45,
+      "summary": "The main theorem: surjective e : A -> (A -> B) implies every f : B -> B has a fixed point.",
+      "mathContext": "If $e : A \\to (A \\to B)$ is surjective and $f : B \\to B$, define $g(a) = f(e(a)(a))$. By surjectivity $\\exists a_0$ with $e(a_0) = g$, giving fixed point $e(a_0)(a_0)$."
+    },
+    {
+      "id": "contrapositive",
+      "title": "No Fixed-Point-Free Corollary",
+      "startLine": 47,
+      "endLine": 56,
+      "summary": "Contrapositive: if f has no fixed point, no surjection A -> (A -> B) exists.",
+      "mathContext": "Direct contrapositive of the Lawvere theorem."
+    },
+    {
+      "id": "cantor",
+      "title": "Cantor's Theorem via Lawvere",
+      "startLine": 58,
+      "endLine": 89,
+      "summary": "Cantor's theorem: no surjection A -> (A -> Prop), because Not has no fixed point.",
+      "mathContext": "$\\neg : \\mathrm{Prop} \\to \\mathrm{Prop}$ has no fixed point. If $\\neg p = p$, cast along this equality to get $p \\to \\neg p$, construct $\\neg p$ by self-application, derive $p$, then contradiction."
+    },
+    {
+      "id": "cantor-bool",
+      "title": "Cantor's Theorem for Bool",
+      "startLine": 91,
+      "endLine": 108,
+      "summary": "Decidable version: no surjection A -> (A -> Bool), using boolean negation.",
+      "mathContext": "Boolean negation $!b \\neq b$ for both $b = \\mathrm{true}$ and $b = \\mathrm{false}$, verified by `decide`."
+    },
+    {
+      "id": "russell",
+      "title": "Russell's Paradox",
+      "startLine": 110,
+      "endLine": 121,
+      "summary": "Russell's paradox restated: no type can classify all predicates on itself.",
+      "mathContext": "Russell's paradox is Cantor's theorem for the specific case where we try to enumerate all subsets of A by elements of A."
+    },
+    {
+      "id": "diagonal",
+      "title": "Explicit Diagonal Construction",
+      "startLine": 123,
+      "endLine": 136,
+      "summary": "The diagonal function g(a) = f(e(a)(a)) is not in the range of e when f has no fixed point.",
+      "mathContext": "Explicit non-membership: if $f$ has no fixed point and $g(a) = f(e(a)(a))$, then $g \\notin \\mathrm{range}(e)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Lawvere fixed-point theorem reveals the common structure behind Cantor's diagonal argument, Russell's paradox, the halting problem, and Godel's incompleteness theorem. All are instances of the principle that surjectivity onto a function space is incompatible with fixed-point-free endomorphisms.",
+    "implications": "This formalization demonstrates that impossibility results in set theory, logic, and computation share a single categorical root. The 3-line proof of the Lawvere theorem shows that the deep content is in the diagonal construction g(a) = f(e(a)(a)) — everything else is a choice of B and f."
+  },
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "generalizes",
+      "description": "The base Cantor proof uses the diagonal argument directly; this proof derives it as a corollary of the more general Lawvere fixed-point theorem"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "generalizes",
+      "description": "Cantor's theorem (|S| < |P(S)|) follows from Lawvere by taking B = Prop and f = Not"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib.Logic.Function.Basic", "Mathlib.Order.BooleanAlgebra"],
+    "opens": [],
+    "namespace": "LawvereCantor",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0
+  }
+}

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ann-fta-oq04-header",
+    "proofId": "fundamental-theorem-algebra-oq-04",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "Overview: C as Unique Algebraic Closure",
+    "content": "The file proves seven results about the relationship between R and C: extension degree [C:R] = 2, algebraicity, algebraic closure, uniqueness via Steinitz, non-closure of R, the characteristic quadratic, and minimality via the tower law. The key insight is that Mathlib provides the heavy machinery (Complex.isAlgClosed, IsAlgClosure.equiv) and this proof assembles these into a comprehensive picture.",
+    "significance": "context"
+  },
+  {
+    "id": "ann-fta-oq04-finrank",
+    "proofId": "fundamental-theorem-algebra-oq-04",
+    "range": { "startLine": 44, "endLine": 46 },
+    "type": "key-step",
+    "title": "Extension Degree [C:R] = 2",
+    "content": "The extension degree $[\\mathbb{C}:\\mathbb{R}] = 2$ follows from `Complex.finrank_real_complex`, which computes the dimension of $\\mathbb{C}$ as an $\\mathbb{R}$-vector space. The basis is $\\{1, i\\}$.",
+    "significance": "major"
+  },
+  {
+    "id": "ann-fta-oq04-algebraic",
+    "proofId": "fundamental-theorem-algebra-oq-04",
+    "range": { "startLine": 58, "endLine": 60 },
+    "type": "key-step",
+    "title": "Finite Extension implies Algebraic",
+    "content": "Since $[\\mathbb{C}:\\mathbb{R}] = 2 < \\infty$, Mathlib's `Algebra.IsAlgebraic.of_finite` establishes that every complex number is algebraic over $\\mathbb{R}$. This is the bridge from linear algebra (finite dimension) to field theory (algebraicity).",
+    "significance": "major"
+  },
+  {
+    "id": "ann-fta-oq04-closure",
+    "proofId": "fundamental-theorem-algebra-oq-04",
+    "range": { "startLine": 72, "endLine": 75 },
+    "type": "key-step",
+    "title": "IsAlgClosure Instance",
+    "content": "Assembles the `IsAlgClosure R C` instance from two components: algebraic closure (`Complex.isAlgClosed` from Mathlib) and algebraicity over $\\mathbb{R}$ (from the finite extension argument). This is the central definition of the file.",
+    "significance": "major"
+  },
+  {
+    "id": "ann-fta-oq04-steinitz",
+    "proofId": "fundamental-theorem-algebra-oq-04",
+    "range": { "startLine": 84, "endLine": 88 },
+    "type": "key-step",
+    "title": "Steinitz Uniqueness",
+    "content": "The uniqueness theorem: any algebraic closure $L$ of $\\mathbb{R}$ is $\\mathbb{R}$-algebra isomorphic to $\\mathbb{C}$, via `IsAlgClosure.equiv`. This is Steinitz's 1910 result, which uses Zorn's lemma to extend embeddings of algebraic closures.",
+    "significance": "major"
+  },
+  {
+    "id": "ann-fta-oq04-tower",
+    "proofId": "fundamental-theorem-algebra-oq-04",
+    "range": { "startLine": 156, "endLine": 173 },
+    "type": "key-step",
+    "title": "No Intermediate Fields (Tower Law)",
+    "content": "Uses the tower law $[\\mathbb{C}:K] \\cdot [K:\\mathbb{R}] = [\\mathbb{C}:\\mathbb{R}] = 2$ to show any intermediate field $K$ has $[K:\\mathbb{R}] \\in \\{1, 2\\}$. The proof derives the upper bound from the multiplicative constraint and uses `interval_cases` to enumerate possibilities.",
+    "significance": "major"
+  }
+]

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04/index.ts
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04/index.ts
@@ -1,0 +1,39 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FundamentalTheoremAlgebraOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fundamentalTheoremAlgebraOQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fundamentalTheoremAlgebraOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fundamentalTheoremAlgebraOQ04Data: ProofData = {
+  proof: fundamentalTheoremAlgebraOQ04Proof,
+  annotations: fundamentalTheoremAlgebraOQ04Annotations,
+  tacticStates: [],
+}
+
+export default fundamentalTheoremAlgebraOQ04Data

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "fundamental-theorem-algebra-oq-04",
+  "title": "C is the Unique Algebraic Closure of R",
+  "slug": "fundamental-theorem-algebra-oq-04",
+  "description": "Proves that the complex numbers C form the unique algebraic closure of the reals R: C is algebraically closed and algebraic over R (making it an algebraic closure), any algebraic closure of R is R-algebra isomorphic to C (Steinitz uniqueness), [C:R] = 2 with no intermediate fields, and R is not algebraically closed (X^2+1 has no real root).",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FundamentalTheoremAlgebraOQ04.lean",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "algebraic-closure",
+      "complex-numbers",
+      "steinitz-theorem",
+      "wiedijk-100"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 207,
+    "assumptions": "None. Fully verified with 0 axioms, 0 sorries. The algebraic closure property delegates to Mathlib's Complex.isAlgClosed; algebraicity follows from the finite extension degree [C:R] = 2; uniqueness uses IsAlgClosure.equiv (Steinitz theorem). All original contributions are fully machine-checked.",
+    "originalContributions": [
+      "complex_algebraic_over_reals: proved C/R is algebraic via finite extension chain",
+      "complex_is_alg_closure: assembled IsAlgClosure instance combining algebraic closure + algebraicity",
+      "unique_algebraic_closure: Steinitz uniqueness for R via IsAlgClosure.equiv",
+      "reals_not_alg_closed: R is not algebraically closed (X^2+1 has no real root)",
+      "charQuad: characteristic real quadratic X^2 - 2Re(z)X + |z|^2 for any z in C",
+      "is_root_charQuad: every z in C satisfies its characteristic quadratic over R",
+      "no_intermediate_field: tower law argument showing no proper intermediate fields between R and C",
+      "closure_degree_is_two: combined statement [C:R]=2 and IsAlgClosure R C"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.isAlgClosed",
+        "description": "C is algebraically closed",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Complex.finrank_real_complex",
+        "description": "[C:R] = 2",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      },
+      {
+        "theorem": "IsAlgClosure.equiv",
+        "description": "Algebraic closures are unique up to isomorphism (Steinitz)",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Algebra.IsAlgebraic.of_finite",
+        "description": "Finite extensions are algebraic",
+        "module": "Mathlib.RingTheory.Algebraic.Basic"
+      },
+      {
+        "theorem": "Module.finrank_mul_finrank",
+        "description": "Tower law for finite extensions",
+        "module": "Mathlib.LinearAlgebra.FreeModule.Finite.Rank"
+      }
+    ],
+    "dateAdded": "2026-03-24"
+  },
+  "overview": {
+    "problemStatement": "Is $\\mathbb{C}$ the unique algebraic closure of $\\mathbb{R}$? Formally: (1) Is $\\mathbb{C}$ an algebraic closure of $\\mathbb{R}$ (algebraically closed + algebraic over $\\mathbb{R}$)? (2) Is any algebraic closure of $\\mathbb{R}$ isomorphic to $\\mathbb{C}$ as an $\\mathbb{R}$-algebra? (3) Is $\\mathbb{C}$ minimal (no proper intermediate algebraically closed field)?",
+    "text": "A 207-line verified formalization proving $\\mathbb{C}$ is the unique algebraic closure of $\\mathbb{R}$, with 0 sorries and 0 axioms. The proof establishes eight results: (1) $[\\mathbb{C}:\\mathbb{R}] = 2$ via Mathlib's `finrank_real_complex`; (2) $\\mathbb{C}/\\mathbb{R}$ is algebraic since finite extensions are algebraic; (3) $\\mathbb{C}$ is an algebraic closure combining algebraic closure with algebraicity; (4) any algebraic closure $L$ of $\\mathbb{R}$ satisfies $L \\cong_{\\mathbb{R}} \\mathbb{C}$ by Steinitz's theorem; (5) $\\mathbb{R}$ is not algebraically closed ($X^2 + 1 > 0$ for all $x \\in \\mathbb{R}$); (6) every $z \\in \\mathbb{C}$ is a root of $X^2 - 2\\mathrm{Re}(z)X + |z|^2 \\in \\mathbb{R}[X]$; (7) the tower law forces any intermediate field to have degree 1 or 2 over $\\mathbb{R}$; (8) the single quadratic extension $\\mathbb{R} \\to \\mathbb{C} = \\mathbb{R}[i]/(i^2+1)$ suffices.",
+    "proofStrategy": "The proof combines three threads from Mathlib:\n\n1. **Algebraic closure**: `Complex.isAlgClosed` (via Liouville's theorem) gives that $\\mathbb{C}$ is algebraically closed. Since $[\\mathbb{C}:\\mathbb{R}] = 2 < \\infty$, the extension is finite $\\implies$ integral $\\implies$ algebraic. Combining these yields `IsAlgClosure \\mathbb{R} \\mathbb{C}`.\n\n2. **Uniqueness (Steinitz)**: `IsAlgClosure.equiv` provides an $\\mathbb{R}$-algebra isomorphism between any two algebraic closures. Applying it with $L$ and $\\mathbb{C}$ gives $L \\cong_{\\mathbb{R}} \\mathbb{C}$.\n\n3. **Minimality (Tower Law)**: For any intermediate field $\\mathbb{R} \\subseteq K \\subseteq \\mathbb{C}$, the tower law gives $[\\mathbb{C}:K] \\cdot [K:\\mathbb{R}] = [\\mathbb{C}:\\mathbb{R}] = 2$. Since both factors are positive, $[K:\\mathbb{R}] \\in \\{1, 2\\}$, meaning $K = \\mathbb{R}$ or $K = \\mathbb{C}$.",
+    "keyInsights": [
+      "**One Extension Suffices**: Adjoining a single element $i = \\sqrt{-1}$ to $\\mathbb{R}$ creates an algebraically closed field. This is exceptional: $\\overline{\\mathbb{Q}}$ requires infinitely many extensions, and $p$-adic fields $\\mathbb{Q}_p$ need uncountably many. The special property of $\\mathbb{R}$ is that it is real-closed: an ordered field where every positive element has a square root and every odd-degree polynomial has a root.",
+      "**Degree 2 is Minimal and Maximal**: $[\\mathbb{C}:\\mathbb{R}] = 2$ is simultaneously the smallest possible nontrivial extension and already enough to close the field. The Artin-Schreier theorem explains why: a field $F$ is real-closed iff $F(\\sqrt{-1})$ is algebraically closed, and any finite extension of a real-closed field has degree 1 or 2.",
+      "**Steinitz Uniqueness**: All algebraic closures of a given field are isomorphic (Steinitz 1910). This is a non-constructive result: the isomorphism uses Zorn's lemma to extend embeddings. For $\\mathbb{R}$, the isomorphism is actually computable (every algebraic closure is $\\mathbb{R}$-isomorphic to $\\mathbb{C}$ via explicit coordinates), but the general theorem applies uniformly.",
+      "**No Intermediate Algebraically Closed Fields**: The tower law argument shows there are no fields properly between $\\mathbb{R}$ and $\\mathbb{C}$. Combined with the fact that $\\mathbb{R}$ is not algebraically closed ($X^2 + 1$ has no real root), this means $\\mathbb{C}$ is the unique minimal algebraically closed extension."
+    ]
+  },
+  "sections": [
+    {
+      "id": "extension-degree",
+      "title": "Extension Degree [C:R] = 2",
+      "startLine": 37,
+      "endLine": 49,
+      "summary": "Establishes that C is a 2-dimensional R-vector space using Mathlib's Complex.finrank_real_complex.",
+      "mathContext": "$[\\mathbb{C}:\\mathbb{R}] = \\dim_{\\mathbb{R}} \\mathbb{C} = 2$, with basis $\\{1, i\\}$. This is the fundamental structural fact about the extension."
+    },
+    {
+      "id": "algebraicity",
+      "title": "C is Algebraic over R",
+      "startLine": 51,
+      "endLine": 60,
+      "summary": "Since [C:R] = 2 < infinity, the extension is finite hence algebraic. Every z in C satisfies a polynomial of degree at most 2 over R.",
+      "mathContext": "Finite $\\implies$ integral $\\implies$ algebraic: if $[K:F] < \\infty$ then every $\\alpha \\in K$ satisfies a polynomial over $F$ of degree $\\leq [K:F]$."
+    },
+    {
+      "id": "algebraic-closure",
+      "title": "C is an Algebraic Closure of R",
+      "startLine": 62,
+      "endLine": 75,
+      "summary": "Combines Complex.isAlgClosed with algebraicity to construct the IsAlgClosure instance.",
+      "mathContext": "$\\mathbb{C}$ is an algebraic closure of $\\mathbb{R}$: algebraically closed (Mathlib) + algebraic over $\\mathbb{R}$ (finite extension)."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness via Steinitz's Theorem",
+      "startLine": 77,
+      "endLine": 88,
+      "summary": "Any algebraic closure L of R is R-algebra isomorphic to C, via IsAlgClosure.equiv (Steinitz's theorem).",
+      "mathContext": "Steinitz (1910): if $K_1, K_2$ are algebraic closures of $R$, there exists an $R$-algebra isomorphism $K_1 \\cong_R K_2$. Applied with $K_1 = L$, $K_2 = \\mathbb{C}$."
+    },
+    {
+      "id": "reals-not-closed",
+      "title": "R is Not Algebraically Closed",
+      "startLine": 90,
+      "endLine": 111,
+      "summary": "X^2 + 1 has no real root since x^2 + 1 > 0 for all x in R, proving R is not algebraically closed.",
+      "mathContext": "$x^2 + 1 > 0$ for all $x \\in \\mathbb{R}$ (by positivity), so $X^2 + 1 \\in \\mathbb{R}[X]$ is a degree-2 polynomial with no root."
+    },
+    {
+      "id": "characteristic-quadratic",
+      "title": "Characteristic Real Quadratic",
+      "startLine": 113,
+      "endLine": 143,
+      "summary": "Defines charQuad z = X^2 - 2Re(z)X + |z|^2 and proves both z and its conjugate are roots.",
+      "mathContext": "For $z = a + bi$: $z^2 - 2az + (a^2+b^2) = (z-a)^2 + b^2 - b^2 I^2 - 2abi + 2abi = 0$. The conjugate $\\bar{z}$ is also a root since $\\mathrm{Re}(\\bar{z}) = \\mathrm{Re}(z)$ and $|\\bar{z}|^2 = |z|^2$."
+    },
+    {
+      "id": "minimality",
+      "title": "Minimality via Tower Law",
+      "startLine": 145,
+      "endLine": 173,
+      "summary": "The tower law [C:K]*[K:R] = [C:R] = 2 forces any intermediate field K to have [K:R] = 1 or 2.",
+      "mathContext": "For $\\mathbb{R} \\subseteq K \\subseteq \\mathbb{C}$: $[\\mathbb{C}:K] \\cdot [K:\\mathbb{R}] = 2$ with both factors positive $\\implies [K:\\mathbb{R}] \\in \\{1,2\\}$."
+    },
+    {
+      "id": "quadratic-extension",
+      "title": "The Quadratic Extension",
+      "startLine": 175,
+      "endLine": 198,
+      "summary": "Establishes i^2 = -1 and z = Re(z) + Im(z)*i, combining the degree and closure results.",
+      "mathContext": "$\\mathbb{C} = \\mathbb{R}[i]/(i^2+1)$: a single quadratic extension closes $\\mathbb{R}$. Contrast: $\\overline{\\mathbb{Q}}$ requires infinitely many extensions."
+    }
+  ],
+  "conclusion": {
+    "summary": "The complex numbers form the unique algebraic closure of the reals, requiring only a single degree-2 extension. This is a deep structural result connecting algebra (algebraic closure), analysis (completeness of R), and field theory (Steinitz uniqueness).",
+    "implications": "This result explains why C is the natural setting for polynomial algebra: it is the smallest field containing R where every polynomial splits. The uniqueness means there is essentially one way to complete R algebraically. The degree [C:R] = 2 being prime means no intermediate algebraically closed fields exist, making C minimal.",
+    "openQuestions": [
+      "The Artin-Schreier theorem characterizes real-closed fields: F is real-closed iff F(sqrt(-1)) is algebraically closed. Can we formalize this generalization and show FTA is the special case F = R?",
+      "Can we formalize that C is the unique algebraically closed field of cardinality continuum and characteristic 0 (up to isomorphism), a stronger uniqueness result?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "extends",
+      "description": "The base FTA proof establishes C is algebraically closed; this proof extends it to show C is the unique algebraic closure of R"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "complementary",
+      "description": "FTA+uniqueness guarantees roots exist in the unique C; Abel-Ruffini shows they cannot always be expressed by radicals"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Polynomial", "Complex"],
+    "namespace": "FTAUniqueAlgebraicClosure",
+    "lineCount": 207,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2
+  }
+}


### PR DESCRIPTION
## Summary
Two new verified gallery proofs, both with **0 sorries and 0 axioms**:

### 1. fundamental-theorem-algebra-oq-04 (207 lines)
**C is the Unique Algebraic Closure of R** - Fixed 5 build errors in existing Lean file and created gallery entry.
- `[C:R] = 2` via Mathlib's `finrank_real_complex`
- `IsAlgClosure R C` instance (algebraically closed + algebraic)
- Steinitz uniqueness: any algebraic closure of R is R-isomorphic to C
- Tower law: no intermediate fields between R and C
- Characteristic quadratic: every z in C satisfies a real polynomial of degree 2

### 2. cantor-diagonalization-oq-03 (149 lines)
**Lawvere Fixed-Point Theorem** - Written from scratch. Unifies Cantor, Russell, and halting problem.
- Lawvere theorem: surjective e : A -> (A -> B) implies every f : B -> B has a fixed point
- Cantor's theorem as corollary (Not has no Prop fixed point)
- Decidable version for Bool
- Russell's paradox as Cantor restated
- Explicit diagonal non-membership construction

## Test plan
- [x] Docker build passes for both proofs
- [x] 0 sorries, 0 axioms verified for both
- [ ] Gallery renders correctly on website

🤖 Generated with [Claude Code](https://claude.com/claude-code)