### PR TITLE
Fix: yang-mills lineCount, section ranges, sorry/theorem counts

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 59,
+    "sorries": 58,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",
@@ -59,7 +59,7 @@
     "millenniumProblem": "yang-mills",
     "axiomCount": 16,
     "assumptions": "1 explicit axiom declaration: gaugeTransform (gauge-transformed field). ~15 structure-encoded assumptions in: CompactSimpleGaugeGroup (compact, connected, simple), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy), YangMillsAction (coupling_pos, action_nonneg), FieldStrength (antisymmetric), Instanton (action_formula, bogomolny_bound), EnergyMomentumTensor (symmetric, energy_density_nonneg, conservation). The Yang-Mills 4D mass gap conjecture remains OPEN.",
-    "lineCount": 48,
+    "lineCount": 28570,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -87,6 +87,7 @@
       "title": "Imports and Setup",
       "summary": "Imports Mathlib modules for Lie algebras, matrix trace, calculus, inner product spaces, measure theory, and polynomials. Sets `maxHeartbeats 4000000` for the computationally intensive proofs.",
       "mathContext": "Imports for $\\mathfrak{g}$ (Lie algebra), $\\text{Tr}$ (matrix trace), $\\nabla$ (calculus), $\\langle \\cdot, \\cdot \\rangle$ (inner product), $\\int$ (measure theory).",
+      "file": "Proofs/YangMillsMassGap.lean",
       "startLine": 1,
       "endLine": 48
     },
@@ -95,132 +96,148 @@
       "title": "Gauge Group and Lie Algebra Infrastructure",
       "summary": "Defines `CompactSimpleGaugeGroup G` (compact, connected, simple), `GaugeLieAlgebra G` with bracket operations, `Spacetime := Fin 4 \\to \\mathbb{R}$, and the Minkowski metric $\\eta_{\\mu\\nu}$ with signature $(-,+,+,+)$. Proves: symmetry, diagonality, $\\eta_{00} = -1$, space components $= 1$, trace $= 2$, Lorentzian signature $(1,3)$, and the Minkowski norm squared.",
       "mathContext": "$G$ compact simple, $\\mathfrak{g}$ with $[X,[Y,Z]] + [Y,[Z,X]] + [Z,[X,Y]] = 0$. $\\eta_{\\mu\\nu} = \\text{diag}(-1,+1,+1,+1)$, signature $(1,3)$, $\\text{Tr}(\\eta) = 2$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Core.lean",
+      "startLine": 26,
+      "endLine": 118
     },
     {
       "id": "gauge-fields",
       "title": "Gauge Fields and Field Strength",
       "summary": "Defines `GaugeField G 𝔤` (connection 1-form $A_\\mu(x) \\in \\mathfrak{g}$) and `FieldStrength G 𝔤` ($F_{\\mu\\nu}$ with antisymmetry). Proves $F_{\\mu\\mu} = 0$ using module arithmetic ($a = -a \\implies 2a = 0 \\implies a = 0$) and that the antisymmetric tensor has 6 independent components.",
       "mathContext": "$A_\\mu(x) \\in \\mathfrak{g}$. $F_{\\mu\\nu} = -F_{\\nu\\mu}$, $F_{\\mu\\mu} = 0$ (char $\\neq 2$). $\\binom{4}{2} = 6$ independent components.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Classical.lean",
+      "startLine": 43,
+      "endLine": 85
     },
     {
       "id": "yang-mills-action",
       "title": "Yang-Mills Action and Classical Equations",
       "summary": "Axiomatizes the Killing form $\\langle X, Y \\rangle$ (symmetric, negative definite, ad-invariant). Defines `YangMillsAction` ($S[A] = -\\frac{1}{4g^2}\\int \\text{Tr}(F^2)$), `CovariantDerivative` ($D_\\mu V = \\partial_\\mu V + [A_\\mu, V]$), `SatisfiesYangMillsEquations` ($D_\\mu F^{\\mu\\nu} = 0$), and the Bianchi identity.",
       "mathContext": "$S[A] = -\\frac{1}{4g^2}\\int \\text{Tr}(F_{\\mu\\nu}F^{\\mu\\nu})d^4x$. $D_\\mu V = \\partial_\\mu V + [A_\\mu, V]$. $D_\\mu F^{\\mu\\nu} = 0$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Classical.lean",
+      "startLine": 87,
+      "endLine": 113
     },
     {
       "id": "gauge-transformations",
       "title": "Gauge Transformations and Invariance",
       "summary": "Defines `GaugeTransformation G` and proves gauge transformations form a group (`gaugeTransformGroup` instance with pointwise multiplication). Axiomatizes $S[A^g] = S[A]$. Proves identity, associativity, and double inversion.",
       "mathContext": "$A_\\mu \\mapsto g A_\\mu g^{-1} + g \\partial_\\mu g^{-1}$. $S[A^g] = S[A]$. $\\mathcal{G} = \\text{Map}(\\mathbb{R}^4, G)$ forms a group.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Classical.lean",
+      "startLine": 115,
+      "endLine": 164
     },
     {
       "id": "maxwell",
       "title": "Maxwell's Equations as U(1) Yang-Mills",
       "summary": "Defines `ElectromagneticTensor`, extracts electric and magnetic fields, proves diagonal vanishing and antisymmetry. Defines `AbelianGaugeTheory` and `MaxwellEquations`: in the abelian case the Lie bracket vanishes, so Yang-Mills equations reduce to $\\partial_\\mu F^{\\mu\\nu} = 0$ (Maxwell's equations).",
       "mathContext": "$U(1)$: $[A_\\mu, A_\\nu] = 0$, so $F_{\\mu\\nu} = \\partial_\\mu A_\\nu - \\partial_\\nu A_\\mu$. $\\partial_\\mu F^{\\mu\\nu} = 0$ are Maxwell's equations.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Classical.lean",
+      "startLine": 166,
+      "endLine": 231
     },
     {
       "id": "quantum-ym",
       "title": "Quantum Yang-Mills and Wightman Axioms",
       "summary": "Defines `WightmanQFT` with Hilbert space $\\mathcal{H}$ (normed, inner product, complete), vacuum state, Hamiltonian, energy bounded below, vacuum as lowest energy state. `QuantumYangMillsTheory` extends with gauge field operators and nontriviality.",
       "mathContext": "Wightman: $\\mathcal{H}$ Hilbert, $|0\\rangle$ with $\\||0\\rangle\\| = 1$, $H : \\mathcal{H} \\to \\mathcal{H}$ with $\\text{Re}\\langle H\\psi, \\psi \\rangle \\geq 0$, $H|0\\rangle = 0$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Quantum.lean",
+      "startLine": 49,
+      "endLine": 79
     },
     {
       "id": "mass-gap",
       "title": "The Mass Gap",
       "summary": "Defines `hasMassGap qft \\Delta$: all states orthogonal to vacuum have energy $\\geq \\Delta > 0$. Defines `hasSomeMassGap`. Proves downward closure: if $\\Delta$ is a mass gap, so is any $0 < \\Delta' \\leq \\Delta$. Proves vacuum has zero energy.",
       "mathContext": "$\\Delta > 0$: $\\forall \\psi \\perp |0\\rangle,\\; \\|\\psi\\| = 1 \\implies \\text{Re}\\langle H\\psi, \\psi \\rangle \\geq \\Delta$. Downward closure: $0 < \\Delta' \\leq \\Delta \\implies \\text{hasMassGap}(\\Delta')$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Quantum.lean",
+      "startLine": 80,
+      "endLine": 109
     },
     {
       "id": "millennium",
       "title": "The Millennium Problem Statement",
       "summary": "Defines `YangMillsMillenniumProblem G 𝔤`: $\\exists$ quantum Yang-Mills theory for gauge group $G$ with a positive mass gap. This is the formal statement of the Clay Mathematics Institute problem.",
       "mathContext": "$\\exists\\, \\text{QYM} : \\text{QuantumYangMillsTheory}(G, \\mathfrak{g}),\\; \\exists \\Delta > 0,\\; \\text{hasMassGap}(\\text{QYM}, \\Delta)$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Quantum.lean",
+      "startLine": 111,
+      "endLine": 124
     },
     {
       "id": "partial-results",
       "title": "Known Partial Results",
       "summary": "States asymptotic freedom ($\\exists b_0 > 0$), lattice Yang-Mills well-definedness ($\\exists Z > 0$), and Wilson area law ($\\exists \\sigma > 0$). These are proved trivially — the physical content is in the naming, not the formal proofs.",
       "mathContext": "$\\exists b_0 > 0$ (asymptotic freedom). $\\exists Z > 0$ (lattice partition function). $\\exists \\sigma > 0$ (string tension).",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Classical.lean",
+      "startLine": 260,
+      "endLine": 277
     },
     {
       "id": "instantons",
       "title": "Instanton Solutions",
       "summary": "Defines `Instanton` with self-duality, topological charge $k \\in \\mathbb{Z}$, and action formula $S = 8\\pi^2|k|/g^2$. Axiomatizes the Bogomolny bound: $S[A] \\geq 8\\pi^2|k|/g^2$.",
       "mathContext": "$F = \\pm *F$ (self-dual), $k \\in \\mathbb{Z}$ (topological charge), $S = 8\\pi^2|k|/g^2$. Bogomolny: $S[A] \\geq 8\\pi^2|k|/g^2$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Classical.lean",
+      "startLine": 233,
+      "endLine": 246
     },
     {
       "id": "energy-momentum",
       "title": "Energy-Momentum Tensor",
       "summary": "Defines `EnergyMomentumTensor` (symmetric, non-negative energy density). Axiomatizes conservation $\\partial_\\mu T^{\\mu\\nu} = 0$ (Noether's theorem) and conformal invariance in 4D: $\\eta^{\\mu\\nu} T_{\\mu\\nu} = 0$.",
       "mathContext": "$T^{\\mu\\nu}$ symmetric, $T^{00} \\geq 0$. $\\partial_\\mu T^{\\mu\\nu} = 0$ (Noether). $\\eta_{\\mu\\nu}T^{\\mu\\nu} = 0$ (conformal, 4D only).",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Classical.lean",
+      "startLine": 248,
+      "endLine": 258
     },
     {
       "id": "wilson-loops",
       "title": "Wilson Loops",
       "summary": "Defines `SpacetimeLoop`, `WilsonLoop` (gauge-invariant, bounded $|W| \\leq 1$), `RectangularWilsonLoop`. Proves trivial loop $= 1$, area law mass scale positivity, area vs perimeter distinction. Defines `WilsonAreaLaw` ($\\langle W(C)\\rangle \\sim e^{-\\sigma \\cdot \\text{Area}}$) and `WilsonPerimeterLaw` ($\\sim e^{-m \\cdot \\text{Perimeter}}$).",
       "mathContext": "$W(C) = \\frac{1}{\\dim R}\\text{Tr}(\\mathcal{P}\\exp \\oint_C A_\\mu dx^\\mu)$. Area law: $\\langle W \\rangle \\sim e^{-\\sigma \\text{Area}}$. Perimeter law: $\\langle W \\rangle \\sim e^{-m \\text{Perimeter}}$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Exploration.lean",
+      "startLine": 44,
+      "endLine": 125
     },
     {
       "id": "lattice-gauge",
       "title": "Lattice Gauge Theory (Wilson, 1974)",
       "summary": "Full lattice formulation: `LatticeSite`, `LatticeLink`, `LinkVariable`, `LatticeGaugeTransform`, `Plaquette`, `plaquetteVariable`. Defines `WilsonLatticeAction` with coupling $\\beta$, character $\\chi$. Proves: plaquette action non-negativity, identity = 0, upper bound $\\leq 2\\beta$, **gauge invariance**, total action bounds, strong coupling bound, partition function existence, continuum limit structure.",
       "mathContext": "$U_P = U_1 U_2 U_3^{-1} U_4^{-1}$. $S_P = \\beta(1 - \\chi(U_P)/\\chi(1))$. $S_P(gU_Pg^{-1}) = S_P(U_P)$ (gauge invariance). $0 \\leq S_W \\leq 2N\\beta$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Exploration.lean",
+      "startLine": 126,
+      "endLine": 380
     },
     {
       "id": "2d-yang-mills",
       "title": "2D Yang-Mills Theory (Exactly Solvable)",
       "summary": "2D lattice structures, `TwoDPartitionFunction` with representation decomposition, **Migdal's formula** (1975): $\\langle W_R(C)\\rangle = (\\dim R) \\cdot e^{-g^2 A C_2(R)/(2\\dim R)}$. Proves the exact area law ($W(A) < W(0)$ for $A > 0$), computes string tension $\\sigma = g^2 C_2(R)/(2\\dim R)$, proves $\\sigma > 0$.",
       "mathContext": "Migdal: $\\langle W_R(C) \\rangle = (\\dim R) \\cdot e^{-g^2 A C_2(R)/(2\\dim R)}$. $\\sigma = g^2 C_2(R)/(2\\dim R) > 0$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Exploration.lean",
+      "startLine": 381,
+      "endLine": 483
     },
     {
       "id": "transfer-matrix",
       "title": "Transfer Matrix Formalism",
       "summary": "Defines `TransferMatrix` with eigenvalues $\\lambda_0 \\geq \\lambda_1 > 0$. The mass gap $\\Delta = -\\ln(\\lambda_1/\\lambda_0)/a$ is positive when $\\lambda_1 < \\lambda_0$. Proves: mass gap positivity, correlation decay rate $\\lambda_1/\\lambda_0 \\leq 1$, ground state dominance.",
       "mathContext": "$Z = \\text{Tr}(T^{N_t})$. $\\Delta = -\\ln(\\lambda_1/\\lambda_0)/a > 0$ when $\\lambda_1 < \\lambda_0$.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Exploration.lean",
+      "startLine": 484,
+      "endLine": 549
     },
     {
       "id": "polyakov-summary",
       "title": "Polyakov Loop, Finite Temperature, and Summary",
       "summary": "Defines `PolyakovLoop` (order parameter for confinement), `ConfinedPhase` ($\\langle P \\rangle = 0$, $\\sigma > 0$), `DeconfinedPhase` ($\\langle P \\rangle \\neq 0$, $T_c > 0$). Proves confinement and deconfinement are mutually exclusive. Summary lists 50+ proven theorems and 7 axioms.",
       "mathContext": "Polyakov: $P(\\vec{x}) = \\text{Tr}(\\prod_t U_0(\\vec{x},t))$. Confined: $\\langle P \\rangle = 0$. Deconfined: $\\langle P \\rangle \\neq 0$. Mutually exclusive.",
-      "startLine": 48,
-      "endLine": 48
+      "file": "Proofs/YangMills/Exploration.lean",
+      "startLine": 550,
+      "endLine": 599
     }
   ],
   "conclusion": {
-    "summary": "This formalization provides infrastructure for the Yang-Mills Millennium Prize Problem across 28,695 lines and 162 parts. The rigorous core (~36% of the file) covers classical gauge theory, lattice gauge theory with proven gauge invariance and bounds, exactly solvable 2D Yang-Mills with Migdal formula, and a proven finite-volume mass gap via transfer matrix / Perron-Frobenius. The remaining ~64% is heuristic exploration of confinement mechanisms, anomalies, SUSY, and deconfinement physics. The 4D mass gap conjecture remains OPEN — this is infrastructure, not progress toward the solution.",
+    "summary": "This formalization provides infrastructure for the Yang-Mills Millennium Prize Problem across 28,570 lines and 162 parts. The rigorous core (~36% of the file) covers classical gauge theory, lattice gauge theory with proven gauge invariance and bounds, exactly solvable 2D Yang-Mills with Migdal formula, and a proven finite-volume mass gap via transfer matrix / Perron-Frobenius. The remaining ~64% is heuristic exploration of confinement mechanisms, anomalies, SUSY, and deconfinement physics. The 4D mass gap conjecture remains OPEN — this is infrastructure, not progress toward the solution.",
     "implications": "Resolution of the Yang-Mills mass gap problem would put quantum chromodynamics on rigorous mathematical foundations, explaining from first principles why quarks and gluons are confined inside hadrons. It would be the first rigorous construction of a 4D interacting quantum field theory and would likely require fundamentally new mathematical techniques bridging functional analysis, probability theory, and geometric analysis.",
     "openQuestions": [
       "Can a rigorous quantum Yang-Mills theory be constructed on $\\mathbb{R}^4$? No 4D interacting QFT satisfying the Wightman axioms has ever been built — the problem remains the central open challenge in mathematical physics.",
@@ -295,9 +312,9 @@
       "Matrix"
     ],
     "namespace": "YangMillsMassGap",
-    "lineCount": 48,
+    "lineCount": 28570,
     "axiomCount": 16,
-    "theoremCount": 1818,
+    "theoremCount": 1805,
     "definitionCount": 260
   },
   "references": [
@@ -305,7 +322,7 @@
       "authors": "Yang, Chen-Ning; Mills, Robert L.",
       "title": "Conservation of Isotopic Spin and Isotopic Gauge Invariance",
       "year": "1954",
-      "venue": "Physical Review 96(1), 191–195",
+      "venue": "Physical Review 96(1), 191-195",
       "note": "The foundational paper introducing non-abelian gauge theory — the mathematical framework for the Standard Model of particle physics"
     },
     {


### PR DESCRIPTION
## Fix

Corrects yang-mills meta.json to match actual Lean source across all 5 submodule files.

## Evidence

**Before**:
- `lineCount`: 48 (wrapper file only, not aggregate)
- `sorries`: 59 (included 1 comment-only match at Exploration.lean:18023)
- `theoremCount`: 1818 (off by 13)
- All 17 sections: `startLine: 48, endLine: 48` (all pointing to wrapper last line)
- Conclusion: "28,695 lines"

**After**:
- `lineCount`: 28570 (48 + 118 + 279 + 124 + 28001 across all files)
- `sorries`: 58 (code-level only, excludes comment `-- [MATHLIB-DRIFT] sorry`)
- `theoremCount`: 1805 (7 + 10 + 2 + 1786 verified via `grep -cE '^theorem '`)
- All sections: added `file` field, corrected `startLine`/`endLine` to actual locations in Core.lean, Classical.lean, Quantum.lean, Exploration.lean
- Conclusion: "28,570 lines"

Closes #6583

---
Automated fix by lean-mechanic agent.