### PR TITLE
Fix: sync erdos-1093 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-1093/meta.json
+++ b/src/data/proofs/erdos-1093/meta.json
@@ -217,8 +217,8 @@
     "opens": [],
     "namespace": null,
     "lineCount": 120,
-    "axiomCount": 5,
-    "theoremCount": 1,
+    "axiomCount": 2,
+    "theoremCount": 4,
     "definitionCount": 6
   }
 }


### PR DESCRIPTION
## Fix

Sync erdos-1093 leanFile axiom and theorem counts with actual Lean source.

## Evidence

**Before**: leanFile.axiomCount=5, leanFile.theoremCount=1
**After**: leanFile.axiomCount=2, leanFile.theoremCount=4

Verified by grep of proofs/Proofs/Erdos1093Problem.lean.

---
Automated fix by lean-mechanic agent.