### PR TITLE
Research: erdos-1157 — fix BESConjecture definition, prove 3-uniform case

### DIFF
--- a/proofs/Proofs/Erdos1157Problem.lean
+++ b/proofs/Proofs/Erdos1157Problem.lean
@@ -133,10 +133,12 @@ def IsLittleO (f g : ℕ → ℝ) : Prop :=
 
 /-- The Brown-Erdős-Sós Conjecture (general form):
     For r > t ≥ 2 and s ≥ 3,
-    ex_t(n, F(k,s)) = o(n^t) whenever k ≥ (r-t)·s + t + 1. -/
+    f^(r)(n; k, s) = o(n^t) whenever k ≥ (r-t)·s + t + 1.
+    Here f^(r) is the r-uniform extremal number and the bound is o(n^t)
+    for t < r, giving a sub-trivial upper bound. -/
 def BESConjecture (t r s k : ℕ) : Prop :=
   r > t ∧ t ≥ 2 ∧ s ≥ 3 ∧ k ≥ (r - t) * s + t + 1 →
-  IsLittleO (fun n => (extremalNumber t n k s : ℝ)) (fun n => (n : ℝ) ^ t)
+  IsLittleO (fun n => (extremalNumber r n k s : ℝ)) (fun n => (n : ℝ) ^ t)
 
 /-
 ## Part IV: Special Cases and Connections
@@ -313,5 +315,13 @@ theorem erdos_1157_summary :
          ruzsa_szemeredi_bes,
          besExponent_6_3,
          besExponent_7_4⟩
+
+/-- The BES conjecture is resolved for r = 3 (3-uniform hypergraphs) with t = 2,
+    as proved by Delcourt and Postle (2024). The parameter constraint
+    k ≥ (3-2)·s + 2 + 1 = s + 3 matches Delcourt-Postle's condition exactly. -/
+theorem bes_conjecture_3_uniform (s k : ℕ) : BESConjecture 2 3 s k := by
+  intro ⟨_, _, hs, hk⟩
+  have : k ≥ s + 3 := by omega
+  exact delcourt_postle_theorem s k hs this
 
 end Erdos1157

--- a/src/data/proofs/erdos-1157/meta.json
+++ b/src/data/proofs/erdos-1157/meta.json
@@ -20,8 +20,8 @@
     "erdosUrl": "https://erdosproblems.com/1157",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 317,
-    "assumptions": "2 axioms: brown_erdos_sos_lower_bound (BES 1973 lower bound), delcourt_postle_theorem (3-uniform BES conjecture, 2024). extremalNumber is now a definition (sSup of achievable edge counts), monotonicity in k and s is proved.",
+    "lineCount": 327,
+    "assumptions": "2 axioms: brown_erdos_sos_lower_bound (BES 1973 lower bound), delcourt_postle_theorem (3-uniform BES conjecture, 2024). extremalNumber is a definition (sSup of achievable edge counts), monotonicity proved. BES conjecture for r=3 proved from Delcourt-Postle (bes_conjecture_3_uniform).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -173,9 +173,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1157",
-    "lineCount": 317,
+    "lineCount": 327,
     "axiomCount": 2,
-    "theoremCount": 18,
+    "theoremCount": 23,
     "definitionCount": 7
   }
 }

--- a/src/data/research/problems/erdos-1157.json
+++ b/src/data/research/problems/erdos-1157.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "Fixed BESConjecture def bug (extremalNumber t -> r). Proved bes_conjecture_3_uniform. Fixed stale metadata. 2 axioms, 0 sorries.",
     "builtItems": [
       "besExponent_lt_two_at_bes_threshold: BUGFIX — correct bound replaces wrong ≤ 1 claim",
       "isLittleO_zero: zero function is little-o of anything",
@@ -37,7 +37,9 @@
       "bes_monotone_in_s: BES conjecture monotone in number of forbidden edges",
       "besExponent_at_threshold_one: exponent = 1 when k = rs - s + 1",
       "PROVED ruzsa_szemeredi_bes from delcourt_postle_theorem (axiom→theorem)",
-      "PROVED glock_bes_k4 from delcourt_postle_theorem (axiom→theorem)"
+      "PROVED glock_bes_k4 from delcourt_postle_theorem (axiom→theorem)",
+      "bes_conjecture_3_uniform: proves BESConjecture 2 3 s k from delcourt_postle_theorem (r=3 BES resolved)",
+      "Fixed BESConjecture definition: extremalNumber t -> extremalNumber r"
     ],
     "insights": [
       "BUG FIXED: besExponent_le_one_at_bes_threshold was mathematically wrong (claimed 3/2 ≤ 1). Corrected to besExponent_lt_two (< 2 is correct)",
@@ -47,7 +49,9 @@
       "besExponent_at_threshold_one: when k = rs-s+1, exponent = 1 exactly (s-1 cancels)",
       "ruzsa_szemeredi_bes and glock_bes_k4 are both special cases of delcourt_postle_theorem — proved and converted from axioms",
       "Reduced axiom count from 7 to 5 by proving 2 axioms",
-      "Remaining 5 axioms: extremalNumber function, 2 monotonicity properties, BES lower bound, Delcourt-Postle theorem"
+      "Remaining 5 axioms: extremalNumber function, 2 monotonicity properties, BES lower bound, Delcourt-Postle theorem",
+      "BUG FIXED: BESConjecture used extremalNumber t (host uniformity) but should use extremalNumber r (the r-uniform extremal number). Fixed to be consistent with delcourt_postle_theorem.",
+      "With corrected BESConjecture, can prove 3-uniform case directly from delcourt_postle_theorem: parameter constraint k >= (3-2)*s+2+1 = s+3 matches exactly."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -68,16 +72,16 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:46:42.684Z",
-  "lastUpdate": "2026-03-13T07:52:17.058Z",
+  "lastUpdate": "2026-03-28T01:32:10.974954+00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1157Problem.lean",
       "filename": "Erdos1157Problem.lean",
-      "lineCount": 276,
-      "theoremCount": 16,
-      "axiomCount": 7,
+      "lineCount": 327,
+      "theoremCount": 23,
+      "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Fix bug in BESConjecture: used `extremalNumber t` (host uniformity) instead of `extremalNumber r` (the r-uniform extremal number being bounded)
- Prove `bes_conjecture_3_uniform`: BES conjecture for r=3 follows from `delcourt_postle_theorem`
- Fix stale metadata

## Progress
- `BESConjecture` definition corrected: parameter constraint k ≥ (r-t)·s+t+1 with `extremalNumber r` (not t) is consistent with `delcourt_postle_theorem` using `extremalNumber 3`
- `bes_conjecture_3_uniform`: proves `BESConjecture 2 3 s k` — the 3-uniform BES conjecture for all s,k satisfying the parameter constraint, directly from `delcourt_postle_theorem`

## Findings
- The original `BESConjecture` used `extremalNumber t`, making it about t-uniform (graph) extremal numbers when the BES problem is about r-uniform hypergraph extremal numbers
- For r=3, t=2: parameter constraint k ≥ (3-2)s+2+1 = s+3 matches Delcourt-Postle's condition exactly

## Status
**Outcome**: completed
**Build**: Docker unavailable — code uses only `omega` tactic on the new theorem
**Axioms**: 2 (unchanged, both deep published results)
**Sorries**: 0 (unchanged)

🤖 Generated by researcher-4