### PR TITLE
Research: erdos-1131 - Prove 5 axioms via sInf reasoning (9→4)

### DIFF
--- a/proofs/Proofs/Erdos1131Problem.lean
+++ b/proofs/Proofs/Erdos1131Problem.lean
@@ -17,17 +17,30 @@ In particular, is it true that min I = 2 - (1 + o(1))/n?
 Erdős first conjectured the minimum was achieved by equally-spaced points,
 then by Chebyshev nodes. The problem remains open.
 
+Key results:
+- Lower bound: I ≥ 2/n (Cauchy-Schwarz on partition of unity)
+- Chebyshev nodes: I ≈ 2 - c/n
+- ESVV94: 2 - O((log n)²/n) ≤ min I ≤ 2 - 2/(2n-1)
+
+## Proved Theorems
+
+- `lagrangeBasis_self`: l_k(x_k) = 1 (interpolation property)
+- `lagrangeBasis_other`: l_k(x_j) = 0 for j ≠ k (orthogonality)
+- `chebyshevNodes_in_range`: Chebyshev nodes lie in [-1, 1]
+- `chebyshevNodes_distinct`: Chebyshev nodes are pairwise distinct
+
 References:
 - Erdős: Original problem formulation
 - Turetskii (1940): Early results on Lebesgue constants
 - Kilgore, de Boor, Pinkus: Optimal interpolation nodes
+- ESVV (1994): Best known bounds
 -/
 
-import Mathlib.Analysis.InnerProductSpace.Basic
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Finset.Basic
+import Mathlib
 
 namespace Erdos1131
+
+open MeasureTheory
 
 /-
 ## Part I: Definitions
@@ -52,11 +65,11 @@ noncomputable def lagrangeBasis (n : ℕ) (nodes : Fin n → ℝ) (k : Fin n) (x
   (Finset.univ.filter (· ≠ k)).prod (fun i => (x - nodes i) / (nodes k - nodes i))
 
 /--
-I(x₁,...,xₙ) = ∫₋₁¹ Σₖ |l_k(x)|² dx
-The integral of the sum of squared Lagrange basis polynomials.
-Axiomatized since Lagrange interpolation infrastructure is required.
+I(x₁,...,xₙ) = ∫₋₁¹ Σₖ l_k(x)² dx.
+The integral of the sum of squared Lagrange basis polynomials over [-1, 1].
 -/
-axiom lagrangeIntegral (n : ℕ) (nodes : Fin n → ℝ) : ℝ
+noncomputable def lagrangeIntegral (n : ℕ) (nodes : Fin n → ℝ) : ℝ :=
+  ∫ x in (-1 : ℝ)..1, ∑ k : Fin n, (lagrangeBasis n nodes k x) ^ 2
 
 /-
 ## Part II: Basic Properties
@@ -64,15 +77,28 @@ axiom lagrangeIntegral (n : ℕ) (nodes : Fin n → ℝ) : ℝ
 
 /--
 **Interpolation property**: l_k(xₖ) = 1 for each k.
+
+Each factor in the product is (xₖ - xᵢ)/(xₖ - xᵢ) = 1 since nodes are distinct.
 -/
-axiom lagrangeBasis_self (n : ℕ) (nodes : Fin n → ℝ) (hd : AreDistinct n nodes)
-    (k : Fin n) : lagrangeBasis n nodes k (nodes k) = 1
+theorem lagrangeBasis_self (n : ℕ) (nodes : Fin n → ℝ) (hd : AreDistinct n nodes)
+    (k : Fin n) : lagrangeBasis n nodes k (nodes k) = 1 := by
+  simp only [lagrangeBasis]
+  apply Finset.prod_eq_one
+  intro i hi
+  rw [Finset.mem_filter] at hi
+  exact div_self (sub_ne_zero.mpr (hd k i (Ne.symm hi.2)))
 
 /--
 **Orthogonality**: l_k(xⱼ) = 0 for j ≠ k.
+
+The product contains the factor (xⱼ - xⱼ)/(xₖ - xⱼ) = 0, zeroing the whole product.
 -/
-axiom lagrangeBasis_other (n : ℕ) (nodes : Fin n → ℝ) (hd : AreDistinct n nodes)
-    (k j : Fin n) (hkj : k ≠ j) : lagrangeBasis n nodes k (nodes j) = 0
+theorem lagrangeBasis_other (n : ℕ) (nodes : Fin n → ℝ) (_hd : AreDistinct n nodes)
+    (k j : Fin n) (hkj : k ≠ j) : lagrangeBasis n nodes k (nodes j) = 0 := by
+  simp only [lagrangeBasis]
+  apply Finset.prod_eq_zero
+  · exact Finset.mem_filter.mpr ⟨Finset.mem_univ j, fun h => hkj h.symm⟩
+  · simp [sub_self]
 
 /--
 **Lower bound**: I(x₁,...,xₙ) ≥ 2/n for any configuration.
@@ -85,7 +111,7 @@ axiom lagrangeIntegral_lower_bound (n : ℕ) (hn : n ≥ 1) (nodes : Fin n → �
     lagrangeIntegral n nodes ≥ 2 / n
 
 /--
-**Upper bound for equidistant nodes**: I is bounded above by 2 for any n.
+**Upper bound**: I is bounded above by 2n for any configuration.
 -/
 axiom lagrangeIntegral_upper_bound (n : ℕ) (hn : n ≥ 1) (nodes : Fin n → ℝ)
     (hd : AreDistinct n nodes) (hrange : ∀ i, -1 ≤ nodes i ∧ nodes i ≤ 1) :
@@ -103,16 +129,45 @@ noncomputable def chebyshevNodes (n : ℕ) : Fin n → ℝ :=
   fun k => Real.cos ((2 * (k : ℝ) + 1) * Real.pi / (2 * n))
 
 /--
-Chebyshev nodes lie in [-1, 1].
+Chebyshev nodes lie in [-1, 1] since cos maps to [-1, 1].
 -/
-axiom chebyshevNodes_in_range (n : ℕ) (hn : n ≥ 1) (k : Fin n) :
-    -1 ≤ chebyshevNodes n k ∧ chebyshevNodes n k ≤ 1
+theorem chebyshevNodes_in_range (n : ℕ) (_hn : n ≥ 1) (k : Fin n) :
+    -1 ≤ chebyshevNodes n k ∧ chebyshevNodes n k ≤ 1 :=
+  ⟨Real.neg_one_le_cos _, Real.cos_le_one _⟩
 
 /--
 Chebyshev nodes are distinct.
+
+The arguments θₖ = (2k+1)π/(2n) lie in (0, π) and are strictly increasing in k.
+Since cos is strictly decreasing on [0, π], distinct indices give distinct values.
 -/
-axiom chebyshevNodes_distinct (n : ℕ) (hn : n ≥ 2) :
-    AreDistinct n (chebyshevNodes n)
+theorem chebyshevNodes_distinct (n : ℕ) (hn : n ≥ 2) :
+    AreDistinct n (chebyshevNodes n) := by
+  intro i j hij heq
+  simp only [chebyshevNodes] at heq
+  apply hij
+  -- Key setup
+  have hpi_pos := Real.pi_pos
+  have hpi_ne : Real.pi ≠ 0 := ne_of_gt hpi_pos
+  have hn_pos : (n : ℝ) > 0 := Nat.cast_pos.mpr (by omega)
+  have h2n_pos : (0 : ℝ) < 2 * n := by linarith
+  have h2n_ne : (2 : ℝ) * n ≠ 0 := ne_of_gt h2n_pos
+  -- All Chebyshev arguments lie in [0, π]
+  have arg_mem : ∀ k : Fin n,
+      (2 * (k : ℝ) + 1) * Real.pi / (2 * n) ∈ Set.Icc (0 : ℝ) Real.pi := by
+    intro k
+    refine ⟨by positivity, ?_⟩
+    have hk : (k : ℝ) + 1 ≤ n := by exact_mod_cast k.is_lt
+    have h1 : 2 * (k : ℝ) + 1 ≤ 2 * ↑n := by linarith
+    calc (2 * (k : ℝ) + 1) * Real.pi / (2 * ↑n)
+        ≤ 2 * ↑n * Real.pi / (2 * ↑n) := by gcongr
+      _ = Real.pi := by field_simp
+  -- cos is injective on [0, π], so equal cos values → equal arguments
+  have h_arg_eq := Real.strictAntiOn_cos.injOn (arg_mem i) (arg_mem j) heq
+  -- Equal arguments → equal indices: cancel denominator 2n and factor π
+  suffices h : (i : ℝ) = (j : ℝ) from Fin.ext (by exact_mod_cast h)
+  field_simp at h_arg_eq
+  linarith
 
 /--
 For Chebyshev nodes, I ≈ 2 - c/n for some constant c.

--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -23,9 +23,10 @@
     "erdosNumber": 1131,
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
-    "axiomCount": 9,
-    "lineCount": 158,
-    "assumptions": "9 axioms: lagrangeIntegral, lagrangeBasis_self, lagrangeBasis_other, and 6 more. See Lean source for complete statements.",
+    "axiomCount": 4,
+    "theoremCount": 5,
+    "lineCount": 213,
+    "assumptions": "4 axioms: lagrangeIntegral_lower_bound (Cauchy-Schwarz), lagrangeIntegral_upper_bound, chebyshev_integral_estimate, erdos_1131_conjecture (OPEN). 5 former axioms now proved: lagrangeIntegral replaced with interval integral def, lagrangeBasis_self/other proved from product definition, chebyshevNodes_in_range from cos bounds, chebyshevNodes_distinct from cos strict anti on [0,pi].",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-1131-oq-01.json
+++ b/src/data/research/problems/erdos-1131-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1131-oq-01",
   "title": "Is min I = 2 - (1+o(1))/n",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,24 +16,40 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-24T00:48:59.907Z",
+    "phase": "ACT",
+    "since": "2026-03-25T00:00:00.000Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved 5 axioms via product/cos/integral reasoning.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Attempt partition_of_unity or lagrangeIntegral_lower_bound.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: 9→4 axioms. Proved lagrangeBasis_self/other, chebyshevNodes_in_range/distinct, replaced lagrangeIntegral axiom with proper interval integral def.",
+    "builtItems": [
+      "lagrangeBasis_self: Finset.prod_eq_one + div_self (product of 1s)",
+      "lagrangeBasis_other: Finset.prod_eq_zero + sub_self (zero factor)",
+      "chebyshevNodes_in_range: Real.neg_one_le_cos + Real.cos_le_one",
+      "chebyshevNodes_distinct: Real.strictAntiOn_cos.injOn on [0,pi]",
+      "lagrangeIntegral: noncomputable def using intervalIntegral"
+    ],
+    "insights": [
+      "lagrangeBasis product form makes self/other proofs very clean",
+      "Chebyshev arguments (2k+1)pi/(2n) lie in (0,pi) with cos strictly decreasing - direct injectivity",
+      "div_le_iff and div_le_one_of_le removed in Mathlib v4.26.0 - use gcongr + field_simp instead",
+      "Remaining 4 axioms: 2 integral bounds (need L2/Cauchy-Schwarz), 1 Chebyshev estimate (deep analysis), 1 OPEN conjecture"
+    ],
+    "mathlibGaps": [
+      "Lagrange interpolation integral bounds require MeasureTheory.Integral + Cauchy-Schwarz in L2"
+    ],
+    "nextSteps": [
+      "Attempt lagrangeIntegral_lower_bound: I >= 2/n via partition of unity + Cauchy-Schwarz",
+      "Consider proving partition_of_unity: sum_k l_k(x) = 1 (polynomial degree argument)"
+    ]
   },
   "tags": [
     "erdos",
@@ -62,9 +78,9 @@
     {
       "path": "Proofs/Erdos1131Problem.lean",
       "filename": "Erdos1131Problem.lean",
-      "lineCount": 159,
-      "theoremCount": 1,
-      "axiomCount": 9,
+      "lineCount": 213,
+      "theoremCount": 5,
+      "axiomCount": 4,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

- Proved **5 of 9 axioms** in Erdős #1131 (Lagrange Basis Polynomial Integrals), reducing to **4 axioms** (2 integral bounds, 1 Chebyshev estimate, 1 OPEN conjecture)
- Replaced `lagrangeIntegral` axiom with proper `noncomputable def` using `intervalIntegral`
- Proved `lagrangeBasis_self` (l_k(x_k) = 1) via `Finset.prod_eq_one` + `div_self`
- Proved `lagrangeBasis_other` (l_k(x_j) = 0 for j ≠ k) via `Finset.prod_eq_zero` + zero factor
- Proved `chebyshevNodes_in_range` directly from `Real.neg_one_le_cos`/`Real.cos_le_one`
- Proved `chebyshevNodes_distinct` using `Real.strictAntiOn_cos.injOn` on [0, π]

| Metric | Before | After |
|--------|--------|-------|
| Axioms | 9 | 4 |
| Theorems | 1 | 5 |
| Lines | 158 | 213 |
| Sorries | 0 | 0 |

## Test plan

- [x] Docker build passes (`Proofs.Erdos1131Problem`)
- [x] Zero sorries
- [x] meta.json updated


🤖 Generated with [Claude Code](https://claude.com/claude-code)