### PR TITLE
Enrich infinitude-primes: fix duplicate annotations

### DIFF
--- a/src/data/proofs/infinitude-primes/annotations.json
+++ b/src/data/proofs/infinitude-primes/annotations.json
@@ -3,14 +3,15 @@
     "id": "ann-imports",
     "proofId": "infinitude-primes",
     "range": {
-      "startLine": 5,
-      "endLine": 38
+      "startLine": 1,
+      "endLine": 3
     },
     "type": "context",
     "title": "Mathlib Imports",
-    "content": "This proof uses Mathlib's established definitions for primes and factorials. `Nat.Prime` provides a robust prime definition, while `Nat.factorial` gives us the factorial function with all its key properties already proven.",
-    "mathContext": "Mathlib provides `Nat.Prime p` and `n.factorial` with extensive lemma libraries.",
+    "content": "This proof uses Mathlib's established definitions for primes and factorials. `Nat.Prime` provides a robust prime definition, `Nat.factorial` gives the factorial function with all its key properties already proven, and `Nat.exists_prime_and_dvd` guarantees that every integer $\\geq 2$ has a prime divisor — the existence result that makes Euclid's construction work.",
+    "mathContext": "Mathlib provides `Nat.Prime p` ($p \\geq 2$ and $p$'s only divisors are $1$ and $p$), `n.factorial` ($n! = 1 \\cdot 2 \\cdots n$), `Nat.dvd_factorial` ($0 < k \\leq n \\Rightarrow k \\mid n!$), and `Nat.exists_prime_and_dvd` ($n \\geq 2 \\Rightarrow \\exists p$ prime, $p \\mid n$).",
     "significance": "supporting",
+    "prerequisites": [],
     "relatedConcepts": [
       "Mathlib",
       "prime definition",
@@ -25,10 +26,11 @@
       "endLine": 38
     },
     "type": "insight",
-    "title": "2,300 Years of Mathematical Truth",
-    "content": "This theorem appears in Euclid's *Elements* (Book IX, Proposition 20), written around 300 BCE. It is one of the oldest theorems whose proof is still taught essentially unchanged.\n\nEuclid's original used the product of the first $n$ primes plus 1. The factorial version is a modern simplification that avoids needing to enumerate primes explicitly.",
-    "mathContext": "Euclid: $p_1 \\cdot p_2 \\cdots p_n + 1$\nModern: $n! + 1$\n\nBoth work because adding 1 shifts away from all 'small' divisors.",
+    "title": "Module Overview: 2,300 Years of Mathematical Truth",
+    "content": "This theorem appears in Euclid's *Elements* (Book IX, Proposition 20), written around 300 BCE. It is one of the oldest theorems whose proof is still taught essentially unchanged. The module docstring documents both the approach (factorial-based variant of Euclid's argument) and the Mathlib dependencies. Euclid's original used the product of the first $n$ primes plus 1; the factorial version is a modern simplification that avoids needing to enumerate primes explicitly, since $n!$ is divisible by every integer from 1 to $n$, hence by every prime $\\leq n$.",
+    "mathContext": "Euclid's construction: $p_1 \\cdot p_2 \\cdots p_k + 1$. Modern variant: $n! + 1$. Both work because adding 1 shifts away from all 'small' divisors: if $p \\leq n$, then $p \\mid n!$ but $p \\nmid (n! + 1)$.",
     "significance": "key",
+    "prerequisites": [],
     "relatedConcepts": [
       "Euclid's Elements",
       "mathematical history",
@@ -43,31 +45,17 @@
       "endLine": 45
     },
     "type": "insight",
-    "title": "Why n! + 1 Works",
-    "content": "The factorial $n! = 1 \\times 2 \\times \\cdots \\times n$ is carefully chosen:\n\n1. **Every small prime divides $n!$**: If $p \\leq n$ is prime, then $p$ appears in the product\n2. **Adding 1 shifts the residue**: If $p \\mid n!$, then $n! \\equiv 0 \\pmod{p}$, so $n! + 1 \\equiv 1 \\pmod{p}$\n3. **Therefore $p \\nmid (n! + 1)$**: No prime $\\leq n$ can divide $n! + 1$\n\nAny prime factor of $n! + 1$ must be $> n$. Existence of such a factor is guaranteed since $n! + 1 \\geq 2$.",
-    "mathContext": "$n! \\equiv 0 \\pmod{p}$ for all primes $p \\leq n$\n$\\Rightarrow n! + 1 \\equiv 1 \\pmod{p}$\n$\\Rightarrow p \\nmid (n! + 1)$",
+    "title": "Why n! + 1 Works: Factorial Divisibility",
+    "content": "The factorial $n! = 1 \\times 2 \\times \\cdots \\times n$ is carefully chosen because every positive integer $k \\leq n$ divides $n!$ (it appears as a factor in the product). The theorem `dvd_factorial` formalizes this via Mathlib's `Nat.dvd_factorial`. Adding 1 shifts the residue: if $p \\mid n!$ then $n! \\equiv 0 \\pmod{p}$, so $n! + 1 \\equiv 1 \\pmod{p}$, meaning $p \\nmid (n! + 1)$. Any prime factor of $n! + 1$ must therefore be $> n$.",
+    "mathContext": "$0 < k \\leq n \\Rightarrow k \\mid n!$. Consequence: $n! \\equiv 0 \\pmod{p}$ for all primes $p \\leq n$, so $n! + 1 \\equiv 1 \\pmod{p}$, and $p \\nmid (n! + 1)$.",
     "significance": "key",
+    "prerequisites": [
+      "ann-imports"
+    ],
     "relatedConcepts": [
       "modular arithmetic",
       "coprimality",
-      "constructive proofs"
-    ]
-  },
-  {
-    "id": "ann-dvd-factorial",
-    "proofId": "infinitude-primes",
-    "range": {
-      "startLine": 44,
-      "endLine": 45
-    },
-    "type": "theorem",
-    "title": "Divisibility in Factorial",
-    "content": "Any positive integer $k \\leq n$ divides $n!$. This is because $k$ appears as one of the factors in the product $1 \\cdot 2 \\cdots n$.\n\nWe simply invoke Mathlib's `Nat.dvd_factorial` which already has this proven.",
-    "mathContext": "$0 < k \\leq n \\Rightarrow k \\mid n!$\n\nThis is why $n! + 1$ cannot share any small prime factors with $n!$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "factorial properties",
-      "product divisibility"
+      "factorial properties"
     ]
   },
   {
@@ -75,15 +63,19 @@
     "proofId": "infinitude-primes",
     "range": {
       "startLine": 50,
-      "endLine": 51
+      "endLine": 54
     },
     "type": "lemma",
-    "title": "n! + 1 is at least 2",
-    "content": "For any $n$, we have $n! + 1 \\geq 2$. Since $n! \\geq 1$ (factorials are always positive), adding 1 gives us at least 2.\n\nThis ensures that $n! + 1$ has at least one prime divisor.",
-    "mathContext": "$n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$",
+    "title": "n! + 1 Is at Least 2",
+    "content": "For any $n$, we have $n! + 1 \\geq 2$. Since $n! \\geq 1$ (factorials are always positive), adding 1 gives us at least 2. This ensures that $n! + 1$ has at least one prime divisor, which is needed for the existence step in Euclid's argument. The proof uses the `omega` tactic — Lean's decision procedure for Presburger arithmetic (the first-order theory of $(\\mathbb{Z}, +, <)$) — which handles the linear inequality $n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$ automatically.",
+    "mathContext": "$n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$. Combined with `Nat.exists_prime_and_dvd`: $n! + 1 \\geq 2 \\Rightarrow \\exists p$ prime, $p \\mid (n! + 1)$.",
     "significance": "supporting",
+    "prerequisites": [
+      "ann-imports"
+    ],
     "relatedConcepts": [
       "positivity",
+      "omega tactic",
       "prime divisor existence"
     ]
   },
@@ -92,17 +84,20 @@
     "proofId": "infinitude-primes",
     "range": {
       "startLine": 56,
-      "endLine": 57
+      "endLine": 61
     },
     "type": "lemma",
     "title": "The Key Divisibility Lemma",
-    "content": "If $p$ divides both $a$ and $a+1$, then $p$ divides 1. This is the heart of Euclid's proof.\n\nThe proof: if $p \\mid a$ and $p \\mid (a+1)$, then $p \\mid ((a+1) - a) = 1$.\n\nSince no prime divides 1, this creates the contradiction we need.",
-    "mathContext": "$p \\mid a \\land p \\mid (a+1) \\Rightarrow p \\mid 1$\n\nEquivalently: consecutive integers are coprime.",
+    "content": "If $p$ divides both $a$ and $a+1$, then $p$ divides 1. This is the heart of Euclid's proof. The proof: if $p \\mid a$ and $p \\mid (a+1)$, then $p \\mid ((a+1) - a) = 1$. Since no prime divides 1 (primes satisfy $p \\geq 2$), this creates the contradiction we need. The Lean proof applies `Nat.dvd_sub'` (if $p \\mid b$ and $p \\mid a$ with $a \\leq b$, then $p \\mid (b - a)$) and simplifies $(a+1) - a = 1$.",
+    "mathContext": "$p \\mid a \\land p \\mid (a+1) \\Rightarrow p \\mid ((a+1) - a) = 1$. Equivalently: consecutive integers are coprime. This is the structural reason why $n!$ and $n! + 1$ cannot share any prime factors.",
     "significance": "key",
+    "prerequisites": [
+      "ann-imports"
+    ],
     "relatedConcepts": [
       "coprimality",
       "consecutive integers",
-      "proof by contradiction"
+      "Nat.dvd_sub'"
     ]
   },
   {
@@ -110,76 +105,24 @@
     "proofId": "infinitude-primes",
     "range": {
       "startLine": 65,
-      "endLine": 78
+      "endLine": 104
     },
     "type": "theorem",
     "title": "Euclid's Theorem: Unbounded Primes",
-    "content": "**For any $n$, there exists a prime $p > n$.**\n\nThe proof constructs $Q = n! + 1$ and reasons:\n1. $Q \\geq 2$, so $Q$ has a prime divisor $p$ (using `Nat.exists_prime_and_dvd`)\n2. Suppose for contradiction that $p \\leq n$\n3. Then $p \\mid n!$ (since $p$ is a factor in $1 \\cdot 2 \\cdots n$)\n4. But $p \\mid Q = n! + 1$\n5. So $p \\mid ((n!+1) - n!) = 1$\n6. Since $p \\mid 1$, we have $p = 1$\n7. **Contradiction**: $p$ is prime, so $p \\neq 1$\n\nTherefore $p > n$. Since $n$ was arbitrary, primes are unbounded.",
-    "mathContext": "$\\forall n, \\exists p$ prime, $p > n$\n\nKey insight: if $p \\mid n!$ and $p \\mid (n!+1)$, then $p \\mid 1$, which is impossible for primes.",
+    "content": "**For any $n$, there exists a prime $p > n$.** The proof constructs $Q = n! + 1$ and reasons: (1) $Q \\geq 2$, so $Q$ has a prime divisor $p$ via `Nat.exists_prime_and_dvd`; (2) suppose for contradiction that $p \\leq n$; (3) then $p \\mid n!$ since $p$ is a factor in $1 \\cdot 2 \\cdots n$; (4) but $p \\mid Q = n! + 1$; (5) so $p \\mid ((n!+1) - n!) = 1$ by `dvd_of_dvd_add_one`; (6) since $p \\mid 1$ implies $p \\leq 1$, but $p$ is prime so $p \\geq 2$ — contradiction. Therefore $p > n$.\n\nThe Lean proof uses `by_contra` to assume $p \\leq n$, `push_neg` to simplify the negation, then chains the divisibility arguments to reach `p = 1`, contradicting `Nat.Prime.one_lt`.",
+    "mathContext": "$\\forall n, \\exists p$ prime, $p > n$. Construction: let $Q = n! + 1 \\geq 2$. Take $p \\mid Q$ prime. If $p \\leq n$, then $p \\mid n!$ and $p \\mid (n!+1)$, so $p \\mid 1$ — contradicting $p \\geq 2$. Hence $p > n$.",
     "significance": "key",
     "prerequisites": [
-      "ann-dvd-factorial",
-      "ann-dvd-add-one",
-      "ann-factorial-ge-two"
+      "ann-why-factorial",
+      "ann-factorial-ge-two",
+      "ann-dvd-add-one"
     ],
     "relatedConcepts": [
       "Euclid's proof",
       "constructive existence",
-      "proof by contradiction"
-    ]
-  },
-  {
-    "id": "ann-by-contra",
-    "proofId": "infinitude-primes",
-    "range": {
-      "startLine": 65,
-      "endLine": 104
-    },
-    "type": "tactic",
-    "title": "Proof by Contradiction Setup",
-    "content": "The `by_contra` tactic sets up a proof by contradiction. We assume $p \\leq n$ (the negation of $p > n$) and derive a contradiction.\n\nThe `push_neg` tactic then simplifies `¬(p > n)` to `p ≤ n`, which is easier to work with.",
-    "mathContext": "Goal: $p > n$\n`by_contra h`: Assume $\\neg(p > n)$\n`push_neg`: Transform to $p \\leq n$",
-    "significance": "key",
-    "relatedConcepts": [
       "proof by contradiction",
-      "negation",
-      "Lean tactics"
-    ]
-  },
-  {
-    "id": "ann-omega",
-    "proofId": "infinitude-primes",
-    "range": {
-      "startLine": 50,
-      "endLine": 54
-    },
-    "type": "tactic",
-    "title": "The omega Tactic",
-    "content": "The `omega` tactic is Lean's decision procedure for linear integer arithmetic. It automatically solves goals involving:\n- Inequalities ($<$, $\\leq$, $>$, $\\geq$)\n- Addition and subtraction\n- Multiplication by constants\n\nHere it proves $n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$ instantly.",
-    "mathContext": "`omega` handles Presburger arithmetic: the first-order theory of $(\\mathbb{Z}, +, <)$.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "decision procedures",
-      "linear arithmetic",
-      "automation"
-    ]
-  },
-  {
-    "id": "ann-prime-ne-one",
-    "proofId": "infinitude-primes",
-    "range": {
-      "startLine": 65,
-      "endLine": 104
-    },
-    "type": "insight",
-    "title": "Primes Are Not 1",
-    "content": "The final contradiction: if $p \\mid 1$, then $p = 1$ (since 1's only positive divisor is 1 itself).\n\nBut $p$ is prime, which by definition means $p \\geq 2$. So $p \\neq 1$.\n\nThis is where Euclid's argument closes: the assumption $p \\leq n$ leads to $p = 1$, which contradicts primality.",
-    "mathContext": "$p \\mid 1 \\Rightarrow p = 1$\n$p$ prime $\\Rightarrow p \\geq 2$\n$\\Rightarrow p = 1$ and $p \\geq 2$ — contradiction!",
-    "significance": "key",
-    "relatedConcepts": [
-      "prime definition",
-      "divisibility",
-      "contradiction"
+      "by_contra tactic",
+      "push_neg tactic"
     ]
   },
   {
@@ -190,13 +133,16 @@
       "endLine": 107
     },
     "type": "theorem",
-    "title": "Infinitude of Primes (Final Statement)",
-    "content": "The theorem `primes_infinite` is simply an alias for `unbounded_primes`, stating the result in a form emphasizing infinitude: for any bound $n$, there exists a prime exceeding it.",
-    "mathContext": "The sequence $2, 3, 5, 7, 11, 13, 17, \\ldots$ never terminates.",
-    "significance": "key",
+    "title": "Infinitude of Primes (Alternative Statement)",
+    "content": "The theorem `primes_infinite` is an alias for `unbounded_primes`, restating the result to emphasize infinitude: for any bound $n$, there exists a prime exceeding it. This alternative phrasing — while logically equivalent — is useful because it directly expresses the set-theoretic infinitude of primes rather than the number-theoretic unboundedness.",
+    "mathContext": "$|\\{p \\in \\mathbb{N} \\mid p \\text{ prime}\\}| = \\infty$. Equivalent to: $\\forall n, \\exists p > n$ prime.",
+    "significance": "supporting",
+    "prerequisites": [
+      "ann-main-theorem"
+    ],
     "relatedConcepts": [
       "unboundedness",
-      "infinity"
+      "set-theoretic infinitude"
     ]
   },
   {
@@ -208,9 +154,12 @@
     },
     "type": "corollary",
     "title": "Every Prime Has a Larger Prime",
-    "content": "Given any prime $p$, there exists another prime $q > p$. This follows immediately from unbounded_primes: we can always find a prime larger than any given number, including primes.",
-    "mathContext": "$\\forall p$ prime, $\\exists q$ prime, $q > p$",
+    "content": "Given any prime $p$, there exists another prime $q > p$. This follows immediately from `unbounded_primes`: we can always find a prime larger than any given number, including primes themselves. This corollary makes explicit the consequence for the sequence of primes: it never terminates.",
+    "mathContext": "$\\forall p$ prime, $\\exists q$ prime, $q > p$. Proof: apply `unbounded_primes` to $p$.",
     "significance": "supporting",
+    "prerequisites": [
+      "ann-main-theorem"
+    ],
     "relatedConcepts": [
       "prime sequences",
       "successor primes"
@@ -225,12 +174,15 @@
     },
     "type": "corollary",
     "title": "No Largest Prime",
-    "content": "There is no largest prime. If there were a prime $p$ such that all primes $q \\leq p$, then by unbounded_primes we could find a prime $q > p$, contradicting that $p$ is largest.\n\nThis is the contrapositive way of saying primes are infinite.",
-    "mathContext": "$\\neg \\exists p$ prime such that $\\forall q$ prime, $q \\leq p$",
+    "content": "There is no largest prime. If there were a prime $p$ such that all primes $q \\leq p$, then by `unbounded_primes` we could find a prime $q > p$, contradicting that $p$ is largest. This is the contrapositive formulation of infinitude, phrased as a non-existence statement.",
+    "mathContext": "$\\neg \\exists p$ prime such that $\\forall q$ prime, $q \\leq p$.",
     "significance": "key",
+    "prerequisites": [
+      "ann-main-theorem"
+    ],
     "relatedConcepts": [
       "unboundedness",
-      "proof by contradiction"
+      "contrapositive"
     ]
   }
 ]

--- a/src/data/proofs/infinitude-primes/annotations.source.json
+++ b/src/data/proofs/infinitude-primes/annotations.source.json
@@ -3,19 +3,19 @@
     "id": "ann-imports",
     "proofId": "infinitude-primes",
     "anchor": {
-      "type": "section-doc",
-      "contains": "What This Proves"
+      "type": "imports"
     },
     "type": "context",
     "title": "Mathlib Imports",
-    "content": "This proof uses Mathlib's established definitions for primes and factorials. `Nat.Prime` provides a robust prime definition, while `Nat.factorial` gives us the factorial function with all its key properties already proven.",
-    "mathContext": "Mathlib provides `Nat.Prime p` and `n.factorial` with extensive lemma libraries.",
+    "content": "This proof uses Mathlib's established definitions for primes and factorials. `Nat.Prime` provides a robust prime definition, `Nat.factorial` gives the factorial function with all its key properties already proven, and `Nat.exists_prime_and_dvd` guarantees that every integer $\\geq 2$ has a prime divisor — the existence result that makes Euclid's construction work.",
+    "mathContext": "Mathlib provides `Nat.Prime p` ($p \\geq 2$ and $p$'s only divisors are $1$ and $p$), `n.factorial` ($n! = 1 \\cdot 2 \\cdots n$), `Nat.dvd_factorial` ($0 < k \\leq n \\Rightarrow k \\mid n!$), and `Nat.exists_prime_and_dvd` ($n \\geq 2 \\Rightarrow \\exists p$ prime, $p \\mid n$).",
     "significance": "supporting",
     "relatedConcepts": [
       "Mathlib",
       "prime definition",
       "factorial"
-    ]
+    ],
+    "prerequisites": []
   },
   {
     "id": "ann-historical",
@@ -25,15 +25,16 @@
       "contains": "What This Proves"
     },
     "type": "insight",
-    "title": "2,300 Years of Mathematical Truth",
-    "content": "This theorem appears in Euclid's *Elements* (Book IX, Proposition 20), written around 300 BCE. It is one of the oldest theorems whose proof is still taught essentially unchanged.\n\nEuclid's original used the product of the first $n$ primes plus 1. The factorial version is a modern simplification that avoids needing to enumerate primes explicitly.",
-    "mathContext": "Euclid: $p_1 \\cdot p_2 \\cdots p_n + 1$\nModern: $n! + 1$\n\nBoth work because adding 1 shifts away from all 'small' divisors.",
+    "title": "Module Overview: 2,300 Years of Mathematical Truth",
+    "content": "This theorem appears in Euclid's *Elements* (Book IX, Proposition 20), written around 300 BCE. It is one of the oldest theorems whose proof is still taught essentially unchanged. The module docstring documents both the approach (factorial-based variant of Euclid's argument) and the Mathlib dependencies. Euclid's original used the product of the first $n$ primes plus 1; the factorial version is a modern simplification that avoids needing to enumerate primes explicitly, since $n!$ is divisible by every integer from 1 to $n$, hence by every prime $\\leq n$.",
+    "mathContext": "Euclid's construction: $p_1 \\cdot p_2 \\cdots p_k + 1$. Modern variant: $n! + 1$. Both work because adding 1 shifts away from all 'small' divisors: if $p \\leq n$, then $p \\mid n!$ but $p \\nmid (n! + 1)$.",
     "significance": "key",
     "relatedConcepts": [
       "Euclid's Elements",
       "mathematical history",
       "proof evolution"
-    ]
+    ],
+    "prerequisites": []
   },
   {
     "id": "ann-why-factorial",
@@ -43,146 +44,87 @@
       "contains": "Any positive k ≤ n divides n!"
     },
     "type": "insight",
-    "title": "Why n! + 1 Works",
-    "content": "The factorial $n! = 1 \\times 2 \\times \\cdots \\times n$ is carefully chosen:\n\n1. **Every small prime divides $n!$**: If $p \\leq n$ is prime, then $p$ appears in the product\n2. **Adding 1 shifts the residue**: If $p \\mid n!$, then $n! \\equiv 0 \\pmod{p}$, so $n! + 1 \\equiv 1 \\pmod{p}$\n3. **Therefore $p \\nmid (n! + 1)$**: No prime $\\leq n$ can divide $n! + 1$\n\nAny prime factor of $n! + 1$ must be $> n$. Existence of such a factor is guaranteed since $n! + 1 \\geq 2$.",
-    "mathContext": "$n! \\equiv 0 \\pmod{p}$ for all primes $p \\leq n$\n$\\Rightarrow n! + 1 \\equiv 1 \\pmod{p}$\n$\\Rightarrow p \\nmid (n! + 1)$",
+    "title": "Why n! + 1 Works: Factorial Divisibility",
+    "content": "The factorial $n! = 1 \\times 2 \\times \\cdots \\times n$ is carefully chosen because every positive integer $k \\leq n$ divides $n!$ (it appears as a factor in the product). The theorem `dvd_factorial` formalizes this via Mathlib's `Nat.dvd_factorial`. Adding 1 shifts the residue: if $p \\mid n!$ then $n! \\equiv 0 \\pmod{p}$, so $n! + 1 \\equiv 1 \\pmod{p}$, meaning $p \\nmid (n! + 1)$. Any prime factor of $n! + 1$ must therefore be $> n$.",
+    "mathContext": "$0 < k \\leq n \\Rightarrow k \\mid n!$. Consequence: $n! \\equiv 0 \\pmod{p}$ for all primes $p \\leq n$, so $n! + 1 \\equiv 1 \\pmod{p}$, and $p \\nmid (n! + 1)$.",
     "significance": "key",
     "relatedConcepts": [
       "modular arithmetic",
       "coprimality",
-      "constructive proofs"
-    ]
-  },
-  {
-    "id": "ann-dvd-factorial",
-    "proofId": "infinitude-primes",
-    "anchor": {
-      "type": "doc-comment",
-      "contains": "Any positive k ≤ n divides n!"
-    },
-    "type": "theorem",
-    "title": "Divisibility in Factorial",
-    "content": "Any positive integer $k \\leq n$ divides $n!$. This is because $k$ appears as one of the factors in the product $1 \\cdot 2 \\cdots n$.\n\nWe simply invoke Mathlib's `Nat.dvd_factorial` which already has this proven.",
-    "mathContext": "$0 < k \\leq n \\Rightarrow k \\mid n!$\n\nThis is why $n! + 1$ cannot share any small prime factors with $n!$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "factorial properties",
-      "product divisibility"
+      "factorial properties"
+    ],
+    "prerequisites": [
+      "ann-imports"
     ]
   },
   {
     "id": "ann-factorial-ge-two",
     "proofId": "infinitude-primes",
     "anchor": {
-      "type": "doc-comment",
-      "contains": "n! + 1 is always ≥ 2 for any n."
+      "type": "declaration",
+      "name": "factorial_succ_ge_two",
+      "kind": "theorem"
     },
     "type": "lemma",
-    "title": "n! + 1 is at least 2",
-    "content": "For any $n$, we have $n! + 1 \\geq 2$. Since $n! \\geq 1$ (factorials are always positive), adding 1 gives us at least 2.\n\nThis ensures that $n! + 1$ has at least one prime divisor.",
-    "mathContext": "$n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$",
+    "title": "n! + 1 Is at Least 2",
+    "content": "For any $n$, we have $n! + 1 \\geq 2$. Since $n! \\geq 1$ (factorials are always positive), adding 1 gives us at least 2. This ensures that $n! + 1$ has at least one prime divisor, which is needed for the existence step in Euclid's argument. The proof uses the `omega` tactic — Lean's decision procedure for Presburger arithmetic (the first-order theory of $(\\mathbb{Z}, +, <)$) — which handles the linear inequality $n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$ automatically.",
+    "mathContext": "$n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$. Combined with `Nat.exists_prime_and_dvd`: $n! + 1 \\geq 2 \\Rightarrow \\exists p$ prime, $p \\mid (n! + 1)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "positivity",
+      "omega tactic",
       "prime divisor existence"
+    ],
+    "prerequisites": [
+      "ann-imports"
     ]
   },
   {
     "id": "ann-dvd-add-one",
     "proofId": "infinitude-primes",
     "anchor": {
-      "type": "doc-comment",
-      "contains": "If p divides both a and a + 1, then p divides 1."
+      "type": "declaration",
+      "name": "dvd_of_dvd_add_one",
+      "kind": "theorem"
     },
     "type": "lemma",
     "title": "The Key Divisibility Lemma",
-    "content": "If $p$ divides both $a$ and $a+1$, then $p$ divides 1. This is the heart of Euclid's proof.\n\nThe proof: if $p \\mid a$ and $p \\mid (a+1)$, then $p \\mid ((a+1) - a) = 1$.\n\nSince no prime divides 1, this creates the contradiction we need.",
-    "mathContext": "$p \\mid a \\land p \\mid (a+1) \\Rightarrow p \\mid 1$\n\nEquivalently: consecutive integers are coprime.",
+    "content": "If $p$ divides both $a$ and $a+1$, then $p$ divides 1. This is the heart of Euclid's proof. The proof: if $p \\mid a$ and $p \\mid (a+1)$, then $p \\mid ((a+1) - a) = 1$. Since no prime divides 1 (primes satisfy $p \\geq 2$), this creates the contradiction we need. The Lean proof applies `Nat.dvd_sub'` (if $p \\mid b$ and $p \\mid a$ with $a \\leq b$, then $p \\mid (b - a)$) and simplifies $(a+1) - a = 1$.",
+    "mathContext": "$p \\mid a \\land p \\mid (a+1) \\Rightarrow p \\mid ((a+1) - a) = 1$. Equivalently: consecutive integers are coprime. This is the structural reason why $n!$ and $n! + 1$ cannot share any prime factors.",
     "significance": "key",
     "relatedConcepts": [
       "coprimality",
       "consecutive integers",
-      "proof by contradiction"
+      "Nat.dvd_sub'"
+    ],
+    "prerequisites": [
+      "ann-imports"
     ]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "infinitude-primes",
     "anchor": {
-      "type": "doc-comment",
-      "contains": "Euclid's Theorem: There are infinitely many primes"
+      "type": "declaration",
+      "name": "unbounded_primes",
+      "kind": "theorem"
     },
     "type": "theorem",
     "title": "Euclid's Theorem: Unbounded Primes",
-    "content": "**For any $n$, there exists a prime $p > n$.**\n\nThe proof constructs $Q = n! + 1$ and reasons:\n1. $Q \\geq 2$, so $Q$ has a prime divisor $p$ (using `Nat.exists_prime_and_dvd`)\n2. Suppose for contradiction that $p \\leq n$\n3. Then $p \\mid n!$ (since $p$ is a factor in $1 \\cdot 2 \\cdots n$)\n4. But $p \\mid Q = n! + 1$\n5. So $p \\mid ((n!+1) - n!) = 1$\n6. Since $p \\mid 1$, we have $p = 1$\n7. **Contradiction**: $p$ is prime, so $p \\neq 1$\n\nTherefore $p > n$. Since $n$ was arbitrary, primes are unbounded.",
-    "mathContext": "$\\forall n, \\exists p$ prime, $p > n$\n\nKey insight: if $p \\mid n!$ and $p \\mid (n!+1)$, then $p \\mid 1$, which is impossible for primes.",
+    "content": "**For any $n$, there exists a prime $p > n$.** The proof constructs $Q = n! + 1$ and reasons: (1) $Q \\geq 2$, so $Q$ has a prime divisor $p$ via `Nat.exists_prime_and_dvd`; (2) suppose for contradiction that $p \\leq n$; (3) then $p \\mid n!$ since $p$ is a factor in $1 \\cdot 2 \\cdots n$; (4) but $p \\mid Q = n! + 1$; (5) so $p \\mid ((n!+1) - n!) = 1$ by `dvd_of_dvd_add_one`; (6) since $p \\mid 1$ implies $p \\leq 1$, but $p$ is prime so $p \\geq 2$ — contradiction. Therefore $p > n$.\n\nThe Lean proof uses `by_contra` to assume $p \\leq n$, `push_neg` to simplify the negation, then chains the divisibility arguments to reach `p = 1`, contradicting `Nat.Prime.one_lt`.",
+    "mathContext": "$\\forall n, \\exists p$ prime, $p > n$. Construction: let $Q = n! + 1 \\geq 2$. Take $p \\mid Q$ prime. If $p \\leq n$, then $p \\mid n!$ and $p \\mid (n!+1)$, so $p \\mid 1$ — contradicting $p \\geq 2$. Hence $p > n$.",
     "significance": "key",
     "prerequisites": [
-      "ann-dvd-factorial",
-      "ann-dvd-add-one",
-      "ann-factorial-ge-two"
+      "ann-why-factorial",
+      "ann-factorial-ge-two",
+      "ann-dvd-add-one"
     ],
     "relatedConcepts": [
       "Euclid's proof",
       "constructive existence",
-      "proof by contradiction"
-    ]
-  },
-  {
-    "id": "ann-by-contra",
-    "proofId": "infinitude-primes",
-    "anchor": {
-      "type": "declaration",
-      "name": "unbounded_primes",
-      "kind": "theorem"
-    },
-    "type": "tactic",
-    "title": "Proof by Contradiction Setup",
-    "content": "The `by_contra` tactic sets up a proof by contradiction. We assume $p \\leq n$ (the negation of $p > n$) and derive a contradiction.\n\nThe `push_neg` tactic then simplifies `¬(p > n)` to `p ≤ n`, which is easier to work with.",
-    "mathContext": "Goal: $p > n$\n`by_contra h`: Assume $\\neg(p > n)$\n`push_neg`: Transform to $p \\leq n$",
-    "significance": "key",
-    "relatedConcepts": [
       "proof by contradiction",
-      "negation",
-      "Lean tactics"
-    ]
-  },
-  {
-    "id": "ann-omega",
-    "proofId": "infinitude-primes",
-    "anchor": {
-      "type": "declaration",
-      "name": "factorial_succ_ge_two",
-      "kind": "theorem"
-    },
-    "type": "tactic",
-    "title": "The omega Tactic",
-    "content": "The `omega` tactic is Lean's decision procedure for linear integer arithmetic. It automatically solves goals involving:\n- Inequalities ($<$, $\\leq$, $>$, $\\geq$)\n- Addition and subtraction\n- Multiplication by constants\n\nHere it proves $n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$ instantly.",
-    "mathContext": "`omega` handles Presburger arithmetic: the first-order theory of $(\\mathbb{Z}, +, <)$.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "decision procedures",
-      "linear arithmetic",
-      "automation"
-    ]
-  },
-  {
-    "id": "ann-prime-ne-one",
-    "proofId": "infinitude-primes",
-    "anchor": {
-      "type": "declaration",
-      "name": "unbounded_primes",
-      "kind": "theorem"
-    },
-    "type": "insight",
-    "title": "Primes Are Not 1",
-    "content": "The final contradiction: if $p \\mid 1$, then $p = 1$ (since 1's only positive divisor is 1 itself).\n\nBut $p$ is prime, which by definition means $p \\geq 2$. So $p \\neq 1$.\n\nThis is where Euclid's argument closes: the assumption $p \\leq n$ leads to $p = 1$, which contradicts primality.",
-    "mathContext": "$p \\mid 1 \\Rightarrow p = 1$\n$p$ prime $\\Rightarrow p \\geq 2$\n$\\Rightarrow p = 1$ and $p \\geq 2$ — contradiction!",
-    "significance": "key",
-    "relatedConcepts": [
-      "prime definition",
-      "divisibility",
-      "contradiction"
+      "by_contra tactic",
+      "push_neg tactic"
     ]
   },
   {
@@ -193,13 +135,16 @@
       "contains": "Alternative statement: The set of primes is infini"
     },
     "type": "theorem",
-    "title": "Infinitude of Primes (Final Statement)",
-    "content": "The theorem `primes_infinite` is simply an alias for `unbounded_primes`, stating the result in a form emphasizing infinitude: for any bound $n$, there exists a prime exceeding it.",
-    "mathContext": "The sequence $2, 3, 5, 7, 11, 13, 17, \\ldots$ never terminates.",
-    "significance": "key",
+    "title": "Infinitude of Primes (Alternative Statement)",
+    "content": "The theorem `primes_infinite` is an alias for `unbounded_primes`, restating the result to emphasize infinitude: for any bound $n$, there exists a prime exceeding it. This alternative phrasing — while logically equivalent — is useful because it directly expresses the set-theoretic infinitude of primes rather than the number-theoretic unboundedness.",
+    "mathContext": "$|\\{p \\in \\mathbb{N} \\mid p \\text{ prime}\\}| = \\infty$. Equivalent to: $\\forall n, \\exists p > n$ prime.",
+    "significance": "supporting",
     "relatedConcepts": [
       "unboundedness",
-      "infinity"
+      "set-theoretic infinitude"
+    ],
+    "prerequisites": [
+      "ann-main-theorem"
     ]
   },
   {
@@ -211,12 +156,15 @@
     },
     "type": "corollary",
     "title": "Every Prime Has a Larger Prime",
-    "content": "Given any prime $p$, there exists another prime $q > p$. This follows immediately from unbounded_primes: we can always find a prime larger than any given number, including primes.",
-    "mathContext": "$\\forall p$ prime, $\\exists q$ prime, $q > p$",
+    "content": "Given any prime $p$, there exists another prime $q > p$. This follows immediately from `unbounded_primes`: we can always find a prime larger than any given number, including primes themselves. This corollary makes explicit the consequence for the sequence of primes: it never terminates.",
+    "mathContext": "$\\forall p$ prime, $\\exists q$ prime, $q > p$. Proof: apply `unbounded_primes` to $p$.",
     "significance": "supporting",
     "relatedConcepts": [
       "prime sequences",
       "successor primes"
+    ],
+    "prerequisites": [
+      "ann-main-theorem"
     ]
   },
   {
@@ -228,12 +176,15 @@
     },
     "type": "corollary",
     "title": "No Largest Prime",
-    "content": "There is no largest prime. If there were a prime $p$ such that all primes $q \\leq p$, then by unbounded_primes we could find a prime $q > p$, contradicting that $p$ is largest.\n\nThis is the contrapositive way of saying primes are infinite.",
-    "mathContext": "$\\neg \\exists p$ prime such that $\\forall q$ prime, $q \\leq p$",
+    "content": "There is no largest prime. If there were a prime $p$ such that all primes $q \\leq p$, then by `unbounded_primes` we could find a prime $q > p$, contradicting that $p$ is largest. This is the contrapositive formulation of infinitude, phrased as a non-existence statement.",
+    "mathContext": "$\\neg \\exists p$ prime such that $\\forall q$ prime, $q \\leq p$.",
     "significance": "key",
     "relatedConcepts": [
       "unboundedness",
-      "proof by contradiction"
+      "contrapositive"
+    ],
+    "prerequisites": [
+      "ann-main-theorem"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- Fixed 3 pairs of duplicate annotations that resolved to identical line ranges
- Fixed `ann-imports` to use proper `imports` anchor (was using `section-doc`)
- Merged duplicate content into consolidated annotations
- Annotation count: 13 → 9 (no duplicate ranges remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)