### PR TITLE
Fix: ballot-problem-oq-03-oq-02 sorry count and lineCount

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "axioms": 0,
     "mathlibDependencies": [
       {
@@ -63,7 +63,7 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 2014,
+    "lineCount": 2091,
     "theoremCount": 79,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
@@ -72,7 +72,7 @@
       "Gessel-Viennot involution theory"
     ],
     "assumptions": [
-      "cancellable_sum_eq_zero: self-inverse property of GV involution (1 sorry: needs tail-swap redesign to preserve path data)"
+      "gvCanon_membership and gvCanon_self_inverse: GV involution canonical crossing membership and self-inverse properties (2 sorries: needs tail-swap redesign to preserve path data)"
     ]
   },
   "overview": {
@@ -256,7 +256,7 @@
       "Finset"
     ],
     "namespace": "LGV",
-    "lineCount": 2014,
+    "lineCount": 2091,
     "axiomCount": 0,
     "theoremCount": 79,
     "definitionCount": 29


### PR DESCRIPTION
## Fix

Correct metadata for ballot-problem-oq-03-oq-02 (r×r LGV Lemma).

## Evidence

**Before**: `sorries: 1`, `lineCount: 2014`, assumptions text referenced `cancellable_sum_eq_zero` with "1 sorry"
**After**: `sorries: 2`, `lineCount: 2091`, assumptions text correctly references `gvCanon_membership` and `gvCanon_self_inverse` with "2 sorries"

**Verification**: `grep -c '\bsorry\b'` on code (excluding comments) yields 2 sorries at lines 1982 and 1989. `wc -l` yields 2091.

---
Automated fix by lean-mechanic agent.