### PR TITLE
Research: erdos-1016 — eliminate bondy_quadratic_threshold axiom (7→6)

### DIFF
--- a/proofs/Proofs/Erdos1016Problem.lean
+++ b/proofs/Proofs/Erdos1016Problem.lean
@@ -86,9 +86,20 @@ theorem hamiltonian_edge_count :
 
 /-- Bondy's theorem: any graph with ≥ n²/4 edges is pancyclic or bipartite.
     For n ≥ 7, n²/4 ≫ n + log₂ n, so the quadratic threshold is far from tight.
-    (The bound fails for n < 7 due to integer division.) -/
-axiom bondy_quadratic_threshold :
-  ∀ n : ℕ, n ≥ 7 → n * n / 4 ≥ n + Nat.log 2 n
+    Proof: small cases by computation, large cases by n²/4 ≥ 2n ≥ n + log₂ n. -/
+theorem bondy_quadratic_threshold :
+    ∀ n : ℕ, n ≥ 7 → n * n / 4 ≥ n + Nat.log 2 n := by
+  intro n hn
+  rcases le_or_lt n 15 with h15 | h16
+  · -- n ∈ {7,...,15}: compute directly
+    interval_cases n <;> native_decide
+  · -- n ≥ 16: n²/4 ≥ 2n and log₂ n ≤ n
+    have h16 : 16 ≤ n := by omega
+    have hq : 2 * n ≤ n * n / 4 := by
+      have : 4 * (2 * n) ≤ n * n := by nlinarith
+      omega
+    have hl : Nat.log 2 n ≤ n := le_of_lt (Nat.log_lt (by omega) (by omega))
+    omega
 
 /-- Monotonicity: adding edges preserves pancyclicity.
     (Trivially true since IsPancyclic does not depend on edgeCount.) -/

--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 1016,
     "erdosUrl": "https://erdosproblems.com/1016",
     "erdosProblemStatus": "open",
-    "axiomCount": 7,
+    "axiomCount": 6,
     "lineCount": 114,
-    "assumptions": "7 axioms: erdos_1016_conjecture, excess_beyond_log, bondy_lower_bound, gkw_upper_bound, bondy_quadratic_threshold, triangle_pancyclic, small_case_4. Three former axioms proved: hamiltonian_edge_count (trivial for ℕ), pancyclic_monotone (IsPancyclic doesn't use edgeCount), bounds_gap (a ≤ a + C). bondy_quadratic_threshold fixed from n≥3 to n≥7 (was false for small n).",
+    "assumptions": "6 axioms: erdos_1016_conjecture, excess_beyond_log, bondy_lower_bound, gkw_upper_bound, triangle_pancyclic, small_case_4. bondy_quadratic_threshold PROVED (was axiom): n²/4 ≥ n + log₂ n for n ≥ 7, by interval_cases for n ≤ 15 + nlinarith/Nat.log_lt for n ≥ 16.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -233,7 +233,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 114,
-    "axiomCount": 7,
+    "axiomCount": 6,
     "theoremCount": 3,
     "definitionCount": 3
   }

--- a/src/data/research/problems/erdos-1016.json
+++ b/src/data/research/problems/erdos-1016.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1016",
   "title": "Erdős #1016",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-15T13:43:13.293Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Axiom cleanup — eliminating trivial and false axioms",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,23 +29,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM CLEANUP: Eliminated 3 trivial axioms (hamiltonian_edge_count, pancyclic_monotone, bounds_gap), fixed false axiom (bondy_quadratic_threshold n≥3→n≥7). Axiom count: 10→7.",
+    "progressSummary": "PROGRESS: Session 3 eliminated bondy_quadratic_threshold axiom (7→6 axioms). Pure arithmetic proof: n²/4 ≥ n + log₂ n.",
     "builtItems": [
       "theorem hamiltonian_edge_count: pancyclicExcess n ≥ 0 (trivial for ℕ)",
       "theorem pancyclic_monotone: IsPancyclic independent of edgeCount",
-      "theorem bounds_gap: h(n) ≤ h(n) + C (tautological, C=0)"
+      "theorem bounds_gap: h(n) ≤ h(n) + C (tautological, C=0)",
+      {
+        "name": "bondy_quadratic_threshold (theorem)",
+        "type": "axiom-elimination",
+        "description": "Proved n²/4 ≥ n + log₂ n for n ≥ 7 — small cases by native_decide, large by nlinarith + Nat.log_lt"
+      }
     ],
     "insights": [
       "hamiltonian_edge_count (pancyclicExcess n ≥ 0) is trivially true for ℕ — eliminated as axiom",
       "pancyclic_monotone is trivially true because IsPancyclic does not use the edgeCount parameter at all",
       "bounds_gap (∃C, h(n) ≤ h(n) + C) is tautological — eliminated as axiom",
       "bondy_quadratic_threshold was FALSE for n=3,4,5 (n²/4 < n + log₂n in those cases) — fixed threshold to n≥7",
-      "Remaining 7 axioms are all either the main conjecture, open questions, or deep published results"
+      "Remaining 7 axioms are all either the main conjecture, open questions, or deep published results",
+      "bondy_quadratic_threshold is pure arithmetic — no graph theory needed. Proved via interval_cases + nlinarith.",
+      "Remaining 6 axioms: 2 open, 2 published deep results, 2 sSup evaluation (triangle_pancyclic, small_case_4)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "triangle_pancyclic and small_case_4 depend on sSup evaluation which is hard to prove",
-      "The remaining 5 non-trivial axioms are the conjecture, open question, or published results"
+      "triangle_pancyclic and small_case_4 need sSup evaluation for pancyclicExcess — very hard",
+      "The 5 non-trivial axioms are published results or open problems — no elimination possible without major formalization"
     ],
     "markdown": "# Erdős #1016 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be minimal such that there is a graph on $n$ vertices with $n+h(n)$ edges which contains a cycle on $k$ vertices, for all $3\\leq k\\leq n$. Estimate $h(n)$. In particular, is it true that\\[h(n) \\geq \\log_2n+\\log_*n-O(1),\\]where $\\log_*n$ is the iterated logarithmic function?\n\n\n\nSuch graphs are called pancyclic. A problem of Bondy \\cite{Bo71}, who claimed a proof (without details) of\\[\\log_2(n-1)-1\\leq h(n) \\leq \\log_2n+\\log_*n+O(1).\\]Erd\\H{o}s \\cite{Er71} believed the upper bound is closer to the truth, but could not even prove $h(n)-\\log_2n\\to \\infty$.\n\nA proof of the above lower bound is provided by Griffin \\cite{Gr13}. The first published proof of the upper bound appears to be in Chapter 4.5 of George, Khodkar, and Wallis \\cite{GKW16}.\n\n\n\n\nReferences\n\n\n[Bo71] Bondy, J. A., Pancyclic graphs. {I}. J. Combinatorial Theory Ser. B (1971), 80--84.\n\n[Er71] Erd\\H{o}s, P., Some unsolved problems in graph theory and combinatorial analysis. Combinatorial Mathematics and its Applications (Proc.\nConf., Oxford, 1969) (1971), 97-109.\n\n[GKW16] George, John C. and Khodkar, Abdollah and Wallis, W. D., Pancyclic and bipancyclic graphs. (2016), xii+108.\n\n[Gr13] S. Griffin, Minimal Pancyclicity. arXiv:1312.0274 (2013).\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1015\n- Problem #1017\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er71\n- Bo71\n- Gr13\n- GKW16\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -64,7 +71,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T13:43:13.294Z",
-  "lastUpdate": "2026-03-13T07:52:17.055Z",
+  "lastUpdate": "2026-03-26T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- Eliminate 1 axiom: `bondy_quadratic_threshold` (n²/4 ≥ n + log₂ n for n ≥ 7)
- Pure arithmetic proof: interval_cases for small n, nlinarith + Nat.log_lt for large n
- Axiom count: 7 → 6

## Progress
- Prior sessions eliminated 3 axioms (10→7)
- This session eliminates 1 more (7→6)
- Remaining 6 axioms: 2 open problems, 2 published deep theorems, 2 sSup evaluations

## Status
**Outcome**: completed (axiom elimination)
**Next Steps**: remaining axioms are deep or open — no further elimination feasible

Generated by researcher-2