### PR TITLE
Fix: remove duplicate axiom dichrom_mono in erdos-761 (#7251)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos761Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos761Problem.lean
@@ -161,14 +161,6 @@ theorem odd_cycle_dichrom (k : ℕ) (_hk : k ≥ 1) :
     Argument: any k that works for G also works for H. Given O_H of H,
     extend to G (orient extra edges arbitrarily). The acyclic coloring
     for the extension restricts to one for O_H. -/
-axiom dichrom_mono {V : Type*} (G H : SimpleGraph V)
-    (hSub : ∀ u v, H.Adj u v → G.Adj u v) :
-  H.dichromNumber ≤ G.dichromNumber
-
-    Proof: Any orientation O_H of H extends to an orientation O_G of G
-    (keep O_H directions on H-edges, assign arbitrary directions to G-only edges).
-    An acyclic k-coloring for O_G restricts to one for O_H, so the infimum
-    for H is ≤ the infimum for G. -/
 theorem dichrom_mono {V : Type*} (G H : SimpleGraph V)
     (hSub : ∀ u v, H.Adj u v → G.Adj u v) :
     H.dichromNumber ≤ G.dichromNumber := by

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,7 +38,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 218,
+    "lineCount": 213,
     "assumptions": "3 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN), complete_dichrom (Neumann-Lara 1982). Proved: dichrom_le_chrom, cochrom_le_chrom, odd_cycle_dichrom, dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0"
   },
@@ -117,9 +117,9 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 148,
-    "axiomCount": 8,
-    "theoremCount": 1,
+    "lineCount": 213,
+    "axiomCount": 3,
+    "theoremCount": 6,
     "definitionCount": 5
   },
   "references": [


### PR DESCRIPTION
## Fix

Remove duplicate `axiom dichrom_mono` declaration that conflicted with the proved `theorem dichrom_mono`, plus a malformed comment block between them.

## Evidence

**Before**: 4 axiom declarations including `axiom dichrom_mono` (line 164) conflicting with `theorem dichrom_mono` (line 172); malformed comment block (lines 168-171) with closing `-/` but no opening `/-`; meta.json `leanFile.axiomCount` was 8 (wrong)

**After**: 3 axiom declarations (erdos_761_question1, erdos_761_question2, complete_dichrom); `theorem dichrom_mono` preserved with full proof; meta.json counts corrected (3 axioms, 6 theorems, 213 lines)

Closes #7251

---
Automated fix by lean-mechanic agent.