### PR TITLE
Gallery integrity: arithmetic-series-oq-02-oq-04 badge original→mathlib

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -15,7 +15,7 @@
       "binomial",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -112,7 +112,7 @@
     }
   ],
   "conclusion": {
-    "summary": "11 theorems with 0 sorries and 0 axioms. The rising factorial identity connects simplicial numbers to ordered selections, explaining why binomial coefficients are integers.",
+    "summary": "11 theorems with 0 sorries and 0 axioms. The main identity derives from Mathlib's ascFactorial_eq_factorial_mul_choose; independent contributions include the explicit product formula (by induction) and structural corollaries. The rising factorial identity connects simplicial numbers to ordered selections, explaining why binomial coefficients are integers.",
     "implications": "**Integrality of binomial coefficients**: The divisibility k! | (n+1)(n+2)...(n+k) provides a clean proof that C(n+k,k) is always a natural number. **Permutation counting**: C(n+k,k) * k! counts the number of k-permutations from a set of n+k elements that include all of the last k elements. **Connection to Stirling numbers**: The rising factorial is the fundamental building block for Stirling number identities and the conversion between ordinary and factorial powers.",
     "openQuestions": [
       "Can the descending factorial analogue n * (n-1) * ... * (n-k+1) = C(n,k) * k! be formalized with the same modular structure?",


### PR DESCRIPTION
## Summary

- Fixed badge from `original` to `mathlib` for arithmetic-series-oq-02-oq-04
- The main identity (`simplicial_factorial`) derives directly from Mathlib's `ascFactorial_eq_factorial_mul_choose` + `mul_comm`
- Updated conclusion summary to credit Mathlib dependency

## Evidence

**meta.json proofStrategy** (unchanged): "**Direct from Mathlib** for the main identity"
**meta.json originalContributions[0]** (unchanged): "simplicial_factorial: ... -- direct from Mathlib"

Per gallery integrity policy, badge should be `mathlib` when core result comes from Mathlib.

## Test plan

- [ ] `pnpm build` passes
- [ ] Badge renders correctly on gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)