### PR TITLE
Research: erdos-731 — eliminate false axiom (3A→2A)

### DIFF
--- a/proofs/Proofs/Erdos731Problem.lean
+++ b/proofs/Proofs/Erdos731Problem.lean
@@ -62,9 +62,16 @@ axiom prime_divides_central_iff (p n : ℕ) (hp : Nat.Prime p) (hle : p ≤ 2 * 
     -- At least one digit of n in base p is ≥ ⌈p/2⌉
     ∃ k : ℕ, (n / p ^ k) % p ≥ (p + 1) / 2
 
-/-- Small primes always divide C(2n, n) for large n. -/
-axiom small_primes_divide (p : ℕ) (hp : Nat.Prime p) :
-  ∃ N : ℕ, ∀ n : ℕ, n ≥ N → p ∣ centralBinom n
+/-- The claim "for each prime p, p | C(2n,n) for all sufficiently large n"
+    is FALSE for p ≥ 3. Counterexample: n = p^k gives 0 carries in base-p
+    addition (Kummer), so p ∤ C(2·p^k, p^k) for all k.
+    Concrete: C(6,3) = 20 and 3 ∤ 20. The correct statement is that
+    the set {n : p ∤ C(2n,n)} has density 0 (most n have a large digit). -/
+theorem small_primes_divide_false :
+    ¬(3 ∣ centralBinom 3) ∧ centralBinom 3 = 20 := by
+  constructor
+  · unfold centralBinom; native_decide
+  · unfold centralBinom; native_decide
 
 /-- C(2n, n) is always even for n ≥ 1.
     Proof: By Pascal's rule, C(2n, n) = C(2n-1, n-1) + C(2n-1, n).

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -20,8 +20,8 @@
     "erdosNumber": 731,
     "erdosUrl": "https://erdosproblems.com/731",
     "erdosProblemStatus": "open",
-    "axiomCount": 3,
-    "lineCount": 154,
+    "axiomCount": 2,
+    "lineCount": 161,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",

--- a/src/data/research/problems/erdos-731.json
+++ b/src/data/research/problems/erdos-731.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PROGRESS: 10 theorems, 2 axioms (down from 3), 0 sorries. Eliminated false axiom small_primes_divide via Kummer counterexample.",
     "builtItems": [
       "Proved erdos_731_conjecture (True placeholder)",
       "Proved kummer_carries (True placeholder)",
@@ -40,7 +40,9 @@
       "Proved two_divides_central: Pascal + choose_symm → C(2n,n) = 2·C(2n-1,n-1)",
       "Proved bertrand_central: Nat.exists_prime_lt_and_le_two_mul + Prime.dvd_choose_add",
       "Proved central_binom_lower: sum_range_choose + choose_le_middle → (2n+1)·C(2n,n) ≥ 4^n",
-      "Proved least_nondiv_counterexample: C(4,2)=6, leastNonDiv=4, 4 not prime"
+      "Proved least_nondiv_counterexample: C(4,2)=6, leastNonDiv=4, 4 not prime",
+      "Eliminated small_primes_divide axiom (FALSE)",
+      "Proved small_primes_divide_false: ¬(3 ∣ C(6,3)) ∧ C(6,3)=20"
     ],
     "insights": [
       "File had pre-existing build failure: omega cannot prove non-divisibility (m+1 does not divide m)",
@@ -49,7 +51,10 @@
       "least_nondiv_is_prime axiom was FALSE: counterexample n=2, C(4,2)=6, leastNonDivisor(6)=4 (not prime)",
       "EGRS result is about ALMOST ALL n, not ALL n — the axiom overclaimed",
       "Bertrand proof uses dvd_choose_add with a=b=n, p in (n,2n]: both n<p and p≤n+n",
-      "Central binom lower bound: max-term argument from Σ C(2n,k) = 4^n with 2n+1 terms"
+      "Central binom lower bound: max-term argument from Σ C(2n,k) = 4^n with 2n+1 terms",
+      "FOUND FALSE AXIOM: small_primes_divide claimed ∀ primes p, ∃ N, ∀ n≥N, p|C(2n,n). FALSE for p≥3: n=p^k gives 0 carries in Kummer theorem, so p∤C(2p^k,p^k) for all k.",
+      "Concrete counterexample: p=3, n=3, C(6,3)=20, 3∤20. Replaced axiom with counterexample theorem.",
+      "Axiom count reduced 3→2"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -76,9 +81,9 @@
     {
       "path": "Proofs/Erdos731Problem.lean",
       "filename": "Erdos731Problem.lean",
-      "lineCount": 155,
-      "theoremCount": 9,
-      "axiomCount": 3,
+      "lineCount": 161,
+      "theoremCount": 10,
+      "axiomCount": 2,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Discovered `small_primes_divide` axiom is FALSE for primes p≥3
- By Kummer's theorem: n=p^k has all base-p digits 0 except one 1, so 2·1 < p means 0 carries, hence p∤C(2p^k, p^k)
- Concrete counterexample: C(6,3)=20, 3∤20 (machine-verified via native_decide)
- Replaced false axiom with counterexample theorem `small_primes_divide_false`
- Axiom count: 3→2

## Findings
The correct statement is that {n : p∤C(2n,n)} has density 0 (for each prime p≥3), but there is no threshold N after which p always divides C(2n,n). The exceptions are exactly the n whose base-p digits are all < ⌈p/2⌉.

## Status
**Outcome**: completed (axiom elimination)
**Next Steps**: 2 remaining axioms (prime_divides_central_iff = Kummer, upper_bound_trivial) are deep

Generated by researcher-4