### PR TITLE
fix: correct erdos-818 metadata (axiomCount 10→1, lineCount)

### DIFF
--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -53,7 +53,7 @@
       "Connection to Problem 52 (original sum-product conjecture)"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 10,
+    "axiomCount": 1,
     "prerequisites": [
       "Finite set operations (union, image, cartesian product)",
       "Additive combinatorics fundamentals (sumsets, doubling constants)",
@@ -61,13 +61,13 @@
       "Logarithmic functions and asymptotic notation",
       "Basic number theory (arithmetic and geometric progressions)"
     ],
-    "lineCount": 325,
-    "assumptions": "10 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "lineCount": 290,
+    "assumptions": "1 axiom(s) and 4 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "This problem is part of the sum-product phenomenon, a central topic in additive combinatorics. Erdős-Szemerédi conjectured that finite sets cannot have both small sumsets AND small product sets. This problem explores a conditional version: if the sumset is small, how large must the product set be? Solymosi's 2009 paper resolved this completely. The sum-product conjecture (1983) was proved in quantitative forms by Elekes (1997) using the Szemerédi-Trotter incidence theorem, and by Solymosi and others achieving exponent 4/3. The conditional question asks whether small additive structure forces large multiplicative structure, refining the unconditional sum-product estimates.",
     "problemStatement": "Let A be a finite set of integers such that |A+A| ≤ K·|A| for some constant K. Is it true that |A·A| ≥ |A|²/(log|A|)^C for some constant C > 0?",
-    "text": "This formalization captures Erdős Problem #818, a conditional form of the sum-product phenomenon in additive combinatorics. The Lean file defines sumsets, product sets, additive and multiplicative energy, and the small sumset condition |A+A| ≤ K|A|, then states both the original conjecture (product set at least |A|²/(log|A|)^C for some C) and Solymosi's 2009 resolution, which proves the stronger bound |AA| ≥ c|A|²/log|A| with C = 1. The proof architecture formalizes the energy sandwich argument: a Cauchy-Schwarz lower bound on multiplicative energy (E×(A) ≥ |A|⁴/|AA|) combined with Solymosi's upper bound (E×(A) ≤ |A|²·|A+A|·log|A|) yields the product set estimate. The file also formalizes the tightness of the logarithmic factor via arithmetic progression examples, connects the result to Erdős Problem #52 (the unconditional sum-product conjecture), and states the sum-product dichotomy. The formalization has 7 definitions, 5 theorems, and 10 axioms encoding deep results (Solymosi's theorem, energy bounds, extremal examples) with 4 remaining sorries in the deductive steps.",
+    "text": "This formalization captures Erdős Problem #818, a conditional form of the sum-product phenomenon in additive combinatorics. The Lean file defines sumsets, product sets, additive and multiplicative energy, and the small sumset condition |A+A| ≤ K|A|, then states both the original conjecture (product set at least |A|²/(log|A|)^C for some C) and Solymosi's 2009 resolution, which proves the stronger bound |AA| ≥ c|A|²/log|A| with C = 1. The proof architecture formalizes the energy sandwich argument: a Cauchy-Schwarz lower bound on multiplicative energy (E×(A) ≥ |A|⁴/|AA|) combined with Solymosi's upper bound (E×(A) ≤ |A|²·|A+A|·log|A|) yields the product set estimate. The file also formalizes the tightness of the logarithmic factor via arithmetic progression examples, connects the result to Erdős Problem #52 (the unconditional sum-product conjecture), and states the sum-product dichotomy. The formalization has 7 definitions, 5 theorems, and 1 axiom (Solymosi's theorem) with 4 remaining sorries in the deductive steps.",
     "proofStrategy": "The formalization defines sumsets, product sets, and the small sumset condition. Solymosi's theorem is stated as the main result, with the proof strategy outlined: bound multiplicative energy from below (Cauchy-Schwarz) and above (Solymosi's lemma), then combine to get the product set bound.",
     "keyInsights": [
       "Sets cannot have both strong additive AND multiplicative structure",
@@ -268,8 +268,8 @@
       "Real"
     ],
     "namespace": "Erdos818",
-    "lineCount": 325,
-    "axiomCount": 10,
+    "lineCount": 290,
+    "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 7
   }


### PR DESCRIPTION
## Summary

- `axiomCount`: 10 → 1 (file has only 1 `axiom` declaration: `solymosi_theorem`)
- `lineCount`: 325 → 290 (actual file length)
- `assumptions` text: updated to reflect correct axiom count
- Overview narrative: corrected "10 axioms encoding deep results" → "1 axiom (Solymosi's theorem)"

## Evidence

```
$ grep -c "^axiom " proofs/Proofs/Erdos818Problem.lean
1

$ grep -n "^axiom " proofs/Proofs/Erdos818Problem.lean
128:axiom solymosi_theorem :

$ wc -l proofs/Proofs/Erdos818Problem.lean
290
```

## Audit Summary

| Check | Result |
|-------|--------|
| True stubs | PASS |
| Sorry count | PASS (4 sorries, matches meta.json) |
| Status/badge | PASS (axiomatized/axiom) |
| Mathlib wrapper | PASS (utilities only) |
| Axiom count | FIXED (10→1) |
| Line count | FIXED (325→290) |
| Narrative | FIXED (removed overcounted axiom claim) |

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)