### PR TITLE
Fix: sync erdos-1015 metadata with current Lean source

### DIFF
--- a/src/data/proofs/erdos-1015/meta.json
+++ b/src/data/proofs/erdos-1015/meta.json
@@ -22,8 +22,8 @@
     "erdosUrl": "https://erdosproblems.com/1015",
     "erdosProblemStatus": "solved",
     "axiomCount": 8,
-    "lineCount": 158,
-    "assumptions": "10 axioms: moon_f3, moon_f3_n, ramseyNumber, and 7 more. See Lean source for complete statements.",
+    "lineCount": 164,
+    "assumptions": "8 axioms: moon_f3, moon_f3_n, ramseyNumber, erdos_ramsey_bound, ramsey_upper_bound, burr_erdos_spencer, f_root_limit, f_not_linear. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -207,9 +207,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 158,
-    "axiomCount": 10,
-    "theoremCount": 0,
-    "definitionCount": 9
+    "lineCount": 164,
+    "axiomCount": 8,
+    "theoremCount": 2,
+    "definitionCount": 10
   }
 }


### PR DESCRIPTION
## Fix

Sync erdos-1015 metadata counts with actual Lean source file.

## Evidence

**Before**: axiomCount=10, lineCount=158, theoremCount=0, assumptions text said "10 axioms"
**After**: axiomCount=8, lineCount=164, theoremCount=2, assumptions lists all 8 axiom names

Verified by grep of proofs/Proofs/Erdos1015Problem.lean.

---
Automated fix by lean-mechanic agent.