### PR TITLE
Research: erdos-872 — Prove 2 axioms, fix bound bug (14→12 axioms)

### DIFF
--- a/proofs/Proofs/Erdos872Problem.lean
+++ b/proofs/Proofs/Erdos872Problem.lean
@@ -38,6 +38,7 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Order.Antichain
 import Mathlib.Data.Set.Card
+import Mathlib.Tactic
 
 open Nat Finset Set
 
@@ -101,10 +102,30 @@ def IsLegalMove (A : Set ℕ) (k : ℕ) : Prop :=
 
 /--
 Equivalently: k doesn't divide or get divided by any element of A.
-Axiomatized: the biconditional requires careful set manipulation.
--/
-axiom legal_move_iff (A : Set ℕ) (k : ℕ) (hA : IsDivisibilityAntichain A) :
-    IsLegalMove A k ↔ k ∉ A ∧ (∀ a ∈ A, ¬(k ∣ a)) ∧ (∀ a ∈ A, ¬(a ∣ k))
+PROVED: set manipulation on the union definition. -/
+theorem legal_move_iff (A : Set ℕ) (k : ℕ) (hA : IsDivisibilityAntichain A) :
+    IsLegalMove A k ↔ k ∉ A ∧ (∀ a ∈ A, ¬(k ∣ a)) ∧ (∀ a ∈ A, ¬(a ∣ k)) := by
+  constructor
+  · -- Forward: IsLegalMove → the three conditions
+    intro ⟨hkA, hAnti⟩
+    refine ⟨hkA, ?_, ?_⟩
+    · intro a ha hka
+      have : k = a := hAnti k a (Or.inr rfl) (Or.inl ha) hka
+      exact hkA (this ▸ ha)
+    · intro a ha hak
+      have : a = k := hAnti a k (Or.inl ha) (Or.inr rfl) hak
+      exact hkA (this ▸ ha)
+  · -- Backward: three conditions → IsLegalMove
+    intro ⟨hkA, hndvd, hndvd'⟩
+    refine ⟨hkA, ?_⟩
+    intro a b ha hb hab
+    rcases ha with ha | ha <;> rcases hb with hb | hb
+    · exact hA a b ha hb hab
+    · simp only [mem_singleton_iff] at hb; subst hb
+      exact absurd hab (hndvd' a ha)
+    · simp only [mem_singleton_iff] at ha; subst ha
+      exact absurd hab (hndvd b hb)
+    · simp only [mem_singleton_iff] at ha hb; exact ha ▸ hb.symm
 
 /- ## Part III: Game State and Termination
 -/
@@ -131,14 +152,17 @@ axiom game_terminates (n : ℕ) (hn : n ≥ 2) :
 
 /--
 **Trivial Upper Bound:**
-Any antichain in {2, ..., n} has at most n/2 elements.
+Any antichain in {2, ..., n} has at most ⌈n/2⌉ = (n+1)/2 elements.
 The set {⌈n/2⌉ + 1, ..., n} achieves this: it has ⌊n/2⌋ elements and
 forms an antichain since all elements exceed n/2, so no element can be
 at least twice another while remaining ≤ n.
--/
+
+**NOTE:** Previously stated as ≤ n/2, which is incorrect for odd n.
+E.g., for n=5, {3,4,5} is an antichain with 3 > 5/2 = 2 elements.
+The correct bound is (n+1)/2 (Nat division). -/
 axiom maximal_antichain_upper_bound (n : ℕ) (hn : n ≥ 2) :
     ∀ A : Set ℕ, A ⊆ gameBoard n → IsDivisibilityAntichain A →
-    A.ncard ≤ n / 2
+    A.ncard ≤ (n + 1) / 2
 
 /--
 **Greedy Lower Bound:**
@@ -192,7 +216,7 @@ In the analogous graph game, Füredi-Seress showed Ω(n log n) moves guaranteed.
 The triangle-free game on Kₙ lasts at least c · n · log n moves for some c > 0.
 -/
 axiom furedi_seress_triangle_game (n : ℕ) (hn : n ≥ 10) :
-    ∃ c : ℚ, c > 0 ∧ ∃ moves : ℕ, (moves : ℚ) ≥ c * n * Nat.log n
+    ∃ c : ℚ, c > 0 ∧ ∃ moves : ℕ, (moves : ℚ) ≥ c * (n : ℚ) * (Nat.log 2 n : ℚ)
 
 /--
 **Upper Bound for Triangle Game:**
@@ -221,10 +245,28 @@ theorem primes_antichain (P : Set ℕ) (hP : ∀ p ∈ P, p.Prime) :
 **Example: {⌈n/2⌉ + 1, ..., n} is an antichain.**
 No element is at least twice another: if a, b > n/2 and a | b with a ≠ b,
 then b ≥ 2a > n, contradicting b ≤ n.
-Axiomatized because the omega-level arithmetic on Set membership is involved.
--/
-axiom upper_half_antichain (n : ℕ) (hn : n ≥ 4) :
-    IsDivisibilityAntichain {k : ℕ | n / 2 + 1 ≤ k ∧ k ≤ n}
+PROVED: direct divisibility argument. -/
+theorem upper_half_antichain (n : ℕ) (hn : n ≥ 4) :
+    IsDivisibilityAntichain {k : ℕ | n / 2 + 1 ≤ k ∧ k ≤ n} := by
+  intro a b ⟨ha_lo, ha_hi⟩ ⟨hb_lo, hb_hi⟩ hab
+  -- If a | b and a ≠ b, then b ≥ 2a > n, contradicting b ≤ n
+  by_contra h_ne
+  obtain ⟨k, hk⟩ := hab
+  have ha_pos : a > 0 := by omega
+  have hk_ge2 : k ≥ 2 := by
+    rcases k with _ | _ | _
+    · -- k = 0: b = a * 0 = 0, but b ≥ n/2 + 1 > 0
+      simp at hk; omega
+    · -- k = 1: b = a, contradicting a ≠ b
+      simp at hk; exact absurd hk.symm h_ne
+    · -- k ≥ 2
+      omega
+  -- b = a*k ≥ (n/2+1)*2 > n, contradicting b ≤ n
+  have hb_ge : b ≥ (n / 2 + 1) * 2 := by
+    calc b = a * k := hk
+      _ ≥ (n / 2 + 1) * k := Nat.mul_le_mul_right k ha_lo
+      _ ≥ (n / 2 + 1) * 2 := Nat.mul_le_mul_left _ hk_ge2
+  omega
 
 /--
 **First Player Advantage:**
@@ -255,7 +297,7 @@ Axiomatized since computing the minimax tree is exponential.
 -/
 axiom gameValue (n : ℕ) : ℕ
 axiom gameValue_pos (n : ℕ) (hn : n ≥ 4) : gameValue n > 0
-axiom gameValue_upper (n : ℕ) (hn : n ≥ 2) : gameValue n ≤ n / 2
+axiom gameValue_upper (n : ℕ) (hn : n ≥ 2) : gameValue n ≤ (n + 1) / 2
 
 /--
 **Open Problem Statement:**
@@ -285,8 +327,8 @@ Related to Hajnal's triangle-free graph game.
 theorem erdos_872_summary :
     -- The primes form a valid antichain
     (∀ P : Set ℕ, (∀ p ∈ P, p.Prime) → IsDivisibilityAntichain P) ∧
-    -- The game value is bounded above by n/2
-    (∀ n : ℕ, n ≥ 2 → gameValue n ≤ n / 2) :=
+    -- The game value is bounded above by (n+1)/2
+    (∀ n : ℕ, n ≥ 2 → gameValue n ≤ (n + 1) / 2) :=
   ⟨primes_antichain, gameValue_upper⟩
 
 end Erdos872


### PR DESCRIPTION
## Summary
- **Prove `legal_move_iff`**: Convert axiom to theorem via set manipulation on the union definition of `IsDivisibilityAntichain`
- **Prove `upper_half_antichain`**: Direct divisibility argument — if a,b > n/2 and a|b with a≠b, then b ≥ 2a > n, contradiction
- **Fix `maximal_antichain_upper_bound` bug**: Bound was `n/2` (incorrect for odd n; e.g., `{3,4,5}` is an antichain in `{2..5}` with 3 > 5/2=2). Changed to correct bound `(n+1)/2`
- **Fix pre-existing build errors**: `Nat.log` arity, `ℚ×ℕ` multiplication coercion

## Axiom count
14 → 12 (2 eliminated, 0 sorries)

## Test plan
- [x] `docker-build.sh Proofs.Erdos872Problem` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)