### PR TITLE
Research: erdos-749 — prove sidon_set_density_zero axiom (2→1 axioms)

### DIFF
--- a/proofs/Proofs/Erdos749Problem.lean
+++ b/proofs/Proofs/Erdos749Problem.lean
@@ -23,6 +23,7 @@ Reference: https://erdosproblems.com/749
 -/
 
 import Mathlib
+import Proofs.Erdos340GreedySidon
 
 /- ## Core Definitions -/
 
@@ -135,20 +136,95 @@ theorem sidon_bounded_rep (A : Set ℕ) (hsidon : ∀ a b c d : ℕ,
   have heq : a + (n - a) = b + (n - b) := by omega
   exact (hsidon a (n - a) b (n - b) ha_A hna_A hb_A hnb_A ha_le hb_le heq).1
 
-/-- Sidon sets have natural density 0: upper density of A is 0.
-    This follows from the classical bound |A ∩ [1,N]| ≤ √(2N) + 1,
-    since all pairwise sums a+b (a ≤ b) are distinct and lie in [2, 2N].
-    Thus Sidon sets can't achieve dense sumsets (they have bounded rep
-    but fail the density requirement of Problem #749).
+/-- Sidon counting bound: |A ∩ [1,N]| ≤ √(2N) + 1 for any set-Sidon A.
+    Bridges Set-based Sidon property to Finset IsSidon and applies
+    the bound from Erdos340GreedySidon. -/
+private lemma sidon_counting_bound (A : Set ℕ)
+    (hsidon : ∀ a b c d : ℕ, a ∈ A → b ∈ A → c ∈ A → d ∈ A →
+      a ≤ b → c ≤ d → a + b = c + d → a = c ∧ b = d)
+    (N : ℕ) : countingFn A N ≤ Nat.sqrt (2 * N) + 1 := by
+  classical
+  unfold countingFn
+  set S := (Finset.Icc 1 N).filter (fun x => x ∈ A) with hS_def
+  have hset_eq : A ∩ Set.Icc 1 N = ↑S := by
+    ext x
+    simp only [Set.mem_inter_iff, Set.mem_Icc, Finset.mem_coe, hS_def,
+      Finset.mem_filter, Finset.mem_Icc]
+    constructor
+    · rintro ⟨hA, h1, hN⟩; exact ⟨⟨h1, hN⟩, hA⟩
+    · rintro ⟨⟨h1, hN⟩, hA⟩; exact ⟨hA, h1, hN⟩
+  rw [hset_eq, Set.ncard_coe_finset]
+  exact sidon_upper_bound_weak S
+    (fun a b c d ha hb hc hd hab hcd heq => by
+      simp only [hS_def, Finset.mem_filter] at ha hb hc hd
+      exact hsidon a b c d ha.2 hb.2 hc.2 hd.2 hab hcd heq)
+    N (fun a ha => by simp only [hS_def, Finset.mem_filter, Finset.mem_Icc] at ha; exact ha.1.2)
 
-    Proof sketch: For S = A ∩ [1,N] with |S| = k, the Sidon property
-    implies the sum map (a,b) ↦ a+b on S×S has each fiber of size ≤ 2
-    (the pair (a,b) and its swap (b,a)). Since sums lie in {2,...,2N},
-    we get k² ≤ 2·(2N-1) < 4N, hence k < 2√N and density → 0. -/
-axiom sidon_set_density_zero (A : Set ℕ) (hsidon : ∀ a b c d : ℕ,
+/-- For K ≥ 1 and N ≥ 2K²+2K+1, the Sidon counting bound times K fits in N.
+    Key step: 2·(√(2N)+1)·K ≤ (√(2N)+1)·(√(2N)-1) = (√(2N))²-1 ≤ 2N-1. -/
+private lemma sqrt_mul_bound (K N : ℕ) (hK : 1 ≤ K)
+    (hN : 2 * K ^ 2 + 2 * K + 1 ≤ N) :
+    (Nat.sqrt (2 * N) + 1) * K ≤ N := by
+  set S := Nat.sqrt (2 * N) with hS_def
+  -- S ≥ 2K+1 because (2K+1)² = 4K²+4K+1 ≤ 2·(2K²+2K+1) ≤ 2N
+  have hS_ge : 2 * K + 1 ≤ S := by
+    rw [hS_def]; exact Nat.le_sqrt.mpr (by nlinarith)
+  -- (Nat.sqrt(2N))² ≤ 2N: defining property of Nat.sqrt
+  have hS_sq : S * S ≤ 2 * N := Nat.sqrt_le (2 * N)
+  -- Chain: 2·(S+1)·K ≤ (S+1)·(S-1) = S²-1 ≤ 2N-1, so (S+1)·K ≤ N
+  have h1 : 2 * K ≤ S - 1 := by omega
+  have h2 : (S + 1) * (2 * K) ≤ (S + 1) * (S - 1) := Nat.mul_le_mul_left _ h1
+  have h3 : (S + 1) * (S - 1) = S * S - 1 := by zify [show S ≥ 1 by omega]; ring
+  have h_sub : S * S - 1 ≤ 2 * N - 1 := Nat.sub_le_sub_right hS_sq 1
+  have h5 : (S + 1) * (2 * K) = 2 * ((S + 1) * K) := by ring
+  have h6 : 2 * ((S + 1) * K) ≤ 2 * N - 1 := by linarith [h2, h3, h_sub, h5]
+  omega
+
+/-- Sidon sets have natural density 0: upper density of A is 0.
+    Proof: |A ∩ [1,N]| ≤ √(2N)+1 (Sidon counting bound), so
+    densityRatio A N ≤ (√(2N)+1)/N → 0 as N → ∞. -/
+theorem sidon_set_density_zero (A : Set ℕ) (hsidon : ∀ a b c d : ℕ,
     a ∈ A → b ∈ A → c ∈ A → d ∈ A → a ≤ b → c ≤ d →
     a + b = c + d → a = c ∧ b = d) :
-    upperDensity A = 0
+    upperDensity A = 0 := by
+  apply le_antisymm
+  · -- upperDensity A ≤ 0: by contradiction
+    by_contra hlt; push_neg at hlt
+    -- hlt : 0 < upperDensity A
+    -- Pick K large enough that 1/(K+1) < upperDensity A / 2
+    obtain ⟨K, hK⟩ := exists_nat_gt (2 / upperDensity A)
+    -- For large N, densityRatio A N ≤ upperDensity A / 2
+    have hev : ∀ᶠ N in Filter.atTop, densityRatio A N ≤ upperDensity A / 2 := by
+      rw [Filter.eventually_atTop]
+      refine ⟨2 * (K + 1) ^ 2 + 2 * (K + 1) + 1, fun N hN => ?_⟩
+      have hN_pos : 0 < N := by omega
+      have hcnt := sidon_counting_bound A hsidon N
+      have hmul := sqrt_mul_bound (K + 1) N (by omega) (by omega)
+      have hprod : countingFn A N * (K + 1) ≤ N :=
+        le_trans (Nat.mul_le_mul_right _ hcnt) hmul
+      -- Cast to ℝ and prove the density bound
+      unfold densityRatio
+      rw [div_le_iff (Nat.cast_pos.mpr hN_pos)]
+      -- Need: (countingFn A N : ℝ) ≤ (upperDensity A / 2) * ↑N
+      have h_cast : (countingFn A N : ℝ) * (↑K + 1) ≤ ↑N := by
+        have := Nat.cast_le (α := ℝ).mpr hprod
+        simp only [Nat.cast_mul, Nat.cast_add, Nat.cast_one] at this
+        linarith
+      have h_eps_K : 1 ≤ (upperDensity A / 2) * (↑K + 1) := by
+        have hK_real : 2 / upperDensity A < ↑K := by exact_mod_cast hK
+        nlinarith
+      calc (countingFn A N : ℝ)
+          ≤ (countingFn A N : ℝ) * ((upperDensity A / 2) * (↑K + 1)) :=
+            le_mul_of_one_le_right (Nat.cast_nonneg _) h_eps_K
+        _ = (upperDensity A / 2) * ((countingFn A N : ℝ) * (↑K + 1)) := by ring
+        _ ≤ (upperDensity A / 2) * ↑N :=
+            mul_le_mul_of_nonneg_left h_cast (by linarith)
+    -- limsup ≤ upperDensity A / 2 < upperDensity A, contradiction
+    have h_le := limsup_le_of_le (by infer_instance) hev
+    unfold upperDensity at hlt h_le
+    linarith
+  · -- 0 ≤ upperDensity A
+    exact le_trans (lowerDensity_nonneg A) (lower_le_upper A)
 
 /- ## Erdős–Turán Conjecture Connection -/
 

--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -79,13 +79,13 @@
       "HasDenseSumset: ε-dense sumset d(A+A) ≥ 1-ε",
       "erdos_749_conjecture: main question as dichotomy (proved via by_cases)",
       "sidon_bounded_rep: proved Sidon → bounded r(n) via Finset.card_le_one",
-      "sidon_set_density_zero: axiomatized Sidon → upper density of A = 0 (known classical result)",
+      "sidon_set_density_zero: PROVED Sidon → upper density of A = 0 via counting bound",
       "erdos_turan_conjecture_28: axiomatized d(A+A) = 1 → ¬HasBoundedRep (open conjecture)",
       "erdos_749_upper_variant: upper density version (proved via by_cases)"
     ],
-    "axiomCount": 2,
-    "lineCount": 177,
-    "assumptions": "2 axioms: sidon_set_density_zero (Sidon sets have zero upper density), erdos_turan_conjecture_28 (ET conjecture, open)."
+    "axiomCount": 1,
+    "lineCount": 253,
+    "assumptions": "1 axiom: erdos_turan_conjecture_28 (Erdős-Turán conjecture, open). sidon_set_density_zero was proved from Sidon counting bound via Erdos340GreedySidon."
   },
   "overview": {
     "historicalContext": "Erdős posed this in 1994, exploring the fundamental tension in additive combinatorics between sumset density and representation function growth. Sidon sets (Erdős-Turán 1941) demonstrate that bounded r(n) is compatible with sparse sumsets: they have r(n) ≤ 1 but |A ∩ [1,N]| ∼ √N, giving density-0 sumsets. At the other extreme, the Erdős-Turán conjecture (Problem #28, $500 bounty) asserts that any additive basis of order 2 (density-1 sumset) must have unbounded r(n).\n\nProblem #749 asks about the boundary: can we get sumset density arbitrarily close to 1 while keeping r(n) bounded? A positive answer would show the Erdős-Turán obstruction is specific to density exactly 1 — a sharp phase transition. A negative answer would show the obstruction appears at some critical density 1-ε₀ < 1, strengthening the Erdős-Turán conjecture quantitatively.",
@@ -131,7 +131,7 @@
     {
       "id": "context",
       "title": "Sidon Sets and Erdős-Turán Connection",
-      "summary": "Proves `sidon_bounded_rep` (Sidon → r(n) ≤ 1). Axiomatizes `sidon_set_density_zero` (Sidon sets have upper density 0, known classical result). Connects to Erdős-Turán conjecture (#28, open) as axiom.",
+      "summary": "Proves `sidon_bounded_rep` (Sidon → r(n) ≤ 1). Proves `sidon_set_density_zero` (Sidon sets have upper density 0) from Sidon counting bound. Connects to Erdős-Turán conjecture (#28, open) as axiom.",
       "startLine": 113,
       "endLine": 150
     },
@@ -155,13 +155,14 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib"
+      "Mathlib",
+      "Proofs.Erdos340GreedySidon"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 177,
-    "axiomCount": 2,
-    "theoremCount": 7,
+    "lineCount": 253,
+    "axiomCount": 1,
+    "theoremCount": 10,
     "definitionCount": 8
   },
   "references": [


### PR DESCRIPTION
## Summary
- Prove `sidon_set_density_zero` axiom, reducing erdos-749 from 2 axioms to 1
- Bridge Set-Sidon property to Finset `IsSidon` and apply `sidon_upper_bound_weak` from Erdos340GreedySidon
- Prove `upperDensity A = 0` for Sidon sets via counting bound and limsup analysis
- Remaining axiom `erdos_turan_conjecture_28` is an open conjecture (appropriately axiomatized)

## Proof Strategy
1. **sidon_counting_bound**: Convert `Set ℕ` Sidon property to `Finset ℕ` `IsSidon`, apply existing `sidon_upper_bound_weak` to get `|A ∩ [1,N]| ≤ √(2N) + 1`
2. **sqrt_mul_bound**: For K ≥ 1 and N ≥ 2K²+2K+1, show `(√(2N)+1)·K ≤ N` using difference-of-squares identity
3. **sidon_set_density_zero**: By contradiction — if `upperDensity A > 0`, pick K large enough that `1/(K+1) < upperDensity A / 2`, show eventually `densityRatio ≤ upperDensity A / 2`, derive `limsup ≤ limsup/2`, contradiction

## Files Modified
- `proofs/Proofs/Erdos749Problem.lean` — axiom → theorem with 3 helper lemmas
- `src/data/proofs/erdos-749/meta.json` — axiomCount 2→1, updated metadata

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos749Problem`
- [ ] Verify `grep -c "^axiom " proofs/Proofs/Erdos749Problem.lean` returns 1

🤖 Generated by researcher-10