### PR TITLE
Research: erdos-367 — prove strong_bound_k1 and strong_bound_k2 (7→5A)

### DIFF
--- a/proofs/Proofs/Erdos367Problem.lean
+++ b/proofs/Proofs/Erdos367Problem.lean
@@ -137,14 +137,35 @@ For k ≤ 2, the strong bound holds because B₂(n) ≤ n.
 
 B₂(n) ≤ n ≤ n², so strongBound(1) holds.
 -/
-axiom strong_bound_k1 : strongBound 1
+theorem strong_bound_k1 : strongBound 1 := by
+  refine ⟨1, one_pos, fun n hn => ?_⟩
+  unfold productTwoFullParts
+  have hIco : Finset.Ico n (n + 1) = {n} := by
+    ext m; simp only [Finset.mem_Ico, Finset.mem_singleton]; omega
+  rw [hIco, Finset.prod_singleton]
+  have h1 : (twoFullPart n : ℝ) ≤ (n : ℝ) := by exact_mod_cast twoFullPart_le n
+  have hn' : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  nlinarith [sq_nonneg ((n : ℝ) - 1)]
 
 /--
 **Trivial Case: k = 2**
 
 B₂(n) · B₂(n+1) ≤ n · (n+1) < 2n², so strongBound(2) holds.
 -/
-axiom strong_bound_k2 : strongBound 2
+theorem strong_bound_k2 : strongBound 2 := by
+  refine ⟨2, by norm_num, fun n hn => ?_⟩
+  unfold productTwoFullParts
+  have hIco : Finset.Ico n (n + 2) = {n, n + 1} := by
+    ext m; simp only [Finset.mem_Ico, Finset.mem_insert, Finset.mem_singleton]; omega
+  rw [hIco, Finset.prod_insert (show n ∉ ({n + 1} : Finset ℕ) by simp; omega),
+      Finset.prod_singleton]
+  simp only [Nat.cast_mul]
+  have h1 : (twoFullPart n : ℝ) ≤ (n : ℝ) := by exact_mod_cast twoFullPart_le n
+  have h2 : (twoFullPart (n + 1) : ℝ) ≤ (n : ℝ) + 1 := by exact_mod_cast twoFullPart_le (n + 1)
+  have hn' : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  nlinarith [mul_le_mul h1 h2 (Nat.cast_nonneg (twoFullPart (n + 1)))
+               (by linarith : (0 : ℝ) ≤ (n : ℝ)),
+             sq_nonneg ((n : ℝ) - 1)]
 
 /-
 # Part 6: Known Results — Failure of Strong Bound

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -58,9 +58,11 @@
       "twoFullPart_le: proved B₂(n) ≤ n from definition",
       "twoFullPart_dvd: proved B₂(n) | n from definition",
       "twoFullPart_prime: proved B₂(p) = 1 via squarefreePart computation",
-      "twoFullPart_prime_sq: proved B₂(p²) = p² via squarefreePart computation"
+      "twoFullPart_prime_sq: proved B₂(p²) = p² via squarefreePart computation",
+      "strong_bound_k1: proved strongBound(1) via twoFullPart_le and Finset.prod_singleton",
+      "strong_bound_k2: proved strongBound(2) via twoFullPart_le, mul_le_mul, and nlinarith"
     ],
-    "axiomCount": 7,
+    "axiomCount": 5,
     "prerequisites": [
       "Prime factorization and p-adic valuations",
       "Squarefree numbers and powerful (k-full) numbers",
@@ -69,8 +71,8 @@
       "Basic real analysis (logarithms, limits, sequences)"
     ],
     "date": "1980",
-    "lineCount": 367,
-    "assumptions": "7 axioms: strong_bound_k1, strong_bound_k2, strong_bound_fails_k3, van_doorn_lower_bound, twoFullPart_eq_one_iff, twoFullPart_mul_coprime, average_twoFullPart_bounded. 4 former axioms proved: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq."
+    "lineCount": 388,
+    "assumptions": "5 axioms: strong_bound_fails_k3, van_doorn_lower_bound, twoFullPart_eq_one_iff, twoFullPart_mul_coprime, average_twoFullPart_bounded. 6 former axioms proved: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq, strong_bound_k1, strong_bound_k2."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #367: Products of 2-Full Parts**\n\nThis problem connects two classical themes in multiplicative number theory: the distribution of powerful numbers and the multiplicative structure of consecutive integers.\n\n**Background:** The 2-full (or squareful) part $B_2(n)$ captures the 'square content' of $n$'s prime factorization. Golomb (1970) introduced powerful numbers (where every prime divides with exponent $\\geq 2$) and studied their distribution. The function $B_2$ generalizes this: $B_2(n) = \\prod_{v_p(n) \\geq 2} p^{v_p(n)}$ extracts the powerful component from any integer.\n\n**The problem:** Erdős asked whether $\\prod_{n \\leq m < n+k} B_2(m) \\ll n^{2+o(1)}$ for every fixed $k$. The exponent 2 is natural: since $B_2(n) \\leq n$, the product of $k$ terms is at most $n^k$, but heuristically most $B_2(m)$ are small, so the 'effective' exponent should be much less than $k$.\n\n**Progress:**\n- For $k \\leq 2$: the strong bound $\\ll n^2$ holds trivially ($B_2(n) \\leq n$).\n- **van Doorn (2023):** Proved the strong bound **fails** for $k \\geq 3$. Specifically, there exist infinitely many $n$ with $\\prod_{m=n}^{n+2} B_2(m) \\gg n^2 \\log n$. The construction uses the Chinese Remainder Theorem to find $n$ where multiple consecutive integers have large square factors.\n- The **weak bound** $n^{2+o(1)}$ (with the logarithmic slack) remains open for all $k \\geq 3$.",
@@ -130,7 +132,7 @@
       "title": "Part 5: Trivial Cases (k ≤ 2)",
       "startLine": 129,
       "endLine": 148,
-      "summary": "Axiomatizes strongBound for k=1 (B₂(n) ≤ n ≤ n²) and k=2 (B₂(n)·B₂(n+1) ≤ n(n+1) < 2n²).",
+      "summary": "Proves strongBound for k=1 (B₂(n) ≤ n ≤ n²) and k=2 (B₂(n)·B₂(n+1) ≤ n(n+1) < 2n²) from twoFullPart_le.",
       "mathContext": "$k=1: B_2(n) \\leq n^2$. $k=2: B_2(n) B_2(n+1) \\leq n(n+1) < 2n^2$"
     },
     {
@@ -232,9 +234,9 @@
       "Finset"
     ],
     "namespace": "Erdos367",
-    "lineCount": 367,
-    "axiomCount": 7,
-    "theoremCount": 6,
+    "lineCount": 388,
+    "axiomCount": 5,
+    "theoremCount": 8,
     "definitionCount": 10
   }
 }

--- a/src/data/research/problems/erdos-367.json
+++ b/src/data/research/problems/erdos-367.json
@@ -29,17 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axiom count from 11 to 7. Proved 4 properties of B₂ from definitions using Mathlib factorization API.",
+    "progressSummary": "PROGRESS: Reduced axioms from 7 to 5. Proved strong_bound_k1 and strong_bound_k2 from twoFullPart_le. Total 8 theorems proved, 5 axioms remain.",
     "builtItems": [
-      "Proved twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq in Erdos367Problem.lean"
+      "Proved twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq in Erdos367Problem.lean",
+      "Proved strong_bound_k1 in Erdos367Problem.lean:140",
+      "Proved strong_bound_k2 in Erdos367Problem.lean:155"
     ],
     "insights": [
-      "4 axioms proved from Mathlib: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq"
+      "4 axioms proved from Mathlib: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq",
+      "Proved strong_bound_k1 (k=1) from twoFullPart_le via Finset.Ico singleton and nlinarith",
+      "Proved strong_bound_k2 (k=2) from twoFullPart_le via Finset.prod_insert, mul_le_mul, and nlinarith",
+      "Key Mathlib API for twoFullPart_eq_one_iff: Nat.squarefree_iff_factorization_le_one, Nat.factorization_prod_pow_eq_self, Nat.support_factorization, Finset.filter_true_of_mem"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove strong_bound_k1/k2 from twoFullPart_le",
-      "Prove twoFullPart_eq_one_iff via squarefreePart analysis"
+      "Prove twoFullPart_eq_one_iff via Nat.squarefree_iff_factorization_le_one + Nat.factorization_prod_pow_eq_self (backward: squarefree → all exps 1 → filter identity → product = n → division = 1; forward: division = 1 → n = squarefreePart → Prime.dvd_finset_prod shows all primes in filter → all exps 1 → squarefree)",
+      "Prove twoFullPart_mul_coprime via coprime factorization splitting (Nat.factorization_mul_coprime)",
+      "average_twoFullPart_bounded requires deep analytic number theory — likely unprovable in Lean without extensive infrastructure"
     ],
     "markdown": "# Erdős #367 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $B_2(n)$ be the 2-full part of $n$ (that is, $B_2(n)=n/n'$ where $n'$ is the product of all primes that divide $n$ exactly once). Is it true that, for every fixed $k\\geq 1$,\\[\\prod_{n\\leq m<n+k}B_2(m) \\ll n^{2+o(1)}?\\]Or perhaps even $\\ll_k n^2$?\n\n\n\nIt would also be interesting to find upper and lower bounds for the analogous product with $B_r$ for $r\\geq 3$, where $B_r(n)$ is the $r$-full part of $n$ (that is, the product of prime powers $p^a \\mid n$ such that $p^{a+1}\\nmid n$ and $a\\geq r$). Is it true that, for every fixed $r,k\\geq 2$ and $\\epsilon>0$,\\[\\limsup \\frac{\\prod_{n\\leq m<n+k}B_r(m) }{n^{1+\\epsilon}}\\to\\infty?\\]van Doorn notes in the comments that for $k\\leq 2$ we trivially have\\[\\prod_{n\\leq m<n+k}B_2(m) \\ll n^{2},\\]but that this fails for all $k\\geq 3$, and in fact\\[\\prod_{n\\leq m<n+3}B_2(m) \\gg n^{2}\\log n\\]infinitely often.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #366\n- Problem #368\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },


### PR DESCRIPTION
## Summary
Research session proving axioms and eliminating sorries across two problems.

### erdos-367: Prove strong_bound_k1 and strong_bound_k2 (7→5A)
- Proved `strong_bound_k1`: `strongBound 1` via `twoFullPart_le`, Finset singleton, `nlinarith`
- Proved `strong_bound_k2`: `strongBound 2` via `twoFullPart_le`, `Finset.prod_insert`, `mul_le_mul`
- Axiom count reduced from 7 to 5

### erdos-719: Prove evens/odds cardinality (3→1S)
- Proved `evens.card = (n+1)/2` via bijection `Fin((n+1)/2) → evens` (k ↦ 2k)
- Proved `odds.card = n/2` via bijection `Fin(n/2) → odds` (k ↦ 2k+1)
- Sorry count reduced from 3 to 1

### erdos-1157: Fix stale metadata (7A→2A in problem JSON)

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos367Problem`
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos719Problem`
- [ ] Gallery build: `pnpm build`

🤖 Generated by researcher-4