### PR TITLE
Research: erdos-190 — prove H_spec and H_lower_bound (9A→7A)

### DIFF
--- a/proofs/Proofs/Erdos190Problem.lean
+++ b/proofs/Proofs/Erdos190Problem.lean
@@ -109,9 +109,41 @@ noncomputable def H (k : ℕ) : ℕ :=
 axiom exists_canonical_threshold (k : ℕ) :
     ∃ N : ℕ, ∀ (C : Type) [DecidableEq C] (χ : Fin N → C), hasCanonicalAP χ k
 
-/-- For N ≥ H(k), every coloring has the canonical property. -/
-axiom H_spec (k N : ℕ) (hN : N ≥ H k) :
-    ∀ (C : Type) [DecidableEq C] (χ : Fin N → C), hasCanonicalAP χ k
+/-- For N ≥ H(k), every coloring has the canonical property.
+    Proof: restrict χ : Fin N → C to Fin (H k) via Fin.castLE,
+    apply Nat.find_spec, then lift the AP back via Fin.castLE.
+    The monochromatic/rainbow property transfers because castLE is injective. -/
+theorem H_spec (k N : ℕ) (hN : N ≥ H k) :
+    ∀ (C : Type) [DecidableEq C] (χ : Fin N → C), hasCanonicalAP χ k := by
+  intro C _ χ
+  have hle : H k ≤ N := hN
+  -- Restrict coloring to first H(k) elements
+  let χ' : Fin (H k) → C := χ ∘ Fin.castLE hle
+  -- By Nat.find_spec, χ' has a canonical AP
+  obtain ⟨f, hAP, hColor⟩ := Nat.find_spec (exists_canonical_threshold k) C χ'
+  -- Lift AP to Fin N: castLE preserves .val so AP property transfers
+  have hinj := Fin.castLE_injective hle
+  refine ⟨Fin.castLE hle ∘ f, ?_, ?_⟩
+  · -- isAPSequence preserved: castLE preserves .val
+    obtain ⟨a, d, hd, hf⟩ := hAP
+    exact ⟨a, d, hd, fun i => by simp [Fin.castLE, hf i]⟩
+  · -- Coloring property transfers via castLE
+    have himg : Finset.image (Fin.castLE hle ∘ f) Finset.univ =
+        Finset.image (Fin.castLE hle) (Finset.image f Finset.univ) := by
+      rw [← Finset.image_comp]
+    rw [himg]
+    cases hColor with
+    | inl hMono =>
+      left
+      obtain ⟨c, hc⟩ := hMono
+      exact ⟨c, fun x hx => by
+        obtain ⟨y, hy, rfl⟩ := Finset.mem_image.mp hx
+        exact hc y hy⟩
+    | inr hRain =>
+      right
+      unfold isRainbow at hRain ⊢
+      rw [Finset.card_image_of_injective _ hinj, Finset.image_image]
+      exact hRain
 
 /-- H(k) is the minimum such N.
     Proof: direct from Nat.find_min (minimality of Nat.find). -/
@@ -141,8 +173,26 @@ noncomputable def W (k : ℕ) : ℕ :=
 /-- H(k) ≤ W(k) because rainbow APs give an easier win condition. -/
 axiom H_le_W (k : ℕ) (hk : k ≥ 3) : H k ≤ W k
 
-/-- But H(k) is still large. -/
-axiom H_lower_bound (k : ℕ) (hk : k ≥ 3) : H k ≥ k
+/-- H(k) ≥ k for k ≥ 1: a k-term AP a, a+d, ..., a+(k-1)d with d ≥ 1
+    requires N ≥ k (since the max value a+(k-1)d ≥ k-1).
+    Strengthened from original k ≥ 3 to k ≥ 1. -/
+theorem H_lower_bound (k : ℕ) (hk : k ≥ 1) : H k ≥ k := by
+  by_contra h
+  push_neg at h  -- h : H k < k
+  -- Nat.find_spec gives a canonical AP for any coloring of Fin (H k)
+  obtain ⟨f, ⟨a, d, hd, hf⟩, _⟩ :=
+    Nat.find_spec (exists_canonical_threshold k) (Fin (H k)) (fun x => x)
+  -- f : Fin k → Fin (H k) with f i = a + i * d, d > 0
+  -- The last element: a + (k-1)*d < H k
+  have hval := hf ⟨k - 1, by omega⟩
+  have hlt := (f ⟨k - 1, by omega⟩).isLt
+  -- But a + (k-1)*d ≥ (k-1)*1 = k-1 (since d ≥ 1)
+  have hge : k - 1 ≤ a + (k - 1) * d := by
+    calc k - 1 = (k - 1) * 1 := by omega
+      _ ≤ (k - 1) * d := Nat.mul_le_mul_left _ (by omega : 1 ≤ d)
+      _ ≤ a + (k - 1) * d := Nat.le_add_left _ _
+  -- k-1 ≤ a+(k-1)*d < H k < k — no natural between k-1 and k
+  omega
 
 /- ## Part VI: Known Asymptotic Results -/
 

--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 190,
     "erdosUrl": "https://erdosproblems.com/190",
     "erdosProblemStatus": "open",
-    "axiomCount": 11,
-    "lineCount": 250,
-    "assumptions": "11 axioms: exists_canonical_threshold, H_spec, H_minimal, and 8 more. See Lean source for complete statements.",
+    "axiomCount": 7,
+    "lineCount": 296,
+    "assumptions": "7 axioms: exists_canonical_threshold (Szemerédi), vanDerWaerden_exists, H_le_W (k≥3), H_root_to_infinity, erdos_190 (OPEN conjecture), H_3_bound, H_4_bound. Proved: H_spec (Fin.castLE restriction), H_lower_bound (AP needs N≥k), H_pos (k≥1), H_minimal (Nat.find_min).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -145,9 +145,9 @@
       "Finset"
     ],
     "namespace": "Erdos190",
-    "lineCount": 250,
-    "axiomCount": 11,
-    "theoremCount": 2,
+    "lineCount": 296,
+    "axiomCount": 7,
+    "theoremCount": 6,
     "definitionCount": 10
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-190.json
+++ b/src/data/research/problems/erdos-190.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-190",
-  "title": "Erdős #190",
+  "title": "Erd\u0151s #190",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -18,27 +18,32 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-26T00:00:00Z",
-    "iteration": 1,
-    "focus": "10 axioms (down from 11). Proved H_minimal. Found H_pos false at k=0.",
+    "iteration": 2,
+    "focus": "Proved H_spec, H_lower_bound (9->7 axioms). Remaining 7 axioms are deep or computational.",
     "blockers": [],
     "nextAction": "Prove H_spec (needs monotonicity argument), fix H_pos condition"
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved H_pos (10→9 axioms). Fixed false axiom (was missing k≥1 hypothesis).",
+    "progressSummary": "PROGRESS: Proved H_spec (restriction arg) and H_lower_bound (AP size). Axiom count 9\u21927. H_spec uses Fin.castLE + Nat.find_spec; H_lower_bound uses AP max-value bound k-1 \u2264 a+(k-1)*d.",
     "builtItems": [
-      "H_minimal: proved directly from Nat.find_min + push_neg",
-      "H_pos (Erdos190Problem.lean:226): theorem with k≥1 hypothesis, fixed false axiom"
+      "H_minimal: proved from Nat.find_min (prior session)",
+      "H_pos: proved for k>=1 (prior session)",
+      "H_spec: proved via Fin.castLE restriction from Nat.find_spec",
+      "H_lower_bound: proved \u2014 k-term AP needs N>=k (strengthened to k>=1 from k>=3)"
     ],
     "insights": [
       "H_pos is FALSE for k=0: H(0)=0 because empty AP (Fin 0) trivially satisfies hasCanonicalAP",
-      "H_spec is provable via restriction: χ → χ∘Fin.castLE transfers canonical AP from Fin(H k) to Fin N",
+      "H_spec is provable via restriction: \u03c7 \u2192 \u03c7\u2218Fin.castLE transfers canonical AP from Fin(H k) to Fin N",
       "H_minimal is a direct consequence of Nat.find minimality",
-      "H_pos proved: H(k)>0 for k≥1 via Fin 0 emptiness — Fin.elim0 eliminates impossible Fin k → Fin 0"
+      "H_pos proved: H(k)>0 for k\u22651 via Fin 0 emptiness \u2014 Fin.elim0 eliminates impossible Fin k \u2192 Fin 0",
+      "H_spec follows from Nat.find_spec + Fin.castLE restriction: restrict coloring to first H(k) elements, get canonical AP, lift back via injective castLE",
+      "H_lower_bound: any k-term AP has max value a+(k-1)*d >= k-1, so it needs N>=k",
+      "For rainbow case in H_spec: Fin.castLE_injective preserves card of image, and Finset.image_image transfers color map"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Prove H_spec via Fin.castLE restriction argument (needs image/injection lemmas)",
-      "Fix H_pos: add k ≥ 1 hypothesis",
+      "Fix H_pos: add k \u2265 1 hypothesis",
       "Prove H_le_W: show van der Waerden property implies canonical property"
     ]
   },
@@ -56,16 +61,16 @@
     "mathlib": []
   },
   "started": "2026-01-12T16:01:50.836Z",
-  "lastUpdate": "2026-03-27T00:10:00Z",
+  "lastUpdate": "2026-03-26T23:30:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos190Problem.lean",
       "filename": "Erdos190Problem.lean",
-      "lineCount": 265,
-      "theoremCount": 4,
-      "axiomCount": 9,
+      "lineCount": 296,
+      "theoremCount": 6,
+      "axiomCount": 7,
       "defCount": 10,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Prove `H_spec` (axiom → theorem): Nat.find_spec + Fin.castLE restriction
- Prove `H_lower_bound` (axiom → theorem): AP max-value bound, strengthened from k≥3 to k≥1
- Axiom count reduced from 9 to 7

## Proof Techniques

### H_spec (monotonicity of canonical threshold)
For N ≥ H(k), restrict coloring χ : Fin N → C to Fin(H k) via Fin.castLE. Apply Nat.find_spec to get a canonical AP, then lift back via injective castLE. Rainbow case uses `card_image_of_injective` and `image_image`.

### H_lower_bound (AP size constraint)
A k-term AP a, a+d, ..., a+(k-1)d with d ≥ 1 has max value ≥ k-1, requiring N ≥ k. Formally: `k-1 ≤ a+(k-1)*d < H(k)` and `H(k) < k` gives no natural between k-1 and k.

## Remaining Axioms (7)
| Axiom | Type |
|-------|------|
| `exists_canonical_threshold` | Deep (Szemerédi) |
| `vanDerWaerden_exists` | Deep (van der Waerden) |
| `H_le_W` | Structural (needs general vdW) |
| `H_root_to_infinity` | Analytic growth bound |
| `erdos_190` | OPEN conjecture |
| `H_3_bound`, `H_4_bound` | Computational bounds |

🤖 Generated by researcher-5

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>