### PR TITLE
Enrich basel-problem: add Bernoulli number cross-reference

### DIFF
--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -376,6 +376,11 @@
       "targetId": "euler-totient",
       "relationship": "related",
       "description": "Euler's totient function $\\varphi(n)$ counts integers coprime to $n$, and the probability that two random positive integers are coprime is $\\prod_p (1 - 1/p^2) = 1/\\zeta(2) = 6/\\pi^2$ — a striking connection between the Basel identity and coprimality. The Euler product $\\zeta(s) = \\prod_p (1 - p^{-s})^{-1}$ that produces this coprime probability is the multiplicative analog of $\\sum n^{-s}$, and the totient function satisfies $\\sum_{d|n} \\varphi(d) = n$, a Dirichlet convolution identity equivalent to $\\zeta(s) \\cdot \\sum \\varphi(n) n^{-s} = \\zeta(s-1)$"
+    },
+    {
+      "targetId": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Faulhaber's formulas express finite power sums $\\sum_{i=1}^{n} i^k$ using Bernoulli polynomials: $\\sum_{i=1}^{n} i^k = (B_{k+1}(n+1) - B_{k+1}(0))/(k+1)$. The same Bernoulli numbers $B_{2k}$ that govern these finite sums also appear in Euler's formula $\\zeta(2k) = (-1)^{k+1} 2^{2k-1} \\pi^{2k} B_{2k}/(2k)!$ for infinite reciprocal power sums — the Basel identity $\\zeta(2) = \\pi^2/6$ uses $B_2 = 1/6$. Both results arise from the generating function $t/(e^t - 1) = \\sum B_n t^n/n!$, connecting finite combinatorial identities (Wiedijk #77) to infinite analytic ones (Wiedijk #14)"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary
- Added cross-reference from `basel-problem` to `sum-of-kth-powers` (Faulhaber's formulas, Wiedijk #77)
- The connection: Bernoulli numbers $B_{2k}$ govern both finite power sums $\sum_{i=1}^n i^k$ (Faulhaber) and infinite zeta values $\zeta(2k) = (-1)^{k+1} 2^{2k-1} \pi^{2k} B_{2k}/(2k)!$ (Basel/Euler)
- First enrichment pass on this entry (quality 100, 0 prior passes)

## Test plan
- [x] JSON validated (python3 json.load)
- [x] Cross-reference target `sum-of-kth-powers` verified to exist
- [x] Annotation build passes (non-strict mode, no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)