### PR TITLE
Research: erdos-698 — Prove sorry + eliminate sorries (0S, 8A)

### DIFF
--- a/proofs/Proofs/Erdos698Problem.lean
+++ b/proofs/Proofs/Erdos698Problem.lean
@@ -31,7 +31,6 @@ import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Real.Sqrt
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
-import Mathlib.Algebra.Order.Floor
 
 open Nat
 
@@ -178,8 +177,21 @@ The function h(n) = ⌊c · √n⌋ tends to infinity.
 -/
 theorem bergmanH_unbounded (c : ℝ) (hc : c > 0) : tendsToInfinity (bergmanH c) := by
   intro M
-  -- For large n, c · √n > M, so ⌊c · √n⌋ > M
-  sorry
+  -- Take N large enough that c · √N > M + 1
+  refine ⟨⌈((↑(M + 1) : ℝ) / c) ^ 2⌉₊, fun n hn => ?_⟩
+  show M < ⌊c * Real.sqrt ↑n⌋₊
+  -- It suffices to show ↑(M + 1) ≤ c * √n
+  suffices h : (↑(M + 1) : ℝ) ≤ c * Real.sqrt ↑n by
+    have := (Nat.le_floor_iff (by positivity : (0 : ℝ) ≤ c * Real.sqrt ↑n)).mpr h
+    omega
+  -- Show c * √n ≥ M + 1 via (M+1)/c ≤ √n
+  have hdc_nn : (0 : ℝ) ≤ (↑(M + 1) : ℝ) / c := by positivity
+  calc (↑(M + 1) : ℝ)
+      = c * ((↑(M + 1) : ℝ) / c) := by field_simp
+    _ ≤ c * Real.sqrt ↑n := by
+        apply mul_le_mul_of_nonneg_left _ hc.le
+        rw [← Real.sqrt_sq hdc_nn]
+        exact Real.sqrt_le_sqrt (le_trans (Nat.le_ceil _) (by exact_mod_cast hn))
 
 /--
 **Affirmative Answer:**
@@ -191,8 +203,15 @@ theorem erdos698_answer : erdos698Question := by
   constructor
   · exact bergmanH_unbounded c hc
   · intro n i j hvalid
-    -- By Bergman's bound, gcd ≥ c · √n ≥ ⌊c · √n⌋
-    sorry
+    -- From isValidPair: 2 ≤ i < j ≤ n/2, so n ≥ 6 ≥ 4
+    have hn4 : n ≥ 4 := by
+      have := hvalid.1; have := hvalid.2.1; have := hvalid.2.2; omega
+    -- Bergman gives (binomGcd n i j : ℝ) ≥ c * √n
+    have hreal := hbound n hn4 i j hvalid
+    -- ⌊c * √n⌋₊ ≤ c * √n ≤ binomGcd n i j
+    show bergmanH c n ≤ binomGcd n i j
+    show ⌊c * Real.sqrt ↑n⌋₊ ≤ binomGcd n i j
+    exact_mod_cast (Nat.floor_le (by positivity : (0 : ℝ) ≤ c * Real.sqrt ↑n)).trans hreal
 
 /-
 ## Part VII: Implications and Generalizations

--- a/src/data/proofs/erdos-698/meta.json
+++ b/src/data/proofs/erdos-698/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 698,
     "erdosUrl": "https://erdosproblems.com/698",
     "erdosProblemStatus": "solved",
@@ -75,7 +75,7 @@
       "Modular arithmetic (Lucas' theorem)"
     ],
     "lineCount": 283,
-    "assumptions": "8 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "assumptions": "8 axiom(s), 0 sorry(s). bergmanH_unbounded and erdos698_answer fully proved; axioms encode deep results (Erdős-Szekeres, Bergman, Kummer, Lucas)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #698**\n\nThis problem concerns GCDs of binomial coefficients in Pascal's triangle.\n\n**Key History:**\n- Erdős & Szekeres (1978): Posed the problem and observed gcd ≥ 2^i\n- They noted this bound is sharp for i=1, j=p, n=2p\n- Bergman (2011): Proved the minimum GCD grows like Ω(√n)\n\n**The Setting:**\nFor valid index pairs 2 ≤ i < j ≤ n/2, we study gcd(C(n,i), C(n,j)).\n\nThe study of divisibility properties of binomial coefficients has a long history, including Kummer's theorem (1852) which expresses the p-adic valuation of C(m+n, m) as the number of carries in base-p addition, and Lucas' theorem (1878) which gives C(n,k) mod p in terms of the base-p digits of n and k. These classical tools underpin Bergman's 2011 proof and reveal how the arithmetic structure of Pascal's triangle enforces non-trivial common factors.",
@@ -212,15 +212,15 @@
       "Mathlib.Data.Real.Basic",
       "Mathlib.Data.Real.Sqrt",
       "Mathlib.Analysis.SpecialFunctions.Pow.Real",
-      "Mathlib.Algebra.Order.Floor"
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real"
     ],
     "opens": [
       "Nat"
     ],
     "namespace": "Erdos698",
-    "lineCount": 283,
+    "lineCount": 302,
     "axiomCount": 8,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 6
   }
 }


### PR DESCRIPTION
## Summary
- Prove `bergmanH_unbounded`: the function h(n) = ⌊c·√n⌋ tends to infinity, using ceiling/sqrt monotonicity argument
- Prove `erdos698_answer`: the affirmative answer to Erdős #698, connecting Bergman's Ω(√n) bound to the floor function via `Nat.floor_le`
- Fix stale import (`Mathlib.Algebra.Order.Floor` → available transitively)
- **2 → 0 sorries**, 8 axioms remain (deep results: Erdős-Szekeres, Bergman, Kummer, Lucas)

## Proof Details

### `bergmanH_unbounded`
For any M, take N = ⌈((M+1)/c)²⌉₊. For n ≥ N: (M+1)/c ≤ √(⌈...⌉₊) ≤ √n, so c·√n ≥ M+1, hence ⌊c·√n⌋₊ > M.

### `erdos698_answer`  
From `isValidPair` derive n ≥ 4, apply `min_gcd_growth` to get (binomGcd : ℝ) ≥ c·√n, then `Nat.floor_le` + transitivity gives ⌊c·√n⌋₊ ≤ binomGcd.

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos698Problem`
- [x] Zero sorries: `grep sorry proofs/Proofs/Erdos698Problem.lean` returns empty
- [x] meta.json updated (sorries: 2→0, lineCount: 283→302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)