### PR TITLE
Fix: correct e-transcendental-oq-01 theoremCount (13→18)

### DIFF
--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 3,
-    "theoremCount": 13,
+    "theoremCount": 18,
     "mathlibDependencies": [
       {
         "theorem": "Transcendental",


### PR DESCRIPTION
## Fix

Update `meta.theoremCount` for e-transcendental-oq-01 from 13 to 18 to match actual Lean file.

## Evidence

**Before**: `meta.theoremCount = 13` (leanFile section already had 18)
**After**: `meta.theoremCount = 18`

Verified by counting `theorem` and `lemma` declarations outside comments. `pnpm build` passes.

---
Automated fix by lean-mechanic agent.