### PR TITLE
Fix: erdos-961 sorry count 3→2

### DIFF
--- a/src/data/proofs/erdos-961/meta.json
+++ b/src/data/proofs/erdos-961/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 961,
     "erdosUrl": "https://erdosproblems.com/961",
     "erdosProblemStatus": "open",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 261,
-    "assumptions": "4 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "This problem connects to a classical result by Sylvester (1892) and Schur (1929) showing that among any $k$ consecutive integers greater than $k$, at least one has a prime factor greater than $k$. Erdős published this as Problem #961, asking for better bounds on $f(k)$.\n\nErdős himself improved the bound in 1955 [Er55d] to $f(k) < 3k/\\log k$, showing sublinear growth. The strongest known result came from Jutila (1974) [Ju74] and independently Ramachandra–Shorey (1973) [RaSh73], who proved $f(k) \\ll \\frac{\\log\\log\\log k}{\\log\\log k} \\cdot \\frac{k}{\\log k}$ using sieve methods.\n\nThe problem is essentially equivalent to Problem #683, which asks about gaps between smooth numbers. The conjecture that $f(k)$ grows only polylogarithmically—$f(k) \\ll (\\log k)^C$—remains wide open. The gap between the known $O(k / \\text{polylog})$ and conjectured $O(\\text{polylog})$ is enormous.\n\nSmooth numbers play a central role in computational number theory: the quadratic sieve and number field sieve factoring algorithms depend on finding smooth numbers in specific ranges. Understanding the distribution of smooth numbers in short intervals is both a fundamental problem in analytic number theory and a question of practical importance.\n\n**Status**: OPEN — Polylogarithmic conjecture unresolved. Best known bound: $f(k) \\ll \\frac{\\log\\log\\log k}{\\log\\log k} \\cdot \\frac{k}{\\log k}$.",


### PR DESCRIPTION
## Fix

Update erdos-961 meta.json sorry count from 3 to 2 to match actual Lean source.

## Evidence

**Before**: `"sorries": 3`
**After**: `"sorries": 2`

Verified: `Proofs/Erdos961Problem.lean` has exactly 2 code-level sorries (lines 147, 206) and 4 axioms.

---
Automated fix by lean-mechanic agent.