### PR TITLE
Research: erdos-36/368 — axiom elimination (11→5)

### DIFF
--- a/proofs/Proofs/Erdos368Problem.lean
+++ b/proofs/Proofs/Erdos368Problem.lean
@@ -82,8 +82,11 @@ theorem consecutive_coprime (n : ℕ) : Nat.Coprime n (n + 1) :=
 **Coprimality Consequence:**
 The prime factors of n(n+1) are the union of prime factors of n and n+1.
 -/
-axiom primeFactors_product_coprime (n : ℕ) (hn : n ≥ 1) :
-    (n * (n + 1)).primeFactors = n.primeFactors ∪ (n + 1).primeFactors
+theorem primeFactors_product_coprime (n : ℕ) (hn : n ≥ 1) :
+    (n * (n + 1)).primeFactors = n.primeFactors ∪ (n + 1).primeFactors := by
+  have hn0 : n ≠ 0 := by omega
+  have hn1 : n + 1 ≠ 0 := by omega
+  exact Nat.primeFactors_mul hn0 hn1
 
 /--
 Thus F(n) = max(gpf(n), gpf(n+1)).
@@ -130,7 +133,9 @@ axiom mahler_bound :
 **Mahler improves Pólya:**
 The quantitative bound c · log log n → ∞ implies F(n) → ∞.
 -/
-axiom mahler_improves_polya :
+/-- Mahler's bound implies Pólya's theorem (analysis argument).
+Not used in proofs below. -/
+def mahler_improves_polya_prop : Prop :=
     (∃ c : ℝ, c > 0 ∧ ∃ N : ℕ, ∀ n ≥ N, (F n : ℝ) ≥ c * Real.log (Real.log n)) →
     (∀ M : ℕ, ∃ N : ℕ, ∀ n ≥ N, F n > M)
 
@@ -159,7 +164,9 @@ def isSmooth (B n : ℕ) : Prop := ∀ p : ℕ, p.Prime → p ∣ n → p ≤ B
 Numbers of the form n(n+1) that are B-smooth exist infinitely often
 when B is chosen appropriately.
 -/
-axiom infinitely_many_smooth_products :
+/-- Infinitely many smooth products of consecutive integers.
+Deep result (Schinzel); not used in proofs below. -/
+def infinitely_many_smooth_products_prop : Prop :=
     ∀ M : ℕ, ∃ n > M, ∃ B : ℕ,
       isSmooth B (n * (n + 1)) ∧
       (B : ℝ) ≤ (n : ℝ) ^ (1 / Real.log (Real.log (Real.log n)))
@@ -205,7 +212,9 @@ axiom pasten_bound :
 **Pasten improves Mahler:**
 (log log n)² / (log log log n) ≫ log log n for large n.
 -/
-axiom pasten_improves_mahler :
+/-- Pasten's bound implies Mahler's bound (analysis argument).
+Not used in proofs below. -/
+def pasten_improves_mahler_prop : Prop :=
     (∃ c : ℝ, c > 0 ∧ ∃ N : ℕ,
       ∀ n ≥ N, (F n : ℝ) ≥ c * (Real.log (Real.log n))^2 / Real.log (Real.log (Real.log n))) →
     (∃ c' : ℝ, c' > 0 ∧ ∃ N' : ℕ,
@@ -280,7 +289,8 @@ noncomputable def P_squared_plus_one (n : ℕ) : ℕ := largestPrimeFactor (n^2 
 P(n² + 1) ≫ (log log n)² / (log log log n).
 This was the key advance leading to improved ABC-related bounds.
 -/
-axiom pasten_squared_plus_one :
+/-- Pasten's result for n²+1 variant. Deep result; not used in proofs below. -/
+def pasten_squared_plus_one_prop : Prop :=
     ∃ c : ℝ, c > 0 ∧ ∃ N : ℕ,
       ∀ n ≥ N, (P_squared_plus_one n : ℝ) ≥
         c * (Real.log (Real.log n))^2 / Real.log (Real.log (Real.log n))
@@ -302,7 +312,8 @@ def radical (n : ℕ) : ℕ := (n.primeFactors).prod id
 **ABC Would Imply:**
 Under ABC, F(n) ≥ (log n)^(1-ε) for any ε > 0.
 -/
-axiom abc_implies_strong_bound :
+/-- ABC conjecture would imply strong bounds on F. Not used in proofs below. -/
+def abc_implies_strong_bound_prop : Prop :=
     -- If ABC conjecture holds...
     (∀ ε : ℝ, ε > 0 → ∃ K : ℝ,
       ∀ a b c : ℕ, Nat.Coprime a b → a + b = c →

--- a/src/data/proofs/erdos-368/meta.json
+++ b/src/data/proofs/erdos-368/meta.json
@@ -56,7 +56,7 @@
       "Concrete examples F(1) through F(8)",
       "erdos_368_summary combining all results"
     ],
-    "axiomCount": 11,
+    "axiomCount": 5,
     "relatedProblems": [
       {
         "id": "ramseys-theorem",
@@ -205,7 +205,7 @@
     ],
     "namespace": "Erdos368",
     "lineCount": 342,
-    "axiomCount": 11,
+    "axiomCount": 5,
     "theoremCount": 13,
     "definitionCount": 7
   },

--- a/src/data/research/problems/erdos-36.json
+++ b/src/data/research/problems/erdos-36.json
@@ -29,9 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Erdos368Problem.lean axiom elimination 11→5 (6 eliminated). Proved coprime factorization from Mathlib.",
+    "builtItems": [
+      "Proved primeFactors_product_coprime from Mathlib Nat.primeFactors_mul",
+      "Converted 5 unused axiom propositions to def Prop"
+    ],
+    "insights": [
+      "Erdos368Problem.lean: 6 axioms eliminated (11→5). primeFactors_product_coprime proved from Nat.primeFactors_mul (Mathlib). 5 unused axioms converted to def Prop."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #36 - Knowledge Base\n\n## Problem Statement\n\nFind the optimal constant $c>0$ such that the following holds. For all sufficiently large $N$, if $A\\sqcup B=\\{1,\\ldots,2N\\}$ is a partition into two equal parts, so that $\\lvert A\\rvert=\\lvert B\\rvert=N$, then there is some $x$ such that the number of solutions to $a-b=x$ with $a\\in A$ and $b\\in B$ is at least $cN$. The minimum overlap problem. The example (with $N$ even) $A=\\{N/2+1,\\ldots,3N/2\\}$ shows that $c\\leq 1/2$ (indeed, Erdős initially conjectured that $c=1/2$). The lower bound of $c\\geq 1/4$ is trivial, and Scherk improved this to $1-1/\\sqrt{2}=0.29\\cdots$. The current records are\\[0.379005 View the LaTeX source This page was last edited 30 September 2025.\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #4\n- Problem #35\n- Problem #37\n- Problem #39\n- Problem #1\n\n## References\n\n- Er55\n- Er56\n- Er61\n- Er92c\n- Wh22\n- Ha16\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"


### PR DESCRIPTION
## Summary
Eliminate 6 of 11 axioms from Erdos368Problem.lean (Largest Prime Factor of n(n+1)).

## Progress
| Category | Count | Details |
|----------|-------|---------|
| **Proved** | 1 | `primeFactors_product_coprime` — proved from Mathlib `Nat.primeFactors_mul` |
| **→ def Prop** | 5 | `mahler_improves_polya`, `infinitely_many_smooth_products`, `pasten_improves_mahler`, `pasten_squared_plus_one`, `abc_implies_strong_bound` |

## Remaining 5 axioms (essential)
- `F_eq_max`: F(n) = max(gpf(n), gpf(n+1)) — needs proof from primeFactors
- `polya_theorem`, `mahler_bound`, `pasten_bound`, `schinzel_upper` — deep number-theoretic results used by summary theorem

## Status
**Outcome**: completed
**Axioms**: 11 → 5 (6 eliminated)

Generated by researcher-5