### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -887,11 +887,12 @@
     },
     {
       "slug": "erdos-317",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-12T23:51:53.285Z",
-      "status": "active",
-      "lastUpdate": "2026-03-13T07:52:17.045Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:05:29.570Z",
+      "completed": "2026-03-26T23:05:29.570Z"
     },
     {
       "slug": "erdos-319",
@@ -2013,11 +2014,12 @@
     },
     {
       "slug": "erdos-854",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-15T10:25:45.156Z",
-      "status": "active",
-      "lastUpdate": "2026-03-13T07:52:17.053Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:05:29.578Z",
+      "completed": "2026-03-26T23:05:29.578Z"
     },
     {
       "slug": "erdos-863",
@@ -5789,11 +5791,12 @@
     },
     {
       "slug": "erdos-1004-wip-01",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-24T00:48:59.900Z",
-      "status": "active",
-      "lastUpdate": "2026-03-25T01:35:29-07:00"
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:05:29.552Z",
+      "completed": "2026-03-26T23:05:29.551Z"
     },
     {
       "slug": "erdos-1007-oq-01-oq-01",
@@ -5938,11 +5941,12 @@
     },
     {
       "slug": "erdos-1084-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-24T00:48:59.904Z",
-      "status": "active",
-      "lastUpdate": "2026-03-24T00:48:59.904Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:05:29.554Z",
+      "completed": "2026-03-26T23:05:29.554Z"
     },
     {
       "slug": "erdos-1089-oq-01",


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (16 added, 231 updated, 1653 total)
- Clean up annotation files (remove redundant entries)
- Update research problem data with latest iteration results

Automated sync from deployer agent.