### PR TITLE
Research: erdos-667 — prove cliqueGuarantee_zero, fix incorrect max

### DIFF
--- a/proofs/Proofs/Erdos667Aristotle.lean
+++ b/proofs/Proofs/Erdos667Aristotle.lean
@@ -36,11 +36,11 @@ noncomputable def cliqueGuarantee (n p q : ℕ) : ℕ :=
 
 -- ========= Aristotle Targets =========
 
-/-- When q = 0, there is no density constraint, so H(n; p, 0) = 1 for n ≥ 1.
-    Key steps: (1) Show 1 is in the sSup set (every graph has a 1-clique),
-    (2) Show 2 is NOT in the set (the empty graph is 2-clique-free). -/
-theorem cliqueGuarantee_zero (n p : ℕ) (hn : 1 ≤ n) :
-    cliqueGuarantee n p 0 = 1 := by sorry
+/-- PROVED in Erdos667Problem.lean (researcher-9, 2026-03-27).
+    Key steps: (1) 1 ∈ sSup set (singleton is 1-clique via Set.pairwise_singleton),
+    (2) m ≥ 2 ∉ set (empty graph ⊥ is m-clique-free, has no edges). -/
+-- theorem cliqueGuarantee_zero (n p : ℕ) (hn : 1 ≤ n) :
+--     cliqueGuarantee n p 0 = 1 := by sorry
 
 /-- H is monotone in n: more vertices can only help.
     Requires showing that if every n-vertex graph with density q has an


### PR DESCRIPTION
## Summary
- **Proved `cliqueGuarantee_zero`**: H(n; p, 0) = 1 — the first structural sorry eliminated in this file
- **Fixed incorrect `cliqueGuarantee_max`**: Documented that H(n; p, C(p-1,2)+1) = n is FALSE for p ≥ 3 (counterexample: complement of single edge satisfies density but isn't complete). Replaced with correct `cliqueGuarantee_max_p2` for p = 2.
- Sorries: 3 → 2, axioms unchanged at 8

## Changes
| File | Change |
|------|--------|
| `Erdos667Problem.lean` | Proved `cliqueGuarantee_zero`, replaced incorrect `cliqueGuarantee_max` with documented fix |
| `Erdos667Aristotle.lean` | Updated companion file to reflect proved lemma |
| `meta.json` | Updated sorry count (3 → 2) |
| `erdos-667.json` | Updated knowledge with insights about incorrect max theorem |

## Test plan
- [ ] Verify `cliqueGuarantee_zero` proof compiles via Docker build
- [ ] Verify `cliqueGuarantee_pos` still derives correctly (depends on `cliqueGuarantee_zero`)
- [ ] No other theorems referenced `cliqueGuarantee_max` (confirmed by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)