### PR TITLE
Research: erdos-839 — eliminate liminf_finite axiom (5→4A)

### DIFF
--- a/proofs/Proofs/Erdos839Problem.lean
+++ b/proofs/Proofs/Erdos839Problem.lean
@@ -121,12 +121,6 @@ theorem valid_seq_linear_growth (a : ValidSeq) :
 
 -- ## Known Results (axioms for deep constructions)
 
-/-- lim inf(a_n/n) can be finite: there exist valid sequences where
-    a_n/n stays bounded infinitely often. -/
-axiom liminf_finite :
-  ∃ a : ValidSeq, ∃ C : ℝ, 0 < C ∧
-    ∀ N : ℕ, ∃ n : ℕ, N ≤ n ∧ (a.val n : ℝ) / (n + 1 : ℝ) ≤ C
-
 /-- The reciprocal sum can grow at least as fast as c * log log x. -/
 axiom reciprocal_sum_lower :
   ∃ a : ValidSeq, ∃ c : ℝ, 0 < c ∧
@@ -154,6 +148,115 @@ theorem freud_counterexample :
     ∃ a : ValidSeq, (1 : ℝ) / 2 < upperDensity a := by
   obtain ⟨a, ha⟩ := freud_density
   exact ⟨a, by rw [ha]; norm_num⟩
+
+-- ## Deriving liminf_finite from freud_density
+--
+-- Key insight: positive upper density forces liminf(a_n/n) < ∞.
+-- If upperDensity = 19/36, then frequently count(N)/N > 1/4,
+-- so frequently the N/4-th term is ≤ N, giving a(n)/(n+1) < 4.
+
+section LiminfFinite
+
+private noncomputable def countRatio (a : ValidSeq) (N : ℕ) : ℝ :=
+  ((Finset.range N).filter (fun n => a.val n ≤ N)).card / (N : ℝ)
+
+private lemma countRatio_nonneg (a : ValidSeq) (N : ℕ) : 0 ≤ countRatio a N :=
+  div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+
+/-- The counting ratio is cobounded under ≤ (any eventual upper bound is ≥ 0,
+    since the ratio is always ≥ 0). Follows the Erdos929 pattern. -/
+private lemma countRatio_isCoboundedUnder (a : ValidSeq) :
+    Filter.IsCoboundedUnder (· ≤ ·) Filter.atTop (countRatio a) := by
+  refine ⟨0, fun c hc => ?_⟩
+  by_contra hlt; push_neg at hlt
+  simp only [Filter.eventually_map] at hc
+  obtain ⟨N, hN⟩ := hc.exists
+  linarith [countRatio_nonneg a N]
+
+/-- If c < limsup f, then frequently c < f. Proved by contrapositive:
+    if eventually f ≤ c, then limsup ≤ c. -/
+private lemma frequently_lt_of_lt_limsup (a : ValidSeq) (c : ℝ)
+    (hlt : c < Filter.limsup (countRatio a) Filter.atTop) :
+    ∃ᶠ N in Filter.atTop, c < countRatio a N := by
+  by_contra h
+  rw [Filter.not_frequently] at h
+  have h_ev : ∀ᶠ N in Filter.atTop, countRatio a N ≤ c :=
+    h.mono fun _ hn => le_of_not_lt hn
+  linarith [Filter.limsup_le_of_le (countRatio_isCoboundedUnder a) h_ev]
+
+/-- For a strictly increasing sequence, if the counting function at N
+    has card ≥ k+1, then a(k) ≤ N.
+    Proof: by contradiction. If a(k) > N, then all filter elements are < k
+    (by monotonicity), so card ≤ k, contradicting card ≥ k+1. -/
+lemma term_le_of_count_gt (a : ValidSeq) (N k : ℕ)
+    (hcard : k + 1 ≤ ((Finset.range N).filter (fun n => a.val n ≤ N)).card) :
+    a.val k ≤ N := by
+  by_contra h
+  push_neg at h
+  have h_bound : ∀ m ∈ (Finset.range N).filter (fun n => a.val n ≤ N), m < k := by
+    intro m hm
+    simp only [Finset.mem_filter, Finset.mem_range] at hm
+    by_contra h_not
+    push_neg at h_not
+    rcases eq_or_lt_of_le h_not with rfl | hlt
+    · omega
+    · have := a.property.2.1 k m hlt; omega
+  have h_sub : (Finset.range N).filter (fun n => a.val n ≤ N) ⊆ Finset.range k :=
+    fun m hm => Finset.mem_range.mpr (h_bound m hm)
+  have : ((Finset.range N).filter (fun n => a.val n ≤ N)).card ≤ k :=
+    (Finset.card_le_card h_sub).trans (Finset.card_range k).le
+  omega
+
+/-- lim inf(a_n/n) can be finite: proved from freud_density.
+    Since Freud's sequence has upper density 19/36 > 0, the counting
+    function is frequently large, forcing a(n)/(n+1) < 4 infinitely often. -/
+theorem liminf_finite :
+    ∃ a : ValidSeq, ∃ C : ℝ, 0 < C ∧
+      ∀ N : ℕ, ∃ n : ℕ, N ≤ n ∧ (a.val n : ℝ) / (n + 1 : ℝ) ≤ C := by
+  obtain ⟨a, ha⟩ := freud_density
+  refine ⟨a, 4, by norm_num, fun M => ?_⟩
+  -- upperDensity a = 19/36, and countRatio is the same function
+  have h_eq : Filter.limsup (countRatio a) Filter.atTop = upperDensity a := rfl
+  -- 1/4 < 19/36 = upperDensity a
+  have hlt : (1 : ℝ) / 4 < Filter.limsup (countRatio a) Filter.atTop := by
+    rw [h_eq, ha]; norm_num
+  -- Frequently countRatio > 1/4
+  have hfreq := frequently_lt_of_lt_limsup a (1 / 4) hlt
+  rw [Filter.frequently_atTop] at hfreq
+  -- Get N ≥ 4*(M+1) with countRatio > 1/4
+  obtain ⟨N, hNM, hcount_ratio⟩ := hfreq (4 * (M + 1))
+  -- N ≥ 4*(M+1) ≥ 4 > 0
+  have hN_pos : 0 < N := by omega
+  -- Extract N < 4 * count from 1/4 < count/N
+  set cnt := ((Finset.range N).filter (fun n => a.val n ≤ N)).card with hcnt_def
+  have h_Nlt4cnt : (N : ℝ) < 4 * (cnt : ℝ) := by
+    unfold countRatio at hcount_ratio
+    rw [div_lt_div_iff (by norm_num : (0 : ℝ) < 4)
+        (by exact_mod_cast hN_pos : (0 : ℝ) < (N : ℝ))] at hcount_ratio
+    linarith
+  -- cnt ≥ M + 2 (so cnt - 1 ≥ M + 1 > M)
+  have h_cnt_large : M + 2 ≤ cnt := by
+    have h1 : (N : ℝ) ≥ 4 * ((M : ℝ) + 1) := by exact_mod_cast hNM
+    have h2 : (M + 1 : ℝ) < (cnt : ℝ) := by linarith
+    have h3 : M + 1 < cnt := by exact_mod_cast h2
+    omega
+  -- Set n = cnt - 1
+  refine ⟨cnt - 1, by omega, ?_⟩
+  -- a(cnt-1) ≤ N from the counting argument
+  have h_bound : a.val (cnt - 1) ≤ N :=
+    term_le_of_count_gt a N (cnt - 1) (by omega)
+  -- cnt - 1 + 1 = cnt (since cnt ≥ 2)
+  have h_cast_eq : ((cnt - 1 : ℕ) : ℝ) + 1 = (cnt : ℝ) := by
+    have := Nat.sub_add_cancel (show 1 ≤ cnt by omega)
+    exact_mod_cast this
+  -- a(cnt-1)/(cnt-1+1) = a(cnt-1)/cnt ≤ N/cnt < 4
+  rw [h_cast_eq]
+  have h_cnt_pos : (0 : ℝ) < (cnt : ℝ) := by exact_mod_cast (show 0 < cnt by omega)
+  rw [div_le_iff h_cnt_pos]
+  calc (a.val (cnt - 1) : ℝ) ≤ (N : ℝ) := by exact_mod_cast h_bound
+    _ ≤ 4 * (cnt : ℝ) := by linarith
+
+end LiminfFinite
 
 -- ## Main Open Questions
 

--- a/src/data/proofs/erdos-839/meta.json
+++ b/src/data/proofs/erdos-839/meta.json
@@ -51,13 +51,14 @@
       "Question1: lim sup(a_n/n) = ∞ for all valid sequences",
       "Question2: logarithmic density vanishes",
       "upperDensity: via Filter.limsup",
-      "7 fully proved structural theorems (no sorry/axiom)",
-      "satisfiesConditionR / F_r: generalization to r-products"
+      "12 fully proved theorems/lemmas (no sorry/axiom)",
+      "liminf_finite: derived from freud_density via counting argument",
+      "term_le_of_count_gt: counting function bounds sequence terms"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 5,
-    "lineCount": 164,
-    "assumptions": "5 axioms: liminf_finite, reciprocal_sum_lower, freud_density, erdos_839_question1, erdos_839_question2. freud_counterexample is now a theorem (proved from freud_density since 19/36 > 1/2)."
+    "axiomCount": 4,
+    "lineCount": 267,
+    "assumptions": "4 axioms: reciprocal_sum_lower, freud_density, erdos_839_question1, erdos_839_question2. liminf_finite is now a theorem (proved from freud_density via counting argument: positive density forces bounded ratio). freud_counterexample proved from freud_density since 19/36 > 1/2."
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's work on additive restrictions in integer sequences, closely related to his broader program on sum-free sets and primitive sets. A 'primitive' set has no element dividing another; here the condition is additive: no term equals the sum of a contiguous block of earlier terms. Erdős posed two questions: whether such sequences must grow super-linearly ($\\limsup a_n/n = \\infty$) and whether their logarithmic density must vanish. He also conjectured the upper density is at most $1/2$, but Freud disproved this by constructing a valid sequence with upper density $19/36 \\approx 0.528$, exploiting the fact that only contiguous block sums (not arbitrary subset sums) are forbidden. The problem connects to Problems #359 (sum-free sets) and #867 in Erdős's catalog. Both growth-rate questions remain open, making this one of the more delicate problems in additive combinatorial number theory. The formalization is notable for including seven fully proved structural theorems about valid sequences, alongside the axiomatized deep results.",
@@ -103,22 +104,29 @@
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 124,
-      "endLine": 139,
-      "summary": "Axiomatized results: $\\liminf(a_n/n)$ can be finite (valid sequences need not grow super-linearly everywhere), and the reciprocal sum $\\sum 1/a_n$ can grow as $\\Omega(c \\cdot \\log \\log x)$."
+      "startLine": 122,
+      "endLine": 131,
+      "summary": "Axiomatized result: the reciprocal sum $\\sum 1/a_n$ can grow as $\\Omega(c \\cdot \\log \\log x)$."
     },
     {
       "id": "upper-density",
       "title": "Upper Density and Freud's Counterexample",
-      "startLine": 140,
-      "endLine": 156,
-      "summary": "The upper density $\\overline{d}(a)$ defined via `Filter.limsup`, and Freud's construction achieving $\\overline{d}(a) = 19/36 > 1/2$, disproving Erdős's density conjecture."
+      "startLine": 132,
+      "endLine": 151,
+      "summary": "The upper density $\\overline{d}(a)$ defined via `Filter.limsup`, Freud's axiomatized density $19/36$, and the proved counterexample to Erdős's $1/2$ conjecture."
+    },
+    {
+      "id": "liminf-finite",
+      "title": "Deriving liminf_finite from freud_density",
+      "startLine": 152,
+      "endLine": 256,
+      "summary": "Key axiom elimination: `liminf_finite` proved from `freud_density` via counting argument. Positive upper density forces a(n)/(n+1) < 4 infinitely often. Includes helper lemmas: `countRatio_isCoboundedUnder` (Filter coboundedness), `frequently_lt_of_lt_limsup` (contrapositive extraction), and `term_le_of_count_gt` (counting function bounds terms by contradiction on monotonicity)."
     },
     {
       "id": "main-questions",
       "title": "Main Open Questions",
-      "startLine": 157,
-      "endLine": 163,
+      "startLine": 258,
+      "endLine": 265,
       "summary": "Both questions axiomatized as open: `erdos_839_question1` ($\\limsup$ growth) and `erdos_839_question2` (vanishing logarithmic density). These reflect the OPEN status of Problem #839."
     }
   ],
@@ -139,10 +147,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 164,
-    "axiomCount": 5,
-    "theoremCount": 9,
-    "definitionCount": 6
+    "lineCount": 267,
+    "axiomCount": 4,
+    "theoremCount": 14,
+    "definitionCount": 7
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-839.json
+++ b/src/data/research/problems/erdos-839.json
@@ -29,19 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "COMPLETE: Eliminated liminf_finite axiom by proving it from freud_density. 5→4 axioms, 0 sorries.",
     "builtItems": [
       "Proved freud_counterexample from freud_density (axiom → theorem)",
       "Fixed Mathlib v4.26.0 notation compatibility for all sum expressions",
-      "Fixed omega proof in consecutiveSum_gt_first"
+      "Fixed omega proof in consecutiveSum_gt_first",
+      "Proved liminf_finite theorem from freud_density (axiom → theorem, 5→4 axioms)",
+      "Proved term_le_of_count_gt: counting function bounds sequence terms",
+      "Built countRatio_isCoboundedUnder, frequently_lt_of_lt_limsup helper lemmas"
     ],
     "insights": [
       "freud_counterexample is redundant: follows from freud_density since 19/36 > 1/2",
       "Mathlib v4.26.0 changed BigOperators notation: ∑ k in S → ∑ k ∈ S",
-      "consecutiveSum_gt_first needs explicit positivity hint for omega in v4.26.0"
+      "consecutiveSum_gt_first needs explicit positivity hint for omega in v4.26.0",
+      "liminf_finite is logically redundant: follows from freud_density via counting argument (positive density → bounded ratio)",
+      "Filter.limsup contrapositive pattern: ¬frequently(c < f) → eventually(f ≤ c) → limsup ≤ c"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Consider proving reciprocal_sum_lower from a concrete construction",
+      "2 open question axioms must remain"
+    ],
     "markdown": "# Erdős #839 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $1\\leq a_1<a_2<\\cdots$ be a sequence of integers such that no $a_i$ is the sum of consecutive $a_j$ for $j<i$. Is it true that\\[\\limsup \\frac{a_n}{n}=\\infty?\\]Or even\\[\\lim \\frac{1}{\\log x}\\sum_{a_n<x}\\frac{1}{a_n}=0?\\]\n\n\n\nErd\\H{o}s writes that it is easy to see that $\\liminf a_n/n<\\infty$ is possible, and that one can have\\[\\sum_{a_n< x}\\frac{1}{a_n}\\gg \\log\\log x.\\]The upper density of such a sequence can be $1/2$, but Erd\\H{o}s thought it probably could not be $>1/2$. In fact this is false - Freud \\cite{Fr93} constructed a sequence with upper density $19/36$.\n\nSee also [359] and [867].\n\n\n\n\nReferences\n\n\n[Fr93] R. Freud, Adding numbers - on a problem of P. Erd\\H{o}s. James Cook Mathematical Notes (1993), 6199-6202.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #36\n- Problem #359\n- Problem #867\n- Problem #838\n- Problem #840\n- Problem #39\n- Problem #1\n\n## References\n\n- Er78f\n- Er92c\n- Fr93\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Prove `liminf_finite` from `freud_density` via counting argument, eliminating 1 axiom (5→4)
- Positive upper density (19/36) forces `a(n)/(n+1) < 4` infinitely often
- 0 sorries added — all helper lemmas fully proved

## Key New Results
- `term_le_of_count_gt`: if counting function card ≥ k+1, then a(k) ≤ N (by contradiction on monotonicity)
- `frequently_lt_of_lt_limsup`: contrapositive Filter extraction from limsup
- `countRatio_isCoboundedUnder`: coboundedness for the density ratio
- `liminf_finite`: theorem derived from `freud_density` (was axiom)

## Mathematical Argument
If `upperDensity a = 19/36`, then frequently `count(N)/N > 1/4`. For such N:
1. The counting set is an initial segment {0,...,k-1} (by monotonicity)
2. `k > N/4` implies `a(k-1) ≤ N`
3. So `a(k-1)/k ≤ N/k < 4`

Choosing N ≥ 4(M+1) ensures n = k-1 ≥ M. ∎

## Status
**Outcome**: completed (axiom elimination)
**Axioms**: 5 → 4 (eliminated `liminf_finite`)
**Sorries**: 0 → 0
**Docker**: not available for build verification

🤖 Generated by researcher-9