### PR TITLE
Enrich abel-ruffini-oq-04-oq-01: add annotation coverage + cross-references

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
@@ -528,5 +528,54 @@
       "group theory (normal subgroups)",
       "simplicity of A5"
     ]
+  },
+  {
+    "id": "ann-abeloq04oq01-complex-conj",
+    "proofId": "abel-ruffini-oq-04-oq-01",
+    "range": {
+      "startLine": 909,
+      "endLine": 996
+    },
+    "type": "technique",
+    "title": "Complex Conjugation as Galois Automorphism: The Key Original Technique",
+    "content": "The proof's most original contribution: constructing a Galois automorphism from complex conjugation, entirely avoiding Dedekind's theorem. The construction: (1) `IsAlgClosed.lift` embeds $SF \\hookrightarrow \\mathbb{C}$, (2) `starRingEnd \\mathbb{C}$ (complex conjugation) is packaged as a $\\mathbb{Q}$-algebra homomorphism, (3) the composition is restricted back to $SF$ via `AlgHom.restrictNormal'` yielding $\\sigma_{\\text{conj}} \\in \\text{Gal}(p)$, (4) the sign of $\\sigma_{\\text{conj}}$ is $-1$ by contradiction: if $+1$, then $\\sigma_{\\text{conj}}(\\Delta) = \\Delta$, so $\\text{sfEmb}(\\Delta) \\in \\mathbb{R}$ (conjugation-invariant), but $\\text{sfEmb}(\\Delta)^2 = -212144 < 0$ contradicts $r^2 \\geq 0$. The involutory property $\\sigma_{\\text{conj}}^2 = 1$ confirms it acts as a transposition.",
+    "mathContext": "$SF \\xrightarrow{\\text{lift}} \\mathbb{C} \\xrightarrow{\\bar{z}} \\mathbb{C} \\xrightarrow{\\text{restrict}} SF$ gives $\\sigma_{\\text{conj}} \\in \\text{Gal}(p/\\mathbb{Q})$ with $\\sigma^2 = 1$, $\\text{sign}(\\sigma) = -1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsAlgClosed.lift",
+      "starRingEnd",
+      "AlgHom.restrictNormal",
+      "complex conjugation",
+      "involution"
+    ],
+    "prerequisites": [
+      "splitting field normality",
+      "vandermondeProduct_sq_val",
+      "Galois group as automorphism group"
+    ]
+  },
+  {
+    "id": "ann-abeloq04oq01-sylow-elim",
+    "proofId": "abel-ruffini-oq-04-oq-01",
+    "range": {
+      "startLine": 998,
+      "endLine": 1341
+    },
+    "type": "technique",
+    "title": "Sylow Elimination: Transposition vs Unique Normal Sylow 5-Subgroup",
+    "content": "Proves $3 \\mid |\\text{Gal}|$ by eliminating non-3-divisible orders $\\{5, 10, 20, 40\\}$. The uniform argument: at each candidate order, the unique Sylow 5-subgroup is normal, so every element normalizes it — but `native_decide` verifies no transposition in $S_5$ normalizes any 5-cycle, contradicting `gal_has_transposition`. **Order 5**: 5-cycles are even, contradicting the odd transposition. **Orders 10, 20, 40**: The Frobenius group $F_{20} = \\text{Norm}_{S_5}(\\langle c_5 \\rangle)$ contains no transpositions. Unique Sylow 5-subgroup at these orders forces the transposition to normalize a 5-cycle — impossible. **Synthesis** (`three_dvd_gal_card`): $|\\text{Gal}| \\notin \\{5,10,20,40\\}$ with $|\\text{Gal}| \\mid 120$ and $5 \\mid |\\text{Gal}|$ gives $3 \\mid |\\text{Gal}|$.",
+    "mathContext": "For $n \\in \\{5,10,20,40\\}$: $H \\leq S_5$, $|H| = n$, $5 \\mid |H|$ $\\Rightarrow$ unique $P_5 \\trianglelefteq H$. Transposition $\\tau \\in H$ must normalize $P_5$, but no $\\tau \\in S_5$ normalizes any 5-cycle. Therefore $|\\text{Gal}| \\notin \\{5,10,20,40\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sylow theorems",
+      "Frobenius group F_20",
+      "normalizer",
+      "native_decide"
+    ],
+    "prerequisites": [
+      "gal_has_transposition",
+      "Sylow theory",
+      "transposition_not_normalizing_5cycle"
+    ]
   }
 ]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -148,6 +148,16 @@
       "targetId": "vietas-formulas",
       "relationship": "foundational",
       "description": "Vieta's formulas express the coefficients of $x^5 - 4x + 2$ as elementary symmetric functions of its roots — this is why the Galois group permutes roots while preserving coefficients, and why the `galActionHom` maps $\\text{Gal}$ into $\\text{Perm}(\\text{rootSet})$"
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "related",
+      "description": "Both are impossibility results proved via Galois theory: Abel-Ruffini (this entry's concrete instance) shows $x^5-4x+2$ is unsolvable by radicals because $\\text{Gal} \\cong S_5$ is non-solvable, while angle trisection shows the general angle cannot be trisected by compass and straightedge because the minimal polynomial of $\\cos(20°)$ has degree 3 over the constructible field extension. Both reduce geometric/algebraic impossibility to group-theoretic obstructions"
+    },
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "foundational",
+      "description": "Kummer theory provides the mechanism underlying the Galois bridge used in `roots_not_solvable_by_rad`: each radical extraction $K \\to K(\\sqrt[n]{a})$ creates a Kummer extension with cyclic Galois group. The impossibility arises because $S_5$ cannot be decomposed into such cyclic layers — exactly what the contrapositive of `solvableByRad.isSolvable'` captures"
     }
   ],
   "overview": {

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -59,7 +59,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Riemann Hypothesis (1859) for the zeta function was generalized by Piltz (1884) to Dirichlet L-functions. GRH predicts that ALL non-trivial zeros of L(s, χ) for ANY Dirichlet character χ lie on the critical line Re(s) = 1/2.\n\nGRH is strictly stronger than RH: it addresses infinitely many L-functions, not just ζ(s). A proof of GRH would have immediate, dramatic consequences for prime distribution in arithmetic progressions, computational number theory, and cryptography.\n\nThe consequences are well-studied: under GRH, the error term in the PNT for APs improves from O(x · exp(-c√log x)) to O(√x · log x), Linnik's bound drops from O(q^5) to O(q² log² q), and Siegel zeros are eliminated entirely.",
+    "historicalContext": "The Riemann Hypothesis (1859) for the zeta function was generalized by Piltz (1884) to Dirichlet L-functions. GRH predicts that ALL non-trivial zeros of L(s, χ) for ANY Dirichlet character χ lie on the critical line Re(s) = 1/2.\n\nGRH is strictly stronger than RH: it addresses infinitely many L-functions, not just ζ(s). A proof of GRH would have immediate, dramatic consequences for prime distribution in arithmetic progressions, computational number theory, and cryptography.\n\nThe consequences are well-studied: under GRH, the error term in the PNT for APs improves from O(x · exp(-c√log x)) to O(√x · log x), Linnik's bound drops from the best unconditional exponent L ≤ 5 (Xylouris, 2011) to effectively L = 2, i.e., O(q² log² q). The Montgomery-Vaughan improvement (1977) of character sums from O(√q log q) to O(√q log log q) under GRH remains one of the deepest consequences.\n\nGRH also eliminates Siegel zeros entirely. Siegel's 1935 ineffective bound |L(1,χ)| ≫ q^{-ε} (with an uncomputable constant) is replaced under GRH by the effective bound |L(1,χ)| ≥ C/(log q)². Goldfeld (1985) resolved the class number problem using Gross-Zagier, but the unconditional bound h(d) ≫ (log|d|)^{1-ε} remains far weaker than the GRH prediction h(d) ≥ C√|d|/log|d|.",
     "problemStatement": "**Open Question**: Does the Generalized Riemann Hypothesis hold for all Dirichlet L-functions? That is, for every Dirichlet character χ modulo q, do all zeros of L(s, χ) with 0 < Re(s) < 1 satisfy Re(s) = 1/2?\n\n**Status**: OPEN. No proof or counterexample exists. Computational verification extends to billions of zeros.\n\n**Key formalization**: We prove GRH ↔ GRH_right_half (no zeros with Re(s) > 1/2), using the functional equation symmetry. We axiomatize all major consequences and prove theorems connecting them.",
     "text": "The Generalized Riemann Hypothesis (GRH) asserts that all non-trivial zeros of Dirichlet L-functions L(s, χ) lie on the critical line Re(s) = 1/2. We formalize GRH, prove equivalences between formulations, and axiomatize its dramatic consequences for prime distribution, character sums, and class numbers.",
     "proofStrategy": "We formalize GRH in three layers:\n\n**1. Definitions**: GRH_for_character (per-character), GRH (all characters), GRH_right_half (no zeros with Re > 1/2).\n\n**2. Proved equivalences**: GRH ↔ GRH_right_half via the functional equation axiom. GRH_right_half = GRH_via_log_derivative.\n\n**3. Consequences (axiomatized)**: Improved PNT for APs, effective Linnik bound, Montgomery-Vaughan character sum improvement, effective L(1,χ) lower bound, class number bounds. Each is stated precisely with the GRH hypothesis.\n\n**4. Connections**: GRH eliminates Siegel zeros (proved from definitions), comprehensive nonvanishing for σ > 1/2 (proved combining GRH, Dirichlet, Euler product).",
@@ -164,6 +164,11 @@
       "targetId": "prime-number-theorem",
       "relationship": "extends",
       "description": "GRH refines the PNT error term for primes in APs from O(x exp(-c√log x)) to O(√x log x), and removes restrictions on the modulus q"
+    },
+    {
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "The divergence of the prime reciprocal series is a consequence of the PNT; GRH strengthens the rate of divergence for primes in arithmetic progressions"
     }
   ],
   "references": [
@@ -201,6 +206,13 @@
       "year": "1985",
       "venue": "Bulletin of the AMS",
       "note": "Solved the class number problem using Gross-Zagier; the unconditional bound h(d) ≫ (log|d|)^{1-ε} is far weaker than the GRH bound"
+    },
+    {
+      "authors": "Carl Ludwig Siegel",
+      "title": "Über die Classenzahl quadratischer Zahlkörper",
+      "year": "1935",
+      "venue": "Acta Arithmetica",
+      "note": "Proved the ineffective lower bound |L(1,χ)| ≫ q^{-ε}; the ineffectivity arises from the possible existence of Siegel zeros, which GRH eliminates"
     }
   ]
 }

--- a/src/data/proofs/dirichlets-theorem-oq-02/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-key-lemma",
+    "proofId": "dirichlets-theorem-oq-02",
+    "range": { "startLine": 17, "endLine": 53 },
+    "type": "technique",
+    "title": "Key Lemma: Prime Factor 3 mod 4",
+    "content": "The key lemma proves that any $n > 1$ with $n \\equiv 3 \\pmod{4}$ has a prime factor $p \\equiv 3 \\pmod{4}$. The proof uses strong induction (`termination_by n`): take any prime factor $p$ of $n$. If $p \\equiv 3$, done. Otherwise $p$ must be odd (since $n$ is odd) and $p \\equiv 1 \\pmod{4}$. Then $n/p \\equiv 3 \\pmod{4}$ (since $1 \\cdot k \\equiv 3$ forces $k \\equiv 3$) and $n/p < n$, so induction applies. The multiplicativity of residues mod 4 is the engine driving the argument.",
+    "mathContext": "$n > 1,\\; n \\equiv 3 \\pmod{4} \\implies \\exists p \\mid n,\\; p \\text{ prime},\\; p \\equiv 3 \\pmod{4}$",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "prime factorization", "modular arithmetic", "well-founded recursion"],
+    "prerequisites": ["prime divisibility", "modular arithmetic", "well-founded induction"]
+  },
+  {
+    "id": "ann-mod4-multiplicativity",
+    "proofId": "dirichlets-theorem-oq-02",
+    "range": { "startLine": 31, "endLine": 48 },
+    "type": "insight",
+    "title": "Mod-4 Multiplicativity of Residues",
+    "content": "The critical algebraic fact: products of integers $\\equiv 1 \\pmod{4}$ are themselves $\\equiv 1 \\pmod{4}$. Contrapositively, if $n \\equiv 3 \\pmod{4}$ and $p \\mid n$ with $p \\equiv 1 \\pmod{4}$, then $n/p \\equiv 3 \\pmod{4}$. In Lean this is proved by rewriting `Nat.mul_mod` and simplifying. This multiplicative closure of the residue class $\\{1 \\bmod 4\\}$ is the group-theoretic core: $(\\mathbb{Z}/4\\mathbb{Z})^\\times = \\{1, 3\\}$ is cyclic of order 2, and the subgroup $\\{1\\}$ is closed under multiplication.",
+    "mathContext": "$p \\equiv 1 \\pmod{4},\\; p \\cdot k \\equiv 3 \\pmod{4} \\implies k \\equiv 3 \\pmod{4}$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative group mod 4", "group theory", "Nat.mul_mod", "residue classes"],
+    "prerequisites": ["modular arithmetic", "group structure of units"]
+  },
+  {
+    "id": "ann-euclid-construction",
+    "proofId": "dirichlets-theorem-oq-02",
+    "range": { "startLine": 55, "endLine": 72 },
+    "type": "technique",
+    "title": "Euclid-Style Construction: N = 4(n+1)! - 1",
+    "content": "The main theorem constructs $N = 4(n+1)! - 1$ for any given bound $n$. This construction ensures three properties simultaneously: (1) $N \\equiv 3 \\pmod{4}$ since $4(n+1)! \\equiv 0 \\pmod{4}$ and subtracting 1 gives residue 3; (2) $N > 1$ since $(n+1)! \\geq 1$; (3) any prime $p \\leq n+1$ divides $(n+1)!$ hence $4(n+1)! = N+1$ but not $N$ (since $\\gcd(N, N+1) = 1$). This is a direct generalization of Euclid's proof of the infinitude of primes.",
+    "mathContext": "$N = 4(n+1)! - 1 \\implies N \\equiv 3 \\pmod{4},\\; N > 1,\\; p \\leq n+1 \\implies p \\nmid N$",
+    "significance": "key",
+    "relatedConcepts": ["Euclid's proof", "factorial", "coprimality", "infinitude of primes"],
+    "prerequisites": ["factorial properties", "prime divisibility of factorial"]
+  },
+  {
+    "id": "ann-contradiction",
+    "proofId": "dirichlets-theorem-oq-02",
+    "range": { "startLine": 73, "endLine": 95 },
+    "type": "technique",
+    "title": "Contradiction: p | N and p | N+1 Impossible",
+    "content": "The contradiction argument shows any prime factor $p \\equiv 3 \\pmod{4}$ of $N$ must satisfy $p > n$. Assuming $p \\leq n$, we get $p \\leq n+1$, so $p \\mid (n+1)!$ (by `Nat.Prime.dvd_factorial`), hence $p \\mid 4(n+1)! = N+1$. But $p \\mid N$ and $p \\mid N+1$ implies $p \\mid 1$, contradicting $p \\geq 2$. The Lean proof uses `nlinarith` to derive $p \\leq 1$ from the equations $N = p \\cdot a$ and $N+1 = p \\cdot b$, which give $p(b-a) = 1$.",
+    "mathContext": "$p \\mid N \\land p \\mid (N+1) \\implies p \\mid \\gcd(N, N+1) = 1 \\implies p \\leq 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["GCD property", "consecutive integers coprime", "proof by contradiction", "nlinarith"],
+    "prerequisites": ["divisibility", "prime properties", "GCD of consecutive integers"]
+  },
+  {
+    "id": "ann-existence-witness",
+    "proofId": "dirichlets-theorem-oq-02",
+    "range": { "startLine": 97, "endLine": 101 },
+    "type": "context",
+    "title": "Existence Witness: 3 is Prime with 3 mod 4 = 3",
+    "content": "The theorem `exists_prime_three_mod_four` witnesses that the set $\\{p : p \\text{ prime}, p \\equiv 3 \\pmod{4}\\}$ is nonempty by exhibiting $p = 3$. Both conditions ($3$ is prime, $3 \\bmod 4 = 3$) are discharged by `norm_num`. While trivial, this witness is useful as a base case and confirms the set whose infinitude was just proved is not vacuously defined.",
+    "mathContext": "$3 \\in \\{p : p \\text{ prime},\\; p \\equiv 3 \\pmod{4}\\}$",
+    "significance": "supporting",
+    "relatedConcepts": ["existence witness", "norm_num", "nonempty set"],
+    "prerequisites": ["primality of 3"]
+  }
+]

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -114,6 +114,11 @@
       "targetId": "dirichlets-theorem-oq-02-oq-01",
       "relationship": "parent",
       "description": "Parent entry for the GRH sub-question about Dirichlet L-functions"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "related",
+      "description": "The PNT gives asymptotic density of primes; this result shows infinitely many primes in the specific residue class 3 mod 4, a qualitative refinement that PNT alone does not capture"
     }
   ],
   "references": [
@@ -123,6 +128,13 @@
       "year": "1837",
       "venue": "Abhandlungen der Königlichen Preußischen Akademie der Wissenschaften",
       "note": "Original proof of the general theorem; this entry formalizes the elementary special case for 3 mod 4"
+    },
+    {
+      "authors": "Daniel A. Marcus",
+      "title": "Number Fields",
+      "year": "1977",
+      "venue": "Springer-Verlag, Universitext",
+      "note": "Chapter 4 discusses primes in arithmetic progressions and the special cases admitting elementary proofs, including primes ≡ 3 (mod 4)"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for abel-ruffini-oq-04-oq-01 (pass 1).

Closes the largest annotation coverage gap: lines 909-1341 (~430 lines of the most important proof content) previously had no annotations. These sections contain the proof's most original contributions.

**Annotations added (21 → 23):**
- **Complex conjugation as Galois automorphism** (lines 909-996): Documents the key original technique — constructing a Galois automorphism via `IsAlgClosed.lift` + `starRingEnd` + `restrictNormal`, proving sign = -1 via the FTGT discriminant argument
- **Sylow elimination of non-3-divisible orders** (lines 998-1341): Documents the uniform elimination of orders {5, 10, 20, 40} via transposition vs unique normal Sylow 5-subgroup

**Cross-references added (12 → 14):**
- `angle-trisection`: Related Galois impossibility result
- `kummer-theorem`: Foundational — Kummer theory underpins the radical tower mechanism