### PR TITLE
Audit fix: inverse-galois-oq-01 counts for dependency chain

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -24,14 +24,14 @@
       "Proofs/InverseGaloisA5.lean"
     ],
     "badge": "axiom",
-    "sorries": 3,
-    "axiomCount": 0,
+    "sorries": 5,
+    "axiomCount": 3,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields, fixed fields)",
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",
       "Field extensions (finrank, tower law)"
     ],
-    "assumptions": "0 axiom declarations. 3 sorry(s): 2 census sorries (A5/S5 realization requires importing other files), 1 intentional sorry for the open Inverse Galois Conjecture.",
+    "assumptions": "3 axioms across dependency chain: Shafarevich's theorem and symmetric group realizability (InverseGalois.lean), A5 Galois group order (InverseGaloisA5.lean). 5 sorries total: 2 census sorries for A5/S5 realization, 1 open Inverse Galois Conjecture, 1 Hilbert irreducibility (InverseGalois.lean), 1 open IGP statement (InverseGalois.lean).",
     "leanFile": {
       "lineCount": 448,
       "theoremCount": 31,


### PR DESCRIPTION
## Summary
- **Sorry count**: 3→5 (includes 2 sorries from imported InverseGalois.lean)
- **Axiom count**: 0→3 (includes axioms from InverseGalois.lean and InverseGaloisA5.lean)
- Updated assumptions text to document full dependency chain

## Evidence
**Primary file** (InverseGaloisOQ01.lean): 3 sorries, 0 axioms
**Additional files**:
- InverseGalois.lean: 2 sorries (IGP open problem + Hilbert irreducibility), 2 axioms (Shafarevich, symmetric realizability)
- InverseGaloisA5.lean: 0 sorries, 1 axiom (A5 Galois group order)

The `additionalFiles` listed in meta.json are imported dependencies — their assumptions affect the proof chain's soundness.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)