### PR TITLE
fix(audit): update stale lineCount for 3 proofs

### DIFF
--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1000",
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
-    "lineCount": 1003,
+    "lineCount": 1119,
     "assumptions": "Two deep axioms: erdos_dichotomy (liminf=0 implies limsup=1, via Euler product for φ(n)/n), haight_resolution (vanishing Cesàro average exists, via highly composite construction). erdos_no_zero_limit is now PROVED from erdos_dichotomy (convergence to 0 contradicts dichotomy via frequently-vs-eventually). cassels_liminf_zero is PROVED from haight_resolution. Infrastructure: complement formula, growth bounds, multiplicity bounds, double-counting vocabulary, growth constraints from low density, deficit counting bounds.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -78,7 +78,7 @@
       "mostVisitedSet_nonempty"
     ],
     "axiomCount": 20,
-    "lineCount": 289,
+    "lineCount": 327,
     "assumptions": "20 axioms: 11 structural (RandomWalk model, visitCount, maxVisitCount, mostVisitedSet), 3 probability framework (AlmostSurely), 6 deep results (Erdős–Taylor, Pólya recurrence, etc.). cumulativeMostVisited was converted from axiom to definition (Finset.biUnion), eliminating 3 axioms."
   },
   "overview": {

--- a/src/data/proofs/erdos-1178/meta.json
+++ b/src/data/proofs/erdos-1178/meta.json
@@ -53,7 +53,7 @@
       "Connection theorems linking to Problems #716 and #1076"
     ],
     "axiomCount": 7,
-    "lineCount": 185,
+    "lineCount": 223,
     "assumptions": "7 axioms: exr (extremal number), dr (threshold function), dr_spec, dr_minimal, sarkozy_selkow_upper, cgls_upper_r3, solymosi_d3_10, erdos_1178 (main conjecture). 3 sorries: bes_lower_bound, ruzsa_szemeredi_d3_3, efr_e3."
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update stale lineCount in 3 meta.json files after recent researcher expansions.

## Evidence

- erdos-1000: 1003 → 1119 (+116 lines)
- erdos-1166: 289 → 327 (+38 lines)
- erdos-1178: 185 → 223 (+38 lines)

Values verified against actual Lean source files.

---
Automated fix by lean-mechanic agent.