### PR TITLE
Enrich erdos-103-oq-01: add 10 annotations, fix sections

### DIFF
--- a/src/data/proofs/erdos-103-oq-01/annotations.json
+++ b/src/data/proofs/erdos-103-oq-01/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "ann-erdos103oq01-header",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "Problem Overview and Imports",
+    "content": "Documents Erdős Problem #103 (1994): does $h(n) \\to \\infty$, where $h(n)$ counts incongruent optimal point configurations with minimum separation 1 and minimal diameter? The file proves metric properties, isometry group structure, congruence symmetry (eliminating a sorry from the parent file), and a counterexample showing that 'unbounded' does not imply 'tends to infinity' without monotonicity. Imports Mathlib for real analysis, square roots, and function inverse machinery.",
+    "mathContext": "Erdős Problem #103: Let $h(n)$ count the number of incongruent sets of $n$ points in $\\mathbb{R}^2$ that minimize diameter subject to pairwise distances $\\geq 1$. Does $h(n) \\to \\infty$?",
+    "significance": "context",
+    "relatedConcepts": ["Erdős problems", "optimal packing", "point configurations", "diameter minimization"],
+    "prerequisites": ["metric geometry", "real analysis", "Lean 4 / Mathlib"]
+  },
+  {
+    "id": "ann-erdos103oq01-definitions",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 54, "endLine": 72 },
+    "type": "definition",
+    "title": "Core Definitions: Points, Distance, Isometry, Congruence",
+    "content": "`PointConfig n` is a finite configuration $\\text{Fin}\\,n \\to \\mathbb{R}^2$. The Euclidean distance `pointDist` computes $\\sqrt{(p_1 - q_1)^2 + (p_2 - q_2)^2}$. `HasMinSeparation` requires all distinct pairs to have distance $\\geq 1$. `Isometry2D` is a structure wrapping a distance-preserving map with a proof that $d(\\sigma(p), \\sigma(q)) = d(p, q)$. `AreCongruent` relates two configurations that differ by an isometry: $\\exists \\sigma,\\, \\forall i,\\, Q_i = \\sigma(P_i)$.",
+    "mathContext": "$d(p,q) = \\sqrt{(p_1-q_1)^2 + (p_2-q_2)^2}$. Configuration $P \\cong Q$ iff $\\exists \\sigma : \\mathbb{R}^2 \\to \\mathbb{R}^2$ distance-preserving with $Q = \\sigma \\circ P$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean distance", "isometry", "congruence", "minimum separation", "packing density"],
+    "prerequisites": ["metric spaces", "Prod type in Lean", "function types"]
+  },
+  {
+    "id": "ann-erdos103oq01-definiteness",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 100, "endLine": 115 },
+    "type": "technique",
+    "title": "Metric Definiteness: d(p,q) = 0 iff p = q",
+    "content": "The crucial metric property: $d(p,q) = 0 \\iff p = q$. The forward direction squares both sides ($d^2 = (p_1-q_1)^2 + (p_2-q_2)^2 = 0$), then uses `nlinarith` with `sq_nonneg` to show each squared term is zero individually, and `sq_eq_zero_iff` to extract coordinate equality. Finally `Prod.ext` combines the two coordinate equalities. This is the key lemma enabling isometry injectivity.",
+    "mathContext": "$d(p,q) = 0 \\iff (p_1-q_1)^2 + (p_2-q_2)^2 = 0 \\iff p_1 = q_1 \\land p_2 = q_2 \\iff p = q$. Uses: sum of nonneg terms = 0 $\\Rightarrow$ each term = 0.",
+    "significance": "key",
+    "relatedConcepts": ["metric definiteness", "positive definite", "nlinarith", "sq_eq_zero_iff", "Prod.ext"],
+    "prerequisites": ["real number arithmetic", "square root properties", "Prod extensionality"]
+  },
+  {
+    "id": "ann-erdos103oq01-injectivity",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 121, "endLine": 127 },
+    "type": "insight",
+    "title": "Isometry Injectivity from Metric Definiteness",
+    "content": "A clean 3-step proof: $\\sigma(p) = \\sigma(q) \\Rightarrow d(\\sigma(p), \\sigma(q)) = 0$ (by `pointDist_self`) $\\Rightarrow d(p,q) = 0$ (by distance preservation) $\\Rightarrow p = q$ (by definiteness). This demonstrates the bridge from distance preservation to injectivity without any axioms — purely from the metric structure.",
+    "mathContext": "$\\sigma(p) = \\sigma(q) \\Rightarrow d(\\sigma(p), \\sigma(q)) = 0 \\Rightarrow d(p,q) = 0 \\Rightarrow p = q$.",
+    "significance": "key",
+    "relatedConcepts": ["injective function", "distance-preserving map", "metric definiteness"],
+    "prerequisites": ["pointDist_eq_zero_iff", "distance preservation property"]
+  },
+  {
+    "id": "ann-erdos103oq01-surjectivity-axiom",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 129, "endLine": 139 },
+    "type": "concept",
+    "title": "Surjectivity Axiom (Mazur-Ulam)",
+    "content": "The single geometric axiom: distance-preserving maps $\\mathbb{R}^2 \\to \\mathbb{R}^2$ are surjective. This follows from the Mazur-Ulam theorem (1932): every surjective isometry of normed spaces is affine. For finite-dimensional $\\mathbb{R}^n$, isometries decompose as orthogonal transformation + translation, both surjective. Proving this formally would require either classifying $\\mathbb{R}^2$ isometries or the full Mazur-Ulam theorem (neither in current Mathlib).",
+    "mathContext": "Axiom: $\\sigma : \\mathbb{R}^2 \\to \\mathbb{R}^2$ distance-preserving $\\Rightarrow \\sigma$ surjective. Consequence of Mazur-Ulam: isometries of $\\mathbb{R}^n$ are affine (rotation/reflection + translation).",
+    "significance": "key",
+    "relatedConcepts": ["Mazur-Ulam theorem", "affine isometry", "surjective function", "orthogonal group"],
+    "prerequisites": ["normed space isometries", "function surjectivity"]
+  },
+  {
+    "id": "ann-erdos103oq01-inverse",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 153, "endLine": 181 },
+    "type": "technique",
+    "title": "Isometry Inverse Construction and Two-Sided Inverse Proofs",
+    "content": "Constructs $\\sigma^{-1}$ via `Function.surjInv` (which picks a preimage for each point). The inverse preserves distances: $d(\\sigma^{-1}(p), \\sigma^{-1}(q)) = d(\\sigma(\\sigma^{-1}(p)), \\sigma(\\sigma^{-1}(q))) = d(p, q)$, using the fact that $\\sigma(\\sigma^{-1}(x)) = x$ (surjective inverse property). Two-sided inverse: left inverse ($\\sigma^{-1} \\circ \\sigma = \\text{id}$) uses injectivity applied to $\\sigma(\\sigma^{-1}(\\sigma(p))) = \\sigma(p)$; right inverse ($\\sigma \\circ \\sigma^{-1} = \\text{id}$) is immediate from surjective inverse definition.",
+    "mathContext": "$\\sigma^{-1} = \\text{surjInv}(\\sigma)$. Distance preservation: $d(\\sigma^{-1}(p), \\sigma^{-1}(q)) = d(\\sigma(\\sigma^{-1}(p)), \\sigma(\\sigma^{-1}(q))) = d(p,q)$. Left inverse: $\\sigma^{-1}(\\sigma(p)) = p$ by injectivity from $\\sigma(\\sigma^{-1}(\\sigma(p))) = \\sigma(p)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Function.surjInv", "two-sided inverse", "bijective function", "group inverse"],
+    "prerequisites": ["injective + surjective = bijective", "surjective inverse construction"]
+  },
+  {
+    "id": "ann-erdos103oq01-congruence-symm",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 191, "endLine": 213 },
+    "type": "insight",
+    "title": "Congruence Symmetry: Eliminating the Parent's Sorry",
+    "content": "The key contribution fixing the parent formalization: if $P \\cong Q$ via $\\sigma$, then $Q \\cong P$ via $\\sigma^{-1}$, because $\\sigma^{-1}(Q_i) = \\sigma^{-1}(\\sigma(P_i)) = P_i$ by the left-inverse property. The parent file had `sorry` here because it lacked the inverse construction. Transitivity follows similarly: $P \\cong Q$ via $\\sigma_1$ and $Q \\cong R$ via $\\sigma_2$ give $P \\cong R$ via $\\sigma_2 \\circ \\sigma_1$. Geometric invariance (`congruent_preserves_separation`) shows isometries preserve the minimum separation constraint.",
+    "mathContext": "Symmetry: $P \\cong Q$ via $\\sigma \\Rightarrow Q \\cong P$ via $\\sigma^{-1}$, since $\\sigma^{-1}(Q_i) = \\sigma^{-1}(\\sigma(P_i)) = P_i$. Transitivity: $(\\sigma_2 \\circ \\sigma_1)(P_i) = \\sigma_2(\\sigma_1(P_i)) = \\sigma_2(Q_i) = R_i$.",
+    "significance": "key",
+    "relatedConcepts": ["equivalence relation", "congruence", "isometry inverse", "sorry elimination"],
+    "prerequisites": ["Isometry2D.inv", "Isometry2D.inv_comp"]
+  },
+  {
+    "id": "ann-erdos103oq01-counterexample",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 219, "endLine": 252 },
+    "type": "insight",
+    "title": "Counterexample: Unbounded Does Not Imply Tends to Infinity",
+    "content": "Defines the oscillating function $f(n) = n$ if $n$ is even, $0$ if odd. **Unbounded**: for any $C$, take $n = 2(C+1)$ (even), so $f(n) = 2(C+1) > C$. **Not tending to infinity**: for any $N$, the odd number $2N+1 \\geq N$ satisfies $f(2N+1) = 0 \\leq 0$, contradicting $f(n) > 0$ for all $n \\geq N$. The master theorem `unbounded_not_implies_tendsto` refutes the universal statement $\\forall f, (\\text{unbounded} \\Rightarrow \\text{tends to } \\infty)$ by instantiating with this counterexample.",
+    "mathContext": "$f(n) = \\begin{cases} n & n \\text{ even} \\\\ 0 & n \\text{ odd} \\end{cases}$. Unbounded: $f(2(C+1)) = 2(C+1) > C$. Not $\\to \\infty$: $f(2N+1) = 0$ for all $N$.",
+    "significance": "key",
+    "relatedConcepts": ["oscillating sequence", "unbounded vs divergent", "counterexample construction", "omega tactic"],
+    "prerequisites": ["natural number parity", "quantifier negation"]
+  },
+  {
+    "id": "ann-erdos103oq01-monotone-equiv",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 258, "endLine": 317 },
+    "type": "technique",
+    "title": "Correct Equivalence with Monotonicity Hypothesis",
+    "content": "Proves the corrected equivalence: for monotone $f$, unbounded $\\iff$ tends to infinity. The key step: if $f$ is monotone and $f(N_0) > C$, then for all $n \\geq N_0$, $f(n) \\geq f(N_0) > C$. This is the 'propagation' that fails without monotonicity. Applied to $h(n)$: the corrected conjecture is $h \\to \\infty$ (requiring monotonicity for the backward direction of the equivalence). Whether $h$ is actually monotone is itself an open question about optimal packing geometry.",
+    "mathContext": "For monotone $f$: $f(N_0) > C$ and $n \\geq N_0 \\Rightarrow f(n) \\geq f(N_0) > C$. Corrected: $h \\to \\infty \\iff h$ unbounded, assuming $h$ monotone.",
+    "significance": "key",
+    "relatedConcepts": ["monotone function", "Filter.Tendsto", "eventually", "Erdős conjecture formulation"],
+    "prerequisites": ["monotonicity", "order theory", "oscillating_unbounded counterexample"]
+  },
+  {
+    "id": "ann-erdos103oq01-conjecture-chain",
+    "proofId": "erdos-103-oq-01",
+    "range": { "startLine": 323, "endLine": 353 },
+    "type": "concept",
+    "title": "Conjecture Hierarchy: Strong → Weak → Very Weak",
+    "content": "Defines three progressively weaker versions of the Erdős 103 conjecture: **Strong** ($h(n) \\to \\infty$), **Weak** ($h(n) \\geq 2$ for all large $n$), **Very Weak** ($h(n) \\geq 2$ for infinitely many $n$). Proves the implication chain: Strong $\\Rightarrow$ Weak $\\Rightarrow$ Very Weak. Even the very weak conjecture — that there exist infinitely many $n$ with at least two distinct optimal configurations — is currently open. The `hMonotoneQuestion` definition highlights monotonicity as an independent structural question.",
+    "mathContext": "Strong: $\\forall C,\\, \\exists N,\\, \\forall n \\geq N,\\, h(n) > C$. Weak: $\\exists N,\\, \\forall n \\geq N,\\, h(n) \\geq 2$. Very weak: $\\forall N,\\, \\exists n \\geq N,\\, h(n) \\geq 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["conjecture hierarchy", "infinitely often", "eventually", "optimal configuration counting"],
+    "prerequisites": ["ErdosConjecture103 definition", "quantifier nesting"]
+  }
+]

--- a/src/data/proofs/erdos-103-oq-01/meta.json
+++ b/src/data/proofs/erdos-103-oq-01/meta.json
@@ -86,52 +86,76 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Overview and Imports",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Documents Erdős Problem #103 and the investigation goals: metric properties, isometry group structure, counterexample to unbounded↔tends-to-infinity, and corrected conjecture formulation. Imports Mathlib.",
+      "mathContext": "Erdős #103 (1994): $h(n) = |\\{P \\subset \\mathbb{R}^2 : |P|=n, d_{\\min} \\geq 1, \\text{diam minimal}\\} / {\\cong}|$. Question: $h(n) \\to \\infty$?"
+    },
+    {
       "id": "definitions",
-      "title": "Basic Definitions",
-      "startLine": 55,
-      "endLine": 82,
+      "title": "Core Definitions",
+      "startLine": 50,
+      "endLine": 72,
       "summary": "Defines PointConfig, pointDist (Euclidean distance), HasMinSeparation, Isometry2D (distance-preserving map), and AreCongruent (related by isometry).",
       "mathContext": "A point configuration is $\\text{Fin}\\, n \\to \\mathbb{R}^2$. Distance $d(p,q) = \\sqrt{(p_1-q_1)^2 + (p_2-q_2)^2}$. Configurations $P \\cong Q$ if $\\exists \\sigma$ distance-preserving with $Q_i = \\sigma(P_i)$."
     },
     {
       "id": "metric-properties",
       "title": "pointDist Metric Properties",
-      "startLine": 84,
-      "endLine": 121,
+      "startLine": 74,
+      "endLine": 116,
       "summary": "Proves pointDist is nonneg, reflexive (d(p,p)=0), symmetric, and definite (d(p,q)=0 iff p=q). Definiteness uses sq_eq_zero_iff to extract p.1=q.1, p.2=q.2 from squared distance = 0.",
       "mathContext": "$d(p,q) = 0 \\iff (p_1 - q_1)^2 + (p_2 - q_2)^2 = 0 \\iff p_1 = q_1 \\land p_2 = q_2 \\iff p = q$."
     },
     {
       "id": "isometry-properties",
-      "title": "Isometry Properties",
-      "startLine": 123,
-      "endLine": 188,
+      "title": "Isometry Properties and Group Structure",
+      "startLine": 117,
+      "endLine": 181,
       "summary": "Proves isometry injectivity from definiteness. Axiomatizes surjectivity (Mazur-Ulam). Constructs identity, composition, and inverse isometries. Proves inv_comp (left inverse) and comp_inv (right inverse).",
       "mathContext": "Injectivity: $\\sigma(p) = \\sigma(q) \\Rightarrow d(\\sigma(p), \\sigma(q)) = 0 \\Rightarrow d(p,q) = 0 \\Rightarrow p = q$. Inverse: $\\sigma^{-1} = \\text{surjInv}(\\sigma)$, a two-sided inverse by injectivity + surjectivity."
     },
     {
       "id": "congruence-relation",
       "title": "Congruence Equivalence Relation",
-      "startLine": 190,
-      "endLine": 220,
+      "startLine": 183,
+      "endLine": 213,
       "summary": "Proves congruence is reflexive (via identity isometry), symmetric (via inverse isometry, eliminating sorry from parent), and transitive (via composition). Also proves congruence preserves minimum separation.",
       "mathContext": "Symmetry: $P \\cong Q$ via $\\sigma \\Rightarrow Q \\cong P$ via $\\sigma^{-1}$, since $\\sigma^{-1}(Q_i) = \\sigma^{-1}(\\sigma(P_i)) = P_i$."
     },
     {
       "id": "counterexample",
       "title": "Unbounded Does Not Imply Tends to Infinity",
-      "startLine": 222,
-      "endLine": 259,
+      "startLine": 215,
+      "endLine": 252,
       "summary": "Defines the oscillating function (n if even, 0 if odd). Proves it is unbounded (take n=2(C+1)) and does NOT tend to infinity (odd 2N+1 always gives 0). Combines these to show the general implication fails.",
       "mathContext": "Define $f(n) = n$ if $n$ even, $f(n) = 0$ if $n$ odd. Then $\\forall C, \\exists n, f(n) > C$ but $\\neg(\\forall C, \\exists N, \\forall n \\geq N, f(n) > C)$."
     },
     {
       "id": "correct-equivalence",
       "title": "Correct Equivalence with Monotonicity",
-      "startLine": 261,
+      "startLine": 254,
       "endLine": 317,
-      "summary": "Proves: for monotone f, unbounded iff tends to infinity. States corrected conjecture formulation for h(n) requiring monotonicity. Proves conjecture chain: h->inf => weak (h>=2 eventually) => very weak (h>=2 infinitely often).",
-      "mathContext": "For monotone $f$: $f(N_0) > C$ and $n \\geq N_0 \\Rightarrow f(n) \\geq f(N_0) > C$. The chain: $h \\to \\infty \\Rightarrow h(n) \\geq 2$ eventually $\\Rightarrow h(n) \\geq 2$ infinitely often."
+      "summary": "Proves: for monotone f, unbounded iff tends to infinity. States corrected conjecture formulation for h(n) requiring monotonicity.",
+      "mathContext": "For monotone $f$: $f(N_0) > C$ and $n \\geq N_0 \\Rightarrow f(n) \\geq f(N_0) > C$."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Conjecture Hierarchy and Structural Questions",
+      "startLine": 319,
+      "endLine": 354,
+      "summary": "Defines the conjecture chain: Strong (h→∞) => Weak (h≥2 eventually) => Very Weak (h≥2 infinitely often). Highlights monotonicity of h as an independent open question.",
+      "mathContext": "Strong: $\\forall C, \\exists N, \\forall n \\geq N, h(n) > C$. Weak: $\\exists N, \\forall n \\geq N, h(n) \\geq 2$. Very weak: $\\forall N, \\exists n \\geq N, h(n) \\geq 2$."
+    },
+    {
+      "id": "verification",
+      "title": "Export and Verification",
+      "startLine": 356,
+      "endLine": 368,
+      "summary": "#check statements verifying all main results: pointDist_eq_zero_iff, isometry2D_injective, congruent_symm, oscillating_unbounded/not_tendsto, unbounded_not_implies_tendsto, mono_unbounded_iff_tendsto, conjecture_equiv_mono, conjecture_chain.",
+      "mathContext": "Lean's #check confirms type-correctness of all 11 exported theorems."
     }
   ],
   "conclusion": {
@@ -142,12 +166,6 @@
       "Can we compute h(4)? The optimal 4-point configuration with separation >= 1 and minimal diameter is known, but counting incongruent optima requires careful analysis.",
       "Is h eventually monotone (monotone for n >= N0)? This weaker condition still suffices for the equivalence.",
       "Can boundary perturbation arguments provide lower bounds on h(n) for large n?"
-    ],
-    "crossReferences": [
-      {
-        "proofId": "erdos-103",
-        "relationship": "Parent problem: this OQ investigates the main conjecture and corrects a logical error in the parent formalization"
-      }
     ]
   },
   "crossReferences": [
@@ -181,7 +199,7 @@
     "imports": ["Mathlib"],
     "opens": ["Metric", "Set", "Finset"],
     "namespace": "Erdos103OQ01",
-    "lineCount": 367,
+    "lineCount": 368,
     "axiomCount": 3,
     "theoremCount": 23,
     "definitionCount": 14


### PR DESCRIPTION
## Enrichment pass for erdos-103-oq-01

Quality improvement from 42 → substantially higher.

- Added 10 comprehensive annotations covering all proof sections (was empty)
- Each annotation includes mathContext (LaTeX), significance, relatedConcepts, prerequisites
- Added header, structural-properties, and verification sections (9 total, was 6)
- Fixed section line ranges to match actual Lean source
- Removed duplicate crossReferences from conclusion
- Fixed lineCount 367→368