### PR TITLE
fix(audit): correct erdos-380 lineCount and leanFile counts

### DIFF
--- a/src/data/proofs/erdos-380/meta.json
+++ b/src/data/proofs/erdos-380/meta.json
@@ -51,7 +51,7 @@
       "bad_interval_v_bound: bad intervals satisfy v < 2u (Bertrand + no-prime)"
     ],
     "axiomCount": 2,
-    "lineCount": 259,
+    "lineCount": 288,
     "assumptions": "3 axioms: erdos_graham_lower (deep analytic result), gpfSquare_asymptotic (deep analytic result), bad_interval_no_prime (elementary but requires p-adic valuation infrastructure). Previously 7 axioms; 4 eliminated by defining greatestPrimeFactor via Nat.primeFactors.max' with proved properties.",
     "theoremCount": 9
   },
@@ -148,10 +148,10 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 259,
+    "lineCount": 288,
     "axiomCount": 2,
-    "theoremCount": 3,
-    "definitionCount": 5
+    "theoremCount": 9,
+    "definitionCount": 6
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Update stale lineCount and leanFile counts for erdos-380 after recent research PRs.

## Evidence

**Before**: lineCount=259, leanFile.theoremCount=3, leanFile.definitionCount=5
**After**: lineCount=288, leanFile.theoremCount=9, leanFile.definitionCount=6

---
Automated fix by lean-mechanic agent.