### PR TITLE
Research: Erdős #1179 — fix false axiom, prove erdos_renyi_decay (2→1 axiom)

### DIFF
--- a/proofs/Proofs/Erdos1179OQ01.lean
+++ b/proofs/Proofs/Erdos1179OQ01.lean
@@ -26,6 +26,8 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecificLimits.Normed
 import Mathlib.Tactic
 
 namespace Erdos1179OQ01
@@ -177,21 +179,91 @@ theorem bounded_implies_sublinear (gEps : ℝ → ℕ → ℕ) (ε : ℝ)
 ## Part VI: Fourier analysis connection
 -/
 
-/-- In ℤ/pℤ (p prime), the Fourier error bound controls reprCount deviations.
-    F_A(g) = (1/p) ∑_χ χ(-g) ∏_{a ∈ A} (1 + χ(a)).
-    The χ ≠ 1 terms contribute at most (p-1) · |cos(π/p)|^k. -/
-axiom fourier_error_bound (p : ℕ) (hp : Nat.Prime p) (k : ℕ) :
-  ∀ A : Finset (ZMod p), A.card = k →
-    ∀ g : ZMod p, |(reprCount A g : ℝ) - (2 : ℝ) ^ k / p| ≤
-      (p - 1 : ℝ) * |Real.cos (Real.pi / p)| ^ k
+/-- |cos(π/p)| < 1 for any prime p ≥ 2.
+    For p = 2: cos(π/2) = 0. For p ≥ 3: 0 < π/p < π so -1 < cos(π/p) < 1. -/
+private lemma abs_cos_pi_div_prime_lt_one (p : ℕ) (hp : Nat.Prime p) :
+    |Real.cos (Real.pi / ↑p)| < 1 := by
+  have hp_pos : (0 : ℝ) < ↑p := Nat.cast_pos.mpr hp.pos
+  have hp_one_lt : (1 : ℝ) < ↑p := by exact_mod_cast hp.one_lt
+  have hx_pos : (0 : ℝ) < π / ↑p := div_pos Real.pi_pos hp_pos
+  have hx_lt_pi : π / ↑p < π := div_lt_self Real.pi_pos hp_one_lt
+  rw [abs_lt]
+  constructor
+  · -- cos(π/p) > cos(π) = -1 since π/p < π and cos strictly decreasing on [0,π]
+    have h1 : π / ↑p ∈ Set.Icc (0 : ℝ) π := ⟨hx_pos.le, hx_lt_pi.le⟩
+    have h2 : π ∈ Set.Icc (0 : ℝ) π := ⟨Real.pi_pos.le, le_refl _⟩
+    have := Real.strictAntiOn_cos h1 h2 hx_lt_pi
+    rw [Real.cos_pi] at this
+    linarith
+  · -- cos(π/p) < cos(0) = 1 since 0 < π/p and cos strictly decreasing on [0,π]
+    have h1 : (0 : ℝ) ∈ Set.Icc (0 : ℝ) π := ⟨le_refl _, Real.pi_pos.le⟩
+    have h2 : π / ↑p ∈ Set.Icc (0 : ℝ) π := ⟨hx_pos.le, hx_lt_pi.le⟩
+    have := Real.strictAntiOn_cos h1 h2 hx_pos
+    rwa [Real.cos_zero] at this
 
-/-- For k ≈ 2 log₂ p, the Fourier error decays to O(1/p).
-    This is the core of the Erdős-Rényi (1965) approach. -/
-axiom erdos_renyi_decay (p : ℕ) (hp : Nat.Prime p) :
-  ∀ ε : ℝ, ε > 0 → ∃ C : ℕ, ∀ k : ℕ, k ≥ Nat.clog 2 p + C →
-    ∀ A : Finset (ZMod p), A.card = k →
-      ∀ g : ZMod p, |(reprCount A g : ℝ) - (2 : ℝ) ^ k / p| ≤
-        ε * ((2 : ℝ) ^ k / p)
+/-- Fourier-analytic error bound for representation counts in ℤ/pℤ.
+
+    For A ⊆ ℤ/pℤ of size k, Fourier inversion gives:
+      F_A(g) = (1/p) ∑_χ χ(-g) ∏_{a ∈ A} (1 + χ(a))
+    The trivial character contributes 2^k/p (the "uniform" term).
+    For χ ≠ 1: |1 + χ(a)| = 2|cos(πja/p)|, and for nonzero a mod p,
+    |cos(πja/p)| ≤ cos(π/p) < 1. The exponent k-1 (not k) accounts for
+    the possibility that 0 ∈ A, where |cos(0)| = 1.
+
+    **Note**: The original axiom (without 2^k/p factor) was mathematically
+    false. Counterexample: A = {1,2} in ℤ/3ℤ gives error 2/3 but the old
+    bound was (3-1)·cos(π/3)² = 1/2 < 2/3. -/
+axiom fourier_error_bound (p : ℕ) (hp : Nat.Prime p) (k : ℕ) (hk : 1 ≤ k) :
+  ∀ A : Finset (ZMod p), A.card = k →
+    ∀ g : ZMod p, |(reprCount A g : ℝ) - (2 : ℝ) ^ k / ↑p| ≤
+      (↑p - 1 : ℝ) * |Real.cos (Real.pi / ↑p)| ^ (k - 1) * ((2 : ℝ) ^ k / ↑p)
+
+/-- For k ≥ clog₂ p + C, the Fourier error decays to at most ε · 2^k/p.
+    This is the core of the Erdős-Rényi (1965) approach.
+
+    Proof: from fourier_error_bound, the relative error is bounded by
+    (p-1) · |cos(π/p)|^(k-1). Since |cos(π/p)| < 1 for all primes,
+    this decays geometrically and falls below ε for large enough k. -/
+theorem erdos_renyi_decay (p : ℕ) (hp : Nat.Prime p) :
+    ∀ ε : ℝ, ε > 0 → ∃ C : ℕ, ∀ k : ℕ, k ≥ Nat.clog 2 p + C →
+      ∀ A : Finset (ZMod p), A.card = k →
+        ∀ g : ZMod p, |(reprCount A g : ℝ) - (2 : ℝ) ^ k / ↑p| ≤
+          ε * ((2 : ℝ) ^ k / ↑p) := by
+  intro ε hε
+  -- |cos(π/p)| < 1 for primes
+  have hcos_lt := abs_cos_pi_div_prime_lt_one p hp
+  have hcos_nn := abs_nonneg (Real.cos (π / ↑p))
+  -- (p : ℝ) - 1 > 0 for primes
+  have hp_sub : (0 : ℝ) < ↑p - 1 := by
+    have : 1 < (p : ℝ) := by exact_mod_cast hp.one_lt
+    linarith
+  -- Find K₀ with |cos(π/p)|^K₀ < ε/(p-1)
+  obtain ⟨K₀, hK₀⟩ := exists_pow_lt_of_lt_one (div_pos hε hp_sub) hcos_lt
+  -- C = K₀ + 1 ensures k-1 ≥ K₀ and k ≥ 1
+  use K₀ + 1
+  intro k hk A hA g
+  have hk1 : 1 ≤ k := by omega
+  -- From fourier_error_bound (corrected):
+  -- |error| ≤ (p-1) · |cos(π/p)|^(k-1) · (2^k/p)
+  have hfourier := fourier_error_bound p hp k hk1 A hA g
+  -- Suffices: (p-1) · |cos(π/p)|^(k-1) ≤ ε
+  suffices hsuff : (↑p - 1 : ℝ) * |Real.cos (π / ↑p)| ^ (k - 1) ≤ ε by
+    calc |(reprCount A g : ℝ) - (2 : ℝ) ^ k / ↑p|
+        ≤ (↑p - 1) * |Real.cos (π / ↑p)| ^ (k - 1) * ((2 : ℝ) ^ k / ↑p) := hfourier
+      _ ≤ ε * ((2 : ℝ) ^ k / ↑p) := by
+          apply mul_le_mul_of_nonneg_right hsuff
+          exact div_nonneg (pow_nonneg (by norm_num : (0:ℝ) ≤ 2) k) (Nat.cast_nonneg p)
+  -- k - 1 ≥ K₀ since k ≥ clog 2 p + K₀ + 1 ≥ K₀ + 1
+  have hk_ge : K₀ ≤ k - 1 := by omega
+  -- |cos(π/p)|^(k-1) ≤ |cos(π/p)|^K₀ (decreasing for base ≤ 1)
+  -- Then (p-1) · |cos(π/p)|^(k-1) ≤ (p-1) · ε/(p-1) = ε
+  calc (↑p - 1 : ℝ) * |Real.cos (π / ↑p)| ^ (k - 1)
+      ≤ (↑p - 1) * |Real.cos (π / ↑p)| ^ K₀ := by
+        apply mul_le_mul_of_nonneg_left _ hp_sub.le
+        exact pow_le_pow_of_le_one hcos_nn hcos_lt.le hk_ge
+    _ ≤ (↑p - 1) * (ε / (↑p - 1)) := by
+        apply mul_le_mul_of_nonneg_left (le_of_lt hK₀) hp_sub.le
+    _ = ε := by field_simp
 
 /-
 ## Part VII: Summary and open question
@@ -205,7 +277,8 @@ axiom erdos_renyi_decay (p : ℕ) (hp : Nat.Prime p) :
     2. Θ(log log N) — by analogy with Problem #543
     3. o(log₂ N) — weakest, already known from Erdős-Hall
 
-    We proved: O(1) ⟹ o(log₂ N), establishing the hierarchy. -/
+    We proved: O(1) ⟹ o(log₂ N), establishing the hierarchy.
+    We proved: erdos_renyi_decay from fourier_error_bound (geometric decay). -/
 theorem second_order_hierarchy (gEps : ℝ → ℕ → ℕ) (ε : ℝ) :
     CorrectionIsBounded gEps ε → CorrectionIsSublinearInLog gEps ε :=
   bounded_implies_sublinear gEps ε

--- a/research/problems/erdos-1179-oq-01/knowledge.md
+++ b/research/problems/erdos-1179-oq-01/knowledge.md
@@ -1,0 +1,42 @@
+# Erdős #1179 OQ-01: Second-Order Term in g_ε(N)
+
+## Problem Summary
+
+For ε > 0, g_ε(N) is the smallest k such that a random k-subset of ℤ/Nℤ
+has approximately uniform representation counts. Known: g_ε(N) ~ log₂ N.
+Open question: what is the precise second-order correction term?
+
+**File**: `proofs/Proofs/Erdos1179OQ01.lean`
+**Status**: 1 axiom, 0 sorries, 11 theorems, 286 lines
+
+## Session 2026-03-25 (Session 1) - Fix false axiom, prove erdos_renyi_decay
+
+**Mode**: FRESH
+**Outcome**: progress (1 axiom eliminated, 1 false axiom corrected)
+
+### What I Did
+- Discovered `fourier_error_bound` axiom was **mathematically false**
+  - Counterexample: A = {1,2} ⊆ ℤ/3ℤ gives error 2/3 but old bound was 1/2
+  - Missing `2^k/p` scaling factor in the bound
+  - Need `k-1` exponent (not `k`) to handle 0 ∈ A where |cos(0)| = 1
+- Corrected the axiom: `|(F_A(g) - 2^k/p| ≤ (p-1)·|cos(π/p)|^(k-1)·(2^k/p)`
+- **Proved `erdos_renyi_decay`** as a theorem (was axiom):
+  - Key insight: relative error is `(p-1)·|cos(π/p)|^(k-1)` which → 0 geometrically
+  - Used `exists_pow_lt_of_lt_one` to find threshold K₀
+  - Used `pow_le_pow_of_le_one` for monotonic decay
+- Proved helper `abs_cos_pi_div_prime_lt_one` via `Real.strictAntiOn_cos`
+- Docker build verified: 0 errors, 0 sorries, 1 axiom
+
+### Key Findings
+- The Fourier bound in the 2^k/p factor cancels when computing relative error, making erdos_renyi_decay a clean consequence
+- `Real.strictAntiOn_cos` on `Set.Icc 0 π` is the right tool for proving |cos(x)| < 1 for 0 < x < π
+- Import paths: `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic` (not `.Order`) and `Mathlib.Analysis.SpecificLimits.Normed` (not `.Basic`)
+
+### Files Modified
+- `proofs/Proofs/Erdos1179OQ01.lean` (213 → 286 lines, 2 → 1 axiom)
+- `src/data/proofs/erdos-1179-oq-01/meta.json` (updated counts)
+- `src/data/research/problems/erdos-1179-oq-01.json` (updated knowledge)
+
+### Next Steps
+- Prove `fourier_error_bound` from Mathlib character theory (requires AddChar infrastructure)
+- Formalize Θ(log log N) ⟹ o(log N) to complete the hierarchy chain

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1179-oq-01",
   "title": "Second-Order Term in Uniform Subset Sum Representations",
   "slug": "erdos-1179-oq-01",
-  "description": "What is the precise second-order term in g_ε(N)? Formalizes the correction term hierarchy (O(1) vs Θ(log log N) vs o(log N)) and proves foundational properties of representation counts in ℤ/Nℤ, including the partition identity ∑_g F_A(g) = 2^|A|, monotonicity under set growth, and coverage monotonicity. The Fourier-analytic connection to character sums is axiomatized.",
+  "description": "What is the precise second-order term in g_ε(N)? Formalizes the correction term hierarchy (O(1) vs Θ(log log N) vs o(log N)) and proves foundational properties of representation counts in ℤ/Nℤ, including the partition identity ∑_g F_A(g) = 2^|A|, monotonicity under set growth, and coverage monotonicity. Proves erdos_renyi_decay (exponential decay of Fourier error) from the corrected fourier_error_bound axiom via geometric series arguments.",
   "meta": {
     "author": "Open Question (Erdős #1179)",
     "sourceUrl": "https://erdosproblems.com/1179",
@@ -19,14 +19,14 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 2,
-    "theoremCount": 9,
+    "axiomCount": 1,
+    "theoremCount": 11,
     "definitionCount": 5,
-    "lineCount": 213,
+    "lineCount": 286,
     "erdosNumber": 1179,
     "erdosUrl": "https://erdosproblems.com/1179",
     "erdosProblemStatus": "open-question",
-    "assumptions": "Two axioms for deep results: fourier_error_bound (Fourier analysis bound for reprCount deviations in ℤ/pℤ via character sums) and erdos_renyi_decay (exponential decay of Fourier error for k ≈ 2 log₂ p, the core of the Erdős-Rényi 1965 approach). All foundational representation count lemmas (partition identity, monotonicity, coverage growth, singleton bound, base cases) are fully proved with zero sorries.",
+    "assumptions": "One axiom: fourier_error_bound (corrected Fourier analysis bound for reprCount deviations in ℤ/pℤ via character sums, with proper 2^k/p scaling factor and k-1 exponent for 0∈A). The erdos_renyi_decay theorem is now PROVED from this axiom via geometric decay of |cos(π/p)|^k. All foundational representation count lemmas (partition identity, monotonicity, coverage growth, singleton bound, base cases) are fully proved with zero sorries.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -77,13 +77,15 @@
         "Mathlib.Data.Real.Basic",
         "Mathlib.Data.ZMod.Basic",
         "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+        "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+        "Mathlib.Analysis.SpecificLimits.Normed",
         "Mathlib.Tactic"
       ],
       "opens": ["Finset", "Real"],
       "namespace": "Erdos1179OQ01",
-      "lineCount": 213,
-      "axiomCount": 2,
-      "theoremCount": 9,
+      "lineCount": 286,
+      "axiomCount": 1,
+      "theoremCount": 11,
       "definitionCount": 5,
       "mainTheorems": [
         {
@@ -109,6 +111,18 @@
           "type": "proved",
           "description": "The correction hierarchy: O(1) implies o(log₂ N)",
           "leanType": "(gEps : ℝ → ℕ → ℕ) → (ε : ℝ) → CorrectionIsBounded gEps ε → CorrectionIsSublinearInLog gEps ε"
+        },
+        {
+          "name": "abs_cos_pi_div_prime_lt_one",
+          "type": "proved",
+          "description": "|cos(π/p)| < 1 for any prime p — key lemma for geometric decay",
+          "leanType": "(p : ℕ) → (hp : Nat.Prime p) → |cos(π/p)| < 1"
+        },
+        {
+          "name": "erdos_renyi_decay",
+          "type": "proved",
+          "description": "Erdős-Rényi exponential decay: for k ≥ clog₂ p + C, Fourier error ≤ ε · 2^k/p. Proved from fourier_error_bound via geometric decay of |cos(π/p)|^(k-1)",
+          "leanType": "(p : ℕ) → (hp : Nat.Prime p) → ∀ ε > 0, ∃ C, ∀ k ≥ clog 2 p + C, ∀ A, A.card = k → ∀ g, |F_A(g) - 2^k/p| ≤ ε · (2^k/p)"
         }
       ]
     }
@@ -186,10 +200,10 @@
     {
       "id": "fourier",
       "title": "Part VI: Fourier Analysis Connection",
-      "startLine": 176,
-      "endLine": 194,
-      "summary": "Two axioms capture the Fourier-analytic core: `fourier_error_bound` (character sum control of $|F_A(g) - 2^k/p|$ by $(p-1)|\\cos(\\pi/p)|^k$) and `erdos_renyi_decay` (for $k \\approx 2\\log_2 p$, the error decays to $O(\\varepsilon \\cdot 2^k/p)$).",
-      "mathContext": "For $A \\subseteq \\mathbb{Z}/p\\mathbb{Z}$: $F_A(g) = \\frac{1}{p}\\sum_\\chi \\chi(-g)\\prod_{a \\in A}(1+\\chi(a))$. Non-trivial characters contribute $\\leq (p-1)|\\cos(\\pi/p)|^k$, which decays exponentially in $k$."
+      "startLine": 178,
+      "endLine": 267,
+      "summary": "Proves `abs_cos_pi_div_prime_lt_one` ($|\\cos(\\pi/p)| < 1$ for primes) via strict monotonicity of cosine on $[0,\\pi]$. One corrected axiom `fourier_error_bound` (with proper $2^k/p$ scaling and $k-1$ exponent). Proves `erdos_renyi_decay` from the axiom: the relative error $(p-1)|\\cos(\\pi/p)|^{k-1}$ decays geometrically below any $\\varepsilon > 0$ for sufficiently large $k$. Original axiom was mathematically false (counterexample: $A=\\{1,2\\} \\subseteq \\mathbb{Z}/3\\mathbb{Z}$).",
+      "mathContext": "For $A \\subseteq \\mathbb{Z}/p\\mathbb{Z}$: $F_A(g) = \\frac{1}{p}\\sum_\\chi \\chi(-g)\\prod_{a \\in A}(1+\\chi(a))$. Non-trivial characters contribute $\\leq (p-1)|\\cos(\\pi/p)|^{k-1} \\cdot 2^k/p$. Since $|\\cos(\\pi/p)| < 1$, geometric decay gives relative error $\\to 0$."
     },
     {
       "id": "summary",
@@ -205,7 +219,7 @@
     "implications": "**Connections to additive combinatorics:** The representation count machinery (partition identity, monotonicity, convolution structure) connects to fundamental tools in additive number theory — Freiman's theorem, the Erdős-Ginzburg-Ziv theorem, and sumset estimates. The Fourier method axiomatized here is a special case of the Hardy-Littlewood circle method applied to finite groups.\n\n**Problem #543 analogy:** The disproof of #543 showed $\\Theta(\\log\\log N)$ is the optimal correction for coverage. If the uniformity problem (#1179) has the same answer, it would reveal a deep structural connection between 'covering all elements' and 'covering them uniformly' — both governed by the same second-order logarithmic correction.\n\n**Computational verification:** The formalized definitions are in principle computable for small $N$ (modulo the `noncomputable` annotation on `reprCount`). A computational investigation of $g_\\varepsilon(N)$ for small $N$ and various $\\varepsilon$ could provide empirical evidence for the correct rate.",
     "openQuestions": [
       "Is the correction term $g_\\varepsilon(N) - \\log_2 N$ bounded ($O(1)$) or does it grow as $\\Theta(\\log\\log N)$? The disproof of Problem #543 suggests the latter, but the uniformity condition here is strictly stronger than coverage.",
-      "Can the Fourier axioms (fourier_error_bound and erdos_renyi_decay) be proved from Mathlib's character theory? This requires discrete Fourier analysis infrastructure: character groups of $\\mathbb{Z}/p\\mathbb{Z}$, Pontryagin duality, and character orthogonality relations.",
+      "Can the remaining fourier_error_bound axiom be proved from Mathlib's character theory? This requires discrete Fourier analysis infrastructure: character groups of $\\mathbb{Z}/p\\mathbb{Z}$, orthogonality relations, and the identity $|1+\\chi(a)| = 2|\\cos(\\pi ja/p)|$.",
       "Can the $\\Theta(\\log\\log N) \\Rightarrow o(\\log N)$ implication be formalized to complete the full hierarchy chain?",
       "Does the second-order term depend on the group structure (cyclic vs general abelian) or only on the group order $N$?"
     ]

--- a/src/data/research/problems/erdos-1179-oq-01.json
+++ b/src/data/research/problems/erdos-1179-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1179-oq-01",
   "title": "What is the precise second-order term in g_ε(N)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-24T00:48:59.907Z",
+    "phase": "ACT",
+    "since": "2026-03-25T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved erdos_renyi_decay, fixed false axiom. 1 axiom remains.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Prove fourier_error_bound or formalize log-log implication",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: Fixed false axiom, proved erdos_renyi_decay theorem (2→1 axiom)",
+    "builtItems": [
+      "abs_cos_pi_div_prime_lt_one: |cos(pi/p)| < 1 via strict antitonicity of cos on [0,pi]",
+      "erdos_renyi_decay: proved from fourier_error_bound via exists_pow_lt_of_lt_one + pow_le_pow_of_le_one",
+      "Corrected fourier_error_bound axiom: added (2^k/p) factor and k-1 exponent"
+    ],
+    "insights": [
+      "fourier_error_bound axiom was FALSE: missing 2^k/p factor. Counterexample A={1,2} in Z/3Z gives error 2/3 > old bound 1/2",
+      "Correct bound needs k-1 exponent (not k) to account for 0 in A where |cos(0)|=1",
+      "erdos_renyi_decay follows from fourier_error_bound: relative error (p-1)·|cos(pi/p)|^(k-1) decays geometrically since |cos(pi/p)|<1 for all primes",
+      "|cos(pi/p)| < 1 proved via Real.strictAntiOn_cos on [0,pi]: cos(pi/p) < cos(0)=1 and cos(pi/p) > cos(pi)=-1"
+    ],
+    "mathlibGaps": [
+      "Discrete Fourier analysis on Z/pZ (character groups, orthogonality) needed to prove fourier_error_bound"
+    ],
+    "nextSteps": [
+      "Prove fourier_error_bound from Mathlib character theory to go from 1 axiom to 0",
+      "Formalize log-log implies o(log N) to complete hierarchy chain"
+    ]
   },
   "tags": [
     "erdos",


### PR DESCRIPTION
## Summary
- **Fixed mathematically false axiom** `fourier_error_bound`: counterexample A={1,2} in ℤ/3ℤ gives error 2/3 but old bound was 1/2. Added missing `2^k/p` scaling factor and `k-1` exponent (for 0∈A case).
- **Proved `erdos_renyi_decay`** as a theorem (was axiom): the relative error `(p-1)·|cos(π/p)|^(k-1)` decays geometrically since `|cos(π/p)| < 1` for all primes.
- **Proved `abs_cos_pi_div_prime_lt_one`**: `|cos(π/p)| < 1` via `Real.strictAntiOn_cos` on `[0,π]`.
- Result: 286 lines, 0 sorries, 1 axiom (was 2), 11 theorems (was 9).

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ01`)
- [x] 0 sorry warnings, 0 errors
- [x] Axiom count reduced from 2 to 1
- [x] meta.json updated with correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)