### PR TITLE
Enrich dissection-of-cubes-oq-01, hilbert-17, cevas-theorem: fix review items

### DIFF
--- a/src/data/proofs/cevas-theorem/annotations.json
+++ b/src/data/proofs/cevas-theorem/annotations.json
@@ -54,7 +54,7 @@
     "type": "definition",
     "title": "Cevian Configuration",
     "content": "A structure capturing the configuration of three cevians through parameters d, e, f. Point D = (1-d)B + dC lies on BC, E = (1-e)C + eA lies on CA, and F = (1-f)A + fB lies on AB. The constraints ensure points are distinct from vertices.",
-    "mathContext": "Parameters must satisfy d, e, f in (0, 1) excluding endpoints",
+    "mathContext": "Parameters $d, e, f \\in \\mathbb{R} \\setminus \\{0, 1\\}$, representing division ratios. Values in $(0,1)$ give internal division; values outside $(0,1)$ give external division points. The constraints $d, e, f \\neq 0$ ensure points are not at vertices, and $\\neq 1$ ensures the signed ratios $t/(1-t)$ are defined.",
     "significance": "key",
     "prerequisites": [
       "Affine combinations",

--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -2,7 +2,7 @@
   "id": "cevas-theorem",
   "title": "Ceva's Theorem",
   "slug": "cevas-theorem",
-  "description": "Ceva's Theorem (Wiedijk's #61): Given a triangle ABC with cevians AD, BE, CF, these lines are concurrent if and only if (AF/FB) * (BD/DC) * (CE/EA) = 1",
+  "description": "Ceva's Theorem (Wiedijk #61): the algebraic equivalence that the Ceva product (AF/FB)(BD/DC)(CE/EA) = 1 iff the parameter condition def = (1-d)(1-e)(1-f) holds, proved from scratch with field_simp and linarith. The geometric interpretation (product = 1 ↔ cevians concurrent) is described in commentary but the proof is purely algebraic.",
   "meta": {
     "author": "Giovanni Ceva (1678, formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ceva%27s_theorem",
@@ -179,19 +179,9 @@
       "description": "Both are fundamental triangle theorems: the law of cosines generalizes Pythagoras metrically, while Ceva's theorem characterizes concurrency of cevians — the law of cosines can be used to derive coordinate proofs of Ceva's theorem"
     },
     {
-      "targetId": "triangle-angle-sum",
-      "relationship": "foundational",
-      "description": "The angle sum property (180 degrees) is the most basic triangle theorem, while Ceva's theorem is a deeper structural result — both concern the fundamental geometry of triangles"
-    },
-    {
       "targetId": "feuerbachs-theorem",
       "relationship": "related",
       "description": "Both are classical triangle geometry results: Ceva's theorem concerns cevian concurrency, while Feuerbach's theorem concerns the tangency of the nine-point circle and incircle — both reveal deep structure in triangle configurations"
-    },
-    {
-      "targetId": "isosceles-triangle",
-      "relationship": "foundational",
-      "description": "The isosceles triangle theorem is the simplest symmetry result in triangle geometry, while Ceva's theorem handles the general asymmetric case — both concern the interplay of vertices and sides"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for three proof entries, addressing peer review findings.

## dissection-of-cubes-oq-01 (Minimum Collision Number in Cube Dissections)
- **Fix axiom integrity**: status `verified` → `axiomatized`, badge `mathlib` → `axiom`, axiomCount `0` → `2`
- Add 2 new annotations, imports/header section, replace tenuous cross-ref
- Deepen keyInsights (6 insights)

## hilbert-17 (Hilbert's 17th Problem: Sum of Squares)
- Expand first section to cover lines 1-91, add setup annotation
- Expand prerequisites from "Abstract algebra" to 4 specific topics

## cevas-theorem (Ceva's Theorem)
- Fix annotation: parameters are R\{0,1}, not restricted to (0,1) (review ai-2)
- Add algebraic form clarification to description (review ai-1)
- Remove generic cross-references: triangle-angle-sum, isosceles-triangle (review ai-3)