### PR TITLE
Audit: erdos-314 sorry count and line count fix

### DIFF
--- a/src/data/proofs/erdos-314/meta.json
+++ b/src/data/proofs/erdos-314/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 314,
     "erdosUrl": "https://erdosproblems.com/314",
     "erdosProblemStatus": "solved",
@@ -56,8 +56,8 @@
       "Connection to Euler-Mascheroni constant"
     ],
     "axiomCount": 10,
-    "lineCount": 184,
-    "assumptions": "10 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "lineCount": 240,
+    "assumptions": "10 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #314: Harmonic Sum Error Term**\n\nThis problem from Erdős-Graham (1980) studies partial harmonic sums. Given n, let m(n) be the minimal integer such that the harmonic sum from n to m reaches at least 1. The error ε(n) is how much the sum overshoots 1.\n\n**Historical Development:**\n- **Erdős-Graham (1980):** Posed the question: is lim inf n²ε(n) = 0?\n- **Lim-Steinerberger (2024):** Proved YES with explicit bounds.\n\n**Key Insight:** Since harmonic sums grow like log(m/n), we have m(n) ≈ e·n. The question asks how precisely the sum can hit 1.",
@@ -159,7 +159,7 @@
     ],
     "opens": [],
     "namespace": "Erdos314",
-    "lineCount": 184,
+    "lineCount": 240,
     "axiomCount": 10,
     "theoremCount": 5,
     "definitionCount": 5


### PR DESCRIPTION
## Summary
- Fixed sorry count in erdos-314 meta.json: 3 → 1 (actual: only `erdos_conjecture_true` at line 187)
- Fixed line count: 184 → 240 (actual file length)
- Updated assumptions field to match

## Audit Details
| Check | Before | After | Verified |
|-------|--------|-------|----------|
| Sorries | 3 | 1 | ✅ grep confirms single sorry |
| Axiom count | 10 | 10 | ✅ correct |
| Line count | 184 | 240 | ✅ wc -l confirms |
| Status | axiomatized | axiomatized | ✅ correct |
| Badge | axiom | axiom | ✅ correct |
| True stubs | N/A | 0 | ✅ clean |

## Test plan
- [ ] `pnpm build` passes with updated meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)