### PR TITLE
Enrich Riesz Representation for Lp Spaces

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-riesz-lp-docstring",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Open Question: Riesz Representation via Hölder",
+    "content": "This proof investigates whether the Riesz representation theorem $(L^p)^* \\cong L^q$ can be derived purely from Hölder's inequality. The answer is nuanced: Hölder gives the embedding direction $L^q \\hookrightarrow (L^p)^*$, but surjectivity requires the Radon-Nikodým theorem — an entirely separate tool from measure theory.",
+    "mathContext": "For conjugate exponents $1/p + 1/q = 1$ with $1 < p < \\infty$, the Riesz representation theorem states $(L^p(\\mu))^* \\cong L^q(\\mu)$ isometrically. The isomorphism sends $g \\in L^q$ to the functional $\\Lambda_g(f) = \\int fg\\,d\\mu$.",
+    "significance": "key",
+    "relatedConcepts": ["Riesz representation theorem", "dual space", "conjugate exponents", "Hölder inequality"],
+    "prerequisites": ["measure theory", "Lp spaces", "bounded linear functionals"]
+  },
+  {
+    "id": "ann-frechet-riesz-l2",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 40, "endLine": 55 },
+    "type": "technique",
+    "title": "Fréchet-Riesz Theorem for L²",
+    "content": "The L² case is resolved completely by the Fréchet-Riesz theorem: every Hilbert space $H$ satisfies $H^* \\cong H$ via the inner product. Since $L^2(\\mu)$ is a Hilbert space with inner product $\\langle f, g \\rangle = \\int f \\bar{g}\\,d\\mu$, both embedding and surjectivity follow at once. The proof delegates directly to Mathlib's `InnerProductSpace.toDual`.",
+    "mathContext": "The Fréchet-Riesz theorem: for a Hilbert space $H$, the map $\\Phi: H \\to H^*$ defined by $\\Phi(g)(f) = \\langle g, f \\rangle$ is a conjugate-linear isometric isomorphism. For $L^2$, this gives $(L^2)^* \\cong L^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Fréchet-Riesz theorem", "Hilbert space", "inner product space", "self-duality"],
+    "prerequisites": ["inner product spaces", "bounded linear functionals", "isometric isomorphism"]
+  },
+  {
+    "id": "ann-l2-surjective",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 61 },
+    "type": "insight",
+    "title": "L² Dual Surjectivity",
+    "content": "Surjectivity of the L² duality map — every bounded linear functional on $L^2$ is represented by an $L^2$ function — follows directly from the fact that `InnerProductSpace.toDual` is a `LinearIsometryEquiv`, hence bijective. This is the key property that fails for general $L^p$ without Radon-Nikodým.",
+    "mathContext": "$\\Phi: L^2 \\xrightarrow{\\sim} (L^2)^*$ is surjective because it is a linear isometric equivalence. For general $p \\neq 2$, establishing surjectivity of $L^q \\to (L^p)^*$ requires constructing the representing function via the Radon-Nikodým derivative.",
+    "significance": "key",
+    "relatedConcepts": ["surjectivity", "linear isometric equivalence", "representing function"],
+    "prerequisites": ["linear isometry", "dual space surjectivity"]
+  },
+  {
+    "id": "ann-l2-inner-integral",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 63, "endLine": 66 },
+    "type": "definition",
+    "title": "L² Inner Product as Integral",
+    "content": "Establishes the concrete formula $\\langle f, g \\rangle_{L^2} = \\int f(x) g(x)\\,d\\mu(x)$, connecting the abstract Hilbert space inner product with measure-theoretic integration. This identity is the bridge between the algebraic Fréchet-Riesz theorem and the analytic Riesz representation.",
+    "mathContext": "$\\langle f, g \\rangle_{L^2(\\mu)} = \\int_\\alpha f(a) \\cdot g(a)\\,d\\mu(a)$",
+    "significance": "supporting",
+    "relatedConcepts": ["inner product", "Lebesgue integral", "L2 space"],
+    "prerequisites": ["measure theory", "Bochner integral"]
+  },
+  {
+    "id": "ann-holder-core",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 86 },
+    "type": "technique",
+    "title": "Hölder's Inequality: The Embedding Direction",
+    "content": "Hölder's inequality is the engine of the embedding $L^q \\hookrightarrow (L^p)^*$. Given $g \\in L^q$, the functional $\\Lambda_g(f) = \\int fg\\,d\\mu$ is bounded on $L^p$ with $\\|\\Lambda_g\\| \\leq \\|g\\|_q$. The proof invokes Mathlib's `ENNReal.lintegral_mul_le_Lp_mul_Lq`, which proves Hölder at the extended-real lintegral level.",
+    "mathContext": "Hölder's inequality: for $1/p + 1/q = 1$, $\\int |fg|\\,d\\mu \\leq \\left(\\int |f|^p\\,d\\mu\\right)^{1/p} \\left(\\int |g|^q\\,d\\mu\\right)^{1/q}$. This makes $g \\mapsto \\Lambda_g$ a well-defined isometric embedding $L^q \\hookrightarrow (L^p)^*$.",
+    "significance": "key",
+    "relatedConcepts": ["Hölder inequality", "conjugate exponents", "isometric embedding", "Young inequality"],
+    "prerequisites": ["Lp norms", "Lebesgue integration", "conjugate exponents"]
+  },
+  {
+    "id": "ann-cs-specialization",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 96 },
+    "type": "insight",
+    "title": "Cauchy-Schwarz as Hölder p=q=2",
+    "content": "The integral Cauchy-Schwarz inequality $\\int fg \\leq (\\int f^2)^{1/2}(\\int g^2)^{1/2}$ is recovered as the $p=q=2$ special case of Hölder. The proof constructs the conjugate exponent witness (`by constructor <;> norm_num`) and delegates to the same Mathlib lemma. This demonstrates the generalization hierarchy: Cauchy-Schwarz → Hölder → Riesz embedding.",
+    "mathContext": "Cauchy-Schwarz at lintegral level: $\\int f \\cdot g\\,d\\mu \\leq \\left(\\int f^2\\,d\\mu\\right)^{1/2} \\left(\\int g^2\\,d\\mu\\right)^{1/2}$, which is Hölder with $p = q = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "specialization", "generalization hierarchy"],
+    "prerequisites": ["Hölder inequality", "conjugate exponents"]
+  },
+  {
+    "id": "ann-radon-nikodym-axiom",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 97, "endLine": 121 },
+    "type": "concept",
+    "title": "Surjectivity via Radon-Nikodým (Axiomatized)",
+    "content": "The hard direction of the Riesz representation: given $\\varphi \\in (L^p)^*$, construct $g \\in L^q$ with $\\varphi(f) = \\int fg\\,d\\mu$. The classical proof defines a signed measure $\\nu(E) = \\varphi(\\mathbf{1}_E)$, proves $\\nu \\ll \\mu$, applies Radon-Nikodým to get $g = d\\nu/d\\mu$, then shows $g \\in L^q$. This direction is axiomatized because Mathlib has Radon-Nikodým but the full composition with $L^p$ machinery is not yet available.",
+    "mathContext": "Given $\\varphi \\in (L^p)^*$: (1) define $\\nu(E) = \\varphi(\\mathbf{1}_E)$, (2) show $\\nu \\ll \\mu$ via $|\\nu(E)| \\leq \\|\\varphi\\| \\cdot \\mu(E)^{1/p}$, (3) Radon-Nikodým gives $g = d\\nu/d\\mu$, (4) prove $g \\in L^q$ with $\\|g\\|_q = \\|\\varphi\\|$.",
+    "significance": "key",
+    "relatedConcepts": ["Radon-Nikodým theorem", "absolute continuity", "signed measure", "surjectivity"],
+    "prerequisites": ["Radon-Nikodým theorem", "signed measures", "absolute continuity", "Lp membership"]
+  },
+  {
+    "id": "ann-hierarchy-summary",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 123, "endLine": 135 },
+    "type": "context",
+    "title": "Inequality Hierarchy and Answer Summary",
+    "content": "The proof concludes by mapping out the dependency chain: Young → Hölder → Lq embedding into (Lp)*, while Radon-Nikodým → surjectivity is an independent path. The two combine for the full Riesz isomorphism. This answers the open question: Hölder is necessary but not sufficient for the full representation theorem.",
+    "mathContext": "Young's inequality $ab \\leq a^p/p + b^q/q$ implies Hölder, which implies $L^q \\hookrightarrow (L^p)^*$. Independently, Radon-Nikodým gives $(L^p)^* \\hookrightarrow L^q$. Together: $(L^p)^* \\cong L^q$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Young inequality", "dependency chain", "isomorphism decomposition"],
+    "prerequisites": ["Hölder inequality", "Radon-Nikodým theorem"]
+  },
+  {
+    "id": "ann-l2-cauchy-schwarz",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 137, "endLine": 141 },
+    "type": "technique",
+    "title": "Cauchy-Schwarz on L² Functions",
+    "content": "The abstract inner product space Cauchy-Schwarz $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ applied to $L^2$. This connects the integral inequality to the abstract Hilbert space bound and shows the Hölder embedding is isometric (norm-preserving) at $p=2$.",
+    "mathContext": "$|\\langle f, g \\rangle_{L^2}| \\leq \\|f\\|_{L^2} \\cdot \\|g\\|_{L^2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "inner product bound", "isometric embedding"],
+    "prerequisites": ["inner product spaces", "norm inequality"]
+  },
+  {
+    "id": "ann-dual-norm-tight",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "range": { "startLine": 143, "endLine": 148 },
+    "type": "insight",
+    "title": "Tightness of the Hölder Bound at p=2",
+    "content": "The dual norm $\\|\\Lambda_g\\| = \\|g\\|$ confirms that the Hölder inequality bound is tight for $L^2$: the embedding $L^2 \\hookrightarrow (L^2)^*$ is an isometry, not merely a contraction. This is a concrete instance of the general fact that the Hölder embedding $L^q \\hookrightarrow (L^p)^*$ is always isometric (equality in Hölder is attained by choosing $f = |g|^{q/p} \\cdot \\mathrm{sgn}(g)$).",
+    "mathContext": "$\\|\\Phi(g)\\|_{(L^2)^*} = \\|g\\|_{L^2}$, showing the Hölder bound $\\|\\Lambda_g\\| \\leq \\|g\\|_q$ is achieved with equality.",
+    "significance": "supporting",
+    "relatedConcepts": ["isometry", "operator norm", "equality in Hölder"],
+    "prerequisites": ["operator norm", "linear isometry"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -21,15 +21,86 @@
     "dateAdded": "2026-03-26"
   },
   "overview": {
-    "problemStatement": "Can the Riesz representation theorem (Lp)* ≅ Lq be derived from the eLpNorm Hölder inequality?",
-    "text": "The Riesz representation theorem identifies the dual of Lp with Lq for conjugate exponents. Hölder's inequality provides the embedding direction; the surjectivity requires Radon-Nikodým.",
-    "proofStrategy": "L2 self-duality via Fréchet-Riesz (Mathlib), Hölder for Lq → (Lp)* embedding, Radon-Nikodým for surjectivity (axiomatized).",
+    "problemStatement": "Can the Riesz representation theorem $(L^p)^* \\cong L^q$ be derived from the $\\mathrm{eLpNorm}$ Hölder inequality?",
+    "text": "The Riesz representation theorem identifies the dual of $L^p$ with $L^q$ for conjugate exponents. Hölder's inequality provides the embedding direction; the surjectivity requires Radon-Nikodým.",
+    "historicalContext": "The duality of $L^p$ spaces was established by Frigyes Riesz in 1910 for $L^2$ and extended to general $L^p$ ($1 < p < \\infty$) through the work of Riesz and others in the 1920s-1930s. The $L^2$ case is a direct consequence of the Fréchet-Riesz theorem (1907), which characterizes the dual of any Hilbert space. The general case was completed by leveraging the Radon-Nikodým theorem (1930), which Johann Radon proved for $\\mathbb{R}^n$ and Otton Nikodým extended to abstract measure spaces. The interplay between Hölder's inequality (Otto Hölder, 1889) and the Radon-Nikodým theorem in establishing $L^p$ duality is a foundational chapter in functional analysis, connecting the theories of integration, measure, and topological vector spaces.",
+    "proofStrategy": "The formalization splits the Riesz representation into two independent directions. The embedding $L^q \\hookrightarrow (L^p)^*$ follows from Hölder's inequality: each $g \\in L^q$ defines a bounded functional $\\Lambda_g(f) = \\int fg\\,d\\mu$ with $\\|\\Lambda_g\\| \\leq \\|g\\|_q$. For $L^2$, the Fréchet-Riesz theorem (via Mathlib's `InnerProductSpace.toDual`) gives both directions simultaneously. For general $p$, surjectivity is axiomatized because the composition of Mathlib's Radon-Nikodým machinery with $L^p$ membership proofs is not yet available in Lean 4.",
     "keyInsights": [
-      "Hölder's inequality gives the isometric embedding Lq ↪ (Lp)* but NOT surjectivity",
-      "The L2 case is special: Hilbert space structure gives both directions",
-      "Surjectivity for general Lp requires constructing the representing function via Radon-Nikodým"
+      "Hölder's inequality gives the isometric embedding $L^q \\hookrightarrow (L^p)^*$ but NOT surjectivity — the two directions of the Riesz isomorphism require fundamentally different tools",
+      "The $L^2$ case is special: Hilbert space self-duality via the inner product gives both directions at once, bypassing the need for Radon-Nikodým entirely",
+      "Surjectivity for general $L^p$ requires constructing the representing function via the Radon-Nikodým derivative $g = d\\nu/d\\mu$ where $\\nu(E) = \\varphi(\\mathbf{1}_E)$",
+      "The generalization hierarchy Young → Hölder → Cauchy-Schwarz is concretely demonstrated: the $p=q=2$ specialization of Hölder recovers the integral Cauchy-Schwarz inequality",
+      "The Hölder embedding is always isometric (not merely bounded), as demonstrated by the dual norm tightness result $\\|\\Phi(g)\\| = \\|g\\|$ at $p=2$"
     ]
   },
+  "sections": [
+    {
+      "id": "header-and-setup",
+      "title": "Module Documentation and Setup",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "States the open question, summarizes the partial answer, and opens the noncomputable section with measure space variables."
+    },
+    {
+      "id": "l2-self-duality",
+      "title": "Part I: L² Self-Duality via Fréchet-Riesz",
+      "startLine": 38,
+      "endLine": 66,
+      "summary": "Proves the complete L² case: the Fréchet-Riesz theorem gives $(L^2)^* \\cong L^2$ as an isometric isomorphism via the inner product, including surjectivity and the concrete integral formula."
+    },
+    {
+      "id": "holder-embedding",
+      "title": "Part II: Hölder-Based Embedding (Easy Direction)",
+      "startLine": 68,
+      "endLine": 96,
+      "summary": "Establishes the embedding direction $L^q \\hookrightarrow (L^p)^*$ via Hölder's inequality at the lintegral level, plus the Cauchy-Schwarz specialization at $p=q=2$."
+    },
+    {
+      "id": "riesz-surjectivity",
+      "title": "Part III: General Riesz Representation (Axiomatized)",
+      "startLine": 97,
+      "endLine": 121,
+      "summary": "States the hard direction (surjectivity) as an axiom: every bounded linear functional on $L^p$ is represented by an $L^q$ function. The classical proof route via Radon-Nikodým is documented but not yet formalizable in Lean 4."
+    },
+    {
+      "id": "hierarchy-and-applications",
+      "title": "Part IV: Hierarchy Summary and Applications",
+      "startLine": 123,
+      "endLine": 151,
+      "summary": "Maps the dependency chain (Young → Hölder → embedding, Radon-Nikodým → surjectivity), proves the Cauchy-Schwarz bound on $L^2$ functions, and shows the Hölder embedding is isometric at $p=2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization provides a definitive answer to whether Hölder's inequality suffices for the Riesz representation theorem: it gives exactly one of the two directions. The embedding $L^q \\hookrightarrow (L^p)^*$ follows from Hölder, while surjectivity requires the independent machinery of Radon-Nikodým. The $L^2$ case stands apart, resolved entirely by Hilbert space structure.",
+    "implications": "The result clarifies the logical dependencies within functional analysis: $L^p$ duality is not a single-tool theorem but requires the confluence of integration inequalities (Hölder) and measure-theoretic decomposition (Radon-Nikodým). This decomposition is pedagogically valuable and reflects how the theorem is typically proved in graduate textbooks (e.g., Rudin's Real and Complex Analysis, Theorem 6.16).",
+    "openQuestions": [
+      "Can Mathlib's Radon-Nikodým machinery (`MeasureTheory.SignedMeasure.rnDeriv`) be composed with $L^p$ membership to eliminate the surjectivity axiom?",
+      "Does the isometric embedding $L^q \\hookrightarrow (L^p)^*$ extend to a formalized proof that equality in Hölder characterizes when $f = c|g|^{q/p} \\cdot \\mathrm{sgn}(g)$?",
+      "Can the Riesz representation for $L^1$ (where $(L^1)^* \\cong L^\\infty$) be formalized, noting it requires $\\sigma$-finiteness?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "generalizes",
+      "description": "The discrete Cauchy-Schwarz inequality; this proof works at the integral/measure-theoretic level"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "extends",
+      "description": "The Bunyakovsky-Schwarz integral inequality; this proof places it within the $L^p$ duality framework"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01",
+      "relationship": "extends",
+      "description": "Hölder's inequality as a generalization of Cauchy-Schwarz; this proof uses Hölder for the Riesz embedding direction"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Riesz-Thorin interpolation from Hölder; a sibling application of Hölder to operator theory"
+    }
+  ],
   "leanFile": {
     "imports": ["Mathlib"],
     "lineCount": 137,


### PR DESCRIPTION
Enrichment pass for cauchy-schwarz-integral-oq-01-oq-01-oq-02 (quality: 6 → enriched, passes: 0 → 1).

## Changes
- **Created annotations.json** with 10 annotations covering all 4 proof parts
  - All annotations include `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`
- **Added historicalContext** tracing Riesz (1910), Fréchet-Riesz (1907), Radon-Nikodým (1930), Hölder (1889)
- **Expanded keyInsights** from 3 to 5, adding hierarchy and isometry observations
- **Added conclusion** with summary, implications, and 3 open questions
- **Added 5 sections** covering the full 151-line Lean file
- **Added cross-references** to 4 related gallery proofs (cauchy-schwarz, cauchy-schwarz-integral, cauchy-schwarz-integral-oq-01, cauchy-schwarz-integral-oq-01-oq-02)

## Axiom integrity
Verified: 1 axiom (`riesz_lp_surjective`) matches `axiomCount: 1` and `status: "axiomatized"`. No structure-encoded assumptions.