### PR TITLE
Gallery integrity: erdos-1131-oq-01 fix sorry field name

### DIFF
--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "sorryCount": 0,
+    "sorries": 0,
     "theoremCount": 11,
     "lineCount": 293,
     "assumptions": "1 axiom: erdos_1131_variance_conjecture (reformulation of OPEN Erdős conjecture in variance form: min ∫variance ≈ 2 - 3/n). All 11 theorems fully proved, 0 sorries. Key results: variance identity, integral decomposition, strict lower bound I > 2/n via epsilon-delta continuity argument.",
@@ -53,7 +53,7 @@
     ],
     "namespace": "Erdos1131OQ01",
     "axiomCount": 1,
-    "sorryCount": 0,
+    "sorries": 0,
     "theoremCount": 11,
     "lineCount": 293,
     "mainTheorems": [


### PR DESCRIPTION
## Summary

- **Proof**: `erdos-1131-oq-01` (Lagrange Basis Variance Decomposition)
- **Problem**: meta.json used `sorryCount` instead of `sorries`, causing the audit scanner to report -1 (field not found)
- **Fix**: Rename `sorryCount` → `sorries` in both `meta` and `leanFile` sections. Value (0) is correct.

## Evidence

Lean source has 0 sorries, 1 axiom (`erdos_1131_variance_conjecture` — open Erdős conjecture), 11 theorems all fully proved. Status `axiomatized`/`axiom` is correct.

---
Discovered during gallery integrity audit.