### PR TITLE
Enrich Rising Factorial Identity

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-oq04-header",
+    "proofId": "arithmetic-series-oq-02-oq-04",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Module Header and Imports",
+    "content": "This file imports the parent module ArithmeticSeriesOQ02, which defines the simplicial number function $S_k(n) = \\binom{n+k}{k}$ and related identities (hockey stick, closed forms). It opens Finset and BigOperators to use finite product notation $\\prod_{i \\in \\mathrm{range}\\,k}$, and the parent namespace to access `simplicial` directly.",
+    "mathContext": "The simplicial number $S_k(n) = \\binom{n+k}{k}$ counts the number of $k$-element multisets drawn from $\\{1, \\ldots, n+1\\}$, or equivalently the number of ways to place $n$ indistinguishable balls into $k+1$ distinguishable bins.",
+    "significance": "context",
+    "relatedConcepts": ["simplicial numbers", "binomial coefficients", "multiset coefficients"],
+    "prerequisites": ["Nat.choose", "Finset.prod", "BigOperators notation"]
+  },
+  {
+    "id": "ann-oq04-main-identity",
+    "proofId": "arithmetic-series-oq-02-oq-04",
+    "range": { "startLine": 34, "endLine": 44 },
+    "type": "technique",
+    "title": "Core Rising Factorial Identity",
+    "content": "The central theorem: $\\binom{n+k}{k} \\cdot k! = (n+1)^{(k)}$, where $(n+1)^{(k)}$ is the ascending factorial. The proof unfolds the `simplicial` definition to expose `Nat.choose`, applies Mathlib's `ascFactorial_eq_factorial_mul_choose` which gives $\\mathrm{ascFactorial}(n+1, k) = k! \\cdot \\binom{n+k}{k}$, then uses commutativity of multiplication to match the goal. This three-step proof demonstrates the power of leveraging Mathlib's existing library.",
+    "mathContext": "$\\binom{n+k}{k} \\cdot k! = (n+1)^{(k)} = (n+1)(n+2)\\cdots(n+k)$. This is the Pochhammer symbol $(n+1)_k$ in the rising factorial convention. The identity says: to go from unordered selections (binomial coefficient) to ordered selections (rising factorial), multiply by the number of orderings ($k!$).",
+    "significance": "key",
+    "relatedConcepts": ["Pochhammer symbol", "ascending factorial", "combinatorial interpretation of binomial coefficients"],
+    "prerequisites": ["Nat.ascFactorial", "Nat.ascFactorial_eq_factorial_mul_choose", "mul_comm"]
+  },
+  {
+    "id": "ann-oq04-product-formula",
+    "proofId": "arithmetic-series-oq-02-oq-04",
+    "range": { "startLine": 50, "endLine": 58 },
+    "type": "technique",
+    "title": "Ascending Factorial as Explicit Product",
+    "content": "Proves the ascending factorial equals the explicit finite product: $\\mathrm{ascFactorial}(n, k) = \\prod_{i=0}^{k-1}(n+i)$. The proof proceeds by induction on $k$. The base case ($k=0$) gives the empty product equal to 1. The inductive step uses `prod_range_succ` to peel off the last factor, then applies the inductive hypothesis and commutativity. This bridges Lean's recursive definition of `ascFactorial` with the more computational product representation.",
+    "mathContext": "$n^{(k)} = \\prod_{i=0}^{k-1}(n+i) = n(n+1)(n+2)\\cdots(n+k-1)$. The recursive definition is $n^{(0)} = 1$ and $n^{(k+1)} = (n+k) \\cdot n^{(k)}$, which unfolds to the product. The induction follows the recurrence exactly.",
+    "significance": "key",
+    "relatedConcepts": ["finite products", "induction on product length", "Finset.prod_range_succ"],
+    "prerequisites": ["Finset.prod_range_succ", "Finset.prod_range_zero", "mathematical induction"]
+  },
+  {
+    "id": "ann-oq04-composed-product",
+    "proofId": "arithmetic-series-oq-02-oq-04",
+    "range": { "startLine": 60, "endLine": 64 },
+    "type": "insight",
+    "title": "Composed Product Formula for Simplicial Numbers",
+    "content": "Combines the main identity with the explicit product to get $S_k(n) \\cdot k! = \\prod_{i=0}^{k-1}(n+1+i)$. This is a two-step rewrite: first apply `simplicial_factorial` to get the ascending factorial, then apply `ascFactorial_eq_prod` to expand it. The result makes the consecutive integer product $(n+1)(n+2)\\cdots(n+k)$ fully explicit as a Finset product, which is the most computational form of the identity.",
+    "mathContext": "$S_k(n) \\cdot k! = \\prod_{i=0}^{k-1}(n+1+i) = (n+1)(n+2)\\cdots(n+k)$. This explicit product form is useful for evaluation and for connecting to the full factorial identity.",
+    "significance": "supporting",
+    "relatedConcepts": ["theorem composition", "explicit evaluation", "consecutive integer products"],
+    "prerequisites": ["simplicial_factorial", "ascFactorial_eq_prod"]
+  },
+  {
+    "id": "ann-oq04-full-factorial",
+    "proofId": "arithmetic-series-oq-02-oq-04",
+    "range": { "startLine": 70, "endLine": 85 },
+    "type": "technique",
+    "title": "Full Factorial Expansion and Divisibility",
+    "content": "Two structural results. First, $S_k(n) \\cdot k! \\cdot n! = (n+k)!$, which decomposes $(n+k)!$ into three factors with clear combinatorial meaning. The proof uses `Nat.choose_mul_factorial_mul_factorial`, which states $\\binom{n+k}{k} \\cdot k! \\cdot (n+k-k)! = (n+k)!$, simplified with $n+k-k = n$. Second, the divisibility result $k! \\mid (n+1)^{(k)}$: since $\\binom{n+k}{k}$ is a natural number, $k!$ must divide the ascending factorial. The proof constructs the explicit witness `simplicial k n`.",
+    "mathContext": "$\\binom{n+k}{k} \\cdot k! \\cdot n! = (n+k)!$ gives the complete factorial decomposition. Equivalently, $\\frac{(n+k)!}{k! \\cdot n!} = \\binom{n+k}{k}$. The divisibility $k! \\mid (n+1)^{(k)}$ is the core integrality result: any product of $k$ consecutive positive integers is divisible by $k!$. This is the combinatorial proof — the quotient counts something (the number of $k$-element subsets).",
+    "significance": "key",
+    "relatedConcepts": ["integrality of binomial coefficients", "divisibility by factorial", "combinatorial proof of divisibility", "Nat.choose_mul_factorial_mul_factorial"],
+    "prerequisites": ["Nat.choose_mul_factorial_mul_factorial", "Dvd", "simplicial_factorial"]
+  },
+  {
+    "id": "ann-oq04-specializations",
+    "proofId": "arithmetic-series-oq-02-oq-04",
+    "range": { "startLine": 91, "endLine": 108 },
+    "type": "concept",
+    "title": "Low-Dimensional Specializations (k = 1, 2, 3)",
+    "content": "Three concrete instantiations of the general identity. For $k=1$: $S_1(n) = n+1$ (natural numbers). For $k=2$: $S_2(n) \\cdot 2 = (n+1)(n+2)$ recovers the triangular number formula $T(n) = \\frac{(n+1)(n+2)}{2}$. For $k=3$: $S_3(n) \\cdot 6 = (n+1)(n+2)(n+3)$ recovers the tetrahedral number formula. Each proof uses `simplicial_product` then simplifies the finite product with `prod_range_succ` and `ring`.",
+    "mathContext": "$k=1$: $S_1(n) = n+1$. $k=2$: $T_n = \\frac{n(n+1)}{2}$ so $T_n \\cdot 2 = n(n+1)$ (shifted by 1). $k=3$: tetrahedral numbers $\\mathrm{Te}_n = \\frac{n(n+1)(n+2)}{6}$. These are the figurate numbers — simplicial numbers in dimensions 1, 2, and 3.",
+    "significance": "supporting",
+    "relatedConcepts": ["triangular numbers", "tetrahedral numbers", "figurate numbers", "simplicial complexes"],
+    "prerequisites": ["simplicial_product", "Finset.prod_range_succ", "ring tactic"]
+  },
+  {
+    "id": "ann-oq04-verification",
+    "proofId": "arithmetic-series-oq-02-oq-04",
+    "range": { "startLine": 114, "endLine": 121 },
+    "type": "technique",
+    "title": "Concrete Numerical Verification",
+    "content": "Three numerical checks using `native_decide`: $S_4(3) \\cdot 24 = 840$ (pentatope number $\\binom{7}{4} = 35$), $S_5(2) \\cdot 120 = 2520$ ($\\binom{7}{5} = 21$), and the product form $\\prod_{i=0}^{3}(4+i) = 840$. The `native_decide` tactic compiles the computation to native code for efficient evaluation, serving as a concrete sanity check that the abstract theorems produce correct numerical results.",
+    "mathContext": "$\\binom{7}{4} \\cdot 4! = 35 \\cdot 24 = 840 = 4 \\cdot 5 \\cdot 6 \\cdot 7$. $\\binom{7}{5} \\cdot 5! = 21 \\cdot 120 = 2520 = 3 \\cdot 4 \\cdot 5 \\cdot 6 \\cdot 7$. Both are products of consecutive integers, confirming the general identity.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide", "computational verification", "pentatope numbers"],
+    "prerequisites": ["native_decide tactic", "Decidable instances for Nat arithmetic"]
+  },
+  {
+    "id": "ann-oq04-summary",
+    "proofId": "arithmetic-series-oq-02-oq-04",
+    "range": { "startLine": 123, "endLine": 158 },
+    "type": "insight",
+    "title": "Summary: Compressed Rising Factorials",
+    "content": "The file's key insight: simplicial numbers (binomial coefficients) are 'compressed' rising factorials. The binomial coefficient $\\binom{n+k}{k}$ counts unordered selections; multiplying by $k!$ recovers the ordered count — the rising factorial $(n+1)(n+2)\\cdots(n+k)$. This is the deep combinatorial reason why $\\binom{n+k}{k}$ is always an integer despite being defined as a ratio of factorials: the rising factorial (a product of consecutive integers) is always divisible by $k!$ because the quotient counts a combinatorial object.",
+    "mathContext": "$\\binom{n+k}{k} = \\frac{(n+1)^{(k)}}{k!} = \\frac{(n+1)(n+2)\\cdots(n+k)}{k!} \\in \\mathbb{N}$. The integrality is a consequence of the combinatorial interpretation, not a numerical coincidence.",
+    "significance": "key",
+    "relatedConcepts": ["integrality of binomial coefficients", "unordered vs ordered selections", "combinatorial proof"],
+    "prerequisites": ["simplicial_factorial", "factorial_dvd_ascFactorial"]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -53,7 +53,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The ascending factorial (Pochhammer symbol) $n^{(k)} = n(n+1)\\cdots(n+k-1)$ was systematically studied by Leo August Pochhammer in 1870, though the notation and concept appeared earlier in the work of Euler and Vandermonde. The identity $\\binom{n+k}{k} \\cdot k! = (n+1)^{(k)}$ is one of the most fundamental relationships in combinatorics, connecting the unordered world of binomial coefficients to the ordered world of permutations. It explains why $\\binom{n}{k}$ is always an integer: the product of any $k$ consecutive integers is always divisible by $k!$.",
+    "historicalContext": "The ascending factorial (Pochhammer symbol) $n^{(k)} = n(n+1)\\cdots(n+k-1)$ was systematically studied by Leo August Pochhammer in his 1870 paper 'Ueber hypergeometrische Reihen n-ter Ordnung' in Crelle's journal, though the concept appeared earlier in the work of Euler on hypergeometric series and Vandermonde's 1772 memoir on determinants. The notation remains notoriously inconsistent: combinatorialists write $n^{\\overline{k}}$ for the rising factorial, while the Pochhammer symbol $(a)_k$ denotes the rising factorial in the theory of special functions but the falling factorial in some combinatorics texts. The identity $\\binom{n+k}{k} \\cdot k! = (n+1)^{(k)}$ is one of the most fundamental relationships in enumerative combinatorics, bridging the unordered world of binomial coefficients to the ordered world of permutations. It explains why $\\binom{n}{k}$ is always an integer: the product of any $k$ consecutive positive integers is always divisible by $k!$, because the quotient counts a combinatorial object — the number of $k$-element subsets. This integrality principle was known to Pascal and appears implicitly in his 1654 'Traité du triangle arithmétique'.",
     "problemStatement": "**Rising Factorial Identity**: For all natural numbers $k$ and $n$:\n\n$$\\binom{n+k}{k} \\cdot k! = (n+1)(n+2)\\cdots(n+k)$$\n\nEquivalently, $S_k(n) \\cdot k! = n^{\\overline{k+1}}_1$ where $S_k(n)$ is the $k$-th simplicial number and $n^{\\overline{k}}$ is the rising factorial.",
     "text": "Proves that the simplicial number S_k(n) = C(n+k, k) times k! equals the ascending factorial (n+1)(n+2)...(n+k). Derives the explicit product formula, full factorial identity S_k(n) * k! * n! = (n+k)!, and divisibility corollary.",
     "proofStrategy": "**Direct from Mathlib** for the main identity, using `Nat.ascFactorial_eq_factorial_mul_choose` with commutativity. The product formula is proved by induction on $k$ using the ascending factorial recurrence. The full factorial identity follows from `Nat.choose_mul_factorial_mul_factorial`.",
@@ -61,7 +61,8 @@
       "The main identity simplicial_factorial is essentially a one-liner: Mathlib's ascFactorial_eq_factorial_mul_choose gives ascFactorial(n+1, k) = k! * C(n+k, k), and commutativity yields C(n+k, k) * k! = ascFactorial(n+1, k).",
       "The ascending factorial recurrence ascFactorial(n, k+1) = (n+k) * ascFactorial(n, k) gives an elegant induction for the product formula, with mul_comm bridging the definitional and goal forms.",
       "The divisibility theorem factorial_dvd_ascFactorial(n, k) : k! | ascFactorial(n+1, k) follows immediately from the existence of simplicial numbers -- this explains why products of k consecutive integers are always divisible by k!.",
-      "The full factorial identity S_k(n) * k! * n! = (n+k)! decomposes (n+k)! into three natural factors: the combinatorial count, the ordering count, and the complement count."
+      "The full factorial identity S_k(n) * k! * n! = (n+k)! decomposes (n+k)! into three natural factors: the combinatorial count, the ordering count, and the complement count.",
+      "The low-dimensional specializations (k=1,2,3) recover the classical figurate number formulas: natural numbers, triangular numbers T(n) = n(n+1)/2, and tetrahedral numbers Te(n) = n(n+1)(n+2)/6, showing that these familiar sequences are all instances of the single identity S_k(n) * k! = (n+1)^(k)."
     ],
     "prerequisites": [
       "Binomial coefficients",
@@ -140,6 +141,16 @@
       "targetId": "binomial-theorem",
       "relationship": "related",
       "description": "The binomial theorem uses C(n,k) coefficients -- the rising factorial identity reveals why these coefficients are always integers"
+    },
+    {
+      "targetId": "erdos-728-factorial-divisibility",
+      "relationship": "related",
+      "description": "Factorial divisibility properties -- this file's k! | ascFactorial(n+1,k) is a specific instance of divisibility of products of consecutive integers by factorials"
+    },
+    {
+      "targetId": "stirling-formula",
+      "relationship": "related",
+      "description": "Stirling's approximation for n! -- the full factorial identity S_k(n)*k!*n! = (n+k)! connects simplicial numbers to factorial growth"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary
- Added 8 comprehensive annotations with mathContext (LaTeX), significance ratings, relatedConcepts, and prerequisites covering all 5 parts of the proof
- Expanded historicalContext with Pochhammer's 1870 paper, notation conventions (rising vs falling), and Pascal's 1654 integrality insight
- Added 5th keyInsight connecting figurate numbers (triangular, tetrahedral) to the general identity
- Added cross-references to erdos-728-factorial-divisibility and stirling-formula

Enrichment pass for arithmetic-series-oq-02-oq-04 (quality: 43 → improved).