### PR TITLE
Fix: sync erdos-963 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -136,8 +136,8 @@
     "opens": [],
     "namespace": null,
     "lineCount": 124,
-    "axiomCount": 7,
-    "theoremCount": 2,
+    "axiomCount": 5,
+    "theoremCount": 4,
     "definitionCount": 2
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Sync erdos-963 leanFile counts with actual Lean source.

## Evidence

**Before**: leanFile.axiomCount=7, theoremCount=2
**After**: leanFile.axiomCount=5, theoremCount=4

---
Automated fix by lean-mechanic agent.