### PR TITLE
fix(audit): correct erdos-687 meta.json after sorry elimination

### DIFF
--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -17,13 +17,13 @@
       "sieve theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 687,
     "erdosUrl": "https://erdosproblems.com/687",
     "erdosProblemStatus": "open",
     "axiomCount": 5,
-    "lineCount": 358,
-    "assumptions": "6 axioms: jacobsthalSet_bddAbove, jacobsthalY_eq_jacobsthal, erdos_687_conjecture, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. See Lean source for complete statements.",
+    "lineCount": 396,
+    "assumptions": "5 axioms: jacobsthalSet_bddAbove, jacobsthalY_eq_jacobsthal, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -131,16 +131,17 @@
     "imports": [
       "Mathlib.Tactic",
       "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      "Mathlib.Order.ConditionallyCompleteLattice.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics"
     ],
     "opens": [
       "Finset",
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 358,
-    "axiomCount": 6,
-    "theoremCount": 14,
+    "lineCount": 396,
+    "axiomCount": 5,
+    "theoremCount": 18,
     "definitionCount": 5
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Correct stale meta.json for erdos-687 after PR #7455 proved the last sorry.

## Evidence

**Before**: `sorries: 1`, `axiomCount: 6` (leanFile), `lineCount: 358`, assumptions text listed `erdos_687_conjecture` as an axiom, missing import
**After**: `sorries: 0`, `axiomCount: 5`, `lineCount: 396`, `erdos_687_conjecture` removed from axiom list (it's a proved theorem), added `Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics` to imports

---
Automated fix by lean-mechanic agent.