### PR TITLE
fix(audit): buffons-needle-oq-01-oq-01 sorries 4→0

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
       "open-question-resolved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_comp_add_right",
@@ -72,7 +72,7 @@
     "dateAdded": "2026-02-25",
     "axiomCount": 1,
     "lineCount": 390,
-    "assumptions": "1 axiom(s) and 4 sorry(s) remain.",
+    "assumptions": "1 axiom: buffon_noodle_smooth_eq. 0 sorries remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Corrects sorry count: meta.json claimed 4, actual is 0 (all mentions in comments)
- Updates assumptions text to name the 1 axiom (buffon_noodle_smooth_eq)

## Evidence
- `grep -w 'sorry' proofs/Proofs/BuffonsNeedleOQ01OQ01.lean` → 5 matches, all in comments/docstrings
- `grep -c '^axiom ' proofs/Proofs/BuffonsNeedleOQ01OQ01.lean` → 1

## Test plan
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)