### PR TITLE
Research: erdos-1151 — fix stale axiom metadata (4→2A)

### DIFF
--- a/proofs/Proofs/Erdos1151Problem.lean
+++ b/proofs/Proofs/Erdos1151Problem.lean
@@ -147,7 +147,7 @@ noncomputable def chebyshevInterpSeq (f : ℝ → ℝ) (x : ℝ) : ℕ → ℝ :
 axiom erdos_1941_divergence (p q : ℕ) (hp : Odd p) (hq : Odd q)
     (hq_pos : 0 < q) :
     let x := Real.cos (p * Real.pi / q)
-    ∃ f : ℝ → ℝ, Continuous f ∧ (∀ x' ∈ Set.Icc (-1 : ℝ) 1, True) ∧
+    ∃ f : ℝ → ℝ, Continuous f ∧
       ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < chebyshevInterpSeq f x n
 
 /-- **The Erdős Conjecture (Problem #1151, [Va99, 2.41]):**

--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -42,7 +42,7 @@
       "Formal statement of the full conjecture with special cases derived"
     ],
     "axiomCount": 2,
-    "assumptions": "4 axioms: chebyshevNodes_injective, limitPointSet_isClosed, erdos_1941_divergence, erdos_1151_conjecture (the open problem).",
+    "assumptions": "2 axioms: erdos_1941_divergence (Erdős 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
     "lineCount": 184,
     "prerequisites": [
       "Polynomial interpolation (Lagrange basis)",
@@ -136,7 +136,7 @@
     ],
     "namespace": "Erdos1151",
     "lineCount": 184,
-    "axiomCount": 4,
+    "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 8
   }

--- a/src/data/research/problems/erdos-1151.json
+++ b/src/data/research/problems/erdos-1151.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-01-15T16:24:55.487Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Metadata audit and cleanup",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "AUDIT: Corrected stale metadata. File has 2 axioms (both justified), 0 sorries, 3 proved theorems. Well-formalized.",
+    "builtItems": [
+      "Fixed meta.json axiomCount from 4 to 2 (corrected stale data)",
+      "Cleaned vacuous clause from erdos_1941_divergence axiom statement",
+      "Updated assumptions description in meta.json"
+    ],
+    "insights": [
+      "Only 2 axioms (not 4 as metadata claimed): erdos_1941_divergence and erdos_1151_conjecture",
+      "chebyshevNodes_injective and limitPointSet_isClosed are fully proved theorems, not axioms",
+      "erdos_1941_divergence is a deep 1941 Erdős result (Ann. of Math.) - not eliminable from Mathlib",
+      "erdos_1151_conjecture is the main open problem - inherently an axiom",
+      "The formalization is well-structured: definitions, proved lemmas, and two justified axioms"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "erdos_1941_divergence could potentially be proved from a formalized version of the 1941 paper, but this is a deep analysis result",
+      "Could add more special cases derived from the main conjecture"
+    ],
     "markdown": "# Erdős #1151 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Fixed stale axiomCount in meta.json: was 4, actually 2
- `chebyshevNodes_injective` and `limitPointSet_isClosed` are proved theorems, not axioms
- Removed vacuous `∀ x' ∈ Set.Icc (-1 : ℝ) 1, True` clause from `erdos_1941_divergence` axiom
- Updated assumptions description to accurately list the 2 actual axioms

## Findings
- The 2 remaining axioms are both justified:
  - `erdos_1941_divergence`: Deep 1941 Erdős result (Ann. of Math.) — not eliminable from Mathlib
  - `erdos_1151_conjecture`: The main open problem
- The formalization is otherwise well-structured with 3 proved theorems and 0 sorries

## Status
**Outcome**: completed (metadata audit)
**Next Steps**: erdos_1941_divergence could be proved from a formalized version of the 1941 paper, but this is deep analysis work

🤖 Generated by researcher-7