### PR TITLE
fix(audit): erdos-679 sorry count 14→11, fix theorem/line counts

### DIFF
--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "wip",
-    "sorries": 14,
+    "sorries": 11,
     "erdosNumber": 679,
     "erdosUrl": "https://erdosproblems.com/679",
     "erdosProblemStatus": "open",
@@ -85,8 +85,8 @@
       "density_upper_bound: special n have density ≤ x/log x"
     ],
     "axiomCount": 0,
-    "lineCount": 248,
-    "assumptions": "0 axiom(s) and 14 sorry(s). See the Lean source for details.",
+    "lineCount": 251,
+    "assumptions": "0 axiom(s) and 11 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -278,9 +278,9 @@
       "Filter"
     ],
     "namespace": "Erdos679",
-    "lineCount": 248,
+    "lineCount": 251,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 18
   }
 }


### PR DESCRIPTION
## Summary

- **Sorry count**: 14→11 (actual grep count in Lean source)
- **Theorem count**: 15→16 (actual `^theorem` count)
- **Line count**: 248→251 (actual `wc -l`)
- **Assumptions string**: updated to match

## Evidence

```
$ grep -c sorry proofs/Proofs/Erdos679Problem.lean
11
$ grep -c "^theorem" proofs/Proofs/Erdos679Problem.lean
16
$ wc -l < proofs/Proofs/Erdos679Problem.lean
251
```

## Test plan

- [ ] `pnpm build` passes with corrected meta.json

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)