### PR TITLE
Research: erdos-524 — prove 6 theorems: sign properties + polynomial bounds

### DIFF
--- a/proofs/Proofs/Erdos524Problem.lean
+++ b/proofs/Proofs/Erdos524Problem.lean
@@ -80,3 +80,52 @@ axiom erdos_524_order_of_magnitude :
       ∃ c₁ c₂ : ℝ, 0 < c₁ ∧ 0 < c₂ ∧
         ∃ N₀ : ℕ, ∀ n : ℕ, N₀ ≤ n →
           c₁ * f n ≤ polyMax t n ∧ polyMax t n ≤ c₂ * f n
+
+/- ## Properties of binary digits -/
+
+/-- The binary digit function returns exactly 1 or -1. -/
+theorem binaryDigit_values (t : ℝ) (k : ℕ) :
+    binaryDigit t k = 1 ∨ binaryDigit t k = -1 := by
+  simp only [binaryDigit]; split_ifs <;> simp
+
+/-- The absolute value of a binary digit (cast to ℝ) is always 1. -/
+theorem binaryDigit_cast_abs (t : ℝ) (k : ℕ) :
+    |(binaryDigit t k : ℝ)| = 1 := by
+  rcases binaryDigit_values t k with h | h <;> simp [h]
+
+/- ## Properties of the polynomial -/
+
+/-- The random sign polynomial vanishes at x = 0. -/
+theorem randSignPoly_eval_zero (t : ℝ) (n : ℕ) : randSignPoly t n 0 = 0 := by
+  simp [randSignPoly]
+
+/-- At x = 1, the polynomial equals the sum of sign values. -/
+theorem randSignPoly_eval_one (t : ℝ) (n : ℕ) :
+    randSignPoly t n 1 = ∑ k ∈ Finset.range n, (binaryDigit t (k + 1) : ℝ) := by
+  simp [randSignPoly]
+
+/-- Recurrence: adding one more term to the polynomial. -/
+theorem randSignPoly_succ (t : ℝ) (n : ℕ) (x : ℝ) :
+    randSignPoly t (n + 1) x = randSignPoly t n x +
+      (binaryDigit t (n + 1) : ℝ) * x ^ (n + 1) := by
+  simp [randSignPoly, Finset.sum_range_succ]
+
+/- ## Trivial upper bound -/
+
+/-- For |x| ≤ 1, the polynomial is bounded: |P_n(t,x)| ≤ n.
+    Each of the n terms has absolute value at most 1. -/
+theorem randSignPoly_abs_le (t : ℝ) (n : ℕ) {x : ℝ} (hx : |x| ≤ 1) :
+    |randSignPoly t n x| ≤ n := by
+  induction n with
+  | zero => simp [randSignPoly]
+  | succ n ih =>
+    rw [randSignPoly_succ]
+    have h_sign : |(↑(binaryDigit t (n + 1)) : ℝ)| = 1 := binaryDigit_cast_abs t (n + 1)
+    have h_pow : |x| ^ (n + 1) ≤ 1 := by
+      calc |x| ^ (n + 1) ≤ 1 ^ (n + 1) := pow_le_pow_left (abs_nonneg x) hx _
+        _ = 1 := one_pow _
+    have h_term : |(↑(binaryDigit t (n + 1)) : ℝ) * x ^ (n + 1)| ≤ 1 := by
+      rw [abs_mul, abs_pow, h_sign, one_mul]; exact h_pow
+    rw [show (↑(n + 1) : ℝ) = ↑n + 1 from by push_cast; ring]
+    linarith [abs_add (randSignPoly t n x)
+      ((↑(binaryDigit t (n + 1)) : ℝ) * x ^ (n + 1))]

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -35,7 +35,7 @@
       }
     ],
     "axiomCount": 4,
-    "lineCount": 82,
+    "lineCount": 131,
     "assumptions": "4 axioms: erdos_lower_bound, chung_upper_bound, salem_zygmund_trigonometric, and 1 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -127,9 +127,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 82,
+    "lineCount": 131,
     "axiomCount": 4,
-    "theoremCount": 0,
+    "theoremCount": 6,
     "definitionCount": 3
   },
   "references": [

--- a/src/data/research/problems/erdos-524.json
+++ b/src/data/research/problems/erdos-524.json
@@ -29,11 +29,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "BUILD: Added 6 proved theorems — binary digit properties, polynomial evaluation, recurrence, trivial upper bound |P_n|≤n. Axiom count unchanged at 4 (all deep/open).",
+    "builtItems": [
+      "binaryDigit_values: sign function returns ±1 (line 86)",
+      "binaryDigit_cast_abs: |sign(t,k)| = 1 as real (line 91)",
+      "randSignPoly_eval_zero: P_n(t,0) = 0 (line 96)",
+      "randSignPoly_eval_one: P_n(t,1) = Σ signs (line 100)",
+      "randSignPoly_succ: recurrence P_{n+1} = P_n + sign·x^{n+1} (line 105)",
+      "randSignPoly_abs_le: |P_n(t,x)| ≤ n for |x|≤1 (line 113)"
+    ],
+    "insights": [
+      "binaryDigit returns exactly 1 or -1 (cast of floor-mod condition)",
+      "|binaryDigit(t,k)| = 1 as a real, enabling clean term-by-term bounds",
+      "P_n(t,0) = 0 since all terms have x^k with k≥1",
+      "P_n(t,1) = sum of signs, connecting polynomial max to partial sums",
+      "|P_n(t,x)| ≤ n for |x| ≤ 1 by triangle inequality + term bound",
+      "All 4 axioms are deep results or open: none provable from Mathlib"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove P_n(t,-1) evaluates to alternating sign sum",
+      "Prove polyMax_nonneg: M_n(t) ≥ 0 (requires sSup machinery)",
+      "Consider L² norm computation: E[P_n²] = n via orthogonality"
+    ],
     "markdown": "# Erdős #524 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor any $t\\in (0,1)$ let $t=\\sum_{k=1}^\\infty \\epsilon_k(t)2^{-k}$ (where $\\epsilon_k(t)\\in \\{0,1\\}$). What is the correct order of magnitude (for almost all $t\\in(0,1)$) for\\[M_n(t)=\\max_{x\\in [-1,1]}\\left\\lvert \\sum_{k\\leq n}(-1)^{\\epsilon_k(t)}x^k\\right\\rvert?\\]\n\n\n\nA problem of Salem and Zygmund \\cite{SaZy54}. Chung showed that, for almost all $t$, there exist infinitely many $n$ such that\\[M_n(t) \\ll \\left(\\frac{n}{\\log\\log n}\\right)^{1/2}.\\]Erd\\H{o}s (unpublished) showed that for almost all $t$ and every $\\epsilon>0$ we have $\\lim_{n\\to \\infty}M_n(t)/n^{1/2-\\epsilon}=\\infty$.\n\n\n\n\nReferences\n\n\n[SaZy54] Salem, R. and Zygmund, A., Some properties of trigonometric series whose terms have\nrandom signs. Acta Math. (1954), 245-301.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #523\n- Problem #525\n- Problem #39\n- Problem #1\n\n## References\n\n- SaZy54\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Prove 6 new theorems for Erdős Problem 524 (random sign polynomials)
- Axiom count unchanged at 4 (all deep analytical results)
- Validates definitions and establishes basic bounds

## Progress
- **binaryDigit_values + binaryDigit_cast_abs**: Sign function returns ±1, |sign| = 1
- **randSignPoly_eval_zero/one**: Polynomial vanishes at 0, equals sum of signs at 1
- **randSignPoly_succ**: Recurrence relation P_{n+1} = P_n + sign·x^{n+1}
- **randSignPoly_abs_le**: Triangle inequality bound |P_n(t,x)| ≤ n for |x| ≤ 1

## Findings
- All 4 axioms are deep results (Erdős lower bound, Chung upper bound, Salem-Zygmund, open problem) — none provable from Mathlib
- The trivial bound |P_n| ≤ n confirms the polynomial is O(n), matching the upper bound framework

## Status
**Outcome**: completed
**Next Steps**: L² norm computation, polyMax non-negativity via sSup, P(-1) evaluation

Generated by researcher-6