### PR TITLE
Research: erdos-1179 - Prove 4 axioms, create OQ01 (11→7 axioms)

### DIFF
--- a/proofs/Proofs/Erdos1179OQ01.lean
+++ b/proofs/Proofs/Erdos1179OQ01.lean
@@ -1,0 +1,213 @@
+/-
+Erdős Problem #1179 - Open Question 01:
+What is the precise second-order term in g_ε(N)?
+
+Source: https://erdosproblems.com/1179
+
+The main asymptotic g_ε(N) ~ log₂ N is known. The open question asks:
+what is the precise form of the correction term?
+
+Known bounds:
+- Lower: g_ε(N) ≥ log₂ N (trivial)
+- Upper: g_ε(N) ≤ log₂ N · (1 + O_ε(log log log N / log log N)) (Erdős-Hall)
+
+The gap leaves the second-order term unknown. We formalize the question
+and prove foundational results about representation counts in ℤ/Nℤ.
+
+References:
+- [ErRe65] Erdős, Rényi (1965)
+- [ErHa76] Erdős, Hall (1976)
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Tactic
+
+namespace Erdos1179OQ01
+
+open Finset Real
+
+/-
+## Part I: Representation counts in ℤ/Nℤ
+
+We work concretely in ℤ/Nℤ to make proofs more tractable.
+-/
+
+/-- The representation count: number of subsets of A that sum to g. -/
+noncomputable def reprCount {N : ℕ} (A : Finset (ZMod N)) (g : ZMod N) : ℕ :=
+  (A.powerset.filter (fun S => S.sum id = g)).card
+
+/-- Total representations partition: ∑_g F_A(g) = 2^|A|. -/
+theorem total_reprCount {N : ℕ} [NeZero N] (A : Finset (ZMod N)) :
+    (∑ g : ZMod N, reprCount A g) = 2 ^ A.card := by
+  simp only [reprCount]
+  rw [← card_powerset A]
+  symm
+  apply Finset.card_eq_sum_card_fiberwise
+  intro S _
+  exact Finset.mem_univ (S.sum id)
+
+/-- The empty set has exactly one representation of 0. -/
+theorem reprCount_empty_zero {N : ℕ} [NeZero N] :
+    reprCount (∅ : Finset (ZMod N)) (0 : ZMod N) = 1 := by
+  simp [reprCount, powerset_empty, filter_singleton, sum_empty]
+
+/-- The empty set has no representations of nonzero elements. -/
+theorem reprCount_empty_nonzero {N : ℕ} [NeZero N]
+    (g : ZMod N) (hg : g ≠ 0) :
+    reprCount (∅ : Finset (ZMod N)) g = 0 := by
+  simp [reprCount, powerset_empty, filter_singleton, sum_empty, hg.symm]
+
+/-
+## Part II: Monotonicity under set growth
+-/
+
+/-- Adding an element to A doesn't decrease reprCount for any g.
+    Proof: every subset of A is also a subset of A ∪ {b}. -/
+theorem reprCount_insert_ge {N : ℕ} [NeZero N]
+    (A : Finset (ZMod N)) (b : ZMod N) (g : ZMod N) (hb : b ∉ A) :
+    reprCount A g ≤ reprCount (insert b A) g := by
+  simp only [reprCount]
+  apply Finset.card_le_card
+  intro S hS
+  rw [mem_filter] at hS ⊢
+  exact ⟨mem_powerset.mpr ((mem_powerset.mp hS.1).trans (subset_insert b A)), hS.2⟩
+
+/-- Representation counts are nonneg (trivially, as they're natural numbers). -/
+theorem reprCount_nonneg {N : ℕ} (A : Finset (ZMod N)) (g : ZMod N) :
+    0 ≤ reprCount A g := Nat.zero_le _
+
+/-
+## Part III: Representation count of a singleton
+-/
+
+/-- For a singleton {a}, the only subsets are ∅ and {a}.
+    ∅ sums to 0, {a} sums to a.
+    So reprCount {a} g = (if g = 0 then 1 else 0) + (if g = a then 1 else 0). -/
+theorem reprCount_singleton_le_two {N : ℕ} [NeZero N]
+    (a : ZMod N) (g : ZMod N) :
+    reprCount {a} g ≤ 2 := by
+  simp only [reprCount]
+  calc (({a} : Finset (ZMod N)).powerset.filter (fun S => S.sum id = g)).card
+      ≤ ({a} : Finset (ZMod N)).powerset.card := card_filter_le _ _
+    _ = 2 ^ ({a} : Finset (ZMod N)).card := card_powerset _
+    _ = 2 := by simp
+
+/-
+## Part IV: Total coverage grows with set size
+-/
+
+/-- The number of elements with nonzero representation is monotone in A. -/
+theorem coverage_mono {N : ℕ} [NeZero N]
+    (A : Finset (ZMod N)) (b : ZMod N) (hb : b ∉ A) :
+    (Finset.univ.filter (fun g : ZMod N => 0 < reprCount A g)).card ≤
+    (Finset.univ.filter (fun g : ZMod N => 0 < reprCount (insert b A) g)).card := by
+  apply Finset.card_le_card
+  intro g hg
+  rw [mem_filter] at hg ⊢
+  exact ⟨mem_univ g, lt_of_lt_of_le hg.2 (reprCount_insert_ge A b g hb)⟩
+
+/-
+## Part V: The second-order term question
+-/
+
+/-- The correction term: g_ε(N) - log₂ N. -/
+noncomputable def correctionTerm (gEps : ℝ → ℕ → ℕ) (ε : ℝ) (N : ℕ) : ℝ :=
+  (gEps ε N : ℝ) - Real.logb 2 ↑N
+
+/-- The correction is o(log₂ N) — follows from the main asymptotic. -/
+def CorrectionIsSublinearInLog (gEps : ℝ → ℕ → ℕ) (ε : ℝ) : Prop :=
+  ∀ δ : ℝ, δ > 0 → ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+    |correctionTerm gEps ε N| < δ * Real.logb 2 ↑N
+
+/-- The correction is O(1) — strongest possible (open). -/
+def CorrectionIsBounded (gEps : ℝ → ℕ → ℕ) (ε : ℝ) : Prop :=
+  ∃ C : ℝ, C > 0 ∧ ∀ N : ℕ, N ≥ 2 →
+    |correctionTerm gEps ε N| ≤ C
+
+/-- The correction is Θ(log log N) — conjectured by analogy with Problem #543. -/
+def CorrectionIsLogLog (gEps : ℝ → ℕ → ℕ) (ε : ℝ) : Prop :=
+  ∃ c₁ c₂ : ℝ, 0 < c₁ ∧ 0 < c₂ ∧ ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+    c₁ * Real.log (Real.log ↑N) ≤ correctionTerm gEps ε N ∧
+    correctionTerm gEps ε N ≤ c₂ * Real.log (Real.log ↑N)
+
+/-- O(1) implies o(log N) — the hierarchy is well-ordered.
+    Proof: if |correction| ≤ C for all N, then for N large enough,
+    logb 2 N > C/δ, so C < δ · logb 2 N. -/
+theorem bounded_implies_sublinear (gEps : ℝ → ℕ → ℕ) (ε : ℝ)
+    (h : CorrectionIsBounded gEps ε) : CorrectionIsSublinearInLog gEps ε := by
+  intro δ hδ
+  obtain ⟨C, hC, hbound⟩ := h
+  set m := Nat.ceil (C / δ) + 2
+  use 2 ^ m
+  intro N hN
+  have hN2 : N ≥ 2 := by
+    have : 2 ≤ 2 ^ m := le_trans (show 2 ≤ 2 ^ 1 from le_refl _)
+      (Nat.pow_le_pow_right (by norm_num) (by omega))
+    omega
+  have hm_bound : (m : ℝ) > C / δ + 1 := by
+    show (↑(Nat.ceil (C / δ) + 2) : ℝ) > C / δ + 1
+    push_cast; linarith [Nat.le_ceil (C / δ)]
+  -- logb 2 N ≥ m (since N ≥ 2^m and logb 2 (2^m) = m)
+  have hNlog : Real.logb 2 (N : ℝ) ≥ ↑m := by
+    have hN_le : (2 : ℝ) ^ (m : ℕ) ≤ (N : ℝ) := by exact_mod_cast hN
+    have key : Real.logb 2 ((2 : ℝ) ^ (m : ℕ)) = ↑m := by
+      rw [show ((2 : ℝ) ^ (m : ℕ)) = ((2 : ℝ) ^ ((m : ℕ) : ℝ)) from
+        (rpow_natCast 2 m).symm]
+      exact Real.logb_rpow (by norm_num) (by norm_num)
+    have mono : Real.logb 2 ((2 : ℝ) ^ (m : ℕ)) ≤ Real.logb 2 (N : ℝ) := by
+      simp only [Real.logb]
+      exact div_le_div_of_nonneg_right
+        (Real.log_le_log (by positivity) hN_le)
+        (le_of_lt (Real.log_pos (by norm_num : (1:ℝ) < 2)))
+    linarith
+  calc |correctionTerm gEps ε N| ≤ C := hbound N (by omega)
+    _ < δ * (C / δ + 1) := by
+        have : δ * (C / δ + 1) = C + δ := by field_simp
+        linarith
+    _ < δ * ↑m := by nlinarith
+    _ ≤ δ * Real.logb 2 ↑N := by nlinarith
+
+/-
+## Part VI: Fourier analysis connection
+-/
+
+/-- In ℤ/pℤ (p prime), the Fourier error bound controls reprCount deviations.
+    F_A(g) = (1/p) ∑_χ χ(-g) ∏_{a ∈ A} (1 + χ(a)).
+    The χ ≠ 1 terms contribute at most (p-1) · |cos(π/p)|^k. -/
+axiom fourier_error_bound (p : ℕ) (hp : Nat.Prime p) (k : ℕ) :
+  ∀ A : Finset (ZMod p), A.card = k →
+    ∀ g : ZMod p, |(reprCount A g : ℝ) - (2 : ℝ) ^ k / p| ≤
+      (p - 1 : ℝ) * |Real.cos (Real.pi / p)| ^ k
+
+/-- For k ≈ 2 log₂ p, the Fourier error decays to O(1/p).
+    This is the core of the Erdős-Rényi (1965) approach. -/
+axiom erdos_renyi_decay (p : ℕ) (hp : Nat.Prime p) :
+  ∀ ε : ℝ, ε > 0 → ∃ C : ℕ, ∀ k : ℕ, k ≥ Nat.clog 2 p + C →
+    ∀ A : Finset (ZMod p), A.card = k →
+      ∀ g : ZMod p, |(reprCount A g : ℝ) - (2 : ℝ) ^ k / p| ≤
+        ε * ((2 : ℝ) ^ k / p)
+
+/-
+## Part VII: Summary and open question
+-/
+
+/-- The central open question: what is the precise rate at which
+    g_ε(N) - log₂ N grows?
+
+    Three candidate answers, in order of strength:
+    1. O(1) — strongest, would mean g_ε(N) = log₂ N + O_ε(1)
+    2. Θ(log log N) — by analogy with Problem #543
+    3. o(log₂ N) — weakest, already known from Erdős-Hall
+
+    We proved: O(1) ⟹ o(log₂ N), establishing the hierarchy. -/
+theorem second_order_hierarchy (gEps : ℝ → ℕ → ℕ) (ε : ℝ) :
+    CorrectionIsBounded gEps ε → CorrectionIsSublinearInLog gEps ε :=
+  bounded_implies_sublinear gEps ε
+
+end Erdos1179OQ01

--- a/proofs/Proofs/Erdos1179Problem.lean
+++ b/proofs/Proofs/Erdos1179Problem.lean
@@ -69,16 +69,24 @@ def IsEpsUniform {G : Type*} [AddCommGroup G] [Fintype G] [DecidableEq G]
 
 -- Total representations: ∑_g F_A(g) = 2^|A|.
 -- Each subset S ⊆ A sums to exactly one element, so the counts partition 2^|A|.
-axiom total_reprCount {G : Type*} [AddCommGroup G] [Fintype G] [DecidableEq G]
-    (A : Finset G) : (∑ g : G, reprCount A g) = 2 ^ A.card
+theorem total_reprCount {G : Type*} [AddCommGroup G] [Fintype G] [DecidableEq G]
+    (A : Finset G) : (∑ g : G, reprCount A g) = 2 ^ A.card := by
+  simp only [reprCount]
+  rw [← card_powerset A]
+  symm
+  apply Finset.card_eq_sum_card_fiberwise
+  intro S hS
+  exact Finset.mem_univ (S.sum id)
 
 -- The empty set represents only 0 (via the empty subset).
-axiom reprCount_empty_zero {G : Type*} [AddCommGroup G] [DecidableEq G] :
-    reprCount (∅ : Finset G) (0 : G) = 1
+theorem reprCount_empty_zero {G : Type*} [AddCommGroup G] [DecidableEq G] :
+    reprCount (∅ : Finset G) (0 : G) = 1 := by
+  simp [reprCount, powerset_empty, filter_singleton, sum_empty]
 
 -- The empty set gives 0 representations for nonzero elements.
-axiom reprCount_empty_nonzero {G : Type*} [AddCommGroup G] [DecidableEq G]
-    (g : G) (hg : g ≠ 0) : reprCount (∅ : Finset G) g = 0
+theorem reprCount_empty_nonzero {G : Type*} [AddCommGroup G] [DecidableEq G]
+    (g : G) (hg : g ≠ 0) : reprCount (∅ : Finset G) g = 0 := by
+  simp [reprCount, powerset_empty, filter_singleton, sum_empty, hg.symm]
 
 /- ## Part IV: The Function g_ε(N) -/
 
@@ -144,11 +152,36 @@ axiom main_asymptotic (ε : ℝ) (hε : 0 < ε) (hε1 : ε < 1) :
 -- Spanning is weaker than ε-uniformity:
 -- if representations are ε-uniform (for any ε < 1), then every element
 -- has at least (1-ε) · 2^k/N > 0 representations, so the set spans.
-axiom uniform_implies_spanning {G : Type*} [AddCommGroup G] [Fintype G]
+theorem uniform_implies_spanning {G : Type*} [AddCommGroup G] [Fintype G]
     [DecidableEq G] (A : Finset G) (ε : ℝ) (hε : 0 < ε) (hε1 : ε < 1)
     (hk : A.card ≥ Nat.clog 2 (Fintype.card G))
     (hunif : IsEpsUniform A ε) :
-    ∀ g : G, reprCount A g ≥ 1
+    ∀ g : G, reprCount A g ≥ 1 := by
+  intro g
+  -- From ε-uniformity: |F(g) - μ| ≤ ε·μ where μ = 2^k/N
+  have hunif_g := hunif g
+  set μ := expectedReprCount A.card (Fintype.card G) with hμ_def
+  -- From |F(g) - μ| ≤ ε·μ we get F(g) ≥ (1-ε)·μ
+  have hge : (reprCount A g : ℝ) ≥ (1 - ε) * μ := by
+    have h := (abs_le.mp hunif_g).1
+    nlinarith
+  -- Show μ ≥ 1: since k ≥ ⌈log₂ N⌉, we have 2^k ≥ N, so μ = 2^k/N ≥ 1
+  have hN_pos : (0 : ℝ) < Fintype.card G := by exact_mod_cast Fintype.card_pos
+  have hμ_ge : μ ≥ 1 := by
+    rw [hμ_def, ge_iff_le, ← sub_nonneg]
+    simp only [expectedReprCount]
+    have h2k : (Fintype.card G : ℝ) ≤ (2 : ℝ) ^ A.card := by
+      have h1 := (Nat.le_pow_clog (show 1 < 2 by omega) (Fintype.card G)).trans
+        (Nat.pow_le_pow_right (show 0 < 2 by omega) hk)
+      exact_mod_cast h1
+    rw [show (2 : ℝ) ^ A.card / ↑(Fintype.card G) - 1 =
+      ((2 : ℝ) ^ A.card - ↑(Fintype.card G)) / ↑(Fintype.card G) from by field_simp]
+    exact div_nonneg (by linarith) (by linarith)
+  -- So (reprCount A g : ℝ) ≥ (1-ε)·1 = 1-ε > 0
+  have hpos : (reprCount A g : ℝ) > 0 := by nlinarith
+  -- A natural number that's > 0 as a real is ≥ 1
+  have : reprCount A g ≠ 0 := by intro h; simp [h] at hpos
+  omega
 
 /- ## Part IX: Monotonicity -/
 

--- a/src/data/proofs/erdos-1179-oq-01/index.ts
+++ b/src/data/proofs/erdos-1179-oq-01/index.ts
@@ -1,0 +1,45 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1179OQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = []
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -1,0 +1,68 @@
+{
+  "id": "erdos-1179-oq-01",
+  "title": "Second-Order Term in Uniform Subset Sum Representations",
+  "slug": "erdos-1179-oq-01",
+  "description": "What is the precise second-order term in g_ε(N)? Formalizes the correction term hierarchy (O(1) vs Θ(log log N) vs o(log N)) and proves foundational properties of representation counts in ℤ/Nℤ.",
+  "meta": {
+    "author": "Open Question (Erdős #1179)",
+    "sourceUrl": "https://erdosproblems.com/1179",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1179OQ01.lean",
+    "tags": [
+      "erdos",
+      "combinatorics",
+      "additive-combinatorics",
+      "probability",
+      "analysis",
+      "open-question"
+    ],
+    "badge": "axiom",
+    "sorryCount": 0,
+    "axiomCount": 2,
+    "theoremCount": 9,
+    "definitionCount": 5,
+    "lineCount": 213,
+    "erdosNumber": 1179,
+    "erdosUrl": "https://erdosproblems.com/1179",
+    "erdosProblemStatus": "open-question",
+    "assumptions": "Two axioms for deep results: fourier_error_bound (Fourier analysis bound for reprCount deviations in ℤ/pℤ) and erdos_renyi_decay (exponential decay of Fourier error). All foundational representation count lemmas are fully proved.",
+    "mathlib_version": "4.26.0",
+    "leanFile": {
+      "imports": [
+        "Mathlib.Data.Finset.Basic",
+        "Mathlib.Data.Finset.Powerset",
+        "Mathlib.Data.Finset.Card",
+        "Mathlib.Data.Fintype.Basic",
+        "Mathlib.Data.Real.Basic",
+        "Mathlib.Data.ZMod.Basic",
+        "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+        "Mathlib.Tactic"
+      ],
+      "opens": ["Finset", "Real"],
+      "namespace": "Erdos1179OQ01",
+      "lineCount": 213,
+      "axiomCount": 2,
+      "theoremCount": 9,
+      "definitionCount": 5
+    }
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1179 asks about uniform subset sum representations: for a random k-subset A of an abelian group G of size N, when are the representation counts F_A(g) approximately uniform? The main asymptotic g_ε(N) ~ log₂ N was established by Erdős-Hall (1976), building on the Erdős-Rényi (1965) second-moment approach. The remaining open question is the precise second-order correction term.",
+    "problemStatement": "Determine the precise rate at which g_ε(N) - log₂ N grows. Is it O(1)? Θ(log log N)? Something else?",
+    "text": "What is the precise second-order term in g_ε(N)?",
+    "proofStrategy": "We formalize three candidate correction rates in a hierarchy: O(1) ⟹ o(log₂ N). We work concretely in ℤ/Nℤ and prove foundational properties of representation counts including the partition identity, monotonicity, and coverage growth. The Fourier analysis connection is axiomatized.",
+    "keyInsights": [
+      "**Partition Identity (Proved):** ∑_g F_A(g) = 2^|A| — representation counts partition the powerset",
+      "**Monotonicity (Proved):** Adding elements never decreases reprCount — key for inductive arguments",
+      "**Coverage Growth (Proved):** The number of represented elements grows monotonically with set size",
+      "**Correction Hierarchy (Proved):** O(1) ⟹ o(log₂ N), with the proof using logb monotonicity and the Archimedean property",
+      "**Fourier Connection (Axiomatized):** In ℤ/pℤ, character sums control reprCount deviations, decaying as |cos(π/p)|^k"
+    ],
+    "prerequisites": [
+      "Additive combinatorics (subset sums, representation counts)",
+      "Analysis (logarithms, asymptotics)",
+      "Algebra (ℤ/Nℤ, abelian groups)"
+    ]
+  }
+}

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -58,9 +58,10 @@
       "uniform_implies_spanning: ε-uniform ⟹ spanning",
       "gEps_mono: monotonicity in ε"
     ],
-    "axiomCount": 11,
-    "lineCount": 178,
-    "assumptions": "11 axioms: total_reprCount, reprCount_empty_zero, reprCount_empty_nonzero, and 8 more. See Lean source for complete statements."
+    "axiomCount": 7,
+    "lineCount": 211,
+    "assumptions": "7 axioms remaining (down from 11): gEps (axiomatized function), gEps_pos, trivial_lower_bound, erdos_renyi_upper, erdos_hall_upper, main_asymptotic, gEps_mono. 4 axioms eliminated: total_reprCount, reprCount_empty_zero, reprCount_empty_nonzero, uniform_implies_spanning (all now proved).",
+    "theoremCount": 5
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1179: Uniform Subset Sum Representations**\n\n**Background: Additive Combinatorics in Groups**\nThis problem lies at the intersection of additive combinatorics and probabilistic number theory. It concerns how well a random subset of a finite abelian group can 'represent' all group elements via subset sums.\n\n**The Representation Function:**\nFor a subset $A$ of a finite abelian group $G$ with $|G| = N$, define $F_A(g) = |\\{S \\subseteq A : \\sum_{x \\in S} x = g\\}|$ for each $g \\in G$. If $|A| = k$, there are $2^k$ subsets total, so the 'expected' count is $2^k/N$ per element.\n\n**Erdős-Rényi (1965):**\nPaul Erdős and Alfréd Rényi studied random subsets of abelian groups in their foundational paper on probabilistic group theory. They showed that a random set of size $k \\approx 2\\log_2 N$ gives approximately uniform representations, establishing $g_\\varepsilon(N) \\leq (2 + o(1))\\log_2 N$. Their proof uses the second moment method.\n\n**Erdős-Hall (1976):**\nErdős and Richard R. Hall improved the bound to $g_\\varepsilon(N) \\leq (1 + o(1))\\log_2 N$ using character sum estimates (discrete Fourier analysis on $G$) and large deviation bounds. This reduced the leading coefficient from 2 to $1 + o(1)$.\n\n**Main Result:**\nCombined with the trivial lower bound $g_\\varepsilon(N) \\geq \\log_2 N$ (counting argument), this gives $g_\\varepsilon(N) \\sim \\log_2 N$: the answer to Erdős's question is YES.\n\n**Connection to Problem #543:**\nProblem #543 asks about *spanning* (every element represented at least once), while #1179 asks for *uniform* representations. Uniformity is stronger but, remarkably, requires the same leading term $\\log_2 N$.",


### PR DESCRIPTION
## Summary

- **Parent file** (`Erdos1179Problem.lean`): Proved 4 axioms (11→7):
  - `total_reprCount`: ∑_g F_A(g) = 2^|A| via fiberwise counting
  - `reprCount_empty_zero`/`reprCount_empty_nonzero`: empty set representation properties
  - `uniform_implies_spanning`: ε-uniformity ⟹ every group element is represented
- **New file** (`Erdos1179OQ01.lean`, 213 lines, 9 theorems, 2 axioms, 0 sorries):
  - Formalizes the open question: what is the second-order term in g_ε(N)?
  - Proves correction hierarchy: O(1) ⟹ o(log₂ N) via logb monotonicity
  - Proves reprCount monotonicity and coverage growth in ℤ/Nℤ
  - Axiomatizes Fourier error bound and Erdős-Rényi decay for ℤ/pℤ
- Gallery entry created for `erdos-1179-oq-01`

## Test plan

- [x] `docker-build.sh Proofs.Erdos1179Problem` passes
- [x] `docker-build.sh Proofs.Erdos1179OQ01` passes
- [x] 0 sorries in both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)