### PR TITLE
Fix: erdos-1084 lineCount and section ranges

### DIFF
--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/1084",
     "axiomCount": 11,
     "assumptions": "11 axiom declarations: maxUnitDistPairs (extremal function definition), f1_exact (f_1(n)=n-1), f2_upper_erdos (Erdos 3n-c*sqrt(n) bound), harborth_exact (2D exact formula), triangular_lattice_optimal (A2 lattice achieves max), f2_trivial_upper (f_2(n)<3n), f3_leading (3D leading coefficient 6), bezdek_reid_upper (3D n^{2/3} correction), erdos_1084_d3_conjecture (3D Theta(n^{2/3}) conjecture), fd_lower_general (general lower bound), fd_upper_general (Kabatyansky-Levenshtein upper bound). f1_upper_bound and f1_achievable are now fully proved.",
-    "lineCount": 365,
+    "lineCount": 368,
     "badge": "axiom",
     "mathlib_version": "4.26.0"
   },
@@ -29,71 +29,47 @@
       "id": "imports",
       "title": "Imports and Setup",
       "startLine": 32,
-      "endLine": 38,
+      "endLine": 41,
       "summary": "Imports from Mathlib: `InnerProductSpace.Basic` for the Euclidean metric on $\\mathbb{R}^d$, `Data.Real.Sqrt` for $\\sqrt{12n-3}$ in Harborth's formula, and general tactics.",
       "mathContext": "Imports: `InnerProductSpace` for $\\|x - y\\|$, `Real.sqrt` for Harborth's $\\lfloor 3n - \\sqrt{12n-3} \\rfloor$."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 39,
-      "endLine": 61,
+      "startLine": 42,
+      "endLine": 59,
       "summary": "Defines `SeparatedConfig d n` (points in $\\mathbb{R}^d$ with pairwise distance $\\ge 1$), `unitDistPairs` (edge count of unit-distance graph), and $f_d(n) = \\max$ unit pairs over all configurations.",
       "mathContext": "$f_d(n) = \\max \\{|\\{(i,j): \\|p_i - p_j\\| = 1\\}| : \\|p_i - p_j\\| \\geq 1\\}$ over $n$-point configs in $\\mathbb{R}^d$."
     },
     {
-      "id": "one-dimensional-setup",
-      "title": "1D Configuration and Helpers",
-      "startLine": 62,
-      "endLine": 78,
-      "summary": "Specialized `SeparatedConfig1D` using $\\mathbb{R}$ directly with $|x - y| \\ge 1$, avoiding the overhead of `EuclideanSpace ℝ (Fin 1)`. Enables direct absolute value case analysis.",
-      "mathContext": "1D specialization: $|x_i - x_j| \\geq 1$ for $i \\neq j$, using $\\mathbb{R}$ directly."
-    },
-    {
-      "id": "triangle-lemma",
-      "title": "1D Triangle Lemma (Proved)",
-      "startLine": 79,
-      "endLine": 99,
-      "summary": "**Machine-verified**: If $|x-y| = |x-z| = 1$ and $|y-z| \\ge 1$, then $|y-z| = 2$. Unit neighbors of $x$ must be on opposite sides. Proof by 4-case analysis on signs of $x-y$ and $x-z$, using `abs_eq` and `linarith`.",
-      "mathContext": "Proved: $|x-y| = |x-z| = 1 \\wedge |y-z| \\geq 1 \\Rightarrow |y-z| = 2$. I.e., $y = x-1, z = x+1$ or vice versa."
-    },
-    {
-      "id": "degree-bound",
-      "title": "1D Degree Bound (Proved)",
-      "startLine": 100,
-      "endLine": 135,
-      "summary": "**Machine-verified**: A point in $\\mathbb{R}$ cannot have 3 unit neighbors among separated points. Exhausts all $2^3 = 8$ sign combinations; in each case, pigeonhole forces two neighbors equal, contradicting separation $\\ge 1$.",
-      "mathContext": "Proved: $\\deg(x) \\leq 2$ in the unit-distance graph. Exhaustive $2^3 = 8$ case analysis."
-    },
-    {
-      "id": "one-dimensional-exact",
-      "title": "1D Exact Result: $f_1(n) = n-1$",
-      "startLine": 136,
-      "endLine": 150,
-      "summary": "Upper bound: unit-distance graph is a forest ($\\le n-1$ edges). Achievability: $\\{0, 1, \\ldots, n-1\\}$ gives $n-1$ unit pairs. Combined: $f_1(n) = n-1$.",
-      "mathContext": "$f_1(n) = n - 1$. Upper: max degree 2 gives forest ($\\leq n-1$ edges). Lower: $\\{0,1,\\ldots,n-1\\}$."
+      "id": "one-dimensional",
+      "title": "One-Dimensional Case: $f_1(n) = n-1$ (Machine-Verified)",
+      "startLine": 60,
+      "endLine": 317,
+      "summary": "Specialized `SeparatedConfig1D` in $\\mathbb{R}$. **Machine-verified**: triangle lemma ($|x-y|=|x-z|=1, |y-z|\\ge 1 \\Rightarrow |y-z|=2$), degree bound ($\\deg \\le 2$), upper bound ($\\le n-1$), and achievability ($\\{0,\\ldots,n-1\\}$ gives $n-1$ pairs via explicit injection).",
+      "mathContext": "Proved: $f_1(n) = n - 1$. Triangle lemma, degree $\\leq 2$, forest bound, and constructive achievability via consecutive integers."
     },
     {
       "id": "two-dimensional",
       "title": "Two-Dimensional Case",
-      "startLine": 151,
-      "endLine": 170,
+      "startLine": 318,
+      "endLine": 337,
       "summary": "Erdős's bound $f_2(n) < 3n - c\\sqrt{n}$, Harborth's exact formula $f_2(n) = \\lfloor 3n - \\sqrt{12n-3} \\rfloor$ (1974), triangular lattice optimality, and the trivial bound $f_2(n) < 3n$ from kissing number $\\tau(2) = 6$.",
       "mathContext": "$f_2(n) = \\lfloor 3n - \\sqrt{12n-3} \\rfloor$ (Harborth 1974). Trivial: $f_2(n) \\leq \\tau(2) \\cdot n/2 = 3n$."
     },
     {
       "id": "three-dimensional",
       "title": "Three-Dimensional Case",
-      "startLine": 171,
-      "endLine": 189,
+      "startLine": 338,
+      "endLine": 356,
       "summary": "Leading coefficient $f_3(n)/n \\to 6$ from $\\tau(3) = 12$, Bezdek–Reid upper bound $f_3(n) < 6n - 0.926 n^{2/3}$ (2013), and Erdős's conjecture $f_3(n) = 6n - \\Theta(n^{2/3})$ — the central open question.",
       "mathContext": "Conjecture: $f_3(n) = 6n - \\Theta(n^{2/3})$. Known: $f_3(n) < 6n - 0.926n^{2/3}$ (Bezdek-Reid 2013)."
     },
     {
       "id": "general-dimension",
       "title": "General Dimension Bounds",
-      "startLine": 190,
-      "endLine": 198,
+      "startLine": 357,
+      "endLine": 368,
       "summary": "Lower bound $f_d(n) \\ge (d - o(1))n$ from $\\mathbb{Z}^d$ lattice, upper bound $f_d(n) \\le 2^{O(d)} n$ from Kabatyansky–Levenshtein (1978). Exponential gap in $d$ remains open.",
       "mathContext": "$dn \\lesssim f_d(n) \\leq \\tau(d) \\cdot n/2 \\leq 2^{0.401d} \\cdot n$. Exponential gap in $d$."
     }


### PR DESCRIPTION
## Fix

Corrects lineCount (365 → 368) and section startLine/endLine ranges in erdos-1084 meta.json. The 1D case expanded from ~90 lines to ~258 lines with machine-verified proofs, causing all downstream section ranges to be misaligned.

## Evidence

**Before**: lineCount: 365, sections mapped to old line ranges (e.g., general-dimension: 190-198)
**After**: lineCount: 368, sections match actual file content (e.g., general-dimension: 357-368)

---
Automated fix by lean-mechanic agent.