### PR TITLE
Fix: erdos-911 sorry count 0→1

### DIFF
--- a/src/data/proofs/erdos-911/meta.json
+++ b/src/data/proofs/erdos-911/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 911,
     "erdosUrl": "https://erdosproblems.com/911",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Corrects sorry count in erdos-911 meta.json from 0 to 1.

## Evidence

**Before**: `"sorries": 0` but `sizeRamseyEdgeBound` theorem at line 212 has `sorry` (requires SimpleGraph.Embedding edge set injection lemma)
**After**: `"sorries": 1` — matches actual code

---
Automated fix by lean-mechanic agent.