### PR TITLE
fix: add missing sections in dissection-of-cubes-oq-02-oq-02

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/index.ts
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/DissectionOfCubesOQ02OQ02.lean?raw'

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "dissection-of-cubes-oq-02-oq-02",
   "title": "Dehn-Sydler Completeness: Tensor Product Dehn Invariant",
   "slug": "dissection-of-cubes-oq-02-oq-02",
-  "description": "Formalizes the proper algebraic Dehn invariant D(P) ∈ ℝ ⊗_ℤ (ℝ/πℤ) using Mathlib's tensor product infrastructure. Proves rational angle vanishing (edges with rational×π dihedral angles contribute 0), cube D=0, tetrahedron D≠0, and Hilbert's Third Problem. States the Dehn-Sydler completeness theorem.",
+  "description": "Formalizes the proper algebraic Dehn invariant D(P) \u2208 \u211d \u2297_\u2124 (\u211d/\u03c0\u2124) using Mathlib's tensor product infrastructure. Proves rational angle vanishing (edges with rational\u00d7\u03c0 dihedral angles contribute 0), cube D=0, tetrahedron D\u22600, and Hilbert's Third Problem. States the Dehn-Sydler completeness theorem.",
   "meta": {
     "author": "Dehn (1900), Sydler (1965), Jessen (1968)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dehn%E2%80%93Sydler_theorem",
@@ -25,17 +25,17 @@
     "mathlibDependencies": [
       {
         "theorem": "TensorProduct",
-        "description": "ℤ-module tensor product for Dehn invariant group",
+        "description": "\u2124-module tensor product for Dehn invariant group",
         "module": "Mathlib.LinearAlgebra.TensorProduct.Basic"
       },
       {
         "theorem": "QuotientAddGroup",
-        "description": "Quotient ℝ/πℤ for angle equivalence classes",
+        "description": "Quotient \u211d/\u03c0\u2124 for angle equivalence classes",
         "module": "Mathlib.GroupTheory.QuotientGroup"
       },
       {
         "theorem": "AddSubgroup.zmultiples",
-        "description": "Subgroup πℤ = {nπ : n ∈ ℤ}",
+        "description": "Subgroup \u03c0\u2124 = {n\u03c0 : n \u2208 \u2124}",
         "module": "Mathlib.GroupTheory.Subgroup.ZPowers"
       },
       {
@@ -45,30 +45,31 @@
       }
     ],
     "originalContributions": [
-      "Proper algebraic Dehn invariant using ℝ ⊗_ℤ (ℝ/πℤ) via Mathlib tensor products",
-      "tmul_torsion_eq_zero: torsion elements vanish in tensor product (ℝ-divisibility argument)",
-      "rational_angle_vanishes: r ⊗ [qπ] = 0 for all q ∈ ℚ (key structural theorem)",
-      "cube_dehn_zero: cube Dehn invariant is zero (π/2 is rational × π)",
-      "tet_dehn_ne_zero: tetrahedron Dehn invariant is nonzero (arccos(1/3)/π irrational)",
-      "hilbert_third_problem: D(cube) ≠ D(tetrahedron)",
-      "octAngle_class: [arccos(-1/3)] = -[arccos(1/3)] in ℝ/πℤ",
+      "Proper algebraic Dehn invariant using \u211d \u2297_\u2124 (\u211d/\u03c0\u2124) via Mathlib tensor products",
+      "tmul_torsion_eq_zero: torsion elements vanish in tensor product (\u211d-divisibility argument)",
+      "rational_angle_vanishes: r \u2297 [q\u03c0] = 0 for all q \u2208 \u211a (key structural theorem)",
+      "cube_dehn_zero: cube Dehn invariant is zero (\u03c0/2 is rational \u00d7 \u03c0)",
+      "tet_dehn_ne_zero: tetrahedron Dehn invariant is nonzero (arccos(1/3)/\u03c0 irrational)",
+      "hilbert_third_problem: D(cube) \u2260 D(tetrahedron)",
+      "octAngle_class: [arccos(-1/3)] = -[arccos(1/3)] in \u211d/\u03c0\u2124",
       "Dehn-Sydler completeness theorem statement"
     ],
     "lineCount": 406,
-    "assumptions": "6 axioms: niven_arccos_third (proved in parent file), tmul_infinite_order_ne_zero (flatness of ℝ over ℤ), arccos_neg_third (trig identity), dehn_preserved_by_scissors, volume_preserved_by_scissors, dehn_sydler_theorem (Sydler 1965).",
+    "assumptions": "6 axioms: niven_arccos_third (proved in parent file), tmul_infinite_order_ne_zero (flatness of \u211d over \u2124), arccos_neg_third (trig identity), dehn_preserved_by_scissors, volume_preserved_by_scissors, dehn_sydler_theorem (Sydler 1965).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Dehn invariant D(P) = Σ_e len(e) ⊗ [θ(e)] ∈ ℝ ⊗_ℤ (ℝ/πℤ) was introduced by Max Dehn in 1900 to prove that equal-volume polyhedra need not be scissors congruent. The tensor product formulation is essential: it automatically kills rational multiples of π (because ℝ is a divisible ℤ-module) while preserving irrational ones. Sydler (1965) proved the stunning converse: volume + Dehn invariant completely characterize scissors congruence in ℝ³.",
-    "problemStatement": "Formalize the Dehn-Sydler completeness theorem: two polyhedra in ℝ³ are scissors congruent if and only if they have equal volume and equal Dehn invariant D(P) ∈ ℝ ⊗_ℤ (ℝ/πℤ). The proof uses the proper tensor product definition of the Dehn invariant, leveraging the divisibility of ℝ as a ℤ-module to prove that rational-multiple-of-π dihedral angles automatically vanish.",
-    "text": "Formalizes the algebraic Dehn invariant D(P) ∈ ℝ ⊗_ℤ (ℝ/πℤ) using Mathlib tensor products. Proves the key structural theorem that rational angles vanish in the tensor product, computes D for cube (0), tetrahedron (≠0), and octahedron (≠0), and states the Dehn-Sydler completeness theorem.",
-    "proofStrategy": "The file constructs the Dehn invariant group as TensorProduct ℤ ℝ (ℝ ⧸ AddSubgroup.zmultiples π). The central theorem tmul_torsion_eq_zero proves that if x ∈ ℝ/πℤ has finite order (n•x = 0), then r⊗x = 0, using the divisibility of ℝ: r = n•(r/n), so r⊗x = (r/n)⊗(n•x) = (r/n)⊗0 = 0. This immediately gives rational_angle_vanishes: for q ∈ ℚ, q.den•[qπ] = [q.num•π] = 0, so r⊗[qπ] = 0. For the tetrahedron, Niven's theorem shows arccos(1/3)/π is irrational, giving infinite order in ℝ/πℤ, and flatness of ℝ over ℤ ensures the tensor product element is nonzero.",
+    "historicalContext": "The Dehn invariant D(P) = \u03a3_e len(e) \u2297 [\u03b8(e)] \u2208 \u211d \u2297_\u2124 (\u211d/\u03c0\u2124) was introduced by Max Dehn in 1900 to prove that equal-volume polyhedra need not be scissors congruent. The tensor product formulation is essential: it automatically kills rational multiples of \u03c0 (because \u211d is a divisible \u2124-module) while preserving irrational ones. Sydler (1965) proved the stunning converse: volume + Dehn invariant completely characterize scissors congruence in \u211d\u00b3.",
+    "problemStatement": "Formalize the Dehn-Sydler completeness theorem: two polyhedra in \u211d\u00b3 are scissors congruent if and only if they have equal volume and equal Dehn invariant D(P) \u2208 \u211d \u2297_\u2124 (\u211d/\u03c0\u2124). The proof uses the proper tensor product definition of the Dehn invariant, leveraging the divisibility of \u211d as a \u2124-module to prove that rational-multiple-of-\u03c0 dihedral angles automatically vanish.",
+    "text": "Formalizes the algebraic Dehn invariant D(P) \u2208 \u211d \u2297_\u2124 (\u211d/\u03c0\u2124) using Mathlib tensor products. Proves the key structural theorem that rational angles vanish in the tensor product, computes D for cube (0), tetrahedron (\u22600), and octahedron (\u22600), and states the Dehn-Sydler completeness theorem.",
+    "proofStrategy": "The file constructs the Dehn invariant group as TensorProduct \u2124 \u211d (\u211d \u29f8 AddSubgroup.zmultiples \u03c0). The central theorem tmul_torsion_eq_zero proves that if x \u2208 \u211d/\u03c0\u2124 has finite order (n\u2022x = 0), then r\u2297x = 0, using the divisibility of \u211d: r = n\u2022(r/n), so r\u2297x = (r/n)\u2297(n\u2022x) = (r/n)\u22970 = 0. This immediately gives rational_angle_vanishes: for q \u2208 \u211a, q.den\u2022[q\u03c0] = [q.num\u2022\u03c0] = 0, so r\u2297[q\u03c0] = 0. For the tetrahedron, Niven's theorem shows arccos(1/3)/\u03c0 is irrational, giving infinite order in \u211d/\u03c0\u2124, and flatness of \u211d over \u2124 ensures the tensor product element is nonzero.",
     "keyInsights": [
-      "The tensor product ℝ ⊗_ℤ (ℝ/πℤ) is the mathematically correct home for the Dehn invariant, automatically identifying rational angles with zero through ℤ-bilinearity",
-      "The proof that rational angles vanish uses a beautiful algebraic argument: ℝ is divisible as a ℤ-module, so torsion elements of ℝ/πℤ are killed in the tensor product",
-      "The cube's zero Dehn invariant follows from π/2 being a rational multiple of π, while the tetrahedron's nonzero invariant comes from Niven's theorem (arccos(1/3)/π is irrational)",
-      "The octahedron's Dehn invariant equals the negative of the tetrahedron's, since arccos(-1/3) = π - arccos(1/3) and [π] = 0 in ℝ/πℤ",
-      "Dehn-Sydler completeness (1965) says volume + Dehn invariant are the COMPLETE scissors congruence invariants in ℝ³, contrasting with 2D where volume alone suffices"
+      "The tensor product \u211d \u2297_\u2124 (\u211d/\u03c0\u2124) is the mathematically correct home for the Dehn invariant, automatically identifying rational angles with zero through \u2124-bilinearity",
+      "The proof that rational angles vanish uses a beautiful algebraic argument: \u211d is divisible as a \u2124-module, so torsion elements of \u211d/\u03c0\u2124 are killed in the tensor product",
+      "The cube's zero Dehn invariant follows from \u03c0/2 being a rational multiple of \u03c0, while the tetrahedron's nonzero invariant comes from Niven's theorem (arccos(1/3)/\u03c0 is irrational)",
+      "The octahedron's Dehn invariant equals the negative of the tetrahedron's, since arccos(-1/3) = \u03c0 - arccos(1/3) and [\u03c0] = 0 in \u211d/\u03c0\u2124",
+      "Dehn-Sydler completeness (1965) says volume + Dehn invariant are the COMPLETE scissors congruence invariants in \u211d\u00b3, contrasting with 2D where volume alone suffices"
     ]
-  }
+  },
+  "sections": []
 }


### PR DESCRIPTION
Build fix: missing sections array and unused TacticState import.