### PR TITLE
Research: erdos-524 — 4 new polyMax infrastructure theorems

### DIFF
--- a/proofs/Proofs/Erdos524Problem.lean
+++ b/proofs/Proofs/Erdos524Problem.lean
@@ -308,3 +308,11 @@ theorem polyMax_diff_le (t : ℝ) (n : ℕ) :
   constructor
   · linarith [polyMax_ge_succ t n]
   · linarith [polyMax_succ_le t n]
+
+/-- General evaluation bound: |P_n(t,x)| ≤ M_n(t) for any x ∈ [-1,1].
+    Generalizes the endpoint lemmas randSignPoly_eval_{one,neg_one}_le_polyMax. -/
+theorem polyMax_ge_eval (t : ℝ) (n : ℕ) {x : ℝ} (hx : x ∈ Set.Icc (-1 : ℝ) 1) :
+    |randSignPoly t n x| ≤ polyMax t n := by
+  unfold polyMax
+  apply le_csSup (polyMax_bddAbove t n)
+  exact ⟨x, hx, rfl⟩

--- a/proofs/Proofs/Erdos524Problem.lean
+++ b/proofs/Proofs/Erdos524Problem.lean
@@ -196,3 +196,76 @@ theorem randSignPoly_eval_neg_one_le_polyMax (t : ℝ) (n : ℕ) :
   unfold polyMax
   apply le_csSup (polyMax_bddAbove t n)
   exact ⟨-1, Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩, rfl⟩
+
+/- ## Additional polyMax results -/
+
+/-- M_0(t) = 0: the empty polynomial has zero maximum (empty sum). -/
+theorem polyMax_zero (t : ℝ) : polyMax t 0 = 0 :=
+  le_antisymm (by simpa using polyMax_le_n t 0) (polyMax_nonneg t 0)
+
+/-- The maximum of |P_n(t,·)| on [-1,1] is achieved: there exists x₀ ∈ [-1,1]
+    with |P_n(t,x₀)| = M_n(t). This is the extreme value theorem applied to the
+    continuous function |P_n(t,·)| on the compact set [-1,1]. -/
+theorem polyMax_achieved (t : ℝ) (n : ℕ) :
+    ∃ x₀ ∈ Set.Icc (-1 : ℝ) 1, |randSignPoly t n x₀| = polyMax t n := by
+  have hcont : ContinuousOn (fun x => |randSignPoly t n x|) (Set.Icc (-1 : ℝ) 1) :=
+    (continuous_abs.comp (randSignPoly_continuous t n)).continuousOn
+  have hne : (Set.Icc (-1 : ℝ) 1).Nonempty := ⟨0, by constructor <;> norm_num⟩
+  obtain ⟨x₀, hx₀_mem, hx₀_max⟩ := isCompact_Icc.exists_isMaxOn hne hcont
+  refine ⟨x₀, hx₀_mem, le_antisymm ?_ ?_⟩
+  · -- |P_n(t,x₀)| ≤ M_n(t): element ≤ sSup
+    unfold polyMax
+    apply le_csSup (polyMax_bddAbove t n)
+    exact ⟨x₀, hx₀_mem, rfl⟩
+  · -- M_n(t) ≤ |P_n(t,x₀)|: x₀ is the maximizer
+    unfold polyMax
+    apply csSup_le
+    · exact ⟨|randSignPoly t n 0|, ⟨0, Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩, rfl⟩⟩
+    · rintro _ ⟨y, hy, rfl⟩
+      exact hx₀_max hy
+
+/-- For n = 1, M_1(t) = 1. The single-term polynomial P₁(t,x) = ε₁·x
+    has maximum |x| on [-1,1], which equals 1. -/
+theorem polyMax_one (t : ℝ) : polyMax t 1 = 1 := by
+  have h_eq : ∀ x : ℝ, |randSignPoly t 1 x| = |x| := by
+    intro x
+    simp only [randSignPoly, Finset.sum_range_one, Nat.zero_add, pow_one,
+               abs_mul, binaryDigit_cast_abs, one_mul]
+  apply le_antisymm
+  · -- M_1(t) ≤ 1: |x| ≤ 1 for x ∈ [-1,1]
+    unfold polyMax
+    apply csSup_le
+    · exact ⟨|randSignPoly t 1 0|, ⟨0, Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩, rfl⟩⟩
+    · rintro _ ⟨x, hx, rfl⟩
+      rw [h_eq]
+      exact abs_le.mpr ⟨by linarith [hx.1], hx.2⟩
+  · -- 1 ≤ M_1(t): achieved at x = 1
+    unfold polyMax
+    apply le_csSup (polyMax_bddAbove t 1)
+    exact ⟨1, Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩, by rw [h_eq]; norm_num⟩
+
+/-- Adding one term changes the maximum by at most 1: M_{n+1}(t) ≤ M_n(t) + 1.
+    The new term |ε_{n+1}·x^{n+1}| ≤ 1 on [-1,1], and by the triangle inequality,
+    |P_{n+1}(t,x)| ≤ |P_n(t,x)| + 1 ≤ M_n(t) + 1 for each x. -/
+theorem polyMax_succ_le (t : ℝ) (n : ℕ) :
+    polyMax t (n + 1) ≤ polyMax t n + 1 := by
+  suffices h : ∀ x ∈ Set.Icc (-1 : ℝ) 1,
+      |randSignPoly t (n + 1) x| ≤ polyMax t n + 1 by
+    unfold polyMax
+    apply csSup_le
+    · exact ⟨|randSignPoly t (n + 1) 0|,
+        ⟨0, Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩, rfl⟩⟩
+    · rintro _ ⟨x, hx, rfl⟩; exact h x hx
+  intro x hx
+  have hx_abs : |x| ≤ 1 := abs_le.mpr ⟨by linarith [hx.1], hx.2⟩
+  rw [randSignPoly_succ]
+  have h_term : |(↑(binaryDigit t (n + 1)) : ℝ) * x ^ (n + 1)| ≤ 1 := by
+    rw [abs_mul, abs_pow, binaryDigit_cast_abs, one_mul]
+    calc |x| ^ (n + 1) ≤ 1 ^ (n + 1) := pow_le_pow_left (abs_nonneg x) hx_abs _
+      _ = 1 := one_pow _
+  have h_poly : |randSignPoly t n x| ≤ polyMax t n := by
+    unfold polyMax
+    apply le_csSup (polyMax_bddAbove t n)
+    exact ⟨x, hx, rfl⟩
+  linarith [abs_add (randSignPoly t n x)
+    ((↑(binaryDigit t (n + 1)) : ℝ) * x ^ (n + 1))]

--- a/proofs/Proofs/Erdos524Problem.lean
+++ b/proofs/Proofs/Erdos524Problem.lean
@@ -316,3 +316,27 @@ theorem polyMax_ge_eval (t : ℝ) (n : ℕ) {x : ℝ} (hx : x ∈ Set.Icc (-1 : 
   unfold polyMax
   apply le_csSup (polyMax_bddAbove t n)
   exact ⟨x, hx, rfl⟩
+
+/-- For n = 2, M_2(t) = 2 for all t. The polynomial P₂(t,x) = ε₁·x + ε₂·x².
+    For each sign pattern, at least one endpoint x ∈ {±1} gives |P₂| = 2.
+    Upper bound: M_2 ≤ M_1 + 1 = 2 by the Lipschitz property. -/
+theorem polyMax_two (t : ℝ) : polyMax t 2 = 2 := by
+  apply le_antisymm
+  · -- M_2 ≤ M_1 + 1 = 2
+    linarith [polyMax_succ_le t 1, polyMax_one t]
+  · -- M_2 ≥ 2: case split on binary digit signs
+    have h1_mem : (1 : ℝ) ∈ Set.Icc (-1) 1 := by norm_num
+    have hn1_mem : (-1 : ℝ) ∈ Set.Icc (-1) 1 := by norm_num
+    rcases binaryDigit_values t 1 with h1 | h1 <;> rcases binaryDigit_values t 2 with h2 | h2
+    · -- ε₁=1, ε₂=1: P₂(t,1) = 2
+      suffices h : |randSignPoly t 2 1| = 2 by linarith [polyMax_ge_eval t 2 h1_mem]
+      simp [randSignPoly, Finset.sum_range_succ, Finset.sum_range_one, h1, h2]; norm_num
+    · -- ε₁=1, ε₂=-1: P₂(t,-1) = -2
+      suffices h : |randSignPoly t 2 (-1)| = 2 by linarith [polyMax_ge_eval t 2 hn1_mem]
+      simp [randSignPoly, Finset.sum_range_succ, Finset.sum_range_one, h1, h2]; norm_num
+    · -- ε₁=-1, ε₂=1: P₂(t,-1) = 2
+      suffices h : |randSignPoly t 2 (-1)| = 2 by linarith [polyMax_ge_eval t 2 hn1_mem]
+      simp [randSignPoly, Finset.sum_range_succ, Finset.sum_range_one, h1, h2]; norm_num
+    · -- ε₁=-1, ε₂=-1: P₂(t,1) = -2
+      suffices h : |randSignPoly t 2 1| = 2 by linarith [polyMax_ge_eval t 2 h1_mem]
+      simp [randSignPoly, Finset.sum_range_succ, Finset.sum_range_one, h1, h2]; norm_num

--- a/proofs/Proofs/Erdos524Problem.lean
+++ b/proofs/Proofs/Erdos524Problem.lean
@@ -269,3 +269,42 @@ theorem polyMax_succ_le (t : ℝ) (n : ℕ) :
     exact ⟨x, hx, rfl⟩
   linarith [abs_add (randSignPoly t n x)
     ((↑(binaryDigit t (n + 1)) : ℝ) * x ^ (n + 1))]
+
+/-- Reverse bound: M_n(t) ≤ M_{n+1}(t) + 1. Removing a term changes the max
+    by at most 1, since P_n(t,x) = P_{n+1}(t,x) - ε_{n+1}·x^{n+1}. -/
+theorem polyMax_ge_succ (t : ℝ) (n : ℕ) :
+    polyMax t n ≤ polyMax t (n + 1) + 1 := by
+  suffices h : ∀ x ∈ Set.Icc (-1 : ℝ) 1,
+      |randSignPoly t n x| ≤ polyMax t (n + 1) + 1 by
+    unfold polyMax
+    apply csSup_le
+    · exact ⟨|randSignPoly t n 0|,
+        ⟨0, Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩, rfl⟩⟩
+    · rintro _ ⟨x, hx, rfl⟩; exact h x hx
+  intro x hx
+  have hx_abs : |x| ≤ 1 := abs_le.mpr ⟨by linarith [hx.1], hx.2⟩
+  -- P_n(t,x) = P_{n+1}(t,x) + (−ε_{n+1}·x^{n+1})
+  have h_rearrange : randSignPoly t n x =
+      randSignPoly t (n + 1) x +
+      (-((↑(binaryDigit t (n + 1)) : ℝ) * x ^ (n + 1))) := by
+    linarith [randSignPoly_succ t n x]
+  rw [h_rearrange]
+  have h_neg_term : |(-((↑(binaryDigit t (n + 1)) : ℝ) * x ^ (n + 1)))| ≤ 1 := by
+    rw [abs_neg, abs_mul, abs_pow, binaryDigit_cast_abs, one_mul]
+    calc |x| ^ (n + 1) ≤ 1 ^ (n + 1) := pow_le_pow_left (abs_nonneg x) hx_abs _
+      _ = 1 := one_pow _
+  have h_poly : |randSignPoly t (n + 1) x| ≤ polyMax t (n + 1) := by
+    unfold polyMax
+    apply le_csSup (polyMax_bddAbove t (n + 1))
+    exact ⟨x, hx, rfl⟩
+  linarith [abs_add (randSignPoly t (n + 1) x)
+    (-((↑(binaryDigit t (n + 1)) : ℝ) * x ^ (n + 1)))]
+
+/-- The polynomial maximum is 1-Lipschitz in n: |M_{n+1}(t) - M_n(t)| ≤ 1.
+    Combining polyMax_succ_le and polyMax_ge_succ. -/
+theorem polyMax_diff_le (t : ℝ) (n : ℕ) :
+    |polyMax t (n + 1) - polyMax t n| ≤ 1 := by
+  rw [abs_le]
+  constructor
+  · linarith [polyMax_ge_succ t n]
+  · linarith [polyMax_succ_le t n]

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -35,7 +35,7 @@
       }
     ],
     "axiomCount": 4,
-    "lineCount": 198,
+    "lineCount": 271,
     "assumptions": "4 axioms: erdos_lower_bound, chung_upper_bound, salem_zygmund_trigonometric, and 1 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -103,6 +103,14 @@
       "endLine": 198,
       "summary": "sSup infrastructure for polyMax: `polyMax_bddAbove` (BddAbove), `polyMax_nonneg` ($M_n \\geq 0$), `polyMax_le_n` ($M_n \\leq n$), and endpoint evaluation lower bounds `randSignPoly_eval_one_le_polyMax` and `randSignPoly_eval_neg_one_le_polyMax`.",
       "mathContext": "The polyMax sSup infrastructure establishes: (1) the supremum is well-defined (BddAbove by the trivial bound $n$), (2) $M_n \\geq 0$ (since $|\\cdot| \\geq 0$ and the domain is nonempty), (3) $M_n \\leq n$ (triangle inequality), and (4) endpoint evaluations $|P_n(t, \\pm 1)| \\leq M_n$ provide lower bounds. The endpoint bound at $x = 1$ is the key observation behind Erdős's lower bound: $M_n \\geq |P_n(t,1)| = |\\sum \\varepsilon_k|$, and by the LIL this is $\\geq \\sqrt{2n \\log\\log n}$ infinitely often."
+    },
+    {
+      "id": "advanced-polymax",
+      "title": "Advanced polyMax Results",
+      "startLine": 200,
+      "endLine": 271,
+      "summary": "Four new results: `polyMax_zero` ($M_0 = 0$), `polyMax_achieved` (extreme value theorem: $\\exists x_0 \\in [-1,1]$ achieving $M_n$), `polyMax_one` ($M_1 = 1$), and `polyMax_succ_le` ($M_{n+1} \\leq M_n + 1$, Lipschitz-type bound on the max sequence).",
+      "mathContext": "The extreme value theorem ensures the supremum defining $M_n$ is actually a maximum — the continuous function $|P_n(t,\\cdot)|$ on the compact interval $[-1,1]$ achieves its supremum. The Lipschitz bound $M_{n+1} \\leq M_n + 1$ follows from $|P_{n+1}(t,x) - P_n(t,x)| = |\\varepsilon_{n+1} x^{n+1}| \\leq 1$ on $[-1,1]$, giving a quantitative bound on how fast the polynomial maximum can grow."
     }
   ],
   "overview": {
@@ -143,9 +151,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 198,
+    "lineCount": 271,
     "axiomCount": 4,
-    "theoremCount": 14,
+    "theoremCount": 18,
     "definitionCount": 3
   },
   "references": [

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -35,7 +35,7 @@
       }
     ],
     "axiomCount": 4,
-    "lineCount": 271,
+    "lineCount": 310,
     "assumptions": "4 axioms: erdos_lower_bound, chung_upper_bound, salem_zygmund_trigonometric, and 1 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -108,9 +108,9 @@
       "id": "advanced-polymax",
       "title": "Advanced polyMax Results",
       "startLine": 200,
-      "endLine": 271,
-      "summary": "Four new results: `polyMax_zero` ($M_0 = 0$), `polyMax_achieved` (extreme value theorem: $\\exists x_0 \\in [-1,1]$ achieving $M_n$), `polyMax_one` ($M_1 = 1$), and `polyMax_succ_le` ($M_{n+1} \\leq M_n + 1$, Lipschitz-type bound on the max sequence).",
-      "mathContext": "The extreme value theorem ensures the supremum defining $M_n$ is actually a maximum — the continuous function $|P_n(t,\\cdot)|$ on the compact interval $[-1,1]$ achieves its supremum. The Lipschitz bound $M_{n+1} \\leq M_n + 1$ follows from $|P_{n+1}(t,x) - P_n(t,x)| = |\\varepsilon_{n+1} x^{n+1}| \\leq 1$ on $[-1,1]$, giving a quantitative bound on how fast the polynomial maximum can grow."
+      "endLine": 310,
+      "summary": "Six new results: `polyMax_zero` ($M_0 = 0$), `polyMax_achieved` (extreme value theorem), `polyMax_one` ($M_1 = 1$), `polyMax_succ_le` ($M_{n+1} \\leq M_n + 1$), `polyMax_ge_succ` ($M_n \\leq M_{n+1} + 1$), and `polyMax_diff_le` ($|M_{n+1} - M_n| \\leq 1$).",
+      "mathContext": "The extreme value theorem ensures $M_n$ is a true maximum. The 1-Lipschitz property $|M_{n+1} - M_n| \\leq 1$ follows from $|P_{n+1}(t,x) - P_n(t,x)| = |\\varepsilon_{n+1} x^{n+1}| \\leq 1$ on $[-1,1]$ — each new term changes the polynomial by at most 1 pointwise, hence the maximum by at most 1."
     }
   ],
   "overview": {
@@ -151,9 +151,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 271,
+    "lineCount": 310,
     "axiomCount": 4,
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 3
   },
   "references": [

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -151,9 +151,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 318,
+    "lineCount": 342,
     "axiomCount": 4,
-    "theoremCount": 21,
+    "theoremCount": 22,
     "definitionCount": 3
   },
   "references": [

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -151,9 +151,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 310,
+    "lineCount": 318,
     "axiomCount": 4,
-    "theoremCount": 20,
+    "theoremCount": 21,
     "definitionCount": 3
   },
   "references": [


### PR DESCRIPTION
## Summary
- **polyMax_zero**: M_0(t) = 0 — the empty polynomial has zero maximum
- **polyMax_achieved**: Extreme value theorem — ∃ x₀ ∈ [-1,1] with |P_n(t,x₀)| = M_n(t)
- **polyMax_one**: M_1(t) = 1 — single-term polynomial max via |ε₁·x| = |x|
- **polyMax_succ_le**: M_{n+1}(t) ≤ M_n(t) + 1 — Lipschitz-type bound on max sequence

## Progress
- 18 theorems (up from 14), 4 axioms (all deep/open), 0 sorries
- Builds on RICH knowledge base (score 28) from prior sessions
- Key techniques: `isCompact_Icc.exists_isMaxOn`, `csSup_le`/`le_csSup` sandwich

## Status
**Outcome**: progress
**Next Steps**: Reverse Lipschitz bound, L² norm computation, polyMax positivity for n ≥ 1

**Note**: Docker was unavailable for build verification. Proofs follow established patterns from the existing file (same `csSup_le`/`le_csSup` approach as existing theorems).

🤖 Generated by researcher-4