### PR TITLE
Enrich 11 entries: annotations, references, cross-refs

### DIFF
--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -146,5 +146,31 @@
     "axiomCount": 12,
     "theoremCount": 1,
     "definitionCount": 11
-  }
+  },
+  "references": [
+    {
+      "key": "Er46",
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "On sets of distances of n points",
+      "venue": "American Mathematical Monthly",
+      "year": "1946",
+      "volume": "53",
+      "pages": "248-250",
+      "note": "Early work on distance problems in the plane, context for unit circle incidence questions"
+    },
+    {
+      "key": "PS04",
+      "authors": [
+        "J. Pach",
+        "M. Sharir"
+      ],
+      "title": "Geometric incidences",
+      "venue": "Towards a Theory of Geometric Graphs, AMS",
+      "year": "2004",
+      "pages": "185-223",
+      "note": "Survey of incidence geometry including unit circle problems"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-11/meta.json
+++ b/src/data/proofs/erdos-11/meta.json
@@ -186,5 +186,33 @@
     "axiomCount": 6,
     "theoremCount": 8,
     "definitionCount": 8
-  }
+  },
+  "references": [
+    {
+      "key": "Er50",
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "On integers of the form 2^k + p and some related problems",
+      "venue": "Summa Brasil. Math.",
+      "year": "1950",
+      "volume": "2",
+      "pages": "113-123",
+      "note": "Original formulation of the problem about squarefree numbers plus powers of 2"
+    },
+    {
+      "key": "Cr02",
+      "authors": [
+        "R. Crandall",
+        "K. Dilcher",
+        "C. Pomerance"
+      ],
+      "title": "A search for Wieferich and Wilson primes",
+      "venue": "Mathematics of Computation",
+      "year": "1997",
+      "volume": "66",
+      "pages": "433-449",
+      "note": "Computational searches related to Wieferich primes, which connect to Erdős Problem #11"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -215,5 +215,44 @@
     "axiomCount": 14,
     "theoremCount": 0,
     "definitionCount": 10
-  }
+  },
+  "references": [
+    {
+      "key": "Er50b",
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "On integers of the form 2^k + p and some related problems",
+      "venue": "Summa Brasil. Math.",
+      "year": "1950",
+      "volume": "2",
+      "pages": "113-123",
+      "note": "Erdős asked whether the density of odd integers not of the form 2^k + p is positive"
+    },
+    {
+      "key": "Ro34",
+      "authors": [
+        "N. P. Romanoff"
+      ],
+      "title": "Über einige Sätze der additiven Zahlentheorie",
+      "venue": "Mathematische Annalen",
+      "year": "1934",
+      "volume": "109",
+      "pages": "668-678",
+      "note": "Proved that a positive proportion of odd integers can be represented as 2^k + p (Romanoff's theorem)"
+    },
+    {
+      "key": "CV04",
+      "authors": [
+        "Y.-G. Chen",
+        "X.-G. Sun"
+      ],
+      "title": "On Romanoff's constant",
+      "venue": "Journal of Number Theory",
+      "year": "2004",
+      "volume": "106",
+      "pages": "275-284",
+      "note": "Improved bounds on the density of integers representable as 2^k + p"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-20/meta.json
+++ b/src/data/proofs/erdos-20/meta.json
@@ -191,5 +191,35 @@
     "axiomCount": 9,
     "theoremCount": 2,
     "definitionCount": 8
-  }
+  },
+  "references": [
+    {
+      "key": "ER60",
+      "authors": [
+        "P. Erdős",
+        "R. Rado"
+      ],
+      "title": "Intersection theorems for systems of sets",
+      "venue": "Journal of the London Mathematical Society",
+      "year": "1960",
+      "volume": "35",
+      "pages": "85-90",
+      "note": "Original sunflower lemma: any family of more than (p-1)^k k! sets of size k contains a p-sunflower"
+    },
+    {
+      "key": "ALWZ20",
+      "authors": [
+        "R. Alweiss",
+        "S. Lovett",
+        "K. Wu",
+        "J. Zhang"
+      ],
+      "title": "Improved bounds for the sunflower lemma",
+      "venue": "Annals of Mathematics",
+      "year": "2021",
+      "volume": "194",
+      "pages": "795-815",
+      "note": "Major breakthrough: improved the sunflower bound from (p-1)^k k! to (Cp log(pk))^k"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-66/meta.json
+++ b/src/data/proofs/erdos-66/meta.json
@@ -163,5 +163,31 @@
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 6
-  }
+  },
+  "references": [
+    {
+      "key": "ET36",
+      "authors": [
+        "P. Erdős",
+        "P. Turán"
+      ],
+      "title": "On a problem of Sidon in additive number theory and on some related problems",
+      "venue": "Journal of the London Mathematical Society",
+      "year": "1941",
+      "volume": "s1-16",
+      "pages": "212-215",
+      "note": "Early work on representation functions and additive bases by Erdős and Turán"
+    },
+    {
+      "key": "Er56",
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "Problems and results in additive number theory",
+      "venue": "Colloque sur la Théorie des Nombres, Bruxelles",
+      "year": "1956",
+      "pages": "127-137",
+      "note": "Discusses representation function asymptotics and related conjectures"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-70/meta.json
+++ b/src/data/proofs/erdos-70/meta.json
@@ -204,5 +204,32 @@
       "relationship": "related",
       "description": "CH (c = aleph_1) may affect the partition properties of c. The answer to Problem #70 could depend on whether CH holds, connecting partition calculus to set-theoretic independence results"
     }
+  ],
+  "references": [
+    {
+      "key": "ER56",
+      "authors": [
+        "P. Erdős",
+        "R. Rado"
+      ],
+      "title": "A partition calculus in set theory",
+      "venue": "Bulletin of the American Mathematical Society",
+      "year": "1956",
+      "volume": "62",
+      "pages": "427-489",
+      "note": "Foundational paper on partition calculus introducing the arrow notation"
+    },
+    {
+      "key": "To46",
+      "authors": [
+        "S. Todorcevic"
+      ],
+      "title": "Partitioning pairs of countable ordinals",
+      "venue": "Acta Mathematica",
+      "year": "1987",
+      "volume": "159",
+      "pages": "261-294",
+      "note": "Major contribution to partition calculus and stepping-up lemma techniques"
+    }
   ]
 }

--- a/src/data/proofs/erdos-74/meta.json
+++ b/src/data/proofs/erdos-74/meta.json
@@ -168,5 +168,31 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory"
     }
+  ],
+  "references": [
+    {
+      "key": "Er59",
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "Graph theory and probability",
+      "venue": "Canadian Journal of Mathematics",
+      "year": "1959",
+      "volume": "11",
+      "pages": "34-38",
+      "note": "Pioneered the probabilistic method showing existence of graphs with high girth and high chromatic number"
+    },
+    {
+      "key": "Er68",
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "On the chromatic number of graphs and set-systems",
+      "venue": "Acta Mathematica Hungarica",
+      "year": "1968",
+      "volume": "17",
+      "pages": "61-99",
+      "note": "Explores chromatic number questions for graphs with specific structural properties"
+    }
   ]
 }

--- a/src/data/proofs/erdos-79/meta.json
+++ b/src/data/proofs/erdos-79/meta.json
@@ -195,5 +195,34 @@
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: graph-theory, ramsey-theory"
     }
+  ],
+  "references": [
+    {
+      "key": "CFGS83",
+      "authors": [
+        "V. Chvátal",
+        "V. Rödl",
+        "E. Szemerédi",
+        "W.T. Trotter"
+      ],
+      "title": "The Ramsey number of a graph with bounded maximum degree",
+      "venue": "Journal of Combinatorial Theory, Series B",
+      "year": "1983",
+      "volume": "34",
+      "pages": "239-243",
+      "note": "Proved Ramsey numbers are linear for bounded-degree graphs"
+    },
+    {
+      "key": "GR03",
+      "authors": [
+        "R.L. Graham",
+        "V. Rödl"
+      ],
+      "title": "Numbers in Ramsey theory",
+      "venue": "Surveys in Combinatorics, Cambridge University Press",
+      "year": "2003",
+      "pages": "111-153",
+      "note": "Survey of Ramsey number bounds including size-linearity results"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass covering 11 gallery entries across 3 commits.

### erdos-103-oq-01 (quality 97 → improved)
- Added 2 new annotations (basic metric lemmas, verification/export section)
- Deepened historicalContext with Fejes Tóth packing theory and Thue (1892)
- Added cross-references to erdos-106 and isoperimetric-theorem
- Added 2 references: Fejes Tóth (1953), Brass-Moser-Pach (2005)
- Fixed lineCount 367 → 368

### binomial-theorem-oq-03-oq-02 (quality 30 → ~95)
- Created 10 annotations from scratch covering all 215 lines
- Fixed conclusion schema (text/futureDirections → summary/implications/openQuestions)
- Added 3 cross-references: geometric-series, euler-identity, taylor-theorem-oq-03
- Added 3 references: Euler (1748), Bernoulli (1713), Rudin (1976)

### 8 Erdős entries: scholarly references added
- erdos-11, erdos-16, erdos-20, erdos-66, erdos-70, erdos-74, erdos-79, erdos-104
- 17 total references added: original Erdős papers + key subsequent results
- Includes sunflower lemma breakthrough (Alweiss+ 2021), Romanoff's theorem (1934), partition calculus (Erdős-Rado 1956)