### PR TITLE
Enrich 2 entries: abel-ruffini cross-refs, amgm-inequality mainTheorems

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -319,6 +319,16 @@
       "targetId": "quadratic-reciprocity",
       "relationship": "related",
       "description": "Gauss's golden theorem $(p/q)(q/p) = (-1)^{(p-1)(q-1)/4}$ was among the first results later explained by class field theory, which classifies abelian extensions of $\\mathbb{Q}$ via Artin reciprocity — the abelian case of the Langlands program. Abel-Ruffini's impossibility concerns the non-abelian boundary: polynomials with abelian Galois groups (covered by class field theory and Kronecker-Weber) are always solvable by radicals, while those with non-solvable groups like $S_5$ are not"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "De Moivre's formula $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$ governs the $n$th roots of unity $\\zeta_n = e^{2\\pi i/n}$ that form a cyclic group under multiplication. These roots of unity are the hidden engine of radical extensions: each radical step $K \\to K(\\sqrt[n]{a})$ in a radical tower implicitly uses the cyclotomic extension $K(\\zeta_n)/K$, whose Galois group $(\\mathbb{Z}/n\\mathbb{Z})^{\\times}$ is abelian. The abelianity of cyclotomic extensions — ultimately traceable to De Moivre — is what makes each layer of a radical tower contribute a solvable Galois quotient"
+    },
+    {
+      "targetId": "de-moivre-oq-03",
+      "relationship": "foundational",
+      "description": "Fractional exponents and root extraction via De Moivre's theorem formalize the precise mechanism underlying radical extensions: the $n$th roots $z^{1/n} = |z|^{1/n} e^{i\\theta/n}$ that define each step $K_i \\to K_i(\\sqrt[n]{a})$ of a radical tower. Abel-Ruffini's impossibility arises when the polynomial's Galois group $S_5$ cannot be decomposed into the cyclic layers that root extraction provides"
     }
   ],
   "references": [

--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -294,16 +294,22 @@
   },
   "mainTheorems": [
     {
-      "name": "amgm",
+      "name": "am_gm_two",
       "type": "core",
-      "description": "AM-GM: arithmetic mean >= geometric mean for non-negative reals",
-      "leanType": "(a : Fin n -> R) -> (forall i, 0 <= a i) -> (sum a / n) >= (prod a)^(1/n)"
+      "description": "Elementary two-variable AM-GM: (a + b) / 2 ≥ √(ab) via (√a - √b)² ≥ 0",
+      "leanType": "(a b : ℝ) → 0 ≤ a → 0 ≤ b → (a + b) / 2 ≥ Real.sqrt (a * b)"
     },
     {
-      "name": "amgm_equality",
+      "name": "am_gm_two_eq_iff",
       "type": "key",
-      "description": "Equality holds iff all values are equal",
-      "leanType": "AM a = GM a <-> forall i j, a i = a j"
+      "description": "Equality characterization: (a + b) / 2 = √(ab) iff a = b",
+      "leanType": "(a b : ℝ) → 0 ≤ a → 0 ≤ b → ((a + b) / 2 = Real.sqrt (a * b) ↔ a = b)"
+    },
+    {
+      "name": "am_gm_weighted",
+      "type": "key",
+      "description": "General weighted AM-GM via Mathlib: ∏ zᵢ^wᵢ ≤ ∑ wᵢzᵢ for weights summing to 1",
+      "leanType": "{ι : Type*} → (s : Finset ι) → (w z : ι → ℝ) → (∀ i ∈ s, 0 ≤ w i) → ∑ i ∈ s, w i = 1 → (∀ i ∈ s, 0 ≤ z i) → ∏ i ∈ s, z i ^ w i ≤ ∑ i ∈ s, w i * z i"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **abel-ruffini**: Added 2 missing cross-references to de-moivre entries referenced in keyInsights but absent from crossReferences array
- **amgm-inequality**: Fixed mainTheorems to use actual Lean names (am_gm_two, am_gm_two_eq_iff, am_gm_weighted) instead of generic placeholders; added am_gm_weighted as third main theorem

All cross-reference targets verified to exist in the gallery.