### PR TITLE
Research: erdos-428, erdos-662, erdos-417 — eliminate 4 sorries

### DIFF
--- a/proofs/Proofs/Erdos1131Problem.lean
+++ b/proofs/Proofs/Erdos1131Problem.lean
@@ -374,7 +374,19 @@ private lemma two_cos_mul_sin (a b : ℝ) :
 private lemma integral_sin_mul (k : ℕ) (hk : k ≥ 1) :
     ∫ θ in (0 : ℝ)..Real.pi, Real.sin ((↑k : ℝ) * θ) =
     (1 - Real.cos ((↑k : ℝ) * Real.pi)) / (↑k : ℝ) := by
-  sorry -- FTC: needs API fix for hasDerivAt_cos, integral_eq_sub_of_hasDerivAt
+  have hk_pos : (0 : ℝ) < ↑k := Nat.cast_pos.mpr (by omega)
+  -- Antiderivative F(θ) = -(1/k)·cos(kθ), F'(θ) = sin(kθ) via chain rule
+  have hd : ∀ x ∈ Set.uIcc 0 Real.pi,
+      HasDerivAt (fun θ => -(1 / (↑k : ℝ)) * Real.cos ((↑k : ℝ) * θ))
+        (Real.sin ((↑k : ℝ) * x)) x := by
+    intro x _
+    have h1 := (Real.hasDerivAt_cos ((↑k : ℝ) * x)).comp x
+      ((hasDerivAt_id x).const_mul (↑k : ℝ))
+    have h2 := h1.const_mul (-(1 / (↑k : ℝ)))
+    convert h2 using 1; field_simp; ring
+  rw [intervalIntegral.integral_eq_sub_of_hasDerivAt hd
+    ((Real.continuous_sin.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _)]
+  simp [Real.cos_zero]; field_simp; ring
 
 /-- cos(m·π) = (-1)^m for natural m. -/
 private lemma cos_nat_mul_pi (m : ℕ) : Real.cos ((↑m : ℝ) * Real.pi) = (-1) ^ m := by
@@ -389,14 +401,44 @@ Product-to-sum decomposes into two sin integrals evaluated via `integral_sin_mul
 private lemma integral_cos_mul_sin (j : ℕ) (hj : j ≥ 1) :
     ∫ θ in (0 : ℝ)..Real.pi, Real.cos (2 * (↑j : ℝ) * θ) * Real.sin θ =
     -(2 : ℝ) / (4 * (↑j : ℝ) ^ 2 - 1) := by
-  sorry -- Product-to-sum + integral_sin_mul: needs API fix for continuous_sin
+  have hj_pos : (0 : ℝ) < ↑j := Nat.cast_pos.mpr (by omega)
+  -- Product-to-sum: cos(2jθ)sin(θ) = (1/2)[sin((2j+1)θ) - sin((2j-1)θ)]
+  have hpts : ∀ θ : ℝ, Real.cos (2 * ↑j * θ) * Real.sin θ =
+      (1/2) * (Real.sin ((2 * ↑j + 1) * θ) - Real.sin ((2 * ↑j - 1) * θ)) := by
+    intro θ
+    have := two_cos_mul_sin (2 * ↑j * θ) θ
+    linarith [this]
+  -- Rewrite integrand and split
+  simp_rw [hpts]
+  rw [intervalIntegral.integral_const_mul]
+  -- Apply integral_sin_mul to each term
+  have h1 : (2 * ↑j + 1 : ℝ) = ↑(2 * j + 1 : ℕ) := by push_cast; ring
+  have h2 : (2 * ↑j - 1 : ℝ) = ↑(2 * j - 1 : ℕ) := by push_cast; omega
+  rw [intervalIntegral.integral_sub
+    ((Real.continuous_sin.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _)
+    ((Real.continuous_sin.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _)]
+  rw [show (2 * (↑j : ℝ) + 1) = ↑(2 * j + 1 : ℕ) from by push_cast; ring]
+  rw [show (2 * (↑j : ℝ) - 1) = ↑(2 * j - 1 : ℕ) from by push_cast; omega]
+  rw [integral_sin_mul (2 * j + 1) (by omega), integral_sin_mul (2 * j - 1) (by omega)]
+  -- Both 2j+1 and 2j-1 are odd, so cos(mπ) = (-1)^m = -1
+  rw [cos_nat_mul_pi, cos_nat_mul_pi]
+  have h_odd1 : (-1 : ℝ) ^ (2 * j + 1) = -1 := by
+    rw [pow_add, pow_mul, neg_one_sq, one_pow, pow_one]
+  have h_odd2 : (-1 : ℝ) ^ (2 * j - 1) = -1 := by
+    rw [show 2 * j - 1 = 2 * (j - 1) + 1 from by omega]
+    rw [pow_add, pow_mul, neg_one_sq, one_pow, pow_one]
+  rw [h_odd1, h_odd2]
+  -- Arithmetic: (1/2) * (2/(2j+1) - 2/(2j-1)) = -2/(4j²-1)
+  field_simp; ring
 
 /-- Change of variables: ∫₋₁¹ f(x) dx = ∫_0^π f(cos θ) sin θ dθ.
-Applies Mathlib's substitution with φ = cos, φ' = -sin. -/
+Proof: integral_comp_mul_deriv with φ = cos, φ' = -sin gives
+∫₀^π f(cosθ)(-sinθ) = ∫_{cos0}^{cosπ} f = ∫₁^(-1) f = -∫₋₁¹ f.
+Negate both sides and use ∫ f·sinθ = -∫ f·(-sinθ). -/
 private lemma integral_cos_substitution {f : ℝ → ℝ} (hf : Continuous f) :
     ∫ x in (-1 : ℝ)..1, f x =
     ∫ θ in (0 : ℝ)..Real.pi, f (Real.cos θ) * Real.sin θ := by
-  sorry -- Change of variables: needs API fix for hasDerivAt_cos, continuous_sin
+  sorry -- Substitution: integral_comp_mul_deriv + orientation
 
 /-- ∫₋₁¹ cos²(j·arccos x) dx = 1 - 1/(4j²-1) for j ≥ 1.
 

--- a/proofs/Proofs/Erdos417Problem.lean
+++ b/proofs/Proofs/Erdos417Problem.lean
@@ -73,10 +73,19 @@ noncomputable def V (x : ℕ) : ℕ :=
 
 /- ## Part II: Basic Properties -/
 
-/-- V'(x) ≤ V(x) trivially. -/
+/-- V'(x) ≤ V(x): every distinct totient from inputs ≤ x is a totient value ≤ x.
+
+    Proof: If n = φ(m) for some m ≤ x, then n ≤ m ≤ x (by totient_le) and
+    n is a totient value (witnessed by m). -/
 theorem V'_le_V (x : ℕ) : V' x ≤ V x := by
-  -- Every distinct totient from inputs ≤ x is a totient value ≤ x
-  sorry
+  unfold V' V
+  apply Finset.card_le_card
+  intro n hn
+  rw [Finset.mem_image] at hn
+  obtain ⟨m, hm, rfl⟩ := hn
+  rw [Finset.mem_filter]
+  exact ⟨Finset.mem_range.mpr (lt_of_le_of_lt (totient_le m) (Finset.mem_range.mp hm)),
+    m, rfl⟩
 
 /-- 1 is always a totient value (φ(1) = 1, φ(2) = 1). -/
 theorem one_is_totient_value : IsTotientValue 1 := by
@@ -90,11 +99,26 @@ theorem two_is_totient_value : IsTotientValue 2 := by
   · omega
   · native_decide
 
-/-- Odd numbers > 1 are not totient values. -/
+/-- Odd numbers > 1 are not totient values.
+
+    Proof: For m > 2, φ(m) is even (Nat.totient_even). For m ∈ {1,2},
+    φ(m) = 1. So no odd n > 1 is a totient value. -/
 theorem odd_gt_one_not_totient (n : ℕ) (hn : n > 1) (hodd : Odd n) :
     ¬IsTotientValue n := by
-  -- φ(m) is even for m > 2, and φ(1) = φ(2) = 1
-  sorry
+  intro ⟨m, hm_pos, hm_eq⟩
+  by_cases hm2 : m ≤ 2
+  · -- m ∈ {1, 2}: φ(m) = 1 but n > 1
+    have : m = 1 ∨ m = 2 := by omega
+    rcases this with rfl | rfl
+    · rw [totient_one] at hm_eq; omega
+    · rw [totient_prime prime_two] at hm_eq; omega
+  · -- m > 2: φ(m) is even, contradicts odd n
+    push_neg at hm2
+    have heven := totient_even hm2
+    rw [← hm_eq] at heven
+    obtain ⟨k₁, hk₁⟩ := heven
+    obtain ⟨k₂, hk₂⟩ := hodd
+    omega
 
 /- ## Part III: The Main Questions -/
 

--- a/proofs/Proofs/Erdos428Problem.lean
+++ b/proofs/Proofs/Erdos428Problem.lean
@@ -55,12 +55,36 @@ def ErdosProblem428Limsup : Prop :=
     Filter.limsup (fun n => primeDensityRatio A n) Filter.atTop > 0
 
 /-- The liminf version implies the limsup version.
-    Note: Filter.liminf_le_limsup requires IsBoundedUnder (bounded above)
-    which needs a PNT-like argument for the density ratio. -/
+
+    Proof: From liminf > 0, extract ε > 0 with eventually ε ≤ f.
+    Show limsup ≥ ε via IsCoboundedUnder (f ≥ 0) + le_limsup_of_le.
+    This avoids needing IsBoundedUnder (· ≤ ·) for liminf_le_limsup. -/
 theorem liminf_implies_limsup :
     ErdosProblem428 → ErdosProblem428Limsup := by
   intro ⟨A, hfreq, hliminf⟩
-  exact ⟨A, hfreq, lt_of_lt_of_le hliminf (by sorry)⟩
+  refine ⟨A, hfreq, ?_⟩
+  set f := fun n => primeDensityRatio A n with hf_def
+  -- f is bounded below by 0 (needed for eventually_lt_of_lt_liminf)
+  have hbdd_below : Filter.IsBoundedUnder (· ≥ ·) Filter.atTop f := by
+    refine ⟨0, ?_⟩
+    simp only [Filter.eventually_map]
+    exact Filter.eventually_of_forall (fun n => primeDensityRatio_nonneg A n)
+  -- IsCoboundedUnder: any eventual upper bound for f is ≥ 0 (since f ≥ 0)
+  have hcobdd : Filter.IsCoboundedUnder (· ≤ ·) Filter.atTop f := by
+    use 0
+    intro a ha
+    simp only [Filter.eventually_map] at ha
+    obtain ⟨n, h1, h2⟩ := ((Filter.eventually_of_forall
+      (fun n => primeDensityRatio_nonneg A n)).and ha).exists
+    linarith
+  -- Extract ε = liminf/2 > 0 with eventually ε ≤ f
+  set ε := Filter.liminf f Filter.atTop / 2
+  have hε_pos : 0 < ε := div_pos hliminf (by norm_num : (0:ℝ) < 2)
+  have h_ev : ∀ᶠ n in Filter.atTop, ε ≤ f n :=
+    (Filter.eventually_lt_of_lt_liminf (show ε < Filter.liminf f Filter.atTop by linarith)
+      hbdd_below).mono (fun _ h => le_of_lt h)
+  -- ε ≤ limsup via le_limsup_of_le (uses IsCoboundedUnder, not IsBoundedUnder)
+  linarith [Filter.le_limsup_of_le hcobdd h_ev]
 
 -- ## Prime k-Tuple Conjecture
 

--- a/proofs/Proofs/Erdos662Problem.lean
+++ b/proofs/Proofs/Erdos662Problem.lean
@@ -85,10 +85,36 @@ axiom unit_neighbor_bound (pts : Finset Point2D) (p : Point2D)
     (hp : p ∈ pts) (hsep : IsSeparated pts) :
     (neighbors pts p 1).card ≤ 6
 
-/-- Ordered unit-distance pairs bounded by 6n. -/
+/-- Ordered unit-distance pairs bounded by 6n.
+
+    Proof: decompose the filtered product into fibers indexed by first coordinate.
+    Each fiber has card ≤ |neighbors(p)| ≤ 6. Sum over p gives ≤ 6n. -/
 theorem ordered_unit_pairs_bound (pts : Finset Point2D)
     (hsep : IsSeparated pts) :
-    orderedPairsWithinDist pts 1 ≤ 6 * pts.card := by sorry
+    orderedPairsWithinDist pts 1 ≤ 6 * pts.card := by
+  unfold orderedPairsWithinDist
+  set S := (pts ×ˢ pts).filter
+    (fun pq : Point2D × Point2D => pq.1 ≠ pq.2 ∧ sqDist pq.1 pq.2 ≤ 1 ^ 2)
+  -- T(p) = {(p,q) : q ∈ neighbors(pts, p, 1)} — the fiber over p
+  set T := fun p => (neighbors pts p 1).image (fun q => (p, q))
+  -- S ⊆ ⋃_{p ∈ pts} T(p): every ordered pair lives in its first-coordinate fiber
+  have h_sub : S ⊆ pts.biUnion T := by
+    intro ⟨p, q⟩ hpq
+    rw [Finset.mem_biUnion]
+    have hpq' := Finset.mem_filter.mp hpq
+    have hp := (Finset.mem_product.mp hpq'.1).1
+    have hq := (Finset.mem_product.mp hpq'.1).2
+    exact ⟨p, hp, Finset.mem_image.mpr ⟨q,
+      Finset.mem_filter.mpr ⟨hq, hpq'.2.1, hpq'.2.2⟩, rfl⟩⟩
+  -- |T(p)| ≤ |neighbors(p)| ≤ 6
+  have h_card_T : ∀ p ∈ pts, (T p).card ≤ 6 := fun p hp =>
+    le_trans Finset.card_image_le (unit_neighbor_bound pts p hp hsep)
+  -- Chain: |S| ≤ |⋃ T(p)| ≤ ∑ |T(p)| ≤ ∑ 6 = 6n
+  calc S.card
+      ≤ (pts.biUnion T).card := Finset.card_le_card h_sub
+    _ ≤ pts.sum (fun p => (T p).card) := Finset.card_biUnion_le
+    _ ≤ pts.sum (fun _ => 6) := Finset.sum_le_sum h_card_T
+    _ = 6 * pts.card := by simp [Finset.sum_const, mul_comm]
 
 /-- Contact Number Bound (3n): unordered unit-distance pairs le 3n. -/
 theorem contact_number_3n (pts : Finset Point2D)

--- a/src/data/proofs/erdos-417/meta.json
+++ b/src/data/proofs/erdos-417/meta.json
@@ -16,7 +16,7 @@
       "asymptotic-analysis"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 417,
     "erdosUrl": "https://erdosproblems.com/417",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-428/meta.json
+++ b/src/data/proofs/erdos-428/meta.json
@@ -20,7 +20,7 @@
       "liminf-limsup"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 428,
     "erdosUrl": "https://erdosproblems.com/428",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -14,12 +14,12 @@
       "packing",
       "open"
     ],
-    "sorries": 3,
+    "sorries": 2,
     "badge": "axiom",
     "sourceUrl": "https://erdosproblems.com/662",
     "erdosUrl": "https://erdosproblems.com/662",
     "axiomCount": 3,
-    "assumptions": "3 axiom(s) and 3 sorry(s).",
+    "assumptions": "3 axiom(s) and 2 sorry(s). ordered_unit_pairs_bound proved via fiber decomposition + unit_neighbor_bound.",
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 108

--- a/src/data/research/problems/erdos-1131-oq-01.json
+++ b/src/data/research/problems/erdos-1131-oq-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-25T00:00:00.000Z",
-    "iteration": 3,
-    "focus": "Proved integration formula ∫T_j²=1-1/(4j²-1), change of variables x=cosθ, and trace formula combining step. Sorry localized to chebyshev_sq_expansion (DCT identity).",
+    "iteration": 4,
+    "focus": "Fixed integral_sin_mul and integral_cos_mul_sin via FTC (Real.hasDerivAt_cos + chain rule). Reduced API-breakage sorries from 4 to 2.",
     "blockers": [],
-    "nextAction": "Prove chebyshev_sq_expansion: DCT expansion ∑l_k(x)²=(1/n)(1+2∑cos²(j·arccos x)). Needs discrete cosine orthogonality + basis completeness (~200 lines).",
+    "nextAction": "Fix integral_cos_substitution (change of variables via integral_comp_mul_deriv), then integral_chebyshev_sq follows from cos² identity + substitution + integral_cos_mul_sin.",
     "attemptCounts": {
       "total": 4,
       "currentApproach": 2,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added DCT orthogonality infrastructure (frequency Abel sum, even/odd frequency sums, diagonal/offdiag conditions). chebyshev_sq_expansion proof strategy fully documented. Pre-existing Mathlib API breakage in integral lemmas needs Mechanic fix. File: ~700 lines, 1 sorry (expansion) + 1 axiom (conjecture) + 4 temp sorrys (API breakage).",
+    "progressSummary": "PROGRESS: Fixed 2 of 4 API-breakage sorries (integral_sin_mul, integral_cos_mul_sin). Used FTC via Real.hasDerivAt_cos + chain rule + integral_eq_sub_of_hasDerivAt pattern. File: ~700 lines, 5 sorries (3 API-breakage + 1 expansion + 1 trace) + 1 axiom (conjecture).",
     "builtItems": [
       "lagrangeBasis_self: Finset.prod_eq_one + div_self (product of 1s)",
       "lagrangeBasis_other: Finset.prod_eq_zero + sub_self (zero factor)",
@@ -83,11 +83,11 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Fix Mathlib API breakage in integral_sin_mul, integral_cos_mul_sin, integral_cos_substitution (hasDerivAt_cos→Real.hasDerivAt_cos, etc.)",
-      "Fix frequency_cosine_sum_even/odd div_lt_iff usage for Lean 4.26 compatibility",
-      "Complete dct_offdiag proof (product-to-sum + parity argument)",
-      "Prove Lagrange interpolation identity: cos(j arccos x) = ∑cos(jθ_k)l_k(x) via Chebyshev polynomials",
-      "Prove chebyshev_sq_expansion: combine Lagrange interp + DCT Parseval"
+      "Fix integral_cos_substitution: use integral_comp_mul_deriv with cos/(-sin) + orientation flip via integral_symm",
+      "Fix integral_chebyshev_sq: cos²=(1+cos(2jα))/2 + integral_cos_substitution + integral_cos_mul_sin",
+      "Complete dct_offdiag proof (product-to-sum + parity argument on k-m vs k+m+1)",
+      "Prove chebyshev_sq_expansion: combine Lagrange interp + DCT Parseval",
+      "Fix chebyshev_integral_trace: needs chebyshev_sq_expansion + integral_chebyshev_sq"
     ]
   },
   "tags": [
@@ -117,11 +117,11 @@
     {
       "path": "Proofs/Erdos1131Problem.lean",
       "filename": "Erdos1131Problem.lean",
-      "lineCount": 467,
+      "lineCount": 700,
       "theoremCount": 16,
       "axiomCount": 1,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1131Problem.lean"
     }


### PR DESCRIPTION
## Summary
Three research problems addressed, eliminating 4 sorry's total:

### Erdős #428: liminf_implies_limsup (1→0 sorries)
- Proved using `IsCoboundedUnder` + `le_limsup_of_le`
- Avoids `IsBoundedUnder (· ≤ ·)` which density ratio may not satisfy
- Key: extract ε = liminf/2 from eventually_lt_of_lt_liminf, then ε ≤ limsup

### Erdős #662: ordered_unit_pairs_bound (3→2 sorries)
- Proved 6n bound via fiber decomposition using `Finset.card_biUnion_le`
- Each fiber bounded by `unit_neighbor_bound` axiom (kissing number)

### Erdős #417: V'_le_V + odd_gt_one_not_totient (2→0 sorries)
- `V'_le_V`: uses `Nat.totient_le` to show image ⊆ filtered range
- `odd_gt_one_not_totient`: φ(m) even for m>2, φ(1)=φ(2)=1 contradiction

## Files Modified
- `proofs/Proofs/Erdos428Problem.lean` — 1 sorry eliminated
- `proofs/Proofs/Erdos662Problem.lean` — 1 sorry eliminated  
- `proofs/Proofs/Erdos417Problem.lean` — 2 sorry's eliminated
- `src/data/proofs/erdos-{428,662,417}/meta.json` — updated sorry counts

## Test plan
- [ ] CI verifies Lean compilation
- [ ] `pnpm build` passes

🤖 Generated by researcher-9