### PR TITLE
Research: erdos-324 — Prove distinct_count_eq_binomial (2→1 axioms)

### DIFF
--- a/proofs/Proofs/Erdos324Problem.lean
+++ b/proofs/Proofs/Erdos324Problem.lean
@@ -13,12 +13,7 @@ conjecture would imply f(x) = xⁿ works for all n ≥ 5.
 - Erdős and Graham (1980, p. 53)
 -/
 
-import Mathlib.Data.Polynomial.Basic
-import Mathlib.Data.Polynomial.Eval
-import Mathlib.Data.Int.Basic
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Set.Function
-import Mathlib.Tactic
+import Mathlib
 
 open Polynomial
 
@@ -82,7 +77,7 @@ theorem squares_not_distinct : ¬PowerPairSumDistinct 2 := by
   have hp1 : ((1 : ℕ), (8 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
   have hp2 : ((4 : ℕ), (7 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
   have heq : pairSumFn (X ^ 2 : ℤ[X]) (1, 8) = pairSumFn (X ^ 2 : ℤ[X]) (4, 7) := by
-    simp [pairSumFn, eval_pow, eval_X]; norm_num
+    simp [pairSumFn, eval_pow, eval_X]
   exact absurd (h hp1 hp2 heq) (by decide)
 
 /-- For n = 3, the property fails: the Hardy–Ramanujan taxicab number
@@ -92,7 +87,7 @@ theorem cubes_not_distinct : ¬PowerPairSumDistinct 3 := by
   have hp1 : ((1 : ℕ), (12 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
   have hp2 : ((9 : ℕ), (10 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
   have heq : pairSumFn (X ^ 3 : ℤ[X]) (1, 12) = pairSumFn (X ^ 3 : ℤ[X]) (9, 10) := by
-    simp [pairSumFn, eval_pow, eval_X]; norm_num
+    simp [pairSumFn, eval_pow, eval_X]
   exact absurd (h hp1 hp2 heq) (by decide)
 
 /-- For n = 4, the property fails: 59⁴ + 158⁴ = 133⁴ + 134⁴ = 635318657
@@ -102,7 +97,7 @@ theorem quartics_not_distinct : ¬PowerPairSumDistinct 4 := by
   have hp1 : ((59 : ℕ), (158 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
   have hp2 : ((133 : ℕ), (134 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
   have heq : pairSumFn (X ^ 4 : ℤ[X]) (59, 158) = pairSumFn (X ^ 4 : ℤ[X]) (133, 134) := by
-    simp [pairSumFn, eval_pow, eval_X]; norm_num
+    simp [pairSumFn, eval_pow, eval_X]
   exact absurd (h hp1 hp2 heq) (by decide)
 
 /-
@@ -111,18 +106,33 @@ theorem quartics_not_distinct : ¬PowerPairSumDistinct 4 := by
 
 /-- Linear polynomials cannot have distinct pair sums:
     for f(x) = ax + b, f(0) + f(3) = f(1) + f(2) = 3a + 2b. -/
-theorem linear_not_distinct (a b : ℤ) (ha : a ≠ 0) :
+theorem linear_not_distinct (a b : ℤ) (_ha : a ≠ 0) :
     ¬HasDistinctPairSums (C a * X + C b) := by
   intro h
   have hp1 : ((0 : ℕ), (3 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
   have hp2 : ((1 : ℕ), (2 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
   have heq : pairSumFn (C a * X + C b) (0, 3) = pairSumFn (C a * X + C b) (1, 2) := by
-    simp [pairSumFn, eval_add, eval_mul, eval_C, eval_X]; push_cast; ring
+    simp [pairSumFn, eval_add, eval_mul, eval_X]; ring
   exact absurd (h hp1 hp2 heq) (by decide)
 
 /-- The degree of any polynomial with distinct pair sums must be ≥ 5. -/
 axiom min_degree_for_distinct :
   ∀ f : ℤ[X], HasDistinctPairSums f → f.natDegree ≥ 5
+
+/-
+## Section V.b: Constant Polynomials
+-/
+
+/-- Constant polynomials cannot have distinct pair sums:
+    f(a) + f(b) = 2c for all pairs, so (0,1) and (0,2) collide. -/
+theorem constant_not_distinct (c : ℤ) :
+    ¬HasDistinctPairSums (C c : ℤ[X]) := by
+  intro h
+  have hp1 : ((0 : ℕ), (1 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have hp2 : ((0 : ℕ), (2 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have heq : pairSumFn (C c : ℤ[X]) (0, 1) = pairSumFn (C c : ℤ[X]) (0, 2) := by
+    simp [pairSumFn]
+  exact absurd (h hp1 hp2 heq) (by decide)
 
 /-
 ## Section VI: Counting Pair Sums
@@ -134,6 +144,101 @@ noncomputable def distinctPairSumCount (f : ℤ[X]) (N : ℕ) : ℕ :=
     (Finset.range (N + 1) ×ˢ Finset.range (N + 1))).image
     (fun p => f.eval (p.1 : ℤ) + f.eval (p.2 : ℤ)) |>.card
 
-/-- For distinct pair sums, the count equals C(N+1, 2). -/
-axiom distinct_count_eq_binomial (f : ℤ[X]) (hf : HasDistinctPairSums f) (N : ℕ) :
-  distinctPairSumCount f N = (N + 1).choose 2
+/-- The number of strictly ordered pairs from {0,...,N} is C(N+1,2).
+    Proof via partition + swap symmetry, following the pattern from
+    Erdős #530 (card_sorted_pairs). -/
+private theorem card_strict_pairs (N : ℕ) :
+    ((Finset.range (N + 1) ×ˢ Finset.range (N + 1)).filter
+      (fun p : ℕ × ℕ => p.1 < p.2)).card = (N + 1).choose 2 := by
+  set S := Finset.range (N + 1)
+  -- |{a<b}| + |{¬(a<b)}| = |S|²
+  have h_total : ((S ×ˢ S).filter (fun p : ℕ × ℕ => p.1 < p.2)).card +
+      ((S ×ˢ S).filter (fun p : ℕ × ℕ => ¬(p.1 < p.2))).card = S.card * S.card := by
+    rw [Finset.filter_card_add_filter_neg_card_eq_card, Finset.card_product]
+  -- Decompose {¬(a<b)} = {b<a} ∪ {a=b}
+  have h_decomp : (S ×ˢ S).filter (fun p : ℕ × ℕ => ¬(p.1 < p.2)) =
+      (S ×ˢ S).filter (fun p : ℕ × ℕ => p.2 < p.1) ∪
+      (S ×ˢ S).filter (fun p : ℕ × ℕ => p.1 = p.2) := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_union, Finset.mem_product, not_lt]
+    constructor
+    · intro ⟨hmem, hle⟩
+      rcases eq_or_lt_of_le hle with h | h
+      · exact Or.inr ⟨hmem, h.symm⟩
+      · exact Or.inl ⟨hmem, h⟩
+    · rintro (⟨hmem, h⟩ | ⟨hmem, h⟩)
+      · exact ⟨hmem, by omega⟩
+      · exact ⟨hmem, by omega⟩
+  -- {b<a} and {a=b} are disjoint
+  have h_disj : Disjoint
+      ((S ×ˢ S).filter (fun p : ℕ × ℕ => p.2 < p.1))
+      ((S ×ˢ S).filter (fun p : ℕ × ℕ => p.1 = p.2)) := by
+    rw [Finset.disjoint_filter]
+    intro ⟨a, b⟩ _ h1 h2; omega
+  -- |{b<a}| = |{a<b}| via swap bijection (a,b) ↦ (b,a)
+  have h_swap : ((S ×ˢ S).filter (fun p : ℕ × ℕ => p.2 < p.1)).card =
+      ((S ×ˢ S).filter (fun p : ℕ × ℕ => p.1 < p.2)).card := by
+    symm
+    apply Finset.card_bij (fun p _ => Prod.swap p)
+    · intro ⟨a, b⟩ h
+      simp only [Finset.mem_filter, Finset.mem_product, Prod.swap] at h ⊢
+      exact ⟨⟨h.1.2, h.1.1⟩, h.2⟩
+    · intro ⟨a₁, b₁⟩ _ ⟨a₂, b₂⟩ _ h
+      simp only [Prod.swap, Prod.mk.injEq] at h
+      exact Prod.ext h.2 h.1
+    · intro ⟨a, b⟩ h
+      simp only [Finset.mem_filter, Finset.mem_product] at h
+      exact ⟨⟨b, a⟩, by
+        simp only [Finset.mem_filter, Finset.mem_product]
+        exact ⟨⟨h.1.2, h.1.1⟩, h.2⟩,
+        by simp [Prod.swap]⟩
+  -- |{a=b}| = |S| via diagonal bijection a ↦ (a,a)
+  have h_diag : ((S ×ˢ S).filter (fun p : ℕ × ℕ => p.1 = p.2)).card = S.card := by
+    symm
+    apply Finset.card_bij (fun x _ => (x, x))
+    · intro a ha
+      exact Finset.mem_filter.mpr ⟨Finset.mem_product.mpr ⟨ha, ha⟩, rfl⟩
+    · intro a₁ _ a₂ _ h
+      exact (Prod.mk.inj h).1
+    · intro p h
+      have hf := Finset.mem_filter.mp h
+      have hp := Finset.mem_product.mp hf.1
+      exact ⟨p.1, hp.1, Prod.ext rfl hf.2⟩
+  -- Key step: |{¬(a<b)}| = |{a<b}| + |S|
+  suffices h_key : ((S ×ˢ S).filter (fun p : ℕ × ℕ => ¬(p.1 < p.2))).card =
+      ((S ×ˢ S).filter (fun p : ℕ × ℕ => p.1 < p.2)).card + S.card by
+    -- From h_total and h_key: card + (card + |S|) = |S|²
+    rw [h_key] at h_total
+    have hcard : S.card = N + 1 := Finset.card_range (N + 1)
+    rw [hcard] at h_total
+    -- h_total: card + (card + (N+1)) = (N+1)*(N+1)
+    -- Use identity: choose(n,2) + choose(n,2) + n = n*n (proved by induction)
+    have h_choose_id : ∀ n : ℕ, n.choose 2 + n.choose 2 + n = n * n := by
+      intro n; induction n with
+      | zero => simp
+      | succ m ih =>
+        rw [Nat.choose_succ_succ, Nat.choose_one_right]
+        linarith
+    linarith [h_choose_id (N + 1)]
+  -- Prove h_key: decompose ¬< into > and =, swap gives |>|=|<|, diagonal gives |=|=|S|
+  rw [h_decomp, Finset.card_union_of_disjoint h_disj, h_swap, h_diag]
+
+/-- For distinct pair sums, the count equals C(N+1, 2).
+    Proof: injectivity gives |image| = |source|, and the source has
+    C(N+1,2) ordered pairs. -/
+theorem distinct_count_eq_binomial (f : ℤ[X]) (hf : HasDistinctPairSums f) (N : ℕ) :
+    distinctPairSumCount f N = (N + 1).choose 2 := by
+  unfold distinctPairSumCount
+  set S := (Finset.range (N + 1) ×ˢ Finset.range (N + 1)).filter
+    (fun p : ℕ × ℕ => p.1 < p.2)
+  -- The function is injective on the filtered set (subset of orderedPairs)
+  have h_inj : Set.InjOn (fun p : ℕ × ℕ => f.eval (↑p.1 : ℤ) + f.eval (↑p.2 : ℤ))
+      (↑S : Set (ℕ × ℕ)) := by
+    intro p₁ hp₁ p₂ hp₂ heq
+    have h1 : p₁ ∈ orderedPairs :=
+      (Finset.mem_filter.mp (Finset.mem_coe.mp hp₁)).2
+    have h2 : p₂ ∈ orderedPairs :=
+      (Finset.mem_filter.mp (Finset.mem_coe.mp hp₂)).2
+    exact hf h1 h2 heq
+  rw [Finset.card_image_of_injOn h_inj]
+  exact card_strict_pairs N


### PR DESCRIPTION
## Summary
- Convert `distinct_count_eq_binomial` from axiom to theorem, reducing axiom count from 2 to 1
- Proof via `Finset.card_image_of_injOn` + counting ordered pairs with partition/swap symmetry
- Add `constant_not_distinct` theorem (degree 0 polynomials fail the distinct pair sum property)
- Fix pre-existing Mathlib v4.26.0 API breaks (stale simp args, moved imports)

## Details
The key insight: if `f` has distinct pair sums (injective on ordered pairs), then the image cardinality equals the source cardinality. The source count `|{(a,b) : a < b ≤ N}| = C(N+1,2)` is proved via:
1. Partition `{¬(a<b)}` into `{b<a} ∪ {a=b}` (disjoint)
2. Swap bijection: `|{b<a}| = |{a<b}|`
3. Diagonal bijection: `|{a=b}| = |S|`
4. Combine with identity `C(n,2) + C(n,2) + n = n²` (by induction)

## File stats
- 244 lines, 1 axiom (min_degree_for_distinct — requires general degree ≤ 4 impossibility), 0 sorries
- Docker build verified

## Test plan
- [x] Docker build succeeds
- [x] 0 sorries
- [x] Axiom count reduced from 2 to 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)