### PR TITLE
Research: erdos-1000-wip-01 — complement formula and structural bounds

### DIFF
--- a/proofs/Proofs/Erdos1000Problem.lean
+++ b/proofs/Proofs/Erdos1000Problem.lean
@@ -400,6 +400,89 @@ theorem phiA_ge_totient' (A : IncreasingSeq) (k : ℕ) :
   exact ⟨⟨dvd_refl _, (A.pos k).ne'⟩,
     fun j hj => Nat.ne_of_gt (A.strictMono (by omega))⟩
 
+/- ## Part IV-D: Complement Formula and Structural Bounds -/
+
+/-- **Complement Formula**: φ_A(k) + Σ_{used} φ(e) = n_k.
+    Splits the identity Σ_{e|n} φ(e) = n into "unused" part (= φ_A(k))
+    and "used" part (divisors appearing as earlier sequence terms).
+    Dual view of phiA_decomposition: instead of summing over unused divisors,
+    we see φ_A as the deficit from total after removing used divisors. -/
+theorem phiA_add_used (A : IncreasingSeq) (k : ℕ) :
+    phiA A k + ((A.seq k).divisors.filter
+      (fun e => ¬∀ j : ℕ, j < k → e ≠ A.seq j)).sum Nat.totient = A.seq k := by
+  rw [phiA_decomposition]
+  have h := Finset.sum_filter_add_sum_filter_not
+    (A.seq k).divisors (fun e => ∀ j : ℕ, j < k → e ≠ A.seq j) Nat.totient
+  linarith [Nat.sum_totient (A.seq k)]
+
+/-- The used-divisor φ-sum ≤ n_k − φ(n_k), since n_k itself is always unused
+    (being strictly greater than all previous terms) and contributes φ(n_k). -/
+theorem used_sum_le (A : IncreasingSeq) (k : ℕ) :
+    ((A.seq k).divisors.filter
+      (fun e => ¬∀ j : ℕ, j < k → e ≠ A.seq j)).sum Nat.totient
+    ≤ A.seq k - Nat.totient (A.seq k) := by
+  have h_add := phiA_add_used A k
+  have h_ge := phiA_ge_totient A k
+  omega
+
+/-- At most k divisors of n_k are "used" at step k: each used divisor
+    equals A.seq j for some j < k, so the used set injects into {0,...,k-1}. -/
+theorem used_card_le (A : IncreasingSeq) (k : ℕ) :
+    ((A.seq k).divisors.filter
+      (fun e => ¬∀ j : ℕ, j < k → e ≠ A.seq j)).card ≤ k := by
+  calc ((A.seq k).divisors.filter
+        (fun e => ¬∀ j : ℕ, j < k → e ≠ A.seq j)).card
+      ≤ ((range k).image A.seq).card := by
+        apply Finset.card_le_card
+        intro e he
+        rw [mem_filter] at he
+        rw [mem_image]
+        have ⟨_, hused⟩ := he
+        push_neg at hused
+        obtain ⟨j, hj, heq⟩ := hused
+        exact ⟨j, mem_range.mpr hj, heq.symm⟩
+    _ ≤ (range k).card := Finset.card_image_le
+    _ = k := card_range k
+
+/-- φ_A(k) ≥ 1 for all k, since n_k is always unused and φ(n_k) ≥ 1. -/
+theorem phiA_pos (A : IncreasingSeq) (k : ℕ) : 0 < phiA A k := by
+  calc 0 < Nat.totient (A.seq k) := Nat.totient_pos.mpr (A.pos k)
+    _ ≤ phiA A k := phiA_ge_totient A k
+
+/-- The density ratio is strictly positive for all k. -/
+theorem densityRatio_pos (A : IncreasingSeq) (k : ℕ) : 0 < densityRatio A k := by
+  unfold densityRatio
+  exact div_pos (by exact_mod_cast phiA_pos A k) (by exact_mod_cast A.pos k)
+
+/-- **Density Ratio Complement**: ρ_A(k) = 1 − (used φ-sum)/n_k.
+    For ρ_A(k) to approach 0, the used divisors must capture almost all
+    of n_k's divisor-totient sum — a severe structural constraint. -/
+theorem densityRatio_complement (A : IncreasingSeq) (k : ℕ) :
+    densityRatio A k = 1 - (((A.seq k).divisors.filter
+      (fun e => ¬∀ j : ℕ, j < k → e ≠ A.seq j)).sum Nat.totient : ℝ) / (A.seq k : ℝ) := by
+  unfold densityRatio
+  set n := A.seq k
+  set used := (n.divisors.filter (fun e => ¬∀ j : ℕ, j < k → e ≠ A.seq j)).sum Nat.totient
+  have hpos : (0 : ℝ) < ↑n := Nat.cast_pos.mpr (A.pos k)
+  have hR : (↑(phiA A k) : ℝ) + ↑used = ↑n := by exact_mod_cast phiA_add_used A k
+  have key : (↑(phiA A k) : ℝ) / ↑n + ↑used / ↑n = 1 := by
+    rw [div_add_div_same, hR, div_self hpos.ne']
+  linarith
+
+/-- When n_k is prime, ρ_A(k) ≥ 1/2. A prime n_k has only divisors {1, n_k},
+    and n_k is always unused, so at most φ(1) = 1 is lost to used divisors. -/
+theorem densityRatio_ge_of_prime (A : IncreasingSeq) (k : ℕ)
+    (hp : Nat.Prime (A.seq k)) : 1 / 2 ≤ densityRatio A k := by
+  have h2 : 2 ≤ A.seq k := hp.two_le
+  calc (1 : ℝ) / 2
+      ≤ (↑(A.seq k) - 1) / ↑(A.seq k) := by
+        rw [div_le_div_iff (by norm_num : (0 : ℝ) < 2)
+            (Nat.cast_pos.mpr (A.pos k))]
+        nlinarith [show (2 : ℝ) ≤ ↑(A.seq k) from by exact_mod_cast h2]
+    _ = (↑(Nat.totient (A.seq k)) : ℝ) / ↑(A.seq k) := by
+        congr 1; rw [Nat.totient_prime hp, Nat.cast_sub (by omega)]
+    _ ≤ densityRatio A k := densityRatio_ge_totient_ratio A k
+
 /- ## Part V: Main Predicates -/
 
 /-- A sequence has vanishing Cesàro average if C_A(N) → 0. -/

--- a/research/problems/erdos-1000-wip-01/knowledge.md
+++ b/research/problems/erdos-1000-wip-01/knowledge.md
@@ -5,7 +5,7 @@ Complete Erdős #1000: Generalized Totients and Diophantine Approximation.
 The existing formalization has 4 axioms (erdos_no_zero_limit, erdos_dichotomy, cassels_liminf_zero, haight_resolution) and 0 sorries. Goal: prove one or more axioms.
 
 ## Summary
-Proved 2 new structural lemmas that establish the fundamental lower bound connecting generalized totients to Euler's totient function. Fixed Mathlib API migration issues.
+Session 1 proved structural lower bounds. Session 2 proved the complement formula and 6 more infrastructure theorems, establishing the framework for proving erdos_no_zero_limit via a double-counting argument.
 
 ## Session 2026-03-25 (Session 1) - Structural Lower Bound
 
@@ -17,32 +17,42 @@ Proved 2 new structural lemmas that establish the fundamental lower bound connec
   - Key insight: coprime elements always pass the phiA filter
   - If gcd(m, n_k) = 1, then reducedDenom m n_k = n_k > n_j for all j < k
   - Proof: subset argument — (range n).filter(Coprime n) ⊆ (Icc 1 n).filter(phiA_cond)
-  - k=0 case: phiA_zero gives phiA = n₀ ≥ totient(n₀)
-  - k≥1 case: n_k ≥ 2, so the subset injection works
 - Proved `densityRatio_ge_totient_ratio`: ρ_A(k) ≥ φ(n_k)/n_k
-  - Direct corollary of phiA_ge_totient via div_le_div_of_nonneg_right
-- Fixed Mathlib API migration issues in existing proofs:
-  - `∑ k in range N` → `∑ k ∈ range N` (3 instances)
-  - `strictMono` proof: `by omega` → `Nat.add_lt_add_right`
-  - Constructor syntax: restructured `⟨by ..., by ...⟩` to `refine ⟨?_, ...⟩`
-  - `simp at hg; omega` → `simp at hg` (simp now closes goal)
-  - `push_cast; linarith` → explicit cast + linarith
-  - `le_div_iff₀` rewrite → explicit mul_div_cancel approach
+- Fixed Mathlib API migration issues (∑ in → ∈, omega, division lemmas)
 
 ### Key Findings
-- The lower bound φ_A(k) ≥ φ(n_k) is necessary but NOT sufficient for erdos_no_zero_limit
+- Lower bound φ_A(k) ≥ φ(n_k) is NOT sufficient for erdos_no_zero_limit
   - φ(n_k)/n_k CAN go to 0 (e.g., primorial sequence)
-  - Erdős' proof must use deeper structural arguments about the counting
-- The Mathlib API has diverged from when this file was written (v4.26.0)
-  - `∑ ... in` syntax replaced by `∑ ... ∈`
-  - Division lemma naming changed
-  - omega behavior with semiimplicit binders changed
+  - Need deeper structural argument
+
+## Session 2026-03-26 (Session 2) - Complement Formula
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+- Proved `phiA_add_used`: φ_A(k) + Σ_{used e|n_k} φ(e) = n_k (complement formula)
+  - Uses Finset.sum_filter_add_sum_filter_not + Nat.sum_totient
+- Proved `used_sum_le`: used φ-sum ≤ n_k - φ(n_k)
+  - n_k is always unused; from phiA_add_used + phiA_ge_totient
+- Proved `used_card_le`: at most k divisors are used
+  - Each used divisor maps injectively to j < k via A.seq
+- Proved `phiA_pos`: φ_A(k) ≥ 1
+- Proved `densityRatio_pos`: ρ_A(k) > 0
+- Proved `densityRatio_complement`: ρ_A(k) = 1 - used/n_k in ℝ
+- Proved `densityRatio_ge_of_prime`: ρ_A(k) ≥ 1/2 when n_k is prime
+
+### Key Findings
+- Complement formula reframes erdos_no_zero_limit: for ρ → 0, used divisors must capture almost ALL of n_k's φ-sum. At most k divisors can do this, and n_k is always excluded.
+- **erdos_no_zero_limit proof approach**: Double-count Σ_k (1-ρ_A(k)). Switch sum order: Σ_j φ(n_j) · Σ_{k>j: n_j|n_k} 1/n_k. Inner sum = reciprocals of multiples of n_j in the sequence. Bound by harmonic sum → contradiction.
+- Blocked on: formalizing the double-counting + real-valued sum bounds
 
 ### Files Modified
-- `proofs/Proofs/Erdos1000Problem.lean` — 2 new theorems + migration fixes (304→370 lines)
-- `src/data/proofs/erdos-1000/meta.json` — updated counts and sections
+- `proofs/Proofs/Erdos1000Problem.lean` — 7 new theorems (370→607 lines)
+- `src/data/proofs/erdos-1000/meta.json` — updated
+- `src/data/research/problems/erdos-1000-wip-01.json` — updated
 
 ### Next Steps
-- Investigate `cassels_liminf_zero`: simplest axiom to prove? Needs explicit sequence construction
-- Investigate `erdos_no_zero_limit`: needs understanding of WHY ρ_A can't converge to 0 despite φ(n_k)/n_k → 0. Likely needs structural argument about the excluded denominators
-- The lower bound enables future work: any proof of `erdos_no_zero_limit` will use `phiA_ge_totient` as a foundation
+- Formalize the double-counting argument for erdos_no_zero_limit
+- Alternative: prove for special cases first (lacunary, prime-rich sequences)
+- cassels_liminf_zero requires continued fraction construction (longer-term)

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -22,8 +22,8 @@
     "erdosUrl": "https://erdosproblems.com/1000",
     "erdosProblemStatus": "solved",
     "axiomCount": 4,
-    "lineCount": 370,
-    "assumptions": "Four deep axioms: erdos_no_zero_limit (φ_A(k)/n_k cannot converge to 0), erdos_dichotomy (liminf=0 implies limsup=1), cassels_liminf_zero (liminf of Cesàro average can be 0), haight_resolution (vanishing Cesàro average exists). New structural lemmas: phiA_ge_totient (φ_A(k) ≥ φ(n_k) for any sequence) and densityRatio_ge_totient_ratio (ρ_A(k) ≥ φ(n_k)/n_k).",
+    "lineCount": 607,
+    "assumptions": "Four deep axioms: erdos_no_zero_limit (φ_A(k)/n_k cannot converge to 0), erdos_dichotomy (liminf=0 implies limsup=1), cassels_liminf_zero (liminf of Cesàro average can be 0), haight_resolution (vanishing Cesàro average exists). Infrastructure: complement formula (phiA_add_used), used-divisor bounds (used_sum_le, used_card_le), positivity (phiA_pos, densityRatio_pos), complement representation (densityRatio_complement), prime lower bound (densityRatio_ge_of_prime).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -95,42 +95,50 @@
       "mathContext": "For any $A$ and $k$: if $\\gcd(m, n_k) = 1$ then the reduced denominator is $n_k / 1 = n_k > n_j$ for all $j < k$. So the set $\\{m \\leq n_k : \\gcd(m, n_k) = 1\\}$ (of size $\\varphi(n_k)$) is a subset of the $\\varphi_A(k)$ filter. This lower bound is the foundation for Erdős' no-zero-limit theorem."
     },
     {
+      "id": "complement-formula",
+      "title": "Part IV-D: Complement Formula and Structural Bounds",
+      "startLine": 403,
+      "endLine": 486,
+      "summary": "Seven new infrastructure theorems: `phiA_add_used` (φ_A(k) + used_sum = n_k, complement of the decomposition), `used_sum_le` (used φ-sum ≤ n_k − φ(n_k)), `used_card_le` (at most k divisors are used), `phiA_pos` (φ_A(k) ≥ 1), `densityRatio_pos` (ρ_A(k) > 0), `densityRatio_complement` (ρ_A(k) = 1 − used/n_k in ℝ), and `densityRatio_ge_of_prime` (ρ_A(k) ≥ 1/2 when n_k is prime).",
+      "mathContext": "The complement formula $\\varphi_A(k) = n_k - \\sum_{e | n_k, e \\text{ used}} \\varphi(e)$ reveals the dual structure: for $\\rho_A(k) \\to 0$, the used divisors must capture almost all of $n_k$'s divisor-totient sum. The prime lower bound shows that whenever $n_k$ is prime, $\\rho_A(k) \\geq 1/2$, since primes have only the trivial divisor 1 available for 'use'."
+    },
+    {
       "id": "main-predicates",
       "title": "Part V: Main Predicates",
-      "startLine": 250,
-      "endLine": 258,
+      "startLine": 488,
+      "endLine": 496,
       "summary": "Defines `VanishingAverage A` ($C_A(N) \\to 0$) and `DensityToZero A` ($\\rho_A(k) \\to 0$) as filter-limit predicates.",
       "mathContext": "$\\text{VanishingAverage}(A) :\\Leftrightarrow \\lim_{N \\to \\infty} C_A(N) = 0$. $\\text{DensityToZero}(A) :\\Leftrightarrow \\lim_{k \\to \\infty} \\rho_A(k) = 0$."
     },
     {
       "id": "erdos-results",
       "title": "Part VI: Erdős' Results (1964)",
-      "startLine": 260,
-      "endLine": 272,
+      "startLine": 498,
+      "endLine": 510,
       "summary": "Two axioms: `erdos_no_zero_limit` ($\\rho_A(k) \\not\\to 0$ for any $A$, via Mertens' bound $\\varphi(n)/n \\geq c/\\log\\log n$) and `erdos_dichotomy` (if $\\liminf \\rho_A = 0$ then $\\limsup \\rho_A = 1$, via the Euler product for $\\varphi(n)/n$).",
       "mathContext": "Axiom 1: $\\neg \\text{DensityToZero}(A)$ for all $A$. Axiom 2: $\\liminf \\rho_A = 0 \\Rightarrow \\limsup \\rho_A = 1$. These establish that the density ratio must oscillate — it can visit near 0 but cannot stay there, and if it visits near 0 it must also visit near 1."
     },
     {
       "id": "cassels-result",
       "title": "Part VII: Cassels' Result (1950)",
-      "startLine": 274,
-      "endLine": 280,
+      "startLine": 512,
+      "endLine": 518,
       "summary": "Axiom `cassels_liminf_zero`: there exists $A$ with $\\liminf C_A(N) = 0$, constructed via continued fraction convergents. Historically the first result showing the average can approach 0.",
       "mathContext": "$\\exists A : \\text{IncreasingSeq},\\; \\forall \\varepsilon > 0,\\; \\exists^\\infty N,\\; C_A(N) < \\varepsilon$. Weaker than Haight's result (liminf = 0 vs lim = 0)."
     },
     {
       "id": "haight-resolution",
       "title": "Part VIII: Haight's Resolution",
-      "startLine": 282,
-      "endLine": 289,
+      "startLine": 520,
+      "endLine": 527,
       "summary": "Axiom `haight_resolution`: $\\exists A$ with $C_A(N) \\to 0$. Resolves Erdős' problem affirmatively. The construction uses rapidly growing highly composite numbers.",
       "mathContext": "$\\exists A : \\text{IncreasingSeq},\\; \\text{VanishingAverage}(A)$. The answer to Erdős' question is YES, contrary to his expectation."
     },
     {
       "id": "corollaries",
       "title": "Part IX: Corollaries",
-      "startLine": 291,
-      "endLine": 370,
+      "startLine": 529,
+      "endLine": 607,
       "summary": "Four proved theorems synthesizing the axioms: `vanishing_avg_visits_zero` (vanishing average implies $\\rho_A$ frequently visits near 0, via a split-sum argument), `haight_oscillation` (Haight's sequence oscillates between near 0 and near 1), `no_density_zero` (no sequence has $\\rho_A \\to 0$), and `pointwise_cesaro_gap` ($\\exists A$ with $C_A(N) \\to 0$ but $\\rho_A(k) \\not\\to 0$, a concrete separation between pointwise and Cesàro convergence).",
       "mathContext": "The key proved result `vanishing_avg_visits_zero` is a 40-line argument: assuming $\\rho_A(k) \\geq \\varepsilon$ eventually, the Cesàro sum is bounded below by $\\varepsilon(N - K)/N \\to \\varepsilon$, contradicting $C_A(N) \\to 0$. The corollaries combine this with the axioms via short compositions."
     }
@@ -194,9 +202,9 @@
       "Topology"
     ],
     "namespace": "Erdos1000",
-    "lineCount": 370,
+    "lineCount": 607,
     "axiomCount": 4,
-    "theoremCount": 14,
+    "theoremCount": 21,
     "definitionCount": 8
   }
 }

--- a/src/data/research/problems/erdos-1000-wip-01.json
+++ b/src/data/research/problems/erdos-1000-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1000-wip-01",
   "title": "Complete Erdős #1000: Generalized Totients and Diophantine Approximation (Work in Progress)",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -11,43 +11,65 @@
     "whyMatters": ["Connects totient theory to Cesàro summation", "Illustrates pointwise vs averaged convergence gap"]
   },
   "knownResults": {
-    "proven": ["phiA_ge_totient: φ_A(k) ≥ φ(n_k)", "densityRatio_ge_totient_ratio: ρ_A(k) ≥ φ(n_k)/n_k"],
+    "proven": [
+      "phiA_ge_totient: φ_A(k) ≥ φ(n_k)",
+      "densityRatio_ge_totient_ratio: ρ_A(k) ≥ φ(n_k)/n_k",
+      "phiA_add_used: φ_A(k) + used_sum = n_k (complement formula)",
+      "used_sum_le: used ≤ n_k - φ(n_k)",
+      "used_card_le: at most k used divisors",
+      "phiA_pos: φ_A(k) ≥ 1",
+      "densityRatio_pos: ρ_A(k) > 0",
+      "densityRatio_complement: ρ_A(k) = 1 - used/n_k",
+      "densityRatio_ge_of_prime: ρ ≥ 1/2 when n_k prime"
+    ],
     "open": ["erdos_no_zero_limit", "erdos_dichotomy", "cassels_liminf_zero", "haight_resolution"],
-    "goal": "Prove erdos_no_zero_limit or cassels_liminf_zero"
+    "goal": "Prove erdos_no_zero_limit — now within reach using complement formula + counting argument"
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-03-25T00:00:00Z",
-    "iteration": 1,
-    "focus": "Proved structural lower bound lemmas. Assessing feasibility of axiom proofs.",
-    "blockers": ["erdos_no_zero_limit requires deeper structural argument beyond phiA ≥ totient"],
-    "nextAction": "Investigate cassels_liminf_zero: explicit sequence construction via continued fractions",
+    "phase": "ACT",
+    "since": "2026-03-26T00:00:00Z",
+    "iteration": 2,
+    "focus": "Built complement formula infrastructure. erdos_no_zero_limit needs double-counting argument.",
+    "blockers": ["erdos_no_zero_limit requires Erdős' 1964 counting argument: bounding Σ_{k<N} used_sum(k)/n_k via order-switching and divisor density. Non-trivial to formalize."],
+    "nextAction": "Formalize the double-counting argument: switch summation order in Σ_k Σ_{j<k,n_j|n_k} φ(n_j)/n_k, bound via harmonic sum, derive contradiction",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved phiA_ge_totient and densityRatio_ge_totient_ratio. Fixed Mathlib migration. 4 axioms remain.",
+    "progressSummary": "PROGRESS: Session 2 built 7 new theorems — complement formula, used-divisor bounds, positivity, prime case. 4 axioms remain. erdos_no_zero_limit is closest to proof via complement formula + counting argument.",
     "builtItems": [
-      {"name": "phiA_ge_totient", "type": "theorem", "description": "φ_A(k) ≥ φ(n_k) for any increasing sequence — coprime elements always pass phiA filter"},
-      {"name": "densityRatio_ge_totient_ratio", "type": "theorem", "description": "ρ_A(k) ≥ φ(n_k)/n_k — real-valued lower bound on density ratio"},
-      {"name": "coprime_range_subset_phiA_filter", "type": "lemma", "description": "Coprime elements in range form subset of phiA filter set"}
+      {"name": "phiA_ge_totient", "type": "theorem", "description": "φ_A(k) ≥ φ(n_k) for any increasing sequence"},
+      {"name": "densityRatio_ge_totient_ratio", "type": "theorem", "description": "ρ_A(k) ≥ φ(n_k)/n_k"},
+      {"name": "coprime_range_subset_phiA_filter", "type": "lemma", "description": "Coprime elements form subset of phiA filter"},
+      {"name": "phiA_add_used", "type": "theorem", "description": "φ_A(k) + Σ_{used e|n_k} φ(e) = n_k — complement of decomposition"},
+      {"name": "used_sum_le", "type": "theorem", "description": "Used φ-sum ≤ n_k − φ(n_k), since n_k is always unused"},
+      {"name": "used_card_le", "type": "theorem", "description": "At most k divisors are used (injective map to range k)"},
+      {"name": "phiA_pos", "type": "theorem", "description": "φ_A(k) ≥ 1 for all k (from totient positivity)"},
+      {"name": "densityRatio_pos", "type": "theorem", "description": "ρ_A(k) > 0 for all k"},
+      {"name": "densityRatio_complement", "type": "theorem", "description": "ρ_A(k) = 1 − used_sum/n_k in ℝ"},
+      {"name": "densityRatio_ge_of_prime", "type": "theorem", "description": "ρ_A(k) ≥ 1/2 when n_k is prime"}
     ],
     "insights": [
       "phiA_ge_totient: coprime m has reducedDenom = n_k > n_j for j < k",
       "Lower bound alone insufficient for erdos_no_zero_limit since φ(n)/n → 0 along primorials",
-      "Erdős' proof needs structural argument about excluded-denominator interplay",
-      "Mathlib v4.26.0 API migration: ∑ in → ∈, omega/semiimplicit, division lemma changes"
+      "Complement formula ρ = 1 - used/n reframes the problem: for ρ → 0, used divisors must capture almost all φ-weight",
+      "erdos_no_zero_limit proof strategy: double-count Σ_k used_sum(k)/n_k by switching summation order, bound inner sum by n_{N-1}/n_j, get harmonic-type bound contradicting →1",
+      "When n_k is prime, only {1,n_k} are divisors; n_k is unused, so ρ ≥ (p-1)/p ≥ 1/2",
+      "At most k of n_k's divisors can be 'used' — each maps to a unique j < k via injectivity of A",
+      "Mathlib v4.26.0 API: sum_filter_add_sum_filter_not, Nat.totient_pos, Nat.totient_prime all available"
     ],
     "mathlibGaps": [
-      "No gaps: Nat.totient, Finset.card_le_card, gcd API all sufficient"
+      "No gaps: Nat.totient, Finset.sum_filter_add_sum_filter_not, card_image_le all sufficient",
+      "For erdos_no_zero_limit: may need Finset.sum_comm or order-switching for double sums"
     ],
     "nextSteps": [
-      "Investigate cassels_liminf_zero via explicit continued fraction construction",
-      "Study erdos_no_zero_limit strategy: why can't ρ_A converge to 0?",
-      "Consider erdos_dichotomy via Euler product techniques"
+      "Formalize erdos_no_zero_limit via complement formula + double-counting argument",
+      "Key intermediate: bound Σ_{j<N} φ(n_j) · |{k>j : n_j | n_k}| / n_k using harmonic sum",
+      "Alternative: prove for special cases first (lacunary sequences, sequences with infinitely many primes)",
+      "cassels_liminf_zero: still requires explicit continued fraction construction"
     ]
   },
   "tags": [
@@ -70,7 +92,7 @@
     "mathlib": ["Mathlib.Data.Nat.Totient"]
   },
   "started": "2026-03-24T00:48:59.900Z",
-  "lastUpdate": "2026-03-25T00:00:00Z",
+  "lastUpdate": "2026-03-26T00:00:00Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Prove 7 new infrastructure theorems for Erdős #1000 (generalized totients)
- Complement formula: φ_A(k) + Σ_{used} φ(e) = n_k
- Used-divisor bounds: at most k used, φ-sum ≤ n_k − φ(n_k)
- Positivity: φ_A(k) ≥ 1 and ρ_A(k) > 0 for all k
- Density ratio complement: ρ_A(k) = 1 − used_sum/n_k
- Prime lower bound: ρ_A(k) ≥ 1/2 when n_k is prime

## Progress
- **Session 2 of erdos-1000-wip-01** (ORIENT → ACT phase)
- 4 axioms remain unchanged; file grows from 370 → 607 lines, 14 → 21 theorems
- The complement formula establishes the key infrastructure for proving `erdos_no_zero_limit` via a double-counting argument

## Findings
- Complement formula reframes the problem: for ρ → 0, used divisors must capture almost all of n_k's divisor-totient sum
- erdos_no_zero_limit needs Erdős' 1964 counting argument (switching summation order over divisibility pairs) — deferred to next session

## Status
**Outcome**: progress
**Next Steps**: Formalize the double-counting argument for erdos_no_zero_limit

Generated by researcher-2