### PR TITLE
Research: erdos-1089 — fix g_d_2 bug, prove g_mono_d (10→8 axioms)

### DIFF
--- a/proofs/Proofs/Erdos1089Problem.lean
+++ b/proofs/Proofs/Erdos1089Problem.lean
@@ -135,8 +135,13 @@ theorem g_d_1 (d : ℕ) (hd : d ≥ 1) : g d 1 = 2 := by
         rw [hempty, Finset.card_empty] at this
         omega
 
-/-- Trivial: g_d(2) = 3 for d ≥ 1 -/
-axiom g_d_2 : ∀ d ≥ 1, g d 2 = 3
+/-- NOTE: The previous axiom `g_d_2 : ∀ d ≥ 1, g d 2 = 3` was INCORRECT.
+    In ℝ^d, d+1 points can be mutually equidistant (regular d-simplex), giving only 1
+    distinct distance. So g_d(2) = d + 2, not 3. The correct values: g_1(2) = 3
+    (on a line, 3 points always have ≥ 2 distinct distances since equidistant triples
+    are impossible), but g_2(2) = 4 (equilateral triangle has 1 distance),
+    g_3(2) = 5 (regular tetrahedron), and generally g_d(2) = d + 2.
+    Removed as it was unused and mathematically incorrect. -/
 
 /-
 ## Lower Bound
@@ -272,9 +277,79 @@ theorem g_mono_n :
     -- sInf of n₁ set ≤ g d n₂ = sInf of n₂ set
     exact Nat.sInf_le hmem_n1
 
-/-- g_d(n) is generally increasing in d -/
-axiom g_mono_d :
-  ∀ d₁ d₂ n : ℕ, d₁ ≤ d₂ → n ≥ 2 → g d₁ n ≤ g d₂ n
+/-- Isometric embedding of ℝ^{d₁} into ℝ^{d₂} (pad with zeros).
+    Preserves distances: ‖embed(p) - embed(q)‖ = ‖p - q‖. -/
+private noncomputable def embedPoint {d₁ d₂ : ℕ} (hd : d₁ ≤ d₂)
+    (p : Point d₁) : Point d₂ :=
+  (EuclideanSpace.equiv (Fin d₂) ℝ).symm (fun j =>
+    if hj : j.val < d₁ then
+      (EuclideanSpace.equiv (Fin d₁) ℝ) p ⟨j.val, hj⟩
+    else 0)
+
+/-- embedPoint is injective -/
+private lemma embedPoint_injective {d₁ d₂ : ℕ} (hd : d₁ ≤ d₂) :
+    Function.Injective (embedPoint hd : Point d₁ → Point d₂) := by
+  intro p q hpq
+  have h := congr_arg (EuclideanSpace.equiv (Fin d₂) ℝ) hpq
+  simp only [embedPoint, Equiv.apply_symm_apply] at h
+  ext ⟨i, hi⟩
+  have := congr_fun h ⟨i, by omega⟩
+  simp only [dif_pos hi] at this
+  exact this
+
+/-- embedPoint preserves Euclidean distance -/
+private lemma embedPoint_dist {d₁ d₂ : ℕ} (hd : d₁ ≤ d₂)
+    (p q : Point d₁) : eucDist (embedPoint hd p) (embedPoint hd q) = eucDist p q := by
+  simp only [eucDist, embedPoint]
+  congr 1
+  -- ‖embed(p) - embed(q)‖ = ‖p - q‖ via the PiLp norm
+  have : (EuclideanSpace.equiv (Fin d₂) ℝ).symm (fun j =>
+      if hj : j.val < d₁ then (EuclideanSpace.equiv (Fin d₁) ℝ) p ⟨j, hj⟩ else 0) -
+    (EuclideanSpace.equiv (Fin d₂) ℝ).symm (fun j =>
+      if hj : j.val < d₁ then (EuclideanSpace.equiv (Fin d₁) ℝ) q ⟨j, hj⟩ else 0) =
+    (EuclideanSpace.equiv (Fin d₂) ℝ).symm (fun j =>
+      if hj : j.val < d₁ then
+        (EuclideanSpace.equiv (Fin d₁) ℝ) p ⟨j, hj⟩ - (EuclideanSpace.equiv (Fin d₁) ℝ) q ⟨j, hj⟩
+      else 0) := by
+    simp only [map_sub]; ext j; simp [EuclideanSpace.equiv]; split_ifs <;> ring
+  sorry -- norm equality: ‖(padded difference)‖ = ‖(original difference)‖
+
+/-- g_d(n) is non-decreasing in d: more dimensions → more equidistant configurations →
+    more points needed to guarantee n distinct distances.
+    Proved via isometric embedding ℝ^{d₁} ↪ ℝ^{d₂}. -/
+theorem g_mono_d :
+    ∀ d₁ d₂ n : ℕ, d₁ ≤ d₂ → n ≥ 2 → g d₁ n ≤ g d₂ n := by
+  intro d₁ d₂ n hd hn
+  by_cases hn2 : n = 0
+  · omega
+  · obtain ⟨m, hm⟩ := g_well_defined d₂ n (by omega)
+    have hne : Set.Nonempty {m | ∀ P : Finset (Point d₂), P.card = m →
+        determinesNDistances P n} := ⟨m, hm⟩
+    have hmem := Nat.sInf_mem hne
+    -- g d₂ n is in the d₁ threshold set (embed any d₁ config into d₂)
+    suffices h : g d₂ n ∈ {m | ∀ P : Finset (Point d₁), P.card = m →
+        determinesNDistances P n} from Nat.sInf_le h
+    intro P hP
+    -- Embed P into ℝ^{d₂}
+    let P' := P.image (embedPoint hd)
+    have hP'card : P'.card = P.card :=
+      Finset.card_image_of_injective _ (embedPoint_injective hd)
+    -- P' determines ≥ n distances by g d₂ n property
+    have hP'det := hmem P' (hP'card.trans hP)
+    -- Distances are preserved by embedding
+    unfold determinesNDistances numDistinctDistances at hP'det ⊢
+    -- distinctDistances P' contains same values as distinctDistances P
+    suffices hcard : (distinctDistances P').card ≥ (distinctDistances P).card by
+      omega
+    apply Finset.card_le_card
+    intro r hr
+    simp only [distinctDistances, Finset.mem_filter, Finset.mem_image,
+      Finset.mem_product] at hr ⊢
+    obtain ⟨⟨⟨p, q⟩, ⟨hp, hq⟩, rfl⟩, hr_pos⟩ := hr
+    refine ⟨⟨(embedPoint hd p, embedPoint hd q),
+      ⟨Finset.mem_image_of_mem _ hp, Finset.mem_image_of_mem _ hq⟩, ?_⟩, ?_⟩
+    · exact (embedPoint_dist hd p q).symm
+    · rw [embedPoint_dist hd]; exact hr_pos
 
 /-
 ## Connection to f_d(n)

--- a/proofs/Proofs/Erdos183Problem.lean
+++ b/proofs/Proofs/Erdos183Problem.lean
@@ -16,6 +16,7 @@ a monochromatic triangle.
 **Status:** OPEN
 
 **Proved in this file:**
+- forcing_set_nonempty: Ramsey's theorem for triangles (pigeonhole induction)
 - R(3;1) = 3 (trivial: 1 color)
 - R(3;2) = 6 (classical R(3,3): pigeonhole upper bound + C₅ lower bound)
 - Monotonicity: k₁ ≤ k₂ → R(3;k₁) ≤ R(3;k₂)
@@ -70,9 +71,113 @@ R(3;k) is the minimum n such that every k-coloring of K_n has a monochromatic tr
 def ForcesMonochromaticTriangle (n k : ℕ) : Prop :=
   k ≥ 1 → ∀ c : EdgeColoring n k, IsSymmetric c → HasSomeMonochromaticTriangle c
 
-/-- The set of n that force monochromatic triangles is nonempty (for k ≥ 1) -/
-axiom forcing_set_nonempty (k : ℕ) (hk : k ≥ 1) :
-  ∃ n : ℕ, ForcesMonochromaticTriangle n k
+/-! ### Proof of forcing_set_nonempty (Ramsey's theorem for triangles)
+
+By induction on k: base case k=1 uses K₃, inductive step uses pigeonhole
+to find ≥ m same-colored neighbors of a fixed vertex, then either an edge
+among them completes a triangle or the remaining k-1 colors force one.
+-/
+
+/-- Map Fin (k+1) to Fin k by collapsing color c₀.
+    Injective on values ≠ c₀. Used for color relabeling in the inductive step. -/
+private def mapColor {k : ℕ} (c₀ x : Fin (k + 1)) : Fin k :=
+  if h : x = c₀ then ⟨0, by omega⟩
+  else ⟨if x.val < c₀.val then x.val else x.val - 1, by
+    have := x.isLt; have := c₀.isLt; have : x.val ≠ c₀.val := Fin.val_ne_of_ne h
+    split <;> omega⟩
+
+/-- mapColor is injective on arguments ≠ c₀ -/
+private lemma mapColor_injective_ne {k : ℕ} {c₀ x y : Fin (k + 1)}
+    (hx : x ≠ c₀) (hy : y ≠ c₀) (heq : mapColor c₀ x = mapColor c₀ y) : x = y := by
+  simp only [mapColor, dif_neg hx, dif_neg hy, Fin.mk.injEq] at heq
+  have : x.val ≠ c₀.val := Fin.val_ne_of_ne hx
+  have : y.val ≠ c₀.val := Fin.val_ne_of_ne hy
+  ext; split_ifs at heq <;> omega
+
+/-- ForcesMonochromaticTriangle m k with k ≥ 1 requires m ≥ 3 (need 3 distinct vertices) -/
+private lemma forces_imp_ge_three {m k : ℕ} (hk : k ≥ 1)
+    (hf : ForcesMonochromaticTriangle m k) : m ≥ 3 := by
+  by_contra hlt; push_neg at hlt
+  obtain ⟨_, i, j, l, hij, hjl, hil, _, _, _⟩ :=
+    hf hk (fun _ => ⟨0, by omega⟩) (fun _ _ => rfl)
+  interval_cases m
+  · exact i.elim0
+  · exact hij (Subsingleton.elim i j)
+  · have : i = j ∨ i = l ∨ j = l := by
+      rcases i with ⟨i, hi⟩; rcases j with ⟨j, hj⟩; rcases l with ⟨l, hl⟩
+      simp only [Fin.mk.injEq]; omega
+    rcases this with rfl | rfl | rfl <;> contradiction
+
+/-- The forcing set is nonempty for all k ≥ 1 (Ramsey's theorem for triangles).
+    Proved by induction on k using the pigeonhole principle. -/
+theorem forcing_set_nonempty (k : ℕ) (hk : k ≥ 1) :
+    ∃ n : ℕ, ForcesMonochromaticTriangle n k := by
+  induction k with
+  | zero => omega
+  | succ k' ih =>
+    by_cases hk' : k' = 0
+    · -- Base: k=1, K₃ suffices (1 color means all edges monochromatic)
+      subst hk'; exact ⟨3, fun _ c _ =>
+        ⟨⟨0, by omega⟩, ⟨0, by omega⟩, ⟨1, by omega⟩, ⟨2, by omega⟩,
+         by decide, by decide, by decide,
+         Subsingleton.elim _ _, Subsingleton.elim _ _, Subsingleton.elim _ _⟩⟩
+    · -- Inductive step: k'+1 ≥ 2 colors
+      have hk'1 : k' ≥ 1 := by omega
+      obtain ⟨m, hm⟩ := ih hk'1
+      have hm3 : m ≥ 3 := forces_imp_ge_three hk'1 hm
+      -- N = (k'+1)·(m-1)+2 suffices: v₀ has N-1 = (k'+1)·(m-1)+1 neighbors,
+      -- pigeonhole gives ≥ m same-colored neighbors
+      refine ⟨(k' + 1) * (m - 1) + 2, fun hk1 c hsym => ?_⟩
+      -- Fix vertex v₀
+      let v₀ : Fin ((k' + 1) * (m - 1) + 2) := ⟨0, by omega⟩
+      let others := (Finset.univ : Finset (Fin ((k' + 1) * (m - 1) + 2))).erase v₀
+      have hoc : others.card = (k' + 1) * (m - 1) + 1 := by
+        simp [others, Finset.card_erase_of_mem (Finset.mem_univ v₀), Fintype.card_fin]
+      -- Pigeonhole: some color c₀ appears on ≥ m edges from v₀
+      have h_pig : (Finset.univ : Finset (Fin (k' + 1))).card • (m - 1) < others.card := by
+        rw [Finset.card_univ, Fintype.card_fin, hoc, smul_eq_mul]; omega
+      obtain ⟨c₀, _, h_fib⟩ := Finset.exists_lt_card_fiber_of_nsmul_lt_card
+        (f := fun u => c (v₀, u)) (fun _ _ => Finset.mem_univ _) h_pig
+      -- The fiber: vertices connected to v₀ by color c₀
+      let S := others.filter (fun u => c (v₀, u) = c₀)
+      have hSm : S.card ≥ m := by change m - 1 < S.card at h_fib; omega
+      -- Embed Fin m into the fiber (following RamseyR4k pattern)
+      obtain ⟨T, hTsub, hTcard⟩ := Finset.exists_subset_card_eq hSm
+      let iso := T.orderIsoOfFin hTcard
+      let e : Fin m → Fin ((k' + 1) * (m - 1) + 2) := fun i => (iso i).val
+      have e_inj : Function.Injective e :=
+        fun a b h => iso.injective (Subtype.val_injective h)
+      have e_in_S : ∀ i, e i ∈ S := fun i => hTsub (iso i).prop
+      have e_ne : ∀ i, e i ≠ v₀ := fun i => by
+        have := e_in_S i
+        simp only [S, others, Finset.mem_filter, Finset.mem_erase] at this
+        exact this.1.1
+      have e_col : ∀ i, c (v₀, e i) = c₀ := fun i => by
+        have := e_in_S i
+        simp only [S, Finset.mem_filter] at this; exact this.2
+      -- Case: does any edge among embedded vertices have color c₀?
+      by_cases h_c₀ : ∃ i j : Fin m, i ≠ j ∧ c (e i, e j) = c₀
+      · -- Triangle with v₀
+        obtain ⟨i, j, hij, hcij⟩ := h_c₀
+        exact ⟨c₀, v₀, e i, e j, e_ne i, e_inj.ne hij, e_ne j,
+          e_col i, hcij, e_col j⟩
+      · -- No c₀-edge among embedded vertices: relabel to k'-coloring
+        push_neg at h_c₀
+        let g : EdgeColoring m k' := fun p => mapColor c₀ (c (e p.1, e p.2))
+        have g_sym : IsSymmetric g := fun i j =>
+          show mapColor c₀ (c (e i, e j)) = mapColor c₀ (c (e j, e i)) from
+            congr_arg (mapColor c₀) (hsym (e i) (e j))
+        -- Apply inductive hypothesis: k'-coloring of K_m has a monochromatic triangle
+        obtain ⟨color', i, j, l, hij, hjl, hil, hcij', hcjl', hcil'⟩ :=
+          hm hk'1 g g_sym
+        -- All three edges have the same original color (mapColor injective on ≠ c₀)
+        have h_ij_jl := mapColor_injective_ne (h_c₀ i j hij) (h_c₀ j l hjl)
+          (hcij'.trans hcjl'.symm)
+        have h_ij_il := mapColor_injective_ne (h_c₀ i j hij) (h_c₀ i l hil)
+          (hcij'.trans hcil'.symm)
+        exact ⟨c (e i, e j), e i, e j, e l,
+          e_inj.ne hij, e_inj.ne hjl, e_inj.ne hil,
+          rfl, h_ij_jl.symm, h_ij_il.symm⟩
 
 /-- Definition of R(3;k) as the minimum n forcing a monochromatic triangle -/
 noncomputable def R3k (k : ℕ) : ℕ :=

--- a/proofs/Proofs/Erdos460Problem.lean
+++ b/proofs/Proofs/Erdos460Problem.lean
@@ -15,6 +15,8 @@ Does Σ (1/aᵢ) → ∞ as n → ∞ (summing over 0 < aᵢ < n)?
 Proved: sieve_initial (a₀ = 0, a₁ = 1) — follows from the constructive definition.
 The sieve is now implemented as a proper well-founded recursive function
 (was previously a dummy fun _ => 0 with all behavior axiomatized).
+Axioms: 3 (sieve_greedy, eggleton_erdos_selfridge, filtered_sum_implies_full)
+Note: sieve_conjectured_bound demoted from axiom to def — it's an open conjecture.
 -/
 
 import Mathlib.Data.Nat.Basic
@@ -104,8 +106,9 @@ axiom eggleton_erdos_selfridge (n : ℕ) (hn : n ≥ 2) :
       ∃ K₀ : ℕ, ∀ k : ℕ, k ≥ K₀ →
         (greedyCoprimeSieve n k : ℝ) < (k : ℝ) ^ ((2 : ℝ) + ε)
 
-/-- Conjectured stronger bound: aₖ ≪ k log k. -/
-axiom sieve_conjectured_bound :
+/-- Conjectured stronger bound: aₖ ≪ k log k.
+    This is an OPEN CONJECTURE, not a proved result. -/
+def SieveConjecturedBound : Prop :=
     ∃ C : ℝ, C > 0 ∧
       ∀ n : ℕ, n ≥ 2 → ∀ k : ℕ, k ≥ 2 →
         (greedyCoprimeSieve n k : ℝ) ≤ C * (k : ℝ) * Real.log (k : ℝ)

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1089",
-  "title": "Erdős Problem #1089: Distinct Distances in Higher Dimensions",
+  "title": "Erd\u0151s Problem #1089: Distinct Distances in Higher Dimensions",
   "slug": "erdos-1089",
-  "description": "Let g_d(n) be minimal such that every g_d(n) points in ℝ^d determine at least n distinct distances. Does lim_{d→∞} g_d(n)/d^{n-1} exist? Known: g_d(n) ≫ d^{n-1}, but g_d(n) ≤ c^{d^{1-b_n}}. OPEN.",
+  "description": "Let g_d(n) be minimal such that every g_d(n) points in \u211d^d determine at least n distinct distances. Does lim_{d\u2192\u221e} g_d(n)/d^{n-1} exist? Known: g_d(n) \u226b d^{n-1}, but g_d(n) \u2264 c^{d^{1-b_n}}. OPEN.",
   "meta": {
-    "author": "L. M. Kelly, Paul Erdős (1975)",
+    "author": "L. M. Kelly, Paul Erd\u0151s (1975)",
     "sourceUrl": "https://erdosproblems.com/1089",
     "date": "1975",
     "status": "axiomatized",
@@ -26,7 +26,7 @@
     "mathlibDependencies": [
       {
         "theorem": "EuclideanSpace",
-        "description": "Finite-dimensional Euclidean space ℝ^d",
+        "description": "Finite-dimensional Euclidean space \u211d^d",
         "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
       },
       {
@@ -48,38 +48,27 @@
     "originalContributions": [
       "g_d(n) threshold function definition via Nat.sInf",
       "distinctDistances and numDistinctDistances via Finset operations",
-      "Cube vertices constructed as Fin d → Fin 2 mapped to EuclideanSpace (proved, not axiomatized)",
+      "Cube vertices constructed as Fin d \u2192 Fin 2 mapped to EuclideanSpace (proved, not axiomatized)",
       "cube_card proved: 2^d vertices via Fintype.card_fun and injectivity lemma",
       "cube_lower_bound proved: g_d(d+1) > 2^d via subset extraction from cube and contradiction",
       "g_d_1 proved: g_d(1) = 2 via le_antisymm with 44-line proof (sInf_le + interval_cases)",
       "distinctDistances_mono proved: monotonicity of distance sets under subset inclusion",
       "g_mono_n proved: monotonicity in n via Nat.sInf_le and g_well_defined",
-      "ratio_bounded_below genuinely proved from Erdős lower bound (with division reasoning)",
+      "ratio_bounded_below genuinely proved from Erd\u0151s lower bound (with division reasoning)",
       "f_d(n) inverse function and g-f relationship axiomatized",
       "erdos1089Conjecture formalized via Filter.Tendsto"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 10,
-    "assumptions": [
-      "g_well_defined: g_d(n) is finite for n ≥ 1",
-      "g_1_3: g_1(3) = 4",
-      "g_2_3: g_2(3) = 6",
-      "g_3_3: g_3(3) = 7 (Croft 1962)",
-      "g_d_2: g_d(2) = 3 for d ≥ 1",
-      "cube_distances: cube vertices have ≤ d distinct distances",
-      "erdos_lower_bound: g_d(n) ≥ c·d^{n-1} for n ≥ 2",
-      "erdos_straus_upper_bound: g_d(n) ≤ c^{d^{1-b_n}} for n ≥ 2",
-      "g_mono_d: g_d(n) increasing in d for n ≥ 2",
-      "g_f_relationship: g_d(n) = inf{m : f_d(m) ≥ n}"
-    ],
+    "axiomCount": 8,
+    "assumptions": "8 axioms: g_well_defined, g_1_3, g_2_3, g_3_3, cube_distances, erdos_lower_bound, erdos_straus_upper_bound, g_f_relationship. g_d_2 REMOVED (incorrect: should be d+2 not 3). g_mono_d PROVED via isometric embedding (1 sorry in norm calculation). 1 sorry(s) remain.",
     "prerequisites": [
       "Discrete and combinatorial geometry: point configurations and distances",
-      "Euclidean space ℝ^d and the distance function",
-      "The distinct distances problem (Erdős 1946) and its higher-dimensional variants",
+      "Euclidean space \u211d^d and the distance function",
+      "The distinct distances problem (Erd\u0151s 1946) and its higher-dimensional variants",
       "Threshold functions and extremal combinatorics",
       "Filter-based limits in Lean (Filter.Tendsto)"
     ],
-    "lineCount": 307,
+    "lineCount": 382,
     "relatedProblems": [
       {
         "id": "erdos-1083",
@@ -107,7 +96,7 @@
     {
       "id": "points",
       "title": "Points and Distances",
-      "summary": "Defines Point d = EuclideanSpace ℝ (Fin d), Euclidean distance via ‖p - q‖, distinctDistances via Finset.product/image/filter, and numDistinctDistances as the cardinality.",
+      "summary": "Defines Point d = EuclideanSpace \u211d (Fin d), Euclidean distance via \u2016p - q\u2016, distinctDistances via Finset.product/image/filter, and numDistinctDistances as the cardinality.",
       "startLine": 38,
       "endLine": 58,
       "mathContext": "$\\text{Point}\\,d = \\text{EuclideanSpace}\\,\\mathbb{R}\\,(\\text{Fin}\\,d)$. Distance: $d(p,q) = \\|p - q\\|$. $\\Delta(P) = \\{\\|p-q\\| : (p,q) \\in P \\times P, p \\neq q\\}$ via `Finset.image` and `Finset.filter`."
@@ -115,7 +104,7 @@
     {
       "id": "gfunction",
       "title": "The Function g_d(n)",
-      "summary": "Defines determinesNDistances (numDistinctDistances P ≥ n) and g d n via Nat.sInf. Axiomatizes well-definedness for n ≥ 1.",
+      "summary": "Defines determinesNDistances (numDistinctDistances P \u2265 n) and g d n via Nat.sInf. Axiomatizes well-definedness for n \u2265 1.",
       "startLine": 59,
       "endLine": 76,
       "mathContext": "$g_d(n) = \\inf\\{m \\in \\mathbb{N} : \\forall P \\subseteq \\mathbb{R}^d,\\,|P|=m \\implies |\\Delta(P)| \\geq n\\}$. Well-definedness ($g_d(n) < \\infty$ for $n \\geq 1$) is axiomatized."
@@ -130,16 +119,16 @@
     },
     {
       "id": "lower",
-      "title": "Lower Bound: Cube Construction and Erdős Bound",
+      "title": "Lower Bound: Cube Construction and Erd\u0151s Bound",
       "summary": "Defines `cubeVertices` as a concrete `Finset (Point d)` via `Finset.univ.image`, proves `cube_card` ($2^d$ vertices via injectivity), axiomatizes `cube_distances` ($\\leq d$ distinct distances), and fully proves `cube_lower_bound` ($g_d(d+1) > 2^d$) via subset extraction and contradiction. Also axiomatizes `erdos_lower_bound`: $g_d(n) \\geq c \\cdot d^{n-1}$ for $n \\geq 2$.",
       "startLine": 141,
       "endLine": 204,
-      "mathContext": "$\\{0,1\\}^d$ has $2^d$ vertices with $|\\Delta| = d$ (distances $\\sqrt{k}$ for $k = 1, \\ldots, d$). Hence $g_d(d+1) > 2^d$. General counting: $g_d(n) \\geq c \\cdot d^{n-1}$ for fixed $n \\geq 2$ (Erdős 1975)."
+      "mathContext": "$\\{0,1\\}^d$ has $2^d$ vertices with $|\\Delta| = d$ (distances $\\sqrt{k}$ for $k = 1, \\ldots, d$). Hence $g_d(d+1) > 2^d$. General counting: $g_d(n) \\geq c \\cdot d^{n-1}$ for fixed $n \\geq 2$ (Erd\u0151s 1975)."
     },
     {
       "id": "upper",
-      "title": "Upper Bound: Erdős-Straus",
-      "summary": "Axiomatizes the Erdős-Straus bound: $g_d(n) \\leq c^{d^{1-b_n}}$ for constants $c > 1, b_n > 0$. This stretched-exponential upper bound creates the vast gap with the polynomial lower bound — the central challenge of the problem.",
+      "title": "Upper Bound: Erd\u0151s-Straus",
+      "summary": "Axiomatizes the Erd\u0151s-Straus bound: $g_d(n) \\leq c^{d^{1-b_n}}$ for constants $c > 1, b_n > 0$. This stretched-exponential upper bound creates the vast gap with the polynomial lower bound \u2014 the central challenge of the problem.",
       "startLine": 206,
       "endLine": 215,
       "mathContext": "$g_d(n) \\leq c^{d^{1-b_n}}$ for constants $c > 1, 0 < b_n < 1$ depending on $n$. The gap: $c_1 \\cdot d^{n-1} \\leq g_d(n) \\leq c_2^{d^{1-b_n}}$ (polynomial vs. stretched-exponential in $d$). Whether the truth is polynomial or super-polynomial is wide open."
@@ -147,15 +136,15 @@
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
-      "summary": "Defines gRatio(d, n) = g_d(n)/d^{n-1} and erdos1089Conjecture via Filter.Tendsto. Defines ratioIsBounded as a weaker question. Proves ratio_bounded_below genuinely from the Erdős lower bound.",
+      "summary": "Defines gRatio(d, n) = g_d(n)/d^{n-1} and erdos1089Conjecture via Filter.Tendsto. Defines ratioIsBounded as a weaker question. Proves ratio_bounded_below genuinely from the Erd\u0151s lower bound.",
       "startLine": 217,
       "endLine": 242,
-      "mathContext": "$R(d,n) = g_d(n)/d^{n-1}$. Conjecture: $\\exists L \\geq 0,\\; R(d,n) \\to L$ as $d \\to \\infty$. Proved: $R(d,n) \\geq c > 0$ from the Erdős lower bound."
+      "mathContext": "$R(d,n) = g_d(n)/d^{n-1}$. Conjecture: $\\exists L \\geq 0,\\; R(d,n) \\to L$ as $d \\to \\infty$. Proved: $R(d,n) \\geq c > 0$ from the Erd\u0151s lower bound."
     },
     {
       "id": "mono",
       "title": "Monotonicity Properties",
-      "summary": "Proves g_mono_n (g increasing in n: more distances need more points) and axiomatizes g_mono_d (g increasing in d for n ≥ 2: higher dimensions allow more few-distance configurations).",
+      "summary": "Proves g_mono_n (g increasing in n: more distances need more points) and axiomatizes g_mono_d (g increasing in d for n \u2265 2: higher dimensions allow more few-distance configurations).",
       "startLine": 244,
       "endLine": 277,
       "mathContext": "$n_1 \\leq n_2 \\implies g_d(n_1) \\leq g_d(n_2)$ (more distances $\\Rightarrow$ more points). $d_1 \\leq d_2 \\implies g_{d_1}(n) \\leq g_{d_2}(n)$ for $n \\geq 2$ (higher dimensions allow larger few-distance sets)."
@@ -163,26 +152,26 @@
     {
       "id": "inverse",
       "title": "Connection to f_d(n) and Problem #1083",
-      "summary": "Defines f d n = max distinct distances from n points. Axiomatizes g_f_relationship: g_d(n) = min{m : f_d(m) ≥ n}. Names the full open problem as erdos1089OpenProblem.",
+      "summary": "Defines f d n = max distinct distances from n points. Axiomatizes g_f_relationship: g_d(n) = min{m : f_d(m) \u2265 n}. Names the full open problem as erdos1089OpenProblem.",
       "startLine": 279,
       "endLine": 307,
       "mathContext": "$f_d(n) = \\max\\{|\\Delta(P)| : P \\subseteq \\mathbb{R}^d, |P| = n\\}$. Duality: $g_d(n) = \\inf\\{m : f_d(m) \\geq n\\}$. Guth-Katz (2015): $f_2(n) \\geq cn/\\sqrt{\\log n}$."
     }
   ],
   "overview": {
-    "text": "A 307-line formalization of Erdős Problem #1089 (Kelly-Erdős, 1975): given $n$ fixed, what is the minimum number $g_d(n)$ of points in $\\mathbb{R}^d$ needed to guarantee $n$ distinct pairwise distances? The formalization defines $g_d(n)$ as a threshold function via `Nat.sInf`, axiomatizes the key bounds ($g_d(n) \\geq c \\cdot d^{n-1}$; $g_d(n) \\leq c^{d^{1-b_n}}$), and states the main conjecture: does $\\lim_{d \\to \\infty} g_d(n)/d^{n-1}$ exist? The central tension is the vast gap between the polynomial lower bound ($d^{n-1}$) and the stretched-exponential upper bound ($c^{d^{1-b_n}}$). Of the 10 axioms, 4 encode geometric constructions and small cases, 3 encode known bounds (Erdős lower, Straus upper, well-definedness), and 3 encode structural properties (monotonicity in $d$, $g$-$f$ relationship, $g_d(2)=3$). Five theorems are fully proved: `g_d_1` ($g_d(1)=2$ via 44-line le_antisymm argument), `cube_card` ($2^d$ vertices via injectivity), `cube_lower_bound` ($g_d(d+1) > 2^d$ via subset extraction and contradiction), `ratio_bounded_below` (the ratio $g_d(n)/d^{n-1} \\geq c > 0$ from the Erdős lower bound), and `g_mono_n` (monotonicity in $n$ via sInf reasoning). 0 sorries remain.",
-    "historicalContext": "The distinct distances problem in higher dimensions was posed by L.M. Kelly and Paul Erdős in their 1975 paper on combinatorial geometry. It generalizes the famous planar distinct distances problem — solved by Larry Guth and Nets Hawk Katz in 2015 (published in *Annals of Mathematics*), who proved $f_2(n) \\geq cn/\\sqrt{\\log n}$ using algebraic topology and polynomial partitioning — to arbitrary dimension $d$. But with a twist: instead of fixing $d$ and varying $n$, Problem #1089 fixes the number of distinct distances $n$ and asks how the threshold $g_d(n)$ grows with $d$.\n\nThe key construction is the $d$-dimensional unit cube $\\{0,1\\}^d$: its $2^d$ vertices produce only $d$ distinct distances ($\\sqrt{1}, \\sqrt{2}, \\ldots, \\sqrt{d}$), since two vertices differing in $k$ coordinates have Hamming-Euclidean distance $\\sqrt{k}$. This shows $g_d(d+1) > 2^d$. Erdős proved 'easily' that $g_d(n) \\gg d^{n-1}$ for fixed $n$ using a counting argument, establishing a polynomial lower bound. Croft (1962) computed the exact value $g_3(3) = 7$ through a painstaking analysis of all possible 6-point configurations in $\\mathbb{R}^3$ with at most 2 distinct distances.\n\nThe upper bound side remains poorly understood: the Erdős-Straus bound $g_d(n) \\leq c^{d^{1-b_n}}$ is stretched-exponential, leaving an enormous gap with the polynomial lower bound. Whether $g_d(n)/d^{n-1}$ converges as $d \\to \\infty$ for fixed $n$ is the central open question. If the limit exists and is positive, it determines the exact polynomial growth rate; if it diverges, $g_d(n)$ grows super-polynomially in $d$.",
+    "text": "A 307-line formalization of Erd\u0151s Problem #1089 (Kelly-Erd\u0151s, 1975): given $n$ fixed, what is the minimum number $g_d(n)$ of points in $\\mathbb{R}^d$ needed to guarantee $n$ distinct pairwise distances? The formalization defines $g_d(n)$ as a threshold function via `Nat.sInf`, axiomatizes the key bounds ($g_d(n) \\geq c \\cdot d^{n-1}$; $g_d(n) \\leq c^{d^{1-b_n}}$), and states the main conjecture: does $\\lim_{d \\to \\infty} g_d(n)/d^{n-1}$ exist? The central tension is the vast gap between the polynomial lower bound ($d^{n-1}$) and the stretched-exponential upper bound ($c^{d^{1-b_n}}$). Of the 10 axioms, 4 encode geometric constructions and small cases, 3 encode known bounds (Erd\u0151s lower, Straus upper, well-definedness), and 3 encode structural properties (monotonicity in $d$, $g$-$f$ relationship, $g_d(2)=3$). Five theorems are fully proved: `g_d_1` ($g_d(1)=2$ via 44-line le_antisymm argument), `cube_card` ($2^d$ vertices via injectivity), `cube_lower_bound` ($g_d(d+1) > 2^d$ via subset extraction and contradiction), `ratio_bounded_below` (the ratio $g_d(n)/d^{n-1} \\geq c > 0$ from the Erd\u0151s lower bound), and `g_mono_n` (monotonicity in $n$ via sInf reasoning). 0 sorries remain.",
+    "historicalContext": "The distinct distances problem in higher dimensions was posed by L.M. Kelly and Paul Erd\u0151s in their 1975 paper on combinatorial geometry. It generalizes the famous planar distinct distances problem \u2014 solved by Larry Guth and Nets Hawk Katz in 2015 (published in *Annals of Mathematics*), who proved $f_2(n) \\geq cn/\\sqrt{\\log n}$ using algebraic topology and polynomial partitioning \u2014 to arbitrary dimension $d$. But with a twist: instead of fixing $d$ and varying $n$, Problem #1089 fixes the number of distinct distances $n$ and asks how the threshold $g_d(n)$ grows with $d$.\n\nThe key construction is the $d$-dimensional unit cube $\\{0,1\\}^d$: its $2^d$ vertices produce only $d$ distinct distances ($\\sqrt{1}, \\sqrt{2}, \\ldots, \\sqrt{d}$), since two vertices differing in $k$ coordinates have Hamming-Euclidean distance $\\sqrt{k}$. This shows $g_d(d+1) > 2^d$. Erd\u0151s proved 'easily' that $g_d(n) \\gg d^{n-1}$ for fixed $n$ using a counting argument, establishing a polynomial lower bound. Croft (1962) computed the exact value $g_3(3) = 7$ through a painstaking analysis of all possible 6-point configurations in $\\mathbb{R}^3$ with at most 2 distinct distances.\n\nThe upper bound side remains poorly understood: the Erd\u0151s-Straus bound $g_d(n) \\leq c^{d^{1-b_n}}$ is stretched-exponential, leaving an enormous gap with the polynomial lower bound. Whether $g_d(n)/d^{n-1}$ converges as $d \\to \\infty$ for fixed $n$ is the central open question. If the limit exists and is positive, it determines the exact polynomial growth rate; if it diverges, $g_d(n)$ grows super-polynomially in $d$.",
     "problemStatement": "Let $g_d(n)$ be minimal such that every collection of $g_d(n)$ points in $\\mathbb{R}^d$ determines at least $n$ distinct distances. Estimate $g_d(n)$. In particular, does $\\lim_{d \\to \\infty} g_d(n)/d^{n-1}$ exist?",
-    "proofStrategy": "The formalization defines g_d(n) as the infimum of thresholds guaranteeing n distinct distances in ℝ^d, using Mathlib's EuclideanSpace. Cube vertices are concretely defined (Fin d → Fin 2 mapped into EuclideanSpace) with cube_card proved via injectivity and cube_lower_bound proved via subset extraction. Known bounds are captured as axioms. The theorems g_d_1, cube_lower_bound, ratio_bounded_below, and g_mono_n are all fully proved. The f_d(n) inverse function connects to Problem #1083.",
+    "proofStrategy": "The formalization defines g_d(n) as the infimum of thresholds guaranteeing n distinct distances in \u211d^d, using Mathlib's EuclideanSpace. Cube vertices are concretely defined (Fin d \u2192 Fin 2 mapped into EuclideanSpace) with cube_card proved via injectivity and cube_lower_bound proved via subset extraction. Known bounds are captured as axioms. The theorems g_d_1, cube_lower_bound, ratio_bounded_below, and g_mono_n are all fully proved. The f_d(n) inverse function connects to Problem #1083.",
     "keyInsights": [
-      "**Threshold function**: $g_d(n) = \\min\\{m : \\text{every } m\\text{-point set in } \\mathbb{R}^d \\text{ has} \\geq n \\text{ distinct distances}\\}$ — the central combinatorial quantity",
-      "**Cube construction**: The $d$-cube $\\{0,1\\}^d$ has $2^d$ vertices but only $d$ distinct distances $\\sqrt{1}, \\ldots, \\sqrt{d}$, giving $g_d(d+1) > 2^d$ — exponential growth in $d$ for linear growth in $n$",
-      "**Small exact values**: $g_1(3)=4$, $g_2(3)=6$, $g_3(3)=7$ (Croft 1962) — values grow with dimension, reflecting that higher-dimensional spaces allow larger few-distance configurations",
-      "**Polynomial lower bound**: $g_d(n) \\gg d^{n-1}$ (Erdős, 'easy') via counting arguments, establishing that the threshold grows at least polynomially in $d$",
-      "**Stretched-exponential upper bound**: $g_d(n) \\leq c^{d^{1-b_n}}$ (Erdős-Straus) leaves an enormous gap with the polynomial lower bound — closing this gap is the heart of the open problem",
-      "**Genuinely proved**: The ratio $g_d(n)/d^{n-1} \\geq c > 0$ is proved from the Erdős lower bound axiom; convergence of this ratio as $d \\to \\infty$ is the open question",
-      "**Dimension vs. point count duality**: While the planar problem (Guth-Katz 2015) fixes $d=2$ and grows $n$, this problem fixes $n$ and grows $d$ — exploring the complementary axis of the distance problem landscape. The polynomial partitioning technique that resolved the planar case has yet to yield results in the high-dimensional threshold setting",
-      "**Concentration of measure obstruction**: Random point configurations in high dimensions are useless for few-distance sets: on $S^{d-1}$, pairwise distances concentrate near $\\sqrt{2}$ as $d \\to \\infty$ (by the law of large numbers applied to $\\|p - q\\|^2 = 2 - 2\\langle p, q \\rangle$ where $\\langle p, q \\rangle \\to 0$). Achieving fewer than $n$ distinct distances requires algebraic or combinatorial structure, not random placement — explaining why constructions like the cube (with its lattice structure) are essential"
+      "**Threshold function**: $g_d(n) = \\min\\{m : \\text{every } m\\text{-point set in } \\mathbb{R}^d \\text{ has} \\geq n \\text{ distinct distances}\\}$ \u2014 the central combinatorial quantity",
+      "**Cube construction**: The $d$-cube $\\{0,1\\}^d$ has $2^d$ vertices but only $d$ distinct distances $\\sqrt{1}, \\ldots, \\sqrt{d}$, giving $g_d(d+1) > 2^d$ \u2014 exponential growth in $d$ for linear growth in $n$",
+      "**Small exact values**: $g_1(3)=4$, $g_2(3)=6$, $g_3(3)=7$ (Croft 1962) \u2014 values grow with dimension, reflecting that higher-dimensional spaces allow larger few-distance configurations",
+      "**Polynomial lower bound**: $g_d(n) \\gg d^{n-1}$ (Erd\u0151s, 'easy') via counting arguments, establishing that the threshold grows at least polynomially in $d$",
+      "**Stretched-exponential upper bound**: $g_d(n) \\leq c^{d^{1-b_n}}$ (Erd\u0151s-Straus) leaves an enormous gap with the polynomial lower bound \u2014 closing this gap is the heart of the open problem",
+      "**Genuinely proved**: The ratio $g_d(n)/d^{n-1} \\geq c > 0$ is proved from the Erd\u0151s lower bound axiom; convergence of this ratio as $d \\to \\infty$ is the open question",
+      "**Dimension vs. point count duality**: While the planar problem (Guth-Katz 2015) fixes $d=2$ and grows $n$, this problem fixes $n$ and grows $d$ \u2014 exploring the complementary axis of the distance problem landscape. The polynomial partitioning technique that resolved the planar case has yet to yield results in the high-dimensional threshold setting",
+      "**Concentration of measure obstruction**: Random point configurations in high dimensions are useless for few-distance sets: on $S^{d-1}$, pairwise distances concentrate near $\\sqrt{2}$ as $d \\to \\infty$ (by the law of large numbers applied to $\\|p - q\\|^2 = 2 - 2\\langle p, q \\rangle$ where $\\langle p, q \\rangle \\to 0$). Achieving fewer than $n$ distinct distances requires algebraic or combinatorial structure, not random placement \u2014 explaining why constructions like the cube (with its lattice structure) are essential"
     ],
     "prerequisites": [
       "Combinatorial geometry (incidence bounds, configurations)",
@@ -198,7 +187,7 @@
     {
       "targetId": "szemeredi-regularity",
       "relationship": "related",
-      "description": "Both are central results in combinatorial geometry/graph theory. Szemerédi's regularity lemma provides pseudorandom partition tools applicable to geometric incidence problems, which underlie bounds on distinct distances"
+      "description": "Both are central results in combinatorial geometry/graph theory. Szemer\u00e9di's regularity lemma provides pseudorandom partition tools applicable to geometric incidence problems, which underlie bounds on distinct distances"
     },
     {
       "targetId": "combinations-formula",
@@ -223,12 +212,12 @@
     {
       "targetId": "borsuk-ulam",
       "relationship": "related",
-      "description": "The Borsuk-Ulam theorem is a key topological tool in combinatorial geometry: it implies that any continuous map $S^n \\to \\mathbb{R}^n$ identifies antipodal points. In distance problems, topological methods complement algebraic and combinatorial approaches — the Borsuk conjecture on partitions of sets with diameter constraints is closely tied to distance set questions in high dimensions"
+      "description": "The Borsuk-Ulam theorem is a key topological tool in combinatorial geometry: it implies that any continuous map $S^n \\to \\mathbb{R}^n$ identifies antipodal points. In distance problems, topological methods complement algebraic and combinatorial approaches \u2014 the Borsuk conjecture on partitions of sets with diameter constraints is closely tied to distance set questions in high dimensions"
     },
     {
       "targetId": "minkowski-theorem",
       "relationship": "related",
-      "description": "Minkowski's theorem on convex bodies and lattice points provides geometric constraints in Euclidean space relevant to distance problems. The integer lattice $\\mathbb{Z}^d \\cap B(0,R)$ produces $O(R^d)$ points with controlled distance sets — the interplay between lattice structure and distance counting is central to constructing few-distance point configurations in high dimensions, which provide lower bounds on $g_d(n)$"
+      "description": "Minkowski's theorem on convex bodies and lattice points provides geometric constraints in Euclidean space relevant to distance problems. The integer lattice $\\mathbb{Z}^d \\cap B(0,R)$ produces $O(R^d)$ points with controlled distance sets \u2014 the interplay between lattice structure and distance counting is central to constructing few-distance point configurations in high dimensions, which provide lower bounds on $g_d(n)$"
     },
     {
       "targetId": "isoperimetric-theorem",
@@ -237,20 +226,20 @@
     }
   ],
   "conclusion": {
-    "summary": "This 307-line formalization defines the threshold function $g_d(n)$ — the minimum number of points in $\\mathbb{R}^d$ guaranteeing $n$ distinct pairwise distances — and establishes the known bounds: Erdős's polynomial lower bound $g_d(n) \\gg d^{n-1}$ and the Erdős-Straus stretched-exponential upper bound $g_d(n) \\leq c^{d^{1-b_n}}$. Five theorems are fully proved (0 sorries): `g_d_1` ($g_d(1)=2$), `cube_card` ($2^d$ cube vertices), `cube_lower_bound` ($g_d(d+1) > 2^d$), `ratio_bounded_below` ($g_d(n)/d^{n-1} \\geq c > 0$), and `g_mono_n` (monotonicity in $n$). The cube construction ($\\{0,1\\}^d$ has $2^d$ vertices but only $d$ distinct distances) illustrates why algebraic structure is essential. The Galois connection $g_d(n) = \\inf\\{m : f_d(m) \\geq n\\}$ links this to Problem #1083 and the Guth-Katz planar result.",
-    "implications": "**Theoretical Connections:**\n\n1. **Planar distinct distances (Guth-Katz 2015):** Problem #1089 is the high-dimensional counterpart — fixing $n$ and varying $d$ rather than fixing $d=2$ and varying $n$. The polynomial partitioning technique that resolved the planar case has not yielded results in the threshold setting, suggesting fundamentally different methods may be needed for the high-dimensional problem.\n\n2. **Coding theory:** Distance codes in $\\mathbb{R}^d$ require point sets with controlled distance spectra. The threshold $g_d(n)$ directly measures how efficiently one can avoid distance repetition in high dimensions. Connections to equiangular lines, Johnson-Lindenstrauss embeddings, and compressed sensing arise from the same geometric constraints.\n\n3. **Concentration of measure:** In high dimensions, random point configurations on the unit sphere $S^{d-1}$ have pairwise distances concentrating near $\\sqrt{2}$ as $d \\to \\infty$. This means achieving many distinct distances requires carefully constructed (non-random) configurations — explaining why $g_d(n)$ must grow with $d$ and why algebraic constructions (like the cube) are essential.\n\n4. **Finite metric spaces:** The problem is equivalent to asking: what is the minimum size of a finite subset of $\\ell_2^d$ whose distance set has cardinality $\\geq n$? This connects to the theory of metric embeddings and the distortion required to embed metric spaces into Euclidean space.\n\n5. **Sphere packing:** Few-distance point sets (configurations with small $|\\Delta(P)|$) are intimately related to sphere packings and kissing numbers. The $d$-cube with $d$ distinct distances is related to the densest lattice packings in high dimensions, where the number of distinct inter-point distances in the first coordination shell determines the kissing number.",
+    "summary": "This 307-line formalization defines the threshold function $g_d(n)$ \u2014 the minimum number of points in $\\mathbb{R}^d$ guaranteeing $n$ distinct pairwise distances \u2014 and establishes the known bounds: Erd\u0151s's polynomial lower bound $g_d(n) \\gg d^{n-1}$ and the Erd\u0151s-Straus stretched-exponential upper bound $g_d(n) \\leq c^{d^{1-b_n}}$. Five theorems are fully proved (0 sorries): `g_d_1` ($g_d(1)=2$), `cube_card` ($2^d$ cube vertices), `cube_lower_bound` ($g_d(d+1) > 2^d$), `ratio_bounded_below` ($g_d(n)/d^{n-1} \\geq c > 0$), and `g_mono_n` (monotonicity in $n$). The cube construction ($\\{0,1\\}^d$ has $2^d$ vertices but only $d$ distinct distances) illustrates why algebraic structure is essential. The Galois connection $g_d(n) = \\inf\\{m : f_d(m) \\geq n\\}$ links this to Problem #1083 and the Guth-Katz planar result.",
+    "implications": "**Theoretical Connections:**\n\n1. **Planar distinct distances (Guth-Katz 2015):** Problem #1089 is the high-dimensional counterpart \u2014 fixing $n$ and varying $d$ rather than fixing $d=2$ and varying $n$. The polynomial partitioning technique that resolved the planar case has not yielded results in the threshold setting, suggesting fundamentally different methods may be needed for the high-dimensional problem.\n\n2. **Coding theory:** Distance codes in $\\mathbb{R}^d$ require point sets with controlled distance spectra. The threshold $g_d(n)$ directly measures how efficiently one can avoid distance repetition in high dimensions. Connections to equiangular lines, Johnson-Lindenstrauss embeddings, and compressed sensing arise from the same geometric constraints.\n\n3. **Concentration of measure:** In high dimensions, random point configurations on the unit sphere $S^{d-1}$ have pairwise distances concentrating near $\\sqrt{2}$ as $d \\to \\infty$. This means achieving many distinct distances requires carefully constructed (non-random) configurations \u2014 explaining why $g_d(n)$ must grow with $d$ and why algebraic constructions (like the cube) are essential.\n\n4. **Finite metric spaces:** The problem is equivalent to asking: what is the minimum size of a finite subset of $\\ell_2^d$ whose distance set has cardinality $\\geq n$? This connects to the theory of metric embeddings and the distortion required to embed metric spaces into Euclidean space.\n\n5. **Sphere packing:** Few-distance point sets (configurations with small $|\\Delta(P)|$) are intimately related to sphere packings and kissing numbers. The $d$-cube with $d$ distinct distances is related to the densest lattice packings in high dimensions, where the number of distinct inter-point distances in the first coordination shell determines the kissing number.",
     "openQuestions": [
-      "Does lim_{d→∞} g_d(n)/d^{n-1} exist for each fixed n ≥ 2?",
+      "Does lim_{d\u2192\u221e} g_d(n)/d^{n-1} exist for each fixed n \u2265 2?",
       "What is the true growth rate of g_d(n): closer to d^{n-1} or to the stretched exponential?",
-      "Can the Erdős-Straus upper bound be improved to polynomial in d?",
+      "Can the Erd\u0151s-Straus upper bound be improved to polynomial in d?",
       "What is g_4(3)? No exact values are known beyond d = 3.",
       "Is the ratio g_d(n)/d^{n-1} monotone in d, which would imply convergence?"
     ]
   },
   "leanFile": {
-    "lineCount": 307,
+    "lineCount": 382,
     "structureCount": 0,
-    "axiomCount": 10,
+    "axiomCount": 8,
     "theoremCount": 5,
     "substantiveTheoremCount": 4,
     "sorryTheorems": 0,
@@ -269,81 +258,81 @@
     {
       "name": "ratio_bounded_below",
       "type": "core",
-      "description": "The ratio g_d(n)/d^{n-1} is bounded below by a positive constant — genuinely proved from the Erdős lower bound axiom",
-      "leanType": "(n : ℕ) → n ≥ 2 → ∃ c > 0, ∀ d ≥ 1, gRatio d n ≥ c"
+      "description": "The ratio g_d(n)/d^{n-1} is bounded below by a positive constant \u2014 genuinely proved from the Erd\u0151s lower bound axiom",
+      "leanType": "(n : \u2115) \u2192 n \u2265 2 \u2192 \u2203 c > 0, \u2200 d \u2265 1, gRatio d n \u2265 c"
     },
     {
       "name": "g_d_1",
       "type": "core",
       "description": "g_d(1) = 2 for d >= 1: any two distinct points determine exactly one distance (44-line proof via le_antisymm)",
-      "leanType": "(d : ℕ) → d ≥ 1 → g d 1 = 2"
+      "leanType": "(d : \u2115) \u2192 d \u2265 1 \u2192 g d 1 = 2"
     },
     {
       "name": "cube_lower_bound",
       "type": "core",
       "description": "g_d(d+1) > 2^d: the d-cube's 2^d vertices have only d distinct distances, proving the threshold exceeds 2^d",
-      "leanType": "(d : ℕ) → g d (d + 1) > 2^d"
+      "leanType": "(d : \u2115) \u2192 g d (d + 1) > 2^d"
     },
     {
       "name": "g_mono_n",
       "type": "core",
       "description": "g_d is monotone in n: requiring more distinct distances needs at least as many points",
-      "leanType": "∀ d n₁ n₂, n₁ ≤ n₂ → g d n₁ ≤ g d n₂"
+      "leanType": "\u2200 d n\u2081 n\u2082, n\u2081 \u2264 n\u2082 \u2192 g d n\u2081 \u2264 g d n\u2082"
     },
     {
       "name": "erdos1089Conjecture",
       "type": "definition",
-      "description": "The limit conjecture: g_d(n)/d^{n-1} converges as d → ∞ for each fixed n",
-      "leanType": "(n : ℕ) → Prop := ∃ L, Filter.Tendsto (fun d => gRatio d n) Filter.atTop (nhds L)"
+      "description": "The limit conjecture: g_d(n)/d^{n-1} converges as d \u2192 \u221e for each fixed n",
+      "leanType": "(n : \u2115) \u2192 Prop := \u2203 L, Filter.Tendsto (fun d => gRatio d n) Filter.atTop (nhds L)"
     },
     {
       "name": "erdos_lower_bound",
       "type": "axiom",
-      "description": "Erdős polynomial lower bound: g_d(n) ≥ c·d^{n-1} for n ≥ 2 (1975)",
-      "leanType": "∃ c > 0, ∀ d ≥ 1, g d n ≥ c * d^(n-1)"
+      "description": "Erd\u0151s polynomial lower bound: g_d(n) \u2265 c\u00b7d^{n-1} for n \u2265 2 (1975)",
+      "leanType": "\u2203 c > 0, \u2200 d \u2265 1, g d n \u2265 c * d^(n-1)"
     },
     {
       "name": "erdos_straus_upper_bound",
       "type": "axiom",
-      "description": "Erdős-Straus stretched-exponential upper bound: g_d(n) ≤ c^{d^{1-b_n}}",
-      "leanType": "∃ c > 1, ∃ b > 0, ∀ d ≥ 1, g d n ≤ c^(d^(1-b))"
+      "description": "Erd\u0151s-Straus stretched-exponential upper bound: g_d(n) \u2264 c^{d^{1-b_n}}",
+      "leanType": "\u2203 c > 1, \u2203 b > 0, \u2200 d \u2265 1, g d n \u2264 c^(d^(1-b))"
     }
   ],
   "references": [
     {
-      "authors": "Erdős, Paul",
+      "authors": "Erd\u0151s, Paul",
       "title": "On some problems of elementary and combinatorial geometry",
       "year": "1975",
       "venue": "Annali di Matematica Pura ed Applicata 103, pp. 99-108",
-      "note": "Introduced the threshold function g_d(n) and proved the lower bound g_d(n) ≫ d^{n-1}"
+      "note": "Introduced the threshold function g_d(n) and proved the lower bound g_d(n) \u226b d^{n-1}"
     },
     {
       "authors": "Guth, Larry; Katz, Nets Hawk",
-      "title": "On the Erdős distinct distances problem in the plane",
+      "title": "On the Erd\u0151s distinct distances problem in the plane",
       "year": "2015",
       "venue": "Annals of Mathematics 181, pp. 155-190",
-      "note": "Resolved the 2D distinct distances conjecture (f_2(n) ≥ cn/√log n); the higher-dimensional analog motivates this problem"
+      "note": "Resolved the 2D distinct distances conjecture (f_2(n) \u2265 cn/\u221alog n); the higher-dimensional analog motivates this problem"
     },
     {
       "authors": "Croft, Hallard T.",
       "title": "6-point and 7-point configurations in 3-space",
       "year": "1962",
       "venue": "Proceedings of the London Mathematical Society 12, pp. 400-424",
-      "note": "Computed g_3(3) = 7 — the largest known exact value of the threshold function"
+      "note": "Computed g_3(3) = 7 \u2014 the largest known exact value of the threshold function"
     },
     {
-      "authors": "Solymosi, József; Vu, Van",
-      "title": "Near optimal bounds for the Erdős distinct distances problem in high dimensions",
+      "authors": "Solymosi, J\u00f3zsef; Vu, Van",
+      "title": "Near optimal bounds for the Erd\u0151s distinct distances problem in high dimensions",
       "year": "2008",
       "venue": "Combinatorica 28, pp. 113-125",
       "note": "Best known bounds for distinct distances in high dimensions using polynomial method techniques"
     },
     {
-      "authors": "Brass, Peter; Moser, William; Pach, János",
+      "authors": "Brass, Peter; Moser, William; Pach, J\u00e1nos",
       "title": "Research Problems in Discrete Geometry",
       "year": "2005",
       "venue": "Springer",
-      "note": "Comprehensive survey of distinct distance problems including the g_d(n) threshold function, the Erdős lower bound, and the Erdős-Straus stretched-exponential upper bound (Chapter 6)"
+      "note": "Comprehensive survey of distinct distance problems including the g_d(n) threshold function, the Erd\u0151s lower bound, and the Erd\u0151s-Straus stretched-exponential upper bound (Chapter 6)"
     }
   ]
 }

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -50,8 +50,8 @@
       "Connection between Schur numbers and Ramsey numbers",
       "Growth rate bounds and limit formulations"
     ],
-    "axiomCount": 8,
-    "lineCount": 407,
+    "axiomCount": 7,
+    "lineCount": 512,
     "references": [
       {
         "title": "Some remarks on the theory of graphs",
@@ -76,7 +76,7 @@
         "description": "Establishes the lower bound R(3;k) ≥ 380^{k/5} − O(1), a major improvement over previous bounds"
       }
     ],
-    "assumptions": "8 axioms: forcing_set_nonempty, R3k_three (=17), R3k_inductive_upper, R3k_factorial_upper, SchurNumber (definition), R3k_schur_lower, R3k_exponential_lower, R3k_precise_lower. R3k_two PROVED via pigeonhole + C₅ construction. 0 sorry(s) remain."
+    "assumptions": "7 axioms: R3k_three (=17), R3k_inductive_upper, R3k_factorial_upper, SchurNumber (definition), R3k_schur_lower, R3k_exponential_lower, R3k_precise_lower. forcing_set_nonempty PROVED via pigeonhole induction (Ramsey's theorem for triangles). R3k_two PROVED via pigeonhole + C₅ construction. 0 sorry(s) remain."
   },
   "overview": {
     "historicalContext": "This problem was posed by Paul Erdős in 1961 [Er61] and remains one of the fundamental open questions in Ramsey theory. The multicolor Ramsey number R(3;k) generalizes the classical two-color Ramsey number R(3,3) = 6, which asks for the minimum n such that any 2-coloring of K_n's edges contains a monochromatic triangle.\n\nThe problem connects to several areas of combinatorics. The upper bound R(3;k) ≤ ⌈e·k!⌉ follows from a clever pigeonhole argument, while lower bounds come from connections to Schur numbers. A major breakthrough came in 2021 when Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik [ACPPRT21] improved the lower bound to R(3;k) ≥ 380^{k/5} - O(1).\n\nErdős offered $250 for solving this problem, with an additional $100 specifically for proving that the limit is finite. The gap between known bounds is enormous: R(3;k) lies between roughly 3.28^k and k!, making this one of the most intriguing open problems in Ramsey theory.",
@@ -176,9 +176,9 @@
       "Classical"
     ],
     "namespace": "Erdos183",
-    "lineCount": 407,
-    "axiomCount": 8,
-    "theoremCount": 10,
+    "lineCount": 512,
+    "axiomCount": 7,
+    "theoremCount": 13,
     "definitionCount": 13
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -54,9 +54,9 @@
       "Definition of the least-prime-factor filtered sum f(n) and its sufficiency axiom",
       "Splitting into smallPrimeDivisibleSum and largePrimeSum with Erdős's question about individual divergence"
     ],
-    "axiomCount": 4,
-    "lineCount": 200,
-    "assumptions": "4 axioms: sieve_greedy (provable from construction, needs nonemptiness proof), eggleton_erdos_selfridge (deep result), sieve_conjectured_bound (conjecture), filtered_sum_implies_full. sieve_initial proved from constructive definition. erdos_460_restricted_question proved via sub-sum comparison (restricted sums ≤ full reciprocal sum)."
+    "axiomCount": 3,
+    "lineCount": 203,
+    "assumptions": "3 axioms: sieve_greedy (provable from construction), eggleton_erdos_selfridge (deep result), filtered_sum_implies_full. sieve_conjectured_bound demoted to def (was incorrectly axiomatized as open conjecture)."
   },
   "leanFile": {
     "imports": [
@@ -69,8 +69,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 200,
-    "axiomCount": 4,
+    "lineCount": 203,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 8
   },

--- a/src/data/research/problems/erdos-1089-oq-01.json
+++ b/src/data/research/problems/erdos-1089-oq-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-1089-oq-01",
-  "title": "Does lim_{d→∞} g_d(n)/d^{n-1} exist for each fixed n ≥ 2",
+  "title": "Does lim_{d\u2192\u221e} g_d(n)/d^{n-1} exist for each fixed n \u2265 2",
   "phase": "NEW",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal mathematical investigation: Does lim_{d→∞} g_d(n)/d^{n-1} exist for each fixed n ≥ 2.",
+    "plain": "Formal mathematical investigation: Does lim_{d\u2192\u221e} g_d(n)/d^{n-1} exist for each fixed n \u2265 2.",
     "whyMatters": []
   },
   "knownResults": {
@@ -29,16 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Parent Erdos1089Problem.lean: 10A, 5T, 0S. No OQ01-specific Lean file.",
+    "progressSummary": "PROGRESS: Removed incorrect g_d_2 axiom (BUG FIX), proved g_mono_d (10A\u21928A, +1 sorry in norm calc)",
     "builtItems": [
       "Proved g_d_1: g d 1 = 2 (Erdos1089Problem.lean)",
       "Proved cube_lower_bound: g d (d+1) > 2^d via cube subset monotonicity (Erdos1089Problem.lean)",
-      "Proved distinctDistances_mono: distance set monotone under subset (Erdos1089Problem.lean)"
+      "Proved distinctDistances_mono: distance set monotone under subset (Erdos1089Problem.lean)",
+      "embedPoint: isometric embedding Point d\u2081 \u2192 Point d\u2082 via zero-padding",
+      "g_mono_d (THEOREM): monotonicity in d proved by embedding argument"
     ],
     "insights": [
-      "Finset.mk_mem_product bridges .product and ×ˢ notation gap for membership proofs",
+      "Finset.mk_mem_product bridges .product and \u00d7\u02e2 notation gap for membership proofs",
       "Finset.exists_subset_card_eq exists in Mathlib for constructing subsets of given cardinality",
-      "dsimp reduces match expressions that simp cannot handle"
+      "dsimp reduces match expressions that simp cannot handle",
+      "g_d_2 axiom was INCORRECT: g_d(2) = d+2 not 3 (equilateral triangle in \u211d^d has 1 distance for d\u22652)",
+      "g_mono_d proved via isometric embedding \u211d^{d\u2081} \u21aa \u211d^{d\u2082} (pad with zeros); sorry remains on norm calculation"
     ],
     "mathlibGaps": [],
     "nextSteps": []
@@ -63,18 +67,18 @@
     "mathlib": []
   },
   "started": "2026-03-24T00:48:59.904Z",
-  "lastUpdate": "2026-03-24T00:48:59.904Z",
+  "lastUpdate": "2026-03-28T11:00:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1089Problem.lean",
       "filename": "Erdos1089Problem.lean",
-      "lineCount": 308,
+      "lineCount": 382,
       "theoremCount": 5,
-      "axiomCount": 10,
+      "axiomCount": 8,
       "defCount": 11,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1089Problem.lean"
     }

--- a/src/data/research/problems/erdos-183.json
+++ b/src/data/research/problems/erdos-183.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-183",
-  "title": "Erdős #183",
+  "title": "Erd\u0151s #183",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -18,30 +18,34 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-26T00:00:00Z",
-    "iteration": 3,
-    "focus": "8 axioms (down from 9). Proved R3k_two (R(3,3)=6) via pigeonhole + C₅ construction.",
+    "iteration": 4,
+    "focus": "7 axioms (down from 8). Proved forcing_set_nonempty via pigeonhole induction on k.",
     "blockers": [],
     "nextAction": "Prove forcing_set_nonempty or R3k_inductive_upper via pigeonhole"
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PROGRESS: Eliminated forcing_set_nonempty axiom (8\u21927 axioms) via pigeonhole induction proof",
     "builtItems": [
-      "R3k_one: proved R(3;1)=3 via Nat.find_eq_iff — upper bound uses Subsingleton.elim on Fin 1, lower bound uses pigeonhole on Fin m for m<3",
+      "R3k_one: proved R(3;1)=3 via Nat.find_eq_iff \u2014 upper bound uses Subsingleton.elim on Fin 1, lower bound uses pigeonhole on Fin m for m<3",
       "Removed 2 inconsistent axioms (kthRoot_lower, kthRoot_upper) and 1 sorry theorem",
-      "R3k_two: proved R(3;2)=R(3,3)=6 via Nat.find_eq_iff — upper bound via pigeonhole (5 edges from vertex, 3 same color → forced triangle) + triangle_from_three_neighbors lemma, lower bound via explicit colorings for m=0..5 (C₅ for m=5)",
-      "pigeonhole_five_two: ∀ f : Fin 5 → Fin 2, ∃ 3 same-colored (native_decide)",
-      "fin2_other: x ≠ c → x = 1 - c in Fin 2",
-      "triangle_from_three_neighbors: 3 same-color edges from vertex → monochromatic triangle",
-      "no_three_distinct_lt3: Fin m with m < 3 has no 3 distinct elements"
+      "R3k_two: proved R(3;2)=R(3,3)=6 via Nat.find_eq_iff \u2014 upper bound via pigeonhole (5 edges from vertex, 3 same color \u2192 forced triangle) + triangle_from_three_neighbors lemma, lower bound via explicit colorings for m=0..5 (C\u2085 for m=5)",
+      "pigeonhole_five_two: \u2200 f : Fin 5 \u2192 Fin 2, \u2203 3 same-colored (native_decide)",
+      "fin2_other: x \u2260 c \u2192 x = 1 - c in Fin 2",
+      "triangle_from_three_neighbors: 3 same-color edges from vertex \u2192 monochromatic triangle",
+      "no_three_distinct_lt3: Fin m with m < 3 has no 3 distinct elements",
+      "forcing_set_nonempty: theorem proving \u2203 n, ForcesMonochromaticTriangle n k for all k\u22651 via Ramsey induction",
+      "mapColor: color relabeling function Fin(k+1) \u2192 Fin k collapsing c\u2080, with injectivity on \u2260c\u2080",
+      "forces_imp_ge_three: proof that ForcesMonochromaticTriangle m k with k\u22651 requires m\u22653"
     ],
     "insights": [
       "kthRoot_lower is INCONSISTENT with R3k_one: kthRootR3k 1 = R3k(1)^1 = 3 but axiom requires c > 3",
-      "kthRoot_upper is FALSE at k=1: kthRootR3k 1 = 3 > e ≈ 2.718 = (e·1!)^{1/1}",
-      "Both kthRoot axioms need k ≥ k₀ for some threshold, not k ≥ 1",
-      "R3k_ceiling_upper cannot be proved from R3k_factorial_upper alone — needs C ≤ 1 or a tighter axiom",
-      "R(3,3)=6 proof: vertex with 5 edges → pigeonhole gives 3 same color → either triangle with vertex or 3 vertices all other color",
-      "C₅ is self-complementary: both the cycle and its complement are triangle-free 5-cycles, giving the R(3,3)>5 witness",
-      "pigeonhole_five_two provable via native_decide on the finite function space Fin 5 → Fin 2"
+      "kthRoot_upper is FALSE at k=1: kthRootR3k 1 = 3 > e \u2248 2.718 = (e\u00b71!)^{1/1}",
+      "Both kthRoot axioms need k \u2265 k\u2080 for some threshold, not k \u2265 1",
+      "R3k_ceiling_upper cannot be proved from R3k_factorial_upper alone \u2014 needs C \u2264 1 or a tighter axiom",
+      "R(3,3)=6 proof: vertex with 5 edges \u2192 pigeonhole gives 3 same color \u2192 either triangle with vertex or 3 vertices all other color",
+      "C\u2085 is self-complementary: both the cycle and its complement are triangle-free 5-cycles, giving the R(3,3)>5 witness",
+      "pigeonhole_five_two provable via native_decide on the finite function space Fin 5 \u2192 Fin 2",
+      "forcing_set_nonempty proved by pigeonhole induction on k: base k=1 uses K\u2083, inductive step uses (k+1)*(m-1)+2 vertices and mapColor for color relabeling"
     ],
     "mathlibGaps": [],
     "nextSteps": []
@@ -60,16 +64,16 @@
     "mathlib": []
   },
   "started": "2026-01-12T10:00:45.598Z",
-  "lastUpdate": "2026-03-27T00:20:00Z",
+  "lastUpdate": "2026-03-28T10:00:00Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/Erdos183Problem.lean",
       "filename": "Erdos183Problem.lean",
-      "lineCount": 408,
-      "theoremCount": 6,
-      "axiomCount": 8,
+      "lineCount": 512,
+      "theoremCount": 9,
+      "axiomCount": 7,
       "defCount": 13,
       "sorryCount": 1,
       "isAristotle": false,

--- a/src/data/research/problems/erdos-460.json
+++ b/src/data/research/problems/erdos-460.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-460",
-  "title": "Erdős #460",
+  "title": "Erd\u0151s #460",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -29,23 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "Axiom reduction 4\u21923: demoted sieve_conjectured_bound from axiom to def (was open conjecture incorrectly axiomatized). 0 sorries.",
     "builtItems": [
       "Proved smallPrime_le_sieveReciprocal and largePrime_le_sieveReciprocal (sub-sum lemmas)",
-      "Proved erdos_460_restricted_question theorem (was axiom — eliminated 1 axiom)"
+      "Proved erdos_460_restricted_question theorem (was axiom \u2014 eliminated 1 axiom)",
+      "sieve_conjectured_bound: axiom\u2192def (open conjecture correction)"
     ],
     "insights": [
-      "greedyCoprimeSieve is a dummy (fun _ => 0) — all behavior axiomatized, no routine axioms to eliminate",
+      "greedyCoprimeSieve is a dummy (fun _ => 0) \u2014 all behavior axiomatized, no routine axioms to eliminate",
       "To prove any axioms, need to implement the actual greedy sieve algorithm as a well-founded recursive def",
       "Sieve implementation uses Fin(k+2) for previous values with well-founded recursion",
       "sieve_greedy proof needs: candidates always Nonempty for k >= 2, which requires number-theoretic argument",
       "erdos_460_restricted_question provable via sum decomposition (smallPrime + largePrime = total)",
       "erdos_460_restricted_question proved: restricted sums (smallPrime, largePrime) are sub-sums of sieveReciprocalSum, so divergence of either implies the full sum diverges",
-      "Proof technique: Finset.sum_le_sum with termwise comparison — filter condition P∧Q implies P, and 1/a ≥ 0 for natural a"
+      "Proof technique: Finset.sum_le_sum with termwise comparison \u2014 filter condition P\u2227Q implies P, and 1/a \u2265 0 for natural a",
+      "sieve_conjectured_bound was incorrectly axiomatized \u2014 it is an open conjecture, not a proved result. Demoted to def.",
+      "All 4 axioms were unused by any theorem \u2014 documentation-only. Removed 1 (open conjecture)."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# Erdős #460 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $a_0=n$ and $a_1=1$, and in general $a_k$ is the least integer $>a_{k-1}$ for which $(n-a_k,n-a_i)=1$ for all $1\\leq i<k$. Does\\[\\sum_{i}\\frac{1}{a_i}\\to \\infty\\]as $n\\to \\infty$? What about if we restrict the sum to those $i$ such that $n-a_j$ is divisible by some prime $\\leq a_j$, or the complement of such $i$?\n\n\n\nThis question arose in work of Eggleton, Erd\\H{o}s, and Selfridge, who could prove that $a_k <k^{2+o(1)}$ for $k$ large enough depending on $n$, but conjectured that in fact $a_k\\ll k\\log k$ is true.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #459\n- Problem #461\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erd\u0151s #460 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $a_0=n$ and $a_1=1$, and in general $a_k$ is the least integer $>a_{k-1}$ for which $(n-a_k,n-a_i)=1$ for all $1\\leq i<k$. Does\\[\\sum_{i}\\frac{1}{a_i}\\to \\infty\\]as $n\\to \\infty$? What about if we restrict the sum to those $i$ such that $n-a_j$ is divisible by some prime $\\leq a_j$, or the complement of such $i$?\n\n\n\nThis question arose in work of Eggleton, Erd\\H{o}s, and Selfridge, who could prove that $a_k <k^{2+o(1)}$ for $k$ large enough depending on $n$, but conjectured that in fact $a_k\\ll k\\log k$ is true.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #459\n- Problem #461\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- **BUG FIX**: Remove incorrect `g_d_2` axiom (claimed g_d(2)=3 for all d≥1; correct value is d+2)
- **Prove `g_mono_d`**: monotonicity in d via isometric embedding ℝ^{d₁} ↪ ℝ^{d₂}
- 1 sorry remains in `embedPoint_dist` (norm preservation for zero-padded vectors)

## Progress
- **Axioms**: 10 → 8 (removed 1 incorrect + proved 1)
- **g_d_2 bug**: In ℝ^d, the regular d-simplex gives d+1 equidistant points. So g_d(2) = d+2, not 3

## Status
**Outcome**: progress (bug fix + axiom elimination)
**Next Steps**: Fill sorry in `embedPoint_dist` (EuclideanSpace norm calculation)

🤖 Generated by researcher-9