### PR TITLE
Gallery integrity: fix sorry counts for 15 proofs (comment-aware audit)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",
@@ -184,7 +184,7 @@
       "Over finite fields $\\mathbb{F}_q$ with $q \\leq n$, the union avoidance lemma fails. What is the exact threshold: for which $(n, q)$ pairs does every nonderogatory $M \\in M_n(\\mathbb{F}_q)$ have a cyclic vector?"
     ]
   },
-  "sorryCount": 1,
+  "sorryCount": 0,
   "status": "formalized",
   "badge": "verified",
   "leanFile": {

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -22,7 +22,7 @@
       "millennium-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "LFunction_apply_one_ne_zero",

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.exists_prime_and_dvd",

--- a/src/data/proofs/erdos-103-oq-01/meta.json
+++ b/src/data/proofs/erdos-103-oq-01/meta.json
@@ -20,7 +20,7 @@
       "monotonicity"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "axioms": 3,
     "erdosNumber": 103,
     "erdosUrl": "https://erdosproblems.com/103",

--- a/src/data/proofs/erdos-1084-oq-01/meta.json
+++ b/src/data/proofs/erdos-1084-oq-01/meta.json
@@ -17,7 +17,7 @@
       "isoperimetric"
     ],
     "proofRepoPath": "Proofs/Erdos1084OQ01.lean",
-    "sorries": 1,
+    "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1084",
     "erdosUrl": "https://erdosproblems.com/1084",
     "axiomCount": 4,

--- a/src/data/proofs/erdos-1138-oq-03/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.bertrand",

--- a/src/data/proofs/erdos-131/meta.json
+++ b/src/data/proofs/erdos-131/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 131,
     "erdosUrl": "https://erdosproblems.com/131",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -17,7 +17,7 @@
       "solved"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 402,
     "erdosUrl": "https://erdosproblems.com/402",
     "erdosProblemStatus": "solved",
@@ -56,7 +56,7 @@
       "Aristotle: {1,2,4} counterexample falsifying equality characterization"
     ],
     "axiomCount": 0,
-    "lineCount": 327,
+    "lineCount": 328,
     "assumptions": "3 sorry(s)."
   },
   "overview": {
@@ -173,7 +173,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 327,
+    "lineCount": 328,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 5

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 60,
     "erdosUrl": "https://erdosproblems.com/60",
     "erdosProblemStatus": "open",
@@ -51,7 +51,7 @@
       "conjecture_implies_two_copies: Aristotle-proved implication"
     ],
     "axiomCount": 8,
-    "lineCount": 385,
+    "lineCount": 386,
     "prerequisites": [
       "Extremal graph theory (Turán-type problems)",
       "4-cycles (C₄) in graphs",
@@ -182,7 +182,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 385,
+    "lineCount": 386,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12

--- a/src/data/proofs/erdos-809/meta.json
+++ b/src/data/proofs/erdos-809/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 809,
     "erdosUrl": "https://erdosproblems.com/809",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 938,
     "erdosUrl": "https://erdosproblems.com/938",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
@@ -14,7 +14,7 @@
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusLebesgue.lean",
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 2,
     "assumptions": "2 axioms: Lebesgue FTC Part 1 (AC → a.e. differentiable) and Part 2 (integral of a.e. derivative = net change). 2 sorry(s) remaining.",
     "mathlibDependencies": [

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -24,7 +24,7 @@
       "Proofs/AbelRuffiniOQ04OQ01.lean"
     ],
     "badge": "formalized",
-    "sorries": 6,
+    "sorries": 1,
     "axiomCount": 1,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields, fixed fields)",

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -16,7 +16,7 @@
       "open-question"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 59,
+    "sorries": 58,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",


### PR DESCRIPTION
## Summary
- Fix sorry count mismatches in 15 proof meta.json files
- Root cause: meta.json sorry counts included `sorry` mentions in Lean comments (docstrings, status notes). A comment-aware counter finds the actual code sorry count is lower.
- Also fixes 2 minor line count mismatches (erdos-402, erdos-60)

## Potential status upgrades (for follow-up)
Three proofs now have 0 sorries + 0 axioms but still show `formalized/wip`:
- cayley-hamilton-minpoly-oq-05-oq-01
- dirichlets-theorem-oq-02
- schauder-fixed-point-oq-01
These may qualify for `verified` status pending True-stub and structure-assumption review.

## Test plan
- [ ] Verify corrected sorry counts match comment-aware grep of Lean source

Discovered during gallery integrity audit iteration 2.