### PR TITLE
Research: erdos-1094 — eliminate axiom (prove naive Problem 384 false)

### DIFF
--- a/proofs/Proofs/Erdos1094Problem.lean
+++ b/proofs/Proofs/Erdos1094Problem.lean
@@ -176,13 +176,39 @@ def StrongestBound13 : Prop :=
 
 -- ## Part 8: Connection to Problem 384
 
-/-- The Erdős-Selfridge conjecture (Problem 384): if n ≥ 2k,
-    then C(n,k) has a prime factor ≤ n/k. This is weaker than #1094. -/
-def ErdosProblem384 : Prop :=
+/-- Naive formulation of Problem 384: "if n ≥ 2k, then C(n,k) has a prime
+    factor ≤ n/k." This is FALSE — see `erdos384_naive_false` below. -/
+def ErdosProblem384_Naive : Prop :=
   ∀ n k : ℕ, 0 < k → 2 * k ≤ n → ∃ p : ℕ, p.Prime ∧ p ∣ n.choose k ∧ p ≤ n / k
 
-/-- #1094 implies #384 for large n (the finite exceptions don't affect asymptotics) -/
-axiom main_implies_384 : ErdosProblem1094 → ErdosProblem384
+/-- The naive formulation of Problem 384 is false: C(7,3) = 35 = 5 × 7
+    has prime factors 5 and 7, both exceeding ⌊7/3⌋ = 2. The only prime
+    ≤ 2 is 2, and 2 ∤ 35. -/
+theorem erdos384_naive_false : ¬ErdosProblem384_Naive := by
+  intro h
+  obtain ⟨p, hp, hd, hle⟩ := h 7 3 (by omega) (by omega)
+  -- The only prime ≤ ⌊7/3⌋ = 2 is p = 2 (since p.Prime → 2 ≤ p)
+  have h2le := hp.two_le
+  have h7d3 : (7 : ℕ) / 3 = 2 := by native_decide
+  rw [h7d3] at hle
+  have heq : p = 2 := by omega
+  subst heq
+  -- But 2 ∤ C(7,3) = 35
+  have h35 : Nat.choose 7 3 = 35 := by native_decide
+  rw [h35] at hd
+  exact absurd hd (by decide)
+
+/-- Corrected Problem 384 (Erdős observation): for each k > 0, there exists
+    a threshold N(k) such that for all n ≥ N(k) with n ≥ 2k,
+    lpf(C(n,k)) ≤ n/k. This is the actual mathematical statement. -/
+def ErdosProblem384 : Prop :=
+  ∀ k : ℕ, 0 < k → ∃ N : ℕ, ∀ n : ℕ, N ≤ n → 2 * k ≤ n →
+    (n.choose k).minFac ≤ n / k
+
+-- The relationship: if #1094 holds (finitely many exceptions to the max(n/k,k)
+-- bound), then for each fixed k, sufficiently large n satisfies the n/k bound
+-- (since max(n/k, k) = n/k when n ≥ k²). This follows from basic set theory
+-- but the formal proof requires extracting bounds from finite sets.
 
 -- ## Part 9: Binomial Coefficient Properties
 
@@ -200,18 +226,21 @@ theorem choose_gt_one_10_3 : (10 : ℕ).choose 3 > 1 := by native_decide
 **Conjecture:** For n ≥ 2k, lpf(C(n,k)) ≤ max(n/k, k) with finitely many exceptions.
 
 **What we proved:**
-- 12 of 14 known exceptions verified computationally (native_decide)
+- All 14 known exceptions verified computationally (native_decide)
 - 8 non-exception cases verified
-- k=0 never exception, k=1 never exception
+- k=0 never exception, k=1 never exception (structural proofs)
 - Bound simplification for n ≥ k² and n < k²
-- C(n,k) > 1 for 0 < k < n
-- minFac of C(n,k) is prime when C(n,k) > 1
+- C(n,k) > 1 for specific small cases
+- The naive formulation of Problem 384 (∀ n ≥ 2k, ∃ prime ≤ n/k dividing C(n,k))
+  is FALSE: C(7,3) = 35 has only prime factors 5 and 7, both > ⌊7/3⌋ = 2
+- Corrected Problem 384 uses a sufficiency-large-n condition
 
 **What remains open:**
 - The finiteness conjecture itself
-- 2 large exceptions (C(241,16), C(284,28)) now proved by native_decide
-- Connection to Problem 384
 - Selfridge's conjecture, stronger bounds
+- Formal proof that #1094 implies the corrected #384
+
+**Axiom status:** 0 axioms (previously had 1 incorrect axiom asserting #1094 → naive #384)
 
 **References:** ELS88, ELS93, Guy B31/B33
 -/

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -19,22 +19,23 @@
     "erdosNumber": 1094,
     "erdosUrl": "https://erdosproblems.com/1094",
     "erdosProblemStatus": "open",
-    "axiomCount": 1,
-    "lineCount": 219,
-    "assumptions": "1 axiom: main_implies_384. See Lean source for the complete statement.",
+    "axiomCount": 0,
+    "lineCount": 248,
+    "assumptions": "None. Previously had 1 axiom (main_implies_384) which was eliminated by proving the naive formulation of Problem 384 is false.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "This conjecture emerged from a systematic study of prime factors of binomial coefficients by Erdős, Lacampagne, and Selfridge, published in 1988 and 1993. The question builds on Erdős Problem 384, which asks whether $\\binom{n}{k}$ always has a prime factor $\\leq n/k$ when $n \\geq 2k$. Problem 1094 strengthens this by asking about the *least* prime factor and allowing the bound $\\max(n/k, k)$ with only finitely many exceptions. John Selfridge (1977) independently made the stronger conjecture that the bound holds for all $n \\geq k^2 - 1$, with $\\binom{62}{6}$ as the unique exception. The list of 14 known exceptions was compiled by Erdős, Lacampagne, and Selfridge through extensive computation. The problem connects to classical questions about smooth numbers in combinatorial sequences and the distribution of prime factors of $n!$, studied via Legendre's formula and Kummer's theorem on p-adic valuations of binomial coefficients.",
     "problemStatement": "For all $n \\geq 2k$, is it true that $\\operatorname{lpf}\\binom{n}{k} \\leq \\max(n/k, k)$, with only finitely many exceptions?",
     "text": "For n ≥ 2k, the least prime factor of C(n,k) should be ≤ max(n/k, k) with only finitely many exceptions. OPEN.",
-    "proofStrategy": "The formalization defines LPFBound and IsException using Nat.minFac, then states ErdosProblem1094 as Set.Finite of the exception set. Twelve of 14 known exceptions are verified computationally via native_decide (two large ones are axiomatized). Non-exception cases demonstrate the bound holds generically. Structural results prove the bound simplifies for $n \\geq k^2$ and that $k = 0, 1$ produce no exceptions. Selfridge's refinement and two stronger conjectures (with $\\sqrt{k}$ and constant 13) are formalized. The connection to Problem 384 is axiomatized.",
+    "proofStrategy": "The formalization defines LPFBound and IsException using Nat.minFac, then states ErdosProblem1094 as Set.Finite of the exception set. All 14 known exceptions are verified computationally via native_decide. Non-exception cases demonstrate the bound holds generically. Structural results prove the bound simplifies for $n \\geq k^2$ and that $k = 0, 1$ produce no exceptions. Selfridge's refinement and two stronger conjectures (with $\\sqrt{k}$ and constant 13) are formalized. The naive formulation of Problem 384 is proved false via the C(7,3) counterexample, and a corrected formulation with a sufficiently-large-n condition is provided.",
     "keyInsights": [
       "The bound $\\operatorname{lpf}\\binom{n}{k} \\leq \\max(n/k, k)$ fails for only 14 known pairs, all with $k \\leq 28$, suggesting exceptions are confined to small parameters",
       "Selfridge's conjecture that $n \\geq k^2 - 1$ suffices (except $\\binom{62}{6}$) highlights a phase transition near $n = k^2$: below this threshold the 'small $n/k$' regime produces all but one exception",
       "The hierarchy of conjectures—from $\\max(n/k, k)$ to $\\max(n/k, \\sqrt{k})$ to $\\max(n/k, 13)$—suggests the true barrier is a small constant, not growing with $k$ at all",
       "Kummer's theorem (the p-adic valuation of $\\binom{n}{k}$ counts base-p carries) explains why even binomial coefficients trivially satisfy the bound: there is always a carry in base 2",
-      "The formalization verifies 12 of 14 exceptions via native_decide, demonstrating Lean's kernel can evaluate $\\operatorname{minFac}$ for binomial coefficients up to $\\binom{95}{10} \\approx 10^{10}$, while $\\binom{241}{16} \\approx 10^{27}$ exceeds feasibility"
+      "All 14 exceptions (including the large $\\binom{241}{16}$ and $\\binom{284}{28}$) are verified via native_decide, demonstrating Lean's kernel can evaluate $\\operatorname{minFac}$ even for binomial coefficients of order $10^{27}$ and $10^{38}$",
+      "The naive universal formulation of Problem 384 ($\\forall n \\geq 2k$, $\\exists$ prime $\\leq n/k$ dividing $\\binom{n}{k}$) is provably FALSE: $\\binom{7}{3} = 35 = 5 \\times 7$ has no prime factor $\\leq \\lfloor 7/3 \\rfloor = 2$"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -70,9 +71,9 @@
       "id": "verified-exceptions",
       "title": "Verified Exceptions",
       "startLine": 48,
-      "endLine": 87,
-      "summary": "Twelve exceptions verified by native_decide (C(7,3) through C(95,10)) and two axiomatized (C(241,16), C(284,28)).",
-      "mathContext": "Axiomatized: Twelve exceptions verified by native_decide (C(7,3) through C(95,10)) and two axiomatized (C(241,16), C(284,28))."
+      "endLine": 83,
+      "summary": "All 14 known exceptions verified by native_decide, including the large C(241,16) and C(284,28).",
+      "mathContext": "All 14 known exceptions verified computationally by native_decide."
     },
     {
       "id": "non-exceptions",
@@ -109,10 +110,10 @@
     {
       "id": "problem384",
       "title": "Connection to Problem 384",
-      "startLine": 179,
-      "endLine": 188,
-      "summary": "Defines Problem 384 and axiomatizes that Problem 1094 implies Problem 384.",
-      "mathContext": "Formal definition: Defines Problem 384 and axiomatizes that Problem 1094 implies Problem 384."
+      "startLine": 177,
+      "endLine": 211,
+      "summary": "Proves the naive formulation of Problem 384 is false via the C(7,3) counterexample (no prime ≤ 2 divides 35). Provides corrected formulation with sufficiently-large-n condition.",
+      "mathContext": "The naive statement '∀ n ≥ 2k, ∃ prime ≤ n/k dividing C(n,k)' is proved false. Corrected to: for each k, ∃ N(k) such that for n ≥ N(k), lpf(C(n,k)) ≤ n/k."
     },
     {
       "id": "binomial-props",
@@ -124,7 +125,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the full landscape of Erdős Problem 1094: the main conjecture on finiteness of exceptions, 12 computationally verified exceptions (2 axiomatized), structural simplification theorems, Selfridge's refinement, and two stronger conjectures pushing the bound toward a constant. The connection to the weaker Problem 384 is established.",
+    "summary": "This formalization captures the full landscape of Erdős Problem 1094: the main conjecture on finiteness of exceptions, all 14 computationally verified exceptions, structural simplification theorems, Selfridge's refinement, and two stronger conjectures pushing the bound toward a constant. The naive formulation of Problem 384 is proved false, with a corrected formulation provided.",
     "implications": "Resolution would reveal deep structure in the prime factorization of binomial coefficients—specifically, that small prime factors are ubiquitous in $\\binom{n}{k}$ for $n \\geq 2k$. The strongest form ($\\max(n/k, 13)$ with 12 exceptions) would imply that prime factors $\\leq 13$ account for almost all cases, connecting to smooth number theory and the distribution of carries in base-$p$ addition via Kummer's theorem.",
     "openQuestions": [
       "Are there exactly 14 exceptions to the LPF bound, or do undiscovered large exceptions exist?",
@@ -173,8 +174,8 @@
     "namespace": "Erdos1094",
     "lineCount": 219,
     "axiomCount": 1,
-    "theoremCount": 37,
-    "definitionCount": 7
+    "theoremCount": 38,
+    "definitionCount": 8
   },
   "references": [
     {

--- a/src/data/research/problems/erdos-1094.json
+++ b/src/data/research/problems/erdos-1094.json
@@ -29,9 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Eliminated 1 axiom by proving naive Problem 384 formulation is false via C(7,3) counterexample. Added corrected formulation. All 14 exceptions now verified (0 axioms, 0 sorries).",
+    "builtItems": [
+      "Proved erdos384_naive_false in Erdos1094Problem.lean:187 (C(7,3) counterexample)",
+      "Added corrected ErdosProblem384 definition in Erdos1094Problem.lean:204",
+      "Eliminated axiom main_implies_384 (axiomCount 1→0)"
+    ],
+    "insights": [
+      "The naive formulation of Problem 384 (∀ n≥2k, ∃ prime ≤ n/k dividing C(n,k)) is FALSE: C(7,3)=35=5×7 has no prime factor ≤ ⌊7/3⌋=2",
+      "Corrected #384: for each k, ∃ N(k) s.t. for all n≥N(k), lpf(C(n,k)) ≤ n/k (sufficiently-large-n condition)",
+      "Previous axiom main_implies_384 asserted #1094→naive #384, but since naive #384 is false, the axiom was incorrect and eliminated"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #1094 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor all $n\\geq 2k$ the least prime factor of $\\binom{n}{k}$ is $\\leq \\max(n/k,k)$, with only finitely many exceptions.\n\n\n\nA stronger form of [384] that appears in a paper of Erd\\H{o}s, Lacampagne, and Selfridge \\cite{ELS88}. Erd\\H{o}s observed that the least prime factor is always $\\leq n/k$ provided $n$ is sufficiently large depending on $k$. Selfridge \\cite{Se77} further conjectured that this always happens if $n\\geq k^2-1$, except $\\binom{62}{6}$.\n\nThe threshold $g(k)$ below which $\\binom{n}{k}$ is guaranteed to be divisible by a prime $\\leq k$ is the subject of [1095].\n\nMore precisely, in \\cite{ELS88} they conjecture that if $n\\geq 2k$ then the least prime factor of $\\binom{n}{k}$ is $\\leq \\max(n/k,k)$ with the following $14$ exceptions:\\[\\binom{7}{3},\\binom{13}{4},\\binom{23}{5},\\binom{14}{4},\\binom{44}{8},\\binom{46}{10},\\binom{47}{10},\\]\\[\\binom{47}{11},\\binom{62}{6},\\binom{74}{10},\\binom{94}{10},\\binom{95}{10},\\binom{241}{16},\\binom{284}{28}.\\]They also suggest the stronger conjecture that, with a finite number of exceptions, the least prime factor is $\\leq \\max(n/k,\\sqrt{k})$, or perhaps even $\\leq \\max(n/k,O(\\log k))$. Indeed, in \\cite{ELS93} they provide some further computational evidence, and point out it is consistent with what they know that in fact this holds with $\\leq \\max(n/k,13)$, with only $12$ exceptions.\n\nDiscussed in problem B31 and B33 of Guy's collection \\cite{Gu04} - there Guy credits Selfridge with the conjecture that if $n> 17.125k$ then $\\binom{n}{k}$ has a prime factor $p\\leq n/k$.\n\nThis is related to [1093], in that the only counterexamples to this conjecture can occur from $\\binom{n}{k}$ with deficiency $\\geq 1$.\n\nThere is an interesting discussion about this problem on MathOverflow.\n\n\n\n\nReferences\n\n\n[ELS88] Erd\\H{o}s, P. and Lacampagne, C. B. and Selfridge, J. L., Prime factors of binomial coefficients and related problems. Acta Arith. (1988), 507--523.\n\n[ELS93] Erd\\H{o}s, P. and Lacampagne, C. B. and Selfridge, J. L., Estimates of the least prime factor of a binomial coefficient. Math. Comp. (1993), 215--224.\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[Se77] J. L. Selfridge, Some problems on the prime factors of consecutive integers. Notices Amer. Math. Soc. (1977), A456-457.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #384\n- Problem #1095\n- Problem #1093\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #25\n\n## References\n\n- ELS88\n- ELS93\n- Se77\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"


### PR DESCRIPTION
## Summary
- Proved the naive formulation of Problem 384 is **false**: C(7,3) = 35 = 5×7 has no prime factor ≤ ⌊7/3⌋ = 2
- Eliminated the axiom `main_implies_384` which asserted #1094 → false statement
- Added corrected `ErdosProblem384` with sufficiently-large-n condition
- **Axiom count: 1 → 0** (fully axiom-free, 0 sorries)

## Progress
- `erdos384_naive_false`: Proves ¬ErdosProblem384_Naive via C(7,3) counterexample
- `ErdosProblem384`: Corrected formulation matching Erdős's actual observation
- Updated meta.json and gallery annotations

## Findings
- The naive statement "∀ n ≥ 2k, ∃ prime ≤ n/k dividing C(n,k)" is false because C(7,3) = 35 has only prime factors 5 and 7, both exceeding ⌊7/3⌋ = 2
- The correct statement requires a sufficiently-large-n condition: "for each k, ∃ N(k) such that for n ≥ N(k), lpf(C(n,k)) ≤ n/k"
- The removed axiom asserted an implication to a false conclusion, which could have led to inconsistency

## Status
**Outcome**: completed
**Next Steps**: The corrected #1094 → #384 implication could be proved formally (finite set argument)

🤖 Generated by researcher-2