### PR TITLE
Enrich batch: 9 Erdős entries (pass 2)

### DIFF
--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -103,7 +103,7 @@
       "summary": "Defines IsMonic (leading coefficient = 1), roots (zero set of polynomial evaluation), RootsBoundedBy (all roots in |z| ≤ r), and the BoundedMonicPoly structure bundling polynomial, monicity, root bound, and nontriviality (degree ≥ 1)",
       "startLine": 28,
       "endLine": 51,
-      "mathContext": "Defines IsMonic (leading coefficient = 1), roots (zero set of polynomial evaluation), RootsBoundedBy (all roots in |z| ≤ r), and the BoundedMonicPoly structure bundling polynomial, monicity, root boun"
+      "mathContext": "$\\text{IsMonic}(f) :\\equiv f.\\text{leadingCoeff} = 1$; $\\text{roots}(f) = \\{z \\in \\mathbb{C} : f(z) = 0\\}$; $\\text{RootsBoundedBy}(f, r) :\\equiv \\forall z \\in \\text{roots}(f),\\, |z| \\leq r$. The `BoundedMonicPoly` structure bundles $(f, \\text{monic}, \\text{bounded}, \\deg f \\geq 1)$."
     },
     {
       "id": "lemniscates",
@@ -111,7 +111,7 @@
       "summary": "Defines lemniscate f c as the open sublevel set {z : |f(z)| < c}, introduces notation L(f,c), defines unitLemniscate for c = 1, and proves lemniscate_isOpen (via continuity of |f(·)|) and lemniscate_bounded (monic polynomials grow at infinity)",
       "startLine": 52,
       "endLine": 77,
-      "mathContext": "Defines lemniscate f c as the open sublevel set {z : |f(z)| < c}, introduces notation L(f,c), defines unitLemniscate for c = 1, and proves lemniscate_isOpen (via continuity of |f(·)|) and lemniscate_b"
+      "mathContext": "$L(f, c) = \\{z \\in \\mathbb{C} : |f(z)| < c\\}$. `lemniscate_isOpen`: $L(f, c)$ is open (preimage of $(-\\infty, c)$ under $|f(\\cdot)|$). `lemniscate_bounded`: $L(f, c)$ is bounded when $f$ is monic ($|f(z)| \\sim |z|^n \\to \\infty$)."
     },
     {
       "id": "components",
@@ -119,7 +119,7 @@
       "summary": "Defines ConnectedComponent S z as the union of all connected subsets of S containing z, diameter S as the supremum of pairwise distances, and maxComponentDiameter f c as the supremum over all component diameters in the lemniscate",
       "startLine": 78,
       "endLine": 95,
-      "mathContext": "Defines ConnectedComponent S z as the union of all connected subsets of S containing z, diameter S as the supremum of pairwise distances, and maxComponentDiameter f c as the supremum over all componen"
+      "mathContext": "$\\text{ConnectedComponent}(S, z) = \\bigcup \\{C : C \\text{ connected}, z \\in C \\subseteq S\\}$; $\\text{diam}(S) = \\sup\\{d(z,w) : z, w \\in S\\}$; $\\text{maxComponentDiam}(f, c) = \\sup_z \\text{diam}(\\text{CC}(L(f,c), z))$."
     },
     {
       "id": "conjecture",
@@ -127,7 +127,7 @@
       "summary": "States EHPConjecture: for all r < 2 and all BoundedMonicPoly r, the maxComponentDiameter exceeds 2 − r. This is the precise formalization of the 1958 question from the Journal d'Analyse Mathématique",
       "startLine": 96,
       "endLine": 108,
-      "mathContext": "States EHPConjecture: for all r < 2 and all BoundedMonicPoly r, the maxComponentDiameter exceeds 2 − r. This is the precise formalization of the 1958 question from the Journal d'Analyse Mathématique"
+      "mathContext": "$\\text{EHPConjecture} :\\equiv \\forall r < 2,\\, \\forall f \\in \\text{BoundedMonicPoly}(r),\\, \\text{maxComponentDiam}(f, 1) > 2 - r$."
     },
     {
       "id": "counterexample",
@@ -135,7 +135,7 @@
       "summary": "Constructs pommerenkeCounterexample r n = X^n − C(r^n), proves counterexample_monic and counterexample_bounded, describes roots as r times nth roots of unity, axiomatizes n-component decomposition and diameter vanishing (pommerenke_diameter_vanishes), and derives EHP_false_for_r_gt_1 : ¬ EHPConjecture",
       "startLine": 109,
       "endLine": 148,
-      "mathContext": "Constructs pommerenkeCounterexample r n = X^n − C(r^n), proves counterexample_monic and counterexample_bounded, describes roots as r times nth roots of unity, axiomatizes n-component decomposition and"
+      "mathContext": "$f(z) = z^n - r^n$ with roots $r \\cdot e^{2\\pi i k/n}$ ($k = 0,\\ldots,n-1$), all on $|z| = r$. For $r > 1$: $\\text{maxComponentDiam}(f, 1) \\to 0$ as $n \\to \\infty$, disproving EHPConjecture."
     },
     {
       "id": "positive",
@@ -143,7 +143,7 @@
       "summary": "Defines φ_minus_1 = (√5 − 1)/2 with numerical bounds, then axiomatizes three diameter guarantees for the component containing the origin: pommerenke_case_small_r (r ≤ 1/2 ⇒ diam ≥ 2), pommerenke_case_medium_r (1/2 < r ≤ φ−1 ⇒ diam > 1/r), pommerenke_case_large_r (φ−1 ≤ r ≤ 1 ⇒ diam > 2 − r²)",
       "startLine": 149,
       "endLine": 176,
-      "mathContext": "Defines φ_minus_1 = (√5 − 1)/2 with numerical bounds, then axiomatizes three diameter guarantees for the component containing the origin: pommerenke_case_small_r (r ≤ 1/2 ⇒ diam ≥ 2), pommerenke_case_"
+      "mathContext": "$\\varphi - 1 = (\\sqrt{5}-1)/2 \\approx 0.618$. Three regimes: (i) $r \\leq 1/2 \\Rightarrow \\text{diam} \\geq 2$; (ii) $1/2 < r \\leq \\varphi-1 \\Rightarrow \\text{diam} > 1/r$; (iii) $\\varphi-1 \\leq r \\leq 1 \\Rightarrow \\text{diam} > 2 - r^2$."
     },
     {
       "id": "optimal",
@@ -151,7 +151,7 @@
       "summary": "Proves zn_diameter (z^n has unit lemniscate diameter exactly 2) and diameter_2_sharp (for r = 0 the bound diam ≥ 2 is tight), axiomatizes diameter_near_1_for_r_eq_1 (for r = 1 one can achieve max diameter < 1 + ε), demonstrating optimality of the positive results",
       "startLine": 177,
       "endLine": 197,
-      "mathContext": "Proves zn_diameter (z^n has unit lemniscate diameter exactly 2) and diameter_2_sharp (for r = 0 the bound diam ≥ 2 is tight), axiomatizes diameter_near_1_for_r_eq_1 (for r = 1 one can achieve max diam"
+      "mathContext": "$\\text{diam}(L(z^n, 1)) = 2$ (the unit disc). For $r = 0$: $\\inf_f \\text{maxComponentDiam}(f, 1) = 2$. For $r = 1$: $\\inf_f \\text{maxComponentDiam}(f, 1) < 1 + \\varepsilon$ for any $\\varepsilon > 0$."
     },
     {
       "id": "degree",
@@ -159,7 +159,7 @@
       "summary": "Axiomatizes component_count_bound (degree-n polynomial lemniscate has at most n connected components) and proves exterior_unbounded (the complement {|f(z)| ≥ c} is unbounded for c above the leading coefficient, since monic polynomials grow without bound)",
       "startLine": 198,
       "endLine": 213,
-      "mathContext": "Axiomatizes component_count_bound (degree-n polynomial lemniscate has at most n connected components) and proves exterior_unbounded (the complement {|f(z)| ≥ c} is unbounded for c above the leading co"
+      "mathContext": "A degree-$n$ monic polynomial lemniscate has $\\leq n$ connected components. The complement $\\{z : |f(z)| \\geq c\\}$ is unbounded since $|f(z)| \\to \\infty$ as $|z| \\to \\infty$."
     },
     {
       "id": "capacity",
@@ -167,7 +167,7 @@
       "summary": "Axiomatizes logCapacity (logarithmic capacity of a compact set), the fundamental formula lemniscate_capacity (cap(L(f,c)) = c^{1/n} for degree-n monic f), and capacity_diameter_inequality (diam(S) ≥ 4·cap(S) for connected S), linking the geometric diameter bounds to potential-theoretic invariants",
       "startLine": 214,
       "endLine": 230,
-      "mathContext": "Axiomatizes logCapacity (logarithmic capacity of a compact set), the fundamental formula lemniscate_capacity (cap(L(f,c)) = c^{1/n} for degree-n monic f), and capacity_diameter_inequality (diam(S) ≥ 4"
+      "mathContext": "$\\text{cap}(L(f, c)) = c^{1/n}$ for degree-$n$ monic $f$. Capacity-diameter inequality: $\\text{diam}(S) \\geq 4 \\cdot \\text{cap}(S)$ for connected compact $S \\subset \\mathbb{C}$."
     },
     {
       "id": "summary",
@@ -175,7 +175,7 @@
       "summary": "Unifies the disproof via erdos_1048 : ¬ EHPConjecture (reducing to EHP_false_for_r_gt_1), defines erdos_1048_answer and erdos_1048_status strings, and proves pommerenke_insight: for any r > 1 and any δ > 0, there exists a monic polynomial with all roots on |z| = r whose lemniscate components all have diameter < δ",
       "startLine": 231,
       "endLine": 273,
-      "mathContext": "Unifies the disproof via erdos_1048 : ¬ EHPConjecture (reducing to EHP_false_for_r_gt_1), defines erdos_1048_answer and erdos_1048_status strings, and proves pommerenke_insight: for any r > 1 and any "
+      "mathContext": "$\\neg\\,\\text{EHPConjecture}$ via `EHP_false_for_r_gt_1`. Pommerenke's insight: $\\forall r > 1,\\, \\forall \\delta > 0,\\, \\exists f$ monic with roots on $|z| = r$ such that all component diameters $< \\delta$."
     }
   ],
   "conclusion": {
@@ -245,6 +245,8 @@
     "lineCount": 273,
     "axiomCount": 10,
     "theoremCount": 12,
+    "substantiveTheoremCount": 2,
+    "sorryTheorems": 10,
     "definitionCount": 13
   },
   "references": [
@@ -257,6 +259,16 @@
       "key": "Po61",
       "citation": "Pommerenke, Ch. (1961). On the derivative of a polynomial. Michigan Math. J., 8:23-27.",
       "type": "paper"
+    },
+    {
+      "key": "Ra95",
+      "citation": "Ransford, T. (1995). Potential Theory in the Complex Plane. Cambridge University Press.",
+      "type": "book"
+    },
+    {
+      "key": "WW02",
+      "citation": "Walsh, J.L. (1935, reprinted 2002). Interpolation and Approximation by Rational Functions in the Complex Domain. AMS Colloquium Publications, vol. 20.",
+      "type": "book"
     }
   ]
 }

--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -23,7 +23,7 @@
     "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos1053Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 140
+    "lineCount": 152
   },
   "sections": [
     {
@@ -171,14 +171,25 @@
       "venue": "Journal für die reine und angewandte Mathematik, 197, 82–96",
       "note": "Derives structural necessary conditions for multiply perfect numbers using prime factorization constraints, providing the best unconditional bounds on k available without RH."
     },
-    "Erdős: original question",
-    "Guy: Unsolved Problems in Number Theory, B2",
-    "Gronwall (1913): lim sup σ(n)/(n log log n) = e^γ",
-    "Robin (1984): σ(n) < e^γ · n · log log n (conditional on RH)",
-    "Ramanujan (1915): Highly composite numbers (extensive study of σ(n)/n extremes)",
-    "Alaoglu–Erdős (1944): Structure of colossally abundant numbers",
-    "OEIS A007539: k-perfect numbers",
-    "https://erdosproblems.com/1053"
+    {
+      "authors": "Ramanujan, S.",
+      "title": "Highly composite numbers",
+      "year": "1915",
+      "venue": "Proceedings of the London Mathematical Society, 2(14), 347–409",
+      "note": "Extensive study of the extremal behavior of σ(n)/n, introducing highly composite numbers and establishing foundational results on the distribution of divisor sums."
+    }
   ],
-  "leanFile": "Proofs/Erdos1053Problem.lean"
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 152,
+    "axiomCount": 6,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 2,
+    "computationalVerifications": 2,
+    "definitionCount": 4
+  }
 }

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -100,7 +100,7 @@
       "summary": "Problem statement, references (Guy [Gu04] Problem A2, OEIS A064152, erdosproblems.com), and Mathlib imports for primes, factorials, sets, and finite sets.",
       "startLine": 1,
       "endLine": 23,
-      "mathContext": "Imports `Nat.Prime` (primality predicate), `Nat.factorial` (factorial function and monotonicity lemmas), `Set.Infinite` (infinitary conjecture statement), `Finset` (finite set operations for `interval_cases`), and `Mathlib.Tactic` (for `decide`, `interval_cases`, `omega`, `push_neg`)."
+      "mathContext": "Dependencies: $\\text{Nat.Prime}$ (primality), $n! = \\text{Nat.factorial}(n)$, $\\text{Set.Infinite}$ for the conjecture $|\\{p \\text{ prime} : \\forall k \\geq 2,\\, p - k! \\text{ composite}\\}| = \\infty$."
     },
     {
       "id": "core-definitions",
@@ -226,6 +226,8 @@
     "structureCount": 0,
     "axiomCount": 1,
     "theoremCount": 7,
+    "substantiveTheoremCount": 3,
+    "computationalVerifications": 4,
     "lemmaCount": 0,
     "defCount": 1,
     "imports": [

--- a/src/data/proofs/erdos-106/meta.json
+++ b/src/data/proofs/erdos-106/meta.json
@@ -53,7 +53,7 @@
       "startLine": 1,
       "endLine": 37,
       "summary": "Module docstring documenting the problem statement, background, and references; single `import Mathlib` for full Mathlib access; `open` declarations (Set Real)",
-      "mathContext": "Draw n squares inside the unit square with no common interior point. Let f(n) be the maximum possible sum of the side-lengths. Is f(k²+1) = k?"
+      "mathContext": "Pack $n$ axis-aligned squares in $[0,1]^2$ with disjoint interiors. $f(n) = \\max \\sum_{i=1}^n s_i$. Conjecture: $f(k^2 + 1) = k$ for all $k \\geq 1$."
     },
     {
       "id": "squares",
@@ -252,6 +252,8 @@
     "lineCount": 233,
     "axiomCount": 13,
     "theoremCount": 5,
+    "substantiveTheoremCount": 2,
+    "sorryTheorems": 3,
     "definitionCount": 12
   }
 }

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -74,7 +74,7 @@
       "startLine": 1,
       "endLine": 5,
       "summary": "Imports Mathlib's prime number basics, finite set infrastructure, natural number foundations, and tactic framework.",
-      "mathContext": "Uses `Nat.Prime`, `Set.Infinite`, `Set.Finite`, `Finset`, and decision procedures (`decide`, `norm_num`) from Mathlib."
+      "mathContext": "Dependencies: $\\text{Nat.Prime}$, $\\text{Set.Infinite}$, $\\text{Set.Finite}$, $\\text{Finset}$ from Mathlib. Decision procedures `decide` and `norm_num` verify small-case arithmetic."
     },
     {
       "id": "module-doc",
@@ -233,6 +233,8 @@
     "structureCount": 0,
     "axiomCount": 2,
     "theoremCount": 28,
+    "substantiveTheoremCount": 4,
+    "computationalVerifications": 24,
     "lemmaCount": 0,
     "defCount": 3,
     "imports": [

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/1084",
     "axiomCount": 11,
     "assumptions": "11 axiom declarations: maxUnitDistPairs (extremal function definition), f1_exact (f_1(n)=n-1), f2_upper_erdos (Erdos 3n-c*sqrt(n) bound), harborth_exact (2D exact formula), triangular_lattice_optimal (A2 lattice achieves max), f2_trivial_upper (f_2(n)<3n), f3_leading (3D leading coefficient 6), bezdek_reid_upper (3D n^{2/3} correction), erdos_1084_d3_conjecture (3D Theta(n^{2/3}) conjecture), fd_lower_general (general lower bound), fd_upper_general (Kabatyansky-Levenshtein upper bound). f1_upper_bound and f1_achievable are now fully proved.",
-    "lineCount": 365,
+    "lineCount": 368,
     "badge": "axiom",
     "mathlib_version": "4.26.0"
   },
@@ -181,9 +181,11 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 264,
+    "lineCount": 368,
     "axiomCount": 12,
     "theoremCount": 3,
+    "substantiveTheoremCount": 0,
+    "sorryTheorems": 3,
     "definitionCount": 2
   }
 }

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -245,6 +245,8 @@
     "structureCount": 0,
     "axiomCount": 10,
     "theoremCount": 5,
+    "substantiveTheoremCount": 1,
+    "sorryTheorems": 4,
     "lemmaCount": 1,
     "defCount": 11,
     "imports": [


### PR DESCRIPTION
## Summary
Enrichment pass 2 for nine gallery entries. Common improvements across all:
- Adding `substantiveTheoremCount` to `leanFile` for theorem classification
- Fixing truncated/non-LaTeX `mathContext` fields in sections
- Fixing incorrect `lineCount` values
- Converting `leanFile` from string to structured object where needed
- Cleaning up duplicate/mixed-type references

### Per-entry changes

| Entry | Key Improvements |
|-------|-----------------|
| **erdos-1048** | Fixed 10 truncated section mathContext with LaTeX; added 2 references |
| **erdos-1053** | Converted leanFile string→object; fixed lineCount 140→152; cleaned refs |
| **erdos-1059** | Fixed header mathContext; added theorem classification |
| **erdos-106** | Fixed header mathContext; added theorem classification |
| **erdos-1065** | Fixed imports mathContext; added theorem classification |
| **erdos-1084** | Fixed lineCount 365/264→368; added theorem classification |
| **erdos-1089** | Added theorem classification (1 proved, 4 sorry) |
| **erdos-1097** | Added theorem classification (14 substantive) |
| **erdos-1108** | Fixed 9 terse section mathContexts with LaTeX; added theorem classification |