### PR TITLE
Fix: clamp section endLine overflow in 7 gallery proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -126,7 +126,7 @@
       "id": "rightmost-good-sketch",
       "title": "Rightmost-Is-Good Sketch (Placeholder)",
       "startLine": 110,
-      "endLine": 131,
+      "endLine": 130,
       "summary": "Placeholder theorem `rightmost_is_good_sketch` (proves 1+1=2 via rfl) with a detailed docstring explaining why the rightmost position i with P(i)=v yields a good rotation. Non-wrapping case: rightmostness forces P(i+offset) > v. Wrapping case: v < minPS + S gives positivity for wrap-around prefix sums. The docstring is valuable exposition; the theorem itself is not yet formalized.",
       "mathContext": "For the rotation starting at position $i$ with $P(i) = v$, define the cyclic prefix sum $\\mathrm{cps}(\\text{off}) = P((i + \\text{off}) \\bmod n) - P(i) + \\epsilon$ where $\\epsilon$ accounts for wrap-around. Non-wrapping ($\\text{off} \\leq n - i$): $\\mathrm{cps}(\\text{off}) = P(i + \\text{off}) - v > 0$ by rightmostness. Wrapping ($\\text{off} > n - i$): $\\mathrm{cps}(\\text{off}) = P(r) + S - v \\geq \\mu + S - v > 0$ since $v < \\mu + S$."
     }

--- a/src/data/proofs/cantor-diagonalization-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/meta.json
@@ -134,7 +134,7 @@
       "id": "verification",
       "title": "Verification Checks",
       "startLine": 144,
-      "endLine": 150,
+      "endLine": 149,
       "summary": "#check statements verifying that all five main results (lawvere_fixpoint, cantor, cantor_bool, russell, diagonal_not_in_range) are defined and type-correct.",
       "mathContext": "Lean's #check command confirms each theorem has the expected type signature."
     }

--- a/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
@@ -122,7 +122,7 @@
       "title": "Growth Classification and Summary",
       "summary": "Unconditional growth bracket: $d \\le f(d) \\le d(d+1)/2$ for all $d \\ge 1$, bounding growth between linear and quadratic. The $d=4$ anomaly analysis ($\\delta(4) = 1$), quadratic sandwich verification for $d \\le 5$, and summary of 15 key theorem exports.",
       "startLine": 294,
-      "endLine": 389,
+      "endLine": 388,
       "mathContext": "$d \\leq f(d) \\leq d(d+1)/2 = \\binom{d+1}{2}$ for $d \\geq 1$. The lower bound is tight at $d = 1$ ($f(1) = 1$); the upper bound is tight at $d \\in \\{1,2,3,5\\}$ (where $f(d) = \\binom{d+1}{2}$)."
     }
   ],

--- a/src/data/proofs/erdos-103-oq-01/meta.json
+++ b/src/data/proofs/erdos-103-oq-01/meta.json
@@ -153,7 +153,7 @@
       "id": "verification",
       "title": "Export and Verification",
       "startLine": 356,
-      "endLine": 368,
+      "endLine": 367,
       "summary": "#check statements verifying all main results: pointDist_eq_zero_iff, isometry2D_injective, congruent_symm, oscillating_unbounded/not_tendsto, unbounded_not_implies_tendsto, mono_unbounded_iff_tendsto, conjecture_equiv_mono, conjecture_chain.",
       "mathContext": "Lean's #check confirms type-correctness of all 11 exported theorems."
     }

--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -72,7 +72,7 @@
       "id": "finiteness-and-criterion",
       "title": "Guy's Finiteness Conjecture and Robin's Criterion",
       "startLine": 124,
-      "endLine": 153,
+      "endLine": 152,
       "summary": "Guy's stronger conjecture (finitely many k-perfect numbers for each k ≥ 3) and the derivation of k = O(log log n) from Robin's criterion."
     }
   ],

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -93,7 +93,7 @@
       "id": "conjectures",
       "title": "The Erdős Problem and Generalization",
       "startLine": 61,
-      "endLine": 86,
+      "endLine": 85,
       "summary": "States ErdosProblem279 for general k ≥ 3 (existence of a covering residue choice), ErdosProblem279_k3 for the specific k = 3 case, the GeneralizedCovering definition using a choice function on an arbitrary set A, and ErdosProblem279_generalized asserting that any set with prime-like density and log-log divergence admits a covering.",
       "mathContext": "Main conjecture: `axiom ErdosProblem279 (k : ℕ) (hk : 3 ≤ k) : ∃ a : ResidueChoice, CoversEventually a k`. The $k = 3$ instance follows by `le_refl 3`. The generalized conjecture replaces primes with arbitrary $A \\subseteq \\mathbb{N}$ satisfying density conditions, using `GeneralizedCovering A k` which existentially quantifies over a choice function on $A$."
     }

--- a/src/data/proofs/erdos-390/meta.json
+++ b/src/data/proofs/erdos-390/meta.json
@@ -82,7 +82,7 @@
       "id": "open-conjecture",
       "title": "The Open Conjecture",
       "startLine": 351,
-      "endLine": 362,
+      "endLine": 361,
       "summary": "Defines `ErdosProblem390`: does $\\lim_{n \\to \\infty} (f(n) - 2n) \\cdot \\log n / n = c$ exist with $c > 0$? Formalized via `Filter.Tendsto` to `nhds c`."
     }
   ],


### PR DESCRIPTION
## Fix

Clamp `sections[].endLine` to actual file line count in 7 proofs where the final section exceeded file length by 1.

## Evidence

| Proof | Section | Before | After |
|-------|---------|--------|-------|
| ballot-problem-oq-01-oq-01 | rightmost-good-sketch | 131 | 130 |
| cantor-diagonalization-oq-03 | verification | 150 | 149 |
| erdos-1007-oq-01-oq-01 | growth-classification | 389 | 388 |
| erdos-103-oq-01 | verification | 368 | 367 |
| erdos-1053 | finiteness-and-criterion | 153 | 152 |
| erdos-279 | conjectures | 86 | 85 |
| erdos-390 | open-conjecture | 362 | 361 |

Build validated: `pnpm build` passes.

---
Automated fix by lean-mechanic agent.