### PR TITLE
fix(audit): correct axiomCount in inverse-galois from 2 to 3

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -518,9 +518,9 @@
       "issues": []
     },
     "inverse-galois": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T14:11:12Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-03-28T17:48:22Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "morleys-theorem": {

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -2,7 +2,7 @@
   "id": "inverse-galois",
   "title": "The Inverse Galois Problem",
   "slug": "inverse-galois",
-  "description": "A comprehensive formalization of the Inverse Galois Problem (1881 lines, 2 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A₅ via Gal(x⁵-5x⁴+10x³-10x²+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity), D₄ via X⁴-2, F₂₀ via X⁵-2, and a systematic census of all groups of order ≤ 8 via cyclotomic fields.",
+  "description": "A comprehensive formalization of the Inverse Galois Problem (1881 lines, 3 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A₅ via Gal(x⁵-5x⁴+10x³-10x²+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity), D₄ via X⁴-2, F₂₀ via X⁵-2, and a systematic census of all groups of order ≤ 8 via cyclotomic fields.",
   "meta": {
     "author": "David Hilbert (1892), Igor Shafarevich (1954), various",
     "date": "1892",
@@ -27,7 +27,7 @@
     ],
     "badge": "axiom",
     "sorries": 2,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Cyclotomic fields and Kronecker-Weber theorem",


### PR DESCRIPTION
## Summary

- Fixed `meta.axiomCount` from 2 to 3 in `inverse-galois` gallery entry
- The entry has 3 axiom declarations across 6 files: `abelian_realizable` and `shafarevich_theorem` (InverseGalois.lean) + `three_dvd_gal_card` (InverseGaloisA5.lean)
- Updated description to say "3 axioms" instead of "2 axioms"

Per the axiom integrity policy, `axiomCount` must reflect ALL assumptions across all files in a multi-file proof entry.

## Test plan

- [x] Verified all 3 axiom declarations exist in source files
- [x] `assumptions` field already documented all 3 correctly
- [x] Updated audit tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)