### PR TITLE
fix(audit): correct metadata for 4 gallery entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -752,9 +752,9 @@
       "issues": []
     },
     "erdos-131": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T15:41:48Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-03-28T21:27:33Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-402": {
@@ -9515,6 +9515,36 @@
     "wolstenholme-theorem-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-03-28T20:35:17Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T21:25:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T21:25:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T21:26:29Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T21:26:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "solution-of-cubic-oq-03-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T21:27:29Z",
       "result": "issues-fixed",
       "issues": []
     }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -79,7 +79,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 235,
+    "lineCount": 274,
     "assumptions": "Build verification pending (Docker unavailable).",
     "mathlib_version": "4.26.0"
   },
@@ -163,7 +163,7 @@
       "Polynomial"
     ],
     "namespace": "NonderogatoryModule",
-    "lineCount": 235,
+    "lineCount": 274,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 7

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -17,10 +17,10 @@
       "finite-fields",
       "module-theory"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 5,
     "axiomCount": 0,
-    "lineCount": 183,
+    "lineCount": 262,
     "assumptions": "0 axioms. 5 sorries: F_2 counterexample (decidable), annPoly definition, annPoly_dvd_minpoly, cyclic_iff_ann_eq_minpoly, main theorem (needs PID structure theorem).",
     "mathlib_version": "4.26.0"
   },
@@ -73,7 +73,7 @@
     "imports": ["Mathlib"],
     "opens": ["Matrix", "Polynomial"],
     "namespace": "NonderogatoryGeneral",
-    "lineCount": 183,
+    "lineCount": 262,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 3

--- a/src/data/proofs/erdos-131/meta.json
+++ b/src/data/proofs/erdos-131/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1975)",
     "sourceUrl": "https://erdosproblems.com/131",
     "date": "1975",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos131Problem.lean",
     "tags": [
       "erdos",
@@ -17,8 +17,8 @@
       "non-averaging-sets",
       "open-problem"
     ],
-    "badge": "mathlib",
-    "sorries": 4,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 131,
     "erdosUrl": "https://erdosproblems.com/131",
     "erdosProblemStatus": "open",
@@ -65,9 +65,9 @@
       "erdos_131_open_question: formal statement of remaining open problem"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 0,
-    "lineCount": 477,
-    "assumptions": "5 sorry(s). No axioms.",
+    "axiomCount": 4,
+    "lineCount": 565,
+    "assumptions": "0 sorries. 4 axiom declarations: elrss_upper_bound (ELRSS 1999 upper bound), pham_zakharov_upper_bound (Pham-Zakharov 2024 upper bound), csaba_lower_bound (Csaba polynomial lower bound), straus_lower_bound (Straus subexponential lower bound).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -173,9 +173,9 @@
       "Classical"
     ],
     "namespace": "Erdos131",
-    "lineCount": 569,
-    "axiomCount": 0,
-    "theoremCount": 29,
+    "lineCount": 565,
+    "axiomCount": 4,
+    "theoremCount": 26,
     "definitionCount": 6
   },
   "crossReferences": [

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
@@ -7,14 +7,14 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vieta%27s_formulas",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SolutionOfCubicOQ03OQ05.lean",
     "tags": ["algebra", "polynomials", "cubic-equations", "vieta-formulas", "symmetric-polynomials", "research"],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-03-28",
     "axiomCount": 0,
-    "lineCount": 120,
+    "lineCount": 112,
     "relatedProblems": [
       {"id": "solution-of-cubic-oq-03", "relationship": "Parent: Vieta's for depressed cubic"},
       {"id": "solution-of-cubic", "relationship": "Root: solution of the cubic equation"}
@@ -25,13 +25,13 @@
     "proofStrategy": "Expand (x-r₁)(x-r₂)(x-r₃) via ring, then extract coefficients at each degree to obtain the three Vieta relations."
   },
   "sorryCount": 0,
-  "status": "formalized",
-  "badge": "verified",
+  "status": "verified",
+  "badge": "original",
   "leanFile": {
     "imports": ["Mathlib"],
     "opens": [],
     "namespace": "VietaCubic",
-    "lineCount": 120,
+    "lineCount": 112,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0


### PR DESCRIPTION
## Summary

- **erdos-131** (CRITICAL): axiomCount 0→4 (has 4 axiom declarations), sorries 4→0 (all theorems proved), status formalized→axiomatized, badge mathlib→axiom, lineCount 477→565
- **cayley-hamilton-minpoly-oq-05-oq-01-oq-03**: lineCount 235→274
- **cayley-hamilton-minpoly-oq-05-oq-01-oq-04**: badge axiom→wip (0 axioms, 5 sorries), lineCount 183→262
- **solution-of-cubic-oq-03-oq-05**: status formalized→verified, badge wip→original (0 sorries, 0 axioms), lineCount 120→112

## Test plan

- [ ] `pnpm build` passes with corrected metadata
- [ ] Verify corrected counts match Lean source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)