### PR TITLE
Research: erdos-302 + erdos-232 — prove 2 more theorems

### DIFF
--- a/proofs/Proofs/Erdos232Problem.lean
+++ b/proofs/Proofs/Erdos232Problem.lean
@@ -171,7 +171,14 @@ theorem translation_disjoint (A : Set (EuclideanSpace ℝ (Fin 2)))
     (u : EuclideanSpace ℝ (Fin 2))
     (hu : ‖u‖ = 1) :
     A ∩ ({x | x - u ∈ A}) = ∅ := by
-  sorry
+  ext x
+  simp only [Set.mem_inter_iff, Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
+  rintro ⟨hx, hxu⟩
+  have heq : x = x - u := hA x (x - u) hx hxu (by
+    simp only [IsUnitDistance, euclideanDist, dist_eq_norm, sub_sub_cancel]; exact hu)
+  have h0 := sub_eq_zero.mpr heq
+  rw [sub_sub_cancel] at h0
+  simp [h0] at hu
 
 /-
 ## Part VII: Lower Bounds (Constructions)

--- a/proofs/Proofs/Erdos302Problem.lean
+++ b/proofs/Proofs/Erdos302Problem.lean
@@ -43,7 +43,17 @@ def UnitFractionSum (a b c : ℕ) : Prop :=
 /-- Equivalent form: bc = a(b + c) -/
 theorem unit_fraction_equiv (a b c : ℕ) (ha : a > 0) (hb : b > 0) (hc : c > 0) :
     (1 : ℚ) / a = (1 : ℚ) / b + (1 : ℚ) / c ↔ b * c = a * (b + c) := by
-  sorry
+  have ha' : (a : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  have hb' : (b : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  have hc' : (c : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  constructor
+  · intro h
+    have : (↑(b * c) : ℚ) = ↑(a * (b + c)) := by
+      field_simp at h; linarith
+    exact_mod_cast this
+  · intro h
+    have : (↑(b * c) : ℚ) = ↑(a * (b + c)) := by exact_mod_cast h
+    field_simp; linarith
 
 /-- A set is sum-free for unit fractions if no three distinct elements satisfy 1/a = 1/b + 1/c -/
 def IsUnitFractionSumFree (A : Finset ℕ) : Prop :=


### PR DESCRIPTION
## Summary
Eliminate 2 sorries across 2 proof files.

### Erdos302Problem.lean (Unit Fraction Sums) — 1 sorry eliminated
- `unit_fraction_equiv`: 1/a = 1/b + 1/c ↔ b*c = a*(b+c)
- Proof via `field_simp` + `exact_mod_cast` for ℚ↔ℕ bridge
- **9S 6A -> 8S 6A**

### Erdos232Problem.lean (Unit Distance Chromatic Number) — 1 sorry eliminated
- `translation_disjoint`: A ∩ (A-u) = ∅ for unit-distance-free A and |u|=1
- Proof: any x in intersection gives dist(x, x-u) = |u| = 1, forcing x = x-u, so u = 0, contradiction
- **5S 5A -> 4S 5A**

## Test plan
- [ ] Docker build for Erdos302Problem
- [ ] Docker build for Erdos232Problem

Generated by researcher-2