### PR TITLE
Fix 34 compilation errors: abel-ruffini-oq-04-oq-01 fully verified

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01.lean
@@ -1094,7 +1094,8 @@ private theorem gal_card_ne_20 : Fintype.card p.Gal ≠ 20 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
       Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
-    exact hc_ne (show ↑c = 1 from by have hgrp : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at hgrp; simp at hgrp; simp [hgrp])
+    have hc1 : c = 1 := by have := (by group : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ'); rw [h1] at this; simpa using this
+    exact hc_ne (congr_arg Subtype.val hc1)
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
     have hdiv : k = 5 * (k / 5) + k % 5 := by omega
     conv_lhs => rw [hdiv]
@@ -1103,7 +1104,7 @@ private theorem gal_card_ne_20 : Fintype.card p.Gal ≠ 20 := by
       rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
     rw [h5z, one_zpow, one_mul]
     conv_lhs => rw [(Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))).symm]
-    exact zpow_natCast (↑c) ((k % 5).toNat)
+    simp only [zpow_natCast]
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by
     rw [Int.toNat_lt (by omega)]; exact Int.emod_lt_of_pos k (by norm_num)
@@ -1189,7 +1190,8 @@ private theorem gal_card_ne_10 : Fintype.card p.Gal ≠ 10 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
       Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
-    exact hc_ne (show ↑c = 1 from by have hgrp : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at hgrp; simp at hgrp; simp [hgrp])
+    have hc1 : c = 1 := by have := (by group : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ'); rw [h1] at this; simpa using this
+    exact hc_ne (congr_arg Subtype.val hc1)
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
     have hdiv : k = 5 * (k / 5) + k % 5 := by omega
     conv_lhs => rw [hdiv]
@@ -1198,7 +1200,7 @@ private theorem gal_card_ne_10 : Fintype.card p.Gal ≠ 10 := by
       rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
     rw [h5z, one_zpow, one_mul]
     conv_lhs => rw [(Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))).symm]
-    exact zpow_natCast (↑c) ((k % 5).toNat)
+    simp only [zpow_natCast]
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by
     rw [Int.toNat_lt (by omega)]; exact Int.emod_lt_of_pos k (by norm_num)
@@ -1284,7 +1286,8 @@ private theorem gal_card_ne_40 : Fintype.card p.Gal ≠ 40 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
       Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
-    exact hc_ne (show ↑c = 1 from by have hgrp : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at hgrp; simp at hgrp; simp [hgrp])
+    have hc1 : c = 1 := by have := (by group : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ'); rw [h1] at this; simpa using this
+    exact hc_ne (congr_arg Subtype.val hc1)
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
     have hdiv : k = 5 * (k / 5) + k % 5 := by omega
     conv_lhs => rw [hdiv]
@@ -1293,7 +1296,7 @@ private theorem gal_card_ne_40 : Fintype.card p.Gal ≠ 40 := by
       rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
     rw [h5z, one_zpow, one_mul]
     conv_lhs => rw [(Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))).symm]
-    exact zpow_natCast (↑c) ((k % 5).toNat)
+    simp only [zpow_natCast]
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by
     rw [Int.toNat_lt (by omega)]; exact Int.emod_lt_of_pos k (by norm_num)

--- a/proofs/Proofs/AbelRuffiniOQ04OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01.lean
@@ -960,10 +960,12 @@ private noncomputable def conjHom : ℂ →ₐ[ℚ] ℂ where
     show starRingEnd ℂ (algebraMap ℚ ℂ r) = algebraMap ℚ ℂ r
     rw [IsScalarTower.algebraMap_apply ℚ ℝ ℂ]; exact Complex.conj_ofReal _
 private noncomputable def sfConjEmb : SF →ₐ[ℚ] ℂ := conjHom.comp sfEmb
-private noncomputable def conjGalAut : SF ≃ₐ[ℚ] SF := sfConjEmb.restrictNormal SF
+private noncomputable def conjGalAut : SF ≃ₐ[ℚ] SF := sfConjEmb.restrictNormal' SF
 private theorem conjGalAut_spec (x : SF) :
-    sfEmb (conjGalAut x) = starRingEnd ℂ (sfEmb x) :=
-  sfConjEmb.restrictNormal_commutes SF x
+    sfEmb (conjGalAut x) = starRingEnd ℂ (sfEmb x) := by
+  have h := sfConjEmb.restrictNormal_commutes SF x
+  simp only [Algebra.id.map_eq_id, RingHom.id_apply] at h
+  exact h
 private theorem conjGalAut_sq : conjGalAut ^ 2 = 1 := by
   ext x; apply sfEmb.injective; show sfEmb ((conjGalAut * conjGalAut) x) = sfEmb x
   simp only [AlgEquiv.mul_apply]; rw [conjGalAut_spec, conjGalAut_spec, Complex.conj_conj]
@@ -976,12 +978,14 @@ private theorem galSign_conjGal : galSign conjGal = -1 := by
     rw [← conjGalAut_spec]; exact congrArg sfEmb hact
   have him : (sfEmb vandermondeProduct).im = 0 := Complex.conj_eq_iff_im.mp hconj
   have hval : sfEmb vandermondeProduct ^ 2 = (-212144 : ℂ) := by
-    rw [← map_pow sfEmb, vandermondeProduct_sq_val, sfEmb.commutes]; push_cast; ring
+    rw [← map_pow sfEmb, vandermondeProduct_sq_val, sfEmb.commutes]; push_cast; norm_num
   have hre : sfEmb vandermondeProduct = ↑(sfEmb vandermondeProduct).re :=
     Complex.ext rfl (by simp [him])
   rw [hre] at hval
   have : ((sfEmb vandermondeProduct).re ^ 2 : ℝ) = -212144 := by
-    have := congr_arg Complex.re hval; simp [Complex.ofReal_pow] at this; linarith
+    have h := congr_arg Complex.re hval
+    simp only [Complex.ofReal_pow, Complex.ofReal_re, map_neg, Complex.ofReal_natCast] at h
+    push_cast at h; linarith
   linarith [sq_nonneg (sfEmb vandermondeProduct).re]
 
 theorem gal_has_transposition :
@@ -1033,8 +1037,8 @@ private theorem gal_card_ne_20 : Fintype.card p.Gal ≠ 20 := by
   haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
   obtain ⟨c, hc_ord⟩ := exists_prime_orderOf_dvd_card (p := 5) (by rw [hG_ft]; norm_num)
   have hc5 : (c : Equiv.Perm (Fin 5)) ^ 5 = 1 := by
-    simpa using congr_arg Subtype.val
-      (show c ^ 5 = (1 : G) from by rw [← hc_ord]; exact pow_orderOf_eq_one c)
+    have h : c ^ orderOf c = (1 : G) := pow_orderOf_eq_one c
+    rw [hc_ord] at h; simpa using congr_arg Subtype.val h
   have hc_ne : (c : Equiv.Perm (Fin 5)) ≠ 1 := fun h =>
     absurd hc_ord (by rw [show c = (1 : G) from Subtype.ext h, orderOf_one]; norm_num)
   set σ' : G := ⟨galToPerm5 σ, ⟨σ, rfl⟩⟩
@@ -1053,7 +1057,7 @@ private theorem gal_card_ne_20 : Fintype.card p.Gal ≠ 20 := by
   haveI : Subsingleton (Sylow 5 G) := by
     haveI := Fintype.ofFinite (Sylow 5 G)
     rw [← Fintype.card_le_one_iff_subsingleton, ← Nat.card_eq_fintype_card]; omega
-  haveI : (↑P₅ : Subgroup G).Normal := by
+  haveI hNP : (↑P₅ : Subgroup G).Normal := by
     apply Subgroup.Normal.mk; intro n hn g
     have : g • P₅ = P₅ := Subsingleton.elim _ _; rw [Sylow.smul_eq_iff_mem_normalizer] at this
     exact ((Subgroup.mem_normalizer_iff.mp this) n).mp hn
@@ -1078,24 +1082,28 @@ private theorem gal_card_ne_20 : Fintype.card p.Gal ≠ 20 := by
     obtain ⟨⟨y, hy⟩, hxy⟩ := hbij.surjective ⟨x, hx⟩
     rwa [show y = x from congr_arg Subtype.val hxy] at hy
   have hconj_zpow : σ' * c * σ'⁻¹ ∈ Subgroup.zpowers c :=
-    (SetLike.ext_iff.mp hP5_eq _).mp ((↑P₅ : Subgroup G).Normal.conj_mem c hc_P5 σ')
+    (SetLike.ext_iff.mp hP5_eq _).mp (hNP.conj_mem c hc_P5 σ')
   obtain ⟨k, hk⟩ := Subgroup.mem_zpowers_iff.mp hconj_zpow
   have hσ_inv : (galToPerm5 σ)⁻¹ = galToPerm5 σ :=
     inv_eq_iff_mul_eq_one.mpr (by rw [← sq]; exact hσ2)
   have hconj_val : galToPerm5 σ * ↑c * galToPerm5 σ = (↑c : Equiv.Perm (Fin 5)) ^ k := by
     have h := congr_arg Subtype.val hk
-    simp only [Subgroup.coe_mul, Subgroup.coe_inv, SubgroupClass.coe_zpow, σ'] at h; rwa [hσ_inv]
+    simp only [Subgroup.coe_mul, Subgroup.coe_inv, SubgroupClass.coe_zpow, σ'] at h
+    rw [hσ_inv] at h; exact h.symm
   have ⟨hn1, hn2, hn3, hn4⟩ := transposition_not_normalizing_5cycle
     ↑c (galToPerm5 σ) hc5 hc_ne hσ_sign hσ2
   have hck_ne : (↑c : Equiv.Perm (Fin 5)) ^ k ≠ 1 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
-      Subtype.ext (by simp [σ', Subgroup.coe_mul, Subgroup.coe_inv, hσ_inv]; exact h)
+      Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
     exact hc_ne (by have : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at this; simpa using this)
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
-    conv_lhs => rw [show k = 5 * (k / 5) + k % 5 from (Int.emod_add_ediv k 5 ▸ by ring)]
-    rw [zpow_add, zpow_mul, show (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 from by
-      rw [zpow_natCast]; exact_mod_cast hc5, one_zpow, one_mul,
+    have hdiv : k = 5 * (k / 5) + k % 5 := by omega
+    conv_lhs => rw [hdiv]
+    rw [zpow_add, zpow_mul]
+    have h5z : (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 := by
+      rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
+    rw [h5z, one_zpow, one_mul, zpow_natCast,
       Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))]
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by
@@ -1123,8 +1131,8 @@ private theorem gal_card_ne_10 : Fintype.card p.Gal ≠ 10 := by
   haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
   obtain ⟨c, hc_ord⟩ := exists_prime_orderOf_dvd_card (p := 5) (by rw [hG_ft]; norm_num)
   have hc5 : (c : Equiv.Perm (Fin 5)) ^ 5 = 1 := by
-    simpa using congr_arg Subtype.val
-      (show c ^ 5 = (1 : G) from by rw [← hc_ord]; exact pow_orderOf_eq_one c)
+    have h : c ^ orderOf c = (1 : G) := pow_orderOf_eq_one c
+    rw [hc_ord] at h; simpa using congr_arg Subtype.val h
   have hc_ne : (c : Equiv.Perm (Fin 5)) ≠ 1 := fun h =>
     absurd hc_ord (by rw [show c = (1 : G) from Subtype.ext h, orderOf_one]; norm_num)
   set σ' : G := ⟨galToPerm5 σ, ⟨σ, rfl⟩⟩
@@ -1143,7 +1151,7 @@ private theorem gal_card_ne_10 : Fintype.card p.Gal ≠ 10 := by
   haveI : Subsingleton (Sylow 5 G) := by
     haveI := Fintype.ofFinite (Sylow 5 G)
     rw [← Fintype.card_le_one_iff_subsingleton, ← Nat.card_eq_fintype_card]; omega
-  haveI : (↑P₅ : Subgroup G).Normal := by
+  haveI hNP : (↑P₅ : Subgroup G).Normal := by
     apply Subgroup.Normal.mk; intro n hn g
     have : g • P₅ = P₅ := Subsingleton.elim _ _; rw [Sylow.smul_eq_iff_mem_normalizer] at this
     exact ((Subgroup.mem_normalizer_iff.mp this) n).mp hn
@@ -1168,24 +1176,28 @@ private theorem gal_card_ne_10 : Fintype.card p.Gal ≠ 10 := by
     obtain ⟨⟨y, hy⟩, hxy⟩ := hbij.surjective ⟨x, hx⟩
     rwa [show y = x from congr_arg Subtype.val hxy] at hy
   have hconj_zpow : σ' * c * σ'⁻¹ ∈ Subgroup.zpowers c :=
-    (SetLike.ext_iff.mp hP5_eq _).mp ((↑P₅ : Subgroup G).Normal.conj_mem c hc_P5 σ')
+    (SetLike.ext_iff.mp hP5_eq _).mp (hNP.conj_mem c hc_P5 σ')
   obtain ⟨k, hk⟩ := Subgroup.mem_zpowers_iff.mp hconj_zpow
   have hσ_inv : (galToPerm5 σ)⁻¹ = galToPerm5 σ :=
     inv_eq_iff_mul_eq_one.mpr (by rw [← sq]; exact hσ2)
   have hconj_val : galToPerm5 σ * ↑c * galToPerm5 σ = (↑c : Equiv.Perm (Fin 5)) ^ k := by
     have h := congr_arg Subtype.val hk
-    simp only [Subgroup.coe_mul, Subgroup.coe_inv, SubgroupClass.coe_zpow, σ'] at h; rwa [hσ_inv]
+    simp only [Subgroup.coe_mul, Subgroup.coe_inv, SubgroupClass.coe_zpow, σ'] at h
+    rw [hσ_inv] at h; exact h.symm
   have ⟨hn1, hn2, hn3, hn4⟩ := transposition_not_normalizing_5cycle
     ↑c (galToPerm5 σ) hc5 hc_ne hσ_sign hσ2
   have hck_ne : (↑c : Equiv.Perm (Fin 5)) ^ k ≠ 1 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
-      Subtype.ext (by simp [σ', Subgroup.coe_mul, Subgroup.coe_inv, hσ_inv]; exact h)
+      Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
     exact hc_ne (by have : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at this; simpa using this)
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
-    conv_lhs => rw [show k = 5 * (k / 5) + k % 5 from (Int.emod_add_ediv k 5 ▸ by ring)]
-    rw [zpow_add, zpow_mul, show (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 from by
-      rw [zpow_natCast]; exact_mod_cast hc5, one_zpow, one_mul,
+    have hdiv : k = 5 * (k / 5) + k % 5 := by omega
+    conv_lhs => rw [hdiv]
+    rw [zpow_add, zpow_mul]
+    have h5z : (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 := by
+      rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
+    rw [h5z, one_zpow, one_mul, zpow_natCast,
       Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))]
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by
@@ -1213,8 +1225,8 @@ private theorem gal_card_ne_40 : Fintype.card p.Gal ≠ 40 := by
   haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
   obtain ⟨c, hc_ord⟩ := exists_prime_orderOf_dvd_card (p := 5) (by rw [hG_ft]; norm_num)
   have hc5 : (c : Equiv.Perm (Fin 5)) ^ 5 = 1 := by
-    simpa using congr_arg Subtype.val
-      (show c ^ 5 = (1 : G) from by rw [← hc_ord]; exact pow_orderOf_eq_one c)
+    have h : c ^ orderOf c = (1 : G) := pow_orderOf_eq_one c
+    rw [hc_ord] at h; simpa using congr_arg Subtype.val h
   have hc_ne : (c : Equiv.Perm (Fin 5)) ≠ 1 := fun h =>
     absurd hc_ord (by rw [show c = (1 : G) from Subtype.ext h, orderOf_one]; norm_num)
   set σ' : G := ⟨galToPerm5 σ, ⟨σ, rfl⟩⟩
@@ -1233,7 +1245,7 @@ private theorem gal_card_ne_40 : Fintype.card p.Gal ≠ 40 := by
   haveI : Subsingleton (Sylow 5 G) := by
     haveI := Fintype.ofFinite (Sylow 5 G)
     rw [← Fintype.card_le_one_iff_subsingleton, ← Nat.card_eq_fintype_card]; omega
-  haveI : (↑P₅ : Subgroup G).Normal := by
+  haveI hNP : (↑P₅ : Subgroup G).Normal := by
     apply Subgroup.Normal.mk; intro n hn g
     have : g • P₅ = P₅ := Subsingleton.elim _ _; rw [Sylow.smul_eq_iff_mem_normalizer] at this
     exact ((Subgroup.mem_normalizer_iff.mp this) n).mp hn
@@ -1258,24 +1270,28 @@ private theorem gal_card_ne_40 : Fintype.card p.Gal ≠ 40 := by
     obtain ⟨⟨y, hy⟩, hxy⟩ := hbij.surjective ⟨x, hx⟩
     rwa [show y = x from congr_arg Subtype.val hxy] at hy
   have hconj_zpow : σ' * c * σ'⁻¹ ∈ Subgroup.zpowers c :=
-    (SetLike.ext_iff.mp hP5_eq _).mp ((↑P₅ : Subgroup G).Normal.conj_mem c hc_P5 σ')
+    (SetLike.ext_iff.mp hP5_eq _).mp (hNP.conj_mem c hc_P5 σ')
   obtain ⟨k, hk⟩ := Subgroup.mem_zpowers_iff.mp hconj_zpow
   have hσ_inv : (galToPerm5 σ)⁻¹ = galToPerm5 σ :=
     inv_eq_iff_mul_eq_one.mpr (by rw [← sq]; exact hσ2)
   have hconj_val : galToPerm5 σ * ↑c * galToPerm5 σ = (↑c : Equiv.Perm (Fin 5)) ^ k := by
     have h := congr_arg Subtype.val hk
-    simp only [Subgroup.coe_mul, Subgroup.coe_inv, SubgroupClass.coe_zpow, σ'] at h; rwa [hσ_inv]
+    simp only [Subgroup.coe_mul, Subgroup.coe_inv, SubgroupClass.coe_zpow, σ'] at h
+    rw [hσ_inv] at h; exact h.symm
   have ⟨hn1, hn2, hn3, hn4⟩ := transposition_not_normalizing_5cycle
     ↑c (galToPerm5 σ) hc5 hc_ne hσ_sign hσ2
   have hck_ne : (↑c : Equiv.Perm (Fin 5)) ^ k ≠ 1 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
-      Subtype.ext (by simp [σ', Subgroup.coe_mul, Subgroup.coe_inv, hσ_inv]; exact h)
+      Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
     exact hc_ne (by have : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at this; simpa using this)
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
-    conv_lhs => rw [show k = 5 * (k / 5) + k % 5 from (Int.emod_add_ediv k 5 ▸ by ring)]
-    rw [zpow_add, zpow_mul, show (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 from by
-      rw [zpow_natCast]; exact_mod_cast hc5, one_zpow, one_mul,
+    have hdiv : k = 5 * (k / 5) + k % 5 := by omega
+    conv_lhs => rw [hdiv]
+    rw [zpow_add, zpow_mul]
+    have h5z : (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 := by
+      rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
+    rw [h5z, one_zpow, one_mul, zpow_natCast,
       Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))]
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by

--- a/proofs/Proofs/AbelRuffiniOQ04OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01.lean
@@ -983,9 +983,7 @@ private theorem galSign_conjGal : galSign conjGal = -1 := by
     Complex.ext rfl (by simp [him])
   rw [hre] at hval
   have : ((sfEmb vandermondeProduct).re ^ 2 : ℝ) = -212144 := by
-    have h := congr_arg Complex.re hval
-    simp only [Complex.ofReal_pow, Complex.ofReal_re, map_neg, Complex.ofReal_natCast] at h
-    push_cast at h; linarith
+    exact_mod_cast hval
   linarith [sq_nonneg (sfEmb vandermondeProduct).re]
 
 theorem gal_has_transposition :
@@ -994,7 +992,7 @@ theorem gal_has_transposition :
   refine ⟨conjGal, ?_, ?_, ?_⟩
   · rw [← map_pow, show conjGal ^ 2 = 1 from conjGalAut_sq, map_one]
   · intro heq; have : galSign conjGal = 1 := by unfold galSign; rw [heq, Equiv.Perm.sign_one]
-    linarith [galSign_conjGal]
+    exact absurd galSign_conjGal (by rw [this]; decide)
   · exact galSign_conjGal
 
 -- Section E6b: |Gal| ≠ 20 (from transposition + F₂₀ structure)
@@ -1096,15 +1094,16 @@ private theorem gal_card_ne_20 : Fintype.card p.Gal ≠ 20 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
       Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
-    exact hc_ne (by have : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at this; simpa using this)
+    exact hc_ne (show ↑c = 1 from by have hgrp : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at hgrp; simp at hgrp; simp [hgrp])
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
     have hdiv : k = 5 * (k / 5) + k % 5 := by omega
     conv_lhs => rw [hdiv]
     rw [zpow_add, zpow_mul]
     have h5z : (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 := by
       rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
-    rw [h5z, one_zpow, one_mul, zpow_natCast,
-      Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))]
+    rw [h5z, one_zpow, one_mul]
+    conv_lhs => rw [(Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))).symm]
+    exact zpow_natCast (↑c) ((k % 5).toNat)
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by
     rw [Int.toNat_lt (by omega)]; exact Int.emod_lt_of_pos k (by norm_num)
@@ -1190,15 +1189,16 @@ private theorem gal_card_ne_10 : Fintype.card p.Gal ≠ 10 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
       Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
-    exact hc_ne (by have : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at this; simpa using this)
+    exact hc_ne (show ↑c = 1 from by have hgrp : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at hgrp; simp at hgrp; simp [hgrp])
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
     have hdiv : k = 5 * (k / 5) + k % 5 := by omega
     conv_lhs => rw [hdiv]
     rw [zpow_add, zpow_mul]
     have h5z : (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 := by
       rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
-    rw [h5z, one_zpow, one_mul, zpow_natCast,
-      Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))]
+    rw [h5z, one_zpow, one_mul]
+    conv_lhs => rw [(Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))).symm]
+    exact zpow_natCast (↑c) ((k % 5).toNat)
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by
     rw [Int.toNat_lt (by omega)]; exact Int.emod_lt_of_pos k (by norm_num)
@@ -1284,15 +1284,16 @@ private theorem gal_card_ne_40 : Fintype.card p.Gal ≠ 40 := by
     rw [← hconj_val]; intro h
     have h1 : σ' * c * σ'⁻¹ = (1 : G) :=
       Subtype.ext (by simp only [σ', Subgroup.coe_mul, Subgroup.coe_inv]; rw [hσ_inv]; exact h)
-    exact hc_ne (by have : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at this; simpa using this)
+    exact hc_ne (show ↑c = 1 from by have hgrp : c = σ'⁻¹ * (σ' * c * σ'⁻¹) * σ' := by group; rw [h1] at hgrp; simp at hgrp; simp [hgrp])
   have hred : (↑c : Equiv.Perm (Fin 5)) ^ k = (↑c) ^ (k % 5).toNat := by
     have hdiv : k = 5 * (k / 5) + k % 5 := by omega
     conv_lhs => rw [hdiv]
     rw [zpow_add, zpow_mul]
     have h5z : (↑c : Equiv.Perm (Fin 5)) ^ (5 : ℤ) = 1 := by
       rw [show (5 : ℤ) = ↑(5 : ℕ) from by norm_cast, zpow_natCast]; exact_mod_cast hc5
-    rw [h5z, one_zpow, one_mul, zpow_natCast,
-      Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))]
+    rw [h5z, one_zpow, one_mul]
+    conv_lhs => rw [(Int.toNat_of_nonneg (Int.emod_nonneg k (by norm_num))).symm]
+    exact zpow_natCast (↑c) ((k % 5).toNat)
   rw [hred] at hconj_val hck_ne
   have hbound : (k % 5).toNat < 5 := by
     rw [Int.toNat_lt (by omega)]; exact Int.emod_lt_of_pos k (by norm_num)

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "abel-ruffini-oq-04-oq-01",
   "title": "Concrete Abel-Ruffini: Gal(x⁵ - 4x + 2) ≅ S₅ and Unsolvability by Radicals",
   "slug": "abel-ruffini-oq-04-oq-01",
-  "description": "Proves that the polynomial x⁵ - 4x + 2 over ℚ has Galois group S₅, completing the Abel-Ruffini proof chain with a concrete witness. The roots of this polynomial cannot be expressed using radicals. Irreducibility proved via Eisenstein at p=2; |Gal|=120 proved from Dedekind's theorem (3||Gal|) and discriminant analysis (Gal⊄A₅), using Sylow theory to rule out orders 15, 30, 60. Realizes S₅ as a Galois group over ℚ.",
+  "description": "Proves that the polynomial x⁵ - 4x + 2 over ℚ has Galois group S₅, completing the Abel-Ruffini proof chain with a concrete witness. The roots of this polynomial cannot be expressed using radicals. Irreducibility proved via Eisenstein at p=2; |Gal|=120 proved axiom-free via Vandermonde discriminant (Gal⊄A₅), complex conjugation (transposition exists), and Sylow theory to rule out orders 5, 10, 15, 20, 30, 40, 60. Realizes S₅ as a Galois group over ℚ.",
   "meta": {
     "author": "Abel (1824), Galois (1832)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem",
@@ -62,7 +62,7 @@
       "Solvable groups and the derived series"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 1581,
+    "lineCount": 1601,
     "relatedProblems": [
       {
         "id": "abel-ruffini-oq-04",
@@ -286,7 +286,7 @@
       "Polynomial"
     ],
     "namespace": "AbelRuffiniOQ04OQ01",
-    "lineCount": 1581,
+    "lineCount": 1601,
     "axiomCount": 0,
     "sorryCount": 0,
     "theoremCount": 88,


### PR DESCRIPTION
## Summary

- Fix all 34 compilation errors in `AbelRuffiniOQ04OQ01.lean` — proof now builds successfully
- **0 axioms, 0 sorries**: Complete axiom-free proof that Gal(x⁵-4x+2/ℚ) ≅ S₅
- Update meta.json line count (1581 → 1601)

### Key fixes

**Complex conjugation section (lines 963-993):**
- `restrictNormal` → `restrictNormal'` for `AlgEquiv` return type
- Rewrite `conjGalAut_spec` proof using `restrictNormal_commutes` + `Algebra.id.map_eq_id`
- `ring` → `norm_num` for algebraMap computation, `exact_mod_cast` for ℂ→ℝ extraction
- `linarith` → `absurd ... decide` for ℤˣ inequality

**Sylow elimination proofs (ne_10, ne_20, ne_40 — 3× identical):**
- `rw [← hc_ord]; exact pow_orderOf_eq_one c` → rewrite on `h` to avoid `Fin 5` motive collision
- `(↑P₅).Normal.conj_mem` → named `hNP.conj_mem` for field notation
- `rwa [hσ_inv]` → `rw [hσ_inv] at h; exact h.symm` (pattern was in hypothesis, not goal)
- Explicit `Subtype.val` coercion for `c = 1` (G) → `↑c = 1` (Perm)
- `Int.emod_add_ediv ▸ ring` → `omega` for division identity
- `zpow_natCast` → `simp only [zpow_natCast]` for type-level matching
- `conv_lhs` + `Int.toNat_of_nonneg` for zpow → pow conversion

## Test plan

- [x] `docker-build.sh Proofs.AbelRuffiniOQ04OQ01` — builds successfully (7743 jobs)
- [x] All `#check` commands at end of file pass
- [x] 0 `error:` lines in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)