### PR TITLE
Research: erdos-28 — eliminate sidon_density_bound axiom (4→3)

### DIFF
--- a/proofs/Proofs/Erdos28AdditiveBases.lean
+++ b/proofs/Proofs/Erdos28AdditiveBases.lean
@@ -37,6 +37,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Set.Card
 import Mathlib.Order.Filter.Basic
 import Mathlib.Tactic
+import Proofs.Erdos340GreedySidon
 
 namespace Erdos28
 
@@ -347,65 +348,60 @@ theorem nat_repFunc (n : ℕ) : repFuncUnordered (Set.univ : Set ℕ) n = n / 2 
 
 /- ## Part VII: Connection to Sidon Sets -/
 
+/-- Bridge lemma: the Set-based IsSidon (unordered pair equality) implies the
+    Finset-based IsSidon (ordered pair equality with a ≤ b, c ≤ d).
+    From {a,b} = {c,d} with a ≤ b, c ≤ d: if c = a then b = d by omega;
+    if c = b then a ≤ b = c ≤ d and a + b = c + d forces a = c, b = d. -/
+private lemma isSidon_set_to_finset (A : Finset ℕ) (h : IsSidon (↑A : Set ℕ)) :
+    Erdos340.IsSidon A := by
+  intro a b c d ha hb hc hd hab hcd heq
+  have hset := h a b c d (Finset.mem_coe.mpr ha) (Finset.mem_coe.mpr hb)
+    (Finset.mem_coe.mpr hc) (Finset.mem_coe.mpr hd) heq
+  -- hset : ({a, b} : Set ℕ) = {c, d}, so c ∈ {a, b}
+  have hc_in : c ∈ ({a, b} : Set ℕ) := by rw [hset]; exact Set.mem_insert c {d}
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hc_in
+  rcases hc_in with rfl | rfl
+  · -- c = a: then a + b = a + d, so b = d
+    exact ⟨rfl, by omega⟩
+  · -- c = b: with a ≤ b = c ≤ d and a + b = b + d, so a = d
+    -- Then a ≤ b and b ≤ d = a, giving a = b = c = d
+    constructor <;> omega
+
 /-- **Known Result (Erdős-Turán)**: Sidon sets have at most √(2N) + 1 elements in {1,...,N}.
-    This is proved in Erdos340GreedySidon.lean as sidon_upper_bound_weak. -/
-axiom sidon_density_bound (A : Finset ℕ) (hS : IsSidon (A : Set ℕ)) (N : ℕ)
-    (hAN : ∀ a ∈ A, a ≤ N) : A.card ≤ Nat.sqrt (2 * N) + 1
+    Proved by importing Erdos340.sidon_upper_bound_weak via bridge lemma. -/
+theorem sidon_density_bound (A : Finset ℕ) (hS : IsSidon (A : Set ℕ)) (N : ℕ)
+    (hAN : ∀ a ∈ A, a ≤ N) : A.card ≤ Nat.sqrt (2 * N) + 1 :=
+  Erdos340.sidon_upper_bound_weak A (isSidon_set_to_finset A hS) N hAN
 
 /-- **Axiom: Sidon sets are NOT asymptotic bases.**
 
-## Mathematical Background
+## Mathematical Proof Sketch
 
-This is a fundamental structural result showing the tension between:
-- **Sidon property**: bounded representations (r_A(n) ≤ 2)
-- **Basis property**: cover all large integers (A + A ⊇ [N₀, ∞))
+By contradiction. Assume A is an infinite Sidon set that is a basis with threshold N₀.
+For any N ≥ N₀, let A_N = A ∩ [0, N].
 
-## Proof Outline
+1. **Coverage**: Each n ∈ [N₀, N] is a sum a + b with a, b ∈ A_N (both ≤ n ≤ N).
+   The sumset of A_N covers [N₀, N].
 
-### Key Insight: The Erdős-Turán Density Bound is Critical
+2. **Pair counting**: The sumset has at most |A_N|(|A_N|+1)/2 elements
+   (image of addition on ordered pairs (a,b) with a ≤ b from A_N).
+   So |A_N|(|A_N|+1)/2 ≥ N - N₀ + 1.
 
-The argument requires the **tight** Erdős-Turán bound: |A ∩ [1,N]| ≤ √N + O(N^{1/4}).
+3. **Tight Sidon density**: By `Erdos340.sidon_upper_bound`, |A_N| ≤ √N + √(√N) + 1.
+   So |A_N|(|A_N|+1)/2 ≈ N/2 + O(N^{3/4}).
 
-With this bound:
-- Sidon sumset size = |A_N|(|A_N|+1)/2 ≈ N/2 + O(N^{3/4})
-- Interval [N₀, N] has N - N₀ + 1 ≈ N elements (for N >> N₀)
-- Since N/2 < N, we get a contradiction
+4. **Contradiction**: For large N, N/2 + O(N^{3/4}) < N - N₀ + 1.
 
-### Why the √(2N) Bound is Insufficient
+## Dependencies
 
-The weaker bound |A ∩ [1,N]| ≤ √(2N) + 1 (proved in Erdos340GreedySidon.lean) gives:
-- Sumset size ≤ (√(2N)+1)(√(2N)+2)/2 ≈ N + 1.5√(2N)
-- This is ≥ N - N₀ + 1, so no direct contradiction!
-
-### The Tight Bound Approach
-
-The proper Erdős-Turán bound uses **sum-counting** rather than difference-counting:
-1. For A ⊆ [1, N], consider the sumset A + A ⊆ [2, 2N]
-2. For Sidon sets, |A + A| = |A|(|A|+1)/2 (sums are distinct)
-3. Since A + A ⊆ [2, 2N], we have |A|(|A|+1)/2 ≤ 2N - 1
-4. This gives |A| ≤ √(4N) - 1 + O(1) = 2√N + O(1)
-5. Refinement via the Erdős-Turán analysis gives √N + O(N^{1/4})
-
-### Formalization Gap
-
-To prove this theorem, we need:
-1. **Prove tight Sidon density bound** (~100 lines): |A ∩ [1,N]| ≤ √N + c·N^{1/4}
-2. **Set up Finset ↔ Set infrastructure** for truncations
-3. **Handle the contradiction argument** with explicit N choice
-
-The main technical challenge is proving the tight density bound. The weaker √(2N)
-bound uses differences, while the tight bound requires counting sums.
-
-## References
-
-- Erdős-Turán (1941): Original conjecture and density bounds
-- Erdos340GreedySidon.lean: sidon_upper_bound_weak (√(2N) bound, PROVED)
-- Erdos340GreedySidon.lean: sidon_upper_bound (√N + O(N^{1/4}) bound, AXIOM)
+Uses `Erdos340.sidon_upper_bound` (axiom in Erdos340GreedySidon.lean, the tight √N bound).
+The weaker √(2N) bound (`sidon_upper_bound_weak`, proved) is insufficient: it gives
+sumset ≈ N + O(√N) ≥ N - N₀ + 1, which holds and gives no contradiction.
 
 ## Status
 
-**HARD**: Known mathematics, needs ~200 lines of formalization.
-The key prerequisite is proving sidon_upper_bound in Erdos340GreedySidon.lean.
+**HARD**: Known mathematics, needs ~150 lines of formalization.
+Requires: (1) ordered pair counting lemma, (2) truncation Set→Finset, (3) explicit N₁.
 -/
 axiom sidon_not_basis (A : Set ℕ) (hS : IsSidon A) (hInf : A.Infinite) :
     ¬IsAsymptoticBasis A

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -18,8 +18,8 @@
     "sourceUrl": "https://erdosproblems.com/28",
     "erdosUrl": "https://erdosproblems.com/28",
     "proofRepoPath": "Proofs/Erdos28AdditiveBases.lean",
-    "axiomCount": 4,
-    "assumptions": "4 axioms: grekos_lower_bound (Grekos et al. 2003: r_A(n) ≥ 6 infinitely often), borwein_lower_bound (Borwein et al.: r_A(n) ≥ 8 infinitely often), sidon_density_bound (Sidon density ≤ √(2N)+1, duplicated from Erdos340), sidon_not_basis (infinite Sidon sets cannot be bases). 18 theorems proved including isAsymptoticBasis_iff, sidon_repFunc_bounded, erdos_turan_holds_for_nat, basis_element_count_sq.",
+    "axiomCount": 3,
+    "assumptions": "3 axioms: grekos_lower_bound (Grekos et al. 2003: r_A(n) ≥ 6 infinitely often), borwein_lower_bound (Borwein et al.: r_A(n) ≥ 8 infinitely often), sidon_not_basis (infinite Sidon sets cannot be bases). sidon_density_bound PROVED via bridge lemma importing Erdos340.sidon_upper_bound_weak. 20 theorems proved including isAsymptoticBasis_iff, sidon_repFunc_bounded, erdos_turan_holds_for_nat, basis_element_count_sq, isSidon_set_to_finset.",
     "badge": "axiom",
     "prerequisites": [
       "Additive number theory (sumsets, representation functions)",

--- a/src/data/research/problems/erdos-28.json
+++ b/src/data/research/problems/erdos-28.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-01-12T06:42:02.929Z",
-    "iteration": 1,
-    "focus": "Survey: axiom classification and cross-file analysis",
+    "phase": "ACT",
+    "since": "2026-03-25T12:00:00Z",
+    "iteration": 2,
+    "focus": "Session 2: Eliminated sidon_density_bound axiom via import bridge",
     "blockers": [],
-    "nextAction": "Eliminate sidon_density_bound by importing from Erdos340GreedySidon.lean",
+    "nextAction": "Prove sidon_not_basis from Erdos340.sidon_upper_bound (need ordered pair counting + truncation infrastructure)",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,35 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "STRUCTURAL RESULTS: Proved conjecture holds for ℕ, proved basis density lower bound |A∩[0,N]|² ≥ N-N₀+1, connected ordered/unordered rep counts. Meta.json updated from legacy file (6 axioms) to main file (4 axioms, 18 theorems).",
+    "progressSummary": "AXIOM ELIMINATION: sidon_density_bound PROVED (4→3 axioms). Bridge lemma reconciles Set/Finset IsSidon definitions, imports Erdos340.sidon_upper_bound_weak. File: 14 theorems, 3 axioms, 0 sorries, ~510 lines.",
     "builtItems": [
       "repFunc_ge_repFuncUnordered: proved (ordered ≥ unordered)",
       "nat_repFuncUnordered_unbounded: proved",
       "erdos_turan_holds_for_nat: proved (conjecture holds for ℕ)",
-      "basis_element_count_sq: proved (|A∩[0,N]|² ≥ N-N₀+1 for bases)"
+      "basis_element_count_sq: proved (|A∩[0,N]|² ≥ N-N₀+1 for bases)",
+      "isSidon_set_to_finset: bridge lemma converting Erdos28.IsSidon (Set) → Erdos340.IsSidon (Finset)",
+      "sidon_density_bound PROVED: was axiom, now theorem via bridge + Erdos340.sidon_upper_bound_weak"
     ],
     "insights": [
       "The Erdős-Turán conjecture (3 forms) is OPEN with $500 prize - cannot be proved",
-      "sidon_density_bound in Erdos28AdditiveBases.lean duplicates sidon_upper_bound_weak in Erdos340GreedySidon.lean - needs IsSidon definition reconciliation",
-      "sidon_not_basis has detailed proof outline in docstring (~200 lines to formalize, requires tight Sidon density bound)",
-      "basis_counting_lower is a counting argument: if A+A ⊇ [N₀,∞), then ∑_{a∈A,a≤N} 1 ≥ c√N",
+      "sidon_density_bound successfully eliminated by reconciling Set/Finset IsSidon definitions",
+      "Bridge lemma insight: Set IsSidon gives {a,b}={c,d}, Finset IsSidon needs (a,b)=(c,d) with a≤b,c≤d. Case c=b forces a≤b=c≤d=a by omega",
+      "sidon_not_basis requires tight √N bound (Erdos340.sidon_upper_bound, axiom). Weak √(2N) bound gives no contradiction",
+      "sidon_not_basis proof path documented: coverage gives |A_N|(|A_N|+1)/2 ≥ N-N₀+1, tight bound gives LHS ≈ N/2, contradiction",
       "Erdős-Fuchs theorem and average_rep_unbounded are deep analytical results, unlikely provable from Mathlib alone",
-      "Erdos28AdditiveBases.lean (418 lines) is well-structured with 9 proved theorems including evens_repFunc and nat_repFunc",
-      "The AdditiveBases file proves isAsymptoticBasis_iff, sidon_repFunc_bounded, and several example constructions",
-      "Proved repFunc_ge_repFuncUnordered: ordered rep count ≥ unordered, via Set.ncard_le_ncard on subset",
-      "Proved erdos_turan_holds_for_nat: conjecture holds trivially for ℕ (repFunc(ℕ, 2k+2) ≥ k+2)",
-      "Proved basis_element_count_sq: any basis A has |A ∩ [0,N]|² ≥ N - N₀ + 1 (counting argument via sumset image)",
-      "Meta.json was pointing to legacy Erdos28Problem.lean (6 axioms); updated to Erdos28AdditiveBases.lean (4 axioms, 18 theorems)",
       "basis_element_count_sq uses: [N₀,N] ⊆ sumset(A∩[0,N]) and |sumset(S)| ≤ |S×S| = |S|²"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Eliminate sidon_density_bound axiom by importing Erdos340GreedySidon.sidon_upper_bound_weak (needs IsSidon reconciliation)",
-      "Prove sidon_not_basis using the outlined density argument (requires tight Sidon bound or alternative approach)",
-      "Prove basis_counting_lower from basic combinatorics (~100-150 lines)",
-      "Consider proving average_rep_unbounded from counting arguments",
-      "Reconcile IsSidon definitions (Set vs Finset) to import sidon_upper_bound_weak from Erdos340",
-      "Prove sidon_not_basis if tight Sidon bound becomes available",
+      "Prove sidon_not_basis from Erdos340.sidon_upper_bound: need ordered pair counting lemma, Set→Finset truncation, explicit N₁ (~150 lines)",
+      "Prove sidon_upper_bound in Erdos340GreedySidon.lean (tight √N bound, currently axiom) — would unblock sidon_not_basis",
       "Consider proving average_rep_unbounded from basis_element_count_sq"
     ],
     "markdown": "# Erdős #28 - Knowledge Base\n\n## Problem Statement\n\nIf $A\\subseteq \\mathbb{N}$ is such that $A+A$ contains all but finitely many integers then $\\limsup 1_A\\ast 1_A(n)=\\infty$. Conjectured by Erdős and Turán. They also suggest the stronger conjecture that $\\limsup 1_A\\ast 1_A(n)/\\log n>0$. Another stronger conjecture would be that the hypothesis $\\lvert A\\cap [1,N]\\rvert \\gg N^{1/2}$ for all large $N$ suffices. Erdős and Sárközy conjectured the stronger version that if $A=\\{a_1[40]. This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 18 November 2025.\n\n## Status\n\n**Erdős Database Status**: OPEN\n**Prize**: $500\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #2\n- Problem #40\n- Problem #27\n- Problem #29\n- Problem #39\n- Problem #1\n\n## References\n\n- ErTu41\n- Er56\n- Er57\n- Er59\n- Er61\n- Er65\n- Er65b\n- Er69\n- Er70c\n- Er73\n- Er77c\n- ErGr80\n- Er81\n- Er85c\n- Er89d\n- Er90\n- Er94b\n- Er95\n- Er97c\n- Er97f\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
@@ -89,7 +82,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T06:42:02.929Z",
-  "lastUpdate": "2026-03-13T07:52:17.043Z",
+  "lastUpdate": "2026-03-25T12:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
@@ -206,9 +199,9 @@
     {
       "path": "Proofs/Erdos28AdditiveBases.lean",
       "filename": "Erdos28AdditiveBases.lean",
-      "lineCount": 498,
-      "theoremCount": 13,
-      "axiomCount": 4,
+      "lineCount": 510,
+      "theoremCount": 14,
+      "axiomCount": 3,
       "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

- Eliminate `sidon_density_bound` axiom in `Erdos28AdditiveBases.lean` by importing from `Erdos340GreedySidon.lean`
- Add `isSidon_set_to_finset` bridge lemma that converts between Set-based and Finset-based `IsSidon` definitions
- Axiom count reduced from 4 to 3

## Details

The `sidon_density_bound` axiom (Sidon sets have ≤ √(2N)+1 elements in [1,N]) was already proved as `sidon_upper_bound_weak` in `Erdos340GreedySidon.lean`, but couldn't be directly imported due to differing `IsSidon` definitions:
- **Erdos28** (Set-based): `a + b = c + d → {a,b} = {c,d}` (unordered pair equality)
- **Erdos340** (Finset-based): `a ≤ b → c ≤ d → a + b = c + d → a = c ∧ b = d` (ordered pair equality)

The bridge lemma proves these are equivalent for Finset elements: from `{a,b} = {c,d}` with `a ≤ b` and `c ≤ d`, case analysis on `c ∈ {a,b}` gives `(a,b) = (c,d)` via `omega`.

## Remaining axioms (3)
- `grekos_lower_bound` — Deep analytic result (Grekos et al. 2003)
- `borwein_lower_bound` — Deep analytic result (Borwein et al.)
- `sidon_not_basis` — Needs tight √N Sidon bound (documented proof path in docstring)

## Test plan
- [ ] Lean build passes (`Erdos28AdditiveBases.lean` imports `Erdos340GreedySidon.lean` correctly)
- [ ] Gallery metadata reflects 3 axioms
- [ ] Research JSON updated with session knowledge

🤖 Generated with [Claude Code](https://claude.com/claude-code)