### PR TITLE
fix(audit): correct erdos-1168 lineCount

### DIFF
--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -21,7 +21,7 @@
     "erdosProblemStatus": "open",
     "badge": "axiom",
     "axiomCount": 2,
-    "lineCount": 130,
+    "lineCount": 145,
     "theoremCount": 4,
     "definitionCount": 5,
     "assumptions": "2 axioms: erdos_1168 (OPEN conjecture), erdos_1168_under_gch (known under GCH). 4 structural theorems proved from definitions.",


### PR DESCRIPTION
## Summary

- Fixed lineCount in erdos-1168/meta.json: 130 → 145 (actual Lean file line count)

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)