### PR TITLE
Audit fix: correct sorry counts (erdos-961, erdos-922)

### DIFF
--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -17,13 +17,13 @@
       "folkman"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 4,
     "erdosNumber": 922,
     "erdosUrl": "https://erdosproblems.com/922",
     "erdosProblemStatus": "solved",
     "axiomCount": 7,
     "lineCount": 237,
-    "assumptions": "7 axiom(s) and 2 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "7 axiom(s) and 4 sorry(s). Sorries: chromaticNumber' definition (line 65), folkman_zero_implies_bipartite (line 103), bipartite_chromatic_le_two (line 108), folkman_density_bound (line 165).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-961/meta.json
+++ b/src/data/proofs/erdos-961/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 961,
     "erdosUrl": "https://erdosproblems.com/961",
     "erdosProblemStatus": "open",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 261,
-    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "assumptions": "4 axiom(s) and 3 sorry(s). Sorries: f_sublinear (line 147), answer(sorry) in polylog_conjecture_open (line 173), f_le_smooth_gap_succ (line 206)."
   },
   "overview": {
     "historicalContext": "This problem connects to a classical result by Sylvester (1892) and Schur (1929) showing that among any $k$ consecutive integers greater than $k$, at least one has a prime factor greater than $k$. Erdős published this as Problem #961, asking for better bounds on $f(k)$.\n\nErdős himself improved the bound in 1955 [Er55d] to $f(k) < 3k/\\log k$, showing sublinear growth. The strongest known result came from Jutila (1974) [Ju74] and independently Ramachandra–Shorey (1973) [RaSh73], who proved $f(k) \\ll \\frac{\\log\\log\\log k}{\\log\\log k} \\cdot \\frac{k}{\\log k}$ using sieve methods.\n\nThe problem is essentially equivalent to Problem #683, which asks about gaps between smooth numbers. The conjecture that $f(k)$ grows only polylogarithmically—$f(k) \\ll (\\log k)^C$—remains wide open. The gap between the known $O(k / \\text{polylog})$ and conjectured $O(\\text{polylog})$ is enormous.\n\nSmooth numbers play a central role in computational number theory: the quadratic sieve and number field sieve factoring algorithms depend on finding smooth numbers in specific ranges. Understanding the distribution of smooth numbers in short intervals is both a fundamental problem in analytic number theory and a question of practical importance.\n\n**Status**: OPEN — Polylogarithmic conjecture unresolved. Best known bound: $f(k) \\ll \\frac{\\log\\log\\log k}{\\log\\log k} \\cdot \\frac{k}{\\log k}$.",


### PR DESCRIPTION
## Summary

- **erdos-961**: sorry count 2→3. Missed `answer(sorry)` term-level sorry on line 173 of `Erdos961Problem.lean`.
- **erdos-922**: sorry count 2→4. Missed definition sorry in `chromaticNumber'` (line 65) and `folkman_density_bound` (line 165).

## Evidence

```bash
$ grep -n "sorry" proofs/Proofs/Erdos961Problem.lean
147:  sorry
173:axiom polylog_conjecture_open : polylog_conjecture ↔ answer(sorry)
206:  sorry

$ grep -n "sorry" proofs/Proofs/Erdos922Problem.lean
65:    sorry⟩
103:  sorry
108:  sorry
165:    sorry⟩
```

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Confirm gallery pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)