### PR TITLE
fix(audit): hilbert-23 axiomCount 8→0

### DIFF
--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -44,9 +44,9 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 23,
-    "axiomCount": 8,
+    "axiomCount": 0,
     "lineCount": 335,
-    "assumptions": "8 axioms: fundamental_lemma, euler_lagrange_necessary, geodesics_are_lines, and 5 more. See Lean source for complete statements.",
+    "assumptions": "0 axioms. Structures (Lagrangian, AdmissibleFunction, TestFunction, ControlSystem, CostFunctional) define mathematical objects. No axiom declarations.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -148,7 +148,7 @@
     "opens": [],
     "namespace": "Hilbert23CalculusVariations",
     "lineCount": 335,
-    "axiomCount": 8,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 9
   },


### PR DESCRIPTION
## Fix

Update hilbert-23 axiomCount from 8 to 0. Structures (Lagrangian, AdmissibleFunction, TestFunction, ControlSystem, CostFunctional) define mathematical objects, not assumptions. No `axiom` declarations in source.

## Evidence

**Before**: `"axiomCount": 8`
**After**: `"axiomCount": 0` — matches `grep -c '^axiom '` = 0

Refs #7360

---
Automated fix by lean-mechanic agent.