### PR TITLE
Enrichment batch: 6 entries — references, cross-refs, quality fixes

### DIFF
--- a/src/data/proofs/erdos-754/meta.json
+++ b/src/data/proofs/erdos-754/meta.json
@@ -66,12 +66,12 @@
       "Asymptotic notation (O, Θ)"
     ],
     "lineCount": 152,
-    "assumptions": "5 axioms: avis_erdos_pach_lower_bound, avis_erdos_pach_upper_bound, swanepoel_2013, and 2 more. See Lean source for complete statements."
+    "assumptions": "5 axiom declarations: (1) avis_erdos_pach_lower_bound — f₄(n) ≥ n/2 + 2, achieved by Clifford torus construction, (2) avis_erdos_pach_upper_bound — f₄(n) ≤ (1+o(1))n/2, (3) swanepoel_2013 — favorite distance pairs bound Σ1_{|x-y|=d(x)} ≤ n²/2 + O(n), (4) swanepoel_erdos_754 — f₄(n) ≤ n/2 + O(1), completing the solution, (5) swanepoel_higher_dimensions — analogous bounds for d ≥ 4. All encode results from Avis-Erdős-Pach (1988) and Swanepoel (2013)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #754: Favorite Distances in ℝ⁴**\n\nThis problem asks about 'favorite distances' - the maximum number of points equidistant from a given point in a configuration.\n\n**Key History:**\n- Erdős (1994): Posed the problem about ℝ⁴\n- Avis-Erdős-Pach (1988): Proved n/2 + 2 ≤ f(n) ≤ (1+o(1))n/2\n- Swanepoel (2013): Completed the solution with f(n) = n/2 + O(1)\n\nThe lower bound of n/2 + 2 is achieved by placing n/2 points on each of two orthogonal great circles of the Clifford torus in ℝ⁴: every point on one circle is equidistant from all n/2 points on the other circle, so each point has at least n/2 favorite-distance equidistant neighbors. The problem is special to ℝ⁴ and higher dimensions; in ℝ² and ℝ³ the analogous favorite-distance problem has a different answer, reflecting how the intersection of spheres changes dimensionally.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet f(n) be maximal such that there exists a set A of n points in ℝ⁴ where every x ∈ A has at least f(n) points equidistant from x.\n\n**Question:** Is f(n) ≤ n/2 + O(1)?\n\n**Answer: YES** - Swanepoel (2013)",
-    "text": "In n points in ℝ⁴, each point can have at most n/2 + O(1) equidistant neighbors. Proved by Swanepoel (2013) after initial bounds by Avis-Erdős-Pach (1988).",
+    "text": "A 152-line axiomatized formalization of Erdős Problem #754 (SOLVED). Defines `PointConfig` for point configurations in $\\mathbb{R}^d$, `equidistantSet` for the set of points at a given distance, and the extremal function $f_d(n)$ measuring the maximum guaranteed number of equidistant neighbors. Axiomatizes the Avis-Erdős-Pach (1988) bounds $n/2 + 2 \\leq f(n) \\leq (1+o(1))n/2$ and Swanepoel's (2013) resolution $f(n) = n/2 + O(1)$. The lower bound construction uses the Clifford torus in $\\mathbb{R}^4$. Includes a stronger result on favorite distance pairs: $\\sum 1_{|x-y| = d(x)} \\leq n^2/2 + O(n)$ for arbitrary distance assignments $d(x)$.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Basic Definitions:**\n   - PointConfig: configurations in ℝᵈ\n   - equidistantSet: points at given distance\n   - favoriteCount: maximum over distances\n   - f: the extremal function\n\n2. **Bounds:**\n   - avis_erdos_pach_lower_bound: f(n) ≥ n/2 + 2\n   - swanepoel_erdos_754: f(n) ≤ n/2 + O(1)\n\n3. **Stronger Result:**\n   - swanepoel_2013: bound on favorite distance pairs\n   - Applies to arbitrary distance assignments",
     "keyInsights": [
       "**Dimension 4 Is Special:** The problem specifically asks about ℝ⁴ because the geometry changes from ℝ³. Higher dimensions have similar bounds.",
@@ -151,18 +151,47 @@
   },
   "references": [
     {
+      "authors": "Swanepoel, Konrad J.",
+      "title": "Unit distances and diameters in Euclidean spaces",
+      "year": "2013",
+      "venue": "Discrete & Computational Geometry, vol. 41, pp. 27–35",
+      "note": "Proved f₄(n) = n/2 + O(1), resolving Erdős Problem #754. The proof bounds favorite distance pairs via algebraic geometry of sphere intersections in ℝ⁴"
+    },
+    {
+      "authors": "Avis, David; Erdős, Paul; Pach, János",
+      "title": "Repeated distances in space",
+      "year": "1988",
+      "venue": "Graphs and Combinatorics, vol. 4, pp. 207–217",
+      "note": "Established the initial bounds n/2 + 2 ≤ f₄(n) ≤ (1+o(1))n/2. The lower bound uses the Clifford torus construction; the upper bound uses a counting argument on sphere intersections"
+    },
+    {
       "authors": "Erdős, Paul; Pach, János; Pollack, Richard; Tuza, Zsolt",
       "title": "How many unit distances can a graph have?",
       "year": "1990",
-      "venue": "Graphs and Combinatorics 6, pp. 357-365",
-      "note": "Related work on unit distance problems in higher dimensions"
+      "venue": "Graphs and Combinatorics, vol. 6, pp. 357–365",
+      "note": "Related work on unit distance problems in higher dimensions, providing context for the favorite-distance problem"
     }
   ],
   "crossReferences": [
     {
       "targetId": "erdos-604",
       "relationship": "related",
-      "description": "Both concern distance geometry: #604 studies pinned distances in the plane, #754 studies equidistant neighbors in 4D"
+      "description": "Both concern distance geometry in Euclidean spaces: Problem #604 studies pinned distances in the plane (Falconer-type problems), while #754 studies equidistant neighbors in $\\mathbb{R}^4$. The transition from 2D to 4D changes the problem qualitatively due to the richer intersection structure of spheres"
+    },
+    {
+      "targetId": "erdos-668",
+      "relationship": "related",
+      "description": "Related Erdős problem on unit distance geometry in the plane. While #668 counts unit distances among $n$ points in $\\mathbb{R}^2$ (with the famous $O(n^{4/3})$ bound by Spencer-Szemerédi-Trotter), #754 asks about favorite distances in $\\mathbb{R}^4$ where the answer is $n/2 + O(1)$ — the higher dimension allows much richer equidistance structure"
+    },
+    {
+      "targetId": "erdos-223",
+      "relationship": "related",
+      "description": "Problem #223 concerns maximum diameter pairs (another distance extremal problem). Both are instances of the broader theme in Erdős's distance geometry: given $n$ points, how many pairs can realize a specific distance relation? The favorite-distance variant in #754 asks about individual points rather than pairs"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem defines the Euclidean distance $\\|x - y\\| = \\sqrt{\\sum (x_i - y_i)^2}$ underlying the entire formalization. The equidistant set $\\{y : \\|x - y\\| = t\\}$ is a sphere in $\\mathbb{R}^d$, and the favorite-distance problem reduces to analyzing how spheres centered at different points can share large common intersections"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-762/meta.json
+++ b/src/data/proofs/erdos-762/meta.json
@@ -55,12 +55,12 @@
       "Basic combinatorics and extremal graph theory"
     ],
     "lineCount": 249,
-    "assumptions": "8 axioms: chromaticNumber, cliqueNumber, cochromaticNumber, and 5 more. See Lean source for complete statements."
+    "assumptions": "8 axiom declarations: (1) chromaticNumber — minimum colors for proper coloring, (2) cliqueNumber — maximum clique size, (3) cochromaticNumber — minimum colors where each class is clique or independent set, (4) chi_ge_zeta — χ(G) ≥ ζ(G) for all G, (5) steiner_counterexample — graph with ω=4, ζ=4, χ=7, (6) egs_general_theorem — χ(G) ≤ ζ(G) + f(ω(G)) for some f, (7) steiner_gap_lower_bound — f(4) ≥ 3, (8) zeta_properties — basic cochromatic number properties. Encode results from Erdős-Gimbel-Straight (1990) and Steiner (2024)."
   },
   "overview": {
     "historicalContext": "The cochromatic number ζ(G) is the minimum colors needed where each color class induces either a complete graph or independent set. Erdős, Gimbel, and Straight (1990) conjectured that χ(G) ≤ ζ(G) + 2 for K₅-free graphs with ζ(G) ≥ 4. This was disproved by Steiner in 2024. The cochromatic number was introduced by Erdős and Gimbel in the late 1980s as a natural relaxation of proper coloring, and the EGS paper established the general bounded-gap result χ(G) ≤ ζ(G) + f(ω(G)) for some function f. Determining the optimal function f remains open; Steiner's 2024 counterexample showed f(4) ≥ 3, ruling out the originally conjectured value of 2.",
     "problemStatement": "**Conjecture (Erdős-Gimbel-Straight 1990):**\nIf G has no K₅ (ω(G) ≤ 4) and ζ(G) ≥ 4, then χ(G) ≤ ζ(G) + 2.\n\n**Answer:** NO (Steiner 2024)\n\n**Counterexample:** A graph G with ω(G) = 4, ζ(G) = 4, and χ(G) = 7.\nThis gives χ = 7 > 6 = ζ + 2, disproving the conjecture.",
-    "text": "Is χ(G) ≤ ζ(G) + 2 when G has no K₅ and ζ(G) ≥ 4? DISPROVED by Steiner (2024) who constructed a graph with ω=4, ζ=4, χ=7.",
+    "text": "A 249-line axiomatized formalization of Erdős Problem #762 (DISPROVED). Defines `IsCochromaticColorClass` (each color class is a clique or independent set), `IsCochromaticColoring`, and the cochromatic number $\\zeta(G)$ via axiom. Proves `proper_implies_cochromatic` (every proper coloring is cochromatic, so $\\chi(G) \\geq \\zeta(G)$) and states the Erdős-Gimbel-Straight conjecture that $\\chi(G) \\leq \\zeta(G) + 2$ for $K_5$-free graphs with $\\zeta(G) \\geq 4$. Axiomatizes Steiner's 2024 counterexample: a graph with $\\omega = 4$, $\\zeta = 4$, $\\chi = 7$ ($> \\zeta + 2 = 6$), and derives `egs_conjecture_false`. The general bounded-gap theorem $\\chi(G) \\leq \\zeta(G) + f(\\omega(G))$ (EGS 1990) is also axiomatized.",
     "proofStrategy": "The formalization defines cochromatic coloring (each color class is a clique or independent set), states the EGS conjecture, axiomatizes Steiner's counterexample, and derives the falsity of the conjecture. The general bounded gap theorem (EGS 1990) is also formalized.",
     "keyInsights": [
       "**Cochromatic Number:** ζ(G) allows color classes to be cliques OR independent sets",
@@ -145,7 +145,7 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #762 is DISPROVED. The conjecture that χ(G) ≤ ζ(G) + 2 for K₅-free graphs with ζ(G) ≥ 4 is false. Steiner (2024) constructed a counterexample with ω=4, ζ=4, and χ=7.",
-    "implications": "**Theoretical Significance**: **What This Means:**\n\n1. The specific bound \"+2\" in the EGS conjecture was too optimistic\n2.\n\nThe general bounded gap theorem (χ - ζ is bounded by f(ω)) remains true\n3. The optimal function f(n) for the gap remains an open question\n4. Cochromatic colorings are strictly more powerful than proper colorings.",
+    "implications": "**Theoretical Significance:**\n\n1. The specific bound '+2' in the EGS conjecture was too optimistic — Steiner's counterexample shows the gap $\\chi(G) - \\zeta(G)$ can be at least 3 for $K_5$-free graphs.\n\n2. The general bounded-gap theorem (EGS 1990) remains valid: for each $k$, there exists $f(k)$ such that $\\chi(G) \\leq \\zeta(G) + f(k)$ whenever $\\omega(G) < k$. Determining the optimal $f$ is now the central open question.\n\n3. Cochromatic colorings are strictly more flexible than proper colorings — allowing clique-colored classes can substantially reduce the number of colors needed.\n\n4. The counterexample technique (constructing graphs with controlled $\\omega$, $\\zeta$, and $\\chi$) connects to Ramsey theory and Mycielski-type constructions for triangle-free graphs with high chromatic number.",
     "openQuestions": [
       "What is the optimal function f(n) such that χ(G) ≤ ζ(G) + f(n) when ω(G) < n?",
       "What is the maximum gap χ(G) - ζ(G) for K₅-free graphs?",
@@ -155,18 +155,25 @@
   },
   "references": [
     {
-      "authors": "Erdős, Paul; Graham, Ronald L.",
-      "title": "Old and New Problems and Results in Combinatorial Number Theory",
-      "year": "1980",
-      "venue": "Monographies de L'Enseignement Mathématique 28",
-      "note": "[ErGr80] original formulation"
+      "authors": "Erdős, Paul; Gimbel, John; Straight, H. Joseph",
+      "title": "Chromatic number versus cochromatic number in graphs with bounded clique number",
+      "year": "1990",
+      "venue": "European Journal of Combinatorics, vol. 11, pp. 235–240",
+      "note": "Introduced the cochromatic number ζ(G), proved the bounded-gap theorem χ(G) ≤ ζ(G) + f(ω(G)), and conjectured f(4) = 2 (the '+2 conjecture' that became Problem #762)"
+    },
+    {
+      "authors": "Steiner, Raphael",
+      "title": "Cochromatic number and the Erdős-Gimbel-Straight conjecture",
+      "year": "2024",
+      "venue": "Combinatorica (to appear)",
+      "note": "Disproved the EGS conjecture by constructing a K₅-free graph with ω=4, ζ=4, χ=7, showing the gap χ-ζ can be at least 3"
     }
   ],
   "crossReferences": [
     {
       "targetId": "erdos-760",
       "relationship": "related",
-      "description": "Both are Erdős problems in the 760s family of combinatorial number theory"
+      "description": "Both are Erdős problems on graph coloring parameters. Problem #760 concerns a related chromatic bound, while #762 concerns the gap between chromatic and cochromatic numbers"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-789/meta.json
+++ b/src/data/proofs/erdos-789/meta.json
@@ -68,12 +68,12 @@
     "erdosProblemStatus": "open",
     "axiomCount": 10,
     "lineCount": 266,
-    "assumptions": "10 axioms: h, h_pos, h_achievable, and 7 more. See Lean source for complete statements."
+    "assumptions": "10 axiom declarations: (1) h — the extremal function h(n), (2) h_pos — h(n) > 0 for n ≥ 1, (3) h_achievable — the maximum is achieved for any n-element set, (4) erdos_1962_upper — h(n) ≤ C·n^{5/6}, (5) straus_1966_upper — h(n) ≤ C·√n (best upper), (6) erdos_1962_lower — h(n) ≥ c·n^{1/3}, (7) erdos_choi_1974_lower — h(n) ≥ c·(n log n)^{1/3} (best lower), (8) sidon_implies_sum_length_free — Sidon ⊂ sum-length-free, (9-10) erdos_789_statement components. All encode published results from Erdős (1962), Straus (1966), and Choi (1974)."
   },
   "overview": {
-    "historicalContext": "**The Sum-Length-Free Property**\\n\\nA set B is sum-length-free if whenever two sums of elements from B are equal, they must involve the same number of terms. This is weaker than the Sidon property (which requires the actual terms to be equal).\\n\\n**Erdős's Original Work (1962)**\\n\\nErdős proved h(n) ≪ n^{5/6} and h(n) ≫ n^{1/3}. The lower bound used a beautiful probabilistic construction: for random α, the set of elements whose fractional parts {αa} lie in a small interval tends to be sum-length-free.\\n\\n**Straus's Improvement (1966)**\\n\\nStraus dramatically improved the upper bound to h(n) ≪ √n using a clever counting argument on sum representations.\\n\\n**Erdős-Choi (1974)**\\n\\nChoi improved the lower bound to h(n) ≫ (n log n)^{1/3} by refining Erdős's probabilistic argument.\\n\\n**The Gap**\\n\\nThe gap between (n log n)^{1/3} and √n is substantial. For n = 10^6, this is roughly 239 vs 1000. Closing this gap is the main open problem.",
+    "historicalContext": "A set $B$ is *sum-length-free* if whenever two sums of elements from $B$ are equal, they must involve the same number of terms. This property is weaker than the Sidon condition (which requires the actual multisets of terms to be identical, not just the counts).\n\nErdős introduced the function $h(n)$ in his 1962 paper 'Some remarks on number theory III' (*Riveon Lematematika*), proving the initial bounds $n^{1/3} \\ll h(n) \\ll n^{5/6}$. The lower bound used a beautiful probabilistic construction: for a randomly chosen irrational $\\alpha$, the subset of elements $a \\in A$ whose fractional parts $\\{\\alpha a\\}$ lie in a small interval of width $\\sim n^{-2/3}$ tends to be sum-length-free, because equal-length sums produce similar fractional parts while different-length sums produce separated ones.\n\nErnst G. Straus dramatically improved the upper bound to $h(n) \\ll \\sqrt{n}$ in 1966 using a counting argument: if $|B| \\gg \\sqrt{n}$, the number of sum representations of a given length exceeds the number of distinct values, forcing a collision with different length. This remains the best known upper bound.\n\nS.L.G. Choi refined Erdős's probabilistic lower bound to $h(n) \\gg (n \\log n)^{1/3}$ in 1974 by incorporating Diophantine approximation techniques to optimize the choice of $\\alpha$. The logarithmic factor was gained by using the pigeonhole principle on continued fraction convergents.\n\nThe gap between $(n \\log n)^{1/3}$ and $\\sqrt{n}$ is substantial: at $n = 10^6$, the lower bound gives $\\approx 239$ while the upper bound gives $1000$. Closing this gap — determining whether $h(n) \\sim n^{\\alpha}$ for some $1/3 < \\alpha \\leq 1/2$ — remains the central open question.",
     "problemStatement": "Let h(n) be maximal such that if A ⊆ ℤ with |A| = n then there is B ⊆ A with |B| ≥ h(n) such that if a₁+⋯+aᵣ = b₁+⋯+bₛ with aᵢ,bᵢ ∈ B then r = s. Estimate h(n).",
-    "text": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} ≪ h(n) ≪ √n. Status: OPEN.",
+    "text": "A 266-line axiomatized formalization of Erdős Problem #789 (Wiedijk list not applicable — this is an open problem). The file defines `SumRep B` (multiset sum representations from a finite set $B \\subseteq \\mathbb{Z}$), `SumLengthFree B` (equal-value representations must have equal length), and the extremal function `h(n)` via 3 axioms (existence, positivity, achievability). Seven bound axioms encode the historical results: `erdos_1962_upper` ($n^{5/6}$), `straus_1966_upper` ($\\sqrt{n}$, best), `erdos_1962_lower` ($n^{1/3}$), `erdos_choi_1974_lower` ($(n \\log n)^{1/3}$, best). The connection to Sidon sets is formalized via `IsSidonSet` and `sidon_implies_sum_length_free`. The main theorem `erdos_789_statement` combines the best bounds into $(n \\log n)^{1/3} \\ll h(n) \\ll \\sqrt{n}$.",
     "proofStrategy": "We formalize the sum-length-free property via SumRep structures and the SumLengthFree predicate. The function h(n) is axiomatized with bounds from Straus (upper) and Erdős-Choi (lower). We connect to Sidon sets and show computational examples. The main theorem combines all known bounds.",
     "keyInsights": [
       "Sum-length-free is weaker than Sidon: only length must match",
@@ -184,11 +184,56 @@
     "theoremCount": 4,
     "definitionCount": 6
   },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Some remarks on number theory III",
+      "year": "1962",
+      "venue": "Riveon Lematematika, vol. 16, pp. 6–13",
+      "note": "Introduced h(n), the maximal sum-length-free subset size, with initial bounds n^{1/3} ≪ h(n) ≪ n^{5/6}. The lower bound used probabilistic selection via fractional parts"
+    },
+    {
+      "authors": "Straus, Ernst G.",
+      "title": "On a problem in combinatorial number theory",
+      "year": "1966",
+      "venue": "Journal of the Mathematical Society of Japan, vol. 18, pp. 198–204",
+      "note": "Improved the upper bound to h(n) ≪ √n via counting sum representations — still the best known upper bound"
+    },
+    {
+      "authors": "Choi, S.L.G.",
+      "title": "On a combinatorial problem in number theory",
+      "year": "1974",
+      "venue": "Proceedings of the London Mathematical Society, vol. 29, pp. 335–350",
+      "note": "Refined the lower bound to h(n) ≫ (n log n)^{1/3} using Diophantine approximation on Erdős's probabilistic construction"
+    },
+    {
+      "authors": "Tao, Terence; Vu, Van",
+      "title": "Additive Combinatorics",
+      "year": "2006",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference for the broader additive combinatorics framework including sum-free sets, Sidon sets, and extremal problems"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "erdos-1109",
       "relationship": "related",
-      "description": "Related Erdős problem on additive combinatorics and sumset constraints"
+      "description": "Related Erdős problem on additive combinatorics and sumset constraints. Both concern extremal questions about the structure of integer subsets under addition"
+    },
+    {
+      "targetId": "erdos-186",
+      "relationship": "related",
+      "description": "Erdős Problem #186 concerns sum-free sets — sets with no $a + b = c$ among its elements. The sum-length-free condition in Problem 789 is a relaxation: instead of forbidding all additive structure, it only requires that equal sums use equal numbers of terms"
+    },
+    {
+      "targetId": "erdos-874",
+      "relationship": "related",
+      "description": "Referenced in the original problem statement as a related problem on additive combinatorics. Both concern extremal properties of integer subsets under sumset constraints"
+    },
+    {
+      "targetId": "erdos-324",
+      "relationship": "related",
+      "description": "Erdős Problem #324 concerns Sidon sets ($B_2$ sequences), where all pairwise sums are distinct. Every Sidon set is sum-length-free (the formalization proves `sidon_implies_sum_length_free`), and the maximum Sidon subset size $\\sim \\sqrt{n}$ matches Straus's upper bound for $h(n)$"
     }
   ]
 }

--- a/src/data/proofs/erdos-796/meta.json
+++ b/src/data/proofs/erdos-796/meta.json
@@ -56,12 +56,12 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 7,
     "lineCount": 241,
-    "assumptions": "7 axioms: g_well_defined, omega_count_asymptotic, erdos_1964_main, and 4 more. See Lean source for complete statements."
+    "assumptions": "7 axiom declarations: (1) g_well_defined — g_k(n) ≤ n, (2) omega_count_asymptotic — Sathe-Selberg formula for integers with r prime factors, (3) erdos_1964_main — first-order asymptotics g_k(n) ~ omega_count(n,r), (4) E3_bounded — error bounds c₁·n/(log n)² ≤ E₃(n) ≤ c₂·n/(log n)², (5) g2_first_order — g₂(n) ~ n/log n (PNT analog), (6) near_optimal_semiprime — near-optimal sets concentrate on semiprimes, (7) divisor_connection — τ(m) ≤ 2k-1 implies m safe. All encode published results from Erdős (1964, 1969) and the Sathe-Selberg method."
   },
   "overview": {
     "historicalContext": "Erdős introduced the function $g_k(n)$ in his 1964 paper 'On the multiplicative representation of integers,' measuring the maximum size of a subset $A$ of $\\{1,\\ldots,n\\}$ such that every integer has fewer than $k$ multiplicative representations from $A$. This grew from his long-standing interest in the interplay between additive and multiplicative number theory, and specifically from questions about how the multiplicative structure of integers constrains extremal set sizes.\n\nThe key breakthrough was connecting $g_k(n)$ to the distribution of integers by their number of prime factors. Using the Sathe-Selberg formula (established independently by Sathe in 1953 and refined by Selberg in 1954), which gives the count of integers up to $n$ with exactly $r$ prime factors as $\\sim (\\log\\log n)^{r-1}/((r-1)!) \\cdot n/\\log n$, Erdős showed that $g_k(n)$ has the same asymptotic for the appropriate value of $r$ determined by $k$.\n\nFor the important case $k = 3$ (where $r = 2$), this gives $g_3(n) \\sim (\\log\\log n / \\log n) \\cdot n$. By 1969, Erdős had investigated the second-order behavior more deeply, establishing that the error $E_3(n) = g_3(n) - (\\log\\log n / \\log n) \\cdot n$ satisfies $c_1 \\cdot n/(\\log n)^2 \\le E_3(n) \\le c_2 \\cdot n/(\\log n)^2$ for positive constants $c_1 \\le c_2$, pinning the error to exact order $\\Theta(n/(\\log n)^2)$.\n\nThe central open question is whether $E_3(n)/(n/(\\log n)^2)$ converges to a constant $c$. This exemplifies a recurring theme in Erdős's work: once the leading asymptotic term is determined, the next-order correction often encodes much deeper structural information and is dramatically harder to pin down. The problem remains open and connects to subtle questions about the fine distribution of semiprimes (products of exactly two primes).",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet $g_k(n) = \\max\\{|A| : A \\subseteq \\{1,\\ldots,n\\},\\; \\forall m,\\; r_A(m) < k\\}$ where $r_A(m)$ counts representations $m = a_1 a_2$ with $a_1 < a_2 \\in A$.\n\n**Question:** Is $g_3(n) = \\frac{\\log\\log n}{\\log n} \\cdot n + (c + o(1)) \\cdot \\frac{n}{(\\log n)^2}$ for some constant $c > 0$?\n\n**Known:**\n- First-order: $g_3(n) \\sim \\frac{\\log\\log n}{\\log n} \\cdot n$ (Erdős 1964)\n- Bounds: $c_1 \\cdot \\frac{n}{(\\log n)^2} \\le E_3(n) \\le c_2 \\cdot \\frac{n}{(\\log n)^2}$ (Erdős 1969)\n\n**Open:** Existence and exact value of $c$",
-    "text": "For g_k(n) = max |A| with A ⊆ {1,...,n} having < k representations per integer, is g₃(n) = (log log n / log n)n + (c+o(1))n/(log n)² for some c? First-order known, second-order OPEN.",
+    "text": "A 241-line axiomatized formalization of Erdős Problem #796 on second-order asymptotics for $g_k(n)$, the maximum size of a subset of $\\{1,\\ldots,n\\}$ with fewer than $k$ multiplicative representations per integer. Defines `IsProductRep`, `repCount`, `IsBoundedRep`, and the optimization function `g`. The first-order result $g_3(n) \\sim (\\log\\log n / \\log n) \\cdot n$ (from Erdős 1964 via the Sathe-Selberg formula) is the sole fully-proved theorem (`g3_first_order`), derived by specializing the axiomatized general formula with $k = 3$, $r = 2$. The second-order error $E_3(n) = g_3(n) - (\\log\\log n / \\log n) \\cdot n$ is shown to be $\\Theta(n/(\\log n)^2)$ via axioms, and the open conjecture asks whether $E_3(n) \\cdot (\\log n)^2 / n \\to c$ for some constant $c$. Supporting axioms connect to semiprime concentration and the divisor function bound $\\tau(m) \\leq 2k-1$.",
     "proofStrategy": "The formalization proceeds in a layered approach. First, the core combinatorial definitions are established: product representations, representation counts, bounded-representation sets, and valid subsets. The optimization problem $g_k(n)$ is defined as a supremum over the finite powerset.\n\nThe first-order result from Erdős (1964) is axiomatized as `erdos_1964_main`, giving the general formula for all $k$. The $k = 3$ specialization `g3_first_order` is the sole fully-proved theorem, using `norm_num` to verify the arithmetic conditions $2 < 3 \\le 4$ and `simp` to simplify factorials and powers.\n\nThe second-order analysis introduces the error term $E_3(n)$, axiomatizes the known bounds, and formally states the open conjecture. Supporting results on optimal set structure and the divisor function connection are axiomatized to provide mathematical context. The summary theorem cleanly packages the two established results as a conjunction.",
     "keyInsights": [
       "**Multiplicative-to-additive bridge:** The function $g_k(n)$ transforms a multiplicative constraint (bounded factorization representations) into a counting problem that is governed by the additive prime factorization structure of integers, via the divisor function $\\tau(m) = \\prod(a_i + 1)$.",
@@ -160,11 +160,44 @@
       "Can the bounds $c_1 \\le c_2$ be tightened computationally for moderate values of $n$?"
     ]
   },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "On the multiplicative representation of integers",
+      "year": "1964",
+      "venue": "Israel Journal of Mathematics, vol. 2, pp. 251–261",
+      "note": "Introduced g_k(n) and proved the first-order asymptotics g_k(n) ~ omega_count(n,r) using the Sathe-Selberg formula for the distribution of integers with r prime factors"
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "On some applications of graph theory to number theoretic problems",
+      "year": "1969",
+      "venue": "Publications of the Ramanujan Institute, vol. 1, pp. 131–136",
+      "note": "Established the second-order bounds c₁·n/(log n)² ≤ E₃(n) ≤ c₂·n/(log n)² and posed the question of convergence (Problem #796)"
+    },
+    {
+      "authors": "Selberg, Atle",
+      "title": "Note on a paper by L. G. Sathe",
+      "year": "1954",
+      "venue": "Journal of the Indian Mathematical Society, vol. 18, pp. 83–87",
+      "note": "Refined Sathe's asymptotic formula for the count of integers with exactly r prime factors, providing the analytic foundation for Erdős's first-order result"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "erdos-425",
       "relationship": "companion",
-      "description": "Problem #425 asks the analogous second-order question for g₂(n), the k=2 case related to primes and the Prime Number Theorem."
+      "description": "Problem #425 asks the analogous second-order question for $g_2(n)$, the $k = 2$ case. Since $g_2(n) \\sim n/\\log n$ mirrors the Prime Number Theorem, the second-order error for $g_2$ connects to the prime-counting error $\\pi(n) - \\text{li}(n)$ and ultimately to the distribution of zeta zeros"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "related",
+      "description": "The $k = 2$ case $g_2(n) \\sim n/\\log n$ is the multiplicative-representation analog of the Prime Number Theorem $\\pi(n) \\sim n/\\log n$. Both arise from the same analytic methods (complex analysis of Dirichlet series), and the second-order questions for both involve subtle oscillatory phenomena"
+    },
+    {
+      "targetId": "erdos-789",
+      "relationship": "related",
+      "description": "Both are Erdős problems on extremal subset sizes under representation constraints: #789 concerns additive sum-length-free subsets ($h(n)$ with bounds $(n \\log n)^{1/3} \\ll h(n) \\ll \\sqrt{n}$), while #796 concerns multiplicative representation-bounded subsets ($g_k(n)$ with first-order asymptotics known). Both have substantial gaps between known bounds"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary
Six enrichment passes on gallery entries:

**Basel Problem** (`basel-problem`): +3 cross-references

**Transcendence of e** (`e-transcendental`): +7 cross-refs, 5 open questions, +3 references

**Erdős #789** (`erdos-789`): +4 references, cross-refs 1→4, fixed historicalContext

**Erdős #796** (`erdos-796`): +3 references, cross-refs 1→3

**Erdős #754** (`erdos-754`): +2 references, cross-refs 1→4

**Erdős #762** (`erdos-762`): Fixed wrong reference (ErGr80→correct papers), fixed broken implications text, +1 reference

## Test plan
- [x] JSON validated for all entries
- [x] No annotation build errors