### PR TITLE
Research: erdos-1071 — geometric foundations (10 new theorems)

### DIFF
--- a/proofs/Proofs/Erdos1071Problem.lean
+++ b/proofs/Proofs/Erdos1071Problem.lean
@@ -125,6 +125,77 @@ theorem disjoint_implies_endpoint_disjoint (s t : UnitSegment) :
   exfalso
   exact Set.disjoint_iff.mp h ⟨hp.1, hp.2⟩
 
+/- Part 4b: Euclidean Distance Properties -/
+
+/-- Euclidean distance is symmetric -/
+theorem euclidDist_symm (p q : ℝ × ℝ) : euclidDist p q = euclidDist q p := by
+  unfold euclidDist; congr 1; ring
+
+/-- Euclidean distance is non-negative -/
+theorem euclidDist_nonneg (p q : ℝ × ℝ) : 0 ≤ euclidDist p q :=
+  Real.sqrt_nonneg _
+
+/-- Distance from a point to itself is 0 -/
+theorem euclidDist_self (p : ℝ × ℝ) : euclidDist p p = 0 := by
+  unfold euclidDist
+  have : (p.1 - p.1) ^ 2 + (p.2 - p.2) ^ 2 = 0 := by ring
+  rw [this, Real.sqrt_zero]
+
+/-- A unit segment's endpoints are distinct -/
+theorem UnitSegment.endpoints_ne (s : UnitSegment) : s.x1 ≠ s.x2 := by
+  intro h; have := s.unit_length; rw [h, euclidDist_self] at this; linarith
+
+/- Part 4c: Convexity of the Unit Square -/
+
+/-- The unit square [0,1]² is convex: convex combinations stay inside -/
+theorem unitSquare_convex {p q : ℝ × ℝ} (hp : InUnitSquare p) (hq : InUnitSquare q)
+    {t : ℝ} (h0 : 0 ≤ t) (h1 : t ≤ 1) :
+    InUnitSquare ((1 - t) * p.1 + t * q.1, (1 - t) * p.2 + t * q.2) := by
+  obtain ⟨hp1, hp2, hp3, hp4⟩ := hp
+  obtain ⟨hq1, hq2, hq3, hq4⟩ := hq
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> nlinarith
+
+/-- All points on a segment between two unit-square points are in [0,1]² -/
+theorem segment_in_square_all_points {p q : ℝ × ℝ}
+    (hp : InUnitSquare p) (hq : InUnitSquare q) :
+    ∀ r ∈ segmentSet p q, InUnitSquare r := by
+  intro r ⟨t, h0, h1, hrfl⟩; rw [hrfl]; exact unitSquare_convex hp hq h0 h1
+
+/-- SegmentInSquare implies all points on the segment are in the square -/
+theorem packing_segment_all_in_square (s : UnitSegment) (h : SegmentInSquare s) :
+    ∀ r ∈ segmentSet s.x1 s.x2, InUnitSquare r :=
+  segment_in_square_all_points h.1 h.2
+
+/- Part 4d: Concrete Constructions -/
+
+/-- The horizontal segment from (0, 1/2) to (1, 1/2) -/
+noncomputable def horizontalMidSegment : UnitSegment where
+  x1 := (0, 1/2)
+  x2 := (1, 1/2)
+  unit_length := by
+    unfold euclidDist
+    have : ((0 : ℝ) - 1) ^ 2 + ((1 : ℝ) / 2 - 1 / 2) ^ 2 = 1 := by ring
+    rw [this, Real.sqrt_one]
+
+/-- The horizontal mid-segment is in the unit square -/
+theorem horizontalMidSegment_in_square : SegmentInSquare horizontalMidSegment := by
+  dsimp [SegmentInSquare, InUnitSquare, horizontalMidSegment]
+  refine ⟨⟨?_, ?_, ?_, ?_⟩, ⟨?_, ?_, ?_, ?_⟩⟩ <;> norm_num
+
+/-- A singleton set is a valid packing -/
+theorem packing_singleton (s : UnitSegment) (h : SegmentInSquare s) :
+    IsPacking {s} := by
+  constructor
+  · intro t ht; rwa [Set.mem_singleton_iff.mp ht]
+  · intro a ha b hb hab
+    exact absurd ((Set.mem_singleton_iff.mp ha).symm.trans (Set.mem_singleton_iff.mp hb)) hab
+
+/-- There exists a non-empty packing (witness: horizontal mid-segment) -/
+theorem exists_nonempty_packing :
+    ∃ S : Set UnitSegment, IsPacking S ∧ S.Nonempty :=
+  ⟨{horizontalMidSegment}, packing_singleton _ horizontalMidSegment_in_square,
+   Set.singleton_nonempty _⟩
+
 /-
 # Part 5: Danzer's Result (SOLVED)
 -/

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -66,7 +66,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 174,
+    "lineCount": 245,
     "assumptions": "3 axioms: danzer_finite_maximal (solved result), ErdosProblem1071b (open), ErdosProblem1071_endpoint_variant (variant). AreDisjoint, disjoint_symm, EndpointDisjoint now defined/proved."
   },
   "overview": {
@@ -296,9 +296,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 174,
+    "lineCount": 245,
     "axiomCount": 3,
-    "theoremCount": 7,
-    "definitionCount": 14
+    "theoremCount": 17,
+    "definitionCount": 15
   }
 }

--- a/src/data/research/problems/erdos-1071.json
+++ b/src/data/research/problems/erdos-1071.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1071",
   "title": "Erdős #1071",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-15T14:38:41.571Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 3,
+    "focus": "Proved structural geometry lemmas. 3 deep axioms remain.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: 3 axioms eliminated (6→3), 7 new theorems proved (0→7), 0 sorries. Definitions strengthened to use ℝ² geometry.",
+    "progressSummary": "PROGRESS: Session 3 added 10 new theorems/defs. euclidDist properties, unit square convexity, concrete segment construction, singleton packing. 3 deep axioms remain.",
     "builtItems": [
       "euclidDist definition",
       "segmentSet definition (convex combination)",
@@ -38,7 +38,52 @@
       "disjoint_symm theorem (was axiom)",
       "left/right_endpoint_mem_segment lemmas",
       "packing_empty, packing_subset, finite_packing_countable theorems",
-      "disjoint_implies_endpoint_disjoint theorem"
+      "disjoint_implies_endpoint_disjoint theorem",
+      {
+        "name": "euclidDist_symm",
+        "type": "theorem",
+        "description": "Euclidean distance is symmetric"
+      },
+      {
+        "name": "euclidDist_nonneg",
+        "type": "theorem",
+        "description": "Euclidean distance is non-negative"
+      },
+      {
+        "name": "euclidDist_self",
+        "type": "theorem",
+        "description": "Distance to self = 0"
+      },
+      {
+        "name": "UnitSegment.endpoints_ne",
+        "type": "theorem",
+        "description": "Unit segment endpoints are distinct"
+      },
+      {
+        "name": "unitSquare_convex",
+        "type": "theorem",
+        "description": "Unit square is convex"
+      },
+      {
+        "name": "segment_in_square_all_points",
+        "type": "theorem",
+        "description": "All segment points in square"
+      },
+      {
+        "name": "horizontalMidSegment",
+        "type": "def",
+        "description": "Concrete unit segment (0,1/2)-(1,1/2)"
+      },
+      {
+        "name": "packing_singleton",
+        "type": "theorem",
+        "description": "Singleton set is a valid packing"
+      },
+      {
+        "name": "exists_nonempty_packing",
+        "type": "theorem",
+        "description": "Non-empty packing exists"
+      }
     ],
     "insights": [
       "Eliminated 3 axioms (AreDisjoint, disjoint_symm, EndpointDisjoint) → definitions/theorems",
@@ -47,13 +92,16 @@
       "EndpointDisjoint defined as intersection ⊆ endpoints",
       "disjoint_symm proved from Disjoint.symm",
       "disjoint_implies_endpoint_disjoint: fully disjoint ⇒ endpoint disjoint (vacuously)",
-      "Only deep axioms remain: Danzer result, open problem, variant"
+      "Only deep axioms remain: Danzer result, open problem, variant",
+      "Unit square convexity proved via nlinarith — all convex combos stay in [0,1]²",
+      "Concrete horizontalMidSegment witnesses non-empty packing",
+      "endpoints_ne: unit_length=1 contradicts euclidDist_self=0 if endpoints equal"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove segment_in_square_of_endpoints (convexity of [0,1]²)",
-      "Prove euclidDist properties (symmetry, positivity, triangle inequality)",
-      "Explore whether packing_singleton can be constructed (needs explicit UnitSegment in square)"
+      "Prove euclidDist triangle inequality for distance-based arguments",
+      "Construct Danzer configuration explicitly (need coordinates from literature)",
+      "Prove segment_nonempty: segmentSet is non-empty (from endpoint membership)"
     ],
     "markdown": "# Erdős #1071 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nAre there a finite set of unit line segments in the unit square, no two of which intersect, which are maximal with respect to this property?\n\nIs there a region $R$ with a maximal set of disjoint unit line segments that is countably infinite?\n\n\n\nA question of Erd\\H{o}s and T\\'{o}th. The answer to the first question is yes (which Erd\\H{o}s gave \\$10 for).\n\nThere are two examples Erd\\H{o}s gives in \\cite{Er87b}, the {IMAGE=1071-one,first} by Danzer, the {IMAGE=1071-two,second} by an unnamed participant.\n\n\n\n\nReferences\n\n\n[Er87b] Erd\\H{o}s, P., Some combinatorial and metric problems in geometry. Intuitive geometry (Si\\'{o}fok, 1985) (1987), 167-177.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1070\n- Problem #1072\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er87b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -72,7 +120,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T14:38:41.571Z",
-  "lastUpdate": "2026-03-13T07:52:17.056Z",
+  "lastUpdate": "2026-03-26T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- Prove 10 new theorems/defs for Erdős #1071 (maximal unit segment packings)
- Euclidean distance properties: symmetry, non-negativity, self=0, endpoint distinctness
- Unit square convexity: convex combinations of [0,1]² points stay in [0,1]²
- Concrete witness: horizontalMidSegment from (0,1/2) to (1,1/2)
- Singleton packing construction and existence of non-empty packings

## Progress
- 175 → 245 lines, 7 → 17 proved theorems
- 3 axioms remain: Danzer result, open problem, endpoint variant
- Structural geometry foundation now in place for future work

## Status
**Outcome**: progress
**Next Steps**: Triangle inequality, Danzer configuration coordinates from literature

Generated by researcher-2