### PR TITLE
Enrich 13 entries: add mainTheorems, fix metadata and sections

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -249,6 +249,32 @@
     "lineCount": 115,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "natDegree_dvd_card_gal",
+        "statement": "For any irreducible polynomial p over a CharZero field F, p.natDegree divides Nat.card p.Gal",
+        "line": 30,
+        "significance": "Generalizes Mathlib's prime_degree_dvd_card to all irreducible polynomials via the tower law on F ⊂ F⟮α⟯ ⊂ SplittingField(p)"
+      },
+      {
+        "name": "galois_2group_implies_degree_pow2",
+        "statement": "If Gal(minpoly(ℚ,α)) is a 2-group, then natDegree(minpoly ℚ α) divides 2^n for some n",
+        "line": 66,
+        "significance": "Eliminates the axiom galois_2group_implies_degree_pow2 from OQ-02 by chaining natDegree_dvd_card_gal with IsPGroup.iff_card"
+      },
+      {
+        "name": "galois_2group_implies_degree_is_pow2",
+        "statement": "If Gal(minpoly(ℚ,α)) is a 2-group, then natDegree(minpoly ℚ α) = 2^k for some k",
+        "line": 76,
+        "significance": "Strengthens divisibility to equality using OQ-01's dvd_pow_two_is_pow_two — the definitive form of the axiom elimination"
+      },
+      {
+        "name": "galois_criterion_implies_degree_criterion",
+        "statement": "The Galois criterion (2-group Gal) implies the degree criterion (natDegree = 2^k)",
+        "line": 97,
+        "significance": "Bridge theorem connecting OQ-02's Galois-theoretic approach to OQ-01's degree-theoretic approach to constructibility"
+      }
+    ]
   }
 }

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -293,7 +293,57 @@
     "lineCount": 298,
     "axiomCount": 1,
     "theoremCount": 15,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "wantzel_galois_characterization",
+        "type": "axiom",
+        "description": "The Wantzel-Galois biconditional: an algebraic number is constructible iff its minimal polynomial has a 2-group Galois group",
+        "leanType": "(α : ℝ) → (hα : IsIntegral ℚ α) → IsConstructibleFromQ α ↔ IsPGroup 2 (minpoly ℚ α).Gal"
+      },
+      {
+        "name": "x_cube_sub_2_gal_not_2group",
+        "type": "core",
+        "description": "Gal(x³-2/ℚ) ≅ S₃ (order 6) is NOT a 2-group, so ∛2 is not constructible",
+        "leanType": "¬ IsPGroup 2 (X ^ 3 - C 2 : ℚ[X]).Gal"
+      },
+      {
+        "name": "cos20_gal_not_2group",
+        "type": "core",
+        "description": "Gal(8x³-6x-1/ℚ) ≅ ℤ/3ℤ (order 3) is NOT a 2-group, so cos(20°) is not constructible",
+        "leanType": "¬ IsPGroup 2 (8 * X ^ 3 - 6 * X - C 1 : ℚ[X]).Gal"
+      },
+      {
+        "name": "x_sq_sub_2_gal_is_2group",
+        "type": "core",
+        "description": "Gal(x²-2/ℚ) ≅ ℤ/2ℤ (order 2 = 2¹) IS a 2-group, so √2 is constructible",
+        "leanType": "IsPGroup 2 (X ^ 2 - C 2 : ℚ[X]).Gal"
+      },
+      {
+        "name": "x_4th_sub_2_gal_is_2group",
+        "type": "core",
+        "description": "Gal(x⁴-2/ℚ) ≅ D₄ (order 8 = 2³) IS a 2-group, so 2^(1/4) is constructible",
+        "leanType": "IsPGroup 2 (X ^ 4 - C 2 : ℚ[X]).Gal"
+      },
+      {
+        "name": "galois_2group_implies_degree_pow2",
+        "type": "key",
+        "description": "2-group Galois group implies the minimal polynomial degree divides a power of 2 (OQ-02 implies OQ-01)",
+        "leanType": "(α : ℝ) → (hα : IsIntegral ℚ α) → IsPGroup 2 (minpoly ℚ α).Gal → ∃ n : ℕ, (minpoly ℚ α).natDegree ∣ 2 ^ n"
+      },
+      {
+        "name": "constructible_implies_degree_dvd_pow2",
+        "type": "key",
+        "description": "Constructibility implies the degree criterion: chains wantzel_galois_characterization with galois_2group_implies_degree_pow2",
+        "leanType": "(α : ℝ) → (hα : IsIntegral ℚ α) → IsConstructibleFromQ α → ∃ n : ℕ, (minpoly ℚ α).natDegree ∣ 2 ^ n"
+      },
+      {
+        "name": "not_constructible_of_not_2group",
+        "type": "key",
+        "description": "Contrapositive: non-2-group Galois group implies non-constructibility",
+        "leanType": "(α : ℝ) → (hα : IsIntegral ℚ α) → ¬ IsPGroup 2 (minpoly ℚ α).Gal → ¬ IsConstructibleFromQ α"
+      }
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -174,7 +174,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes a comprehensive framework for the generalized ballot problem, building from basic list combinatorics through cyclic rotation theory to the statement of the Dvoretzky-Motzkin cycle lemma. The key infrastructure - including the prefix sum relation for rotations - is complete, providing the foundation needed to prove the cycle lemma and derive the counting formula.",
+    "summary": "A fully verified 789-line formalization of the generalized ballot problem for k-fold dominance. The proof builds from list combinatorics through cyclic rotation infrastructure to a complete proof of the Dvoretzky-Motzkin cycle lemma (|goodRotations| = a - kb) via a sandwich argument: an injection into {0,...,S-1} for the upper bound and a levelPos surjection (discrete IVT) for the lower bound. The generalized counting formula is proved via binomial coefficient identities, and the k=1 case is validated against Mathlib's Wiedijk #30.",
     "implications": "**Theoretical Significance**: The Dvoretzky-Motzkin cycle lemma is one of the most powerful tools in lattice path combinatorics. It unifies the classical ballot problem, Catalan number identities, and Raney's theorem under a single rotational symmetry argument.\n\n**Applications**:\n1. **Voting theory**: Probability of sustained dominance in elections with weighted votes\n2. **Queueing theory**: Probability that a $k$-server queue never empties — the ballot condition models server utilization exceeding demand\n3. **Random walks**: Paths with asymmetric step sizes ($+1$ and $-k$) staying above a barrier, generalizing Dyck paths ($k=1$)\n4. **Lattice path enumeration**: Counting paths with generalized step constraints, with connections to Catalan numbers ($C_n = \\frac{1}{n+1}\\binom{2n}{n}$ counts Dyck paths of length $2n$)\n5. **Random trees**: Raney's theorem (a corollary of the cycle lemma) counts the number of labeled plane trees, connecting ballot sequences to tree enumeration",
     "openQuestions": [
       "**Multi-candidate generalization**: For $m \\geq 3$ candidates with vote counts $a_1 > a_2 > \\cdots > a_m$, what is the probability that candidate 1 leads all others throughout counting? The $m$-candidate ballot problem requires higher-dimensional lattice path analysis — the path must stay in a Weyl chamber rather than above a single line",
@@ -282,6 +282,38 @@
     "lineCount": 789,
     "axiomCount": 0,
     "theoremCount": 57,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "mainTheorems": [
+      {
+        "name": "cycle_lemma",
+        "line": 764,
+        "statement": "(goodRotations l).card = a - k * b",
+        "description": "The Dvoretzky-Motzkin Cycle Lemma: for a ballot sequence l in kCountedSequence(k,a,b) with a > kb, exactly a - kb of its a + b cyclic rotations have all positive prefix sums"
+      },
+      {
+        "name": "generalized_ballot_count",
+        "line": 226,
+        "statement": "∃ good_count, good_count * (a + b) = (a - k * b) * (a + b).choose a",
+        "description": "The generalized counting formula: the number of favorable ballot orderings times (a+b) equals (a-kb) times the binomial coefficient C(a+b, a)"
+      },
+      {
+        "name": "generalized_ballot_prob",
+        "line": 246,
+        "statement": "((a : ℚ) - k * b) / (a + b) > 0",
+        "description": "The probability of k-fold dominance throughout counting is strictly positive when a > kb"
+      },
+      {
+        "name": "kCountedSequence_eq_countedSequence",
+        "line": 152,
+        "statement": "kCountedSequence 1 a b = Ballot.countedSequence a b",
+        "description": "When k=1, the generalized ballot sequence reduces to Mathlib's classical ballot sequence (Wiedijk #30)"
+      },
+      {
+        "name": "path_height_interpretation",
+        "line": 783,
+        "statement": "(l.take i).sum = (l.take i).count 1 - (k : ℤ) * (l.take i).count (-(k : ℤ))",
+        "description": "The lattice path height at step i equals the count of A-votes minus k times the count of B-votes up to that point"
+      }
+    ]
   }
 }

--- a/src/data/proofs/ballot-problem-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02/meta.json
@@ -246,6 +246,19 @@
     ],
     "namespace": "ContinuousBallot",
     "lineCount": 339,
+    "mainTheorems": [
+      "continuous_ballot_theorem",
+      "first_passage_cdf",
+      "first_passage_monotone",
+      "prob_pos_eq_prob_neg",
+      "discrete_ballot_probability"
+    ],
+    "mainDefinitions": [
+      "BrownianMotion",
+      "firstPassageTime",
+      "maxEvent",
+      "positiveTime"
+    ],
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 3

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -211,9 +211,9 @@
     "summary": "Comprehensive formalization of 2D lattice path combinatorics. Proves the Crossing Lemma, path count formula, Catalan numbers, ballot theorem, Vandermonde identity, binomial coefficient symmetry via path flip bijection, LGV determinant algebra, and Catalan-Ballot unification. The Lindström involution infrastructure is in place for the full LGV proof.",
     "implications": "**Theoretical Significance and Applications:**\n1. **Combinatorics**: The LGV lemma is the foundation for counting plane partitions, standard Young tableaux, and Aztec diamond tilings\n2. **Algebra**: Determinantal identities for Schur polynomials follow from LGV\n3. **Probability**: The ballot problem and Catalan numbers are unified through lattice path bijections and the reflection principle\n4. **Geometry**: Non-intersecting path counting generalizes to higher-dimensional reflection principles\n5. **Formalization**: This 2878-line development demonstrates that substantial enumerative combinatorics (binomial identities, bijective proofs, sign-reversing involutions) can be machine-verified in Lean 4 with Mathlib",
     "openQuestions": [
-      "Complete lgv_lemma_2x2: formalize the Lindström involution bijection (swapTails at first meeting column creates an involution between intersecting identity pairs and all crossing pairs)",
-      "Extend to r×r LGV lemma for r > 2 paths using the general Lindström-Gessel-Viennot determinant",
-      "Formalize the bijection between non-intersecting Dyck paths and Standard Young Tableaux"
+      "Extend to the general r×r LGV lemma for r > 2 non-intersecting lattice path tuples using the full Lindström-Gessel-Viennot determinant formula",
+      "Formalize the bijection between non-intersecting Dyck paths and Standard Young Tableaux via the RSK correspondence",
+      "Derive the hook-length formula for Standard Young Tableaux as a corollary of the r×r LGV lemma"
     ]
   },
   "crossReferences": [
@@ -311,6 +311,68 @@
     "lineCount": 2878,
     "axiomCount": 0,
     "theoremCount": 119,
-    "definitionCount": 32
+    "definitionCount": 32,
+    "mainTheorems": [
+      {
+        "name": "lgv_lemma_2x2",
+        "line": 2834,
+        "statement": "The 2x2 LGV Lemma: niPairCount equals lgvDet under proper source/target ordering (a1 <= a2, b1 <= b2)",
+        "description": "Core result. The count of non-intersecting lattice path pairs equals the 2x2 determinant of binomial path counts. Proved via complement counting and the Lindstrom involution bijection."
+      },
+      {
+        "name": "crossing_lemma",
+        "line": 257,
+        "statement": "If y1 < y2 and y1+n1 > y2+n2, then the paths are not non-intersecting",
+        "description": "The 2D reflection principle: paths that start lower but end higher must share a lattice point. Proved by column induction on the entry gap."
+      },
+      {
+        "name": "path_count_eq_choose",
+        "line": 351,
+        "statement": "|pathType m n| = C(m+n, m)",
+        "description": "The number of lattice paths with m East and n North steps equals the binomial coefficient, proved via the pathSplitEquiv bijection and Pascal's identity."
+      },
+      {
+        "name": "lindstrom_involution",
+        "line": 2803,
+        "statement": "Dual injections between intersecting identity pairs and crossing pairs yield equal cardinalities",
+        "description": "The Lindstrom sign-reversing involution: swapping suffixes at the canonical shared point bijects intersecting identity pairs with all crossing pairs."
+      },
+      {
+        "name": "ballot_formula",
+        "line": 574,
+        "statement": "ballotSeqCount(p,q) * (p+q) = (p-q) * C(p+q, p) for q < p",
+        "description": "The classical ballot theorem in multiplicative form, proved via the absorption identity."
+      },
+      {
+        "name": "catalan_formula",
+        "line": 523,
+        "statement": "Cn(n) * (n+1) = C(2n, n)",
+        "description": "The Catalan number division formula, proved algebraically via the absorption identity."
+      },
+      {
+        "name": "catalan_eq_ballot",
+        "line": 1097,
+        "statement": "Cn(n) = ballotSeqCount(n+1, n)",
+        "description": "Unifies the Catalan number with the ballot count: the n-th Catalan number counts ballot sequences where A (n+1 votes) always leads B (n votes)."
+      },
+      {
+        "name": "vandermonde",
+        "line": 499,
+        "statement": "C(m+n, r) = sum over k of C(m,k) * C(n, r-k)",
+        "description": "Vandermonde's convolution identity, derived from Mathlib's Nat.add_choose_eq."
+      },
+      {
+        "name": "choose_symm_via_paths",
+        "line": 1062,
+        "statement": "C(m+n, m) = C(m+n, n) via the pathFlip bijection",
+        "description": "Bijective proof of binomial symmetry: swapping East and North steps gives pathType(m,n) ≃ pathType(n,m)."
+      },
+      {
+        "name": "lgvDet_nonneg",
+        "line": 2872,
+        "statement": "0 <= lgvDet(m, a1, b1, a2, b2) under proper ordering",
+        "description": "Non-negativity of the LGV determinant follows from the LGV lemma since it counts non-intersecting path pairs."
+      }
+    ]
   }
 }


### PR DESCRIPTION
Enrichment pass for 13 entries (first pass for most).

## Changes by entry

| Entry | Changes |
|-------|---------|
| abel-ruffini | Add inverse-galois-oq-01 cross-ref, update 3 open questions |
| abel-ruffini-oq-04-oq-01 | Fix duplicate sorries, fix lineCount 1591→1593, add 4 sections, add 2 mainTheorems |
| amgm-inequality-oq-03-oq-02 | Add 5 mainTheorems |
| angle-trisection-oq-02 | Add 8 mainTheorems |
| angle-trisection-oq-02-oq-01 | Add 4 mainTheorems |
| angle-trisection-oq-02-oq-03 | Add 6 mainTheorems, add annotation for uncovered section |
| angle-trisection-oq-02-oq-03-oq-01 | Fix theoremCount/definitionCount, add 6 mainTheorems |
| area-of-circle-oq-01-oq-03 | Fix lineCount/sorries counts, update sections, add 7 mainTheorems |
| area-of-circle-oq-03-oq-02 | Fix false "1 sorry" description, add 5 mainTheorems |
| arithmetic-series-oq-02 | Add 5 mainTheorems, fix section line ranges |
| arithmetic-series-oq-02-oq-02 | Add 3 mainTheorems |
| ballot-problem-oq-01 | Add 5 mainTheorems, fix conclusion (was falsely "incomplete") |
| ballot-problem-oq-02 | Add 5 mainTheorems + 4 mainDefinitions |
| ballot-problem-oq-03 | Add 10 mainTheorems, fix stale openQuestions |