### PR TITLE
fix(audit): update stale lineCount for 46 proofs

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -141,7 +141,7 @@
       "BoundedPrimeGaps"
     ],
     "namespace": "BoundedPrimeGapsOQ03OQ01",
-    "lineCount": 172,
+    "lineCount": 329,
     "axiomCount": 4,
     "theoremCount": 15,
     "definitionCount": 3

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -232,7 +232,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 194,
+    "lineCount": 216,
     "axiomCount": 8,
     "theoremCount": 1,
     "definitionCount": 9

--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -213,7 +213,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 154,
+    "lineCount": 196,
     "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 3

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/1020",
     "erdosProblemStatus": "open",
     "axiomCount": 11,
-    "lineCount": 247,
+    "lineCount": 253,
     "assumptions": "11 axiom(s) and 2 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
@@ -184,7 +184,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 247,
+    "lineCount": 253,
     "axiomCount": 11,
     "theoremCount": 4,
     "definitionCount": 11

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -195,7 +195,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 141,
+    "lineCount": 162,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 5

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -60,7 +60,7 @@
       "sierpinski_infinitely_many: Sierpinski's theorem that infinitely many covered numbers exist"
     ],
     "leanFile": {
-      "lineCount": 207,
+      "lineCount": 172,
       "structureCount": 0,
       "axiomCount": 9,
       "theoremCount": 5,

--- a/src/data/proofs/erdos-1144/meta.json
+++ b/src/data/proofs/erdos-1144/meta.json
@@ -211,7 +211,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 175,
+    "lineCount": 205,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 5

--- a/src/data/proofs/erdos-1157/meta.json
+++ b/src/data/proofs/erdos-1157/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/1157",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 354,
+    "lineCount": 366,
     "assumptions": "2 axioms: brown_erdos_sos_lower_bound (BES 1973 lower bound), delcourt_postle_theorem (Delcourt-Postle 2024, full 3-uniform BES). Previously axiomatized extremalNumber, monotonicity in k/s now proved constructively from sSup definition.",
     "mathlib_version": "4.26.0"
   },
@@ -173,7 +173,7 @@
     ],
     "opens": [],
     "namespace": "Erdos1157",
-    "lineCount": 354,
+    "lineCount": 366,
     "axiomCount": 2,
     "theoremCount": 25,
     "definitionCount": 7

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -207,7 +207,7 @@
       "Real"
     ],
     "namespace": "Erdos1166",
-    "lineCount": 289,
+    "lineCount": 327,
     "axiomCount": 20,
     "theoremCount": 10,
     "definitionCount": 1

--- a/src/data/proofs/erdos-1173/meta.json
+++ b/src/data/proofs/erdos-1173/meta.json
@@ -172,7 +172,7 @@
       "Ordinal"
     ],
     "namespace": "Erdos1173",
-    "lineCount": 202,
+    "lineCount": 232,
     "axiomCount": 4,
     "theoremCount": 7,
     "definitionCount": 11

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -212,7 +212,7 @@
       "Real"
     ],
     "namespace": "Erdos1179",
-    "lineCount": 218,
+    "lineCount": 300,
     "axiomCount": 7,
     "theoremCount": 5,
     "definitionCount": 3

--- a/src/data/proofs/erdos-120/meta.json
+++ b/src/data/proofs/erdos-120/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/120",
     "erdosProblemStatus": "open",
     "axiomCount": 5,
-    "lineCount": 331,
+    "lineCount": 345,
     "assumptions": "7 axioms: steinhaus_finite, unbounded_avoidable, dense_in_interval_avoidable, and 4 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -151,7 +151,7 @@
       "Filter"
     ],
     "namespace": "Erdos120",
-    "lineCount": 331,
+    "lineCount": 345,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 10

--- a/src/data/proofs/erdos-153/meta.json
+++ b/src/data/proofs/erdos-153/meta.json
@@ -139,7 +139,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 341,
+    "lineCount": 457,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 8

--- a/src/data/proofs/erdos-155/meta.json
+++ b/src/data/proofs/erdos-155/meta.json
@@ -27,7 +27,7 @@
       "erdos-234"
     ],
     "axiomCount": 6,
-    "lineCount": 193,
+    "lineCount": 218,
     "assumptions": "6 axioms: erdos_turan_upper, sidon_lower_asymptotic, erdos_155_conjecture (OPEN), erdos_155_strong (OPEN), increase_points_sparse, small_values_large. 7 proved theorems.",
     "mathlib_version": "4.26.0"
   },
@@ -134,7 +134,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 193,
+    "lineCount": 218,
     "axiomCount": 6,
     "theoremCount": 7,
     "definitionCount": 1

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -158,7 +158,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 185,
+    "lineCount": 224,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 4

--- a/src/data/proofs/erdos-181/meta.json
+++ b/src/data/proofs/erdos-181/meta.json
@@ -156,7 +156,7 @@
     ],
     "opens": [],
     "namespace": "Erdos181",
-    "lineCount": 263,
+    "lineCount": 382,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 2

--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -142,7 +142,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 264,
+    "lineCount": 315,
     "axiomCount": 5,
     "theoremCount": 15,
     "definitionCount": 7

--- a/src/data/proofs/erdos-26/meta.json
+++ b/src/data/proofs/erdos-26/meta.json
@@ -46,7 +46,7 @@
       "Educational documentation of thick/Behrend sequence concepts"
     ],
     "axiomCount": 7,
-    "lineCount": 209,
+    "lineCount": 217,
     "prerequisites": [
       "Arithmetic progressions and AP-free sets",
       "Behrend's construction (sphere method)",
@@ -163,7 +163,7 @@
       "in"
     ],
     "namespace": "Erdos26",
-    "lineCount": 209,
+    "lineCount": 217,
     "axiomCount": 7,
     "theoremCount": 4,
     "definitionCount": 9

--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -112,7 +112,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 309,
+    "lineCount": 351,
     "axiomCount": 2,
     "theoremCount": 18,
     "definitionCount": 5

--- a/src/data/proofs/erdos-297/meta.json
+++ b/src/data/proofs/erdos-297/meta.json
@@ -62,7 +62,7 @@
       "at_least_three_representations: verified examples {1}, {2,3,6}, {2,4,5,20}"
     ],
     "axiomCount": 5,
-    "lineCount": 252,
+    "lineCount": 256,
     "assumptions": "14 axioms: two_three_six_is_egyptian, two_four_five_twenty_is_egyptian, two_three_seven_fortytwo_is_egyptian, and 11 more. See Lean source for complete statements."
   },
   "overview": {
@@ -203,7 +203,7 @@
       "Finset"
     ],
     "namespace": "Erdos297",
-    "lineCount": 252,
+    "lineCount": 256,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 9

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -67,7 +67,7 @@
       "prime-factorization",
       "abc-conjecture"
     ],
-    "lineCount": 176
+    "lineCount": 171
   },
   "crossReferences": [
     {
@@ -213,7 +213,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 121,
+    "lineCount": 171,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 0,

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -141,7 +141,7 @@
       "Classical"
     ],
     "namespace": "",
-    "lineCount": 128,
+    "lineCount": 195,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 5

--- a/src/data/proofs/erdos-397/meta.json
+++ b/src/data/proofs/erdos-397/meta.json
@@ -46,7 +46,7 @@
       "Verified computations of small central binomial values"
     ],
     "axiomCount": 2,
-    "lineCount": 119,
+    "lineCount": 122,
     "assumptions": "3 axiom(s). No sorries."
   },
   "overview": {
@@ -122,7 +122,7 @@
       "Finset"
     ],
     "namespace": "Erdos397",
-    "lineCount": 119,
+    "lineCount": 122,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 4

--- a/src/data/proofs/erdos-421/meta.json
+++ b/src/data/proofs/erdos-421/meta.json
@@ -186,7 +186,7 @@
       "Filter"
     ],
     "namespace": "Erdos421",
-    "lineCount": 237,
+    "lineCount": 430,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 18

--- a/src/data/proofs/erdos-423/meta.json
+++ b/src/data/proofs/erdos-423/meta.json
@@ -28,7 +28,7 @@
       "Asymptotic analysis and Filter.Tendsto",
       "Set.Infinite and natural density concepts"
     ],
-    "lineCount": 314,
+    "lineCount": 321,
     "assumptions": "5 axioms: consSeq_is_consecutive_sum, consSeq_minimal (structural), excess_nondecreasing, excess_unbounded, infinitely_many_missing (Bolan-Tang). consSeq_strictMono proved from definition.",
     "mathlib_version": "4.26.0"
   },
@@ -171,7 +171,7 @@
       "Finset"
     ],
     "namespace": "Erdos423",
-    "lineCount": 267,
+    "lineCount": 321,
     "axiomCount": 5,
     "theoremCount": 27,
     "definitionCount": 8

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -101,7 +101,7 @@
       }
     ],
     "axiomCount": 4,
-    "lineCount": 248,
+    "lineCount": 260,
     "assumptions": "4 axioms: dirichlet_primes_mod1 (Dirichlet's theorem), linnik_bound (Linnik's theorem), erdos_strict_inequality (Erdős infinitude result), m_over_n_diverges (Erdős density result). All deep published results. 8 formerly-axiom properties now proved from sInf well-ordering."
   },
   "overview": {
@@ -191,7 +191,7 @@
       "Nat"
     ],
     "namespace": "Erdos456",
-    "lineCount": 210,
+    "lineCount": 260,
     "axiomCount": 4,
     "theoremCount": 14,
     "definitionCount": 8

--- a/src/data/proofs/erdos-461/meta.json
+++ b/src/data/proofs/erdos-461/meta.json
@@ -56,7 +56,7 @@
       "Only sorry: smoothComponent_largest (maximality) — proof strategy documented, infrastructure prepared"
     ],
     "axiomCount": 1,
-    "lineCount": 276,
+    "lineCount": 281,
     "assumptions": "1 axiom(s). No sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -145,7 +145,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 276,
+    "lineCount": 281,
     "axiomCount": 1,
     "theoremCount": 18,
     "definitionCount": 3

--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -95,7 +95,7 @@
     "https://erdosproblems.com/469"
   ],
   "leanFile": {
-    "lineCount": 215,
+    "lineCount": 327,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 19,

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -143,7 +143,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 222,
+    "lineCount": 265,
     "axiomCount": 3,
     "theoremCount": 15,
     "definitionCount": 5

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/667",
     "erdosProblemStatus": "open",
     "axiomCount": 8,
-    "lineCount": 435,
+    "lineCount": 444,
     "dateAdded": "2026-02-10",
     "mathlibDependencies": [
       {
@@ -188,7 +188,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos667",
-    "lineCount": 435,
+    "lineCount": 444,
     "axiomCount": 8,
     "theoremCount": 30,
     "definitionCount": 4

--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -138,7 +138,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 274,
+    "lineCount": 358,
     "axiomCount": 6,
     "theoremCount": 14,
     "definitionCount": 5

--- a/src/data/proofs/erdos-71/meta.json
+++ b/src/data/proofs/erdos-71/meta.json
@@ -30,7 +30,7 @@
       "Bipartite graphs and parity of cycles",
       "Extremal graph theory (Bondy-Simonovits theorem)"
     ],
-    "lineCount": 274,
+    "lineCount": 278,
     "assumptions": "6 axioms: arithProg_infinite, bollobas_theorem, bondy_simonovits, and 3 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -184,7 +184,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos71",
-    "lineCount": 274,
+    "lineCount": 278,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 8

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -162,7 +162,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 195,
+    "lineCount": 371,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 7

--- a/src/data/proofs/erdos-726/meta.json
+++ b/src/data/proofs/erdos-726/meta.json
@@ -134,7 +134,7 @@
     "https://erdosproblems.com/726"
   ],
   "leanFile": {
-    "lineCount": 224,
+    "lineCount": 316,
     "structureCount": 0,
     "axiomCount": 4,
     "theoremCount": 12,

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -143,7 +143,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 154,
+    "lineCount": 161,
     "axiomCount": 7,
     "theoremCount": 9,
     "definitionCount": 3

--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -160,7 +160,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 210,
+    "lineCount": 286,
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 8

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,7 +38,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 251,
+    "lineCount": 258,
     "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, bipartite_dichrom_le_two, odd_cycle_dichrom, dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0"
   },
@@ -124,7 +124,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 251,
+    "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 7

--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -183,7 +183,7 @@
       "Finset"
     ],
     "namespace": "Erdos782",
-    "lineCount": 271,
+    "lineCount": 294,
     "axiomCount": 4,
     "theoremCount": 7,
     "definitionCount": 19

--- a/src/data/proofs/erdos-827/meta.json
+++ b/src/data/proofs/erdos-827/meta.json
@@ -135,7 +135,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 135,
+    "lineCount": 177,
     "axiomCount": 6,
     "theoremCount": 0,
     "definitionCount": 8

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -185,7 +185,7 @@
       "Finset"
     ],
     "namespace": "Erdos831",
-    "lineCount": 281,
+    "lineCount": 398,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 10

--- a/src/data/proofs/erdos-861/meta.json
+++ b/src/data/proofs/erdos-861/meta.json
@@ -169,7 +169,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos861",
-    "lineCount": 255,
+    "lineCount": 276,
     "axiomCount": 6,
     "theoremCount": 5,
     "definitionCount": 7

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -157,7 +157,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 531,
+    "lineCount": 755,
     "axiomCount": 1,
     "theoremCount": 16,
     "definitionCount": 5

--- a/src/data/proofs/erdos-896/meta.json
+++ b/src/data/proofs/erdos-896/meta.json
@@ -128,7 +128,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 182,
+    "lineCount": 204,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 7

--- a/src/data/proofs/erdos-911/meta.json
+++ b/src/data/proofs/erdos-911/meta.json
@@ -52,7 +52,7 @@
       "erdos_911_statement theorem: equivalence"
     ],
     "axiomCount": 8,
-    "lineCount": 295,
+    "lineCount": 276,
     "assumptions": "8 axiom(s) and 0 sorry(s). Axioms: sizeRamseyNumber, sizeRamseyNumber_spec, sizeRamseyNumber_minimal, beck_path_size_ramsey, bounded_degree_linear_size_ramsey, complete_graph_size_ramsey, vertex_ramsey_number, size_ramsey_upper_bound."
   },
   "overview": {
@@ -186,7 +186,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos911",
-    "lineCount": 295,
+    "lineCount": 276,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 7

--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -153,7 +153,7 @@
       "Finset"
     ],
     "namespace": "Erdos913",
-    "lineCount": 235,
+    "lineCount": 274,
     "axiomCount": 3,
     "theoremCount": 8,
     "definitionCount": 5

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -57,7 +57,7 @@
       "primes_mod_4_connection axiom: relation to primes ≡ 1 (mod 4)"
     ],
     "axiomCount": 4,
-    "lineCount": 395,
+    "lineCount": 492,
     "assumptions": "4 axioms: gaussian_prime_classification, tsuchimura, gaussian_prime_theorem, primes_mod_4_connection. jordan_rabung and gethner_et_al proved from tsuchimura. 1 sorry (definition)."
   },
   "overview": {
@@ -170,7 +170,7 @@
       "GaussianInt"
     ],
     "namespace": "Erdos952",
-    "lineCount": 245,
+    "lineCount": 492,
     "axiomCount": 4,
     "theoremCount": 3,
     "definitionCount": 20


### PR DESCRIPTION
## Fix

Update stale `lineCount` values in meta.json for 46 proofs where the Lean source files grew during research iterations but the metadata was not updated.

## Evidence

**Method**: Programmatic scan comparing `leanFile.lineCount` and `meta.lineCount` in meta.json against actual `wc -l` of the corresponding Lean source file. Threshold: >2 line difference.

**Scope**: 46 proofs across the gallery. Both `leanFile.lineCount` (outer) and `meta.lineCount` (inner) updated where present.

**Validation**: All JSON files validated, `pnpm annotations:build` passes.

---
Automated fix by lean-mechanic agent.