### PR TITLE
Enrich erdos-1050: fix leanFile metadata

### DIFF
--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -223,11 +223,12 @@
   "leanFile": {
     "imports": [],
     "opens": [],
-    "namespace": null,
+    "namespace": "",
     "lineCount": 1,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "mainTheorems": []
   },
   "references": [
     {


### PR DESCRIPTION
Enrichment pass for erdos-1050 (quality 100, pass 2).

Minor metadata fixes:
- `leanFile.namespace`: `null` → `""` (Lean file is empty stub)
- Added empty `mainTheorems` array for schema consistency