### PR TITLE
Fix: erdos-155 and erdos-190 stale metadata

### DIFF
--- a/src/data/proofs/erdos-155/meta.json
+++ b/src/data/proofs/erdos-155/meta.json
@@ -27,8 +27,8 @@
       "erdos-234"
     ],
     "axiomCount": 6,
-    "lineCount": 161,
-    "assumptions": "11 axioms: maxSidonSize, maxSidon_achievable, maxSidon_optimal, and 8 more. See Lean source for complete statements.",
+    "lineCount": 193,
+    "assumptions": "6 axioms: erdos_turan_upper, sidon_lower_asymptotic, erdos_155_conjecture (OPEN), erdos_155_strong (OPEN), increase_points_sparse, small_values_large. 7 proved theorems.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -134,9 +134,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 109,
-    "axiomCount": 11,
-    "theoremCount": 0,
+    "lineCount": 193,
+    "axiomCount": 6,
+    "theoremCount": 7,
     "definitionCount": 1
   },
   "references": [

--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/190",
     "erdosProblemStatus": "open",
     "axiomCount": 7,
-    "lineCount": 296,
+    "lineCount": 315,
     "assumptions": "7 axioms: exists_canonical_threshold (Szemerédi), vanDerWaerden_exists, H_le_W (k≥3), H_root_to_infinity, erdos_190 (OPEN conjecture), H_3_bound, H_4_bound. Proved: H_spec (Fin.castLE restriction), H_lower_bound (AP needs N≥k), H_pos (k≥1), H_minimal (Nat.find_min).",
     "mathlib_version": "4.26.0"
   },
@@ -145,7 +145,7 @@
       "Finset"
     ],
     "namespace": "Erdos190",
-    "lineCount": 296,
+    "lineCount": 315,
     "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 10


### PR DESCRIPTION
## Fix

Corrects stale metadata in erdos-155 (axiom count, line count, theorem count, assumptions text) and erdos-190 (line count) after recent axiom elimination research.

## Evidence

**erdos-155 before**: leanFile.axiomCount: 11, leanFile.lineCount: 109, meta.lineCount: 161, assumptions: "11 axioms"
**erdos-155 after**: leanFile.axiomCount: 6, leanFile.lineCount: 193, meta.lineCount: 193, assumptions: "6 axioms" with correct names

**erdos-190 before**: lineCount: 296 (both meta and leanFile)
**erdos-190 after**: lineCount: 315 (both meta and leanFile)

Verified by `wc -l` and `grep -c "^axiom "` against actual Lean source files.

Closes #7064

---
Automated fix by lean-mechanic agent.