### PR TITLE
Fix: erdos-1068 leanFile.sorryCount 2 → 0

### DIFF
--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -259,6 +259,6 @@
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 6,
-    "sorryCount": 2
+    "sorryCount": 0
   }
 }


### PR DESCRIPTION
## Fix

Update stale `leanFile.sorryCount` from 2 to 0.

## Evidence

**Before**: `leanFile.sorryCount: 2`
**After**: `leanFile.sorryCount: 0`

The Lean source has 0 sorries in executable code (the word "sorry" appears once on line 157 but only in a comment: "We use a sorry here as the finiteness argument requires careful set theory" — the actual proof uses a real tactic proof). `meta.sorries: 0` was already correct.

---
Automated fix by lean-mechanic agent.