### PR TITLE
Fix: close 4 unclosed block comments in Erdos818Problem.lean

### DIFF
--- a/proofs/Proofs/Erdos818Problem.lean
+++ b/proofs/Proofs/Erdos818Problem.lean
@@ -205,7 +205,7 @@ theorem proof_outline (A : Finset ℤ) (hA : A.card ≥ 2) (hne : A.Nonempty)
 There exist sets A with small sumset where |AA| = O(|A|² / log|A|).
 So the log factor cannot be removed entirely.
 -/
-/- The log factor is tight: there exist sets A with |A+A| ≤ 2|A| - 1
+/- The log factor is tight: there exist sets A with |A+A| ≤ 2|A| - 1 -/
 
 /-
 ## Part VII: Connection to Sum-Product Conjecture
@@ -227,7 +227,7 @@ Problem 818 asks: if |A+A| ≤ K|A|, then |AA| ≥ |A|²/log|A|?
 
 The latter is a conditional result: GIVEN small sumset, product set is large.
 -/
-/- Problem 52 conjectures max(|A+A|, |AA|) ≥ |A|^{2-ε}.
+/- Problem 52 conjectures max(|A+A|, |AA|) ≥ |A|^{2-ε}. -/
 
 /-
 ## Part VIII: Examples
@@ -239,7 +239,7 @@ If A = {1, 2, ..., n}, then:
 - |A + A| = 2n - 1 (small, additive doubling ~2)
 - |A · A| ≈ n²/log n (by Erdős multiplication table problem)
 -/
-/- For A = {1, ..., n}: |A+A| = 2n-1, |AA| ~ n²/log n.
+/- For A = {1, ..., n}: |A+A| = 2n-1, |AA| ~ n²/log n. -/
 
 /--
 **Example: Geometric progression**
@@ -248,7 +248,7 @@ If A = {1, r, r², ..., r^{n-1}}, then:
 - |A · A| = 2n - 1 (small, multiplicative structure)
 This shows the opposite extreme.
 -/
-/- For A = {1, r, r², ..., r^{n-1}} with r > n:
+/- For A = {1, r, r², ..., r^{n-1}} with r > n: -/
 
 /-
 ## Part IX: Summary

--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -17,7 +17,7 @@
       "product-set"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 4,
     "erdosNumber": 818,
     "erdosUrl": "https://erdosproblems.com/818",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Close 4 unclosed block comments that were nesting progressively and hiding the last ~80 lines from Lean.

## Evidence

**Before**: Lines 208, 230, 242, 251 had `/- ...` without matching `-/`, creating comment depth 4 that swallowed:
- `theorem erdos_818_summary` (line 269)
- `theorem key_insight` with sorry (line 284)
- `end Erdos818` (line 290)

**After**: All 4 comments properly closed. Theorems visible to Lean. meta.json sorries updated 3→4.

Closes #7191

---
Automated fix by lean-mechanic agent.