### PR TITLE
Gallery integrity: erdos-1030 axiomCount 16→7, lineCount 293→256

### DIFF
--- a/src/data/proofs/erdos-1030/meta.json
+++ b/src/data/proofs/erdos-1030/meta.json
@@ -50,9 +50,9 @@
       "erdos-544",
       "erdos-1014"
     ],
-    "axiomCount": 16,
-    "lineCount": 293,
-    "assumptions": "16 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "axiomCount": 7,
+    "lineCount": 256,
+    "assumptions": "7 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Ramsey Theory and Growth Rates**\n\nFrank Ramsey proved his foundational theorem in 1930: for any $k, \\ell \\ge 2$, there exists $n$ such that every 2-coloring of $K_n$ contains a red $k$-clique or blue $\\ell$-clique. The minimum such $n$ is the Ramsey number $R(k, \\ell)$. Erdős and Szekeres (1935) established the recursive bound $R(k, \\ell) \\le R(k-1, \\ell) + R(k, \\ell-1)$, yielding $R(k, k) \\le \\binom{2k-2}{k-1} \\sim 4^k/\\sqrt{\\pi k}$. In his celebrated 1947 paper, Erdős used the **probabilistic method** — the first major application of this technique — to prove $R(k, k) \\ge 2^{k/2}$, establishing the exponential growth of diagonal Ramsey numbers.\n\n**The Off-Diagonal Question**: Erdős and Sós asked whether the ratio $R(k+1, k)/R(k, k)$ stays bounded away from 1. The trivial bound $R(k+1, k) - R(k, k) \\ge k - 2$ was known, but they couldn't even prove $R(k+1, k) - R(k, k) > k^c$ for any $c > 1$.\n\n**Resolution**: Burr, Erdős, Faudree, and Schelp (1989) proved $R(k+1, k) - R(k, k) \\ge 2k - 5$ in their paper 'On the difference between consecutive Ramsey numbers' (Utilitas Math.), asymptotically doubling the trivial bound and resolving the conjecture. The key technique involved careful analysis of critical colorings — 2-colorings of $K_{R(k,k)-1}$ avoiding both a red $(k+1)$-clique and a blue $k$-clique.",
@@ -249,8 +249,8 @@
       "Finset"
     ],
     "namespace": "Erdos1030",
-    "lineCount": 293,
-    "axiomCount": 16,
+    "lineCount": 256,
+    "axiomCount": 7,
     "theoremCount": 8,
     "definitionCount": 16
   }


### PR DESCRIPTION
## Summary
- Fixed `axiomCount`: 16 → 7 (file has exactly 7 `axiom` declarations, no structure-encoded assumptions)
- Fixed `lineCount`: 293 → 256 (actual file length)
- Fixed `assumptions` text to reflect correct count

## Evidence
- `grep -c "^axiom " proofs/Proofs/Erdos1030Problem.lean` → 7
- `wc -l proofs/Proofs/Erdos1030Problem.lean` → 256
- Sorry count (1) is correct — verified at line 201

## Test plan
- [ ] `pnpm build` passes with updated meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)