### PR TITLE
Fix: schauder-fixed-point-oq-01 metadata (sorries 3→0, verified)

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -16,7 +16,7 @@
       "open-question"
     ],
     "badge": "verified",
-    "sorries": 3,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-03-06",
     "axiomCount": 0,
-    "assumptions": "0 axioms, 3 sorries remaining. See the Lean source for details.",
+    "assumptions": "0 axioms, 0 sorries. Fully machine-checked.",
     "proofRepoPath": "Proofs/SchauderFixedPointOQ01.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 315


### PR DESCRIPTION
## Fix

Update schauder-fixed-point-oq-01 meta.json to reflect the fully-proved Lean source.

## Evidence

**Before**: `sorries: 3`, `status: "formalized"`, assumptions text says "3 sorries remaining"
**After**: `sorries: 0`, `status: "verified"`, assumptions text says "Fully machine-checked"

The Lean file `Proofs/SchauderFixedPointOQ01.lean` contains 0 code sorries, 0 axioms, and 0 structure-encoded assumptions. All 315 lines are fully proved.

---
Automated fix by lean-mechanic agent.