### PR TITLE
chore: audit tracker updates (cycle 3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9192,6 +9192,24 @@
       "lastAudited": "2026-03-24T19:57:18Z",
       "result": "clean",
       "issues": []
+    },
+    "cantor-diagonalization-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T23:11:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-rule-of-signs-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T23:11:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fundamental-theorem-algebra-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-24T23:11:13Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {


### PR DESCRIPTION
## Summary
- Audited 4 proofs: erdos-1089, descartes-rule-of-signs-oq-02, cantor-diagonalization-oq-03, fundamental-theorem-algebra-oq-04
- Filed #6393 (erdos-1089 overview text says 13 axioms, actual 10) and #6395 (fta-oq-04 badge should be mathlib)
- 2 clean, 2 issues-found

## Test plan
- [x] Tracker JSON is valid
- [x] No metadata changes, only tracker updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)