### PR TITLE
Enrich hilbert-17: add mathContext formulas, expand cross-references

### DIFF
--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -83,7 +83,7 @@
       "startLine": 8,
       "endLine": 82,
       "summary": "Historical exposition covering Hilbert (1888, 1900), Artin (1927), Motzkin (1967), and the proof strategy. Documents Mathlib dependencies and references.",
-      "mathContext": "Historical exposition covering Hilbert (1888, 1900), Artin (1927), Motzkin (1967), and the proof strategy. Documents Mathlib dependencies and references."
+      "mathContext": "**Hilbert's 17th Problem**: If $f \\in \\mathbb{R}[x_1,\\ldots,x_n]$ satisfies $f(\\mathbf{x}) \\geq 0$ for all $\\mathbf{x} \\in \\mathbb{R}^n$, is $f$ a sum of squares? **Artin (1927)**: Yes, as rational functions: $f = \\sum_i (g_i/h_i)^2$. **Motzkin (1967)**: Not as polynomials."
     },
     {
       "id": "definitions",
@@ -91,7 +91,7 @@
       "startLine": 92,
       "endLine": 133,
       "summary": "Defines IsSumOfSquaresPolynomial, IsSumOfSquaresMvPolynomial, IsSumOfSquaresRatFunc, IsPositiveSemidefinite, and IsPositiveSemidefiniteMv using existential quantification over Fin m.",
-      "mathContext": "Defines IsSumOfSquaresPolynomial, IsSumOfSquaresMvPolynomial, IsSumOfSquaresRatFunc, IsPositiveSemidefinite, and IsPositiveSemidefiniteMv using existential quantification over Fin m."
+      "mathContext": "**SOS**: $f$ is SOS $\\iff \\exists g_1,\\ldots,g_m$ s.t. $f = \\sum_{i=1}^m g_i^2$. **PSD**: $f$ is PSD $\\iff \\forall \\mathbf{x},\\, f(\\mathbf{x}) \\geq 0$. Three SOS variants: polynomial ($g_i \\in \\mathbb{R}[\\mathbf{x}]$), multivariate ($g_i \\in \\mathbb{R}[x_1,\\ldots,x_n]$), rational ($g_i \\in \\mathbb{R}(\\mathbf{x})$)."
     },
     {
       "id": "artin-theorem",
@@ -99,7 +99,7 @@
       "startLine": 134,
       "endLine": 183,
       "summary": "Axiomatizes artin_hilbert17 (multivariate PSD → rational-SOS) and artin_univariate (univariate PSD → rational-SOS, which is actually polynomial-SOS).",
-      "mathContext": "Axiomatizes artin_hilbert17 (multivariate PSD → rational-SOS) and artin_univariate (univariate PSD → rational-SOS, which is actually polynomial-SOS)."
+      "mathContext": "**Artin's Theorem**: $f \\in \\mathbb{R}[x_1,\\ldots,x_n],\\, f \\geq 0 \\Rightarrow f = \\sum_i (g_i/h_i)^2$ with $g_i, h_i \\in \\mathbb{R}[x_1,\\ldots,x_n]$. **Univariate case**: $f \\in \\mathbb{R}[x],\\, f \\geq 0 \\Rightarrow f = g_1^2 + g_2^2$ (polynomial squares suffice via complex factorization)."
     },
     {
       "id": "motzkin",
@@ -107,7 +107,7 @@
       "startLine": 184,
       "endLine": 268,
       "summary": "Defines motzkin polynomial, axiomatizes non-negativity (via AM-GM) and non-polynomial-SOS (via degree analysis), then derives motzkin_sos_ratfunc by applying Artin's theorem.",
-      "mathContext": "Defines motzkin polynomial, axiomatizes non-negativity (via AM-GM) and non-polynomial-SOS (via degree analysis), then derives motzkin_sos_ratfunc by applying Artin's theorem."
+      "mathContext": "**Motzkin polynomial**: $M(x,y) = x^4y^2 + x^2y^4 - 3x^2y^2 + 1 \\geq 0$ (by AM-GM: $x^4y^2 + x^2y^4 + 1 \\geq 3x^2y^2$). **Non-SOS**: $M \\neq \\sum p_i^2$ for any $p_i \\in \\mathbb{R}[x,y]$ (degree obstruction). **Key deduction**: $M \\geq 0 \\xrightarrow{\\text{Artin}} M = \\sum (g_i/h_i)^2$."
     },
     {
       "id": "hilbert-1888",
@@ -115,7 +115,7 @@
       "startLine": 269,
       "endLine": 343,
       "summary": "Axiomatizes univariate_psd_is_sos (complex factorization) and quadratic_psd_is_sos (Gram matrix / Cholesky) — the two tractable cases from Hilbert's classification.",
-      "mathContext": "Axiomatizes univariate_psd_is_sos (complex factorization) and quadratic_psd_is_sos (Gram matrix / Cholesky) — the two tractable cases from Hilbert's classification."
+      "mathContext": "**Hilbert 1888**: PSD = polynomial-SOS in exactly 3 cases: (1) univariate ($n=1$, any degree), (2) quadratic forms (any $n$, degree 2), (3) bivariate quartics ($n=2$, degree 4). **Univariate**: $f(x) \\geq 0 \\Rightarrow f = g^2 + h^2$ via $f = c\\prod(x-\\alpha_i)(x-\\bar{\\alpha}_i)$. **Quadratic**: PSD $\\iff$ Gram matrix $Q \\succeq 0$ $\\iff$ Cholesky $Q = L^TL$."
     },
     {
       "id": "pfister",
@@ -123,7 +123,7 @@
       "startLine": 344,
       "endLine": 396,
       "summary": "Axiomatizes pfister_bound (at most 2^n rational function squares for n variables) and cassels_bound_bivariate (4 squares for bivariate).",
-      "mathContext": "Axiomatizes pfister_bound (at most 2^n rational function squares for n variables) and cassels_bound_bivariate (4 squares for bivariate)."
+      "mathContext": "**Pfister bound**: $f \\in \\mathbb{R}[x_1,\\ldots,x_n],\\, f \\geq 0 \\Rightarrow f = \\sum_{i=1}^{2^n} (g_i/h_i)^2$. The bound $2^n$ is achieved by Pfister forms (multiplicative quadratic forms from tensor products). **Cassels (bivariate)**: $f \\in \\mathbb{R}[x,y],\\, f \\geq 0 \\Rightarrow f = \\sum_{i=1}^4 (g_i/h_i)^2$ ($2^2 = 4$)."
     },
     {
       "id": "real-closed",
@@ -131,7 +131,7 @@
       "startLine": 397,
       "endLine": 439,
       "summary": "Documents the role of real closed fields in Artin's proof. Includes placeholder real_is_real_closed and axiomatized real_closed_transfer principle.",
-      "mathContext": "Documents the role of real closed fields in Artin's proof. Includes placeholder real_is_real_closed and axiomatized real_closed_transfer principle."
+      "mathContext": "**Real closed fields**: $\\mathbb{R}$ is real closed (every PSD element is a sum of squares, and every odd-degree polynomial has a root). **Artin's strategy**: if $f \\geq 0$ were not SOS in $\\mathbb{R}(\\mathbf{x})$, one could order $\\mathbb{R}(\\mathbf{x})$ making $f < 0$, then pass to the real closure to get a point where $f < 0$ — contradiction."
     },
     {
       "id": "applications",
@@ -139,7 +139,7 @@
       "startLine": 440,
       "endLine": 480,
       "summary": "Documents SOS programming via SDP, Positivstellensatz, Stengle's and Schmüdgen's theorems, and applications to control theory, robotics, and formal verification.",
-      "mathContext": "Documents SOS programming via SDP, Positivstellensatz, Stengle's and Schmüdgen's theorems, and applications to control theory, robotics, and formal verification."
+      "mathContext": "**SOS programming**: Checking if $f = \\sum g_i^2$ reduces to semidefinite programming (SDP): $f$ is polynomial-SOS $\\iff$ the Gram matrix $Q$ in $f(\\mathbf{x}) = \\mathbf{v}(\\mathbf{x})^T Q\\, \\mathbf{v}(\\mathbf{x})$ satisfies $Q \\succeq 0$. **Positivstellensatz**: Certificates of positivity on semialgebraic sets $\\{\\mathbf{x} : g_i(\\mathbf{x}) \\geq 0\\}$."
     },
     {
       "id": "counterexamples",
@@ -147,7 +147,7 @@
       "startLine": 481,
       "endLine": 542,
       "summary": "Defines Robinson's 3-variable degree-6 polynomial (axiomatized PSD and non-SOS) and Choi-Lam's 4-variable degree-4 polynomial (defined only).",
-      "mathContext": "Defines Robinson's 3-variable degree-6 polynomial (axiomatized PSD and non-SOS) and Choi-Lam's 4-variable degree-4 polynomial (defined only)."
+      "mathContext": "**Robinson**: $R(x,y,z) = x^6 + y^6 + z^6 - x^4y^2 - x^2y^4 - y^4z^2 - y^2z^4 - z^4x^2 - z^2x^4 + 3x^2y^2z^2 \\geq 0$ (Schur's inequality) but $R \\notin$ polynomial-SOS. **Choi-Lam**: $1 + x^2y^2 + y^2z^2 + z^2x^2 - 4xyz \\geq 0$ (AM-GM), non-SOS in 4 variables."
     },
     {
       "id": "summary",
@@ -155,7 +155,7 @@
       "startLine": 543,
       "endLine": 572,
       "summary": "Uses #check to verify main theorems and provides a final prose overview of the complete picture: PSD → rational-SOS (Artin), but PSD ↛ polynomial-SOS (Motzkin), with Pfister's 2^n bound.",
-      "mathContext": "Uses #check to verify main theorems and provides a final prose overview of the complete picture: PSD → rational-SOS (Artin), but PSD ↛ polynomial-SOS (Motzkin), with Pfister's 2^n bound."
+      "mathContext": "**Complete picture**: $\\text{PSD} \\xrightarrow{\\text{Artin}} \\text{rational-SOS}$ (with $\\leq 2^n$ squares by Pfister), but $\\text{PSD} \\not\\Rightarrow \\text{polynomial-SOS}$ (Motzkin). Equality holds for univariate, quadratic, and bivariate quartic polynomials (Hilbert 1888)."
     }
   ],
   "conclusion": {
@@ -170,16 +170,34 @@
   },
   "crossReferences": [
     {
-      "relationship": "The univariate case of Hilbert 17 relies on complex root factorization, which is a consequence of the fundamental theorem of algebra",
-      "targetId": "fundamental-theorem-algebra"
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "foundational",
+      "description": "The univariate case of Hilbert 17 relies on complex root factorization: a non-negative f(x) factors as c·∏(x-αᵢ)(x-ᾱᵢ), and each conjugate pair contributes a sum of two squares. FTA guarantees the factorization exists."
     },
     {
-      "relationship": "Fellow Hilbert problem — Problem 10 (Diophantine equations) involves polynomial decidability, while Problem 17 involves polynomial positivity",
-      "targetId": "hilbert-10"
+      "targetId": "hilbert-10",
+      "relationship": "related",
+      "description": "Fellow Hilbert problem: Problem 10 asks about decidability of Diophantine equations (negative answer, Matiyasevich 1970), while Problem 17 asks about polynomial positivity certificates (positive answer, Artin 1927). Both concern the solvability of polynomial conditions."
     },
     {
-      "relationship": "Adjacent Hilbert problem — Problem 16 (limit cycles) also concerns real polynomial geometry, specifically the topology of real algebraic curves",
-      "targetId": "hilbert-16"
+      "targetId": "hilbert-16",
+      "relationship": "related",
+      "description": "Adjacent Hilbert problem: Problem 16 concerns the topology of real algebraic curves and limit cycles, another aspect of real polynomial geometry connected to Hilbert 17's real algebraic positivity."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "technique",
+      "description": "The AM-GM inequality proves Motzkin's polynomial is non-negative: x⁴y² + x²y⁴ + 1 ≥ 3x²y² follows directly from AM-GM on three terms. This is the simplest proof of PSD for the first known non-SOS polynomial."
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The Cauchy-Schwarz inequality is itself a sum-of-squares identity (Lagrange's identity), and SOS decompositions generalize this paradigm. The Gram matrix approach to polynomial SOS extends the inner product structure underlying Cauchy-Schwarz."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "technique",
+      "description": "The Gram matrix / Cholesky approach to quadratic SOS uses matrix theory: a quadratic form q(x) = xᵀQx is SOS iff Q ≽ 0 iff Q = LᵀL (Cholesky). Cayley-Hamilton and matrix polynomial theory underpin these decompositions."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
First enrichment pass for hilbert-17 (peer review grade C+).

- **mathContext formulas**: All 9 sections had mathContext duplicating summary text. Replaced with proper LaTeX covering Artin's theorem, Motzkin polynomial AM-GM proof, Hilbert 1888 classification, Pfister bounds, real closed field strategy, SOS/SDP programming, Robinson/Choi-Lam counterexamples, and summary dichotomy
- **crossReferences**: Expanded from 3 to 6 entries, fixed field format, added AM-GM, Cauchy-Schwarz, Cayley-Hamilton connections