### PR TITLE
Fix: stale sorry counts for 4 proofs

### DIFF
--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Update stale sorry counts in meta.json for 4 proofs where research agents reduced sorries.

## Evidence

| Proof | Before | After | Verified against |
|-------|--------|-------|-----------------|
| erdos-392 | 3 | 2 | `Proofs/Stubs/Erdos392Problem.lean` |
| erdos-138 | 5 | 4 | `Proofs/Stubs/Erdos138Problem.lean` |
| erdos-628 | 12 | 11 | `Proofs/Stubs/Erdos628Problem.lean` |
| erdos-746 | 4 | 3 | `Proofs/Erdos746Problem.lean` |

Counts verified by parsing Lean files and excluding sorry occurrences in comments.

`pnpm build` passes.

---
Automated fix by lean-mechanic agent.