### PR TITLE
Enrich 3 entries: add scholarly references (batch 4)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
@@ -167,5 +167,22 @@
       "relationship": "extends",
       "description": "Parent formalization; this entry extends it with further exploration"
     }
+  ],
+  "references": [
+    {
+      "key": "Bu77",
+      "citation": "Buffon, G.-L.L., Essai d'arithmétique morale, Supplément à l'Histoire Naturelle 4 (1777). Original Buffon needle problem and first geometric probability result.",
+      "type": "paper"
+    },
+    {
+      "key": "Kl04",
+      "citation": "Klain, D.A. and Rota, G.-C., Introduction to Geometric Probability, Cambridge University Press (2004). Modern treatment of geometric probability including higher-dimensional Buffon-type results and kinematic formulas.",
+      "type": "book"
+    },
+    {
+      "key": "Sa04",
+      "citation": "Santaló, L.A., Integral Geometry and Geometric Probability, 2nd ed., Cambridge University Press (2004). Definitive reference for integral geometry including n-dimensional crossing probabilities.",
+      "type": "book"
+    }
   ]
 }

--- a/src/data/proofs/cayley-hamilton-reduction-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01/meta.json
@@ -155,5 +155,22 @@
       "relationship": "sibling",
       "description": "Sibling open question: Minimal Polynomial vs Characteristic Polynomial Reduction"
     }
+  ],
+  "references": [
+    {
+      "key": "CH53",
+      "citation": "Cayley, A., A memoir on the theory of matrices, Philosophical Transactions of the Royal Society of London 148 (1858), 17–37. Original statement of the Cayley-Hamilton theorem.",
+      "type": "paper"
+    },
+    {
+      "key": "HJ13",
+      "citation": "Horn, R.A. and Johnson, C.R., Matrix Analysis, 2nd ed., Cambridge University Press (2013), Chapter 2. Modern treatment of Cayley-Hamilton with applications to matrix functions and polynomials.",
+      "type": "book"
+    },
+    {
+      "key": "La95",
+      "citation": "Lancaster, P. and Tismenetsky, M., The Theory of Matrices, 2nd ed., Academic Press (1985). Comprehensive treatment of matrix polynomials and computational aspects of Cayley-Hamilton reduction.",
+      "type": "book"
+    }
   ]
 }

--- a/src/data/proofs/cevas-theorem-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04/meta.json
@@ -172,5 +172,22 @@
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Ceva's Theorem for Spherical Polygons"
     }
+  ],
+  "references": [
+    {
+      "key": "Ha59",
+      "citation": "Hausner, M., The center of mass and affine geometry, The American Mathematical Monthly 69(8) (1962), 724–737. Early systematic treatment of mass point geometry.",
+      "type": "paper"
+    },
+    {
+      "key": "Co67",
+      "citation": "Coxeter, H.S.M., Geometry Revisited (with S.L. Greitzer), MAA (1967), Chapter 4. Includes mass point methods for Ceva's theorem.",
+      "type": "book"
+    },
+    {
+      "key": "Ce78",
+      "citation": "Ceva, G., De lineis rectis se invicem secantibus statica constructio, Mediolani (1678). Original statement of Ceva's theorem.",
+      "type": "book"
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment pass: add scholarly references

- **cayley-hamilton-reduction-oq-01**: 3 refs (Cayley 1858, Horn-Johnson 2013, Lancaster 1985)
- **buffons-needle-oq-02-oq-01**: 3 refs (Buffon 1777, Klain-Rota 2004, Santaló 2004)
- **cevas-theorem-oq-04**: 3 refs (Hausner 1962, Coxeter 1967, Ceva 1678)