### PR TITLE
Bump Herald posting limits: 3h cycle, 8/day

### DIFF
--- a/.lean/roles/herald.md
+++ b/.lean/roles/herald.md
@@ -70,8 +70,8 @@ Use your judgment. If it would interest someone who follows #LeanProver or #Form
 
 ## Rate Limits
 
-- **Max 1 post per scan cycle** (6 hours default)
-- **Max 4 posts per calendar day (UTC)**
+- **Max 2 posts per scan cycle** (3 hours default)
+- **Max 8 posts per calendar day (UTC)**
 - If multiple results exist, **consolidate into one richer post** or save for next cycle
 - Prefer 1 substantial post over 3 thin announcements
 

--- a/scripts/herald/launch-agent.sh
+++ b/scripts/herald/launch-agent.sh
@@ -38,7 +38,7 @@ SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 STATE_DIR="$REPO_ROOT/.loom/state"
 SESSION_NAME="herald-agent"
 LOG_FILE="$LOGS_DIR/herald.log"
-INTERVAL="${HERALD_INTERVAL:-360}"
+INTERVAL="${HERALD_INTERVAL:-180}"
 STATE_FILE="$STATE_DIR/herald-posts.json"
 
 # Colors

--- a/scripts/herald/post-mathstodon.sh
+++ b/scripts/herald/post-mathstodon.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Config
 MASTODON_INSTANCE="https://mathstodon.xyz"
 MAX_CHARS=500
-MAX_DAILY_POSTS=4
+MAX_DAILY_POSTS=8
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
- Herald scan interval: 6h → 3h (more frequent posting opportunities)
- Daily post limit: 4 → 8
- Posts per cycle: 1 → 2

Growing the Mathstodon presence — more frequent quality posts to build engagement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)