### PR TITLE
fix(audit): correct erdos-1089 sorry count and stale narrative

### DIFF
--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -19,7 +19,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1089,
     "erdosUrl": "https://erdosproblems.com/1089",
     "erdosProblemStatus": "open",
@@ -60,7 +60,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 8,
-    "assumptions": "8 axioms: g_well_defined, g_1_3, g_2_3, g_3_3, cube_distances, erdos_lower_bound, erdos_straus_upper_bound, g_f_relationship. g_d_2 REMOVED (incorrect: should be d+2 not 3). g_mono_d PROVED via isometric embedding (1 sorry in norm calculation). 1 sorry(s) remain.",
+    "assumptions": "8 axioms: g_well_defined, g_1_3, g_2_3, g_3_3, cube_distances, erdos_lower_bound, erdos_straus_upper_bound, g_f_relationship. g_mono_d proved via isometric embedding (1 sorry in embedPoint_dist norm calculation). 1 sorry remains.",
     "prerequisites": [
       "Discrete and combinatorial geometry: point configurations and distances",
       "Euclidean space \u211d^d and the distance function",
@@ -144,25 +144,25 @@
     {
       "id": "mono",
       "title": "Monotonicity Properties",
-      "summary": "Proves g_mono_n (g increasing in n: more distances need more points) and axiomatizes g_mono_d (g increasing in d for n \u2265 2: higher dimensions allow more few-distance configurations).",
+      "summary": "Proves g_mono_n (g increasing in n: more distances need more points) and g_mono_d (g increasing in d for n \u2265 2, via isometric embedding with 1 sorry in norm preservation).",
       "startLine": 244,
-      "endLine": 277,
+      "endLine": 352,
       "mathContext": "$n_1 \\leq n_2 \\implies g_d(n_1) \\leq g_d(n_2)$ (more distances $\\Rightarrow$ more points). $d_1 \\leq d_2 \\implies g_{d_1}(n) \\leq g_{d_2}(n)$ for $n \\geq 2$ (higher dimensions allow larger few-distance sets)."
     },
     {
       "id": "inverse",
       "title": "Connection to f_d(n) and Problem #1083",
       "summary": "Defines f d n = max distinct distances from n points. Axiomatizes g_f_relationship: g_d(n) = min{m : f_d(m) \u2265 n}. Names the full open problem as erdos1089OpenProblem.",
-      "startLine": 279,
-      "endLine": 307,
+      "startLine": 354,
+      "endLine": 382,
       "mathContext": "$f_d(n) = \\max\\{|\\Delta(P)| : P \\subseteq \\mathbb{R}^d, |P| = n\\}$. Duality: $g_d(n) = \\inf\\{m : f_d(m) \\geq n\\}$. Guth-Katz (2015): $f_2(n) \\geq cn/\\sqrt{\\log n}$."
     }
   ],
   "overview": {
-    "text": "A 307-line formalization of Erd\u0151s Problem #1089 (Kelly-Erd\u0151s, 1975): given $n$ fixed, what is the minimum number $g_d(n)$ of points in $\\mathbb{R}^d$ needed to guarantee $n$ distinct pairwise distances? The formalization defines $g_d(n)$ as a threshold function via `Nat.sInf`, axiomatizes the key bounds ($g_d(n) \\geq c \\cdot d^{n-1}$; $g_d(n) \\leq c^{d^{1-b_n}}$), and states the main conjecture: does $\\lim_{d \\to \\infty} g_d(n)/d^{n-1}$ exist? The central tension is the vast gap between the polynomial lower bound ($d^{n-1}$) and the stretched-exponential upper bound ($c^{d^{1-b_n}}$). Of the 10 axioms, 4 encode geometric constructions and small cases, 3 encode known bounds (Erd\u0151s lower, Straus upper, well-definedness), and 3 encode structural properties (monotonicity in $d$, $g$-$f$ relationship, $g_d(2)=3$). Five theorems are fully proved: `g_d_1` ($g_d(1)=2$ via 44-line le_antisymm argument), `cube_card` ($2^d$ vertices via injectivity), `cube_lower_bound` ($g_d(d+1) > 2^d$ via subset extraction and contradiction), `ratio_bounded_below` (the ratio $g_d(n)/d^{n-1} \\geq c > 0$ from the Erd\u0151s lower bound), and `g_mono_n` (monotonicity in $n$ via sInf reasoning). 0 sorries remain.",
+    "text": "A 382-line formalization of Erd\u0151s Problem #1089 (Kelly-Erd\u0151s, 1975): given $n$ fixed, what is the minimum number $g_d(n)$ of points in $\\mathbb{R}^d$ needed to guarantee $n$ distinct pairwise distances? The formalization defines $g_d(n)$ as a threshold function via `Nat.sInf`, axiomatizes the key bounds ($g_d(n) \\geq c \\cdot d^{n-1}$; $g_d(n) \\leq c^{d^{1-b_n}}$), and states the main conjecture: does $\\lim_{d \\to \\infty} g_d(n)/d^{n-1}$ exist? The central tension is the vast gap between the polynomial lower bound ($d^{n-1}$) and the stretched-exponential upper bound ($c^{d^{1-b_n}}$). Of the 8 axioms, 4 encode geometric constructions and small cases, 3 encode known bounds (Erd\u0151s lower, Straus upper, well-definedness), and 1 encodes the $g$-$f$ relationship. Five theorems are fully proved: `g_d_1` ($g_d(1)=2$ via 44-line le_antisymm argument), `cube_card` ($2^d$ vertices via injectivity), `cube_lower_bound` ($g_d(d+1) > 2^d$ via subset extraction and contradiction), `ratio_bounded_below` (the ratio $g_d(n)/d^{n-1} \\geq c > 0$ from the Erd\u0151s lower bound), and `g_mono_n` (monotonicity in $n$ via sInf reasoning). A sixth theorem `g_mono_d` (monotonicity in $d$) is proved via isometric embedding modulo 1 sorry in the norm-preservation lemma. 1 sorry remains.",
     "historicalContext": "The distinct distances problem in higher dimensions was posed by L.M. Kelly and Paul Erd\u0151s in their 1975 paper on combinatorial geometry. It generalizes the famous planar distinct distances problem \u2014 solved by Larry Guth and Nets Hawk Katz in 2015 (published in *Annals of Mathematics*), who proved $f_2(n) \\geq cn/\\sqrt{\\log n}$ using algebraic topology and polynomial partitioning \u2014 to arbitrary dimension $d$. But with a twist: instead of fixing $d$ and varying $n$, Problem #1089 fixes the number of distinct distances $n$ and asks how the threshold $g_d(n)$ grows with $d$.\n\nThe key construction is the $d$-dimensional unit cube $\\{0,1\\}^d$: its $2^d$ vertices produce only $d$ distinct distances ($\\sqrt{1}, \\sqrt{2}, \\ldots, \\sqrt{d}$), since two vertices differing in $k$ coordinates have Hamming-Euclidean distance $\\sqrt{k}$. This shows $g_d(d+1) > 2^d$. Erd\u0151s proved 'easily' that $g_d(n) \\gg d^{n-1}$ for fixed $n$ using a counting argument, establishing a polynomial lower bound. Croft (1962) computed the exact value $g_3(3) = 7$ through a painstaking analysis of all possible 6-point configurations in $\\mathbb{R}^3$ with at most 2 distinct distances.\n\nThe upper bound side remains poorly understood: the Erd\u0151s-Straus bound $g_d(n) \\leq c^{d^{1-b_n}}$ is stretched-exponential, leaving an enormous gap with the polynomial lower bound. Whether $g_d(n)/d^{n-1}$ converges as $d \\to \\infty$ for fixed $n$ is the central open question. If the limit exists and is positive, it determines the exact polynomial growth rate; if it diverges, $g_d(n)$ grows super-polynomially in $d$.",
     "problemStatement": "Let $g_d(n)$ be minimal such that every collection of $g_d(n)$ points in $\\mathbb{R}^d$ determines at least $n$ distinct distances. Estimate $g_d(n)$. In particular, does $\\lim_{d \\to \\infty} g_d(n)/d^{n-1}$ exist?",
-    "proofStrategy": "The formalization defines g_d(n) as the infimum of thresholds guaranteeing n distinct distances in \u211d^d, using Mathlib's EuclideanSpace. Cube vertices are concretely defined (Fin d \u2192 Fin 2 mapped into EuclideanSpace) with cube_card proved via injectivity and cube_lower_bound proved via subset extraction. Known bounds are captured as axioms. The theorems g_d_1, cube_lower_bound, ratio_bounded_below, and g_mono_n are all fully proved. The f_d(n) inverse function connects to Problem #1083.",
+    "proofStrategy": "The formalization defines g_d(n) as the infimum of thresholds guaranteeing n distinct distances in \u211d^d, using Mathlib's EuclideanSpace. Cube vertices are concretely defined (Fin d \u2192 Fin 2 mapped into EuclideanSpace) with cube_card proved via injectivity and cube_lower_bound proved via subset extraction. Known bounds are captured as axioms. The theorems g_d_1, cube_card, cube_lower_bound, ratio_bounded_below, and g_mono_n are fully proved. g_mono_d (monotonicity in d) is proved via isometric embedding with 1 sorry in the norm-preservation lemma. The f_d(n) inverse function connects to Problem #1083.",
     "keyInsights": [
       "**Threshold function**: $g_d(n) = \\min\\{m : \\text{every } m\\text{-point set in } \\mathbb{R}^d \\text{ has} \\geq n \\text{ distinct distances}\\}$ \u2014 the central combinatorial quantity",
       "**Cube construction**: The $d$-cube $\\{0,1\\}^d$ has $2^d$ vertices but only $d$ distinct distances $\\sqrt{1}, \\ldots, \\sqrt{d}$, giving $g_d(d+1) > 2^d$ \u2014 exponential growth in $d$ for linear growth in $n$",
@@ -226,7 +226,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This 307-line formalization defines the threshold function $g_d(n)$ \u2014 the minimum number of points in $\\mathbb{R}^d$ guaranteeing $n$ distinct pairwise distances \u2014 and establishes the known bounds: Erd\u0151s's polynomial lower bound $g_d(n) \\gg d^{n-1}$ and the Erd\u0151s-Straus stretched-exponential upper bound $g_d(n) \\leq c^{d^{1-b_n}}$. Five theorems are fully proved (0 sorries): `g_d_1` ($g_d(1)=2$), `cube_card` ($2^d$ cube vertices), `cube_lower_bound` ($g_d(d+1) > 2^d$), `ratio_bounded_below` ($g_d(n)/d^{n-1} \\geq c > 0$), and `g_mono_n` (monotonicity in $n$). The cube construction ($\\{0,1\\}^d$ has $2^d$ vertices but only $d$ distinct distances) illustrates why algebraic structure is essential. The Galois connection $g_d(n) = \\inf\\{m : f_d(m) \\geq n\\}$ links this to Problem #1083 and the Guth-Katz planar result.",
+    "summary": "This 382-line formalization defines the threshold function $g_d(n)$ \u2014 the minimum number of points in $\\mathbb{R}^d$ guaranteeing $n$ distinct pairwise distances \u2014 and establishes the known bounds: Erd\u0151s's polynomial lower bound $g_d(n) \\gg d^{n-1}$ and the Erd\u0151s-Straus stretched-exponential upper bound $g_d(n) \\leq c^{d^{1-b_n}}$. Five theorems are fully proved: `g_d_1` ($g_d(1)=2$), `cube_card` ($2^d$ cube vertices), `cube_lower_bound` ($g_d(d+1) > 2^d$), `ratio_bounded_below` ($g_d(n)/d^{n-1} \\geq c > 0$), and `g_mono_n` (monotonicity in $n$). A sixth theorem `g_mono_d` (monotonicity in $d$) is proved via isometric embedding with 1 sorry remaining in the norm-preservation lemma. The cube construction ($\\{0,1\\}^d$ has $2^d$ vertices but only $d$ distinct distances) illustrates why algebraic structure is essential. The Galois connection $g_d(n) = \\inf\\{m : f_d(m) \\geq n\\}$ links this to Problem #1083 and the Guth-Katz planar result.",
     "implications": "**Theoretical Connections:**\n\n1. **Planar distinct distances (Guth-Katz 2015):** Problem #1089 is the high-dimensional counterpart \u2014 fixing $n$ and varying $d$ rather than fixing $d=2$ and varying $n$. The polynomial partitioning technique that resolved the planar case has not yielded results in the threshold setting, suggesting fundamentally different methods may be needed for the high-dimensional problem.\n\n2. **Coding theory:** Distance codes in $\\mathbb{R}^d$ require point sets with controlled distance spectra. The threshold $g_d(n)$ directly measures how efficiently one can avoid distance repetition in high dimensions. Connections to equiangular lines, Johnson-Lindenstrauss embeddings, and compressed sensing arise from the same geometric constraints.\n\n3. **Concentration of measure:** In high dimensions, random point configurations on the unit sphere $S^{d-1}$ have pairwise distances concentrating near $\\sqrt{2}$ as $d \\to \\infty$. This means achieving many distinct distances requires carefully constructed (non-random) configurations \u2014 explaining why $g_d(n)$ must grow with $d$ and why algebraic constructions (like the cube) are essential.\n\n4. **Finite metric spaces:** The problem is equivalent to asking: what is the minimum size of a finite subset of $\\ell_2^d$ whose distance set has cardinality $\\geq n$? This connects to the theory of metric embeddings and the distortion required to embed metric spaces into Euclidean space.\n\n5. **Sphere packing:** Few-distance point sets (configurations with small $|\\Delta(P)|$) are intimately related to sphere packings and kissing numbers. The $d$-cube with $d$ distinct distances is related to the densest lattice packings in high dimensions, where the number of distinct inter-point distances in the first coordination shell determines the kissing number.",
     "openQuestions": [
       "Does lim_{d\u2192\u221e} g_d(n)/d^{n-1} exist for each fixed n \u2265 2?",
@@ -240,10 +240,10 @@
     "lineCount": 382,
     "structureCount": 0,
     "axiomCount": 8,
-    "theoremCount": 5,
-    "substantiveTheoremCount": 4,
-    "sorryTheorems": 0,
-    "lemmaCount": 2,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 5,
+    "sorryTheorems": 1,
+    "lemmaCount": 4,
     "defCount": 12,
     "imports": [
       "Mathlib"
@@ -278,6 +278,12 @@
       "type": "core",
       "description": "g_d is monotone in n: requiring more distinct distances needs at least as many points",
       "leanType": "\u2200 d n\u2081 n\u2082, n\u2081 \u2264 n\u2082 \u2192 g d n\u2081 \u2264 g d n\u2082"
+    },
+    {
+      "name": "g_mono_d",
+      "type": "core",
+      "description": "g_d(n) is non-decreasing in d: proved via isometric embedding \u211d^{d\u2081} \u21aa \u211d^{d\u2082} (1 sorry in norm-preservation lemma)",
+      "leanType": "\u2200 d\u2081 d\u2082 n, d\u2081 \u2264 d\u2082 \u2192 n \u2265 2 \u2192 g d\u2081 n \u2264 g d\u2082 n"
     },
     {
       "name": "erdos1089Conjecture",


### PR DESCRIPTION
## Summary

- **erdos-1089** meta.json claimed `sorries: 0` but Lean source has 1 sorry (`embedPoint_dist` norm-preservation lemma, line 315)
- Fixed sorry count (0 → 1), theorem count (5 → 6, missing `g_mono_d`), lemma count (2 → 4), sorryTheorems (0 → 1)
- Updated stale overview/conclusion text: "307-line" → "382-line", "10 axioms" → "8 axioms", corrected section line ranges
- Added `g_mono_d` to `mainTheorems` list
- Fixed mono section summary that said "axiomatizes g_mono_d" when it's now proved (with 1 sorry)

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page for erdos-1089 renders correctly
- [ ] Sorry count in meta.json matches Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)