### PR TITLE
Fix: sync erdos-810 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-810/meta.json
+++ b/src/data/proofs/erdos-810/meta.json
@@ -159,9 +159,9 @@
     "opens": [],
     "namespace": "Erdos810",
     "lineCount": 213,
-    "axiomCount": 2,
-    "theoremCount": 1,
-    "definitionCount": 5
+    "axiomCount": 1,
+    "theoremCount": 4,
+    "definitionCount": 6
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Sync erdos-810 leanFile counts with actual Lean source.

## Evidence

**Before**: axiomCount=2, theoremCount=1, definitionCount=5
**After**: axiomCount=1, theoremCount=4, definitionCount=6

---
Automated fix by lean-mechanic agent.