### PR TITLE
Fix Aristotle recovery pipeline and integrate solved proof

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ03Aristotle.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ03Aristotle.lean
@@ -21,71 +21,81 @@ noncomputable section
 
 namespace IsoperimetricOQAristotle
 
-/-- Parseval identity for periodic real functions on [0, 2π].
+/-
+PROBLEM
+The complex-valued function ofReal ∘ f is MemLp 2 on Ioc 0 (2π) when f is C¹.
 
-    For a C¹ periodic function f : ℝ → ℝ, the integral of f² over [0, 2π]
-    equals 2π times the sum of squared norms of its complex Fourier
-    coefficients (computed via fourierCoeffOn on [0, 2π]).
+PROVIDED SOLUTION
+Since f is C¹, it is continuous. Then ofReal ∘ f is continuous (composition of continuous functions). A continuous function on any interval is in Lp for any p, because Ioc 0 (2π) has finite measure. Use Continuous.memLp_restrict or memLp_of_bounded_continuous or similar.
+-/
+lemma memLp_ofReal_comp_of_contDiff (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f) :
+    MemLp (ofReal ∘ f) 2 (volume.restrict (Set.Ioc 0 (2 * π))) := by
+  refine' MeasureTheory.MemLp.mono' _ _ _;
+  refine' fun x => ( SupSet.sSup ( Set.image ( fun y => |f y| ) ( Set.Icc 0 ( 2 * Real.pi ) ) ) );
+  · exact MeasureTheory.memLp_const _;
+  · exact Continuous.aestronglyMeasurable ( by exact Complex.continuous_ofReal.comp hf.continuous );
+  · filter_upwards [ MeasureTheory.ae_restrict_mem measurableSet_Ioc ] with x hx using by simpa using le_csSup ( IsCompact.bddAbove ( isCompact_Icc.image ( show Continuous fun y => |f y| from continuous_abs.comp hf.continuous ) ) ) ( Set.mem_image_of_mem _ <| Set.Ioc_subset_Icc_self hx ) ;
 
-    Proof strategy:
-    1. Lift f to g : AddCircle(2π) → ℂ via AddCircle.liftIoc
-    2. g is continuous (hence in L²) since f is C¹
-    3. Apply tsum_sq_fourierCoeff to get Σ‖ĉₙ‖² = ∫_{AddCircle} ‖g‖² dμ
-    4. Bridge: fourierCoeff_liftIoc_eq gives fourierCoeff g n = fourierCoeffOn hab f n
-    5. Convert: ∫_{AddCircle} ‖g‖² dμ_Haar = (1/2π) ∫₀²π |f|²
-       since haarAddCircle is the probability measure (total mass 1) -/
+/-
+PROBLEM
+For a real number x, ‖ofReal x‖² = x².
+
+PROVIDED SOLUTION
+‖ofReal x‖ = |x| (by norm_ofReal or similar). Then |x|² = x² (by sq_abs). So ‖ofReal x‖² = x².
+-/
+lemma norm_ofReal_sq (x : ℝ) : ‖(ofReal x : ℂ)‖ ^ 2 = x ^ 2 := by
+  norm_num [ ← sq_abs ]
+
+/-
+PROBLEM
+Convert the interval integral of ‖ofReal ∘ f‖² to interval integral of f².
+
+PROVIDED SOLUTION
+The integrands are equal pointwise: ‖(ofReal ∘ f) t‖² = ‖ofReal (f t)‖² = (f t)² by norm_ofReal_sq. Use intervalIntegral.integral_congr or congrArg with ext.
+-/
+lemma intervalIntegral_norm_ofReal_sq (f : ℝ → ℝ) :
+    ∫ t in (0 : ℝ)..(2 * π), ‖(ofReal ∘ f) t‖ ^ 2 =
+    ∫ t in (0 : ℝ)..(2 * π), (f t : ℝ) ^ 2 := by
+  norm_num [ ← sq, norm_ofReal_sq ]
+
+/-- Parseval identity for periodic real functions on [0, 2π]. -/
 theorem parseval_periodic_real (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
     (hperiod : ∀ t, f (t + 2 * π) = f t) (hab : (0 : ℝ) < 2 * π)
     (ĉ : ℤ → ℂ) (hĉ : ĉ = fun n => fourierCoeffOn hab (ofReal ∘ f) n) :
     (Summable fun n => ‖ĉ n‖ ^ 2) ∧
     ∫ t in (0 : ℝ)..(2 * π), (f t : ℝ) ^ 2 =
       (2 * π) * ∑' n : ℤ, ‖ĉ n‖ ^ 2 := by
-  sorry
+  have hL2 := memLp_ofReal_comp_of_contDiff f hf
+  have hparseval := hasSum_sq_fourierCoeffOn hab hL2
+  -- hparseval : HasSum (fun i => ‖fourierCoeffOn hab (ofReal ∘ f) i‖ ^ 2)
+  --   ((2π - 0)⁻¹ • ∫ x in 0..2π, ‖(ofReal ∘ f) x‖ ^ 2)
+  subst hĉ
+  constructor
+  · exact hparseval.summable
+  · have htsum := hparseval.tsum_eq
+    rw [intervalIntegral_norm_ofReal_sq] at htsum
+    simp only [sub_zero] at htsum
+    -- htsum : ∑' i, ‖fourierCoeffOn hab (ofReal ∘ f) i‖ ^ 2 = (2π)⁻¹ • ∫ t in 0..2π, (f t)²
+    -- Goal : ∫ t in 0..2π, (f t)² = 2π * ∑' i, ‖fourierCoeffOn hab (ofReal ∘ f) i‖ ^ 2
+    rw [htsum, smul_eq_mul]
+    field_simp
 
-/-- IBP for Fourier coefficients of periodic functions on [0, 2π].
-
-    For a C¹ periodic function f with period 2π and n ≠ 0,
-    the Fourier coefficient of the derivative equals in times
-    the Fourier coefficient of f:
-      ĉₙ(f') = in · ĉₙ(f)
-
-    Proof strategy:
-    1. Apply fourierCoeffOn_of_hasDerivAt (Mathlib) to get:
-       ĉₙ(f) = 1/(-2πin) · (fourier(-n)(↑0) · (f(2π)-f(0)) - 2π · ĉₙ(f'))
-    2. By periodicity: f(2π) = f(0), so f(2π) - f(0) = 0
-    3. Simplify: ĉₙ(f) = 1/(-2πin) · (-2π · ĉₙ(f')) = ĉₙ(f') / (in)
-    4. Rearrange: ĉₙ(f') = in · ĉₙ(f) -/
+/-- IBP for Fourier coefficients of periodic functions on [0, 2π]. -/
 theorem fourierCoeffOn_deriv_periodic (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
     (hperiod : ∀ t, f (t + 2 * π) = f t)
     (hab : (0 : ℝ) < 2 * π) (n : ℤ) (hn : n ≠ 0) :
     fourierCoeffOn hab (ofReal ∘ deriv f) n =
     I * ↑n * fourierCoeffOn hab (ofReal ∘ f) n := by
-  -- Apply fourierCoeffOn_of_hasDerivAt (IBP for Fourier coefficients)
-  have hle : (0 : ℝ) ≤ 2 * π := le_of_lt hab
-  -- f composed with ofReal has derivative (ofReal ∘ deriv f) at each point
-  have hderiv : ∀ x ∈ Set.uIcc 0 (2 * π),
-      HasDerivAt (ofReal ∘ f) ((ofReal ∘ deriv f) x) x := by
-    intro x _
-    exact (hasDerivAt_ofReal_comp x (hf.differentiable le_rfl x).hasDerivAt)
-  -- The derivative is interval-integrable (C¹ → continuous → integrable)
-  have hint : IntervalIntegrable (ofReal ∘ deriv f) MeasureTheory.volume 0 (2 * π) := by
-    apply Continuous.intervalIntegrable
-    exact continuous_ofReal.comp (hf.continuous_deriv le_rfl)
-  -- Apply the IBP formula
-  have hibp := fourierCoeffOn_of_hasDerivAt hab n hderiv hint
-  -- The boundary term vanishes: f(2π) - f(0) = 0 by periodicity
-  have hperiod_eq : f (2 * π) = f 0 := by
-    have := hperiod 0; simp at this; exact this
-  -- Rearrange: from the IBP formula, extract ĉₙ(f') = in · ĉₙ(f)
-  -- hibp says: fourierCoeffOn hab (ofReal ∘ f) n =
-  --   1/(-2πin/(2π)) * (fourier(-n)(↑0) * (f(2π)-f(0)) - (2π) * fourierCoeffOn hab (ofReal ∘ deriv f) n)
-  -- With f(2π) = f(0), the first term vanishes
-  rw [hperiod_eq, sub_self, map_zero, zero_smul, zero_sub, neg_mul] at hibp
-  -- Now hibp: fourierCoeffOn hab (ofReal ∘ f) n = (2π * fourierCoeffOn hab (ofReal ∘ deriv f) n) / (2πin/(2π))
-  -- Solve for fourierCoeffOn hab (ofReal ∘ deriv f) n
-  have hn' : (↑n : ℂ) ≠ 0 := Int.cast_ne_zero.mpr hn
-  have hI : (I : ℂ) ≠ 0 := I_ne_zero
-  field_simp at hibp ⊢
-  linarith
+  have := @fourierCoeffOn_of_hasDerivAt 0 (2 * Real.pi) hab (ofReal ∘ f) (ofReal ∘ deriv f) n
+  norm_num at *
+  have h_periodic : f (2 * Real.pi) = f 0 := by simpa using hperiod 0
+  specialize this hn (fun x hx => ?_) (?_) <;> norm_num [h_periodic] at *
+  · convert HasDerivAt.ofReal_comp
+      (hasDerivAt_deriv_iff.mpr <| show DifferentiableAt ℝ f x from
+        hf.contDiffAt.differentiableAt <| by norm_num) using 1
+  · exact Continuous.intervalIntegrable
+      (by exact Complex.continuous_ofReal.comp (hf.continuous_deriv le_rfl)) _ _
+  · rw [this]; ring; norm_num [hn, Real.pi_ne_zero]; ring
+    rw [show f (Real.pi * 2) = f 0 by simpa [mul_comm] using hperiod 0]; ring
 
 end IsoperimetricOQAristotle

--- a/scripts/aristotle/submit-batch.sh
+++ b/scripts/aristotle/submit-batch.sh
@@ -276,6 +276,29 @@ main() {
             return 0
         fi
         echo ""
+
+        # Safety check: if many COMPLETE projects on server are not tracked locally
+        # at all, the recovery pipeline may be broken. This prevents wasting server
+        # resources by resubmitting files whose results were never retrieved.
+        local server_complete_ids
+        server_complete_ids=$(uvx --from aristotlelib aristotle list --status COMPLETE --limit 100 2>&1 | grep -oE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' 2>/dev/null || true)
+        if [[ -n "$server_complete_ids" ]]; then
+            local tracked_ids
+            tracked_ids=$(jq -r '.jobs[].project_id // empty' "$JOBS_FILE" 2>/dev/null | sort -u)
+            local untracked=0
+            while IFS= read -r pid; do
+                [[ -z "$pid" ]] && continue
+                if ! echo "$tracked_ids" | grep -q "^${pid}$"; then
+                    untracked=$((untracked + 1))
+                fi
+            done <<< "$server_complete_ids"
+            if [[ "$untracked" -gt 10 ]]; then
+                echo -e "${RED}WARNING: $untracked COMPLETE projects on server not tracked locally${NC}"
+                echo -e "${RED}Recovery pipeline may be broken — skipping submissions until resolved${NC}"
+                echo -e "${YELLOW}Run: ./scripts/aristotle/retrieve-integrate.sh to recover results${NC}"
+                return 0
+            fi
+        fi
     fi
 
     # Calculate how many to submit


### PR DESCRIPTION
## Summary
- Integrate `AreaOfCircleOQ01OQ03Aristotle.lean` (1 sorry → 0 sorries) — solved by Aristotle weeks ago but never retrieved
- Add server-side safety guard to `submit-batch.sh` to prevent duplicate submissions when recovery is broken

## Context
The Aristotle pipeline was non-functional for weeks due to a stale temp file (`aristotle-recover-XXXXXX.lean`) blocking all `mktemp` calls in the recovery script. This caused:
- 100 duplicate submissions of the same file to the server
- 0 results integrated despite successful completions
- Wasted server capacity

The stale temp file has been removed (not in this PR — it was a local `/tmp` file). The jobs tracking file was also cleaned up locally.

## Test plan
- [x] Verified `AreaOfCircleOQ01OQ03Aristotle.lean` now has 0 sorries
- [x] Verified safety guard blocks submissions when >10 untracked COMPLETE projects exist
- [x] Verified safety guard passes when COMPLETE projects are tracked locally
- [x] Verified `find-candidates.sh` finds 83 candidates
- [x] Woke Aristotle agent to start next cycle with fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)