### PR TITLE
Enrich area-of-circle: trim cross-references (14→11)

### DIFF
--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -144,74 +144,59 @@
   },
   "crossReferences": [
     {
-      "targetId": "pi-transcendental",
-      "relationship": "related",
-      "description": "π is transcendental (Lindemann 1882) — the same constant whose geometric meaning as the area-to-radius-squared ratio this file formalizes. Transcendence means πr² cannot be a constructible area for all r"
-    },
-    {
-      "targetId": "pythagorean-theorem",
-      "relationship": "foundational",
-      "description": "The circle x²+y²=r² is defined by the Pythagorean relation — the equation underpinning the Lebesgue measure computation of the disk's area"
-    },
-    {
-      "targetId": "hermite-lindemann",
-      "relationship": "related",
-      "description": "The Hermite-Lindemann theorem proves π is transcendental, meaning the area πr² is transcendental for all nonzero algebraic r — connecting the geometric formula to number-theoretic impossibility"
-    },
-    {
-      "targetId": "basel-problem",
-      "relationship": "related",
-      "description": "Euler's Basel problem (∑1/n² = π²/6) provides another unexpected appearance of π — the same constant whose geometric meaning as the area-to-radius² ratio is formalized here. Euler's proof connecting ∑1/n² to sin(x)/x reveals π's dual role in geometry and analysis"
-    },
-    {
       "targetId": "area-of-circle-oq-01",
       "relationship": "extended-by",
-      "description": "Derives the circumference formula $C = 2\\pi r$ via differentiation of the area $A = \\pi r^2$ with respect to $r$ — the infinitesimal shell argument that $dA/dr = C$ connects area and perimeter"
+      "description": "Derives circumference $C = 2\\pi r$ via differentiation of area — the infinitesimal shell argument $dA/dr = C$"
     },
     {
       "targetId": "area-of-circle-oq-03",
       "relationship": "extended-by",
-      "description": "Formalizes Archimedes' method of exhaustion directly: approximating the circle's area by inscribed and circumscribed regular polygons, providing the historical approach that this file's measure-theoretic proof subsumes"
-    },
-    {
-      "targetId": "intermediate-value-theorem",
-      "relationship": "foundational",
-      "description": "The intermediate value theorem underpins the continuity arguments needed for integration. Archimedes' method of exhaustion is essentially a continuity argument — the area function $A(r) = \\pi r^2$ is continuous, and the method of exhaustion proves equalities by showing the difference can be made arbitrarily small"
-    },
-    {
-      "targetId": "isoperimetric-theorem",
-      "relationship": "complementary",
-      "description": "The isoperimetric inequality states that among all planar curves of fixed perimeter $L$, the circle encloses the maximum area $L^2/(4\\pi)$. This provides a variational characterization of the circle: $A = \\pi r^2$ is the maximum area achievable with perimeter $C = 2\\pi r$. Equality holds if and only if the curve is a circle, making the area formula a consequence of the isoperimetric optimality"
+      "description": "Formalizes Archimedes' method of exhaustion: approximating circle area by inscribed/circumscribed regular polygons"
     },
     {
       "targetId": "area-of-circle-oq-01-oq-02",
       "relationship": "extended-by",
-      "description": "Derives the area formula by integrating circumference: $A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$, showing the circle's area as the accumulation of concentric ring circumferences — a radial integration approach complementing the Cartesian disk-area proof"
-    },
-    {
-      "targetId": "area-of-circle-oq-01-oq-03",
-      "relationship": "extended-by",
-      "description": "The isoperimetric inequality $C^2 \\geq 4\\pi A$ with equality iff the curve is a circle — the variational characterization showing the circle maximizes area for a given perimeter, connecting the area formula $\\pi r^2$ to the deep optimality of circular geometry"
+      "description": "Derives area by integrating circumference: $A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$ — the radial integration approach"
     },
     {
       "targetId": "area-of-circle-oq-03-oq-02",
       "relationship": "extended-by",
-      "description": "Archimedes' bounds $223/71 < \\pi < 22/7$ via inscribed and circumscribed regular 96-gons — the computational complement to the area formula, providing the first rigorous numerical approximation of the constant $\\pi$ that appears in $A = \\pi r^2$"
+      "description": "Archimedes' bounds $223/71 < \\pi < 22/7$ via 96-gons — first rigorous numerical approximation of $\\pi$"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The circle $x^2+y^2=r^2$ is defined by the Pythagorean relation — underpinning the disk's Lebesgue measure computation"
+    },
+    {
+      "targetId": "pi-transcendental",
+      "relationship": "related",
+      "description": "$\\pi$ is transcendental (Lindemann 1882) — the same constant whose geometric meaning as the area-to-radius-squared ratio this file formalizes"
+    },
+    {
+      "targetId": "isoperimetric-theorem",
+      "relationship": "complementary",
+      "description": "The circle maximizes area for a given perimeter: $A = \\pi r^2$ is the supremum of $A(\\gamma)$ over curves with length $2\\pi r$"
     },
     {
       "targetId": "lebesgue-measure",
       "relationship": "foundational",
-      "description": "This proof formalizes area as Lebesgue measure $\\lambda^2$. The Lebesgue measure entry provides the measure-theoretic infrastructure underpinning `MeasureTheory.volume` and the $n$-dimensional ball volume formula $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ that specializes to $\\pi r^2$ for $n=2$"
+      "description": "Area formalized as Lebesgue measure $\\lambda^2$, using the $n$-ball volume $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ specialized to $n=2$"
     },
     {
-      "targetId": "fundamental-theorem-calculus",
-      "relationship": "foundational",
-      "description": "The annular ring derivation of $A = \\pi r^2$ is a direct application of the Fundamental Theorem of Calculus: $A(r) = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$, and the derivative relationship $A'(r) = C(r) = 2\\pi r$ is FTC in action. The measure-theoretic proof in this file uses Fubini's theorem (the higher-dimensional analog) rather than FTC directly, but the connection between area and circumference via differentiation is a central pedagogical theme"
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Euler's $\\sum 1/n^2 = \\pi^2/6$ reveals $\\pi$'s dual role in geometry (area ratio) and analysis (infinite series)"
     },
     {
-      "targetId": "area-of-circle-oq-01-oq-02-oq-01",
-      "relationship": "extended-by",
-      "description": "Generalizes the circumference-to-area integration to $n$ dimensions: derives $V_n(r)$ from $S_n(r)$ via $V_n(r) = \\int_0^r S_n(\\rho)\\, d\\rho$, extending the annular ring argument from the 2D case ($A = \\int_0^r 2\\pi\\rho\\, d\\rho$) to arbitrary dimension"
+      "targetId": "greens-theorem",
+      "relationship": "related",
+      "description": "Green's theorem gives area as a line integral: $A = \\frac{1}{2}\\oint (x\\,dy - y\\,dx) = \\pi r^2$ for a circle — a vector calculus proof"
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "related",
+      "description": "Buffon's needle (1733) gives a probabilistic method for computing $\\pi$: $P(\\text{crossing}) = 2\\ell/(\\pi d)$, linking circle geometry to integral geometry"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for area-of-circle. Trimmed 5 weak/redundant links, added 2 direct connections.

**Removed** (5): hermite-lindemann (redundant with pi-transcendental), intermediate-value-theorem (generic), fundamental-theorem-calculus (generic), area-of-circle-oq-01-oq-03 (redundant with isoperimetric-theorem), area-of-circle-oq-01-oq-02-oq-01 (deep in tree)

**Added** (2): greens-theorem (vector calculus proof of πr²), buffons-needle (probabilistic π via integral geometry)

**Retained** (9): area-of-circle-oq-01, area-of-circle-oq-03, area-of-circle-oq-01-oq-02, area-of-circle-oq-03-oq-02, pythagorean-theorem, pi-transcendental, isoperimetric-theorem, lebesgue-measure, basel-problem