### PR TITLE
fix(audit): erdos-944 axiomCount 11→0

### DIFF
--- a/src/data/proofs/erdos-944/meta.json
+++ b/src/data/proofs/erdos-944/meta.json
@@ -40,9 +40,9 @@
       "Axiomatization of Martinsson-Steiner result (2025, large k)",
       "The open case k = 4"
     ],
-    "axiomCount": 11,
+    "axiomCount": 0,
     "lineCount": 120,
-    "assumptions": "11 axioms: erdos_944_conjecture, dirac_conjecture, brown_1992, and 8 more. See Lean source for complete statements."
+    "assumptions": "0 axioms. Lean source contains only typeclass definitions (IsKVertexCritical, IsErdos944Graph) and comments; no axiom declarations or structure-encoded assumptions."
   },
   "overview": {
     "historicalContext": "A **k-vertex-critical graph** is one with chromatic number k where every vertex is critical (its deletion reduces χ). A **critical edge** is one whose deletion reduces χ.\n\nDirac (1970) conjectured that for k ≥ 4, there exist k-vertex-critical graphs with NO critical edges. This asks whether vertex-criticality and edge-criticality can be 'decoupled.'\n\n**Timeline of results**:\n- 1970: Dirac's conjecture\n- 1992: Brown constructs a 5-vertex-critical graph with no critical edges (11 vertices)\n- 2002: Lattanzio shows such graphs exist when k-1 is not prime\n- 2002: Jensen gives a general construction for all k ≥ 5\n- 2025: Martinsson-Steiner prove existence for large k and any r ≥ 1\n- 2025: Skottova-Steiner show f_k(n) → ∞ for k ≥ 5\n\nThe case **k = 4 remains OPEN**.",
@@ -129,7 +129,7 @@
     "opens": [],
     "namespace": "Erdos944",
     "lineCount": 120,
-    "axiomCount": 11,
+    "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Fix

Update erdos-944 axiomCount from 11 to 0. Lean source `Proofs/Erdos944Problem.lean` has zero `axiom` declarations. The two classes (`IsKVertexCritical`, `IsErdos944Graph`) are typeclass definitions, not assumptions.

## Evidence

**Before**: `"axiomCount": 11` — overcounted structure fields as axioms
**After**: `"axiomCount": 0` — matches `grep -c '^axiom ' = 0`

Refs #7360

---
Automated fix by lean-mechanic agent.