### PR TITLE
Fix: erdos-1131 sorry count mismatch (1→2)

### DIFF
--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -24,9 +24,9 @@
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "theoremCount": 30,
+    "theoremCount": 31,
     "lineCount": 958,
-    "assumptions": "1 axiom: erdos_1131_conjecture (OPEN). 2 sorries: chebyshev_interp (Chebyshev polynomial interpolation at nodes), chebyshev_sq_expansion (DCT Parseval identity — needs Lagrange interpolation of Chebyshev polynomials, substantial infrastructure).",
+    "assumptions": "1 axiom: erdos_1131_conjecture (OPEN). 2 sorries: chebyshev_interp (Lagrange interpolation exactness for Chebyshev polynomials — needs polynomial uniqueness argument), chebyshev_sq_expansion (DCT Parseval identity — needs chebyshev_interp + bilinear expansion). Previously sorry lemmas now fully proved: dct_offdiag, integral_cos_substitution, integral_chebyshev_sq, chebyshev_integral_trace.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -116,7 +116,7 @@
       "title": "Integration and Substitution Lemmas",
       "startLine": 365,
       "endLine": 409,
-      "summary": "Six lemmas for evaluating $\\int_{-1}^{1} T_j(x)^2\\,dx$: `two_cos_mul_sin` (product-to-sum, proved), `integral_sin_mul` ($\\int_0^\\pi \\sin(k\\theta)\\,d\\theta$ by FTC — sorry, needs `hasDerivAt_cos`), `cos_nat_mul_pi` ($\\cos(m\\pi)=(-1)^m$ by induction, proved), `integral_cos_mul_sin` ($\\int_0^\\pi \\cos(2j\\theta)\\sin\\theta\\,d\\theta = -2/(4j^2-1)$ — sorry, needs `continuous_sin`), `integral_cos_substitution` (change of variables $x=\\cos\\theta$ — sorry, needs `hasDerivAt_cos`), and `integral_chebyshev_sq` ($\\int_{-1}^{1} T_j(x)^2\\,dx = 1-1/(4j^2-1)$ — sorry, blocked on `continuous_cos.comp`).",
+      "summary": "Six fully proved lemmas for evaluating $\\int_{-1}^{1} T_j(x)^2\\,dx$: `two_cos_mul_sin` (product-to-sum), `integral_sin_mul` ($\\int_0^\\pi \\sin(k\\theta)\\,d\\theta$ by FTC with antiderivative $-\\cos(k\\theta)/k$), `cos_nat_mul_pi` ($\\cos(m\\pi)=(-1)^m$ by induction), `integral_cos_mul_sin` ($\\int_0^\\pi \\cos(2j\\theta)\\sin\\theta\\,d\\theta = -2/(4j^2-1)$ via product-to-sum decomposition), `integral_cos_substitution` (change of variables $x=\\cos\\theta$ via `integral_comp_mul_deriv`), and `integral_chebyshev_sq` ($\\int_{-1}^{1} T_j(x)^2\\,dx = 1-1/(4j^2-1)$ combining substitution with cos² identity).",
       "mathContext": "$\\int_0^\\pi \\sin(k\\theta)\\,d\\theta = \\frac{1-\\cos(k\\pi)}{k}$. Change of variables: $\\int_{-1}^{1} f(x)\\,dx = \\int_0^\\pi f(\\cos\\theta)\\sin\\theta\\,d\\theta$. $\\int_{-1}^{1} T_j(x)^2\\,dx = 1 - \\frac{1}{4j^2-1}$."
     },
     {
@@ -124,7 +124,7 @@
       "title": "DCT Orthogonality Infrastructure",
       "startLine": 410,
       "endLine": 563,
-      "summary": "Discrete Cosine Transform orthogonality at Chebyshev angles, forming the backbone of the Chebyshev expansion. `two_cos_mul_cos` (product-to-sum for cosines, proved). `frequency_abel_sum`: Abel summation identity $2\\sin\\beta\\sum\\cos(2j\\beta)=(1-(-1)^s)\\sin\\beta$ using telescoping (proved). `frequency_cosine_sum_even`/`_odd`: frequency sums equal 0 (even $s$) or 1 (odd $s$), proved by factoring out $\\sin\\beta\\ne 0$. `dct_diagonal`: $1+2\\sum_{j=1}^{n-1}\\cos^2(j\\theta_k)=n$ (proved via `frequency_cosine_sum_odd`). `dct_offdiag`: $1+2\\sum\\cos(j\\theta_k)\\cos(j\\theta_m)=0$ for $k\\ne m$ (sorry — product-to-sum + parity). `chebyshev_sq_expansion`: $\\sum l_k^2 = (1/n)(1+2\\sum T_j^2)$ (sorry — needs DCT Parseval).",
+      "summary": "Discrete Cosine Transform orthogonality at Chebyshev angles, forming the backbone of the Chebyshev expansion. `two_cos_mul_cos` (product-to-sum for cosines, proved). `frequency_abel_sum`: Abel summation identity $2\\sin\\beta\\sum\\cos(2j\\beta)=(1-(-1)^s)\\sin\\beta$ using telescoping (proved). `frequency_cosine_sum_even`/`_odd`: frequency sums equal 0 (even $s$) or 1 (odd $s$), proved by factoring out $\\sin\\beta\\ne 0$. `dct_diagonal`: $1+2\\sum_{j=1}^{n-1}\\cos^2(j\\theta_k)=n$ (proved via `frequency_cosine_sum_odd`). `dct_offdiag`: $1+2\\sum\\cos(j\\theta_k)\\cos(j\\theta_m)=0$ for $k\\ne m$ (proved via product-to-sum + parity case split). `chebyshev_interp`: Lagrange interpolation exactness for Chebyshev polynomials (sorry — needs polynomial uniqueness). `chebyshev_sq_expansion`: $\\sum l_k^2 = (1/n)(1+2\\sum T_j^2)$ (sorry — needs chebyshev_interp + bilinear expansion).",
       "mathContext": "DCT orthogonality: $\\frac{1}{n}\\sum_{k=0}^{n-1}\\cos(j\\theta_k)\\cos(m\\theta_k)=\\frac{1}{2}\\delta_{jm}$ for $1\\le j,m\\le n-1$, where $\\theta_k=\\frac{(2k+1)\\pi}{2n}$. Chebyshev expansion: $\\sum_k l_k(x)^2=\\frac{1}{n}\\bigl(1+2\\sum_{j=1}^{n-1}T_j(x)^2\\bigr)$."
     },
     {
@@ -132,7 +132,7 @@
       "title": "Chebyshev Integral: Exact Value and Estimates",
       "startLine": 565,
       "endLine": 629,
-      "summary": "Four theorems on the Chebyshev integral. `chebyshev_integral_trace`: trace formula $I = (1/n)(2n - 2\\sum 1/(4j^2-1))$ (sorry — needs `chebyshev_sq_expansion` + `integral_chebyshev_sq`). `chebyshev_integral_exact`: $I = 2 - 2(n-1)/(n(2n-1))$, proved by combining the trace formula with `partial_fraction_sum`. `chebyshev_integral_lt_two`: $I < 2$ since the correction term is positive (proved). `chebyshev_integral_estimate`: $\\exists c>0$ with $|I-(2-c/n)|\\le c/n^2$, proved by taking $c = n(2-I)$.",
+      "summary": "Four fully proved theorems on the Chebyshev integral. `chebyshev_integral_trace`: trace formula $I = (1/n)(2n - 2\\sum 1/(4j^2-1))$, proved by combining `chebyshev_sq_expansion` with `integral_chebyshev_sq`. `chebyshev_integral_exact`: $I = 2 - 2(n-1)/(n(2n-1))$, proved by combining the trace formula with `partial_fraction_sum`. `chebyshev_integral_lt_two`: $I < 2$ since the correction term is positive. `chebyshev_integral_estimate`: $\\exists c>0$ with $|I-(2-c/n)|\\le c/n^2$, proved by taking $c = n(2-I)$.",
       "mathContext": "$I_{\\text{Cheb}}(n) = 2 - \\frac{2(n-1)}{n(2n-1)} < 2$. Asymptotically: $I_{\\text{Cheb}} = 2 - \\frac{1}{n} + O(1/n^2)$."
     },
     {
@@ -201,8 +201,8 @@
     "namespace": "Erdos1131",
     "lineCount": 958,
     "axiomCount": 1,
-    "sorryCount": 1,
-    "theoremCount": 30,
+    "sorryCount": 2,
+    "theoremCount": 31,
     "definitionCount": 6
   }
 }


### PR DESCRIPTION
## Summary
- **sorry count**: meta.json claimed 1 sorry, actual Lean file has 2 (`chebyshev_interp` line 761, `chebyshev_sq_expansion` line 808)
- **lineCount**: 904→958, **theoremCount**: 30→31 (new `chebyshev_interp` lemma factored out)
- **Section summaries**: updated 3 sections where previously-sorry lemmas are now fully proved (`dct_offdiag`, `integral_cos_substitution`, `integral_chebyshev_sq`, `chebyshev_integral_trace`)

## Audit Evidence
```
grep -n '\bsorry\b' proofs/Proofs/Erdos1131Problem.lean
761:  sorry    # chebyshev_interp
808:  sorry    # chebyshev_sq_expansion
```

meta.json `sorries` field said 1. Corrected to 2.

## Test plan
- [x] Verified sorry count via grep against Lean source
- [x] Verified axiom count (1) matches
- [x] No True stubs detected
- [x] Section summaries updated to reflect proved lemmas

🤖 Generated with [Claude Code](https://claude.com/claude-code)