### PR TITLE
Enrich product-of-segments-of-chords: expand cross-references (3->10), deepen annotations

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -792,6 +792,11 @@
       "passes": 1,
       "lastEnriched": "2026-03-26T08:51:43Z",
       "quality": 95
+    },
+    "product-of-segments-of-chords": {
+      "passes": 1,
+      "lastEnriched": "2026-03-26T09:06:31.409Z",
+      "quality": 95
     }
   }
 }

--- a/src/data/proofs/product-of-segments-of-chords/annotations.json
+++ b/src/data/proofs/product-of-segments-of-chords/annotations.json
@@ -8,8 +8,8 @@
     },
     "type": "concept",
     "title": "Intersecting Chords",
-    "content": "The **Product of Segments of Chords** theorem states that when two chords of a circle intersect at a point P:\n\n$$PA \\cdot PB = PC \\cdot PD$$\n\nThis elegant result says that the product of the segments is the same for *any* chord through P. The product depends only on P's position relative to the circle, not on which direction the chord goes.",
-    "mathContext": "$PA \\cdot PB = PC \\cdot PD$ for any two chords $AB$, $CD$ intersecting at $P$. Equivalently, the power $\\text{pow}(P) = |PO|^2 - r^2$ is a chord-independent invariant.",
+    "content": "The **Product of Segments of Chords** theorem states that when two chords of a circle intersect at a point P:\n\n$$PA \\cdot PB = PC \\cdot PD$$\n\nThis elegant result says that the product of the segments is the same for *any* chord through P. The product depends only on P's position relative to the circle, not on which direction the chord goes. Equivalently, every chord through P 'sees' the same power of the point, an invariant that encodes P's relationship to the circle in a single real number.",
+    "mathContext": "$PA \\cdot PB = PC \\cdot PD$ for any two chords $AB$, $CD$ intersecting at $P$. Equivalently, the power $\\text{pow}(P) = \\|PO\\|^2 - r^2$ is a chord-independent invariant. The sign distinguishes interior ($< 0$), boundary ($= 0$), and exterior ($> 0$) points.",
     "significance": "key",
     "prerequisites": [
       "Euclidean geometry",
@@ -23,6 +23,29 @@
     ]
   },
   {
+    "id": "ann-historical",
+    "proofId": "product-of-segments-of-chords",
+    "range": {
+      "startLine": 8,
+      "endLine": 44
+    },
+    "type": "insight",
+    "title": "From Euclid to Steiner: 2100 Years of Circle Geometry",
+    "content": "**Euclid (c. 300 BCE)**: The theorem appears as Proposition 35 in Book III of the *Elements*. Euclid proved it using similar triangles formed by the chords. Two companion propositions follow: III.36 (secant-tangent case: $PA \\cdot PB = PT^2$) and III.37 (its converse). Together, these three propositions constitute the complete power-of-a-point theory for the ancient Greeks.\n\n**Jakob Steiner (1826)**: In *Einige geometrische Betrachtungen*, Steiner unified all four cases under the single concept of the 'power of a point':\n- Intersecting chords (interior point)\n- Two secants (exterior point)\n- Secant and tangent ($PA \\cdot PB = PT^2$)\n- Two tangents ($PT_1 = PT_2$)\n\nSteiner's insight was that these are all manifestations of the same invariant $\\|P - O\\|^2 - r^2$. He further introduced the **radical axis** of two circles as the locus where their powers are equal -- a line perpendicular to the line of centers, fundamental in inversive and projective geometry.",
+    "significance": "key",
+    "prerequisites": [
+      "similar triangles",
+      "inscribed angle theorem"
+    ],
+    "relatedConcepts": [
+      "history of mathematics",
+      "Euclid's Elements",
+      "Jakob Steiner",
+      "radical axis"
+    ],
+    "mathContext": "Euclid proved the theorem synthetically using similar triangles: $\\triangle PAC \\sim \\triangle PDB$ (by the inscribed angle theorem, $\\angle ACP = \\angle DBP$ since both subtend arc $AD$), so $PA/PD = PC/PB$, hence $PA \\cdot PB = PC \\cdot PD$. Steiner's 1826 unification introduced the power $\\text{pow}(P) = \\|P - O\\|^2 - r^2$ as a chord-independent invariant."
+  },
+  {
     "id": "ann-power",
     "proofId": "product-of-segments-of-chords",
     "range": {
@@ -31,8 +54,8 @@
     },
     "type": "definition",
     "title": "Power of a Point",
-    "content": "The **power of a point** P with respect to a circle is:\n\n$$\\text{pow}(P) = |PO|^2 - r^2$$\n\nwhere O is the center and r is the radius.\n\n- **P outside circle**: pow(P) > 0\n- **P on circle**: pow(P) = 0\n- **P inside circle**: pow(P) < 0\n\nFor any chord through P, the product of signed distances equals the power. For an interior point, $PA \\cdot PB = |\\text{pow}(P)| = r^2 - |PO|^2$.",
-    "mathContext": "$\\text{pow}(P) = |PO|^2 - r^2 = \\|P - O\\|^2 - r^2$. For $P$ inside the circle, $\\text{pow}(P) < 0$ and $PA \\cdot PB = r^2 - \\|P - O\\|^2$.",
+    "content": "The **power of a point** P with respect to a circle with center O and radius r is:\n\n$$\\text{pow}(P) = \\|P - O\\|^2 - r^2$$\n\nThe sign classifies P's position:\n- **P outside circle**: pow(P) > 0, and $PA \\cdot PB = \\text{pow}(P)$ for any secant\n- **P on circle**: pow(P) = 0\n- **P inside circle**: pow(P) < 0, and $PA \\cdot PB = |\\text{pow}(P)| = r^2 - \\|P - O\\|^2$\n\nThe power is the central invariant of the proof: since it depends only on $\\|P - O\\|$ and $r$ (not the chord direction), any two chords through P yield the same product. The power function $P \\mapsto \\|P - O\\|^2 - r^2$ defines a quadratic form on the plane, and its level sets are concentric circles centered at O.",
+    "mathContext": "$\\text{pow}(P) = \\|P - O\\|^2 - r^2$. For $P$ inside the circle, $\\text{pow}(P) < 0$ and $PA \\cdot PB = r^2 - \\|P - O\\|^2$. The power is a smooth function whose gradient $\\nabla\\,\\text{pow}(P) = 2(P - O)$ points radially outward.",
     "significance": "key",
     "prerequisites": [
       "norm/distance in inner product spaces",
@@ -41,29 +64,31 @@
     "relatedConcepts": [
       "radical axis",
       "inversive geometry",
-      "circle invariants"
+      "circle invariants",
+      "quadratic forms"
     ]
   },
   {
-    "id": "ann-main",
+    "id": "ann-inner-product-expansion",
     "proofId": "product-of-segments-of-chords",
     "range": {
-      "startLine": 419,
-      "endLine": 437
+      "startLine": 101,
+      "endLine": 196
     },
-    "type": "theorem",
-    "title": "The Main Theorem",
-    "content": "**Theorem (Euclid III.35)**:\n\nIf two chords AB and CD of a circle intersect at point P, then:\n$$PA \\cdot PB = PC \\cdot PD$$\n\n**Proof idea**: Both products equal the absolute value of the power of P:\n1. $PA \\cdot PB = |\\text{pow}(P)|$\n2. $PC \\cdot PD = |\\text{pow}(P)|$\n3. Therefore $PA \\cdot PB = PC \\cdot PD$\n\nThe power is an invariant of the point's position relative to the circle.",
-    "mathContext": "$PA \\cdot PB = PC \\cdot PD = |\\,\\|P - O\\|^2 - r^2\\,|$ for any chords $AB$, $CD$ through $P$.",
+    "type": "technique",
+    "title": "Inner Product Expansion for Circle Intersection",
+    "content": "The algebraic heart of the proof is expanding $\\|P + t\\mathbf{d} - O\\|^2 = r^2$ using the inner product bilinearity:\n\n$$\\|P + t\\mathbf{d} - O\\|^2 = \\|P - O\\|^2 + 2t\\langle P - O, \\mathbf{d}\\rangle + t^2\\|\\mathbf{d}\\|^2$$\n\nSetting this equal to $r^2$ yields a quadratic in $t$ whose coefficients encode the circle's geometry:\n- **Leading coefficient** $\\|\\mathbf{d}\\|^2$: the direction vector's magnitude (normalized to 1 for unit directions)\n- **Linear coefficient** $2\\langle P - O, \\mathbf{d}\\rangle$: how far P is from center in direction $\\mathbf{d}$\n- **Constant term** $\\|P - O\\|^2 - r^2 = \\text{pow}(P)$: the power of P, independent of $\\mathbf{d}$\n\nThe direction-independence of the constant term is exactly why the chord product is an invariant.",
+    "mathContext": "The quadratic $t^2\\|\\mathbf{d}\\|^2 + 2t\\langle P - O, \\mathbf{d}\\rangle + (\\|P - O\\|^2 - r^2) = 0$ has roots $t_1, t_2$ representing the signed distances along $\\mathbf{d}$ from $P$ to the circle. The product $t_1 t_2 = (\\|P - O\\|^2 - r^2)/\\|\\mathbf{d}\\|^2$ shows that $|t_1 t_2| \\cdot \\|\\mathbf{d}\\|^2 = |\\text{pow}(P)|$ is direction-independent.",
     "significance": "key",
     "prerequisites": [
-      "power of a point definition",
-      "chord-circle intersection"
+      "inner product bilinearity",
+      "norm-squared expansion",
+      "quadratic equation theory"
     ],
     "relatedConcepts": [
-      "chord properties",
-      "circle invariants",
-      "Euclid's Elements Book III"
+      "Cauchy-Schwarz inequality",
+      "quadratic forms",
+      "parametric line equations"
     ]
   },
   {
@@ -74,9 +99,9 @@
       "endLine": 219
     },
     "type": "proof",
-    "title": "Algebraic Approach",
-    "content": "**Vieta's Formulas Approach**:\n\nParameterize points on a chord through P in direction $\\vec{d}$:\n$$Q(t) = P + t\\vec{d}$$\n\nA point is on the circle of radius r centered at origin iff:\n$$|P + t\\vec{d}|^2 = r^2$$\n\nExpanding (with $|\\vec{d}| = 1$):\n$$t^2 + 2t\\langle P, \\vec{d}\\rangle + |P|^2 - r^2 = 0$$\n\nBy **Vieta's formulas**, the product of roots is:\n$$t_1 \\cdot t_2 = |P|^2 - r^2$$\n\nSince distances are $|t_1|$ and $|t_2|$, we get $|t_1| \\cdot |t_2| = r^2 - |P|^2$ for interior points.",
-    "mathContext": "Parametrize the chord as $Q(t) = P + t\\vec{d}$. Circle equation gives $t^2 + 2t\\langle P, \\vec{d}\\rangle + (\\|P\\|^2 - r^2) = 0$. By Vieta: $t_1 t_2 = \\|P\\|^2 - r^2 = \\text{pow}(P)$.",
+    "title": "Vieta's Formulas: The Algebraic Core",
+    "content": "**Vieta's Formulas Approach**:\n\nParameterize points on a chord through P in direction $\\vec{d}$:\n$$Q(t) = P + t\\vec{d}$$\n\nThe circle equation $\\|Q(t) - O\\|^2 = r^2$ yields a quadratic in $t$. By **Vieta's formulas**, the product of roots equals the constant term divided by the leading coefficient:\n$$t_1 \\cdot t_2 = \\frac{\\|P - O\\|^2 - r^2}{\\|\\vec{d}\\|^2}$$\n\nSince $PA = |t_1| \\cdot \\|\\vec{d}\\|$ and $PB = |t_2| \\cdot \\|\\vec{d}\\|$:\n$$PA \\cdot PB = |t_1 t_2| \\cdot \\|\\vec{d}\\|^2 = |\\text{pow}(P)|$$\n\nThe direction $\\vec{d}$ cancels completely, proving invariance. This is why the formalization uses Vieta's formulas rather than Euclid's synthetic approach: the algebraic proof naturally reveals the invariance structure.",
+    "mathContext": "Parametrize the chord as $Q(t) = P + t\\vec{d}$. Circle equation gives $t^2\\|\\vec{d}\\|^2 + 2t\\langle P - O, \\vec{d}\\rangle + (\\|P - O\\|^2 - r^2) = 0$. By Vieta: $t_1 t_2 = \\text{pow}(P)/\\|\\vec{d}\\|^2$, so $PA \\cdot PB = |t_1| \\cdot |t_2| \\cdot \\|\\vec{d}\\|^2 = |\\text{pow}(P)|$.",
     "significance": "key",
     "prerequisites": [
       "inner product expansion",
@@ -90,6 +115,29 @@
     ]
   },
   {
+    "id": "ann-main",
+    "proofId": "product-of-segments-of-chords",
+    "range": {
+      "startLine": 419,
+      "endLine": 437
+    },
+    "type": "theorem",
+    "title": "The Main Theorem (Wiedijk #55)",
+    "content": "**Theorem (Euclid III.35, Wiedijk #55)**:\n\nIf two chords AB and CD of a circle intersect at point P, then:\n$$PA \\cdot PB = PC \\cdot PD$$\n\n**Proof structure**: The key insight is that the chord product factors through the power:\n1. $PA \\cdot PB = |\\text{pow}(P)|$ (invariance for chord $AB$)\n2. $PC \\cdot PD = |\\text{pow}(P)|$ (invariance for chord $CD$)\n3. Therefore $PA \\cdot PB = PC \\cdot PD$ (transitivity of equality)\n\nThe power $\\text{pow}(P) = \\|P - O\\|^2 - r^2$ depends only on the distance from P to the center, not on which chord passes through P. This factorization through a common invariant is the conceptual core of the proof.",
+    "mathContext": "$PA \\cdot PB = PC \\cdot PD = |\\,\\|P - O\\|^2 - r^2\\,|$ for any chords $AB$, $CD$ through $P$. The power $\\text{pow}(P)$ is the unique value such that every chord through $P$ has segment product $|\\text{pow}(P)|$.",
+    "significance": "key",
+    "prerequisites": [
+      "power of a point definition",
+      "chord-circle intersection",
+      "Vieta's formulas"
+    ],
+    "relatedConcepts": [
+      "chord properties",
+      "circle invariants",
+      "Euclid's Elements Book III"
+    ]
+  },
+  {
     "id": "ann-center",
     "proofId": "product-of-segments-of-chords",
     "range": {
@@ -98,15 +146,16 @@
     },
     "type": "example",
     "title": "Special Case: Center",
-    "content": "When P is at the **center** of the circle:\n\n- Every chord through P is a diameter\n- Both segments have length r (the radius)\n- The product is $r \\cdot r = r^2$\n\nThis confirms our formula since pow(center) = $0^2 - r^2 = -r^2$, and $|\\text{pow}| = r^2$.\n\nThis is the *maximum* value of PA * PB for any interior point.",
-    "mathContext": "When $P = O$: $\\text{pow}(O) = -r^2$, so $PA \\cdot PB = r^2$ for every chord (which is a diameter). This is maximal since $r^2 - \\|P-O\\|^2 \\leq r^2$.",
+    "content": "When P is at the **center** of the circle:\n\n- Every chord through P is a diameter\n- Both segments have length r (the radius)\n- The product is $r \\cdot r = r^2$\n\nThis confirms our formula since $\\text{pow}(O) = 0^2 - r^2 = -r^2$, and $|\\text{pow}| = r^2$.\n\nThis is the *maximum* value of $PA \\cdot PB$ for any interior point, since $r^2 - \\|P - O\\|^2 \\leq r^2$ with equality only at the center. The minimum (approaching 0) occurs as P approaches the circle boundary.",
+    "mathContext": "When $P = O$: $\\text{pow}(O) = -r^2$, so $PA \\cdot PB = r^2$ for every chord (which is a diameter). This is maximal since $r^2 - \\|P-O\\|^2 \\leq r^2$, and the power function $P \\mapsto r^2 - \\|P-O\\|^2$ has its unique maximum at the center.",
     "significance": "supporting",
     "prerequisites": [
       "power of a point at center"
     ],
     "relatedConcepts": [
       "diameter",
-      "maximum product"
+      "maximum product",
+      "optimization"
     ]
   },
   {
@@ -117,9 +166,9 @@
       "endLine": 490
     },
     "type": "theorem",
-    "title": "The Converse",
-    "content": "**Converse Theorem**:\n\nIf lines AB and CD intersect at P, and:\n$$PA \\cdot PB = PC \\cdot PD$$\n\nthen A, B, C, D all lie on a common circle (they are **concyclic**).\n\nThis is a powerful criterion for proving four points lie on a circle. The converse follows because equal products imply equal power, which determines a unique circle.",
-    "mathContext": "$PA \\cdot PB = PC \\cdot PD \\Rightarrow A, B, C, D$ are concyclic. Equal products imply equal power with respect to some circle, uniquely determining the circumcircle.",
+    "title": "The Converse: A Concyclicity Criterion",
+    "content": "**Converse Theorem**:\n\nIf lines AB and CD intersect at P, and:\n$$PA \\cdot PB = PC \\cdot PD$$\n\nthen A, B, C, D all lie on a common circle (they are **concyclic**).\n\nThis is a powerful criterion for proving four points lie on a circle. The converse follows because equal products imply equal power, and a point has equal power with respect to a circle for all lines through it. The circle through three of the four points (which exists and is unique by the circumcircle theorem) must therefore also pass through the fourth.\n\nThis converse is axiomatized in the formalization: the forward direction is proved algebraically, but the converse requires geometric reasoning about circle uniqueness that goes beyond the algebraic framework used here.",
+    "mathContext": "$PA \\cdot PB = PC \\cdot PD \\Rightarrow A, B, C, D$ are concyclic. Let $\\omega$ be the circumcircle of $A, B, C$. Then $\\text{pow}_{\\omega}(P) = PA \\cdot PB = PC \\cdot PD$, so $D$ lies on $\\omega$ by uniqueness of the circle through three non-collinear points.",
     "significance": "key",
     "prerequisites": [
       "power of a point uniqueness",
@@ -140,37 +189,39 @@
     },
     "type": "example",
     "title": "Worked Examples",
-    "content": "**Example 1**: Circle of radius 5, point P at distance 3 from center.\n- Power = $5^2 - 3^2 = 16$\n- For any chord: $PA \\cdot PB = 16$\n- If PA = 2, then PB = 8\n\n**Example 2**: If one chord gives segments 2 and 8:\n- Product = 16\n- Other chord: if PC = 4, then PD = 4\n- (The chord is bisected at P!)\n\n**Example 3**: Segments 1 and 12:\n- Product = 12\n- Other chord: segments could be 2 and 6, or 3 and 4",
+    "content": "**Example 1**: Circle of radius 5, point P at distance 3 from center.\n- Power = $5^2 - 3^2 = 16$\n- For any chord: $PA \\cdot PB = 16$\n- If PA = 2, then PB = 8\n\n**Example 2**: If one chord gives segments 2 and 8:\n- Product = 16\n- Other chord: if PC = 4, then PD = 4\n- (The chord is bisected at P -- this happens exactly when the chord is perpendicular to the line OP.)\n\n**Example 3**: Segments 1 and 12:\n- Product = 12\n- Other chord: segments could be 2 and 6, or 3 and 4\n- Circle has $r^2 - d^2 = 12$ where $d = \\|P - O\\|$",
     "significance": "supporting",
     "relatedConcepts": [
       "numerical verification",
       "chord bisection"
     ],
     "prerequisites": [
-      "mathematical foundations"
+      "power of a point computation"
     ],
-    "mathContext": "Numerical verification via `norm_num`: for a circle of radius $r = 5$ with $P$ at distance $d = 3$ from center, $PA \\cdot PB = r^2 - d^2 = 25 - 9 = 16$ for every chord through $P$. If one chord has segments $2$ and $8$, another through the same point could have segments $4$ and $4$."
+    "mathContext": "Numerical verification via `norm_num`: for a circle of radius $r = 5$ with $P$ at distance $d = 3$ from center, $PA \\cdot PB = r^2 - d^2 = 25 - 9 = 16$ for every chord through $P$. If one chord has segments $2$ and $8$, another through the same point could have segments $4$ and $4$ (the perpendicular chord)."
   },
   {
-    "id": "ann-historical",
+    "id": "ann-secant-tangent",
     "proofId": "product-of-segments-of-chords",
     "range": {
-      "startLine": 8,
-      "endLine": 44
+      "startLine": 509,
+      "endLine": 541
     },
     "type": "insight",
-    "title": "From Euclid to Steiner",
-    "content": "**Euclid (300 BCE)**: The theorem appears as Proposition 35 in Book III of the Elements. Euclid proved it using similar triangles formed by the chords.\n\n**Jakob Steiner (1826)**: Systematized the \"power of a point\" concept, unifying:\n- Intersecting chords (interior point)\n- Two secants (exterior point)\n- Secant and tangent\n- Two tangents\n\nAll are manifestations of the same invariant!",
-    "significance": "supporting",
+    "title": "Steiner's Unification: Four Theorems as One",
+    "content": "The power of a point unifies four classical theorems into a single statement: for any line through P intersecting a circle, the product of signed distances to the intersection points equals $\\text{pow}(P)$.\n\n**1. Intersecting chords** (P inside, Euclid III.35): $PA \\cdot PB = r^2 - d^2$ where both roots have opposite signs.\n\n**2. Two secants** (P outside, Euclid III.36 corollary): $PA \\cdot PB = d^2 - r^2$ where both roots have the same sign.\n\n**3. Secant-tangent** (P outside, Euclid III.36): $PA \\cdot PB = PT^2$ when the secant degenerates to a tangent ($t_1 = t_2$, a double root).\n\n**4. Two tangents** (P outside): $PT_1 = PT_2 = \\sqrt{d^2 - r^2}$ -- the tangent lengths from an external point are equal.\n\nAll four follow from the same quadratic $t^2 + 2t\\langle P-O, \\mathbf{d}\\rangle + (d^2 - r^2) = 0$ and Vieta's product formula.",
+    "mathContext": "The discriminant $\\Delta = 4(\\langle P-O, \\mathbf{d}\\rangle^2 - \\|\\mathbf{d}\\|^2(d^2 - r^2))$ determines the intersection type: $\\Delta > 0$ (secant/chord), $\\Delta = 0$ (tangent), $\\Delta < 0$ (no intersection). The product of roots $t_1 t_2 = (d^2 - r^2)/\\|\\mathbf{d}\\|^2$ is always the same invariant regardless of $\\mathbf{d}$.",
+    "significance": "key",
     "prerequisites": [
-      "similar triangles",
-      "inscribed angle theorem"
+      "power of a point",
+      "quadratic discriminant",
+      "Vieta's formulas"
     ],
     "relatedConcepts": [
-      "history of mathematics",
-      "Euclid's Elements",
-      "Jakob Steiner"
-    ],
-    "mathContext": "Euclid proved the theorem synthetically using similar triangles: $\\triangle PAC \\sim \\triangle PDB$ (by the inscribed angle theorem), so $PA/PD = PC/PB$, hence $PA \\cdot PB = PC \\cdot PD$. Steiner's 1826 unification introduced the power $\\text{pow}(P) = |PO|^2 - r^2$ as a chord-independent invariant."
+      "secant-tangent theorem",
+      "tangent from external point",
+      "radical axis",
+      "Steiner's unification"
+    ]
   }
 ]

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -133,30 +133,65 @@
     }
   ],
   "conclusion": {
-    "summary": "The Product of Segments of Chords theorem is verified using Mathlib's Euclidean geometry infrastructure. We connect it to the power of a point concept and prove the main result along with special cases and the converse.",
-    "implications": "This theorem is fundamental to circle geometry and has many applications:\n\n**1. Geometric constructions**\nFinding circle centers and constructing tangents.\n\n**2. Lens design**\nOptical path calculations through curved surfaces.\n\n**3. Proof techniques**\nFoundation for proving many other circle theorems.\n\n**4. Coordinate geometry**\nComputing intersections of circles and lines.",
+    "summary": "This 541-line formalization of the Product of Segments of Chords theorem (Wiedijk #55) takes the algebraic approach to Euclid III.35, using Vieta's formulas rather than Euclid's original similar-triangle argument. The proof factors through the power of a point invariant $\\text{pow}(P) = \\|P - O\\|^2 - r^2$: every chord through P yields the same segment product $|\\text{pow}(P)|$, so any two chords give equal products. The formalization includes the center special case ($PA \\cdot PB = r^2$), the axiomatized converse (equal products imply concyclicity), and numerical verification via `norm_num`.",
+    "implications": "**Theoretical Significance:**\n\n**1. Power of a point** -- Steiner's unification (1826) shows this theorem is one of four manifestations of the power invariant: intersecting chords, two secants, secant-tangent, and two tangents. The radical axis of two circles (locus of equal powers) is a fundamental tool in inversive and projective geometry.\n\n**2. Inversive geometry** -- The power of a point is preserved under inversion: if $P'$ is the image of $P$ under inversion in a circle $\\omega$, then $\\text{pow}_{\\omega}(P) \\cdot \\text{pow}_{\\omega}(P') = r_{\\omega}^4$. This makes the theorem central to the theory of Mobius transformations.\n\n**3. Proof techniques** -- The converse provides a powerful concyclicity criterion: to show four points are concyclic, show that two lines through their intersection point satisfy $PA \\cdot PB = PC \\cdot PD$. This is widely used in olympiad geometry.\n\n**4. Computational geometry** -- The power function $P \\mapsto \\|P - O\\|^2 - r^2$ determines whether a point is inside, on, or outside a circle, and is used in Delaunay triangulation algorithms (a point is inside the circumcircle iff its power is negative).",
     "openQuestions": [
-      "How does this theorem generalize to spheres in 3D?",
-      "What is the relationship to inversive geometry and Mobius transformations?",
-      "How can this be extended to non-Euclidean geometries?",
-      "What are efficient algorithms for computing the power of a point in computational geometry?"
+      "Generalization to 3D: for a sphere with center O and radius r, is the product PA * PB = |d^2 - r^2| still invariant for all secant lines through P? (Yes, by the same algebraic argument, since the inner product expansion is dimension-independent.)",
+      "Can the converse (currently axiomatized) be proved algebraically within the formalization, avoiding the synthetic circumcircle argument?",
+      "How does the power of a point relate to the determinant criterion for concyclicity: four points are concyclic iff the 4x4 determinant with rows (x_i^2 + y_i^2, x_i, y_i, 1) vanishes?",
+      "What is the connection to algebraic geometry: the power function defines a quadratic form, and the radical axis is the linear locus where two quadratic forms agree -- can this be formalized using Mathlib's algebraic geometry?"
     ]
   },
   "crossReferences": [
     {
       "targetId": "ptolemys-theorem",
       "relationship": "related",
-      "description": "Ptolemy's theorem on cyclic quadrilaterals — both are fundamental results about circles relating products of distances"
+      "description": "Ptolemy's theorem ($AC \\cdot BD = AB \\cdot CD + AD \\cdot BC$ for cyclic quadrilateral $ABCD$) and the intersecting chords theorem are both consequences of the power of a point. Ptolemy's inequality characterizes when four points are concyclic, while the intersecting chords theorem provides an equivalent criterion via segment products"
     },
     {
       "targetId": "cevas-theorem",
       "relationship": "related",
-      "description": "Ceva's theorem on concurrent cevians — related triangle-circle geometry using similar ratio arguments"
+      "description": "Both theorems relate products of segment ratios in geometric configurations. Ceva's theorem ($\\frac{AF}{FB} \\cdot \\frac{BD}{DC} \\cdot \\frac{CE}{EA} = 1$ for concurrent cevians) uses similar ratio arguments, and the trigonometric form of Ceva's theorem connects to inscribed angles in circles"
     },
     {
       "targetId": "area-of-circle",
       "relationship": "related",
-      "description": "Circle area formalization using the same Mathlib Euclidean geometry infrastructure"
+      "description": "Both formalizations build on Mathlib's Euclidean inner product space infrastructure. The area formula $A = \\pi r^2$ and the power $\\text{pow}(P) = d^2 - r^2$ both express geometric properties of circles in terms of the radius $r$ and Euclidean distance"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "The Pythagorean theorem underlies the power of a point: $\\text{pow}(P) = \\|P - O\\|^2 - r^2$ uses the squared Euclidean distance $\\|P - O\\|^2 = (x_P - x_O)^2 + (y_P - y_O)^2$, which is the Pythagorean theorem applied to the displacement vector. The norm-squared expansion in the algebraic proof is essentially repeated application of the Pythagorean identity"
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "foundational",
+      "description": "The algebraic proof directly uses Vieta's formulas: the chord-circle intersection yields a quadratic $t^2 + 2bt + c = 0$ whose root product $t_1 t_2 = c$ equals the power of the point. This is the $n = 2$ case of Vieta's formulas: the constant term of a monic quadratic equals the product of its roots"
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "The law of cosines generalizes the Pythagorean theorem to arbitrary triangles, just as the power of a point generalizes the intersecting chords theorem to arbitrary point positions. Both use the inner product structure of the Euclidean plane: $\\|A - B\\|^2 = \\|A\\|^2 - 2\\langle A, B\\rangle + \\|B\\|^2$ appears in both proofs"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "related",
+      "description": "Feuerbach's theorem (the nine-point circle is internally tangent to the incircle) is proved using the power of a point: the tangency condition is equivalent to the power of the incenter with respect to the nine-point circle equaling $(r_9 - r_I)^2$, where $r_9$ and $r_I$ are the respective radii"
+    },
+    {
+      "targetId": "desargues-theorem",
+      "relationship": "thematic",
+      "description": "Both are classical results in projective/Euclidean geometry formalized using Mathlib's geometric infrastructure. Desargues' theorem concerns perspectivity of triangles; the intersecting chords theorem concerns circle invariants. Both can be stated and proved within the framework of projective geometry, where circles become conics"
+    },
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "thematic",
+      "description": "Both are among the oldest results in their respective geometric domains, appearing on Wiedijk's list of 100 famous theorems (chords = #55, Euler's formula = #9). Both reveal deep structural invariants: the power of a point is a circle invariant, $V - E + F = 2$ is a topological invariant"
+    },
+    {
+      "targetId": "picks-theorem",
+      "relationship": "thematic",
+      "description": "Both are classical geometry results on Wiedijk's list (#55 and #63) that express geometric quantities (segment products, polygon area) through algebraic formulas. Pick's theorem computes area from lattice points; the intersecting chords theorem computes segment products from the power invariant"
     }
   ],
   "leanFile": {
@@ -180,10 +215,31 @@
   "references": [
     {
       "authors": "Euclid",
-      "title": "Elements, Book III, Proposition 35",
+      "title": "Elements, Book III, Propositions 35-37",
       "year": "~300 BCE",
       "venue": "Alexandria",
-      "note": "The power of a point theorem: if two chords intersect inside a circle, the products of their segments are equal"
+      "note": "Propositions 35-37 of Book III contain the complete ancient treatment: intersecting chords (35), secant-tangent (36), and its converse (37) -- the three cases that Steiner would later unify as the power of a point"
+    },
+    {
+      "authors": "Steiner, Jakob",
+      "title": "Einige geometrische Betrachtungen",
+      "year": "1826",
+      "venue": "Journal fur die reine und angewandte Mathematik, vol. 1, pp. 161-184",
+      "note": "Introduced the 'power of a point' concept, unifying the four classical circle-line intersection theorems as manifestations of a single invariant, and defined the radical axis of two circles"
+    },
+    {
+      "authors": "Coxeter, H. S. M.",
+      "title": "Introduction to Geometry",
+      "year": "1969",
+      "venue": "Wiley, 2nd edition",
+      "note": "Chapter 6 develops the power of a point systematically, connecting it to inversive geometry, coaxial circles, and the radical axis -- the modern framework for Steiner's original ideas"
+    },
+    {
+      "authors": "Johnson, Roger A.",
+      "title": "Advanced Euclidean Geometry",
+      "year": "1929",
+      "venue": "Houghton Mifflin (reprinted by Dover, 2007)",
+      "note": "Comprehensive treatment of circle geometry including the power of a point, radical axes, coaxial systems, and inversive distance -- the classical reference for advanced synthetic geometry"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary

Enriches the Product of Segments of Chords gallery entry (Wiedijk #55, Euclid III.35):

- **Cross-references expanded from 3 to 10**: Added connections to pythagorean-theorem (foundational -- norm-squared expansion), vietas-formulas (foundational -- algebraic core of the proof), law-of-cosines (related -- inner product structure), feuerbachs-theorem (related -- power of a point in tangency proofs), desargues-theorem, euler-polyhedral-formula, picks-theorem (thematic -- Wiedijk list geometry results). Existing cross-references to ptolemys-theorem, cevas-theorem, area-of-circle deepened with specific mathematical connections.
- **Annotations improved from 8 to 10**: Added "Inner Product Expansion for Circle Intersection" (explains the algebraic heart of the proof) and "Steiner's Unification: Four Theorems as One" (shows how the power of a point unifies intersecting chords, two secants, secant-tangent, and two tangents). Existing annotations deepened with more mathematical detail.
- **References expanded from 1 to 4**: Added Steiner (1826, original power-of-a-point paper), Coxeter (1969, inversive geometry context), Johnson (1929, classical advanced Euclidean geometry reference).
- **Conclusion section rewritten** with specific theoretical significance (inversive geometry, concyclicity criteria, Delaunay triangulation) and more concrete open questions.