### PR TITLE
Fix: inverse-galois axiomCount 2→3

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -27,7 +27,7 @@
     ],
     "badge": "axiom",
     "sorries": 2,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Cyclotomic fields and Kronecker-Weber theorem",


### PR DESCRIPTION
## Summary
- **axiomCount**: meta.json claimed 2, actual is 3 across multi-file proof
- 3 axiom declarations: `abelian_realizable`, `shafarevich_theorem` (InverseGalois.lean), `three_dvd_gal_card` (InverseGaloisA5.lean)
- The `assumptions` text field already correctly stated "3 axiom declarations" — only the numeric field was wrong

## Test plan
- [x] Verified axiom count via `grep "^axiom "` across all 8 related Lean files
- [x] Verified sorry count (2) is correct
- [x] No True stubs detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)