### PR TITLE
fix(audit): batch sorry/axiom/count fixes for 3 proofs

### DIFF
--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -18,7 +18,7 @@
       "asymptotic-analysis"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 6,
     "erdosNumber": 309,
     "erdosUrl": "https://erdosproblems.com/309",
     "erdosProblemStatus": "solved",
@@ -68,7 +68,7 @@
     ],
     "axiomCount": 7,
     "lineCount": 351,
-    "assumptions": "7 axiom(s) and 7 sorry(s). See the Lean source for details."
+    "assumptions": "7 axiom(s) and 6 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Egyptian Fractions and Erdős's Question**\n\nThis problem concerns a fundamental question about **Egyptian fractions** - sums of distinct unit fractions 1/n. The ancient Egyptians represented all fractions this way.\n\n**The Question:** Given denominators from {1, ..., N}, how many integers can be represented as such sums? Specifically, is this count o(log N) (sublogarithmic)?\n\n**The Answer:** NO. The count F(N) grows like log N + γ, where γ ≈ 0.5772 is the Euler-Mascheroni constant.\n\n**Key Contributors:**\n- Yokota (1997): First logarithmic lower bound\n- Croot (1999): Exact threshold for representability\n- Yokota (2002): Refined bounds with (log log N)² correction\n\n**The harmonic number H_N = 1 + 1/2 + ... + 1/N ~ log N + γ** is central to understanding this problem, as representable integers are bounded by H_N.",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -82,7 +82,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 234,
-    "assumptions": "9 axiom declarations (all with non-trivial mathematical content), 5 sorries, 2 opaque framework predicates (AlmostSurely, ProbInGnm). Axioms encode: Dirac's theorem, Erdős-Rényi matching threshold, Pósa's theorem, Korshunov's sharp threshold, Komlós-Szemerédi limiting probability, asymptotic limit behavior of limitingProbability, connectivity threshold, and minimum degree concentration. Probabilistic statements use opaque AlmostSurely/ProbInGnm predicates since full formalization requires a measure space on graphs."
+    "assumptions": "1 axiom (komlos_szemeredi_theorem), 4 sorries. Probabilistic statements use opaque AlmostSurely/ProbInGnm predicates since full formalization requires a measure space on graphs."
   },
   "overview": {
     "historicalContext": "**The Erdős-Rényi Random Graph Revolution**\n\nErdős and Rényi's 1959–1966 papers on random graphs $G(n, m)$ revolutionized combinatorics by introducing probabilistic methods to study graph properties. They discovered that many graph properties exhibit **sharp thresholds**: the property jumps from almost surely absent to almost surely present as $m$ crosses a critical value.\n\n**The Matching-Hamiltonicity Connection**\n\nIn 1966, Erdős and Rényi proved that $G(n, m)$ with $m \\ge (1/2 + \\varepsilon) n \\log n$ almost surely has a perfect matching. Since a Hamiltonian cycle decomposes into two perfect matchings, they conjectured the same threshold for Hamiltonicity — one of the most natural questions in random graph theory.\n\n**The Path to Resolution**\n\nPósa (1976) proved Hamiltonicity for $Cn \\log n$ edges using his **rotation-extension technique**, a landmark method that became central to probabilistic combinatorics. Korshunov (1977) established the sharp threshold as $(1/2) n \\log n + (1/2) n \\log \\log n + o(n)$, confirming Erdős-Rényi's conjecture. Finally, Komlós and Szemerédi (1983) determined the precise limiting distribution: with $m = (1/2) n \\log n + (1/2) n \\log \\log n + cn$ edges, $\\Pr[\\text{Hamiltonian}] \\to e^{-e^{-2c}}$ — a **Gumbel (double exponential)** distribution.\n\n**The Threshold Coincidence**\n\nRemarkably, the Hamiltonicity threshold coincides with the connectivity threshold. Both are controlled by the same bottleneck: vertices of degree 0 or 1. The factor 2 in the Gumbel exponent $e^{-2c}$ reflects the two failure modes (degree 0 and degree 1) at the critical edge count.",
@@ -229,7 +229,7 @@
     "lineCount": 234,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 19
+    "definitionCount": 17
   },
   "references": [
     {

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -19,7 +19,7 @@
       "classic"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
@@ -58,9 +58,9 @@
       "definitions": 14,
       "instances": 0
     },
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 384,
-    "assumptions": "2 axiom(s): equilateral_side_length_axiom, morleys_theorem_axiom. See Lean source for complete statements.",
+    "assumptions": "1 axiom: morleys_theorem_axiom. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -226,9 +226,9 @@
       "Real"
     ],
     "namespace": "MorleysTheorem",
-    "lineCount": 352,
-    "axiomCount": 2,
-    "theoremCount": 7,
+    "lineCount": 384,
+    "axiomCount": 1,
+    "theoremCount": 8,
     "definitionCount": 15
   },
   "references": [


### PR DESCRIPTION
## Summary

Batch audit fixes for three gallery entries:

### erdos-309
- **Sorry count**: 7→6

### morleys-theorem
- **Sorry count**: 1→0 (all proofs complete)
- **Axiom count**: 2→1 (equilateral_side_length_axiom is now a theorem)
- **leanFile.lineCount**: 352→384
- **Theorem count**: 7→8

### erdos-746
- **Definition count**: 19→17
- **Assumptions text**: claimed "9 axiom declarations" but file has only 1 axiom

## Evidence

```
$ grep -c sorry proofs/Proofs/Erdos309Problem.lean
6
$ grep -c sorry proofs/Proofs/MorleysTheorem.lean
0
$ grep -c "^axiom " proofs/Proofs/MorleysTheorem.lean
1
$ grep -c "^theorem" proofs/Proofs/MorleysTheorem.lean
8
$ grep -c "^def \|^noncomputable def " proofs/Proofs/Erdos746Problem.lean
17
$ grep -c "^axiom " proofs/Proofs/Erdos746Problem.lean
1
```

## Test plan

- [ ] `pnpm build` passes with corrected meta.json files

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)