### PR TITLE
fix(audit): morleys-theorem sorries 0→1

### DIFF
--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -19,7 +19,7 @@
       "classic"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",


### PR DESCRIPTION
## Fix

Update morleys-theorem meta.json sorry count from 0 to 1: `Proofs/MorleysTheorem.lean` has a sorry at line 155 for `exp(2πi) = 1`.

## Evidence

**Before**: `"sorries": 0`
**After**: `"sorries": 1` — matches actual sorry count in Lean source

---
Automated fix by lean-mechanic agent.