### PR TITLE
Create Aristotle companion for erdos-866 (3 routine sorries)

### DIFF
--- a/proofs/Proofs/Erdos866Aristotle.lean
+++ b/proofs/Proofs/Erdos866Aristotle.lean
@@ -1,0 +1,58 @@
+/-
+  Aristotle targets for Erdős Problem #866
+  Routine supporting lemmas for automated proof search.
+  See Erdos866Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known result likely in Mathlib (monotonicity, cardinality, bounds, etc.)
+  - Clean theorem statement with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+
+  Targets:
+  1. upperExponent_increasing: geometric sequence monotonicity
+  2. oddNumbers_card: counting odd numbers in {1,...,2N}
+  3. oddNumbers_no_triple: parity pigeonhole argument
+-/
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+open Finset Real
+
+namespace Erdos866
+
+/-- The interval {1, 2, ..., 2N}. -/
+def Interval (N : ℕ) : Finset ℕ :=
+  (Finset.range (2 * N + 1)).filter (fun n => n ≥ 1)
+
+/-- A set A has all pairwise sums of b₁,...,b_k if for all i < j,
+    b_i + b_j ∈ A. -/
+def HasAllPairwiseSums (A : Finset ℕ) (b : Fin k → ℤ) : Prop :=
+  ∀ i j : Fin k, i < j → (b i + b j).toNat ∈ A
+
+/-- The set of odd numbers in {1,...,2N}. -/
+def oddNumbers (N : ℕ) : Finset ℕ :=
+  (Interval N).filter (fun n => n % 2 = 1)
+
+/-- The exponent 1 - 2^{-k} in the upper bound. -/
+noncomputable def upperExponent (k : ℕ) : ℝ :=
+  1 - (2 : ℝ)⁻¹ ^ k
+
+-- Routine lemma: geometric sequence is strictly decreasing,
+-- so 1 - (1/2)^k < 1 - (1/2)^(k+1)
+theorem upperExponent_increasing (k : ℕ) (hk : k ≥ 1) :
+    upperExponent k < upperExponent (k + 1) := by sorry
+
+-- Routine lemma: the odd numbers in {1,...,2N} have cardinality N
+theorem oddNumbers_card (N : ℕ) : (oddNumbers N).card = N := by sorry
+
+-- Routine lemma: parity pigeonhole — among any 3 integers,
+-- two share parity, so their sum is even and not in oddNumbers
+theorem oddNumbers_no_triple (N : ℕ) :
+    ¬∃ b : Fin 3 → ℤ, HasAllPairwiseSums (oddNumbers N) b := by sorry
+
+end Erdos866


### PR DESCRIPTION
## Fix

Creates Aristotle companion file for erdos-866 with 3 routine supporting lemmas suitable for automated proof search.

## Evidence

**Before**: erdos-866 had 6 sorries, no Aristotle companion file. 3 of the sorries are routine supporting lemmas (not the main conjecture).

**After**: `Erdos866Aristotle.lean` exposes these 3 provable targets:
- `upperExponent_increasing`: geometric sequence `(1/2)^k` is strictly decreasing, so `1 - (1/2)^k` is increasing
- `oddNumbers_card`: the odd numbers in `{1,...,2N}` have cardinality `N`
- `oddNumbers_no_triple`: parity pigeonhole — among 3 integers, two share parity, their sum is even

All pre-submission checks pass: no definition sorries, no axiom declarations, no `/-!` docstrings.

---
Automated fix by lean-mechanic agent.