### PR TITLE
chore: audit erdos-1131 — sorry count 7→5, line count stale

### DIFF
--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -19,14 +19,14 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 5,
     "erdosNumber": 1131,
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "theoremCount": 14,
-    "lineCount": 665,
-    "assumptions": "1 axiom: erdos_1131_conjecture (OPEN). 7 sorries: chebyshev_sq_expansion (DCT identity), integral_chebyshev_sq (FTC API), product_to_sum_integral (sin/cos API), change_of_variables (hasDerivAt_cos), cos_sq_substitution (continuous_cos), chebyshev_inner_product (frequency sums), and lagrange_sum_formula (needs chebyshev_sq_expansion). All blocked on Mathlib calculus API gaps (hasDerivAt_cos, integral_sin_mul, continuous_sin/cos.comp).",
+    "theoremCount": 12,
+    "lineCount": 707,
+    "assumptions": "1 axiom: erdos_1131_conjecture (OPEN). 5 sorries: integral_cos_substitution (change of variables, needs integral_comp_mul_deriv), integral_chebyshev_sq (cos² substitution + FTC), dct_offdiag (product-to-sum + parity), chebyshev_sq_expansion (needs DCT Parseval), chebyshev_integral_trace (needs chebyshev_sq_expansion + integral_chebyshev_sq). Blocked on Mathlib calculus API gaps (continuous_cos.comp, integral_comp_mul_deriv).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -199,8 +199,9 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos1131",
-    "lineCount": 665,
+    "lineCount": 707,
     "axiomCount": 1,
+    "sorryCount": 5,
     "theoremCount": 12,
     "definitionCount": 6
   }


### PR DESCRIPTION
## Summary

- Fix stale sorry count in erdos-1131 meta.json: **7 → 5** (two sorries proved since last update)
- Fix stale line count: **665 → 707**
- Fix theoremCount inconsistency: top-level had 14, leanFile had 12 — unified to 12
- Update assumptions text to list the 5 actual remaining sorries

## Evidence

`integral_sin_mul` and `integral_cos_mul_sin` are now fully proved in `Erdos1131Problem.lean` (FTC chain rule and product-to-sum decomposition respectively). grep confirms exactly 5 `sorry` tokens in the file.

## Test plan

- [x] Verified sorry count by grep: 5 matches (lines 441, 450, 590, 605, 616)
- [x] Verified axiom count: 1 (`erdos_1131_conjecture`)
- [x] Verified line count: `wc -l` = 707

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)