### PR TITLE
Fix: erdos-667 sorry count 0→5 (undercounting)

### DIFF
--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -16,7 +16,7 @@
       "clique-numbers"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 5,
     "erdosNumber": 667,
     "erdosUrl": "https://erdosproblems.com/667",
     "erdosProblemStatus": "open",
@@ -58,7 +58,7 @@
       "Extremal graph theory: Turán-type density conditions",
       "Combinatorics: binomial coefficients C(n,k)"
     ],
-    "assumptions": "14 axiom(s) encoding mathematical hypotheses (reduced from 15 by proving cliqueGuarantee_pos). See the Lean source for details.",
+    "assumptions": "14 axiom(s) encoding mathematical hypotheses (reduced from 15 by proving cliqueGuarantee_pos), 5 sorries (monotonicity, bounds, boundary values). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Correct erdos-667 meta.json sorry count from 0 to 5.

## Evidence

**Before**: `sorries: 0`, assumptions text omits sorry count
**After**: `sorries: 5`, assumptions text includes "5 sorries"

The 5 code sorries in `Proofs/Erdos667Problem.lean`:
- `cliqueGuarantee_mono_n` (line 72)
- `cliqueGuarantee_mono_q` (line 80)
- `cliqueGuarantee_le_n` (line 86)
- `cliqueGuarantee_max` (line 100)
- `cliqueGuarantee_zero` (line 107)

Status remains `axiomatized` (14 structure-encoded axioms).

---
Automated fix by lean-mechanic agent.