### PR TITLE
Research: prove 13 sorries across 8 companion files

### DIFF
--- a/proofs/Proofs/Erdos1105Aristotle.lean
+++ b/proofs/Proofs/Erdos1105Aristotle.lean
@@ -38,7 +38,13 @@ theorem card_strict_pairs_eq (n : ℕ) :
 -/
 theorem card_diag_pairs_eq (n : ℕ) :
     (Finset.univ.filter (fun e : Fin n × Fin n => e.1 = e.2)).card = n := by
-  sorry
+  -- Bijection with Fin n: i ↦ (i, i)
+  convert Fintype.card_fin n using 1
+  rw [← Finset.card_univ (α := Fin n)]
+  apply Finset.card_nbij (fun i _ => (i, i))
+  · intro i _; simp
+  · intro i _ j _ h; exact Prod.mk.inj h |>.1
+  · intro ⟨i, j⟩ h; simp at h; exact ⟨i, Finset.mem_univ _, by rw [h]⟩
 
 /-
   Target 3: Gauss sum for Fin values.
@@ -46,6 +52,7 @@ theorem card_diag_pairs_eq (n : ℕ) :
 -/
 theorem sum_fin_val_eq_choose (n : ℕ) :
     ∑ j : Fin n, (j : ℕ) = n.choose 2 := by
-  sorry
+  simp only [Finset.sum_fin_eq_sum_range, Finset.sum_range_id]
+  rw [Nat.choose_two_right]
 
 end Erdos1105Aristotle

--- a/proofs/Proofs/Erdos309Aristotle.lean
+++ b/proofs/Proofs/Erdos309Aristotle.lean
@@ -86,7 +86,9 @@ theorem sumUnitFractions_insert (S : Finset ℕ) (d : ℕ) (hd : d ∉ S) :
 
 -- Harmonic number
 /-- H_1 = 1. -/
-theorem harmonicNumber_one : harmonicNumber 1 = 1 := by sorry
+theorem harmonicNumber_one : harmonicNumber 1 = 1 := by
+  unfold harmonicNumber sumUnitFractions denominatorRange
+  simp [unitFraction]
 
 -- Representability
 /-- 0 is always representable (empty set). -/

--- a/proofs/Proofs/Erdos456Aristotle.lean
+++ b/proofs/Proofs/Erdos456Aristotle.lean
@@ -44,12 +44,12 @@ def smallestPrimeMod1 (n : ℕ) : ℕ :=
     From Nat.totient_prime_pow_succ with p = 2. -/
 theorem totient_two_pow_succ (m : ℕ) :
     Nat.totient (2 ^ (m + 1)) = 2 ^ m := by
-  sorry
+  rw [Nat.totient_prime_pow_succ Nat.prime_two]; simp
 
 /-- 2 * 2^k = 2^(k+1) — basic power arithmetic. -/
 theorem two_mul_two_pow (k : ℕ) :
     2 * 2 ^ k = 2 ^ (k + 1) := by
-  sorry
+  ring
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- Target 2: AlmostAll counting argument
@@ -66,7 +66,16 @@ theorem density_implies_witness (P : ℕ → Prop) (N M : ℕ)
     (hM : 2 * N < M)
     (hcount : (Finset.filter (fun n => ¬P n) (Finset.range M)).card * 2 < M) :
     ∃ n, N ≤ n ∧ n < M ∧ P n := by
-  sorry
+  by_contra h
+  push_neg at h
+  -- Every n in [N, M) fails P, so [N, M) ⊆ exceptions
+  have hsub : Finset.Ico N M ⊆ Finset.filter (fun n => ¬P n) (Finset.range M) := by
+    intro n hn
+    rw [Finset.mem_Ico] at hn
+    exact Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), h n hn.1 hn.2⟩
+  have hle := Finset.card_le_card hsub
+  rw [Finset.card_Ico] at hle
+  omega
 
 end
 

--- a/proofs/Proofs/Erdos637Aristotle.lean
+++ b/proofs/Proofs/Erdos637Aristotle.lean
@@ -91,7 +91,19 @@ def inducedSubgraph (G : SimpleGraph V) (S : Finset V) : SimpleGraph S where
 /-- Degrees in an induced subgraph are bounded by degrees in the full graph. -/
 theorem induced_degree_le (G : SimpleGraph V) [DecidableRel G.Adj]
     (S : Finset V) (v : S) [DecidableRel (inducedSubgraph G S).Adj] :
-    (inducedSubgraph G S).degree v ≤ G.degree v.val := by sorry
+    (inducedSubgraph G S).degree v ≤ G.degree v.val := by
+  simp only [SimpleGraph.degree]
+  -- Map induced neighbors injectively into full graph neighbors
+  calc ((inducedSubgraph G S).neighborFinset v).card
+      = (((inducedSubgraph G S).neighborFinset v).image Subtype.val).card :=
+        (Finset.card_image_of_injective _ Subtype.val_injective).symm
+    _ ≤ (G.neighborFinset v.val).card := by
+        apply Finset.card_le_card
+        intro u hu
+        rw [Finset.mem_image] at hu
+        obtain ⟨w, hw, rfl⟩ := hu
+        rw [SimpleGraph.mem_neighborFinset] at hw ⊢
+        exact hw
 
 -- The empty graph
 /-- The empty graph (no edges) is 0-regular. -/

--- a/proofs/Proofs/Erdos859Aristotle.lean
+++ b/proofs/Proofs/Erdos859Aristotle.lean
@@ -45,7 +45,8 @@ theorem divisors_mul_coprime {m n : ℕ} (hmn : Nat.Coprime m n) (hm : m > 0) (h
 
 theorem primePower_divisors (p : ℕ) (hp : p.Prime) (a : ℕ) :
     Nat.divisors (p ^ a) = (Finset.range (a + 1)).map ⟨fun i => p ^ i, fun _ _ => by
-      intro h; exact Nat.pow_right_injective hp.two_le h⟩ := by sorry
+      intro h; exact Nat.pow_right_injective hp.two_le h⟩ :=
+  Nat.divisors_prime_pow hp
 
 /- Target 3: Density of the full set is 1 -/
 

--- a/proofs/Proofs/Erdos895Aristotle.lean
+++ b/proofs/Proofs/Erdos895Aristotle.lean
@@ -99,7 +99,7 @@ theorem schur_two_colors :
     ∀ c : Fin 5 → Fin 2,
     ∃ a b : Fin 5, a.val > 0 ∧ b.val > 0 ∧ a.val + b.val < 5 ∧
       c a = c b ∧ c a = c ⟨a.val + b.val, by omega⟩ := by
-  sorry
+  native_decide
 
 -- Routine: Pigeonhole — if n items are colored with k colors,
 -- some color class has at least ⌈n/k⌉ items.

--- a/proofs/Proofs/Erdos964Aristotle.lean
+++ b/proofs/Proofs/Erdos964Aristotle.lean
@@ -67,6 +67,26 @@ theorem tau_twelve : tau 12 = 6 := by native_decide
 /-- Rationals are dense in the positive reals. -/
 theorem rationals_dense_in_positives :
     ∀ r : ℝ, r > 0 → ∀ ε : ℝ, ε > 0 →
-    ∃ p q : ℕ, p ≥ 1 ∧ q ≥ 1 ∧ |((p : ℝ) / q) - r| < ε := by sorry
+    ∃ p q : ℕ, p ≥ 1 ∧ q ≥ 1 ∧ |((p : ℝ) / q) - r| < ε := by
+  intro r hr ε hε
+  -- Find q with 1/q < ε via Archimedean property
+  obtain ⟨q, hq⟩ := exists_nat_gt (1 / ε)
+  have hq_cast : (1 : ℝ) / ε < (q : ℝ) := by exact_mod_cast hq
+  have hq_pos : (0 : ℝ) < (q : ℝ) := lt_trans (div_pos one_pos hε) hq_cast
+  have hq_ge1 : q ≥ 1 := by omega
+  have h1q_lt_ε : (1 : ℝ) / q < ε := by
+    rw [div_lt_iff hq_pos]; linarith [mul_comm ε ((q : ℝ)), (div_lt_iff hε).mp hq_cast]
+  -- Find p = ⌈r * q⌉₊
+  set p := ⌈r * (q : ℝ)⌉₊
+  have hrq_pos : r * (q : ℝ) > 0 := mul_pos hr hq_pos
+  have hp_pos : 0 < p := Nat.ceil_pos.mpr hrq_pos
+  have hp_ge : (p : ℝ) ≥ r * q := Nat.le_ceil _
+  have hpq_ge_r : (p : ℝ) / q ≥ r := (le_div_iff hq_pos).mpr (by linarith)
+  refine ⟨p, q, by omega, hq_ge1, ?_⟩
+  rw [abs_of_nonneg (by linarith)]
+  have hp_lt : (p : ℝ) < r * q + 1 := Nat.ceil_lt_add_one (le_of_lt hrq_pos)
+  calc (p : ℝ) / q - r = ((p : ℝ) - r * q) / q := by field_simp
+    _ < 1 / q := (div_lt_div_right hq_pos).mpr (by linarith)
+    _ < ε := h1q_lt_ε
 
 end Erdos964Aristotle


### PR DESCRIPTION
## Summary
Systematic sorry elimination across Aristotle companion files.

## Sorries Eliminated (13 total)

| File | Lemma | Technique |
|------|-------|-----------|
| Erdos637Aristotle | `induced_degree_le` | Injective image of neighbor set |
| Erdos964Aristotle | `rationals_dense_in_positives` | Archimedean + Nat.ceil |
| Erdos309Aristotle | `harmonicNumber_one` | Definitional simp |
| Erdos859Aristotle | `primePower_divisors` | exact Nat.divisors_prime_pow |
| Erdos456Aristotle | `totient_two_pow_succ` | Nat.totient_prime_pow_succ |
| Erdos456Aristotle | `two_mul_two_pow` | ring |
| Erdos456Aristotle | `density_implies_witness` | Pigeonhole (by_contra + omega) |
| Erdos1105Aristotle | `card_diag_pairs_eq` | Bijection with Fin n |
| Erdos1105Aristotle | `sum_fin_val_eq_choose` | Finset.sum_range_id + choose_two_right |
| Erdos895Aristotle | `schur_two_colors` | native_decide (finite check) |

Plus 3 lemmas in Erdos1021Aristotle that were pushed to the first PR commit.

## Note
Docker was not available for build verification. All proofs use standard Mathlib tactics.

🤖 Generated by researcher-1