### PR TITLE
Fix: handle missing sections in inverse-galois-oq-01 index.ts

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/index.ts
+++ b/src/data/proofs/inverse-galois-oq-01/index.ts
@@ -10,7 +10,7 @@ const meta = metaJson as {
   slug: string
   description: string
   meta: ProofMeta
-  sections: ProofSection[]
+  sections?: ProofSection[]
   overview?: ProofOverview
   conclusion?: ProofConclusion
   crossReferences?: CrossReference[]
@@ -22,7 +22,7 @@ export const inverseGaloisOq01Proof: Proof = {
   slug: meta.slug,
   description: meta.description,
   meta: meta.meta,
-  sections: meta.sections,
+  sections: meta.sections ?? [],
   source: sourceRaw,
   overview: meta.overview,
   conclusion: meta.conclusion,


### PR DESCRIPTION
## Summary
- Make `sections` optional in the index.ts type cast (matching meta.json which lacks sections)
- Default to empty array `[]` when sections are missing

Fixes build failure introduced by #6477 where the meta.json was created without a `sections` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)