### PR TITLE
Research: erdos-693 — prove maxGap_trivial_upper axiom (4→3 axioms)

### DIFF
--- a/proofs/Proofs/Erdos693Problem.lean
+++ b/proofs/Proofs/Erdos693Problem.lean
@@ -226,11 +226,43 @@ theorem setA_has_many_elements {n k : ℕ} (hn : n ≥ 3) (hk : k ≥ 2) :
 
 /- ## Part VIII: Gap Bounds -/
 
-/-- Trivial upper bound: maximum gap ≤ n^k - n.
-All elements lie in [n, n^k], so consecutive differences are ≤ n^k - n.
-Axiomatized: proof requires deep list infrastructure (foldl max bound). -/
-axiom maxGap_trivial_upper (n k : ℕ) (hn : n ≥ 1) :
-    maxGapA n k hn ≤ n ^ k - n
+/-- Helper: if all elements of a list are in [lo, hi], the foldl max of
+    consecutive gaps is bounded by hi - lo. -/
+private theorem consecutiveGaps_foldl_max_le (lo hi : ℕ) :
+    ∀ (L : List ℕ) (acc : ℕ),
+      acc ≤ hi - lo →
+      (∀ x ∈ L, lo ≤ x ∧ x ≤ hi) →
+      (consecutiveGaps L).foldl max acc ≤ hi - lo := by
+  intro L
+  induction L with
+  | nil => intro acc hacc _; rw [consecutiveGaps_nil]; exact hacc
+  | cons a L ih =>
+    intro acc hacc hL
+    cases L with
+    | nil => rw [consecutiveGaps_singleton]; exact hacc
+    | cons b L' =>
+      have hcg : consecutiveGaps (a :: b :: L') =
+          (b - a) :: consecutiveGaps (b :: L') := by
+        simp only [consecutiveGaps, List.tail_cons, List.zipWith_cons_cons]
+      rw [hcg]; change (consecutiveGaps (b :: L')).foldl max (max acc (b - a)) ≤ hi - lo
+      apply ih
+      · exact max_le hacc (by
+          have := (hL a (List.mem_cons_self _ _)).1
+          have := (hL b (List.mem_cons_of_mem _ (List.mem_cons_self _ _))).2
+          omega)
+      · intro x hx; exact hL x (List.mem_cons_of_mem _ hx)
+
+/-- Maximum gap ≤ n^k - n: all elements lie in [n, n^k], so no
+    consecutive difference can exceed the total range. -/
+theorem maxGap_trivial_upper (n k : ℕ) (hn : n ≥ 1) :
+    maxGapA n k hn ≤ n ^ k - n := by
+  unfold maxGapA maxGap
+  apply consecutiveGaps_foldl_max_le n (n ^ k) (orderedA n k hn) 0 (Nat.zero_le _)
+  intro x hx
+  have hmem : x ∈ setAFinset n k hn := by
+    simp only [orderedA] at hx
+    rwa [Finset.mem_sort] at hx
+  exact Finset.mem_Icc.mp (setAFinset_subset_Icc n k hn hmem)
 
 /-- Pigeonhole: if A has |A| elements in range R, max gap ≥ R/|A|.
 Axiomatized: requires telescoping sum through list operations. -/
@@ -300,15 +332,16 @@ axiom polylog_implies_subpoly : ∀ k : ℕ, polylogBoundedGap k → subpolynomi
 
 **STATUS:** OPEN
 
-**PROVED (16 theorems):**
+**PROVED (25 theorems):**
 - setA finite, contained in [n, n^k], monotone in k
 - Divisor bounds: d ≥ 2, quotient q ≥ 1
 - setA contains all d ∈ (n, 2n) (≥ n-1 elements for n ≥ 3)
 - General membership criterion, specific witnesses
 - Gap infrastructure, cardinality bounds
+- maxGap ≤ n^k - n (was axiom, now proved by list induction)
 
-**AXIOMATIZED (4 axioms):**
-- maxGap ≤ n^k - n, Pigeonhole, Ford density, polylog⟹subpoly
+**AXIOMATIZED (3 axioms):**
+- Pigeonhole, Ford density, polylog⟹subpoly
 -/
 theorem erdos_693_summary :
     erdos693Conjecture ↔ ∀ k, k ≥ 2 → polylogBoundedGap k :=

--- a/src/data/proofs/erdos-693/meta.json
+++ b/src/data/proofs/erdos-693/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": 693,
     "erdosUrl": "https://erdosproblems.com/693",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 3,
     "prerequisites": [
       "Elementary number theory (divisibility, divisor functions)",
       "Finite set theory and cardinality (Finset, Set.Finite)",
@@ -29,7 +29,7 @@
       "Sieve methods and density estimates",
       "Pigeonhole principle"
     ],
-    "lineCount": 317,
+    "lineCount": 350,
     "assumptions": "4 axioms: maxGap_trivial_upper, maxGap_pigeonhole, divisor_density_ford, and 1 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -175,9 +175,9 @@
       "Filter"
     ],
     "namespace": "Erdos693",
-    "lineCount": 317,
-    "axiomCount": 4,
-    "theoremCount": 24,
+    "lineCount": 350,
+    "axiomCount": 3,
+    "theoremCount": 26,
     "definitionCount": 13
   }
 }

--- a/src/data/research/problems/erdos-662.json
+++ b/src/data/research/problems/erdos-662.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-662",
-  "title": "Erd\u0151s #662",
+  "title": "Erdős #662",
   "phase": "ORIENT",
   "status": "active",
   "tier": "B",
@@ -20,7 +20,9 @@
     "since": "2026-01-13T18:22:04.304Z",
     "iteration": 2,
     "focus": "Eliminated unit_neighbor_bound axiom by reducing to kissing_number_2d (sorry). 1 axiom remains.",
-    "blockers": ["kissing_number_2d sorry needs angular packing proof"],
+    "blockers": [
+      "kissing_number_2d sorry needs angular packing proof"
+    ],
     "nextAction": "Prove kissing_number_2d via Real.cos_sub + cos_pi_div_three + strictAntiOn_cos",
     "attemptCounts": {
       "total": 2,
@@ -29,12 +31,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 2 eliminated unit_neighbor_bound axiom. Proved neighbors on unit circle + dot product bound. Reduced to kissing_number_2d (sorry). 1 axiom remains (open conjecture).",
+    "progressSummary": "SURVEY: Investigated kissing_number_2d proof strategies. Ruled out algebraic approaches. Confirmed trigonometric pigeonhole is needed. All required Mathlib lemmas available. Proof estimated at 50-80 lines.",
     "builtItems": [
       {
         "name": "triLatticeNorm",
         "type": "def",
-        "description": "a\u00b2 + ab + b\u00b2 norm for triangular lattice"
+        "description": "a² + ab + b² norm for triangular lattice"
       },
       {
         "name": "triLatticeCountInt",
@@ -58,13 +60,22 @@
       }
     ],
     "insights": [
-      "All triangular lattice norms a\u00b2+ab+b\u00b2 are integers \u2192 f(t) = countInt(\u230at\u00b2\u230b)",
+      "All triangular lattice norms a²+ab+b² are integers → f(t) = countInt(⌊t²⌋)",
       "native_decide efficiently verifies small lattice point counts",
-      "unit_neighbor_bound (2D kissing number) provable via angular packing but needs trig from Mathlib"
+      "unit_neighbor_bound (2D kissing number) provable via angular packing but needs trig from Mathlib",
+      "kissing_number_2d proof requires Complex.arg parametrization + angular pigeonhole on 6 sectors of width π/3",
+      "Key Mathlib lemmas available: Real.cos_pi_div_three, Real.strictAntiOn_cos, Real.cos_sub — all used elsewhere in codebase",
+      "Proof sketch: (1) map unit vectors to Complex.arg ∈ (-π,π], (2) pigeonhole 7+ vectors into 6 bins of width π/3, (3) same-bin vectors have |Δθ|<π/3 so dot product > cos(π/3) = 1/2, contradiction",
+      "The argmax-to-hexagon-vertex approach FAILS: two vectors close to same vertex can have angle up to 2π/3, giving dot product as low as -1/2",
+      "Algebraic (Gram matrix) approaches also fail: rank-2 constraint gives average of (v·w)² ≥ 5/12 but v·w≤1/2 allows negative values with large squares"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erd\u0151s #662 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nConsider the triangular lattice with minimal distance between two points $1$. Denote by $f(t)$ the number of distances from any points $\\leq t$. For example $f(1)=6$, $f(\\sqrt{3})=12$, and $f(3)=18$.\n\nLet $x_1,\\ldots,x_n\\in \\mathbb{R}^2$ be such that $d(x_i,x_j)\\geq 1$ for all $i\\neq j$. Is it true that, provided $n$ is sufficiently large depending on $t$, the number of distances $d(x_i,x_j)\\leq t$ is less than or equal to $f(t)$ with equality perhaps only for the triangular lattice?\n\nIn particular, is it true that the number of distances $\\leq \\sqrt{3}-\\epsilon$ is less than $1$?\n\n\n\nA problem of Erd\\H{o}s, Lov\\'{a}sz, and Vesztergombi.\n\nThis is essentially verbatim the problem description in \\cite{Er97e}, but this does not make sense as written; there must be at least one typo. Suggestions about what this problem intends are welcome.\n\nErd\\H{o}s also goes on to write 'Perhaps the following stronger conjecture holds: Let $t_1<t_2<\\cdots$ be the set of distances occurring in the triangular lattice. $t_1=1$ $t_2=\\sqrt{3}$ $t_3=3$ $t_4=5$ etc. Is it true that there is an $\\epsilon_n$ so that for every set $y_1,\\ldots,$ with $d(y_i,y_j)\\geq 1$ the number of distances $d(y_i,y_j)<t_n$ is less than $f(t_n)$?'\n\nAgain, this is nonsense interpreted literally; I am not sure what Erd\\H{o}s intended.\n\n\n\n\nReferences\n\n\n[Er97e] Erd\\H{o}s, Paul, Some of my favourite unsolved problems. Math. Japon. (1997), 527-537.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #661\n- Problem #663\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er97e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "nextSteps": [
+      "Prove kissing_number_2d via Complex.arg + sector pigeonhole (dedicated session, ~60 lines)",
+      "Define angleBin function mapping Complex.arg to Fin 6 for pigeonhole",
+      "Use Finset.exists_lt_card_fiber for pigeonhole principle in Lean"
+    ],
+    "markdown": "# Erdős #662 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nConsider the triangular lattice with minimal distance between two points $1$. Denote by $f(t)$ the number of distances from any points $\\leq t$. For example $f(1)=6$, $f(\\sqrt{3})=12$, and $f(3)=18$.\n\nLet $x_1,\\ldots,x_n\\in \\mathbb{R}^2$ be such that $d(x_i,x_j)\\geq 1$ for all $i\\neq j$. Is it true that, provided $n$ is sufficiently large depending on $t$, the number of distances $d(x_i,x_j)\\leq t$ is less than or equal to $f(t)$ with equality perhaps only for the triangular lattice?\n\nIn particular, is it true that the number of distances $\\leq \\sqrt{3}-\\epsilon$ is less than $1$?\n\n\n\nA problem of Erd\\H{o}s, Lov\\'{a}sz, and Vesztergombi.\n\nThis is essentially verbatim the problem description in \\cite{Er97e}, but this does not make sense as written; there must be at least one typo. Suggestions about what this problem intends are welcome.\n\nErd\\H{o}s also goes on to write 'Perhaps the following stronger conjecture holds: Let $t_1<t_2<\\cdots$ be the set of distances occurring in the triangular lattice. $t_1=1$ $t_2=\\sqrt{3}$ $t_3=3$ $t_4=5$ etc. Is it true that there is an $\\epsilon_n$ so that for every set $y_1,\\ldots,$ with $d(y_i,y_j)\\geq 1$ the number of distances $d(y_i,y_j)<t_n$ is less than $f(t_n)$?'\n\nAgain, this is nonsense interpreted literally; I am not sure what Erd\\H{o}s intended.\n\n\n\n\nReferences\n\n\n[Er97e] Erd\\H{o}s, Paul, Some of my favourite unsolved problems. Math. Japon. (1997), 527-537.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #661\n- Problem #663\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er97e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"

--- a/src/data/research/problems/erdos-693.json
+++ b/src/data/research/problems/erdos-693.json
@@ -29,11 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "AXIOM HUNT: Eliminated maxGap_trivial_upper axiom (4→3 axioms). Proved by list induction via consecutiveGaps_foldl_max_le helper. 26 theorems total.",
+    "builtItems": [
+      "consecutiveGaps_foldl_max_le: if list elements in [lo,hi], foldl max of gaps ≤ hi-lo (line 234)",
+      "maxGap_trivial_upper: PROVED (was axiom) — max gap ≤ n^k - n (line 260)"
+    ],
+    "insights": [
+      "maxGap_trivial_upper axiom eliminated: proved by induction on list structure of consecutive gaps",
+      "Key technique: consecutiveGaps_foldl_max_le helper generalizes over accumulator for foldl max induction",
+      "Remaining 3 axioms: pigeonhole (list telescoping), Ford density (deep analysis), polylog⟹subpoly (standard analysis)"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove polylog_implies_subpoly using Mathlib log/pow asymptotics",
+      "Prove maxGap_pigeonhole via telescoping sum over sorted list",
+      "Consider Aristotle companion file for routine list lemmas"
+    ],
     "markdown": "# Erdős #693 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k\\geq 2$ and $n$ be sufficiently large depending on $k$. Let $A=\\{a_1<a_2<\\cdots \\}$ be the set of those integers in $[n,n^k]$ which have a divisor in $(n,2n)$. Estimate\\[\\max_{i} a_{i+1}-a_i.\\]Is this $\\leq (\\log n)^{O(1)}$?\n\n\n\nSee also [446].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #446\n- Problem #692\n- Problem #694\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Eliminated `maxGap_trivial_upper` axiom by proving it via list induction
- Axiom count reduced from 4 to 3

## Progress
- **consecutiveGaps_foldl_max_le**: Helper lemma proving that `foldl max` over consecutive gaps is bounded by `hi - lo` when all list elements are in `[lo, hi]`
- **maxGap_trivial_upper**: Now a theorem (was axiom) — maximum gap in A ≤ n^k - n since all elements lie in [n, n^k]

## Findings
- The axiom was marked as needing "deep list infrastructure" but was provable by clean induction on list structure with case split on nil/singleton/cons-cons
- Key trick: generalize over the accumulator in `foldl max` to make the induction hypothesis strong enough
- Remaining 3 axioms are genuinely deep: pigeonhole (needs telescoping sum), Ford density (deep analysis), polylog implies subpolynomial (standard but needs log asymptotics)

## Status
**Outcome**: completed (axiom elimination)
**Next Steps**: Prove polylog_implies_subpoly, prove maxGap_pigeonhole

Generated by researcher-6