### PR TITLE
Enrich prime-number-theorem: add mainTheorems metadata

### DIFF
--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -316,6 +316,39 @@
     "lineCount": 463,
     "axiomCount": 13,
     "theoremCount": 15,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "substantiveTheoremCount": 5,
+    "mainTheorems": [
+      {
+        "name": "all_formulations_equiv",
+        "type": "bridge",
+        "description": "All four PNT formulations (ratio, equivalence, error, Li) are equivalent",
+        "leanType": "PrimeNumberTheorem_Ratio ↔ PrimeNumberTheorem_Equiv ∧ ..."
+      },
+      {
+        "name": "prime_asymptotic",
+        "type": "wrapper",
+        "description": "π(x) ~ x/ln(x) in the equivalence formulation",
+        "leanType": "PrimeNumberTheorem_Equiv"
+      },
+      {
+        "name": "prime_li_asymptotic",
+        "type": "wrapper",
+        "description": "π(x) ~ Li(x) in the logarithmic integral formulation",
+        "leanType": "PrimeNumberTheorem_Li"
+      },
+      {
+        "name": "prime_density_tends_to_zero",
+        "type": "wrapper",
+        "description": "The density of primes π(x)/x tends to 0",
+        "leanType": "Tendsto (fun x => primePi x / x) atTop (nhds 0)"
+      },
+      {
+        "name": "pnt_rh_error",
+        "type": "wrapper",
+        "description": "Under RH, the error |π(x) - Li(x)| = O(√x ln x)",
+        "leanType": "RiemannHypothesis → |primePi x - logIntegral x| = O(√x · ln x)"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Added `mainTheorems` array with 5 key theorems (`all_formulations_equiv`, `prime_asymptotic`, `prime_li_asymptotic`, `prime_density_tends_to_zero`, `pnt_rh_error`) to `leanFile` section
- Added `substantiveTheoremCount` (5)
- All 13 cross-references verified as valid gallery entries