### PR TITLE
Enrich erdos-1014-oq-01: deepen overview and cross-references

### DIFF
--- a/src/data/proofs/erdos-1014-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1014-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-imports-namespace",
+    "proofId": "erdos-1014-oq-01",
+    "range": { "startLine": 28, "endLine": 32 },
+    "type": "context",
+    "title": "Mathlib Import and Namespace Setup",
+    "content": "A single `import Mathlib` brings in the full library, providing `Real.log`, casting lemmas (`Nat.cast_le`, `exact_mod_cast`), division monotonicity (`div_le_div_of_nonneg_right`, `div_le_div_of_nonneg_left`), and absolute value (`abs_of_nonneg`). The `open Real` directive makes `log` available without qualification. The `Erdos1014OQ01` namespace scopes all declarations, avoiding collision with the parent `Erdos1014Problem` formalization.",
+    "mathContext": "The proof operates in $\\mathbb{R}$ after casting natural-number Ramsey values via `(ramseyNumber k l : \\mathbb{R})$. Lean's `Nat.cast` coercion preserves order ($\\leq$) and arithmetic, allowing seamless translation between the combinatorial setting ($\\mathbb{N}$) and the analytic setting ($\\mathbb{R}$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.cast coercion", "Real.log", "namespace isolation"],
+    "prerequisites": ["Lean 4 import system", "Mathlib real analysis"]
+  },
+  {
     "id": "ann-header",
     "proofId": "erdos-1014-oq-01",
     "range": { "startLine": 1, "endLine": 26 },


### PR DESCRIPTION
## Summary
- Enrichment pass 2 for erdos-1014-oq-01 (Ramsey ratio convergence, k=3 case of Erdős #1014)
- Quality improvement from 38 to estimated ~85: added missing sections, cross-references, key insights, and expanded overview/conclusion

## Changes
- Added imports/header section (lines 1-33) and imports/namespace annotation
- Expanded `overview.text` from 1 sentence to detailed proof structure description
- Deepened `proofStrategy` with step-by-step squeeze argument breakdown
- Added 2 new `keyInsights`: generalization barrier at k=4, recurrence as telescoping constraint
- Added 2 new `openQuestions`: sorry closure strategy via Mathlib, Ramsey recurrence formalization
- Expanded `conclusion.implications` with methodological significance, recursive structure, and Cesàro connections
- Added cross-references to `ramseys-theorem` (foundational) and `erdos-1030` (related Ramsey problem)
- Added `originalContributions`, `relatedProblems`, `prerequisites` metadata fields

## Test plan
- [x] JSON validation passes (meta.json and annotations.json)
- [x] Annotation build runs without new errors (pre-existing type warnings only)