### PR TITLE
Research: erdos-261, erdos-635 — prove representable_one, f_t1, totient structure

### DIFF
--- a/proofs/Proofs/Erdos261Problem.lean
+++ b/proofs/Proofs/Erdos261Problem.lean
@@ -129,8 +129,29 @@ theorem partial_sum_formula (n : ℕ) :
 
 /- ## Known Results -/
 
+/-- n = 1 is representable: 1/2 = 4/16 + 5/32 + 6/64. -/
+theorem representable_one : IsRepresentable 1 := by
+  refine ⟨{4, 5, 6}, ?_, ?_, ?_⟩
+  · -- card ≥ 2
+    simp [Finset.card_insert_of_not_mem, Finset.card_singleton]; omega
+  · -- all ≥ 1
+    intro k hk; simp [Finset.mem_insert, Finset.mem_singleton] at hk
+    rcases hk with rfl | rfl | rfl <;> omega
+  · -- sum = 1/2 (= recipPow2Weight 1)
+    show recipPow2Sum {4, 5, 6} = recipPow2Weight 1
+    simp only [recipPow2Sum, recipPow2Weight]
+    simp only [Finset.sum_insert (show (4 : ℕ) ∉ ({5, 6} : Finset ℕ) by decide),
+                Finset.sum_insert (show (5 : ℕ) ∉ ({6} : Finset ℕ) by decide),
+                Finset.sum_singleton]
+    norm_num
+
 /-- Borwein–Loring explicit family: n = 2^{m+1} − m − 2 is representable
-    via the consecutive block {n+1, ..., n+m} -/
+    via the consecutive block {n+1, ..., n+m} for m ≥ 2.
+    For m = 1 (n = 1), the consecutive block has card 1, so we use
+    representable_one instead.
+    Proof strategy for m ≥ 2: telescoping via partial_sum_formula gives
+    ∑_{k=n+1}^{n+m} = (n+2)/2^n - (n+m+2)/2^{n+m} = n/2^n
+    using the key identity n + m + 2 = 2^{m+1}. -/
 axiom borwein_loring_family (m : ℕ) (hm : 1 ≤ m) :
   let n := 2 ^ (m + 1) - m - 2
   IsRepresentable n

--- a/src/data/proofs/erdos-635/meta.json
+++ b/src/data/proofs/erdos-635/meta.json
@@ -67,9 +67,9 @@
       "no_far_multiples axiom: structural consequence excluding multiples",
       "erdos_635_t1_solved theorem: the t = 1 case from axioms"
     ],
-    "axiomCount": 5,
-    "lineCount": 265,
-    "assumptions": "5 axioms: f_t1 (t=1 exact value), f_t2_lower/erdos_construction_t2 (t=2 results), erdos_635 (OPEN conjecture), f_t1_density (limit). Proved: f_upper_trivial, f_monotone_t, f_lower_half."
+    "axiomCount": 4,
+    "lineCount": 358,
+    "assumptions": "4 axioms: f_t2_lower/erdos_construction_t2 (t=2 logarithmic improvement), erdos_635 (OPEN conjecture), f_t1_density (limit). f_t1 now fully proved via no-consecutive grouping argument."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #635** originates from a letter Erdős wrote to Imre Ruzsa around 1980. The problem asks a deceptively simple question: given a subset A of {1,...,N} where large differences between elements cannot divide the larger element, how big can A be? This sits at the intersection of additive and multiplicative number theory, where the additive structure (gaps between elements) interacts with multiplicative structure (divisibility).\n\nThe problem has a clean answer for t = 1: the optimal set consists of all odd numbers in {1,...,N}, giving exactly ⌊(N+1)/2⌋ elements. The key insight is that the difference of two odd numbers is always even, and an even number cannot divide an odd number. This elegant argument completely resolves the t = 1 case. For t = 2, Erdős himself showed that one can beat the N/2 barrier by a logarithmic factor, constructing sets of size N/2 + c·log(N) by augmenting odd numbers with carefully chosen powers of 2.\n\nDespite these partial results, the general conjecture — that the density is always close to 1/2 regardless of t — remains open. The difficulty lies in the fact that larger t relaxes the constraint (applying only to pairs with large enough gaps), yet the conjecture asserts this doesn't fundamentally change the extremal density. The references [Gu83] by Gupta and [Ru99] by Ruzsa contain related work on divisibility conditions in combinatorial number theory.",
@@ -183,8 +183,8 @@
     ],
     "namespace": "Erdos635",
     "lineCount": 265,
-    "axiomCount": 8,
-    "theoremCount": 5,
+    "axiomCount": 4,
+    "theoremCount": 9,
     "definitionCount": 5
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-261.json
+++ b/src/data/research/problems/erdos-261.json
@@ -44,7 +44,10 @@
       "Key identity: sum_{k=1}^n k/2^k = 2 - (n+2)/2^n, proved by induction in partial_sum_formula",
       "Partial sum formula enables proving BL family: n+m+2 = 2^{m+1} makes telescoping sum equal n/2^n",
       "For m=1 (n=1), the BL set {n+1} has only 1 element — need separate argument for representability of 1",
-      "recipPow2Weight has the coincidence w(1) = w(2) = 1/2, then strictly decreasing for k >= 2"
+      "recipPow2Weight has the coincidence w(1) = w(2) = 1/2, then strictly decreasing for k >= 2",
+      "borwein_loring_identity key step: (n+2)/2^n - 2^{m+1}/2^{n+m} = n/2^n, since 2^{m+1}/2^{n+m} = 2/2^n",
+      "For m=1 (n=1): consecutive block {2} has card 1, need alternate construction S={4,5,6} (verified: 4/16+5/32+6/64=1/2)",
+      "Proof strategy: Icc sum = difference of partial sums via partial_sum_formula, then n+m+2=2^{m+1} collapses everything"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-261.json
+++ b/src/data/research/problems/erdos-261.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 8 new lemmas including key partial_sum_formula. File has 16 theorems, 5 axioms, 195 lines. Path to proving borwein_loring_family is clear.",
+    "progressSummary": "PROGRESS: Proved representable_one (n=1 via S={4,5,6}). 5 axioms, 17+ theorems. borwein_loring_family proof strategy documented.",
     "builtItems": [
       "recipPow2Weight_zero: w(0) = 0",
       "recipPow2Weight_three: w(3) = 3/8",
@@ -37,7 +37,8 @@
       "recipPow2Sum_insert: sum decomposes on insert",
       "recipPow2Sum_pair: explicit sum for 2-element set",
       "recipPow2Sum_le_of_subset: monotonicity of sum under subset inclusion",
-      "partial_sum_formula: KEY — sum_{k=1}^n k/2^k = 2 - (n+2)/2^n by induction"
+      "partial_sum_formula: KEY — sum_{k=1}^n k/2^k = 2 - (n+2)/2^n by induction",
+      "representable_one: proved n=1 is representable via S={4,5,6} with norm_num"
     ],
     "insights": [
       "borwein_loring_family is the only provable axiom (5 total) — proof requires partial_sum_formula + telescoping + substitution",


### PR DESCRIPTION
## Summary

### erdos-261: Prove representable_one
- Prove `representable_one`: n=1 is representable via S={4,5,6} (4/16 + 5/32 + 6/64 = 1/2)
- Document telescoping proof strategy for general Borwein-Loring construction

### erdos-635: Prove f_t1 (5→4 axioms)
- **PROVED** `f_t1`: f(N,1) = ⌊(N+1)/2⌋ via no-consecutive grouping argument
- Add `t1_no_consecutive`, `no_consec_card_bound`, `f_large_t`

### erdos-705: Threshold bound (+2 theorems)
- Prove `threshold_ge_6`: any k satisfying conjecture must be ≥ 6

### erdos-417: Totient structure (+3 theorems)
- Prove `totient_zero_one_or_even`, `V_element_structure`, `prime_sub_one_even`

## Axiom changes
- erdos-635: 5→4 axioms (f_t1 proved!)
- Others: axiom counts unchanged

🤖 Generated by researcher-1