### PR TITLE
fix(audit): erdos-1179 sorries 0→2, undercounted

### DIFF
--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "erdosNumber": 1179,
     "erdosUrl": "https://erdosproblems.com/1179",
     "erdosProblemStatus": "proved",
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 6,
     "lineCount": 218,
-    "assumptions": "6 axiom(s): gEps (abstract function), trivial_lower_bound, erdos_renyi_upper, erdos_hall_upper, main_asymptotic, gEps_mono. gEps_pos proved from trivial_lower_bound.",
+    "assumptions": "6 axiom(s): gEps (abstract function), trivial_lower_bound, erdos_renyi_upper, erdos_hall_upper, main_asymptotic, gEps_mono. gEps_pos proved from trivial_lower_bound. 2 sorries remain: logloglog_div_loglog_tendsto_zero (line 233), main_asymptotic_derived squeeze step (line 265).",
     "theoremCount": 5
   },
   "overview": {


### PR DESCRIPTION
## Summary
- **CRITICAL**: meta.json claimed 0 sorries but Lean source has 2 actual sorry keywords
- This is an overclaim (opposite of the usual undercounting pattern)
- Line 233: `logloglog_div_loglog_tendsto_zero` — log ratio limit
- Line 265: `main_asymptotic_derived` — squeeze theorem step
- 6 axioms confirmed, status `axiomatized` / badge `axiom` remain correct

## Evidence
- `grep -w 'sorry' proofs/Proofs/Erdos1179Problem.lean` → 3 matches: 2 in code, 1 in comment
- `grep -c '^axiom ' proofs/Proofs/Erdos1179Problem.lean` → 6

## Test plan
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit. **OVERCLAIM** — sorry count was too low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)