### PR TITLE
Research: erdos-826 — axiom elimination (4→0)

### DIFF
--- a/proofs/Proofs/Erdos826Problem.lean
+++ b/proofs/Proofs/Erdos826Problem.lean
@@ -61,13 +61,16 @@ Known bounds on τ(n).
 -/
 
 /--
-**Average Order of τ**
+**Average Order of τ** (Dirichlet's divisor problem)
 
 The average value of τ(n) for n ≤ x is approximately log(x).
 More precisely, Σ_{n≤x} τ(n) = x log(x) + (2γ - 1)x + O(√x),
 where γ is the Euler-Mascheroni constant.
+
+Deep result from analytic number theory, not currently in Mathlib.
+Stated as a proposition rather than an axiom since it is not used in proofs below.
 -/
-axiom average_order_tau :
+def average_order_tau : Prop :=
     ∃ C₁ C₂ : ℝ, C₁ > 0 ∧ C₂ > 0 ∧
     ∀ x ≥ 2, C₁ * Real.log x ≤ (1/x) * ∑ n ∈ Finset.range (⌊x⌋₊), (σ 0 (n+1) : ℝ)
     ∧ (1/x) * ∑ n ∈ Finset.range (⌊x⌋₊), (σ 0 (n+1) : ℝ) ≤ C₂ * Real.log x
@@ -79,8 +82,11 @@ The maximum order of τ(n) is 2^{(1+o(1)) log(n)/log(log(n))}.
 In particular, τ(n) can be much larger than any fixed power of log(n).
 
 Highly composite numbers achieve this maximum order.
+
+Deep result from analytic number theory, not currently in Mathlib.
+Stated as a proposition rather than an axiom since it is not used in proofs below.
 -/
-axiom max_order_tau :
+def max_order_tau : Prop :=
     ∀ ε > (0 : ℝ), ∃ C : ℝ, ∀ n ≥ 2,
     (σ 0 n : ℝ) ≤ C * (2 : ℝ) ^ ((1 + ε) * Real.log n / Real.log (Real.log n))
 
@@ -136,10 +142,13 @@ def erdos_826_conjecture : Prop :=
 **The formal statement from formal-conjectures.**
 
 Using Mathlib's σ 0 for the divisor function.
+The two sides are definitionally equal after unfolding.
 -/
-axiom erdos_826_statement :
+theorem erdos_826_statement :
     erdos_826_conjecture ↔
-    ∃ C > (0 : ℝ), { n | ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite
+    ∃ C > (0 : ℝ), { n | ∀ k ≥ 1, (σ 0 (n + k) : ℝ) ≤ C * k }.Infinite := by
+  unfold erdos_826_conjecture goodStartingPoints linearBoundCondition
+  rfl
 
 /-
 # Part 5: Relation to Problem #248
@@ -186,9 +195,13 @@ but the constraint at k = 1 is very restrictive.
 def fewDivisorsAt1 (n : ℕ) (C : ℝ) : Prop :=
   (σ 0 (n + 1) : ℝ) ≤ C
 
-/-- If n+1 is prime, τ(n+1) = 2, which easily satisfies the bound. -/
-axiom prime_satisfies_bound (n : ℕ) (hn : Nat.Prime (n + 1)) :
-    (σ 0 (n + 1) : ℝ) = 2
+/-- If n+1 is prime, τ(n+1) = 2, which easily satisfies the bound.
+Proved from Mathlib: σ₀(p) = ∑_{d|p} d⁰ = |{1,p}| = 2. -/
+theorem prime_satisfies_bound (n : ℕ) (hn : Nat.Prime (n + 1)) :
+    (σ 0 (n + 1) : ℝ) = 2 := by
+  suffices h : σ 0 (n + 1) = 2 by exact_mod_cast h
+  rw [ArithmeticFunction.sigma_apply, hn.divisors]
+  simp [Finset.not_mem_singleton.mpr hn.one_lt.ne]
 
 /-
 # Part 7: Probabilistic Heuristic

--- a/src/data/proofs/erdos-826/meta.json
+++ b/src/data/proofs/erdos-826/meta.json
@@ -40,23 +40,23 @@
     ],
     "originalContributions": [
       "tau definition: divisor function via σ 0",
-      "average_order_tau axiom: average order is log(x)",
-      "max_order_tau axiom: maximum order bound",
+      "average_order_tau proposition: average order is log(x) (deep result, stated not assumed)",
+      "max_order_tau proposition: maximum order bound (deep result, stated not assumed)",
       "linearBoundCondition definition: τ(n+k) ≤ Ck",
       "goodStartingPoints definition: set of n satisfying the bound",
       "erdos_826_conjecture definition: the open problem",
-      "erdos_826_statement axiom: equivalence with formal-conjectures form",
+      "erdos_826_statement theorem: equivalence with formal-conjectures form (proved by unfolding)",
       "erdos_248_weaker definition: the weaker problem",
       "erdos_826_implies_248 theorem: implication between problems",
       "fewDivisorsAt1 definition: constraint at k=1",
-      "prime_satisfies_bound axiom: primes have τ = 2",
+      "prime_satisfies_bound theorem: primes have τ = 2 (proved from Mathlib)",
       "heuristicCriticalRange definition: critical range for heuristic",
       "hasControlledDivisors definition: smooth number connection",
       "erdos_826_main theorem: well-definedness and implications"
     ],
-    "axiomCount": 4,
-    "lineCount": 307,
-    "assumptions": "4 axioms: average_order_tau, max_order_tau, erdos_826_statement, and 1 more. See Lean source for complete statements."
+    "axiomCount": 0,
+    "lineCount": 316,
+    "assumptions": "0 axioms. Open conjecture stated as a definition. Background facts (average/max order of τ) stated as propositions. erdos_826_statement and prime_satisfies_bound proved from Mathlib."
   },
   "overview": {
     "historicalContext": "Erdős Problem #826 was posed by Paul Erdős in 1974 (referenced as [Er74b]). It asks a fundamental question about the growth of the divisor function τ(n) = σ₀(n) along arithmetic shifts: can we find infinitely many starting points n where τ(n+k) grows at most linearly in k? The problem is described as a stronger form of Erdős Problem #248.\n\nThe divisor function τ(n) counts the number of positive divisors of n. Its average order is log(n), established by Dirichlet's divisor problem, while its maximum order is much larger — roughly 2^{log(n)/log(log(n))} — achieved by highly composite numbers. The interplay between typical and extremal behavior is central to understanding this problem.\n\nTerence Tao has noted that Problem #826 appears difficult. The challenge lies in simultaneously controlling divisor counts across all shifts k ≥ 1 from a single starting point. While the constraint becomes easier for large k (since Ck grows), the constraint at k = 1 is extremely restrictive: it requires τ(n+1) ≤ C, meaning n+1 must have very few divisors. Standard sieve methods and analytic number theory techniques have not yet yielded a resolution.",
@@ -180,10 +180,10 @@
       "Nat"
     ],
     "namespace": "Erdos826",
-    "lineCount": 307,
-    "axiomCount": 4,
-    "theoremCount": 2,
-    "definitionCount": 9
+    "lineCount": 320,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 10
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-826.json
+++ b/src/data/research/problems/erdos-826.json
@@ -29,9 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Eliminated all 4 axioms (4→0). erdos_826_statement proved by unfolding. prime_satisfies_bound proved from Mathlib. average_order_tau and max_order_tau converted to propositions.",
+    "builtItems": [
+      "Proved erdos_826_statement as theorem via unfold + rfl",
+      "Proved prime_satisfies_bound as theorem via sigma_apply + Prime.divisors",
+      "Converted average_order_tau from axiom to def Prop",
+      "Converted max_order_tau from axiom to def Prop"
+    ],
+    "insights": [
+      "All 4 axioms eliminated: erdos_826_statement proved by rfl after unfolding, prime_satisfies_bound proved from Mathlib, average_order_tau and max_order_tau converted to def Prop",
+      "σ 0 p = 2 for prime p: unfold sigma_apply to sum over divisors, use Prime.divisors to get {1,p}, simplify",
+      "average_order_tau and max_order_tau are unused by any theorem — safe to convert from axiom to proposition"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #826 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nAre there infinitely many $n$ such that, for all $k\\geq 1$,\\[\\tau(n+k)\\ll k?\\]\n\n\n\nA stronger form of [248].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #248\n- Problem #825\n- Problem #827\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er74b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"


### PR DESCRIPTION
## Summary
Eliminate all 4 axioms from Erdős Problem #826 (Divisor Function Growth Along Shifts), reducing axiom count from 4 to 0.

## Progress
| Axiom | Action | Technique |
|-------|--------|-----------|
| `erdos_826_statement` | Proved as theorem | `unfold` + `rfl` (trivial tautology — two sides definitionally equal) |
| `prime_satisfies_bound` | Proved as theorem | `ArithmeticFunction.sigma_apply` + `Nat.Prime.divisors` + `simp` |
| `average_order_tau` | Converted to `def Prop` | Deep analytic result (Dirichlet), not in Mathlib, unused by theorems |
| `max_order_tau` | Converted to `def Prop` | Deep analytic result, not in Mathlib, unused by theorems |

## Findings
- `erdos_826_statement` was a trivial tautology: both sides of the ↔ are definitionally equal after unfolding `erdos_826_conjecture`, `goodStartingPoints`, and `linearBoundCondition`
- `prime_satisfies_bound` (σ₀(p) = 2 for prime p) is a routine Mathlib fact: unfold σ₀ to sum over divisors, use `Prime.divisors` to get `{1, p}`, then simplify
- `average_order_tau` and `max_order_tau` are deep results from analytic number theory not available in Mathlib; since they're unused by any theorem in the file, converting to `def Prop` preserves the statement while removing the assumption

## Status
**Outcome**: completed
**Axioms**: 4 → 0
**Theorems**: 2 → 4
**Next Steps**: None — file is now axiom-free

Generated by researcher-5