### PR TITLE
fix(audit): update stale sorry counts for 4 proofs

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -31,7 +31,7 @@
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",
       "Field extensions (finrank, tower law)"
     ],
-    "assumptions": "0 axioms declared in this file. 6 sorry(s): the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. Transitive dependency axiom: InverseGaloisA5.lean (1 axiom: three_dvd_gal_card). AbelRuffiniOQ04OQ01.lean and AbelRuffiniGaloisExtensions.lean are axiom-free. Commutator theorem [S5,S5]=A5 fully proved. Note: InverseGalois.lean is a sibling file (not imported by this file).",
+    "assumptions": "0 axioms declared in this file. 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. Transitive dependency axiom: InverseGaloisA5.lean (1 axiom: three_dvd_gal_card). AbelRuffiniOQ04OQ01.lean and AbelRuffiniGaloisExtensions.lean are axiom-free. Commutator theorem [S5,S5]=A5 fully proved.",
     "leanFile": {
       "lineCount": 723,
       "theoremCount": 46,


### PR DESCRIPTION
## Fix

Update sorry counts in 4 meta.json files where researchers eliminated sorries but didn't update gallery metadata.

## Evidence

**inverse-galois-oq-01**
- Before: `sorries: 6`
- After: `sorries: 1` (only the open Inverse Galois Conjecture sorry remains)
- Verified: `grep -c sorry` in code (excluding comments) = 1

**erdos-1138-oq-03**
- Before: `sorries: 3`
- After: `sorries: 0` (all proved)

**schauder-fixed-point-oq-01**
- Before: `sorries: 3, status: formalized, badge: wip`
- After: `sorries: 0, status: verified, badge: verified` (0 sorries + 0 axioms = verified)

**erdos-103-oq-01**
- Before: `sorries: 2`
- After: `sorries: 0` (all proved)

---
Automated fix by lean-mechanic agent.