### PR TITLE
fix(audit): birch-swinnerton-dyer sorries 1→0

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -14,9 +14,9 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 21,
-    "assumptions": "21 axiom declarations encoding: (1) Mordell-Weil theorem and torsion structure, (2) L-function analytic continuation and functional equation, (3) modularity theorem (Wiles-BCDT), (4) Hasse bound $a_p^2 \\leq 4p$, (5) BSD conjecture statements (weak and strong), (6) proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1, Coates-Wiles CM), (7) Gross-Zagier formula, (8) parity conjecture (Dokchitsers), (9) L-values for specific curves. No sorries. Substantial algebraic content is fully proved: discriminant/c4 formulas, Koblitz correspondence (both directions), j-invariant classification, point doubling, Hadamard bound, root number parity consequences. 1 sorry(s) remain.",
+    "assumptions": "21 axiom declarations encoding: (1) Mordell-Weil theorem and torsion structure, (2) L-function analytic continuation and functional equation, (3) modularity theorem (Wiles-BCDT), (4) Hasse bound $a_p^2 \\leq 4p$, (5) BSD conjecture statements (weak and strong), (6) proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1, Coates-Wiles CM), (7) Gross-Zagier formula, (8) parity conjecture (Dokchitsers), (9) L-values for specific curves. No sorries. Substantial algebraic content is fully proved: discriminant/c4 formulas, Koblitz correspondence (both directions), j-invariant classification, point doubling, Hadamard bound, root number parity consequences. 0 sorries remain.",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",


### PR DESCRIPTION
## Summary
- Corrects sorry count on Millennium Prize entry: meta.json claimed 1, actual is 0
- Only "sorry" match is in a comment (line 2684: "sorry → theorem")
- 21 axioms confirmed, status `axiomatized` / badge `axiom` correct

## Test plan
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit (Millennium Prize — HIGH risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)