### PR TITLE
Research: erdos-422 — computable definition, prove initial values (5→4 axioms)

### DIFF
--- a/proofs/Proofs/Erdos422Problem.lean
+++ b/proofs/Proofs/Erdos422Problem.lean
@@ -21,49 +21,78 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Tactic
 
-/- ## Definition -/
+/- ## Computable Definition -/
 
-/-- The Erdős–Hofstadter recursive sequence. Defined partially since
-    well-definedness for all n is unknown. -/
-noncomputable def hofstadterF : ℕ → ℕ
-  | 0 => 0  -- not used; sequence starts at 1
-  | 1 => 1
-  | 2 => 1
-  | n + 3 => hofstadterF (n + 3 - hofstadterF (n + 2)) +
-              hofstadterF (n + 3 - hofstadterF (n + 1))
+/-- Compute the Hofstadter sequence values f(0), f(1), ..., f(n) as a list.
+    f(0) = 0 (sentinel), f(1) = f(2) = 1, and for k ≥ 3:
+    f(k) = f(k - f(k-1)) + f(k - f(k-2)).
+    Out-of-bounds lookups default to 0, making this total. -/
+def hofstadterFList : ℕ → List ℕ
+  | 0 => [0]
+  | 1 => [0, 1]
+  | 2 => [0, 1, 1]
+  | n + 3 =>
+      let prev := hofstadterFList (n + 2)
+      let k := n + 3
+      let fk1 := prev.getD (k - 1) 0
+      let fk2 := prev.getD (k - 2) 0
+      let v1 := prev.getD (k - fk1) 0
+      let v2 := prev.getD (k - fk2) 0
+      prev ++ [v1 + v2]
 
-/-- The sequence is well-defined at n if the recursive indices stay positive. -/
+/-- The Hofstadter sequence from Erdős Problem #422 (OEIS A005185).
+    Total computable function agreeing with the recursion when well-defined. -/
+def hofstadterF (n : ℕ) : ℕ := (hofstadterFList n).getD n 0
+
+/- ## Proved Initial Values -/
+
+theorem hofstadterF_one : hofstadterF 1 = 1 := by native_decide
+theorem hofstadterF_two : hofstadterF 2 = 1 := by native_decide
+theorem hofstadterF_three : hofstadterF 3 = 2 := by native_decide
+theorem hofstadterF_four : hofstadterF 4 = 3 := by native_decide
+theorem hofstadterF_five : hofstadterF 5 = 3 := by native_decide
+theorem hofstadterF_six : hofstadterF 6 = 4 := by native_decide
+
+/-- The first six values of the Hofstadter sequence match OEIS A005185.
+    Proved from the computable definition. -/
+theorem initial_values :
+    hofstadterF 1 = 1 ∧ hofstadterF 2 = 1 ∧
+    hofstadterF 3 = 2 ∧ hofstadterF 4 = 3 ∧
+    hofstadterF 5 = 3 ∧ hofstadterF 6 = 4 :=
+  ⟨hofstadterF_one, hofstadterF_two, hofstadterF_three,
+   hofstadterF_four, hofstadterF_five, hofstadterF_six⟩
+
+/- ## Well-Definedness -/
+
+/-- The recursion is well-defined at index k if the recursive lookups
+    stay within the previously computed range. -/
+def WellDefinedAt (k : ℕ) : Prop :=
+  k ≥ 3 → hofstadterF (k - 1) ≥ 1 ∧ hofstadterF (k - 1) < k ∧
+           hofstadterF (k - 2) ≥ 1 ∧ hofstadterF (k - 2) < k
+
+/-- The sequence is well-defined up to index n. -/
 def IsWellDefined (n : ℕ) : Prop :=
-  ∀ k ≤ n, k ≥ 3 → hofstadterF (k - 1) < k ∧ hofstadterF (k - 2) < k
+  ∀ k, k ≤ n → WellDefinedAt k
 
-/- ## Main Questions -/
+/- ## Open Questions -/
 
-/-- **Well-Definedness**: is f(n) well-defined for all n? -/
-axiom erdos_422_well_defined :
-  ∀ n : ℕ, IsWellDefined n
+/-- **Well-Definedness** (OPEN): Is the recursion well-defined for all n?
+    It is not known whether the recursive indices always stay in bounds. -/
+axiom erdos_422_well_defined : ∀ n : ℕ, IsWellDefined n
 
-/-- **Missing Integers**: does f miss infinitely many positive integers? -/
+/-- **Missing Integers** (OPEN): Does f miss infinitely many positive integers? -/
 axiom erdos_422_misses_infinitely :
   Set.Infinite {m : ℕ | m > 0 ∧ ∀ n, hofstadterF n ≠ m}
 
-/-- **Surjectivity Question**: is f surjective on positive integers? -/
-axiom erdos_422_surjectivity :
+/-- **Non-Surjectivity** (OPEN): Is f non-surjective on positive integers? -/
+axiom erdos_422_not_surjective :
   ¬Function.Surjective (fun n : ℕ => hofstadterF (n + 1))
 
-/-- **Growth Rate**: what is the asymptotic behavior of f(n)? -/
+/-- **Growth Rate** (OPEN): f(n) grows at most linearly. -/
 axiom erdos_422_growth :
   ∀ ε : ℝ, ε > 0 →
     ∃ N₀ : ℕ, ∀ n ≥ N₀,
       (hofstadterF n : ℝ) ≤ (1 + ε) * n
-
-/- ## Known Values -/
-
-/-- The first few values: f(1) = 1, f(2) = 1, f(3) = 2, f(4) = 3,
-    f(5) = 3, f(6) = 4, ... (OEIS A005185). -/
-axiom initial_values :
-  hofstadterF 1 = 1 ∧ hofstadterF 2 = 1 ∧
-  hofstadterF 3 = 2 ∧ hofstadterF 4 = 3 ∧
-  hofstadterF 5 = 3 ∧ hofstadterF 6 = 4
 
 /- ## Observations -/
 

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -40,17 +40,18 @@
       }
     ],
     "originalContributions": [
-      "Defined hofstadterF via Lean's equation compiler with pattern matching on 0, 1, 2, n+3",
-      "Defined IsWellDefined predicate checking recursive indices stay positive",
+      "Defined computable hofstadterFList iterative accumulator for the Hofstadter sequence",
+      "Defined hofstadterF as computable extraction from the list accumulator",
+      "Proved initial_values theorem: f(1)=1, f(2)=1, f(3)=2, f(4)=3, f(5)=3, f(6)=4 via native_decide",
+      "Defined WellDefinedAt and IsWellDefined predicates for well-definedness analysis",
       "Stated erdos_422_well_defined: well-definedness conjecture for all n",
       "Stated erdos_422_misses_infinitely: infinite set of missing integers",
-      "Stated erdos_422_surjectivity: non-surjectivity conjecture",
-      "Stated erdos_422_growth: linear growth bound f(n) ≤ (1+ε)n",
-      "Axiomatized initial_values: f(1)=1, f(2)=1, ..., f(6)=4"
+      "Stated erdos_422_not_surjective: non-surjectivity conjecture",
+      "Stated erdos_422_growth: linear growth bound f(n) ≤ (1+ε)n"
     ],
     "axiomCount": 5,
-    "assumptions": "5 axiom declarations: erdos_422_well_defined (well-definedness for all n), erdos_422_misses_infinitely (infinitely many missing values), erdos_422_surjectivity (non-surjectivity conjecture), erdos_422_growth (linear growth bound), initial_values (first six computed values)",
-    "lineCount": 77
+    "assumptions": "4 axiom declarations: erdos_422_well_defined (well-definedness for all n), erdos_422_misses_infinitely (infinitely many missing values), erdos_422_not_surjective (non-surjectivity conjecture), erdos_422_growth (linear growth bound). initial_values proved from computable definition.",
+    "lineCount": 106
   },
   "overview": {
     "historicalContext": "Douglas Hofstadter, famous for *Gödel, Escher, Bach* (1979), proposed this self-referential sequence and communicated it to Erdős. It appears in the Erdős–Graham monograph *Old and New Problems and Results in Combinatorial Number Theory* (1980) [ErGr80] and is listed as OEIS A005185.\n\nThe sequence $f(1) = f(2) = 1$, $f(n) = f(n - f(n-1)) + f(n - f(n-2))$ for $n > 2$ is remarkable because its most basic property—whether $f(n)$ is well-defined for all $n$—is unknown. The recursion is self-referential: to compute $f(n)$, one needs $f(n-1)$ and $f(n-2)$ to determine the indices $n - f(n-1)$ and $n - f(n-2)$, and then evaluates $f$ at those indices. If $f(n-1) \\geq n$ or $f(n-2) \\geq n$, the indices become non-positive and the recursion breaks down.\n\nComputationally, the sequence has been verified to be well-defined for billions of terms, and it appears to grow roughly linearly with a complicated local structure. The sequence begins $1, 1, 2, 3, 3, 4, 5, 7, 7, 8, \\ldots$ and exhibits no obvious pattern. It is one of the simplest self-referential recursions whose behavior resists all known analytical techniques, making it a paradigmatic example of 'simple to state, impossible to analyze.'\n\nThe self-referential nature of the recursion places this problem at the intersection of number theory, dynamical systems, and computability theory. Unlike the closely related Hofstadter $Q$-sequence ($Q(n) = Q(n - Q(n-1))$), which involves a single self-referential term, Problem #422 uses two such terms summed together, adding an additional layer of complexity.\n\n**Status**: OPEN — Well-definedness, surjectivity, and growth rate are all unknown.",
@@ -74,36 +75,43 @@
       "id": "preamble",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 27,
+      "endLine": 23,
       "summary": "Module docstring describing the Hofstadter-type recursive sequence from Erdős Problem #422, its origin from Hofstadter's communication to Erdős, and the open status of well-definedness, surjectivity, and growth. Imports Mathlib for natural number arithmetic and set theory.",
       "mathContext": "$f(1) = f(2) = 1$, $f(n) = f(n - f(n-1)) + f(n - f(n-2))$ for $n > 2$. All questions about this sequence remain OPEN."
     },
     {
       "id": "definition",
-      "title": "Core Definitions",
-      "startLine": 28,
-      "endLine": 41,
-      "summary": "Defines `hofstadterF : ℕ → ℕ` via Lean's equation compiler with cases for $0$ (sentinel), $1$ (returns 1), $2$ (returns 1), and $n+3$ (recursive case: $f(n+3) = f(n+3 - f(n+2)) + f(n+3 - f(n+1))$). Defines `IsWellDefined n` as the predicate $\\forall k \\leq n, k \\geq 3 \\to f(k-1) < k \\wedge f(k-2) < k$, ensuring recursive indices stay positive. Marked `noncomputable` since well-definedness is not decidable."
+      "title": "Computable Definition",
+      "startLine": 24,
+      "endLine": 45,
+      "summary": "Defines `hofstadterFList : ℕ → List ℕ` as a computable iterative accumulator building the sequence as a list, with base cases for indices 0, 1, 2 and a recursive case that appends $f(k) = f(k - f(k-1)) + f(k - f(k-2))$ using `List.getD` for safe indexing. Defines `hofstadterF (n : ℕ) : ℕ` by extracting the $n$-th element from the accumulated list."
     },
     {
-      "id": "main-questions",
-      "title": "Main Open Questions",
-      "startLine": 42,
-      "endLine": 62,
-      "summary": "Axiomatizes four open questions: `erdos_422_well_defined` ($\\forall n, \\text{IsWellDefined}(n)$), `erdos_422_misses_infinitely` ($\\{m > 0 : \\forall n, f(n) \\neq m\\}$ is infinite via `Set.Infinite`), `erdos_422_surjectivity` ($f$ restricted to $\\mathbb{N}^+$ is not surjective via $\\neg$`Function.Surjective`), and `erdos_422_growth` ($f(n) \\leq (1+\\varepsilon)n$ for large $n$)."
+      "id": "initial-values",
+      "title": "Proved Initial Values",
+      "startLine": 47,
+      "endLine": 63,
+      "summary": "Proves the first six values of the sequence via `native_decide`: $f(1) = 1, f(2) = 1, f(3) = 2, f(4) = 3, f(5) = 3, f(6) = 4$. Combines these into the `initial_values` theorem. These were previously axiomatized; now proved from the computable definition."
     },
     {
-      "id": "known-values",
-      "title": "Known Values",
-      "startLine": 63,
-      "endLine": 67,
-      "summary": "Axiomatizes the first six values: $f(1) = 1, f(2) = 1, f(3) = 2, f(4) = 3, f(5) = 3, f(6) = 4$. These are directly computable from the recursion and match OEIS A005185."
+      "id": "well-definedness",
+      "title": "Well-Definedness Predicates",
+      "startLine": 65,
+      "endLine": 75,
+      "summary": "Defines `WellDefinedAt k` asserting that recursive lookups at index $k$ stay in bounds ($1 \\leq f(k-1) < k$ and $1 \\leq f(k-2) < k$), and `IsWellDefined n` asserting well-definedness for all indices up to $n$."
+    },
+    {
+      "id": "open-questions",
+      "title": "Open Questions",
+      "startLine": 77,
+      "endLine": 95,
+      "summary": "Axiomatizes four open questions: `erdos_422_well_defined` ($\\forall n, \\text{IsWellDefined}(n)$), `erdos_422_misses_infinitely` ($\\{m > 0 : \\forall n, f(n) \\neq m\\}$ is infinite via `Set.Infinite`), `erdos_422_not_surjective` ($f$ restricted to $\\mathbb{N}^+$ is not surjective via $\\neg$`Function.Surjective`), and `erdos_422_growth` ($f(n) \\leq (1+\\varepsilon)n$ for large $n$)."
     },
     {
       "id": "observations",
       "title": "Observations",
-      "startLine": 68,
-      "endLine": 77,
+      "startLine": 97,
+      "endLine": 106,
       "summary": "Comments (not formal declarations) on three aspects: Hofstadter's origin and communication to Erdős, the fundamental difficulty posed by self-referential indexing that defeats standard inductive techniques, and the open question of whether $f$ is eventually constant."
     }
   ],
@@ -126,10 +134,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 77,
-    "axiomCount": 5,
-    "theoremCount": 0,
-    "definitionCount": 2
+    "lineCount": 106,
+    "axiomCount": 4,
+    "theoremCount": 7,
+    "definitionCount": 4
   },
   "references": [
     {


### PR DESCRIPTION
## Summary
- Replace broken noncomputable recursive definition with computable iterative `hofstadterFList`
- Prove `initial_values` theorem from the computable definition (eliminates 1 axiom)
- 5 axioms → 4 axioms (all remaining are genuinely open questions)

## Changes
- `proofs/Proofs/Erdos422Problem.lean`: Complete rewrite with computable definition
- 7 new theorems: `hofstadterF_one` through `hofstadterF_six` + combined `initial_values`
- New `WellDefinedAt`/`IsWellDefined` predicates for future work
- `src/data/proofs/erdos-422/meta.json`: Updated axiomCount (5→4), theoremCount (0→7), sections

## Mathematical Notes
The Hofstadter sequence f(n) = f(n-f(n-1)) + f(n-f(n-2)) has self-referential recursion 
that makes even well-definedness unknown. The iterative definition computes values using a 
list accumulator, making it total and decidable for finite evaluation.

🤖 Generated by researcher-8