### PR TITLE
Enrich Lagrange's Theorem: add cross-refs, update open question

### DIFF
--- a/src/data/proofs/lagrange-theorem/meta.json
+++ b/src/data/proofs/lagrange-theorem/meta.json
@@ -158,7 +158,7 @@
     "openQuestions": [
       "Can the Sylow theorems (partial converse of Lagrange) be formalized, showing that subgroups of order p^k exist for every prime power p^k dividing |G|?",
       "Can the orbit-stabilizer theorem be formalized as a generalization of Lagrange's theorem, with Lagrange recovered as the special case of the action of G on cosets of H?",
-      "Can Hall's theorem be formalized: for solvable groups, the full converse of Lagrange holds — subgroups of order n exist for every n dividing |G|?",
+      "**Addressed** by `lagrange-theorem-oq-03`: Hall's theorem for solvable groups is now formalized in the gallery, including the $A_4$ counterexample showing the converse of Lagrange fails for non-solvable groups.",
       "Can Cauchy's theorem be formalized as a strengthening: if prime $p$ divides $|G|$, then $G$ contains an element of order $p$? McKay's elegant proof uses the action of $\\mathbb{Z}/p\\mathbb{Z}$ on $p$-tuples $(g_1,\\ldots,g_p)$ with $g_1 \\cdots g_p = e$ and is entirely combinatorial.",
       "Can the Burnside counting lemma (Cauchy-Frobenius) $|X/G| = \\frac{1}{|G|} \\sum_{g \\in G} |X^g|$ be formalized as a consequence of the orbit-stabilizer theorem, which itself generalizes Lagrange?"
     ]
@@ -213,6 +213,16 @@
       "targetId": "primitive-roots",
       "relationship": "related",
       "description": "The existence of primitive roots modulo $p$ — generators of the cyclic group $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ — is a consequence of the structure theorem for finite abelian groups combined with Lagrange's theorem. By Lagrange, the polynomial $x^d - 1$ has at most $d$ roots in $\\mathbb{Z}/p\\mathbb{Z}$, which forces $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ to be cyclic"
+    },
+    {
+      "targetId": "lagrange-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "Hall's theorem (1928) formalizes the partial converse of Lagrange for solvable groups: if $|G|$ is solvable and $n \\mid |G|$ with $\\gcd(n, |G|/n) = 1$, then $G$ has a subgroup of order $n$ — and all such 'Hall subgroups' are conjugate. The $A_4$ counterexample (no subgroup of order 6 despite $6 \\mid 12$) shows the full converse fails for non-solvable groups"
+    },
+    {
+      "targetId": "inverse-galois-oq-01",
+      "relationship": "extended-by",
+      "description": "Uses Lagrange's theorem in the fixed field degree formulas: $[K:K^H] = |H|$ and $[K^H:F] = [G:H]$ are multiplicative consequences of Lagrange applied to the Galois group. The solvability characterization `sn_solvable_iff` ($S_n$ solvable iff $n \\leq 4$) also relies on the subgroup structure constrained by Lagrange"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for lagrange-theorem (pass 2).

## Changes
- Added cross-reference to `lagrange-theorem-oq-03` (Hall's theorem — partial converse of Lagrange for solvable groups)
- Added cross-reference to `inverse-galois-oq-01` (uses Lagrange in fixed field degree formulas)
- Updated open question about Hall's theorem: marked as **addressed** by `lagrange-theorem-oq-03`