### PR TITLE
Gallery enrichment: sections + mainTheorems for 170 entries

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -465,5 +465,13 @@
       "venue": "Springer (edited by V.B. Alekseev; based on Arnold's 1963 lectures to Moscow high school students)",
       "note": "Presents Arnold's remarkable topological proof of Abel-Ruffini via monodromy of polynomial roots: as coefficients vary along loops, roots braid with monodromy group S₅, which is not solvable — so no radical expression (whose monodromy is always solvable) can represent the roots. Uses only continuity and fundamental groups, no abstract algebra. Originally presented to high school students, demonstrating the quintic's impossibility is fundamentally a topological fact about branched coverings"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "exists_not_solvable_by_rad",
+      "type": "core",
+      "description": "There exists a polynomial of degree >= 5 whose roots cannot be expressed by radicals",
+      "leanType": "exists (p : Polynomial F), 5 <= p.natDegree and exists alpha, aeval alpha p = 0 and not (IsSolvableByRad F alpha)"
+    }
   ]
 }

--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -291,5 +291,19 @@
     "substantiveTheoremCount": 3,
     "mathlibWrappers": 5,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "amgm",
+      "type": "core",
+      "description": "AM-GM: arithmetic mean >= geometric mean for non-negative reals",
+      "leanType": "(a : Fin n -> R) -> (forall i, 0 <= a i) -> (sum a / n) >= (prod a)^(1/n)"
+    },
+    {
+      "name": "amgm_equality",
+      "type": "key",
+      "description": "Equality holds iff all values are equal",
+      "leanType": "AM a = GM a <-> forall i j, a i = a j"
+    }
+  ]
 }

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -298,5 +298,19 @@
       "citation": "De Morgan, A., A Budget of Paradoxes, Longmans, Green & Co. (1872, posthumous; 2nd ed. 1915). Catalogues angle trisection and circle squaring claims from amateur mathematicians, documenting the persistence of these problems long after their impossibility was proved.",
       "type": "book"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "angle_trisection_impossible",
+      "type": "core",
+      "description": "The general angle cannot be trisected by compass and straightedge",
+      "leanType": "not (forall theta, exists constructible_trisection theta)"
+    },
+    {
+      "name": "sixty_degree_not_trisectible",
+      "type": "key",
+      "description": "60 degrees cannot be trisected: cos(20 deg) is not constructible",
+      "leanType": "not (Constructible (Real.cos (20 * pi / 180)))"
+    }
   ]
 }

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -347,5 +347,19 @@
       "venue": "https://www.cs.ru.nl/~freek/100/",
       "note": "The definitive list of 100 well-known mathematical theorems and their formalization status across proof assistants. The area of a circle is #9. This formalization contributes to the Lean 4 / Mathlib column"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "area_circle",
+      "type": "core",
+      "description": "Area of a circle of radius r is pi*r^2",
+      "leanType": "(r : R) -> 0 <= r -> area (circle r) = pi * r^2"
+    },
+    {
+      "name": "circumference_circle",
+      "type": "key",
+      "description": "Circumference of a circle of radius r is 2*pi*r",
+      "leanType": "(r : R) -> 0 <= r -> circumference (circle r) = 2 * pi * r"
+    }
   ]
 }

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -249,5 +249,13 @@
       "venue": "American Scientist, Vol. 94, No. 3, pp. 200-205",
       "note": "Investigates the historical accuracy of the Gauss schoolboy anecdote, tracing over 100 versions of the story and showing how details have been embellished over two centuries"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "arithmetic_series_sum",
+      "type": "core",
+      "description": "Sum of first n natural numbers equals n*(n+1)/2 (Gauss formula)",
+      "leanType": "(n : Nat) -> sum k in range (n+1), k = n * (n+1) / 2"
+    }
   ]
 }

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -267,5 +267,13 @@
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "ballot_problem",
+      "type": "core",
+      "description": "If candidate A gets a votes and B gets b votes with a > b, probability A leads throughout is (a-b)/(a+b)",
+      "leanType": "a > b -> P(A leads throughout) = (a - b) / (a + b)"
+    }
+  ]
 }

--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -144,6 +144,30 @@
       "endLine": 185,
       "summary": "Proved: irrationality conjecture implies Rivoal and Zudilin; transcendence conjecture recovers all known results.",
       "mathContext": "The implication landscape: $\\forall k,\\, \\zeta(2k+1) \\notin \\mathbb{Q}$ implies Rivoal's 'infinitely many irrational' and Zudilin's 'one of $\\{\\zeta(5),\\zeta(7),\\zeta(9),\\zeta(11)\\}$ irrational'. The stronger transcendence conjecture $\\forall k,\\, \\zeta(2k+1) \\notin \\overline{\\mathbb{Q}}$ recovers ALL known results as corollaries — a strong consistency check."
+    },
+    {
+      "id": "odd-conjectures",
+      "title": "Odd Zeta Transcendence and Irrationality Conjectures",
+      "startLine": 186,
+      "endLine": 196,
+      "summary": "Defines $\text{odd\\_zeta\\_transcendence\\_conjecture}$: all $\\zeta(2k+1)$ for $k \\geq 1$ are transcendental. Defines the weaker $\text{odd\\_zeta\\_irrationality\\_conjecture}$: all odd zeta values are irrational. Notes that no specific odd zeta value beyond $\\zeta(3)$ has been proved irrational.",
+      "mathContext": "Transcendence conjecture: $\\zeta(2k+1) \\in \\overline{\\mathbb{Q}}^c$ for all $k \\geq 1$. Irrationality conjecture: $\\zeta(2k+1) \notin \\mathbb{Q}$ for all $k \\geq 1$."
+    },
+    {
+      "id": "structural-relationships",
+      "title": "Structural Relationships Between Conjectures",
+      "startLine": 197,
+      "endLine": 219,
+      "summary": "Proves the logical chain: transcendence conjecture implies irrationality conjecture, which implies Apery's theorem ($\\zeta(3)$ irrational) as the $k=1$ case, and further implies joint irrationality of $\\zeta(3)$ and $\\zeta(5)$.",
+      "mathContext": "Logical hierarchy: $\text{Transcendental}(\\zeta(2k+1)) \\Rightarrow \text{Irrational}(\\zeta(2k+1)) \\Rightarrow \text{Irrational}(\\zeta(3)) \\wedge \text{Irrational}(\\zeta(5))$."
+    },
+    {
+      "id": "even-odd-divide",
+      "title": "The Even-Odd Divide and Problem Status",
+      "startLine": 220,
+      "endLine": 274,
+      "summary": "Defines $\text{even\\_zeta\\_rational\\_multiple}$: $\\zeta(2k) = q \\cdot \\pi^{2k}$ for rational $q$. Verifies transcendence of $\\zeta(2)$ and $\\zeta(4)$ from axiomatized Lindemann. Proves the arithmetic hierarchy: $\\zeta(2)$ transcendental, $\\zeta(3)$ irrational (Apery), $\\zeta(5)$ status unknown.",
+      "mathContext": "Even-odd dichotomy: $\\zeta(2k) = c_k \\pi^{2k}$ (transcendental via Lindemann) vs. $\\zeta(2k+1)$ with no known closed form. Arithmetic hierarchy: transcendental \\supset irrational \\supset algebraic."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -422,5 +422,19 @@
         "leanType": "(k : ℕ) → k ≠ 0 → HasSum (fun n : ℕ => 1 / (↑n : ℝ) ^ (2 * k)) ((-1)^(k+1) * 2^(2*k-1) * π^(2*k) * bernoulli (2*k) / (2*k).factorial)"
       }
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "basel_problem",
+      "type": "core",
+      "description": "Sum of reciprocal squares: sum 1/n^2 = pi^2/6 (Euler 1734)",
+      "leanType": "HasSum (fun n => 1 / (n+1)^2) (pi^2 / 6)"
+    },
+    {
+      "name": "zeta_two",
+      "type": "key",
+      "description": "The Riemann zeta function at 2 equals pi^2/6",
+      "leanType": "riemannZeta 2 = pi^2 / 6"
+    }
+  ]
 }

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -233,5 +233,13 @@
       "venue": "Proceedings of the Japan Academy 28(4), 177–181",
       "note": "Strengthened Bertrand: for n > 25, there is always a prime between n and 6n/5, reducing the gap ratio from 2 to 1.2"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "bertrands_postulate",
+      "type": "core",
+      "description": "For every n >= 1, there exists a prime p with n < p <= 2n",
+      "leanType": "(n : Nat) -> 1 <= n -> exists p, Nat.Prime p and n < p and p <= 2*n"
+    }
   ]
 }

--- a/src/data/proofs/bezout-identity/meta.json
+++ b/src/data/proofs/bezout-identity/meta.json
@@ -274,5 +274,13 @@
       "venue": "Oxford University Press, 6th edition",
       "note": "Standard reference with multiple proofs of Bézout's identity via the Euclidean algorithm"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "bezout_identity",
+      "type": "core",
+      "description": "For integers a, b, there exist x, y with ax + by = gcd(a,b)",
+      "leanType": "(a b : Int) -> exists x y : Int, a * x + b * y = Int.gcd a b"
+    }
   ]
 }

--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -326,5 +326,25 @@
     "lemmaCount": 0,
     "defCount": 0,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "binomial_theorem",
+      "type": "core",
+      "description": "(x+y)^n = sum_k C(n,k) * x^k * y^(n-k) for commutative semirings",
+      "leanType": "[CommSemiring R] -> (x y : R) -> (n : Nat) -> (x + y)^n = sum k in range (n+1), choose n k * x^k * y^(n-k)"
+    },
+    {
+      "name": "sum_binomial_coefficients",
+      "type": "key",
+      "description": "Sum of binomial coefficients: sum C(n,k) = 2^n",
+      "leanType": "(n : Nat) -> sum k in range (n+1), choose n k = 2^n"
+    },
+    {
+      "name": "alternating_sum_binomial",
+      "type": "key",
+      "description": "Alternating sum for n >= 1: sum (-1)^k C(n,k) = 0",
+      "leanType": "(n : Nat) -> 0 < n -> sum k in range (n+1), (-1)^k * choose n k = 0"
+    }
+  ]
 }

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -796,5 +796,13 @@
       "venue": "Inventiones Mathematicae 195(1), 1–277",
       "note": "Proved the other divisibility of the Iwasawa Main Conjecture for elliptic curves with good ordinary reduction, completing the p-adic approach to BSD rank 0/1"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "bsd_conjecture",
+      "type": "core",
+      "description": "Millennium Prize: rank of E(Q) equals order of vanishing of L(E,s) at s=1",
+      "leanType": "EllipticCurve E -> rank E(Q) = ord_{s=1} L(E,s)"
+    }
   ]
 }

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -291,5 +291,13 @@
       "venue": "Prentice Hall, Chapter 15",
       "note": "Historical context: traces the birthday problem from von Mises (1939) through its popularization by mathematical recreationists and its unexpected applications in cryptography and DNA forensics"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "birthday_probability",
+      "type": "core",
+      "description": "Probability that at least 2 of n people share a birthday in a 365-day year",
+      "leanType": "P(collision among n) = 1 - prod k in range n, (365 - k) / 365"
+    }
   ]
 }

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -263,5 +263,13 @@
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 6
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "borsuk_ulam",
+      "type": "core",
+      "description": "For any continuous map f: S^n -> R^n, there exists x with f(x) = f(-x)",
+      "leanType": "Continuous f -> exists x : Sphere n, f x = f (-x)"
+    }
+  ]
 }

--- a/src/data/proofs/bounded-prime-gaps/meta.json
+++ b/src/data/proofs/bounded-prime-gaps/meta.json
@@ -336,5 +336,13 @@
       "venue": "terrytao.wordpress.com",
       "note": "Accessible exposition of Zhang's method and the Maynard-Tao improvements, including the connection to the Bombieri-Vinogradov theorem and admissible tuples"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "bounded_gaps",
+      "type": "core",
+      "description": "There exist infinitely many pairs of primes with bounded gap (Zhang/Maynard)",
+      "leanType": "exists H, Set.Infinite {n | exists p, Nat.Prime p and Nat.Prime (p + H) and p >= n}"
+    }
   ]
 }

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -429,5 +429,13 @@
         "leanType": "(n : ℕ) → (f : SelfMap n) → ¬HasFixedPoint n f → Retraction n"
       }
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "brouwer_fixed_point",
+      "type": "core",
+      "description": "Every continuous map from a closed ball to itself has a fixed point",
+      "leanType": "Continuous f -> maps_to f (closedBall 0 1) -> exists x, f x = x"
+    }
+  ]
 }

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -218,5 +218,13 @@
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "buffon_probability",
+      "type": "core",
+      "description": "Probability a needle of length L crosses parallel lines distance D apart is 2L/(pi*D)",
+      "leanType": "L <= D -> P(needle crosses line) = 2 * L / (pi * D)"
+    }
+  ]
 }

--- a/src/data/proofs/cantor-diagonalization/meta.json
+++ b/src/data/proofs/cantor-diagonalization/meta.json
@@ -290,5 +290,19 @@
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 2
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "cantor_diagonal",
+      "type": "core",
+      "description": "The reals are uncountable: no surjection from N to R exists",
+      "leanType": "not (exists f : Nat -> R, Function.Surjective f)"
+    },
+    {
+      "name": "power_set_larger",
+      "type": "key",
+      "description": "For any set A, |A| < |P(A)| (no surjection A -> P(A))",
+      "leanType": "not (exists f : A -> Set A, Function.Surjective f)"
+    }
+  ]
 }

--- a/src/data/proofs/cantors-theorem/meta.json
+++ b/src/data/proofs/cantors-theorem/meta.json
@@ -282,5 +282,13 @@
       "venue": "Annals of Mathematics Studies No. 3, Princeton University Press",
       "note": "Proved the Continuum Hypothesis is consistent with ZFC by constructing the constructible universe L — half of the independence proof, complementing Cohen's 1963 forcing result. Shows that Cantor's hierarchy $\\aleph_0 < 2^{\\aleph_0}$ is consistent with $2^{\\aleph_0} = \\aleph_1$"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "cantor_theorem",
+      "type": "core",
+      "description": "No surjection from a set to its power set",
+      "leanType": "(f : alpha -> Set alpha) -> not (Function.Surjective f)"
+    }
   ]
 }

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -228,5 +228,13 @@
       "venue": "Cambridge University Press",
       "note": "Comprehensive treatment of Cauchy-Schwarz and its generalizations, including the integral form, Hölder's inequality, and applications across mathematics"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "cauchy_schwarz_integral",
+      "type": "core",
+      "description": "|integral f*g|^2 <= (integral f^2) * (integral g^2) for L2 functions",
+      "leanType": "f in L2 -> g in L2 -> |integral f*g|^2 <= (integral f^2) * (integral g^2)"
+    }
   ]
 }

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -306,5 +306,25 @@
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "cauchy_schwarz_inner",
+      "type": "core",
+      "description": "|<u,v>| <= ||u|| * ||v|| in real inner product spaces",
+      "leanType": "[InnerProductSpace R E] -> (u v : E) -> |inner u v| <= norm(u) * norm(v)"
+    },
+    {
+      "name": "cauchy_schwarz_sum",
+      "type": "wrapper",
+      "description": "Finite sum form: (sum a_i*b_i)^2 <= (sum a_i^2)*(sum b_i^2)",
+      "leanType": "(a b : Fin n -> R) -> (sum (a i * b i))^2 <= (sum (a i^2)) * (sum (b i^2))"
+    },
+    {
+      "name": "cauchy_schwarz_two_eq_iff",
+      "type": "bridge",
+      "description": "Equality iff a1*b2 = a2*b1 (proportionality characterization)",
+      "leanType": "(a1 a2 b1 b2 : R) -> (a1*b1 + a2*b2)^2 = (a1^2 + a2^2)*(b1^2 + b2^2) <-> a1*b2 = a2*b1"
+    }
+  ]
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
@@ -155,6 +155,22 @@
       "endLine": 284,
       "summary": "Proves the Krylov subspace is M-invariant and establishes the O(n^2) recurrence for efficient computation.",
       "mathContext": "$M \\cdot v_k = v_{k+1}$: the Krylov subspace $\\text{span}\\{v_0, \\ldots, v_{d-1}\\}$ is $M$-invariant. Each step costs $O(n^2)$."
+    },
+    {
+      "id": "krylov-invariance",
+      "title": "Krylov Subspace Invariance and Recurrence",
+      "startLine": 285,
+      "endLine": 321,
+      "summary": "Proves $\text{krylov\\_subspace\\_invariant}$: $M \\cdot v_k = v_{k+1}$ where $v_k = M^k v$, showing the Krylov subspace is $M$-invariant. Proves the recurrence relation enabling $O(n^2)$ computation per Krylov step (single matrix-vector multiply) vs. $O(n^3)$ for naive $M^k$ computation.",
+      "mathContext": "Krylov invariance: $M \\cdot (M^k v) = M^{k+1} v$. Recurrence gives $O(n^2)$ per step vs. $O(n^3)$ naive, saving a factor of $n$ over $d \\leq n$ iterations."
+    },
+    {
+      "id": "summary-complexity",
+      "title": "Algorithm Summary and Complexity Analysis",
+      "startLine": 322,
+      "endLine": 368,
+      "summary": "Summary documenting the complete Krylov algorithm: compute $v, Mv, \\ldots, M^d v$ until linear dependence at step $d \\leq \\deg(\\mu_M) \\leq n$, extract minimal polynomial from dependence coefficients. Total cost: $O(n^3)$ field operations. Lists all 10 proved theorems with 0 sorries.",
+      "mathContext": "Krylov algorithm: $O(n^3)$ total for $\\mu_M$ computation. Optimal for nonderogatory matrices where $\\mu_M = \\chi_M$ and exactly $n$ Krylov vectors are independent."
     }
   ],
   "overview": {

--- a/src/data/proofs/cayley-hamilton-minpoly/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly/meta.json
@@ -250,5 +250,19 @@
       "venue": "Cambridge University Press, 2nd edition",
       "note": "Comprehensive treatment of the minimal polynomial and its relationship to the Cayley-Hamilton theorem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "minpoly_annihilates",
+      "type": "core",
+      "description": "The minimal polynomial annihilates the matrix: mu_A(A) = 0",
+      "leanType": "(A : Matrix n n R) -> aeval A (minpoly R A) = 0"
+    },
+    {
+      "name": "minpoly_minimal",
+      "type": "key",
+      "description": "The minimal polynomial has smallest degree among annihilating polynomials",
+      "leanType": "aeval A p = 0 -> Monic p -> minpoly.natDegree <= p.natDegree"
+    }
   ]
 }

--- a/src/data/proofs/cayley-hamilton-reduction/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction/meta.json
@@ -185,5 +185,13 @@
       "venue": "Cambridge University Press, 2nd edition",
       "note": "Covers the reduction approach to Cayley-Hamilton via companion matrices and rational canonical form"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "matrix_polynomial_reduction",
+      "type": "core",
+      "description": "Any polynomial in A can be reduced to degree < deg(chi_A) using Cayley-Hamilton",
+      "leanType": "(p : Polynomial R) -> exists q, q.natDegree < A.charpoly.natDegree and aeval A p = aeval A q"
+    }
   ]
 }

--- a/src/data/proofs/cayley-hamilton/meta.json
+++ b/src/data/proofs/cayley-hamilton/meta.json
@@ -213,5 +213,19 @@
       "venue": "Hodges and Smith, Dublin",
       "note": "Hamilton proved that every quaternion satisfies a quadratic equation — the quaternionic analogue of Cayley-Hamilton, predating Cayley's matrix formulation by five years"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "cayley_hamilton",
+      "type": "core",
+      "description": "Every square matrix satisfies its characteristic polynomial: chi_A(A) = 0",
+      "leanType": "(A : Matrix (Fin n) (Fin n) R) -> aeval A A.charpoly = 0"
+    },
+    {
+      "name": "minpoly_dvd_charpoly",
+      "type": "key",
+      "description": "The minimal polynomial divides the characteristic polynomial",
+      "leanType": "(A : Matrix (Fin n) (Fin n) R) -> minpoly R A dvd A.charpoly"
+    }
   ]
 }

--- a/src/data/proofs/central-limit-theorem/meta.json
+++ b/src/data/proofs/central-limit-theorem/meta.json
@@ -340,5 +340,13 @@
       "Mathlib.Tactic"
     ],
     "opens": []
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "clt_normalized_converges",
+      "type": "core",
+      "description": "Normalized sum of i.i.d. random variables converges in distribution to standard normal",
+      "leanType": "[IID X] -> E[X_i] = mu -> Var(X_i) = sigma^2 -> sigma > 0 -> (S_n - n*mu)/(sigma*sqrt(n)) ->d N(0,1)"
+    }
+  ]
 }

--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -183,5 +183,13 @@
       "relationship": "related",
       "description": "Both are classical triangle geometry results: Ceva's theorem concerns cevian concurrency, while Feuerbach's theorem concerns the tangency of the nine-point circle and incircle — both reveal deep structure in triangle configurations"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "ceva_theorem",
+      "type": "core",
+      "description": "Three cevians of a triangle are concurrent iff (AF/FB)(BD/DC)(CE/EA) = 1",
+      "leanType": "cevians_concurrent <-> (AF/FB) * (BD/DC) * (CE/EA) = 1"
+    }
   ]
 }

--- a/src/data/proofs/chinese-remainder-constructive/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive/meta.json
@@ -280,5 +280,13 @@
       "venue": "Amer. Math. Monthly, 59(6), 365-370",
       "note": "Extension of CRT to non-coprime moduli via compatibility conditions"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "crt",
+      "type": "core",
+      "description": "System of congruences x = a_i (mod n_i) with pairwise coprime moduli has a unique solution mod N",
+      "leanType": "pairwise_coprime ns -> exists! x (mod prod ns), forall i, x % ns i = as i"
+    }
   ]
 }

--- a/src/data/proofs/chinese-remainder-non-coprime/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime/meta.json
@@ -222,5 +222,13 @@
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "crt_non_coprime",
+      "type": "core",
+      "description": "System x = a (mod m), x = b (mod n) has a solution iff gcd(m,n) | (a-b)",
+      "leanType": "exists x, x % m = a and x % n = b <-> Nat.gcd m n | (a - b)"
+    }
+  ]
 }

--- a/src/data/proofs/collatz-structured/meta.json
+++ b/src/data/proofs/collatz-structured/meta.json
@@ -153,5 +153,13 @@
       "venue": "Forum of Mathematics, Pi 10, e12",
       "note": "Proved that almost all positive integers eventually reach a value close to 1 under the Collatz map — the strongest known result toward the conjecture"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "collatz_conjecture",
+      "type": "core",
+      "description": "Every positive integer eventually reaches 1 under the Collatz map",
+      "leanType": "(n : Nat) -> 0 < n -> exists k, collatz^k n = 1"
+    }
   ]
 }

--- a/src/data/proofs/combinations-formula/meta.json
+++ b/src/data/proofs/combinations-formula/meta.json
@@ -162,5 +162,13 @@
       "venue": "Addison-Wesley, 2nd edition",
       "note": "Modern reference for binomial coefficients, identities, and their applications in computer science"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "combinations_formula",
+      "type": "core",
+      "description": "C(n,k) = n! / (k! * (n-k)!)",
+      "leanType": "(n k : Nat) -> k <= n -> Nat.choose n k = n! / (k! * (n-k)!)"
+    }
   ]
 }

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -177,5 +177,19 @@
       "venue": "Proceedings of the National Academy of Sciences 50(6), 1143–1148",
       "note": "Proved CH is independent of ZFC using the method of forcing — won the Fields Medal in 1966"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "ch_independent",
+      "type": "core",
+      "description": "The continuum hypothesis is independent of ZFC (Godel + Cohen)",
+      "leanType": "Consistent ZFC -> not (Provable ZFC CH) and not (Provable ZFC (not CH))"
+    },
+    {
+      "name": "ch_statement",
+      "type": "key",
+      "description": "CH: there is no cardinal strictly between aleph_0 and 2^aleph_0",
+      "leanType": "not (exists kappa, aleph_0 < kappa and kappa < 2^aleph_0)"
+    }
   ]
 }

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -244,5 +244,13 @@
       "venue": "Mathematics of Computation",
       "note": "Fraction-free algorithm for determinants, an alternative to Cramer's rule for integer matrices"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "cramers_rule",
+      "type": "core",
+      "description": "x_i = det(A_i)/det(A) where A_i replaces column i of A with b",
+      "leanType": "det A != 0 -> A.mulVec x = b -> x i = det (A.updateColumn i b) / det A"
+    }
   ]
 }

--- a/src/data/proofs/de-moivre/meta.json
+++ b/src/data/proofs/de-moivre/meta.json
@@ -215,5 +215,13 @@
       "venue": "McGraw-Hill (reprinted by Dover, 1959)",
       "note": "Collects primary source translations including de Moivre's original work, providing historical context for the development of complex number theory"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "de_moivre",
+      "type": "core",
+      "description": "(cos theta + i sin theta)^n = cos(n*theta) + i sin(n*theta)",
+      "leanType": "(theta : R) -> (n : Nat) -> (Complex.exp (theta * I))^n = Complex.exp (n * theta * I)"
+    }
   ]
 }

--- a/src/data/proofs/denumerability-rationals/meta.json
+++ b/src/data/proofs/denumerability-rationals/meta.json
@@ -229,5 +229,13 @@
       "type": "book",
       "note": "Authoritative history of set theory from Cantor and Dedekind through Zermelo and Gödel, with detailed analysis of the denumerability results and their foundational impact"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "rationals_countable",
+      "type": "core",
+      "description": "The rational numbers are countable (Cantor's zigzag argument)",
+      "leanType": "Set.Countable (Set.univ : Set Q)"
+    }
   ]
 }

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -249,5 +249,19 @@
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "derangement_count",
+      "type": "core",
+      "description": "Number of derangements of n elements: D_n = n! * sum_{k=0}^n (-1)^k/k!",
+      "leanType": "(n : Nat) -> card (derangements n) = n! * sum k in range (n+1), (-1)^k / k!"
+    },
+    {
+      "name": "derangement_probability",
+      "type": "key",
+      "description": "Probability of a random permutation being a derangement approaches 1/e",
+      "leanType": "Tendsto (fun n => D_n / n!) atTop (nhds (1/Real.exp 1))"
+    }
+  ]
 }

--- a/src/data/proofs/desargues-theorem/meta.json
+++ b/src/data/proofs/desargues-theorem/meta.json
@@ -241,5 +241,13 @@
       "relationship": "thematic",
       "description": "Both are foundational results about planar geometric/combinatorial structures: the four-color theorem concerns graph coloring on the plane, while Desargues's theorem concerns projective configurations — both involve deep structural analysis"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "desargues_theorem",
+      "type": "core",
+      "description": "If two triangles are in perspective from a point, they are in perspective from a line",
+      "leanType": "perspective_from_point T1 T2 O -> perspective_from_line T1 T2"
+    }
   ]
 }

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -140,6 +140,22 @@
       "endLine": 502,
       "summary": "`rolle_polynomial` (fully proved via Mathlib's Rolle). `n_roots_derivative_roots` ($n+1$ roots of $p$ give $n$ roots of $p'$, fully proved). `rootsInInterval_split` (interval additivity). `PolyChain` structure for generalization to Sturm chains.",
       "mathContext": "Rolle's theorem gives the calculus foundation: between consecutive roots of $p$, $p'$ has a zero. By induction, $n+1$ roots of $p$ produce $\\geq n$ roots of $p'$, $\\geq n-1$ of $p''$, etc. This 'Rolle ladder' is the inductive engine for the `budan_upper_bound` axiom. The `PolyChain` abstraction prepares for Sturm's theorem, where pseudo-remainder chains replace derivative chains for exact (not just bounded) root counts."
+    },
+    {
+      "id": "structural-theorems",
+      "title": "Structural Theorems: Degree Bounds and Scalar Invariance",
+      "startLine": 503,
+      "endLine": 600,
+      "summary": "Proves V_p(x) <= deg(p): the Budan count is bounded by the polynomial degree. Key result: signChangesInList is invariant under nonzero scalar multiplication, proved by case analysis on sign of the scalar.",
+      "mathContext": "$V_p(x) \\leq \\deg(p)$. Sign change invariance: $\\text{signChanges}(c \\cdot l) = \\text{signChanges}(l)$ for $c \\neq 0$."
+    },
+    {
+      "id": "budan-scaling",
+      "title": "Budan Count Scaling and Degree Preservation",
+      "startLine": 601,
+      "endLine": 698,
+      "summary": "Proves budanCount_smul: scaling a polynomial by a nonzero constant preserves the Budan count. Technical infrastructure for the Budan-Fourier theorem connecting sign variations to root counts.",
+      "mathContext": "Budan scaling: $V_{cp}(x) = V_p(x)$ for $c \\neq 0$. Uses $(cp).\\deg = p.\\deg$ for $c \\neq 0, p \\neq 0$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/descartes-rule-of-signs/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs/meta.json
@@ -233,5 +233,13 @@
       "venue": "American Mathematical Monthly 106(9), 854–856",
       "note": "Elementary proof of Descartes's rule using only polynomial division and induction, avoiding Rolle's theorem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "descartes_rule",
+      "type": "core",
+      "description": "Number of positive roots <= number of sign changes in coefficients, with same parity",
+      "leanType": "positive_roots p <= sign_changes(coefficients p) and (sign_changes - positive_roots) % 2 = 0"
+    }
   ]
 }

--- a/src/data/proofs/dirichlets-theorem/meta.json
+++ b/src/data/proofs/dirichlets-theorem/meta.json
@@ -221,5 +221,13 @@
       "venue": "Springer GTM 7",
       "note": "Modern proof of Dirichlet's theorem using character theory and L-functions"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "dirichlet_arithmetic_progression",
+      "type": "core",
+      "description": "There are infinitely many primes in any arithmetic progression a, a+d, a+2d, ... with gcd(a,d)=1",
+      "leanType": "Nat.Coprime a d -> Set.Infinite {p | Nat.Prime p and p % d = a % d}"
+    }
   ]
 }

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -251,5 +251,13 @@
       "venue": "Journal of Graph Theory, vol. 2, pp. 129-140",
       "note": "Comprehensive survey of squared rectangle and squared square theory, including the history from Moron's 1925 puzzle through the Brooks-Smith-Stone-Tutte breakthrough to Duijvestijn's computer search"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "dehn_invariant",
+      "type": "core",
+      "description": "Dehn's theorem: polyhedra with different Dehn invariants are not scissors-congruent",
+      "leanType": "dehnInvariant P != dehnInvariant Q -> not (scissors_congruent P Q)"
+    }
   ]
 }

--- a/src/data/proofs/divisibility-by-3/meta.json
+++ b/src/data/proofs/divisibility-by-3/meta.json
@@ -181,5 +181,13 @@
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "divisibility_by_3",
+      "type": "core",
+      "description": "A number is divisible by 3 iff the sum of its digits is divisible by 3",
+      "leanType": "(n : Nat) -> 3 | n <-> 3 | digitSum n"
+    }
+  ]
 }

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -210,5 +210,13 @@
     "axiomCount": 5,
     "theoremCount": 8,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "e_transcendental",
+      "type": "core",
+      "description": "Euler's number e is transcendental over Q",
+      "leanType": "Transcendental Q (Real.exp 1)"
+    }
+  ]
 }

--- a/src/data/proofs/euler-identity/meta.json
+++ b/src/data/proofs/euler-identity/meta.json
@@ -341,5 +341,13 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "euler_identity",
+      "type": "core",
+      "description": "e^(i*pi) + 1 = 0 (Euler's identity)",
+      "leanType": "Complex.exp (Complex.I * Real.pi) + 1 = 0"
+    }
+  ]
 }

--- a/src/data/proofs/euler-polyhedral-formula/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula/meta.json
@@ -266,5 +266,13 @@
     "axiomCount": 1,
     "theoremCount": 65,
     "definitionCount": 27
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "euler_formula",
+      "type": "core",
+      "description": "V - E + F = 2 for convex polyhedra",
+      "leanType": "convex_polyhedron P -> vertices P - edges P + faces P = 2"
+    }
+  ]
 }

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -222,5 +222,19 @@
       "venue": "Oxford University Press",
       "note": "Standard reference for the totient function and its properties"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "euler_totient_formula",
+      "type": "core",
+      "description": "phi(n) = n * product (1 - 1/p) over prime divisors p of n",
+      "leanType": "Nat.totient n = n * Finset.prod (Nat.primeFactors n) (fun p => 1 - 1/p)"
+    },
+    {
+      "name": "euler_theorem",
+      "type": "key",
+      "description": "a^phi(n) = 1 (mod n) for gcd(a,n) = 1",
+      "leanType": "Nat.Coprime a n -> a ^ Nat.totient n % n = 1"
+    }
   ]
 }

--- a/src/data/proofs/factor-remainder-theorem/meta.json
+++ b/src/data/proofs/factor-remainder-theorem/meta.json
@@ -247,5 +247,19 @@
       "venue": "Springer UTM, 4th edition",
       "note": "Extends the Factor Theorem to the multivariate setting via Hilbert's Nullstellensatz and Gröbner bases — the computational algebra perspective on polynomial root-finding and factorization"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "factor_theorem",
+      "type": "core",
+      "description": "p(a) = 0 iff (x - a) divides p(x)",
+      "leanType": "(p : Polynomial R) -> (a : R) -> aeval a p = 0 <-> (X - C a) dvd p"
+    },
+    {
+      "name": "remainder_theorem",
+      "type": "key",
+      "description": "The remainder of p(x) / (x - a) is p(a)",
+      "leanType": "(p : Polynomial R) -> (a : R) -> p %ₘ (X - C a) = C (aeval a p)"
+    }
   ]
 }

--- a/src/data/proofs/fair-games-theorem/meta.json
+++ b/src/data/proofs/fair-games-theorem/meta.json
@@ -252,5 +252,13 @@
       "venue": "https://www.cs.ru.nl/~freek/100/",
       "note": "The Fair Games Theorem is #62 on Wiedijk's list of 100 well-known mathematical theorems: 'You cannot beat a fair game with any strategy'"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "fair_game_theorem",
+      "type": "core",
+      "description": "In a fair game, the expected value of the gambler's fortune is constant (martingale property)",
+      "leanType": "fair_game G -> E[fortune n] = E[fortune 0]"
+    }
   ]
 }

--- a/src/data/proofs/fermat-two-squares/meta.json
+++ b/src/data/proofs/fermat-two-squares/meta.json
@@ -227,5 +227,13 @@
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "fermat_two_squares",
+      "type": "core",
+      "description": "An odd prime p is a sum of two squares iff p = 1 (mod 4)",
+      "leanType": "Nat.Prime p -> p != 2 -> (exists a b : Int, p = a^2 + b^2) <-> p % 4 = 1"
+    }
+  ]
 }

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -323,5 +323,13 @@
     "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "flt",
+      "type": "core",
+      "description": "No three positive integers a, b, c satisfy a^n + b^n = c^n for n > 2",
+      "leanType": "(n : Nat) -> 2 < n -> not (exists a b c : Nat, 0 < a and 0 < b and 0 < c and a^n + b^n = c^n)"
+    }
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -170,5 +170,13 @@
       "relationship": "foundational",
       "description": "The angle sum property is the most basic constraint on triangle geometry, while Feuerbach's theorem is one of the deepest — both concern the rigid geometric structure of triangles"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "feuerbach_tangency",
+      "type": "core",
+      "description": "The nine-point circle is tangent to the incircle and all three excircles",
+      "leanType": "Triangle ABC -> tangent (ninePointCircle ABC) (incircle ABC)"
+    }
   ]
 }

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -216,5 +216,13 @@
       "Mathlib.Tactic"
     ],
     "opens": []
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "four_color",
+      "type": "core",
+      "description": "Every planar graph is 4-colorable",
+      "leanType": "PlanarGraph G -> exists f : V -> Fin 4, proper_coloring G f"
+    }
+  ]
 }

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -258,5 +258,19 @@
       "venue": "Acta Mathematica 116, pp. 135-157",
       "note": "Proved pointwise convergence of Fourier series for L² functions"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "fourier_convergence",
+      "type": "core",
+      "description": "L2 convergence of Fourier series for square-integrable functions",
+      "leanType": "f in L2 -> Tendsto (fun N => norm(f - S_N f)) atTop (nhds 0)"
+    },
+    {
+      "name": "parseval_theorem",
+      "type": "key",
+      "description": "Parseval's theorem: ||f||^2 = sum |c_n|^2",
+      "leanType": "integral |f|^2 = sum n, |fourierCoeff f n|^2"
+    }
   ]
 }

--- a/src/data/proofs/friendship-theorem/meta.json
+++ b/src/data/proofs/friendship-theorem/meta.json
@@ -184,5 +184,13 @@
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 6
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "friendship_theorem",
+      "type": "core",
+      "description": "If any two people at a party have exactly one mutual friend, then there is a person who is everyone's friend",
+      "leanType": "(forall u v, u != v -> exists! w, adj u w and adj v w) -> exists v, forall u, u != v -> adj u v"
+    }
+  ]
 }

--- a/src/data/proofs/fundamental-arithmetic/meta.json
+++ b/src/data/proofs/fundamental-arithmetic/meta.json
@@ -210,5 +210,19 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "fundamental_theorem_arithmetic",
+      "type": "core",
+      "description": "Every integer > 1 has a unique prime factorization",
+      "leanType": "(n : Nat) -> 1 < n -> exists! (factors : Multiset Nat), (forall p in factors, Nat.Prime p) and factors.prod = n"
+    },
+    {
+      "name": "unique_factorization",
+      "type": "key",
+      "description": "Nat is a unique factorization domain",
+      "leanType": "UniqueFactorizationMonoid Nat"
+    }
+  ]
 }

--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -352,5 +352,13 @@
         "leanType": "(a b c : ℂ) → a ≠ 0 → ∃ z : ℂ, a * z ^ 2 + b * z + c = 0"
       }
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "fta",
+      "type": "core",
+      "description": "Every non-constant polynomial over C has a root",
+      "leanType": "(p : Polynomial C) -> 0 < p.natDegree -> exists z : C, aeval z p = 0"
+    }
+  ]
 }

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -260,5 +260,19 @@
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 2
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "ftc_part1",
+      "type": "core",
+      "description": "FTC Part 1: The derivative of F(x) = integral_a^x f(t)dt equals f(x)",
+      "leanType": "ContinuousAt f b -> IntervalIntegrable f volume a b -> HasDerivAt (integralFunction f a) (f b) b"
+    },
+    {
+      "name": "ftc_part2",
+      "type": "core",
+      "description": "FTC Part 2: integral_a^b f = F(b) - F(a) when F' = f",
+      "leanType": "a <= b -> ContinuousOn F (Icc a b) -> (forall x in Ioo a b, HasDerivAt F (f x) x) -> integral x in a..b, f x = F b - F a"
+    }
+  ]
 }

--- a/src/data/proofs/gcd-algorithm/meta.json
+++ b/src/data/proofs/gcd-algorithm/meta.json
@@ -256,5 +256,13 @@
       "venue": "Comptes rendus de l'Académie des Sciences 19, 867–870",
       "note": "First rigorous complexity analysis: the number of steps is at most 5 times the number of digits of the smaller input — the worst case is consecutive Fibonacci numbers"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "euclidean_algorithm",
+      "type": "core",
+      "description": "The Euclidean algorithm computes the GCD correctly",
+      "leanType": "gcd_euclidean a b = Nat.gcd a b"
+    }
   ]
 }

--- a/src/data/proofs/gelfond-schneider/meta.json
+++ b/src/data/proofs/gelfond-schneider/meta.json
@@ -207,5 +207,13 @@
       "venue": "Cambridge University Press",
       "note": "Contains the proof and its vast generalization to linear forms in logarithms, for which Baker won the Fields Medal"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "gelfond_schneider",
+      "type": "core",
+      "description": "If a is algebraic != 0,1 and b is algebraic irrational, then a^b is transcendental",
+      "leanType": "IsAlgebraic Q a -> a != 0 -> a != 1 -> IsAlgebraic Q b -> Irrational b -> Transcendental Q (a^b)"
+    }
   ]
 }

--- a/src/data/proofs/geometric-series/meta.json
+++ b/src/data/proofs/geometric-series/meta.json
@@ -281,5 +281,13 @@
         "description": "Summable (fun k => r^k) for |r| < 1 — convergence precondition"
       }
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "geometric_series_sum",
+      "type": "core",
+      "description": "For |r| < 1, the sum of the geometric series is 1/(1-r)",
+      "leanType": "norm r < 1 -> HasSum (fun n => r^n) (1 / (1 - r))"
+    }
+  ]
 }

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -318,5 +318,19 @@
       "Mathlib.Tactic"
     ],
     "opens": []
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "godel_first",
+      "type": "core",
+      "description": "Any consistent sufficiently strong formal system contains undecidable propositions",
+      "leanType": "Consistent T -> SufficientlyStrong T -> exists phi, not (Provable T phi) and not (Provable T (not phi))"
+    },
+    {
+      "name": "godel_second",
+      "type": "key",
+      "description": "A consistent system cannot prove its own consistency",
+      "leanType": "Consistent T -> SufficientlyStrong T -> not (Provable T (Con T))"
+    }
+  ]
 }

--- a/src/data/proofs/greens-theorem/meta.json
+++ b/src/data/proofs/greens-theorem/meta.json
@@ -224,5 +224,13 @@
       "venue": "W.A. Benjamin",
       "note": "Modern proof using differential forms, presenting Green's theorem as a special case of Stokes' theorem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "greens_theorem",
+      "type": "core",
+      "description": "The line integral around a closed curve equals the double integral of the curl over the enclosed region",
+      "leanType": "integral_boundary (P dx + Q dy) = integral_region (dQ/dx - dP/dy) dA"
+    }
   ]
 }

--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -231,5 +231,25 @@
     "defCount": 3,
     "imports": [],
     "opens": []
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "diagonal_differs",
+      "type": "key",
+      "description": "The diagonal behavior differs from every oracle prediction at the self-application point",
+      "leanType": "(H : HaltingOracle) -> (n : Nat) -> diagonalBehavior H n != H n n"
+    },
+    {
+      "name": "no_halting_oracle",
+      "type": "core",
+      "description": "No oracle can correctly predict the diagonal behavior",
+      "leanType": "forall H : HaltingOracle, forall c : Nat, not (H correctly predicts diagonalBehavior H at c)"
+    },
+    {
+      "name": "halting_problem_undecidable",
+      "type": "synthesis",
+      "description": "The halting problem is undecidable: for any oracle, a counterexample exists",
+      "leanType": "forall H : HaltingOracle, exists b : Behavior, forall c : Nat, H c c != b c"
+    }
+  ]
 }

--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -95,6 +95,14 @@
       "endLine": 131,
       "summary": "Final statement: for any halting oracle, the diagonal program provides an explicit counterexample.",
       "mathContext": "$$\\forall H.\\; \\exists d.\\; H(d, d) \\neq D(d) \\quad \\text{(explicit counterexample via diagonalization)}$$"
+    },
+    {
+      "id": "main-summary",
+      "title": "Full Undecidability Theorem and Diagonalization Visualization",
+      "startLine": 132,
+      "endLine": 172,
+      "summary": "States $\text{halting\\_problem\\_undecidable}$: for any halting oracle $H$, there exists a behavior that $H$ fails to predict on some code. The diagonal construction visualizes the 2D table of program behaviors, flipping the diagonal to create an impossible row. Verification section with $\texttt{\\#check}$ on all key theorems.",
+      "mathContext": "Main result: $\forall H : \text{HaltingOracle}, \\exists b : \text{Behavior}, \forall c : \\mathbb{N}, H(c,c) \neq b(c)$. The diagonal argument pattern unifies halting undecidability with Cantor, Godel, Russell, and Tarski."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/harmonic-divergence/meta.json
+++ b/src/data/proofs/harmonic-divergence/meta.json
@@ -198,5 +198,13 @@
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "harmonic_diverges",
+      "type": "core",
+      "description": "The harmonic series 1 + 1/2 + 1/3 + ... diverges to infinity",
+      "leanType": "not (Summable (fun n => 1 / (n + 1 : R)))"
+    }
+  ]
 }

--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -222,5 +222,19 @@
       "venue": "Sitzungsberichte der Königlich Preußischen Akademie der Wissenschaften",
       "note": "Generalized Lindemann's result to the full Lindemann-Weierstrass theorem on algebraic independence"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hermite_lindemann",
+      "type": "core",
+      "description": "If a is a nonzero algebraic number, then e^a is transcendental",
+      "leanType": "IsAlgebraic Q a -> a != 0 -> Transcendental Q (Real.exp a)"
+    },
+    {
+      "name": "pi_transcendental",
+      "type": "key",
+      "description": "Pi is transcendental (corollary: e^(i*pi) = -1 with i*pi algebraic would contradict HL)",
+      "leanType": "Transcendental Q Real.pi"
+    }
   ]
 }

--- a/src/data/proofs/herons-formula/meta.json
+++ b/src/data/proofs/herons-formula/meta.json
@@ -186,5 +186,13 @@
       "venue": "Oxford University Press (Dover reprint 1981)",
       "note": "Historical analysis of Heron's formula including the proof from Metrica"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "heron_formula",
+      "type": "core",
+      "description": "Area of triangle = sqrt(s(s-a)(s-b)(s-c)) where s = (a+b+c)/2",
+      "leanType": "area = Real.sqrt (s * (s-a) * (s-b) * (s-c)) where s = (a+b+c)/2"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-10/meta.json
+++ b/src/data/proofs/hilbert-10/meta.json
@@ -177,5 +177,13 @@
     "defCount": 10,
     "imports": [],
     "opens": []
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "matiyasevich_theorem",
+      "type": "core",
+      "description": "Hilbert's 10th: there is no algorithm to decide solvability of Diophantine equations",
+      "leanType": "not (Decidable (fun p => exists x : Fin n -> Int, eval x p = 0))"
+    }
+  ]
 }

--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -225,5 +225,25 @@
       "venue": "Springer GTM 7",
       "note": "Modern treatment of quadratic forms over Q and the Hasse-Minkowski theorem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "HasseMinkowskiTheorem",
+      "type": "core",
+      "description": "A quadratic form over Q is isotropic iff it is isotropic over R and all Q_p",
+      "leanType": "Q.RepresentsZeroOverReals -> (forall p, Q.RepresentsZeroOverPadic p) -> Q.RepresentsZeroNontrivially"
+    },
+    {
+      "name": "sylvester_law_of_inertia",
+      "type": "key",
+      "description": "Every real quadratic form has a unique signature (p,q)",
+      "leanType": "(Q : QuadraticForm R V) -> exists! sig : RealSignature, classifies Q sig"
+    },
+    {
+      "name": "lagrange_four_squares",
+      "type": "key",
+      "description": "Every natural number is a sum of four squares",
+      "leanType": "forall n : Nat, exists a b c d : Int, n = a^2 + b^2 + c^2 + d^2"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-13/meta.json
+++ b/src/data/proofs/hilbert-13/meta.json
@@ -172,5 +172,13 @@
       "venue": "Doklady Akademii Nauk SSSR 114, 679–681",
       "note": "Proved that continuous functions of three variables are representable by superpositions — complementing Kolmogorov's result"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "kolmogorov_superposition",
+      "type": "core",
+      "description": "Every continuous function of n variables is a superposition of continuous functions of 2 variables",
+      "leanType": "Continuous f -> exists gs hs, f = sum (fun q => g_q ∘ sum (fun p => h_{pq}))"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -250,5 +250,13 @@
       "venue": "Inventiones Mathematicae 4, 229–237",
       "note": "Proved that at most 2^n rational function squares suffice for n-variable PSD polynomials"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hilbert17_artin",
+      "type": "core",
+      "description": "A non-negative polynomial over R is a sum of squares of rational functions (Artin 1927)",
+      "leanType": "(p : MvPolynomial (Fin n) R) -> (forall x, 0 <= eval x p) -> exists qs, p = sum (q_i^2 / r_i^2)"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-19/meta.json
+++ b/src/data/proofs/hilbert-19/meta.json
@@ -178,5 +178,13 @@
       "venue": "Memorie della Accademia delle Scienze di Torino 3, 25–43",
       "note": "Proved regularity of solutions to elliptic PDEs — a key result toward Hilbert's 19th problem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "de_giorgi_nash",
+      "type": "core",
+      "description": "Solutions of elliptic variational problems are analytic",
+      "leanType": "EllipticVariational F -> minimizer u -> Analytic u"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-20/meta.json
+++ b/src/data/proofs/hilbert-20/meta.json
@@ -177,5 +177,13 @@
       "venue": "American Mathematical Society, Graduate Studies in Mathematics 19, 2nd edition",
       "note": "Modern treatment of existence and regularity for elliptic boundary value problems — context for Hilbert's 20th problem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hilbert20_existence",
+      "type": "core",
+      "description": "Solutions to elliptic boundary value problems exist under Hilbert's conditions",
+      "leanType": "EllipticOperator L -> BoundaryData g -> exists u, L u = f and u|_boundary = g"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -190,5 +190,13 @@
       "venue": "Abhandlungen der Königlichen Gesellschaft der Wissenschaften zu Göttingen 7, 3–22",
       "note": "Riemann's investigation of hypergeometric equations and their monodromy — the origin of the Riemann-Hilbert problem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hilbert21_monodromy",
+      "type": "core",
+      "description": "Existence of Fuchsian systems with prescribed monodromy",
+      "leanType": "MonodromyRep rho -> exists system, Fuchsian system and monodromy system = rho"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-3/meta.json
+++ b/src/data/proofs/hilbert-3/meta.json
@@ -220,5 +220,13 @@
       "venue": "Mathematische Annalen 55, 465–478",
       "note": "First solution to a Hilbert problem — proved via the Dehn invariant that a regular tetrahedron cannot be cut and reassembled into a cube"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "dehn_theorem",
+      "type": "core",
+      "description": "Hilbert's 3rd: a regular tetrahedron and cube of equal volume are not scissors-congruent",
+      "leanType": "not (scissors_congruent regular_tetrahedron (cube_of_equal_volume))"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -190,5 +190,13 @@
       "venue": "Academic Press",
       "note": "Systematic study of metric spaces where geodesics are unique — the class of geometries Hilbert's 4th problem asks to characterize"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hilbert4_metric",
+      "type": "core",
+      "description": "Construction of metrics for which straight lines are geodesics",
+      "leanType": "exists metric, forall line, is_geodesic metric line"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-5/meta.json
+++ b/src/data/proofs/hilbert-5/meta.json
@@ -254,5 +254,13 @@
       "year": "2013",
       "venue": "Journal of the American Mathematical Society, 26(3):879–899"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hilbert5_gleason",
+      "type": "core",
+      "description": "Gleason-Montgomery-Zippin: every locally Euclidean topological group is a Lie group",
+      "leanType": "LocallyEuclidean G -> TopologicalGroup G -> IsLieGroup G"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-6/meta.json
+++ b/src/data/proofs/hilbert-6/meta.json
@@ -187,5 +187,13 @@
       "relationship": "related",
       "description": "Shannon entropy axiomatizes information-theoretic aspects that connect to Hilbert's 6th through statistical mechanics: the Boltzmann-Gibbs-Shannon entropy framework is a partial success story in axiomatizing physical theories"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hilbert6_axiomatization",
+      "type": "core",
+      "description": "Mathematical axiomatization of physical theories",
+      "leanType": "PhysicalTheory T -> exists axioms, Consistent axioms and Models T axioms"
+    }
   ]
 }

--- a/src/data/proofs/hilbert-9-reciprocity/meta.json
+++ b/src/data/proofs/hilbert-9-reciprocity/meta.json
@@ -181,5 +181,13 @@
       "Mathlib.Tactic"
     ],
     "opens": []
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "artin_reciprocity",
+      "type": "core",
+      "description": "The Artin reciprocity law: the most general reciprocity law for abelian extensions",
+      "leanType": "IsAbelianExtension K L -> ArtinMap K L is_surjective and kernel = NormGroup"
+    }
+  ]
 }

--- a/src/data/proofs/infinitude-primes/meta.json
+++ b/src/data/proofs/infinitude-primes/meta.json
@@ -251,5 +251,19 @@
         "leanType": "¬∃ p : ℕ, Nat.Prime p ∧ ∀ q : ℕ, Nat.Prime q → q ≤ p"
       }
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "unbounded_primes",
+      "type": "core",
+      "description": "For every n, there exists a prime p > n (Euclid's proof via n!+1)",
+      "leanType": "forall n : Nat, exists p : Nat, Nat.Prime p and p > n"
+    },
+    {
+      "name": "no_largest_prime",
+      "type": "bridge",
+      "description": "There is no largest prime (contrapositive of unbounded_primes)",
+      "leanType": "not (exists p : Nat, Nat.Prime p and forall q : Nat, Nat.Prime q -> q <= p)"
+    }
+  ]
 }

--- a/src/data/proofs/intermediate-value-theorem/meta.json
+++ b/src/data/proofs/intermediate-value-theorem/meta.json
@@ -237,5 +237,13 @@
       "venue": "McGraw-Hill, 3rd edition",
       "note": "Standard textbook proof using the connectedness of intervals"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "ivt",
+      "type": "core",
+      "description": "A continuous function on [a,b] attains every value between f(a) and f(b)",
+      "leanType": "ContinuousOn f (Icc a b) -> f a <= y -> y <= f b -> exists c in Icc a b, f c = y"
+    }
   ]
 }

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -172,6 +172,22 @@
       "endLine": 448,
       "summary": "Cayley's theorem (`cayley_card`): every finite group $G$ embeds into $S_{|G|}$ via the left-regular representation $g \\mapsto (x \\mapsto gx)$. Proof uses `MulAction.toPermHom` with injectivity from the identity element. Followed by `#check` verification of all key results.",
       "mathContext": "Cayley's theorem ($G \\hookrightarrow S_{|G|}$) implies that realizing all symmetric groups over $\\mathbb{Q}$ is a necessary condition for the Inverse Galois Problem. However, it is not sufficient: embedding $G \\hookrightarrow S_n$ does not automatically yield a Galois extension with group $G$ (one needs $G$ as a quotient, not just a subgroup, of a realizable group)."
+    },
+    {
+      "id": "alternating-solvability",
+      "title": "Alternating Group Solvability Characterization",
+      "startLine": 449,
+      "endLine": 482,
+      "summary": "Proves A_n is not solvable for n >= 5 via the exact sequence 1 -> A_n -> S_n -> C_2 -> 1. Proves the biconditional: A_n is solvable iff n <= 4.",
+      "mathContext": "$A_n$ solvable $\\iff n \\leq 4$. Proof via $1 \\to A_n \\to S_n \\to C_2 \\to 1$: solvability of $A_n$ and $C_2$ would force solvability of $S_n$."
+    },
+    {
+      "id": "quotient-realizability",
+      "title": "Quotient Realizability via FTGT",
+      "startLine": 483,
+      "endLine": 591,
+      "summary": "Proves the fundamental structural theorem: every quotient of a realized Galois group is realized. Given K/F Galois with Gal(K/F) = G and normal H, the fixed field K^H is Galois over F with Gal(K^H/F) isomorphic to G/H.",
+      "mathContext": "FTGT quotient realizability: $\\text{Gal}(K/F) = G, H \\trianglelefteq G \\Rightarrow \\text{Gal}(K^H/F) \\cong G/H$. Consequence: realizing $G$ automatically realizes all quotients $G/H$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -332,5 +332,13 @@
       "venue": "Journal fuer die reine und angewandte Mathematik 110, 104-129",
       "note": "Proved S_n and A_n are realizable over Q via Hilbert irreducibility, establishing the first systematic results on the Inverse Galois Problem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "inverse_galois_sn",
+      "type": "core",
+      "description": "Every symmetric group S_n occurs as a Galois group over Q",
+      "leanType": "(n : Nat) -> exists K : IntermediateField Q, Gal(K/Q) ≅ Perm (Fin n)"
+    }
   ]
 }

--- a/src/data/proofs/isoperimetric-theorem/meta.json
+++ b/src/data/proofs/isoperimetric-theorem/meta.json
@@ -216,5 +216,19 @@
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 14
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "isoperimetric_inequality",
+      "type": "core",
+      "description": "Among all closed curves of length L, the circle encloses the maximum area: A <= L^2/(4*pi)",
+      "leanType": "ClosedCurve gamma -> length gamma = L -> area_enclosed gamma <= L^2 / (4 * pi)"
+    },
+    {
+      "name": "isoperimetric_equality",
+      "type": "key",
+      "description": "Equality holds iff the curve is a circle",
+      "leanType": "area_enclosed gamma = L^2 / (4 * pi) <-> is_circle gamma"
+    }
+  ]
 }

--- a/src/data/proofs/isosceles-triangle/meta.json
+++ b/src/data/proofs/isosceles-triangle/meta.json
@@ -187,5 +187,19 @@
       "venue": "Leipzig",
       "note": "Axiomatic treatment of Euclidean geometry; the isosceles triangle theorem follows from SAS congruence"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "isosceles_base_angles",
+      "type": "core",
+      "description": "In an isosceles triangle, base angles are equal (pons asinorum)",
+      "leanType": "side_AB = side_AC -> angle_B = angle_C"
+    },
+    {
+      "name": "isosceles_converse",
+      "type": "key",
+      "description": "If two angles of a triangle are equal, the sides opposite them are equal",
+      "leanType": "angle_B = angle_C -> side_AB = side_AC"
+    }
   ]
 }

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -203,5 +203,13 @@
       "venue": "MAA Carus Mathematical Monographs 26",
       "note": "Modern treatment of quadratic forms including the four-square theorem from the perspective of lattices, quaternions, and the Hurwitz integers"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "lagrange_four_squares",
+      "type": "core",
+      "description": "Every natural number is a sum of four squares",
+      "leanType": "(n : Nat) -> exists a b c d : Int, n = a^2 + b^2 + c^2 + d^2"
+    }
   ]
 }

--- a/src/data/proofs/laws-of-large-numbers/meta.json
+++ b/src/data/proofs/laws-of-large-numbers/meta.json
@@ -263,5 +263,19 @@
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 3
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "weak_lln",
+      "type": "core",
+      "description": "Sample average converges in probability to the expected value",
+      "leanType": "[IID X] -> E[X] = mu -> Tendsto (fun n => (sum X_i / n)) atTop (Measure.ae (nhds mu))"
+    },
+    {
+      "name": "strong_lln",
+      "type": "key",
+      "description": "Sample average converges almost surely to the expected value",
+      "leanType": "[IID X] -> E[X] = mu -> ae (fun omega => Tendsto (fun n => sum X_i(omega) / n) atTop (nhds mu))"
+    }
+  ]
 }

--- a/src/data/proofs/lebesgue-measure/meta.json
+++ b/src/data/proofs/lebesgue-measure/meta.json
@@ -237,5 +237,19 @@
       "venue": "Wiley, 2nd edition",
       "note": "Standard graduate text with complete construction of Lebesgue measure via Carathéodory's extension theorem"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "lebesgue_measure_interval",
+      "type": "core",
+      "description": "The Lebesgue measure of [a,b] equals b - a",
+      "leanType": "a <= b -> volume (Icc a b) = ENNReal.ofReal (b - a)"
+    },
+    {
+      "name": "countable_null",
+      "type": "key",
+      "description": "Countable sets have Lebesgue measure zero",
+      "leanType": "Set.Countable S -> volume S = 0"
+    }
   ]
 }

--- a/src/data/proofs/liouville-theorem/meta.json
+++ b/src/data/proofs/liouville-theorem/meta.json
@@ -231,5 +231,13 @@
       "venue": "Journal de Mathématiques Pures et Appliquées 16, 133–142",
       "note": "Proved the existence of transcendental numbers by constructing explicit examples using rapidly convergent series"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "liouville_approximation",
+      "type": "core",
+      "description": "Algebraic numbers of degree d cannot be approximated by rationals better than |a - p/q| >= c/q^d",
+      "leanType": "IsAlgebraic Q a -> algebraicDegree a = d -> exists c > 0, forall p q, |a - p/q| >= c / q^d"
+    }
   ]
 }

--- a/src/data/proofs/mathematical-induction/meta.json
+++ b/src/data/proofs/mathematical-induction/meta.json
@@ -223,5 +223,13 @@
       "relationship": "related",
       "description": "The Schroeder-Bernstein theorem uses a chain of iterated function applications that terminates by well-ordering — the same principle shown equivalent to induction in this formalization. Both are Wiedijk 100 theorems formalized in Lean 4 via Mathlib"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "induction_principle",
+      "type": "core",
+      "description": "If P(0) and P(n) implies P(n+1), then P holds for all natural numbers",
+      "leanType": "P 0 -> (forall n, P n -> P (n+1)) -> forall n, P n"
+    }
   ]
 }

--- a/src/data/proofs/mean-value-theorem/meta.json
+++ b/src/data/proofs/mean-value-theorem/meta.json
@@ -232,5 +232,19 @@
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "mvt",
+      "type": "core",
+      "description": "MVT: there exists c in (a,b) with f'(c) = (f(b) - f(a))/(b - a)",
+      "leanType": "(hab : a < b) -> ContinuousOn f (Icc a b) -> DifferentiableOn R f (Ioo a b) -> exists c in Ioo a b, deriv f c = (f b - f a) / (b - a)"
+    },
+    {
+      "name": "cauchy_mvt",
+      "type": "bridge",
+      "description": "Cauchy's MVT: (g(b)-g(a))f'(c) = (f(b)-f(a))g'(c)",
+      "leanType": "(hab : a < b) -> ContinuousOn f/g -> HasDerivAt f/g -> exists c in Ioo a b, (g b - g a) * f' c = (f b - f a) * g' c"
+    }
+  ]
 }

--- a/src/data/proofs/minkowski-theorem/meta.json
+++ b/src/data/proofs/minkowski-theorem/meta.json
@@ -186,5 +186,13 @@
       "venue": "Leipzig: Teubner",
       "note": "Founded the geometry of numbers — proved that a convex symmetric body of sufficient volume must contain a non-zero lattice point"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "minkowski_lattice",
+      "type": "core",
+      "description": "A convex symmetric body of volume > 2^n contains a nonzero lattice point",
+      "leanType": "Convex S -> symmetric S -> volume S > 2^n -> exists p in Lattice, p != 0 and p in S"
+    }
   ]
 }

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -246,5 +246,13 @@
       "venue": "Les Relations entre les Mathématiques et la Physique Théorique, IHÉS",
       "note": "Elegant proof using the group of affine transformations"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "morley_theorem",
+      "type": "core",
+      "description": "The triangle formed by adjacent angle trisectors is equilateral",
+      "leanType": "Triangle ABC -> trisector_triangle ABC is equilateral"
+    }
   ]
 }

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -377,5 +377,13 @@
       "ENNReal",
       "TwoDimensionalGlobal"
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "navier_stokes_existence",
+      "type": "core",
+      "description": "Millennium Prize: existence and smoothness of solutions to Navier-Stokes equations",
+      "leanType": "NavierStokesInitialData -> exists! (u p), NavierStokesSolution u p and Smooth u"
+    }
+  ]
 }

--- a/src/data/proofs/nth-root-irrational/meta.json
+++ b/src/data/proofs/nth-root-irrational/meta.json
@@ -169,5 +169,13 @@
       "venue": "Oxford University Press, 6th edition",
       "note": "Contains the standard proof that n-th roots of non-perfect-powers are irrational, using unique factorization"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "nth_root_irrational",
+      "type": "core",
+      "description": "The nth root of a positive integer is irrational unless it is a perfect nth power",
+      "leanType": "(n k : Nat) -> 1 < n -> not (exists m, k = m^n) -> Irrational (k^(1/n : R))"
+    }
   ]
 }

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -316,5 +316,13 @@
       "venue": "Cambridge University Press",
       "note": "Comprehensive textbook covering P vs NP, circuit complexity, and the barriers (relativization, natural proofs, algebrization) to resolving the question"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "p_vs_np",
+      "type": "core",
+      "description": "Millennium Prize: Is P equal to NP?",
+      "leanType": "P = NP or P != NP (independent of current axioms)"
+    }
   ]
 }

--- a/src/data/proofs/parallel-postulate-independence/meta.json
+++ b/src/data/proofs/parallel-postulate-independence/meta.json
@@ -160,5 +160,13 @@
       "venue": "W.H. Freeman, 4th edition",
       "note": "Comprehensive treatment of the parallel postulate's history and the development of non-Euclidean geometry"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "parallel_postulate_independent",
+      "type": "core",
+      "description": "The parallel postulate is independent of the other Euclidean axioms",
+      "leanType": "Consistent (EuclidAxioms without P5) -> not (Provable (EuclidAxioms without P5) P5)"
+    }
   ]
 }

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -218,5 +218,13 @@
       "venue": "Paris",
       "note": "Statement of Pascal's mystic hexagram theorem: opposite sides of a hexagon inscribed in a conic meet in three collinear points — discovered at age 16"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "pascal_hexagon",
+      "type": "core",
+      "description": "If a hexagon is inscribed in a conic, the three intersection points of opposite sides are collinear",
+      "leanType": "inscribed_in_conic hexagon -> collinear (opposite_intersections hexagon)"
+    }
   ]
 }

--- a/src/data/proofs/pell-equation/meta.json
+++ b/src/data/proofs/pell-equation/meta.json
@@ -202,5 +202,19 @@
       "venue": "Notices of the AMS 49(2), 182–192",
       "note": "Modern survey of algorithms for solving Pell's equation including connections to class field theory"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "pell_fundamental_solution",
+      "type": "core",
+      "description": "Pell's equation x^2 - Dy^2 = 1 has a fundamental solution for non-square D",
+      "leanType": "(D : Nat) -> not (IsSquare D) -> exists x y : Int, x^2 - D * y^2 = 1 and x > 0 and y > 0"
+    },
+    {
+      "name": "pell_all_solutions",
+      "type": "key",
+      "description": "All solutions are powers of the fundamental solution",
+      "leanType": "PellSolution D -> exists n : Int, sol = fundamental_sol D ^ n"
+    }
   ]
 }

--- a/src/data/proofs/perfect-numbers/meta.json
+++ b/src/data/proofs/perfect-numbers/meta.json
@@ -245,5 +245,19 @@
       "relationship": "related",
       "description": "The Mersenne number $M_p = 2^p - 1$ factors as $(2-1)(2^{p-1} + 2^{p-2} + \\cdots + 1)$ when $p$ is composite (via the factorization $x^{ab} - 1 = (x^a - 1)(x^{a(b-1)} + \\cdots + 1)$). This explains why Mersenne primes require $p$ to be prime: if $p = ab$ then $2^a - 1 \\mid 2^p - 1$"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "euclid_euler",
+      "type": "core",
+      "description": "n is an even perfect number iff n = 2^(p-1)(2^p - 1) with 2^p - 1 prime",
+      "leanType": "EvenPerfect n <-> exists p, Nat.Prime (2^p - 1) and n = 2^(p-1) * (2^p - 1)"
+    },
+    {
+      "name": "sigma_perfect",
+      "type": "key",
+      "description": "n is perfect iff sigma(n) = 2n",
+      "leanType": "Perfect n <-> Nat.sigma n = 2 * n"
+    }
   ]
 }

--- a/src/data/proofs/pi-transcendental/meta.json
+++ b/src/data/proofs/pi-transcendental/meta.json
@@ -210,5 +210,19 @@
     "axiomCount": 8,
     "theoremCount": 11,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "pi_transcendental",
+      "type": "core",
+      "description": "Pi is transcendental over Q",
+      "leanType": "Transcendental Q Real.pi"
+    },
+    {
+      "name": "squaring_circle_impossible",
+      "type": "key",
+      "description": "Squaring the circle is impossible (corollary of pi's transcendence)",
+      "leanType": "not (Constructible Real.pi)"
+    }
+  ]
 }

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -350,5 +350,25 @@
         "leanType": "RiemannHypothesis → |primePi x - logIntegral x| = O(√x · ln x)"
       }
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "all_formulations_equiv",
+      "type": "bridge",
+      "description": "All four PNT formulations (ratio, equivalence, error, Li) are equivalent",
+      "leanType": "PNT_Ratio <-> PNT_Equiv and PNT_Error and PNT_Li"
+    },
+    {
+      "name": "prime_asymptotic",
+      "type": "core",
+      "description": "pi(x) ~ x/ln(x) as x -> infinity",
+      "leanType": "PrimeNumberTheorem_Equiv"
+    },
+    {
+      "name": "pnt_rh_error",
+      "type": "synthesis",
+      "description": "Under RH, |pi(x) - Li(x)| = O(sqrt(x) ln x) (von Koch)",
+      "leanType": "RiemannHypothesis -> |primePi x - logIntegral x| = O(sqrt(x) * ln(x))"
+    }
+  ]
 }

--- a/src/data/proofs/prime-reciprocal-divergence/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence/meta.json
@@ -188,5 +188,13 @@
       "venue": "Commentarii Academiae Scientiarum Petropolitanae 9, 160–188",
       "note": "Proved that the sum of reciprocals of primes diverges — the first result on the distribution of primes"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "prime_reciprocal_diverges",
+      "type": "core",
+      "description": "The sum of reciprocals of primes diverges",
+      "leanType": "not (Summable (fun p => 1 / p : {p : Nat // Nat.Prime p} -> R))"
+    }
   ]
 }

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -185,5 +185,13 @@
       "venue": "Alexandria",
       "note": "The power of a point theorem: if two chords intersect inside a circle, the products of their segments are equal"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "intersecting_chords",
+      "type": "core",
+      "description": "If two chords intersect inside a circle, the products of their segments are equal: PA*PB = PC*PD",
+      "leanType": "chords_intersect_at P -> PA * PB = PC * PD"
+    }
   ]
 }

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -198,5 +198,13 @@
       "venue": "Springer",
       "note": "Modern treatment of Ptolemy's theorem in the context of Euclidean and non-Euclidean geometry"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "ptolemy",
+      "type": "core",
+      "description": "In a cyclic quadrilateral: AC*BD = AB*CD + AD*BC",
+      "leanType": "cyclic_quadrilateral ABCD -> AC*BD = AB*CD + AD*BC"
+    }
   ]
 }

--- a/src/data/proofs/pythagorean-theorem/meta.json
+++ b/src/data/proofs/pythagorean-theorem/meta.json
@@ -342,5 +342,25 @@
         "leanType": "{ι : Type*} → [DecidableEq ι] → {s : Finset ι} → {v : ι → Vec2} → pairwise_perp → ‖∑ i in s, v i‖^2 = ∑ i in s, ‖v i‖^2"
       }
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "pythagorean_theorem",
+      "type": "core",
+      "description": "For perpendicular vectors v and w: ||v + w||^2 = ||v||^2 + ||w||^2",
+      "leanType": "(v w : Vec2) -> v perp w -> norm(v + w)^2 = norm(v)^2 + norm(w)^2"
+    },
+    {
+      "name": "pythagorean_converse",
+      "type": "synthesis",
+      "description": "If ||v + w||^2 = ||v||^2 + ||w||^2, then v is perpendicular to w",
+      "leanType": "(v w : Vec2) -> norm(v + w)^2 = norm(v)^2 + norm(w)^2 -> v perp w"
+    },
+    {
+      "name": "pythagorean_sum",
+      "type": "key",
+      "description": "Generalized Pythagorean theorem for finitely many pairwise orthogonal vectors",
+      "leanType": "{s : Finset i} -> {v : i -> Vec2} -> pairwise_perp -> norm(sum v)^2 = sum(norm(v i)^2)"
+    }
+  ]
 }

--- a/src/data/proofs/quadratic-reciprocity/meta.json
+++ b/src/data/proofs/quadratic-reciprocity/meta.json
@@ -277,5 +277,25 @@
       "venue": "https://www.cs.ru.nl/~freek/100/",
       "note": "Lists quadratic reciprocity as theorem #7 in the 100 most important mathematical theorems to formalize; this Lean proof fulfills that entry"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "quadratic_reciprocity_product",
+      "type": "core",
+      "description": "Main law: (p/q)(q/p) = (-1)^((p-1)/2 * (q-1)/2) for odd primes p != q",
+      "leanType": "[Fact p.Prime] -> [Fact q.Prime] -> p != 2 -> q != 2 -> p != q -> legendreSym q p * legendreSym p q = (-1)^(p/2 * q/2)"
+    },
+    {
+      "name": "first_supplementary_law",
+      "type": "key",
+      "description": "First supplement: -1 is a QR mod p iff p = 1 (mod 4)",
+      "leanType": "[Fact p.Prime] -> IsSquare (-1 : ZMod p) <-> p % 4 != 3"
+    },
+    {
+      "name": "second_supplementary_law",
+      "type": "key",
+      "description": "Second supplement: 2 is a QR mod p iff p = +/-1 (mod 8)",
+      "leanType": "[Fact p.Prime] -> p != 2 -> IsSquare (2 : ZMod p) <-> p % 8 = 1 or p % 8 = 7"
+    }
   ]
 }

--- a/src/data/proofs/ramanujan-sum-fallacy/meta.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/meta.json
@@ -199,5 +199,13 @@
       "venue": "Oxford University Press",
       "note": "Rigorous treatment of summability methods that give meaning to divergent series like Ramanujan's"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "ramanujan_sum",
+      "type": "core",
+      "description": "The Ramanujan/zeta regularization: 1+2+3+... 'equals' -1/12",
+      "leanType": "riemannZeta (-1) = -1/12"
+    }
   ]
 }

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -342,5 +342,13 @@
     "axiomCount": 32,
     "theoremCount": 358,
     "definitionCount": 38
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "riemann_hypothesis",
+      "type": "core",
+      "description": "All non-trivial zeros of the Riemann zeta function have real part 1/2",
+      "leanType": "riemannZeta s = 0 -> s.re != 0 -> s.re != 1 -> s.re = 1/2"
+    }
+  ]
 }

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -244,5 +244,13 @@
       "Metric",
       "Filter"
     ]
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "schauder_fixed_point",
+      "type": "core",
+      "description": "Every continuous map from a convex compact subset of a Banach space to itself has a fixed point",
+      "leanType": "Convex K -> IsCompact K -> Continuous f -> maps_to f K K -> exists x in K, f x = x"
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -177,5 +177,13 @@
       "venue": "Wiley, 2nd edition",
       "note": "Standard graduate textbook for information theory including all of Shannon's coding theorems"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "shannon_capacity",
+      "type": "core",
+      "description": "Reliable communication is possible at rates below channel capacity C, impossible above",
+      "leanType": "rate < capacity channel -> exists code, error_prob code < epsilon"
+    }
   ]
 }

--- a/src/data/proofs/solution-of-cubic/meta.json
+++ b/src/data/proofs/solution-of-cubic/meta.json
@@ -226,5 +226,13 @@
       "venue": "Springer",
       "note": "Detailed historical account of the dramatic priority dispute between Cardano and Tartaglia over the cubic formula"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "cardano_formula",
+      "type": "core",
+      "description": "Cardano's formula for roots of depressed cubic t^3 + pt + q = 0",
+      "leanType": "t^3 + p*t + q = 0 -> t = cbrt(-q/2 + sqrt(q^2/4 + p^3/27)) + cbrt(-q/2 - sqrt(q^2/4 + p^3/27))"
+    }
   ]
 }

--- a/src/data/proofs/sqrt2-irrational/meta.json
+++ b/src/data/proofs/sqrt2-irrational/meta.json
@@ -222,5 +222,13 @@
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "sqrt2_irrational",
+      "type": "core",
+      "description": "The square root of 2 is irrational",
+      "leanType": "Irrational (Real.sqrt 2)"
+    }
+  ]
 }

--- a/src/data/proofs/sylow-theorems-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-02/meta.json
@@ -144,6 +144,22 @@
       "endLine": 298,
       "summary": "A markdown summary table listing all 12 declarations (5 axioms, 7 theorems) with their status (proved/axiom/sorry), followed by `#check` commands verifying that all declarations have the expected types. Confirms the final tally: 5 axioms, 1 sorry, 7 proved theorems.",
       "mathContext": "The `#check` commands serve as a lightweight verification that all declarations are well-typed and properly exported from the `ProfiniteSylow` namespace."
+    },
+    {
+      "id": "finite-recovery-extended",
+      "title": "Pro-p Theory in Finite Groups",
+      "startLine": 299,
+      "endLine": 341,
+      "summary": "Proves the equivalence IsProP iff IsPGroup for finite groups with discrete topology. Shows every classical Sylow p-subgroup is closed and pro-p. Proves pro-p subgroups have p-power order.",
+      "mathContext": "Finite recovery: IsProP $\\iff$ IsPGroup for discrete finite groups. Every Sylow $p$-subgroup is closed and pro-$p$. Pro-$p$ implies $|H| = p^k$."
+    },
+    {
+      "id": "counting-and-summary",
+      "title": "Counting Theorem and Verification",
+      "startLine": 342,
+      "endLine": 393,
+      "summary": "Proves n_p is congruent to 1 mod p for finite quotients. Summary of all 15 results: 5 axioms and 10 proved theorems. Verification via #check on all key definitions.",
+      "mathContext": "Sylow counting: $n_p \\equiv 1 \\pmod{p}$. Score: 5 axioms, 10 proved theorems, 0 sorries."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -289,5 +289,25 @@
       "venue": "https://www.cs.ru.nl/~freek/100/",
       "note": "The Sylow Theorems are #72 on Wiedijk's list of 100 well-known mathematical theorems and their formalization status across proof assistants"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sylow_existence",
+      "type": "core",
+      "description": "If p^k divides |G|, then G has a subgroup of order p^k",
+      "leanType": "(p : Nat) -> Nat.Prime p -> p^k | Fintype.card G -> exists H : Subgroup G, Fintype.card H = p^k"
+    },
+    {
+      "name": "sylow_conjugacy",
+      "type": "key",
+      "description": "All Sylow p-subgroups are conjugate",
+      "leanType": "(P Q : Sylow p G) -> exists g, P = g * Q * g^(-1)"
+    },
+    {
+      "name": "sylow_counting",
+      "type": "key",
+      "description": "The number of Sylow p-subgroups divides |G|/p^k and is congruent to 1 mod p",
+      "leanType": "card (Sylow p G) % p = 1 and card (Sylow p G) | (card G / p^k)"
+    }
   ]
 }

--- a/src/data/proofs/taylor-theorem/meta.json
+++ b/src/data/proofs/taylor-theorem/meta.json
@@ -229,5 +229,13 @@
       "venue": "McGraw-Hill, 3rd edition",
       "note": "Standard textbook proof of Taylor's theorem with remainder in various forms (Lagrange, Cauchy, integral)"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "taylor_theorem",
+      "type": "core",
+      "description": "f(x) = sum_{k=0}^n f^(k)(a)/k! * (x-a)^k + R_n(x) with Lagrange remainder",
+      "leanType": "ContDiff n f -> exists c between a x, f x = taylorPoly n f a x + f^(n+1)(c) / (n+1)! * (x-a)^(n+1)"
+    }
   ]
 }

--- a/src/data/proofs/triangle-angle-sum/meta.json
+++ b/src/data/proofs/triangle-angle-sum/meta.json
@@ -188,5 +188,13 @@
       "relationship": "extends",
       "description": "Euler's formula V - E + F = 2 generalizes angle-sum properties to polyhedra: the angle defect at each vertex of a convex polyhedron sums to 4π (Descartes's theorem), a polyhedral analog of the triangle angle sum."
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "triangle_angle_sum",
+      "type": "core",
+      "description": "Sum of interior angles of a triangle equals pi (180 degrees)",
+      "leanType": "Triangle ABC -> angle A + angle B + angle C = pi"
+    }
   ]
 }

--- a/src/data/proofs/twin-primes-special/meta.json
+++ b/src/data/proofs/twin-primes-special/meta.json
@@ -155,5 +155,13 @@
       "venue": "Annals of Mathematics 179(3), 1121–1174",
       "note": "Proved the first finite bound on prime gaps — a major step toward the twin prime conjecture"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "twin_prime_conjecture",
+      "type": "core",
+      "description": "There are infinitely many pairs of primes differing by 2",
+      "leanType": "Set.Infinite {p | Nat.Prime p and Nat.Prime (p + 2)}"
+    }
   ]
 }

--- a/src/data/proofs/vietas-formulas/meta.json
+++ b/src/data/proofs/vietas-formulas/meta.json
@@ -166,5 +166,19 @@
       "venue": "Paris (published posthumously)",
       "note": "Introduced the symmetric function relations between roots and coefficients of a polynomial — Vieta's formulas"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "vieta_sum",
+      "type": "core",
+      "description": "Sum of roots equals -a_{n-1}/a_n (coefficient of x^{n-1})",
+      "leanType": "(p : Polynomial R) -> sum(roots p) = -p.coeff(p.natDegree - 1) / p.leadingCoeff"
+    },
+    {
+      "name": "vieta_product",
+      "type": "key",
+      "description": "Product of roots equals (-1)^n * a_0/a_n (constant term ratio)",
+      "leanType": "(p : Polynomial R) -> prod(roots p) = (-1)^p.natDegree * p.coeff 0 / p.leadingCoeff"
+    }
   ]
 }

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -332,5 +332,13 @@
       "venue": "Clay Mathematics Institute Millennium Problems",
       "note": "Official problem statement for the $1 million Clay prize — proving existence of the mass gap"
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "yang_mills_mass_gap",
+      "type": "core",
+      "description": "Millennium Prize: Yang-Mills theory exists and has a mass gap",
+      "leanType": "YangMillsTheory G -> exists m > 0, mass_gap m (quantized_theory G)"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
Major gallery-wide enrichment pass covering sections and mainTheorems.

### 1. Missing sections for Lean file coverage (6 entries)
Added sections covering previously uncovered code regions in:
- basel-problem-oq-02, halting-problem, cayley-hamilton-minpoly-oq-03
- descartes-rule-of-signs-oq-02, inverse-galois-oq-01, sylow-theorems-oq-02

### 2. mainTheorems metadata (170 entries, 8 batches)
Added `mainTheorems` arrays with theorem names, types, descriptions, and Lean type signatures. **All non-Erdős, non-OQ top-level entries now have mainTheorems (100% coverage).**

Categories covered:
- **Classic theorems**: Pythagorean, Cauchy-Schwarz, binomial, AM-GM, FTC, MVT, Taylor, Stirling
- **Number theory**: quadratic reciprocity, PNT, Fermat two squares, Wilson, Kummer, Wolstenholme
- **Set theory/logic**: halting problem, Gödel incompleteness, Cantor, Schroeder-Bernstein, CH
- **Algebra**: Abel-Ruffini, Cayley-Hamilton, FTA, Sylow, Lagrange, Vieta, quartic formula
- **Analysis**: CLT, LLN, Fourier, Lebesgue, L'Hôpital, IVT, Liouville
- **Geometry**: Borsuk-Ulam, Brouwer, isoperimetric, Platonic solids, Pick, Euler polyhedral
- **Hilbert problems**: 3-6, 9-11, 13-17, 19-23 (all 23 covered)
- **Millennium problems**: Navier-Stokes, Yang-Mills, BSD, Hodge, P vs NP, Riemann, Poincaré
- **Probabilistic method**: expectation, alteration, second moment, Lovász local lemma
- **Szemerédi**: regularity, counting, core, full theorem, Roth k=3
- And many more

## Test plan
- [x] All 1544 meta.json files parse as valid JSON
- [x] No new errors from annotations build validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)