### PR TITLE
Enrich abel-ruffini-oq-04: add cross-ref to concrete witness

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -53,6 +53,10 @@
       {
         "id": "abel-ruffini",
         "relationship": "Extension of the base Abel-Ruffini theorem, making the internal proof chain explicit with named, independently verifiable steps"
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-01",
+        "relationship": "Child exploration providing a concrete witness: x⁵ − 4x + 2 has Galois group S₅, instantiating the abstract non-solvability chain with a specific polynomial"
       }
     ]
   },
@@ -126,6 +130,11 @@
       "targetId": "hilbert-13",
       "relationship": "related",
       "description": "Hilbert's 13th problem (1900) asked whether degree-7 polynomial roots require genuinely trivariate functions. Abel-Ruffini rules out radicals (univariate operations); Kolmogorov-Arnold (1957) resolved the continuous case, but the algebraic version remains subtle — connecting non-solvability of S₇ to questions about the minimal complexity of root expressions"
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-01",
+      "relationship": "parent",
+      "description": "Concrete witness: proves Gal(x⁵ − 4x + 2 / ℚ) ≅ S₅ via Eisenstein irreducibility, giving a specific polynomial whose roots cannot be expressed by radicals — the concrete counterpart to this file's abstract non-solvability chain"
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
- Added cross-reference to `abel-ruffini-oq-04-oq-01` (concrete quintic x⁵ − 4x + 2 with Gal ≅ S₅)
- Added `relatedProblems` entry linking to the child exploration

Connects the abstract non-solvability chain to its concrete instantiation.

## Test plan
- [x] JSON validated (node parse)
- [x] Annotation build passes for this proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)