### PR TITLE
Fix: correct off-by-one lineCount in 60 gallery proofs

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
@@ -57,7 +57,7 @@
     "dateAdded": "2026-03-11",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "lineCount": 1162,
+    "lineCount": 1163,
     "assumptions": "1 axiom (Tucker's lemma in 2D axiomatized). No sorries."
   },
   "overview": {
@@ -186,7 +186,7 @@
       "Topology"
     ],
     "namespace": "BorsukUlamOQ03OQ01",
-    "lineCount": 1162,
+    "lineCount": 1163,
     "axiomCount": 1,
     "theoremCount": 47,
     "definitionCount": 4

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-02-11",
     "axiomCount": 0,
-    "lineCount": 117,
+    "lineCount": 118,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -187,7 +187,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 117,
+    "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0

--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -46,7 +46,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. All three theorems were proved by Aristotle automated proof search. No structure-encoded assumptions.",
-    "lineCount": 82,
+    "lineCount": 83,
     "prerequisites": [
       "Finite set theory (Finset operations, powerset, filter)",
       "Injective functions and the pigeonhole principle",
@@ -266,7 +266,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 82,
+    "lineCount": 83,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 1

--- a/src/data/proofs/erdos-1005/meta.json
+++ b/src/data/proofs/erdos-1005/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -230,7 +230,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/1008",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"verified\".",
     "mathlib_version": "4.26.0"
   },
@@ -134,7 +134,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -224,7 +224,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -231,7 +231,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -25,7 +25,7 @@
       901
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -215,7 +215,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 7,
-    "lineCount": 317,
+    "lineCount": 318,
     "assumptions": "7 axioms: erdos_upper, erdos_spencer_lower, erdos_spencer_improves, and 4 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -238,7 +238,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 317,
+    "lineCount": 318,
     "axiomCount": 7,
     "theoremCount": 7,
     "definitionCount": 10

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 3,
-    "lineCount": 743,
+    "lineCount": 744,
     "assumptions": "3 axiom(s) and 12 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
@@ -271,7 +271,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 743,
+    "lineCount": 744,
     "axiomCount": 3,
     "theoremCount": 17,
     "definitionCount": 22

--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -25,7 +25,7 @@
       1031
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -210,7 +210,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -63,7 +63,7 @@
       "erdos-257"
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
   },
   "overview": {
@@ -219,7 +219,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -46,7 +46,7 @@
       "Special case extraction for Rödl's r=4 theorem"
     ],
     "axiomCount": 1,
-    "lineCount": 141,
+    "lineCount": 142,
     "assumptions": "1 axiom: erdos_hajnal_rodl_theorem. See Lean source for the complete statement."
   },
   "overview": {
@@ -220,7 +220,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos108",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 0

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -49,7 +49,7 @@
       "Verified example for even numbers"
     ],
     "axiomCount": 1,
-    "lineCount": 437,
+    "lineCount": 438,
     "assumptions": "1 axiom: moreira_richter_robertson. See Lean source for the complete statement."
   },
   "overview": {
@@ -257,7 +257,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos109",
-    "lineCount": 437,
+    "lineCount": 438,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 9

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -54,7 +54,7 @@
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
     "axiomCount": 2,
-    "lineCount": 332,
+    "lineCount": 333,
     "assumptions": "2 axioms from Beker [Be25d]: beker_characterization (f_k(n) ≥ (n-1)! implies lcm divisibility) and beker_maximizer_achieves (minimal lcm-divisible k achieves (n-1)!). All other theorems are fully proved, including max_permCount_ge_sub_factorial which uses a direct n-cycle counting argument independent of Beker's results."
   },
   "overview": {
@@ -143,7 +143,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 332,
+    "lineCount": 333,
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 3

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/123",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 317,
+    "lineCount": 318,
     "assumptions": "3 axiom(s): powers23_repr, erdos_123_conjecture, erdos_lewin_357. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -116,7 +116,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 317,
+    "lineCount": 318,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$250",
     "axiomCount": 5,
-    "lineCount": 391,
+    "lineCount": 392,
     "assumptions": "5 axiom(s) and 6 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
@@ -136,7 +136,7 @@
       "Real"
     ],
     "namespace": "Erdos135",
-    "lineCount": 391,
+    "lineCount": 392,
     "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 11

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -30,7 +30,7 @@
       "Szemerédi regularity lemma (for understanding the proof chain)",
       "Roth's theorem and the corners theorem (k=3 case)"
     ],
-    "lineCount": 260,
+    "lineCount": 261,
     "assumptions": "4 axiom(s) and 1 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
     "mathlib_version": "4.26.0"
   },
@@ -113,7 +113,7 @@
       "Topology"
     ],
     "namespace": "Erdos139",
-    "lineCount": 260,
+    "lineCount": 261,
     "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 5

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -46,7 +46,7 @@
       "Formalized the KLL 2025 partial resolution"
     ],
     "axiomCount": 3,
-    "lineCount": 119,
+    "lineCount": 120,
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements."
   },
   "overview": {
@@ -219,7 +219,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 119,
+    "lineCount": 120,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 7

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -59,7 +59,7 @@
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 2,
-    "lineCount": 179,
+    "lineCount": 180,
     "assumptions": "2 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -159,7 +159,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 179,
+    "lineCount": 180,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 7

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -28,7 +28,7 @@
       "extremal combinatorics",
       "linear programming relaxation"
     ],
-    "lineCount": 290,
+    "lineCount": 291,
     "assumptions": "5 axioms: haxell_kohayakawa, tuza_for_k4_free, IsPlanar, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -136,7 +136,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 290,
+    "lineCount": 291,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 7

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -55,7 +55,7 @@
       "Formalized the irrationality question"
     ],
     "axiomCount": 5,
-    "lineCount": 186,
+    "lineCount": 187,
     "assumptions": "5 axioms: gsw_limit_exists, limit_positive, limit_less_than_one, and 2 more. See Lean source for complete statements."
   },
   "overview": {
@@ -141,7 +141,7 @@
       "Finset"
     ],
     "namespace": "Erdos168",
-    "lineCount": 186,
+    "lineCount": 187,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 7

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -56,7 +56,7 @@
       "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
     ],
     "axiomCount": 3,
-    "lineCount": 183,
+    "lineCount": 184,
     "references": [
       {
         "title": "The chromatic number of the plane is at least 5",
@@ -194,7 +194,7 @@
       "Metric"
     ],
     "namespace": "Erdos171",
-    "lineCount": 183,
+    "lineCount": 184,
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 3

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -46,7 +46,7 @@
       "Explicit connection between finite and infinite versions"
     ],
     "axiomCount": 3,
-    "lineCount": 144,
+    "lineCount": 145,
     "references": [
       {
         "title": "Monochromatic sums and products in ℕ",
@@ -155,7 +155,7 @@
       "Finset"
     ],
     "namespace": "Erdos172",
-    "lineCount": 144,
+    "lineCount": 145,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/193",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 89,
+    "lineCount": 90,
     "assumptions": "1 axiom: gerver_ramsey_2d (Gerver-Ramsey 2D theorem). collinear_symm now proved via CRT-style witness transformation.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -53,7 +53,7 @@
       "Multiple theorems proved by Aristotle including f_mono, f_le_N, L_mono, L_subpolynomial"
     ],
     "axiomCount": 0,
-    "lineCount": 808,
+    "lineCount": 809,
     "assumptions": "4 sorry(s). No axioms."
   },
   "overview": {
@@ -175,7 +175,7 @@
       "Classical"
     ],
     "namespace": "Erdos202",
-    "lineCount": 808,
+    "lineCount": 809,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 19

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -59,7 +59,7 @@
       "jacobsthal n: maximum gap function"
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
   },
   "overview": {
@@ -165,7 +165,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
     "axiomCount": 8,
-    "lineCount": 453,
+    "lineCount": 454,
     "prerequisites": [
       "Additive bases and Waring's problem",
       "Explicit vs. probabilistic constructions",
@@ -171,7 +171,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 453,
+    "lineCount": 454,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -54,7 +54,7 @@
       "Proof that powers of 2 have unbounded gaps"
     ],
     "axiomCount": 1,
-    "lineCount": 324,
+    "lineCount": 325,
     "assumptions": "1 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -170,7 +170,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 324,
+    "lineCount": 325,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erdős #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 258,
+    "lineCount": 259,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements."
   },
   "overview": {
@@ -144,7 +144,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 258,
+    "lineCount": 259,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -48,7 +48,7 @@
       "Fibonacci-like sequence example with ratio approximately φ"
     ],
     "axiomCount": 3,
-    "lineCount": 386,
+    "lineCount": 387,
     "assumptions": "3 axiom(s): geometric_series_sum, vanDoorn_Kovac_theorem, lambda_two_fails. See Lean source for complete statements."
   },
   "overview": {
@@ -147,7 +147,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 386,
+    "lineCount": 387,
     "axiomCount": 3,
     "theoremCount": 14,
     "definitionCount": 7

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -80,7 +80,7 @@
       "Classical axioms: schnirelmann_theorem, mann_theorem"
     ],
     "axiomCount": 6,
-    "lineCount": 367,
+    "lineCount": 368,
     "prerequisites": [
       "Essential components in additive number theory",
       "Lacunary sequences and their properties",
@@ -225,7 +225,7 @@
       "Filter"
     ],
     "namespace": "Erdos37",
-    "lineCount": 367,
+    "lineCount": 368,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 10

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,12 +64,12 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
     "axiomCount": 11,
-    "lineCount": 255,
+    "lineCount": 256,
     "assumptions": "11 axiom(s) and 2 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs."
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 255,
+    "lineCount": 256,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -56,7 +56,7 @@
       "Aristotle: {1,2,4} counterexample falsifying equality characterization"
     ],
     "axiomCount": 0,
-    "lineCount": 327,
+    "lineCount": 328,
     "assumptions": "2 sorry(s)."
   },
   "overview": {
@@ -163,7 +163,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 327,
+    "lineCount": 328,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 5

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -40,7 +40,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 140,
+    "lineCount": 141,
     "prerequisites": [
       "Egyptian fractions and unit fraction decompositions",
       "Ramsey theory and monochromatic structures",
@@ -133,7 +133,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos45",
-    "lineCount": 140,
+    "lineCount": 141,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 5

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
-    "lineCount": 280,
+    "lineCount": 281,
     "assumptions": "2 axiom(s) and 7 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -115,7 +115,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 280,
+    "lineCount": 281,
     "axiomCount": 2,
     "theoremCount": 10,
     "definitionCount": 6

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -51,7 +51,7 @@
       "Verified example showing exponential sequences have Fejér gaps"
     ],
     "dateAdded": "2025-12-22",
-    "lineCount": 175,
+    "lineCount": 176,
     "prerequisites": [
       "Complex analysis: entire functions, power series",
       "Lacunary (gap) series and Fabry/Fejér gap conditions",
@@ -145,7 +145,7 @@
       "Topology"
     ],
     "namespace": "Erdos517",
-    "lineCount": 175,
+    "lineCount": 176,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 3

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/551",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 603,
+    "lineCount": 604,
     "assumptions": "No axioms. 22 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -173,7 +173,7 @@
       "Finset"
     ],
     "namespace": "Erdos551",
-    "lineCount": 603,
+    "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -51,7 +51,7 @@
       "conjecture_implies_two_copies: Aristotle-proved implication"
     ],
     "axiomCount": 8,
-    "lineCount": 385,
+    "lineCount": 386,
     "prerequisites": [
       "Extremal graph theory (Turán-type problems)",
       "4-cycles (C₄) in graphs",
@@ -182,7 +182,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 385,
+    "lineCount": 386,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -59,7 +59,7 @@
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ],
-    "lineCount": 227,
+    "lineCount": 228,
     "assumptions": "No axioms. 3 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -179,7 +179,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 227,
+    "lineCount": 228,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 11

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
-    "lineCount": 218,
+    "lineCount": 219,
     "assumptions": "5 axioms: erdos_hajnal_upper_bound, erdos_624_open, weaker_conjecture_open, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -172,7 +172,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 218,
+    "lineCount": 219,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -64,7 +64,7 @@
       "PrizeValue: $1000 (false) / $100 (true)"
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
   },
   "overview": {
@@ -194,7 +194,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/629",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 911,
+    "lineCount": 912,
     "assumptions": "7 sorry(s). No axioms.",
     "mathlib_version": "4.26.0"
   },
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos629",
-    "lineCount": 911,
+    "lineCount": 912,
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -52,7 +52,7 @@
       "SoiferFamily generalization to (√p, √q, √r) triangles"
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -153,7 +153,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -49,7 +49,7 @@
       "Statement of Erdős-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
-    "lineCount": 1432,
+    "lineCount": 1433,
     "assumptions": "3 axiom(s) and 4 sorry(s)."
   },
   "overview": {
@@ -186,7 +186,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1432,
+    "lineCount": 1433,
     "axiomCount": 3,
     "theoremCount": 45,
     "definitionCount": 15

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -65,7 +65,7 @@
       "Sunflower connection: relationship to Erdős-Rado sunflower lemma"
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -199,7 +199,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -57,7 +57,7 @@
       "Guth-Katz theorem statement for general distinct distances"
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"verified\".",
     "mathlib_version": "4.26.0"
   },
@@ -137,7 +137,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -63,7 +63,7 @@
       "MainConjecture definition: Q1 iff Q2?"
     ],
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
   },
   "overview": {
@@ -197,7 +197,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -64,7 +64,7 @@
       "Chebyshev-type bounds on prime products",
       "Native decision procedures in Lean 4"
     ],
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -163,7 +163,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -33,7 +33,7 @@
       "Nat.cast_div",
       "native_decide"
     ],
-    "lineCount": 292,
+    "lineCount": 293,
     "assumptions": "None. Fully verified: 0 axioms, 0 sorries. The open conjecture (Erdos686Conjecture) is stated as a Prop definition, not axiomatized. All supporting infrastructure is proved.",
     "mathlib_version": "4.26.0"
   },
@@ -205,7 +205,7 @@
       "Nat"
     ],
     "namespace": "Erdos686",
-    "lineCount": 292,
+    "lineCount": 293,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 8

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -45,7 +45,7 @@
       "Structure connecting Problem 69 to Problem 257"
     ],
     "axiomCount": 0,
-    "lineCount": 188,
+    "lineCount": 189,
     "prerequisites": [
       "Arithmetic functions (ω, d, Ω) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",
@@ -194,7 +194,7 @@
       "Finset"
     ],
     "namespace": "Erdos69",
-    "lineCount": 188,
+    "lineCount": 189,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 2

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 518,
+    "lineCount": 519,
     "assumptions": "15 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 518,
+    "lineCount": 519,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 7

--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/840",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"verified\".",
     "mathlib_version": "4.26.0"
   },
@@ -125,7 +125,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -61,7 +61,7 @@
       "convex_distinct_distances/convex_max_multiplicity/convex_unit_distance: related bounds"
     ],
     "axiomCount": 0,
-    "lineCount": 432,
+    "lineCount": 433,
     "assumptions": "No axioms. 12 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -182,7 +182,7 @@
       "Real"
     ],
     "namespace": "Erdos94",
-    "lineCount": 432,
+    "lineCount": 433,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 16

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -58,7 +58,7 @@
       "generalizedQuestion: Problem #1107 connection"
     ],
     "axiomCount": 4,
-    "lineCount": 326,
+    "lineCount": 327,
     "assumptions": "4 axiom(s) and 2 sorry(s)."
   },
   "overview": {
@@ -182,7 +182,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 326,
+    "lineCount": 327,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/977",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 0,
+    "lineCount": 1,
     "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
     "mathlib_version": "4.26.0"
   },
@@ -138,7 +138,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
+    "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21110,
+    "lineCount": 21111,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -264,7 +264,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 5,
     "theoremCount": 1009,
     "definitionCount": 104

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Theorem total_dissipation_bound: ∫₀ᵀ 2νP(t) dt ≤ E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries.",
     "relatedProblems": [
       {
@@ -181,7 +181,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 1009,
     "definitionCount": 104

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -59,7 +59,7 @@
       "Theorem continuous_dependence_2d: for any ε > 0, threshold δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -202,7 +202,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 846,
     "definitionCount": 104

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21110
+    "lineCount": 21111
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",
@@ -335,7 +335,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21110,
+    "lineCount": 21111,
     "structureCount": 249,
     "axiomCount": 5,
     "theoremCount": 832,


### PR DESCRIPTION
## Fix

Correct `meta.lineCount` and `leanFile.lineCount` for 60 gallery proofs that were all off by exactly -1 (trailing newline not counted).

## Evidence

**Before**: `lineCount` was 1 less than actual file line count (e.g., erdos-1: meta=82, actual=83)
**After**: All 60 proofs now have `lineCount` matching actual Lean file line counts

Affected proofs include erdos-*, navier-stokes-*, borsuk-ulam-oq-03-oq-01, cauchy-schwarz-integral, and others.

Build validated: `pnpm build` passes.

---
Automated fix by lean-mechanic agent.