### PR TITLE
Research: erdos-1150 — prove backward direction, axioms 5→4

### DIFF
--- a/proofs/Proofs/Erdos1150Problem.lean
+++ b/proofs/Proofs/Erdos1150Problem.lean
@@ -134,21 +134,61 @@ theorem conjecture_implies_no_ultraflat :
   obtain ⟨n, hgt, hlt'⟩ := (hev'.and hlt).exists
   linarith
 
-/-- **Backward direction (axiomatized):**
+/-- **Backward direction (proved):**
     If no ultraflat Littlewood sequence exists, then the conjecture holds.
 
-    Proof sketch (contrapositive): Assume ¬Conjecture. For each k ≥ 1,
-    the negation gives arbitrarily large n with a degree-n Littlewood P
-    satisfying supNorm(P) ≤ (1+1/k)√n. By dependent choice, extract a
-    strictly increasing sequence n₁ < n₂ < ... with corresponding
-    Littlewood P_k of degree n_k and supNorm(P_k)/√n_k ≤ 1+1/k.
-    Combined with Parseval (ratio ≥ √((n+1)/n) → 1), the squeeze theorem
-    gives ratio → 1, yielding an ultraflat sequence.
-
-    This proof requires dependent choice, Filter.Frequently ↔ ¬Eventually,
-    and the squeeze theorem for Tendsto. -/
-axiom no_ultraflat_implies_conjecture :
-    (∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P) → Erdos1150Conjecture
+    Proof (contrapositive): Assume ¬Conjecture. For each k, ¬Conjecture with
+    c = 1/(k+1) gives frequently many n with a degree-n Littlewood P satisfying
+    supNorm(P) ≤ (1+1/(k+1))√n. Extract witnesses with degree ≥ k using
+    Filter.frequently_atTop. The resulting sequence has degrees → ∞ (since
+    n(k) ≥ k) and ratio supNorm/√degree → 1 (squeeze between Parseval's
+    ratio ≥ 1 and the bound 1+1/(k+1) → 1), yielding an ultraflat sequence.
+    Contradiction. -/
+theorem no_ultraflat_implies_conjecture :
+    (∀ P : ℕ → Polynomial ℂ, ¬ IsUltraflat P) → Erdos1150Conjecture := by
+  intro hall
+  by_contra hcontra
+  -- For each c > 0, frequently there's a near-flat polynomial
+  have hfreq : ∀ c : ℝ, c > 0 → ∃ᶠ n in atTop,
+      ∃ p : Polynomial ℂ, p.natDegree = n ∧ IsLittlewoodPolynomial p ∧
+      supNorm p ≤ (1 + c) * Real.sqrt ↑n := by
+    intro c hc
+    have h : ¬(∀ᶠ n in atTop, ∀ p : Polynomial ℂ, p.natDegree = n →
+        IsLittlewoodPolynomial p → supNorm p > (1 + c) * Real.sqrt ↑n) :=
+      fun hev => hcontra ⟨c, hc, hev⟩
+    rw [Filter.not_eventually] at h
+    exact h.mono fun n hn => by push_neg at hn; exact hn
+  -- For each k, extract witness with c = 1/(k+1) and degree ≥ k
+  have hext : ∀ k : ℕ, ∃ m : ℕ, m ≥ k ∧ ∃ p : Polynomial ℂ,
+      p.natDegree = m ∧ IsLittlewoodPolynomial p ∧
+      supNorm p ≤ (1 + 1 / ((k : ℝ) + 1)) * Real.sqrt ↑m := by
+    intro k
+    exact Filter.frequently_atTop.mp (hfreq (1 / ((k : ℝ) + 1)) (by positivity)) k
+  -- Choose sequences: m(k) ≥ k with polynomial p(k) of degree m(k)
+  choose m hm_ge p hdeg hlit hbound using hext
+  -- Contradiction: p is an ultraflat Littlewood sequence
+  apply hall p
+  refine ⟨hlit, ?_, ?_⟩
+  -- Degrees tend to infinity: (p k).natDegree = m k ≥ k → ∞
+  · rw [Filter.tendsto_atTop_atTop]
+    intro b
+    exact ⟨b, fun k hk => by rw [hdeg k]; exact le_trans hk (hm_ge k)⟩
+  -- Ratio → 1 by squeeze between Parseval's 1 and 1 + 1/(k+1)
+  · have hlb : ∀ᶠ k in atTop,
+        (1 : ℝ) ≤ supNorm (p k) / Real.sqrt ↑((p k).natDegree) :=
+      Filter.eventually_atTop.mpr ⟨1, fun k hk =>
+        parseval_ratio_ge_one (p k) (hlit k) (by rw [hdeg k]; have := hm_ge k; omega)⟩
+    have hub : ∀ᶠ k in atTop,
+        supNorm (p k) / Real.sqrt ↑((p k).natDegree) ≤ 1 + 1 / ((k : ℝ) + 1) :=
+      Filter.eventually_atTop.mpr ⟨1, fun k hk => by
+        have hsqrt_pos : (0 : ℝ) < Real.sqrt ↑((p k).natDegree) :=
+          Real.sqrt_pos_of_pos (Nat.cast_pos.mpr (by rw [hdeg k]; have := hm_ge k; omega))
+        rw [div_le_iff₀ hsqrt_pos, hdeg k]
+        exact hbound k⟩
+    have hub_tends : Tendsto (fun k : ℕ => (1 : ℝ) + 1 / ((k : ℝ) + 1)) atTop (nhds 1) := by
+      have := tendsto_const_nhds.add (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ))
+      rwa [add_zero] at this
+    exact tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hub_tends hlb hub
 
 /-- The full equivalence follows from both directions. -/
 theorem conjecture_equiv_no_ultraflat :
@@ -264,9 +304,10 @@ every degree-n ±1 polynomial has max_{|z|=1} |P(z)| > (1+c)√n?
 ultraflat ±1 polynomials exist. Erdős conjectured they don't.
 
 **Proved in this file**:
-5. Conjecture ↔ no ultraflat ±1 sequences (forward direction proved,
-   backward direction axiomatized). Uses subsequence-based ultraflat
-   definition (degrees → ∞, ratio → 1) for mathematical correctness.
+5. Conjecture ↔ no ultraflat ±1 sequences (both directions proved).
+   Forward: conjecture bound contradicts ratio → 1.
+   Backward: contrapositive diagonal extraction + squeeze theorem.
+   Uses subsequence-based ultraflat definition for mathematical correctness.
 6. BBMST implies supNorm bound (proved from pointwise bound)
 -/
 theorem erdos_1150_summary :

--- a/research/problems/erdos-1150/knowledge.md
+++ b/research/problems/erdos-1150/knowledge.md
@@ -73,6 +73,37 @@ Initial formalization: definitions, conjecture statement, axiomatized known resu
 - Potentially prove no_ultraflat_implies_conjecture (diagonal argument)
 - Consider whether Parseval can be proved from Mathlib integration theory
 
+### Session 5 (2026-03-28, researcher-3)
+
+**What Was Done:**
+- **Proved `no_ultraflat_implies_conjecture`** — eliminated 1 axiom (5→4)
+- Backward direction of equivalence: contrapositive diagonal extraction + squeeze
+- Proof structure:
+  1. by_contra: assume ¬Conjecture
+  2. For each k, ¬Conjecture with c=1/(k+1) gives Frequently at atTop
+  3. Filter.frequently_atTop.mp extracts witnesses with degree ≥ k
+  4. choose gives sequences m(k), p(k)
+  5. Degrees → ∞ via tendsto_atTop_atTop (m k ≥ k)
+  6. Ratio → 1 via squeeze: parseval_ratio_ge_one ≤ ratio ≤ 1+1/(k+1)
+  7. tendsto_of_tendsto_of_tendsto_of_le_of_le' closes the squeeze
+- 327 lines, 4 axioms, 8 theorems, 0 sorries
+
+**Key Insights:**
+- No dependent choice needed: Filter.frequently_atTop gives ∃ m ≥ k directly
+- parseval_ratio_ge_one (from session 4) was essential for the squeeze lower bound
+- tendsto_one_div_add_atTop_nhds_zero_nat provides 1/(k+1) → 0 for squeeze upper bound
+
+**Updated Axiom Classification:**
+1. `parseval_lower_bound` — Deep (requires Fourier analysis on unit circle)
+2. ~~`no_ultraflat_implies_conjecture`~~ — **PROVED** (session 5)
+3. `bbmst_flat` — Deep (2019 breakthrough, probabilistic construction)
+4. `kahane_unimodular_ultraflat` — Deep (1980, continuous phase optimization)
+5. `rudin_shapiro_bound` — Medium (constructive, recursive bound proof)
+
+**Next Steps:**
+- Prove `rudin_shapiro_bound` (constructive: define Rudin-Shapiro polynomials, prove |P_k|²+|Q_k|²=2^{k+1})
+- Consider whether `parseval_lower_bound` can be proved from Mathlib integration theory
+
 ---
 
-*Updated by researcher-5 on 2026-03-23*
+*Updated by researcher-3 on 2026-03-28*

--- a/src/data/proofs/erdos-1150/meta.json
+++ b/src/data/proofs/erdos-1150/meta.json
@@ -18,29 +18,29 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axioms": 5,
+    "axioms": 4,
     "erdosNumber": 1150,
     "erdosUrl": "https://erdosproblems.com/1150",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-11",
-    "dateUpdated": "2026-03-12",
+    "dateUpdated": "2026-03-28",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "Definition IsLittlewoodPolynomial, supNorm, IsUltraflat, Erdos1150Conjecture",
       "Proved parseval_bound_pos (√(n+1) > 0)",
       "Proved conjecture_implies_no_ultraflat (forward direction: conjecture → no ultraflat)",
-      "Proved conjecture_equiv_no_ultraflat (full iff from proved forward + axiom backward)",
+      "Proved no_ultraflat_implies_conjecture (backward: contrapositive diagonal extraction + squeeze)",
+      "Proved conjecture_equiv_no_ultraflat (full iff, both directions proved)",
       "Proved flat_does_not_imply_ultraflat (flat ≠ ultraflat)",
       "Proved erdos_1150_summary (Parseval + BBMST + equivalence combined)",
       "Axiom parseval_lower_bound (sup ≥ √(n+1))",
-      "Axiom no_ultraflat_implies_conjecture (backward direction: requires diagonal argument)",
       "Axiom bbmst_flat (flat Littlewood polynomials exist)",
       "Axiom kahane_unimodular_ultraflat (ultraflat for unimodular coefficients)",
       "Axiom rudin_shapiro_bound (concrete ≤ √(2n) family)"
     ],
-    "axiomCount": 5,
-    "lineCount": 270,
-    "assumptions": "5 axiom(s) and 0 sorry(s). Forward direction of equivalence proved. Backward direction axiomatized. IsUltraflat uses subsequence-based definition for mathematical correctness."
+    "axiomCount": 4,
+    "lineCount": 327,
+    "assumptions": "4 axiom(s) and 0 sorry(s). Full equivalence (conjecture ↔ no ultraflat) proved in both directions. Remaining axioms: parseval_lower_bound, bbmst_flat, kahane_unimodular_ultraflat, rudin_shapiro_bound."
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #1150 as part of his investigations into extremal properties of polynomials with restricted coefficients. The study of Littlewood polynomials — polynomials with all coefficients ±1 — dates to J.E. Littlewood's 1966 monograph, where he asked about the minimal sup norm on the unit circle. By Parseval's identity, every degree-$n$ Littlewood polynomial satisfies $\\max_{|z|=1}|P(z)| \\ge \\sqrt{n+1}$, since the $L^2$ norm equals $\\sqrt{n+1}$. The question is whether this can be improved by a multiplicative constant. Kahane's 1980 breakthrough showed that for general unimodular coefficients ($|a_k| = 1$, complex phases allowed), ultraflat polynomials exist — the sup norm can be made $(1+o(1))\\sqrt{n}$. This made the ±1 restriction the essential barrier. The problem gained renewed attention after Balister, Bollobás, Morris, Sahasrabudhe, and Tiba (BBMST, 2019) proved flat Littlewood polynomials exist ($c_1\\sqrt{n} \\le |P(z)| \\le c_2\\sqrt{n}$), resolving Erdős Problem #228. But flat is weaker than ultraflat: the gap between 'bounded ratio' and 'ratio converging to 1' is precisely what Problem #1150 asks about. The Rudin-Shapiro polynomials, constructed recursively since the 1950s, provide the best explicit examples with sup norm at most $\\sqrt{2(n+1)}$.",
@@ -91,8 +91,8 @@
       "title": "Ultraflat Equivalence",
       "startLine": 83,
       "endLine": 141,
-      "summary": "Defines IsUltraflat (supNorm/√n → 1). Proves forward direction: conjecture → no ultraflat (by contradiction with Filter.Tendsto). Axiomatizes backward direction (requires diagonal/choice argument). Full equivalence is a theorem.",
-      "mathContext": "Defines IsUltraflat (supNorm/√n → 1). Proves forward direction: conjecture → no ultraflat (by contradiction with Filter.Tendsto). Axiomatizes backward direction (requires diagonal/choice argument). Full equivalence is a theorem."
+      "summary": "Defines IsUltraflat (supNorm/√n → 1). Proves both directions of the equivalence: forward by contradiction with Filter.Tendsto, backward by contrapositive diagonal extraction + squeeze theorem. Full equivalence is a proved theorem.",
+      "mathContext": "Defines IsUltraflat (supNorm/√n → 1). Proves both directions of the equivalence: forward by contradiction with Filter.Tendsto, backward by contrapositive diagonal extraction + squeeze theorem. Full equivalence is a proved theorem."
     },
     {
       "id": "known-results",
@@ -128,7 +128,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1150, an open question in extremal polynomial theory. The conjecture asks whether the sup norm of degree-$n$ Littlewood polynomials on the unit circle must exceed $(1+c)\\sqrt{n}$ for some universal $c > 0$ — equivalently, whether ultraflat Littlewood polynomials do not exist. All major known results are axiomatized: Parseval lower bound, BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), Rudin-Shapiro explicit bounds, and the equivalence with non-existence of ultraflat sequences. Key theorems proved: forward direction of the ultraflat equivalence, BBMST sup norm bound from pointwise bound (via ciSup_le), and a combined summary. Contains 0 sorries and 5 axioms encoding deep results. Uses subsequence-based IsUltraflat definition for mathematical correctness.",
+    "summary": "This formalization captures Erdős Problem #1150, an open question in extremal polynomial theory. The conjecture asks whether the sup norm of degree-$n$ Littlewood polynomials on the unit circle must exceed $(1+c)\\sqrt{n}$ for some universal $c > 0$ — equivalently, whether ultraflat Littlewood polynomials do not exist. Known results axiomatized: Parseval lower bound, BBMST flat polynomials (2019), Kahane unimodular ultraflat (1980), Rudin-Shapiro explicit bounds. Key theorems proved: full equivalence conjecture ↔ no ultraflat (both directions), BBMST sup norm bound, Parseval ratio bound, and a combined summary. Contains 0 sorries and 4 axioms encoding deep external results. Uses subsequence-based IsUltraflat definition for mathematical correctness.",
     "implications": "**Theoretical Significance**: A positive resolution (confirming the conjecture) would establish that the discrete structure of {-1,+1} coefficients imposes a fundamental rigidity on polynomial behavior on the unit circle — a qualitative separation from the continuous case |$a_k$| = 1.\n\nThis would connect to concentration of measure phenomena and Boolean function analysis. A negative resolution (constructing ultraflat ±1 polynomials) would be equally striking, requiring new techniques beyond BBMST's probabilistic approach.",
     "openQuestions": [
       "Does the conjecture hold: is $\\inf_{P \\in \\mathcal{L}_n} \\|P\\|_\\infty / \\sqrt{n} > 1$ for all large $n$?",
@@ -165,9 +165,9 @@
       "Filter"
     ],
     "namespace": "Erdos1150",
-    "lineCount": 270,
-    "axiomCount": 5,
-    "theoremCount": 7,
+    "lineCount": 327,
+    "axiomCount": 4,
+    "theoremCount": 8,
     "definitionCount": 4
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-1150.json
+++ b/src/data/research/problems/erdos-1150.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-1150",
-  "title": "Erd\u0151s #1150",
+  "title": "Erdős #1150",
   "phase": "ACT",
   "status": "in-progress",
   "tier": "A",
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-15T16:24:55.487Z",
-    "iteration": 4,
-    "focus": "Session 4: Added parseval_ratio_ge_one. Axioms are deep (Parseval, BBMST, Kahane, Rudin-Shapiro) or open.",
+    "iteration": 5,
+    "focus": "Session 5: Proved no_ultraflat_implies_conjecture, eliminating 1 axiom. Axioms: 5→4.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,28 +29,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 7 theorems, 5 axioms. Added parseval_ratio_ge_one. All axioms deep/open.",
+    "progressSummary": "PROGRESS: 8 theorems, 4 axioms. Proved backward direction of ultraflat equivalence via contrapositive diagonal extraction + squeeze.",
     "builtItems": [
       "conjecture_implies_no_ultraflat theorem: forward direction proved via filter contradiction",
       "conjecture_equiv_no_ultraflat theorem: full equivalence from proved forward + axiom backward",
       "supNorm redesigned to use unit circle subtype for clean ciSup_le interaction",
       "bbmst_upper_bound_exists: eliminated sorry via ciSup_le on subtype",
       "IsUltraflat corrected: subsequence-based (Tendsto degree atTop atTop) instead of all-n",
-      "Proved parseval_ratio_ge_one: supNorm(P)/sqrt(deg P) \u2265 1 via div_self + div_le_div_right"
+      "Proved parseval_ratio_ge_one: supNorm(P)/sqrt(deg P) ≥ 1 via div_self + div_le_div_right",
+      "no_ultraflat_implies_conjecture: backward direction proved via by_contra + Filter.frequently_atTop + squeeze theorem"
     ],
     "insights": [
-      "Forward direction is clean: supNorm/\u221an > 1+c eventually contradicts Tendsto ... (nhds 1)",
+      "Forward direction is clean: supNorm/√n > 1+c eventually contradicts Tendsto ... (nhds 1)",
       "Backward direction needs countable choice: extract witnesses for 1/k, build ultraflat sequence",
-      "Old IsUltraflat requiring degree=n for ALL n was mathematically incorrect: \u00acConjecture gives witnesses for infinitely many n only, so backward direction was unprovable",
-      "supNorm defined over subtype {z : \u2102 // \u2016z\u2016 = 1} avoids ciSup empty-index issues entirely",
+      "Old IsUltraflat requiring degree=n for ALL n was mathematically incorrect: ¬Conjecture gives witnesses for infinitely many n only, so backward direction was unprovable",
+      "supNorm defined over subtype {z : ℂ // ‖z‖ = 1} avoids ciSup empty-index issues entirely",
       "Parseval axiom potentially provable if Mathlib has circle integration theory",
-      "parseval_ratio_ge_one is key ingredient for squeeze in backward direction: ratio \u2265 1 from Parseval, \u2264 1+1/k from construction \u2192 ratio \u2192 1"
+      "parseval_ratio_ge_one is key ingredient for squeeze in backward direction: ratio ≥ 1 from Parseval, ≤ 1+1/k from construction → ratio → 1",
+      "Backward direction proved without dependent choice: Filter.frequently_atTop gives ∃ m ≥ k directly, no need for strictly increasing extraction",
+      "tendsto_of_tendsto_of_tendsto_of_le_of_le + parseval_ratio_ge_one + tendsto_one_div_add_atTop_nhds_zero_nat gives the squeeze"
     ],
     "mathlibGaps": [
       "Integration on unit circle (for Parseval)"
     ],
     "nextSteps": [],
-    "markdown": "# Erd\u0151s #1150 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erdős #1150 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -67,16 +70,16 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:24:55.487Z",
-  "lastUpdate": "2026-03-13T07:52:17.058Z",
+  "lastUpdate": "2026-03-28T08:15:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1150Problem.lean",
       "filename": "Erdos1150Problem.lean",
-      "lineCount": 271,
-      "theoremCount": 6,
-      "axiomCount": 5,
+      "lineCount": 327,
+      "theoremCount": 8,
+      "axiomCount": 4,
       "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Proved `no_ultraflat_implies_conjecture`: the backward direction of the ultraflat equivalence
- Eliminated 1 axiom (5→4), completing the full equivalence: Conjecture ↔ no ultraflat ±1 sequences
- Proof: contrapositive diagonal extraction + squeeze theorem using `Filter.frequently_atTop`, `parseval_ratio_ge_one`, and `tendsto_of_tendsto_of_tendsto_of_le_of_le'`

## Progress
- `proofs/Proofs/Erdos1150Problem.lean`: axiom → theorem (327 lines, 4 axioms, 8 theorems, 0 sorries)
- `src/data/proofs/erdos-1150/meta.json`: updated axiom count, contributions, summary
- `src/data/research/problems/erdos-1150.json`: updated knowledge and iteration
- `research/problems/erdos-1150/knowledge.md`: added session 5 notes

## Findings
- No dependent choice needed: `Filter.frequently_atTop` gives `∃ m ≥ k` directly
- `parseval_ratio_ge_one` (session 4) was essential for the squeeze lower bound
- Remaining 4 axioms are genuinely deep: Parseval (circle integration), BBMST (2019 breakthrough), Kahane (1980), Rudin-Shapiro (constructive but substantial)

## Status
**Outcome**: progress (axiom elimination)
**Next Steps**: Prove `rudin_shapiro_bound` (constructive recursive construction)

**Note**: Docker was unavailable for local build verification. CI will validate.

🤖 Generated by researcher-3