### PR TITLE
Fix: stale line counts in erdos-1084-oq-01, erdos-1153

### DIFF
--- a/src/data/proofs/erdos-1084-oq-01/meta.json
+++ b/src/data/proofs/erdos-1084-oq-01/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1084",
     "axiomCount": 4,
     "assumptions": "4 axiom declarations: degree_le_kissing (degree bound from kissing number), fcc_cluster_pairs (FCC lower bound), bezdek_reid (Bezdek-Reid upper bound), harborth_formula (Harborth 2D exact formula). Eliminated: kissingNumber (now concrete def with known values), kissing_1d/2d/3d (proved by rfl), degree_sum_eq_twice_pairs (handshaking proved by double-counting). Machine-verified: f1_upper, f1_achieve, 1D triangle/degree lemmas, f2_upper_3n, f3_upper_6n, isoperimetric exponent analysis, erdos_1084_oq01 conjecture decomposition.",
-    "lineCount": 533,
+    "lineCount": 607,
     "badge": "axiom",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1153/meta.json
+++ b/src/data/proofs/erdos-1153/meta.json
@@ -54,7 +54,7 @@
       "chebyshev_lebesgue_upper"
     ],
     "axiomCount": 2,
-    "lineCount": 160,
+    "lineCount": 175,
     "assumptions": "2 axiom(s): erdos_1153 (the logarithmic lower bound, proved by Bernstein/Erdős), chebyshev_lebesgue_upper (matching upper bound via Chebyshev nodes)."
   },
   "overview": {
@@ -123,7 +123,7 @@
       "Finset"
     ],
     "namespace": "Erdos1153",
-    "lineCount": 160,
+    "lineCount": 175,
     "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 4


### PR DESCRIPTION
## Fix

Updates stale line counts to match current Lean source files.

## Evidence

**erdos-1084-oq-01**: meta.lineCount 533 → 607 (leanFile.lineCount was already 607)
**erdos-1153**: lineCount 160 → 175 (both meta and leanFile)

Verified by `wc -l` against actual Lean files.

Closes #7089

---
Automated fix by lean-mechanic agent.