### PR TITLE
fix(audit): erdos-404 axiomCount 2→3, fix theorem/axiom labels

### DIFF
--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -51,14 +51,13 @@
       "lin_bound axiom: f(2, 2) ≤ 254",
       "lin_bound_meaning axiom: 2^255 never divides such sums",
       "legendreSum: Legendre's formula computation",
-      "legendre_formula axiom: v_p(n!) = Σ⌊n/p^i⌋",
+      "legendre_formula theorem: v_p(n!) = Σ⌊n/p^i⌋ (proved via Mathlib's padicValNat_factorial)",
       "padic_val_factorial_asymp axiom: v_p(n!)/n → 1/(p-1)",
-      "factorial_sum_mod axiom: modular structure of factorial sums",
-      "factorial_sum_factored axiom: factorization of factorial sums",
+      "factorial_sum_factored theorem: factorization a₁! + a₂! = a₁!(1 + a₂!/a₁!)",
       "Two proved examples by native_decide",
       "erdos_404_summary: proved conjunction of Lin's bounds"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "prerequisites": [
       "p-adic valuation (padicValNat) and basic properties",
       "Factorials and divisibility in number theory",
@@ -66,8 +65,8 @@
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
-    "lineCount": 120,
-    "assumptions": "3 axioms: lin_bound_meaning (Lin 1976), legendre_formula, padic_val_factorial_asymp. lin_bound proved from lin_bound_meaning via csSup_le."
+    "lineCount": 99,
+    "assumptions": "3 axioms: lin_bound (f(2,2) ≤ 254), lin_bound_meaning (2^255 never divides such sums), padic_val_factorial_asymp (v_p(n!)/n → 1/(p-1)). legendre_formula is a proved theorem using Mathlib's padicValNat_factorial."
   },
   "overview": {
     "historicalContext": "**Prime Power Divisibility of Factorial Sums**\n\nThe interaction between prime divisibility and factorials has deep roots: Legendre's formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ (1808) gives the exact $p$-adic valuation of $n!$, and Kummer's theorem (1852) extends this to binomial coefficients. Erdős and Graham posed Problem #404 in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*: for integers $a \\geq 1$ and primes $p$, define $f(a,p) = \\sup\\{k : p^k \\mid a_1! + \\cdots + a_n!$ for some $a = a_1 < \\cdots < a_n\\}$. Is $f(a,p)$ always finite?\n\n**Chronological Development:**\n- **1808 (Legendre):** Formula for $v_p(n!)$ — the foundational tool\n- **1976 (Lin):** Proved $f(2,2) \\leq 254$ — the only known concrete upper bound for any $(a,p)$ pair. Lin's argument used careful analysis of carries in $p$-adic addition of factorials\n- **1980 (Erdős–Graham):** Problem 404 posed formally, alongside the related Problem #403 on factorial sums modulo primes\n\nThe problem is surprisingly resistant because factorial sums can have cancellation patterns that concentrate $p$-adic valuation. The gap between the known lower bound $f(2,2) \\geq 3$ (from $2^3 \\mid 2! + 3!$) and Lin's upper bound of 254 illustrates how little is understood about the $p$-adic structure of factorial sums.",
@@ -202,9 +201,9 @@
       "Filter"
     ],
     "namespace": "Erdos404",
-    "lineCount": 96,
-    "axiomCount": 2,
-    "theoremCount": 2,
+    "lineCount": 99,
+    "axiomCount": 3,
+    "theoremCount": 3,
     "definitionCount": 7
   }
 }


### PR DESCRIPTION
## Summary

- **axiomCount** corrected from 2 to 3 — Lean source has 3 `axiom` declarations: `lin_bound`, `lin_bound_meaning`, `padic_val_factorial_asymp`
- **assumptions field** fixed: `legendre_formula` is a proved theorem (not an axiom), correctly attributed to Mathlib's `padicValNat_factorial`
- **originalContributions** fixed: removed incorrect "axiom" labels from proved theorems, removed phantom `factorial_sum_mod` (not in Lean source)
- **theoremCount** corrected from 2 to 3
- **lineCount** corrected to 99 (actual file length)

## Evidence

| Field | Before | After | Lean source |
|-------|--------|-------|-------------|
| axiomCount | 2 | 3 | 3 `axiom` declarations |
| theoremCount | 2 | 3 | 3 `theorem` declarations |
| lineCount | 120 / 96 | 99 | 99 lines |

## Test plan

- [ ] `pnpm build` succeeds with updated meta.json
- [ ] Gallery page for erdos-404 renders correctly

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)