### PR TITLE
Fix sorry count mismatches in 9 gallery proofs

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -72,7 +72,7 @@
     "dateAdded": "2026-02-25",
     "axiomCount": 1,
     "lineCount": 390,
-    "assumptions": "1 axiom declaration (buffon_noodle_smooth_eq), 5 sorries remaining. See the Lean source for details.",
+    "assumptions": "1 axiom declaration (buffon_noodle_smooth_eq), 0 sorries. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Fixed 9 gallery proofs where meta.json claimed nonzero sorry counts but Lean source has 0 actual sorries
- Updated status from `formalized` to `verified` for 5 proofs that are now fully sorry-free and axiom-free
- Updated assumptions text to reflect correct sorry counts

## Proofs Fixed

| Proof | Sorries | Status Change |
|-------|---------|---------------|
| erdos-1132 | 1 → 0 | (stays axiomatized, 5 axioms) |
| erdos-951 | 1 → 0 | (stays axiomatized, 7 axioms) |
| erdos-929 | 1 → 0 | (stays axiomatized, 2 axioms) |
| erdos-1006-oq-02-oq-03 | 1 → 0 | formalized → verified |
| derangements-oq-02 | 1 → 0 | formalized → verified |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | 1 → 0 | formalized → verified |
| ballot-problem-oq-01-oq-01 | 2 → 0 | formalized → verified |
| buffons-needle-oq-01-oq-01 | 5 → 0 | (stays axiomatized, 1 axiom) |
| schauder-fixed-point-oq-01 | 3 → 0 | formalized → verified |

## Evidence
Each Lean file was verified to contain 0 actual `sorry` tactics. Previous sorry counts reflected comments/docstrings mentioning "sorry" or stale metadata from earlier versions.

## Test plan
- [ ] Verify `pnpm build` succeeds with updated meta.json
- [ ] Verify gallery pages render correctly for affected proofs

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)