### PR TITLE
fix(audit): correct erdos-1021 axiomCount 7→4, sorries 4→3

### DIFF
--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -17,7 +17,7 @@
       "bipartite-graphs"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 1021,
     "erdosUrl": "https://erdosproblems.com/1021",
     "erdosProblemStatus": "open",
@@ -25,9 +25,9 @@
       "erdos-572",
       "erdos-926"
     ],
-    "axiomCount": 7,
-    "lineCount": 286,
-    "assumptions": "7 axioms: G3_is_C6, erdos_simonovits_limit, weak_conjecture_open, C6_extremal_bound, Gk_from_Hk, kovari_sos_turan, conjecturedGap. 4 sorries remain.",
+    "axiomCount": 4,
+    "lineCount": 260,
+    "assumptions": "4 axioms: G3_is_C6, erdos_simonovits_limit, C6_extremal_bound, kovari_sos_turan. 3 sorries remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -252,9 +252,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos1021",
-    "lineCount": 286,
-    "axiomCount": 7,
-    "theoremCount": 6,
+    "lineCount": 260,
+    "axiomCount": 4,
+    "theoremCount": 5,
     "definitionCount": 17
   }
 }


### PR DESCRIPTION
## Summary

- **Fix axiom count: 7 → 4** (3 listed axioms don't exist in Lean source)
- Fix sorry count: 4 → 3
- Fix lineCount: 286 → 260
- Fix theoremCount: 6 → 5
- Update assumptions text to list only the 4 actual axioms

## Evidence

**meta.json claimed**: 7 axioms (G3_is_C6, erdos_simonovits_limit, weak_conjecture_open, C6_extremal_bound, Gk_from_Hk, kovari_sos_turan, conjecturedGap)
**Lean source has**: 4 axioms (G3_is_C6, erdos_simonovits_limit, C6_extremal_bound, kovari_sos_turan)

The 3 nonexistent axioms (weak_conjecture_open, Gk_from_Hk, conjecturedGap) were likely removed in a prior refactor but meta.json was never updated.

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] `grep -c '^axiom ' proofs/Proofs/Erdos1021Problem.lean` → 4
- [ ] `grep -c 'sorry' proofs/Proofs/Erdos1021Problem.lean` → 3

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)