### PR TITLE
Research: erdos-332 — prove density-finiteness connection

### DIFF
--- a/proofs/Proofs/Erdos332Problem.lean
+++ b/proofs/Proofs/Erdos332Problem.lean
@@ -193,6 +193,54 @@ theorem infinite_of_diffSet_bounded_gaps (A : Set ℕ)
   rw [← diffSet_nonempty_iff]
   exact hasBoundedGaps_nonempty _ h
 
+/- ## Density–finiteness connection -/
+
+/-- The counting function is bounded by N: at most N elements in {1,...,N}. -/
+theorem countingFn_le (A : Set ℕ) (N : ℕ) : countingFn A N ≤ N := by
+  unfold countingFn
+  have h1 : (Finset.Icc 1 N |>.filter (· ∈ A)).card ≤ (Finset.Icc 1 N).card :=
+    Finset.card_filter_le _ _
+  have h2 : (Finset.Icc 1 N).card ≤ N := by simp [Finset.card_Icc]; omega
+  omega
+
+/-- Positive upper density implies A is infinite.
+    Proof: if A were finite, countingFn A N ≤ |A| for all N, but
+    density gives δ * N ≤ countingFn A N for arbitrarily large N,
+    contradicting the Archimedean property. -/
+theorem positive_upper_density_infinite (A : Set ℕ)
+    (h : HasPositiveUpperDensity A) : Set.Infinite A := by
+  obtain ⟨δ, hδ, hdens⟩ := h
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  set C := hfin.toFinset.card with hC_def
+  have hcf_bound : ∀ N, countingFn A N ≤ C := by
+    intro N
+    unfold countingFn
+    exact Finset.card_le_card
+      (fun hx => hfin.mem_toFinset.mpr ((Finset.mem_filter.mp hx).2))
+  obtain ⟨N₀, hN₀⟩ := exists_nat_gt ((C : ℚ) / δ)
+  obtain ⟨N, hN, hδN⟩ := hdens N₀
+  have h1 : (C : ℚ) / δ < (N : ℚ) := lt_of_lt_of_le hN₀ (by exact_mod_cast hN)
+  have h2 : (C : ℚ) < δ * (N : ℚ) := by rwa [div_lt_iff hδ] at h1
+  have h3 : δ * (N : ℚ) ≤ (C : ℚ) := le_trans hδN (by exact_mod_cast hcf_bound N)
+  linarith
+
+/-- Positive upper density implies D(A) is nonempty (contains zero).
+    Completes the chain: density → infinite → D(A) nonempty. -/
+theorem positive_upper_density_diffSet_nonempty (A : Set ℕ)
+    (h : HasPositiveUpperDensity A) : (diffSet A).Nonempty :=
+  diffSet_nonempty_of_infinite A (positive_upper_density_infinite A h)
+
+/-- Full implication chain for Erdős 332:
+    positive upper density → A infinite → D(A) nonempty → D(A) syndetic.
+    The last step uses the Prikry axiom. -/
+theorem density_chain (A : Set ℕ)
+    (h : HasPositiveUpperDensity A) :
+    Set.Infinite A ∧ (diffSet A).Nonempty ∧ HasBoundedGaps (diffSet A) :=
+  ⟨positive_upper_density_infinite A h,
+   positive_upper_density_diffSet_nonempty A h,
+   positive_density_bounded_gaps A h⟩
+
 /- ## Main problem -/
 
 /-- Erdős Problem 332: What conditions on `A ⊆ ℕ` are sufficient to

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/332",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "assumptions": "3 axiom declarations: positive_density_bounded_gaps (Prikry's theorem), positive_density_diffset_dense (density inheritance for D(A)), diffSet_harmonic_diverges (harmonic thickness conjecture). 7 theorems proved: diffSet_symm, zero_mem_diffSet, diffSet_mono, diffSet_finite_eq_empty, diffSet_nonempty_of_infinite, lower_density_implies_upper, positive_lower_density_bounded_gaps.",
+    "assumptions": "3 axiom declarations: positive_density_bounded_gaps (Prikry's theorem), positive_density_diffset_dense (density inheritance for D(A)), diffSet_harmonic_diverges (harmonic thickness conjecture). 20 theorems proved including density-finiteness connection (positive_upper_density_infinite) and complete implication chain.",
     "dateAdded": "2026-01-22",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -52,7 +52,11 @@
       "Proved diffSet_nonempty_of_infinite: D(A) is nonempty for infinite A (corollary of zero_mem_diffSet)",
       "Proved lower_density_implies_upper: positive lower density → positive upper density",
       "Proved positive_lower_density_bounded_gaps: lower density suffices for bounded gaps (combines density implication with Prikry's theorem)",
-      "Axiomatized Prikry's theorem, density inheritance, and harmonic thickness conjecture as the known landscape for Problem #332"
+      "Axiomatized Prikry's theorem, density inheritance, and harmonic thickness conjecture as the known landscape for Problem #332",
+      "Proved countingFn_le: counting function bounded by N (|A ∩ {1,...,N}| ≤ N)",
+      "Proved positive_upper_density_infinite: positive upper density implies A is infinite, via Archimedean contradiction",
+      "Proved positive_upper_density_diffSet_nonempty: density → D(A) nonempty (bridges density and difference set theory)",
+      "Proved density_chain: complete implication chain density → infinite → D(A) nonempty → D(A) syndetic"
     ],
     "prerequisites": [
       "Integer arithmetic (ℤ) and natural-to-integer coercion",
@@ -61,7 +65,7 @@
       "Additive combinatorics: difference sets, syndetic sets",
       "Ergodic theory basics: Furstenberg correspondence principle (for context)"
     ],
-    "lineCount": 154
+    "lineCount": 263
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory* [ErGr80], building on the classical study of difference sets pioneered by Khintchine (1930s) and Følner (1954). The key known result is due to Karel Prikry, who proved that positive upper density of $A$ guarantees $D(A)$ has bounded gaps (syndeticity); related work by Robert Tijdeman and Cameron Stewart refined the quantitative bounds on the gap parameter $M$ in terms of the density $\\delta$. The problem connects deeply to Hillel Furstenberg's 1977 correspondence principle (*Journal d'Analyse Mathématique*), which translates combinatorial density questions into ergodic theory — Prikry's theorem follows from Poincaré recurrence in the associated measure-preserving system. The open question of finding the *weakest* sufficient condition sits within the broader program of understanding how density forces structure: Szemerédi's theorem (1975) shows positive density forces arithmetic progressions, and the Green–Tao theorem (2008) extends this to the primes. Problem #332 asks the analogous question for difference sets rather than progressions.",
@@ -252,9 +256,9 @@
       "Set"
     ],
     "namespace": "",
-    "lineCount": 154,
+    "lineCount": 263,
     "axiomCount": 3,
-    "theoremCount": 7,
+    "theoremCount": 20,
     "definitionCount": 6,
     "mainTheorems": [
       {

--- a/src/data/research/problems/erdos-332.json
+++ b/src/data/research/problems/erdos-332.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 16 theorems, 3 deep axioms, 0 sorries. Complete D(A) characterization + bounded gaps properties. All structural results for the problem are in place.",
+    "progressSummary": "PROGRESS: 20 theorems, 3 deep axioms, 0 sorries. Complete D(A) characterization + density-finiteness connection + full implication chain. All provable structural results are now in place.",
     "builtItems": [
       "Assessment: all 3A appropriate and deep",
       "Proved diffSet_mono in Erdos332Problem.lean:102",
@@ -45,7 +45,11 @@
       "diffSet_union_subset: D(A)∪D(B) ⊆ D(A∪B)",
       "hasBoundedGaps_nonempty: syndetic sets are nonempty",
       "hasBoundedGaps_mono: bounded gaps is upward closed",
-      "infinite_of_diffSet_bounded_gaps: D(A) syndetic ⟹ A infinite"
+      "infinite_of_diffSet_bounded_gaps: D(A) syndetic ⟹ A infinite",
+      "countingFn_le in Erdos332Problem.lean",
+      "positive_upper_density_infinite in Erdos332Problem.lean",
+      "positive_upper_density_diffSet_nonempty in Erdos332Problem.lean",
+      "density_chain in Erdos332Problem.lean"
     ],
     "insights": [
       "3 axioms all deep: positive_density_bounded_gaps (Furstenberg), positive_density_diffset_dense (additive combinatorics), diffSet_harmonic_diverges. None provable from Mathlib.",
@@ -55,7 +59,10 @@
       "Proved lower_density_implies_upper: liminf > 0 → limsup > 0, connects density definitions",
       "Proved positive_lower_density_bounded_gaps: lower density suffices for bounded gaps (combines with Prikry axiom)",
       "D(A) characterization is now sharp: ∅ iff A finite, nonempty iff A infinite, syndetic if density positive",
-      "D(A) characterization is now complete: empty↔finite, nonempty↔infinite, syndetic↔positive density"
+      "D(A) characterization is now complete: empty↔finite, nonempty↔infinite, syndetic↔positive density",
+      "Proved positive_upper_density_infinite: positive upper density → A infinite via Archimedean contradiction on bounded countingFn",
+      "Completed full implication chain: density → infinite → D(A) nonempty → D(A) syndetic",
+      "Added countingFn_le: elementary bound countingFn A N ≤ N"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -82,8 +89,8 @@
     {
       "path": "Proofs/Erdos332Problem.lean",
       "filename": "Erdos332Problem.lean",
-      "lineCount": 215,
-      "theoremCount": 16,
+      "lineCount": 263,
+      "theoremCount": 20,
       "axiomCount": 3,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- Prove `positive_upper_density_infinite`: positive upper density implies A is infinite (Archimedean argument)
- Prove `positive_upper_density_diffSet_nonempty`: density → D(A) nonempty
- Prove `density_chain`: complete chain density → infinite → D(A) nonempty → D(A) syndetic
- Prove `countingFn_le`: elementary bound countingFn A N ≤ N
- File now: 20 theorems, 3 deep axioms, 0 sorries

## Findings
The key new result `positive_upper_density_infinite` bridges density theory and set finiteness: if A has positive upper density, then countingFn A N is unbounded (grows as δ·N), which contradicts the bounded counting function of any finite set. This completes the full implication chain from density through all intermediate properties to syndeticity.

## Status
**Outcome**: completed
**Next Steps**: All provable structural results are in place. The 3 remaining axioms (Prikry, density inheritance, harmonic divergence) are deep results from ergodic theory/additive combinatorics.

Generated by researcher-4