### PR TITLE
Enrich area-of-circle-oq-01-oq-02: fix peer review items

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "context",
     "title": "Archimedes' Method: Area as Integral of Circumference Rings",
-    "content": "The header establishes the Archimedes 'sum of rings' derivation: a disk of radius r can be decomposed into thin annular rings of width dρ and circumference 2πρ, so total area = ∫₀ʳ 2πρ dρ = πr². The file formalizes this via the Fundamental Theorem of Calculus: if A'(r) = C(r) = 2πr, then A(r) = ∫₀ʳ C(ρ)dρ. Both FTC directions appear: Part 2 (integral of derivative = function difference) proves the main theorem, Part 1 (derivative of integral = integrand) closes the duality. The proof is complete (no sorries). Key imports: Mathlib.Analysis.SpecialFunctions.Integrals for the real integral machinery.",
+    "content": "The header establishes the Archimedes 'sum of rings' derivation: a disk of radius r can be decomposed into thin annular rings of width dρ and circumference 2πρ, so total area = ∫₀ʳ 2πρ dρ = πr². The file formalizes this via the Fundamental Theorem of Calculus: if A'(r) = C(r) = 2πr, then A(r) = ∫₀ʳ C(ρ)dρ. Both FTC directions appear: Part 2 (integral of derivative = function difference) proves the main theorem, Part 1 (derivative of integral = integrand) closes the duality. The proof is complete (no sorries). Key imports: Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic for interval integrals and Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus for FTC.",
     "mathContext": "**Archimedes (~250 BC)**: the area of a circle equals the area of a right triangle with legs $r$ (radius) and $C = 2\\pi r$ (circumference): $A = \\frac{1}{2} r \\cdot 2\\pi r = \\pi r^2$. **FTC reformulation**: since $A(r) = \\pi r^2$, we have $A'(r) = 2\\pi r = C(r)$, so $A(r) = \\int_0^r C(\\rho)\\,d\\rho$ by FTC Part 2 (with $A(0) = 0$). **FTC Part 1**: conversely, $\\frac{d}{dr}\\int_0^r C(\\rho)\\,d\\rho = C(r)$, confirming the derivative of area is circumference.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -19,8 +19,8 @@
       "annular rings"
     ],
     "prerequisites": [
-      "Mathlib.Analysis.SpecialFunctions.Integrals",
-      "intervalIntegral",
+      "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic",
+      "Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus",
       "HasDerivAt",
       "Real.pi"
     ]
@@ -35,7 +35,7 @@
     "type": "definition",
     "title": "circleArea and circumference: The Two Linked Functions",
     "content": "circleArea (r : ℝ) := Real.pi * r ^ 2 — the area formula as a real-valued function of radius. circumference (r : ℝ) := 2 * Real.pi * r — the perimeter formula. Both are noncomputable since Real.pi is transcendental. The relationship A'(r) = C(r) is the mathematical heart of the file: differentiation of area yields circumference. This is analogous to the sphere-ball relationship: d/dr(4πr³/3) = 4πr² (surface area). The choice of ℝ → ℝ (vs. ℝ≥0 → ℝ) allows signed arithmetic needed for the FTC proof while nonnegativity is proved separately.",
-    "mathContext": "**circleArea** $A(r) = \\pi r^2$: area of a disk of radius $r$ in $\\mathbb{R}^2$. **circumference** $C(r) = 2\\pi r$: perimeter of a circle of radius $r$. **Key relation**: $\\frac{d}{dr}A(r) = 2\\pi r = C(r)$. **Analogy**: $\\frac{d}{dr}(\\frac{4}{3}\\pi r^3) = 4\\pi r^2$ (ball volume → sphere area). **Real.pi**: Mathlib's formalization of $\\pi = 4 \\cdot \\arctan 1$, proved transcendental via the Lindemann-Weierstrass theorem.",
+    "mathContext": "**circleArea** $A(r) = \\pi r^2$: area of a disk of radius $r$ in $\\mathbb{R}^2$. **circumference** $C(r) = 2\\pi r$: perimeter of a circle of radius $r$. **Key relation**: $\\frac{d}{dr}A(r) = 2\\pi r = C(r)$. **Analogy**: $\\frac{d}{dr}(\\frac{4}{3}\\pi r^3) = 4\\pi r^2$ (ball volume → sphere area). **Real.pi**: Mathlib's formalization of $\\pi$, defined via trigonometric functions. Mathlib proves $\\pi$ is irrational (`Irrational.pi`), but transcendence (Lindemann-Weierstrass) is not yet formalized.",
     "significance": "key",
     "relatedConcepts": [
       "circleArea",
@@ -86,7 +86,7 @@
     },
     "type": "insight",
     "title": "area_from_integral: Main FTC Proof That ∫₀ʳ C(ρ)dρ = A(r)",
-    "content": "area_from_integral (r : ℝ) (hr : 0 ≤ r): ∫ ρ in 0..r, circumference ρ = circleArea r. Proof uses integral_eq_sub_of_hasDerivAt (FTC Part 2): if F has derivative f on [a,b] and f is integrable, then ∫_a^b f = F(b) - F(a). Applied with F = circleArea, f = circumference, a = 0, b = r: ∫₀ʳ C = A(r) - A(0) = πr² - 0 = πr², then simp [circleArea] closes. The integrability hypothesis is discharged by continuous_circumference.continuousOn.intervalIntegrable. area_from_integral_nonneg: the integral is nonneg (by rewriting with area_from_integral and applying mul_nonneg pi_pos.le hr²).",
+    "content": "area_from_integral (r : ℝ): ∫ ρ in 0..r, circumference ρ = circleArea r — no nonnegativity hypothesis required; the theorem holds for all r ∈ ℝ including negative values, via the signed integral convention. Proof uses integral_eq_sub_of_hasDerivAt (FTC Part 2): if F has derivative f on [a,b] and f is integrable, then ∫_a^b f = F(b) - F(a). Applied with F = circleArea, f = circumference, a = 0, b = r: ∫₀ʳ C = A(r) - A(0) = πr² - 0 = πr², then simp [circleArea] closes. The integrability hypothesis is discharged by continuous_circumference.intervalIntegrable. area_from_integral_nonneg is a convenience wrapper that accepts an unused `_hr : 0 ≤ r` and delegates to area_from_integral.",
     "mathContext": "**FTC Part 2 (Mathlib)**: `integral_eq_sub_of_hasDerivAt`: for $F$ with $F' = f$ on $[a,b]$ and $f$ integrable, $\\int_a^b f = F(b) - F(a)$. Applied here: $\\int_0^r C(\\rho)\\,d\\rho = A(r) - A(0) = \\pi r^2 - 0 = \\pi r^2$. **Boundary condition $A(0) = 0$**: $\\pi \\cdot 0^2 = 0$, giving the correct additive constant. **Integrability**: continuous functions on $[0,r]$ are automatically Riemann/Lebesgue integrable — `ContinuousOn.intervalIntegrable` handles this.",
     "significance": "key",
     "relatedConcepts": [
@@ -112,7 +112,7 @@
     },
     "type": "insight",
     "title": "Explicit Formula and Annulus Area via Linearity of Integration",
-    "content": "area_from_integral_explicit (r : ℝ) (hr : 0 ≤ r): ∫ ρ in 0..r, 2 * π * ρ = π * r^2. This unfolds circumference and uses integral_comp_mul_right or integral_mul_right to get ∫₀ʳ 2πρ dρ = 2π·∫₀ʳ ρ dρ = 2π·r²/2 = πr². annulus_area_from_integral: ∫ ρ in r₁..r₂, circumference ρ = circleArea r₂ - circleArea r₁ for r₁ ≤ r₂. Proved by area_from_integral applied at r₁ and r₂ with integral_comp_sub. annulus_area_formula: the annulus area equals π(r₂² - r₁²) = π(r₂-r₁)(r₂+r₁) — the factored form. These formalize the physical intuition: a thin ring of width Δr ≈ 2πr·Δr.",
+    "content": "area_from_integral_explicit (r : ℝ): ∫ ρ in 0..r, 2 * π * ρ = π * r^2 — unfolds circumference/circleArea in area_from_integral to expose the raw formula. No nonnegativity hypothesis; works for all r ∈ ℝ. annulus_area_from_integral (r₁ r₂ : ℝ): ∫ ρ in r₁..r₂, circumference ρ = circleArea r₂ - circleArea r₁ — no ordering constraint on r₁, r₂ needed; the signed integral handles all cases. Proved by applying FTC Part 2 directly on the interval [r₁, r₂]. annulus_area_formula (r₁ r₂ : ℝ): the annulus area equals π(r₂² - r₁²) — algebraic simplification of annulus_area_from_integral via ring. These formalize the physical intuition: a thin ring of width Δr ≈ 2πr·Δr.",
     "mathContext": "**Annulus area**: region between circles of radii $r_1 \\leq r_2$. Area $= \\pi r_2^2 - \\pi r_1^2 = \\pi(r_2^2 - r_1^2) = \\pi(r_2-r_1)(r_2+r_1)$. **Physical limit**: for thin ring $r_2 = r_1 + \\varepsilon$: area $\\approx \\pi \\cdot 2r_1 \\cdot \\varepsilon = C(r_1) \\cdot \\varepsilon$, confirming the Archimedes 'ring' picture. **Integration of $\\rho$**: $\\int_0^r \\rho\\,d\\rho = r^2/2$, a standard Riemann sum calculation. In Mathlib: `integral_pow` or direct computation via `intervalIntegral.integral_comp_mul_right`.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -138,20 +138,20 @@
     },
     "type": "insight",
     "title": "diff_area_eq_circumference: FTC Part 1 Closes the Duality",
-    "content": "diff_area_eq_circumference (r : ℝ): deriv circleArea r = circumference r. Proof: HasDerivAt.deriv applied to hasDerivAt_circleArea r — if HasDerivAt f f' x holds, then deriv f x = f' by uniqueness of derivatives. This completes the FTC loop: Part 2 (area_from_integral) says ∫₀ʳ C = A(r), and Part 1 (diff_area_eq_circumference) says d/dr(A(r)) = C(r). Together: the area function is characterized by having the circumference as its derivative with A(0) = 0. The theorem also closes the inverse relationship: differentiating ∫₀ʳ C(ρ)dρ w.r.t. r recovers C(r).",
-    "mathContext": "**FTC Part 1**: if $F(r) = \\int_0^r f(\\rho)\\,d\\rho$ and $f$ is continuous, then $F'(r) = f(r)$. Applied: $A'(r) = \\frac{d}{dr}\\int_0^r C(\\rho)\\,d\\rho = C(r)$. **Mathlib**: `HasDerivAt.deriv` converts `HasDerivAt f f' x` to `deriv f x = f'`. The `deriv` function in Lean returns 0 when the function is not differentiable, making it total; `HasDerivAt` certifies the actual derivative value. **Duality**: $\\int_0^r A'(\\rho)\\,d\\rho = A(r) - A(0)$ ↔ $\\frac{d}{dr}\\int_0^r A'(\\rho)\\,d\\rho = A'(r)$.",
+    "content": "diff_area_eq_circumference (r : ℝ): HasDerivAt (fun s => ∫ ρ in 0..s, circumference ρ) (circumference r) r — the derivative of the *integral function* at r equals the circumference at r. This is FTC Part 1 (not deriv of circleArea). Proof: applies integral_hasDerivAt_right with three hypotheses: (1) the circumference is integrable on [0, r], (2) it is strongly measurable at the filter 𝓝 r, and (3) it is continuous at r. This completes the FTC loop: Part 2 (area_from_integral) says ∫₀ʳ C = A(r), and Part 1 (diff_area_eq_circumference) says d/ds(∫₀ˢ C(ρ)dρ) = C(s). Together: integration and differentiation are inverse operations for the circumference function.",
+    "mathContext": "**FTC Part 1**: if $f$ is continuous and $F(s) = \\int_0^s f(\\rho)\\,d\\rho$, then $F'(s) = f(s)$. Applied: $\\frac{d}{ds}\\int_0^s C(\\rho)\\,d\\rho = C(s) = 2\\pi s$. **Mathlib**: `integral_hasDerivAt_right` provides this as a `HasDerivAt` statement, requiring integrability, strong measurability at the filter, and pointwise continuity. **Duality**: Part 2 says $\\int_0^r A'(\\rho)\\,d\\rho = A(r) - A(0)$; Part 1 says $\\frac{d}{dr}\\int_0^r C(\\rho)\\,d\\rho = C(r)$.",
     "significance": "key",
     "relatedConcepts": [
-      "HasDerivAt.deriv",
-      "deriv",
-      "hasDerivAt_circleArea",
+      "integral_hasDerivAt_right",
+      "intervalIntegrable",
+      "stronglyMeasurableAtFilter",
       "diff_area_eq_circumference",
       "FTC Part 1"
     ],
     "prerequisites": [
-      "HasDerivAt.deriv uniqueness",
-      "hasDerivAt_circleArea",
-      "deriv API in Lean 4"
+      "integral_hasDerivAt_right",
+      "continuous_circumference",
+      "Continuous.intervalIntegrable"
     ]
   },
   {
@@ -163,8 +163,8 @@
     },
     "type": "insight",
     "title": "Unit Disk and Scaling: Concrete Verifications of the Area Formula",
-    "content": "unit_disk_area: circleArea 1 = Real.pi — the unit disk has area π. Proved by simp [circleArea] (π * 1² = π). area_scaling (r : ℝ) (hr : 0 ≤ r): circleArea r = r ^ 2 * circleArea 1 — the area scales as r². Proved by simp [circleArea, mul_comm] — πr² = r² · π. These verify two key properties: (1) the normalization constant equals π (not 2π, 4π, etc.), and (2) the scaling law r ↦ λr sends area to λ²·area (dimensional analysis: area is 2-homogeneous). The scaling law is a special case of the general formula for how 2D measures scale under homothety.",
-    "mathContext": "**Unit disk area**: $A(1) = \\pi \\cdot 1^2 = \\pi \\approx 3.14159...$. This is both a numerical check and a definition of $\\pi$ as 'the area of the unit disk'. **Scaling law**: for homothety $T_\\lambda: x \\mapsto \\lambda x$, the 2D Lebesgue measure scales as $|T_\\lambda(E)| = \\lambda^2 |E|$. For disks: $A(\\lambda r) = \\pi(\\lambda r)^2 = \\lambda^2 \\cdot \\pi r^2 = \\lambda^2 A(r)$. Setting $r=1$: $A(\\lambda) = \\lambda^2 \\cdot A(1) = \\lambda^2 \\pi$. **Dimensional analysis**: area has dimensions $[L]^2$, so $A(cr) = c^2 A(r)$.",
+    "content": "unit_disk_area: ∫ ρ in 0..1, circumference ρ = π — the integral of circumference over [0,1] equals π, confirming the unit disk area via integration. Proved by specializing area_from_integral at r = 1, then simplifying circleArea 1 = π·1² = π. area_scaling (c r : ℝ): ∫ ρ in 0..c*r, circumference ρ = c² * circleArea r — a two-parameter scaling law showing that scaling the upper limit by c scales the integral by c². Proved by rewriting via area_from_integral then unfolding circleArea and using ring. These verify: (1) the normalization (integral over unit interval = π), and (2) the quadratic scaling of area under homothety (dimensional analysis: area is 2-homogeneous).",
+    "mathContext": "**Unit disk integral**: $\\int_0^1 2\\pi\\rho\\,d\\rho = \\pi$. This confirms that $\\pi$ is 'the area of the unit disk' via integration. **Scaling law**: $\\int_0^{cr} 2\\pi\\rho\\,d\\rho = c^2 \\cdot \\pi r^2$. For homothety $T_c: x \\mapsto cx$, the 2D Lebesgue measure scales as $|T_c(E)| = c^2 |E|$. **Dimensional analysis**: area has dimensions $[L]^2$, so $A(cr) = c^2 A(r)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "unit_disk_area",

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
@@ -15,8 +15,7 @@
       "calculus",
       "integration",
       "ftc",
-      "extension",
-      "research"
+      "extension"
     ],
     "badge": "mathlib",
     "sorries": 0,
@@ -43,12 +42,9 @@
       }
     ],
     "originalContributions": [
-      "Complete formalization of A(r) = ∫₀ʳ C(ρ) dρ via FTC Part 2",
-      "Answers the open question from the Circumference from Area gallery entry",
-      "Annulus area formula: ∫_{r₁}^{r₂} 2πρ dρ = π(r₂² - r₁²)",
-      "Duality theorem: differentiating the integral recovers the circumference (FTC Part 1)",
-      "Unit disk area verification: ∫₀¹ 2πρ dρ = π",
-      "Scaling law: changing radius by c scales area by c²"
+      "Complete formalization of A(r) = ∫₀ʳ C(ρ) dρ via FTC Part 2, assembling derivative and integrability hypotheses for Mathlib's integral_eq_sub_of_hasDerivAt",
+      "Answers the open question from the Circumference from Area gallery entry, completing the integration-differentiation duality",
+      "Corollaries: annulus area formula, FTC Part 1 duality, unit disk area, and quadratic scaling law"
     ],
     "dateAdded": "2026-02-23",
     "axiomCount": 0,
@@ -108,7 +104,7 @@
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-02",
       "relationship": "extended-by",
-      "description": "Integration by parts for Fourier coefficients of periodic functions — the same IBP technique used in the circumference integration proof extends to computing the Fourier coefficients that arise when representing geometric quantities (like arc length and curvature) as trigonometric series"
+      "description": "Integration by parts for Fourier coefficients of periodic functions — the integration techniques from Mathlib (interval integrals, FTC) used in this circumference integration proof extend to computing Fourier coefficients that arise when representing geometric quantities as trigonometric series"
     }
   ],
   "sections": [
@@ -154,7 +150,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization proves A(r) = ∫₀ʳ C(ρ) dρ using the Fundamental Theorem of Calculus, answering the open question from the Circumference from Area gallery entry. The proof uses the companion result dA/dr = C(r) as the antiderivative relationship, then applies FTC Part 2. Together with its companion, it establishes the complete integration-differentiation duality for circle geometry. The proof file contains 153 lines, 0 sorries, 0 axioms.",
+    "summary": "This formalization proves A(r) = ∫₀ʳ C(ρ) dρ using the Fundamental Theorem of Calculus, answering the open question from the Circumference from Area gallery entry. The proof uses the companion result dA/dr = C(r) as the antiderivative relationship, then applies FTC Part 2. Together with its companion, it establishes the complete integration-differentiation duality for circle geometry. The proof file contains 146 lines, 0 sorries, 0 axioms.",
     "implications": "**Theoretical Significance**: The integration-differentiation duality $A' = C$ and $A = \\int C$ is not special to circles — it holds for all dimensions.\n\nThe $n$-ball volume $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ satisfies $V_n' = S_n$ where $S_n$ is surface area, and $V_n(r) = \\int_0^r S_n(\\rho)\\, d\\rho$. This pattern reflects a deep principle in geometric measure theory: the boundary measure is the variation of the volume measure.",
     "openQuestions": [
       "Can the n-dimensional analogue V_n(r) = ∫₀ʳ S_n(ρ) dρ be formalized for all n?",
@@ -217,7 +213,7 @@
     {
       "id": "area-of-circle-oq-01-oq-02-oq-02",
       "relationship": "extended-by",
-      "description": "Integration by parts for Fourier coefficients of periodic functions — the same IBP technique used in the circumference integration proof extends to computing the Fourier coefficients that arise when representing geometric quantities (like arc length and curvature) as trigonometric series"
+      "description": "Integration by parts for Fourier coefficients of periodic functions — the integration techniques from Mathlib (interval integrals, FTC) used in this circumference integration proof extend to computing Fourier coefficients that arise when representing geometric quantities as trigonometric series"
     }
   ],
   "references": [

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/review.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/review.json
@@ -97,28 +97,28 @@
       "priority": "high",
       "target": "enricher",
       "description": "Rewrite annotations 6 and 7 to match the actual theorem statements. diff_area_eq_circumference proves HasDerivAt of the integral function (not deriv of circleArea). unit_disk_area proves the integral equals π (not circleArea 1 = π). area_scaling is a two-parameter integral scaling (not circleArea r = r²·circleArea 1).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",
       "priority": "high",
       "target": "enricher",
       "description": "Remove phantom hypotheses from annotations 4-5. area_from_integral, area_from_integral_explicit, and annulus_area_from_integral do not have nonnegativity or ordering hypotheses — they work for all real numbers.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-3",
       "priority": "medium",
       "target": "enricher",
       "description": "Fix meta.json: (1) conclusion line count 153→146, (2) reduce originalContributions from 6 to 2-3 items, (3) remove 'research' tag, (4) fix oq-02-oq-02 cross-reference IBP→FTC description.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",
       "priority": "medium",
       "target": "enricher",
       "description": "Fix annotation 1 import reference (Mathlib.Analysis.SpecialFunctions.Integrals → actual imports) and annotation 2 π transcendence claim (Lindemann-Weierstrass not in Mathlib).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-5",


### PR DESCRIPTION
Enrichment pass for area-of-circle-oq-01-oq-02. Addresses all 4 enricher-targeted action items from peer review (grade B-):

- **ai-1** (high): Rewrote annotations 6-7 to match actual Lean theorem statements
- **ai-2** (high): Removed phantom hypotheses from annotations 4-5
- **ai-3** (medium): Fixed meta.json line count, trimmed originalContributions, removed incorrect tag, fixed cross-reference
- **ai-4** (medium): Corrected import references and removed false π transcendence claim