### PR TITLE
Enrich erdos-273: add moduli_even and verification annotations

### DIFF
--- a/src/data/proofs/erdos-273/annotations.json
+++ b/src/data/proofs/erdos-273/annotations.json
@@ -240,6 +240,36 @@
     ]
   },
   {
+    "id": "ann-e273-moduli-even",
+    "proofId": "erdos-273",
+    "range": {
+      "startLine": 126,
+      "endLine": 136
+    },
+    "type": "technique",
+    "title": "All Moduli in p≥5 Systems Are Even (Proved)",
+    "content": "Proves `moduli_even`: every modulus in a covering system with all moduli of the form $p-1$ ($p \\geq 5$ prime) is even. The proof: $p \\geq 5$ and $p$ prime implies $p$ is odd (using `Nat.Prime.eq_two_or_odd` — if $p = 2$ then $p \\geq 5$ gives contradiction). Then $p - 1 = m_i$ is even since $p$ odd and 1 odd gives even difference (`Nat.Odd.sub_odd`). This structural constraint means modulus 2 is never available, making coverage of both parities fundamentally harder — the densest single class covers only $1/4$ of integers.",
+    "mathContext": "$p \\geq 5$ prime $\\Rightarrow$ $p$ odd $\\Rightarrow$ $p - 1$ even. All moduli $m_i \\in \\{4, 6, 10, 12, 16, 18, \\ldots\\}$ are even. Without modulus 2, covering all integers requires at least 4 classes (since $1/4$ is the maximum density of any single class).",
+    "significance": "key",
+    "relatedConcepts": ["parity of primes", "Nat.Prime.eq_two_or_odd", "Nat.Odd.sub_odd", "structural parity constraint"],
+    "prerequisites": ["AllModuliPrimeMinusOne", "Nat.Prime", "Even predicate"]
+  },
+  {
+    "id": "ann-e273-verification",
+    "proofId": "erdos-273",
+    "range": {
+      "startLine": 142,
+      "endLine": 182
+    },
+    "type": "technique",
+    "title": "Computational Verification of Easy Primes and Density Bound",
+    "content": "Five `decide` and `norm_num` proofs verifying properties of the concrete modulus set $\\{4, 6, 12, 18, 36, 60, 180\\}$. `easyPrimes_all_prime`: all 7 elements are prime. `easyPrimes_ge_five`: all are $\\geq 5$. `easyPrimes_mod_divides_360`: each $p-1$ divides 360. These are checked by `decide` (kernel computation). Then `max_single_density` proves that no single residue class with modulus $p-1$ ($p \\geq 5$) can cover more than $1/4$ of integers, since $1/(p-1) \\leq 1/4$ when $p \\geq 5$. The proof uses `div_le_div_iff` and `linarith`. Together these establish the quantitative constraints on covering with prime-minus-one moduli.",
+    "mathContext": "Verified: $\\{5,7,13,19,37,61,181\\}$ are all primes $\\geq 5$ with $(p-1) \\mid 360$. Density bound: $\\forall p \\geq 5$ prime, $1/(p-1) \\leq 1/4$. Equality at $p = 5$: modulus 4 gives the densest class. At least $\\lceil 1/(1/4) \\rceil = 4$ classes needed to cover all integers.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide tactic", "norm_num", "computational verification", "density upper bound", "div_le_div_iff"],
+    "prerequisites": ["easyPrimes", "Nat.Prime", "rational inequality"]
+  },
+  {
     "id": "ann-e273-reciprocal",
     "proofId": "erdos-273",
     "range": {


### PR DESCRIPTION
## Summary
- Added 2 annotations for erdos-273 covering lines 126-182 (moduli_even theorem, verification block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)