### PR TITLE
Audit fix: erdos-1099 sorry count 0→1, axiom count 6→5

### DIFF
--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1099,
     "erdosUrl": "https://erdosproblems.com/1099",
     "erdosProblemStatus": "solved",
@@ -59,9 +59,9 @@
       "sum_divisor_ratios_lower_bound axiom: Σ(d_{i+1}/dᵢ) > τ(n) + log(n)",
       "Examples for primes, powers of 2, and highly composite numbers"
     ],
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 443,
-    "assumptions": "6 axioms: h_alpha_ge_one, vose_bounded_sequence, vose_liminf_bounded, sum_divisor_ratios_lower_bound, prime_h_alpha_unbounded, power_of_two_h_alpha. See Lean source for complete statements."
+    "assumptions": "5 axioms: vose_bounded_sequence, vose_liminf_bounded, sum_divisor_ratios_lower_bound, prime_h_alpha_unbounded, power_of_two_h_alpha. 1 sorry: h_alpha_ge_one (converted from axiom to theorem, gap in formalizing sorted divisor ratio bound). See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1099** was posed by Erdős in 1981 as part of his study of divisor structure. The problem asks about the regularity of divisor gaps: can we find integers whose consecutive divisor ratios are all close to 1?\n\n**Historical Development:**\n- **1981 (Erdős [Er81h]):** Posed the problem, noting that n! and lcm{1,...,n} seem like good candidates.\n- **1984 (Vose [Vo84]):** Resolved the problem affirmatively by constructing a specific sequence with bounded h_α.\n\n**Key Insight:** The question is about how \"smooth\" the divisor structure of integers can be. While primes have terrible divisor gaps (ratio = p), and even powers of 2 grow linearly in h_α, Vose showed there exist numbers with much smoother divisor distributions.",
@@ -290,7 +290,7 @@
     ],
     "namespace": "Erdos1099",
     "lineCount": 443,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 19,
     "definitionCount": 7
   }


### PR DESCRIPTION
## Summary
- **Sorry count**: 0→1 (h_alpha_ge_one converted from axiom to theorem-with-sorry)
- **Axiom count**: 6→5 (h_alpha_ge_one no longer an axiom)
- Updated assumptions text

## Evidence
**meta.json claimed**: 0 sorries, 6 axioms
**Lean file shows**: 1 sorry (line 283, h_alpha_ge_one gap), 5 axiom declarations

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)