### PR TITLE
Fix: erdos-404 axiomCount 2→3 (lin_bound is an axiom)

### DIFF
--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -58,7 +58,7 @@
       "Two proved examples by native_decide",
       "erdos_404_summary: proved conjunction of Lin's bounds"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "prerequisites": [
       "p-adic valuation (padicValNat) and basic properties",
       "Factorials and divisibility in number theory",
@@ -67,7 +67,7 @@
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
     "lineCount": 120,
-    "assumptions": "3 axioms: lin_bound_meaning (Lin 1976), legendre_formula, padic_val_factorial_asymp. lin_bound proved from lin_bound_meaning via csSup_le."
+    "assumptions": "3 axioms: lin_bound (f(2,2) ≤ 254), lin_bound_meaning (2^255 never divides such sums; Lin 1976), padic_val_factorial_asymp (v_p(n!)/n → 1/(p-1)). legendre_formula is proved from Mathlib's padicValNat_factorial."
   },
   "overview": {
     "historicalContext": "**Prime Power Divisibility of Factorial Sums**\n\nThe interaction between prime divisibility and factorials has deep roots: Legendre's formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ (1808) gives the exact $p$-adic valuation of $n!$, and Kummer's theorem (1852) extends this to binomial coefficients. Erdős and Graham posed Problem #404 in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*: for integers $a \\geq 1$ and primes $p$, define $f(a,p) = \\sup\\{k : p^k \\mid a_1! + \\cdots + a_n!$ for some $a = a_1 < \\cdots < a_n\\}$. Is $f(a,p)$ always finite?\n\n**Chronological Development:**\n- **1808 (Legendre):** Formula for $v_p(n!)$ — the foundational tool\n- **1976 (Lin):** Proved $f(2,2) \\leq 254$ — the only known concrete upper bound for any $(a,p)$ pair. Lin's argument used careful analysis of carries in $p$-adic addition of factorials\n- **1980 (Erdős–Graham):** Problem 404 posed formally, alongside the related Problem #403 on factorial sums modulo primes\n\nThe problem is surprisingly resistant because factorial sums can have cancellation patterns that concentrate $p$-adic valuation. The gap between the known lower bound $f(2,2) \\geq 3$ (from $2^3 \\mid 2! + 3!$) and Lin's upper bound of 254 illustrates how little is understood about the $p$-adic structure of factorial sums.",
@@ -203,7 +203,7 @@
     ],
     "namespace": "Erdos404",
     "lineCount": 96,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 7
   }


### PR DESCRIPTION
## Summary

- Fixes `axiomCount: 2` → `axiomCount: 3` in erdos-404 meta.json (both `meta` and `leanFile` sections)
- The Lean source has 3 explicit axiom declarations: `lin_bound`, `lin_bound_meaning`, `padic_val_factorial_asymp`
- Fixes `assumptions` text: `legendre_formula` was listed as an axiom but it's a proved theorem; `lin_bound` was described as proved but it's an axiom

## Evidence

**meta.json claimed**: `axiomCount: 2`
**Lean source shows**: 3 axiom declarations

```lean
axiom lin_bound : f 2 2 ≤ 254
axiom lin_bound_meaning : ∀ s : StrictIncSeq 2, ¬(2^255 ∣ factorialSum s)
axiom padic_val_factorial_asymp (p : ℕ) (hp : p.Prime) : ...
```

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)