### PR TITLE
refactor: /lean skill dispatches to launch.sh daemon

### DIFF
--- a/.claude/commands/lean.md
+++ b/.claude/commands/lean.md
@@ -1,296 +1,93 @@
 # Lean
 
-Assume the Lean Daemon role and run the **continuous** mathematical orchestration system.
+Dispatch mathematical orchestration commands via the shell daemon (`launch.sh`).
 
-## Process
+## Important: Use the Shell Daemon
 
-1. **Parse arguments**: Extract command and options
-2. **Initialize state**: Load or create `.loom/lean-state.json`
-3. **Run continuous loop**: Spawn mathematical agents, monitor progress, scale pools
-4. **Run until cancelled**: Continue until Ctrl+C or stop signal
+The shell daemon (`./scripts/lean/launch.sh daemon`) is the primary orchestration system. It runs continuously in a tmux session, handles token rotation, health checks, respawning, and crash recovery autonomously.
 
-## Work Scope
+**Do NOT try to implement a continuous loop using Claude Code subagents.** That approach requires manual cycling, suffers from auth expiration, and reinvents what `launch.sh` already does.
 
-As the **Lean Daemon**, you **continuously** orchestrate the mathematical agent team:
+## Dispatch Logic
 
-- **Spawn Erdős enhancers** to upgrade gallery stubs with Lean formalizations
-- **Spawn Aristotle agents** to manage proof search queue
-- **Spawn Researchers** to work on open mathematical problems
-- **Spawn Seekers** to select research problems when the candidate pool runs low
-- **Spawn Deployers** to merge PRs and deploy the website
-- **Monitor progress** by checking tmux sessions and work queues
-- **Scale pools** based on available work
-- **Track state** in `.loom/lean-state.json` for crash recovery
+Parse `$ARGUMENTS` and route:
 
-You don't do the mathematical work yourself - you spawn worker agents to do the work in parallel.
-
-## Usage
-
-```
-/lean                     # Start daemon with default pool (2 erdos, 1 aristotle, 1 researcher, 1 seeker, 1 deployer)
-/lean status              # Report current system state only
-/lean start --erdos 3 --researcher 2    # Start with custom pool sizes
-/lean spawn erdos         # Manually spawn one Erdős enhancer
-/lean spawn aristotle     # Manually spawn Aristotle agent
-/lean spawn researcher    # Manually spawn Researcher agent
-/lean spawn seeker        # Manually spawn Seeker agent
-/lean spawn deployer      # Manually spawn Deployer agent
-/lean scale erdos 3       # Scale Erdős pool to 3 agents
-/lean stop                # Graceful shutdown of all agents
-```
-
-## Commands
-
-| Command | Description |
-|---------|-------------|
-| (none) | Start continuous daemon loop with defaults |
-| `status` | Report system state without starting loop |
-| `start [options]` | Start daemon with custom pool configuration |
-| `spawn <type>` | Manually spawn one agent of specified type |
-| `scale <type> <count>` | Scale agent pool to specified count |
-| `stop` | Graceful shutdown of all agents |
-
-## Start Options
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--erdos N` | 2 | Number of Erdős enhancer agents |
-| `--aristotle N` | 1 | Number of Aristotle agents |
-| `--researcher N` | 1 | Number of Researcher agents |
-| `--seeker N` | 1 | Number of Seeker agents |
-| `--deployer N` | 1 | Number of Deployer agents |
-
-## Pool Configuration
-
-```json
-{
-  "erdos": { "min": 0, "max": 5, "default": 2 },
-  "aristotle": { "min": 0, "max": 2, "default": 1 },
-  "researcher": { "min": 0, "max": 3, "default": 1 },
-  "seeker": { "min": 0, "max": 1, "default": 1 },
-  "deployer": { "min": 0, "max": 1, "default": 1 }
-}
-```
-
-## Status Command
-
-The `status` command displays the current system state without taking any action.
-
-**To run status**, execute the helper script:
+### No arguments, `start`, or `daemon` → Start the shell daemon
 
 ```bash
-# Display formatted status
-./scripts/lean/status.sh
+# Check if already running
+./scripts/lean/launch.sh health
 
-# Get status as JSON for scripting
-./scripts/lean/status.sh --json
+# Start in tmux (recommended — runs autonomously)
+tmux new-session -d -s lean-daemon './scripts/lean/launch.sh daemon --enricher 2 --researcher 1 --deployer 1'
+
+# Or with custom pool
+tmux new-session -d -s lean-daemon './scripts/lean/launch.sh daemon --enricher 2 --researcher 3 --aristotle 1 --seeker 1 --deployer 1 --auditor 1 --mechanic 1'
 ```
 
-**Status shows**:
-- Daemon status (running/stopped, uptime)
-- Work queue depths for each agent type
-- Agent pool status (active/idle, current work)
-- Session statistics (stubs enhanced, proofs submitted, deployments)
-
-## Continuous Loop
-
-The daemon runs **continuously** until cancelled:
-
-```
-while not cancelled:
-    1. Check for shutdown signal (.loom/signals/stop-lean-daemon)
-    2. Assess work queues (stubs, proofs, research problems, PRs)
-    3. Check agent completions (tmux session status)
-    4. Spawn/scale agents based on work availability
-    5. Print status report
-    6. Sleep 60 seconds, repeat
-```
-
-## Spawning Agents
-
-Agents are spawned via the existing launch scripts which create tmux sessions:
+### `status` → Show system state
 
 ```bash
-# Spawn Erdős enhancers
-./scripts/erdos/parallel-enhance.sh N
-
-# Spawn Aristotle agent
-./scripts/aristotle/launch-agent.sh
-
-# Spawn Researchers
-./scripts/research/parallel-research.sh N
-
-# Spawn Seeker agent
-./scripts/research/launch-seeker.sh
-
-# Spawn Deployer
-./scripts/deploy/launch-agent.sh
+./scripts/lean/launch.sh health
+./scripts/lean/launch.sh status
 ```
 
-The daemon monitors these tmux sessions to track agent status.
-
-## Work Queue Monitoring
-
-| Agent Type | Work Source | Check Command |
-|------------|-------------|---------------|
-| Erdős | Stubs needing enhancement | `npx tsx scripts/erdos/find-stubs.ts --stats` |
-| Aristotle | Pending proof search jobs | `jq '.jobs \| map(select(.status=="submitted")) \| length' research/aristotle-jobs.json` |
-| Researcher | Available research problems | `jq '.candidates \| map(select(.status=="available")) \| length' .lean/state/candidate-pool.json` |
-| Seeker | Low candidate pool | `jq '.candidates \| map(select(.status=="available")) \| length' .lean/state/candidate-pool.json` (triggers when < 5) |
-| Deployer | PRs ready to merge | `gh pr list --label "loom:pr" --json number \| jq length` |
-
-## Status Report
-
-```
-═══════════════════════════════════════════════════
-  LEAN GENIUS STATUS
-═══════════════════════════════════════════════════
-  Daemon: Running (uptime: 2h 15m)
-
-  Work Queue:
-    Stubs needing enhancement: 127 (with sources)
-    Aristotle jobs pending: 5
-    Research problems available: 12
-    PRs ready to merge: 2
-
-  Agent Pool:
-    Erdős Enhancers: 2/2 active
-      erdos-enhancer-1: Running (45m)
-      erdos-enhancer-2: Running (12m)
-    Aristotle: 1/1 active
-      aristotle-agent: Running
-    Researcher: 1/1 active
-      researcher-1: Running (1h 20m)
-    Seeker: 1/1 active
-      seeker-agent: Running (15m cycle)
-    Deployer: 1/1 active
-      deployer: Last cycle 30m ago
-
-  Session Stats:
-    Stubs enhanced: 5
-    Proofs submitted: 3
-    Problems selected: 2
-    Deployments: 1
-═══════════════════════════════════════════════════
-```
-
-## State Persistence
-
-State tracked in `.loom/lean-state.json`:
-
-```json
-{
-  "started_at": "2026-01-24T10:00:00Z",
-  "running": true,
-  "config": {
-    "erdos": 2,
-    "aristotle": 1,
-    "researcher": 1,
-    "seeker": 1,
-    "deployer": 1
-  },
-  "agents": {
-    "erdos-enhancer-1": { "status": "running", "started": "2026-01-24T10:00:00Z" },
-    "erdos-enhancer-2": { "status": "running", "started": "2026-01-24T10:05:00Z" },
-    "aristotle-agent": { "status": "running", "started": "2026-01-24T10:00:00Z" },
-    "researcher-1": { "status": "running", "started": "2026-01-24T10:00:00Z" },
-    "seeker-agent": { "status": "running", "started": "2026-01-24T10:00:00Z" },
-    "deployer": { "status": "running", "started": "2026-01-24T10:00:00Z" }
-  },
-  "session_stats": {
-    "stubs_enhanced": 5,
-    "proofs_submitted": 3,
-    "proofs_integrated": 2,
-    "problems_selected": 2,
-    "deployments": 1
-  }
-}
-```
-
-## Graceful Shutdown
+### `stop` → Stop the daemon and agents
 
 ```bash
-# Option 1: Create stop signal
-touch .loom/signals/stop-lean-daemon
-
-# Option 2: Use command
-/lean stop
-
-# Daemon will:
-# 1. Stop spawning new agents
-# 2. Send graceful stop to all agents
-# 3. Wait for agents to complete current work (max 5 min)
-# 4. Clean up state
-# 5. Exit
+./scripts/lean/launch.sh stop --force
 ```
 
-## Agent Coordination
-
-### Erdős Enhancers
-- Use random stub selection to avoid collisions
-- Each agent works in isolated worktree
-- Creates PR when stub is enhanced
-
-### Aristotle
-- Single agent manages proof search queue
-- Submits jobs, retrieves results, integrates proofs
-- Runs on 30-minute cycle
-
-### Researchers
-- Claim problems atomically via claim files
-- Each works in isolated worktree
-- Creates PR with proof progress
-
-### Seeker
-- Monitors candidate pool depth (triggers when < 5 available)
-- Selects problems using knowledge score + tractability ranking
-- Initializes research workspaces for new problems
-- Runs on 15-minute cycle
-- Single instance (max 1 agent)
-
-### Deployer
-- Merges approved PRs (`loom:pr` label)
-- Syncs data and deploys to Cloudflare
-- Runs on 30-minute cycle
-
-## Layer Architecture
-
-| Layer | Role | Purpose |
-|-------|------|---------|
-| Layer 2 | **Lean Daemon** (`/lean`) | Spawns workers, manages pools, monitors progress |
-| Layer 1 | **Workers** (`/lean-erdos`, `/aristotle`, `/lean-research`, `/lean-scout`, `/lean-seeker`, `/lean-deploy`) | Execute mathematical work |
-
-Use `/lean-erdos`, `/aristotle`, `/lean-research`, `/lean-scout`, `/lean-seeker`, or `/lean-deploy` for single-agent work.
-Use `/lean` to run the continuous orchestrator that manages the full team.
-
-## Integration with Loom
-
-The Lean Daemon coexists with the Loom Daemon:
-- `/loom` orchestrates development work (Builder, Judge, Curator)
-- `/lean` orchestrates mathematical work (Erdős, Aristotle, Researcher, Seeker, Deployer)
-
-They share:
-- Worktree infrastructure (`.loom/worktrees/`)
-- PR workflow (PRs get `loom:review-requested` for Judge review)
-- GitHub coordination (labels, issues)
-
-## Example Session
+### `spawn <type>` → Spawn one agent
 
 ```bash
-# Start the mathematical team
-/lean start --erdos 2 --aristotle 1 --researcher 1 --seeker 1 --deployer 1
-
-# Check status periodically
-/lean status
-
-# Scale up Erdős enhancers if many stubs available
-/lean scale erdos 4
-
-# Add another researcher
-/lean spawn researcher
-
-# Graceful shutdown when done
-/lean stop
+./scripts/lean/launch.sh spawn <type>
 ```
+
+Or for a one-shot Claude subagent (independent of the daemon pool), use the Agent tool with `isolation: "worktree"`.
+
+### `scale <type> <N>` → Scale pool
+
+```bash
+./scripts/lean/launch.sh scale <type> <N>
+```
+
+### `health` → Health check
+
+```bash
+./scripts/lean/launch.sh health
+```
+
+### `wake [type]` → Wake sleeping agent
+
+```bash
+./scripts/lean/launch.sh wake [type]
+```
+
+## Account Pinning
+
+Check/change which OAuth account agents use:
+```bash
+./scripts/agents/pin-account.sh status    # Show current pin
+./scripts/agents/pin-account.sh pin <name> # Pin to account (partial match OK)
+./scripts/agents/pin-account.sh unpin      # Resume load balancing
+```
+
+## Quick Reference
+
+| User says | You do |
+|-----------|--------|
+| `/lean` | Start shell daemon in tmux with defaults |
+| `/lean start --researcher 3` | Start shell daemon with custom pool |
+| `/lean status` | Run `launch.sh status` + `launch.sh health` |
+| `/lean stop` | Run `launch.sh stop --force` |
+| `/lean spawn researcher` | Run `launch.sh spawn researcher` |
+| `/lean scale enricher 4` | Run `launch.sh scale enricher 4` |
+
+## What NOT to do
+
+- Don't implement a continuous monitoring loop inside Claude Code's conversation
+- Don't spawn multiple background Agent tool subagents and manually cycle them
+- Don't reinvent health checks, respawning, or token rotation — `launch.sh` handles all of it
 
 ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## Summary
- Rewrites `/lean` skill from a "be the daemon" prompt to a dispatcher
- Routes all commands to `./scripts/lean/launch.sh` which handles continuous monitoring, respawning, health checks, and token rotation autonomously
- Explicitly warns against building a loop out of Claude Code subagents
- Documents account pinning via `pin-account.sh`

## Why
The previous `/lean` skill told Claude to spawn Agent tool subagents and manually cycle them. This required manual intervention between cycles, suffered from OAuth token expiration, and reinvented what `launch.sh daemon` already does autonomously.

## Test plan
- [ ] `/lean` starts daemon via tmux
- [ ] `/lean status` runs `launch.sh health` + `launch.sh status`
- [ ] `/lean stop` runs `launch.sh stop --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)