### PR TITLE
Fix erdos-1089 metadata: sorry count 2→0, lineCount update

### DIFF
--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -19,7 +19,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1089,
     "erdosUrl": "https://erdosproblems.com/1089",
     "erdosProblemStatus": "open",
@@ -76,7 +76,7 @@
       "Threshold functions and extremal combinatorics",
       "Filter-based limits in Lean (Filter.Tendsto)"
     ],
-    "lineCount": 239,
+    "lineCount": 307,
     "relatedProblems": [
       {
         "id": "erdos-1083",
@@ -241,7 +241,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 239,
+    "lineCount": 307,
     "structureCount": 0,
     "axiomCount": 10,
     "theoremCount": 5,


### PR DESCRIPTION
## Fix

Update erdos-1089 meta.json: sorries were eliminated by prior research but metadata was not updated.

## Evidence

**Before**: `sorries: 2`, `lineCount: 239`
**After**: `sorries: 0`, `lineCount: 307`

Verified: `pnpm build` passes. `grep -c '\bsorry\b'` on the Lean file (with comments stripped) returns 0.

---
Automated fix by lean-mechanic agent.