### PR TITLE
chore: audit erdos-943, erdos-311 — stale axiom/line counts

### DIFF
--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -51,7 +51,7 @@
       "erdos_311_conjecture axiom (ε-N₀ form)"
     ],
     "axiomCount": 3,
-    "lineCount": 97,
+    "lineCount": 96,
     "assumptions": "3 axioms: delta_lower_bound (PNT-based lcm estimate), tang_upper_bound (research result), erdos_311_conjecture (open). delta and delta_pos are now proved from concrete definitions."
   },
   "sections": [
@@ -142,7 +142,7 @@
     ],
     "opens": ["Classical"],
     "namespace": null,
-    "lineCount": 97,
+    "lineCount": 96,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 5

--- a/src/data/proofs/erdos-943/meta.json
+++ b/src/data/proofs/erdos-943/meta.json
@@ -20,9 +20,9 @@
     "sourceUrl": "https://erdosproblems.com/943",
     "erdosUrl": "https://erdosproblems.com/943",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 87,
-    "assumptions": "4 axioms: erdos_943_subpolynomial, powerful_density, trivial_upper_bound, and 1 more. See Lean source for complete statements.",
+    "axiomCount": 3,
+    "lineCount": 140,
+    "assumptions": "3 axioms: erdos_943_subpolynomial (OPEN conjecture), powerful_density (√x density of powerful numbers), powerful_structure (a²b³ characterization). trivial_upper_bound eliminated — now proved from powerful_density.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -114,8 +114,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 87,
-    "axiomCount": 4,
+    "lineCount": 140,
+    "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Summary

- **erdos-943**: axiomCount 4→3 (`trivial_upper_bound` axiom eliminated, now proved from `powerful_density`), lineCount 87→140
- **erdos-311**: lineCount 97→96

## Evidence

- `grep -c '^axiom ' Erdos943Problem.lean` = 3 (was claimed 4)
- `wc -l Erdos943Problem.lean` = 140 (was claimed 87)
- `wc -l Erdos311Problem.lean` = 96 (was claimed 97)

## Test plan

- [x] Verified axiom names in erdos-943: erdos_943_subpolynomial, powerful_density, powerful_structure
- [x] Verified line counts via `wc -l`

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)