### PR TITLE
Fix: count_sorries double-output bug in Aristotle recovery

### DIFF
--- a/scripts/aristotle/retrieve-integrate.sh
+++ b/scripts/aristotle/retrieve-integrate.sh
@@ -127,7 +127,9 @@ retrieve_solution() {
 
 # Count sorries in a file
 count_sorries() {
-    grep -c "sorry" "$1" 2>/dev/null || echo 0
+    local count
+    count=$(grep -c "sorry" "$1" 2>/dev/null) || true
+    echo "${count:-0}"
 }
 
 # Count theorems proved (sorries eliminated) by comparing original and solution


### PR DESCRIPTION
## Summary
- `grep -c` outputs `0` then exits with code 1 when no matches found
- `|| echo 0` fires, producing `0\n0` (two lines) instead of `0`
- This breaks `[[ $new_sorries -lt $orig_sorries ]]` with syntax error
- Fix: capture grep output separately, ignore exit code with `|| true`

## Test plan
- [x] Already hotfixed in the live Aristotle worktree
- [x] `bash -n` syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)