### PR TITLE
Peer review: cevas-theorem-oq-02-oq-01 (A-)

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/review.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/review.json
@@ -1,0 +1,108 @@
+{
+  "version": 1,
+  "proofId": "cevas-theorem-oq-02-oq-01",
+  "reviewDate": "2026-03-25T01:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "A-",
+    "oneLiner": "A genuinely strong formalization of spherical Ceva via unit-vector weight parameters, anchored by a substantial 56-line sin-ratio proof with real algebraic computation",
+    "tier": "A",
+    "tierJustification": "All 6 theorems are fully proved with 0 sorries and 0 axioms. The file completely answers its stated open question (OQ-02-OQ-01). The core proof (sin_ratio_cevian_point) is original work using Mathlib infrastructure for a novel formulation. No filler -- every theorem proves what it claims."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "sin_ratio_cevian_point, lines 73-128",
+      "finding": "A substantial 56-line proof doing genuine algebraic computation: computes inner products of normalized vectors (lines 107-111), derives n^2 expansion (lines 99-105), establishes strict bounds on m = <B,C> (lines 86-93), proves the key identity n^2 - (alpha + beta*m)^2 = beta^2(1-m^2) (line 112), applies sin(arccos(t)) = sqrt(1-t^2) (lines 114-125), and achieves the cancellation sqrt(1-m^2)/n in the ratio (lines 126-128). This is NOT a Mathlib wrapper -- the entire chain of computation is original proof work using Mathlib as infrastructure.",
+      "recommendation": "Preserve. This is the file's core value and demonstrates real inner-product-space reasoning in Lean 4."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Overall file structure (lines 1-262)",
+      "finding": "The file has a clean mathematical arc: single-cevian formula -> triple product -> algebraic criterion -> main iff theorem. Each theorem builds naturally on the previous one. The structure mirrors how a mathematician would develop the result, making it pedagogically effective as well as formally correct.",
+      "recommendation": "Preserve this modular structure. It makes the proof readable and each component independently useful."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json overview.proofStrategy (line 70) and keyInsights (lines 71-78)",
+      "finding": "The proof strategy explanation accurately captures the algebraic mechanism: the key identity derivation, the cancellation of sqrt(1-m^2)/n, and how the three cevian ratios multiply independently. Key insight #1 ('sin-ratio depends ONLY on weight parameters') is the mathematical heart of the result and is correctly highlighted.",
+      "recommendation": "Preserve."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions[4] and conclusion.implications item 3",
+      "finding": "Claims the file 'bridges CevasTheoremSinRatio.lean and CevasTheoremNonEuclidean.lean via explicit weight parameters.' However, the file does NOT import from either of these files. It re-derives the sin-ratio formula from scratch. The 'bridge' is conceptual (the mathematical connection exists) but not formally implemented (no Lean-level dependency). A reader might expect formal interoperability.",
+      "recommendation": "Enricher action: Qualify the bridge claim. Change originalContributions[4] to: 'Provides a concrete unit-vector formulation that conceptually connects the sin-ratio approach (CevasTheoremSinRatio.lean) with the abstract Ceva formulation (CevasTheoremNonEuclidean.lean) -- the formal bridge is not yet implemented as Lean imports.' Similarly update conclusion.implications item 3."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json sections",
+      "finding": "Sections 'weight-balance' (170-262) and 'special-cases' (200-262) overlap by 62 lines. The weight-balance section claims lines 170-262 but should end around 201 (after spherical_ceva_weight_balance_iff). Lines 203-216 (weight_balance_symmetric, equal_weight_ceva) belong to special-cases. Lines 218-261 (spherical_ceva_iff_weight_balance, the main theorem) should be their own section.",
+      "recommendation": "Enricher action: Split into three non-overlapping sections: 'weight-balance-criterion' (170-201), 'special-cases' (203-216), and 'main-theorem' (218-261). Remove the overlap."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json badge field",
+      "finding": "Badge is 'verified' but the author field says 'unit-vector formulation original'. The sin_ratio_cevian_point proof is original work on a novel formulation -- it doesn't just verify a known Mathlib result. Badge 'original' would more accurately reflect the contribution.",
+      "recommendation": "Enricher action: Consider changing badge from 'verified' to 'original' to reflect the novel formulation. Either is defensible; 'original' better matches the file's actual contribution."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json mathlibDependencies",
+      "finding": "Lists 4 dependencies (sin_arccos, inner_smul_right, norm_add_sq_real, sqrt_mul) but the proof uses at least 6 more: real_inner_self_eq_norm_sq (lines 95-96), norm_sub_sq_real (line 88), norm_pos_iff (line 84), sqrt_pos (line 127), sqrt_sq (lines 119, 125), and field_simp (line 128). The listed 4 are the most important, but the list is incomplete.",
+      "recommendation": "Enricher action: Add at least real_inner_self_eq_norm_sq and norm_sub_sq_real to the mathlibDependencies list, as these are mathematically significant (not just tactic calls)."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "crossReferences, pythagorean-theorem entry",
+      "finding": "The cross-reference to pythagorean-theorem claims 'Pythagoras and Ceva are both fundamental results about triangles that admit deep generalizations.' This is too generic to be useful -- nearly all classical geometry theorems fit this description. The connection is not mathematically illuminating.",
+      "recommendation": "Enricher action: Either replace with a more specific cross-reference (e.g., to a spherical geometry entry) or remove entirely."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Qualify the 'bridge' claim in originalContributions[4] and conclusion.implications item 3. The file re-derives the sin-ratio formula rather than importing it from CevasTheoremSinRatio.lean. Note the bridge is conceptual, not formal.",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix overlapping sections: split 'weight-balance' (170-262) into 'weight-balance-criterion' (170-201), 'special-cases' (203-216), and 'main-theorem' (218-261).",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Consider upgrading badge from 'verified' to 'original'. Add real_inner_self_eq_norm_sq and norm_sub_sq_real to mathlibDependencies. Replace or remove the generic pythagorean-theorem cross-reference.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 8,
+    "originalityAccuracy": 8,
+    "completeness": 9,
+    "framingPrecision": 8,
+    "pedagogicalQuality": 9,
+    "internalConsistency": 7,
+    "overall": 8.2
+  },
+
+  "suggestedBestFraming": "A complete formalization of the spherical Ceva theorem using concrete unit vectors in an abstract real inner product space. The core result: for cevian points D = normalize(alpha*B + beta*C) on great-circle arcs, sin(BD)/sin(DC) = beta/alpha, and the concurrency condition reduces to the weight-balance equation alpha_D*alpha_E*alpha_F = beta_D*beta_E*beta_F. All 6 theorems fully proved, 0 axioms, 0 sorries."
+}

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -328,6 +328,14 @@
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0
+    },
+    "cevas-theorem-oq-02-oq-01": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-25T00:38:18Z",
+      "overallGrade": "A-",
+      "qualityScore": null,
+      "actionItems": 0,
+      "resolvedItems": 0
     }
   }
 }


### PR DESCRIPTION
## Summary

First peer review of `cevas-theorem-oq-02-oq-01` — Spherical Ceva via Unit Vectors and Weight Balance.

**Grade: A-** (overall score 8.2/10)

**Strengths**:
- `sin_ratio_cevian_point` is a substantial 56-line proof with genuine algebraic computation (inner products, norm bounds, trig identities, cancellation). NOT a Mathlib wrapper.
- Clean mathematical arc: single-cevian formula -> triple product -> algebraic criterion -> main iff theorem
- Proof strategy documentation matches the code line-by-line
- All 6 theorems fully proved, 0 sorries, 0 axioms (legitimate Tier A)

**Issues found**:
- **Moderate**: Claims to "bridge" sibling Lean files but doesn't import from them (re-derives instead). Bridge is conceptual, not formal.
- **Moderate**: Two sections overlap (weight-balance 170-262 and special-cases 200-262)
- **Minor**: Badge could be "original" rather than "verified", mathlibDependencies incomplete, generic pythagorean-theorem cross-reference

**Scores**: Substance 8, Originality 8, Completeness 9, Framing 8, Pedagogy 9, Consistency 7

## Action items

| ID | Priority | Target | Description |
|----|----------|--------|-------------|
| ai-1 | Medium | Enricher | Qualify the conceptual-not-formal "bridge" claim |
| ai-2 | Medium | Enricher | Fix overlapping section boundaries |
| ai-3 | Low | Enricher | Badge, mathlibDeps, cross-ref tweaks |

## Test plan

- [x] review.json validates as JSON
- [x] review-tracker.json updated
- [x] No modifications to proof source or meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)