### PR TITLE
Fix: correct 10 status-overclaim entries (verified → formalized/axiomatized)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Archimedes (c. 250 BCE), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Archimedes",
     "date": "-250",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "geometry",
       "analysis",
@@ -18,8 +18,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Core π bounds derived from Mathlib's pi_gt_d4 and pi_lt_d4.",
+    "assumptions": "1 sorry(s) remain in the formalization.",
     "lineCount": 102,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cycle_lemma",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,8 +18,8 @@
       "finset",
       "research"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",
@@ -66,7 +66,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 130,
-    "assumptions": "0 axioms, 0 sorries. Fully machine-checked. Two auxiliary theorems are trivial placeholders (rfl); the substantive content is ballot_discrete_ivt.",
+    "assumptions": "2 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid; formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euclid%27s_lemma",
     "date": "~300 BCE",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -15,8 +15,8 @@
       "algorithms",
       "research"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Int.mul_ediv_cancel'",
@@ -33,7 +33,7 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 182,
-    "assumptions": "0 axioms, 0 sorries . Fully machine-checked.",
+    "assumptions": "1 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,8 +20,8 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 5,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_comp_add_right",
@@ -72,7 +72,7 @@
     "dateAdded": "2026-02-25",
     "axiomCount": 1,
     "lineCount": 390,
-    "assumptions": "No axiom declarations, 0 sorries. The reference to buffon_noodle_smooth_eq appears only in a block comment quoting the parent file. Fully verified.",
+    "assumptions": "1 axiom(s) and 5 sorry(s) remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,8 +17,8 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",
@@ -78,7 +78,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 270,
-    "assumptions": "0 axioms, 0 sorries . Uses Classical.propDecidable as a local instance for decidability of propositions. Fully machine-checked.",
+    "assumptions": "1 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,10 +7,10 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "tags": [
       "combinatorics",
       "permutations",
@@ -68,7 +68,7 @@
     "dateAdded": "2026-02-25",
     "axiomCount": 0,
     "lineCount": 357,
-    "assumptions": "0 axioms, 0 sorries . Core cardinality result uses Mathlib's card_derangements_eq_numDerangements. Fully machine-checked.",
+    "assumptions": "1 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Euclid-style argument)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions#Special_cases",
     "date": "classical",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/DirichletsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -18,8 +18,8 @@
       "elementary",
       "research"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Nat.exists_prime_and_dvd",
@@ -45,7 +45,8 @@
     "dateAdded": "2026-03-24",
     "axiomCount": 0,
     "lineCount": 101,
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "assumptions": "1 sorry(s) remain in the formalization."
   },
   "overview": {
     "historicalContext": "Dirichlet's theorem (1837) states that every arithmetic progression a, a+q, a+2q, ... with gcd(a,q) = 1 contains infinitely many primes. The general proof requires analytic number theory (L-functions, characters). However, certain special cases — including primes ≡ 3 (mod 4) — admit elementary proofs using Euclid-style constructions.\n\nThe key insight: if n ≡ 3 (mod 4) and n > 1, then n must have at least one prime factor ≡ 3 (mod 4). This is because any product of primes ≡ 1 (mod 4) is itself ≡ 1 (mod 4), so a number ≡ 3 (mod 4) cannot be composed entirely of such primes.",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",
@@ -65,7 +65,7 @@
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
     "lineCount": 247,
-    "assumptions": "0 axioms, 0 sorries . Fully machine-checked.",
+    "assumptions": "1 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -15,8 +15,8 @@
       "convex-analysis",
       "open-question"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-03-06",
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Fully machine-checked.",
+    "assumptions": "3 sorry(s) remain in the formalization.",
     "proofRepoPath": "Proofs/SchauderFixedPointOQ01.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 315

--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical / Krasner / Ostrowski (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Ultra/Basic.html",
     "date": "1913 / 1946",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "geometry",
       "analysis",
@@ -18,7 +18,7 @@
       "topology"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ03.lean",
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 255,
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
-    "assumptions": "No axiom declarations, 0 sorries. Fully verified."
+    "assumptions": "1 axiom declaration(s) remain."
   },
   "overview": {
     "historicalContext": "The study of non-Archimedean analysis began with Kurt Hensel's invention of p-adic numbers in 1897, motivated by analogies between number fields and function fields. Alexander Ostrowski (1916) classified all absolute values on the rationals: they are either the usual absolute value, a p-adic absolute value, or the trivial absolute value. This classification theorem shows that the ultrametric inequality is not an exotic curiosity but governs half of all possible notions of 'distance' on the rationals.\n\nThe ultrametric inequality d(x,z) ≤ max(d(x,y), d(y,z)) — strictly stronger than the usual d(x,z) ≤ d(x,y) + d(y,z) — was studied systematically by Marc Krasner (1940s) who developed the theory of ultrametric spaces and their striking topological properties: every point inside a ball is its center, balls are clopen (both open and closed), and distinct balls of equal radius are disjoint.\n\nThese 'strange' properties have profound consequences in number theory: the p-adic integers form a compact open subring (impossible over ℝ), p-adic analysis has no Archimedean property (|n|_p ≤ 1 for all integers), and Hensel's lemma provides a p-adic Newton's method with guaranteed convergence. Today, p-adic geometry underlies the Langlands program, perfectoid spaces (Scholze, Fields Medal 2018), and modern arithmetic geometry.",


### PR DESCRIPTION
## Fix

Correct 10 gallery entries falsely claiming `status: "verified"` while their Lean source contains sorry(s) or axiom declarations.

## Evidence

**Before**: 10 entries had `status: "verified"` and `sorries: 0` in meta.json, but their Lean files contained unproven sorry/axiom declarations.

**After**: 
- 8 entries corrected to `status: "formalized"`, `badge: "wip"` with accurate sorry counts
- 2 entries corrected to `status: "axiomatized"`, `badge: "axiom"` (buffons-needle-oq-01-oq-01, triangle-inequality-oq-03)

| Proof | Issue | New Status |
|-------|-------|------------|
| area-of-circle-oq-03-oq-02 | 1 sorry | formalized |
| ballot-problem-oq-01-oq-01 | 2 sorries | formalized |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | 1 sorry | formalized |
| buffons-needle-oq-01-oq-01 | 5 sorries + 1 axiom | axiomatized |
| cayley-hamilton-minpoly-oq-05-oq-01 | 1 sorry | formalized |
| derangements-oq-02 | 1 sorry | formalized |
| dirichlets-theorem-oq-02 | 1 sorry | formalized |
| erdos-1006-oq-02-oq-03 | 1 sorry | formalized |
| schauder-fixed-point-oq-01 | 3 sorries | formalized |
| triangle-inequality-oq-03 | 1 axiom | axiomatized |

---
Automated fix by lean-mechanic agent.