### PR TITLE
fix(audit): erdos-25 axiomCount 4→0

### DIFF
--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 25,
     "erdosUrl": "https://erdosproblems.com/25",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 0,
     "lineCount": 166,
     "assumptions": "Main file: 0 axioms (finite_sieve_density_exists proved vacuously — hypothesis contradicts StrictMono; sieve_density_positive removed — mathematically false). Companion Erdos25LogDensity.lean: 4 axioms (logDensity_avoid_one_residue, naturalDensity_implies_logDensity, exists_logDensity_no_naturalDensity, davenport_erdos). Previously 6 main-file axioms: logDensity/logDensity_mem_unit/logDensity_unique proved via constructive HasLogDensity; sieved_set_nonempty proved with corrected hypothesis (seq_n 0 ≥ 2).",
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Fix

Update erdos-25 meta.axiomCount from 4 to 0. Main file `Proofs/Erdos25Problem.lean` has 0 axiom declarations. The CongruenceSieve structure defines a mathematical object, not assumptions. (4 axioms exist in companion `Erdos25LogDensity.lean`, not the main file.)

## Evidence

**Before**: `"axiomCount": 4`
**After**: `"axiomCount": 0` — matches main file `grep -c '^axiom '` = 0

Refs #7360

---
Automated fix by lean-mechanic agent.