### PR TITLE
Audit: erdos-635 fix axiom count (4→3)

### DIFF
--- a/src/data/proofs/erdos-635/meta.json
+++ b/src/data/proofs/erdos-635/meta.json
@@ -67,9 +67,9 @@
       "no_far_multiples axiom: structural consequence excluding multiples",
       "erdos_635_t1_solved theorem: the t = 1 case from axioms"
     ],
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 388,
-    "assumptions": "4 axioms: f_t2_lower/erdos_construction_t2 (t=2 logarithmic improvement), erdos_635 (OPEN conjecture), f_t1_density (limit). f_t1 now fully proved via no-consecutive grouping argument."
+    "assumptions": "3 axioms: f_t2_lower, erdos_construction_t2 (t=2 logarithmic improvement), erdos_635 (OPEN conjecture). f_t1_density removed (proved via no-consecutive grouping argument)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #635** originates from a letter Erdős wrote to Imre Ruzsa around 1980. The problem asks a deceptively simple question: given a subset A of {1,...,N} where large differences between elements cannot divide the larger element, how big can A be? This sits at the intersection of additive and multiplicative number theory, where the additive structure (gaps between elements) interacts with multiplicative structure (divisibility).\n\nThe problem has a clean answer for t = 1: the optimal set consists of all odd numbers in {1,...,N}, giving exactly ⌊(N+1)/2⌋ elements. The key insight is that the difference of two odd numbers is always even, and an even number cannot divide an odd number. This elegant argument completely resolves the t = 1 case. For t = 2, Erdős himself showed that one can beat the N/2 barrier by a logarithmic factor, constructing sets of size N/2 + c·log(N) by augmenting odd numbers with carefully chosen powers of 2.\n\nDespite these partial results, the general conjecture — that the density is always close to 1/2 regardless of t — remains open. The difficulty lies in the fact that larger t relaxes the constraint (applying only to pairs with large enough gaps), yet the conjecture asserts this doesn't fundamentally change the extremal density. The references [Gu83] by Gupta and [Ru99] by Ruzsa contain related work on divisibility conditions in combinatorial number theory.",
@@ -183,7 +183,7 @@
     ],
     "namespace": "Erdos635",
     "lineCount": 388,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 9,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Summary
- Fix axiomCount: 4→3 (f_t1_density axiom was proved and removed from Lean file)
- Update assumptions text to reflect current state

## Evidence
- **meta.json claimed**: 4 axioms
- **Lean file has**: 3 axioms (f_t2_lower, erdos_construction_t2, erdos_635)
- f_t1_density was proved via no-consecutive grouping argument but axiomCount not decremented

## Severity
MEDIUM — axiom count directly affects gallery badge credibility

---
Discovered during gallery integrity audit cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)