### PR TITLE
Enrich derangements-oq-03 and brouwer-fixed-point

### DIFF
--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -92,7 +92,11 @@
     "relatedProblems": [
       {
         "id": "brouwer-fixed-point-oq-02",
-        "relationship": "Extension of brouwer fixed point"
+        "relationship": "Explores the computational complexity of finding approximate Brouwer fixed points (PPAD-completeness)"
+      },
+      {
+        "id": "brouwer-fixed-point-oq-04",
+        "relationship": "Kakutani's generalization to set-valued maps, with applications to Nash equilibrium existence"
       }
     ]
   },
@@ -328,6 +332,11 @@
       "targetId": "isoperimetric-theorem",
       "relationship": "thematic",
       "description": "Both characterize fundamental properties of the ball/sphere: the isoperimetric theorem shows the ball maximizes volume for given surface area, while Brouwer's theorem shows the ball has the fixed point property. Both use compactness and convexity in essential ways — the isoperimetric theorem via calculus of variations, Brouwer via algebraic topology"
+    },
+    {
+      "targetId": "brouwer-fixed-point-oq-04",
+      "relationship": "extended-by",
+      "description": "Kakutani's fixed point theorem (1941) generalizes Brouwer from single-valued to set-valued (multi-valued) maps: every upper hemicontinuous correspondence with non-empty convex compact values on a compact convex set has a fixed point. Nash's equilibrium theorem is a direct application"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for two entries:

## derangements-oq-03 (Derangements Convergence Rate to 1/e)
- Replaced all 7 section mathContext fields with proper LaTeX formulas
- Expanded crossReferences from 3 to 8 (added e-transcendental, taylor-theorem, birthday-problem, inclusion-exclusion, stirling-formula)
- Added 2 new annotations covering definitions (41-66) and consequences (311-342)
- Expanded prerequisites from generic to specific

## brouwer-fixed-point (Brouwer Fixed Point Theorem)
- Added missing brouwer-fixed-point-oq-04 (Kakutani) to relatedProblems and crossReferences