### PR TITLE
Enrich erdos-273: add 2 cross-references

### DIFF
--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -179,6 +179,16 @@
       "targetId": "chinese-remainder-constructive",
       "relationship": "foundational",
       "description": "The Chinese Remainder Theorem is the key tool for constructing covering systems from residue classes. Any covering system modulo coprime m_i can be verified by checking finitely many residues mod lcm(m_i)"
+    },
+    {
+      "targetId": "erdos-2",
+      "relationship": "related",
+      "description": "Problem #2 asks whether covering systems with distinct moduli and minimum modulus $> k$ exist for all $k$. Problem #273 adds the restriction that moduli must be $p-1$ for primes $p$, connecting covering system existence to prime structure"
+    },
+    {
+      "targetId": "chinese-remainder-non-coprime",
+      "relationship": "foundational",
+      "description": "Non-coprime CRT generalizes to overlapping residue classes, directly relevant to covering systems where moduli $p_i - 1$ need not be coprime — the system $\\{a_i \\pmod{p_i-1}\\}$ requires handling non-coprime moduli"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-278/annotations.json
+++ b/src/data/proofs/erdos-278/annotations.json
@@ -290,5 +290,80 @@
       "maxCoverageDensity",
       "coverageDensity"
     ]
+  },
+  {
+    "id": "erdos-278-complement-count",
+    "proofId": "erdos-278",
+    "range": {
+      "startLine": 263,
+      "endLine": 373
+    },
+    "type": "theorem",
+    "title": "Complement Count via CRT (Main Technical Lemma)",
+    "content": "The file's largest proved result (~110 lines): for pairwise coprime moduli $n_1, \\ldots, n_k$, the number of integers in $[0, \\prod n_i)$ not covered by the congruence system with residues $a_i$ is exactly $\\prod(n_i - 1)$. The proof uses `Finset.induction` on the moduli set, with the inductive step establishing that each modulus $n$ contributes a factor of $(n-1)/n$ to the uncovered proportion via the CRT-based residue shift argument. This is the heart of the coprime density formula.",
+    "mathContext": "For pairwise coprime $n_1, \\ldots, n_k$: $|\\{m \\in [0, \\prod n_i) : m \\not\\equiv a_i \\pmod{n_i} \\; \\forall i\\}| = \\prod_{i=1}^k (n_i - 1)$. Dividing by $\\prod n_i$: uncovered fraction $= \\prod(1 - 1/n_i)$, so coverage density $= 1 - \\prod(1 - 1/n_i)$.",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "Finset.induction", "complement counting", "coprime moduli"],
+    "prerequisites": ["systemLCM_coprime_eq_prod", "coprime_residue_cover", "Finset.card_filter_eq"]
+  },
+  {
+    "id": "erdos-278-equal-residues",
+    "proofId": "erdos-278",
+    "range": {
+      "startLine": 474,
+      "endLine": 490
+    },
+    "type": "theorem",
+    "title": "Equal Residues Minimize Density (Simpson's Application)",
+    "content": "Proves that choosing all residues equal ($a_i = a$ for all $i$) minimizes the coverage density: `equal_residues_minimize` shows $\\delta(\\text{sys}_{\\text{all-}a}) \\leq \\delta(\\text{sys})$ for any system. This uses `simpson_theorem` (axiomatized): Simpson proved that the minimum density over all residue choices equals $1 - \\prod(1 - 1/n_i)$, achieved exactly when all residues are equal (maximizing overlaps between congruence classes).",
+    "mathContext": "$\\delta_{\\min}(n_1, \\ldots, n_k) = 1 - \\prod_{i=1}^k (1 - 1/n_i)$, achieved by $a_1 = a_2 = \\cdots = a_k = a$ (any common $a$). Equal residues maximize overlaps between arithmetic progressions.",
+    "significance": "key",
+    "relatedConcepts": ["Simpson's theorem", "minimum density", "overlapping progressions", "equal residues"],
+    "prerequisites": ["simpson_theorem", "coverageDensity", "Finset.card_filter"]
+  },
+  {
+    "id": "erdos-278-coprime-density",
+    "proofId": "erdos-278",
+    "range": {
+      "startLine": 497,
+      "endLine": 551
+    },
+    "type": "theorem",
+    "title": "Coprime Density Formula: All Residue Choices Give Same Density",
+    "content": "`coprime_density_formula`: for **pairwise coprime** moduli, every choice of residues gives the same coverage density $1 - \\prod(1 - 1/n_i)$. This is the CRT uniformity result: when moduli are coprime, the covering pattern is determined solely by the moduli (not the residues), because CRT gives a bijection between residue tuples and elements of $\\mathbb{Z}/\\prod n_i$. The proof uses `complement_count_coprime` to show uncovered count is $\\prod(n_i-1)$ regardless of residues.",
+    "mathContext": "For coprime $n_1, \\ldots, n_k$: $\\delta(a_1, \\ldots, a_k) = 1 - \\prod(1 - 1/n_i)$ for ALL choices of $a_i$. Equivalently: $\\delta_{\\max} = \\delta_{\\min} = 1 - \\prod(1 - 1/n_i)$.",
+    "significance": "key",
+    "relatedConcepts": ["CRT uniformity", "coprime moduli independence", "coverage invariance"],
+    "prerequisites": ["complement_count_coprime", "systemLCM_coprime_eq_prod", "density_bounds"]
+  },
+  {
+    "id": "erdos-278-coprime-max-min",
+    "proofId": "erdos-278",
+    "range": {
+      "startLine": 560,
+      "endLine": 575
+    },
+    "type": "theorem",
+    "title": "Coprime Moduli: Max = Min Density",
+    "content": "`coprime_max_eq_min`: for pairwise coprime moduli, the maximum and minimum coverage densities coincide. This is a direct corollary of `coprime_density_formula` — if all residue choices give the same density, then the supremum and infimum over choices are trivially equal. This makes the non-coprime case the interesting one for Problem #278.",
+    "mathContext": "Coprime $\\Rightarrow$ $\\delta_{\\max}(n_1, \\ldots, n_k) = \\delta_{\\min}(n_1, \\ldots, n_k) = 1 - \\prod(1 - 1/n_i)$. The gap $\\delta_{\\max} - \\delta_{\\min} > 0$ only occurs for non-coprime moduli.",
+    "significance": "supporting",
+    "relatedConcepts": ["coprime density equality", "max-min gap", "non-coprime obstruction"],
+    "prerequisites": ["coprime_density_formula", "maxCoverageDensity", "minCoverageDensity"]
+  },
+  {
+    "id": "erdos-278-singleton-density",
+    "proofId": "erdos-278",
+    "range": {
+      "startLine": 603,
+      "endLine": 646
+    },
+    "type": "theorem",
+    "title": "Singleton and Single-Modulus Density Results",
+    "content": "Three results for the simplest cases: `singleton_coverage_density` proves $\\delta(\\{n\\}, a) = 1/n$ for any modulus $n$ and residue $a$. `single_modulus_density` proves max = min = $1/n$ for a single modulus. These establish the base case from which the general coprime density formula builds by induction.",
+    "mathContext": "For $k = 1$: $\\delta(\\{n\\}) = 1/n$, $\\delta_{\\max}(\\{n\\}) = \\delta_{\\min}(\\{n\\}) = 1/n$. The formula $1 - (1 - 1/n) = 1/n$ matches.",
+    "significance": "supporting",
+    "relatedConcepts": ["base case", "singleton modulus", "arithmetic progression density"],
+    "prerequisites": ["coverageDensity", "systemLCM", "Finset.card_filter"]
   }
 ]

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -103,12 +103,28 @@
       "mathContext": "Simpson: $\\delta_{\\min} = \\delta(\\{0 \\pmod{n_i}\\})$; all-zero residues minimize density. Shift invariance: $\\delta(a) = \\delta(0)$ for constant $a$."
     },
     {
-      "id": "open-question",
-      "title": "Maximum Density (Open)",
+      "id": "coprime-infrastructure",
+      "title": "Coprime LCM and Residue Shift Machinery",
       "startLine": 133,
-      "endLine": 334,
-      "summary": "Axiomatized coprime maximum ($\\delta_{\\max} = 1 - \\prod(1 - 1/n_i)$ by CRT), proved $\\delta_{\\max} \\leq 1$ for general moduli, and the single modulus base case ($\\delta = 1/n$).",
-      "mathContext": "Coprime case: $\\gcd(n_i, n_j) = 1 \\Rightarrow \\delta_{\\max} = 1 - \\prod(1 - 1/n_i)$ (CRT independence). Open: general formula for $\\delta_{\\max}$."
+      "endLine": 262,
+      "summary": "Technical infrastructure: coprime density axiom, `systemLCM_coprime_eq_prod` ($\\text{lcm} = \\prod$ for coprime moduli), residue shift injectivity and surjectivity via CRT, and the complement count per-modulus argument.",
+      "mathContext": "For coprime $L, n$: $k \\mapsto (j + kL) \\bmod n$ is bijective on $\\{0, \\ldots, n-1\\}$. This CRT bijection drives the complement counting."
+    },
+    {
+      "id": "complement-and-simpson",
+      "title": "Complement Count, Product Formula, and Simpson's Theorem",
+      "startLine": 263,
+      "endLine": 400,
+      "summary": "The file's central result: `complement_count_coprime` (~110 lines, proved by Finset.induction) shows uncovered count for coprime moduli is $\\prod(n_i-1)$. `product_fraction` converts to $\\prod(1-1/n_i)$. Simpson's theorem axiomatized: minimum density is achieved by equal residues.",
+      "mathContext": "$|\\text{uncovered}| = \\prod(n_i - 1)$. Density $= 1 - \\prod(1 - 1/n_i)$. Simpson: $\\delta_{\\min} = \\delta(a, a, \\ldots, a)$."
+    },
+    {
+      "id": "density-formulas-and-applications",
+      "title": "Coprime Density Formula, Max=Min, and Applications",
+      "startLine": 401,
+      "endLine": 646,
+      "summary": "Helper lemmas for shift invariance, `equal_residues_minimize` (equal residues achieve minimum), `coprime_density_formula` (all residue choices give same density for coprime moduli), `coprime_max_eq_min`, and singleton/single-modulus base cases.",
+      "mathContext": "Coprime: $\\delta_{\\max} = \\delta_{\\min} = 1 - \\prod(1 - 1/n_i)$. Singleton: $\\delta(\\{n\\}) = 1/n$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for erdos-273 (pass 2).

- Added cross-reference to erdos-2 (covering systems)
- Added cross-reference to chinese-remainder-non-coprime