### PR TITLE
Refactor: unify Mathstodon posting pipeline

### DIFF
--- a/.lean/roles/herald.md
+++ b/.lean/roles/herald.md
@@ -234,8 +234,9 @@ Track posted milestones in `.loom/state/herald-posts.json`:
 
 ## Tools
 
-- `./scripts/herald/post-mathstodon.sh "text"` — Post to Mathstodon
-- `./scripts/herald/post-mathstodon.sh --dry-run "text"` — Preview without posting
+- `./scripts/herald/post-mathstodon.sh --automated --subject "KEY" --arc "ARC" "text"` — Post to Mathstodon (updates state automatically)
+- `./scripts/herald/post-mathstodon.sh --dry-run --subject "KEY" "text"` — Preview without posting or updating state
+- `./scripts/herald/post-mathstodon.sh --status` — Check rate limit and recent post history
 - `git log --oneline --since="7 hours ago"` — Recent commits
 - `jq` — Parse state files and meta.json
 - `ls src/data/proofs/{slug}/meta.json` — Verify proof slug exists locally

--- a/scripts/herald/launch-agent.sh
+++ b/scripts/herald/launch-agent.sh
@@ -102,6 +102,39 @@ You are the **herald** agent for Lean Genius. Your mission is to post noteworthy
 - INTERVAL: ${INTERVAL} minutes (${INTERVAL_HOURS} hours)
 - STATE_FILE: ${STATE_FILE}
 - LOG_FILE: ${LOG_FILE}
+- POST_SCRIPT: ${REPO_ROOT}/scripts/herald/post-mathstodon.sh
+
+## Posting Tool
+
+All posting goes through `post-mathstodon.sh`. The script handles:
+- Posting to the Mastodon API
+- Updating state file (post history + daily counts) automatically
+- Rate limit enforcement (max 4 posts/day)
+- Dedup checking (blocks posts with previously-used subject keys)
+- Appending `[automated post]` tag when `--automated` is set
+
+**You do NOT need to manually update the state file.** The script does it for you.
+
+### Usage
+```bash
+# Always use --automated (you are an automated agent)
+# Always provide --subject for dedup tracking
+# Provide --arc when the post belongs to a narrative arc
+${REPO_ROOT}/scripts/herald/post-mathstodon.sh \
+    --automated \
+    --subject "SUBJECT_KEY" \
+    --arc "ARC_NAME" \
+    "POST_TEXT"
+
+# Dry run first if unsure
+${REPO_ROOT}/scripts/herald/post-mathstodon.sh \
+    --dry-run \
+    --subject "SUBJECT_KEY" \
+    "POST_TEXT"
+
+# Check rate limit and recent history
+${REPO_ROOT}/scripts/herald/post-mathstodon.sh --status
+```
 
 ## Your Workflow (Repeat Every Cycle)
 
@@ -118,17 +151,14 @@ fi
 cat ${REPO_ROOT}/.lean/roles/herald.md
 ```
 
-### 3. Check daily rate limit
+### 3. Check rate limit and post history
 ```bash
-TODAY=$(date -u +%Y-%m-%d)
-POSTS_TODAY=$(jq -r --arg d "$TODAY" '.daily_counts[$d] // 0' ${STATE_FILE})
-echo "Posts today: $POSTS_TODAY (max: 2)"
+${REPO_ROOT}/scripts/herald/post-mathstodon.sh --status
 ```
-If already at 2 posts today, skip to sleep.
+If daily rate limit is reached, skip to sleep.
 
-### 4. Load post history (for dedup)
+### 4. Load recent post subjects (for choosing new topics)
 ```bash
-# Recent post subjects to avoid duplicates
 jq -r '.posts[-10:][].subject' ${STATE_FILE} 2>/dev/null || echo "(no history)"
 ```
 
@@ -173,30 +203,34 @@ Skip if nothing meets the threshold.
 If a significant result is found:
 
 a. Compose a post (max 500 chars). Follow the style guide in herald.md.
+   Choose a unique SUBJECT_KEY (e.g., "theorem-name-milestone-type").
+   Choose an ARC_NAME if it fits a narrative arc (e.g., "szemeredi-pipeline", "number-theory").
 
-b. Check it hasn't been posted before:
+b. Dry-run first to verify:
 ```bash
-jq --arg s "SUBJECT_KEY" '.posts[] | select(.subject == $s)' ${STATE_FILE}
+${REPO_ROOT}/scripts/herald/post-mathstodon.sh \
+    --dry-run \
+    --automated \
+    --subject "SUBJECT_KEY" \
+    --arc "ARC_NAME" \
+    "POST_TEXT"
 ```
 
-c. Post it:
+c. If dry-run looks good, post it (dedup + rate limit + state update all handled automatically):
 ```bash
-${REPO_ROOT}/scripts/herald/post-mathstodon.sh "Your post text here"
+${REPO_ROOT}/scripts/herald/post-mathstodon.sh \
+    --automated \
+    --subject "SUBJECT_KEY" \
+    --arc "ARC_NAME" \
+    "POST_TEXT"
 ```
 
-d. Update state:
-```bash
-TODAY=$(date -u +%Y-%m-%d)
-NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-tmp=$(mktemp)
-jq --arg subject "SUBJECT_KEY" \
-   --arg text "POST_TEXT" \
-   --arg url "POST_URL" \
-   --arg ts "$NOW" \
-   --arg day "$TODAY" \
-   '.posts += [{"subject": $subject, "text": $text, "url": $url, "posted_at": $ts}] | .daily_counts[$day] = ((.daily_counts[$day] // 0) + 1)' \
-   ${STATE_FILE} > "$tmp" && mv "$tmp" ${STATE_FILE}
-```
+The script will:
+- Block the post if the subject was already posted (dedup)
+- Block the post if the daily rate limit (4/day) is reached
+- Post to Mastodon API
+- Update the state file with the post record and daily count
+- Append `[automated post]` tag to the text
 
 ### 8. Sleep until next cycle
 ```bash
@@ -208,11 +242,13 @@ sleep ${INTERVAL}m
 
 ## Important Rules
 
-- **Max 1 post per cycle, max 2 posts per day**
+- **Max 1 post per cycle, max 4 posts per day**
 - **Never post about**: build fixes, data syncs, enrichment batches, axiom decomposition
-- **Always check dedup** before posting
-- Posts must be ≤500 characters
+- **Always use --subject** for every post (enables dedup)
+- **Always use --automated** (you are an automated agent)
+- Posts must be ≤500 characters (the [automated post] tag is added by the script and counts toward the limit)
 - Use --dry-run first if unsure about a post
+- Do NOT manually edit the state file — the posting script manages it
 
 Good luck, herald!
 PROMPT_EOF
@@ -318,7 +354,7 @@ check_status() {
             local today_posts
             today_posts=$(jq -r --arg d "$today" '.daily_counts[$d] // 0' "$STATE_FILE" 2>/dev/null || echo "0")
             echo "Total posts: $total_posts"
-            echo "Posts today: $today_posts / 2"
+            echo "Posts today: $today_posts / 4"
 
             if [[ "$total_posts" -gt 0 ]]; then
                 echo ""

--- a/scripts/herald/post-mathstodon.sh
+++ b/scripts/herald/post-mathstodon.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 #
-# post-mathstodon.sh - Post a status to Mathstodon (Mastodon)
+# post-mathstodon.sh - Single source of truth for all Mathstodon posting
+#
+# Posts to Mastodon API, updates state file, enforces rate limits, and dedup.
+# Used by both manual posts and the Herald agent.
 #
 # Usage:
-#   ./post-mathstodon.sh "Your post text here"
-#   ./post-mathstodon.sh --dry-run "Test post"
+#   ./post-mathstodon.sh "Post text here"
+#   ./post-mathstodon.sh --subject "key" --arc "name" "Post text"
+#   ./post-mathstodon.sh --automated --subject "key" --arc "name" "Post text"
+#   ./post-mathstodon.sh --dry-run --subject "key" "Test post"
+#   ./post-mathstodon.sh --status
 #
 # Environment:
 #   MATHSTODON_TOKEN - API access token (read from .env if not set)
@@ -15,6 +21,7 @@ set -euo pipefail
 # Config
 MASTODON_INSTANCE="https://mathstodon.xyz"
 MAX_CHARS=500
+MAX_DAILY_POSTS=4
 
 # Colors
 RED='\033[0;31m'
@@ -25,21 +32,134 @@ NC='\033[0m'
 
 # Find repo root
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+STATE_FILE="$REPO_ROOT/.loom/state/herald-posts.json"
+
+# Ensure state directory and file exist
+init_state() {
+    mkdir -p "$(dirname "$STATE_FILE")"
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo '{"posts": [], "daily_counts": {}}' > "$STATE_FILE"
+    fi
+}
 
 # Load token from .env if not already set
-if [[ -z "${MATHSTODON_TOKEN:-}" ]]; then
-    if [[ -f "$REPO_ROOT/.env" ]]; then
-        MATHSTODON_TOKEN=$(grep '^MATHSTODON_TOKEN=' "$REPO_ROOT/.env" | cut -d= -f2- | tr -d "'\"")
+load_token() {
+    if [[ -z "${MATHSTODON_TOKEN:-}" ]]; then
+        if [[ -f "$REPO_ROOT/.env" ]]; then
+            MATHSTODON_TOKEN=$(grep '^MATHSTODON_TOKEN=' "$REPO_ROOT/.env" | cut -d= -f2- | tr -d "'\"")
+        fi
     fi
-fi
 
-if [[ -z "${MATHSTODON_TOKEN:-}" ]]; then
-    echo -e "${RED}Error: MATHSTODON_TOKEN not set. Add it to .env or export it.${NC}" >&2
-    exit 1
-fi
+    if [[ -z "${MATHSTODON_TOKEN:-}" ]]; then
+        echo -e "${RED}Error: MATHSTODON_TOKEN not set. Add it to .env or export it.${NC}" >&2
+        exit 1
+    fi
+}
+
+# Get today's post count
+get_daily_count() {
+    local today
+    today=$(date -u +%Y-%m-%d)
+    init_state
+    jq -r --arg d "$today" '.daily_counts[$d] // 0' "$STATE_FILE"
+}
+
+# Check if subject was already posted
+check_dedup() {
+    local subject="$1"
+    init_state
+    local existing
+    existing=$(jq -r --arg s "$subject" '[.posts[] | select(.subject == $s)] | length' "$STATE_FILE")
+    if [[ "$existing" -gt 0 ]]; then
+        return 0  # duplicate found
+    fi
+    return 1  # no duplicate
+}
+
+# Update state file after a successful post
+update_state() {
+    local subject="$1"
+    local text="$2"
+    local url="$3"
+    local arc="$4"
+
+    local today now tmp
+    today=$(date -u +%Y-%m-%d)
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    tmp=$(mktemp)
+
+    init_state
+
+    # Build the post object conditionally (include arc only if provided)
+    if [[ -n "$arc" ]]; then
+        jq --arg subject "$subject" \
+           --arg text "$text" \
+           --arg url "$url" \
+           --arg ts "$now" \
+           --arg day "$today" \
+           --arg arc "$arc" \
+           '.posts += [{"subject": $subject, "text": $text, "url": $url, "posted_at": $ts, "arc": $arc}] | .daily_counts[$day] = ((.daily_counts[$day] // 0) + 1)' \
+           "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+    else
+        jq --arg subject "$subject" \
+           --arg text "$text" \
+           --arg url "$url" \
+           --arg ts "$now" \
+           --arg day "$today" \
+           '.posts += [{"subject": $subject, "text": $text, "url": $url, "posted_at": $ts}] | .daily_counts[$day] = ((.daily_counts[$day] // 0) + 1)' \
+           "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+    fi
+}
+
+# Increment daily count only (when no subject is provided)
+increment_daily_count() {
+    local today tmp
+    today=$(date -u +%Y-%m-%d)
+    tmp=$(mktemp)
+
+    init_state
+
+    jq --arg day "$today" \
+       '.daily_counts[$day] = ((.daily_counts[$day] // 0) + 1)' \
+       "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+# Show status
+show_status() {
+    init_state
+    local today total_posts today_posts
+    today=$(date -u +%Y-%m-%d)
+    total_posts=$(jq '.posts | length' "$STATE_FILE")
+    today_posts=$(jq -r --arg d "$today" '.daily_counts[$d] // 0' "$STATE_FILE")
+
+    echo -e "${BLUE}=== Mathstodon Posting Status ===${NC}"
+    echo ""
+    echo "State file: $STATE_FILE"
+    echo "Total posts tracked: $total_posts"
+    echo "Posts today ($today): $today_posts / $MAX_DAILY_POSTS"
+    echo ""
+
+    if [[ "$today_posts" -ge "$MAX_DAILY_POSTS" ]]; then
+        echo -e "${RED}Daily rate limit reached. No more posts today.${NC}"
+    else
+        local remaining=$((MAX_DAILY_POSTS - today_posts))
+        echo -e "${GREEN}$remaining posts remaining today.${NC}"
+    fi
+
+    if [[ "$total_posts" -gt 0 ]]; then
+        echo ""
+        echo "Last 5 posts:"
+        jq -r '.posts[-5:][] | "  [\(.posted_at)] \(.subject // "(no subject)"): \(.text[0:70])..."' "$STATE_FILE" 2>/dev/null || true
+    fi
+
+    exit 0
+}
 
 # Parse arguments
 DRY_RUN=false
+AUTOMATED=false
+SUBJECT=""
+ARC=""
 TEXT=""
 
 while [[ $# -gt 0 ]]; do
@@ -47,6 +167,50 @@ while [[ $# -gt 0 ]]; do
         --dry-run)
             DRY_RUN=true
             shift
+            ;;
+        --automated)
+            AUTOMATED=true
+            shift
+            ;;
+        --subject)
+            SUBJECT="$2"
+            shift 2
+            ;;
+        --arc)
+            ARC="$2"
+            shift 2
+            ;;
+        --status)
+            show_status
+            ;;
+        --help|-h)
+            cat << 'EOF'
+post-mathstodon.sh - Single source of truth for Mathstodon posting
+
+Usage:
+  ./post-mathstodon.sh "Post text"
+  ./post-mathstodon.sh --subject "key" --arc "name" "Post text"
+  ./post-mathstodon.sh --automated --subject "key" --arc "name" "Post text"
+  ./post-mathstodon.sh --dry-run --subject "key" "Test post"
+  ./post-mathstodon.sh --status
+
+Options:
+  --subject KEY    Dedup key for tracking (prevents double-posting)
+  --arc NAME       Narrative arc this post belongs to
+  --automated      Append [automated post] tag (for Herald agent)
+  --dry-run        Show what would happen without posting or updating state
+  --status         Show current rate limit and recent post history
+  --help           Show this help
+
+Environment:
+  MATHSTODON_TOKEN   API access token (read from .env if not set)
+EOF
+            exit 0
+            ;;
+        -*)
+            echo -e "${RED}Error: Unknown option: $1${NC}" >&2
+            echo "Run '$0 --help' for usage" >&2
+            exit 1
             ;;
         *)
             TEXT="$1"
@@ -56,14 +220,16 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$TEXT" ]]; then
-    echo "Usage: $0 [--dry-run] \"Post text\"" >&2
+    echo "Usage: $0 [--dry-run] [--automated] [--subject KEY] [--arc NAME] \"Post text\"" >&2
     exit 1
 fi
 
-# Append automated post tag
-TEXT="${TEXT}
+# Append automated post tag only when --automated is set
+if [[ "$AUTOMATED" == "true" ]]; then
+    TEXT="${TEXT}
 
 [automated post]"
+fi
 
 # Validate character limit
 CHAR_COUNT=${#TEXT}
@@ -72,11 +238,41 @@ if [[ $CHAR_COUNT -gt $MAX_CHARS ]]; then
     exit 1
 fi
 
+# Initialize state
+init_state
+
+# Check daily rate limit
+DAILY_COUNT=$(get_daily_count)
+if [[ "$DAILY_COUNT" -ge "$MAX_DAILY_POSTS" ]]; then
+    echo -e "${RED}Error: Daily rate limit reached ($DAILY_COUNT/$MAX_DAILY_POSTS posts today)${NC}" >&2
+    echo -e "${YELLOW}Use --status to see recent posts.${NC}" >&2
+    exit 1
+fi
+
+# Check dedup if subject provided
+if [[ -n "$SUBJECT" ]]; then
+    if check_dedup "$SUBJECT"; then
+        echo -e "${RED}Error: Subject '$SUBJECT' already posted. Skipping duplicate.${NC}" >&2
+        echo -e "${YELLOW}Existing post:${NC}" >&2
+        jq -r --arg s "$SUBJECT" '.posts[] | select(.subject == $s) | "  [\(.posted_at)] \(.url)"' "$STATE_FILE" >&2
+        exit 1
+    fi
+fi
+
+# Dry run: show what would happen
 if [[ "$DRY_RUN" == "true" ]]; then
     echo -e "${YELLOW}[DRY RUN] Would post ($CHAR_COUNT chars):${NC}"
     echo "$TEXT"
+    echo ""
+    echo -e "${BLUE}State updates that would be applied:${NC}"
+    echo "  Subject: ${SUBJECT:-"(none - post won't be tracked for dedup)"}"
+    echo "  Arc: ${ARC:-"(none)"}"
+    echo "  Daily count: $DAILY_COUNT -> $((DAILY_COUNT + 1)) / $MAX_DAILY_POSTS"
     exit 0
 fi
+
+# Load token (only needed for actual posting)
+load_token
 
 # Post via Mastodon API
 # Use jq for proper JSON escaping of the status text
@@ -100,6 +296,16 @@ if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
         echo "$POST_URL"
     fi
     echo "$POST_ID"
+
+    # Update state file
+    if [[ -n "$SUBJECT" ]]; then
+        update_state "$SUBJECT" "$TEXT" "${POST_URL:-""}" "$ARC"
+        echo -e "${BLUE}State updated: subject='$SUBJECT'${ARC:+", arc='$ARC'"}${NC}"
+    else
+        # No subject: just increment daily count
+        increment_daily_count
+        echo -e "${YELLOW}Warning: No --subject provided. Post tracked in daily count but not in dedup history.${NC}"
+    fi
 else
     ERROR_MSG=$(echo "$BODY" | jq -r '.error // "Unknown error"' 2>/dev/null || echo "$BODY")
     echo -e "${RED}Error posting (HTTP $HTTP_CODE): $ERROR_MSG${NC}" >&2


### PR DESCRIPTION
## Summary

- Refactors `scripts/herald/post-mathstodon.sh` to be the **single source of truth** for all Mathstodon posting — both manual posts and Herald agent posts now share the same pipeline
- The script now handles API posting, state file updates, daily rate limit enforcement (max 4/day), and dedup checking — previously the Herald agent had to do state management manually via jq
- Adds `--subject`, `--arc`, `--automated`, and `--status` flags; `[automated post]` tag is now opt-in via `--automated` instead of always appended
- Updates Herald agent prompt in `launch-agent.sh` to use the new flags, removing the fragile manual state update steps (old steps 7c/7d merged into a single script call)
- Updates Herald role definition (`.lean/roles/herald.md`) with the new tool interface

## Files changed

| File | Change |
|------|--------|
| `scripts/herald/post-mathstodon.sh` | Full rewrite: state management, rate limiting, dedup, new CLI flags |
| `scripts/herald/launch-agent.sh` | Updated Herald prompt (steps 3/7), fixed daily limit display (2 -> 4) |
| `.lean/roles/herald.md` | Updated Tools section with new CLI interface |

## New CLI interface

```bash
# Manual post (no [automated post] tag)
./scripts/herald/post-mathstodon.sh "Post text here"

# Manual post with dedup tracking
./scripts/herald/post-mathstodon.sh --subject "key" --arc "name" "Post text"

# Herald automated post (appends [automated post])
./scripts/herald/post-mathstodon.sh --automated --subject "key" --arc "name" "Post text"

# Dry run (no posting, no state update)
./scripts/herald/post-mathstodon.sh --dry-run --subject "key" "Test post"

# Check rate limit status
./scripts/herald/post-mathstodon.sh --status
```

## Test plan

- [ ] Verify `--dry-run` shows correct output without posting or updating state
- [ ] Verify `--status` shows rate limit and recent history
- [ ] Verify `--automated` appends `[automated post]` tag, omitted without the flag
- [ ] Verify dedup blocks a post when `--subject` matches an existing entry
- [ ] Verify rate limit blocks when daily count >= 4
- [ ] Verify state file is updated after successful post (subject, arc, daily count)
- [ ] Verify Herald agent prompt references the new flags correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)