### PR TITLE
Fix: erdos-828 leanFile counts (lineCount 205→346, theoremCount 7→8)

### DIFF
--- a/src/data/proofs/erdos-828/meta.json
+++ b/src/data/proofs/erdos-828/meta.json
@@ -191,9 +191,9 @@
       "Set"
     ],
     "namespace": "Erdos828",
-    "lineCount": 205,
+    "lineCount": 346,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 3
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Update stale `leanFile.lineCount` from 205 to 346 and `leanFile.theoremCount` from 7 to 8.

## Evidence

**Before**: `leanFile.lineCount: 205`, `leanFile.theoremCount: 7`
**After**: `leanFile.lineCount: 346`, `leanFile.theoremCount: 8`

The Lean file was expanded significantly (141 lines added, 1 theorem added) but the `leanFile` section was not updated. `meta.lineCount: 346` was already correct.

---
Automated fix by lean-mechanic agent.