### PR TITLE
Enrich cayley-hamilton-minpoly-oq-05: fix stale sorry refs, unify badge

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05/annotations.json
@@ -139,11 +139,11 @@
     "proofId": "cayley-hamilton-minpoly-oq-05",
     "range": {
       "startLine": 166,
-      "endLine": 239
+      "endLine": 232
     },
     "type": "technique",
     "title": "Algebra Tower: Base Change of Minimal Polynomials",
-    "content": "**Tower theorems** for $K \\subseteq L \\subseteq A$:\n\n1. **Integrality lifts**: `IsIntegral K x → IsIntegral L x` via `IsIntegral.tower_top`\n2. **Tower divisibility**: $\\mu_L(x) | \\text{map}(\\mu_K(x))$ — the minimal polynomial over $L$ divides the base-changed one over $K$\n3. **Degree bound**: $\\deg(\\mu_L(x)) \\le \\deg(\\mu_K(x))$ — more polynomials available over $L$ means potentially smaller minpoly\n4. **Equality condition** (1 sorry): $\\mu_L(x) = \\text{map}(\\mu_K(x))$ when $\\text{map}(\\mu_K(x))$ remains irreducible over $L$\n\nThe sorry is in showing associated monic polynomials are equal.",
+    "content": "**Tower theorems** for $K \\subseteq L \\subseteq A$:\n\n1. **Integrality lifts**: `IsIntegral K x → IsIntegral L x` via `IsIntegral.tower_top`\n2. **Tower divisibility**: $\\mu_L(x) | \\text{map}(\\mu_K(x))$ — the minimal polynomial over $L$ divides the base-changed one over $K$\n3. **Degree bound**: $\\deg(\\mu_L(x)) \\le \\deg(\\mu_K(x))$ — more polynomials available over $L$ means potentially smaller minpoly\n4. **Equality condition**: $\\mu_L(x) = \\text{map}(\\mu_K(x))$ when $\\text{map}(\\mu_K(x))$ remains irreducible over $L$ (proved via `minpoly.eq_of_irreducible_of_monic`)",
     "mathContext": "In the tower $K \\subset L$, the base change $\\mu_K \\mapsto \\mu_K \\otimes_K L$ gives an annihilating polynomial over $L$. Since $\\mu_L$ is the minimal such, $\\mu_L | (\\mu_K \\otimes L)$. Equality holds iff $\\mu_K$ stays irreducible over $L$ — the criterion for the extension $K(x)/K$ being linearly disjoint from $L/K$.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
@@ -17,7 +17,7 @@
       "scalar-tower",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -33,11 +33,6 @@
       {
         "theorem": "minpoly.dvd",
         "description": "Minpoly divides any annihilating polynomial",
-        "module": "Mathlib.FieldTheory.Minpoly.Basic"
-      },
-      {
-        "theorem": "minpoly.irreducible",
-        "description": "Minimal polynomial is irreducible over the base field",
         "module": "Mathlib.FieldTheory.Minpoly.Basic"
       },
       {
@@ -67,14 +62,9 @@
       }
     ],
     "originalContributions": [
-      "minpoly_reduction: aeval x f = aeval x (f mod minpoly) for any integral x in a K-algebra",
-      "minpoly_annihilator_iff: aeval x f = 0 ↔ minpoly K x | f (full characterization)",
-      "minpoly_congruence_iff: aeval x f = aeval x g ↔ minpoly K x | (f - g)",
-      "power_reduction: x^k = aeval x (X^k mod minpoly) for higher power computation",
-      "minpoly_dvd_of_idempotent/involutory/nilpotent: special element minpoly divisibility",
-      "minpoly_dvd_map_of_tower: minpoly L x | (minpoly K x).map(algebraMap K L) in towers",
-      "minpoly_natDegree_tower_le: degree over L ≤ degree over K",
-      "minpoly_eq_map_of_irreducible: equality when base-changed minpoly stays irreducible (1 sorry)"
+      "Substantive proofs: minpoly_reduction (calc proof via division algorithm), minpoly_annihilator_iff (bidirectional characterization), minpoly_congruence_iff (quotient structure), power_reduction (efficient computation), minpoly_natDegree_tower_le (tower degree bound)",
+      "Pedagogical wrappers around Mathlib: minpoly_dvd_of_idempotent/involutory/nilpotent (special element divisibility, 2-line proofs via minpoly.dvd), minpoly_dvd_map_of_tower (tower divisibility), minpoly_eq_map_of_irreducible (equality via minpoly.eq_of_irreducible_of_monic)",
+      "Seven-section pedagogical organization mirroring textbook progression from core reduction through annihilator theory to tower behavior"
     ],
     "dateAdded": "2026-03-21",
     "prerequisites": [
@@ -181,15 +171,14 @@
       "title": "Section VII: Algebra Tower Reduction",
       "startLine": 166,
       "endLine": 232,
-      "summary": "For towers $K \\subseteq L \\subseteq A$: integrality lifts, $\\mu_L(x) | \\text{map}(\\mu_K(x))$, and $\\deg(\\mu_L(x)) \\le \\deg(\\mu_K(x))$. Equality holds when the mapped polynomial stays irreducible (1 sorry remaining)",
+      "summary": "For towers $K \\subseteq L \\subseteq A$: integrality lifts, $\\mu_L(x) | \\text{map}(\\mu_K(x))$, and $\\deg(\\mu_L(x)) \\le \\deg(\\mu_K(x))$. Equality holds when the mapped polynomial stays irreducible",
       "mathContext": "In the tower $K \\subset L \\subset A$, the minimal polynomial over $L$ divides the base change of the one over $K$: more polynomials are available over $L$, so the degree can only decrease. Equality $\\mu_L = \\text{map}(\\mu_K)$ holds iff $\\mu_K$ stays irreducible over $L$."
     }
   ],
   "conclusion": {
-    "summary": "This file develops two complementary theories: (1) modular arithmetic of polynomial evaluation via the minimal polynomial, showing that evaluation depends only on the remainder mod minpoly, and (2) base change behavior in algebra towers, proving degree can only decrease. All results except the irreducibility equality condition are fully verified.",
+    "summary": "This file develops two complementary theories: (1) modular arithmetic of polynomial evaluation via the minimal polynomial, showing that evaluation depends only on the remainder mod minpoly, and (2) base change behavior in algebra towers, proving degree can only decrease. All 23 theorems are fully verified with 0 sorries and 0 axioms.",
     "implications": "The modular reduction theory provides the algebraic foundation for efficient computation in quotient algebras K[x]/(minpoly). The tower results extend the K-algebra invariance theory to base-ring-changing transformations.",
     "openQuestions": [
-      "Complete the sorry in minpoly_eq_map_of_irreducible (show associated monic polynomials are equal)",
       "Can the minpoly over L be characterized via irreducible factors of the mapped minpoly?",
       "What is the relationship between [L:K] and the degree drop of the minimal polynomial?"
     ]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05/review.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05/review.json
@@ -101,28 +101,28 @@
       "priority": "high",
       "target": "enricher",
       "description": "Remove all stale sorry references: update originalContributions[7] to remove '(1 sorry)', update sections[6].summary to remove '1 sorry remaining', remove conclusion.openQuestions[0] about completing the sorry, and update annotation ann-chmoq05-6 to remove '(1 sorry)' from content.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",
       "priority": "medium",
       "target": "enricher",
       "description": "Unify badge fields: both meta.badge and root badge should be 'verified' (0 sorries, 0 axioms = verified per project conventions).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-3",
       "priority": "medium",
       "target": "enricher",
       "description": "Reframe originalContributions to distinguish substantive proofs (minpoly_reduction, minpoly_annihilator_iff, minpoly_congruence_iff, power_reduction, minpoly_natDegree_tower_le) from pedagogical Mathlib wrappers (minpoly_dvd_of_idempotent etc.).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",
       "priority": "low",
       "target": "enricher",
       "description": "Remove minpoly.irreducible from mathlibDependencies (not used in the Lean file). Fix annotation ann-chmoq05-6 endLine from 239 to 232.",
-      "status": "open"
+      "status": "resolved"
     }
   ],
 


### PR DESCRIPTION
## Summary
Address all 4 peer review action items for cayley-hamilton-minpoly-oq-05:
- Remove stale "(1 sorry)" references — all 23 theorems are fully proved
- Unify badge to `verified` (0 sorries, 0 axioms)
- Reframe originalContributions to distinguish substantive proofs from Mathlib wrappers
- Remove unused minpoly.irreducible from mathlibDependencies, fix annotation endLine

## Test plan
- [x] JSON validation passes (meta.json, annotations.json, review.json)
- [x] All review action items addressed and marked resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)