### PR TITLE
Enrich Lawvere Fixed-Point Theorem: add depth, cross-refs, history

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/annotations.json
@@ -2,28 +2,97 @@
   {
     "id": "ann-lawvere-main",
     "proofId": "cantor-diagonalization-oq-03",
-    "range": { "startLine": 39, "endLine": 45 },
-    "type": "key-step",
+    "range": { "startLine": 42, "endLine": 48 },
+    "type": "technique",
     "title": "Lawvere Fixed-Point Theorem",
     "content": "The core 3-line proof: given surjective $e$ and any $f$, obtain $a_0$ with $e(a_0) = \\lambda a. f(e(a)(a))$ by surjectivity, then $e(a_0)(a_0)$ is the fixed point. The diagonal construction $g(a) = f(e(a)(a))$ is the categorical essence of all diagonal arguments.",
-    "significance": "major"
+    "mathContext": "$\\forall f : B \\to B,\\; \\exists b : B,\\; f(b) = b$ whenever $e : A \\to (A \\to B)$ is surjective. The witness is $b = e(a_0)(a_0)$ where $e(a_0) = g$ and $g(a) := f(e(a)(a))$.",
+    "significance": "key",
+    "relatedConcepts": ["diagonal argument", "Lawvere fixed-point theorem", "cartesian closed category", "surjection", "Yanofsky's universal approach"],
+    "prerequisites": ["function surjectivity", "function extensionality"]
+  },
+  {
+    "id": "ann-contrapositive",
+    "proofId": "cantor-diagonalization-oq-03",
+    "range": { "startLine": 58, "endLine": 62 },
+    "type": "technique",
+    "title": "No Fixed-Point-Free Corollary",
+    "content": "The contrapositive of the Lawvere theorem: if some endomorphism $f : B \\to B$ has no fixed point (i.e., $\\forall b,\\; f(b) \\neq b$), then no function $e : A \\to (A \\to B)$ can be surjective. This is the form most directly applied to derive impossibility results.",
+    "mathContext": "$\\neg(\\exists\\, e : A \\to (A \\to B),\\; \\text{Surjective}(e))$ whenever $\\exists f : B \\to B$ with $\\forall b,\\; f(b) \\neq b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["contrapositive reasoning", "impossibility proof", "fixed-point-free map"],
+    "prerequisites": ["Lawvere fixed-point theorem"]
   },
   {
     "id": "ann-lawvere-negation",
     "proofId": "cantor-diagonalization-oq-03",
-    "range": { "startLine": 71, "endLine": 78 },
-    "type": "key-step",
+    "range": { "startLine": 72, "endLine": 80 },
+    "type": "insight",
     "title": "Negation Has No Fixed Point",
-    "content": "If $\\neg p = p$, cast along this equality to get $p \\to \\neg p$ and $\\neg p \\to p$. Define $\\neg p := \\lambda h. (\\mathrm{cast}\\,h^{-1}\\,h)\\,h$ (self-application), then apply to get $p$, yielding contradiction. This uses the same self-referential trick as Russell's paradox.",
-    "significance": "major"
+    "content": "If $\\neg p = p$, cast along this equality to get $p \\to \\neg p$ and $\\neg p \\to p$. Define $\\neg p := \\lambda h.\\, (\\mathrm{cast}\\,h^{-1}\\,h)\\,h$ (self-application), then apply to get $p$, yielding contradiction. This uses the same self-referential trick as Russell's paradox and the liar sentence.",
+    "mathContext": "$\\forall p : \\mathrm{Prop},\\; \\neg p \\neq p$. Proof: assume $\\neg p = p$, then $\\mathrm{cast}(h^{-1}) : p \\to \\neg p$ and $\\mathrm{cast}(h) : \\neg p \\to p$. Construct $\\neg p$ by $\\lambda hp.\\, (\\mathrm{cast}(h^{-1})\\, hp)\\, hp$, then derive $p$ via $\\mathrm{cast}(h)$, contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["liar paradox", "self-reference", "Russell's paradox", "cast in type theory", "proof irrelevance"],
+    "prerequisites": ["propositional logic", "type-theoretic cast/transport"]
   },
   {
     "id": "ann-lawvere-cantor",
     "proofId": "cantor-diagonalization-oq-03",
-    "range": { "startLine": 80, "endLine": 85 },
+    "range": { "startLine": 83, "endLine": 87 },
     "type": "key-step",
-    "title": "Cantor from Lawvere",
-    "content": "Cantor's theorem in 3 lines: assume surjective $e : A \\to (A \\to \\mathrm{Prop})$, apply Lawvere with $f = \\mathrm{Not}$, get fixed point $b$ with $\\neg b = b$, contradicting `not_has_no_fixpoint`.",
-    "significance": "major"
+    "title": "Cantor's Theorem from Lawvere",
+    "content": "Cantor's theorem in 3 lines: assume surjective $e : A \\to (A \\to \\mathrm{Prop})$, apply Lawvere with $f = \\mathrm{Not}$, get fixed point $b$ with $\\neg b = b$, contradicting `not_has_no_fixpoint`. This derivation makes explicit that the only property of $\\mathrm{Prop}$ used is that it admits a fixed-point-free endomorphism.",
+    "mathContext": "$\\neg\\,\\text{Surjective}(e)$ for any $e : A \\to (A \\to \\mathrm{Prop})$. Instantiation: $B = \\mathrm{Prop}$, $f = \\neg$.",
+    "significance": "key",
+    "relatedConcepts": ["Cantor's theorem", "power set", "cardinality", "diagonal argument"],
+    "prerequisites": ["Lawvere fixed-point theorem", "negation has no fixed point"]
+  },
+  {
+    "id": "ann-cantor-alt",
+    "proofId": "cantor-diagonalization-oq-03",
+    "range": { "startLine": 90, "endLine": 92 },
+    "type": "context",
+    "title": "Alternative Cantor Statement",
+    "content": "Restates Cantor's theorem in existential form: there is no pair $(e, \\text{proof of surjectivity})$ for any $e : A \\to (A \\to \\mathrm{Prop})$. This is a direct application of the contrapositive form (`no_surjection_if_no_fixpoint`) with $f = \\neg$, showing how the different formulations compose cleanly.",
+    "mathContext": "$\\neg\\,(\\exists\\, e : A \\to (A \\to \\mathrm{Prop}),\\; \\text{Surjective}(e))$.",
+    "significance": "supporting",
+    "relatedConcepts": ["existential quantification", "proof term composition"],
+    "prerequisites": ["Cantor's theorem", "contrapositive corollary"]
+  },
+  {
+    "id": "ann-cantor-bool",
+    "proofId": "cantor-diagonalization-oq-03",
+    "range": { "startLine": 102, "endLine": 111 },
+    "type": "technique",
+    "title": "Cantor's Theorem for Bool",
+    "content": "The decidable version replaces $\\mathrm{Prop}$ with $\\mathrm{Bool}$ and $\\neg$ with boolean negation $!$. The key lemma `bnot_has_no_fixpoint` is proved by `cases b <;> decide` — Lean's kernel computation verifies $!\\mathrm{true} \\neq \\mathrm{true}$ and $!\\mathrm{false} \\neq \\mathrm{false}$ automatically. This variant is useful in computational contexts where classical propositions are unavailable.",
+    "mathContext": "$\\neg\\,\\text{Surjective}(e)$ for any $e : A \\to (A \\to \\mathrm{Bool})$, using $!b \\neq b$ for all $b : \\mathrm{Bool}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decidability", "boolean algebra", "kernel computation", "constructive mathematics"],
+    "prerequisites": ["Lawvere fixed-point theorem", "boolean negation"]
+  },
+  {
+    "id": "ann-russell",
+    "proofId": "cantor-diagonalization-oq-03",
+    "range": { "startLine": 123, "endLine": 125 },
+    "type": "insight",
+    "title": "Russell's Paradox as Cantor Instance",
+    "content": "Russell's paradox — the set $R = \\{x \\mid x \\notin x\\}$ leads to contradiction — is exactly Cantor's theorem for the identity: if every predicate on $A$ were represented by an element of $A$, we'd have a surjection $A \\to (A \\to \\mathrm{Prop})$. The formal proof is a one-line invocation of `cantor_no_surjection`, making the logical connection transparent.",
+    "mathContext": "$\\neg\\,(\\exists\\, e : A \\to (A \\to \\mathrm{Prop}),\\; \\forall S : A \\to \\mathrm{Prop},\\; \\exists a,\\; e(a) = S)$.",
+    "significance": "key",
+    "relatedConcepts": ["Russell's paradox", "naive set theory", "type universe", "comprehension principle"],
+    "prerequisites": ["Cantor's theorem"]
+  },
+  {
+    "id": "ann-diagonal",
+    "proofId": "cantor-diagonalization-oq-03",
+    "range": { "startLine": 136, "endLine": 140 },
+    "type": "technique",
+    "title": "Explicit Diagonal Non-Membership",
+    "content": "Makes the diagonal construction explicit as a set-theoretic non-membership result: the function $g(a) = f(e(a)(a))$ is not in the range of $e$ when $f$ is fixed-point-free. This is the constructive content of Cantor's argument — rather than deriving a contradiction from surjectivity, it directly exhibits a function outside the range.",
+    "mathContext": "$(\\lambda a.\\, f(e(a)(a))) \\notin \\text{range}(e)$ whenever $\\forall b,\\; f(b) \\neq b$. Proof: if $e(a_0) = g$, then $f(e(a_0)(a_0)) = e(a_0)(a_0)$, contradicting fixed-point-freeness.",
+    "significance": "key",
+    "relatedConcepts": ["constructive proof", "explicit witness", "range of a function", "diagonal function"],
+    "prerequisites": ["function range (Set.range)", "fixed-point-free endomorphism"]
   }
 ]

--- a/src/data/proofs/cantor-diagonalization-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/meta.json
@@ -34,13 +34,15 @@
   },
   "overview": {
     "problemStatement": "Prove the Lawvere fixed-point theorem as a categorical generalization of Cantor's diagonal argument: if a surjection $e : A \\to (A \\to B)$ exists, then every endomorphism $f : B \\to B$ has a fixed point. Derive Cantor's theorem as a corollary.",
+    "historicalContext": "Georg Cantor published his diagonal argument in 1891, proving that the set of all infinite binary sequences is uncountable. The argument was revolutionary: it showed that infinite sets come in different sizes, settling debates about the nature of infinity. Bertrand Russell discovered his paradox in 1901 by applying the diagonal idea to the set of all sets that don't contain themselves, exposing a fundamental flaw in naive set theory. In 1936, Alan Turing proved the unsolvability of the halting problem using an essentially identical diagonal construction. F. William Lawvere, in his 1969 paper 'Diagonal arguments and cartesian closed categories' (published in *Reprints in Theory and Applications of Categories*, No. 15), showed that all these results are instances of a single fixed-point theorem in cartesian closed categories. Lawvere's insight was that the diagonal construction $g(a) = f(e(a)(a))$ captures the common structure: what varies between Cantor, Russell, Turing, and Gödel is only the choice of the codomain $B$ and the fixed-point-free endomorphism $f$. Noson Yanofsky later extended this perspective in his 2003 paper 'A Universal Approach to Self-Referential Paradoxes, Incompleteness and Fixed Points', systematically cataloguing the instances.",
     "text": "A 149-line verified formalization of the Lawvere fixed-point theorem (1969) with 0 sorries and 0 axioms. The main theorem states: if $e : A \\to (A \\to B)$ is surjective, then every $f : B \\to B$ has a fixed point. The proof constructs the diagonal function $g(a) = f(e(a)(a))$ and uses surjectivity to find $a_0$ with $e(a_0) = g$, yielding $f(g(a_0)) = g(a_0)$. Five corollaries follow: Cantor's theorem for Prop, Cantor's theorem for Bool, Russell's paradox, the contrapositive (no fixed-point-free endomorphism implies no surjection), and an explicit diagonal non-membership result.",
     "proofStrategy": "1. **Lawvere's diagonal trick**: Given surjective $e : A \\to (A \\to B)$ and $f : B \\to B$, define $g(a) = f(e(a)(a))$. By surjectivity, $\\exists a_0$ with $e(a_0) = g$. Then $e(a_0)(a_0) = g(a_0) = f(e(a_0)(a_0))$, so $e(a_0)(a_0)$ is a fixed point of $f$.\n\n2. **Cantor from Lawvere**: Take $B = \\mathrm{Prop}$ and $f = \\neg$. Since $\\neg$ has no fixed point ($\\neg p = p$ leads to contradiction via self-application), Lawvere implies no surjection $A \\to (A \\to \\mathrm{Prop})$ exists.\n\n3. **Negation has no fixed point**: If $\\neg p = p$, cast along this equality to get $p \\to \\neg p$ and $\\neg p \\to p$. Define $\\neg p$ by $\\lambda h. (\\mathrm{cast}\\, h^{-1}\\, h)\\, h$, then derive contradiction.",
     "keyInsights": [
-      "**One Proof, Many Theorems**: Lawvere's fixed-point theorem unifies Cantor's diagonal argument, Russell's paradox, the halting problem, and Godel's incompleteness theorem. Each is an instance with different B and f.",
-      "**The Diagonal is Universal**: The construction g(a) = f(e(a)(a)) is the categorical essence of all diagonal arguments. It extracts the common pattern from seemingly different impossibility proofs.",
-      "**Self-Application is the Key**: The proof of not_has_no_fixpoint uses the same self-application trick as Russell's paradox: if we can apply something to itself, contradiction follows. This is the type-theoretic core of all diagonal arguments.",
-      "**Surjectivity is the Barrier**: Cantor's theorem is not about size per se — it's about the impossibility of a certain surjection. This formulation makes the logical content precise without appealing to cardinal arithmetic."
+      "**One Proof, Many Theorems**: Lawvere's fixed-point theorem unifies Cantor's diagonal argument, Russell's paradox, the halting problem, and Gödel's incompleteness theorem. Each is an instance with different $B$ and $f$: Cantor uses $B = \\mathrm{Prop}$, $f = \\neg$; Turing uses $B = \\mathrm{Bool}$, $f = !$; Russell uses the identity surjection.",
+      "**The Diagonal is Universal**: The construction $g(a) = f(e(a)(a))$ is the categorical essence of all diagonal arguments. It extracts the common pattern from seemingly different impossibility proofs into a single 3-line proof.",
+      "**Self-Application is the Key**: The proof of `not_has_no_fixpoint` uses the same self-application trick as Russell's paradox: if $\\neg p = p$, then $p$ can be applied to itself via cast, producing both $p$ and $\\neg p$. This is the type-theoretic core of all diagonal arguments.",
+      "**Surjectivity is the Barrier**: Cantor's theorem is not about size per se — it's about the impossibility of a certain surjection. This formulation makes the logical content precise without appealing to cardinal arithmetic.",
+      "**Constructive vs. Contradictory Forms**: The formalization presents both styles: `cantor` derives a contradiction from a hypothetical surjection, while `diagonal_not_in_range` constructively exhibits a function outside the range of any given $e$. The constructive form is stronger — it produces an explicit witness rather than merely refuting an assumption."
     ]
   },
   "sections": [
@@ -94,8 +96,13 @@
     }
   ],
   "conclusion": {
-    "summary": "The Lawvere fixed-point theorem reveals the common structure behind Cantor's diagonal argument, Russell's paradox, the halting problem, and Godel's incompleteness theorem. All are instances of the principle that surjectivity onto a function space is incompatible with fixed-point-free endomorphisms.",
-    "implications": "This formalization demonstrates that impossibility results in set theory, logic, and computation share a single categorical root. The 3-line proof of the Lawvere theorem shows that the deep content is in the diagonal construction g(a) = f(e(a)(a)) — everything else is a choice of B and f."
+    "summary": "The Lawvere fixed-point theorem reveals the common structure behind Cantor's diagonal argument, Russell's paradox, the halting problem, and Gödel's incompleteness theorem. All are instances of the principle that surjectivity onto a function space is incompatible with fixed-point-free endomorphisms.",
+    "implications": "This formalization demonstrates that impossibility results in set theory, logic, and computation share a single categorical root. The 3-line proof of the Lawvere theorem shows that the deep content is in the diagonal construction $g(a) = f(e(a)(a))$ — everything else is a choice of $B$ and $f$. The type-theoretic presentation avoids the set-theoretic machinery of cardinal arithmetic entirely, showing these results are consequences of pure logic.",
+    "openQuestions": [
+      "Can the Lawvere fixed-point theorem be formalized in a topos-theoretic setting in Lean, recovering the original categorical generality beyond type theory?",
+      "Is there a constructive analogue of Lawvere's theorem that works in a predicative type theory without propositional extensionality?",
+      "Can Rice's theorem (every non-trivial semantic property of programs is undecidable) be derived as a Lawvere instance in Lean, completing the connection to computability theory?"
+    ]
   },
   "crossReferences": [
     {
@@ -107,6 +114,16 @@
       "targetId": "cantors-theorem",
       "relationship": "generalizes",
       "description": "Cantor's theorem (|S| < |P(S)|) follows from Lawvere by taking B = Prop and f = Not"
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "related",
+      "description": "The halting problem is another instance of Lawvere's theorem: the undecidability of halting follows from the same diagonal construction with B = Bool and f = boolean negation"
+    },
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "related",
+      "description": "Gödel's incompleteness theorem can be viewed as a Lawvere instance where the surjection encodes formulas as numbers and f maps provability to its negation"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment: cantor-diagonalization-oq-03

**Lawvere Fixed-Point Theorem and Cantor's Theorem** — quality 52 → enriched (pass 1)

### Changes
- **Annotations**: Expanded from 3 to 8, now covering all 7 theorems in the file
  - Added `mathContext` (LaTeX formulas) to all annotations
  - Added `relatedConcepts` and `prerequisites` arrays
  - New annotations for: contrapositive, alternative Cantor statement, Bool variant, Russell's paradox, diagonal non-membership
- **Historical context**: Added 200+ word narrative tracing Cantor (1891) → Russell (1901) → Turing (1936) → Lawvere (1969) → Yanofsky (2003)
- **Key insights**: Added 5th insight on constructive vs. contradictory proof forms
- **Conclusion**: Added 3 open questions (topos-theoretic formalization, predicative type theory, Rice's theorem as Lawvere instance)
- **Cross-references**: Added links to `halting-problem` and `godel-incompleteness` gallery entries

### Verification
- JSON files validated successfully
- Build passes in non-strict mode (annotation type warnings are pre-existing across gallery)