### PR TITLE
Gallery integrity: fix triangle-inequality-oq-03 metadata

### DIFF
--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical / Krasner / Ostrowski (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Ultra/Basic.html",
     "date": "1913 / 1946",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "geometry",
       "analysis",
@@ -18,9 +18,9 @@
       "topology"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ03.lean",
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 255,
     "mathlibDependencies": [
       {
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
-    "assumptions": "1 axiom declaration, 0 sorries. See the Lean source for details."
+    "assumptions": "No axiom declarations, 0 sorries. Fully verified."
   },
   "overview": {
     "historicalContext": "The study of non-Archimedean analysis began with Kurt Hensel's invention of p-adic numbers in 1897, motivated by analogies between number fields and function fields. Alexander Ostrowski (1916) classified all absolute values on the rationals: they are either the usual absolute value, a p-adic absolute value, or the trivial absolute value. This classification theorem shows that the ultrametric inequality is not an exotic curiosity but governs half of all possible notions of 'distance' on the rationals.\n\nThe ultrametric inequality d(x,z) ≤ max(d(x,y), d(y,z)) — strictly stronger than the usual d(x,z) ≤ d(x,y) + d(y,z) — was studied systematically by Marc Krasner (1940s) who developed the theory of ultrametric spaces and their striking topological properties: every point inside a ball is its center, balls are clopen (both open and closed), and distinct balls of equal radius are disjoint.\n\nThese 'strange' properties have profound consequences in number theory: the p-adic integers form a compact open subring (impossible over ℝ), p-adic analysis has no Archimedean property (|n|_p ≤ 1 for all integers), and Hensel's lemma provides a p-adic Newton's method with guaranteed convergence. Today, p-adic geometry underlies the Langlands program, perfectoid spaces (Scholze, Fields Medal 2018), and modern arithmetic geometry.",
@@ -189,7 +189,7 @@
   "leanFile": {
     "lineCount": 255,
     "structureCount": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 15,
     "lemmaCount": 0,
     "defCount": 0,


### PR DESCRIPTION
## Fix

Correct axiomCount and status for triangle-inequality-oq-03. The Lean source has 0 `axiom` declarations and 0 sorries — the word "axiom" only appears in docstring comments describing the ultrametric axiom of metric spaces.

## Evidence

**Before**: `axiomCount: 1`, `status: "axiomatized"`, `badge: "axiom"` (in both meta and leanFile sections)
**After**: `axiomCount: 0`, `status: "verified"`, `badge: "verified"`

**Verification**: No `axiom` keyword outside of block comments in `Proofs/TriangleInequalityOQ03.lean`. No sorry statements outside comments.

---
Automated fix by lean-mechanic agent.