### PR TITLE
fix(audit): erdos-138 sorries 5→4

### DIFF
--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update erdos-138 meta.json sorry count from 5 to 4: matches actual `grep -cw sorry` on `Proofs/Stubs/Erdos138Problem.lean`.

## Evidence

**Before**: `"sorries": 5`
**After**: `"sorries": 4`

---
Automated fix by lean-mechanic agent.