### PR TITLE
fix(audit): update stale metadata for erdos-738

### DIFF
--- a/src/data/proofs/erdos-738/meta.json
+++ b/src/data/proofs/erdos-738/meta.json
@@ -47,7 +47,7 @@
       "Added pathTree and starTree constructors with tree property obligations"
     ],
     "axiomCount": 2,
-    "lineCount": 302,
+    "lineCount": 329,
     "assumptions": [
       "gyarfas_conjecture: The main open conjecture — every triangle-free graph with χ(G)=∞ contains every finite tree as an induced subgraph",
       "gyarfas_finite_version: Finite quantitative version with explicit chromatic threshold N(T) for each tree (equivalent to main conjecture via compactness)"
@@ -125,7 +125,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #738 (Gyárfás conjecture) is formalized with FiniteTree enforcing actual tree structure via Mathlib's IsTree. Tree-class predicates (HasRadius, IsCaterpillar) make partial results genuinely weaker than the full conjecture. 2 sorries remain for tree property proofs of pathGraph and starGraph (Aristotle candidates). 2 axioms: the main conjecture and its finite quantitative version.",
+    "summary": "Erdős Problem #738 (Gyárfás conjecture) is formalized with FiniteTree enforcing actual tree structure via Mathlib's IsTree. Tree-class predicates (HasRadius, IsCaterpillar) make partial results genuinely weaker than the full conjecture. 1 sorry remains for a tree property proof (Aristotle candidate). 2 axioms: the main conjecture and its finite quantitative version.",
     "implications": "A resolution would advance the theory of $\\chi$-bounded graph classes, establishing that triangle-free graphs with unbounded chromatic number are 'structurally rich' enough to contain all finite trees. This would extend the classical Ramsey-theoretic understanding of graph coloring to induced subgraph containment, with applications to graph decomposition and structural graph theory.",
     "openQuestions": [
       "Does every triangle-free graph with $\\chi(G) = \\infty$ contain every finite tree as an induced subgraph?",
@@ -164,10 +164,10 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 302,
+    "lineCount": 329,
     "axiomCount": 2,
-    "theoremCount": 10,
-    "definitionCount": 10
+    "theoremCount": 12,
+    "definitionCount": 11
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Update stale meta.json for erdos-738 after research PRs #7433 and #7437 added theorems and proved a sorry.

## Evidence

**Before**: lineCount=302, theoremCount=10, definitionCount=10, conclusion mentions "2 sorries"
**After**: lineCount=329, theoremCount=12, definitionCount=11, conclusion updated to "1 sorry"

Sorry and axiom counts were already correct (1S, 2A).

---
Automated fix by lean-mechanic agent.