### PR TITLE
Fix: correct erdos-1099 sorries count (0→1)

### DIFF
--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1099,
     "erdosUrl": "https://erdosproblems.com/1099",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Correct sorry count for erdos-1099 from 0 to 1.

## Evidence

**Before**: `sorries: 0`
**After**: `sorries: 1` — `h_alpha_ge_one` theorem (line 267) has a sorry at line 283 for the divisor ratio sum formalization step.

---
Automated fix by lean-mechanic agent.