### PR TITLE
Enrich 3 entries: expand cross-references

### DIFF
--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -247,6 +247,11 @@
       "targetId": "area-of-circle-oq-01-oq-02-oq-01",
       "relationship": "extended-by",
       "description": "Generalizes the circumference-to-area integration to $n$ dimensions: derives $V_n(r)$ from $S_n(r)$ via $V_n(r) = \\int_0^r S_n(\\rho)\\, d\\rho$, extending the annular ring argument from the 2D case ($A = \\int_0^r 2\\pi\\rho\\, d\\rho$) to arbitrary dimension"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "De Moivre's formula $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$ governs the unit circle parameterization in $\\mathbb{C}$ that this proof relies on: the disk $\\{z : |z - c| \\leq r\\}$ is bounded by the circle $c + re^{i\\theta}$ for $\\theta \\in [0, 2\\pi)$. The polar coordinate area element $r\\,dr\\,d\\theta$ — which the annular ring derivation $A = \\int_0^r 2\\pi\\rho\\,d\\rho = \\pi r^2$ uses — derives from this De Moivre parameterization of the circular boundary. More precisely, the Jacobian of the map $(r,\\theta) \\mapsto re^{i\\theta}$ is $r$, giving $dA = r\\,dr\\,d\\theta$"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/cayley-hamilton/meta.json
+++ b/src/data/proofs/cayley-hamilton/meta.json
@@ -158,6 +158,11 @@
       "targetId": "cayley-hamilton-minpoly",
       "relationship": "extended-by",
       "description": "Develops the minimal polynomial theory: the minimal polynomial $m(x)$ divides the characteristic polynomial $p(x)$ by Cayley-Hamilton, and $m(M) = 0$ is the strongest polynomial annihilation result — answering the open question about minimal polynomials"
+    },
+    {
+      "targetId": "cramers-rule",
+      "relationship": "related",
+      "description": "Cramer's rule ($x_i = \\det(A_i)/\\det(A)$) and Cayley-Hamilton share the same algebraic core: the adjugate matrix identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$. Cramer's rule uses it to solve linear systems, while Cayley-Hamilton evaluates $\\text{adj}(XI - A) \\cdot (XI - A) = \\det(XI - A) \\cdot I$ at $X = A$ to prove $p_A(A) = 0$. The inverse formula $A^{-1} = \\frac{1}{\\det(A)} \\text{adj}(A)$ — a direct consequence of both results — appears explicitly in the 2×2 case section"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/desargues-theorem/meta.json
+++ b/src/data/proofs/desargues-theorem/meta.json
@@ -240,6 +240,11 @@
       "targetId": "four-color-theorem",
       "relationship": "thematic",
       "description": "Both are foundational results about planar geometric/combinatorial structures: the four-color theorem concerns graph coloring on the plane, while Desargues's theorem concerns projective configurations — both involve deep structural analysis"
+    },
+    {
+      "targetId": "hilbert-4",
+      "relationship": "related",
+      "description": "Hilbert's 4th problem asks for all metrics on a projective space where straight lines are geodesics — a question about projective geometry, the same framework in which Desargues's theorem lives. Desargues's theorem characterizes which projective planes can be coordinatized over division rings (Desarguesian planes), while Hilbert's 4th problem characterizes which metrics respect the projective line structure. Both reveal the deep interplay between algebraic structure and geometric axioms in projective spaces"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for area-of-circle, cayley-hamilton, and desargues-theorem.

## Changes

Added missing cross-references to 3 gallery entries:

- **area-of-circle**: Added `de-moivre` (foundational) — De Moivre's formula governs the unit circle parameterization in ℂ that the proof's ambient space relies on
- **cayley-hamilton**: Added `cramers-rule` (related) — both share the adjugate matrix identity as their algebraic core
- **desargues-theorem**: Added `hilbert-4` (related) — both concern algebraic structure in projective geometry