### PR TITLE
Research: erdos-667, erdos-430 — false theorem removal + sorry elimination

### DIFF
--- a/proofs/Proofs/Erdos430Problem.lean
+++ b/proofs/Proofs/Erdos430Problem.lean
@@ -151,9 +151,51 @@ theorem erdos_385_equivalence :
     intro n hn
     obtain ⟨m, hm_gt1, hm_lt_n, hm_not_prime, hm_factors⟩ :=
       hN₀ n (le_trans (le_max_left _ _) hn)
-    -- The greedy sequence must contain m (or terminate at m)
-    -- because it starts above m and m is always a valid next choice
-    sorry
+    have hn2 : n ≥ 2 := le_trans (le_max_right _ _) hn
+    have hm_adm : IsAdmissible n m := ⟨by omega, hm_lt_n, hm_factors⟩
+    -- Key lemma: greedyNext n prev ≥ m when prev > m (m is always a valid candidate)
+    have greedyNext_ge_m : ∀ prev, m < prev → m ≤ greedyNext n prev := by
+      intro prev hprev
+      unfold greedyNext
+      apply Finset.le_sup (f := id)
+      simp only [Finset.mem_filter, Finset.mem_Icc, id]
+      exact ⟨⟨by omega, by omega⟩, decide_eq_true hm_adm⟩
+    -- greedyNext is strictly less than prev (picks from [1, prev-1])
+    have greedyNext_lt : ∀ prev, 0 < greedyNext n prev → greedyNext n prev < prev := by
+      intro prev hpos
+      unfold greedyNext at hpos ⊢
+      set S := (Finset.Icc 1 (prev - 1)).filter (fun m => decide (IsAdmissible n m) = true)
+      have hne : S.Nonempty := by
+        by_contra hempty
+        simp [Finset.not_nonempty_iff_eq_empty.mp hempty, Finset.sup_empty] at hpos
+      have : S.sup id ≤ prev - 1 :=
+        Finset.sup_le fun b hb => (Finset.mem_Icc.mp (Finset.mem_filter.mp hb).1).2
+      omega
+    -- Descent: the sequence reaches m by strong induction on the gap (current - m)
+    suffices ∃ k, greedySeq n k = m by
+      obtain ⟨k, hk⟩ := this
+      exact ⟨k, by rw [hk]; omega, by rw [hk]; exact hm_not_prime, by rw [hk]; exact hm_gt1⟩
+    -- By strong induction on (greedySeq n k - m): show if f(k) ≥ m, some k' has f(k') = m
+    have h0_ge : m ≤ greedySeq n 0 := by simp [greedySeq]; omega
+    suffices ∀ d, ∀ k₀, greedySeq n k₀ = m + d → ∃ k, greedySeq n k = m by
+      exact this (greedySeq n 0 - m) 0 (by omega)
+    intro d
+    induction d using Nat.strongRecOn with
+    | ind d ih =>
+      intro k₀ hk₀
+      rcases d with _ | d
+      · exact ⟨k₀, by omega⟩
+      · -- greedySeq n k₀ = m + d + 1 > m, so greedyNext picks from ≥ m
+        have h_next_ge : m ≤ greedySeq n (k₀ + 1) := by
+          show m ≤ greedyNext n (greedySeq n k₀)
+          exact greedyNext_ge_m (greedySeq n k₀) (by omega)
+        have h_next_lt : greedySeq n (k₀ + 1) < greedySeq n k₀ := by
+          show greedyNext n (greedySeq n k₀) < greedySeq n k₀
+          apply greedyNext_lt
+          have := greedyNext_ge_m (greedySeq n k₀) (by omega)
+          omega
+        -- The gap decreased: greedySeq n (k₀+1) - m < d + 1
+        exact ih (greedySeq n (k₀ + 1) - m) (by omega) (k₀ + 1) (by omega)
 
 /- ## Main Conjecture -/
 

--- a/proofs/Proofs/Erdos667Problem.lean
+++ b/proofs/Proofs/Erdos667Problem.lean
@@ -66,10 +66,45 @@ noncomputable def cliqueGuarantee (n p q : ℕ) : ℕ :=
 
 -- Notation: H(n; p, q) = cliqueGuarantee n p q
 
-/-- H is monotone in n: more vertices can only help. -/
+/-- H is monotone in n: more vertices can only help.
+    Proof sketch: S_n ⊆ S_{n+1} because for any G on Fin (n+1) with density,
+    pulling back to G' = G.comap castSucc on Fin n preserves the density condition
+    (edgeCount unchanged by injective embedding). Any m-clique in G' lifts to G. -/
+open scoped Classical in
 theorem cliqueGuarantee_mono_n (p q n : ℕ) :
     cliqueGuarantee n p q ≤ cliqueGuarantee (n + 1) p q := by
-  sorry
+  simp only [cliqueGuarantee]
+  by_cases hne : {m : ℕ | m ≤ n ∧ ∀ (G : SimpleGraph (Fin n)),
+      HasDensity G p q → ¬G.CliqueFree m}.Nonempty
+  · apply csSup_le_csSup
+    · exact ⟨n + 1, fun m ⟨hm, _⟩ => hm⟩
+    · exact hne
+    · -- S_n ⊆ S_{n+1}
+      intro m ⟨hm_le, hm⟩
+      refine ⟨by omega, fun G hd => ?_⟩
+      -- Pull back G to Fin n via castSucc: G' = G.comap castSucc
+      -- HasDensity G' p q because edgeCount (G.comap f) S = edgeCount G (S.map f)
+      -- for injective f (castSucc preserves the pair structure bijectively)
+      have hcf := hm (G.comap Fin.castSucc) (by
+        intro S hS
+        -- edgeCount (G.comap castSucc) S = edgeCount G (S.map castSucc) ≥ q
+        -- The filter on S×S with (a ≠ b ∧ G.Adj (f a) (f b)) bijects via f×f
+        -- with the filter on (S.map f)×(S.map f) with (a ≠ b ∧ G.Adj a b)
+        sorry)
+      -- Lift: ¬CliqueFree (G.comap castSucc) m → ¬CliqueFree G m
+      intro hcfG
+      apply hcf
+      intro s hs
+      apply hcfG (s.map ⟨Fin.castSucc, Fin.castSucc_injective n⟩)
+      refine ⟨?_, by rw [Finset.card_map]; exact hs.card_eq⟩
+      -- IsClique: castSucc preserves adjacency from G.comap castSucc to G
+      intro a ha b hb hab
+      simp only [Finset.coe_map, Set.mem_image, Function.Embedding.coeFn_mk] at ha hb
+      obtain ⟨a', ha', rfl⟩ := ha
+      obtain ⟨b', hb', rfl⟩ := hb
+      exact hs.isClique (Finset.mem_coe.mpr ha') (Finset.mem_coe.mpr hb')
+        (fun h => hab (congrArg Fin.castSucc h))
+  · rw [Set.not_nonempty_iff_eq_empty.mp hne, sSup_empty]; exact bot_le
 
 /-- H is monotone in q: more edges per p-set yields larger cliques.
     Proof: HasDensity G p (q+1) implies HasDensity G p q, so the density
@@ -109,20 +144,46 @@ theorem cliqueGuarantee_le_n (n p q : ℕ) :
 The function c(p,q) has known values at the endpoints.
 -/
 
-/-- When q = C(p-1, 2) + 1, every p-set is a clique, forcing G to be complete.
-    Hence H(n; p, q) = n.
-    Proof: C(p-1,2)+1 edges in a p-set exceeds the maximum for non-complete
-    graphs, forcing all p-sets (hence all pairs) to be adjacent. -/
-theorem cliqueGuarantee_max (n p : ℕ) (hp : 2 ≤ p) :
-    cliqueGuarantee n p (Nat.choose (p - 1) 2 + 1) = n := by
-  sorry
+/-- REMOVED (FALSE): Previously claimed H(n; p, C(p-1,2)+1) = n (i.e., graph must
+    be complete). Counterexample: C₄ (4-cycle on Fin 4) satisfies HasDensity 3 2
+    (every triple spans exactly 2 edges) but has clique number 2, not 4.
+
+    The correct fact is that the *exponent* c(p, C(p-1,2)+1) = 1, meaning H(n) ~ n
+    (grows linearly), but H(n) ≠ n exactly. This is captured by axiom `cpq_at_max`.
+
+    For p=3, q=C(2,2)+1=2: the complement of any satisfying graph is a matching,
+    giving clique number ⌈n/2⌉, so c(3,2) = lim inf log(⌈n/2⌉)/log(n) = 1. -/
 
 /-- When q = 0, there is no constraint, so H(n; p, 0) = 1 trivially.
     Every graph has at least one vertex (when n ≥ 1), forming a trivial 1-clique.
-    The empty graph on n vertices shows we can't guarantee 2-cliques. -/
+    The empty graph on n vertices shows we can't guarantee 2-cliques.
+    Proof: S = {m ≤ n | ∀ G, ¬CliqueFree G m} = {0, 1} since the empty graph
+    is CliqueFree m for m ≥ 2, and every nonempty graph has a 0-clique and 1-clique. -/
+open scoped Classical in
 theorem cliqueGuarantee_zero (n p : ℕ) (hn : 1 ≤ n) :
     cliqueGuarantee n p 0 = 1 := by
-  sorry
+  simp only [cliqueGuarantee]
+  apply le_antisymm
+  · -- Upper bound: sSup S ≤ 1
+    apply csSup_le
+    · -- S is nonempty: 0 ∈ S (empty set is a 0-clique in any graph)
+      exact ⟨0, Nat.zero_le n, fun G _ hcf =>
+        hcf ∅ ⟨Set.pairwise_empty _, rfl⟩⟩
+    · -- All elements of S are ≤ 1
+      intro m ⟨_, hm⟩
+      by_contra hgt
+      push_neg at hgt
+      -- m ≥ 2: the empty graph ⊥ satisfies HasDensity but is CliqueFree m
+      apply hm (⊥ : SimpleGraph (Fin n)) (fun _ _ => Nat.zero_le _)
+      -- Goal: CliqueFree ⊥ m
+      intro s hs
+      obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp (by rw [hs.card_eq]; omega)
+      exact hs.isClique (Finset.mem_coe.mpr ha) (Finset.mem_coe.mpr hb) hab
+  · -- Lower bound: 1 ≤ sSup S
+    apply le_csSup ⟨n, fun m ⟨hm, _⟩ => hm⟩
+    -- 1 ∈ S: singleton {⟨0, _⟩} is a 1-clique in any graph on Fin n (n ≥ 1)
+    exact ⟨hn, fun G _ hcf =>
+      hcf {⟨0, by omega⟩} ⟨Set.pairwise_singleton _ _, Finset.card_singleton _⟩⟩
 
 /-- Extended monotonicity: H(n; p, q1) ≤ H(n; p, q2) for q1 ≤ q2. -/
 theorem cliqueGuarantee_mono_q_general (n p q1 q2 : ℕ) (h : q1 ≤ q2) :

--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -17,13 +17,13 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 430,
     "erdosUrl": "https://erdosproblems.com/430",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "assumptions": "2 axioms: erdos_430_conjecture (composites appear for large n), small_n_all_prime (small n can be all-prime). 1 sorry remaining in greedy sequence containment proof.",
-    "lineCount": 172,
+    "assumptions": "2 axioms: erdos_430_conjecture (the open conjecture: composites appear for large n), small_n_all_prime (small n can be all-prime). 0 sorries — equivalence with Problem #385 fully proved via greedy descent argument.",
+    "lineCount": 214,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-430.json
+++ b/src/data/research/problems/erdos-430.json
@@ -29,11 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Made greedySeq computable. Proved example_n8 by native_decide. Axioms 4->3.",
+    "progressSummary": "COMPLETE: 0 sorries, equivalence fully proved. Only axioms are the open conjecture and small_n_all_prime.",
     "builtItems": [
       "Decidable instance for allPrimeFactorsExceed in Erdos430Problem.lean:37-49",
       "Decidable instance for IsAdmissible in Erdos430Problem.lean:56-57",
-      "Proved example_n8 in Erdos430Problem.lean:86"
+      "Proved example_n8 in Erdos430Problem.lean:86",
+      "PROVED backward direction of erdos_385_equivalence (was sorry)",
+      "greedyNext_ge_m: greedy next ≥ m when m is admissible and prev > m",
+      "greedyNext_lt: greedy next < prev (picks from [1, prev-1])"
     ],
     "insights": [
       "greedySeq uses noncomputable Finset.sup with decide on universal quantifier - not computable",
@@ -42,7 +45,9 @@
       "Provided Decidable instance for allPrimeFactorsExceed via bounded quantification over Finset.range",
       "Added explicit Decidable instance for IsAdmissible",
       "Removed noncomputable from greedyNext, greedySeq - now fully computable",
-      "example_n8 proved by native_decide (greedySeq 8 0 = 7, greedySeq 8 1 = 5)"
+      "example_n8 proved by native_decide (greedySeq 8 0 = 7, greedySeq 8 1 = 5)",
+      "erdos_385_equivalence fully proved: backward direction via greedy descent — if admissible composite m exists, greedy sequence reaches it since greedyNext ≥ m when prev > m",
+      "Strong induction on gap (current - m): sequence strictly decreases while bounded below by m, must reach m"
     ],
     "mathlibGaps": [],
     "nextSteps": [],

--- a/src/data/research/problems/erdos-667.json
+++ b/src/data/research/problems/erdos-667.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 2 of 5 sorry theorems (cliqueGuarantee_le_n, cliqueGuarantee_mono_q). 3 sorries remain. 8 axioms unchanged. Aristotle companion file created.",
+    "progressSummary": "PROGRESS: 3S→1S, false theorem removed (C₄ counterexample). Proved cliqueGuarantee_zero and cliqueGuarantee_mono_n (1 sorry remaining on edgeCount equality).",
     "builtItems": [
       "Proved cliqueGuarantee_pos from other axioms (axiom elimination: 15->14)",
       "Added cliqueGuarantee_mono_q_general: extended monotonicity for H",
@@ -42,7 +42,10 @@
       "p4_ramsey_upper: proved (c(4,1) ≤ 2/5)",
       "Proved cliqueGuarantee_le_n in Erdos667Problem.lean (was sorry)",
       "Proved cliqueGuarantee_mono_q in Erdos667Problem.lean (was sorry)",
-      "Created Erdos667Aristotle.lean companion file with 6 targets"
+      "Created Erdos667Aristotle.lean companion file with 6 targets",
+      "PROVED cliqueGuarantee_zero in Erdos667Problem.lean (was sorry)",
+      "PROVED cliqueGuarantee_mono_n structure (modulo edgeCount equality under injective pullback)",
+      "REMOVED false theorem cliqueGuarantee_max with C₄ counterexample documentation"
     ],
     "insights": [
       "cliqueGuarantee_pos is derivable from cliqueGuarantee_zero + cliqueGuarantee_mono_q by induction on q",
@@ -57,14 +60,15 @@
       "cliqueGuarantee_le_n: sSup of {m | m ≤ n ∧ ...} is ≤ n — proved via csSup_le or sSup_empty/bot_le",
       "cliqueGuarantee_mono_q: set for q ⊆ set for q+1 (strengthening antecedent) — proved via csSup_le_csSup",
       "Remaining 3 sorries require graph constructions (empty graph, vertex embedding) — submitted to Aristotle",
-      "cpq axiom elimination would require defining cpq as Filter.liminf — major future task eliminating 5 of 8 axioms"
+      "cpq axiom elimination would require defining cpq as Filter.liminf — major future task eliminating 5 of 8 axioms",
+      "cliqueGuarantee_max is FALSE: C₄ (4-cycle) satisfies HasDensity(3,2) with clique number 2, not 4. H(n)≠n but c(p,q_max)=1 is correct (liminf exponent).",
+      "cliqueGuarantee_zero PROVED: sSup argument via le_antisymm — empty graph counterexample for m≥2, singleton for 1-clique",
+      "For p=3,q=2: complement of any satisfying graph is a matching → clique number ⌈n/2⌉ → c(3,2)=1"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Define cliqueGuarantee as proper Lean definition to eliminate more axioms (cliqueGuarantee itself, mono_q, le_n, zero, mono_n)",
-      "Define cpq using liminf from Mathlib.Topology.Algebra.Order.LiminfLimsup to eliminate cpq axioms",
-      "Investigate whether cpq_mono_q can be derived from the definition of cpq + cliqueGuarantee_mono_q",
-      "Create Aristotle companion file with routine lemmas for automated proof search"
+      "Complete the edgeCount equality lemma in cliqueGuarantee_mono_n (injective pullback preserves filtered pair count)",
+      "Consider defining cpq via Filter.liminf to eliminate cpq axioms (major infrastructure)"
     ],
     "markdown": "# Erdős #667 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $p,q\\geq 1$ be fixed integers. We define $H(n)=H(N;p,q)$ to be the largest $m$ such that any graph on $n$ vertices where every set of $p$ vertices spans at least $q$ edges must contain a complete graph on $m$ vertices.\nIs\\[c(p,q)=\\liminf \\frac{\\log H(n)}{\\log n}\\]a strictly increasing function of $q$ for $1\\leq q\\leq \\binom{p-1}{2}+1$?\n\n\n\nA problem of Erd\\H{o}s, Faudree, Rousseau, and Schelp.\n\nWhen $q=1$ this corresponds exactly to the classical Ramsey problem, and hence for example\\[\\frac{1}{p-1}\\leq c(p,1) \\leq \\frac{2}{p+1}.\\]It is easy to see that if $q=\\binom{p-1}{2}+1$ then $c(p,q)=1$. Erd\\H{o}s, Faudree, Rousseau, and Schelp have shown that $c(p,\\binom{p-1}{2})\\leq 1/2$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #666\n- Problem #668\n- Problem #39\n- Problem #1\n\n## References\n\n- Er97f\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },


### PR DESCRIPTION
## Summary
### erdos-667: Remove false theorem, prove 2 sorries (3S→1S)
- **REMOVED** `cliqueGuarantee_max` (FALSE): C₄ (4-cycle on Fin 4) satisfies HasDensity(3, 2) with clique number 2, not 4. The axiom `cpq_at_max` (liminf exponent = 1) remains correct.
- **PROVED** `cliqueGuarantee_zero`: H(n; p, 0) = 1 via `le_antisymm` — empty graph ⊥ is CliqueFree for m ≥ 2, singleton {⟨0, _⟩} is a 1-clique for n ≥ 1. This enables the `cliqueGuarantee_pos` proof chain.
- **PROVED** `cliqueGuarantee_mono_n` (modulo 1 sorry on edgeCount equality): pulls back G on Fin (n+1) to G.comap castSucc on Fin n, preserving density; cliques lift via the injective embedding.
- **Net**: 3 sorries → 1 sorry, 1 false theorem identified and removed

### erdos-430: Prove equivalence backward direction (1S→0S)
- **PROVED** backward direction of `erdos_385_equivalence`: if there exists an admissible composite m < n, the greedy large-factor sequence must contain it.
- Proof by descent: `greedyNext n prev ≥ m` when `prev > m` (m is always a valid candidate), and `greedyNext < prev` (picks from [1, prev-1]). Strong induction on (current - m).
- **Net**: 1 sorry → 0 sorries

## Test plan
- [ ] Verify Lean compilation via Docker build / CI
- [ ] Check erdos-667: 435 lines, 8A, 1S
- [ ] Check erdos-430: 214 lines, 2A, 0S

🤖 Generated with [Claude Code](https://claude.com/claude-code)