### PR TITLE
Fix: erdos-922 sorry count 4→2

### DIFF
--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -17,13 +17,13 @@
       "folkman"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "erdosNumber": 922,
     "erdosUrl": "https://erdosproblems.com/922",
     "erdosProblemStatus": "solved",
     "axiomCount": 7,
     "lineCount": 237,
-    "assumptions": "7 axiom(s) and 4 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "7 axiom(s) and 2 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update erdos-922 meta.json sorry count from 4 to 2 to match actual Lean source.

## Evidence

**Before**: `"sorries": 4` and `"assumptions": "7 axiom(s) and 4 sorry(s)..."`
**After**: `"sorries": 2` and `"assumptions": "7 axiom(s) and 2 sorry(s)..."`

Verified: `Proofs/Erdos922Problem.lean` has exactly 2 code-level sorries (lines 103, 108) and 7 axioms.

---
Automated fix by lean-mechanic agent.