### PR TITLE
fix(audit): correct stale lineCount in erdos-370

### DIFF
--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,12 +64,12 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
     "axiomCount": 2,
-    "lineCount": 280,
+    "lineCount": 284,
     "assumptions": "2 axioms (gpf_mul_le, dickman_density) and 2 sorries. gpf function and 7 properties now proved from Mathlib."
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 258,
+    "lineCount": 284,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Fix

Correct stale `lineCount` values in erdos-370 meta.json. The Lean source file (`Proofs/Erdos370Problem.lean`) has 284 lines but meta.json had two inconsistent stale values (280 in meta section, 258 in leanFile section).

## Evidence

**Before**: meta.lineCount=280, leanFile.lineCount=258
**After**: both set to 284 (verified with `wc -l proofs/Proofs/Erdos370Problem.lean`)

---
Automated fix by lean-mechanic agent.