### PR TITLE
Gallery integrity: fix sorry/axiom/line counts for 5 proofs

### DIFF
--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "erdosNumber": 277,
     "erdosUrl": "https://erdosproblems.com/277",
     "erdosProblemStatus": "solved",
@@ -60,8 +60,8 @@
       "IsHighlyComposite, IsSuperabundant: related concepts"
     ],
     "axiomCount": 6,
-    "lineCount": 294,
-    "assumptions": "6 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "lineCount": 296,
+    "assumptions": "6 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Covering systems of congruences were introduced by Erdős in 1950 in his proof that there exist odd integers not representable as a prime plus a power of 2. The concept became central to his research program in combinatorial number theory. In the 1970s, Erdős formulated Problem #277 as part of a cluster of questions (#273-#279) exploring the interplay between covering systems and number-theoretic properties.\n\nThe problem connects two classical threads: the sum of divisors function $\\sigma(n) = \\sum_{d \\mid n} d$, studied since Euler, and the combinatorics of congruence coverings. Gronwall (1913) proved $\\limsup \\sigma(n)/(n \\ln\\ln n) = e^\\gamma$, showing highly abundant numbers exist at every threshold. The question is whether such numbers can simultaneously resist being covered.\n\nJ.A. Haight resolved the problem in 1979 ('Covering systems of congruences, a negative result', Mathematika 26, 53-61). His constructive proof builds $n$ as a product of carefully chosen large primes, ensuring high abundancy while structurally preventing any covering system from using only divisors of $n$ as moduli. The key insight exploits the reciprocal sum constraint: a covering system with distinct moduli $m_1, \\ldots, m_k$ requires $\\sum 1/m_i \\geq 1$, but Haight's numbers have divisors too sparse to satisfy this.\n\nThe result connects to Ramanujan's highly composite numbers (1915), Alaoglu and Erdős's superabundant numbers (1944), and later work by Hough (2015) resolving Erdős's minimum modulus conjecture for covering systems with distinct moduli.",
@@ -274,7 +274,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos277",
-    "lineCount": 294,
+    "lineCount": 296,
     "axiomCount": 6,
     "theoremCount": 11,
     "definitionCount": 22

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -193,7 +193,7 @@
       "title": "Density Considerations",
       "summary": "If special n exist, their count is at most x/log x (zero density). Asks whether density is even x^α for α < 1.",
       "startLine": 199,
-      "endLine": 248,
+      "endLine": 251,
       "mathContext": "Mathematical content: If special n exist, their count is at most x/log x (zero density). Asks whether density is even x^α for α < 1."
     }
   ],

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -27,14 +27,14 @@
     ],
     "badge": "axiom",
     "sorries": 2,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Cyclotomic fields and Kronecker-Weber theorem",
       "Group theory (symmetric and alternating groups, Sylow theorems, solvability)",
       "Algebraic number theory (Eisenstein criterion, Dedekind's theorem)"
     ],
-    "assumptions": "3 axiom declarations across 2 files: abelian_realizable, shafarevich_theorem (InverseGalois.lean), three_dvd_gal_card (InverseGaloisA5.lean). 2 sorries: inverse_galois_problem (line 77, open problem), symmetric_group_realizable (line 364, Hilbert irreducibility).",
+    "assumptions": "2 axiom declarations: abelian_realizable, shafarevich_theorem (InverseGalois.lean). 2 sorries: inverse_galois_problem (line 77, open problem), symmetric_group_realizable (line 364, Hilbert irreducibility).",
     "leanFile": {
       "lineCount": 1881,
       "theoremCount": 107,


### PR DESCRIPTION
## Summary
- Fix stale sorry/axiom/line counts in 5 proof meta.json files
- Root cause: researcher commits eliminated sorries and axioms but didn't update gallery metadata
- erdos-382 is highest severity: claimed 0 sorries but actually has 3

## Affected proofs
- erdos-679: sorry 14→11, lines 248→251
- erdos-382: sorry 0→3, axiomCount 4/5→3, lines 490→509
- erdos-277: sorry 4→2, lines 294→296
- morleys-theorem: sorry 1→0, axiomCount 2→1, lines 352→384
- inverse-galois: axiomCount 3→2

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Spot-check corrected values against Lean source files

Discovered during gallery integrity audit.