### PR TITLE
Fix: sync erdos-430 leanFile axiomCount with Lean source

### DIFF
--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -138,7 +138,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 172,
-    "axiomCount": 4,
+    "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Fix

Sync erdos-430 leanFile axiomCount with actual Lean source.

## Evidence

**Before**: leanFile.axiomCount=4
**After**: leanFile.axiomCount=2

---
Automated fix by lean-mechanic agent.