### PR TITLE
chore: audit 8 gallery proofs — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9385,6 +9385,54 @@
       "lastAudited": "2026-03-27T20:05:33Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1014-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T15:50:20Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1151": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T15:50:20Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1162": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T15:50:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1168": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T15:50:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1178": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T15:50:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1183": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T15:50:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-20-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T15:50:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shapley-folkman": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T15:50:21Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {


### PR DESCRIPTION
## Summary
- Audited 8 previously unaudited gallery proofs: erdos-1014-oq-02, erdos-1151, erdos-1162, erdos-1168, erdos-1178, erdos-1183, hilbert-20-oq-01, shapley-folkman
- All sorry counts, axiom counts, status/badge fields verified against Lean source
- No integrity issues found — gallery is fully audited (1570/1570)

## Test plan
- [x] Verify audit-tracker.json is valid JSON
- [x] Verify `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 unaudited

🤖 Generated with [Claude Code](https://claude.com/claude-code)