### PR TITLE
Enrich 3 entries: add scholarly references (batch 3)

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02/meta.json
@@ -174,5 +174,22 @@
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Ceva's Theorem via Mass Point Geometry"
     }
+  ],
+  "references": [
+    {
+      "key": "Ce78",
+      "citation": "Ceva, G., De lineis rectis se invicem secantibus statica constructio, Mediolani (1678). Original statement of Ceva's theorem on concurrent cevians.",
+      "type": "book"
+    },
+    {
+      "key": "Co67",
+      "citation": "Coxeter, H.S.M., Geometry Revisited (with S.L. Greitzer), MAA (1967), Chapter 1. Classic treatment including Ceva, Menelaus, and their duality.",
+      "type": "book"
+    },
+    {
+      "key": "Ra94",
+      "citation": "Ratcliffe, J.G., Foundations of Hyperbolic Manifolds, Springer GTM 149 (1994). Hyperbolic geometry foundations including non-Euclidean Ceva-type theorems.",
+      "type": "book"
+    }
   ]
 }

--- a/src/data/proofs/chinese-remainder-constructive-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04/meta.json
@@ -174,5 +174,22 @@
       "relationship": "extends",
       "description": "Parent formalization; this entry extends it with further exploration"
     }
+  ],
+  "references": [
+    {
+      "key": "SZ",
+      "citation": "Sun Zi, Sunzi Suanjing (Master Sun's Mathematical Manual), c. 3rd–5th century CE. Earliest known statement of what is now called the Chinese Remainder Theorem.",
+      "type": "book"
+    },
+    {
+      "key": "Ga01",
+      "citation": "Gauss, C.F., Disquisitiones Arithmeticae, Leipzig (1801), §36. First modern formulation of the CRT for arbitrary moduli using congruences.",
+      "type": "book"
+    },
+    {
+      "key": "IR90",
+      "citation": "Ireland, K. and Rosen, M., A Classical Introduction to Modern Number Theory, 2nd ed., Springer GTM 84 (1990), Chapter 3. Modern treatment of CRT with applications to number theory.",
+      "type": "book"
+    }
   ]
 }

--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -171,5 +171,27 @@
       "Mathlib.Tactic"
     ],
     "opens": []
-  }
+  },
+  "references": [
+    {
+      "key": "La85",
+      "citation": "Lagarias, J.C., The 3x+1 problem and its generalizations, The American Mathematical Monthly 92(1) (1985), 3–23. Foundational survey of the Collatz conjecture.",
+      "type": "paper"
+    },
+    {
+      "key": "El93",
+      "citation": "Eliahou, S., The 3x+1 problem: new lower bounds on nontrivial cycle lengths, Discrete Mathematics 118 (1993), 45–56. Non-existence results for small Collatz cycles.",
+      "type": "paper"
+    },
+    {
+      "key": "La10",
+      "citation": "Lagarias, J.C. (ed.), The Ultimate Challenge: The 3x+1 Problem, AMS (2010). Comprehensive collection of results on the Collatz problem.",
+      "type": "book"
+    },
+    {
+      "key": "Ta20",
+      "citation": "Tao, T., Almost all orbits of the Collatz map attain almost bounded values, Forum of Mathematics, Pi 10, e12 (2022). Best known partial result toward the Collatz conjecture.",
+      "type": "paper"
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment pass: add scholarly references

- **cevas-theorem-oq-02**: 3 refs (Ceva 1678, Coxeter-Greitzer 1967, Ratcliffe 1994)
- **chinese-remainder-constructive-oq-04**: 3 refs (Sun Zi, Gauss 1801, Ireland-Rosen 1990)
- **collatz-structured-oq-02**: 4 refs (Lagarias 1985, Eliahou 1993, Lagarias 2010, Tao 2022)