### PR TITLE
Research: erdos-1131-oq-01 - Prove partial fraction sum and discrete cosine vanishing

### DIFF
--- a/proofs/Proofs/Erdos1131Problem.lean
+++ b/proofs/Proofs/Erdos1131Problem.lean
@@ -281,18 +281,120 @@ This is proved via the discrete Chebyshev expansion:
    (by partial fractions 1/(4j²-1) = (1/2)(1/(2j-1) - 1/(2j+1)))
 -/
 
+/-- Product-to-sum identity: 2·sin(a)·cos(b) = sin(a+b) + sin(a-b). -/
+private lemma two_sin_mul_cos (a b : ℝ) :
+    2 * Real.sin a * Real.cos b = Real.sin (a + b) + Real.sin (a - b) := by
+  rw [Real.sin_add, Real.sin_sub]; ring
+
+/-- sin(m·π) = 0 for natural numbers m. -/
+private lemma sin_nat_mul_pi (m : ℕ) : Real.sin (↑m * Real.pi) = 0 := by
+  induction m with
+  | zero => simp
+  | succ k ih =>
+    rw [Nat.cast_succ, add_mul, one_mul, Real.sin_add, ih, zero_mul, zero_add,
+        Real.sin_pi, mul_zero]
+
+/-- **Discrete cosine vanishing** at Chebyshev angles:
+∑_{k=0}^{n-1} cos(r·θ_k) = 0 for 0 < r < 2n, where θ_k = (2k+1)π/(2n).
+
+Proof by Abel summation: multiply by 2·sin(rπ/(2n)), use product-to-sum to get
+a telescoping sum that evaluates to sin(rπ) - sin(0) = 0.
+
+This is a key ingredient for discrete cosine orthogonality at Chebyshev nodes. -/
+lemma discrete_cosine_vanishing (n : ℕ) (hn : n ≥ 1) (r : ℕ) (hr : 0 < r) (hr2 : r < 2 * n) :
+    ∑ k ∈ Finset.range n,
+      Real.cos (↑r * ((2 * (↑k : ℝ) + 1) * Real.pi / (2 * ↑n))) = 0 := by
+  set α : ℝ := ↑r * Real.pi / (2 * ↑n) with hα_def
+  -- sin(α) ≠ 0 since 0 < α < π
+  have hn_pos : (0 : ℝ) < ↑n := Nat.cast_pos.mpr (by omega)
+  have hr_pos : (0 : ℝ) < ↑r := Nat.cast_pos.mpr hr
+  have hα_pos : 0 < α := div_pos (mul_pos hr_pos Real.pi_pos) (by linarith)
+  have hα_lt_pi : α < Real.pi := by
+    have h_frac : (↑r : ℝ) / (2 * ↑n) < 1 := by
+      rw [div_lt_one (show (0 : ℝ) < 2 * ↑n by linarith)]
+      exact_mod_cast hr2
+    calc α = (↑r / (2 * ↑n)) * Real.pi := by simp only [hα_def]; ring
+      _ < 1 * Real.pi := mul_lt_mul_of_pos_right h_frac Real.pi_pos
+      _ = Real.pi := one_mul _
+  have hsin_ne : Real.sin α ≠ 0 :=
+    ne_of_gt (Real.sin_pos_of_pos_of_lt_pi hα_pos hα_lt_pi)
+  -- Strategy: show 2·sin(α)·S = 0, deduce S = 0 since sin(α) ≠ 0
+  suffices h : 2 * Real.sin α *
+      ∑ k ∈ Finset.range n,
+        Real.cos (↑r * ((2 * (↑k : ℝ) + 1) * Real.pi / (2 * ↑n))) = 0 by
+    exact (mul_eq_zero.mp h).resolve_left (mul_ne_zero two_ne_zero hsin_ne)
+  rw [Finset.mul_sum]
+  -- Each term: 2·sin(α)·cos(r·(2k+1)·π/(2n)) = sin(2(k+1)α) - sin(2kα)
+  have term_eq : ∀ k ∈ Finset.range n,
+      2 * Real.sin α *
+        Real.cos (↑r * ((2 * (↑k : ℝ) + 1) * Real.pi / (2 * ↑n))) =
+      Real.sin (2 * (↑(k + 1) : ℝ) * α) - Real.sin (2 * (↑k : ℝ) * α) := by
+    intro k _
+    have harg : (↑r : ℝ) * ((2 * ↑k + 1) * Real.pi / (2 * ↑n)) = (2 * ↑k + 1) * α := by
+      simp only [hα_def]; ring
+    rw [harg, two_sin_mul_cos α ((2 * ↑k + 1) * α)]
+    have h1 : α + (2 * (↑k : ℝ) + 1) * α = 2 * (↑(k + 1) : ℝ) * α := by push_cast; ring
+    have h2 : α - (2 * (↑k : ℝ) + 1) * α = -(2 * (↑k : ℝ) * α) := by ring
+    rw [h1, h2, Real.sin_neg, sub_eq_add_neg]
+  rw [Finset.sum_congr rfl term_eq,
+      Finset.sum_range_sub (fun i => Real.sin (2 * (↑i : ℝ) * α))]
+  -- sin(0) = 0, sin(2nα) = sin(rπ) = 0
+  simp only [Nat.cast_zero, mul_zero, zero_mul, Real.sin_zero, sub_zero]
+  have h2nα : 2 * (↑n : ℝ) * α = ↑r * Real.pi := by simp only [hα_def]; field_simp
+  rw [h2nα, sin_nat_mul_pi]
+
+/-- **Telescoping partial fraction sum**: ∑_{j=0}^{m-1} 1/(4(j+1)²-1) = m/(2m+1).
+
+By partial fractions, 1/((2j+1)(2j+3)) = (1/2)(1/(2j+1) - 1/(2j+3)), and the
+sum telescopes to (1/2)(1 - 1/(2m+1)) = m/(2m+1). -/
+lemma partial_fraction_sum (m : ℕ) :
+    ∑ j ∈ Finset.range m, (1 : ℝ) / (4 * ((↑j : ℝ) + 1) ^ 2 - 1) =
+    (↑m : ℝ) / (2 * (↑m : ℝ) + 1) := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_range_succ, ih]
+    push_cast
+    have hm : (0 : ℝ) ≤ ↑m := Nat.cast_nonneg m
+    have h1 : (2 : ℝ) * ↑m + 1 ≠ 0 := by linarith
+    have h2 : (2 : ℝ) * ↑m + 3 ≠ 0 := by linarith
+    have h3 : (4 : ℝ) * ((↑m : ℝ) + 1) ^ 2 - 1 ≠ 0 := by nlinarith
+    field_simp
+    ring
+
+/-- **Trace formula**: The Chebyshev integral equals (1/n)(2n - 2·∑1/(4j²-1)).
+
+This encapsulates two deep analytical results:
+1. **Chebyshev expansion**: For Chebyshev nodes, ∑_k l_k(x)² = (1/n)(1 + 2∑_{j=1}^{n-1} T_j(x)²),
+   via discrete cosine orthogonality (see `discrete_cosine_vanishing`).
+2. **Integration formula**: ∫₋₁¹ T_j(x)² dx = 1 - 1/(4j²-1) for j ≥ 1,
+   via substitution x = cos θ and product-to-sum identities. -/
+private lemma chebyshev_integral_trace (n : ℕ) (hn : n ≥ 2) :
+    lagrangeIntegral n (chebyshevNodes n) =
+    (1 / ↑n : ℝ) * (2 * ↑n - 2 * ∑ j ∈ Finset.range (n - 1),
+      (1 : ℝ) / (4 * ((↑j : ℝ) + 1) ^ 2 - 1)) := by
+  sorry
+
 /-- The exact value of the Lagrange integral for Chebyshev nodes.
 
 I_cheb(n) = 2 - 2(n-1)/(n(2n-1)).
 
-The proof combines discrete cosine orthogonality at Chebyshev nodes with
-the integration formula for Chebyshev polynomials T_j(x)² on [-1,1].
-See the detailed proof sketch above.
--/
+Proved by combining the trace formula with the telescoping partial fraction sum.
+See the detailed proof sketch in Part III.5 above. -/
 theorem chebyshev_integral_exact (n : ℕ) (hn : n ≥ 2) :
     lagrangeIntegral n (chebyshevNodes n) =
       2 - 2 * (↑n - 1) / (↑n * (2 * ↑n - 1)) := by
-  sorry
+  rw [chebyshev_integral_trace n hn, partial_fraction_sum (n - 1)]
+  have hn_pos : (0 : ℝ) < ↑n := Nat.cast_pos.mpr (by omega)
+  have hn_ne : (↑n : ℝ) ≠ 0 := ne_of_gt hn_pos
+  have hn_ge : (2 : ℝ) ≤ ↑n := by exact_mod_cast hn
+  -- Convert ↑(n-1) to ↑n - 1
+  rw [Nat.cast_sub (show 1 ≤ n from by omega), Nat.cast_one]
+  -- Simplify denominator: 2*(↑n-1)+1 = 2*↑n-1
+  have h_den_eq : (2 : ℝ) * (↑n - 1) + 1 = 2 * ↑n - 1 := by ring
+  rw [h_den_eq]
+  have h2n1 : (2 : ℝ) * ↑n - 1 ≠ 0 := by linarith
+  field_simp
 
 /--
 For Chebyshev nodes with n ≥ 2, the Lagrange integral is strictly less than 2.

--- a/research/problems/erdos-1131-oq-01/knowledge.md
+++ b/research/problems/erdos-1131-oq-01/knowledge.md
@@ -7,9 +7,9 @@ Find the minimum of I(x₁,...,xₙ) = ∫₋₁¹ Σₖ |l_k(x)|² dx.
 Conjecture: min I = 2 - (1+o(1))/n.
 
 ## Current State
-- **File**: `proofs/Proofs/Erdos1131Problem.lean` (306 lines)
-- **Sorries**: 0
-- **Axioms**: 2 (chebyshev_integral_estimate, erdos_1131_conjecture)
+- **File**: `proofs/Proofs/Erdos1131Problem.lean` (467 lines)
+- **Sorries**: 1 (chebyshev_integral_trace — Chebyshev expansion + integration)
+- **Axioms**: 1 (erdos_1131_conjecture — OPEN, must stay)
 - **Theorems**: 9 (all fully proved)
 
 ## Session 2026-03-25 (Session 2) - Prove sorries, remove false axiom
@@ -47,3 +47,27 @@ Conjecture: min I = 2 - (1+o(1))/n.
 ### Next Steps
 - `chebyshev_integral_estimate` requires Chebyshev polynomial T_n representation of l_k and exact integral computation — substantial infrastructure needed
 - `erdos_1131_conjecture` is genuinely OPEN, stays as axiom
+
+## Session 2026-03-24 (Session 3) - Factor exact formula, prove algebraic components
+
+**Mode**: REVISIT (RICH knowledge, score 32)
+**Outcome**: progress
+
+### What I Did
+1. **Proved `partial_fraction_sum`**: ∑1/(4(j+1)²-1) = m/(2m+1) by induction
+2. **Proved `discrete_cosine_vanishing`**: ∑cos(rθ_k) = 0 via Abel summation + telescoping
+3. **Proved `chebyshev_integral_exact`** from `chebyshev_integral_trace` + `partial_fraction_sum`
+4. Added helpers: `two_sin_mul_cos`, `sin_nat_mul_pi`
+
+### Key Findings
+- `unfold_let` not valid in Lean 4.26.0 — use `simp only [hα_def]`
+- `∑ k in ...` syntax invalid — use `∑ k ∈ ...`
+- `positivity` needs explicit positivity hypotheses for Nat.cast
+- `field_simp` needs denominators pre-normalized (rewrite `2*(n-1)+1` to `2*n-1` first)
+
+### Files Modified
+- `proofs/Proofs/Erdos1131Problem.lean` (365→467 lines, +5 proved lemmas)
+
+### Next Steps
+- Prove `chebyshev_integral_trace`: needs Chebyshev expansion + ∫T_j²dx
+- `erdos_1131_conjecture` stays as axiom

--- a/src/data/research/problems/erdos-1131-oq-01.json
+++ b/src/data/research/problems/erdos-1131-oq-01.json
@@ -19,17 +19,17 @@
     "phase": "ACT",
     "since": "2026-03-25T00:00:00.000Z",
     "iteration": 3,
-    "focus": "Eliminated chebyshev_integral_estimate axiom. Proved I_cheb < 2 and asymptotic estimate from exact formula (1 sorry).",
+    "focus": "Factored chebyshev_integral_exact into algebraic + analytic parts. Proved partial_fraction_sum, discrete_cosine_vanishing, and the algebraic assembly. Sorry localized to chebyshev_integral_trace.",
     "blockers": [],
-    "nextAction": "Prove chebyshev_integral_exact via discrete cosine orthogonality and Chebyshev polynomial integration.",
+    "nextAction": "Prove chebyshev_integral_trace: needs Chebyshev expansion ∑l_k²=(1/n)(1+2∑T_j²) and integration ∫T_j²=1-1/(4j²-1).",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 1,
-      "approachesTried": 3
+      "total": 4,
+      "currentApproach": 2,
+      "approachesTried": 4
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 2→1 axioms, 0→1 sorries. Converted chebyshev_integral_estimate axiom to theorem via exact formula approach. I_cheb(n) = 2 - 2(n-1)/(n(2n-1)) < 2.",
+    "progressSummary": "PROGRESS: Factored exact formula proof. partial_fraction_sum + discrete_cosine_vanishing PROVED. chebyshev_integral_exact proved from trace formula. Sorry now on chebyshev_integral_trace only.",
     "builtItems": [
       "lagrangeBasis_self: Finset.prod_eq_one + div_self (product of 1s)",
       "lagrangeBasis_other: Finset.prod_eq_zero + sub_self (zero factor)",
@@ -40,7 +40,12 @@
       "partition_of_unity: sum_k l_k(x) = 1 for all x (via Lagrange.sum_basis)",
       "sum_sq_lagrangeBasis_ge: ∑l_k² ≥ 1/n via variance identity (PROVED, 0 sorry)",
       "lagrangeIntegral_lower_bound: I ≥ 2/n via integral monotonicity (PROVED, 0 sorry)",
-      "chebyshev_integral_exact: I_cheb = 2 - 2(n-1)/(n(2n-1)) (1 sorry - exact formula)",
+      "two_sin_mul_cos: product-to-sum 2sin(a)cos(b) = sin(a+b)+sin(a-b) (PROVED)",
+      "sin_nat_mul_pi: sin(m*π) = 0 for ℕ (PROVED by induction)",
+      "discrete_cosine_vanishing: ∑cos(rθ_k) = 0 via Abel summation (PROVED)",
+      "partial_fraction_sum: ∑1/(4(j+1)²-1) = m/(2m+1) (PROVED by induction)",
+      "chebyshev_integral_trace: I = (1/n)(2n - 2∑1/(4j²-1)) (sorry - Chebyshev expansion + integration)",
+      "chebyshev_integral_exact: I_cheb = 2 - 2(n-1)/(n(2n-1)) (PROVED from trace + partial_fraction)",
       "chebyshev_integral_lt_two: I_cheb < 2 (PROVED from exact formula)",
       "chebyshev_integral_estimate: ∃c>0, |I-(2-c/n)|≤c/n² (PROVED, was axiom)"
     ],
@@ -61,12 +66,10 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove chebyshev_integral_exact: key sorry. Five sub-steps needed:",
-      "  1. Cosine sum vanishing: ∑_k cos(rθ_k)=0 via telescoping + Finset.sum_range_sub",
-      "  2. Discrete cosine orthogonality: ∑_k cos(jθ_k)cos(mθ_k) = (n/2)δ_{jm}",
-      "  3. Chebyshev expansion: l_k(x) = (1/n)[1+2∑cos(jθ_k)T_j(x)] (polynomial uniqueness)",
-      "  4. Integration: ∫₋₁¹ T_j²dx = 1-1/(4j²-1) (substitution x=cosθ + trig identities)",
-      "  5. Telescoping: ∑1/(4j²-1) = (n-1)/(2n-1) (partial fractions)",
+      "Prove chebyshev_integral_trace (remaining sorry). Two sub-results needed:",
+      "  1. Chebyshev expansion: ∑l_k(x)² = (1/n)(1+2∑T_j(x)²) — needs discrete cosine orthogonality + polynomial expansion",
+      "  2. Integration: ∫₋₁¹ T_j(x)² dx = 1-1/(4j²-1) — needs substitution x=cosθ + product-to-sum",
+      "discrete_cosine_vanishing (PROVED) provides foundation for step 1",
       "The open conjecture erdos_1131_conjecture correctly remains as axiom"
     ]
   },
@@ -97,8 +100,8 @@
     {
       "path": "Proofs/Erdos1131Problem.lean",
       "filename": "Erdos1131Problem.lean",
-      "lineCount": 365,
-      "theoremCount": 12,
+      "lineCount": 467,
+      "theoremCount": 16,
       "axiomCount": 1,
       "defCount": 6,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary
- Prove `partial_fraction_sum`: ∑1/(4(j+1)²-1) = m/(2m+1) by induction with `field_simp; ring`
- Prove `discrete_cosine_vanishing`: ∑cos(rθ_k) = 0 via Abel summation and `Finset.sum_range_sub` telescoping
- Factor `chebyshev_integral_exact` proof: now proved algebraically from `chebyshev_integral_trace` + `partial_fraction_sum`
- Add helper lemmas: `two_sin_mul_cos` (product-to-sum), `sin_nat_mul_pi` (sin(mπ)=0)
- Sorry relocated from `chebyshev_integral_exact` to `chebyshev_integral_trace` (Chebyshev expansion + integration of T_j²)

## File changes
- `proofs/Proofs/Erdos1131Problem.lean`: 365→467 lines, +5 proved lemmas, sorry localized

## Test plan
- [x] Docker build passes with only expected sorry warning on `chebyshev_integral_trace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)