### PR TITLE
Research: erdos-635, erdos-705, erdos-417 — prove f_t1, threshold bound, totient structure

### DIFF
--- a/src/data/proofs/erdos-635/meta.json
+++ b/src/data/proofs/erdos-635/meta.json
@@ -67,9 +67,9 @@
       "no_far_multiples axiom: structural consequence excluding multiples",
       "erdos_635_t1_solved theorem: the t = 1 case from axioms"
     ],
-    "axiomCount": 5,
-    "lineCount": 265,
-    "assumptions": "5 axioms: f_t1 (t=1 exact value), f_t2_lower/erdos_construction_t2 (t=2 results), erdos_635 (OPEN conjecture), f_t1_density (limit). Proved: f_upper_trivial, f_monotone_t, f_lower_half."
+    "axiomCount": 4,
+    "lineCount": 358,
+    "assumptions": "4 axioms: f_t2_lower/erdos_construction_t2 (t=2 logarithmic improvement), erdos_635 (OPEN conjecture), f_t1_density (limit). f_t1 now fully proved via no-consecutive grouping argument."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #635** originates from a letter Erdős wrote to Imre Ruzsa around 1980. The problem asks a deceptively simple question: given a subset A of {1,...,N} where large differences between elements cannot divide the larger element, how big can A be? This sits at the intersection of additive and multiplicative number theory, where the additive structure (gaps between elements) interacts with multiplicative structure (divisibility).\n\nThe problem has a clean answer for t = 1: the optimal set consists of all odd numbers in {1,...,N}, giving exactly ⌊(N+1)/2⌋ elements. The key insight is that the difference of two odd numbers is always even, and an even number cannot divide an odd number. This elegant argument completely resolves the t = 1 case. For t = 2, Erdős himself showed that one can beat the N/2 barrier by a logarithmic factor, constructing sets of size N/2 + c·log(N) by augmenting odd numbers with carefully chosen powers of 2.\n\nDespite these partial results, the general conjecture — that the density is always close to 1/2 regardless of t — remains open. The difficulty lies in the fact that larger t relaxes the constraint (applying only to pairs with large enough gaps), yet the conjecture asserts this doesn't fundamentally change the extremal density. The references [Gu83] by Gupta and [Ru99] by Ruzsa contain related work on divisibility conditions in combinatorial number theory.",
@@ -183,8 +183,8 @@
     ],
     "namespace": "Erdos635",
     "lineCount": 265,
-    "axiomCount": 8,
-    "theoremCount": 5,
+    "axiomCount": 4,
+    "theoremCount": 9,
     "definitionCount": 5
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

### erdos-635: Prove f_t1 Axiom (5→4 axioms)
- **PROVED** `f_t1`: f(N,1) = ⌊(N+1)/2⌋ — was axiom, now fully proved theorem
  - Key insight: 1-admissibility prohibits consecutive elements (1 divides everything)
  - Grouping argument: map n → (n+1)/2, injective on non-consecutive sets
  - Upper bound from group count, lower bound from odd set
- Add `t1_no_consecutive`, `no_consec_card_bound`, `f_large_t`

### erdos-705: Threshold Lower Bound (+2 theorems)
- Prove `threshold_ge_6`: any threshold k satisfying the conjecture must be ≥ 6

### erdos-417: Totient Value Structure (+3 theorems)
- Prove `totient_zero_one_or_even`, `V_element_structure`, `prime_sub_one_even`

## Status
- **erdos-635**: 5→4 axioms, 5→9 theorems (axiom eliminated!)
- **erdos-705**: 6 axioms, +2 theorems
- **erdos-417**: 3 axioms (all open), +3 theorems

🤖 Generated by researcher-1