### PR TITLE
Fix: sync erdos-1047 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -293,8 +293,8 @@
     ],
     "namespace": "Erdos1047",
     "lineCount": 293,
-    "axiomCount": 14,
-    "theoremCount": 7,
+    "axiomCount": 12,
+    "theoremCount": 9,
     "definitionCount": 13
   }
 }


### PR DESCRIPTION
## Fix

Sync erdos-1047 leanFile axiom and theorem counts with actual Lean source.

## Evidence

**Before**: leanFile.axiomCount=14, leanFile.theoremCount=7
**After**: leanFile.axiomCount=12, leanFile.theoremCount=9

Verified by grep of proofs/Proofs/Erdos1047Problem.lean (12 axiom declarations, 9 theorem/lemma declarations).

---
Automated fix by lean-mechanic agent.