### PR TITLE
Audit fix: erdos-1179-oq-01 rename sorryCount→sorries

### DIFF
--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -18,7 +18,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorryCount": 0,
+    "sorries": 0,
     "axiomCount": 2,
     "theoremCount": 9,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

- Rename `sorryCount` → `sorries` in erdos-1179-oq-01/meta.json to match the standard field name convention (1542 entries use `sorries`, only 17 use `sorryCount`).
- The gallery code reads `.sorries` for listing pages, so this entry's sorry count was not being displayed correctly.

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Confirm erdos-1179-oq-01 page displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)