### PR TITLE
Enrich navier-stokes-oq-02, abel-ruffini: add annotations, cross-refs

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -349,6 +349,11 @@
       "targetId": "angle-trisection-oq-02",
       "relationship": "related",
       "description": "The Wantzel-Galois theorem — an algebraic number $\\alpha$ is constructible by compass and straightedge iff $\\text{Gal}(\\text{minpoly}_{\\mathbb{Q}}(\\alpha))$ is a 2-group — is the constructibility analogue of Abel-Ruffini's radical solvability criterion. Both results reduce a geometric/algebraic question to group theory via the same Galois-theoretic framework: Abel-Ruffini asks whether the Galois group is solvable (abelian composition factors), while Wantzel-Galois asks whether it is a 2-group (all composition factors $\\mathbb{Z}/2$)"
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03",
+      "relationship": "related",
+      "description": "The Gauss-Wantzel theorem: a regular $n$-gon is constructible iff $\\varphi(n)$ is a power of 2, i.e., $n = 2^k p_1 \\cdots p_r$ with distinct Fermat primes $p_i$. This is the definitive constructibility criterion, paralleling Abel-Ruffini's solvability criterion: both reduce a classical question (constructibility / radical solvability) to a group-theoretic condition ($\\text{Gal}$ is a 2-group / $\\text{Gal}$ is solvable) via the same Galois correspondence, and both explain a sharp boundary ($n$-gon constructibility fails for $n = 7$ just as radical solvability fails for degree 5)"
     }
   ],
   "references": [

--- a/src/data/proofs/navier-stokes-oq-02/annotations.json
+++ b/src/data/proofs/navier-stokes-oq-02/annotations.json
@@ -1,122 +1,98 @@
 [
   {
+    "id": "ann-ladyzhenskaya-derivation",
+    "proofId": "navier-stokes-oq-02",
+    "range": { "startLine": 2694, "endLine": 2709 },
+    "type": "context",
+    "title": "Physical Derivation of the Ladyzhenskaya Stability Estimate",
+    "content": "Documents the PDE derivation underlying the `NSSolutionPair2D` structure. Starting from the difference equation for $w = u_1 - u_2$, take the $L^2$ inner product with $w$: the viscous term $-2\\nu\\|\\nabla w\\|^2 \\leq 0$ is stabilizing, but the nonlinear term $|\\langle (w \\cdot \\nabla) u_1, w \\rangle|$ can drive growth. The Ladyzhenskaya inequality bounds this by $C \\|\\nabla u_1\\| \\|w\\|^2$, giving $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$.",
+    "mathContext": "Energy method: $\\frac{1}{2}\\frac{d}{dt}\\|w\\|^2 = -\\nu\\|\\nabla w\\|^2 + \\langle (w \\cdot \\nabla)u_1, w \\rangle$. By Ladyzhenskaya's 2D inequality: $|\\langle (w \\cdot \\nabla)u_1, w \\rangle| \\leq C\\|\\nabla u_1\\|\\|w\\|^2$. Dropping the viscous term: $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$.",
+    "significance": "key",
+    "relatedConcepts": ["Ladyzhenskaya inequality", "energy method", "trilinear form", "viscous dissipation"],
+    "prerequisites": ["L² inner product", "Navier-Stokes equations", "Ladyzhenskaya inequality in 2D"]
+  },
+  {
     "id": "ann-solution-pair-structure",
-    "range": {
-      "startLine": 2710,
-      "endLine": 2732
-    },
+    "proofId": "navier-stokes-oq-02",
+    "range": { "startLine": 2710, "endLine": 2722 },
     "type": "definition",
     "title": "NSSolutionPair2D: Comparing Two Solutions via Difference Energy",
-    "mathContext": "For two solutions $u_1, u_2$ of 2D incompressible Navier-Stokes, define $W(t) = \\|u_1(t) - u_2(t)\\|_{L^2}^2$. The difference $w = u_1 - u_2$ satisfies a linearized equation, and the Ladyzhenskaya inequality in 2D gives:\n$$\\frac{d}{dt}W(t) \\leq C \\cdot E(t) \\cdot W(t),$$\nwhere $E(t) = \\|\\nabla u_1(t)\\|_{L^2}^2$ is the enstrophy and $C$ depends on the domain. This is the critical estimate that enables the Gronwall argument.",
+    "content": "`NSSolutionPair2D` encodes two 2D Navier-Stokes solutions being compared via their difference energy W(t) = ‖u₁(t) - u₂(t)‖². The structure bundles: `sol` (a `GlobalNSSolution2D` providing enstrophy E(t) with bound E(t) ≤ E(0)), `W` (the difference energy function), `C_stab` (the positive Ladyzhenskaya constant), `W_nonneg` and `W_cont` (regularity), and the crucial `stability_estimate`: W'(t) ≤ C·E(t)·W(t). This abstracts away the PDE analysis into a structural hypothesis.",
+    "mathContext": "For two solutions $u_1, u_2$ of 2D incompressible Navier-Stokes, define $W(t) = \\|u_1(t) - u_2(t)\\|_{L^2}^2$. The Ladyzhenskaya inequality in 2D gives $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$.",
     "significance": "key",
-    "relatedConcepts": [
-      "Ladyzhenskaya inequality",
-      "Gronwall inequality",
-      "difference energy",
-      "stability estimate"
-    ],
-    "prerequisites": [
-      "GlobalNSSolution2D",
-      "global_enstrophy_bound"
-    ],
-    "proofId": "navier-stokes-oq-02",
-    "content": "`NSSolutionPair2D` encodes two 2D Navier-Stokes solutions being compared via their difference energy W(t) = ‖u₁(t) - u₂(t)‖². The key hypothesis is the Ladyzhenskaya stability estimate: W'(t) ≤ C·E(t)·W(t), where E(t) is the enstrophy of the reference solution. This abstracts away the PDE analysis (Sobolev embeddings, trilinear form estimates) into a structural hypothesis, making the Gronwall argument modular."
+    "relatedConcepts": ["Ladyzhenskaya inequality", "Gronwall inequality", "difference energy", "stability estimate"],
+    "prerequisites": ["GlobalNSSolution2D", "global_enstrophy_bound"]
   },
   {
     "id": "ann-gronwall-stability",
-    "range": {
-      "startLine": 2734,
-      "endLine": 2815
-    },
-    "type": "concept",
-    "title": "Gronwall L² Stability: The Integrating Factor Proof",
-    "mathContext": "Set $K = C \\cdot E(0)$. Since $E(t) \\leq E(0)$ in 2D (bounded enstrophy), $W'(t) \\leq C \\cdot E(t) \\cdot W(t) \\leq K \\cdot W(t)$.\n\nDefine $g(s) = W(s) \\cdot e^{-Ks}$. Then:\n$$g'(s) = W'(s) e^{-Ks} - K W(s) e^{-Ks} = (W'(s) - KW(s)) e^{-Ks} \\leq 0.$$\n\nSo $g$ is antitone on $[0,\\infty)$: $g(t) \\leq g(0) = W(0)$. Hence:\n$$W(t) e^{-Kt} \\leq W(0) \\implies W(t) \\leq W(0) \\cdot e^{Kt} = W(0) \\cdot e^{CE(0)t}.$$",
-    "significance": "key",
-    "relatedConcepts": [
-      "integrating factor",
-      "antitoneOn_of_deriv_nonpos",
-      "Gronwall inequality",
-      "bounded enstrophy"
-    ],
-    "prerequisites": [
-      "NSSolutionPair2D",
-      "global_enstrophy_bound",
-      "antitoneOn_of_deriv_nonpos",
-      "Real.exp_add",
-      "Real.exp_le_exp"
-    ],
     "proofId": "navier-stokes-oq-02",
-    "content": "`gronwall_stability_2d` proves W(t) ≤ W(0)·exp(C·E(0)·t). The proof sets K = C·E(0) (justified because E(t) ≤ E(0) in 2D via `global_enstrophy_bound`), then defines the integrating factor g(s) = W(s)·exp(-K·s). Since W'(s) ≤ C·E(s)·W(s) ≤ K·W(s), we get g'(s) = (W'(s) - K·W(s))·exp(-Ks) ≤ 0. Applying `antitoneOn_of_deriv_nonpos` gives g(t) ≤ g(0) = W(0), hence W(t)·exp(-Kt) ≤ W(0), and multiplying by exp(Kt) yields the bound."
+    "range": { "startLine": 2724, "endLine": 2804 },
+    "type": "technique",
+    "title": "Gronwall L² Stability: The Integrating Factor Proof",
+    "content": "`gronwall_stability_2d` proves W(t) ≤ W(0)·exp(C·E(0)·t) in 70 lines. The proof: (1) set K = C·E(0), (2) define g(u) = W(u)·exp(-K·u), (3) show g continuous and differentiable, (4) compute g'(u) ≤ 0 since W' ≤ K·W, (5) apply `antitoneOn_of_deriv_nonpos`, (6) conclude g(t) ≤ g(0) = W(0), (7) cancel exp(-Kt) via `Real.exp_add`.",
+    "mathContext": "Set $K = C \\cdot E(0)$. Define $g(s) = W(s) \\cdot e^{-Ks}$. Then $g'(s) = (W'(s) - KW(s)) e^{-Ks} \\leq 0$. So $g$ antitone: $g(t) \\leq g(0) = W(0)$. Hence $W(t) \\leq W(0) \\cdot e^{CE(0)t}$.",
+    "significance": "key",
+    "relatedConcepts": ["integrating factor", "antitoneOn_of_deriv_nonpos", "Gronwall inequality", "bounded enstrophy"],
+    "prerequisites": ["NSSolutionPair2D", "global_enstrophy_bound", "antitoneOn_of_deriv_nonpos", "Real.exp_add"]
   },
   {
     "id": "ann-uniqueness",
-    "range": {
-      "startLine": 2817,
-      "endLine": 2827
-    },
-    "type": "concept",
-    "title": "Uniqueness of 2D Navier-Stokes: A One-Line Corollary",
-    "mathContext": "From $W(0) = 0$:\n$$0 \\leq W(t) \\leq W(0) \\cdot e^{Kt} = 0 \\cdot e^{Kt} = 0.$$\nHence $W(t) = 0$, meaning $\\|u_1(t) - u_2(t)\\|^2 = 0$, i.e., $u_1(t) = u_2(t)$ for all $t > 0$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "uniqueness",
-      "Hadamard well-posedness",
-      "le_antisymm",
-      "Ladyzhenskaya"
-    ],
-    "prerequisites": [
-      "gronwall_stability_2d",
-      "NSSolutionPair2D.W_nonneg"
-    ],
     "proofId": "navier-stokes-oq-02",
-    "content": "`uniqueness_2d` proves that W(0) = 0 implies W(t) = 0 for all t > 0. The proof is a one-liner: from `gronwall_stability_2d` we get W(t) ≤ W(0)·exp(Kt) = 0·exp(Kt) = 0, and from W_nonneg we get W(t) ≥ 0, so W(t) = 0 by `le_antisymm`. This is the classical Ladyzhenskaya uniqueness result for 2D Navier-Stokes."
+    "range": { "startLine": 2806, "endLine": 2823 },
+    "type": "insight",
+    "title": "Uniqueness of 2D Navier-Stokes: Determinism from Gronwall",
+    "content": "`uniqueness_2d` proves W(0) = 0 implies W(t) = 0 for all t > 0. From `gronwall_stability_2d`: W(t) ≤ 0·exp(Kt) = 0. From `W_nonneg`: W(t) ≥ 0. So W(t) = 0. Physical meaning: 2D Navier-Stokes is deterministic. Contrast with 3D, where uniqueness of weak solutions remains unknown.",
+    "mathContext": "$W(0) = 0 \\Rightarrow W(t) \\leq 0 \\cdot e^{Kt} = 0$. Combined with $W(t) \\geq 0$: $W(t) = 0$, i.e., $u_1(t) = u_2(t)$ in $L^2$.",
+    "significance": "key",
+    "relatedConcepts": ["uniqueness", "Hadamard well-posedness", "determinism", "3D open problem"],
+    "prerequisites": ["gronwall_stability_2d", "NSSolutionPair2D.W_nonneg"]
   },
   {
     "id": "ann-amplification",
-    "range": {
-      "startLine": 2836,
-      "endLine": 2853
-    },
-    "type": "concept",
-    "title": "Stability Amplification Factor: Uniform Bound on [0,T]",
-    "mathContext": "For $0 < t < T$, since $t \\leq T$ and $\\exp$ is monotone:\n$$W(t) \\leq W(0) \\cdot e^{CE(0)t} \\leq W(0) \\cdot e^{CE(0)T}.$$\nThe amplification factor $e^{CE(0)T}$ depends on:\n- $C$: the Ladyzhenskaya constant (geometry-dependent)\n- $E(0)$: initial enstrophy (finite in 2D)\n- $T$: time horizon (finite for any fixed interval)\n\nIn 3D, $E(t)$ could potentially blow up, making $\\int_0^T CE(t)\\,dt$ infinite.",
-    "significance": "key",
-    "relatedConcepts": [
-      "amplification factor",
-      "finite enstrophy",
-      "2D vs 3D",
-      "Lipschitz continuity"
-    ],
-    "prerequisites": [
-      "gronwall_stability_2d",
-      "Real.exp_le_exp",
-      "mul_le_mul_of_nonneg_right"
-    ],
     "proofId": "navier-stokes-oq-02",
-    "content": "`stability_amplification_2d` proves W(t) ≤ W(0)·exp(C·E(0)·T) for all t ∈ (0,T). The amplification factor exp(C·E(0)·T) is FINITE because 2D enstrophy E(0) < ∞. This is the key 2D vs 3D distinction: in 3D, if enstrophy blew up, the amplification factor would be infinite and this bound would fail."
+    "range": { "startLine": 2826, "endLine": 2848 },
+    "type": "technique",
+    "title": "Stability Amplification Factor: Uniform Bound on [0,T]",
+    "content": "`stability_amplification_2d` upgrades the pointwise Gronwall bound to a uniform bound: W(t) ≤ W(0)·exp(C·E(0)·T) for all t ∈ (0,T). Uses monotonicity of exp: since t ≤ T, exp(K·t) ≤ exp(K·T). The amplification factor is FINITE because 2D enstrophy E(0) < ∞.",
+    "mathContext": "For $0 < t < T$: $W(t) \\leq W(0) e^{CE(0)t} \\leq W(0) e^{CE(0)T}$. Finite iff $E(0) < \\infty$ (always true in 2D, unknown in 3D).",
+    "significance": "key",
+    "relatedConcepts": ["amplification factor", "finite enstrophy", "2D vs 3D", "exp monotonicity"],
+    "prerequisites": ["gronwall_stability_2d", "Real.exp_le_exp", "mul_le_mul_of_nonneg_left"]
   },
   {
     "id": "ann-continuous-dependence",
-    "range": {
-      "startLine": 2864,
-      "endLine": 2893
-    },
-    "type": "concept",
-    "title": "Continuous Dependence: Completing Hadamard Well-Posedness",
-    "mathContext": "Given $\\varepsilon > 0$, set $\\delta = \\varepsilon \\cdot e^{-CE(0)T} > 0$. If $W(0) \\leq \\delta$, then:\n$$W(t) \\leq W(0) \\cdot e^{CE(0)T} \\leq \\delta \\cdot e^{CE(0)T} = \\varepsilon \\cdot e^{-CE(0)T} \\cdot e^{CE(0)T} = \\varepsilon.$$\n\nThe explicit formula $\\delta = \\varepsilon \\cdot e^{-CE(0)T}$ shows that:\n- Longer time horizons $T$ require closer initial data (smaller $\\delta$)\n- Higher initial enstrophy $E(0)$ also requires closer initial data\n- For fixed $T$ and $E(0)$, the dependence is continuous (not just upper semicontinuous)",
-    "significance": "key",
-    "relatedConcepts": [
-      "Hadamard well-posedness",
-      "continuous dependence",
-      "stability threshold",
-      "exponential amplification"
-    ],
-    "prerequisites": [
-      "stability_amplification_2d",
-      "Real.exp_add",
-      "mul_le_mul_of_nonneg_right"
-    ],
     "proofId": "navier-stokes-oq-02",
-    "content": "`continuous_dependence_2d` proves that for any ε > 0, the threshold δ = ε·exp(-C·E(0)·T) > 0 ensures W(0) ≤ δ implies W(t) ≤ ε for all t ∈ (0,T). The proof chains the stability amplification with the explicit choice of δ: W(t) ≤ W(0)·exp(KT) ≤ δ·exp(KT) = ε·exp(-KT)·exp(KT) = ε. Together with existence and uniqueness, this establishes all three pillars of Hadamard well-posedness."
+    "range": { "startLine": 2850, "endLine": 2888 },
+    "type": "insight",
+    "title": "Continuous Dependence: Completing Hadamard Well-Posedness",
+    "content": "`continuous_dependence_2d` completes the Hadamard triple. Given ε > 0, δ = ε·exp(-C·E(0)·T) ensures W(0) ≤ δ implies W(t) ≤ ε on (0,T). The `calc` chain uses `Real.exp_add` for cancellation and `nlinarith` for the exponent bound. The explicit δ formula reveals quantitative stability.",
+    "mathContext": "$\\forall \\varepsilon > 0$, set $\\delta = \\varepsilon e^{-CE(0)T}$. Then $W(0) \\leq \\delta \\Rightarrow W(t) \\leq \\delta e^{CE(0)T} = \\varepsilon$. Hadamard well-posedness: existence + uniqueness + continuous dependence.",
+    "significance": "key",
+    "relatedConcepts": ["Hadamard well-posedness", "continuous dependence", "quantitative estimate", "epsilon-delta"],
+    "prerequisites": ["stability_amplification_2d", "Real.exp_add", "nlinarith"]
+  },
+  {
+    "id": "ann-2d-vs-3d",
+    "proofId": "navier-stokes-oq-02",
+    "range": { "startLine": 2778, "endLine": 2784 },
+    "type": "insight",
+    "title": "The 2D vs 3D Divide: Where the Millennium Problem Lives",
+    "content": "The critical step: bounding $C \\cdot E(t) \\cdot W(t) \\leq K \\cdot W(t)$ where $K = C \\cdot E(0)$. This uses `global_enstrophy_bound` (E(t) ≤ E(0)), which holds in 2D because vortex stretching vanishes identically. In 3D, vortex stretching $\\omega \\cdot \\nabla u$ can amplify enstrophy without bound. If E(t) → ∞, the Gronwall bound becomes vacuous — this is the Millennium Prize Problem obstruction.",
+    "mathContext": "In 2D: $\\frac{d}{dt}E(t) \\leq 0$ (no vortex stretching). In 3D: $\\frac{d}{dt}E(t) = -2\\nu\\|\\nabla \\omega\\|^2 + \\int \\omega \\cdot \\nabla u \\cdot \\omega$ where the stretching term can dominate.",
+    "significance": "key",
+    "relatedConcepts": ["Millennium Prize Problem", "vortex stretching", "enstrophy blow-up", "global regularity"],
+    "prerequisites": ["global_enstrophy_bound", "3D vorticity equation"]
+  },
+  {
+    "id": "ann-integrating-factor-technique",
+    "proofId": "navier-stokes-oq-02",
+    "range": { "startLine": 2744, "endLine": 2757 },
+    "type": "technique",
+    "title": "Integrating Factor Setup: Continuity and Differentiability",
+    "content": "Technical foundation: g(u) = W(u)·exp(-K·u) must be continuous on [0,T] and differentiable on (0,T) for `antitoneOn_of_deriv_nonpos`. Continuity: `ContinuousOn.mul` of `W_cont` and exponential. Differentiability: product rule `hw'.mul hlin.exp` at each u > 0 from `stability_estimate`.",
+    "mathContext": "$g(u) = W(u) \\cdot e^{-Ku}$ needs: (1) $g \\in C([0,T])$ and (2) $g$ differentiable on $(0,T)$. Differentiability: $g'(u) = W'(u)e^{-Ku} + W(u)(-K)e^{-Ku}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["integrating factor", "ContinuousOn", "DifferentiableOn", "HasDerivAt", "product rule"],
+    "prerequisites": ["ContinuousOn.mul", "HasDerivAt.mul", "HasDerivAt.exp"]
   }
 ]

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -85,12 +85,20 @@
   },
   "sections": [
     {
+      "id": "ladyzhenskaya-derivation",
+      "title": "Ladyzhenskaya Stability Estimate Derivation",
+      "startLine": 2694,
+      "endLine": 2709,
+      "summary": "Documents the PDE derivation of the stability estimate: take the L² inner product of the difference equation with $(u_1 - u_2)$, bound the nonlinear term via the Ladyzhenskaya inequality (2D only!), and obtain $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$.",
+      "mathContext": "The Ladyzhenskaya inequality in 2D: $\\|u\\|_{L^4} \\leq C \\|u\\|_{L^2}^{1/2} \\|\\nabla u\\|_{L^2}^{1/2}$. Applied to the trilinear form: $|\\langle (u_1-u_2) \\cdot \\nabla u_1, u_1-u_2 \\rangle| \\leq C \\|\\nabla u_1\\| \\|u_1-u_2\\|^2$."
+    },
+    {
       "id": "pair-structure",
       "title": "NSSolutionPair2D: Framework for Comparing Solutions",
       "startLine": 2710,
-      "endLine": 2733,
-      "summary": "Defines the NSSolutionPair2D structure: two 2D NS solutions compared via difference energy W(t) with the Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t). This abstracts the PDE analysis into a structural hypothesis.",
-      "mathContext": "Structure fields: $W : \\mathbb{R} \\to \\mathbb{R}$ (difference energy $\\|u_1 - u_2\\|^2_{L^2}$), $E : \\mathbb{R} \\to \\mathbb{R}$ (enstrophy $\\|\\nabla u\\|^2_{L^2}$), $C > 0$ (Ladyzhenskaya constant). Key hypothesis: $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$ and $E(t) \\leq E(0)$ (bounded enstrophy, 2D-specific)."
+      "endLine": 2722,
+      "summary": "Defines the NSSolutionPair2D structure: W (difference energy), C_stab (Ladyzhenskaya constant), stability_estimate W'(t) ≤ C·E(t)·W(t). References GlobalNSSolution2D.E for enstrophy with bound E(t) ≤ E(0).",
+      "mathContext": "Structure fields: $W : \\mathbb{R} \\to \\mathbb{R}$ (difference energy $\\|u_1 - u_2\\|^2_{L^2}$), $C_{\\text{stab}} > 0$ (Ladyzhenskaya constant), stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$."
     },
     {
       "id": "gronwall-stability",
@@ -119,9 +127,9 @@
     {
       "id": "continuous-dependence",
       "title": "Continuous Dependence on Initial Data",
-      "startLine": 2864,
-      "endLine": 21110,
-      "summary": "continuous_dependence_2d: for any ε > 0, δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε on (0,T). Together with uniqueness, establishes Hadamard well-posedness.",
+      "startLine": 2850,
+      "endLine": 2891,
+      "summary": "continuous_dependence_2d: for any ε > 0, δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε on (0,T). Together with uniqueness, establishes Hadamard well-posedness. Section closes with `end GronwallStability`.",
       "mathContext": "$\\forall \\varepsilon > 0,\\, \\delta = \\varepsilon \\cdot e^{-CE(0)T}$: $W(0) \\leq \\delta \\Rightarrow W(t) \\leq \\delta \\cdot e^{CE(0)T} = \\varepsilon$ for $t \\in [0,T]$. This completes Hadamard's third criterion (continuous dependence on initial data)."
     }
   ],


### PR DESCRIPTION
## Summary
- **navier-stokes-oq-02**: Added 3 annotations, fixed sections
- **abel-ruffini**: Added cross-reference to `angle-trisection-oq-02-oq-03` (Gauss-Wantzel regular n-gon constructibility theorem)

## Changes
- `navier-stokes-oq-02/annotations.json`: +3 annotations, section fixes
- `abel-ruffini/meta.json`: +1 cross-reference (Gauss-Wantzel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)