### PR TITLE
Fix: stale lineCount for 5 proofs

### DIFF
--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -58,7 +58,7 @@
       "diameter_asymptotic axiom: relation to packing"
     ],
     "axiomCount": 6,
-    "lineCount": 248,
+    "lineCount": 259,
     "assumptions": "6 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -260,7 +260,7 @@
       "Finset"
     ],
     "namespace": "Erdos103",
-    "lineCount": 248,
+    "lineCount": 259,
     "axiomCount": 6,
     "theoremCount": 5,
     "definitionCount": 17

--- a/src/data/proofs/erdos-1126/meta.json
+++ b/src/data/proofs/erdos-1126/meta.json
@@ -59,7 +59,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 5,
-    "lineCount": 143,
+    "lineCount": 154,
     "assumptions": "5 axioms: continuous_additive_is_linear, de_bruijn_jurkat_theorem, additive_zero_ae, wild_additive_exist, measurable_additive_is_linear. additive_ae_unique is now a proved theorem."
   },
   "overview": {
@@ -171,7 +171,7 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos1126",
-    "lineCount": 143,
+    "lineCount": 154,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5

--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -38,7 +38,7 @@
       "Formal statement of irrationality threshold at β = 2"
     ],
     "axiomCount": 7,
-    "lineCount": 217,
+    "lineCount": 233,
     "assumptions": "7 axioms. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -148,7 +148,7 @@
     ],
     "opens": [],
     "namespace": "Erdos265",
-    "lineCount": 217,
+    "lineCount": 233,
     "axiomCount": 7,
     "theoremCount": 2,
     "definitionCount": 11

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: erdos_389 (main open conjecture), erdos_389_n2 (n=2 k=5 case). Previously axiomatized results now proved.",
-    "lineCount": 98,
+    "lineCount": 115,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -112,7 +112,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 98,
+    "lineCount": 115,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 3

--- a/src/data/proofs/erdos-933/meta.json
+++ b/src/data/proofs/erdos-933/meta.json
@@ -56,7 +56,7 @@
       "Three equivalent main statements: `erdos_933`, `erdos_933_main`, `erdos_933_solved`"
     ],
     "axiomCount": 6,
-    "lineCount": 230,
+    "lineCount": 214,
     "assumptions": "6 axiom(s) and 3 sorry(s). limsup_infinite proved from steinerberger_proof axiom (eliminated 2 sorries)."
   },
   "overview": {
@@ -183,7 +183,7 @@
       "Real"
     ],
     "namespace": "Erdos933",
-    "lineCount": 230,
+    "lineCount": 214,
     "axiomCount": 6,
     "theoremCount": 9,
     "definitionCount": 12


### PR DESCRIPTION
## Fix

Sync stale `lineCount` values in meta.json to match actual Lean file lengths.

## Evidence

| Proof | Before | After | Lean File |
|-------|--------|-------|-----------|
| erdos-389 | 98 | 115 | Stubs/Erdos389Problem.lean |
| erdos-933 | 230 | 214 | Erdos933Problem.lean |
| erdos-265 | 217 | 233 | Stubs/Erdos265Problem.lean |
| erdos-1126 | 143 | 154 | Stubs/Erdos1126Problem.lean |
| erdos-103 | 248 | 259 | Erdos103Problem.lean |

`pnpm build` passes.

---
Automated fix by lean-mechanic agent.