### PR TITLE
Enrich erdos-40: add mainTheorems, fix namespace

### DIFF
--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -191,10 +191,27 @@
       "Mathlib.Tactic"
     ],
     "opens": [],
-    "namespace": null,
+    "namespace": "",
     "lineCount": 125,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "mainTheorems": [
+      {
+        "name": "repUnbounded_iff",
+        "type": "equivalence",
+        "description": "Characterizes unbounded representation: ∀ B, ∃ n, repCount A n > B ↔ ¬∃ B, ∀ n, repCount A n ≤ B"
+      },
+      {
+        "name": "bounded_rep_not_unbounded",
+        "type": "original",
+        "description": "If repCount is bounded by B for all n, then the representation function is not unbounded"
+      },
+      {
+        "name": "basis2_iff",
+        "type": "equivalence",
+        "description": "Equivalence of two formulations of asymptotic basis of order 2"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Enrichment pass for erdos-40 (quality 100, pass 2).

- Added `mainTheorems` array with 3 proved theorems: `repUnbounded_iff`, `bounded_rep_not_unbounded`, `basis2_iff`
- Fixed `leanFile.namespace`: `null` → `""`