### PR TITLE
fix(audit): correct stale metadata in erdos-1014-oq-02 and platonic-solids-oq-02

### DIFF
--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-28",
     "axiomCount": 6,
-    "lineCount": 151,
+    "lineCount": 233,
     "assumptions": "6 axioms: ramseyNumber (definition), ramsey_monotone_right, ramsey_recurrence, ramsey_k2, ramsey_symm, R3_lower_bound. 2 sorries in conditional general-k rate theorem (growth ratio bound and 3-factor combination).",
     "mathlib_version": "4.26.0"
   },
@@ -125,9 +125,9 @@
       "Topology"
     ],
     "namespace": "Erdos1014OQ02",
-    "lineCount": 151,
+    "lineCount": 233,
     "axiomCount": 6,
-    "theoremCount": 7,
+    "theoremCount": 4,
     "definitionCount": 0,
     "substantiveTheoremCount": 4,
     "mainTheorems": [

--- a/src/data/proofs/platonic-solids-oq-02/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02/meta.json
@@ -21,9 +21,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 22,
-    "defCount": 20,
-    "lineCount": 210,
+    "theoremCount": 21,
+    "defCount": 31,
+    "lineCount": 231,
     "mathlibDependencies": [
       {
         "theorem": "native_decide",
@@ -125,10 +125,10 @@
     ],
     "opens": [],
     "namespace": "ArchimedeanSolids",
-    "lineCount": 210,
+    "lineCount": 231,
     "axiomCount": 1,
-    "theoremCount": 22,
-    "definitionCount": 20
+    "theoremCount": 21,
+    "definitionCount": 31
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Correct stale lineCount, theoremCount, and defCount in 2 gallery meta.json files. (Replacement for #7558 which had merge conflicts after erdos-1096 and buffons-needle fixes were merged separately.)

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| erdos-1014-oq-02 | lineCount | 151 | **233** |
| erdos-1014-oq-02 | leanFile.theoremCount | 7 | **4** |
| platonic-solids-oq-02 | lineCount | 210 | **231** |
| platonic-solids-oq-02 | theoremCount | 22 | **21** |
| platonic-solids-oq-02 | defCount | 20 | **31** |

All counts verified by `wc -l` and `grep` against current Lean source. JSON validated with `jq`.

---
Automated fix by lean-mechanic agent.