### PR TITLE
Research: erdos-700 + erdos-421 + erdos-1179 — axiom/sorry elimination

### DIFF
--- a/proofs/Proofs/Erdos700Problem.lean
+++ b/proofs/Proofs/Erdos700Problem.lean
@@ -79,6 +79,66 @@ theorem le_largestPrimeFactor {n r : ℕ} (hr : r.Prime) (hdvd : r ∣ n) (hn : 
   exact Finset.le_sup (f := id)
     (Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), hr, hdvd⟩)
 
+/-- From the absorption identity: n divides k * C(n, k) for 1 ≤ k ≤ n.
+    Uses Nat.succ_mul_choose_eq: (n+1) * C(n,k) = C(n+1,k+1) * (k+1). -/
+private theorem n_dvd_k_mul_choose {n k : ℕ} (hn : 1 ≤ n) (hk : 1 ≤ k) (hkn : k ≤ n) :
+    n ∣ k * n.choose k := by
+  have hn' : n - 1 + 1 = n := by omega
+  have hk' : k - 1 + 1 = k := by omega
+  have h := Nat.succ_mul_choose_eq (n - 1) (k - 1)
+  rw [hn', hk'] at h
+  -- h : n * (n - 1).choose (k - 1) = n.choose k * k
+  exact ⟨(n - 1).choose (k - 1), by rw [mul_comm k]; exact h.symm⟩
+
+/-- For n ≥ 4 and k ∈ [2, n/2], gcd(n, C(n,k)) ≥ minFac(n).
+    Key idea: n/gcd(n,k) divides both n and C(n,k) (by coprime cancellation
+    from the absorption identity), hence divides their gcd. Since gcd(n,k) ≤ k ≤ n/2 < n,
+    the quotient n/gcd(n,k) ≥ minFac(n). -/
+private theorem gcd_choose_ge_minFac {n k : ℕ} (hn : 4 ≤ n) (hk : 2 ≤ k) (hkn : k ≤ n / 2) :
+    n.minFac ≤ Nat.gcd n (n.choose k) := by
+  have hk_le_n : k ≤ n := le_trans hkn (Nat.div_le_self n 2)
+  -- Step 1: n | k * C(n, k) from absorption identity
+  have h_dvd := n_dvd_k_mul_choose (by omega : 1 ≤ n) (by omega : 1 ≤ k) hk_le_n
+  -- Step 2: Setup gcd, derive (n/g) | C(n,k) by coprime cancellation
+  set g := Nat.gcd n k
+  have hg_pos : 0 < g := Nat.gcd_pos_of_pos_left k (by omega)
+  have hg_dvd_n := Nat.gcd_dvd_left n k
+  have hg_dvd_k := Nat.gcd_dvd_right n k
+  have hcop : Nat.Coprime (n / g) (k / g) := Nat.coprime_div_gcd_div_gcd hg_pos
+  have hgk : g * (k / g) = k := by rw [mul_comm]; exact Nat.div_mul_cancel hg_dvd_k
+  have hgn : g * (n / g) = n := by rw [mul_comm]; exact Nat.div_mul_cancel hg_dvd_n
+  obtain ⟨m, hm⟩ := h_dvd
+  have h_eq : k / g * n.choose k = n / g * m := by
+    have h1 : g * (k / g * n.choose k) = g * (n / g * m) := by
+      calc g * (k / g * n.choose k)
+          = g * (k / g) * n.choose k := (mul_assoc g (k / g) (n.choose k)).symm
+        _ = k * n.choose k := by rw [hgk]
+        _ = n * m := hm
+        _ = g * (n / g) * m := by rw [hgn]
+        _ = g * (n / g * m) := mul_assoc g (n / g) m
+    exact Nat.eq_of_mul_eq_mul_left hg_pos h1
+  have h_nd_dvd_C : n / g ∣ n.choose k := hcop.dvd_of_dvd_mul_left ⟨m, h_eq⟩
+  -- Step 3: (n/g) divides gcd(n, C(n,k))
+  have h_nd_dvd_n : n / g ∣ n := ⟨g, (Nat.div_mul_cancel hg_dvd_n).symm⟩
+  have h_nd_dvd_gcd : n / g ∣ Nat.gcd n (n.choose k) := Nat.dvd_gcd h_nd_dvd_n h_nd_dvd_C
+  -- Step 4: gcd ≥ n/g ≥ minFac(n)
+  have h_gcd_ge : n / g ≤ Nat.gcd n (n.choose k) :=
+    Nat.le_of_dvd (Nat.gcd_pos_of_pos_left _ (by omega)) h_nd_dvd_gcd
+  have h_minFac_le : n.minFac ≤ n / g := by
+    apply Nat.minFac_le_of_dvd
+    · -- 2 ≤ n / g: since g ≤ k ≤ n/2 < n, if n/g ≤ 1 then n ≤ g ≤ n/2, contradiction
+      by_contra h
+      push_neg at h
+      have hng1 : n / g ≤ 1 := by omega
+      have hng : n ≤ g := by
+        calc n = n / g * g := (Nat.div_mul_cancel hg_dvd_n).symm
+          _ ≤ 1 * g := Nat.mul_le_mul_right g hng1
+          _ = g := one_mul g
+      have : g ≤ n / 2 := le_trans (Nat.le_of_dvd (by omega) hg_dvd_k) hkn
+      omega
+    · exact h_nd_dvd_n
+  linarith
+
 /- ## Basic Bounds -/
 
 /-- f(n) ≤ n/P(n) for all composite n.
@@ -89,11 +149,19 @@ axiom f_upper_bound (n : ℕ) (hn : ¬n.Prime) (hn2 : 2 ≤ n) :
   fBinom n ≤ n / largestPrimeFactor n
 
 /-- f(n) ≥ p(n), the smallest prime factor of n.
-    For every 1 < k ≤ n/2, the smallest prime p dividing n also
-    divides gcd(n, C(n,k)), since by Kummer's theorem v_p(C(n,k)) ≥ 1
-    whenever p | n and 0 < k < n. -/
-axiom f_lower_bound (n : ℕ) (hn : 2 ≤ n) :
-  smallestPrimeFactor n ≤ fBinom n
+    For every 2 ≤ k ≤ n/2, gcd(n, C(n,k)) ≥ minFac(n).
+    Proof: from the absorption identity n | k·C(n,k), coprime
+    cancellation gives (n/gcd(n,k)) | C(n,k). Since gcd(n,k) ≤ k ≤ n/2 < n,
+    we get n/gcd(n,k) ≥ minFac(n), completing the bound. -/
+theorem f_lower_bound (n : ℕ) (hn : 4 ≤ n) :
+    smallestPrimeFactor n ≤ fBinom n := by
+  unfold fBinom smallestPrimeFactor
+  rw [dif_pos hn]
+  apply Finset.le_min'
+  intro x hx
+  obtain ⟨k, hk, rfl⟩ := Finset.mem_image.mp hx
+  obtain ⟨hk2, hkn⟩ := Finset.mem_Icc.mp hk
+  exact gcd_choose_ge_minFac hn hk2 hkn
 
 /- ## Known Equalities -/
 
@@ -102,6 +170,7 @@ axiom f_lower_bound (n : ℕ) (hn : 2 ≤ n) :
 theorem f_semiprime (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hpq : p ≤ q) :
     fBinom (p * q) = p := by
   have h2 : 2 ≤ p * q := by have := hp.two_le; nlinarith
+  have h4 : 4 ≤ p * q := by have := hp.two_le; have := hq.two_le; nlinarith
   have hcomp : ¬(p * q).Prime := by
     intro hprime
     rcases hprime.eq_one_or_self_of_dvd p (dvd_mul_right p q) with h1 | h2
@@ -110,7 +179,7 @@ theorem f_semiprime (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hpq : p ≤ q) :
       exact absurd this (by omega)
   -- Lower bound: p ≤ f(pq)
   have hlower : p ≤ fBinom (p * q) := by
-    have hmin := f_lower_bound (p * q) h2
+    have hmin := f_lower_bound (p * q) h4
     rw [show smallestPrimeFactor (p * q) = Nat.minFac (p * q) from rfl,
         minFac_mul_prime hp hq hpq] at hmin
     exact hmin
@@ -129,10 +198,23 @@ theorem f_semiprime (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hpq : p ≤ q) :
     linarith
   omega
 
-/-- f(30) = 30/5 = 6. One verifies gcd(30, C(30,k)) ≥ 6 for all
-    1 < k ≤ 15, with equality at k = 5 where C(30,5) = 142506
+/-- f(30) = 30/5 = 6. Verified by checking gcd(30, C(30,k)) ≥ 6 for all
+    2 ≤ k ≤ 15, with equality at k = 5 where C(30,5) = 142506
     and gcd(30, 142506) = 6. -/
-axiom f_30 : fBinom 30 = 6
+theorem f_30 : fBinom 30 = 6 := by
+  unfold fBinom
+  rw [dif_pos (show (4 : ℕ) ≤ 30 by norm_num)]
+  apply le_antisymm
+  · -- Upper bound: min' ≤ 6 via k = 5
+    apply Finset.min'_le
+    exact Finset.mem_image.mpr ⟨5, Finset.mem_Icc.mpr ⟨by norm_num, by norm_num⟩,
+      by native_decide⟩
+  · -- Lower bound: 6 ≤ min' (all gcd values ≥ 6)
+    apply Finset.le_min'
+    intro x hx
+    obtain ⟨k, hk, rfl⟩ := Finset.mem_image.mp hx
+    obtain ⟨hk2, hk15⟩ := Finset.mem_Icc.mp hk
+    interval_cases k <;> native_decide
 
 /- ## Question 1: Characterization (OPEN)
 
@@ -149,8 +231,8 @@ axiom f_30 : fBinom 30 = 6
     PROVED from f_lower_bound and minFac(p²) = p. -/
 theorem f_prime_square (p : ℕ) (hp : p.Prime) :
     p ≤ fBinom (p * p) := by
-  have h2 : 2 ≤ p * p := by have := hp.two_le; nlinarith
-  have hbound := f_lower_bound (p * p) h2
+  have h4 : 4 ≤ p * p := by have := hp.two_le; nlinarith
+  have hbound := f_lower_bound (p * p) h4
   have hmin : smallestPrimeFactor (p * p) = p := by
     unfold smallestPrimeFactor
     exact minFac_prime_sq p hp

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -19,9 +19,9 @@
     "sourceUrl": "https://erdosproblems.com/700",
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 175,
-    "assumptions": "5 axioms: f_upper_bound, f_lower_bound, f_semiprime, erdos_700_question2, erdos_700_question3. fBinom now defined (not axiomatized). f_prime_square proved from f_lower_bound.",
+    "axiomCount": 3,
+    "lineCount": 257,
+    "assumptions": "3 axioms: f_upper_bound (needs Kummer's theorem), erdos_700_question2, erdos_700_question3 (both open problems). f_lower_bound PROVED via absorption identity + coprime cancellation. f_30 PROVED computationally. f_semiprime proved from bounds.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -45,25 +45,25 @@
       "id": "helper-lemmas",
       "title": "Helper Lemmas",
       "startLine": 48,
-      "endLine": 80,
-      "summary": "Proves `minFac_prime_sq` ($\\text{minFac}(p^2) = p$) via `dvd_of_dvd_pow` and prime uniqueness. Proves `minFac_mul_prime` ($\\text{minFac}(pq) = p$ for primes $p \\le q$) via case analysis on which prime factor the minFac divides. Proves `le_largestPrimeFactor`: any prime factor $r \\mid n$ satisfies $r \\le P(n)$.",
-      "mathContext": "Lemma `minFac_prime_sq`: $\\text{minFac}(p^2)$ is prime and divides $p^2$, hence divides $p$ by `dvd_of_dvd_pow`, and equals $p$ since $p$ is prime. Lemma `minFac_mul_prime`: $\\text{minFac}(pq)$ divides $pq$, so divides $p$ or $q$; combined with $\\text{minFac}(pq) \\le p$ (from `minFac_le_of_dvd`), yields $\\text{minFac}(pq) = p$. These are used in proving $f(pq) = p$ and $f(p^2) \\ge p$."
+      "endLine": 134,
+      "summary": "Proves `minFac_prime_sq`, `minFac_mul_prime`, `le_largestPrimeFactor` (existing). NEW: `n_dvd_k_mul_choose` (absorption identity: $n \\mid k \\cdot \\binom{n}{k}$, from `Nat.succ_mul_choose_eq`). NEW: `gcd_choose_ge_minFac` (for $n \\ge 4$ and $2 \\le k \\le n/2$, $\\gcd(n, \\binom{n}{k}) \\ge \\text{minFac}(n)$, via coprime cancellation: $n/\\gcd(n,k) \\mid \\binom{n}{k}$).",
+      "mathContext": "Key new result: from the absorption identity $k \\cdot \\binom{n}{k} = n \\cdot \\binom{n-1}{k-1}$, coprime cancellation gives $n/\\gcd(n,k) \\mid \\binom{n}{k}$. Since $\\gcd(n,k) \\le k \\le n/2$, the quotient $n/\\gcd(n,k) \\ge \\text{minFac}(n)$ (every proper divisor of $n$ is $\\le n/\\text{minFac}(n)$). This establishes the lower bound $\\gcd(n, \\binom{n}{k}) \\ge \\text{minFac}(n)$ for all $k$ in range."
     },
     {
       "id": "bounds",
       "title": "Basic Sandwich Bounds",
-      "startLine": 82,
-      "endLine": 96,
-      "summary": "Axiomatizes `f_upper_bound` ($f(n) \\le n/P(n)$ for composite $n$, via Kummer's theorem) and `f_lower_bound` ($p(n) \\le f(n)$ for $n \\ge 2$, since the smallest prime dividing $n$ divides every $\\gcd(n, \\binom{n}{k})$).",
-      "mathContext": "The sandwich inequality $p(n) \\le f(n) \\le n/P(n)$ is the fundamental structural result. Upper bound: choosing $k = p^a$ where $p^a \\| n$ gives exactly one carry in base-$p$ addition, so $v_p(\\binom{n}{k}) = 1$, hence $\\gcd(n, \\binom{n}{p^a}) = n/p^a \\le n/P(n)$. Lower bound: for every $0 < k < n$, Kummer's theorem gives $v_p(\\binom{n}{k}) \\ge 1$ when $p \\mid n$."
+      "startLine": 135,
+      "endLine": 157,
+      "summary": "Axiomatizes `f_upper_bound` ($f(n) \\le n/P(n)$, needs Kummer's theorem). PROVES `f_lower_bound` ($p(n) \\le f(n)$ for $n \\ge 4$) via the absorption identity and coprime cancellation: for each $k$, $n/\\gcd(n,k) \\mid \\gcd(n, \\binom{n}{k})$, and $n/\\gcd(n,k) \\ge \\text{minFac}(n)$ since $\\gcd(n,k) \\le n/2$.",
+      "mathContext": "The sandwich inequality $p(n) \\le f(n) \\le n/P(n)$ is fundamental. Upper bound (axiomatized): Kummer's theorem. Lower bound (NOW PROVED): from $n \\mid k \\cdot \\binom{n}{k}$ and coprime cancellation, every $\\gcd(n, \\binom{n}{k})$ is divisible by $n/\\gcd(n,k) \\ge \\text{minFac}(n)$."
     },
     {
       "id": "equalities",
       "title": "Known Exact Values",
-      "startLine": 98,
-      "endLine": 135,
-      "summary": "PROVES `f_semiprime`: $f(pq) = p$ for primes $p \\le q$, by sandwiching between `f_lower_bound` (giving $p \\le f(pq)$) and `f_upper_bound` (giving $f(pq) \\le pq/P(pq) \\le p$). Axiomatizes `f_30`: $f(30) = 6 = 30/5$, the first non-semiprime example achieving $f(n) = n/P(n)$.",
-      "mathContext": "Proved: $f(pq) = p$ for primes $p \\le q$. Lower bound: $p = \\text{minFac}(pq) \\le f(pq)$. Upper bound: $f(pq) \\le pq/P(pq)$, and $q \\le P(pq)$ (since $q$ is a prime factor), so $pq/P(pq) \\le pq/q \\cdot P(pq)/P(pq) \\le p$. The case $n = 30 = 2 \\cdot 3 \\cdot 5$ with $f(30) = 6$ shows the characterization extends beyond semiprimes."
+      "startLine": 159,
+      "endLine": 211,
+      "summary": "PROVES `f_semiprime` ($f(pq) = p$) and NOW PROVES `f_30` ($f(30) = 6$) computationally via `interval_cases` + `native_decide` over all $k \\in [2, 15]$. The sandwich gives equality for semiprimes; $n = 30$ requires checking all 14 GCD values explicitly.",
+      "mathContext": "Proved: $f(pq) = p$ for primes $p \\le q$ (sandwich argument). NOW PROVED: $f(30) = 6$ by verifying $\\gcd(30, \\binom{30}{k}) \\ge 6$ for all $k \\in [2, 15]$, with equality at $k = 5$ where $\\gcd(30, 142506) = 6$."
     },
     {
       "id": "question1",
@@ -146,9 +146,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 175,
-    "axiomCount": 5,
-    "theoremCount": 2,
+    "lineCount": 257,
+    "axiomCount": 3,
+    "theoremCount": 9,
     "definitionCount": 3
   },
   "references": [


### PR DESCRIPTION
## Summary
Three research problems addressed:

### Erdős #700 (5→3 axioms)
- **Prove `f_lower_bound`**: absorption identity n|k·C(n,k) + coprime cancellation → gcd(n,C(n,k)) ≥ minFac(n)
- **Fix hypothesis bug**: was FALSE for n=2,3 (fBinom returns 0 for n<4)
- **Prove `f_30`**: computational verification via interval_cases + native_decide
- **Remaining**: 3 axioms (f_upper_bound needs Kummer, q2/q3 open problems)

### Erdős #421 (1→0 sorries)
- **Fix `numValidPairs_eq`**: Nat subtraction bug for n=0. Fixed to use Finset.range
- **Prove `numValidPairs_eq`**: induction with disjoint set decomposition + Gauss formula
- **File now sorry-free** (1 axiom: selfridge_construction)

### Erdős #1179 (1→0 sorries)
- **Prove `logloglog_div_loglog_tendsto_zero`**: log(log(log N))/log(log N) → 0 via isLittleO_log_rpow_atTop composed with log∘log→∞
- **File now sorry-free** (5 axioms: deep results in additive combinatorics)

## Test plan
- [ ] Docker build of `Proofs.Erdos700Problem`
- [ ] Docker build of `Proofs.Erdos421Problem`
- [ ] Docker build of `Proofs.Erdos1179Problem`

🤖 Generated by researcher-2