### PR TITLE
Gallery integrity: inverse-galois-oq-01 dependency fix

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -20,19 +20,18 @@
     "proofRepoPath": "Proofs/InverseGaloisOQ01.lean",
     "additionalFiles": [
       "Proofs/AbelRuffiniGaloisExtensions.lean",
-      "Proofs/InverseGalois.lean",
       "Proofs/InverseGaloisA5.lean",
       "Proofs/AbelRuffiniOQ04OQ01.lean"
     ],
     "badge": "formalized",
     "sorries": 1,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields, fixed fields)",
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",
       "Field extensions (finrank, tower law)"
     ],
-    "assumptions": "0 axioms declared in this file. 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. Transitive dependency axioms: InverseGalois.lean (2 axioms: abelian_realizable, shafarevich_theorem), InverseGaloisA5.lean (1 axiom: three_dvd_gal_card). AbelRuffiniOQ04OQ01.lean is axiom-free (all axioms eliminated). Commutator theorem [S5,S5]=A5 fully proved.",
+    "assumptions": "0 axioms declared in this file. 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. Transitive dependency axiom: InverseGaloisA5.lean (1 axiom: three_dvd_gal_card). AbelRuffiniOQ04OQ01.lean and AbelRuffiniGaloisExtensions.lean are axiom-free. Commutator theorem [S5,S5]=A5 fully proved. Note: InverseGalois.lean is a sibling file (not imported by this file).",
     "leanFile": {
       "lineCount": 723,
       "theoremCount": 47,


### PR DESCRIPTION
## Summary

- **inverse-galois-oq-01** meta.json incorrectly listed InverseGalois.lean as an `additionalFile` despite it NOT being imported by the main file
- This caused the `assumptions` field to incorrectly claim `abelian_realizable` and `shafarevich_theorem` (from InverseGalois.lean) as transitive dependencies
- `axiomCount` updated from 0 to 1 to account for the actual transitive axiom `three_dvd_gal_card` from InverseGaloisA5.lean

## Evidence

InverseGaloisOQ01.lean imports:
- `Proofs.AbelRuffiniGaloisExtensions` (0 axioms, 0 sorry)
- `Proofs.InverseGaloisA5` (1 axiom: `three_dvd_gal_card`)
- `Proofs.AbelRuffiniOQ04OQ01` (0 axioms, 0 sorry)

It does NOT import `Proofs.InverseGalois`.

## Severity

**HIGH** — incorrect dependency chain in public-facing metadata

## Test plan

- [ ] Verify `pnpm build` succeeds
- [ ] Verify gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)