### PR TITLE
Gallery integrity: erdos-911 sorry count 0→1 (overclaim fix)

### DIFF
--- a/src/data/proofs/erdos-911/meta.json
+++ b/src/data/proofs/erdos-911/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 911,
     "erdosUrl": "https://erdosproblems.com/911",
     "erdosProblemStatus": "open",
@@ -52,8 +52,8 @@
       "erdos_911_statement theorem: equivalence"
     ],
     "axiomCount": 3,
-    "lineCount": 251,
-    "assumptions": "3 axioms: sizeRamseyNumber (definition), sizeRamseyNumber_spec, sizeRamseyNumber_minimal (specification). All essential for the core concept."
+    "lineCount": 236,
+    "assumptions": "3 axiom(s) and 1 sorry(s). Axioms: sizeRamseyNumber, sizeRamseyNumber_spec, sizeRamseyNumber_minimal. Sorry in size_ramsey_ge_edges (edge injection lemma)."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1982 [Er82e, p.78]. Size Ramsey numbers, introduced by Erdős, Faudree, Rousseau, and Schelp in 1978, measure the minimum edge complexity of Ramsey graphs.\n\nMajor results include:\n- Beck (1983): Paths have linear size Ramsey numbers R̂(Pₙ) = O(n)\n- Rödl-Szemerédi (2000): Complete graphs have R̂(Kₙ) = Θ(n²)\n- Kohayakawa-Rödl-Schacht-Szemerédi (2011): Bounded degree graphs have linear R̂\n\nThe question asks whether edge density forces additional Ramsey complexity. The motivation is that complete graphs K_n have Θ(n²) edges and R̂(K_n) = Θ(n²), giving R̂(G)/e(G) bounded — so no superlinear factor emerges even for the densest graphs. Erdős asked whether some dense family must exhibit superlinear R̂/e(G) growth, distinguishing density-driven complexity from degree-driven complexity established by the KRSS theorem.",
@@ -186,9 +186,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos911",
-    "lineCount": 210,
+    "lineCount": 236,
     "axiomCount": 3,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 7
   }
 }


### PR DESCRIPTION
## Summary
- **OVERCLAIM FIX**: `sorries` was 0, actual is 1 (sorry in `size_ramsey_ge_edges` at line 187, needs SimpleGraph.Embedding edge injection lemma)
- Fixed `lineCount`: 251→236 (meta section), 210→236 (leanFile section)
- Fixed `theoremCount`: 9→11
- Updated `assumptions` text to mention the sorry

## Severity
**HIGH** — Claiming 0 sorries when 1 exists misrepresents the verification status. The `size_ramsey_ge_edges` theorem is incomplete.

## Evidence
- `grep -n sorry proofs/Proofs/Erdos911Problem.lean` → line 187
- `wc -l proofs/Proofs/Erdos911Problem.lean` → 236
- `grep -c "^theorem " proofs/Proofs/Erdos911Problem.lean` → 11

## Test plan
- [ ] `pnpm build` passes with updated meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)