### PR TITLE
Research: abel-ruffini-oq-04-oq-01 - Eliminate Axiom B via Vandermonde

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01.lean
@@ -569,30 +569,204 @@ theorem no_subgroup_order_30 (H : Subgroup (Equiv.Perm (Fin 5)))
     exact no_subgroup_order_15 K hK_card
 
 -- ============================================================================
--- Part V(e): Axiom Decomposition for |Gal(p/ℚ)| = 120
+-- Part V(e): Vandermonde Product and Discriminant → Odd Permutation
 -- ============================================================================
 
 /-
-## Axiom Decomposition
+## Vandermonde Product Approach
 
-The original axiom `gal_card_eq_120 : Fintype.card p.Gal = 120` has been
-decomposed into two narrower axioms, each corresponding to a specific
-theorem not yet in Mathlib:
+The Vandermonde product Δ = det(vandermonde(rootEnum)) satisfies:
+  σ(Δ) = sign(σ) · Δ for every σ ∈ Gal(p/ℚ).
 
-**Axiom A (Dedekind at p = 13):** 3 | |Gal(p/ℚ)|.
-  x⁵ - 4x + 2 mod 13 factors as (x-2)(x-5)(x³+7x²+8).
-  The cubic has no roots mod 13 (cubic_factor_no_roots_mod13), hence is
-  irreducible over F₁₃. By Dedekind's theorem, the Frobenius at 13 has
-  cycle type (1,1,3), giving an element of order 3 in the Galois group.
-  Supporting computations: p_root_mod13_at_2, p_root_mod13_at_5.
+If Δ² ∈ ℚ is not a perfect square, then Δ ∉ ℚ, so some σ has sign(σ) = -1.
 
-**Axiom B (Discriminant → Odd Permutation):**
-  disc(p) = Res(p, p') = -212144 < 0.
-  Since the Vandermonde product Δ satisfies Δ² = disc(p) < 0, we have
-  Δ ∉ ℚ (no rational squares negative). The Galois action σ(Δ) = sign(σ)·Δ
-  with Δ ∉ ℚ implies ∃ σ with sign(σ) = -1, i.e., Gal ⊄ A₅.
-  Requires: disc(f) = Δ² identity (not in Mathlib).
+For p = x⁵ - 4x + 2: disc(p) = Δ² = -212144 < 0 (not a perfect square in ℚ),
+so Gal(p) contains an odd permutation (Gal ⊄ A₅).
+
+The approach follows InverseGaloisA5.lean's Vandermonde infrastructure.
 -/
+
+-- Abbreviation for the splitting field
+private abbrev SF := p.SplittingField
+
+-- Section E1: Root Enumeration
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- Canonical enumeration of the 5 roots of p in its splitting field. -/
+noncomputable def rootEnum : Fin 5 → SF :=
+  fun i => ((Fintype.equivOfCardEq (by rw [p_rootSet_card, Fintype.card_fin]) :
+    p.rootSet p.SplittingField ≃ Fin 5).symm i : SF)
+
+/-- Each value of rootEnum is a root of p. -/
+theorem rootEnum_is_root (i : Fin 5) :
+    Polynomial.aeval (rootEnum i) p = 0 := by
+  unfold rootEnum
+  have hmem := ((Fintype.equivOfCardEq (by rw [p_rootSet_card, Fintype.card_fin]) :
+    p.rootSet p.SplittingField ≃ Fin 5).symm i).prop
+  rw [Polynomial.mem_rootSet] at hmem
+  exact hmem.2
+
+/-- The roots are distinct (p is separable). -/
+theorem rootEnum_injective : Function.Injective rootEnum := by
+  intro i j hij
+  unfold rootEnum at hij
+  have hsub : (Fintype.equivOfCardEq (by rw [p_rootSet_card, Fintype.card_fin]) :
+    p.rootSet p.SplittingField ≃ Fin 5).symm i =
+    (Fintype.equivOfCardEq (by rw [p_rootSet_card, Fintype.card_fin]) :
+    p.rootSet p.SplittingField ≃ Fin 5).symm j := Subtype.ext hij
+  exact (Fintype.equivOfCardEq (by rw [p_rootSet_card, Fintype.card_fin]) :
+    p.rootSet p.SplittingField ≃ Fin 5).symm.injective hsub
+
+-- Section E2: Vandermonde Product
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- The Vandermonde product of p's roots:
+    Δ = det(vandermonde(rootEnum)) = ∏_{i<j} (rootEnum j - rootEnum i). -/
+noncomputable def vandermondeProduct : SF :=
+  Matrix.det (Matrix.vandermonde rootEnum)
+
+/-- The Vandermonde product is nonzero (since p is separable, all roots are distinct). -/
+theorem vandermondeProduct_ne_zero : vandermondeProduct ≠ 0 := by
+  unfold vandermondeProduct
+  rw [Matrix.det_vandermonde]
+  intro h
+  rw [Finset.prod_eq_zero_iff] at h
+  obtain ⟨i, _, hi⟩ := h
+  rw [Finset.prod_eq_zero_iff] at hi
+  obtain ⟨j, hj, hij⟩ := hi
+  have hne : j ≠ i := by simp [Finset.mem_Iio] at hj; omega
+  exact hne (rootEnum_injective (sub_eq_zero.mp hij))
+
+-- Section E3: Galois Action on Vandermonde Product
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- The Galois group permutes roots according to galToPerm5. -/
+theorem gal_permutes_roots (σ : p.Gal) (i : Fin 5) :
+    σ (rootEnum i) = rootEnum (galToPerm5 σ i) := by
+  unfold rootEnum galToPerm5 galPermHomAux
+  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.coe_mk,
+    Equiv.toFun_as_coe, Equiv.permCongr_apply, Equiv.symm_apply_apply,
+    MulAction.toPermHom_apply]
+  rfl
+
+/-- Vandermonde with permuted input = row-permuted Vandermonde. -/
+private theorem vandermonde_comp_eq_submatrix
+    (v : Fin 5 → SF) (π : Equiv.Perm (Fin 5)) :
+    Matrix.vandermonde (v ∘ π) = (Matrix.vandermonde v).submatrix π id := by
+  ext i j; simp [Matrix.vandermonde, Matrix.submatrix, Function.comp]
+
+/-- Vandermonde permutation: det(V(v ∘ π)) = sign(π) · det(V(v)). -/
+private theorem vandermonde_perm_det
+    (v : Fin 5 → SF) (π : Equiv.Perm (Fin 5)) :
+    (Matrix.vandermonde (v ∘ π)).det =
+    ↑↑(Equiv.Perm.sign π) * (Matrix.vandermonde v).det := by
+  rw [vandermonde_comp_eq_submatrix]
+  exact Matrix.det_permute π (Matrix.vandermonde v)
+
+/-- σ maps the Vandermonde matrix entry-wise according to root permutation. -/
+private theorem gal_map_vandermonde_entry (σ : p.Gal) (i j : Fin 5) :
+    σ ((Matrix.vandermonde rootEnum) i j) =
+    (Matrix.vandermonde (rootEnum ∘ galToPerm5 σ)) i j := by
+  simp only [Matrix.vandermonde, Matrix.of_apply, Function.comp]
+  rw [map_pow]
+  congr 1
+  exact gal_permutes_roots σ i
+
+/-- **σ(Δ) = galSign(σ) · Δ** — the Galois action on the Vandermonde determinant
+    equals the sign of the induced permutation times the determinant. -/
+theorem gal_acts_on_vandermondeProduct (σ : p.Gal) :
+    σ vandermondeProduct = ↑↑(galSign σ) * vandermondeProduct := by
+  unfold vandermondeProduct galSign
+  trans (Matrix.vandermonde (rootEnum ∘ galToPerm5 σ)).det
+  · change σ.toAlgHom.toRingHom (Matrix.vandermonde rootEnum).det =
+      (Matrix.vandermonde (rootEnum ∘ galToPerm5 σ)).det
+    rw [RingHom.map_det]
+    congr 1; ext i j
+    simp only [RingHom.mapMatrix_apply]
+    change σ ((Matrix.vandermonde rootEnum) i j) =
+      (Matrix.vandermonde (rootEnum ∘ galToPerm5 σ)) i j
+    exact gal_map_vandermonde_entry σ i j
+  · exact vandermonde_perm_det rootEnum (galToPerm5 σ)
+
+-- Section E4: Discriminant Value (Axiom)
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- **Axiom (discriminant computation)**: Δ² = -212144 in the splitting field.
+
+    This is a verifiable computation: disc(x⁵-4x+2) = 256(-4)⁵+3125·2⁴ = -212144.
+    The Sylvester matrix of p and p' = 5x⁴-4 is a 9×9 integer matrix whose
+    determinant equals -212144.
+
+    Axiomatized because computing resultants of explicit polynomials requires
+    API that is not yet available in Lean4/Mathlib v4.26.0. -/
+axiom vandermondeProduct_sq_val :
+  vandermondeProduct ^ 2 = algebraMap ℚ SF (-212144)
+
+-- Section E5: Negative Discriminant → Odd Permutation
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- The Vandermonde product is NOT in the range of algebraMap ℚ SF.
+
+    Proof: Δ² = algebraMap ℤ SF (-212144). If Δ = algebraMap ℚ SF r for some r,
+    then r² = -212144 in ℚ. But r² ≥ 0 in ℚ (characteristic 0, ordered field),
+    contradiction. -/
+theorem vandermondeProduct_not_rational :
+    vandermondeProduct ∉ Set.range (algebraMap ℚ SF) := by
+  intro ⟨r, hr⟩
+  have hinj : Function.Injective (algebraMap ℚ SF) := (algebraMap ℚ SF).injective
+  have hr2 : r ^ 2 = (-212144 : ℚ) := hinj (by rw [map_pow, hr]; exact vandermondeProduct_sq_val)
+  linarith [sq_nonneg r]
+
+/-- Helper: in the Galois splitting field, elements fixed by ALL automorphisms
+    lie in the base field ℚ.
+
+    This is one direction of the Fundamental Theorem of Galois Theory.
+    Proof: fixingSubgroup(⊥) = ⊤ (every ℚ-alg. aut. fixes ℚ), and by
+    IsGalois.fixedField_fixingSubgroup, fixedField(fixingSubgroup(⊥)) = ⊥. -/
+private theorem fixed_by_all_gal_is_rational (x : SF)
+    (hfix : ∀ σ : SF ≃ₐ[ℚ] SF, σ x = x) :
+    x ∈ Set.range (algebraMap ℚ SF) := by
+  haveI : IsGalois ℚ SF := IsGalois.mk
+  -- x ∈ fixedField(⊤)
+  have hmem : x ∈ IntermediateField.fixedField (⊤ : Subgroup (SF ≃ₐ[ℚ] SF)) := by
+    rw [IntermediateField.mem_fixedField_iff]
+    exact fun σ _ => hfix σ
+  -- fixingSubgroup(⊥) = ⊤: every automorphism fixes ℚ
+  have hfix_bot : (⊥ : IntermediateField ℚ SF).fixingSubgroup = ⊤ := by
+    rw [eq_top_iff]; intro σ _ y
+    obtain ⟨r, hr⟩ := IntermediateField.mem_bot.mp y.prop
+    show σ • (y : SF) = (y : SF)
+    rw [show (y : SF) = algebraMap ℚ SF r from hr.symm]
+    exact σ.commutes r
+  -- fixedField(fixingSubgroup(⊥)) = ⊥ (FTGT)
+  have hftgt : IntermediateField.fixedField (⊤ : Subgroup (SF ≃ₐ[ℚ] SF)) = ⊥ := by
+    rw [← hfix_bot]; exact IsGalois.fixedField_fixingSubgroup ⊥
+  rw [hftgt] at hmem
+  exact IntermediateField.mem_bot.mp hmem
+
+/-- Not all Galois signs are positive: some σ has galSign(σ) = -1.
+
+    Proof: If all signs were +1, then σ(Δ) = Δ for all σ, which would mean
+    Δ is fixed by the entire Galois group, hence Δ ∈ ℚ. But Δ ∉ ℚ. -/
+theorem exists_odd_galSign :
+    ∃ σ : p.Gal, galSign σ = -1 := by
+  by_contra hall
+  push_neg at hall
+  have hall_one : ∀ σ : p.Gal, galSign σ = 1 := fun σ =>
+    (Int.units_eq_one_or (galSign σ)).resolve_right (hall σ)
+  have hfix : ∀ σ : p.Gal, σ vandermondeProduct = vandermondeProduct := by
+    intro σ
+    have h := gal_acts_on_vandermondeProduct σ
+    rw [hall_one σ] at h; simpa using h
+  exact vandermondeProduct_not_rational (fixed_by_all_gal_is_rational vandermondeProduct hfix)
+
+/-- **THEOREM** (formerly Axiom B): The Galois group contains an odd permutation.
+    Proved from the Vandermonde product approach and disc(p) = -212144 < 0. -/
+theorem gal_has_odd_perm :
+  ∃ σ : p.Gal, Equiv.Perm.sign (galToPerm5 σ) = -1 := exists_odd_galSign
+
+-- Section E6: Remaining Axiom
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /-- **Axiom A**: 3 divides |Gal(p)|.
 
@@ -605,18 +779,6 @@ theorem not yet in Mathlib:
     Supporting evidence: p_root_mod13_at_2, p_root_mod13_at_5,
     cubic_factor_no_roots_mod13 verify the factorization. -/
 axiom three_dvd_gal_card : 3 ∣ Fintype.card p.Gal
-
-/-- **Axiom B**: The Galois group is NOT contained in A₅.
-
-    disc(p) = -212144 < 0, so the Vandermonde product Δ satisfies
-    Δ² < 0, hence Δ ∉ ℚ. Since σ(Δ) = sign(σ)·Δ and Δ generates
-    a degree-2 extension of ℚ, there exists σ with sign(σ) = -1.
-
-    Axiomatized because Mathlib lacks the disc(f) = Δ² identity.
-    The discriminant value -212144 is verifiable via the Sylvester
-    matrix determinant of p and p'. -/
-axiom gal_has_odd_perm :
-  ∃ σ : p.Gal, Equiv.Perm.sign (galToPerm5 σ) = -1
 
 -- ============================================================================
 -- Part V(f): |Gal(p/ℚ)| = 120 (PROVED from Axioms A, B)

--- a/research/problems/abel-ruffini-oq-04-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-oq-04-oq-01/knowledge.md
@@ -110,9 +110,40 @@ we proved a concrete witness: Gal(x^5 - 4x + 2 / Q) ≅ S_5.
 - src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json (updated counts)
 - src/data/research/problems/abel-ruffini-oq-04-oq-01.json (to be updated)
 
+## Session 2026-03-24 (Session 4) - Vandermonde Product: Axiom B Eliminated
+
+**Mode**: REVISIT (RICH knowledge, score ~29)
+**Outcome**: progress (Axiom B eliminated, replaced with narrower disc computation axiom)
+
+### What I Did
+- Built complete Vandermonde product infrastructure for polynomial p
+  - rootEnum, rootEnum_is_root, rootEnum_injective
+  - vandermondeProduct = det(Vandermonde(rootEnum)), nonzero
+  - gal_permutes_roots, vandermonde_perm_det, gal_map_vandermonde_entry
+  - **gal_acts_on_vandermondeProduct**: σ(Δ) = galSign(σ) · Δ
+- Proved **vandermondeProduct_not_rational**: Δ ∉ ℚ (from Δ² = -212144 < 0)
+- Proved **fixed_by_all_gal_is_rational**: FTGT direction (fixedField(⊤) = ⊥)
+  - Key: fixingSubgroup(⊥) = ⊤ (automorphisms fix ℚ by σ.commutes)
+  - Then IsGalois.fixedField_fixingSubgroup gives fixedField(⊤) = ⊥
+- Proved **exists_odd_galSign** = **gal_has_odd_perm** as a THEOREM
+- Former Axiom B is now PROVED; replaced with narrower axiom vandermondeProduct_sq_val
+
+### Key Findings
+- IntermediateField.mem_fixedField_iff is the correct API (not mem_fixedField)
+- fixingSubgroup membership requires `show ∀ y : ↑↑⊥, σ • ↑y = ↑y` pattern
+- IsGalois ℚ SF needs explicit `IsGalois.mk` (inferInstance may fail for abbrevs)
+- The FTGT (fixedField ⊤ = ⊥) follows from fixingSubgroup ⊥ = ⊤ + Galois correspondence
+- Pattern from InverseGaloisA5.lean (vandermonde_perm_det, gal_map_vandermonde_entry) transfers directly
+
+### Files Modified
+- proofs/Proofs/AbelRuffiniOQ04OQ01.lean (874→1036 lines, 37→48 theorems, 2 axioms still)
+- src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json (updated counts)
+- src/data/research/problems/abel-ruffini-oq-04-oq-01.json (updated knowledge)
+
 ### Remaining Work to Eliminate ALL Axioms
-1. **Dedekind's theorem**: Formalize the connection between mod-p factorization and Frobenius cycle types (~200-300 lines)
-2. **Discriminant-Vandermonde identity**: Prove disc(f) = Δ² for monic separable polynomials (~100-200 lines)
-   - Mathlib has Matrix.det_vandermonde; need to connect to Polynomial.disc
-3. **Alternative for Axiom B**: Could use IVT approach instead (3 real roots → disc < 0)
-   - IVT gives roots, derivative gives upper bound, combined: exactly 3 real → disc negative
+1. **Axiom A (three_dvd_gal_card)**: Needs Dedekind's theorem (~200-300 lines)
+2. **Axiom B replacement (vandermondeProduct_sq_val)**: Prove Δ² = -212144 from Res(p,p')
+   - Chain: Δ² = ∏_{i≠j}(αᵢ-αⱼ) = ∏ᵢ p'(αᵢ) = Res(p,p') = disc(p) = -212144
+   - InverseGaloisA5.lean proves this for q via ℂ embedding + Sophie Germain (~400 lines)
+   - For p = x⁵-4x+2, p'=5x⁴-4 doesn't factor as nicely (no Sophie Germain)
+   - Alternative: direct Sylvester matrix determinant computation (9×9 over ℤ)

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "assumptions": "Two axioms: (A) three_dvd_gal_card (3||Gal|, from Dedekind's theorem at p=13: mod 13 factorization verified computationally), (B) gal_has_odd_perm (Gal⊄A₅, from disc=-212144<0 and Vandermonde-discriminant identity). The former opaque axiom |Gal|=120 is now a THEOREM proved from these via Sylow theory (no order-15 or order-30 subgroups in S₅) and A₅ simplicity.",
+    "assumptions": "Two axioms: (A) three_dvd_gal_card (3||Gal|, from Dedekind's theorem at p=13: mod 13 factorization verified computationally), (B) vandermondeProduct_sq_val (Δ²=-212144, verifiable discriminant computation). Former Axiom B (gal_has_odd_perm) is now a THEOREM proved via Vandermonde product approach: σ(Δ)=sign(σ)·Δ, disc<0 so Δ∉ℚ, hence ∃σ with sign(σ)=-1. Uses FTGT (fixedField(⊤)=⊥).",
     "wiedijkNumber": 16,
     "dateAdded": "2026-03-25",
     "mathlibDependencies": [
@@ -233,10 +233,10 @@
       "Polynomial"
     ],
     "namespace": "AbelRuffiniOQ04OQ01",
-    "lineCount": 874,
+    "lineCount": 1036,
     "axiomCount": 2,
-    "theoremCount": 37,
-    "definitionCount": 6,
+    "theoremCount": 48,
+    "definitionCount": 8,
     "sorryCount": 0
   },
   "references": [

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "abel-ruffini-oq-04-oq-01",
-  "title": "Formalize the Galois group computation for the generic quintic: Gal(x\u2075 + a\u2081x\u2074...",
+  "title": "Formalize the Galois group computation for the generic quintic: Gal(x⁵ + a₁x⁴...",
   "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formalize the Galois group computation for the generic quintic: Gal(x\u2075 + a\u2081x\u2074...",
+    "plain": "Formalize the Galois group computation for the generic quintic: Gal(x⁵ + a₁x⁴...",
     "whyMatters": []
   },
   "knownResults": {
@@ -29,14 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 5 evaluation lemmas proved. 1 axiom remains (|Gal|=120). Next: IVT for real roots, then group theory.",
+    "progressSummary": "PROGRESS: Axiom B eliminated. gal_has_odd_perm now a THEOREM via Vandermonde+FTGT. 2 axioms remain: three_dvd_gal_card + vandermondeProduct_sq_val (narrow disc computation).",
     "builtItems": [
       "Proofs/AbelRuffiniOQ04OQ01.lean: Full proof (362 lines, 12 theorems, 1 axiom)",
       "p_irreducible: Eisenstein at 2 for x^5-4x+2",
-      "gal_iso_s5: Gal(p/Q) \u2245 S_5 via galActionHom bijectivity",
+      "gal_iso_s5: Gal(p/Q) ≅ S_5 via galActionHom bijectivity",
       "roots_not_solvable_by_rad: contrapositive of Galois theorem",
       "s5_realizable: S_5 realized as Galois group over Q",
-      "Polynomial evaluations p(-2)=-22, p(-1)=5, p(0)=2, p(1)=-1, p(2)=26 (AbelRuffiniOQ04OQ01.lean)"
+      "Polynomial evaluations p(-2)=-22, p(-1)=5, p(0)=2, p(1)=-1, p(2)=26 (AbelRuffiniOQ04OQ01.lean)",
+      "rootEnum, vandermondeProduct, gal_acts_on_vandermondeProduct, gal_permutes_roots, vandermondeProduct_not_rational, fixed_by_all_gal_is_rational, exists_odd_galSign (proves former Axiom B)"
     ],
     "insights": [
       "Concrete polynomial approach more tractable than generic polynomial: x^5-4x+2 via Eisenstein at 2",
@@ -44,17 +45,18 @@
       "solvable_of_surjective (not isSolvable_of_surjective) is the correct Mathlib4 name for solvability transfer",
       "Generic polynomial approach (MvPolynomial + FractionRing + esymmAlgEquiv) requires 3-4 substantial gap lemmas",
       "simp [eval_sub, eval_add, eval_mul, eval_pow, eval_C, eval_X] suffices for polynomial evaluation; ring only needed sometimes",
-      "To eliminate gal_card_eq_120: need IVT over \u211d for real roots + group theory lemma (transitive + transposition + p-cycle \u2192 S_p)"
+      "To eliminate gal_card_eq_120: need IVT over ℝ for real roots + group theory lemma (transitive + transposition + p-cycle → S_p)",
+      "Vandermonde product approach: σ(Δ)=sign(σ)·Δ, with Δ²=disc(p)=-212144<0, gives Δ∉ℚ. By FTGT, fixed by all σ→in ℚ. Contrapositive: Δ∉ℚ→∃σ with sign=-1."
     ],
     "mathlibGaps": [
       "No generic polynomial Galois group computation in Mathlib (FractionRing of MvPolynomial + Galois theory)",
-      "No direct MulEquiv.isSolvable_iff \u2014 must use solvable_of_surjective with explicit surjectivity proof"
+      "No direct MulEquiv.isSolvable_iff — must use solvable_of_surjective with explicit surjectivity proof"
     ],
     "nextSteps": [
-      "Cast evaluations to \u211d and apply IVT (Polynomial.aeval continuity + IVT) to get roots in (-2,-1), (0,1), (1,2)",
+      "Cast evaluations to ℝ and apply IVT (Polynomial.aeval continuity + IVT) to get roots in (-2,-1), (0,1), (1,2)",
       "Show f'=5x^4-4 has exactly 2 real roots to bound real root count to 3",
       "Prove group theory: transitive subgroup of S_p (p prime) with transposition = S_p",
-      "Complex conjugation on 2 non-real roots gives transposition in Gal \u2192 Gal = S_5 \u2192 |Gal|=120"
+      "Complex conjugation on 2 non-real roots gives transposition in Gal → Gal = S_5 → |Gal|=120"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- **Axiom B eliminated**: `gal_has_odd_perm` is now a **theorem** (was axiom)
- Built Vandermonde product infrastructure and proved `σ(Δ) = sign(σ)·Δ`
- Used FTGT (`fixedField(⊤) = ⊥`) to show: disc(p) < 0 → Δ ∉ ℚ → ∃ odd permutation
- File grows from 874→1036 lines, 37→48 theorems
- Still 2 axioms: `three_dvd_gal_card` (unchanged), `vandermondeProduct_sq_val` (narrow disc computation replacing opaque axiom)

## Key theorems added

| Theorem | Purpose |
|---------|---------|
| `gal_acts_on_vandermondeProduct` | σ(Δ) = sign(σ)·Δ |
| `vandermondeProduct_not_rational` | Δ ∉ ℚ (from Δ² = -212144 < 0) |
| `fixed_by_all_gal_is_rational` | FTGT: fixed by all σ → in ℚ |
| `exists_odd_galSign` | ∃σ with sign(σ) = -1 |
| `gal_has_odd_perm` | **THEOREM** (formerly axiom) |

## Test plan

- [x] Docker build passes (`Proofs.AbelRuffiniOQ04OQ01`)
- [x] 0 sorries, 2 axioms (down from 2 axioms with opaque Axiom B)
- [x] All downstream theorems still compile (gal_card_eq_120, gal_iso_s5, roots_not_solvable_by_rad)

🤖 Generated with [Claude Code](https://claude.com/claude-code)