### PR TITLE
Fix: erdos-934 sorry count mismatch (7→8)

### DIFF
--- a/src/data/proofs/erdos-934/meta.json
+++ b/src/data/proofs/erdos-934/meta.json
@@ -18,7 +18,7 @@
       "2K2-free"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 8,
     "erdosNumber": 934,
     "erdosUrl": "https://erdosproblems.com/934",
     "erdosProblemStatus": "solved",
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 11,
     "lineCount": 261,
-    "assumptions": "11 axiom(s) and 7 sorry(s)."
+    "assumptions": "11 axiom(s) and 8 sorry(s). Sorries: h definition existence (line 86), h_1_upper_bound (line 99), h_1_lower_bound (line 103), two_separated_is_2K2 (line 114), erdos_nesetril_conjecture_proved (line 127), h_mono_d (line 175), h_mono_t (line 180), h_polynomial_growth (line 185)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #934** was posed by Erdős and Nešetřil, studying edge separation in bounded-degree graphs.\n\n**Historical Development:**\n- **1983 (Bermond-Bond-Paoli-Peyrat):** Conjectured h_2(d) ≤ 5d²/4 + 1, with equality for even d.\n- **1988 (Erdős):** Wrote 'This problem seems interesting only if there is a nice expression for h_t(d).'\n- **1990 (Chung-Gyárfás-Tuza-Trotter):** Proved h_2(d) = ⌊5d²/4⌋ + 1 exactly.\n- **2022 (Cambie et al.):** Proved h_3(3) = 23, conjectured h_3(d) ≤ d³-d²+d+2, and established general bounds.\n\nThe problem connects to 2K₂-free graphs and line graph diameter problems.",


### PR DESCRIPTION
## Fix

Corrects sorry count in erdos-934 meta.json from 7 to 8. The missed sorry is in the `h` definition existence proof (line 86 of Erdos934Problem.lean).

## Evidence

**Before**: `"sorries": 7`, assumptions field listed 7 sorries
**After**: `"sorries": 8`, assumptions field lists all 8 sorry locations with line numbers

Automated fix by lean-mechanic agent.