### PR TITLE
Research: erdos-1099 — prove 2 results, eliminate 1 axiom (5A+1S → 4A+0S)

### DIFF
--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -258,6 +258,32 @@ theorem first_ratio_ge_two (n : ℕ) (hn : n ≥ 2) :
   simp only [Nat.cast_one, div_one]
   exact_mod_cast hd2
 
+/-- In a sorted list of positive naturals, consecutive division ratios are ≥ 1. -/
+private theorem zipWith_div_ge_one :
+    ∀ (l : List ℕ), l.Pairwise (· ≤ ·) → (∀ x ∈ l, 0 < x) →
+    ∀ q ∈ List.zipWith (fun a b => (a : ℚ) / (b : ℚ)) l.tail l, (1 : ℚ) ≤ q := by
+  intro l
+  induction l with
+  | nil => simp
+  | cons a t ih =>
+    intro hsorted hpos q hq
+    cases t with
+    | nil => simp at hq
+    | cons b rest =>
+      simp only [List.tail_cons, List.zipWith_cons_cons] at hq
+      rcases List.mem_cons.mp hq with rfl | hmem
+      · -- q = ↑b / ↑a, show 1 ≤ ↑b / ↑a since a ≤ b (sorted) and a > 0
+        rw [le_div_iff (Nat.cast_pos.mpr (hpos a (List.mem_cons_self _ _))), one_mul]
+        exact Nat.cast_le.mpr
+          ((List.pairwise_cons.mp hsorted).1 b (List.mem_cons_self _ _))
+      · exact ih (List.pairwise_cons.mp hsorted).2
+          (fun x hx => hpos x (List.mem_cons_of_mem _ hx)) q hmem
+
+theorem divisorRatios_ge_one (n : ℕ) (hn : n ≥ 1) :
+    ∀ q ∈ divisorRatios n, (1 : ℚ) ≤ q :=
+  zipWith_div_ge_one (sortedDivisors n) (sortedDivisors_sorted n)
+    (fun x hx => sortedDivisors_pos n x hx)
+
 /--
 **Trivial lower bound:**
 For α > 1 and n ≥ 2, we have h_α(n) ≥ 1.
@@ -269,7 +295,6 @@ theorem h_alpha_ge_one (α : ℝ) (hα : α > 1) (n : ℕ) (hn : n ≥ 2) :
   unfold h_alpha
   obtain ⟨r, hr_mem, hr_ge⟩ := first_ratio_ge_two n hn
   set f := (fun (r : ℚ) => ((r : ℝ) - 1) ^ α) with hf_def
-  -- The term for r is ≥ 1 (since r ≥ 2, so r-1 ≥ 1, and 1^α = 1 ≤ (r-1)^α)
   have hr1 : (1 : ℝ) ≤ (r : ℝ) - 1 := by
     have : (2 : ℚ) ≤ r := hr_ge
     have : (2 : ℝ) ≤ (r : ℝ) := by exact_mod_cast this
@@ -277,10 +302,15 @@ theorem h_alpha_ge_one (α : ℝ) (hα : α > 1) (n : ℕ) (hn : n ≥ 2) :
   have hterm_ge : 1 ≤ f r := by
     simp only [hf_def]
     exact Real.one_le_rpow hr1 (by linarith)
-  -- h_alpha ≥ 1 because the sum contains a term ≥ 1 and all terms are nonneg
-  -- The nonneg condition requires: all divisor ratios ≥ 1 (sorted divisors increasing)
-  -- This is the remaining gap: formalizing that zipWith (/) tail divs ≥ 1 for sorted divs
-  sorry
+  -- All terms nonneg: ratios ≥ 1 so (r-1) ≥ 0 and rpow of nonneg is nonneg
+  have hall_nonneg : ∀ x ∈ (divisorRatios n).map f, 0 ≤ x := by
+    intro x hx
+    obtain ⟨q, hq_mem, rfl⟩ := List.mem_map.mp hx
+    simp only [hf_def]
+    exact Real.rpow_nonneg (by
+      have : (1 : ℝ) ≤ (q : ℝ) := by exact_mod_cast divisorRatios_ge_one n (by omega) q hq_mem
+      linarith) α
+  linarith [List.single_le_sum hall_nonneg (List.mem_map.mpr ⟨r, hr_mem, rfl⟩)]
 
 /-
 ## Part IV: Special Sequences
@@ -404,13 +434,67 @@ But proving uniform bounds on consecutive ratios is non-trivial.
 ## Part IX: Examples
 -/
 
+/-- For prime p, the ratio p/1 = p appears in divisorRatios p. -/
+private theorem prime_ratio_mem (p : ℕ) (hp : Nat.Prime p) :
+    (p : ℚ) ∈ divisorRatios p := by
+  obtain ⟨d₂, rest, heq, hd2⟩ := sortedDivisors_cons2 p hp.two_le
+  have hd2_dvd : d₂ ∣ p := by
+    have : d₂ ∈ p.divisors := by
+      have : d₂ ∈ sortedDivisors p :=
+        heq ▸ List.mem_cons.mpr (Or.inr (List.mem_cons.mpr (Or.inl rfl)))
+      simpa [sortedDivisors] using this
+    exact (Nat.mem_divisors.mp this).1
+  have hd2_eq : d₂ = p := (hp.eq_one_or_self_of_dvd d₂ hd2_dvd).resolve_left (by omega)
+  subst hd2_eq
+  have : divisorRatios p = List.zipWith (fun a b => (↑a : ℚ) / ↑b)
+      (sortedDivisors p).tail (sortedDivisors p) := rfl
+  rw [this, heq, List.tail_cons, List.zipWith_cons_cons]
+  simp [Nat.cast_one, div_one]
+
 /--
 **Example: Prime p**
 For a prime p, divisors are {1, p}, so the only ratio is p/1 = p.
 h_α(p) = (p - 1)^α, which is unbounded as p → ∞.
 -/
-axiom prime_h_alpha_unbounded :
-    ∀ M : ℝ, ∃ p : ℕ, Nat.Prime p ∧ ∀ α : ℝ, α ≥ 1 → h_alpha α p > M
+theorem prime_h_alpha_unbounded :
+    ∀ M : ℝ, ∃ p : ℕ, Nat.Prime p ∧ ∀ α : ℝ, α ≥ 1 → h_alpha α p > M := by
+  intro M
+  obtain ⟨p, hp_ge, hp⟩ := Nat.exists_infinite_primes (⌈max M 0⌉₊ + 2)
+  refine ⟨p, hp, fun α hα => ?_⟩
+  have hp2 : p ≥ 2 := by omega
+  -- Step 1: (p:ℝ) - 1 > M (by choice of p)
+  have hpM : (p : ℝ) - 1 > M := by
+    have h1 := Nat.le_ceil (max M 0)
+    have h2 : (p : ℝ) ≥ (↑(⌈max M 0⌉₊ + 2) : ℝ) := by exact_mod_cast hp_ge
+    push_cast at h2
+    linarith [le_max_left M (0 : ℝ)]
+  -- Step 2: h_alpha α p ≥ (p-1) via ratio p in divisorRatios
+  suffices h : h_alpha α p ≥ (p : ℝ) - 1 from by linarith
+  have hp_sub : (1 : ℝ) ≤ (p : ℝ) - 1 := by
+    have : (2 : ℝ) ≤ (p : ℝ) := by exact_mod_cast hp2
+    linarith
+  calc h_alpha α p
+      ≥ ((p : ℝ) - 1) ^ α := by
+        unfold h_alpha
+        set f := (fun r : ℚ => ((r : ℝ) - 1) ^ α)
+        have hr := prime_ratio_mem p hp
+        have hall : ∀ x ∈ (divisorRatios p).map f, 0 ≤ x := by
+          intro x hx
+          obtain ⟨q, hq, rfl⟩ := List.mem_map.mp hx
+          exact Real.rpow_nonneg (by
+            have : (1 : ℝ) ≤ (q : ℝ) := by
+              exact_mod_cast divisorRatios_ge_one p (by omega) q hq
+            linarith) α
+        have hfmem : f (↑p : ℚ) ∈ (divisorRatios p).map f :=
+          List.mem_map.mpr ⟨_, hr, rfl⟩
+        have : f (↑p : ℚ) ≤ ((divisorRatios p).map f).sum :=
+          List.single_le_sum hall hfmem
+        simp only [Rat.cast_natCast] at this
+        linarith
+    _ ≥ (p : ℝ) - 1 := by
+        calc ((p : ℝ) - 1) ^ α
+            ≥ ((p : ℝ) - 1) ^ (1 : ℝ) := Real.rpow_le_rpow_left hp_sub (by linarith)
+          _ = (p : ℝ) - 1 := Real.rpow_one _
 
 /--
 **Example: Power of 2**

--- a/research/problems/erdos-1099-oq-01/knowledge.md
+++ b/research/problems/erdos-1099-oq-01/knowledge.md
@@ -1,0 +1,39 @@
+# Erdős Problem #1099: Divisor Ratio Sum Boundedness
+
+**Problem**: For α > 1, is liminf h_α(n) bounded, where h_α(n) = Σ((d_{i+1}/dᵢ) - 1)^α?
+**Answer**: YES (Vose, 1984)
+**Status**: IN-PROGRESS (0 sorries, 4 axioms)
+
+## Current State
+
+- **File**: `proofs/Proofs/Erdos1099Problem.lean` (542 lines, 24 theorems)
+- **Sorries**: 0
+- **Axioms**: 4 (vose_bounded_sequence, vose_liminf_bounded, sum_divisor_ratios_lower_bound, power_of_two_h_alpha)
+- All theorems are sorry-free
+
+## Session 2026-03-25 (Session 2) - Prove h_alpha_ge_one and prime_h_alpha_unbounded
+
+**Mode**: REVISIT (MODERATE knowledge, score 12)
+**Outcome**: progress (5A+1S → 4A+0S)
+
+### What I Did
+- Proved `zipWith_div_ge_one`: consecutive ratios in sorted positive lists are ≥ 1 (by list induction)
+- Proved `divisorRatios_ge_one`: all divisor ratios are ≥ 1 (corollary)
+- Completed `h_alpha_ge_one` proof: used nonneg terms + `List.single_le_sum` to show sum ≥ largest term ≥ 1
+- Proved `prime_ratio_mem`: for prime p, the ratio p/1 = p appears in divisorRatios (via `Nat.Prime.eq_one_or_self_of_dvd`)
+- Converted `prime_h_alpha_unbounded` from axiom to theorem: for any M, find prime p with p-1 > M, then h_α(p) ≥ (p-1)^α ≥ p-1 > M
+
+### Key Findings
+- `le_div_iff` + `Nat.cast_le` handles the ratio ≥ 1 proof cleanly
+- `Real.rpow_nonneg` requires `0 ≤ base`; for ratios ≥ 1, `base = ratio - 1 ≥ 0` works
+- `Real.rpow_le_rpow_left` gives exponent monotonicity: x^1 ≤ x^α when x ≥ 1, α ≥ 1
+- `Nat.exists_infinite_primes` + natural ceiling gives prime p > M+1
+
+### Files Modified
+- `proofs/Proofs/Erdos1099Problem.lean` (458→542 lines, +5 theorems, -1 axiom, -1 sorry)
+- `src/data/proofs/erdos-1099/meta.json` (updated counts)
+- `src/data/research/problems/erdos-1099-oq-01.json` (updated knowledge)
+
+### Next Steps
+- Prove `power_of_two_h_alpha` via `Nat.divisors_prime_pow` + sorted list of powers of 2
+- Prove `sum_divisor_ratios_lower_bound` via AM-GM + telescoping product (Πrᵢ = n)

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1099,
     "erdosUrl": "https://erdosproblems.com/1099",
     "erdosProblemStatus": "solved",
@@ -59,9 +59,9 @@
       "sum_divisor_ratios_lower_bound axiom: Σ(d_{i+1}/dᵢ) > τ(n) + log(n)",
       "Examples for primes, powers of 2, and highly composite numbers"
     ],
-    "axiomCount": 5,
-    "lineCount": 458,
-    "assumptions": "5 axioms: vose_bounded_sequence, vose_liminf_bounded, sum_divisor_ratios_lower_bound, prime_h_alpha_unbounded, power_of_two_h_alpha. 1 sorry: h_alpha_ge_one (converted from axiom to theorem, gap in formalizing sorted divisor ratio bound). See Lean source for complete statements."
+    "axiomCount": 4,
+    "lineCount": 542,
+    "assumptions": "4 axioms: vose_bounded_sequence, vose_liminf_bounded (deep Vose 1984 construction), sum_divisor_ratios_lower_bound, power_of_two_h_alpha. All theorems sorry-free."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1099** was posed by Erdős in 1981 as part of his study of divisor structure. The problem asks about the regularity of divisor gaps: can we find integers whose consecutive divisor ratios are all close to 1?\n\n**Historical Development:**\n- **1981 (Erdős [Er81h]):** Posed the problem, noting that n! and lcm{1,...,n} seem like good candidates.\n- **1984 (Vose [Vo84]):** Resolved the problem affirmatively by constructing a specific sequence with bounded h_α.\n\n**Key Insight:** The question is about how \"smooth\" the divisor structure of integers can be. While primes have terrible divisor gaps (ratio = p), and even powers of 2 grow linearly in h_α, Vose showed there exist numbers with much smoother divisor distributions.",
@@ -289,9 +289,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos1099",
-    "lineCount": 458,
-    "axiomCount": 5,
-    "theoremCount": 19,
+    "lineCount": 542,
+    "axiomCount": 4,
+    "theoremCount": 24,
     "definitionCount": 7
   }
 }

--- a/src/data/research/problems/erdos-1099-oq-01.json
+++ b/src/data/research/problems/erdos-1099-oq-01.json
@@ -29,26 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 9->6 axioms (3 eliminated), divisorRatios bug fixed",
+    "progressSummary": "PROGRESS: 0 sorries, 4 axioms (down from 5A+1S). h_alpha_ge_one proved, prime_h_alpha_unbounded proved.",
     "builtItems": [
       "17 new infrastructure theorems for sorted divisor properties",
       "first_divisor_is_one theorem (was axiom)",
       "last_divisor_is_n theorem (was axiom)",
-      "first_ratio_ge_two theorem (was axiom)"
+      "first_ratio_ge_two theorem (was axiom)",
+      "zipWith_div_ge_one: sorted positive list consecutive ratios >= 1",
+      "divisorRatios_ge_one: all divisor ratios >= 1",
+      "h_alpha_ge_one: proved via nonneg sum + single_le_sum",
+      "prime_ratio_mem: for prime p, ratio p is in divisorRatios",
+      "prime_h_alpha_unbounded: proved via prime ratio + rpow monotonicity"
     ],
     "insights": [
       "divisorRatios had a critical bug: computed d_i/d_{i+1} instead of d_{i+1}/d_i",
       "first_divisor_is_one: proved using Finset.sort + Pairwise contradiction",
       "last_divisor_is_n: proved using custom le_getLast_of_mem_pairwise_le helper",
-      "first_ratio_ge_two: proved by showing second divisor d2 >= 2"
+      "first_ratio_ge_two: proved by showing second divisor d2 >= 2",
+      "Key to h_alpha_ge_one: prove all divisor ratios >= 1 via zipWith induction on sorted lists",
+      "For prime unboundedness: Nat.exists_infinite_primes + rpow_le_rpow_left for exponent monotonicity",
+      "Real.rpow_nonneg requires 0 <= base; for ratios >= 1 we get base = ratio - 1 >= 0"
     ],
     "mathlibGaps": [
       "No direct Finset.sort getLast = max lemma"
     ],
     "nextSteps": [
-      "Prove h_alpha_ge_one via rpow monotonicity",
-      "Prove prime_h_alpha_unbounded via Nat.Prime.divisors",
-      "Prove power_of_two_h_alpha via induction on Nat.divisors(2^k)"
+      "Prove power_of_two_h_alpha via Nat.divisors_prime_pow + sorted list computation",
+      "Prove sum_divisor_ratios_lower_bound via AM-GM + telescoping product"
     ]
   },
   "tags": [
@@ -78,11 +85,11 @@
     {
       "path": "Proofs/Erdos1099Problem.lean",
       "filename": "Erdos1099Problem.lean",
-      "lineCount": 459,
-      "theoremCount": 18,
-      "axiomCount": 5,
+      "lineCount": 542,
+      "theoremCount": 24,
+      "axiomCount": 4,
       "defCount": 7,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1099Problem.lean"
     }


### PR DESCRIPTION
## Summary
- **Proved `h_alpha_ge_one`** (sorry → theorem): trivial lower bound h_α(n) ≥ 1 via sorted divisor ratio ≥ 1 + nonneg sum argument
- **Proved `prime_h_alpha_unbounded`** (axiom → theorem): for any M, primes give unbounded h_α via rpow monotonicity
- Added 5 new helper theorems: `zipWith_div_ge_one`, `divisorRatios_ge_one`, `prime_ratio_mem` and supporting infrastructure

**Before**: 5 axioms, 1 sorry, 19 theorems, 458 lines
**After**: 4 axioms, 0 sorries, 24 theorems, 542 lines

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.Erdos1099Problem`)
- [x] Zero compilation errors
- [x] Metadata updated (meta.json, research JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)