### PR TITLE
Enrich angle-trisection: address peer review, fix stale axiom refs

### DIFF
--- a/src/data/proofs/angle-trisection/annotations.json
+++ b/src/data/proofs/angle-trisection/annotations.json
@@ -31,7 +31,7 @@
     },
     "type": "context",
     "title": "The Three Classical Greek Problems",
-    "content": "The module docstring surveys the three famous classical Greek construction problems that drove 2000 years of mathematical effort: angle trisection, doubling the cube, and squaring the circle. It outlines the proof approach (translating geometry into algebra via field extensions), lists the axiom inventory (3 deep results: Wantzel's theorem, polynomial irreducibility, Lindemann's theorem), and catalogs the 18+ proved theorems.\n\nThe docstring carefully distinguishes the status: the three impossibility results are PROVED from the axioms (not axiomatized themselves), while the axioms encode deep results not currently in Mathlib.",
+    "content": "The module docstring surveys the three famous classical Greek construction problems that drove 2000 years of mathematical effort: angle trisection, doubling the cube, and squaring the circle. It outlines the proof approach (translating geometry into algebra via field extensions) and catalogs 23 proved theorems across 383 lines.\n\n**Current status**: Wantzel's constructibility criterion is encoded in the `IsConstructible` definition. Trisection polynomial irreducibility is proved via Eisenstein criterion (imported from companion file `AngleTrisectionCos20Gal.lean`). Lindemann's $\\pi$ transcendence is derived from the `PiTranscendental` import (which itself uses axioms). Angle trisection and cube doubling are fully axiom-free; circle squaring has a transitive axiom dependency.",
     "mathContext": "Wantzel (1837) proved trisection and cube doubling impossible: constructible $\\Rightarrow$ degree $2^n$. Lindemann (1882) proved $\\pi$ transcendental $\\Rightarrow$ circle squaring impossible. The approach: compass-straightedge $\\leftrightarrow$ quadratic extensions $\\leftrightarrow$ degree divides $2^n$.",
     "significance": "key",
     "relatedConcepts": [
@@ -230,8 +230,8 @@
       "endLine": 198
     },
     "type": "insight",
-    "title": "Wantzel's Theorem (Axiom 1)",
-    "content": "`axiom wantzel_theorem`: if $\\alpha$ is constructible with minimal polynomial degree $d > 0$, then $d \\mid 2^n$ for some $n$. This is the deep algebraic result (Wantzel, 1837) encoding the equivalence between compass-straightedge geometry and quadratic field extensions.\n\nThis is stated as an axiom because the full proof — that each construction step corresponds to a degree-2 extension — requires formalizing compass-straightedge operations as algebraic operations on field extensions, which is substantial infrastructure not in Mathlib.",
+    "title": "Wantzel's Theorem (Definition Extract)",
+    "content": "`wantzel_theorem`: if $\\alpha$ is constructible with minimal polynomial degree $d > 0$, then $d \\mid 2^n$ for some $n$. This encodes Wantzel's 1837 algebraic criterion for constructibility.\n\n**Note on proof status**: The Lean proof is `fun h _ => h.2` — it simply extracts the second component of the `IsConstructible` definition (`d > 0 ∧ ∃ n, d ∣ 2^n`). The geometric content of Wantzel's theorem (that compass-and-straightedge constructions correspond to towers of quadratic extensions) is encoded in the `IsConstructible` definition rather than proved from geometric axioms. This is a valid formalization choice — it assumes the deep result at the definition level — but the 'theorem' itself is a trivial definition unwrapping, not a non-trivial proof.",
     "mathContext": "Wantzel's theorem: $\\alpha$ constructible $\\Rightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] \\mid 2^n$. Equivalently, the Galois group of the minimal polynomial of a constructible number is a 2-group.",
     "significance": "key",
     "relatedConcepts": [
@@ -252,8 +252,8 @@
       "endLine": 214
     },
     "type": "technique",
-    "title": "Axiom 2 (Irreducibility) and Lindemann's Theorem",
-    "content": "Two results complete the algebraic setup:\n\n1. **Axiom 2** (`trisectionPolynomial_irreducible`): The polynomial $8x^3 - 6x - 1$ is irreducible over $\\mathbb{Q}$. Stated as an axiom because Mathlib's irreducibility API for specific polynomials is difficult to interface with `norm_num` verification. The computational evidence (`no_rational_roots`) makes the axiom well-justified: a degree-3 polynomial with no rational roots is irreducible over $\\mathbb{Q}$.\n\n2. **Lindemann's theorem** (`lindemann_pi_transcendental`): $\\pi$ is transcendental over $\\mathbb{Q}$. Unlike the axioms, this is **proved** from the project's own `PiTranscendental` module, which establishes transcendence over $\\mathbb{Z}$ and lifts via `IsFractionRing.isAlgebraic_iff`.",
+    "title": "Irreducibility (Proved) and Lindemann's Theorem",
+    "content": "Two results complete the algebraic setup:\n\n1. **`trisectionPolynomial_irreducible`**: The polynomial $8x^3 - 6x - 1$ is irreducible over $\\mathbb{Q}$. This was originally an axiom but is now **proved** via the companion file `AngleTrisectionCos20Gal.lean` (474 lines), which applies the Eisenstein criterion to the shifted polynomial $X^3 - 6X^2 + 9X - 3$ (Eisenstein at $p = 3$) and transfers irreducibility via an invertible linear substitution. This is genuine Galois theory formalization work.\n\n2. **`lindemann_pi_transcendental`**: $\\pi$ is transcendental over $\\mathbb{Q}$. Derived from the project's `PiTranscendental` module via `IsFractionRing.isAlgebraic_iff`. **Caveat**: `PiTranscendental.lean` itself uses axiom declarations (including `pi_transcendental`), so this result has a transitive axiom dependency — it is not axiom-free.",
     "mathContext": "Irreducibility: a cubic $f \\in \\mathbb{Q}[X]$ is irreducible iff it has no root in $\\mathbb{Q}$. Since $\\deg(f) = 3 < 4$, any non-trivial factorization must include a linear factor, hence a rational root. Transcendence: $\\pi \\notin \\overline{\\mathbb{Q}}$ (Lindemann 1882), proved here via Hermite-Lindemann-Weierstrass.",
     "significance": "key",
     "relatedConcepts": [
@@ -389,7 +389,7 @@
     },
     "type": "context",
     "title": "Summary and Proof Architecture",
-    "content": "The closing summary recaps the three impossibilities and their distinct obstruction mechanisms: trisection and cube doubling fail because degree 3 is not a power of 2, while circle squaring fails because $\\pi$ (hence $\\sqrt{\\pi}$) is transcendental.\n\nThe proof architecture is carefully documented: 3 axioms (Wantzel's theorem, irreducibility of $8x^3 - 6x - 1$, and $\\pi$'s transcendence via the imported `PiTranscendental` module) serve as the deep inputs, while 18+ theorems are fully proved from these axioms and Mathlib. This layered design separates 'assumed deep results' from 'derived consequences', making the formalization both rigorous and pedagogically transparent.",
+    "content": "The closing summary recaps the three impossibilities and their distinct obstruction mechanisms: trisection and cube doubling fail because degree 3 is not a power of 2, while circle squaring fails because $\\pi$ (hence $\\sqrt{\\pi}$) is transcendental.\n\n**Proof architecture**: Wantzel's criterion is encoded in the `IsConstructible` definition. Trisection polynomial irreducibility is proved via Eisenstein criterion in the companion file `AngleTrisectionCos20Gal.lean` (474 lines). Pi transcendence is derived from the `PiTranscendental` import (which uses axiom declarations). 23 theorems and 6 definitions in 383 lines, with 0 local axioms and 0 sorries. Angle trisection and cube doubling are fully verified (0 axioms transitively); circle squaring depends on axiomatized $\\pi$ transcendence.",
     "mathContext": "The three obstructions: (1) $[\\mathbb{Q}(\\cos 20°) : \\mathbb{Q}] = 3 \\neq 2^n$, (2) $[\\mathbb{Q}(\\sqrt[3]{2}) : \\mathbb{Q}] = 3 \\neq 2^n$, (3) $\\sqrt{\\pi}$ is transcendental $\\Rightarrow$ no finite degree over $\\mathbb{Q}$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -40,6 +40,16 @@
         "theorem": "IntermediateField",
         "description": "Field extensions",
         "module": "Mathlib.FieldTheory.IntermediateField.Basic"
+      },
+      {
+        "theorem": "IrreducibleRing",
+        "description": "Polynomial irreducibility infrastructure",
+        "module": "Mathlib.RingTheory.Polynomial.IrreducibleRing"
+      },
+      {
+        "theorem": "Tactic",
+        "description": "Proof automation (norm_num, ring, omega, decide)",
+        "module": "Mathlib.Tactic"
       }
     ],
     "originalContributions": [
@@ -72,7 +82,7 @@
         "relationship": "Further extensions of the constructibility framework"
       }
     ],
-    "assumptions": "Fully verified (0 axioms, 0 sorries). All three impossibility results proved: angle trisection, cube doubling, and circle squaring. pi_transcendental imported from PiTranscendental.lean (no longer an axiom).",
+    "assumptions": "0 local axioms, 0 sorries. Angle trisection and cube doubling: fully verified (0 axioms transitively). Circle squaring: depends on axiomatized pi_transcendental from PiTranscendental.lean (which uses axiom declarations). Wantzel's constructibility criterion is encoded in the IsConstructible definition. Trisection polynomial irreducibility is proved via Eisenstein criterion in companion file AngleTrisectionCos20Gal.lean.",
     "mathlib_version": "4.26.0"
   },
   "leanFile": {
@@ -92,8 +102,8 @@
     "axiomCount": 0,
     "theoremCount": 23,
     "lemmaCount": 0,
-    "defCount": 4,
-    "definitionCount": 4
+    "defCount": 6,
+    "definitionCount": 6
   },
   "crossReferences": [
     {
@@ -165,7 +175,7 @@
   "overview": {
     "historicalContext": "The problem of trisecting an arbitrary angle using only compass and straightedge is one of the three famous classical Greek problems, alongside doubling the cube and squaring the circle. These problems appear to have been formulated by the 5th century BCE. Hippocrates of Chios (c. 470–410 BCE) made the first recorded attempt at cube doubling by reducing it to finding two mean proportionals between 1 and 2. The Delian problem — doubling the altar of Apollo — is attributed by Eratosthenes to an oracle's demand during a plague on Delos (c. 430 BCE), though this may be apocryphal.\n\nGreek mathematicians found solutions using curves beyond compass and straightedge: Hippias's quadratrix (c. 420 BCE) could trisect angles, Menaechmus (c. 350 BCE) solved cube doubling using conic sections, and Archimedes (c. 250 BCE) demonstrated angle trisection by *neusis* (a marked ruler slid between two constraints). Nicomedes' conchoid (c. 200 BCE) could also trisect angles. These solutions were considered legitimate but geometrically 'impure' — the restriction to compass and straightedge was a philosophical choice, not a practical one.\n\nThe impossibility question remained open for two millennia until Pierre Laurent Wantzel published his proof in 1837 in the *Journal de Mathématiques Pures et Appliquées*. Wantzel, only 23 at the time, showed that compass-and-straightedge constructions correspond to towers of quadratic field extensions, so constructible numbers have degree $2^n$ over the rationals. Since $\\cos(20°)$ satisfies an irreducible cubic, its degree is 3 (not a power of 2), and the trisection of 60° is impossible. Wantzel's paper — barely 7 pages — was largely overlooked for decades; he died in 1848 at age 33 from overwork and stimulant abuse, and his priority was not fully recognized until the 20th century.\n\nThe squaring of the circle was proven impossible by Ferdinand von Lindemann in 1882, when he showed that $\\pi$ is transcendental. This was a strictly stronger result: constructibility requires algebraic degree $2^n$, but $\\pi$ has no algebraic degree at all. Lindemann's proof, building on Hermite's 1873 proof that $e$ is transcendental, completed the resolution of all three classical problems.\n\nRemarkably, angle trisection 'cranks' — amateur mathematicians claiming to have trisected the angle — persisted well into the 20th century. Augustus De Morgan catalogued such claims in his *Budget of Paradoxes* (1872), and mathematics departments continued receiving purported constructions long after Wantzel's proof.",
     "problemStatement": "Given an arbitrary angle θ, can it be divided into three equal parts using only a compass and unmarked straightedge?\n\nThe answer is NO for a general angle. In particular, a 60° angle cannot be trisected.\n\nTo trisect 60°, we would need to construct a 20° angle, which is equivalent to constructing the number cos(20°). Using the triple angle formula:\n$$\\cos(60°) = 4\\cos^3(20°) - 3\\cos(20°)$$\n$$\\frac{1}{2} = 4x^3 - 3x$$\n$$8x^3 - 6x - 1 = 0$$\n\nSo cos(20°) satisfies an irreducible cubic polynomial over ℚ.",
-    "text": "A 383-line Lean 4 formalization of the impossibility of angle trisection, doubling the cube, and squaring the circle with 37 declarations and 0 sorries. Imports `AngleTrisectionCos20Gal` (Galois group computation) and `PiTranscendental` (π transcendence, axiomatized). Angle trisection and cube doubling are fully verified; circle squaring depends on 1 axiom (pi_transcendental). The core argument: `trisectionPolynomial` ($8x^3 - 6x - 1$) is shown irreducible by exhaustive rational root checking, `cos_20_satisfies_cubic` connects it to $\\cos(20°)$ via the triple-angle formula, and `three_not_power_of_two` establishes that degree 3 is incompatible with Wantzel's constructibility criterion.",
+    "text": "A 383-line Lean 4 formalization of the impossibility of angle trisection, doubling the cube, and squaring the circle with 23 theorems, 6 definitions, and 0 sorries. Imports `AngleTrisectionCos20Gal` (Eisenstein-criterion irreducibility proof and Galois group computation, 474 lines) and `PiTranscendental` ($\\pi$ transcendence, axiomatized). Angle trisection and cube doubling are fully verified with 0 axioms transitively; circle squaring depends on axiomatized $\\pi$ transcendence. The core argument: `trisectionPolynomial` ($8x^3 - 6x - 1$) is shown irreducible via Eisenstein criterion on the shifted polynomial (companion file), `cos_20_satisfies_cubic` connects it to $\\cos(20°)$ via the triple-angle formula, and `three_not_power_of_two` establishes that degree 3 is incompatible with Wantzel's constructibility criterion (encoded in the `IsConstructible` definition).",
     "proofStrategy": "The proof proceeds in several stages:\n\n1. **Algebraic Translation**: Show that trisecting 60° requires constructing cos(20°).\n\n2. **Find the Minimal Polynomial**: Use the triple angle formula to derive that cos(20°) satisfies 8x³ - 6x - 1 = 0.\n\n3. **Prove Irreducibility**: By the rational root theorem, check that ±1, ±1/2, ±1/4, ±1/8 are not roots. For cubics, no rational roots means irreducible over ℚ.\n\n4. **Degree Argument**: Since the polynomial is irreducible of degree 3, we have [ℚ(cos 20°) : ℚ] = 3.\n\n5. **Constructibility Criterion**: Wantzel's theorem: constructible numbers have degree 2^n over ℚ.\n\n6. **Contradiction**: 3 is not a power of 2, so cos(20°) is not constructible.",
     "keyInsights": [
       "Compass and straightedge constructions correspond to quadratic field extensions - each new point requires solving at most a quadratic equation",

--- a/src/data/proofs/angle-trisection/review.json
+++ b/src/data/proofs/angle-trisection/review.json
@@ -169,21 +169,21 @@
       "description": "Update annotations to remove stale 'Axiom 1/2/3' references and reflect current code where wantzel_theorem is derived from definition and irreducibility is imported from companion file",
       "targetAgent": "enricher",
       "priority": "medium",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "action-2",
       "description": "Correct meta.json counts: theoremCount should be 23, defCount/definitionCount should be 6. Verify or remove '37 declarations' claim in overview text.",
       "targetAgent": "enricher",
       "priority": "medium",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "action-3",
       "description": "Clarify transitive axiom dependency in assumptions field: angle trisection and cube doubling are fully axiom-free, but lindemann_pi_transcendental depends on axiomatized pi_transcendental in PiTranscendental.lean",
       "targetAgent": "enricher",
       "priority": "medium",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "action-4",
@@ -197,7 +197,7 @@
       "description": "Add Mathlib.Tactic and Mathlib.RingTheory.Polynomial.IrreducibleRing to mathlibDependencies list in meta.json",
       "targetAgent": "enricher",
       "priority": "low",
-      "status": "open"
+      "status": "resolved"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Addresses all 5 enricher-targeted action items from the peer review (grade B, quality 6.8):

- **action-1 (medium)**: Removed stale 'Axiom 1/2/3' references from 4 annotations. `wantzel_theorem` now described as a definition extract, `trisectionPolynomial_irreducible` as proved via Eisenstein criterion (companion file), `lindemann_pi_transcendental` with transitive axiom caveat
- **action-2 (medium)**: Fixed `defCount`/`definitionCount` 4→6, overview text '37 declarations' → '23 theorems, 6 definitions'
- **action-3 (medium)**: Clarified transitive axiom dependency: trisection & cube doubling are axiom-free, circle squaring depends on axiomatized `pi_transcendental`
- **action-5 (low)**: Added `Mathlib.Tactic` and `Mathlib.RingTheory.Polynomial.IrreducibleRing` to `mathlibDependencies`
- Marked all 4 enricher action items as `resolved` in review.json

## Peer review findings addressed
| Finding | Severity | Status |
|---------|----------|--------|
| Stale axiom annotations | minor | Fixed |
| Inaccurate counts | minor | Fixed |
| Transitive axiom clarity | minor | Fixed |
| Missing mathlibDeps | minor | Fixed |
| Wantzel definitional | moderate | Noted in annotation |

## Test plan
- [x] All 3 JSON files validated (python3 json.load)
- [x] No annotation build errors for angle-trisection