### PR TITLE
Research: erdos-951 — eliminate all axioms (2→0)

### DIFF
--- a/proofs/Proofs/Erdos667Problem.lean
+++ b/proofs/Proofs/Erdos667Problem.lean
@@ -88,9 +88,18 @@ theorem cliqueGuarantee_mono_n (p q n : ℕ) :
       have hcf := hm (G.comap Fin.castSucc) (by
         intro S hS
         -- edgeCount (G.comap castSucc) S = edgeCount G (S.map castSucc) ≥ q
-        -- The filter on S×S with (a ≠ b ∧ G.Adj (f a) (f b)) bijects via f×f
-        -- with the filter on (S.map f)×(S.map f) with (a ≠ b ∧ G.Adj a b)
-        sorry)
+        let emb : Fin n ↪ Fin (n + 1) := ⟨Fin.castSucc, Fin.castSucc_injective n⟩
+        suffices h : edgeCount (G.comap Fin.castSucc) S =
+            edgeCount G (S.map emb) by
+          rw [h]; exact hd _ (by rw [Finset.card_map]; exact hS)
+        -- Edge count preserved: comap pullback bijects with mapped product
+        simp only [edgeCount, ← Finset.prodMap_map_product emb emb,
+          Finset.filter_map, Finset.card_map]
+        congr 1
+        apply Finset.filter_congr
+        intro ⟨a, b⟩ _
+        simp only [Function.comp, Function.Embedding.prodMap_apply, Prod.map,
+          SimpleGraph.comap_adj, (Fin.castSucc_injective n).ne_iff])
       -- Lift: ¬CliqueFree (G.comap castSucc) m → ¬CliqueFree G m
       intro hcfG
       apply hcf

--- a/proofs/Proofs/Erdos951Problem.lean
+++ b/proofs/Proofs/Erdos951Problem.lean
@@ -37,6 +37,7 @@ import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Data.Finsupp.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Data.Nat.Prime.Nth
+import Mathlib.Data.Nat.Factorization.Basic
 
 open Nat BigOperators Finset Real
 
@@ -119,9 +120,61 @@ theorem primeSeq_gt_one : ∀ n, primeSeq n > 1 := by
   simp only [primeSeq]
   exact_mod_cast (primeSeq_isPrime n).one_lt
 
+/-- The factorization of a product of indexed prime powers, evaluated at the nth prime,
+    gives the exponent of that index. This is the key step for unique factorization:
+    distinct Finsupp exponent tuples yield distinct natural number products. -/
+private lemma factorization_prod_at (S : Finset ℕ) (e : ℕ → ℕ) (n : ℕ) :
+    (∏ i ∈ S, (Nat.nth Nat.Prime i) ^ (e i)).factorization (Nat.nth Nat.Prime n) =
+      if n ∈ S then e n else 0 := by
+  induction S using Finset.induction with
+  | empty => simp [Nat.factorization_one]
+  | insert j s hjs ih =>
+    have ha : (Nat.nth Nat.Prime j) ^ (e j) ≠ 0 :=
+      Nat.pos_iff_ne_zero.mp
+        (pow_pos (Nat.nth_mem_of_infinite Nat.infinite_setOf_prime j).pos _)
+    have hb : (∏ i ∈ s, (Nat.nth Nat.Prime i) ^ (e i)) ≠ 0 :=
+      Nat.pos_iff_ne_zero.mp (Finset.prod_pos fun i _ =>
+        pow_pos (Nat.nth_mem_of_infinite Nat.infinite_setOf_prime i).pos _)
+    rw [Finset.prod_insert hjs, Nat.factorization_mul ha hb, Finsupp.add_apply, ih,
+        Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul,
+        Nat.factorization_prime (Nat.nth_mem_of_infinite Nat.infinite_setOf_prime j),
+        Finsupp.single_apply]
+    have h_inj := (Nat.nth_strictMono Nat.infinite_setOf_prime).injective
+    by_cases hn : j = n
+    · subst hn; simp [hjs]
+    · simp [show Nat.nth Nat.Prime j ≠ Nat.nth Nat.Prime n from fun h => hn (h_inj h),
+            hn, Ne.symm hn]
+
 /-- The ordinary primes have well-separated products by the
-    Fundamental Theorem of Arithmetic. -/
-axiom primeSeq_well_separated : WellSeparatedProducts primeSeq
+    Fundamental Theorem of Arithmetic: distinct exponent tuples yield
+    distinct natural number products, and distinct naturals differ by ≥ 1. -/
+theorem primeSeq_well_separated : WellSeparatedProducts primeSeq := by
+  intro k ℓ hne
+  simp only [WellSeparatedProducts, primeSeq]
+  -- Define the products as natural numbers
+  set Pk := ∏ i ∈ k.support, (Nat.nth Nat.Prime i) ^ (k i) with hPk_def
+  set Pℓ := ∏ j ∈ ℓ.support, (Nat.nth Nat.Prime j) ^ (ℓ j) with hPℓ_def
+  -- Step 1: Products are distinct (by unique prime factorization)
+  have hne_prod : Pk ≠ Pℓ := by
+    intro heq
+    apply hne; ext n
+    have h := congr_arg (fun m => Nat.factorization m (Nat.nth Nat.Prime n)) heq
+    rw [factorization_prod_at, factorization_prod_at] at h
+    simpa [Finsupp.mem_support_iff] using h
+  -- Step 2: The real-valued products equal the natural products cast to ℝ
+  have h_cast_k :
+      ∏ i ∈ k.support, (↑(Nat.nth Nat.Prime i) : ℝ) ^ (k i) = (↑Pk : ℝ) := by
+    norm_cast
+  have h_cast_ℓ :
+      ∏ j ∈ ℓ.support, (↑(Nat.nth Nat.Prime j) : ℝ) ^ (ℓ j) = (↑Pℓ : ℝ) := by
+    norm_cast
+  rw [h_cast_k, h_cast_ℓ]
+  -- Step 3: Distinct natural numbers cast to ℝ differ by at least 1
+  rcases hne_prod.lt_or_lt with h | h
+  · rw [abs_of_nonpos (sub_nonpos.mpr (Nat.cast_le.mpr h.le))]
+    linarith [show (↑Pk : ℝ) + 1 ≤ ↑Pℓ from by exact_mod_cast Nat.succ_le_of_lt h]
+  · rw [abs_of_nonneg (sub_nonneg.mpr (Nat.cast_le.mpr h.le))]
+    linarith [show (↑Pℓ : ℝ) + 1 ≤ ↑Pk from by exact_mod_cast Nat.succ_le_of_lt h]
 
 /-- The ordinary primes form a Beurling prime sequence. -/
 noncomputable def actualPrimes : BeurlingPrimes where
@@ -183,8 +236,9 @@ def IsBeurlingInteger (a : ℕ → ℝ) (x : ℝ) : Prop :=
 noncomputable def beurlingN (a : ℕ → ℝ) (x : ℝ) : ℕ :=
   Set.ncard {y : ℝ | IsBeurlingInteger a y ∧ 1 ≤ y ∧ y ≤ x}
 
-/-- Beurlings conjecture: if N_a(x) = x + o(log x), then a_i must be the primes. -/
-axiom beurlings_conjecture :
+/-- Beurlings conjecture: if N_a(x) = x + o(log x), then a_i must be the primes.
+    This is an open conjecture; we state it as a Prop without asserting truth. -/
+def beurlings_conjecture : Prop :=
     ∀ bp : BeurlingPrimes,
       (∀ ε > 0, ∃ X : ℝ, ∀ x ≥ X, |beurlingN bp.a x - x| ≤ ε * Real.log x) →
       bp.a = primeSeq

--- a/src/data/proofs/erdos-951/meta.json
+++ b/src/data/proofs/erdos-951/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (problem), Beurling (generalized primes theory)",
     "sourceUrl": "https://erdosproblems.com/951",
     "date": "1937-present",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos951Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "prime-counting",
       "open"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 951,
     "erdosUrl": "https://erdosproblems.com/951",
@@ -61,7 +61,7 @@
       "beurlings_conjecture: if N_a(x) = x + o(log x), then aᵢ = primes",
       "separation_implies_distinct theorem: well-separation implies distinctness"
     ],
-    "axiomCount": 2,
+    "axiomCount": 0,
     "sorries": 0,
     "lineCount": 204,
     "assumptions": "2 axioms: primeSeq_well_separated (products of distinct primes are ≥1 apart, by FTA), beurlings_conjecture (Beurling's rigidity conjecture, deep). All other claims fully proved."
@@ -169,7 +169,7 @@
     ],
     "namespace": "Erdos951",
     "lineCount": 204,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 9
   },

--- a/src/data/research/problems/erdos-667.json
+++ b/src/data/research/problems/erdos-667.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 8A (5 structural for cpq + 3 deep results), 29T proved, 1S (edgeCount pullback bijection in cliqueGuarantee_mono_n). Aristotle companion has 7 targets.",
+    "progressSummary": "PROGRESS: Filled sorry in cliqueGuarantee_mono_n (edgeCount pullback bijection). 8A, 29T, 0S in main file.",
     "builtItems": [
       "Proved cliqueGuarantee_pos from other axioms (axiom elimination: 15->14)",
       "Added cliqueGuarantee_mono_q_general: extended monotonicity for H",
@@ -45,7 +45,8 @@
       "Created Erdos667Aristotle.lean companion file with 6 targets",
       "PROVED cliqueGuarantee_zero in Erdos667Problem.lean (was sorry)",
       "PROVED cliqueGuarantee_mono_n structure (modulo edgeCount equality under injective pullback)",
-      "REMOVED false theorem cliqueGuarantee_max with C₄ counterexample documentation"
+      "REMOVED false theorem cliqueGuarantee_max with C₄ counterexample documentation",
+      "Proved edgeCount pullback bijection in cliqueGuarantee_mono_n via Finset.prodMap_map_product + filter_map + castSucc_injective.ne_iff"
     ],
     "insights": [
       "cliqueGuarantee_pos is derivable from cliqueGuarantee_zero + cliqueGuarantee_mono_q by induction on q",
@@ -65,7 +66,8 @@
       "cliqueGuarantee_zero PROVED: sSup argument via le_antisymm — empty graph counterexample for m≥2, singleton for 1-clique",
       "For p=3,q=2: complement of any satisfying graph is a matching → clique number ⌈n/2⌉ → c(3,2)=1",
       "5 structural cpq axioms (noncomputable function + properties) + 3 deep results (Ramsey bounds, EFRS bound)",
-      "1 sorry: edgeCount equality under injective pullback (combinatorial bijection on filtered pairs)"
+      "1 sorry: edgeCount equality under injective pullback (combinatorial bijection on filtered pairs)",
+      "edgeCount (G.comap f) S = edgeCount G (S.map f) for injective f: use prodMap_map_product to rewrite the Cartesian product, filter_map to push filter inside map, then ne_iff from injectivity to match filter predicates"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-951.json
+++ b/src/data/research/problems/erdos-951.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Eliminated 5 axioms (7→2, 0 sorries). Proved primeSeq_strictly_increasing (Nat.nth_strictMono), primeSeq_gt_one (Nat.Prime.one_lt), actualPrimes_counting (Galois connection nth/count). Removed 2 false axioms (powersOfTwo). Fixed primePi definition.",
+    "progressSummary": "COMPLETED: Eliminated ALL axioms (2→0). Proved primeSeq_well_separated via Nat.factorization (FTA). Converted beurlings_conjecture from axiom to def (open conjecture, not asserted). File now fully verified: 0 axioms, 0 sorries.",
     "builtItems": [
       "Proved primeSeq_isPrime helper theorem (Nat.nth_mem_of_infinite)",
       "Proved primeSeq_strictly_increasing from Nat.nth_strictMono",
@@ -40,7 +40,10 @@
       "Proved primeSeq_gt_one via Nat.Prime.one_lt",
       "Proved actualPrimes_counting via Galois connection + Set.ncard_coe_Finset",
       "Removed false powersOfTwo axioms (counterexample: k={0↦2}, ℓ={1↦1})",
-      "Fixed primePi: primeCounting counts ≤ n, so no +1 needed"
+      "Fixed primePi: primeCounting counts ≤ n, so no +1 needed",
+      "Proved primeSeq_well_separated via factorization_prod_at helper + FTA injectivity",
+      "Converted beurlings_conjecture axiom → def (Prop not asserted)",
+      "factorization_prod_at: Finset.induction + Nat.factorization_mul/pow/prime"
     ],
     "insights": [
       "primeSeq_strictly_increasing proved via Nat.nth_strictMono + Nat.infinite_setOf_prime",
@@ -50,12 +53,12 @@
       "primeSeq_well_separated is correct (products of distinct primes are distinct integers by FTA) but needs formal unique factorization proof",
       "actualPrimes_counting is correct with fixed primePi: uses Galois connection nth/count (Nat.lt_nth_iff_count_lt)",
       "primeCounting n = #{primes ≤ n} = count Prime (n+1). Verified via primeCounting 10 = 4",
-      "Galois connection: n < count p m ↔ nth p n < m (Nat.lt_nth_iff_count_lt)"
+      "Galois connection: n < count p m ↔ nth p n < m (Nat.lt_nth_iff_count_lt)",
+      "primeSeq_well_separated proof: (1) factor prod at nth prime = exponent via FTA, (2) cast ℕ→ℝ preserving distinctness, (3) distinct naturals have |a-b|≥1",
+      "beurlings_conjecture was never used as a proof term — safe to convert axiom→def without breaking anything"
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Prove primeSeq_well_separated from Mathlib UniqueFactorizationMonoid (hard)"
-    ],
+    "nextSteps": [],
     "markdown": "# Erdős #951 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $1<a_1<\\cdots$ be a sequence of real numbers such that\\[\\left\\lvert \\prod_i a_i^{k_i}-\\prod_j a_j^{\\ell_j}\\right\\rvert \\geq 1\\]for every distinct pair of non-negative finitely supported integer tuples $k_i,\\ell_j\\geq 0$. Is it true that\\[\\#\\{ a_i \\leq x\\} \\leq \\pi(x)?\\]\n\n\n\nErd\\H{o}s says this question was asked 'during [his] lecture at Queens College [by] one member of the audience (perhaps S. Shapiro)'. Such a sequence of $a_i$ is sometimes called a set of Beurling prime numbers.\n\nBeurling conjectured that if the number of reals in $[1,x]$ of the form $\\prod a_i^{k_i}$ is $x+o(\\log x)$ then the $a_i$ must be the sequence of primes.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #950\n- Problem #952\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -79,9 +82,9 @@
     {
       "path": "Proofs/Erdos951Problem.lean",
       "filename": "Erdos951Problem.lean",
-      "lineCount": 205,
-      "theoremCount": 7,
-      "axiomCount": 2,
+      "lineCount": 258,
+      "theoremCount": 9,
+      "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Prove `primeSeq_well_separated` from Fundamental Theorem of Arithmetic via `Nat.factorization`
- Convert `beurlings_conjecture` from `axiom` to `def` (open conjecture, never used as proof term)
- File goes from 2 axioms → 0 axioms, status upgraded from `axiomatized` to `verified`

## Proof Approach
Helper lemma `factorization_prod_at` shows: the factorization of `∏ i ∈ S, p_i^(e_i)` at `p_n` equals `e_n` (or 0 if n ∉ S). Uses `Finset.induction` with `Nat.factorization_mul`, `Nat.factorization_pow`, `Nat.factorization_prime`, and injectivity of `Nat.nth`. Main theorem: distinct Finsupp exponents → distinct ℕ products → |cast difference| ≥ 1.

## Status
**Outcome**: completed  
**Axioms**: 2 → 0 (primeSeq_well_separated proved, beurlings_conjecture → def)
**Sorries**: 0

Generated by researcher-3