### PR TITLE
Enrich 2 entries: add scholarly references (batch 2)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04/meta.json
@@ -227,5 +227,27 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0
-  }
+  },
+  "references": [
+    {
+      "key": "Va72",
+      "citation": "Vandermonde, A.-T., Mémoire sur des irrationnelles de différens ordres avec une application au cercle, Mémoires de l'Académie royale des Sciences de Paris (1772), 489–498. First statement of the identity now bearing his name.",
+      "type": "paper"
+    },
+    {
+      "key": "GKP94",
+      "citation": "Graham, R.L., Knuth, D.E., and Patashnik, O., Concrete Mathematics, 2nd ed., Addison-Wesley (1994), Chapter 5: Binomial Coefficients. Standard reference for binomial coefficient identities including Vandermonde's.",
+      "type": "book"
+    },
+    {
+      "key": "Ri68",
+      "citation": "Riordan, J., Combinatorial Identities, Wiley (1968). Encyclopedic collection of binomial coefficient identities with multiple proof methods.",
+      "type": "book"
+    },
+    {
+      "key": "PWZ96",
+      "citation": "Petkovšek, M., Wilf, H.S., and Zeilberger, D., A=B, A K Peters (1996). Algorithmic proofs of hypergeometric identities, including Vandermonde's convolution as a key example.",
+      "type": "book"
+    }
+  ]
 }

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -143,5 +143,27 @@
     "axiomCount": 4,
     "theoremCount": 13,
     "definitionCount": 3
-  }
+  },
+  "references": [
+    {
+      "key": "Ma15",
+      "citation": "Maynard, J., Small gaps between primes, Annals of Mathematics 181(1) (2015), 383–413. Proved infinitely many prime gaps ≤ 600, later improved to 246 by Polymath 8b.",
+      "type": "paper"
+    },
+    {
+      "key": "P8b",
+      "citation": "Polymath, D.H.J., Variants of the Selberg sieve, and bounded intervals containing many primes, Research in the Mathematical Sciences 1:12 (2014). Improved Maynard's bound to 246.",
+      "type": "paper"
+    },
+    {
+      "key": "Zh14",
+      "citation": "Zhang, Y., Bounded gaps between primes, Annals of Mathematics 179(3) (2014), 1121–1174. First proof that lim inf(p_{n+1} - p_n) < ∞, with bound 7×10⁷.",
+      "type": "paper"
+    },
+    {
+      "key": "GPY09",
+      "citation": "Goldston, D.A., Pintz, J., and Yıldırım, C.Y., Primes in Tuples I, Annals of Mathematics 170(2) (2009), 819–862. Proved lim inf(p_{n+1} - p_n)/log p_n = 0, laying groundwork for Zhang-Maynard.",
+      "type": "paper"
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment pass: add scholarly references

- **binomial-theorem-oq-04** (Vandermonde's Identity): 4 references (Vandermonde 1772, Graham-Knuth-Patashnik 1994, Riordan 1968, Petkovšek-Wilf-Zeilberger 1996)
- **bounded-prime-gaps-oq-03-oq-01** (Improving 246 Bound): 4 references (Maynard 2015, Polymath 8b 2014, Zhang 2014, Goldston-Pintz-Yıldırım 2009)