### PR TITLE
Enrich 6 entries: cross-references and open question updates

### DIFF
--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -129,6 +129,21 @@
       "targetId": "desargues-theorem",
       "relationship": "related",
       "description": "Desargues' theorem is central to Hamel's 2D characterization: Desarguesian projective metrics are exactly Minkowski metrics in the plane"
+    },
+    {
+      "targetId": "parallel-postulate-independence",
+      "relationship": "related",
+      "description": "Both concern Hilbert's axiomatization of geometry. Hilbert's 4th problem asks which metrics make straight lines shortest paths (a question about metric geometry axioms), while the independence of the parallel postulate asks which geometries arise from weakening Euclid's 5th axiom. Both explore the boundary between Euclidean and non-Euclidean geometry"
+    },
+    {
+      "targetId": "hilbert-10",
+      "relationship": "thematic",
+      "description": "Both are Hilbert problems. Hilbert's 4th (geometry of shortest lines) was 'resolved' by Busemann's classification, while Hilbert's 10th (Diophantine decidability) was proved undecidable by Matiyasevich. Together they illustrate the range of Hilbert's 23 problems: from classification to impossibility"
+    },
+    {
+      "targetId": "hilbert-13",
+      "relationship": "thematic",
+      "description": "Another Hilbert problem in the gallery. Hilbert's 13th asks whether solutions of 7th-degree equations can be expressed as superpositions of functions of two variables, connecting to Abel-Ruffini and the expressibility hierarchy. Both Hilbert's 4th and 13th were partially resolved with qualifications about the precise formulation"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Batch enrichment pass 2 for 6 entries: adding cross-references and updating addressed open questions.

## riemann-hypothesis (+4 cross-refs)
quadratic-reciprocity, birch-swinnerton-dyer, fermats-last-theorem, godel-incompleteness

## fair-games-theorem (+2 cross-refs)
prob-method-lovasz-local, prob-method-second-moment

## cantor-diagonalization (+1 cross-ref)
cantor-diagonalization-oq-03 (Lawvere fixed-point theorem)

## borsuk-ulam (+3 cross-refs)
borsuk-ulam-oq-03-oq-01, borsuk-ulam-oq-03-oq-01-oq-01, borsuk-ulam-oq-03-oq-03

## hilbert-4 (+3 cross-refs)
parallel-postulate-independence, hilbert-10, hilbert-13