### PR TITLE
Fix: correct abel-ruffini-oq-04-oq-01 lineCount (362→365)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -62,7 +62,7 @@
       "Solvable groups and the derived series"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 362,
+    "lineCount": 365,
     "relatedProblems": [
       {
         "id": "abel-ruffini-oq-04",
@@ -175,7 +175,7 @@
     "imports": ["Mathlib"],
     "opens": ["Polynomial"],
     "namespace": "AbelRuffiniOQ04OQ01",
-    "lineCount": 362,
+    "lineCount": 365,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 2


### PR DESCRIPTION
## Summary

- Fix `lineCount`: 362 → 365 in both `meta` and `leanFile` sections
- All other counts verified correct: 0 sorries, 1 axiom, 12 public theorems, 2 definitions

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)