### PR TITLE
Research: multi-problem session — 3 axioms eliminated, metadata fixes, new theorems

### DIFF
--- a/proofs/Proofs/Erdos1137Problem.lean
+++ b/proofs/Proofs/Erdos1137Problem.lean
@@ -160,6 +160,13 @@ theorem primeGap_three : primeGap 3 = 4 := by
   unfold primeGap
   rw [nth_prime_three, nth_prime_four]
 
+/-- The maximum gap function is monotone: maxGap x ≤ maxGap y whenever x ≤ y.
+    Taking the supremum over a larger Finset can only increase the value. -/
+theorem maxGap_mono : Monotone maxGap := by
+  intro x y hxy
+  unfold maxGap
+  exact Finset.sup_mono (Finset.range_mono hxy)
+
 -- ## Part V: Main Conjecture
 
 /-- **Erdős Problem #1137 (OPEN)**:
@@ -292,6 +299,7 @@ of consecutive prime gaps to the square of the maximum gap tends to 0.
 - All 13 original theorems about prime gaps (positivity, parity, specific values)
 - dvd_factorial: k divides n! when 1 ≤ k ≤ n
 - not_prime_factorial_add: n!+k is composite for 2 ≤ k ≤ n
+- maxGap_mono: maxGap is monotone non-decreasing (via Finset.sup_mono)
 - erdosRatio_le_one: ratio ≤ 1 (previously axiom, now PROVED)
 - primeGap_unbounded: ∀ B, ∃ n, primeGap n ≥ B (factorial + Galois connection)
 - maxGap_tendsto_atTop: max gap → ∞ (previously axiom, now PROVED)

--- a/proofs/Proofs/Erdos469Problem.lean
+++ b/proofs/Proofs/Erdos469Problem.lean
@@ -290,6 +290,19 @@ def IsWeird (n : ℕ) : Prop := IsAbundant n ∧ ¬IsPseudoperfect n
 --
 -- The core of Erdős #469 remains open.
 
+/-- **Erdős Problem #469 (OPEN)**: Does the sum of reciprocals of primitive
+    pseudoperfect numbers converge?
+    Σ_{n ∈ A} 1/n where A = {6, 20, 28, 88, 104, 272, ...}
+    This is stated as a Prop definition (NOT axiom) since it is open. -/
+def erdos469_conjecture : Prop :=
+  Summable (fun n : ℕ => if IsPrimitivePseudoperfect n then (1 : ℝ) / n else 0)
+
+/-- There are infinitely many primitive pseudoperfect numbers.
+    Known: every even perfect number is primitive pseudoperfect (verified for 6, 28).
+    This is also open, stated as a Prop definition. -/
+def infinitely_many_primitive : Prop :=
+  Set.Infinite primitivePseudoperfectSet
+
 /-- Every multiple of a pseudoperfect number is pseudoperfect.
     Proof: if n = d₁ + ⋯ + dₖ with dᵢ proper divisors of n, then
     n·m = d₁·m + ⋯ + dₖ·m, and each dᵢ·m is a proper divisor of n·m. -/

--- a/proofs/Proofs/Erdos951Problem.lean
+++ b/proofs/Proofs/Erdos951Problem.lean
@@ -66,32 +66,33 @@ noncomputable def beurlingPi (a : ℕ → ℝ) (x : ℝ) : ℕ :=
     Nat.primeCounting n counts primes ≤ n (unfolding: count Prime (n+1) = #{p < n+1 | Prime p}). -/
 noncomputable def primePi (x : ℝ) : ℕ := Nat.primeCounting (Nat.floor x)
 
+/-- Consecutive Beurling primes differ by at least 1.
+    This follows from well-separation applied to single-element Finsupp representations. -/
+theorem beurling_consec_gap (bp : BeurlingPrimes) (n : ℕ) :
+    bp.a (n + 1) ≥ bp.a n + 1 := by
+  have hne : Finsupp.single (n + 1) (1 : ℕ) ≠ Finsupp.single n 1 :=
+    fun h => absurd (Finsupp.single_left_injective (by omega) h) (by omega)
+  have hsep := bp.well_separated _ _ hne
+  have hs1 : (Finsupp.single (n + 1) (1 : ℕ)).support = {n + 1} :=
+    Finsupp.support_single_ne_zero _ (by omega)
+  have hs2 : (Finsupp.single n (1 : ℕ)).support = {n} :=
+    Finsupp.support_single_ne_zero _ (by omega)
+  rw [hs1, hs2, Finset.prod_singleton, Finset.prod_singleton] at hsep
+  simp only [Finsupp.single_eq_same] at hsep
+  rw [abs_of_pos (by linarith [bp.strictly_increasing n (n + 1) (by omega)])] at hsep
+  linarith
+
 /-- The counting set {n | a n <= x} is finite for Beurling prime sequences.
     Since a is strictly increasing with all a_n > 1, only finitely many
     indices satisfy a_n <= x. -/
 theorem beurlingPi_finite (bp : BeurlingPrimes) (x : ℝ) :
     Set.Finite {n : ℕ | bp.a n ≤ x} := by
-  -- Step 1: consecutive terms differ by ≥ 1 (from well-separated products
-  -- applied to single-element Finsupp representations)
-  have step : ∀ n : ℕ, bp.a (n + 1) ≥ bp.a n + 1 := by
-    intro n
-    have hne : Finsupp.single (n + 1) (1 : ℕ) ≠ Finsupp.single n 1 :=
-      fun h => absurd (Finsupp.single_left_injective (by omega) h) (by omega)
-    have hsep := bp.well_separated _ _ hne
-    have hs1 : (Finsupp.single (n + 1) (1 : ℕ)).support = {n + 1} :=
-      Finsupp.support_single_ne_zero _ (by omega)
-    have hs2 : (Finsupp.single n (1 : ℕ)).support = {n} :=
-      Finsupp.support_single_ne_zero _ (by omega)
-    rw [hs1, hs2, Finset.prod_singleton, Finset.prod_singleton] at hsep
-    simp only [Finsupp.single_eq_same] at hsep
-    rw [abs_of_pos (by linarith [bp.strictly_increasing n (n + 1) (by omega)])] at hsep
-    linarith
-  -- Step 2: a_n ≥ a_0 + n (by induction on the step bound)
+  -- Step 1: a_n ≥ a_0 + n (by induction using beurling_consec_gap)
   have growth : ∀ n : ℕ, bp.a n ≥ bp.a 0 + n := by
     intro n; induction n with
     | zero => simp
-    | succ k ih => push_cast at *; linarith [step k]
-  -- Step 3: the set is a bounded subset of ℕ, hence finite
+    | succ k ih => push_cast at *; linarith [beurling_consec_gap bp k]
+  -- Step 2: the set is a bounded subset of ℕ, hence finite
   apply Set.Finite.subset (Set.finite_Iic ⌊x⌋₊)
   intro n hn
   simp only [Set.mem_setOf_eq] at hn

--- a/src/data/proofs/erdos-1137/meta.json
+++ b/src/data/proofs/erdos-1137/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1137,
     "erdosUrl": "https://erdosproblems.com/1137",
     "erdosProblemStatus": "open",
@@ -60,16 +60,17 @@
       "primeGap_even: for n ≥ 1, d_n is even (odd − odd)",
       "primeGap_ge_two: for n ≥ 1, d_n ≥ 2 (even + positive)",
       "primeGap_unbounded: for any B, ∃ n with primeGap n ≥ B (factorial argument + Nat.nth/count Galois connection)",
-      "maxGap_tendsto_atTop: max prime gap → ∞ (previously axiom, now PROVED from primeGap_unbounded)"
+      "maxGap_tendsto_atTop: max prime gap → ∞ (previously axiom, now PROVED from primeGap_unbounded)",
+      "maxGap_mono: maxGap is monotone non-decreasing (via Finset.sup_mono)"
     ],
     "dateAdded": "2026-03-23",
     "axiomCount": 1,
-    "lineCount": 314,
-    "assumptions": "1 axiom: erdos_1137 (the main open conjecture, ratio → 0). All other results fully proved: maxGap_tendsto_atTop proved via factorial composites + Galois connection (Nat.nth/Nat.count), erdosRatio_le_one proved from Finset.sup properties. 1 sorry(s) remain."
+    "lineCount": 322,
+    "assumptions": "1 axiom: erdos_1137 (the main open conjecture, ratio → 0). All other results fully proved: maxGap_tendsto_atTop proved via factorial composites + Galois connection (Nat.nth/Nat.count), erdosRatio_le_one proved from Finset.sup properties, maxGap_mono proved via Finset.sup_mono. 0 sorries remain."
   },
   "leanFile": {
     "path": "Proofs/Erdos1137Problem.lean",
-    "lineCount": 314,
+    "lineCount": 322,
     "namespace": "Erdos1137",
     "imports": [
       "Mathlib"
@@ -83,7 +84,8 @@
       "primeGap_three",
       "nth_prime_not_even",
       "primeGap_even",
-      "primeGap_ge_two"
+      "primeGap_ge_two",
+      "maxGap_mono"
     ],
     "mainDefinitions": [
       "primeGap",
@@ -91,7 +93,7 @@
       "erdosRatio"
     ],
     "axiomCount": 1,
-    "theoremCount": 22
+    "theoremCount": 23
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-467/meta.json
+++ b/src/data/proofs/erdos-467/meta.json
@@ -145,7 +145,7 @@
     "namespace": null,
     "lineCount": 250,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 23,
     "definitionCount": 6
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -5,7 +5,7 @@
   "description": "A primitive pseudoperfect number is a sum of distinct proper divisors, with no proper divisor having this property. Does Σ_{n ∈ A} 1/n converge? OEIS A006036. Open.",
   "meta": {
     "erdosNumber": 469,
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "erdos",
       "number-theory",
@@ -18,9 +18,9 @@
     "sourceUrl": "https://erdosproblems.com/469",
     "erdosUrl": "https://erdosproblems.com/469",
     "axiomCount": 0,
-    "badge": "axiom",
-    "lineCount": 215,
-    "assumptions": "2 axioms: infinitely_many_primitive, erdos_469_convergence. See Lean source for complete statements.",
+    "badge": "verified",
+    "lineCount": 327,
+    "assumptions": "0 axioms. All former axioms removed. The open conjectures (erdos469_conjecture, infinitely_many_primitive) are stated as def : Prop, not asserted as axioms. File is fully verified.",
     "proofRepoPath": "Proofs/Erdos469Problem.lean",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-951/meta.json
+++ b/src/data/proofs/erdos-951/meta.json
@@ -63,8 +63,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 204,
-    "assumptions": "2 axioms: primeSeq_well_separated (products of distinct primes are ≥1 apart, by FTA), beurlings_conjecture (Beurling's rigidity conjecture, deep). All other claims fully proved."
+    "lineCount": 259,
+    "assumptions": "0 axioms. All former axioms eliminated: primeSeq_well_separated proved via FTA (factorization_prod_at), beurlings_conjecture converted to def (Prop, not asserted). File is fully verified."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #951: Beurling Prime Numbers**\n\nThis problem connects Erdős's interest in extremal properties of primes with Beurling's theory of generalized primes, asking whether the ordinary primes are the densest well-separated multiplicative sequence.\n\n**Historical Timeline:**\n- 1937: Arne Beurling introduced generalized primes in his paper 'Analyse de la loi asymptotique de la distribution des nombres premiers généralisés', proving a generalized PNT\n- 1960s: Erdős reported this question was posed during his lecture at Queens College, possibly by S. Shapiro\n- 1977: Diamond proved Beurling's theorem is sharp — the error term $o(\\log x)$ in the generalized PNT cannot be weakened\n- 2000s: Zhang and others developed the modern theory of Beurling generalized integers with applications to number theory\n\n**Beurling's Framework:** A Beurling prime sequence $1 < a_1 < a_2 < \\ldots$ generates 'Beurling integers' via products $\\prod a_i^{k_i}$. The key condition is that distinct products differ by at least 1, mimicking how distinct products of ordinary primes (i.e., distinct positive integers) are at least 1 apart by the Fundamental Theorem of Arithmetic.\n\n**The Deep Question:** Erdős asks whether this well-separation condition alone — without any further structure — forces $\\pi_a(x) \\le \\pi(x)$. This would mean that among all multiplicatively well-separated sequences, the primes pack the most elements below any threshold $x$. This is a remarkable extremality claim about the primes.\n\n**Why It's Hard:** The well-separation condition is global: changing one element of the sequence affects all products, creating complex constraints. There is no known technique to bound $\\pi_a(x)$ from below for arbitrary well-separated sequences.",
@@ -168,9 +168,9 @@
       "Real"
     ],
     "namespace": "Erdos951",
-    "lineCount": 204,
+    "lineCount": 259,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 10,
     "definitionCount": 9
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary
### erdos-1137 (Consecutive Prime Gap Products)
- Proved `maxGap_mono : Monotone maxGap` via `Finset.sup_mono`
- Fixed gallery metadata: `sorries: 1 → 0`

### erdos-951 (Beurling Prime Numbers)
- Extracted `beurling_consec_gap` as named theorem
- Fixed gallery metadata: lineCount, theoremCount, stale assumptions

### erdos-469 (Primitive Pseudoperfect Numbers)
- Stated `erdos469_conjecture` and `infinitely_many_primitive` formally as `def : Prop`
- Fixed gallery metadata

### erdos-467 (Dual Covering)
- Fixed theorem count 21→23

### erdos-1166 (Most-Visited Points in Planar Random Walk)
- **Eliminated 3 axioms** by converting `cumulativeMostVisited` from axiom to `def` (Finset.biUnion)
- Proved `cumulativeMostVisited_contains` and `_subset` as theorems
- Updated metadata

## Status
- erdos-1137: 1A (open conjecture), 0S
- erdos-951: 0A, 0S (fully verified)
- erdos-469: 0A, 0S (fully verified)
- erdos-467: 1A (open conjecture), 0S
- erdos-1166: 20A (3 eliminated), 1S

🤖 Generated by researcher-1