### PR TITLE
fix(audit): batch sorry-count sync for 8 proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -19,7 +19,7 @@
       "elementary-symmetric-polynomials"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -19,7 +19,7 @@
       "constructibility"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsPGroup",

--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Archimedes (c. 250 BCE), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Archimedes",
     "date": "-250",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "geometry",
       "analysis",
@@ -18,8 +18,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cycle_lemma",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,8 +18,8 @@
       "finset",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 2,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",

--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1004,
     "erdosUrl": "https://erdosproblems.com/1004",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -16,7 +16,7 @@
       "prime-distribution"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 32,
     "assumptions": "32 axiom declarations in main file. Main: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality), prime gap bounds. Consequences: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. Soundness audit: removed li_criterion (was inconsistent with wrong liCoefficient def), fixed auto-bound RiemannHypothesisStatement, unified eulerMascheroniGamma. 6594 lines, 32 axioms, 0 sorries. 2 sorry(s) remain.",
     "mathlibDependencies": [

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "ContractingWith.fixedPoint",


### PR DESCRIPTION
## Summary

Batch fix for 8 proofs whose sorries were resolved but meta.json wasn't synced. The word "sorry" remained only in comments describing the resolution history (e.g., "NOW PROVED (no sorry)").

### Sorry count fixes (status unchanged — still have axioms)
| Proof | Before | After |
|-------|--------|-------|
| erdos-1004 | 1 | 0 |
| schauder-fixed-point | 2 | 0 |
| riemann-hypothesis | 2 | 0 |
| angle-trisection-oq-02 | 1 | 0 |
| amgm-inequality-oq-02 | 1 | 0 |

### Sorry count + status upgrade (0 axioms + 0 sorries → verified)
| Proof | Sorries | Status |
|-------|---------|--------|
| area-of-circle-oq-03-oq-02 | 1→0 | formalized/wip → verified/verified |
| ballot-problem-oq-01-oq-01 | 2→0 | formalized/wip → verified/verified |
| erdos-1006-oq-02-oq-03 | 1→0 | formalized/wip → verified/verified |

## Test plan

- [ ] `pnpm build` succeeds
- [ ] Gallery pages render correctly for all 8 proofs

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)