### PR TITLE
Enrich angle-trisection-oq-02: fix annotation range and discriminant text

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02/annotations.json
@@ -81,7 +81,7 @@
     "proofId": "angle-trisection-oq-02",
     "range": {
       "startLine": 77,
-      "endLine": 89
+      "endLine": 93
     },
     "type": "technique",
     "title": "Wantzel-Galois Theorem: Constructibility ↔ 2-Group Galois",
@@ -117,7 +117,7 @@
     "type": "technique",
     "title": "Non-Constructibility: Coprimality Proves Order 6 Is Not a 2-Power",
     "content": "Two coprimality lemmas prove that certain group orders cannot be 2-powers. `not_pow_two_of_eq_six` proves `6 ≠ 2^n` by contradiction: if `6 = 2^n`, then `Coprime 3 (2^n)` (since gcd(3,2)=1 implies gcd(3,2^n)=1 via `Nat.Coprime.pow_right`), but `3 ∣ 2^n` (since 3 ∣ 6 = 2^n) — a number coprime to 3 cannot be divisible by 3. `not_pow_two_of_eq_three` proves `3 ≠ 2^n` by bounding: `n ≤ 1` since `2^n ≥ 4` for `n ≥ 2`, then `interval_cases` eliminates `n = 0` and `n = 1`.\n\nThese drive the two non-constructibility results: `x_cube_sub_2_gal_not_2group` uses `|Gal(x³-2)| = 6` (from InverseGalois.lean) with `not_pow_two_of_eq_six`; `cos20_gal_not_2group` uses `|Gal(8x³-6x-1)| = 3` (from AngleTrisectionCos20Gal.lean) with `not_pow_two_of_eq_three`. Both follow the same pattern: assume `IsPGroup 2`, extract `Nat.card = 2^n` via `IsPGroup.iff_card.mp`, rewrite with the known cardinality, and derive a contradiction.",
-    "mathContext": "Two distinct arguments:\n\n**Order 6** ($\\text{Gal}(x^3-2/\\mathbb{Q}) \\cong S_3$): Coprimality argument — $\\gcd(3, 2) = 1 \\Rightarrow \\gcd(3, 2^n) = 1$, but $3 \\mid 6$, so $6 \\neq 2^n$. In Lean 4: `Nat.Coprime.pow_right n (by norm_num : Nat.Coprime 3 2)` gives `Coprime 3 (2^n)`, then `Nat.dvd_gcd (dvd_refl 3) h3dvd` constructs the contradiction.\n\n**Order 3** ($\\text{Gal}(8x^3-6x-1/\\mathbb{Q}) \\cong \\mathbb{Z}/3\\mathbb{Z}$, the triple-angle formula polynomial for $\\cos(20°)$): Bounding argument — $2^n \\geq 4$ for $n \\geq 2$, so $3 = 2^n$ forces $n \\leq 1$; `interval_cases` eliminates both. The discriminant of $8x^3-6x-1$ is $(-6)^2 - 4(8)(-1) = 68$... actually $\\Delta = 81 = 9^2$, a perfect square, so $\\text{Gal} \\subseteq A_3 \\cong \\mathbb{Z}/3\\mathbb{Z}$ (order 3, not $S_3$).",
+    "mathContext": "Two distinct arguments:\n\n**Order 6** ($\\text{Gal}(x^3-2/\\mathbb{Q}) \\cong S_3$): Coprimality argument — $\\gcd(3, 2) = 1 \\Rightarrow \\gcd(3, 2^n) = 1$, but $3 \\mid 6$, so $6 \\neq 2^n$. In Lean 4: `Nat.Coprime.pow_right n (by norm_num : Nat.Coprime 3 2)` gives `Coprime 3 (2^n)`, then `Nat.dvd_gcd (dvd_refl 3) h3dvd` constructs the contradiction.\n\n**Order 3** ($\\text{Gal}(8x^3-6x-1/\\mathbb{Q}) \\cong \\mathbb{Z}/3\\mathbb{Z}$, the triple-angle formula polynomial for $\\cos(20°)$): Bounding argument — $2^n \\geq 4$ for $n \\geq 2$, so $3 = 2^n$ forces $n \\leq 1$; `interval_cases` eliminates both. The discriminant of $8x^3-6x-1$ is $\\Delta = 81 = 9^2$, a perfect square, so $\\text{Gal} \\subseteq A_3 \\cong \\mathbb{Z}/3\\mathbb{Z}$ (order 3, not $S_3$).",
     "significance": "key",
     "prerequisites": [
       "not_pow_two_of_eq_six",


### PR DESCRIPTION
Enrichment pass for angle-trisection-oq-02 (quality: 100, passes: 0).

## Changes
- **Fixed annotation range**: `ann-wantzel-galois` had range 77-89, missing the actual axiom declaration on lines 92-93. Extended to 77-93 to match the corresponding section boundary.
- **Fixed discriminant text**: `ann-non-constructible` mathContext contained an erroneous quadratic formula calculation applied to a cubic ("(-6)² - 4(8)(-1) = 68") that self-corrected mid-sentence. Replaced with the correct discriminant Δ = 81 = 9².

## Verification
- JSON validated
- Annotations build passes with no errors for angle-trisection-oq-02