### PR TITLE
fix(audit): correct sorry/axiom counts for 3 proofs

### DIFF
--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Correct sorry counts and related metadata for 3 proofs where meta.json didn't match the actual Lean source.

## Changes

| Proof | Field | Before | After | Reason |
|-------|-------|--------|-------|--------|
| erdos-309 | sorries | 7 | 6 | One sorry was removed |
| erdos-746 | sorries | 4 | 5 | Multi-sorry lines undercounted |
| morleys-theorem | sorries | 1 | 0 | `equilateral_side_length_axiom` proved |
| morleys-theorem | axiomCount | 2 | 1 | Same: axiom→theorem |
| morleys-theorem | lineCount | 352 | 384 | File grew when axiom was proved |
| morleys-theorem | theoremCount | 7 | 8 | +1 from axiom→theorem conversion |

## Evidence

**Verification method**: Programmatic scan comparing `meta.json` sorry/axiom counts against actual Lean source (comments and strings excluded from sorry counting).

**Before**: 6 sorry-count mismatches in gallery
**After**: 3 fewer mismatches (the other 3 were fixed by #7426)

---
Automated fix by lean-mechanic agent.