### PR TITLE
Gallery integrity: erdos-623 sorry count 6→5

### DIFF
--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -18,7 +18,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 6,
+    "sorries": 5,
     "erdosNumber": 623,
     "erdosUrl": "https://erdosproblems.com/623",
     "erdosProblemStatus": "open",
@@ -52,7 +52,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "1 axiom declaration: erdos_hajnal_below_aleph_omega (for |X| < aleph_omega, exists free f with no infinite independent set)",
-    "lineCount": 268
+    "lineCount": 272
   },
   "overview": {
     "historicalContext": "Erdős and Hajnal introduced this problem in their landmark 1958 paper on partition relations for cardinal numbers, which laid the foundations of infinitary combinatorics. The central question asks whether every 'free' function $f: [X]^{<\\omega} \\to X$ on a set of cardinality $\\aleph_\\omega$ must admit an infinite independent set.\n\nThe Erdős-Hajnal theorem (1958) provides a complete negative answer for all cardinals below $\\aleph_\\omega$: for each $\\aleph_n$ with $n < \\omega$, one can construct a free function with no infinite independent set. The construction uses transfinite induction along the ordinal $\\omega_n$, building a 'defeating' function level by level. This makes $\\aleph_\\omega$ the precise threshold where the question transitions from resolved to open.\n\nThe significance of $\\aleph_\\omega$ lies in its being the first singular cardinal—its cofinality is $\\omega$ (countable), yet its cardinality is uncountable. Saharon Shelah's PCF theory (1978–1994) revealed deep structural properties of singular cardinals, showing that products $\\prod_{n<\\omega} \\aleph_n$ can be analyzed through 'possible cofinalities.' Silver's theorem (1974) showed that if GCH holds below a singular cardinal of uncountable cofinality, it holds at that cardinal too—but $\\aleph_\\omega$ has countable cofinality, so Silver's theorem does not apply.\n\nIn 1999, Erdős himself suggested this problem is 'perhaps undecidable,' meaning its truth might depend on set-theoretic axioms beyond ZFC. This connects to the broader phenomenon that combinatorial problems at singular cardinals—including Shelah's celebrated work on the singular cardinals hypothesis—often exhibit independence from standard axioms. The Proper Forcing Axiom (PFA) and large cardinal hypotheses could potentially determine the answer.",
@@ -194,7 +194,7 @@
       "Set"
     ],
     "namespace": "Erdos623",
-    "lineCount": 268,
+    "lineCount": 272,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 10


### PR DESCRIPTION
## Summary
- Fixed `sorries`: 6 → 5 (actual sorry occurrences at lines 54, 104, 123, 150, 235)
- Fixed `lineCount`: 268 → 272 (both meta and leanFile sections)

## Evidence
- `grep -n sorry proofs/Proofs/Erdos623Problem.lean` → 5 matches
- `wc -l proofs/Proofs/Erdos623Problem.lean` → 272
- All sorries verified outside comments (comment depth=0 at each)

## Test plan
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)