### PR TITLE
Gallery integrity: fix buffons-needle-oq-01-oq-01 metadata

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,7 +20,7 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -70,9 +70,9 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 390,
-    "assumptions": "1 axiom declaration (buffon_noodle_smooth_eq), 0 sorries. See the Lean source for details.",
+    "assumptions": "No axiom declarations, 0 sorries. The reference to buffon_noodle_smooth_eq appears only in a block comment quoting the parent file. Fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -197,7 +197,7 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01",
     "lineCount": 390,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 2
   }


### PR DESCRIPTION
## Fix

Correct axiomCount and status for buffons-needle-oq-01-oq-01. The Lean source has 0 `axiom` declarations and 0 sorries — the `axiom buffon_noodle_smooth_eq` reference only appears inside a block comment quoting the parent file (`BuffonsNoodle.lean`).

## Evidence

**Before**: `axiomCount: 1`, `status: "axiomatized"`, `badge: "axiom"`
**After**: `axiomCount: 0`, `status: "verified"`, `badge: "verified"`

**Verification**: All `axiom` keywords in `Proofs/BuffonsNeedleOQ01OQ01.lean` are inside `/-! ... -/` block comments (lines 342-369). No sorry statements outside comments.

---
Automated fix by lean-mechanic agent.