### PR TITLE
Audit fix: erdos-1131 sorry count 0→2, axiom count 4→3

### DIFF
--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -19,14 +19,14 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "erdosNumber": 1131,
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "theoremCount": 5,
-    "lineCount": 213,
-    "assumptions": "4 axioms: lagrangeIntegral_lower_bound (Cauchy-Schwarz), lagrangeIntegral_upper_bound, chebyshev_integral_estimate, erdos_1131_conjecture (OPEN). 5 former axioms now proved: lagrangeIntegral replaced with interval integral def, lagrangeBasis_self/other proved from product definition, chebyshevNodes_in_range from cos bounds, chebyshevNodes_distinct from cos strict anti on [0,pi].",
+    "axiomCount": 3,
+    "theoremCount": 9,
+    "lineCount": 264,
+    "assumptions": "3 axioms: lagrangeIntegral_upper_bound, chebyshev_integral_estimate, erdos_1131_conjecture (OPEN). 2 sorries: sum_sq_lagrangeBasis_ge (Cauchy-Schwarz variance step), lagrangeIntegral_lower_bound (integral monotonicity step). 6 former axioms now proved: lagrangeIntegral replaced with interval integral def, lagrangeBasis_self/other proved from product definition, chebyshevNodes_in_range from cos bounds, chebyshevNodes_distinct from cos strict anti on [0,pi], lagrangeIntegral_lower_bound converted from axiom to theorem with sorry.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- **Sorry count**: 0→2 (sum_sq_lagrangeBasis_ge and lagrangeIntegral_lower_bound have sorries)
- **Axiom count**: 4→3 (lagrangeIntegral_lower_bound was converted from axiom to theorem-with-sorry)
- **Theorem count**: 5→9 (research commit added 4 new theorems)
- **Line count**: 213→264 (file grew from research work)
- Updated assumptions text to reflect current state

## Evidence
**meta.json claimed**: 0 sorries, 4 axioms
**Lean file shows**: 2 sorries (lines 149, 162), 3 axioms (lagrangeIntegral_upper_bound, chebyshev_integral_estimate, erdos_1131_conjecture)

The "Prove partition of unity (4→3 axioms)" research commit converted `lagrangeIntegral_lower_bound` from axiom to theorem-with-sorry but didn't update the meta.json sorry count.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)