### PR TITLE
Enrich Erdos #1014 OQ-01: add annotations, deepen history

### DIFF
--- a/src/data/proofs/erdos-1014-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1014-oq-01/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-lower-bound-axiom",
+    "proofId": "erdos-1014-oq-01",
+    "range": { "startLine": 62, "endLine": 64 },
+    "type": "context",
+    "title": "Kim-Shearer Lower Bound Axiom",
+    "content": "Axiomatizes the Kim (1995) / Shearer (1995) lower bound: $R(3,l) \\geq c \\cdot l^2 / \\log l$ for some $c > 0$ and all sufficiently large $l$. This was improved by Mattheus-Verstraëte (2024) to $R(3,t) \\geq (1/4 - o(1)) \\cdot t^2 / \\log t$. The existential form ($\\exists c > 0, \\exists L_0$) is deliberately weaker than stating a specific constant, making the result robust to future improvements.",
+    "mathContext": "$\\exists c > 0,\\; \\exists L_0,\\; \\forall l > L_0: R(3,l) \\geq c \\cdot l^2 / \\log l$.",
+    "significance": "key",
+    "relatedConcepts": ["Kim's lower bound", "Shearer's bound", "Ramsey number asymptotics", "probabilistic method"],
+    "prerequisites": ["Ramsey numbers R(k,l)", "asymptotic notation"]
+  },
+  {
+    "id": "ann-increment-bound",
+    "proofId": "erdos-1014-oq-01",
+    "range": { "startLine": 75, "endLine": 81 },
+    "type": "key-step",
+    "title": "Linear Increment Bound from Recurrence",
+    "content": "The key structural lemma: $R(3, l+1) \\leq R(3, l) + (l+1)$. Derived by substituting $k = 3$ into the recurrence $R(k, l+1) \\leq R(k,l) + R(k-1, l+1)$ and using $R(2, l+1) = l+1$. This bounds the increment between consecutive Ramsey numbers linearly, while the values themselves grow as $\\Theta(l^2/\\log l)$. The disparity between increment and magnitude is what drives ratio convergence.",
+    "mathContext": "$R(3, l+1) - R(3, l) \\leq R(2, l+1) = l + 1 = O(l)$, while $R(3, l) = \\Theta(l^2 / \\log l)$.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey recurrence", "telescoping bound", "growth rate"],
+    "prerequisites": ["ramsey_recurrence", "ramsey_k2"]
+  },
+  {
+    "id": "ann-analysis-sorry",
+    "proofId": "erdos-1014-oq-01",
+    "range": { "startLine": 90, "endLine": 96 },
+    "type": "context",
+    "title": "Analysis Lemma (1 Sorry)",
+    "content": "States that $(l+1) \\cdot \\log l / (c \\cdot l^2) < \\varepsilon$ for sufficiently large $l$. The sorry is routine: simplify to $2 \\log l / (c \\cdot l) < \\varepsilon$ using $(l+1)/l \\leq 2$, then apply $\\log x = o(x)$ (Mathlib's `isLittleO_log_rpow_atTop` with exponent 1). This is the only sorry in the file.",
+    "mathContext": "$\\frac{(l+1) \\cdot \\log l}{c \\cdot l^2} \\leq \\frac{2 \\log l}{c \\cdot l} \\to 0$ as $l \\to \\infty$, since $\\log x = o(x)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["little-o notation", "logarithmic growth", "isLittleO_log_rpow_atTop"],
+    "prerequisites": ["real analysis", "asymptotic analysis", "Mathlib Filter.Eventually"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "erdos-1014-oq-01",
+    "range": { "startLine": 110, "endLine": 167 },
+    "type": "technique",
+    "title": "Main Theorem: R(3,l+1)/R(3,l) → 1",
+    "content": "The main result, proved via a `calc` chain that squeezes the ratio to 1. The chain: (1) absolute value simplification using monotonicity ($R' \\geq R > 0$ gives $|R'/R - 1| = (R'-R)/R$), (2) increment bound ($\\leq (l+1)/R$), (3) lower bound substitution ($\\leq (l+1) \\cdot \\log l / (c \\cdot l^2)$), (4) analysis lemma ($< \\varepsilon$). The `field_simp` and `div_le_div` lemmas handle the algebraic manipulations, while `exact_mod_cast` bridges $\\mathbb{N}$ and $\\mathbb{R}$.",
+    "mathContext": "$|R(3,l+1)/R(3,l) - 1| = \\frac{R(3,l+1) - R(3,l)}{R(3,l)} \\leq \\frac{l+1}{R(3,l)} \\leq \\frac{(l+1) \\log l}{c \\cdot l^2} < \\varepsilon$.",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem", "ratio convergence", "calc chain", "Nat/Real cast"],
+    "prerequisites": ["increment_bound", "R3_lower_bound", "eventually_ratio_small", "ramsey_monotone_right"]
+  },
+  {
+    "id": "ann-monotonicity-cast",
+    "proofId": "erdos-1014-oq-01",
+    "range": { "startLine": 134, "endLine": 136 },
+    "type": "technique",
+    "title": "Nat-to-Real Cast for Monotonicity",
+    "content": "Bridges the $\\mathbb{N}$ monotonicity axiom to $\\mathbb{R}$ using `Nat.cast_le`. This cast is essential because the main theorem works in $\\mathbb{R}$ (for division and absolute value) while the Ramsey axioms are stated over $\\mathbb{N}$. The `exact_mod_cast` tactic automates these coercions elsewhere in the proof.",
+    "mathContext": "$R(3,l) \\leq R(3,l+1)$ in $\\mathbb{N}$ $\\implies$ $(R(3,l) : \\mathbb{R}) \\leq (R(3,l+1) : \\mathbb{R})$ via `Nat.cast_le`.",
+    "significance": "technical",
+    "relatedConcepts": ["type coercion", "Nat.cast_le", "exact_mod_cast"],
+    "prerequisites": ["Lean 4 coercion system"]
+  }
+]

--- a/src/data/proofs/erdos-1014-oq-01/meta.json
+++ b/src/data/proofs/erdos-1014-oq-01/meta.json
@@ -32,6 +32,11 @@
       "relationship": "extends",
       "description": "Resolves the k=3 case of the open question from Erdős #1014 parent formalization.",
       "targetId": "erdos-1014"
+    },
+    {
+      "relationship": "related",
+      "description": "Uses properties of Ramsey numbers (recurrence, monotonicity) that are consequences of Ramsey's theorem.",
+      "targetId": "ramseys-theorem"
     }
   ],
   "sections": [
@@ -69,7 +74,7 @@
     }
   ],
   "overview": {
-    "historicalContext": "Erdős asked in 1971 whether R(k,l+1)/R(k,l) → 1 for fixed k ≥ 3. The widespread belief was that the known Θ(l²/log l) bounds for R(3,l) were insufficient because the constants in the upper and lower bounds differ. This formalization shows that the recurrence relation provides an independent constraint on the increment R(3,l+1) - R(3,l) ≤ l+1 that, combined with only the lower bound, yields ratio convergence.",
+    "historicalContext": "Erdős asked in 1971 whether $R(k, l+1)/R(k, l) \\to 1$ for fixed $k \\geq 3$. The question is intimately connected to the structure of Ramsey numbers, which have been studied since Ramsey's 1929 paper. For $k = 3$, the lower bound $R(3, l) \\geq c \\cdot l^2 / \\log l$ was established independently by Kim (1995) and Shearer (1995) using the probabilistic method, confirming the order of magnitude predicted by Erdős and Szekeres (1935). The upper bound $R(3, l) \\leq (1 + o(1)) l^2 / (2 \\log l)$ from Ajtai, Komlós, and Szemerédi (1980) shows $R(3, l) = \\Theta(l^2 / \\log l)$. The widespread belief was that these $\\Theta$-bounds were insufficient for ratio convergence because the leading constants differ. This formalization reveals that the recurrence relation — often overlooked in this context — provides an independent constraint on consecutive increments $R(3, l+1) - R(3, l) \\leq l+1$ that, combined with only the lower bound, yields ratio convergence without needing matched constants.",
     "problemStatement": "Prove R(3, l+1)/R(3, l) → 1 as l → ∞.",
     "text": "For k = 3, the Ramsey recurrence R(3,l+1) ≤ R(3,l) + R(2,l+1) = R(3,l) + (l+1) bounds the increment linearly. Combined with R(3,l) ≥ c·l²/log l (Kim-Shearer), this gives R(3,l+1)/R(3,l) - 1 ≤ O(log l / l) → 0.",
     "proofStrategy": "Squeeze theorem: monotonicity gives 1 ≤ R(3,l+1)/R(3,l), and the recurrence plus lower bound give R(3,l+1)/R(3,l) ≤ 1 + O(log l/l). The ratio is squeezed to 1.",


### PR DESCRIPTION
## Enrichment: erdos-1014-oq-01

**Erdős #1014 (k=3): Ramsey Ratio Convergence** — quality 38 → enriched (pass 1)

### Changes
- **Annotations**: Created 5 annotations from scratch (was empty `[]`)
  - Kim-Shearer lower bound axiom with historical context
  - Linear increment bound: the key structural lemma
  - Analysis lemma sorry: context for the routine sorry
  - Main theorem: detailed `calc` chain walkthrough
  - Nat/Real cast technique note
- All annotations include `mathContext`, `relatedConcepts`, `prerequisites`
- **Historical context**: Expanded with Kim (1995), Shearer (1995), AKS (1980), Erdős-Szekeres (1935) references
- **Cross-references**: Added link to `ramseys-theorem` gallery entry

### Verification
- JSON validated successfully
- Annotation build passes (no missing Lean constructs)

(Note: Previous PR content for erdos-103-oq-01 was merged separately as PR #6426)