### PR TITLE
Enrich amgm-inequality: add substantiveTheoremCount

### DIFF
--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -288,6 +288,8 @@
     "lineCount": 225,
     "axiomCount": 0,
     "theoremCount": 8,
+    "substantiveTheoremCount": 3,
+    "mathlibWrappers": 5,
     "definitionCount": 0
   }
 }


### PR DESCRIPTION
Enrichment pass 2 for amgm-inequality.

Added `substantiveTheoremCount: 3` and `mathlibWrappers: 5` to the `leanFile`
section of meta.json, distinguishing the 3 substantive theorems (am_gm_two,
am_gm_two_eq_iff, product_le_mean_sq) from 5 Mathlib wrappers/aliases.

Addresses peer reviewer feedback about undifferentiated "8 theorems" count.