### PR TITLE
Research: erdos-719 — 8 structural theorems for hypergraph decomposition

### DIFF
--- a/proofs/Proofs/Erdos1009Problem.lean
+++ b/proofs/Proofs/Erdos1009Problem.lean
@@ -183,6 +183,28 @@ axiom turan_extremal :
     ∀ G : SimpleGraph V, ∀ _ : DecidableRel G.Adj,
       (∀ T : Triangle G, False) → numEdges G ≤ turanThreshold (numVertices G)
 
+/-- Edge-disjointness is symmetric. -/
+theorem edgeDisjoint_comm {G : SimpleGraph V} (T₁ T₂ : Triangle G) :
+    edgeDisjoint T₁ T₂ ↔ edgeDisjoint T₂ T₁ := by
+  simp [edgeDisjoint, Finset.inter_comm]
+
+/-- turanThreshold 0 = 0. -/
+@[simp] theorem turanThreshold_zero : turanThreshold 0 = 0 := by
+  simp [turanThreshold]
+
+/-- turanThreshold 1 = 0. -/
+@[simp] theorem turanThreshold_one : turanThreshold 1 = 0 := by
+  simp [turanThreshold]
+
+/-- For n ≥ 2, the Turán threshold is positive. -/
+theorem turanThreshold_pos {n : ℕ} (hn : 2 ≤ n) : 0 < turanThreshold n := by
+  unfold turanThreshold; omega
+
+/-- The Turán threshold is monotone non-decreasing. -/
+theorem turanThreshold_mono {m n : ℕ} (h : m ≤ n) :
+    turanThreshold m ≤ turanThreshold n := by
+  unfold turanThreshold; exact Nat.div_le_div_right (Nat.pow_le_pow_left h 2)
+
 /-- Every graph exceeding Turán bound contains a triangle -/
 theorem exceeds_turan_has_triangle (G : SimpleGraph V) [DecidableRel G.Adj]
     (h : numEdges G > turanThreshold (numVertices G)) :

--- a/proofs/Proofs/Erdos102Problem.lean
+++ b/proofs/Proofs/Erdos102Problem.lean
@@ -67,6 +67,18 @@ theorem collinear₃_perm12 (p q r : ℝ × ℝ) : collinear₃ p q r ↔ collin
 theorem collinear₃_self_left (p q : ℝ × ℝ) : collinear₃ p p q := by
   unfold collinear₃; ring
 
+/-- Collinearity under cyclic permutation of all three arguments. -/
+theorem collinear₃_cycle (p q r : ℝ × ℝ) : collinear₃ p q r ↔ collinear₃ q r p := by
+  rw [collinear₃_perm12, collinear₃_comm]
+
+/-- Any point is collinear with q and itself (degenerate triangle). -/
+theorem collinear₃_self_right (p q : ℝ × ℝ) : collinear₃ p q p := by
+  unfold collinear₃; ring
+
+/-- q is collinear with p and q (degenerate triangle). -/
+theorem collinear₃_self_mid (p q : ℝ × ℝ) : collinear₃ p q q := by
+  unfold collinear₃; ring
+
 /- ## Known Results -/
 
 /-- **Upper Bound**: h_c(n) ≪_c √n. The maximum collinear count from cn²
@@ -114,6 +126,36 @@ theorem connection_101_for_same_c (c : ℝ) (hc : c > 0)
     by_contra hge
     push_neg at hge
     exact absurd (hN₀ P hsize hge) (by omega)⟩
+
+/-- **Proved**: The same-c connection extends to all ε ≥ c.
+    If h_c(n) → ∞, then for any ε ≥ c, configurations with max collinear ≤ 4
+    have < ε·n² rich lines (since c·n² ≤ ε·n²). -/
+theorem connection_101_for_larger_eps (c : ℝ) (hc : c > 0) (ε : ℝ) (hεc : c ≤ ε)
+    (hdiv : ∀ M : ℕ, ∃ N₀ : ℕ, ∀ P : PointConfig,
+      P.points.card ≥ N₀ → (richLineCount P : ℝ) ≥ c * (P.points.card : ℝ) ^ 2 →
+        maxCollinear P ≥ M) :
+    ∃ N₁ : ℕ, ∀ P : PointConfig,
+      P.points.card ≥ N₁ → maxCollinear P ≤ 4 →
+        (richLineCount P : ℝ) < ε * (P.points.card : ℝ) ^ 2 := by
+  obtain ⟨N₁, hN₁⟩ := connection_101_for_same_c c hc hdiv
+  exact ⟨N₁, fun P hsize hmax =>
+    calc (richLineCount P : ℝ) < c * (P.points.card : ℝ) ^ 2 := hN₁ P hsize hmax
+      _ ≤ ε * (P.points.card : ℝ) ^ 2 := by nlinarith [sq_nonneg (P.points.card : ℝ)]⟩
+
+/-- **Key Insight (PROVED)**: The `connection_101` axiom (∀ε conclusion from single-c
+    divergence) is actually derivable from the FULL conjecture (divergence ∀c).
+    For any ε > 0, apply the full conjecture with c' = ε to get the bound.
+    This shows connection_101 is not an independent assumption. -/
+theorem connection_101_from_full_divergence
+    (hdiv_all : ∀ c : ℝ, c > 0 → ∀ M : ℕ, ∃ N₀ : ℕ, ∀ P : PointConfig,
+      P.points.card ≥ N₀ →
+      (richLineCount P : ℝ) ≥ c * (P.points.card : ℝ) ^ 2 →
+        maxCollinear P ≥ M) :
+    ∀ c : ℝ, c > 0 → ∀ ε > 0, ∃ N₁ : ℕ, ∀ P : PointConfig,
+      P.points.card ≥ N₁ → maxCollinear P ≤ 4 →
+        (richLineCount P : ℝ) < ε * (P.points.card : ℝ) ^ 2 := by
+  intro c _ ε hε
+  exact connection_101_for_same_c ε hε (hdiv_all ε hε)
 
 /- ## Observations -/
 

--- a/proofs/Proofs/Erdos1144Problem.lean
+++ b/proofs/Proofs/Erdos1144Problem.lean
@@ -129,6 +129,22 @@ axiom atherfold_upper_bound :
 theorem partialSum_zero (f : ℕ → ℤ) : partialSum f 0 = 0 := by
   simp [partialSum]
 
+/-- The partial sum at 1 is 0 (range 1 = {0}, filtered to ∅). -/
+theorem partialSum_one (f : ℕ → ℤ) : partialSum f 1 = 0 := by
+  simp [partialSum]
+
+/-- The partial sum at 2 equals f(1). -/
+theorem partialSum_two (f : ℕ → ℤ) : partialSum f 2 = f 1 := by
+  simp [partialSum, Finset.range_succ, Finset.filter_insert, Finset.sum_singleton]
+
+/-- Recursion: partialSum f (N+1) = partialSum f N + f N for N ≥ 1. -/
+theorem partialSum_succ (f : ℕ → ℤ) (N : ℕ) (hN : 1 ≤ N) :
+    partialSum f (N + 1) = partialSum f N + f N := by
+  simp only [partialSum, Finset.range_succ, Finset.filter_insert, show N ≥ 1 from hN,
+    ite_true]
+  rw [Finset.sum_insert (by simp [Finset.mem_filter, Finset.mem_range])]
+  ring
+
 /-- NOTE: A previous version stated that Atherfold's bound gives subpolynomial
     growth for ALL Rademacher multiplicative functions. This is FALSE:
     the constant function f ≡ 1 is Rademacher multiplicative (f(p) = 1 for

--- a/proofs/Proofs/Erdos1179Problem.lean
+++ b/proofs/Proofs/Erdos1179Problem.lean
@@ -88,6 +88,21 @@ theorem reprCount_empty_nonzero {G : Type*} [AddCommGroup G] [DecidableEq G]
     (g : G) (hg : g ≠ 0) : reprCount (∅ : Finset G) g = 0 := by
   simp [reprCount, powerset_empty, filter_singleton, sum_empty, hg.symm]
 
+/-- Every element has at most 2^|A| representations (each subset counted ≤ once). -/
+theorem reprCount_le_pow {G : Type*} [AddCommGroup G] [DecidableEq G]
+    (A : Finset G) (g : G) : reprCount A g ≤ 2 ^ A.card := by
+  unfold reprCount
+  calc (A.powerset.filter (fun S => S.sum id = g)).card
+      ≤ A.powerset.card := Finset.card_filter_le _ _
+      _ = 2 ^ A.card := Finset.card_powerset A
+
+/-- The expected representation count is positive for N ≥ 1. -/
+theorem expectedReprCount_pos {k N : ℕ} (hN : 1 ≤ N) :
+    0 < expectedReprCount k N := by
+  unfold expectedReprCount
+  apply div_pos (pow_pos (by norm_num : (0:ℝ) < 2) k)
+  exact_mod_cast Nat.lt_of_lt_pred (by omega : 0 < N)
+
 /- ## Part IV: The Function g_ε(N) -/
 
 -- g_ε(N) is the minimal k such that a random k-subset of any abelian group

--- a/proofs/Proofs/Erdos461Problem.lean
+++ b/proofs/Proofs/Erdos461Problem.lean
@@ -205,3 +205,40 @@ theorem smoothComponent_prime (t p : ℕ) (hp : p.Prime) :
   split <;> rename_i h
   · simp [List.prod_cons]
   · simp
+
+/-- For a prime p ≥ t, the smooth component is 1. -/
+theorem smoothComponent_prime_ge (t p : ℕ) (hp : p.Prime) (hpt : t ≤ p) :
+    smoothComponent t p = 1 := by
+  rw [smoothComponent_prime t p hp, if_neg (by omega)]
+
+/-- If all prime factors of n are < t, then smoothComponent t n = n. -/
+theorem smoothComponent_id_of_smooth (t n : ℕ) (hn : n ≠ 0)
+    (h : ∀ p ∈ n.factors, p < t) : smoothComponent t n = n := by
+  unfold smoothComponent
+  rw [show n.factors.filter (· < t) = n.factors from
+    List.filter_eq_self.mpr (fun x hx => by simpa using h x hx)]
+  exact Nat.prod_factors hn
+
+/-- If n < t (and n > 0), then smoothComponent t n = n
+    (all prime factors of n are ≤ n < t). -/
+theorem smoothComponent_id_of_lt (t n : ℕ) (hn : 0 < n) (hnt : n < t) :
+    smoothComponent t n = n :=
+  smoothComponent_id_of_smooth t n (by omega) fun p hp =>
+    lt_of_le_of_lt (Nat.le_of_dvd hn (Nat.dvd_of_mem_factors hp)) hnt
+
+/-- For t ≥ 1 and any n, there is at least one smooth component value. -/
+theorem smoothDistinctCount_pos (n t : ℕ) (ht : 1 ≤ t) :
+    0 < smoothDistinctCount n t := by
+  unfold smoothDistinctCount
+  exact Finset.card_pos.mpr ((Finset.nonempty_Icc.mpr (by omega)).image _)
+
+/-- For t ≤ 1, all smooth components are 1, so at most 1 distinct value. -/
+theorem smoothDistinctCount_t_le_one (n t : ℕ) (ht : t ≤ 1) :
+    smoothDistinctCount n t ≤ 1 := by
+  unfold smoothDistinctCount
+  calc ((Finset.Icc (n + 1) (n + t)).image (smoothComponent t)).card
+      ≤ ({1} : Finset ℕ).card := Finset.card_le_card (fun x hx => by
+        simp only [Finset.mem_image] at hx
+        obtain ⟨m, _, rfl⟩ := hx
+        simp [smoothComponent_t_le_one m ht])
+      _ = 1 := by simp

--- a/proofs/Proofs/Erdos687Problem.lean
+++ b/proofs/Proofs/Erdos687Problem.lean
@@ -181,6 +181,44 @@ axiom maier_pomerance_conjecture :
   ∀ ε : ℝ, 0 < ε → ∃ C : ℝ, 0 < C ∧ ∀ᶠ (x : ℕ) in atTop,
     (jacobsthalY x : ℝ) ≤ C * (x : ℝ) * Real.log (x : ℝ) ^ (2 + ε)
 
+/- ## Concrete Computations -/
+
+/-- Helper: for x ≤ 1, no prime p satisfies p ≤ x. -/
+private lemma no_prime_le_one (p : ℕ) (hp : p.Prime) (hpx : p ≤ 1) : False := by
+  have := hp.two_le; omega
+
+/-- Y(0) = 0: with no primes ≤ 0, no integer can be covered. -/
+theorem jacobsthalY_zero : jacobsthalY 0 = 0 := by
+  unfold jacobsthalY
+  refine Nat.le_zero.mp (csSup_le (jacobsthalSet_nonempty 0) fun y hy => ?_)
+  by_contra h; push_neg at h
+  obtain ⟨a, ha⟩ := hy
+  obtain ⟨p, hp, hpx, _⟩ := ha 1 le_rfl (by exact_mod_cast (show 1 ≤ y by omega))
+  exact no_prime_le_one p hp (by omega)
+
+/-- Y(1) = 0: with no primes ≤ 1, no integer can be covered. -/
+theorem jacobsthalY_one : jacobsthalY 1 = 0 := by
+  unfold jacobsthalY
+  refine Nat.le_zero.mp (csSup_le (jacobsthalSet_nonempty 1) fun y hy => ?_)
+  by_contra h; push_neg at h
+  obtain ⟨a, ha⟩ := hy
+  obtain ⟨p, hp, hpx, _⟩ := ha 1 le_rfl (by exact_mod_cast (show 1 ≤ y by omega))
+  exact no_prime_le_one p hp hpx
+
+/-- For x ≤ 1, jacobsthalSet x = {0} (no primes means only vacuous covering). -/
+theorem jacobsthalSet_eq_zero_of_le_one {x : ℕ} (hx : x ≤ 1) :
+    jacobsthalSet x = {0} := by
+  ext y; constructor
+  · intro hy
+    simp only [Set.mem_singleton_iff]
+    by_contra h
+    obtain ⟨a, ha⟩ := hy
+    obtain ⟨p, hp, hpx, _⟩ := ha 1 le_rfl (by exact_mod_cast (show 1 ≤ y by omega))
+    exact no_prime_le_one p hp (by omega)
+  · intro hy
+    simp only [Set.mem_singleton_iff] at hy; subst hy
+    exact ⟨fun _ _ _ => 0, fun n h1 h2 => by omega⟩
+
 /- ## Trivial Lower Bound — FALSE (removed)
 
 The original axiom claimed Y(x) ≥ x + 1 for x ≥ 2, based on the argument

--- a/proofs/Proofs/Erdos719Problem.lean
+++ b/proofs/Proofs/Erdos719Problem.lean
@@ -129,6 +129,70 @@ theorem choose_succ_self (r : ℕ) : Nat.choose (r + 1) r = r + 1 := by
   rw [Nat.choose_symm (Nat.le_succ r)]
   simp [Nat.choose]
 
+/-- Edges in a complete clique are subsets of the vertex set. -/
+theorem completeClique_subset {V : Type*} [DecidableEq V] (r : ℕ) (S : Finset V) :
+    ∀ e ∈ completeClique r S, e ⊆ S := by
+  intro e he
+  simp [completeClique, Finset.mem_filter, Finset.mem_powerset] at he
+  exact he.1
+
+/-- Edges in a complete clique have exactly r elements. -/
+theorem completeClique_uniform {V : Type*} [DecidableEq V] (r : ℕ) (S : Finset V) :
+    ∀ e ∈ completeClique r S, e.card = r := by
+  intro e he
+  simp [completeClique, Finset.mem_filter] at he
+  exact he.2
+
+/-- PiecesEdgeDisjoint is symmetric. -/
+theorem piecesEdgeDisjoint_comm {V : Type*} [DecidableEq V]
+    (p₁ p₂ : Finset (Finset V)) :
+    PiecesEdgeDisjoint p₁ p₂ ↔ PiecesEdgeDisjoint p₂ p₁ := by
+  simp only [PiecesEdgeDisjoint, and_comm]
+
+-- ## Clique Cardinality
+
+/-- completeClique r S equals powersetCard r S: the family of all r-element
+    subsets of S. This connects our definition to Mathlib's combinatorial API. -/
+theorem completeClique_eq_powersetCard {V : Type*} [DecidableEq V] (r : ℕ) (S : Finset V) :
+    completeClique r S = S.powersetCard r := by
+  ext e
+  simp [completeClique, Finset.mem_powersetCard, Finset.mem_filter, Finset.mem_powerset]
+
+/-- The number of r-edges in a complete clique on S equals C(|S|, r). -/
+theorem completeClique_card {V : Type*} [DecidableEq V] (r : ℕ) (S : Finset V) :
+    (completeClique r S).card = Nat.choose S.card r := by
+  rw [completeClique_eq_powersetCard, Finset.card_powersetCard]
+
+/-- A complete (r+1)-clique K_{r+1}^r has exactly r+1 hyperedges. -/
+theorem fullClique_edge_count {V : Type*} [DecidableEq V] (r : ℕ) (S : Finset V)
+    (hS : S.card = r + 1) :
+    (completeClique r S).card = r + 1 := by
+  rw [completeClique_card, hS, Nat.choose_succ_self_right]
+
+/-- completeClique is monotone: larger vertex sets yield more r-edges. -/
+theorem completeClique_mono {V : Type*} [DecidableEq V] (r : ℕ) {S T : Finset V} (h : S ⊆ T) :
+    completeClique r S ⊆ completeClique r T := by
+  intro e he
+  rw [completeClique_eq_powersetCard] at he ⊢
+  exact Finset.powersetCard_mono h he
+
+/-- Each piece in a valid decomposition has at most r + 1 edges:
+    single edges contribute 1, full cliques contribute r + 1. -/
+theorem decomp_piece_card_le {V : Type*} [DecidableEq V] [Fintype V] (r : ℕ)
+    (H : RUniformHypergraph V r) (pieces : Finset (Finset (Finset V)))
+    (hdecomp : IsValidDecomp r H pieces)
+    (p : Finset (Finset V)) (hp : p ∈ pieces) :
+    p.card ≤ r + 1 := by
+  rcases hdecomp.pieces_valid p hp with ⟨e, he⟩ | ⟨S, hS⟩
+  · -- p = {e}: a single r-edge
+    have : p = {e} := he.2
+    subst this; simp
+  · -- p = completeClique r S with |S| = r+1
+    have hcard : S.card = r + 1 := hS.1
+    have : p = completeClique r S := hS.2
+    subst this
+    rw [completeClique_card, hcard, Nat.choose_succ_self_right]
+
 -- ## Empty and Trivial Cases
 
 /-- The empty hypergraph trivially satisfies the Erdős–Sauer conjecture. -/

--- a/proofs/Proofs/Erdos719Problem.lean
+++ b/proofs/Proofs/Erdos719Problem.lean
@@ -193,6 +193,37 @@ theorem decomp_piece_card_le {V : Type*} [DecidableEq V] [Fintype V] (r : ℕ)
     subst this
     rw [completeClique_card, hcard, Nat.choose_succ_self_right]
 
+-- ## Edge Counting and Turán Bound
+
+/-- Any r-uniform hypergraph on Fin n has at most C(n, r) edges,
+    since each edge is an r-element subset of an n-element set. -/
+theorem edges_le_choose (n r : ℕ) (H : RUniformHypergraph (Fin n) r) :
+    H.edges.card ≤ Nat.choose n r := by
+  calc H.edges.card
+      ≤ ((Finset.univ : Finset (Fin n)).powersetCard r).card := by
+        apply Finset.card_le_card
+        intro e he
+        rw [Finset.mem_powersetCard]
+        exact ⟨Finset.subset_univ e, H.uniform e he⟩
+    _ = Nat.choose n r := by
+        rw [Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin]
+
+/-- The set of edge counts of clique-free r-uniform hypergraphs on Fin n
+    is bounded above by C(n, r). -/
+theorem cliqueFree_edgeCounts_bddAbove (n r : ℕ) :
+    BddAbove {m : ℕ | ∃ (H : RUniformHypergraph (Fin n) r),
+      IsCliqueFree r H ∧ H.edges.card = m} := by
+  refine ⟨Nat.choose n r, fun m hm => ?_⟩
+  obtain ⟨G, -, rfl⟩ := hm
+  exact edges_le_choose n r G
+
+/-- Any clique-free r-uniform hypergraph has at most turanHypergraph n r edges.
+    This is the fundamental property of the Turán number as a supremum. -/
+theorem cliqueFree_le_turan (n r : ℕ) (H : RUniformHypergraph (Fin n) r)
+    (hcf : IsCliqueFree r H) :
+    H.edges.card ≤ turanHypergraph n r :=
+  le_csSup (cliqueFree_edgeCounts_bddAbove n r) ⟨H, hcf, rfl⟩
+
 -- ## Empty and Trivial Cases
 
 /-- The empty hypergraph trivially satisfies the Erdős–Sauer conjecture. -/

--- a/src/data/research/problems/erdos-1009-oq-01.json
+++ b/src/data/research/problems/erdos-1009-oq-01.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-24T00:48:59.901Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,12 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ASSESSED: 8A all appropriate.",
+    "progressSummary": "PROGRESS: Added 5 structural theorems (1T→6T). Turán threshold properties + edge-disjoint symmetry. 8A unchanged.",
     "builtItems": [
-      "Assessment: 8A all appropriate (opaque function + deep results)"
+      "Assessment: 8A all appropriate (opaque function + deep results)",
+      "edgeDisjoint_comm: symmetry of edge-disjointness",
+      "turanThreshold_zero, turanThreshold_one: small value computations",
+      "turanThreshold_pos: positivity for n≥2",
+      "turanThreshold_mono: monotonicity of Turán threshold"
     ],
     "insights": [
-      "8 axioms: boundFunction (opaque) + deep graph theory (Györi, Turán, Sauer). All appropriate."
+      "8 axioms: boundFunction (opaque) + deep graph theory (Györi, Turán, Sauer). All appropriate.",
+      "turanThreshold is n²/4 rounded down — monotone, positive for n≥2, zero for n≤1",
+      "8 axioms encode Györi 1988 (solved), Erdős partial, Sauer counterexample, Turán — all deep, no elimination possible"
     ],
     "mathlibGaps": [],
     "nextSteps": []
@@ -59,15 +65,15 @@
     "mathlib": []
   },
   "started": "2026-03-24T00:48:59.901Z",
-  "lastUpdate": "2026-03-24T00:48:59.901Z",
+  "lastUpdate": "2026-03-28T05:55:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1009Problem.lean",
       "filename": "Erdos1009Problem.lean",
-      "lineCount": 195,
-      "theoremCount": 1,
+      "lineCount": 216,
+      "theoremCount": 6,
       "axiomCount": 8,
       "defCount": 9,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1144.json
+++ b/src/data/research/problems/erdos-1144.json
@@ -29,9 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Added 3 partialSum theorems (7T→10T). Recursion + small values. 1A deep (unchanged).",
+    "builtItems": [
+      "partialSum_one: partialSum f 1 = 0",
+      "partialSum_two: partialSum f 2 = f 1",
+      "partialSum_succ: recursion partialSum f (N+1) = partialSum f N + f N for N ≥ 1"
+    ],
+    "insights": [
+      "partialSum sums f(m) for m ∈ [1, N-1] (range N filtered by ≥ 1), so it is off-by-one from mathematical convention ∑_{m≤N}",
+      "1 axiom (atherfold_upper_bound 2025) — deep, cannot eliminate",
+      "All f(m) values are ±1 by strong induction on prime factorization (proved by Aristotle)"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #1144 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
@@ -51,15 +59,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:41:04.200Z",
-  "lastUpdate": "2026-03-13T07:52:17.058Z",
+  "lastUpdate": "2026-03-28T06:05:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1144Problem.lean",
       "filename": "Erdos1144Problem.lean",
-      "lineCount": 176,
-      "theoremCount": 7,
+      "lineCount": 191,
+      "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1179.json
+++ b/src/data/research/problems/erdos-1179.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-15T17:01:06.709Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,12 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ASSESSED: 6A all appropriate.",
+    "progressSummary": "PROGRESS: Added 2 theorems (6T→8T). reprCount bound + expectedReprCount positivity. 6A unchanged.",
     "builtItems": [
-      "Assessment: 6A all appropriate"
+      "Assessment: 6A all appropriate",
+      "reprCount_le_pow: each element has ≤ 2^|A| representations",
+      "expectedReprCount_pos: expected count positive for N≥1"
     ],
     "insights": [
-      "6 axioms: gEps (opaque function) + 5 properties. All appropriate."
+      "6 axioms: gEps (opaque function) + 5 properties. All appropriate.",
+      "main_asymptotic axiom is potentially provable from trivial_lower_bound + erdos_hall_upper via log(log(log N))/log(log N) → 0, but requires complex limit manipulation",
+      "OQ01 sorries are deep: Fourier character expansion + error bound assembly over ZMod p"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -56,7 +60,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T17:01:06.709Z",
-  "lastUpdate": "2026-03-13T07:52:17.060Z",
+  "lastUpdate": "2026-03-28T06:00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -74,8 +78,8 @@
     {
       "path": "Proofs/Erdos1179Problem.lean",
       "filename": "Erdos1179Problem.lean",
-      "lineCount": 219,
-      "theoremCount": 6,
+      "lineCount": 232,
+      "theoremCount": 8,
       "axiomCount": 6,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-461.json
+++ b/src/data/research/problems/erdos-461.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-13T04:11:10.512Z",
-    "iteration": 2,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 3,
+    "focus": "Infrastructure building: structural theorems for smooth components",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,15 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ASSESSED: 1A deep, 10T, 0S.",
+    "progressSummary": "PROGRESS: Added 5 structural theorems (10→15T). Identity, corollaries, count bounds. 1A deep (unchanged).",
     "builtItems": [
-      "Assessment: 1A deep, well-developed file"
+      "Assessment: 1A deep, well-developed file",
+      "smoothComponent_prime_ge: clean corollary for primes ≥ t",
+      "smoothComponent_id_of_smooth: identity when all factors < t",
+      "smoothComponent_id_of_lt: identity when n < t (all factors trivially bounded)",
+      "smoothDistinctCount_pos: count ≥ 1 for non-empty intervals (t ≥ 1)",
+      "smoothDistinctCount_t_le_one: count ≤ 1 for trivial smoothness bound (t ≤ 1)"
     ],
     "insights": [
-      "1 axiom (erdos_graham_lower — deep). 10T, 0S. Clean."
+      "1 axiom (erdos_graham_lower — deep). 10T, 0S. Clean.",
+      "smoothComponent_id_of_lt via Nat.le_of_dvd: prime factor p ≤ n < t gives p < t",
+      "smoothDistinctCount bounded: 0 (t=0) ≤ count ≤ t, with count ≥ 1 for t ≥ 1 and count ≤ 1 for t ≤ 1",
+      "Next infrastructure: smoothComponent_mul (multiplicativity for coprime inputs) needs Nat.factors_mul perm lemma from Mathlib"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove smoothComponent_mul: multiplicativity for coprime inputs (needs List.Perm infrastructure for Nat.factors_mul)",
+      "erdos_graham_lower axiom is deep — stays as axiom"
+    ],
     "markdown": "# Erdős #461 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $s_t(n)$ be the $t$-smooth component of $n$ - that is, the product of all primes $p$ (with multiplicity) dividing $n$ such that $p<t$. Let $f(n,t)$ count the number of distinct possible values for $s_t(m)$ for $m\\in [n+1,n+t]$. Is it true that\\[f(n,t)\\gg t\\](uniformly, for all $t$ and $n$)?\n\n\n\nErd\\H{o}s and Graham report they can show\\[f(n,t) \\gg \\frac{t}{\\log t}.\\]\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #460\n- Problem #462\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -54,15 +65,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:11:10.512Z",
-  "lastUpdate": "2026-03-13T07:52:17.049Z",
+  "lastUpdate": "2026-03-28T05:30:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos461Problem.lean",
       "filename": "Erdos461Problem.lean",
-      "lineCount": 208,
-      "theoremCount": 10,
+      "lineCount": 244,
+      "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-719.json
+++ b/src/data/research/problems/erdos-719.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 8 structural theorems connecting hypergraph clique definitions to Mathlib. Key: completeClique = powersetCard, piece cardinality bound. Identified path to eliminate turan_graph axiom via SimpleGraph bridge.",
+    "progressSummary": "PROGRESS: 11 proved theorems (0 sorries). Key results: clique cardinality via powersetCard, decomposition piece bound, universal edge bound C(n,r), and cliqueFree_le_turan connecting IsCliqueFree to turanHypergraph sSup. Next: bridge to Mathlib SimpleGraph for turan_graph axiom elimination.",
     "builtItems": [
       "completeClique_eq_powersetCard: bridge to Mathlib powersetCard",
       "completeClique_card: |completeClique r S| = C(|S|, r)",
@@ -38,13 +38,19 @@
       "decomp_piece_card_le: piece cardinality bound",
       "completeClique_subset: edges are subsets of vertex set",
       "completeClique_uniform: edges have exactly r elements",
-      "piecesEdgeDisjoint_comm: symmetry of edge-disjointness"
+      "piecesEdgeDisjoint_comm: symmetry of edge-disjointness",
+      "edges_le_choose: universal edge count bound C(n,r)",
+      "cliqueFree_edgeCounts_bddAbove: BddAbove for the Turán sSup",
+      "cliqueFree_le_turan: clique-free → edges ≤ turanHypergraph n r"
     ],
     "insights": [
       "completeClique r S equals Finset.powersetCard r S — bridges to Mathlib combinatorial API",
       "Each decomposition piece has at most r+1 edges (single edges: 1, full cliques: r+1)",
       "Mathlib has full Turán theorem (SimpleGraph.Extremal.Turan) but bridging RUniformHypergraph to SimpleGraph for r=2 is non-trivial",
-      "turan_graph axiom could be proved by building RUniformHypergraph-to-SimpleGraph bridge and using card_edgeFinset_turanGraph"
+      "turan_graph axiom could be proved by building RUniformHypergraph-to-SimpleGraph bridge and using card_edgeFinset_turanGraph",
+      "edges_le_choose: any r-uniform hypergraph on Fin n has ≤ C(n,r) edges, since edges ⊆ univ.powersetCard r",
+      "cliqueFree_le_turan: fundamental Turán bound from sSup definition, using BddAbove + le_csSup on ℕ",
+      "ℕ has ConditionallyCompleteLinearOrderBot, so sSup and le_csSup work for the Turán number definition"
     ],
     "mathlibGaps": [
       "No Mathlib API for r-uniform hypergraphs (only SimpleGraph)",
@@ -71,15 +77,15 @@
     "mathlib": []
   },
   "started": "2026-01-14T21:21:40.197Z",
-  "lastUpdate": "2026-03-27T00:00:00.000Z",
+  "lastUpdate": "2026-03-27T01:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos719Problem.lean",
       "filename": "Erdos719Problem.lean",
-      "lineCount": 259,
-      "theoremCount": 12,
+      "lineCount": 290,
+      "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 7,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-719.json
+++ b/src/data/research/problems/erdos-719.json
@@ -16,24 +16,45 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-01-14T21:21:40.197Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Structural theorems and Mathlib bridge identification",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Build graph-hypergraph bridge for r=2 to prove turan_graph axiom",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS: Added 8 structural theorems connecting hypergraph clique definitions to Mathlib. Key: completeClique = powersetCard, piece cardinality bound. Identified path to eliminate turan_graph axiom via SimpleGraph bridge.",
+    "builtItems": [
+      "completeClique_eq_powersetCard: bridge to Mathlib powersetCard",
+      "completeClique_card: |completeClique r S| = C(|S|, r)",
+      "fullClique_edge_count: K_{r+1}^r has r+1 edges",
+      "completeClique_mono: monotonicity in vertex set",
+      "decomp_piece_card_le: piece cardinality bound",
+      "completeClique_subset: edges are subsets of vertex set",
+      "completeClique_uniform: edges have exactly r elements",
+      "piecesEdgeDisjoint_comm: symmetry of edge-disjointness"
+    ],
+    "insights": [
+      "completeClique r S equals Finset.powersetCard r S — bridges to Mathlib combinatorial API",
+      "Each decomposition piece has at most r+1 edges (single edges: 1, full cliques: r+1)",
+      "Mathlib has full Turán theorem (SimpleGraph.Extremal.Turan) but bridging RUniformHypergraph to SimpleGraph for r=2 is non-trivial",
+      "turan_graph axiom could be proved by building RUniformHypergraph-to-SimpleGraph bridge and using card_edgeFinset_turanGraph"
+    ],
+    "mathlibGaps": [
+      "No Mathlib API for r-uniform hypergraphs (only SimpleGraph)",
+      "SimpleGraph.Extremal.Turan has card_edgeFinset_turanGraph but needs bridge to RUniformHypergraph"
+    ],
+    "nextSteps": [
+      "Build RUniformHypergraph-to-SimpleGraph bridge for r=2 to prove turan_graph axiom",
+      "Create Aristotle companion file for routine supporting lemmas",
+      "Prove that valid decompositions have total edge count equal to H.edges.card"
+    ],
     "markdown": "# Erdős #719 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $\\mathrm{ex}_r(n;K_{r+1}^r)$ be the maximum number of $r$-edges that can be placed on $n$ vertices without forming a $K_{r+1}^r$ (the $r$-uniform complete graph on $r+1$ vertices).\n\nIs every $r$-hypergraph $G$ on $n$ vertices the union of at most $\\mathrm{ex}_{r}(n;K_{r+1}^r)$ many copies of $K_r^r$ and $K_{r+1}^r$, no two of which share a $K_r^r$?\n\n\n\nA conjecture of Erd\\H{o}s and Sauer.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #718\n- Problem #720\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er81\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [
@@ -50,15 +71,15 @@
     "mathlib": []
   },
   "started": "2026-01-14T21:21:40.197Z",
-  "lastUpdate": "2026-03-13T07:52:17.052Z",
+  "lastUpdate": "2026-03-27T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos719Problem.lean",
       "filename": "Erdos719Problem.lean",
-      "lineCount": 196,
-      "theoremCount": 4,
+      "lineCount": 259,
+      "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 7,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Research session for erdos-719 (Erdős-Sauer conjecture on hypergraph decomposition into cliques).

## Progress (15 theorems, 0 sorries)

### Clique Cardinality
- `completeClique_eq_powersetCard`: bridges to Mathlib's `Finset.powersetCard`
- `completeClique_card`: |completeClique r S| = C(|S|, r)
- `fullClique_edge_count`: K_{r+1}^r has exactly r+1 hyperedges
- `completeClique_mono`: monotonicity in vertex sets
- `completeClique_subset`, `completeClique_uniform`: basic edge properties

### Decomposition Structure
- `decomp_piece_card_le`: each piece has at most r+1 edges
- `piecesEdgeDisjoint_comm`: symmetry of edge-disjointness

### Turán Bound Infrastructure
- `edges_le_choose`: any r-uniform hypergraph on Fin n has ≤ C(n,r) edges
- `cliqueFree_edgeCounts_bddAbove`: the sSup in turanHypergraph is well-defined (BddAbove)
- `cliqueFree_le_turan`: clique-free ⟹ edges ≤ turanHypergraph n r

## Findings
- Mathlib `SimpleGraph.Extremal.Turan` has `card_edgeFinset_turanGraph` with exact formula
- The `turan_graph` axiom can be eliminated by bridging `RUniformHypergraph` to `SimpleGraph` (r=2)
- This bridge requires `import Mathlib.Combinatorics.SimpleGraph.Extremal.Turan`

## Status
**Outcome**: progress (2 sessions)
**Next Steps**: Build graph-hypergraph bridge to eliminate `turan_graph` axiom

Generated by researcher-6