### PR TITLE
Research: erdos-183 — prove R(3,3) = 6

### DIFF
--- a/proofs/Proofs/Erdos183Problem.lean
+++ b/proofs/Proofs/Erdos183Problem.lean
@@ -15,6 +15,12 @@ a monochromatic triangle.
 
 **Status:** OPEN
 
+**Proved in this file:**
+- R(3;1) = 3 (trivial: 1 color)
+- R(3;2) = 6 (classical R(3,3): pigeonhole upper bound + C₅ lower bound)
+- Monotonicity: k₁ ≤ k₂ → R(3;k₁) ≤ R(3;k₂)
+- R(3;k) ≥ 3 for all k ≥ 1
+
 **Reference:** [Er61], [ACPPRT21]
 
 Adapted from erdosproblems.com (Apache 2.0 License)
@@ -108,8 +114,112 @@ theorem R3k_one : R3k 1 = 3 := by
         simp only [Fin.mk.injEq]; omega
       rcases this with rfl | rfl | rfl <;> contradiction
 
-/-- R(3;2) = 6 is the classical Ramsey number R(3,3) -/
-axiom R3k_two : R3k 2 = 6
+/-- Pigeonhole for 5 items in 2 bins: at least 3 share a value.
+    Used to find 3 same-colored edges from a vertex in K_6. -/
+private lemma pigeonhole_five_two (f : Fin 5 → Fin 2) :
+    ∃ (color : Fin 2) (i j k : Fin 5), i ≠ j ∧ j ≠ k ∧ i ≠ k ∧
+      f i = color ∧ f j = color ∧ f k = color := by
+  native_decide
+
+/-- In Fin 2, if x ≠ c then x equals the other value. -/
+private lemma fin2_other {x c : Fin 2} (h : x ≠ c) : x = (1 : Fin 2) - c := by
+  fin_cases x <;> fin_cases c <;> simp_all
+
+/-- Given vertex v₀ and three neighbors u₁,u₂,u₃ all connected to v₀ by the same color,
+    there must be a monochromatic triangle (either with v₀ or among u₁,u₂,u₃).
+    This is the key step in proving R(3,3) = 6. -/
+private lemma triangle_from_three_neighbors {n : ℕ} (c : EdgeColoring n 2)
+    (v₀ u₁ u₂ u₃ : Fin n)
+    (h01 : v₀ ≠ u₁) (h02 : v₀ ≠ u₂) (h03 : v₀ ≠ u₃)
+    (h12 : u₁ ≠ u₂) (h23 : u₂ ≠ u₃) (h13 : u₁ ≠ u₃)
+    (color : Fin 2)
+    (hc1 : c (v₀, u₁) = color) (hc2 : c (v₀, u₂) = color) (hc3 : c (v₀, u₃) = color) :
+    HasSomeMonochromaticTriangle c := by
+  -- Check edges among u₁,u₂,u₃. If any has `color`, we get a triangle with v₀.
+  -- If none does, all three have the other color → monochromatic triangle {u₁,u₂,u₃}.
+  by_cases h_e12 : c (u₁, u₂) = color
+  · exact ⟨color, v₀, u₁, u₂, h01, h12, h02, hc1, h_e12, hc2⟩
+  by_cases h_e23 : c (u₂, u₃) = color
+  · exact ⟨color, v₀, u₂, u₃, h02, h23, h03, hc2, h_e23, hc3⟩
+  by_cases h_e13 : c (u₁, u₃) = color
+  · exact ⟨color, v₀, u₁, u₃, h01, h13, h03, hc1, h_e13, hc3⟩
+  · -- All three edges have the other color
+    exact ⟨(1 : Fin 2) - color, u₁, u₂, u₃, h12, h23, h13,
+      fin2_other h_e12, fin2_other h_e23, fin2_other h_e13⟩
+
+/-- Helper: no three distinct elements exist in Fin m for m < 3. -/
+private lemma no_three_distinct_lt3 {m : ℕ} (hm : m < 3) (i j l : Fin m)
+    (hij : i ≠ j) (hjl : j ≠ l) (hil : i ≠ l) : False := by
+  interval_cases m
+  · exact i.elim0
+  · exact hij (Subsingleton.elim i j)
+  · have : i = j ∨ i = l ∨ j = l := by
+      rcases i with ⟨i, hi⟩; rcases j with ⟨j, hj⟩; rcases l with ⟨l, hl⟩
+      simp only [Fin.mk.injEq]; omega
+    rcases this with rfl | rfl | rfl <;> contradiction
+
+/-- R(3;2) = 6 is the classical Ramsey number R(3,3).
+    Proof: Upper bound by pigeonhole (vertex with 5 edges → 3 same color → forced triangle).
+    Lower bound: exhibit triangle-free 2-colorings for K₃, K₄, K₅. -/
+theorem R3k_two : R3k 2 = 6 := by
+  unfold R3k
+  rw [dif_pos (show (2 : ℕ) ≥ 1 from by omega)]
+  apply Nat.find_eq_iff.mpr
+  refine ⟨?_, ?_⟩
+  · -- UPPER BOUND: ForcesMonochromaticTriangle 6 2
+    intro _ c _hsym
+    -- Consider edges from vertex 0 to the 5 other vertices
+    let f : Fin 5 → Fin 2 := fun i => c (⟨0, by omega⟩, ⟨i.val + 1, by omega⟩)
+    -- Pigeonhole: some color appears on ≥ 3 of these 5 edges
+    obtain ⟨color, i, j, k, hij, hjk, hik, hci, hcj, hck⟩ := pigeonhole_five_two f
+    -- Apply the triangle lemma to vertex 0 and the three same-colored neighbors
+    exact triangle_from_three_neighbors c
+      ⟨0, by omega⟩ ⟨i.val + 1, by omega⟩ ⟨j.val + 1, by omega⟩ ⟨k.val + 1, by omega⟩
+      (by intro h; simp [Fin.ext_iff] at h; omega)
+      (by intro h; simp [Fin.ext_iff] at h; omega)
+      (by intro h; simp [Fin.ext_iff] at h; omega)
+      (by intro h; simp [Fin.ext_iff] at h; exact hij (Fin.ext (by omega)))
+      (by intro h; simp [Fin.ext_iff] at h; exact hjk (Fin.ext (by omega)))
+      (by intro h; simp [Fin.ext_iff] at h; exact hik (Fin.ext (by omega)))
+      color hci hcj hck
+  · -- LOWER BOUND: ∀ m < 6, ¬ForcesMonochromaticTriangle m 2
+    intro m hm hf
+    interval_cases m
+    -- m = 0: Fin 0 is empty
+    · obtain ⟨_, i, _, _, _, _, _, _, _, _⟩ :=
+        hf (by omega) (fun _ => ⟨0, by omega⟩) (fun _ _ => rfl)
+      exact i.elim0
+    -- m = 1: Fin 1 is a singleton
+    · obtain ⟨_, i, j, _, hij, _, _, _, _, _⟩ :=
+        hf (by omega) (fun _ => ⟨0, by omega⟩) (fun _ _ => rfl)
+      exact hij (Subsingleton.elim i j)
+    -- m = 2: Fin 2, can't find 3 distinct
+    · obtain ⟨_, i, j, l, hij, hjl, hil, _, _, _⟩ :=
+        hf (by omega) (fun _ => ⟨0, by omega⟩) (fun _ _ => rfl)
+      exact no_three_distinct_lt3 (by omega) i j l hij hjl hil
+    -- m = 3: color edge {0,1} with 0, rest with 1
+    · let c₃ : EdgeColoring 3 2 := fun p =>
+        if (p.1.val = 0 ∧ p.2.val = 1) ∨ (p.1.val = 1 ∧ p.2.val = 0) then 0 else 1
+      have hsym₃ : IsSymmetric c₃ := by
+        intro i j; simp only [c₃]; fin_cases i <;> fin_cases j <;> simp
+      obtain ⟨color, i, j, l, hij, hjl, hil, hcij, hcjl, hcil⟩ := hf (by omega) c₃ hsym₃
+      fin_cases color <;> fin_cases i <;> fin_cases j <;> fin_cases l <;> simp_all [c₃]
+    -- m = 4: matching {01, 23} color 0, rest color 1
+    · let c₄ : EdgeColoring 4 2 := fun p =>
+        if (p.1.val = 0 ∧ p.2.val = 1) ∨ (p.1.val = 1 ∧ p.2.val = 0) ∨
+           (p.1.val = 2 ∧ p.2.val = 3) ∨ (p.1.val = 3 ∧ p.2.val = 2) then 0 else 1
+      have hsym₄ : IsSymmetric c₄ := by
+        intro i j; simp only [c₄]; fin_cases i <;> fin_cases j <;> simp
+      obtain ⟨color, i, j, l, hij, hjl, hil, hcij, hcjl, hcil⟩ := hf (by omega) c₄ hsym₄
+      fin_cases color <;> fin_cases i <;> fin_cases j <;> fin_cases l <;> simp_all [c₄]
+    -- m = 5: C₅ coloring — cycle {01,12,23,34,40} color 0, diagonals color 1
+    · let c₅ : EdgeColoring 5 2 := fun p =>
+        let d := (p.1.val + 5 - p.2.val) % 5
+        if d = 1 ∨ d = 4 then 0 else 1
+      have hsym₅ : IsSymmetric c₅ := by
+        intro i j; simp only [c₅]; fin_cases i <;> fin_cases j <;> simp
+      obtain ⟨color, i, j, l, hij, hjl, hil, hcij, hcjl, hcil⟩ := hf (by omega) c₅ hsym₅
+      fin_cases color <;> fin_cases i <;> fin_cases j <;> fin_cases l <;> simp_all [c₅]
 
 /-- R(3;3) = 17 (Greenwood and Gleason, 1955) -/
 axiom R3k_three : R3k 3 = 17

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -50,8 +50,8 @@
       "Connection between Schur numbers and Ramsey numbers",
       "Growth rate bounds and limit formulations"
     ],
-    "axiomCount": 9,
-    "lineCount": 297,
+    "axiomCount": 8,
+    "lineCount": 407,
     "references": [
       {
         "title": "Some remarks on the theory of graphs",
@@ -76,7 +76,7 @@
         "description": "Establishes the lower bound R(3;k) ≥ 380^{k/5} − O(1), a major improvement over previous bounds"
       }
     ],
-    "assumptions": "12 axiom(s) and 1 sorry(s)."
+    "assumptions": "8 axioms: forcing_set_nonempty, R3k_three (=17), R3k_inductive_upper, R3k_factorial_upper, SchurNumber (definition), R3k_schur_lower, R3k_exponential_lower, R3k_precise_lower. R3k_two PROVED via pigeonhole + C₅ construction."
   },
   "overview": {
     "historicalContext": "This problem was posed by Paul Erdős in 1961 [Er61] and remains one of the fundamental open questions in Ramsey theory. The multicolor Ramsey number R(3;k) generalizes the classical two-color Ramsey number R(3,3) = 6, which asks for the minimum n such that any 2-coloring of K_n's edges contains a monochromatic triangle.\n\nThe problem connects to several areas of combinatorics. The upper bound R(3;k) ≤ ⌈e·k!⌉ follows from a clever pigeonhole argument, while lower bounds come from connections to Schur numbers. A major breakthrough came in 2021 when Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik [ACPPRT21] improved the lower bound to R(3;k) ≥ 380^{k/5} - O(1).\n\nErdős offered $250 for solving this problem, with an additional $100 specifically for proving that the limit is finite. The gap between known bounds is enormous: R(3;k) lies between roughly 3.28^k and k!, making this one of the most intriguing open problems in Ramsey theory.",
@@ -176,9 +176,9 @@
       "Classical"
     ],
     "namespace": "Erdos183",
-    "lineCount": 297,
-    "axiomCount": 9,
-    "theoremCount": 5,
+    "lineCount": 407,
+    "axiomCount": 8,
+    "theoremCount": 10,
     "definitionCount": 13
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-183.json
+++ b/src/data/research/problems/erdos-183.json
@@ -19,31 +19,36 @@
     "phase": "ACT",
     "since": "2026-03-26T00:00:00Z",
     "iteration": 3,
-    "focus": "11 axioms (down from 12), 1 sorry. Proved R3k_one from scratch. Found 2 inconsistent axioms.",
+    "focus": "8 axioms (down from 9). Proved R3k_two (R(3,3)=6) via pigeonhole + C₅ construction.",
     "blockers": [],
-    "nextAction": "Fix kthRoot_lower/kthRoot_upper (change k≥1 to k≥k₀), prove more axioms from Mathlib"
+    "nextAction": "Prove forcing_set_nonempty or R3k_inductive_upper via pigeonhole"
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Removed 2 inconsistent axioms and 1 sorry (12→9 axioms, 1→0 sorries). Prior session proved R3k_one (12→11).",
+    "progressSummary": "PROGRESS: 9→8 axioms. Proved R3k_two (R(3,3)=6) via pigeonhole + C₅ construction. Prior sessions: 12→9 axioms (proved R3k_one, removed 2 inconsistent axioms).",
     "builtItems": [
       "R3k_one: proved R(3;1)=3 via Nat.find_eq_iff — upper bound uses Subsingleton.elim on Fin 1, lower bound uses pigeonhole on Fin m for m<3",
-      "Removed 2 inconsistent axioms (kthRoot_lower, kthRoot_upper) and 1 sorry theorem"
+      "Removed 2 inconsistent axioms (kthRoot_lower, kthRoot_upper) and 1 sorry theorem",
+      "R3k_two: proved R(3;2)=R(3,3)=6 via Nat.find_eq_iff — upper bound via pigeonhole (5 edges from vertex, 3 same color → forced triangle) + triangle_from_three_neighbors lemma, lower bound via explicit colorings for m=0..5 (C₅ for m=5)",
+      "pigeonhole_five_two: ∀ f : Fin 5 → Fin 2, ∃ 3 same-colored (native_decide)",
+      "fin2_other: x ≠ c → x = 1 - c in Fin 2",
+      "triangle_from_three_neighbors: 3 same-color edges from vertex → monochromatic triangle",
+      "no_three_distinct_lt3: Fin m with m < 3 has no 3 distinct elements"
     ],
     "insights": [
       "kthRoot_lower is INCONSISTENT with R3k_one: kthRootR3k 1 = R3k(1)^1 = 3 but axiom requires c > 3",
       "kthRoot_upper is FALSE at k=1: kthRootR3k 1 = 3 > e ≈ 2.718 = (e·1!)^{1/1}",
       "Both kthRoot axioms need k ≥ k₀ for some threshold, not k ≥ 1",
       "R3k_ceiling_upper cannot be proved from R3k_factorial_upper alone — needs C ≤ 1 or a tighter axiom",
-      "Removed kthRoot_lower (inconsistent: required c>3 for all k≥1, but kthRootR3k(1)=3)",
-      "Removed kthRoot_upper (false at k=1: kthRootR3k(1)=3 > e≈2.718)",
-      "Removed R3k_ceiling_upper sorry — the theorem was unprovable from R3k_factorial_upper alone"
+      "R(3,3)=6 proof: vertex with 5 edges → pigeonhole gives 3 same color → either triangle with vertex or 3 vertices all other color",
+      "C₅ is self-complementary: both the cycle and its complement are triangle-free 5-cycles, giving the R(3,3)>5 witness",
+      "pigeonhole_five_two provable via native_decide on the finite function space Fin 5 → Fin 2"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Fix kthRoot_lower: change ∀ k ≥ 1 to ∀ k ≥ k₀ for appropriate k₀",
-      "Fix kthRoot_upper: same fix, or remove (derivable from R3k_factorial_upper for large k)",
-      "Prove forcing_set_nonempty via classical Ramsey theorem (would eliminate 1 axiom)",
-      "Prove R3k_inductive_upper via pigeonhole counting (would eliminate 1 axiom)"
+      "Prove forcing_set_nonempty via induction on k using pigeonhole argument (would eliminate 1 axiom, enable R3k def without axiom)",
+      "Prove R3k_inductive_upper: R(3;k) ≤ 2 + k(R(3;k-1)-1) via pigeonhole counting (~100+ lines, would eliminate 1 axiom)",
+      "Prove R3k_factorial_upper from R3k_inductive_upper by induction (would eliminate 1 axiom)",
+      "R3k_three (=17), SchurNumber, R3k_schur_lower, R3k_exponential_lower, R3k_precise_lower are deep results"
     ]
   },
   "tags": [
@@ -67,11 +72,11 @@
     {
       "path": "Proofs/Erdos183Problem.lean",
       "filename": "Erdos183Problem.lean",
-      "lineCount": 310,
-      "theoremCount": 6,
-      "axiomCount": 11,
+      "lineCount": 407,
+      "theoremCount": 10,
+      "axiomCount": 8,
       "defCount": 13,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos183Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Prove `R3k_two : R3k 2 = 6` — the classical Ramsey number R(3,3) = 6
- Eliminates 1 axiom (9 → 8 axioms)
- Fix stale metadata (axiomCount, assumptions, lineCount)

## Proof Strategy
**Upper bound** (any 2-coloring of K₆ has monochromatic triangle):
1. Pick vertex 0 with 5 edges to other vertices
2. Pigeonhole (`native_decide` on Fin 5 → Fin 2): 3 edges share a color
3. `triangle_from_three_neighbors`: either triangle with vertex 0 or all-other-color triangle

**Lower bound** (K₅ avoids monochromatic triangles):
- m = 0,1,2: too few vertices for 3 distinct elements
- m = 3,4: explicit matchings/colorings checked via `fin_cases`
- m = 5: C₅ coloring (self-complementary — both color classes are triangle-free 5-cycles)

## Helper Lemmas Added
- `pigeonhole_five_two`: ∀ f : Fin 5 → Fin 2, ∃ 3 indices with same value
- `fin2_other`: x ≠ c → x = 1 - c in Fin 2
- `triangle_from_three_neighbors`: 3 same-color edges from vertex → forced triangle
- `no_three_distinct_lt3`: Fin m with m < 3 has no 3 distinct elements

## Status
**Outcome**: progress (1 axiom eliminated)
**Next Steps**: Prove `forcing_set_nonempty` or `R3k_inductive_upper` via pigeonhole

🤖 Generated by researcher-3