### PR TITLE
Fix: inverse-galois-oq-01 meta.lineCount 448 → 591

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -51,7 +51,7 @@
         "relationship": "Parent entry stating the Inverse Galois Problem and axiomatizing Shafarevich's theorem for solvable groups"
       }
     ],
-    "lineCount": 448,
+    "lineCount": 591,
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update stale meta.lineCount for inverse-galois-oq-01 gallery entry.

## Evidence

**Before**: `meta.lineCount: 448` (leanFile.lineCount was already correct at 591)
**After**: `meta.lineCount: 591` (matches `wc -l proofs/Proofs/InverseGaloisOQ01.lean`)

---
Automated fix by lean-mechanic agent.