### PR TITLE
fix(audit): correct stale lineCount in 5 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-11/meta.json
+++ b/src/data/proofs/erdos-11/meta.json
@@ -46,7 +46,7 @@
       "Axiomatization of computational verification bounds"
     ],
     "axiomCount": 4,
-    "lineCount": 117,
+    "lineCount": 127,
     "assumptions": "4 axioms: granville_soundararajan, hercher_verification, odlyzko_verification, erdos_almost_all. Wieferich prime facts (1093, 3511) now proved by native_decide."
   },
   "overview": {

--- a/src/data/proofs/erdos-151/meta.json
+++ b/src/data/proofs/erdos-151/meta.json
@@ -59,7 +59,7 @@
         "relationship": "Both involve graph coloring/independence structure; the four-color theorem guarantees large independent sets in planar graphs"
       }
     ],
-    "lineCount": 203,
+    "lineCount": 180,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -135,7 +135,7 @@
     ],
     "opens": [],
     "namespace": "Erdos151",
-    "lineCount": 203,
+    "lineCount": 180,
     "axiomCount": 16,
     "theoremCount": 8,
     "definitionCount": 2

--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -61,7 +61,7 @@
       "Main conjecture as disjunction: all (m,m+1) valid or cutoff exists"
     ],
     "axiomCount": 8,
-    "lineCount": 309,
+    "lineCount": 274,
     "assumptions": "8 axioms: erdos_348_characterization, erdos_348_main_problem (open problem), vanDoorn_theorem, complete_bounded_gaps (deep results), fib_complete (Zeckendorf), fib_1_robust (Fibonacci resilience), fib_not_2_robust (Fibonacci fragility), complete_iff_repr (requires Fintype machinery). powersOf2_complete and powersOf2_not_1_robust are now FULLY PROVED.",
     "mathlib_version": "4.26.0"
   },
@@ -174,7 +174,7 @@
     ],
     "opens": [],
     "namespace": "Erdos348",
-    "lineCount": 309,
+    "lineCount": 274,
     "axiomCount": 8,
     "theoremCount": 6,
     "definitionCount": 14

--- a/src/data/proofs/erdos-649/meta.json
+++ b/src/data/proofs/erdos-649/meta.json
@@ -51,7 +51,7 @@
       "Positive examples: (2,3) and (3,2) work"
     ],
     "axiomCount": 6,
-    "lineCount": 345,
+    "lineCount": 364,
     "assumptions": "6 axioms: gpf_mul, gpf_eq_two_iff, consecutive_gpf_divides, tong_theorem, no_solution_19_2, mahler_growth. P(n) function and 5 properties now proved from Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -163,7 +163,7 @@
       "Finset"
     ],
     "namespace": "Erdos649",
-    "lineCount": 345,
+    "lineCount": 364,
     "axiomCount": 6,
     "theoremCount": 14,
     "definitionCount": 1

--- a/src/data/proofs/erdos-892/meta.json
+++ b/src/data/proofs/erdos-892/meta.json
@@ -59,7 +59,7 @@
       "Fully proved erdos_1935_necessary: sum splitting at threshold N₀, head bounded by finite sum, tail bounded via reciprocal_log_comparison and primitive convergence axiom"
     ],
     "axiomCount": 3,
-    "lineCount": 290,
+    "lineCount": 282,
     "assumptions": "3 axioms: ess_1967_necessary, primitive_counting_bound, primitive_reciprocal_log_convergent. All theorem sorries eliminated. See Lean source.",
     "mathlib_version": "4.26.0"
   },
@@ -181,7 +181,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 290,
+    "lineCount": 282,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 6


### PR DESCRIPTION
## Fix

Update stale lineCount values in meta.json to match actual Lean file line counts.

## Evidence

| Proof | Before | After | Source |
|-------|--------|-------|--------|
| erdos-348 | 309 | 274 | `wc -l Proofs/Erdos348Problem.lean` |
| erdos-151 | 203 | 180 | `wc -l Proofs/Erdos151Problem.lean` |
| erdos-649 | 345 | 364 | `wc -l Proofs/Erdos649Problem.lean` |
| erdos-11 | 117 | 127 | `wc -l Proofs/Erdos11Problem.lean` |
| erdos-892 | 290 | 282 | `wc -l Proofs/Erdos892Problem.lean` |

---
Automated fix by lean-mechanic agent.