### PR TITLE
chore: audit iteration 7 — line/theorem count fixes (4 proofs)

### DIFF
--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1000",
     "erdosProblemStatus": "solved",
     "axiomCount": 3,
-    "lineCount": 681,
+    "lineCount": 988,
     "assumptions": "Three deep axioms: erdos_no_zero_limit (φ_A(k)/n_k cannot converge to 0), erdos_dichotomy (liminf=0 implies limsup=1), haight_resolution (vanishing Cesàro average exists). cassels_liminf_zero is now PROVED as a corollary of haight_resolution (convergence to 0 implies liminf = 0). Infrastructure: complement formula (phiA_add_used), used-divisor bounds (used_sum_le, used_card_le), positivity (phiA_pos, densityRatio_pos), complement representation (densityRatio_complement), prime lower bound (densityRatio_ge_of_prime).",
     "mathlib_version": "4.26.0"
   },
@@ -202,9 +202,9 @@
       "Topology"
     ],
     "namespace": "Erdos1000",
-    "lineCount": 681,
+    "lineCount": 988,
     "axiomCount": 3,
-    "theoremCount": 22,
+    "theoremCount": 52,
     "definitionCount": 8
   }
 }

--- a/src/data/proofs/erdos-1167/meta.json
+++ b/src/data/proofs/erdos-1167/meta.json
@@ -68,7 +68,7 @@
       "infinite_ramsey_one"
     ],
     "axiomCount": 3,
-    "lineCount": 352,
+    "lineCount": 608,
     "assumptions": "3 axiom(s): erdos_1167_conjecture, infinite_ramsey, erdos_rado_theorem. The infinite_ramsey axiom is only needed for r >= 2; the r=0 and r=1 cases are proved from first principles (infinite_ramsey_zero, infinite_ramsey_one)."
   },
   "overview": {
@@ -163,9 +163,9 @@
       "Set"
     ],
     "namespace": "Erdos1167",
-    "lineCount": 352,
+    "lineCount": 608,
     "axiomCount": 3,
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 5
   },
   "references": [

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/193",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 159,
+    "lineCount": 158,
     "assumptions": "1 axiom: gerver_ramsey_2d (Gerver-Ramsey 2D theorem). 9 proved theorems including collinearity permutations, d=1 case, and singleton step set case.",
     "mathlib_version": "4.26.0"
   },
@@ -143,7 +143,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 159,
+    "lineCount": 158,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 5

--- a/src/data/proofs/erdos-451/meta.json
+++ b/src/data/proofs/erdos-451/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2025-01-01",
     "mathlib_version": "4.26.0",
     "axiomCount": 6,
-    "lineCount": 155,
+    "lineCount": 195,
     "assumptions": "6 axiom(s). No sorries."
   },
   "overview": {
@@ -122,9 +122,9 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 155,
+    "lineCount": 195,
     "axiomCount": 6,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 8
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

Fix stale line counts and theorem counts after recent research commits:

| Proof | Lines | Theorems |
|-------|-------|----------|
| erdos-1000 | 681→988 | 22→52 |
| erdos-1167 | 352→608 | 17→19 |
| erdos-451 | 155→195 | 5→8 |
| erdos-193 | 159→158 | 9 (ok) |

## Test plan

- [x] All counts verified via `wc -l` and `grep -c` against Lean source files
- [x] Sorry and axiom counts verified as current

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)