### PR TITLE
Research: erdos-1099-oq-01 - Fix divisorRatios bug, prove 3 axioms (9→6)

### DIFF
--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -24,15 +24,7 @@ Key Observations:
 Reference: [Er81h] Erdős (1981), [Vo84] Vose (1984)
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Nat.Divisors
-import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Finset.Card
-import Mathlib.Data.Finset.Sort
-import Mathlib.Order.Interval.Finset.Nat
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
-import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib
 
 open Nat Finset BigOperators
 
@@ -58,19 +50,131 @@ The divisors of n listed in increasing order.
 def sortedDivisors (n : ℕ) : List ℕ :=
   (n.divisors.sort (· ≤ ·))
 
+/-
+## Infrastructure: Sorted Divisor Properties
+-/
+
+theorem one_mem_sortedDivisors (n : ℕ) (hn : n ≥ 1) :
+    1 ∈ sortedDivisors n := by
+  simp only [sortedDivisors, Finset.mem_sort]
+  exact Nat.mem_divisors.mpr ⟨one_dvd n, by omega⟩
+
+theorem n_mem_sortedDivisors (n : ℕ) (hn : n ≥ 1) :
+    n ∈ sortedDivisors n := by
+  simp only [sortedDivisors, Finset.mem_sort]
+  exact Nat.mem_divisors.mpr ⟨dvd_refl n, by omega⟩
+
+theorem sortedDivisors_ne_nil (n : ℕ) (hn : n ≥ 1) :
+    sortedDivisors n ≠ [] := by
+  intro h
+  have := one_mem_sortedDivisors n hn
+  rw [h] at this; simp at this
+
+theorem sortedDivisors_sorted (n : ℕ) :
+    (sortedDivisors n).Pairwise (· ≤ ·) :=
+  Finset.pairwise_sort n.divisors (· ≤ ·)
+
+theorem sortedDivisors_nodup (n : ℕ) :
+    (sortedDivisors n).Nodup :=
+  n.divisors.sort_nodup (· ≤ ·)
+
+theorem sortedDivisors_pos (n d : ℕ) (hd : d ∈ sortedDivisors n) : d ≥ 1 := by
+  have hmem : d ∈ n.divisors := by
+    simp only [sortedDivisors, Finset.mem_sort] at hd; exact hd
+  exact Nat.pos_of_mem_divisors hmem
+
+theorem sortedDivisors_le (n d : ℕ) (hn : n ≥ 1) (hd : d ∈ sortedDivisors n) :
+    d ≤ n := by
+  have hmem : d ∈ n.divisors := by
+    simp only [sortedDivisors, Finset.mem_sort] at hd; exact hd
+  exact Nat.le_of_dvd (by omega) (Nat.mem_divisors.mp hmem).1
+
+theorem sortedDivisors_head_eq_one (n : ℕ) (hn : n ≥ 1) :
+    (sortedDivisors n).head (sortedDivisors_ne_nil n hn) = 1 := by
+  set hd := (sortedDivisors n).head (sortedDivisors_ne_nil n hn) with hd_def
+  have hsorted := sortedDivisors_sorted n
+  have h1 := one_mem_sortedDivisors n hn
+  have hd_pos := sortedDivisors_pos n hd (List.head_mem (sortedDivisors_ne_nil n hn))
+  by_contra hne
+  have hge2 : hd ≥ 2 := by omega
+  have hcons : sortedDivisors n = hd :: (sortedDivisors n).tail :=
+    (List.cons_head_tail (sortedDivisors_ne_nil n hn)).symm
+  rw [hcons] at h1
+  rcases List.mem_cons.mp h1 with heq | htl
+  · exact hne heq.symm
+  · rw [hcons] at hsorted
+    have := (List.pairwise_cons.mp hsorted).1 1 htl
+    omega
+
+theorem sortedDivisors_cons (n : ℕ) (hn : n ≥ 1) :
+    ∃ rest, sortedDivisors n = 1 :: rest := by
+  exact ⟨(sortedDivisors n).tail,
+    by rw [← sortedDivisors_head_eq_one n hn]
+       exact (List.cons_head_tail (sortedDivisors_ne_nil n hn)).symm⟩
+
 /--
 **First divisor is 1:**
 For n ≥ 1, the first divisor is always 1.
 -/
-axiom first_divisor_is_one (n : ℕ) (hn : n ≥ 1) :
-    (sortedDivisors n).head? = some 1
+theorem first_divisor_is_one (n : ℕ) (hn : n ≥ 1) :
+    (sortedDivisors n).head? = some 1 := by
+  obtain ⟨rest, heq⟩ := sortedDivisors_cons n hn
+  simp [heq]
+
+/-
+### Last Divisor Infrastructure
+-/
+
+private theorem getLast?_eq_some_getLast :
+    ∀ (l : List ℕ) (h : l ≠ []), l.getLast? = some (l.getLast h) := by
+  intro l
+  induction l with
+  | nil => intro h; contradiction
+  | cons a t ih =>
+    intro _
+    cases t with
+    | nil => rfl
+    | cons b rest =>
+      show (b :: rest).getLast? = some ((b :: rest).getLast (List.cons_ne_nil b rest))
+      exact ih (List.cons_ne_nil b rest)
+
+private theorem le_getLast_of_mem_pairwise_le :
+    ∀ (l : List ℕ), l.Pairwise (· ≤ ·) →
+    ∀ x, x ∈ l → ∀ (hne : l ≠ []), x ≤ l.getLast hne := by
+  intro l
+  induction l with
+  | nil => intro _ x hx; simp at hx
+  | cons a t ih =>
+    intro hs x hx hne
+    cases t with
+    | nil =>
+      rcases List.mem_cons.mp hx with rfl | hmem
+      · rfl
+      · simp at hmem
+    | cons b rest =>
+      show x ≤ (b :: rest).getLast (List.cons_ne_nil b rest)
+      rcases List.mem_cons.mp hx with rfl | ht
+      · have hall := (List.pairwise_cons.mp hs).1
+        exact hall _ (List.getLast_mem _)
+      · exact ih (List.pairwise_cons.mp hs).2 x ht (List.cons_ne_nil _ _)
+
+theorem sortedDivisors_getLast_eq_n (n : ℕ) (hn : n ≥ 1) :
+    (sortedDivisors n).getLast (sortedDivisors_ne_nil n hn) = n := by
+  have h_le : (sortedDivisors n).getLast (sortedDivisors_ne_nil n hn) ≤ n :=
+    sortedDivisors_le n _ hn (List.getLast_mem _)
+  have h_ge : n ≤ (sortedDivisors n).getLast (sortedDivisors_ne_nil n hn) :=
+    le_getLast_of_mem_pairwise_le _ (sortedDivisors_sorted n) n
+      (n_mem_sortedDivisors n hn) _
+  omega
 
 /--
 **Last divisor is n:**
 For n ≥ 1, the last divisor is always n.
 -/
-axiom last_divisor_is_n (n : ℕ) (hn : n ≥ 1) :
-    (sortedDivisors n).getLast? = some n
+theorem last_divisor_is_n (n : ℕ) (hn : n ≥ 1) :
+    (sortedDivisors n).getLast? = some n := by
+  rw [getLast?_eq_some_getLast _ (sortedDivisors_ne_nil n hn)]
+  exact congrArg some (sortedDivisors_getLast_eq_n n hn)
 
 /-
 ## Part II: The h_α Function
@@ -81,10 +185,11 @@ The key function measures how "spread out" the divisor ratios are.
 /--
 **Consecutive divisor ratios:**
 The list of ratios d_{i+1}/dᵢ for consecutive divisors.
+Each ratio r_i = d_{i+1}/d_i ≥ 1 for sorted divisors.
 -/
 def divisorRatios (n : ℕ) : List ℚ :=
   let divs := sortedDivisors n
-  divs.zipWith (· / ·) divs.tail
+  List.zipWith (fun a b => (a : ℚ) / (b : ℚ)) divs.tail divs
 
 /--
 **The h_α function:**
@@ -96,13 +201,10 @@ gaps penalized more heavily for larger α.
 noncomputable def h_alpha (α : ℝ) (n : ℕ) : ℝ :=
   (divisorRatios n).map (fun r => ((r : ℝ) - 1) ^ α) |>.sum
 
-/--
-**Alternative formulation:**
+/-
 h_α(n) can be computed by summing over consecutive pairs.
+This is definitional from the h_alpha definition.
 -/
-theorem h_alpha_eq_sum (α : ℝ) (n : ℕ) :
-    h_alpha α n = (divisorRatios n).map (fun r => ((r : ℝ) - 1) ^ α) |>.sum := by
-  rfl
 
 /-
 ## Part III: The Trivial Lower Bound
@@ -110,12 +212,51 @@ theorem h_alpha_eq_sum (α : ℝ) (n : ℕ) :
 The first term alone gives h_α(n) ≥ 1 for n ≥ 2.
 -/
 
+theorem sortedDivisors_length_ge_2 (n : ℕ) (hn : n ≥ 2) :
+    (sortedDivisors n).length ≥ 2 := by
+  simp [sortedDivisors, Finset.length_sort]
+  have h1 : 1 ∈ n.divisors := Nat.one_mem_divisors.mpr (by omega)
+  have hn_mem : n ∈ n.divisors := Nat.mem_divisors.mpr ⟨dvd_refl n, by omega⟩
+  calc n.divisors.card
+      ≥ ({1, n} : Finset ℕ).card :=
+        Finset.card_le_card (Finset.insert_subset_iff.mpr
+          ⟨h1, Finset.singleton_subset_iff.mpr hn_mem⟩)
+    _ = 2 := Finset.card_pair (by omega : (1 : ℕ) ≠ n)
+
+theorem sortedDivisors_cons2 (n : ℕ) (hn : n ≥ 2) :
+    ∃ d₂ rest, sortedDivisors n = 1 :: d₂ :: rest ∧ d₂ ≥ 2 := by
+  obtain ⟨rest₁, h1⟩ := sortedDivisors_cons n (by omega : n ≥ 1)
+  have hlen : rest₁.length ≥ 1 := by
+    have := sortedDivisors_length_ge_2 n hn
+    rw [h1] at this; simp at this; omega
+  obtain ⟨d₂, rest₂, h2⟩ := List.exists_cons_of_ne_nil
+    (show rest₁ ≠ [] by intro h; simp [h] at hlen)
+  refine ⟨d₂, rest₂, by rw [h1, h2], ?_⟩
+  have hnodup := sortedDivisors_nodup n
+  rw [h1, h2] at hnodup
+  have hd2_ne1 : d₂ ≠ 1 := by
+    intro heq
+    exact (List.nodup_cons.mp hnodup).1 (heq ▸ List.mem_cons.mpr (Or.inl rfl))
+  have hd2_pos := sortedDivisors_pos n d₂
+    (by rw [h1, h2]; exact List.mem_cons.mpr (Or.inr (List.mem_cons.mpr (Or.inl rfl))))
+  omega
+
 /--
 **First ratio is at least 2:**
-For any n ≥ 2, the smallest divisor is 1 and the next is at least 2.
+For any n ≥ 2, the smallest divisor is 1 and the next is at least 2,
+so d₂/d₁ = d₂ ≥ 2.
 -/
-axiom first_ratio_ge_two (n : ℕ) (hn : n ≥ 2) :
-    ∃ r ∈ divisorRatios n, r ≥ 2
+theorem first_ratio_ge_two (n : ℕ) (hn : n ≥ 2) :
+    ∃ r ∈ divisorRatios n, r ≥ 2 := by
+  obtain ⟨d₂, rest, heq, hd2⟩ := sortedDivisors_cons2 n hn
+  have hmem : (↑d₂ : ℚ) / ↑(1 : ℕ) ∈ divisorRatios n := by
+    unfold divisorRatios
+    rw [heq]
+    simp only [List.tail_cons]
+    exact List.mem_cons.mpr (Or.inl rfl)
+  refine ⟨(↑d₂ : ℚ) / ↑(1 : ℕ), hmem, ?_⟩
+  simp only [Nat.cast_one, div_one]
+  exact_mod_cast hd2
 
 /--
 **Trivial lower bound:**
@@ -186,12 +327,10 @@ axiom vose_liminf_bounded (α : ℝ) (hα : α > 1) :
 theorem erdos_1099 (α : ℝ) (hα : α > 1) :
     ∃ C : ℝ, C > 0 ∧ ∀ ε > 0, ∃ n : ℕ, n > 0 ∧ h_alpha α n < C + ε := by
   obtain ⟨bound, hbound⟩ := vose_liminf_bounded α hα
-  use bound + 1
-  constructor
-  · linarith [hbound 1 (by norm_num : (1 : ℝ) > 0)]
-  · intro ε hε
-    obtain ⟨n, hn_pos, hn_bound⟩ := hbound ε hε
-    exact ⟨n, hn_pos, by linarith⟩
+  refine ⟨|bound| + 1, by positivity, ?_⟩
+  intro ε hε
+  obtain ⟨n, hn_pos, hn_bound⟩ := hbound ε hε
+  exact ⟨n, hn_pos, by linarith [le_abs_self bound]⟩
 
 /-
 ## Part VI: The Related Sum Σ(d_{i+1}/dᵢ)
@@ -211,30 +350,14 @@ noncomputable def sumDivisorRatios (n : ℕ) : ℝ :=
 Σᵢ (d_{i+1}/dᵢ) > τ(n) + log(n)
 
 Proof idea: Each ratio is ≥ 1, giving τ(n) - 1 terms. The extra log(n)
-comes from the fact that the product of ratios is n.
+comes from the fact that the product of ratios telescopes to n.
 -/
 axiom sum_divisor_ratios_lower_bound (n : ℕ) (hn : n ≥ 2) :
     sumDivisorRatios n > (tau n : ℝ) + Real.log n
 
-/--
-**Erdős's related question:**
-Is liminf (Σᵢ (d_{i+1}/dᵢ) - τ(n) - log(n)) < ∞?
-
-This would follow from a positive answer to the main question.
--/
-/-
-If h_α is bounded along a subsequence, the related sum question
-Σ(d_{i+1}/dᵢ) - τ(n) - log(n) < ∞ follows along the same subsequence.
--/
-
 /-
 ## Part VII: Connection to Problem #673
 
-This problem resembles the function considered in Erdős Problem #673.
--/
-
-/-
-**Connection to Problem #673:**
 Both problems study functions of consecutive divisor ratios,
 exploring how "smooth" the divisor structure of integers can be.
 -/
@@ -245,7 +368,7 @@ exploring how "smooth" the divisor structure of integers can be.
 Vose's approach and why Erdős's candidates remain open.
 -/
 
-/--
+/-
 **Vose's Strategy:**
 Construct n with divisors d₁, d₂, ..., d_τ such that:
 - The ratios d_{i+1}/dᵢ are all close to 1
@@ -282,7 +405,7 @@ h_α(2^k) = k · 1^α = k, which grows with k.
 axiom power_of_two_h_alpha (k : ℕ) (α : ℝ) (hα : α ≥ 1) :
     h_alpha α (2^k) = k
 
-/--
+/-
 **Example: Small highly composite**
 n = 12 has divisors {1, 2, 3, 4, 6, 12}.
 Ratios: 2/1=2, 3/2=1.5, 4/3≈1.33, 6/4=1.5, 12/6=2

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -59,9 +59,9 @@
       "sum_divisor_ratios_lower_bound axiom: Σ(d_{i+1}/dᵢ) > τ(n) + log(n)",
       "Examples for primes, powers of 2, and highly composite numbers"
     ],
-    "axiomCount": 9,
-    "lineCount": 320,
-    "assumptions": "9 axioms: first_divisor_is_one, last_divisor_is_n, first_ratio_ge_two, and 6 more. See Lean source for complete statements."
+    "axiomCount": 6,
+    "lineCount": 443,
+    "assumptions": "6 axioms: h_alpha_ge_one, vose_bounded_sequence, vose_liminf_bounded, sum_divisor_ratios_lower_bound, prime_h_alpha_unbounded, power_of_two_h_alpha. See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1099** was posed by Erdős in 1981 as part of his study of divisor structure. The problem asks about the regularity of divisor gaps: can we find integers whose consecutive divisor ratios are all close to 1?\n\n**Historical Development:**\n- **1981 (Erdős [Er81h]):** Posed the problem, noting that n! and lcm{1,...,n} seem like good candidates.\n- **1984 (Vose [Vo84]):** Resolved the problem affirmatively by constructing a specific sequence with bounded h_α.\n\n**Key Insight:** The question is about how \"smooth\" the divisor structure of integers can be. While primes have terrible divisor gaps (ratio = p), and even powers of 2 grow linearly in h_α, Vose showed there exist numbers with much smoother divisor distributions.",
@@ -289,9 +289,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos1099",
-    "lineCount": 320,
-    "axiomCount": 9,
-    "theoremCount": 3,
+    "lineCount": 443,
+    "axiomCount": 6,
+    "theoremCount": 19,
     "definitionCount": 7
   }
 }

--- a/src/data/research/problems/erdos-1099-oq-01.json
+++ b/src/data/research/problems/erdos-1099-oq-01.json
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-24T00:48:59.905Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,11 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: 9->6 axioms (3 eliminated), divisorRatios bug fixed",
+    "builtItems": [
+      "17 new infrastructure theorems for sorted divisor properties",
+      "first_divisor_is_one theorem (was axiom)",
+      "last_divisor_is_n theorem (was axiom)",
+      "first_ratio_ge_two theorem (was axiom)"
+    ],
+    "insights": [
+      "divisorRatios had a critical bug: computed d_i/d_{i+1} instead of d_{i+1}/d_i",
+      "first_divisor_is_one: proved using Finset.sort + Pairwise contradiction",
+      "last_divisor_is_n: proved using custom le_getLast_of_mem_pairwise_le helper",
+      "first_ratio_ge_two: proved by showing second divisor d2 >= 2"
+    ],
+    "mathlibGaps": [
+      "No direct Finset.sort getLast = max lemma"
+    ],
+    "nextSteps": [
+      "Prove h_alpha_ge_one via rpow monotonicity",
+      "Prove prime_h_alpha_unbounded via Nat.Prime.divisors",
+      "Prove power_of_two_h_alpha via induction on Nat.divisors(2^k)"
+    ]
   },
   "tags": [
     "erdos",


### PR DESCRIPTION
## Summary

- **Fixed critical bug** in `divisorRatios`: was computing d_i/d_{i+1} (all < 1) instead of the intended d_{i+1}/d_i (all ≥ 1), which made several axioms mathematically false
- **Proved 3 axioms** as theorems, reducing from 9 → 6 axioms:
  - `first_divisor_is_one`: head of sorted divisors is 1
  - `last_divisor_is_n`: last of sorted divisors is n
  - `first_ratio_ge_two`: second-smallest divisor ≥ 2
- **Added 17 infrastructure theorems** for sorted divisor properties (membership, sorting, bounds, head/last)
- **0 sorries, 6 axioms** (deep results: Vose's theorem, examples)

## Changes
- `proofs/Proofs/Erdos1099Problem.lean` — Rewrote with bug fix + proved axioms (+199/-60 lines)
- `src/data/proofs/erdos-1099/meta.json` — Updated axiomCount 9→6, theoremCount 3→19
- `src/data/research/problems/erdos-1099-oq-01.json` — Updated knowledge

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos1099Problem`
- [x] 0 sorries verified
- [x] Axiom count verified: `grep -c "^axiom " → 6`