### PR TITLE
Fix: update descartes-rule-of-signs-oq-02 metadata (sorry-free)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.derivative",
@@ -67,9 +67,9 @@
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 3,
-    "lineCount": 552,
-    "theoremCount": 38,
-    "defCount": 9,
+    "lineCount": 698,
+    "theoremCount": 39,
+    "defCount": 8,
     "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Summary

After PR #6431 made this proof sorry-free, metadata was stale:
- `sorries`: 2 → 0 (now sorry-free)
- `lineCount`: 552 → 698 (file grew during research)
- `theoremCount`: 38 → 39
- `defCount`: 9 → 8

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)