### PR TITLE
Enrich 4 entries: bounded-prime-gaps, buffons-needle, cantor-diag-oq-01, chinese-remainder-nc-oq-04

### DIFF
--- a/src/data/proofs/bounded-prime-gaps/meta.json
+++ b/src/data/proofs/bounded-prime-gaps/meta.json
@@ -261,6 +261,16 @@
       "targetId": "bertrands-postulate-oq-03",
       "relationship": "related",
       "description": "Sub-entry extending Bertrand's postulate with refined prime counting bounds. The bounded prime gaps formalization uses Bertrand to prove primeGap_le_nthPrime ($g(n) \\leq p_n$), connecting the classical upper bound on every gap to the modern Polymath lower-frequency result ($g(n) \\leq 246$ infinitely often)"
+    },
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Both concern density and patterns in the primes. The Green-Tao theorem (2004) — that primes contain arbitrarily long arithmetic progressions — combines Szemerédi's theorem with a transference principle. Similarly, the bounded prime gaps result uses sieve theory to detect patterns (admissible tuples) in the primes. Both represent the application of combinatorial tools to analytic number theory"
+    },
+    {
+      "targetId": "legendre-partial",
+      "relationship": "related",
+      "description": "Legendre conjectured (c. 1808) that there is a prime between consecutive perfect squares $n^2$ and $(n+1)^2$, implying prime gaps grow at most as $2n + 1$. While Legendre's conjecture remains open, the bounded prime gaps theorem gives the complementary result: infinitely often, consecutive primes are within 246 of each other — capturing the opposite extreme of prime gap behavior"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -177,6 +177,21 @@
       "targetId": "buffons-needle-oq-02",
       "relationship": "extended-by",
       "description": "Extends Buffon's needle to 3 dimensions: a needle dropped among parallel planes spaced $d$ apart has expected crossing count $L/(2d)$ — answering the open question about higher-dimensional generalizations"
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "foundational",
+      "description": "The Fundamental Theorem of Calculus underlies the key integral $\\int_0^\\pi \\sin\\theta\\, d\\theta = [-\\cos\\theta]_0^\\pi = 2$ that is the computational heart of Buffon's result. Without FTC, the geometric probability would require Archimedes-style exhaustion methods"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The Monte Carlo $\\pi$ estimator $\\hat{\\pi} = 2\\ell n/(kd)$ converges to $\\pi$ by the law of large numbers, with error governed by the Central Limit Theorem: $\\hat{\\pi} - \\pi$ is approximately $N(0, \\sigma^2/n)$ where $\\sigma^2 = P(1-P) \\cdot (2\\ell/(Pd))^2$. The CLT quantifies the convergence rate of this earliest Monte Carlo method"
+    },
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "The geometric setup of Buffon's needle uses the intermediate value theorem implicitly: the needle crosses a line iff the perpendicular distance from its center to the nearest line is less than $(\\ell/2)\\sin\\theta$, and IVT ensures this crossing threshold varies continuously with the angle"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -127,7 +127,7 @@
   ],
   "conclusion": {
     "summary": "Cantor's diagonal argument is powerful enough to generate the entire beth number tower ℵ₀ < 2^ℵ₀ < 2^(2^ℵ₀) < ⋯ and to establish the fundamental bounds ℵ₀ < ℵ₁ ≤ 2^ℵ₀.",
-    "implications": "But it reaches its fundamental limit when asked whether any cardinality lies *between* ℵ₀ and 2^ℵ₀. The Continuum Hypothesis — that no such intermediate cardinal exists — is provably independent of ZFC (Gödel-Cohen), meaning the diagonal argument, however iterated, cannot resolve this question.",
+    "implications": "**1. Independence from ZFC**: The Continuum Hypothesis is the first and most famous example of a natural mathematical statement independent of the standard axioms. Gödel (1940) showed CH is consistent with ZFC by constructing the constructible universe $L$, where CH holds. Cohen (1963) showed $\\neg$CH is consistent by introducing the method of forcing, constructing models where $2^{\\aleph_0} = \\aleph_2$ or any regular cardinal $\\geq \\aleph_1$. Together, CH is independent of ZFC — neither provable nor refutable.\n\n**2. Set-theoretic pluralism**: The independence of CH led to a fundamental philosophical question: is there a 'correct' answer to CH, or are there genuinely different mathematical universes? The multiverse view (Hamkins) holds that different set-theoretic universes are equally real; the universe view (Woodin, early period) holds that there is a definite truth about CH that stronger axioms might reveal.\n\n**3. Forcing and modern set theory**: Cohen's method of forcing, developed to prove $\\neg$CH consistent, became the most powerful technique in modern set theory. Forcing has been used to prove the independence of hundreds of combinatorial principles and to construct models with exotic properties. It is the set-theoretic analog of Galois's group theory: a general framework that transforms individual impossibility results into a systematic theory.\n\n**4. Cardinal arithmetic**: CH is equivalent to $2^{\\aleph_0} = \\aleph_1$. The Generalized Continuum Hypothesis (GCH: $2^{\\aleph_\\alpha} = \\aleph_{\\alpha+1}$ for all ordinals $\\alpha$) is also independent of ZFC. Easton's theorem (1970) shows that the function $\\alpha \\mapsto 2^{\\aleph_\\alpha}$ can be essentially arbitrary on regular cardinals — any non-decreasing function with $\\text{cf}(2^{\\aleph_\\alpha}) > \\aleph_\\alpha$ is consistent with ZFC.\n\n**5. Connections to analysis**: CH has concrete consequences in real analysis. Under CH, there exist pathological objects like Sierpiński sets (uncountable sets meeting every Lebesgue null set in a countable set) and Luzin sets (uncountable sets meeting every meager set in a countable set). Under $\\neg$CH with Martin's Axiom, these cannot exist. The independence of CH thus implies that certain questions about the real line are undecidable in ZFC.",
     "openQuestions": [
       "Does there exist a cardinal κ with ℵ₀ < κ < 2^ℵ₀? (The Continuum Hypothesis — independent of ZFC)",
       "Is the Continuum Hypothesis decided by large cardinal axioms?",
@@ -159,6 +159,16 @@
       "targetId": "schroeder-bernstein",
       "relationship": "foundational",
       "description": "The Schröder-Bernstein theorem (injections both ways ↔ bijection) provides the cardinal arithmetic framework in which CH is formulated: ℵ₀ < 2^ℵ₀ uses the strict ordering of cardinals"
+    },
+    {
+      "targetId": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "The dedicated Continuum Hypothesis entry formalizing the statement $2^{\\aleph_0} = \\aleph_1$ and its independence from ZFC. This entry (OQ-01 of Cantor diagonalization) approaches CH from the perspective of the diagonal argument's limitations"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Both are impossibility results that transformed mathematics: Abel-Ruffini showed no radical formula solves the general quintic (1824), while Gödel-Cohen showed no ZFC proof decides CH (1940/1963). Both revealed that certain natural questions have no answer within a given formal framework, inaugurating the study of impossibility and independence"
     }
   ],
   "references": [

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
@@ -158,12 +158,7 @@
   ],
   "conclusion": {
     "summary": "We have formalized Dirichlet's approximation theorem via the pigeonhole principle, establishing the foundational result of Diophantine approximation. The proof demonstrates how finite combinatorics (pigeonhole on N+1 fractional parts) yields a powerful analytic result (rational approximation quality 1/(qN)). The connections to CRT lattice structure, Stern-Brocot mediants, and the golden ratio show how number theory, combinatorics, and geometry interweave in the theory of Diophantine approximation.",
-    "implications": [
-      "Every irrational has infinitely many rational approximations p/q with quality better than 1/q²",
-      "The golden ratio is the hardest-to-approximate irrational (Hurwitz constant √5)",
-      "CRT solvability for non-coprime moduli reduces to lattice point counting",
-      "Dirichlet's method extends to simultaneous approximation in higher dimensions (Minkowski's theorem)"
-    ],
+    "implications": "**1. Diophantine approximation**: Every irrational $\\alpha$ has infinitely many rational approximations $p/q$ satisfying $|\\alpha - p/q| < 1/q^2$. Hurwitz's theorem (1891) sharpens this to $1/(\\sqrt{5}q^2)$ — optimal because the golden ratio $\\phi = (1+\\sqrt{5})/2$ is the worst-approximable irrational.\n\n**2. Lattice connections**: CRT solvability for non-coprime moduli reduces to lattice point counting — the system $x \\equiv a_i \\pmod{m_i}$ is solvable iff $\\gcd(m_i, m_j) \\mid (a_i - a_j)$ for all pairs, connecting number theory to the geometry of numbers.\n\n**3. Higher-dimensional extensions**: Dirichlet's method extends via Minkowski's theorem to simultaneous approximation: for $\\alpha_1, \\ldots, \\alpha_n \\in \\mathbb{R}$, there exist integers with $|\\alpha_i - p_i/q| < 1/q^{1+1/n}$ for all $i$.\n\n**4. Transcendence theory**: Roth's theorem (1955, Fields Medal) proves $|\\alpha - p/q| > c_\\varepsilon/q^{2+\\varepsilon}$ for algebraic $\\alpha$ — matching Dirichlet's bound up to $\\varepsilon$ and providing the sharpest known measure of irrationality for algebraic numbers.",
     "openQuestions": [
       "Can the pigeonhole-based proof be extended to simultaneous Diophantine approximation in Lean, formalizing Minkowski's lattice point theorem for convex bodies?",
       "What is the formal relationship between the Stern-Brocot mediant operation and the convergents of continued fraction expansions — can this be unified in Lean's Mathlib?",


### PR DESCRIPTION
Enrichment pass for 4 entries.

## bounded-prime-gaps
- Added 2 cross-references: `szemeredi-theorem`, `legendre-partial`

## buffons-needle
- Added 3 cross-references: `fundamental-theorem-calculus`, `central-limit-theorem`, `intermediate-value-theorem`

## cantor-diagonalization-oq-01 (Continuum Hypothesis)
- Expanded `implications` from 1 paragraph to 5 sections (independence, pluralism, forcing, cardinal arithmetic, analysis)
- Added 2 cross-references: `continuum-hypothesis`, `abel-ruffini`

## chinese-remainder-non-coprime-oq-04 (Dirichlet's Approximation)
- Fixed `implications` from invalid array format to proper string
- Expanded to 4 detailed sections: Diophantine approximation, lattice connections, Minkowski, Roth's theorem

🤖 Generated with [Claude Code](https://claude.com/claude-code)