### PR TITLE
Enrich 6 entries: annotations, index.ts, scholarly references

### DIFF
--- a/src/data/proofs/collatz-structured-oq-02/index.ts
+++ b/src/data/proofs/collatz-structured-oq-02/index.ts
@@ -1,0 +1,39 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CollatzCycles.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const collatzStructuredOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const collatzStructuredOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const collatzStructuredOQ02Data: ProofData = {
+  proof: collatzStructuredOQ02Proof,
+  annotations: collatzStructuredOQ02Annotations,
+  tacticStates: [],
+}
+
+export default collatzStructuredOQ02Data

--- a/src/data/proofs/erdos-1139/index.ts
+++ b/src/data/proofs/erdos-1139/index.ts
@@ -1,0 +1,39 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1139Problem.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1139Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1139Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1139Data: ProofData = {
+  proof: erdos1139Proof,
+  annotations: erdos1139Annotations,
+  tacticStates: [],
+}
+
+export default erdos1139Data

--- a/src/data/proofs/taylor-sincos-convergence/index.ts
+++ b/src/data/proofs/taylor-sincos-convergence/index.ts
@@ -1,0 +1,39 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TaylorSinCosConvergence.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const taylorSinCosConvergenceProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const taylorSinCosConvergenceAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const taylorSinCosConvergenceData: ProofData = {
+  proof: taylorSinCosConvergenceProof,
+  annotations: taylorSinCosConvergenceAnnotations,
+  tacticStates: [],
+}
+
+export default taylorSinCosConvergenceData


### PR DESCRIPTION
## Enrichment batch (6 entries)

### abel-ruffini-oq-04-oq-01 (quality 18 → enriched)
- Created annotations.json with 9 comprehensive annotations (was missing)
- Created index.ts for gallery integration (was missing)
- Added historicalContext covering Abel (1824), Galois (1832), Artin (1942)
- Added conclusion with summary, implications, and 3 open questions
- Fixed references to proper scholarly format, added Wiedijk reference

### erdos-1014-oq-01 (quality 38 → enriched)
- Added 5 annotations with mathContext covering all proof sections
- Added header section, fixed references to proper scholarly format
- Added originalContributions and relatedProofs fields

### geometric-series-oq-01 (missing index.ts)
- Created index.ts for gallery integration

### erdos-1139 (missing index.ts)
- Created index.ts for gallery integration (11 annotations already present)

### collatz-structured-oq-02 (missing index.ts)
- Created index.ts for gallery integration (8 annotations already present)

### taylor-sincos-convergence (missing index.ts)
- Created index.ts for gallery integration (12 annotations already present)