### PR TITLE
Enrich abel-ruffini-oq-04-oq-01: fix line ranges, add cross-references

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
@@ -72,9 +72,21 @@
     "prerequisites": ["Galois group action on roots", "cardinal arithmetic"]
   },
   {
+    "id": "ann-abeloq04oq01-evaluations",
+    "proofId": "abel-ruffini-oq-04-oq-01",
+    "range": { "startLine": 199, "endLine": 226 },
+    "type": "technique",
+    "title": "Polynomial Evaluations: Sign Changes Locating 3 Real Roots",
+    "content": "Formally computes $p(-2) = -22$, $p(-1) = 5$, $p(0) = 2$, $p(1) = -1$, $p(2) = 26$ using `unfold p; simp [...]; ring`. The three sign changes $(-22 \\to 5, 2 \\to -1, -1 \\to 26)$ locate real roots in $(-2,-1)$, $(0,1)$, and $(1,2)$ by the intermediate value theorem. Combined with the derivative $p'(x) = 5x^4 - 4$ having exactly 2 real critical points, $p$ has exactly 3 real roots and 2 complex conjugate roots. This is the computational foundation for the axiom $|\\text{Gal}| = 120$: complex conjugation swaps the 2 non-real roots (a transposition), which together with a 5-cycle generates $S_5$.",
+    "mathContext": "$p(-2) = -22 < 0$, $p(-1) = 5 > 0$, $p(0) = 2 > 0$, $p(1) = -1 < 0$, $p(2) = 26 > 0$. Three sign changes $\\Rightarrow$ at least 3 real roots. $p'(x) = 5x^4 - 4$ has 2 real roots $\\Rightarrow$ at most 3 real roots. Therefore exactly 3 real, 2 complex conjugate roots.",
+    "significance": "supporting",
+    "relatedConcepts": ["intermediate value theorem", "sign changes", "polynomial evaluation", "Rolle's theorem", "derivative analysis"],
+    "prerequisites": ["polynomial evaluation", "ring tactic", "real root counting"]
+  },
+  {
     "id": "ann-abeloq04oq01-axiom",
     "proofId": "abel-ruffini-oq-04-oq-01",
-    "range": { "startLine": 243, "endLine": 243 },
+    "range": { "startLine": 270, "endLine": 276 },
     "type": "concept",
     "title": "Axiom: |Gal| = 120 (Detailed Justification)",
     "content": "The single axiom: $|\\text{Gal}(p/\\mathbb{Q})| = 120$. The extensive documentation justifies this via a classical argument: (1) $p$ has exactly 3 real roots (by sign changes at $-2, -1, 0, 1, 2$ and derivative analysis: $p'(x) = 5x^4 - 4$ has 2 real roots, giving 2 critical points, bounding real roots to 3), (2) complex conjugation gives a transposition in $\\text{Gal}$ (swaps the 2 non-real roots), (3) irreducibility of prime degree gives a 5-cycle, (4) a transitive subgroup of $S_p$ ($p$ prime) containing a transposition generates $S_p$. Formalizing this fully would require the intermediate value theorem over $\\mathbb{R}$ and the classification of transitive permutation groups.",
@@ -86,7 +98,7 @@
   {
     "id": "ann-abeloq04oq01-iso",
     "proofId": "abel-ruffini-oq-04-oq-01",
-    "range": { "startLine": 253, "endLine": 278 },
+    "range": { "startLine": 282, "endLine": 311 },
     "type": "insight",
     "title": "Gal(p/Q) = S_5 via galActionHom Bijectivity",
     "content": "The central isomorphism: $\\text{Gal}(p/\\mathbb{Q}) \\cong S_5$. The proof proceeds in three steps: (1) `galActionHom` is injective (Mathlib), (2) $|\\text{Gal}| = 120 = |\\text{Perm}(\\text{rootSet})|$ (axiom + root set card), so `galActionHom` is bijective by the pigeonhole principle (`Fintype.bijective_iff_injective_and_card`), (3) transfer from $\\text{Perm}(\\text{rootSet})$ to $\\text{Perm}(\\text{Fin}\\;5)$ via `Equiv.permCongr`. The `MulEquiv.ofBijective` constructor packages the bijective homomorphism as a group isomorphism.",
@@ -98,7 +110,7 @@
   {
     "id": "ann-abeloq04oq01-nonsolvable",
     "proofId": "abel-ruffini-oq-04-oq-01",
-    "range": { "startLine": 285, "endLine": 297 },
+    "range": { "startLine": 317, "endLine": 330 },
     "type": "technique",
     "title": "Non-Solvability: S_5 to Gal Transfer",
     "content": "Two-step argument: (1) $S_5$ is not solvable, proved by `Equiv.Perm.not_solvable` which requires $5 \\leq |\\text{Fin}\\;5|$ (since $S_n$ is non-solvable for $n \\geq 5$, because the derived series $S_n \\supset A_n \\supset \\{e\\}$ stabilizes at the simple group $A_n$). (2) Transfer to $\\text{Gal}$: if $\\text{Gal}$ were solvable, then $S_5$ would be solvable via the surjective image of the isomorphism (`solvable_of_surjective`), contradiction. The surjectivity is extracted from the `MulEquiv` using `iso.apply_symm_apply`.",
@@ -110,7 +122,7 @@
   {
     "id": "ann-abeloq04oq01-main",
     "proofId": "abel-ruffini-oq-04-oq-01",
-    "range": { "startLine": 322, "endLine": 332 },
+    "range": { "startLine": 349, "endLine": 365 },
     "type": "insight",
     "title": "Abel-Ruffini Conclusion: Roots Not Solvable by Radicals",
     "content": "The culminating theorem: no root of $x^5 - 4x + 2$ can be expressed using $+, -, \\times, \\div$, and $n$-th roots starting from rationals. The proof is a clean contrapositive: assume root $\\alpha$ is solvable by radicals, then by Galois's theorem (`solvableByRad.isSolvable'`, which uses $p$ irreducible and $p(\\alpha) = 0$), $\\text{Gal}(p/\\mathbb{Q})$ would be solvable — contradicting `gal_not_solvable`. This is the concrete incarnation of Abel's 1824 impossibility result: not merely \"some\" quintic is unsolvable, but *this specific* quintic is unsolvable.",
@@ -122,7 +134,7 @@
   {
     "id": "ann-abeloq04oq01-realizability",
     "proofId": "abel-ruffini-oq-04-oq-01",
-    "range": { "startLine": 339, "endLine": 349 },
+    "range": { "startLine": 371, "endLine": 382 },
     "type": "insight",
     "title": "S_5 Realizability as a Galois Group over Q",
     "content": "A contribution to the inverse Galois problem: $S_5$ is realizable as $\\text{Gal}(K/\\mathbb{Q})$ for some finite Galois extension $K$. The witness is $K = $ splitting field of $x^5 - 4x + 2$. The proof constructs the requisite structure: $K/\\mathbb{Q}$ is finite-dimensional (splitting field of a polynomial), normal (splitting fields are normal), separable ($\\text{char}(\\mathbb{Q}) = 0$), hence Galois. The isomorphism $S_5 \\cong \\text{Gal}(K/\\mathbb{Q})$ is the inverse of `gal_iso_s5`. This complements other gallery realizations: $S_3$ via cubic discriminant, $F_{20}$ via cyclotomic fields.",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -93,6 +93,31 @@
       "targetId": "inverse-galois",
       "relationship": "contributes",
       "description": "Realizes S₅ as Gal(x⁵-4x+2/ℚ), complementing S₃ and F₂₀ realizations in the gallery"
+    },
+    {
+      "targetId": "inverse-galois-oq-01",
+      "relationship": "related",
+      "description": "Proves the complete solvability characterization $S_n$ solvable iff $n \\leq 4$, which is the group-theoretic foundation for the non-solvability of $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$"
+    },
+    {
+      "targetId": "general-quartic",
+      "relationship": "complementary",
+      "description": "Ferrari's quartic formula succeeds because $S_4$ is solvable — this entry shows $x^5 - 4x + 2$ fails because $S_5$ is not, illustrating the sharp degree-5 boundary"
+    },
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "complementary",
+      "description": "Cardano's cubic formula succeeds because $S_3$ is solvable — the positive counterpart to this entry's quintic impossibility"
+    },
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "complementary",
+      "description": "FTA guarantees the roots of $x^5-4x+2$ exist in $\\mathbb{C}$; this entry shows those roots cannot be named using radical expressions"
+    },
+    {
+      "targetId": "descartes-rule-of-signs",
+      "relationship": "foundational",
+      "description": "Descartes' rule bounds real root counts by sign changes in coefficients — the same sign-change analysis used to justify the axiom $|\\text{Gal}| = 120$ (3 real roots from 3 sign changes)"
     }
   ],
   "overview": {
@@ -113,80 +138,80 @@
       "id": "header",
       "title": "Problem Overview and Proof Chain",
       "startLine": 1,
-      "endLine": 57,
-      "summary": "Documents the complete Abel-Ruffini proof chain and motivation for choosing $x^5 - 4x + 2$. Lists all 5 steps from $A_5$ simplicity to unsolvability by radicals.",
+      "endLine": 60,
+      "summary": "Documents the complete Abel-Ruffini proof chain and motivation for choosing $x^5 - 4x + 2$. Lists all 5 steps from $A_5$ simplicity to unsolvability by radicals. Opens namespace and imports Mathlib.",
       "mathContext": "Proof chain: (1) $A_5$ simple, (2) $S_n$ not solvable for $n \\geq 5$, (3) solvable by radicals $\\Rightarrow$ solvable Gal, (4) $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$, (5) roots not expressible by radicals."
     },
     {
       "id": "polynomial",
-      "title": "The Polynomial p = X⁵ - 4X + 2",
-      "startLine": 58,
-      "endLine": 68,
-      "summary": "Defines $p = X^5 - 4X + 2$ over $\\mathbb{Q}$ and its $\\mathbb{Z}[X]$ version for Eisenstein criterion application.",
+      "title": "Part I: The Polynomial p = X⁵ - 4X + 2",
+      "startLine": 62,
+      "endLine": 70,
+      "summary": "Defines $p = X^5 - 4X + 2$ over $\\mathbb{Q}$ and its $\\mathbb{Z}[X]$ version `p_int` for Eisenstein criterion application.",
       "mathContext": "$p(x) = x^5 - 4x + 2 \\in \\mathbb{Q}[X]$, $p_{\\text{int}} = x^5 - 4x + 2 \\in \\mathbb{Z}[X]$."
     },
     {
       "id": "irreducibility",
-      "title": "Irreducibility via Eisenstein at p = 2",
-      "startLine": 69,
-      "endLine": 175,
+      "title": "Part II: Irreducibility via Eisenstein at p = 2",
+      "startLine": 72,
+      "endLine": 145,
       "summary": "Proves $p$ is irreducible over $\\mathbb{Q}$. First proves irreducibility over $\\mathbb{Z}$ using Eisenstein's criterion at the prime ideal $(2)$, then transfers to $\\mathbb{Q}$ via Gauss's lemma (monic $\\Rightarrow$ primitive).",
       "mathContext": "Eisenstein at $(2) \\subset \\mathbb{Z}$: $2 \\nmid 1$, $2 \\mid 0, 0, 0, -4, 2$, $4 \\nmid 2$. Therefore $p$ is irreducible over $\\mathbb{Z}$, hence over $\\mathbb{Q}$ by Gauss's lemma."
     },
     {
       "id": "structure",
-      "title": "Basic Structural Properties",
-      "startLine": 176,
-      "endLine": 206,
+      "title": "Part III: Basic Structural Properties",
+      "startLine": 147,
+      "endLine": 169,
       "summary": "Proves $\\deg(p) = 5$, $p$ is monic, $p$ is separable (char 0), and $|\\text{rootSet}(p)| = 5$.",
       "mathContext": "$\\deg(p) = 5$, $p$ monic and separable. In the splitting field: $|\\{\\alpha : p(\\alpha) = 0\\}| = 5$."
     },
     {
       "id": "galois-structure",
-      "title": "Galois Group Structure",
-      "startLine": 207,
-      "endLine": 228,
+      "title": "Part IV: Galois Group Structure",
+      "startLine": 171,
+      "endLine": 193,
       "summary": "Proves $5 \\mid |\\text{Gal}|$ (prime degree gives transitive action, orbit-stabilizer) and $|\\text{Gal}| \\mid 120$ (galActionHom embeds $\\text{Gal}$ into $S_5$). Together: $|\\text{Gal}| \\in \\{5, 10, 15, 20, 30, 40, 60, 120\\}$.",
       "mathContext": "$5 \\mid |\\text{Gal}|$ and $|\\text{Gal}| \\mid 5! = 120$. Possible orders: $\\{5, 10, 15, 20, 30, 40, 60, 120\\}$."
     },
     {
       "id": "gal-order",
-      "title": "Galois Group Order (Axiom)",
-      "startLine": 229,
-      "endLine": 267,
-      "summary": "Axiomatizes $|\\text{Gal}| = 120$ with detailed justification: 3 real roots (sign changes + derivative analysis), complex conjugation gives a transposition, transposition + 5-cycle generates $S_5$.",
-      "mathContext": "Axiom: $|\\text{Gal}(x^5-4x+2/\\mathbb{Q})| = 120 = 5!$. Justified: 3 real roots $\\Rightarrow$ transposition, prime degree $\\Rightarrow$ 5-cycle, $\\langle (i\\;j), (1\\;2\\;3\\;4\\;5) \\rangle = S_5$."
+      "title": "Part V: Polynomial Evaluations and Galois Group Order (Axiom)",
+      "startLine": 195,
+      "endLine": 276,
+      "summary": "Computes $p(-2) = -22$, $p(-1) = 5$, $p(0) = 2$, $p(1) = -1$, $p(2) = 26$ (showing 3 sign changes hence $\\geq 3$ real roots). Axiomatizes $|\\text{Gal}| = 120$ with detailed justification: 3 real roots + derivative analysis, complex conjugation gives a transposition, transposition + 5-cycle generates $S_5$.",
+      "mathContext": "Axiom: $|\\text{Gal}(x^5-4x+2/\\mathbb{Q})| = 120 = 5!$. Justified: 3 sign changes in $p$ at integer values, $p'(x) = 5x^4 - 4$ has 2 real critical points, so $p$ has exactly 3 real roots $\\Rightarrow$ transposition, prime degree $\\Rightarrow$ 5-cycle, $\\langle (i\\;j), (1\\;2\\;3\\;4\\;5) \\rangle = S_5$."
     },
     {
       "id": "gal-iso",
-      "title": "Gal(p/ℚ) ≅ S₅",
-      "startLine": 268,
-      "endLine": 280,
-      "summary": "Proves $\\text{Gal} \\cong S_5$ via galActionHom bijectivity: injective + $|\\text{Gal}| = |\\text{Perm}(\\text{rootSet})| = 120$. Transfers via $\\text{rootSet} \\simeq \\text{Fin}\\;5$.",
+      "title": "Part VI: Gal(p/ℚ) ≅ S₅",
+      "startLine": 278,
+      "endLine": 311,
+      "summary": "Proves $\\text{Gal} \\cong S_5$ via galActionHom bijectivity: injective (Mathlib) + $|\\text{Gal}| = |\\text{Perm}(\\text{rootSet})| = 120$ (axiom). Transfers via $\\text{rootSet} \\simeq \\text{Fin}\\;5$ using `Equiv.permCongr`.",
       "mathContext": "$\\text{galActionHom}$ injective + $|\\text{Gal}| = |S_5| = 120$ $\\Rightarrow$ bijective $\\Rightarrow$ $\\text{Gal}(p/\\mathbb{Q}) \\cong S_5$."
     },
     {
       "id": "not-solvable",
-      "title": "Non-Solvability",
-      "startLine": 281,
-      "endLine": 300,
-      "summary": "Proves $S_5$ is not solvable ($A_5$ is simple, $5 \\geq 5$) and transfers to $\\text{Gal}$ via the surjective isomorphism.",
-      "mathContext": "$S_5$ not solvable (derived series: $S_5 \\supset A_5 \\supset \\{e\\}$, $A_5$ simple non-abelian). $\\text{Gal} \\cong S_5 \\Rightarrow \\text{Gal}$ not solvable."
+      "title": "Part VII: Non-Solvability",
+      "startLine": 313,
+      "endLine": 330,
+      "summary": "Proves $S_5$ is not solvable ($A_5$ is simple, $5 \\geq 5$ via `Equiv.Perm.not_solvable`) and transfers to $\\text{Gal}$ via the surjective isomorphism using `solvable_of_surjective`.",
+      "mathContext": "$S_5$ not solvable (derived series: $S_5 \\supset A_5 \\supset A_5 \\supset \\cdots$, $A_5$ simple non-abelian). $\\text{Gal} \\cong S_5 \\Rightarrow \\text{Gal}$ not solvable."
     },
     {
       "id": "abel-ruffini",
-      "title": "Abel-Ruffini Conclusion",
-      "startLine": 301,
-      "endLine": 340,
-      "summary": "Main theorem: the roots of $x^5 - 4x + 2$ are not solvable by radicals. By contrapositive: if $\\alpha$ were solvable by radicals, $\\text{Gal}(p/\\mathbb{Q})$ would be solvable, but $S_5$ is not.",
+      "title": "Part VIII: Abel-Ruffini Conclusion",
+      "startLine": 332,
+      "endLine": 365,
+      "summary": "Main theorem `roots_not_solvable_by_rad`: the roots of $x^5 - 4x + 2$ are not solvable by radicals. Proof by contrapositive: if $\\alpha$ were solvable by radicals, `solvableByRad.isSolvable'` gives $\\text{Gal}$ solvable, contradicting `gal_not_solvable`.",
       "mathContext": "$\\alpha \\in \\text{Rad}(\\mathbb{Q}) \\Rightarrow \\text{Gal}(p/\\mathbb{Q})$ solvable $\\Rightarrow S_5$ solvable $\\Rightarrow \\bot$."
     },
     {
       "id": "realizability",
-      "title": "$S_5$ Realizability",
-      "startLine": 341,
-      "endLine": 365,
-      "summary": "$S_5$ is realizable as a Galois group over $\\mathbb{Q}$, witnessed by the splitting field of $x^5 - 4x + 2$. Contributes to the inverse Galois problem.",
+      "title": "Part IX: $S_5$ Realizability and Verification",
+      "startLine": 367,
+      "endLine": 398,
+      "summary": "$S_5$ is realizable as a Galois group over $\\mathbb{Q}$, witnessed by the splitting field of $x^5 - 4x + 2$. Followed by `#check` verification of all key theorems and namespace closure.",
       "mathContext": "$\\exists K/\\mathbb{Q}$ Galois: $\\text{Gal}(K/\\mathbb{Q}) \\cong S_5$. Witness: $K = $ splitting field of $x^5 - 4x + 2$."
     }
   ],
@@ -233,6 +258,21 @@
       "key": "DF04",
       "citation": "Dummit, D.S. and Foote, R.M., Abstract Algebra, 3rd ed., Wiley (2004). Section 14.6: example of x^5-4x+2 with Galois group S_5.",
       "type": "book"
+    },
+    {
+      "key": "La02",
+      "citation": "Lang, S., Algebra, 3rd ed., Springer GTM 211 (2002). Chapter VI: Galois theory, with standard examples of quintics with Galois group S_5.",
+      "type": "book"
+    },
+    {
+      "key": "St15",
+      "citation": "Stewart, I., Galois Theory, 4th ed., Chapman & Hall/CRC (2015). Chapters 22-23: explicit Galois group computations for specific polynomials.",
+      "type": "book"
+    },
+    {
+      "key": "Ei50",
+      "citation": "Eisenstein, G., Über die Irreductibilität und einige andere Eigenschaften der Gleichung..., Journal für die reine und angewandte Mathematik 39 (1850), pp. 160-179. The irreducibility criterion used to prove x^5-4x+2 is irreducible.",
+      "type": "paper"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for abel-ruffini-oq-04-oq-01 (pass 1).

- Fixed all 10 section line ranges (were off by 20-50 lines in later parts)
- Fixed 5 annotation line ranges to match actual Lean file
- Added annotation for polynomial evaluation section (sign changes)
- Added 5 cross-references (general-quartic, solution-of-cubic, inverse-galois-oq-01, fundamental-theorem-algebra, descartes-rule-of-signs)
- Added 3 scholarly references (Lang, Stewart, Eisenstein)