### PR TITLE
Gallery integrity: cayley-hamilton-minpoly-oq-02-oq-02 is fully verified

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jordan_normal_form#Uniqueness",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
     "tags": [
       "linear-algebra",
@@ -21,8 +21,8 @@
       "extension",
       "research"
     ],
-    "badge": "formalized",
-    "sorries": 3,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.dvd",
@@ -58,8 +58,8 @@
     ],
     "dateAdded": "2026-03-27",
     "axiomCount": 0,
-    "lineCount": 250,
-    "assumptions": "3 sorries: minpoly_matA and minpoly_matB minimality steps (degree classification of divisors of X^2), and intertwining constraint extraction (Fin 4 sum computation). Non-similarity proof (main result) is structurally complete.",
+    "lineCount": 390,
+    "assumptions": "None. All theorems fully proved including minpoly computations via UFD divisor classification and intertwining constraint extraction via Fin 4 case analysis.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -86,32 +86,32 @@
     {
       "id": "definitions",
       "title": "Counterexample Matrices",
-      "startLine": 36,
-      "endLine": 65,
+      "startLine": 59,
+      "endLine": 81,
       "summary": "Defines matA (Jordan type [2,2]: A(0,1)=A(2,3)=1, else 0) and matB (Jordan type [2,1,1]: B(0,1)=1, else 0) over an arbitrary field K.",
       "mathContext": "$A = \\begin{pmatrix} 0&1&0&0\\\\0&0&0&0\\\\0&0&0&1\\\\0&0&0&0 \\end{pmatrix}$, $B = \\begin{pmatrix} 0&1&0&0\\\\0&0&0&0\\\\0&0&0&0\\\\0&0&0&0 \\end{pmatrix}$"
     },
     {
       "id": "nilpotency",
       "title": "Nilpotency and Nonzero",
-      "startLine": 67,
-      "endLine": 95,
+      "startLine": 87,
+      "endLine": 109,
       "summary": "Proves A^2 = B^2 = 0 (both nilpotent of order at most 2) and A != 0, B != 0 (nilpotent of order exactly 2).",
       "mathContext": "$A^2 = B^2 = 0$ (entry-by-entry computation). $A \\neq 0$ since $A_{01} = 1$. $B \\neq 0$ since $B_{01} = 1$."
     },
     {
       "id": "same-minpoly",
       "title": "Same Minimal Polynomial X^2",
-      "startLine": 97,
-      "endLine": 168,
-      "summary": "Shows X^2 annihilates both matrices, X does not annihilate either, and deduces minpoly = X^2 for both. The minimality step (classifying monic divisors of X^2) has sorries.",
+      "startLine": 115,
+      "endLine": 228,
+      "summary": "Shows X^2 annihilates both matrices, X does not annihilate either, and deduces minpoly = X^2 for both. Minimality proved via UFD classification: minpoly divides X^2 with X prime, so minpoly = X^j; j != 0 (degree > 0) and j != 1 (A != 0), so j = 2.",
       "mathContext": "Since $A^2 = 0$, $\\text{minpoly}(A) \\mid X^2$. Since $A \\neq 0$, $\\text{minpoly}(A) \\nmid X$. The only monic divisors of $X^2$ are $\\{1, X, X^2\\}$; ruling out $1$ and $X$ gives $\\text{minpoly}(A) = X^2$."
     },
     {
       "id": "not-similar",
       "title": "Non-Similarity (Main Result)",
-      "startLine": 170,
-      "endLine": 240,
+      "startLine": 234,
+      "endLine": 350,
       "summary": "Proves A and B are not similar via the intertwining matrix argument: AP = PB forces det(P) = 0. Uses pigeonhole on the Leibniz formula.",
       "mathContext": "If $B = P^{-1}AP$ then $AP = PB$. Entry analysis shows $P_{1j} = P_{3j} = 0$ for $j \\neq 1$. In $\\det(P) = \\sum_\\sigma \\text{sgn}(\\sigma) \\prod_i P_{\\sigma(i),i}$, each term needs $\\sigma(\\{0,2,3\\}) \\subseteq \\{0,2\\}$, impossible by pigeonhole."
     }
@@ -135,9 +135,9 @@
       "Polynomial"
     ],
     "namespace": "SimilarCounterexample",
-    "lineCount": 250,
+    "lineCount": 390,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 16,
     "definitionCount": 2
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

- **Proof**: `cayley-hamilton-minpoly-oq-02-oq-02` (Counterexample: Same Minpoly and Charpoly, Not Similar)
- **Problem**: meta.json claimed 3 sorries and status `formalized`, but Lean source has 0 sorries — all theorems fully proved
- **Fixes**: status `formalized`→`verified`, badge `formalized`→`original`, sorries `3`→`0`, theoremCount `12`→`16`, lineCount `250`→`390`, corrected section line numbers, updated assumptions field

## Evidence

| Field | meta.json (before) | Lean source (actual) |
|-------|-------------------|---------------------|
| sorries | 3 | **0** |
| status | formalized | **verified** |
| badge | formalized | **original** |
| axiomCount | 0 | 0 (correct) |
| theoremCount | 12 | **16** |
| lineCount | 250 | **390** |
| True stubs | — | None |

## Tier Classification

**Tier A — Fully formalized theorem.** Core result (non-similarity via intertwining/pigeonhole) is independently proved. Mathlib dependencies are API-level (minpoly theory, determinant formula), not theorem-level.

---
Discovered during gallery integrity audit.