### PR TITLE
fix(audit): batch metadata corrections for 9 gallery entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9433,6 +9433,90 @@
       "lastAudited": "2026-03-28T15:50:21Z",
       "result": "clean",
       "issues": []
+    },
+    "buffons-needle-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:23:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:25:13Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:26:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:27:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:28:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:28:51Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:29:52Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "fourier-series-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:30:52Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "isoperimetric-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:31:51Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "platonic-solids-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:33:19Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "solution-of-cubic-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:33:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "solution-of-cubic-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:35:17Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "solution-of-cubic-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:35:17Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "wolstenholme-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T20:35:17Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
     "tags": [
       "linear-algebra",
@@ -18,7 +18,7 @@
       "haar-measure",
       "research"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -163,7 +163,7 @@
     ]
   },
   "sorryCount": 0,
-  "status": "formalized",
+  "status": "verified",
   "badge": "verified",
   "leanFile": {
     "imports": [
@@ -178,7 +178,7 @@
     "namespace": "CyclicVectorMeasure",
     "lineCount": 270,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 3
   },
   "crossReferences": [

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
@@ -46,8 +46,8 @@
     "namespace": "JacobiCertifiedComputation",
     "lineCount": 189,
     "axiomCount": 0,
-    "theoremCount": 16,
-    "definitionCount": 3
+    "theoremCount": 18,
+    "definitionCount": 2
   },
   "crossReferences": [
     {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -1,1 +1,58 @@
-{"id":"elementary-quadratic-reciprocity-oq-03-oq-02","title":"The Kronecker Symbol: Extending Jacobi to All Integers","slug":"elementary-quadratic-reciprocity-oq-03-oq-02","description":"Defines the Kronecker symbol extending the Jacobi symbol to even moduli, negative integers, and zero. Proves values at special arguments, agreement with Jacobi for odd positive moduli, and states multiplicativity and generalized quadratic reciprocity.","meta":{"author":"Kronecker (1885); formalized here","date":"1885","status":"axiomatized","proofRepoPath":"Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean","tags":["number-theory","quadratic-reciprocity","kronecker-symbol","jacobi-symbol","research"],"badge":"axiom","sorries":0,"axiomCount":3,"theoremCount":14,"defCount":4,"lineCount":175,"dateAdded":"2026-03-28","assumptions":"3 axioms: kronecker_mul_left, kronecker_mul_right (multiplicativity), kronecker_reciprocity (generalized QR). No sorries.","mathlib_version":"4.26.0"},"overview":{"historicalContext":"Leopold Kronecker extended the Jacobi symbol in 1885 to handle all integer arguments, creating a symbol fundamental to algebraic number theory, Dirichlet L-functions, and modular forms.","problemStatement":"Define the Kronecker symbol (a/n) for all integers a,n and prove its basic properties.","text":"Formalizes the Kronecker symbol extension of the Jacobi symbol."},"sections":[],"conclusion":{"summary":"The Kronecker symbol provides a uniform framework for quadratic characters over all integers.","openQuestions":["Prove multiplicativity from the definition","Formalize connection to Dirichlet characters"]},"leanFile":{"imports":["Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"],"namespace":"KroneckerSymbol","lineCount":175,"axiomCount":3,"theoremCount":14,"definitionCount":4},"crossReferences":[{"targetId":"elementary-quadratic-reciprocity-oq-03","relationship":"extends","description":"Extends the Jacobi symbol formalization to the Kronecker symbol for all integers"}]}
+{
+  "id": "elementary-quadratic-reciprocity-oq-03-oq-02",
+  "title": "The Kronecker Symbol: Extending Jacobi to All Integers",
+  "slug": "elementary-quadratic-reciprocity-oq-03-oq-02",
+  "description": "Defines the Kronecker symbol extending the Jacobi symbol to even moduli, negative integers, and zero. Proves values at special arguments, agreement with Jacobi for odd positive moduli, and states multiplicativity and generalized quadratic reciprocity.",
+  "meta": {
+    "author": "Kronecker (1885); formalized here",
+    "date": "1885",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "kronecker-symbol",
+      "jacobi-symbol",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "theoremCount": 13,
+    "defCount": 4,
+    "lineCount": 175,
+    "dateAdded": "2026-03-28",
+    "assumptions": "3 axioms: kronecker_mul_left, kronecker_mul_right (multiplicativity), kronecker_reciprocity (generalized QR). No sorries.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Leopold Kronecker extended the Jacobi symbol in 1885 to handle all integer arguments, creating a symbol fundamental to algebraic number theory, Dirichlet L-functions, and modular forms.",
+    "problemStatement": "Define the Kronecker symbol (a/n) for all integers a,n and prove its basic properties.",
+    "text": "Formalizes the Kronecker symbol extension of the Jacobi symbol."
+  },
+  "sections": [],
+  "conclusion": {
+    "summary": "The Kronecker symbol provides a uniform framework for quadratic characters over all integers.",
+    "openQuestions": [
+      "Prove multiplicativity from the definition",
+      "Formalize connection to Dirichlet characters"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+    ],
+    "namespace": "KroneckerSymbol",
+    "lineCount": 175,
+    "axiomCount": 3,
+    "theoremCount": 13,
+    "definitionCount": 4
+  },
+  "crossReferences": [
+    {
+      "targetId": "elementary-quadratic-reciprocity-oq-03",
+      "relationship": "extends",
+      "description": "Extends the Jacobi symbol formalization to the Kronecker symbol for all integers"
+    }
+  ]
+}

--- a/src/data/proofs/fourier-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03/meta.json
@@ -12,8 +12,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "theoremCount": 8,
-    "defCount": 4,
+    "theoremCount": 6,
+    "defCount": 3,
     "lineCount": 147,
     "dateAdded": "2026-03-28",
     "assumptions": "2 axioms: sharp_constant_is_half (extremal family existence), lipschitz_sawtooth_extremal (sawtooth achieves bound). No sorries.",
@@ -36,6 +36,6 @@
     "summary": "The constant 1/2 in the Fourier-Hölder decay bound is sharp.",
     "openQuestions": ["Compute the sharp constant for the Sobolev embedding converse", "Sharp constants for analytic (exponential) decay bounds"]
   },
-  "leanFile": {"imports": ["Mathlib.Analysis.Fourier.AddCircle", "Mathlib.Topology.MetricSpace.Holder"], "namespace": "FourierSharpConstant", "lineCount": 147, "axiomCount": 2, "theoremCount": 8, "definitionCount": 4},
+  "leanFile": {"imports": ["Mathlib.Analysis.Fourier.AddCircle", "Mathlib.Topology.MetricSpace.Holder"], "namespace": "FourierSharpConstant", "lineCount": 147, "axiomCount": 2, "theoremCount": 6, "definitionCount": 3},
   "crossReferences": [{"targetId": "fourier-series-oq-02", "relationship": "extends", "description": "Investigates sharpness of the decay bound proved in the parent OQ-02"}]
 }

--- a/src/data/proofs/isoperimetric-theorem-oq-01/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01/meta.json
@@ -139,7 +139,7 @@
     "lineCount": 392,
     "axiomCount": 4,
     "theoremCount": 15,
-    "definitionCount": 14
+    "definitionCount": 13
   },
   "crossReferences": [
     {

--- a/src/data/proofs/platonic-solids-oq-02/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02/meta.json
@@ -21,8 +21,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 22,
-    "defCount": 20,
+    "theoremCount": 21,
+    "defCount": 31,
     "lineCount": 231,
     "mathlibDependencies": [
       {
@@ -41,7 +41,7 @@
       "Soccer ball (truncated icosahedron) identified as Archimedean"
     ],
     "dateAdded": "2026-03-28",
-    "assumptions": "1 axiom: archimedean_classification (full classification requires geometric realizability beyond combinatorics). No sorries.",
+    "assumptions": "1 axiom: archimedean_classification — currently a True-stub placeholder (asserts ∀ vt, True). The full classification statement requires geometric definitions not yet formalized. Effective assumption count is 0; all 21 proved theorems are genuine. No sorries.",
     "prerequisites": [
       "Euler's polyhedral formula V - E + F = 2",
       "Interior angles of regular polygons",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-02/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-02/meta.json
@@ -13,8 +13,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "theoremCount": 13,
-    "defCount": 8,
+    "theoremCount": 11,
+    "defCount": 7,
     "lineCount": 199,
     "dateAdded": "2026-03-28",
     "assumptions": "3 axioms: trigRoots_distinct (cosine injectivity), trigRoot_is_root (triple angle identity), wantzel_casus_irreducibilis (Galois theory). No sorries.",
@@ -39,6 +39,6 @@
     "summary": "The casus irreducibilis demonstrates that complex numbers are not just a convenience but a necessity: some real polynomial equations with entirely real roots cannot be solved without passing through the complex numbers.",
     "openQuestions": ["Formalize Wantzel's theorem using Lean's Galois theory infrastructure", "Extend to quartics: when does the quartic casus irreducibilis occur?"]
   },
-  "leanFile": {"imports": ["Mathlib.Analysis.SpecialFunctions.Pow.Complex", "Mathlib.Data.Complex.Basic"], "namespace": "CasusIrreducibilis", "lineCount": 199, "axiomCount": 3, "theoremCount": 13, "definitionCount": 8},
+  "leanFile": {"imports": ["Mathlib.Analysis.SpecialFunctions.Pow.Complex", "Mathlib.Data.Complex.Basic"], "namespace": "CasusIrreducibilis", "lineCount": 199, "axiomCount": 3, "theoremCount": 11, "definitionCount": 7},
   "crossReferences": [{"targetId": "solution-of-cubic", "relationship": "extends", "description": "The casus irreducibilis is a fundamental limitation of Cardano's cubic formula from the parent proof"}]
 }

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
@@ -9,7 +9,7 @@
   "difficulty": "intermediate",
   "leanFile": "Proofs/SolutionOfCubicOQ03OQ03.lean",
   "lineCount": 262,
-  "theoremCount": 9,
+  "theoremCount": 8,
   "axiomCount": 0,
   "sorryCount": 0,
   "assumptions": [],

--- a/src/data/proofs/wolstenholme-theorem-oq-01/meta.json
+++ b/src/data/proofs/wolstenholme-theorem-oq-01/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 4,
-    "theoremCount": 23,
+    "theoremCount": 22,
     "defCount": 6,
     "lineCount": 248,
     "mathlibDependencies": [
@@ -183,7 +183,7 @@
     "namespace": "WolstenholmeInfinitude",
     "lineCount": 248,
     "axiomCount": 4,
-    "theoremCount": 23,
+    "theoremCount": 22,
     "definitionCount": 6
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

- Audited 14 new gallery proofs, found and fixed metadata discrepancies in 9 entries
- Most common issue: theorem/definition counts off by 1-3 from actual Lean source
- One status upgrade: `cayley-hamilton-minpoly-oq-05-oq-01-oq-02` promoted from `formalized/wip` to `verified/verified` (0 sorries, 0 axioms confirmed)
- One True-stub axiom flagged: `platonic-solids-oq-02` has an axiom asserting `∀ vt, True` (placeholder for classification theorem)
- Gallery now fully audited: **1584/1584 proofs, 0 critical issues**

## Entries Fixed

| Entry | Fix |
|-------|-----|
| cayley-hamilton-minpoly-oq-05-oq-01-oq-02 | status/badge upgrade, theoremCount 7→8 |
| elementary-quadratic-reciprocity-oq-03-oq-01-oq-02 | theoremCount 16→18, defCount 3→2 |
| elementary-quadratic-reciprocity-oq-03-oq-02 | theoremCount 14→13 |
| fourier-series-oq-02-oq-03 | theoremCount 8→6, defCount 4→3 |
| isoperimetric-theorem-oq-01 | definitionCount 14→13 |
| platonic-solids-oq-02 | theoremCount 22→21, defCount 20→31, True-stub note |
| solution-of-cubic-oq-03-oq-02 | theoremCount 13→11, defCount 8→7 |
| solution-of-cubic-oq-03-oq-03 | theoremCount 9→8 |
| wolstenholme-theorem-oq-01 | theoremCount 23→22 |

## Test plan

- [ ] `pnpm build` passes (meta.json schema validation)
- [ ] No broken gallery pages for modified entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)