### PR TITLE
Fix: sync erdos-685 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-685/meta.json
+++ b/src/data/proofs/erdos-685/meta.json
@@ -138,8 +138,8 @@
     ],
     "namespace": null,
     "lineCount": 106,
-    "axiomCount": 3,
-    "theoremCount": 3,
+    "axiomCount": 2,
+    "theoremCount": 6,
     "definitionCount": 3
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Sync erdos-685 leanFile counts with actual Lean source.

## Evidence

**Before**: axiomCount=3, theoremCount=3
**After**: axiomCount=2, theoremCount=6

---
Automated fix by lean-mechanic agent.