### PR TITLE
Enrich 10 entries: add/fix mainTheorems, sections, cross-refs

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -116,6 +116,11 @@
       "targetId": "abel-ruffini-oq-04-oq-01",
       "relationship": "extended-by",
       "description": "Completes the proof chain with a concrete witness: proves Gal(x^5 - 4x + 2 / Q) = S_5 and that this specific polynomial is unsolvable by radicals, instantiating the abstract group-theoretic chain proved here"
+    },
+    {
+      "targetId": "inverse-galois-oq-01",
+      "relationship": "related",
+      "description": "Proves the complete solvability characterization: Sₙ and Aₙ are solvable iff n ≤ 4, and [S₅,S₅] = A₅. Provides the full bidirectional threshold that this file witnesses from one side (non-solvability for n ≥ 5)"
     }
   ],
   "overview": {
@@ -226,6 +231,32 @@
     "trivialSpecializations": 6,
     "definitionCount": 0
   },
+  "mainTheorems": [
+    {
+      "name": "symmetric_not_solvable",
+      "type": "core",
+      "description": "The symmetric group Sₙ is not solvable for n ≥ 5. Bridges Mathlib's cardinal-level Equiv.Perm.not_solvable to a natural number bound via simp + exact_mod_cast",
+      "leanType": "(n : ℕ) → 5 ≤ n → ¬ IsSolvable (Equiv.Perm (Fin n))"
+    },
+    {
+      "name": "a5_is_simple",
+      "type": "alias",
+      "description": "A₅ is a simple group — direct alias for Mathlib's alternatingGroup.isSimpleGroup_five",
+      "leanType": "IsSimpleGroup (alternatingGroup (Fin 5))"
+    },
+    {
+      "name": "five_is_the_threshold",
+      "type": "key",
+      "description": "The exact solvability threshold: S₁ is solvable and S₅ is not, witnessing the sharp dichotomy at n = 5",
+      "leanType": "IsSolvable (Equiv.Perm (Fin 1)) ∧ ¬ IsSolvable (Equiv.Perm (Fin 5))"
+    },
+    {
+      "name": "s5_not_solvable",
+      "type": "specialization",
+      "description": "S₅ is not solvable — direct application of symmetric_not_solvable to n = 5",
+      "leanType": "¬ IsSolvable (Equiv.Perm (Fin 5))"
+    }
+  ],
   "references": [
     {
       "key": "Ab24",

--- a/src/data/proofs/erdos-1055/annotations.json
+++ b/src/data/proofs/erdos-1055/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "erdos-1055-termination",
+    "proofId": "erdos-1055",
+    "range": {
+      "startLine": 30,
+      "endLine": 62
+    },
+    "type": "technique",
+    "title": "Termination Lemma: nonSmooth_factor_lt",
+    "content": "The key lemma enabling well-founded recursion for `primeClass`: any prime factor $q$ of $p+1$ with $q \\notin \\{2,3\\}$ satisfies $q < p$. The proof proceeds by contradiction: $q \\leq p+1$ (since $q \\mid p+1$), and $q = p$ is impossible (since $p \\mid p+1$ implies $p \\mid 1$), and $q = p+1$ is impossible (since $p+1$ being prime and even — because $p$ is odd — forces $p+1 = 2$, contradiction). This strict decrease $q < p$ is the termination argument: recursive calls to `primeClass q` always use a smaller input.",
+    "mathContext": "If $p$ is prime and $q \\mid (p+1)$ with $q \\neq 2, 3$ and $q$ prime, then $q < p$. Proof: $q \\leq p+1$; if $q = p$ then $p \\mid (p+1)$ so $p \\mid 1$, impossible; if $q = p+1$ then $p+1$ is prime but $2 \\mid (p+1)$ (since $p$ is odd prime), so $p+1 = 2$, contradiction. Hence $q \\leq p-1 < p$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "well-founded recursion",
+      "termination proofs",
+      "prime divisor bounds",
+      "omega-decidability"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "well-founded induction"
+    ]
+  },
+  {
     "id": "prime-class",
     "proofId": "erdos-1055",
     "range": {

--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -78,18 +78,18 @@
     },
     {
       "id": "structural",
-      "title": "Structural Properties",
-      "startLine": 130,
-      "endLine": 222,
-      "summary": "Proves key structural results: class monotonicity ($c(q) < c(p)$ for nonSmooth factors), class-1 characterization ($c(p)=1 \\iff p+1$ is $3$-smooth), and positivity ($c(p) \\ge 1$ for primes). All fully proved with 0 sorries.",
+      "title": "Structural Properties and Concrete Evidence",
+      "startLine": 131,
+      "endLine": 200,
+      "summary": "Proves key structural results: class monotonicity ($c(q) < c(p)$ for nonSmooth factors), class-1 characterization ($c(p)=1 \\iff p+1$ is $3$-smooth), positivity ($c(p) \\ge 1$ for primes), and concrete evidence for infinitude (counting primes in classes 1-3 via native_decide).",
       "mathContext": "Monotonicity: $q \\mid (p+1), q \\notin \\{2,3\\} \\implies c(q) < c(p)$. Class-1 characterization: $c(p) = 1 \\iff p + 1 = 2^a \\cdot 3^b$ ($p+1$ is 3-smooth). Positivity: $c(p) \\geq 1$ for all primes $p$."
     },
     {
       "id": "conjectures",
       "title": "Main Conjectures (OPEN)",
-      "startLine": 222,
+      "startLine": 202,
       "endLine": 222,
-      "summary": "States the OPEN conjectures as axioms: infinitude of each class, Erdős growth conjecture ($p_r^{1/r} \\to \\infty$), Selfridge bounded conjecture ($p_r^{1/r}$ bounded), and subpolynomial density of each class.",
+      "summary": "States the four OPEN conjectures as axioms: infinitude of each class, Erdős growth conjecture ($p_r^{1/r} \\to \\infty$), Selfridge bounded conjecture ($p_r^{1/r}$ bounded), and subpolynomial density of each class. Note Erdős and Selfridge conjectures are mutually exclusive.",
       "mathContext": "Four axioms: (1) $|\\{p \\leq n : c(p) = r\\}| \\to \\infty$; (2) Erdős: $p_r^{1/r} \\to \\infty$; (3) Selfridge: $\\exists C, p_r^{1/r} \\leq C$; (4) $|\\{p \\leq n : c(p) = r\\}| = n^{o(1)}$. Note (2) and (3) are mutually exclusive."
     }
   ],
@@ -122,6 +122,50 @@
       "Does the analogous $p - 1$ classification behave differently? The $p - 1$ variant connects to Cunningham chains and may have different growth properties."
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "nonSmooth_factor_lt",
+      "type": "core",
+      "description": "Termination lemma: any non-{2,3} prime factor q of p+1 satisfies q < p, enabling well-founded recursion on primeClass",
+      "leanType": "{p q : ℕ} → Nat.Prime p → q ∈ ((p + 1).primeFactorsList.dedup.filter (fun r => r != 2 && r != 3)) → q < p"
+    },
+    {
+      "name": "class_of_factor_lt",
+      "type": "core",
+      "description": "Class monotonicity: if q is a non-{2,3} prime factor of p+1, then primeClass q < primeClass p",
+      "leanType": "(p q : ℕ) → Nat.Prime p → Nat.Prime q → q ∣ p + 1 → q ≠ 2 → q ≠ 3 → primeClass q < primeClass p"
+    },
+    {
+      "name": "class_one_iff_smooth",
+      "type": "core",
+      "description": "Class-1 characterization: primeClass p = 1 iff all prime factors of p+1 are 2 or 3 (p+1 is 3-smooth)",
+      "leanType": "(p : ℕ) → Nat.Prime p → (primeClass p = 1 ↔ ∀ q ∈ (p + 1).primeFactorsList, q = 2 ∨ q = 3)"
+    },
+    {
+      "name": "primeClass_pos_of_prime",
+      "type": "supporting",
+      "description": "Every prime has class at least 1",
+      "leanType": "(p : ℕ) → Nat.Prime p → primeClass p ≥ 1"
+    },
+    {
+      "name": "infinitely_many_in_each_class",
+      "type": "axiom",
+      "description": "For each r ≥ 1, there are infinitely many primes in class r (OPEN conjecture)",
+      "leanType": "(r : ℕ) → r ≥ 1 → Set.Infinite {p : ℕ | p.Prime ∧ primeClass p = r}"
+    },
+    {
+      "name": "erdos_growth_conjecture",
+      "type": "axiom",
+      "description": "Erdős's conjecture: p_r^(1/r) → ∞ (superexponential growth of least class-r prime)",
+      "leanType": "∀ M : ℝ, ∃ R : ℕ, ∀ r ≥ R, ∀ p, p.Prime → primeClass p = r → (least in class) → p^(1/r) ≥ M"
+    },
+    {
+      "name": "selfridge_bounded_conjecture",
+      "type": "axiom",
+      "description": "Selfridge's conjecture: p_r^(1/r) is bounded (at most exponential growth). Mutually exclusive with Erdős's conjecture",
+      "leanType": "∃ M : ℝ, ∀ r ≥ 1, ∀ p, p.Prime → primeClass p = r → (least in class) → p^(1/r) ≤ M"
+    }
+  ],
   "crossReferences": [
     {
       "relationship": "companion",

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -236,30 +236,40 @@
       "Mathlib.Data.Set.Basic",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Tactic"
-    ],
-    "mainTheorems": [
-      {
-        "name": "example_101",
-        "type": "verified",
-        "description": "p = 101 satisfies AllFactorialSubtractionsComposite"
-      },
-      {
-        "name": "example_211",
-        "type": "verified",
-        "description": "p = 211 satisfies AllFactorialSubtractionsComposite"
-      },
-      {
-        "name": "counterexample_89",
-        "type": "verified",
-        "description": "p = 89 does NOT satisfy AllFactorialSubtractionsComposite (89-6=83 prime)"
-      },
-      {
-        "name": "ErdosProblem1059",
-        "type": "definition",
-        "description": "Set.Infinite {p : ℕ | p.Prime ∧ AllFactorialSubtractionsComposite p} (open conjecture, stated as def)"
-      }
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "example_101",
+      "type": "verified",
+      "description": "p = 101 satisfies AllFactorialSubtractionsComposite — verified by interval_cases + decide",
+      "leanType": "AllFactorialSubtractionsComposite 101"
+    },
+    {
+      "name": "example_211",
+      "type": "verified",
+      "description": "p = 211 satisfies AllFactorialSubtractionsComposite — verified by interval_cases + decide",
+      "leanType": "AllFactorialSubtractionsComposite 211"
+    },
+    {
+      "name": "counterexample_89",
+      "type": "verified",
+      "description": "p = 89 does NOT satisfy the property (89 - 3! = 83 is prime)",
+      "leanType": "¬ AllFactorialSubtractionsComposite 89"
+    },
+    {
+      "name": "two_witnesses",
+      "type": "core",
+      "description": "Summary: both 101 and 211 are prime and factorial-avoiding, packaging four proofs into one conjunction",
+      "leanType": "(Nat.Prime 101) ∧ AllFactorialSubtractionsComposite 101 ∧ (Nat.Prime 211) ∧ AllFactorialSubtractionsComposite 211"
+    },
+    {
+      "name": "erdos_alternative_approach",
+      "type": "axiom",
+      "description": "Erdős's smooth-number variant: infinitely many l-rough n in (l!, (l+1)!] with all factorial subtractions composite",
+      "leanType": "Set.Infinite {n : ℕ | ∃ l, l.factorial < n ∧ ...}"
+    }
+  ],
   "conclusion": {
     "summary": "Erdős Problem #1059 remains open: are there infinitely many primes $p$ with every factorial subtraction $p - k!$ composite? This 160-line formalization verifies two concrete witnesses ($p = 101, 211$) and one counterexample ($p = 89$) using Lean's certified `decide` tactic, reducing the infinite universal quantifier to finite case analysis via factorial growth bounds. The key structural insight is the extreme sparsity of factorials: only $O(\\log n / \\log \\log n)$ factorials lie below $n$, making the condition surprisingly mild for large primes. The probabilistic heuristic predicts density 1 among primes (each subtraction is independently prime with probability $\\sim 1/\\ln p$, and the few checks make all-composite increasingly likely), yet no rigorous proof exists. The formalization axiomatizes the main conjecture (`Set.Infinite`) alongside Erdős's smooth-number variant — replacing primality with $l$-roughness — which may be more tractable via sieve theory.",
     "implications": "**Theoretical Significance**: A resolution would illuminate the relationship between prime distribution and factorial arithmetic.\n\nThe probabilistic heuristic strongly suggests the answer is yes — in fact, it predicts that the density of qualifying primes among all primes approaches 1 — but converting such arguments into rigorous proofs remains a central challenge in analytic number theory.\n\nThe problem connects to several themes: (1) the general question of whether primes 'avoid' structured sequences (cf. Bunyakovsky conjecture, Bateman-Horn conjecture); (2) Erdős's smooth-number variant links to sieve theory and the Dickman function $\\rho(u)$, which governs the distribution of integers with no prime factors exceeding $n^{1/u}$; (3) the computational verification strategy — reducing an infinite problem to finite case analysis via factorial growth bounds — demonstrates a pattern common to many number-theoretic formalizations.",

--- a/src/data/proofs/erdos-106/meta.json
+++ b/src/data/proofs/erdos-106/meta.json
@@ -155,30 +155,68 @@
       "Is there a continuous analogue: what is $\\sup \\int_F s\\, d\\mu$ over packings of infinitely many squares?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "conjecture_equiv",
+      "type": "core",
+      "description": "The conjecture f(k²+1) = k is equivalent to f(k²+1) = f(k²) — one extra square beyond a perfect grid never helps",
+      "leanType": "∀ k : ℕ, k ≥ 1 → (f (k^2 + 1) = k ↔ f (k^2 + 1) = f (k^2))"
+    },
+    {
+      "name": "perfect_square_plateau",
+      "type": "core",
+      "description": "k² is a plateau point iff the conjecture holds at k: k² ∈ plateauSet ↔ f(k²+1) = k",
+      "leanType": "(k : ℕ) → k ≥ 1 → (k^2 ∈ plateauSet ↔ f (k^2 + 1) = k)"
+    },
+    {
+      "name": "one_in_plateau",
+      "type": "supporting",
+      "description": "1 is a plateau point: f(2) = f(1) = 1, the base case proved from f_1 and f_2 axioms",
+      "leanType": "1 ∈ plateauSet"
+    },
+    {
+      "name": "f_upper_bound",
+      "type": "supporting",
+      "description": "Cauchy-Schwarz bound: f(n) ≤ √n for all n",
+      "leanType": "(n : ℕ) → f n ≤ Real.sqrt n"
+    },
+    {
+      "name": "bku_theorem",
+      "type": "axiom",
+      "description": "Baek-Koizumi-Ueoro (2024): g(k²+1) = k for axis-parallel squares, resolving the restricted problem",
+      "leanType": "∀ k : ℕ, k ≥ 1 → g (k^2 + 1) = k"
+    }
+  ],
   "crossReferences": [
     {
-      "relationship": "Erdős Problem #99 asks whether minimal-diameter point sets with unit minimum distance must contain equilateral triangles — another packing optimality problem where Cauchy-Schwarz type arguments yield tight bounds on configurations.",
-      "targetId": "erdos-99"
+      "targetId": "erdos-99",
+      "relationship": "related",
+      "description": "Both are packing optimality problems: #99 asks about minimal-diameter point sets with unit minimum distance, #106 about maximizing side-length sum. Both use Cauchy-Schwarz type arguments for tight bounds"
     },
     {
-      "relationship": "Erdős Problem #103 counts incongruent optimal point configurations minimizing diameter, paralleling the question of how many combinatorially distinct optimal packings achieve f(k²) = k.",
-      "targetId": "erdos-103"
+      "targetId": "erdos-103",
+      "relationship": "related",
+      "description": "Both concern optimal discrete geometric configurations: #103 counts incongruent optimal point sets minimizing diameter, #106 asks about optimal square packings at perfect squares"
     },
     {
-      "relationship": "The Cauchy-Schwarz inequality is the central analytic tool: (Σsᵢ)² ≤ n·Σsᵢ² ≤ n gives f(n) ≤ √n, tight at perfect squares. The entire conjecture concerns when this bound can be matched just beyond a perfect square.",
-      "targetId": "cauchy-schwarz"
+      "targetId": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "The central analytic tool: (Σsᵢ)² ≤ n·Σsᵢ² ≤ n gives f(n) ≤ √n, tight at perfect squares. The entire conjecture concerns behavior just beyond these tight points"
     },
     {
-      "relationship": "The isoperimetric theorem is the prototype extremal geometry result: asking which shape maximizes area for fixed perimeter. The square packing problem similarly asks which packing maximizes total side length under a containment constraint, exhibiting the same rigidity-at-extrema phenomenon.",
-      "targetId": "isoperimetric-theorem"
+      "targetId": "isoperimetric-theorem",
+      "relationship": "related",
+      "description": "Prototype extremal geometry result: both ask which configuration maximizes an objective under a containment constraint, exhibiting the same rigidity-at-extrema phenomenon"
     },
     {
-      "relationship": "The Happy Ending Problem (Erdős–Szekeres) is a foundational Erdős combinatorial geometry problem where exact thresholds are conjectured for finite configurations. Like Problem #106, it features a well-known lower bound construction (convex position) and a long-open matching upper bound.",
-      "targetId": "erdos-107"
+      "targetId": "erdos-107",
+      "relationship": "related",
+      "description": "The Happy Ending Problem features a conjectured tight threshold for finite configurations, like #106. Both have known lower bound constructions and long-open matching upper bounds"
     },
     {
-      "relationship": "The Borsuk-Ulam theorem is a cornerstone of combinatorial topology applied to geometry. The axis-parallel BKU (2024) resolution of Problem #106 used topological and measure-theoretic techniques, placing the problem in the broader tradition of applying analytic tools to packing questions.",
-      "targetId": "borsuk-ulam"
+      "targetId": "borsuk-ulam",
+      "relationship": "related",
+      "description": "The BKU (2024) axis-parallel resolution used topological and measure-theoretic techniques, connecting to the broader tradition of applying analytic topology to packing questions"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -244,40 +244,50 @@
       "Mathlib.Tactic"
     ],
     "opens": [],
-    "namespace": null,
-    "mainTheorems": [
-      {
-        "name": "fourteen_examples_le_100",
-        "type": "verified",
-        "description": "All 14 Form A primes ≤ 100 verified: 3, 5, 7, 11, 13, 23, 29, 41, 47, 53, 59, 83, 89, 97"
-      },
-      {
-        "name": "strict_inclusion_37",
-        "type": "proved",
-        "description": "37 witnesses Form A ⊊ Form B: 37 = 2·3²·2 + 1 is Form B but not Form A"
-      },
-      {
-        "name": "not_form_b_71",
-        "type": "proved",
-        "description": "71 is not Form B: 70 = 2·5·7 has no 2^k·3^l·q factorization with q prime"
-      },
-      {
-        "name": "form_a_implies_b",
-        "type": "proved",
-        "description": "Form A ⊆ Form B via l = 0 specialization"
-      },
-      {
-        "name": "erdos_1065a",
-        "type": "axiom",
-        "description": "Set.Infinite {p prime | ∃ q prime, k : p = 2^k·q + 1}"
-      },
-      {
-        "name": "erdos_1065b",
-        "type": "axiom",
-        "description": "Set.Infinite {p prime | ∃ q prime, k, l : p = 2^k·3^l·q + 1}"
-      }
-    ]
+    "namespace": null
   },
+  "mainTheorems": [
+    {
+      "name": "fourteen_examples_le_100",
+      "type": "verified",
+      "description": "All 14 Form A primes ≤ 100 verified: 3, 5, 7, 11, 13, 23, 29, 41, 47, 53, 59, 83, 89, 97",
+      "leanType": "conjunction of IsTwoTimePrimePlusOne for each prime"
+    },
+    {
+      "name": "form_a_implies_b",
+      "type": "core",
+      "description": "Form A ⊆ Form B: every Form A prime is also Form B, via l = 0 specialization",
+      "leanType": "∀ p, IsTwoTimePrimePlusOne p → IsTwoThreeTimePrimePlusOne p"
+    },
+    {
+      "name": "conjecture_a_implies_b",
+      "type": "core",
+      "description": "Conjecture A implies Conjecture B via Set.Infinite.mono",
+      "leanType": "Set.Infinite {p | IsTwoTimePrimePlusOne p} → Set.Infinite {p | IsTwoThreeTimePrimePlusOne p}"
+    },
+    {
+      "name": "strict_inclusion_37",
+      "type": "supporting",
+      "description": "37 witnesses Form A ⊊ Form B: 37 = 2·3²·2 + 1 is Form B but not Form A"
+    },
+    {
+      "name": "not_form_b_71",
+      "type": "supporting",
+      "description": "71 is not Form B: 70 = 2·5·7 has no 2^k·3^l·q factorization with q prime"
+    },
+    {
+      "name": "erdos_1065a",
+      "type": "axiom",
+      "description": "Conjecture A: infinitely many primes p = 2^k·q + 1",
+      "leanType": "Set.Infinite {p : ℕ | IsTwoTimePrimePlusOne p}"
+    },
+    {
+      "name": "erdos_1065b",
+      "type": "axiom",
+      "description": "Conjecture B: infinitely many primes p = 2^k·3^l·q + 1",
+      "leanType": "Set.Infinite {p : ℕ | IsTwoThreeTimePrimePlusOne p}"
+    }
+  ],
   "references": [
     {
       "authors": "Guy, Richard K.",

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -106,24 +106,29 @@
   },
   "crossReferences": [
     {
-      "slug": "kepler-conjecture",
-      "relationship": "The Kepler conjecture (FCC sphere packing optimality) directly governs the large-n behavior of f₃(n): the conjectured lower bound f₃(n) ≥ 6n - Θ(n^{2/3}) would follow from understanding how finite FCC/HCP clusters approach the infinite-volume limit, making the Kepler structure the conjectured optimal configuration."
+      "targetId": "kepler-conjecture",
+      "relationship": "related",
+      "description": "The Kepler conjecture (FCC sphere packing optimality) governs f₃(n) asymptotics: the conjectured lower bound f₃(n) ≥ 6n - Θ(n^{2/3}) follows from finite FCC/HCP clusters approaching the infinite-volume limit"
     },
     {
-      "slug": "erdos-1085",
-      "relationship": "Erdős Problem #1085 studies the unit distance problem without the separation constraint (f_d(n) for arbitrary point sets). Problem #1084 imposes the additional ≥1 separation condition, which converts a graph-theoretic extremal problem into a sphere-packing one. The two problems share notation but differ sharply in difficulty and techniques."
+      "targetId": "erdos-1085",
+      "relationship": "companion",
+      "description": "Studies unit distances without the separation constraint. Problem #1084 adds the ≥1 separation condition, converting a graph-theoretic extremal problem into a sphere-packing one"
     },
     {
-      "slug": "erdos-1083",
-      "relationship": "Erdős Problem #1083 asks for the minimum number of distinct distances among n points in ℝ^d (f_d(n) = n^{2/d - o(1)}). Both problems use the same dimension-indexed function f_d(n) and the same Euclidean setup, and both exhibit an isoperimetric correction term of order n^{(d-1)/d} in the sub-leading behavior."
+      "targetId": "erdos-1083",
+      "relationship": "companion",
+      "description": "Asks for the minimum number of distinct distances among n points in ℝ^d. Both use dimension-indexed f_d(n) and exhibit isoperimetric correction terms of order n^{(d-1)/d}"
     },
     {
-      "slug": "erdos-1086",
-      "relationship": "Erdős Problem #1086 on triangles of equal area is a neighboring extremal combinatorial geometry problem sharing the same era (1971), the same authors (Erdős–Purdy), and the same incidence-geometry toolkit (Szemerédi–Trotter, algebraic methods). The techniques for bounding repeated distances and repeated areas overlap substantially."
+      "targetId": "erdos-1086",
+      "relationship": "related",
+      "description": "Neighboring extremal combinatorial geometry problem (Erdős-Purdy, 1971) on triangles of equal area, sharing incidence-geometry toolkit (Szemerédi-Trotter)"
     },
     {
-      "slug": "erdos-97",
-      "relationship": "Erdős Problem #97 on equidistant vertices in convex polygons is another discrete-geometry problem about distance multiplicity in point configurations. The kissing-number constraint τ(2) = 6 that drives f₂(n) ≤ 3n also bounds the number of vertices equidistant from a given point in convex position, linking the two problems via the hexagonal lattice geometry."
+      "targetId": "erdos-97",
+      "relationship": "related",
+      "description": "Distance multiplicity in point configurations: the kissing-number constraint τ(2) = 6 driving f₂(n) ≤ 3n also bounds equidistant vertices in convex position"
     }
   ],
   "references": [
@@ -163,5 +168,37 @@
     "substantiveTheoremCount": 0,
     "sorryTheorems": 3,
     "definitionCount": 2
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "unit_distance_1d_triangle",
+      "type": "core",
+      "description": "In 1D with ≥1 separation, three points cannot all be at unit distance — the fundamental triangle inequality for separated points",
+      "leanType": "(x y z : ℝ) → |x - y| ≥ 1 → |y - z| ≥ 1 → |x - z| ≥ 1 → ¬(|x - y| = 1 ∧ |y - z| = 1 ∧ |x - z| = 1)"
+    },
+    {
+      "name": "f1_upper_bound",
+      "type": "core",
+      "description": "The 1D upper bound: f₁(n) ≤ n - 1 for any separated configuration of n points",
+      "leanType": "(n : ℕ) → n ≥ 1 → (C : SeparatedConfig1D n) → unitDistPairs1D C ≤ n - 1"
+    },
+    {
+      "name": "f1_achievable",
+      "type": "core",
+      "description": "The 1D bound is tight: there exists a configuration achieving n - 1 unit distances (consecutive integers)",
+      "leanType": "(n : ℕ) → n ≥ 1 → ∃ C : SeparatedConfig1D n, unitDistPairs1D C = n - 1"
+    },
+    {
+      "name": "harborth_exact",
+      "type": "axiom",
+      "description": "Harborth's formula: f₂(n) = ⌊3n - √(12n-3)⌋ for separated points in ℝ², optimal on triangular lattice",
+      "leanType": "(n : ℕ) → n ≥ 2 → maxUnitDistPairs 2 n = ⌊3n - √(12n-3)⌋"
+    },
+    {
+      "name": "erdos_1084_d3_conjecture",
+      "type": "axiom",
+      "description": "The d=3 conjecture: f₃(n) ~ 6n - Θ(n^{2/3}), with leading coefficient from the kissing number τ(3) = 12",
+      "leanType": "∃ C₁ C₂ > 0, ∀ n ≥ 2, 6n - C₁·n^(2/3) ≤ maxUnitDistPairs 3 n ≤ 6n - C₂·n^(2/3)"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -260,30 +260,40 @@
       "Set",
       "Finset"
     ],
-    "namespace": null,
-    "mainTheorems": [
-      {
-        "name": "ratio_bounded_below",
-        "type": "proved",
-        "description": "g_d(n)/d^{n-1} ≥ c > 0 from the Erdős lower bound"
-      },
-      {
-        "name": "erdos1089Conjecture",
-        "type": "axiom",
-        "description": "Filter.Tendsto (gRatio · n) atTop (nhds L) — the limit exists"
-      },
-      {
-        "name": "erdos_lower_bound",
-        "type": "axiom",
-        "description": "g_d(n) ≥ c·d^{n-1} for n ≥ 2 (Erdős 1975)"
-      },
-      {
-        "name": "erdos_straus_upper_bound",
-        "type": "axiom",
-        "description": "g_d(n) ≤ c^{d^{1-b_n}} stretched-exponential upper bound"
-      }
-    ]
+    "namespace": null
   },
+  "mainTheorems": [
+    {
+      "name": "ratio_bounded_below",
+      "type": "core",
+      "description": "The ratio g_d(n)/d^{n-1} is bounded below by a positive constant — genuinely proved from the Erdős lower bound axiom",
+      "leanType": "(n : ℕ) → n ≥ 2 → ∃ c > 0, ∀ d ≥ 1, gRatio d n ≥ c"
+    },
+    {
+      "name": "g_mono_n",
+      "type": "core",
+      "description": "g_d is monotone in n: requiring more distinct distances needs at least as many points",
+      "leanType": "∀ d n₁ n₂, n₁ ≤ n₂ → g d n₁ ≤ g d n₂"
+    },
+    {
+      "name": "erdos1089Conjecture",
+      "type": "axiom",
+      "description": "The limit conjecture: g_d(n)/d^{n-1} converges as d → ∞ for each fixed n",
+      "leanType": "Filter.Tendsto (gRatio · n) atTop (nhds L)"
+    },
+    {
+      "name": "erdos_lower_bound",
+      "type": "axiom",
+      "description": "Erdős polynomial lower bound: g_d(n) ≥ c·d^{n-1} for n ≥ 2 (1975)",
+      "leanType": "∃ c > 0, ∀ d ≥ 1, g d n ≥ c * d^(n-1)"
+    },
+    {
+      "name": "erdos_straus_upper_bound",
+      "type": "axiom",
+      "description": "Erdős-Straus stretched-exponential upper bound: g_d(n) ≤ c^{d^{1-b_n}}",
+      "leanType": "∃ c > 1, ∃ b > 0, ∀ d ≥ 1, g d n ≤ c^(d^(1-b))"
+    }
+  ],
   "references": [
     {
       "authors": "Erdős, Paul",

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -214,5 +214,37 @@
     "axiomCount": 10,
     "theoremCount": 2,
     "definitionCount": 11
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "g_gt_k_plus_one",
+      "type": "core",
+      "description": "g(k) > k + 1 for all k — the Erdős-Selfridge function always exceeds k+1, proved from the definition",
+      "leanType": "(k : ℕ) → g k > k + 1"
+    },
+    {
+      "name": "g_is_k_rough",
+      "type": "core",
+      "description": "C(g(k), k) is k-rough — the defining property, proved from the minimality of g(k)",
+      "leanType": "(k : ℕ) → binomIsKRough (g k) k"
+    },
+    {
+      "name": "ees_lower_bound",
+      "type": "axiom",
+      "description": "Ecklund-Erdős-Selfridge lower bound: g(k) ≥ k^{1+c} for some c > 0 (1974)",
+      "leanType": "∃ c > 0, ∀ k ≥ 2, g k ≥ k^(1+c)"
+    },
+    {
+      "name": "ees_upper_bound",
+      "type": "axiom",
+      "description": "Ecklund-Erdős-Selfridge upper bound: g(k) ≤ exp((1+o(1))k) (1974)",
+      "leanType": "∀ ε > 0, ∃ K, ∀ k ≥ K, g k ≤ exp((1+ε)*k)"
+    },
+    {
+      "name": "konyagin_lower_bound",
+      "type": "axiom",
+      "description": "Konyagin's improved lower bound: g(k) ≥ exp(c·(log k)²) via Rankin's method (1999)",
+      "leanType": "∃ c > 0, ∀ k ≥ 2, g k ≥ exp(c * (log k)^2)"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -205,40 +205,46 @@
     "opens": [
       "Finset"
     ],
-    "namespace": null,
-    "mainTheorems": [
-      {
-        "name": "ap_diff_subset",
-        "type": "proved",
-        "description": "D(B) ⊆ D(A) for B ⊆ A (monotonicity)"
-      },
-      {
-        "name": "ap_diff_translate",
-        "type": "proved",
-        "description": "D(A + c) = D(A) (translation invariance)"
-      },
-      {
-        "name": "katz_tao_upper",
-        "type": "axiom",
-        "description": "|D(A)| = O(n^{11/6}) (Katz-Tao 1999, incidence geometry)"
-      },
-      {
-        "name": "lemm_lower",
-        "type": "axiom",
-        "description": "|D(A)| = Ω(n^{1.778}) (Lemm 2015, best human lower bound)"
-      },
-      {
-        "name": "chan_equivalence",
-        "type": "axiom",
-        "description": "3-AP exponent = Bourgain sums-differences exponent"
-      },
-      {
-        "name": "current_knowledge",
-        "type": "proved",
-        "description": "Summary: critical exponent lies in (1.778, 11/6]"
-      }
-    ]
+    "namespace": null
   },
+  "mainTheorems": [
+    {
+      "name": "ap_diff_subset",
+      "type": "core",
+      "description": "Monotonicity: D(B) ⊆ D(A) for B ⊆ A — fewer elements means fewer common differences",
+      "leanType": "∀ A B : Finset ℕ, B ⊆ A → apDiffSet B ⊆ apDiffSet A"
+    },
+    {
+      "name": "ap_diff_translate",
+      "type": "core",
+      "description": "Translation invariance: D(A + c) = D(A) — common differences are shift-invariant",
+      "leanType": "∀ A : Finset ℕ, ∀ c : ℕ, apDiffSet (A.map (· + c)) = apDiffSet A"
+    },
+    {
+      "name": "current_knowledge",
+      "type": "core",
+      "description": "Summary theorem: the critical exponent α lies in (1.778, 11/6], packaging the lower and upper bounds",
+      "leanType": "1.778 < α ∧ α ≤ 11/6"
+    },
+    {
+      "name": "katz_tao_upper",
+      "type": "axiom",
+      "description": "|D(A)| = O(n^{11/6}) — Katz-Tao 1999 upper bound via incidence geometry",
+      "leanType": "∃ C, ∀ A : Finset ℕ, |A| = n → |apDiffSet A| ≤ C * n^(11/6)"
+    },
+    {
+      "name": "lemm_lower",
+      "type": "axiom",
+      "description": "|D(A)| = Ω(n^{1.778}) — Lemm 2015, best known lower bound surpassing probabilistic barrier",
+      "leanType": "∃ c > 0, ∀ n, ∃ A : Finset ℕ, |A| = n ∧ |apDiffSet A| ≥ c * n^1.778"
+    },
+    {
+      "name": "chan_equivalence",
+      "type": "axiom",
+      "description": "The 3-AP exponent equals the Bourgain sums-differences exponent — Chan's structural equivalence",
+      "leanType": "apExponent = bourgainExponent"
+    }
+  ],
   "references": [
     {
       "authors": "Katz, Nets Hawk; Tao, Terence",

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -64,7 +64,8 @@
       "Powers of 2 give perfect completeness (binary representation) but are fragile: removing 2^k destroys all representations of 2^k. The challenge is building robustness into a ratio-2 sequence",
       "The cofinite robustness requirement means each integer must have 'many' different subset sum representations, so that deleting finitely many terms still leaves enough to cover almost everything",
       "The Tao-van Doorn construction perturbs powers of 2 with controlled redundancy, creating a sequence where the 'repair cost' of removing any finite set of terms is bounded",
-      "This is one of the solved Erdos problems, demonstrating that formal verification can capture and confirm combinatorial constructions"
+      "This is one of the solved Erdos problems, demonstrating that formal verification can capture and confirm combinatorial constructions",
+      "The formalization exposed a subtle set-vs-multiset trap: the naive closure property $s \\in P(A) \\wedge a \\in A \\Rightarrow s + a \\in P(A)$ is false because subsets are sets (no repeated elements). The corrected `subsetSums_insert` requires $a \\notin S$ — a non-trivial finding that illustrates how formal verification can catch errors invisible in informal reasoning"
     ],
     "prerequisites": [
       "Subset sum theory: completeness of sequences ($P(A) = \\{\\sum_{a \\in S} a : S \\subseteq A, S \\text{ finite}\\}$ covers all large integers), density of sumsets, and the binary representation threshold at ratio 2",
@@ -160,6 +161,32 @@
     "theoremCount": 3,
     "definitionCount": 8
   },
+  "mainTheorems": [
+    {
+      "name": "erdos347_affirmative",
+      "type": "axiom",
+      "description": "The answer to Erdős Problem 347 is affirmative: there exists a monotone sequence with ratio limit 2 such that every cofinite subsequence has density-1 subset sums",
+      "leanType": "ErdosProblem347"
+    },
+    {
+      "name": "subsetSums_insert",
+      "type": "core",
+      "description": "Corrected additive closure: if S ⊆ A witnesses sum s and a ∈ A \\ S, then s + a ∈ P(A). Requires the fresh-witness condition a ∉ S",
+      "leanType": "(A : Set ℕ) → (S : Finset ℕ) → (a : ℕ) → ↑S ⊆ A → a ∈ A → a ∉ S → S.sum id + a ∈ subsetSums A"
+    },
+    {
+      "name": "zero_mem_subsetSums",
+      "type": "supporting",
+      "description": "The empty sum is 0: 0 ∈ P(A) for any A",
+      "leanType": "(A : Set ℕ) → 0 ∈ subsetSums A"
+    },
+    {
+      "name": "subsetSums_mono",
+      "type": "supporting",
+      "description": "Subset sums are monotone: A ⊆ B implies P(A) ⊆ P(B)",
+      "leanType": "(A B : Set ℕ) → A ⊆ B → subsetSums A ⊆ subsetSums B"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "erdos-1",
@@ -201,6 +228,20 @@
       "year": "1966",
       "venue": "Canadian Journal of Mathematics, vol. 18, pp. 643–655",
       "note": "Classical results on complete sequences and the relationship between growth rate and completeness"
+    },
+    {
+      "authors": "Cassels, J.W.S.",
+      "title": "On the representation of integers as the sums of distinct summands taken from a fixed set",
+      "year": "1960",
+      "venue": "Acta Scientiarum Mathematicarum, vol. 21, pp. 111–124",
+      "note": "Early systematic study of complete sequences; establishes growth-rate criteria for completeness that motivated the Erdős-Graham formulation"
+    },
+    {
+      "authors": "Hegyváry, Norbert; Hennecart, François; Lev, Vsevolod",
+      "title": "Subset sums and complete sequences",
+      "year": "2003",
+      "venue": "Annales de l'Institut Fourier, vol. 53, no. 3, pp. 781–791",
+      "note": "Results on subset sum completeness under various growth conditions; strengthens Folkman-type criteria"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Systematic enrichment pass across 10 gallery entries, focusing on adding `mainTheorems` fields, fixing cross-reference format, and correcting section ranges.

### Entries enriched:
| Entry | Changes |
|-------|---------|
| abel-ruffini-oq-04 | Added `mainTheorems` (4), cross-ref to inverse-galois-oq-01 |
| erdos-347 | Added `mainTheorems` (4), 6th keyInsight, 2 references |
| erdos-1055 | Added `mainTheorems` (7), fixed section ranges, added annotation |
| erdos-1059 | Moved `mainTheorems` to top level, expanded with `leanType` |
| erdos-106 | Added `mainTheorems` (5), fixed crossRefs format |
| erdos-1065 | Moved `mainTheorems` to top level (7 entries) |
| erdos-1084 | Added `mainTheorems` (5), fixed crossRefs (slug→targetId) |
| erdos-1089 | Moved `mainTheorems` to top level (5 entries) |
| erdos-1097 | Moved `mainTheorems` to top level (6 entries) |
| erdos-1095 | Added `mainTheorems` (5 entries) |

## Test plan
- [x] JSON validates for all 10 entries
- [x] All cross-reference targets verified to exist
- [x] Annotations build passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)