### PR TITLE
Enrich Recursive Computation of Unit Ball Volumes

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,1 +1,110 @@
-[]
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Open Question: Recursive Unit Ball Volume Computation",
+    "content": "This proof answers the question of whether unit ball volumes can be computed recursively, without direct Gamma function evaluation. The answer is yes: the two-step recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ reduces all volumes to elementary arithmetic on $\\pi$, starting from $\\omega_0 = 1$ and $\\omega_1 = 2$.",
+    "mathContext": "$\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$ is the volume of the unit $n$-ball. The recurrence eliminates the need to evaluate $\\Gamma$ at half-integer or integer arguments.",
+    "significance": "key",
+    "relatedConcepts": ["unit ball volume", "Gamma function", "recurrence relation"],
+    "prerequisites": ["Gamma function theory", "n-dimensional geometry"]
+  },
+  {
+    "id": "ann-omega-definition",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 29, "endLine": 32 },
+    "type": "definition",
+    "title": "Unit Ball Volume Definition",
+    "content": "Defines $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$, the standard closed-form expression for the volume of the unit $n$-ball. This matches the `unitBallVolume` definition in the parent file but is redefined locally for self-containment.",
+    "mathContext": "$\\omega_n = \\frac{\\pi^{n/2}}{\\Gamma(n/2+1)}$. For integer arguments $\\Gamma(k+1) = k!$, so $\\omega_{2k} = \\pi^k/k!$. For half-integers $\\Gamma(k+1/2) = (2k-1)!!/2^k \\cdot \\sqrt{\\pi}$.",
+    "significance": "key",
+    "relatedConcepts": ["Gamma function", "n-ball volume formula", "pi"],
+    "prerequisites": ["Gamma function", "real power function"]
+  },
+  {
+    "id": "ann-base-case-zero",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 34, "endLine": 40 },
+    "type": "technique",
+    "title": "Base Case: ω₀ = 1",
+    "content": "The 0-dimensional unit ball is a single point with volume 1. The proof unfolds the definition and uses $\\Gamma(1) = 1$ (Mathlib's `Gamma_one`) with $\\pi^0 = 1$. This is the even-dimension base case for the recurrence.",
+    "mathContext": "$\\omega_0 = \\pi^0/\\Gamma(1) = 1/1 = 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma function evaluation", "degenerate dimension"],
+    "prerequisites": ["Gamma_one"]
+  },
+  {
+    "id": "ann-base-case-one",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 41, "endLine": 52 },
+    "type": "technique",
+    "title": "Base Case: ω₁ = 2",
+    "content": "The 1-dimensional unit ball is the interval $[-1,1]$ with length 2. This is the more subtle base case, requiring $\\Gamma(3/2) = \\sqrt{\\pi}/2$. The proof chains: $\\Gamma(3/2) = (1/2)\\cdot\\Gamma(1/2) = \\sqrt{\\pi}/2$ (via `Gamma_add_one` and `Gamma_one_half_eq`), then $\\omega_1 = \\pi^{1/2}/(\\sqrt{\\pi}/2) = 2$.",
+    "mathContext": "$\\omega_1 = \\frac{\\sqrt{\\pi}}{\\Gamma(3/2)} = \\frac{\\sqrt{\\pi}}{\\sqrt{\\pi}/2} = 2$, where $\\Gamma(3/2) = \\frac{1}{2}\\Gamma(\\frac{1}{2}) = \\frac{\\sqrt{\\pi}}{2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma at half-integers", "Gamma_one_half_eq", "interval length"],
+    "prerequisites": ["Gamma function recurrence", "Gamma(1/2) = √π"]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 65 },
+    "type": "technique",
+    "title": "Positivity of Unit Ball Volumes",
+    "content": "Establishes $\\omega_n > 0$ for all $n$ as a prerequisite for the recurrence proof (where we divide by $\\omega_n$). The proof uses `rpow_pos_of_pos` for $\\pi^{n/2} > 0$ and `Gamma_pos_of_pos` for $\\Gamma(n/2+1) > 0$ (since $n/2 + 1 > 0$ for all $n \\in \\mathbb{N}$). A helper `gamma_half_pos` isolates the Gamma positivity fact.",
+    "mathContext": "$\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1) > 0$ since $\\pi > 0$ implies $\\pi^{n/2} > 0$, and $n/2+1 > 0$ implies $\\Gamma(n/2+1) > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity", "Gamma function positivity", "division well-definedness"],
+    "prerequisites": ["rpow_pos_of_pos", "Gamma_pos_of_pos"]
+  },
+  {
+    "id": "ann-main-recurrence",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 93 },
+    "type": "insight",
+    "title": "Main Theorem: ω_{n+2} = (2π/(n+2))·ω_n",
+    "content": "The central result. The proof has three algebraic phases: (1) cast arithmetic to rewrite $(n+2)/2 = n/2+1$, (2) split $\\pi^{n/2+1} = \\pi \\cdot \\pi^{n/2}$ via `rpow_add`, and (3) split $\\Gamma(n/2+2) = (n/2+1)\\cdot\\Gamma(n/2+1)$ via the Gamma recurrence `Gamma_add_one`. The remaining algebra is handled by `field_simp` and `ring`. The two-step nature means even and odd dimensions evolve along independent chains.",
+    "mathContext": "$\\omega_{n+2} = \\frac{\\pi^{(n+2)/2}}{\\Gamma((n+2)/2+1)} = \\frac{\\pi \\cdot \\pi^{n/2}}{(n/2+1)\\Gamma(n/2+1)} = \\frac{2\\pi}{n+2} \\cdot \\frac{\\pi^{n/2}}{\\Gamma(n/2+1)} = \\frac{2\\pi}{n+2} \\cdot \\omega_n$",
+    "significance": "key",
+    "relatedConcepts": ["Gamma functional equation", "rpow_add", "two-step recurrence", "cast arithmetic"],
+    "prerequisites": ["Gamma_add_one", "rpow_add", "field_simp"]
+  },
+  {
+    "id": "ann-omega-two",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 95, "endLine": 103 },
+    "type": "technique",
+    "title": "Computation: ω₂ = π (Area of Unit Disk)",
+    "content": "The first corollary: $\\omega_2 = (2\\pi/2)\\cdot\\omega_0 = \\pi \\cdot 1 = \\pi$. This recovers the classical area of the unit circle as a special case of the recurrence, connecting back to the root proof `area-of-circle`.",
+    "mathContext": "$\\omega_2 = \\frac{2\\pi}{0+2} \\cdot \\omega_0 = \\pi \\cdot 1 = \\pi$",
+    "significance": "supporting",
+    "relatedConcepts": ["area of circle", "unit disk"],
+    "prerequisites": ["omega_recurrence", "omega_zero"]
+  },
+  {
+    "id": "ann-higher-dims",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 105, "endLine": 121 },
+    "type": "technique",
+    "title": "Higher Dimensions: ω₃ through ω₅",
+    "content": "Demonstrates the recurrence's computability by calculating $\\omega_3 = 4\\pi/3$ (volume of unit 3-ball), $\\omega_4 = \\pi^2/2$, and $\\omega_5 = 8\\pi^2/15$. Each proof applies the recurrence once, substitutes the previously computed value, and closes with `push_cast; ring`. The pattern shows that the recurrence reduces each volume to a rational multiple of a power of $\\pi$.",
+    "mathContext": "$\\omega_3 = \\frac{2\\pi}{3}\\cdot 2 = \\frac{4\\pi}{3}$, $\\omega_4 = \\frac{2\\pi}{4}\\cdot\\pi = \\frac{\\pi^2}{2}$, $\\omega_5 = \\frac{2\\pi}{5}\\cdot\\frac{4\\pi}{3} = \\frac{8\\pi^2}{15}$",
+    "significance": "supporting",
+    "relatedConcepts": ["computability", "rational multiples of pi", "n-ball volumes"],
+    "prerequisites": ["omega_recurrence", "push_cast", "ring"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 123, "endLine": 151 },
+    "type": "context",
+    "title": "Summary and Answer to Open Question",
+    "content": "The proof summary confirms: YES, all unit ball volumes are recursively computable. The key insight is that the recurrence is a direct algebraic consequence of $\\Gamma(z+1) = z\\Gamma(z)$. An important correction is noted: the formula $(2\\pi/n)\\cdot\\omega_n$ sometimes cited has an off-by-two indexing error; the correct formula is $(2\\pi/(n+2))\\cdot\\omega_n$, as verified by the computation $\\omega_2 = \\pi$.",
+    "mathContext": "The recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ with base cases $\\omega_0 = 1$, $\\omega_1 = 2$ computes all unit ball volumes in $\\lfloor n/2 \\rfloor$ steps.",
+    "significance": "supporting",
+    "relatedConcepts": ["computability", "indexing convention", "off-by-two error"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -45,14 +45,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The volume of the unit n-ball $\\omega_n = \\pi^{n/2}/\\Gamma(n/2 + 1)$ is a fundamental constant in geometry and analysis. While the Gamma function provides a closed-form expression, the two-step recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ offers a purely algebraic computation requiring only multiplication and division, starting from $\\omega_0 = 1$ and $\\omega_1 = 2$. This recurrence is a direct consequence of the Gamma function's functional equation $\\Gamma(z+1) = z\\cdot\\Gamma(z)$.",
+    "historicalContext": "The volume of the unit $n$-ball $\\omega_n = \\pi^{n/2}/\\Gamma(n/2 + 1)$ is a fundamental constant whose formula dates to Dirichlet's 1839 work on multi-dimensional integrals, later refined by Schläfli (1852) in his studies of higher-dimensional geometry. The Gamma function $\\Gamma(z+1) = z\\cdot\\Gamma(z)$, discovered by Euler in 1729 as an extension of the factorial to non-integer arguments, provides the key structural identity. The two-step recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ is a folklore result that appears in various forms in analysis textbooks (e.g., Folland's 'Introduction to Partial Differential Equations', Stein and Shakarchi's 'Real Analysis'). A notable feature of the volume sequence is that $\\omega_n \\to 0$ as $n \\to \\infty$ — the unit ball becomes negligible in high dimensions, a phenomenon known as the 'curse of dimensionality' in statistics and machine learning.",
     "problemStatement": "Can the unit ball volumes $\\omega_n$ be computed for all $n$ via a recursive formula?",
     "text": "Proves the recurrence \u03c9_{n+2} = (2\u03c0/(n+2))\u00b7\u03c9_n for computing unit n-ball volumes.",
     "proofStrategy": "The proof unfolds $\\omega_{n+2}$ and $\\omega_n$ by definition, uses `push_cast` and `ring` for cast arithmetic, `rpow_add` to factor $\\pi^{(n+2)/2}$ into $\\pi \\cdot \\pi^{n/2}$, and `Gamma_add_one` to factor $\\Gamma(n/2+2)$ into $(n/2+1)\\cdot\\Gamma(n/2+1)$. Finally `field_simp` and `ring` close the algebraic identity.",
     "keyInsights": [
       "The recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ reduces to the Gamma function identity $\\Gamma(z+1) = z\\cdot\\Gamma(z)$ applied at $z = n/2 + 1$",
       "The two-step nature (even and odd dimensions evolve independently) reflects the factorization $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$ where the parity of $n$ determines whether we evaluate $\\Gamma$ at integers or half-integers",
-      "The formula $(2\\pi/n)\\cdot\\omega_n$ sometimes cited in the literature has an off-by-two indexing error; the correct formula is $(2\\pi/(n+2))\\cdot\\omega_n$, easily verified: $\\omega_2 = \\pi = (2\\pi/2)\\cdot 1 = \\pi$ from $\\omega_0 = 1$"
+      "The formula $(2\\pi/n)\\cdot\\omega_n$ sometimes cited in the literature has an off-by-two indexing error; the correct formula is $(2\\pi/(n+2))\\cdot\\omega_n$, easily verified: $\\omega_2 = \\pi = (2\\pi/2)\\cdot 1 = \\pi$ from $\\omega_0 = 1$",
+      "All unit ball volumes are rational multiples of powers of $\\pi$: $\\omega_n \\in \\mathbb{Q} \\cdot \\pi^{\\lfloor n/2 \\rfloor}$, a direct consequence of the recurrence multiplying by rational factors at each step",
+      "The proof technique — using `push_cast; ring` after applying `Gamma_add_one` and `rpow_add` — is a reusable pattern for any identity reducible to the Gamma functional equation"
     ],
     "prerequisites": [
       "Gamma function theory (functional equation)",


### PR DESCRIPTION
Enrichment pass for area-of-circle-oq-01-oq-02-oq-01-oq-01 (quality: 36 → enriched, passes: 0 → 1).

## Changes
- **Created 9 annotations** covering all 5 proof parts with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- **Expanded historicalContext** with Dirichlet (1839), Schläfli (1852), Euler (1729), curse of dimensionality
- **Added 2 new keyInsights** (5 total): rational multiples of π structure, reusable Gamma recurrence technique

## Axiom integrity
Verified: 0 axioms, 0 sorries, `status: "verified"`, `badge: "verified"` — all correct.