### PR TITLE
Enrich 10 oq entries: expand cross-references

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -171,6 +171,16 @@
     {
       "relationship": "Explores further consequences of Brouwer FPT beyond Kakutani (topological degree, dimension theory)",
       "targetId": "brouwer-fixed-point-oq-02"
+    },
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "The Intermediate Value Theorem is the 1-dimensional special case of Brouwer's fixed point theorem. This formalization's 1D Kakutani proof via IVT (Section 5) directly uses the IVT on g(x) = u(x) - x to find a fixed point, demonstrating the IVT-to-Brouwer-to-Kakutani hierarchy."
+    },
+    {
+      "targetId": "poincare-conjecture",
+      "relationship": "related",
+      "description": "Both concern deep topological properties of compact manifolds. Brouwer's theorem applies to contractible spaces (disks), while the Poincare conjecture characterizes the 3-sphere among simply connected closed 3-manifolds. The algebraic topology techniques (homotopy, homology) used to prove Brouwer's theorem are foundational to the Poincare conjecture."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/de-moivre-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-03/meta.json
@@ -244,6 +244,21 @@
       "targetId": "de-moivre-oq-02",
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Chebyshev Polynomial Properties via De Moivre's Theorem"
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "foundational",
+      "description": "Euler's identity e^(i*pi) + 1 = 0 is the special case of Euler's formula that underpins this entire formalization. The fractional root negation zeta_1 = -zeta_0 for square roots is a direct consequence of e^(i*pi) = -1."
+    },
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "The Fundamental Theorem of Algebra guarantees that z^q - w = 0 has exactly q roots in C. This formalization constructively exhibits and proves distinctness of all q roots of (e^(i*theta))^p, providing a concrete instance of the FTA for cyclotomic-type polynomials."
+    },
+    {
+      "targetId": "primitive-roots",
+      "relationship": "related",
+      "description": "The q-th roots of unity omega_k = e^(2*pi*i*k/q) used in the root factorization zeta_k = zeta_0 * omega_k are primitive roots when gcd(k,q) = 1. The cyclic group structure mu_q of roots of unity connects De Moivre's fractional powers to the theory of primitive roots."
     }
   ]
 }

--- a/src/data/proofs/derangements-oq-03/meta.json
+++ b/src/data/proofs/derangements-oq-03/meta.json
@@ -222,6 +222,21 @@
       "targetId": "derangements-oq-02-oq-01",
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Partial Derangements for Arbitrary Finite Types"
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "foundational",
+      "description": "The classical derangement formula D(n) = n! * sum_{k=0}^n (-1)^k/k! is derived via the inclusion-exclusion principle applied to the sets A_i = {permutations fixing i}. The Euler identity proved here by strong induction is the algebraic consequence of that combinatorial argument."
+    },
+    {
+      "targetId": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation n! ~ sqrt(2*pi*n) * (n/e)^n gives the asymptotic growth of factorials. Combined with D(n)/n! -> 1/e proved here, it yields the asymptotic count D(n) ~ n!/e, and Stirling refines this to D(n) ~ sqrt(2*pi*n) * (n/e)^n / e."
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "related",
+      "description": "Both derangements and combinations are fundamental counting functions in combinatorics. The partial derangement count (permutations with exactly k fixed points) equals C(n,k) * D(n-k), directly linking the binomial coefficient to the derangement count proved here."
     }
   ]
 }

--- a/src/data/proofs/divisibility-by-3-oq-04/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-04/meta.json
@@ -156,6 +156,21 @@
       "targetId": "chinese-remainder-constructive",
       "relationship": "related",
       "description": "Both formalize modular arithmetic applications: CRT combines congruences mod coprime moduli, while casting out nines uses congruences for arithmetic verification"
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) underlies divisibility theory. The digit-sum congruence n = digitsum(n) (mod 9) is a consequence of 10 = 1 (mod 9), and the generalization to arbitrary bases uses the same modular structure that prime factorization governs."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function and Euler's theorem a^phi(n) = 1 (mod n) are central to modular arithmetic. The casting-out principle b = 1 (mod d) is a special case of the modular structure that Euler's theorem describes, and both rely on the ring homomorphism property of reduction mod d."
+    },
+    {
+      "targetId": "mathematical-induction",
+      "relationship": "foundational",
+      "description": "Mathematical induction is the proof technique underlying the digit-sum congruence: the base representation n = sum a_k * b^k and the congruence b^k = 1 (mod d) are established inductively. The parent proof's strong induction on digit count directly parallels classical induction."
     }
   ],
   "references": [

--- a/src/data/proofs/lagrange-theorem-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-03/meta.json
@@ -241,6 +241,16 @@
       "targetId": "lagrange-theorem",
       "relationship": "extends",
       "description": "Parent formalization; this entry extends it with further exploration"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Both Lagrange's theorem and the Cayley-Hamilton theorem concern structural constraints in algebra. While Lagrange constrains subgroup orders in finite groups, Cayley-Hamilton constrains eigenvalues of matrices. The connection deepens for matrix groups where Sylow and Hall subgroups correspond to eigenvalue structures."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function phi(n) counts units in Z/nZ, and Euler's theorem a^phi(n) = 1 (mod n) follows from Lagrange's theorem applied to (Z/nZ)*. Hall's coprimality condition gcd(|H|, [G:H]) = 1 generalizes the coprimality central to Euler's totient theory."
     }
   ]
 }

--- a/src/data/proofs/mean-value-theorem-oq-03/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-03/meta.json
@@ -222,6 +222,16 @@
       "targetId": "triangle-inequality",
       "relationship": "foundational",
       "description": "The triangle inequality in normed spaces is the key tool replacing IVT in the vector-valued setting, enabling the norm bound ||f(b)-f(a)|| <= C(b-a) that defines the mean value inequality."
+    },
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "related",
+      "description": "Taylor's theorem generalizes the MVT to higher-order approximations: f(b) = f(a) + f'(a)(b-a) + f''(c)(b-a)^2/2. The MVT is the first-order Taylor remainder estimate, and the vector-valued MVT inequality here provides the foundation for vector-valued Taylor remainder bounds in Banach spaces."
+    },
+    {
+      "targetId": "lhopital",
+      "relationship": "related",
+      "description": "L'Hopital's rule evaluates indeterminate limits by comparing derivatives, and its proof relies on the Cauchy mean value theorem (a ratio form of the MVT). The vector-valued MVT inequality generalizes the derivative comparison to norm estimates, extending L'Hopital-type reasoning to Banach-space-valued functions."
     }
   ],
   "references": [

--- a/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
+++ b/src/data/proofs/parallel-postulate-independence-oq-02/meta.json
@@ -197,6 +197,16 @@
       "targetId": "godel-incompleteness",
       "relationship": "related",
       "description": "Both establish independence via model construction. Gödel's incompleteness constructs a sentence independent of Peano arithmetic; the Beltrami-Klein model constructs a geometry where all axioms except the parallel postulate hold, proving independence. The model-theoretic technique — finding a structure satisfying all but one axiom — is the same"
+    },
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "related",
+      "description": "The triangle angle sum being exactly pi is equivalent to the parallel postulate in neutral geometry. In the Beltrami-Klein model formalized here, triangles have angle sum less than pi (hyperbolic defect), directly witnessing the failure of both the parallel postulate and the Euclidean angle-sum property."
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The Pythagorean theorem a^2 + b^2 = c^2 holds only in Euclidean geometry and is equivalent to the parallel postulate. In the Beltrami-Klein hyperbolic model, the Pythagorean relation is replaced by cosh(c) = cosh(a)*cosh(b), providing another manifestation of the parallel postulate's independence."
     }
   ]
 }

--- a/src/data/proofs/pythagorean-theorem-oq-03/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03/meta.json
@@ -243,6 +243,16 @@
       "targetId": "area-of-circle",
       "relationship": "related",
       "description": "Hyperbolic and spherical area formulas connect to circle area through the angular defect/excess: hyperbolic triangle area = pi - alpha - beta - gamma, with connections to hyperbolic disk area formulas."
+    },
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "related",
+      "description": "The angle sum of a triangle is exactly pi in Euclidean geometry but less than pi in hyperbolic and greater than pi in spherical geometry. The area-defect formulas in this formalization (area = pi/2 - alpha - beta for hyperbolic right triangles) directly encode this angle-sum variation."
+    },
+    {
+      "targetId": "herons-formula",
+      "relationship": "related",
+      "description": "Heron's formula computes Euclidean triangle area from side lengths alone. The non-Euclidean Pythagorean theorems here generalize the side-length relations that underpin Heron's formula, and the hyperbolic/spherical area-defect formulas provide the non-Euclidean analogues of area computation."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/shannon-source-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-02/meta.json
@@ -157,6 +157,16 @@
       "targetId": "shannon-channel-coding",
       "relationship": "related",
       "description": "Source coding (compression) and channel coding (reliability) are dual halves of Shannon theory"
+    },
+    {
+      "targetId": "laws-of-large-numbers",
+      "relationship": "related",
+      "description": "The law of large numbers underpins the source coding theorem: the Asymptotic Equipartition Property (AEP) shows that for long sequences, -log(P(X_1,...,X_n))/n -> H(X) almost surely. This concentration result is what makes Shannon coding achievable — typical sequences have probability close to 2^(-nH), enabling compression to H bits per symbol."
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The CLT refines the LLN convergence underlying source coding: the log-probability of a length-n sequence is approximately normal with mean nH and variance n*sigma^2. This gives the finite-blocklength refinement of Huffman coding performance: the excess rate above entropy decreases as O(1/sqrt(n))."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -156,6 +156,16 @@
       "targetId": "cauchy-schwarz",
       "relationship": "related",
       "description": "Cauchy-Schwarz gives $|\\langle x,y \\rangle| \\leq \\|x\\| \\cdot \\|y\\|$, which implies the Euclidean triangle inequality via $\\|x+y\\| \\leq \\|x\\| + \\|y\\|$. The ultrametric inequality $d(x,z) \\leq \\max(d(x,y), d(y,z))$ is strictly stronger — it replaces the additive bound with a maximum, reflecting the non-Archimedean nature of $p$-adic and formal power series valuations"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The Pythagorean theorem establishes the Euclidean distance formula d(x,y) = sqrt(sum (x_i - y_i)^2), which satisfies the standard triangle inequality d(x,z) <= d(x,y) + d(y,z). The ultrametric inequality strengthens this to d(x,z) <= max(d(x,y), d(y,z)), showing that p-adic distances behave fundamentally differently from Euclidean distances."
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "The law of cosines c^2 = a^2 + b^2 - 2ab*cos(C) determines when a triangle is acute, right, or obtuse in Euclidean geometry. In ultrametric spaces, the isosceles triangle theorem (every triangle has at least two equal sides) replaces this classification entirely: triangles cannot be scalene, and the 'angle' information is collapsed to the max operation."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary
Enrichment pass adding cross-references to 10 sub-entries (-oq- entries) that had only 3 cross-references each.

- **pythagorean-theorem-oq-03**: +2 (triangle-angle-sum, herons-formula)
- **de-moivre-oq-03**: +3 (euler-identity, fundamental-theorem-algebra, primitive-roots)
- **lagrange-theorem-oq-03**: +2 (cayley-hamilton, euler-totient)
- **brouwer-fixed-point-oq-04**: +2 (intermediate-value-theorem, poincare-conjecture)
- **derangements-oq-03**: +3 (inclusion-exclusion, stirling-formula, combinations-formula)
- **triangle-inequality-oq-03**: +2 (pythagorean-theorem, law-of-cosines)
- **shannon-source-coding-oq-02**: +2 (laws-of-large-numbers, central-limit-theorem)
- **divisibility-by-3-oq-04**: +3 (fundamental-arithmetic, euler-totient, mathematical-induction)
- **parallel-postulate-independence-oq-02**: +2 (triangle-angle-sum, pythagorean-theorem)
- **mean-value-theorem-oq-03**: +2 (taylor-theorem, lhopital)

## Test plan
- [x] All new target entries verified to exist
- [x] Duplicates checked and avoided
- [x] All 10 JSON files validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)