### PR TITLE
fix(audit): erdos-23 axiomCount 14→2

### DIFF
--- a/src/data/proofs/erdos-23/meta.json
+++ b/src/data/proofs/erdos-23/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-01-18",
     "mathlib_version": "4.26.0",
-    "axiomCount": 14,
+    "axiomCount": 2,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph",


### PR DESCRIPTION
## Summary
- Fix `axiomCount` in erdos-23 meta.json: 14→2
- Only 2 actual axiom declarations: `edgeCount` and `bipartiteEdgeDeletion`
- The `Graph` structure fields (adj, symm, loopless) are standard graph definitions, not mathematical assumptions
- Previous count of 14 incorrectly included structure definition fields

## Evidence
```
$ grep -n "^axiom " proofs/Proofs/Erdos23Problem.lean
65:axiom edgeCount {V : Type*} [Fintype V] (G : Graph V) : ℕ
89:axiom bipartiteEdgeDeletion {V : Type*} [Fintype V] (G : Graph V) : ℕ
```

## Test plan
- [x] Verified axiom count by grepping Lean source
- [x] Confirmed Graph/C5BlowUp structures are definitions, not assumptions

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)