### PR TITLE
Peer review: area-of-circle-oq-01-oq-02 (B-)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02/review.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/review.json
@@ -1,0 +1,143 @@
+{
+  "version": 1,
+  "proofId": "area-of-circle-oq-01-oq-02",
+  "reviewDate": "2026-03-24T12:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "B-",
+    "oneLiner": "Solid FTC Part 2 application to circle geometry with good companion structure, but annotations contain multiple factual errors about theorem statements and proof strategies.",
+    "tier": "B",
+    "tierJustification": "Core theorem is a direct application of Mathlib's integral_eq_sub_of_hasDerivAt (FTC Part 2) with the antiderivative relationship established via hasDerivAt_pow. The file provides genuine value in assembling the FTC hypotheses and extending to annuli and duality, but the heavy lifting is done by Mathlib."
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "AreaFromCircumferenceIntegral.lean, overall structure",
+      "finding": "The file is well-organized with a clear logical flow: definitions → derivative → main theorem → corollaries. The main theorem (area_from_integral, line 82) cleanly applies FTC Part 2 by assembling the derivative and integrability hypotheses. The annulus generalization (line 108) and FTC Part 1 duality (line 125) are natural extensions that add real value. The companion relationship with area-of-circle-oq-01 is well-conceived.",
+      "recommendation": "Preserve this structure as a model for other FTC-based gallery entries."
+    },
+    {
+      "severity": "minor",
+      "category": "filler",
+      "location": "area_from_integral_nonneg, line 94",
+      "finding": "This theorem has hypothesis `_hr : 0 ≤ r` (note the underscore prefix) that is never used. The proof body is just `area_from_integral r`, which works for all r : ℝ. This is a pure filler theorem — identical to the main theorem but with an unused parameter.",
+      "recommendation": "Remove area_from_integral_nonneg entirely. The main theorem already covers all r ∈ ℝ including nonneg. If a restricted-domain version is desired, it should at least use the hypothesis."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "meta.json originalContributions (6 items)",
+      "finding": "Lists 6 'original contributions' but only the first two are substantive: (1) the main FTC formalization and (2) answering the companion entry's open question. Items 3-6 (annulus formula, FTC Part 1, unit disk, scaling) are each 1-3 line corollaries — annulus_area_formula is two lines delegating to annulus_area_from_integral + ring; diff_area_eq_circumference is a direct call to integral_hasDerivAt_right; unit_disk_area specializes r=1; area_scaling uses the main theorem + ring. Listing these as 'original contributions' inflates the impression of novelty.",
+      "recommendation": "Reduce to 2-3 items. Keep the main theorem and companion answer. Combine the rest as 'corollaries including annulus area, FTC duality, and scaling law' in a single bullet."
+    },
+    {
+      "severity": "major",
+      "category": "inconsistency",
+      "location": "annotations.json, annotation 6 (ann-area-circle-oq02-06-ftc-part1)",
+      "finding": "Annotation describes the theorem as 'deriv circleArea r = circumference r' but the actual theorem diff_area_eq_circumference (line 125) proves 'HasDerivAt (fun s => ∫ ρ in 0..s, circumference ρ) (circumference r) r' — the derivative of the *integral function*, not of circleArea. These are related by FTC but are different statements. The annotation also claims the proof uses HasDerivAt.deriv, but the actual proof uses integral_hasDerivAt_right. Both the statement and the proof strategy are wrong.",
+      "recommendation": "Rewrite annotation 6 to accurately describe the theorem: it proves FTC Part 1 (derivative of the integral recovers the integrand), using integral_hasDerivAt_right with continuity hypotheses."
+    },
+    {
+      "severity": "major",
+      "category": "inconsistency",
+      "location": "annotations.json, annotation 7 (ann-area-circle-oq02-07-unit-scaling)",
+      "finding": "Two theorems are fundamentally misdescribed. (1) unit_disk_area is described as 'circleArea 1 = Real.pi' but the actual theorem (line 134) is '∫ ρ in 0..1, circumference ρ = π' — about the integral, not circleArea directly. (2) area_scaling is described as 'circleArea r = r^2 * circleArea 1' but the actual theorem (line 140) is '∫ ρ in 0..c*r, circumference ρ = c^2 * circleArea r' — a two-parameter scaling of the integral. Both the statements and proof descriptions are inaccurate.",
+      "recommendation": "Rewrite annotation 7 to match the actual theorems. unit_disk_area proves the integral over [0,1] equals π. area_scaling proves the integral over [0, c*r] equals c² times the area."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "annotations.json, annotations 4-5 (ann-area-circle-oq02-04, ann-area-circle-oq02-05)",
+      "finding": "Multiple theorems are given incorrect type signatures in the annotations. Annotation 4 says area_from_integral has '(hr : 0 ≤ r)' but the actual theorem (line 82) has no such hypothesis. Annotation 5 says area_from_integral_explicit has '(hr : 0 ≤ r)' but line 100 shows no hypothesis. Annotation 5 also says annulus_area_from_integral requires 'r₁ ≤ r₂' but line 108 has no ordering constraint. These phantom hypotheses could mislead users about when the theorems apply.",
+      "recommendation": "Remove the nonexistent hypotheses from annotations 4 and 5. The main theorem works for all r ∈ ℝ (including negative, via signed integrals), which is actually a strength worth highlighting."
+    },
+    {
+      "severity": "moderate",
+      "category": "inconsistency",
+      "location": "meta.json conclusion.summary",
+      "finding": "The conclusion states 'The proof file contains 153 lines' but the actual file (AreaFromCircumferenceIntegral.lean) has exactly 146 lines. The leanFile.lineCount field correctly says 146, contradicting the conclusion.",
+      "recommendation": "Update the conclusion to say '146 lines' to match the actual file and the leanFile.lineCount field."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "crossReferences, area-of-circle-oq-01-oq-02-oq-02",
+      "finding": "The cross-reference description says 'the same IBP technique used in the circumference integration proof extends to computing the Fourier coefficients.' This proof does NOT use integration by parts — it uses FTC Part 2 (integral_eq_sub_of_hasDerivAt). The Fourier entry may use IBP, but the claimed technique connection is inaccurate.",
+      "recommendation": "Rewrite the cross-reference to accurately describe the relationship. If the connection is through FTC (integration and differentiation being inverse operations), say that instead of claiming shared IBP technique."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "annotations.json, annotation 1 (ann-area-circle-oq02-01-header)",
+      "finding": "Cites 'Key imports: Mathlib.Analysis.SpecialFunctions.Integrals' but this module is not imported. The actual integral imports are Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic and Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus.",
+      "recommendation": "Correct the import reference to match the actual file."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "annotations.json, annotation 2 mathContext",
+      "finding": "Claims 'Real.pi: Mathlib's formalization of π = 4·arctan 1, proved transcendental via the Lindemann-Weierstrass theorem.' Mathlib defines π via trigonometric functions but does not contain a proof of π's transcendence as of Mathlib 4.26. The Lindemann-Weierstrass theorem is not formalized in Mathlib.",
+      "recommendation": "Remove the transcendence claim. State that π is defined in Mathlib and its irrationality is proved, but transcendence is not yet formalized."
+    },
+    {
+      "severity": "minor",
+      "category": "overclaim",
+      "location": "meta.json tags",
+      "finding": "The 'research' tag is inappropriate for this entry. The proof is a standard FTC application to a textbook computation (∫₀ʳ 2πρ dρ = πr²). While it answers a gallery open question, it does not constitute mathematical research. The 'extension' tag is appropriate.",
+      "recommendation": "Remove the 'research' tag. Keep 'extension' and the other tags."
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Rewrite annotations 6 and 7 to match the actual theorem statements. diff_area_eq_circumference proves HasDerivAt of the integral function (not deriv of circleArea). unit_disk_area proves the integral equals π (not circleArea 1 = π). area_scaling is a two-parameter integral scaling (not circleArea r = r²·circleArea 1).",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "high",
+      "target": "enricher",
+      "description": "Remove phantom hypotheses from annotations 4-5. area_from_integral, area_from_integral_explicit, and annulus_area_from_integral do not have nonnegativity or ordering hypotheses — they work for all real numbers.",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix meta.json: (1) conclusion line count 153→146, (2) reduce originalContributions from 6 to 2-3 items, (3) remove 'research' tag, (4) fix oq-02-oq-02 cross-reference IBP→FTC description.",
+      "status": "open"
+    },
+    {
+      "id": "ai-4",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Fix annotation 1 import reference (Mathlib.Analysis.SpecialFunctions.Integrals → actual imports) and annotation 2 π transcendence claim (Lindemann-Weierstrass not in Mathlib).",
+      "status": "open"
+    },
+    {
+      "id": "ai-5",
+      "priority": "low",
+      "target": "researcher",
+      "description": "Consider removing area_from_integral_nonneg (line 94) — it is identical to the main theorem with an unused hypothesis, pure filler.",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 7,
+    "originalityAccuracy": 6,
+    "completeness": 9,
+    "framingPrecision": 7,
+    "pedagogicalQuality": 7,
+    "internalConsistency": 5,
+    "overall": 6.8
+  },
+
+  "suggestedBestFraming": "A complete, sorry-free formalization of A(r) = ∫₀ʳ 2πρ dρ = πr² using Mathlib's FTC Part 2, complementing the companion entry's differentiation direction dA/dr = C(r). Includes annulus formula, FTC Part 1 duality, and scaling corollaries. Primary value: clean pedagogical application of the Fundamental Theorem of Calculus to circle geometry."
+}

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -384,6 +384,14 @@
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0
+    },
+    "area-of-circle-oq-01-oq-02": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-25T04:34:12Z",
+      "overallGrade": "B-",
+      "qualityScore": null,
+      "actionItems": 0,
+      "resolvedItems": 0
     }
   }
 }


### PR DESCRIPTION
Peer review of area-of-circle-oq-01-oq-02. Grade: B-. 11 findings, 5 action items.

**Key findings:**
- Solid FTC Part 2 application with clean proof architecture (positive)
- Annotations contain multiple factual errors about theorem statements (2 major)
- originalContributions list inflated from 6 to ~2 substantive items (moderate)
- Line count mismatch in conclusion (146 vs 153)
- One filler theorem (area_from_integral_nonneg with unused hypothesis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)