### PR TITLE
Fix: correct erdos-392 sorries count (2→3)

### DIFF
--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary

- Fix `sorries` field: 2 → 3 (line 166 has 1 sorry in `A_one_bound`, line 218 has 2 `by sorry` instances in `erdos_392_summary`)

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)