### PR TITLE
fix: erdos-162 meta.json — sorry count 2→1

### DIFF
--- a/src/data/proofs/erdos-162/meta.json
+++ b/src/data/proofs/erdos-162/meta.json
@@ -16,18 +16,18 @@
       "graph-colouring"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 162,
     "erdosUrl": "https://erdosproblems.com/162",
     "erdosProblemStatus": "open",
     "dateAdded": "2025-01-01",
     "mathlib_version": "4.26.0",
     "axiomCount": 7,
-    "lineCount": 186,
-    "assumptions": "7 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "lineCount": 214,
+    "assumptions": "7 axiom(s) and 1 sorry (colourEdgeCount_total counting lemma). balanced_requires_le_half now fully proved via nlinarith."
   },
   "overview": {
-    "historicalContext": "Erdős posed this problem around 1990, asking for the precise asymptotic of F(n, α) — the largest k such that some 2-colouring of K_n has every induced subgraph on at least k vertices α-balanced (each colour appears on more than α fraction of edges). The problem sits at the intersection of Ramsey theory and discrepancy theory.\n\nThe probabilistic method readily establishes that F(n, α) = Θ(log n) for each fixed 0 < α ≤ 1/2: a random 2-colouring of K_n is α-balanced on all sets of size ≤ c₁ log n with positive probability (via Chernoff bounds and a union bound over subsets), while a Ramsey-type counting argument shows any colouring must have an imbalanced induced subgraph of size ≤ c₂ log n.\n\nThe conjecture goes beyond these order-of-magnitude bounds to assert that the ratio F(n, α)/log n converges to a definite limit c_α. Determining this constant as a function of α would give a precise quantitative understanding of how balanced large 2-colourings can be. The case α = 1/2 is extremal (requiring near-equal colour distribution) and is related to Problems #161, #163, and #617 on balanced colourings. The formalization at 187 lines includes 2 sorries for counting lemmas and computational verification examples.",
+    "historicalContext": "Erdős posed this problem around 1990, asking for the precise asymptotic of F(n, α) — the largest k such that some 2-colouring of K_n has every induced subgraph on at least k vertices α-balanced (each colour appears on more than α fraction of edges). The problem sits at the intersection of Ramsey theory and discrepancy theory.\n\nThe probabilistic method readily establishes that F(n, α) = Θ(log n) for each fixed 0 < α ≤ 1/2: a random 2-colouring of K_n is α-balanced on all sets of size ≤ c₁ log n with positive probability (via Chernoff bounds and a union bound over subsets), while a Ramsey-type counting argument shows any colouring must have an imbalanced induced subgraph of size ≤ c₂ log n.\n\nThe conjecture goes beyond these order-of-magnitude bounds to assert that the ratio F(n, α)/log n converges to a definite limit c_α. Determining this constant as a function of α would give a precise quantitative understanding of how balanced large 2-colourings can be. The case α = 1/2 is extremal (requiring near-equal colour distribution) and is related to Problems #161, #163, and #617 on balanced colourings. The formalization at 214 lines includes 1 sorry for a counting lemma (colourEdgeCount_total).",
     "problemStatement": "Prove that F(n, α) ~ c_α log n for some constant c_α depending on α.",
     "text": "For 0 < α ≤ 1/2, is F(n, α) ~ c_α log n, where F(n, α) is the largest k such that some 2-colouring of K_n has every k-vertex subgraph α-balanced?",
     "proofStrategy": "The formalization defines EdgeColouring as a symmetric Bool-valued function on pairs, IsBalancedOn requiring each colour class to exceed α · C(|S|,2) edges, and IsKBalanced for all subsets of size ≥ k. The function discrepancyF is axiomatized with characterization spec and monotonicity properties. Logarithmic bounds from the probabilistic method are stated. The main conjecture asserts ε-δ convergence of F(n,α)/log n to c_α.",
@@ -48,7 +48,7 @@
       "colourEdgeCount_total: total edges equals C(|S|,2) (sorry)",
       "IsBalancedOn: α-balanced colouring on vertex set S",
       "IsKBalanced: every subset of size ≥ k is α-balanced",
-      "balanced_requires_le_half: α > 1/2 makes balance impossible (sorry)",
+      "balanced_requires_le_half: α > 1/2 makes balance impossible (proved via nlinarith)",
       "discrepancyF: axiomatized F(n,α) with spec and monotonicity",
       "discrepancy_lower: c₁ log n lower bound from probabilistic method",
       "discrepancy_upper: c₂ log n upper bound from Ramsey counting",
@@ -107,7 +107,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 162 at 187 lines, defining edge 2-colourings, α-balanced subgraphs, the function F(n,α), and the convergence conjecture. The Θ(log n) sandwich is proved from axiomatized bounds. 2 sorries remain for counting lemmas.",
+    "summary": "The formalization captures Erdős Problem 162 at 214 lines, defining edge 2-colourings, α-balanced subgraphs, the function F(n,α), and the convergence conjecture. The Θ(log n) sandwich is proved from axiomatized bounds. 1 sorry remains for a counting lemma (colourEdgeCount_total).",
     "implications": "Determining c_α would give a precise quantitative understanding of how balanced large 2-colourings can be across all induced subgraphs, bridging Ramsey theory and discrepancy theory.",
     "openQuestions": [
       "Does the limit c_α = lim F(n,α)/log n exist for each α?",
@@ -123,7 +123,7 @@
     ],
     "opens": [],
     "namespace": "Erdos162",
-    "lineCount": 186,
+    "lineCount": 214,
     "axiomCount": 7,
     "theoremCount": 4,
     "definitionCount": 4


### PR DESCRIPTION
## Summary

- **erdos-162** meta.json sorry count was stale: `balanced_requires_le_half` is now fully proved
- Sorry count: `2` → `1` (only `colourEdgeCount_total` counting lemma remains)
- Line count: `186` → `214`
- Updated `originalContributions`, overview text, and conclusion to reflect 1 sorry

## Evidence

**meta.json claimed**: `"sorries": 2`
**Lean file shows**: 1 `sorry` occurrence (line 68, in `colourEdgeCount_total`)

`balanced_requires_le_half` (formerly a sorry) is now proved via `nlinarith` using `colourEdgeCount_total`.

## Test plan

- [x] JSON validates
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)