### PR TITLE
fix: correct dirichlets-theorem-oq-02-oq-01 metadata (axiomCount, lineCount)

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -53,9 +53,9 @@
       "Axioms for PNT for APs, Linnik bound, character sum bounds, class numbers"
     ],
     "dateAdded": "2026-03-25",
-    "axiomCount": 13,
-    "lineCount": 445,
-    "assumptions": "13 axioms: L_function_functional_symmetry, classical_zero_free_region_dirichlet, siegel_walfisz_theorem, GRH_PNT_for_APs, linnik_theorem, GRH_least_prime, polya_vinogradov, GRH_character_sum_bound, L_function_nonzero_re_gt_one, GRH_effective_L_one_bound, GRH_class_number_bound, unconditional_class_number_bound, GRH_verified_height",
+    "axiomCount": 4,
+    "lineCount": 366,
+    "assumptions": "4 axioms: L_function_functional_symmetry, classical_zero_free_region_dirichlet, L_function_nonzero_re_gt_one, GRH_effective_L_one_bound",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- `axiomCount`: 13 → 4 (file has 4 `axiom` declarations, down from 13 in an older version)
- `lineCount`: 445 → 366 (actual file length)
- `assumptions` text: updated to list only the 4 actual axioms

## Evidence

```
$ grep -c "^axiom " proofs/Proofs/DirichletsTheoremOQ02OQ01.lean
4

$ grep -n "^axiom " proofs/Proofs/DirichletsTheoremOQ02OQ01.lean
89:axiom L_function_functional_symmetry :
138:axiom classical_zero_free_region_dirichlet :
262:axiom L_function_nonzero_re_gt_one :
286:axiom GRH_effective_L_one_bound :

$ wc -l proofs/Proofs/DirichletsTheoremOQ02OQ01.lean
366
```

## Audit Summary

| Check | Result |
|-------|--------|
| True stubs | PASS |
| Sorry count | PASS (0 sorries) |
| Status/badge | PASS (axiomatized/axiom) |
| Axiom count | FIXED (13→4) |
| Line count | FIXED (445→366) |

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)