### PR TITLE
chore: audit inverse-galois-oq-01 — fix axiom attribution

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -32,7 +32,7 @@
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",
       "Field extensions (finrank, tower law)"
     ],
-    "assumptions": "0 axioms declared in this file. 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem now sorry-free via imports of InverseGaloisA5.lean (1 axiom: Dedekind) and AbelRuffiniOQ04OQ01.lean (2 axioms: Dedekind). Commutator theorem [S5,S5]=A5 fully proved.",
+    "assumptions": "0 axioms declared in this file. 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. Transitive dependency axioms: InverseGalois.lean (2 axioms: abelian_realizable, shafarevich_theorem), InverseGaloisA5.lean (1 axiom: three_dvd_gal_card). AbelRuffiniOQ04OQ01.lean is axiom-free (all axioms eliminated). Commutator theorem [S5,S5]=A5 fully proved.",
     "leanFile": {
       "lineCount": 723,
       "theoremCount": 47,


### PR DESCRIPTION
## Summary

- Fix inaccurate assumptions text in inverse-galois-oq-01 meta.json
- AbelRuffiniOQ04OQ01.lean was incorrectly claimed to have 2 axioms — it has 0 (all eliminated)
- Correctly identifies the 3 transitive dependency axioms and their locations

## Evidence

- `grep -c "^axiom " AbelRuffiniOQ04OQ01.lean` = 0
- `grep "^axiom " InverseGalois.lean` = `abelian_realizable`, `shafarevich_theorem`
- `grep "^axiom " InverseGaloisA5.lean` = `three_dvd_gal_card`

## Test plan

- [x] Verified per-file axiom counts across all 4 dependency files
- [x] Verified 1 sorry (line 412, open IGP conjecture)
- [x] No True stubs
- [x] Line count matches (723)

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)