### PR TITLE
Enrich 2 entries: power mean monotonicity, spherical Ceva

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/annotations.json
@@ -97,6 +97,21 @@
     ]
   },
   {
+    "id": "ann-ceva-oq02-oq01-04b-special-cases",
+    "proofId": "cevas-theorem-oq-02-oq-01",
+    "range": {
+      "startLine": 203,
+      "endLine": 216
+    },
+    "type": "insight",
+    "title": "Symmetry and Equal-Weight Special Case",
+    "content": "Two structural results. `weight_balance_symmetric` shows the Ceva condition $\\alpha_D \\alpha_E \\alpha_F = \\beta_D \\beta_E \\beta_F$ is symmetric (proved by `eq_comm` — equality is symmetric, so this is definitional). `equal_weight_ceva` shows that when all weights are equal ($\\alpha_i = \\beta_i = \\alpha$), the product $(\\alpha/\\alpha)^3 = 1$ holds trivially. This is the spherical analogue of the fact that medians of a planar triangle are concurrent — arc-bisecting cevians on the sphere are automatically concurrent.",
+    "mathContext": "Equal weights: $\\alpha_D = \\beta_D = \\alpha_E = \\beta_E = \\alpha_F = \\beta_F = \\alpha$. Then $\\alpha^3 = \\alpha^3$, so the Ceva condition holds. These are the 'spherical medians' — cevians to the midpoints of each arc.",
+    "significance": "supporting",
+    "relatedConcepts": ["eq_comm", "field_simp", "spherical medians", "midpoint of arc"],
+    "prerequisites": ["weight balance criterion"]
+  },
+  {
     "id": "ann-ceva-oq02-oq01-05-main-theorem",
     "proofId": "cevas-theorem-oq-02-oq-01",
     "range": {

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
@@ -104,13 +104,6 @@
       "mathContext": "Working in a generic real inner product space $V$ with $\\|\\cdot\\|$ and $\\langle \\cdot, \\cdot \\rangle$, where unit vectors $A, B, C$ with $\\|A\\|=\\|B\\|=\\|C\\|=1$ represent spherical triangle vertices."
     },
     {
-      "id": "special-cases",
-      "title": "Special Cases and Symmetry",
-      "startLine": 200,
-      "endLine": 262,
-      "summary": "weight_balance_symmetric: the weight-balance condition is symmetric under cyclic permutation of cevians. equal_weight_ceva: equal weights α_i = β_i = 1 give the medial cevians (concurrent by α·α·α = β·β·β = 1). spherical_ceva_iff_weight_balance: the full iff statement connecting the sin-product form to the weight-product form."
-    },
-    {
       "id": "sin-ratio-formula",
       "title": "Sin-Ratio Formula for a Single Cevian",
       "startLine": 60,


### PR DESCRIPTION
## Enrichment batch: 2 entries

### amgm-inequality-oq-03-oq-01 (Negative Power Mean Monotonicity)
- Added 2 new annotations (5→7): exponent negation/reduction setup, explicit inversion calc technique
- Added cross-reference to `cauchy-schwarz` entry

### cevas-theorem-oq-02-oq-01 (Spherical Ceva via Unit Vectors)
- Added 1 new annotation (5→6): symmetry and equal-weight special case
- Fixed duplicate "special-cases" section ID in meta.json