### PR TITLE
fix(audit): correct stale metadata in erdos-1085

### DIFF
--- a/src/data/proofs/erdos-1085/meta.json
+++ b/src/data/proofs/erdos-1085/meta.json
@@ -43,16 +43,11 @@
     ],
     "originalContributions": [
       "Definition of PointConfig for n-point configurations in ℝ^d",
-      "Definition of unitDistanceCount counting pairs at distance 1",
-      "Axiomatization of maxUnitDistances (f_d(n))",
-      "Erdős 1946 lower bound for d=2: n^(1+c/log log n)",
-      "Spencer-Szemerédi-Trotter 1984 upper bound: O(n^(4/3))",
-      "Erdős 1960 lower bound for d=3: Ω(n^(4/3) log log n)",
-      "Lenz construction lower bound for d≥4",
-      "Erdős-Stone upper bound for d≥4",
-      "Brass 1997 exact formula for d=4",
-      "Swanepoel 2009 exact formulas for even d≥6",
-      "Erdős-Pach 1990 tight bounds for odd d≥5"
+      "Definition of distinctPairs and unitDistanceCount for unit-distance graph edge counting",
+      "Axiomatization of maxUnitDistances f_d(n) as the extremal function",
+      "Prop definition of 2D conjecture f_2(n) = n^(1+o(1))",
+      "Prop definition of 3D open question on tight bounds",
+      "Definition of lenzCoefficient (p-1)/(2p) for high-dimensional leading term"
     ],
     "axiomCount": 1,
     "lineCount": 126,
@@ -62,7 +57,7 @@
     "historicalContext": "The **Unit Distance Problem** is one of the most celebrated problems in combinatorial geometry. Given n points in ℝ^d, how many pairs can be at distance exactly 1?\n\n**Historical Timeline**:\n- **1946**: Erdős posed the 2D problem and proved the lower bound n^(1+c/log log n)\n- **1960**: Erdős extended to d=3 with lower bound n^(4/3) log log n\n- **1984**: Spencer, Szemerédi, and Trotter proved the landmark O(n^(4/3)) upper bound using the crossing number inequality\n- **1990**: Clarkson et al. achieved O(n^(3/2) β(n)) for d=3; Erdős-Pach settled odd d≥5\n- **1997**: Brass found the exact formula for d=4\n- **2009**: Swanepoel determined exact formulas for all even d≥6\n\n**The Lenz Construction**: For d≥4, place points on orthogonal unit circles. Points on different circles are at distance √2, but a clever arrangement makes them distance 1. This achieves ~(p-1)/(2p)·n² unit distances where p=⌊d/2⌋.\n\n**Connection to Erdős #90**: The d=2 case is sometimes listed as Problem #90. The gap between n^(1+o(1)) and n^(4/3) has been open for 80 years!",
     "problemStatement": "**Erdős Problem #1085**: Let $f_d(n)$ be the maximum number of pairs of points at unit distance among any set of $n$ points in $\\mathbb{R}^d$. Estimate $f_d(n)$.\n\n**Dimension 2** (Classical Unit Distance Problem):\n$$n^{1+\\frac{c}{\\log\\log n}} < f_2(n) \\ll n^{4/3}$$\nLower bound: Erdős (1946) using integer lattice constructions\nUpper bound: Spencer-Szemerédi-Trotter (1984) using crossing numbers\n**GAP IS OPEN**\n\n**Dimension 3**:\n$$n^{4/3}\\log\\log n \\ll f_3(n) \\ll n^{3/2}\\beta(n)$$\nwhere $\\beta(n)$ is the inverse Ackermann function\n\n**Dimension $d \\geq 4$**: Let $p = \\lfloor d/2 \\rfloor$. Then:\n$$f_d(n) = \\frac{p-1}{2p} n^2 + o(n^2)$$\n- For d=4: Exact formula by Brass (1997)\n- For even d≥6: Exact formulas by Swanepoel (2009)\n- For odd d≥5: Error term O(n^(4/3)) by Erdős-Pach (1990)",
     "text": "Let f_d(n) be the maximum number of pairs at unit distance among n points in ℝ^d. For d=2: n^(1+o(1)) ≤ f_2(n) ≤ O(n^(4/3)) with gap OPEN. For d≥4: f_d(n) ≈ (p-1)/(2p)·n² where p=⌊d/2⌋ (essentially SOLVED).",
-    "proofStrategy": "The formalization captures the dimension-by-dimension structure of known results:\n\n1. **Core Definitions**:\n   - `PointConfig d n`: Configuration of n points in ℝ^d\n   - `unitDistanceCount P`: Number of pairs at distance 1 in configuration P\n   - `maxUnitDistances d n`: f_d(n) = max over all configurations\n\n2. **Dimension 2 Bounds**:\n   - `erdos_1946_lower_d2`: n^(1+c/log log n) lower bound\n   - `sst_1984_upper_d2`: O(n^(4/3)) upper bound\n   - `erdos_1085_2d_conjecture`: Open question - is f_2(n) = O(n^(1+o(1)))?\n\n3. **Dimension 3 Bounds**:\n   - `erdos_1960_lower_d3`: Ω(n^(4/3) log log n)\n   - `cegsw_1990_upper_d3`: O(n^(3/2))\n\n4. **High Dimensions (d ≥ 4)**:\n   - `lenz_lower_d4`: Lenz construction lower bound\n   - `erdos_stone_upper_d4`: Erdős-Stone theorem upper bound\n   - Exact results: `brass_1997_d4`, `swanepoel_2009_even`, `erdos_pach_1990_odd`",
+    "proofStrategy": "The formalization provides a scaffold for the dimension-by-dimension structure of known results. No bounds are proved as theorems; the file axiomatizes the extremal function and states open conjectures as Prop definitions.\n\n1. **Core Definitions**:\n   - `PointConfig d n`: Configuration of n points in ℝ^d\n   - `distinctPairs n`: Index pairs (i,j) with i < j\n   - `unitDistanceCount P`: Number of pairs at distance 1 in configuration P\n   - `maxUnitDistances d n` (axiom): f_d(n) = max over all configurations\n\n2. **Open Problems as Props**:\n   - `erdos_1085_2d_conjecture`: Is f_2(n) = O(n^(1+o(1)))?\n   - `erdos_1085_3d_open_question`: Is f_3(n) = O(n^(4/3) log log n)?\n\n3. **High-Dimensional Coefficient**:\n   - `lenzCoefficient d`: Computes (p-1)/(2p) for p = ⌊d/2⌋",
     "keyInsights": [
       "**The crossing number breakthrough**: The Spencer-Szemerédi-Trotter O(n^(4/3)) bound uses a clever graph-theoretic argument. The unit distance graph (vertices = points, edges = unit distances) has crossing number Ω(e³/n²), forcing e ≤ O(n^(4/3)).",
       "**Why d=2 and d=3 are hard**: In low dimensions, points are too constrained. A circle has infinitely many points at unit distance from its center, allowing complex configurations. In d≥4, geometric rigidity kicks in.",


### PR DESCRIPTION
## Summary

- Trimmed `originalContributions` from 11 items to 6 to match actual Lean declarations (0 theorems, 6 defs, 1 axiom)
- Removed 8 claimed bounds/theorems (Erdős 1946, SST 1984, Lenz construction, Brass 1997, Swanepoel 2009, Erdős-Pach 1990) that only appear in comments, not as Lean theorems
- Fixed `proofStrategy` to reference only identifiers that exist in the source file

**Failure mode**: Pipeline inflation (#4) — historical results described in comments were listed as original contributions

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page for erdos-1085 renders correctly
- [ ] No other metadata files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)