### PR TITLE
fix: remove leftover conflict markers

### DIFF
--- a/src/data/proofs/erdos-181/meta.json
+++ b/src/data/proofs/erdos-181/meta.json
@@ -156,7 +156,6 @@
     ],
     "opens": [],
     "namespace": "Erdos181",
-<<<<<<< HEAD
     "lineCount": 263,
     "axiomCount": 3,
     "theoremCount": 11,

--- a/src/data/research/problems/erdos-770.json
+++ b/src/data/research/problems/erdos-770.json
@@ -29,17 +29,12 @@
     }
   },
   "knowledge": {
-<<<<<<< HEAD
     "progressSummary": "PROGRESS: Added 7 Fermat-based structural theorems (61T\u219268T). Proved prime_dvd_pow_sub_one, prime_not_dvd_self_pow_sub_one, prime_dvd_gcdPowerSeq, prime_not_dvd_gcdPowerSeq_self, gcdPowerSeq_ne_one_of_large_prime, gcdPowerSeq_fermat_transition, dvd_fold_gcd_of_dvd_all. 2A unchanged (both open).",
-=======
-    "progressSummary": "PROGRESS: Proved Fermat-based structural theory (69T, 2A open). Key: prime_dvd_pow_sub_one, prime_dvd_gcdPowerSeq, prime_not_dvd_self_power, gcdPowerSeq_breaks_at_prime. These formalize WHY h(n) works via Fermat's little theorem.",
->>>>>>> 1f646fc9a5 (Research: erdos-770 — prove Fermat-based structural theory (5 new theorems))
     "builtItems": [
       "PROVED erdos_770_density_exists (trivial: \u03b4=0 works). 3A\u21922A.",
       "gcdPowerSeq_dvd_of_le: monotone divisibility for gcd fold",
       "gcdPowerSeq_ne_one_of_le: stability contrapositive",
       "gcdPowerSeq_dvd_term: explicit fold-dvd-member access",
-<<<<<<< HEAD
       "dvd_fold_gcd_of_dvd_all: if d|f(a) for all a\u2208S, then d|fold_gcd S f",
       "prime_dvd_pow_sub_one: Fermat corollary \u2014 p|a^n-1 when p-1|n and gcd(a,p)=1",
       "prime_not_dvd_self_pow_sub_one: p never divides p^n-1",
@@ -61,27 +56,6 @@
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erd\u0151s #770 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be minimal such that $2^n-1,3^n-1,\\ldots,h(n)^n-1$ are mutually coprime.\n\nDoes, for every prime $p$, the density $\\delta_p$ of integers with $h(n)=p$ exist? Does $\\liminf h(n)=\\infty$? Is it true that if $p$ is the greatest prime such that $p-1\\mid n$ and $p>n^\\epsilon$ then $h(n)=p$?\n\n\n\n\nIt is easy to see that $h(n)=n+1$ if and only if $n+1$ is prime, and that $h(n)$ is unbounded for odd $n$.\n\nIt is probably true that $h(n)=3$ for infinitely many $n$.\n\nSee also [820].\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #820\n- Problem #769\n- Problem #771\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er74b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
-=======
-      "prime_dvd_pow_sub_one: PROVED — Fermat's little theorem: p prime, (p-1)|n, p∤a → p | a^n-1",
-      "dvd_fold_gcd_of_dvd_all: PROVED — if d | f(a) for all a ∈ S, then d | fold gcd S f",
-      "prime_dvd_gcdPowerSeq: PROVED — p prime, (p-1)|n → p | gcdPowerSeq n (p-1)",
-      "prime_not_dvd_self_power: PROVED — p prime, n≥1 → p ∤ p^n-1",
-      "gcdPowerSeq_breaks_at_prime: PROVED — combines the above: p divides gcd but not p^n-1"
-    ],
-    "insights": [
-      "Remaining 2 axioms: erdos_770_unbounded and erdos_770_largest_prime (both OPEN questions, cannot be eliminated)",
-      "Fermat's little theorem is THE key mechanism: when p prime and (p-1)|n, p divides all a^n-1 for a coprime to p",
-      "Adding k=p to the sequence breaks the shared factor p because p ∤ p^n-1 (since p^n ≡ 0 mod p)",
-      "h(n) = n+1 iff n+1 prime: forward proved computationally, general proof requires showing n+1 is the ONLY shared prime (needs: primes q ≤ n can't divide gcd since q ∤ q^n-1, and primes q > n+1 have (q-1) ∤ n)",
-      "ZMod.pow_card_sub_one_eq_one and ZMod.natCast_eq_natCast_iff' are the key Mathlib tools for Fermat ↔ divisibility"
-    ],
-    "mathlibGaps": [],
-    "nextSteps": [
-      "Prove h(n)=n+1 characterization (forward): needs showing p=n+1 is the ONLY prime factor of gcdPowerSeq n n",
-      "The backward direction (h(n)=n+1 → n+1 prime) needs different techniques"
-    ],
-    "markdown": "# Erdős #770 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be minimal such that $2^n-1,3^n-1,\\ldots,h(n)^n-1$ are mutually coprime.\n\nDoes, for every prime $p$, the density $\\delta_p$ of integers with $h(n)=p$ exist? Does $\\liminf h(n)=\\infty$? Is it true that if $p$ is the greatest prime such that $p-1\\mid n$ and $p>n^\\epsilon$ then $h(n)=p$?\n\n\n\n\nIt is easy to see that $h(n)=n+1$ if and only if $n+1$ is prime, and that $h(n)$ is unbounded for odd $n$.\n\nIt is probably true that $h(n)=3$ for infinitely many $n$.\n\nSee also [820].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #820\n- Problem #769\n- Problem #771\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er74b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
->>>>>>> 1f646fc9a5 (Research: erdos-770 — prove Fermat-based structural theory (5 new theorems))
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
Removes <<<<<<< HEAD markers that leaked into erdos-770.json and erdos-181/meta.json during squash merges, breaking the build.