### PR TITLE
Gallery integrity: erdos-193 axiom count + stats

### DIFF
--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 193,
     "erdosUrl": "https://erdosproblems.com/193",
     "erdosProblemStatus": "open",
-    "axiomCount": 1,
-    "lineCount": 158,
-    "assumptions": "1 axiom: gerver_ramsey_2d (Gerver-Ramsey 2D theorem). 9 proved theorems including collinearity permutations, d=1 case, and singleton step set case.",
+    "axiomCount": 2,
+    "lineCount": 268,
+    "assumptions": "2 axioms: gerver_ramsey_2d (Gerver-Ramsey 2D theorem), erdos193_rank_le_2 (rank ≤ 2 reduction to Gerver-Ramsey). 14 proved theorems including collinearity properties, d=1 case, singleton step sets, parallel step sets, and dimension reduction framework.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -123,10 +123,26 @@
       "endLine": 158,
       "summary": "For walks with $|S| = 1$, all visited points lie on a line ($w(n) = w(0) + nv$), so any three are collinear. Proved by induction on position formula, then multiplicative commutativity.",
       "mathContext": "Mathematical content: Proves $\\text{singleton\\_walk\\_pos}$ (position formula by induction), $\\text{singleton\\_step\\_collinear}$ (collinearity via witnesses $(k-i, j-i)$), and $\\text{erdos193\\_singleton}$ (the conjecture for $|S|=1$, without requiring injectivity)."
+    },
+    {
+      "id": "parallel-step-sets",
+      "title": "Parallel Step Sets",
+      "startLine": 160,
+      "endLine": 217,
+      "summary": "For walks where all steps are multiples of a single direction $v$, the walk lies on a line. Proves position formula, collinearity via integer coefficients, and the conjecture for all parallel step sets.",
+      "mathContext": "Mathematical content: Defines $\\text{IsParallelStepSet}$, proves $\\text{parallel\\_walk\\_on\\_line}$ (walk stays on affine line), $\\text{line\\_points\\_collinear}$ (collinearity helper), $\\text{parallel\\_step\\_collinear}$, and $\\text{erdos193\\_parallel}$ (the conjecture for parallel step sets)."
+    },
+    {
+      "id": "dimension-reduction",
+      "title": "Dimension Reduction Framework",
+      "startLine": 218,
+      "endLine": 268,
+      "summary": "Defines $\\text{SpansAtMost2D}$ (step set in a 2D subspace), axiomatizes the rank $\\leq 2$ case via Gerver-Ramsey reduction, and proves that ErdosProblem193 reduces to the full-rank (rank 3) case.",
+      "mathContext": "Mathematical content: Defines $\\text{SpansAtMost2D}$, axiomatizes $\\text{erdos193\\_rank\\_le\\_2}$ (rank $\\leq 2$ reduction), and proves $\\text{erdos193\\_reduces\\_to\\_full\\_rank}$: the conjecture holds iff it holds for full-rank step sets."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 193 — the question of whether infinite injective lattice walks in $\\mathbb{Z}^3$ must contain three collinear points. It records the known Gerver–Ramsey 2D result, proves the conjecture for dimension 1 and singleton step sets, and establishes full permutation symmetry of the collinearity relation.",
+    "summary": "The formalization captures Erdős Problem 193 — the question of whether infinite injective lattice walks in $\\mathbb{Z}^3$ must contain three collinear points. It records the known Gerver–Ramsey 2D result, proves the conjecture for dimension 1, singleton step sets, parallel step sets, and rank ≤ 2 step sets (via axiom), and establishes a dimension reduction showing the conjecture reduces to the full-rank case.",
     "implications": "Resolution would illuminate the geometric structure of self-avoiding walks on three-dimensional lattices and establish new bounds on unavoidable linear patterns in discrete geometry. The dimension gap between $d = 2$ (resolved) and $d = 3$ (open) highlights a fundamental threshold in combinatorial geometry.",
     "openQuestions": [
       "Does every infinite injective $S$-walk in $\\mathbb{Z}^3$ contain three collinear points?",
@@ -143,10 +159,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 158,
-    "axiomCount": 1,
-    "theoremCount": 9,
-    "definitionCount": 5
+    "lineCount": 268,
+    "axiomCount": 2,
+    "theoremCount": 14,
+    "definitionCount": 10
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

- **erdos-193** meta.json was out of date after the Lean file was extended with parallel step sets and a dimension reduction framework
- axiomCount was 1 but the file has 2 axioms (`gerver_ramsey_2d` + `erdos193_rank_le_2`)
- theoremCount was 9 but the file now has 14 proved theorems
- lineCount was 158 but the file is now 268 lines
- definitionCount was 5 but there are now 10 definitions
- Added missing sections for parallel step sets and dimension reduction
- Updated conclusion to reflect all proved special cases

## Severity

**HIGH** — axiom count understatement (claims 1, actually 2)

## Test plan

- [ ] Verify `pnpm build` succeeds
- [ ] Spot-check gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)