### PR TITLE
fix(audit): erdos-400 sorries 1→0, axiom text 5→3

### DIFF
--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -17,7 +17,7 @@
       "divisibility"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 400,
     "erdosUrl": "https://erdosproblems.com/400",
     "erdosProblemStatus": "open",
@@ -58,7 +58,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 183,
-    "assumptions": "5 axioms: gExcess_upper_bound, gExcess_nonneg, g2_binomial_connection, and 2 more. See Lean source for complete statements. 1 sorry(s) remain."
+    "assumptions": "3 axioms: gExcess_upper_bound, g2_excess_characterization, average_g2_growth. gExcess_nonneg and g2_binomial_connection were converted to proved theorems. 0 sorries remain."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #400**\n\nThis problem appears in the Erdős-Graham monograph *Old and New Problems and Results in Combinatorial Number Theory* (1980, p. 77), investigating the maximum excess that $k$ factorials can achieve over $n!$ while dividing it.\n\n**Historical Development:**\n- **Erdős & Graham (1980):** Posed the problem and proved the fundamental upper bound $g_k(n) = O(\\log n)$ using Legendre's formula for $p$-adic valuations of factorials: $v_p(n!) = \\sum_{j \\ge 1} \\lfloor n/p^j \\rfloor$. The logarithmic bound arises because excess $g$ in the sum forces additional $p$-adic valuation, which is constrained by $v_p(n!)$.\n- **Connection to Multinomials:** The condition $a_1! \\cdots a_k! \\mid n!$ generalizes the integrality of multinomial coefficients $\\binom{n}{a_1, \\ldots, a_k}$. When $\\sum a_i = n$, the divisibility always holds; the problem asks how far beyond $n$ the sum can go.\n- **Kummer's Theorem (1852):** For $k = 2$, the $p$-adic valuation $v_p(\\binom{a+b}{a})$ equals the number of carries when adding $a$ and $b$ in base $p$. This provides a concrete combinatorial interpretation of the divisibility condition.\n\n**Mathematical Context:**\nThe problem sits at the intersection of factorial arithmetic, $p$-adic analysis, and asymptotic number theory. The excess function $g_k(n)$ encodes subtle information about how the prime factorization of $n!$ constrains the joint factorizations of its components. The two-part conjecture asks whether this excess exhibits both average growth ($\\sim c_k \\cdot \\log n$) and concentration (sharp typicality), analogous to the Erdős-Kac phenomenon for additive functions.",


### PR DESCRIPTION
## Summary
- Sorry count 1→0: only "sorry" match is in header comment (line 18)
- Assumptions text corrected: said "5 axioms" but axiomCount is 3
  - gExcess_nonneg and g2_binomial_connection were converted from axioms to proved theorems
  - Remaining 3 axioms: gExcess_upper_bound, g2_excess_characterization, average_g2_growth

## Test plan
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)