### PR TITLE
Gallery integrity: fix shapley-folkman sorry count and line count

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "formalized",
-    "sorries": 5,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 148,
+    "lineCount": 158,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -79,7 +79,7 @@
         "Pointwise"
       ],
       "namespace": "ShapleyFolkman",
-      "lineCount": 148,
+      "lineCount": 158,
       "axiomCount": 0,
       "theoremCount": 5,
       "definitionCount": 2
@@ -89,7 +89,7 @@
   "overview": {
     "historicalContext": "The Shapley-Folkman lemma originated in 1966 from an exchange between Lloyd Shapley and Jon Folkman at the RAND Corporation. Shapley posed the question of bounding non-convexity in sums; Folkman provided the proof. The result was not published by either author but was communicated by Ross Starr, who applied it to prove that large economies have near-equilibria even when individual preferences are non-convex.\n\nStartr's 1969 paper 'Quasi-Equilibria in Markets with Non-Convex Preferences' in Econometrica brought the lemma to prominence in economics. The quantitative form (Shapley-Folkman-Starr theorem) bounds the Hausdorff distance between a Minkowski sum and its convex hull.\n\nThe lemma is standard in mathematical economics but remarkably little-known in pure mathematics, despite being elementary. Its proof uses the same Caratheodory reduction technique that underlies Caratheodory's and Radon's theorems. Starr called it 'one of the most useful results in convex analysis' for economics.\n\nAnderson (1978) used it to prove core convergence theorems. Mas-Colell (1978) applied it to existence of competitive equilibria. It remains a workhorse in general equilibrium theory, mechanism design, and optimization.",
     "problemStatement": "**Shapley-Folkman Lemma**: Let $S_1, \\ldots, S_N$ be nonempty subsets of $\\mathbb{R}^d$. For any point $x \\in \\text{conv}(S_1 + S_2 + \\cdots + S_N)$, there exist $x_i \\in \\text{conv}(S_i)$ with $\\sum x_i = x$ such that $x_i \\in S_i$ for all but at most $d$ indices $i$.\n\nEquivalently: the Minkowski sum of convex hulls is 'almost' the convex hull of the Minkowski sum, with the error controlled by the ambient dimension rather than the number of summands.",
-    "text": "A formalization of the Shapley-Folkman lemma in 148 lines. The proof is structured around Caratheodory's reduction: among all decompositions $x = \\sum x_i$ with $x_i \\in \\text{conv}(S_i)$, choose one minimizing total Caratheodory vertices. If more than $d$ summands require convexification ($x_i \\notin S_i$), the excess vertices are affinely dependent (dimension argument), enabling a reduction that contradicts minimality. Includes a `Decomposition` structure recording the summand choices, the main theorem `shapley_folkman` bounding excess indices by `Module.finrank`, and corollaries for the Shapley-Folkman-Starr qualitative bound and the economic application to repeated sums.",
+    "text": "A formalization of the Shapley-Folkman lemma in 158 lines. The proof is structured around Caratheodory's reduction: among all decompositions $x = \\sum x_i$ with $x_i \\in \\text{conv}(S_i)$, choose one minimizing total Caratheodory vertices. If more than $d$ summands require convexification ($x_i \\notin S_i$), the excess vertices are affinely dependent (dimension argument), enabling a reduction that contradicts minimality. Includes a `Decomposition` structure recording the summand choices, the main theorem `shapley_folkman` bounding excess indices by `Module.finrank`, and corollaries for the Shapley-Folkman-Starr qualitative bound and the economic application to repeated sums.",
     "proofStrategy": "The proof proceeds by a minimality argument mirroring Caratheodory's theorem:\n\n1. **Existence of decomposition**: Since $x \\in \\sum \\text{conv}(S_i)$, write $x = \\sum x_i$ with $x_i \\in \\text{conv}(S_i)$.\n\n2. **Caratheodory representation**: By Caratheodory's theorem, each $x_i$ is a convex combination of at most $d + 1$ points from $S_i$.\n\n3. **Choose minimal representation**: Among all such decompositions, choose one minimizing the total number of vertices across all Caratheodory representations.\n\n4. **Count excess vertices**: If $x_i \\notin S_i$, then $x_i$ needs at least 2 vertices. Call this index 'excess'. Each excess index contributes $\\geq 1$ extra vertex beyond the 1-vertex minimum.\n\n5. **Dimension bound**: If there are $> d$ excess indices, collect one extra vertex from each. These $> d$ vectors in $\\mathbb{R}^d$ must be affinely dependent.\n\n6. **Reduction via dependence**: The affine dependence lets us shift weights between the excess representations, strictly reducing the total vertex count while maintaining the constraint $\\sum x_i = x$. This contradicts minimality.\n\n7. **Conclusion**: At most $d$ indices can be excess.",
     "keyInsights": [
       "**Dimension controls non-convexity, not the number of sets**: The bound $d = \\dim(E)$ is independent of $N$. Adding more sets to the Minkowski sum does not increase the convexification error. This is why large economies (many agents) are nearly convex even if individual preferences are not.",
@@ -142,7 +142,7 @@
       "id": "corollaries",
       "title": "Part 4: Corollaries",
       "startLine": 121,
-      "endLine": 148,
+      "endLine": 158,
       "summary": "Two corollaries: (1) the qualitative Shapley-Folkman-Starr form for points in conv(sum Si); (2) the economic application for n-fold sums of a single set, showing that large averages are nearly convex regardless of n.",
       "mathContext": "Corollary 1: $x \\in \\text{conv}(\\sum S_i) \\Rightarrow x = \\sum f_i$ with at most $d$ non-original terms. Corollary 2: For $x \\in \\text{conv}(nS)$, at most $d$ of the $n$ terms need convexification. As $n \\to \\infty$, fraction $d/n \\to 0$."
     }
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 148,
+    "lineCount": 158,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 5,


### PR DESCRIPTION
## Summary

- **Sorry count**: meta.json claimed 5 sorries but actual count is 4. The theorem `excess_vertices_affine_dependent` was proved in a recent commit but meta.json was not updated.
- **Line count**: meta.json claimed 148 lines in multiple locations but the actual Lean file is 158 lines. Updated all instances (meta.lineCount, meta.leanFile.lineCount, top-level leanFile.lineCount, overview text, and corollaries section endLine).

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)