### PR TITLE
Research: erdos-460 — prove sieve_greedy

### DIFF
--- a/proofs/Proofs/Erdos460Problem.lean
+++ b/proofs/Proofs/Erdos460Problem.lean
@@ -49,21 +49,75 @@ theorem sieve_initial (n : ℕ) (hn : n ≥ 2) :
     greedyCoprimeSieve n 0 = 0 ∧ greedyCoprimeSieve n 1 = 1 := by
   constructor <;> simp [greedyCoprimeSieve]
 
-/-- Each subsequent term is the least integer > previous term
-such that n - aₖ is coprime to all previous n - aᵢ.
-Provable from the construction when candidates are nonempty.
+/-- Unfolding lemma for greedyCoprimeSieve at k + 2. -/
+private theorem greedyCoprimeSieve_succ_succ (n k : ℕ) :
+    greedyCoprimeSieve n (k + 2) =
+      let a : Fin (k + 2) → ℕ := fun i => greedyCoprimeSieve n i.val
+      let last := greedyCoprimeSieve n (k + 1)
+      let candidates := (Finset.range (n + 1)).filter fun m =>
+        last < m ∧ ∀ i : Fin (k + 2), Nat.Coprime (n - m) (n - a i)
+      if h : candidates.Nonempty then candidates.min' h else n + 1 := by
+  simp [greedyCoprimeSieve]
+
+/-- Each subsequent term is the least integer > previous term such that
+n - aₖ is coprime to all previous n - aᵢ. PROVED from the constructive
+definition: the filter gives coprimality, min' gives minimality, and
+hvalid rules out the sentinel.
 
 NOTE: The precondition `hvalid : greedyCoprimeSieve n k ≤ n` ensures
-the sieve has not terminated (sentinel value is n+1). Without it,
-the axiom is false: e.g., n=2, k=2 gives sentinel 3, and
-Coprime(2-3, 2) = Coprime(0, 2) is false in ℕ. -/
-axiom sieve_greedy (n : ℕ) (hn : n ≥ 2) (k : ℕ) (hk : k ≥ 2)
+the sieve has not terminated (sentinel is n+1). Without it, the theorem
+is false: e.g., n=2, k=2 gives sentinel 3. -/
+theorem sieve_greedy (n : ℕ) (_hn : n ≥ 2) (k : ℕ) (hk : k ≥ 2)
     (hvalid : greedyCoprimeSieve n k ≤ n) :
     let a := greedyCoprimeSieve n
     a k > a (k - 1) ∧
     (∀ i, i < k → Nat.Coprime (n - a k) (n - a i)) ∧
     (∀ m, a (k - 1) < m → m < a k →
-      ∃ i, i < k ∧ ¬Nat.Coprime (n - m) (n - a i))
+      ∃ i, i < k ∧ ¬Nat.Coprime (n - m) (n - a i)) := by
+  obtain ⟨k', rfl⟩ : ∃ k', k = k' + 2 := ⟨k - 2, by omega⟩
+  simp only [show k' + 2 - 1 = k' + 1 from by omega]
+  set a := greedyCoprimeSieve n with ha_def
+  set last := a (k' + 1)
+  set prev : Fin (k' + 2) → ℕ := fun i => a i.val
+  set candidates := (Finset.range (n + 1)).filter fun m =>
+    last < m ∧ ∀ i : Fin (k' + 2), Nat.Coprime (n - m) (n - prev i)
+  -- Since a(k'+2) ≤ n by hvalid, the sentinel case (n+1) is impossible,
+  -- so candidates must have been nonempty
+  have hne : candidates.Nonempty := by
+    by_contra hemp
+    rw [Finset.not_nonempty_iff_eq_empty] at hemp
+    have heq := greedyCoprimeSieve_succ_succ n k'
+    simp only [ha_def] at hvalid
+    rw [heq] at hvalid
+    simp only [hemp, dite_false] at hvalid
+    omega
+  -- a(k'+2) = candidates.min' hne
+  have hval : a (k' + 2) = candidates.min' hne := by
+    have heq := greedyCoprimeSieve_succ_succ n k'
+    simp only [ha_def, heq, dif_pos hne]
+  -- min' is in candidates, so it satisfies the filter
+  have hmin_mem := Finset.min'_mem candidates hne
+  simp only [Finset.mem_filter, Finset.mem_range] at hmin_mem
+  obtain ⟨_, hlast_lt, hcoprime⟩ := hmin_mem
+  refine ⟨?_, ?_, ?_⟩
+  · -- a(k'+2) > a(k'+1)
+    rw [hval]; exact hlast_lt
+  · -- Coprimality with all previous terms
+    intro i hi
+    rw [hval]; exact hcoprime ⟨i, hi⟩
+  · -- Minimality: anything between last and a(k'+2) fails coprimality
+    intro m hlast_m hm_val
+    rw [hval] at hm_val
+    have hm_not_mem : m ∉ candidates :=
+      fun hm => Nat.not_lt.mpr (Finset.min'_le candidates m hm) hm_val
+    simp only [Finset.mem_filter, Finset.mem_range, not_and] at hm_not_mem
+    have hm_range : m < n + 1 := by
+      have := Finset.min'_le candidates (candidates.min' hne) (Finset.min'_mem _ _)
+      omega
+    have hfail := hm_not_mem hm_range
+    push_neg at hfail
+    obtain ⟨i, hi⟩ := hfail hlast_m
+    exact ⟨i.val, i.isLt, hi⟩
 
 /-
 ## Section II: The Sequence Terminates Before n

--- a/src/data/research/problems/erdos-460.json
+++ b/src/data/research/problems/erdos-460.json
@@ -19,9 +19,9 @@
     "phase": "NEW",
     "since": "2026-01-13T04:11:10.512Z",
     "iteration": 2,
-    "focus": "Implemented greedy sieve as well-founded recursive function. Proved sieve_initial. 5 axioms remain.",
+    "focus": "Proved sieve_greedy from definition. 3 axioms remain (deep results).",
     "blockers": [],
-    "nextAction": "Prove sieve_greedy from construction (needs candidates nonemptiness). erdos_460_restricted_question provable via sum decomposition.",
+    "nextAction": "Assess remaining axioms — filtered_sum_implies_full may be provable.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,9 +29,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Fixed false sieve_greedy axiom (sentinel counterexample at n=2, k=2). Added hvalid precondition. 5 axioms, 0 sorries.",
+    "progressSummary": "PROGRESS: Proved sieve_greedy from constructive definition (4→3 axioms, 0 sorries). Used Finset.min'_mem/min'_le + sentinel elimination.",
     "builtItems": [
-      "Fixed sieve_greedy: added hvalid : greedyCoprimeSieve n k ≤ n precondition"
+      "Fixed sieve_greedy: added hvalid : greedyCoprimeSieve n k ≤ n precondition",
+      "greedyCoprimeSieve_succ_succ: unfolding lemma for k+2 case",
+      "sieve_greedy: PROVED — filter gives coprimality, min' gives minimality, hvalid rules out sentinel"
     ],
     "insights": [
       "greedyCoprimeSieve is a dummy (fun _ => 0) — all behavior axiomatized, no routine axioms to eliminate",
@@ -43,8 +45,8 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Implement greedyCoprimeSieve as a proper well-founded recursive definition",
-      "Then sieve_initial and sieve_greedy become provable by construction"
+      "Remaining 3 axioms are deep published results: eggleton_erdos_selfridge, sieve_conjectured_bound, filtered_sum_implies_full",
+      "filtered_sum_implies_full might be provable if leastPrimeFilteredSum terms are a subset of sieveReciprocalSum terms"
     ],
     "markdown": "# Erdős #460 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $a_0=n$ and $a_1=1$, and in general $a_k$ is the least integer $>a_{k-1}$ for which $(n-a_k,n-a_i)=1$ for all $1\\leq i<k$. Does\\[\\sum_{i}\\frac{1}{a_i}\\to \\infty\\]as $n\\to \\infty$? What about if we restrict the sum to those $i$ such that $n-a_j$ is divisible by some prime $\\leq a_j$, or the complement of such $i$?\n\n\n\nThis question arose in work of Eggleton, Erd\\H{o}s, and Selfridge, who could prove that $a_k <k^{2+o(1)}$ for $k$ large enough depending on $n$, but conjectured that in fact $a_k\\ll k\\log k$ is true.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #459\n- Problem #461\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
@@ -69,9 +71,9 @@
     {
       "path": "Proofs/Erdos460Problem.lean",
       "filename": "Erdos460Problem.lean",
-      "lineCount": 161,
-      "theoremCount": 1,
-      "axiomCount": 5,
+      "lineCount": 263,
+      "theoremCount": 2,
+      "axiomCount": 3,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Prove `sieve_greedy` from the constructive `greedyCoprimeSieve` definition (4→3 axioms)
- The greedy coprime sieve function already computes the minimum valid candidate; the proof extracts properties from `Finset.min'`

## Proof Strategy
1. Unfold `greedyCoprimeSieve n (k'+2)` via equation lemma
2. Since `hvalid : greedyCoprimeSieve n k ≤ n`, the sentinel case (n+1) is impossible → candidates nonempty
3. `Finset.min'_mem`: the minimum is in the filter → coprimality with all previous terms
4. `Finset.min'_le`: anything below the minimum is NOT in the filter → fails coprimality
5. Combine for all three conjuncts

## Status
**Outcome**: progress (1 axiom eliminated)
**Remaining axioms**: eggleton_erdos_selfridge, sieve_conjectured_bound, filtered_sum_implies_full (all deep results)

🤖 Generated by researcher-3