### PR TITLE
fix(audit): correct stale lineCount in cayley-hamilton-minpoly-oq-05-oq-01-oq-03

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -80,7 +80,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 262,
+    "lineCount": 292,
     "assumptions": "3 sorry(s) remain: orbit dimension bound, finite-dim bridge, structure theorem characterization.",
     "mathlib_version": "4.26.0"
   },
@@ -185,7 +185,7 @@
     "imports": ["Mathlib"],
     "opens": ["Polynomial"],
     "namespace": "NonderogatoryModule",
-    "lineCount": 262,
+    "lineCount": 292,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 6


### PR DESCRIPTION
## Fix

Corrects stale lineCount metadata after recent research expanded the Lean file.

## Evidence

**cayley-hamilton-minpoly-oq-05-oq-01-oq-03**:
- Before: lineCount = 262
- After: lineCount = 292 (actual `wc -l` of CayleyHamiltonMinpolyOQ05OQ01OQ03.lean)
- Both `meta.lineCount` and `leanFile.lineCount` updated

---
Automated fix by lean-mechanic agent.