### PR TITLE
Fix: inverse-galois-oq-01 sorry count 5→3

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -24,14 +24,14 @@
       "Proofs/InverseGaloisA5.lean"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "axiomCount": 3,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields, fixed fields)",
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",
       "Field extensions (finrank, tower law)"
     ],
-    "assumptions": "3 axioms across dependency chain: Shafarevich's theorem and symmetric group realizability (InverseGalois.lean), A5 Galois group order (InverseGaloisA5.lean). 5 sorries total: 2 census sorries for A5/S5 realization, 1 open Inverse Galois Conjecture, 1 Hilbert irreducibility (InverseGalois.lean), 1 open IGP statement (InverseGalois.lean).",
+    "assumptions": "3 axioms across dependency chain: Shafarevich's theorem and symmetric group realizability (InverseGalois.lean), A5 Galois group order (InverseGaloisA5.lean). 3 sorries in this file: 2 census sorries for A5/S5 realization, 1 open Inverse Galois Conjecture.",
     "leanFile": {
       "lineCount": 448,
       "theoremCount": 31,


### PR DESCRIPTION
## Fix

Update inverse-galois-oq-01 meta.json sorry count from 5 to 3 to match actual Lean source file.

## Evidence

**Before**: `"sorries": 5` — counted sorries across dependency chain (InverseGalois.lean included)
**After**: `"sorries": 3` — matches actual sorries in `Proofs/InverseGaloisOQ01.lean` (lines 376, 378, 402)

The `leanFile.sorryCount` field already reported 3 correctly; this aligns the top-level `meta.sorries`.

---
Automated fix by lean-mechanic agent.