### PR TITLE
fix(audit): correct stale lineCount in 4 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-1054-oq-01/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01/meta.json
@@ -60,7 +60,7 @@
       "sigma_ratio_2a_3b_bound: σ(2^a·3^b) ≤ 3·2^a·3^b"
     ],
     "axiomCount": 2,
-    "lineCount": 352,
+    "lineCount": 521,
     "assumptions": "2 axiom(s): erdos_1054_almost_all (open conjecture), tao_counterexample_1054 (Tao's result). All theorems fully proved."
   },
   "overview": {
@@ -197,7 +197,7 @@
       "Filter"
     ],
     "namespace": "Erdos1054AlmostAll",
-    "lineCount": 352,
+    "lineCount": 521,
     "axiomCount": 2,
     "theoremCount": 24,
     "definitionCount": 4

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -64,7 +64,7 @@
     ],
     "dateAdded": "2026-03-06",
     "leanFile": {
-      "lineCount": 710,
+      "lineCount": 437,
       "structures": 2,
       "axioms": 2,
       "theorems": 34,
@@ -83,7 +83,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 710,
+    "lineCount": 437,
     "assumptions": "2 axioms: ehrhart_is_polynomial (Ehrhart counting function is polynomial), ehrhart_macdonald_reciprocity (interior count via sign-change).",
     "mathlib_version": "4.26.0"
   },
@@ -243,7 +243,7 @@
     ],
     "opens": [],
     "namespace": "EhrhartPolynomial",
-    "lineCount": 710,
+    "lineCount": 437,
     "axiomCount": 2,
     "theoremCount": 45,
     "definitionCount": 21

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -55,7 +55,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 8,
-    "lineCount": 463,
+    "lineCount": 462,
     "assumptions": "8 axioms: primeNumberTheorem (PNT itself), li_equiv_approx_axiom (Li ~ x/ln x), nth_prime_asymptotic_axiom, mertens_sum_primes_axiom, prime_gaps_sublinear_axiom, RiemannHypothesis_statement, pnt_rh_error_axiom, chebyshev_bounds_axiom. Eliminated 5 axioms by proving from Mathlib: ratio_iff_equiv (via isEquivalent_iff_tendsto_one), equiv_iff_error (definitional), li_iff_equiv (transitivity of ~), prime_counting_tendsto_top (Nat.tendsto_primeCounting), prime_density_tends_to_zero (from PNT).",
     "mathlib_version": "4.26.0",
     "prerequisites": [
@@ -135,7 +135,7 @@
       "id": "elementary-bounds",
       "title": "Elementary Bounds",
       "startLine": 353,
-      "endLine": 463,
+      "endLine": 462,
       "summary": "Chebyshev's pre-PNT bounds (0.92 < π·ln x/x < 1.11), infinitude of primes, and Euler product connection.",
       "mathContext": "Chebyshev (1852): \\(0.92 < \\pi(x)\\ln x/x < 1.11\\) for large \\(x\\). Euler product: \\(\\zeta(s) = \\prod_p (1-p^{-s})^{-1}\\) for \\(\\operatorname{Re}(s)>1\\)"
     }
@@ -320,7 +320,7 @@
       "BigOperators"
     ],
     "namespace": "PrimeNumberTheorem",
-    "lineCount": 463,
+    "lineCount": 462,
     "axiomCount": 8,
     "theoremCount": 15,
     "definitionCount": 9,

--- a/src/data/proofs/wolstenholme-theorem-oq-02/meta.json
+++ b/src/data/proofs/wolstenholme-theorem-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 3,
     "theoremCount": 30,
     "defCount": 5,
-    "lineCount": 262,
+    "lineCount": 144,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",
@@ -166,7 +166,7 @@
       "Nat"
     ],
     "namespace": "WolstenholmePrimeMod4",
-    "lineCount": 262,
+    "lineCount": 144,
     "axiomCount": 3,
     "theoremCount": 30,
     "definitionCount": 5


### PR DESCRIPTION
## Fix

Correct stale `lineCount` values in 4 gallery proof meta.json files where the Lean source files changed but metadata wasn't updated.

## Evidence

| Proof | Before | After | Delta |
|-------|--------|-------|-------|
| erdos-1054-oq-01 | 352 | 521 | +169 |
| picks-theorem-oq-03 | 710 | 437 | -273 |
| wolstenholme-theorem-oq-02 | 262 | 144 | -118 |
| prime-number-theorem | 463 | 462 | -1 |

All corrected values verified with `wc -l` against the actual Lean source files. Also fixed the `endLine` for prime-number-theorem's last section (463→462).

`pnpm build` confirms no new errors introduced (2610 pre-existing annotation warnings unchanged).

---
Automated fix by lean-mechanic agent.