### PR TITLE
Research: erdos-332 — 5 structural theorems for difference sets

### DIFF
--- a/proofs/Proofs/Erdos332Problem.lean
+++ b/proofs/Proofs/Erdos332Problem.lean
@@ -96,6 +96,41 @@ theorem zero_mem_diffSet (A : Set ℕ) (hA : Set.Infinite A) :
   exact hA ((hfin.image Prod.fst).subset
     (fun a ha => ⟨⟨a, a⟩, ⟨ha, ha, by push_cast; ring⟩, rfl⟩))
 
+/- ## Structural properties -/
+
+/-- Monotonicity: if `A ⊆ B` then `D(A) ⊆ D(B)`. -/
+theorem diffSet_mono (A B : Set ℕ) (h : A ⊆ B) : diffSet A ⊆ diffSet B := by
+  intro d hd
+  simp only [diffSet, Set.mem_setOf_eq] at hd ⊢
+  intro hfin
+  exact hd (hfin.subset (fun ⟨a₁, a₂⟩ ⟨ha₁, ha₂, hd⟩ => ⟨h ha₁, h ha₂, hd⟩))
+
+/-- A finite set has empty difference set: no difference can occur
+    infinitely often among finitely many pairs. -/
+theorem diffSet_finite_eq_empty (A : Set ℕ) (hA : A.Finite) : diffSet A = ∅ := by
+  ext d
+  simp only [diffSet, Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
+  intro hinf
+  exact hinf ((hA.prod hA).subset (fun ⟨a₁, a₂⟩ ⟨ha₁, ha₂, _⟩ => ⟨ha₁, ha₂⟩))
+
+/-- If `A` is infinite, `D(A)` is nonempty (it contains zero). -/
+theorem diffSet_nonempty_of_infinite (A : Set ℕ) (hA : Set.Infinite A) :
+    (diffSet A).Nonempty :=
+  ⟨0, zero_mem_diffSet A hA⟩
+
+/-- Positive lower density implies positive upper density. -/
+theorem lower_density_implies_upper (A : Set ℕ) :
+    HasPositiveLowerDensity A → HasPositiveUpperDensity A := by
+  rintro ⟨δ, hδ, N₀, hN₀⟩
+  exact ⟨δ, hδ, fun M => ⟨max N₀ M, le_max_right _ _, hN₀ (max N₀ M) (le_max_left _ _)⟩⟩
+
+/-- Positive lower density implies `D(A)` has bounded gaps:
+    a corollary combining `lower_density_implies_upper` with the
+    Prikry–Tijdeman–Stewart result. -/
+theorem positive_lower_density_bounded_gaps (A : Set ℕ) :
+    HasPositiveLowerDensity A → HasBoundedGaps (diffSet A) :=
+  fun h => positive_density_bounded_gaps A (lower_density_implies_upper A h)
+
 /- ## Main problem -/
 
 /-- Erdős Problem 332: What conditions on `A ⊆ ℕ` are sufficient to

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/332",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "assumptions": "3 axiom declarations: positive_density_bounded_gaps (Prikry's theorem), positive_density_diffset_dense (density inheritance for D(A)), diffSet_harmonic_diverges (harmonic thickness conjecture). diffSet_symm and zero_mem_diffSet are now proved theorems.",
+    "assumptions": "3 axiom declarations: positive_density_bounded_gaps (Prikry's theorem), positive_density_diffset_dense (density inheritance for D(A)), diffSet_harmonic_diverges (harmonic thickness conjecture). 7 theorems proved: diffSet_symm, zero_mem_diffSet, diffSet_mono, diffSet_finite_eq_empty, diffSet_nonempty_of_infinite, lower_density_implies_upper, positive_lower_density_bounded_gaps.",
     "dateAdded": "2026-01-22",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -47,6 +47,11 @@
       "Formal framework: diffSet (D(A) via infinite fibre), HasBoundedGaps (syndeticity), density predicates over ℚ, ErdosProblem332 (weakest condition characterization)",
       "Proved diffSet_symm: D(A) = -D(A) via the bijection (a₁,a₂) ↦ (a₂,a₁)",
       "Proved zero_mem_diffSet: 0 ∈ D(A) for infinite A (any element pairs with itself)",
+      "Proved diffSet_mono: A ⊆ B → D(A) ⊆ D(B) via subset transfer on infinite fibres",
+      "Proved diffSet_finite_eq_empty: D(A) = ∅ for finite A via Set.Finite.prod bound on pairs",
+      "Proved diffSet_nonempty_of_infinite: D(A) is nonempty for infinite A (corollary of zero_mem_diffSet)",
+      "Proved lower_density_implies_upper: positive lower density → positive upper density",
+      "Proved positive_lower_density_bounded_gaps: lower density suffices for bounded gaps (combines density implication with Prikry's theorem)",
       "Axiomatized Prikry's theorem, density inheritance, and harmonic thickness conjecture as the known landscape for Problem #332"
     ],
     "prerequisites": [
@@ -56,12 +61,12 @@
       "Additive combinatorics: difference sets, syndetic sets",
       "Ergodic theory basics: Furstenberg correspondence principle (for context)"
     ],
-    "lineCount": 118
+    "lineCount": 154
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory* [ErGr80], building on the classical study of difference sets pioneered by Khintchine (1930s) and Følner (1954). The key known result is due to Karel Prikry, who proved that positive upper density of $A$ guarantees $D(A)$ has bounded gaps (syndeticity); related work by Robert Tijdeman and Cameron Stewart refined the quantitative bounds on the gap parameter $M$ in terms of the density $\\delta$. The problem connects deeply to Hillel Furstenberg's 1977 correspondence principle (*Journal d'Analyse Mathématique*), which translates combinatorial density questions into ergodic theory — Prikry's theorem follows from Poincaré recurrence in the associated measure-preserving system. The open question of finding the *weakest* sufficient condition sits within the broader program of understanding how density forces structure: Szemerédi's theorem (1975) shows positive density forces arithmetic progressions, and the Green–Tao theorem (2008) extends this to the primes. Problem #332 asks the analogous question for difference sets rather than progressions.",
     "problemStatement": "Let $A \\subseteq \\mathbb{N}$ and $D(A) = \\{d \\in \\mathbb{Z} : a_1 - a_2 = d \\text{ for infinitely many } (a_1, a_2) \\in A^2\\}$. What is the weakest condition on $A$ guaranteeing that $D(A)$ has bounded gaps (is syndetic)?",
-    "text": "A 118-line formalization of Erdős Problem #332 studying the difference set $D(A) = \\{d \\in \\mathbb{Z} : a_1 - a_2 = d \\text{ for infinitely many pairs}\\}$ and the conditions forcing it to be syndetic (have bounded gaps). Defines 6 predicates: `diffSet` (infinite-fibre differences), `HasBoundedGaps` (syndeticity), `countingFn` ($A(N) = |A \\cap [1,N]|$), `HasPositiveUpperDensity` and `HasPositiveLowerDensity` (density via $\\mathbb{Q}$ ratios), and `ErdosProblem332` (weakest sufficient condition). Axiomatizes Prikry's theorem ($\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic), density inheritance, and the harmonic thickness conjecture. Proves `diffSet_symm` ($D(A) = -D(A)$) and `zero_mem_diffSet` ($0 \\in D(A)$ for infinite $A$).",
+    "text": "A 154-line formalization of Erdős Problem #332 studying the difference set $D(A) = \\{d \\in \\mathbb{Z} : a_1 - a_2 = d \\text{ for infinitely many pairs}\\}$ and the conditions forcing it to be syndetic (have bounded gaps). Defines 6 predicates: `diffSet` (infinite-fibre differences), `HasBoundedGaps` (syndeticity), `countingFn` ($A(N) = |A \\cap [1,N]|$), `HasPositiveUpperDensity` and `HasPositiveLowerDensity` (density via $\\mathbb{Q}$ ratios), and `ErdosProblem332` (weakest sufficient condition). Axiomatizes Prikry's theorem ($\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic), density inheritance, and the harmonic thickness conjecture. Proves 7 theorems including symmetry, zero membership, monotonicity, finite emptiness, nonemptiness for infinite sets, density hierarchy, and bounded gaps from lower density.",
     "proofStrategy": "We formalize $D(A)$ as the set of differences with infinite fibre, bounded gaps (syndeticity) via interval covering with parameter $M$, positive upper/lower density via counting functions over $\\mathbb{Q}$, and axiomatize Prikry's theorem and related structural results (density inheritance, symmetry, zero membership). The main problem is stated as a characterization question about optimal sufficient conditions.",
     "keyInsights": [
       "**$D(A)$ captures persistent differences**: Unlike the ordinary difference set $A - A$, $D(A)$ requires each difference to have infinitely many witness pairs — a much stronger structural property that filters out 'accidental' differences",
@@ -120,18 +125,26 @@
       "mathContext": "Axioms: Prikry's theorem $\\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$; density inheritance. Proved: $D(A) = -D(A)$, $0 \\in D(A)$ for infinite $A$."
     },
     {
+      "id": "structural-properties",
+      "title": "Structural Properties",
+      "startLine": 99,
+      "endLine": 132,
+      "summary": "Five proved theorems: monotonicity ($A \\subseteq B \\Rightarrow D(A) \\subseteq D(B)$), empty difference set for finite sets, nonemptiness for infinite sets, positive lower density implies positive upper density, and bounded gaps from lower density (combining density implication with Prikry's theorem).",
+      "mathContext": "Proved: $D$ is monotone, $D(A) = \\emptyset$ for finite $A$, $D(A) \\neq \\emptyset$ for infinite $A$, $\\underline{d}(A) > 0 \\Rightarrow \\overline{d}(A) > 0$, $\\underline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$."
+    },
+    {
       "id": "main-problem",
       "title": "The Main Open Problem",
-      "startLine": 99,
-      "endLine": 109,
+      "startLine": 134,
+      "endLine": 144,
       "summary": "Erdős Problem 332: characterize the weakest property $P$ such that $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Positive upper density is the best known sufficient condition.",
       "mathContext": "Find weakest $P$: $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Known: $\\overline{d}(A) > 0$ suffices."
     },
     {
       "id": "related-questions",
       "title": "Related Questions",
-      "startLine": 111,
-      "endLine": 118,
+      "startLine": 146,
+      "endLine": 154,
       "summary": "Does positive density imply $\\sum_{d \\in D(A)} 1/d = \\infty$? This would show $D(A)$ has 'harmonic thickness' beyond mere syndeticity.",
       "mathContext": "Open: $\\overline{d}(A) > 0 \\Rightarrow \\sum_{d \\in D(A)} 1/|d| = \\infty$? (harmonic thickness conjecture)"
     }
@@ -158,6 +171,36 @@
       "type": "original",
       "description": "0 ∈ D(A) for any infinite A: every element pairs with itself, giving infinitely many witness pairs",
       "leanType": "(A : Set ℕ) → Set.Infinite A → (0 : ℤ) ∈ diffSet A"
+    },
+    {
+      "name": "diffSet_mono",
+      "type": "original",
+      "description": "Monotonicity: A ⊆ B → D(A) ⊆ D(B), proved via subset transfer on infinite fibres",
+      "leanType": "(A B : Set ℕ) → A ⊆ B → diffSet A ⊆ diffSet B"
+    },
+    {
+      "name": "diffSet_finite_eq_empty",
+      "type": "original",
+      "description": "Finite sets have empty difference set: D(A) = ∅ when A is finite, since A × A is finite",
+      "leanType": "(A : Set ℕ) → A.Finite → diffSet A = ∅"
+    },
+    {
+      "name": "diffSet_nonempty_of_infinite",
+      "type": "original",
+      "description": "D(A) is nonempty for infinite A (contains zero), corollary of zero_mem_diffSet",
+      "leanType": "(A : Set ℕ) → Set.Infinite A → (diffSet A).Nonempty"
+    },
+    {
+      "name": "lower_density_implies_upper",
+      "type": "original",
+      "description": "Positive lower density implies positive upper density: liminf > 0 → limsup > 0",
+      "leanType": "(A : Set ℕ) → HasPositiveLowerDensity A → HasPositiveUpperDensity A"
+    },
+    {
+      "name": "positive_lower_density_bounded_gaps",
+      "type": "original",
+      "description": "Lower density suffices for bounded gaps: combines density implication with Prikry's theorem",
+      "leanType": "(A : Set ℕ) → HasPositiveLowerDensity A → HasBoundedGaps (diffSet A)"
     }
   ],
   "crossReferences": [
@@ -209,9 +252,9 @@
       "Set"
     ],
     "namespace": "",
-    "lineCount": 118,
+    "lineCount": 154,
     "axiomCount": 3,
-    "theoremCount": 2,
+    "theoremCount": 7,
     "definitionCount": 6,
     "mainTheorems": [
       {

--- a/src/data/research/problems/erdos-332.json
+++ b/src/data/research/problems/erdos-332.json
@@ -29,13 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ASSESSED: 3A all deep/appropriate. 2T, 0S.",
+    "progressSummary": "PROGRESS: 5 new theorems proved (diffSet_mono, diffSet_finite_eq_empty, diffSet_nonempty_of_infinite, lower_density_implies_upper, positive_lower_density_bounded_gaps). 7T total, 3A (all deep), 0S.",
     "builtItems": [
-      "Assessment: all 3A appropriate and deep"
+      "Assessment: all 3A appropriate and deep",
+      "Proved diffSet_mono in Erdos332Problem.lean:102",
+      "Proved diffSet_finite_eq_empty in Erdos332Problem.lean:110",
+      "Proved diffSet_nonempty_of_infinite in Erdos332Problem.lean:117",
+      "Proved lower_density_implies_upper in Erdos332Problem.lean:122",
+      "Proved positive_lower_density_bounded_gaps in Erdos332Problem.lean:130"
     ],
     "insights": [
       "3 axioms all deep: positive_density_bounded_gaps (Furstenberg), positive_density_diffset_dense (additive combinatorics), diffSet_harmonic_diverges. None provable from Mathlib.",
-      "2 theorems proved, 0 sorries. File is clean but minimal."
+      "2 theorems proved, 0 sorries. File is clean but minimal.",
+      "Proved diffSet_mono: monotonicity A ⊆ B → D(A) ⊆ D(B) via subset transfer on infinite fibres",
+      "Proved diffSet_finite_eq_empty: D(A) = ∅ for finite A using Set.Finite.prod bound",
+      "Proved lower_density_implies_upper: liminf > 0 → limsup > 0, connects density definitions",
+      "Proved positive_lower_density_bounded_gaps: lower density suffices for bounded gaps (combines with Prikry axiom)",
+      "D(A) characterization is now sharp: ∅ iff A finite, nonempty iff A infinite, syndetic if density positive"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -62,8 +72,8 @@
     {
       "path": "Proofs/Erdos332Problem.lean",
       "filename": "Erdos332Problem.lean",
-      "lineCount": 119,
-      "theoremCount": 2,
+      "lineCount": 154,
+      "theoremCount": 7,
       "axiomCount": 3,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- Prove 5 new theorems for Erdős Problem #332 (difference sets and bounded gaps)
- Strengthen formalization from 2 to 7 proved theorems, 0 sorries
- 3 axioms remain (all deep: Prikry's theorem, density inheritance, harmonic divergence)

## New Theorems
- `diffSet_mono`: Monotonicity — A ⊆ B → D(A) ⊆ D(B)
- `diffSet_finite_eq_empty`: D(A) = ∅ for finite A (no infinite fibres among finite pairs)
- `diffSet_nonempty_of_infinite`: D(A) nonempty for infinite A (corollary of zero_mem_diffSet)
- `lower_density_implies_upper`: Positive lower density → positive upper density
- `positive_lower_density_bounded_gaps`: Lower density suffices for bounded gaps (combines density implication with Prikry's theorem)

## Mathematical Significance
The formalization now captures the complete structural hierarchy of D(A): empty for finite sets, nonempty (containing 0) for infinite sets, monotone in A, and syndetic when A has positive density (upper or lower). The density chain is now fully connected.

## Status
**Outcome**: completed
**Next Steps**: Further structural properties (translation invariance, union bounds) could be added in future sessions.

🤖 Generated by researcher-2