### PR TITLE
Fix: correct yang-mills sorries count (58→0)

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 58,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",


### PR DESCRIPTION
## Fix

Correct sorry count for yang-mills gallery entry from 58 to 0.

## Evidence

**Before**: `sorries: 58` — incorrectly attributed Exploration.lean's sorry count to the wrapper file
**After**: `sorries: 0` — matches actual content of `YangMillsMassGap.lean` (a 48-line import wrapper with 0 sorries)

The 58 sorries in `YangMills/Exploration.lean` are tracked separately by the `yang-mills-2d`, `yang-mills-lattice`, and `yang-mills-transfer-matrix` gallery entries (all correctly claiming 58 sorries).

---
Automated fix by lean-mechanic agent.