### PR TITLE
Enrich erdos-28, erdos-347, erdos-278: fix annotation ranges, add metadata

### DIFF
--- a/src/data/proofs/erdos-278/annotations.json
+++ b/src/data/proofs/erdos-278/annotations.json
@@ -5,7 +5,7 @@
     "type": "concept",
     "range": {
       "startLine": 21,
-      "endLine": 26
+      "endLine": 25
     },
     "title": "Imports and Setup",
     "content": "Imports Mathlib for `Finset.Card` (counting covered residues), `Nat.GCD.Basic` and `Nat.Prime.Basic` (for LCM and coprimality), `Data.Real.Basic` (for density as a real number), and tactics. The formalization works with moduli in $\\mathbb{N}$ and densities in $\\mathbb{R}$.",
@@ -139,7 +139,7 @@
     "type": "concept",
     "range": {
       "startLine": 60,
-      "endLine": 80
+      "endLine": 113
     },
     "title": "LCM Positivity Lemmas",
     "content": "Two lemmas establishing that `foldl Nat.lcm` preserves positivity (by induction on the list) and that `systemLCM` is always positive. These are needed to ensure the density denominator is nonzero. The proof uses `Nat.lcm_eq_zero_iff` to show the LCM of positive numbers is positive.",
@@ -251,8 +251,8 @@
     "proofId": "erdos-278",
     "type": "concept",
     "range": {
-      "startLine": 141,
-      "endLine": 142
+      "startLine": 489,
+      "endLine": 550
     },
     "title": "Maximum Density: The Open Problem",
     "content": "The main open part of Problem #278: what is the maximum coverage density for general (non-coprime) moduli? Axiomatized as $\\delta_{\\max} \\leq 1$, which is trivially true but highlights that no tighter bound is known in general. Non-coprimality allows clever residue alignment to control overlap structure.",
@@ -274,8 +274,8 @@
     "proofId": "erdos-278",
     "type": "technique",
     "range": {
-      "startLine": 147,
-      "endLine": 148
+      "startLine": 584,
+      "endLine": 646
     },
     "title": "Single Modulus Case",
     "content": "For a single modulus $n$, there is only one residue to choose, and the coverage density is exactly $1/n$ regardless of the choice. This is the trivial base case: max = min = $1/n$.",

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -24,7 +24,30 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: simpson_theorem (minimum density achieved with equal residues — Simpson 1986). coprime_density_formula is now FULLY PROVED via CRT complement counting argument.",
     "lineCount": 646,
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_filter_le_iff",
+        "description": "Bounds on filtered finset cardinality for density calculations",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.lcm",
+        "description": "Least common multiple used for the coverage period",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime",
+        "description": "Coprimality predicate for the CRT-based density formula",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ],
+    "originalContributions": [
+      "CRT-based complement counting proof of coprime_density_formula (coverage density = 1 - prod(1 - 1/n_i) for coprime moduli)",
+      "CongruenceSystem structure with moduli, residue functions, and positivity constraints",
+      "Complete LCM infrastructure: foldl_lcm_pos, init_dvd_foldl_lcm, mem_dvd_foldl_lcm, dvd_systemLCM",
+      "Single modulus base case: coverageDensity_singleton and single_modulus_density via filter characterization"
+    ]
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p.28), as part of their systematic study of covering systems — a topic Erdős championed from his groundbreaking 1950 paper showing that covering systems with distinct moduli greater than 1 exist. The problem asks: given fixed moduli, how should one choose residues to optimize coverage?\n\nCovering systems have a rich history. Erdős introduced them in his 1950 proof that there exist infinitely many odd integers not representable as $2^k + p$ (a prime), using a covering system with moduli $\\{2, 3, 4, 8, 12, 24\\}$. He conjectured that covering systems with arbitrarily large minimum modulus exist — a conjecture that stood for over 60 years until Bob Hough's 2015 proof (Annals of Mathematics) showed that any covering system with distinct moduli must include a modulus at most $10^{16}$, dramatically settling the question in the negative.\n\nR.J. Simpson resolved the minimum question of Problem #278 in 1986 (Discrete Mathematics 59), proving by an elegant averaging argument that equal residues minimize coverage density. His proof uses the key observation that uniformly shifting all residues preserves the expected density, so the minimum cannot exceed the equal-residue density. The maximum question remains open and is fundamentally harder: for coprime moduli, the Chinese Remainder Theorem forces all residue choices to yield the same density $1 - \\prod(1 - 1/n_i)$, but for non-coprime moduli, the overlap structure between congruence classes depends delicately on the residue choices. The problem connects to sieve-theoretic methods in analytic number theory and to combinatorial optimization on lattice structures.",

--- a/src/data/proofs/erdos-28/annotations.json
+++ b/src/data/proofs/erdos-28/annotations.json
@@ -1,10 +1,33 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "erdos-28",
+    "range": {
+      "startLine": 1,
+      "endLine": 33
+    },
+    "type": "context",
+    "title": "Module Documentation: Problem Statement and Status",
+    "content": "The module docstring establishes the mathematical context for Erdős Problem #28: the Erdős–Turán conjecture on additive bases. It states the conjecture ($\\limsup r_A(n) = \\infty$ for any asymptotic basis $A$), notes the $500 prize, records the OPEN status, and lists the key partial results (Grekos et al.: $r_A(n) \\geq 6$ i.o.; Borwein et al.: $r_A(n) \\geq 8$ i.o.). The stronger conjectures (logarithmic growth and density version) are also previewed. The outline of the formalization lists five components: representation function, asymptotic basis definition, formal conjecture statement, basic properties, and constructions with unbounded representations.",
+    "mathContext": "The conjecture: if $A + A \\supseteq \\{N_0, N_0+1, \\ldots\\}$ then $\\limsup_{n \\to \\infty} r_A(n) = \\infty$, where $r_A(n) = |\\{(a,b) \\in A^2 : a+b=n\\}|$. The $500 prize reflects its status as one of the deepest open problems in additive number theory, unsolved since 1941.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős problems",
+      "additive bases",
+      "representation functions",
+      "Erdős–Turán conjecture"
+    ],
+    "prerequisites": [
+      "additive number theory",
+      "Erdős problem catalog"
+    ]
+  },
+  {
     "id": "imports-setup",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 20,
-      "endLine": 29
+      "startLine": 35,
+      "endLine": 43
     },
     "type": "concept",
     "title": "Imports and Setup",
@@ -25,8 +48,8 @@
     "id": "rep-function",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 33,
-      "endLine": 36
+      "startLine": 47,
+      "endLine": 55
     },
     "type": "definition",
     "title": "Representation Function",
@@ -49,8 +72,8 @@
     "id": "asymptotic-basis",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 38,
-      "endLine": 41
+      "startLine": 63,
+      "endLine": 73
     },
     "type": "definition",
     "title": "Asymptotic Basis of Order 2",
@@ -73,8 +96,8 @@
     "id": "counting-fn",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 43,
-      "endLine": 45
+      "startLine": 57,
+      "endLine": 59
     },
     "type": "definition",
     "title": "Counting Function",
@@ -96,8 +119,8 @@
     "id": "main-conjecture",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 49,
-      "endLine": 56
+      "startLine": 201,
+      "endLine": 210
     },
     "type": "technique",
     "title": "Erdős–Turán Conjecture (1941)",
@@ -120,8 +143,8 @@
     "id": "strong-form",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 60,
-      "endLine": 63
+      "startLine": 212,
+      "endLine": 218
     },
     "type": "technique",
     "title": "Logarithmic Growth Conjecture",
@@ -144,8 +167,8 @@
     "id": "density-version",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 65,
-      "endLine": 70
+      "startLine": 447,
+      "endLine": 462
     },
     "type": "definition",
     "title": "Density Version of the Conjecture",
@@ -167,8 +190,8 @@
     "id": "basis-counting",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 74,
-      "endLine": 77
+      "startLine": 449,
+      "endLine": 462
     },
     "type": "technique",
     "title": "Basis Counting Lower Bound",
@@ -190,8 +213,8 @@
     "id": "sidon-connection",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 79,
-      "endLine": 84
+      "startLine": 350,
+      "endLine": 411
     },
     "type": "concept",
     "title": "Sidon Sets Cannot Be Bases",
@@ -214,8 +237,8 @@
     "id": "problem-40",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 88,
-      "endLine": 93
+      "startLine": 220,
+      "endLine": 223
     },
     "type": "concept",
     "title": "Connection to Problem #40 (B₂[g] Sets)",
@@ -238,8 +261,8 @@
     "id": "erdos-fuchs",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 97,
-      "endLine": 103
+      "startLine": 225,
+      "endLine": 233
     },
     "type": "concept",
     "title": "Erdős–Fuchs Theorem (1956)",
@@ -263,8 +286,8 @@
     "id": "average-rep",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 105,
-      "endLine": 111
+      "startLine": 225,
+      "endLine": 233
     },
     "type": "concept",
     "title": "Average Representation Unbounded (Halberstam–Roth)",

--- a/src/data/proofs/erdos-347/annotations.json
+++ b/src/data/proofs/erdos-347/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "erdos-347-header",
+    "proofId": "erdos-347",
+    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 21
+    },
+    "title": "Module Header: Problem Statement and Imports",
+    "content": "The module docstring states Erdős Problem #347: does there exist a monotone sequence with ratio limit 2 such that every cofinite subsequence has density-1 subset sums? The problem was solved affirmatively by ebarschkis, building on ideas from Terence Tao and Wouter van Doorn. Six Mathlib imports provide the foundation: `Data.Nat.Basic` and `Data.Finset.Basic/Card` for natural number and finite set arithmetic, `Data.Real.Basic` for real-valued bounds (used in density definitions via rational approximation), `Data.Set.Basic` for set operations (complements, ranges), and `Tactic` for automation. The `open Set` declaration enables unqualified access to set operations.",
+    "mathContext": "The problem sits at the critical growth threshold: $\\lim a_{n+1}/a_n = 2$ is the boundary between easy completeness ($r < 2$, slow growth fills gaps via greedy algorithms) and impossible completeness ($r > 2$, gaps grow exponentially). Powers of 2 achieve $P(\\{1,2,4,\\ldots\\}) = \\mathbb{N}$ but are fragile under deletion.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Erdős problems",
+      "complete sequences",
+      "critical growth rate"
+    ],
+    "prerequisites": [
+      "Mathlib imports",
+      "Lean 4 set notation"
+    ]
+  },
+  {
     "id": "erdos-347-subset-sums",
     "proofId": "erdos-347",
     "type": "definition",
@@ -77,7 +99,7 @@
     "type": "definition",
     "range": {
       "startLine": 56,
-      "endLine": 61
+      "endLine": 63
     },
     "title": "Cofinite Subsequences",
     "content": "IsCofiniteSubseq a iota means iota is a strictly monotone reindexing omitting only finitely many indices. This captures robustness: removing finitely many terms should not destroy the density-1 property.",

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -21,14 +21,36 @@
     "erdosUrl": "https://erdosproblems.com/347",
     "erdosProblemStatus": "proved",
     "axiomCount": 1,
-    "assumptions": "1 axiom(s). No sorries.",
+    "assumptions": "1 axiom: `erdos347_affirmative` asserts the existential statement `ErdosProblem347` — that a monotone sequence with ratio limit 2 exists such that every cofinite subsequence has density-1 subset sums. This axiomatizes the affirmative solution by ebarschkis (Tao-van Doorn construction). No sorries.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum",
+        "description": "Summation over finite sets, used for subset sum definition",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "StrictMono",
+        "description": "Strictly monotone functions, used for cofinite subsequence reindexing",
+        "module": "Mathlib.Order.Monotone.Basic"
+      },
+      {
+        "theorem": "Set.Finite",
+        "description": "Finiteness predicate for sets, used for cofinite complement condition",
+        "module": "Mathlib.Data.Set.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Complete formal framework for subset sum density problems: subsetSums, HasDensity, HasRatioLimit, IsCofiniteSubseq",
+      "Corrected subsetSums_insert with fresh-witness requirement (original subsetSums_add was incorrect for multiset-like reasoning)",
+      "Three proved structural properties: zero_mem_subsetSums, subsetSums_insert, subsetSums_mono"
+    ],
     "lineCount": 102,
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this in their 1980 monograph, asking about the interplay between multiplicative growth rates and additive completeness. The ratio limit 2 is the critical threshold for subset sum completeness: powers of 2 give every natural number via binary representation ($P(\\{1,2,4,8,\\ldots\\}) = \\mathbb{N}$), but small perturbations can destroy this. The question asks whether a sequence growing at rate 2 can be made 'robustly complete' — not just complete, but maintaining density-1 subset sums even after removing finitely many terms. This robustness requirement is much stronger than simple completeness and connects to the stability theory of additive representations. The problem was solved affirmatively by ebarschkis, building on ideas from Terence Tao and Wouter van Doorn. The construction carefully perturbs powers of 2 to create controlled redundancy: each integer has many different subset sum representations, so deleting finitely many terms still leaves enough representations to cover almost all integers.",
     "problemStatement": "Is there a sequence A = {a_1 <= a_2 <= ...} with lim a_{n+1}/a_n = 2 such that P(A') has density 1 for every cofinite subsequence A' of A?",
-    "text": "Is there a monotone integer sequence with ratio limit 2 such that every cofinite subsequence has subset sums of density 1? Solved affirmatively by ebarschkis (based on Tao-van Doorn ideas).",
+    "text": "A 102-line formalization of Erdős Problem #347 (solved affirmatively) that builds the complete framework for studying subset sum density under cofinite deletions. Defines `subsetSums A` (finite subset sums of $A$), `HasDensity S \\delta$ (asymptotic density via $\\varepsilon$-$N_0$ convergence of $|S \\cap [1,N]|/N$), `HasRatioLimit a r` (consecutive ratio convergence), and `IsCofiniteSubseq a \\iota$ (strictly monotone reindexing with cofinite range). The main statement `ErdosProblem347` combines all conditions existentially, and `erdos347_affirmative` axiomatizes the affirmative answer (ebarschkis, building on Tao-van Doorn). Three proved theorems establish basic algebraic properties: $0 \\in P(A)$ (empty sum), the corrected additive closure (requiring fresh witnesses to avoid the multiset trap), and monotonicity under set inclusion. The fresh-witness correction in `subsetSums_insert` is a non-trivial finding: the naive formulation $s \\in P(A) \\wedge a \\in A \\Rightarrow s+a \\in P(A)$ is false because subsets are sets, not multisets.",
     "proofStrategy": "We formalize `subsetSums A` as the set of all finite subset sums, `HasDensity S delta` as the limit of the counting function ratio, `HasRatioLimit a r` as convergence of consecutive ratios, and `IsCofiniteSubseq` via strictly monotone injections with cofinite range. The main statement `ErdosProblem347` combines all conditions existentially, and `erdos347_affirmative` axiomatizes the positive answer. Basic algebraic properties of subset sums (zero membership, additive closure, monotonicity) are included.",
     "keyInsights": [
       "Ratio limit 2 is the critical threshold: for r < 2, completeness is easy (slow growth fills gaps); for r > 2, completeness fails (fast growth creates unbridgeable gaps). The problem lives exactly at the boundary",
@@ -45,6 +67,14 @@
     ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 22,
+      "summary": "Module docstring stating the problem, its solved status, and reference. Six Mathlib imports for natural numbers, finite sets, reals, sets, and tactics. Opens Set namespace.",
+      "mathContext": "Erdős Problem #347: $\\exists A$ monotone with $a_{n+1}/a_n \\to 2$ such that $P(A')$ has density 1 for every cofinite $A' \\subseteq A$. Solved affirmatively."
+    },
     {
       "id": "subset-sums",
       "title": "Subset Sums",


### PR DESCRIPTION
Enrichment pass for three entries.

## erdos-28: Fix 12 annotation line ranges + add header
- Fixed 12 annotation line ranges pointing to wrong Lean file sections
- Added header annotation for lines 1-33 (module docstring)

## erdos-347: Expand metadata and annotations
- Added header annotation for lines 1-21 (docstring + imports)
- Added header section in meta.json
- Expanded assumptions, mathlibDependencies, originalContributions, overview.text
- Fixed cofinite annotation range (56-61 -> 56-63)

## erdos-278: Fix 4 annotation ranges + add metadata
- Fixed erdos-278-open (141-142 -> 489-550) and erdos-278-single-modulus (147-148 -> 584-646) — both pointed to completely wrong code
- Fixed erdos-278-lcm-pos (60-80 -> 60-113) to cover full LCM infrastructure
- Added mathlibDependencies and originalContributions