### PR TITLE
Research: erdos-1084 — prove f1_upper_bound (12→11 axioms)

### DIFF
--- a/proofs/Proofs/Erdos1084Problem.lean
+++ b/proofs/Proofs/Erdos1084Problem.lean
@@ -20,6 +20,9 @@ n points in ℝ^d with all pairwise distances ≥ 1. Estimate f_d(n).
   points are distance 2 apart (on opposite sides).
 - `unit_distance_1d_degree_at_most_two`: A point in ℝ has at most
   2 neighbors at unit distance among mutually separated points.
+- `f1_upper_bound`: For any 1D separated config on n points, the
+  number of unit-distance pairs is at most n - 1. Proved via
+  injection of unit pairs into Fin n via left-endpoint map.
 - `f1_achievable`: The consecutive integer configuration 0, 1, ..., n-1
   achieves exactly n-1 unit-distance pairs.
 
@@ -147,14 +150,115 @@ private lemma nat_consecutive_abs_eq_one (i : ℕ) :
 
 /- ### 1D Bounds -/
 
+/-- If |a - b| = 1 and a ≤ b, then b = a + 1. -/
+private lemma unit_dist_left {a b : ℝ} (hunit : |a - b| = 1) (hle : a ≤ b) :
+    b = a + 1 := by
+  have := (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hunit
+  rcases this with h | h <;> linarith
+
 /-- For a 1D separated config, the number of unit-distance pairs
     is at most n - 1. (Upper bound for f_1(n).)
 
-    Proof sketch: Each point has at most 2 unit neighbors (one on
-    each side). The unit-distance graph is a union of paths, hence
-    a forest with at most n-1 edges. -/
-axiom f1_upper_bound (n : ℕ) (hn : n ≥ 1) (C : SeparatedConfig1D n) :
-  unitDistPairs1D C ≤ n - 1
+    Proof: Inject unit pairs into Fin n via the "left endpoint" map
+    (the index whose real value is smaller). Injectivity: two pairs
+    sharing a left endpoint at value v must both have their other
+    index at value v + 1; by separation those indices coincide. The
+    index with the globally maximum value cannot be a left endpoint,
+    so the image has at most n - 1 elements. -/
+theorem f1_upper_bound (n : ℕ) (hn : n ≥ 1) (C : SeparatedConfig1D n) :
+    unitDistPairs1D C ≤ n - 1 := by
+  unfold unitDistPairs1D
+  set S := Finset.filter
+    (fun p : Fin n × Fin n => p.1 < p.2 ∧ |C.points p.1 - C.points p.2| = 1)
+    Finset.univ
+  -- Find the index with the maximum point value
+  obtain ⟨M, -, hM⟩ := Finset.exists_max_image Finset.univ C.points
+    ⟨⟨0, by omega⟩, Finset.mem_univ _⟩
+  -- Left-endpoint map: returns the index with smaller point value
+  let f : Fin n × Fin n → Fin n := fun p =>
+    if C.points p.1 ≤ C.points p.2 then p.1 else p.2
+  -- f maps S into Finset.univ \ {M} (the max can never be a left endpoint)
+  have himg : ∀ p ∈ S, f p ∈ Finset.univ.erase M := by
+    rintro ⟨i, j⟩ hp
+    have ⟨_, hlt, hunit⟩ := Finset.mem_filter.mp hp
+    simp only [Finset.mem_erase, Ne, Finset.mem_univ, and_true, f]
+    split_ifs with hle
+    · -- Left endpoint is i; if i = M then j has value > max, contradiction
+      intro heq; subst heq
+      linarith [unit_dist_left hunit hle, hM j (Finset.mem_univ j)]
+    · -- Left endpoint is j; if j = M then i has value > max, contradiction
+      intro heq; subst heq; push_neg at hle
+      have hswap : |C.points j - C.points i| = 1 := by rw [abs_sub_comm]; exact hunit
+      linarith [unit_dist_left hswap (le_of_lt hle), hM i (Finset.mem_univ i)]
+  -- f is injective on S
+  have hinj : Set.InjOn f ↑S := by
+    rintro ⟨i₁, j₁⟩ h₁ ⟨i₂, j₂⟩ h₂ hfeq
+    have ⟨_, hlt₁, hu₁⟩ := Finset.mem_filter.mp (Finset.mem_coe.mp h₁)
+    have ⟨_, hlt₂, hu₂⟩ := Finset.mem_filter.mp (Finset.mem_coe.mp h₂)
+    show (i₁, j₁) = (i₂, j₂)
+    simp only [f] at hfeq
+    by_cases hle₁ : C.points i₁ ≤ C.points j₁ <;>
+      by_cases hle₂ : C.points i₂ ≤ C.points j₂
+    · -- Both: left = first index, so i₁ = i₂; right endpoints match by separation
+      rw [if_pos hle₁, if_pos hle₂] at hfeq
+      have hv₁ := unit_dist_left hu₁ hle₁
+      have hv₂ := unit_dist_left hu₂ hle₂
+      have hj : j₁ = j₂ := by
+        by_contra hne
+        have hsep := C.separated j₁ j₂ hne
+        have : C.points j₁ = C.points j₂ := by linarith [congrArg C.points hfeq]
+        rw [this, sub_self, abs_zero] at hsep; linarith
+      exact Prod.ext hfeq hj
+    · -- Mixed: i₁ = j₂, derive index ordering contradiction
+      rw [if_pos hle₁, if_neg hle₂] at hfeq
+      exfalso; push_neg at hle₂
+      have hv₁ := unit_dist_left hu₁ hle₁
+      have hu₂' : |C.points j₂ - C.points i₂| = 1 := by rw [abs_sub_comm]; exact hu₂
+      have hv₂ := unit_dist_left hu₂' (le_of_lt hle₂)
+      have hji : j₁ = i₂ := by
+        by_contra hne
+        have hsep := C.separated j₁ i₂ hne
+        have : C.points j₁ = C.points i₂ := by linarith [congrArg C.points hfeq]
+        rw [this, sub_self, abs_zero] at hsep; linarith
+      -- i₁ < j₁ = i₂ < j₂ = i₁, contradiction
+      simp only [Fin.lt_def, Fin.ext_iff] at hlt₁ hlt₂ hfeq hji
+      omega
+    · -- Symmetric mixed case: j₁ = i₂, same contradiction
+      rw [if_neg hle₁, if_pos hle₂] at hfeq
+      exfalso; push_neg at hle₁
+      have hu₁' : |C.points j₁ - C.points i₁| = 1 := by rw [abs_sub_comm]; exact hu₁
+      have hv₁ := unit_dist_left hu₁' (le_of_lt hle₁)
+      have hv₂ := unit_dist_left hu₂ hle₂
+      have hji : j₂ = i₁ := by
+        by_contra hne
+        have hsep := C.separated j₂ i₁ hne
+        have : C.points j₂ = C.points i₁ := by linarith [congrArg C.points hfeq]
+        rw [this, sub_self, abs_zero] at hsep; linarith
+      simp only [Fin.lt_def, Fin.ext_iff] at hlt₁ hlt₂ hfeq hji
+      omega
+    · -- Both: left = second index, so j₁ = j₂; right endpoints match by separation
+      rw [if_neg hle₁, if_neg hle₂] at hfeq
+      push_neg at hle₁ hle₂
+      have hu₁' : |C.points j₁ - C.points i₁| = 1 := by rw [abs_sub_comm]; exact hu₁
+      have hu₂' : |C.points j₂ - C.points i₂| = 1 := by rw [abs_sub_comm]; exact hu₂
+      have hv₁ := unit_dist_left hu₁' (le_of_lt hle₁)
+      have hv₂ := unit_dist_left hu₂' (le_of_lt hle₂)
+      have hi : i₁ = i₂ := by
+        by_contra hne
+        have hsep := C.separated i₁ i₂ hne
+        have : C.points i₁ = C.points i₂ := by linarith [congrArg C.points hfeq]
+        rw [this, sub_self, abs_zero] at hsep; linarith
+      exact Prod.ext hi hfeq
+  -- Apply the injection bound: |S| ≤ |univ \ {M}| = n - 1
+  have hsub : S.image f ⊆ Finset.univ.erase M := by
+    intro x hx
+    obtain ⟨p, hp, rfl⟩ := Finset.mem_image.mp hx
+    exact himg p hp
+  calc S.card
+      = (S.image f).card := (Finset.card_image_of_injOn hinj).symm
+    _ ≤ (Finset.univ.erase M).card := Finset.card_le_card hsub
+    _ = n - 1 := by
+        rw [Finset.card_erase_of_mem (Finset.mem_univ M), Finset.card_univ, Fintype.card_fin]
 
 /-- The consecutive integer configuration achieves n-1 unit pairs.
     Place points at 0, 1, 2, ..., n-1.

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -18,9 +18,9 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1084",
     "erdosUrl": "https://erdosproblems.com/1084",
-    "axiomCount": 12,
-    "assumptions": "12 axiom declarations: maxUnitDistPairs (extremal function definition), f1_upper_bound (1D forest bound), f1_exact (f_1(n)=n-1), f2_upper_erdos (Erdos 3n-c*sqrt(n) bound), harborth_exact (2D exact formula), triangular_lattice_optimal (A2 lattice achieves max), f2_trivial_upper (f_2(n)<3n), f3_leading (3D leading coefficient 6), bezdek_reid_upper (3D n^{2/3} correction), erdos_1084_d3_conjecture (3D Theta(n^{2/3}) conjecture), fd_lower_general (general lower bound), fd_upper_general (Kabatyansky-Levenshtein upper bound). f1_achievable is now fully proved.",
-    "lineCount": 264,
+    "axiomCount": 11,
+    "assumptions": "11 axiom declarations: maxUnitDistPairs (extremal function definition), f1_exact (f_1(n)=n-1), f2_upper_erdos (Erdos 3n-c*sqrt(n) bound), harborth_exact (2D exact formula), triangular_lattice_optimal (A2 lattice achieves max), f2_trivial_upper (f_2(n)<3n), f3_leading (3D leading coefficient 6), bezdek_reid_upper (3D n^{2/3} correction), erdos_1084_d3_conjecture (3D Theta(n^{2/3}) conjecture), fd_lower_general (general lower bound), fd_upper_general (Kabatyansky-Levenshtein upper bound). f1_upper_bound and f1_achievable are now fully proved.",
+    "lineCount": 365,
     "badge": "axiom",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Summary

- Prove `f1_upper_bound`: the 1D upper bound theorem stating that any separated configuration of n points on ℝ has at most n-1 unit-distance pairs
- Proof technique: injection of unit pairs into `Fin n` via "left endpoint" map, with the maximum-value index excluded from the image
- Add helper lemma `unit_dist_left` for extracting directional unit distance
- Reduce axiom count from 12 to 11

## Proof Details

The key insight is that for each unit pair `(i, j)`, the index whose point value is smaller (the "left endpoint") determines the pair uniquely: if two pairs shared a left endpoint at value `v`, both would have their other endpoint at `v + 1`, but separation prevents two distinct indices from having the same real value. The index with the globally maximum value cannot be a left endpoint (no point exists at max + 1), so the image has size ≤ n - 1.

## Files Modified

- `proofs/Proofs/Erdos1084Problem.lean` — Convert `axiom f1_upper_bound` to `theorem` with full proof (+104 lines)
- `src/data/proofs/erdos-1084/meta.json` — Update axiomCount 12→11, lineCount 264→368

## Test plan

- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos1084Problem`
- [x] Zero sorries remain
- [x] All existing theorems still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)