### PR TITLE
Research: 6 problems — 16 axioms eliminated + 1 new proof

### DIFF
--- a/proofs/Proofs/Erdos776Problem.lean
+++ b/proofs/Proofs/Erdos776Problem.lean
@@ -100,19 +100,73 @@ axiom sperner_theorem (n : ℕ) :
 
 /-- The middle layer has the most sets: all sets of size ⌊n/2⌋ form
     an antichain with one distinct size and multiplicity C(n, ⌊n/2⌋). -/
-axiom middle_layer_antichain (n : ℕ) :
-  ∃ F : SubsetFamily n, IsAntichain F ∧
-    numDistinctSizes F = 1 ∧
-    F.card = Nat.choose n (n / 2)
+theorem middle_layer_antichain (n : ℕ) :
+    ∃ F : SubsetFamily n, IsAntichain F ∧
+      numDistinctSizes F = 1 ∧
+      F.card = Nat.choose n (n / 2) := by
+  -- Take F = all (n/2)-element subsets of Fin n
+  use (Finset.univ : Finset (Fin n)).powersetCard (n / 2)
+  refine ⟨?_, ?_, ?_⟩
+  · -- IsAntichain: same-size sets can't have proper subset relation
+    intro A hA B hB hne hsub
+    rw [Finset.mem_powersetCard] at hA hB
+    exact hne (Finset.eq_of_subset_of_card_le hsub (hB.2 ▸ hA.2 ▸ le_refl _))
+  · -- numDistinctSizes = 1: all sets have the same cardinality
+    unfold numDistinctSizes distinctSizes
+    -- Every element has card = n/2, so image = {n/2}
+    have hall : ∀ A ∈ (Finset.univ : Finset (Fin n)).powersetCard (n / 2),
+        A.card = n / 2 := by
+      intro A hA; exact (Finset.mem_powersetCard.mp hA).2
+    -- The family is nonempty (powersetCard k univ is nonempty when k ≤ n)
+    have hne : ((Finset.univ : Finset (Fin n)).powersetCard (n / 2)).Nonempty := by
+      obtain ⟨t, ht, htc⟩ := Finset.exists_smaller_set
+        (Finset.univ : Finset (Fin n)) (n / 2) (by simp [Fintype.card_fin]; omega)
+      exact ⟨t, Finset.mem_powersetCard.mpr ⟨ht, htc⟩⟩
+    -- Image of card on same-sized sets is a singleton
+    have himg : Finset.image Finset.card
+        ((Finset.univ : Finset (Fin n)).powersetCard (n / 2)) = {n / 2} := by
+      ext s; simp only [Finset.mem_image, Finset.mem_singleton]; constructor
+      · rintro ⟨A, hA, rfl⟩; exact hall A hA
+      · intro hs; obtain ⟨A, hA⟩ := hne
+        exact ⟨A, hA, (hall A hA).trans hs.symm⟩
+    rw [himg, Finset.card_singleton]
+  · -- card = C(n, n/2)
+    rw [Finset.card_powersetCard, Fintype.card_fin]
 
 /-- To get many distinct sizes, we need sets from many different layers.
     The antichain constraint limits how sets from different layers interact. -/
-axiom size_variety_tradeoff (n r : ℕ) (hr : r ≥ 1) :
-  ∀ F : SubsetFamily n, IsAntichain F → HasMultiplicity F r →
-    -- The family needs at least r·(numDistinctSizes F) sets
-    F.card ≥ r * numDistinctSizes F
+theorem size_variety_tradeoff (n r : ℕ) (hr : r ≥ 1) :
+    ∀ F : SubsetFamily n, IsAntichain F → HasMultiplicity F r →
+      F.card ≥ r * numDistinctSizes F := by
+  intro F _ hmult
+  unfold numDistinctSizes
+  -- F decomposes into disjoint groups by cardinality
+  -- Step 1: F = ⋃_{s ∈ distinctSizes F} (F.filter (·.card = s))
+  have h_eq : F = (distinctSizes F).biUnion (fun s => F.filter (fun A => A.card = s)) := by
+    ext A; constructor
+    · intro hA
+      rw [Finset.mem_biUnion]
+      exact ⟨A.card, Finset.mem_image.mpr ⟨A, hA, rfl⟩, Finset.mem_filter.mpr ⟨hA, rfl⟩⟩
+    · intro hA
+      rw [Finset.mem_biUnion] at hA
+      obtain ⟨_, _, hAf⟩ := hA
+      exact (Finset.mem_filter.mp hAf).1
+  -- Step 2: The groups are pairwise disjoint
+  have h_disj : ∀ s ∈ distinctSizes F, ∀ t ∈ distinctSizes F, s ≠ t →
+      Disjoint (F.filter (fun A => A.card = s)) (F.filter (fun A => A.card = t)) := by
+    intro s _ t _ hst
+    rw [Finset.disjoint_left]
+    intro A hAs hAt
+    exact hst ((Finset.mem_filter.mp hAs).2 ▸ (Finset.mem_filter.mp hAt).2)
+  -- Step 3: |F| = ∑ |groups| ≥ ∑ r = r · d
+  rw [h_eq, Finset.card_biUnion h_disj]
+  calc ∑ s ∈ distinctSizes F, (F.filter (fun A => A.card = s)).card
+      ≥ ∑ _s ∈ distinctSizes F, r := Finset.sum_le_sum (fun s hs => hmult s hs)
+    _ = r * (distinctSizes F).card := by
+        rw [Finset.sum_const, mul_comm]; simp [smul_eq_mul]
 
 /-- For size k, the number of k-element subsets of {1,...,n} is C(n,k).
     The multiplicity constraint r requires C(n,k) ≥ r for each used size k. -/
-axiom size_availability (n r k : ℕ) (hk : k ≤ n) :
-  Nat.choose n k ≥ r → True  -- Size k can contribute to a multiplicity-r family
+theorem size_availability (n r k : ℕ) (hk : k ≤ n) :
+  Nat.choose n k ≥ r → True := by
+  intro; trivial

--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -42,11 +42,14 @@
       "Defined maxDistinctSizes via Finset.sup over all valid families",
       "Proved erdos_trotter_exact from upper and lower bound axioms using omega",
       "Formalized the threshold conjecture with minimality condition",
-      "Axiomatized the size-variety tradeoff and size availability constraints"
+      "Axiomatized the size-variety tradeoff and size availability constraints",
+      "Proved size_variety_tradeoff via partition-by-cardinality counting argument",
+      "Proved middle_layer_antichain by constructing powersetCard family",
+      "Proved size_availability (trivially True conclusion)"
     ],
-    "axiomCount": 8,
-    "lineCount": 118,
-    "assumptions": "8 axioms: erdos_trotter_r1, erdos_trotter_upper, erdos_trotter_achievable, and 5 more. See Lean source for complete statements.",
+    "axiomCount": 5,
+    "lineCount": 172,
+    "assumptions": "5 axioms: erdos_trotter_r1, erdos_trotter_upper, erdos_trotter_achievable, erdos_776_threshold (open), sperner_theorem. See Lean source.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -105,12 +108,12 @@
       "title": "Structural Observations",
       "startLine": 94,
       "endLine": 118,
-      "summary": "Axiomatizes Sperner's theorem ($|\\mathcal{F}| \\leq \\binom{n}{\\lfloor n/2 \\rfloor}$), the middle layer antichain (one size, maximum cardinality), the size-variety tradeoff ($|\\mathcal{F}| \\geq r \\cdot d$), and the size availability condition ($\\binom{n}{k} \\geq r$ needed for layer $k$).",
+      "summary": "Axiomatizes Sperner's theorem ($|\\mathcal{F}| \\leq \\binom{n}{\\lfloor n/2 \\rfloor}$). Proves the middle layer antichain (constructing powersetCard family), the size-variety tradeoff ($|\\mathcal{F}| \\geq r \\cdot d$) via partition counting, and size availability (trivially True).",
       "mathContext": "Sperner: $|\\mathcal{F}| \\leq \\binom{n}{\\lfloor n/2\\rfloor}$. Middle layer: $d = 1$, $|\\mathcal{F}| = \\binom{n}{\\lfloor n/2\\rfloor}$. Tradeoff: $|\\mathcal{F}| \\geq r \\cdot d$. Availability: layer $k$ usable iff $\\binom{n}{k} \\geq r$."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #776 is formalized with 5 definitions, 1 proved theorem, and 6 axioms. The theorem `erdos_trotter_exact` is genuinely proved from the upper and lower bound axioms. The open question is to determine the threshold $N(r)$ as a function of $r$, which would complete the characterization of multiplicity-constrained antichains.",
+    "summary": "Erdős Problem #776 is formalized with 6 definitions, 4 proved theorems, and 5 axioms. The theorem `erdos_trotter_exact` is proved from axiomatized bounds, `size_variety_tradeoff` is proved via partition-by-cardinality counting, `middle_layer_antichain` is proved constructively, and `size_availability` is trivially proved. The open question is to determine the threshold $N(r)$ as a function of $r$.",
     "implications": "**Theoretical Significance**: Resolution would advance the extremal theory of antichains in Boolean lattices beyond classical Sperner-type results.\n\nThe threshold $N(r)$ likely depends on the growth of $\\binom{n}{k}$ near the extremes, connecting to concentration phenomena for binomial coefficients. A precise formula would extend the Griggs result ($r = 1$, max $= n - 2$) to the full multiplicity spectrum.",
     "openQuestions": [
       "What is the precise threshold $N(r)$ as a function of $r$? Is it polynomial, exponential, or something else?",
@@ -157,9 +160,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 118,
-    "axiomCount": 8,
-    "theoremCount": 1,
+    "lineCount": 172,
+    "axiomCount": 5,
+    "theoremCount": 4,
     "definitionCount": 6
   }
 }

--- a/src/data/research/problems/erdos-776.json
+++ b/src/data/research/problems/erdos-776.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-776",
-  "title": "Erdős #776",
+  "title": "Erd\u0151s #776",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -29,12 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Reduced axiom count 8->5 by proving size_availability (trivial), size_variety_tradeoff (counting), middle_layer_antichain (construction). Remaining 5 axioms: 3 deep Erdos-Trotter results, 1 open conjecture, 1 Sperner theorem (Mathlib bridge needed).",
+    "builtItems": [
+      "Proved size_availability (axiom->theorem) in Erdos776Problem.lean",
+      "Proved size_variety_tradeoff (axiom->theorem) via Finset.card_biUnion + Finset.sum_le_sum",
+      "Proved middle_layer_antichain (axiom->theorem) via powersetCard construction"
+    ],
+    "insights": [
+      "size_availability axiom has trivially True conclusion \u2014 provable with intro; trivial",
+      "size_variety_tradeoff provable via partition-by-cardinality: biUnion of disjoint filters, sum of lower bounds",
+      "middle_layer_antichain provable by constructing powersetCard (n/2) univ and showing antichain + singleton image",
+      "sperner_theorem: Mathlib has IsAntichain.sperner via LYM, but custom IsAntichain definition creates bridge gap"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #776 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $r\\geq 2$ and $A_1,\\ldots,A_m\\subseteq \\{1,\\ldots,n\\}$ be such that $A_i\\not\\subseteq A_j$ for all $i\\neq j$ and for any $t$ if there exists some $i$ with $\\lvert A_i\\rvert=t$ then there must exist at least $r$ sets of that size.\n\nHow large must $n$ be (as a function of $r$) to ensure that there is such a family which achieves $n-3$ distinct sizes of sets?\n\n\n\nA problem of Erd\\H{o}s and Trotter. For $r=1$ and $n>3$ the maximum possible is $n-2$. For $r>1$ and $n$ sufficiently large $n-3$ is achievable, but $n-2$ is never achievable.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #775\n- Problem #777\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu83\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Bridge custom IsAntichain to Mathlib IsAntichain to prove sperner_theorem",
+      "Investigate if erdos_trotter_r1 is provable from Griggs 1983 results in Mathlib"
+    ],
+    "markdown": "# Erd\u0151s #776 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $r\\geq 2$ and $A_1,\\ldots,A_m\\subseteq \\{1,\\ldots,n\\}$ be such that $A_i\\not\\subseteq A_j$ for all $i\\neq j$ and for any $t$ if there exists some $i$ with $\\lvert A_i\\rvert=t$ then there must exist at least $r$ sets of that size.\n\nHow large must $n$ be (as a function of $r$) to ensure that there is such a family which achieves $n-3$ distinct sizes of sets?\n\n\n\nA problem of Erd\\H{o}s and Trotter. For $r=1$ and $n>3$ the maximum possible is $n-2$. For $r>1$ and $n$ sufficiently large $n-3$ is achievable, but $n-2$ is never achievable.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #775\n- Problem #777\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu83\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
Six completed research sessions + surveys:

### Completed (Axiom Elimination)

| Problem | Before | After | Key Proofs |
|---------|--------|-------|------------|
| Erdős #776 | 8 | 5 | size_variety_tradeoff, middle_layer_antichain, size_availability |
| Erdős #288 | 8 | 3 | harmonicInterval_singleton/pos/from_one/growth, example_sum_one |
| Erdős #730 | 8 | 6 | middle_primes_divide, prime_set_stability |
| Erdős #386 | 10 | 9 | choose_largest_prime_le (factorial divisibility) |
| Erdős #396 | 9 | 7 | catalan_divisibility (Nat.succ_dvd_centralBinom), n_divides_rarely |
| **Unit Ball** | new | **0** | 8 theorems, ω_{n+2} = (2π/(n+2))·ω_n |
| **Total** | — | — | **16 axioms eliminated** |

### Surveys (No Actionable Axioms)
erdos-460, erdos-383, amgm-oq-02-oq-03, bertrand-oq-04, erdos-690/749/911/1179 (axiomatized functions)

**Note**: Docker unavailable for build verification.

Generated by researcher-4