### PR TITLE
Enrich 18 entries: fix mainTheorems with actual Lean 4 signatures

### DIFF
--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -331,20 +331,20 @@
     {
       "name": "binomial_theorem",
       "type": "core",
-      "description": "(x+y)^n = sum_k C(n,k) * x^k * y^(n-k) for commutative semirings",
-      "leanType": "[CommSemiring R] -> (x y : R) -> (n : Nat) -> (x + y)^n = sum k in range (n+1), choose n k * x^k * y^(n-k)"
+      "description": "Binomial theorem: (x+y)ⁿ = ∑ C(n,k) xᵏ yⁿ⁻ᵏ for commutative semirings",
+      "leanType": "{R : Type*} → [CommSemiring R] → (x y : R) → (n : ℕ) → (x + y) ^ n = ∑ k in range (n + 1), Nat.choose n k * x ^ k * y ^ (n - k)"
     },
     {
       "name": "sum_binomial_coefficients",
       "type": "key",
-      "description": "Sum of binomial coefficients: sum C(n,k) = 2^n",
-      "leanType": "(n : Nat) -> sum k in range (n+1), choose n k = 2^n"
+      "description": "Sum of binomial coefficients: ∑ C(n,k) = 2ⁿ",
+      "leanType": "(n : ℕ) → ∑ k in range (n + 1), Nat.choose n k = 2 ^ n"
     },
     {
       "name": "alternating_sum_binomial",
       "type": "key",
-      "description": "Alternating sum for n >= 1: sum (-1)^k C(n,k) = 0",
-      "leanType": "(n : Nat) -> 0 < n -> sum k in range (n+1), (-1)^k * choose n k = 0"
+      "description": "Alternating sum for n ≥ 1: ∑ (-1)ᵏ C(n,k) = 0",
+      "leanType": "(n : ℕ) → 0 < n → ∑ k in range (n + 1), (-1 : ℤ) ^ k * Nat.choose n k = 0"
     }
   ]
 }

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -252,16 +252,16 @@
   },
   "mainTheorems": [
     {
-      "name": "derangement_count",
+      "name": "derangements_recurrence",
       "type": "core",
-      "description": "Number of derangements of n elements: D_n = n! * sum_{k=0}^n (-1)^k/k!",
-      "leanType": "(n : Nat) -> card (derangements n) = n! * sum k in range (n+1), (-1)^k / k!"
+      "description": "Derangement recurrence: D(n+2) = (n+1)(D(n) + D(n+1))",
+      "leanType": "(n : ℕ) → numDerangements (n + 2) = (n + 1) * (numDerangements n + numDerangements (n + 1))"
     },
     {
       "name": "derangement_probability",
       "type": "key",
-      "description": "Probability of a random permutation being a derangement approaches 1/e",
-      "leanType": "Tendsto (fun n => D_n / n!) atTop (nhds (1/Real.exp 1))"
+      "description": "Probability of a derangement approaches 1/e as n → ∞",
+      "leanType": "Filter.Tendsto (fun n => (numDerangements n : ℝ) / n.factorial) Filter.atTop (nhds (1 / Real.exp 1))"
     }
   ]
 }

--- a/src/data/proofs/mean-value-theorem/meta.json
+++ b/src/data/proofs/mean-value-theorem/meta.json
@@ -237,14 +237,14 @@
     {
       "name": "mvt",
       "type": "core",
-      "description": "MVT: there exists c in (a,b) with f'(c) = (f(b) - f(a))/(b - a)",
-      "leanType": "(hab : a < b) -> ContinuousOn f (Icc a b) -> DifferentiableOn R f (Ioo a b) -> exists c in Ioo a b, deriv f c = (f b - f a) / (b - a)"
+      "description": "MVT: ∃ c ∈ (a,b) with f'(c) = (f(b) - f(a))/(b - a)",
+      "leanType": "{a b : ℝ} → a < b → {f : ℝ → ℝ} → ContinuousOn f (Icc a b) → DifferentiableOn ℝ f (Ioo a b) → ∃ c ∈ Ioo a b, deriv f c = (f b - f a) / (b - a)"
     },
     {
       "name": "cauchy_mvt",
-      "type": "bridge",
-      "description": "Cauchy's MVT: (g(b)-g(a))f'(c) = (f(b)-f(a))g'(c)",
-      "leanType": "(hab : a < b) -> ContinuousOn f/g -> HasDerivAt f/g -> exists c in Ioo a b, (g b - g a) * f' c = (f b - f a) * g' c"
+      "type": "key",
+      "description": "Cauchy's generalized MVT: (g(b)-g(a))f'(c) = (f(b)-f(a))g'(c)",
+      "leanType": "{a b : ℝ} → a < b → {f g : ℝ → ℝ} → ContinuousOn f (Icc a b) → ContinuousOn g (Icc a b) → ∃ c ∈ Ioo a b, (g b - g a) * deriv f c = (f b - f a) * deriv g c"
     }
   ]
 }

--- a/src/data/proofs/taylor-theorem/meta.json
+++ b/src/data/proofs/taylor-theorem/meta.json
@@ -232,10 +232,10 @@
   ],
   "mainTheorems": [
     {
-      "name": "taylor_theorem",
+      "name": "taylor_lagrange",
       "type": "core",
-      "description": "f(x) = sum_{k=0}^n f^(k)(a)/k! * (x-a)^k + R_n(x) with Lagrange remainder",
-      "leanType": "ContDiff n f -> exists c between a x, f x = taylorPoly n f a x + f^(n+1)(c) / (n+1)! * (x-a)^(n+1)"
+      "description": "Taylor's theorem with Lagrange remainder: f(x) = T_n(x) + f⁽ⁿ⁺¹⁾(c)/(n+1)! · (x-x₀)ⁿ⁺¹",
+      "leanType": "{f : ℝ → ℝ} → {x₀ x : ℝ} → {n : ℕ} → x₀ < x → ContDiffOn ℝ (n + 1) f (Icc x₀ x) → ∃ x' ∈ Ioo x₀ x, f x - taylorWithinEval f n (Icc x₀ x) x₀ x = iteratedDerivWithin (n + 1) f (Icc x₀ x) x' * (x - x₀) ^ (n + 1) / (n + 1).factorial"
     }
   ]
 }

--- a/src/data/proofs/triangle-angle-sum/meta.json
+++ b/src/data/proofs/triangle-angle-sum/meta.json
@@ -193,8 +193,8 @@
     {
       "name": "triangle_angle_sum",
       "type": "core",
-      "description": "Sum of interior angles of a triangle equals pi (180 degrees)",
-      "leanType": "Triangle ABC -> angle A + angle B + angle C = pi"
+      "description": "Sum of interior angles of a triangle equals π",
+      "leanType": "{p₁ p₂ p₃ : P} → p₂ ≠ p₁ → p₃ ≠ p₁ → ∠ p₁ p₂ p₃ + ∠ p₂ p₃ p₁ + ∠ p₃ p₁ p₂ = Real.pi"
     }
   ]
 }

--- a/src/data/proofs/triangle-inequality/meta.json
+++ b/src/data/proofs/triangle-inequality/meta.json
@@ -234,10 +234,10 @@
   ],
   "mainTheorems": [
     {
-      "name": "triangle_inequality",
+      "name": "abs_triangle",
       "type": "core",
-      "description": "||x + y|| <= ||x|| + ||y|| in normed spaces",
-      "leanType": "[NormedAddCommGroup E] -> (x y : E) -> norm(x + y) <= norm x + norm y"
+      "description": "|x + y| ≤ |x| + |y| for real numbers",
+      "leanType": "(x y : ℝ) → |x + y| ≤ |x| + |y|"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Systematic fix of top-level `mainTheorems` across 18 entries to use actual Lean 4 theorem names and type signatures instead of generic pseudo-types.

### Pattern
Many entries had mainTheorems with pseudo-syntax like `norm(u)`, `forall`, `exists`, `->`, or non-existent theorem names. These are now corrected to match the actual Lean 4 files with proper Unicode symbols (∀, ∃, ∧, →, ↔, ‖‖, ⟪⟫, ∠, ∑, ∑', |·|) and exact type signatures.

### Entries fixed:
| Entry | Key Fix |
|-------|---------|
| angle-trisection | Added cube_doubling_impossible, circle_squaring_impossible |
| ballot-problem | ballot_problem → ballot_theorem, added real-valued form |
| binomial-theorem | Proper Nat.choose, ∑ notation, CommSemiring types |
| cauchy-schwarz | ⟪⟫_ℝ, ‖‖, ∑ notation, NormedAddCommGroup types |
| derangements | derangement_count → derangements_recurrence, numDerangements |
| fundamental-theorem-calculus | Added ∀ x ∈, ∫ x in a..b, StronglyMeasurableAtFilter |
| geometric-series | geometric_series_sum → infinite_geom_sum, ∑' and ⁻¹ |
| infinitude-primes | forall/exists/and → ∀/∃/∧ |
| lagrange-theorem | lagrange_theorem → lagrange, full [Group G] types |
| mean-value-theorem | Proper ∃ c ∈ Ioo, DifferentiableOn ℝ types |
| pythagorean-theorem | ⊥, ‖‖ Unicode, DecidableEq types |
| taylor-theorem | taylor_theorem → taylor_lagrange, actual signature |
| triangle-angle-sum | ∠ notation, Real.pi, point types |
| triangle-inequality | triangle_inequality → abs_triangle, |·| notation |
| wilsons-theorem | wilson_theorem → wilsons_theorem, ZMod form |
| (+ 3 already merged in previous PRs) | |