### PR TITLE
Audit: erdos-818 sorry count fix (4→3)

### DIFF
--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -17,7 +17,7 @@
       "product-set"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 818,
     "erdosUrl": "https://erdosproblems.com/818",
     "erdosProblemStatus": "solved",
@@ -61,7 +61,7 @@
       "Logarithmic functions and asymptotic notation",
       "Basic number theory (arithmetic and geometric progressions)"
     ],
-    "lineCount": 290,
+    "lineCount": 294,
     "assumptions": "1 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -268,7 +268,7 @@
       "Real"
     ],
     "namespace": "Erdos818",
-    "lineCount": 290,
+    "lineCount": 294,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 7


### PR DESCRIPTION
## Summary
- Fixed `sorries`: 4 → 3 (actual: lines 153, 205, 292)
- Fixed `lineCount`: 290 → 294 (both meta and leanFile sections)
- Note: `assumptions` field already correctly said "3 sorry(s)"

## Audit Details
| Check | Before | After | Verified |
|-------|--------|-------|----------|
| Sorries | 4 | 3 | ✅ grep confirms 3 |
| Axiom count | 1 | 1 | ✅ correct |
| Line count | 290 | 294 | ✅ wc -l confirms |
| Status | axiomatized | axiomatized | ✅ correct |
| Badge | axiom | axiom | ✅ correct |

## Test plan
- [ ] `pnpm build` passes with updated meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)