### PR TITLE
fix(audit): yang-mills axiomCount 0→16, sorry count 58→59

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 58,
+    "sorries": 59,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",
@@ -58,8 +58,8 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "yang-mills",
     "axiomCount": 16,
-    "assumptions": "1 explicit axiom declaration: gaugeTransform (gauge-transformed field). 15 structure-encoded assumptions in: CompactSimpleGaugeGroup (compact, connected, simple), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy), YangMillsAction (coupling_pos, action_nonneg), FieldStrength (antisymmetric), Instanton (action_formula), EnergyMomentumTensor (symmetric, energy_density_nonneg), QuantumYangMillsTheory (nontrivial). The Yang-Mills 4D mass gap conjecture remains OPEN.",
-    "lineCount": 48,
+    "assumptions": "16 total assumptions: 1 explicit axiom (gaugeTransform) + 15 structure-encoded: CompactSimpleGaugeGroup (compact, connected, simple — 3), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi — 2), FieldStrength (antisymmetric — 1), YangMillsAction (coupling_pos, action_nonneg — 2), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy — 3), QuantumYangMillsTheory (nontrivial — 1), Instanton (action_formula — 1), EnergyMomentumTensor (symmetric, energy_density_nonneg — 2). The Yang-Mills 4D mass gap conjecture remains OPEN.",
+    "lineCount": 28570,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -312,8 +312,8 @@
       "Matrix"
     ],
     "namespace": "YangMillsMassGap",
-    "lineCount": 48,
-    "axiomCount": 0,
+    "lineCount": 28570,
+    "axiomCount": 16,
     "theoremCount": 1805,
     "definitionCount": 260
   },


### PR DESCRIPTION
## Summary

**CRITICAL fix for Millennium Prize problem metadata.**

- **axiomCount** corrected from 0 to 16 — the file has 1 explicit `axiom` declaration + 15 structure-encoded assumptions across 7 structures/typeclasses
- **sorries** corrected from 58 to 59
- **lineCount** corrected from 48 to 28,570 (was only counting wrapper file, not the 4 module files)

## Evidence

The `assumptions` field in the same meta.json already described all 16 assumptions in prose, but `axiomCount` said 0. This violates the Axiom Integrity Policy which states: "axiomCount in meta.json must reflect ALL assumptions: axiom declarations + assumption-carrying structure fields."

| Field | Before | After | Source |
|-------|--------|-------|--------|
| axiomCount | 0 | 16 | 1 axiom + 15 structure fields |
| sorries | 58 | 59 | `grep -c sorry Exploration.lean` → 59 |
| lineCount | 48 | 28,570 | `wc -l` across all YangMills/*.lean |

## Test plan

- [ ] `pnpm build` succeeds with updated meta.json
- [ ] Gallery page for yang-mills renders correctly

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)