### PR TITLE
fix(audit): erdos-1004 sorries 1→0

### DIFF
--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -16,13 +16,13 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1004,
     "erdosUrl": "https://erdosproblems.com/1004",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
     "lineCount": 609,
-    "assumptions": "Three axioms: EPS87 upper bound (eps87_theorem: consolidated existential for constant, threshold, and bound), existence of fixed-length distinct runs (longer_runs_need_larger_n), and asymptotic count of distinct totient values (distinct_totients_asymptotic, Erdős 1935/Ford 1998). eps87_constant, eps87_threshold derived as noncomputable defs; eps87_constant_pos, eps87_upper_bound derived as theorems. 1 sorry(s) remain.",
+    "assumptions": "Three axioms: EPS87 upper bound (eps87_theorem: consolidated existential for constant, threshold, and bound), existence of fixed-length distinct runs (longer_runs_need_larger_n), and asymptotic count of distinct totient values (distinct_totients_asymptotic, Erdős 1935/Ford 1998). eps87_constant, eps87_threshold derived as noncomputable defs; eps87_constant_pos, eps87_upper_bound derived as theorems. 0 sorries remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Corrects sorry count mismatch: meta.json claimed 1 sorry but Lean source has 0
- The sorry was previously removed (was on a false statement per line 219 comment) but meta.json wasn't updated
- Updates `assumptions` text to reflect 0 sorries remaining

## Evidence
- `grep -c 'sorry' proofs/Proofs/Erdos1004Problem.lean` → 0 actual sorries (1 mention in comment only)
- 3 axioms confirmed: `eps87_theorem`, `longer_runs_need_larger_n`, `distinct_totients_asymptotic`
- Status `axiomatized` / badge `axiom` remain correct

## Test plan
- [ ] `pnpm build` passes with updated meta.json

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)