### PR TITLE
Fix: amgm-inequality-oq-03-oq-01 lineCount 124 → 372

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 124,
+    "lineCount": 372,
     "focusedRange": {"startLine": 220, "endLine": 343},
     "assumptions": "0 axioms, 0 sorries. Core building blocks (Jensen, rpow arithmetic) from Mathlib; original proofs for duality identity and negative-exponent monotonicity.",
     "mathlib_version": "4.26.0"
@@ -146,7 +146,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 124,
+    "lineCount": 372,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 13,


### PR DESCRIPTION
## Fix

Update stale lineCount for amgm-inequality-oq-03-oq-01 gallery entry.

## Evidence

**Before**: `lineCount: 124` (both meta and leanFile sections)
**After**: `lineCount: 372` (matches `wc -l proofs/Proofs/AmgmInequalityOQ03.lean`)

The Lean file grew since the gallery entry was created. No other metadata changes needed.

---
Automated fix by lean-mechanic agent.