### PR TITLE
chore: audit iteration 6 — sorry/axiom/line count fixes (7 proofs)

### DIFF
--- a/src/data/proofs/erdos-1144/meta.json
+++ b/src/data/proofs/erdos-1144/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1144,
     "erdosUrl": "https://erdosproblems.com/1144",
     "erdosProblemStatus": "open",
@@ -66,7 +66,7 @@
       "conjecture_and_atherfold_pinch"
     ],
     "axiomCount": 1,
-    "lineCount": 185,
+    "lineCount": 175,
     "assumptions": "1 axiom(s) and 1 sorry(s)."
   },
   "overview": {
@@ -211,7 +211,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 185,
+    "lineCount": 175,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 5

--- a/src/data/proofs/erdos-1176/meta.json
+++ b/src/data/proofs/erdos-1176/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1176,
     "erdosUrl": "https://erdosproblems.com/1176",
     "erdosProblemStatus": "open",
@@ -57,7 +57,7 @@
       "edgeColorClass"
     ],
     "axiomCount": 1,
-    "lineCount": 223,
+    "lineCount": 225,
     "assumptions": "1 axiom(s) and 1 sorry(s). erdos_1176 proved from hajnal_komjath_consistency_witness axiom. Remaining sorry: strong_implies_domination."
   },
   "overview": {
@@ -176,7 +176,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos1176",
-    "lineCount": 223,
+    "lineCount": 225,
     "axiomCount": 1,
     "theoremCount": 6,
     "definitionCount": 11

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -19,15 +19,15 @@
       "fourier-analysis"
     ],
     "badge": "formalized",
-    "sorries": 5,
+    "sorries": 2,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 7,
-    "lineCount": 414,
+    "lineCount": 525,
     "erdosNumber": 1179,
     "erdosUrl": "https://erdosproblems.com/1179",
     "erdosProblemStatus": "open-question",
-    "assumptions": "Zero axioms. Five sorries remain in the Fourier analysis infrastructure: (1) reprCount_fourier_expansion (the core Fourier inversion identity on Z/pZ via character orthogonality and subset product identity), (2) norm_one_add_omegap_pow (|1+omega^m| = 2|cos(pi*m/p)|), (3) abs_cos_mul_pi_div_le (|cos(pi*m/p)| <= cos(pi/p) for m in {1,...,p-1}), (4) fourier_product_bound (product of character factors bounded by 2^k*cos(pi/p)^(k-1)), (5) fourier_error_bound assembly (combining Fourier expansion with product bounds via triangle inequality). All foundational lemmas and erdos_renyi_decay are fully proved.",
+    "assumptions": "Zero axioms. Two sorries remain: (1) reprCount_fourier_expansion (the core Fourier inversion identity on Z/pZ via character orthogonality and subset product identity), (2) fourier_error_bound assembly (combining Fourier expansion with product bounds via triangle inequality). Three previously sorry'd lemmas (norm_one_add_omegap_pow, abs_cos_mul_pi_div_le, fourier_product_bound) are now fully proved. All foundational lemmas and erdos_renyi_decay fully proved.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -84,9 +84,10 @@
       ],
       "opens": ["Finset", "Real"],
       "namespace": "Erdos1179OQ01",
-      "lineCount": 286,
-      "axiomCount": 1,
-      "theoremCount": 11,
+      "lineCount": 525,
+      "axiomCount": 0,
+      "sorryCount": 2,
+      "theoremCount": 23,
       "definitionCount": 5,
       "mainTheorems": [
         {

--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -12,7 +12,7 @@
     "erdosUrl": "https://erdosproblems.com/160",
     "erdosProblemStatus": "open",
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -21,9 +21,9 @@
       "van-der-waerden",
       "open"
     ],
-    "axiomCount": 7,
-    "lineCount": 225,
-    "assumptions": "7 axiom(s) and 3 sorry(s). See the Lean source for details.",
+    "axiomCount": 6,
+    "lineCount": 252,
+    "assumptions": "6 axioms (h, h_achievable, h_minimal, upper_bound_two_thirds, upper_bound_hunter, lower_bound_exp) and 2 sorries (h_sublinear, h_superlog). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -131,8 +131,8 @@
       "Finset"
     ],
     "namespace": "Erdos160",
-    "lineCount": 225,
-    "axiomCount": 7,
+    "lineCount": 252,
+    "axiomCount": 6,
     "theoremCount": 12,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -16,12 +16,12 @@
       "erdos-hajnal"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 640,
     "erdosUrl": "https://erdosproblems.com/640",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 259,
+    "lineCount": 291,
     "assumptions": "2 axioms: steiner_equivalence, trivial_case_k3. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -127,7 +127,7 @@
       "in"
     ],
     "namespace": "Erdos640",
-    "lineCount": 259,
+    "lineCount": 291,
     "axiomCount": 2,
     "theoremCount": 11,
     "definitionCount": 8

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -17,7 +17,7 @@
       "decomposition"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 719,
     "erdosUrl": "https://erdosproblems.com/719",
     "erdosProblemStatus": "open",
@@ -77,7 +77,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 196,
+    "lineCount": 195,
     "assumptions": "2 axioms and 1 sorry (decomp_pieces_le_edges at line 156)."
   },
   "overview": {
@@ -162,7 +162,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 196,
+    "lineCount": 195,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 7

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -18,13 +18,13 @@
       "popcount"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 875,
     "erdosUrl": "https://erdosproblems.com/875",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
     "lineCount": 135,
-    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details.",
+    "assumptions": "4 axioms and 1 sorry (pow2_admissible: disjoint sumsets via popcount argument). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- Fix stale sorry counts across 7 proofs (total: 14→6 sorries corrected)
- Fix stale axiom count for erdos-160 (7→6) and erdos-1179-oq-01 leanFile (1→0)
- Fix stale line counts across 6 proofs
- Update assumptions text for erdos-160, erdos-875, erdos-1179-oq-01

### Details

| Proof | Sorry | Axiom | Lines |
|-------|-------|-------|-------|
| erdos-1179-oq-01 | 5→2 | 0 (leanFile: 1→0) | 414→525 |
| erdos-160 | 3→2 | 7→6 | 225→252 |
| erdos-875 | 2→1 | 4 (ok) | 135 (ok) |
| erdos-1144 | 1→0 | 1 (ok) | 185→175 |
| erdos-1176 | 1→0 | 1 (ok) | 223→225 |
| erdos-640 | 1→0 | 2 (ok) | 259→291 |
| erdos-719 | 1→0 | 2 (ok) | 196→195 |

## Test plan

- [x] Verified all sorry counts by `grep -c '\bsorry\b'` against each Lean source file
- [x] Verified axiom counts by `grep -c '^axiom '` against each Lean source file
- [x] Verified line counts by `wc -l` against each Lean source file

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)