### PR TITLE
fix(audit): erdos-1162 sorry count 7→6, fix theorem/def/line counts

### DIFF
--- a/src/data/proofs/erdos-1162/meta.json
+++ b/src/data/proofs/erdos-1162/meta.json
@@ -17,7 +17,7 @@
       "asymptotic"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 6,
     "erdosNumber": 1162,
     "erdosUrl": "https://erdosproblems.com/1162",
     "erdosProblemStatus": "open",
@@ -56,8 +56,8 @@
       "erdos1162_asymptotic: formal statement of the asymptotic result"
     ],
     "axiomCount": 7,
-    "lineCount": 155,
-    "assumptions": "7 axioms: numSubgroups, numSubgroups_pos, pyber_theorem, numSubgroupsElem2, elem2_subgroup_count_asymptotic, most_subgroups_are_2groups, f4. 7 sorries: trivial_upper, roney_dougal_tracey, rdt_implies_pyber, f1, f2, f3, constant_explanation (proved)."
+    "lineCount": 162,
+    "assumptions": "7 axioms: numSubgroups, numSubgroups_pos, pyber_theorem, numSubgroupsElem2, elem2_subgroup_count_asymptotic, most_subgroups_are_2groups, f4. 6 sorries: trivial_upper, roney_dougal_tracey, rdt_implies_pyber, f1, f2, f3."
   },
   "overview": {
     "historicalContext": "Erdős and Turán posed the question of counting subgroups of the symmetric group S_n. Pyber (1993) established the order of magnitude: log f(n) is between c₁n² and c₂n² for positive constants c₁, c₂. The precise asymptotic was a long-standing open problem until Roney-Dougal and Tracey (2025) proved that log f(n) = (1/16 + o(1))n². The constant 1/16 = (1/4)² reflects that the dominant subgroups are elementary abelian 2-groups embedded via the wreath product (Z/2Z) ≀ S_{⌊n/4⌋}.",
@@ -204,9 +204,9 @@
       "Filter"
     ],
     "namespace": "Erdos1162",
-    "lineCount": 155,
+    "lineCount": 162,
     "axiomCount": 7,
-    "theoremCount": 9,
-    "definitionCount": 5
+    "theoremCount": 8,
+    "definitionCount": 4
   }
 }


### PR DESCRIPTION
## Summary

- **Sorry count**: 7→6 (`constant_explanation` is proved by `norm_num`, not sorry)
- **Theorem count**: 9→8
- **Definition count**: 5→4
- **Line count**: 155→162

## Evidence

```
$ grep -c sorry proofs/Proofs/Erdos1162Problem.lean
6
$ grep -c "^theorem" proofs/Proofs/Erdos1162Problem.lean
8
$ grep -c "^def\|^noncomputable def" proofs/Proofs/Erdos1162Problem.lean
4
$ wc -l < proofs/Proofs/Erdos1162Problem.lean
162
```

Note: `most_subgroups_are_2groups` axiom has vacuous body (`True`), but is correctly counted as an axiom declaration.

## Test plan

- [ ] `pnpm build` passes with corrected meta.json

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)