### PR TITLE
fix(audit): correct sorry count and stale counts for erdos-1089

### DIFF
--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -19,7 +19,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1089,
     "erdosUrl": "https://erdosproblems.com/1089",
     "erdosProblemStatus": "open",
@@ -240,10 +240,10 @@
     "lineCount": 382,
     "structureCount": 0,
     "axiomCount": 8,
-    "theoremCount": 5,
-    "substantiveTheoremCount": 4,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 5,
     "sorryTheorems": 0,
-    "lemmaCount": 2,
+    "lemmaCount": 4,
     "defCount": 12,
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Summary

- Fix sorry count: claimed 0, actual **1** (`embedPoint_dist` L315 has sorry for norm equality)
- The `assumptions` field already noted "1 sorry(s) remain" but the `sorries` field was 0 — internal contradiction resolved
- Update stale theoremCount: 5→6 (added `g_mono_d`)
- Update stale lemmaCount: 2→4 (added `embedPoint_injective`, `embedPoint_dist`)

## Evidence

**meta.json claimed**: `"sorries": 0`
**Lean file shows**: `sorry` at line 315 in `embedPoint_dist`
**assumptions field said**: "1 sorry(s) remain" — contradicted the sorries field

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)