### PR TITLE
Enrich 2 entries: add scholarly references

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02/meta.json
@@ -187,5 +187,32 @@
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Finite-Dimensional Cauchy-Schwarz, AM-GM, Nesbitt, and Titu'"
     }
+  ],
+  "references": [
+    {
+      "key": "Mi96",
+      "citation": "Minkowski, H., Geometrie der Zahlen, Teubner, Leipzig (1896). Introduced the inequality ‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p as a triangle inequality for L^p spaces.",
+      "type": "book"
+    },
+    {
+      "key": "Ho89",
+      "citation": "Hölder, O., Ueber einen Mittelwerthssatz, Nachrichten von der Königlichen Gesellschaft der Wissenschaften und der Georg-Augusts-Universität zu Göttingen (1889), 38–47. Proved Hölder's inequality, which generalizes Cauchy-Schwarz to L^p/L^q duality.",
+      "type": "paper"
+    },
+    {
+      "key": "RS80",
+      "citation": "Reed, M. and Simon, B., Methods of Modern Mathematical Physics I: Functional Analysis, Academic Press (1980), Chapter II. Standard reference for L^p space theory including Minkowski and Hölder inequalities.",
+      "type": "book"
+    },
+    {
+      "key": "Ru87",
+      "citation": "Rudin, W., Real and Complex Analysis, 3rd ed., McGraw-Hill (1987), Chapter 3. Systematic development of L^p spaces with Minkowski and Hölder inequalities via measure theory.",
+      "type": "book"
+    },
+    {
+      "key": "LL01",
+      "citation": "Lieb, E.H. and Loss, M., Analysis, 2nd ed., AMS Graduate Studies in Mathematics 14 (2001), Chapter 2. Modern treatment of integral inequalities including the two-variable Minkowski integral inequality.",
+      "type": "book"
+    }
   ]
 }

--- a/src/data/proofs/central-limit-theorem-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01/meta.json
@@ -178,5 +178,27 @@
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Categorical Structure of Distributions Under Convolution"
     }
+  ],
+  "references": [
+    {
+      "key": "GK54",
+      "citation": "Gnedenko, B.V. and Kolmogorov, A.N., Limit Distributions for Sums of Independent Random Variables, Addison-Wesley (1954, English translation by K.L. Chung). Foundational treatment of stable distributions and domains of attraction.",
+      "type": "book"
+    },
+    {
+      "key": "Fe71",
+      "citation": "Feller, W., An Introduction to Probability Theory and Its Applications, Vol. II, 2nd ed., Wiley (1971), Chapters VIII–XVII. Comprehensive treatment of stable laws, infinite variance, and generalized CLT.",
+      "type": "book"
+    },
+    {
+      "key": "ST94",
+      "citation": "Samorodnitsky, G. and Taqqu, M.S., Stable Non-Gaussian Random Processes: Stochastic Models with Infinite Variance, Chapman & Hall/CRC (1994). Standard reference for stable distributions and their applications.",
+      "type": "book"
+    },
+    {
+      "key": "No07",
+      "citation": "Nolan, J.P., Stable Distributions: Models for Heavy Tailed Data, Birkhäuser (2007, in progress). Modern treatment emphasizing computational aspects of stable distributions.",
+      "type": "book"
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment pass: add scholarly references

Adds missing `references` field to 2 gallery entries:

- **cauchy-schwarz-integral-oq-02**: 5 references (Minkowski 1896, Hölder 1889, Reed-Simon 1980, Rudin 1987, Lieb-Loss 2001)
- **central-limit-theorem-oq-01**: 4 references (Gnedenko-Kolmogorov 1954, Feller 1971, Samorodnitsky-Taqqu 1994, Nolan 2007)