### PR TITLE
Fix: replace 9 vacuous True stubs in erdos-746 with real math content

### DIFF
--- a/proofs/Proofs/Erdos746Problem.lean
+++ b/proofs/Proofs/Erdos746Problem.lean
@@ -60,6 +60,24 @@ noncomputable def preciseThreshold (n : ℕ) : ℝ :=
   else (1/2) * n * Real.log n + (1/2) * n * Real.log (Real.log n)
 
 /-
+## Probabilistic Framework
+
+The results below concern random graphs, where properties hold
+"asymptotically almost surely" (a.a.s.), meaning with probability → 1
+as n → ∞. We introduce opaque predicates to represent these probabilistic
+notions; full formalization would require a measure space on graphs.
+-/
+
+/-- Property P holds asymptotically almost surely for G(n, m(n)):
+    Pr[P(G(n, m(n)))] → 1 as n → ∞. Opaque; full formalization
+    requires a probability space on graphs. -/
+opaque AlmostSurely (m : ℕ → ℝ) (P : (n : ℕ) → GraphOnN n → Prop) : Prop
+
+/-- The probability that a uniformly random graph G(n, m) satisfies P.
+    Opaque; defines the random variable used in limit statements. -/
+opaque ProbInGnm (n : ℕ) (m : ℝ) (P : GraphOnN n → Prop) : ℝ
+
+/-
 ## Part II: Hamiltonicity
 -/
 
@@ -99,10 +117,10 @@ def HasPerfectMatching (G : GraphOnN n) : Prop :=
 
 /-- **Erdős-Rényi (1966):**
     Random graph with ≥ (1/2 + ε)n log n edges almost surely has a perfect matching. -/
-axiom erdos_renyi_matching (n : ℕ) (hn : n ≥ 2) (hn_even : Even n) (ε : ℝ) (hε : ε > 0) :
-  -- With probability tending to 1:
-  -- G(n, m) with m ≥ (1/2 + ε)n log n has a perfect matching
-  True
+axiom erdos_renyi_matching (ε : ℝ) (hε : ε > 0) :
+  AlmostSurely
+    (fun n => hamiltonianThreshold n ε)
+    (fun n G => HasPerfectMatching G)
 
 /-
 ## Part V: The Erdős Question
@@ -112,8 +130,9 @@ axiom erdos_renyi_matching (n : ℕ) (hn : n ≥ 2) (hn_even : Even n) (ε : ℝ
     ≥ (1/2 + ε)n log n edges are Hamiltonian? -/
 def ErdosQuestion746 : Prop :=
   ∀ ε : ℝ, ε > 0 →
-    -- Almost surely: G(n, m) with m ≥ (1/2 + ε)n log n is Hamiltonian
-    True
+    AlmostSurely
+      (fun n => hamiltonianThreshold n ε)
+      (fun n G => IsHamiltonian G)
 
 /-
 ## Part VI: Pósa's Result
@@ -123,9 +142,9 @@ def ErdosQuestion746 : Prop :=
     Random graph with ≥ Cn log n edges is almost surely Hamiltonian (for large C). -/
 axiom posa_theorem :
   ∃ C : ℝ, C > 0 ∧
-    ∀ n : ℕ, n ≥ 3 →
-      -- Almost surely: G(n, m) with m ≥ Cn log n is Hamiltonian
-      True
+    AlmostSurely
+      (fun n => C * ↑n * Real.log ↑n)
+      (fun n G => IsHamiltonian G)
 
 /-- Pósa's constant is finite but not optimal. -/
 def posaConstant : ℝ := 1000 -- Placeholder, actual value not specified
@@ -134,36 +153,35 @@ def posaConstant : ℝ := 1000 -- Placeholder, actual value not specified
 ## Part VII: Korshunov's Improvement
 -/
 
-/-- **Korshunov (1977):**
-    ≥ (1/2)n log n + (1/2)n log log n + ω(n)n edges suffices for Hamiltonicity,
-    where ω(n) → ∞ as n → ∞. -/
-axiom korshunov_theorem :
-  ∀ ω : ℕ → ℝ, (∀ n, ω n > 0) → (Filter.Tendsto ω Filter.atTop Filter.atTop) →
-    ∀ n : ℕ, n ≥ 3 →
-      -- Almost surely: G(n, m) with m ≥ (1/2)n log n + (1/2)n log log n + ω(n)n
-      -- is Hamiltonian
-      True
-
 /-- Korshunov established the sharp threshold up to lower order terms. -/
 def korshunovThreshold (n : ℕ) (ω : ℕ → ℝ) : ℝ :=
   if n ≤ 2 then 0
   else (1/2) * n * Real.log n + (1/2) * n * Real.log (Real.log n) + ω n * n
 
+/-- **Korshunov (1977):**
+    ≥ (1/2)n log n + (1/2)n log log n + ω(n)n edges suffices for Hamiltonicity,
+    where ω(n) → ∞ as n → ∞. -/
+axiom korshunov_theorem (ω : ℕ → ℝ) (hω_pos : ∀ n, ω n > 0)
+    (hω_tend : Filter.Tendsto ω Filter.atTop Filter.atTop) :
+  AlmostSurely
+    (fun n => korshunovThreshold n ω)
+    (fun n G => IsHamiltonian G)
+
 /-
 ## Part VIII: Komlós-Szemerédi Precise Result
 -/
+
+/-- The limiting probability at threshold. -/
+noncomputable def limitingProbability (c : ℝ) : ℝ :=
+  Real.exp (-Real.exp (-2 * c))
 
 /-- **Komlós-Szemerédi (1983):**
     With (1/2)n log n + (1/2)n log log n + cn edges,
     P(Hamiltonian) → e^{-e^{-2c}} as n → ∞. -/
 axiom komlos_szemeredi_theorem (c : ℝ) :
-  -- The probability that G(n, m) is Hamiltonian tends to e^{-e^{-2c}}
-  -- when m = (1/2)n log n + (1/2)n log log n + cn
-  True
-
-/-- The limiting probability at threshold. -/
-noncomputable def limitingProbability (c : ℝ) : ℝ :=
-  Real.exp (-Real.exp (-2 * c))
+  Filter.Tendsto
+    (fun n => ProbInGnm n (preciseThreshold n + c * ↑n) (fun G => IsHamiltonian G))
+    Filter.atTop (nhds (limitingProbability c))
 
 /-- At c = 0, probability is e^{-1} ≈ 0.368. -/
 theorem limiting_prob_at_zero : limitingProbability 0 = Real.exp (-1) := by
@@ -181,16 +199,15 @@ axiom limiting_prob_at_neg_infinity :
 ## Part IX: The Answer
 -/
 
-/-- The answer is YES: the conjecture is true. -/
+/-- The answer is YES: the conjecture is true.
+    Follows from Korshunov's theorem: for any ε > 0, choosing ω → ∞ slowly
+    gives korshunovThreshold ≤ hamiltonianThreshold for large n. -/
 theorem erdos_746_answer : ErdosQuestion746 := by
-  intro ε hε
-  -- Korshunov's theorem implies this
-  trivial
+  sorry
 
 /-- The threshold for Hamiltonicity is (1/2)n log n + (1/2)n log log n. -/
 def hamiltonianThresholdValue : Prop :=
-  -- The sharp threshold is (1/2)n log n + (1/2)n log log n
-  True
+  AlmostSurely (fun n => preciseThreshold n) (fun n G => IsHamiltonian G)
 
 /-
 ## Part X: Connection to Connectivity
@@ -201,19 +218,22 @@ def IsConnected (G : GraphOnN n) : Prop :=
   ∀ u v : Fin n, G.Reachable u v
 
 /-- The threshold for connectivity is also (1/2)n log n. -/
-axiom connectivity_threshold (n : ℕ) (hn : n ≥ 2) (ε : ℝ) (hε : ε > 0) :
-  -- Almost surely: G(n, m) with m ≥ (1/2 + ε)n log n is connected
-  True
+axiom connectivity_threshold (ε : ℝ) (hε : ε > 0) :
+  AlmostSurely
+    (fun n => hamiltonianThreshold n ε)
+    (fun n G => IsConnected G)
 
 /-- Hamiltonicity implies connectivity. -/
 theorem hamiltonian_implies_connected (G : GraphOnN n) (hn : n ≥ 2) :
     IsHamiltonian G → IsConnected G := by
   sorry
 
-/-- The thresholds for connectivity and Hamiltonicity coincide. -/
+/-- The thresholds for connectivity and Hamiltonicity coincide:
+    both properties hold a.a.s. above (1/2 + ε)n log n edges. -/
 def thresholdCoincidence : Prop :=
-  -- Both are (1/2)n log n (up to lower order terms)
-  True
+  ∀ ε : ℝ, ε > 0 →
+    AlmostSurely (fun n => hamiltonianThreshold n ε) (fun n G => IsHamiltonian G) ∧
+    AlmostSurely (fun n => hamiltonianThreshold n ε) (fun n G => IsConnected G)
 
 /-
 ## Part XI: Related Properties
@@ -223,10 +243,11 @@ def thresholdCoincidence : Prop :=
 def MinDegree (G : GraphOnN n) : ℕ :=
   (Finset.univ : Finset (Fin n)).inf' (by sorry) (fun v => G.degree v)
 
-/-- Random graphs typically have minimum degree close to average degree. -/
-axiom random_graph_min_degree (n m : ℕ) (hn : n ≥ 2) :
-  -- In G(n, m), the minimum degree is close to 2m/n with high probability
-  True
+/-- Random graphs above the Hamiltonicity threshold a.a.s. have no isolated vertices. -/
+axiom random_graph_min_degree (ε : ℝ) (hε : ε > 0) :
+  AlmostSurely
+    (fun n => hamiltonianThreshold n ε)
+    (fun n G => MinDegree G ≥ 1)
 
 /-
 ## Part XII: Summary
@@ -246,15 +267,14 @@ Answer: YES
 theorem erdos_746 : ErdosQuestion746 := erdos_746_answer
 
 /-- Main result: The conjecture is true. -/
-theorem erdos_746_main :
-    ∀ ε : ℝ, ε > 0 → True := -- Probability statement about Hamiltonicity
-  fun ε hε => erdos_746 ε hε
+theorem erdos_746_main : ErdosQuestion746 := erdos_746
 
 /-- The precise limiting distribution is known. -/
 theorem erdos_746_precise (c : ℝ) :
-    -- P(Hamiltonian) → e^{-e^{-2c}} at the threshold
-    True := by
-  exact komlos_szemeredi_theorem c
+    Filter.Tendsto
+      (fun n => ProbInGnm n (preciseThreshold n + c * ↑n) (fun G => IsHamiltonian G))
+      Filter.atTop (nhds (limitingProbability c)) :=
+  komlos_szemeredi_theorem c
 
 /-- The problem is completely solved. -/
 theorem erdos_746_solved : ErdosQuestion746 := erdos_746

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",
@@ -51,15 +51,17 @@
       "GraphOnN: simple graphs on n vertices",
       "numEdges: edge count",
       "hamiltonianThreshold, preciseThreshold: threshold functions",
+      "AlmostSurely, ProbInGnm: opaque framework predicates for probabilistic random graph statements",
       "IsHamiltonianCycle, IsHamiltonian: Hamiltonicity definitions",
       "IsPerfectMatching, HasPerfectMatching: matching definitions",
-      "ErdosQuestion746: formal problem statement",
-      "erdos_renyi_matching axiom: perfect matching threshold",
-      "posa_theorem axiom: Cn log n suffices",
-      "korshunov_theorem axiom: sharp threshold",
-      "komlos_szemeredi_theorem axiom: limiting probability e^{-e^{-2c}}",
+      "ErdosQuestion746: formal problem statement (AlmostSurely Hamiltonian above threshold)",
+      "erdos_renyi_matching axiom: a.a.s. perfect matching above (1/2+ε)n log n",
+      "posa_theorem axiom: ∃ C, a.a.s. Hamiltonian above Cn log n",
+      "korshunov_theorem axiom: a.a.s. Hamiltonian above sharp threshold",
+      "komlos_szemeredi_theorem axiom: Pr(Ham) → e^{-e^{-2c}} via Filter.Tendsto",
       "limitingProbability, limiting_prob_at_zero: probability function",
-      "IsConnected, hamiltonian_implies_connected: connectivity"
+      "IsConnected, hamiltonian_implies_connected: connectivity",
+      "thresholdCoincidence: Hamiltonicity and connectivity share the threshold"
     ],
     "relatedProblems": [
       {
@@ -80,7 +82,7 @@
     ],
     "axiomCount": 9,
     "lineCount": 262,
-    "assumptions": "9 axiom declarations, 4 sorries. WARNING: 7 of 9 axioms conclude with True (vacuous). Core definition ErdosQuestion746 is ∀ ε, ε > 0 → True, making summary theorems trivially provable. Only dirac_theorem, limiting_prob_at_infinity, and limiting_prob_at_neg_infinity encode non-trivial mathematical content."
+    "assumptions": "9 axiom declarations (all with non-trivial mathematical content), 5 sorries, 2 opaque framework predicates (AlmostSurely, ProbInGnm). Axioms encode: Dirac's theorem, Erdős-Rényi matching threshold, Pósa's theorem, Korshunov's sharp threshold, Komlós-Szemerédi limiting probability, asymptotic limit behavior of limitingProbability, connectivity threshold, and minimum degree concentration. Probabilistic statements use opaque AlmostSurely/ProbInGnm predicates since full formalization requires a measure space on graphs."
   },
   "overview": {
     "historicalContext": "**The Erdős-Rényi Random Graph Revolution**\n\nErdős and Rényi's 1959–1966 papers on random graphs $G(n, m)$ revolutionized combinatorics by introducing probabilistic methods to study graph properties. They discovered that many graph properties exhibit **sharp thresholds**: the property jumps from almost surely absent to almost surely present as $m$ crosses a critical value.\n\n**The Matching-Hamiltonicity Connection**\n\nIn 1966, Erdős and Rényi proved that $G(n, m)$ with $m \\ge (1/2 + \\varepsilon) n \\log n$ almost surely has a perfect matching. Since a Hamiltonian cycle decomposes into two perfect matchings, they conjectured the same threshold for Hamiltonicity — one of the most natural questions in random graph theory.\n\n**The Path to Resolution**\n\nPósa (1976) proved Hamiltonicity for $Cn \\log n$ edges using his **rotation-extension technique**, a landmark method that became central to probabilistic combinatorics. Korshunov (1977) established the sharp threshold as $(1/2) n \\log n + (1/2) n \\log \\log n + o(n)$, confirming Erdős-Rényi's conjecture. Finally, Komlós and Szemerédi (1983) determined the precise limiting distribution: with $m = (1/2) n \\log n + (1/2) n \\log \\log n + cn$ edges, $\\Pr[\\text{Hamiltonian}] \\to e^{-e^{-2c}}$ — a **Gumbel (double exponential)** distribution.\n\n**The Threshold Coincidence**\n\nRemarkably, the Hamiltonicity threshold coincides with the connectivity threshold. Both are controlled by the same bottleneck: vertices of degree 0 or 1. The factor 2 in the Gumbel exponent $e^{-2c}$ reflects the two failure modes (degree 0 and degree 1) at the critical edge count.",
@@ -221,10 +223,10 @@
       "Finset"
     ],
     "namespace": "Erdos746",
-    "lineCount": 262,
+    "lineCount": 282,
     "axiomCount": 9,
     "theoremCount": 7,
-    "definitionCount": 17
+    "definitionCount": 19
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Replace all 9 vacuous `True` conclusions in erdos-746 (Hamiltonicity of Random Graphs) with actual mathematical content encoding the probabilistic random graph theorems.

## Evidence

**Before**: 7 of 9 axioms and 2 of 3 key definitions concluded with `True`, making `ErdosQuestion746 := ∀ ε, ε > 0 → True` and all summary theorems trivially provable by `trivial`.

**After**: All axioms now conclude with substantive mathematical assertions:
- `erdos_renyi_matching`: concludes with `AlmostSurely ... HasPerfectMatching`
- `ErdosQuestion746`: defined as `∀ ε > 0, AlmostSurely ... IsHamiltonian`
- `posa_theorem`: concludes with `∃ C > 0, AlmostSurely ... IsHamiltonian`
- `korshunov_theorem`: concludes with `AlmostSurely (korshunovThreshold) ... IsHamiltonian`
- `komlos_szemeredi_theorem`: concludes with `Filter.Tendsto ProbInGnm ... (nhds (limitingProbability c))`
- `connectivity_threshold`: concludes with `AlmostSurely ... IsConnected`
- `random_graph_min_degree`: concludes with `AlmostSurely ... MinDegree ≥ 1`
- `hamiltonianThresholdValue`: encodes a.a.s. Hamiltonicity at precise threshold
- `thresholdCoincidence`: encodes both Hamiltonicity and connectivity above threshold

Two `opaque` framework predicates added (`AlmostSurely`, `ProbInGnm`) to represent probabilistic content without requiring a measure space on graphs.

**Counts**: sorries 4→5 (erdos_746_answer now requires proof), axioms 9→9, defs 17→19.

Closes #6441

---
Automated fix by lean-mechanic agent.