### PR TITLE
fix(audit): area-of-circle-oq-01-oq-03 sorry count 3→2

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
       "isoperimetric"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",
@@ -57,7 +57,7 @@
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
     "lineCount": 1477,
-    "assumptions": "2 sorries remain in supporting lemmas: (1) fourierCoeffOn_deriv_periodic — IBP for Fourier coefficients of periodic C¹ functions (ĉₙ(f') = in·ĉₙ(f)), (2) exists_arclength_reparam — arc-length reparametrization of smooth closed curves to constant speed. 0 axioms. Parseval's identity (parseval_periodic_real), the Fourier decomposition theorem, Wirtinger's inequality, the general isoperimetric inequality, and equality characterization are all fully proved. 3 sorry(s) remain.",
+    "assumptions": "2 sorries remain in supporting lemmas: (1) fourierCoeffOn_deriv_periodic — IBP for Fourier coefficients of periodic C¹ functions (ĉₙ(f') = in·ĉₙ(f)), (2) exists_arclength_reparam — arc-length reparametrization of smooth closed curves to constant speed. 0 axioms. Parseval's identity (parseval_periodic_real), the Fourier decomposition theorem, Wirtinger's inequality, the general isoperimetric inequality, and equality characterization are all fully proved. 2 sorry(s) remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Fix `sorries` field in meta.json: 3→2 to match actual Lean source
- Fix `assumptions` trailer: "3 sorry(s) remain" → "2 sorry(s) remain"
- Lean file has exactly 2 sorries: `fourierCoeffOn_deriv_periodic` (line 395) and `exists_arclength_reparam` (line 909)
- The `description` field already correctly stated "2 sorries"

## Evidence
```
$ grep -n "sorry" proofs/Proofs/AreaOfCircleOQ01OQ03.lean
395:  sorry    # fourierCoeffOn_deriv_periodic
909:  sorry    # exists_arclength_reparam
```

## Test plan
- [x] Verified sorry count by grepping Lean source
- [x] Confirmed no axiom declarations or structure-encoded assumptions
- [x] Confirmed no True stubs
- [x] Status "formalized" / badge "wip" remain appropriate for 2 sorries

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)