### PR TITLE
Research: erdos-430 — eliminate small_n_all_prime axiom (2A→1A)

### DIFF
--- a/proofs/Proofs/Erdos430Problem.lean
+++ b/proofs/Proofs/Erdos430Problem.lean
@@ -207,8 +207,22 @@ axiom erdos_430_conjecture :
 
 /- ## Auxiliary: Prime Elements Dominate for Small n -/
 
-/-- For small n, the sequence may consist entirely of primes.
-    The key difficulty is showing this cannot persist for all large n. -/
-axiom small_n_all_prime :
+/-- greedyNext applied to 0 returns 0: the candidate set Icc 1 (0-1) = Icc 1 0 is empty. -/
+private lemma greedyNext_zero (n : ℕ) : greedyNext n 0 = 0 := by
+  unfold greedyNext
+  have : Finset.Icc 1 (0 - 1 : ℕ) = ∅ := Finset.Icc_eq_empty (by omega)
+  simp [this]
+
+/-- For n ≤ 1, the greedy sequence is identically 0. -/
+private lemma greedySeq_zero_of_le_one {n : ℕ} (hn : n ≤ 1) (k : ℕ) :
+    greedySeq n k = 0 := by
+  induction k with
+  | zero => simp [greedySeq]; omega
+  | succ k ih => simp only [greedySeq]; rw [ih]; exact greedyNext_zero n
+
+/-- For small n (specifically n ≤ 1), the sequence consists entirely of zeros,
+    so every positive element is vacuously prime or 1. -/
+theorem small_n_all_prime :
   ∃ n₀ : ℕ, ∀ n : ℕ, n ≤ n₀ →
-    ∀ k : ℕ, 0 < greedySeq n k → (greedySeq n k).Prime ∨ greedySeq n k = 1
+    ∀ k : ℕ, 0 < greedySeq n k → (greedySeq n k).Prime ∨ greedySeq n k = 1 :=
+  ⟨1, fun n hn k hpos => absurd (greedySeq_zero_of_le_one hn k) (by omega)⟩

--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 430,
     "erdosUrl": "https://erdosproblems.com/430",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
-    "assumptions": "2 axioms: erdos_430_conjecture (the open conjecture: composites appear for large n), small_n_all_prime (small n can be all-prime). 0 sorries — equivalence with Problem #385 fully proved via greedy descent argument.",
-    "lineCount": 214,
+    "axiomCount": 1,
+    "assumptions": "1 axiom: erdos_430_conjecture (the open conjecture: composites appear for large n). small_n_all_prime proved (n₀=1: for n≤1 the greedy sequence is identically 0). 0 sorries — equivalence with Problem #385 fully proved via greedy descent argument.",
+    "lineCount": 228,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -137,9 +137,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 214,
-    "axiomCount": 2,
-    "theoremCount": 2,
+    "lineCount": 228,
+    "axiomCount": 1,
+    "theoremCount": 3,
     "definitionCount": 7
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-430.json
+++ b/src/data/research/problems/erdos-430.json
@@ -29,14 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 2A appropriate (open conjecture + small_n_all_prime), 2T proved, 0S.",
+    "progressSummary": "COMPLETE: 1A (open conjecture only), 3T proved, 0S. Eliminated small_n_all_prime axiom.",
     "builtItems": [
       "Decidable instance for allPrimeFactorsExceed in Erdos430Problem.lean:37-49",
       "Decidable instance for IsAdmissible in Erdos430Problem.lean:56-57",
       "Proved example_n8 in Erdos430Problem.lean:86",
       "PROVED backward direction of erdos_385_equivalence (was sorry)",
       "greedyNext_ge_m: greedy next ≥ m when m is admissible and prev > m",
-      "greedyNext_lt: greedy next < prev (picks from [1, prev-1])"
+      "greedyNext_lt: greedy next < prev (picks from [1, prev-1])",
+      "greedyNext_zero: greedyNext n 0 = 0 via empty Finset.Icc",
+      "greedySeq_zero_of_le_one: greedySeq n k = 0 for all k when n≤1",
+      "small_n_all_prime: proved (was axiom) using n₀=1"
     ],
     "insights": [
       "greedySeq uses noncomputable Finset.sup with decide on universal quantifier - not computable",
@@ -47,7 +50,8 @@
       "Removed noncomputable from greedyNext, greedySeq - now fully computable",
       "example_n8 proved by native_decide (greedySeq 8 0 = 7, greedySeq 8 1 = 5)",
       "erdos_385_equivalence fully proved: backward direction via greedy descent — if admissible composite m exists, greedy sequence reaches it since greedyNext ≥ m when prev > m",
-      "Strong induction on gap (current - m): sequence strictly decreases while bounded below by m, must reach m"
+      "Strong induction on gap (current - m): sequence strictly decreases while bounded below by m, must reach m",
+      "Proved small_n_all_prime: for n≤1, greedySeq is identically 0 (vacuously true). Reduces axiom count from 2 to 1."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
- Prove `small_n_all_prime` axiom, reducing axiom count from 2 to 1
- For n ≤ 1, `greedySeq n k = 0` for all k (base: n-1=0, step: `greedyNext n 0 = 0` since `Finset.Icc 1 0 = ∅`)
- The hypothesis `0 < greedySeq n k` is therefore vacuously false
- Remaining axiom: `erdos_430_conjecture` (the open problem itself)

## Progress
- **Outcome**: completed (axiom elimination)
- **Files modified**: `proofs/Proofs/Erdos430Problem.lean`, `src/data/proofs/erdos-430/meta.json`, `src/data/research/problems/erdos-430.json`

## Findings
- `greedyNext n 0 = 0` because `Finset.Icc 1 (0-1) = Finset.Icc 1 0 = ∅`, so `Finset.sup ∅ id = 0`
- By induction: `greedySeq n k = 0` for all k when n ≤ 1

## Status
**Outcome**: completed
**Next Steps**: None — erdos-430 is complete (1A for the open conjecture, 0S)

🤖 Generated by researcher-7