### PR TITLE
Research: erdos-1160 — structural axioms + m=4 proof

### DIFF
--- a/proofs/Proofs/Erdos1160Problem.lean
+++ b/proofs/Proofs/Erdos1160Problem.lean
@@ -52,11 +52,38 @@ axiom numGroups_prime (p : ℕ) (hp : Nat.Prime p) : numGroups p = 1
 theorem numGroups_two : numGroups 2 = 1 :=
   numGroups_prime 2 (by norm_num)
 
-/-- Known values for small orders.
-    Further known values (for reference): g(16) = 14, g(32) = 51, g(64) = 267. -/
-axiom numGroups_four : numGroups 4 = 2
-axiom numGroups_six : numGroups 6 = 2
+/-- For any prime p, there are exactly 2 groups of order p²:
+    the cyclic group ℤ/p²ℤ and the direct product ℤ/pℤ × ℤ/pℤ. -/
+axiom numGroups_prime_sq (p : ℕ) (hp : Nat.Prime p) : numGroups (p ^ 2) = 2
+
+/-- numGroups 4 = 2: derived from numGroups_prime_sq since 4 = 2². -/
+theorem numGroups_four : numGroups 4 = 2 := by
+  have : (2 : ℕ) ^ 2 = 4 := by norm_num
+  rw [← this]; exact numGroups_prime_sq 2 (by norm_num)
+
+/-- For distinct primes p > q with q ∣ (p - 1), there are exactly 2 groups
+    of order pq: the cyclic group ℤ/pqℤ and a semidirect product ℤ/pℤ ⋊ ℤ/qℤ. -/
+axiom numGroups_pq_dvd (p q : ℕ) (hp : Nat.Prime p) (hq : Nat.Prime q) (hlt : q < p)
+    (hdvd : q ∣ (p - 1)) : numGroups (p * q) = 2
+
+/-- For distinct primes p > q with q ∤ (p - 1), there is exactly 1 group
+    of order pq: the cyclic group ℤ/pqℤ (by Sylow theory). -/
+axiom numGroups_pq_ndvd (p q : ℕ) (hp : Nat.Prime p) (hq : Nat.Prime q) (hlt : q < p)
+    (hndvd : ¬(q ∣ (p - 1))) : numGroups (p * q) = 1
+
+/-- numGroups 6 = 2: derived from numGroups_pq_dvd since 6 = 3 × 2 and 2 ∣ (3-1). -/
+theorem numGroups_six : numGroups 6 = 2 := by
+  have : 6 = 3 * 2 := by norm_num
+  rw [this]; exact numGroups_pq_dvd 3 2 (by norm_num) (by norm_num) (by omega) ⟨1, by omega⟩
+
+/-- Known value: g(8) = 5. The 5 groups are: ℤ/8ℤ, ℤ/4ℤ×ℤ/2ℤ, (ℤ/2ℤ)³, D₄, Q₈. -/
 axiom numGroups_eight : numGroups 8 = 5
+
+/-- Known value: g(12) = 5. The 5 groups are: ℤ/12ℤ, ℤ/2ℤ×ℤ/6ℤ, D₆, A₄, Dic₃. -/
+axiom numGroups_twelve : numGroups 12 = 5
+
+/-- Known value: g(16) = 14. There are 14 non-isomorphic groups of order 2⁴. -/
+axiom numGroups_sixteen : numGroups 16 = 14
 
 /-
 ## Section II: Basic Properties
@@ -223,6 +250,52 @@ theorem erdos_1160_m_eq_three (n : ℕ) (hn : n ≤ 8) :
   · rw [numGroups_prime 5 (by norm_num), numGroups_eight]; omega
   · rw [numGroups_six, numGroups_eight]; omega
   · rw [numGroups_prime 7 (by norm_num), numGroups_eight]; omega
+  · exact le_refl _
+
+/-- Helper: g(9) = 2, since 9 = 3² and g(p²) = 2 for all primes. -/
+theorem numGroups_nine : numGroups 9 = 2 := by
+  have : (3 : ℕ) ^ 2 = 9 := by norm_num
+  rw [← this]; exact numGroups_prime_sq 3 (by norm_num)
+
+/-- Helper: g(10) = 2, since 10 = 5 × 2 and 2 ∣ (5 - 1). -/
+theorem numGroups_ten : numGroups 10 = 2 := by
+  have : 10 = 5 * 2 := by norm_num
+  rw [this]; exact numGroups_pq_dvd 5 2 (by norm_num) (by norm_num) (by omega) ⟨2, by omega⟩
+
+/-- Helper: g(14) = 2, since 14 = 7 × 2 and 2 ∣ (7 - 1). -/
+theorem numGroups_fourteen : numGroups 14 = 2 := by
+  have : 14 = 7 * 2 := by norm_num
+  rw [this]; exact numGroups_pq_dvd 7 2 (by norm_num) (by norm_num) (by omega) ⟨3, by omega⟩
+
+/-- Helper: g(15) = 1, since 15 = 5 × 3 and 3 ∤ (5 - 1) = 4. -/
+theorem numGroups_fifteen : numGroups 15 = 1 := by
+  have : 15 = 5 * 3 := by norm_num
+  rw [this]; exact numGroups_pq_ndvd 5 3 (by norm_num) (by norm_num) (by omega)
+    (by omega)
+
+/-- The conjecture for all n ≤ 16 (m = 4).
+    Uses structural axioms: g(p²) = 2, g(pq) formulas, plus g(8) = 5, g(12) = 5, g(16) = 14. -/
+theorem erdos_1160_m_eq_four (n : ℕ) (hn : n ≤ 16) :
+    numGroups n ≤ numGroups (2 ^ 4) := by
+  have h16 : (2 : ℕ) ^ 4 = 16 := by norm_num
+  rw [h16]
+  interval_cases n
+  · rw [numGroups_zero]; exact Nat.zero_le _
+  · rw [numGroups_one, numGroups_sixteen]; omega
+  · rw [numGroups_two, numGroups_sixteen]; omega
+  · rw [numGroups_prime 3 (by norm_num), numGroups_sixteen]; omega
+  · rw [numGroups_four, numGroups_sixteen]; omega
+  · rw [numGroups_prime 5 (by norm_num), numGroups_sixteen]; omega
+  · rw [numGroups_six, numGroups_sixteen]; omega
+  · rw [numGroups_prime 7 (by norm_num), numGroups_sixteen]; omega
+  · rw [numGroups_eight, numGroups_sixteen]; omega
+  · rw [numGroups_nine, numGroups_sixteen]; omega
+  · rw [numGroups_ten, numGroups_sixteen]; omega
+  · rw [numGroups_prime 11 (by norm_num), numGroups_sixteen]; omega
+  · rw [numGroups_twelve, numGroups_sixteen]; omega
+  · rw [numGroups_prime 13 (by norm_num), numGroups_sixteen]; omega
+  · rw [numGroups_fourteen, numGroups_sixteen]; omega
+  · rw [numGroups_fifteen, numGroups_sixteen]; omega
   · exact le_refl _
 
 /-- If the conjecture holds for m, and g(2^m) ≤ g(2^(m+1)),

--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -19,13 +19,13 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 10,
+    "axiomCount": 13,
     "erdosNumber": 1160,
     "erdosUrl": "https://erdosproblems.com/1160",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-24",
     "mathlib_version": "4.26.0",
-    "lineCount": 240,
+    "lineCount": 312,
     "mathlibDependencies": [
       {
         "theorem": "Nat.Prime",
@@ -59,11 +59,15 @@
       "pantelidakis_odd: axiomatized partial result for odd n",
       "numGroups_prime_power_pos: proved positivity for prime powers from numGroups_prime + monotonicity",
       "erdos_1160_m_eq_two: proved conjecture for all n ≤ 4 (m=2 case)",
-      "erdos_1160_m_eq_three: proved conjecture for all n ≤ 8 (m=3 case)"
+      "erdos_1160_m_eq_three: proved conjecture for all n ≤ 8 (m=3 case)",
+      "numGroups_prime_sq: generalized g(p²)=2 for all primes (subsumes numGroups_four)",
+      "numGroups_pq_dvd/ndvd: structural axioms for g(pq) (subsumes numGroups_six)",
+      "erdos_1160_m_eq_four: proved conjecture for all n ≤ 16 (m=4 case)"
     ],
     "assumptions": [
       "numGroups is axiomatized (Lean/Mathlib lacks group enumeration)",
-      "Known values g(1)=1, g(2)=1, g(4)=2, g(6)=2, g(8)=5 are axiomatized",
+      "Known values g(8)=5, g(12)=5, g(16)=14 are axiomatized; g(4), g(6), g(9), g(10), g(14), g(15) are derived from structural axioms",
+      "g(p²)=2 for all primes p (axiom); g(pq) formula for distinct primes (axioms)",
       "Pantelidakis's result for odd n (m ≥ 3619) is axiomatized",
       "Asymptotic growth formula log₂(g(2^m)) ~ (2/27)m³ is axiomatized"
     ]
@@ -138,7 +142,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1160 and its strengthened BNV form, proves the equivalence of two conjecture formulations, verifies base cases (n = 0, 1, prime n, m ≤ 3), and axiomatizes the key known partial result (Pantelidakis for odd n) and the Higman–Sims asymptotic formula. The 10 axioms encode the group counting function and its known properties, since group enumeration is not available in Lean/Mathlib.",
+    "summary": "This formalization captures Erdős Problem #1160 and its strengthened BNV form, proves the equivalence of two conjecture formulations, verifies the conjecture for m ≤ 4 (all n ≤ 16), and axiomatizes the key known partial result (Pantelidakis for odd n) and the Higman–Sims asymptotic formula. Structural axioms for g(p²) and g(pq) enable deriving many group counts from general principles rather than individual value axioms. The 13 axioms encode the group counting function and its known properties, since group enumeration is not available in Lean/Mathlib.",
     "implications": "A proof of the full conjecture would establish that 2-groups are the dominant source of finite group diversity at every scale — a fundamental structural fact about finite group theory. The BNV stronger form would imply that the diversity of 2-groups grows so fast that a single order $2^m$ harbors more non-isomorphic groups than all smaller orders combined. Progress on this conjecture is closely tied to advances in $p$-group enumeration and nilpotent Lie algebra classification.",
     "openQuestions": [
       "Can the Pantelidakis threshold of $m \\geq 3619$ for odd $n$ be significantly lowered, perhaps to $m \\geq 10$ or smaller?",

--- a/src/data/research/problems/erdos-1160.json
+++ b/src/data/research/problems/erdos-1160.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Removed 2 unused axioms (11→10), added numGroups_six, proved erdos_1160_m_eq_three (m=3 case)",
+    "progressSummary": "PROGRESS: Generalized numGroups_four→numGroups_prime_sq, numGroups_six→numGroups_pq structural axioms. Proved erdos_1160_m_eq_four (conjecture for all n≤16). Net +3 axioms (10→13) but structural axioms cover infinite cases.",
     "builtItems": [
       "Created Erdos1160Problem.lean with numGroups axiomatization",
       "Proved erdos_1160_equiv (two formulations equivalent)",
@@ -46,7 +46,19 @@
       "numGroups_two_power_pos: re-proved without numGroups_pos axiom",
       "erdos_1160_m_eq_two: proved conjecture for all n≤4 (m=2 case)",
       "numGroups_six: g(6)=2 axiom for non-prime composite case",
-      "erdos_1160_m_eq_three: conjecture for m=3 (all n <= 8)"
+      "erdos_1160_m_eq_three: conjecture for m=3 (all n <= 8)",
+      "numGroups_prime_sq: axiom g(p²)=2 for all primes",
+      "numGroups_pq_dvd: axiom g(pq)=2 when q|(p-1)",
+      "numGroups_pq_ndvd: axiom g(pq)=1 when q∤(p-1)",
+      "numGroups_four: converted from axiom to theorem (derived from numGroups_prime_sq)",
+      "numGroups_six: converted from axiom to theorem (derived from numGroups_pq_dvd)",
+      "numGroups_nine: theorem g(9)=2 from numGroups_prime_sq",
+      "numGroups_ten: theorem g(10)=2 from numGroups_pq_dvd",
+      "numGroups_fourteen: theorem g(14)=2 from numGroups_pq_dvd",
+      "numGroups_fifteen: theorem g(15)=1 from numGroups_pq_ndvd",
+      "numGroups_twelve: axiom g(12)=5",
+      "numGroups_sixteen: axiom g(16)=14",
+      "erdos_1160_m_eq_four: proved conjecture for all n ≤ 16"
     ],
     "insights": [
       "g(2^m) grows as 2^{(2/27)m³} due to nilpotent Lie algebra correspondence",
@@ -62,7 +74,12 @@
       "erdos_1160_m_eq_two: conjecture verified for m=2 using interval_cases and numGroups_prime for g(3)=1",
       "Removed unused axioms numGroups_sixteen and numGroups_thirtytwo (never referenced in proofs)",
       "Added numGroups_six : numGroups 6 = 2 (g(6)=2: Z/6Z and S_3)",
-      "Proved erdos_1160_m_eq_three: conjecture verified for all n <= 8 via interval_cases"
+      "Proved erdos_1160_m_eq_three: conjecture verified for all n <= 8 via interval_cases",
+      "numGroups_prime_sq: g(p²)=2 for all primes p (two groups: Z/p²Z and Z/pZ×Z/pZ) — generalizes numGroups_four",
+      "numGroups_pq_dvd/ndvd: g(pq)=2 if q|(p-1), g(pq)=1 if q∤(p-1) — Sylow-based classification covers all pq orders",
+      "erdos_1160_m_eq_four: conjecture verified for all n ≤ 16 via interval_cases + structural axioms",
+      "g(9)=2, g(10)=2, g(14)=2, g(15)=1 all derived as theorems from structural axioms (not new axioms)",
+      "Only g(12)=5 and g(16)=14 required new specific value axioms for m=4 case"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -90,9 +107,9 @@
     {
       "path": "Proofs/Erdos1160Problem.lean",
       "filename": "Erdos1160Problem.lean",
-      "lineCount": 222,
-      "theoremCount": 13,
-      "axiomCount": 11,
+      "lineCount": 312,
+      "theoremCount": 21,
+      "axiomCount": 13,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- Generalized specific value axioms into structural theorems for group counting
- Proved Erdős #1160 conjecture for all n ≤ 16 (m=4 case, extending from m=3)

## Progress
- **numGroups_prime_sq**: g(p²) = 2 for ALL primes (replaces numGroups_four)
- **numGroups_pq_dvd/ndvd**: g(pq) = 2 when q|(p-1), = 1 when q∤(p-1) (replaces numGroups_six)
- **Derived as theorems**: g(4), g(6), g(9), g(10), g(14), g(15) — no longer axioms
- **erdos_1160_m_eq_four**: conjecture verified for all n ≤ 16 via interval_cases

## Findings
- Structural axioms for g(p²) and g(pq) are more powerful than individual values — they cover infinitely many cases and will reduce future axiom additions
- For m=4, only g(12)=5 and g(16)=14 needed new specific axioms (both are non-prime-power/non-pq orders)
- Net axiom change: 10 → 13 (+3 structural/value axioms, -2 specific values converted to theorems)

## Status
**Outcome**: progress
**Next Steps**: Consider extending structural axioms further (e.g., g(p³) formula) or proving m=5

🤖 Generated by researcher-3