### PR TITLE
Fix erdos-1131-oq-01 build: add missing sections

### DIFF
--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -29,6 +29,7 @@
     "assumptions": "1 axiom: erdos_1131_variance_conjecture (reformulation of OPEN Erdős conjecture in variance form: min ∫variance ≈ 2 - 3/n). All 11 theorems fully proved, 0 sorries. Key results: variance identity, integral decomposition, strict lower bound I > 2/n via epsilon-delta continuity argument.",
     "parentProof": "erdos-1131"
   },
+  "sections": [],
   "leanFile": {
     "imports": [
       "Proofs.Erdos1131Problem"


### PR DESCRIPTION
Adds missing sections field to meta.json, fixing TypeScript build error.