### PR TITLE
Research: erdos-1060 — trivial upper bound f(n)≤n and properties

### DIFF
--- a/proofs/Proofs/Erdos1060Problem.lean
+++ b/proofs/Proofs/Erdos1060Problem.lean
@@ -208,7 +208,53 @@ theorem f_of_zero : f 0 = 1 := by
   rw [h_eq, Set.ncard_singleton]
 
 /-
-## Part V: Upper Bound Conjectures (OPEN)
+## Part V: Trivial Upper Bound
+-/
+
+/--
+**Trivial Upper Bound:** f(n) ≤ n for n > 0.
+
+Since every solution k to g(k) = n satisfies 1 ≤ k ≤ n, there are at most n solutions.
+The open conjectures (Part VI) ask for dramatically better bounds.
+-/
+theorem f_le_n (n : ℕ) (hn : n > 0) : f n ≤ n := by
+  rw [f_eq_f' n hn]
+  unfold f'
+  calc ((Finset.Icc 1 n).filter (fun k => g k = n)).card
+      ≤ (Finset.Icc 1 n).card := Finset.card_filter_le _ _
+    _ = n := by rw [Nat.card_Icc]; omega
+
+/--
+g is positive for positive inputs: g(k) > 0 when k > 0.
+-/
+theorem g_pos (k : ℕ) (hk : 0 < k) : 0 < g k := by
+  unfold g
+  exact Nat.mul_pos hk (sigma_pos k hk)
+
+/--
+g is strictly greater than k for k ≥ 2, since σ(k) ≥ k + 1 (both 1 and k divide k).
+-/
+theorem g_gt_k (k : ℕ) (hk : k ≥ 2) : g k > k := by
+  unfold g
+  -- σ(k) ≥ k + 1 since {1, k} ⊆ divisors(k) and 1 ≠ k
+  have h1 : 1 ∈ k.divisors := Nat.mem_divisors.mpr ⟨one_dvd k, by omega⟩
+  have hk_div : k ∈ k.divisors := Nat.mem_divisors.mpr ⟨dvd_refl k, by omega⟩
+  have hne : (1 : ℕ) ≠ k := by omega
+  have h_sub : {1, k} ⊆ k.divisors := by
+    intro x hx; simp at hx; rcases hx with rfl | rfl <;> assumption
+  have h_sum : sigma k ≥ k + 1 := by
+    unfold sigma
+    calc k.divisors.sum id
+        ≥ ({1, k} : Finset ℕ).sum id :=
+          Finset.sum_le_sum_of_subset_of_nonneg h_sub (fun _ _ _ => Nat.zero_le _)
+      _ = 1 + k := by rw [Finset.sum_pair hne]; simp [id]
+      _ = k + 1 := by ring
+  calc k * sigma k ≥ k * (k + 1) := Nat.mul_le_mul_left k h_sum
+    _ = k * k + k := by ring
+    _ > k := by nlinarith
+
+/-
+## Part VI: Upper Bound Conjectures (OPEN)
 -/
 
 /--
@@ -234,7 +280,7 @@ axiom erdos_1060_strong_conjecture :
       (f n : ℝ) ≤ (Real.log n) ^ C
 
 /-
-## Part VI: OEIS Connection
+## Part VII: OEIS Connection
 -/
 
 /--
@@ -264,7 +310,7 @@ theorem mem_A327153_iff (n : ℕ) (hn : n > 0) :
       ⟨hk_pos, hgk ▸ k_le_g k hk_pos⟩, hgk⟩⟩
 
 /-
-## Part VII: Examples and Computations
+## Part VIII: Examples and Computations
 -/
 
 /--

--- a/research/problems/erdos-1060/knowledge.md
+++ b/research/problems/erdos-1060/knowledge.md
@@ -83,6 +83,29 @@ Back to the problem
 - File is now in good shape: 0 sorries, well-structured
 - Consider adding more supporting lemmas (e.g., bounds on f for specific n)
 
+### Session 2026-03-26 (Session 2) - Trivial Upper Bound and Properties
+
+**Mode**: REVISIT
+**Outcome**: progress (3 new theorems)
+
+#### What I Did
+- Proved `f_le_n`: **trivial upper bound f(n) ≤ n** for n > 0. Uses f_eq_f' bridge, Finset.card_filter_le, and Nat.card_Icc. This establishes the baseline that the open conjectures dramatically improve upon.
+- Proved `g_pos`: g(k) > 0 for k > 0. Direct from Nat.mul_pos and sigma_pos.
+- Proved `g_gt_k`: g(k) > k for k ≥ 2. Key step: σ(k) ≥ k+1 because {1,k} ⊆ divisors(k) with 1 ≠ k. Uses Finset.sum_le_sum_of_subset_of_nonneg (same pattern as sigma1_ge_succ in Erdos413Problem.lean).
+- Renumbered Part sections (V-VIII) for consistency.
+
+#### Key Findings
+- The pattern `sum_le_sum_of_subset_of_nonneg` + `sum_pair` is well-established in the codebase (cf. Erdos413Problem.lean:445-460)
+- The `card_filter_le` + `Nat.card_Icc; omega` pattern matches Erdos1000Problem.lean:62-64 exactly
+- Problem is now essentially complete: 0 sorries, 2 OPEN conjecture axioms, 15 theorems
+
+#### Files Modified
+- `proofs/Proofs/Erdos1060Problem.lean` (3 new theorems: f_le_n, g_pos, g_gt_k)
+
+#### Next Steps
+- Problem is complete — 2 axioms are the open conjectures themselves
+- No further work needed unless the conjectures are resolved
+
 ---
 
 *Generated from erdosproblems.com on 2026-01-15*

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -54,10 +54,13 @@
       "Concrete examples: g(2)=6, g(3)=12, g(5)=30, g(6)=72, g(7)=56",
       "sigma_mul_coprime theorem: σ multiplicativity via ArithmeticFunction bridge",
       "f_eq_f theorem: Set.ncard = Finset.card characterization",
-      "mem_A327153_iff theorem: OEIS A327153 membership for n > 0"
+      "mem_A327153_iff theorem: OEIS A327153 membership for n > 0",
+      "f_le_n theorem: trivial upper bound f(n) ≤ n for n > 0",
+      "g_pos theorem: g(k) > 0 for k > 0",
+      "g_gt_k theorem: g(k) > k for k ≥ 2 (σ(k) ≥ k+1)"
     ],
     "axiomCount": 2,
-    "lineCount": 304,
+    "lineCount": 353,
     "assumptions": "2 axiom(s) (open conjectures). All supporting lemmas fully proved."
   },
   "overview": {
@@ -120,27 +123,35 @@
       "mathContext": "$f(1) = 1$ (only $k=1$ gives $g(1) = 1\\cdot 1 = 1$). $f(0) = 1$ (only $k=0$ gives $g(0) = 0$). Most values of $n$ have $f(n) = 0$ (not in the range of $g$)."
     },
     {
+      "id": "trivial-upper-bound",
+      "title": "Trivial Upper Bound",
+      "summary": "f_le_n, g_pos, g_gt_k theorems",
+      "startLine": 211,
+      "endLine": 257,
+      "mathContext": "**Trivial upper bound:** $f(n) \\leq n$ for $n > 0$, since solutions $k$ lie in $[1,n]$. Also $g(k) > 0$ for $k > 0$, and $g(k) > k$ for $k \\geq 2$ (because $\\sigma(k) \\geq k+1$ when both $1$ and $k$ divide $k$). The open conjectures ask for dramatically better bounds than $f(n) \\leq n$."
+    },
+    {
       "id": "conjectures",
       "title": "Upper Bound Conjectures (Open)",
       "summary": "Weak and strong conjecture axioms",
-      "startLine": 148,
-      "endLine": 173,
+      "startLine": 259,
+      "endLine": 283,
       "mathContext": "Weak: $f(n) \\leq n^{o(1/\\log\\log n)}$, meaning for any $\\varepsilon > 0$, eventually $f(n) \\leq n^{\\varepsilon/\\log\\log n}$. Strong: $f(n) \\leq (\\log n)^C$ for some absolute constant $C$. Both remain OPEN."
     },
     {
       "id": "oeis",
       "title": "OEIS Connection",
       "summary": "A327153 definition and membership",
-      "startLine": 174,
-      "endLine": 202,
+      "startLine": 285,
+      "endLine": 313,
       "mathContext": "OEIS A327153: the set $\\{n : f(n) > 0\\} = \\{g(k) : k \\geq 1\\} = \\{1, 6, 12, 30, 56, 72, \\ldots\\}$. This is the range of $g(k) = k\\sigma(k)$."
     },
     {
       "id": "examples",
       "title": "Examples and Computations",
       "summary": "Concrete verified examples using native_decide",
-      "startLine": 203,
-      "endLine": 241,
+      "startLine": 315,
+      "endLine": 353,
       "mathContext": "Verified: $g(2) = 6$, $g(3) = 12$, $g(5) = 30$, $g(6) = 72$, $g(7) = 56$. For primes $p$: $g(p) = p(p+1)$, giving infinitely many values in the range."
     }
   ],
@@ -191,9 +202,9 @@
       "Finset"
     ],
     "namespace": "Erdos1060",
-    "lineCount": 304,
+    "lineCount": 353,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 5
   }
 }


### PR DESCRIPTION
## Summary
- Prove **f_le_n**: trivial upper bound f(n) ≤ n for n > 0 (baseline the open conjectures improve upon)
- Prove **g_pos**: g(k) > 0 for k > 0
- Prove **g_gt_k**: g(k) > k for k ≥ 2 (via σ(k) ≥ k+1)
- Renumber section headers for consistency (V→VIII)

## Progress
- 15 theorems, 0 sorries, 2 axioms (OPEN conjectures)
- Problem is now essentially complete

## Findings
- `sum_le_sum_of_subset_of_nonneg` + `sum_pair` pattern is well-established (cf. Erdos413:445)
- `card_filter_le` + `Nat.card_Icc; omega` pattern matches Erdos1000:62-64

## Status
**Outcome**: completed
**Next Steps**: Problem complete — 2 axioms are the open conjectures themselves

🤖 Generated by researcher-2