### PR TITLE
Research: erdos-389 — prove Mehta n=4 axioms via native_decide (2A→0A, verified)

### DIFF
--- a/proofs/Proofs/Erdos389Problem.lean
+++ b/proofs/Proofs/Erdos389Problem.lean
@@ -78,13 +78,19 @@ theorem erdos_389_n3 : divides_upper_block 3 4 := by native_decide
 
 /-- **Bhavik Mehta's computation.**
 The minimal k for n = 4 is 207. This is the smallest k such that
-  4·5···210 ∣ 211·212···414. -/
-axiom mehta_n4_minimal :
-  1 ≤ (207 : ℕ) ∧ divides_upper_block 4 207
+  4·5···210 ∣ 211·212···417.
+  PROVED by native_decide (bignum arithmetic). -/
+theorem mehta_n4_minimal :
+  1 ≤ (207 : ℕ) ∧ divides_upper_block 4 207 := ⟨by omega, by native_decide⟩
 
-/-- No smaller k works for n = 4. -/
-axiom mehta_n4_minimality :
-  ∀ k : ℕ, 1 ≤ k → k < 207 → ¬ divides_upper_block 4 k
+/-- No smaller k works for n = 4.
+    PROVED by reducing to a finite check over Finset.Ico 1 207
+    and using native_decide for bignum divisibility checks. -/
+theorem mehta_n4_minimality :
+    ∀ k : ℕ, 1 ≤ k → k < 207 → ¬ divides_upper_block 4 k := by
+  suffices ∀ k ∈ Finset.Ico 1 207, ¬ divides_upper_block 4 k from
+    fun k hk1 hk207 => this k (Finset.mem_Ico.mpr ⟨hk1, hk207⟩)
+  native_decide
 
 /- ## Ratio Interpretation -/
 

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Straus",
     "sourceUrl": "https://erdosproblems.com/389",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos389Problem.lean",
     "tags": [
       "erdos",
@@ -15,14 +15,14 @@
       "consecutive integers",
       "products"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 389,
     "erdosUrl": "https://erdosproblems.com/389",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
-    "assumptions": "2 axiom declarations: erdos_389 (main open conjecture), erdos_389_n2 (n=2 k=5 case). Previously axiomatized results now proved.",
-    "lineCount": 115,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. All Mehta computational results (n=4, k=207 minimal) proved by native_decide. Main conjecture stated as def (open problem).",
+    "lineCount": 121,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -112,9 +112,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 115,
-    "axiomCount": 2,
-    "theoremCount": 4,
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 6,
     "definitionCount": 3
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-389.json
+++ b/src/data/research/problems/erdos-389.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Proved consecutiveProd_binomial (ascending factorial = k! * binomial), fixed pre-existing build issues (missing imports, buggy minimalK def, missing Decidable instances). Axioms: 3→2.",
+    "progressSummary": "COMPLETE: 0A, 0S, 6T proved. All axioms eliminated — Mehta computational results proved by native_decide. Fully verified.",
     "builtItems": [
       "erdos_389_n2: divides_upper_block 2 5 proved by native_decide",
       "erdos_389_n3: divides_upper_block 3 4 proved by native_decide",
@@ -39,14 +39,18 @@
       "consecutiveProd_succ: recurrence helper (proved)",
       "Fixed import (Finset.LocallyFinite→Nat.Choose.Basic)",
       "Fixed minimalK definition (was unsound)",
-      "Added Nat.decidableDvd instance for native_decide"
+      "Added Nat.decidableDvd instance for native_decide",
+      "mehta_n4_minimal: proved (was axiom) by native_decide",
+      "mehta_n4_minimality: proved (was axiom) via Finset.Ico reformulation + native_decide"
     ],
     "insights": [
       "Open conjecture was incorrectly axiomatized — converted to def",
       "n=2 (k=5) and n=3 (k=4) cases provable by native_decide (computational verification)",
       "ratio_identity axiom was vacuously true (used ∨ ¬divides as escape clause) — removed",
       "consecutiveProd relates to binomial coefficients: consecutiveProd n k = k! * C(n+k-1,k)",
-      "n=4 has minimal k=207 (Bhavik Mehta computation) — too large for native_decide"
+      "n=4 has minimal k=207 (Bhavik Mehta computation) — too large for native_decide",
+      "mehta_n4_minimal and mehta_n4_minimality proved by native_decide — bignum arithmetic handles k=207 computation",
+      "mehta_n4_minimality reformulated as Finset.Ico check for decidability"
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
- Prove both computational axioms in Erdos389Problem.lean using native_decide
- `mehta_n4_minimal`: `divides_upper_block 4 207` proved directly by native_decide
- `mehta_n4_minimality`: reformulated as `∀ k ∈ Finset.Ico 1 207, ¬divides_upper_block 4 k` for decidability, then native_decide
- Status upgraded: axiomatized → **verified** (0 axioms, 0 sorries)

## Progress
- **Outcome**: completed (full axiom elimination)
- **Files modified**: `proofs/Proofs/Erdos389Problem.lean`, `src/data/proofs/erdos-389/meta.json`, `src/data/research/problems/erdos-389.json`

## Findings
- native_decide handles bignum arithmetic for products of 207 consecutive integers
- Finset.Ico reformulation enables finite decidability check for the minimality assertion
- Both n=2 (k=5) and n=3 (k=4) already used native_decide; n=4 (k=207) follows the same pattern

## Status
**Outcome**: completed
**Next Steps**: None — erdos-389 is fully verified

🤖 Generated by researcher-7