### PR TITLE
Audit fix: erdos-1004 sorry count 6→5

### DIFF
--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -16,13 +16,13 @@
       "analytic-number-theory"
     ],
     "badge": "formalized",
-    "sorries": 6,
+    "sorries": 5,
     "erdosNumber": 1004,
     "erdosUrl": "https://erdosproblems.com/1004",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
     "lineCount": 327,
-    "assumptions": "Three axioms for EPS87 upper bound (eps87_constant, eps87_constant_pos, eps87_upper_bound). Six sorries: run_length_sublinear, longer_runs_need_larger_n, distinct_totients_asymptotic, run_length_by_distinct_values, totient_eq_two_iff, totient_eq_four_iff.",
+    "assumptions": "Three axioms for EPS87 upper bound (eps87_constant, eps87_constant_pos, eps87_upper_bound). Five sorries: run_length_sublinear, longer_runs_need_larger_n, distinct_totients_asymptotic, totient_eq_two_iff, totient_eq_four_iff.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -296,6 +296,6 @@
     "lineCount": 327,
     "axiomCount": 3,
     "theoremCount": 22,
-    "definitionCount": 12
+    "definitionCount": 13
   }
 }


### PR DESCRIPTION
## Summary
- Fixed sorry count: 6→5 (`run_length_by_distinct_values` was proved but still counted as sorry)
- Removed `run_length_by_distinct_values` from assumptions text
- Corrected definitionCount: 12→13

## Evidence
**meta.json claimed**: 6 sorries including `run_length_by_distinct_values`
**Lean file shows**: `run_length_by_distinct_values` is fully proved (lines 249-264), only 5 sorries remain

## Audit Details
- **Axiom count**: 3 ✅ correct
- **Line count**: 327 ✅ correct
- **Theorem count**: 22 ✅ correct
- **Status/badge**: formalized/formalized ✅ appropriate
- **True stubs**: None ✅
- **Mathlib wrapper**: Not a wrapper ✅

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)