### PR TITLE
Fix: sync erdos-14 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -139,8 +139,8 @@
     ],
     "namespace": null,
     "lineCount": 108,
-    "axiomCount": 7,
-    "theoremCount": 0,
+    "axiomCount": 6,
+    "theoremCount": 1,
     "definitionCount": 4
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Sync erdos-14 leanFile counts with actual Lean source.

## Evidence

**Before**: axiomCount=7, theoremCount=0
**After**: axiomCount=6, theoremCount=1

---
Automated fix by lean-mechanic agent.