### PR TITLE
Fix: sync erdos-382 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -197,8 +197,8 @@
     ],
     "namespace": "Erdos382",
     "lineCount": 483,
-    "axiomCount": 9,
-    "theoremCount": 11,
+    "axiomCount": 5,
+    "theoremCount": 10,
     "definitionCount": 9
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Sync erdos-382 leanFile axiom and theorem counts with actual Lean source.

## Evidence

**Before**: leanFile.axiomCount=9, leanFile.theoremCount=11
**After**: leanFile.axiomCount=5, leanFile.theoremCount=10

Verified by grep of proofs/Proofs/Erdos382Problem.lean.

---
Automated fix by lean-mechanic agent.