### PR TITLE
fix(audit): erdos-628 sorries 12→11

### DIFF
--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update erdos-628 meta.json sorry count from 12 to 11: matches actual `grep -cw sorry` on `Proofs/Stubs/Erdos628Problem.lean`.

## Evidence

**Before**: `"sorries": 12`
**After**: `"sorries": 11`

---
Automated fix by lean-mechanic agent.