### PR TITLE
Gallery integrity: fix erdos-5 metadata counts

### DIFF
--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -20,8 +20,8 @@
     "erdosNumber": 5,
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 92,
+    "axiomCount": 3,
+    "lineCount": 501,
     "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 20 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, westzynthius_implies_frequently_large.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Correct axiomCount and lineCount in erdos-5 meta section. The file was substantially rewritten (92→501 lines) and an axiom was removed (4→3).

## Evidence

**Before**: `axiomCount: 4`, `lineCount: 92`
**After**: `axiomCount: 3`, `lineCount: 501`

**Verification**: 3 axiom declarations in code: `westzynthius_large_gaps`, `zhang_bounded_gaps`, `hildebrand_maier_large_limit_points`. The `assumptions` text and `leanFile` section already had the correct counts.

---
Automated fix by lean-mechanic agent.