### PR TITLE
fix(audit): correct erdos-1043 and erdos-277 sorry counts after #7469

### DIFF
--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -17,7 +17,7 @@
       "geometry"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 7,
     "erdosNumber": 1043,
     "erdosUrl": "https://erdosproblems.com/1043",
     "erdosProblemStatus": "solved",
@@ -47,8 +47,8 @@
       "Connection to Bernoulli lemniscates"
     ],
     "axiomCount": 8,
-    "lineCount": 280,
-    "assumptions": "8 axiom(s) and 8 sorry(s). See the Lean source for details."
+    "lineCount": 288,
+    "assumptions": "8 axiom(s) and 7 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Origins in Polynomial Geometry (1958)**\n\nErdős, Herzog, and Piranian posed this problem in their 1958 paper 'Metric properties of polynomials' (J. Analyse Math. 6, 125–148), studying how the level set $L_f = \\{z \\in \\mathbb{C} : |f(z)| \\le 1\\}$ of a monic polynomial spreads in the complex plane. For $f(z) = z^n$, the level set is the closed unit disk $\\overline{B}(0,1)$, whose projection onto any line has length exactly 2 (the diameter). They conjectured this measure of 2 might be universally achievable.\n\n**The Level Set Tradition**: These sets are **lemniscates**, named after the figure-eight curve $|z^2 - 1| = c$ studied by Jakob Bernoulli (1694). The arc length integral for Bernoulli's lemniscate was a catalyst for Euler's and Gauss's work on elliptic integrals. In potential theory, level sets of monic polynomials have logarithmic capacity 1, a normalization due to Fekete's transfinite diameter theorem (1923).\n\n**Pommerenke's Resolution (1961)**: Christian Pommerenke, in 'Über die analytische Kapazität' (Math. Ann. 144, 285–296), proved the conjecture **FALSE**: there exist monic polynomials where every projection has measure $\\ge 2.386$, so no direction achieves the disk's measure of 2. He also proved the positive result that every monic polynomial has some projection $\\le 3.3$. The exact value of the **Pommerenke constant** $\\mathcal{P} = \\sup_f \\inf_u \\mu(\\pi_u(L_f)) \\in [2.386, 3.3]$ remains unknown.",
@@ -251,7 +251,7 @@
       "Complex"
     ],
     "namespace": "Erdos1043",
-    "lineCount": 280,
+    "lineCount": 288,
     "axiomCount": 8,
     "theoremCount": 12,
     "definitionCount": 15

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 277,
     "erdosUrl": "https://erdosproblems.com/277",
     "erdosProblemStatus": "solved",
@@ -60,8 +60,8 @@
       "IsHighlyComposite, IsSuperabundant: related concepts"
     ],
     "axiomCount": 6,
-    "lineCount": 296,
-    "assumptions": "6 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "lineCount": 297,
+    "assumptions": "6 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Covering systems of congruences were introduced by Erdős in 1950 in his proof that there exist odd integers not representable as a prime plus a power of 2. The concept became central to his research program in combinatorial number theory. In the 1970s, Erdős formulated Problem #277 as part of a cluster of questions (#273-#279) exploring the interplay between covering systems and number-theoretic properties.\n\nThe problem connects two classical threads: the sum of divisors function $\\sigma(n) = \\sum_{d \\mid n} d$, studied since Euler, and the combinatorics of congruence coverings. Gronwall (1913) proved $\\limsup \\sigma(n)/(n \\ln\\ln n) = e^\\gamma$, showing highly abundant numbers exist at every threshold. The question is whether such numbers can simultaneously resist being covered.\n\nJ.A. Haight resolved the problem in 1979 ('Covering systems of congruences, a negative result', Mathematika 26, 53-61). His constructive proof builds $n$ as a product of carefully chosen large primes, ensuring high abundancy while structurally preventing any covering system from using only divisors of $n$ as moduli. The key insight exploits the reciprocal sum constraint: a covering system with distinct moduli $m_1, \\ldots, m_k$ requires $\\sum 1/m_i \\geq 1$, but Haight's numbers have divisors too sparse to satisfy this.\n\nThe result connects to Ramanujan's highly composite numbers (1915), Alaoglu and Erdős's superabundant numbers (1944), and later work by Hough (2015) resolving Erdős's minimum modulus conjecture for covering systems with distinct moduli.",
@@ -274,7 +274,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos277",
-    "lineCount": 296,
+    "lineCount": 297,
     "axiomCount": 6,
     "theoremCount": 11,
     "definitionCount": 22


### PR DESCRIPTION
## Fix

Update stale meta.json sorry counts and line counts after research PR #7469 proved sorries in Erdos1043 and Erdos277.

## Evidence

**erdos-1043**:
- **Before**: sorries=8, lineCount=280
- **After**: sorries=7, lineCount=288 (verified via `grep -c sorry` and `wc -l`)

**erdos-277**:
- **Before**: sorries=2, lineCount=296
- **After**: sorries=1, lineCount=297 (verified via `grep -c sorry` and `wc -l`)

---
Automated fix by lean-mechanic agent.