### PR TITLE
Enrich 8 entries: add mathContext to all annotations gallery-wide

### DIFF
--- a/src/data/proofs/fermats-last-theorem/annotations.json
+++ b/src/data/proofs/fermats-last-theorem/annotations.json
@@ -17,7 +17,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Imports `FLT.Basic` (the predicate $\\text{FermatLastTheoremFor}(n)$: $\\forall a,b,c \\in \\mathbb{Z} \\setminus \\{0\\},\\; a^n + b^n \\neq c^n$), `FLT.Four` (Fermat's descent proof of the $n=4$ case via $x^4+y^4 \\neq z^2$), and `FLT.Three` (Euler's proof of $n=3$ via the Eisenstein integers $\\mathbb{Z}[\\omega]$)."
   },
   {
     "id": "ann-flt-history",

--- a/src/data/proofs/four-color-theorem/annotations.json
+++ b/src/data/proofs/four-color-theorem/annotations.json
@@ -9,6 +9,7 @@
     "type": "concept",
     "title": "The Theorem That Took 124 Years",
     "content": "The Four Color Theorem has a remarkable history. Posed in 1852, it resisted proof for over a century, defeating many brilliant mathematicians. Its eventual 1976 proof required something unprecedented: a computer checking thousands of cases no human could verify.\n\nThe theorem states that any map can be colored with at most four colors such that no two adjacent regions share a color. While easy to state and seemingly simple, the proof revealed deep connections between graph theory, combinatorics, and computation.\n\nThis formalization presents the conceptual structure. The complete proof (Appel-Haken 1976, Gonthier 2005) requires computer verification of 1,936 configurations.",
+    "mathContext": "For every planar graph $G$, $\\chi(G) \\leq 4$, where $\\chi(G)$ is the chromatic number (minimum number of colors for a proper coloring). Equivalently: every map on the sphere or plane can be colored with 4 colors so no two adjacent regions share a color.",
     "significance": "key",
     "relatedConcepts": [
       "graph theory",
@@ -29,6 +30,7 @@
     "type": "definition",
     "title": "Graphs and Their Structure",
     "content": "We model maps as graphs where vertices represent regions and edges connect adjacent regions. This transforms the map coloring problem into a graph coloring problem.\n\nA graph $G = (V, E)$ consists of:\n- A set $V$ of vertices (the regions)\n- A set $E$ of edges (adjacency relations)\n- Edges are symmetric: if region A borders B, then B borders A\n\nThis abstraction lets us apply graph-theoretic tools to a geometric problem.",
+    "mathContext": "A `SimpleGraph V` in Lean is a symmetric, irreflexive relation on $V$: `G.Adj : V \\to V \\to \\text{Prop}` with $G.\\text{Adj}(u, v) \\Rightarrow G.\\text{Adj}(v, u)$ and $\\neg G.\\text{Adj}(v, v)$. Map coloring reduces to graph coloring via the dual graph construction.",
     "significance": "key",
     "relatedConcepts": [
       "vertex",
@@ -70,6 +72,7 @@
     "type": "definition",
     "title": "Planar Graphs",
     "content": "A graph is **planar** if it can be drawn in the plane with no edge crossings. Equivalently, it can be embedded on a sphere.\n\nNot all graphs are planar! The complete graph $K_5$ (5 vertices, all connected) and the complete bipartite graph $K_{3,3}$ are the 'forbidden minors'—every non-planar graph contains one of these as a substructure.\n\nPlanarity is essential to the theorem. Non-planar graphs can require arbitrarily many colors.",
+    "mathContext": "A graph $G$ is planar iff it has no $K_5$ or $K_{3,3}$ minor (Wagner's theorem) or subdivision (Kuratowski's theorem). Planarity implies $|E| \\leq 3|V| - 6$ for $|V| \\geq 3$, bounding the edge density. Axiomatized in this file since Mathlib lacks a planarity predicate.",
     "significance": "key",
     "relatedConcepts": [
       "planar embedding",
@@ -151,6 +154,7 @@
     "type": "concept",
     "title": "Kempe Chains: The Color-Swapping Trick",
     "content": "A **Kempe chain** for colors a and b starting at vertex v is the maximal connected subgraph of vertices colored a or b containing v.\n\nThe crucial property: swapping colors a ↔ b on a Kempe chain produces another valid coloring! Adjacent vertices still have different colors because:\n- Vertices outside the chain keep their colors\n- Inside the chain, neighbors alternate between a and b\n\nKempe invented this for his 1879 'proof' of Four Colors. His argument was flawed, but the technique is correct and essential. The flaw was in handling cases where multiple Kempe chains interact.",
+    "mathContext": "Given a proper coloring $c: V \\to \\{1,\\ldots,k\\}$ and colors $a, b$, the $(a,b)$-Kempe chain at $v$ is the connected component of $v$ in $G[c^{-1}(\\{a,b\\})]$. Swapping $a \\leftrightarrow b$ on this component yields a new proper coloring. Kempe (1879) used this to attempt a 4-color proof, but the case where two Kempe chains interfere was the gap Heawood found in 1890.",
     "significance": "key",
     "relatedConcepts": [
       "color swapping",
@@ -191,6 +195,7 @@
     "type": "concept",
     "title": "Reducibility: Configurations That Can't Block Coloring",
     "content": "A configuration C is **reducible** if it cannot appear in a minimal counterexample to Four Color. That is: if a planar graph G contains C, then G is 4-colorable (or G can be simplified to a smaller graph that's 4-colorable).\n\nProving reducibility requires showing that any 4-coloring of the graph minus the configuration can be extended to include it. This involves analyzing all possible colorings of the boundary and showing Kempe chains can always make room.\n\nFor many configurations, this case analysis is astronomically complex—too many cases for human verification. This is where computers become essential.",
+    "mathContext": "A configuration $C$ in a planar graph $G$ is **reducible** if every 4-coloring of $G \\setminus C$ extends to a 4-coloring of $G$, possibly after Kempe chain rearrangements on the boundary ring. Appel-Haken verified reducibility for 1,936 configurations; Robertson-Sanders-Seymour-Thomas (1997) reduced this to 633.",
     "significance": "key",
     "relatedConcepts": [
       "minimal counterexample",
@@ -211,6 +216,7 @@
     "type": "concept",
     "title": "Computer-Assisted Proof",
     "content": "The Appel-Haken proof (1976) required:\n- 1,200 hours of computer time\n- Verification of 1,936 configurations\n- 400+ pages of hand-written supporting proofs\n\nInitial reception was skeptical. How can we trust a proof no human can check? What if there's a bug in the program?\n\nGeorges Gonthier's 2005 Coq formalization addressed these concerns by reducing trust to a small, verified proof-checking kernel. The proof certificate is machine-checkable, and the checker itself is tiny enough to be human-verified.\n\nThis paradigm shift—from 'trust the program' to 'trust the proof checker'—has become foundational in formal methods.",
+    "mathContext": "The proof has two parts: (1) an **unavoidable set** of configurations (every planar triangulation contains at least one), and (2) a **reducibility** check for each configuration. Part (1) is proved by the discharging method; part (2) requires exhaustive case analysis. Gonthier's Coq formalization (2005) verified both parts in the SSReflect framework, reducing trust to Coq's type-checking kernel (~10,000 lines of OCaml).",
     "significance": "key",
     "relatedConcepts": [
       "Coq",
@@ -231,6 +237,7 @@
     "type": "insight",
     "title": "Gonthier's Coq Formalization",
     "content": "In 2005, Georges Gonthier completed a full formalization of the Four Color Theorem in Coq. This was a landmark achievement:\n\n- **Complete verification:** Every step machine-checked, including all 1,936 configurations\n- **Independent verification:** The Coq proof is a certificate anyone can verify using the proof checker\n- **Trust reduction:** We no longer trust Appel-Haken's program; we trust Coq's small kernel\n\nThe formalization took several person-years but provided certainty that the theorem is correct. It demonstrated that even massive computational proofs can be made rigorous through formal methods.",
+    "mathContext": "Gonthier formalized the Robertson-Sanders-Seymour-Thomas (1997) proof rather than the original Appel-Haken, using 633 configurations instead of 1,936. The formalization is approximately 60,000 lines of Coq, using the SSReflect proof language. The computational verification of each configuration's reducibility is done by Coq's kernel via `native_compute`, not by an external program.",
     "significance": "key",
     "relatedConcepts": [
       "Coq proof assistant",

--- a/src/data/proofs/godel-incompleteness/annotations.json
+++ b/src/data/proofs/godel-incompleteness/annotations.json
@@ -17,7 +17,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Gödel's First Incompleteness Theorem (1931): For any consistent, recursively axiomatizable formal system $F$ that can express basic arithmetic, there exists a sentence $G_F$ such that neither $F \\vdash G_F$ nor $F \\vdash \\neg G_F$. The Second Incompleteness Theorem: if $F$ is consistent, then $F \\not\\vdash \\text{Con}(F)$."
   },
   {
     "id": "ann-formula-type",
@@ -37,7 +38,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Formulas are built inductively: atomic propositions, logical connectives ($\\neg, \\land, \\lor, \\to$), and quantifiers ($\\forall, \\exists$) over a countable language. In this formalization, `Formula` is an inductive type with constructors for each syntactic form, and `Sentence` is the type of closed formulas (no free variables)."
   },
   {
     "id": "ann-provability",
@@ -98,7 +100,8 @@
     "relatedConcepts": [
       "prime factorization",
       "encoding schemes"
-    ]
+    ],
+    "mathContext": "Gödel numbering $\\ulcorner \\cdot \\urcorner : \\text{Formula} \\to \\mathbb{N}$ must be injective: distinct formulas get distinct codes. This ensures the arithmetic encoding faithfully represents the syntactic objects, so provability in the formal system corresponds exactly to a number-theoretic property of the codes."
   },
   {
     "id": "ann-prov-formula",
@@ -264,7 +267,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Hilbert's program (1920s) sought a finitary consistency proof for all of mathematics. Gödel's Second Incompleteness Theorem shows this is impossible: any system $F$ strong enough to formalize basic arithmetic cannot prove $\\text{Con}(F) \\equiv \\neg\\text{Prov}(\\ulcorner 0 = 1 \\urcorner)$ from within $F$ itself, assuming $F$ is consistent."
   },
   {
     "id": "ann-limits",
@@ -284,7 +288,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Gödel's theorems reveal that mathematical truth transcends any single formal system. For any consistent $F$, the Gödel sentence $G_F$ is true (in the standard model $\\mathbb{N}$) but unprovable in $F$. Adding $G_F$ as an axiom yields $F' = F + G_F$, which is consistent but has its own unprovable Gödel sentence $G_{F'}$ — an inexhaustible hierarchy of truths."
   },
   {
     "id": "ann-mechanism-debate",
@@ -304,6 +309,7 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "The Gödel sentence $G_F$ asserts its own unprovability: $G_F \\leftrightarrow \\neg\\text{Prov}_F(\\ulcorner G_F \\urcorner)$. If the mind is a formal system $F$, then $G_F$ is true but unknowable to $F$. Lucas (1961) and Penrose (1989) argued this shows minds transcend machines; Putnam and others countered that the argument assumes the mind's consistency, which cannot itself be verified."
   }
 ]

--- a/src/data/proofs/navier-stokes/annotations.json
+++ b/src/data/proofs/navier-stokes/annotations.json
@@ -37,7 +37,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "The Faber-Krahn inequality gives a lower bound on the first Dirichlet eigenvalue: $\\lambda_1(\\Omega) \\geq \\lambda_1(B^*)$ where $B^*$ is a ball of equal volume. Here $c_{FK} = (1 - e^{-2})\\pi^2/4 \\approx 2.11$ quantifies the minimum dissipation rate per unit enstrophy in a concentration ball."
   },
   {
     "id": "ann-key-numerical",
@@ -97,7 +98,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Bernoulli's inequality: $(1 + x)^n \\geq 1 + nx$ for $x \\geq -1$ and $n \\in \\mathbb{N}$. Applied here with $x = \\lambda_1 h > 0$, giving $E_0(1 + \\lambda_1 h)^n \\geq E_0(1 + n\\lambda_1 h) \\to \\infty$, which shows backward-time enstrophy growth is unbounded."
   },
   {
     "id": "ann-backward-growth",
@@ -223,7 +225,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "The Beale-Kato-Majda criterion (1984): a smooth solution blows up at time $T$ if and only if $\\int_0^T \\|\\omega(\\cdot, t)\\|_{L^\\infty}\\, dt = \\infty$. Equivalently, bounded $\\|\\omega\\|_{L^\\infty}$ on $[0, T)$ implies the solution extends smoothly past $T$."
   },
   {
     "id": "ann-typeII-scenario",

--- a/src/data/proofs/product-of-segments-of-chords/annotations.json
+++ b/src/data/proofs/product-of-segments-of-chords/annotations.json
@@ -148,7 +148,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Numerical verification via `norm_num`: for a circle of radius $r = 5$ with $P$ at distance $d = 3$ from center, $PA \\cdot PB = r^2 - d^2 = 25 - 9 = 16$ for every chord through $P$. If one chord has segments $2$ and $8$, another through the same point could have segments $4$ and $4$."
   },
   {
     "id": "ann-historical",
@@ -169,6 +170,7 @@
       "history of mathematics",
       "Euclid's Elements",
       "Jakob Steiner"
-    ]
+    ],
+    "mathContext": "Euclid proved the theorem synthetically using similar triangles: $\\triangle PAC \\sim \\triangle PDB$ (by the inscribed angle theorem), so $PA/PD = PC/PB$, hence $PA \\cdot PB = PC \\cdot PD$. Steiner's 1826 unification introduced the power $\\text{pow}(P) = |PO|^2 - r^2$ as a chord-independent invariant."
   }
 ]

--- a/src/data/proofs/ramanujan-sum-fallacy/annotations.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/annotations.json
@@ -58,7 +58,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Defines `naturals : \\mathbb{N} \\to \\mathbb{R}$ by $n \\mapsto n + 1$, so `naturals 0 = 1`, `naturals 1 = 2`, etc., giving the sequence $1, 2, 3, 4, \\ldots$ The offset by $1$ accounts for Lean's convention that $\\mathbb{N}$ starts at $0$."
   },
   {
     "id": "ann-false-claim",
@@ -159,7 +160,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "The alternating series $\\sum (-1)^n(n+1) = 1 - 2 + 3 - 4 + \\cdots$ diverges because $|(-1)^n(n+1)| = n + 1 \\to \\infty$, violating the necessary condition that terms tend to $0$. In Lean, `Summable.tendsto_atTop_zero` provides this criterion."
   },
   {
     "id": "ann-shift-requires-summable",
@@ -198,7 +200,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "The `tsum_eq_zero_add` lemma in Mathlib has signature `(hf : Summable f) : \\sum f = f(0) + \\sum f(n+1)$. Without the `Summable` proof obligation, the shift-and-add manipulation is blocked at the type level, preventing invalid reasoning about divergent series."
   },
   {
     "id": "ann-unbounded",
@@ -278,7 +281,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Step 2 claims $2S_2 = S_1$ via shift-and-add on $1 - 2 + 3 - 4 + \\cdots$. In Lean, both `tsum alternatingNaturals` and `tsum grandi` equal $0$ (non-summable convention), so $2 \\cdot 0 = 0$ holds trivially but reveals nothing about $-\\tfrac{1}{12}$."
   },
   {
     "id": "ann-step3",
@@ -310,6 +314,7 @@
     "type": "concept",
     "title": "Conclusion: Type Systems Enforce Rigor",
     "content": "Lean's type system and Mathlib's design choices enforce mathematical rigor automatically:\n\n1. **Summable typeclass**: Acts as proof obligation before series manipulation\n2. **tsum = 0 convention**: Prevents arithmetic on divergent 'values'\n3. **Distinct types**: Regularization would be a different function entirely\n\nThe -1/12 result is useful in physics, but it requires different mathematical machinery that Lean would model with appropriate types.",
+    "mathContext": "Three layers of protection: (1) `Summable f` as a typeclass gate on `tsum_add`, `tsum_eq_zero_add`, etc.; (2) `tsum_eq_zero_of_not_summable` ensuring divergent series evaluate to $0$; (3) a separate `zeta_regularized` axiom distinguishing $\\zeta(-1) = -\\tfrac{1}{12}$ from ordinary summation.",
     "significance": "key",
     "relatedConcepts": [
       "formal verification",

--- a/src/data/proofs/randomized-maxcut/annotations.json
+++ b/src/data/proofs/randomized-maxcut/annotations.json
@@ -17,7 +17,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Imports `SimpleGraph.Basic` (symmetric adjacency $G : V \\to V \\to \\text{Prop}$), `SimpleGraph.Finite` (the finite edge set `edgeFinset`), `Sym2` (unordered pairs $\\{u, v\\}$ representing edges), and `Finset.Basic` (finite summation $\\sum_{x \\in S} f(x)$ for linearity of expectation)."
   },
   {
     "id": "ann-maxcut-theorem2",
@@ -100,7 +101,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Edges in Mathlib are unordered pairs `Sym2 V` (quotient of $V \\times V$ by the swap relation). The tactic `induction e using Sym2.ind` destructs an edge $e$ into representatives $u, v$ with $e = \\{u, v\\}$; the hypothesis `\\neg e.\\text{IsDiag}` ensures $u \\neq v$."
   },
   {
     "id": "ann-maxcut-theorem4",

--- a/src/data/proofs/sqrt2-irrational/annotations.json
+++ b/src/data/proofs/sqrt2-irrational/annotations.json
@@ -17,7 +17,8 @@
     ],
     "prerequisites": [
       "mathematical foundations"
-    ]
+    ],
+    "mathContext": "Imports `Data.Real.Irrational` (the `Irrational` predicate and key results like `irrational_sqrt_two` and `Nat.Prime.irrational_sqrt`), `Algebra.Ring.Parity` (the `Even`/`Odd` predicates and lemmas on integer parity), and `Tactic` (automation including `norm_num`, `decide`, `ring`)."
   },
   {
     "id": "ann-sqrt2-irrational-def",


### PR DESCRIPTION
## Summary

Added missing `mathContext` fields to annotations across 8 gallery entries, completing 100% mathContext coverage across all 1,544 entries.

### Entries enriched
| Entry | Annotations added | Details |
|-------|------------------|---------|
| four-color-theorem | 7/12 | chromatic number, SimpleGraph, planarity, Kempe chains, reducibility, Gonthier |
| godel-incompleteness | 6/15 | theorem statements, Formula type, encoding, Hilbert, inexhaustibility, mechanism |
| fermats-last-theorem | 1/12 | FLT imports |
| navier-stokes | 3/17 | Faber-Krahn, Bernoulli, BKM criterion |
| product-of-segments-of-chords | 2/8 | examples, historical |
| ramanujan-sum-fallacy | 5/16 | naturals, alternating, shift, step2, conclusion |
| randomized-maxcut | 2/9 | imports, Sym2 induction |
| sqrt2-irrational | 1/17 | imports |

**Total: 27 mathContext fields added across 8 entries**

## Test plan
- [x] JSON validated for all 8 entries
- [x] Verified 0 annotations remain without mathContext gallery-wide