### PR TITLE
Research: Erdős #941 — 2→0 sorries, fix build

### DIFF
--- a/proofs/Proofs/Erdos941Problem.lean
+++ b/proofs/Proofs/Erdos941Problem.lean
@@ -49,10 +49,7 @@ The following was proved by Aristotle:
   - OEIS A056828: Powerful numbers
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Nat.Factorization.Basic
-import Mathlib.NumberTheory.Divisors
-import Mathlib.Data.Finset.Basic
+import Mathlib
 
 
 open Nat
@@ -99,15 +96,13 @@ theorem powerful_iff_alt (n : ℕ) (hn : n > 0) :
     intro x hx y hy h; subst h; simp_all +decide [ Nat.Prime.dvd_mul ] ;
     intro p pp dp; rcases dp with ( dp | dp ) <;> [ exact dvd_mul_of_dvd_left ( pow_dvd_pow_of_dvd ( pp.dvd_of_dvd_pow dp ) 2 ) _; exact dvd_mul_of_dvd_right ( pow_dvd_pow_of_dvd ( pp.dvd_of_dvd_pow dp ) 2 |> fun h => dvd_trans h ( pow_dvd_pow _ <| show 3 ≥ 2 by decide ) ) _ ] ;
 
-/-- 1 is powerful (vacuously). -/
+/-- 1 is powerful (vacuously: no prime divides 1). -/
 theorem one_is_powerful : IsPowerful 1 := by
   constructor
   · omega
   · intro p hp hpn
-    have : p = 1 := Nat.eq_one_of_pos_of_self_mul_self_mod_eq_one (hp.one_lt) (by
-      simp at hpn
-      omega)
-    omega
+    exfalso
+    exact hp.one_lt.not_ge (Nat.le_of_dvd one_pos hpn)
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 
@@ -116,10 +111,10 @@ numerals are data in Lean, but the expected type is a proposition
 /-- Perfect squares are powerful. -/
 theorem square_is_powerful (a : ℕ) (ha : a > 0) : IsPowerful (a^2) := by
   constructor
-  · exact Nat.pos_pow_of_pos 2 ha
+  · exact pow_pos ha 2
   · intro p hp hpn
     -- p | a² → p | a → p² | a²
-    sorry
+    exact pow_dvd_pow_of_dvd (hp.dvd_of_dvd_pow hpn) 2
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 
@@ -128,9 +123,11 @@ numerals are data in Lean, but the expected type is a proposition
 /-- Perfect cubes are powerful. -/
 theorem cube_is_powerful (b : ℕ) (hb : b > 0) : IsPowerful (b^3) := by
   constructor
-  · exact Nat.pos_pow_of_pos 3 hb
+  · exact pow_pos hb 3
   · intro p hp hpn
-    sorry
+    -- p | b³ → p | b → p² | b² | b³
+    have hpb : p ∣ b := hp.dvd_of_dvd_pow hpn
+    exact dvd_trans (pow_dvd_pow_of_dvd hpb 2) (pow_dvd_pow b (by norm_num : 2 ≤ 3))
 
 /-- Products of powerful numbers are powerful. -/
 theorem powerful_mul (m n : ℕ) (hm : IsPowerful m) (hn : IsPowerful n) :
@@ -161,10 +158,10 @@ example : IsPowerful 8 := cube_is_powerful 2 (by omega)
 
 /-- 72 = 8 × 9 = 2³ × 3² is powerful. -/
 theorem _72_is_powerful : IsPowerful 72 := by
-  have h8 := cube_is_powerful 2 (by omega)
-  have h9 := square_is_powerful 3 (by omega)
-  have : 72 = 8 * 9 := by norm_num
-  rw [this]
+  have h8 : IsPowerful 8 := cube_is_powerful 2 (by omega)
+  have h9 : IsPowerful 9 := square_is_powerful 3 (by omega)
+  have h72 : (72 : ℕ) = 8 * 9 := by norm_num
+  rw [h72]
   exact powerful_mul 8 9 h8 h9
 
 /-
@@ -264,10 +261,10 @@ has type
 
 /-- The number of representations of n as sum of 3 powerful numbers. -/
 noncomputable def numRepresentations (n : ℕ) : ℕ :=
-  (Finset.Icc 0 n).filter (fun a =>
-    (Finset.Icc 0 (n - a)).filter (fun b =>
-      IsPowerful a ∧ IsPowerful b ∧ IsPowerful (n - a - b)
-    ).card > 0).card
+  haveI : DecidablePred IsPowerful := Classical.decPred _
+  ((Finset.Icc 0 n).filter (fun a =>
+    ((Finset.Icc 0 (n - a)).filter (fun b =>
+      IsPowerful a ∧ IsPowerful b ∧ IsPowerful (n - a - b))).card > 0)).card
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 
@@ -278,8 +275,8 @@ Hint: Additional diagnostic information may be available using the `set_option d
 /-- Asymptotic density of powerful numbers. -/
 axiom powerful_density :
   ∃ c : ℝ, c > 0 ∧
-    Filter.Tendsto (fun N =>
-      ((Finset.Icc 1 N).filter IsPowerful).card / (N : ℝ)^(1/2))
+    Filter.Tendsto (fun (N : ℕ) =>
+      (@Finset.filter ℕ IsPowerful (Classical.decPred _) (Finset.Icc 1 N)).card / Real.sqrt N)
     Filter.atTop (nhds c)
 
 /-

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 941,
     "erdosUrl": "https://erdosproblems.com/941",
     "erdosProblemStatus": "solved",
@@ -58,14 +58,14 @@
       "generalizedQuestion: Problem #1107 connection"
     ],
     "axiomCount": 4,
-    "lineCount": 327,
-    "assumptions": "4 axiom(s) and 2 sorry(s)."
+    "lineCount": 323,
+    "assumptions": "4 axiom(s) and 0 sorry(s)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #941: Sums of Three Powerful Numbers**\n\nThis problem was posed by Erdős and Ivić at the 1986 Oberwolfach conference, asking whether every sufficiently large integer is the sum of at most three powerful (squarefull) numbers.\n\n**Historical Timeline:**\n- 1970: Golomb proved the characterization $n$ is powerful $\\iff$ $n = a^2 b^3$ for some $a, b \\ge 1$\n- 1976: Erdős studied the distribution of powerful numbers and their additive properties in [Er76d]\n- 1986: Erdős and Ivić formally posed the question at Oberwolfach\n- 1988: Heath-Brown proved the affirmative answer using ternary quadratic forms\n- 1994: Baker and Brüdern proved the complementary result that sums of $\\le 2$ powerful numbers have density 0 (Problem #940)\n\n**Heath-Brown's Method:** The proof uses deep results from the theory of ternary quadratic forms. The key idea is to write $n = a^2 + b^2 c^3 + d^2 e^3$ where each summand is automatically powerful (squarefull). Representing $n$ in this form reduces to showing that a certain ternary quadratic form represents $n$, which Heath-Brown establishes using the Hasse principle and Siegel's mass formula for ternary forms.\n\n**The Threshold Mystery:** Heath-Brown's proof is ineffective — it shows a threshold $N_0$ exists but does not compute it. The ineffectivity comes from the use of Siegel's theorem on ternary forms, which involves class number estimates with ineffective constants. Computing $N_0$ explicitly would require effective bounds in the Hasse principle.\n\n**Phase Transition:** Combined with Baker-Brüdern (1994), we know: sums of $\\le 2$ powerful numbers have density 0, but sums of $\\le 3$ powerful numbers contain all large integers. This sharp 2-to-3 transition is the central phenomenon in the additive theory of powerful numbers.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $n$ be a powerful number if $p \\mid n \\Rightarrow p^2 \\mid n$ for every prime $p$. Are all sufficiently large positive integers the sum of at most three powerful numbers?\n\n**Answer: YES** (Heath-Brown 1988)\n\nEvery sufficiently large positive integer can be written as $a + b + c$ where each of $a, b, c$ is either 0 or a powerful number.",
     "text": "Are all large integers the sum of at most three powerful numbers (p | n → p² | n)? SOLVED: YES (Heath-Brown 1988). Every sufficiently large integer is the sum of at most 3 powerful numbers.",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Powerful Numbers:** `IsPowerful` ($p \\mid n \\Rightarrow p^2 \\mid n$) and `IsPowerfulAlt` ($n = a^2 b^3$), with `powerful_iff_alt` (sorry) connecting them\n2. **Structural Properties:** `one_is_powerful` (proved), `square_is_powerful` (sorry), `cube_is_powerful` (sorry), `powerful_mul` (sorry) — establishing the multiplicative monoid structure\n3. **Sum Framework:** `IsSumOfKPowerful` (general $k$), `IsSumOf3Powerful` (exactly 3), `IsSumOf3PowerfulOrZero` (at most 3)\n4. **Main Question:** `ErdosIvicQuestion` ($\\exists N, \\forall n \\ge N$, representable)\n5. **Heath-Brown:** `heath_brown_theorem` axiom resolving the question affirmatively\n6. **Asymptotics:** `numRepresentations` and `powerful_density` (axiom, $\\sim c\\sqrt{x}$)\n7. **Generalization:** `IsRPowerful r n` and `generalizedQuestion r k` connecting to Problems #940 and #1107",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Powerful Numbers:** `IsPowerful` ($p \\mid n \\Rightarrow p^2 \\mid n$) and `IsPowerfulAlt` ($n = a^2 b^3$), with `powerful_iff_alt` (sorry) connecting them\n2. **Structural Properties:** `one_is_powerful`, `square_is_powerful`, `cube_is_powerful`, `powerful_mul` (all proved) — establishing the multiplicative monoid structure\n3. **Sum Framework:** `IsSumOfKPowerful` (general $k$), `IsSumOf3Powerful` (exactly 3), `IsSumOf3PowerfulOrZero` (at most 3)\n4. **Main Question:** `ErdosIvicQuestion` ($\\exists N, \\forall n \\ge N$, representable)\n5. **Heath-Brown:** `heath_brown_theorem` axiom resolving the question affirmatively\n6. **Asymptotics:** `numRepresentations` and `powerful_density` (axiom, $\\sim c\\sqrt{x}$)\n7. **Generalization:** `IsRPowerful r n` and `generalizedQuestion r k` connecting to Problems #940 and #1107",
     "keyInsights": [
       "**Golomb's characterization**: A number $n$ is powerful if and only if $n = a^2 b^3$ for some $a, b \\ge 1$. The proof uses the division algorithm on prime exponents: $e_i = 2q_i + 3r_i$ with $r_i \\in \\{0, 1\\}$",
       "**Counting function**: The number of powerful numbers $\\le x$ is $\\sim \\frac{\\zeta(3/2)}{\\zeta(3)} \\sqrt{x} \\approx 2.173\\sqrt{x}$. This sublinear growth ($x^{1/2}$) means powerful numbers are sparse, yet 3 summands suffice to represent all large integers",
@@ -92,7 +92,7 @@
       "title": "Powerful Numbers",
       "startLine": 38,
       "endLine": 85,
-      "summary": "Defines `IsPowerful n` ($n > 0 \\wedge \\forall p$ prime, $p \\mid n \\Rightarrow p^2 \\mid n$) and `IsPowerfulAlt n` ($n = a^2 b^3$). States `powerful_iff_alt` (sorry). Proves `one_is_powerful`. States `square_is_powerful`, `cube_is_powerful`, `powerful_mul` (all sorry).",
+      "summary": "Defines `IsPowerful n` ($n > 0 \\wedge \\forall p$ prime, $p \\mid n \\Rightarrow p^2 \\mid n$) and `IsPowerfulAlt n` ($n = a^2 b^3$). Proves `powerful_iff_alt`, `one_is_powerful`, `square_is_powerful`, `cube_is_powerful`, `powerful_mul` (all proved).",
       "mathContext": "Defines `IsPowerful n` ($n > 0 \\wedge \\forall p$ prime, $p \\mid n \\Rightarrow p^2 \\mid n$) and `IsPowerfulAlt n` ($n = a^2 b^3$). Proves `one_is_powerful`."
     },
     {
@@ -132,8 +132,8 @@
       "title": "Small Cases",
       "startLine": 159,
       "endLine": 180,
-      "summary": "Defines `notSumOf3Powerful`. Axiomatizes `small_exceptions` (finitely many integers not representable). States `_2_exceptional_without_zero` (sorry): 2 is not a sum of 3 strictly positive powerful numbers.",
-      "mathContext": "Defines `notSumOf3Powerful`. Axiomatizes `small_exceptions` (finitely many integers not representable). States `_2_exceptional_without_zero` (sorry): 2 is not a sum of 3 strictly positive powerful numbers."
+      "summary": "Defines `notSumOf3Powerful`. Axiomatizes `small_exceptions` (finitely many integers not representable). Proves `_2_exceptional_without_zero`: 2 is not a sum of 3 strictly positive powerful numbers.",
+      "mathContext": "Defines `notSumOf3Powerful`. Axiomatizes `small_exceptions` (finitely many integers not representable). Proves `_2_exceptional_without_zero`: 2 is not a sum of 3 strictly positive powerful numbers."
     },
     {
       "id": "counting-representations",
@@ -161,28 +161,24 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem #941 on sums of three powerful numbers. Heath-Brown's 1988 theorem (axiomatized) resolves the Erdős-Ivić question affirmatively: every sufficiently large integer is the sum of at most 3 powerful numbers. The formalization includes two equivalent definitions of powerful numbers (IsPowerful and IsPowerfulAlt), structural properties (multiplicative monoid, proved for 1, sorry for squares/cubes/products), the sum representation framework, counting functions, and the r-powerful generalization connecting to Problems #940 and #1107. 5 sorries remain (mostly in structural lemmas provable from Mathlib).",
+    "summary": "The formalization captures Erdős Problem #941 on sums of three powerful numbers. Heath-Brown's 1988 theorem (axiomatized) resolves the Erdős-Ivić question affirmatively: every sufficiently large integer is the sum of at most 3 powerful numbers. The formalization includes two equivalent definitions of powerful numbers (IsPowerful and IsPowerfulAlt), structural properties (multiplicative monoid, proved for 1, sorry for squares/cubes/products), the sum representation framework, counting functions, and the r-powerful generalization connecting to Problems #940 and #1107. 0 sorries remain. All structural lemmas (square_is_powerful, cube_is_powerful, powerful_mul, powerful_iff_alt, one_is_powerful) are fully proved.",
     "implications": "**Theoretical Significance**: **Connections to Number Theory**\n\n1. **Ternary Quadratic Forms**: Heath-Brown's proof reduces the representation problem to the theory of ternary quadratic forms, connecting additive number theory to algebraic geometry\n2. **Phase Transition**: The 2-to-3 summand transition (density 0 for 2, density 1 for 3) is a prototype for threshold phenomena in additive combinatorics\n**3. Problem #940**: The companion problem asks whether the diagonal case (r summands of r-powerful numbers) has density 0 for r ≥ 3 — still OPEN\n4. **Problem #1107**: The natural generalization asks for the minimal k such that all large integers are sums of ≤ k r-powerful numbers\n5. **Waring's Problem**: Since perfect r-th powers are r-powerful, Waring-type results are special cases of powerful number sum problems.",
     "openQuestions": [
       "What is the smallest threshold $N_0$ such that all $n \\ge N_0$ are sums of $\\le 3$ powerful numbers? (ineffective in Heath-Brown's proof)",
       "How does the average number of representations $r_3(n)$ grow? Is it $\\Theta(n^{1/2})$ or faster?",
-      "Can the 4 remaining structural sorries (square_is_powerful, cube_is_powerful, powerful_mul, powerful_iff_alt) be resolved via Aristotle proof search?",
-      "For $r$-powerful numbers with $r \\ge 3$, what is the minimal basis order $k(r)$ such that all large integers are sums of $\\le k(r)$ $r$-powerful numbers?",
+            "For $r$-powerful numbers with $r \\ge 3$, what is the minimal basis order $k(r)$ such that all large integers are sums of $\\le k(r)$ $r$-powerful numbers?",
       "Does the Baker-Brüdern density-0 result for 2 squarefull summands extend to 2 cubefull summands (the $r = 3, k = 2$ case)?"
     ]
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Nat.Factorization.Basic",
-      "Mathlib.NumberTheory.Divisors",
-      "Mathlib.Data.Finset.Basic"
+      "Mathlib"
     ],
     "opens": [
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 327,
+    "lineCount": 323,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13


### PR DESCRIPTION
## Summary
- Prove `square_is_powerful` and `cube_is_powerful` (2→0 sorries)
- Fix pre-existing build errors (missing API, import, decidability, types)
- Result: 0 sorries, 4 axioms, 323 lines, clean Docker build

## Changes
- `proofs/Proofs/Erdos941Problem.lean`: Prove both sorry theorems using `Prime.dvd_of_dvd_pow` + `pow_dvd_pow_of_dvd`; fix `one_is_powerful`, imports, `numRepresentations`, `powerful_density`
- `src/data/proofs/erdos-941/meta.json`: Update sorry count, line count, descriptions

## Proof techniques
- `square_is_powerful`: `p | a² → p | a` (Prime.dvd_of_dvd_pow) → `p² | a²` (pow_dvd_pow_of_dvd)
- `cube_is_powerful`: `p | b³ → p | b` → `p² | b²` → `p² | b³` (transitivity via pow_dvd_pow)

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos941Problem`
- [x] 0 sorries verified via grep
- [x] 4 axioms (all legitimate: Heath-Brown theorem, explicit bound, exceptions, density)

🤖 Generated with [Claude Code](https://claude.com/claude-code)