### PR TITLE
Fix: remove unrelated ConjecturedFormula from erdos-674 Aristotle companion

### DIFF
--- a/proofs/Proofs/Erdos674Aristotle.lean
+++ b/proofs/Proofs/Erdos674Aristotle.lean
@@ -53,15 +53,12 @@ theorem koY_value : koY = 1679616 := by sorry
 theorem koZ_value : koZ = 4478976 := by sorry
 
 -- ═══════════════════════════════════════════════════════════════════
--- Section 2: Conjectured Formula Properties
+-- Section 2: Symmetry and Small Cases
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- The conjectured formula: (k-1)(n-1) + 1. -/
-def ConjecturedFormula (k n : ℕ) : ℕ := (k - 1) * (n - 1) + 1
-
-/-- The conjectured formula is monotone in both arguments. -/
-theorem formula_mono (k₁ k₂ n₁ n₂ : ℕ) (hk : k₁ ≤ k₂) (hn : n₁ ≤ n₂) :
-    ConjecturedFormula k₁ n₁ ≤ ConjecturedFormula k₂ n₂ := by sorry
+/-- Swapping x and y preserves the product x^x * y^y. -/
+theorem swap_preserves_eq (x y z : ℕ) :
+    x ^ x * y ^ y = z ^ z → y ^ y * x ^ x = z ^ z := by sorry
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 3: GCD and Divisibility Lemmas


### PR DESCRIPTION
## Fix

Remove unrelated `ConjecturedFormula(k,n) = (k-1)(n-1)+1` and `formula_mono` from the Erdős #674 Aristotle companion file. These definitions belong to a different problem and were incorrectly included. Replaced with `swap_preserves_eq`, a symmetry lemma relevant to the x^x y^y = z^z equation.

## Evidence

**Before**: Section 2 contained `ConjecturedFormula` and `formula_mono` — unrelated to Erdős #674
**After**: Section 2 contains `swap_preserves_eq` — relevant symmetry lemma for x^x y^y = z^z

---
Automated fix by lean-mechanic agent.