### PR TITLE
Research: erdos-374 + erdos-406 + erdos-935 — 3 theorems, 1 assessment

### DIFF
--- a/proofs/Proofs/Erdos374Problem.lean
+++ b/proofs/Proofs/Erdos374Problem.lean
@@ -98,6 +98,22 @@ theorem squares_have_square_factorial_product (n : ℕ) (hn : 2 ≤ n) :
 example : HasSquareFactorialProduct 4 2 :=
   ⟨[3, 4], rfl, by decide, by decide, ⟨12, by native_decide⟩⟩
 
+/-- F(n²) = 2 for n ≥ 2: the Nat.find gives 2 because:
+    - k = 2 satisfies 2 ≤ k ∧ HasSquareFactorialProduct (proved above)
+    - k = 0, 1 fail the 2 ≤ k condition -/
+theorem bigF_eq_two_of_square (n : ℕ) (hn : 2 ≤ n) : bigF (n * n) = 2 := by
+  unfold bigF
+  have h : ∃ k, 2 ≤ k ∧ HasSquareFactorialProduct (n * n) k :=
+    ⟨2, le_refl 2, squares_have_square_factorial_product n hn⟩
+  rw [dif_pos h]
+  exact Nat.find_eq_iff.mpr ⟨⟨le_refl 2, squares_have_square_factorial_product n hn⟩,
+    fun k hk ⟨h1, _⟩ => by omega⟩
+
+/-- Every perfect square n² with n ≥ 2 belongs to D₂. This is the
+    backward direction of D2_eq_squares, now proved. -/
+theorem square_in_D2 (n : ℕ) (hn : 2 ≤ n) : inDk 2 (n * n) :=
+  bigF_eq_two_of_square n hn
+
 /- ## Known Results (Axiomatized — deep results from Erdős-Graham 1976) -/
 
 /-- D₂ consists of all perfect squares > 1 (Erdős-Graham 1976).

--- a/proofs/Proofs/Erdos406Problem.lean
+++ b/proofs/Proofs/Erdos406Problem.lean
@@ -106,3 +106,17 @@ theorem digits01_sum_of_powers (n : ℕ) (h : HasOnlyDigits01Base3 n) :
 digits 0 and 1. -/
 theorem zero_hasOnlyDigits01 : HasOnlyDigits01Base3 0 := by
   intro d hd; exact absurd hd (List.not_mem_nil d)
+
+/-- Complete classification for n ≤ 15: exactly n ∈ {0, 2, 8} give
+    powers of 2 with only ternary digits 0 and 1. Together with
+    Saye's computation (n ≥ 16), this means the known examples
+    {1, 4, 256} = {2⁰, 2², 2⁸} are the only ones up to 2^(5.9×10²¹). -/
+theorem sparse_complete_to_15 :
+    ∀ n : ℕ, n ≤ 15 → HasOnlyDigits01Base3 (2 ^ n) → n = 0 ∨ n = 2 ∨ n = 8 := by
+  intro n hn h
+  interval_cases n <;>
+    first
+    | left; rfl
+    | right; left; rfl
+    | right; right; rfl
+    | exact absurd h (by native_decide)

--- a/src/data/research/problems/erdos-374.json
+++ b/src/data/research/problems/erdos-374.json
@@ -29,15 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: All 5 axioms are legitimate cited results (Erdos-Graham 1976) or open problem. 5 theorems proved including squares_have_square_factorial_product.",
+    "progressSummary": "PROGRESS: Proved backward D₂=squares direction (5T→7T). bigF(n²)=2 via Nat.find_eq_iff. 5 axioms remain (all deep or open).",
     "builtItems": [
-      "Assessment: all axioms legitimate, 5 theorems already proved"
+      "Proved bigF_eq_two_of_square: F(n²) = 2 for n≥2 via Nat.find_eq_iff",
+      "Proved square_in_D2: n² ∈ D₂ for n≥2 (backward direction of D2_eq_squares)"
     ],
     "insights": [
-      "D2_eq_squares forward direction requires p-adic valuation analysis (deep)",
-      "no_square_factorial_product_for_primes uses v_p(p!) = 1 argument (deep)",
-      "Dk_empty_above_6 and D6_smallest are cited Erdos-Graham results",
-      "erdos_374_growth_rate is the actual open problem"
+      "D2_eq_squares backward direction is PROVABLE from squares_have_square_factorial_product + Nat.find analysis",
+      "D2_eq_squares forward direction (D₂ ⊆ squares) requires deep p-adic valuation, stays as axiom",
+      "no_square_factorial_product_for_primes is deep (p-adic valuation of p! has odd component)",
+      "Dk_empty_above_6 and D6_smallest are Erdős-Graham 1976, deep combinatorial results",
+      "erdos_374_growth_rate is THE open question"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -64,8 +66,8 @@
     {
       "path": "Proofs/Erdos374Problem.lean",
       "filename": "Erdos374Problem.lean",
-      "lineCount": 150,
-      "theoremCount": 5,
+      "lineCount": 165,
+      "theoremCount": 7,
       "axiomCount": 5,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-406.json
+++ b/src/data/research/problems/erdos-406.json
@@ -29,20 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 4 axioms (6A→2A). one_in_ternarySparse via native_decide, four_in_ternarySparse via native_decide, pow2_8_in_ternarySparse via native_decide, digits01_sum_of_powers via structural induction on digit list. Remaining: saye_computation (deep computational), open conjecture.",
+    "progressSummary": "PROGRESS: Proved complete small-case classification (5T→6T). 1 axiom remains (Saye computation, appropriate).",
     "builtItems": [
-      "PROVED zero_hasOnlyDigits01 (6A→5A)",
-      "PROVED one_in_ternarySparse: ⟨0, rfl, by native_decide⟩ (5A→4A)",
-      "PROVED four_in_ternarySparse: ⟨2, rfl, by native_decide⟩ (4A→3A)",
-      "PROVED pow2_8_in_ternarySparse: ⟨8, rfl, by native_decide⟩ (3A→2A) — digits 3 256 = [1,1,1,0,0,1]",
-      "PROVED digits01_sum_of_powers: structural induction on Nat.digits list + Finset.sum shifting"
+      "Proved sparse_complete_to_15: exactly n∈{0,2,8} give ternary-sparse 2^n for n≤15"
     ],
     "insights": [
-      "Proved zero_hasOnlyDigits01 (Nat.digits 3 0 = [], vacuously true). 6A→5A.",
-      "one_in_ternarySparse, four_in_ternarySparse, pow2_8_in_ternarySparse provable via native_decide: provide exponent k explicitly, rfl for 2^k=n, native_decide for digit check",
-      "digits01_sum_of_powers proof: induction on List of digits, key shift lemma 3 * S'.sum(3^·) = (S'.image(·+1)).sum(3^·), uses Nat.ofDigits_digits for reconstruction",
-      "saye_computation (n up to 5.9×10²¹) is NOT provable — would require computing 2^n for astronomical n",
-      "Remaining 2 axioms: saye_computation (deep), open conjecture (not axiom but def)"
+      "saye_computation (sole axiom) covers n≥16 up to 5.9×10^21 — appropriate",
+      "Combined with sparse_complete_to_15, known examples {1,4,256} are verified as complete to 2^(5.9×10^21)",
+      "native_decide handles ¬HasOnlyDigits01Base3(2^n) for n≤15 easily"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -69,8 +63,8 @@
     {
       "path": "Proofs/Erdos406Problem.lean",
       "filename": "Erdos406Problem.lean",
-      "lineCount": 98,
-      "theoremCount": 5,
+      "lineCount": 122,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 6,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-935.json
+++ b/src/data/research/problems/erdos-935.json
@@ -29,13 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ASSESSED: 6A (powerfulPart definable → could reduce to 1A). Noted for future work.",
+    "progressSummary": "ASSESSED: 5/6 axioms eliminable by constructive def of powerfulPart. Needs Finsupp.prod and Nat.factorization API.",
     "builtItems": [
-      "Assessment: powerfulPart is definable, reducing 5 of 6 axioms to provable"
+      "Assessment: 5 of 6 axioms are for opaque powerfulPart — all eliminable by constructive def"
     ],
     "insights": [
-      "6 axioms: powerfulPart (opaque function + 4 properties) + mahler_lower_bound. All appropriate since powerfulPart is axiomatized.",
-      "powerfulPart could be defined from Nat.factorization but currently axiomatized. Defining it would reduce 5 axioms to 0."
+      "powerfulPart can be defined as n.factorization.prod(fun p k => if 2≤k then p^k else 1)",
+      "powerfulPart_one: follows from factorization_one = 0 → empty product = 1",
+      "powerfulPart_dvd: use Finset.prod_dvd_prod since each factor divides p^k",
+      "powerfulPart_is_powerful: immediate from filtering on exponent ≥ 2",
+      "powerfulPart_mul coprime: use Nat.factorization_mul_of_coprime",
+      "mahler_lower_bound: deep result from Mahler 1953, appropriate axiom"
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary

### Erdős #374 — Factorial Products as Perfect Squares (5T→7T)
- Proved `bigF_eq_two_of_square`: F(n²) = 2 for n ≥ 2 via `Nat.find_eq_iff`
- Proved `square_in_D2`: n² ∈ D₂ for n ≥ 2 (backward direction of D2_eq_squares)

### Erdős #406 — Powers of 2 in Base 3 (5T→6T)
- Proved `sparse_complete_to_15`: exactly n ∈ {0, 2, 8} give ternary-sparse 2^n for n ≤ 15
- Combined with Saye's computation, verifies known examples are complete

### Erdős #935 — Powerful Part (assessment)
- 5 of 6 axioms are for opaque `powerfulPart` function — all eliminable by constructive definition
- Detailed roadmap in knowledge for future researcher

🤖 Generated by researcher-2