### PR TITLE
fix: inverse-galois & inverse-galois-oq-01 axiom counts

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -25,13 +25,13 @@
     ],
     "badge": "formalized",
     "sorries": 1,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields, fixed fields)",
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",
       "Field extensions (finrank, tower law)"
     ],
-    "assumptions": "0 axioms declared in this file. 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. Transitive dependency axiom: InverseGaloisA5.lean (1 axiom: three_dvd_gal_card). AbelRuffiniOQ04OQ01.lean and AbelRuffiniGaloisExtensions.lean are axiom-free. Commutator theorem [S5,S5]=A5 fully proved.",
+    "assumptions": "1 axiom total (0 in main file, 1 transitive via InverseGaloisA5.lean: three_dvd_gal_card — Dedekind's theorem that 3 divides the Galois group order). 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. AbelRuffiniOQ04OQ01.lean and AbelRuffiniGaloisExtensions.lean are axiom-free. Commutator theorem [S5,S5]=A5 fully proved.",
     "leanFile": {
       "lineCount": 723,
       "theoremCount": 46,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -27,21 +27,21 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Cyclotomic fields and Kronecker-Weber theorem",
       "Group theory (symmetric and alternating groups, Sylow theorems, solvability)",
       "Algebraic number theory (Eisenstein criterion, Dedekind's theorem)"
     ],
-    "assumptions": "3 axiom declarations: abelian_realizable, shafarevich_theorem (InverseGalois.lean), three_dvd_gal_card (InverseGaloisA5.lean). 2 sorries: inverse_galois_problem (line 77, open problem), symmetric_group_realizable (line 364, Hilbert irreducibility). + inverse_galois_problem_open_conjecture (OPEN PROBLEM), symmetric_group_realizable (Hilbert irreducibility, not in Mathlib). 0 sorries.",
+    "assumptions": "5 axioms total across all files: inverse_galois_problem_open_conjecture (OPEN PROBLEM, line 73), abelian_realizable (Kronecker-Weber, line 293), shafarevich_theorem (solvable groups realizable, line 319), symmetric_group_realizable (Hilbert irreducibility, line 363) in InverseGalois.lean; three_dvd_gal_card (Dedekind's theorem) in InverseGaloisA5.lean. 0 sorries.",
     "leanFile": {
-      "lineCount": 1881,
+      "lineCount": 1882,
       "theoremCount": 107,
       "lemmaCount": 1,
       "defCount": 1,
-      "axiomCount": 2,
-      "sorryCount": 2,
+      "axiomCount": 4,
+      "sorryCount": 0,
       "imports": [
         "Mathlib.NumberTheory.Cyclotomic.Basic",
         "Mathlib.NumberTheory.Cyclotomic.Gal",


### PR DESCRIPTION
## Summary

- **inverse-galois-oq-01**: `axiomCount` `0`→`1` (transitive dependency: `three_dvd_gal_card` from InverseGaloisA5.lean)
- **inverse-galois**: `axiomCount` `4`→`5` (same transitive axiom), `leanFile.axiomCount` `2`→`4`, `leanFile.sorryCount` `2`→`0` (former sorries were converted to axiom declarations), `lineCount` `1881`→`1882`
- Fixed contradictory `assumptions` text in inverse-galois (said both "2 sorries" and "0 sorries")

## Evidence

**inverse-galois-oq-01**: Main file has 0 axioms, but imports InverseGaloisA5.lean which declares `axiom three_dvd_gal_card`. Per axiom integrity policy, total axiomCount should include transitive dependencies listed in `additionalFiles`.

**inverse-galois**: Main file has 4 axiom declarations (`inverse_galois_problem_open_conjecture`, `abelian_realizable`, `shafarevich_theorem`, `symmetric_group_realizable`). `leanFile.axiomCount` was 2 and `sorryCount` was 2 — the 2 "sorries" were actually converted to axiom declarations.

## Test plan

- [x] JSON validates for both files
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)