### PR TITLE
fix(audit): inverse-galois sorries 14→2

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -26,7 +26,7 @@
       "Proofs/AbelRuffini.lean"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 2,
     "axiomCount": 3,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
@@ -34,7 +34,7 @@
       "Group theory (symmetric and alternating groups, Sylow theorems, solvability)",
       "Algebraic number theory (Eisenstein criterion, Dedekind's theorem)"
     ],
-    "assumptions": "3 axiom declarations across 2 files: abelian_realizable, shafarevich_theorem (InverseGalois.lean), three_dvd_gal_card (InverseGaloisA5.lean). 14 sorry(s).",
+    "assumptions": "3 axiom declarations across 2 files: abelian_realizable, shafarevich_theorem (InverseGalois.lean), three_dvd_gal_card (InverseGaloisA5.lean). 2 sorries: inverse_galois_problem (line 77, open problem), symmetric_group_realizable (line 364, Hilbert irreducibility).",
     "leanFile": {
       "lineCount": 1881,
       "theoremCount": 107,


### PR DESCRIPTION
## Summary
- Sorry count 14→2: of 14 grep matches, only 2 are actual sorry in proof code
  - Line 77: `inverse_galois_problem` (intentional — open problem)
  - Line 364: `symmetric_group_realizable` (Hilbert irreducibility, not in Mathlib)
- Remaining 12 matches are in comments/docstrings ("no sorry", "sorry-free", etc.)
- 3 axioms confirmed across 2 files: abelian_realizable, shafarevich_theorem, three_dvd_gal_card

## Test plan
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)