### PR TITLE
Peer review: area-of-circle-oq-01 (B)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01/review.json
+++ b/src/data/proofs/area-of-circle-oq-01/review.json
@@ -1,14 +1,31 @@
 {
   "version": 1,
   "proofId": "area-of-circle-oq-01",
-  "reviewDate": "2026-03-24T12:00:00Z",
+  "reviewDate": "2026-03-24T18:30:00Z",
   "reviewer": "peer-reviewer",
 
   "overallAssessment": {
-    "grade": "C+",
-    "oneLiner": "A clean Mathlib power-rule application dressed up with 12+ trivial corollaries and an expansive historical narrative that substantially outweighs the formal content.",
+    "grade": "B",
+    "oneLiner": "A well-crafted pedagogical entry that honestly applies Mathlib's power rule to connect area differentiation with circumference, with excellent historical context and thorough annotations, though padded with trivial corollaries.",
     "tier": "B",
-    "tierJustification": "The core proof applies hasDerivAt_pow from Mathlib to differentiate πr². All 18 theorems depend on Mathlib's calculus infrastructure; the original contribution is defining two functions and connecting them via the power rule. This is solidly Tier B (Mathlib-based formalization)."
+    "tierJustification": "The core proof applies hasDerivAt_pow from Mathlib to differentiate πr². The two definitions and the power-rule application are the original contribution; all substantive calculus machinery comes from Mathlib. This is solidly Tier B (Mathlib-based formalization with pedagogical value).",
+    "stratification": {
+      "proved": [
+        "hasDerivAt_circleArea (main theorem: dA/dr = 2πr via power rule)",
+        "deriv2_circleArea (second derivative = 2π via extensionality)",
+        "circleArea_mono / circumference_mono (monotonicity for non-negative radii)",
+        "circumference_pos / circleArea_pos (positivity via positivity tactic)",
+        "12 additional corollaries (trivial: unfold + ring or one-line API extractions)"
+      ],
+      "axiomatized": [],
+      "elementary": [
+        "circumference_unit, circumference_zero, circleArea_zero, circleArea_unit (special-case evaluation)",
+        "circumference_scaling, circleArea_scaling (homogeneity identities)",
+        "isoperimetric_equality (algebraic tautology: (2πr)² = 4π·(πr²))",
+        "circumference_from_deriv (one-line rewrite of deriv_circleArea_eq_circumference)"
+      ],
+      "assessment": "All 18 theorems are fully proved with no axioms or sorries. However, only the main theorem and second derivative involve multi-step reasoning; the remaining 16 are one-liners or unfold+ring tautologies, making the theorem count a misleading measure of substance."
+    }
   },
 
   "findings": [
@@ -16,71 +33,64 @@
       "severity": "positive",
       "category": "strength",
       "location": "meta.json assumptions field",
-      "finding": "The assumptions field honestly states 'Main result is a direct application of Mathlib hasDerivAt_pow.' This is the most accurate sentence in the entire entry and sets the right expectation for what follows.",
-      "recommendation": "Preserve this honest framing. Consider aligning the rest of the entry (especially originalContributions) with this tone."
+      "finding": "The assumptions field states '0 axioms, 0 sorries. Main result is a direct application of Mathlib hasDerivAt_pow.' This honest self-assessment sets appropriate expectations and is the most accurate characterization in the entry.",
+      "recommendation": "Preserve. This kind of honesty should be the template for all gallery entries."
     },
     {
       "severity": "positive",
       "category": "strength",
-      "location": "overview.historicalContext in meta.json",
-      "finding": "The historical context is well-researched and accurate: Archimedes' exhaustion method, Newton/Leibniz FTC, Federer-Fleming coarea formula, and Weierstrass/Hurwitz isoperimetric proofs are all correctly described and properly attributed.",
-      "recommendation": "Preserve. The quality of the historical writing is a genuine asset for pedagogy."
+      "location": "meta.json overview.historicalContext",
+      "finding": "The historical narrative is well-researched and accurate: Archimedes' exhaustion method (~250 BCE), Newton/Leibniz FTC (1660s-1680s), Federer-Fleming coarea formula (1960), Weierstrass isoperimetric proof (1870s), and Hurwitz's Fourier-analytic proof (1902) are all correctly described and attributed. The progression from ancient to modern is pedagogically effective.",
+      "recommendation": "Preserve. This is a model for how historical context should be written — substantive, accurate, proportionate."
     },
     {
       "severity": "positive",
       "category": "strength",
-      "location": "hasDerivAt_circleArea, line 57-65",
-      "finding": "The main theorem is clearly structured: unfold definition, apply power rule, apply constant multiple rule, close with ring. The proof is readable and the comments are helpful.",
-      "recommendation": "Good proof style to maintain."
+      "location": "hasDerivAt_circleArea, lines 57-65",
+      "finding": "The main theorem proof is clearly structured and readable: unfold the definition, apply hasDerivAt_pow 2 r, chain .const_mul π, close with ring. The inline comment 'd/dr (π * r²) = π * 2r = 2πr' aids comprehension. This is a good example of a well-written Mathlib application proof.",
+      "recommendation": "Maintain this proof style for future entries."
     },
     {
-      "severity": "moderate",
-      "category": "overclaim",
-      "location": "meta.json originalContributions (6 items)",
-      "finding": "Lists 6 'original contributions' including 'Complete formalization of C = 2πr via differentiation of A = πr²' and 'HasDerivAt and deriv proofs for the circle area function.' These are applications of Mathlib's power rule and API, not original contributions. The same entry's assumptions field honestly calls this 'a direct application of Mathlib hasDerivAt_pow,' contradicting the originalContributions framing.",
-      "recommendation": "Reduce to 2-3 items and reframe as 'what this entry provides' rather than 'original contributions.' E.g.: 'Pedagogical formalization connecting area differentiation to circumference,' 'Second derivative and monotonicity corollaries,' 'Isoperimetric algebraic identity C² = 4πA.'"
-    },
-    {
-      "severity": "moderate",
-      "category": "overclaim",
-      "location": "isoperimetric_equality, line 152-155",
-      "finding": "The theorem name 'isoperimetric_equality' and its docstring 'the equality case of the isoperimetric inequality for circles' imply a connection to the isoperimetric theorem. In reality, this is the algebraic tautology (2πr)² = 4π·(πr²), which holds by expanding definitions. It says nothing about optimality — that circles maximize area for a given perimeter is not proved here.",
-      "recommendation": "Rename to 'circumference_area_relation' or 'csq_eq_four_pi_area' and update the docstring to: 'Algebraic relationship between circumference and area for circles: C² = 4πA. This is the equality case of the isoperimetric inequality, though the inequality itself is not proved here.'"
+      "severity": "positive",
+      "category": "strength",
+      "location": "annotations.json, all entries",
+      "finding": "The annotations are thorough, accurate, and well-calibrated. The isoperimetric annotation (ann-isoperimetric) honestly states 'purely by expanding definitions' and clarifies 'the inequality itself... is not proved here.' Significance ratings appropriately distinguish 'key' results from 'supporting' ones.",
+      "recommendation": "Preserve. The annotation quality here exceeds most gallery entries."
     },
     {
       "severity": "moderate",
       "category": "filler",
-      "location": "circumference_unit (line 91), circumference_zero (line 95), circleArea_zero (line 104), circleArea_unit (line 108)",
-      "finding": "These four theorems are trivial special cases proved by 'unfold; ring'. They contribute no mathematical content beyond evaluating a polynomial at r=0 or r=1. Together with circumference_scaling and circleArea_scaling (also unfold; ring), six of 18 theorems are pure algebraic tautologies.",
-      "recommendation": "These are acceptable as pedagogical examples but should not be counted as substantive theorems. Consider noting them as 'convenience lemmas' or 'special cases' rather than featuring them in sections descriptions."
+      "location": "lines 90-114: circumference_unit, circumference_zero, circumference_scaling, circleArea_zero, circleArea_unit, circleArea_scaling",
+      "finding": "Six of 18 theorems are trivial evaluations or homogeneity identities proved by 'unfold; ring'. They contribute no mathematical content beyond evaluating a polynomial at 0 or 1, or verifying that πr² is degree-2 homogeneous. Combined with circumference_from_deriv (a one-line rewrite) and the HasDerivAt/deriv/Differentiable API extractions, 15 of 18 theorems are essentially one-liners.",
+      "recommendation": "These are fine as convenience lemmas but the meta.json theoremCount of 18 overstates substance. Consider grouping them under a 'convenience lemmas' subsection in the section descriptions rather than featuring them alongside the main theorem."
+    },
+    {
+      "severity": "moderate",
+      "category": "overclaim",
+      "location": "isoperimetric_equality, lines 150-155; meta.json sections[6] (isoperimetric)",
+      "finding": "The theorem name 'isoperimetric_equality' and its docstring ('the equality case of the isoperimetric inequality for circles') imply a connection to the isoperimetric theorem. The proof body is simply 'unfold circumference circleArea; ring' — it verifies the algebraic tautology (2πr)² = 4π·(πr²). The isoperimetric content (that circles are optimal among all curves) is not proved. The section title 'Isoperimetric Equality and Duality' elevates this further.",
+      "recommendation": "Rename the theorem to 'csq_eq_four_pi_area' or 'circumference_area_identity'. Update the section title to 'Algebraic Identity and Duality'. The docstring should lead with 'algebraic relationship' rather than 'isoperimetric.'"
     },
     {
       "severity": "minor",
       "category": "inconsistency",
-      "location": "meta.json sections[0] (imports-setup), mathContext field",
-      "finding": "Claims imports from 'Analysis.SpecialFunctions.Trigonometric.Deriv' and 'MeasureTheory.Measure.Lebesgue.EqHaar'. The actual imports are 'Trigonometric.Basic' and 'VolumeOfBalls'. These are different modules.",
-      "recommendation": "Fix the mathContext to list the actual imports: Deriv.Basic, Deriv.Pow, Trigonometric.Basic, VolumeOfBalls, Tactic."
+      "location": "relatedProofs[3] (fundamental-theorem-calculus), lines 233-238 vs crossReferences[3], lines 91-94",
+      "finding": "The crossReferences entry for fundamental-theorem-calculus correctly qualifies: 'This entry proves the derivative direction... The integral direction... is listed as an open question but not formalized here.' However, the relatedProofs entry for the same target says 'differentiating the area function πr² yields the circumference 2πr, and integrating the circumference recovers the area' without qualification — implying both directions are proved.",
+      "recommendation": "Align relatedProofs[3] with crossReferences[3]: add 'The integral direction remains an open question' or remove the integration claim."
     },
     {
       "severity": "minor",
       "category": "inconsistency",
       "location": "Lean file line 4: import VolumeOfBalls",
-      "finding": "MeasureTheory.Measure.Lebesgue.VolumeOfBalls is imported but nothing from this module is used anywhere in the file. The header comment mentions 'Connect back to the Lebesgue measure formulation from AreaOfCircle.lean' (line 28) but this connection is never made.",
-      "recommendation": "Either remove the unused import or add a comment explaining why it is retained (e.g., for future connection to the measure-theoretic area formulation)."
+      "finding": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls is imported but nothing from this module appears in any theorem or definition. The meta.json sections[0].mathContext correctly notes it is 'unused in current proofs', and the Lean header (line 28) mentions a planned connection to AreaOfCircle.lean that was never implemented.",
+      "recommendation": "Remove the unused import to keep the dependency graph clean, or add the planned connection as a future open question item."
     },
     {
       "severity": "minor",
       "category": "precision",
-      "location": "crossReferences: fundamental-theorem-calculus",
-      "finding": "The cross-reference claims 'differentiating the area function πr² yields the circumference 2πr, and integrating the circumference recovers the area.' Only the derivative direction is proved. The integral direction (A(r) = ∫₀ʳ C(ρ) dρ) is listed as an open question in the conclusion but not formalized.",
-      "recommendation": "Qualify the cross-reference: 'This entry proves the derivative direction (dA/dr = C). The integral direction remains an open question.'"
-    },
-    {
-      "severity": "minor",
-      "category": "precision",
-      "location": "description in meta.json",
-      "finding": "Describes the result as 'the deep geometric connection that the boundary length equals the rate of change of area.' The word 'deep' is disproportionate — this is a standard calculus exercise (differentiating πr²). The geometric interpretation is interesting, but the formalization itself is an application of the power rule.",
-      "recommendation": "Replace 'deep geometric connection' with 'classical geometric relationship' or 'fundamental relationship.'"
+      "location": "meta.json originalContributions[2]",
+      "finding": "Lists 'Algebraic identity C² = 4πA (isoperimetric equality case for circles)' as an original contribution. This identity is proved by 'unfold; ring' — it is an algebraic tautology, not a meaningful contribution. The parenthetical '(isoperimetric equality case for circles)' again elevates simple algebra.",
+      "recommendation": "Remove this item or downgrade to: 'Convenience lemma: C² = 4πA algebraic identity for circles.'"
     }
   ],
 
@@ -89,47 +99,41 @@
       "id": "ai-1",
       "priority": "medium",
       "target": "enricher",
-      "description": "Reframe originalContributions from 6 items to 2-3 honest items. Align tone with the assumptions field which already correctly identifies this as a Mathlib application.",
-      "status": "resolved"
+      "description": "Rename section 'Isoperimetric Equality and Duality' to 'Algebraic Identity and Duality'. Remove 'isoperimetric' framing from section summary since the actual isoperimetric theorem (optimality of circles) is not proved here.",
+      "status": "open"
     },
     {
       "id": "ai-2",
       "priority": "medium",
       "target": "enricher",
-      "description": "Fix sections[0].mathContext: replace incorrect import names (Trigonometric.Deriv, EqHaar) with actual imports (Trigonometric.Basic, VolumeOfBalls).",
-      "status": "resolved"
+      "description": "Align relatedProofs[3] (fundamental-theorem-calculus) with crossReferences[3]: qualify that only the derivative direction is proved and the integral direction is an open question.",
+      "status": "open"
     },
     {
       "id": "ai-3",
       "priority": "low",
       "target": "enricher",
-      "description": "Qualify the fundamental-theorem-calculus cross-reference to note that only the derivative direction is proved, not the integral direction.",
-      "status": "resolved"
+      "description": "Remove originalContributions[2] ('Algebraic identity C² = 4πA') or reframe without isoperimetric language — it is an unfold+ring tautology.",
+      "status": "open"
     },
     {
       "id": "ai-4",
       "priority": "low",
       "target": "researcher",
-      "description": "Consider removing unused import VolumeOfBalls, or adding the planned connection to the measure-theoretic area formulation.",
+      "description": "Remove unused import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls from CircumferenceFromArea.lean, or implement the planned connection to the measure-theoretic area formulation.",
       "status": "open"
-    },
-    {
-      "id": "ai-5",
-      "priority": "low",
-      "target": "enricher",
-      "description": "Rename or re-describe isoperimetric_equality to clarify it is an algebraic identity, not a proof of the isoperimetric inequality. Update cross-reference to isoperimetric-theorem accordingly.",
-      "status": "resolved"
     }
   ],
 
   "qualityScores": {
-    "mathematicalSubstance": 4,
-    "originalityAccuracy": 5,
-    "completeness": 8,
-    "framingPrecision": 5,
-    "pedagogicalQuality": 7,
-    "internalConsistency": 6,
-    "overall": 5.8
+    "mathematicalSubstance": 5,
+    "originalityAccuracy": 7,
+    "completeness": 9,
+    "framingPrecision": 7,
+    "pedagogicalQuality": 8,
+    "internalConsistency": 7,
+    "epistemicCoherence": 8,
+    "overall": 7.3
   },
 
   "suggestedBestFraming": "A pedagogical formalization that applies Mathlib's power rule to derive C = 2πr from A = πr², with corollaries for differentiability, monotonicity, scaling, and the algebraic identity C² = 4πA."

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -394,9 +394,9 @@
       "resolvedItems": 0
     },
     "area-of-circle-oq-01": {
-      "reviewCount": 1,
-      "lastReviewed": "2026-03-25T05:34:32Z",
-      "overallGrade": "already-reviewed",
+      "reviewCount": 2,
+      "lastReviewed": "2026-03-25T06:32:34Z",
+      "overallGrade": "B",
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0


### PR DESCRIPTION
## Summary

Re-review of `area-of-circle-oq-01` (Circumference Formula via Area Differentiation) reflecting resolved action items from the prior C+ review.

**Grade: B** (up from C+). 9 findings (4 positive, 2 moderate, 3 minor). 4 open action items.

### Key improvements since prior review
- `originalContributions` trimmed from 6 to 3 with honest framing
- `sections[0].mathContext` import names fixed
- `crossReferences` FTC entry now qualifies that only derivative direction is proved

### Remaining action items
- Rename "Isoperimetric Equality" section/theorem (algebraic tautology, not the isoperimetric theorem)
- Align `relatedProofs[3]` with `crossReferences[3]` for FTC (qualify integral direction)
- Remove or downgrade `originalContributions[2]` (C²=4πA is unfold+ring)
- Remove unused `VolumeOfBalls` import

### Quality scores
| Dimension | Score |
|-----------|-------|
| Mathematical Substance | 5 |
| Originality Accuracy | 7 |
| Completeness | 9 |
| Framing Precision | 7 |
| Pedagogical Quality | 8 |
| Internal Consistency | 7 |
| Epistemic Coherence | 8 |
| **Overall** | **7.3** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)