### PR TITLE
fix(audit): correct stale lineCount in 3 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-1129/meta.json
+++ b/src/data/proofs/erdos-1129/meta.json
@@ -67,7 +67,7 @@
       "erdos_1129_summary theorem: complete summary"
     ],
     "axiomCount": 5,
-    "lineCount": 494,
+    "lineCount": 454,
     "assumptions": "9 axiom(s) encoding deep results (Faber, Erdős bounds, Kilgore-Cheney, Brutman). All previously sorry theorems are now fully proved."
   },
   "overview": {
@@ -277,7 +277,7 @@
       "Real"
     ],
     "namespace": "Erdos1129",
-    "lineCount": 494,
+    "lineCount": 454,
     "axiomCount": 5,
     "theoremCount": 6,
     "definitionCount": 10

--- a/src/data/proofs/erdos-1172/meta.json
+++ b/src/data/proofs/erdos-1172/meta.json
@@ -66,7 +66,7 @@
       "omega2_lt_omega3"
     ],
     "axiomCount": 5,
-    "lineCount": 241,
+    "lineCount": 227,
     "assumptions": "8 axioms encoding mathematical hypotheses. See the Lean source for details."
   },
   "overview": {
@@ -202,7 +202,7 @@
       "Cardinal"
     ],
     "namespace": "Erdos1172",
-    "lineCount": 241,
+    "lineCount": 227,
     "axiomCount": 5,
     "theoremCount": 16,
     "definitionCount": 12

--- a/src/data/proofs/erdos-345/meta.json
+++ b/src/data/proofs/erdos-345/meta.json
@@ -52,7 +52,7 @@
       "threshold_mono_small axiom"
     ],
     "axiomCount": 5,
-    "lineCount": 110,
+    "lineCount": 152,
     "assumptions": "9 axioms: threshold (function), threshold_spec, threshold_minimal, threshold_powerSeq_1, threshold_squares, threshold_cubes, threshold_fourth, threshold_fifth, powerSeq_complete. 2 proved: powerSeq_1_complete, threshold_mono_small."
   },
   "overview": {
@@ -176,7 +176,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 110,
+    "lineCount": 152,
     "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 4


### PR DESCRIPTION
## Fix

Update stale lineCount values in meta.json to match actual Lean file line counts.

## Evidence

| Proof | Before | After | Source |
|-------|--------|-------|--------|
| erdos-345 | 110 | 152 | `wc -l Proofs/Erdos345Problem.lean` |
| erdos-1129 | 494 | 454 | `wc -l Proofs/Erdos1129Problem.lean` |
| erdos-1172 | 241 | 227 | `wc -l Proofs/Erdos1172Problem.lean` |

---
Automated fix by lean-mechanic agent.