### PR TITLE
Enrich fundamental-theorem-algebra: trim cross-references (15→11)

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -150,79 +150,59 @@
   },
   "crossReferences": [
     {
+      "targetId": "fundamental-theorem-algebra-oq-04",
+      "relationship": "extended-by",
+      "description": "Proves $\\mathbb{C}$ is the unique algebraic closure of $\\mathbb{R}$: algebraically closed (FTA) and algebraic ($[\\mathbb{C}:\\mathbb{R}] = 2$)"
+    },
+    {
       "targetId": "abel-ruffini",
       "relationship": "complementary",
-      "description": "FTA guarantees roots exist in C; Abel-Ruffini shows they cannot always be expressed by radicals — existence does not imply explicit formulas"
+      "description": "FTA guarantees roots exist in $\\mathbb{C}$; Abel-Ruffini shows they cannot always be expressed by radicals — existence does not imply explicit formulas"
     },
     {
       "targetId": "liouville-theorem",
       "relationship": "uses",
-      "description": "The Mathlib proof of FTA relies on Liouville's theorem (bounded entire function is constant): if p(z) ≠ 0 everywhere, then 1/p is bounded entire, hence constant — contradiction"
+      "description": "The Mathlib proof relies on Liouville's theorem: if $p(z) \\neq 0$ everywhere then $1/p$ is bounded entire, hence constant — contradiction"
     },
     {
       "targetId": "angle-trisection",
       "relationship": "complementary",
-      "description": "FTA guarantees the polynomial 8x³-6x-1 has roots in C; the angle trisection impossibility shows those roots lie outside the constructible field (degree 2^n extensions)"
+      "description": "FTA guarantees $8x^3-6x-1$ has roots in $\\mathbb{C}$; angle trisection impossibility shows those roots lie outside the constructible field"
     },
     {
       "targetId": "solution-of-cubic",
       "relationship": "specializes",
-      "description": "Cardano's cubic formula provides explicit complex roots for degree-3 polynomials; FTA guarantees such roots exist without needing an explicit formula"
-    },
-    {
-      "targetId": "inverse-galois",
-      "relationship": "related",
-      "description": "FTA shows every polynomial splits over C, so every Galois group embeds in some S_n. The Inverse Galois Problem asks which groups arise over Q — a question that presupposes FTA's guarantee that roots exist"
+      "description": "Cardano's formula provides explicit complex roots for degree 3; FTA guarantees such roots exist without needing an explicit formula"
     },
     {
       "targetId": "general-quartic",
       "relationship": "specializes",
-      "description": "Ferrari's quartic formula provides explicit complex roots for degree-4 polynomials; FTA guarantees such roots exist for any degree, subsuming all explicit formula results"
+      "description": "Ferrari's formula provides explicit complex roots for degree 4; FTA guarantees existence for any degree"
     },
     {
       "targetId": "vietas-formulas",
       "relationship": "complementary",
-      "description": "Vieta's formulas express polynomial coefficients as elementary symmetric functions of roots: $a_{n-k}/a_n = (-1)^k e_k(r_1,\\ldots,r_n)$. FTA guarantees these $n$ roots exist in $\\mathbb{C}$, making Vieta's formulas universally applicable over $\\mathbb{C}$ — without FTA, the roots might not exist and the formulas would be vacuous"
+      "description": "FTA guarantees $n$ roots exist in $\\mathbb{C}$, making Vieta's formulas universally applicable — without FTA, the roots might not exist"
     },
     {
       "targetId": "intermediate-value-theorem",
       "relationship": "foundational",
-      "description": "Gauss's algebraic proof of FTA (1849) reduces to IVT: every odd-degree real polynomial has a real root (by IVT, since it tends to $\\pm\\infty$), and every complex number has a square root. These two facts, both consequences of the completeness of $\\mathbb{R}$, suffice to prove FTA — making IVT one of the minimal prerequisites"
+      "description": "Gauss's algebraic FTA proof reduces to IVT: odd-degree real polynomials have a real root, and every complex number has a square root"
     },
     {
       "targetId": "brouwer-fixed-point",
       "relationship": "related",
-      "description": "Both FTA and Brouwer's fixed point theorem are topological results about continuous maps on compact sets. The topological proof of FTA via winding numbers (the degree of $p(z)/|p(z)|$ on a large circle is $n$) uses the same homotopy-theoretic tools that prove Brouwer's theorem — both are consequences of the non-triviality of $\\pi_1(S^1) \\cong \\mathbb{Z}$"
-    },
-    {
-      "targetId": "cayley-hamilton",
-      "relationship": "related",
-      "description": "The Cayley-Hamilton theorem ($p_A(A) = 0$ for the characteristic polynomial $p_A$) combined with FTA guarantees every complex matrix has an eigenvalue: FTA gives a root $\\lambda$ of $p_A$, making $A - \\lambda I$ singular. This is why linear algebra over $\\mathbb{C}$ admits Jordan normal form — a direct consequence of algebraic closure"
-    },
-    {
-      "targetId": "fundamental-theorem-algebra-oq-04",
-      "relationship": "extended-by",
-      "description": "Proves $\\mathbb{C}$ is the unique algebraic closure of $\\mathbb{R}$: algebraically closed (from FTA) and algebraic over $\\mathbb{R}$ (since $[\\mathbb{C}:\\mathbb{R}] = 2$), with uniqueness via the universal property. Addresses the open question about formalizing $\\mathbb{C}$ as the algebraic closure"
+      "description": "Both are topological results: FTA via winding numbers and Brouwer via degree theory — both consequences of $\\pi_1(S^1) \\cong \\mathbb{Z}$"
     },
     {
       "targetId": "hermite-lindemann",
       "relationship": "complementary",
-      "description": "FTA guarantees that the polynomial equation $p(z) = 0$ always has solutions in $\\mathbb{C}$ for any $p \\in \\mathbb{C}[z]$. Hermite-Lindemann shows that certain important constants ($e$, $\\pi$) are NOT solutions of any polynomial with rational coefficients — they are transcendental, lying outside $\\overline{\\mathbb{Q}}$ even though they live in $\\mathbb{C}$. Together they illustrate the distinction between algebraic closure (FTA) and transcendence"
+      "description": "FTA says polynomial equations always have solutions in $\\mathbb{C}$; Hermite-Lindemann shows $e, \\pi$ are transcendental — outside $\\overline{\\mathbb{Q}}$ despite living in $\\mathbb{C}$"
     },
     {
       "targetId": "puiseux-theorem",
       "relationship": "complementary",
-      "description": "Puiseux's theorem provides an alternative 'algebraic closure': the field of fractional power series $\\bigcup_n \\mathbb{C}((t^{1/n}))$ is algebraically closed, so polynomial roots can always be expressed as Puiseux series. FTA proves algebraic closure of $\\mathbb{C}$ via analysis; Puiseux proves it for the Puiseux series field via algebra. Both show that roots 'exist' — in different mathematical settings"
-    },
-    {
-      "targetId": "descartes-rule-of-signs",
-      "relationship": "complementary",
-      "description": "FTA guarantees $n$ complex roots for a degree-$n$ polynomial; Descartes' rule bounds how many are positive real: at most as many as sign changes in the coefficient sequence. Together they constrain root location: FTA gives existence in $\\mathbb{C}$, Descartes constrains which are in $\\mathbb{R}_{>0}$"
-    },
-    {
-      "targetId": "factor-remainder-theorem",
-      "relationship": "foundational",
-      "description": "The Factor Theorem — $(x-a) \\mid p(x)$ if and only if $p(a) = 0$ — is the algebraic engine behind FTA's complete factorization. Once FTA guarantees a root $z_1$ exists, the Factor Theorem allows factoring out $(x - z_1)$, reducing degree by 1. Iterating this process $n$ times yields $p(x) = a_n(x-z_1)(x-z_2)\\cdots(x-z_n)$ — the linear factorization whose existence is the strongest form of FTA. The Mathlib formalization uses this pattern via `Polynomial.roots` and `prod_multiset_X_sub_C_of_monic_of_roots_card_eq`"
+      "description": "Alternative algebraic closure: Puiseux series field is algebraically closed, so roots always exist as fractional power series — a complementary perspective to FTA's analytic proof"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for fundamental-theorem-algebra. Trimmed 4 weak/tangential cross-references.

**Removed** (4): inverse-galois (tangential), cayley-hamilton (weak eigenvalue connection), descartes-rule-of-signs (tangential root counting), factor-remainder-theorem (generic foundational)

**Retained** (11): fundamental-theorem-algebra-oq-04, abel-ruffini, liouville-theorem, angle-trisection, solution-of-cubic, general-quartic, vietas-formulas, intermediate-value-theorem, brouwer-fixed-point, hermite-lindemann, puiseux-theorem