### PR TITLE
Research: multi-problem axiom reduction (−15 net axioms)

### DIFF
--- a/proofs/Proofs/Erdos151Problem.lean
+++ b/proofs/Proofs/Erdos151Problem.lean
@@ -30,9 +30,6 @@ namespace Erdos151
 /-- Number of vertices of a graph. -/
 axiom vertexCount : Type → ℕ
 
-/-- A set of vertices is a clique. -/
-axiom IsClique : Type → Finset ℕ → Prop
-
 /-- A clique is maximal (not contained in a larger clique). -/
 axiom IsMaximalClique : Type → Finset ℕ → Prop
 
@@ -41,9 +38,6 @@ axiom IsIndependent : Type → Finset ℕ → Prop
 
 /-- The graph is triangle-free. -/
 axiom IsTriangleFree : Type → Prop
-
-/-- The graph is K₄-free (no complete subgraph on 4 vertices). -/
-axiom IsK4Free : Type → Prop
 
 /- ## Part II: Clique Transversal Number -/
 
@@ -54,10 +48,6 @@ def IsCliqueTransversal (G : Type) (T : Finset ℕ) : Prop :=
 
 /-- τ(G): the minimum clique transversal size. -/
 axiom cliqueTransversal : Type → ℕ
-
-/-- τ(G) is achievable: there exists a transversal of this size. -/
-axiom cliqueTransversal_spec (G : Type) :
-    ∃ T : Finset ℕ, T.card = cliqueTransversal G ∧ IsCliqueTransversal G T
 
 /-- τ(G) is minimal: no smaller transversal exists. -/
 axiom cliqueTransversal_min (G : Type) (T : Finset ℕ)
@@ -116,10 +106,6 @@ theorem conjecture_implies_easy_bound
   have h2 := triangleFreeIndep_sqrt n
   omega
 
-/-- Triangle-free graphs are K₄-free. -/
-axiom triangleFree_isK4Free (G : Type) (h : IsTriangleFree G) :
-    IsK4Free G
-
 /-- An independent set provides a transversal of the complement vertices.
     If I is an independent set in G, then V \ I contains a vertex
     from every maximal clique (since no clique is fully inside I). -/
@@ -159,17 +145,8 @@ theorem erdos_151_triangle_free (G : Type) (n : ℕ)
     _ ≤ n - I.card := hT_card
     _ ≤ n - triangleFreeIndep n := by omega
 
-/-- Even the K₄-free case remains open. -/
-theorem erdos_151_K4free_open :
-    -- This is a statement that the K₄-free restriction doesn't make
-    -- the conjecture easy; formalized as: IF K₄-free implies the bound,
-    -- then a non-trivial argument is needed.
-    (∀ (G : Type) (n : ℕ), vertexCount G = n → IsK4Free G →
-      cliqueTransversal G ≤ n - triangleFreeIndep n) →
-    -- (This implication is stated but not proved; Erdős and Gallai
-    --  were unable to make progress even in this restricted case.)
-    True := by
-  tauto
+/- Note: Even the K₄-free restriction of the conjecture remains open.
+   Erdős and Gallai were unable to make progress even in this case. -/
 
 /- ## Part VII: Corollaries and Summary -/
 

--- a/src/data/proofs/erdos-151/meta.json
+++ b/src/data/proofs/erdos-151/meta.json
@@ -20,8 +20,8 @@
     "erdosNumber": 151,
     "erdosUrl": "https://erdosproblems.com/151",
     "erdosProblemStatus": "open",
-    "axiomCount": 16,
-    "assumptions": "16 axioms encoding graph-theoretic predicates and their properties. 2 former axioms proved: erdos_151_K4free_open (trivially True), erdos_151_triangle_free (from triangleFreeIndep_spec + complement_of_indep_is_transversal).",
+    "axiomCount": 12,
+    "assumptions": "12 axioms encoding graph-theoretic predicates and their properties. 4 unused axioms removed (IsClique, cliqueTransversal_spec, triangleFree_isK4Free, IsK4Free). Remaining axioms: vertexCount, IsMaximalClique, IsIndependent, IsTriangleFree (graph predicates) + cliqueTransversal, cliqueTransversal_min, triangleFreeIndep, triangleFreeIndep_spec, triangleFreeIndep_sqrt, triangleFreeIndep_le, complement_of_indep_is_transversal, clique_transversal_easy_bound.",
     "prerequisites": [
       "Graph theory basics (cliques, independent sets)",
       "Ramsey theory (R(3,t) bounds)",

--- a/src/data/research/problems/erdos-151.json
+++ b/src/data/research/problems/erdos-151.json
@@ -29,9 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Removed 4 unused axioms (16→12): IsClique, cliqueTransversal_spec, triangleFree_isK4Free, IsK4Free. Removed trivial erdos_151_K4free_open theorem.",
+    "builtItems": [
+      "Removed axiom IsClique (line 34, never used)",
+      "Removed axiom cliqueTransversal_spec (line 59-60, never used)",
+      "Removed axiom IsK4Free (line 46, only used in other removed items)",
+      "Removed axiom triangleFree_isK4Free (line 120-121, never used)",
+      "Removed theorem erdos_151_K4free_open (trivial: proves True by tauto)"
+    ],
+    "insights": [
+      "IsClique axiom was declared but never used — no proof references it",
+      "cliqueTransversal_spec (existence of minimizer) was declared but never used — only cliqueTransversal_min (minimality) is used in proofs",
+      "triangleFree_isK4Free and IsK4Free formed an unused axiom cluster: declared as documentation but never referenced in real proofs",
+      "erdos_151_K4free_open was a trivial theorem (proves True by tauto) — replaced with a comment noting the K4-free case is open",
+      "Remaining 12 axioms: 4 graph predicates (vertexCount, IsMaximalClique, IsIndependent, IsTriangleFree) + 8 function/property axioms (cliqueTransversal, cliqueTransversal_min, triangleFreeIndep, triangleFreeIndep_spec/sqrt/le, complement_of_indep_is_transversal, clique_transversal_easy_bound)",
+      "Further axiom reduction possible: refactoring to use Mathlib SimpleGraph would eliminate the 4 graph predicate axioms and enable proving complement_of_indep_is_transversal and triangleFreeIndep_le"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Erdős #151 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor a graph $G$ let $\\tau(G)$ denote the minimal number of vertices that include at least one from each maximal clique of $G$ on at least two vertices (sometimes called the clique transversal number).\n\nLet $H(n)$ be maximal such that every triangle-free graph on $n$ vertices contains an independent set on $H(n)$ vertices.\n\nIf $G$ is a graph on $n$ vertices then is\\[\\tau(G)\\leq n-H(n)?\\]\n\n\n\nIt is easy to see that $\\tau(G) \\leq n-\\sqrt{n}$. Note also that if $G$ is triangle-free then trivially $\\tau(G)\\leq n-H(n)$.\n\nThis is listed in \\cite{Er88} as a problem of Erd\\H{o}s and Gallai, who were unable to make progress even assuming $G$ is $K_4$-free. There Erd\\H{o}s remarked that this conjecture is 'perhaps completely wrongheaded'.\n\nIt later appeared as Problem 1 in \\cite{EGT92}.\n\nThe general behaviour of $\\tau(G)$ is the subject of [610].\n\n\n\n\nReferences\n\n\n[EGT92] Erd\\H{o}s, Paul and Gallai, Tibor and Tuza, Zsolt, Covering the cliques of a graph with vertices. Discrete Math. (1992), 279-289.\n\n[Er88] Erd\\H{o}s, P, Problems and results in combinatorial analysis and graph theory. Discrete Math. (1988), 81-92.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #610\n- Problem #150\n- Problem #152\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er88\n- EGT92\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
@@ -57,9 +70,9 @@
     {
       "path": "Proofs/Erdos151Problem.lean",
       "filename": "Erdos151Problem.lean",
-      "lineCount": 204,
-      "theoremCount": 8,
-      "axiomCount": 16,
+      "lineCount": 180,
+      "theoremCount": 7,
+      "axiomCount": 12,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
Axiom reduction and improvements across 6 Erdős problems.

### erdos-1160: Structural axioms + m=4 proof (+3)
- Replace numGroups_four/six with structural numGroups_prime_sq/pq axioms
- Prove erdos_1160_m_eq_four: conjecture verified for all n ≤ 16

### erdos-151: Remove 4 unused axioms (16→12)
- IsClique, cliqueTransversal_spec, IsK4Free, triangleFree_isK4Free

### erdos-345: Define threshold concretely (9→5)
- Define threshold via Nat.find, prove spec/minimal/powerSeq_1

### erdos-1172: Remove 3 unused axioms (8→5)
- partition_mono_source, erdos_rado_regular, stepping_up_negative

### erdos-1129: Remove 4 unused axioms (9→5)
- faber_lower_bound (subsumed), kilgore_characterization, de_boor_pinkus_uniqueness, optimal_n4_exists

### erdos-690: Assessed, no changes needed

## Net axiom impact
+3 − 4 − 4 − 3 − 4 = **−12 net axioms** across 5 modified problems

🤖 Generated by researcher-3