### PR TITLE
Enrich erdos-365: add mathContext, references, cross-refs

### DIFF
--- a/src/data/proofs/erdos-365/annotations.json
+++ b/src/data/proofs/erdos-365/annotations.json
@@ -16,7 +16,10 @@
       "Pell equations",
       "consecutive integers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime factorization",
+      "divisibility"
+    ]
   },
   {
     "id": "ann-e365-powerful-def",
@@ -35,7 +38,11 @@
       "squarefull numbers",
       "Nat.Prime"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.Prime and prime divisibility in Lean",
+      "p^k | n notation and divisibility",
+      "basic number theory (squares, cubes)"
+    ]
   },
   {
     "id": "ann-e365-example-8-9",
@@ -54,7 +61,11 @@
       "decide",
       "computational verification"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsPowerful definition (ann-e365-powerful-def)",
+      "interval_cases tactic for case splitting on bounded naturals",
+      "decide tactic for decidable propositions"
+    ]
   },
   {
     "id": "ann-e365-pell",
@@ -73,7 +84,11 @@
       "continued fractions",
       "recurrence relation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsPowerful and IsConsecutivePowerfulPair definitions",
+      "Pell equation theory (existence and structure of solutions to x^2 - Dy^2 = 1)",
+      "continued fractions and fundamental solutions"
+    ]
   },
   {
     "id": "ann-e365-golomb",
@@ -92,7 +107,11 @@
       "native_decide",
       "perfect square test"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsConsecutivePowerfulPair definition",
+      "Question1 formulation (the square-requirement conjecture)",
+      "native_decide tactic for kernel-level computation"
+    ]
   },
   {
     "id": "ann-e365-walker",
@@ -111,7 +130,39 @@
       "infinite family",
       "non-square powerful numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsConsecutivePowerfulPair and IsPowerful definitions",
+      "Pell equation connection (ann-e365-pell)",
+      "Golomb's counterexample establishing that non-Pell pairs exist (ann-e365-golomb)",
+      "generalized Pell equations in quadratic number fields"
+    ]
+  },
+  {
+    "id": "ann-e365-counting",
+    "proofId": "erdos-365",
+    "range": {
+      "startLine": 148,
+      "endLine": 164
+    },
+    "type": "concept",
+    "title": "Question 2: Counting Consecutive Powerful Pairs",
+    "content": "**countingFunction x** computes P(x) = |{n <= x : IsConsecutivePowerfulPair n}| using Finset.filter over Finset.range. **Question2** formalizes the conjecture that P(x) = O((log x)^C) for some constants C > 0 and K > 0 -- i.e., the number of consecutive powerful pairs up to x grows at most polylogarithmically. This remains OPEN.",
+    "mathContext": "Each Pell-type equation a^3 x^2 - b^3 y^2 = 1 has solutions growing exponentially, contributing O(log x) pairs up to x. If only finitely many such equation families produce consecutive powerful pairs, P(x) = O((log x)^C). The formalization uses Finset.card with Finset.filter, making P(x) computable in principle but intractable for large x. The Real.log function from Mathlib.Data.Real.Basic provides the logarithm for the asymptotic bound.",
+    "significance": "key",
+    "relatedConcepts": [
+      "counting function",
+      "polylogarithmic bound",
+      "Finset.filter",
+      "Real.log",
+      "open problem"
+    ],
+    "prerequisites": [
+      "IsConsecutivePowerfulPair definition",
+      "Pell equation families and their solution counts (ann-e365-pell)",
+      "Finset.card and Finset.filter from Mathlib",
+      "Real.log from Mathlib.Data.Real.Basic",
+      "asymptotic notation (O-notation)"
+    ]
   },
   {
     "id": "ann-e365-summary",
@@ -130,6 +181,11 @@
       "partial resolution",
       "open problem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "question1_false axiom (ann-e365-golomb)",
+      "golomb_counterexample axiom (ann-e365-golomb)",
+      "walker_infinitely_many axiom (ann-e365-walker)",
+      "Question2 definition and countingFunction (counting section)"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-365/meta.json
+++ b/src/data/proofs/erdos-365/meta.json
@@ -23,14 +23,95 @@
     "erdosProblemStatus": "open",
     "axiomCount": 8,
     "lineCount": 189,
-    "assumptions": "8 axioms: square_is_powerful, cube_is_powerful, mahler_pell_gives_powerful, and 5 more. See Lean source for complete statements.",
+    "assumptions": [
+      "square_is_powerful: every perfect square k^2 (k >= 1) is powerful",
+      "cube_is_powerful: every perfect cube k^3 (k >= 1) is powerful",
+      "mahler_pell_gives_powerful: Pell solutions (x,y) of x^2 = 8y^2 + 1 yield consecutive powerful pairs (8y^2, 8y^2+1)",
+      "infinitely_many_pell: the Pell equation x^2 - 8y^2 = 1 has infinitely many solutions with strictly increasing y",
+      "question1_false: the assertion that every consecutive powerful pair has a square member is false",
+      "golomb_counterexample: (12167, 12168) is a consecutive powerful pair with neither element a perfect square",
+      "walker_infinitely_many: the equation 7^3 x^2 = 3^3 y^2 + 1 has infinitely many solutions with strictly increasing y",
+      "walker_gives_nonsquare: every solution to Walker's equation yields a consecutive powerful pair where neither element is a perfect square"
+    ],
+    "originalContributions": [
+      "Formal definition of powerful numbers via prime factorization (p^2 | n for all p | n) and alternative characterization (n = a^2 b^3)",
+      "Proved example_8_9: the pair (8, 9) is a consecutive powerful pair, verified by interval_cases and decide",
+      "Verified factorizations 12167 = 23^3 and 12168 = 2^3 * 3^2 * 13^2 by native_decide",
+      "Formalized the counting function P(x) and the open Question 2 as a Lean Prop",
+      "Summary theorem packaging Q1 refutation, Golomb counterexample, and Walker infinite family into a single conjunction"
+    ],
+    "references": [
+      {
+        "key": "Go70",
+        "authors": "Golomb, S. W.",
+        "title": "Powerful numbers",
+        "journal": "American Mathematical Monthly",
+        "year": 1970,
+        "pages": "848-855",
+        "note": "Introduced the term 'powerful number' and found the first counterexample to Q1"
+      },
+      {
+        "key": "Wa76",
+        "authors": "Walker, D. T.",
+        "title": "Consecutive integer pairs of powerful numbers and related Diophantine equations",
+        "journal": "The Fibonacci Quarterly",
+        "year": 1976,
+        "pages": "111-116",
+        "note": "Proved infinitely many non-Pell consecutive powerful pairs via 343x^2 = 27y^2 + 1"
+      },
+      {
+        "key": "Gu04",
+        "authors": "Guy, R. K.",
+        "title": "Unsolved Problems in Number Theory",
+        "year": 2004,
+        "note": "Problem B16: consecutive powerful numbers"
+      },
+      {
+        "key": "OEIS-A060355",
+        "authors": "OEIS Foundation",
+        "title": "A060355: n such that n and n+1 are both powerful",
+        "url": "https://oeis.org/A060355"
+      }
+    ],
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Erdős asked Mahler whether infinitely many consecutive powerful pairs exist. Mahler immediately answered yes, observing that solutions to the Pell equation x² - 8y² = 1 yield pairs (8y², 8y² + 1) where both terms are powerful. The fundamental solution (3, 1) gives the pair (8, 9). Erdős then posed the deeper question: must all such pairs arise from Pell equations? Equivalently, must either n or n+1 be a perfect square?\n\nGolomb (1970) answered this decisively: NO. He exhibited the counterexample 12167 = 23³ and 12168 = 2³·3²·13², both powerful with neither being a perfect square. Walker (1976) went further, showing that the generalized Pell equation 343x² = 27y² + 1 has infinitely many solutions, each producing a consecutive powerful pair where neither element is a square. This demonstrated that non-Pell counterexamples are not isolated curiosities but form infinite families.\n\nThe second part of the problem — whether the counting function P(x) = |{n ≤ x : n and n+1 both powerful}| satisfies P(x) = O((log x)^C) — remains open. Since most known pairs come from Pell-type equations, whose solution counts grow polylogarithmically, the bound is widely expected to hold. The problem connects to fundamental questions about the distribution of powerful numbers and the structure of Diophantine equations.",
     "problemStatement": "Q1: Do all pairs of consecutive powerful numbers n, n+1 come from Pell equations? Equivalently, must either n or n+1 be a square? Q2: Is the number of such n ≤ x bounded by (log x)^O(1)?",
-    "text": "Do all pairs of consecutive powerful numbers come from Pell equations? Must one be a square? Is the count O((log x)^O(1))?",
-    "proofStrategy": "The formalization defines powerful numbers via prime factorization (p² | n for all primes p | n), formalizes consecutive powerful pairs, and records the key results. Golomb's counterexample (12167, 12168) and Walker's infinite family via 7³x² = 3³y² + 1 are axiomatized. The Pell equation connection through Mahler's observation is formalized. Verified examples include the factorizations 12167 = 23³ and 12168 = 2³·3²·13² via native_decide.",
+    "text": "A powerful (or squarefull) number n satisfies p^2 | n for every prime p | n, equivalently n = a^2 b^3. These numbers have density ~c sqrt(x) up to x, but consecutive powerful pairs are far rarer. Mahler showed Pell equations produce infinitely many such pairs, e.g. (8, 9) from x^2 - 8y^2 = 1. Erdos asked: must every consecutive powerful pair arise from a Pell equation -- i.e., must one element be a perfect square? Golomb (1970) disproved this with the pair (12167, 12168) = (23^3, 2^3 * 3^2 * 13^2), and Walker (1976) showed infinitely many non-Pell pairs exist via the generalized equation 343x^2 = 27y^2 + 1. The counting question -- whether the number of pairs up to x is O((log x)^C) -- remains open.",
+    "proofStrategy": {
+      "overview": "The formalization proceeds in seven parts, building from definitions through proved examples to axiomatized deep results, culminating in a summary theorem that packages the resolved portion of the problem.",
+      "parts": [
+        {
+          "name": "Part I: Powerful Numbers",
+          "description": "Defines IsPowerful via prime factorization (p^2 | n for all primes p | n) and the equivalent characterization IsPowerfulAlt (n = a^2 b^3). Axiomatizes that all perfect squares and cubes are powerful."
+        },
+        {
+          "name": "Part II: Consecutive Powerful Pairs",
+          "description": "Defines IsConsecutivePowerfulPair and proves the smallest example (8, 9) by enumerating prime divisors with interval_cases and verifying divisibility conditions with decide."
+        },
+        {
+          "name": "Part III: Pell Equation Connection",
+          "description": "Formalizes IsPellSolution and axiomatizes Mahler's observation that solutions to x^2 = 8y^2 + 1 yield consecutive powerful pairs, together with the existence of infinitely many such solutions."
+        },
+        {
+          "name": "Part IV: Question 1 Refutation",
+          "description": "Formalizes Question1 as a Prop and axiomatizes its negation. Records Golomb's specific counterexample (12167, 12168) with verified factorizations 12167 = 23^3 and 12168 = 2^3 * 3^2 * 13^2 via native_decide."
+        },
+        {
+          "name": "Part V: Walker's Infinite Family",
+          "description": "Formalizes WalkerEquation (7^3 x^2 = 3^3 y^2 + 1) and axiomatizes both the existence of infinitely many solutions and the fact that each solution yields a non-square consecutive powerful pair."
+        },
+        {
+          "name": "Part VI: Question 2",
+          "description": "Defines the counting function P(x) as a Finset.card computation and formalizes the open Question2 as the existence of constants C, K such that P(x) <= K (log x)^C."
+        },
+        {
+          "name": "Part VII: Summary",
+          "description": "The theorem erdos_365_summary packages three results into a conjunction: negation of Question1, Golomb's counterexample, and Walker's infinite family, using the axioms directly."
+        }
+      ]
+    },
     "keyInsights": [
       "Q1 is FALSE: Golomb found 12167 = 23³, 12168 = 2³·3²·13² (neither square)",
       "Walker: infinitely many counterexamples via 7³x² = 3³y² + 1",
@@ -39,8 +120,10 @@
       "OEIS A060355 lists consecutive powerful pairs"
     ],
     "prerequisites": [
-      "Combinatorics and number theory",
-      "Number theory (primes, divisibility)"
+      "Prime factorization and divisibility (p^k | n conditions)",
+      "Pell equations and continued fractions (x^2 - Dy^2 = 1)",
+      "Elementary number theory (perfect squares, cubes, squarefull numbers)",
+      "Basic asymptotic notation (O, polylogarithmic bounds)"
     ]
   },
   "sections": [
@@ -49,54 +132,65 @@
       "title": "Powerful Numbers",
       "startLine": 40,
       "endLine": 58,
-      "summary": "Definition of powerful numbers and basic axioms about squares and cubes"
+      "summary": "Definition of powerful numbers and basic axioms about squares and cubes",
+      "mathContext": "A powerful (squarefull) number n satisfies p^2 | n for every prime p dividing n. Equivalently, n = a^2 b^3 for some positive integers a, b. The equivalence follows by writing each prime exponent e_i = 2q_i + 3r_i with r_i in {0,1}. Powerful numbers up to x number approximately c * sqrt(x) where c = zeta(3/2)/zeta(3) ~ 2.17. The axioms square_is_powerful and cube_is_powerful avoid detailed factorization arithmetic: for k^m with m >= 2, every prime in the factorization of k appears with exponent at least m >= 2."
     },
     {
       "id": "consecutive",
       "title": "Consecutive Powerful Numbers",
       "startLine": 59,
       "endLine": 78,
-      "summary": "Definition of consecutive powerful pairs and proved example (8, 9)"
+      "summary": "Definition of consecutive powerful pairs and proved example (8, 9)",
+      "mathContext": "The pair (8, 9) = (2^3, 3^2) is the smallest consecutive powerful pair. It arises from the fundamental Pell solution (3, 1) to x^2 - 8y^2 = 1 since 8 * 1^2 = 8 and 3^2 = 9 = 8 + 1. The Lean proof uses interval_cases to enumerate primes up to 8 and 9, then checks p^2 | n for each prime divisor p computationally with decide. The next Pell-derived pair is (288, 289) = (2^5 * 3^2, 17^2) from the solution (17, 6)."
     },
     {
       "id": "pell",
       "title": "Pell Equation Connection",
       "startLine": 79,
       "endLine": 100,
-      "summary": "Mahler's observation and infinitely many Pell solutions"
+      "summary": "Mahler's observation and infinitely many Pell solutions",
+      "mathContext": "Mahler's key insight: if x^2 = 8y^2 + 1, then 8y^2 = x^2 - 1 = (x-1)(x+1). Since x must be odd (x^2 = 1 mod 8), both x-1 and x+1 are even. The factorization gives 8y^2 enough prime-power structure: 8y^2 = 2^3 * y^2 is automatically powerful (cube times square). Meanwhile x^2 = 8y^2 + 1 is a perfect square, hence powerful. The Pell equation x^2 - 8y^2 = 1 has fundamental solution (3, 1) and generates all solutions via the recurrence (x_{k+1}, y_{k+1}) = (3x_k + 8y_k, x_k + 3y_k), producing pairs at y = 1, 6, 35, 204, ..."
     },
     {
       "id": "question1",
       "title": "Question 1 - Square Requirement",
       "startLine": 101,
       "endLine": 126,
-      "summary": "Q1 is FALSE: Golomb's counterexample with verified factorizations"
+      "summary": "Q1 is FALSE: Golomb's counterexample with verified factorizations",
+      "mathContext": "Golomb's 1970 paper in the American Mathematical Monthly introduced the term 'powerful number' and exhibited the pair (12167, 12168) where 12167 = 23^3 is a perfect cube and 12168 = 2^3 * 3^2 * 13^2 has all prime exponents >= 2. Neither is a perfect square: sqrt(12167) ~ 110.30 and sqrt(12168) ~ 110.31. The factorizations are computationally verified in Lean via native_decide. This answered Erdos's question decisively: not all consecutive powerful pairs require a square member."
     },
     {
       "id": "walker",
       "title": "Walker's Infinite Family",
       "startLine": 127,
       "endLine": 147,
-      "summary": "Infinitely many non-Pell counterexamples via Walker's equation"
+      "summary": "Infinitely many non-Pell counterexamples via Walker's equation",
+      "mathContext": "Walker (1976) showed that the generalized Pell equation 7^3 x^2 = 3^3 y^2 + 1 (i.e. 343x^2 = 27y^2 + 1) has infinitely many positive integer solutions. Each solution (x, y) gives the consecutive powerful pair (27y^2, 343x^2) = (3^3 * y^2, 7^3 * x^2), where both elements are products of a cube and a square and hence powerful, but neither is a perfect square (since 3^3 and 7^3 are not squares). The equation is a Pell-like equation in the ring Z[sqrt(21)], and its solutions grow exponentially."
     },
     {
       "id": "counting",
       "title": "Question 2 - Counting",
       "startLine": 148,
       "endLine": 164,
-      "summary": "Open question about polylogarithmic bound on P(x)"
+      "summary": "Open question about polylogarithmic bound on P(x)",
+      "mathContext": "Let P(x) count pairs (n, n+1) with n <= x where both are powerful. Each family of Pell-type equations a^3 x^2 - b^3 y^2 = 1 contributes O(log x) pairs up to x (since Pell solutions grow exponentially). If only finitely many such equation families produce consecutive powerful pairs, then P(x) = O((log x)^C) for some constant C depending on the number of families. The formalization defines P(x) using Finset.filter over Finset.range and expresses Question2 as the existence of constants C > 0, K > 0 bounding P(x) by K * (log x)^C."
     },
     {
       "id": "summary",
       "title": "Summary",
       "startLine": 165,
       "endLine": 189,
-      "summary": "Three-part conjunction: Q1 false, Golomb counterexample, Walker family"
+      "summary": "Three-part conjunction: Q1 false, Golomb counterexample, Walker family",
+      "mathContext": "The summary theorem erdos_365_summary combines the complete resolution of Q1 into a single statement: the negation of Question1, Golomb's explicit counterexample, and Walker's infinite family. This captures three levels of generality -- qualitative (Q1 fails), concrete (specific counterexample), and structural (infinitely many counterexamples). Question 2 is deliberately excluded since it remains open. The Lean proof is a direct tuple construction from the three axioms."
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem #365 is partially resolved. Q1 (must one be a square?) is FALSE — Golomb found the counterexample (12167, 12168) and Walker proved infinitely many exist. Q2 (polylogarithmic count) remains OPEN but is expected to be true from Pell equation theory.",
-    "implications": "Consecutive powerful pairs have rich structure beyond simple Pell equations. The variety of Pell-like equations (7³x² = 3³y² + 1, etc.) contribute additional pairs, but the counting question remains unresolved.",
+    "implications": {
+      "structuralInsight": "The resolution of Q1 reveals that the arithmetic of consecutive powerful numbers is richer than the Pell equation framework suggests. While Mahler's construction via x^2 - 8y^2 = 1 produces pairs where one element is always a perfect square, Walker's generalized equation 7^3 x^2 = 3^3 y^2 + 1 demonstrates that the structure of powerful pairs extends into a broader family of Diophantine equations of the form a^3 x^2 - b^3 y^2 = 1.",
+      "connectionToDistribution": "The counting question (Q2) connects to deep problems in analytic number theory. The density of powerful numbers up to x is asymptotically c * sqrt(x), so the probability that a random n is powerful is ~c / sqrt(n). Heuristically, consecutive powerful pairs should have density ~c^2 / n, giving P(x) ~ c^2 log(x), consistent with the conjectured polylogarithmic bound. Making this rigorous requires understanding correlations between the powerful-number property at n and n+1.",
+      "broaderContext": "This problem belongs to a rich cluster of Erdos problems about powerful numbers: Problem #364 asks about three consecutive powerful numbers (still open), Problem #366 asks about consecutive k-full numbers for k >= 3, and Problems #935-#943 explore arithmetic structure (progressions, sums, distribution) within the powerful numbers. The Pell equation machinery developed here reappears in several of these related problems."
+    },
     "openQuestions": [
       "Is P(x) = O((log x)^C) for some constant C?",
       "What is the exact asymptotic count of consecutive powerful pairs?",
@@ -121,17 +215,37 @@
     {
       "targetId": "erdos-137",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+      "description": "Problem #137 asks whether the product of k >= 3 consecutive integers can be powerful. While #365 studies individual powerful numbers that happen to be consecutive, #137 studies when a product of consecutive integers has no prime factor appearing exactly once. Both problems illuminate how the powerful-number property interacts with the additive structure of consecutive integers."
+    },
+    {
+      "targetId": "erdos-364",
+      "relationship": "extension",
+      "description": "Problem #364 asks the natural successor question: can three consecutive integers all be powerful? The quadruple case is impossible (proved), but the triple case remains open. Problem #365's Pell equation machinery is directly relevant -- Pell-type constructions produce pairs but not triples, suggesting that triples, if they exist, would require fundamentally new methods."
     },
     {
       "targetId": "erdos-366",
-      "relationship": "related",
-      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+      "relationship": "generalization",
+      "description": "Problem #366 generalizes from 2-full (powerful) to k-full consecutive pairs: is there a powerful n with n+1 being 3-full (cubeful)? The pair (8, 9) = (2^3, 3^2) and Golomb's (12167, 12168) = (23^3, 2^3*3^2*13^2) are related, but neither has a 3-full member followed by a 2-full member. The problem asks about the asymmetry between higher fullness levels in consecutive pairs."
     },
     {
       "targetId": "erdos-367",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, powerful-numbers"
+      "description": "Problem #367 studies B_2(m), the 2-full (powerful) part of m, asking whether the product of B_2(m) over k consecutive values of m is bounded by n^{2+o(1)}. This connects to #365's counting question: the distribution of powerful parts among consecutive integers constrains how often both n and n+1 can be entirely powerful."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "foundation",
+      "description": "The Pell equation entry formalizes the theory of x^2 - Dy^2 = 1 that underlies Mahler's construction of consecutive powerful pairs. The fundamental solution and recurrence for D = 8 produce the infinite family of Pell-derived pairs (8y^2, 8y^2 + 1), and Walker's generalization extends this to Pell-like equations in quadratic number fields."
+    },
+    {
+      "targetId": "erdos-942",
+      "relationship": "related",
+      "description": "Problem #942 counts powerful numbers in the interval [n^2, (n+1)^2). Both problems concern the fine distribution of powerful numbers in short intervals: #365 asks about the narrowest possible interval (length 1, consecutive integers), while #942 asks about intervals of length ~2n between consecutive squares."
+    },
+    {
+      "targetId": "erdos-936",
+      "relationship": "thematic",
+      "description": "Problem #936 asks whether 2^n +/- 1 and n! +/- 1 are powerful for only finitely many n, conditionally resolved via the ABC conjecture. Both problems study how powerful numbers interact with structured sequences (consecutive integers in #365, exponential/factorial sequences in #936), and the ABC conjecture is relevant to both counting questions."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for erdos-365 (Erdős Problem #365: Powerful Numbers in Short Intervals).

**Quality improvements:**
- Added mathContext to all 7 sections with precise mathematical descriptions
- Deepened proofStrategy with 7-part architecture matching Lean file
- Detailed all 8 axioms in assumptions field with complete descriptions
- Added originalContributions array
- Added 4 references: Golomb 1970, Walker 1976, Guy 2004, OEIS A060355
- Expanded cross-references from 3 generic to 7 substantive (erdos-137, erdos-364, erdos-366, erdos-367, pell-equation, erdos-942, erdos-936)
- Added prerequisites to all 8 annotations
- Added new annotation covering counting section (lines 148-164)
- Expanded implications with structural, distributional, and broader themes