### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -6286,19 +6286,21 @@
     },
     {
       "slug": "cauchy-schwarz-oq-01-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-26T20:00:24.433Z",
-      "status": "active",
-      "lastUpdate": "2026-03-26T20:00:24.433Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:04:39.175Z",
+      "completed": "2026-03-27T10:04:39.175Z"
     },
     {
       "slug": "cayley-hamilton-minpoly-oq-02-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-26T20:00:24.433Z",
-      "status": "active",
-      "lastUpdate": "2026-03-26T20:00:24.433Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:04:39.174Z",
+      "completed": "2026-03-27T10:04:39.173Z"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (16 added, 268 updated, 1813 total iterations)
- Update research problem JSON files with latest metadata
- Update gallery proof annotations
- Update research registry

Automated sync from deployer agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)