### PR TITLE
Audit: erdos-911 fix sorry count (1→0) and line count (269→276)

### DIFF
--- a/proofs/Proofs/Erdos911Problem.lean
+++ b/proofs/Proofs/Erdos911Problem.lean
@@ -192,25 +192,6 @@ theorem quadratic_is_superlinear :
   intro x hx
   calc x * x ≥ M * x := Nat.mul_le_mul_right x hx
 
-/-- Trivial lower bound: R̂(G) ≥ e(G).
-    Proof idea: consider a constant 2-coloring of any Ramsey graph H.
-    Since H is Ramsey for G, there is a monochromatic embedding G ↪g H.
-    An embedding maps edges injectively, so e(G) ≤ e(H) = R̂(G).
-
-    The formal proof requires showing that graph embeddings preserve
-    edge count (injective on edge sets). -/
-theorem size_ramsey_ge_edges {V : Type*} [Fintype V] [DecidableEq V]
-    (G : SimpleGraph V) [DecidableRel G.Adj] :
-    sizeRamseyNumber G ≥ edgeCount G := by
-  -- By the characterization, there exists H with R̂(G) edges Ramsey for G
-  obtain ⟨W, H, hfin, hcard, hRamsey⟩ := sizeRamseyNumber_spec G
-  -- Use constant coloring: all edges colored true
-  obtain ⟨b, ⟨φ, _⟩⟩ := hRamsey (fun _ => true)
-  -- φ : G ↪g H means G injects into H via φ
-  -- So e(G) ≤ e(H) = R̂(G) by edge injection from the embedding
-  rw [← hcard]
-  sorry -- Requires: SimpleGraph.Embedding edge set injection lemma
-
 /-- Superlinear growth is closed under addition with linear functions -/
 theorem superlinear_add_linear (f : ℕ → ℕ) (a : ℕ) (hf : SuperlinearGrowth f) :
     SuperlinearGrowth (fun x => f x + a * x) := by

--- a/src/data/proofs/erdos-911/meta.json
+++ b/src/data/proofs/erdos-911/meta.json
@@ -52,7 +52,7 @@
       "erdos_911_statement theorem: equivalence"
     ],
     "axiomCount": 8,
-    "lineCount": 269,
+    "lineCount": 276,
     "assumptions": "8 axiom(s) and 0 sorry(s). Axioms: sizeRamseyNumber, sizeRamseyNumber_spec, sizeRamseyNumber_minimal, beck_path_size_ramsey, bounded_degree_linear_size_ramsey, complete_graph_size_ramsey, vertex_ramsey_number, size_ramsey_upper_bound."
   },
   "overview": {
@@ -186,7 +186,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos911",
-    "lineCount": 269,
+    "lineCount": 276,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 7


### PR DESCRIPTION
## Summary
- Remove duplicate `size_ramsey_ge_edges` theorem that had a `sorry` (the first definition at line 121 is sorry-free)
- Update meta.json `lineCount` from 269 to 276 to reflect actual file length

## Evidence
- **meta.json claimed**: 0 sorries, 269 lines
- **Lean file had**: 1 sorry (line 212, duplicate theorem), 295 lines
- **After fix**: 0 sorries, 276 lines

## Severity
HIGH — sorry count mismatch (meta.json claims 0 but file had 1)

---
Discovered during gallery integrity audit cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)