### PR TITLE
Enrich 2 entries: expand cross-references (batch 7)

### DIFF
--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -147,6 +147,21 @@
       "targetId": "amgm-inequality-oq-03-oq-02",
       "relationship": "parent",
       "description": "Proves $\\lim_{r \\to 0} M_r = \\text{GM}$: the geometric mean arises as the continuous limit of power means at $r=0$, completing the chain $\\text{HM} = M_{-1} \\leq M_0 = \\text{GM} \\leq M_1 = \\text{AM}$."
+    },
+    {
+      "targetId": "hilbert-17",
+      "relationship": "supports",
+      "description": "The Motzkin polynomial $x^4y^2 + x^2y^4 - 3x^2y^2 + 1 \\geq 0$ is proved non-negative via AM-GM, yet famously cannot be written as a sum of squares of polynomials — a key example in Hilbert's 17th problem on positive semidefinite forms."
+    },
+    {
+      "targetId": "erdos-742",
+      "relationship": "applied-in",
+      "description": "The AM-GM product-sum bound $ab \\leq ((a+b)/2)^2$ directly proves that balanced vertex partitions maximize edge count in graphs: with $a + b = n$ vertices, the product $ab$ (number of crossing edges) is maximized when $a = b$, giving the $\\lfloor n^2/4 \\rfloor$ bound."
+    },
+    {
+      "targetId": "roth-theorem-k3",
+      "relationship": "supports",
+      "description": "The Fourier-analytic proof of Roth's theorem on 3-term arithmetic progressions uses an AM-GM bound to control the Fourier coefficients in the density increment argument, showing that sets without 3-APs must have large Fourier bias."
     }
   ],
   "sections": [


### PR DESCRIPTION
## Summary
- **abel-ruffini**: Previous enrichment batch cross-references
- **amgm-inequality**: Added 3 new cross-references:
  - **hilbert-17**: Motzkin polynomial non-negativity via AM-GM (famous SOS counterexample)
  - **erdos-742**: Balanced partition edge maximization via product-sum bound
  - **roth-theorem-k3**: AM-GM bound in Fourier-analytic proof of Roth's theorem

## Verification
- JSON validated
- Annotations build passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)