### PR TITLE
Prove all 5 axioms in erdos-366 (consecutive k-full numbers)

### DIFF
--- a/proofs/Proofs/Erdos366Problem.lean
+++ b/proofs/Proofs/Erdos366Problem.lean
@@ -20,11 +20,7 @@
   - Guy, R.K., "Unsolved Problems in Number Theory" (2004), Problem B16
 -/
 
-import Mathlib.NumberTheory.Divisors
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
-import Mathlib.Data.Nat.Factorization.Basic
-import Mathlib.Data.Nat.Prime.Defs
-import Mathlib.Data.Set.Finite.Basic
+import Mathlib
 
 open Nat Finset
 
@@ -58,25 +54,70 @@ def IsPowerful (n : ℕ) : Prop := IsKFull 2 n
 def IsCubeful (n : ℕ) : Prop := IsKFull 3 n
 
 /-
+## Structural Properties
+-/
+
+/-- The two definitions of k-full are equivalent for nonzero n. -/
+theorem isKFull_iff_isKFull' {k n : ℕ} (hn : n ≠ 0) : IsKFull k n ↔ IsKFull' k n := by
+  constructor
+  · intro h p hmem
+    have ⟨hp, hdvd, _⟩ := Nat.mem_primeFactors.mp hmem
+    exact h p hp hdvd
+  · intro h p hp hdvd
+    exact h p (Nat.mem_primeFactors.mpr ⟨hp, hdvd, hn⟩)
+
+/-- If n is k-full and j ≤ k, then n is also j-full. -/
+theorem IsKFull.mono {j k n : ℕ} (hjk : j ≤ k) (h : IsKFull k n) : IsKFull j n :=
+  fun p hp hdvd => le_trans hjk (h p hp hdvd)
+
+/-
 ## Basic Properties of k-Full Numbers
 -/
 
 /-- 1 is vacuously k-full for any k (no prime factors). -/
 theorem one_is_kfull (k : ℕ) : IsKFull k 1 := by
   intro p hp hdiv
-  -- p | 1 implies p = 1, but p is prime so p ≥ 2, contradiction
-  have h1 : p = 1 := Nat.dvd_one.mp hdiv
-  exact absurd h1 (Nat.Prime.ne_one hp)
+  exact absurd (Nat.dvd_one.mp hdiv) hp.ne_one
+
+/-
+## Helper Lemmas
+-/
+
+/-- If p^k divides n (with p prime and n ≠ 0), then k ≤ n.factorization p.
+Uses factorization_le_iff_dvd and evaluates the factorization of the prime power. -/
+private theorem le_factorization_of_pow_dvd {p k n : ℕ} (hp : p.Prime) (hn : n ≠ 0)
+    (h : p ^ k ∣ n) : k ≤ n.factorization p := by
+  have h1 := ((Nat.factorization_le_iff_dvd (pow_ne_zero k hp.ne_zero) hn).mpr h) p
+  simp only [Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul,
+    hp.factorization, Finsupp.single_eq_same, mul_one] at h1
+  exact h1
+
+/-- If p is prime and divides q^k where q is also prime, then p = q. -/
+private theorem eq_of_prime_of_dvd_prime_pow {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    {k : ℕ} (h : p ∣ q ^ k) : p = q :=
+  (hq.eq_one_or_self_of_dvd p (hp.dvd_of_dvd_pow h)).resolve_left hp.ne_one
 
 /-
 ## Examples of k-Full Numbers
 -/
 
 /-- 8 = 2³ is 3-full (cubeful). -/
-axiom eight_is_cubeful : IsCubeful 8
+theorem eight_is_cubeful : IsCubeful 8 := by
+  intro p hp hdvd
+  have h8 : (8 : ℕ) = 2 ^ 3 := by norm_num
+  rw [h8] at hdvd
+  have hp2 : p = 2 := eq_of_prime_of_dvd_prime_pow hp (by norm_num) hdvd
+  subst hp2
+  exact le_factorization_of_pow_dvd hp (by norm_num) (by norm_num : 2 ^ 3 ∣ 8)
 
 /-- 9 = 3² is 2-full (powerful). -/
-axiom nine_is_powerful : IsPowerful 9
+theorem nine_is_powerful : IsPowerful 9 := by
+  intro p hp hdvd
+  have h9 : (9 : ℕ) = 3 ^ 2 := by norm_num
+  rw [h9] at hdvd
+  have hp3 : p = 3 := eq_of_prime_of_dvd_prime_pow hp (by norm_num) hdvd
+  subst hp3
+  exact le_factorization_of_pow_dvd hp (by norm_num) (by norm_num : 3 ^ 2 ∣ 9)
 
 /-
 ## The Main Question: 2-Full n with 3-Full n+1
@@ -106,10 +147,33 @@ def CubefulPowerfulPairs : Set ℕ := { n | IsCubeful n ∧ IsPowerful (n + 1) }
 theorem eight_nine_pair : 8 ∈ CubefulPowerfulPairs := ⟨eight_is_cubeful, nine_is_powerful⟩
 
 /-- 12167 = 23³ is cubeful. -/
-axiom cubeful_12167 : IsCubeful 12167
+theorem cubeful_12167 : IsCubeful 12167 := by
+  intro p hp hdvd
+  have h : (12167 : ℕ) = 23 ^ 3 := by norm_num
+  rw [h] at hdvd
+  have hp23 : p = 23 := eq_of_prime_of_dvd_prime_pow hp (by norm_num) hdvd
+  subst hp23
+  exact le_factorization_of_pow_dvd hp (by norm_num) (by norm_num : 23 ^ 3 ∣ 12167)
 
 /-- 12168 = 2³ × 3² × 13² is powerful. -/
-axiom powerful_12168 : IsPowerful 12168
+theorem powerful_12168 : IsPowerful 12168 := by
+  intro p hp hdvd
+  have hf : (12168 : ℕ) = 2 ^ 3 * (3 ^ 2 * 13 ^ 2) := by norm_num
+  rw [hf] at hdvd
+  rcases hp.dvd_or_dvd hdvd with h1 | h1
+  · -- p | 2^3 → p = 2
+    have := eq_of_prime_of_dvd_prime_pow hp (by norm_num) h1
+    subst this
+    exact le_factorization_of_pow_dvd hp (by norm_num) (by norm_num : 2 ^ 2 ∣ 12168)
+  · rcases hp.dvd_or_dvd h1 with h2 | h2
+    · -- p | 3^2 → p = 3
+      have := eq_of_prime_of_dvd_prime_pow hp (by norm_num) h2
+      subst this
+      exact le_factorization_of_pow_dvd hp (by norm_num) (by norm_num : 3 ^ 2 ∣ 12168)
+    · -- p | 13^2 → p = 13
+      have := eq_of_prime_of_dvd_prime_pow hp (by norm_num) h2
+      subst this
+      exact le_factorization_of_pow_dvd hp (by norm_num) (by norm_num : 13 ^ 2 ∣ 12168)
 
 /-- (12167, 12168) is a cubeful-powerful pair (Golomb 1970). -/
 theorem golomb_pair : 12167 ∈ CubefulPowerfulPairs :=
@@ -122,8 +186,10 @@ Erdős originally asked Mahler about consecutive powerful numbers.
 Mahler immediately showed infinitely many exist via Pell equations.
 -/
 
-/-- 8 = 2³ has 2 appearing with multiplicity 3 ≥ 2, so 8 is powerful. -/
-axiom eight_is_powerful : IsPowerful 8
+/-- 8 = 2³ has 2 appearing with multiplicity 3 ≥ 2, so 8 is powerful.
+Follows from eight_is_cubeful by monotonicity (cubeful → powerful). -/
+theorem eight_is_powerful : IsPowerful 8 :=
+  eight_is_cubeful.mono (by omega)
 
 /-- 8 and 9 are consecutive powerful numbers. -/
 theorem eight_nine_powerful : IsPowerful 8 ∧ IsPowerful 9 :=

--- a/src/data/proofs/erdos-366/meta.json
+++ b/src/data/proofs/erdos-366/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Golomb, Mahler",
     "sourceUrl": "https://erdosproblems.com/366",
     "date": "",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos366Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "consecutive-integers",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 366,
     "erdosUrl": "https://erdosproblems.com/366",
@@ -44,15 +44,20 @@
     "originalContributions": [
       "Definition of k-full numbers using prime factorization",
       "Definitions of IsPowerful (2-full) and IsCubeful (3-full)",
+      "Equivalence of IsKFull and IsKFull' (primeFactors-based)",
+      "Monotonicity: k-full implies j-full for j ≤ k",
+      "Proved 8 is cubeful (2³ factorization via prime power analysis)",
+      "Proved 9 is powerful (3² factorization)",
+      "Proved 12167 is cubeful (23³ factorization)",
+      "Proved 12168 is powerful (2³×3²×13² via dvd_or_dvd splitting)",
+      "Proved 8 is powerful (from cubeful via monotonicity)",
       "Statement of the main open conjecture (2-full n, 3-full n+1)",
-      "Theorems for known pairs: (8,9) and (12167,12168)",
-      "Weaker question: consecutive 3-full integers",
-      "Connection to Mahler's result on consecutive powerful numbers",
-      "Density growth bounds for k-full numbers"
+      "Theorems for known pairs: (8,9) and (12167,12168)"
     ],
-    "axiomCount": 5,
-    "lineCount": 143,
-    "assumptions": "5 axioms: eight_is_cubeful, nine_is_powerful, cubeful_12167, and 2 more. See Lean source for complete statements."
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "lineCount": 209,
+    "assumptions": "None. All numerical claims (8 is cubeful, 9 is powerful, 12167 is cubeful, 12168 is powerful) are fully proved. The open conjecture is stated as a definition, not assumed."
   },
   "overview": {
     "historicalContext": "A natural number n is **k-full** (or k-powerful) if every prime factor of n appears with multiplicity at least k. Special cases:\n- **2-full = powerful**: Every prime appears at least squared (4, 8, 9, 16, 25, 27, 32, 36, ...)\n- **3-full = cubeful**: Every prime appears at least cubed (8, 16, 27, 32, 64, 81, ...)\n\n**Historical Background**:\nErdős originally asked Mahler about consecutive powerful numbers. Mahler immediately showed infinitely many exist via the Pell equation x² = 8y² + 1, which yields solutions like (8,9), (288,289), etc.\n\nThe harder question: What about mixed consecutive pairs?\n- **(n 3-full, n+1 2-full)**: Two known examples\n  - (8, 9): 8 = 2³ is cubeful, 9 = 3² is powerful\n  - (12167, 12168): 12167 = 23³ is cubeful, 12168 = 2³ × 3² × 13² is powerful (Golomb 1970)\n- **(n 2-full, n+1 3-full)**: NO KNOWN EXAMPLES (the main open question)\n\nOEIS A060355 lists 3-full n with 2-full n+1. Only {8, 12167} are known below 10²².",
@@ -149,24 +154,20 @@
       "Can heuristic arguments predict whether (2-full, 3-full) pairs should exist?"
     ]
   },
-  "axiomCount": 5,
-  "lineCount": 143,
+  "axiomCount": 0,
+  "lineCount": 209,
   "leanFile": {
     "imports": [
-      "Mathlib.NumberTheory.Divisors",
-      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
-      "Mathlib.Data.Nat.Factorization.Basic",
-      "Mathlib.Data.Nat.Prime.Defs",
-      "Mathlib.Data.Set.Finite.Basic"
+      "Mathlib"
     ],
     "opens": [
       "Nat",
       "Finset"
     ],
     "namespace": "Erdos366",
-    "lineCount": 143,
-    "axiomCount": 5,
-    "theoremCount": 4,
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 11,
     "definitionCount": 6
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

Eliminate all 5 axioms from Erdős Problem #366, reducing axiom count from **5 → 0**.

| Axiom Proved | Technique |
|---|---|
| `eight_is_cubeful` | 8 = 2³, prime power factorization |
| `nine_is_powerful` | 9 = 3², prime power factorization |
| `cubeful_12167` | 12167 = 23³, prime power factorization |
| `powerful_12168` | 12168 = 2³×3²×13², dvd_or_dvd splitting |
| `eight_is_powerful` | From `eight_is_cubeful` via IsKFull.mono |

**New infrastructure:**
- `isKFull_iff_isKFull'`: equivalence of the two k-full definitions
- `IsKFull.mono`: k-full implies j-full for j ≤ k
- `le_factorization_of_pow_dvd`: reduces factorization bounds to divisibility
- `eq_of_prime_of_dvd_prime_pow`: identifies primes dividing prime powers

**Result:** 0 axioms, 0 sorries, 11 theorems, 209 lines (was 5 axioms, 4 theorems, 143 lines)

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.Erdos366Problem`)
- [x] meta.json updated (status: verified, axiomCount: 0, theoremCount: 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)