### PR TITLE
Research: erdos-317 — Prove weak_inequality (1→0 axioms)

### DIFF
--- a/proofs/Proofs/Erdos317Problem.lean
+++ b/proofs/Proofs/Erdos317Problem.lean
@@ -134,9 +134,43 @@ theorem nonzero_signed_sum_exists :
 /-- Each term δ_k/(k+1) in the signed sum has denominator dividing lcm(1,...,n).
     When the sum is expressed over this common denominator, a nonzero sum
     has numerator with absolute value ≥ 1, giving |sum| ≥ 1/lcm(1,...,n). -/
-axiom weak_inequality (n : ℕ) (δ : Fin n → ℤ) (hδ : IsSignFunction n δ)
+theorem weak_inequality (n : ℕ) (δ : Fin n → ℤ) (_hδ : IsSignFunction n δ)
     (hne : signedUnitFractionSum n δ ≠ 0) :
-    |signedUnitFractionSum n δ| ≥ 1 / (lcm_1_to_n n : ℚ)
+    |signedUnitFractionSum n δ| ≥ 1 / (lcm_1_to_n n : ℚ) := by
+  set L := lcm_1_to_n n
+  set S := signedUnitFractionSum n δ
+  -- Trivial if L = 0 (then 1/0 = 0 in ℚ, and |S| ≥ 0)
+  by_cases hL : (L : ℚ) = 0
+  · simp only [hL, div_zero]; exact abs_nonneg _
+  have hLQ_pos : (0 : ℚ) < L := lt_of_le_of_ne (Nat.cast_nonneg L) (Ne.symm hL)
+  -- Key: L * S is an integer (since each (k+1) divides L)
+  have ⟨m, hm⟩ : ∃ m : ℤ, (L : ℚ) * S = m := by
+    simp only [S, signedUnitFractionSum, Finset.mul_sum]
+    suffices h : ∀ k : Fin n, ∃ m : ℤ,
+        (L : ℚ) * ((δ k : ℚ) / ((k.val : ℚ) + 1)) = m from by
+      choose f hf using h
+      exact ⟨∑ k, f k, by simp_rw [hf, ← Int.cast_sum]⟩
+    intro k
+    obtain ⟨c, hc⟩ := Finset.dvd_lcm (f := (· + 1))
+      (show k.val ∈ Finset.range n from Finset.mem_range.mpr k.isLt)
+    exact ⟨δ k * c, by
+      have hkne : ((k.val : ℚ) + 1) ≠ 0 := by positivity
+      have hLc : (L : ℚ) = ((k.val : ℚ) + 1) * (c : ℚ) := by exact_mod_cast hc
+      rw [hLc]; field_simp; push_cast; ring⟩
+  -- S ≠ 0 and L ≠ 0 imply m ≠ 0
+  have hm_ne : m ≠ 0 := by
+    intro h; apply hne
+    have : (L : ℚ) * S = 0 := by simp [hm, h]
+    exact (mul_eq_zero.mp this).resolve_left (ne_of_gt hLQ_pos)
+  -- Conclude: |S| ≥ 1/L, since |S| * L = |m| ≥ 1
+  rw [ge_iff_le, div_le_iff₀ hLQ_pos]
+  calc (1 : ℚ) ≤ |(m : ℚ)| := by
+          exact_mod_cast (show (1 : ℤ) ≤ |m| by
+            rcases le_or_gt 0 m with h | h
+            · rw [abs_of_nonneg h]; omega
+            · rw [abs_of_neg h]; omega)
+    _ = |(L : ℚ) * S| := by congr 1; exact hm.symm
+    _ = |S| * L := by rw [abs_mul, abs_of_pos hLQ_pos, mul_comm]
 
 /- ## Part VI: Summary -/
 

--- a/src/data/proofs/erdos-317/meta.json
+++ b/src/data/proofs/erdos-317/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham [ErGr80]",
     "sourceUrl": "https://erdosproblems.com/317",
     "date": "1980",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos317Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "diophantine-approximation",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 317,
     "erdosUrl": "https://erdosproblems.com/317",
@@ -47,20 +47,20 @@
       "Question1: formal statement of the c/2^n conjecture",
       "lcm_1_to_n: LCM of {1,...,n} via Finset.lcm",
       "Question2: formal statement of 1/lcm strict lower bound",
-      "weak_inequality axiom: |sum| ≥ 1/lcm when nonzero",
-      "counterexample_small_n axiom: equality at n=4",
-      "kovac_van_doorn_bound axiom: nonzero signed sums exist",
+      "weak_inequality theorem (PROVED): |sum| ≥ 1/lcm when nonzero — denominator divisibility argument via Finset.dvd_lcm",
+      "counterexample_small_n theorem: equality at n=4 via native_decide",
+      "nonzero_signed_sum_exists theorem: trivially via harmonic number (allOnesDelta)",
       "erdos_317_summary: proved — combining weak inequality and counterexample"
     ],
-    "axiomCount": 1,
-    "lineCount": 158,
-    "assumptions": "1 axiom: weak_inequality. See Lean source for the complete statement."
+    "axiomCount": 0,
+    "lineCount": 192,
+    "assumptions": "None. All theorems fully machine-checked."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #317: Signed Unit Fraction Approximations**\n\nFrom Erdős-Graham (1980), p.42. This problem asks how small a nonzero signed combination of the first n unit fractions can be.\n\n**Two Questions:**\n1. Can we achieve exponentially small sums < c/2^n for some universal constant c?\n2. For large n, is 1/lcm(1,...,n) a strict lower bound for nonzero sums?\n\n**Known Results:** Kovac and van Doorn achieved 2^{-n·(log log log n)^{1+o(1)}/log n}, far from c/2^n. Van Doorn's heuristic suggests this may be optimal, which would make Question 1 false. Question 2 fails for small n: 1/2 - 1/3 - 1/4 = -1/12 achieves exactly 1/lcm(1,2,3,4).",
     "problemStatement": "**Problem Statement (OPEN)**\n\n**Question 1:** Is there $c > 0$ such that for every $n \\geq 1$, there exist $\\delta_k \\in \\{-1, 0, 1\\}$ with $0 < |\\sum_{k=1}^n \\delta_k/k| < c/2^n$?\n\n**Question 2:** For sufficiently large $n$, must $|\\sum \\delta_k/k| > 1/\\text{lcm}(1,\\ldots,n)$ whenever the sum is nonzero?\n\n**Known:** Weak inequality $\\geq 1/\\text{lcm}$ holds trivially. Strict inequality fails for $n = 4$.",
     "text": "A 158-line formalization of Erdős Problem #317 (open, Erdős-Graham 1980) on signed unit fraction approximations. Two questions: (Q1) is there $c > 0$ such that for every $n$, signs $\\delta_k \\in \\{-1, 0, 1\\}$ exist with $0 < |\\sum_{k=1}^n \\delta_k/k| < c/2^n$? (Q2) For large $n$, must nonzero signed sums exceed $1/\\text{lcm}(1,\\ldots,n)$? Defines `IsSignFunction`, `signedUnitFractionSum`, and `signedSumAbs` using `Fin n` and `Finset.sum`. Known results axiomatized: the weak inequality $|\\sum \\delta_k/k| \\geq 1/\\text{lcm}$ (trivial), a counterexample at $n = 4$ ($1/2 - 1/3 - 1/4 = -1/12 = 1/\\text{lcm}(1,2,3,4)$), and the Kova\\v{c}-van Doorn bound achieving $2^{-n \\cdot (\\log\\log\\log n)^{1+o(1)}/\\log n}$.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Clean Definitions:** IsSignFunction, signedUnitFractionSum, signedSumAbs using Fin n and Finset.sum.\n\n2. **Both Questions as Defs:** Question1 and Question2 as Prop definitions (open problems).\n\n3. **Known Results as Axioms:** weak_inequality (denominator divisibility), counterexample_small_n (n=4 equality), kovac_van_doorn_bound (nonzero sums exist).\n\n4. **Summary Theorem:** erdos_317_summary proved from axioms, combining the weak inequality with the counterexample.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Clean Definitions:** IsSignFunction, signedUnitFractionSum, signedSumAbs using Fin n and Finset.sum.\n\n2. **Both Questions as Defs:** Question1 and Question2 as Prop definitions (open problems).\n\n3. **All Known Results Proved:** weak_inequality (denominator divisibility via Finset.dvd_lcm), counterexample_small_n (n=4 equality via native_decide), nonzero_signed_sum_exists (harmonic number positivity).\n\n4. **Summary Theorem:** erdos_317_summary proved, combining the weak inequality with the counterexample and existence result.\n\n5. **Key Proof: weak_inequality** — Shows L*S is an integer (each (k+1) divides L = lcm(1,...,n)), so nonzero S has |S| >= 1/L.",
     "keyInsights": [
       "**Exponential vs Sub-exponential:** c/2^n is exponential in n; the known Kovac-van Doorn bound 2^{-n·polylog/log n} is sub-exponential — a huge gap",
       "**Weak vs Strict:** |sum| ≥ 1/lcm is trivial (denominator divisibility); |sum| > 1/lcm (strict) is the hard question",
@@ -150,9 +150,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos317",
-    "lineCount": 158,
-    "axiomCount": 1,
-    "theoremCount": 7,
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 8,
     "definitionCount": 8
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-317.json
+++ b/src/data/research/problems/erdos-317.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-12T23:51:53.285Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Proved weak_inequality, eliminating last axiom",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: 1→0 axioms. All theorems fully machine-checked. 8 theorems, 0 axioms, 0 sorries.",
+    "builtItems": [
+      "weak_inequality theorem in Erdos317Problem.lean:137 — full proof replacing axiom"
+    ],
+    "insights": [
+      "weak_inequality proved: denominator divisibility argument via Finset.dvd_lcm shows L*S is an integer, so |S| >= 1/L when S != 0"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "No further axioms to eliminate — proof is complete"
+    ],
     "markdown": "# Erdős #317 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there some constant $c>0$ such that for every $n\\geq 1$ there exists some $\\delta_k\\in \\{-1,0,1\\}$ for $1\\leq k\\leq n$ with\\[0< \\left\\lvert \\sum_{1\\leq k\\leq n}\\frac{\\delta_k}{k}\\right\\rvert < \\frac{c}{2^n}?\\]Is it true that for sufficiently large $n$, for any $\\delta_k\\in \\{-1,0,1\\}$,\\[\\left\\lvert \\sum_{1\\leq k\\leq n}\\frac{\\delta_k}{k}\\right\\rvert > \\frac{1}{[1,\\ldots,n]}\\]whenever the left-hand side is not zero?\n\n\n\nInequality is obvious for the second claim, the problem is strict inequality. This fails for small $n$, for example\\[\\frac{1}{2}-\\frac{1}{3}-\\frac{1}{4}=-\\frac{1}{12}.\\]Arguments of Kovac and van Doorn in the comment section prove a weak version of the first question, with an upper bound of\\[2^{-n\\frac{(\\log\\log\\log n)^{1+o(1)}}{\\log n}},\\]and van Doorn gives a heuristic that suggests this may be the true order of magnitude.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #316\n- Problem #318\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
@@ -50,16 +56,16 @@
     "mathlib": []
   },
   "started": "2026-01-12T23:51:53.285Z",
-  "lastUpdate": "2026-03-13T07:52:17.045Z",
+  "lastUpdate": "2026-03-25T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos317Problem.lean",
       "filename": "Erdos317Problem.lean",
-      "lineCount": 159,
-      "theoremCount": 7,
-      "axiomCount": 1,
+      "lineCount": 192,
+      "theoremCount": 8,
+      "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

- Proved `weak_inequality` theorem for Erdős #317 (signed unit fraction approximations), eliminating the last axiom
- The proof shows `lcm(1,...,n) * ∑ δ_k/k` is an integer via `Finset.dvd_lcm`, then uses `|m| ≥ 1` for nonzero integers to conclude `|∑ δ_k/k| ≥ 1/lcm(1,...,n)`
- Fixed Mathlib v4.26.0 API changes: `div_le_iff` → `div_le_iff₀`, `le_or_lt` → `le_or_gt`

## Results

| Metric | Before | After |
|--------|--------|-------|
| Axioms | 1 | **0** |
| Sorries | 0 | 0 |
| Theorems | 7 | **8** |
| Lines | 158 | 192 |
| Status | axiomatized | **verified** |

## Test plan

- [x] `docker-build.sh Proofs.Erdos317Problem` — builds with 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)