### PR TITLE
Enrich batch: erdos-585, erdos-91, gcd-algorithm-oq-01, erdos-97, erdos-480, cauchy-schwarz-oq-03-oq-01

### DIFF
--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -38,7 +38,12 @@
       "The problem connects cycle decomposition theory to extremal graph theory, bridging Hamiltonian graph theory and Turán-type questions"
     ],
     "prerequisites": [
-      "Combinatorics and number theory"
+      "Extremal graph theory: Turán-type problems bounding edges by forbidden substructures",
+      "Graph cycles: Hamiltonian cycles on vertex subsets, edge-disjoint cycle decompositions",
+      "Asymptotic notation: Ω, O, Θ for growth rates of extremal functions",
+      "Simple graphs: vertices, edges, adjacency in Mathlib's SimpleGraph",
+      "The Szemerédi regularity lemma and its applications to cycle-finding",
+      "Ramsey-type arguments: guaranteed substructures in dense graphs"
     ]
   },
   "sections": [
@@ -47,49 +52,56 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 20,
-      "summary": "Docstring stating the problem with known bounds and references. Imports Mathlib's SimpleGraph, Finset, Filter, and Tactic modules."
+      "summary": "Docstring stating the problem with known bounds and references. Imports Mathlib's SimpleGraph, Finset, Filter, and Tactic modules.",
+      "mathContext": "Problem: what is $f(n) = \\max\\{|E(G)| : G \\text{ on } n \\text{ vertices, no two edge-disjoint cycles on same vertex set}\\}$?"
     },
     {
       "id": "cycles",
       "title": "Cycles and Edge-Disjointness",
       "startLine": 21,
       "endLine": 47,
-      "summary": "Defines a cycle on vertex set S via injective vertex sequences with consecutive adjacencies, and edge-disjoint cycles on the same vertex set as two Hamiltonian cycles on S sharing at least one different edge."
+      "summary": "Defines a cycle on vertex set S via injective vertex sequences with consecutive adjacencies, and edge-disjoint cycles on the same vertex set as two Hamiltonian cycles on S sharing at least one different edge.",
+      "mathContext": "A cycle on $S \\subseteq V(G)$ visits each vertex of $S$ exactly once. Two cycles on the same $S$ are edge-disjoint if they share no edge."
     },
     {
       "id": "extremal",
       "title": "The Extremal Function f(n)",
       "startLine": 48,
       "endLine": 56,
-      "summary": "Defines f(n) as the supremum of edge counts over n-vertex simple graphs avoiding the forbidden configuration of two edge-disjoint cycles on any common vertex set."
+      "summary": "Defines f(n) as the supremum of edge counts over n-vertex simple graphs avoiding the forbidden configuration of two edge-disjoint cycles on any common vertex set.",
+      "mathContext": "$f(n) = \\sup\\{|E(G)| : |V(G)| = n, G \\text{ avoids the forbidden configuration}\\}$."
     },
     {
       "id": "lower-bound",
       "title": "Pyber–Rödl–Szemerédi Lower Bound",
       "startLine": 57,
       "endLine": 66,
-      "summary": "Axiomatizes the 1995 result: f(n) ≥ c·n·log log n, stated using Filter.atTop for the asymptotic quantifier."
+      "summary": "Axiomatizes the 1995 result: f(n) ≥ c·n·log log n, stated using Filter.atTop for the asymptotic quantifier.",
+      "mathContext": "Pyber-Rödl-Szemerédi (1995): $f(n) \\geq c \\cdot n \\log\\log n$ for a constant $c > 0$."
     },
     {
       "id": "upper-bound",
       "title": "CJMM Upper Bound (2024)",
       "startLine": 67,
       "endLine": 77,
-      "summary": "Axiomatizes the 2024 breakthrough by Chakraborti, Janzer, Methuku, and Montgomery: f(n) ≤ C·n·(log n)^α for positive constants C, α."
+      "summary": "Axiomatizes the 2024 breakthrough by Chakraborti, Janzer, Methuku, and Montgomery: f(n) ≤ C·n·(log n)^α for positive constants C, α.",
+      "mathContext": "CJMM (2024): $f(n) \\leq C \\cdot n \\cdot (\\log n)^{\\alpha}$ for constants $C, \\alpha > 0$."
     },
     {
       "id": "main-problem",
       "title": "Combined Bounds and the Erdős Problem",
       "startLine": 78,
       "endLine": 90,
-      "summary": "States both bounds together as a single axiom capturing the current state of knowledge: Ω(n log log n) ≤ f(n) ≤ O(n(log n)^C)."
+      "summary": "States both bounds together as a single axiom capturing the current state of knowledge: Ω(n log log n) ≤ f(n) ≤ O(n(log n)^C).",
+      "mathContext": "$\\Omega(n \\log\\log n) \\leq f(n) \\leq O(n (\\log n)^C)$. The gap between these bounds is the central open problem."
     },
     {
       "id": "k-cycles",
       "title": "k-Cycle Generalization",
       "startLine": 91,
       "endLine": 99,
-      "summary": "The CJMM generalization: for any k ≥ 2, graphs exceeding the O(n(log n)^C) threshold must contain k pairwise edge-disjoint cycles on some common vertex set."
+      "summary": "The CJMM generalization: for any k ≥ 2, graphs exceeding the O(n(log n)^C) threshold must contain k pairwise edge-disjoint cycles on some common vertex set.",
+      "mathContext": "CJMM generalization: $\\forall k \\geq 2$, graphs with $> C_k n (\\log n)^{\\alpha_k}$ edges contain $k$ pairwise edge-disjoint cycles on a common vertex set."
     }
   ],
   "conclusion": {
@@ -123,6 +135,11 @@
       "targetId": "erdos-1016",
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: cycles, extremal graph theory, graph theory"
+    },
+    {
+      "targetId": "erdos-543",
+      "relationship": "related",
+      "description": "Related Erdős problem on graph decomposition: both concern extremal questions about cycle structures in graphs"
     }
   ]
 }


### PR DESCRIPTION
## Enrichment Batch

Six gallery entries enriched with prerequisites, mathContext, and cross-references.

### Entries enriched
1. **cauchy-schwarz-oq-03-oq-01**: +7 prerequisites, +4 cross-refs
2. **erdos-480**: +6 prerequisites, fixed 9 section mathContexts, +2 cross-refs
3. **erdos-97**: +6 prerequisites, +7 section mathContexts, +1 cross-ref, deeper implications
4. **gcd-algorithm-oq-01**: +6 prerequisites, fixed section mathContexts, +2 cross-refs
5. **erdos-91**: +6 prerequisites, +6 section mathContexts, +2 cross-refs
6. **erdos-585**: +6 prerequisites, +7 section mathContexts, +1 cross-ref