### PR TITLE
Research: erdos-460 and erdos-456 — eliminate 8 axioms

### DIFF
--- a/proofs/Proofs/Erdos313Problem.lean
+++ b/proofs/Proofs/Erdos313Problem.lean
@@ -62,20 +62,49 @@ axiom primary_pseudoperfect_infinite :
 /- ## Verified Examples -/
 
 /-- m = 2, P = {2}: 1/2 = 1 − 1/2. -/
-axiom solution_2 : (2, ({2} : Finset ℕ)) ∈ erdos313Solutions
+theorem solution_2 : (2, ({2} : Finset ℕ)) ∈ erdos313Solutions := by
+  refine ⟨by norm_num, ⟨2, Finset.mem_singleton.mpr rfl⟩, ?_, ?_⟩
+  · intro p hp; rw [Finset.mem_singleton.mp hp]; decide
+  · simp [Finset.sum_singleton]; push_cast; norm_num
 
 /-- m = 6, P = {2, 3}: 1/2 + 1/3 = 5/6 = 1 − 1/6. -/
-axiom solution_6 : (6, ({2, 3} : Finset ℕ)) ∈ erdos313Solutions
+theorem solution_6 : (6, ({2, 3} : Finset ℕ)) ∈ erdos313Solutions := by
+  refine ⟨by norm_num, ⟨2, by simp⟩, ?_, ?_⟩
+  · intro p hp; simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl <;> decide
+  · simp only [Finset.sum_insert (by decide : (2:ℕ) ∉ ({3} : Finset ℕ)),
+               Finset.sum_singleton]; push_cast; norm_num
 
 /-- m = 42, P = {2, 3, 7}: 1/2 + 1/3 + 1/7 = 41/42 = 1 − 1/42. -/
-axiom solution_42 : (42, ({2, 3, 7} : Finset ℕ)) ∈ erdos313Solutions
+theorem solution_42 : (42, ({2, 3, 7} : Finset ℕ)) ∈ erdos313Solutions := by
+  refine ⟨by norm_num, ⟨2, by simp⟩, ?_, ?_⟩
+  · intro p hp; simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl | rfl <;> decide
+  · simp only [Finset.sum_insert (by decide : (2:ℕ) ∉ ({3, 7} : Finset ℕ)),
+               Finset.sum_insert (by decide : (3:ℕ) ∉ ({7} : Finset ℕ)),
+               Finset.sum_singleton]; push_cast; norm_num
 
 /-- m = 1806, P = {2, 3, 7, 43}: 1/2 + 1/3 + 1/7 + 1/43 = 1 − 1/1806. -/
-axiom solution_1806 : (1806, ({2, 3, 7, 43} : Finset ℕ)) ∈ erdos313Solutions
+theorem solution_1806 : (1806, ({2, 3, 7, 43} : Finset ℕ)) ∈ erdos313Solutions := by
+  refine ⟨by norm_num, ⟨2, by simp⟩, ?_, ?_⟩
+  · intro p hp; simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl | rfl | rfl <;> decide
+  · simp only [Finset.sum_insert (by decide : (2:ℕ) ∉ ({3, 7, 43} : Finset ℕ)),
+               Finset.sum_insert (by decide : (3:ℕ) ∉ ({7, 43} : Finset ℕ)),
+               Finset.sum_insert (by decide : (7:ℕ) ∉ ({43} : Finset ℕ)),
+               Finset.sum_singleton]; push_cast; norm_num
 
 /-- m = 47058, P = {2, 3, 11, 23, 31}:
   1/2 + 1/3 + 1/11 + 1/23 + 1/31 = 1 − 1/47058. -/
-axiom solution_47058 : (47058, ({2, 3, 11, 23, 31} : Finset ℕ)) ∈ erdos313Solutions
+theorem solution_47058 : (47058, ({2, 3, 11, 23, 31} : Finset ℕ)) ∈ erdos313Solutions := by
+  refine ⟨by norm_num, ⟨2, by simp⟩, ?_, ?_⟩
+  · intro p hp; simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl | rfl | rfl | rfl <;> decide
+  · simp only [Finset.sum_insert (by decide : (2:ℕ) ∉ ({3, 11, 23, 31} : Finset ℕ)),
+               Finset.sum_insert (by decide : (3:ℕ) ∉ ({11, 23, 31} : Finset ℕ)),
+               Finset.sum_insert (by decide : (11:ℕ) ∉ ({23, 31} : Finset ℕ)),
+               Finset.sum_insert (by decide : (23:ℕ) ∉ ({31} : Finset ℕ)),
+               Finset.sum_singleton]; push_cast; norm_num
 
 /- ## Structural Properties -/
 
@@ -100,5 +129,7 @@ axiom at_least_eight :
   1/p₁ + ··· + 1/pₖ + 1/m = 1,
 which is an Egyptian fraction representation of 1 using distinct
 denominators where all but possibly m are prime. -/
-axiom egyptian_fraction_form (m : ℕ) (P : Finset ℕ) (h : (m, P) ∈ erdos313Solutions) :
-  ∑ p ∈ P, (1 : ℚ) / p + 1 / m = 1
+theorem egyptian_fraction_form (m : ℕ) (P : Finset ℕ) (h : (m, P) ∈ erdos313Solutions) :
+    ∑ p ∈ P, (1 : ℚ) / p + 1 / m = 1 := by
+  have := h.2.2.2
+  linarith

--- a/proofs/Proofs/Erdos358Problem.lean
+++ b/proofs/Proofs/Erdos358Problem.lean
@@ -87,8 +87,11 @@ f(n) ≥ 2 for all sufficiently large n?
 def Erdos358Weak : Prop :=
   ∃ A : IntSequence, ∃ N₀ : ℤ, ∀ n ≥ N₀, consecutiveSumCount A n ≥ 2
 
-/-- Strong implies weak. -/
-axiom strong_implies_weak : Erdos358Strong → Erdos358Weak
+/-- Strong implies weak: if f(n) → ∞, then certainly f(n) ≥ 2 for all large n. -/
+theorem strong_implies_weak : Erdos358Strong → Erdos358Weak := by
+  intro ⟨A, hA⟩
+  obtain ⟨N, hN⟩ := Filter.tendsto_atTop_atTop.mp hA (2 : ℝ)
+  exact ⟨A, N, fun n hn => by exact_mod_cast hN n hn⟩
 
 /- ## Part IV: Known Observations -/
 

--- a/proofs/Proofs/Erdos460Problem.lean
+++ b/proofs/Proofs/Erdos460Problem.lean
@@ -154,8 +154,50 @@ noncomputable def largePrimeSum (n : ℕ) : ℝ :=
       (1 : ℝ) / (a : ℝ)
     else 0
 
-/-- Erdős also asked whether the restricted sums individually diverge. -/
-axiom erdos_460_restricted_question :
+/-
+## Section VIII: Structural Theorems
+-/
+
+/-- The smallPrimeDivisibleSum is bounded by sieveReciprocalSum: the small-prime condition
+    (a > 0 ∧ a < n ∧ ∃ p prime, p ≤ a ∧ p ∣ (n-a)) implies the full condition (a > 0 ∧ a < n),
+    so each term of the restricted sum is ≤ the corresponding term of the full sum. -/
+private lemma smallPrimeDivisibleSum_le (n : ℕ) :
+    smallPrimeDivisibleSum n ≤ sieveReciprocalSum n := by
+  unfold smallPrimeDivisibleSum sieveReciprocalSum
+  apply Finset.sum_le_sum
+  intro k _
+  dsimp only
+  split_ifs with h₁ h₂
+  · exact le_refl _
+  · exact absurd ⟨h₁.1, h₁.2.1⟩ h₂
+  · exact div_nonneg zero_le_one (Nat.cast_nonneg _)
+  · exact le_refl _
+
+/-- The largePrimeSum is bounded by sieveReciprocalSum: the large-prime condition
+    (a > 0 ∧ a < n ∧ leastPrimeFactor(n-a) > a) implies the full condition (a > 0 ∧ a < n),
+    so each term of the restricted sum is ≤ the corresponding term of the full sum. -/
+private lemma largePrimeSum_le (n : ℕ) :
+    largePrimeSum n ≤ sieveReciprocalSum n := by
+  unfold largePrimeSum sieveReciprocalSum
+  apply Finset.sum_le_sum
+  intro k _
+  dsimp only
+  split_ifs with h₁ h₂
+  · exact le_refl _
+  · exact absurd ⟨h₁.1, h₁.2.1⟩ h₂
+  · exact div_nonneg zero_le_one (Nat.cast_nonneg _)
+  · exact le_refl _
+
+/-- Erdős also asked whether the restricted sums individually diverge.
+    If either restricted sum diverges, the full sum diverges too,
+    since each restricted sum is bounded by the full sum (subset of non-negative terms). -/
+theorem erdos_460_restricted_question :
     (∀ M : ℝ, M > 0 → ∃ N₀ : ℕ, ∀ n ≥ N₀, smallPrimeDivisibleSum n > M) ∨
     (∀ M : ℝ, M > 0 → ∃ N₀ : ℕ, ∀ n ≥ N₀, largePrimeSum n > M) →
-    ErdosProblem460
+    ErdosProblem460 := by
+  intro h M hM
+  rcases h with hsmall | hlarge
+  · obtain ⟨N₀, hN₀⟩ := hsmall M hM
+    exact ⟨N₀, fun n hn => lt_of_lt_of_le (hN₀ n hn) (smallPrimeDivisibleSum_le n)⟩
+  · obtain ⟨N₀, hN₀⟩ := hlarge M hM
+    exact ⟨N₀, fun n hn => lt_of_lt_of_le (hN₀ n hn) (largePrimeSum_le n)⟩

--- a/proofs/Proofs/Stubs/Erdos456Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos456Problem.lean
@@ -55,45 +55,73 @@ noncomputable def smallestTotientDiv (n : ℕ) : ℕ :=
 axiom dirichlet_primes_mod1 (n : ℕ) (hn : 1 ≤ n) :
   ∀ N : ℕ, ∃ p : ℕ, N ≤ p ∧ p.Prime ∧ n ∣ (p - 1)
 
-/-- pₙ is prime -/
-axiom smallestPrimeMod1_prime (n : ℕ) (hn : 1 ≤ n) :
-  (smallestPrimeMod1 n).Prime
+/-- The set of primes ≡ 1 (mod n) is nonempty for n ≥ 1. -/
+private lemma primes_mod1_nonempty (n : ℕ) (hn : 1 ≤ n) :
+    Set.Nonempty {p : ℕ | p.Prime ∧ n ∣ (p - 1)} := by
+  obtain ⟨p, _, hp, hd⟩ := dirichlet_primes_mod1 n hn 0
+  exact ⟨p, hp, hd⟩
 
-/-- pₙ ≡ 1 (mod n) -/
-axiom smallestPrimeMod1_cong (n : ℕ) (hn : 1 ≤ n) :
-  n ∣ (smallestPrimeMod1 n - 1)
+/-- The set of positive m with n | φ(m) is nonempty for n ≥ 1. -/
+private lemma totient_div_nonempty (n : ℕ) (hn : 1 ≤ n) :
+    Set.Nonempty {m : ℕ | 0 < m ∧ n ∣ m.totient} := by
+  obtain ⟨p, _, hp, hd⟩ := dirichlet_primes_mod1 n hn 0
+  exact ⟨p, hp.pos, Nat.totient_prime hp ▸ hd⟩
 
-/-- pₙ is minimal among such primes -/
-axiom smallestPrimeMod1_minimal (n : ℕ) (hn : 1 ≤ n) (p : ℕ)
+/-- pₙ is prime: follows from sInf membership in the set of primes ≡ 1 (mod n). -/
+theorem smallestPrimeMod1_prime (n : ℕ) (hn : 1 ≤ n) :
+    (smallestPrimeMod1 n).Prime := by
+  unfold smallestPrimeMod1
+  exact (Nat.sInf_mem (primes_mod1_nonempty n hn)).1
+
+/-- pₙ ≡ 1 (mod n): follows from sInf membership. -/
+theorem smallestPrimeMod1_cong (n : ℕ) (hn : 1 ≤ n) :
+    n ∣ (smallestPrimeMod1 n - 1) := by
+  unfold smallestPrimeMod1
+  exact (Nat.sInf_mem (primes_mod1_nonempty n hn)).2
+
+/-- pₙ is minimal among primes ≡ 1 (mod n): follows from sInf being a lower bound. -/
+theorem smallestPrimeMod1_minimal (n : ℕ) (hn : 1 ≤ n) (p : ℕ)
     (hp : p.Prime) (hcong : n ∣ (p - 1)) :
-  smallestPrimeMod1 n ≤ p
+    smallestPrimeMod1 n ≤ p := by
+  unfold smallestPrimeMod1
+  exact Nat.sInf_le ⟨hp, hcong⟩
 
 /-
 # Part 3: Properties of smallestTotientDiv
 -/
 
-/-- mₙ is positive -/
-axiom smallestTotientDiv_pos (n : ℕ) (hn : 1 ≤ n) :
-  0 < smallestTotientDiv n
+/-- mₙ is positive: follows from sInf membership in the set of positive m with n | φ(m). -/
+theorem smallestTotientDiv_pos (n : ℕ) (hn : 1 ≤ n) :
+    0 < smallestTotientDiv n := by
+  unfold smallestTotientDiv
+  exact (Nat.sInf_mem (totient_div_nonempty n hn)).1
 
-/-- n | φ(mₙ) -/
-axiom smallestTotientDiv_divides (n : ℕ) (hn : 1 ≤ n) :
-  n ∣ (smallestTotientDiv n).totient
+/-- n | φ(mₙ): follows from sInf membership. -/
+theorem smallestTotientDiv_divides (n : ℕ) (hn : 1 ≤ n) :
+    n ∣ (smallestTotientDiv n).totient := by
+  unfold smallestTotientDiv
+  exact (Nat.sInf_mem (totient_div_nonempty n hn)).2
 
-/-- mₙ is minimal -/
-axiom smallestTotientDiv_minimal (n : ℕ) (hn : 1 ≤ n) (m : ℕ)
+/-- mₙ is minimal among positive m with n | φ(m): follows from sInf being a lower bound. -/
+theorem smallestTotientDiv_minimal (n : ℕ) (hn : 1 ≤ n) (m : ℕ)
     (hm : 0 < m) (hdiv : n ∣ m.totient) :
-  smallestTotientDiv n ≤ m
+    smallestTotientDiv n ≤ m := by
+  unfold smallestTotientDiv
+  exact Nat.sInf_le ⟨hm, hdiv⟩
 
 /-
 # Part 4: Known Results
 -/
 
 /-- mₙ ≤ pₙ always.
-    Proof sketch: φ(pₙ) = pₙ − 1 and n | pₙ − 1, so pₙ is in the set defining mₙ.
+    φ(pₙ) = pₙ − 1 and n | pₙ − 1, so pₙ is in the set defining mₙ.
     By minimality of mₙ, mₙ ≤ pₙ. -/
-axiom m_le_p (n : ℕ) (hn : 1 ≤ n) :
-  smallestTotientDiv n ≤ smallestPrimeMod1 n
+theorem m_le_p (n : ℕ) (hn : 1 ≤ n) :
+    smallestTotientDiv n ≤ smallestPrimeMod1 n := by
+  apply smallestTotientDiv_minimal n hn
+  · exact (smallestPrimeMod1_prime n hn).pos
+  · rw [Nat.totient_prime (smallestPrimeMod1_prime n hn)]
+    exact smallestPrimeMod1_cong n hn
 
 /-- Linnik's theorem: pₙ = O(n^L) for some constant L -/
 axiom linnik_bound :

--- a/src/data/proofs/erdos-313/meta.json
+++ b/src/data/proofs/erdos-313/meta.json
@@ -56,9 +56,9 @@
       "at_least_eight: lower bound on known solutions",
       "egyptian_fraction_form: connection to Egyptian fractions of 1"
     ],
-    "axiomCount": 11,
-    "lineCount": 104,
-    "assumptions": "11 axioms: erdos_313_conjecture, primary_pseudoperfect_infinite, solution_2, and 8 more. See Lean source for complete statements."
+    "axiomCount": 5,
+    "lineCount": 131,
+    "assumptions": "5 axioms: erdos_313_conjecture (open), primary_pseudoperfect_infinite (open), product_constraint, uniqueness, at_least_eight. 6 former axioms proved: 5 solutions verified by computation (norm_num), egyptian_fraction_form by algebra (linarith)."
   },
   "sections": [
     {
@@ -143,9 +143,9 @@
       "BigOperators"
     ],
     "namespace": null,
-    "lineCount": 104,
-    "axiomCount": 11,
-    "theoremCount": 0,
+    "lineCount": 131,
+    "axiomCount": 5,
+    "theoremCount": 6,
     "definitionCount": 2
   },
   "references": [

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -57,9 +57,9 @@
       "PositiveDensityConjecture definition: positive upper density",
       "Classical characterization: n = sum of >=2 consecutive iff n != 2^k"
     ],
-    "axiomCount": 5,
-    "lineCount": 183,
-    "assumptions": "5 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "axiomCount": 4,
+    "lineCount": 186,
+    "assumptions": "4 axioms: naturals_count_odd_divisors, power_of_two_obstruction, primesSeq, primesSeq_def. strong_implies_weak proved via Filter.tendsto_atTop_atTop. 3 sorries remain."
   },
   "overview": {
     "historicalContext": "Erdos Problem #358 was posed in 1977 [Er77c] and revisited in Erdos-Graham (1980). It asks a deceptively simple question about how many ways an integer can be written as a sum of consecutive terms from a fixed sequence.\n\nErdos himself remarked: \"This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me.\"\n\nThe problem connects to classical results about sums of consecutive integers (which relate to odd divisors) and to the Erdos-Moser conjecture (1963) about consecutive prime sums.",
@@ -168,8 +168,8 @@
     ],
     "namespace": "Erdos358",
     "lineCount": 183,
-    "axiomCount": 5,
-    "theoremCount": 4,
+    "axiomCount": 4,
+    "theoremCount": 5,
     "definitionCount": 8
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -102,9 +102,9 @@
         "relationship": "Primes in arithmetic progressions"
       }
     ],
-    "axiomCount": 12,
-    "lineCount": 168,
-    "assumptions": "12 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "axiomCount": 5,
+    "lineCount": 189,
+    "assumptions": "5 axioms: dirichlet_primes_mod1 (Dirichlet's theorem), linnik_bound (Linnik's theorem), erdos_strict_inequality (Erdős), m_over_n_diverges (Erdős), van_doorn_power_of_two. 7 former axioms proved from sInf properties + Dirichlet + Nat.totient_prime. 2 sorries remain (part2_implies_part1, part1_implies_infinitely_many)."
   },
   "overview": {
     "historicalContext": "Erdős Problem #456 compares two natural arithmetic functions of n. The first, pₙ, is the smallest prime congruent to 1 modulo n — guaranteed to exist by Dirichlet's theorem (1837) on primes in arithmetic progressions. The second, mₙ, is the smallest positive integer m such that n divides Euler's totient φ(m).\n\nPeter Gustav Lejeune Dirichlet (1805-1859) proved in 1837 that every arithmetic progression a, a+d, a+2d, ... with gcd(a,d) = 1 contains infinitely many primes. This landmark result — one of the great achievements of 19th-century number theory — ensures pₙ is well-defined. Yuri Vladimirovich Linnik (1915-1972) proved in 1944 that the smallest such prime satisfies pₙ ≤ n^L for some absolute constant L, now called Linnik's constant. The best known bound, L ≤ 5.18, was established by Triantafyllos Xylouris in his 2011 Bonn thesis, improving earlier work by Heath-Brown (L ≤ 5.5, 1992).\n\nThe trivial inequality mₙ ≤ pₙ holds because φ(pₙ) = pₙ - 1 is divisible by n (since pₙ ≡ 1 mod n), making pₙ a candidate for mₙ. Equality mₙ = pₙ occurs when n = q - 1 for a prime q: then mₙ must be at least q (since φ(m) divisible by q - 1 requires m to have a prime factor ≡ 1 mod (q-1), and q is the smallest such prime).\n\nVan Doorn observed that for n = 2^{2k+1}, we have φ(2n) = φ(2^{2k+2}) = 2^{2k+1} = n, so mₙ ≤ 2n. Since pₙ grows polynomially by Linnik's theorem, this gives explicit families where mₙ < pₙ. Erdős proved that mₙ < pₙ for infinitely many n and that mₙ/n → ∞ for almost all n.\n\nThe three open questions ask progressively stronger statements: (1) is mₙ < pₙ for almost all n (density 1), (2) does pₙ/mₙ → ∞ (the gap widens), and (3) are there infinitely many 'rigid' primes p where p - 1 is the unique n with mₙ = p?",
@@ -194,9 +194,9 @@
       "Nat"
     ],
     "namespace": "Erdos456",
-    "lineCount": 168,
-    "axiomCount": 12,
-    "theoremCount": 2,
+    "lineCount": 189,
+    "axiomCount": 5,
+    "theoremCount": 11,
     "definitionCount": 6
   },
   "references": [

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -54,9 +54,9 @@
       "Definition of the least-prime-factor filtered sum f(n) and its sufficiency axiom",
       "Splitting into smallPrimeDivisibleSum and largePrimeSum with Erdős's question about individual divergence"
     ],
-    "axiomCount": 5,
-    "lineCount": 161,
-    "assumptions": "5 axioms: sieve_greedy (provable from construction, needs nonemptiness proof), eggleton_erdos_selfridge (deep result), sieve_conjectured_bound (conjecture), filtered_sum_implies_full, erdos_460_restricted_question. sieve_initial proved from constructive definition."
+    "axiomCount": 4,
+    "lineCount": 204,
+    "assumptions": "4 axioms: sieve_greedy (provable from construction, needs nonemptiness proof), eggleton_erdos_selfridge (deep result), sieve_conjectured_bound (conjecture), filtered_sum_implies_full. sieve_initial proved from constructive definition. erdos_460_restricted_question proved via subset comparison of non-negative Finset sums."
   },
   "leanFile": {
     "imports": [
@@ -69,9 +69,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 161,
-    "axiomCount": 5,
-    "theoremCount": 1,
+    "lineCount": 204,
+    "axiomCount": 4,
+    "theoremCount": 4,
     "definitionCount": 8
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

Eliminate **15 axioms** across 4 problems via structural proofs, computation, and algebra:

### erdos-460 (1 axiom eliminated, 5 → 4)
- Prove `erdos_460_restricted_question`: if either restricted sum diverges, the full sieve reciprocal sum diverges (subset comparison of non-negative Finset sums via `Finset.sum_le_sum`)
- Add helper lemmas: `smallPrimeDivisibleSum_le`, `largePrimeSum_le`

### erdos-456 (7 axioms eliminated, 12 → 5)
- Prove all 6 `sInf` properties from definitions + Dirichlet's theorem: `smallestPrimeMod1_prime`, `_cong`, `_minimal` via `Nat.sInf_mem`/`Nat.sInf_le`; `smallestTotientDiv_pos`, `_divides`, `_minimal` via same
- Prove `m_le_p` from `Nat.totient_prime` + minimality
- Only 5 deep published results remain as axioms (Dirichlet, Linnik, etc.)

### erdos-313 (6 axioms eliminated, 11 → 5)
- Prove 5 solution axioms (`solution_2/6/42/1806/47058`) by computation: `Finset.sum` expansion + `push_cast` + `norm_num` for sum equations, `decide` for primality
- Prove `egyptian_fraction_form` by `linarith` from membership equation

### erdos-358 (1 axiom eliminated, 5 → 4)
- Prove `strong_implies_weak` via `Filter.tendsto_atTop_atTop`: if f(n) → ∞ (Strong), then f(n) ≥ 2 for all large n (Weak)

## Test plan
- [ ] `pnpm build` gallery builds
- [ ] Docker build for each modified proof file (when Docker available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)