### PR TITLE
Research: erdos-662 + erdos-383 + erdos-460 — metadata, axiom elimination, sieve implementation

### DIFF
--- a/proofs/Proofs/Erdos383Problem.lean
+++ b/proofs/Proofs/Erdos383Problem.lean
@@ -22,8 +22,9 @@ occur with positive density, supporting an affirmative conjecture.
 
 **Reference:** Erdős & Graham 1980 [ErGr80]
 
-**Proved in this file (7 theorems):**
+**Proved in this file (8 theorems):**
 - hasLargestPrimeFactor_iff: equivalence of largest prime factor definitions
+- conjecture_equiv: ErdosConjecture383 ↔ ErdosConjecture383' (was axiom, now proved)
 - zero_good: every prime is 0-good (p is largest prime factor of p²)
 - infinitely_many_zero_good: infinitely many 0-good primes
 - kGood_iff_smooth: k-good iff all p²+i are p-smooth
@@ -67,6 +68,33 @@ theorem hasLargestPrimeFactor_iff (n p : ℕ) (hn : n ≠ 0) :
       fun q hq_mem => by
         rw [Nat.mem_primeFactors] at hq_mem
         exact hmax q hq_mem.1 hq_mem.2.1⟩
+
+/-- The largest prime factor of n, or 0 if n ≤ 1. -/
+noncomputable def maxPrimeFac (n : ℕ) : ℕ :=
+  if h : n.primeFactors.Nonempty then n.primeFactors.max' h else 0
+
+private lemma maxPrimeFac_mem {n : ℕ} (hn : n.primeFactors.Nonempty) :
+    maxPrimeFac n ∈ n.primeFactors := by
+  simp only [maxPrimeFac, dif_pos hn]
+  exact Finset.max'_mem _ hn
+
+private lemma le_maxPrimeFac {n q : ℕ} (hq : q ∈ n.primeFactors) :
+    q ≤ maxPrimeFac n := by
+  have hne : n.primeFactors.Nonempty := ⟨q, hq⟩
+  simp only [maxPrimeFac, dif_pos hne]
+  exact Finset.le_max' _ _ hq
+
+/-- hasLargestPrimeFactor and maxPrimeFac agree when primeFactors is nonempty. -/
+private lemma hasLargestPrimeFactor_iff_maxPrimeFac {n p : ℕ}
+    (hne : n.primeFactors.Nonempty) :
+    hasLargestPrimeFactor n p ↔ maxPrimeFac n = p := by
+  simp only [hasLargestPrimeFactor, primeDivisors]
+  constructor
+  · intro ⟨hp_mem, hmax⟩
+    exact le_antisymm (hmax _ (maxPrimeFac_mem hne)) (le_maxPrimeFac hp_mem)
+  · intro heq
+    subst heq
+    exact ⟨maxPrimeFac_mem hne, fun q hq => le_maxPrimeFac hq⟩
 
 /-
 # Part 2: The Product Definition
@@ -136,9 +164,31 @@ def ErdosConjecture383 : Prop :=
   ∀ k : ℕ, (kGoodPrimes k).Infinite
 
 def ErdosConjecture383' : Prop :=
-  ∀ k : ℕ, {p : ℕ | p.Prime ∧ Nat.maxPrimeFac (consecutiveSquareProduct p k) = p}.Infinite
+  ∀ k : ℕ, {p : ℕ | p.Prime ∧ maxPrimeFac (consecutiveSquareProduct p k) = p}.Infinite
 
-axiom conjecture_equiv : ErdosConjecture383 ↔ ErdosConjecture383'
+theorem conjecture_equiv : ErdosConjecture383 ↔ ErdosConjecture383' := by
+  simp only [ErdosConjecture383, ErdosConjecture383', kGoodPrimes]
+  apply forall_congr'
+  intro k
+  congr 1
+  ext p
+  simp only [Set.mem_setOf_eq, isKGood]
+  constructor
+  · intro ⟨hp, hlpf⟩
+    refine ⟨hp, ?_⟩
+    have hne : (consecutiveSquareProduct p k).primeFactors.Nonempty := ⟨p, hlpf.1⟩
+    exact (hasLargestPrimeFactor_iff_maxPrimeFac hne).mp hlpf
+  · intro ⟨hp, heq⟩
+    refine ⟨hp, ?_⟩
+    have hp_mem : p ∈ (consecutiveSquareProduct p k).primeFactors := by
+      rw [Nat.mem_primeFactors]
+      refine ⟨hp, ?_, consecutiveSquareProduct_ne_zero hp⟩
+      rw [consecutiveSquareProduct_eq]
+      apply dvd_trans (dvd_pow_self p 2)
+      have : p ^ 2 + 0 = p ^ 2 := by ring
+      rw [← this]
+      exact Finset.dvd_prod_of_mem _ (Finset.mem_range.mpr (Nat.zero_lt_succ k))
+    exact (hasLargestPrimeFactor_iff_maxPrimeFac ⟨p, hp_mem⟩).mpr heq
 
 /-
 # Part 5: Partial Results
@@ -238,7 +288,7 @@ def erdos_383_status : String := "OPEN"
 
 theorem erdos_383_statement :
     ErdosConjecture383' ↔
-    ∀ k, {p : ℕ | p.Prime ∧ Nat.maxPrimeFac (∏ i ∈ Icc 0 k, (p ^ 2 + i)) = p}.Infinite := by
+    ∀ k, {p : ℕ | p.Prime ∧ maxPrimeFac (∏ i ∈ Icc 0 k, (p ^ 2 + i)) = p}.Infinite := by
   simp only [ErdosConjecture383', consecutiveSquareProduct]
 
 end Erdos383

--- a/proofs/Proofs/Erdos460Problem.lean
+++ b/proofs/Proofs/Erdos460Problem.lean
@@ -11,6 +11,10 @@ Does Σ (1/aᵢ) → ∞ as n → ∞ (summing over 0 < aᵢ < n)?
 - Erdős (1977), p.64
 - Erdős–Graham (1980), p.91
 - Eggleton–Erdős–Selfridge: aₖ < k^{2+o(1)}
+
+Proved: sieve_initial (a₀ = 0, a₁ = 1) — follows from the constructive definition.
+The sieve is now implemented as a proper well-founded recursive function
+(was previously a dummy fun _ => 0 with all behavior axiomatized).
 -/
 
 import Mathlib.Data.Nat.Basic
@@ -27,16 +31,27 @@ import Mathlib.Tactic
 /-- The greedy coprime sieve sequence for a given n.
 Starting with a₀ = 0, a₁ = 1, each aₖ is the least integer > aₖ₋₁
 such that (n - aₖ) is coprime to (n - aᵢ) for all i < k.
-We model this as a function from ℕ (index k) to ℕ (value aₖ). -/
-noncomputable def greedyCoprimeSieve (n : ℕ) : ℕ → ℕ :=
-  fun _ => 0  -- specification only; defined by axiom below
+When no valid candidate exists in [0, n], returns n + 1 (sentinel). -/
+noncomputable def greedyCoprimeSieve (n : ℕ) : ℕ → ℕ
+  | 0 => 0
+  | 1 => 1
+  | k + 2 =>
+    let a : Fin (k + 2) → ℕ := fun i => greedyCoprimeSieve n i.val
+    let last := greedyCoprimeSieve n (k + 1)
+    let candidates := (Finset.range (n + 1)).filter fun m =>
+      last < m ∧ ∀ i : Fin (k + 2), Nat.Coprime (n - m) (n - a i)
+    if h : candidates.Nonempty then candidates.min' h else n + 1
+termination_by k => k
+decreasing_by all_goals omega
 
 /-- The defining property: a₀ = 0 and a₁ = 1. -/
-axiom sieve_initial (n : ℕ) (hn : n ≥ 2) :
-    greedyCoprimeSieve n 0 = 0 ∧ greedyCoprimeSieve n 1 = 1
+theorem sieve_initial (n : ℕ) (hn : n ≥ 2) :
+    greedyCoprimeSieve n 0 = 0 ∧ greedyCoprimeSieve n 1 = 1 := by
+  constructor <;> simp [greedyCoprimeSieve]
 
 /-- Each subsequent term is the least integer > previous term
-such that n - aₖ is coprime to all previous n - aᵢ. -/
+such that n - aₖ is coprime to all previous n - aᵢ.
+Provable from the construction when candidates are nonempty. -/
 axiom sieve_greedy (n : ℕ) (hn : n ≥ 2) (k : ℕ) (hk : k ≥ 2) :
     let a := greedyCoprimeSieve n
     a k > a (k - 1) ∧

--- a/research/problems/erdos-662/knowledge.md
+++ b/research/problems/erdos-662/knowledge.md
@@ -69,3 +69,33 @@ Triangular lattice maximality conjecture for pair distances.
 ### Next Steps
 - Prove kissing_number_2d via angular packing (good Aristotle candidate)
 - The main conjecture `erdos_662_lattice_optimal` remains open (unprovable)
+
+## Session 2026-03-27 (Session 3) - Gallery Metadata Update & Completion
+
+**Mode**: REVISIT
+**Outcome**: completed
+
+### What I Did
+- Verified file state: 0 sorries, 1 axiom (erdos_662_lattice_optimal — the main OPEN conjecture)
+- kissing_number_2d was already fully proved (angular sector pigeonhole via Complex.arg)
+- Updated gallery meta.json:
+  - leanFile section: corrected lineCount (108→375), axiomCount (3→1), theoremCount (5→9), lemmaCount (0→10), defCount (2→10), added missing import
+  - sections array: updated all line ranges, added 3 new sections (geometric-reductions, kissing-number-helpers, kissing-number) to reflect the full proof structure
+  - proofStrategy: updated to describe the complete kissing number proof
+- Updated research problem JSON: leanFiles stats, progress summary, cleared blockers
+
+### Stats (Final)
+| Metric | Value |
+|--------|-------|
+| Axioms | **1** (open conjecture only) |
+| Sorries | **0** |
+| Theorems | 9 (public) |
+| Lemmas | 10 (private) |
+| Definitions | 10 |
+| Lines | 375 |
+
+### Key Status
+- **Formalization is at maximum potential**: all provable parts are fully machine-checked
+- **The only axiom** is `erdos_662_lattice_optimal` — the main open conjecture, which cannot be proved
+- **kissing_number_2d** is a clean, self-contained theorem that could be contributed to Mathlib
+- **contact_number_3n** resolves the t=1 case of the conjecture completely

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -52,15 +52,15 @@
       "dickman_asymptotic axiom: Dickman function asymptotics",
       "erdos_383_statement theorem: formal statement"
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "prerequisites": [
       "Elementary number theory (prime factorization, divisibility)",
       "Smooth numbers and the Dickman rho function",
       "Finite products over consecutive integers",
       "Basic analytic number theory (asymptotic density)"
     ],
-    "lineCount": 244,
-    "assumptions": "3 axiom(s). No sorries."
+    "lineCount": 294,
+    "assumptions": "2 axioms: positive_density_smooth (smooth number density — deep analytic), dickman_asymptotic (Dickman function asymptotics — deep analytic). conjecture_equiv proved by defining maxPrimeFac and showing equivalence with hasLargestPrimeFactor."
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph [ErGr80]. It asks whether primes can dominate the factorization of consecutive integers near their square — specifically, whether for each k, infinitely many primes p have no prime factor of p²(p²+1)···(p²+k) exceeding p. The problem connects deeply to smooth number theory, pioneered by Nicolaas Govert de Bruijn in 1951, who showed that the density of y-smooth numbers up to x is asymptotic to ρ(log x / log y) where ρ is the Dickman function. Since ρ(2) ≈ 0.307, about 30.7% of integers have all prime factors below their square root, providing strong heuristic evidence for a positive answer. The k=0 case is trivial (p always dominates p²), and the k=1 case is directly connected to Problem #382, which asks about primes where all prime factors of p²+1 are at most p. Despite the compelling probabilistic heuristics, proving the conjecture even for k=1 remains open, illustrating the difficulty of converting density arguments into unconditional infinitude results.",
@@ -208,9 +208,9 @@
       "Nat"
     ],
     "namespace": "Erdos383",
-    "lineCount": 244,
-    "axiomCount": 3,
-    "theoremCount": 13,
+    "lineCount": 294,
+    "axiomCount": 2,
+    "theoremCount": 17,
     "definitionCount": 12
   }
 }

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -54,9 +54,9 @@
       "Definition of the least-prime-factor filtered sum f(n) and its sufficiency axiom",
       "Splitting into smallPrimeDivisibleSum and largePrimeSum with Erdős's question about individual divergence"
     ],
-    "axiomCount": 6,
-    "lineCount": 146,
-    "assumptions": "6 axioms: sieve_initial, sieve_greedy, eggleton_erdos_selfridge, and 3 more. See Lean source for complete statements."
+    "axiomCount": 5,
+    "lineCount": 161,
+    "assumptions": "5 axioms: sieve_greedy (provable from construction, needs nonemptiness proof), eggleton_erdos_selfridge (deep result), sieve_conjectured_bound (conjecture), filtered_sum_implies_full, erdos_460_restricted_question. sieve_initial proved from constructive definition."
   },
   "leanFile": {
     "imports": [
@@ -69,9 +69,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 146,
-    "axiomCount": 6,
-    "theoremCount": 0,
+    "lineCount": 161,
+    "axiomCount": 5,
+    "theoremCount": 1,
     "definitionCount": 8
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "1 axiom: erdos_662_lattice_optimal (the main open conjecture — unprovable). kissing_number_2d fully proved via angular sector pigeonhole (Complex.arg → normalized angle → 6 bins → injective → card ≤ 6). All supporting lemmas proved: unit_neighbor_bound, neighbor_sqDist_eq_one, neighbor_dot_le_half, contact_number_3n.",
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 373
+    "lineCount": 375
   },
   "sections": [
     {
@@ -37,9 +37,9 @@
       "id": "imports",
       "title": "Library Imports",
       "startLine": 12,
-      "endLine": 18,
-      "summary": "Imports Mathlib's $\\mathbb{R}$, $\\mathbb{N}$, $\\text{Finset}$, cardinality, and tactics for coordinate geometry and finite combinatorial computations.",
-      "mathContext": "Mathematical content: Imports Mathlib's $\\mathbb{R}$, $\\mathbb{N}$, $\\text{Finset}$, cardinality, and tactics for coordinate geometry and finite combinatorial computations."
+      "endLine": 21,
+      "summary": "Imports Mathlib's $\\mathbb{R}$, $\\mathbb{N}$, $\\text{Finset}$, cardinality, Complex.Arg (for angular analysis), and tactics for coordinate geometry, trigonometry, and finite combinatorics.",
+      "mathContext": "Mathematical content: Imports Mathlib's $\\mathbb{R}$, $\\mathbb{N}$, $\\text{Finset}$, cardinality, Complex.Arg, and tactics."
     },
     {
       "id": "point-distance",
@@ -60,32 +60,56 @@
     {
       "id": "triangular-lattice",
       "title": "Triangular Lattice Construction",
-      "startLine": 48,
-      "endLine": 55,
-      "summary": "Constructs the triangular lattice $\\Lambda = \\mathbb{Z}(1,0) + \\mathbb{Z}(\\frac{1}{2}, \\frac{\\sqrt{3}}{2})$ and axiomatizes the lattice count function $f(t) = |\\{\\mathbf{v} \\in \\Lambda \\setminus \\{\\mathbf{0}\\} : \\|\\mathbf{v}\\| \\le t\\}|$.",
-      "mathContext": "Constructs the triangular lattice $\\Lambda = \\mathbb{Z}(1,0) + \\mathbb{Z}(\\frac{1}{2}, \\frac{\\sqrt{3}}{2})$ and axiomatizes the lattice count function $f(t) = |\\{\\mathbf{v} \\in \\Lambda \\setminus \\{\\mathbf{0}\\} : \\|\\mathbf{v}\\| \\le t\\}|$."
+      "startLine": 49,
+      "endLine": 71,
+      "summary": "Constructs the triangular lattice $\\Lambda = \\mathbb{Z}(1,0) + \\mathbb{Z}(\\frac{1}{2}, \\frac{\\sqrt{3}}{2})$ with the Loeschian norm $a^2 + ab + b^2$, computable lattice point counting, and $f(t) = \\text{countInt}(\\lfloor t^2 \\rfloor)$.",
+      "mathContext": "Constructs the triangular lattice with computable enumeration. All lattice norms are Loeschian integers, enabling $f(t) = \\text{countInt}(\\lfloor t^2 \\rfloor)$ via decidable counting over $[-T, T]^2$."
     },
     {
       "id": "lattice-distance",
       "title": "Lattice Distance Formula and Known Values",
-      "startLine": 59,
-      "endLine": 71,
+      "startLine": 73,
+      "endLine": 110,
       "summary": "Proves the Loeschian quadratic form $d^2 = a^2 + ab + b^2$ for lattice point $(a,b)$ and establishes $f(1) = 6$, $f(\\sqrt{3}) = 12$: the first two coordination shells of the triangular lattice.",
       "mathContext": "Verified: Proves the Loeschian quadratic form $d^2 = a^2 + ab + b^2$ for lattice point $(a,b)$ and establishes $f(1) = 6$, $f(\\sqrt{3}) = 12$: the first two coordination shells of the triangular lattice."
     },
     {
+      "id": "geometric-reductions",
+      "title": "Geometric Reductions for Contact Bound",
+      "startLine": 112,
+      "endLine": 145,
+      "summary": "Proves that in a 1-separated set, all unit neighbors lie on the unit circle ($d^2 = 1$ exactly) and their relative position vectors have dot product $\\le 1/2$, reducing the contact bound to the 2D kissing number.",
+      "mathContext": "Key reductions: neighbor_sqDist_eq_one (separation + neighborhood gives exactly unit distance) and neighbor_dot_le_half (algebraic identity $d^2(q_1,q_2) = 2 - 2 \\cdot \\text{dot}$ plus separation gives dot $\\le 1/2$)."
+    },
+    {
+      "id": "kissing-number-helpers",
+      "title": "Angular Machinery for Kissing Number",
+      "startLine": 147,
+      "endLine": 241,
+      "summary": "Builds the angular analysis toolkit: complex number encoding of 2D vectors, angle normalization from $(-\\pi, \\pi]$ to $[0, 2\\pi)$, preservation of cosine under normalization, floor-based angular binning, and the key lemma $|\\theta| < \\pi/3 \\Rightarrow \\cos\\theta > 1/2$.",
+      "mathContext": "Infrastructure for the angular sector pigeonhole. Uses Complex.arg for angle parametrization, proves dot(v,w) = cos(arg v - arg w) for unit vectors, and establishes cos monotonicity via Mathlib's strictAntiOn_cos."
+    },
+    {
+      "id": "kissing-number",
+      "title": "2D Kissing Number Theorem",
+      "startLine": 243,
+      "endLine": 298,
+      "summary": "**Fully proved**: At most 6 unit vectors in $\\mathbb{R}^2$ can have pairwise dot product $\\le 1/2$. Proof: angular sector pigeonhole — assign each vector to one of 6 sectors of width $\\pi/3$; sector map is injective (collision implies angular separation $< \\pi/3$ implies dot $> 1/2$, contradiction), so $|S| \\le 6$.",
+      "mathContext": "The 2D kissing number theorem, fully machine-checked. Angular sector pigeonhole with Complex.arg parametrization. No sorries, no axioms."
+    },
+    {
       "id": "contact-number",
       "title": "Contact Number Bounds",
-      "startLine": 75,
-      "endLine": 91,
-      "summary": "Axiomatizes the per-vertex bound $|N_1(p)| \\le 6$ (2D kissing number), derives the ordered bound $6n$, and proves the contact number bound $\\text{pairs}_1(S) \\le 3n$ — the resolved $t = 1$ case of the conjecture.",
-      "mathContext": "Axiomatizes the per-vertex bound $|N_1(p)| \\le 6$ (2D kissing number), derives the ordered bound $6n$, and proves the contact number bound $\\text{pairs}_1(S) \\le 3n$ — the resolved $t = 1$ case of the conjecture."
+      "startLine": 300,
+      "endLine": 366,
+      "summary": "Proves the per-vertex bound $|N_1(p)| \\le 6$ by reduction to kissing_number_2d via translation, derives the ordered bound $6n$ by fiber decomposition, and proves the contact number bound $\\text{pairs}_1(S) \\le 3n$.",
+      "mathContext": "Fully proved chain: unit_neighbor_bound (translation + kissing number) $\\Rightarrow$ ordered_unit_pairs_bound ($6n$) $\\Rightarrow$ contact_number_3n ($3n$). The resolved $t = 1$ case of the conjecture."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture (OPEN)",
-      "startLine": 95,
-      "endLine": 100,
+      "startLine": 368,
+      "endLine": 375,
       "summary": "States the Erdős–Lovász–Vesztergombi conjecture: for all $t \\ge 1$ and sufficiently large $n$, $\\text{pairs}_t(S) \\le n \\cdot f(t)/2$ for every 1-separated $S$ with $|S| = n$. Axiomatized as the conjecture remains open.",
       "mathContext": "States the Erdős–Lovász–Vesztergombi conjecture: for all $t \\ge 1$ and sufficiently large $n$, $\\text{pairs}_t(S) \\le n \\cdot f(t)/2$ for every 1-separated $S$ with $|S| = n$. Axiomatized as the conjecture remains open."
     }
@@ -94,7 +118,7 @@
     "historicalContext": "Erdős, Lovász, and Vesztergombi posed this problem in their 1997 paper 'Problems and results on the grid,' asking whether the triangular lattice universally maximizes short-range pair interactions among 1-separated point sets. The question extends a classical line of inquiry beginning with Thue's 1910 proof that the hexagonal lattice gives the densest circle packing in the plane, later made rigorous by Fejes Tóth (1940). The t = 1 case reduces to the contact number problem — how many unit-distance pairs can occur in a 1-separated set — which was resolved by Harborth (1974), who showed the exact answer is ⌊3n − √(12n − 3)⌋, achieved by hexagonal configurations. For general t, the problem connects to the Gauss circle problem for the Loeschian quadratic form a² + ab + b² (the norm form of the Eisenstein integers ℤ[ω]), since counting lattice points within distance t is equivalent to counting representations by this form. Despite nearly three decades since its posing, the conjecture remains open for all t > 1.",
     "problemStatement": "For $n$ points in $\\mathbb{R}^2$ with all pairwise distances $\\ge 1$, is the number of pairs at distance $\\le t$ maximized (for each $t \\ge 1$ and $n$ sufficiently large) by the triangular lattice configuration? That is, does $\\text{pairs}_t(S) \\le n \\cdot f(t)/2$ hold, where $f(t)$ is the coordination number of the triangular lattice at radius $t$?",
     "text": "For 1-separated points in ℝ², is the number of pairs at distance ≤ t maximized by the triangular lattice? f(1)=6, f(√3)=12, f(3)=18. Erdős–Lovász–Vesztergombi. Open.",
-    "proofStrategy": "The formalization defines 1-separated point sets and the pair count function, constructs the triangular lattice with basis vectors $(1, 0)$ and $(1/2, \\sqrt{3}/2)$, and axiomatizes the lattice count function. It establishes the Loeschian distance formula $d^2 = a^2 + ab + b^2$ and known coordination shell values. The t = 1 case is proved via the per-vertex bound of 6 neighbors (2D kissing number), giving the contact number bound 3n.",
+    "proofStrategy": "The formalization defines 1-separated point sets and the pair count function, constructs the triangular lattice with computable lattice point counting via the Loeschian norm $a^2 + ab + b^2$, and verifies $f(1) = 6$, $f(\\sqrt{3}) = 12$ by `native_decide`. The $t = 1$ case is fully proved: neighbors lie on the unit circle (algebraic reduction), dot products $\\le 1/2$ (from separation), and the 2D kissing number $\\le 6$ (angular sector pigeonhole via Complex.arg). This gives the contact number bound $3n$. The general conjecture remains axiomatized.",
     "keyInsights": [
       "**Loeschian quadratic form**: Distances in the triangular lattice are governed by $a^2 + ab + b^2$, the norm form of the Eisenstein integers $\\mathbb{Z}[\\omega]$, connecting discrete geometry to algebraic number theory",
       "**Contact number resolved**: The $t = 1$ case follows from the 2D kissing number (6) via double counting: at most $6n$ ordered pairs, hence $\\le 3n$ unordered pairs, matching Harborth's exact formula $\\lfloor 3n - \\sqrt{12n-3}\\rfloor$",
@@ -126,18 +150,19 @@
     "https://erdosproblems.com/662"
   ],
   "leanFile": {
-    "lineCount": 108,
+    "lineCount": 375,
     "structureCount": 0,
-    "axiomCount": 3,
-    "theoremCount": 5,
-    "lemmaCount": 0,
-    "defCount": 2,
+    "axiomCount": 1,
+    "theoremCount": 9,
+    "lemmaCount": 10,
+    "defCount": 10,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Real.Basic",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Data.Finset.Card",
-      "Mathlib.Tactic"
+      "Mathlib.Tactic",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Arg"
     ],
     "opens": [
       "Finset",

--- a/src/data/research/problems/erdos-383.json
+++ b/src/data/research/problems/erdos-383.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-383",
-  "title": "Erd\u0151s #383",
+  "title": "Erdős #383",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
@@ -18,10 +18,12 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-13T00:59:36.242Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "iteration": 2,
+    "focus": "Eliminated conjecture_equiv axiom. 2 axioms remain (both deep analytic).",
+    "blockers": [
+      "positive_density_smooth and dickman_asymptotic are deep analytic"
+    ],
+    "nextAction": "Both remaining axioms are deep analytic.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,16 +31,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 3 axioms remain (2 deep analytic, 1 possibly provable). File already has 7 proved theorems. Good shape.",
+    "progressSummary": "COMPLETED: Eliminated conjecture_equiv axiom (3 to 2). Defined maxPrimeFac, proved equivalence.",
     "builtItems": [],
     "insights": [
       "File already well-developed: 7 proved theorems, only 3 axioms remain",
       "conjecture_equiv might be provable if Nat.maxPrimeFac API is well-defined in Mathlib",
-      "positive_density_smooth and dickman_asymptotic are deep analytic results, not provable"
+      "positive_density_smooth and dickman_asymptotic are deep analytic results, not provable",
+      "Nat.maxPrimeFac does not exist in Mathlib",
+      "Both remaining axioms require real analysis beyond Mathlib"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# Erd\u0151s #383 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that for every $k$ there are infinitely many primes $p$ such that the largest prime divisor of\\[\\prod_{0\\leq i\\leq k}(p^2+i)\\]is $p$?\n\n\n\nA positive answer to this would give an answer to the second part of [382]. Heuristically, the 'probability' that $n$ has no prime divisors $\\geq n^{1/2}$ is $1-\\log 2>0$, so standard heuristics predict the answer to this is yes.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #382\n- Problem #2\n- Problem #384\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erdős #383 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that for every $k$ there are infinitely many primes $p$ such that the largest prime divisor of\\[\\prod_{0\\leq i\\leq k}(p^2+i)\\]is $p$?\n\n\n\nA positive answer to this would give an answer to the second part of [382]. Heuristically, the 'probability' that $n$ has no prime divisors $\\geq n^{1/2}$ is $1-\\log 2>0$, so standard heuristics predict the answer to this is yes.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #382\n- Problem #2\n- Problem #384\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"
@@ -61,10 +65,10 @@
     {
       "path": "Proofs/Erdos383Problem.lean",
       "filename": "Erdos383Problem.lean",
-      "lineCount": 245,
-      "theoremCount": 13,
-      "axiomCount": 3,
-      "defCount": 12,
+      "lineCount": 294,
+      "theoremCount": 17,
+      "axiomCount": 2,
+      "defCount": 13,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos383Problem.lean"

--- a/src/data/research/problems/erdos-460.json
+++ b/src/data/research/problems/erdos-460.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-460",
-  "title": "Erd\u0151s #460",
+  "title": "Erdős #460",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-13T04:11:10.512Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Implemented greedy sieve as well-founded recursive function. Proved sieve_initial. 5 axioms remain.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Prove sieve_greedy from construction (needs candidates nonemptiness). erdos_460_restricted_question provable via sum decomposition.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,18 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: All 6 axioms are either open conjectures, deep results, or specifications for a dummy function. No routine axioms to eliminate without first implementing the greedy sieve.",
+    "progressSummary": "PROGRESS: Implemented greedyCoprimeSieve as proper well-founded recursive function (was dummy fun _ => 0). Proved sieve_initial (6 to 5 axioms). sieve_greedy now provable from construction but needs candidates-nonemptiness lemma.",
     "builtItems": [],
     "insights": [
-      "greedyCoprimeSieve is a dummy (fun _ => 0) \u2014 all behavior axiomatized, no routine axioms to eliminate",
-      "To prove any axioms, need to implement the actual greedy sieve algorithm as a well-founded recursive def"
+      "greedyCoprimeSieve is a dummy (fun _ => 0) — all behavior axiomatized, no routine axioms to eliminate",
+      "To prove any axioms, need to implement the actual greedy sieve algorithm as a well-founded recursive def",
+      "Sieve implementation uses Fin(k+2) for previous values with well-founded recursion",
+      "sieve_greedy proof needs: candidates always Nonempty for k >= 2, which requires number-theoretic argument",
+      "erdos_460_restricted_question provable via sum decomposition (smallPrime + largePrime = total)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Implement greedyCoprimeSieve as a proper well-founded recursive definition",
       "Then sieve_initial and sieve_greedy become provable by construction"
     ],
-    "markdown": "# Erd\u0151s #460 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $a_0=n$ and $a_1=1$, and in general $a_k$ is the least integer $>a_{k-1}$ for which $(n-a_k,n-a_i)=1$ for all $1\\leq i<k$. Does\\[\\sum_{i}\\frac{1}{a_i}\\to \\infty\\]as $n\\to \\infty$? What about if we restrict the sum to those $i$ such that $n-a_j$ is divisible by some prime $\\leq a_j$, or the complement of such $i$?\n\n\n\nThis question arose in work of Eggleton, Erd\\H{o}s, and Selfridge, who could prove that $a_k <k^{2+o(1)}$ for $k$ large enough depending on $n$, but conjectured that in fact $a_k\\ll k\\log k$ is true.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #459\n- Problem #461\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erdős #460 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $a_0=n$ and $a_1=1$, and in general $a_k$ is the least integer $>a_{k-1}$ for which $(n-a_k,n-a_i)=1$ for all $1\\leq i<k$. Does\\[\\sum_{i}\\frac{1}{a_i}\\to \\infty\\]as $n\\to \\infty$? What about if we restrict the sum to those $i$ such that $n-a_j$ is divisible by some prime $\\leq a_j$, or the complement of such $i$?\n\n\n\nThis question arose in work of Eggleton, Erd\\H{o}s, and Selfridge, who could prove that $a_k <k^{2+o(1)}$ for $k$ large enough depending on $n$, but conjectured that in fact $a_k\\ll k\\log k$ is true.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #459\n- Problem #461\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"
@@ -63,9 +66,9 @@
     {
       "path": "Proofs/Erdos460Problem.lean",
       "filename": "Erdos460Problem.lean",
-      "lineCount": 147,
-      "theoremCount": 0,
-      "axiomCount": 6,
+      "lineCount": 161,
+      "theoremCount": 1,
+      "axiomCount": 5,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/erdos-662.json
+++ b/src/data/research/problems/erdos-662.json
@@ -18,12 +18,10 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-01-13T18:22:04.304Z",
-    "iteration": 2,
-    "focus": "Eliminated unit_neighbor_bound axiom by reducing to kissing_number_2d (sorry). 1 axiom remains.",
-    "blockers": [
-      "kissing_number_2d sorry needs angular packing proof"
-    ],
-    "nextAction": "Prove kissing_number_2d via Real.cos_sub + cos_pi_div_three + strictAntiOn_cos",
+    "iteration": 3,
+    "focus": "All supporting theorems proved. kissing_number_2d fully proved via angular sector pigeonhole. 0 sorries, 1 axiom (open conjecture). Gallery metadata updated.",
+    "blockers": [],
+    "nextAction": "Problem at maximum formalization potential — only axiom is the open conjecture.",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -31,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: Investigated kissing_number_2d proof strategies. Ruled out algebraic (Gram matrix) approaches: rank-2 + dot≤1/2 doesn't bound |dot|≤1/2, so Tr(G²) argument fails. Trigonometric pigeonhole confirmed necessary. All Mathlib lemmas available. Proof ~60 lines.",
+    "progressSummary": "COMPLETED: All provable parts fully machine-checked. kissing_number_2d proved via Complex.arg angular sector pigeonhole (no sorries). Contact number bound 3n proved. Gallery meta.json sections and leanFile stats updated to match current 375-line file (9 theorems, 10 lemmas, 1 axiom). Only remaining axiom is the main open conjecture erdos_662_lattice_optimal.",
     "builtItems": [
       {
         "name": "triLatticeNorm",
@@ -101,11 +99,11 @@
     {
       "path": "Proofs/Erdos662Problem.lean",
       "filename": "Erdos662Problem.lean",
-      "lineCount": 234,
-      "theoremCount": 13,
+      "lineCount": 375,
+      "theoremCount": 19,
       "axiomCount": 1,
-      "defCount": 7,
-      "sorryCount": 1,
+      "defCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos662Problem.lean"
     }


### PR DESCRIPTION
## Summary
Three problems addressed: metadata alignment, axiom elimination, and sieve implementation.

## erdos-662 (metadata update)
- meta.json leanFile section: corrected lineCount (108→375), axiomCount (3→1), theoremCount (5→9)
- Added 3 new sections for kissing number proof structure
- File at maximum formalization potential — only axiom is the open conjecture

## erdos-383 (axiom elimination: 3→2)
- `Nat.maxPrimeFac` does not exist in Mathlib — defined `maxPrimeFac` via `Finset.max'` of `primeFactors`
- Proved `hasLargestPrimeFactor_iff_maxPrimeFac` bridge lemma
- Replaced `axiom conjecture_equiv` with `theorem conjecture_equiv`
- Remaining 2 axioms are deep analytic results (smooth number density, Dickman asymptotics)

## erdos-460 (sieve implementation + axiom elimination: 6→5)
- Replaced dummy `greedyCoprimeSieve` (`fun _ => 0`) with proper well-founded recursive definition
- Uses `Fin (k+2)` for previous values, `Finset.filter` for candidate search
- Converted `axiom sieve_initial` to `theorem` (proved by simp)
- `sieve_greedy` remains axiom but now provable from construction

## Axiom reduction summary
| Problem | Before | After | Eliminated |
|---------|--------|-------|-----------|
| erdos-662 | (metadata only) | — | — |
| erdos-383 | 3 axioms | 2 axioms | conjecture_equiv |
| erdos-460 | 6 axioms | 5 axioms | sieve_initial |

🤖 Generated by researcher-9