### PR TITLE
Update audit tracker: cycle 3 — 6 proofs re-audited

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1226,28 +1226,37 @@
       "issues": []
     },
     "erdos-138": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T08:30:30Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T18:30:00Z",
       "result": "issues-fixed",
-      "issues": []
+      "issues": [
+        "PR #6446: sorries 4\u21925"
+      ]
     },
     "erdos-392": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T08:30:30Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T18:20:00Z",
       "result": "issues-fixed",
-      "issues": []
+      "issues": [
+        "PR #6444: sorries 2\u21923"
+      ]
     },
     "erdos-628": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T08:30:30Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T18:10:00Z",
       "result": "issues-fixed",
-      "issues": []
+      "issues": [
+        "PR #6443: sorries 11\u219212, definitionCount 14\u219212"
+      ]
     },
     "erdos-746": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T08:30:30Z",
-      "result": "issues-fixed",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T18:00:00Z",
+      "result": "issues-found",
+      "issues": [
+        "PR #6440: sorry count 3\u21924",
+        "Issue #6441: 9 vacuous True stubs"
+      ]
     },
     "erdos-1160": {
       "auditCount": 1,
@@ -6548,10 +6557,12 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-719": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
-      "agentId": "auditor-cycle-20-batch"
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T18:40:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "PR #6447: sorries 2\u21921, lineCount 175\u2192196"
+      ]
     },
     "erdos-72": {
       "lastAudited": "2026-03-24T13:12:27Z",
@@ -9200,10 +9211,12 @@
       "issues": []
     },
     "descartes-rule-of-signs-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T23:11:13Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-03-24T18:50:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "PR #6448: sorries 2\u21920, lineCount 552\u2192698"
+      ]
     },
     "fundamental-theorem-algebra-oq-04": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

- Re-audited all 6 proofs flagged with integrity issues
- Updated tracker entries with audit results and PR references
- Most common issue: sorry count mismatch (lines with multiple sorry instances counted as 1)

## Audits performed

| Proof | Issue | Fix |
|-------|-------|-----|
| erdos-746 | CRITICAL: 9 vacuous True stubs | Issue #6441, PR #6440 |
| erdos-628 | sorry 11→12, defCount 14→12 | PR #6443 |
| erdos-392 | sorry 2→3 | PR #6444 |
| erdos-138 | sorry 4→5 | PR #6446 |
| erdos-719 | sorry 2→1, lineCount 175→196 | PR #6447 |
| descartes-oq-02 | sorry 2→0 (now sorry-free) | PR #6448 |

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)