### PR TITLE
Fix: sync erdos-196 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -136,9 +136,9 @@
     ],
     "namespace": null,
     "lineCount": 171,
-    "axiomCount": 5,
-    "theoremCount": 2,
-    "definitionCount": 8
+    "axiomCount": 4,
+    "theoremCount": 4,
+    "definitionCount": 9
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Sync erdos-196 leanFile counts with actual Lean source.

## Evidence

**Before**: axiomCount=5, theoremCount=2, definitionCount=8
**After**: axiomCount=4, theoremCount=4, definitionCount=9

---
Automated fix by lean-mechanic agent.