### PR TITLE
Enrich erdos-36: fix leanFile schema

### DIFF
--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -77,11 +77,9 @@
   },
   "leanFile": {
     "lineCount": 91,
-    "structureCount": 0,
     "axiomCount": 6,
     "theoremCount": 0,
-    "lemmaCount": 0,
-    "defCount": 3,
+    "definitionCount": 3,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Int.Basic",
@@ -90,7 +88,8 @@
       "Mathlib.Tactic"
     ],
     "opens": [],
-    "namespace": null
+    "namespace": "",
+    "mainTheorems": []
   },
   "sections": [
     {


### PR DESCRIPTION
Enrichment pass for erdos-36 (quality 100, pass 2).

- Fixed `leanFile.namespace`: `null` → `""`
- Normalized field names: `defCount`→`definitionCount`, removed non-standard `structureCount`/`lemmaCount`
- Added empty `mainTheorems` array for schema consistency