### PR TITLE
Gallery integrity: erdos-31 hidden axiom, status formalized→axiomatized

### DIFF
--- a/src/data/proofs/erdos-31/meta.json
+++ b/src/data/proofs/erdos-31/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Straus (conjecture); Lorentz (1954, proof)",
     "sourceUrl": "https://erdosproblems.com/31",
     "date": "1954",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos31Problem.lean",
     "tags": [
       "erdos",
@@ -16,8 +16,8 @@
       "sumsets",
       "additive-bases"
     ],
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 31,
     "erdosUrl": "https://erdosproblems.com/31",
     "erdosProblemStatus": "solved",
@@ -55,15 +55,15 @@
       "Proof that optimal B-density is 0 (using non-negativity of density)",
       "Connection to asymptotic additive bases of order 2"
     ],
-    "axiomCount": 0,
-    "lineCount": 815,
+    "axiomCount": 1,
+    "lineCount": 786,
     "prerequisites": [
       "Additive complements of sets",
       "Asymptotic density",
       "Sumset theory (A + B)",
       "Analytic number theory"
     ],
-    "assumptions": "1 sorry: density zero of greedy Lorentz complement (lorentzB_density_zero). Coverage is fully proved."
+    "assumptions": "1 axiom(s) and 0 sorry(s). Axiom: lorentz_theorem (Lorentz's 1954 result axiomatized). No sorries remain."
   },
   "overview": {
     "historicalContext": "Erdős and Straus conjectured that any infinite set A can be 'completed' to cover almost all of ℕ using only a very sparse set B (density 0).\n\nLorentz proved this in 1954, showing that the additive structure of infinite sets is quite flexible. The proof constructs B by filling in 'gaps' in the sumset, and the sparseness of the construction depends on the distribution of A.\n\nThis result is fundamental to additive combinatorics: it shows that even very sparse sets can have rich additive structure when combined appropriately.",
@@ -155,8 +155,8 @@
       "Filter"
     ],
     "namespace": "Erdos31",
-    "lineCount": 815,
-    "axiomCount": 0,
+    "lineCount": 786,
+    "axiomCount": 1,
     "theoremCount": 28,
     "definitionCount": 14
   },


### PR DESCRIPTION
## Summary
- **Hidden axiom**: `lorentz_theorem` at line 551 was not reflected in `axiomCount` (0→1)
- **Wrong status**: "formalized" → "axiomatized" (has 1 axiom, 0 sorries)
- **Badge**: "formalized" → "axiom"
- **Sorries**: 1→0 (sorry was previously removed from Lean file but meta not updated)
- **lineCount**: 815→786

## Severity
**MEDIUM** — Axiom masking: the axiomCount of 0 hid the fact that the main result (Lorentz's theorem) is axiomatized, not proved.

## Evidence
- `grep -n "^axiom " proofs/Proofs/Erdos31Problem.lean` → line 551: `axiom lorentz_theorem`
- `grep -n sorry proofs/Proofs/Erdos31Problem.lean` → no matches
- `wc -l proofs/Proofs/Erdos31Problem.lean` → 786

## Test plan
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)