### PR TITLE
Enrich bezout-identity-oq-03: add LaTeX mathContext formulas

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03/meta.json
@@ -87,7 +87,7 @@
       "startLine": 1,
       "endLine": 4,
       "summary": "Imports Int.GCD (Bézout coefficients), RingTheory.Coprime.Basic (IsCoprime.mul_dvd), and Tactic (linear_combination, linarith, push_cast).",
-      "mathContext": "Imports Int.GCD (Bézout coefficients), RingTheory.Coprime.Basic (IsCoprime.mul_dvd), and Tactic (linear_combination, linarith, push_cast)."
+      "mathContext": "Mathlib imports: `Int.GCD` provides Bézout coefficients $\\gcd(m,n) = mu + nv$; `RingTheory.Coprime.Basic` provides `IsCoprime` and `IsCoprime.mul_dvd` for uniqueness modulo $mn$."
     },
     {
       "id": "module-docstring",
@@ -95,7 +95,7 @@
       "startLine": 5,
       "endLine": 34,
       "summary": "Documents the open question, the answer (yes!), the explicit formula, why it works (Bézout coefficients act as selectors), and proof status (0 sorries).",
-      "mathContext": "Documents the open question, the answer (yes!), the explicit formula, why it works (Bézout coefficients act as selectors), and proof status (0 sorries)."
+      "mathContext": "**CRT via Bézout**: Given $\\gcd(m,n) = 1$ with $mu + nv = 1$, the solution $x = anv + bmu$ satisfies $x \\equiv a \\pmod{m}$ and $x \\equiv b \\pmod{n}$, unique modulo $mn$."
     },
     {
       "id": "bezout-int",
@@ -103,7 +103,7 @@
       "startLine": 35,
       "endLine": 67,
       "summary": "Two theorems: bezout_int (restates the fundamental Bézout identity for integers) and coprime_bezout (specializes to gcd = 1 case, giving m*u + n*v = 1 via push_cast and linarith).",
-      "mathContext": "Two theorems: bezout_int (restates the fundamental Bézout identity for integers) and coprime_bezout (specializes to gcd = 1 case, giving m*u + n*v = 1 via push_cast and linarith)."
+      "mathContext": "**Bézout's identity**: $\\forall m, n \\in \\mathbb{Z},\\, \\exists u, v,\\, m \\cdot u + n \\cdot v = \\gcd(m, n)$. When $\\gcd(m,n) = 1$: $mu + nv = 1$, so $nv \\equiv 1 \\pmod{m}$ and $mu \\equiv 1 \\pmod{n}$."
     },
     {
       "id": "existence",
@@ -127,7 +127,7 @@
       "startLine": 127,
       "endLine": 161,
       "summary": "crt_iscop and crt_unique_iscop: alternative formulations using IsCoprime directly. Cleaner algebraically since IsCoprime unpacks to exactly the Bézout coefficients needed.",
-      "mathContext": "crt_iscop and crt_unique_iscop: alternative formulations using IsCoprime directly. Cleaner algebraically since IsCoprime unpacks to exactly the Bézout coefficients needed."
+      "mathContext": "Alternative via `IsCoprime`: $\\text{IsCoprime}(m, n) \\iff \\exists u,v,\\, mu + nv = 1$. CRT stated as: $m \\mid (x-a) \\wedge n \\mid (x-b)$ with uniqueness via `IsCoprime.mul_dvd`: $m \\mid z \\wedge n \\mid z \\Rightarrow mn \\mid z$."
     },
     {
       "id": "combined",
@@ -135,7 +135,7 @@
       "startLine": 162,
       "endLine": 181,
       "summary": "crt_via_bezout: packages existence and uniqueness into a single theorem using transitivity of congruences.",
-      "mathContext": "crt_via_bezout: packages existence and uniqueness into a single theorem using transitivity of congruences."
+      "mathContext": "Combined theorem: $\\exists x,\\, m \\mid (x - a) \\wedge n \\mid (x - b) \\wedge \\forall y,\\, (m \\mid (y-a) \\wedge n \\mid (y-b)) \\to mn \\mid (y - x)$. Packages existence + uniqueness via `⟨x, hx_mod_m, hx_mod_n, uniqueness⟩`."
     },
     {
       "id": "examples",
@@ -151,7 +151,7 @@
       "startLine": 242,
       "endLine": 271,
       "summary": "crtInt: a computable function returning x = a*n*gcdB + b*m*gcdA. Proved correct via crtInt_mod_left and crtInt_mod_right using linear_combination with the Bézout identity.",
-      "mathContext": "crtInt: a computable function returning x = a*n*gcdB + b*m*gcdA. Proved correct via crtInt_mod_left and crtInt_mod_right using linear_combination with the Bézout identity."
+      "mathContext": "Computable function $\\text{crtInt}(a, b, m, n) = a \\cdot n \\cdot v + b \\cdot m \\cdot u$ where $(u, v) = \\text{Int.gcdA/gcdB}(m, n)$. Returns the explicit CRT witness without existential quantification."
     },
     {
       "id": "summary",
@@ -159,7 +159,7 @@
       "startLine": 272,
       "endLine": 284,
       "summary": "Documents the 5-step proof strategy and the key insight that bezout_int and IsCoprime are two faces of the same coin.",
-      "mathContext": "Documents the 5-step proof strategy and the key insight that bezout_int and IsCoprime are two faces of the same coin."
+      "mathContext": "Five-step proof: (1) Bézout gives $mu + nv = 1$, (2) construct $x = anv + bmu$, (3) verify $x \\equiv a \\pmod{m}$ and $x \\equiv b \\pmod{n}$, (4) uniqueness mod $mn$ via `IsCoprime.mul_dvd`, (5) package into combined theorem."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
First enrichment pass for bezout-identity-oq-03 (CRT via Bézout's Identity).

7 of 10 sections had auto-generated mathContext identical to summary. Replaced with proper LaTeX formulas covering Bézout's identity, CRT explicit construction, IsCoprime equivalence, combined existence+uniqueness, and computable crtInt function.