### PR TITLE
fix(audit): correct stale lineCount in erdos-465 and eq-reciprocity-oq-03-oq-01

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01/meta.json
@@ -8,7 +8,7 @@
   "badge": "mathlib",
   "difficulty": "intermediate",
   "leanFile": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01.lean",
-  "lineCount": 252,
+  "lineCount": 311,
   "theoremCount": 22,
   "axiomCount": 0,
   "sorryCount": 0,

--- a/src/data/proofs/erdos-465/meta.json
+++ b/src/data/proofs/erdos-465/meta.json
@@ -87,7 +87,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 231,
+    "lineCount": 270,
     "assumptions": "3 axioms: sarkozy_1976, konyagin_2001, problem_466_lower_bound. Structure fields are object definitions, not assumptions."
   },
   "overview": {
@@ -184,7 +184,7 @@
       "Real"
     ],
     "namespace": "Erdos465",
-    "lineCount": 231,
+    "lineCount": 270,
     "axiomCount": 15,
     "theoremCount": 7,
     "definitionCount": 11


### PR DESCRIPTION
## Fix

Corrects stale lineCount metadata in two gallery entries after recent research expanded the Lean files.

## Evidence

**erdos-465**:
- Before: lineCount = 231
- After: lineCount = 270 (actual `wc -l` of Erdos465Problem.lean)
- Both `meta.lineCount` and `leanFile.lineCount` updated

**elementary-quadratic-reciprocity-oq-03-oq-01**:
- Before: top-level lineCount = 252 (inner meta.lineCount was already 311)
- After: top-level lineCount = 311 (matches actual `wc -l` of file)

---
Automated fix by lean-mechanic agent.