### PR TITLE
Research: erdos-113 — axiom elimination (21→8)

### DIFF
--- a/proofs/Proofs/Erdos113Problem.lean
+++ b/proofs/Proofs/Erdos113Problem.lean
@@ -54,13 +54,15 @@ The parameter k encodes the forbidden subgraph abstractly.
 -/
 axiom extremalNumber : ℕ → ℕ → ℕ
 
-/-- The extremal number is monotonic in n. -/
-axiom extremal_mono (k n m : ℕ) (h : n ≤ m) :
-    extremalNumber n k ≤ extremalNumber m k
+/-- The extremal number is monotonic in n.
+Property of the abstract extremal number function; not used in proofs below. -/
+def extremal_mono_prop : Prop :=
+    ∀ k n m : ℕ, n ≤ m → extremalNumber n k ≤ extremalNumber m k
 
-/-- ex(n, k) ≤ n(n-1)/2 (at most all edges). -/
-axiom extremal_trivial_upper (n k : ℕ) :
-    extremalNumber n k ≤ n * (n - 1) / 2
+/-- ex(n, k) ≤ n(n-1)/2 (at most all edges).
+Property of the abstract extremal number function; not used in proofs below. -/
+def extremal_trivial_upper_prop : Prop :=
+    ∀ n k : ℕ, extremalNumber n k ≤ n * (n - 1) / 2
 
 /-
 ## Part II: Graph Degeneracy
@@ -78,15 +80,20 @@ k-degeneracy is axiomatized for a graph encoded by parameter g.
 -/
 axiom isDegenerate : ℕ → ℕ → Prop
 
-/-- Every graph is k-degenerate for some k. -/
-axiom degenerate_exists (g : ℕ) : ∃ k, isDegenerate g k
+/-- Every graph is k-degenerate for some k.
+Property of the abstract degeneracy predicate; not used in proofs below. -/
+def degenerate_exists_prop : Prop :=
+    ∀ g : ℕ, ∃ k, isDegenerate g k
 
-/-- If g is k-degenerate and k ≤ m, then g is m-degenerate. -/
-axiom degenerate_mono (g k m : ℕ) : isDegenerate g k → k ≤ m → isDegenerate g m
+/-- If g is k-degenerate and k ≤ m, then g is m-degenerate.
+Property of the abstract degeneracy predicate; not used in proofs below. -/
+def degenerate_mono_prop : Prop :=
+    ∀ g k m : ℕ, isDegenerate g k → k ≤ m → isDegenerate g m
 
-/-- 2-degenerate means no induced subgraph has min degree ≥ 3. -/
-axiom two_degenerate_char (g : ℕ) :
-    isDegenerate g 2 ↔ ∀ S : ℕ, S > 0 → ∃ v : ℕ, True  -- Axiomatized characterization
+/-- 2-degenerate means no induced subgraph has min degree ≥ 3.
+Property of the abstract degeneracy predicate; not used in proofs below. -/
+def two_degenerate_char_prop : Prop :=
+    ∀ g : ℕ, isDegenerate g 2 ↔ ∀ S : ℕ, S > 0 → ∃ v : ℕ, True
 
 /-
 ## Part III: Bipartite Graphs
@@ -98,13 +105,15 @@ axiom isBipartite : ℕ → Prop
 /-- The complete bipartite graph K_{s,t} (encoded as s + t). -/
 def completeBipartiteCode (s t : ℕ) : ℕ := s * 1000 + t
 
-/-- K_{s,t} is bipartite. -/
-axiom completeBipartite_is_bipartite (s t : ℕ) :
-    isBipartite (completeBipartiteCode s t)
+/-- K_{s,t} is bipartite.
+Property of the abstract bipartite predicate; not used in proofs below. -/
+def completeBipartite_is_bipartite_prop : Prop :=
+    ∀ s t : ℕ, isBipartite (completeBipartiteCode s t)
 
-/-- K_{s,t} has degeneracy min(s,t). -/
-axiom completeBipartite_degeneracy (s t : ℕ) (hs : s ≥ 1) (ht : t ≥ 1) :
-    isDegenerate (completeBipartiteCode s t) (min s t)
+/-- K_{s,t} has degeneracy min(s,t).
+Property of abstract functions; not used in proofs below. -/
+def completeBipartite_degeneracy_prop : Prop :=
+    ∀ s t : ℕ, s ≥ 1 → t ≥ 1 → isDegenerate (completeBipartiteCode s t) (min s t)
 
 /-
 ## Part IV: The Kővári-Sós-Turán Theorem
@@ -117,13 +126,16 @@ The fundamental upper bound for bipartite forbidden subgraphs.
 ex(n; K_{s,t}) ≤ (1/2)(t-1)^{1/s} · n^{2-1/s} + (s-1)n/2
 
 For t ≥ s ≥ 1.
+Deep result from extremal graph theory; not used in proofs below.
 -/
-axiom kovari_sos_turan (n s t : ℕ) (hs : s ≥ 1) (hst : t ≥ s) :
+def kovari_sos_turan_prop : Prop :=
+    ∀ n s t : ℕ, s ≥ 1 → t ≥ s →
     ∃ C : ℝ, C > 0 ∧
       (extremalNumber n (completeBipartiteCode s t) : ℝ) ≤ C * (n : ℝ).rpow (2 - 1/s)
 
-/-- For K_{2,2} = C_4: ex(n; C_4) = O(n^{3/2}). -/
-axiom c4_extremal :
+/-- For K_{2,2} = C_4: ex(n; C_4) = O(n^{3/2}).
+Deep result; not used in proofs below. -/
+def c4_extremal_prop : Prop :=
     ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ,
       (extremalNumber n (completeBipartiteCode 2 2) : ℝ) ≤ C * (n : ℝ).rpow (3/2)
 
@@ -137,9 +149,16 @@ def AsympLe (f g : ℕ → ℝ) : Prop :=
 
 notation:50 f " ≪ " g => AsympLe f g
 
-/-- Asymptotic comparison is transitive (if exponents compare correctly). -/
-axiom asymp_trans_exponent (f : ℕ → ℝ) (α β : ℝ) (hαβ : α < β) :
-    (f ≪ (fun n => (n : ℝ).rpow α)) → (f ≪ (fun n => (n : ℝ).rpow β))
+/-- Asymptotic comparison is transitive (if exponents compare correctly).
+Proved from rpow monotonicity: 1 ≤ n → α ≤ β → n^α ≤ n^β. -/
+theorem asymp_trans_exponent (f : ℕ → ℝ) (α β : ℝ) (hαβ : α < β) :
+    (f ≪ (fun n => (n : ℝ).rpow α)) → (f ≪ (fun n => (n : ℝ).rpow β)) := by
+  intro ⟨C, hC, n₀, hf⟩
+  refine ⟨C, hC, max n₀ 1, fun n hn => ?_⟩
+  have hn₀ : n₀ ≤ n := (le_max_left n₀ 1).trans hn
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast (le_max_right n₀ 1).trans hn
+  exact (hf n hn₀).trans (mul_le_mul_of_nonneg_left
+    (Real.rpow_le_rpow_of_exponent_le hn1 hαβ.le) hC.le)
 
 /-
 ## Part VI: The Erdős-Simonovits Conjecture
@@ -227,19 +246,24 @@ theorem janzer_beats_threshold (ε : ℝ) (hε : ε > 0) (hε' : ε < 1/6) :
 /--
 **Füredi's Theorem (1996):**
 Tight bounds for ex(n; K_{s,t}) when t is large relative to s.
+Deep result; not used in proofs below.
 -/
-axiom furedi_tight (s t : ℕ) (hs : s ≥ 2) (hst : t ≥ s) :
+def furedi_tight_prop : Prop :=
+    ∀ s t : ℕ, s ≥ 2 → t ≥ s →
     ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
       ∀ n : ℕ, c₁ * (n : ℝ).rpow (2 - 1/s) ≤ extremalNumber n (completeBipartiteCode s t) ∧
                (extremalNumber n (completeBipartiteCode s t) : ℝ) ≤ c₂ * (n : ℝ).rpow (2 - 1/s)
 
-/-- Erdős Problem #146: Zarankiewicz problem asks for exact values of ex(n; K_{s,t}). -/
-axiom erdos_146_zarankiewicz (s t : ℕ) :
-    ∀ n : ℕ, ∃ z : ℕ, z = extremalNumber n (completeBipartiteCode s t)
+/-- Erdős Problem #146: Zarankiewicz problem asks for exact values of ex(n; K_{s,t}).
+Trivially true: the extremal number always exists. -/
+theorem erdos_146_zarankiewicz (s t : ℕ) :
+    ∀ n : ℕ, ∃ z : ℕ, z = extremalNumber n (completeBipartiteCode s t) :=
+  fun _ => ⟨_, rfl⟩
 
-/-- Erdős Problem #147: Turán exponent exists for bipartite graphs. -/
-axiom erdos_147_turan_exponent (g : ℕ) :
-    isBipartite g → ∃ r : ℝ, 1 ≤ r ∧ r ≤ 2 ∧
+/-- Erdős Problem #147: Turán exponent exists for bipartite graphs.
+Deep conjecture; not used in proofs below. -/
+def erdos_147_turan_exponent_prop : Prop :=
+    ∀ g : ℕ, isBipartite g → ∃ r : ℝ, 1 ≤ r ∧ r ≤ 2 ∧
       (fun n => (extremalNumber n g : ℝ)) ≪ (fun n => (n : ℝ).rpow r)
 
 /-

--- a/src/data/proofs/erdos-113/meta.json
+++ b/src/data/proofs/erdos-113/meta.json
@@ -53,9 +53,9 @@
       "Janzer's 3-regular bipartite counterexample theorem",
       "Main theorem: ¬ErdosSimonovitsConjecture"
     ],
-    "axiomCount": 21,
-    "lineCount": 271,
-    "assumptions": "21 axioms: extremalNumber, extremal_mono, extremal_trivial_upper, and 18 more. See Lean source for complete statements.",
+    "axiomCount": 8,
+    "lineCount": 295,
+    "assumptions": "8 axioms: 4 abstract function declarations (extremalNumber, isDegenerate, isBipartite, isRegular) + 4 deep results (forward_direction, backward_false, regular3_not_2degenerate, janzer_counterexample). 13 axioms eliminated: 11 converted to propositions (unused by theorems), asymp_trans_exponent proved from rpow monotonicity, erdos_146_zarankiewicz proved trivially.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -243,9 +243,9 @@
       "Real"
     ],
     "namespace": "Erdos113",
-    "lineCount": 271,
-    "axiomCount": 21,
-    "theoremCount": 3,
-    "definitionCount": 3
+    "lineCount": 295,
+    "axiomCount": 8,
+    "theoremCount": 5,
+    "definitionCount": 14
   }
 }

--- a/src/data/research/problems/erdos-113-oq-01.json
+++ b/src/data/research/problems/erdos-113-oq-01.json
@@ -29,9 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Eliminated 13 of 21 axioms (21→8). Proved asymp_trans_exponent and erdos_146_zarankiewicz. Converted 11 unused axioms to propositions.",
+    "builtItems": [
+      "Proved asymp_trans_exponent from Mathlib rpow_le_rpow_of_exponent_le",
+      "Proved erdos_146_zarankiewicz trivially (⟨_, rfl⟩)",
+      "Converted 11 unused axiom propositions to def Prop"
+    ],
+    "insights": [
+      "13 axioms eliminated (21→8): 11 unused props→def Prop, asymp_trans_exponent proved from rpow_le_rpow_of_exponent_le, erdos_146_zarankiewicz proved trivially",
+      "Remaining 8 axioms are essential: 4 abstract function declarations (extremalNumber, isDegenerate, isBipartite, isRegular) and 4 deep results (forward_direction, backward_false, regular3_not_2degenerate, janzer_counterexample)",
+      "asymp_trans_exponent: if f ≪ n^α and α < β, then f ≪ n^β — follows from rpow monotonicity for base ≥ 1"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary
Eliminate 13 of 21 axioms from Erdős Problem #113 (Extremal Numbers and Degeneracy of Bipartite Graphs).

## Progress
| Category | Axioms | Action |
|----------|--------|--------|
| **Proved** | `asymp_trans_exponent` | Proved from `rpow_le_rpow_of_exponent_le` (rpow monotonicity) |
| **Proved** | `erdos_146_zarankiewicz` | Trivially true: `⟨_, rfl⟩` |
| **→ def Prop** | 11 unused axioms | `extremal_mono`, `extremal_trivial_upper`, `degenerate_exists`, `degenerate_mono`, `two_degenerate_char`, `completeBipartite_is_bipartite`, `completeBipartite_degeneracy`, `kovari_sos_turan`, `c4_extremal`, `furedi_tight`, `erdos_147_turan_exponent` |

## Remaining 8 axioms (essential)
- 4 abstract function declarations: `extremalNumber`, `isDegenerate`, `isBipartite`, `isRegular`
- 4 deep results used by theorems: `forward_direction`, `backward_false`, `regular3_not_2degenerate`, `janzer_counterexample`

## Findings
- `erdos_146_zarankiewicz` was trivially true — it just asserts `∃ z, z = extremalNumber n k` which is `⟨_, rfl⟩`
- `asymp_trans_exponent` (O(n^α) → O(n^β) when α < β) follows from rpow monotonicity for base ≥ 1
- The 11 converted axioms were all unused by any theorem in the file — converting to `def Prop` preserves statements while removing assumptions

## Status
**Outcome**: completed
**Axioms**: 21 → 8 (13 eliminated)
**Theorems**: 3 → 5

Generated by researcher-5