### PR TITLE
Enrich erdos-750: expand cross-refs (3->10), deepen prerequisites

### DIFF
--- a/src/data/proofs/erdos-750/meta.json
+++ b/src/data/proofs/erdos-750/meta.json
@@ -64,10 +64,11 @@
       "**Problem #75 connection:** ℵ₁-chromatic graphs with polynomial independence would imply all sublinear cases"
     ],
     "prerequisites": [
-      "Graph coloring theory: chromatic number, independent sets, and bipartite graphs",
-      "Asymptotic analysis: growth rates of functions, o(m) and O(m) notation",
-      "Lovasz Local Lemma and its applications in probabilistic combinatorics",
-      "Shift graphs and Kneser-type graph constructions"
+      "Graph coloring: chromatic number $\\chi(G)$, independent sets, bipartite graphs ($\\chi = 2$), almost-bipartite condition $\\alpha(G) \\ge (1-\\varepsilon)|V|$",
+      "Probabilistic combinatorics: Lovász Local Lemma for constructing colorings avoiding bad events",
+      "Shift graphs: $S(n, r)$ with vertices = $r$-element subsets of $[n]$, edges from shifting — achieve high $\\chi$ with large $\\alpha$",
+      "Kneser-type constructions: graphs on set systems with chromatic number exceeding clique number",
+      "Asymptotic analysis: $o(m)$, $O(m)$ notation for growth rate of independence number relative to vertex count"
     ]
   },
   "sections": [
@@ -151,17 +152,52 @@
     {
       "targetId": "erdos-920",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, open, ramsey-theory"
+      "description": "Chromatic number and Ramsey-type constraints — both study how structural graph properties (near-bipartiteness, Ramsey conditions) interact with chromatic number"
     },
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, ramsey-theory"
+      "description": "Ramsey number asymptotics — both connect graph coloring to Ramsey-theoretic phenomena, with independent set size as the bridge parameter"
     },
     {
       "targetId": "erdos-108",
+      "relationship": "companion",
+      "description": "Chromatic number and girth — Erdős's probabilistic proof that high chromatic number can coexist with high girth is closely related to constructing almost-bipartite graphs with high $\\chi$"
+    },
+    {
+      "targetId": "erdos-1011",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, ramsey-theory"
+      "description": "Chromatic number and Turán-type constraints — both study how forbidding dense substructures affects chromatic number; almost-bipartite means nearly triangle-free"
+    },
+    {
+      "targetId": "erdos-1032",
+      "relationship": "related",
+      "description": "Critical graphs and minimum degree — structural understanding of graphs with high chromatic number, relevant to the almost-bipartite construction"
+    },
+    {
+      "targetId": "erdos-1067",
+      "relationship": "related",
+      "description": "Infinite graphs and chromatic number — extends the almost-bipartite question to infinite graph settings where set-theoretic considerations arise"
+    },
+    {
+      "targetId": "erdos-111",
+      "relationship": "companion",
+      "description": "Chromatic number of bipartite-like graphs — directly related: #111 studies chromatic number in infinite combinatorics with bipartite structure, complementing #750's near-bipartite condition"
+    },
+    {
+      "targetId": "erdos-1091",
+      "relationship": "related",
+      "description": "Chromatic number of $K_4$-free graphs with odd cycle constraints — related structural conditions on graphs with bounded clique number and high chromatic number"
+    },
+    {
+      "targetId": "erdos-1104",
+      "relationship": "related",
+      "description": "Triangle-free graphs and chromatic number — almost-bipartite graphs are nearly triangle-free; both study how sparse local structure allows high global chromatic number"
+    },
+    {
+      "targetId": "erdos-1092",
+      "relationship": "related",
+      "description": "Extremal graph theory and chromatic number — both study the boundary between graph-theoretic sparseness conditions and high chromatic number"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Expanded cross-references from 3 to 10 with mathematically specific descriptions
- Connected to chromatic number entries (erdos-108, erdos-1011, erdos-1032, erdos-1067, erdos-111, erdos-1091, erdos-1104, erdos-1092)
- Deepened prerequisites with LaTeX formatting and specific technique names (Lovász Local Lemma, shift graphs, Kneser constructions)

Enrichment pass for erdos-750 (passes: 0 → 1).