### PR TITLE
Fix: poincare-conjecture leanFile.sorryCount 0→1

### DIFF
--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -80,7 +80,7 @@
       "lemmaCount": 0,
       "defCount": 365,
       "axiomCount": 32,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "structureCount": 183,
       "instanceCount": 21,
       "parts": 100,


### PR DESCRIPTION
## Fix

Correct `leanFile.sorryCount` from 0 to 1 in poincare-conjecture meta.json.

## Evidence

**Before**: `leanFile.sorryCount: 0` (inconsistent with `meta.sorries: 1`)
**After**: `leanFile.sorryCount: 1` (matches actual sorry at line 2965 in `rp3_locallyEuclidean`)

The sorry is a regression from Quotient.exact API changes in Lean v4.26.0. The `meta.sorries` field was already correct at 1.

---
Automated fix by lean-mechanic agent.