### PR TITLE
fix(audit): erdos-701 axiomCount 8→0

### DIFF
--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 701,
     "erdosUrl": "https://erdosproblems.com/701",
     "erdosProblemStatus": "open",
-    "axiomCount": 8,
+    "axiomCount": 0,
     "prerequisites": [
       "Basic set theory (subsets, intersections, power sets)",
       "Finite combinatorics and cardinality arguments",
@@ -29,7 +29,7 @@
       "Extremal set theory fundamentals"
     ],
     "lineCount": 284,
-    "assumptions": "8 axioms: chvatal_conjecture_open, chvatal_1974_injection_version, sterboul_1974, and 5 more. See Lean source for complete statements.",
+    "assumptions": "0 axioms. All constructs are definitions and theorems; no axiom declarations or structure-encoded assumptions.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -139,7 +139,7 @@
     ],
     "namespace": "Erdos701",
     "lineCount": 284,
-    "axiomCount": 8,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 8
   }


### PR DESCRIPTION
## Fix

Update erdos-701 axiomCount from 8 to 0. Lean source `Proofs/Erdos701Problem.lean` has zero `axiom` declarations. All constructs are definitions (IsHereditary, IsIntersecting, Star, ChvatalConjecture, SterboulConditions, etc.) and theorems.

## Evidence

**Before**: `"axiomCount": 8` — overcounted definitions as axioms
**After**: `"axiomCount": 0` — matches `grep -c '^axiom '` = 0

Refs #7360

---
Automated fix by lean-mechanic agent.