### PR TITLE
fix(audit): update stale metadata for erdos-358

### DIFF
--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 358,
     "erdosUrl": "https://erdosproblems.com/358",
     "erdosProblemStatus": "open",
@@ -57,9 +57,9 @@
       "PositiveDensityConjecture definition: positive upper density",
       "Classical characterization: n = sum of >=2 consecutive iff n != 2^k"
     ],
-    "axiomCount": 4,
-    "lineCount": 186,
-    "assumptions": "4 axioms: naturals_count_odd_divisors, power_of_two_obstruction, primesSeq, primesSeq_def. strong_implies_weak proved via Filter.tendsto_atTop_atTop. 3 sorries remain."
+    "axiomCount": 6,
+    "lineCount": 214,
+    "assumptions": "6 axioms: consecutive_sum_char, naturals_count_odd_divisors, naturals_always_representable, power_of_two_obstruction, primesSeq, primesSeq_def. All sorries eliminated; strong_implies_weak proved via Filter.tendsto_atTop_atTop."
   },
   "overview": {
     "historicalContext": "Erdos Problem #358 was posed in 1977 [Er77c] and revisited in Erdos-Graham (1980). It asks a deceptively simple question about how many ways an integer can be written as a sum of consecutive terms from a fixed sequence.\n\nErdos himself remarked: \"This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me.\"\n\nThe problem connects to classical results about sums of consecutive integers (which relate to odd divisors) and to the Erdos-Moser conjecture (1963) about consecutive prime sums.",
@@ -167,10 +167,10 @@
       "Finset"
     ],
     "namespace": "Erdos358",
-    "lineCount": 186,
-    "axiomCount": 4,
-    "theoremCount": 5,
-    "definitionCount": 8
+    "lineCount": 214,
+    "axiomCount": 6,
+    "theoremCount": 6,
+    "definitionCount": 9
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Update stale meta.json for erdos-358 after research PR #7438 proved all 3 sorries.

## Evidence

**Before**: sorries=3, axiomCount=4, lineCount=186, theoremCount=5, definitionCount=8
**After**: sorries=0, axiomCount=6, lineCount=214, theoremCount=6, definitionCount=9

Six axiom declarations in Lean source:
- `consecutive_sum_char` — classical characterization of consecutive sums
- `naturals_count_odd_divisors` — f(n) = odd divisor count for naturals
- `naturals_always_representable` — every n≥1 has a representation
- `power_of_two_obstruction` — powers of 2 have no ≥2-term representation
- `primesSeq` — the prime number sequence
- `primesSeq_def` — primesSeq relates to Nat.nth Prime

---
Automated fix by lean-mechanic agent.