### PR TITLE
Research: erdos-25 — eliminate last 2 main-file axioms (2→0)

### DIFF
--- a/proofs/Proofs/Erdos25Problem.lean
+++ b/proofs/Proofs/Erdos25Problem.lean
@@ -98,10 +98,18 @@ def PrimeResidueCase : Prop :=
     LogDensityExists (sievedSet σ)
 
 /-- The finite sieve case: if only finitely many moduli are used,
-the logarithmic density trivially exists by periodicity. -/
-axiom finite_sieve_density_exists (σ : CongruenceSieve) (N : ℕ)
+the logarithmic density trivially exists by periodicity.
+Note: The hypothesis (∀ i ≥ N, seq_n i = seq_n N) contradicts StrictMono seq_n,
+making this vacuously true. A meaningful finite sieve would need a different
+formulation (e.g., a finite list of moduli rather than an eventually-constant
+infinite sequence). -/
+theorem finite_sieve_density_exists (σ : CongruenceSieve) (N : ℕ)
     (h : ∀ i, i ≥ N → σ.seq_n i = σ.seq_n N) :
-  LogDensityExists (sievedSet σ)
+    LogDensityExists (sievedSet σ) := by
+  exfalso
+  have h1 := h (N + 1) (by omega)
+  have h2 := σ.strictly_mono (show N < N + 1 by omega)
+  omega
 
 /-- Problem 486 asks the same question but for a broader class of sieves.
     A positive answer to Problem 486 would imply Erdős Problem 25. -/
@@ -136,12 +144,13 @@ theorem sieved_set_nonempty (σ : CongruenceSieve) (h : σ.seq_n 0 ≥ 2) :
   have : (1 : ℕ) < σ.seq_n 0 := by omega
   exact_mod_cast this
 
-/-- Each individual congruence class excludes at most a 1/nᵢ fraction.
-The sieved set has positive logarithmic density when it exists. -/
-axiom sieve_density_positive (σ : CongruenceSieve) (d : ℝ)
-    (h : logDensity (sievedSet σ) d)
-    (hprod : ∀ i j, i ≠ j → Nat.Coprime (σ.seq_n i) (σ.seq_n j)) :
-  d > 0
+/- Note on density positivity: The previously-stated axiom
+sieve_density_positive (for coprime moduli, log density > 0) was
+mathematically false. Counterexample: take seq_n i = pᵢ (i-th prime),
+seq_a i = 0. The moduli are pairwise coprime, but the sieved set is {1}
+(every m > 1 is divisible by some prime), which has log density 0.
+A correct version would need additional hypotheses, e.g., that only
+finitely many moduli are used, or that Σ 1/nᵢ converges. -/
 
 /-
 ## Section VI: Monotonicity Properties

--- a/src/data/proofs/erdos-1014-oq-01/meta.json
+++ b/src/data/proofs/erdos-1014-oq-01/meta.json
@@ -103,8 +103,12 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
     "namespace": "Erdos1014OQ01",
     "lineCount": 197,
     "axiomCount": 6,
@@ -114,7 +118,9 @@
   "references": [
     {
       "key": "Kim95",
-      "authors": ["J.H. Kim"],
+      "authors": [
+        "J.H. Kim"
+      ],
       "title": "The Ramsey number R(3,t) has order of magnitude t²/log t",
       "venue": "Random Structures & Algorithms",
       "year": "1995",
@@ -124,7 +130,9 @@
     },
     {
       "key": "She95",
-      "authors": ["J.B. Shearer"],
+      "authors": [
+        "J.B. Shearer"
+      ],
       "title": "On the independence number of sparse graphs",
       "venue": "Random Structures & Algorithms",
       "year": "1995",
@@ -134,7 +142,11 @@
     },
     {
       "key": "AKS80",
-      "authors": ["M. Ajtai", "J. Komlós", "E. Szemerédi"],
+      "authors": [
+        "M. Ajtai",
+        "J. Komlós",
+        "E. Szemerédi"
+      ],
       "title": "A note on Ramsey numbers",
       "venue": "Journal of Combinatorial Theory, Series A",
       "year": "1980",
@@ -144,7 +156,10 @@
     },
     {
       "key": "MV24",
-      "authors": ["S. Mattheus", "J. Verstraëte"],
+      "authors": [
+        "S. Mattheus",
+        "J. Verstraëte"
+      ],
       "title": "The asymptotics of r(4,t)",
       "venue": "Annals of Mathematics",
       "year": "2024",
@@ -154,10 +169,13 @@
     },
     {
       "key": "Er71",
-      "authors": ["P. Erdős"],
+      "authors": [
+        "P. Erdős"
+      ],
       "title": "Some unsolved problems in graph theory and combinatorial analysis",
       "year": "1971",
       "note": "Original source of Problem #1014 asking whether R(k,l+1)/R(k,l) → 1"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 25,
     "erdosUrl": "https://erdosproblems.com/25",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
-    "lineCount": 157,
-    "assumptions": "2 axioms: finite_sieve_density_exists, sieve_density_positive. Previously 6: logDensity/logDensity_mem_unit/logDensity_unique proved via constructive HasLogDensity; sieved_set_nonempty proved with corrected hypothesis (seq_n 0 ≥ 2).",
+    "axiomCount": 4,
+    "lineCount": 166,
+    "assumptions": "Main file: 0 axioms (finite_sieve_density_exists proved vacuously — hypothesis contradicts StrictMono; sieve_density_positive removed — mathematically false). Companion Erdos25LogDensity.lean: 4 axioms (logDensity_avoid_one_residue, naturalDensity_implies_logDensity, exists_logDensity_no_naturalDensity, davenport_erdos). Previously 6 main-file axioms: logDensity/logDensity_mem_unit/logDensity_unique proved via constructive HasLogDensity; sieved_set_nonempty proved with corrected hypothesis (seq_n 0 ≥ 2).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -74,16 +74,16 @@
       "title": "Special Cases",
       "startLine": 71,
       "endLine": 90,
-      "summary": "Defines the prime-residue case (moduli are all primes). Axiomatizes finite sieve density existence (eventual periodicity). Notes the relationship to Problem 486.",
-      "mathContext": "`PrimeResidueCase`: $\\forall \\sigma,\\, (\\forall i,\\, \\text{Prime}(n_i)) \\Rightarrow \\text{LogDensityExists}(A(\\sigma))$. Axiom `finite_sieve_density_exists`: if $n_i = n_N$ for $i \\ge N$, then $A(\\sigma)$ is eventually periodic and its density exists. The tautology `erdos_486_implies_25` records that Problem 486 generalizes Problem 25."
+      "summary": "Defines the prime-residue case (moduli are all primes). Proves finite sieve density existence vacuously (the eventually-constant hypothesis contradicts StrictMono). Notes the relationship to Problem 486.",
+      "mathContext": "`PrimeResidueCase`: $\\forall \\sigma,\\, (\\forall i,\\, \\text{Prime}(n_i)) \\Rightarrow \\text{LogDensityExists}(A(\\sigma))$. Theorem `finite_sieve_density_exists`: proved vacuously — the hypothesis $n_i = n_N$ for $i \\ge N$ contradicts `StrictMono seq_n` (taking $i = N+1$). The tautology `erdos_486_implies_25` records that Problem 486 generalizes Problem 25."
     },
     {
       "id": "density-bounds",
       "title": "Density Bounds",
       "startLine": 91,
       "endLine": 106,
-      "summary": "Axiomatizes nonemptiness of sieved sets (small integers pass all conditions) and positive density under pairwise coprimality of moduli.",
-      "mathContext": "Axiom `sieved_set_nonempty`: $\\exists m > 0,\\, m \\in A(\\sigma)$ (integers $m < n_1$ pass all conditions). Axiom `sieve_density_positive`: if $\\gcd(n_i, n_j) = 1$ for $i \\ne j$ and $\\delta_\\ell(A(\\sigma)) = d$, then $d > 0$. By CRT, coprime exclusions are independent: $\\delta_\\ell \\approx \\prod_i (1 - 1/n_i)$."
+      "summary": "Proves nonemptiness of sieved sets (integers below the first modulus pass all conditions). Notes that the density-positivity axiom was removed as mathematically false.",
+      "mathContext": "Proved theorem `sieved_set_nonempty` (with hypothesis $n_0 \\ge 2$): $\\exists m > 0,\\, m \\in A(\\sigma)$. The former axiom `sieve_density_positive` was removed: it claimed positive density for coprime sieves, but this is false for the prime sieve (sieved set = \\{1\\}, density = 0)."
     },
     {
       "id": "monotonicity",
@@ -141,9 +141,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 157,
-    "axiomCount": 3,
-    "theoremCount": 3,
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 8,
     "definitionCount": 6
   },
   "references": [

--- a/src/data/research/problems/erdos-25.json
+++ b/src/data/research/problems/erdos-25.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 4 axioms total from Erdos25Problem.lean. Session 1: sieved_set_nonempty proved with corrected hypothesis. Session 2: logDensity/logDensity_mem_unit/logDensity_unique proved via constructive HasLogDensity. Problem file axioms: 6->2. Build verified via Docker.",
+    "progressSummary": "COMPLETED (main file): All 6 original axioms eliminated. Main file: 0 axioms, 0 sorries, 8 theorems. Companion Erdos25LogDensity.lean still has 4 axioms (deep results).",
     "builtItems": [
       "Proved logWeightedCount_nonneg in Erdos25LogDensity.lean",
       "Proved logWeightedCount_mono in Erdos25LogDensity.lean",
@@ -53,7 +53,9 @@
       "sieved_set_nonempty: PROVED (was axiom, added hypothesis seq_n 0 >= 2)",
       "Converted logDensity from axiom to def (= Erdos25.HasLogDensity) in Erdos25Problem.lean",
       "Proved logDensity_mem_unit: d>=0 via ge_of_tendsto, d<=1 via limsup_le_limsup + harmonic ratio comparison",
-      "Proved logDensity_unique via tendsto_nhds_unique in Erdos25Problem.lean"
+      "Proved logDensity_unique via tendsto_nhds_unique in Erdos25Problem.lean",
+      "PROVED finite_sieve_density_exists via exfalso (contradictory hypotheses, 4 lines)",
+      "REMOVED sieve_density_positive (false axiom, replaced with counterexample comment)"
     ],
     "insights": [
       "The axiom logDensityRatio_bounded claiming ratio <= 1 for N >= 2 is mathematically incorrect since H_N/log N > 1 for all finite N",
@@ -62,7 +64,9 @@
       "logWeightedCount splits additively over disjoint unions",
       "The Problem file axiomatized logDensity separately from LogDensity files constructive HasLogDensity - unifying them eliminated 3 axioms at once",
       "d<=1 proof requires limsup comparison (not pointwise bound) because harmonicSum/log > 1 for all finite N",
-      "sieved_set_nonempty axiom was unsound: false when seq_n 0 = 1 (mod 1 excludes everything)"
+      "sieved_set_nonempty axiom was unsound: false when seq_n 0 = 1 (mod 1 excludes everything)",
+      "finite_sieve_density_exists hypothesis (∀ i≥N, seq_n i = seq_n N) contradicts StrictMono seq_n — axiom proved vacuously via exfalso+omega",
+      "sieve_density_positive is mathematically false: prime sieve (seq_n=primes, seq_a=0) yields sieved set {1} with log density 0, not >0"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- **finite_sieve_density_exists**: proved vacuously — the hypothesis `∀ i ≥ N, seq_n i = seq_n N` contradicts `StrictMono seq_n`
- **sieve_density_positive**: removed as mathematically false (prime sieve with all residues 0 → sieved set {1} → log density 0)
- Main file now: **0 axioms, 0 sorries, 8 theorems**
- Companion `Erdos25LogDensity.lean`: 4 axioms remain (deep analytic number theory results)

## Test plan
- [x] Docker build passes for `Proofs.Erdos25Problem`
- [x] meta.json updated with correct axiom counts and descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)