### PR TITLE
fix(audit): hodge-conjecture sorries 1→0

### DIFF
--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -14,9 +14,9 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 49,
-    "assumptions": "49 axiom declarations (down from 101) encoding Hodge structures, known cases (Lefschetz 1,1, abelian varieties, K3, top codimension), categorical operations, motives, p-adic Hodge theory, counterexamples (Atiyah-Hirzebruch, Voisin, Totaro), and related conjectures. 3 unused axioms removed (tateTwist, tateStructure, deligne_cycle_class). The Hodge Conjecture itself remains open. 1 sorry(s) remain.",
+    "assumptions": "49 axiom declarations (down from 101) encoding Hodge structures, known cases (Lefschetz 1,1, abelian varieties, K3, top codimension), categorical operations, motives, p-adic Hodge theory, counterexamples (Atiyah-Hirzebruch, Voisin, Totaro), and related conjectures. 3 unused axioms removed (tateTwist, tateStructure, deligne_cycle_class). The Hodge Conjecture itself remains open. 0 sorries remain.",
     "mathlibDependencies": [],
     "originalContributions": [
       "Abstract Hodge structures with complexification maps",


### PR DESCRIPTION
## Summary
- Sorry count 1→0: only match in comment (line 6890: "PROVED (no sorry, no axiom)")
- 49 axioms confirmed (Millennium Prize — axiomatized formalization)

## Test plan
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit (Millennium Prize — HIGH risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)