### PR TITLE
Fix: erdos-382 leanFile.axiomCount 9 → 5

### DIFF
--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -197,7 +197,7 @@
     ],
     "namespace": "Erdos382",
     "lineCount": 483,
-    "axiomCount": 9,
+    "axiomCount": 5,
     "theoremCount": 11,
     "definitionCount": 9
   },


### PR DESCRIPTION
## Fix

Update stale `leanFile.axiomCount` from 9 to 5.

## Evidence

**Before**: `leanFile.axiomCount: 9`
**After**: `leanFile.axiomCount: 5`

The Lean source has 5 axiom declarations: `erdos_382_q1`, `erdos_382_q2_heuristic`, `ramachandra_bound`, `cramer_implies_q1`, `condition_iff_no_large_prime`. Four axioms were previously removed (including `exp_ge_two_needs_square` marked incorrect) but the `leanFile` section was not updated. `meta.axiomCount: 5` was already correct.

---
Automated fix by lean-mechanic agent.