### PR TITLE
Enrich central-limit-theorem + Abel-Ruffini annotation fix

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -338,7 +338,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -365,8 +365,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "context",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -341,6 +341,11 @@
       "description": "Hall's theorem (1928) is the partial converse of Lagrange's theorem for solvable groups: every Hall divisor of a solvable group's order yields a subgroup, and all such Hall subgroups are conjugate. This directly constrains the group-theoretic concept central to Abel-Ruffini — group solvability. The A₄ counterexample (6 divides $|A_4| = 12$ but $A_4$ has no subgroup of order 6) illustrates the subtlety of solvable group structure at the degree-4/5 threshold"
     },
     {
+      "targetId": "inverse-galois-oq-01",
+      "relationship": "extends",
+      "description": "Proves the complete characterization: $S_n$ is solvable iff $n \\leq 4$. Formalizes $A_5$ as simple, perfect, and non-solvable — the same group-theoretic facts that drive Abel-Ruffini's impossibility, now presented as a standalone result in the non-solvable frontier of the Inverse Galois Problem"
+    },
+    {
       "targetId": "angle-trisection-oq-02",
       "relationship": "related",
       "description": "The Wantzel-Galois theorem — an algebraic number $\\alpha$ is constructible by compass and straightedge iff $\\text{Gal}(\\text{minpoly}_{\\mathbb{Q}}(\\alpha))$ is a 2-group — is the constructibility analogue of Abel-Ruffini's radical solvability criterion. Both results reduce a geometric/algebraic question to group theory via the same Galois-theoretic framework: Abel-Ruffini asks whether the Galois group is solvable (abelian composition factors), while Wantzel-Galois asks whether it is a 2-group (all composition factors $\\mathbb{Z}/2$)"

--- a/src/data/proofs/central-limit-theorem/annotations.json
+++ b/src/data/proofs/central-limit-theorem/annotations.json
@@ -9,7 +9,13 @@
     "type": "concept",
     "title": "Dual Perspectives on CLT",
     "content": "This proof presents the Central Limit Theorem through two complementary lenses. The **classical approach** uses characteristic functions (Fourier transforms) to show convergence. The **topological approach** reveals why the Gaussian emerges: it is a fixed-point attractor in the dynamics of averaging.",
+    "mathContext": "Let $X_1, X_2, \\ldots$ be i.i.d. with mean $\\mu$ and variance $\\sigma^2$. The CLT states $Z_n = (\\sum_{i=1}^n X_i - n\\mu)/(\\sigma\\sqrt{n}) \\xrightarrow{d} N(0,1)$. The classical proof shows $\\varphi_{Z_n}(t) \\to e^{-t^2/2}$ (Gaussian char. function); the topological proof shows the Gaussian is the unique attractor of the averaging map $T_n(\\mu) = (1/\\sqrt{n}) \\cdot \\mu^{*n}$.",
     "significance": "key",
+    "prerequisites": [
+      "probability theory (random variables, expectation, variance)",
+      "Fourier analysis (characteristic functions)",
+      "topology of probability measures"
+    ],
     "relatedConcepts": [
       "characteristic functions",
       "fixed point theory",
@@ -26,7 +32,13 @@
     "type": "concept",
     "title": "Mathlib Dependencies",
     "content": "We import from multiple Mathlib domains: **Probability.Distributions.Gaussian** for the Gaussian measure, **Fourier.FourierTransform** for characteristic functions, and **Topology.MetricSpace** for the geometric interpretation. This interdisciplinary foundation reflects the theorem's broad reach.",
+    "mathContext": "The file uses Mathlib's `MeasureTheory.Measure` for probability measures, `Complex.exp` for characteristic functions $\\varphi_X(t) = \\mathbb{E}[e^{itX}]$, and axiomatizes several deep results (Lévy continuity, Taylor remainder bounds, Berry-Esseen) that are not yet in Mathlib.",
     "significance": "supporting",
+    "prerequisites": [
+      "Mathlib.Probability.Distributions.Gaussian",
+      "Mathlib.Analysis.Fourier.FourierTransform",
+      "Mathlib.Topology.MetricSpace.Basic"
+    ],
     "relatedConcepts": [
       "Mathlib",
       "measure theory",
@@ -45,6 +57,11 @@
     "content": "The **characteristic function** $\\varphi_X(t) = \\mathbb{E}[e^{itX}]$ is the Fourier transform of a probability distribution. It uniquely determines the distribution and has a crucial property: for independent $X, Y$, we have $\\varphi_{X+Y} = \\varphi_X \\cdot \\varphi_Y$. This converts convolution (sums of random variables) into multiplication.",
     "mathContext": "Characteristic functions always exist (bounded exponential integrand) and are uniformly continuous. They encode all moments: $\\varphi^{(k)}(0) = i^k \\mathbb{E}[X^k]$ when moments exist.",
     "significance": "key",
+    "prerequisites": [
+      "Lebesgue integration",
+      "complex exponential",
+      "probability measure"
+    ],
     "relatedConcepts": [
       "Fourier transform",
       "moment generating function",
@@ -63,6 +80,10 @@
     "content": "At $t = 0$, the characteristic function equals 1 for any probability measure: $\\varphi(0) = \\mathbb{E}[e^{i \\cdot 0 \\cdot X}] = \\mathbb{E}[1] = 1$. This normalization anchors the Fourier representation.",
     "mathContext": "This simple fact is essential: it means all characteristic functions pass through the same point, allowing us to compare different distributions on a common scale.",
     "significance": "supporting",
+    "prerequisites": [
+      "ann-clt-charfun-def",
+      "probability measure normalization"
+    ],
     "relatedConcepts": [
       "probability normalization",
       "Fourier analysis"
@@ -78,7 +99,13 @@
     "type": "insight",
     "title": "Moments from Derivatives",
     "content": "Taking derivatives of the characteristic function at $t=0$ extracts moments: $\\varphi'(0) = i\\mu$ (mean), $\\varphi''(0) = i^2(\\mu^2 + \\sigma^2)$ (second moment). The Taylor expansion $\\varphi(t) = 1 + it\\mu - t^2\\sigma^2/2 + O(t^3)$ encodes the distribution's shape in its coefficients.",
+    "mathContext": "For a mean-zero, unit-variance random variable: $\\varphi(t) = 1 - t^2/2 + O(t^3)$. This quadratic approximation is the key input to the CLT proof: raising it to the $n$-th power gives $(1 - t^2/(2n))^n \\to e^{-t^2/2}$.",
     "significance": "key",
+    "prerequisites": [
+      "ann-clt-charfun-def",
+      "Taylor's theorem with remainder",
+      "differentiation under integral sign"
+    ],
     "relatedConcepts": [
       "Taylor series",
       "moments",
@@ -116,7 +143,13 @@
     "type": "concept",
     "title": "The Product-to-Exponential Limit",
     "content": "The classical limit $(1 + x/n)^n \\to e^x$ is the engine of CLT. For the normalized sum $S_n = (X_1 + \\cdots + X_n)/\\sqrt{n}$, we have $\\varphi_{S_n}(t) = [\\varphi_X(t/\\sqrt{n})]^n$. Taylor expansion gives $\\varphi_X(t/\\sqrt{n}) \\approx 1 - t^2/(2n)$, and $(1 - t^2/(2n))^n \\to e^{-t^2/2}$.",
+    "mathContext": "Independence converts sums to products of characteristic functions: $\\varphi_{X_1+\\cdots+X_n}(t) = \\prod_{i=1}^n \\varphi_{X_i}(t)$. For i.i.d. variables this simplifies to $[\\varphi_X(t)]^n$. The $1/\\sqrt{n}$ normalization ensures the Taylor coefficient is $-t^2/(2n)$, triggering the exponential limit.",
     "significance": "key",
+    "prerequisites": [
+      "ann-clt-taylor-expansion",
+      "independence of random variables",
+      "limit $(1+x/n)^n \\to e^x$"
+    ],
     "relatedConcepts": [
       "exponential limit",
       "compound interest",
@@ -155,8 +188,13 @@
     "type": "theorem",
     "title": "Lévy Continuity Theorem",
     "content": "**The Bridge**: Pointwise convergence of characteristic functions to a continuous function implies weak convergence of probability measures. This connects the Fourier (analysis) world to the distributional (probability) world.\n\nLévy's theorem is the inverse of the continuity of the Fourier transform: if the images converge, so do the preimages.",
-    "mathContext": "Continuity at $t=0$ is essential and automatic for characteristic functions (they equal 1 at 0). The theorem fails for discontinuous limits.",
+    "mathContext": "Continuity at $t=0$ is essential and automatic for characteristic functions (they equal 1 at 0). The theorem fails for discontinuous limits. Axiomatized as `levy_continuity_axiom` since the full proof requires tightness arguments not yet in Mathlib.",
     "significance": "key",
+    "prerequisites": [
+      "ann-clt-key-convergence",
+      "weak convergence of measures",
+      "Prokhorov's theorem"
+    ],
     "relatedConcepts": [
       "weak convergence",
       "Fourier inversion",
@@ -195,7 +233,13 @@
     "type": "concept",
     "title": "The Topological Viewpoint",
     "content": "Now we shift perspective: instead of computing limits, we ask WHY the Gaussian emerges. The answer: **it is a fixed point attractor** of the renormalization group flow on the space of probability distributions.\n\nThis dynamical systems perspective reveals that CLT is not an accident of computation but a consequence of the structure of the convolution operation.",
+    "mathContext": "The renormalization map $T: \\mathcal{P}_2(\\mathbb{R}) \\to \\mathcal{P}_2(\\mathbb{R})$ sends $\\mu \\mapsto$ the distribution of $(X_1 + X_2)/(\\sqrt{2})$ where $X_i \\sim \\mu$. The Gaussian $N(0,\\sigma^2)$ is a fixed point: averaging two i.i.d. Gaussians gives another Gaussian with the same variance (after rescaling). CLT says this fixed point is globally attracting.",
     "significance": "key",
+    "prerequisites": [
+      "ann-clt-main-theorem",
+      "dynamical systems (fixed points, attractors)",
+      "metric space of probability measures"
+    ],
     "relatedConcepts": [
       "dynamical systems",
       "fixed point theory",
@@ -214,6 +258,11 @@
     "content": "The space $\\mathcal{P}_2(\\mathbb{R})$ of probability measures with finite second moment forms a metric space under the **Wasserstein-2 distance**: $W_2(\\mu, \\nu)^2 = \\inf \\int |x-y|^2 \\, d\\gamma(x,y)$ over all couplings $\\gamma$.\n\nThis is the natural geometry for CLT because:\n- Convolution is well-defined and continuous\n- Variance is a continuous functional\n- The Gaussian has finite distance to all distributions in $\\mathcal{P}_2$",
     "mathContext": "The Wasserstein metric captures the 'cost' of transporting one distribution to another. It makes $\\mathcal{P}_2$ a complete metric space (Villani's work on optimal transport).",
     "significance": "key",
+    "prerequisites": [
+      "optimal transport theory",
+      "metric space completeness",
+      "measure coupling"
+    ],
     "relatedConcepts": [
       "optimal transport",
       "Wasserstein metric",
@@ -233,7 +282,8 @@
     "mathContext": "The 'domain of attraction' is exactly the set of distributions with finite variance. Infinite variance leads to stable distributions with $\\alpha < 2$ (Lévy flights).",
     "significance": "key",
     "prerequisites": [
-      "ann-clt-fixed-point"
+      "ann-clt-topological-intro",
+      "ann-clt-wasserstein"
     ],
     "relatedConcepts": [
       "basin of attraction",
@@ -253,6 +303,11 @@
     "content": "The Gaussian **maximizes entropy** among all distributions with fixed variance. This information-theoretic characterization explains why thermal fluctuations (maximum disorder given constraints) are Gaussian.\n\n$H(\\mu) \\leq H(\\mathcal{N})$ for all $\\mu$ with $\\text{Var}(\\mu) = \\text{Var}(\\mathcal{N})$, with equality iff $\\mu = \\mathcal{N}$.",
     "mathContext": "Maximum entropy = maximum uncertainty = the 'most random' distribution consistent with known constraints (Jaynes' principle). This connects thermodynamics to probability.",
     "significance": "key",
+    "prerequisites": [
+      "Shannon entropy $H(\\mu) = -\\int p \\log p$",
+      "Jaynes' maximum entropy principle",
+      "Lagrange multipliers"
+    ],
     "relatedConcepts": [
       "Shannon entropy",
       "maximum entropy principle",
@@ -271,6 +326,11 @@
     "content": "The Gaussian is its own Fourier transform (up to scaling). This explains why the same function $e^{-t^2/2}$ appears as both the characteristic function AND the probability density (after appropriate normalization).\n\nSelf-duality under Fourier transform is a unique property that singles out the Gaussian among all probability distributions.",
     "mathContext": "More precisely: if $f(x) = e^{-x^2/2}/\\sqrt{2\\pi}$, then $\\hat{f}(\\xi) = e^{-\\xi^2/2}$. The Hermite functions (Gaussian times polynomials) form an orthonormal basis of eigenfunctions for the Fourier transform.",
     "significance": "key",
+    "prerequisites": [
+      "Fourier transform on $L^2$",
+      "Gaussian integral $\\int e^{-x^2/2} = \\sqrt{2\\pi}$",
+      "Hermite functions"
+    ],
     "relatedConcepts": [
       "Fourier transform",
       "eigenfunctions",
@@ -289,6 +349,11 @@
     "content": "**Quantitative CLT**: The Kolmogorov distance between $F_{Z_n}$ and $\\Phi$ (standard normal CDF) is $O(\\rho/\\sqrt{n})$, where $\\rho = \\mathbb{E}[|X|^3]$ is the third absolute moment.\n\n$\\sup_x |F_{Z_n}(x) - \\Phi(x)| \\leq \\frac{C \\rho}{\\sqrt{n}}$ with $C \\approx 0.4748$.\n\nThis tells us HOW FAST the convergence occurs, not just that it happens.",
     "mathContext": "The $1/\\sqrt{n}$ rate is optimal: there exist distributions achieving this rate. The constant $C$ has been refined by many authors.",
     "significance": "key",
+    "prerequisites": [
+      "ann-clt-main-theorem",
+      "CDF and Kolmogorov distance",
+      "third absolute moment"
+    ],
     "relatedConcepts": [
       "rate of convergence",
       "Kolmogorov distance",
@@ -307,6 +372,11 @@
     "content": "When variance is infinite, the Gaussian is no longer the attractor. Instead, **$\\alpha$-stable distributions** (Lévy distributions) emerge as limits. The Gaussian corresponds to $\\alpha = 2$; the Cauchy to $\\alpha = 1$.\n\nHeavy-tailed phenomena (earthquakes, financial crashes, network traffic) often follow stable laws with $\\alpha < 2$, exhibiting infinite variance and 'Lévy flights.'",
     "mathContext": "A distribution is $\\alpha$-stable if it is closed under convolution and appropriate rescaling: $X_1 + X_2 \\stackrel{d}{=} cX$ for some $c$. Only for $\\alpha = 2$ is variance finite.",
     "significance": "key",
+    "prerequisites": [
+      "generalized CLT",
+      "domain of attraction theory",
+      "regular variation"
+    ],
     "relatedConcepts": [
       "stable distributions",
       "Lévy flights",
@@ -324,7 +394,14 @@
     "type": "concept",
     "title": "Synthesis: Why the Gaussian is Universal",
     "content": "The Central Limit Theorem reveals the Gaussian as a **mathematical necessity**, not an accident:\n\n1. **Dynamically**: It is the unique fixed-point attractor of the averaging operation\n2. **Information-theoretically**: It maximizes entropy at fixed variance\n3. **Analytically**: It is self-dual under Fourier transform\n4. **Probabilistically**: It is the only finite-variance stable distribution\n\nWherever we see many small independent effects being summed—measurement errors, thermal fluctuations, stock prices, IQ scores—the Gaussian emerges because averaging dynamics demand it.",
+    "mathContext": "Four independent characterizations of the Gaussian, each from a different branch of mathematics, all pointing to the same conclusion: $N(0,\\sigma^2)$ is the unique distribution that is simultaneously a fixed point of averaging, a maximum entropy distribution at fixed variance, an eigenfunction of the Fourier transform, and an $\\alpha$-stable distribution with $\\alpha = 2$.",
     "significance": "key",
+    "prerequisites": [
+      "ann-clt-topological-intro",
+      "ann-clt-why-gaussian-entropy",
+      "ann-clt-self-duality",
+      "ann-clt-stable"
+    ],
     "relatedConcepts": [
       "universality",
       "emergence",

--- a/src/data/proofs/central-limit-theorem/annotations.source.json
+++ b/src/data/proofs/central-limit-theorem/annotations.source.json
@@ -8,11 +8,17 @@
     "type": "concept",
     "title": "Dual Perspectives on CLT",
     "content": "This proof presents the Central Limit Theorem through two complementary lenses. The **classical approach** uses characteristic functions (Fourier transforms) to show convergence. The **topological approach** reveals why the Gaussian emerges: it is a fixed-point attractor in the dynamics of averaging.",
+    "mathContext": "Let $X_1, X_2, \\ldots$ be i.i.d. with mean $\\mu$ and variance $\\sigma^2$. The CLT states $Z_n = (\\sum_{i=1}^n X_i - n\\mu)/(\\sigma\\sqrt{n}) \\xrightarrow{d} N(0,1)$. The classical proof shows $\\varphi_{Z_n}(t) \\to e^{-t^2/2}$ (Gaussian char. function); the topological proof shows the Gaussian is the unique attractor of the averaging map $T_n(\\mu) = (1/\\sqrt{n}) \\cdot \\mu^{*n}$.",
     "significance": "key",
     "relatedConcepts": [
       "characteristic functions",
       "fixed point theory",
       "renormalization group"
+    ],
+    "prerequisites": [
+      "probability theory (random variables, expectation, variance)",
+      "Fourier analysis (characteristic functions)",
+      "topology of probability measures"
     ]
   },
   {
@@ -25,11 +31,17 @@
     "type": "concept",
     "title": "Mathlib Dependencies",
     "content": "We import from multiple Mathlib domains: **Probability.Distributions.Gaussian** for the Gaussian measure, **Fourier.FourierTransform** for characteristic functions, and **Topology.MetricSpace** for the geometric interpretation. This interdisciplinary foundation reflects the theorem's broad reach.",
+    "mathContext": "The file uses Mathlib's `MeasureTheory.Measure` for probability measures, `Complex.exp` for characteristic functions $\\varphi_X(t) = \\mathbb{E}[e^{itX}]$, and axiomatizes several deep results (Lévy continuity, Taylor remainder bounds, Berry-Esseen) that are not yet in Mathlib.",
     "significance": "supporting",
     "relatedConcepts": [
       "Mathlib",
       "measure theory",
       "Fourier analysis"
+    ],
+    "prerequisites": [
+      "Mathlib.Probability.Distributions.Gaussian",
+      "Mathlib.Analysis.Fourier.FourierTransform",
+      "Mathlib.Topology.MetricSpace.Basic"
     ]
   },
   {
@@ -48,6 +60,11 @@
       "Fourier transform",
       "moment generating function",
       "convolution"
+    ],
+    "prerequisites": [
+      "Lebesgue integration",
+      "complex exponential",
+      "probability measure"
     ]
   },
   {
@@ -65,6 +82,10 @@
     "relatedConcepts": [
       "probability normalization",
       "Fourier analysis"
+    ],
+    "prerequisites": [
+      "ann-clt-charfun-def",
+      "probability measure normalization"
     ]
   },
   {
@@ -78,11 +99,17 @@
     "type": "insight",
     "title": "Moments from Derivatives",
     "content": "Taking derivatives of the characteristic function at $t=0$ extracts moments: $\\varphi'(0) = i\\mu$ (mean), $\\varphi''(0) = i^2(\\mu^2 + \\sigma^2)$ (second moment). The Taylor expansion $\\varphi(t) = 1 + it\\mu - t^2\\sigma^2/2 + O(t^3)$ encodes the distribution's shape in its coefficients.",
+    "mathContext": "For a mean-zero, unit-variance random variable: $\\varphi(t) = 1 - t^2/2 + O(t^3)$. This quadratic approximation is the key input to the CLT proof: raising it to the $n$-th power gives $(1 - t^2/(2n))^n \\to e^{-t^2/2}$.",
     "significance": "key",
     "relatedConcepts": [
       "Taylor series",
       "moments",
       "cumulants"
+    ],
+    "prerequisites": [
+      "ann-clt-charfun-def",
+      "Taylor's theorem with remainder",
+      "differentiation under integral sign"
     ]
   },
   {
@@ -118,11 +145,17 @@
     "type": "concept",
     "title": "The Product-to-Exponential Limit",
     "content": "The classical limit $(1 + x/n)^n \\to e^x$ is the engine of CLT. For the normalized sum $S_n = (X_1 + \\cdots + X_n)/\\sqrt{n}$, we have $\\varphi_{S_n}(t) = [\\varphi_X(t/\\sqrt{n})]^n$. Taylor expansion gives $\\varphi_X(t/\\sqrt{n}) \\approx 1 - t^2/(2n)$, and $(1 - t^2/(2n))^n \\to e^{-t^2/2}$.",
+    "mathContext": "Independence converts sums to products of characteristic functions: $\\varphi_{X_1+\\cdots+X_n}(t) = \\prod_{i=1}^n \\varphi_{X_i}(t)$. For i.i.d. variables this simplifies to $[\\varphi_X(t)]^n$. The $1/\\sqrt{n}$ normalization ensures the Taylor coefficient is $-t^2/(2n)$, triggering the exponential limit.",
     "significance": "key",
     "relatedConcepts": [
       "exponential limit",
       "compound interest",
       "Euler's definition of e"
+    ],
+    "prerequisites": [
+      "ann-clt-taylor-expansion",
+      "independence of random variables",
+      "limit $(1+x/n)^n \\to e^x$"
     ]
   },
   {
@@ -158,12 +191,17 @@
     "type": "theorem",
     "title": "Lévy Continuity Theorem",
     "content": "**The Bridge**: Pointwise convergence of characteristic functions to a continuous function implies weak convergence of probability measures. This connects the Fourier (analysis) world to the distributional (probability) world.\n\nLévy's theorem is the inverse of the continuity of the Fourier transform: if the images converge, so do the preimages.",
-    "mathContext": "Continuity at $t=0$ is essential and automatic for characteristic functions (they equal 1 at 0). The theorem fails for discontinuous limits.",
+    "mathContext": "Continuity at $t=0$ is essential and automatic for characteristic functions (they equal 1 at 0). The theorem fails for discontinuous limits. Axiomatized as `levy_continuity_axiom` since the full proof requires tightness arguments not yet in Mathlib.",
     "significance": "key",
     "relatedConcepts": [
       "weak convergence",
       "Fourier inversion",
       "tightness"
+    ],
+    "prerequisites": [
+      "ann-clt-key-convergence",
+      "weak convergence of measures",
+      "Prokhorov's theorem"
     ]
   },
   {
@@ -199,11 +237,17 @@
     "type": "concept",
     "title": "The Topological Viewpoint",
     "content": "Now we shift perspective: instead of computing limits, we ask WHY the Gaussian emerges. The answer: **it is a fixed point attractor** of the renormalization group flow on the space of probability distributions.\n\nThis dynamical systems perspective reveals that CLT is not an accident of computation but a consequence of the structure of the convolution operation.",
+    "mathContext": "The renormalization map $T: \\mathcal{P}_2(\\mathbb{R}) \\to \\mathcal{P}_2(\\mathbb{R})$ sends $\\mu \\mapsto$ the distribution of $(X_1 + X_2)/(\\sqrt{2})$ where $X_i \\sim \\mu$. The Gaussian $N(0,\\sigma^2)$ is a fixed point: averaging two i.i.d. Gaussians gives another Gaussian with the same variance (after rescaling). CLT says this fixed point is globally attracting.",
     "significance": "key",
     "relatedConcepts": [
       "dynamical systems",
       "fixed point theory",
       "renormalization group"
+    ],
+    "prerequisites": [
+      "ann-clt-main-theorem",
+      "dynamical systems (fixed points, attractors)",
+      "metric space of probability measures"
     ]
   },
   {
@@ -223,6 +267,11 @@
       "optimal transport",
       "Wasserstein metric",
       "metric geometry"
+    ],
+    "prerequisites": [
+      "optimal transport theory",
+      "metric space completeness",
+      "measure coupling"
     ]
   },
   {
@@ -239,7 +288,8 @@
     "mathContext": "The 'domain of attraction' is exactly the set of distributions with finite variance. Infinite variance leads to stable distributions with $\\alpha < 2$ (Lévy flights).",
     "significance": "key",
     "prerequisites": [
-      "ann-clt-fixed-point"
+      "ann-clt-topological-intro",
+      "ann-clt-wasserstein"
     ],
     "relatedConcepts": [
       "basin of attraction",
@@ -264,6 +314,11 @@
       "Shannon entropy",
       "maximum entropy principle",
       "thermodynamics"
+    ],
+    "prerequisites": [
+      "Shannon entropy $H(\\mu) = -\\int p \\log p$",
+      "Jaynes' maximum entropy principle",
+      "Lagrange multipliers"
     ]
   },
   {
@@ -283,6 +338,11 @@
       "Fourier transform",
       "eigenfunctions",
       "Hermite polynomials"
+    ],
+    "prerequisites": [
+      "Fourier transform on $L^2$",
+      "Gaussian integral $\\int e^{-x^2/2} = \\sqrt{2\\pi}$",
+      "Hermite functions"
     ]
   },
   {
@@ -302,6 +362,11 @@
       "rate of convergence",
       "Kolmogorov distance",
       "third moment"
+    ],
+    "prerequisites": [
+      "ann-clt-main-theorem",
+      "CDF and Kolmogorov distance",
+      "third absolute moment"
     ]
   },
   {
@@ -322,6 +387,11 @@
       "Lévy flights",
       "heavy tails",
       "power laws"
+    ],
+    "prerequisites": [
+      "generalized CLT",
+      "domain of attraction theory",
+      "regular variation"
     ]
   },
   {
@@ -334,11 +404,18 @@
     "type": "concept",
     "title": "Synthesis: Why the Gaussian is Universal",
     "content": "The Central Limit Theorem reveals the Gaussian as a **mathematical necessity**, not an accident:\n\n1. **Dynamically**: It is the unique fixed-point attractor of the averaging operation\n2. **Information-theoretically**: It maximizes entropy at fixed variance\n3. **Analytically**: It is self-dual under Fourier transform\n4. **Probabilistically**: It is the only finite-variance stable distribution\n\nWherever we see many small independent effects being summed—measurement errors, thermal fluctuations, stock prices, IQ scores—the Gaussian emerges because averaging dynamics demand it.",
+    "mathContext": "Four independent characterizations of the Gaussian, each from a different branch of mathematics, all pointing to the same conclusion: $N(0,\\sigma^2)$ is the unique distribution that is simultaneously a fixed point of averaging, a maximum entropy distribution at fixed variance, an eigenfunction of the Fourier transform, and an $\\alpha$-stable distribution with $\\alpha = 2$.",
     "significance": "key",
     "relatedConcepts": [
       "universality",
       "emergence",
       "mathematical inevitability"
+    ],
+    "prerequisites": [
+      "ann-clt-topological-intro",
+      "ann-clt-why-gaussian-entropy",
+      "ann-clt-self-duality",
+      "ann-clt-stable"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `central-limit-theorem` (Central Limit Theorem).

## Changes

Added `mathContext` and `prerequisites` to all 18 annotations:

- **6 annotations** gained new `mathContext`: ann-clt-intro (CLT statement, renormalization map), ann-clt-imports (Mathlib dependencies), ann-clt-taylor-expansion (quadratic approximation), ann-clt-limit-setup (product-to-exponential), ann-clt-topological-intro (fixed-point attractor), ann-clt-conclusion (four characterizations)
- **14 annotations** gained `prerequisites`
- All 18 annotations now have full field coverage

## Quality Summary

- All 18 annotations: `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- 0 annotation build warnings for this entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)