### PR TITLE
Enrich 5 erdos entries: fix annotation quality and metadata

### DIFF
--- a/src/data/proofs/erdos-273/annotations.json
+++ b/src/data/proofs/erdos-273/annotations.json
@@ -223,7 +223,7 @@
     "type": "theorem",
     "range": {
       "startLine": 115,
-      "endLine": 115
+      "endLine": 122
     },
     "title": "Minimum Modulus $\\geq 4$",
     "content": "**min_modulus_ge_4**: Every modulus in a $p \\geq 5$ covering system satisfies $m_i \\geq 4$. Since $p \\geq 5$ implies $p - 1 \\geq 4$, and the only primes with $p - 1 < 4$ are $p = 2$ ($m = 1$, excluded by $m \\geq 2$) and $p = 3$ ($m = 2$, excluded by $p \\geq 5$).",

--- a/src/data/proofs/erdos-273/annotations.json
+++ b/src/data/proofs/erdos-273/annotations.json
@@ -199,7 +199,7 @@
     "type": "technique",
     "range": {
       "startLine": 104,
-      "endLine": 109
+      "endLine": 113
     },
     "title": "Even Coverage Difficulty ($m_i > 2$)",
     "content": "**difficulty_even_coverage**: For $p \\geq 5$, all allowed moduli satisfy $m_i > 2$. The only prime with $p - 1 = 2$ is $p = 3$, which is excluded. This means no single residue class can cover all even (or all odd) integers.",
@@ -220,9 +220,9 @@
   {
     "id": "erdos-273-obstacles",
     "proofId": "erdos-273",
-    "type": "concept",
+    "type": "theorem",
     "range": {
-      "startLine": 111,
+      "startLine": 115,
       "endLine": 115
     },
     "title": "Minimum Modulus $\\geq 4$",
@@ -246,13 +246,22 @@
       "startLine": 126,
       "endLine": 136
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "All Moduli in p≥5 Systems Are Even (Proved)",
     "content": "Proves `moduli_even`: every modulus in a covering system with all moduli of the form $p-1$ ($p \\geq 5$ prime) is even. The proof: $p \\geq 5$ and $p$ prime implies $p$ is odd (using `Nat.Prime.eq_two_or_odd` — if $p = 2$ then $p \\geq 5$ gives contradiction). Then $p - 1 = m_i$ is even since $p$ odd and 1 odd gives even difference (`Nat.Odd.sub_odd`). This structural constraint means modulus 2 is never available, making coverage of both parities fundamentally harder — the densest single class covers only $1/4$ of integers.",
     "mathContext": "$p \\geq 5$ prime $\\Rightarrow$ $p$ odd $\\Rightarrow$ $p - 1$ even. All moduli $m_i \\in \\{4, 6, 10, 12, 16, 18, \\ldots\\}$ are even. Without modulus 2, covering all integers requires at least 4 classes (since $1/4$ is the maximum density of any single class).",
     "significance": "key",
-    "relatedConcepts": ["parity of primes", "Nat.Prime.eq_two_or_odd", "Nat.Odd.sub_odd", "structural parity constraint"],
-    "prerequisites": ["AllModuliPrimeMinusOne", "Nat.Prime", "Even predicate"]
+    "relatedConcepts": [
+      "parity of primes",
+      "Nat.Prime.eq_two_or_odd",
+      "Nat.Odd.sub_odd",
+      "structural parity constraint"
+    ],
+    "prerequisites": [
+      "AllModuliPrimeMinusOne",
+      "Nat.Prime",
+      "Even predicate"
+    ]
   },
   {
     "id": "ann-e273-verification",
@@ -266,8 +275,18 @@
     "content": "Five `decide` and `norm_num` proofs verifying properties of the concrete modulus set $\\{4, 6, 12, 18, 36, 60, 180\\}$. `easyPrimes_all_prime`: all 7 elements are prime. `easyPrimes_ge_five`: all are $\\geq 5$. `easyPrimes_mod_divides_360`: each $p-1$ divides 360. These are checked by `decide` (kernel computation). Then `max_single_density` proves that no single residue class with modulus $p-1$ ($p \\geq 5$) can cover more than $1/4$ of integers, since $1/(p-1) \\leq 1/4$ when $p \\geq 5$. The proof uses `div_le_div_iff` and `linarith`. Together these establish the quantitative constraints on covering with prime-minus-one moduli.",
     "mathContext": "Verified: $\\{5,7,13,19,37,61,181\\}$ are all primes $\\geq 5$ with $(p-1) \\mid 360$. Density bound: $\\forall p \\geq 5$ prime, $1/(p-1) \\leq 1/4$. Equality at $p = 5$: modulus 4 gives the densest class. At least $\\lceil 1/(1/4) \\rceil = 4$ classes needed to cover all integers.",
     "significance": "supporting",
-    "relatedConcepts": ["decide tactic", "norm_num", "computational verification", "density upper bound", "div_le_div_iff"],
-    "prerequisites": ["easyPrimes", "Nat.Prime", "rational inequality"]
+    "relatedConcepts": [
+      "decide tactic",
+      "norm_num",
+      "computational verification",
+      "density upper bound",
+      "div_le_div_iff"
+    ],
+    "prerequisites": [
+      "easyPrimes",
+      "Nat.Prime",
+      "rational inequality"
+    ]
   },
   {
     "id": "ann-e273-reciprocal",

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -114,7 +114,7 @@
       "id": "connections",
       "title": "Connection to Other Problems",
       "startLine": 94,
-      "endLine": 115,
+      "endLine": 113,
       "summary": "Enumerates `easyPrimes` $= \\{5, 7, 13, 19, 37, 61, 181\\}$ (primes $p \\geq 5$ with $(p-1) \\mid 360$) and axiomatizes the key constraints: all moduli $> 2$ and $\\geq 4$ when restricted to $p \\geq 5$.",
       "mathContext": "Easy primes: $\\{p \\geq 5 : (p-1) \\mid 360\\} = \\{5,7,13,19,37,61,181\\}$. Constraint: all $m_i \\geq 4$ for $p \\geq 5$."
     },


### PR DESCRIPTION
## Summary

Enrichment pass fixing annotation line ranges, type mismatches, metadata issues, and Unicode normalization across 5 erdos entries. All build with zero annotation warnings.

### erdos-321
- Remove spurious `"in"` from `leanFile.opens`
- Align `overview.prerequisites` with `meta.prerequisites`

### erdos-332
- Fixed 7 annotation startLine/endLine values
- Added `Classical` to `leanFile.opens`

### erdos-341
- Fixed 3 annotation types to match Lean constructs
- Fixed 2 startLine values

### erdos-347
- Fixed annotation type (insight → theorem) and endLine
- Unicode normalization

### erdos-273
- Fixed annotation types (concept→theorem, technique→theorem)
- Fixed 3 annotation line ranges and section endLine
- Unicode normalization throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)