### PR TITLE
fix(audit): navier-stokes-existence sorries 23→0

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 23,
+    "sorries": 0,
     "axiomCount": 5,
     "assumptions": "NSAxioms structure with 5 fields: Type II exponent bound, spectral gap on dissipation scale, theta dynamics bound, blowup rate estimate, BKM criterion. These encode the physical hypotheses needed for conditional 3D regularity.",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary
- Corrects sorry count mismatch on HIGH-RISK Millennium Prize entry
- meta.json claimed 23 sorries but all 23 matches are in comments saying "no sorry, no axiom"
- Zero actual sorry keywords in proof code
- The count of 23 was likely from naive grep including comment text
- 5 structure-encoded assumptions (NSAxioms) confirmed, axiomCount correct

## Evidence
- `grep -w 'sorry' proofs/Proofs/NavierStokes.lean` → 23 matches, ALL in comments
- `grep -c '^axiom ' proofs/Proofs/NavierStokes.lean` → 0
- NSAxioms structure has 5 fields (lines 895-917)

## Test plan
- [ ] `pnpm build` passes with updated meta.json

---
Discovered during gallery integrity audit (Millennium Prize — HIGH risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)