### PR TITLE
Verify Stern-Brocot tree proof: resolve all 4 sorries (OQ-03)

### DIFF
--- a/proofs/Proofs/DenumerabilityRationalsOQ03.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ03.lean
@@ -394,41 +394,24 @@ theorem value_between_ancestors (s : State) (p : Path) (hdet : s.det = 1) :
       simp only [eval, State.left] at ih1 ih2 ⊢
       constructor
       · exact ih1
-      · -- Need: t_num * rb < ra * t_den. Chain via ih2 and det.
-        have hdet' : (↑s.la + ↑s.ra : ℤ) * ↑s.rb < ↑s.ra * (↑s.lb + ↑s.rb) := by
-          simp only [State.det] at hdet; nlinarith
-        have h_pos : (0 : ℤ) < ↑s.lb + ↑s.rb := by
-          have := lb_pos_of_det s hdet; zify at this ⊢; omega
-        have h_tpos : (0 : ℤ) < ↑(eval s.left rest).lb + ↑(eval s.left rest).rb := by
-          have h1 := lb_ge_eval s.left rest
-          have h2 := lb_pos_of_det s hdet
-          have : s.left.lb = s.lb := rfl
-          have h3 : 0 < (eval s.left rest).lb := by omega
-          positivity
-        -- Explicit chain: t_num*(lb+rb)*rb < (la+ra)*t_den*rb = (la+ra)*rb*t_den < ra*(lb+rb)*t_den
-        -- Divide by (lb+rb) > 0: t_num*rb < ra*t_den
-        -- Chain: ih2 * rb gives t_num*(lb+rb)*rb ≤ (la+ra)*t_den*rb
-        -- hdet' * t_den gives (la+ra)*rb*t_den < ra*(lb+rb)*t_den
-        -- Combined and divided by (lb+rb): t_num*rb < ra*t_den
-        -- TODO: provide nlinarith with mul_le_mul_of_nonneg_right + mul_lt_mul_of_pos_right hints
-        sorry
+      · -- Linear combination: ih1 + ih2 expanded gives tnum*rb - ra*tden < 0
+        -- Lift to ℤ (simp may have reduced to ℕ)
+        have ih1_z : (↑s.la : ℤ) *
+            (↑(eval s.left rest).lb + ↑(eval s.left rest).rb) <
+            (↑(eval s.left rest).la + ↑(eval s.left rest).ra) * ↑s.lb := by
+          exact_mod_cast ih1
+        have ih2_z : (↑(eval s.left rest).la + ↑(eval s.left rest).ra : ℤ) *
+            (↑s.lb + ↑s.rb) < (↑s.la + ↑s.ra) *
+            (↑(eval s.left rest).lb + ↑(eval s.left rest).rb) := by
+          exact_mod_cast ih2
+        nlinarith [ih1_z, ih2_z]
     | R =>
       obtain ⟨ih1, ih2⟩ := ih s.right (det_right s hdet)
       simp only [eval, State.right] at ih1 ih2 ⊢
       constructor
-      · -- Need: la * t_den < t_num * lb. Chain via ih1 and det.
-        have hdet' : (↑s.la : ℤ) * (↑s.lb + ↑s.rb) < (↑s.la + ↑s.ra) * ↑s.lb := by
-          simp only [State.det] at hdet; nlinarith
-        have h_pos : (0 : ℤ) < ↑s.lb + ↑s.rb := by
-          have := lb_pos_of_det s hdet; zify at this ⊢; omega
-        have h_tpos : (0 : ℤ) < ↑(eval s.right rest).lb + ↑(eval s.right rest).rb := by
-          have h1 := lb_ge_eval s.right rest
-          have h2 := lb_pos_of_det s hdet
-          have : s.right.lb = s.lb + s.rb := rfl
-          have h3 : 0 < (eval s.right rest).lb := by omega
-          positivity
-        -- Symmetric chain to L case
-        sorry
+      · -- ih1 (ℤ): (la+ra)*tden < tnum*(lb+rb), ih2 (ℕ): tnum*rb < ra*tden
+        -- Combined: la*tden < tnum*lb
+        zify at ih2; push_cast at ih1 ih2; nlinarith
       · exact ih2
 
 /-- eval is injective from any state with det = 1. -/
@@ -479,12 +462,10 @@ theorem eval_injective_gen (s : State) (p1 p2 : Path) (hdet : s.det = 1)
           have hL := (value_between_ancestors s.left rest1 (det_left s hdet)).2
           have hR := (value_between_ancestors s.right rest2 (det_right s hdet)).1
           simp only [State.left, State.right] at hL hR
-          -- hL: t_num_L * (lb+rb) < (la+ra) * t_den_L
-          -- hR: (la+ra) * t_den_R < t_num_R * (lb+rb)
-          -- But eval s.left rest1 = eval s.right rest2, so same state:
-          -- hL: A < B, hR: B < A' where A'=A (from h). Contradiction.
-          -- TODO: nlinarith needs congr_arg product hints
-          sorry
+          -- hL and hR give A < B and B < A after unifying via h
+          simp only [State.left, State.right] at h
+          rw [h] at hL
+          zify at hL; push_cast at hL hR; linarith
       | R =>
         cases d2 with
         | L =>
@@ -493,9 +474,10 @@ theorem eval_injective_gen (s : State) (p1 p2 : Path) (hdet : s.det = 1)
           have hR := (value_between_ancestors s.right rest1 (det_right s hdet)).1
           have hL := (value_between_ancestors s.left rest2 (det_left s hdet)).2
           simp only [State.left, State.right] at hR hL
-          -- hL: A < B, hR: B < A' where A'=A (from h). Contradiction.
-          -- TODO: nlinarith needs congr_arg product hints
-          sorry
+          -- hR and hL give A < B and B < A after unifying via h
+          simp only [State.left, State.right] at h
+          rw [h] at hR
+          zify at hL; push_cast at hL hR; linarith
         | R =>
           simp only [eval] at h
           exact congrArg (List.cons Dir.R) (ih s.right rest2 (det_right s hdet) h)

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Stern (1858), Brocot (1861)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Stern%E2%80%93Brocot_tree",
     "date": "1858",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DenumerabilityRationalsOQ03.lean",
     "tags": [
       "set-theory",
@@ -19,8 +19,8 @@
       "coprimality",
       "wiedijk-100"
     ],
-    "badge": "wip",
-    "sorries": 4,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-22",
     "prerequisites": [
@@ -58,15 +58,15 @@
       "toRat_pos: every tree node represents a positive rational",
       "7 concrete verification examples for first 3 tree levels"
     ],
-    "lineCount": 618,
-    "assumptions": "0 axioms. 4 sorries remaining (surjectivity, completeness proofs).",
+    "lineCount": 600,
+    "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "The Stern-Brocot tree was independently discovered by Moritz Abraham Stern in 1858 and Achille Brocot in 1861. Stern was a German mathematician studying number-theoretic functions; Brocot was a French clockmaker seeking optimal gear ratios for mechanical clocks. Both arrived at the same elegant structure: a binary tree containing every positive rational number exactly once, already in lowest terms.\n\nThe tree is built using the mediant operation: given fractions a/b and c/d, their mediant is (a+c)/(b+d). Starting with the 'sentinels' 0/1 and 1/0, the root is their mediant 1/1. Each node's left child is the mediant of the node with its left ancestor, and likewise for the right.\n\nThe Stern-Brocot tree has deep connections to continued fractions (the path to any rational encodes its continued fraction expansion), the Euclidean algorithm (the search path mimics gcd computation), Farey sequences (each level of the tree corresponds to a Farey-like refinement), and the Calkin-Wilf tree (a closely related structure with the same enumeration but different tree shape).\n\nGraham, Knuth, and Patashnik's 'Concrete Mathematics' (1994) popularized the tree in computer science, using it to derive properties of continued fractions and to prove the density of rationals in the reals constructively.",
     "problemStatement": "**Stern-Brocot Tree Encoding (OQ-03)**\n\nFormalize the Stern-Brocot tree as an alternative encoding of the positive rationals, proving:\n\n1. Every node is in lowest terms (coprimality)\n2. Every node represents a positive rational\n3. The tree is strictly ordered (left < root < right)\n4. The encoding is injective (different paths give different rationals)",
     "text": "Formalizes the Stern-Brocot tree, an alternative to Cantor's diagonal enumeration that lists every positive rational exactly once in lowest terms. Proves the determinant invariant, automatic coprimality of all tree nodes, positivity, mediant ordering, and injectivity (different paths yield different rationals).",
-    "proofStrategy": "**Formalization Approach**\n\nThe Lean file provides 584 lines with 30 theorems and 0 sorries:\n\n1. **State Machine:** Define navigation as a state `(la/lb, ra/rb)` tracking the left and right ancestors. The current node is the mediant `(la+ra)/(lb+rb)`.\n\n2. **Determinant Invariant:** Prove `det(s) = ra*lb - la*rb = 1` is preserved by both steps. This drives all other properties.\n\n3. **Coprimality:** From `ra*lb - la*rb = 1`, derive `gcd(la+ra, lb+rb) = 1` via Bezout.\n\n4. **Positivity:** By induction, `la + ra > 0` and `lb + rb > 0` at every reachable state.\n\n5. **BST Ordering:** `value_between_ancestors` proves that any descendant's value lies strictly between its ancestors, using cross-product inequalities and the determinant.\n\n6. **Injectivity:** `eval_injective_gen` by induction on paths: nil vs cons uses monotonicity; L vs R uses BST ordering; same direction uses IH.",
+    "proofStrategy": "**Formalization Approach**\n\nThe Lean file provides 600 lines with 30 theorems and 0 sorries:\n\n1. **State Machine:** Define navigation as a state `(la/lb, ra/rb)` tracking the left and right ancestors. The current node is the mediant `(la+ra)/(lb+rb)`.\n\n2. **Determinant Invariant:** Prove `det(s) = ra*lb - la*rb = 1` is preserved by both steps. This drives all other properties.\n\n3. **Coprimality:** From `ra*lb - la*rb = 1`, derive `gcd(la+ra, lb+rb) = 1` via Bezout.\n\n4. **Positivity:** By induction, `la + ra > 0` and `lb + rb > 0` at every reachable state.\n\n5. **BST Ordering:** `value_between_ancestors` proves that any descendant's value lies strictly between its ancestors, using cross-product inequalities and the determinant.\n\n6. **Injectivity:** `eval_injective_gen` by induction on paths: nil vs cons uses monotonicity; L vs R uses BST ordering; same direction uses IH.",
     "keyInsights": [
       "**The Determinant Invariant**: The single identity ra*lb - la*rb = 1 drives everything. From it we get coprimality (via the Bezout-like identity), ordering (via positivity of the cross-product), and ultimately completeness. This is more elegant than Cantor's pairing, which requires separate reduction to lowest terms.",
       "**State Machine vs Tree**: Representing the Stern-Brocot tree as a state machine navigated by L/R directions is more natural for formal verification than an explicit recursive tree type. The state carries exactly the information needed for proofs: the bounding ancestors.",
@@ -153,7 +153,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Stern-Brocot tree is fully formalized as a state-machine navigation system with 30 theorems in 584 lines, with 0 sorries and 0 axioms. All key properties are machine-checked: the determinant invariant (ra*lb - la*rb = 1 at all nodes), automatic coprimality, positivity, ordering, the BST ancestor-bound invariant, and injectivity (different paths yield different rationals). The formalization demonstrates that the Stern-Brocot encoding provides a mathematically richer alternative to Cantor's pairing function for enumerating the rationals.",
+    "summary": "The Stern-Brocot tree is fully formalized as a state-machine navigation system with 30 theorems in 600 lines, with 0 sorries and 0 axioms. All key properties are machine-checked: the determinant invariant (ra*lb - la*rb = 1 at all nodes), automatic coprimality, positivity, ordering, the BST ancestor-bound invariant, and injectivity (different paths yield different rationals). The formalization demonstrates that the Stern-Brocot encoding provides a mathematically richer alternative to Cantor's pairing function for enumerating the rationals.",
     "implications": "The Stern-Brocot tree connects multiple areas: number theory (continued fractions, Farey sequences), algorithms (the Euclidean algorithm), and set theory (enumerations of Q). With injectivity proved, the remaining step for a complete bijection is surjectivity.",
     "openQuestions": [
       "Prove surjectivity: every positive rational appears somewhere in the tree, via the Euclidean algorithm connection.",
@@ -169,7 +169,7 @@
     ],
     "opens": [],
     "namespace": "SternBrocot",
-    "lineCount": 618,
+    "lineCount": 600,
     "axiomCount": 0,
     "theoremCount": 30,
     "definitionCount": 12


### PR DESCRIPTION
## Summary

- Resolve all 4 remaining `sorry` goals in `DenumerabilityRationalsOQ03.lean`
- Proof now fully verified: 0 sorries, 0 axioms, 600 lines, 30 theorems
- Update gallery metadata: status formalized → verified, badge wip → verified

### Sorries resolved

1. **`value_between_ancestors` L-case (right conjunct)**: Chain ih1 + ih2 via `exact_mod_cast` + `nlinarith`
2. **`value_between_ancestors` R-case (left conjunct)**: Normalize ℕ→ℤ coercions with `zify` + `push_cast` before `nlinarith`
3. **`eval_injective_gen` L/R contradiction**: Rewrite via `h` to unify eval states, then `linarith`
4. **`eval_injective_gen` R/L contradiction**: Same rewrite + linarith approach

### Key technique

The main challenge was nlinarith/linarith not seeing through `↑(a + b)` vs `↑a + ↑b` coercion differences after `simp` expanded `State.right` to struct literals. Fix: `zify at ih2; push_cast at ih1 ih2` normalizes all cast forms before the arithmetic solver.

## Test plan

- [x] `docker-build.sh Proofs.DenumerabilityRationalsOQ03` passes (0 errors)
- [x] `grep sorry` returns no matches
- [x] meta.json updated with correct sorry count and status

🤖 Generated with [Claude Code](https://claude.com/claude-code)