### PR TITLE
Research: erdos-200 — prove 6 axioms, longest prime AP (11A→5A)

### DIFF
--- a/proofs/Proofs/Erdos200Problem.lean
+++ b/proofs/Proofs/Erdos200Problem.lean
@@ -63,9 +63,17 @@ axiom prime_ap_upper_pnt :
 axiom green_tao :
   ∀ k : ℕ, ∃ N : ℕ, IsPrimeAP k N
 
-/-- Consequence: longestPrimeAP N is unbounded. -/
-axiom longest_prime_ap_unbounded :
-  ∀ M : ℕ, ∃ N : ℕ, longestPrimeAP N ≥ M
+/-- Consequence: longestPrimeAP N is unbounded.
+    Proof: from green_tao, IsPrimeAP M N holds for some N,
+    so M ∈ the sSup set and longestPrimeAP N ≥ M. -/
+theorem longest_prime_ap_unbounded :
+    ∀ M : ℕ, ∃ N : ℕ, longestPrimeAP N ≥ M := by
+  intro M
+  obtain ⟨N, hN⟩ := green_tao M
+  exact ⟨N, le_csSup ⟨N + 1, fun k ⟨a, d, hd, _, hle⟩ => by
+    rcases k with _ | k
+    · omega
+    · have := hle k (by omega); omega⟩ hN⟩
 
 /- ## Main Conjecture -/
 
@@ -80,11 +88,15 @@ axiom erdos_200_conjecture :
 
 /- ## Known Bounds and Examples -/
 
-/-- The AP {3, 5, 7} has length 3 — trivial example. -/
-axiom prime_ap_3 : IsPrimeAP 3 7
+/-- The AP {3, 5, 7} has length 3 — proved by explicit construction. -/
+theorem prime_ap_3 : IsPrimeAP 3 7 :=
+  ⟨3, 2, by omega, fun i hi => by interval_cases i <;> native_decide,
+   fun i hi => by interval_cases i <;> omega⟩
 
-/-- The AP {5, 11, 17, 23, 29} has length 5. -/
-axiom prime_ap_5 : IsPrimeAP 5 29
+/-- The AP {5, 11, 17, 23, 29} has length 5 — proved by explicit construction. -/
+theorem prime_ap_5 : IsPrimeAP 5 29 :=
+  ⟨5, 6, by omega, fun i hi => by interval_cases i <;> native_decide,
+   fun i hi => by interval_cases i <;> omega⟩
 
 /-- Green–Tao–Maynard: quantitative bounds on the least N containing
     a prime AP of length k. The best bounds give
@@ -100,14 +112,14 @@ axiom green_tao_quantitative :
     the expected number of prime k-APs with difference d ≤ x is
     ~ c_k · x / (log x)^k, predicting longestPrimeAP(N) ~ c · log N
     for some constant c < 1. -/
-axiom hardy_littlewood_prediction :
-  True  -- Predicts longestPrimeAP(N) ~ c · log N, NOT o(log N)
+theorem hardy_littlewood_prediction :
+    True := trivial  -- Predicts longestPrimeAP(N) ~ c · log N, NOT o(log N)
 
 /-- Note: the Hardy–Littlewood prediction suggests the answer to
     Erdős's question might be NO — the longest prime AP could be
     Θ(log N), not o(log N). This makes the problem delicate. -/
-axiom hl_suggests_negative :
-  True  -- Heuristically, longestPrimeAP(N) / log(N) → c for some c ∈ (0,1]
+theorem hl_suggests_negative :
+    True := trivial  -- Heuristically, longestPrimeAP(N) / log(N) → c for some c ∈ (0,1]
 
 /- ## Structural Observations -/
 
@@ -120,6 +132,7 @@ axiom ap_difference_primorial (k : ℕ) (hk : k ≥ 3) :
 
 /-- The primorial constraint means a prime AP of length k uses
     numbers up to at least a + (k-1) · k#, which grows rapidly. -/
-axiom primorial_growth :
-  ∀ ε : ℝ, ε > 0 → ∃ K₀ : ℕ, ∀ k : ℕ, k > K₀ →
-    True  -- k# ≥ e^((1-ε)k)
+theorem primorial_growth :
+    ∀ ε : ℝ, ε > 0 → ∃ K₀ : ℕ, ∀ k : ℕ, k > K₀ →
+      True := -- k# ≥ e^((1-ε)k)
+  fun _ _ => ⟨0, fun _ _ => trivial⟩

--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -66,9 +66,9 @@
       "ap_difference_primorial: Axiom encoding the primorial divisibility constraint on AP differences"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 11,
-    "lineCount": 125,
-    "assumptions": "11 axioms: prime_ap_upper_pnt, green_tao, longest_prime_ap_unbounded, and 8 more. See Lean source for complete statements.",
+    "axiomCount": 5,
+    "lineCount": 131,
+    "assumptions": "5 axioms: prime_ap_upper_pnt (PNT bound), green_tao (arbitrarily long prime APs), erdos_200_conjecture (OPEN), green_tao_quantitative (effective bounds), ap_difference_primorial (primorial divisibility). Proved: longest_prime_ap_unbounded (from green_tao), prime_ap_3/5 (explicit construction), hardy_littlewood_prediction/hl_suggests_negative/primorial_growth (trivial True).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -160,9 +160,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 125,
-    "axiomCount": 11,
-    "theoremCount": 0,
+    "lineCount": 131,
+    "axiomCount": 5,
+    "theoremCount": 6,
     "definitionCount": 3
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary
- Prove 6 axioms in Erdos200Problem.lean (Longest Prime Arithmetic Progression)
- Axiom count reduced from 11 to 5

## Proofs

| Axiom | Technique |
|-------|-----------|
| `longest_prime_ap_unbounded` | From `green_tao` via `le_csSup` with BddAbove witness |
| `prime_ap_3` | Explicit (a=3, d=2) → {3,5,7}, primality by `native_decide` |
| `prime_ap_5` | Explicit (a=5, d=6) → {5,11,17,23,29}, primality by `native_decide` |
| `hardy_littlewood_prediction` | Trivial (`True`) |
| `hl_suggests_negative` | Trivial (`True`) |
| `primorial_growth` | Trivial (conclusion is `True`) |

## Remaining Axioms (5)
| Axiom | Type |
|-------|------|
| `prime_ap_upper_pnt` | PNT upper bound |
| `green_tao` | Deep (Green-Tao theorem) |
| `erdos_200_conjecture` | OPEN |
| `green_tao_quantitative` | Effective bounds |
| `ap_difference_primorial` | Primorial divisibility |

🤖 Generated by researcher-5

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>