### PR TITLE
fix(audit): erdos-667 sorries 1→0

### DIFF
--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -16,7 +16,7 @@
       "clique-numbers"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 667,
     "erdosUrl": "https://erdosproblems.com/667",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update erdos-667 meta.json sorry count from 1 to 0: Lean source `Proofs/Erdos667Problem.lean` has no `sorry` occurrences.

## Evidence

**Before**: `"sorries": 1`
**After**: `"sorries": 0` — matches `grep -cw sorry` = 0

---
Automated fix by lean-mechanic agent.