### PR TITLE
fix(audit): correct stale metadata in erdos-34 and erdos-719

### DIFF
--- a/src/data/proofs/erdos-34/meta.json
+++ b/src/data/proofs/erdos-34/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos (1977); Disproved by Hegyvari (1986), Konieczny (2015)",
     "sourceUrl": "https://erdosproblems.com/34",
     "date": "1977",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos34Problem.lean",
     "tags": [
       "erdos",
@@ -15,8 +15,8 @@
       "permutations",
       "disproved"
     ],
-    "badge": "axiom",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "erdosNumber": 34,
     "erdosUrl": "https://erdosproblems.com/34",
     "erdosProblemStatus": "disproved",
@@ -55,8 +55,8 @@
       "Basic combinatorics and counting arguments",
       "Cardinality of finite sets"
     ],
-    "lineCount": 204,
-    "assumptions": "8 axiom(s) and 1 sorry(s)."
+    "lineCount": 209,
+    "assumptions": "0 axioms, 0 sorries. All stated theorems fully proved."
   },
   "overview": {
     "historicalContext": "For a permutation π of {1,...,n}, the consecutive sums ∑_{i=u}^{v} π(i) range over O(n²) possible values (there are n(n+1)/2 intervals [u,v]). The quantity S(π) — the number of distinct values among these sums — measures how 'spread out' the sums are.\n\nErdős observed that the identity permutation has S(id) = o(n²) because its consecutive sums form arithmetic progressions with many coincidences. He conjectured this holds for ALL permutations — one of his rare spectacularly wrong conjectures.\n\nHegyvári (1986) gave the first counterexample, constructing a permutation with S(π) ≥ n²/18. Konieczny (2015) showed the conjecture is 'extremely false': there exist permutations achieving S(π) ≥ n²/4, which is asymptotically optimal since S(π) ≤ n²/2 trivially. The maximum f(n) = max_π S(π) satisfies 0.286n² ≤ f(n) ≤ 0.446n², with the lower bound coming from random permutations: for a random π, S(π) ∼ (1 + e⁻²)/4 · n² ≈ 0.284n². The connection to random permutations suggests that most permutations are far from Erdős's conjecture.",
@@ -141,10 +141,10 @@
       "BigOperators"
     ],
     "namespace": "Erdos34",
-    "lineCount": 204,
+    "lineCount": 209,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -17,7 +17,7 @@
       "decomposition"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 719,
     "erdosUrl": "https://erdosproblems.com/719",
     "erdosProblemStatus": "open",
@@ -77,8 +77,8 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 371,
-    "assumptions": "2 axioms and 1 sorry (decomp_pieces_le_edges at line 156)."
+    "lineCount": 462,
+    "assumptions": "2 axioms (erdos_sauer_conjecture, turan_graph) and 3 sorries (hevens/hodds counting at lines 422/424, turanHypergraph_graph_le at line 456)."
   },
   "overview": {
     "historicalContext": "Turán's theorem (1941) determines the maximum number of edges in a triangle-free graph on $n$ vertices: $\\text{ex}_2(n; K_3) = \\lfloor n^2/4 \\rfloor$, achieved by the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. This foundational result of extremal graph theory was extended by the Erdős-Stone-Simonovits theorem (1966) to determine $\\text{ex}_2(n; H)$ for all non-bipartite graphs $H$.\n\nFor $r$-uniform hypergraphs with $r \\ge 3$, the Turán problem becomes dramatically harder. Even $\\text{ex}_3(n; K_4^3)$ — the 3-uniform analogue of the triangle Turán number — is a central open problem. Turán conjectured the extremal hypergraph is a specific 3-partite construction with $(5/9 + o(1))\\binom{n}{3}$ edges, but this remains unproven.\n\nErdős and Sauer (1981) posed Problem #719: can every $r$-uniform hypergraph on $n$ vertices be decomposed into at most $\\text{ex}_r(n; K_{r+1}^r)$ edge-disjoint pieces, where each piece is either a single $r$-edge ($K_r^r$) or a complete $(r+1)$-clique ($K_{r+1}^r$)? The conjecture connects two deep areas: Turán-type extremal theory (bounding edge counts) and decomposition theory (partitioning edge sets into canonical structures).\n\nFor $r = 2$, the conjecture asks whether every graph on $n$ vertices can be written as at most $\\lfloor n^2/4 \\rfloor$ edges and triangles — already non-trivial. For $r \\ge 3$, the conjecture is doubly open: the decomposition bound depends on a Turán number that is itself unknown. The problem remains OPEN.",
@@ -162,10 +162,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 371,
+    "lineCount": 462,
     "axiomCount": 2,
-    "theoremCount": 5,
-    "definitionCount": 7
+    "theoremCount": 20,
+    "definitionCount": 8
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

- **erdos-34**: sorry count 1→0, status axiomatized→verified, badge axiom→original, lineCount 204→209, definitionCount 8→9. After recent research PR, all theorems are fully proved with 0 sorries and 0 axioms.
- **erdos-719**: sorry count 2→3, lineCount 371→462, theoremCount 5→20, definitionCount 7→8. File grew with new Turán theorem infrastructure (bipartite construction, clique-free proof, edge counting).

## Evidence

**erdos-34**: `grep -c sorry Erdos34Problem.lean` = 0, `grep -c '^axiom ' Erdos34Problem.lean` = 0, `wc -l` = 209
**erdos-719**: `grep -c sorry Erdos719Problem.lean` = 3 (lines 422, 424, 456), `grep -c '^axiom ' Erdos719Problem.lean` = 2, `wc -l` = 462

## Test plan

- [ ] `pnpm build` passes with corrected metadata
- [ ] Audit tracker shows both proofs clean after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)