### PR TITLE
Research: general-quartic + pi-transcendental — prove 4 axioms (17→13)

### DIFF
--- a/proofs/Proofs/GeneralQuartic.lean
+++ b/proofs/Proofs/GeneralQuartic.lean
@@ -90,39 +90,45 @@ noncomputable def depressionCoeffs (a b c d : ℂ) : ℂ × ℂ × ℂ :=
   let r := d - a * c / 4 + a^2 * b / 16 - 3 * a^4 / 256
   (p, q, r)
 
-/-! ## Axiom Catalog
+/-! ## Proved Results and Remaining Axioms
 
-The following axioms capture proof gaps that require extensive algebraic computation or
-connections to other theorems (e.g., Fundamental Theorem of Algebra). These represent
-mathematically sound statements whose formal verification is deferred. -/
+The depressed quartic forward/backward transformations and the resolvent cubic existence
+have been fully proved. The remaining axioms capture Ferrari's factorization and the
+biquadratic special case, which require more intricate algebraic manipulation. -/
 
-/-- **Axiom: Depressed Quartic Forward**
-The substitution y = x - a/4 transforms the general quartic x^4 + ax^3 + bx^2 + cx + d = 0
+/-- **Depressed Quartic Forward** (formerly axiom, now proved)
+The substitution y = x + a/4 transforms the general quartic x^4 + ax^3 + bx^2 + cx + d = 0
 into the depressed form y^4 + py^2 + qy + r = 0. This direction shows that if x is a root
 of the original quartic, then y = x + a/4 is a root of the depressed quartic.
 
-This involves expanding (y - a/4)^4 + a(y - a/4)^3 + b(y - a/4)^2 + c(y - a/4) + d
-and verifying that the y^3 coefficient vanishes and collecting terms gives the claimed
-coefficients p, q, r. The computation is routine but lengthy. -/
-axiom depressed_quartic_forward (a b c d x : ℂ)
+The proof is by the polynomial identity: expanding (x + a/4)^4 + p(x + a/4)^2 + q(x + a/4) + r
+yields exactly x^4 + ax^3 + bx^2 + cx + d, so the result follows from h. -/
+theorem depressed_quartic_forward (a b c d x : ℂ)
     (h : x^4 + a * x^3 + b * x^2 + c * x + d = 0) :
     let shift := a / 4
     let y := x + shift
     let p := b - 3 * a^2 / 8
     let q := c - a * b / 2 + a^3 / 8
     let r := d - a * c / 4 + a^2 * b / 16 - 3 * a^4 / 256
-    y^4 + p * y^2 + q * y + r = 0
+    y^4 + p * y^2 + q * y + r = 0 := by
+  simp only []
+  linear_combination h
 
-/-- **Axiom: Depressed Quartic Backward**
+/-- **Depressed Quartic Backward** (formerly axiom, now proved)
 The inverse direction: if y is a root of the depressed quartic, then x = y - a/4
-is a root of the original quartic. This is the converse transformation. -/
-axiom depressed_quartic_backward (a b c d y : ℂ)
+is a root of the original quartic. This is the converse transformation.
+
+By the same polynomial identity: (y - a/4)^4 + a(y - a/4)^3 + b(y - a/4)^2 + c(y - a/4) + d
+equals y^4 + py^2 + qy + r, so the result follows from h. -/
+theorem depressed_quartic_backward (a b c d y : ℂ)
     (h : let p := b - 3 * a^2 / 8
          let q := c - a * b / 2 + a^3 / 8
          let r := d - a * c / 4 + a^2 * b / 16 - 3 * a^4 / 256
          y^4 + p * y^2 + q * y + r = 0) :
     let x := y - a / 4
-    x^4 + a * x^3 + b * x^2 + c * x + d = 0
+    x^4 + a * x^3 + b * x^2 + c * x + d = 0 := by
+  simp only [] at h ⊢
+  linear_combination h
 
 /-- **Axiom: Ferrari Factorization Forward**
 If y is a root of the depressed quartic and m is a root of the resolvent cubic,
@@ -145,11 +151,21 @@ axiom ferrari_factorization_backward (p q r m α β y : ℂ)
     (h : (y^2 + p/2 + m - α * y + β = 0) ∨ (y^2 + p/2 + m + α * y - β = 0)) :
     y^4 + p * y^2 + q * y + r = 0
 
-/-- **Axiom: Resolvent Cubic Has Root**
+/-- **Resolvent Cubic Has Root** (formerly axiom, now proved)
 By the Fundamental Theorem of Algebra, every polynomial of degree >= 1 over ℂ has a root.
-Since the resolvent cubic has degree 3, it has a root. -/
-axiom resolvent_cubic_has_root (p q r : ℂ) :
-    ∃ m : ℂ, (resolventCubic p q r).eval m = 0
+Since the resolvent cubic has degree 3 (leading coefficient 8 ≠ 0), it has a root. -/
+theorem resolvent_cubic_has_root (p q r : ℂ) :
+    ∃ m : ℂ, (resolventCubic p q r).eval m = 0 := by
+  -- The coefficient of X^3 is 8 ≠ 0
+  have hcoeff : (resolventCubic p q r).coeff 3 ≠ 0 := by
+    simp only [resolventCubic, Polynomial.coeff_add, Polynomial.coeff_C_mul,
+               Polynomial.coeff_X_pow, Polynomial.coeff_C, Polynomial.coeff_X]
+    norm_num
+  -- Therefore degree ≠ 0, and by FTA (ℂ is algebraically closed) there exists a root
+  suffices hdeg : (resolventCubic p q r).degree ≠ 0 from
+    IsAlgClosed.exists_root _ hdeg
+  intro h0
+  exact hcoeff (by rw [Polynomial.eq_C_of_degree_le_zero (le_of_eq h0)]; simp [Polynomial.coeff_C])
 
 /-- **Axiom: Quartic Has Four Roots**
 By the Fundamental Theorem of Algebra, a degree 4 polynomial over ℂ has exactly 4 roots

--- a/proofs/Proofs/PiTranscendental.lean
+++ b/proofs/Proofs/PiTranscendental.lean
@@ -186,11 +186,12 @@ theorem I_algebraic : IsAlgebraic ℤ Complex.I := by
 -- PART 6: Corollaries
 -- ============================================================
 
-/-- **Axiom: π is irrational**
+/-- **π is irrational** (formerly axiom, now proved from Mathlib)
 
-    Transcendental implies irrational: if π = p/q for integers p, q, then
-    π would be algebraic (root of q·X - p = 0), contradicting transcendence. -/
-axiom pi_irrational_axiom : Irrational Real.pi
+    Mathlib provides `irrational_pi` directly. This also follows from transcendence:
+    if π = p/q for integers p, q, then π would be algebraic (root of q·X - p = 0),
+    contradicting transcendence. -/
+theorem pi_irrational_axiom : Irrational Real.pi := irrational_pi
 
 /-- π is irrational (weaker than transcendental, but follows from it) -/
 theorem pi_irrational : Irrational Real.pi := pi_irrational_axiom

--- a/research/problems/general-quartic/knowledge.md
+++ b/research/problems/general-quartic/knowledge.md
@@ -1,0 +1,51 @@
+# General Quartic — Research Knowledge
+
+## Session 1 (2026-03-26, researcher-7)
+
+**Mode**: AXIOM HUNT
+**Prior**: 9 axioms, 6 theorems, 344 lines
+**After**: 6 axioms, 9 theorems, 360 lines
+
+### Axioms Eliminated (3)
+
+1. **`depressed_quartic_forward`** — Pure polynomial ring identity. The substitution y = x + a/4
+   transforms x⁴ + ax³ + bx² + cx + d into y⁴ + py² + qy + r. Proved via `linear_combination h`:
+   the expanded depression is identically equal to the original quartic.
+
+2. **`depressed_quartic_backward`** — Converse of above, same ring identity in reverse direction.
+   Also proved via `linear_combination h`.
+
+3. **`resolvent_cubic_has_root`** — By the Fundamental Theorem of Algebra (ℂ is algebraically closed),
+   any polynomial of degree ≥ 1 has a root. The resolvent cubic has leading coefficient 8 ≠ 0,
+   hence degree 3 ≥ 1. Proved via `IsAlgClosed.exists_root` + coefficient analysis showing
+   coeff 3 = 8 via `Polynomial.coeff_*` simp lemmas.
+
+### Remaining Axioms (6) — Analysis
+
+| Axiom | Difficulty | Notes |
+|-------|-----------|-------|
+| `ferrari_factorization_forward` | Hard | Requires showing quartic = product of two factors given resolvent condition. Non-trivial algebra with auxiliary hypotheses. |
+| `ferrari_factorization_backward` | Hard | Same factorization, reverse direction. Note: the file's resolvent cubic may use non-standard parameterization. |
+| `quartic_has_four_roots` | Medium | FTA gives ≤ 4 roots for degree 4. Exact factorization into 4 linear factors needs `Polynomial.roots` multiset API. |
+| `biquadratic_forward` | Medium | Involves `Complex.cpow` (square root). Need (cpow z (1/2))² = z. |
+| `biquadratic_backward` | Medium | Quadratic formula verification through `Complex.cpow`. |
+| `ferrari_roots_verify` | Hard | Substitution of explicit radical formulas back into quartic. Heavy `Complex.cpow` manipulation. |
+
+### Insight: Resolvent Cubic Parameterization
+
+The file's resolvent cubic `8m³ + 20pm² + (16p²-8r)m + (4p³-4pr-q²) = 0` is the SHIFTED
+version of the standard resolvent. Substituting `t = m + p/2` into the standard form
+`8t³ + 8pt² + 2p²t - 8rt - q² = 0` gives exactly the file's form.
+
+This means:
+- The file uses `m` where standard references use `m - p/2`
+- The factorization conditions (α² = 2m + p, β = q/(2α)) should be verified against this shifted form
+- There may be an inconsistency between the resolvent definition and the factorization axioms
+  (standard factorization with shifted resolvent needs α² = 2m, not α² = 2m + p)
+
+### Next Steps
+
+- Investigate whether Ferrari factorization axioms are mathematically consistent with the resolvent cubic definition
+- If consistent: prove `ferrari_factorization_backward` via product = quartic identity
+- If inconsistent: fix the resolvent cubic definition (change to standard form)
+- Consider proving `biquadratic_backward` via `Complex.cpow` properties

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -39,15 +39,15 @@
     ],
     "dateAdded": "2025-12-28",
     "wiedijkNumber": 46,
-    "axiomCount": 9,
-    "lineCount": 344,
+    "axiomCount": 6,
+    "lineCount": 360,
     "prerequisites": [
       "Complex numbers and polynomial evaluation",
       "Cubic equation solution (Cardano's formula)",
       "Quadratic formula for complex coefficients",
       "Completing the square and factorization techniques"
     ],
-    "assumptions": "9 axioms: depressed_quartic_forward, depressed_quartic_backward, ferrari_factorization_forward, and 6 more. See Lean source for complete statements.",
+    "assumptions": "6 axioms: ferrari_factorization_forward, ferrari_factorization_backward, quartic_has_four_roots, biquadratic_forward, biquadratic_backward, ferrari_roots_verify. 3 axioms proved: depressed_quartic_forward/backward (ring identity), resolvent_cubic_has_root (FTA).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -190,9 +190,9 @@
       "Complex"
     ],
     "namespace": "GeneralQuartic",
-    "lineCount": 344,
-    "axiomCount": 9,
-    "theoremCount": 6,
+    "lineCount": 360,
+    "axiomCount": 6,
+    "theoremCount": 9,
     "definitionCount": 5
   },
   "mainTheorems": [

--- a/src/data/proofs/pi-transcendental/meta.json
+++ b/src/data/proofs/pi-transcendental/meta.json
@@ -38,9 +38,9 @@
       "Connection to constructibility with ruler and compass"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 8,
-    "lineCount": 380,
-    "assumptions": "8 axioms: lindemann_theorem, pi_transcendental, pi_irrational_axiom, and 5 more. See Lean source for complete statements.",
+    "axiomCount": 7,
+    "lineCount": 381,
+    "assumptions": "7 axioms: lindemann_theorem, pi_transcendental, two_pi_transcendental_axiom, and 4 more. pi_irrational_axiom proved from Mathlib's irrational_pi.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -206,9 +206,9 @@
       "Polynomial"
     ],
     "namespace": null,
-    "lineCount": 380,
-    "axiomCount": 8,
-    "theoremCount": 11,
+    "lineCount": 381,
+    "axiomCount": 7,
+    "theoremCount": 12,
     "definitionCount": 0
   },
   "mainTheorems": [


### PR DESCRIPTION
## Summary
Two proof files improved via axiom elimination:

### GeneralQuartic.lean (9→6 axioms)
- Proved `depressed_quartic_forward` — ring identity via `linear_combination h`
- Proved `depressed_quartic_backward` — same ring identity, reverse direction
- Proved `resolvent_cubic_has_root` — FTA via `IsAlgClosed.exists_root` + coefficient analysis

### PiTranscendental.lean (8→7 axioms)
- Proved `pi_irrational_axiom` — directly from Mathlib's `irrational_pi`

## Stats
| File | Axioms Before | Axioms After | Theorems Added |
|------|:---:|:---:|:---:|
| GeneralQuartic | 9 | **6** | +3 |
| PiTranscendental | 8 | **7** | +1 |
| **Total** | **17** | **13** | **+4** |

## Findings
- Depressed quartic substitution is a pure polynomial identity — `linear_combination` suffices
- Resolvent cubic leading coefficient is 8 ≠ 0, so FTA applies
- Mathlib directly provides `irrational_pi`
- Documented potential inconsistency in resolvent cubic parameterization (see knowledge.md)

## Status
**Outcome**: progress (4 axioms proved across 2 files)

🤖 Generated by researcher-7