### PR TITLE
Audit: erdos-1157 axiom count correction (5→2)

### DIFF
--- a/src/data/proofs/erdos-1157/meta.json
+++ b/src/data/proofs/erdos-1157/meta.json
@@ -19,9 +19,9 @@
     "erdosNumber": 1157,
     "erdosUrl": "https://erdosproblems.com/1157",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 276,
-    "assumptions": "5 axioms: extremalNumber, extremalNumber_mono_k, extremalNumber_mono_s, brown_erdos_sos_lower_bound, delcourt_postle_theorem. ruzsa_szemeredi_bes and glock_bes_k4 proved as special cases of Delcourt-Postle.",
+    "axiomCount": 2,
+    "lineCount": 317,
+    "assumptions": "2 axioms: brown_erdos_sos_lower_bound (BES 1973 lower bound), delcourt_postle_theorem (3-uniform BES conjecture, 2024). extremalNumber is now a definition (sSup of achievable edge counts), monotonicity in k and s is proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -55,8 +55,8 @@
       "title": "General Extremal Number",
       "startLine": 31,
       "endLine": 53,
-      "summary": "Axiomatizes f^(r)(n; k, s) as extremalNumber : ℕ⁴ → ℕ with monotonicity axioms in k and s.",
-      "mathContext": "Axiomatizes f^(r)(n; k, s) as extremalNumber : ℕ⁴ $\\to$ $\\mathbb{N}$ with monotonicity axioms in k and s."
+      "summary": "Defines f^(r)(n; k, s) as extremalNumber : ℕ⁴ → ℕ via sSup with proved monotonicity in k and s.",
+      "mathContext": "Defines f^(r)(n; k, s) as extremalNumber : ℕ⁴ $\\to$ $\\mathbb{N}$ via sSup with proved monotonicity in k and s."
     },
     {
       "id": "bes-exponent",
@@ -173,9 +173,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1157",
-    "lineCount": 276,
-    "axiomCount": 5,
+    "lineCount": 317,
+    "axiomCount": 2,
     "theoremCount": 18,
-    "definitionCount": 4
+    "definitionCount": 7
   }
 }


### PR DESCRIPTION
## Summary
- Fixed `meta.axiomCount`: 5 → 2 (3 former axioms now proved as defs/theorems)
- Fixed `meta.lineCount`: 276 → 317
- Fixed `leanFile.axiomCount`: 5 → 2, `lineCount`: 276 → 317, `definitionCount`: 4 → 7
- Updated `assumptions` text to reflect only 2 remaining axioms
- Updated section summary that incorrectly said "axiomatizes with monotonicity axioms"

## Evidence
Research PRs #7243 and #7244 converted 3 axioms to proved constructs:
- `extremalNumber`: now `noncomputable def` via `sSup` (was axiom)
- `extremalNumber_mono_k`: now proved `theorem` (was axiom)  
- `extremalNumber_mono_s`: now proved `theorem` (was axiom)

Only 2 axioms remain: `brown_erdos_sos_lower_bound` and `delcourt_postle_theorem`.

## Test plan
- [ ] `pnpm build` passes with updated meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)