### PR TITLE
Research: Erdős #1131 - Prove lower bound I ≥ 2/n (2→0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1131Problem.lean
+++ b/proofs/Proofs/Erdos1131Problem.lean
@@ -135,31 +135,64 @@ theorem partition_of_unity (n : ℕ) (hn : n ≥ 1) (nodes : Fin n → ℝ)
   exact heval
 
 /--
-**Pointwise lower bound**: ∑ₖ l_k(x)² ≥ 1/n via partition of unity + variance bound.
+**Pointwise lower bound**: ∑ₖ l_k(x)² ≥ 1/n via variance bound on partition of unity.
+
+The variance identity ∑(l_k - 1/n)² = ∑l_k² - 1/n together with non-negativity
+of sums of squares gives ∑l_k² ≥ 1/n.
 -/
 theorem sum_sq_lagrangeBasis_ge (n : ℕ) (hn : n ≥ 1) (nodes : Fin n → ℝ)
     (hd : AreDistinct n nodes) (x : ℝ) :
     ∑ k : Fin n, (lagrangeBasis n nodes k x) ^ 2 ≥ 1 / n := by
   have hpou := partition_of_unity n hn nodes hd x
   have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
-  -- Cauchy-Schwarz / variance: 0 ≤ ∑(l_k - 1/n)² = ∑l_k² - 1/n
+  have hn_ne : (↑n : ℝ) ≠ 0 := ne_of_gt hn_pos
   rw [ge_iff_le, ← sub_nonneg]
+  -- Variance: 0 ≤ ∑(l_k - 1/n)²
   have hvar : 0 ≤ ∑ k : Fin n, (lagrangeBasis n nodes k x - 1 / ↑n) ^ 2 :=
     Finset.sum_nonneg fun k _ => sq_nonneg _
-  sorry
+  -- Expand (a - c)² = a² + (-2c·a + c²) and distribute sum
+  have hexp : ∀ k : Fin n, (lagrangeBasis n nodes k x - 1 / ↑n) ^ 2 =
+    (lagrangeBasis n nodes k x) ^ 2 +
+    (-(2 / ↑n) * lagrangeBasis n nodes k x + 1 / ↑n ^ 2) := by intro k; ring
+  simp_rw [hexp] at hvar
+  rw [Finset.sum_add_distrib] at hvar
+  -- Factor the remainder sum: ∑(-(2/n)·l_k + 1/n²) = -(2/n)·∑l_k + n·(1/n²)
+  rw [show ∑ k : Fin n, (-(2 / ↑n) * lagrangeBasis n nodes k x + 1 / ↑n ^ 2) =
+      -(2 / ↑n) * ∑ k : Fin n, lagrangeBasis n nodes k x + ↑n * (1 / ↑n ^ 2) from by
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, Finset.sum_const, Finset.card_fin,
+        nsmul_eq_mul]] at hvar
+  rw [hpou, mul_one] at hvar
+  -- hvar : 0 ≤ ∑l_k² + (-(2/n) + n/n²), simplify -(2/n) + n/n² = -1/n
+  have key : -(2 / (↑n : ℝ)) + ↑n * (1 / ↑n ^ 2) = -(1 / ↑n) := by field_simp; ring
+  linarith
 
 /--
 **Lower bound**: I(x₁,...,xₙ) ≥ 2/n for any configuration.
 
-Uses partition of unity (∑ l_k = 1) and pointwise variance bound (∑ l_k² ≥ 1/n).
+Uses pointwise bound ∑ l_k² ≥ 1/n and integral monotonicity:
+∫₋₁¹ ∑ l_k² ≥ ∫₋₁¹ (1/n) = 2/n.
 -/
 theorem lagrangeIntegral_lower_bound (n : ℕ) (hn : n ≥ 1) (nodes : Fin n → ℝ)
-    (hd : AreDistinct n nodes) (hrange : ∀ i, -1 ≤ nodes i ∧ nodes i ≤ 1) :
+    (hd : AreDistinct n nodes) (_hrange : ∀ i, -1 ≤ nodes i ∧ nodes i ≤ 1) :
     lagrangeIntegral n nodes ≥ 2 / n := by
   unfold lagrangeIntegral
-  have hpw := fun x => sum_sq_lagrangeBasis_ge n hn nodes hd x
-  -- ∫₋₁¹ (Σ l_k²) ≥ ∫₋₁¹ (1/n) = 2/n (integral monotonicity)
-  sorry
+  have hpw : ∀ x, 1 / ↑n ≤ ∑ k : Fin n, (lagrangeBasis n nodes k x) ^ 2 :=
+    fun x => sum_sq_lagrangeBasis_ge n hn nodes hd x
+  have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
+  have hn_ne : (↑n : ℝ) ≠ 0 := ne_of_gt hn_pos
+  -- Integrand is continuous (polynomial), hence integrable
+  have h_cont : Continuous (fun x => ∑ k : Fin n, (lagrangeBasis n nodes k x) ^ 2) := by
+    apply continuous_finset_sum; intro k _
+    apply Continuous.pow
+    unfold lagrangeBasis
+    exact continuous_finset_prod _ fun i _ => (continuous_id.sub continuous_const).div_const _
+  rw [ge_iff_le, ← sub_nonneg]
+  -- Rewrite 2/n as ∫₋₁¹ (1/n), then use linearity + nonnegativity
+  rw [show (2 : ℝ) / ↑n = ∫ _ in (-1 : ℝ)..1, (1 : ℝ) / ↑n from by
+    rw [intervalIntegral.integral_const, smul_eq_mul]; ring]
+  rw [← intervalIntegral.integral_sub (h_cont.intervalIntegrable _ _) intervalIntegrable_const]
+  exact intervalIntegral.integral_nonneg (by norm_num : (-1 : ℝ) ≤ 1)
+    fun u _hu => by linarith [hpw u]
 
 /--
 **Upper bound**: I is bounded above by 2n for any configuration.

--- a/src/data/research/problems/erdos-1131-oq-01.json
+++ b/src/data/research/problems/erdos-1131-oq-01.json
@@ -18,37 +18,45 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-25T00:00:00.000Z",
-    "iteration": 1,
-    "focus": "Proved 5 axioms via product/cos/integral reasoning.",
+    "iteration": 2,
+    "focus": "Lower bound I ≥ 2/n fully proved. 0 sorries, 3 axioms remain (upper bound, Chebyshev estimate, open conjecture).",
     "blockers": [],
-    "nextAction": "Attempt partition_of_unity or lagrangeIntegral_lower_bound.",
+    "nextAction": "Remove false upper bound axiom. Consider proving Chebyshev integral estimate.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 9→4 axioms. Proved lagrangeBasis_self/other, chebyshevNodes_in_range/distinct, replaced lagrangeIntegral axiom with proper interval integral def.",
+    "progressSummary": "PROGRESS: 4→3 axioms, 2→0 sorries. Lower bound I ≥ 2/n fully proved via variance identity + integral monotonicity.",
     "builtItems": [
       "lagrangeBasis_self: Finset.prod_eq_one + div_self (product of 1s)",
       "lagrangeBasis_other: Finset.prod_eq_zero + sub_self (zero factor)",
       "chebyshevNodes_in_range: Real.neg_one_le_cos + Real.cos_le_one",
       "chebyshevNodes_distinct: Real.strictAntiOn_cos.injOn on [0,pi]",
-      "lagrangeIntegral: noncomputable def using intervalIntegral"
+      "lagrangeIntegral: noncomputable def using intervalIntegral",
+      "lagrangeBasis_eq_eval_basis: connects product form to Mathlib Lagrange.basis",
+      "partition_of_unity: sum_k l_k(x) = 1 for all x (via Lagrange.sum_basis)",
+      "sum_sq_lagrangeBasis_ge: ∑l_k² ≥ 1/n via variance identity (PROVED, 0 sorry)",
+      "lagrangeIntegral_lower_bound: I ≥ 2/n via integral monotonicity (PROVED, 0 sorry)"
     ],
     "insights": [
       "lagrangeBasis product form makes self/other proofs very clean",
       "Chebyshev arguments (2k+1)pi/(2n) lie in (0,pi) with cos strictly decreasing - direct injectivity",
       "div_le_iff and div_le_one_of_le removed in Mathlib v4.26.0 - use gcongr + field_simp instead",
-      "Remaining 4 axioms: 2 integral bounds (need L2/Cauchy-Schwarz), 1 Chebyshev estimate (deep analysis), 1 OPEN conjecture"
+      "Mathlib has Lagrange.sum_basis in LinearAlgebra.Lagrange - partition of unity for free",
+      "Connection between product-form and Mathlib polynomial form needs Finset.erase/filter equivalence + field_simp",
+      "Upper bound axiom I <= 2n is mathematically FALSE for nodes with small separation",
+      "Variance identity approach: ∑(l_k-1/n)² = ∑l_k² - 1/n avoids need for sq_sum_le_card_mul_sum_sq",
+      "intervalIntegral.integral_sub + integral_nonneg is cleaner than integral_mono for lower bounds",
+      "Continuous.intervalIntegrable provides integrability for polynomial-type functions via continuous_finset_sum/prod"
     ],
-    "mathlibGaps": [
-      "Lagrange interpolation integral bounds require MeasureTheory.Integral + Cauchy-Schwarz in L2"
-    ],
+    "mathlibGaps": [],
     "nextSteps": [
-      "Attempt lagrangeIntegral_lower_bound: I >= 2/n via partition of unity + Cauchy-Schwarz",
-      "Consider proving partition_of_unity: sum_k l_k(x) = 1 (polynomial degree argument)"
+      "Remove false upper bound axiom (or add minimum separation condition)",
+      "Consider proving chebyshev_integral_estimate if feasible",
+      "The open conjecture erdos_1131_conjecture is an axiom (correctly so - it's unsolved)"
     ]
   },
   "tags": [
@@ -71,18 +79,18 @@
     "mathlib": []
   },
   "started": "2026-03-24T00:48:59.907Z",
-  "lastUpdate": "2026-03-24T00:48:59.907Z",
+  "lastUpdate": "2026-03-25T00:38:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1131Problem.lean",
       "filename": "Erdos1131Problem.lean",
-      "lineCount": 265,
-      "theoremCount": 9,
+      "lineCount": 297,
+      "theoremCount": 11,
       "axiomCount": 3,
-      "defCount": 6,
-      "sorryCount": 2,
+      "defCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1131Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Proved `sum_sq_lagrangeBasis_ge`: ∑l_k² ≥ 1/n via variance identity
- Proved `lagrangeIntegral_lower_bound`: I ≥ 2/n via integral monotonicity
- **2→0 sorries** eliminated, Docker build verified clean (no warnings)

## Proof techniques
- **Variance identity**: ∑(l_k - 1/n)² = ∑l_k² - 1/n ≥ 0, expanded via `Finset.sum_add_distrib` + `Finset.mul_sum` + partition of unity
- **Integral monotonicity**: `intervalIntegral.integral_sub` + `integral_nonneg` with continuity-based integrability

## File state
- 0 sorries, 3 axioms (upper bound [known false], Chebyshev estimate, open conjecture)
- 297 lines, 11 theorems

## Test plan
- [x] Docker build passes with 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)