### PR TITLE
Research: erdos-1004 - Prove run_length_sublinear (3→2 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1004Problem.lean
+++ b/proofs/Proofs/Erdos1004Problem.lean
@@ -120,10 +120,76 @@ axiom eps87_constant_pos : eps87_constant > 0
 axiom eps87_upper_bound (n K : ℕ) (hn : n > 0) (hrun : IsDistinctTotientRun n K) :
     (K : ℝ) ≤ (n : ℝ) / Real.exp (eps87_constant * (Real.log (n : ℝ)) ^ ((1 : ℝ)/3))
 
+/-- The maxDistinctRunLength is bounded by the EPS87 bound for n > 0. -/
+private lemma maxDistinctRunLength_le_eps87 (n : ℕ) (hn : n > 0) :
+    (maxDistinctRunLength n : ℝ) ≤
+      (n : ℝ) / Real.exp (eps87_constant * (Real.log (n : ℝ)) ^ ((1 : ℝ) / 3)) := by
+  unfold maxDistinctRunLength
+  set S : Set ℕ := {K : ℕ | IsDistinctTotientRun n K} with hS_def
+  set B := (n : ℝ) / Real.exp (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3)) with hB_def
+  have hB : 0 ≤ B := div_nonneg (Nat.cast_nonneg n) (le_of_lt (Real.exp_pos _))
+  have hne : S.Nonempty := ⟨1, distinctRun_one n⟩
+  have hsup : sSup S ≤ ⌊B⌋₊ :=
+    csSup_le hne fun K hK => Nat.le_floor (eps87_upper_bound n K hn hK)
+  calc (↑(sSup S) : ℝ) ≤ ↑⌊B⌋₊ := Nat.cast_le.mpr hsup
+    _ ≤ B := Nat.floor_le hB
+
 /-- Corollary: The run length is o(n). -/
 theorem run_length_sublinear :
     Tendsto (fun n : ℕ => (maxDistinctRunLength n : ℝ) / (n : ℝ)) atTop (𝓝 (0 : ℝ)) := by
-  sorry
+  have hc := eps87_constant_pos
+  -- Prepare bounding function g and prove g → 0
+  have h_log : Tendsto (fun n : ℕ => Real.log (↑n : ℝ)) atTop atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  -- (log n)^(1/3) → ∞
+  have h_rpow : Tendsto (fun n : ℕ => (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3)) atTop atTop := by
+    rw [Filter.tendsto_atTop_atTop]
+    intro b
+    obtain ⟨N, hN⟩ := (Filter.tendsto_atTop_atTop.mp h_log) ((max b 0) ^ (3 : ℕ))
+    exact ⟨N, fun n hn => by
+      have hlog := hN n hn
+      have hM : (0 : ℝ) ≤ max b 0 := le_max_right b 0
+      suffices hsuff : ((max b 0) ^ (3 : ℕ) : ℝ) ^ ((1 : ℝ) / 3) = max b 0 by
+        calc b ≤ max b 0 := le_max_left b 0
+          _ = ((max b 0) ^ (3 : ℕ) : ℝ) ^ ((1 : ℝ) / 3) := hsuff.symm
+          _ ≤ (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3) :=
+              Real.rpow_le_rpow (pow_nonneg hM 3) hlog (by norm_num)
+      rw [← Real.rpow_natCast (max b 0) 3, ← Real.rpow_mul hM]
+      have : ((3 : ℕ) : ℝ) * ((1 : ℝ) / 3) = 1 := by push_cast; ring
+      rw [this, Real.rpow_one]⟩
+  -- c * (log n)^(1/3) → ∞
+  have h_mul : Tendsto (fun n : ℕ => eps87_constant * (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3))
+      atTop atTop := by
+    rw [Filter.tendsto_atTop_atTop]
+    intro b
+    obtain ⟨N, hN⟩ := Filter.tendsto_atTop_atTop.mp h_rpow (b / eps87_constant)
+    exact ⟨N, fun n hn => by
+      have h := hN n hn
+      have hcb : eps87_constant * (b / eps87_constant) = b := by field_simp
+      linarith [mul_le_mul_of_nonneg_left h (le_of_lt hc)]⟩
+  -- g = (exp ∘ (c * ·) ∘ (·^(1/3)) ∘ log ∘ ↑)⁻¹ → 0
+  have h_lim : Tendsto (fun n : ℕ => (Real.exp (eps87_constant *
+      (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3)))⁻¹) atTop (𝓝 0) :=
+    tendsto_inv_atTop_zero.comp (Real.tendsto_exp_atTop.comp h_mul)
+  -- Upper bound
+  have h_bound : ∀ n : ℕ, (maxDistinctRunLength n : ℝ) / ↑n ≤
+      (Real.exp (eps87_constant * (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3)))⁻¹ := by
+    intro n
+    by_cases hn : n = 0
+    · simp [hn]
+    · have hn' := Nat.pos_of_ne_zero hn
+      have hn_pos : (0 : ℝ) < ↑n := Nat.cast_pos.mpr hn'
+      have hexp_pos := Real.exp_pos (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3))
+      rw [inv_eq_one_div, div_le_div_iff₀ hn_pos hexp_pos, one_mul]
+      calc ↑(maxDistinctRunLength n) *
+              Real.exp (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3))
+          ≤ (↑n / Real.exp (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3))) *
+              Real.exp (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3)) :=
+            mul_le_mul_of_nonneg_right (maxDistinctRunLength_le_eps87 n hn') (le_of_lt hexp_pos)
+        _ = ↑n := div_mul_cancel₀ _ (ne_of_gt hexp_pos)
+  -- Squeeze: 0 ≤ f ≤ g, g → 0
+  exact squeeze_zero (fun n => div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _))
+    h_bound h_lim
 
 /-! ## Part V: The Main Conjecture -/
 
@@ -331,11 +397,13 @@ theorem totient_eq_two_iff (n : ℕ) : phi n = 2 ↔ n = 3 ∨ n = 4 ∨ n = 6 :
         simp only [hS, Finset.mem_filter, Finset.mem_range]
         refine ⟨by omega, ?_⟩
         show Nat.gcd n (n - 1) = 1
-        have h1 : Nat.gcd n (n - 1) ∣ 1 := by
-          have := Nat.dvd_sub' (Nat.gcd_dvd_left n (n - 1)) (Nat.gcd_dvd_right n (n - 1))
-          rwa [show n - (n - 1) = 1 from by omega] at this
-        exact Nat.le_antisymm (Nat.le_of_dvd one_pos h1)
-          (Nat.gcd_pos_of_pos_left (n - 1) (by omega))
+        -- Consecutive integers are coprime: gcd(n, n-1) = 1
+        -- n = 1 + (n-1), so n % (n-1) = 1, then gcd(n, n-1) = gcd(n-1, 1) = 1
+        have hmod : n % (n - 1) = 1 := by
+          nth_rewrite 1 [show n = 1 + (n - 1) from by omega]
+          rw [Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : 1 < n - 1)]
+        rw [Nat.gcd_comm, Nat.gcd_rec, hmod]
+        simp
       have hsub : ({1, 5, n - 1} : Finset ℕ) ⊆ S := by
         intro x hx; simp only [Finset.mem_insert, Finset.mem_singleton] at hx
         rcases hx with rfl | rfl | rfl <;> assumption

--- a/research/problems/erdos-1004-wip-01/knowledge.md
+++ b/research/problems/erdos-1004-wip-01/knowledge.md
@@ -1,0 +1,41 @@
+# Erdős #1004: Distinct Consecutive Totient Values
+
+## Problem Summary
+
+For c > 0, if x is sufficiently large, does there exist n ≤ x such that
+φ(n+1), φ(n+2), ..., φ(n+⌊(log x)^c⌋) are all distinct?
+
+**Status**: OPEN (partial results from EPS 1987)
+**File**: `proofs/Proofs/Erdos1004Problem.lean`
+**Sorries**: 2 remaining (was 3, then 5 originally)
+**Axioms**: 3 (EPS87 bound)
+
+## Session 2026-03-25 (Session 2) - Prove run_length_sublinear
+
+**Mode**: FRESH (REVISIT of in-progress problem)
+**Outcome**: progress (1 sorry eliminated)
+
+### What I Did
+- Proved `run_length_sublinear`: maxDistinctRunLength(n)/n → 0 as n → ∞
+  - Created helper `maxDistinctRunLength_le_eps87` bounding sSup via EPS87 axiom
+  - Used squeeze theorem with bound g(n) = 1/exp(c·(log n)^{1/3})
+  - Proved limit via composition chain: log→∞, rpow→∞, c*·→∞, exp→∞, inv→0
+- Fixed pre-existing `Nat.dvd_sub'` build error in `totient_eq_two_iff`
+  - Used Euclidean algorithm approach: gcd_rec + manual mod proof via nth_rewrite
+- Assessed `longer_runs_need_larger_n`: too deep for this session (requires existence of K-long distinct totient runs for arbitrary K)
+
+### Key Findings
+- The sSup bound technique: csSup_le + Nat.le_floor + Nat.floor_le cleanly transfers real bounds to ℕ sup
+- rpow cube root identity: `(a^3)^(1/3) = a` via rpow_natCast + rpow_mul + norm_num
+- omega cannot handle `n % (n-1) = 1` for variable n; need manual Euclidean approach
+- `longer_runs_need_larger_n` reduces to existence of a single m with K distinct consecutive totients (via ∃ n₀ trick), but even that single existence is deep
+
+### Files Modified
+- `proofs/Proofs/Erdos1004Problem.lean` (424 → 492 lines, 3 → 2 sorries)
+- `src/data/proofs/erdos-1004/meta.json` (updated counts)
+- `src/data/research/problems/erdos-1004-wip-01.json` (updated knowledge)
+
+### Next Steps
+- `longer_runs_need_larger_n`: try CRT-based constructive existence or density argument
+- `distinct_totients_asymptotic`: deep analytic result (Ford 1998), likely needs Aristotle or axiomatization
+- Consider submitting both as HARD to Aristotle

--- a/research/registry.json
+++ b/research/registry.json
@@ -5785,11 +5785,11 @@
     },
     {
       "slug": "erdos-1004-wip-01",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-03-24T00:48:59.900Z",
       "status": "active",
-      "lastUpdate": "2026-03-24T00:48:59.900Z"
+      "lastUpdate": "2026-03-25T01:35:29-07:00"
     },
     {
       "slug": "erdos-1007-oq-01-oq-01",

--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -16,13 +16,13 @@
       "analytic-number-theory"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 1004,
     "erdosUrl": "https://erdosproblems.com/1004",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 424,
-    "assumptions": "Three axioms for EPS87 upper bound (eps87_constant, eps87_constant_pos, eps87_upper_bound). Three sorries: run_length_sublinear, longer_runs_need_larger_n, distinct_totients_asymptotic.",
+    "lineCount": 492,
+    "assumptions": "Three axioms for EPS87 upper bound (eps87_constant, eps87_constant_pos, eps87_upper_bound). Two sorries: longer_runs_need_larger_n, distinct_totients_asymptotic. run_length_sublinear proved from axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -260,9 +260,9 @@
       "Topology"
     ],
     "namespace": "Erdos1004",
-    "lineCount": 424,
+    "lineCount": 492,
     "axiomCount": 3,
-    "theoremCount": 22,
+    "theoremCount": 23,
     "definitionCount": 13
   }
 }

--- a/src/data/research/problems/erdos-1004-wip-01.json
+++ b/src/data/research/problems/erdos-1004-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1004-wip-01",
   "title": "Complete Erdős #1004: Distinct Consecutive Totient Values (Work in Progress)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-24T00:48:59.901Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved run_length_sublinear. 2 deep sorries remain.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Attempt longer_runs_need_larger_n via constructive approach or submit to Aristotle",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,17 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 2 totient characterizations (sorries 5→3). Remaining: 3 deep sorries (sublinear growth, long runs existence, asymptotic density).",
+    "progressSummary": "PROGRESS: Proved run_length_sublinear corollary + 2 totient characterizations (sorries 5→2). Remaining: 2 sorries (long runs existence, asymptotic density).",
     "builtItems": [
       "Proved totient_eq_two_iff: φ(n) = 2 ↔ n ∈ {3,4,6}",
       "Proved totient_eq_four_iff: φ(n) = 4 ↔ n ∈ {5,8,10,12}",
-      "Helper prime_pred_dvd_totient via factorization + multiplicativity"
+      "Helper prime_pred_dvd_totient via factorization + multiplicativity",
+      "Proved maxDistinctRunLength_le_eps87: sSup bound from EPS87 axiom via csSup_le + Nat.floor",
+      "Proved run_length_sublinear: maxDistinctRunLength(n)/n → 0 via squeeze theorem",
+      "Fixed Nat.dvd_sub bug in totient_eq_two_iff via Euclidean gcd_rec"
     ],
     "insights": [
-      "prime_pred_dvd_totient: if prime p | n then (p-1) | φ(n), key infrastructure for totient characterizations"
+      "prime_pred_dvd_totient: if prime p | n then (p-1) | φ(n), key infrastructure for totient characterizations",
+      "run_length_sublinear proof chain: sSup bound → squeeze_zero with g(n)=1/exp(c·(log n)^{1/3}) → limit via composition (log→∞, rpow→∞, exp→∞, inv→0)",
+      "Key Mathlib API: csSup_le for ℕ, Nat.le_floor/floor_le for real-to-nat bound transfer, rpow_mul for cube root identity",
+      "longer_runs_need_larger_n requires deep number theory: existence of arbitrarily long distinct consecutive totient runs for fixed K"
     ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "longer_runs_need_larger_n: needs existence proof for K-long distinct runs; consider CRT-based construction or density argument",
+      "distinct_totients_asymptotic: needs ~x/log(x) distinct totients ≤ x; this is a deep analytic result (Ford 1998)",
+      "Consider submitting both remaining sorries to Aristotle as HARD classification"
+    ]
   },
   "tags": [
     "erdos",


### PR DESCRIPTION
## Summary
- Prove `run_length_sublinear`: maxDistinctRunLength(n)/n → 0, derived from axiomatized EPS87 bound via squeeze theorem with limit composition chain
- Fix pre-existing `Nat.dvd_sub'` build error in `totient_eq_two_iff` using Euclidean gcd_rec approach
- Update gallery metadata and research knowledge

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.Erdos1004Problem`)
- [x] Sorry count reduced from 3 to 2
- [x] No new axioms introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)