### PR TITLE
fix(audit): correct erdos-687 sorry count and stale metadata

### DIFF
--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -17,13 +17,13 @@
       "sieve theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 687,
     "erdosUrl": "https://erdosproblems.com/687",
     "erdosProblemStatus": "open",
     "axiomCount": 5,
-    "lineCount": 358,
-    "assumptions": "6 axioms: jacobsthalSet_bddAbove, jacobsthalY_eq_jacobsthal, erdos_687_conjecture, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. See Lean source for complete statements.",
+    "lineCount": 396,
+    "assumptions": "5 axioms: jacobsthalSet_bddAbove, jacobsthalY_eq_jacobsthal, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. erdos_687_conjecture is a theorem proved from maier_pomerance_conjecture. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -138,7 +138,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 358,
+    "lineCount": 396,
     "axiomCount": 6,
     "theoremCount": 14,
     "definitionCount": 5

--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -139,7 +139,7 @@
     ],
     "namespace": null,
     "lineCount": 396,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 14,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Summary

- **erdos-687** meta.json claimed `sorries: 1` but Lean source has 0 sorries (the sorry was eliminated in a prior research PR)
- Fixed lineCount: 358 → 396
- Fixed assumptions text: listed `erdos_687_conjecture` as an axiom but it's a theorem proved from `maier_pomerance_conjecture`

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page for erdos-687 renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)