### PR TITLE
Fix: update stale leanFile.axiomCount for erdos-1099 (4→3)

### DIFF
--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -56,7 +56,7 @@
       "vose_liminf_bounded axiom: main theorem from 1984",
       "erdos_1099 theorem: resolution of the problem",
       "sumDivisorRatios definition: related sum",
-      "sum_divisor_ratios_lower_bound axiom: Σ(d_{i+1}/dᵢ) > τ(n) + log(n)",
+      "power_of_two_h_alpha axiom: h_α(2^k) growth for powers of 2",
       "Examples for primes, powers of 2, and highly composite numbers"
     ],
     "axiomCount": 3,
@@ -289,8 +289,8 @@
       "BigOperators"
     ],
     "namespace": "Erdos1099",
-    "lineCount": 542,
-    "axiomCount": 4,
+    "lineCount": 541,
+    "axiomCount": 3,
     "theoremCount": 24,
     "definitionCount": 7
   }


### PR DESCRIPTION
## Fix

Update `leanFile.axiomCount` from 4 to 3 in erdos-1099 meta.json. The `sum_divisor_ratios_lower_bound` axiom was removed in #6700 (false: off by 1 in τ count) but `leanFile.axiomCount` was not updated.

## Evidence

**Before**: `leanFile.axiomCount: 4`, stale ref to removed axiom in originalContributions
**After**: `leanFile.axiomCount: 3`, matching `meta.axiomCount: 3` and actual `grep "^axiom " Erdos1099Problem.lean` count

Also fixed:
- `lineCount`: 542 → 541 (actual)
- Replaced stale `sum_divisor_ratios_lower_bound` in originalContributions with `power_of_two_h_alpha`

---
Automated fix by lean-mechanic agent.