### PR TITLE
fix(audit): batch sorry count corrections for 17 proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -19,7 +19,7 @@
       "elementary-symmetric-polynomials"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -19,7 +19,7 @@
       "constructibility"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "IsPGroup",

--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
     "badge": "verified",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "verified",
-    "sorries": 0,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",

--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1004,
     "erdosUrl": "https://erdosproblems.com/1004",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "verified",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -16,7 +16,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "sourceUrl": "https://erdosproblems.com/761",
     "erdosUrl": "https://erdosproblems.com/761",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -19,7 +19,7 @@
       "classic"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 23,
     "axiomCount": 5,
     "assumptions": "NSAxioms structure with 5 fields: Type II exponent bound, spectral gap on dissipation scale, theta dynamics bound, blowup rate estimate, BKM criterion. These encode the physical hypotheses needed for conditional 3D regularity.",
     "mathlibDependencies": [

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 0,
+    "sorries": 23,
     "axiomCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -22,7 +22,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 0,
+    "sorries": 23,
     "axiomCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -53,7 +53,7 @@
       "K-ball-concentration"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 23,
     "axiomCount": 5,
     "assumptions": "5 structure-encoded assumptions in NSAxioms (Type II exponent, spectral gap, theta dynamics, blowup rate, BKM criterion). 0 Lean axiom declarations, but the 3D regularity theorem is conditional on the NSAxioms structure (5 fields encoding physical hypotheses: Type II exponent, spectral gap, theta dynamics, blowup rate, and BKM criterion). These structure fields are mathematically equivalent to axiom declarations -- the assumptions were reorganized, not eliminated. The 2D global existence theorem (Ladyzhenskaya 1969) is genuinely unconditional. The Millennium Prize problem remains unsolved.",
     "mathlibDependencies": [

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -16,7 +16,7 @@
       "prime-distribution"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "axiomCount": 32,
     "assumptions": "32 axiom declarations in main file. Main: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality), prime gap bounds. Consequences: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. Soundness audit: removed li_criterion (was inconsistent with wrong liCoefficient def), fixed auto-bound RiemannHypothesisStatement, unified eulerMascheroniGamma. 6594 lines, 32 axioms, 0 sorries. 2 sorry(s) remain.",
     "mathlibDependencies": [

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "ContractingWith.fixedPoint",

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -17,7 +17,7 @@
       "migdal-formula"
     ],
     "badge": "wip",
-    "sorries": 58,
+    "sorries": 59,
     "axiomCount": 0,
     "assumptions": "Structure-encoded assumptions: TwoDPartitionFunction requires representation decomposition and Casimir values. MigdalFormula encodes the exact Wilson loop expectation. SU(2)/SU(3) Casimir values are computed from representation theory. The 2D theory is exactly solvable — all results follow from these structures.",
     "lineCount": 28001,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -16,7 +16,7 @@
       "strong-coupling"
     ],
     "badge": "wip",
-    "sorries": 58,
+    "sorries": 59,
     "axiomCount": 0,
     "assumptions": "Structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
     "lineCount": 28001,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -17,7 +17,7 @@
       "millennium-prize"
     ],
     "badge": "wip",
-    "sorries": 58,
+    "sorries": 59,
     "axiomCount": 0,
     "assumptions": "Structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
     "lineCount": 28001,


### PR DESCRIPTION
## Summary
Full gallery sorry audit (1550 proofs) found 17 remaining mismatches after previous fixes:

**Major — shared file undercounting:**
- `navier-stokes` (4 variants): 0→23 (NavierStokes.lean, 21K lines)
- `yang-mills-2d/lattice/transfer-matrix`: 58→59 (Exploration.lean, 28K lines)

**Minor corrections (diff 1-2):**
- 10 proofs with 0→1 or 0→2 sorry mismatches

## Method
```python
# Counted all occurrences of \bsorry\b in each proofRepoPath file
actual = len(re.findall(r'\bsorry\b', content))
```

## Note
The `yang-mills` wrapper file (YangMillsMassGap.lean) correctly reports 59 sorries as a combined total across its submodules — it is NOT miscounted despite the wrapper file itself having 0 sorries.

## Test plan
- [x] Full sorry audit of all 1550 proofs
- [x] Verified yang-mills wrapper vs submodule distinction
- [x] Excluded already-fixed proofs from PRs #7340, #7354, #7356

🤖 Generated with [Claude Code](https://claude.com/claude-code)