### PR TITLE
fix(audit): correct stale metadata in 4 gallery meta.json files

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
@@ -22,10 +22,10 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 5,
-    "theoremCount": 21,
+    "axiomCount": 4,
+    "theoremCount": 19,
     "defCount": 3,
-    "lineCount": 237,
+    "lineCount": 265,
     "mathlibDependencies": [
       {
         "theorem": "Real.Gamma",
@@ -67,7 +67,7 @@
       "Recurrence-derived values: c₅ = 2/3, c₆ = 3/π"
     ],
     "dateAdded": "2026-03-28",
-    "assumptions": "5 axiom(s): gamma_one_half (Γ(1/2)=√π, Gaussian integral), buffon_higher_dim (Cauchy-Crofton formula), buffonConstant_le_one (|cosine|≤1), buffonConstant_recurrence (sphere volume recurrence). No sorries.",
+    "assumptions": "4 axioms: gamma_one_half (Γ(1/2)=√π, Gaussian integral), buffonConstant_le_one (c_n ≤ 1), buffon_higher_dim (Cauchy-Crofton formula), buffonConstant_recurrence (sphere volume recurrence). No sorries.",
     "prerequisites": [
       "The Gamma function and its functional equation",
       "Buffon's needle problem in 2D",
@@ -174,9 +174,9 @@
       "Real"
     ],
     "namespace": "BuffonHigherDim",
-    "lineCount": 237,
-    "axiomCount": 5,
-    "theoremCount": 21,
+    "lineCount": 265,
+    "axiomCount": 4,
+    "theoremCount": 19,
     "definitionCount": 3
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-28",
     "axiomCount": 6,
-    "lineCount": 151,
+    "lineCount": 233,
     "assumptions": "6 axioms: ramseyNumber (definition), ramsey_monotone_right, ramsey_recurrence, ramsey_k2, ramsey_symm, R3_lower_bound. 2 sorries in conditional general-k rate theorem (growth ratio bound and 3-factor combination).",
     "mathlib_version": "4.26.0"
   },
@@ -125,9 +125,9 @@
       "Topology"
     ],
     "namespace": "Erdos1014OQ02",
-    "lineCount": 151,
+    "lineCount": 233,
     "axiomCount": 6,
-    "theoremCount": 7,
+    "theoremCount": 4,
     "definitionCount": 0,
     "substantiveTheoremCount": 4,
     "mainTheorems": [

--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 0,
     "erdosNumber": 1096,
     "erdosUrl": "https://erdosproblems.com/1096",
     "erdosProblemStatus": "open",
@@ -50,8 +50,8 @@
       "ejs_refinement axiom: for q < φ, only need m = 2"
     ],
     "axiomCount": 9,
-    "lineCount": 304,
-    "assumptions": "Nine axioms remain: qSequence (ordered enumeration), qSequence_initial (initial values), smallestPisot_minimal (Siegel theorem), pisot_no_gap_property (EJK 1990), gap_universal_bound (EJK 1990), bugeaud_characterization (Bugeaud 1996), ejs_refinement (EJS 1996), density_near_one (density result), qSequenceM (m-digit enumeration). Five axioms eliminated: IsPisot (now concrete def via polynomial roots), smallestPisot (now def via IVT for x^3-x-1=0), smallestPisot_value/smallestPisot_is_pisot/goldenRatio_is_pisot (now theorems with sorry).",
+    "lineCount": 438,
+    "assumptions": "Nine axioms remain: qSequence (ordered enumeration), qSequence_initial (initial values), smallestPisot_minimal (Siegel theorem), pisot_no_gap_property (EJK 1990), gap_universal_bound (EJK 1990), bugeaud_characterization (Bugeaud 1996), ejs_refinement (EJS 1996), density_near_one (density result), qSequenceM (m-digit enumeration). All 6 sorries proved (0 remaining). Five axioms eliminated: IsPisot (now concrete def via polynomial roots), smallestPisot (now def via IVT for x^3-x-1=0), smallestPisot_value/smallestPisot_is_pisot/goldenRatio_is_pisot (now proved theorems).",
     "theoremCount": 14,
     "definitionCount": 9
   },
@@ -165,10 +165,10 @@
       "Real"
     ],
     "namespace": "Erdos1096",
-    "lineCount": 304,
-    "axiomCount": 14,
-    "theoremCount": 5,
-    "definitionCount": 7
+    "lineCount": 438,
+    "axiomCount": 9,
+    "theoremCount": 14,
+    "definitionCount": 9
   },
   "crossReferences": [
     {

--- a/src/data/proofs/platonic-solids-oq-02/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02/meta.json
@@ -21,9 +21,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 22,
-    "defCount": 20,
-    "lineCount": 210,
+    "theoremCount": 21,
+    "defCount": 31,
+    "lineCount": 231,
     "mathlibDependencies": [
       {
         "theorem": "native_decide",
@@ -125,10 +125,10 @@
     ],
     "opens": [],
     "namespace": "ArchimedeanSolids",
-    "lineCount": 210,
+    "lineCount": 231,
     "axiomCount": 1,
-    "theoremCount": 22,
-    "definitionCount": 20
+    "theoremCount": 21,
+    "definitionCount": 31
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Correct stale lineCount, sorries, axiomCount, theoremCount, and defCount values in 4 gallery meta.json files.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| erdos-1096 | sorries | 6 | **0** (all proved) |
| erdos-1096 | lineCount | 304 | **438** |
| erdos-1096 | leanFile.axiomCount | 14 | **9** |
| erdos-1096 | leanFile.theoremCount | 5 | **14** |
| erdos-1096 | leanFile.definitionCount | 7 | **9** |
| erdos-1014-oq-02 | lineCount | 151 | **233** |
| erdos-1014-oq-02 | leanFile.theoremCount | 7 | **4** |
| buffons-needle-oq-01-oq-02 | lineCount | 237 | **265** |
| buffons-needle-oq-01-oq-02 | axiomCount | 5 | **4** |
| buffons-needle-oq-01-oq-02 | theoremCount | 21 | **19** |
| platonic-solids-oq-02 | lineCount | 210 | **231** |
| platonic-solids-oq-02 | theoremCount | 22 | **21** |
| platonic-solids-oq-02 | defCount | 20 | **31** |

All counts verified by `grep` against current Lean source files. JSON validated with `jq`.

---
Automated fix by lean-mechanic agent.