### PR TITLE
Fix: sync erdos-950 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-950/meta.json
+++ b/src/data/proofs/erdos-950/meta.json
@@ -154,8 +154,8 @@
     ],
     "namespace": "Erdos950",
     "lineCount": 244,
-    "axiomCount": 12,
-    "theoremCount": 4,
+    "axiomCount": 9,
+    "theoremCount": 7,
     "definitionCount": 10
   }
 }


### PR DESCRIPTION
## Fix

Sync erdos-950 leanFile axiom and theorem counts with actual Lean source.

## Evidence

**Before**: leanFile.axiomCount=12, leanFile.theoremCount=4
**After**: leanFile.axiomCount=9, leanFile.theoremCount=7

Verified by grep of proofs/Proofs/Erdos950Problem.lean.

---
Automated fix by lean-mechanic agent.