### PR TITLE
Audit: erdos-864 axiomCount (3→2), erdos-913/864/159 lineCount fixes

### DIFF
--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -61,7 +61,7 @@
       "ramseyC4Kn_ge theorem: trivial lower bound R ≥ n proved from specification (was axiom)"
     ],
     "axiomCount": 2,
-    "lineCount": 185,
+    "lineCount": 224,
     "assumptions": "2 axioms: szemeredi_upper (Szemerédi upper bound), spencer_lower (Spencer lower bound). The Ramsey function ramseyC4Kn and its threshold specification are now defined/proved from the finite Ramsey theorem via Nat.find."
   },
   "overview": {
@@ -158,7 +158,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 185,
+    "lineCount": 224,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 4

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -51,9 +51,9 @@
       "Axiomatized Erdős-Freud lower bound with explicit (2/√3 − ε)·√N form",
       "Axiomatized the reflected construction B ∪ (N − B) with B Sidon in {1,...,N/3}"
     ],
-    "axiomCount": 3,
-    "lineCount": 269,
-    "assumptions": "3 axioms: erdos_freud_lower_bound, sidon_upper_bound, reflected_construction_valid. Previously 4; almost_sidon_sum_range proved FALSE (counterexample: A={1,2,4,6,7}, N=7, collision at sum 8 with multiplicity 3).",
+    "axiomCount": 2,
+    "lineCount": 531,
+    "assumptions": "2 axioms: erdos_freud_lower_bound, sidon_upper_bound. Previously 4; almost_sidon_sum_range proved FALSE (counterexample), reflected_construction_valid removed.",
     "mathlib_version": "4.26.0"
   },
   "sections": [

--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/913",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 150,
+    "lineCount": 235,
     "assumptions": "3 axioms: infinite_8p_sq_minus_1_primes, erdos_913_conditional, exponent_structure. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Summary
- **erdos-864**: axiomCount 3→2 (`reflected_construction_valid` removed in #7258), lineCount 269→531
- **erdos-913**: lineCount 150→235
- **erdos-159**: lineCount 185→224

## Evidence
All three entries were recently modified by research agents (#7258, #7260) but meta.json counts were not updated.

## Severity
- erdos-864 axiom count: MEDIUM (axiom count directly affects gallery badge credibility)
- lineCount mismatches: LOW (cosmetic)

---
Discovered during gallery integrity audit cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)