### PR TITLE
Peer review: cauchy-schwarz-oq-03 (B+)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03/review.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03/review.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "proofId": "cauchy-schwarz-oq-03",
+  "reviewDate": "2026-03-24T13:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "B+",
+    "oneLiner": "A well-organized pedagogical formalization with a genuinely substantive Lagrange identity proof of Cauchy-Schwarz, honest Mathlib attribution, and a clean proof chain from Young to Hölder to CS.",
+    "tier": "B",
+    "tierJustification": "Three of 8 theorems are Mathlib wrappers (holder_nnreal, holder_lintegral, cauchy_schwarz_inner) and one is a pure alias (cauchy_schwarz_from_holder). But cauchy_schwarz_finite is a substantive 27-line proof via Lagrange's identity, and holder_real is an 18-line NNReal lift. The file adds genuine proof work and valuable pedagogical organization."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "cauchy_schwarz_finite, lines 100-126",
+      "finding": "The Lagrange identity proof of Cauchy-Schwarz is the file's standout contribution. At 27 lines, it is a genuinely substantive formalization: non-negativity of the double sum, (a-b)² expansion, three separate sub-sum computations via Finset.mul_sum and Finset.sum_comm, and final assembly with linarith. This is real mathematical reasoning, not a Mathlib wrapper.",
+      "recommendation": "Preserve. This proof is the file's primary original contribution and demonstrates meaningful formal reasoning."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "meta.json assumptions field",
+      "finding": "Exemplary honesty: 'Core Hölder inequality derived from Mathlib's NNReal.inner_le_Lp_mul_Lq and ENNReal.lintegral_mul_le_Lp_mul_Lq. Lagrange identity proof of Cauchy-Schwarz is independent.' This clearly separates Mathlib contributions from original work.",
+      "recommendation": "Preserve this framing as a model for other entries."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "holder_real, lines 146-163",
+      "finding": "The NNReal lift is a well-executed type-theoretic argument: packaging absolute values as NNReal, applying Hölder, casting back to ℝ, and chaining via the triangle inequality. This demonstrates a useful Lean proof pattern.",
+      "recommendation": "Preserve."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "cauchy_schwarz_from_holder, lines 130-132",
+      "finding": "The theorem name 'cauchy_schwarz_from_holder' and its docstring 'Cauchy-Schwarz is the p = q = 2 special case of Holder's inequality' claim this derives CS from Hölder. But the implementation is `cauchy_schwarz_finite s f g` — it calls the Lagrange identity proof, not the Hölder chain. The actual Hölder→CS derivation is in `cauchy_schwarz_holder_bridge` (line 208), which works on NNReal.",
+      "recommendation": "Either (a) rename to `cauchy_schwarz_finite'` with an accurate docstring, or (b) actually implement the Hölder derivation: derive the squared form from holder_nnreal at p=q=2 by squaring both sides of the square-root form."
+    },
+    {
+      "severity": "minor",
+      "category": "filler",
+      "location": "cauchy_schwarz_from_holder, lines 130-132",
+      "finding": "This is a pure alias: `cauchy_schwarz_from_holder = cauchy_schwarz_finite`. It inflates the theorem count from 7 unique theorems to 8. The docstring creates a misleading impression that two independent proofs are provided when the code is identical.",
+      "recommendation": "Either make it a genuine Hölder-based derivation or remove it and mention the connection in a comment."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "originalContributions[4]: 'Complete proof chain from Young's inequality'",
+      "finding": "Young's inequality is internal to Mathlib's NNReal.inner_le_Lp_mul_Lq — it's not proved in this file. The chain starts at holder_nnreal (which calls Mathlib), not at Young's inequality. The educational comments describe Young's derivation but the formal chain starts with Mathlib's built-in result.",
+      "recommendation": "Reframe as 'Pedagogical organization of the proof chain from Mathlib's Hölder to multiple forms of Cauchy-Schwarz.'"
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "overview.proofStrategy, Route 1 steps 1-4",
+      "finding": "The Young normalization argument (steps 1-4) is described as the proof strategy, but this derivation is internal to Mathlib — the file doesn't perform these steps. holder_nnreal is a one-liner calling Mathlib. The strategy description conflates what Mathlib does internally with what this file formalizes.",
+      "recommendation": "Add a note: 'Steps 1-4 are performed internally by Mathlib\\'s NNReal.inner_le_Lp_mul_Lq. This file uses that result and builds additional forms.'"
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "medium",
+      "target": "researcher",
+      "description": "Fix cauchy_schwarz_from_holder: either rename to cauchy_schwarz_finite' (honest alias) or implement an actual Hölder-based derivation (derive squared form from holder_nnreal at p=q=2).",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Reframe originalContributions[4]: 'Complete proof chain from Young's' should note Young's is in Mathlib. Change to 'Pedagogical organization of proof chain from Mathlib Hölder through multiple CS forms.'",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Add note to proofStrategy Route 1 clarifying that the Young normalization steps are internal to Mathlib, not performed in this file.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 7,
+    "originalityAccuracy": 8,
+    "completeness": 7,
+    "framingPrecision": 7,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 7,
+    "overall": 7.3
+  },
+
+  "suggestedBestFraming": "A pedagogical formalization connecting Hölder's inequality (via Mathlib) to Cauchy-Schwarz (via an original Lagrange identity proof), with the NNReal-to-Real lift and the explicit p=q=2 bridge demonstrating CS as a Hölder special case."
+}

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -376,6 +376,14 @@
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0
+    },
+    "cauchy-schwarz-oq-03": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-25T03:38:16Z",
+      "overallGrade": "B+",
+      "qualityScore": null,
+      "actionItems": 0,
+      "resolvedItems": 0
     }
   }
 }


### PR DESCRIPTION
## Summary

Peer review of `cauchy-schwarz-oq-03` (Hölder's Inequality as Cauchy-Schwarz Generalization).

**Grade: B+** (overall 7.3/10)

**Tier: B** — Mathlib-based formalization with genuine original work (Lagrange identity proof) and valuable pedagogical organization.

## Key Findings

- **Strengths**: Substantive 27-line Lagrange identity proof, exemplary honesty in assumptions field, well-executed NNReal lift
- **Inconsistency**: `cauchy_schwarz_from_holder` claims to derive CS from Hölder but actually calls the Lagrange identity proof
- **Precision**: "Complete proof chain from Young's" — Young's is internal to Mathlib, not proved in this file
- **Overall**: Honest, well-organized entry with real proof work

## Scores

| Dimension | Score |
|-----------|-------|
| Mathematical Substance | 7/10 |
| Originality Accuracy | 8/10 |
| Completeness | 7/10 |
| Framing Precision | 7/10 |
| Pedagogical Quality | 8/10 |
| Internal Consistency | 7/10 |

## Action Items

3 action items (1 for researcher, 2 for enricher). See review.json for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)