### PR TITLE
Gallery integrity: fix sorry/line counts for erdos-302, erdos-232, erdos-35

### DIFF
--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -17,7 +17,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 232,
     "erdosUrl": "https://erdosproblems.com/232",
     "erdosProblemStatus": "solved",
@@ -68,8 +68,8 @@
       }
     ],
     "axiomCount": 9,
-    "lineCount": 333,
-    "assumptions": "9 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "lineCount": 340,
+    "assumptions": "9 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Moser's Problem on Unit-Distance-Avoiding Sets**\n\nLeo Moser posed this problem in 1966 in his collection of 'poorly formulated unsolved problems of combinatorial geometry,' a deliberately provocative title for a set of deceptively deep questions. The problem asks: given a measurable subset $A \\subseteq \\mathbb{R}^2$ containing no two points at Euclidean distance 1, how large can $A$ be in the sense of asymptotic upper density?\n\n**Early Progress (1960s-1970s):**\nThe trivial upper bound $m_1 \\leq 1/2$ follows from a translation argument: for any unit vector $u$, the sets $A$ and $A + u$ must be disjoint, so their combined density cannot exceed 1. For lower bounds, the hexagonal lattice construction -- placing open discs of radius $1/2$ at vertices of a suitably spaced hexagonal lattice -- achieves density $\\pi/(8\\sqrt{3}) \\approx 0.2267$. H.T. Croft improved this in 1967 to $m_1 \\geq 0.22936$ using a modified annular construction.\n\n**Stagnation (1970s-2020s):**\nFor over 50 years, neither the lower bound of 0.22936 nor the trivial upper bound of 1/2 was improved. The problem attracted attention because of its connection to the Hadwiger-Nelson problem (chromatic number of the plane), but the analytic techniques needed for the upper bound seemed out of reach.\n\n**Breakthrough (2023):**\nAmbrus, Csiszarik, Matolcsi, Varga, and Zsamboki proved $m_1 \\leq 0.247$ using Fourier-analytic methods inspired by Delsarte's linear programming bound from coding theory. Their approach studies the autocorrelation of the indicator function $\\mathbf{1}_A$ and exploits the vanishing of its Fourier transform on the unit circle. This definitively answered Erdos's question: YES, $m_1 \\leq 1/4$.\n\n**Current Status:** SOLVED. Best bounds: $0.22936 \\leq m_1 \\leq 0.247$, a gap of only $\\approx 0.018$. The exact value remains unknown.",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "Erdos232",
-    "lineCount": 333,
+    "lineCount": 340,
     "axiomCount": 9,
     "theoremCount": 11,
     "definitionCount": 8

--- a/src/data/proofs/erdos-302/meta.json
+++ b/src/data/proofs/erdos-302/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 8,
     "erdosNumber": 302,
     "erdosUrl": "https://erdosproblems.com/302",
     "erdosProblemStatus": "open",
@@ -76,8 +76,8 @@
       "Extremal combinatorics (density arguments)",
       "Asymptotic notation (o(1), liminf, limsup)"
     ],
-    "lineCount": 261,
-    "assumptions": "6 axiom(s) and 9 sorry(s). See the Lean source for details."
+    "lineCount": 271,
+    "assumptions": "6 axiom(s) and 8 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Unit Fraction Sum-Free Sets**\n\nErdős Problem #302 concerns the equation $\\frac{1}{a} = \\frac{1}{b} + \\frac{1}{c}$, which sits at the intersection of unit fraction theory and extremal combinatorics. The study of unit fraction decompositions traces back to ancient Egypt: the Rhind papyrus (c. 1650 BCE) represents fractions exclusively as sums of distinct unit fractions, and understanding which unit fraction equations have solutions has been a theme in number theory ever since.\n\nThe problem was posed by Erdős and Graham in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory* (Monographies de L'Enseignement Mathématique 28). They asked: if $f(N)$ denotes the size of the largest subset $A \\subseteq \\{1, \\ldots, N\\}$ containing no solution to $\\frac{1}{a} = \\frac{1}{b} + \\frac{1}{c}$ with distinct $a, b, c \\in A$, is it true that $f(N) = (\\frac{1}{2} + o(1))N$?\n\n**Historical Development:**\n- **1980 (Erdős-Graham):** Problem posed with the conjecture $f(N) = (\\frac{1}{2}+o(1))N$, motivated by two natural constructions (odd integers and the upper half $[N/2, N]$) both giving density $\\frac{1}{2}$.\n- **1991 (Brown-Rödl):** Solved the related coloring version (Problem #303): $\\{1, \\ldots, N\\}$ can always be 2-colored with no monochromatic solution.\n- **2023 (Cambie):** Disproved the original conjecture by combining odd integers $\\leq N/4$ with the interval $[N/2, N]$, yielding $f(N) \\geq (\\frac{5}{8}+o(1))N$.\n- **2023 (van Doorn):** Established the first non-trivial upper bound $f(N) \\leq (\\frac{9}{10}+o(1))N$ using structural analysis of solution-rich regions.\n\nThe problem remains open: the asymptotic density of $f(N)/N$ is known to lie in $[\\frac{5}{8}, \\frac{9}{10}] = [0.625, 0.9]$, but the exact value is unknown. This wide gap highlights the difficulty of extremal problems for multiplicative equations.",
@@ -234,7 +234,7 @@
     ],
     "opens": [],
     "namespace": "Erdos302",
-    "lineCount": 261,
+    "lineCount": 271,
     "axiomCount": 6,
     "theoremCount": 15,
     "definitionCount": 10

--- a/src/data/proofs/erdos-35/meta.json
+++ b/src/data/proofs/erdos-35/meta.json
@@ -24,7 +24,7 @@
     "erdosUrl": "https://erdosproblems.com/35",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 225,
+    "lineCount": 229,
     "prerequisites": [
       "Schnirelmann density and its properties",
       "Additive bases and Waring's problem",
@@ -140,7 +140,7 @@
       "Set"
     ],
     "namespace": "Erdos35",
-    "lineCount": 225,
+    "lineCount": 229,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 9


### PR DESCRIPTION
## Summary
- Fix stale sorry and line counts in 3 proof meta.json files
- Root cause: research commit ad855c88 proved theorems but didn't update gallery metadata

## Affected proofs
- erdos-302: sorry 9→8, lines 261→271
- erdos-232: sorry 2→1, lines 333→340
- erdos-35: lines 225→229 (sorry count already correct)

## Test plan
- [ ] Verify corrected values against Lean source files

Discovered during gallery integrity audit iteration 2.