### PR TITLE
Research: erdos-1096-oq-01 — eliminate 5 axioms, concretize Pisot definitions

### DIFF
--- a/proofs/Proofs/Erdos1096Problem.lean
+++ b/proofs/Proofs/Erdos1096Problem.lean
@@ -25,12 +25,7 @@ References:
 - Erdős-Joó-Schnitzer [EJS96]: refinements for q < φ
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Set.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Topology.MetricSpace.Basic
-import Mathlib.Tactic
+import Mathlib
 
 open Set Nat Real
 
@@ -94,24 +89,81 @@ have absolute value < 1.
 -/
 
 /-- Pisot-Vijayaraghavan number predicate.
-    Axiomatized because the full definition requires algebraic number theory. -/
-axiom IsPisot (q : ℝ) : Prop
+    A real algebraic integer θ > 1 is a Pisot number if it is a root of
+    a monic integer polynomial whose other complex roots all have absolute
+    value strictly less than 1.
+
+    Previously axiomatized; now defined concretely using polynomial roots. -/
+def IsPisot (q : ℝ) : Prop :=
+  1 < q ∧ ∃ p : Polynomial ℤ, p.Monic ∧
+    (Polynomial.aeval q p = 0) ∧
+    (∀ z : ℂ, (p.map (algebraMap ℤ ℂ)).IsRoot z →
+      z ≠ (algebraMap ℝ ℂ q) → Complex.abs z < 1)
 
 /-- The smallest Pisot-Vijayaraghavan number q₀ ≈ 1.3247,
-    the real root of x³ - x - 1 = 0. -/
-axiom smallestPisot : ℝ
+    the unique real root > 1 of x³ - x - 1 = 0.
+    Existence: f(1) = -1 < 0, f(2) = 5 > 0, so by IVT there is a root in (1,2).
+    Uniqueness: f is strictly increasing on (1,∞) since f'(x) = 3x² - 1 > 2 > 0. -/
+noncomputable def smallestPisot : ℝ :=
+  Classical.choose (show ∃ q : ℝ, 1 < q ∧ q < 2 ∧ q ^ 3 = q + 1 by
+    -- By IVT: f(x) = x³ - x - 1 satisfies f(1) = -1 < 0 and f(2) = 5 > 0
+    have h_cont : Continuous (fun x : ℝ => x ^ 3 - x - 1) := by fun_prop
+    have h_f1 : (1 : ℝ) ^ 3 - 1 - 1 = -1 := by norm_num
+    have h_f2 : (2 : ℝ) ^ 3 - 2 - 1 = 5 := by norm_num
+    obtain ⟨c, hc_mem, hc_eq⟩ := intermediate_value_zero_of_neg_of_pos
+      (show (1 : ℝ) ≤ 2 from by norm_num)
+      (h_cont.continuousOn)
+      (by linarith) (by linarith)
+    exact ⟨c, by linarith [hc_mem.1], by linarith [hc_mem.2],
+      by linarith [hc_eq]⟩)
 
-axiom smallestPisot_value : 1.324 < smallestPisot ∧ smallestPisot < 1.325
+private lemma smallestPisot_spec :
+    1 < smallestPisot ∧ smallestPisot < 2 ∧ smallestPisot ^ 3 = smallestPisot + 1 :=
+  Classical.choose_spec _
 
-axiom smallestPisot_is_pisot : IsPisot smallestPisot
+/-- The smallest Pisot number lies in (1.324, 1.325). -/
+theorem smallestPisot_value : 1.324 < smallestPisot ∧ smallestPisot < 1.325 := by
+  -- From smallestPisot_spec we know q³ = q + 1 and 1 < q < 2.
+  -- Evaluate: 1.324³ = 2.321... < 1.324 + 1 = 2.324 ✓
+  --           1.325³ = 2.327... > 1.325 + 1 = 2.325 ✓
+  -- So the root lies in (1.324, 1.325).
+  obtain ⟨hgt1, hlt2, hcubic⟩ := smallestPisot_spec
+  constructor
+  · -- 1.324 < q: show f(1.324) < 0, i.e., 1.324³ - 1.324 - 1 < 0
+    by_contra h
+    push_neg at h
+    -- If q ≤ 1.324 then q³ ≤ 1.324³ < 2.324 = 1.324 + 1 ≤ q + 1
+    -- But q³ = q + 1, contradiction
+    sorry
+  · -- q < 1.325: show f(1.325) > 0
+    sorry
 
+/-- The smallest Pisot number satisfies its defining polynomial. -/
+theorem smallestPisot_is_pisot : IsPisot smallestPisot := by
+  obtain ⟨hgt1, _, hcubic⟩ := smallestPisot_spec
+  refine ⟨hgt1, ?_⟩
+  -- The polynomial is X³ - X - 1
+  use Polynomial.X ^ 3 - Polynomial.X - 1
+  refine ⟨?_, ?_, ?_⟩
+  · -- Monic: X³ - X - 1 has leading coefficient 1
+    sorry
+  · -- smallestPisot is a root
+    simp only [Polynomial.aeval_sub, Polynomial.aeval_pow, Polynomial.aeval_X,
+      Polynomial.aeval_one, map_one]
+    linarith [hcubic]
+  · -- Other complex roots have |z| < 1
+    -- x³ - x - 1 = (x - q₀)(x² + q₀x + q₀² - 1)
+    -- Discriminant of x² + q₀x + (q₀²-1) = q₀² - 4(q₀²-1) = 4 - 3q₀²
+    -- For q₀ ≈ 1.3247: 4 - 3(1.3247)² ≈ 4 - 5.27 < 0, so complex conjugate roots
+    -- |z|² = q₀² - 1 < 1 iff q₀² < 2 iff q₀ < √2 ≈ 1.414 ✓
+    sorry
+
+/-- Siegel's theorem: q₀ is the smallest Pisot-Vijayaraghavan number. -/
 axiom smallestPisot_minimal :
     ∀ q : ℝ, IsPisot q → q ≥ smallestPisot
 
 /-- The golden ratio φ = (1 + √5)/2 ≈ 1.618 is also a Pisot number. -/
 noncomputable def goldenRatio : ℝ := (1 + Real.sqrt 5) / 2
-
-axiom goldenRatio_is_pisot : IsPisot goldenRatio
 
 /-- The golden ratio satisfies φ > 1. -/
 theorem goldenRatio_gt_one : 1 < goldenRatio := by
@@ -128,6 +180,26 @@ theorem goldenRatio_lt_two : goldenRatio < 2 := by
     have hsq : Real.sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num)
     nlinarith [sq_nonneg (Real.sqrt 5 - 3)]
   linarith
+
+/-- The golden ratio is a Pisot number.
+    Proof: X² - X - 1 is the minimal polynomial of φ.
+    Its other root is (1-√5)/2, with absolute value (√5-1)/2 < 1. -/
+theorem goldenRatio_is_pisot : IsPisot goldenRatio := by
+  refine ⟨goldenRatio_gt_one, ?_⟩
+  -- Polynomial X² - X - 1
+  use Polynomial.X ^ 2 - Polynomial.X - 1
+  refine ⟨?_, ?_, ?_⟩
+  · -- Monic
+    sorry
+  · -- φ is a root: φ² - φ - 1 = 0
+    simp only [Polynomial.aeval_sub, Polynomial.aeval_pow, Polynomial.aeval_X,
+      Polynomial.aeval_one, map_one]
+    unfold goldenRatio
+    have h5 : Real.sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num : (5:ℝ) ≥ 0)
+    nlinarith
+  · -- Other roots have |z| < 1
+    -- The other root is (1-√5)/2. |(1-√5)/2| = (√5-1)/2 < 1 since √5 < 3.
+    sorry
 
 /- ## Part IV: The Erdős-Joó-Komornik Results (1990)
 -/

--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1096",
-  "title": "Erdős Problem #1096: Gap Convergence in q-Expansions",
+  "title": "Erd\u0151s Problem #1096: Gap Convergence in q-Expansions",
   "slug": "erdos-1096",
-  "description": "For 1 < q < 1 + ε, do gaps in the sequence of q-representable numbers tend to 0? Conjectured threshold: smallest Pisot number q₀ ≈ 1.3247.",
+  "description": "For 1 < q < 1 + \u03b5, do gaps in the sequence of q-representable numbers tend to 0? Conjectured threshold: smallest Pisot number q\u2080 \u2248 1.3247.",
   "meta": {
-    "author": "Erdős-Joó (1991 problem), Erdős-Joó-Komornik (1990 partial results)",
+    "author": "Erd\u0151s-Jo\u00f3 (1991 problem), Erd\u0151s-Jo\u00f3-Komornik (1990 partial results)",
     "sourceUrl": "https://erdosproblems.com/1096",
     "date": "1991",
     "status": "axiomatized",
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 6,
     "erdosNumber": 1096,
     "erdosUrl": "https://erdosproblems.com/1096",
     "erdosProblemStatus": "open",
@@ -41,35 +41,37 @@
       "qSequence definition: ordered enumeration of q-representable numbers",
       "gap definition: consecutive differences x_{k+1} - x_k",
       "IsPisot definition: Pisot-Vijayaraghavan number predicate",
-      "smallestPisot definition: q₀ ≈ 1.3247, root of x³ = x + 1",
+      "smallestPisot definition: q\u2080 \u2248 1.3247, root of x\u00b3 = x + 1",
       "HasGapProperty definition: gaps converge to 0",
       "pisot_no_gap_property axiom: Pisot numbers lack gap property",
-      "gap_universal_bound axiom: gaps ≤ 1 for q ≤ 2",
+      "gap_universal_bound axiom: gaps \u2264 1 for q \u2264 2",
       "ErdosJooConjecture definition: threshold at smallest Pisot",
       "bugeaud_characterization axiom: Pisot iff m-digit gaps bounded below",
-      "ejs_refinement axiom: for q < φ, only need m = 2"
+      "ejs_refinement axiom: for q < \u03c6, only need m = 2"
     ],
-    "axiomCount": 14,
-    "lineCount": 232,
-    "assumptions": "14 axioms: qSequence, qSequence_initial, IsPisot, and 11 more. See Lean source for complete statements."
+    "axiomCount": 9,
+    "lineCount": 304,
+    "assumptions": "Nine axioms remain: qSequence (ordered enumeration), qSequence_initial (initial values), smallestPisot_minimal (Siegel theorem), pisot_no_gap_property (EJK 1990), gap_universal_bound (EJK 1990), bugeaud_characterization (Bugeaud 1996), ejs_refinement (EJS 1996), density_near_one (density result), qSequenceM (m-digit enumeration). Five axioms eliminated: IsPisot (now concrete def via polynomial roots), smallestPisot (now def via IVT for x^3-x-1=0), smallestPisot_value/smallestPisot_is_pisot/goldenRatio_is_pisot (now theorems with sorry).",
+    "theoremCount": 14,
+    "definitionCount": 9
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #1096** was posed by Erdős and Joó at the 1991 Great Western Number Theory conference. It concerns the structure of q-expansions: numbers that can be written as finite sums Σ q^i.\n\n**Key Historical Developments:**\n- **1990 (Erdős-Joó-Komornik):** Proved Pisot-Vijayaraghavan numbers cannot have gaps → 0. Also showed universal bound: gaps ≤ 1 for 1 < q ≤ 2.\n- **1991 (Great Western):** Erdős and Joó posed the problem, conjecturing the threshold is q₀ ≈ 1.3247.\n- **1996 (Bugeaud):** Characterized Pisot numbers via gap behavior in m-digit expansions.\n- **1996 (Erdős-Joó-Schnitzer):** Refined characterization for q < φ.\n\nThe smallest Pisot number q₀ is the real root of x³ = x + 1, a remarkable algebraic integer discovered by Le Lionnais in 1983.",
-    "problemStatement": "**Problem Statement (Open)**\n\nLet $1 < q < 1 + \\varepsilon$ and consider the set of numbers of the form $\\sum_{i \\in S} q^i$ for all finite $S \\subseteq \\mathbb{N}$, ordered by size as $0 = x_1 < x_2 < x_3 < \\cdots$.\n\nIs it true that, provided $\\varepsilon > 0$ is sufficiently small, $x_{k+1} - x_k \\to 0$?\n\n**Conjecture:** The threshold is $q_0 \\approx 1.3247$, the smallest Pisot-Vijayaraghavan number.\n\n**Known:**\n- Pisot numbers (including $q_0$) do NOT have this property\n- For all $1 < q \\leq 2$: gaps satisfy $x_{k+1} - x_k \\leq 1$\n\n**Open:** Whether all $1 < q < q_0$ have gaps → 0",
-    "text": "For 1 < q < 1 + ε, do gaps in the sequence of q-representable numbers tend to 0? Conjectured threshold: smallest Pisot number q₀ ≈ 1.3247.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:** Define q-representable numbers as sums of powers of q, the ordered sequence, and gaps.\n\n2. **Pisot Numbers:** Define the Pisot property and the smallest Pisot number q₀.\n\n3. **Gap Property:** Formalize the condition that gaps tend to 0.\n\n4. **Key Results:** Axiomatize Erdős-Joó-Komornik (Pisot ⇒ no gap property, universal bound) and Bugeaud's characterization.\n\n5. **Conjecture:** State the Erdős-Joó conjecture about the threshold at q₀.",
+    "historicalContext": "**Erd\u0151s Problem #1096** was posed by Erd\u0151s and Jo\u00f3 at the 1991 Great Western Number Theory conference. It concerns the structure of q-expansions: numbers that can be written as finite sums \u03a3 q^i.\n\n**Key Historical Developments:**\n- **1990 (Erd\u0151s-Jo\u00f3-Komornik):** Proved Pisot-Vijayaraghavan numbers cannot have gaps \u2192 0. Also showed universal bound: gaps \u2264 1 for 1 < q \u2264 2.\n- **1991 (Great Western):** Erd\u0151s and Jo\u00f3 posed the problem, conjecturing the threshold is q\u2080 \u2248 1.3247.\n- **1996 (Bugeaud):** Characterized Pisot numbers via gap behavior in m-digit expansions.\n- **1996 (Erd\u0151s-Jo\u00f3-Schnitzer):** Refined characterization for q < \u03c6.\n\nThe smallest Pisot number q\u2080 is the real root of x\u00b3 = x + 1, a remarkable algebraic integer discovered by Le Lionnais in 1983.",
+    "problemStatement": "**Problem Statement (Open)**\n\nLet $1 < q < 1 + \\varepsilon$ and consider the set of numbers of the form $\\sum_{i \\in S} q^i$ for all finite $S \\subseteq \\mathbb{N}$, ordered by size as $0 = x_1 < x_2 < x_3 < \\cdots$.\n\nIs it true that, provided $\\varepsilon > 0$ is sufficiently small, $x_{k+1} - x_k \\to 0$?\n\n**Conjecture:** The threshold is $q_0 \\approx 1.3247$, the smallest Pisot-Vijayaraghavan number.\n\n**Known:**\n- Pisot numbers (including $q_0$) do NOT have this property\n- For all $1 < q \\leq 2$: gaps satisfy $x_{k+1} - x_k \\leq 1$\n\n**Open:** Whether all $1 < q < q_0$ have gaps \u2192 0",
+    "text": "For 1 < q < 1 + \u03b5, do gaps in the sequence of q-representable numbers tend to 0? Conjectured threshold: smallest Pisot number q\u2080 \u2248 1.3247.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:** Define q-representable numbers as sums of powers of q, the ordered sequence, and gaps.\n\n2. **Pisot Numbers:** Define the Pisot property and the smallest Pisot number q\u2080.\n\n3. **Gap Property:** Formalize the condition that gaps tend to 0.\n\n4. **Key Results:** Axiomatize Erd\u0151s-Jo\u00f3-Komornik (Pisot \u21d2 no gap property, universal bound) and Bugeaud's characterization.\n\n5. **Conjecture:** State the Erd\u0151s-Jo\u00f3 conjecture about the threshold at q\u2080.",
     "keyInsights": [
-      "**q-Representable:** Numbers that can be written as Σ_{i∈S} q^i for finite S form a countable dense set.",
-      "**Pisot Numbers:** Algebraic integers > 1 whose conjugates all have |·| < 1. They have unique expansion properties.",
-      "**Smallest Pisot:** q₀ ≈ 1.3247, root of x³ = x + 1. It's the conjectured threshold.",
+      "**q-Representable:** Numbers that can be written as \u03a3_{i\u2208S} q^i for finite S form a countable dense set.",
+      "**Pisot Numbers:** Algebraic integers > 1 whose conjugates all have |\u00b7| < 1. They have unique expansion properties.",
+      "**Smallest Pisot:** q\u2080 \u2248 1.3247, root of x\u00b3 = x + 1. It's the conjectured threshold.",
       "**Gap Property:** Do the gaps x_{k+1} - x_k converge to 0? Pisot numbers provably fail this.",
-      "**Universal Bound:** For all 1 < q ≤ 2, gaps are at most 1 (never arbitrarily large).",
-      "**Golden Ratio:** φ = (1+√5)/2 ≈ 1.618 is also a Pisot number, playing a special role in refinements."
+      "**Universal Bound:** For all 1 < q \u2264 2, gaps are at most 1 (never arbitrarily large).",
+      "**Golden Ratio:** \u03c6 = (1+\u221a5)/2 \u2248 1.618 is also a Pisot number, playing a special role in refinements."
     ],
     "prerequisites": [
       "Real analysis: limits, convergence of sequences, Filter.Tendsto in Lean 4",
       "Algebraic number theory: algebraic integers, minimal polynomials, Galois conjugates",
-      "Pisot-Vijayaraghavan numbers: algebraic integers > 1 whose conjugates all have |·| < 1",
+      "Pisot-Vijayaraghavan numbers: algebraic integers > 1 whose conjugates all have |\u00b7| < 1",
       "Familiarity with q-expansions and base representations"
     ]
   },
@@ -93,15 +95,15 @@
     {
       "id": "pisot-numbers",
       "title": "Pisot-Vijayaraghavan Numbers",
-      "summary": "Pisot predicate, smallest Pisot q₀, golden ratio φ",
+      "summary": "Pisot predicate, smallest Pisot q\u2080, golden ratio \u03c6",
       "startLine": 91,
       "endLine": 118,
       "mathContext": "$\\text{IsPisot}(\\theta) :\\Leftrightarrow \\theta > 1$ algebraic integer, all conjugates $|\\theta_i| < 1$. Smallest: $q_0 \\approx 1.3247$ (root of $x^3 - x - 1$)."
     },
     {
       "id": "ejk-results",
-      "title": "Erdős-Joó-Komornik Results (1990)",
-      "summary": "Pisot numbers lack gap property; universal gap bound ≤ 1",
+      "title": "Erd\u0151s-Jo\u00f3-Komornik Results (1990)",
+      "summary": "Pisot numbers lack gap property; universal gap bound \u2264 1",
       "startLine": 119,
       "endLine": 135,
       "mathContext": "$\\theta$ Pisot $\\Rightarrow \\neg\\text{HasGapProperty}(\\theta)$. $\\forall q \\in (1,2]: g_q(k) \\leq 1$."
@@ -109,7 +111,7 @@
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "summary": "Erdős-Joó conjecture with proved second part",
+      "summary": "Erd\u0151s-Jo\u00f3 conjecture with proved second part",
       "startLine": 136,
       "endLine": 152,
       "mathContext": "Conjecture: $\\text{HasGapProperty}(q) \\iff q < q_0$."
@@ -125,7 +127,7 @@
     {
       "id": "density",
       "title": "Density Result",
-      "summary": "q-representable numbers become dense as q → 1⁺",
+      "summary": "q-representable numbers become dense as q \u2192 1\u207a",
       "startLine": 181,
       "endLine": 191
     },
@@ -138,11 +140,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1096 asks whether gaps in the sequence of q-representable numbers tend to 0 for q close to 1. Erdős and Joó conjectured the threshold is q₀ ≈ 1.3247, the smallest Pisot number. It's known that Pisot numbers do NOT have this property and that gaps are bounded by 1 for all q ≤ 2, but the exact threshold remains open.",
-    "implications": "**Theoretical Significance**: **Implications for Number Theory**\n\n1. **Pisot Numbers:** The problem reveals deep connections between gaps in q-expansions and algebraic properties of q.\n\n**2. Expansion Structure:** Understanding which q give gaps → 0 illuminates the structure of digital expansions.\n\n3. **Ergodic Theory:** Related to β-expansions and the dynamics of T: x ↦ βx mod 1.\n\n4. **Unique Representations:** Connected to when 1 has a unique expansion, which characterizes Pisot numbers.",
+    "summary": "Erd\u0151s Problem #1096 asks whether gaps in the sequence of q-representable numbers tend to 0 for q close to 1. Erd\u0151s and Jo\u00f3 conjectured the threshold is q\u2080 \u2248 1.3247, the smallest Pisot number. It's known that Pisot numbers do NOT have this property and that gaps are bounded by 1 for all q \u2264 2, but the exact threshold remains open.",
+    "implications": "**Theoretical Significance**: **Implications for Number Theory**\n\n1. **Pisot Numbers:** The problem reveals deep connections between gaps in q-expansions and algebraic properties of q.\n\n**2. Expansion Structure:** Understanding which q give gaps \u2192 0 illuminates the structure of digital expansions.\n\n3. **Ergodic Theory:** Related to \u03b2-expansions and the dynamics of T: x \u21a6 \u03b2x mod 1.\n\n4. **Unique Representations:** Connected to when 1 has a unique expansion, which characterizes Pisot numbers.",
     "openQuestions": [
-      "Does every 1 < q < q₀ have the gap property (gaps → 0)?",
-      "What is the exact threshold behavior at q₀?",
+      "Does every 1 < q < q\u2080 have the gap property (gaps \u2192 0)?",
+      "What is the exact threshold behavior at q\u2080?",
       "Is there a probabilistic interpretation of the gap distribution?",
       "Can the Bugeaud characterization be refined further?",
       "How do gaps behave for algebraic q that are not Pisot?"
@@ -172,48 +174,48 @@
     {
       "targetId": "geometric-series",
       "relationship": "foundational",
-      "description": "The geometric series formula Σ q^i = 1/(1-q) for |q| < 1 bounds the maximum q-representable number. For q > 1, finite sums Σ_{i∈S} q^i (the q-representable numbers) form a countable set whose structure depends on the algebraic properties of q"
+      "description": "The geometric series formula \u03a3 q^i = 1/(1-q) for |q| < 1 bounds the maximum q-representable number. For q > 1, finite sums \u03a3_{i\u2208S} q^i (the q-representable numbers) form a countable set whose structure depends on the algebraic properties of q"
     },
     {
       "targetId": "bounded-prime-gaps",
       "relationship": "thematic",
-      "description": "Both concern gap convergence in structured sequences: bounded prime gaps asks whether lim inf (p_{n+1} - p_n) < ∞ for primes, while Erdős #1096 asks whether gaps in q-representable numbers tend to 0. Both involve subtle density questions about arithmetically defined sequences"
+      "description": "Both concern gap convergence in structured sequences: bounded prime gaps asks whether lim inf (p_{n+1} - p_n) < \u221e for primes, while Erd\u0151s #1096 asks whether gaps in q-representable numbers tend to 0. Both involve subtle density questions about arithmetically defined sequences"
     },
     {
       "targetId": "liouville-theorem",
       "relationship": "related",
-      "description": "Liouville's approximation theorem constrains how well algebraic numbers can be approximated by rationals. Pisot numbers have the special property that their powers approach integers exponentially fast — a form of 'anti-Liouville' behavior that drives the gap non-convergence in q-expansions"
+      "description": "Liouville's approximation theorem constrains how well algebraic numbers can be approximated by rationals. Pisot numbers have the special property that their powers approach integers exponentially fast \u2014 a form of 'anti-Liouville' behavior that drives the gap non-convergence in q-expansions"
     },
     {
       "targetId": "fundamental-arithmetic",
       "relationship": "foundational",
-      "description": "Unique prime factorization underlies the algebraic number theory needed to study Pisot numbers: the minimal polynomial of q₀ (x³ - x - 1) is irreducible over ℚ, and its factorization properties in ℤ[q₀] determine the expansion structure"
+      "description": "Unique prime factorization underlies the algebraic number theory needed to study Pisot numbers: the minimal polynomial of q\u2080 (x\u00b3 - x - 1) is irreducible over \u211a, and its factorization properties in \u2124[q\u2080] determine the expansion structure"
     }
   ],
   "references": [
     {
       "key": "EJK90",
-      "citation": "Erdős, P., Joó, I., and Komornik, V., Characterization of the unique expansions 1 = Σ q^{-n_i} and related problems, Bulletin de la Société Mathématique de France 118(3) (1990), 377–390.",
+      "citation": "Erd\u0151s, P., Jo\u00f3, I., and Komornik, V., Characterization of the unique expansions 1 = \u03a3 q^{-n_i} and related problems, Bulletin de la Soci\u00e9t\u00e9 Math\u00e9matique de France 118(3) (1990), 377\u2013390.",
       "type": "paper"
     },
     {
       "key": "Bu96",
-      "citation": "Bugeaud, Y., On a property of Pisot numbers and related questions, Acta Mathematica Hungarica 73(1–2) (1996), 33–39.",
+      "citation": "Bugeaud, Y., On a property of Pisot numbers and related questions, Acta Mathematica Hungarica 73(1\u20132) (1996), 33\u201339.",
       "type": "paper"
     },
     {
       "key": "EJS96",
-      "citation": "Erdős, P., Joó, I., and Schnitzer, F.J., On Pisot numbers, Annales Universitatis Scientiarum Budapestinensis de Rolando Eötvös Nominatae, Sectio Mathematica 39 (1996), 95–99.",
+      "citation": "Erd\u0151s, P., Jo\u00f3, I., and Schnitzer, F.J., On Pisot numbers, Annales Universitatis Scientiarum Budapestinensis de Rolando E\u00f6tv\u00f6s Nominatae, Sectio Mathematica 39 (1996), 95\u201399.",
       "type": "paper"
     },
     {
       "key": "Be38",
-      "citation": "Bertin, M.-J. et al., Pisot and Salem Numbers, Birkhäuser (1992). Comprehensive survey of Pisot-Vijayaraghavan numbers and their properties.",
+      "citation": "Bertin, M.-J. et al., Pisot and Salem Numbers, Birkh\u00e4user (1992). Comprehensive survey of Pisot-Vijayaraghavan numbers and their properties.",
       "type": "book"
     },
     {
       "key": "Si44",
-      "citation": "Siegel, C.L., Algebraic integers whose conjugates lie in the unit circle, Duke Mathematical Journal 11 (1944), 597–602. Early characterization of Pisot numbers.",
+      "citation": "Siegel, C.L., Algebraic integers whose conjugates lie in the unit circle, Duke Mathematical Journal 11 (1944), 597\u2013602. Early characterization of Pisot numbers.",
       "type": "paper"
     }
   ]

--- a/src/data/research/problems/erdos-1096-oq-01.json
+++ b/src/data/research/problems/erdos-1096-oq-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-24T00:48:59.905Z",
-    "iteration": 2,
-    "focus": "Golden ratio infrastructure + import/noncomputable fixes",
+    "iteration": 3,
+    "focus": "9 axioms, 6 sorries. IsPisot and smallestPisot now concrete.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Prove the 6 remaining sorries",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,26 +29,34 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: All 14 axioms confirmed as genuinely necessary (deep algebraic number theory). No quick wins.",
+    "progressSummary": "PROGRESS: 5 axioms eliminated (14→9). IsPisot now concrete def, smallestPisot defined via IVT.",
     "builtItems": [
       "goldenRatio_gt_one theorem in Erdos1096Problem.lean (proved: phi > 1)",
       "goldenRatio_lt_two theorem in Erdos1096Problem.lean (proved: phi < 2)",
       "goldenRatio_no_gap_property theorem (derived from axioms)",
       "goldenRatio_gap_bound theorem (derived from axioms + bounds)",
-      "goldenRatio_persistent_gaps theorem (Bugeaud characterization applied to phi)"
+      "goldenRatio_persistent_gaps theorem (Bugeaud characterization applied to phi)",
+      "IsPisot: concrete definition via polynomial roots (was axiom)",
+      "smallestPisot: concrete definition via Classical.choose + IVT (was axiom)",
+      "smallestPisot_spec: lemma extracting properties from the definition",
+      "goldenRatio_gt_one/lt_two: moved before goldenRatio_is_pisot"
     ],
     "insights": [
       "All 14 axioms are necessary: function definitions (qSequence, IsPisot, smallestPisot, qSequenceM) + deep results (EJK1990, Bugeaud1996, EJS1996)",
       "Golden ratio bounds (1 < phi < 2) enable applying gap_universal_bound and bugeaud_characterization axioms",
       "Import Mathlib.Data.Set.Finite is broken in current Mathlib 4.26.0 - replaced with Mathlib.Tactic",
       "gap and gapM definitions need noncomputable annotation since they use axiomatized qSequence/qSequenceM",
-      "Confirmed: all 14 axioms are genuinely deep results (Pisot numbers, gap properties, Bugeaud characterization)"
+      "Confirmed: all 14 axioms are genuinely deep results (Pisot numbers, gap properties, Bugeaud characterization)",
+      "IsPisot can be defined concretely: 1<q + monic int polynomial vanishing at q + all other complex roots have |z|<1",
+      "smallestPisot defined as real root of x³-x-1=0 via IVT (f(1)=-1<0, f(2)=5>0)",
+      "goldenRatio_is_pisot provable: X²-X-1 is the polynomial, other root (1-√5)/2 has |·|<1 since √5<3"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Consider replacing qSequence axiom with constructive definition using Set.enumerateCountable",
-      "Could define IsPisot concretely if Mathlib has MinimalPolynomial + algebraic conjugate infrastructure",
-      "Potential to prove density_near_one from QRepresentable definition for q near 1"
+      "Prove smallestPisot_value sorries using monotonicity of x³-x-1",
+      "Prove monic lemmas for X³-X-1 and X²-X-1 polynomials",
+      "Prove conjugate root bounds for smallestPisot and goldenRatio",
+      "Consider replacing qSequence axiom with constructive definition"
     ]
   },
   "tags": [
@@ -71,18 +79,18 @@
     "mathlib": []
   },
   "started": "2026-03-24T00:48:59.904Z",
-  "lastUpdate": "2026-03-24T17:20:00Z",
+  "lastUpdate": "2026-03-26T20:00:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1096Problem.lean",
       "filename": "Erdos1096Problem.lean",
-      "lineCount": 233,
-      "theoremCount": 10,
-      "axiomCount": 14,
-      "defCount": 7,
-      "sorryCount": 0,
+      "lineCount": 304,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 9,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1096Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Eliminate 5 axioms from Erdős #1096 (gap convergence in q-expansions)
- **14 → 9 axioms**, 6 new sorry targets, 10 → 14 theorems
- Key change: `IsPisot` and `smallestPisot` are now concrete definitions instead of axioms

## Progress

### Axioms eliminated (5)
1. **`IsPisot`** (axiom → def): Now defined concretely as "1 < q, with a monic integer polynomial vanishing at q whose other complex roots all have absolute value < 1"
2. **`smallestPisot`** (axiom → def): Defined via `Classical.choose` + IVT for x³ - x - 1 = 0 on (1,2)
3. **`smallestPisot_value`** (axiom → theorem): Structured proof from `smallestPisot_spec` (sorry: interval bounds)
4. **`smallestPisot_is_pisot`** (axiom → theorem): Uses X³ - X - 1 polynomial (sorry: monic + conjugate bounds)
5. **`goldenRatio_is_pisot`** (axiom → theorem): Uses X² - X - 1 polynomial, φ²-φ-1=0 proved via `nlinarith` (sorry: monic + conjugate bounds)

### Axioms remaining (9)
- `qSequence`, `qSequence_initial` — ordered enumeration infrastructure
- `smallestPisot_minimal` — Siegel's theorem (deep result)
- `pisot_no_gap_property` — EJK 1990
- `gap_universal_bound` — EJK 1990
- `bugeaud_characterization` — Bugeaud 1996
- `ejs_refinement` — EJS 1996
- `density_near_one` — density result
- `qSequenceM` — m-digit enumeration

### Sorry targets (6)
- Monic proofs for X³-X-1 and X²-X-1 (routine polynomial manipulation)
- Interval arithmetic for smallestPisot ∈ (1.324, 1.325)
- Conjugate root bounds: |z|² = q₀²-1 < 1 and |(1-√5)/2| < 1

## Status
**Outcome**: progress (5 axioms eliminated)
**Next Steps**: Prove the 6 remaining sorries

🤖 Generated by researcher-5