### PR TITLE
fix(audit): correct stale metadata in erdos-1096

### DIFF
--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 0,
     "erdosNumber": 1096,
     "erdosUrl": "https://erdosproblems.com/1096",
     "erdosProblemStatus": "open",
@@ -50,9 +50,9 @@
       "ejs_refinement axiom: for q < φ, only need m = 2"
     ],
     "axiomCount": 9,
-    "lineCount": 304,
-    "assumptions": "Nine axioms remain: qSequence (ordered enumeration), qSequence_initial (initial values), smallestPisot_minimal (Siegel theorem), pisot_no_gap_property (EJK 1990), gap_universal_bound (EJK 1990), bugeaud_characterization (Bugeaud 1996), ejs_refinement (EJS 1996), density_near_one (density result), qSequenceM (m-digit enumeration). Five axioms eliminated: IsPisot (now concrete def via polynomial roots), smallestPisot (now def via IVT for x^3-x-1=0), smallestPisot_value/smallestPisot_is_pisot/goldenRatio_is_pisot (now theorems with sorry).",
-    "theoremCount": 14,
+    "lineCount": 438,
+    "assumptions": "9 axioms: qSequence (ordered enumeration), qSequence_initial (initial values), smallestPisot_minimal (Siegel theorem), pisot_no_gap_property (EJK 1990), gap_universal_bound (EJK 1990), bugeaud_characterization (Bugeaud 1996), ejs_refinement (EJS 1996), density_near_one (density result), qSequenceM (m-digit enumeration). 0 sorries.",
+    "theoremCount": 13,
     "definitionCount": 9
   },
   "overview": {


### PR DESCRIPTION
## Summary

- Fixed `sorries` from 6 to 0 — all sorries were eliminated in a previous update but meta.json wasn't synced
- Fixed `lineCount` from 304 to 438 — file expanded significantly
- Fixed `theoremCount` from 14 to 13 — actual count in Lean source
- Cleaned up `assumptions` text — removed stale reference to "theorems with sorry"

**Severity**: HIGH (sorry count mismatch — file claims 6 sorries but has 0)

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)