### PR TITLE
Aristotle: register zombie projects, submit 3 new jobs

### DIFF
--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -1636,6 +1636,841 @@
       "file": "proofs/Proofs/AreaOfCircleOQ01OQ03Aristotle.lean",
       "problem_id": "areaofcircleoq01oq03",
       "submitted": "2026-03-25T01:18:22Z",
+      "status": "integrated",
+      "preprocessed": false,
+      "preprocessing_log": null,
+      "companion_file": true,
+      "notes": "Companion file submission (T1)",
+      "outcome": "Already integrated - 0 sorries remaining. Parseval periodic real + IBP Fourier coefficients proved.",
+      "integrated": "2026-03-26"
+    },
+    {
+      "project_id": "b97814d2-ae94-473c-888b-e83945764914",
+      "file": "null",
+      "problem_id": "zombie-b97814d2",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "09ef09ac-ec33-4f1d-b793-d03d19c79f9f",
+      "file": "null",
+      "problem_id": "zombie-09ef09ac",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "b1922710-f49a-4a4f-811a-01176a9f5a4c",
+      "file": "null",
+      "problem_id": "zombie-b1922710",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "755e2c15-0199-45bf-94ab-2f790995ae49",
+      "file": "null",
+      "problem_id": "zombie-755e2c15",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "c744adbc-73a1-4278-909d-7e953ae19437",
+      "file": "null",
+      "problem_id": "zombie-c744adbc",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "2f8c6d89-ba5b-4774-bdca-1239250bca28",
+      "file": "null",
+      "problem_id": "zombie-2f8c6d89",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "b385f227-70ac-48ce-866f-6bc81409e5f5",
+      "file": "null",
+      "problem_id": "zombie-b385f227",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "e6faa0b1-dd94-45be-85d7-3e14d5e44f52",
+      "file": "null",
+      "problem_id": "zombie-e6faa0b1",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "bdcc84f8-b037-4cb2-ac47-4f226c98322f",
+      "file": "null",
+      "problem_id": "zombie-bdcc84f8",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "36351020-0302-48c0-b45a-e6c8c1bc039b",
+      "file": "null",
+      "problem_id": "zombie-36351020",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "c74f4b90-5c59-44a5-8fe3-987eca24d80a",
+      "file": "null",
+      "problem_id": "zombie-c74f4b90",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "78b2bb8e-2cc8-469b-b18d-9610470ff4e2",
+      "file": "null",
+      "problem_id": "zombie-78b2bb8e",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "8afe7255-28b6-474b-8135-c662b09cb54d",
+      "file": "null",
+      "problem_id": "zombie-8afe7255",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "8cdd2863-578d-4ad1-8986-10f558dfce70",
+      "file": "null",
+      "problem_id": "zombie-8cdd2863",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "cfbc7346-b799-4088-a829-356d36baedce",
+      "file": "null",
+      "problem_id": "zombie-cfbc7346",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "cf8fad09-c527-4079-a383-575fb0306f8c",
+      "file": "null",
+      "problem_id": "zombie-cf8fad09",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "0e44ac43-fda7-4b7f-bd7b-99019d845ae8",
+      "file": "null",
+      "problem_id": "zombie-0e44ac43",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "e607eaf2-41e0-4622-a60f-4ecd23563154",
+      "file": "null",
+      "problem_id": "zombie-e607eaf2",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "8271749b-70e5-4e39-a5e5-29882dd1bfc0",
+      "file": "null",
+      "problem_id": "zombie-8271749b",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "753752a2-1d4c-4877-a4b1-7ec70fc7f938",
+      "file": "null",
+      "problem_id": "zombie-753752a2",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "3784bead-6cc4-4cff-82bb-ce6c9fff9360",
+      "file": "null",
+      "problem_id": "zombie-3784bead",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "12fd3291-caf7-4339-a4e3-b2a402739cf0",
+      "file": "null",
+      "problem_id": "zombie-12fd3291",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "0e97f3fc-4ff5-4a4d-81dc-6a25b4aac834",
+      "file": "null",
+      "problem_id": "zombie-0e97f3fc",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "961432c8-e0bb-45d6-b9c5-0e82e12c482c",
+      "file": "null",
+      "problem_id": "zombie-961432c8",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "3a493a6c-0c49-478d-a173-e94e385a22af",
+      "file": "null",
+      "problem_id": "zombie-3a493a6c",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "493a2f77-3b5b-4946-9435-6c16ffd1ddde",
+      "file": "null",
+      "problem_id": "zombie-493a2f77",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "2e95a024-4518-47a1-aab1-4e50f83e4df8",
+      "file": "null",
+      "problem_id": "zombie-2e95a024",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "608f0faa-7900-465d-bea5-08eb747e37b5",
+      "file": "null",
+      "problem_id": "zombie-608f0faa",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "334b4bfb-719d-4581-9d64-8285d9880c66",
+      "file": "null",
+      "problem_id": "zombie-334b4bfb",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "54123d5f-5786-4f45-a74f-f3954a3d0074",
+      "file": "null",
+      "problem_id": "zombie-54123d5f",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "a57a010f-7e3f-475b-b485-a6173f8e7b7f",
+      "file": "null",
+      "problem_id": "zombie-a57a010f",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "17eabe69-2929-460b-b715-96e9bc3e48e2",
+      "file": "null",
+      "problem_id": "zombie-17eabe69",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "88487291-b349-40e4-b955-edba74a8d091",
+      "file": "null",
+      "problem_id": "zombie-88487291",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "dc38789f-6fb9-4aa7-b39c-503addf675ce",
+      "file": "null",
+      "problem_id": "zombie-dc38789f",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "ef3f4fa4-1ffb-453c-bebf-551ce2bb0b6b",
+      "file": "null",
+      "problem_id": "zombie-ef3f4fa4",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "e8dab341-a9d1-4582-bda6-5ade5fb83742",
+      "file": "null",
+      "problem_id": "zombie-e8dab341",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "5d7a9eeb-98df-42c9-a41f-9c193127ca89",
+      "file": "null",
+      "problem_id": "zombie-5d7a9eeb",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "6e33d06f-0781-4fd3-a7f5-030558db1885",
+      "file": "null",
+      "problem_id": "zombie-6e33d06f",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "3a08bcf5-70af-417f-9b49-cdee4941aaec",
+      "file": "null",
+      "problem_id": "zombie-3a08bcf5",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "a99029d3-3a99-4256-82f7-d8f8e05f1d17",
+      "file": "null",
+      "problem_id": "zombie-a99029d3",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "672512f5-0294-44cc-b7d4-3ee73276dafa",
+      "file": "null",
+      "problem_id": "zombie-672512f5",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "75110610-c84f-49bc-8410-016aea2d048c",
+      "file": "null",
+      "problem_id": "zombie-75110610",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "3c65eb5d-5ce1-44f4-964b-3d4586d0218b",
+      "file": "null",
+      "problem_id": "zombie-3c65eb5d",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "69e2d56d-d284-48a1-bf45-0cca9fd8044f",
+      "file": "null",
+      "problem_id": "zombie-69e2d56d",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "40678635-7593-4777-86be-30581f4f4e20",
+      "file": "null",
+      "problem_id": "zombie-40678635",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "db22cff2-3862-45d9-a8df-3b7cdc128022",
+      "file": "null",
+      "problem_id": "zombie-db22cff2",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "551c9134-2723-42e7-97cb-b6034c5dcaef",
+      "file": "null",
+      "problem_id": "zombie-551c9134",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "ef63f4c0-2586-4fca-96a4-ba66922ade26",
+      "file": "null",
+      "problem_id": "zombie-ef63f4c0",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "64b73a5e-1106-4f96-9144-0bc7deb015a8",
+      "file": "null",
+      "problem_id": "zombie-64b73a5e",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "08562e18-324c-42a6-8bb8-8cb061ec5753",
+      "file": "null",
+      "problem_id": "zombie-08562e18",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "74c1ba88-5011-4036-aa94-717b31c8c091",
+      "file": "null",
+      "problem_id": "zombie-74c1ba88",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "6e36b531-e786-47e4-bf86-46a962ef39df",
+      "file": "null",
+      "problem_id": "zombie-6e36b531",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "25b7a9f5-8ce5-4eb0-b84a-944fd6739737",
+      "file": "null",
+      "problem_id": "zombie-25b7a9f5",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "5da96568-acc2-488f-80d3-cd1d42e53bb0",
+      "file": "null",
+      "problem_id": "zombie-5da96568",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "2900f9f8-2383-4ac6-a6a2-e2607b8867bf",
+      "file": "null",
+      "problem_id": "zombie-2900f9f8",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "3789c1a8-2da8-441b-a7aa-7876eb44d0f8",
+      "file": "null",
+      "problem_id": "zombie-3789c1a8",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "e2ed475f-9c0e-4f87-8aee-b34ac693033a",
+      "file": "null",
+      "problem_id": "zombie-e2ed475f",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "05732fbd-86f7-493a-9891-16b042e1a91e",
+      "file": "null",
+      "problem_id": "zombie-05732fbd",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "10d81e38-70a7-435f-8fd7-fd778a4d0209",
+      "file": "null",
+      "problem_id": "zombie-10d81e38",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "31d75a77-2234-408a-a668-65b1cd6d1356",
+      "file": "null",
+      "problem_id": "zombie-31d75a77",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "c1f4f599-bdcc-47c2-9d66-e272406be343",
+      "file": "null",
+      "problem_id": "zombie-c1f4f599",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "99afd465-0889-465c-b444-98917dab1076",
+      "file": "null",
+      "problem_id": "zombie-99afd465",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "551928e7-a827-45e4-8302-78928827d831",
+      "file": "null",
+      "problem_id": "zombie-551928e7",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "213ac4c8-02b5-43c7-ac8b-5fe2d51e8039",
+      "file": "null",
+      "problem_id": "zombie-213ac4c8",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "0abfab2a-1deb-400f-8d12-5f4a9f48fa7d",
+      "file": "null",
+      "problem_id": "zombie-0abfab2a",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "e379e327-a6ad-44cb-b677-8ffd3b8f22aa",
+      "file": "null",
+      "problem_id": "zombie-e379e327",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "4818bb3c-9b6a-49c8-9c5c-b9e47cc439be",
+      "file": "null",
+      "problem_id": "zombie-4818bb3c",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "51e730b0-909f-47dd-9bdf-2ba86b1c0cdb",
+      "file": "null",
+      "problem_id": "zombie-51e730b0",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "c65e5f71-3d89-45bb-8ec4-19650064f134",
+      "file": "null",
+      "problem_id": "zombie-c65e5f71",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "2c993536-b0d7-45a4-8e90-9bb394329daf",
+      "file": "null",
+      "problem_id": "zombie-2c993536",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "8a2ffaf6-a65d-4a6e-8098-41133ec8f5cf",
+      "file": "null",
+      "problem_id": "zombie-8a2ffaf6",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "95be7f8e-ed53-47bb-b6ba-4edcd7eac7a8",
+      "file": "null",
+      "problem_id": "zombie-95be7f8e",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "376a4f0e-b8ee-4561-a250-b5a25c4f98b9",
+      "file": "null",
+      "problem_id": "zombie-376a4f0e",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "93f6897c-21aa-4d53-bed4-680de76c697b",
+      "file": "null",
+      "problem_id": "zombie-93f6897c",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "a0bfc0ef-f1e8-40aa-80bb-569882331df2",
+      "file": "null",
+      "problem_id": "zombie-a0bfc0ef",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "8ea6a29d-7489-4068-b90a-db2a176aa237",
+      "file": "null",
+      "problem_id": "zombie-8ea6a29d",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "b89d2612-13f1-4c4a-a25e-20b6afd49ab8",
+      "file": "null",
+      "problem_id": "zombie-b89d2612",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "9e79ec9a-76df-4d07-af73-837fbfd843a5",
+      "file": "null",
+      "problem_id": "zombie-9e79ec9a",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "fbee843b-b861-4903-9bd8-a1181670ff5e",
+      "file": "null",
+      "problem_id": "zombie-fbee843b",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "3a4351cc-7ae3-48f8-b51d-1e998315d794",
+      "file": "null",
+      "problem_id": "zombie-3a4351cc",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "4f95b089-d847-4f42-ab09-23001ac2d220",
+      "file": "null",
+      "problem_id": "zombie-4f95b089",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "a2392356-a9e6-401d-a6af-eb7b9e5b43c0",
+      "file": "null",
+      "problem_id": "zombie-a2392356",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "377f8c65-6359-4422-8be7-0e77bb5efaef",
+      "file": "null",
+      "problem_id": "zombie-377f8c65",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "0b8c474c-f62b-4264-bd6d-80fa57628a90",
+      "file": "null",
+      "problem_id": "zombie-0b8c474c",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "9ee74139-5fab-4e76-b230-dda1997f2213",
+      "file": "null",
+      "problem_id": "zombie-9ee74139",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "ded5d4f2-a125-412f-b47b-7d3142e79cf2",
+      "file": "null",
+      "problem_id": "zombie-ded5d4f2",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "6c77dec9-b13b-4b64-b7f7-e9df92ba540c",
+      "file": "null",
+      "problem_id": "zombie-6c77dec9",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "15337aa1-82a7-49ba-a144-31ae459c6edd",
+      "file": "null",
+      "problem_id": "zombie-15337aa1",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "f3f91cc0-287f-4ca4-bce0-3da10cc6b7df",
+      "file": "null",
+      "problem_id": "zombie-f3f91cc0",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "960542ba-1ac3-48cb-b444-4924aa6f86c4",
+      "file": "null",
+      "problem_id": "zombie-960542ba",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "db1832bc-736c-4a00-a550-4d33ea0eaeff",
+      "file": "null",
+      "problem_id": "zombie-db1832bc",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "0aae8e46-0b24-4093-aaf1-6d7bbef3d242",
+      "file": "null",
+      "problem_id": "zombie-0aae8e46",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "7ee3f2ce-1841-409f-a109-bc2016c2fda4",
+      "file": "null",
+      "problem_id": "zombie-7ee3f2ce",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "4256d0fc-ea34-410e-91c7-2b04ee2b28d8",
+      "file": "null",
+      "problem_id": "zombie-4256d0fc",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "adc2094b-b26c-4c9e-9b0a-a3fd959aec6d",
+      "file": "null",
+      "problem_id": "zombie-adc2094b",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "13cddffd-c215-4d58-990e-66281b25e5a0",
+      "file": "null",
+      "problem_id": "zombie-13cddffd",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "ede85214-05b0-4f0c-bacd-315c75d97d01",
+      "file": "null",
+      "problem_id": "zombie-ede85214",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "b9048ae3-e54e-4da9-a2ab-e4952598d007",
+      "file": "null",
+      "problem_id": "zombie-b9048ae3",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "8b7b590f-ac8c-42eb-bfac-94bf0b01fb2f",
+      "file": "null",
+      "problem_id": "zombie-8b7b590f",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "10fa5cb3-023d-4736-a71e-4fdd13bdda9f",
+      "file": "null",
+      "problem_id": "zombie-10fa5cb3",
+      "submitted": "unknown",
+      "status": "zombie",
+      "notes": "Zombie project discovered by reconciliation at 2026-03-26T08:47:48Z. COMPLETE on server, no improvement found. Registered to unblock submissions."
+    },
+    {
+      "project_id": "a1a577e9-33f7-4536-8d7e-260b1517224d",
+      "file": "proofs/Proofs/Erdos247Aristotle.lean",
+      "problem_id": "erdos-247",
+      "submitted": "2026-03-26T08:48:16Z",
+      "status": "submitted",
+      "preprocessed": false,
+      "preprocessing_log": null,
+      "companion_file": true,
+      "notes": "Companion file submission (T1)"
+    },
+    {
+      "project_id": "48497dc9-214a-4c99-8d5e-5bbff10a9311",
+      "file": "proofs/Proofs/Erdos44Aristotle.lean",
+      "problem_id": "erdos-44",
+      "submitted": "2026-03-26T08:48:25Z",
+      "status": "submitted",
+      "preprocessed": false,
+      "preprocessing_log": null,
+      "companion_file": true,
+      "notes": "Companion file submission (T1)"
+    },
+    {
+      "project_id": "2282a010-d101-41c1-aab0-d23b151293ee",
+      "file": "proofs/Proofs/ChineseRemainderNonCoprimeOQ03Aristotle.lean",
+      "problem_id": "chineseremaindernoncoprimeoq03",
+      "submitted": "2026-03-26T08:48:46Z",
       "status": "submitted",
       "preprocessed": false,
       "preprocessing_log": null,


### PR DESCRIPTION
## Summary
- Registered 100 COMPLETE server projects as zombies in `aristotle-jobs.json` to unblock the submission pipeline (safety check requires <10 untracked COMPLETE projects)
- Updated AreaOfCircleOQ01OQ03 job status to `integrated` (file already had 0 sorries from a previous integration)
- Successfully submitted 3 new T1 companion files to Aristotle proof search:
  - **Erdos247Aristotle** (1 sorry)
  - **Erdos44Aristotle** (1 sorry)
  - **ChineseRemainderNonCoprimeOQ03Aristotle** (2 sorries)

## Pipeline Status
| Status | Count |
|--------|-------|
| integrated | 48 |
| submitted | 3 |
| zombie | 200 |
| build_failed | 5 |
| failed | 7 |
| resolved_manually | 2 |

## Context
The submission pipeline was blocked because 100 COMPLETE projects on the Aristotle server were not tracked in the local jobs file. The `retrieve-integrate.sh` script confirmed all 100 produced "No improvement" (mapping to files already at 0 sorries). Registering them as zombies allows the submit-batch safety check to pass.

Generated with [Claude Code](https://claude.com/claude-code)