### PR TITLE
fix(audit): erdos-392 sorries 3→2

### DIFF
--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Update erdos-392 meta.json sorry count from 3 to 2: matches actual `grep -cw sorry` on `Proofs/Stubs/Erdos392Problem.lean`.

## Evidence

**Before**: `"sorries": 3`
**After**: `"sorries": 2`

---
Automated fix by lean-mechanic agent.