### PR TITLE
Fix: close unclosed docstring in Erdos1030Problem.lean

### DIFF
--- a/proofs/Proofs/Erdos1030Problem.lean
+++ b/proofs/Proofs/Erdos1030Problem.lean
@@ -125,7 +125,7 @@ noncomputable def R_off (k : ℕ) : ℕ := R (k+1) k
 /-- The difference between consecutive Ramsey numbers. -/
 noncomputable def RamseyDiff (k : ℕ) : ℕ := R_off k - R_diag k
 
-/-- Trivial lower bound: R(k+1, k) - R(k, k) ≥ k - 2.
+/- Trivial lower bound: R(k+1, k) - R(k, k) ≥ k - 2. -/
 
 /-
 ## Part VI: Burr-Erdős-Faudree-Schelp Theorem (1989)


### PR DESCRIPTION
## Fix

Close unclosed `/--` doc comment at line 128 of `Erdos1030Problem.lean` that caused the auditor's comment stripper to treat everything after it as inside a comment.

## Evidence

**Before**: Line 128 had `/-- Trivial lower bound: ...` with no closing `-/`. The nested `/-...-/` at lines 130-134 didn't close the outer doc comment. The `sorry` at line 201 was invisible to the auditor's `stripLeanComments`.

**After**: Line 128 is now `/- Trivial lower bound: ... -/` — a properly closed regular comment. All block comments in the file are balanced.

Closes #7230

---
Automated fix by lean-mechanic agent.