### PR TITLE
Fix: erdos-269 section ranges (inverted and misaligned)

### DIFF
--- a/src/data/proofs/erdos-269/meta.json
+++ b/src/data/proofs/erdos-269/meta.json
@@ -139,43 +139,43 @@
     },
     {
       "id": "examples",
-      "title": "Examples",
+      "title": "Part VII: Examples",
       "summary": "P = {2,3} worked examples",
-      "startLine": 194,
-      "endLine": 229,
+      "startLine": 180,
+      "endLine": 195,
       "mathContext": "P = {2,3} worked examples"
     },
     {
       "id": "padic",
-      "title": "Structural Properties",
+      "title": "Part VIII: Structural Properties",
       "summary": "P-adic valuation analysis",
-      "startLine": 230,
-      "endLine": 257,
+      "startLine": 196,
+      "endLine": 209,
       "mathContext": "P-adic valuation analysis"
     },
     {
       "id": "difficulty",
-      "title": "Why It's Hard",
+      "title": "Part IX: Why It's Hard",
       "summary": "Analysis of the finite P difficulty",
-      "startLine": 258,
-      "endLine": 273,
+      "startLine": 210,
+      "endLine": 223,
       "mathContext": "Analysis of the finite P difficulty"
     },
     {
       "id": "partial-result",
-      "title": "Known Partial Result",
-      "summary": "Distinct terms case is solved",
-      "startLine": 284,
-      "endLine": 273,
-      "mathContext": "Distinct terms case is solved"
+      "title": "Part X: Known Partial Result",
+      "summary": "Distinct terms case is solved (distinctLcmTerms, erdos_269_distinct axiom)",
+      "startLine": 224,
+      "endLine": 241,
+      "mathContext": "Distinct terms case is solved (distinctLcmTerms, erdos_269_distinct axiom)"
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_269_summary theorem",
-      "startLine": 308,
-      "endLine": 273,
-      "mathContext": "erdos_269_summary theorem"
+      "title": "Part XI: Summary",
+      "summary": "erdos_269_summary theorem, erdos_269_conjecture restating the main open problem",
+      "startLine": 242,
+      "endLine": 275,
+      "mathContext": "erdos_269_summary theorem, erdos_269_conjecture restating the main open problem"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Correct section line ranges for erdos-269 gallery entry.

## Evidence

**Before**: Sections `partial-result` and `summary` had inverted ranges (startLine > endLine). Sections `examples`, `padic`, `difficulty` had ranges misaligned with actual Part headers.

**After**: All 5 affected sections corrected to match `grep -n '## Part' proofs/Proofs/Erdos269Problem.lean`:
- Part VII: 180-195, Part VIII: 196-209, Part IX: 210-223
- Part X: 224-241, Part XI: 242-275

---
Automated fix by lean-mechanic agent.