### PR TITLE
Research: erdos-42 — prove sidon_size_bound from axioms (5→4)

### DIFF
--- a/proofs/Proofs/Erdos42Problem.lean
+++ b/proofs/Proofs/Erdos42Problem.lean
@@ -48,14 +48,72 @@ def DisjointDiffs (A B : Finset ℕ) : Prop :=
 
 /- ## Basic Properties -/
 
-/-- A Sidon set in {1,...,N} has size at most ~√(2N).
-    By difference counting: all A.card*(A.card-1) ordered nonzero differences
-    are distinct and lie in {-(N-1),...,-1, 1,...,N-1} (2*(N-1) elements).
-    Note: the previous bound A.card² ≤ 2N+1 was incorrect
-    (counterexample: {1,2,5,7} ⊂ [1,7] has |A|²=16 > 15=2·7+1). -/
-axiom sidon_size_bound (A : Finset ℕ) (N : ℕ) (hn : 1 ≤ N)
+/-- A Sidon set in {1,...,N} satisfies |A|(|A|-1) ≤ 2(N-1).
+    Proof: the map (a₁,a₂) ↦ a₁-a₂ is injective on off-diagonal ordered pairs
+    of A by the Sidon property, and the image lies in {-(N-1),...,N-1}\{0}
+    which has 2(N-1) elements. -/
+theorem sidon_size_bound (A : Finset ℕ) (N : ℕ) (hn : 1 ≤ N)
     (hs : IsSidonSet A) (hi : InInterval A N) :
-  A.card * (A.card - 1) ≤ 2 * (N - 1)
+  A.card * (A.card - 1) ≤ 2 * (N - 1) := by
+  -- The difference map on ordered pairs
+  let f : ℕ × ℕ → ℤ := fun p => (↑p.1 : ℤ) - ↑p.2
+  -- Step 1: f is injective on A.offDiag (by the Sidon property)
+  have h_inj : Set.InjOn f ↑A.offDiag := by
+    rintro ⟨a₁, a₂⟩ ha ⟨b₁, b₂⟩ hb heq
+    simp only [Finset.mem_coe, Finset.mem_offDiag] at ha hb
+    dsimp only [f] at heq
+    -- From equal differences, derive equal ℕ sums
+    have h_sum : a₁ + b₂ = b₁ + a₂ := by
+      have : (↑(a₁ + b₂) : ℤ) = ↑(b₁ + a₂) := by push_cast; linarith
+      exact_mod_cast this
+    -- Apply Sidon: {a₁, b₂} = {b₁, a₂}
+    have h_set := hs a₁ ha.1 b₂ hb.2.1 b₁ hb.1 a₂ ha.2.1 h_sum
+    -- Extract: a₁ ∈ {b₁, a₂}
+    have ha₁_mem : a₁ ∈ ({b₁, a₂} : Finset ℕ) := by
+      rw [← h_set]; exact Finset.mem_insert_self a₁ _
+    simp only [Finset.mem_insert, Finset.mem_singleton] at ha₁_mem
+    rcases ha₁_mem with h_eq | h_eq
+    · -- a₁ = b₁ ⟹ a₂ = b₂ from the sum equation
+      exact Prod.ext h_eq (by omega)
+    · -- a₁ = a₂: contradicts off-diagonal
+      exact absurd h_eq ha.2.2
+  -- Step 2: Image of f on A.offDiag ⊆ {-(N-1),...,N-1} \ {0}
+  have h_sub : A.offDiag.image f ⊆ (Finset.Icc (1 - (↑N : ℤ)) (↑N - 1)).erase 0 := by
+    intro d hd
+    rw [Finset.mem_image] at hd
+    obtain ⟨⟨a₁, a₂⟩, hmem, rfl⟩ := hd
+    rw [Finset.mem_offDiag] at hmem
+    dsimp only [f]
+    rw [Finset.mem_erase, Finset.mem_Icc]
+    refine ⟨?_, ?_, ?_⟩
+    · intro h; apply hmem.2.2
+      exact_mod_cast show (↑a₁ : ℤ) = ↑a₂ by linarith
+    · have : (1 : ℤ) ≤ ↑a₁ := by exact_mod_cast (hi a₁ hmem.1).1
+      have : (↑a₂ : ℤ) ≤ ↑N := by exact_mod_cast (hi a₂ hmem.2.1).2
+      linarith
+    · have : (↑a₁ : ℤ) ≤ ↑N := by exact_mod_cast (hi a₁ hmem.1).2
+      have : (1 : ℤ) ≤ ↑a₂ := by exact_mod_cast (hi a₂ hmem.2.1).1
+      linarith
+  -- Step 3: Target set has 2*(N-1) elements
+  have h_card : ((Finset.Icc (1 - (↑N : ℤ)) (↑N - 1)).erase 0).card = 2 * (N - 1) := by
+    rw [Finset.card_erase_of_mem (by rw [Finset.mem_Icc]; constructor <;> omega)]
+    rw [Int.card_Icc]
+    omega
+  -- Step 4: |A|*(|A|-1) = |offDiag|
+  have h_offDiag : A.card * (A.card - 1) = A.offDiag.card := by
+    rw [Finset.offDiag_card]
+    generalize A.card = m
+    cases m with
+    | zero => simp
+    | succ n =>
+      simp only [show (n + 1) * (n + 1) = (n + 1) * n + (n + 1) from by ring,
+                  Nat.add_sub_cancel]
+  -- Combine
+  rw [h_offDiag]
+  calc A.offDiag.card
+      = (A.offDiag.image f).card := (Finset.card_image_of_injOn h_inj).symm
+    _ ≤ ((Finset.Icc (1 - (↑N : ℤ)) (↑N - 1)).erase 0).card := Finset.card_le_card h_sub
+    _ = 2 * (N - 1) := h_card
 
 /-- 0 is always in A − A: pick any a ∈ A, then a - a = 0. -/
 theorem zero_in_diffSet (A : Finset ℕ) (hne : A.Nonempty) :

--- a/src/data/proofs/erdos-42/meta.json
+++ b/src/data/proofs/erdos-42/meta.json
@@ -20,22 +20,22 @@
     "erdosNumber": 42,
     "erdosUrl": "https://erdosproblems.com/42",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 131,
+    "axiomCount": 4,
+    "lineCount": 189,
     "prerequisites": [
       "Sidon sets (B₂ sequences) and their properties",
       "Difference sets of finite sets",
       "Extremal combinatorics and Ramsey theory",
       "Finite field constructions (Singer difference sets)"
     ],
-    "assumptions": "5 axiom declarations: sidon_size_bound, sedov_M2, sedov_M3, ErdosProblem42, ErdosProblem42_constructive. Former axioms proved in research PR #5569.",
+    "assumptions": "4 axiom declarations: sedov_M2, sedov_M3, ErdosProblem42, ErdosProblem42_constructive. sidon_size_bound proved from Mathlib via difference counting injection.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Sidon sets (also called B₂ sets) were introduced by Simon Sidon in the 1930s through correspondence with Erdős. A Sidon set is a set of integers where all pairwise sums are distinct. Erdős and Turán (1941) proved the fundamental size bound |A| ≤ √(2N) for Sidon subsets of {1,...,N}. Problem 42 asks about the rigidity of maximal Sidon sets: even though adding any new element to a maximal Sidon set creates a repeated sum, the conjecture asserts that the difference set A−A cannot monopolize all available differences. Sedov proved the cases M = 2 (by pigeonhole counting) and M = 3 (by combining analytic estimates with computational verification). The problem connects to broader questions in additive combinatorics about the structure of B₂ sets, including the Erdős–Turán conjecture on the maximum size of Sidon sets and Ruzsa's constructions of near-optimal Sidon sets.",
     "problemStatement": "For every M ≥ 1 and N sufficiently large, is it true that every maximal Sidon set A ⊆ {1,...,N} admits a companion Sidon set B ⊆ {1,...,N} of size M with (A−A) ∩ (B−B) = {0}?",
     "text": "For every maximal Sidon set A ⊆ {1,...,N}, does there exist a Sidon set B of size M with (A−A) ∩ (B−B) = {0}? Proved for M ≤ 3 (Sedov). Open in general.",
-    "proofStrategy": "The formalization defines Sidon sets via sum-distinctness on Finset ℕ, interval containment, and maximality in the inclusion order. Difference sets are computed as Finset ℤ via biUnion. The key axioms record the classical size bound |A|² ≤ 2N+1, Sedov's results for M ≤ 3, and both the existential and constructive forms of the general conjecture. The constructive version asks for an explicit threshold function f(M) bounding the required N.",
+    "proofStrategy": "The formalization defines Sidon sets via sum-distinctness on Finset ℕ, interval containment, and maximality in the inclusion order. Difference sets are computed as Finset ℤ via biUnion. The classical size bound |A|(|A|-1) ≤ 2(N-1) is proved from Mathlib by showing the difference map is injective on off-diagonal pairs (via Sidon property) with image in a bounded integer interval. The remaining axioms record Sedov's M=2,3 results and the open general conjecture.",
     "keyInsights": [
       "**Difference occupation**: A Sidon set A with |A| ≈ √N generates |A−A| ≈ N distinct differences out of 2N possible, leaving substantial room in principle for companion sets",
       "**Maximality vs. maximum**: Maximal Sidon sets (inclusion-maximal) are typically smaller than maximum Sidon sets, which complicates the difference-counting heuristic",
@@ -95,9 +95,9 @@
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 52,
-      "endLine": 65,
-      "summary": "Records the classical size bound |A|² ≤ 2N+1, the trivial 0 ∈ A−A, and a concrete example {1,2,4}.",
-      "mathContext": "Records the classical size bound |A|² $\\leq$ 2N+1, the trivial 0 ∈ A−A, and a concrete example {1,2,4}."
+      "endLine": 110,
+      "summary": "Proves the classical size bound |A|(|A|-1) ≤ 2(N-1) from Mathlib via difference counting injection, plus 0 ∈ A−A and example {1,2,4}.",
+      "mathContext": "Proved: The classical Sidon set size bound |A|(|A|-1) $\\leq$ 2(N-1) is proved from Mathlib by showing the difference map is injective on off-diagonal pairs. Also proves 0 ∈ A−A and verifies {1,2,4} as a concrete maximal Sidon set."
     },
     {
       "id": "sedov-M2",
@@ -151,9 +151,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 131,
-    "axiomCount": 5,
-    "theoremCount": 0,
+    "lineCount": 189,
+    "axiomCount": 4,
+    "theoremCount": 1,
     "definitionCount": 5
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-1167.json
+++ b/src/data/research/problems/erdos-1167.json
@@ -16,9 +16,9 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-01-15T16:53:51.159Z",
-    "iteration": 1,
+    "iteration": 3,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,14 +29,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 3 axioms (main conjecture + infinite Ramsey + Erdos-Rado). 15 proved theorems - well-developed.",
-    "builtItems": [],
+    "progressSummary": "SURVEY: Confirmed infinite_ramsey axiom IS buildable (~150-200 lines) using Mathlib pigeonhole. PR #7041 has r=0,r=1 proofs. Detailed implementation plan with 5 concrete steps documented. erdos_rado_theorem NOT buildable. Main conjecture OPEN.",
+    "builtItems": [
+      "infinite_ramsey_zero: proved PartitionRelation aleph0 aleph0 0 k for all k",
+      "infinite_ramsey_one: proved PartitionRelation aleph0 aleph0 1 k for k >= 1 via pigeonhole"
+    ],
     "insights": [
       "All axioms are deep set-theoretic results not provable from current Mathlib",
-      "15 proved theorems make this a strong formalization already"
+      "15 proved theorems make this a strong formalization already",
+      "r=0 case of infinite Ramsey is trivially provable (unique 0-subset)",
+      "r=1 case follows from infinite pigeonhole (Finite.exists_infinite_fiber)",
+      "The infinite_ramsey axiom is only needed for r >= 2 where Ramsey diagonal argument + transfinite recursion are required",
+      "infinite_ramsey IS buildable (~150-200 lines): Mathlib has Finite.exists_infinite_fiber (infinite pigeonhole), Set.Infinite lemmas, and Classical.choice — all needed for the proof",
+      "Proof strategy for infinite_ramsey: induction on r. Base r=0,1 proved in PR #7041. Inductive step: thinning chain construction using pigeonhole at each step, then pigeonhole on colors",
+      "Key formalization challenge: recursive chain construction carrying Set.Infinite proofs, converting between Set.Infinite and Infinite typeclass, and working with RSubset α 2 (2-element Finset subtypes)",
+      "erdos_rado_theorem is NOT buildable without major infrastructure (delta-system lemma, transfinite recursion)",
+      "partition_one_color already proves infinite_ramsey r 1 and infinite_ramsey r 0 is vacuously true, so axiom only needed for r >= 2 and k >= 2",
+      "PR #7041 (open, researcher-6) has r=0 and r=1 proofs — coordinate to avoid duplicate work"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Implement thin_step helper: given infinite S and pair-coloring into Fin k, return (element, color, infinite_subset) using Finite.exists_infinite_fiber on the subtype",
+      "Implement chain : ℕ → (Set α × α × β) using Nat.rec with thin_step, carrying Set.Infinite proof through the recursion",
+      "Prove chain monotonicity: chain(n+1).set ⊆ chain(n).set and chain(n).element ∈ chain(n).set",
+      "Apply Finite.exists_infinite_fiber to the color sequence to extract infinite monochromatic subsequence",
+      "Verify IsMonochromatic property: for any 2-subset of the extracted set, the color equals chain(i).color where i is the smaller index"
+    ],
     "markdown": "# Erdős #1167 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -54,15 +72,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:53:51.159Z",
-  "lastUpdate": "2026-03-13T07:52:17.059Z",
+  "lastUpdate": "2026-03-26T23:30:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1167Problem.lean",
       "filename": "Erdos1167Problem.lean",
-      "lineCount": 291,
-      "theoremCount": 15,
+      "lineCount": 352,
+      "theoremCount": 17,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-42.json
+++ b/src/data/research/problems/erdos-42.json
@@ -16,9 +16,9 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-12T06:58:30.838Z",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,11 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: Assessed 5 axioms. sidon_size_bound is provable (standard counting). sedov_M2/M3 are published results. ErdosProblem42/constructive are open.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: Proved sidon_size_bound from Mathlib (axiom count 5→4). Remaining 4 axioms: sedov_M2, sedov_M3 (published results), ErdosProblem42, ErdosProblem42_constructive (open conjecture).",
+    "builtItems": [
+      "theorem sidon_size_bound in Proofs/Erdos42Problem.lean:56 — axiom eliminated (5→4)"
+    ],
     "insights": [
       "sidon_size_bound is provable: for Sidon A⊆[1,N], the map (a,b)↦(a:ℤ)-(b:ℤ) is injective on off-diagonal A×A pairs (by Sidon + Finset.pair analysis), image ⊆ [-N+1,N-1]\\{0}, giving |A|(|A|-1) ≤ 2(N-1)",
-      "ErdosProblem42 and ErdosProblem42_constructive are genuinely OPEN, sedov_M2/M3 are published results"
+      "ErdosProblem42 and ErdosProblem42_constructive are genuinely OPEN, sedov_M2/M3 are published results",
+      "sidon_size_bound PROVED: injective difference map on A.offDiag → Finset.Icc (1-N) (N-1) \\ {0}, using Sidon to derive sum equality, Finset.pair membership, and omega"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -65,7 +68,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T06:58:30.839Z",
-  "lastUpdate": "2026-03-13T07:52:17.043Z",
+  "lastUpdate": "2026-03-26T23:05:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- Prove `sidon_size_bound` theorem for Erdős Problem #42: for a Sidon set A ⊆ {1,...,N}, |A|(|A|-1) ≤ 2(N-1)
- Axiom count reduced from 5 to 4 (remaining: sedov_M2, sedov_M3, ErdosProblem42, ErdosProblem42_constructive)

## Progress
- **Axiom eliminated**: `sidon_size_bound` proved from Mathlib using injection argument
- **Proof technique**: The difference map (a₁,a₂) ↦ a₁-a₂ is injective on off-diagonal ordered pairs by the Sidon property, with image in {-(N-1),...,N-1}\{0} (2(N-1) elements)
- Uses `Finset.offDiag`, `Finset.card_image_of_injOn`, `Int.card_Icc`

## Findings
- `sidon_size_bound` is a standard counting argument, fully provable from Mathlib
- sedov_M2/M3 are deep published results (not eliminable without substantial work)
- ErdosProblem42/ErdosProblem42_constructive are the main open conjecture

## Status
**Outcome**: progress (axiom elimination)
**Next Steps**: Consider proving sedov_M2 computationally for small N via native_decide

🤖 Generated by researcher-9