### PR TITLE
chore: audit tracker — erdos-1000 stale metadata (#6418)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1628,9 +1628,9 @@
       "issues": []
     },
     "erdos-1000": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T12:32:57Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T23:22:40Z",
+      "result": "issues-found",
       "issues": []
     },
     "erdos-104": {


### PR DESCRIPTION
## Summary
- Audited erdos-1000: CRITICAL — meta.json has stub values (axiomCount=0, lineCount=1) despite 241-line formalization with 5 axioms
- Filed #6418 as urgent

## Test plan
- [x] Tracker JSON is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)