### PR TITLE
Enrich 5 entries: cross-refs, stale metadata, verified status updates

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02/meta.json
@@ -184,6 +184,31 @@
       "targetId": "arithmetic-series-oq-02",
       "relationship": "related",
       "description": "Both involve multi-index combinatorics: multinomial coefficients generalize binomial coefficients, while simplicial numbers generalize triangular numbers — both are diagonal entries of Pascal's simplex"
+    },
+    {
+      "targetId": "binomial-theorem-oq-01",
+      "relationship": "related",
+      "description": "Newton's generalized binomial theorem extends $(1+x)^\\alpha$ to non-integer $\\alpha$ via infinite series, while the multinomial theorem extends to multiple variables — orthogonal generalizations of the classical binomial theorem"
+    },
+    {
+      "targetId": "binomial-theorem-oq-04",
+      "relationship": "related",
+      "description": "Vandermonde's identity $\\binom{m+n}{r} = \\sum_k \\binom{m}{k}\\binom{n}{r-k}$ is a convolution of binomial coefficients that generalizes naturally to multinomial convolutions — the entry's open question explicitly asks about proving Vandermonde via multinomial identities"
+    },
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "related",
+      "description": "The binomial distribution $P(X=k) = \\binom{n}{k}p^k(1-p)^{n-k}$ generalizes to the multinomial distribution using the multinomial coefficients proved here — the entry's open question explicitly asks about formalizing this connection"
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "related",
+      "description": "Inclusion-exclusion provides an alternative derivation of multinomial coefficient identities: counting arrangements of a multiset by inclusion-exclusion over collision conditions yields the formula $n!/(k_1! \\cdots k_m!)$"
+    },
+    {
+      "targetId": "subset-count",
+      "relationship": "foundational",
+      "description": "The identity $\\sum_{k=0}^n \\binom{n}{k} = 2^n$ (the number of subsets of an $n$-set) generalizes to $\\sum_{\\sum k_i = n} \\text{multinomial}(k) = m^n$ for $m$ variables — both are special cases of the multinomial/binomial sum identity proved here"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment batch from enricher-3:

1. **abel-ruffini-oq-04-oq-01** (pass 1): Updated 13 stale axiom/sorry references to reflect fully verified status (0 axioms, 0 sorries).

2. **arithmetic-series-oq-02** (pass 1): Added 3 cross-references (derangements, ballot-problem, inclusion-exclusion). 6→9 cross-refs.

3. **ballot-problem-oq-01** (pass 1): Added 2 cross-references (arithmetic-series-oq-02, derangements). 8→10 cross-refs.

4. **binomial-theorem-oq-02** (pass 1): Added 6 cross-references connecting to sibling binomial entries and combinatorics network. 3→9 cross-refs.