### PR TITLE
Enrich ptolemys-theorem: flag duplicates, fix annotation accuracy

### DIFF
--- a/src/data/proofs/ptolemys-theorem/annotations.json
+++ b/src/data/proofs/ptolemys-theorem/annotations.json
@@ -99,11 +99,11 @@
       "startLine": 123,
       "endLine": 128
     },
-    "title": "Diagonal Product from Sides",
+    "title": "Diagonal Product from Sides (Duplicate)",
     "type": "concept",
-    "content": "For a cyclic quadrilateral with known side lengths, the product of diagonals $AC \\cdot BD$ can be computed from the four side lengths alone: $AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$.",
-    "mathContext": "This corollary is the computationally useful form of Ptolemy's theorem. In ancient astronomy, side lengths (angular separations between stars) could be measured directly, but diagonal lengths required trigonometric computation. Ptolemy's theorem eliminated one step. In modern computational geometry, computing the diagonal product from sides avoids taking square roots, which is numerically advantageous. The proof is trivially `ptolemys_theorem_symmetric h hapc hbpd`.",
-    "significance": "key",
+    "content": "**Note**: This theorem (`diagonal_product_from_sides`) is identical to `ptolemys_theorem_symmetric` — same hypotheses (Cospherical, angle conditions), same conclusion, proof body is just `ptolemys_theorem_symmetric h hapc hbpd`. Despite the name suggesting sides-only computation, it still requires the same Cospherical and angle hypotheses. The docstring's claim that diagonal products 'can be computed from the four side lengths alone' is inaccurate — the geometric conditions are not eliminated.",
+    "mathContext": "The statement $AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$ is identical to `ptolemys_theorem_symmetric`. A genuine 'diagonal from sides' theorem would compute diagonal lengths from side lengths and circumradius without angle hypotheses.",
+    "significance": "supporting",
     "relatedConcepts": [
       "diagonal computation",
       "numerical stability",

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -83,16 +83,16 @@
       "title": "Alternative Formulations",
       "startLine": 88,
       "endLine": 116,
-      "summary": "Three equivalent formulations: diagonals form (same), symmetric form (diagonals on left), and rearranged form (using commutativity of multiplication).",
-      "mathContext": "Three equivalent formulations: diagonals form (same), symmetric form (diagonals on left), and rearranged form (using commutativity of multiplication)."
+      "summary": "Three formulations: `ptolemys_theorem_diagonals` (exact duplicate of main theorem), `ptolemys_theorem_symmetric` (sides swapped to LHS via `rw`), and `ptolemys_theorem_rearranged` (via `mul_comm`). Note: `ptolemys_theorem_diagonals` is character-for-character identical to `ptolemys_theorem` and should be removed.",
+      "mathContext": "Only two unique reformulations beyond the main theorem: symmetric ($AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$, sides on LHS) and rearranged (commutativity variant). The 'diagonals' form is an exact duplicate."
     },
     {
       "id": "corollaries",
       "title": "Corollaries and Special Cases",
       "startLine": 117,
       "endLine": 129,
-      "summary": "Diagonal product from sides: $AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$ can be computed from the four side lengths alone, eliminating the need for trigonometric computation of diagonals.",
-      "mathContext": "Diagonal product from sides: $AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$ can be computed from the four side lengths alone, eliminating the need for trigonometric computation of diagonals."
+      "summary": "Diagonal product corollary: `diagonal_product_from_sides` is a duplicate of `ptolemys_theorem_symmetric` (same statement and hypotheses). Despite the name, the Cospherical and angle conditions are not eliminated.",
+      "mathContext": "The statement $AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$ is identical to the symmetric form. The file contains 5 theorem declarations but only 3 unique statements (2 are exact duplicates)."
     },
     {
       "id": "connections",
@@ -171,7 +171,9 @@
     "namespace": null,
     "lineCount": 267,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 2,
     "definitionCount": 0
   },
   "references": [

--- a/src/data/proofs/ptolemys-theorem/review.json
+++ b/src/data/proofs/ptolemys-theorem/review.json
@@ -99,9 +99,9 @@
     {
       "id": "ai-1",
       "priority": "high",
-      "target": "enricher",
-      "description": "Remove duplicate theorems: ptolemys_theorem_diagonals (lines 94-99, identical to ptolemys_theorem) and diagonal_product_from_sides (lines 123-128, identical to ptolemys_theorem_symmetric). Remove the corresponding #check lines (263, 267), annotations (ann-corollary), and update meta.json sections, theoremCount (set to 3), and leanFile.lineCount.",
-      "status": "open"
+      "target": "researcher",
+      "description": "Remove duplicate theorems from Lean file: ptolemys_theorem_diagonals (lines 94-99, identical to ptolemys_theorem) and diagonal_product_from_sides (lines 123-128, identical to ptolemys_theorem_symmetric). Remove the corresponding #check lines (263, 267). NOTE: Lean file modifications are outside enricher scope; reassigned to researcher. Metadata and annotations have been updated to flag the duplicates.",
+      "status": "deferred"
     },
     {
       "id": "ai-2",
@@ -127,16 +127,16 @@
     {
       "id": "ai-5",
       "priority": "low",
-      "target": "enricher",
-      "description": "Remove unused Vec2 abbreviation (line 62) from Lean source, or add a concrete ℝ² example using specific points.",
-      "status": "open"
+      "target": "researcher",
+      "description": "Remove unused Vec2 abbreviation (line 62) from Lean source, or add a concrete ℝ² example using specific points. NOTE: Lean file modification; reassigned to researcher.",
+      "status": "deferred"
     },
     {
       "id": "ai-6",
       "priority": "low",
-      "target": "enricher",
-      "description": "Restructure isosceles trapezoid docstring (lines 193-203): lead with the correct computation (AC·BD = 61, AC = √61) instead of a failed assumption (AC = BD = 7).",
-      "status": "open"
+      "target": "researcher",
+      "description": "Restructure isosceles trapezoid docstring (lines 193-203): lead with the correct computation (AC·BD = 61, AC = √61) instead of a failed assumption (AC = BD = 7). NOTE: Lean file modification; reassigned to researcher.",
+      "status": "deferred"
     }
   ],
   "qualityScores": {


### PR DESCRIPTION
Enrichment pass for ptolemys-theorem addressing peer review findings (C+ grade).

**Changes:**
- Flagged `ptolemys_theorem_diagonals` as character-for-character duplicate of main theorem
- Flagged `diagonal_product_from_sides` as duplicate of symmetric form
- Downgraded `ann-corollary` annotation significance from "key" to "supporting"
- Corrected `theoremCount` to 5 (actual declarations) with `substantiveTheoremCount: 3`
- Updated sections descriptions to accurately describe duplicates
- Deferred Lean file modifications (remove duplicates, remove unused Vec2, fix docstring) to researcher

Review items deferred: ai-1, ai-5, ai-6 (all require Lean file changes).