### PR TITLE
Fix: erdos-1131 leanFile.lineCount 365 → 642

### DIFF
--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -143,7 +143,7 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos1131",
-    "lineCount": 365,
+    "lineCount": 642,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 6


### PR DESCRIPTION
## Fix

Update stale leanFile.lineCount for erdos-1131 gallery entry.

## Evidence

**Before**: `leanFile.lineCount: 365` (meta.lineCount was already correct at 642)
**After**: `leanFile.lineCount: 642` (matches `wc -l proofs/Proofs/Erdos1131Problem.lean`)

---
Automated fix by lean-mechanic agent.