### PR TITLE
Research: erdos-533 — add structural theorems and partial resolution

### DIFF
--- a/proofs/Proofs/Erdos533Problem.lean
+++ b/proofs/Proofs/Erdos533Problem.lean
@@ -14,10 +14,7 @@ Status: OPEN.
 Reference: https://erdosproblems.com/533
 -/
 
-import Mathlib.Tactic
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Finset.Basic
+import Mathlib
 
 /- ## Definitions -/
 
@@ -132,6 +129,18 @@ theorem isTriangleFree_of_no_triangle {n : ℕ} (G : SGraph n)
       first | exact absurd rfl hij | exact eab | exact ebc | exact eac |
       exact G.symm _ _ eab | exact G.symm _ _ ebc | exact G.symm _ _ eac
 
+/-- Clique-freeness is upward-closed: no j-clique implies no k-clique for k ≥ j.
+    Contrapositive of hasClique_mono. -/
+theorem not_hasClique_mono {n : ℕ} (G : SGraph n) {j k : ℕ} (hjk : j ≤ k)
+    (hj : ¬HasClique G j) : ¬HasClique G k :=
+  fun hk => hj (hasClique_mono G hjk hk)
+
+/-- K₅-free graphs are also K₇-free. The Erdős–Rogers counterexample
+    uses K₇-free graphs, so it does not directly obstruct Problem 533. -/
+theorem k5_free_implies_k7_free {n : ℕ} (G : SGraph n) (h : ¬HasClique G 5) :
+    ¬HasClique G 7 :=
+  not_hasClique_mono G (by omega) h
+
 /- ## Known Partial Results -/
 
 /-- Erdős–Hajnal–Simonovits–Sós–Szemerédi: for δ > 1/16, any K₅-free graph
@@ -159,6 +168,19 @@ axiom erdos_rogers_counterexample :
     (1 : ℝ) / 4 * n ^ 2 ≤ (edgeCount G : ℝ) ∧
     ∀ (S : Finset (Fin n)), IsTriangleFree G S →
       (S.card : ℝ) < C * n
+
+/- ## Partial Resolution -/
+
+/-- For δ > 1/16, Problem 533 follows from the known ehsss_result.
+    The constant c = δ/2 works. The open part is 0 < δ ≤ 1/16. -/
+theorem erdos_533_for_large_delta (δ : ℝ) (hδ : 0 < δ) (hδ_large : 1 / 16 < δ) :
+    ∃ c : ℝ, 0 < c ∧ ∀ (n : ℕ) (hn : 1 ≤ n)
+      (G : SGraph n) (hK5 : ¬HasClique G 5)
+      (hEdges : δ * n ^ 2 ≤ (edgeCount G : ℝ)),
+    ∃ (S : Finset (Fin n)), IsTriangleFree G S ∧
+      (S.card : ℝ) ≥ c * n :=
+  ⟨δ / 2, by linarith, fun n hn G hK5 hEdges =>
+    ehsss_result n hn δ hδ_large G hK5 hEdges⟩
 
 /- ## The Open Question -/
 

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -21,8 +21,8 @@
     "erdosUrl": "https://erdosproblems.com/533",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
-    "lineCount": 173,
-    "assumptions": "4 axioms: ehsss_result, k4_free_triangle_free_subset, erdos_rogers_counterexample, and 1 more. See Lean source for complete statements.",
+    "lineCount": 195,
+    "assumptions": "4 axioms: ehsss_result (EHSSS partial result), k4_free_triangle_free_subset (K4-free case), erdos_rogers_counterexample (K7 counterexample), erdos_533_conjecture (the open conjecture). All are deep published results or open problems.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -139,16 +139,13 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Tactic",
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Finset.Basic"
+      "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 173,
+    "lineCount": 195,
     "axiomCount": 4,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 5
   },
   "references": [

--- a/src/data/research/problems/erdos-533.json
+++ b/src/data/research/problems/erdos-533.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 7 structural lemmas (monotonicity, subsets, basic clique/triangle-free properties). File now has 12 theorems, 4 axioms, 0 sorries, 173 lines.",
+    "progressSummary": "SURVEYED: Added 3 theorems (clique-free monotonicity, K5→K7 connection, partial resolution for delta>1/16). 4 axioms are all deep/open — cannot be eliminated.",
     "builtItems": [
       "isTriangleFree_subset: monotonicity of triangle-free sets (line 84-88)",
       "isClique_subset: monotonicity of cliques (line 90-93)",
@@ -37,7 +37,10 @@
       "hasClique_zero: trivial 0-clique via empty set (line 102-104)",
       "hasClique_one: singleton 1-clique (line 106-109)",
       "isTriangleFree_pair: pairs are triangle-free (line 111-117)",
-      "isTriangleFree_of_no_triangle: no K3 implies all subsets triangle-free (line 119-134)"
+      "isTriangleFree_of_no_triangle: no K3 implies all subsets triangle-free (line 119-134)",
+      "Proved not_hasClique_mono (contrapositive clique-free monotonicity)",
+      "Proved k5_free_implies_k7_free",
+      "Proved erdos_533_for_large_delta (partial resolution using ehsss axiom)"
     ],
     "insights": [
       "Axioms are all deep published results (EHSSS, K4-free case, Erdos-Rogers counterex, main conjecture) - none provable from Mathlib",
@@ -45,7 +48,10 @@
       "Triangle-free and clique definitions compose naturally via negation/subset transfer",
       "HasClique is monotone: k-clique implies j-clique for j ≤ k via Finset.exists_smaller_set",
       "IsTriangleFree is anti-monotone: subsets of triangle-free sets are triangle-free",
-      "Absence of K3 (triangle) implies all subsets are trivially triangle-free"
+      "Absence of K3 (triangle) implies all subsets are trivially triangle-free",
+      "4 axioms are all deep results (EHSSS, K4-free case, Erdos-Rogers) or the open conjecture itself — cannot be eliminated from Mathlib",
+      "For delta > 1/16, the conjecture follows directly from ehsss_result with c = delta/2",
+      "K5-free implies K7-free, so the Erdos-Rogers counterexample (K7-free) does not obstruct Problem 533"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Added 3 theorems to erdos-533 (K₅-free triangle-free subsets in dense graphs)
- Proved partial resolution: conjecture follows from known results for δ > 1/16
- Unified imports to `import Mathlib`

## Progress
- `not_hasClique_mono`: Clique-freeness is upward-closed (contrapositive of hasClique_mono)
- `k5_free_implies_k7_free`: K₅-free implies K₇-free, so Erdős-Rogers counterexample doesn't apply
- `erdos_533_for_large_delta`: For δ > 1/16, the conjecture follows from ehsss_result with c = δ/2

## Findings
- All 4 axioms are deep published results or the open conjecture itself — cannot be eliminated from Mathlib
- The open part of Problem 533 is specifically 0 < δ ≤ 1/16

## Status
**Outcome**: surveyed
**Next Steps**: The 4 axioms require deep extremal graph theory infrastructure to prove formally

🤖 Generated by researcher-2