### PR TITLE
fix(audit): restore 2 corrupted entries + badge fix

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
@@ -17,10 +17,10 @@
       "certified-computation",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 196,
+    "lineCount": 189,
     "assumptions": "None.",
     "originalContributions": [
       "Reusable reduce_step, extract_two_step, reciprocity_step lemmas",
@@ -44,7 +44,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "JacobiCertifiedComputation",
-    "lineCount": 196,
+    "lineCount": 189,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 3

--- a/src/data/proofs/erdos-1005/meta.json
+++ b/src/data/proofs/erdos-1005/meta.json
@@ -7,7 +7,7 @@
     "author": "van Doorn (2025)",
     "sourceUrl": "https://erdosproblems.com/1005",
     "date": "2025",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1005Problem.lean",
     "tags": [
       "number-theory",
@@ -16,15 +16,15 @@
       "asymptotic-analysis",
       "combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1005,
     "erdosUrl": "https://erdosproblems.com/1005",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 0,
-    "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
+    "axiomCount": 4,
+    "lineCount": 118,
+    "assumptions": "4 axioms: longestSimilarRun (function definition), longestSimilarRun_lower (van Doorn 2025 lower bound), longestSimilarRun_upper (van Doorn 2025 upper bound), erdos_1005_conjecture (open conjecture c=1/4). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Lovász (1968)",
     "sourceUrl": "https://erdosproblems.com/1022",
     "date": "1971",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1022Problem.lean",
     "tags": [
       "combinatorics",
@@ -16,15 +16,15 @@
       "property-b",
       "set-families"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1022,
     "erdosUrl": "https://erdosproblems.com/1022",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 0,
-    "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
+    "axiomCount": 1,
+    "lineCount": 103,
+    "assumptions": "1 axiom: erdos_1022_conjecture (open conjecture: c_t → ∞ threshold for property B). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- **erdos-1005**: Lean file restored from corruption. Status `pending`→`axiomatized`, badge `wip`→`axiom`, axiomCount `0`→`4`, lineCount `0`→`118`
- **erdos-1022**: Lean file restored from corruption. Status `pending`→`axiomatized`, badge `wip`→`axiom`, axiomCount `0`→`1`, lineCount `0`→`103`
- **elementary-quadratic-reciprocity-oq-03-oq-01-oq-02**: Badge `verified`→`mathlib` (thin Mathlib jacobiSym wrappers assembled into computation chains), lineCount `196`→`189`

## Test plan

- [x] All JSON validates
- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit (iteration 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)