### PR TITLE
Fix: sync erdos-388 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -109,9 +109,9 @@
     ],
     "namespace": null,
     "lineCount": 121,
-    "axiomCount": 4,
-    "theoremCount": 1,
-    "definitionCount": 2
+    "axiomCount": 3,
+    "theoremCount": 2,
+    "definitionCount": 4
   },
   "references": [
     "Erdős & Selfridge (1975): 'The product of consecutive integers is never a power', Illinois Journal of Mathematics 19, 292–301",


### PR DESCRIPTION
## Fix

Sync erdos-388 leanFile counts with actual Lean source.

## Evidence

**Before**: axiomCount=4, theoremCount=1, definitionCount=2
**After**: axiomCount=3, theoremCount=2, definitionCount=4

---
Automated fix by lean-mechanic agent.