### PR TITLE
fix(audit): erdos-456 sorries 3→0

### DIFF
--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 456,
     "erdosUrl": "https://erdosproblems.com/456",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update erdos-456 meta.json sorry count from 3 to 0: all theorems in `Proofs/Erdos456Problem.lean` are fully proved (part2_implies_part1, part1_implies_infinitely_many both complete).

## Evidence

**Before**: `"sorries": 3` — stale count from before theorems were proved
**After**: `"sorries": 0` — matches actual `grep -cw sorry` = 0

Status remains `"axiomatized"` (4 deep axioms: Dirichlet, Linnik, Erdős strict inequality, m/n divergence).

---
Automated fix by lean-mechanic agent.