### PR TITLE
Enrich 73 entries: cross-references and section mathContext

### DIFF
--- a/src/data/proofs/divisibility-by-3/meta.json
+++ b/src/data/proofs/divisibility-by-3/meta.json
@@ -79,49 +79,56 @@
       "title": "Introduction",
       "startLine": 1,
       "endLine": 41,
-      "summary": "Overview of the divisibility by 3 rule and its significance as Wiedijk #85."
+      "summary": "Overview of the divisibility by 3 rule and its significance as Wiedijk #85.",
+      "mathContext": "The digit sum divisibility rule (Wiedijk #85): $3 \\mid n \\iff 3 \\mid \\text{digitSum}(n)$. Based on the key congruence $10 \\equiv 1 \\pmod{3}$."
     },
     {
       "id": "key-insight",
       "title": "The Key Insight",
       "startLine": 42,
       "endLine": 63,
-      "summary": "Explanation of why the rule works: 10 ≡ 1 (mod 3)."
+      "summary": "Explanation of why the rule works: 10 ≡ 1 (mod 3).",
+      "mathContext": "The fundamental observation: since $10 \\equiv 1 \\pmod{3}$, we have $10^k \\equiv 1 \\pmod{3}$ for all $k$, so $n = \\sum d_i \\cdot 10^i \\equiv \\sum d_i \\pmod{3}$."
     },
     {
       "id": "main-theorems",
       "title": "Main Theorems",
       "startLine": 64,
       "endLine": 98,
-      "summary": "The divisibility by 3 and 9 rules with both divisibility and congruence forms."
+      "summary": "The divisibility by 3 and 9 rules with both divisibility and congruence forms.",
+      "mathContext": "The divisibility rules: $3 \\mid n \\iff 3 \\mid \\text{digitSum}(n)$ and $9 \\mid n \\iff 9 \\mid \\text{digitSum}(n)$. Both follow from $10 \\equiv 1 \\pmod{3}$ (and $\\pmod{9}$)."
     },
     {
       "id": "general-principle",
       "title": "General Principle",
       "startLine": 99,
       "endLine": 118,
-      "summary": "Generalization to arbitrary bases and divisors."
+      "summary": "Generalization to arbitrary bases and divisors.",
+      "mathContext": "Generalization: in base $b$, $d \\mid (b-1) \\Rightarrow d \\mid n \\iff d \\mid \\text{digitSum}_b(n)$. The classical rules for 3 and 9 are the base-10 cases since $3 \\mid 9 = 10 - 1$."
     },
     {
       "id": "examples",
       "title": "Examples",
       "startLine": 119,
       "endLine": 178,
-      "summary": "Concrete examples verifying the divisibility rules."
+      "summary": "Concrete examples verifying the divisibility rules.",
+      "mathContext": "Concrete examples verifying the rule at specific numbers."
     },
     {
       "id": "proof-explanation",
       "title": "Why It Works",
       "startLine": 179,
       "endLine": 206,
-      "summary": "Detailed explanation of the proof idea with modular arithmetic examples."
+      "summary": "Detailed explanation of the proof idea with modular arithmetic examples.",
+      "mathContext": "The modular arithmetic proof: $n = d_k \\cdot 10^k + \\cdots + d_1 \\cdot 10 + d_0 \\equiv d_k + \\cdots + d_1 + d_0 \\pmod{3}$, since each $10^i \\equiv 1^i = 1$."
     },
     {
       "id": "applications",
       "title": "Applications",
       "startLine": 207,
       "endLine": 235,
-      "summary": "Theorems for iterative digit sums and transitivity properties."
+      "summary": "Theorems for iterative digit sums and transitivity properties.",
+      "mathContext": "Applications: iterative digit sums (applying the rule repeatedly until reaching a single digit), transitivity ($3 \\mid \\text{digitSum}(n)$ and the rule give $3 \\mid n$), and the 'casting out nines' technique."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -83,49 +83,56 @@
       "title": "Imports and Documentation",
       "summary": "Imports `ZMod.Basic`, `Nat.Totient`, `RingTheory.Int.Basic`, and `Tactic`. Docstring with $a^{\\varphi(n)} \\equiv 1$, approach via Lagrange's theorem, and historical note (Euler 1763, Wiedijk #10).",
       "startLine": 1,
-      "endLine": 43
+      "endLine": 43,
+      "mathContext": "Imports `ZMod.Basic`, `Nat.Totient`, and `Tactic`. Euler's totient $\\varphi(n) = |\\{k : 1 \\leq k \\leq n,\\, \\gcd(k,n) = 1\\}|$ counts units in $\\mathbb{Z}/n\\mathbb{Z}$."
     },
     {
       "id": "main-theorem",
       "title": "Euler's Theorem",
       "summary": "Proves $a^{\\varphi(n)} = 1$ for $a \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times$ via `ZMod.pow_totient`. One-line proof from Lagrange's theorem.",
       "startLine": 44,
-      "endLine": 59
+      "endLine": 59,
+      "mathContext": "Euler's theorem: $a^{\\varphi(n)} \\equiv 1 \\pmod{n}$ for $\\gcd(a,n) = 1$. In Lean: `ZMod.unitOfCoprime` and `ZMod.IsUnit.pow_totient`. This generalizes Fermat's little theorem from primes to arbitrary moduli."
     },
     {
       "id": "fermat-corollary",
       "title": "Fermat's Little Theorem",
       "summary": "Derives $a^{p-1} = 1$ for prime $p$ by substituting $\\varphi(p) = p-1$ (`Nat.totient_prime`) into Euler's theorem. Also proves full form $a^p = a$ via `ZMod.pow_card`.",
       "startLine": 60,
-      "endLine": 83
+      "endLine": 83,
+      "mathContext": "Fermat's little theorem as a corollary: $a^{p-1} \\equiv 1 \\pmod{p}$ for prime $p$ and $p \\nmid a$. Obtained by substituting $\\varphi(p) = p - 1$ (`Nat.totient_prime`)."
     },
     {
       "id": "totient-values",
       "title": "Totient Function Examples",
       "summary": "Computes $\\varphi(n)$ for $n = 1, \\ldots, 6$ by `rfl`. Verifies $2^{\\varphi(5)} \\equiv 1 \\pmod{5}$ and $3^{\\varphi(7)} \\equiv 1 \\pmod{7}$ by `native_decide`.",
       "startLine": 84,
-      "endLine": 114
+      "endLine": 114,
+      "mathContext": "Computed values: $\\varphi(1) = 1$, $\\varphi(2) = 1$, $\\varphi(3) = 2$, $\\varphi(4) = 2$, $\\varphi(5) = 4$, $\\varphi(6) = 2$. Verified computationally by `rfl` in Lean."
     },
     {
       "id": "counterexample",
       "title": "Non-Coprime Counterexample",
       "summary": "Shows $2^{\\varphi(4)} \\not\\equiv 1 \\pmod{4}$ when $\\gcd(2,4) = 2 \\neq 1$, demonstrating the coprimality hypothesis is necessary.",
       "startLine": 115,
-      "endLine": 118
+      "endLine": 118,
+      "mathContext": "Demonstrates the coprimality hypothesis is necessary: $2^{\\varphi(4)} = 2^2 = 4 \\not\\equiv 1 \\pmod{4}$ because $\\gcd(2,4) = 2 \\neq 1$. Without coprimality, Euler's theorem fails."
     },
     {
       "id": "totient-properties",
       "title": "Totient Function Properties",
       "summary": "Proves $\\varphi(p) = p-1$ via `Nat.totient_prime` and $\\varphi(p^k) = p^{k-1}(p-1)$ via `Nat.totient_prime_pow`.",
       "startLine": 119,
-      "endLine": 131
+      "endLine": 131,
+      "mathContext": "Key properties: $\\varphi(p) = p - 1$ for primes, $\\varphi(p^k) = p^{k-1}(p-1)$ for prime powers, and the product formula $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$."
     },
     {
       "id": "verification",
       "title": "Verification Checks",
       "summary": "Uses `#check` to confirm the API surface: `euler_totient`, `fermat_little_theorem`, `fermat_little_theorem_full`.",
       "startLine": 132,
-      "endLine": 136
+      "endLine": 136,
+      "mathContext": "Type-checking the main results via `#check` to confirm the API surface."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/intermediate-value-theorem/meta.json
+++ b/src/data/proofs/intermediate-value-theorem/meta.json
@@ -71,49 +71,56 @@
       "title": "Setup and Imports",
       "startLine": 1,
       "endLine": 43,
-      "summary": "Introduces the historical context, imports Mathlib's topology and intermediate value libraries, and opens the namespace."
+      "summary": "Introduces the historical context, imports Mathlib's topology and intermediate value libraries, and opens the namespace.",
+      "mathContext": "Imports `Mathlib.Topology.Order.IntermediateValue` and `Mathlib.Analysis.SpecificLimits.Basic`. The IVT states: if $f: [a,b] \\to \\mathbb{R}$ is continuous and $c$ lies between $f(a)$ and $f(b)$, then $\\exists x \\in [a,b],\\, f(x) = c$. Wiedijk #60."
     },
     {
       "id": "classical-statement",
       "title": "The Classical Statement",
       "startLine": 45,
       "endLine": 72,
-      "summary": "Presents the main IVT theorem: continuous functions on closed intervals hit all intermediate values."
+      "summary": "Presents the main IVT theorem: continuous functions on closed intervals hit all intermediate values.",
+      "mathContext": "The classical IVT: for $f : \\mathbb{R} \\to \\mathbb{R}$ continuous on $[a,b]$ with $f(a) \\leq c \\leq f(b)$ (or $f(b) \\leq c \\leq f(a)$), there exists $x \\in [a,b]$ with $f(x) = c$. In Lean: `IsPreconnected.intermediate_value` from Mathlib's topological formulation."
     },
     {
       "id": "existence-form",
       "title": "Explicit Existence Form",
       "startLine": 74,
       "endLine": 107,
-      "summary": "Reformulates IVT as an explicit existence statement: given c between f(a) and f(b), there exists x with f(x) = c."
+      "summary": "Reformulates IVT as an explicit existence statement: given c between f(a) and f(b), there exists x with f(x) = c.",
+      "mathContext": "The explicit existence formulation: given $a \\leq b$ and $c$ between $f(a)$ and $f(b)$, construct a witness $x \\in [a,b]$ satisfying $f(x) = c$. This is computationally richer than the classical statement, as it provides the intermediate point rather than just asserting its existence."
     },
     {
       "id": "bolzano",
       "title": "Root-Finding Corollary (Bolzano's Theorem)",
       "startLine": 109,
       "endLine": 167,
-      "summary": "Proves that if f(a) and f(b) have opposite signs, f has a root in (a, b). Also proves the general sign-change criterion."
+      "summary": "Proves that if f(a) and f(b) have opposite signs, f has a root in (a, b). Also proves the general sign-change criterion.",
+      "mathContext": "Bolzano's theorem (1817): if $f$ is continuous on $[a,b]$ with $f(a) < 0 < f(b)$ (or vice versa), then $\\exists x \\in (a,b),\\, f(x) = 0$. This is the special case $c = 0$ of IVT and historically preceded the general statement. The proof uses the completeness of $\\mathbb{R}$ via the least upper bound property: $x = \\sup\\{t \\in [a,b] : f(t) < 0\\}$."
     },
     {
       "id": "connected-sets",
       "title": "Continuous Functions on Connected Sets",
       "startLine": 169,
       "endLine": 183,
-      "summary": "Shows IVT as a consequence of the general principle that continuous images of connected sets are connected."
+      "summary": "Shows IVT as a consequence of the general principle that continuous images of connected sets are connected.",
+      "mathContext": "The topological generalization: if $S$ is connected and $f: S \\to \\mathbb{R}$ is continuous, then $f(S)$ is connected (hence an interval). IVT follows because $[a,b]$ is connected in $\\mathbb{R}$ and continuous images of connected sets are connected. This is Mathlib's primary formulation via `IsPreconnected.intermediate_value`."
     },
     {
       "id": "applications",
       "title": "Applications and Corollaries",
       "startLine": 185,
       "endLine": 213,
-      "summary": "Proves that odd-degree polynomials have roots and the fixed point theorem for continuous self-maps on intervals."
+      "summary": "Proves that odd-degree polynomials have roots and the fixed point theorem for continuous self-maps on intervals.",
+      "mathContext": "Two classical applications: (1) every odd-degree real polynomial has a real root (since $\\lim_{x \\to \\pm\\infty} p(x) = \\pm\\infty$, IVT gives a zero); (2) the fixed-point theorem for $f: [a,b] \\to [a,b]$ continuous ($g(x) = f(x) - x$ satisfies $g(a) \\geq 0$ and $g(b) \\leq 0$, so Bolzano gives a fixed point)."
     },
     {
       "id": "checks",
       "title": "Type Checking",
       "startLine": 215,
       "endLine": 221,
-      "summary": "Verifies the types of the main theorems using #check commands."
+      "summary": "Verifies the types of the main theorems using #check commands.",
+      "mathContext": "Type-checking the main theorems with `#check` to verify their signatures match the expected statements."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/isosceles-triangle/meta.json
+++ b/src/data/proofs/isosceles-triangle/meta.json
@@ -71,49 +71,56 @@
       "title": "Module Documentation and Historical Context",
       "startLine": 1,
       "endLine": 49,
-      "summary": "Docstring covering the isosceles triangle theorem (Pons Asinorum, Euclid I.5, Wiedijk #65). States forward ($AB = AC \\Rightarrow \\angle ABC = \\angle ACB$) and converse directions. Documents Mathlib dependencies: `angle_eq_angle_of_dist_eq`, `dist_eq_of_angle_eq_angle_of_angle_ne_pi`, `angle_sub_eq_angle_sub_rev_of_norm_eq`. Historical note on medieval naming and Pappus's simplified proof."
+      "summary": "Docstring covering the isosceles triangle theorem (Pons Asinorum, Euclid I.5, Wiedijk #65). States forward ($AB = AC \\Rightarrow \\angle ABC = \\angle ACB$) and converse directions. Documents Mathlib dependencies: `angle_eq_angle_of_dist_eq`, `dist_eq_of_angle_eq_angle_of_angle_ne_pi`, `angle_sub_eq_angle_sub_rev_of_norm_eq`. Historical note on medieval naming and Pappus's simplified proof.",
+      "mathContext": "The isosceles triangle theorem (Pons Asinorum, Euclid I.5, Wiedijk #1): if $|AB| = |AC|$ in triangle $ABC$, then $\\angle ABC = \\angle ACB$. One of the oldest theorems in mathematics, first proved rigorously by Euclid circa 300 BCE."
     },
     {
       "id": "setup",
       "title": "Imports and Type Variables",
       "startLine": 1,
       "endLine": 57,
-      "summary": "Imports `Mathlib.Geometry.Euclidean.Triangle` and `Mathlib.Tactic`. Opens `EuclideanGeometry` namespace. Declares type variables $V$ (normed inner product space over $\\mathbb{R}$) and $P$ (metric space with $V$-torsor structure), enabling the theorem in arbitrary-dimensional Euclidean spaces."
+      "summary": "Imports `Mathlib.Geometry.Euclidean.Triangle` and `Mathlib.Tactic`. Opens `EuclideanGeometry` namespace. Declares type variables $V$ (normed inner product space over $\\mathbb{R}$) and $P$ (metric space with $V$-torsor structure), enabling the theorem in arbitrary-dimensional Euclidean spaces.",
+      "mathContext": "Imports for Euclidean geometry: inner product spaces, metric spaces, and norm definitions. Sets up the framework for proving that equal sides imply equal base angles in a triangle."
     },
     {
       "id": "forward",
       "title": "Forward Direction: Equal Sides Imply Equal Angles",
       "startLine": 58,
       "endLine": 74,
-      "summary": "Proves `base_angles_equal_of_sides_equal`: $d(A,B) = d(A,C) \\Rightarrow \\angle ABC = \\angle ACB$. Direct application of `EuclideanGeometry.angle_eq_angle_of_dist_eq`. This is Euclid's Proposition I.5."
+      "summary": "Proves `base_angles_equal_of_sides_equal`: $d(A,B) = d(A,C) \\Rightarrow \\angle ABC = \\angle ACB$. Direct application of `EuclideanGeometry.angle_eq_angle_of_dist_eq`. This is Euclid's Proposition I.5.",
+      "mathContext": "The forward direction: $d(A,B) = d(A,C) \\Rightarrow \\angle ABC = \\angle ACB$. In the inner product space formulation, equal norms of the displacement vectors $\\overrightarrow{BA}$ and $\\overrightarrow{CA}$ imply equal angles."
     },
     {
       "id": "converse",
       "title": "Converse: Equal Angles Imply Equal Sides",
       "startLine": 75,
       "endLine": 92,
-      "summary": "Proves `sides_equal_of_base_angles_equal`: $\\angle ABC = \\angle ACB \\land \\angle BAC \\neq \\pi \\Rightarrow d(A,B) = d(A,C)$. The non-degeneracy hypothesis $\\angle BAC \\neq \\pi$ excludes collinear configurations. Uses `dist_eq_of_angle_eq_angle_of_angle_ne_pi`. This is Euclid's Proposition I.6."
+      "summary": "Proves `sides_equal_of_base_angles_equal`: $\\angle ABC = \\angle ACB \\land \\angle BAC \\neq \\pi \\Rightarrow d(A,B) = d(A,C)$. The non-degeneracy hypothesis $\\angle BAC \\neq \\pi$ excludes collinear configurations. Uses `dist_eq_of_angle_eq_angle_of_angle_ne_pi`. This is Euclid's Proposition I.6.",
+      "mathContext": "The converse: if $\\angle ABC = \\angle ACB$ then $|AB| = |AC|$. Together with the forward direction, this gives: a triangle has two equal sides if and only if it has two equal base angles."
     },
     {
       "id": "biconditional",
       "title": "Biconditional Characterization",
       "startLine": 93,
       "endLine": 107,
-      "summary": "Proves `isosceles_triangle_iff`: for non-degenerate triangles, $d(A,B) = d(A,C) \\iff \\angle ABC = \\angle ACB$. Combines forward and converse via $\\langle$`base_angles_equal_of_sides_equal`, $\\lambda h \\Rightarrow$ `sides_equal_of_base_angles_equal h hnd`$\\rangle$."
+      "summary": "Proves `isosceles_triangle_iff`: for non-degenerate triangles, $d(A,B) = d(A,C) \\iff \\angle ABC = \\angle ACB$. Combines forward and converse via $\\langle$`base_angles_equal_of_sides_equal`, $\\lambda h \\Rightarrow$ `sides_equal_of_base_angles_equal h hnd`$\\rangle$.",
+      "mathContext": "The full characterization: for non-degenerate triangles, $d(A,B) = d(A,C) \\iff \\angle ABC = \\angle ACB$. This combines the forward direction (Euclid I.5) with the converse (Euclid I.6)."
     },
     {
       "id": "vector-form",
       "title": "Vector Formulation",
       "startLine": 108,
       "endLine": 121,
-      "summary": "Proves `angle_eq_of_norm_eq`: for vectors $x, y \\in V$ with $\\|x\\| = \\|y\\|$, the angles $\\angle(x, x-y) = \\angle(y, y-x)$. Uses `InnerProductGeometry.angle_sub_eq_angle_sub_rev_of_norm_eq`. Interprets the theorem using position vectors from the apex."
+      "summary": "Proves `angle_eq_of_norm_eq`: for vectors $x, y \\in V$ with $\\|x\\| = \\|y\\|$, the angles $\\angle(x, x-y) = \\angle(y, y-x)$. Uses `InnerProductGeometry.angle_sub_eq_angle_sub_rev_of_norm_eq`. Interprets the theorem using position vectors from the apex.",
+      "mathContext": "The inner product space formulation: for vectors $x, y \\in V$ with $\\|x\\| = \\|y\\|$, the angle between $x$ and any reference direction equals the angle between $y$ and the same reference. This abstracts the isosceles theorem to arbitrary inner product spaces."
     },
     {
       "id": "verification",
       "title": "Verification and Exports",
       "startLine": 122,
       "endLine": 129,
-      "summary": "Exports all four main results via `#check`: `base_angles_equal_of_sides_equal`, `sides_equal_of_base_angles_equal`, `isosceles_triangle_iff`, `angle_eq_of_norm_eq`. Closes `IsoscelesTriangle` namespace."
+      "summary": "Exports all four main results via `#check`: `base_angles_equal_of_sides_equal`, `sides_equal_of_base_angles_equal`, `isosceles_triangle_iff`, `angle_eq_of_norm_eq`. Closes `IsoscelesTriangle` namespace.",
+      "mathContext": "Type-checking the four main results to verify their Lean signatures."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/mathematical-induction/meta.json
+++ b/src/data/proofs/mathematical-induction/meta.json
@@ -78,49 +78,56 @@
       "title": "Introduction",
       "startLine": 1,
       "endLine": 45,
-      "summary": "Overview of mathematical induction, its historical significance, and role in Lean's foundations."
+      "summary": "Overview of mathematical induction, its historical significance, and role in Lean's foundations.",
+      "mathContext": "Mathematical induction is the foundational proof technique for $\\mathbb{N}$: $P(0) \\land (\\forall n,\\, P(n) \\to P(n+1)) \\Rightarrow \\forall n,\\, P(n)$. In Lean 4, induction is built into the type theory via the `Nat` recursor."
     },
     {
       "id": "weak-induction",
       "title": "Weak Induction",
       "startLine": 49,
       "endLine": 77,
-      "summary": "The standard form of induction: prove P(0), prove P(n) -> P(n+1), conclude forall n. P(n)."
+      "summary": "The standard form of induction: prove P(0), prove P(n) -> P(n+1), conclude forall n. P(n).",
+      "mathContext": "Weak (ordinary) induction: to prove $\\forall n \\in \\mathbb{N},\\, P(n)$, it suffices to prove $P(0)$ (base case) and $\\forall n,\\, P(n) \\to P(n+1)$ (inductive step). In Lean, this is `Nat.rec` or the `induction` tactic."
     },
     {
       "id": "strong-induction",
       "title": "Strong Induction",
       "startLine": 78,
       "endLine": 105,
-      "summary": "Complete induction where the hypothesis is P(k) for all k < n."
+      "summary": "Complete induction where the hypothesis is P(k) for all k < n.",
+      "mathContext": "Strong (complete) induction: to prove $\\forall n,\\, P(n)$, assume $P(k)$ holds for ALL $k < n$ and prove $P(n)$. Equivalent to weak induction over well-founded relations. In Lean: `Nat.strongRecOn` or `WellFoundedRelation`."
     },
     {
       "id": "equivalence",
       "title": "Equivalence of Weak and Strong Induction",
       "startLine": 106,
       "endLine": 148,
-      "summary": "Proof that weak and strong induction can derive each other."
+      "summary": "Proof that weak and strong induction can derive each other.",
+      "mathContext": "Proof that weak and strong induction are equivalent: strong induction implies weak (take $k = n$ in the hypothesis), and weak implies strong (by inducting on the proposition $Q(n) := \\forall k < n,\\, P(k)$)."
     },
     {
       "id": "examples",
       "title": "Example Applications",
       "startLine": 149,
       "endLine": 174,
-      "summary": "Classic examples: sum of first n naturals and existence of prime divisors."
+      "summary": "Classic examples: sum of first n naturals and existence of prime divisors.",
+      "mathContext": "Concrete examples proving sum formulas, divisibility properties, and other standard induction exercises."
     },
     {
       "id": "well-ordering",
       "title": "Well-Ordering Principle",
       "startLine": 175,
       "endLine": 203,
-      "summary": "The well-ordering principle and its connection to strong induction."
+      "summary": "The well-ordering principle and its connection to strong induction.",
+      "mathContext": "The well-ordering principle: every non-empty subset of $\\mathbb{N}$ has a least element. This is equivalent to induction and provides an alternative proof technique (assume $\\neg P(n)$ for some $n$, take the minimal counterexample)."
     },
     {
       "id": "peano-axioms",
       "title": "Connection to Peano Axioms",
       "startLine": 204,
       "endLine": 249,
-      "summary": "How induction relates to Lean's type theory and the Nat recursor."
+      "summary": "How induction relates to Lean's type theory and the Nat recursor.",
+      "mathContext": "Connection to Lean 4's type theory: `Nat` is defined as an inductive type with constructors `zero` and `succ`, and the recursor `Nat.rec` IS mathematical induction at the type level. Peano's axioms are encoded in the type definition."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/nth-root-irrational/meta.json
+++ b/src/data/proofs/nth-root-irrational/meta.json
@@ -72,49 +72,56 @@
       "title": "Setup and Definitions",
       "startLine": 1,
       "endLine": 52,
-      "summary": "Module documentation, imports, and the nthRoot definition."
+      "summary": "Module documentation, imports, and the nthRoot definition.",
+      "mathContext": "Imports for number theory and irrationality from Mathlib. The $n$th root of a non-perfect-$n$th-power integer is irrational: $\\sqrt[n]{k} \\notin \\mathbb{Q}$ unless $k = m^n$ for some $m \\in \\mathbb{Z}$."
     },
     {
       "id": "power-identity",
       "title": "Power Identity",
       "startLine": 53,
       "endLine": 64,
-      "summary": "Proof that (m^(1/n))^n = m using rpow properties."
+      "summary": "Proof that (m^(1/n))^n = m using rpow properties.",
+      "mathContext": "The identity $(m^{1/n})^n = m$ for $m \\geq 0$ and $n \\geq 1$, proved via `rpow` (real-valued power) properties. This connects the $n$th root definition $\\sqrt[n]{m} := m^{1/n}$ to the characterizing equation $x^n = m$."
     },
     {
       "id": "not-integer",
       "title": "Not-an-Integer Lemma",
       "startLine": 65,
       "endLine": 79,
-      "summary": "Contrapositive: if m^(1/n) were integer k, then k^n = m."
+      "summary": "Contrapositive: if m^(1/n) were integer k, then k^n = m.",
+      "mathContext": "Contrapositive argument: if $\\sqrt[n]{m} = k \\in \\mathbb{Z}$, then $k^n = m$, so $m$ is a perfect $n$th power. Therefore, if $m$ is NOT a perfect $n$th power, $\\sqrt[n]{m} \\notin \\mathbb{Z}$."
     },
     {
       "id": "general-theorem",
       "title": "The General Theorem",
       "startLine": 80,
       "endLine": 99,
-      "summary": "Main result combining power identity and not-an-integer via irrational_nrt_of_notint_nrt."
+      "summary": "Main result combining power identity and not-an-integer via irrational_nrt_of_notint_nrt.",
+      "mathContext": "Main irrationality result using `irrational_nrt_of_notint_nrt`: $\\sqrt[n]{m} \\notin \\mathbb{Q}$ when $m$ is not a perfect $n$th power. The proof combines the power identity with the not-integer argument and the fact that $\\sqrt[n]{m}$ being rational but not integer contradicts unique factorization."
     },
     {
       "id": "not-perfect-power",
       "title": "Not-a-Perfect-Power Lemmas",
       "startLine": 100,
       "endLine": 231,
-      "summary": "Concrete proofs that specific small numbers are not perfect squares, cubes, 4th or 5th powers."
+      "summary": "Concrete proofs that specific small numbers are not perfect squares, cubes, 4th or 5th powers.",
+      "mathContext": "Concrete verifications that specific small integers are not perfect powers: $2, 3, 5$ are not perfect squares; $2, 3, 5$ are not perfect cubes; etc. Each proved by exhaustive case analysis or `omega`/`norm_num`."
     },
     {
       "id": "corollaries",
       "title": "Concrete Corollaries",
       "startLine": 232,
       "endLine": 276,
-      "summary": "Specific irrationality results: sqrt(2,3,5), cbrt(2,3,5), 4thrt(2,3), 5thrt(2)."
+      "summary": "Specific irrationality results: sqrt(2,3,5), cbrt(2,3,5), 4thrt(2,3), 5thrt(2).",
+      "mathContext": "Specific irrationality results: $\\sqrt{2}, \\sqrt{3}, \\sqrt{5} \\notin \\mathbb{Q}$; $\\sqrt[3]{2}, \\sqrt[3]{3}, \\sqrt[3]{5} \\notin \\mathbb{Q}$; $\\sqrt[4]{2}, \\sqrt[4]{3} \\notin \\mathbb{Q}$; $\\sqrt[5]{2} \\notin \\mathbb{Q}$. Each instantiates the general theorem."
     },
     {
       "id": "converse",
       "title": "The Converse: Perfect Powers",
       "startLine": 277,
       "endLine": 312,
-      "summary": "Shows the characterization is tight: perfect nth powers give integer nth roots."
+      "summary": "Shows the characterization is tight: perfect nth powers give integer nth roots.",
+      "mathContext": "The characterization is tight: $\\sqrt[n]{m^n} = m \\in \\mathbb{Z}$ for any positive integer $m$. Thus $\\sqrt[n]{k} \\in \\mathbb{Q} \\iff k$ is a perfect $n$th power."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/quadratic-reciprocity/meta.json
+++ b/src/data/proofs/quadratic-reciprocity/meta.json
@@ -76,49 +76,56 @@
       "title": "Introduction",
       "startLine": 1,
       "endLine": 62,
-      "summary": "Overview of quadratic reciprocity, historical context, and significance."
+      "summary": "Overview of quadratic reciprocity, historical context, and significance.",
+      "mathContext": "Imports `Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity` which provides `legendreSym.quadratic_reciprocity` and the supplementary laws. The Legendre symbol $\\left(\\frac{a}{p}\\right) \\in \\{-1, 0, 1\\}$ measures whether $a$ is a quadratic residue mod $p$: it equals $1$ if $\\exists x,\\, x^2 \\equiv a \\pmod{p}$, and $-1$ otherwise. Wiedijk #7."
     },
     {
       "id": "main-law",
       "title": "The Main Law",
       "startLine": 63,
       "endLine": 115,
-      "summary": "Product form, quotient form, and special cases for 1 mod 4 and 3 mod 4."
+      "summary": "Product form, quotient form, and special cases for 1 mod 4 and 3 mod 4.",
+      "mathContext": "The main law in product form: $\\left(\\frac{q}{p}\\right)\\left(\\frac{p}{q}\\right) = (-1)^{\\frac{p-1}{2} \\cdot \\frac{q-1}{2}}$ for distinct odd primes $p, q$. Equivalently: the symbols agree unless both $p \\equiv q \\equiv 3 \\pmod{4}$, in which case they differ by a sign. Four formulations: product form (`quadratic_reciprocity_product`), quotient form (`quadratic_reciprocity_quotient`), and the two case splits for $p \\equiv 1 \\pmod{4}$ and $p \\equiv q \\equiv 3 \\pmod{4}$."
     },
     {
       "id": "first-supplementary",
       "title": "First Supplementary Law",
       "startLine": 116,
       "endLine": 128,
-      "summary": "When -1 is a quadratic residue modulo a prime."
+      "summary": "When -1 is a quadratic residue modulo a prime.",
+      "mathContext": "First supplementary law: $\\left(\\frac{-1}{p}\\right) = (-1)^{(p-1)/2}$, i.e., $-1$ is a quadratic residue mod $p$ iff $p \\equiv 1 \\pmod{4}$. Lean statement: `IsSquare (-1 : ZMod p) \\leftrightarrow p \\% 4 \\neq 3`. This determines when $x^2 \\equiv -1 \\pmod{p}$ has solutions — equivalently, when the Gaussian integers $\\mathbb{Z}[i]$ split the prime $p$."
     },
     {
       "id": "second-supplementary",
       "title": "Second Supplementary Law",
       "startLine": 129,
       "endLine": 147,
-      "summary": "When 2 is a quadratic residue modulo a prime, and the combined -2 law."
+      "summary": "When 2 is a quadratic residue modulo a prime, and the combined -2 law.",
+      "mathContext": "Second supplementary law: $\\left(\\frac{2}{p}\\right) = (-1)^{(p^2-1)/8}$, i.e., $2$ is a QR mod $p$ iff $p \\equiv \\pm 1 \\pmod{8}$. The combined $-2$ law (`neg_two_is_square_iff`): $-2$ is a QR mod $p$ iff $p \\equiv 1$ or $3 \\pmod{8}$. These determine when $\\mathbb{Z}[\\sqrt{2}]$ and $\\mathbb{Z}[\\sqrt{-2}]$ split the prime $p$."
     },
     {
       "id": "square-roots-between-primes",
       "title": "Square Roots Between Primes",
       "startLine": 149,
       "endLine": 161,
-      "summary": "IsSquare equivalences between two primes: p ≡ 1 (mod 4) case and p ≡ q ≡ 3 (mod 4) case."
+      "summary": "IsSquare equivalences between two primes: p ≡ 1 (mod 4) case and p ≡ q ≡ 3 (mod 4) case.",
+      "mathContext": "Reformulations as `IsSquare` equivalences between two primes. For $p \\equiv 1 \\pmod{4}$: $q$ is a square mod $p$ $\\iff$ $p$ is a square mod $q$ (perfect symmetry). For $p \\equiv q \\equiv 3 \\pmod{4}$: $q$ is a square mod $p$ $\\iff$ $p$ is NOT a square mod $q$ (anti-symmetry). These are the `IsSquare` translations of the Legendre symbol formulations."
     },
     {
       "id": "examples",
       "title": "Examples",
       "startLine": 163,
       "endLine": 199,
-      "summary": "Concrete calculations for primes 3, 5, and 7."
+      "summary": "Concrete calculations for primes 3, 5, and 7.",
+      "mathContext": "Concrete computations verifying the theorems at small primes. Reciprocity: $(3/5) = (5/3) = -1$ (since $5 \\equiv 1 \\pmod{4}$), and $(3/7) = -(7/3) = -1$ (since $3 \\equiv 7 \\equiv 3 \\pmod{4}$). First supplementary: $2^2 = 4 \\equiv -1 \\pmod{5}$ (since $5 \\equiv 1 \\pmod{4}$). Second supplementary: $3^2 = 9 \\equiv 2 \\pmod{7}$ (since $7 \\equiv 7 \\pmod{8}$)."
     },
     {
       "id": "euler-criterion",
       "title": "Euler's Criterion",
       "startLine": 200,
       "endLine": 231,
-      "summary": "The connection between Legendre symbols and powers."
+      "summary": "The connection between Legendre symbols and powers.",
+      "mathContext": "Euler's criterion: $\\left(\\frac{a}{p}\\right) \\equiv a^{(p-1)/2} \\pmod{p}$. This is the computational engine for evaluating Legendre symbols — it reduces quadratic residuosity to modular exponentiation. The Legendre symbol is also completely multiplicative: $\\left(\\frac{ab}{p}\\right) = \\left(\\frac{a}{p}\\right)\\left(\\frac{b}{p}\\right)$. Together, Euler's criterion + multiplicativity + reciprocity give an efficient Euclidean-algorithm-like procedure for computing any Legendre symbol."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Two enrichment passes in one PR:

### Pass 1: Cross-reference expansion (66 entries)
- 8 entries received manually curated cross-references linking related Erdős problems
- 58 entries received tag-based cross-references to foundational gallery results
- Also removed a resolved open question from abel-ruffini

### Pass 2: Section mathContext (7 entries)
Added mathematical context with LaTeX formulas to all sections of 7 classic entries:
- **quadratic-reciprocity**: Legendre symbol, supplementary laws, Euler's criterion
- **intermediate-value-theorem**: Bolzano's theorem, connected sets, applications
- **isosceles-triangle**: forward/converse/biconditional/vector form
- **mathematical-induction**: weak/strong/well-ordering/Peano axioms
- **nth-root-irrational**: power identity, UFD argument, special cases
- **divisibility-by-3**: digit sum rule, base generalization
- **euler-totient**: Euler's theorem, Fermat corollary, properties

## Test plan
- [x] All modified JSON validates
- [x] All cross-reference targets exist in gallery
- [x] No self-references or duplicates