### PR TITLE
Enrich 10 oq entries: expand cross-references (batch 2)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02/meta.json
@@ -169,6 +169,16 @@
       "targetId": "fundamental-arithmetic",
       "relationship": "related",
       "description": "Unique factorization in PIDs follows from the generalized Euclid's lemma: irreducible = prime in decomposition monoids"
+    },
+    {
+      "targetId": "bezout-identity-oq-03-oq-01",
+      "relationship": "related",
+      "description": "CRT ring isomorphism ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ — both results depend on the IsCoprime/Bézout structure in commutative rings; CRT uses coprimality for the isomorphism, Euclid's lemma uses it for divisibility transfer"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "The irreducible ↔ prime equivalence in Bézout domains (used here for Euclid's lemma) connects to Galois theory: polynomial irreducibility over fields determines solvability by radicals in the Abel-Ruffini theorem"
     }
   ],
   "references": [

--- a/src/data/proofs/bezout-identity-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04/meta.json
@@ -171,6 +171,16 @@
       "targetId": "bezout-identity-oq-03-oq-01",
       "relationship": "related",
       "description": "CRT ring isomorphism — both characterize solution sets: CRT gives ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ, this file gives {(x₀+bt/d, y₀-at/d) : t ∈ ℤ} for Diophantine equations"
+    },
+    {
+      "targetId": "chinese-remainder-non-coprime",
+      "relationship": "related",
+      "description": "Non-coprime CRT extends simultaneous congruences to gcd-compatible moduli — the LCM-based solution bound parallels this entry's lattice parametrization, both reducing to gcd structure"
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "Unique factorization provides the GCD computation that underpins the solution lattice: d = gcd(a,b) determines solvability (d | c) and the lattice spacing (b/d, a/d)"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
@@ -224,6 +224,16 @@
       "targetId": "borsuk-ulam-oq-03-oq-03",
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Constructive 2D Borsuk-Ulam via Tucker's Lemma"
+    },
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "foundational",
+      "description": "The continuous IVT is the analytic foundation for circle Borsuk-Ulam proved here: g(0) and g(π) have opposite signs, so IVT gives θ with g(θ)=0, i.e., an antipodal agreement point on S¹"
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "ancestor",
+      "description": "The root Borsuk-Ulam formalization — this entry provides the 1D combinatorial infrastructure (Tucker's lemma, discrete IVT) that forms the base case for inductive approaches to the full n-dimensional theorem"
     }
   ]
 }

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
@@ -233,6 +233,16 @@
       "targetId": "borsuk-ulam-oq-03-oq-01-oq-01",
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Tucker 2D Lemma via Graph-Theoretic Path-Following"
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "related",
+      "description": "Borsuk-Ulam implies Brouwer's fixed point theorem: if f: Bⁿ→Bⁿ had no fixed point, the retraction Bⁿ→Sⁿ⁻¹ would contradict BU. The constructive BU approach here suggests a constructive path to Brouwer via Tucker's lemma"
+    },
+    {
+      "targetId": "borsuk-ulam-oq-02",
+      "relationship": "related",
+      "description": "Equivariant Borsuk-Ulam for general group actions — while this entry proves BU constructively for ℤ/2 (antipodal) via Tucker, the equivariant version extends to ℤ/p and compact Lie group actions"
     }
   ]
 }

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
@@ -139,6 +139,16 @@
       "targetId": "continuum-hypothesis",
       "relationship": "related",
       "description": "The Continuum Hypothesis asks whether $2^{\\aleph_0} = \\aleph_1$. The properties of $\\aleph_1$ established here (regularity, successor structure) are foundational to understanding CH and its independence."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling extension exploring the Continuum Hypothesis directly — this entry's characterization of ℵ₁ as a regular successor cardinal is precisely the object whose relationship to 2^ℵ₀ is independent of ZFC"
+    },
+    {
+      "targetId": "schroeder-bernstein",
+      "relationship": "related",
+      "description": "Schroeder-Bernstein (injections in both directions imply bijection) is the key tool for establishing cardinal equalities; the aleph hierarchy properties proved here rely on the well-ordering of cardinals that Schroeder-Bernstein helps formalize"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/cantor-diagonalization-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02/meta.json
@@ -231,6 +231,16 @@
       "targetId": "cantor-diagonalization-oq-02-oq-01",
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: ω₁ Properties: Aleph Hierarchy, Regularity, and Cofinality"
+    },
+    {
+      "targetId": "schroeder-bernstein",
+      "relationship": "related",
+      "description": "Schroeder-Bernstein establishes that cardinal comparison is antisymmetric — essential for the cardinality argument here: proving |countable ordinals| = ℵ₁ requires showing both ≤ and ≥ directions of cardinal equality"
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "related",
+      "description": "Both proofs use diagonal/self-referential arguments: Cantor's diagonal shows no countable enumeration of countable ordinals is complete; Turing's diagonal shows no algorithm decides halting. The shared technique reveals deep connections between set theory and computability"
     }
   ]
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
@@ -245,6 +245,16 @@
       "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
       "relationship": "sibling",
       "description": "Sibling open question from the same parent: Finite-Dimensional Cauchy-Schwarz, AM-GM, Nesbitt, and Titu'"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "ancestor",
+      "description": "The Bunyakovsky-Schwarz integral inequality is the L² special case of Hölder's inequality that this entry generalizes via Riesz-Thorin interpolation to arbitrary Lp spaces"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "ancestor",
+      "description": "The discrete Cauchy-Schwarz inequality — the finite-dimensional inner product space origin of the entire Hölder/interpolation hierarchy formalized in this entry's Riesz-Thorin theorem"
     }
   ]
 }

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-01/meta.json
@@ -191,6 +191,16 @@
       "targetId": "bezout-identity",
       "relationship": "foundational",
       "description": "Bézout's identity ($\\gcd(m,n) = sm + tn$) underpins both the coprime CRT construction and the reduction step that makes non-coprime CRT efficient"
+    },
+    {
+      "targetId": "bezout-identity-oq-03-oq-01",
+      "relationship": "related",
+      "description": "CRT ring isomorphism ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ — the algebraic structure that Garner's algorithm exploits for efficient mixed-radix representation, converting between residue and positional systems"
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Quadratic reciprocity depends on modular arithmetic with varying moduli — efficient CRT for non-coprime moduli enables practical computation of Legendre symbols and quadratic residues across composite moduli"
     }
   ],
   "references": [

--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -165,6 +165,16 @@
       "relationship": "related",
       "description": "Fermat's two-squares theorem uses mod 4 residue analysis in a different number-theoretic context, illustrating how parity and divisibility arguments appear across number theory",
       "targetId": "fermat-two-squares"
+    },
+    {
+      "relationship": "related",
+      "description": "The prime number theorem's density estimates for primes inform heuristic arguments about Collatz: the 3n+1 map interacts with prime factorization, and the expected number of halving steps relates to the distribution of 2-adic valuations",
+      "targetId": "prime-number-theorem"
+    },
+    {
+      "relationship": "related",
+      "description": "Erdős Problem #1009 on edge-disjoint triangles in dense graphs — Erdős himself called Collatz 'hopeless' and contributed to combinatorial number theory; both problems involve counting structures under arithmetic constraints",
+      "targetId": "erdos-1009"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -229,6 +229,16 @@
       "targetId": "hermite-lindemann",
       "relationship": "foundational",
       "description": "The Hermite-Lindemann theorem underlies both e-transcendental and pi-transcendental; its formalization is the prerequisite for eliminating the foundational axioms in this entry"
+    },
+    {
+      "targetId": "gelfond-schneider",
+      "relationship": "related",
+      "description": "Gelfond-Schneider proves a^b is transcendental for algebraic a ≠ 0,1 and irrational algebraic b — a complementary transcendence technique; if e+π were algebraic, combined with Gelfond-Schneider-type results this would constrain e·π, tightening the Vieta argument"
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "The irrationality of √2 is the simplest algebraic/transcendental boundary result — proving numbers are NOT algebraic (transcendental) requires fundamentally harder techniques like Hermite's integral method used for e, contrasting with the elementary proof for √2"
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary
Enrichment pass adding 2 cross-references each to 10 sub-entries (-oq- entries) that had only 3.

- bezout-identity-oq-02-oq-02, bezout-identity-oq-04
- borsuk-ulam-oq-03-oq-01, borsuk-ulam-oq-03-oq-03
- cantor-diagonalization-oq-02, cantor-diagonalization-oq-02-oq-01
- cauchy-schwarz-integral-oq-01-oq-02
- chinese-remainder-non-coprime-oq-01
- collatz-structured-oq-02
- e-transcendental-oq-01

All entries went from 3 → 5 cross-references. 20 new cross-references total.

## Test plan
- [x] All target entries verified to exist
- [x] All 10 JSON files validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)