### PR TITLE
fix(audit): schauder-fixed-point sorries 2→0

### DIFF
--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "ContractingWith.fixedPoint",
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-10",
     "axiomCount": 5,
-    "assumptions": "5 axiom(s). No sorries. 2 sorry(s) remain.",
+    "assumptions": "5 axiom(s): brouwer_compact_convex, mazur_compact_convex_hull, brouwer_finite_dim_subset, peano_existence_via_schauder, infinite_dim_counterexample. 0 sorries remain.",
     "proofRepoPath": "Proofs/SchauderFixedPoint.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 601


### PR DESCRIPTION
## Summary
- Corrects sorry count mismatch: meta.json claimed 2 sorries but Lean source has 0
- All "sorry" matches in SchauderFixedPoint.lean and SchauderFixedPointOQ01.lean are in comments only
- Fixes contradictory assumptions text ("No sorries. 2 sorry(s) remain.") and enumerates all 5 axioms

## Evidence
- `grep -w 'sorry' proofs/Proofs/SchauderFixedPoint.lean` → 2 matches, both in comments
- `grep -w 'sorry' proofs/Proofs/SchauderFixedPointOQ01.lean` → 3 matches, all in comments
- 5 axioms confirmed: `brouwer_compact_convex`, `mazur_compact_convex_hull`, `brouwer_finite_dim_subset`, `peano_existence_via_schauder`, `infinite_dim_counterexample`

## Test plan
- [ ] `pnpm build` passes with updated meta.json

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)