### PR TITLE
Enrich abel-ruffini-oq-04-oq-01: fix stale references and line ranges

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 57
+      "endLine": 133
     },
     "type": "context",
     "title": "Proof Chain Overview and Mathematical Background",
@@ -29,8 +29,8 @@
     "id": "ann-abeloq04oq01-polynomial",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 67,
-      "endLine": 70
+      "startLine": 140,
+      "endLine": 143
     },
     "type": "definition",
     "title": "The Polynomial p = X^5 - 4X + 2",
@@ -52,8 +52,8 @@
     "id": "ann-abeloq04oq01-eisenstein",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 93,
-      "endLine": 133
+      "startLine": 166,
+      "endLine": 210
     },
     "type": "technique",
     "title": "Eisenstein's Irreducibility Criterion at p = 2",
@@ -77,8 +77,8 @@
     "id": "ann-abeloq04oq01-gauss",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 134,
-      "endLine": 145
+      "startLine": 211,
+      "endLine": 219
     },
     "type": "technique",
     "title": "Transfer to Q-Irreducibility via Gauss's Lemma",
@@ -100,8 +100,8 @@
     "id": "ann-abeloq04oq01-structural",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 152,
-      "endLine": 169
+      "startLine": 225,
+      "endLine": 243
     },
     "type": "technique",
     "title": "Structural Properties: Degree, Separability, Root Set",
@@ -125,8 +125,8 @@
     "id": "ann-abeloq04oq01-galois-bounds",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 176,
-      "endLine": 193
+      "startLine": 249,
+      "endLine": 267
     },
     "type": "technique",
     "title": "Galois Group Order Bounds: 5 | |Gal| and |Gal| | 120",
@@ -149,12 +149,12 @@
     "id": "ann-abeloq04oq01-evaluations",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 233,
-      "endLine": 260
+      "startLine": 273,
+      "endLine": 299
     },
     "type": "technique",
     "title": "Polynomial Evaluations: Sign Changes Locating 3 Real Roots",
-    "content": "Formally computes $p(-2) = -22$, $p(-1) = 5$, $p(0) = 2$, $p(1) = -1$, $p(2) = 26$ using `unfold p; simp [...]; ring`. The three sign changes $(-22 \\to 5, 2 \\to -1, -1 \\to 26)$ locate real roots in $(-2,-1)$, $(0,1)$, and $(1,2)$ by the intermediate value theorem. Combined with the derivative $p'(x) = 5x^4 - 4$ having exactly 2 real critical points, $p$ has exactly 3 real roots and 2 complex conjugate roots. This is the computational foundation for the axiom $|\\text{Gal}| = 120$: complex conjugation swaps the 2 non-real roots (a transposition), which together with a 5-cycle generates $S_5$.",
+    "content": "Formally computes $p(-2) = -22$, $p(-1) = 5$, $p(0) = 2$, $p(1) = -1$, $p(2) = 26$ using `unfold p; simp [...]; ring`. The three sign changes $(-22 \\to 5, 2 \\to -1, -1 \\to 26)$ locate real roots in $(-2,-1)$, $(0,1)$, and $(1,2)$ by the intermediate value theorem. Combined with the derivative $p'(x) = 5x^4 - 4$ having exactly 2 real critical points, $p$ has exactly 3 real roots and 2 complex conjugate roots. This is computational support for the theorem $|\\text{Gal}| = 120$: complex conjugation swaps the 2 non-real roots (a transposition), which together with the Sylow elimination argument establishes the full Galois group.",
     "mathContext": "$p(-2) = -22 < 0$, $p(-1) = 5 > 0$, $p(0) = 2 > 0$, $p(1) = -1 < 0$, $p(2) = 26 > 0$. Three sign changes $\\Rightarrow$ at least 3 real roots. $p'(x) = 5x^4 - 4$ has 2 real roots $\\Rightarrow$ at most 3 real roots. Therefore exactly 3 real, 2 complex conjugate roots.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -174,8 +174,8 @@
     "id": "ann-abeloq04oq01-group-theory",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 262,
-      "endLine": 365
+      "startLine": 321,
+      "endLine": 393
     },
     "type": "technique",
     "title": "5-Cycle + Transposition Generates S₅ (closure_cycle_swap_eq_top) [Vestigial]",
@@ -201,8 +201,8 @@
     "id": "ann-abeloq04oq01-galtoperm5",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 360,
-      "endLine": 405
+      "startLine": 420,
+      "endLine": 439
     },
     "type": "technique",
     "title": "galToPerm5: Injection Infrastructure from Gal to S₅",
@@ -226,8 +226,8 @@
     "id": "ann-abeloq04oq01-proof-strategy",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 580,
-      "endLine": 612
+      "startLine": 635,
+      "endLine": 682
     },
     "type": "concept",
     "title": "Proof Decomposition: Discriminant + Sylow Strategy",
@@ -235,24 +235,24 @@
     "mathContext": "Thread A: $\\Delta^2 = \\text{disc}(p) = -212144 < 0 \\Rightarrow \\Delta \\notin \\mathbb{Q} \\Rightarrow \\exists \\sigma, \\text{sign}(\\sigma) = -1$ (FTGT argument). Thread B: $3 \\mid |\\text{Gal}|$ (proved by Sylow elimination of orders 5, 10, 20, 40).",
     "significance": "key",
     "relatedConcepts": [
-      "Dedekind's theorem",
-      "Frobenius element",
-      "cycle type",
+      "Vandermonde determinant",
       "discriminant",
-      "Vandermonde determinant"
+      "complex conjugation",
+      "Sylow theory",
+      "FTGT (Fundamental Theorem of Galois Theory)"
     ],
     "prerequisites": [
-      "mod-p factorization of polynomials",
       "discriminant-Vandermonde identity",
-      "Galois action on Δ"
+      "Galois action on Δ",
+      "Sylow theorems"
     ]
   },
   {
     "id": "ann-abeloq04oq01-vandermonde",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 631,
-      "endLine": 710
+      "startLine": 635,
+      "endLine": 826
     },
     "type": "technique",
     "title": "Vandermonde Product Infrastructure and Permutation Identity",
@@ -277,12 +277,12 @@
     "id": "ann-abeloq04oq01-iso",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 958,
-      "endLine": 987
+      "startLine": 1489,
+      "endLine": 1515
     },
     "type": "insight",
     "title": "Gal(p/Q) = S_5 via galActionHom Bijectivity",
-    "content": "The central isomorphism: $\\text{Gal}(p/\\mathbb{Q}) \\cong S_5$. The proof proceeds in three steps: (1) `galActionHom` is injective (Mathlib), (2) $|\\text{Gal}| = 120 = |\\text{Perm}(\\text{rootSet})|$ (axiom + root set card), so `galActionHom` is bijective by the pigeonhole principle (`Fintype.bijective_iff_injective_and_card`), (3) transfer from $\\text{Perm}(\\text{rootSet})$ to $\\text{Perm}(\\text{Fin}\\;5)$ via `Equiv.permCongr`. The `MulEquiv.ofBijective` constructor packages the bijective homomorphism as a group isomorphism.",
+    "content": "The central isomorphism: $\\text{Gal}(p/\\mathbb{Q}) \\cong S_5$. The proof proceeds in three steps: (1) `galActionHom` is injective (Mathlib), (2) $|\\text{Gal}| = 120 = |\\text{Perm}(\\text{rootSet})|$ (`gal_card_eq_120` + root set card), so `galActionHom` is bijective by the pigeonhole principle (`Fintype.bijective_iff_injective_and_card`), (3) transfer from $\\text{Perm}(\\text{rootSet})$ to $\\text{Perm}(\\text{Fin}\\;5)$ via `Equiv.permCongr`. The `MulEquiv.ofBijective` constructor packages the bijective homomorphism as a group isomorphism.",
     "mathContext": "$\\text{galActionHom}: \\text{Gal}(p/\\mathbb{Q}) \\hookrightarrow \\text{Perm}(\\text{rootSet})$. Injective + $|\\text{Gal}| = |\\text{Perm}(\\text{rootSet})| = 120$ $\\Rightarrow$ bijective $\\Rightarrow$ $\\text{Gal}(p/\\mathbb{Q}) \\cong S_5$.",
     "significance": "key",
     "relatedConcepts": [
@@ -302,8 +302,8 @@
     "id": "ann-abeloq04oq01-nonsolvable",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 993,
-      "endLine": 1006
+      "startLine": 1521,
+      "endLine": 1534
     },
     "type": "technique",
     "title": "Non-Solvability: S_5 to Gal Transfer",
@@ -327,8 +327,8 @@
     "id": "ann-abeloq04oq01-main",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 1025,
-      "endLine": 1041
+      "startLine": 1558,
+      "endLine": 1569
     },
     "type": "insight",
     "title": "Abel-Ruffini Conclusion: Roots Not Solvable by Radicals",
@@ -352,8 +352,8 @@
     "id": "ann-abeloq04oq01-realizability",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 1047,
-      "endLine": 1058
+      "startLine": 1575,
+      "endLine": 1601
     },
     "type": "insight",
     "title": "S_5 Realizability as a Galois Group over Q",
@@ -377,8 +377,8 @@
     "id": "ann-abeloq04oq01-sylow-no15",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 401,
-      "endLine": 530
+      "startLine": 449,
+      "endLine": 609
     },
     "type": "technique",
     "title": "Sylow Theory: No Subgroups of Order 15 or 30 in S₅",
@@ -403,8 +403,8 @@
     "id": "ann-abeloq04oq01-proof-decomposition",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 532,
-      "endLine": 612
+      "startLine": 635,
+      "endLine": 908
     },
     "type": "concept",
     "title": "Three Proof Components: Vandermonde, Complex Conjugation, Sylow",
@@ -430,12 +430,12 @@
     "id": "ann-abeloq04oq01-gal-card-ne60",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 863,
-      "endLine": 917
+      "startLine": 1452,
+      "endLine": 1480
     },
     "type": "technique",
     "title": "|Gal| ≠ 60: Excluding A₅ via Odd Permutation",
-    "content": "The most intricate case elimination: $|\\text{Gal}| \\neq 60$. A subgroup of $S_5$ of order 60 must be contained in $A_5$ (the unique index-2 subgroup). Proof by contradiction: if some element of the Galois image lies outside $A_5$, then the sign homomorphism $\\text{signG}: \\text{Gal} \\to \\mathbb{Z}^\\times$ has a non-trivial kernel $K = \\text{Gal} \\cap A_5$ of index 2, hence $|K| = 30$. But `no_subgroup_order_30` shows $S_5$ has no subgroup of order 30 — contradiction. This forces all Galois elements into $A_5$, contradicting Axiom B (`gal_has_odd_perm`). The argument elegantly bootstraps the order-30 impossibility into the order-60 case.",
+    "content": "The most intricate case elimination: $|\\text{Gal}| \\neq 60$. A subgroup of $S_5$ of order 60 must be contained in $A_5$ (the unique index-2 subgroup). Proof by contradiction: if some element of the Galois image lies outside $A_5$, then the sign homomorphism $\\text{signG}: \\text{Gal} \\to \\mathbb{Z}^\\times$ has a non-trivial kernel $K = \\text{Gal} \\cap A_5$ of index 2, hence $|K| = 30$. But `no_subgroup_order_30` shows $S_5$ has no subgroup of order 30 — contradiction. This forces all Galois elements into $A_5$, contradicting `gal_has_odd_perm`. The argument elegantly bootstraps the order-30 impossibility into the order-60 case.",
     "mathContext": "$|\\text{Gal}| = 60 \\Rightarrow \\text{Im}(\\text{galToPerm5}) \\leq A_5$ (unique order-60 subgroup). But $\\exists \\sigma \\in \\text{Gal}$ with $\\text{sign}(\\text{galToPerm5}(\\sigma)) = -1$ (`gal_has_odd_perm`), contradiction.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -455,8 +455,8 @@
     "id": "ann-abeloq04oq01-gal-card-theorem",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 700,
-      "endLine": 753
+      "startLine": 1452,
+      "endLine": 1480
     },
     "type": "theorem",
     "title": "Main Theorem: |Gal| = 120 (Fully Proved)",
@@ -480,8 +480,8 @@
     "id": "ann-abeloq04oq01-odd-perm",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 720,
-      "endLine": 819
+      "startLine": 827,
+      "endLine": 908
     },
     "type": "technique",
     "title": "Galois Group Contains an Odd Permutation (Discriminant Sign Argument)",
@@ -507,8 +507,8 @@
     "id": "ann-abeloq04oq01-case-elim",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 821,
-      "endLine": 862
+      "startLine": 1353,
+      "endLine": 1451
     },
     "type": "technique",
     "title": "Case Elimination: |Gal| ≠ 15 and |Gal| ≠ 30",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -137,7 +137,7 @@
     {
       "targetId": "lagrange-theorem",
       "relationship": "foundational",
-      "description": "Lagrange's theorem ($|H|$ divides $|G|$ for $H \\leq G$) underpins the entire order-elimination strategy: $5 \\mid |\\text{Gal}|$ (orbit-stabilizer), $|\\text{Gal}| \\mid 120$ (embedding into $S_5$), and the Dedekind argument ($3 \\mid |\\text{Gal}|$ because the Frobenius element has order divisible by 3)"
+      "description": "Lagrange's theorem ($|H|$ divides $|G|$ for $H \\leq G$) underpins the entire order-elimination strategy: $5 \\mid |\\text{Gal}|$ (orbit-stabilizer for transitive action on 5 roots), $|\\text{Gal}| \\mid 120$ (embedding into $S_5$ via `galActionHom`), and the Sylow elimination argument that narrows candidate orders to $\\{15, 30, 60, 120\\}$"
     },
     {
       "targetId": "nth-root-irrational",
@@ -151,7 +151,7 @@
     }
   ],
   "overview": {
-    "historicalContext": "The Abel-Ruffini theorem has a dramatic history. Ruffini (1799) gave the first incomplete proof that the general quintic is unsolvable by radicals, but his argument had gaps in the treatment of permutation groups. Abel (1824) provided the first rigorous proof, showing no universal radical formula exists for degree 5 or higher. Galois (1832, published posthumously after his death in a duel at age 20) gave the definitive framework: a polynomial is solvable by radicals if and only if its Galois group is solvable. Since $S_5$ is not solvable (because $A_5$ is simple and non-abelian), any polynomial with Galois group $S_5$ has unsolvable roots.\n\nThe polynomial $x^5 - 4x + 2$ is a standard textbook example appearing in Dummit-Foote, Artin, and Lang, chosen because Eisenstein's criterion gives easy irreducibility and derivative analysis shows exactly 3 real roots. Eisenstein's criterion itself was published by Gotthold Eisenstein in 1850 in Crelle's Journal — the same journal that published Abel's refined proof in 1826. Eisenstein, who died of tuberculosis at age 29 (like Abel at 26), provided what Gauss called the simplest and most elegant irreducibility test. The criterion that $p$ divides all non-leading coefficients but $p^2$ does not divide the constant term remains the most frequently used irreducibility tool in textbooks.\n\nThe Galois group computation in this formalization uses Dedekind's theorem (1882): the cycle type of the Frobenius automorphism at a prime $p$ of good reduction matches the degree partition of the mod-$p$ factorization. Richard Dedekind, who also coined the term 'field' (Körper) and developed the ideal theory underlying Eisenstein's criterion, published this theorem as part of his foundational work on algebraic number theory. Here, reduction modulo 13 gives factorization $(x-2)(x-5)(x^3+7x^2+8)$ with cycle type $(1,1,3)$, establishing $3 \\mid |\\text{Gal}|$.\n\nThis formalization bridges abstract impossibility to a concrete witness: these five specific complex numbers cannot be written using radicals.",
+    "historicalContext": "The Abel-Ruffini theorem has a dramatic history. Ruffini (1799) gave the first incomplete proof that the general quintic is unsolvable by radicals, but his argument had gaps in the treatment of permutation groups. Abel (1824) provided the first rigorous proof, showing no universal radical formula exists for degree 5 or higher. Galois (1832, published posthumously after his death in a duel at age 20) gave the definitive framework: a polynomial is solvable by radicals if and only if its Galois group is solvable. Since $S_5$ is not solvable (because $A_5$ is simple and non-abelian), any polynomial with Galois group $S_5$ has unsolvable roots.\n\nThe polynomial $x^5 - 4x + 2$ is a standard textbook example appearing in Dummit-Foote, Artin, and Lang, chosen because Eisenstein's criterion gives easy irreducibility and derivative analysis shows exactly 3 real roots. Eisenstein's criterion itself was published by Gotthold Eisenstein in 1850 in Crelle's Journal — the same journal that published Abel's refined proof in 1826. Eisenstein, who died of tuberculosis at age 29 (like Abel at 26), provided what Gauss called the simplest and most elegant irreducibility test. The criterion that $p$ divides all non-leading coefficients but $p^2$ does not divide the constant term remains the most frequently used irreducibility tool in textbooks.\n\nThe classical textbook approach to computing the Galois group of a specific quintic uses Dedekind's theorem (1882) — the cycle type of the Frobenius automorphism matches the mod-$p$ factorization — to establish divisibility conditions on $|\\text{Gal}|$. This formalization takes a different route: it establishes $\\text{Gal} \\not\\subset A_5$ via the Vandermonde discriminant ($\\Delta^2 = -212144 < 0$, so the Fundamental Theorem of Galois Theory forces an odd permutation), obtains a transposition via complex conjugation (embedding the splitting field into $\\mathbb{C}$ via `IsAlgClosed.lift` and composing with `starRingEnd`), and then eliminates non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$ via Sylow theory. This approach avoids all mod-$p$ arithmetic and works purely within algebraic and group-theoretic methods.\n\nThis formalization bridges abstract impossibility to a concrete witness: these five specific complex numbers cannot be written using radicals.",
     "problemStatement": "Prove that the polynomial $x^5 - 4x + 2$ has Galois group $S_5$ over $\\mathbb{Q}$, and conclude that its roots cannot be expressed using radicals.",
     "text": "This file completes the Abel-Ruffini proof chain by providing a concrete polynomial whose roots are provably unsolvable by radicals. The polynomial x⁵ - 4x + 2 is shown irreducible via Eisenstein's criterion at p=2, and its Galois group is identified as S₅ via the galActionHom bijectivity argument. Since S₅ is not solvable, Galois's theorem implies the roots cannot be expressed by radicals.",
     "proofStrategy": "The proof has four main stages:\n\n**1. Irreducibility** (Part II): Eisenstein's criterion at the prime ideal $(2) \\subset \\mathbb{Z}$ shows $x^5 - 4x + 2$ is irreducible over $\\mathbb{Z}$: all non-leading coefficients $(0, 0, 0, -4, 2)$ are divisible by 2, the constant term 2 is not divisible by 4, and the leading coefficient 1 is coprime to 2. Gauss's lemma (monic $\\Rightarrow$ primitive) transfers irreducibility from $\\mathbb{Z}[X]$ to $\\mathbb{Q}[X]$.\n\n**2. Galois group identification** (Parts III-VI): The `galActionHom` embeds $\\text{Gal}$ into $\\text{Perm}(\\text{rootSet}) \\cong S_5$ (injective by Mathlib). Establishing $|\\text{Gal}| = 120$ proceeds by elimination: (a) $5 \\mid |\\text{Gal}|$ by orbit-stabilizer (irreducible of prime degree gives transitive action), (b) $\\text{Gal} \\not\\subset A_5$ via the discriminant sign argument: the Vandermonde product $\\Delta$ satisfies $\\Delta^2 = \\text{disc}(p) = -212144 < 0$ (proved from the derivative product identity), so by FTGT if all Galois automorphisms were even then $\\Delta \\in \\mathbb{Q}$, contradicting $\\Delta^2 < 0$; thus `gal_has_odd_perm` establishes a transposition in the Galois image, (c) $3 \\mid |\\text{Gal}|$ by eliminating non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$ via Sylow theory: a transposition cannot normalize the unique Sylow 5-subgroup in groups of these orders, (d) Sylow theory eliminates orders 15 (unique $P_3, P_5$ force cyclic, impossible in $S_5$) and 30 ($A_5$ simplicity), (e) order 60 eliminated because $\\text{Gal} \\not\\subset A_5$ by step (b). Only $|\\text{Gal}| = 120$ remains. Bijectivity of `galActionHom` follows by the pigeonhole principle.\n\n**3. Non-solvability transfer** (Part VII): $S_5$ is not solvable (Mathlib's `Equiv.Perm.not_solvable`, since $A_5$ is simple). The isomorphism $\\text{Gal} \\cong S_5$ transfers non-solvability via `solvable_of_surjective`.\n\n**4. Abel-Ruffini conclusion** (Part VIII): By contrapositive of Galois's theorem (`solvableByRad.isSolvable'`), non-solvable Galois group implies roots are not expressible by radicals.",
@@ -169,111 +169,111 @@
       "Abstract algebra (groups, solvable groups, symmetric groups)",
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Polynomial algebra (irreducibility criteria, Eisenstein criterion)",
-      "Number theory (p-adic valuations, reduction modulo primes)"
+      "Sylow theory (Sylow subgroup existence, uniqueness, and counting)"
     ]
   },
   "sections": [
     {
       "id": "header",
-      "title": "Problem Overview and Proof Chain",
+      "title": "Problem Overview, Proof Chain, and Vestigial Lemmas",
       "startLine": 1,
-      "endLine": 91,
-      "summary": "Documents the complete Abel-Ruffini proof chain and motivation for choosing $x^5 - 4x + 2$. Lists all 5 steps from $A_5$ simplicity to unsolvability by radicals. Opens namespace and imports Mathlib.",
+      "endLine": 133,
+      "summary": "Documents the complete Abel-Ruffini proof chain and motivation for choosing $x^5 - 4x + 2$. Lists all 5 steps from $A_5$ simplicity to unsolvability by radicals. Includes vestigial computational lemmas (mod-13 facts, normalizer computations) from earlier proof strategies. Opens namespace and imports Mathlib.",
       "mathContext": "Proof chain: (1) $A_5$ simple, (2) $S_n$ not solvable for $n \\geq 5$, (3) solvable by radicals $\\Rightarrow$ solvable Gal, (4) $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$, (5) roots not expressible by radicals."
     },
     {
       "id": "polynomial",
       "title": "Part I: The Polynomial p = X⁵ - 4X + 2",
-      "startLine": 96,
-      "endLine": 105,
+      "startLine": 135,
+      "endLine": 143,
       "summary": "Defines $p = X^5 - 4X + 2$ over $\\mathbb{Q}$ and its $\\mathbb{Z}[X]$ version `p_int` for Eisenstein criterion application.",
       "mathContext": "$p(x) = x^5 - 4x + 2 \\in \\mathbb{Q}[X]$, $p_{\\text{int}} = x^5 - 4x + 2 \\in \\mathbb{Z}[X]$."
     },
     {
       "id": "irreducibility",
       "title": "Part II: Irreducibility via Eisenstein at p = 2",
-      "startLine": 106,
-      "endLine": 181,
+      "startLine": 145,
+      "endLine": 219,
       "summary": "Proves $p$ is irreducible over $\\mathbb{Q}$. First proves irreducibility over $\\mathbb{Z}$ using Eisenstein's criterion at the prime ideal $(2)$, then transfers to $\\mathbb{Q}$ via Gauss's lemma (monic $\\Rightarrow$ primitive).",
       "mathContext": "Eisenstein at $(2) \\subset \\mathbb{Z}$: $2 \\nmid 1$, $2 \\mid 0, 0, 0, -4, 2$, $4 \\nmid 2$. Therefore $p$ is irreducible over $\\mathbb{Z}$, hence over $\\mathbb{Q}$ by Gauss's lemma."
     },
     {
       "id": "structure",
       "title": "Part III: Basic Structural Properties",
-      "startLine": 182,
-      "endLine": 205,
+      "startLine": 220,
+      "endLine": 243,
       "summary": "Proves $\\deg(p) = 5$, $p$ is monic, $p$ is separable (char 0), and $|\\text{rootSet}(p)| = 5$.",
       "mathContext": "$\\deg(p) = 5$, $p$ monic and separable. In the splitting field: $|\\{\\alpha : p(\\alpha) = 0\\}| = 5$."
     },
     {
       "id": "galois-structure",
       "title": "Part IV: Galois Group Structure",
-      "startLine": 206,
-      "endLine": 229,
+      "startLine": 244,
+      "endLine": 267,
       "summary": "Proves $5 \\mid |\\text{Gal}|$ (prime degree gives transitive action, orbit-stabilizer) and $|\\text{Gal}| \\mid 120$ (galActionHom embeds $\\text{Gal}$ into $S_5$). Together: $|\\text{Gal}| \\in \\{5, 10, 15, 20, 30, 40, 60, 120\\}$.",
       "mathContext": "$5 \\mid |\\text{Gal}|$ and $|\\text{Gal}| \\mid 5! = 120$. Possible orders: $\\{5, 10, 15, 20, 30, 40, 60, 120\\}$."
     },
     {
       "id": "gal-order",
       "title": "Parts V(a)-(f): Galois Group Order |Gal| = 120 (Theorem)",
-      "startLine": 233,
-      "endLine": 952,
-      "summary": "The largest section (720 lines): proves $|\\text{Gal}| = 120$ via systematic case elimination. (a) Lines 233-260: polynomial evaluations showing 3 sign changes. (b) Lines 262-365: `closure_cycle_swap_eq_top` — 5-cycle + transposition generates $S_5$ via `native_decide` conjugation. (c) Lines 366-405: `galToPerm5` injection from $\\text{Gal}$ to $S_5$. (d) Lines 406-530: Sylow elimination of orders 15 and 30. (e) Lines 532-819: Dedekind's theorem, discriminant sign, Vandermonde machinery, and `gal_has_odd_perm`. (f) Lines 821-952: case elimination and `gal_card_eq_120`. Fully proved with 0 axioms.",
+      "startLine": 268,
+      "endLine": 1480,
+      "summary": "The largest section (~1200 lines): proves $|\\text{Gal}| = 120$ via systematic case elimination. (a) Lines 268-299: polynomial evaluations showing 3 sign changes. (b) Lines 301-393: `closure_cycle_swap_eq_top` — 5-cycle + transposition generates $S_5$ [vestigial]. (c) Lines 394-439: `galToPerm5` injection from $\\text{Gal}$ to $S_5$. (d) Lines 440-609: Sylow elimination of orders 15 and 30. (e) Lines 610-908: Vandermonde machinery, discriminant sign, and `gal_has_odd_perm`. (e2) Lines 909-1341: complex conjugation gives transposition, Sylow elimination of non-3-divisible orders. (f) Lines 1348-1480: case elimination and `gal_card_eq_120`. Fully proved with 0 axioms.",
       "mathContext": "Theorem: $|\\text{Gal}(x^5-4x+2/\\mathbb{Q})| = 120$. From $5 \\mid |G|$, $3 \\mid |G|$, $|G| \\mid 120$: $|G| \\in \\{15,30,60,120\\}$. Not 15 (Sylow), not 30 ($A_5$ simple), not 60 ($\\text{Gal} \\not\\subset A_5$ by discriminant sign). All steps fully proved."
     },
     {
       "id": "gal-iso",
       "title": "Part VI: Gal(p/ℚ) ≅ S₅",
-      "startLine": 954,
-      "endLine": 987,
+      "startLine": 1481,
+      "endLine": 1515,
       "summary": "Proves `gal_iso_s5`: $\\text{Gal} \\cong S_5$ via galActionHom bijectivity. Injective (Mathlib's `galActionHom_injective`) + $|\\text{Gal}| = |\\text{Perm}(\\text{rootSet})| = 120$ from `gal_card_eq_120`. Bijectivity via `Fintype.bijective_iff_injective_and_card`. Transfer from $\\text{Perm}(\\text{rootSet})$ to $\\text{Perm}(\\text{Fin}\\;5)$ via `Equiv.permCongr`.",
       "mathContext": "$\\text{galActionHom}$ injective + $|\\text{Gal}| = |S_5| = 120$ $\\Rightarrow$ bijective $\\Rightarrow$ $\\text{Gal}(p/\\mathbb{Q}) \\cong S_5$."
     },
     {
       "id": "not-solvable",
       "title": "Part VII: Non-Solvability",
-      "startLine": 989,
-      "endLine": 1006,
+      "startLine": 1516,
+      "endLine": 1534,
       "summary": "`s5_not_solvable`: $S_5$ not solvable via `Equiv.Perm.not_solvable` with $5 \\leq |\\text{Fin}\\;5|$. `gal_not_solvable`: transfers non-solvability from $S_5$ to $\\text{Gal}$ via the surjective `MulEquiv` from Part VI using `solvable_of_surjective`.",
       "mathContext": "$S_5$ not solvable (derived series stalls at $A_5$). $\\text{Gal} \\cong S_5 \\Rightarrow \\text{Gal}$ not solvable."
     },
     {
       "id": "abel-ruffini-conclusion",
       "title": "Part VIII: Abel-Ruffini Conclusion",
-      "startLine": 1008,
-      "endLine": 1041,
+      "startLine": 1535,
+      "endLine": 1569,
       "summary": "Main theorem `roots_not_solvable_by_rad`: for any root $\\alpha$ of $x^5 - 4x + 2$, $\\alpha \\notin \\text{solvableByRad}(\\mathbb{Q})$. Proof: assume $\\alpha$ solvable by radicals; by `solvableByRad.isSolvable'` with `p_irreducible` and `hroot`, $\\text{Gal}(p)$ is solvable — contradicting `gal_not_solvable`.",
       "mathContext": "$\\alpha \\in \\text{Rad}(\\mathbb{Q}) \\Rightarrow \\text{Gal}(p/\\mathbb{Q})$ solvable $\\Rightarrow S_5$ solvable $\\Rightarrow \\bot$."
     },
     {
       "id": "three-dvd-proved",
       "title": "Part V(d2): three_dvd_gal_card as Theorem (formerly Axiom A)",
-      "startLine": 1098,
-      "endLine": 1131,
+      "startLine": 1313,
+      "endLine": 1341,
       "summary": "Proves `three_dvd_gal_card`: $3 \\mid |\\text{Gal}|$ by eliminating all non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$. Order 5 eliminated by sign argument (order-5 permutations in $S_5$ are even). Order 20 eliminated by `gal_card_ne_20` (F₂₀ has no transpositions but Gal does). Orders 10 and 40 eliminated via Sylow theory. All cases fully proved.",
       "mathContext": "$|\\text{Gal}| \\in \\{5,10,15,20,30,40,60,120\\}$. Not 5 (sign), not 10, 20, 40 (Sylow/transposition arguments). Remaining: $\\{15,30,60,120\\}$ — all divisible by 3."
     },
     {
       "id": "vandermonde-infrastructure",
-      "title": "Part V(e2): Vandermonde and Discriminant Infrastructure",
-      "startLine": 1133,
-      "endLine": 1530,
+      "title": "Part V(e)+(e2): Vandermonde, Complex Conjugation, and Discriminant Infrastructure",
+      "startLine": 610,
+      "endLine": 1341,
       "summary": "Root enumeration (`rootEnum_p`), Vandermonde product $\\Delta = \\det(V(\\text{roots}))$, Galois permutation of roots, Vandermonde permutation identity ($\\sigma(\\Delta) = \\text{sign}(\\sigma) \\cdot \\Delta$), and `gal_has_odd_perm` proved via the discriminant sign argument ($\\text{disc}(p) < 0$ implies $\\Delta \\notin \\mathbb{Q}$, so some $\\sigma$ has odd sign).",
       "mathContext": "$\\Delta = \\prod_{i<j}(\\alpha_j - \\alpha_i)$. $\\sigma(\\Delta) = \\text{sign}(\\sigma) \\cdot \\Delta$. If all signs $+1$, $\\Delta \\in \\mathbb{Q}$ but $\\Delta^2 < 0$ — contradiction."
     },
     {
-      "id": "abel-ruffini-conclusion-extended",
-      "title": "Part VIII (extended): Abel-Ruffini Conclusion",
-      "startLine": 1530,
-      "endLine": 1560,
-      "summary": "Main theorem `roots_not_solvable_by_rad`: for any root $\\alpha$ of $x^5 - 4x + 2$ in any field extension, $\\alpha \\notin \\text{solvableByRad}(\\mathbb{Q})$.",
-      "mathContext": "$\\forall \\alpha: p(\\alpha) = 0 \\Rightarrow \\alpha \\notin \\text{Rad}(\\mathbb{Q})$."
+      "id": "gal-card-120",
+      "title": "Part V(f): |Gal(p/ℚ)| = 120 (Case Elimination)",
+      "startLine": 1348,
+      "endLine": 1480,
+      "summary": "Proves `gal_card_eq_120`: $|\\text{Gal}| = 120$ by combining $15 \\mid |\\text{Gal}|$ (from `five_dvd_gal_card` and `three_dvd_gal_card`) with elimination of orders 15 (Sylow), 30 ($A_5$ simplicity), and 60 (odd permutation). Only 120 remains.",
+      "mathContext": "$15 \\mid |G|$, $|G| \\mid 120$: $|G| \\in \\{15,30,60,120\\}$. Not 15, 30, 60 $\\Rightarrow |G| = 120$."
     },
     {
       "id": "realizability",
       "title": "Part IX: $S_5$ Realizability and Verification",
-      "startLine": 1562,
-      "endLine": 1593,
+      "startLine": 1570,
+      "endLine": 1601,
       "summary": "`s5_realizable`: $S_5$ is realizable as a Galois group over $\\mathbb{Q}$, witnessed by the splitting field of $x^5 - 4x + 2$. Lines 1583-1591: `#check` verification of all 9 key theorems.",
       "mathContext": "$\\exists K/\\mathbb{Q}$ Galois: $\\text{Gal}(K/\\mathbb{Q}) \\cong S_5$. Witness: $K = $ splitting field of $x^5 - 4x + 2$."
     }


### PR DESCRIPTION
Enrichment pass for abel-ruffini-oq-04-oq-01 (Concrete Abel-Ruffini: Gal(x⁵-4x+2) ≅ S₅).

## Changes

**meta.json:**
- Updated `historicalContext` to accurately describe the axiom-free proof (complex conjugation + Sylow) rather than the superseded Dedekind approach
- Fixed all 13 section line ranges to match current 1601-line Lean file
- Updated `overview.prerequisites` (Sylow theory replaces mod-p number theory)
- Fixed `lagrange-theorem` cross-reference (removed stale Dedekind/Frobenius language)

**annotations.json:**
- Fixed all 21 annotation line ranges — many were shifted 40-700+ lines from actual code
- Adjusted startLines to point to actual Lean constructs (eliminates "No Lean construct found" warnings)
- Removed stale "axiom" references in 3 annotations (evaluations, iso, gal-card-ne60)
- Updated `relatedConcepts` and `prerequisites` for proof-strategy annotation (Dedekind/Frobenius/mod-p → Vandermonde/complex conjugation/Sylow/FTGT)

All peer review action items (ai-1 through ai-6, ai-9) were already resolved; this pass addresses the remaining precision issues noted in the review.