### PR TITLE
fix(audit): erdos-382 sorry count 0→3, axiom count 4→3

### DIFF
--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 3,
     "erdosNumber": 382,
     "erdosUrl": "https://erdosproblems.com/382",
     "erdosProblemStatus": "open",
@@ -59,14 +59,14 @@
       "question1: subpolynomial growth conjecture (v−u = v^o(1))",
       "question2: unbounded length conjecture",
       "ramachandra_bound axiom: v−u ≤ v^{1/2+ε}",
-      "cramersConjecture definition and cramer_implies_q1 axiom",
+      "cramersConjecture definition and cramer_implies_q1 theorem (3 sorries)",
       "noPrimeLargerThanSqrt: equivalent prime-free interval formulation",
       "erdos_382_summary: combined known results theorem",
       "Concrete example: prodInterval 2 4 = 24 via native_decide"
     ],
-    "axiomCount": 4,
-    "lineCount": 490,
-    "assumptions": "4 axioms: erdos_382_q1 (OPEN conjecture), erdos_382_q2_heuristic (OPEN conjecture), ramachandra_bound (deep result), cramer_implies_q1 (deep result). Proved: exponentInProduct_sum (factorization distributes over Finset product), largest_prime_exp_one (Bertrand's postulate), no_prime_in_upper_half (Bertrand + exponent sum). Removed: exp_ge_two_needs_square (incorrect), condition_iff_no_large_prime (backward direction incorrect — counterexample [24,28])."
+    "axiomCount": 3,
+    "lineCount": 509,
+    "assumptions": "3 axioms: erdos_382_q1 (OPEN conjecture), erdos_382_q2_heuristic (OPEN conjecture), ramachandra_bound (deep result). 3 sorries in cramer_implies_q1 (growth rate steps). Proved: exponentInProduct_sum, largest_prime_exp_one (Bertrand's postulate), no_prime_in_upper_half."
   },
   "overview": {
     "historicalContext": "Erdős Problem #382 originates from the 1980 monograph by Erdős and Graham [ErGr80], which systematically cataloged open problems in combinatorial number theory. The problem studies the factorization structure of products of consecutive integers u·(u+1)·...·v, specifically asking about the exponent of the largest prime divisor.\n\nThe key constraint is that the largest prime p dividing the product must appear with exponent ≥ 2. Since p² must divide some integer in [u,v], this forces p ≤ √v, meaning the interval [u,v] is 'prime-free' above √v. The problem asks two questions: whether v−u grows subpolynomially in v, and whether v−u can be arbitrarily large.\n\nRamachandra established the best known upper bound v−u ≤ v^{1/2+o(1)}, using techniques from the distribution of primes in short intervals. Cramér's famous conjecture on prime gaps would imply the stronger result that v−u = v^o(1). Cambie's heuristic analysis suggests that v−u can indeed be arbitrarily large, but both questions remain open.",
@@ -204,8 +204,8 @@
       "Real"
     ],
     "namespace": "Erdos382",
-    "lineCount": 490,
-    "axiomCount": 5,
+    "lineCount": 509,
+    "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 9
   },


### PR DESCRIPTION
## Summary

- **Sorry count**: 0→3 (`cramer_implies_q1` has 3 incomplete proof steps)
- **Axiom count**: 4→3 (`cramer_implies_q1` is a theorem, not an axiom)
- **leanFile.axiomCount**: 5→3 (was inconsistent with meta.axiomCount)
- **Line count**: 490→509
- Fixed `originalContributions` to correctly describe `cramer_implies_q1` as theorem

## Evidence

```
$ grep -c sorry proofs/Proofs/Erdos382Problem.lean
3
$ grep -c "^axiom " proofs/Proofs/Erdos382Problem.lean
3
$ wc -l < proofs/Proofs/Erdos382Problem.lean
509
```

## Test plan

- [ ] `pnpm build` passes with corrected meta.json

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)