### PR TITLE
fix(audit): correct axiom/line counts in buffons-needle-oq-01-oq-02

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
@@ -22,10 +22,10 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 5,
-    "theoremCount": 21,
+    "axiomCount": 4,
+    "theoremCount": 19,
     "defCount": 3,
-    "lineCount": 237,
+    "lineCount": 265,
     "mathlibDependencies": [
       {
         "theorem": "Real.Gamma",
@@ -67,7 +67,7 @@
       "Recurrence-derived values: c₅ = 2/3, c₆ = 3/π"
     ],
     "dateAdded": "2026-03-28",
-    "assumptions": "5 axiom(s): gamma_one_half (Γ(1/2)=√π, Gaussian integral), buffon_higher_dim (Cauchy-Crofton formula), buffonConstant_le_one (|cosine|≤1), buffonConstant_recurrence (sphere volume recurrence). No sorries.",
+    "assumptions": "4 axioms: gamma_one_half (Γ(1/2)=√π, Gaussian integral), buffon_higher_dim (Cauchy-Crofton formula), buffonConstant_le_one (c_n≤1 from |cosine|≤1), buffonConstant_recurrence (sphere volume recurrence). No sorries.",
     "prerequisites": [
       "The Gamma function and its functional equation",
       "Buffon's needle problem in 2D",


### PR DESCRIPTION
## Summary

- Fixed `axiomCount` from 5 to 4 (file has exactly 4 `axiom` declarations)
- Fixed `lineCount` from 237 to 265 (file was extended after initial metadata)
- Fixed `theoremCount` from 21 to 19 (actual count in Lean source)
- Fixed `assumptions` text from "5 axiom(s)" to "4 axioms"

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)