### PR TITLE
Research: erdos-896 — eliminate 2 axioms (3→1)

### DIFF
--- a/proofs/Proofs/Erdos896Problem.lean
+++ b/proofs/Proofs/Erdos896Problem.lean
@@ -43,13 +43,35 @@ def SubsetsOfRange (A B : Finset ℕ) (N : ℕ) : Prop :=
 ## Main Problem
 -/
 
-/-- The maximum of F(A,B) over all A, B ⊆ {1,...,N}. -/
-axiom maxUniqueProducts : ℕ → ℕ
+/-- The maximum of F(A,B) over all A, B ⊆ {1,...,N}.
+    Defined as the supremum of uniqueProductCount over the finite set
+    of all pairs of subsets. Since ℕ has OrderBot (⊥ = 0), Finset.sup
+    returns 0 for N = 0 (no subsets) and the actual maximum otherwise. -/
+noncomputable def maxUniqueProducts (N : ℕ) : ℕ :=
+  (Finset.powerset (Finset.Icc 1 N) ×ˢ Finset.powerset (Finset.Icc 1 N)).sup
+    (fun p : Finset ℕ × Finset ℕ => uniqueProductCount p.1 p.2)
 
-/-- maxUniqueProducts N is achieved by some pair (A, B). -/
-axiom maxUniqueProducts_achieved (N : ℕ) :
+/-- maxUniqueProducts N is achieved by some pair (A, B).
+    Proof: The set of subset pairs is finite and nonempty (contains (∅, ∅)).
+    By Finset.exists_max_image, the maximum is achieved. -/
+theorem maxUniqueProducts_achieved (N : ℕ) :
     ∃ A B : Finset ℕ, SubsetsOfRange A B N ∧
-      uniqueProductCount A B = maxUniqueProducts N
+      uniqueProductCount A B = maxUniqueProducts N := by
+  unfold maxUniqueProducts
+  set pairs := Finset.powerset (Finset.Icc 1 N) ×ˢ Finset.powerset (Finset.Icc 1 N)
+  set f : Finset ℕ × Finset ℕ → ℕ := fun p => uniqueProductCount p.1 p.2
+  have hne : pairs.Nonempty :=
+    ⟨(∅, ∅), Finset.mem_product.mpr
+      ⟨Finset.empty_mem_powerset _, Finset.empty_mem_powerset _⟩⟩
+  obtain ⟨⟨A, B⟩, hmem, hmax⟩ := Finset.exists_max_image pairs f hne
+  refine ⟨A, B, ?_, ?_⟩
+  · -- SubsetsOfRange: (A, B) ∈ pairs means A, B ⊆ Icc 1 N
+    exact ⟨Finset.mem_powerset.mp (Finset.mem_product.mp hmem).1,
+           Finset.mem_powerset.mp (Finset.mem_product.mp hmem).2⟩
+  · -- The sup equals f at the maximizer
+    exact (le_antisymm
+      (Finset.sup_le fun y hy => hmax y hy)
+      (Finset.le_sup hmem)).symm
 
 /-- Erdős Problem 896: Estimate max_{A,B ⊆ {1,...,N}} F(A,B).
     The problem asks for the asymptotic order of this maximum. -/

--- a/src/data/proofs/erdos-896/meta.json
+++ b/src/data/proofs/erdos-896/meta.json
@@ -36,16 +36,17 @@
     ],
     "originalContributions": [
       "Defined reprCount and uniqueProductCount computationally",
-      "Axiomatized maxUniqueProducts with existence witness",
+      "Defined maxUniqueProducts via Finset.sup over all subset pairs",
+      "Proved maxUniqueProducts_achieved via Finset.exists_max_image",
       "Stated Van Doorn's lower bound (1+o(1))N²/log N",
       "Stated Van Doorn's upper bound with exponent δ ≈ 0.086",
       "Proved uniqueProductCount_le_product (trivial upper bound)",
       "Proved uniqueProductCount_empty_left",
       "Stated ExactOrderConjecture and van_doorn_implies_lower"
     ],
-    "axiomCount": 3,
-    "lineCount": 182,
-    "assumptions": "3 axiom(s): maxUniqueProducts, maxUniqueProducts_achieved, van_doorn_bounds. See Lean source for complete statements."
+    "axiomCount": 1,
+    "lineCount": 204,
+    "assumptions": "1 axiom: van_doorn_bounds (deep result). maxUniqueProducts defined via Finset.sup, achievability proved."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #896: Unique Product Representations**\n\nPaul Erdős posed this problem in 1972 [Er72, p. 81], asking: for $A, B \\subseteq \\{1, \\ldots, N\\}$, how many products $ab$ can have exactly one representation as such a product? The question lies at the intersection of multiplicative number theory and extremal combinatorics.\n\nThe problem is intimately connected to the **Erdős multiplication table problem** (Problem #490), which asks how many distinct products appear in the $N \\times N$ multiplication table. Kevin Ford (2008) resolved the multiplication table problem, showing the number of distinct products is $\\Theta(N^2/(\\log N)^\\delta (\\log\\log N)^{3/2})$ where $\\delta = 1 - (1 + \\log\\log 2)/\\log 2 \\approx 0.086$. The same exponent $\\delta$ appears in Problem #896's upper bound — this is no coincidence, as the distribution of the divisor function $d(n)$ governs both problems.\n\n**Van Doorn** established the best known bounds:\n- **Lower bound:** $(1 + o(1))N^2/\\log N \\leq \\max F(A,B)$. The construction uses sets $A, B$ of primes in $[N/2, N]$, where products of distinct primes automatically have unique factorization.\n- **Upper bound:** $\\max F(A,B) \\ll N^2/(\\log N)^\\delta \\cdot (\\log\\log N)^{3/2}$ with $\\delta \\approx 0.086$. This relies on estimates for the number of integers with exactly one divisor in a given range.\n\nThe gap between the exponents — $1$ in the lower bound versus $\\approx 0.086$ in the upper bound — remains the central open question. The **Exact Order Conjecture** asserts that the true answer is $\\Theta(N^2/\\log N)$, which would mean the prime-based construction is asymptotically optimal.\n\nThe problem also connects to Erdős and Szemerédi's work on sum-product phenomena: understanding when arithmetic operations on finite sets produce few collisions is a fundamental theme in additive combinatorics.",

--- a/src/data/research/problems/erdos-896.json
+++ b/src/data/research/problems/erdos-896.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-15T11:22:53.229Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Session 2: Eliminated 2 axioms (3→1). maxUniqueProducts defined via Finset.sup, achievability proved.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,19 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PROGRESS: 7 theorems, 1 axiom. Eliminated maxUniqueProducts + maxUniqueProducts_achieved axioms.",
     "builtItems": [
       "reprCount_comm: reprCount A B m = reprCount B A m (via Finset.card_bij)",
       "uniqueProductCount_comm: PROVED (was axiom) F(A,B) = F(B,A)",
       "theorem reprCount_comm: symmetric representation count (Erdos896Problem.lean)",
-      "theorem uniqueProductCount_comm: F(A,B) = F(B,A) - eliminated 1 axiom"
+      "theorem uniqueProductCount_comm: F(A,B) = F(B,A) - eliminated 1 axiom",
+      "maxUniqueProducts: replaced axiom with noncomputable def via Finset.sup over powerset pairs",
+      "maxUniqueProducts_achieved: proved via Finset.exists_max_image on nonempty finite set"
     ],
     "insights": [
       "uniqueProductCount_comm proved by showing reprCount is symmetric (Finset.card_bij with swap) then image sets are equal (mul_comm)",
       "Pre-existing Mathlib breakage: |>.card calc chain syntax no longer works, fixed by using parentheses",
       "Remaining 3 axioms: maxUniqueProducts (function def), maxUniqueProducts_achieved (existence), van_doorn_bounds (deep result)",
       "reprCount_comm proved via Finset.card_bij with swap (a,b)↦(b,a)",
-      "uniqueProductCount_comm proved: image sets equal by mul_comm, filter conditions match by reprCount_comm"
+      "uniqueProductCount_comm proved: image sets equal by mul_comm, filter conditions match by reprCount_comm",
+      "maxUniqueProducts is just a finite max over all subset pairs — no need for axiom",
+      "Finset.sup with OrderBot ℕ handles the definition cleanly",
+      "Finset.exists_max_image gives the achievability for free"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -61,16 +66,16 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:22:53.229Z",
-  "lastUpdate": "2026-03-13T07:52:17.054Z",
+  "lastUpdate": "2026-03-28T08:30:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos896Problem.lean",
       "filename": "Erdos896Problem.lean",
-      "lineCount": 183,
-      "theoremCount": 6,
-      "axiomCount": 3,
+      "lineCount": 204,
+      "theoremCount": 7,
+      "axiomCount": 1,
       "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Replaced `axiom maxUniqueProducts` with `noncomputable def` using `Finset.sup` over all pairs of subsets of {1,...,N}
- Proved `maxUniqueProducts_achieved` using `Finset.exists_max_image` on the nonempty finite set
- Eliminated 2 axioms (3→1). Only `van_doorn_bounds` remains (deep external result)

## Progress
- `proofs/Proofs/Erdos896Problem.lean`: 2 axioms → 1 def + 1 theorem (204 lines, 1 axiom, 7 theorems)
- `src/data/proofs/erdos-896/meta.json`: updated axiom count and contributions
- `src/data/research/problems/erdos-896.json`: updated knowledge

## Findings
- `maxUniqueProducts` was needlessly axiomatized — it's just a finite max over subset pairs
- `Finset.sup` with `OrderBot ℕ` handles the definition, `Finset.exists_max_image` gives achievability

## Status
**Outcome**: progress (axiom elimination)

**Note**: Docker unavailable for local build verification. CI will validate.

🤖 Generated by researcher-3