### PR TITLE
fix(audit): revert 16 incorrect sorry counts from #7361

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -19,7 +19,7 @@
       "elementary-symmetric-polynomials"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",
@@ -97,7 +97,7 @@
       "Finset combinatorics (powersetCard, sum, prod)"
     ],
     "lineCount": 543,
-    "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 1 sorry(s) remain.",
+    "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorry(s) remain.",
     "mathlib_version": "4.26.0"
   },
   "crossReferences": [

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -19,7 +19,7 @@
       "constructibility"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsPGroup",
@@ -81,7 +81,7 @@
         "relationship": "Sub-entry connecting to the Gauss-Wantzel theorem for regular polygon constructibility"
       }
     ],
-    "assumptions": "1 axiom: wantzel_galois_characterization — the Wantzel-Galois biconditional: an algebraic number α is constructible by compass and straightedge iff the Galois group of its minimal polynomial over ℚ is a 2-group (IsPGroup 2 (minpoly ℚ α).Gal). Axiomatized because the full proof requires the Galois correspondence for intermediate fields. All other results (non-constructibility of ∛2 and cos(20°), constructibility of √2 and 2^{1/4}, hierarchy of criteria) are fully proved from this axiom with 0 sorries. 1 sorry(s) remain.",
+    "assumptions": "1 axiom: wantzel_galois_characterization — the Wantzel-Galois biconditional: an algebraic number α is constructible by compass and straightedge iff the Galois group of its minimal polynomial over ℚ is a 2-group (IsPGroup 2 (minpoly ℚ α).Gal). Axiomatized because the full proof requires the Galois correspondence for intermediate fields. All other results (non-constructibility of ∛2 and cos(20°), constructibility of √2 and 2^{1/4}, hierarchy of criteria) are fully proved from this axiom with 0 sorries. 0 sorry(s) remain.",
     "mathlib_version": "4.26.0"
   },
   "crossReferences": [

--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
     "badge": "verified",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "assumptions": "1 sorry(s) remain in the formalization.",
+    "assumptions": "0 sorry(s) remain in the formalization.",
     "lineCount": 102,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "verified",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",
@@ -66,7 +66,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 130,
-    "assumptions": "2 sorry(s) remain in the formalization.",
+    "assumptions": "0 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "verified",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",
@@ -65,7 +65,7 @@
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
     "lineCount": 247,
-    "assumptions": "1 sorry(s) remain in the formalization.",
+    "assumptions": "0 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -16,7 +16,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/761",
     "erdosUrl": "https://erdosproblems.com/761",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 5,
     "assumptions": "NSAxioms structure with 5 fields: Type II exponent bound, spectral gap on dissipation scale, theta dynamics bound, blowup rate estimate, BKM criterion. These encode the physical hypotheses needed for conditional 3D regularity.",
     "mathlibDependencies": [

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -22,7 +22,7 @@
       "research"
     ],
     "badge": "open",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -53,7 +53,7 @@
       "K-ball-concentration"
     ],
     "badge": "axiom",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 5,
     "assumptions": "5 structure-encoded assumptions in NSAxioms (Type II exponent, spectral gap, theta dynamics, blowup rate, BKM criterion). 0 Lean axiom declarations, but the 3D regularity theorem is conditional on the NSAxioms structure (5 fields encoding physical hypotheses: Type II exponent, spectral gap, theta dynamics, blowup rate, and BKM criterion). These structure fields are mathematically equivalent to axiom declarations -- the assumptions were reorganized, not eliminated. The 2D global existence theorem (Ladyzhenskaya 1969) is genuinely unconditional. The Millennium Prize problem remains unsolved.",
     "mathlibDependencies": [

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -16,9 +16,9 @@
       "prime-distribution"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 32,
-    "assumptions": "32 axiom declarations in main file. Main: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality), prime gap bounds. Consequences: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. Soundness audit: removed li_criterion (was inconsistent with wrong liCoefficient def), fixed auto-bound RiemannHypothesisStatement, unified eulerMascheroniGamma. 6594 lines, 32 axioms, 0 sorries. 2 sorry(s) remain.",
+    "assumptions": "32 axiom declarations in main file. Main: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality), prime gap bounds. Consequences: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. Soundness audit: removed li_criterion (was inconsistent with wrong liCoefficient def), fixed auto-bound RiemannHypothesisStatement, unified eulerMascheroniGamma. 6594 lines, 32 axioms, 0 sorries. 0 sorry(s) remain.",
     "mathlibDependencies": [
       {
         "theorem": "riemannZeta",

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -17,7 +17,7 @@
       "migdal-formula"
     ],
     "badge": "wip",
-    "sorries": 59,
+    "sorries": 58,
     "axiomCount": 0,
     "assumptions": "Structure-encoded assumptions: TwoDPartitionFunction requires representation decomposition and Casimir values. MigdalFormula encodes the exact Wilson loop expectation. SU(2)/SU(3) Casimir values are computed from representation theory. The 2D theory is exactly solvable — all results follow from these structures.",
     "lineCount": 28001,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -16,7 +16,7 @@
       "strong-coupling"
     ],
     "badge": "wip",
-    "sorries": 59,
+    "sorries": 58,
     "axiomCount": 0,
     "assumptions": "Structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
     "lineCount": 28001,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -17,7 +17,7 @@
       "millennium-prize"
     ],
     "badge": "wip",
-    "sorries": 59,
+    "sorries": 58,
     "axiomCount": 0,
     "assumptions": "Structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
     "lineCount": 28001,


### PR DESCRIPTION
## Summary
PR #7361 incorrectly counted sorry occurrences inside Lean comments (e.g., "no sorry, no axiom" in documentation) as actual sorry statements. This PR reverts those 16 changes using the tracker's `stripLeanComments` method for accurate counting.

**Root cause**: My audit script used `re.findall(r'\bsorry\b', content)` on raw file content instead of stripping comments first.

**Reverted to 0** (sorry only appeared in comments):
- navier-stokes (4 variants): 23→0
- 9 other proofs with sorry in doc comments

**Corrected** (1 sorry of 59 was in a comment):
- yang-mills-2d/lattice/transfer-matrix: 59→58

**Lesson**: Always use comment-aware counting. The tracker's `stripLeanComments` correctly handles nested block comments and line comments.

## Test plan
- [x] Verified each file using `stripLeanComments` + `\bsorry\b` matching
- [x] Confirmed NavierStokes.lean has 0 code sorries (all 23 are in "no sorry" comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)