### PR TITLE
Audit: fix stale axiom counts across 15 proofs

### DIFF
--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -38,9 +38,9 @@
       "Historical significance as first explicitly transcendental constant"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 2,
+    "axiomCount": 1,
     "assumptions": "5 axiom declarations: e_transcendental (Hermite 1873: e is transcendental), e_irrational_axiom (corollary: e is irrational), exp_nat_transcendental_axiom (e^n transcendental for n ≥ 1, from Lindemann-Weierstrass), e_inv_transcendental_axiom (1/e transcendental), e_plus_one_transcendental_axiom (e+1 transcendental). All are consequences of the Hermite-Lindemann-Weierstrass theorem.",
-    "lineCount": 267,
+    "lineCount": 304,
     "relatedProblems": [
       {
         "id": "e-transcendental-oq-01",
@@ -207,8 +207,8 @@
       "Polynomial"
     ],
     "namespace": null,
-    "lineCount": 267,
-    "axiomCount": 4,
+    "lineCount": 304,
+    "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -19,7 +19,7 @@
     "erdosNumber": 1165,
     "erdosUrl": "https://erdosproblems.com/1165",
     "erdosProblemStatus": "solved",
-    "axiomCount": 8,
+    "axiomCount": 7,
     "lineCount": 188,
     "assumptions": "8 axioms: VisitCount and FavouriteSites (random walk infrastructure), prob_favourite_count_io with bounds (probability events), toth_favourite_sites_geq_4 (Tóth 2001), hao_li_okada_zheng_three_favourite_sites (Hao et al. 2024), bass_griffin_1d_unique (background). All theorems fully proved from axioms (0 sorries).",
     "mathlib_version": "4.26.0"
@@ -171,7 +171,7 @@
     ],
     "namespace": "Erdos1165",
     "lineCount": 188,
-    "axiomCount": 8,
+    "axiomCount": 7,
     "theoremCount": 5,
     "definitionCount": 2,
     "sorryCount": 0

--- a/src/data/proofs/erdos-33/meta.json
+++ b/src/data/proofs/erdos-33/meta.json
@@ -21,8 +21,8 @@
     "erdosNumber": 33,
     "erdosUrl": "https://erdosproblems.com/33",
     "erdosProblemStatus": "open",
-    "axiomCount": 7,
-    "lineCount": 179,
+    "axiomCount": 5,
+    "lineCount": 186,
     "prerequisites": [
       "Perfect squares and their distribution",
       "Additive complements",
@@ -109,8 +109,8 @@
       "Topology"
     ],
     "namespace": "Erdos33",
-    "lineCount": 179,
-    "axiomCount": 7,
+    "lineCount": 186,
+    "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-351/meta.json
+++ b/src/data/proofs/erdos-351/meta.json
@@ -47,9 +47,9 @@
       "Axiomatized Graham-Alekseyev theorem for p(x) = x²",
       "Verified bounds on n + 1/n"
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 115,
-    "assumptions": "3 axiom(s): erdos_351_open, graham_theorem_linear, graham_alekseyev_quadratic. See Lean source for complete statements."
+    "assumptions": "2 axiom(s): erdos_351_open, graham_theorem_linear, graham_alekseyev_quadratic. See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "Erdős Problem #351 concerns the additive structure of sequences of the form {p(n) + 1/n : n ∈ ℕ} where p(x) is a polynomial. The notion of 'strong completeness' is a robust form of additive completeness that survives removal of any finite set of elements.\n\nGraham (1963) proved the foundational case p(x) = x, showing that {n + 1/n : n ∈ ℕ} is strongly complete. This was a significant result in additive number theory.\n\nThe case p(x) = x² was resolved much later by combining Graham's work with Alekseyev's 2019 results on partitions into squares. The general question—whether ALL polynomials with positive leading coefficient yield strongly complete sets—remains open.",
@@ -127,7 +127,7 @@
     ],
     "namespace": "Erdos351",
     "lineCount": 115,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-495/meta.json
+++ b/src/data/proofs/erdos-495/meta.json
@@ -56,8 +56,8 @@
       "PAdicLittlewood: p-adic variant definition",
       "badziahin_velani_padic: partial result for p-adic case"
     ],
-    "axiomCount": 7,
-    "lineCount": 188,
+    "axiomCount": 4,
+    "lineCount": 194,
     "assumptions": "7 axioms: distInt_nonneg, distInt_le_half, littlewoodProduct_nonneg, and 4 more. See Lean source for complete statements."
   },
   "overview": {
@@ -149,8 +149,8 @@
     ],
     "opens": [],
     "namespace": "Erdos495",
-    "lineCount": 188,
-    "axiomCount": 7,
+    "lineCount": 194,
+    "axiomCount": 4,
     "theoremCount": 1,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-515/meta.json
+++ b/src/data/proofs/erdos-515/meta.json
@@ -63,7 +63,7 @@
       "lewis_rossi_weitsman_1984 axiom: single path for all f",
       "erdos_515 theorem: main result"
     ],
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 290,
     "assumptions": "4 axioms: huber_1957, zhang_1977, lewis_rossi_weitsman_1984, and 1 more. See Lean source for complete statements."
   },
@@ -182,7 +182,7 @@
     ],
     "namespace": "Erdos515",
     "lineCount": 290,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -56,7 +56,7 @@
       "IsLittlewood, LittlewoodProblem: connections",
       "mahlerMeasure: geometric mean measure"
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 255,
     "assumptions": "8 axioms: salem_zygmund_order, halasz_theorem, halasz_almost_sure, and 5 more. See Lean source for complete statements."
   },
@@ -202,7 +202,7 @@
     ],
     "namespace": "Erdos523",
     "lineCount": 255,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 21
   },

--- a/src/data/proofs/erdos-589/meta.json
+++ b/src/data/proofs/erdos-589/meta.json
@@ -23,9 +23,9 @@
     "erdosNumber": 589,
     "erdosUrl": "https://erdosproblems.com/589",
     "erdosProblemStatus": "solved",
-    "axiomCount": 6,
+    "axiomCount": 4,
     "lineCount": 343,
-    "assumptions": "6 axiom(s) and 3 sorry(s). See the Lean source for details.",
+    "assumptions": "4 axiom(s) and 3 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -152,7 +152,7 @@
     ],
     "namespace": "Erdos589",
     "lineCount": 343,
-    "axiomCount": 6,
+    "axiomCount": 4,
     "theoremCount": 7,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-728/meta.json
+++ b/src/data/proofs/erdos-728/meta.json
@@ -51,9 +51,9 @@
       "legendreSum for p-adic valuation calculation",
       "divisibility_via_legendre axiom for verification"
     ],
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 258,
-    "assumptions": "5 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "4 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #728**\n\nThis problem was posed by Erdos, Graham, Ruzsa, and Straus in their 1975 paper [EGRS75, p.91]. It refines a classical 1968 result of Erdos.\n\n**Historical Background:**\n- Erdos (1968) proved that if a! * b! | n!, then a + b <= n + O(log n)\n- This shows the divisibility condition strongly constrains a + b\n- The 1975 question asks: can we ACHIEVE divisibility at this upper limit?\n\n**Resolution:**\nThe problem was solved by Barreto and ChatGPT-5.2, who showed infinitely many solutions exist using the construction b = n/2, a = n/2 + O(log n).\n\n**Status:** SOLVED (proved in Lean)",
@@ -173,7 +173,7 @@
     ],
     "namespace": "Erdos728",
     "lineCount": 258,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-763/meta.json
+++ b/src/data/proofs/erdos-763/meta.json
@@ -57,7 +57,7 @@
       "perfectSquares, arithmeticProgression, IsSidonSet examples",
       "sidon_not_bounded theorem: application to Sidon sets"
     ],
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 285,
     "assumptions": "5 axioms: erdos_fuchs_theorem, erdos_fuchs_strong, montgomery_vaughan, and 2 more. See Lean source for complete statements."
   },
@@ -173,7 +173,7 @@
     ],
     "namespace": "Erdos763",
     "lineCount": 285,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-918/meta.json
+++ b/src/data/proofs/erdos-918/meta.json
@@ -47,8 +47,8 @@
       "Proved theorems about aleph cardinal ordering",
       "Educational commentary on infinite chromatic numbers"
     ],
-    "axiomCount": 7,
-    "lineCount": 148,
+    "axiomCount": 5,
+    "lineCount": 150,
     "assumptions": "7 axioms: Question1, Question2, erdos_hajnal_finite, and 4 more. See Lean source for complete statements."
   },
   "overview": {
@@ -139,8 +139,8 @@
       "Cardinal"
     ],
     "namespace": "Erdos918",
-    "lineCount": 148,
-    "axiomCount": 7,
+    "lineCount": 150,
+    "axiomCount": 5,
     "theoremCount": 1,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-969/meta.json
+++ b/src/data/proofs/erdos-969/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 969,
     "erdosUrl": "https://erdosproblems.com/969",
     "erdosProblemStatus": "open",
-    "axiomCount": 9,
-    "lineCount": 251,
-    "assumptions": "9 axiom(s) and 1 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "axiomCount": 7,
+    "lineCount": 252,
+    "assumptions": "7 axiom(s) and 1 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -152,8 +152,8 @@
       "Filter"
     ],
     "namespace": "Erdos969",
-    "lineCount": 251,
-    "axiomCount": 9,
+    "lineCount": 252,
+    "axiomCount": 7,
     "theoremCount": 11,
     "definitionCount": 7
   },

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -50,7 +50,7 @@
       "Nat.Prime and ring theory from Mathlib"
     ],
     "wiedijkNumber": 33,
-    "axiomCount": 5,
+    "axiomCount": 2,
     "lineCount": 204,
     "assumptions": "5 axioms total. 2 with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p, the consequence of Modularity+Ribet) and fermatLastTheorem (the full FLT statement: ∀ n ≥ 3, FermatLastTheoremFor n). 3 placeholder axioms concluding with True (FreyCurve_is_semistable, ModularityTheorem_semistable, RibetTheorem) — these serve as proof-structure markers documenting the Frey-Ribet-Wiles chain without encoding actual mathematical statements. The n=3 and n=4 cases are fully proved via Mathlib (fermatLastTheoremThree, fermatLastTheoremFour).",
     "mathlib_version": "4.26.0"
@@ -285,7 +285,7 @@
     "opens": [],
     "namespace": "FermatsLastTheorem",
     "lineCount": 204,
-    "axiomCount": 5,
+    "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 0
   },

--- a/src/data/proofs/hilbert-16/meta.json
+++ b/src/data/proofs/hilbert-16/meta.json
@@ -24,8 +24,8 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 16,
-    "axiomCount": 10,
-    "lineCount": 565,
+    "axiomCount": 9,
+    "lineCount": 568,
     "assumptions": "10 axioms: hilbert_number_ge_witness, linear_poly_degree_le_one, linear_no_limit_cycles_axiom, and 7 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -203,8 +203,8 @@
       "MvPolynomial"
     ],
     "namespace": "Hilbert16",
-    "lineCount": 565,
-    "axiomCount": 10,
+    "lineCount": 568,
+    "axiomCount": 9,
     "theoremCount": 10,
     "definitionCount": 22
   },

--- a/src/data/proofs/pi-transcendental/meta.json
+++ b/src/data/proofs/pi-transcendental/meta.json
@@ -38,8 +38,8 @@
       "Connection to constructibility with ruler and compass"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 4,
-    "lineCount": 381,
+    "axiomCount": 2,
+    "lineCount": 423,
     "assumptions": "7 axioms: lindemann_theorem, pi_transcendental, two_pi_transcendental_axiom, and 4 more. pi_irrational_axiom proved from Mathlib's irrational_pi.",
     "mathlib_version": "4.26.0"
   },
@@ -206,8 +206,8 @@
       "Polynomial"
     ],
     "namespace": null,
-    "lineCount": 381,
-    "axiomCount": 7,
+    "lineCount": 423,
+    "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Summary
PR #7249 proved 31 axioms across 17 Lean files but did not update meta.json. This batch corrects axiomCount and lineCount for all 15 affected gallery entries.

### High-profile fixes
| Proof | Before | After |
|-------|--------|-------|
| fermats-last-theorem | 5 axioms | 2 axioms |
| pi-transcendental | 4 axioms | 2 axioms |
| e-transcendental | 2 axioms | 1 axiom |
| hilbert-16 | 10 axioms | 9 axioms |

### Erdős fixes
| Proof | Before | After |
|-------|--------|-------|
| erdos-523 | 8 | 3 |
| erdos-33 | 7 | 5 |
| erdos-495 | 7 | 4 |
| erdos-918 | 7 | 5 |
| erdos-969 | 9 | 7 |
| erdos-1165 | 8 | 7 |
| erdos-589 | 6 | 4 |
| erdos-728 | 5 | 4 |
| erdos-763 | 5 | 4 |
| erdos-515 | 4 | 3 |
| erdos-351 | 3 | 2 |

## Verification method
For each proof: `grep -c "^axiom " <lean-file>` compared against meta.json axiomCount.

## Test plan
- [ ] `pnpm build` passes with all updated meta.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)