### PR TITLE
Research: erdos-1157 — replace extremalNumber axiom, prove monotonicity (7→4)

### DIFF
--- a/proofs/Proofs/Erdos1157Problem.lean
+++ b/proofs/Proofs/Erdos1157Problem.lean
@@ -24,7 +24,9 @@ References:
 
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Real.Basic
+import Mathlib.Data.Finset.Powerset
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Order.ConditionallyCompleteLattice.Basic
 
 namespace Erdos1157
 
@@ -36,21 +38,57 @@ r-uniform hypergraph on n vertices with no s edges spanning at most k vertices.
 We axiomatize this as a function ℕ⁴ → ℕ.
 -/
 
+/-- A valid (r,k,s)-free hypergraph: an r-uniform hypergraph E on n vertices
+    such that no s edges span at most k vertices. -/
+def IsValidHypergraph (r n k s : ℕ) (E : Finset (Finset (Fin n))) : Prop :=
+  (∀ e ∈ E, e.card = r) ∧
+  (∀ F : Finset (Finset (Fin n)), F ⊆ E → F.card ≥ s → (F.biUnion id).card > k)
+
+/-- The set of achievable edge counts for (r,k,s)-free hypergraphs on n vertices. -/
+def achievableEdgeCounts (r n k s : ℕ) : Set ℕ :=
+  {m : ℕ | ∃ E : Finset (Finset (Fin n)), IsValidHypergraph r n k s E ∧ E.card = m}
+
+/-- The achievable set is always nonempty (the empty hypergraph is valid). -/
+private theorem achievable_nonempty (r n k s : ℕ) :
+    (achievableEdgeCounts r n k s).Nonempty :=
+  ⟨0, ∅, ⟨fun _ h => absurd h (Finset.not_mem_empty _),
+    fun F hF hFs => absurd (Finset.card_eq_zero.mpr (Finset.subset_empty.mp hF) ▸ hFs)
+      (by omega)⟩, rfl⟩
+
+/-- The achievable set is bounded above (by the number of all possible edges). -/
+private theorem achievable_bddAbove (r n k s : ℕ) :
+    BddAbove (achievableEdgeCounts r n k s) :=
+  ⟨(Finset.univ : Finset (Finset (Fin n))).card,
+    fun m ⟨E, _, hcard⟩ => hcard ▸ Finset.card_le_univ E⟩
+
 /-- The general extremal number f^(r)(n; k, s):
     maximum number of edges in an r-uniform hypergraph on n vertices
     that contains no s edges spanning at most k vertices. -/
-axiom extremalNumber (r n k s : ℕ) : ℕ
+noncomputable def extremalNumber (r n k s : ℕ) : ℕ :=
+  sSup (achievableEdgeCounts r n k s)
 
 /-- Monotonicity in k: increasing k means more edge-sets are forbidden
-    (any s edges spanning ≤ k₂ ≥ k₁ vertices includes more configurations),
-    so fewer hypergraphs are valid and the extremal number decreases. -/
-axiom extremalNumber_mono_k (r n s k₁ k₂ : ℕ) (h : k₁ ≤ k₂) :
-  extremalNumber r n k₂ s ≤ extremalNumber r n k₁ s
+    (any s edges spanning ≤ k₂ includes those spanning ≤ k₁),
+    so fewer hypergraphs are valid and the extremal number decreases.
+    Proof: span > k₂ implies span > k₁ when k₁ ≤ k₂, so the valid
+    set for k₂ ⊆ valid set for k₁. -/
+theorem extremalNumber_mono_k (r n s k₁ k₂ : ℕ) (h : k₁ ≤ k₂) :
+    extremalNumber r n k₂ s ≤ extremalNumber r n k₁ s := by
+  unfold extremalNumber
+  apply csSup_le_csSup (achievable_bddAbove r n k₁ s) (achievable_nonempty r n k₂ s)
+  intro m ⟨E, ⟨hunif, hspan⟩, hcard⟩
+  exact ⟨E, ⟨hunif, fun F hF hFs => lt_of_le_of_lt h (hspan F hF hFs)⟩, hcard⟩
 
-/-- Monotonicity in s: requiring more forbidden edges makes it harder
-    to find violations, so the extremal number increases. -/
-axiom extremalNumber_mono_s (r n k s₁ s₂ : ℕ) (h : s₁ ≤ s₂) :
-  extremalNumber r n k s₁ ≤ extremalNumber r n k s₂
+/-- Monotonicity in s: requiring more forbidden edges (s₂ ≥ s₁) makes it harder
+    to find violations, so the extremal number increases.
+    Proof: if all s₁-subsets have span > k, then all s₂-subsets (with s₂ ≥ s₁)
+    also satisfy this (since F.card ≥ s₂ ≥ s₁ triggers the s₁ condition). -/
+theorem extremalNumber_mono_s (r n k s₁ s₂ : ℕ) (h : s₁ ≤ s₂) :
+    extremalNumber r n k s₁ ≤ extremalNumber r n k s₂ := by
+  unfold extremalNumber
+  apply csSup_le_csSup (achievable_bddAbove r n k s₂) (achievable_nonempty r n k s₁)
+  intro m ⟨E, ⟨hunif, hspan⟩, hcard⟩
+  exact ⟨E, ⟨hunif, fun F hF hFs => hspan F hF (le_trans h hFs)⟩, hcard⟩
 
 /-
 ## Part II: The Brown-Erdős-Sós Lower Bound (1973)

--- a/src/data/research/problems/erdos-1157.json
+++ b/src/data/research/problems/erdos-1157.json
@@ -29,20 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed besExponent_le_one bug (mathematically wrong), added 4 structural lemmas. File has 16 theorems, 7 axioms, 0 sorries, 275 lines.",
+    "progressSummary": "PROGRESS: Replaced extremalNumber axiom with proper sSup def, proved both monotonicity axioms. 7→4 axioms, 19+ theorems.",
     "builtItems": [
       "besExponent_lt_two_at_bes_threshold: BUGFIX — correct bound replaces wrong ≤ 1 claim",
       "isLittleO_zero: zero function is little-o of anything",
       "isLittleO_of_eventually_le: comparison lemma for little-o",
       "bes_monotone_in_s: BES conjecture monotone in number of forbidden edges",
-      "besExponent_at_threshold_one: exponent = 1 when k = rs - s + 1"
+      "besExponent_at_threshold_one: exponent = 1 when k = rs - s + 1",
+      "IsValidHypergraph: formal predicate for (r,k,s)-free hypergraphs",
+      "achievableEdgeCounts: set of achievable sizes with sSup-friendly properties",
+      "extremalNumber: noncomputable def via sSup (was axiom)",
+      "extremalNumber_mono_k: proved (was axiom)",
+      "extremalNumber_mono_s: proved (was axiom)"
     ],
     "insights": [
       "BUG FIXED: besExponent_le_one_at_bes_threshold was mathematically wrong (claimed 3/2 ≤ 1). Corrected to besExponent_lt_two (< 2 is correct)",
       "All 7 axioms are deep: extremalNumber definition, monotonicity properties, published results (BES/RS/Glock/DP). None provable from Mathlib",
       "BES exponent = (2s-3)/(s-1) at threshold, which approaches 2 from below as s→∞",
       "IsLittleO utility lemmas enable cleaner monotonicity proofs",
-      "besExponent_at_threshold_one: when k = rs-s+1, exponent = 1 exactly (s-1 cancels)"
+      "besExponent_at_threshold_one: when k = rs-s+1, exponent = 1 exactly (s-1 cancels)",
+      "extremalNumber properly defined via sSup of achievable edge counts using Fin n hypergraphs",
+      "mono_k proof: span > k₂ implies span > k₁, so valid set shrinks",
+      "mono_s proof: F.card ≥ s₂ ≥ s₁ triggers the s₁ condition"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Replace `extremalNumber` axiom with proper `noncomputable def` via `sSup` of achievable edge counts
- Define `IsValidHypergraph` for (r,k,s)-free hypergraphs on `Fin n`
- Prove `extremalNumber_mono_k` (was axiom): valid set for k₂ ⊆ valid set for k₁
- Prove `extremalNumber_mono_s` (was axiom): s₁ condition implies s₂ condition

## Axiom changes
- **7 → 4 axioms** (3 eliminated!)
- Remaining 4: BES lower bound, Ruzsa-Szemerédi, Glock BES k=4, Delcourt-Postle

🤖 Generated by researcher-1