### PR TITLE
Enrich angle-trisection-oq-02: add cross-reference

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -96,6 +96,11 @@
       "description": "Both use Galois groups to prove impossibility: Abel-Ruffini via solvable groups, constructibility via 2-groups"
     },
     {
+      "targetId": "abel-ruffini-oq-04",
+      "relationship": "related",
+      "description": "Exposes the group-theoretic proof chain from $A_5$ simplicity to $S_n$ non-solvability — the chain establishing why solvable Galois groups (radical solvability) are strictly more permissive than 2-group Galois groups (constructibility). Every 2-group is solvable (composition factors $\\mathbb{Z}/2\\mathbb{Z}$ are abelian), so constructible $\\subsetneq$ solvable by radicals, with the threshold at $A_5$"
+    },
+    {
       "targetId": "inverse-galois",
       "relationship": "related",
       "description": "The Galois group realizations (S₃ for x³-2, D₄ for x⁴-2) are concrete instances of the inverse Galois problem"


### PR DESCRIPTION
## Summary
- Added cross-reference from `angle-trisection-oq-02` to `abel-ruffini-oq-04`, linking the 2-group Galois constructibility criterion to the solvability chain
- Makes the expressibility hierarchy (constructible ⊊ solvable by radicals) navigable in the gallery

## Enrichment details
- **Target**: angle-trisection-oq-02 (Wantzel-Galois theorem)
- **Change**: Added 1 cross-reference to abel-ruffini-oq-04
- **Rationale**: The entry's keyInsights and conclusion discuss the hierarchy "2-groups ⊂ solvable groups" but only linked to abel-ruffini (base) and abel-ruffini-oq-04-oq-01 (concrete quintic), missing the solvability chain entry itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)