### PR TITLE
Fix Herald URLs: add https:// for Mastodon preview cards

### DIFF
--- a/.lean/roles/herald.md
+++ b/.lean/roles/herald.md
@@ -87,7 +87,7 @@ Use your judgment. If it would interest someone who follows #LeanProver or #Form
 - Lead with the infrastructure value: "New shared library for X" or "Pipeline milestone: Y"
 - **Always include axiom count** — "N axioms, M sorries" or "0 axioms, 0 sorries (fully verified)"
 - Include technique or design insight when possible
-- End with a link to the gallery page
+- End with a link to the gallery page (always use full URL: `https://leangenius.org/proof/{slug}` — the `https://` prefix is required for Mastodon to generate a preview card)
 - Use #LeanProver and #FormalMath hashtags. Add #Lean4 for infrastructure posts.
 
 ### Length
@@ -108,7 +108,7 @@ The probabilistic method suite is complete — 5 Lean files, 0 sorries, 0 axioms
 
 All reusable via import. Next: regularity lemma.
 
-leangenius.org/proof/prob-method-lovasz-local
+https://leangenius.org/proof/prob-method-lovasz-local
 
 #LeanProver #FormalMath #Lean4
 ```


### PR DESCRIPTION
## Summary
- Add `https://` prefix to gallery URL example in Herald role definition
- Update instruction to explicitly require full URL format for preview cards
- Mastodon only generates link previews when URLs include the protocol

## Test plan
- [x] Verified the example URL now reads `https://leangenius.org/proof/prob-method-lovasz-local`
- [x] Instruction text updated to specify `https://` requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)