### PR TITLE
fix(audit): erdos-687 sorries 0→1

### DIFF
--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -17,7 +17,7 @@
       "sieve theory"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 687,
     "erdosUrl": "https://erdosproblems.com/687",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Update erdos-687 meta.json sorry count from 0 to 1: `Proofs/Erdos687Problem.lean` has a sorry at line 239 in `log_pow_eventually_le_rpow` (standard asymptotic: polynomial growth dominates log powers).

## Evidence

**Before**: `"sorries": 0`
**After**: `"sorries": 1` — matches actual sorry count in Lean source

---
Automated fix by lean-mechanic agent.