### PR TITLE
Fix: yang-mills axiomCount 0→16 (1 explicit + 15 structure-encoded)

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -57,8 +57,8 @@
     ],
     "dateAdded": "2025-12-29",
     "millenniumProblem": "yang-mills",
-    "axiomCount": 0,
-    "assumptions": "1 explicit axiom declaration: gaugeTransform (gauge-transformed field). ~15 structure-encoded assumptions in: CompactSimpleGaugeGroup (compact, connected, simple), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy), YangMillsAction (coupling_pos, action_nonneg), FieldStrength (antisymmetric), Instanton (action_formula, bogomolny_bound), EnergyMomentumTensor (symmetric, energy_density_nonneg, conservation). The Yang-Mills 4D mass gap conjecture remains OPEN.",
+    "axiomCount": 16,
+    "assumptions": "1 explicit axiom declaration: gaugeTransform (gauge-transformed field). 15 structure-encoded assumptions in: CompactSimpleGaugeGroup (compact, connected, simple), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy), YangMillsAction (coupling_pos, action_nonneg), FieldStrength (antisymmetric), Instanton (action_formula), EnergyMomentumTensor (symmetric, energy_density_nonneg), QuantumYangMillsTheory (nontrivial). The Yang-Mills 4D mass gap conjecture remains OPEN.",
     "lineCount": 48,
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Summary

- Fixes `axiomCount: 0` → `axiomCount: 16` in yang-mills meta.json
- The formalization has 1 explicit `axiom` declaration (`gaugeTransform`) and 15 structure-encoded assumptions
- Fixes `assumptions` text: removes stale references to `bogomolny_bound` and `conservation` (not structure fields), adds `QuantumYangMillsTheory (nontrivial)`

## Evidence

**meta.json claimed**: `axiomCount: 0`
**Lean source shows**: 1 explicit axiom + 15 structure-encoded = 16 total

Counted from Core.lean, Classical.lean, and Quantum.lean:
- `CompactSimpleGaugeGroup`: compact, connected, simple (3)
- `GaugeLieAlgebra`: bracket_anticomm, bracket_jacobi (2)
- `FieldStrength`: antisymmetric (1)
- `YangMillsAction`: coupling_pos, action_nonneg (2)
- `Instanton`: action_formula (1)
- `EnergyMomentumTensor`: symmetric, energy_density_nonneg (2)
- `WightmanQFT`: vacuum_normalized, energy_bounded_below, vacuum_lowest_energy (3)
- `QuantumYangMillsTheory`: nontrivial (1)
- `axiom gaugeTransform` (1 explicit)

Consistent with the wrapper file's own "Axiom Count: 16" comment.

## Additional checks

- Sorry count: meta.json says 58, Lean source has 58 actual sorries (1 grep match is in a comment) ✓
- Status: `axiomatized` ✓ (Millennium Prize problem)
- Badge: `axiom` ✓

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)