### PR TITLE
fix: remove duplicate theorem declarations in erdos-687

### DIFF
--- a/proofs/Proofs/Erdos687Problem.lean
+++ b/proofs/Proofs/Erdos687Problem.lean
@@ -368,29 +368,3 @@ theorem not_mem_jacobsthalSet_two {y : ℕ} (hy : 2 ≤ y) :
   -- So 1 % 2 = a(2) % 2 = 2 % 2, i.e., 1 = 0. Contradiction.
   have := hcov₁.trans hcov₂.symm
   norm_num at this
-
-/-- 1 ∈ jacobsthalSet 2: choosing residue class 1 mod 2 covers [1, 1]. -/
-theorem one_mem_jacobsthalSet_two : (1 : ℕ) ∈ jacobsthalSet 2 := by
-  refine ⟨fun _ _ _ => 1, fun n h1 hn => ?_⟩
-  -- n ∈ [1, 1] means n = 1
-  have hn_eq : n = 1 := le_antisymm hn h1
-  subst hn_eq
-  -- 1 is covered by prime 2 with class 1: 1 % 2 = 1 % 2
-  exact ⟨2, by decide, le_refl 2, rfl⟩
-
-/-- Y(2) = 1. With only prime 2 available, the best covering picks one
-    parity class, achieving exactly [1, 1].
-    Note: this proof uses a LOCAL BddAbove argument for x = 2,
-    independent of the general jacobsthalSet_bddAbove axiom. -/
-theorem jacobsthalY_two : jacobsthalY 2 = 1 := by
-  unfold jacobsthalY
-  apply le_antisymm
-  · -- sSup ≤ 1: every element of jacobsthalSet 2 is ≤ 1
-    apply csSup_le (jacobsthalSet_nonempty 2)
-    intro y hy
-    by_contra h; push_neg at h
-    exact not_mem_jacobsthalSet_two (by omega) hy
-  · -- 1 ≤ sSup: 1 is in the set and the set is bounded above
-    exact le_csSup ⟨1, fun y hy => by
-      by_contra h; push_neg at h
-      exact not_mem_jacobsthalSet_two (by omega) hy⟩ one_mem_jacobsthalSet_two

--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/687",
     "erdosProblemStatus": "open",
     "axiomCount": 5,
-    "lineCount": 396,
+    "lineCount": 370,
     "assumptions": "5 axioms: jacobsthalSet_bddAbove, jacobsthalY_eq_jacobsthal, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. erdos_687_conjecture is a theorem proved from maier_pomerance_conjecture. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -138,9 +138,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 396,
+    "lineCount": 370,
     "axiomCount": 5,
-    "theoremCount": 14,
+    "theoremCount": 18,
     "definitionCount": 5
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Remove duplicate declarations of `one_mem_jacobsthalSet_two` and `jacobsthalY_two` that were introduced in #7455.

## Evidence

**Before**: `one_mem_jacobsthalSet_two` declared at lines 132 AND 373; `jacobsthalY_two` declared at lines 172 AND 385
**After**: Each theorem declared exactly once (earlier versions kept, as `jacobsthalSet_two` depends on forward references)

Also updates meta.json lineCount (396→370) and leanFile.theoremCount (14→18).

Closes #7468

---
Automated fix by lean-mechanic agent.