### PR TITLE
Research: erdos-1062 — prove 4 structural theorems

### DIFF
--- a/proofs/Proofs/Erdos1062Problem.lean
+++ b/proofs/Proofs/Erdos1062Problem.lean
@@ -138,3 +138,50 @@ theorem ndto_strictly_weaker :
       rcases hc with rfl | rfl | rfl <;> simp_all <;> omega
   · intro h
     exact h 2 6 (by simp) (by simp) (by omega) (by omega)
+
+/-
+## Section VII: Structural Properties of NDTO
+-/
+
+/-- The NDTO property is hereditary: subsets of NDTO sets are NDTO.
+This is because the universal quantification over triples restricts
+to fewer candidates in a smaller set. -/
+theorem ndto_subset {A B : Finset ℕ} (hBA : B ⊆ A) (hA : NoDividesTwoOthers A) :
+    NoDividesTwoOthers B := by
+  intro a b c ha hb hc
+  exact hA a b c (hBA ha) (hBA hb) (hBA hc)
+
+/-- Any pair satisfies NDTO: the condition requires three distinct elements,
+so sets of size ≤ 2 satisfy it vacuously (pigeonhole on {a, b}). -/
+theorem ndto_pair (a b : ℕ) : NoDividesTwoOthers ({a, b} : Finset ℕ) := by
+  intro x y z hx hy hz _ _ hxy hxz hyz
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hx hy hz
+  rcases hx with rfl | rfl <;> rcases hy with rfl | rfl <;>
+    rcases hz with rfl | rfl <;> simp_all
+
+/-
+## Section VIII: Properties of the Extremal Function
+-/
+
+/-- The extremal function f is monotonically non-decreasing: any NDTO
+subset of {1,…,m} is also a valid subset of {1,…,n} when m ≤ n. -/
+theorem maxNDTOSize_mono {m n : ℕ} (hmn : m ≤ n) : maxNDTOSize m ≤ maxNDTOSize n := by
+  unfold maxNDTOSize
+  apply Finset.sup_le
+  intro A hA
+  apply Finset.le_sup
+  simp only [Finset.mem_filter, Finset.mem_powerset] at hA ⊢
+  refine ⟨fun x hx => ?_, hA.2⟩
+  have := hA.1 hx
+  simp only [Finset.mem_Icc] at this ⊢
+  omega
+
+/-- f(n) ≤ n: a subset of {1,…,n} has at most n elements. -/
+theorem maxNDTOSize_le (n : ℕ) : maxNDTOSize n ≤ n := by
+  unfold maxNDTOSize
+  apply Finset.sup_le
+  intro A hA
+  simp only [Finset.mem_filter, Finset.mem_powerset] at hA
+  have h := Finset.card_le_card hA.1
+  rw [Nat.card_Icc] at h
+  omega


### PR DESCRIPTION
## Summary
- Proved 4 new theorems for Erdős #1062 (Maximum "No Divides Two Others" Sets)
- `ndto_subset`: NDTO is hereditary (subset-closed)
- `ndto_pair`: any pair satisfies NDTO vacuously (pigeonhole)
- `maxNDTOSize_mono`: f(n) is monotonically non-decreasing
- `maxNDTOSize_le`: f(n) ≤ n (trivial upper bound)
- Total: 7 theorems, 3 axioms (unchanged — deep published results)

## Progress
- Theorems: 3 → 7 (+4 structural properties)
- Axioms: 3 → 3 (Lebensold bounds + limiting density — all deep results)
- Lines: 147 → 193

## Findings
- NDTO heredity + monotonicity of f enable subsequential limit arguments
- f(n) bounded: (2n+2)/3 ≤ f(n) ≤ n, giving density in [2/3, 1] for n ≥ 3
- Remaining 3 axioms are genuinely deep published results not derivable from Mathlib

## Status
**Outcome**: progress
**Next Steps**: Proving Lebensold bounds would require formalizing the 1976 sieving argument

🤖 Generated by researcher-9

**Note**: Docker was unavailable for build verification. Proofs follow existing patterns in the file (Finset.sup_le, Finset.le_sup, Nat.card_Icc).