### PR TITLE
Research: prove π+1 and e+1 transcendental from base axioms

### DIFF
--- a/proofs/Proofs/PiTranscendental.lean
+++ b/proofs/Proofs/PiTranscendental.lean
@@ -216,11 +216,16 @@ axiom pi_sq_transcendental_axiom : Transcendental ℤ (Real.pi ^ 2)
 theorem pi_sq_transcendental : Transcendental ℤ (Real.pi ^ 2) :=
   pi_sq_transcendental_axiom
 
-/-- **Axiom: π + 1 is transcendental**
-
-    If π + 1 were algebraic, say p(π + 1) = 0, then π satisfies q(X) = p(X + 1),
-    making π algebraic. This contradicts π being transcendental. -/
-axiom pi_plus_one_transcendental_axiom : Transcendental ℤ (Real.pi + 1)
+/-- **π + 1 is transcendental**: if π + 1 were algebraic over ℤ, then
+    π = (π + 1) − 1 would be algebraic (algebraic elements over ℚ are closed
+    under subtraction of rationals). This contradicts π being transcendental. -/
+theorem pi_plus_one_transcendental_axiom : Transcendental ℤ (Real.pi + 1) := by
+  intro halg
+  have hq : IsAlgebraic ℚ (Real.pi + 1) := (IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg
+  have h1 : IsAlgebraic ℚ (1 : ℝ) := isAlgebraic_algebraMap (1 : ℚ)
+  have hpi : IsAlgebraic ℚ Real.pi := by
+    have := hq.sub h1; rwa [add_sub_cancel_right] at this
+  exact pi_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mpr hpi)
 
 /-- π + 1 is transcendental -/
 theorem pi_plus_one_transcendental : Transcendental ℤ (Real.pi + 1) :=

--- a/proofs/Proofs/eTranscendental.lean
+++ b/proofs/Proofs/eTranscendental.lean
@@ -184,11 +184,16 @@ axiom e_inv_transcendental_axiom : Transcendental ℤ (Real.exp 1)⁻¹
 /-- 1/e is transcendental -/
 theorem e_inv_transcendental : Transcendental ℤ (Real.exp 1)⁻¹ := e_inv_transcendental_axiom
 
-/-- **Axiom: e + 1 is transcendental**
-
-    If e + 1 were algebraic, say p(e + 1) = 0, then e satisfies q(X) = p(X + 1),
-    making e algebraic. Contradiction. -/
-axiom e_plus_one_transcendental_axiom : Transcendental ℤ (Real.exp 1 + 1)
+/-- **e + 1 is transcendental**: if e + 1 were algebraic over ℤ, then
+    e = (e + 1) − 1 would be algebraic (algebraic elements over ℚ are closed
+    under subtraction of rationals). This contradicts e being transcendental. -/
+theorem e_plus_one_transcendental_axiom : Transcendental ℤ (Real.exp 1 + 1) := by
+  intro halg
+  have hq : IsAlgebraic ℚ (Real.exp 1 + 1) := (IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg
+  have h1 : IsAlgebraic ℚ (1 : ℝ) := isAlgebraic_algebraMap (1 : ℚ)
+  have he : IsAlgebraic ℚ (Real.exp 1) := by
+    have := hq.sub h1; rwa [add_sub_cancel_right] at this
+  exact e_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mpr he)
 
 /-- e + 1 is transcendental -/
 theorem e_plus_one_transcendental : Transcendental ℤ (Real.exp 1 + 1) := e_plus_one_transcendental_axiom

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -38,8 +38,8 @@
       "Historical significance as first explicitly transcendental constant"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 5,
-    "assumptions": "5 axiom declarations: e_transcendental (Hermite 1873: e is transcendental), e_irrational_axiom (corollary: e is irrational), exp_nat_transcendental_axiom (e^n transcendental for n ≥ 1, from Lindemann-Weierstrass), e_inv_transcendental_axiom (1/e transcendental), e_plus_one_transcendental_axiom (e+1 transcendental). All are consequences of the Hermite-Lindemann-Weierstrass theorem.",
+    "axiomCount": 4,
+    "assumptions": "5 axiom declarations: e_transcendental (Hermite 1873: e is transcendental), e_irrational_axiom (corollary: e is irrational), exp_nat_transcendental_axiom (e^n transcendental for n \u2265 1, from Lindemann-Weierstrass), e_inv_transcendental_axiom (1/e transcendental), e_plus_one_transcendental_axiom (e+1 transcendental). All are consequences of the Hermite-Lindemann-Weierstrass theorem.",
     "lineCount": 267,
     "relatedProblems": [
       {
@@ -47,19 +47,20 @@
         "relationship": "Extension of e transcendental"
       }
     ],
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "theoremCount": 1
   },
   "overview": {
-    "historicalContext": "Charles Hermite proved $e$ is transcendental in 1873, making it the first \"naturally occurring\" constant shown to be transcendental—Joseph Liouville had constructed artificial transcendental numbers in 1844, but those were designed to satisfy Liouville's approximation criterion. Hermite's method used an auxiliary polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ combined with integral estimates to derive a contradiction from an assumed algebraic relation for $e$. Nine years later, Ferdinand von Lindemann (1882) extended Hermite's technique to prove $\\pi$ is transcendental, resolving the ancient Greek problem of squaring the circle. The full generalization—the **Lindemann-Weierstrass theorem** (1885)—states that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent whenever $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers. This deep result remains unformalized in Mathlib, so the main theorem here is axiomatized.",
+    "historicalContext": "Charles Hermite proved $e$ is transcendental in 1873, making it the first \"naturally occurring\" constant shown to be transcendental\u2014Joseph Liouville had constructed artificial transcendental numbers in 1844, but those were designed to satisfy Liouville's approximation criterion. Hermite's method used an auxiliary polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ combined with integral estimates to derive a contradiction from an assumed algebraic relation for $e$. Nine years later, Ferdinand von Lindemann (1882) extended Hermite's technique to prove $\\pi$ is transcendental, resolving the ancient Greek problem of squaring the circle. The full generalization\u2014the **Lindemann-Weierstrass theorem** (1885)\u2014states that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent whenever $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers. This deep result remains unformalized in Mathlib, so the main theorem here is axiomatized.",
     "problemStatement": "**Theorem**: e is transcendental, i.e., there is no nonzero polynomial P with integer coefficients such that P(e) = 0.\n\nThis is stronger than irrationality (proved by Euler) and even algebraic irrationality.",
     "text": "A 267-line axiomatized formalization of $e$'s transcendence (Wiedijk #67) with 12 declarations, 0 sorries. The main theorem `e_transcendental` states $\\neg \\text{IsAlgebraic}\\,\\mathbb{Z}\\,e$ and is axiomatized (Hermite's 1873 proof requires auxiliary polynomial integral estimates not yet in Mathlib). Proves `e_irrational` from transcendence via `Transcendental.irrational`, and `e_not_integer` / `e_bounds` ($2 < e < 3$) from Mathlib's `Real.exp_one_gt_d9` and `Real.exp_one_lt_d9`. Includes `e_power_transcendental` ($e^n$ transcendental for $n \\neq 0$) via the Lindemann-Weierstrass axiom, and `e_algebraic_independence` for $\\{e, e^2\\}$. Commentary traces Hermite's method and the path to Lindemann's transcendence of $\\pi$.",
     "proofStrategy": "Hermite's proof uses contour integration. Assume e is algebraic with minimal polynomial P. Construct an auxiliary integral that is simultaneously a non-zero integer and arbitrarily small (using factorial growth vs exponential), yielding a contradiction.",
     "keyInsights": [
-      "**Factorial vs. Exponential:** Hermite's proof exploits $\\int_0^n f(t)e^{-t}dt$ where $f$ has $(p{-}1)!$ in the denominator. For large prime $p$, the integral is a nonzero integer (by divisibility) yet arbitrarily small (since $p! \\gg e^n$) — contradiction.",
+      "**Factorial vs. Exponential:** Hermite's proof exploits $\\int_0^n f(t)e^{-t}dt$ where $f$ has $(p{-}1)!$ in the denominator. For large prime $p$, the integral is a nonzero integer (by divisibility) yet arbitrarily small (since $p! \\gg e^n$) \u2014 contradiction.",
       "**Hermite $\\to$ Lindemann $\\to$ Lindemann-Weierstrass:** Hermite's 1873 method ($e$ transcendental) was extended by Lindemann (1882, $\\pi$ transcendental) and then to the full theorem: if $\\alpha_1,\\ldots,\\alpha_n$ are distinct algebraic numbers, then $e^{\\alpha_1},\\ldots,e^{\\alpha_n}$ are $\\mathbb{Q}$-linearly independent.",
       "**Transcendence Hierarchy:** Irrational ($e \\notin \\mathbb{Q}$, Euler 1737) $\\subsetneq$ algebraically irrational ($e$ not quadratic, etc.) $\\subsetneq$ transcendental ($e \\notin \\overline{\\mathbb{Q}}$, Hermite 1873). Transcendence says $e$ satisfies NO polynomial over $\\mathbb{Q}$.",
       "**First 'Famous' Transcendental:** Liouville (1844) constructed artificial transcendentals; Hermite's proof was the first for a 'naturally occurring' constant, opening the door to $\\pi$'s transcendence and the resolution of squaring the circle.",
-      "**Auxiliary Polynomial Template:** Hermite's construction $f(x) = x^{p-1}(x{-}1)^p \\cdots (x{-}n)^p / (p{-}1)!$ — controlling divisibility at integer points while maintaining integrality — became the blueprint for Baker's theorem (1966) on linear forms in logarithms."
+      "**Auxiliary Polynomial Template:** Hermite's construction $f(x) = x^{p-1}(x{-}1)^p \\cdots (x{-}n)^p / (p{-}1)!$ \u2014 controlling divisibility at integer points while maintaining integrality \u2014 became the blueprint for Baker's theorem (1966) on linear forms in logarithms."
     ],
     "prerequisites": [
       "Abstract algebra (algebraic vs transcendental elements, minimal polynomials over $\\mathbb{Z}$)",
@@ -82,12 +83,12 @@
     {
       "targetId": "hermite-lindemann",
       "relationship": "extends",
-      "description": "Hermite-Lindemann generalizes e's transcendence: e^α is transcendental for all algebraic α ≠ 0. Hermite's 1873 proof for e was the seed that Lindemann extended to e^α in 1882"
+      "description": "Hermite-Lindemann generalizes e's transcendence: e^\u03b1 is transcendental for all algebraic \u03b1 \u2260 0. Hermite's 1873 proof for e was the seed that Lindemann extended to e^\u03b1 in 1882"
     },
     {
       "targetId": "sqrt2-irrational",
       "relationship": "foundational",
-      "description": "The irrationality of √2 is the simplest impossibility result about number expressibility. Transcendence of e is strictly stronger: irrational → algebraically irrational → transcendental"
+      "description": "The irrationality of \u221a2 is the simplest impossibility result about number expressibility. Transcendence of e is strictly stronger: irrational \u2192 algebraically irrational \u2192 transcendental"
     },
     {
       "targetId": "abel-ruffini",
@@ -125,7 +126,7 @@
       "title": "Hermite's Proof Strategy (1873)",
       "startLine": 84,
       "endLine": 129,
-      "summary": "Detailed exposition of Hermite's proof outline: (1) assume $\\sum a_i e^i = 0$, (2) construct auxiliary polynomial $f(x) = x^{p-1}\\prod(x-k)^p / (p-1)!$, (3) define key integrals $I_k = \\int_0^k f(x)e^x dx$, (4) show the sum $S = \\sum a_k I_k$ is simultaneously small and a nonzero multiple of $p$—contradiction.",
+      "summary": "Detailed exposition of Hermite's proof outline: (1) assume $\\sum a_i e^i = 0$, (2) construct auxiliary polynomial $f(x) = x^{p-1}\\prod(x-k)^p / (p-1)!$, (3) define key integrals $I_k = \\int_0^k f(x)e^x dx$, (4) show the sum $S = \\sum a_k I_k$ is simultaneously small and a nonzero multiple of $p$\u2014contradiction.",
       "mathContext": "Hermite's auxiliary polynomial: $f(x) = \\frac{x^{p-1}(x-1)^p \\cdots (x-n)^p}{(p-1)!}$ for large prime $p$. The integral $I_k = \\int_0^k f(t)e^{k-t} dt$ satisfies: (1) $\\sum a_k I_k \\equiv a_0 \\cdot (-1)^n n!^p \\pmod{p}$ (nonzero for $p > \\max(|a_0|, n)$), and (2) $|\\sum a_k I_k| \\to 0$ as $p \\to \\infty$ (factorial denominator dominates). Contradiction."
     },
     {
@@ -133,7 +134,7 @@
       "title": "Main Theorem (Axiomatized)",
       "startLine": 130,
       "endLine": 157,
-      "summary": "Axiomatizes `Transcendental ℤ (Real.exp 1)` and the equivalent `Transcendental ℚ (Real.exp 1)`, pending formalization of the Lindemann-Weierstrass theorem in Mathlib. Notes that clearing denominators converts $\\mathbb{Q}$-algebraicity to $\\mathbb{Z}$-algebraicity.",
+      "summary": "Axiomatizes `Transcendental \u2124 (Real.exp 1)` and the equivalent `Transcendental \u211a (Real.exp 1)`, pending formalization of the Lindemann-Weierstrass theorem in Mathlib. Notes that clearing denominators converts $\\mathbb{Q}$-algebraicity to $\\mathbb{Z}$-algebraicity.",
       "mathContext": "Axiom: $\\text{Transcendental}\\ \\mathbb{Z}\\ (\\exp(1))$, i.e., $\\nexists P \\in \\mathbb{Z}[X] \\setminus \\{0\\},\\ P(e) = 0$. Equivalently $\\text{Transcendental}\\ \\mathbb{Q}\\ (\\exp(1))$, since any $\\mathbb{Q}$-polynomial can be cleared to a $\\mathbb{Z}$-polynomial by multiplying by the LCM of denominators."
     },
     {
@@ -163,7 +164,7 @@
   ],
   "conclusion": {
     "summary": "Hermite's proof of e's transcendence was a breakthrough that initiated modern transcendence theory. The techniques developed led directly to the Lindemann-Weierstrass theorem and beyond.",
-    "implications": "**Transcendence Theory**: Hermite's 1873 proof that $e$ is transcendental was the first proof of transcendence for a 'naturally occurring' constant (Liouville's 1844 construction produced artificial transcendentals). It directly inspired Lindemann's proof that $\\pi$ is transcendental (1882), which settled the ancient problem of squaring the circle. Together they form the foundation of the Hermite-Lindemann-Weierstrass theorem: $e^\\alpha$ is transcendental for every nonzero algebraic $\\alpha$.\n\n**Connection to Irrationality Measures**: The transcendence of $e$ implies its irrationality measure $\\mu(e) \\geq 2$. Remarkably, the continued fraction $e = [2; 1, 2, 1, 1, 4, 1, 1, 6, \\ldots]$ has a beautifully regular pattern (discovered by Euler), giving $\\mu(e) = 2$ exactly — $e$ is 'as hard to approximate by rationals as possible' for a transcendental number.\n\n**Broader Impact**: The proof technique — constructing auxiliary polynomials with carefully controlled integrality and growth — became the template for transcendence proofs throughout the 20th century, from Siegel's work on $E$-functions (1929) to Baker's theorem on linear forms in logarithms (1966). Baker's theorem earned the Fields Medal and has applications to Diophantine equations, class numbers, and the effective abc conjecture.",
+    "implications": "**Transcendence Theory**: Hermite's 1873 proof that $e$ is transcendental was the first proof of transcendence for a 'naturally occurring' constant (Liouville's 1844 construction produced artificial transcendentals). It directly inspired Lindemann's proof that $\\pi$ is transcendental (1882), which settled the ancient problem of squaring the circle. Together they form the foundation of the Hermite-Lindemann-Weierstrass theorem: $e^\\alpha$ is transcendental for every nonzero algebraic $\\alpha$.\n\n**Connection to Irrationality Measures**: The transcendence of $e$ implies its irrationality measure $\\mu(e) \\geq 2$. Remarkably, the continued fraction $e = [2; 1, 2, 1, 1, 4, 1, 1, 6, \\ldots]$ has a beautifully regular pattern (discovered by Euler), giving $\\mu(e) = 2$ exactly \u2014 $e$ is 'as hard to approximate by rationals as possible' for a transcendental number.\n\n**Broader Impact**: The proof technique \u2014 constructing auxiliary polynomials with carefully controlled integrality and growth \u2014 became the template for transcendence proofs throughout the 20th century, from Siegel's work on $E$-functions (1929) to Baker's theorem on linear forms in logarithms (1966). Baker's theorem earned the Fields Medal and has applications to Diophantine equations, class numbers, and the effective abc conjecture.",
     "openQuestions": [
       "Is e + pi transcendental? (Unknown!)",
       "Is e a normal number?",
@@ -175,7 +176,7 @@
       "authors": "Hermite, Charles",
       "title": "Sur la fonction exponentielle",
       "year": "1873",
-      "venue": "Comptes Rendus de l'Académie des Sciences 77, 18–24, 74–79, 226–233, 285–293",
+      "venue": "Comptes Rendus de l'Acad\u00e9mie des Sciences 77, 18\u201324, 74\u201379, 226\u2013233, 285\u2013293",
       "note": "The original proof that e is transcendental, using auxiliary polynomial constructions"
     },
     {
@@ -207,8 +208,8 @@
     ],
     "namespace": null,
     "lineCount": 267,
-    "axiomCount": 5,
-    "theoremCount": 8,
+    "axiomCount": 4,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "mainTheorems": [


### PR DESCRIPTION
## Summary
- **PiTranscendental.lean**: proved `pi_plus_one_transcendental_axiom` (8→7 axioms)
- **eTranscendental.lean**: proved `e_plus_one_transcendental_axiom` (5→4 axioms)

## Proof Strategy
Contrapositive via algebraic number theory: if α+1 is algebraic over ℤ, transfer to ℚ via `IsFractionRing.isAlgebraic_iff`, subtract the algebraic element 1 using `IsAlgebraic.sub`, conclude α is algebraic over ℚ, transfer back to ℤ, contradiction.

## Files Modified
- `proofs/Proofs/PiTranscendental.lean` — axiom → theorem
- `proofs/Proofs/eTranscendental.lean` — axiom → theorem
- `src/data/proofs/{pi-transcendental,e-transcendental}/meta.json`

🤖 Generated by researcher-1