### PR TITLE
Research: erdos-667 — prove edgeCount pullback bijection (1→0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos667Problem.lean
+++ b/proofs/Proofs/Erdos667Problem.lean
@@ -88,9 +88,18 @@ theorem cliqueGuarantee_mono_n (p q n : ℕ) :
       have hcf := hm (G.comap Fin.castSucc) (by
         intro S hS
         -- edgeCount (G.comap castSucc) S = edgeCount G (S.map castSucc) ≥ q
-        -- The filter on S×S with (a ≠ b ∧ G.Adj (f a) (f b)) bijects via f×f
-        -- with the filter on (S.map f)×(S.map f) with (a ≠ b ∧ G.Adj a b)
-        sorry)
+        let emb : Fin n ↪ Fin (n + 1) := ⟨Fin.castSucc, Fin.castSucc_injective n⟩
+        suffices h : edgeCount (G.comap Fin.castSucc) S =
+            edgeCount G (S.map emb) by
+          rw [h]; exact hd _ (by rw [Finset.card_map]; exact hS)
+        -- Edge count preserved: comap pullback bijects with mapped product
+        simp only [edgeCount, ← Finset.prodMap_map_product emb emb,
+          Finset.filter_map, Finset.card_map]
+        congr 1
+        apply Finset.filter_congr
+        intro ⟨a, b⟩ _
+        simp only [Function.comp, Function.Embedding.prodMap_apply, Prod.map,
+          SimpleGraph.comap_adj, (Fin.castSucc_injective n).ne_iff])
       -- Lift: ¬CliqueFree (G.comap castSucc) m → ¬CliqueFree G m
       intro hcfG
       apply hcf

--- a/src/data/research/problems/erdos-667.json
+++ b/src/data/research/problems/erdos-667.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 8A (5 structural for cpq + 3 deep results), 29T proved, 1S (edgeCount pullback bijection in cliqueGuarantee_mono_n). Aristotle companion has 7 targets.",
+    "progressSummary": "PROGRESS: Filled sorry in cliqueGuarantee_mono_n (edgeCount pullback bijection). 8A, 29T, 0S in main file.",
     "builtItems": [
       "Proved cliqueGuarantee_pos from other axioms (axiom elimination: 15->14)",
       "Added cliqueGuarantee_mono_q_general: extended monotonicity for H",
@@ -45,7 +45,8 @@
       "Created Erdos667Aristotle.lean companion file with 6 targets",
       "PROVED cliqueGuarantee_zero in Erdos667Problem.lean (was sorry)",
       "PROVED cliqueGuarantee_mono_n structure (modulo edgeCount equality under injective pullback)",
-      "REMOVED false theorem cliqueGuarantee_max with C₄ counterexample documentation"
+      "REMOVED false theorem cliqueGuarantee_max with C₄ counterexample documentation",
+      "Proved edgeCount pullback bijection in cliqueGuarantee_mono_n via Finset.prodMap_map_product + filter_map + castSucc_injective.ne_iff"
     ],
     "insights": [
       "cliqueGuarantee_pos is derivable from cliqueGuarantee_zero + cliqueGuarantee_mono_q by induction on q",
@@ -65,7 +66,8 @@
       "cliqueGuarantee_zero PROVED: sSup argument via le_antisymm — empty graph counterexample for m≥2, singleton for 1-clique",
       "For p=3,q=2: complement of any satisfying graph is a matching → clique number ⌈n/2⌉ → c(3,2)=1",
       "5 structural cpq axioms (noncomputable function + properties) + 3 deep results (Ramsey bounds, EFRS bound)",
-      "1 sorry: edgeCount equality under injective pullback (combinatorial bijection on filtered pairs)"
+      "1 sorry: edgeCount equality under injective pullback (combinatorial bijection on filtered pairs)",
+      "edgeCount (G.comap f) S = edgeCount G (S.map f) for injective f: use prodMap_map_product to rewrite the Cartesian product, filter_map to push filter inside map, then ne_iff from injectivity to match filter predicates"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for erdos-667 (Clique Guarantee and Ramsey-type bounds).

## Progress
- Filled sorry in `cliqueGuarantee_mono_n`: proved that `edgeCount` is preserved under `SimpleGraph.comap` for injective maps
- Technique: `Finset.prodMap_map_product` + `Finset.filter_map` + `castSucc_injective.ne_iff`
- Main file sorry count: 1 → 0

## Files Modified
- `proofs/Proofs/Erdos667Problem.lean` — Filled sorry at line 93
- `src/data/research/problems/erdos-667.json` — Updated knowledge

## Status
**Outcome**: progress
**Remaining**: 8 essential axioms (5 for cpq function + 3 deep results), 4 sorries in Aristotle companion

🤖 Generated by researcher-3