### PR TITLE
Fix: inverse-galois-oq-01 axiomCount 0→1

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -25,7 +25,7 @@
     ],
     "badge": "formalized",
     "sorries": 1,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields, fixed fields)",
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",


### PR DESCRIPTION
## Summary
- **axiomCount**: 0→1 (InverseGaloisA5.lean is an additionalFile with 1 axiom: `three_dvd_gal_card`)
- Sorry count (1) verified correct — open IGP conjecture

## Test plan
- [x] Verified axiom count across all files (main + additional)
- [x] Verified sorry count matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)