### PR TITLE
Enrich ptolemys-theorem and hilbert-15: address peer review findings

### DIFF
--- a/src/data/proofs/hilbert-15/review.json
+++ b/src/data/proofs/hilbert-15/review.json
@@ -3,14 +3,12 @@
   "proofId": "hilbert-15",
   "reviewDate": "2026-03-24T12:30:00Z",
   "reviewer": "peer-reviewer",
-
   "overallAssessment": {
     "grade": "B-",
     "oneLiner": "Well-formulated linear algebra definitions with clean axiom statements for deep algebraic geometry results, but all proofs are trivial and the Schubert number constants float unconnected from the axiomatized machinery.",
     "tier": "C",
     "tierJustification": "Scaffold/axiomatized. The 14 definitions are genuine and use Mathlib's linear algebra properly (Grassmannian via submodule subtypes, intersection predicates, partitions). However, all 3 theorems are trivial (rfl or subtype extraction) and the 8 axioms carry all mathematical content. The Schubert numbers are hardcoded constants with no formal derivation from the axiomatized intersection theory. The quality of definitions elevates this above a mere scaffold, but no non-trivial proof exists in the file."
   },
-
   "findings": [
     {
       "severity": "positive",
@@ -76,7 +74,6 @@
       "recommendation": "Add a qualifier: 'The step-by-step computation (described in annotations) shows how...' or formalize the intermediate steps as axioms/theorems."
     }
   ],
-
   "actionItems": [
     {
       "id": "ai-1",
@@ -90,7 +87,7 @@
       "priority": "medium",
       "target": "enricher",
       "description": "Fix meta.json: (1) change originalContributions #6 from 'verified' to 'axiomatized', (2) list all 8 axioms in assumptions field, (3) remove empty strings from relatedProofs, (4) add qualifier to keyInsight #5 about intermediate computation.",
-      "status": "done",
+      "status": "resolved",
       "resolution": "Fixed in PR #5961 (merged)"
     },
     {
@@ -115,7 +112,6 @@
       "status": "open"
     }
   ],
-
   "qualityScores": {
     "mathematicalSubstance": 5,
     "originalityAccuracy": 7,
@@ -125,6 +121,5 @@
     "internalConsistency": 7,
     "overall": 6.7
   },
-
   "suggestedBestFraming": "An axiomatized formalization of Schubert calculus on Grassmannians in Lean 4, with clean linear-algebraic definitions of the Grassmannian Gr(k,n), lines in P³, and Schubert classes, and well-stated axioms for the Four Lines Theorem, Schubert basis theorem, and Littlewood-Richardson rule — the algebraic geometry results await Mathlib infrastructure."
 }

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -28,7 +28,7 @@
     "originalContributions": [
       "Pedagogical examples connecting Ptolemy to the Pythagorean theorem (rectangle case)",
       "Curated exposition of historical and mathematical context",
-      "Symmetric formulation of Ptolemy's theorem"
+      "Named theorem API providing symmetric and rearranged forms for downstream use"
     ],
     "dateAdded": "2025-12-27",
     "wiedijkNumber": 95,
@@ -145,7 +145,7 @@
     }
   ],
   "conclusion": {
-    "summary": "A well-curated Mathlib wrapper presenting Ptolemy's theorem via EuclideanGeometry.mul_dist_le_mul_dist_add_mul_dist. The file provides 3 distinct theorem statements (main, symmetric, and rectangle/Pythagorean specialization) with extensive historical and pedagogical context. The core mathematical work is in Mathlib.",
+    "summary": "A well-curated Mathlib wrapper presenting Ptolemy's theorem via `mul_dist_add_mul_dist_eq_mul_dist_of_cospherical`. The file provides 3 named theorem variants (main, symmetric, rearranged) with 4 verified numerical examples and extensive historical and pedagogical context. The core mathematical work is in Mathlib.",
     "implications": "**Theoretical Significance**: Ptolemy's theorem bridges ancient and modern mathematics. It yields the trigonometric addition formulas (the foundation of trigonometry), generalizes the Pythagorean theorem, and characterizes cyclic quadrilaterals.\n\nThe complex-number proof reveals connections to conformal mappings and inversive geometry. Ptolemy's inequality generalizes to higher dimensions and is related to the positive semidefiniteness of the Cayley-Menger determinant.",
     "openQuestions": [
       "Can Ptolemy's inequality (AC·BD ≤ AB·CD + AD·BC for arbitrary four points) be formalized, with equality characterized by concyclicity?",

--- a/src/data/proofs/ptolemys-theorem/review.json
+++ b/src/data/proofs/ptolemys-theorem/review.json
@@ -3,14 +3,12 @@
   "proofId": "ptolemys-theorem",
   "reviewDate": "2026-03-24T20:15:00Z",
   "reviewer": "peer-reviewer",
-
   "overallAssessment": {
     "grade": "C+",
     "oneLiner": "Honest Mathlib wrapper with excellent pedagogy, undermined by duplicate theorems, a wrong function reference, and inflated theorem counts",
     "tier": "B",
     "tierJustification": "The entire mathematical content is a single call to Mathlib's mul_dist_add_mul_dist_eq_mul_dist_of_cospherical. The file adds naming, two trivial algebraic variants (rw, mul_comm), four arithmetic examples, and extensive commentary. Three of eight sections contain no formal Lean content at all — they are pure /-! ... -/ comment blocks. No original proof reasoning beyond a 3-step square example."
   },
-
   "findings": [
     {
       "severity": "positive",
@@ -97,7 +95,6 @@
       "recommendation": "If the theorem is removed (recommended), delete this annotation. If kept, change significance to 'supporting'."
     }
   ],
-
   "actionItems": [
     {
       "id": "ai-1",
@@ -111,21 +108,21 @@
       "priority": "high",
       "target": "enricher",
       "description": "Fix wrong Mathlib function name in conclusion.summary: replace 'EuclideanGeometry.mul_dist_le_mul_dist_add_mul_dist' (inequality) with 'mul_dist_add_mul_dist_eq_mul_dist_of_cospherical' (equality). The current name points to Ptolemy's inequality, not the equality theorem actually used.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-3",
       "priority": "medium",
       "target": "enricher",
       "description": "Rewrite conclusion.summary: replace '3 distinct theorem statements (main, symmetric, and rectangle/Pythagorean specialization)' with '3 named theorem variants (main, symmetric, rearranged) with 4 verified numerical examples.' The rectangle case is an unnamed example, not a named theorem.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",
       "priority": "medium",
       "target": "enricher",
       "description": "Replace originalContributions[2] ('Symmetric formulation of Ptolemy's theorem') with 'Named theorem API providing symmetric and rearranged forms for downstream use' — a one-line rw step is not an original contribution.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-5",
@@ -142,7 +139,6 @@
       "status": "open"
     }
   ],
-
   "qualityScores": {
     "mathematicalSubstance": 4,
     "originalityAccuracy": 6,
@@ -152,6 +148,5 @@
     "internalConsistency": 5,
     "overall": 5.8
   },
-
   "suggestedBestFraming": "A pedagogical Mathlib wrapper that names and documents Ptolemy's theorem (Wiedijk #95) with four verified numerical examples — including the elegant reduction to the Pythagorean theorem for rectangular cyclic quadrilaterals — and extensive, well-researched historical context on Ptolemy's Almagest and ancient chord tables."
 }


### PR DESCRIPTION
## Enrichment: peer review fixes

### ptolemys-theorem
Addresses 3 of 6 peer review action items (in enricher scope):
- **ai-2** (high): Fixed wrong Mathlib function name in conclusion.summary
- **ai-3** (medium): Rewrote conclusion.summary accurately
- **ai-4** (medium): Fixed originalContributions[2]

Remaining items (ai-1, ai-5, ai-6) involve Lean source changes — deferred to mechanic.

### hilbert-15
- **ai-2**: Marked as resolved (already fixed in merged PR #5961)