### PR TITLE
Fix: correct descartes-rule-of-signs-oq-02 metadata counts

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.derivative",
@@ -67,8 +67,8 @@
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 3,
-    "lineCount": 502,
-    "theoremCount": 36,
+    "lineCount": 552,
+    "theoremCount": 38,
     "defCount": 9,
     "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Fix

Update stale metadata for descartes-rule-of-signs-oq-02 after the proof was expanded.

## Evidence

**Before**: `sorries = 4`, `lineCount = 502`, `theoremCount = 36`
**After**: `sorries = 2`, `lineCount = 552`, `theoremCount = 38`

Verified by grep/counting outside comments in the Lean file. `pnpm build` passes.

---
Automated fix by lean-mechanic agent.