### PR TITLE
Enrich Erdős 1017 OQ-01 (clique partition): add annotations and conclusion

### DIFF
--- a/src/data/proofs/erdos-1017-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1017-oq-01/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-edge-clique-partition",
+    "proofId": "erdos-1017-oq-01",
+    "range": { "startLine": 42, "endLine": 63 },
+    "type": "definition",
+    "title": "Edge Clique Partition Framework",
+    "content": "Defines the central objects: `EdgeCliquePartition G` is a structure packaging a finset of cliques that cover all edges of $G$, `cliquePartitionNum G` is the minimum partition size (defined via `sInf`), and `usesOnlyEdgesAndTriangles` restricts cliques to $K_2$ and $K_3$. The EGP theorem shows this restriction is without loss of generality up to the Turán bound. The use of `sInf` over a set of natural numbers is well-founded since $\\mathbb{N}$ is well-ordered.",
+    "mathContext": "$\\text{cp}(G) = \\min\\{|\\mathcal{P}| : \\mathcal{P} \\text{ is an edge clique partition of } G\\}$. An edge clique partition $\\mathcal{P} = \\{C_1, \\ldots, C_m\\}$ satisfies: each $C_i$ is a complete subgraph, and $\\bigsqcup_i E(C_i) = E(G)$.",
+    "significance": "key",
+    "relatedConcepts": ["clique partition number", "edge decomposition", "clique cover", "graph factorization"],
+    "prerequisites": ["graph theory", "complete subgraphs", "set partitions"]
+  },
+  {
+    "id": "ann-turan-bound",
+    "proofId": "erdos-1017-oq-01",
+    "range": { "startLine": 70, "endLine": 84 },
+    "type": "definition",
+    "title": "Turán Bound: ⌊n²/4⌋",
+    "content": "Defines `turanBound n = n²/4` (integer division), which equals the Turán number $\\text{ex}(n, K_3)$ — the maximum number of edges in a triangle-free graph on $n$ vertices. Concrete values are verified for $n = 0,\\ldots,4$, and monotonicity is proved using `Nat.div_le_div_right` and `Nat.pow_le_pow_left`. This bound appears throughout the formalization as the universal upper bound for clique partition numbers.",
+    "mathContext": "$\\text{turanBound}(n) = \\lfloor n^2/4 \\rfloor = \\text{ex}(n, K_3)$. For $n$ even: $n^2/4$; for $n$ odd: $(n^2-1)/4$. Achieved by $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$.",
+    "significance": "key",
+    "relatedConcepts": ["Turán number", "extremal graph theory", "triangle-free graph", "Mantel's theorem"],
+    "prerequisites": ["Turán's theorem", "extremal graph theory"]
+  },
+  {
+    "id": "ann-egp-theorem",
+    "proofId": "erdos-1017-oq-01",
+    "range": { "startLine": 91, "endLine": 109 },
+    "type": "concept",
+    "title": "Erdős-Goodman-Pósa Theorem (1966)",
+    "content": "The EGP theorem: every graph on $n$ vertices can be edge-partitioned into at most $\\lfloor n^2/4 \\rfloor$ complete subgraphs, using only edges and triangles. The proof idea is elegant: greedily extract a maximal set of edge-disjoint triangles, then the remainder is triangle-free, hence bipartite (by Ramsey's theorem for $R(3,3)=6$, or more directly by König's theorem). A bipartite graph on $n$ vertices has at most $\\lfloor n^2/4 \\rfloor$ edges by Turán. Each extracted triangle replaces 3 edges with 1 clique, maintaining the bound. The corollary `cliquePartitionNum_le_turan` is proved from the EGP axiom using `sInf` properties.",
+    "mathContext": "$\\text{cp}(G) \\leq \\lfloor n^2/4 \\rfloor$ for every $n$-vertex graph $G$ (Erdős-Goodman-Pósa, 1966). The partition uses only $K_2$ and $K_3$.",
+    "significance": "key",
+    "relatedConcepts": ["greedy algorithm", "triangle extraction", "Ramsey's theorem", "bipartite graph"],
+    "prerequisites": ["Ramsey theory", "Turán's theorem", "greedy algorithms in combinatorics"]
+  },
+  {
+    "id": "ann-complete-bipartite",
+    "proofId": "erdos-1017-oq-01",
+    "range": { "startLine": 116, "endLine": 156 },
+    "type": "technique",
+    "title": "Extremal Example: K_{k,k} Shows EGP is Tight",
+    "content": "Constructs the complete bipartite graph $K_{k,k}$ on `Fin k ⊕ Fin k` with a `DecidableRel` instance for computation. Three facts are established: (1) $K_{k,k}$ is triangle-free (axiom), (2) it has $k^2$ edges (axiom), and (3) triangle-free graphs need one clique per edge (axiom). Together: $\\text{cp}(K_{k,k}) = k^2 = \\lfloor (2k)^2/4 \\rfloor = \\text{turanBound}(2k)$. This shows the EGP bound cannot be improved for sparse (triangle-free) graphs — the question is whether dense graphs allow improvement.",
+    "mathContext": "$K_{k,k}$: $k^2$ edges, triangle-free. $\\text{cp}(K_{k,k}) = k^2 = \\lfloor (2k)^2/4 \\rfloor$. This is the unique extremal graph for Turán's theorem with $n = 2k$.",
+    "significance": "key",
+    "relatedConcepts": ["complete bipartite graph", "extremal graph", "tightness", "sum type"],
+    "prerequisites": ["bipartite graphs", "Turán's theorem", "Lean sum types"]
+  },
+  {
+    "id": "ann-dense-and-open-question",
+    "proofId": "erdos-1017-oq-01",
+    "range": { "startLine": 168, "endLine": 198 },
+    "type": "concept",
+    "title": "The Open Question: Dense Graphs with Large Cliques",
+    "content": "A graph is *dense* if $|E(G)| > \\lfloor n^2/4 \\rfloor$, which by Turán's theorem forces the existence of triangles. Erdős's question asks: can these forced triangles (and larger cliques) be exploited to bring $\\text{cp}(G)$ below $\\lfloor n^2/4 \\rfloor$? The savings calculations show each $K_r$ replaces $\\binom{r}{2}$ edges with 1 clique, saving $\\binom{r}{2} - 1$ edges: triangle saves 2, $K_4$ saves 5, $K_5$ saves 9. Notably, $K_4$ saves more than two triangles ($5 > 2 \\times 2$), suggesting larger cliques are more efficient — but overlapping cliques complicate the optimization.",
+    "mathContext": "$\\text{isDense}(G) \\iff |E(G)| > \\lfloor n^2/4 \\rfloor$. Savings: $K_r$ saves $\\binom{r}{2} - 1$. Open: $\\text{isDense}(G) \\implies \\text{cp}(G) < \\lfloor n^2/4 \\rfloor$?",
+    "significance": "key",
+    "relatedConcepts": ["Turán's theorem", "forced subgraph", "optimization", "NP-hardness"],
+    "prerequisites": ["Turán's theorem", "clique partition", "combinatorial optimization"]
+  },
+  {
+    "id": "ann-gyori-keszegh",
+    "proofId": "erdos-1017-oq-01",
+    "range": { "startLine": 205, "endLine": 240 },
+    "type": "concept",
+    "title": "Győri-Keszegh Resolution for K₄-Free Graphs (2017)",
+    "content": "The key partial result: if $G$ is $K_4$-free with $\\lfloor n^2/4 \\rfloor + m$ edges, then $G$ contains $m$ edge-disjoint triangles. Since each triangle saves 2 from the partition count, $\\text{cp}(G) = \\lfloor n^2/4 \\rfloor - m$. The proof `k4free_improves` then shows dense $K_4$-free graphs satisfy $\\text{cp}(G) < \\lfloor n^2/4 \\rfloor$, answering Erdős's question positively in this restricted case. The argument uses that $K_4$-freeness means the only available cliques are edges and triangles, making the optimization tractable. The general case (when $K_4$ is present) remains open.",
+    "mathContext": "Győri-Keszegh (2017): $K_4$-free, $|E(G)| = \\lfloor n^2/4 \\rfloor + m \\implies \\text{cp}(G) = \\lfloor n^2/4 \\rfloor - m$. Proved: $\\text{isDense}(G) \\wedge K_4\\text{-free} \\implies \\text{cp}(G) < \\lfloor n^2/4 \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["edge-disjoint triangles", "triangle packing", "Győri-Keszegh theorem", "partial resolution"],
+    "prerequisites": ["triangle packing", "extremal graph theory", "K₄-free graphs"]
+  },
+  {
+    "id": "ann-lovasz-covering",
+    "proofId": "erdos-1017-oq-01",
+    "range": { "startLine": 247, "endLine": 255 },
+    "type": "context",
+    "title": "Lovász Covering Bound (1968)",
+    "content": "Lovász (1968) proved a covering bound: every graph can be covered by at most $n(n-1)/2$ cliques. The covering problem is strictly easier than partitioning because cliques may overlap (share edges). The gap between covering number and partition number is not well understood. For many graphs, $\\text{cp}(G)$ is significantly larger than the minimum clique cover, making the partition problem harder and more interesting.",
+    "mathContext": "Clique cover number $\\theta(G) \\leq n(n-1)/2$. Partition constraint: cliques must be edge-disjoint. In general $\\theta(G) \\leq \\text{cp}(G)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["clique cover", "covering vs partitioning", "Lovász theorem", "edge-disjoint"],
+    "prerequisites": ["graph theory", "covering problems"]
+  },
+  {
+    "id": "ann-connections",
+    "proofId": "erdos-1017-oq-01",
+    "range": { "startLine": 262, "endLine": 273 },
+    "type": "insight",
+    "title": "Connections: Edge Coloring and Supersaturation",
+    "content": "Two important connections: (1) The clique partition number of $G$ equals the chromatic index of the complement $\\chi'(\\overline{G})$, linking clique partitions to Vizing's theorem and edge coloring theory. (2) Razborov's flag algebra result (2010) shows supersaturation: graphs with $\\lfloor n^2/4 \\rfloor + m$ edges contain $\\Omega(m^2)$ triangles. More triangles mean more potential for savings in clique partitions, but exploiting them requires solving the NP-hard optimization of finding edge-disjoint triangle packings.",
+    "mathContext": "$\\text{cp}(G) = \\chi'(\\overline{G})$ (edge coloring of complement). Razborov supersaturation: $|E(G)| \\geq \\lfloor n^2/4 \\rfloor + m \\implies \\text{tri}(G) \\geq cm^2$ for some $c > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["chromatic index", "Vizing's theorem", "graph complement", "flag algebras", "Razborov", "supersaturation"],
+    "prerequisites": ["edge coloring", "Vizing's theorem", "flag algebras"]
+  }
+]

--- a/src/data/proofs/erdos-1017-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-01/meta.json
@@ -58,7 +58,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Clique Partition of Graphs**\n\nThe clique partition problem asks: how many complete subgraphs are needed to partition all edges of a graph? Erdős, Goodman, and Pósa (1966) proved the elegant bound f(n,k) ≤ ⌊n²/4⌋ using only edges and triangles. The key insight: greedy triangle extraction leaves a triangle-free remainder, which is bipartite (Ramsey) and has at most ⌊n²/4⌋ edges (Turán).\n\nThe bound is tight: K_{n/2,n/2} has n²/4 edges, no triangles, so each edge must be its own clique. Erdős then asked: when k > n²/4, the graph must contain triangles. Can these be exploited to reduce the partition count below ⌊n²/4⌋?",
+    "historicalContext": "The clique partition problem — decomposing a graph's edges into complete subgraphs — emerged from the interplay of extremal graph theory and combinatorial optimization. Erdős, Goodman, and Pósa (1966) proved the foundational bound $\\text{cp}(G) \\leq \\lfloor n^2/4 \\rfloor$ using a greedy triangle extraction followed by Turán's theorem on the triangle-free remainder. This was connected to earlier work by Mantel (1907) on triangle-free graphs and Turán (1941) on extremal graph density.\n\nThe bound is tight for $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$, which is triangle-free and needs one clique per edge. Erdős asked whether dense graphs (with more than $\\lfloor n^2/4 \\rfloor$ edges) — which must contain triangles by Turán's theorem — allow improvement. Győri and Keszegh (2017) resolved the $K_4$-free case by proving that every excess edge yields an edge-disjoint triangle, reducing the partition count by exactly 1 per excess edge. The general case, when $K_4$ and larger cliques are present, remains open and connects to NP-hard optimization problems in graph decomposition.",
     "problemStatement": "**Open Question**: Can $f(n,k) < \\lfloor n^2/4 \\rfloor$ when $k > n^2/4$?\n\n**Known**: Erdős-Goodman-Pósa: $f(n,k) \\leq \\lfloor n^2/4 \\rfloor$ for all $k$.\n**Extremal**: $K_{n/2,n/2}$ achieves equality.\n**Partial**: $K_4$-free case resolved by Győri-Keszegh (2017): $f = \\lfloor n^2/4 \\rfloor - m$ when the graph has $\\lfloor n^2/4 \\rfloor + m$ edges and avoids $K_4$.\n**Open**: General case with $K_4$ and larger cliques.",
     "text": "Can f(n,k) < ⌊n²/4⌋ when k > n²/4? Formalizes the Erdős-Goodman-Pósa framework, tightness via K_{n/2,n/2}, and the Győri-Keszegh K₄-free resolution. The general case with K₄ and larger cliques remains open.",
     "proofStrategy": "The formalization builds a complete framework for edge clique partitions in 8 parts:\n\n1. **EdgeCliquePartition structure**: cliques covering all edges\n2. **Turán bound**: ⌊n²/4⌋ with concrete values and monotonicity\n3. **EGP theorem**: every graph partitions into ≤ ⌊n²/4⌋ cliques\n4. **Extremal example**: K_{k,k} with triangle-freeness and edge count\n5. **Open question**: formal statement with isDense predicate\n6. **Győri-Keszegh**: K₄-free resolution with triangle packing\n7. **Lovász covering**: related covering bound\n8. **Connections**: supersaturation and edge-coloring duality",
@@ -133,6 +133,16 @@
       "mathContext": "Related bounds: Lovász covering, edge-coloring duality ($\\text{cp}(G) = \\chi'(\\bar{G})$), and Razborov supersaturation."
     }
   ],
+  "conclusion": {
+    "summary": "This formalization captures the complete framework for Erdős's clique partition question (#1017 OQ-01): the Erdős-Goodman-Pósa bound $\\lfloor n^2/4 \\rfloor$, its tightness via $K_{k,k}$, the formal statement of the open question for dense graphs, and the Győri-Keszegh resolution for $K_4$-free graphs. The key proved result is that dense $K_4$-free graphs satisfy $\\text{cp}(G) < \\lfloor n^2/4 \\rfloor$.",
+    "implications": "A positive resolution of the general case would establish a universal improvement principle: density always reduces clique partition numbers. This would have implications for edge coloring (via the $\\text{cp}(G) = \\chi'(\\overline{G})$ duality), graph compression, and communication complexity (where clique partitions relate to non-deterministic communication complexity of graph properties).",
+    "openQuestions": [
+      "Can f(n,k) < ⌊n²/4⌋ when the graph contains K₄? This is the core of Erdős #1017 OQ-01.",
+      "What is the precise savings from K₄? If each K₄ saves 5 edges but can overlap with triangles, what is the optimal packing strategy?",
+      "Does supersaturation (Razborov 2010) provide enough edge-disjoint triangles to improve the bound for all dense graphs?",
+      "Is there a polynomial-time algorithm for optimal clique partitions of dense graphs, or is it NP-hard even in the dense regime?"
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "erdos-1017",


### PR DESCRIPTION
## Enrichment pass for erdos-1017-oq-01

**Quality improvements:**
- Created 8 annotations (from 0) covering all major Lean code sections with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`
- Added `conclusion` section with summary, implications (edge coloring duality, communication complexity), and 4 open questions
- Deepened `historicalContext` with Mantel (1907), Turán (1941), NP-hardness connections

**Annotation coverage:**
- Edge clique partition framework (EdgeCliquePartition, cliquePartitionNum, usesOnlyEdgesAndTriangles)
- Turán bound ⌊n²/4⌋ with monotonicity
- Erdős-Goodman-Pósa theorem (1966)
- Extremal example K_{k,k} and tightness
- Open question: dense graphs with large cliques
- Győri-Keszegh K₄-free resolution (2017)
- Lovász covering bound (1968)
- Connections: edge coloring duality and Razborov supersaturation