### PR TITLE
Gallery integrity: fix metadata counts for 2 proofs (#2)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
@@ -41,7 +41,7 @@
     ],
     "dateAdded": "2026-03-27",
     "axiomCount": 0,
-    "lineCount": 145,
+    "lineCount": 154,
     "assumptions": "0 axioms, 0 sorries. S₂ via CommGroup instance, S₃ via decide on derived series, S₄ via native_decide. Classification theorem combines with Mathlib's Equiv.Perm.not_solvable.",
     "mathlib_version": "4.26.0"
   },
@@ -116,7 +116,7 @@
       "Equiv"
     ],
     "namespace": "AbelRuffiniOQ04OQ02",
-    "lineCount": 145,
+    "lineCount": 154,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -105,7 +105,7 @@
     "imports": ["Mathlib"],
     "lineCount": 151,
     "axiomCount": 1,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Summary

- **abel-ruffini-oq-04-oq-02**: `lineCount` 145→154
- **cauchy-schwarz-integral-oq-01-oq-01-oq-02**: `theoremCount` 7→8

Both are LOW severity metadata count mismatches. No status/badge/sorry/axiom issues.

---
Discovered during gallery integrity audit.