### PR TITLE
chore: audit tracker — erdos-34 and erdos-719 marked issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4139,9 +4139,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-34": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-28T16:25:34Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-340-greedy-sidon": {
@@ -6557,8 +6557,8 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-719": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T18:40:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-03-28T16:25:35Z",
       "result": "issues-fixed",
       "issues": [
         "PR #6447: sorries 2\u21921, lineCount 175\u2192196"


### PR DESCRIPTION
## Summary

- Marks erdos-34 and erdos-719 as `issues-fixed` in the audit tracker
- Metadata fixes in rjwalters/lean-genius#7515

🤖 Generated with [Claude Code](https://claude.com/claude-code)