### PR TITLE
fix(metadata): correct axiomCount for yang-mills variant entries

### DIFF
--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "wip",
     "sorries": 47,
-    "axiomCount": 0,
-    "assumptions": "Structure-encoded assumptions: TwoDPartitionFunction requires representation decomposition and Casimir values. MigdalFormula encodes the exact Wilson loop expectation. SU(2)/SU(3) Casimir values are computed from representation theory. The 2D theory is exactly solvable — all results follow from these structures.",
+    "axiomCount": 1,
+    "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TwoDPartitionFunction requires representation decomposition and Casimir values. MigdalFormula encodes the exact Wilson loop expectation. SU(2)/SU(3) Casimir values are computed from representation theory. The 2D theory is exactly solvable — all results follow from these structures.",
     "lineCount": 28025,
     "mathlibDependencies": [
       {
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28001,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1786,
     "lemmaCount": 0,
     "defCount": 251,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -17,8 +17,8 @@
     ],
     "badge": "wip",
     "sorries": 58,
-    "axiomCount": 0,
-    "assumptions": "Structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
+    "axiomCount": 1,
+    "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
     "lineCount": 28001,
     "mathlibDependencies": [
       {
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28001,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1786,
     "lemmaCount": 0,
     "defCount": 251,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "wip",
     "sorries": 58,
-    "axiomCount": 0,
-    "assumptions": "Structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
+    "axiomCount": 1,
+    "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
     "lineCount": 28001,
     "mathlibDependencies": [
       {
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28001,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1786,
     "lemmaCount": 0,
     "defCount": 251,


### PR DESCRIPTION
## Fix

Correct axiomCount from 0 to 1 for three yang-mills variant entries (yang-mills-2d, yang-mills-lattice, yang-mills-transfer-matrix). All three share `Proofs/YangMills/Exploration.lean` which imports `Classical.lean` containing 1 explicit `axiom` declaration (`gaugeTransform`).

## Evidence

**Before**: `axiomCount: 0` in all three entries
**After**: `axiomCount: 1` in all three entries

Status was already correctly `formalized`. These entries share the same Lean file and the same root cause.

---
Automated fix by lean-mechanic agent.