### PR TITLE
Enrich: 6 proofs — annotations, mathContext, warnings fixed

### DIFF
--- a/src/data/proofs/erdos-1153/annotations.json
+++ b/src/data/proofs/erdos-1153/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-lagrange-basis-def",
+    "proofId": "erdos-1153",
+    "range": { "startLine": 54, "endLine": 56 },
+    "type": "definition",
+    "title": "Lagrange Basis Polynomial",
+    "content": "Defines the $k$-th Lagrange basis polynomial $l_k(x) = \\prod_{i \\neq k} \\frac{x - x_i}{x_k - x_i}$, the unique polynomial of degree $\\le n-1$ satisfying $l_k(x_j) = \\delta_{kj}$. The `Finset.univ.erase k` expression computes the product over all indices except $k$. This is the fundamental building block of Lagrange interpolation: the interpolating polynomial for data $(x_i, y_i)$ is $p(x) = \\sum_k y_k l_k(x)$.",
+    "mathContext": "$l_k(x) = \\prod_{i \\neq k} \\frac{x - x_i}{x_k - x_i}$. Satisfies $l_k(x_j) = \\delta_{kj}$ (proved in `lagrangeBasis_other` and `lagrangeBasis_self`).",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange interpolation", "Kronecker delta", "polynomial basis"],
+    "prerequisites": ["Finset.prod", "division in ℝ"]
+  },
+  {
+    "id": "ann-lebesgue-function-def",
+    "proofId": "erdos-1153",
+    "range": { "startLine": 60, "endLine": 62 },
+    "type": "definition",
+    "title": "Lebesgue Function",
+    "content": "The Lebesgue function $\\lambda(x) = \\sum_k |l_k(x)|$ measures the worst-case error amplification of Lagrange interpolation at the point $x$. If $p$ is the interpolant of $f$ and $p^*$ is the best polynomial approximation, then $|f(x) - p(x)| \\le (1 + \\lambda(x)) \\cdot \\|f - p^*\\|_\\infty$. The maximum of $\\lambda$ over the interval is the Lebesgue constant $\\Lambda_n$, which governs the overall quality of the interpolation scheme.",
+    "mathContext": "$\\lambda(x) = \\sum_{k=0}^{n-1} |l_k(x)|$. The Lebesgue constant $\\Lambda_n = \\max_x \\lambda(x)$ satisfies $\\|f - p\\|_\\infty \\le (1 + \\Lambda_n) \\cdot \\inf_{\\deg q \\le n-1} \\|f - q\\|_\\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["condition number", "error amplification", "best approximation"],
+    "prerequisites": ["Lagrange basis", "absolute value", "Finset.sum"]
+  },
+  {
+    "id": "ann-kronecker-delta",
+    "proofId": "erdos-1153",
+    "range": { "startLine": 80, "endLine": 96 },
+    "type": "insight",
+    "title": "Kronecker Delta Property of Lagrange Basis",
+    "content": "Proves the two halves of the Kronecker delta property: (1) `lagrangeBasis_other`: $l_k(x_j) = 0$ for $j \\neq k$ because the product contains the factor $(x_j - x_j)/(x_k - x_j) = 0$, proved via `Finset.prod_eq_zero`. (2) `lagrangeBasis_self`: $l_k(x_k) = 1$ because each factor equals $(x_k - x_i)/(x_k - x_i) = 1$ for distinct nodes, proved via `Finset.prod_eq_one` and `div_self`. These are the only fully machine-checked theorems about Lagrange interpolation in the file.",
+    "mathContext": "$l_k(x_j) = \\delta_{kj}$: when $j \\neq k$, the factor $\\frac{x_j - x_j}{x_k - x_j} = 0$ kills the product; when $j = k$, each factor $\\frac{x_k - x_i}{x_k - x_i} = 1$ (requiring $x_k \\neq x_i$, i.e., distinct nodes).",
+    "significance": "key",
+    "relatedConcepts": ["Kronecker delta", "Finset.prod_eq_zero", "div_self"],
+    "prerequisites": ["DistinctNodes (injectivity)", "Finset product manipulation"]
+  },
+  {
+    "id": "ann-lebesgue-at-nodes",
+    "proofId": "erdos-1153",
+    "range": { "startLine": 103, "endLine": 133 },
+    "type": "insight",
+    "title": "Lebesgue Function Evaluation at Nodes",
+    "content": "Three results about $\\lambda$ at nodes: (1) `lebesgueFunction_nonneg`: $\\lambda(x) \\ge 0$ (sum of absolute values). (2) `lebesgueFunction_at_node`: $\\lambda(x_k) \\ge 1$ because the single term $|l_k(x_k)| = 1$ contributes at least 1, via `Finset.single_le_sum`. (3) `lebesgueFunction_at_node_eq`: $\\lambda(x_k) = 1$ exactly, since $l_j(x_k) = 0$ for $j \\neq k$ by the Kronecker delta property, so the sum collapses to a single term. The last result shows that the Lebesgue function is minimal at interpolation nodes.",
+    "mathContext": "$\\lambda(x_k) = \\sum_j |l_j(x_k)| = |l_k(x_k)| + \\sum_{j \\neq k} |l_j(x_k)| = 1 + 0 = 1$. The Lebesgue function achieves its minimum value of 1 precisely at the interpolation nodes.",
+    "significance": "supporting",
+    "relatedConcepts": ["absolute value sum", "Finset.single_le_sum", "minimum of Lebesgue function"],
+    "prerequisites": ["Kronecker delta property", "abs_nonneg", "abs_one"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "erdos-1153",
+    "range": { "startLine": 149, "endLine": 164 },
+    "type": "insight",
+    "title": "Erdős #1153: Universal Logarithmic Lower Bound",
+    "content": "The main result (axiomatized): for any $\\varepsilon > 0$ and any subinterval $[a,b] \\subseteq [-1,1]$, for all sufficiently large $n$, every choice of $n$ distinct nodes in $[-1,1]$ produces a Lebesgue function exceeding $(2/\\pi - \\varepsilon) \\log n$ somewhere on $[a,b]$. The asymptotic formulation with $\\varepsilon$ avoids stating the exact lower-order terms. The full-interval corollary follows by setting $a = -1$, $b = 1$. The proof (Bernstein 1931, Erdős 1961) uses properties of Chebyshev polynomials and equioscillation theory.",
+    "mathContext": "$\\forall \\varepsilon > 0,\\; \\forall [a,b] \\subseteq [-1,1],\\; \\exists N:\\; \\forall n \\ge N,\\; \\forall \\{x_i\\}_{i=1}^n \\text{ distinct in } [-1,1]: \\max_{x \\in [a,b]} \\lambda(x) \\ge \\left(\\frac{2}{\\pi} - \\varepsilon\\right) \\log n$.",
+    "significance": "key",
+    "relatedConcepts": ["Bernstein's theorem", "Erdős approximation theory", "logarithmic growth"],
+    "prerequisites": ["Lebesgue function definition", "NodesInInterval", "DistinctNodes", "Real.log", "Real.pi"]
+  },
+  {
+    "id": "ann-chebyshev-tightness",
+    "proofId": "erdos-1153",
+    "range": { "startLine": 168, "endLine": 173 },
+    "type": "insight",
+    "title": "Chebyshev Optimality (Matching Upper Bound)",
+    "content": "The matching upper bound (axiomatized): there exist node configurations (Chebyshev polynomial roots $x_k = \\cos\\left(\\frac{2k-1}{2n}\\pi\\right)$) for which the Lebesgue constant is at most $(2/\\pi + \\varepsilon) \\log n$. Together with the lower bound, this establishes $2/\\pi$ as the sharp constant for the growth rate of the optimal Lebesgue constant. The Chebyshev roots are the unique nodes achieving this minimum, making them the provably best interpolation nodes on $[-1,1]$.",
+    "mathContext": "$\\exists \\{x_k\\}:\\; \\max_{x \\in [-1,1]} \\lambda(x) \\le \\left(\\frac{2}{\\pi} + \\varepsilon\\right) \\log n$. Combined with the lower bound: $\\min_{\\text{nodes}} \\Lambda_n = \\frac{2}{\\pi} \\log n + O(1)$, achieved by Chebyshev roots.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev polynomials", "minimax property", "optimal interpolation nodes"],
+    "prerequisites": ["erdos_1153 axiom", "Chebyshev polynomial roots"]
+  }
+]

--- a/src/data/proofs/erdos-1153/meta.json
+++ b/src/data/proofs/erdos-1153/meta.json
@@ -80,28 +80,32 @@
       "title": "Definitions",
       "startLine": 42,
       "endLine": 68,
-      "summary": "Defines lagrangeBasis (Lagrange basis polynomial via finite product), lebesgueFunction (sum of absolute values), NodesInInterval (nodes in [-1,1]), and DistinctNodes (injectivity)."
+      "summary": "Defines lagrangeBasis (Lagrange basis polynomial via finite product), lebesgueFunction (sum of absolute values), NodesInInterval (nodes in [-1,1]), and DistinctNodes (injectivity).",
+      "mathContext": "$l_k(x) = \\prod_{i \\neq k} \\frac{x - x_i}{x_k - x_i}$, $\\lambda(x) = \\sum_k |l_k(x)|$. Nodes constrained to $[-1,1]$ and required to be distinct (injective)."
     },
     {
       "id": "lagrange-properties",
       "title": "Lagrange Basis Properties",
       "startLine": 69,
       "endLine": 93,
-      "summary": "Proves the Kronecker delta property: lₖ(xⱼ) = 0 for j ≠ k (zero factor in product) and lₖ(xₖ) = 1 (all factors cancel for distinct nodes)."
+      "summary": "Proves the Kronecker delta property: lₖ(xⱼ) = 0 for j ≠ k (zero factor in product) and lₖ(xₖ) = 1 (all factors cancel for distinct nodes).",
+      "mathContext": "$l_k(x_j) = \\delta_{kj}$: the zero case uses `Finset.prod_eq_zero`, the identity case uses `Finset.prod_eq_one` with `div_self` (requires node distinctness)."
     },
     {
       "id": "lebesgue-properties",
       "title": "Lebesgue Function Properties",
       "startLine": 94,
       "endLine": 126,
-      "summary": "Proves nonnegativity, the lower bound λ(xₖ) ≥ 1 at nodes, and the exact value λ(xₖ) = 1 at nodes for distinct node sets."
+      "summary": "Proves nonnegativity, the lower bound λ(xₖ) ≥ 1 at nodes, and the exact value λ(xₖ) = 1 at nodes for distinct node sets.",
+      "mathContext": "$\\lambda(x) \\ge 0$ (sum of absolute values), $\\lambda(x_k) \\ge 1$ (`Finset.single_le_sum`), and $\\lambda(x_k) = 1$ (Kronecker delta collapses the sum)."
     },
     {
       "id": "main-result",
       "title": "Main Result and Tightness",
       "startLine": 127,
       "endLine": 160,
-      "summary": "States the main theorem (logarithmic lower bound with constant 2/π on arbitrary subintervals) and the matching Chebyshev upper bound as axioms. Proves the full-interval corollary."
+      "summary": "States the main theorem (logarithmic lower bound with constant 2/π on arbitrary subintervals) and the matching Chebyshev upper bound as axioms. Proves the full-interval corollary.",
+      "mathContext": "$\\max_{x \\in [a,b]} \\lambda(x) \\ge (2/\\pi - \\varepsilon) \\log n$ (axiom). Matching upper bound: Chebyshev roots give $\\Lambda_n \\le (2/\\pi + \\varepsilon) \\log n$ (axiom). Full-interval corollary: direct instantiation with $a = -1$, $b = 1$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass for 6 proofs

### 1. area-of-circle-oq-01-oq-02-oq-01-oq-01 (Recursive Unit Ball Volumes)
- Added 7 annotations (was 0), expanded historicalContext, added 2 keyInsights

### 2. cauchy-schwarz-integral-oq-01-oq-01-oq-02 (Riesz Representation for Lp)
- Created annotations.json (7 annotations) and index.ts (both missing)
- Added historicalContext, sections, conclusion, crossReferences

### 3. minkowski-theorem (Minkowski's Fundamental Theorem)
- Added 2 annotations, fixed ann-volume type warning

### 4. product-of-segments-of-chords (Intersecting Chords)
- Added 2 annotations for uncovered main theorem section

### 5. mean-value-theorem (Mean Value Theorem)
- Fixed build warning, improved section mathContext

### 6. erdos-1153 (Lebesgue Constants)
- Added 6 annotations (was 0), added mathContext to all sections

### Quality
- Build passes with 0 warnings for all 6 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)