### PR TITLE
Research: erdos-1099 — prove divisorRatios_two_pow (0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1004Problem.lean
+++ b/proofs/Proofs/Erdos1004Problem.lean
@@ -120,10 +120,76 @@ axiom eps87_constant_pos : eps87_constant > 0
 axiom eps87_upper_bound (n K : ℕ) (hn : n > 0) (hrun : IsDistinctTotientRun n K) :
     (K : ℝ) ≤ (n : ℝ) / Real.exp (eps87_constant * (Real.log (n : ℝ)) ^ ((1 : ℝ)/3))
 
+/-- The maxDistinctRunLength is bounded by the EPS87 bound for n > 0. -/
+private lemma maxDistinctRunLength_le_eps87 (n : ℕ) (hn : n > 0) :
+    (maxDistinctRunLength n : ℝ) ≤
+      (n : ℝ) / Real.exp (eps87_constant * (Real.log (n : ℝ)) ^ ((1 : ℝ) / 3)) := by
+  unfold maxDistinctRunLength
+  set S : Set ℕ := {K : ℕ | IsDistinctTotientRun n K} with hS_def
+  set B := (n : ℝ) / Real.exp (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3)) with hB_def
+  have hB : 0 ≤ B := div_nonneg (Nat.cast_nonneg n) (le_of_lt (Real.exp_pos _))
+  have hne : S.Nonempty := ⟨1, distinctRun_one n⟩
+  have hsup : sSup S ≤ ⌊B⌋₊ :=
+    csSup_le hne fun K hK => Nat.le_floor (eps87_upper_bound n K hn hK)
+  calc (↑(sSup S) : ℝ) ≤ ↑⌊B⌋₊ := Nat.cast_le.mpr hsup
+    _ ≤ B := Nat.floor_le hB
+
 /-- Corollary: The run length is o(n). -/
 theorem run_length_sublinear :
     Tendsto (fun n : ℕ => (maxDistinctRunLength n : ℝ) / (n : ℝ)) atTop (𝓝 (0 : ℝ)) := by
-  sorry
+  have hc := eps87_constant_pos
+  -- Prepare bounding function g and prove g → 0
+  have h_log : Tendsto (fun n : ℕ => Real.log (↑n : ℝ)) atTop atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  -- (log n)^(1/3) → ∞
+  have h_rpow : Tendsto (fun n : ℕ => (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3)) atTop atTop := by
+    rw [Filter.tendsto_atTop_atTop]
+    intro b
+    obtain ⟨N, hN⟩ := (Filter.tendsto_atTop_atTop.mp h_log) ((max b 0) ^ (3 : ℕ))
+    exact ⟨N, fun n hn => by
+      have hlog := hN n hn
+      have hM : (0 : ℝ) ≤ max b 0 := le_max_right b 0
+      suffices hsuff : ((max b 0) ^ (3 : ℕ) : ℝ) ^ ((1 : ℝ) / 3) = max b 0 by
+        calc b ≤ max b 0 := le_max_left b 0
+          _ = ((max b 0) ^ (3 : ℕ) : ℝ) ^ ((1 : ℝ) / 3) := hsuff.symm
+          _ ≤ (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3) :=
+              Real.rpow_le_rpow (pow_nonneg hM 3) hlog (by norm_num)
+      rw [← Real.rpow_natCast (max b 0) 3, ← Real.rpow_mul hM]
+      have : ((3 : ℕ) : ℝ) * ((1 : ℝ) / 3) = 1 := by push_cast; ring
+      rw [this, Real.rpow_one]⟩
+  -- c * (log n)^(1/3) → ∞
+  have h_mul : Tendsto (fun n : ℕ => eps87_constant * (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3))
+      atTop atTop := by
+    rw [Filter.tendsto_atTop_atTop]
+    intro b
+    obtain ⟨N, hN⟩ := Filter.tendsto_atTop_atTop.mp h_rpow (b / eps87_constant)
+    exact ⟨N, fun n hn => by
+      have h := hN n hn
+      have hcb : eps87_constant * (b / eps87_constant) = b := by field_simp
+      linarith [mul_le_mul_of_nonneg_left h (le_of_lt hc)]⟩
+  -- g = (exp ∘ (c * ·) ∘ (·^(1/3)) ∘ log ∘ ↑)⁻¹ → 0
+  have h_lim : Tendsto (fun n : ℕ => (Real.exp (eps87_constant *
+      (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3)))⁻¹) atTop (𝓝 0) :=
+    tendsto_inv_atTop_zero.comp (Real.tendsto_exp_atTop.comp h_mul)
+  -- Upper bound
+  have h_bound : ∀ n : ℕ, (maxDistinctRunLength n : ℝ) / ↑n ≤
+      (Real.exp (eps87_constant * (Real.log (↑n : ℝ)) ^ ((1 : ℝ) / 3)))⁻¹ := by
+    intro n
+    by_cases hn : n = 0
+    · simp [hn]
+    · have hn' := Nat.pos_of_ne_zero hn
+      have hn_pos : (0 : ℝ) < ↑n := Nat.cast_pos.mpr hn'
+      have hexp_pos := Real.exp_pos (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3))
+      rw [inv_eq_one_div, div_le_div_iff₀ hn_pos hexp_pos, one_mul]
+      calc ↑(maxDistinctRunLength n) *
+              Real.exp (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3))
+          ≤ (↑n / Real.exp (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3))) *
+              Real.exp (eps87_constant * (Real.log ↑n) ^ ((1 : ℝ) / 3)) :=
+            mul_le_mul_of_nonneg_right (maxDistinctRunLength_le_eps87 n hn') (le_of_lt hexp_pos)
+        _ = ↑n := div_mul_cancel₀ _ (ne_of_gt hexp_pos)
+  -- Squeeze: 0 ≤ f ≤ g, g → 0
+  exact squeeze_zero (fun n => div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _))
+    h_bound h_lim
 
 /-! ## Part V: The Main Conjecture -/
 
@@ -331,11 +397,13 @@ theorem totient_eq_two_iff (n : ℕ) : phi n = 2 ↔ n = 3 ∨ n = 4 ∨ n = 6 :
         simp only [hS, Finset.mem_filter, Finset.mem_range]
         refine ⟨by omega, ?_⟩
         show Nat.gcd n (n - 1) = 1
-        have h1 : Nat.gcd n (n - 1) ∣ 1 := by
-          have := Nat.dvd_sub' (Nat.gcd_dvd_left n (n - 1)) (Nat.gcd_dvd_right n (n - 1))
-          rwa [show n - (n - 1) = 1 from by omega] at this
-        exact Nat.le_antisymm (Nat.le_of_dvd one_pos h1)
-          (Nat.gcd_pos_of_pos_left (n - 1) (by omega))
+        -- Consecutive integers are coprime: gcd(n, n-1) = 1
+        -- n = 1 + (n-1), so n % (n-1) = 1, then gcd(n, n-1) = gcd(n-1, 1) = 1
+        have hmod : n % (n - 1) = 1 := by
+          nth_rewrite 1 [show n = 1 + (n - 1) from by omega]
+          rw [Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : 1 < n - 1)]
+        rw [Nat.gcd_comm, Nat.gcd_rec, hmod]
+        simp
       have hsub : ({1, 5, n - 1} : Finset ℕ) ⊆ S := by
         intro x hx; simp only [Finset.mem_insert, Finset.mem_singleton] at hx
         rcases hx with rfl | rfl | rfl <;> assumption

--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -506,13 +506,47 @@ All consecutive divisor ratios = 2, so h_α(2^k) = k·(2-1)^α = k.
 Proof: both lists are sorted permutations of the same multiset. -/
 private theorem sortedDivisors_two_pow (k : ℕ) :
     sortedDivisors (2 ^ k) = (List.range (k + 1)).map (HPow.hPow 2) := by
-  sorry -- sort uniqueness via Nat.divisors_prime_pow + Perm.eq_of_pairwise
+  unfold sortedDivisors
+  have hp : Nat.Prime 2 := by norm_num
+  rw [Nat.divisors_prime_pow hp]
+  -- Target list properties
+  have T_nodup : ((List.range (k + 1)).map (HPow.hPow 2)).Nodup :=
+    List.Nodup.map (Nat.pow_right_injective (by norm_num : 1 < 2)) List.nodup_range
+  have T_sorted : ((List.range (k + 1)).map (HPow.hPow 2)).Pairwise (· ≤ ·) := by
+    rw [List.pairwise_map]
+    exact List.Pairwise.imp (fun hab => Nat.pow_le_pow_right (by omega) (le_of_lt hab))
+      List.pairwise_lt_range
+  -- Build perm proof with explicit types (needed for typeclass resolution)
+  set S := ((Finset.range (k + 1)).map
+    ⟨(HPow.hPow 2 : ℕ → ℕ), Nat.pow_right_injective hp.one_lt⟩) with hS_def
+  have S_nodup : (S.sort (· ≤ ·)).Nodup := Finset.sort_nodup _ _
+  have S_sorted : (S.sort (· ≤ ·)).Pairwise (· ≤ ·) := Finset.pairwise_sort _ _
+  have hmem : ∀ x, x ∈ S.sort (· ≤ ·) ↔
+      x ∈ (List.range (k + 1)).map (HPow.hPow 2) := by
+    intro x; rw [Finset.mem_sort (r := (· ≤ ·))]
+    simp only [hS_def, Finset.mem_map, Finset.mem_range, Function.Embedding.coeFn_mk,
+               List.mem_map, List.mem_range]
+  have hperm : (S.sort (· ≤ ·)).Perm ((List.range (k + 1)).map (HPow.hPow 2)) :=
+    (List.perm_ext_iff_of_nodup S_nodup T_nodup).mpr hmem
+  exact hperm.eq_of_pairwise (fun _ _ _ _ h1 h2 => le_antisymm h1 h2) S_sorted T_sorted
+
+/-- Normalize monadic list map: l.flatMap (fun a => [f a]) = l.map f (general version) -/
+private theorem flatMap_singleton_eq_map' {α β : Type} (f : α → β) (l : List α) :
+    l.flatMap (fun a => [f a]) = l.map f := by
+  induction l with
+  | nil => rfl
+  | cons a t ih => simp [List.flatMap_cons, ih]
 
 /-- The consecutive divisor ratios of 2^k consist of k copies of 2.
-Each ratio d_{i+1}/d_i = 2^(i+1)/2^i = 2. -/
+Each ratio d_{i+1}/d_i = 2^(i+1)/2^i = 2.
+
+Note: The proof is blocked by Lean 4's elaboration of the ℕ→ℚ cast inside
+`zipWith (fun a b => (↑a : ℚ) / ↑b)`, which normalizes to monadic do/let/pure
+form, preventing standard List rewrite lemmas from matching. The mathematical
+content is straightforward: each ratio 2^(i+1)/2^i = 2. -/
 private theorem divisorRatios_two_pow (k : ℕ) :
     divisorRatios (2 ^ k) = List.replicate k (2 : ℚ) := by
-  sorry -- via sortedDivisors_two_pow + zipWith computation
+  sorry -- Lean 4 monadic normalization blocker; see docstring above
 
 private theorem flatMap_singleton_eq_map (f : ℚ → ℝ) (l : List ℚ) :
     l.flatMap (fun a => [f a]) = l.map f := by

--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -201,6 +201,31 @@ gaps penalized more heavily for larger α.
 noncomputable def h_alpha (α : ℝ) (n : ℕ) : ℝ :=
   (divisorRatios n).map (fun r => ((r : ℝ) - 1) ^ α) |>.sum
 
+-- Normalization: Lean 4 elaborates casts via do/pure monadic syntax.
+-- These helpers convert monadic forms back to List.map for proof convenience.
+private theorem flatMap_singleton_eq {α β : Type*} (f : α → β) (l : List α) :
+    l.flatMap (fun a => [f a]) = l.map f := by
+  induction l with
+  | nil => rfl
+  | cons a t ih => simp [List.flatMap_cons, ih]
+
+private theorem flatMap_pure_eq {α : Type*} (l : List α) :
+    l.flatMap (fun a => [a]) = l := by
+  induction l with
+  | nil => rfl
+  | cons a t ih => simp [List.flatMap_cons, ih]
+
+
+-- h_alpha normalizes: monad form = direct map form
+private theorem h_alpha_eq_map_sum (α : ℝ) (n : ℕ) :
+    h_alpha α n = ((divisorRatios n).map (fun r : ℚ => ((↑r : ℝ) - 1) ^ α)).sum := by
+  unfold h_alpha
+  congr 1
+  rw [show (do let a ← divisorRatios n; pure (↑a : ℝ)) =
+    (divisorRatios n).map (Rat.cast : ℚ → ℝ) from flatMap_singleton_eq Rat.cast _,
+    List.map_map]
+  simp only [Function.comp_def]
+
 /-
 h_α(n) can be computed by summing over consecutive pairs.
 This is definitional from the h_alpha definition.
@@ -292,7 +317,7 @@ Proof: The first term is ((d₂/1) - 1)^α ≥ (2-1)^α = 1.
 -/
 theorem h_alpha_ge_one (α : ℝ) (hα : α > 1) (n : ℕ) (hn : n ≥ 2) :
     h_alpha α n ≥ 1 := by
-  unfold h_alpha
+  rw [h_alpha_eq_map_sum]
   obtain ⟨r, hr_mem, hr_ge⟩ := first_ratio_ge_two n hn
   set f := (fun (r : ℚ) => ((r : ℝ) - 1) ^ α) with hf_def
   have hr1 : (1 : ℝ) ≤ (r : ℝ) - 1 := by
@@ -311,8 +336,8 @@ theorem h_alpha_ge_one (α : ℝ) (hα : α > 1) (n : ℕ) (hn : n ≥ 2) :
       have : (1 : ℝ) ≤ (q : ℝ) := by exact_mod_cast divisorRatios_ge_one n (by omega) q hq_mem
       linarith) α
   exact le_trans hterm_ge (by
-    apply List.single_le_sum hall_nonneg
-    simp only [List.mem_map]; exact ⟨r, hr_mem, rfl⟩)
+    have hmem : f r ∈ (divisorRatios n).map f := List.mem_map.mpr ⟨r, hr_mem, rfl⟩
+    exact List.single_le_sum hall_nonneg (f r) hmem)
 
 /-
 ## Part IV: Special Sequences
@@ -445,11 +470,11 @@ private theorem prime_ratio_mem (p : ℕ) (hp : Nat.Prime p) :
       simpa [sortedDivisors] using this
     exact (Nat.mem_divisors.mp this).1
   have hd2_eq : d₂ = p := (hp.eq_one_or_self_of_dvd d₂ hd2_dvd).resolve_left (by omega)
-  subst hd2_eq
-  have : divisorRatios p = List.zipWith (fun a b => (↑a : ℚ) / ↑b)
-      (sortedDivisors p).tail (sortedDivisors p) := rfl
-  rw [this, heq, List.tail_cons, List.zipWith_cons_cons]
-  simp [Nat.cast_one, div_one]
+  rw [hd2_eq] at heq
+  show (↑p : ℚ) ∈ divisorRatios p
+  unfold divisorRatios
+  rw [heq]
+  simp [List.tail_cons, List.zipWith_cons_cons, Nat.cast_one, div_one, List.mem_cons]
 
 /--
 **Example: Prime p**
@@ -475,7 +500,7 @@ theorem prime_h_alpha_unbounded :
     linarith
   calc h_alpha α p
       ≥ ((p : ℝ) - 1) ^ α := by
-        unfold h_alpha
+        rw [h_alpha_eq_map_sum]
         set f := (fun r : ℚ => ((r : ℝ) - 1) ^ α)
         have hr := prime_ratio_mem p hp
         have hall : ∀ x ∈ (divisorRatios p).map f, 0 ≤ x := by
@@ -485,10 +510,10 @@ theorem prime_h_alpha_unbounded :
             have : (1 : ℝ) ≤ (q : ℝ) := by
               exact_mod_cast divisorRatios_ge_one p (by omega) q hq
             linarith) α
-        have hsle := by
-          apply List.single_le_sum hall
-          simp only [List.mem_map]; exact ⟨_, hr, rfl⟩
-        simp only [Rat.cast_natCast] at hsle
+        have hsle : f (↑p : ℚ) ≤ ((divisorRatios p).map f).sum :=
+          List.single_le_sum hall _ (List.mem_map.mpr ⟨_, hr, rfl⟩)
+        -- f (↑p : ℚ) = ((↑(↑p:ℚ):ℝ) - 1)^α = ((↑p:ℝ) - 1)^α
+        simp only [f, Rat.cast_natCast] at hsle
         linarith
     _ ≥ (p : ℝ) - 1 := by
         calc ((p : ℝ) - 1) ^ α
@@ -506,47 +531,49 @@ All consecutive divisor ratios = 2, so h_α(2^k) = k·(2-1)^α = k.
 Proof: both lists are sorted permutations of the same multiset. -/
 private theorem sortedDivisors_two_pow (k : ℕ) :
     sortedDivisors (2 ^ k) = (List.range (k + 1)).map (HPow.hPow 2) := by
+  have hprime : Nat.Prime 2 := by decide
   unfold sortedDivisors
-  have hp : Nat.Prime 2 := by norm_num
-  rw [Nat.divisors_prime_pow hp]
-  -- Target list properties
-  have T_nodup : ((List.range (k + 1)).map (HPow.hPow 2)).Nodup :=
-    List.Nodup.map (Nat.pow_right_injective (by norm_num : 1 < 2)) List.nodup_range
-  have T_sorted : ((List.range (k + 1)).map (HPow.hPow 2)).Pairwise (· ≤ ·) := by
-    rw [List.pairwise_map]
-    exact List.Pairwise.imp (fun hab => Nat.pow_le_pow_right (by omega) (le_of_lt hab))
-      List.pairwise_lt_range
-  -- Build perm proof with explicit types (needed for typeclass resolution)
-  set S := ((Finset.range (k + 1)).map
-    ⟨(HPow.hPow 2 : ℕ → ℕ), Nat.pow_right_injective hp.one_lt⟩) with hS_def
-  have S_nodup : (S.sort (· ≤ ·)).Nodup := Finset.sort_nodup _ _
-  have S_sorted : (S.sort (· ≤ ·)).Pairwise (· ≤ ·) := Finset.pairwise_sort _ _
-  have hmem : ∀ x, x ∈ S.sort (· ≤ ·) ↔
-      x ∈ (List.range (k + 1)).map (HPow.hPow 2) := by
-    intro x; rw [Finset.mem_sort (r := (· ≤ ·))]
-    simp only [hS_def, Finset.mem_map, Finset.mem_range, Function.Embedding.coeFn_mk,
-               List.mem_map, List.mem_range]
-  have hperm : (S.sort (· ≤ ·)).Perm ((List.range (k + 1)).map (HPow.hPow 2)) :=
-    (List.perm_ext_iff_of_nodup S_nodup T_nodup).mpr hmem
-  exact hperm.eq_of_pairwise (fun _ _ _ _ h1 h2 => le_antisymm h1 h2) S_sorted T_sorted
+  rw [Nat.divisors_prime_pow hprime]
+  -- Both sides are sorted (pairwise ≤) and permutations → equal
+  -- First show they're permutations via nodup + same members
+  have hinj : Function.Injective (HPow.hPow 2 : ℕ → ℕ) := by
+    intro a b h; exact Nat.pow_right_injective (by omega) h
+  have hnodup_target : ((List.range (k + 1)).map (HPow.hPow 2 : ℕ → ℕ)).Nodup :=
+    List.nodup_range.map hinj
+  have hnodup_sort : (((Finset.range (k + 1)).map ⟨HPow.hPow 2, hinj⟩).sort
+      (· ≤ ·)).Nodup := Finset.sort_nodup _ _
+  have hperm : ((List.range (k + 1)).map (HPow.hPow 2 : ℕ → ℕ)).Perm
+      (((Finset.range (k + 1)).map ⟨HPow.hPow 2, hinj⟩).sort (· ≤ ·)) := by
+    rw [List.perm_ext_iff_of_nodup hnodup_target hnodup_sort]
+    intro a
+    simp [Finset.mem_sort, Finset.mem_map, List.mem_map, Finset.mem_range, List.mem_range]
+  symm
+  exact List.eq_of_perm_of_sorted
+    (fun _ _ _ _ hab hba => le_antisymm hab hba)
+    (by simp only [List.pairwise_map]
+        exact List.pairwise_lt_range.imp fun h => Nat.pow_le_pow_right (by omega) h.le)
+    (Finset.pairwise_sort _ _)
+    hperm
 
-/-- Normalize monadic list map: l.flatMap (fun a => [f a]) = l.map f (general version) -/
-private theorem flatMap_singleton_eq_map' {α β : Type} (f : α → β) (l : List α) :
-    l.flatMap (fun a => [f a]) = l.map f := by
-  induction l with
-  | nil => rfl
-  | cons a t ih => simp [List.flatMap_cons, ih]
+/-- In the List monad, `do let a ← l; pure ↑a` normalizes to `l.map Nat.cast` for ℕ→ℚ. -/
+private theorem list_bind_pure_natCast (l : List ℕ) :
+    (do let a ← l; pure (↑a : ℚ)) = l.map (Nat.cast · : ℕ → ℚ) :=
+  flatMap_singleton_eq Nat.cast l
 
 /-- The consecutive divisor ratios of 2^k consist of k copies of 2.
 Each ratio d_{i+1}/d_i = 2^(i+1)/2^i = 2.
-
-Note: The proof is blocked by Lean 4's elaboration of the ℕ→ℚ cast inside
-`zipWith (fun a b => (↑a : ℚ) / ↑b)`, which normalizes to monadic do/let/pure
-form, preventing standard List rewrite lemmas from matching. The mathematical
-content is straightforward: each ratio 2^(i+1)/2^i = 2. -/
+Proved extensionally via List.ext_getElem after normalizing monadic ℕ→ℚ casts. -/
 private theorem divisorRatios_two_pow (k : ℕ) :
     divisorRatios (2 ^ k) = List.replicate k (2 : ℚ) := by
-  sorry -- Lean 4 monadic normalization blocker; see docstring above
+  simp only [divisorRatios, sortedDivisors_two_pow, list_bind_pure_natCast]
+  apply List.ext_getElem
+  · simp [List.length_zipWith]
+  · intro i h1 h2
+    simp only [List.getElem_zipWith, List.getElem_map, List.getElem_tail,
+               List.getElem_range, List.getElem_replicate]
+    push_cast
+    rw [pow_succ]
+    field_simp
 
 private theorem flatMap_singleton_eq_map (f : ℚ → ℝ) (l : List ℚ) :
     l.flatMap (fun a => [f a]) = l.map f := by

--- a/research/problems/erdos-1004-wip-01/knowledge.md
+++ b/research/problems/erdos-1004-wip-01/knowledge.md
@@ -1,0 +1,41 @@
+# Erdős #1004: Distinct Consecutive Totient Values
+
+## Problem Summary
+
+For c > 0, if x is sufficiently large, does there exist n ≤ x such that
+φ(n+1), φ(n+2), ..., φ(n+⌊(log x)^c⌋) are all distinct?
+
+**Status**: OPEN (partial results from EPS 1987)
+**File**: `proofs/Proofs/Erdos1004Problem.lean`
+**Sorries**: 2 remaining (was 3, then 5 originally)
+**Axioms**: 3 (EPS87 bound)
+
+## Session 2026-03-25 (Session 2) - Prove run_length_sublinear
+
+**Mode**: FRESH (REVISIT of in-progress problem)
+**Outcome**: progress (1 sorry eliminated)
+
+### What I Did
+- Proved `run_length_sublinear`: maxDistinctRunLength(n)/n → 0 as n → ∞
+  - Created helper `maxDistinctRunLength_le_eps87` bounding sSup via EPS87 axiom
+  - Used squeeze theorem with bound g(n) = 1/exp(c·(log n)^{1/3})
+  - Proved limit via composition chain: log→∞, rpow→∞, c*·→∞, exp→∞, inv→0
+- Fixed pre-existing `Nat.dvd_sub'` build error in `totient_eq_two_iff`
+  - Used Euclidean algorithm approach: gcd_rec + manual mod proof via nth_rewrite
+- Assessed `longer_runs_need_larger_n`: too deep for this session (requires existence of K-long distinct totient runs for arbitrary K)
+
+### Key Findings
+- The sSup bound technique: csSup_le + Nat.le_floor + Nat.floor_le cleanly transfers real bounds to ℕ sup
+- rpow cube root identity: `(a^3)^(1/3) = a` via rpow_natCast + rpow_mul + norm_num
+- omega cannot handle `n % (n-1) = 1` for variable n; need manual Euclidean approach
+- `longer_runs_need_larger_n` reduces to existence of a single m with K distinct consecutive totients (via ∃ n₀ trick), but even that single existence is deep
+
+### Files Modified
+- `proofs/Proofs/Erdos1004Problem.lean` (424 → 492 lines, 3 → 2 sorries)
+- `src/data/proofs/erdos-1004/meta.json` (updated counts)
+- `src/data/research/problems/erdos-1004-wip-01.json` (updated knowledge)
+
+### Next Steps
+- `longer_runs_need_larger_n`: try CRT-based constructive existence or density argument
+- `distinct_totients_asymptotic`: deep analytic result (Ford 1998), likely needs Aristotle or axiomatization
+- Consider submitting both as HARD to Aristotle

--- a/research/registry.json
+++ b/research/registry.json
@@ -5785,11 +5785,11 @@
     },
     {
       "slug": "erdos-1004-wip-01",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-03-24T00:48:59.900Z",
       "status": "active",
-      "lastUpdate": "2026-03-24T00:48:59.900Z"
+      "lastUpdate": "2026-03-25T01:35:29-07:00"
     },
     {
       "slug": "erdos-1007-oq-01-oq-01",

--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -16,13 +16,13 @@
       "analytic-number-theory"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 1004,
     "erdosUrl": "https://erdosproblems.com/1004",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 424,
-    "assumptions": "Three axioms for EPS87 upper bound (eps87_constant, eps87_constant_pos, eps87_upper_bound). Three sorries: run_length_sublinear, longer_runs_need_larger_n, distinct_totients_asymptotic.",
+    "lineCount": 492,
+    "assumptions": "Three axioms for EPS87 upper bound (eps87_constant, eps87_constant_pos, eps87_upper_bound). Two sorries: longer_runs_need_larger_n, distinct_totients_asymptotic. run_length_sublinear proved from axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -260,9 +260,9 @@
       "Topology"
     ],
     "namespace": "Erdos1004",
-    "lineCount": 424,
+    "lineCount": 492,
     "axiomCount": 3,
-    "theoremCount": 22,
+    "theoremCount": 23,
     "definitionCount": 13
   }
 }

--- a/src/data/research/problems/erdos-1004-wip-01.json
+++ b/src/data/research/problems/erdos-1004-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1004-wip-01",
   "title": "Complete Erdős #1004: Distinct Consecutive Totient Values (Work in Progress)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-24T00:48:59.901Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved run_length_sublinear. 2 deep sorries remain.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Attempt longer_runs_need_larger_n via constructive approach or submit to Aristotle",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,17 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 2 totient characterizations (sorries 5→3). Remaining: 3 deep sorries (sublinear growth, long runs existence, asymptotic density).",
+    "progressSummary": "PROGRESS: Proved run_length_sublinear corollary + 2 totient characterizations (sorries 5→2). Remaining: 2 sorries (long runs existence, asymptotic density).",
     "builtItems": [
       "Proved totient_eq_two_iff: φ(n) = 2 ↔ n ∈ {3,4,6}",
       "Proved totient_eq_four_iff: φ(n) = 4 ↔ n ∈ {5,8,10,12}",
-      "Helper prime_pred_dvd_totient via factorization + multiplicativity"
+      "Helper prime_pred_dvd_totient via factorization + multiplicativity",
+      "Proved maxDistinctRunLength_le_eps87: sSup bound from EPS87 axiom via csSup_le + Nat.floor",
+      "Proved run_length_sublinear: maxDistinctRunLength(n)/n → 0 via squeeze theorem",
+      "Fixed Nat.dvd_sub bug in totient_eq_two_iff via Euclidean gcd_rec"
     ],
     "insights": [
-      "prime_pred_dvd_totient: if prime p | n then (p-1) | φ(n), key infrastructure for totient characterizations"
+      "prime_pred_dvd_totient: if prime p | n then (p-1) | φ(n), key infrastructure for totient characterizations",
+      "run_length_sublinear proof chain: sSup bound → squeeze_zero with g(n)=1/exp(c·(log n)^{1/3}) → limit via composition (log→∞, rpow→∞, exp→∞, inv→0)",
+      "Key Mathlib API: csSup_le for ℕ, Nat.le_floor/floor_le for real-to-nat bound transfer, rpow_mul for cube root identity",
+      "longer_runs_need_larger_n requires deep number theory: existence of arbitrarily long distinct consecutive totient runs for fixed K"
     ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "longer_runs_need_larger_n: needs existence proof for K-long distinct runs; consider CRT-based construction or density argument",
+      "distinct_totients_asymptotic: needs ~x/log(x) distinct totients ≤ x; this is a deep analytic result (Ford 1998)",
+      "Consider submitting both remaining sorries to Aristotle as HARD classification"
+    ]
   },
   "tags": [
     "erdos",

--- a/src/data/research/problems/erdos-1099-oq-01.json
+++ b/src/data/research/problems/erdos-1099-oq-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-1099-oq-01",
-  "title": "Does h_α(n",
+  "title": "Does h_\u03b1(n",
   "phase": "NEW",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in number theory: Does h_α(n.",
+    "plain": "Formal investigation in number theory: Does h_\u03b1(n.",
     "whyMatters": []
   },
   "knownResults": {
@@ -17,7 +17,7 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-03-24T00:48:59.905Z",
+    "since": "2026-03-25T00:00:00Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: power_of_two_h_alpha converted from axiom to theorem (2 sorry helpers pending). 2 axioms remain (Vose 1984). sum_divisor_ratios_lower_bound removed (false bound).",
+    "progressSummary": "PROGRESS: sortedDivisors_two_pow proved (1 sorry eliminated, 1 remains). Lean 4 monadic elaboration blocks divisorRatios_two_pow.",
     "builtItems": [
       "17 new infrastructure theorems for sorted divisor properties",
       "first_divisor_is_one theorem (was axiom)",
@@ -40,13 +40,15 @@
       "h_alpha_ge_one: proved via nonneg sum + single_le_sum",
       "prime_ratio_mem: for prime p, ratio p is in divisorRatios",
       "prime_h_alpha_unbounded: proved via prime ratio + rpow monotonicity",
-      "Fixed le_div_iff → le_div_iff₀ rename in zipWith_div_ge_one",
-      "Fixed Real.rpow_le_rpow_left → Real.rpow_le_rpow_of_exponent_le rename",
-      "Fixed List.mem_cons_self → .head _ for membership proofs",
-      "Fixed List.mem_map.mpr → simp [List.mem_map] + apply List.single_le_sum pattern",
-      "power_of_two_h_alpha theorem (was axiom): h_alpha α (2^k) = k",
+      "Fixed le_div_iff \u2192 le_div_iff\u2080 rename in zipWith_div_ge_one",
+      "Fixed Real.rpow_le_rpow_left \u2192 Real.rpow_le_rpow_of_exponent_le rename",
+      "Fixed List.mem_cons_self \u2192 .head _ for membership proofs",
+      "Fixed List.mem_map.mpr \u2192 simp [List.mem_map] + apply List.single_le_sum pattern",
+      "power_of_two_h_alpha theorem (was axiom): h_alpha \u03b1 (2^k) = k",
       "flatMap_singleton_eq_map: normalize monadic flatMap to List.map",
-      "list_bind_pure_ratCast: bridge monad do/pure to explicit map for ℚ→ℝ cast"
+      "list_bind_pure_ratCast: bridge monad do/pure to explicit map for \u211a\u2192\u211d cast",
+      "sortedDivisors_two_pow: proved sorted divisors of 2^k = [1, 2, 4, ..., 2^k]",
+      "flatMap_singleton_eq_map' (generalized): l.flatMap (fun a => [f a]) = l.map f for Type\u2192Type"
     ],
     "insights": [
       "divisorRatios had a critical bug: computed d_i/d_{i+1} instead of d_{i+1}/d_i",
@@ -56,17 +58,19 @@
       "Key to h_alpha_ge_one: prove all divisor ratios >= 1 via zipWith induction on sorted lists",
       "For prime unboundedness: Nat.exists_infinite_primes + rpow_le_rpow_left for exponent monotonicity",
       "Real.rpow_nonneg requires 0 <= base; for ratios >= 1 we get base = ratio - 1 >= 0",
-      "sum_divisor_ratios_lower_bound axiom was FALSE: claimed Σ(d_{i+1}/dᵢ) > τ(n) + log(n) but correct bound is τ(n)-1+log(n) (off by 1 because there are τ-1 ratios, not τ). Counterexample: n=2, sum=2 but τ+log(2)≈2.69. Removed the false axiom.",
+      "sum_divisor_ratios_lower_bound axiom was FALSE: claimed \u03a3(d_{i+1}/d\u1d62) > \u03c4(n) + log(n) but correct bound is \u03c4(n)-1+log(n) (off by 1 because there are \u03c4-1 ratios, not \u03c4). Counterexample: n=2, sum=2 but \u03c4+log(2)\u22482.69. Removed the false axiom.",
       "Lean 4 v4.26.0 has List.map normalization issues: map f l normalizes to do/flatMap form, breaking List.mem_map.mpr and List.single_le_sum proofs",
-      "sum_divisor_ratios_lower_bound was FALSE: fails for n=2 (2 > 2+ln2≈2.69), n=6 (5.5 > 4+ln6≈5.79)",
-      "Lean4 monad elaboration creates do/pure form when composing List.map with casts — need flatMap_singleton helper to normalize"
+      "sum_divisor_ratios_lower_bound was FALSE: fails for n=2 (2 > 2+ln2\u22482.69), n=6 (5.5 > 4+ln6\u22485.79)",
+      "Lean4 monad elaboration creates do/pure form when composing List.map with casts \u2014 need flatMap_singleton helper to normalize",
+      "sortedDivisors_two_pow proved via Perm+Pairwise: Nat.pow_right_injective for nodup, List.pairwise_lt_range+Nat.pow_le_pow_right for sorted",
+      "divisorRatios_two_pow blocked by Lean 4 monadic elaboration: zipWith with \u2115\u2192\u211a cast normalizes to do/let/pure form, preventing List rewrite lemmas from matching"
     ],
     "mathlibGaps": [
       "No direct Finset.sort getLast = max lemma"
     ],
     "nextSteps": [
-      "Fill in sortedDivisors_two_pow sorry via Perm.eq_of_pairwise + Nat.divisors_prime_pow",
-      "Fill in divisorRatios_two_pow sorry via sortedDivisors_two_pow + zipWith computation"
+      "Resolve Lean 4 monadic normalization for divisorRatios_two_pow (cast inside zipWith creates do/pure form)",
+      "Consider proving power_of_two_h_alpha directly without divisorRatios_two_pow helper"
     ]
   },
   "tags": [
@@ -89,7 +93,7 @@
     "mathlib": []
   },
   "started": "2026-03-24T00:48:59.905Z",
-  "lastUpdate": "2026-03-24T00:48:59.905Z",
+  "lastUpdate": "2026-03-25T00:00:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- Prove `divisorRatios_two_pow`: consecutive divisor ratios of 2^k are all 2 (eliminates last sorry in Erdos1099Problem.lean)
- Add `list_bind_pure_natCast` helper to normalize Lean 4's monadic ℕ→ℚ cast elaboration back to `List.map`
- Proof strategy: extensional equality via `List.ext_getElem` with element-wise computation `2^(i+1)/2^i = 2`

## Details
The previous sorry was blocked by Lean 4's elaboration of `(↑a : ℚ)` inside `List.zipWith`, which normalized to `do/let/pure` monadic form, preventing standard `List.getElem_*` simp lemmas from matching. The fix converts the monadic form back to explicit `List.map` using a new helper lemma, then proves element equality at each index.

**Before**: 1 sorry, 2 axioms
**After**: 0 sorries, 2 axioms (status: axiomatized)

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos1099Problem`
- [x] Zero sorries: `grep -c sorry proofs/Proofs/Erdos1099Problem.lean` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

research