### PR TITLE
Enrich erdos-332: fix line ranges for full coverage

### DIFF
--- a/src/data/proofs/erdos-332/annotations.json
+++ b/src/data/proofs/erdos-332/annotations.json
@@ -211,8 +211,8 @@
     "proofId": "erdos-332",
     "type": "concept",
     "range": {
-      "startLine": 85,
-      "endLine": 88
+      "startLine": 101,
+      "endLine": 109
     },
     "title": "Erdős Problem 332: Weakest Sufficient Condition",
     "content": "The main open question formalized: find the weakest property $P$ of subsets $A \\subseteq \\mathbb{N}$ such that $P(A)$ implies $D(A)$ has bounded gaps. The formalization states this as: any such $P$ must be implied by positive upper density. The actual open question is whether conditions strictly weaker than positive density also work — for instance, does $\\sum_{a \\in A} 1/a = \\infty$ suffice?",
@@ -234,8 +234,8 @@
     "proofId": "erdos-332",
     "type": "concept",
     "range": {
-      "startLine": 92,
-      "endLine": 97
+      "startLine": 113,
+      "endLine": 118
     },
     "title": "Harmonic Sum Divergence for D(A)",
     "content": "An axiomatized related question: does positive upper density of $A$ imply that $\\sum_{d \\in D(A) \\cap \\mathbb{N}} 1/d = \\infty$? If true, this would show $D(A)$ is not only syndetic but has 'harmonic thickness'. The divergence of the harmonic sum is strictly weaker than positive density (the primes have divergent harmonic sum but zero density), so this would be a different kind of structural richness.",

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -114,24 +114,24 @@
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 58,
-      "endLine": 77,
+      "startLine": 59,
+      "endLine": 97,
       "summary": "Four axiomatized results: **Prikry's theorem** ($\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic), density inheritance for $D(A)$, symmetry $D(A) = -D(A)$, and $0 \\in D(A)$ for infinite $A$.",
       "mathContext": "Prikry: $\\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Structure: $D(A) = -D(A)$, $0 \\in D(A)$ for infinite $A$."
     },
     {
       "id": "main-problem",
       "title": "The Main Open Problem",
-      "startLine": 78,
-      "endLine": 89,
+      "startLine": 99,
+      "endLine": 109,
       "summary": "Erdős Problem 332: characterize the weakest property $P$ such that $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Positive upper density is the best known sufficient condition.",
       "mathContext": "Find weakest $P$: $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Known: $\\overline{d}(A) > 0$ suffices."
     },
     {
       "id": "related-questions",
       "title": "Related Questions",
-      "startLine": 90,
-      "endLine": 97,
+      "startLine": 111,
+      "endLine": 118,
       "summary": "Does positive density imply $\\sum_{d \\in D(A)} 1/d = \\infty$? This would show $D(A)$ has 'harmonic thickness' beyond mere syndeticity.",
       "mathContext": "Open: $\\overline{d}(A) > 0 \\Rightarrow \\sum_{d \\in D(A)} 1/|d| = \\infty$? (harmonic thickness conjecture)"
     }


### PR DESCRIPTION
Enrichment pass for erdos-332 (pass 2).

- Fixed 3 section and 2 annotation line ranges to match actual Lean file
- Sections now cover full 118-line file