### PR TITLE
Research: erdos-409 — prove one_iteration_infinite (4→3 axioms)

### DIFF
--- a/proofs/Proofs/Erdos409Problem.lean
+++ b/proofs/Proofs/Erdos409Problem.lean
@@ -265,7 +265,27 @@ theorem two_fixed_point : totientPlusOne 2 = 2 := by
 theorem four_to_three : totientPlusOne 4 = 3 := by
   native_decide
 
-/-- F(n) = 1 infinitely often: whenever φ(n) + 1 is prime,
-    which happens infinitely often. -/
-axiom one_iteration_infinite :
-  {n : ℕ | n > 1 ∧ (totientPlusOne n).Prime}.Infinite
+/-- F(n) = 1 infinitely often: the set {n > 1 | φ(n)+1 prime} is infinite.
+    Proof: for every odd prime p, φ(2p) = φ(2)·φ(p) = 1·(p−1), so
+    φ(2p)+1 = p is prime. Since odd primes are infinite, so is this set. -/
+theorem one_iteration_infinite :
+    {n : ℕ | n > 1 ∧ (totientPlusOne n).Prime}.Infinite := by
+  -- The set of odd primes {p prime | p ≠ 2} is infinite
+  have h_odd_inf : (setOf Nat.Prime \ {2}).Infinite :=
+    Nat.infinite_setOf_prime.diff (Set.finite_singleton 2)
+  -- Map odd primes to our target set via p ↦ 2p (injective on ℕ)
+  apply Set.Infinite.mono _
+    (Set.Infinite.image (2 * ·) h_odd_inf (fun a _ b _ h => by omega))
+  -- Show {2p | p odd prime} ⊆ {n > 1 | (totientPlusOne n).Prime}
+  rintro n ⟨p, hp_mem, rfl⟩
+  have hp : p.Prime := (Set.mem_diff _).mp hp_mem |>.1
+  have hp2 : p ≠ 2 := fun h =>
+    (Set.mem_diff _).mp hp_mem |>.2 (Set.mem_singleton_iff.mpr h)
+  refine ⟨by omega, ?_⟩
+  -- Key computation: totientPlusOne (2*p) = p
+  suffices h : totientPlusOne (2 * p) = p from h ▸ hp
+  unfold totientPlusOne
+  have hcop : Nat.Coprime 2 p :=
+    Nat.coprime_two_left.mpr (hp.odd_of_ne_two hp2)
+  rw [Nat.totient_mul hcop, Nat.totient_prime Nat.prime_two, Nat.totient_prime hp]
+  have := hp.two_le; omega

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -21,10 +21,11 @@
     "erdosNumber": 409,
     "erdosUrl": "https://erdosproblems.com/409",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "assumptions": "4 axiom declarations: erdos_409_upper_bound (F(n) = o(n) bound, open), erdos_409_same_prime (infinite basin existence, open), erdos_409_density (basin natural density, open), one_iteration_infinite (infinitely many F=1). Proved (11 theorems): iterate_decreasing, iteration_terminates (strong induction), prime_zero_iterations (sSup reasoning on {0}), one_iteration_criterion (sSup on {0,1}, requires ¬n.Prime), sigma_growing (Finset.divisors subset bound), totient_plus_one_odd, totientIterate_zero, totientIterate_one, two_fixed_point, four_to_three, sigma_variant_question.",
-    "lineCount": 271,
-    "mathlib_version": "4.26.0"
+    "axiomCount": 3,
+    "assumptions": "3 axiom declarations: erdos_409_upper_bound (F(n) = o(n) bound, open), erdos_409_same_prime (infinite basin existence, open), erdos_409_density (basin natural density, open). All three are genuinely open parts of Erdos 409. Proved (12 theorems): iterate_decreasing, iteration_terminates (strong induction), prime_zero_iterations, one_iteration_criterion, one_iteration_infinite (via odd primes: for p odd prime, phi(2p)+1=p), sigma_growing, totient_plus_one_odd, totientIterate_zero, totientIterate_one, two_fixed_point, four_to_three, sigma_variant_question.",
+    "lineCount": 291,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12
   },
   "overview": {
     "historicalContext": "This problem originates with Finucane and was popularized by Erdos and Graham in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p. 81). The map $T(n) = \\varphi(n) + 1$ defines a discrete dynamical system on the positive integers: since $\\varphi(n) < n - 1$ for composite $n > 1$, each application strictly decreases the value until a prime fixed point is reached ($T(p) = p$ for primes $p$). The iteration count $F(n) = \\min\\{k \\geq 0 : T^k(n) \\text{ is prime}\\}$ appears as OEIS A039651. Cambie noted that $F(n) = o(n)$ is trivial but the true growth rate remains unknown --- heuristically $F(n) = O(\\log n)$ since $\\varphi(n)/n$ has mean value $6/\\pi^2 \\approx 0.608$, suggesting each step reduces $n$ by a constant factor. Guy discusses the problem in UPINT (B41). The companion problem replacing $\\varphi$ by $\\sigma$ (sum of divisors) yields $n \\mapsto \\sigma(n) - 1$, which is non-decreasing for composites, making termination at a prime an entirely separate open question related to aliquot sequences and the Catalan--Dickson conjecture.",
@@ -112,8 +113,8 @@
       "id": "small-cases",
       "title": "Small Cases and Fixed Points",
       "startLine": 191,
-      "endLine": 205,
-      "summary": "Concrete computations: $T(2) = 2$ (fixed point, proved by $\\texttt{simp}$), $T(4) = 3$ (one-step example), and $F(n) = 1$ infinitely often since $\\{n > 1 : \\varphi(n) + 1 \\text{ is prime}\\}$ is infinite.",
+      "endLine": 291,
+      "summary": "Concrete computations: $T(2) = 2$ (fixed point), $T(4) = 3$ (one-step example), and \\textbf{\\texttt{one\\_iteration\\_infinite}}: $F(n) = 1$ infinitely often --- proved by showing that for every odd prime $p$, $\\varphi(2p) + 1 = p$ via Euler totient multiplicativity.",
       "mathContext": "Concrete computations: $T(2) = 2$ (fixed point, proved by $\\texttt{simp}$), $T(4) = 3$ (one-step example), and $F(n) = 1$ infinitely often since $\\{n > 1 : \\varphi(n) + 1 \\text{ is prime}\\}$ is infinite."
     }
   ],
@@ -136,26 +137,26 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 271,
-    "axiomCount": 4,
-    "theoremCount": 11,
+    "lineCount": 291,
+    "axiomCount": 3,
+    "theoremCount": 12,
     "definitionCount": 3
   },
   "crossReferences": [
     {
       "targetId": "erdos-412",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: dynamical-systems, iteration, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: dynamical-systems, iteration, number-theory"
     },
     {
       "targetId": "erdos-1059",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, primes"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, primes"
     },
     {
       "targetId": "erdos-1113",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, primes"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, primes"
     }
   ]
 }

--- a/src/data/research/problems/erdos-409.json
+++ b/src/data/research/problems/erdos-409.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-409",
-  "title": "Erdős #409",
+  "title": "Erd\u0151s #409",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
@@ -29,21 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION: Proved 3 more axioms (prime_zero_iterations via sSup={0}, one_iteration_criterion via sSup={0,1} with ¬Prime fix, sigma_growing via Finset.divisors subset). Axioms: 7→4. Total 8 axioms eliminated across all sessions (12→4). Remaining 4 are genuinely open.",
+    "progressSummary": "AXIOM ELIMINATION: Proved one_iteration_infinite (4->3 axioms). Key insight: for odd prime p, phi(2p)+1=p via totient multiplicativity. Remaining 3 axioms are genuinely open (F(n) upper bound, basin infinity, density).",
     "builtItems": [
       "Proved sigma_variant_question (was trivially True placeholder)",
       "Proved four_to_three via native_decide",
       "Fixed two_fixed_point proof (simp->native_decide)",
       "Fixed sigma_growing syntax (Finset pipeline operator)",
       "Proved prime_zero_iterations: set S={0} since iterate(p,0)=p is prime, csSup_singleton gives 0",
-      "Proved one_iteration_criterion: fixed bug (added ¬n.Prime), set S={0,1}, csSup_pair gives 1",
-      "Proved sigma_growing: {1,n}⊆divisors gives σ(n)≥1+n, hence σ(n)-1≥n via omega",
+      "Proved one_iteration_criterion: fixed bug (added \u00acn.Prime), set S={0,1}, csSup_pair gives 1",
+      "Proved sigma_growing: {1,n}\u2286divisors gives \u03c3(n)\u22651+n, hence \u03c3(n)-1\u2265n via omega",
       "Added helper lemmas totientIterate_zero, totientIterate_one",
       "Switched to import Mathlib for csSup_singleton/csSup_pair access",
       "Removed stale import Mathlib.Order.Filter.AtTopBot",
       "Proved iterate_decreasing via Finset reasoning (0 and minFac non-coprime)",
       "Proved iteration_terminates via strong induction on iterate_decreasing",
-      "Proved totient_plus_one_odd from Nat.totient_even + Even.add_one"
+      "Proved totient_plus_one_odd from Nat.totient_even + Even.add_one",
+      "theorem one_iteration_infinite: {n>1 | (phi(n)+1).Prime}.Infinite via odd primes image (Erdos409Problem.lean:271-291)"
     ],
     "insights": [
       "sigma_variant_question was a trivially True placeholder axiom",
@@ -57,16 +58,19 @@
       "Nat.minFac_prime + minFac_dvd key for composite characterization",
       "csSup_singleton and csSup_pair are the key lemmas for sSup-based stopping time proofs",
       "Set equality approach (show S = explicit set, then rewrite) is cleaner than upper/lower bound reasoning for sSup",
-      "one_iteration_criterion had a bug: claimed F(n)=1 for all n>1 with φ(n)+1 prime, but F(p)=0 for primes. Fixed by adding ¬n.Prime hypothesis",
-      "sigma_growing holds for all n>1 (not just composites) since σ(n)≥1+n whenever 1≠n are both divisors"
+      "one_iteration_criterion had a bug: claimed F(n)=1 for all n>1 with \u03c6(n)+1 prime, but F(p)=0 for primes. Fixed by adding \u00acn.Prime hypothesis",
+      "sigma_growing holds for all n>1 (not just composites) since \u03c3(n)\u22651+n whenever 1\u2260n are both divisors",
+      "one_iteration_infinite is PROVABLE (not open): for odd prime p, phi(2p)=phi(2)*phi(p)=1*(p-1)=p-1, so phi(2p)+1=p is prime",
+      "Key Mathlib API: Nat.coprime_two_left.mpr, Nat.Prime.odd_of_ne_two, Nat.totient_mul, Nat.totient_prime, Set.Infinite.image",
+      "Remaining 3 axioms are all genuinely open parts of Erdos 409 (upper bound, basin infinity, density)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "All eliminable axioms have been proved. Remaining 4 axioms are genuinely open conjectures or deep results",
-      "one_iteration_infinite could potentially be proved if Mathlib gains Dirichlet's theorem on primes in arithmetic progressions applied to φ preimages",
+      "one_iteration_infinite could potentially be proved if Mathlib gains Dirichlet's theorem on primes in arithmetic progressions applied to \u03c6 preimages",
       "erdos_409_upper_bound is the core open question - any sub-linear bound better than o(n) would be significant"
     ],
-    "markdown": "# Erdős #409 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nHow many iterations of $n\\mapsto \\phi(n)+1$ are needed before a prime is reached? Can infinitely many $n$ reach the same prime? What is the density of $n$ which reach any fixed prime?\n\n\n\nA problem of Finucane. One can also ask similar questions about $n\\mapsto \\sigma(n)-1$: do iterates of this always reach a prime? If so, how soon? (It is easily seen that iterates of this cannot reach the same prime infinitely often, since they are non-decreasing.)\n\nThis problem is somewhat ambiguously phrased. Let $F(n)$ count the number of iterations of $n\\mapsto \\phi(n)+1$ before reaching a prime. The number of iterations required is A039651 in the OEIS.\n\nCambie notes in the comments that $F(n)=o(n)$ is trivial, and $F(n)=1$ infinitely often. Presumably the intended question is to find 'good' upper bounds for $F(n)$.\n\nThis is discussed in problem B41 of Guy's collection \\cite{Gu04}.\n\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #408\n- Problem #410\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erd\u0151s #409 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nHow many iterations of $n\\mapsto \\phi(n)+1$ are needed before a prime is reached? Can infinitely many $n$ reach the same prime? What is the density of $n$ which reach any fixed prime?\n\n\n\nA problem of Finucane. One can also ask similar questions about $n\\mapsto \\sigma(n)-1$: do iterates of this always reach a prime? If so, how soon? (It is easily seen that iterates of this cannot reach the same prime infinitely often, since they are non-decreasing.)\n\nThis problem is somewhat ambiguously phrased. Let $F(n)$ count the number of iterations of $n\\mapsto \\phi(n)+1$ before reaching a prime. The number of iterations required is A039651 in the OEIS.\n\nCambie notes in the comments that $F(n)=o(n)$ is trivial, and $F(n)=1$ infinitely often. Presumably the intended question is to find 'good' upper bounds for $F(n)$.\n\nThis is discussed in problem B41 of Guy's collection \\cite{Gu04}.\n\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #408\n- Problem #410\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- **Proved** `one_iteration_infinite`: the set `{n > 1 | (φ(n)+1).Prime}` is infinite
- **Axiom count**: 4 → 3 (remaining 3 are genuinely open parts of Erdős 409)

## Proof Strategy
For every odd prime p, φ(2p) = φ(2)·φ(p) = 1·(p−1) = p−1, so φ(2p)+1 = p is prime. The image of the infinite set of odd primes under p ↦ 2p gives an infinite subset of the target set.

Key Mathlib lemmas: `Nat.totient_mul`, `Nat.coprime_two_left`, `Nat.Prime.odd_of_ne_two`, `Set.Infinite.image`, `Set.Infinite.mono`.

## Files Modified
- `proofs/Proofs/Erdos409Problem.lean` — axiom → theorem (lines 268-291)
- `src/data/proofs/erdos-409/meta.json` — axiomCount, theoremCount, lineCount
- `src/data/research/problems/erdos-409.json` — knowledge update

## Status
**Outcome**: progress (axiom elimination)
**Remaining**: 3 axioms (all genuinely open: F(n) upper bound, basin infinity, density)

🤖 Generated by researcher-1