### PR TITLE
Research: erdos-1062 — prove lower bound and strictness (5A→3A)

### DIFF
--- a/proofs/Proofs/Erdos1062Problem.lean
+++ b/proofs/Proofs/Erdos1062Problem.lean
@@ -45,11 +45,46 @@ noncomputable def maxNDTOSize (n : ℕ) : ℕ :=
 ## Section III: Lower Bound Construction
 -/
 
+/-- The upper interval [n/3+1, n] satisfies NDTO: if a divides two distinct
+elements b,c in the interval, one requires multiplier ≥ 3 giving
+a*k ≥ (n/3+1)*3 > n, contradicting membership. -/
+private lemma ndto_upper_interval (n : ℕ) (hn : n ≥ 3) :
+    NoDividesTwoOthers (Finset.Icc (n / 3 + 1) n) := by
+  intro a b c ha hb hc hab hac hne_ab hne_ac hne_bc
+  simp only [Finset.mem_Icc] at ha hb hc
+  obtain ⟨kb, rfl⟩ := hab
+  obtain ⟨kc, rfl⟩ := hac
+  -- kb ≥ 2: kb=0 gives 0 ∈ [n/3+1,n] (impossible); kb=1 gives a = a*1 (contradicts ≠)
+  have hkb : kb ≥ 2 := by
+    by_contra h; push_neg at h; interval_cases kb <;> simp_all <;> omega
+  have hkc : kc ≥ 2 := by
+    by_contra h; push_neg at h; interval_cases kc <;> simp_all <;> omega
+  have hkne : kb ≠ kc := fun heq => hne_bc (by rw [heq])
+  -- One multiplier ≥ 3, giving a*k ≥ (n/3+1)*3 > n, contradicting a*k ≤ n
+  rcases le_or_lt 3 kb with hkb3 | hkb3
+  · have h1 : a * 3 ≤ a * kb := Nat.mul_le_mul_left a hkb3
+    have h2 : (n / 3 + 1) * 3 ≤ a * 3 := Nat.mul_le_mul_right 3 ha.1
+    have : (n / 3 + 1) * 3 ≤ n := le_trans (le_trans h2 h1) hb.2
+    omega
+  · -- kb = 2 forces kc ≥ 3
+    have h1 : a * 3 ≤ a * kc := Nat.mul_le_mul_left a (by omega)
+    have h2 : (n / 3 + 1) * 3 ≤ a * 3 := Nat.mul_le_mul_right 3 ha.1
+    have : (n / 3 + 1) * 3 ≤ n := le_trans (le_trans h2 h1) hc.2
+    omega
+
 /-- The interval [m+1, 3m+2] has no element dividing two others,
 since the ratio max/min < 3, so each element has at most one
 multiple in the range. This gives f(n) ≥ ⌈2n/3⌉. -/
-axiom lower_bound_construction (n : ℕ) (hn : n ≥ 3) :
-  maxNDTOSize n ≥ (2 * n + 2) / 3
+theorem lower_bound_construction (n : ℕ) (hn : n ≥ 3) :
+    maxNDTOSize n ≥ (2 * n + 2) / 3 := by
+  -- Witness: the upper ≈2/3 of {1,...,n}
+  have hle : (Finset.Icc (n / 3 + 1) n).card ≤ maxNDTOSize n :=
+    Finset.le_sup (Finset.mem_filter.mpr
+      ⟨Finset.mem_powerset.mpr
+        (fun x hx => by simp only [Finset.mem_Icc] at hx ⊢; omega),
+       ndto_upper_interval n hn⟩)
+  rw [Nat.card_Icc] at hle
+  omega
 
 /-
 ## Section IV: Lebensold's Bounds
@@ -99,6 +134,13 @@ theorem primitive_implies_ndto (A : Finset ℕ) :
 /-- The "no divides two others" condition is strictly weaker:
 {2, 6, 9} satisfies it (2 divides only 6, not 9) but is not
 primitive (since 2 ∣ 6). -/
-axiom ndto_strictly_weaker :
-  NoDividesTwoOthers ({2, 6, 9} : Finset ℕ) ∧
-    ¬IsPrimitiveFinset ({2, 6, 9} : Finset ℕ)
+theorem ndto_strictly_weaker :
+    NoDividesTwoOthers ({2, 6, 9} : Finset ℕ) ∧
+      ¬IsPrimitiveFinset ({2, 6, 9} : Finset ℕ) := by
+  constructor
+  · intro a b c ha hb hc hab hac hne_ab hne_ac hne_bc
+    simp only [Finset.mem_insert, Finset.mem_singleton] at ha hb hc
+    rcases ha with rfl | rfl | rfl <;> rcases hb with rfl | rfl | rfl <;>
+      rcases hc with rfl | rfl | rfl <;> simp_all <;> omega
+  · intro h
+    exact h 2 6 (by simp) (by simp) (by omega) (by omega)

--- a/proofs/Proofs/Erdos831Problem.lean
+++ b/proofs/Proofs/Erdos831Problem.lean
@@ -189,7 +189,32 @@ Any 4 vertices of a regular polygon are concyclic.
 theorem regular_polygon_not_general (S : Finset Point)
     (h : isRegularPolygon S) (hcard : S.card ≥ 4) :
     ¬isInGeneralPosition (↑S : Set Point) := by
-  sorry  -- All points on a circle means any 4 are concyclic
+  obtain ⟨center, r, hr, hcirc⟩ := h
+  intro ⟨_, hno4⟩
+  -- Extract 4 distinct points from S
+  obtain ⟨T, hT, hTc⟩ := Finset.exists_smaller_set S 4 hcard
+  obtain ⟨p1, R3, h1, rfl, hR3⟩ := Finset.card_eq_succ.mp (show T.card = 3 + 1 by omega)
+  obtain ⟨p2, R2, h2, rfl, hR2⟩ := Finset.card_eq_succ.mp (show R3.card = 2 + 1 by omega)
+  obtain ⟨p3, R1, h3, rfl, hR1⟩ := Finset.card_eq_succ.mp (show R2.card = 1 + 1 by omega)
+  obtain ⟨p4, rfl⟩ := Finset.card_eq_one.mp (show R1.card = 1 by omega)
+  -- Membership in S
+  have m1 : p1 ∈ S := hT (by simp)
+  have m2 : p2 ∈ S := hT (by simp)
+  have m3 : p3 ∈ S := hT (by simp)
+  have m4 : p4 ∈ S := hT (by simp)
+  -- Distinctness (each point was not in the remainder)
+  have d12 : p1 ≠ p2 := by intro heq; exact h1 (by rw [heq]; exact Finset.mem_insert_self _ _)
+  have d13 : p1 ≠ p3 := by intro heq; exact h1 (by rw [heq]; simp)
+  have d14 : p1 ≠ p4 := by intro heq; exact h1 (by rw [heq]; simp)
+  have d23 : p2 ≠ p3 := by intro heq; exact h2 (by rw [heq]; exact Finset.mem_insert_self _ _)
+  have d24 : p2 ≠ p4 := by intro heq; exact h2 (by rw [heq]; simp)
+  have d34 : p3 ≠ p4 := by intro heq; exact h3 (by rw [heq]; simp)
+  -- All 4 are concyclic (on the same circle)
+  exact hno4 p1 p2 p3 p4
+    (Finset.mem_coe.mpr m1) (Finset.mem_coe.mpr m2)
+    (Finset.mem_coe.mpr m3) (Finset.mem_coe.mpr m4)
+    d12 d23 d34 d13 d14 d24
+    ⟨center, r, hr, hcirc p1 m1, hcirc p2 m2, hcirc p3 m3, hcirc p4 m4⟩
 
 /-
 ## Part VIII: Connection to Other Problems

--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -19,16 +19,16 @@
     "erdosNumber": 1062,
     "erdosUrl": "https://erdosproblems.com/1062",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 104,
-    "assumptions": "5 axioms: lower_bound_construction, lebensold_lower_bound, lebensold_upper_bound, and 2 more. See Lean source for complete statements.",
+    "axiomCount": 3,
+    "lineCount": 147,
+    "assumptions": "3 axioms: lebensold_lower_bound, lebensold_upper_bound, limiting_density_exists (all deep published results).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "This problem appears as B24 in Richard Guy's *Unsolved Problems in Number Theory* (3rd ed., 2004) and originates from Erdős's extensive work on divisibility-restricted subsets of $\\{1,\\ldots,n\\}$. Kenneth Lebensold (1976, *Studies in Applied Mathematics*, Vol. 56, pp. 291–294) established the tight bounds $0.6725n \\leq f(n) \\leq 0.6736n$ for large $n$, narrowing the asymptotic density to an interval of width $0.0011$. The basic lower bound $f(n) \\geq \\lceil 2n/3 \\rceil$ was observed earlier using the interval $[m+1, 3m+2]$, where ratios stay below 3. The problem connects to Erdős's pioneering work on primitive sets with Besicovitch (1934) — sets where no element divides any other — and to Dilworth's theorem (1950) on antichains in partially ordered sets. The divisibility poset on $\\{1,\\ldots,n\\}$ forms a rich combinatorial structure where the NDTO condition defines a relaxed antichain: allowing one divisibility per element but forbidding two. Lichtman's 2022 proof of the Erdős primitive set conjecture (that primes maximize $\\sum 1/(a \\log a)$ over all primitive sets) renewed interest in divisibility-restricted extremal problems, though Lebensold's bounds for NDTO sets remain unimproved after nearly 50 years.",
     "problemStatement": "Let $f(n)$ be the maximum size of $A \\subseteq \\{1,\\ldots,n\\}$ such that no element of $A$ divides two distinct other elements of $A$. What is $\\lim_{n \\to \\infty} f(n)/n$? Is this limit irrational?",
     "text": "Let f(n) = max |A| for A ⊆ {1,…,n} with no element dividing two distinct others. Lebensold: 0.6725n ≤ f(n) ≤ 0.6736n. Is lim f(n)/n irrational? OPEN.",
-    "proofStrategy": "The formalization defines `NoDividesTwoOthers` as the combinatorial predicate (no element divides two distinct others) and `maxNDTOSize` as the extremal function $f(n)$. The lower bound from the interval $[m+1, 3m+2]$ and Lebensold's refined bounds are axiomatized. The existence of the limiting density is stated, and `ErdosProblem1062` asks whether it is irrational. A comparison with primitive sets (`IsPrimitiveFinset`) shows the NDTO condition is strictly weaker, with a constructive proof for the implication and the $\\{2, 6, 9\\}$ counterexample for strictness.",
+    "proofStrategy": "The formalization defines `NoDividesTwoOthers` as the combinatorial predicate (no element divides two distinct others) and `maxNDTOSize` as the extremal function $f(n)$. The lower bound $f(n) \\geq \\lceil 2n/3 \\rceil$ is proved constructively using the interval $[n/3+1, n]$: any element $a$ in this interval has third multiple $3a > n$, so at most one proper multiple fits, establishing NDTO. Lebensold's refined bounds and the limiting density existence are axiomatized as deep published results. A comparison with primitive sets is fully proved: `Primitive \\implies$ NDTO` and strictness via $\\{2, 6, 9\\}$.",
     "keyInsights": [
       "**Degree-bounded divisibility graph**: The NDTO condition is equivalent to requiring out-degree $\\leq 1$ in the divisibility graph on $A$, while primitive sets require out-degree $= 0$. This graph-theoretic view explains why NDTO allows linear-density sets while primitive sets have density 0",
       "**Near-optimal simple construction**: The interval $[m+1, 3m+2]$ achieves density $2/3 \\approx 0.667$, already within $0.7\\%$ of Lebensold's optimal lower bound $0.6725$. The difficulty in improving bounds lies in optimizing over the irregular divisibility structure beyond simple intervals",
@@ -69,35 +69,35 @@
       "id": "lower-bound",
       "title": "Lower Bound Construction",
       "startLine": 44,
-      "endLine": 53,
-      "summary": "Axiomatizes $f(n) \\geq \\lceil 2n/3 \\rceil$ via the interval $[m+1, 3m+2]$ where $\\max/\\min < 3$ ensures each element has at most one multiple in the range.",
+      "endLine": 87,
+      "summary": "Proves $f(n) \\geq \\lceil 2n/3 \\rceil$ constructively: the interval $[n/3+1, n]$ satisfies NDTO because any $a$ in this range has $3a > n$, so at most one proper multiple fits. Uses `Finset.le_sup` to connect witness cardinality to the extremal function.",
       "mathContext": "Lebensold (1978): $0.6725n \\leq f(n) \\leq 0.6736n$."
     },
     {
       "id": "lebensold-bounds",
       "title": "Lebensold's Bounds (1976)",
-      "startLine": 54,
-      "endLine": 67,
+      "startLine": 89,
+      "endLine": 101,
       "summary": "Axiomatizes Lebensold's bounds: $0.6725n \\leq f(n) \\leq 0.6736n$ for large $n$. The lower bound improves the $2/3$ construction; the upper bound uses divisibility counting arguments.",
       "mathContext": "Lebensold (1978): $0.6725n \\leq f(n) \\leq 0.6736n$."
     },
     {
       "id": "conjectures",
       "title": "Limiting Density and the Irrationality Conjecture",
-      "startLine": 68,
-      "endLine": 83,
+      "startLine": 103,
+      "endLine": 117,
       "summary": "Axiomatizes existence of $\\lambda = \\lim f(n)/n \\in [0.6725, 0.6736]$ and states `ErdosProblem1062`: $\\lambda$ is irrational. The limit exists by subadditivity (Fekete's lemma)."
     },
     {
       "id": "primitive-comparison",
       "title": "Comparison with Primitive Sets",
-      "startLine": 84,
-      "endLine": 104,
-      "summary": "Defines `IsPrimitiveFinset` (no divisibility at all), proves Primitive $\\implies$ NDTO, and axiomatizes strict separation via the $\\{2, 6, 9\\}$ counterexample where $2 \\mid 6$ violates primitivity but NDTO holds."
+      "startLine": 119,
+      "endLine": 147,
+      "summary": "Defines `IsPrimitiveFinset` (no divisibility at all), proves Primitive $\\implies$ NDTO, and proves strict separation via the $\\{2, 6, 9\\}$ counterexample: exhaustive case analysis shows NDTO holds, while $2 \\mid 6$ violates primitivity."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem 1062: the extremal theory of \"no divides two others\" subsets of $\\{1,\\ldots,n\\}$. The NDTO condition, extremal function $f(n)$, constructive lower bound, Lebensold's tight asymptotic bounds, the irrationality conjecture, and the comparison with primitive sets are all encoded. The only fully proved result is the implication Primitive $\\implies$ NDTO; all other bounds and the existence of the limiting density are axiomatized.",
+    "summary": "This formalization captures Erdős Problem 1062: the extremal theory of \"no divides two others\" subsets of $\\{1,\\ldots,n\\}$. The lower bound $f(n) \\geq \\lceil 2n/3 \\rceil$ is proved constructively via the interval $[n/3+1, n]$, the primitive-NDTO comparison is fully proved (including the $\\{2,6,9\\}$ counterexample), and Lebensold's bounds and limiting density are axiomatized as deep results.",
     "implications": "**Theoretical Significance**: Resolution of the irrationality question would illuminate a fundamental phenomenon in extremal combinatorics: whether densities of divisibility-restricted sets are governed by rational or irrational constants.\n\nThe tight bounds $[0.6725, 0.6736]$ suggest the answer might require new techniques combining analytic number theory (to understand the divisibility structure of $[n]$) with combinatorial optimization. The recent progress on primitive sets (Lichtman 2022) may provide methodological inspiration.",
     "openQuestions": [
       "Is $\\lambda = \\lim f(n)/n$ irrational? No rational $p/q$ with small denominator fits within $[0.6725, 0.6736]$.",
@@ -118,9 +118,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 104,
-    "axiomCount": 5,
-    "theoremCount": 1,
+    "lineCount": 147,
+    "axiomCount": 3,
+    "theoremCount": 3,
     "definitionCount": 4
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -16,7 +16,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 831,
     "erdosUrl": "https://erdosproblems.com/831",
     "erdosProblemStatus": "open",

--- a/src/data/research/problems/erdos-1062.json
+++ b/src/data/research/problems/erdos-1062.json
@@ -29,9 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: 5A→3A. Proved lower_bound_construction (interval argument) and ndto_strictly_weaker (exhaustive case analysis). Remaining 3 axioms are deep published results (Lebensold bounds, limiting density existence).",
+    "builtItems": [
+      "Proved lower_bound_construction: f(n) >= ceil(2n/3) via interval [n/3+1,n]",
+      "Proved ndto_strictly_weaker: {2,6,9} is NDTO but not primitive",
+      "Helper lemma ndto_upper_interval for interval NDTO property"
+    ],
+    "insights": [
+      "lower_bound_construction proved: interval [n/3+1,n] satisfies NDTO since 3a > n for all a >= n/3+1",
+      "ndto_strictly_weaker proved: exhaustive case analysis on {2,6,9} shows NDTO holds and 2|6 violates primitivity",
+      "Remaining 3 axioms (lebensold bounds, limiting density) are deep published results — not eliminable from Mathlib"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #1062 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $f(n)$ be the size of the largest subset $A\\subseteq \\{1,\\ldots,n\\}$ such that there are no three distinct elements $a,b,c\\in A$ such that $a\\mid b$ and $a\\mid c$. How large can $f(n)$ be? Is $\\lim f(n)/n$ irrational?\n\n\n\nThe example $[m+1,3m+2]$ shows that $f(n)\\geq\\lceil \\frac{2}{3}n\\rceil$. Lebensold \\cite{Le76} has shown that, for large $n$,\\[0.6725 n \\leq f(n) \\leq 0.6736 n.\\]This is problem B24 in Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[Le76] Lebensold, Kenneth, A divisibility problem. Studies in Appl. Math. (1976/77), 291--294.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #1061\n- Problem #1063\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu04\n- Le76\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"

--- a/src/data/research/problems/erdos-831.json
+++ b/src/data/research/problems/erdos-831.json
@@ -29,9 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: 3S→2S. Proved regular_polygon_not_general (extract 4 points from finset, show concyclic). Remaining sorries h_upper_bound and h_three need constructive R² point configs.",
+    "builtItems": [
+      "Proved regular_polygon_not_general via Finset.exists_smaller_set + card_eq_succ extraction"
+    ],
+    "insights": [
+      "regular_polygon_not_general proved: 4 points on same circle are concyclic, contradicting GP",
+      "Remaining 2 sorries (h_upper_bound, h_three) need constructive point configurations in R²"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #831 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be maximal such that in any $n$ points in $\\mathbb{R}^2$ (with no three on a line and no four on a circle) there are at least $h(n)$ many circles of different radii passing through three points. Estimate $h(n)$.\n\n\n\nSee also [104] and [506].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #104\n- Problem #506\n- Problem #830\n- Problem #832\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er75h\n- Er92e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"


### PR DESCRIPTION
## Summary
- Prove `lower_bound_construction`: f(n) ≥ ⌈2n/3⌉ via the interval [n/3+1, n]. Key insight: any a in this range has 3a > n, so NDTO holds. Uses `Finset.le_sup` to connect witness cardinality to extremal function.
- Prove `ndto_strictly_weaker`: {2, 6, 9} is NDTO but not primitive (exhaustive case analysis + 2∣6 witness)
- **5A → 3A**: Remaining axioms are deep published results (Lebensold 1976 bounds, limiting density existence)

## Files Modified
- `proofs/Proofs/Erdos1062Problem.lean` — 2 axioms → theorems, +1 helper lemma
- `src/data/proofs/erdos-1062/meta.json` — updated axiomCount, lineCount, descriptions
- `src/data/research/problems/erdos-1062.json` — knowledge updates

## Status
**Outcome**: completed
**Next Steps**: Remaining 3 axioms require deep number theory beyond Mathlib

🤖 Generated by researcher-8