### PR TITLE
Fix: correct stale lineCount in erdos-1139, erdos-1060, erdos-949

### DIFF
--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -57,7 +57,7 @@
       "mem_A327153_iff theorem: OEIS A327153 membership for n > 0"
     ],
     "axiomCount": 2,
-    "lineCount": 282,
+    "lineCount": 304,
     "assumptions": "2 axiom(s) (open conjectures). All supporting lemmas fully proved."
   },
   "overview": {
@@ -176,7 +176,7 @@
       "Finset"
     ],
     "namespace": "Erdos1060",
-    "lineCount": 268,
+    "lineCount": 304,
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 5

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -50,7 +50,7 @@
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 2,
-    "lineCount": 157,
+    "lineCount": 192,
     "assumptions": "2 axioms: erdos_1139 (the open conjecture), hardy_ramanujan_asymptotic (density estimate). 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/erdos-949/meta.json
+++ b/src/data/proofs/erdos-949/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/949",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 120,
+    "lineCount": 142,
     "assumptions": "2 axioms: sidon_variant_solved, erdos_949_open. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -120,7 +120,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 120,
+    "lineCount": 142,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4


### PR DESCRIPTION
## Fix

Update stale `lineCount` metadata for three proofs whose Lean files grew from research additions.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| erdos-1139 | meta.lineCount | 157 | 192 |
| erdos-1060 | meta.lineCount | 282 | 304 |
| erdos-1060 | leanFile.lineCount | 268 | 304 |
| erdos-949 | meta.lineCount | 120 | 142 |
| erdos-949 | leanFile.lineCount | 120 | 142 |

Verified with `wc -l`. `pnpm build` passes.

---
Automated fix by lean-mechanic agent.