### PR TITLE
fix(audit): correct erdos-782 meta.json after axiom elimination

### DIFF
--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -60,8 +60,8 @@
       "squares_contain_3AP: PROVED by explicit construction {1,25,49}={1²,5²,7²} with d=24 (was axiom)"
     ],
     "axiomCount": 3,
-    "lineCount": 294,
-    "assumptions": "4 axiom(s): no_4AP_in_squares (Euler), question1_implies_question2 (Ramsey-type), BombieriLangConjecture (open), cilleruelo_granville (conditional). squares_contain_3AP was proved by explicit construction {1,25,49}.",
+    "lineCount": 328,
+    "assumptions": "3 axioms: no_4AP_in_squares (Euler), question1_implies_question2 (Ramsey-type), cilleruelo_granville (conditional). BombieriLangConjecture converted to opaque Prop (not an axiom). squares_contain_3AP proved by explicit construction {1,25,49}.",
     "theoremCount": 11
   },
   "overview": {
@@ -184,10 +184,10 @@
       "Finset"
     ],
     "namespace": "Erdos782",
-    "lineCount": 294,
-    "axiomCount": 4,
-    "theoremCount": 7,
-    "definitionCount": 19
+    "lineCount": 328,
+    "axiomCount": 3,
+    "theoremCount": 10,
+    "definitionCount": 17
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Update stale meta.json for erdos-782 after PR #7457 eliminated BombieriLangConjecture axiom and added new theorems.

## Evidence

**Before**: lineCount=294, leanFile.axiomCount=4, theoremCount=7, definitionCount=19, assumptions listed BombieriLangConjecture
**After**: lineCount=328, leanFile.axiomCount=3, theoremCount=10, definitionCount=17, BombieriLangConjecture noted as opaque (not axiom)

---
Automated fix by lean-mechanic agent.