### PR TITLE
Enrich basel-problem: fix zeta_general type accuracy

### DIFF
--- a/src/data/proofs/basel-problem/annotations.json
+++ b/src/data/proofs/basel-problem/annotations.json
@@ -240,7 +240,7 @@
     "proofId": "basel-problem",
     "range": {
       "startLine": 145,
-      "endLine": 161
+      "endLine": 164
     },
     "type": "context",
     "title": "Numerical Approximation and Convergence Rate",

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -360,8 +360,8 @@
       {
         "name": "zeta_general",
         "type": "wrapper",
-        "description": "General formula ζ(2k) = (-1)^(k+1) · 2^(2k-1) · π^(2k) · B_{2k} / (2k)!",
-        "leanType": "(k : ℕ) → HasSum (fun n : ℕ => 1 / (↑n : ℝ) ^ (2 * k)) (ζ_value k)"
+        "description": "General formula ζ(2k) = (-1)^(k+1) · 2^(2k-1) · π^(2k) · B_{2k} / (2k)! for k ≠ 0",
+        "leanType": "(k : ℕ) → k ≠ 0 → HasSum (fun n : ℕ => 1 / (↑n : ℝ) ^ (2 * k)) ((-1)^(k+1) * 2^(2*k-1) * π^(2*k) * bernoulli (2*k) / (2*k).factorial)"
       }
     ]
   }


### PR DESCRIPTION
First enrichment pass for basel-problem. Fixes factual inaccuracies:

- **mainTheorems.zeta_general**: Added missing `(hk : k ≠ 0)` hypothesis and replaced placeholder `ζ_value k` with actual Bernoulli number expression
- **Annotation coverage**: Extended last annotation range to cover full file (lines 145-164)