### PR TITLE
fix(metadata): correct dissection-of-cubes-oq-01 status to axiomatized

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Littlewood / formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Squaring_the_square",
     "date": "1953",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DissectionOfCubesOQ01.lean",
     "tags": [
       "geometry",
@@ -17,7 +17,7 @@
       "open-problem",
       "wiedijk-100"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -52,7 +52,7 @@
       "Floor argument commentary: why Littlewood's cascade forces many collisions in practice"
     ],
     "dateAdded": "2026-02-23",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 274,
     "assumptions": "2 axioms (inherited from DissectionOfCubes.lean): axioms for 3D geometric properties used in the descent argument. This file has 0 direct axioms and 0 sorries, but all theorems depend transitively on the parent file's 2 axioms. Note: the covering constraint (covers_unit_cube) is a placeholder (covers_unit_cube : True), so results technically apply to disjoint cube arrangements, not necessarily actual dissections of the unit cube."
   },
@@ -140,7 +140,7 @@
     ],
     "namespace": "DissectionOfCubesOQ01",
     "lineCount": 274,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Fix

Correct dissection-of-cubes-oq-01 metadata from `verified` to `axiomatized`. The proof imports `DissectionOfCubes.lean` which contains 2 `axiom` declarations (`smaller_cube_above_axiom`, `all_different_implies_long_chains_axiom`).

## Evidence

**Before**: `status: "verified"`, `badge: "mathlib"`, `axiomCount: 0`
**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2`

The `assumptions` text already acknowledged this: "2 axioms (inherited from DissectionOfCubes.lean)".

---
Automated fix by lean-mechanic agent.