### PR TITLE
fix(audit): correct stale axiomCount in erdos-28 and erdos-83

### DIFF
--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/28",
     "erdosUrl": "https://erdosproblems.com/28",
     "proofRepoPath": "Proofs/Erdos28AdditiveBases.lean",
-    "axiomCount": 6,
+    "axiomCount": 2,
     "assumptions": "2 axioms: grekos_lower_bound (Grekos et al. 2003: r_A(n) ≥ 6 infinitely often), borwein_lower_bound (Borwein et al.: r_A(n) ≥ 8 infinitely often). sidon_not_basis PROVED as theorem (PR #6840). sidon_density_bound PROVED via bridge lemma importing Erdos340.sidon_upper_bound_weak. 14 theorems proved including isAsymptoticBasis_iff, sidon_repFunc_bounded, erdos_turan_holds_for_nat, basis_element_count_sq, sidon_density_bound.",
     "badge": "axiom",
     "prerequisites": [

--- a/src/data/proofs/erdos-83/meta.json
+++ b/src/data/proofs/erdos-83/meta.json
@@ -71,9 +71,9 @@
       "erdos_83_summary: both directions (bound + tightness)",
       "erdos_83: final theorem statement"
     ],
-    "axiomCount": 9,
+    "axiomCount": 7,
     "lineCount": 289,
-    "assumptions": "9 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "7 axioms: erdos_ko_rado_bound, ekr_achieved, starLikeFamily_achieves, starLikeFamily_valid, ahlswede_khachatrian_theorem, erdos83_from_ak, erdos83_bound_asymptotic. 3 sorry(s)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #83: The Complete Intersection Theorem**\n\nThis problem represents one of the most celebrated successes in extremal set theory, bridging a 36-year gap from conjecture to proof.\n\n**The Erdős-Ko-Rado Foundation (1961):** Erdős, Ko, and Rado proved that for $k$-subsets of $[n]$ with $n \\geq 2k$, the largest *intersecting* family (every pair shares $\\geq 1$ element) has size $\\binom{n-1}{k-1}$. This launched the field of extremal set theory. The 'star' family $\\{A : x \\in A\\}$ achieves this bound.\n\n**The $t$-Intersecting Conjecture:** EKR naturally asked: what about $t$-intersecting families ($|A \\cap B| \\geq t$)? For the specific case of $2n$-subsets of $[4n]$ with $t = 2$, they conjectured the bound $\\frac{1}{2}(\\binom{4n}{2n} - \\binom{2n}{n}^2)$. Erdős attached a **\\$500 prize** — one of his larger prizes, reflecting the difficulty.\n\n**36 Years of Partial Progress:** Wilson (1984) proved the result for $t$ sufficiently large relative to $k$. Frankl (1978) developed the 'shifting' technique, solving many special cases. But the general problem resisted all approaches.\n\n**The Breakthrough (1997):** Ahlswede and Khachatrian proved the **Complete Intersection Theorem**, which determines the maximum $t$-intersecting $k$-uniform family on $[m]$ for *all* valid parameters $(m, k, t)$. Their proof introduced the 'pushing-pulling' technique, a two-directional generalization of Frankl's shifting that preserves the $t$-intersecting property.\n\n**The Key Innovation:** Classical shifting (replacing element $j$ with element $i < j$ if the result stays in the family) preserves $1$-intersecting but can destroy $t$-intersecting for $t \\geq 2$. Ahlswede-Khachatrian's pushing-pulling modifies pairs of elements simultaneously, maintaining the stronger intersection requirement.\n\n**Phase Transitions:** A remarkable feature of the AK theorem is that the extremal family changes structure at critical parameter values. The optimal family $\\mathcal{A}(r)$ consists of all $k$-subsets with $\\geq t+r$ elements from a fixed $(t+2r)$-set, where $r$ depends on $(m, k, t)$. As parameters vary, $r$ jumps — a discrete phase transition.",
@@ -200,7 +200,7 @@
     ],
     "namespace": "Erdos83",
     "lineCount": 289,
-    "axiomCount": 9,
+    "axiomCount": 7,
     "theoremCount": 3,
     "definitionCount": 12
   },


### PR DESCRIPTION
## Fix

Correct stale axiomCount values in 2 gallery meta.json files where axioms were previously proved as theorems but the count was not updated.

## Evidence

| Proof | Field | Before | After | Reason |
|-------|-------|--------|-------|--------|
| erdos-28 | meta.axiomCount | 6 | **2** | 4 axioms proved as theorems (sidon_not_basis etc.) |
| erdos-83 | meta.axiomCount | 9 | **7** | Stale count; file has exactly 7 `axiom` declarations |
| erdos-83 | leanFile.axiomCount | 9 | **7** | Same |

All counts verified by `grep -c '^axiom '` against current Lean source. JSON validated with `jq`.

---
Automated fix by lean-mechanic agent.