### PR TITLE
Fix: cauchy-schwarz-integral-oq-01-oq-01-oq-02 stale line count

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 137,
+    "lineCount": 151,
     "assumptions": "1 axiom: riesz_lp_surjective (the hard direction requiring Radon-Nikodym). L2 case fully proved via InnerProductSpace.toDual. Embedding direction proved via Hölder.",
     "dateAdded": "2026-03-26"
   },
@@ -32,7 +32,7 @@
   },
   "leanFile": {
     "imports": ["Mathlib"],
-    "lineCount": 137,
+    "lineCount": 151,
     "axiomCount": 1,
     "theoremCount": 7,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Updates stale line count to match current Lean source file.

## Evidence

**Before**: lineCount: 137 (both meta and leanFile)
**After**: lineCount: 151 (both meta and leanFile)

Verified by `wc -l` against actual Lean file.

Closes #7088

---
Automated fix by lean-mechanic agent.