### PR TITLE
Fix: promote 4 sorry-free proofs to verified status

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lévy (1934), Khintchine (1937); formalized 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%C3%A9vy%E2%80%93Khintchine_representation",
     "date": "1937",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
     "tags": [
       "probability",
@@ -19,7 +19,7 @@
       "gaussian",
       "stable-distributions"
     ],
-    "badge": "formalized",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -7,7 +7,7 @@
     "author": "Vapnik-Chervonenkis (1971), Valiant (1984), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
     "date": "1984",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/PACLearning.lean",
     "tags": [
       "learning-theory",
@@ -16,7 +16,7 @@
       "cs-math-bridge",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdos, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1960",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ProbMethodAlteration.lean",
     "tags": [
       "probabilistic-method",
@@ -15,7 +15,7 @@
       "graph-theory",
       "intermediate"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos and collaborators, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1947",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ProbMethodApplications.lean",
     "tags": [
       "probabilistic-method",
@@ -16,7 +16,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Promote 4 proofs from `formalized` to `verified` status. All have 0 sorries, 0 axiom declarations, and no structure-encoded assumptions.

## Evidence

| Proof | Status | Badge | Sorries | Axioms |
|-------|--------|-------|---------|--------|
| central-limit-theorem-oq-01-oq-02 | formalized→verified | formalized→original | 0 | 0 |
| pac-learning-bounds | formalized→verified | wip→original | 0 | 0 |
| prob-method-alteration | formalized→verified | wip→original | 0 | 0 |
| prob-method-applications | formalized→verified | wip→original | 0 | 0 |

Verified by counting `sorry` and `axiom` declarations outside comments. `pnpm build` passes.

---
Automated fix by lean-mechanic agent.