### PR TITLE
Enrich erdos-1131-oq-01: create annotations, add full metadata

### DIFF
--- a/src/data/proofs/erdos-1131-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1131-oq-01/annotations.json
@@ -1,0 +1,167 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "erdos-1131-oq-01",
+    "range": { "startLine": 1, "endLine": 18 },
+    "type": "context",
+    "title": "Module Documentation: Variance Decomposition Approach",
+    "content": "This file takes a novel approach to Erdős Problem #1131 by decomposing the Lagrange basis integral $I = \\int_{-1}^{1} \\sum_k l_k(x)^2\\,dx$ into a 'uniform floor' $2/n$ and a 'variance excess' $\\int \\text{var}(x)\\,dx$. The key result is that the Cauchy-Schwarz bound $I \\geq 2/n$ is never tight for $n \\geq 2$: the strict inequality $I > 2/n$ holds because the integrated variance is strictly positive. The Erdős conjecture $\\min I = 2 - (1+o(1))/n$ is reformulated as $\\min \\int \\text{var} = 2 - (3+o(1))/n$, separating the understood floor from the open conjecture about the excess.",
+    "mathContext": "$I = \\frac{2}{n} + \\int_{-1}^{1} \\sum_{k=1}^{n}\\left(l_k(x) - \\frac{1}{n}\\right)^2 dx$. The first term is the contribution of a perfectly uniform basis; the second measures deviation from uniformity.",
+    "significance": "key",
+    "prerequisites": [
+      "Lagrange interpolation",
+      "Erdős Problem #1131",
+      "measure theory"
+    ],
+    "relatedConcepts": [
+      "variance decomposition",
+      "Lagrange basis polynomials",
+      "Cauchy-Schwarz inequality",
+      "approximation theory"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-1131-oq-01",
+    "range": { "startLine": 26, "endLine": 47 },
+    "type": "definition",
+    "title": "Pointwise and Integrated Variance",
+    "content": "`pointwiseVariance n nodes x` computes $\\sum_k (l_k(x) - 1/n)^2$ — the mean squared deviation of the Lagrange basis values from the uniform distribution $1/n$. `integratedVariance n nodes` integrates this over $[-1,1]$. The continuity theorem `continuous_pointwiseVariance` follows from the fact that each $l_k$ is a ratio of polynomials (continuous for distinct nodes) and finite sums/powers preserve continuity.\n\nThe continuity proof is notable for its compositionality: it builds from `continuous_id`, `continuous_const`, `Continuous.sub`, `Continuous.div_const`, `continuous_finset_prod`, and `Continuous.pow` — a tower of Mathlib continuity lemmas composed to handle the product-of-differences structure of Lagrange basis polynomials.",
+    "mathContext": "$\\text{var}(x) = \\sum_{k=1}^{n} \\left(l_k(x) - \\frac{1}{n}\\right)^2, \\quad \\int\\text{var} = \\int_{-1}^{1} \\text{var}(x)\\,dx$. Continuity: each $l_k(x) = \\prod_{i \\neq k} \\frac{x - x_i}{x_k - x_i}$ is a polynomial in $x$ (for fixed nodes), hence continuous.",
+    "significance": "key",
+    "prerequisites": [
+      "Lagrange basis polynomials",
+      "Lebesgue integration",
+      "continuous functions"
+    ],
+    "relatedConcepts": [
+      "variance",
+      "pointwise convergence",
+      "interval integrability",
+      "compositional continuity proofs"
+    ]
+  },
+  {
+    "id": "ann-variance-identity",
+    "proofId": "erdos-1131-oq-01",
+    "range": { "startLine": 49, "endLine": 79 },
+    "type": "theorem",
+    "title": "Variance Identity: The Decomposition Formula",
+    "content": "`variance_identity` proves $\\sum_k l_k(x)^2 = 1/n + \\text{var}(x)$ — the pointwise decomposition underlying the entire file. The proof expands $(l_k - 1/n)^2 = l_k^2 - 2l_k/n + 1/n^2$, sums over $k$, uses the partition of unity $\\sum l_k = 1$ to simplify the cross terms, and obtains $\\text{var}(x) = \\sum l_k^2 - 1/n$. The algebraic manipulations use `Finset.sum_add_distrib`, `Finset.mul_sum`, `field_simp`, and `ring` to handle the rational arithmetic.\n\nThis identity is the key structural insight: it separates $\\sum l_k^2$ (which appears in the integral $I$) into a constant floor $1/n$ and a non-negative excess $\\text{var}(x)$ that measures non-uniformity.",
+    "mathContext": "$\\sum_{k=1}^{n} l_k(x)^2 = \\frac{1}{n} + \\sum_{k=1}^{n} \\left(l_k(x) - \\frac{1}{n}\\right)^2$. Proof: expand squares and use $\\sum l_k = 1$ (partition of unity).",
+    "significance": "key",
+    "prerequisites": [
+      "partition of unity",
+      "algebraic manipulation",
+      "Finset.sum_add_distrib"
+    ],
+    "relatedConcepts": [
+      "bias-variance decomposition",
+      "partition of unity",
+      "sum of squares decomposition",
+      "Cauchy-Schwarz inequality"
+    ]
+  },
+  {
+    "id": "ann-node-evaluation",
+    "proofId": "erdos-1131-oq-01",
+    "range": { "startLine": 81, "endLine": 98 },
+    "type": "theorem",
+    "title": "Node Evaluation: Kronecker Delta Identity",
+    "content": "`sum_sq_at_node` proves $\\sum_k l_k(x_j)^2 = 1$ at each node $x_j$. This follows directly from the cardinal basis property: $l_j(x_j) = 1$ and $l_k(x_j) = 0$ for $k \\neq j$. The Lean proof rewrites the right-hand side as $\\sum_k (\\text{if } k = j \\text{ then } 1 \\text{ else } 0)$ and uses `lagrangeBasis_self` and `lagrangeBasis_other` from the parent file.\n\nThis is a foundational identity for interpolation: the Lagrange basis functions form a partition of unity that is maximally 'peaked' at node points.",
+    "mathContext": "$\\sum_{k=1}^{n} l_k(x_j)^2 = 0^2 + \\cdots + 1^2 + \\cdots + 0^2 = 1$ using $l_k(x_j) = \\delta_{kj}$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Lagrange basis cardinal property",
+      "Kronecker delta"
+    ],
+    "relatedConcepts": [
+      "cardinal basis",
+      "interpolation nodes",
+      "Kronecker delta"
+    ]
+  },
+  {
+    "id": "ann-variance-at-node",
+    "proofId": "erdos-1131-oq-01",
+    "range": { "startLine": 100, "endLine": 126 },
+    "type": "theorem",
+    "title": "Variance at Nodes and Positivity",
+    "content": "`variance_at_node` computes $\\text{var}(x_j) = (n-1)/n$. At node $x_j$, the $j$-th basis function contributes $(1 - 1/n)^2 = ((n-1)/n)^2$ and each of the $n-1$ others contributes $(0 - 1/n)^2 = 1/n^2$. Total: $((n-1)/n)^2 + (n-1)/n^2 = (n-1)/n$. The proof uses the variance identity and the node evaluation identity, then `field_simp` for rational simplification.\n\n`variance_pos_at_node` deduces $\\text{var}(x_j) > 0$ for $n \\geq 2$ using `positivity`. This is the seed of the strict lower bound: the variance is continuous, non-negative, and strictly positive at an interior point of $[-1,1]$.",
+    "mathContext": "$\\text{var}(x_j) = \\left(1 - \\frac{1}{n}\\right)^2 + (n-1)\\left(\\frac{1}{n}\\right)^2 = \\frac{(n-1)^2 + (n-1)}{n^2} = \\frac{n-1}{n}$. For $n \\geq 2$: $\\frac{n-1}{n} \\geq \\frac{1}{2} > 0$.",
+    "significance": "key",
+    "prerequisites": [
+      "variance_identity",
+      "sum_sq_at_node",
+      "positivity tactic"
+    ],
+    "relatedConcepts": [
+      "positivity at a point",
+      "continuous function positivity",
+      "epsilon-delta arguments"
+    ]
+  },
+  {
+    "id": "ann-integral-decomposition",
+    "proofId": "erdos-1131-oq-01",
+    "range": { "startLine": 128, "endLine": 162 },
+    "type": "theorem",
+    "title": "Integral Decomposition: I = 2/n + Integrated Variance",
+    "content": "`integral_decomposition` lifts the pointwise identity to an integral: $I = 2/n + \\int \\text{var}$. The proof substitutes the variance identity into the integrand, then splits the integral of a sum into a sum of integrals using `intervalIntegral.integral_add`. The constant integral $\\int_{-1}^{1} 1/n\\,dx = 2/n$ is computed via `intervalIntegral.integral_const` and `smul_eq_mul`.\n\n`integratedVariance_nonneg` establishes $\\int \\text{var} \\geq 0$ using `intervalIntegral.integral_nonneg` and the fact that each $(l_k(x) - 1/n)^2 \\geq 0$. This immediately recovers the Cauchy-Schwarz bound $I \\geq 2/n$.",
+    "mathContext": "$I = \\int_{-1}^{1} \\sum_k l_k(x)^2\\,dx = \\int_{-1}^{1} \\left(\\frac{1}{n} + \\text{var}(x)\\right)dx = \\frac{2}{n} + \\int_{-1}^{1} \\text{var}(x)\\,dx$.",
+    "significance": "key",
+    "prerequisites": [
+      "variance_identity",
+      "intervalIntegral.integral_add",
+      "interval integrability"
+    ],
+    "relatedConcepts": [
+      "integral decomposition",
+      "Cauchy-Schwarz inequality",
+      "non-negative integrals"
+    ]
+  },
+  {
+    "id": "ann-strict-lower-bound",
+    "proofId": "erdos-1131-oq-01",
+    "range": { "startLine": 164, "endLine": 261 },
+    "type": "theorem",
+    "title": "Strict Lower Bound: I > 2/n via Epsilon-Delta Continuity",
+    "content": "The file's main analytical result: `integratedVariance_strictly_pos` proves $\\int \\text{var} > 0$ for $n \\geq 2$, implying $I > 2/n$ via the decomposition. The proof is a textbook epsilon-delta argument formalized in Lean:\n\n1. **Seed**: $\\text{var}(x_0) = (n-1)/n > 0$ at the first node $x_0 \\in [-1,1]$\n2. **Continuity**: By `Metric.continuousAt_iff`, there exists $\\delta > 0$ such that $|y - x_0| < \\delta \\Rightarrow |\\text{var}(y) - c| < c/2$ where $c = (n-1)/n$\n3. **Localization**: Construct $[a,b] = [\\max(-1, x_0-\\delta/2), \\min(1, x_0+\\delta/2)] \\subset [-1,1]$ with $a < b$\n4. **Bound on subinterval**: For $y \\in [a,b]$, $\\text{var}(y) \\geq c/2$\n5. **Split integral**: $\\int_{-1}^{1} = \\int_{-1}^{a} + \\int_{a}^{b} + \\int_{b}^{1}$, where the flanking integrals are $\\geq 0$ and the middle integral $\\geq (c/2)(b-a) > 0$\n\nThis is a clean formalization of the standard real analysis argument: a continuous non-negative function with a positive value has positive integral.\n\n`lagrangeIntegral_strict_lower` combines this with the decomposition to get $I > 2/n$.",
+    "mathContext": "$\\int_{-1}^{1} \\text{var}(x)\\,dx \\geq \\int_{a}^{b} \\text{var}(x)\\,dx \\geq \\frac{c}{2}(b-a) > 0$ where $c = \\frac{n-1}{n}$ and $[a,b]$ is a $\\delta$-neighborhood of a node clamped to $[-1,1]$.",
+    "significance": "key",
+    "prerequisites": [
+      "continuous_pointwiseVariance",
+      "variance_pos_at_node",
+      "Metric.continuousAt_iff",
+      "intervalIntegral.integral_mono_on"
+    ],
+    "relatedConcepts": [
+      "epsilon-delta continuity",
+      "strictly positive integrals",
+      "interval decomposition",
+      "real analysis formalization"
+    ]
+  },
+  {
+    "id": "ann-conjecture-reformulation",
+    "proofId": "erdos-1131-oq-01",
+    "range": { "startLine": 263, "endLine": 293 },
+    "type": "insight",
+    "title": "Conjecture Reformulation and Main Theorem",
+    "content": "`minIntegratedVariance n` defines the infimum of the integrated variance over all node configurations. The axiom `erdos_1131_variance_conjecture` states the reformulated Erdős conjecture: $\\min \\int \\text{var} \\approx 2 - 3/n$. Since $I = 2/n + \\int \\text{var}$, this is equivalent to $\\min I \\approx 2 - 1/n$ (the original conjecture: $\\min I = 2 - (1+o(1))/n$).\n\nThe main theorem `erdos_1131_oq01` is the strict lower bound $I > 2/n$, delegating directly to `lagrangeIntegral_strict_lower`. This resolves OQ-01 of the parent problem: the Cauchy-Schwarz bound is never achieved.\n\nThe reformulation $\\min I = 2/n + \\min \\int \\text{var}$ separates the problem into an understood component ($2/n$) and an open question (the minimum integrated variance). The open question is: how uniform can a Lagrange basis be made over $[-1,1]$?",
+    "mathContext": "$\\min I = \\frac{2}{n} + \\min \\int \\text{var}$. Conjecture: $\\min \\int \\text{var} = 2 - \\frac{3+o(1)}{n}$, equivalently $\\min I = 2 - \\frac{1+o(1)}{n}$.",
+    "significance": "key",
+    "prerequisites": [
+      "integral_decomposition",
+      "sInf definition",
+      "asymptotic notation"
+    ],
+    "relatedConcepts": [
+      "infimum over configurations",
+      "open conjecture",
+      "problem reformulation",
+      "asymptotic analysis"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1131-oq-01/index.ts
+++ b/src/data/proofs/erdos-1131-oq-01/index.ts
@@ -1,9 +1,10 @@
 import type { ProofEntry } from "@/types";
 import meta from "./meta.json";
+import annotations from "./annotations.json";
 
 const entry: ProofEntry = {
   ...meta,
-  annotations: [],
+  annotations,
 };
 
 export default entry;

--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1131-oq-01",
   "title": "Lagrange Basis Variance Decomposition and Strict Lower Bound",
   "slug": "erdos-1131-oq-01",
-  "description": "Proves that the Cauchy-Schwarz bound I ≥ 2/n for Lagrange basis integrals is NEVER tight: I > 2/n strictly for n ≥ 2. Uses a variance decomposition I = 2/n + ∫variance, where the integrated variance is strictly positive by continuity and positivity at nodes.",
+  "description": "Proves that the Cauchy-Schwarz bound I ≥ 2/n for Lagrange basis integrals is NEVER tight: I > 2/n strictly for n ≥ 2. Uses a variance decomposition I = 2/n + ∫variance, where the integrated variance is strictly positive by continuity and positivity at nodes. Reformulates the open Erdős conjecture min I ≈ 2 - 1/n in terms of minimum integrated variance.",
   "meta": {
     "author": "Erdős, Szabados, Varma, Vértesi",
     "sourceUrl": "https://erdosproblems.com/1131",
@@ -27,7 +27,19 @@
     "theoremCount": 11,
     "lineCount": 293,
     "assumptions": "1 axiom: erdos_1131_variance_conjecture (reformulation of OPEN Erdős conjecture in variance form: min ∫variance ≈ 2 - 3/n). All 11 theorems fully proved, 0 sorries. Key results: variance identity, integral decomposition, strict lower bound I > 2/n via epsilon-delta continuity argument.",
-    "parentProof": "erdos-1131"
+    "parentProof": "erdos-1131",
+    "prerequisites": [
+      "Lagrange interpolation and basis polynomials",
+      "Measure theory and Lebesgue integration",
+      "Real analysis (continuity, epsilon-delta arguments)",
+      "Polynomial algebra over ordered fields"
+    ],
+    "relatedProblems": [
+      {
+        "id": "erdos-1131",
+        "relationship": "Parent formalization: defines NodeConfig, lagrangeBasis, the partition of unity, and the Cauchy-Schwarz lower bound I ≥ 2/n"
+      }
+    ]
   },
   "leanFile": {
     "imports": [
@@ -37,13 +49,147 @@
       "MeasureTheory",
       "Erdos1131"
     ],
+    "namespace": "Erdos1131OQ01",
     "axiomCount": 1,
     "sorryCount": 0,
     "theoremCount": 11,
-    "lineCount": 293
+    "lineCount": 293,
+    "mainTheorems": [
+      {
+        "name": "variance_identity",
+        "type": "structural",
+        "description": "Pointwise decomposition: Σ l_k(x)² = 1/n + Σ(l_k(x) - 1/n)²"
+      },
+      {
+        "name": "integral_decomposition",
+        "type": "structural",
+        "description": "Integral form: I = 2/n + ∫ variance"
+      },
+      {
+        "name": "integratedVariance_strictly_pos",
+        "type": "analytical",
+        "description": "∫ variance > 0 for n ≥ 2 via epsilon-delta continuity argument"
+      },
+      {
+        "name": "erdos_1131_oq01",
+        "type": "main",
+        "description": "Strict lower bound: I > 2/n for n ≥ 2 (Cauchy-Schwarz bound is never tight)"
+      }
+    ]
   },
   "overview": {
     "title": "Variance Decomposition and Strict Lower Bound",
-    "text": "This file investigates Erdős Problem #1131 by decomposing the Lagrange basis integral I = ∫₋₁¹ Σ l_k(x)² dx into a 'uniform floor' and 'variance excess'. The key structural insight is the identity I = 2/n + ∫ variance, where variance = Σ(l_k(x) - 1/n)² measures non-uniformity. This decomposition shows: (1) the Cauchy-Schwarz bound I ≥ 2/n is exactly the uniform floor contribution, (2) the bound is NEVER tight for n ≥ 2, because variance > 0 at every node point (with value (n-1)/n), and a continuous non-negative function that's positive at an interior point has positive integral. The Erdős conjecture min I = 2 - (1+o(1))/n is reformulated as min ∫variance = 2 - (3+o(1))/n, separating the well-understood floor from the open conjecture about the excess."
-  }
+    "historicalContext": "Erdős Problem #1131 asks for the minimum of $I = \\int_{-1}^{1} \\sum_k l_k(x)^2\\,dx$ over all choices of $n$ distinct interpolation nodes in $[-1,1]$. The problem arose from Fejér's 1932 study of optimal interpolation, which showed that zeros of Legendre polynomials minimize the Lebesgue function $\\Lambda_n(x) = \\sum |l_k(x)|$ in the $L^\\infty$ norm. Erdős conjectured $\\min I = 2 - (1+o(1))/n$. Szabados (1966) showed that Legendre nodes are NOT optimal for the $L^2$ problem when $n > 3$ — a surprising contrast with the $L^\\infty$ case. The best known bounds, due to Erdős, Szabados, Varma, and Vértesi (1994), are $2 - O((\\log n)^2/n) \\leq \\min I \\leq 2 - 2/(2n-1)$, leaving a logarithmic factor unresolved. This OQ-01 file contributes a structural insight: the variance decomposition $I = 2/n + \\int \\text{var}$ separates the trivial Cauchy-Schwarz floor from the genuinely hard optimization problem, and proves the floor is never achieved.",
+    "problemStatement": "For $n \\geq 2$ distinct nodes $x_1, \\ldots, x_n \\in [-1,1]$, prove the strict inequality $I = \\int_{-1}^{1} \\sum_k l_k(x)^2\\,dx > \\frac{2}{n}$. Equivalently: the Cauchy-Schwarz bound $I \\geq 2/n$ (from $\\sum l_k = 1$ and Cauchy-Schwarz) is never tight.",
+    "text": "This file investigates Erdős Problem #1131 by decomposing the Lagrange basis integral $I = \\int_{-1}^{1} \\sum l_k(x)^2\\,dx$ into a 'uniform floor' and 'variance excess'. The key structural insight is the identity $I = 2/n + \\int \\text{var}$, where $\\text{var}(x) = \\sum(l_k(x) - 1/n)^2$ measures non-uniformity. This decomposition shows: (1) the Cauchy-Schwarz bound $I \\geq 2/n$ is exactly the uniform floor contribution, (2) the bound is NEVER tight for $n \\geq 2$, because $\\text{var}(x_j) = (n-1)/n > 0$ at every node point, and a continuous non-negative function that's positive at an interior point has positive integral. The Erdős conjecture $\\min I = 2 - (1+o(1))/n$ is reformulated as $\\min \\int \\text{var} = 2 - (3+o(1))/n$, separating the well-understood floor from the open conjecture about the excess.",
+    "proofStrategy": "The proof proceeds in three stages:\n\n1. **Algebraic decomposition** (Parts I-II): Define pointwise variance $\\text{var}(x) = \\sum(l_k(x) - 1/n)^2$ and prove the identity $\\sum l_k(x)^2 = 1/n + \\text{var}(x)$ by expanding squares and using the partition of unity $\\sum l_k = 1$.\n\n2. **Node evaluation** (Part III): Compute $\\text{var}(x_j) = (n-1)/n$ at each node using the Kronecker delta property $l_k(x_j) = \\delta_{kj}$, and deduce $\\text{var}(x_j) > 0$ for $n \\geq 2$.\n\n3. **Epsilon-delta integration** (Parts IV-V): Lift the pointwise identity to $I = 2/n + \\int \\text{var}$. Prove $\\int \\text{var} > 0$ by the standard analysis argument: variance is continuous and non-negative with $\\text{var}(x_0) > 0$; by continuity, $\\text{var}(y) > c/2$ on a $\\delta$-ball around $x_0$; decompose the integral into three pieces and bound the middle piece below by $(c/2)(b-a) > 0$.",
+    "keyInsights": [
+      "**Variance decomposition separates known from unknown**: $I = 2/n + \\int \\text{var}$ cleanly splits the integral into the Cauchy-Schwarz floor (trivially computed) and the variance excess (the open problem). The Erdős conjecture becomes: how small can $\\int \\text{var}$ be?",
+      "**Lagrange basis is maximally peaked at nodes**: $\\text{var}(x_j) = (n-1)/n \\to 1$ as $n \\to \\infty$, meaning the basis functions are very far from uniform at node points. The variance measures this non-uniformity and is bounded away from zero.",
+      "**Epsilon-delta as a formalization pattern**: The strict positivity proof formalizes the textbook argument 'continuous, non-negative, positive at a point $\\Rightarrow$ positive integral' using Lean's `Metric.continuousAt_iff`, interval decomposition, and `intervalIntegral.integral_mono_on`. This pattern is reusable for any similar problem.",
+      "**The gap between $2/n$ and $2 - 1/n$ is vast**: For large $n$, $2/n \\approx 0$ while $2 - 1/n \\approx 2$. The Cauchy-Schwarz bound is extremely loose — the true minimum integral is close to 2, not close to 0. The variance excess $\\int \\text{var} \\approx 2 - 3/n$ dominates $I$ asymptotically.",
+      "**Connection to bias-variance tradeoff**: The decomposition $I = 2/n + \\int \\text{var}$ is structurally analogous to the bias-variance decomposition in statistics: $2/n$ is the 'bias' (uniform contribution) and $\\int \\text{var}$ is the 'variance' (excess from non-uniformity). Minimizing $I$ requires balancing the inherent non-uniformity of Lagrange basis functions."
+    ],
+    "prerequisites": [
+      "Lagrange interpolation and basis polynomials",
+      "Measure theory and Lebesgue integration",
+      "Real analysis (continuity, epsilon-delta arguments)",
+      "Polynomial algebra over ordered fields"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Part I: Definitions",
+      "startLine": 26,
+      "endLine": 47,
+      "summary": "Defines `pointwiseVariance` ($\\sum(l_k(x) - 1/n)^2$), `integratedVariance` ($\\int_{-1}^{1} \\text{var}\\,dx$), and proves `continuous_pointwiseVariance` via compositional continuity of Lagrange basis products.",
+      "mathContext": "$\\text{var}(x) = \\sum_{k=1}^{n} (l_k(x) - 1/n)^2$, $\\int\\text{var} = \\int_{-1}^{1} \\text{var}(x)\\,dx$."
+    },
+    {
+      "id": "variance-decomposition",
+      "title": "Part II: Variance Decomposition (Pointwise)",
+      "startLine": 49,
+      "endLine": 79,
+      "summary": "Proves `variance_identity`: $\\sum l_k(x)^2 = 1/n + \\text{var}(x)$ by expanding $(l_k - 1/n)^2$, summing, and applying the partition of unity $\\sum l_k = 1$. Uses `Finset.sum_add_distrib`, `field_simp`, and `ring`.",
+      "mathContext": "$\\sum l_k^2 = \\frac{1}{n} + \\sum (l_k - \\frac{1}{n})^2$ from $\\sum (l_k - \\frac{1}{n})^2 = \\sum l_k^2 - \\frac{2}{n}\\underbrace{\\sum l_k}_{=1} + \\frac{n}{n^2} = \\sum l_k^2 - \\frac{1}{n}$."
+    },
+    {
+      "id": "node-evaluation",
+      "title": "Part III: Node Evaluation Identity",
+      "startLine": 81,
+      "endLine": 126,
+      "summary": "Three results: `sum_sq_at_node` ($\\sum l_k(x_j)^2 = 1$ from $l_k(x_j) = \\delta_{kj}$), `variance_at_node` ($\\text{var}(x_j) = (n-1)/n$), and `variance_pos_at_node` ($\\text{var}(x_j) > 0$ for $n \\geq 2$ via `positivity`).",
+      "mathContext": "$\\text{var}(x_j) = (1-1/n)^2 + (n-1)/n^2 = (n-1)/n > 0$ for $n \\geq 2$."
+    },
+    {
+      "id": "integral-decomposition",
+      "title": "Part IV: Integral Decomposition",
+      "startLine": 128,
+      "endLine": 162,
+      "summary": "Lifts pointwise identity to $I = 2/n + \\int \\text{var}$ via `intervalIntegral.integral_add`. Proves $\\int \\text{var} \\geq 0$ from pointwise non-negativity.",
+      "mathContext": "$I = \\int_{-1}^{1} (1/n + \\text{var}(x))\\,dx = 2/n + \\int \\text{var}$."
+    },
+    {
+      "id": "strict-lower-bound",
+      "title": "Part V: Strict Lower Bound",
+      "startLine": 164,
+      "endLine": 261,
+      "summary": "The file's analytical core. Proves `integratedVariance_strictly_pos` ($\\int \\text{var} > 0$ for $n \\geq 2$) via an epsilon-delta argument: localize around a node where $\\text{var} > 0$, construct a $\\delta$-ball, bound the integral below on the ball, and combine. Deduces `lagrangeIntegral_strict_lower` ($I > 2/n$).",
+      "mathContext": "$\\int_{-1}^{1} \\text{var}\\,dx \\geq \\int_{a}^{b} \\text{var}\\,dx \\geq \\frac{c}{2}(b-a) > 0$ where $c = (n-1)/n$."
+    },
+    {
+      "id": "conjecture-reformulation",
+      "title": "Parts VI-VII: Conjecture Reformulation and Main Theorem",
+      "startLine": 263,
+      "endLine": 293,
+      "summary": "Defines `minIntegratedVariance n` as the infimum of $\\int \\text{var}$ over all node configurations. States the Erdős conjecture in variance form as an axiom. The main theorem `erdos_1131_oq01` is the strict bound $I > 2/n$.",
+      "mathContext": "$\\min I = 2/n + \\min \\int \\text{var}$. Conjecture: $\\min \\int \\text{var} = 2 - (3+o(1))/n$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves that the Cauchy-Schwarz lower bound $I \\geq 2/n$ for Lagrange basis integrals is never achieved: $I > 2/n$ strictly for $n \\geq 2$. The proof introduces a variance decomposition $I = 2/n + \\int \\text{var}$ that separates the trivial floor from a non-negative excess, then shows the excess is strictly positive via an epsilon-delta continuity argument anchored at node points where $\\text{var}(x_j) = (n-1)/n > 0$.",
+    "implications": "The variance decomposition $I = 2/n + \\int \\text{var}$ reduces the Erdős conjecture to minimizing the integrated variance. Since $2/n$ is a computable constant independent of node placement, the entire difficulty of Problem #1131 resides in the variance excess. The strict positivity $\\int \\text{var} > 0$ rules out the Cauchy-Schwarz bound as a candidate for the minimum, confirming that optimal node placement requires a more subtle analysis than uniform distribution arguments.\n\nThe epsilon-delta proof pattern — continuous non-negative function with a positive value implies positive integral — is a reusable formalization template applicable to many similar real analysis results.",
+    "openQuestions": [
+      "What is the exact asymptotic behavior of $\\min \\int \\text{var}$? The Erdős conjecture states $\\min \\int \\text{var} = 2 - (3+o(1))/n$, which would imply $\\min I = 2 - (1+o(1))/n$. Closing the logarithmic gap in the ESVV94 bounds remains open.",
+      "Can the strict lower bound be made quantitative? The current proof shows $I > 2/n$ but does not compute the gap. A quantitative bound $I \\geq 2/n + f(n)$ for some explicit $f(n)$ would strengthen the result.",
+      "For which node configurations is $\\int \\text{var}$ minimized? Chebyshev nodes give $I \\approx 2 - 2/n$ (close to the conjectured minimum), but Szabados showed they are not optimal for $n > 3$. Characterizing the optimizer is a deeper question.",
+      "Can the variance decomposition approach be extended to $L^p$ norms? The $L^1$ analog $\\int \\sum |l_k(x)|\\,dx$ (Lebesgue constants) and weighted norms are studied in approximation theory, and a similar bias-variance framework may apply."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1131",
+      "relationship": "extends",
+      "description": "Parent formalization defining NodeConfig, lagrangeBasis, partition of unity, and the Cauchy-Schwarz lower bound $I \\geq 2/n$. This OQ-01 file proves the bound is never tight and reformulates the conjecture via variance decomposition"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "The Cauchy-Schwarz inequality $I \\geq 2/n$ (from $(\\sum l_k)^2 \\leq n \\sum l_k^2$ with $\\sum l_k = 1$) is the lower bound that this file proves is never achieved"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul; Szabados, József; Varma, Arun K.; Vértesi, Péter",
+      "title": "On the convergence of Hermite-Fejér type interpolation based on Jacobi-type abscissas",
+      "year": "1994",
+      "venue": "Studia Scientiarum Mathematicarum Hungarica",
+      "note": "Best known bounds for Problem #1131: proved 2 - O((log n)²/n) ≤ min I ≤ 2 - 2/(2n-1)"
+    },
+    {
+      "authors": "Szabados, József",
+      "title": "On the norm of certain interpolating operators",
+      "year": "1966",
+      "venue": "Acta Mathematica Academiae Scientiarum Hungaricae",
+      "note": "Showed that Legendre nodes are not optimal for the L² problem when n > 3, disproving the natural conjecture from the L∞ case"
+    },
+    {
+      "authors": "Fejér, Lipót",
+      "title": "Bestimmung derjenigen Abscissen eines Intervalles, für welche die Quadratsumme der Grundfunktionen der Lagrangeschen Interpolation im Intervalle ein Möglichst kleines Maximum besitzt",
+      "year": "1932",
+      "venue": "Annali della Scuola Normale Superiore di Pisa",
+      "note": "Proved that zeros of Legendre polynomials minimize the L∞ Lebesgue function — the precursor that motivated Erdős's L² question"
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for erdos-1131-oq-01 (pass 1, quality 0 → comprehensive).

This entry had no annotations and minimal metadata. Added:

- **annotations.json**: 8 annotations covering all 293 lines of the Lean proof, with mathContext, significance, prerequisites, and relatedConcepts for each
- **historicalContext**: Fejér 1932, Szabados 1966, ESVV94 bounds
- **proofStrategy**: 3-stage approach (algebraic decomposition → node evaluation → epsilon-delta integration)
- **5 keyInsights**: variance decomposition, peaked basis, epsilon-delta pattern, gap magnitude, bias-variance analogy
- **conclusion**: summary, implications (variance reduction of conjecture, reusable proof pattern), 4 open questions
- **6 sections** covering Parts I-VII with mathContext
- **crossReferences**: erdos-1131 (parent), cauchy-schwarz
- **3 references**: ESVV94, Szabados 1966, Fejér 1932
- Updated index.ts to import annotations