### PR TITLE
Research: erdos-1099-oq-01 — All sorries eliminated (0 sorries, 2 axioms)

### DIFF
--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -502,17 +502,47 @@ Sorted divisors of 2^k = [1, 2, 4, ..., 2^k] by sort uniqueness.
 All consecutive divisor ratios = 2, so h_α(2^k) = k·(2-1)^α = k.
 -/
 
+/-- List.range n is strictly sorted. -/
+private theorem list_range_pairwise_lt : ∀ (n : ℕ), (List.range n).Pairwise (· < ·) := by
+  intro n; induction n with
+  | zero => exact List.Pairwise.nil
+  | succ n ih =>
+    rw [List.range_succ, List.pairwise_append]
+    refine ⟨ih, ?_, fun a ha b hb => ?_⟩
+    · exact .cons (by simp) .nil
+    · simp only [List.mem_range] at ha
+      simp only [List.mem_singleton] at hb
+      subst hb; exact ha
+
 /-- Sorted divisors of 2^k are [2^0, 2^1, ..., 2^k].
-Proof: both lists are sorted permutations of the same multiset. -/
+Both lists are sorted, nodup, with the same elements → equal. -/
 private theorem sortedDivisors_two_pow (k : ℕ) :
     sortedDivisors (2 ^ k) = (List.range (k + 1)).map (HPow.hPow 2) := by
-  sorry -- sort uniqueness via Nat.divisors_prime_pow + Perm.eq_of_pairwise
+  have hnd₁ := sortedDivisors_nodup (2 ^ k)
+  have hnd₂ : ((List.range (k + 1)).map (HPow.hPow 2)).Nodup := by
+    apply List.Nodup.map
+    · exact Nat.pow_right_injective (by norm_num : 1 < 2)
+    · exact List.nodup_range
+  have hmem : ∀ x, x ∈ sortedDivisors (2 ^ k) ↔
+      x ∈ (List.range (k + 1)).map (HPow.hPow 2) := by
+    intro x
+    simp only [sortedDivisors, Finset.mem_sort,
+               Nat.divisors_prime_pow (by norm_num : Nat.Prime 2),
+               Finset.mem_map, Function.Embedding.coeFn_mk, Finset.mem_range,
+               List.mem_map, List.mem_range]
+  have hperm := (List.perm_ext_iff_of_nodup hnd₁ hnd₂).mpr hmem
+  have hs₂ : ((List.range (k + 1)).map (HPow.hPow 2)).Pairwise (· ≤ ·) := by
+    rw [List.pairwise_map]
+    exact (list_range_pairwise_lt (k + 1)).imp
+      (fun hab => Nat.pow_le_pow_right (by omega) (le_of_lt hab))
+  exact hperm.eq_of_pairwise (fun _ _ _ _ h1 h2 => le_antisymm h1 h2)
+    (sortedDivisors_sorted (2 ^ k)) hs₂
 
 /-- The consecutive divisor ratios of 2^k consist of k copies of 2.
 Each ratio d_{i+1}/d_i = 2^(i+1)/2^i = 2. -/
 private theorem divisorRatios_two_pow (k : ℕ) :
     divisorRatios (2 ^ k) = List.replicate k (2 : ℚ) := by
-  sorry -- via sortedDivisors_two_pow + zipWith computation
+  sorry -- Monadic ℕ→ℚ cast normalization blocks direct proof; sortedDivisors_two_pow proved above
 
 private theorem flatMap_singleton_eq_map (f : ℚ → ℝ) (l : List ℚ) :
     l.flatMap (fun a => [f a]) = l.map f := by

--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -207,6 +207,32 @@ This is definitional from the h_alpha definition.
 -/
 
 /-
+## Monadic Normalization Helpers
+
+Lean 4 elaborates coercions List ℕ → List ℚ and List ℚ → List ℝ via
+monadic do/pure forms. These lemmas normalize back to explicit List.map.
+-/
+
+private theorem flatMap_singleton_eq_map {α β : Type*} (f : α → β) (l : List α) :
+    l.flatMap (fun a => [f a]) = l.map f := by
+  induction l with
+  | nil => rfl
+  | cons a t ih => simp [List.flatMap_cons, ih]
+
+private theorem list_bind_pure_ratCast (l : List ℚ) :
+    (do let a ← l; pure (↑a : ℝ)) = l.map (Rat.cast · : ℚ → ℝ) :=
+  flatMap_singleton_eq_map Rat.cast l
+
+private theorem list_bind_pure_natCast (l : List ℕ) :
+    (do let a ← l; pure (↑a : ℚ)) = l.map (Nat.cast · : ℕ → ℚ) :=
+  flatMap_singleton_eq_map Nat.cast l
+
+/-- Normalize h_alpha to avoid Lean 4 monadic coercion elaboration. -/
+private theorem h_alpha_as_map (α : ℝ) (n : ℕ) :
+    h_alpha α n = ((divisorRatios n).map (fun (r : ℚ) => ((r : ℝ) - 1) ^ α)).sum := by
+  delta h_alpha; rw [list_bind_pure_ratCast, List.map_map]; congr 1
+
+/-
 ## Part III: The Trivial Lower Bound
 
 The first term alone gives h_α(n) ≥ 1 for n ≥ 2.
@@ -292,7 +318,7 @@ Proof: The first term is ((d₂/1) - 1)^α ≥ (2-1)^α = 1.
 -/
 theorem h_alpha_ge_one (α : ℝ) (hα : α > 1) (n : ℕ) (hn : n ≥ 2) :
     h_alpha α n ≥ 1 := by
-  unfold h_alpha
+  rw [h_alpha_as_map]
   obtain ⟨r, hr_mem, hr_ge⟩ := first_ratio_ge_two n hn
   set f := (fun (r : ℚ) => ((r : ℝ) - 1) ^ α) with hf_def
   have hr1 : (1 : ℝ) ≤ (r : ℝ) - 1 := by
@@ -445,11 +471,16 @@ private theorem prime_ratio_mem (p : ℕ) (hp : Nat.Prime p) :
       simpa [sortedDivisors] using this
     exact (Nat.mem_divisors.mp this).1
   have hd2_eq : d₂ = p := (hp.eq_one_or_self_of_dvd d₂ hd2_dvd).resolve_left (by omega)
-  subst hd2_eq
-  have : divisorRatios p = List.zipWith (fun a b => (↑a : ℚ) / ↑b)
-      (sortedDivisors p).tail (sortedDivisors p) := rfl
-  rw [this, heq, List.tail_cons, List.zipWith_cons_cons]
-  simp [Nat.cast_one, div_one]
+  rw [hd2_eq] at heq
+  -- heq : sortedDivisors p = 1 :: p :: rest
+  -- Show (↑p : ℚ) is in the first position of divisorRatios
+  have hmem : (↑p : ℚ) / ↑(1 : ℕ) ∈ divisorRatios p := by
+    unfold divisorRatios
+    rw [heq]
+    simp only [List.tail_cons]
+    exact List.mem_cons.mpr (Or.inl rfl)
+  simp [Nat.cast_one, div_one] at hmem
+  exact hmem
 
 /--
 **Example: Prime p**
@@ -475,7 +506,7 @@ theorem prime_h_alpha_unbounded :
     linarith
   calc h_alpha α p
       ≥ ((p : ℝ) - 1) ^ α := by
-        unfold h_alpha
+        rw [h_alpha_as_map]
         set f := (fun r : ℚ => ((r : ℝ) - 1) ^ α)
         have hr := prime_ratio_mem p hp
         have hall : ∀ x ∈ (divisorRatios p).map f, 0 ≤ x := by
@@ -488,7 +519,7 @@ theorem prime_h_alpha_unbounded :
         have hsle := by
           apply List.single_le_sum hall
           simp only [List.mem_map]; exact ⟨_, hr, rfl⟩
-        simp only [Rat.cast_natCast] at hsle
+        simp only [f, Rat.cast_natCast] at hsle
         linarith
     _ ≥ (p : ℝ) - 1 := by
         calc ((p : ℝ) - 1) ^ α
@@ -542,29 +573,41 @@ private theorem sortedDivisors_two_pow (k : ℕ) :
 Each ratio d_{i+1}/d_i = 2^(i+1)/2^i = 2. -/
 private theorem divisorRatios_two_pow (k : ℕ) :
     divisorRatios (2 ^ k) = List.replicate k (2 : ℚ) := by
-  sorry -- Monadic ℕ→ℚ cast normalization blocks direct proof; sortedDivisors_two_pow proved above
-
-private theorem flatMap_singleton_eq_map (f : ℚ → ℝ) (l : List ℚ) :
-    l.flatMap (fun a => [f a]) = l.map f := by
-  induction l with
-  | nil => rfl
-  | cons a t ih => simp [List.flatMap_cons, ih]
-
-private theorem list_bind_pure_ratCast (l : List ℚ) :
-    (do let a ← l; pure (↑a : ℝ)) = l.map (Rat.cast · : ℚ → ℝ) :=
-  flatMap_singleton_eq_map Rat.cast l
+  -- After unfolding, Lean 4 creates monadic do/pure forms for ℕ→ℚ coercions.
+  -- We normalize these, then prove element-wise equality.
+  unfold divisorRatios
+  rw [sortedDivisors_two_pow]
+  -- Normalize monadic ℕ→ℚ coercions
+  simp only [list_bind_pure_natCast]
+  -- Move map inside tail: map f l.tail → (map f l).tail
+  rw [show ∀ (f : ℕ → ℚ) (l : List ℕ), (l.tail).map f = (l.map f).tail from
+    fun f l => by cases l <;> simp]
+  -- Fuse double maps: map g (map f l) → map (g ∘ f) l
+  simp only [List.map_map]
+  -- Now: zipWith (·/·) ((range (k+1)).map g).tail ((range (k+1)).map g) = replicate k 2
+  apply List.ext_getElem
+  · -- Length equality
+    simp [List.length_zipWith, List.length_tail, List.length_map, List.length_range,
+          List.length_replicate]
+  · -- Element equality: each ratio 2^(n+1)/2^n = 2
+    intro n h₁ h₂
+    simp only [List.getElem_zipWith, List.getElem_replicate]
+    -- Handle l.tail[n] → l[n+1]
+    have htail : ∀ {β : Type} (l : List β) (i : ℕ) (h : i < l.tail.length),
+        l.tail[i] = l[i + 1]'(by rw [List.length_tail] at h; omega) := by
+      intro β l; cases l with
+      | nil => intro i h; simp at h
+      | cons a t => intro i _; rfl
+    simp only [htail, List.getElem_map, List.getElem_range, Function.comp_apply]
+    -- Goal: ↑(2 ^ (n + 1)) / ↑(2 ^ n) = 2
+    rw [pow_succ]; push_cast; field_simp
 
 set_option maxHeartbeats 1600000 in
 /-- For n = 2^k, h_α(2^k) = k since all k ratios equal 2 and (2-1)^α = 1^α = 1. -/
 theorem power_of_two_h_alpha (k : ℕ) (α : ℝ) (hα : α ≥ 1) :
     h_alpha α (2^k) = k := by
-  delta h_alpha
-  rw [divisorRatios_two_pow]
-  -- Convert monadic do/pure to explicit map, fuse maps, compute on replicate
-  rw [list_bind_pure_ratCast, List.map_map, List.map_replicate, List.sum_replicate]
-  -- Goal: k • ((fun r : ℚ => ((↑r : ℝ) - 1) ^ α) (2 : ℚ)) = ↑k
-  simp only [Function.comp_apply, show ((2 : ℚ) : ℝ) - 1 = 1 from by push_cast; ring,
-             Real.one_rpow, nsmul_eq_mul, mul_one]
+  rw [h_alpha_as_map, divisorRatios_two_pow, List.map_replicate, List.sum_replicate, nsmul_eq_mul]
+  norm_num [Real.one_rpow]
 
 /-
 **Example: Small highly composite**

--- a/research/problems/erdos-1099-oq-01/knowledge.md
+++ b/research/problems/erdos-1099-oq-01/knowledge.md
@@ -2,7 +2,7 @@
 
 **Problem**: For α > 1, is liminf h_α(n) bounded, where h_α(n) = Σ((d_{i+1}/dᵢ) - 1)^α?
 **Answer**: YES (Vose, 1984)
-**Status**: IN-PROGRESS (2 sorries, 2 axioms)
+**Status**: COMPLETE (0 sorries, 2 axioms)
 
 ## Current State
 
@@ -63,3 +63,33 @@
 - `src/data/proofs/erdos-1099/meta.json` (axiomCount: 3→2, sorries: 0→2)
 - `src/data/research/problems/erdos-1099-oq-01.json` (knowledge updated)
 - `research/problems/erdos-1099-oq-01/knowledge.md` (session added)
+
+## Session 2026-03-25 (Session 4) - Prove divisorRatios_two_pow (1→0 sorries)
+
+**Mode**: REVISIT (RICH knowledge, score 33)
+**Outcome**: completed (2A+1S → 2A+0S, all sorries eliminated)
+
+### What I Did
+- Proved `divisorRatios_two_pow`: consecutive divisor ratios of 2^k are all 2
+- Added `list_bind_pure_natCast`: normalize monadic ℕ→ℚ coercion
+- Added `h_alpha_as_map`: normalize h_alpha to avoid monadic ℚ→ℝ elaboration
+- Generalized `flatMap_singleton_eq_map` to work with arbitrary types
+- Fixed 4 pre-existing proof regressions caused by Lean 4 monadic coercion changes
+- Simplified `power_of_two_h_alpha` using the new normalization infrastructure
+
+### Key Findings
+- **Root cause of monadic form**: Lean 4 elaborates `(a : ℚ)` where `a : ℕ` as a type annotation (making a : ℚ), not a coercion. This causes zipWith to expect List ℚ inputs, triggering monadic List coercion.
+- **Fix pattern**: Normalize `(do let a ← l; pure ↑a)` to `l.map ↑` via `flatMap_singleton_eq_map`, then fuse maps with `List.map_map`.
+- **simp vs rw for let bindings**: `simp only [List.tail_cons]` handles `have/let` bindings in goals; `rw [List.tail_cons]` does not.
+- **List.ext_getElem approach**: Prove list equality element-wise. Custom `htail` helper converts `l.tail[i]` to `l[i+1]` (not in Lean 4 stdlib).
+- **field_simp for ℚ division**: `2^(n+1)/2^n = 2` cleanly handled by `rw [pow_succ]; push_cast; field_simp`.
+
+### Files Modified
+- `proofs/Proofs/Erdos1099Problem.lean` (~575→647 lines, +5 lemmas, -1 sorry, many proof fixes)
+- `src/data/proofs/erdos-1099/meta.json` (sorries: 1→0)
+- `src/data/research/problems/erdos-1099-oq-01.json` (knowledge updated)
+- `research/problems/erdos-1099-oq-01/knowledge.md` (session added)
+
+### Next Steps
+- Problem complete — 0 sorries, 2 axioms (Vose deep results)
+- No further work needed on this problem

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -60,9 +60,9 @@
       "Examples for primes, powers of 2, and highly composite numbers"
     ],
     "axiomCount": 2,
-    "sorries": 1,
-    "lineCount": 575,
-    "assumptions": "2 axioms: vose_bounded_sequence, vose_liminf_bounded (deep Vose 1984 construction). power_of_two_h_alpha converted from axiom to theorem. sortedDivisors_two_pow proved via sorted permutation uniqueness. 1 sorry: divisorRatios_two_pow (blocked by Lean4 monadic ℕ→ℚ cast normalization)."
+    "sorries": 0,
+    "lineCount": 647,
+    "assumptions": "2 axioms: vose_bounded_sequence, vose_liminf_bounded (deep Vose 1984 construction). All infrastructure theorems fully proved: power_of_two_h_alpha, sortedDivisors_two_pow, divisorRatios_two_pow."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1099** was posed by Erdős in 1981 as part of his study of divisor structure. The problem asks about the regularity of divisor gaps: can we find integers whose consecutive divisor ratios are all close to 1?\n\n**Historical Development:**\n- **1981 (Erdős [Er81h]):** Posed the problem, noting that n! and lcm{1,...,n} seem like good candidates.\n- **1984 (Vose [Vo84]):** Resolved the problem affirmatively by constructing a specific sequence with bounded h_α.\n\n**Key Insight:** The question is about how \"smooth\" the divisor structure of integers can be. While primes have terrible divisor gaps (ratio = p), and even powers of 2 grow linearly in h_α, Vose showed there exist numbers with much smoother divisor distributions.",

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -60,9 +60,9 @@
       "Examples for primes, powers of 2, and highly composite numbers"
     ],
     "axiomCount": 2,
-    "sorries": 2,
+    "sorries": 1,
     "lineCount": 575,
-    "assumptions": "2 axioms: vose_bounded_sequence, vose_liminf_bounded (deep Vose 1984 construction). power_of_two_h_alpha converted from axiom to theorem. 2 sorries in infrastructure helpers (sortedDivisors_two_pow, divisorRatios_two_pow) pending Lean4 API iteration."
+    "assumptions": "2 axioms: vose_bounded_sequence, vose_liminf_bounded (deep Vose 1984 construction). power_of_two_h_alpha converted from axiom to theorem. sortedDivisors_two_pow proved via sorted permutation uniqueness. 1 sorry: divisorRatios_two_pow (blocked by Lean4 monadic ℕ→ℚ cast normalization)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1099** was posed by Erdős in 1981 as part of his study of divisor structure. The problem asks about the regularity of divisor gaps: can we find integers whose consecutive divisor ratios are all close to 1?\n\n**Historical Development:**\n- **1981 (Erdős [Er81h]):** Posed the problem, noting that n! and lcm{1,...,n} seem like good candidates.\n- **1984 (Vose [Vo84]):** Resolved the problem affirmatively by constructing a specific sequence with bounded h_α.\n\n**Key Insight:** The question is about how \"smooth\" the divisor structure of integers can be. While primes have terrible divisor gaps (ratio = p), and even powers of 2 grow linearly in h_α, Vose showed there exist numbers with much smoother divisor distributions.",

--- a/src/data/research/problems/erdos-1099-oq-01.json
+++ b/src/data/research/problems/erdos-1099-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: power_of_two_h_alpha converted from axiom to theorem (2 sorry helpers pending). 2 axioms remain (Vose 1984). sum_divisor_ratios_lower_bound removed (false bound).",
+    "progressSummary": "PROGRESS: sortedDivisors_two_pow proved (2→1 sorries). divisorRatios_two_pow blocked by Lean4 monadic cast normalization.",
     "builtItems": [
       "17 new infrastructure theorems for sorted divisor properties",
       "first_divisor_is_one theorem (was axiom)",
@@ -46,7 +46,9 @@
       "Fixed List.mem_map.mpr → simp [List.mem_map] + apply List.single_le_sum pattern",
       "power_of_two_h_alpha theorem (was axiom): h_alpha α (2^k) = k",
       "flatMap_singleton_eq_map: normalize monadic flatMap to List.map",
-      "list_bind_pure_ratCast: bridge monad do/pure to explicit map for ℚ→ℝ cast"
+      "list_bind_pure_ratCast: bridge monad do/pure to explicit map for ℚ→ℝ cast",
+      "sortedDivisors_two_pow theorem: sorted divisors of 2^k = [2^0,...,2^k] via Nat.divisors_prime_pow + sorted permutation uniqueness",
+      "list_range_pairwise_lt: List.range n is Pairwise (· < ·)"
     ],
     "insights": [
       "divisorRatios had a critical bug: computed d_i/d_{i+1} instead of d_{i+1}/d_i",
@@ -59,14 +61,15 @@
       "sum_divisor_ratios_lower_bound axiom was FALSE: claimed Σ(d_{i+1}/dᵢ) > τ(n) + log(n) but correct bound is τ(n)-1+log(n) (off by 1 because there are τ-1 ratios, not τ). Counterexample: n=2, sum=2 but τ+log(2)≈2.69. Removed the false axiom.",
       "Lean 4 v4.26.0 has List.map normalization issues: map f l normalizes to do/flatMap form, breaking List.mem_map.mpr and List.single_le_sum proofs",
       "sum_divisor_ratios_lower_bound was FALSE: fails for n=2 (2 > 2+ln2≈2.69), n=6 (5.5 > 4+ln6≈5.79)",
-      "Lean4 monad elaboration creates do/pure form when composing List.map with casts — need flatMap_singleton helper to normalize"
+      "Lean4 monad elaboration creates do/pure form when composing List.map with casts — need flatMap_singleton helper to normalize",
+      "sortedDivisors_two_pow proved via List.perm_ext_iff_of_nodup + Perm.eq_of_pairwise with explicit antisymmetry",
+      "divisorRatios_two_pow blocked by Lean4 monadic normalization: zipWith with ℕ→ℚ cast creates do/pure form that breaks type matching with structural recursion helper"
     ],
     "mathlibGaps": [
       "No direct Finset.sort getLast = max lemma"
     ],
     "nextSteps": [
-      "Fill in sortedDivisors_two_pow sorry via Perm.eq_of_pairwise + Nat.divisors_prime_pow",
-      "Fill in divisorRatios_two_pow sorry via sortedDivisors_two_pow + zipWith computation"
+      "Prove divisorRatios_two_pow by working around monadic normalization (use native_decide for small k + structural induction, or restate zipWith_div_doubles to match normalized types)"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-1099-oq-01.json
+++ b/src/data/research/problems/erdos-1099-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: sortedDivisors_two_pow proved (2→1 sorries). divisorRatios_two_pow blocked by Lean4 monadic cast normalization.",
+    "progressSummary": "COMPLETE: All sorries eliminated (1→0). 2 axioms remain (Vose 1984 deep results). divisorRatios_two_pow proved via List.ext_getElem + monadic normalization.",
     "builtItems": [
       "17 new infrastructure theorems for sorted divisor properties",
       "first_divisor_is_one theorem (was axiom)",
@@ -48,7 +48,10 @@
       "flatMap_singleton_eq_map: normalize monadic flatMap to List.map",
       "list_bind_pure_ratCast: bridge monad do/pure to explicit map for ℚ→ℝ cast",
       "sortedDivisors_two_pow theorem: sorted divisors of 2^k = [2^0,...,2^k] via Nat.divisors_prime_pow + sorted permutation uniqueness",
-      "list_range_pairwise_lt: List.range n is Pairwise (· < ·)"
+      "list_range_pairwise_lt: List.range n is Pairwise (· < ·)",
+      "list_bind_pure_natCast: normalize monadic ℕ→ℚ cast",
+      "h_alpha_as_map: normalize h_alpha to avoid monadic ℚ→ℝ elaboration",
+      "divisorRatios_two_pow: proved via ext_getElem + monadic normalization (was sorry)"
     ],
     "insights": [
       "divisorRatios had a critical bug: computed d_i/d_{i+1} instead of d_{i+1}/d_i",
@@ -63,13 +66,16 @@
       "sum_divisor_ratios_lower_bound was FALSE: fails for n=2 (2 > 2+ln2≈2.69), n=6 (5.5 > 4+ln6≈5.79)",
       "Lean4 monad elaboration creates do/pure form when composing List.map with casts — need flatMap_singleton helper to normalize",
       "sortedDivisors_two_pow proved via List.perm_ext_iff_of_nodup + Perm.eq_of_pairwise with explicit antisymmetry",
-      "divisorRatios_two_pow blocked by Lean4 monadic normalization: zipWith with ℕ→ℚ cast creates do/pure form that breaks type matching with structural recursion helper"
+      "divisorRatios_two_pow blocked by Lean4 monadic normalization: zipWith with ℕ→ℚ cast creates do/pure form that breaks type matching with structural recursion helper",
+      "divisorRatios_two_pow proved by: (1) normalize monadic ℕ→ℚ coercions via list_bind_pure_natCast, (2) fuse double maps with List.map_map, (3) prove element-wise via List.ext_getElem with custom tail indexing helper, (4) compute 2^(n+1)/2^n = 2 via field_simp",
+      "Lean4 monadic coercion also broke h_alpha elaboration — fixed with h_alpha_as_map normalization lemma using list_bind_pure_ratCast + List.map_map",
+      "Key fix for prime_ratio_mem: use simp only [List.tail_cons] instead of rw (simp handles let/have bindings, rw does not)"
     ],
     "mathlibGaps": [
       "No direct Finset.sort getLast = max lemma"
     ],
     "nextSteps": [
-      "Prove divisorRatios_two_pow by working around monadic normalization (use native_decide for small k + structural induction, or restate zipWith_div_doubles to match normalized types)"
+      "Problem complete — 0 sorries, 2 axioms (Vose deep results). No further work needed."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Prove `divisorRatios_two_pow`: consecutive divisor ratios of 2^k are all 2 (eliminates last sorry)
- Add monadic normalization infrastructure (`list_bind_pure_natCast`, `h_alpha_as_map`) to handle Lean 4's coercion elaboration
- Fix 4 pre-existing proof regressions from Mathlib API changes in `h_alpha_ge_one`, `prime_ratio_mem`, `prime_h_alpha_unbounded`, `power_of_two_h_alpha`

## Technical Details
Lean 4 elaborates `(a : ℚ)` where `a : ℕ` as a type annotation, causing `zipWith` to expect `List ℚ` inputs and triggering monadic `do/pure` coercion of `List ℕ → List ℚ`. Fixed by normalizing `(do let a ← l; pure ↑a)` to `l.map ↑` via `flatMap_singleton_eq_map`, then fusing maps.

`divisorRatios_two_pow` proved via `List.ext_getElem` with custom tail-indexing helper (`l.tail[i] = l[i+1]`), then computing `2^(n+1)/2^n = 2` via `field_simp`.

## Final State
- **0 sorries** (down from 2 at start of branch)
- **2 axioms**: `vose_bounded_sequence`, `vose_liminf_bounded` (deep Vose 1984 construction results)
- **647 lines**

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos1099Problem`
- [x] Zero sorries confirmed via grep
- [x] meta.json updated (sorries: 0, lineCount: 647)

🤖 Generated with [Claude Code](https://claude.com/claude-code)