### PR TITLE
Research: erdos-1099-oq-01 — Prove sortedDivisors_two_pow (2→1 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -502,17 +502,47 @@ Sorted divisors of 2^k = [1, 2, 4, ..., 2^k] by sort uniqueness.
 All consecutive divisor ratios = 2, so h_α(2^k) = k·(2-1)^α = k.
 -/
 
+/-- List.range n is strictly sorted. -/
+private theorem list_range_pairwise_lt : ∀ (n : ℕ), (List.range n).Pairwise (· < ·) := by
+  intro n; induction n with
+  | zero => exact List.Pairwise.nil
+  | succ n ih =>
+    rw [List.range_succ, List.pairwise_append]
+    refine ⟨ih, ?_, fun a ha b hb => ?_⟩
+    · exact .cons (by simp) .nil
+    · simp only [List.mem_range] at ha
+      simp only [List.mem_singleton] at hb
+      subst hb; exact ha
+
 /-- Sorted divisors of 2^k are [2^0, 2^1, ..., 2^k].
-Proof: both lists are sorted permutations of the same multiset. -/
+Both lists are sorted, nodup, with the same elements → equal. -/
 private theorem sortedDivisors_two_pow (k : ℕ) :
     sortedDivisors (2 ^ k) = (List.range (k + 1)).map (HPow.hPow 2) := by
-  sorry -- sort uniqueness via Nat.divisors_prime_pow + Perm.eq_of_pairwise
+  have hnd₁ := sortedDivisors_nodup (2 ^ k)
+  have hnd₂ : ((List.range (k + 1)).map (HPow.hPow 2)).Nodup := by
+    apply List.Nodup.map
+    · exact Nat.pow_right_injective (by norm_num : 1 < 2)
+    · exact List.nodup_range
+  have hmem : ∀ x, x ∈ sortedDivisors (2 ^ k) ↔
+      x ∈ (List.range (k + 1)).map (HPow.hPow 2) := by
+    intro x
+    simp only [sortedDivisors, Finset.mem_sort,
+               Nat.divisors_prime_pow (by norm_num : Nat.Prime 2),
+               Finset.mem_map, Function.Embedding.coeFn_mk, Finset.mem_range,
+               List.mem_map, List.mem_range]
+  have hperm := (List.perm_ext_iff_of_nodup hnd₁ hnd₂).mpr hmem
+  have hs₂ : ((List.range (k + 1)).map (HPow.hPow 2)).Pairwise (· ≤ ·) := by
+    rw [List.pairwise_map]
+    exact (list_range_pairwise_lt (k + 1)).imp
+      (fun hab => Nat.pow_le_pow_right (by omega) (le_of_lt hab))
+  exact hperm.eq_of_pairwise (fun _ _ _ _ h1 h2 => le_antisymm h1 h2)
+    (sortedDivisors_sorted (2 ^ k)) hs₂
 
 /-- The consecutive divisor ratios of 2^k consist of k copies of 2.
 Each ratio d_{i+1}/d_i = 2^(i+1)/2^i = 2. -/
 private theorem divisorRatios_two_pow (k : ℕ) :
     divisorRatios (2 ^ k) = List.replicate k (2 : ℚ) := by
-  sorry -- via sortedDivisors_two_pow + zipWith computation
+  sorry -- Monadic ℕ→ℚ cast normalization blocks direct proof; sortedDivisors_two_pow proved above
 
 private theorem flatMap_singleton_eq_map (f : ℚ → ℝ) (l : List ℚ) :
     l.flatMap (fun a => [f a]) = l.map f := by

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -60,9 +60,9 @@
       "Examples for primes, powers of 2, and highly composite numbers"
     ],
     "axiomCount": 2,
-    "sorries": 2,
+    "sorries": 1,
     "lineCount": 575,
-    "assumptions": "2 axioms: vose_bounded_sequence, vose_liminf_bounded (deep Vose 1984 construction). power_of_two_h_alpha converted from axiom to theorem. 2 sorries in infrastructure helpers (sortedDivisors_two_pow, divisorRatios_two_pow) pending Lean4 API iteration."
+    "assumptions": "2 axioms: vose_bounded_sequence, vose_liminf_bounded (deep Vose 1984 construction). power_of_two_h_alpha converted from axiom to theorem. sortedDivisors_two_pow proved via sorted permutation uniqueness. 1 sorry: divisorRatios_two_pow (blocked by Lean4 monadic ℕ→ℚ cast normalization)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1099** was posed by Erdős in 1981 as part of his study of divisor structure. The problem asks about the regularity of divisor gaps: can we find integers whose consecutive divisor ratios are all close to 1?\n\n**Historical Development:**\n- **1981 (Erdős [Er81h]):** Posed the problem, noting that n! and lcm{1,...,n} seem like good candidates.\n- **1984 (Vose [Vo84]):** Resolved the problem affirmatively by constructing a specific sequence with bounded h_α.\n\n**Key Insight:** The question is about how \"smooth\" the divisor structure of integers can be. While primes have terrible divisor gaps (ratio = p), and even powers of 2 grow linearly in h_α, Vose showed there exist numbers with much smoother divisor distributions.",

--- a/src/data/research/problems/erdos-1099-oq-01.json
+++ b/src/data/research/problems/erdos-1099-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: power_of_two_h_alpha converted from axiom to theorem (2 sorry helpers pending). 2 axioms remain (Vose 1984). sum_divisor_ratios_lower_bound removed (false bound).",
+    "progressSummary": "PROGRESS: sortedDivisors_two_pow proved (2→1 sorries). divisorRatios_two_pow blocked by Lean4 monadic cast normalization.",
     "builtItems": [
       "17 new infrastructure theorems for sorted divisor properties",
       "first_divisor_is_one theorem (was axiom)",
@@ -46,7 +46,9 @@
       "Fixed List.mem_map.mpr → simp [List.mem_map] + apply List.single_le_sum pattern",
       "power_of_two_h_alpha theorem (was axiom): h_alpha α (2^k) = k",
       "flatMap_singleton_eq_map: normalize monadic flatMap to List.map",
-      "list_bind_pure_ratCast: bridge monad do/pure to explicit map for ℚ→ℝ cast"
+      "list_bind_pure_ratCast: bridge monad do/pure to explicit map for ℚ→ℝ cast",
+      "sortedDivisors_two_pow theorem: sorted divisors of 2^k = [2^0,...,2^k] via Nat.divisors_prime_pow + sorted permutation uniqueness",
+      "list_range_pairwise_lt: List.range n is Pairwise (· < ·)"
     ],
     "insights": [
       "divisorRatios had a critical bug: computed d_i/d_{i+1} instead of d_{i+1}/d_i",
@@ -59,14 +61,15 @@
       "sum_divisor_ratios_lower_bound axiom was FALSE: claimed Σ(d_{i+1}/dᵢ) > τ(n) + log(n) but correct bound is τ(n)-1+log(n) (off by 1 because there are τ-1 ratios, not τ). Counterexample: n=2, sum=2 but τ+log(2)≈2.69. Removed the false axiom.",
       "Lean 4 v4.26.0 has List.map normalization issues: map f l normalizes to do/flatMap form, breaking List.mem_map.mpr and List.single_le_sum proofs",
       "sum_divisor_ratios_lower_bound was FALSE: fails for n=2 (2 > 2+ln2≈2.69), n=6 (5.5 > 4+ln6≈5.79)",
-      "Lean4 monad elaboration creates do/pure form when composing List.map with casts — need flatMap_singleton helper to normalize"
+      "Lean4 monad elaboration creates do/pure form when composing List.map with casts — need flatMap_singleton helper to normalize",
+      "sortedDivisors_two_pow proved via List.perm_ext_iff_of_nodup + Perm.eq_of_pairwise with explicit antisymmetry",
+      "divisorRatios_two_pow blocked by Lean4 monadic normalization: zipWith with ℕ→ℚ cast creates do/pure form that breaks type matching with structural recursion helper"
     ],
     "mathlibGaps": [
       "No direct Finset.sort getLast = max lemma"
     ],
     "nextSteps": [
-      "Fill in sortedDivisors_two_pow sorry via Perm.eq_of_pairwise + Nat.divisors_prime_pow",
-      "Fill in divisorRatios_two_pow sorry via sortedDivisors_two_pow + zipWith computation"
+      "Prove divisorRatios_two_pow by working around monadic normalization (use native_decide for small k + structural induction, or restate zipWith_div_doubles to match normalized types)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Prove `sortedDivisors_two_pow`: sorted divisors of 2^k = [2^0, 2^1, ..., 2^k]
- Uses `Nat.divisors_prime_pow`, `List.perm_ext_iff_of_nodup`, and sorted permutation uniqueness
- Adds helper `list_range_pairwise_lt`: List.range n is Pairwise (· < ·)
- Reduces sorry count from 2 to 1 (remaining: `divisorRatios_two_pow`, blocked by Lean4 monadic ℕ→ℚ cast normalization)

## Test plan
- [x] Docker build passes (new proofs compile; pre-existing errors on main unchanged)
- [ ] `pnpm build` gallery integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)