### PR TITLE
fix(audit): erdos-746 sorries 5→4

### DIFF
--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Update erdos-746 meta.json sorry count from 5 to 4: matches actual `grep -cw sorry` on `Proofs/Erdos746Problem.lean`.

## Evidence

**Before**: `"sorries": 5`
**After**: `"sorries": 4`

---
Automated fix by lean-mechanic agent.