### PR TITLE
fix(audit): correct erdos-738 sorries 1→0, lineCount 329→420

### DIFF
--- a/src/data/proofs/erdos-738/meta.json
+++ b/src/data/proofs/erdos-738/meta.json
@@ -16,7 +16,7 @@
       "induced-subgraphs"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 738,
     "erdosUrl": "https://erdosproblems.com/738",
     "erdosProblemStatus": "open",
@@ -47,7 +47,7 @@
       "Added pathTree and starTree constructors with tree property obligations"
     ],
     "axiomCount": 2,
-    "lineCount": 329,
+    "lineCount": 420,
     "assumptions": [
       "gyarfas_conjecture: The main open conjecture — every triangle-free graph with χ(G)=∞ contains every finite tree as an induced subgraph",
       "gyarfas_finite_version: Finite quantitative version with explicit chromatic threshold N(T) for each tree (equivalent to main conjecture via compactness)"
@@ -103,29 +103,29 @@
       "id": "constructions",
       "title": "Graph Constructions and Properties",
       "startLine": 63,
-      "endLine": 139,
-      "summary": "Defines `pathGraph` and `starGraph` with proved triangle-freeness. States `pathGraph_isTree` and `starGraph_isTree` (sorry'd — Aristotle candidates). Constructs `pathTree` and `starTree` as `FiniteTree` instances.",
-      "mathContext": "Concrete constructions: $P_n$ (path on $n$ vertices) and $K_{1,n}$ (star with center $0$). Tree properties stated but not yet formally proved."
+      "endLine": 303,
+      "summary": "Defines `pathGraph` and `starGraph` with proved triangle-freeness and tree properties. Proves `pathGraph_isTree` and `starGraph_isTree` with full acyclicity proofs. Constructs `pathTree` and `starTree` as `FiniteTree` instances.",
+      "mathContext": "Concrete constructions: $P_n$ (path on $n$ vertices) and $K_{1,n}$ (star with center $0$). Tree properties fully proved via walk analysis."
     },
     {
       "id": "conjecture",
       "title": "Main Conjecture and Partial Results",
-      "startLine": 140,
-      "endLine": 195,
+      "startLine": 305,
+      "endLine": 377,
       "summary": "Axiomatizes `gyarfas_conjecture` over actual trees. Derives paths and stars results. Defines `HasRadius` and `IsCaterpillar` predicates. States Kierstead-Penrice (radius ≤ 2) and Scott (caterpillars) as properly constrained partial results.",
       "mathContext": "$\\forall G$ triangle-free with $\\chi(G) = \\infty$, $\\forall T \\in \\text{Tree}(n)$: $G \\supseteq_{\\text{ind}} T$. Partial results for radius-2 trees and caterpillars."
     },
     {
       "id": "structural",
       "title": "Structural Observations and Reductions",
-      "startLine": 196,
-      "endLine": 244,
+      "startLine": 378,
+      "endLine": 420,
       "summary": "Proves `triangle_free_large_chrom_local_tree`. Axiomatizes `gyarfas_finite_version`. States `finite_implies_infinite_version` (finite→infinite via De Bruijn-Erdős compactness, currently using axiom).",
       "mathContext": "Finite version: $\\forall T$, $\\exists N(T)$ such that $\\chi(G) > N(T) \\implies G \\supseteq_{\\text{ind}} T$."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #738 (Gyárfás conjecture) is formalized with FiniteTree enforcing actual tree structure via Mathlib's IsTree. Tree-class predicates (HasRadius, IsCaterpillar) make partial results genuinely weaker than the full conjecture. 1 sorry remains for a tree property proof (Aristotle candidate). 2 axioms: the main conjecture and its finite quantitative version.",
+    "summary": "Erdős Problem #738 (Gyárfás conjecture) is formalized with FiniteTree enforcing actual tree structure via Mathlib's IsTree. Tree-class predicates (HasRadius, IsCaterpillar) make partial results genuinely weaker than the full conjecture. All tree properties (pathGraph_isTree, starGraph_isTree) are fully proved. 0 sorries remain. 2 axioms: the main conjecture and its finite quantitative version.",
     "implications": "A resolution would advance the theory of $\\chi$-bounded graph classes, establishing that triangle-free graphs with unbounded chromatic number are 'structurally rich' enough to contain all finite trees. This would extend the classical Ramsey-theoretic understanding of graph coloring to induced subgraph containment, with applications to graph decomposition and structural graph theory.",
     "openQuestions": [
       "Does every triangle-free graph with $\\chi(G) = \\infty$ contain every finite tree as an induced subgraph?",
@@ -164,9 +164,9 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 329,
+    "lineCount": 420,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 11
   },
   "references": [


### PR DESCRIPTION
## Summary

- **Fix sorry count: 1 → 0** (tree property proofs completed)
- Fix lineCount: 329 → 420 (file grew with full acyclicity proofs)
- Fix theoremCount: 12 → 14 (new private lemmas for tree proofs)
- Update section line ranges and stale descriptions
- Update conclusion to reflect 0 remaining sorries

## Evidence

**meta.json claimed**: 1 sorry (tree property proof)
**Lean source shows**: 0 sorries — `pathGraph_isTree` and `starGraph_isTree` both have complete proofs with full acyclicity arguments

The tree property proofs added ~91 lines of new proof content (4 supporting lemmas + 2 main theorems).

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] `grep -c 'sorry' proofs/Proofs/Erdos738Problem.lean` → 0

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)