### PR TITLE
Research: erdos-118 — define ordPartition, prove partition_monotone_down (6A→4A)

### DIFF
--- a/proofs/Proofs/Erdos1168Problem.lean
+++ b/proofs/Proofs/Erdos1168Problem.lean
@@ -1,0 +1,145 @@
+/-
+Erdős Problem #1168: Negative Partition Relation for ℵ_{ω+1}
+
+Source: https://erdosproblems.com/1168
+Status: OPEN
+Reference: [Va99, 7.80]
+
+Statement:
+Prove that ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}²
+without assuming the generalised continuum hypothesis (GCH).
+
+That is: there exists a coloring of pairs from ℵ_{ω+1} using countably many
+colors such that:
+(1) Color 0 has no homogeneous set of cardinality ℵ_{ω+1}
+(2) Each color i ≥ 1 has no monochromatic triangle (3-clique)
+
+Context:
+- Under GCH, this follows from classical Erdős–Hajnal–Rado results
+  on negative partition relations for successor cardinals.
+- The problem asks for a ZFC-only proof (without GCH).
+- ℵ_ω is singular (cofinality ω), making its successor ℵ_{ω+1} a
+  successor of a singular cardinal — a setting where pcf theory
+  (Shelah) provides powerful ZFC combinatorial tools.
+
+Tags: set-theory, ramsey-theory
+-/
+
+import Mathlib.SetTheory.Cardinal.Basic
+import Mathlib.SetTheory.Cardinal.Ordinal
+import Mathlib.SetTheory.Ordinal.Arithmetic
+import Mathlib.Tactic
+
+open Cardinal Ordinal
+
+namespace Erdos1168
+
+/- ## Part I: The Cardinals -/
+
+/-- The cardinal ℵ_ω: the supremum of {ℵ_n : n < ω}. -/
+noncomputable def aleph_omega : Cardinal := Cardinal.aleph Ordinal.omega0
+
+/-- The cardinal ℵ_{ω+1}: the successor of ℵ_ω. -/
+noncomputable def aleph_omega_succ : Cardinal := Cardinal.aleph (Ordinal.omega0 + 1)
+
+/- ## Part II: Multi-Color Partition Relation
+
+The partition relation κ → (α₀, α₁, …)²_c means:
+for any c-coloring of pairs from κ, some color i has a
+homogeneous set of size αᵢ.
+
+We use ℕ-indexed colors (countably many). -/
+
+/-- A set S is homogeneous for color i under coloring f:
+    all pairs of distinct elements in S are colored i. -/
+def IsHomogeneous {V : Type*} (f : V → V → ℕ) (S : Set V) (i : ℕ) : Prop :=
+  ∀ a ∈ S, ∀ b ∈ S, a ≠ b → f a b = i
+
+/-- The countable-color partition relation:
+    κ → (targets)²_ℵ₀ means for any ℕ-coloring of pairs from a type
+    of cardinality κ, some color i has a homogeneous set of
+    cardinality ≥ targets(i). -/
+def partitionRelation (κ : Cardinal) (targets : ℕ → Cardinal) : Prop :=
+  ∀ (V : Type*) (_ : #V = κ) (f : V → V → ℕ),
+    ∃ (i : ℕ) (S : Set V), #S ≥ targets i ∧ IsHomogeneous f S i
+
+/- ## Part III: The Problem Statement -/
+
+/-- The target function for Erdős #1168:
+    - Color 0: must avoid homogeneous set of size ℵ_{ω+1}
+    - All other colors: must avoid triangles (size 3) -/
+noncomputable def targets : ℕ → Cardinal
+  | 0 => aleph_omega_succ
+  | _ + 1 => 3
+
+/-- **Erdős Problem #1168 (OPEN):**
+    ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀}
+
+    There exists a coloring of pairs from ℵ_{ω+1} using countably many
+    colors such that color 0 has no homogeneous set of size ℵ_{ω+1},
+    and each other color has no monochromatic triangle.
+
+    The challenge is to prove this in ZFC without assuming GCH. -/
+axiom erdos_1168 : ¬ partitionRelation aleph_omega_succ targets
+
+/- ## Part IV: Known Results -/
+
+/-- Under GCH, Erdős–Hajnal–Rado theory establishes negative partition
+    relations for successor cardinals. The result follows from the
+    stepping-up lemma applied at ℵ_ω. -/
+axiom erdos_1168_under_gch :
+    (∀ κ : Cardinal.{0}, 2 ^ κ = Order.succ κ) →
+    ¬ partitionRelation aleph_omega_succ targets
+
+/- ## Part V: Structural Observations -/
+
+/-- The empty set is vacuously homogeneous for any color. -/
+theorem empty_homogeneous {V : Type*} (f : V → V → ℕ) (i : ℕ) :
+    IsHomogeneous f ∅ i :=
+  fun a ha => absurd ha (Set.not_mem_empty a)
+
+/-- A singleton is homogeneous for any color. -/
+theorem singleton_homogeneous {V : Type*} (f : V → V → ℕ) (v : V) (i : ℕ) :
+    IsHomogeneous f {v} i := by
+  intro a ha b hb hab
+  rw [Set.mem_singleton_iff] at ha hb
+  exact absurd (ha.trans hb.symm) hab
+
+/-- Homogeneity is monotone: if S is homogeneous and T ⊆ S, then T is homogeneous. -/
+theorem IsHomogeneous.subset {V : Type*} {f : V → V → ℕ} {S T : Set V}
+    {i : ℕ} (hS : IsHomogeneous f S i) (hTS : T ⊆ S) : IsHomogeneous f T i :=
+  fun a ha b hb hab => hS a (hTS ha) b (hTS hb) hab
+
+/-- The partition relation is antimonotone in the targets:
+    if targets' ≤ targets pointwise and the relation holds for targets,
+    then it holds for targets'. -/
+theorem partitionRelation.mono_targets {κ : Cardinal}
+    {t₁ t₂ : ℕ → Cardinal} (h : ∀ i, t₂ i ≤ t₁ i)
+    (hp : partitionRelation κ t₁) : partitionRelation κ t₂ := by
+  intro V hV f
+  obtain ⟨i, S, hS, hH⟩ := hp V hV f
+  exact ⟨i, S, le_trans (h i) hS, hH⟩
+
+/-
+## Summary
+
+**Erdős Problem #1168: OPEN**
+
+**Question:** Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} in ZFC.
+
+**Known:**
+1. Under GCH, the result follows from Erdős–Hajnal–Rado theory
+2. ℵ_ω is singular (cofinality ω), making pcf theory applicable
+3. Shelah's pcf theory provides ZFC tools for successor-of-singular
+
+**Axioms (2):**
+- erdos_1168: the main open conjecture
+- erdos_1168_under_gch: GCH-conditional version (known result)
+
+**Proved (4):**
+- empty_homogeneous, singleton_homogeneous: basic homogeneity facts
+- IsHomogeneous.subset: homogeneity is monotone under subsets
+- partitionRelation.mono_targets: partition relation antimonotone in targets
+-/
+
+end Erdos1168

--- a/proofs/Proofs/Erdos118Problem.lean
+++ b/proofs/Proofs/Erdos118Problem.lean
@@ -26,8 +26,19 @@ import Mathlib.Tactic
 
 /-- The ordinal partition relation: α → (α, k)² means that for any 2-coloring
     of pairs from α, there is either a monochromatic-red set of order type α
-    or a monochromatic-blue set of size k. -/
-axiom ordPartition (α : Ordinal.{0}) (k : ℕ) : Prop
+    or a monochromatic-blue set of size k.
+
+    Formally: given any coloring f of ordered pairs of ordinals less than α,
+    either there exists a strictly monotone embedding φ of [0,α) into itself
+    with all pairs colored true (red), or there exist k ordinals less than α
+    forming a strictly increasing sequence with all pairs colored false (blue). -/
+def ordPartition (α : Ordinal.{0}) (k : ℕ) : Prop :=
+  ∀ f : Ordinal → Ordinal → Bool,
+    (∃ (φ : Ordinal → Ordinal), StrictMono φ ∧
+      (∀ x, x < α → φ x < α) ∧
+      ∀ x y, x < y → x < α → y < α → f (φ x) (φ y) = true) ∨
+    (∃ (ψ : Fin k → Ordinal), StrictMono ψ ∧ (∀ i, ψ i < α) ∧
+      ∀ i j, i < j → f (ψ i) (ψ j) = false)
 
 /-- A partition ordinal for k-cliques: α satisfies α → (α, k)². -/
 def IsPartitionOrd (α : Ordinal.{0}) (k : ℕ) : Prop :=
@@ -68,9 +79,21 @@ theorem erdos_118_disproved : ¬ ErdosHajnalConjecture := by
 axiom partitionThreshold (α : Ordinal.{0}) : ℕ
 
 /-- If α → (α, k)² holds, then α → (α, j)² holds for all j ≤ k.
-    The partition relation is monotone decreasing in k. -/
-axiom partition_monotone_down (α : Ordinal.{0}) (k j : ℕ) (hjk : j ≤ k)
-    (hk : IsPartitionOrd α k) : IsPartitionOrd α j
+    The partition relation is monotone decreasing in k.
+
+    Proof: Given a blue k-clique, any j-element initial segment (j ≤ k)
+    is also a blue clique. A red set of order type α passes through unchanged. -/
+theorem partition_monotone_down (α : Ordinal.{0}) (k j : ℕ) (hjk : j ≤ k)
+    (hk : IsPartitionOrd α k) : IsPartitionOrd α j := by
+  intro f
+  rcases hk f with ⟨φ, hφ_mono, hφ_bound, hφ_red⟩ | ⟨ψ, hψ_mono, hψ_bound, hψ_blue⟩
+  · left; exact ⟨φ, hφ_mono, hφ_bound, hφ_red⟩
+  · -- Restrict the blue k-clique ψ : Fin k → Ordinal to a j-element initial segment
+    right
+    let embed : Fin j → Fin k := fun i => ⟨i.val, Nat.lt_of_lt_of_le i.isLt hjk⟩
+    have hemb : StrictMono embed := fun _ _ h => h
+    exact ⟨ψ ∘ embed, hψ_mono.comp hemb, fun i => hψ_bound _,
+           fun a b hab => hψ_blue _ _ (hemb hab)⟩
 
 /-- The threshold captures the exact boundary: the partition property holds
     at the threshold and fails one step above. -/

--- a/research/problems/erdos-1168/knowledge.md
+++ b/research/problems/erdos-1168/knowledge.md
@@ -1,37 +1,25 @@
-# Erdős #1168 - Knowledge Base
+# Erdős #1168: Negative Partition Relation for ℵ_{ω+1}
 
-## Problem Statement
+**Problem**: Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}² without GCH
+**Status**: SURVEY COMPLETE (2 axioms, 0 sorries, 4 proved theorems)
 
-Problem statement not found
+## Current State
 
-## Status
+- **File**: `proofs/Proofs/Erdos1168Problem.lean` (~130 lines)
+- **Axioms**: 2 (erdos_1168 = OPEN conjecture, erdos_1168_under_gch = known under GCH)
+- **Proved**: 4 structural theorems (homogeneity monotonicity, partition relation properties)
 
-**Erdős Database Status**: OPEN
+## Session 2026-03-28 (Session 1) - Initial formalization
 
-**Tractability Score**: 6/10
-**Aristotle Suitable**: No
+**Mode**: FRESH (EMPTY knowledge)
+**Outcome**: surveyed (new formalization created)
 
-## Tags
+### What I Did
+- Looked up problem statement from erdosproblems.com
+- Created Lean formalization with multi-color partition relation
+- 2 axioms (open conjecture + GCH conditional), 4 proved structural theorems
 
-- erdos
-
-## Related Problems
-
-- Problem #2000
-- Problem #83
-- Problem #888
-- Problem #2
-- Problem #39
-- Problem #1
-
-## References
-
-- (None available)
-
-## Sessions
-
-(No research sessions yet)
-
----
-
-*Generated from erdosproblems.com on 2026-01-15*
+### Key Findings
+- Problem is about ZFC vs GCH: result known under GCH, challenge is ZFC-only
+- ℵ_ω singular (cofinality ω) → successor amenable to pcf theory
+- Docker not available — needs build verification

--- a/research/problems/erdos-118-oq-01/knowledge.md
+++ b/research/problems/erdos-118-oq-01/knowledge.md
@@ -1,0 +1,40 @@
+# Erdős #118 OQ-01: Partition Threshold of ω^{ω²}
+
+**Problem**: Is the partition threshold of ω^{ω²} exactly 3 or 4?
+**Status**: IN-PROGRESS (4 axioms, 0 sorries)
+
+## Current State
+
+- **File**: `proofs/Proofs/Erdos118Problem.lean` (~144 lines)
+- **Axioms**: 4 (counter_partition_3, counter_not_partition_5, partitionThreshold, threshold_exact)
+- **Proved**: ordPartition (was axiom, now def), partition_monotone_down (was axiom, now theorem)
+- **Key theorem**: omega_omega2_threshold bounds threshold to {3, 4}
+
+## Session 2026-03-28 (Session 1) - Define ordPartition, prove partition_monotone_down
+
+**Mode**: FRESH (MODERATE knowledge, score 11)
+**Outcome**: progress (6A→4A, 2 axioms eliminated)
+
+### What I Did
+- Converted `ordPartition` from axiom to concrete definition:
+  - Red condition: ∃ φ : Ordinal → Ordinal, StrictMono φ ∧ maps [0,α) into itself ∧ all pairs red
+  - Blue condition: ∃ ψ : Fin k → Ordinal, StrictMono ψ ∧ all < α ∧ all pairs blue
+- Proved `partition_monotone_down`: given blue k-clique, restrict to j-element initial segment via Fin.castLE
+
+### Key Findings
+- `ordPartition` was an opaque axiom making everything downstream unprovable. Now it's a concrete Prop.
+- `partition_monotone_down` follows cleanly: compose with `embed : Fin j → Fin k` that preserves `.val`
+- `StrictMono embed` holds because Fin comparison is by `.val`, and embed preserves `.val`
+- `partitionThreshold` and `threshold_exact` remain axioms (would need bounded set theory for proper definition)
+- Counter-partition axioms (Schipperus, Larson) remain axioms (deep results, not in Mathlib)
+- Docker not available — build verification needed
+
+### Files Modified
+- `proofs/Proofs/Erdos118Problem.lean` (121→144 lines, -2 axioms, +1 def, +1 theorem)
+- `src/data/proofs/erdos-118/meta.json` (axiomCount: 6→4, lineCount: 120→144)
+- `src/data/research/problems/erdos-118-oq-01.json` (knowledge updated)
+
+### Next Steps
+- Verify build when Docker available
+- Consider defining partitionThreshold as noncomputable def with Nat.find
+- The exact threshold value (3 vs 4) requires deep ordinal combinatorics beyond current scope

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -1,0 +1,31 @@
+{
+  "id": "erdos-1168",
+  "title": "Erdős Problem #1168: Negative Partition Relation for ℵ_{ω+1}",
+  "slug": "erdos-1168",
+  "description": "Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}² without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
+  "meta": {
+    "erdosNumber": 1168,
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1168Problem.lean",
+    "tags": [
+      "erdos",
+      "set-theory",
+      "ramsey-theory",
+      "partition-relations",
+      "cardinals",
+      "open-conjecture"
+    ],
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1168",
+    "erdosUrl": "https://erdosproblems.com/1168",
+    "erdosProblemStatus": "open",
+    "badge": "axiom",
+    "axiomCount": 2,
+    "lineCount": 130,
+    "theoremCount": 4,
+    "definitionCount": 5,
+    "assumptions": "2 axioms: erdos_1168 (OPEN conjecture), erdos_1168_under_gch (known under GCH). 4 structural theorems proved from definitions.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-03-28"
+  }
+}

--- a/src/data/proofs/erdos-118/meta.json
+++ b/src/data/proofs/erdos-118/meta.json
@@ -23,9 +23,9 @@
     "relatedProblems": [
       592
     ],
-    "axiomCount": 6,
-    "lineCount": 120,
-    "assumptions": "6 axioms: ordPartition, counter_partition_3, counter_not_partition_5, partitionThreshold, partition_monotone_down, threshold_exact. omega_omega2_threshold proved from threshold_exact + monotonicity + counterexamples. relation_to_592 proved directly from counterexamples.",
+    "axiomCount": 4,
+    "lineCount": 144,
+    "assumptions": "4 axioms: counter_partition_3 (Schipperus), counter_not_partition_5 (Larson), partitionThreshold, threshold_exact. ordPartition now properly defined. partition_monotone_down proved from definition (blue clique restriction). omega_omega2_threshold proved from threshold_exact + monotonicity + counterexamples. relation_to_592 proved directly from counterexamples.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -34,7 +34,7 @@
       "title": "Core Definitions",
       "startLine": 20,
       "endLine": 39,
-      "summary": "Defines the ordinal partition relation $\\alpha \\to (\\alpha, k)^2$ (axiomatized), the `IsPartitionOrd` predicate, and the Erdős–Hajnal conjecture: $\\alpha \\to (\\alpha,3)^2 \\implies \\forall n \\ge 3,\\, \\alpha \\to (\\alpha,n)^2$."
+      "summary": "Defines the ordinal partition relation $\\alpha \\to (\\alpha, k)^2$ as a concrete Prop (strict monotone red embedding or blue Fin-clique), the `IsPartitionOrd` predicate, and the Erdős–Hajnal conjecture."
     },
     {
       "id": "counterexample",
@@ -55,7 +55,7 @@
       "title": "Partition Threshold and Monotonicity",
       "startLine": 63,
       "endLine": 86,
-      "summary": "Introduces the partition threshold $\\text{thr}(\\alpha) = \\max\\{k : \\alpha \\to (\\alpha,k)^2\\}$, axiomatizes monotonicity ($j \\le k$ preserves the relation), and bounds $\\text{thr}(\\omega^{\\omega^2}) \\in \\{3, 4\\}$. The exact value remains open."
+      "summary": "Introduces the partition threshold $\\text{thr}(\\alpha) = \\max\\{k : \\alpha \\to (\\alpha,k)^2\\}$, proves monotonicity ($j \\le k$ preserves the relation) from the ordPartition definition, and bounds $\\text{thr}(\\omega^{\\omega^2}) \\in \\{3, 4\\}$. The exact value remains open."
     },
     {
       "id": "relation-592",
@@ -102,10 +102,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 120,
-    "axiomCount": 6,
-    "theoremCount": 3,
-    "definitionCount": 3
+    "lineCount": 144,
+    "axiomCount": 4,
+    "theoremCount": 4,
+    "definitionCount": 4
   },
   "references": [
     "Erdős–Hajnal: original conjecture",

--- a/src/data/research/problems/erdos-1168.json
+++ b/src/data/research/problems/erdos-1168.json
@@ -29,9 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEY: Formalized problem statement, defined multi-color partition relation, 2 axioms + 4 proved structural theorems.",
+    "builtItems": [
+      "partitionRelation: multi-color partition relation (ℕ-indexed colors)",
+      "IsHomogeneous: homogeneity predicate",
+      "targets: target function (aleph_{omega+1} for color 0, 3 for others)",
+      "aleph_omega, aleph_omega_succ: cardinal definitions",
+      "empty_homogeneous, singleton_homogeneous: basic homogeneity facts",
+      "IsHomogeneous.subset: monotonicity of homogeneity",
+      "partitionRelation.mono_targets: antimonotonicity in targets"
+    ],
+    "insights": [
+      "Problem asks for ZFC proof of negative partition relation, known under GCH",
+      "aleph_omega is singular (cofinality omega) making pcf theory applicable",
+      "ℕ-indexed colors give countably many color classes",
+      "The partition relation is antimonotone in targets (weaker targets easier to satisfy)"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #1168 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
@@ -52,5 +65,16 @@
   "started": "2026-01-15T16:53:51.159Z",
   "lastUpdate": "2026-03-13T07:52:17.059Z",
   "significance": 7,
-  "tractability": 6
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1168Problem.lean",
+      "filename": "Erdos1168Problem.lean",
+      "lineCount": 130,
+      "theoremCount": 4,
+      "axiomCount": 2,
+      "defCount": 5,
+      "sorryCount": 0
+    }
+  ]
 }

--- a/src/data/research/problems/erdos-118-oq-01.json
+++ b/src/data/research/problems/erdos-118-oq-01.json
@@ -29,11 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PROGRESS: Defined ordPartition (axiom→def), proved partition_monotone_down (6A→4A). Needs build verification.",
     "builtItems": [
       "Proved relation_to_592 as theorem (trivially follows from counterexample axioms)",
       "Fixed build: Ordinal universe annotations (.{0}), Ordinal.omega->omega0, added Exponential import",
-      "theorem omega_omega2_threshold: proved from threshold_exact + partition_monotone_down + counterexample axioms"
+      "theorem omega_omega2_threshold: proved from threshold_exact + partition_monotone_down + counterexample axioms",
+      "ordPartition: axiom→def with concrete Prop (strict monotone embedding + Fin clique)",
+      "partition_monotone_down: axiom→theorem (blue clique restriction proof)"
     ],
     "insights": [
       "relation_to_592 was redundant: directly provable from counter_partition_3 and counter_not_partition_5",
@@ -43,7 +45,11 @@
       "omega_omega2_threshold remains an independent axiom - the guard in threshold_exact blocks the proof when threshold < 2",
       "threshold_exact guard (threshold+1>2) was blocking omega_omega2_threshold proof — removing it enables both bounds",
       "Lower bound (≥3): if threshold≤2, then threshold+1≤3, monotonicity from counter_partition_3 gives partition at threshold+1, contradicting threshold_exact",
-      "Upper bound (≤4): if threshold≥5, monotonicity from threshold_exact gives IsPartitionOrd at 5, contradicting counter_not_partition_5"
+      "Upper bound (≤4): if threshold≥5, monotonicity from threshold_exact gives IsPartitionOrd at 5, contradicting counter_not_partition_5",
+      "ordPartition properly defined using StrictMono φ (red) or StrictMono ψ:Fin k→Ordinal (blue)",
+      "partition_monotone_down follows from Fin.castLE restriction of blue clique",
+      "partitionThreshold and threshold_exact remain as axioms (need bounded set theory)",
+      "counter_partition_3 and counter_not_partition_5 remain as axioms (deep results)"
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Summary
- Convert `ordPartition` from opaque axiom to concrete definition using `StrictMono` embeddings and `Fin k` cliques
- Prove `partition_monotone_down` from the definition via blue clique restriction through `Fin.castLE`
- 2 axioms eliminated (6→4): `ordPartition` (→def) and `partition_monotone_down` (→theorem)
- Remaining 4 axioms are genuinely deep: counterexample facts (Schipperus/Larson) + threshold axioms

## Progress
- `ordPartition α k` now defined as: ∀ f, (∃ red StrictMono embedding) ∨ (∃ blue Fin k clique)
- `partition_monotone_down` proved: restrict blue k-clique to j-element initial segment
- Updated meta.json (axiomCount: 6→4, lineCount: 120→144)

## Status
**Outcome**: progress (6A→4A)
**Build**: Docker not available — needs build verification
**Next Steps**: Verify build; consider defining `partitionThreshold` properly

Generated by researcher-4