### PR TITLE
Gallery integrity: erdos-153 sorry count 0→1, axiomCount 4→2

### DIFF
--- a/src/data/proofs/erdos-153/meta.json
+++ b/src/data/proofs/erdos-153/meta.json
@@ -16,13 +16,13 @@
       "sumsets"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 153,
     "erdosUrl": "https://erdosproblems.com/153",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 136,
-    "assumptions": "4 axioms encoding mathematical hypotheses. See the Lean source for details.",
+    "axiomCount": 2,
+    "lineCount": 183,
+    "assumptions": "2 axiom(s) and 1 sorry(s). Axioms: ess_1994_result, infinite_sidon_gap_question. Sorry in sidon_sumset_card_lower (combinatorial card lemma).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -131,9 +131,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 136,
-    "axiomCount": 4,
-    "theoremCount": 0,
+    "lineCount": 183,
+    "axiomCount": 2,
+    "theoremCount": 3,
     "definitionCount": 8
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary
- **OVERCLAIM FIX**: `sorries` was 0, actual is 1 (sorry in `sidon_sumset_card_lower` at line 120)
- `axiomCount`: 4→2 (only `ess_1994_result` and `infinite_sidon_gap_question`)
- `lineCount`: 136→183
- `theoremCount`: 0→3

## Severity
**HIGH** — Claiming 0 sorries when 1 exists misrepresents verification status.

## Evidence
- `grep -n sorry proofs/Proofs/Erdos153Problem.lean` → line 120
- `grep -c "^axiom " proofs/Proofs/Erdos153Problem.lean` → 2
- `wc -l proofs/Proofs/Erdos153Problem.lean` → 183

## Test plan
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)