### PR TITLE
fix(audit): sorry token counts for erdos-628, erdos-392, erdos-138

### DIFF
--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Summary

Lines with multiple sorry tokens need token-level counting, not line-level:

- **erdos-628**: sorries 11→12 (line 209: `(hC₁_cycle : sorry) (hC₂_cycle : sorry)`)
- **erdos-392**: sorries 2→3 (line 218: two `by sorry` tokens)
- **erdos-138**: sorries 4→5 (line 46: two `by sorry` tokens in def body)

## Evidence

```
$ grep -o sorry proofs/Proofs/Stubs/Erdos628Problem.lean | wc -l
12
$ grep -o sorry proofs/Proofs/Stubs/Erdos392Problem.lean | wc -l
3
$ grep -o sorry proofs/Proofs/Stubs/Erdos138Problem.lean | wc -l
5
```

## Test plan

- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)