### PR TITLE
Enrich 2 entries: add scholarly references (batch 6)

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/meta.json
@@ -179,5 +179,27 @@
       "relationship": "extends",
       "description": "Parent formalization; this entry extends it with further exploration"
     }
+  ],
+  "references": [
+    {
+      "key": "Go40",
+      "citation": "Gödel, K., The Consistency of the Axiom of Choice and of the Generalized Continuum Hypothesis with the Axioms of Set Theory, Annals of Mathematics Studies 3, Princeton University Press (1940). Proved Con(ZFC) → Con(ZFC + GCH).",
+      "type": "book"
+    },
+    {
+      "key": "Co63",
+      "citation": "Cohen, P.J., The independence of the continuum hypothesis, Proceedings of the National Academy of Sciences 50(6) (1963), 1143–1148. Proved Con(ZFC) → Con(ZFC + ¬CH) via forcing.",
+      "type": "paper"
+    },
+    {
+      "key": "Wo01",
+      "citation": "Woodin, W.H., The Continuum Hypothesis, Parts I & II, Notices of the AMS 48(6-7) (2001). Survey of large cardinal axioms and their bearing on CH.",
+      "type": "paper"
+    },
+    {
+      "key": "Ku80",
+      "citation": "Kunen, K., Set Theory: An Introduction to Independence Proofs, North-Holland (1980). Standard reference for forcing and independence results.",
+      "type": "book"
+    }
   ]
 }

--- a/src/data/proofs/cramers-rule-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-03/meta.json
@@ -163,5 +163,22 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 3
-  }
+  },
+  "references": [
+    {
+      "key": "GGRW05",
+      "citation": "Gelfand, I., Gelfand, S., Retakh, V., and Wilson, R.L., Quasideterminants, Advances in Mathematics 193(1) (2005), 56–141. Comprehensive treatment of quasideterminants over non-commutative rings.",
+      "type": "paper"
+    },
+    {
+      "key": "Co95",
+      "citation": "Cohn, P.M., Skew Fields: Theory of General Division Rings, Cambridge University Press (1995). Non-commutative algebra foundations including Cramer's rule generalizations.",
+      "type": "book"
+    },
+    {
+      "key": "Dr83",
+      "citation": "Draxl, P.K., Skew Fields, London Mathematical Society Lecture Note Series 81, Cambridge University Press (1983). Introduction to non-commutative determinants and linear algebra over division rings.",
+      "type": "book"
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment pass: add scholarly references

- **continuum-hypothesis-oq-01**: 4 refs (Gödel 1940, Cohen 1963, Woodin 2001, Kunen 1980)
- **cramers-rule-oq-03**: 3 refs (Gelfand et al. 2005, Cohn 1995, Draxl 1983)