### PR TITLE
Enrich: fix review items + status/count mismatches

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-03-24",
-    "status": "axiomatized",
+    "status": "formalized",
     "tags": [
       "algebra",
       "galois-theory",
@@ -24,7 +24,7 @@
       "Proofs/InverseGaloisA5.lean",
       "Proofs/AbelRuffiniOQ04OQ01.lean"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 1,
     "axiomCount": 0,
     "prerequisites": [


### PR DESCRIPTION
## Summary
Multi-entry enrichment pass addressing peer review items and data quality issues.

### erdos-273 (6 review items)
- Fixed "axiomatized" → "proved" (all 13 theorems proved, 0 axioms)
- Updated section/annotation line ranges, mathlibDependencies

### bezout-identity-oq-03 (2 review items)
- Fixed section overlap and annotation type

### inverse-galois-oq-01 (status fix)
- Fixed status "axiomatized" → "formalized" (has 1 sorry, 0 axioms)
- Updated badge to match

### erdos-28 (count fixes)
- Fixed leanFile counts: axiomCount 4→3, theoremCount 13→14, defCount 10→11

### erdos-332 (section fix)
- Fixed section description ("four axiomatized" → "2 axioms + 2 proved")
- Added erdos-3 cross-reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)