### PR TITLE
fix(audit): erdos-1037 sorry count 9→8

### DIFF
--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -17,14 +17,14 @@
       "counterexample"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 8,
     "erdosNumber": 1037,
     "erdosUrl": "https://erdosproblems.com/1037",
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 5,
     "lineCount": 276,
-    "assumptions": "5 axiom(s) and 9 sorry(s). See the Lean source for details.",
+    "assumptions": "5 axiom(s) and 8 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- **Sorry count**: 9→8 (actual grep count in Lean source)

## Evidence

```
$ grep -c sorry proofs/Proofs/Erdos1037Problem.lean
8
```

## Test plan

- [ ] `pnpm build` passes with corrected meta.json

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)