### PR TITLE
fix(audit): correct erdos-642 sorries 7→6 and section line ranges

### DIFF
--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 6,
     "erdosNumber": 642,
     "erdosUrl": "https://erdosproblems.com/642",
     "erdosProblemStatus": "open",
@@ -60,8 +60,8 @@
       "ramseys-theorem"
     ],
     "axiomCount": 4,
-    "lineCount": 271,
-    "assumptions": "4 axiom(s) and 7 sorry(s). See the Lean source for details."
+    "lineCount": 275,
+    "assumptions": "4 axioms (chen_erdos_staton, dmms_2024, turan_C4_free, expander_cycle_lemma) and 6 sorries. max_diagonals_in_cycle now proved."
   },
   "overview": {
     "historicalContext": "**Cycles with More Vertices than Diagonals: An Open Extremal Problem**\n\nA 'diagonal' (or 'chord') of a cycle $C$ in a graph $G$ is an edge of $G$ connecting two non-adjacent vertices of $C$. The condition '$|V(C)| > |\\text{diag}(C)|$' says every cycle has strictly more vertices than chords — a natural sparsity condition on how densely cycles can be chorded.\n\n**Origins**: This problem was posed by Hamburger and Szegedy and appears in Erdős's problem collections. It asks for the maximum number of edges $f(n)$ in an $n$-vertex graph satisfying this condition.\n\n**The Critical Threshold at $k = 5$**: Short cycles ($k \\le 4$) always satisfy the condition: a triangle has 0 possible diagonals, and a $C_4$ has at most 2 (both satisfying $k > \\text{diag}$). But a pentagon $C_5$ has 5 possible diagonals, and $5 \\not> 5$, so a $C_5$ with all diagonals (which is $K_5$) violates the condition. This critical transition at $k = 5$ explains why girth-5 graphs are the natural construction for the lower bound.\n\n**Progress on the Upper Bound**:\n- **Chen-Erdős-Staton (1996)**: Proved $f(n) = O(n^{3/2})$. Their argument uses neighborhood counting: in a dense graph, vertices have large neighborhoods, and the overlap of neighborhoods creates cycles with many chords. This was the state of the art for nearly 30 years.\n- **Draganić-Methuku-Munhá Correia-Sudakov (2024)**: Dramatically improved to $f(n) = O(n(\\log n)^8)$ using sublinear expander techniques. The key insight: any graph with $\\gg n(\\log n)^8$ edges contains a sublinear expander subgraph, and random walks in such expanders efficiently find cycles with many chords.\n\n**The Lower Bound**: Girth-5 graphs (no $C_3$ or $C_4$) trivially satisfy the condition (their cycles have very few diagonals). By the Kővári-Sós-Turán theorem and algebraic constructions (incidence graphs of projective planes, Reiman 1958), such graphs can have $\\Theta(n^{3/2})$ edges. This gives $f(n) = \\Omega(n^{3/2})$.\n\n**The Open Question**: Is $f(n) = o(n)$? Even $f(n) = O(n)$ is unknown. The current bounds $\\Omega(n^{3/2}) \\le f(n) \\le O(n(\\log n)^8)$ leave a gap of $(\\log n)^8/\\sqrt{n}$ in multiplicative terms, which tends to 0 — but this does not resolve the conjecture.",
@@ -109,65 +109,65 @@
     {
       "id": "trivial",
       "title": "Trivial Bounds",
-      "summary": "Three basic observations: f_ge_tree (f(n) ≥ n-1 from acyclic graphs), f_le_complete (f(n) ≤ n(n-1)/2 from complete graph), and max_diagonals_in_cycle (a k-cycle has at most k(k-3)/2 diagonals = C(k,2) - k). All carry sorry — they bound f(n) between n-1 and n²/2.",
+      "summary": "Three basic observations: f_ge_tree (f(n) ≥ n-1, sorry), f_le_complete (f(n) ≤ n(n-1)/2, sorry), and max_diagonals_in_cycle (k(k-3)/2 = C(k,2) - k, proved via Nat.choose_two_right). Bounds f(n) between n-1 and n²/2.",
       "startLine": 89,
-      "endLine": 107,
-      "mathContext": "Three basic observations: f_ge_tree (f(n) ≥ n-1 from acyclic graphs), f_le_complete (f(n) ≤ n(n-1)/2 from complete graph), and max_diagonals_in_cycle (a k-cycle has at most k(k-3)/2 diagonals = C(k,2) - k). All carry sorry — they bound f(n) between n-1 and n²/2."
+      "endLine": 111,
+      "mathContext": "Three basic observations: f_ge_tree (f(n) ≥ n-1 from acyclic graphs), f_le_complete (f(n) ≤ n(n-1)/2 from complete graph), and max_diagonals_in_cycle (a k-cycle has at most k(k-3)/2 diagonals = C(k,2) - k, now proved)."
     },
     {
       "id": "ces",
       "title": "Chen-Erdős-Staton Bound",
       "summary": "Axiomatizes chen_erdos_staton: f(n) ≤ 2⌊n^(3/2)⌋ for n ≥ 10. This 1996 result was the first non-trivial upper bound and the best known for nearly 30 years. The proof uses neighborhood overlap in dense graphs to find heavily-chorded cycles. Also defines ces_exponent = 3/2.",
-      "startLine": 108,
-      "endLine": 120,
+      "startLine": 112,
+      "endLine": 124,
       "mathContext": "Axiomatizes chen_erdos_staton: f(n) ≤ 2⌊n^(3/2)⌋ for n ≥ 10. This 1996 result was the first non-trivial upper bound and the best known for nearly 30 years. The proof uses neighborhood overlap in dense graphs to find heavily-chorded cycles. Also defines ces_exponent = 3/2."
     },
     {
       "id": "dmms",
       "title": "DMMS Bound (2024)",
       "summary": "Axiomatizes dmms_2024: f(n) ≤ ⌈n(log n)^8⌉ for n ≥ 10, the state-of-the-art from Draganić-Methuku-Munhá Correia-Sudakov. This dramatic improvement from O(n^(3/2)) to O(n(log n)^8) uses sublinear expander techniques. dmms_improves_ces (sorry) verifies the improvement for n ≥ 1000.",
-      "startLine": 121,
-      "endLine": 135,
+      "startLine": 125,
+      "endLine": 139,
       "mathContext": "Axiomatizes dmms_2024: f(n) ≤ ⌈n(log n)^8⌉ for n ≥ 10, the state-of-the-art from Draganić-Methuku-Munhá Correia-Sudakov. This dramatic improvement from O(n^(3/2)) to O(n(log n)^8) uses sublinear expander techniques. dmms_improves_ces (sorry) verifies the improvement for n ≥ 1000."
     },
     {
       "id": "conjecture",
       "title": "The Open Conjecture",
       "summary": "States two open conjectures: HamburgerSzegedyConjecture (f(n) = o(n), formalized as ∀ε>0, ∃N, ∀n≥N, f(n) < εn) and the weaker LinearBoundConjecture (f(n) = O(n)). Both remain OPEN — the DMMS bound O(n(log n)^8) is still superlinear. conjecture_stronger_than_dmms (sorry) notes the logical relationship.",
-      "startLine": 136,
-      "endLine": 155,
+      "startLine": 140,
+      "endLine": 159,
       "mathContext": "States two open conjectures: HamburgerSzegedyConjecture (f(n) = o(n), formalized as ∀ε>0, ∃N, ∀n≥N, f(n) < εn) and the weaker LinearBoundConjecture (f(n) = O(n)). Both remain OPEN — the DMMS bound O(n(log n)^8) is still superlinear."
     },
     {
       "id": "girth",
       "title": "Related Extremal Problems",
       "summary": "Connects to girth-5 graphs: HasGirth G 5 requires all cycles have length ≥ 5. girth_5_satisfies (sorry) shows these satisfy the condition. turan_C4_free (axiom) gives girth-5 graphs with Ω(n^(3/2)) edges from projective plane incidence graphs. f_lower_bound chains these to get f(n) ≥ Ω(n^(3/2)). This is the Kővári-Sós-Turán / Reiman construction.",
-      "startLine": 156,
-      "endLine": 181,
+      "startLine": 160,
+      "endLine": 185,
       "mathContext": "Connects to girth-5 graphs: HasGirth G 5 requires all cycles have length ≥ 5. girth_5_satisfies (sorry) shows these satisfy the condition. turan_C4_free (axiom) gives girth-5 graphs with Ω(n^(3/2)) edges from projective plane incidence graphs. f_lower_bound chains these to get f(n) ≥ Ω(n^(3/2))."
     },
     {
       "id": "expanders",
       "title": "Expander Techniques",
       "summary": "Formalizes the DMMS proof machinery: IsExpander G d λ (d-regular with spectral gap λ < d), IsSublinearExpander (degree d = n^ε for ε < 1), and the key expander_cycle_lemma dichotomy: good expanders either violate the condition or are sparse (|E| < dn/2). This is the technical heart of the 2024 breakthrough.",
-      "startLine": 182,
-      "endLine": 206,
+      "startLine": 186,
+      "endLine": 210,
       "mathContext": "Formalizes the DMMS proof machinery: IsExpander G d λ (d-regular with spectral gap λ < d), IsSublinearExpander (degree d = n^ε for ε < 1), and the key expander_cycle_lemma dichotomy: good expanders either violate the condition or are sparse (|E| < dn/2)."
     },
     {
       "id": "short-long",
       "title": "Short vs Long Cycles",
       "summary": "Complete critical length analysis — all proved without sorry: short_cycles_ok (k ≤ 4 ⟹ k > k(k-3)/2, by interval_cases + norm_num), pentagon_all_diags_violates (¬(5 > 5), by norm_num), and critical_length (k ≥ 5 ⟹ k ≤ k(k-3)/2, by omega). Together these show the exact transition at k = 5 between safe and potentially-violating cycle lengths.",
-      "startLine": 207,
-      "endLine": 226,
+      "startLine": 211,
+      "endLine": 230,
       "mathContext": "Complete critical length analysis — all proved without sorry: short_cycles_ok (k ≤ 4 ⟹ k > k(k-3)/2, by interval_cases + norm_num), pentagon_all_diags_violates (¬(5 > 5), by norm_num), and critical_length (k ≥ 5 ⟹ k ≤ k(k-3)/2, by omega)."
     },
     {
       "id": "main-result",
       "title": "Main Results",
       "summary": "erdos_642_bounds combines both bounds: ⌊n^(3/2)/4⌋ ≤ f(n) ≤ ⌈n(log n)^8⌉ for n ≥ 10, using constructor with f_lower_bound and dmms_2024. Utility definitions record the OPEN status. bounds_gap proves the ratio is (log n)^8/√n via ring_nf. Three #check commands verify the key theorems typecheck.",
-      "startLine": 227,
-      "endLine": 271,
+      "startLine": 231,
+      "endLine": 275,
       "mathContext": "erdos_642_bounds combines both bounds: ⌊n^(3/2)/4⌋ ≤ f(n) ≤ ⌈n(log n)^8⌉ for n ≥ 10, using constructor with f_lower_bound and dmms_2024. Utility definitions record the OPEN status. bounds_gap proves the ratio is (log n)^8/√n via ring_nf. Three #check commands verify the key theorems typecheck."
     }
   ],
@@ -192,7 +192,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos642",
-    "lineCount": 271,
+    "lineCount": 275,
     "axiomCount": 4,
     "theoremCount": 12,
     "definitionCount": 14


### PR DESCRIPTION
## Summary

- **sorries**: 7 → 6 (`max_diagonals_in_cycle` proved in #7459)
- **lineCount**: 271 → 275 (both `meta` and `leanFile` sections)
- **assumptions**: enumerate all 4 axioms explicitly, note `max_diagonals_in_cycle` proved
- **trivial section**: endLine 107→111, update summary to note proof status
- **7 subsequent sections**: shift start/end by +4

## Test plan

- [ ] Verify `pnpm build` succeeds
- [ ] Check gallery page renders correctly for erdos-642

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)