### PR TITLE
Enrich de-moivre-oq-02: fix notation, overclaim, and theorem count

### DIFF
--- a/src/data/proofs/de-moivre-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02/meta.json
@@ -57,8 +57,8 @@
     ],
     "originalContributions": [
       "Composition identity: T_m(T_n(cos θ)) = T_{mn}(cos θ) with commutativity, identity (T_1), and associativity — demonstrating monoid-like structure on cos θ values (no Monoid instance constructed)",
-      "Product-to-sum formula: 2·T_m(x)·T_n(x) = T_{m+n}(x) + T_{m-n}(x), the Chebyshev analog of trigonometric product-to-sum",
-      "Parity: T_n(-x) = (-1)^n · T_n(x), with even/odd specializations showing T_{2n} even and T_{2n+1} odd",
+      "Product-to-sum formula: 2·T_m(cos θ)·T_n(cos θ) = T_{m+n}(cos θ) + T_{m-n}(cos θ), the Chebyshev analog of trigonometric product-to-sum",
+      "Parity: T_n(-cos θ) = (-1)^n · T_n(cos θ), with even/odd specializations showing T_{2n} even and T_{2n+1} odd on cos-values",
       "Special values: T_n(1) = 1, T_n(-1) = (-1)^n, T_n(0) = cos(nπ/2)",
       "Roots: T_n vanishes at cos((2k+1)π/(2n)) for all k ∈ ℤ"
     ],
@@ -71,7 +71,7 @@
   "overview": {
     "historicalContext": "**Beyond the Basic Identity**\n\nThe OQ-01 extension established the fundamental connection: $T_n(\\cos\\theta) = \\cos(n\\theta)$. This OQ-02 extension explores the rich algebraic structure that follows from this identity.\n\n**Composition Monoid**\n\nSince $T_m(T_n(\\cos\\theta)) = T_m(\\cos(n\\theta)) = \\cos(mn\\theta) = T_{mn}(\\cos\\theta)$, the Chebyshev polynomials form a commutative monoid under function composition. This is a remarkable algebraic structure: $T_m \\circ T_n = T_{mn}$, with $T_1$ as the identity element.\n\n**Product-to-Sum**\n\nThe identity $2T_m(x)T_n(x) = T_{m+n}(x) + T_{m-n}(x)$ is the polynomial analog of the trigonometric product-to-sum formula $2\\cos(A)\\cos(B) = \\cos(A+B) + \\cos(A-B)$. This identity is central to Chebyshev spectral methods in numerical analysis.\n\n**Parity and Roots**\n\nThe parity relation $T_n(-x) = (-1)^nT_n(x)$ shows that even-index Chebyshev polynomials are even functions and odd-index ones are odd. The roots $x_k = \\cos\\frac{(2k+1)\\pi}{2n}$ are the Chebyshev nodes, optimal for polynomial interpolation.",
     "problemStatement": "**The Open Question**\n\nCan we formalize deeper Chebyshev polynomial properties — composition, product-to-sum, parity, special values, and roots — directly from the De Moivre connection?\n\n**Answer: YES**\n\nAll properties follow elegantly from the single identity $T_n(\\cos\\theta) = \\cos(n\\theta)$ combined with standard trigonometric identities.",
-    "text": "A complete formalization of deeper Chebyshev polynomial properties derived from De Moivre's theorem: the composition identity T_m(T_n(cos θ)) = T_{mn}(cos θ), the product-to-sum formula 2·T_m(x)·T_n(x) = T_{m+n}(x) + T_{m-n}(x), parity relations T_n(-x) = (-1)^n·T_n(x), special values T_n(±1) and T_n(0), and the roots T_n(cos((2k+1)π/(2n))) = 0.",
+    "text": "A formalization of key Chebyshev polynomial properties derived from De Moivre's theorem: the composition identity T_m(T_n(cos θ)) = T_{mn}(cos θ), the product-to-sum formula 2·T_m(cos θ)·T_n(cos θ) = T_{m+n}(cos θ) + T_{m-n}(cos θ), parity relations T_n(-cos θ) = (-1)^n·T_n(cos θ), special values T_n(±1) and T_n(0), and the roots T_n(cos((2k+1)π/(2n))) = 0.",
     "proofStrategy": "**Formalization Strategy**\n\nEvery theorem follows the same pattern: (1) apply `T_real_cos` to convert Chebyshev evaluations to cosine expressions, (2) use trigonometric identities (`cos_add`, `cos_sub`, `cos_pi_sub`, etc.) to simplify, (3) close with algebraic tactics (`ring`, `linarith`, `push_cast`).\n\n1. **Composition**: Rewrite both sides via `T_real_cos`, reducing to $\\cos(m \\cdot n\\theta) = \\cos(mn \\cdot \\theta)$ which is `push_cast; ring`.\n2. **Product-to-sum**: Rewrite via `T_real_cos`, then use `cos_add` and `cos_sub` to get `linarith`.\n3. **Parity**: Bridge $-\\cos\\theta = \\cos(\\pi - \\theta)$ via `cos_pi_sub`, then `cos_int_mul_pi_sub`.\n4. **Special values**: Use $\\cos(0) = 1$, $\\cos(\\pi) = -1$, $\\cos(\\pi/2) = 0$.\n5. **Roots**: Simplify $n \\cdot \\frac{(2k+1)\\pi}{2n} = (2k+1)\\frac{\\pi}{2} = k\\pi + \\frac{\\pi}{2}$, then $\\cos(k\\pi + \\pi/2) = 0$.",
     "keyInsights": [
       "**One identity rules them all**: Every theorem reduces to T_real_cos followed by trigonometric manipulation — the power of the De Moivre bridge.",
@@ -91,7 +91,7 @@
     {
       "id": "composition",
       "title": "Composition Identity",
-      "summary": "Proves T_m(T_n(cos θ)) = T_{mn}(cos θ): Chebyshev polynomials form a commutative monoid under composition. Also proves commutativity, identity (T_1), associativity, and special cases T_2 ∘ T_n and T_n ∘ T_n.",
+      "summary": "Proves T_m(T_n(cos θ)) = T_{mn}(cos θ), demonstrating monoid-like structure of Chebyshev composition on cos θ values (no Monoid instance constructed). Also proves commutativity, identity (T_1), associativity, and special cases T_2 ∘ T_n and T_n ∘ T_n.",
       "startLine": 25,
       "endLine": 61,
       "mathContext": "$T_m \\circ T_n = T_{mn}$: the map $n \\mapsto T_n$ is a monoid homomorphism $(\\mathbb{Z}, \\times) \\to (\\mathbb{R}[X], \\circ)$. Commutativity: $T_m \\circ T_n = T_n \\circ T_m$ since $mn = nm$. Identity: $T_1(x) = x$."
@@ -134,7 +134,7 @@
       "summary": "Packages composition, product-to-sum, parity, and T_n(1) = 1 into a single conjunction theorem for easy citation.",
       "startLine": 146,
       "endLine": 157,
-      "mathContext": "Summary conjunction: $T_m \\circ T_n = T_{mn}$ $\\wedge$ $2T_m T_n = T_{m+n} + T_{m-n}$ $\\wedge$ $T_n(-x) = (-1)^n T_n(x)$ $\\wedge$ $T_n(1) = 1$. All 15 theorems proved with 0 sorries."
+      "mathContext": "Summary conjunction: $T_m \\circ T_n = T_{mn}$ $\\wedge$ $2T_m T_n = T_{m+n} + T_{m-n}$ $\\wedge$ $T_n(-x) = (-1)^n T_n(x)$ $\\wedge$ $T_n(1) = 1$. All 16 theorems proved with 0 sorries."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/de-moivre-oq-02/review.json
+++ b/src/data/proofs/de-moivre-oq-02/review.json
@@ -98,28 +98,28 @@
       "priority": "medium",
       "target": "enricher",
       "description": "Fix x-vs-cos θ notation in originalContributions[1] and [2]: change generic x to cos θ to match the actual Lean theorem signatures. See finding for exact wording.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",
       "priority": "medium",
       "target": "enricher",
       "description": "In overview.text, replace 'A complete formalization of deeper' with 'A formalization of key'. In sections[0].summary, moderate the monoid claim to 'demonstrates monoid-like structure' with the same parenthetical already used in originalContributions[0].",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-3",
       "priority": "low",
       "target": "enricher",
       "description": "Fix theorem count in sections[5].mathContext: change '15 theorems' to '16 theorems'.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",
       "priority": "low",
       "target": "enricher",
       "description": "In overview.text, use cos θ notation for the product-to-sum and parity formulas to match the Lean file's scope.",
-      "status": "open"
+      "status": "resolved"
     }
   ],
 


### PR DESCRIPTION
Enrichment pass for de-moivre-oq-02 (Chebyshev Polynomial Properties via De Moivre's Theorem).

## Changes

Resolves all 4 open peer review action items:

- **ai-1** (medium): Fixed `originalContributions[1]` and `[2]` — changed generic `x` notation to `cos θ` to match actual Lean theorem signatures
- **ai-2** (medium): Fixed `overview.text` overclaim ("A complete formalization" → "A formalization of key"); moderated monoid claim in `sections[0].summary` with parenthetical "(no Monoid instance constructed)"
- **ai-3** (low): Fixed theorem count in `sections[5].mathContext` (15 → 16)
- **ai-4** (low): Fixed `overview.text` product-to-sum and parity descriptions to use `cos θ` notation matching Lean scope