### PR TITLE
Research: erdos-1167 — sorry-free proof of infinite Ramsey theorem

### DIFF
--- a/proofs/Proofs/Erdos1167Problem.lean
+++ b/proofs/Proofs/Erdos1167Problem.lean
@@ -445,10 +445,40 @@ theorem infinite_ramsey_proved (r k : ℕ) :
         exact Set.image_subset_iff.mpr fun ⟨a, ha⟩ _ => ha
       · -- Monochromaticity: for r-subsets s ⊆ (Subtype.val '' H) with x ∉ s,
         -- f(cons x s) = c
-        -- Requires lifting s back to Finset ↥(S\{x}) and applying hMono
-        sorry -- finset lifting: for each a ∈ s, obtain ⟨b, hb, rfl⟩ from hsub,
-              -- build the lifted Finset, apply hMono to get g(lifted) = c,
-              -- then show g(lifted) = f(cons x s) by definition of g
+        -- Strategy: lift s to Finset ↥(S\{x}) via preimage, apply hMono, then
+        -- connect back via T.map subtype_val = s
+        intro s hs hsub hxs
+        -- All elements of s are in S \ {x}
+        have hs_diff : (↑s : Set α) ⊆ S \ {x} :=
+          hsub.trans (Set.image_subset_iff.mpr fun ⟨_, ha⟩ _ => ha)
+        -- Lift s to Finset of the subtype via preimage
+        let T : Finset ↥(S \ {x}) :=
+          s.preimage Subtype.val Subtype.val_injective.injOn
+        -- T maps back to s
+        have hT_map : T.map ⟨Subtype.val, Subtype.val_injective⟩ = s := by
+          ext a; simp only [Finset.mem_map, Finset.mem_preimage,
+            Function.Embedding.coeFn_mk]
+          exact ⟨fun ⟨b, hb, rfl⟩ => hb,
+            fun ha => ⟨⟨a, hs_diff (Finset.mem_coe.mpr ha)⟩, ha, rfl⟩⟩
+        -- T has card r
+        have hT_card : T.card = r := by
+          rw [← Finset.card_map ⟨Subtype.val, Subtype.val_injective⟩, hT_map]; exact hs
+        -- T ⊆ H (each element of T has its val in s ⊆ Subtype.val '' H)
+        have hT_sub_H : (↑T : Set ↥(S \ {x})) ⊆ H := by
+          intro b hb
+          rw [Finset.mem_coe, Finset.mem_preimage] at hb
+          obtain ⟨b', hb'H, hb'val⟩ := hsub (Finset.mem_coe.mpr hb)
+          rwa [show b' = b from Subtype.val_injective hb'val] at hb'H
+        -- Apply monochromaticity of g on H
+        have hgc := hMono ⟨T, hT_card⟩ hT_sub_H
+        -- hgc : g ⟨T, hT_card⟩ = c, which unfolds to
+        -- f ⟨Finset.cons x (T.map subtype_val) _, _⟩ = c
+        -- Since T.map subtype_val = s, this gives f ⟨Finset.cons x s _, _⟩ = c
+        -- Definitional unfolding + rewrite to match goal
+        change f ⟨Finset.cons x (T.map ⟨Subtype.val, Subtype.val_injective⟩) _ , _⟩ = c at hgc
+        rw [hT_map] at hgc
+        convert hgc using 2
+        exact Subtype.ext rfl
     -- ===== CHAIN CONSTRUCTION =====
     -- Build decreasing chain of infinite sets using Nat.rec:
     --   state(0) = Set.univ (the whole of α, which is infinite)
@@ -513,15 +543,64 @@ theorem infinite_ramsey_proved (r k : ℕ) :
     -- ===== MONOCHROMATICITY VERIFICATION =====
     -- Any (r+1)-subset of A has color c* under f
     have hA_mono : IsMonochromatic f A c_star := by
-      -- For any (r+1)-subset s with ↑s ⊆ A:
-      -- Each element is getElem(nᵢ) for some nᵢ with getColor(nᵢ) = c*.
-      -- Let n₀ be the minimum index. Then:
-      -- - {getElem(nᵢ) | i > 0} is an r-subset of state(n₀+1)
-      -- - getElem(n₀) ∉ {getElem(nᵢ) | i > 0} by injectivity
-      -- - f(cons (getElem n₀) rest) = getColor(n₀) = c* by hStep_mono
-      sorry -- requires: (1) extracting index function from s ⊆ A,
-            -- (2) finding minimum index, (3) showing rest ⊆ state(n₀+1),
-            -- (4) applying hStep_mono + hElem_in_later
+      intro ⟨s, hcard⟩ hs
+      -- For each a ∈ s, find its chain index (with color c* and getElem = a)
+      have h_idx : ∀ a ∈ s, ∃ n, getColor n = c_star ∧ getElem n = a := by
+        intro a ha
+        obtain ⟨n, hn, rfl⟩ := hs (Finset.mem_coe.mpr ha)
+        exact ⟨n, by rwa [Set.mem_preimage, Set.mem_singleton_iff] at hn, rfl⟩
+      choose idx hidx using h_idx
+      -- s is nonempty (r+1 ≥ 1)
+      have hs_ne : s.Nonempty := Finset.card_pos.mp (by omega)
+      -- Build index set and find minimum index n₀
+      let idx_of : { a // a ∈ s } → ℕ := fun ⟨a, ha⟩ => idx a ha
+      let idx_set := s.attach.image idx_of
+      have hne_idx : idx_set.Nonempty :=
+        (Finset.attach_nonempty_iff.mpr hs_ne).image _
+      let n₀ := idx_set.min' hne_idx
+      -- n₀ is realized by some a₀ ∈ s with idx a₀ ha₀ = n₀
+      have hn₀_mem : n₀ ∈ idx_set := Finset.min'_mem _ _
+      rw [Finset.mem_image] at hn₀_mem
+      obtain ⟨⟨a₀, ha₀⟩, _, hn₀_eq⟩ := hn₀_mem
+      -- hn₀_eq : idx a₀ ha₀ = n₀
+      have hn₀_elem : getElem n₀ = a₀ := by rw [← hn₀_eq]; exact (hidx a₀ ha₀).2
+      have hn₀_color : getColor n₀ = c_star := by rw [← hn₀_eq]; exact (hidx a₀ ha₀).1
+      -- Decompose s = cons a₀ (s.erase a₀)
+      let rest := s.erase a₀
+      have hrest_card : rest.card = r := by
+        rw [Finset.card_erase_of_mem ha₀, hcard]; omega
+      -- Every element of rest has index > n₀, so is in state(n₀+1)
+      have hrest_sub : (↑rest : Set α) ⊆ (state (n₀ + 1)).val := by
+        intro b hb_rest
+        rw [Finset.mem_coe] at hb_rest
+        have hbs : b ∈ s := Finset.erase_subset _ _ hb_rest
+        have hbne : b ≠ a₀ := Finset.ne_of_mem_erase hb_rest
+        -- n₀ ≤ idx b hbs (minimality)
+        have hge : n₀ ≤ idx b hbs :=
+          Finset.min'_le _ _ (Finset.mem_image_of_mem _ (Finset.mem_attach _ _))
+        -- idx b hbs ≠ n₀ (since getElem injective and b ≠ a₀)
+        have hne : idx b hbs ≠ n₀ := by
+          intro h; apply hbne
+          calc b = getElem (idx b hbs) := ((hidx b hbs).2).symm
+            _ = getElem n₀ := by rw [h]
+            _ = a₀ := hn₀_elem
+        -- n₀ < idx b hbs
+        rw [← (hidx b hbs).2]
+        exact hElem_in_later n₀ _ (lt_of_le_of_ne hge hne)
+      -- getElem n₀ ∉ rest (since getElem n₀ = a₀ and a₀ ∉ s.erase a₀)
+      have hn₀_nrest : getElem n₀ ∉ rest := by rw [hn₀_elem]; exact Finset.not_mem_erase _ _
+      -- Apply hStep_mono: f(cons (getElem n₀) rest) = getColor n₀ = c*
+      have hstep := hStep_mono n₀ rest hrest_card hrest_sub hn₀_nrest
+      rw [hn₀_color] at hstep
+      -- Reconstruct: cons a₀ (s.erase a₀) = s
+      have hrecons : Finset.cons a₀ rest (Finset.not_mem_erase _ _) = s :=
+        Finset.cons_erase ha₀
+      -- Goal: f ⟨s, hcard⟩ = c_star, known: f ⟨cons (getElem n₀) rest _, _⟩ = c_star
+      -- These match since cons (getElem n₀) rest = cons a₀ rest = s
+      convert hstep using 2
+      apply Subtype.ext
+      show s = Finset.cons (getElem n₀) rest hn₀_nrest
+      rw [hn₀_elem]; exact hrecons.symm
     -- ===== CONCLUSION =====
     refine ⟨c_star, A, hA_mono, ?_⟩
     exact le_of_eq (mk_infinite_subset_eq_aleph0 hα A hA_inf).symm

--- a/proofs/Proofs/Erdos1167Problem.lean
+++ b/proofs/Proofs/Erdos1167Problem.lean
@@ -349,4 +349,181 @@ theorem infinite_ramsey_one (k : ℕ) (hk : k ≥ 1) :
     haveI := Cardinal.lt_aleph0_iff_finite.mp hlt
     exact hc (Set.toFinite _)
 
+/-
+## Section 6: Proof of the Infinite Ramsey Theorem
+
+Proved by induction on r with a "thinning chain" construction.
+This theorem replaces the `infinite_ramsey` axiom above.
+
+Proof outline (inductive step, r → r+1):
+  Given f : [α]^{r+1} → β with α infinite (ℵ₀) and β finite (k colors):
+  1. Build chain: pick x₀ ∈ α, restrict f to r-subsets fixing x₀,
+     apply IH to get infinite monochromatic H₀ ⊆ α \ {x₀} with color c₀.
+     Pick x₁ ∈ H₀, repeat. Produces sequences (xₙ), (cₙ), (Sₙ).
+  2. Pigeonhole: cₙ ∈ β with β finite → some c* has infinite preimage I.
+  3. A = {xₙ : n ∈ I} is infinite and monochromatic for f with color c*.
+     Proof: any (r+1)-subset of A contains smallest element xₙ₀ (n₀ ∈ I),
+     the rest is an r-subset of Sₙ₀₊₁ (monochromatic for f(· ∪ {xₙ₀}) = cₙ₀ = c*).
+
+Once all sorries are resolved, the `infinite_ramsey` axiom can be removed,
+reducing axiom count from 3 to 2.
+-/
+
+-- Helper: cardinality of an infinite subset of a type with #α = ℵ₀ is ℵ₀
+private lemma mk_infinite_subset_eq_aleph0 {α : Type*}
+    (hα : #α = ℵ₀) (S : Set α) (hS : Set.Infinite S) : #↥S = ℵ₀ := by
+  apply le_antisymm
+  · exact (Cardinal.mk_subtype_le S).trans (le_of_eq hα)
+  · by_contra h
+    simp only [not_le] at h
+    exact hS (Set.finite_coe_iff.mpr (Cardinal.lt_aleph0_iff_finite.mp h))
+
+-- The infinite Ramsey theorem (proof by induction on r)
+-- Once complete (all sorries resolved), this replaces the axiom `infinite_ramsey`
+theorem infinite_ramsey_proved (r k : ℕ) :
+    PartitionRelation ℵ₀ ℵ₀ r k := by
+  induction r with
+  | zero => exact infinite_ramsey_zero k
+  | succ r ih =>
+    intro α hα β hβ f
+    classical
+    -- α is infinite (cardinality ℵ₀)
+    haveI hInfα : Infinite α := by
+      by_contra h; simp only [not_infinite] at h
+      exact absurd (Cardinal.lt_aleph0_iff_finite.mpr h)
+        (not_lt.mpr (le_of_eq hα.symm))
+    -- β is finite (cardinality k)
+    haveI hFinβ : Finite β := Cardinal.lt_aleph0_iff_finite.mp
+      (hβ ▸ Cardinal.nat_lt_aleph0 k)
+    -- Handle vacuous case: β empty → no coloring can exist
+    by_cases hβne : Nonempty β
+    swap
+    · -- β empty means k = 0, but RSubset α (r+1) is nonempty (α is infinite),
+      -- so f : nonempty → empty is impossible
+      have : Nonempty (RSubset α (r + 1)) := by
+        -- An infinite type has finsets of any finite size
+        -- Use Infinite.natEmbedding to get ℕ ↪ α, then map a range finset
+        exact ⟨⟨(Finset.range (r + 1)).map (Infinite.natEmbedding α),
+          by simp [Finset.card_map]⟩⟩
+      exact absurd ⟨f this.some⟩ hβne
+    -- ===== THINNING STEP =====
+    -- For any infinite subset S ⊆ α, we can pick an element x ∈ S,
+    -- apply the IH to the restricted coloring on S \ {x}, and get
+    -- an infinite monochromatic subset T ⊆ S \ {x} with some color c.
+    have thin_step : ∀ (S : Set α), Set.Infinite S →
+        ∃ (x : α) (c : β) (T : Set α),
+          x ∈ S ∧ Set.Infinite T ∧ T ⊆ S \ {x} ∧
+          (∀ (s : Finset α) (_hs : s.card = r) (_hsub : (↑s : Set α) ⊆ T) (hxs : x ∉ s),
+            f ⟨Finset.cons x s hxs, by rw [Finset.card_cons]; omega⟩ = c) := by
+      intro S hS
+      obtain ⟨x, hxS⟩ := hS.nonempty
+      -- S \ {x} is infinite with cardinality ℵ₀
+      have hS' : Set.Infinite (S \ {x}) := hS.diff (Set.finite_singleton x)
+      have hcardS' : #↥(S \ {x}) = ℵ₀ := mk_infinite_subset_eq_aleph0 hα _ hS'
+      -- Define restricted coloring g on r-subsets of (S \ {x}):
+      -- g(T) = f({x} ∪ T), where T is lifted from the subtype to α
+      let g : Coloring ↥(S \ {x}) r β := fun ⟨T, hcard⟩ =>
+        let T' := T.map ⟨Subtype.val, Subtype.val_injective⟩
+        have hx_nmem : x ∉ T' := by
+          simp only [Finset.mem_map, Function.Embedding.coeFn_mk]
+          rintro ⟨⟨a, ha⟩, _, rfl⟩
+          exact (Set.mem_diff_singleton.mp ha).2 rfl
+        f ⟨Finset.cons x T' hx_nmem,
+          by rw [Finset.card_cons, Finset.card_map, hcard]⟩
+      -- Apply IH: PartitionRelation ℵ₀ ℵ₀ r k for the subtype ↥(S \ {x})
+      obtain ⟨c, H, hMono, hHcard⟩ := ih ↥(S \ {x}) hcardS' β hβ g
+      -- Convert H : Set ↥(S \ {x}) to T : Set α via Subtype.val
+      refine ⟨x, c, Subtype.val '' H, hxS, ?_, ?_, ?_⟩
+      · -- Subtype.val '' H is infinite (injective image of infinite set)
+        have : Set.Infinite H := by
+          rw [Set.infinite_coe_iff]
+          by_contra hinf; simp only [not_infinite] at hinf
+          exact absurd (Cardinal.lt_aleph0_iff_finite.mpr hinf)
+            (not_lt.mpr hHcard)
+        exact this.image Subtype.val_injective
+      · -- Subtype.val '' H ⊆ S \ {x}
+        exact Set.image_subset_iff.mpr fun ⟨a, ha⟩ _ => ha
+      · -- Monochromaticity: for r-subsets s ⊆ (Subtype.val '' H) with x ∉ s,
+        -- f(cons x s) = c
+        -- Requires lifting s back to Finset ↥(S\{x}) and applying hMono
+        sorry -- finset lifting: for each a ∈ s, obtain ⟨b, hb, rfl⟩ from hsub,
+              -- build the lifted Finset, apply hMono to get g(lifted) = c,
+              -- then show g(lifted) = f(cons x s) by definition of g
+    -- ===== CHAIN CONSTRUCTION =====
+    -- Build decreasing chain of infinite sets using Nat.rec:
+    --   state(0) = Set.univ (the whole of α, which is infinite)
+    --   state(n+1) = T from thin_step applied to state(n)
+    -- And extract element/color sequences from thin_step at each level.
+    let state : ℕ → { S : Set α // Set.Infinite S } :=
+      Nat.rec ⟨Set.univ, Set.infinite_univ⟩ fun _ ⟨S, hS⟩ =>
+        let h := thin_step S hS
+        ⟨h.choose_spec.choose_spec.choose,
+         h.choose_spec.choose_spec.choose_spec.2.1⟩
+    -- Element and color at step n (extracted from the same thin_step call)
+    let getElem (n : ℕ) : α :=
+      (thin_step (state n).val (state n).prop).choose
+    let getColor (n : ℕ) : β :=
+      (thin_step (state n).val (state n).prop).choose_spec.choose
+    -- ===== KEY CHAIN PROPERTIES =====
+    -- Property 1: getElem n ∈ (state n).val
+    have hElem_in : ∀ n, getElem n ∈ (state n).val :=
+      fun n => (thin_step (state n).val (state n).prop).choose_spec.choose_spec.choose_spec.1
+    -- Property 2: state(n+1) ⊆ state(n) \ {getElem n}
+    have hState_sub : ∀ n, (state (n + 1)).val ⊆ (state n).val \ {getElem n} :=
+      fun n => (thin_step (state n).val (state n).prop).choose_spec.choose_spec.choose_spec.2.2.1
+    -- Property 3: monochromaticity at each step
+    have hStep_mono : ∀ n (s : Finset α) (_hs : s.card = r)
+        (_hsub : (↑s : Set α) ⊆ (state (n + 1)).val) (hxs : getElem n ∉ s),
+        f ⟨Finset.cons (getElem n) s hxs, by rw [Finset.card_cons]; omega⟩ = getColor n :=
+      fun n => (thin_step (state n).val (state n).prop).choose_spec.choose_spec.choose_spec.2.2.2
+    -- Monotonicity of state chain (without singleton removal)
+    have hState_mono : ∀ n, (state (n + 1)).val ⊆ (state n).val :=
+      fun n => (hState_sub n).trans Set.diff_subset
+    -- Transitivity: state(m) ⊆ state(n) when n ≤ m
+    have hState_mono_le : ∀ n m, n ≤ m → (state m).val ⊆ (state n).val := by
+      intro n m hnm
+      obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hnm
+      induction d with
+      | zero => exact Set.Subset.rfl
+      | succ d ihd => exact (hState_mono (n + d)).trans ihd
+    -- Property 4: for m > n, getElem m ∈ state(n+1)
+    have hElem_in_later : ∀ n m, n < m → getElem m ∈ (state (n + 1)).val :=
+      fun n m hnm => hState_mono_le (n + 1) m hnm (hElem_in m)
+    -- getElem n ∉ state(n+1) (key for injectivity)
+    have hElem_not_in_next : ∀ n, getElem n ∉ (state (n + 1)).val := by
+      intro n hin
+      have := hState_sub n hin
+      exact (Set.mem_diff_singleton.mp this).2 rfl
+    -- Property 5: getElem is injective
+    have hElem_inj : Function.Injective getElem := by
+      intro a b hab
+      by_contra hne
+      rcases Nat.lt_or_gt_of_ne hne with hlt | hlt
+      · exact hElem_not_in_next a (hab ▸ hElem_in_later a b hlt)
+      · exact hElem_not_in_next b (hab.symm ▸ hElem_in_later b a hlt)
+    -- ===== PIGEONHOLE EXTRACTION =====
+    -- getColor : ℕ → β with ℕ infinite and β finite
+    -- By infinite pigeonhole, some color appears infinitely often
+    obtain ⟨c_star, hc_star⟩ := Finite.exists_infinite_fiber getColor
+    -- hc_star : Set.Infinite (getColor ⁻¹' {c_star})
+    -- The monochromatic set: elements at indices where color = c*
+    let A : Set α := getElem '' (getColor ⁻¹' {c_star})
+    -- A is infinite (injective image of infinite set)
+    have hA_inf : Set.Infinite A := hc_star.image hElem_inj.injOn
+    -- ===== MONOCHROMATICITY VERIFICATION =====
+    -- Any (r+1)-subset of A has color c* under f
+    have hA_mono : IsMonochromatic f A c_star := by
+      -- For any (r+1)-subset s with ↑s ⊆ A:
+      -- Each element is getElem(nᵢ) for some nᵢ with getColor(nᵢ) = c*.
+      -- Let n₀ be the minimum index. Then:
+      -- - {getElem(nᵢ) | i > 0} is an r-subset of state(n₀+1)
+      -- - getElem(n₀) ∉ {getElem(nᵢ) | i > 0} by injectivity
+      -- - f(cons (getElem n₀) rest) = getColor(n₀) = c* by hStep_mono
+      sorry -- requires: (1) extracting index function from s ⊆ A,
+            -- (2) finding minimum index, (3) showing rest ⊆ state(n₀+1),
+            -- (4) applying hStep_mono + hElem_in_later
+    -- ===== CONCLUSION =====
+    refine ⟨c_star, A, hA_mono, ?_⟩
+    exact le_of_eq (mk_infinite_subset_eq_aleph0 hα A hA_inf).symm
+
 end Erdos1167

--- a/src/data/research/problems/erdos-1167.json
+++ b/src/data/research/problems/erdos-1167.json
@@ -16,9 +16,9 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-01-15T16:53:51.159Z",
-    "iteration": 1,
+    "iteration": 3,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,23 +29,44 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved r=0 and r=1 cases of infinite Ramsey theorem (2 new theorems). The axiom is only needed for r >= 2. 3 axioms (main conjecture + 2 deep results), 17 theorems, 352 lines.",
+    "progressSummary": "COMPLETE: Full sorry-free proof of infinite_ramsey theorem (thinning chain construction). Pending Docker compilation verification. Once verified, axiom count drops 3→2.",
     "builtItems": [
       "infinite_ramsey_zero: proved PartitionRelation aleph0 aleph0 0 k for all k",
-      "infinite_ramsey_one: proved PartitionRelation aleph0 aleph0 1 k for k >= 1 via pigeonhole"
+      "infinite_ramsey_one: proved PartitionRelation aleph0 aleph0 1 k for k >= 1 via pigeonhole",
+      "infinite_ramsey_proved: full proof by induction on r with thinning chain (~170 lines)",
+      "mk_infinite_subset_eq_aleph0: cardinality helper for infinite subsets",
+      "Chain construction: state/getElem/getColor sequences via Nat.rec + Classical.choice",
+      "Chain properties: hState_sub, hState_mono, hState_mono_le, hElem_in_later fully proved",
+      "hElem_not_in_next + hElem_inj: element injectivity fully proved",
+      "Pigeonhole extraction: Finite.exists_infinite_fiber on color sequence",
+      "thin_step monochromaticity: finset lifting via Finset.preimage + Subtype.val_injective (sorry resolved)",
+      "Final monochromaticity: minimum index extraction via Finset.min, cons decomposition, hStep_mono application (sorry resolved)"
     ],
     "insights": [
       "All axioms are deep set-theoretic results not provable from current Mathlib",
       "15 proved theorems make this a strong formalization already",
       "r=0 case of infinite Ramsey is trivially provable (unique 0-subset)",
       "r=1 case follows from infinite pigeonhole (Finite.exists_infinite_fiber)",
-      "The infinite_ramsey axiom is only needed for r >= 2 where Ramsey diagonal argument + transfinite recursion are required"
+      "The infinite_ramsey axiom is only needed for r >= 2 where Ramsey diagonal argument + transfinite recursion are required",
+      "infinite_ramsey IS buildable (~150-200 lines): Mathlib has Finite.exists_infinite_fiber (infinite pigeonhole), Set.Infinite lemmas, and Classical.choice — all needed for the proof",
+      "Proof strategy for infinite_ramsey: induction on r. Base r=0,1 proved in PR #7041. Inductive step: thinning chain construction using pigeonhole at each step, then pigeonhole on colors",
+      "Key formalization challenge: recursive chain construction carrying Set.Infinite proofs, converting between Set.Infinite and Infinite typeclass, and working with RSubset α 2 (2-element Finset subtypes)",
+      "erdos_rado_theorem is NOT buildable without major infrastructure (delta-system lemma, transfinite recursion)",
+      "partition_one_color already proves infinite_ramsey r 1 and infinite_ramsey r 0 is vacuously true, so axiom only needed for r >= 2 and k >= 2",
+      "PR #7041 (open, researcher-6) has r=0 and r=1 proofs — coordinate to avoid duplicate work",
+      "Thinning chain proof works cleanly: Nat.rec with {S : Set α // Set.Infinite S} state",
+      "Chain consistency guaranteed by Classical.choice determinism on same proof term",
+      "Key difficulty: finset lifting between subtypes (↥(S\\{x}) → α) to connect restricted coloring mono to original coloring",
+      "Set.Infinite.image Subtype.val_injective used for infinite image transfer",
+      "The k=0 case is handled by Infinite.natEmbedding giving Nonempty RSubset",
+      "Docker was not running - needs compilation verification"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove the r=2 case (infinite Ramsey for pairs) - requires formalizing Ramseys diagonal argument",
-      "Explore whether Erdos-Rado theorem can be partially proved from Mathlib",
-      "Docker build verification needed - Docker was not running during this session"
+      "CRITICAL: Docker build verification — full proof is sorry-free but compilation not tested",
+      "If compilation succeeds: remove axiom infinite_ramsey, replace all uses with infinite_ramsey_proved, update axiomCount in meta.json from 3 to 2",
+      "Potential API name issues: Set.Infinite.image, Finset.preimage, Infinite.natEmbedding, Nat.exists_eq_add_of_le — verify these exist in current Mathlib",
+      "Consider whether erdos_rado_theorem axiom could be partially proved"
     ],
     "markdown": "# Erdős #1167 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -64,15 +85,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:53:51.159Z",
-  "lastUpdate": "2026-03-13T07:52:17.059Z",
+  "lastUpdate": "2026-03-27T00:00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1167Problem.lean",
       "filename": "Erdos1167Problem.lean",
-      "lineCount": 352,
-      "theoremCount": 17,
+      "lineCount": 608,
+      "theoremCount": 19,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Complete sorry-free proof of the infinite Ramsey theorem (`infinite_ramsey_proved`):
  ∀ r k : ℕ, PartitionRelation ℵ₀ ℵ₀ r k

This proves the same statement as the `infinite_ramsey` axiom, enabling its removal
once Docker compilation verifies the proof (axiom count: 3 → 2).

## Proof Structure (255 new lines)
1. **Base cases** (existing): r=0 (trivial), r=1 (pigeonhole)
2. **Inductive step** (new): thinning chain construction
   - `mk_infinite_subset_eq_aleph0`: cardinality helper
   - `thin_step`: restricted coloring + IH application
   - Chain via `Nat.rec` with `{S : Set α // Set.Infinite S}` state
   - 7 chain properties proved (monotonicity, transitivity, injectivity)
   - Pigeonhole extraction via `Finite.exists_infinite_fiber`
   - Monochromaticity via minimum index + `Finset.cons_erase` decomposition

## Key Techniques
- Restricted coloring: `Coloring ↥(S\{x}) r β` via `Finset.map Subtype.val`
- Finset lifting: `Finset.preimage Subtype.val` for subtype ↔ α conversion
- Minimum index: `Finset.min'` on `s.attach.image idx_of`
- Element injectivity: `hElem_not_in_next` + `hElem_in_later`

## Status
- **0 sorries** — proof is complete
- **Needs Docker compilation verification** (Docker was not running)
- Potential API name issues to watch: `Set.Infinite.image`, `Finset.preimage`,
  `Infinite.natEmbedding`, `Nat.exists_eq_add_of_le`

## Impact
Once verified: remove `axiom infinite_ramsey`, reducing axiom count from 3 to 2.
The remaining axioms (`erdos_1167_conjecture` — OPEN, `erdos_rado_theorem` — deep result)
cannot be eliminated without major new infrastructure.

🤖 Generated by researcher-3