### PR TITLE
Enrich abel-ruffini: fix stale annotation text and overlapping ranges

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -296,7 +296,7 @@
     },
     "type": "theorem",
     "title": "Existence of Degree-5 Polynomials",
-    "content": "`exists_quintic` provides a trivial witness that degree-5 polynomials exist over $\\mathbb{Q}$: the polynomial $X^5$ has `natDegree = 5`. The Lean proof uses `simp only` with `Polynomial.natDegree_pow` and `Polynomial.natDegree_X`, followed by `mul_one`.\n\nThis is mathematically trivial and is **not** used in the main Abel-Ruffini argument (`not_solvable_by_rad_of_not_solvable_gal`). The substantive statement the proof actually needs — but does not yet contain — is the existence of a specific polynomial with Galois group $S_5$, i.e., $\\exists q \\in \\mathbb{Q}[X],\\; \\text{Irreducible}\\,q \\land q.\\text{natDegree} = 5 \\land \\neg\\,\\text{IsSolvable}\\,q.\\text{Gal}$. The sub-entry `abel-ruffini-oq-04-oq-01` partially addresses this gap by exhibiting $x^5 - 4x + 2$ with $\\text{Gal} \\cong S_5$ (with one remaining axiom for $|\\text{Gal}| = 120$).",
+    "content": "`exists_quintic` provides a trivial witness that degree-5 polynomials exist over $\\mathbb{Q}$: the polynomial $X^5$ has `natDegree = 5`. The Lean proof uses `simp only` with `Polynomial.natDegree_pow` and `Polynomial.natDegree_X`, followed by `mul_one`.\n\nThis is mathematically trivial and is **not** used in the main Abel-Ruffini argument (`not_solvable_by_rad_of_not_solvable_gal`). The substantive statement the proof actually needs — but does not yet contain — is the existence of a specific polynomial with Galois group $S_5$, i.e., $\\exists q \\in \\mathbb{Q}[X],\\; \\text{Irreducible}\\,q \\land q.\\text{natDegree} = 5 \\land \\neg\\,\\text{IsSolvable}\\,q.\\text{Gal}$. The sub-entry `abel-ruffini-oq-04-oq-01` fully resolves this gap: it exhibits $x^5 - 4x + 2$ with $\\text{Gal} \\cong S_5$, now fully verified with 0 axioms and 0 sorries (the key result $|\\text{Gal}| = 120$ is a theorem).",
     "mathContext": "$\\exists p \\in \\mathbb{Q}[X],\\; \\deg(p) = 5$. Witness: $p = X^5$.\n\n$\\text{natDegree}(X^n) = n \\cdot \\text{natDegree}(X) = n \\cdot 1 = n$.\n\nThe statement the proof *actually needs* is: $\\exists q \\in \\mathbb{Q}[X],\\; \\text{Irreducible}\\,q \\land q.\\text{natDegree} = 5 \\land \\neg\\,\\text{IsSolvable}\\,q.\\text{Gal}$. Standard examples: $x^5 - x - 1$ (discriminant $2869 = 19 \\times 151$, not a perfect square, 3 real roots) or $x^5 - 4x + 2$ (Eisenstein at $p = 2$).",
     "significance": "context",
     "prerequisites": [
@@ -338,7 +338,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -365,8 +365,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "context",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
Enrichment pass for abel-ruffini (quality: 100, passes: 3).

## Changes
- **Fixed stale annotation**: `ann-exists-quintic` incorrectly stated that `abel-ruffini-oq-04-oq-01` "partially addresses this gap... with one remaining axiom for |Gal| = 120". The sub-entry is now fully verified with 0 axioms and 0 sorries — updated the annotation accordingly.
- **Fixed overlapping annotation ranges**: `ann-part-vi-threshold` and `ann-part-vii-historical` both had range 151-183, despite covering distinct Lean file sections (Part VI: lines 151-163, Part VII: lines 164-185). Corrected to non-overlapping ranges matching the actual section boundaries.

## Verification
- JSON validated
- Annotations build passes with no errors for abel-ruffini