### PR TITLE
Enrich cauchy-schwarz-oq-04: deepen historicalContext, add annotations and cross-references

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-04/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "csoq04-header",
+    "proofId": "cauchy-schwarz-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 28
+    },
+    "type": "context",
+    "title": "Module Header and Problem Setup",
+    "content": "The module header establishes the context: when Cauchy-Schwarz equality $|\\langle u,v\\rangle| = \\|u\\|\\|v\\|$ holds, what is the exact proportionality constant? The answer — the orthogonal projection coefficient $\\langle u,v\\rangle/\\|v\\|^2$ — connects the inequality to projection theory.\n\nThe proof works in an abstract real inner product space `E` with `[NormedAddCommGroup E] [InnerProductSpace ℝ E]`, making all results applicable to $\\mathbb{R}^n$, $L^2$ function spaces, and any Hilbert space over $\\mathbb{R}$. The `import Mathlib` brings the full Mathlib library; `open scoped InnerProductSpace` enables the `⟪u, v⟫_ℝ` notation for real inner products.",
+    "mathContext": "The proof works in an arbitrary real inner product space $(E, \\langle\\cdot,\\cdot\\rangle)$ satisfying the axioms: symmetry $\\langle u,v\\rangle = \\langle v,u\\rangle$, linearity in the first argument, and positive-definiteness $\\langle u,u\\rangle > 0$ for $u \\neq 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "InnerProductSpace",
+      "NormedAddCommGroup",
+      "Cauchy-Schwarz inequality"
+    ],
+    "prerequisites": [
+      "Lean 4 type classes",
+      "Mathlib inner product spaces"
+    ]
+  },
+  {
     "id": "csoq04-projcoeff",
     "proofId": "cauchy-schwarz-oq-04",
     "type": "concept",
@@ -110,6 +132,73 @@
     ]
   },
   {
+    "id": "csoq04-reverse-direction",
+    "proofId": "cauchy-schwarz-oq-04",
+    "range": {
+      "startLine": 93,
+      "endLine": 112
+    },
+    "type": "technique",
+    "title": "Reverse Direction and Full Biconditional",
+    "content": "`cs_equality_of_exact_constant` proves the reverse: if $u = \\text{projCoeff}(u,v) \\cdot v$, then $|\\langle u,v\\rangle| = \\|u\\|\\|v\\|$. The proof substitutes $u = cv$ into both sides: $|\\langle cv, v\\rangle| = |c| \\cdot \\|v\\|^2$ and $\\|cv\\| \\cdot \\|v\\| = |c| \\cdot \\|v\\|^2$, then uses `ring` to close. The biconditional `cs_equality_iff_exact_constant` combines both directions via `Iff.intro`.",
+    "mathContext": "Reverse: $u = cv \\Rightarrow |\\langle u,v\\rangle| = |c|\\|v\\|^2 = \\|cv\\|\\|v\\| = \\|u\\|\\|v\\|$. The biconditional: $|\\langle u,v\\rangle| = \\|u\\|\\|v\\| \\iff u = \\frac{\\langle u,v\\rangle}{\\|v\\|^2}v$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "biconditional proof",
+      "norm_smul",
+      "inner_smul_left"
+    ],
+    "prerequisites": [
+      "cs_equality_exact_constant",
+      "real_inner_self_eq_norm_sq"
+    ]
+  },
+  {
+    "id": "csoq04-coefficient-props",
+    "proofId": "cauchy-schwarz-oq-04",
+    "range": {
+      "startLine": 118,
+      "endLine": 143
+    },
+    "type": "technique",
+    "title": "Projection Coefficient Algebra",
+    "content": "Four algebraic properties of `projCoeff`:\n\n1. **Recovery** (`projCoeff_of_smul`): $\\text{projCoeff}(cv, v) = c$ — the coefficient recovers scalars. Uses `inner_smul_left` + `mul_div_cancel_right₀`.\n2. **Normalization** (`projCoeff_self`): $\\text{projCoeff}(v, v) = 1$ — as a corollary of recovery with $c = 1$.\n3. **Additivity** (`projCoeff_add`): $\\text{projCoeff}(u_1 + u_2, v) = \\text{projCoeff}(u_1, v) + \\text{projCoeff}(u_2, v)$ — from `inner_add_left` + `add_div`.\n4. **Homogeneity** (`projCoeff_smul`): $\\text{projCoeff}(cu, v) = c \\cdot \\text{projCoeff}(u, v)$ — from `inner_smul_left` + `mul_div_assoc`.\n\nTogether, these show $u \\mapsto \\text{projCoeff}(u, v)$ is a linear functional — the Riesz representative is $v/\\|v\\|^2$.",
+    "mathContext": "The map $\\pi_v : u \\mapsto \\text{projCoeff}(u,v)$ is a continuous linear functional with $\\pi_v(cv) = c$ (recovery), $\\pi_v(v) = 1$ (normalization), and $\\|\\pi_v\\| = 1/\\|v\\|$ (Riesz representation).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "linear functional",
+      "Riesz representation",
+      "Gram-Schmidt"
+    ],
+    "prerequisites": [
+      "inner_smul_left",
+      "inner_add_left",
+      "div_mul_cancel"
+    ]
+  },
+  {
+    "id": "csoq04-residual-bridge",
+    "proofId": "cauchy-schwarz-oq-04",
+    "range": {
+      "startLine": 149,
+      "endLine": 197
+    },
+    "type": "insight",
+    "title": "Residual Characterization and Bridge to Existential Form",
+    "content": "**Residual characterization** (`cs_equality_iff_zero_residual`): CS equality $\\iff$ $u - \\text{proj}(u,v) = 0$. This reframes the algebraic equality condition geometrically: CS equality holds precisely when $u$ has no component orthogonal to $v$.\n\n**Geometric interpretation** (Parts IV-V): The sign of `projCoeff` determines the direction relationship: $\\text{projCoeff} > 0$ when $\\langle u,v\\rangle > 0$ (same direction), $\\text{projCoeff} < 0$ when $\\langle u,v\\rangle < 0$ (opposite direction).\n\n**Bridge** (`existential_constant_is_projCoeff`): If $u = cv$ for any scalar $c$, then $c = \\text{projCoeff}(u,v)$. This shows the constant is unique, sharpening the base CauchySchwarz.lean result from $\\exists c$ to the specific $c = \\langle u,v\\rangle/\\|v\\|^2$.",
+    "mathContext": "Three equivalent characterizations of CS equality: (1) $|\\langle u,v\\rangle| = \\|u\\|\\|v\\|$, (2) $u = \\frac{\\langle u,v\\rangle}{\\|v\\|^2}v$, (3) $u - \\text{proj}_v(u) = 0$. Uniqueness: $u = cv \\Rightarrow c = \\langle u,v\\rangle/\\|v\\|^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthogonal complement",
+      "zero residual",
+      "unique determination"
+    ],
+    "prerequisites": [
+      "cs_equality_iff_exact_constant",
+      "projCoeff_of_smul"
+    ]
+  },
+  {
     "id": "csoq04-finite-sum",
     "proofId": "cauchy-schwarz-oq-04",
     "type": "concept",
@@ -153,6 +242,27 @@
     "prerequisites": [
       "projCoeff_pos_of_inner_pos",
       "projCoeff_neg_of_inner_neg"
+    ]
+  },
+  {
+    "id": "csoq04-examples",
+    "proofId": "cauchy-schwarz-oq-04",
+    "range": {
+      "startLine": 274,
+      "endLine": 288
+    },
+    "type": "context",
+    "title": "Verified Examples and Type Checks",
+    "content": "Concrete sanity checks verifying the projection coefficient on simple cases: `projCoeff(3v, v) = 3` (the coefficient recovers the scalar when $u$ is a known multiple of $v$) and `projCoeff(v, v) = 1` (self-projection gives unit coefficient). The `#check` commands verify that the main theorems have the expected types, serving as a lightweight regression test — if the theorem signatures change, the `#check` calls will fail.",
+    "mathContext": "$\\text{projCoeff}(3v, v) = \\frac{\\langle 3v, v\\rangle}{\\|v\\|^2} = \\frac{3\\|v\\|^2}{\\|v\\|^2} = 3$ and $\\text{projCoeff}(v, v) = \\frac{\\|v\\|^2}{\\|v\\|^2} = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "projCoeff_of_smul",
+      "projCoeff_self",
+      "#check"
+    ],
+    "prerequisites": [
+      "projCoeff definition"
     ]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04/meta.json
@@ -63,7 +63,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Cauchy-Schwarz inequality $|\\langle u,v\\rangle| \\leq \\|u\\|\\|v\\|$ is one of the most important inequalities in mathematics. Its equality condition -- that the vectors must be proportional -- is well-known, but the **exact proportionality constant** $c = \\langle u,v\\rangle/\\|v\\|^2$ is often stated informally. This formalization makes the constant precise: when equality holds, $u$ equals exactly the orthogonal projection of $u$ onto $v$, with the scalar being the projection coefficient.\n\nThe projection coefficient $\\text{projCoeff}(u,v) = \\langle u,v\\rangle/\\|v\\|^2$ appears throughout functional analysis, statistics (regression coefficients), and signal processing (matched filtering). This formalization proves its defining properties and shows it is the unique scalar satisfying the equality condition.",
+    "historicalContext": "The Cauchy-Schwarz inequality $|\\langle u,v\\rangle| \\leq \\|u\\|\\|v\\|$ traces to Cauchy's 1821 *Cours d'Analyse* (discrete sums), Bunyakovsky's 1859 extension to integrals, and Schwarz's 1885 rigorous proof for square-integrable functions. The equality condition $|\\langle u,v\\rangle| = \\|u\\|\\|v\\|$ iff $u$ and $v$ are proportional was recognized early, but the **exact proportionality constant** $c = \\langle u,v\\rangle/\\|v\\|^2$ was typically left implicit. This formalization makes the constant precise: when equality holds, $u$ equals the orthogonal projection of $u$ onto $v$.\n\nThe projection coefficient $\\text{projCoeff}(u,v) = \\langle u,v\\rangle/\\|v\\|^2$ emerged as a central concept through several independent developments. In 1905, Hilbert's theory of integral equations introduced orthogonal expansions in function spaces, and the projection coefficient became the Fourier coefficient in the basis $\\{v/\\|v\\|\\}$. Schmidt's 1907 orthogonalization process (later called Gram-Schmidt after Gram's 1883 work) uses exactly this coefficient at each step: subtract $\\text{projCoeff}(u, e_k) \\cdot e_k$ for each basis vector $e_k$.\n\nIn statistics, the projection coefficient appears as the simple linear regression slope $\\hat{\\beta} = \\text{Cov}(X,Y)/\\text{Var}(X) = \\langle X - \\bar{X}, Y - \\bar{Y}\\rangle / \\|X - \\bar{X}\\|^2$, connecting Gauss's 1809 method of least squares to inner product geometry. In signal processing, matched filtering maximizes the signal-to-noise ratio by correlating the received signal with a template — the optimal filter coefficient is precisely $\\text{projCoeff}$. The Lagrange identity used for the finite-sum version dates to Lagrange's 1773 work on quadratic forms and was the historical precursor to the abstract Cauchy-Schwarz inequality.",
     "problemStatement": "**Open Question (cauchy-schwarz-oq-04)**: When $|\\langle u,v\\rangle| = \\|u\\|\\|v\\|$, give the exact proportionality constant.\n\n**Result**: $u = \\frac{\\langle u,v\\rangle}{\\|v\\|^2} \\cdot v$, i.e., $u$ equals the orthogonal projection of $u$ onto $v$.\n\n**Also proved**: The biconditional (iff) version, projection coefficient linearity and algebraic properties, geometric sign interpretation (same/opposite direction), zero residual characterization, finite sum version via Lagrange identity, and bridge to the existential result in the base CauchySchwarz.lean.",
     "text": "When |inner u v| = norm u * norm v, the exact proportionality constant is u = (inner u v / norm v^2) * v. Proves the biconditional characterization, projection coefficient properties, geometric interpretation, and finite sum version via the Lagrange identity.",
     "proofStrategy": "**Proof Strategy: Residual Norm Decomposition**\n\n1. **Define** projCoeff(u,v) = inner(u,v) / norm(v)^2 and proj(u,v) = projCoeff(u,v) * v.\n2. **Prove** the residual u - proj(u,v) is orthogonal to v (inner product is zero).\n3. **Derive** the Pythagorean decomposition: norm(u)^2 = projCoeff^2 * norm(v)^2 + norm(residual)^2.\n4. **Show** that CS equality forces norm(residual) = 0, hence u = proj(u,v).\n5. **Reverse direction**: if u = projCoeff * v, direct computation gives |inner u v| = norm u * norm v.\n6. **Finite sum version**: uses the Lagrange identity; CS equality forces all cross-terms a_i*b_j - a_j*b_i = 0, giving a_i = (sum a_j*b_j / sum b_j^2) * b_i.",
@@ -75,17 +75,28 @@
       "**Bridge to OQ-03 (Hölder)**: The equality condition for Cauchy-Schwarz (p=q=2) is a special case of Hölder equality — the general case requires $f_i^p/g_i^q$ constant. At p=q=2 this reduces to proportionality $f_i/g_i = c$, unifying the geometric (projection) and analytic (Hölder) perspectives"
     ],
     "prerequisites": [
-      "Mathematical analysis"
+      "Inner product spaces (InnerProductSpace ℝ E in Mathlib)",
+      "Cauchy-Schwarz inequality and its equality condition",
+      "Orthogonal projection in Hilbert spaces",
+      "Finite sums and the Lagrange identity"
     ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "Module docstring, Mathlib import, CauchySchwarzOQ04 namespace, InnerProductSpace scoped open, and universe-polymorphic variable declarations for an abstract real inner product space E.",
+      "mathContext": "The proof operates in an abstract real inner product space $(E, \\langle\\cdot,\\cdot\\rangle_\\mathbb{R})$ with `[NormedAddCommGroup E] [InnerProductSpace ℝ E]`. The scoped open brings the inner product notation $\\langle u, v\\rangle_\\mathbb{R}$ into scope."
+    },
     {
       "id": "projection-coefficient",
       "title": "Orthogonal Projection Coefficient",
       "startLine": 29,
       "endLine": 65,
       "summary": "Defines projCoeff(u,v) = inner(u,v)/norm(v)^2 and proj(u,v) = projCoeff(u,v) * v. Proves the residual u - proj(u,v) is orthogonal to v and derives the Pythagorean norm decomposition.",
-      "mathContext": "Defines projCoeff(u,v) = inner(u,v)/norm(v)^2 and proj(u,v) = projCoeff(u,v) * v. Proves the residual u - proj(u,v) is orthogonal to v and derives the Pythagorean norm decomposition."
+      "mathContext": "$\\text{projCoeff}(u,v) = \\frac{\\langle u,v\\rangle}{\\|v\\|^2}$, $\\text{proj}(u,v) = \\text{projCoeff}(u,v) \\cdot v$. The Pythagorean decomposition: $\\|u\\|^2 = \\text{projCoeff}^2 \\|v\\|^2 + \\|u - \\text{proj}(u,v)\\|^2$, from $\\langle u - \\text{proj}(u,v), v\\rangle = 0$."
     },
     {
       "id": "exact-constant",
@@ -93,7 +104,7 @@
       "startLine": 70,
       "endLine": 112,
       "summary": "Proves cs_equality_exact_constant (forward), cs_equality_of_exact_constant (reverse), and the full biconditional cs_equality_iff_exact_constant: |inner u v| = norm u * norm v iff u = projCoeff(u,v) * v.",
-      "mathContext": "Proves cs_equality_exact_constant (forward), cs_equality_of_exact_constant (reverse), and the full biconditional cs_equality_iff_exact_constant: |inner u v| = norm u * norm v iff u = projCoeff(u,v) * "
+      "mathContext": "$|\\langle u,v\\rangle| = \\|u\\|\\|v\\| \\iff u = \\frac{\\langle u,v\\rangle}{\\|v\\|^2} \\cdot v$. Forward: CS equality $\\Rightarrow$ $\\text{projCoeff}^2\\|v\\|^2 = \\|u\\|^2$ $\\Rightarrow$ residual $= 0$ by Pythagoras. Reverse: $u = cv$ $\\Rightarrow$ direct computation via $\\langle cv, v\\rangle = c\\|v\\|^2$."
     },
     {
       "id": "coefficient-properties",
@@ -101,7 +112,7 @@
       "startLine": 117,
       "endLine": 143,
       "summary": "Proves projCoeff(cv, v) = c, projCoeff(v, v) = 1, additivity projCoeff(u1+u2, v) = projCoeff(u1,v) + projCoeff(u2,v), and scaling projCoeff(cu, v) = c * projCoeff(u,v).",
-      "mathContext": "Proves projCoeff(cv, v) = c, projCoeff(v, v) = 1, additivity projCoeff(u1+u2, v) = projCoeff(u1,v) + projCoeff(u2,v), and scaling projCoeff(cu, v) = c * projCoeff(u,v)."
+      "mathContext": "The map $u \\mapsto \\text{projCoeff}(u,v) = \\langle u,v\\rangle/\\|v\\|^2$ is a bounded linear functional on $E$ (by Riesz representation). Linearity: $\\text{projCoeff}(u_1+u_2,v) = \\text{projCoeff}(u_1,v) + \\text{projCoeff}(u_2,v)$ and $\\text{projCoeff}(cu,v) = c \\cdot \\text{projCoeff}(u,v)$. Normalization: $\\text{projCoeff}(v,v) = 1$."
     },
     {
       "id": "residual",
@@ -109,7 +120,7 @@
       "startLine": 148,
       "endLine": 154,
       "summary": "Proves CS equality holds iff the residual u - proj(u,v) = 0, connecting the equality condition to orthogonal projection theory.",
-      "mathContext": "Proves CS equality holds iff the residual u - proj(u,v) = 0, connecting the equality condition to orthogonal projection theory."
+      "mathContext": "$|\\langle u,v\\rangle| = \\|u\\|\\|v\\| \\iff u - \\text{proj}(u,v) = 0$. This is the geometric characterization: CS equality holds exactly when $u$ lies in $\\text{span}(v)$, i.e., the orthogonal complement component vanishes."
     },
     {
       "id": "geometric",
@@ -117,7 +128,7 @@
       "startLine": 159,
       "endLine": 186,
       "summary": "Proves projCoeff > 0 when inner(u,v) > 0 (same direction) and projCoeff < 0 when inner(u,v) < 0 (opposite direction). Derives the direction-specific equality conditions.",
-      "mathContext": "Proves projCoeff > 0 when inner(u,v) > 0 (same direction) and projCoeff < 0 when inner(u,v) < 0 (opposite direction). Derives the direction-specific equality conditions."
+      "mathContext": "Since $\\text{projCoeff} = \\langle u,v\\rangle/\\|v\\|^2$ and $\\|v\\|^2 > 0$: $\\text{sign}(\\text{projCoeff}) = \\text{sign}(\\langle u,v\\rangle) = \\text{sign}(\\cos\\theta)$ where $\\theta$ is the angle between $u$ and $v$. Same direction ($\\theta < \\pi/2$) gives $c > 0$; opposite direction ($\\theta > \\pi/2$) gives $c < 0$."
     },
     {
       "id": "bridge",
@@ -125,7 +136,7 @@
       "startLine": 191,
       "endLine": 197,
       "summary": "Shows that any scalar c satisfying u = cv must equal projCoeff(u,v), connecting to the existential characterization in the base CauchySchwarz.lean formalization.",
-      "mathContext": "Shows that any scalar c satisfying u = cv must equal projCoeff(u,v), connecting to the existential characterization in the base CauchySchwarz.lean formalization."
+      "mathContext": "$u = cv \\Rightarrow c = \\text{projCoeff}(u,v)$. Uniqueness: if $u = cv$ then $\\text{projCoeff}(u,v) = \\text{projCoeff}(cv,v) = c$ by the recovery property. This sharpens $\\exists c,\\, u = cv$ to $c = \\langle u,v\\rangle/\\|v\\|^2$."
     },
     {
       "id": "finite-sum",
@@ -133,7 +144,7 @@
       "startLine": 203,
       "endLine": 268,
       "summary": "Proves the finite sum version via the Lagrange identity: if (sum a_i*b_i)^2 = (sum a_i^2)(sum b_i^2), then a_i = (sum a_j*b_j / sum b_j^2) * b_i for all i. Uses cross-term vanishing from the double-sum expansion.",
-      "mathContext": "Proves the finite sum version via the Lagrange identity: if (sum a_i*b_i)^2 = (sum a_i^2)(sum b_i^2), then a_i = (sum a_j*b_j / sum b_j^2) * b_i for all i. Uses cross-term vanishing from the double-su"
+      "mathContext": "Lagrange identity: $\\sum_{i<j}(a_ib_j - a_jb_i)^2 = (\\sum a_i^2)(\\sum b_i^2) - (\\sum a_ib_i)^2$. Equality forces all cross-terms $a_ib_j = a_jb_i$, giving the common ratio $a_i/b_i = \\sum a_jb_j / \\sum b_j^2$ for all $i$. This is the finite-dimensional analog of the abstract projection coefficient."
     },
     {
       "id": "examples",
@@ -141,19 +152,49 @@
       "startLine": 273,
       "endLine": 288,
       "summary": "Concrete verifications: projCoeff(3v, v) = 3 and projCoeff(v, v) = 1, with type-check confirmations of the main theorems.",
-      "mathContext": "Concrete verifications: projCoeff(3v, v) = 3 and projCoeff(v, v) = 1, with type-check confirmations of the main theorems."
+      "mathContext": "Sanity checks: $\\text{projCoeff}(3v, v) = 3$ (recovery property) and $\\text{projCoeff}(v, v) = 1$ (normalization). The `#check` commands verify that `cs_equality_exact_constant`, `cs_equality_iff_exact_constant`, and `finite_sum_exact_constant` have the expected types."
     }
   ],
   "crossReferences": [
     {
       "targetId": "cauchy-schwarz",
       "relationship": "extends",
-      "description": "Strengthens the base Cauchy-Schwarz equality characterization from 'exists c, u = cv' to the exact constant c = inner(u,v)/norm(v)^2."
+      "description": "Strengthens the base Cauchy-Schwarz equality characterization from 'exists c, u = cv' to the exact constant c = inner(u,v)/norm(v)^2"
     },
     {
       "targetId": "cauchy-schwarz-oq-03",
       "relationship": "related",
-      "description": "Both are open questions extending the base Cauchy-Schwarz formalization with deeper characterizations of the equality condition."
+      "description": "OQ-03 generalizes Cauchy-Schwarz to Hölder's inequality; this entry's equality condition (proportionality with exact constant) is the p=q=2 special case of Hölder equality ($f_i^p/g_i^q$ constant)"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The integral version of Cauchy-Schwarz. This entry's projection coefficient generalizes to the $L^2$ inner product: $\\text{projCoeff}(f,g) = \\int fg / \\int g^2$, which is the Fourier coefficient of $f$ in the direction of $g$"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean norm decomposition $\\|u\\|^2 = \\|\\text{proj}\\|^2 + \\|u - \\text{proj}\\|^2$ used in the main proof is the inner product space generalization of the Pythagorean theorem for orthogonal vectors"
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "related",
+      "description": "The triangle inequality for normed spaces follows from Cauchy-Schwarz. The equality condition for the triangle inequality ($\\|u+v\\| = \\|u\\|+\\|v\\|$) is related to the CS equality condition: both require proportionality with the same sign"
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Cauchy-Schwarz is the $M_1 \\leq M_2$ case of power mean monotonicity: $\\sum w_i x_i \\leq (\\sum w_i x_i^2)^{1/2}$, connecting the projection coefficient to the power mean chain"
+    },
+    {
+      "targetId": "fourier-series",
+      "relationship": "related",
+      "description": "Fourier coefficients $\\hat{f}(n) = \\langle f, e_n\\rangle / \\|e_n\\|^2$ are exactly projCoeff applied to each basis function. The Bessel inequality $\\sum |\\hat{f}(n)|^2 \\leq \\|f\\|^2$ is the multi-dimensional extension of the Pythagorean decomposition proved here"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01",
+      "relationship": "related",
+      "description": "Another extension of the base Cauchy-Schwarz formalization in the same family of open questions, exploring different aspects of the inequality"
     }
   ],
   "conclusion": {
@@ -181,18 +222,39 @@
   },
   "references": [
     {
-      "authors": "A.-L. Cauchy",
+      "authors": "Cauchy, Augustin-Louis",
       "title": "Cours d'Analyse de l'École Royale Polytechnique",
       "year": "1821",
       "venue": "Paris",
-      "note": "Original discrete inequality with equality case noted"
+      "note": "Original discrete inequality (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²) with the equality case noted as proportionality of the sequences"
     },
     {
-      "authors": "J. M. Steele",
-      "title": "The Cauchy-Schwarz Master Class",
+      "authors": "Schwarz, Hermann Amandus",
+      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung",
+      "year": "1885",
+      "venue": "Acta Societatis Scientiarum Fennicae, vol. 15, pp. 315–362",
+      "note": "Rigorous proof of the integral version (∫fg)² ≤ (∫f²)(∫g²), often cited alongside Cauchy's discrete version as the 'Cauchy-Schwarz inequality'"
+    },
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy-Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
       "year": "2004",
-      "venue": "Cambridge University Press",
-      "note": "Chapter 2: detailed treatment of equality conditions"
+      "venue": "Cambridge University Press, MAA Problem Books Series",
+      "note": "Chapter 2: detailed treatment of equality conditions and the projection interpretation. Chapter 4: Lagrange identity and cross-term vanishing used in the finite sum version"
+    },
+    {
+      "authors": "Halmos, Paul R.",
+      "title": "Finite-Dimensional Vector Spaces",
+      "year": "1958",
+      "venue": "Springer, Undergraduate Texts in Mathematics (2nd edition)",
+      "note": "Section 67: orthogonal projections in inner product spaces, the residual norm characterization, and the connection between CS equality and linear dependence — the abstract setting formalized in this entry"
+    },
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Recherches d'arithmétique",
+      "year": "1773",
+      "venue": "Nouveaux Mémoires de l'Académie royale des Sciences et Belles-Lettres de Berlin",
+      "note": "Contains the Lagrange identity ∑(aᵢbⱼ - aⱼbᵢ)² = (∑aᵢ²)(∑bᵢ²) - (∑aᵢbᵢ)² used in the finite sum version of the exact constant theorem"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for cauchy-schwarz-oq-04 (Cauchy-Schwarz Equality: Exact Proportionality Constant).

**Quality improvements:**
- Expanded historicalContext with Schwarz (1885), Bunyakovsky (1859), Hilbert/Schmidt projection history
- Added 5 new annotations covering previously uncovered code sections (header, reverse direction, coefficient properties, residual/bridge, examples)
- Expanded crossReferences from 2 to 8 (added pythagorean-theorem, cauchy-schwarz-integral, triangle-inequality, amgm-inequality, fourier-series, cauchy-schwarz-oq-01)
- Improved all section mathContext fields with proper LaTeX formulas
- Expanded references from 2 to 5 (added Schwarz 1885, Halmos 1958, Lagrange 1773)
- Improved prerequisites from generic to specific