### PR TITLE
fix(audit): erdos-719 sorries 0→2

### DIFF
--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -17,7 +17,7 @@
       "decomposition"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "erdosNumber": 719,
     "erdosUrl": "https://erdosproblems.com/719",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update erdos-719 meta.json sorry count from 0 to 2: `Proofs/Erdos719Problem.lean` has 2 sorry occurrences at lines 350 and 365 (completeBipartiteHypergraph_card and turanHypergraph_graph_le).

## Evidence

**Before**: `"sorries": 0`
**After**: `"sorries": 2` — matches actual `grep -nw sorry` count

---
Automated fix by lean-mechanic agent.