### PR TITLE
Research: erdos-929 — fix semantic error, eliminate 3 axioms (6→3)

### DIFF
--- a/proofs/Proofs/Erdos929Problem.lean
+++ b/proofs/Proofs/Erdos929Problem.lean
@@ -1,17 +1,23 @@
 /-
-# Erdős Problem #929 — Smooth Numbers in Short Intervals
+# Erdős Problem #929 — Small Prime Factors in Consecutive Blocks
 
 Let k ≥ 2 and let S(k) be the minimal x such that there exists a positive
-density set of n where n+1, n+2, …, n+k are all x-smooth (divisible only
-by primes ≤ x).
+density set of n where each of n+1, n+2, …, n+k has a prime factor ≤ x.
 
 Estimate S(k). Is S(k) ≥ k^{1−o(1)}?
+
+## Semantic Note
+
+The original Erdős formulation says the numbers are "divisible by primes ≤ x,"
+meaning each has AT LEAST ONE prime factor ≤ x (not that ALL prime factors are
+≤ x, which would be x-smoothness). With x-smoothness, the density of x-smooth
+numbers → 0 for any fixed x, making the existence claim false.
 
 ## Status: OPEN
 
 ## Key Results
 
-- **Trivial upper bound**: S(k) ≤ k+1 (take n ≡ −1 mod (k+1)!).
+- **Trivial upper bound**: S(k) ≤ k+1 (take n ≡ 1 mod (k+1)!).
 - **Rosser's sieve**: S(k) > k^{1/2−o(1)}.
 - **Ford–Green–Konyagin–Maynard–Tao (2018)**:
   S(k) ≪ k · (log log log k) / (log log k · log log log log k).
@@ -23,22 +29,26 @@ The conjecture S(k) ≥ k^{1−o(1)} remains open.
 
 import Mathlib.Tactic
 import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Topology.Algebra.Order.LiminfLimsup
 
-open Filter
+open Filter Finset
 
 /- ## Core Definitions -/
 
-/-- A natural number n is x-smooth if all its prime factors are ≤ x. -/
-def IsSmooth (n : ℕ) (x : ℕ) : Prop :=
-  ∀ p : ℕ, p.Prime → p ∣ n → p ≤ x
+/-- A natural number n has a prime factor ≤ x. Equivalently, its least
+prime factor is at most x. For n ≤ 1, handled by Nat.minFac:
+minFac 0 = 2, minFac 1 = 1. -/
+def HasSmallFactor (n : ℕ) (x : ℕ) : Prop :=
+  n.minFac ≤ x
 
-/-- A block of k consecutive integers starting at n+1 is x-smooth
-if each of n+1, n+2, …, n+k is x-smooth. -/
+/-- A block of k consecutive integers starting at n+1 each has a
+prime factor ≤ x. -/
 def SmoothBlock (n k x : ℕ) : Prop :=
-  ∀ i : ℕ, 1 ≤ i → i ≤ k → IsSmooth (n + i) x
+  ∀ i : ℕ, 1 ≤ i → i ≤ k → HasSmallFactor (n + i) x
 
-/-- The set of n for which the block n+1, …, n+k is x-smooth. -/
+/-- The set of n for which the block n+1, …, n+k all have small factors. -/
 def smoothBlockSet (k x : ℕ) : Set ℕ :=
   { n | SmoothBlock n k x }
 
@@ -49,14 +59,111 @@ noncomputable def Set.upperDensity (S : Set ℕ) : ℝ :=
       (Finset.range (n + 1))) : ℝ)
     / (↑(n + 1) : ℝ)) atTop
 
-/-- For any k ≥ 2, taking x = k+1 gives positive density of smooth blocks.
-The argument: by CRT, choosing n ≡ 0 mod ∏(primes ≤ k+1) gives a periodic
-set where all n+1,...,n+k are (k+1)-smooth. -/
-axiom smooth_block_exists (k : ℕ) :
-  ∃ x : ℕ, 0 < (smoothBlockSet k x).upperDensity
+/- ## Helper Lemmas -/
 
-/-- S(k) is the minimal x such that the set of n with a smooth block
-n+1, …, n+k has positive upper density. -/
+/-- Every positive integer m ≤ n divides n!. -/
+theorem dvd_factorial_of_pos_le {m n : ℕ} (hm : 0 < m) (hmn : m ≤ n) :
+    m ∣ n.factorial := by
+  induction n with
+  | zero => omega
+  | succ n ih =>
+    rw [Nat.factorial_succ]
+    rcases Nat.eq_or_lt_of_le hmn with h | h
+    · subst h; exact dvd_mul_right _ _
+    · exact dvd_mul_of_dvd_right (ih (by omega)) _
+
+/- ## Density Monotonicity -/
+
+/-- The density counting ratio at N: |S ∩ {0,…,N}| / (N+1). -/
+noncomputable abbrev densityRatio (S : Set ℕ) (N : ℕ) : ℝ :=
+  (Finset.card (@Finset.filter _ (· ∈ S) (Classical.decPred (· ∈ S))
+    (Finset.range (N + 1))) : ℝ) / (↑(N + 1) : ℝ)
+
+theorem densityRatio_nonneg (S : Set ℕ) (N : ℕ) : 0 ≤ densityRatio S N :=
+  div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+
+theorem densityRatio_le_one (S : Set ℕ) (N : ℕ) : densityRatio S N ≤ 1 := by
+  unfold densityRatio
+  rw [div_le_one (by positivity : (0 : ℝ) < ↑(N + 1))]
+  have h1 := @Finset.card_filter_le ℕ (Finset.range (N + 1)) (· ∈ S) (Classical.decPred _)
+  rw [Finset.card_range] at h1
+  exact_mod_cast h1
+
+theorem densityRatio_mono {A B : Set ℕ} (h : A ⊆ B) (N : ℕ) :
+    densityRatio A N ≤ densityRatio B N := by
+  unfold densityRatio
+  apply div_le_div_of_nonneg_right _ (by positivity)
+  apply Nat.cast_le.mpr
+  apply Finset.card_le_card
+  intro x hx
+  simp only [Finset.mem_filter, Finset.mem_range] at hx ⊢
+  exact ⟨hx.1, h hx.2⟩
+
+theorem densityRatio_isBoundedUnder (S : Set ℕ) :
+    IsBoundedUnder (· ≤ ·) atTop (densityRatio S) := by
+  refine ⟨1, ?_⟩
+  rw [Filter.eventually_map]
+  exact Eventually.of_forall (densityRatio_le_one S)
+
+theorem densityRatio_isCoboundedUnder (S : Set ℕ) :
+    IsCoboundedUnder (· ≤ ·) atTop (densityRatio S) := by
+  refine ⟨0, ?_⟩; intro a ha
+  by_contra hlt; push_neg at hlt
+  simp only [eventually_map] at ha
+  obtain ⟨N, hN⟩ := ha.exists
+  linarith [densityRatio_nonneg S N]
+
+/-- If A ⊆ B, then upper density of A ≤ upper density of B. -/
+theorem upperDensity_mono {A B : Set ℕ} (h : A ⊆ B) :
+    A.upperDensity ≤ B.upperDensity := by
+  show limsup (fun n => densityRatio A n) atTop ≤
+       limsup (fun n => densityRatio B n) atTop
+  exact Filter.limsup_le_limsup
+    (Eventually.of_forall (fun N => densityRatio_mono h N))
+    (densityRatio_isCoboundedUnder A)
+    (densityRatio_isBoundedUnder B)
+
+/- ## Smooth Block Existence -/
+
+/-- For n ≡ 1 mod (k+1)!, each n+i (1 ≤ i ≤ k) has factor (i+1) ≤ k+1.
+
+Proof: n+i = (k+1)!·t + (i+1). Since (i+1) | (k+1)! (as 2 ≤ i+1 ≤ k+1),
+we get (i+1) | (n+i), so minFac(n+i) ≤ (i+1) ≤ k+1. -/
+theorem smoothBlock_of_factorial_cong (k t : ℕ) :
+    SmoothBlock ((k + 1).factorial * t + 1) k (k + 1) := by
+  intro i hi1 hik
+  show ((k + 1).factorial * t + 1 + i).minFac ≤ k + 1
+  have heq : (k + 1).factorial * t + 1 + i = (k + 1).factorial * t + (i + 1) := by omega
+  rw [heq]
+  have hdvd_fact : (i + 1) ∣ (k + 1).factorial :=
+    dvd_factorial_of_pos_le (by omega) (by omega)
+  have hdvd : (i + 1) ∣ ((k + 1).factorial * t + (i + 1)) :=
+    dvd_add (dvd_trans hdvd_fact (dvd_mul_right _ _)) (dvd_refl _)
+  exact le_trans (Nat.minFac_le_of_dvd (by omega : 2 ≤ i + 1) hdvd) (by omega)
+
+/-- The AP {(k+1)!·t + 1 : t ∈ ℕ} ⊆ smoothBlockSet k (k+1). -/
+theorem arithProg_subset_smoothBlockSet (k t : ℕ) :
+    (k + 1).factorial * t + 1 ∈ smoothBlockSet k (k + 1) :=
+  smoothBlock_of_factorial_cong k t
+
+/-- smoothBlockSet k (k+1) has positive upper density: the AP
+{(k+1)!·t + 1 : t ≥ 0} is contained in it and has density 1/(k+1)!.
+[The density counting argument is left as sorry — the mathematical
+content (CRT + factorial) is proved in smoothBlock_of_factorial_cong.] -/
+theorem smoothBlockSet_pos_density (k : ℕ) :
+    0 < (smoothBlockSet k (k + 1)).upperDensity := by
+  -- The AP {M*t + 1 : t ∈ ℕ} ⊆ smoothBlockSet k (k+1) has density 1/M.
+  -- The counting function |S ∩ {0,...,N}| ≥ ⌊(N-1)/M⌋ + 1 ≥ N/(2M) for large N,
+  -- giving limsup ≥ 1/(2M) > 0.
+  sorry
+
+/-- For any k, ∃ x with smoothBlockSet k x having positive density. -/
+theorem smooth_block_exists (k : ℕ) :
+    ∃ x : ℕ, 0 < (smoothBlockSet k x).upperDensity :=
+  ⟨k + 1, smoothBlockSet_pos_density k⟩
+
+/-- S(k) is the minimal x such that smoothBlockSet k x has positive
+upper density. -/
 noncomputable def smoothThreshold (k : ℕ) : ℕ :=
   Nat.find (smooth_block_exists k)
 
@@ -64,8 +171,7 @@ noncomputable def smoothThreshold (k : ℕ) : ℕ :=
 
 /-- **Erdős Problem #929 (Open).**
 S(k) ≥ k^{1−o(1)}, meaning for every ε > 0 and all sufficiently
-large k, S(k) ≥ k^{1−ε}.
-Stated as a definition since this is an open conjecture. -/
+large k, S(k) ≥ k^{1−ε}. -/
 def Erdos929Conjecture : Prop :=
   ∀ ε : ℝ, 0 < ε → ∀ᶠ (k : ℕ) in atTop,
     (smoothThreshold k : ℝ) ≥ (k : ℝ) ^ (1 - ε)
@@ -73,9 +179,11 @@ def Erdos929Conjecture : Prop :=
 /- ## Known Bounds -/
 
 /-- **Trivial upper bound.** S(k) ≤ k+1.
-Take n ≡ −1 mod (k+1)!, then n+1, …, n+k are all (k+1)-smooth. -/
-axiom trivial_upper (k : ℕ) (hk : 2 ≤ k) :
-  smoothThreshold k ≤ k + 1
+The AP {(k+1)!·t + 1} witnesses positive density for x = k+1,
+so Nat.find returns ≤ k+1. -/
+theorem trivial_upper (k : ℕ) (_hk : 2 ≤ k) :
+    smoothThreshold k ≤ k + 1 := by
+  exact Nat.find_le (smoothBlockSet_pos_density k)
 
 /-- **Rosser's sieve.** S(k) > k^{1/2−o(1)}.
 For every ε > 0 and large enough k, S(k) ≥ k^{1/2−ε}. -/
@@ -84,9 +192,7 @@ axiom rosser_lower :
     (smoothThreshold k : ℝ) ≥ (k : ℝ) ^ (1/2 - ε)
 
 /-- **Ford–Green–Konyagin–Maynard–Tao (2018).**
-S(k) ≪ k · log log log k / (log log k · log log log log k).
-This improves the trivial upper bound S(k) ≤ k+1 by iterated
-logarithmic factors, using their work on large gaps between primes. -/
+S(k) ≪ k · log log log k / (log log k · log log log log k). -/
 axiom fgkmt_upper :
   ∃ C : ℝ, 0 < C ∧ ∀ᶠ (k : ℕ) in atTop,
     (smoothThreshold k : ℝ) ≤ C * (k : ℝ) *
@@ -95,16 +201,24 @@ axiom fgkmt_upper :
 
 /- ## Structural Observations -/
 
-/-- If k₁ ≤ k₂, then any smooth block of length k₂ contains a smooth block of length k₁. -/
+/-- If k₁ ≤ k₂, the small-factor block set for k₂ is contained in that for k₁. -/
 theorem smoothBlockSet_antitone (k₁ k₂ x : ℕ) (h : k₁ ≤ k₂) :
     smoothBlockSet k₂ x ⊆ smoothBlockSet k₁ x :=
   fun _ hn i hi1 hi2 => hn i hi1 (le_trans hi2 h)
 
-/-- S(k) is monotone non-decreasing in k: requiring more consecutive
-smooth numbers can only increase the threshold. -/
-axiom smoothThreshold_mono (k₁ k₂ : ℕ) (h : k₁ ≤ k₂)
-    (hk : 2 ≤ k₁) : smoothThreshold k₁ ≤ smoothThreshold k₂
+/-- S(k) is monotone non-decreasing: more consecutive small-factor
+conditions can only increase the threshold. -/
+theorem smoothThreshold_mono (k₁ k₂ : ℕ) (h : k₁ ≤ k₂)
+    (_hk : 2 ≤ k₁) : smoothThreshold k₁ ≤ smoothThreshold k₂ := by
+  unfold smoothThreshold
+  apply Nat.find_le
+  -- Goal: 0 < (smoothBlockSet k₁ (Nat.find (smooth_block_exists k₂))).upperDensity
+  have hk₂ := Nat.find_spec (smooth_block_exists k₂)
+  -- hk₂ : 0 < (smoothBlockSet k₂ (find ...)).upperDensity
+  exact lt_of_lt_of_le hk₂
+    (upperDensity_mono (smoothBlockSet_antitone k₁ k₂ _ h))
 
-/-- For k = 2, S(2) = 3: there is a positive density set of n where
-both n+1 and n+2 are 3-smooth, but not 2-smooth. -/
+/-- For k = 2, S(2) = 3: the AP n ≡ 2 mod 6 gives 3∣(n+1) and 2∣(n+2),
+so x = 3 works with density 1/6. For x ≤ 2: consecutive integers can't
+both have all prime factors ≤ 2, so density = 0. -/
 axiom smooth_threshold_2 : smoothThreshold 2 = 3

--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 929,
     "erdosUrl": "https://erdosproblems.com/929",
     "erdosProblemStatus": "open",
-    "axiomCount": 6,
-    "lineCount": 110,
-    "assumptions": "6 axiom(s) and 0 sorry(s). See the Lean source for details.",
+    "axiomCount": 3,
+    "lineCount": 224,
+    "assumptions": "3 axiom(s) and 1 sorry(s). Deep axioms: rosser_lower, fgkmt_upper, smooth_threshold_2. Sorry: arithmetic progression density argument.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -132,9 +132,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 110,
-    "axiomCount": 6,
-    "theoremCount": 1,
-    "definitionCount": 5
+    "lineCount": 224,
+    "axiomCount": 3,
+    "theoremCount": 14,
+    "definitionCount": 7
   }
 }

--- a/src/data/research/problems/erdos-929.json
+++ b/src/data/research/problems/erdos-929.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-929",
   "title": "Erdős #929",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -29,23 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: Fixed sorry in smoothThreshold definition (converted to explicit axiom smooth_block_exists). Fixed pre-existing DecidablePred bug in upperDensity. Added smoothBlockSet_antitone theorem. 7 axioms (1 new: smooth_block_exists), 0 sorries, 1 theorem, 109 lines.",
+    "progressSummary": "PROGRESS: Fixed critical semantic error (IsSmooth→HasSmallFactor: x-smooth was wrong, need 'has small factor'). Eliminated 3 axioms (6→3): proved smooth_block_exists, trivial_upper, smoothThreshold_mono. Added 13 new theorems including upperDensity_mono and CRT-based smooth block construction. 1 sorry remains: AP density argument in smoothBlockSet_pos_density.",
     "builtItems": [
       "Fixed sorry in smoothThreshold: converted to explicit axiom smooth_block_exists",
       "Fixed DecidablePred bug: used Classical.decPred in Set.upperDensity",
-      "Proved smoothBlockSet_antitone: monotonicity of smooth block sets"
+      "Proved smoothBlockSet_antitone: monotonicity of smooth block sets",
+      "SEMANTIC FIX: Replaced IsSmooth (all factors ≤ x) with HasSmallFactor (minFac ≤ x)",
+      "Proved dvd_factorial_of_pos_le: m | n! for 0 < m ≤ n",
+      "Proved densityRatio_mono + densityRatio_le_one + bounded/cobounded conditions",
+      "Proved upperDensity_mono: A ⊆ B → upperDensity A ≤ upperDensity B",
+      "Proved smoothBlock_of_factorial_cong: CRT argument for n ≡ 1 mod (k+1)!",
+      "Proved smooth_block_exists as theorem (was axiom) using k+1 witness",
+      "Proved trivial_upper as theorem (was axiom) via Nat.find_le",
+      "Proved smoothThreshold_mono as theorem (was axiom) via Nat.find_le + upperDensity_mono"
     ],
     "insights": [
-      "7 axioms classified: erdos_929_conjecture (open), rosser_lower/fgkmt_upper (deep bounds), trivial_upper/smoothThreshold_mono/smooth_threshold_2 (structural), smooth_block_exists (density witness)",
-      "smoothThreshold definition had a sorry masking a DecidablePred bug in upperDensity - both fixed",
-      "smoothBlockSet_antitone: proved that larger k gives smaller smooth block sets (k1<=k2 implies inclusion)",
-      "The structural axioms (trivial_upper, smoothThreshold_mono, smooth_threshold_2) could potentially be proved with more work on upperDensity properties"
+      "CRITICAL: Original IsSmooth (all factors ≤ x) was WRONG for this problem. x-smooth numbers have density 0 for fixed x, making smooth_block_exists false. Erdős means 'has a prime factor ≤ x' (minFac ≤ x).",
+      "CRT argument: n ≡ 1 mod (k+1)! forces (i+1) | (n+i) for 1≤i≤k since (i+1) | (k+1)!. Then minFac(n+i) ≤ i+1 ≤ k+1.",
+      "upperDensity_mono via limsup_le_limsup: needs Eventually pointwise ≤, IsCoboundedUnder for left, IsBoundedUnder for right",
+      "Density ratios are in [0,1]: bounded above by 1 (card_filter_le), below by 0 (nonneg)",
+      "smooth_threshold_2 = 3 needs showing: for x ≤ 2, smoothBlockSet 2 x has density 0 (consecutive integers can't both be even)"
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "No general AP density lemma: need to prove arithmetic progressions have positive upper density from scratch"
+    ],
     "nextSteps": [
-      "Prove smoothThreshold_mono from smoothBlockSet_antitone + upperDensity monotonicity",
-      "Prove trivial_upper (S(k) <= k+1) using CRT argument",
-      "Prove smooth_threshold_2 (S(2)=3) computationally"
+      "Prove smoothBlockSet_pos_density sorry: show AP {M*t+1} has positive upper density via le_limsup_of_frequently_le",
+      "Prove smooth_threshold_2 (S(2)=3): show smoothBlockSet 2 x empty/singleton for x≤2, positive density for x=3"
     ],
     "markdown": "# Erdős #929 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k\\geq 2$ be large and let $S(k)$ be the minimal $x$ such that there is a positive density set of $n$ where\\[n+1,n+2,\\ldots,n+k\\]are all divisible by primes $\\leq x$.\n\nEstimate $S(k)$ - in particular, is it true that $S(k)\\geq k^{1-o(1)}$?\n\n\n\nIt follows from Rosser's sieve that $S(k)> k^{1/2-o(1)}$.\n\nIt is trivial that $S(k)\\leq k+1$ since, for example, one can take $n\\equiv 1\\pmod{(k+1)!}$. The best bound on large gaps between primes due to Ford, Green, Konyagin, Maynard, and Tao \\cite{FGKMT18} (see [4]) implies\\[S(k) \\ll k \\frac{\\log\\log\\log k}{\\log\\log k\\log\\log\\log\\log k}.\\]\n\n\n\n\nReferences\n\n\n[FGKMT18] Ford, Kevin and Green, Ben and Konyagin, Sergei and Maynard, James and Tao, Terence, Long gaps between primes. J. Amer. Math. Soc. (2018), 65-105.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #4\n- Problem #928\n- Problem #930\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n- FGKMT18\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -70,11 +80,11 @@
     {
       "path": "Proofs/Erdos929Problem.lean",
       "filename": "Erdos929Problem.lean",
-      "lineCount": 111,
-      "theoremCount": 1,
-      "axiomCount": 6,
-      "defCount": 6,
-      "sorryCount": 0,
+      "lineCount": 224,
+      "theoremCount": 14,
+      "axiomCount": 3,
+      "defCount": 7,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos929Problem.lean"
     }


### PR DESCRIPTION
## Summary

- **Critical semantic fix**: `IsSmooth` (all factors ≤ x) was **wrong** for Erdős #929. The original problem asks for "has a prime factor ≤ x" (i.e., `minFac ≤ x`), not x-smoothness. With x-smoothness, `smooth_block_exists` was mathematically **false** (x-smooth numbers have density 0 for any fixed x).
- **Eliminated 3 axioms** (6→3) by proving them as theorems:
  - `smooth_block_exists`: CRT argument — `n ≡ 1 mod (k+1)!` forces `(i+1) | (n+i)` via factorial divisibility
  - `trivial_upper` (S(k) ≤ k+1): via `Nat.find_le` with the k+1 witness
  - `smoothThreshold_mono`: via `Nat.find_le` + new `upperDensity_mono` lemma
- **Added 13 new theorems**: density monotonicity helpers, `dvd_factorial_of_pos_le`, `smoothBlock_of_factorial_cong`, etc.
- **Remaining**: 3 axioms (deep: `rosser_lower`, `fgkmt_upper`, `smooth_threshold_2`), 1 sorry (AP density counting argument)

## Test plan

- [x] Docker build passes (`Proofs.Erdos929Problem`)
- [x] Only expected sorry warning in `smoothBlockSet_pos_density`
- [x] Meta.json and research problem JSON updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)