### PR TITLE
Audit 6 gallery proofs: complete gallery coverage

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9133,9 +9133,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "yang-mills": {
-      "lastAudited": "2026-03-24T19:01:46Z",
-      "auditCount": 2,
-      "result": "clean",
+      "lastAudited": "2026-03-25T02:57:50Z",
+      "auditCount": 3,
+      "result": "issues-found",
       "agentId": "auditor-cycle-20-batch"
     },
     "cayley-hamilton-minpoly-oq-03": {
@@ -9233,6 +9233,42 @@
     "erdos-103-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-03-24T23:34:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-25T02:54:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-25T02:59:03Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-25T02:59:42Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dissection-of-cubes-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-25T03:00:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1179-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-25T03:00:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylow-theorems-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-25T03:01:28Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary
- Audited 6 remaining unaudited proofs plus re-audited yang-mills
- 5 clean: inverse-galois-oq-01, abel-ruffini-oq-04-oq-01, binomial-theorem-oq-03-oq-02, dissection-of-cubes-oq-02-oq-02, erdos-1179-oq-01, sylow-theorems-oq-02
- 1 issues-found: yang-mills (#6583 filed — lineCount/section ranges broken)
- Gallery now at 1543/1543 audited (100% coverage)

## Test plan
- [x] Verify `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 unaudited
- [x] Verify audit-tracker.json entries are correctly populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)