### PR TITLE
Fix erdos-667 meta: axiomCount 14→8, sorries 0→5

### DIFF
--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -16,11 +16,11 @@
       "clique-numbers"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 5,
     "erdosNumber": 667,
     "erdosUrl": "https://erdosproblems.com/667",
     "erdosProblemStatus": "open",
-    "axiomCount": 14,
+    "axiomCount": 8,
     "lineCount": 343,
     "dateAdded": "2026-02-10",
     "mathlibDependencies": [
@@ -58,7 +58,7 @@
       "Extremal graph theory: Turán-type density conditions",
       "Combinatorics: binomial coefficients C(n,k)"
     ],
-    "assumptions": "14 axiom(s) encoding mathematical hypotheses (reduced from 15 by proving cliqueGuarantee_pos). See the Lean source for details.",
+    "assumptions": "8 axiom declarations (cpq, cpq_nonneg, cpq_le_one, cpq_mono_q, cpq_lower_ramsey, cpq_upper_ramsey, cpq_at_max, efrs_bound) and 5 sorries (cliqueGuarantee monotonicity/bounds theorems). Reduced from 14 axioms by concretizing cliqueGuarantee via sSup and proving cliqueGuarantee_pos and extended monotonicity.",
     "mathlib_version": "4.26.0"
   },
   "crossReferences": [
@@ -189,7 +189,7 @@
     ],
     "namespace": "Erdos667",
     "lineCount": 343,
-    "axiomCount": 14,
+    "axiomCount": 8,
     "theoremCount": 22,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Summary
- Fixed `axiomCount: 14` → `8` (research PR #7001 eliminated 6 axioms)
- Fixed `sorries: 0` → `5` (eliminated axioms became sorry-backed theorems)
- Updated `assumptions` text to reflect current state

## Evidence
**meta.json claimed**: 14 axioms, 0 sorries
**Lean file shows**: 8 `axiom` declarations, 5 `sorry` tactics

The 5 sorries are in newly concretized theorems:
- `cliqueGuarantee_mono_n` (line 72)
- `cliqueGuarantee_mono_q` (line 80)
- `cliqueGuarantee_le_n` (line 86)
- `cliqueGuarantee_max` (line 100)
- `cliqueGuarantee_zero` (line 107)

## Risk
HIGH — sorry count mismatch (overclaiming 0 sorries when 5 exist)

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)