### PR TITLE
Research: erdos-234 — prove small_gaps_exist from average_normalized_gap

### DIFF
--- a/proofs/Proofs/Erdos234Problem.lean
+++ b/proofs/Proofs/Erdos234Problem.lean
@@ -321,11 +321,6 @@ theorem gallagher_implies_conjecture (hRH : RiemannHypothesis) :
 ## Section VII: Partial Results on Gap Distribution
 -/
 
-/-- Small gaps exist: for any ε > 0, infinitely many primes have
-g_n < (1 + ε) log p_n (toward the twin prime conjecture). -/
-axiom small_gaps_exist (ε : ℝ) (hε : ε > 0) :
-    {n : ℕ | (primeGap n : ℝ) < (1 + ε) * Real.log (nthPrime n)}.Infinite
-
 /-- Large gaps exist: g_n/log n can be made arbitrarily large.
 (Rankin, Pintz, Ford–Green–Konyagin–Tao, Maynard) -/
 axiom large_gaps_exist :
@@ -334,6 +329,106 @@ axiom large_gaps_exist :
 /-- The average normalized gap tends to 1 by the Prime Number Theorem. -/
 axiom average_normalized_gap :
     Tendsto (fun N => (∑ n ∈ Finset.range N, normalizedGap n) / N) atTop (nhds 1)
+
+/-
+## Section VII': Small gaps from average gap (axiom elimination)
+
+Reduces axiom count from 4 to 3 by deriving small_gaps_exist from
+average_normalized_gap. If only finitely many n had normalizedGap n < 1+ε,
+the Cesàro average would exceed 1, contradicting average_normalized_gap.
+-/
+
+/-- The nth prime is at least n (primes form an infinite, strictly increasing subset of ℕ). -/
+private lemma nthPrime_ge (n : ℕ) : n ≤ nthPrime n := by
+  induction n with
+  | zero => exact Nat.zero_le _
+  | succ k ih =>
+    have h_infinite : (setOf Nat.Prime).Infinite := by
+      intro hf; obtain ⟨N, hN⟩ := hf.bddAbove
+      obtain ⟨p, hp, hpp⟩ := Nat.exists_infinite_primes (N + 1)
+      have := hN hpp; omega
+    have : nthPrime k < nthPrime (k + 1) :=
+      Nat.nth_strictMono h_infinite (by omega : k < k + 1)
+    omega
+
+/-- If {n | normalizedGap n < c} were finite for c > 1, the Cesàro average
+of normalizedGap would exceed 1, contradicting average_normalized_gap. -/
+private lemma infinite_normalizedGap_lt (c : ℝ) (hc : c > 1) :
+    {n : ℕ | normalizedGap n < c}.Infinite := by
+  by_contra h_fin
+  rw [Set.not_infinite] at h_fin
+  obtain ⟨M, hM⟩ := h_fin.bddAbove
+  -- For n > M: normalizedGap n ≥ c
+  have h_ge : ∀ n : ℕ, M < n → normalizedGap n ≥ c := by
+    intro n hn; by_contra hlt; push_neg at hlt
+    exact absurd (hM hlt) (by omega)
+  -- Sum lower bound: for N > M+1, ∑ normalizedGap ≥ (N-(M+1))·c
+  have h_sum : ∀ N : ℕ, M + 1 < N →
+      (∑ n ∈ Finset.range N, normalizedGap n) ≥ ↑(N - (M + 1)) * c := by
+    intro N hN
+    calc ∑ n ∈ Finset.range N, normalizedGap n
+        ≥ ∑ n ∈ Finset.Ico (M + 1) N, normalizedGap n :=
+          Finset.sum_le_sum_of_subset_of_nonneg
+            (fun x hx => Finset.mem_range.mpr ((Finset.mem_Ico.mp hx).2))
+            (fun i _ _ => normalizedGap_nonneg i)
+      _ ≥ ∑ _n ∈ Finset.Ico (M + 1) N, c :=
+          Finset.sum_le_sum fun n hn =>
+            h_ge n (by have := (Finset.mem_Ico.mp hn).1; omega)
+      _ = ↑(N - (M + 1)) * c := by
+          rw [Finset.sum_const, Finset.card_Ico, nsmul_eq_mul]
+  -- avg → 1 by average_normalized_gap, so eventually avg < (c+1)/2
+  have h_mid : (1 : ℝ) < (c + 1) / 2 := by linarith
+  have h_upper := average_normalized_gap.eventually (Iio_mem_nhds h_mid)
+  -- Pick N satisfying: avg < (c+1)/2, N > M+1, and N large enough for sum bound
+  have h_big : ∀ᶠ N in atTop, M + 1 < (N : ℕ) :=
+    eventually_atTop.mpr ⟨M + 2, fun N hN => by omega⟩
+  obtain ⟨K, hK⟩ := exists_nat_gt (2 * c * (↑M + 1) / (c - 1))
+  have h_vbig : ∀ᶠ N in atTop, K ≤ (N : ℕ) :=
+    eventually_atTop.mpr ⟨K, fun N hN => hN⟩
+  obtain ⟨N, ⟨hN_avg, hNM⟩, hNK⟩ := ((h_upper.and h_big).and h_vbig).exists
+  -- Derive contradiction: sum bound + avg bound + N size bound are incompatible
+  have hN_pos : (0 : ℝ) < ↑N := Nat.cast_pos.mpr (by omega)
+  have hS := h_sum N hNM
+  have h_avg_lt : (∑ n ∈ Finset.range N, normalizedGap n) < (c + 1) / 2 * ↑N :=
+    (div_lt_iff hN_pos).mp hN_avg
+  -- (N-(M+1))*c ≤ ∑ < (c+1)/2 * N, so (N-(M+1))*c < (c+1)/2 * N
+  have hNM_cast : (↑(N - (M + 1)) : ℝ) = ↑N - ↑(M + 1) := Nat.cast_sub (by omega)
+  rw [hNM_cast] at hS
+  -- N*(c-1) > 2c*(M+1) from the Archimedean bound
+  have hN_ge_K : (↑N : ℝ) ≥ ↑K := Nat.cast_le.mpr hNK
+  have hN_real : (↑N : ℝ) > 2 * c * (↑M + 1) / (c - 1) := lt_of_lt_of_le hK hN_ge_K
+  have hN_cleared : 2 * c * (↑M + 1) < ↑N * (c - 1) := by
+    rwa [div_lt_iff (by linarith : (c : ℝ) - 1 > 0)] at hN_real
+  -- (↑N - ↑(M+1))*c ≤ ∑ < (c+1)/2*↑N, but ↑N*(c-1) > 2c*(↑M+1) makes this impossible
+  nlinarith
+
+/-- For n ≥ 2 with normalizedGap n < c (c > 0), primeGap n < c · log(p_n),
+since log(p_n) ≥ log(n) (the nth prime is at least n). -/
+private lemma primeGap_lt_of_normalizedGap_lt (n : ℕ) (c : ℝ) (hn : n ≥ 2) (hc : c > 0)
+    (h : normalizedGap n < c) :
+    (primeGap n : ℝ) < c * Real.log (nthPrime n) := by
+  have hlog_n_pos : Real.log (↑n) > 0 :=
+    Real.log_pos (by exact_mod_cast show 1 < n by omega)
+  have hlog_ge : Real.log (↑(nthPrime n)) ≥ Real.log (↑n) :=
+    Real.log_le_log (by positivity) (Nat.cast_le.mpr (nthPrime_ge n))
+  unfold normalizedGap at h
+  simp only [show ¬(n ≤ 1) by omega, ↓reduceIte] at h
+  rw [div_lt_iff hlog_n_pos] at h
+  linarith [mul_le_mul_of_nonneg_left hlog_ge hc.le]
+
+/-- **small_gaps_exist** (previously axiom, now theorem):
+For any ε > 0, infinitely many n have g_n < (1+ε) · log(p_n).
+Derived from average_normalized_gap via Cesàro contrapositive. -/
+theorem small_gaps_exist (ε : ℝ) (hε : ε > 0) :
+    {n : ℕ | (primeGap n : ℝ) < (1 + ε) * Real.log (nthPrime n)}.Infinite := by
+  have h_inf := infinite_normalizedGap_lt (1 + ε) (by linarith)
+  -- Remove n ≤ 1 from the infinite set (they may not satisfy the log bound)
+  have h_inf2 : ({n : ℕ | normalizedGap n < 1 + ε} \ {n : ℕ | n < 2}).Infinite :=
+    h_inf.diff (Set.toFinite _)
+  apply h_inf2.mono
+  intro n hn
+  obtain ⟨hn_ng, hn_ge⟩ := Set.mem_diff.mp hn
+  exact primeGap_lt_of_normalizedGap_lt n (1 + ε) (by omega) (by linarith) hn_ng
 
 /-
 ## Section VIII: Additional Properties of Cramér's Model

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 234,
     "erdosUrl": "https://erdosproblems.com/234",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 363,
-    "assumptions": "4 axioms: gallagher_conditional (RH→exponential distribution), small_gaps_exist (GPY/Maynard-Tao), large_gaps_exist (FGKT/Maynard), average_normalized_gap (PNT). density_at_infinity was proved from average_normalized_gap via Markov's inequality.",
+    "axiomCount": 3,
+    "lineCount": 437,
+    "assumptions": "3 axioms: gallagher_conditional (RH→exponential distribution), large_gaps_exist (FGKT/Maynard), average_normalized_gap (PNT). Previously 5 axioms: density_at_infinity proved via Markov (session 2), small_gaps_exist proved via Cesàro contrapositive (session 3).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -112,8 +112,8 @@
       "title": "Partial Results on Gap Distribution",
       "startLine": 324,
       "endLine": 341,
-      "summary": "Axiomatizes: (1) small_gaps_exist (GPY/Maynard–Tao: infinitely many $g_n < (1+\\varepsilon)\\log p_n$), (2) large_gaps_exist (FGKT: unbounded $g_n/\\log n$), (3) average $g_n/\\log n \\to 1$ by PNT.",
-      "mathContext": "Axiomatizes: (1) small_gaps_exist (GPY/Maynard–Tao: infinitely many $g_n < (1+\\varepsilon)\\log p_n$), (2) large_gaps_exist (FGKT: unbounded $g_n/\\$\\log n$$), (3) average $g_n/\\$\\log n$ \\to 1$ by PNT."
+      "summary": "Axiomatizes: (1) large_gaps_exist (FGKT: unbounded $g_n/\\log n$), (2) average $g_n/\\log n \\to 1$ by PNT. Then proves small_gaps_exist from average_normalized_gap via Cesàro contrapositive argument, reducing axiom count from 4 to 3.",
+      "mathContext": "Axiomatizes: (1) large_gaps_exist (FGKT: unbounded $g_n/\\$\\log n$$), (2) average $g_n/\\$\\log n$ \\to 1$ by PNT. Then proves small_gaps_exist from average_normalized_gap via Cesàro contrapositive argument, reducing axiom count from 4 to 3."
     },
     {
       "id": "cramer-properties",
@@ -175,9 +175,9 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 363,
-    "axiomCount": 4,
-    "theoremCount": 20,
+    "lineCount": 437,
+    "axiomCount": 3,
+    "theoremCount": 21,
     "definitionCount": 8
   },
   "references": [

--- a/src/data/research/problems/erdos-234.json
+++ b/src/data/research/problems/erdos-234.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-12T16:08:36.613Z",
-    "iteration": 2,
-    "focus": "Axiom elimination via Markov inequality",
+    "iteration": 3,
+    "focus": "Axiom elimination: small_gaps_exist proved from average_normalized_gap",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,24 +29,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATED: Proved density_at_infinity from average_normalized_gap via Markov inequality. Axiom count reduced from 5 to 4. Added 3 helper lemmas and 1 theorem (117 new lines).",
+    "progressSummary": "AXIOM ELIMINATED: Proved small_gaps_exist from average_normalized_gap via Cesàro contrapositive + Markov bound. Axiom count reduced from 4 to 3. Added 4 lemmas/theorems (~90 new lines). Remaining axioms: gallagher_conditional, large_gaps_exist, average_normalized_gap — all deep published results.",
     "builtItems": [
       "finset_markov_bound: c * |{gap ≥ c}| ≤ ∑ gap (finite Markov inequality)",
       "complement_card: |{gap ≥ c}| = N - countSmallNormGaps N c",
       "gapProportion_markov: gapProportion N c ≥ 1 - ∑gap/(N*c)",
-      "theorem density_at_infinity (was axiom): proved from average_normalized_gap"
+      "theorem density_at_infinity (was axiom): proved from average_normalized_gap",
+      "nthPrime_ge: n ≤ nthPrime n via induction + Nat.nth_strictMono",
+      "infinite_normalizedGap_lt: {n | normalizedGap n < c}.Infinite for c > 1, via Cesàro contradiction",
+      "primeGap_lt_of_normalizedGap_lt: normalizedGap < c implies primeGap < c·log(p_n) for n ≥ 2",
+      "theorem small_gaps_exist: proved from average_normalized_gap (was axiom, axiom count 4 → 3)"
     ],
     "insights": [
       "density_at_infinity (f(c)→1 as c→∞) follows from average_normalized_gap via Markov inequality",
       "Markov bound: gapProportion(N,c) ≥ 1 - (avg gap)/c, so large c gives proportion near 1",
       "Choosing c₀ = 2/ε + 1 ensures (1+ε/2)/c₀ = ε/2, giving the strict bound > 1 - ε",
-      "All 4 remaining axioms (gallagher_conditional, small_gaps_exist, large_gaps_exist, average_normalized_gap) are deep published results"
+      "All 4 remaining axioms (gallagher_conditional, small_gaps_exist, large_gaps_exist, average_normalized_gap) are deep published results",
+      "small_gaps_exist can be derived from average_normalized_gap via Cesàro contrapositive: if only finitely many n have normalizedGap n < c (for c > 1), the average would exceed 1",
+      "Key helper: nthPrime n ≥ n (by induction using Nat.nth_strictMono for infinite sets)",
+      "Bridge lemma: for n ≥ 2, normalizedGap n < c implies primeGap n < c·log(p_n), since log(p_n) ≥ log(n)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Verify Lean compilation via Docker build",
-      "Consider whether any of the 4 remaining axioms can be further reduced",
-      "average_normalized_gap might be provable from PNT if Mathlib has sufficient prime counting infrastructure"
+      "Docker build verification needed (Docker was offline during this session)",
+      "Consider if large_gaps_exist could be proved from Westzynthius-type argument",
+      "average_normalized_gap might be provable from PNT if Mathlib has prime counting infrastructure",
+      "Check if any API name mismatches prevent compilation"
     ],
     "markdown": "# Erdős #234 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor every $c\\geq 0$ the density $f(c)$ of integers for which\\[\\frac{p_{n+1}-p_n}{\\log n}< c\\]exists and is a continuous function of $c$.\n\n\n\nSee also [5].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #5\n- Problem #233\n- Problem #235\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er55c\n- Er61\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
@@ -71,9 +79,9 @@
     {
       "path": "Proofs/Erdos234Problem.lean",
       "filename": "Erdos234Problem.lean",
-      "lineCount": 364,
-      "theoremCount": 17,
-      "axiomCount": 4,
+      "lineCount": 437,
+      "theoremCount": 21,
+      "axiomCount": 3,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- **Axiom elimination**: Convert `small_gaps_exist` from axiom to theorem, reducing axiom count from 4 to 3
- Proof via Cesàro contrapositive argument: if only finitely many n have normalizedGap(n) < 1+ε, the average would exceed 1, contradicting `average_normalized_gap`
- Added 4 lemmas/theorems (~90 new lines): `nthPrime_ge`, `infinite_normalizedGap_lt`, `primeGap_lt_of_normalizedGap_lt`, `small_gaps_exist`

## Mathematical Argument
1. **Cesàro bound**: If {n | normalizedGap n < c} is finite (bounded by M), then for N > M+1: ∑ normalizedGap(n) ≥ (N-M-1)·c, so avg ≥ c·(1-(M+1)/N) → c > 1
2. **Contradiction**: But `average_normalized_gap` says avg → 1 < c
3. **Log bridge**: For n ≥ 2, nthPrime n ≥ n, so log(p_n) ≥ log(n), converting normalizedGap bound to primeGap bound

## Remaining 3 axioms
- `gallagher_conditional` (Gallagher 1976, conditional on RH)
- `large_gaps_exist` (Westzynthius/FGKT/Maynard)
- `average_normalized_gap` (PNT consequence)

## Test plan
- [ ] Docker build verification (Docker was offline during session)
- [ ] Verify axiom count matches meta.json claims

🤖 Generated by researcher-8