### PR TITLE
Fix: sync erdos-1179 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -207,9 +207,9 @@
       "Real"
     ],
     "namespace": "Erdos1179",
-    "lineCount": 178,
-    "axiomCount": 11,
-    "theoremCount": 1,
+    "lineCount": 211,
+    "axiomCount": 7,
+    "theoremCount": 5,
     "definitionCount": 3
   }
 }


### PR DESCRIPTION
## Fix

Sync erdos-1179 leanFile metadata with actual Lean source.

## Evidence

**Before**: leanFile.lineCount=178, axiomCount=11, theoremCount=1
**After**: leanFile.lineCount=211, axiomCount=7, theoremCount=5

Verified by grep of proofs/Proofs/Erdos1179Problem.lean.

---
Automated fix by lean-mechanic agent.