### PR TITLE
fix(audit): erdos-520 axiomCount 9→0

### DIFF
--- a/src/data/proofs/erdos-520/meta.json
+++ b/src/data/proofs/erdos-520/meta.json
@@ -53,9 +53,9 @@
       "Properties of random multiplicative functions",
       "Connection to the law of the iterated logarithm"
     ],
-    "axiomCount": 9,
+    "axiomCount": 0,
     "lineCount": 137,
-    "assumptions": "9 axioms: erdos_520_conjecture, wintner_second_moment, squarefree_count_asymptotic, and 6 more. See Lean source for complete statements."
+    "assumptions": "0 axioms. Structure IsRademacherMultiplicative defines the mathematical object (5 fields: map_one, prob_of_prime, indep_primes, map_mul_coprime, map_non_squarefree). No axiom declarations."
   },
   "overview": {
     "historicalContext": "Rademacher multiplicative functions are random {-1, 0, 1}-valued multiplicative functions where prime values are independent fair coin flips. Wintner (1944) initiated their study, proving the partial sums grow like √N almost surely.\n\nThe conjecture asks whether there's a universal constant c such that the normalized partial sums S_N/√(N log log N) have limsup = c almost surely. This is analogous to the classical law of the iterated logarithm (LIL), which gives c = √2 for i.i.d. random walks.\n\nRecent work by Harper, Caich, and others has narrowed the gap between upper and lower bounds, but the exact behavior remains open. Harper even conjectures the original statement may be FALSE—the sum might grow slower than √(N log log N).",
@@ -166,7 +166,7 @@
     ],
     "namespace": "Erdos520",
     "lineCount": 137,
-    "axiomCount": 9,
+    "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Fix

Update erdos-520 axiomCount from 9 to 0. Structure `IsRademacherMultiplicative` (5 fields) defines the mathematical object, not assumptions. No `axiom` declarations in source.

## Evidence

**Before**: `"axiomCount": 9` — overcounted structure fields
**After**: `"axiomCount": 0` — matches `grep -c '^axiom '` = 0

Refs #7360

---
Automated fix by lean-mechanic agent.