### PR TITLE
Research: erdos-662 — prove kissing_number_2d (0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos662Problem.lean
+++ b/proofs/Proofs/Erdos662Problem.lean
@@ -14,6 +14,8 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Tactic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Complex.Arg
 
 open Finset Classical
 
@@ -143,18 +145,134 @@ private lemma neighbor_dot_le_half (pts : Finset Point2D) (p q₁ q₂ : Point2D
       2 * ((q₁.1 - p.1) * (q₂.1 - p.1) + (q₁.2 - p.2) * (q₂.2 - p.2)) := by ring
   linarith
 
+-- ===== Kissing Number Proof Infrastructure =====
+
+/-- Sector assignment for angles in (-π, π]: six half-open arcs of width π/3. -/
+private noncomputable def angleSector (θ : ℝ) : Fin 6 :=
+  if θ ≤ -2 * Real.pi / 3 then ⟨0, by omega⟩
+  else if θ ≤ -Real.pi / 3 then ⟨1, by omega⟩
+  else if θ ≤ 0 then ⟨2, by omega⟩
+  else if θ ≤ Real.pi / 3 then ⟨3, by omega⟩
+  else if θ ≤ 2 * Real.pi / 3 then ⟨4, by omega⟩
+  else ⟨5, by omega⟩
+
+private noncomputable def sectorLo : Fin 6 → ℝ
+  | ⟨0, _⟩ => -Real.pi
+  | ⟨1, _⟩ => -2 * Real.pi / 3
+  | ⟨2, _⟩ => -Real.pi / 3
+  | ⟨3, _⟩ => 0
+  | ⟨4, _⟩ => Real.pi / 3
+  | ⟨5, _⟩ => 2 * Real.pi / 3
+  | ⟨n + 6, h⟩ => absurd h (by omega)
+
+private noncomputable def sectorHi : Fin 6 → ℝ
+  | ⟨0, _⟩ => -2 * Real.pi / 3
+  | ⟨1, _⟩ => -Real.pi / 3
+  | ⟨2, _⟩ => 0
+  | ⟨3, _⟩ => Real.pi / 3
+  | ⟨4, _⟩ => 2 * Real.pi / 3
+  | ⟨5, _⟩ => Real.pi
+  | ⟨n + 6, h⟩ => absurd h (by omega)
+
+private lemma sectorHi_sub_sectorLo (k : Fin 6) :
+    sectorHi k - sectorLo k = Real.pi / 3 := by
+  fin_cases k <;> simp [sectorHi, sectorLo] <;> ring
+
+private lemma angleSector_in_range (θ : ℝ) (hθ : θ ∈ Set.Ioc (-Real.pi) Real.pi) :
+    sectorLo (angleSector θ) < θ ∧ θ ≤ sectorHi (angleSector θ) := by
+  simp only [angleSector]
+  split_ifs with h1 h2 h3 h4 h5
+  all_goals (simp only [sectorLo, sectorHi]; constructor <;> linarith [hθ.1, hθ.2])
+
+private lemma same_sector_diff_lt {θ φ : ℝ}
+    (hθ : θ ∈ Set.Ioc (-Real.pi) Real.pi)
+    (hφ : φ ∈ Set.Ioc (-Real.pi) Real.pi)
+    (hs : angleSector θ = angleSector φ) :
+    |θ - φ| < Real.pi / 3 := by
+  obtain ⟨hlo_θ, hhi_θ⟩ := angleSector_in_range θ hθ
+  obtain ⟨hlo_φ, hhi_φ⟩ := angleSector_in_range φ hφ
+  rw [hs] at hlo_φ hhi_φ
+  have hw := sectorHi_sub_sectorLo (angleSector θ)
+  rw [abs_sub_lt_iff]; constructor <;> linarith
+
+private lemma cos_gt_half_of_abs_lt {d : ℝ} (hd : |d| < Real.pi / 3) :
+    1 / 2 < Real.cos d := by
+  have hpi := Real.pi_pos
+  have heven : Real.cos d = Real.cos |d| := by
+    rcases le_or_lt 0 d with h | h
+    · rw [abs_of_nonneg h]
+    · rw [abs_of_neg h, Real.cos_neg]
+  rw [heven, show (1 : ℝ) / 2 = Real.cos (Real.pi / 3) from Real.cos_pi_div_three.symm]
+  rcases eq_or_lt_of_le (abs_nonneg d) with h0 | h0
+  · rw [← h0, Real.cos_zero, Real.cos_pi_div_three]; norm_num
+  · exact Real.strictAntiOn_cos
+      (Set.mem_Icc.mpr ⟨le_of_lt h0, by linarith⟩)
+      (Set.mem_Icc.mpr ⟨by linarith, by linarith⟩)
+      hd
+
+/-- Dot product of unit vectors equals cosine of their Complex.arg difference. -/
+private lemma unit_dot_eq_cos_arg_sub {v w : ℝ × ℝ}
+    (hv : v.1 ^ 2 + v.2 ^ 2 = 1) (hw : w.1 ^ 2 + w.2 ^ 2 = 1) :
+    v.1 * w.1 + v.2 * w.2 =
+      Real.cos (Complex.arg ⟨v.1, v.2⟩ - Complex.arg ⟨w.1, w.2⟩) := by
+  set zv : ℂ := ⟨v.1, v.2⟩
+  set zw : ℂ := ⟨w.1, w.2⟩
+  have hv_ne : zv ≠ 0 := by
+    intro h; have := Complex.ext_iff.mp h; simp at this; nlinarith [this.1, this.2, hv]
+  have hw_ne : zw ≠ 0 := by
+    intro h; have := Complex.ext_iff.mp h; simp at this; nlinarith [this.1, this.2, hw]
+  have hv_abs : Complex.abs zv = 1 := by
+    have hsq : (Complex.abs zv) ^ 2 = 1 := by
+      rw [sq_abs]; simp [Complex.normSq_apply, zv]; nlinarith
+    have hnn := Complex.abs.nonneg zv
+    nlinarith [sq_nonneg (Complex.abs zv - 1)]
+  have hw_abs : Complex.abs zw = 1 := by
+    have hsq : (Complex.abs zw) ^ 2 = 1 := by
+      rw [sq_abs]; simp [Complex.normSq_apply, zw]; nlinarith
+    have hnn := Complex.abs.nonneg zw
+    nlinarith [sq_nonneg (Complex.abs zw - 1)]
+  rw [Real.cos_sub,
+    show Real.cos (Complex.arg zv) = v.1 from by
+      rw [Complex.cos_arg hv_ne, hv_abs, div_one],
+    show Real.sin (Complex.arg zv) = v.2 from by
+      rw [Complex.sin_arg hv_ne, hv_abs, div_one],
+    show Real.cos (Complex.arg zw) = w.1 from by
+      rw [Complex.cos_arg hw_ne, hw_abs, div_one],
+    show Real.sin (Complex.arg zw) = w.2 from by
+      rw [Complex.sin_arg hw_ne, hw_abs, div_one]]
+
+-- ===== Main Kissing Number Theorem =====
+
 /-- **2D Kissing Number**: At most 6 unit vectors in ℝ² can have pairwise
     dot product ≤ 1/2. Equivalently: at most 6 points on the unit circle
     can have pairwise distance ≥ 1.
 
-    Proof outline: Each unit vector v = (cos θ, sin θ). The constraint
-    cos(θᵢ - θⱼ) ≤ 1/2 forces angular separation ≥ π/3 (using
-    Real.strictAntiOn_cos). Since 6 · (π/3) = 2π, at most 6 fit. -/
+    Proof: Assign each vector to one of 6 sectors of width π/3 via Complex.arg.
+    Two vectors in the same sector have angular separation < π/3, hence
+    dot product > cos(π/3) = 1/2. So the sector map is injective on S,
+    giving |S| ≤ 6. -/
 theorem kissing_number_2d (S : Finset (ℝ × ℝ))
     (hunit : ∀ v ∈ S, v.1 ^ 2 + v.2 ^ 2 = 1)
     (hdot : ∀ v ∈ S, ∀ w ∈ S, v ≠ w → v.1 * w.1 + v.2 * w.2 ≤ 1 / 2) :
     S.card ≤ 6 := by
-  sorry -- Angular packing: uses Real.cos_sub, Real.cos_pi_div_three, Real.strictAntiOn_cos
+  let f : ℝ × ℝ → Fin 6 := fun v => angleSector (Complex.arg ⟨v.1, v.2⟩)
+  have hinj : Set.InjOn f ↑S := by
+    intro v hv w hw hfw
+    by_contra hvw
+    have hv_mem : v ∈ S := Finset.mem_coe.mp hv
+    have hw_mem : w ∈ S := Finset.mem_coe.mp hw
+    have hv_range : Complex.arg ⟨v.1, v.2⟩ ∈ Set.Ioc (-Real.pi) Real.pi :=
+      ⟨Complex.neg_pi_lt_arg _, Complex.arg_le_pi _⟩
+    have hw_range : Complex.arg ⟨w.1, w.2⟩ ∈ Set.Ioc (-Real.pi) Real.pi :=
+      ⟨Complex.neg_pi_lt_arg _, Complex.arg_le_pi _⟩
+    have h_close := same_sector_diff_lt hv_range hw_range hfw
+    have h_cos := cos_gt_half_of_abs_lt h_close
+    have h_dot := unit_dot_eq_cos_arg_sub (hunit v hv_mem) (hunit w hw_mem)
+    linarith [hdot v hv_mem w hw_mem hvw]
+  have h1 := (Finset.card_image_of_injOn hinj).symm
+  have h2 := Finset.card_le_univ (S.image f)
+  simp [Fintype.card_fin] at h2
+  linarith
 
 /-- In a 1-separated set, each point has at most 6 unit neighbors.
     Reduces to the 2D kissing number via translation to the origin. -/

--- a/proofs/Proofs/Erdos929Problem.lean
+++ b/proofs/Proofs/Erdos929Problem.lean
@@ -148,14 +148,68 @@ theorem arithProg_subset_smoothBlockSet (k t : ℕ) :
 
 /-- smoothBlockSet k (k+1) has positive upper density: the AP
 {(k+1)!·t + 1 : t ≥ 0} is contained in it and has density 1/(k+1)!.
-[The density counting argument is left as sorry — the mathematical
-content (CRT + factorial) is proved in smoothBlock_of_factorial_cong.] -/
+
+Proof: The AP {M·i + 1 : i ∈ ℕ} (M = (k+1)!) is contained in S = smoothBlockSet k (k+1)
+by `arithProg_subset_smoothBlockSet`. At index n = M·t, the AP contributes ≥ t members
+to {0,...,n}, giving densityRatio S n ≥ t/(M·t+1) ≥ 1/(M+1) > 0 for t ≥ 1.
+Since this happens frequently, limsup ≥ 1/(M+1) > 0. -/
 theorem smoothBlockSet_pos_density (k : ℕ) :
     0 < (smoothBlockSet k (k + 1)).upperDensity := by
-  -- The AP {M*t + 1 : t ∈ ℕ} ⊆ smoothBlockSet k (k+1) has density 1/M.
-  -- The counting function |S ∩ {0,...,N}| ≥ ⌊(N-1)/M⌋ + 1 ≥ N/(2M) for large N,
-  -- giving limsup ≥ 1/(2M) > 0.
-  sorry
+  set M := (k + 1).factorial with hM_def
+  set S := smoothBlockSet k (k + 1) with hS_def
+  have hM_pos : (0 : ℕ) < M := Nat.factorial_pos _
+  -- Suffices: 1/(M+1) ≤ upperDensity S, since 1/(M+1) > 0
+  apply lt_of_lt_of_le (show (0 : ℝ) < 1 / (↑M + 1) from by positivity)
+  -- Use: if f is frequently ≥ c and bounded above, then limsup f ≥ c
+  apply Filter.le_limsup_of_frequently_le
+  · -- Show densityRatio S n ≥ 1/(M+1) frequently
+    rw [Filter.frequently_atTop]
+    intro N
+    -- Choose n = M * (N + 1)
+    set t := N + 1 with ht_def
+    refine ⟨M * t, by nlinarith, ?_⟩
+    -- Goal is: 1/(M+1) ≤ (fun n => densityRatio S n) (M*t)
+    -- which reduces to: 1/(M+1) ≤ densityRatio S (M*t)
+    change 1 / ((↑M : ℝ) + 1) ≤ densityRatio S (M * t)
+    -- densityRatio S (M*t) = card(filter (· ∈ S) (range(M*t+1))) / (M*t+1)
+    unfold densityRatio
+    -- Step 1: The AP {M*0+1, M*1+1, ..., M*(t-1)+1} gives card ≥ t
+    have hcard : t ≤ (@Finset.filter _ (· ∈ S) (Classical.decPred (· ∈ S))
+        (Finset.range (M * t + 1))).card := by
+      -- Injection: (range t).image (M * · + 1) ⊆ filter, with card = t
+      have hsub : (Finset.range t).image (fun i => M * i + 1) ⊆
+          @Finset.filter _ (· ∈ S) (Classical.decPred (· ∈ S))
+            (Finset.range (M * t + 1)) := by
+        intro x hx
+        obtain ⟨i, hi, rfl⟩ := Finset.mem_image.mp hx
+        rw [Finset.mem_range] at hi
+        refine @Finset.mem_filter _ (· ∈ S) (Classical.decPred (· ∈ S)) _ _ |>.mpr
+          ⟨Finset.mem_range.mpr
+            (show M * i + 1 < M * t + 1 from
+              Nat.add_lt_add_right (mul_lt_mul_of_pos_left hi hM_pos) 1),
+           arithProg_subset_smoothBlockSet k i⟩
+      calc t = (Finset.range t).card := (Finset.card_range t).symm
+        _ = ((Finset.range t).image (fun i => M * i + 1)).card := by
+            rw [Finset.card_image_of_injOn]
+            intro a _ b _ hab
+            have hmul : M * a = M * b := by linarith
+            exact mul_left_cancel₀ (by omega : M ≠ 0) hmul
+        _ ≤ (@Finset.filter _ (· ∈ S) (Classical.decPred (· ∈ S))
+            (Finset.range (M * t + 1))).card :=
+            Finset.card_le_card hsub
+    -- Step 2: 1/(M+1) ≤ card/(M*t+1)
+    -- Cross-multiply: M*t+1 ≤ card*(M+1)
+    -- Since card ≥ t and t*(M+1) = M*t+t ≥ M*t+1 (t ≥ 1)
+    rw [div_le_div_iff₀ (by positivity : (0 : ℝ) < ↑M + 1)
+        (by positivity : (0 : ℝ) < (↑(M * t + 1) : ℝ))]
+    have ht_pos : (1 : ℝ) ≤ ↑t := by exact_mod_cast (show 1 ≤ t from by omega)
+    have hcard_real : (↑t : ℝ) ≤
+        (↑(@Finset.filter _ (· ∈ S) (Classical.decPred (· ∈ S))
+          (Finset.range (M * t + 1))).card : ℝ) := by exact_mod_cast hcard
+    push_cast [Nat.cast_mul]
+    nlinarith
+  · -- IsBoundedUnder (· ≤ ·) atTop (densityRatio S)
+    exact densityRatio_isBoundedUnder S
 
 /-- For any k, ∃ x with smoothBlockSet k x having positive density. -/
 theorem smooth_block_exists (k : ℕ) :

--- a/research/problems/erdos-662/knowledge.md
+++ b/research/problems/erdos-662/knowledge.md
@@ -26,31 +26,16 @@ Triangular lattice maximality conjecture for pair distances.
 | Theorems | 5 | **9** |
 | Lines | 109 | 164 |
 
-### Key Findings
-- All lattice norms are integers, so f(t) = countInt ⌊t²⌋₊
-- `native_decide` handles enumeration of lattice points efficiently
-- Remaining axiom `unit_neighbor_bound` (2D kissing number ≤ 6) is provable via angular packing argument but requires Mathlib angle/trig infrastructure
-
-### Next Steps
-- Prove `unit_neighbor_bound` via angular packing (min angle π/3, at most 6 fit in 2π)
-- The main conjecture `erdos_662_lattice_optimal` remains open
-
 ## Session 2026-03-26 (Session 2) - Eliminate unit_neighbor_bound Axiom
 
 **Mode**: REVISIT
 **Outcome**: progress
 
 ### What I Did
-- Proved `neighbor_sqDist_eq_one`: all unit neighbors are at exactly unit distance
-  - From neighbors def (sqDist ≤ 1) + separation (sqDist ≥ 1) → sqDist = 1
-- Proved `neighbor_dot_le_half`: dot product of translated neighbors ≤ 1/2
-  - Key identity: sqDist(q₁,q₂) = 2 - 2·dot, so dot ≤ 1/2 from separation
-  - Proved using ring + linarith
-- Stated `kissing_number_2d`: at most 6 unit vectors with pairwise dot ≤ 1/2
-  - Left with sorry — needs angular packing argument
-  - Proof strategy documented: uses Real.cos_sub, cos_pi_div_three, strictAntiOn_cos
-- Replaced `axiom unit_neighbor_bound` with `theorem unit_neighbor_bound`
-  - Wired via translation to kissing_number_2d
+- Proved `neighbor_sqDist_eq_one`: neighbors at exactly unit distance
+- Proved `neighbor_dot_le_half`: dot product bound from separation
+- Stated `kissing_number_2d` with sorry
+- Replaced `axiom unit_neighbor_bound` with `theorem` via kissing_number_2d
 
 ### Stats Change
 | Metric | Before | After |
@@ -60,12 +45,32 @@ Triangular lattice maximality conjecture for pair distances.
 | Theorems | 9 | **13** |
 | Lines | 164 | 234 |
 
-### Key Findings
-- Neighbors are on the unit circle (sqDist = 1) — key geometric reduction
-- Dot product bound follows from algebraic identity, no trig needed
-- kissing_number_2d is the clean combinatorial core — purely about unit vectors
-- Mathlib has all needed trig lemmas: cos_pi_div_three, cos_sub, strictAntiOn_cos
+## Session 2026-03-27 (Session 3) - Prove kissing_number_2d
 
-### Next Steps
-- Prove kissing_number_2d via angular packing (good Aristotle candidate)
-- The main conjecture `erdos_662_lattice_optimal` remains open (unprovable)
+**Mode**: REVISIT
+**Outcome**: completed (pending CI verification)
+
+### What I Did
+- Added imports for Trigonometric.Basic and Complex.Arg
+- Proved `angleSector_in_range`: sector assignment maps to correct half-open arc
+- Proved `same_sector_diff_lt`: two angles in same sector differ by < π/3
+- Proved `cos_gt_half_of_abs_lt`: |d| < π/3 → cos d > 1/2
+- Proved `unit_dot_eq_cos_arg_sub`: dot product = cos(arg difference) for unit vectors
+- Proved `kissing_number_2d`: at most 6 unit vectors with pairwise dot ≤ 1/2
+  - Strategy: sector pigeonhole on Complex.arg with 6 arcs of width π/3
+  - Injectivity: same sector → close angles → cos > 1/2 → contradiction with dot ≤ 1/2
+  - Cardinality: injective map to Fin 6 → |S| ≤ 6
+
+### Stats Change
+| Metric | Before | After |
+|--------|--------|-------|
+| Axioms | 1 | **1** (open conjecture, unchanged) |
+| Sorries | 1 | **0** |
+| Theorems | 13 | **14+** (with helper lemmas) |
+| Lines | 234 | **353** |
+
+### Key Findings
+- Sector pigeonhole avoids sorting angles — cleaner than the standard textbook proof
+- `Complex.arg` provides angles in (-π, π] which partition cleanly into 6 half-open sectors
+- The width property (sectorHi - sectorLo = π/3) is proved generically, making same_sector_diff_lt clean
+- Main open question remains the Erdős-Lovász-Vesztergombi conjecture (axiom)

--- a/research/problems/erdos-929/knowledge.md
+++ b/research/problems/erdos-929/knowledge.md
@@ -64,7 +64,29 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-03-25 (Session 1) — Eliminate smoothBlockSet_pos_density sorry
+
+**Mode**: REVISIT
+**Outcome**: completed (sorry eliminated)
+
+#### What I Did
+- Proved `smoothBlockSet_pos_density`: the set smoothBlockSet k (k+1) has positive upper density
+- Proof strategy: the AP {M*i+1 : i ∈ ℕ} (M = (k+1)!) is contained in the smooth block set (via `arithProg_subset_smoothBlockSet`). At index n=M*t, the AP contributes ≥ t members to {0,...,n}. So densityRatio ≥ t/(M*t+1) ≥ 1/(M+1) > 0 frequently.
+- Used `Filter.le_limsup_of_frequently_le` + `densityRatio_isBoundedUnder` for the limsup bound
+- Used `Finset.card_image_of_injOn` + `Finset.card_le_card` for the cardinality injection
+- Overcame DecidablePred instance mismatch: `change` to `densityRatio S (M*t)` then `unfold densityRatio` to match exact Classical.decPred instance from Set.upperDensity definition
+
+#### Key Findings
+- DecidablePred instance from `haveI` does NOT match the one embedded in Set.upperDensity definition — must use `@Finset.filter` with explicit `Classical.decPred (· ∈ S)` to match
+- `div_le_div_iff` is deprecated; use `div_le_div_iff₀` in current Mathlib
+- `omega` cannot handle nonlinear multiplication (M*a = M*b); use `linarith` + `mul_left_cancel₀`
+
+#### Files Modified
+- `proofs/Proofs/Erdos929Problem.lean` — eliminated sorry in smoothBlockSet_pos_density
+
+#### Next Steps
+- smooth_threshold_2 (S(2)=3) may be provable: show x≤2 gives zero density, x=3 works via n≡2 mod 6
+- rosser_lower and fgkmt_upper are deep analytic NT — keep as axioms
 
 ---
 

--- a/research/problems/erdos-929/state.md
+++ b/research/problems/erdos-929/state.md
@@ -1,27 +1,17 @@
-# Current State
+# Research State: erdos-929
 
-**Phase**: NEW
-**Since**: 2026-01-15T11:43:50.649Z
-**Iteration**: 1
+## Current State
+**Phase**: ACT
+**Since**: 2026-03-25T12:00:00Z
+**Iteration**: 4
 
 ## Current Focus
+Eliminated the last sorry (smoothBlockSet_pos_density). File now has 0 sorries, 3 axioms.
 
-Initial exploration of the problem.
-
-## Active Approach
-
-None yet.
-
-## Blockers
-
-None.
+## Attempt Count
+- Total attempts: 4
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Next Action
-
-Begin problem exploration.
-
-## Attempt Counts
-
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+Only deep axioms remain (rosser_lower, fgkmt_upper, smooth_threshold_2). smooth_threshold_2 could potentially be proved.

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -14,15 +14,15 @@
       "packing",
       "open"
     ],
-    "sorries": 1,
+    "sorries": 0,
     "badge": "axiom",
     "sourceUrl": "https://erdosproblems.com/662",
     "erdosUrl": "https://erdosproblems.com/662",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_662_lattice_optimal (the main open conjecture — unprovable). 1 sorry: kissing_number_2d (2D kissing number ≤ 6 — provable via angular packing). Eliminated unit_neighbor_bound axiom by proving neighbor_sqDist_eq_one (neighbors on unit circle) and neighbor_dot_le_half (dot product bound) and reducing to kissing_number_2d.",
+    "assumptions": "1 axiom: erdos_662_lattice_optimal (the main open conjecture). All other results are sorry-free. kissing_number_2d proved via sector pigeonhole on Complex.arg.",
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 234
+    "lineCount": 353
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-929",
   "title": "Smooth Numbers in Short Intervals",
   "slug": "erdos-929",
-  "description": "Let S(k) be the minimal x such that a positive density of n have n+1,...,n+k all x-smooth. Is S(k) ≥ k^{1−o(1)}? Known: k^{1/2−o(1)} ≤ S(k) ≤ k·(log³ k)/(log² k · log⁴ k) by Ford–Green–Konyagin–Maynard–Tao.",
+  "description": "Let S(k) be the minimal x such that a positive density of n have n+1,...,n+k all x-smooth. Is S(k) \u2265 k^{1\u2212o(1)}? Known: k^{1/2\u2212o(1)} \u2264 S(k) \u2264 k\u00b7(log\u00b3 k)/(log\u00b2 k \u00b7 log\u2074 k) by Ford\u2013Green\u2013Konyagin\u2013Maynard\u2013Tao.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/929",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos929Problem.lean",
@@ -26,15 +26,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős posed this problem in 1976, motivated by his longstanding interest in the distribution of smooth (or friable) numbers — integers whose prime factors are all bounded. The study of smooth numbers dates back to Ramanujan (1917) who first investigated their counting function, later made precise by Dickman (1930) through his function $\\rho(u)$ estimating $\\Psi(x, x^{1/u})/x$. The connection to consecutive integers goes deeper: Størmer (1897) had already studied consecutive smooth numbers, and Erdős and others explored how many consecutive integers can share the property of having only small prime factors. The breakthrough of Ford, Green, Konyagin, Maynard, and Tao (2018) on large gaps between primes — settling a conjecture of Erdős on prime gap sizes — unexpectedly provided the best known upper bound on $S(k)$, connecting this problem to one of the central achievements in 21st-century analytic number theory.",
+    "historicalContext": "Erd\u0151s posed this problem in 1976, motivated by his longstanding interest in the distribution of smooth (or friable) numbers \u2014 integers whose prime factors are all bounded. The study of smooth numbers dates back to Ramanujan (1917) who first investigated their counting function, later made precise by Dickman (1930) through his function $\\rho(u)$ estimating $\\Psi(x, x^{1/u})/x$. The connection to consecutive integers goes deeper: St\u00f8rmer (1897) had already studied consecutive smooth numbers, and Erd\u0151s and others explored how many consecutive integers can share the property of having only small prime factors. The breakthrough of Ford, Green, Konyagin, Maynard, and Tao (2018) on large gaps between primes \u2014 settling a conjecture of Erd\u0151s on prime gap sizes \u2014 unexpectedly provided the best known upper bound on $S(k)$, connecting this problem to one of the central achievements in 21st-century analytic number theory.",
     "problemStatement": "Let $S(k)$ be the minimal $x$ such that the set $\\{n \\in \\mathbb{N} : n+1, \\ldots, n+k \\text{ are all } x\\text{-smooth}\\}$ has positive upper density. Is $S(k) \\geq k^{1-o(1)}$?",
-    "text": "Let S(k) be the minimal x such that a positive density of n have n+1,...,n+k all x-smooth. Is S(k) ≥ k^{1−o(1)}? Known: k^{1/2−o(1)} ≤ S(k) ≤ k·(log³ k)/(log² k · log⁴ k) by Ford–Green–Konyagin–Maynard–Tao.",
-    "proofStrategy": "We formalize the core definitions — $x$-smoothness, smooth blocks, upper density, and the threshold function $S(k)$ — then state the main conjecture and known bounds as axioms. The definition of $S(k)$ uses `Nat.find` with the trivial upper bound $S(k) \\leq k+1$ as existence witness. The known bounds are formalized using Lean's filter-based `∀ᶠ ... in atTop` for eventual inequalities, and the FGKMT result is stated with explicit iterated logarithmic factors.",
+    "text": "Let S(k) be the minimal x such that a positive density of n have n+1,...,n+k all x-smooth. Is S(k) \u2265 k^{1\u2212o(1)}? Known: k^{1/2\u2212o(1)} \u2264 S(k) \u2264 k\u00b7(log\u00b3 k)/(log\u00b2 k \u00b7 log\u2074 k) by Ford\u2013Green\u2013Konyagin\u2013Maynard\u2013Tao.",
+    "proofStrategy": "We formalize the core definitions \u2014 $x$-smoothness, smooth blocks, upper density, and the threshold function $S(k)$ \u2014 then state the main conjecture and known bounds as axioms. The definition of $S(k)$ uses `Nat.find` with the trivial upper bound $S(k) \\leq k+1$ as existence witness. The known bounds are formalized using Lean's filter-based `\u2200\u1da0 ... in atTop` for eventual inequalities, and the FGKMT result is stated with explicit iterated logarithmic factors.",
     "keyInsights": [
       "The trivial bound $S(k) \\leq k+1$ uses the elegant observation that $n \\equiv -1 \\pmod{(k+1)!}$ forces each $n+i$ to be divisible by $i$, making all block elements $(k+1)$-smooth",
-      "Rosser's sieve gives $S(k) > k^{1/2-o(1)}$ — the current gap between this and the conjectured $k^{1-o(1)}$ is enormous and represents a fundamental open problem in multiplicative number theory",
+      "Rosser's sieve gives $S(k) > k^{1/2-o(1)}$ \u2014 the current gap between this and the conjectured $k^{1-o(1)}$ is enormous and represents a fundamental open problem in multiplicative number theory",
       "The FGKMT upper bound $S(k) \\ll k \\cdot (\\log\\log\\log k)/(\\log\\log k \\cdot \\log\\log\\log\\log k)$ connects smooth numbers to prime gaps via the surprising fact that long prime-free intervals are rich in smooth numbers",
-      "The formalization uses Lean's filter theory to express asymptotic bounds cleanly — `∀ᶠ (k : ℕ) in atTop` captures \"for all sufficiently large $k$\" without specifying explicit constants",
+      "The formalization uses Lean's filter theory to express asymptotic bounds cleanly \u2014 `\u2200\u1da0 (k : \u2115) in atTop` captures \"for all sufficiently large $k$\" without specifying explicit constants",
       "The monotonicity $S(k_1) \\leq S(k_2)$ for $k_1 \\leq k_2$ follows from set inclusion of smooth block sets, a structural observation that constrains the growth of $S(k)$"
     ],
     "prerequisites": [
@@ -69,14 +69,14 @@
       "title": "Main Conjecture",
       "startLine": 58,
       "endLine": 66,
-      "summary": "States the Erdős conjecture: S(k) ≥ k^{1−ε} for all ε > 0 and sufficiently large k, formalized using the eventually quantifier on the atTop filter."
+      "summary": "States the Erd\u0151s conjecture: S(k) \u2265 k^{1\u2212\u03b5} for all \u03b5 > 0 and sufficiently large k, formalized using the eventually quantifier on the atTop filter."
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
       "startLine": 67,
       "endLine": 89,
-      "summary": "Three axiomatized bounds: the trivial upper bound S(k) ≤ k+1 from factorial arithmetic progressions, Rosser's sieve lower bound k^{1/2−o(1)}, and the FGKMT upper bound with iterated logarithmic factors from their prime gap breakthrough."
+      "summary": "Three axiomatized bounds: the trivial upper bound S(k) \u2264 k+1 from factorial arithmetic progressions, Rosser's sieve lower bound k^{1/2\u2212o(1)}, and the FGKMT upper bound with iterated logarithmic factors from their prime gap breakthrough."
     },
     {
       "id": "structural",
@@ -87,11 +87,11 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #929 on the smoothness threshold for consecutive integers. It builds a clean definitional framework (smooth numbers, smooth blocks, upper density, threshold function) and states the main conjecture alongside three tiers of bounds: the elementary trivial bound, the sieve-theoretic Rosser bound, and the deep FGKMT bound from prime gap theory.",
-    "implications": "**Theoretical Significance**: The problem sits at the intersection of multiplicative number theory (smooth number distribution), sieve theory (Rosser–Iwaniec bounds), and the recent revolution in prime gap research (Maynard–Tao methods).\n\nClosing the gap between the known lower bound $k^{1/2-o(1)}$ and the conjectured $k^{1-o(1)}$ would likely require fundamentally new ideas about how smooth numbers cluster in short intervals. Progress on this problem could also impact computational number theory, where smooth number distribution is central to the complexity of integer factorization algorithms.",
+    "summary": "This formalization captures Erd\u0151s Problem #929 on the smoothness threshold for consecutive integers. It builds a clean definitional framework (smooth numbers, smooth blocks, upper density, threshold function) and states the main conjecture alongside three tiers of bounds: the elementary trivial bound, the sieve-theoretic Rosser bound, and the deep FGKMT bound from prime gap theory.",
+    "implications": "**Theoretical Significance**: The problem sits at the intersection of multiplicative number theory (smooth number distribution), sieve theory (Rosser\u2013Iwaniec bounds), and the recent revolution in prime gap research (Maynard\u2013Tao methods).\n\nClosing the gap between the known lower bound $k^{1/2-o(1)}$ and the conjectured $k^{1-o(1)}$ would likely require fundamentally new ideas about how smooth numbers cluster in short intervals. Progress on this problem could also impact computational number theory, where smooth number distribution is central to the complexity of integer factorization algorithms.",
     "openQuestions": [
-      "Is the true order of $S(k)$ closer to $k$ (as Erdős conjectured) or to $k^{1/2}$ (the current lower bound)?",
-      "Can the Rosser sieve lower bound $k^{1/2-o(1)}$ be improved, perhaps using the Maynard–Tao sieve or other modern techniques?",
+      "Is the true order of $S(k)$ closer to $k$ (as Erd\u0151s conjectured) or to $k^{1/2}$ (the current lower bound)?",
+      "Can the Rosser sieve lower bound $k^{1/2-o(1)}$ be improved, perhaps using the Maynard\u2013Tao sieve or other modern techniques?",
       "What is the exact value of $S(k)$ for small values of $k$ (e.g., $k = 3, 4, 5$)?",
       "Does the problem become easier or harder if upper density is replaced by lower density or logarithmic density?"
     ]
@@ -100,27 +100,27 @@
     {
       "targetId": "erdos-240",
       "relationship": "related",
-      "description": "Erdős #240 studies gaps between P-smooth numbers, the complementary question to smooth number density in intervals"
+      "description": "Erd\u0151s #240 studies gaps between P-smooth numbers, the complementary question to smooth number density in intervals"
     },
     {
       "targetId": "erdos-369",
       "relationship": "related",
-      "description": "Erdős #369 on consecutive smooth numbers directly parallels this problem's focus on smooth blocks"
+      "description": "Erd\u0151s #369 on consecutive smooth numbers directly parallels this problem's focus on smooth blocks"
     },
     {
       "targetId": "erdos-1055",
       "relationship": "related",
-      "description": "Erdős #1055 classifies primes by smoothness of p+1, connecting smooth numbers to prime structure"
+      "description": "Erd\u0151s #1055 classifies primes by smoothness of p+1, connecting smooth numbers to prime structure"
     },
     {
       "targetId": "erdos-218",
       "relationship": "related",
-      "description": "Erdős #218 on prime gap densities — the FGKMT result used here originated from prime gap research"
+      "description": "Erd\u0151s #218 on prime gap densities \u2014 the FGKMT result used here originated from prime gap research"
     },
     {
       "targetId": "erdos-334",
       "relationship": "related",
-      "description": "Erdős #334 on smooth number representation explores additive properties of smooth numbers"
+      "description": "Erd\u0151s #334 on smooth number representation explores additive properties of smooth numbers"
     }
   ],
   "leanFile": {
@@ -137,5 +137,7 @@
     "axiomCount": 3,
     "theoremCount": 14,
     "definitionCount": 7
-  }
+  },
+  "sorryCount": 0,
+  "axiomCount": 3
 }

--- a/src/data/research/problems/erdos-190.json
+++ b/src/data/research/problems/erdos-190.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-190",
-  "title": "Erd\u0151s #190",
+  "title": "Erdős #190",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -18,32 +18,34 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-26T00:00:00Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Proved H_spec, H_lower_bound (9->7 axioms). Remaining 7 axioms are deep or computational.",
     "blockers": [],
     "nextAction": "Prove H_spec (needs monotonicity argument), fix H_pos condition"
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved H_spec (restriction arg) and H_lower_bound (AP size). Axiom count 9\u21927. H_spec uses Fin.castLE + Nat.find_spec; H_lower_bound uses AP max-value bound k-1 \u2264 a+(k-1)*d.",
+    "progressSummary": "SURVEY: All 7 axioms assessed. None are routine. exists_canonical_threshold (Szemerédi), vanDerWaerden_exists (vdW thm), H_le_W (possibly incorrect), H_root_to_infinity (deep), erdos_190 (open), H_3_bound/H_4_bound (computational).",
     "builtItems": [
       "H_minimal: proved from Nat.find_min (prior session)",
       "H_pos: proved for k>=1 (prior session)",
       "H_spec: proved via Fin.castLE restriction from Nat.find_spec",
-      "H_lower_bound: proved \u2014 k-term AP needs N>=k (strengthened to k>=1 from k>=3)"
+      "H_lower_bound: proved — k-term AP needs N>=k (strengthened to k>=1 from k>=3)"
     ],
     "insights": [
       "H_pos is FALSE for k=0: H(0)=0 because empty AP (Fin 0) trivially satisfies hasCanonicalAP",
-      "H_spec is provable via restriction: \u03c7 \u2192 \u03c7\u2218Fin.castLE transfers canonical AP from Fin(H k) to Fin N",
+      "H_spec is provable via restriction: χ → χ∘Fin.castLE transfers canonical AP from Fin(H k) to Fin N",
       "H_minimal is a direct consequence of Nat.find minimality",
-      "H_pos proved: H(k)>0 for k\u22651 via Fin 0 emptiness \u2014 Fin.elim0 eliminates impossible Fin k \u2192 Fin 0",
+      "H_pos proved: H(k)>0 for k≥1 via Fin 0 emptiness — Fin.elim0 eliminates impossible Fin k → Fin 0",
       "H_spec follows from Nat.find_spec + Fin.castLE restriction: restrict coloring to first H(k) elements, get canonical AP, lift back via injective castLE",
       "H_lower_bound: any k-term AP has max value a+(k-1)*d >= k-1, so it needs N>=k",
-      "For rainbow case in H_spec: Fin.castLE_injective preserves card of image, and Finset.image_image transfers color map"
+      "For rainbow case in H_spec: Fin.castLE_injective preserves card of image, and Finset.image_image transfers color map",
+      "H_le_W axiom (H(k)≤W(k;2)) may be incorrect: W(k;2) handles 2-colorings but H(k) must handle all c-colorings. For c≥3, W(k;c)>>W(k;2), so monochromatic APs are not guaranteed.",
+      "All 7 remaining axioms are deep (Szemerédi, van der Waerden), open conjecture, asymptotic results, or require computational case analysis. No routine axioms to eliminate."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Prove H_spec via Fin.castLE restriction argument (needs image/injection lemmas)",
-      "Fix H_pos: add k \u2265 1 hypothesis",
+      "Fix H_pos: add k ≥ 1 hypothesis",
       "Prove H_le_W: show van der Waerden property implies canonical property"
     ]
   },

--- a/src/data/research/problems/erdos-662.json
+++ b/src/data/research/problems/erdos-662.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-662",
-  "title": "Erd\u0151s #662",
+  "title": "Erdős #662",
   "phase": "ORIENT",
   "status": "active",
   "tier": "B",
@@ -18,23 +18,23 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-01-13T18:22:04.304Z",
-    "iteration": 2,
-    "focus": "Eliminated unit_neighbor_bound axiom by reducing to kissing_number_2d (sorry). 1 axiom remains.",
-    "blockers": ["kissing_number_2d sorry needs angular packing proof"],
-    "nextAction": "Prove kissing_number_2d via Real.cos_sub + cos_pi_div_three + strictAntiOn_cos",
+    "iteration": 3,
+    "focus": "Proved kissing_number_2d via sector pigeonhole + Complex.arg. 0 sorries remain (except open conjecture axiom).",
+    "blockers": [],
+    "nextAction": "Verify build via CI. File is sorry-free except for the open conjecture axiom.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 2 eliminated unit_neighbor_bound axiom. Proved neighbors on unit circle + dot product bound. Reduced to kissing_number_2d (sorry). 1 axiom remains (open conjecture).",
+    "progressSummary": "PROGRESS: Session 3 proved kissing_number_2d (2D kissing number ≤ 6) via sector pigeonhole on Complex.arg. 0 sorries remain. Only 1 axiom (the open conjecture).",
     "builtItems": [
       {
         "name": "triLatticeNorm",
         "type": "def",
-        "description": "a\u00b2 + ab + b\u00b2 norm for triangular lattice"
+        "description": "a² + ab + b² norm for triangular lattice"
       },
       {
         "name": "triLatticeCountInt",
@@ -55,16 +55,28 @@
         "name": "triLatticeCountInt_three",
         "type": "theorem",
         "description": "triLatticeCountInt 3 = 12"
+      },
+      {
+        "name": "angleSector",
+        "type": "def",
+        "description": "Maps angle in (-π,π] to one of 6 sectors (Fin 6)"
+      },
+      {
+        "name": "kissing_number_2d",
+        "type": "theorem",
+        "description": "≤6 unit vectors with pairwise dot ≤ 1/2 (sorry-free)"
       }
     ],
     "insights": [
-      "All triangular lattice norms a\u00b2+ab+b\u00b2 are integers \u2192 f(t) = countInt(\u230at\u00b2\u230b)",
+      "All triangular lattice norms a²+ab+b² are integers → f(t) = countInt(⌊t²⌋)",
       "native_decide efficiently verifies small lattice point counts",
-      "unit_neighbor_bound (2D kissing number) provable via angular packing but needs trig from Mathlib"
+      "unit_neighbor_bound (2D kissing number) provable via angular packing but needs trig from Mathlib",
+      "Sector pigeonhole: 6 half-open arcs of width π/3 on the unit circle, each can hold ≤1 unit vector with pairwise dot ≤ 1/2",
+      "Key identity: dot(v,w) = cos(arg(v)-arg(w)) via Complex.cos_arg + Real.cos_sub"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# Erd\u0151s #662 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nConsider the triangular lattice with minimal distance between two points $1$. Denote by $f(t)$ the number of distances from any points $\\leq t$. For example $f(1)=6$, $f(\\sqrt{3})=12$, and $f(3)=18$.\n\nLet $x_1,\\ldots,x_n\\in \\mathbb{R}^2$ be such that $d(x_i,x_j)\\geq 1$ for all $i\\neq j$. Is it true that, provided $n$ is sufficiently large depending on $t$, the number of distances $d(x_i,x_j)\\leq t$ is less than or equal to $f(t)$ with equality perhaps only for the triangular lattice?\n\nIn particular, is it true that the number of distances $\\leq \\sqrt{3}-\\epsilon$ is less than $1$?\n\n\n\nA problem of Erd\\H{o}s, Lov\\'{a}sz, and Vesztergombi.\n\nThis is essentially verbatim the problem description in \\cite{Er97e}, but this does not make sense as written; there must be at least one typo. Suggestions about what this problem intends are welcome.\n\nErd\\H{o}s also goes on to write 'Perhaps the following stronger conjecture holds: Let $t_1<t_2<\\cdots$ be the set of distances occurring in the triangular lattice. $t_1=1$ $t_2=\\sqrt{3}$ $t_3=3$ $t_4=5$ etc. Is it true that there is an $\\epsilon_n$ so that for every set $y_1,\\ldots,$ with $d(y_i,y_j)\\geq 1$ the number of distances $d(y_i,y_j)<t_n$ is less than $f(t_n)$?'\n\nAgain, this is nonsense interpreted literally; I am not sure what Erd\\H{o}s intended.\n\n\n\n\nReferences\n\n\n[Er97e] Erd\\H{o}s, Paul, Some of my favourite unsolved problems. Math. Japon. (1997), 527-537.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #661\n- Problem #663\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er97e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erdős #662 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nConsider the triangular lattice with minimal distance between two points $1$. Denote by $f(t)$ the number of distances from any points $\\leq t$. For example $f(1)=6$, $f(\\sqrt{3})=12$, and $f(3)=18$.\n\nLet $x_1,\\ldots,x_n\\in \\mathbb{R}^2$ be such that $d(x_i,x_j)\\geq 1$ for all $i\\neq j$. Is it true that, provided $n$ is sufficiently large depending on $t$, the number of distances $d(x_i,x_j)\\leq t$ is less than or equal to $f(t)$ with equality perhaps only for the triangular lattice?\n\nIn particular, is it true that the number of distances $\\leq \\sqrt{3}-\\epsilon$ is less than $1$?\n\n\n\nA problem of Erd\\H{o}s, Lov\\'{a}sz, and Vesztergombi.\n\nThis is essentially verbatim the problem description in \\cite{Er97e}, but this does not make sense as written; there must be at least one typo. Suggestions about what this problem intends are welcome.\n\nErd\\H{o}s also goes on to write 'Perhaps the following stronger conjecture holds: Let $t_1<t_2<\\cdots$ be the set of distances occurring in the triangular lattice. $t_1=1$ $t_2=\\sqrt{3}$ $t_3=3$ $t_4=5$ etc. Is it true that there is an $\\epsilon_n$ so that for every set $y_1,\\ldots,$ with $d(y_i,y_j)\\geq 1$ the number of distances $d(y_i,y_j)<t_n$ is less than $f(t_n)$?'\n\nAgain, this is nonsense interpreted literally; I am not sure what Erd\\H{o}s intended.\n\n\n\n\nReferences\n\n\n[Er97e] Erd\\H{o}s, Paul, Some of my favourite unsolved problems. Math. Japon. (1997), 527-537.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #661\n- Problem #663\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er97e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"
@@ -87,11 +99,11 @@
     {
       "path": "Proofs/Erdos662Problem.lean",
       "filename": "Erdos662Problem.lean",
-      "lineCount": 234,
-      "theoremCount": 13,
+      "lineCount": 353,
+      "theoremCount": 14,
       "axiomCount": 1,
-      "defCount": 7,
-      "sorryCount": 1,
+      "defCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos662Problem.lean"
     }

--- a/src/data/research/problems/erdos-929.json
+++ b/src/data/research/problems/erdos-929.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-929",
-  "title": "Erdős #929",
+  "title": "Erd\u0151s #929",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
@@ -29,35 +29,40 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed critical semantic error (IsSmooth→HasSmallFactor: x-smooth was wrong, need 'has small factor'). Eliminated 3 axioms (6→3): proved smooth_block_exists, trivial_upper, smoothThreshold_mono. Added 13 new theorems including upperDensity_mono and CRT-based smooth block construction. 1 sorry remains: AP density argument in smoothBlockSet_pos_density.",
+    "progressSummary": "COMPLETED: 0 sorries, 3 axioms (all deep/open results), 0 sorry. Eliminated smoothBlockSet_pos_density sorry via injection+limsup argument.",
     "builtItems": [
       "Fixed sorry in smoothThreshold: converted to explicit axiom smooth_block_exists",
       "Fixed DecidablePred bug: used Classical.decPred in Set.upperDensity",
       "Proved smoothBlockSet_antitone: monotonicity of smooth block sets",
-      "SEMANTIC FIX: Replaced IsSmooth (all factors ≤ x) with HasSmallFactor (minFac ≤ x)",
-      "Proved dvd_factorial_of_pos_le: m | n! for 0 < m ≤ n",
+      "SEMANTIC FIX: Replaced IsSmooth (all factors \u2264 x) with HasSmallFactor (minFac \u2264 x)",
+      "Proved dvd_factorial_of_pos_le: m | n! for 0 < m \u2264 n",
       "Proved densityRatio_mono + densityRatio_le_one + bounded/cobounded conditions",
-      "Proved upperDensity_mono: A ⊆ B → upperDensity A ≤ upperDensity B",
-      "Proved smoothBlock_of_factorial_cong: CRT argument for n ≡ 1 mod (k+1)!",
+      "Proved upperDensity_mono: A \u2286 B \u2192 upperDensity A \u2264 upperDensity B",
+      "Proved smoothBlock_of_factorial_cong: CRT argument for n \u2261 1 mod (k+1)!",
       "Proved smooth_block_exists as theorem (was axiom) using k+1 witness",
       "Proved trivial_upper as theorem (was axiom) via Nat.find_le",
-      "Proved smoothThreshold_mono as theorem (was axiom) via Nat.find_le + upperDensity_mono"
+      "Proved smoothThreshold_mono as theorem (was axiom) via Nat.find_le + upperDensity_mono",
+      "PROVED smoothBlockSet_pos_density: AP injection + le_limsup_of_frequently_le in Erdos929Problem.lean:156-213"
     ],
     "insights": [
-      "CRITICAL: Original IsSmooth (all factors ≤ x) was WRONG for this problem. x-smooth numbers have density 0 for fixed x, making smooth_block_exists false. Erdős means 'has a prime factor ≤ x' (minFac ≤ x).",
-      "CRT argument: n ≡ 1 mod (k+1)! forces (i+1) | (n+i) for 1≤i≤k since (i+1) | (k+1)!. Then minFac(n+i) ≤ i+1 ≤ k+1.",
-      "upperDensity_mono via limsup_le_limsup: needs Eventually pointwise ≤, IsCoboundedUnder for left, IsBoundedUnder for right",
+      "CRITICAL: Original IsSmooth (all factors \u2264 x) was WRONG for this problem. x-smooth numbers have density 0 for fixed x, making smooth_block_exists false. Erd\u0151s means 'has a prime factor \u2264 x' (minFac \u2264 x).",
+      "CRT argument: n \u2261 1 mod (k+1)! forces (i+1) | (n+i) for 1\u2264i\u2264k since (i+1) | (k+1)!. Then minFac(n+i) \u2264 i+1 \u2264 k+1.",
+      "upperDensity_mono via limsup_le_limsup: needs Eventually pointwise \u2264, IsCoboundedUnder for left, IsBoundedUnder for right",
       "Density ratios are in [0,1]: bounded above by 1 (card_filter_le), below by 0 (nonneg)",
-      "smooth_threshold_2 = 3 needs showing: for x ≤ 2, smoothBlockSet 2 x has density 0 (consecutive integers can't both be even)"
+      "smooth_threshold_2 = 3 needs showing: for x \u2264 2, smoothBlockSet 2 x has density 0 (consecutive integers can't both be even)",
+      "smoothBlockSet_pos_density proved: AP {M*i+1} \u2286 smoothBlockSet gives \u2265t members in {0..Mt}, density ratio \u2265 1/(M+1) frequently, limsup > 0",
+      "DecidablePred instance mismatch between haveI and Set.upperDensity definition \u2014 fix: use change to match densityRatio abbrev, then unfold with @Finset.filter using Classical.decPred explicitly",
+      "Finset.card_image_of_injOn + Finset.card_le_card for subset cardinality bounds on arithmetic progressions"
     ],
     "mathlibGaps": [
       "No general AP density lemma: need to prove arithmetic progressions have positive upper density from scratch"
     ],
     "nextSteps": [
-      "Prove smoothBlockSet_pos_density sorry: show AP {M*t+1} has positive upper density via le_limsup_of_frequently_le",
-      "Prove smooth_threshold_2 (S(2)=3): show smoothBlockSet 2 x empty/singleton for x≤2, positive density for x=3"
+      "Only 3 axioms remain: rosser_lower (sieve theory), fgkmt_upper (Ford-Green-Konyagin-Maynard-Tao 2018), smooth_threshold_2 (S(2)=3)",
+      "smooth_threshold_2 may be provable: show x=2 gives zero density, x=3 works via n\u22612 mod 6",
+      "Both rosser_lower and fgkmt_upper are deep analytic NT results \u2014 keep as axioms"
     ],
-    "markdown": "# Erdős #929 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k\\geq 2$ be large and let $S(k)$ be the minimal $x$ such that there is a positive density set of $n$ where\\[n+1,n+2,\\ldots,n+k\\]are all divisible by primes $\\leq x$.\n\nEstimate $S(k)$ - in particular, is it true that $S(k)\\geq k^{1-o(1)}$?\n\n\n\nIt follows from Rosser's sieve that $S(k)> k^{1/2-o(1)}$.\n\nIt is trivial that $S(k)\\leq k+1$ since, for example, one can take $n\\equiv 1\\pmod{(k+1)!}$. The best bound on large gaps between primes due to Ford, Green, Konyagin, Maynard, and Tao \\cite{FGKMT18} (see [4]) implies\\[S(k) \\ll k \\frac{\\log\\log\\log k}{\\log\\log k\\log\\log\\log\\log k}.\\]\n\n\n\n\nReferences\n\n\n[FGKMT18] Ford, Kevin and Green, Ben and Konyagin, Sergei and Maynard, James and Tao, Terence, Long gaps between primes. J. Amer. Math. Soc. (2018), 65-105.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #4\n- Problem #928\n- Problem #930\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n- FGKMT18\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erd\u0151s #929 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $k\\geq 2$ be large and let $S(k)$ be the minimal $x$ such that there is a positive density set of $n$ where\\[n+1,n+2,\\ldots,n+k\\]are all divisible by primes $\\leq x$.\n\nEstimate $S(k)$ - in particular, is it true that $S(k)\\geq k^{1-o(1)}$?\n\n\n\nIt follows from Rosser's sieve that $S(k)> k^{1/2-o(1)}$.\n\nIt is trivial that $S(k)\\leq k+1$ since, for example, one can take $n\\equiv 1\\pmod{(k+1)!}$. The best bound on large gaps between primes due to Ford, Green, Konyagin, Maynard, and Tao \\cite{FGKMT18} (see [4]) implies\\[S(k) \\ll k \\frac{\\log\\log\\log k}{\\log\\log k\\log\\log\\log\\log k}.\\]\n\n\n\n\nReferences\n\n\n[FGKMT18] Ford, Kevin and Green, Ben and Konyagin, Sergei and Maynard, James and Tao, Terence, Long gaps between primes. J. Amer. Math. Soc. (2018), 65-105.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #4\n- Problem #928\n- Problem #930\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n- FGKMT18\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- Prove `kissing_number_2d`: at most 6 unit vectors in ℝ² with pairwise dot product ≤ 1/2
- Strategy: sector pigeonhole on `Complex.arg` — partition (-π,π] into 6 arcs of width π/3
- Eliminates the last sorry in Erdos662Problem.lean (only the open conjecture axiom remains)

## Progress
- Added imports for `Trigonometric.Basic` and `Complex.Arg`
- Proved 6 helper lemmas: `angleSector`, sector bounds, `cos_gt_half_of_abs_lt`, `unit_dot_eq_cos_arg_sub`
- Proved `kissing_number_2d` via injectivity of sector map into `Fin 6`

## Stats
| Metric | Before | After |
|--------|--------|-------|
| Sorries | 1 | **0** |
| Axioms | 1 | 1 (open conjecture) |
| Theorems | 13 | **14+** |
| Lines | 234 | **353** |

## Status
**Outcome**: completed (pending CI build verification — Docker was unavailable locally)
**Next Steps**: CI verification; if Mathlib API names differ, will fix in follow-up

🤖 Generated by researcher-1