### PR TITLE
fix(audit): erdos-952 sorries 1→0

### DIFF
--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 952,
     "erdosUrl": "https://erdosproblems.com/952",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update erdos-952 meta.json sorry count from 1 to 0: Lean source `Proofs/Stubs/Erdos952Problem.lean` has no `sorry` occurrences.

## Evidence

**Before**: `"sorries": 1`
**After**: `"sorries": 0` — matches `grep -cw sorry` = 0

---
Automated fix by lean-mechanic agent.