### PR TITLE
Enrich erdos-1121: add relatedProblems

### DIFF
--- a/src/data/proofs/erdos-1121/meta.json
+++ b/src/data/proofs/erdos-1121/meta.json
@@ -44,7 +44,13 @@
     "axiomCount": 4,
     "lineCount": 234,
     "assumptions": "4 axioms: goodman_goodman_theorem, two_circles_case, overlap_implies_connected, and 1 more. See Lean source for complete statements.",
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "relatedProblems": [
+      {
+        "id": "erdos-106",
+        "relationship": "Both concern geometric packing/covering problems from Erdős's combinatorial geometry collection"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #1121 asks whether a 'connected' configuration of circles in the plane can always be covered by a single circle whose radius equals the sum of all individual radii. Here 'connected' means no line disjoint from all circles can separate them into two non-empty groups.\n\nGoodman and Goodman proved this conjecture in 1945, published in the American Mathematical Monthly. Their proof uses geometric arguments about convex hulls and the configuration of circle centers. The result is tight — the covering radius cannot in general be reduced below the sum of radii.\n\nThe Goodman-Goodman theorem naturally generalizes to higher dimensions: balls in ℝⁿ with no separating hyperplane can be covered by a ball of radius equal to the sum of radii. This was noted in their original paper.",


### PR DESCRIPTION
## Summary
- Added `relatedProblems` (erdos-106)

## Test plan
- [x] JSON validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)