### PR TITLE
Gallery integrity: erdos-667 sorry count 3→1

### DIFF
--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -16,12 +16,12 @@
       "clique-numbers"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 667,
     "erdosUrl": "https://erdosproblems.com/667",
     "erdosProblemStatus": "open",
     "axiomCount": 8,
-    "lineCount": 374,
+    "lineCount": 435,
     "dateAdded": "2026-02-10",
     "mathlibDependencies": [
       {
@@ -58,7 +58,7 @@
       "Extremal graph theory: Turán-type density conditions",
       "Combinatorics: binomial coefficients C(n,k)"
     ],
-    "assumptions": "8 axiom declarations (cpq, cpq_nonneg, cpq_le_one, cpq_mono_q, cpq_lower_ramsey, cpq_upper_ramsey, cpq_at_max, efrs_bound) and 3 sorries (cliqueGuarantee_mono_n, cliqueGuarantee_max, cliqueGuarantee_zero). Proved cliqueGuarantee_le_n (sSup bound) and cliqueGuarantee_mono_q (subset of sSup sets). Aristotle companion file created for remaining sorries.",
+    "assumptions": "8 axiom declarations (cpq, cpq_nonneg, cpq_le_one, cpq_mono_q, cpq_lower_ramsey, cpq_upper_ramsey, cpq_at_max, efrs_bound) and 1 sorry (cliqueGuarantee_mono_n: comap castSucc density transfer). cliqueGuarantee_zero and cliqueGuarantee_max resolved.",
     "mathlib_version": "4.26.0"
   },
   "crossReferences": [
@@ -188,7 +188,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos667",
-    "lineCount": 374,
+    "lineCount": 435,
     "axiomCount": 8,
     "theoremCount": 30,
     "definitionCount": 4


### PR DESCRIPTION
## Summary

- **Proof**: `erdos-667` (Clique Density Exponent)
- **Problem**: meta.json claimed 3 sorries but Lean source has only 1. Two sorries (`cliqueGuarantee_zero`, `cliqueGuarantee_max`) were resolved in recent research commits.
- **Fixes**: `sorries` 3→1, `lineCount` 374→435, updated `assumptions` field

## Evidence

| Field | Before | After |
|-------|--------|-------|
| sorries | 3 | **1** (only `cliqueGuarantee_mono_n` remains) |
| lineCount | 374 | **435** |

---
Discovered during gallery integrity audit.