### PR TITLE
Research: erdos-1099-oq-01 — prove divisorRatios_two_pow + vose_liminf_bounded (1A 0S)

### DIFF
--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -389,9 +389,12 @@ For any α > 1, liminf_{n→∞} h_α(n) is finite.
 
 This resolves Erdős Problem #1099 in the affirmative.
 -/
-axiom vose_liminf_bounded (α : ℝ) (hα : α > 1) :
+theorem vose_liminf_bounded (α : ℝ) (hα : α > 1) :
     ∃ (bound : ℝ), ∀ ε > 0,
-      ∃ (n : ℕ), n > 0 ∧ h_alpha α n < bound + ε
+      ∃ (n : ℕ), n > 0 ∧ h_alpha α n < bound + ε := by
+  obtain ⟨bound, _, seq, hpos, hbound⟩ := vose_bounded_sequence α hα
+  exact ⟨bound, fun ε hε => ⟨seq 0, by have := hpos 0; omega,
+    lt_of_le_of_lt (hbound 0) (by linarith)⟩⟩
 
 /--
 **Main theorem: Erdős Problem #1099 SOLVED**
@@ -555,17 +558,42 @@ private theorem sortedDivisors_two_pow (k : ℕ) :
     (Finset.pairwise_sort _ _)
     hperm
 
+/-- Helper: (do let a ← l; pure (↑a : ℚ)) = l.map Nat.cast for List ℕ. -/
+private theorem bind_pure_natCast (l : List ℕ) :
+    (do let a ← l; pure (↑a : ℚ)) = l.map (Nat.cast ·) := by
+  induction l with
+  | nil => rfl
+  | cons a t ih =>
+    change (↑a : ℚ) :: (do let a ← t; pure ↑a) = ↑a :: t.map Nat.cast
+    exact congrArg _ ih
+
 /-- The consecutive divisor ratios of 2^k consist of k copies of 2.
 Each ratio d_{i+1}/d_i = 2^(i+1)/2^i = 2. -/
 private theorem divisorRatios_two_pow (k : ℕ) :
     divisorRatios (2 ^ k) = List.replicate k (2 : ℚ) := by
-  unfold divisorRatios
+  simp only [divisorRatios]
   rw [sortedDivisors_two_pow]
-  -- The do/pure monad elaboration creates nested flatMap/bind forms
-  -- that resist direct normalization. The mathematical content is trivial
-  -- (2^(i+1)/2^i = 2) but the Lean 4 elaboration barrier requires
-  -- specialized bind/flatMap lemmas not yet available.
-  sorry
+  set L := (List.range (k + 1)).map (HPow.hPow 2) with hL_def
+  have hL_len : L.length = k + 1 := by simp [hL_def]
+  have htail_len : L.tail.length = k := by rw [List.length_tail, hL_len]; omega
+  have hL_ne : L ≠ [] := by intro h; simp [h] at hL_len
+  -- Convert do notation to explicit map
+  rw [bind_pure_natCast L.tail, bind_pure_natCast L]
+  apply List.ext_getElem
+  · rw [List.length_zipWith, List.length_map, List.length_map, htail_len, hL_len,
+        List.length_replicate, Nat.min_eq_left (by omega : k ≤ k + 1)]
+  · intro i hi₁ hi₂
+    have hik : i < k := by rwa [List.length_replicate] at hi₂
+    simp only [List.getElem_zipWith, List.getElem_replicate, List.getElem_map]
+    -- tail[i] = L[i+1]
+    have htail_eq : L.tail[i]'(by omega) =
+        L[i + 1]'(by rw [hL_len]; omega) := by
+      obtain ⟨a, t, heq⟩ := List.exists_cons_of_ne_nil hL_ne
+      simp [heq]
+    rw [htail_eq]
+    simp only [hL_def, List.getElem_map, List.getElem_range]
+    rw [Nat.pow_succ, Nat.cast_mul]
+    field_simp; norm_cast
 
 private theorem flatMap_singleton_eq_map (f : ℚ → ℝ) (l : List ℚ) :
     l.flatMap (fun a => [f a]) = l.map f := by

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1099,
     "erdosUrl": "https://erdosproblems.com/1099",
     "erdosProblemStatus": "solved",
@@ -52,17 +52,17 @@
       "divisorRatios definition: consecutive divisor ratios",
       "h_alpha definition: the main function Σ((d_{i+1}/dᵢ) - 1)^α",
       "h_alpha_ge_one theorem: trivial lower bound of 1",
-      "vose_bounded_sequence axiom: existence of bounded subsequence",
-      "vose_liminf_bounded axiom: liminf boundedness (Vose 1984, axiomatized due to Mathlib breaks)",
+      "vose_bounded_sequence axiom: existence of bounded subsequence (Vose 1984)",
+      "vose_liminf_bounded theorem: liminf boundedness proved from vose_bounded_sequence",
       "erdos_1099 theorem: resolution of the problem",
       "sumDivisorRatios definition: related sum",
       "power_of_two_h_alpha theorem: h_α(2^k) growth for powers of 2",
       "Examples for primes, powers of 2, and highly composite numbers"
     ],
-    "axiomCount": 2,
-    "sorries": 1,
-    "lineCount": 627,
-    "assumptions": "2 axioms: vose_bounded_sequence (deep Vose 1984 construction of bounded subsequence) and vose_liminf_bounded (liminf boundedness — was previously proved from axiom but reverted to axiom due to Mathlib breaks during research PR #6843). 1 sorry in divisorRatios_two_pow (zipWith computation over sorted divisor lists). sortedDivisors_two_pow is proved. power_of_two_h_alpha is proved via helper lemmas."
+    "axiomCount": 1,
+    "sorries": 0,
+    "lineCount": 655,
+    "assumptions": "1 axiom: vose_bounded_sequence (deep Vose 1984 construction of bounded subsequence — requires formalizing Vose's probabilistic divisor spacing argument, estimated 500+ lines). vose_liminf_bounded proved from vose_bounded_sequence. All sorries eliminated: divisorRatios_two_pow proved via List.ext_getElem."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1099** was posed by Erdős in 1981 as part of his study of divisor structure. The problem asks about the regularity of divisor gaps: can we find integers whose consecutive divisor ratios are all close to 1?\n\n**Historical Development:**\n- **1981 (Erdős [Er81h]):** Posed the problem, noting that n! and lcm{1,...,n} seem like good candidates.\n- **1984 (Vose [Vo84]):** Resolved the problem affirmatively by constructing a specific sequence with bounded h_α.\n\n**Key Insight:** The question is about how \"smooth\" the divisor structure of integers can be. While primes have terrible divisor gaps (ratio = p), and even powers of 2 grow linearly in h_α, Vose showed there exist numbers with much smoother divisor distributions.",
@@ -290,9 +290,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos1099",
-    "lineCount": 627,
-    "axiomCount": 2,
-    "theoremCount": 32,
+    "lineCount": 655,
+    "axiomCount": 1,
+    "theoremCount": 34,
     "definitionCount": 7
   }
 }


### PR DESCRIPTION
## Summary
- Prove `divisorRatios_two_pow` sorry via `List.ext_getElem` + `bind_pure_natCast` do-notation normalization
- Prove `vose_liminf_bounded` from `vose_bounded_sequence` (trivial: pick `seq 0`)
- Add `bind_pure_natCast` helper to normalize monadic `do/pure` to `List.map` for `List ℕ → List ℚ`

**Result**: 0 sorries (was 1), 1 axiom (was 2), 34 theorems. Docker build verified.

Supersedes #6865 (same sorry fix, different approach to resolve merge conflicts).

## Test plan
- [x] Docker build succeeds: `./proofs/scripts/docker-build.sh Proofs.Erdos1099Problem`
- [x] 0 sorry, 1 axiom verified via grep
- [x] meta.json updated (axiomCount: 2→1, sorries: 1→0)

Labels: `research`