### PR TITLE
Research: prove 7 axioms across 4 Erdős problems

### DIFF
--- a/proofs/Proofs/Erdos1028Problem.lean
+++ b/proofs/Proofs/Erdos1028Problem.lean
@@ -72,6 +72,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Int.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 
 open Finset
@@ -152,9 +153,12 @@ They proved H(n) ≫ n^{3/2}, matching the upper bound.
 axiom erdos_spencer_lower : ∃ c > 0, ∃ N : ℕ, ∀ n ≥ N,
   (H n : ℝ) ≥ c * (n : ℝ) ^ (3/2 : ℝ)
 
-/-- n ≤ n^{3/2} for n ≥ 2: the cubic-root bound is weaker. -/
-axiom erdos_spencer_improves (n : ℕ) (hn : n ≥ 2) :
-    (n : ℝ) ≤ (n : ℝ) ^ (3/2 : ℝ)
+/-- n ≤ n^{3/2} for n ≥ 2: follows from n = n^1 and exponent monotonicity. -/
+theorem erdos_spencer_improves (n : ℕ) (hn : n ≥ 2) :
+    (n : ℝ) ≤ (n : ℝ) ^ (3/2 : ℝ) := by
+  have h1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast (show 1 ≤ n by omega)
+  conv_lhs => rw [← rpow_one (↑n : ℝ)]
+  exact rpow_le_rpow_of_exponent_le h1 (by norm_num : (1 : ℝ) ≤ 3 / 2)
 /-
 ## The Main Result: H(n) = Θ(n^{3/2})
 

--- a/proofs/Proofs/Erdos663Problem.lean
+++ b/proofs/Proofs/Erdos663Problem.lean
@@ -100,14 +100,30 @@ def RelatedToProblem457 : Prop :=
 /-- Small primes always divide sufficiently long consecutive products.
     If p ≤ k, then p divides (n+1)(n+2)···(n+k) since among k consecutive
     integers, at least one is divisible by p. -/
-axiom small_prime_divides_product (n k p : ℕ)
+theorem small_prime_divides_product (n k p : ℕ)
     (hp : p.Prime) (hpk : p ≤ k) :
-    p ∣ consecutiveProduct n k
+    p ∣ consecutiveProduct n k := by
+  unfold consecutiveProduct
+  -- Among k ≥ p consecutive integers n+1, ..., n+k, one is divisible by p.
+  -- Specifically, take i = (p - (n+1) mod p) mod p; then i < p ≤ k and p | (n+i+1).
+  have hp_pos := hp.pos
+  have ⟨i, hi, hdvd⟩ : ∃ i < k, p ∣ (n + i + 1) := by
+    refine ⟨(p - (n + 1) % p) % p, lt_of_lt_of_le (Nat.mod_lt _ hp_pos) hpk, ?_⟩
+    have h_div := Nat.div_add_mod (n + 1) p
+    by_cases hr : (n + 1) % p = 0
+    · simp [hr, Nat.mod_self]; exact ⟨(n + 1) / p, by omega⟩
+    · rw [Nat.mod_eq_of_lt (by omega : p - (n + 1) % p < p)]
+      exact ⟨(n + 1) / p + 1, by omega⟩
+  exact dvd_trans hdvd (Finset.dvd_prod_of_mem _ (Finset.mem_range.mpr hi))
 
 /-- Lower bound: q(n,k) > k for all n, since every prime p ≤ k divides
     some term in k consecutive integers. -/
-axiom q_gt_k (n k : ℕ) (hk : 1 < k) :
-    k < smallestMissingPrime n k
+theorem q_gt_k (n k : ℕ) (hk : 1 < k) :
+    k < smallestMissingPrime n k := by
+  by_contra h
+  push_neg at h
+  exact smallestMissingPrime_not_dvd n k (by omega)
+    (small_prime_divides_product n k _ (smallestMissingPrime_prime n k (by omega)) h)
 
 /- ## Monotonicity Properties -/
 

--- a/proofs/Proofs/Erdos855Problem.lean
+++ b/proofs/Proofs/Erdos855Problem.lean
@@ -41,9 +41,12 @@ noncomputable def primePi (n : ℕ) : ℕ :=
 
 /--
 **Basic Property:**
-π is monotonically increasing.
+π is monotonically increasing, since Icc 1 m ⊆ Icc 1 n when m ≤ n.
 -/
-axiom primePi_monotone : Monotone primePi
+theorem primePi_monotone : Monotone primePi := by
+  intro m n hmn
+  unfold primePi
+  exact Finset.card_le_card (Finset.filter_subset_filter _ (Finset.Icc_subset_Icc_right hmn))
 
 /--
 **Prime Number Theorem:**

--- a/proofs/Proofs/Erdos913Problem.lean
+++ b/proofs/Proofs/Erdos913Problem.lean
@@ -93,14 +93,33 @@ Small examples of n with distinct exponents in n(n+1):
 - n = 127: 127·128 = 2⁷·127, exponents {7,1} distinct
 -/
 
+/-- Helper: prove distinct exponents by reducing to concrete prime factor enumeration. -/
+private theorem hasDistinctExponents_of_primeFactors_pair
+    {n : ℕ} {m p q : ℕ} (hm : n * (n + 1) = m) (hpf : m.primeFactors = {p, q})
+    (hne : m.factorization p ≠ m.factorization q) :
+    HasDistinctExponents n := by
+  unfold HasDistinctExponents
+  rw [hm, hpf]
+  intro x hx y hy heq
+  simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
+             Set.mem_singleton_iff] at hx hy
+  rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
+  · rfl
+  · exact absurd heq hne
+  · exact absurd heq (Ne.symm hne)
+  · rfl
+
 /-- n = 3 has distinct exponents: 3·4 = 2²·3¹. -/
-axiom example_n3 : HasDistinctExponents 3
+theorem example_n3 : HasDistinctExponents 3 :=
+  hasDistinctExponents_of_primeFactors_pair (by norm_num) (by native_decide) (by native_decide)
 
 /-- n = 7 has distinct exponents: 7·8 = 2³·7¹. -/
-axiom example_n7 : HasDistinctExponents 7
+theorem example_n7 : HasDistinctExponents 7 :=
+  hasDistinctExponents_of_primeFactors_pair (by norm_num) (by native_decide) (by native_decide)
 
 /-- n = 8 has distinct exponents: 8·9 = 2³·3². -/
-axiom example_n8 : HasDistinctExponents 8
+theorem example_n8 : HasDistinctExponents 8 :=
+  hasDistinctExponents_of_primeFactors_pair (by norm_num) (by native_decide) (by native_decide)
 
 /-
 ## Section 6: Connection to Bunyakovsky conjecture

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1028",
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
-    "axiomCount": 7,
-    "lineCount": 318,
-    "assumptions": "7 axioms: erdos_upper, erdos_spencer_lower, erdos_spencer_improves, and 4 more. See Lean source for complete statements.",
+    "axiomCount": 6,
+    "lineCount": 320,
+    "assumptions": "6 axioms: erdos_upper, erdos_spencer_lower, random_upper, large_discrepancy_exists, H_two, H_three. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-663/meta.json
+++ b/src/data/proofs/erdos-663/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 663,
     "erdosUrl": "https://erdosproblems.com/663",
     "erdosProblemStatus": "open",
-    "axiomCount": 7,
-    "lineCount": 127,
-    "assumptions": "7 axioms: smallestMissingPrime, smallestMissingPrime_prime, smallestMissingPrime_not_dvd, and 4 more. See Lean source for complete statements.",
+    "axiomCount": 5,
+    "lineCount": 140,
+    "assumptions": "5 axioms: smallestMissingPrime (def), smallestMissingPrime_prime, smallestMissingPrime_not_dvd, smallestMissingPrime_least, q_mono_k. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-855/meta.json
+++ b/src/data/proofs/erdos-855/meta.json
@@ -54,9 +54,9 @@
       "StrausConjecture and ErdosWeakerConjecture formulations",
       "erdos_855_summary theorem"
     ],
-    "axiomCount": 7,
+    "axiomCount": 6,
     "lineCount": 186,
-    "assumptions": "7 axioms: primePi_monotone, prime_number_theorem, hensley_richards_incompatibility, and 4 more. See Lean source for complete statements."
+    "assumptions": "6 axioms: prime_number_theorem, hensley_richards_incompatibility, montgomery_vaughan_upper, k_tuples_conjecture, second_HL, prime_gap_bound. See Lean source."
   },
   "overview": {
     "historicalContext": "The Second Hardy-Littlewood Conjecture asserts that π(x+y) ≤ π(x) + π(y) for all sufficiently large x and y, where π denotes the prime counting function. Erdős described it as 'an old conjecture of mine which was probably already stated by Hardy and Littlewood.' The conjecture suggests that the interval [1, x+y] can never contain more primes than the intervals [1, x] and [1, y] combined.\n\nThe major development came in 1973 when Hensley and Richards proved that this conjecture is incompatible with the prime k-tuples conjecture, which asserts that any admissible pattern of primes occurs infinitely often. Their proof showed that admissible tuples can be denser than the primes themselves: for large k, there exist admissible k-tuples in [0,k) with more than π(k) elements. If k-tuples holds, placing these dense tuples at the right position would violate π(x+y) ≤ π(x) + π(y).\n\nSince most number theorists believe the k-tuples conjecture is true (it is supported by extensive numerical evidence and heuristic arguments), the Second Hardy-Littlewood Conjecture is considered likely false. However, no explicit counterexample has been found despite extensive computation. Montgomery and Vaughan proved the unconditional bound π(x+y) ≤ π(x) + 2y/log(y), which is weaker but does not require any unproved hypothesis.",
@@ -146,7 +146,7 @@
     "opens": [],
     "namespace": "Erdos855",
     "lineCount": 186,
-    "axiomCount": 7,
+    "axiomCount": 6,
     "theoremCount": 2,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -19,9 +19,9 @@
     "erdosNumber": 913,
     "erdosUrl": "https://erdosproblems.com/913",
     "erdosProblemStatus": "open",
-    "axiomCount": 6,
-    "lineCount": 134,
-    "assumptions": "6 axioms: infinite_8p_sq_minus_1_primes, erdos_913_conditional, example_n3, and 3 more. See Lean source for complete statements.",
+    "axiomCount": 3,
+    "lineCount": 150,
+    "assumptions": "3 axioms: infinite_8p_sq_minus_1_primes, erdos_913_conditional, exponent_structure. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -154,8 +154,8 @@
     ],
     "namespace": "Erdos913",
     "lineCount": 134,
-    "axiomCount": 6,
-    "theoremCount": 0,
+    "axiomCount": 3,
+    "theoremCount": 4,
     "definitionCount": 5
   }
 }


### PR DESCRIPTION
## Summary
- **erdos-913**: Proved `example_n3`, `example_n7`, `example_n8` via concrete factorization verification (6→3 axioms)
- **erdos-663**: Proved `small_prime_divides_product` (pigeonhole on consecutive integers) and derived `q_gt_k` (7→5 axioms)
- **erdos-1028**: Proved `erdos_spencer_improves` (n ≤ n^{3/2}) via exponent monotonicity (7→6 axioms)
- **erdos-855**: Proved `primePi_monotone` via Finset.Icc monotonicity (7→6 axioms)

**Total: 7 axioms eliminated across 4 problems**

## Key Techniques
- `native_decide` for concrete `Nat.primeFactors` and `Nat.factorization` evaluation
- Pigeonhole principle: among k ≥ p consecutive integers, one divisible by p
- `rpow_le_rpow_of_exponent_le` for real power monotonicity
- `Finset.Icc_subset_Icc_right` for prime counting function monotonicity

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos913Problem`
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos663Problem`
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1028Problem`
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos855Problem`
- [ ] Gallery build: `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)