### PR TITLE
Peer review: cantor-diagonalization-oq-03 (B+)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03/review.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/review.json
@@ -1,0 +1,122 @@
+{
+  "version": 1,
+  "proofId": "cantor-diagonalization-oq-03",
+  "reviewDate": "2026-03-25T12:00:00Z",
+  "reviewer": "peer-reviewer",
+
+  "overallAssessment": {
+    "grade": "B+",
+    "oneLiner": "A clean, genuinely original formalization of the Lawvere fixed-point theorem with well-structured corollaries, let down only by minor overclaiming in the original-contributions list and an inaccurate theorem count.",
+    "tier": "A",
+    "tierJustification": "Fully formalized with 0 sorries, 0 axioms. The main theorem (lawvere_fixpoint) is proved from first principles with minimal Mathlib dependency (only Function.Surjective and Set.range). All corollaries are machine-checked.",
+    "stratification": {
+      "proved": [
+        "lawvere_fixpoint (general fixed-point theorem)",
+        "not_has_no_fixpoint (negation has no fixed point via cast/self-application)",
+        "cantor (no surjection A → (A → Prop))",
+        "cantor_bool (decidable variant with Bool)",
+        "russell (Russell's paradox = Cantor restated)",
+        "diagonal_not_in_range (constructive non-membership)",
+        "no_surjection_if_no_fixpoint (contrapositive)",
+        "cantor_no_surjection (existential form)",
+        "bnot_has_no_fixpoint (boolean negation case split)"
+      ],
+      "axiomatized": [],
+      "elementary": [
+        "bnot_has_no_fixpoint (cases b <;> decide — kernel computation)",
+        "russell (one-liner = cantor_no_surjection A)",
+        "cantor_no_surjection (one-liner applying contrapositive)"
+      ],
+      "assessment": "All components are fully proved and at a compatible epistemic level. The core theorem (lawvere_fixpoint) carries the mathematical weight; the corollaries are instantiations that demonstrate generality rather than adding independent substance."
+    }
+  },
+
+  "findings": [
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "lawvere_fixpoint, line 42-48",
+      "finding": "The Lawvere fixed-point theorem is formalized from first principles with a 2-line proof body that does genuine mathematical work. The only Mathlib dependency is the definition of Function.Surjective. This is not a wrapper — it is original formalization of a categorical result at the type-theoretic level.",
+      "recommendation": "Preserve as-is. This is the entry's strongest feature."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "not_has_no_fixpoint, line 72-80",
+      "finding": "The proof that negation has no fixed point uses cast/transport and self-application — the same trick underlying Russell's paradox. The 7-line proof has real mathematical content and is well-commented, making the self-referential core visible.",
+      "recommendation": "Preserve. The inline comments (lines 74-79) are excellent and genuinely aid understanding."
+    },
+    {
+      "severity": "positive",
+      "category": "strength",
+      "location": "Overall file structure",
+      "finding": "The pedagogical progression — Lawvere → contrapositive → Cantor → Bool → Russell → constructive diagonal — is well-designed. Each theorem builds on the previous, demonstrating how a single result generates multiple classical theorems. The file reads as a coherent mathematical essay, not a disconnected collection.",
+      "recommendation": "Preserve this structure. It is the entry's main pedagogical contribution."
+    },
+    {
+      "severity": "minor",
+      "category": "inconsistency",
+      "location": "meta.json leanFile.theoremCount",
+      "finding": "meta.json reports theoremCount: 7, but the Lean file contains 9 theorem declarations: lawvere_fixpoint, no_surjection_if_no_fixpoint, not_has_no_fixpoint, cantor, cantor_no_surjection, bnot_has_no_fixpoint, cantor_bool, russell, diagonal_not_in_range.",
+      "recommendation": "Update theoremCount to 9."
+    },
+    {
+      "severity": "minor",
+      "category": "overclaim",
+      "location": "meta.json originalContributions",
+      "finding": "Lists 6 items as 'original contributions,' but several are trivial instantiations: russell is literally `= cantor_no_surjection A` (a one-term proof), cantor is a 3-line application of lawvere_fixpoint with Not, and cantor_bool follows the same pattern. The genuinely original contributions are lawvere_fixpoint (the general theorem) and not_has_no_fixpoint (the self-application argument). The others are pedagogically motivated restatements.",
+      "recommendation": "Restructure originalContributions to distinguish the core original work (lawvere_fixpoint, not_has_no_fixpoint) from the derived corollaries. E.g., 'cantor: Cantor's theorem derived as a direct corollary of Lawvere (instantiation, not independent proof).'"
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json description and overview.keyInsights[0]",
+      "finding": "The description says the theorem 'unifies Cantor's diagonal argument, Russell's paradox, and the halting problem as instances of a single principle.' Key insight #1 states 'Turing uses B = Bool, f = !' suggesting cantor_bool IS the halting problem result. While Lawvere's paper does unify these conceptually, this file only formally derives Cantor and Russell. The cantor_bool theorem proves no surjection A → (A → Bool) exists — this is algebraically related to the halting argument but is not a formalization of Turing's undecidability result, which requires a model of computation.",
+      "recommendation": "Soften the halting-problem claim to 'the same algebraic pattern underlies the halting problem' rather than implying formal derivation. Key insight #1 could note that the Bool variant captures the algebraic skeleton but not the computability-theoretic content."
+    },
+    {
+      "severity": "minor",
+      "category": "precision",
+      "location": "meta.json conclusion.implications",
+      "finding": "The conclusion claims 'impossibility results in set theory, logic, and computation share a single categorical root' and that this formalization 'demonstrates' this. The formalization demonstrates the set-theory and logic instances (Cantor, Russell) but not the computation instance (halting problem). The categorical root claim is Lawvere's contribution, which this file formalizes in type theory — the distinction between categorical and type-theoretic settings could be noted.",
+      "recommendation": "Qualify: 'This formalization demonstrates the set-theoretic and logical instances; the computational instances (halting, Rice) remain to be formalized as Lawvere corollaries.'"
+    }
+  ],
+
+  "actionItems": [
+    {
+      "id": "ai-1",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Update meta.json theoremCount from 7 to 9",
+      "status": "open"
+    },
+    {
+      "id": "ai-2",
+      "priority": "medium",
+      "target": "enricher",
+      "description": "Restructure originalContributions to distinguish core original work (lawvere_fixpoint, not_has_no_fixpoint) from derived corollaries (cantor, cantor_bool, russell, etc.)",
+      "status": "open"
+    },
+    {
+      "id": "ai-3",
+      "priority": "low",
+      "target": "enricher",
+      "description": "Soften halting-problem language in description, key insight #1, and conclusion to clarify that the Bool variant captures the algebraic pattern but is not a formalization of Turing's undecidability result",
+      "status": "open"
+    }
+  ],
+
+  "qualityScores": {
+    "mathematicalSubstance": 8,
+    "originalityAccuracy": 7,
+    "completeness": 9,
+    "framingPrecision": 8,
+    "pedagogicalQuality": 9,
+    "internalConsistency": 8,
+    "epistemicCoherence": 9,
+    "overall": 8.3
+  },
+
+  "suggestedBestFraming": "A verified formalization of the Lawvere fixed-point theorem — if a surjection A → (A → B) exists, every endomorphism B → B has a fixed point — with Cantor's theorem, Russell's paradox, and a constructive diagonal result derived as corollaries, all in 149 lines with 0 axioms."
+}

--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -416,6 +416,14 @@
       "qualityScore": null,
       "actionItems": 0,
       "resolvedItems": 0
+    },
+    "cantor-diagonalization-oq-03": {
+      "reviewCount": 1,
+      "lastReviewed": "2026-03-25T07:32:47Z",
+      "overallGrade": "B+",
+      "qualityScore": null,
+      "actionItems": 0,
+      "resolvedItems": 0
     }
   }
 }


### PR DESCRIPTION
## Summary
- Peer review of `cantor-diagonalization-oq-03` (Lawvere Fixed-Point Theorem and Cantor's Theorem)
- **Grade: B+** (overall 8.3/10)
- 7 findings (3 positive, 4 minor), 3 action items

## Key Findings
- **Strength**: `lawvere_fixpoint` is a genuine formalization from first principles — not a Mathlib wrapper
- **Strength**: Excellent pedagogical progression from general theorem through specific corollaries
- **Minor**: theoremCount in meta.json says 7, actual count is 9
- **Minor**: Some corollaries (russell, cantor_no_surjection) listed as "original contributions" but are one-liner instantiations
- **Minor**: Halting problem language slightly overreaches — the Bool variant captures the algebraic pattern but is not a formal undecidability result

🤖 Generated with [Claude Code](https://claude.com/claude-code)