### PR TITLE
Fix: correct erdos-746 sorries count and document True-stubs

### DIFF
--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 4,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",
@@ -80,7 +80,7 @@
     ],
     "axiomCount": 9,
     "lineCount": 262,
-    "assumptions": "9 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "assumptions": "9 axiom declarations, 4 sorries. WARNING: 7 of 9 axioms conclude with True (vacuous). Core definition ErdosQuestion746 is ∀ ε, ε > 0 → True, making summary theorems trivially provable. Only dirac_theorem, limiting_prob_at_infinity, and limiting_prob_at_neg_infinity encode non-trivial mathematical content."
   },
   "overview": {
     "historicalContext": "**The Erdős-Rényi Random Graph Revolution**\n\nErdős and Rényi's 1959–1966 papers on random graphs $G(n, m)$ revolutionized combinatorics by introducing probabilistic methods to study graph properties. They discovered that many graph properties exhibit **sharp thresholds**: the property jumps from almost surely absent to almost surely present as $m$ crosses a critical value.\n\n**The Matching-Hamiltonicity Connection**\n\nIn 1966, Erdős and Rényi proved that $G(n, m)$ with $m \\ge (1/2 + \\varepsilon) n \\log n$ almost surely has a perfect matching. Since a Hamiltonian cycle decomposes into two perfect matchings, they conjectured the same threshold for Hamiltonicity — one of the most natural questions in random graph theory.\n\n**The Path to Resolution**\n\nPósa (1976) proved Hamiltonicity for $Cn \\log n$ edges using his **rotation-extension technique**, a landmark method that became central to probabilistic combinatorics. Korshunov (1977) established the sharp threshold as $(1/2) n \\log n + (1/2) n \\log \\log n + o(n)$, confirming Erdős-Rényi's conjecture. Finally, Komlós and Szemerédi (1983) determined the precise limiting distribution: with $m = (1/2) n \\log n + (1/2) n \\log \\log n + cn$ edges, $\\Pr[\\text{Hamiltonian}] \\to e^{-e^{-2c}}$ — a **Gumbel (double exponential)** distribution.\n\n**The Threshold Coincidence**\n\nRemarkably, the Hamiltonicity threshold coincides with the connectivity threshold. Both are controlled by the same bottleneck: vertices of degree 0 or 1. The factor 2 in the Gumbel exponent $e^{-2c}$ reflects the two failure modes (degree 0 and degree 1) at the critical edge count.",


### PR DESCRIPTION
## Summary

- Fix `sorries` field: 3 → 4 (actual count: 2 in `IsHamiltonianCycle` line 72, 1 in `hamiltonian_implies_connected` line 211, 1 in `MinDegree` line 224)
- Document True-stub problem in `assumptions` field: 7 of 9 axioms conclude with `True` (vacuous), and `ErdosQuestion746` is defined as `∀ ε, ε > 0 → True`

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Confirm sorry count matches Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)