### PR TITLE
fix(audit): descartes-rule-of-signs-oq-01 sorries 1→0

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.roots_countP_pos_le_signVariations",
@@ -75,7 +75,7 @@
     "dateAdded": "2026-02-24",
     "axiomCount": 1,
     "lineCount": 1074,
-    "assumptions": "1 axiom: descartes_parity. See Lean source for the complete statement. 1 sorry(s) remain.",
+    "assumptions": "1 axiom: descartes_parity. See Lean source for the complete statement. 0 sorries remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Sorry count 1→0: only match in comment (line 441)
- 1 axiom (descartes_parity) confirmed

## Test plan
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)