### PR TITLE
fix(daemon): stale failure counts and pinned-token retry storm

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -358,13 +358,31 @@ rotate_to_working_token() {
         return 1
     fi
 
-    # If pinned, don't rotate — stay on the pinned account
+    # If pinned, don't rotate — unless we've failed too many times
     local _pin_file="$_tokens_dir/.pinned"
+    local _pin_fail_file="$_tokens_dir/.pin-exhaust-count"
+    local _pin_exhaust_limit=5
     if [[ -f "$_pin_file" ]]; then
         local _pinned_acct
         _pinned_acct=$(tr -d '[:space:]' < "$_pin_file")
-        log_warn "Account pinned to $_pinned_acct — not rotating (will backoff instead)"
-        return 1
+
+        # Track consecutive exhaustion failures while pinned
+        local _pin_fails=0
+        if [[ -f "$_pin_fail_file" ]]; then
+            _pin_fails=$(tr -d '[:space:]' < "$_pin_fail_file")
+            _pin_fails=${_pin_fails:-0}
+        fi
+        _pin_fails=$((_pin_fails + 1))
+        echo "$_pin_fails" > "$_pin_fail_file"
+
+        if [[ $_pin_fails -ge $_pin_exhaust_limit ]]; then
+            log_warn "Account pinned to $_pinned_acct exhausted after $_pin_fails attempts — auto-unpinning to allow rotation"
+            rm -f "$_pin_file" "$_pin_fail_file"
+            # Fall through to normal rotation below
+        else
+            log_warn "Account pinned to $_pinned_acct — not rotating (attempt $_pin_fails/$_pin_exhaust_limit, will backoff instead)"
+            return 1
+        fi
     fi
 
     local _token_files=("$_tokens_dir"/*.token)
@@ -623,6 +641,8 @@ run_daemon() {
                 log_success "Daemon cycle $cycle: Claude completed successfully"
                 backoff=$INITIAL_BACKOFF
                 consecutive_failures=0
+                # Reset pin-exhaust counter on success
+                rm -f "${REPO_ROOT:-.}/.loom/tokens/.pin-exhaust-count" 2>/dev/null
                 cycle=$((cycle + 1))
                 continue
                 ;;

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -888,8 +888,17 @@ get_consecutive_failures() {
         *) echo "0"; return ;;
     esac
     if [[ ! -f "$log_file" ]]; then echo "0"; return; fi
+
+    # Only count failures from the current daemon run (after the last "Cycle 1 start")
+    local last_restart_line
+    last_restart_line=$(grep -n "Cycle 1 start" "$log_file" | tail -1 | cut -d: -f1)
+
     local count
-    count=$(grep -o "consecutive failures: [0-9]*" "$log_file" | tail -1 | grep -o '[0-9]*$')
+    if [[ -n "$last_restart_line" ]]; then
+        count=$(tail -n +"$last_restart_line" "$log_file" | grep -o "consecutive failures: [0-9]*" | tail -1 | grep -o '[0-9]*$')
+    else
+        count=$(grep -o "consecutive failures: [0-9]*" "$log_file" | tail -1 | grep -o '[0-9]*$')
+    fi
     echo "${count:-0}"
 }
 CONSECUTIVE_FAILURE_THRESHOLD=10

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "OBSERVE",
     "since": "2026-03-23T00:42:35.516Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,9 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEYED: Fully verified (0A, 23T, 0S). No further work needed.",
+    "builtItems": [
+      "Survey: file already fully verified"
+    ],
+    "insights": [
+      "0 axioms, 23 theorems, 0 sorries \u2014 nothing to improve"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary

- **Stale failure counts**: `health` command grepped the entire log file for the last `consecutive failures: N` line, showing ghost counts from previous daemon runs (e.g., researcher-6 showed 128 failures despite being healthy). Now only reads failures after the most recent `Cycle 1 start` marker.

- **Pinned-token retry storm**: When account-pinned and token-exhausted, `rotate_to_working_token()` returned failure unconditionally, causing agents to retry every 5 minutes forever. Now tracks consecutive pin-exhaust failures and auto-unpins after 5 attempts, allowing rotation to a working token.

## Test plan

- [ ] Run `./scripts/lean/launch.sh health` — verify fail counts show 0 for recently-restarted agents
- [ ] Pin an account, exhaust it, verify auto-unpin triggers after 5 rotation attempts in wrapper logs
- [ ] Verify pin-exhaust counter resets on successful daemon cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)