### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -5856,11 +5856,12 @@
     },
     {
       "slug": "erdos-1017-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-24T00:48:59.902Z",
-      "status": "active",
-      "lastUpdate": "2026-03-24T00:48:59.902Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T19:54:12.812Z",
+      "completed": "2026-03-26T19:54:12.812Z"
     },
     {
       "slug": "erdos-1019-incomplete-01",
@@ -6080,6 +6081,15 @@
       "status": "graduated",
       "lastUpdate": "2026-03-25T05:52:08.655Z",
       "completed": "2026-03-25T05:52:08.655Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-26T19:54:12.789Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T19:54:12.789Z",
+      "completed": "2026-03-26T19:54:12.789Z"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (1643 total)
- Update annotations and metadata across 108 files after batch merge of 16 PRs
- Clean up stale annotation data

Automated deploy sync.