### PR TITLE
fix(audit): update stale lineCount for 25 proofs

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -29,7 +29,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 3,
-    "lineCount": 172,
+    "lineCount": 329,
     "assumptions": "3 axioms (minAdmissibleDiameter values for k=2,3,50) and 2 sorries. Previously 4 axioms; maynard_under_eh proved as theorem from minAdmissibleDiameter_3.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -55,7 +55,7 @@
       "exceeds_turan_has_triangle: corollary of Turán's theorem"
     ],
     "axiomCount": 8,
-    "lineCount": 194,
+    "lineCount": 216,
     "assumptions": "8 axioms: boundFunction, gyori_theorem, gyori_bound, and 5 more. See Lean source for complete statements."
   },
   "overview": {

--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -47,7 +47,7 @@
       "Stated Erdős–Purdy origin connection"
     ],
     "axiomCount": 5,
-    "lineCount": 154,
+    "lineCount": 196,
     "assumptions": "5 axiom(s): 1 open conjecture (erdos_102_divergence), 4 deep results. erdos_purdy_connection PROVED: rich lines existing implies some line has ≥4 points."
   },
   "overview": {

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/1092",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 141,
+    "lineCount": 162,
     "assumptions": "None. All axioms removed: rodl_upper_bound (unused), f_trivial_lower (FALSE), erdos_744_connection (FALSE), Questions 1&2 (disproved by Rödl).",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1144/meta.json
+++ b/src/data/proofs/erdos-1144/meta.json
@@ -66,7 +66,7 @@
       "conjecture_and_atherfold_pinch"
     ],
     "axiomCount": 1,
-    "lineCount": 175,
+    "lineCount": 205,
     "assumptions": "1 axiom(s) and 1 sorry(s)."
   },
   "overview": {

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -59,7 +59,7 @@
       "gEps_mono: monotonicity in ε"
     ],
     "axiomCount": 6,
-    "lineCount": 218,
+    "lineCount": 276,
     "assumptions": "6 axiom(s): gEps (abstract function), trivial_lower_bound, erdos_renyi_upper, erdos_hall_upper, main_asymptotic, gEps_mono. gEps_pos proved from trivial_lower_bound. 2 sorries remain: logloglog_div_loglog_tendsto_zero (line 233), main_asymptotic_derived squeeze step (line 265).",
     "theoremCount": 5
   },

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -61,7 +61,7 @@
       "ramseyC4Kn_ge theorem: trivial lower bound R ≥ n proved from specification (was axiom)"
     ],
     "axiomCount": 2,
-    "lineCount": 185,
+    "lineCount": 224,
     "assumptions": "2 axioms: szemeredi_upper (Szemerédi upper bound), spencer_lower (Spencer lower bound). The Ramsey function ramseyC4Kn and its threshold specification are now defined/proved from the finite Ramsey theorem via Nat.find."
   },
   "overview": {

--- a/src/data/proofs/erdos-181/meta.json
+++ b/src/data/proofs/erdos-181/meta.json
@@ -62,7 +62,7 @@
       "ramseyNumber_zero_eq: exact computation R(Q_0) = 1"
     ],
     "axiomCount": 3,
-    "lineCount": 263,
+    "lineCount": 382,
     "assumptions": "3 axioms: erdos_181_conjecture (OPEN conjecture), tikhomirov_2022 (2022 best upper bound), lower_bound (trivial lower bound from vertex count). trivial_upper_bound was proved from tikhomirov_2022."
   },
   "overview": {

--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/201",
     "erdosProblemStatus": "open",
     "axiomCount": 5,
-    "lineCount": 264,
+    "lineCount": 315,
     "assumptions": "5 axioms: g3_5_eq, r3_5_eq, g3_14_le, r3_14_eq (computational), komlos_sulyok_szemeredi (deep). gk defined via sSup, gk_le_rk proved.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -33,7 +33,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 309,
+    "lineCount": 351,
     "assumptions": "3 axioms: borwein_loring_family (provable constructive result), tengely_ulas_zygadlo (computational verification), ErdosProblem261_all (open conjecture). 2 former axioms (continuum/two_reps) proved trivially due to incomplete IsInfiniteRep definition.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-352/meta.json
+++ b/src/data/proofs/erdos-352/meta.json
@@ -54,7 +54,7 @@
       "Reduction to finite unions of compact convex interiors"
     ],
     "axiomCount": 0,
-    "lineCount": 200,
+    "lineCount": 235,
     "assumptions": "0 axioms, 0 sorries. All supporting theorems fully proved. Main conjecture stated as definition (open problem)."
   },
   "overview": {

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/374",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 128,
+    "lineCount": 195,
     "dateAdded": "2026-02-10",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-421/meta.json
+++ b/src/data/proofs/erdos-421/meta.json
@@ -61,7 +61,7 @@
       "selfridge_construction axiom"
     ],
     "axiomCount": 1,
-    "lineCount": 237,
+    "lineCount": 430,
     "assumptions": "1 axiom: selfridge_construction. See Lean source for the complete statement."
   },
   "overview": {

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/533",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 222,
+    "lineCount": 265,
     "assumptions": "3 axioms: ehsss_result (EHSSS partial result, used), k4_free_triangle_free_subset (K4-free case, used), erdos_533_conjecture (OPEN). erdos_rogers_counterexample removed (unused).",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/687",
     "erdosProblemStatus": "open",
     "axiomCount": 5,
-    "lineCount": 274,
+    "lineCount": 358,
     "assumptions": "6 axioms: jacobsthalSet_bddAbove, jacobsthalY_eq_jacobsthal, erdos_687_conjecture, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -77,7 +77,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 195,
+    "lineCount": 371,
     "assumptions": "2 axioms and 1 sorry (decomp_pieces_le_edges at line 156)."
   },
   "overview": {

--- a/src/data/proofs/erdos-726/meta.json
+++ b/src/data/proofs/erdos-726/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "6 axioms: mertens_theorem, erdos_726_conjecture, upper_half_count, and 3 more. See Lean source for complete statements.",
     "proofRepoPath": "Proofs/Erdos726Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 224
+    "lineCount": 316
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -84,7 +84,7 @@
       "erdos_749_upper_variant: upper density version (proved via by_cases)"
     ],
     "axiomCount": 2,
-    "lineCount": 210,
+    "lineCount": 286,
     "assumptions": "2 axioms: sidon_set_density_zero (Sidon sets have zero upper density), erdos_turan_conjecture_28 (ET conjecture, open)."
   },
   "overview": {

--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -60,7 +60,7 @@
       "squares_contain_3AP: PROVED by explicit construction {1,25,49}={1²,5²,7²} with d=24 (was axiom)"
     ],
     "axiomCount": 4,
-    "lineCount": 271,
+    "lineCount": 294,
     "assumptions": "4 axiom(s): no_4AP_in_squares (Euler), question1_implies_question2 (Ramsey-type), BombieriLangConjecture (open), cilleruelo_granville (conditional). squares_contain_3AP was proved by explicit construction {1,25,49}."
   },
   "overview": {

--- a/src/data/proofs/erdos-827/meta.json
+++ b/src/data/proofs/erdos-827/meta.json
@@ -52,7 +52,7 @@
       "nk_three, nk_monotone, nk_ge_k: basic properties"
     ],
     "axiomCount": 6,
-    "lineCount": 135,
+    "lineCount": 177,
     "assumptions": "6 axioms: minimalNk (function), minimalNk_valid, minimalNk_sharp, martinez_roldan_pensado, nk_three, nk_ge_k. Proved: nk_monotone (from valid+sharp+subset argument)."
   },
   "overview": {

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -55,7 +55,7 @@
       "erdos_831_summary theorem: known bounds"
     ],
     "axiomCount": 1,
-    "lineCount": 281,
+    "lineCount": 398,
     "assumptions": "1 axiom: h_four_lower (h(4)≥2, used in summary theorem). All other axioms eliminated as unused."
   },
   "overview": {

--- a/src/data/proofs/erdos-861/meta.json
+++ b/src/data/proofs/erdos-861/meta.json
@@ -53,7 +53,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 6,
     "assumptions": "7 axiom declarations: sidon_equiv (two Sidon definitions equivalent), erdos_turan_sidon (f(N) ~ sqrt(N)), cameron_erdos_q1_true (A(N)/2^f(N) diverges), cameron_erdos_q2_false (exponent not 1+o(1)), saxton_thomason_lower_bound (2^{1.16f(N)} lower), klrs_upper_bound (2^{6.442f(N)} upper), extend_sidon (Sidon set extension)",
-    "lineCount": 255
+    "lineCount": 276
   },
   "overview": {
     "historicalContext": "This problem, posed by Cameron and Erdős, asks about counting Sidon sets (sets where all pairwise sums are distinct). It connects to additive combinatorics and the hypergraph container method. The problem appears as C9 in Guy's 'Unsolved Problems in Number Theory'. Sidon sets — also called B₂ sequences — were introduced by Simon Sidon in the 1930s in the context of Fourier analysis; Erdős and Turán proved in 1941 that the maximum Sidon subset of {1, …, N} has size ~√N, and constructions achieving this via Singer difference sets in finite fields were known by the 1940s. Cameron and Erdős posed their counting question in the early 1990s, anticipating that the exponential structure of 2^{f(N)} subsets would need to be understood more precisely. The 2015 resolution using the hypergraph container method of Balogh-Morris-Samotij and independently Saxton-Thomason represented a major breakthrough in counting sparse combinatorial structures.",

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -52,7 +52,7 @@
       "Axiomatized the reflected construction B ∪ (N − B) with B Sidon in {1,...,N/3}"
     ],
     "axiomCount": 1,
-    "lineCount": 700,
+    "lineCount": 755,
     "assumptions": "1 axiom: erdos_freud_lower_bound. Previously 2; sidon_upper_bound ELIMINATED by proving difference-counting bound (sidon_diff_counting_bound, sidon_card_sq_le_2N). reflected_construction_valid was proved as theorem in prior session.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -57,7 +57,7 @@
       "primes_mod_4_connection axiom: relation to primes ≡ 1 (mod 4)"
     ],
     "axiomCount": 4,
-    "lineCount": 245,
+    "lineCount": 395,
     "assumptions": "4 axioms: gaussian_prime_classification, tsuchimura, gaussian_prime_theorem, primes_mod_4_connection. jordan_rabung and gethner_et_al proved from tsuchimura. 1 sorry (definition)."
   },
   "overview": {

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -51,7 +51,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 352,
+      "lineCount": 384,
       "structures": 2,
       "axioms": 2,
       "theorems": 6,
@@ -59,7 +59,7 @@
       "instances": 0
     },
     "axiomCount": 2,
-    "lineCount": 352,
+    "lineCount": 384,
     "assumptions": "2 axiom(s): equilateral_side_length_axiom, morleys_theorem_axiom. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Batch-correct stale lineCount values in 25 meta.json files. Researchers expanded proofs without updating gallery metadata.

## Evidence

All 25 proofs had lineCount discrepancy of >= 20 lines vs actual Lean source. Largest mismatches:
- erdos-421: 237 → 430 (+193 lines)
- erdos-719: 195 → 371 (+176 lines)
- bounded-prime-gaps-oq-03-oq-01: 172 → 329 (+157 lines)
- erdos-952: 245 → 395 (+150 lines)

Values verified by counting actual lines in each Lean source file.

---
Automated fix by lean-mechanic agent.