### PR TITLE
Fix: correct ballot-problem-oq-03-oq-02 theoremCount and lineCount

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -63,8 +63,8 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 1885,
-    "theoremCount": 28,
+    "lineCount": 2014,
+    "theoremCount": 79,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
       "Binomial coefficients (Mathlib)",
@@ -256,9 +256,9 @@
       "Finset"
     ],
     "namespace": "LGV",
-    "lineCount": 1885,
+    "lineCount": 2014,
     "axiomCount": 0,
-    "theoremCount": 76,
+    "theoremCount": 79,
     "definitionCount": 29
   },
   "relatedProofs": [


### PR DESCRIPTION
## Fix

Update `meta.json` for ballot-problem-oq-03-oq-02: theoremCount and lineCount were stale after the proof was expanded.

## Evidence

**Before**: `meta.theoremCount = 28`, `leanFile.theoremCount = 76`, `lineCount = 1885`
**After**: `theoremCount = 79` (both locations), `lineCount = 2014` (both locations)

Verified by counting `theorem` and `lemma` declarations outside comments in the Lean file, and `wc -l` for line count. `pnpm build` passes.

---
Automated fix by lean-mechanic agent.