### PR TITLE
fix(audit): correct stale metadata in erdos-1179

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2939,9 +2939,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1179": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-28T18:11:12Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-118": {

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1179,
     "erdosUrl": "https://erdosproblems.com/1179",
     "erdosProblemStatus": "proved",
@@ -59,9 +59,9 @@
       "gEps_mono: monotonicity in ε"
     ],
     "axiomCount": 5,
-    "lineCount": 300,
-    "assumptions": "5 axiom(s): gEps (abstract function), trivial_lower_bound, erdos_renyi_upper, erdos_hall_upper, gEps_mono. Eliminated: main_asymptotic (now derived via squeeze theorem from trivial_lower_bound + erdos_hall_upper). 1 sorry remains: logloglog_div_loglog_tendsto_zero (standard analysis fact).",
-    "theoremCount": 5
+    "lineCount": 330,
+    "assumptions": "5 axiom(s): gEps (abstract function), trivial_lower_bound, erdos_renyi_upper, erdos_hall_upper, gEps_mono. 0 sorries. Eliminated: main_asymptotic (now derived via squeeze theorem from trivial_lower_bound + erdos_hall_upper), logloglog_div_loglog_tendsto_zero (now proved).",
+    "theoremCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1179: Uniform Subset Sum Representations**\n\n**Background: Additive Combinatorics in Groups**\nThis problem lies at the intersection of additive combinatorics and probabilistic number theory. It concerns how well a random subset of a finite abelian group can 'represent' all group elements via subset sums.\n\n**The Representation Function:**\nFor a subset $A$ of a finite abelian group $G$ with $|G| = N$, define $F_A(g) = |\\{S \\subseteq A : \\sum_{x \\in S} x = g\\}|$ for each $g \\in G$. If $|A| = k$, there are $2^k$ subsets total, so the 'expected' count is $2^k/N$ per element.\n\n**Erdős-Rényi (1965):**\nPaul Erdős and Alfréd Rényi studied random subsets of abelian groups in their foundational paper on probabilistic group theory. They showed that a random set of size $k \\approx 2\\log_2 N$ gives approximately uniform representations, establishing $g_\\varepsilon(N) \\leq (2 + o(1))\\log_2 N$. Their proof uses the second moment method.\n\n**Erdős-Hall (1976):**\nErdős and Richard R. Hall improved the bound to $g_\\varepsilon(N) \\leq (1 + o(1))\\log_2 N$ using character sum estimates (discrete Fourier analysis on $G$) and large deviation bounds. This reduced the leading coefficient from 2 to $1 + o(1)$.\n\n**Main Result:**\nCombined with the trivial lower bound $g_\\varepsilon(N) \\geq \\log_2 N$ (counting argument), this gives $g_\\varepsilon(N) \\sim \\log_2 N$: the answer to Erdős's question is YES.\n\n**Connection to Problem #543:**\nProblem #543 asks about *spanning* (every element represented at least once), while #1179 asks for *uniform* representations. Uniformity is stronger but, remarkably, requires the same leading term $\\log_2 N$.",
@@ -212,9 +212,9 @@
       "Real"
     ],
     "namespace": "Erdos1179",
-    "lineCount": 300,
-    "axiomCount": 7,
-    "theoremCount": 5,
+    "lineCount": 330,
+    "axiomCount": 5,
+    "theoremCount": 10,
     "definitionCount": 3
   }
 }


### PR DESCRIPTION
## Summary

- Fixed `sorries`: 1→0 (logloglog_div_loglog_tendsto_zero was proved by researcher)
- Fixed `lineCount`: 300→330 (file grew with new theorems)
- Fixed `leanFile.axiomCount`: 7→5 (was overcounted)
- Fixed `leanFile.theoremCount`: 5→10 (was undercounted after sorry elimination)
- Updated `assumptions` text to reflect 0 sorries

## Test plan

- [x] Verified 0 sorries in Erdos1179Problem.lean
- [x] Verified 5 axiom declarations via grep
- [x] Verified 10 theorem declarations via grep
- [x] Verified 330 lines via wc -l

🤖 Generated with [Claude Code](https://claude.com/claude-code)