### PR TITLE
Research: erdos-1000 structural lemmas (phiA_ge_totient)

### DIFF
--- a/proofs/Proofs/Erdos1000Problem.lean
+++ b/proofs/Proofs/Erdos1000Problem.lean
@@ -22,6 +22,8 @@
   Axiom count: 4 (erdos_no_zero_limit, erdos_dichotomy,
     cassels_liminf_zero, haight_resolution)
   Proved: naturalSeq_phiA_eq_totient (filter condition ↔ coprimality + Icc/range bridge)
+  Proved: phiA_ge_totient (φ_A(k) ≥ φ(n_k) — coprime elements always pass the filter)
+  Proved: densityRatio_ge_totient_ratio (ρ_A(k) ≥ φ(n_k)/n_k)
 
   Tags: number-theory, diophantine-approximation, totient-function, cesaro-averages
 -/
@@ -98,7 +100,7 @@ theorem densityRatio_zero (A : IncreasingSeq) :
 
 /-- The Cesàro average C_A(N) = (1/N) Σ_{k<N} ρ_A(k). -/
 noncomputable def cesaroAvg (A : IncreasingSeq) (N : ℕ) : ℝ :=
-  (∑ k in range N, densityRatio A k) / N
+  (∑ k ∈ range N, densityRatio A k) / N
 
 /-- C_A(N) ≥ 0 for all N. -/
 theorem cesaroAvg_nonneg (A : IncreasingSeq) (N : ℕ) :
@@ -110,8 +112,8 @@ theorem cesaroAvg_le_one (A : IncreasingSeq) (N : ℕ) (hN : 0 < N) :
     cesaroAvg A N ≤ 1 := by
   unfold cesaroAvg
   rw [div_le_one (by exact_mod_cast hN : (0 : ℝ) < ↑N)]
-  calc ∑ k in range N, densityRatio A k
-      ≤ ∑ _ in range N, (1 : ℝ) := sum_le_sum fun k _ => densityRatio_le_one A k
+  calc ∑ k ∈ range N, densityRatio A k
+      ≤ ∑ _ ∈ range N, (1 : ℝ) := sum_le_sum fun k _ => densityRatio_le_one A k
     _ = N := by simp
 
 /- ## Part IV: The Natural Sequence -/
@@ -119,7 +121,7 @@ theorem cesaroAvg_le_one (A : IncreasingSeq) (N : ℕ) (hN : 0 < N) :
 /-- The natural sequence A = {1, 2, 3, ...} (0-indexed: seq(k) = k+1). -/
 def naturalSeq : IncreasingSeq where
   seq := fun n => n + 1
-  strictMono := fun _ _ h => by omega
+  strictMono := fun {a b} hab => Nat.add_lt_add_right hab 1
   pos := fun _ => by omega
 
 /-- For A = ℕ, φ_A(k) equals Euler's totient φ(k+1).
@@ -175,17 +177,74 @@ theorem naturalSeq_phiA_eq_totient (k : ℕ) :
     constructor
     · -- Icc → range: m ≤ n ∧ gcd(m,n)=1 → m < n (since gcd(n,n)=n≠1)
       rintro ⟨⟨hm1, hmn⟩, hg⟩
-      exact ⟨by rcases eq_or_lt_of_le hmn with rfl | h
-               · rw [Nat.gcd_self] at hg; omega
-               · exact h,
-             by rwa [Nat.gcd_comm]⟩
+      refine ⟨?_, by rwa [Nat.gcd_comm]⟩
+      rcases eq_or_lt_of_le hmn with rfl | h
+      · rw [Nat.gcd_self] at hg; omega
+      · exact h
     · -- range → Icc: m < n ∧ gcd(n,m)=1 → 1 ≤ m (since gcd(n,0)=n≠1)
       rintro ⟨hmn, hg⟩
       rw [Nat.gcd_comm] at hg
-      exact ⟨⟨by rcases Nat.eq_zero_or_pos m with rfl | h
-                · simp [Nat.gcd_zero_left] at hg; omega
-                · exact h,
-              le_of_lt hmn⟩, hg⟩
+      refine ⟨⟨?_, le_of_lt hmn⟩, hg⟩
+      rcases Nat.eq_zero_or_pos m with rfl | h
+      · simp [Nat.gcd_zero_left] at hg
+      · exact h
+
+/- ## Part IV-B: Structural Lower Bound -/
+
+/-- For n ≥ 2 and m coprime to n, m is in {1,...,n} and the reduced denominator
+    n/gcd(m,n) = n exceeds all previous sequence terms. So coprime elements
+    in range(n) are a subset of the phiA filter set. -/
+private lemma coprime_range_subset_phiA_filter (A : IncreasingSeq) (k : ℕ)
+    (hn : 2 ≤ A.seq (k + 1)) :
+    (Finset.range (A.seq (k + 1))).filter (Nat.Coprime (A.seq (k + 1))) ⊆
+    (Icc 1 (A.seq (k + 1))).filter (fun m =>
+      ∀ j : ℕ, j < k + 1 → reducedDenom m (A.seq (k + 1)) ≠ A.seq j) := by
+  intro m hm
+  simp only [mem_filter, mem_range] at hm
+  obtain ⟨hm_lt, hm_cop⟩ := hm
+  simp only [mem_filter, mem_Icc]
+  refine ⟨⟨?_, le_of_lt hm_lt⟩, ?_⟩
+  · -- 1 ≤ m: since Coprime n m and n ≥ 2, m ≠ 0
+    rcases Nat.eq_zero_or_pos m with rfl | hpos
+    · simp [Nat.Coprime] at hm_cop; omega
+    · exact hpos
+  · -- ∀ j < k+1, reducedDenom m n ≠ A.seq j
+    intro j hj
+    unfold reducedDenom
+    -- gcd(m, n) = 1 since Coprime n m means gcd(n, m) = 1
+    have hgcd : Nat.gcd m (A.seq (k + 1)) = 1 := by rwa [Nat.gcd_comm]
+    rw [hgcd, Nat.div_one]
+    -- A.seq (k+1) > A.seq j since j < k+1
+    exact Nat.ne_of_gt (A.strictMono (by omega))
+
+/-- Key structural lemma: φ_A(k) ≥ φ(n_k) for any increasing sequence A.
+    Every m coprime to n_k has reduced denominator n_k, which exceeds all
+    previous terms n_j (j < k). So coprime elements always pass the filter.
+    This lower bound is the foundation for Erdős' no-zero-limit theorem. -/
+theorem phiA_ge_totient (A : IncreasingSeq) (k : ℕ) :
+    Nat.totient (A.seq k) ≤ phiA A k := by
+  rcases k with _ | k
+  · -- k = 0: phiA = n₀ ≥ totient(n₀)
+    rw [phiA_zero]
+    exact Nat.totient_le _
+  · -- k ≥ 1: n = A.seq (k+1) ≥ 2
+    unfold phiA
+    have hn : 2 ≤ A.seq (k + 1) := by
+      have h0 : 0 < A.seq 0 := A.pos 0
+      have h1 : A.seq 0 < A.seq (k + 1) := A.strictMono (by omega)
+      omega
+    -- totient n = card of (range n).filter(Coprime n) by definition
+    -- This is ⊆ the phiA filter set, so card inequality follows
+    exact Finset.card_le_card (coprime_range_subset_phiA_filter A k hn)
+
+/-- The density ratio ρ_A(k) is bounded below by φ(n_k)/n_k.
+    Real-valued corollary of phiA_ge_totient. -/
+theorem densityRatio_ge_totient_ratio (A : IncreasingSeq) (k : ℕ) :
+    (Nat.totient (A.seq k) : ℝ) / (A.seq k : ℝ) ≤ densityRatio A k := by
+  unfold densityRatio
+  apply div_le_div_of_nonneg_right
+  · exact_mod_cast phiA_ge_totient A k
+  · exact Nat.cast_nonneg _
 
 /- ## Part V: Main Predicates -/
 
@@ -240,7 +299,7 @@ theorem vanishing_avg_visits_zero (A : IncreasingSeq) (hV : VanishingAverage A)
   by_contra h
   rw [Filter.not_frequently] at h
   -- h : ∀ᶠ k in atTop, ¬ (densityRatio A k < ε)
-  have hev : ∀ᶠ k in atTop, ε ≤ densityRatio A k := h.mono fun k hk => le_of_not_lt hk
+  have hev : ∀ᶠ k in atTop, ε ≤ densityRatio A k := h.mono fun k hk => le_of_not_gt hk
   obtain ⟨K, hK⟩ := eventually_atTop.mp hev
   -- VanishingAverage: eventually C_A(N) < ε/2
   have hV2 : ∀ᶠ N in atTop, cesaroAvg A N < ε / 2 := by
@@ -260,21 +319,28 @@ theorem vanishing_avg_visits_zero (A : IncreasingSeq) (hV : VanishingAverage A)
   have h1 : cesaroAvg A N < ε / 2 := hN₀ N hN0_bound
   -- C_A(N) ≥ ε/2 (from the lower bound on the sum)
   have h2 : ε / 2 ≤ cesaroAvg A N := by
-    unfold cesaroAvg
-    -- Need: ε/2 ≤ (Σ ρ(k)) / N, i.e., ε/2 * N ≤ Σ ρ(k)
     have hNR : (0 : ℝ) < ↑N := Nat.cast_pos.mpr hNpos
-    rw [le_div_iff₀ hNR]
     -- Σ_{k<N} ρ(k) ≥ Σ_{K≤k<N} ε = (N-K)·ε ≥ N/2·ε = ε/2·N
-    calc ε / 2 * ↑N ≤ ↑(N - K) * ε := by
-            have : (K : ℝ) ≤ (N : ℝ) / 2 := by push_cast; linarith
-            rw [Nat.cast_sub hKleN]; nlinarith
-      _ = ∑ _i ∈ Ico K N, ε := by rw [sum_const, Nat.card_Ico, nsmul_eq_mul]
-      _ ≤ ∑ i ∈ Ico K N, densityRatio A i :=
-            sum_le_sum fun i hi => hK i (mem_Ico.mp hi).1
-      _ ≤ ∑ i ∈ range N, densityRatio A i := by
-            apply sum_le_sum_of_subset_of_nonneg
-            · intro x hx; exact mem_range.mpr (mem_Ico.mp hx).2
-            · intro i _ _; exact densityRatio_nonneg A i
+    have hsum : ε / 2 * ↑N ≤ ∑ k ∈ range N, densityRatio A k := by
+      calc ε / 2 * ↑N ≤ ↑(N - K) * ε := by
+              have : (K : ℝ) ≤ (N : ℝ) / 2 := by
+                have h2K : (2 * (K : ℝ) + 1 ≤ ↑N) := by exact_mod_cast hN_bound
+                linarith
+              rw [Nat.cast_sub hKleN]; nlinarith
+        _ = ∑ _i ∈ Ico K N, ε := by rw [sum_const, Nat.card_Ico, nsmul_eq_mul]
+        _ ≤ ∑ i ∈ Ico K N, densityRatio A i :=
+              sum_le_sum fun i hi => hK i (mem_Ico.mp hi).1
+        _ ≤ ∑ i ∈ range N, densityRatio A i := by
+              apply sum_le_sum_of_subset_of_nonneg
+              · intro x hx; exact mem_range.mpr (mem_Ico.mp hx).2
+              · intro i _ _; exact densityRatio_nonneg A i
+    -- ε/2 ≤ Σ/N from ε/2 * N ≤ Σ and N > 0
+    show ε / 2 ≤ cesaroAvg A N
+    unfold cesaroAvg
+    have hNne : (↑N : ℝ) ≠ 0 := hNR.ne'
+    have key : ε / 2 * ↑N / ↑N ≤ (∑ k ∈ range N, densityRatio A k) / ↑N :=
+      div_le_div_of_nonneg_right hsum hNR.le
+    rwa [mul_div_cancel_right₀ _ hNne] at key
   linarith
 
 /-- Haight oscillation: the sequence achieving vanishing Cesàro average

--- a/research/problems/erdos-1000-wip-01/knowledge.md
+++ b/research/problems/erdos-1000-wip-01/knowledge.md
@@ -1,0 +1,48 @@
+# Research Knowledge: erdos-1000-wip-01
+
+## Problem
+Complete Erdős #1000: Generalized Totients and Diophantine Approximation.
+The existing formalization has 4 axioms (erdos_no_zero_limit, erdos_dichotomy, cassels_liminf_zero, haight_resolution) and 0 sorries. Goal: prove one or more axioms.
+
+## Summary
+Proved 2 new structural lemmas that establish the fundamental lower bound connecting generalized totients to Euler's totient function. Fixed Mathlib API migration issues.
+
+## Session 2026-03-25 (Session 1) - Structural Lower Bound
+
+**Mode**: FRESH
+**Outcome**: progress
+
+### What I Did
+- Proved `phiA_ge_totient`: φ_A(k) ≥ φ(n_k) for any increasing sequence A
+  - Key insight: coprime elements always pass the phiA filter
+  - If gcd(m, n_k) = 1, then reducedDenom m n_k = n_k > n_j for all j < k
+  - Proof: subset argument — (range n).filter(Coprime n) ⊆ (Icc 1 n).filter(phiA_cond)
+  - k=0 case: phiA_zero gives phiA = n₀ ≥ totient(n₀)
+  - k≥1 case: n_k ≥ 2, so the subset injection works
+- Proved `densityRatio_ge_totient_ratio`: ρ_A(k) ≥ φ(n_k)/n_k
+  - Direct corollary of phiA_ge_totient via div_le_div_of_nonneg_right
+- Fixed Mathlib API migration issues in existing proofs:
+  - `∑ k in range N` → `∑ k ∈ range N` (3 instances)
+  - `strictMono` proof: `by omega` → `Nat.add_lt_add_right`
+  - Constructor syntax: restructured `⟨by ..., by ...⟩` to `refine ⟨?_, ...⟩`
+  - `simp at hg; omega` → `simp at hg` (simp now closes goal)
+  - `push_cast; linarith` → explicit cast + linarith
+  - `le_div_iff₀` rewrite → explicit mul_div_cancel approach
+
+### Key Findings
+- The lower bound φ_A(k) ≥ φ(n_k) is necessary but NOT sufficient for erdos_no_zero_limit
+  - φ(n_k)/n_k CAN go to 0 (e.g., primorial sequence)
+  - Erdős' proof must use deeper structural arguments about the counting
+- The Mathlib API has diverged from when this file was written (v4.26.0)
+  - `∑ ... in` syntax replaced by `∑ ... ∈`
+  - Division lemma naming changed
+  - omega behavior with semiimplicit binders changed
+
+### Files Modified
+- `proofs/Proofs/Erdos1000Problem.lean` — 2 new theorems + migration fixes (304→370 lines)
+- `src/data/proofs/erdos-1000/meta.json` — updated counts and sections
+
+### Next Steps
+- Investigate `cassels_liminf_zero`: simplest axiom to prove? Needs explicit sequence construction
+- Investigate `erdos_no_zero_limit`: needs understanding of WHY ρ_A can't converge to 0 despite φ(n_k)/n_k → 0. Likely needs structural argument about the excluded denominators
+- The lower bound enables future work: any proof of `erdos_no_zero_limit` will use `phiA_ge_totient` as a foundation

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -22,8 +22,8 @@
     "erdosUrl": "https://erdosproblems.com/1000",
     "erdosProblemStatus": "solved",
     "axiomCount": 4,
-    "lineCount": 304,
-    "assumptions": "Four deep axioms: erdos_no_zero_limit (φ_A(k)/n_k cannot converge to 0), erdos_dichotomy (liminf=0 implies limsup=1), cassels_liminf_zero (liminf of Cesàro average can be 0), haight_resolution (vanishing Cesàro average exists). Previously axiomatized naturalSeq_phiA_eq_totient now proved via filter/coprimality argument.",
+    "lineCount": 370,
+    "assumptions": "Four deep axioms: erdos_no_zero_limit (φ_A(k)/n_k cannot converge to 0), erdos_dichotomy (liminf=0 implies limsup=1), cassels_liminf_zero (liminf of Cesàro average can be 0), haight_resolution (vanishing Cesàro average exists). New structural lemmas: phiA_ge_totient (φ_A(k) ≥ φ(n_k) for any sequence) and densityRatio_ge_totient_ratio (ρ_A(k) ≥ φ(n_k)/n_k).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -87,42 +87,50 @@
       "mathContext": "For $A = \\mathbb{N}$: the reduced denominator of $m/(k+2)$ avoids $\\{1, \\ldots, k+1\\}$ iff $\\gcd(m, k+2) = 1$, because $\\frac{k+2}{\\gcd(m, k+2)} = k+2$ iff $\\gcd = 1$. The Icc/range bridge uses the facts that $\\gcd(n,n) = n \\neq 1$ and $\\gcd(n,0) = n \\neq 1$ for $n \\geq 2$."
     },
     {
+      "id": "structural-lower-bound",
+      "title": "Part IV-B: Structural Lower Bound",
+      "startLine": 192,
+      "endLine": 248,
+      "summary": "Proves two key structural lemmas: `phiA_ge_totient` ($\\varphi_A(k) \\geq \\varphi(n_k)$ for any increasing sequence $A$) and `densityRatio_ge_totient_ratio` ($\\rho_A(k) \\geq \\varphi(n_k)/n_k$). The proof shows that every $m$ coprime to $n_k$ has reduced denominator $n_k$, which exceeds all previous terms by strict monotonicity.",
+      "mathContext": "For any $A$ and $k$: if $\\gcd(m, n_k) = 1$ then the reduced denominator is $n_k / 1 = n_k > n_j$ for all $j < k$. So the set $\\{m \\leq n_k : \\gcd(m, n_k) = 1\\}$ (of size $\\varphi(n_k)$) is a subset of the $\\varphi_A(k)$ filter. This lower bound is the foundation for Erdős' no-zero-limit theorem."
+    },
+    {
       "id": "main-predicates",
       "title": "Part V: Main Predicates",
-      "startLine": 190,
-      "endLine": 198,
+      "startLine": 250,
+      "endLine": 258,
       "summary": "Defines `VanishingAverage A` ($C_A(N) \\to 0$) and `DensityToZero A` ($\\rho_A(k) \\to 0$) as filter-limit predicates.",
       "mathContext": "$\\text{VanishingAverage}(A) :\\Leftrightarrow \\lim_{N \\to \\infty} C_A(N) = 0$. $\\text{DensityToZero}(A) :\\Leftrightarrow \\lim_{k \\to \\infty} \\rho_A(k) = 0$."
     },
     {
       "id": "erdos-results",
       "title": "Part VI: Erdős' Results (1964)",
-      "startLine": 200,
-      "endLine": 212,
+      "startLine": 260,
+      "endLine": 272,
       "summary": "Two axioms: `erdos_no_zero_limit` ($\\rho_A(k) \\not\\to 0$ for any $A$, via Mertens' bound $\\varphi(n)/n \\geq c/\\log\\log n$) and `erdos_dichotomy` (if $\\liminf \\rho_A = 0$ then $\\limsup \\rho_A = 1$, via the Euler product for $\\varphi(n)/n$).",
       "mathContext": "Axiom 1: $\\neg \\text{DensityToZero}(A)$ for all $A$. Axiom 2: $\\liminf \\rho_A = 0 \\Rightarrow \\limsup \\rho_A = 1$. These establish that the density ratio must oscillate — it can visit near 0 but cannot stay there, and if it visits near 0 it must also visit near 1."
     },
     {
       "id": "cassels-result",
       "title": "Part VII: Cassels' Result (1950)",
-      "startLine": 214,
-      "endLine": 220,
+      "startLine": 274,
+      "endLine": 280,
       "summary": "Axiom `cassels_liminf_zero`: there exists $A$ with $\\liminf C_A(N) = 0$, constructed via continued fraction convergents. Historically the first result showing the average can approach 0.",
       "mathContext": "$\\exists A : \\text{IncreasingSeq},\\; \\forall \\varepsilon > 0,\\; \\exists^\\infty N,\\; C_A(N) < \\varepsilon$. Weaker than Haight's result (liminf = 0 vs lim = 0)."
     },
     {
       "id": "haight-resolution",
       "title": "Part VIII: Haight's Resolution",
-      "startLine": 222,
-      "endLine": 229,
+      "startLine": 282,
+      "endLine": 289,
       "summary": "Axiom `haight_resolution`: $\\exists A$ with $C_A(N) \\to 0$. Resolves Erdős' problem affirmatively. The construction uses rapidly growing highly composite numbers.",
       "mathContext": "$\\exists A : \\text{IncreasingSeq},\\; \\text{VanishingAverage}(A)$. The answer to Erdős' question is YES, contrary to his expectation."
     },
     {
       "id": "corollaries",
       "title": "Part IX: Corollaries",
-      "startLine": 231,
-      "endLine": 304,
+      "startLine": 291,
+      "endLine": 370,
       "summary": "Four proved theorems synthesizing the axioms: `vanishing_avg_visits_zero` (vanishing average implies $\\rho_A$ frequently visits near 0, via a split-sum argument), `haight_oscillation` (Haight's sequence oscillates between near 0 and near 1), `no_density_zero` (no sequence has $\\rho_A \\to 0$), and `pointwise_cesaro_gap` ($\\exists A$ with $C_A(N) \\to 0$ but $\\rho_A(k) \\not\\to 0$, a concrete separation between pointwise and Cesàro convergence).",
       "mathContext": "The key proved result `vanishing_avg_visits_zero` is a 40-line argument: assuming $\\rho_A(k) \\geq \\varepsilon$ eventually, the Cesàro sum is bounded below by $\\varepsilon(N - K)/N \\to \\varepsilon$, contradicting $C_A(N) \\to 0$. The corollaries combine this with the axioms via short compositions."
     }
@@ -186,9 +194,9 @@
       "Topology"
     ],
     "namespace": "Erdos1000",
-    "lineCount": 304,
+    "lineCount": 370,
     "axiomCount": 4,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 8
   }
 }

--- a/src/data/research/problems/erdos-1000-wip-01.json
+++ b/src/data/research/problems/erdos-1000-wip-01.json
@@ -1,39 +1,54 @@
 {
   "slug": "erdos-1000-wip-01",
   "title": "Complete Erdős #1000: Generalized Totients and Diophantine Approximation (Work in Progress)",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in number theory: Complete Erdős #1000: Generalized Totients and Diophantine Approximation (Work in Progress).",
-    "whyMatters": []
+    "formal": "Prove one or more of the 4 axioms in Erdos1000Problem.lean: erdos_no_zero_limit, erdos_dichotomy, cassels_liminf_zero, haight_resolution",
+    "plain": "The existing formalization of Erdős #1000 has 4 deep axioms about generalized totients and Cesàro averages. Goal: reduce the axiom count by proving structural results.",
+    "whyMatters": ["Connects totient theory to Cesàro summation", "Illustrates pointwise vs averaged convergence gap"]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": ["phiA_ge_totient: φ_A(k) ≥ φ(n_k)", "densityRatio_ge_totient_ratio: ρ_A(k) ≥ φ(n_k)/n_k"],
+    "open": ["erdos_no_zero_limit", "erdos_dichotomy", "cassels_liminf_zero", "haight_resolution"],
+    "goal": "Prove erdos_no_zero_limit or cassels_liminf_zero"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-24T00:48:59.900Z",
+    "phase": "ORIENT",
+    "since": "2026-03-25T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "focus": "Proved structural lower bound lemmas. Assessing feasibility of axiom proofs.",
+    "blockers": ["erdos_no_zero_limit requires deeper structural argument beyond phiA ≥ totient"],
+    "nextAction": "Investigate cassels_liminf_zero: explicit sequence construction via continued fractions",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: No Lean file exists.",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: Proved phiA_ge_totient and densityRatio_ge_totient_ratio. Fixed Mathlib migration. 4 axioms remain.",
+    "builtItems": [
+      {"name": "phiA_ge_totient", "type": "theorem", "description": "φ_A(k) ≥ φ(n_k) for any increasing sequence — coprime elements always pass phiA filter"},
+      {"name": "densityRatio_ge_totient_ratio", "type": "theorem", "description": "ρ_A(k) ≥ φ(n_k)/n_k — real-valued lower bound on density ratio"},
+      {"name": "coprime_range_subset_phiA_filter", "type": "lemma", "description": "Coprime elements in range form subset of phiA filter set"}
+    ],
+    "insights": [
+      "phiA_ge_totient: coprime m has reducedDenom = n_k > n_j for j < k",
+      "Lower bound alone insufficient for erdos_no_zero_limit since φ(n)/n → 0 along primorials",
+      "Erdős' proof needs structural argument about excluded-denominator interplay",
+      "Mathlib v4.26.0 API migration: ∑ in → ∈, omega/semiimplicit, division lemma changes"
+    ],
+    "mathlibGaps": [
+      "No gaps: Nat.totient, Finset.card_le_card, gcd API all sufficient"
+    ],
+    "nextSteps": [
+      "Investigate cassels_liminf_zero via explicit continued fraction construction",
+      "Study erdos_no_zero_limit strategy: why can't ρ_A converge to 0?",
+      "Consider erdos_dichotomy via Euler product techniques"
+    ]
   },
   "tags": [
     "erdos",
@@ -51,11 +66,11 @@
   ],
   "references": {
     "papers": [],
-    "urls": [],
-    "mathlib": []
+    "urls": ["https://erdosproblems.com/1000"],
+    "mathlib": ["Mathlib.Data.Nat.Totient"]
   },
   "started": "2026-03-24T00:48:59.900Z",
-  "lastUpdate": "2026-03-24T00:48:59.900Z",
+  "lastUpdate": "2026-03-25T00:00:00Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Prove **phiA_ge_totient**: φ_A(k) ≥ φ(n_k) for any increasing sequence A — coprime elements always pass the generalized totient filter
- Prove **densityRatio_ge_totient_ratio**: ρ_A(k) ≥ φ(n_k)/n_k — real-valued density ratio lower bound
- Fix Mathlib API migration issues in existing Erdos1000Problem.lean (∑ syntax, strictMono, constructor syntax, division lemmas)

These structural lemmas establish the fundamental connection between the generalized totient φ_A and Euler's totient φ, providing the foundation for future proofs of the 4 remaining axioms.

## Build verification
- Docker build: 0 errors, 0 warnings, 0 sorries
- Line count: 304 → 370 (+66 lines of proved content)
- Theorem count: 12 → 14 (2 new theorems + 1 private helper lemma)

## Test plan
- [x] `docker-build.sh Proofs.Erdos1000Problem` passes cleanly
- [x] Gallery metadata updated with new section annotations
- [x] Research knowledge documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)