### PR TITLE
Prove 3 axioms across erdos-89 and erdos-193

### DIFF
--- a/proofs/Proofs/Erdos193Problem.lean
+++ b/proofs/Proofs/Erdos193Problem.lean
@@ -66,14 +66,24 @@ axiom gerver_ramsey_2d :
 
 /- ## Basic properties -/
 
-/-- Collinearity is reflexive: any point is collinear with itself. -/
+/-- Collinearity is reflexive: any point is collinear with itself.
+    Uses witnesses (0, 1): 0·(q-p) = 1·(p-p) = 0. -/
 theorem collinear_refl {d : ℕ} (p q : LatPoint d) :
     AreCollinear p q p := by
-  exact ⟨1, 0, Or.inl one_ne_zero, fun j => by ring⟩
+  exact ⟨0, 1, Or.inr one_ne_zero, fun j => by ring⟩
 
-/-- Collinearity is symmetric in the outer two points. -/
-axiom collinear_symm {d : ℕ} (p q r : LatPoint d) :
-    AreCollinear p q r → AreCollinear r q p
+/-- Collinearity is symmetric in the outer two points.
+    Given a(q-p) = b(r-p), witnesses (a, a-b) satisfy a(q-r) = (a-b)(p-r). -/
+theorem collinear_symm {d : ℕ} (p q r : LatPoint d) :
+    AreCollinear p q r → AreCollinear r q p := by
+  rintro ⟨a, b, hab, h⟩
+  refine ⟨a, a - b, ?_, fun j => ?_⟩
+  · -- a ≠ 0 ∨ a - b ≠ 0: if a = 0 then b ≠ 0 so a - b = -b ≠ 0
+    rcases ne_or_eq a 0 with ha | rfl
+    · exact Or.inl ha
+    · exact Or.inr (by simpa using hab.resolve_left (not_not.mpr rfl))
+  · -- a * (q j - r j) = (a - b) * (p j - r j) follows from a*(q_j-p_j) = b*(r_j-p_j)
+    have := h j; linarith
 
 /-- A constant walk (all points equal) trivially has collinear triples. -/
 theorem collinear_const {d : ℕ} (v : LatPoint d) :

--- a/proofs/Proofs/Erdos89Problem.lean
+++ b/proofs/Proofs/Erdos89Problem.lean
@@ -127,7 +127,17 @@ For x > 1, we have √x < x.
 Proof: √x < x ↔ x < x² (squaring, valid since both positive)
       ↔ 1 < x (dividing by x > 0) ✓
 -/
-axiom sqrt_lt_self_of_one_lt {x : ℝ} (hx : x > 1) : Real.sqrt x < x
+theorem sqrt_lt_self_of_one_lt {x : ℝ} (hx : x > 1) : Real.sqrt x < x := by
+  have h0 : (0 : ℝ) < x := by linarith
+  -- √x < x ↔ √x · 1 < √x · √x (since √x > 0), i.e., 1 < √x
+  -- And 1 < √x ↔ 1 < x (since √ is monotone and √1 = 1)
+  have h1 : 1 < Real.sqrt x := by
+    rw [show (1 : ℝ) = Real.sqrt 1 from (Real.sqrt_one).symm]
+    exact Real.sqrt_lt_sqrt (by linarith) hx
+  -- Now √x · √x = x > √x · 1 = √x
+  calc Real.sqrt x = Real.sqrt x * 1 := (mul_one _).symm
+    _ < Real.sqrt x * Real.sqrt x := by exact mul_lt_mul_of_pos_left h1 (Real.sqrt_pos.mpr h0)
+    _ = x := Real.mul_self_sqrt (le_of_lt h0)
 
 /--
 For c > 0 and n > 0 with log n > 1 (i.e., n > e), we have:
@@ -153,7 +163,10 @@ log 3 > 1, since 3 > e ≈ 2.718...
 We state this as an axiom since the numerical verification is straightforward
 but requires careful handling of exp bounds.
 -/
-axiom log_three_gt_one : Real.log 3 > 1
+theorem log_three_gt_one : Real.log 3 > 1 := by
+  -- log 3 > 1 ↔ 3 > exp 1, since log is monotone and log(exp 1) = 1
+  rw [show (1 : ℝ) = Real.log (Real.exp 1) from (Real.log_exp 1).symm]
+  exact Real.log_lt_log (Real.exp_pos 1) (by linarith [Real.exp_one_lt_d9])
 
 /--
 If the Erdős conjecture holds, then Guth-Katz follows.

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 193,
     "erdosUrl": "https://erdosproblems.com/193",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
-    "lineCount": 80,
-    "assumptions": "2 axioms: gerver_ramsey_2d, collinear_symm. See Lean source for complete statements.",
+    "axiomCount": 1,
+    "lineCount": 89,
+    "assumptions": "1 axiom: gerver_ramsey_2d (Gerver-Ramsey 2D theorem). collinear_symm now proved via CRT-style witness transformation.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -129,7 +129,7 @@
     "namespace": null,
     "lineCount": 80,
     "axiomCount": 2,
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 5
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-89/meta.json
+++ b/src/data/proofs/erdos-89/meta.json
@@ -55,9 +55,9 @@
       "Theorem showing conjecture implies Guth-Katz",
       "Historical bounds from Chung and Tardos"
     ],
-    "axiomCount": 6,
-    "lineCount": 234,
-    "assumptions": "6 axioms: guthKatz, gridUpperBound, sqrt_lt_self_of_one_lt, and 3 more. See Lean source for complete statements."
+    "axiomCount": 4,
+    "lineCount": 247,
+    "assumptions": "4 axioms: guthKatz, gridUpperBound, chung1992, tardos2004. sqrt_lt_self_of_one_lt and log_three_gt_one now proved."
   },
   "overview": {
     "historicalContext": "The distinct distances problem is one of Erdős's most famous problems in combinatorial geometry, posed in 1946. Given n points in the plane, how many distinct pairwise distances must exist?\n\nThe √n × √n integer grid has only O(n/√(log n)) distinct distances, showing this bound would be tight if true. Erdős offered $500 for a proof.\n\nAfter decades of progress (Chung 1992, Solymosi-Tóth 2001, Tardos 2004), Guth and Katz made a breakthrough in 2015, proving Ω(n/log n) distinct distances using algebraic methods. This is tantalizingly close to Erdős's conjecture, differing only by a factor of √(log n).",
@@ -147,9 +147,9 @@
       "Topology"
     ],
     "namespace": "Erdos89",
-    "lineCount": 234,
-    "axiomCount": 6,
-    "theoremCount": 2,
+    "lineCount": 247,
+    "axiomCount": 4,
+    "theoremCount": 4,
     "definitionCount": 6
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

- **erdos-193**: Proved `collinear_symm` (2→1 axioms) + fixed `collinear_refl` bug (wrong witnesses)
- **erdos-89**: Proved `sqrt_lt_self_of_one_lt` and `log_three_gt_one` (6→4 axioms)

**Net impact**: -3 axioms eliminated, +1 bug fix

### erdos-193 details
- `collinear_symm`: Given witnesses `(a,b)` for `a(q-p)=b(r-p)`, use `(a, a-b)` for `a(q-r)=(a-b)(p-r)` by linarith
- Fixed `collinear_refl`: was using `(1,0)` which requires `q=p`; corrected to `(0,1)` giving `0·(q-p) = 1·(p-p) = 0`

### erdos-89 details
- `sqrt_lt_self_of_one_lt`: `√x < x` for `x > 1` via `√x·√x = x > √x·1` since `√x > 1`
- `log_three_gt_one`: `log 3 > 1` via `log(exp 1) = 1` and `exp 1 < 2.72 < 3` (Mathlib's `exp_one_lt_d9`)

## Test plan
- [x] `docker-build.sh Proofs.Erdos193Problem` passes
- [x] `docker-build.sh Proofs.Erdos89Problem` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)