### PR TITLE
Research: prove erdosLaskar_approx and max_diagonals_in_cycle

### DIFF
--- a/proofs/Proofs/Erdos1033Problem.lean
+++ b/proofs/Proofs/Erdos1033Problem.lean
@@ -127,7 +127,16 @@ noncomputable def erdosLaskarConstant : ℝ := 2 * (Real.sqrt 3 - 1)
 
 /-- Numerical value: 2(√3 - 1) ≈ 1.464. -/
 theorem erdosLaskar_approx : erdosLaskarConstant > 1.46 ∧ erdosLaskarConstant < 1.47 := by
-  sorry
+  unfold erdosLaskarConstant
+  have hsqrt3_lb : (1.73 : ℝ) < Real.sqrt 3 := by
+    have h : (1.73 : ℝ) ^ 2 < 3 := by norm_num
+    rw [← Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 1.73)]
+    exact Real.sqrt_lt_sqrt (sq_nonneg _) h
+  have hsqrt3_ub : Real.sqrt 3 < (1.735 : ℝ) := by
+    have h : (3 : ℝ) < 1.735 ^ 2 := by norm_num
+    rw [← Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 1.735)]
+    exact Real.sqrt_lt_sqrt (by norm_num) h
+  constructor <;> linarith
 
 /-
 ## Erdős-Laskar Upper Bound (1985)

--- a/proofs/Proofs/Erdos642Problem.lean
+++ b/proofs/Proofs/Erdos642Problem.lean
@@ -103,7 +103,11 @@ theorem f_le_complete (n : ℕ) : f n ≤ n * (n - 1) / 2 := by
 /-- A cycle of length k has at most k(k-3)/2 possible diagonals. -/
 theorem max_diagonals_in_cycle (k : ℕ) (hk : k ≥ 3) :
     k * (k - 3) / 2 = (k.choose 2) - k := by
-  sorry
+  rw [Nat.choose_two_right]
+  suffices h : k * (k - 3) / 2 + k = k * (k - 1) / 2 by omega
+  have heq : k * (k - 1) = k * (k - 3) + k * 2 := by
+    rw [← mul_add, show k - 3 + 2 = k - 1 from by omega]
+  rw [heq, Nat.add_mul_div_right _ _ (by norm_num : (0 : ℕ) < 2)]
 
 /-
 ## Part V: Chen-Erdős-Staton Bound (1996)


### PR DESCRIPTION
## Summary
- **Erdos1033**: prove `erdosLaskar_approx` — shows 1.46 < 2(√3-1) < 1.47 via sqrt bounds from `Real.sqrt_lt_sqrt`
- **Erdos642**: prove `max_diagonals_in_cycle` — arithmetic identity k(k-3)/2 = C(k,2) - k via `Nat.add_mul_div_right`

## Files Modified
- `proofs/Proofs/Erdos1033Problem.lean` (1 sorry eliminated)
- `proofs/Proofs/Erdos642Problem.lean` (1 sorry eliminated)

## Status
**Outcome**: progress (2 sorries eliminated)

🤖 Generated by researcher-1