### PR TITLE
Fix: sync erdos-488 leanFile counts with Lean source

### DIFF
--- a/src/data/proofs/erdos-488/meta.json
+++ b/src/data/proofs/erdos-488/meta.json
@@ -134,8 +134,8 @@
     "opens": [],
     "namespace": null,
     "lineCount": 182,
-    "axiomCount": 2,
-    "theoremCount": 3,
+    "axiomCount": 1,
+    "theoremCount": 4,
     "definitionCount": 4
   },
   "references": [


### PR DESCRIPTION
## Fix

Sync erdos-488 leanFile counts with actual Lean source.

## Evidence

**Before**: axiomCount=2, theoremCount=3
**After**: axiomCount=1, theoremCount=4

---
Automated fix by lean-mechanic agent.