### PR TITLE
fix(audit): correct metadata for 3 gallery entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9525,9 +9525,9 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-28T21:25:54Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-28T21:51:07Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04": {
@@ -9546,6 +9546,18 @@
       "auditCount": 1,
       "lastAudited": "2026-03-28T21:27:29Z",
       "result": "issues-fixed",
+      "issues": []
+    },
+    "descartes-rule-of-signs-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T21:50:41Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fair-games-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T21:51:05Z",
+      "result": "clean",
       "issues": []
     }
   },

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cyclic_module",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
     "tags": [
       "linear-algebra",
@@ -18,8 +18,8 @@
       "infinite-dimensional",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.aeval",
@@ -79,8 +79,8 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 274,
-    "assumptions": "None. 0 axioms, 0 sorries. All 19 theorems fully proved from Mathlib. Build verification pending.",
+    "lineCount": 305,
+    "assumptions": "3 sorries: cyclicSubspace_le_minpoly_degree (orbit bound via induction), matrix_nonderogatory_implies_module (defers to OQ05OQ01), structure_theorem_cyclic_iff (needs PID structure theorem).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -152,9 +152,9 @@
       "Connect the annihilator ideal to the spectrum of T in the infinite-dimensional case"
     ]
   },
-  "sorryCount": 0,
-  "status": "verified",
-  "badge": "verified",
+  "sorryCount": 3,
+  "status": "formalized",
+  "badge": "wip",
   "leanFile": {
     "imports": [
       "Mathlib"
@@ -163,9 +163,9 @@
       "Polynomial"
     ],
     "namespace": "NonderogatoryModule",
-    "lineCount": 274,
+    "lineCount": 305,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 19,
     "definitionCount": 7
   },
   "crossReferences": [

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -17,7 +17,7 @@
       "finite-fields",
       "module-theory"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 5,
     "axiomCount": 0,
     "lineCount": 183,

--- a/src/data/proofs/fair-games-theorem-oq-02/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02/meta.json
@@ -12,7 +12,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 145,
+    "lineCount": 159,
     "assumptions": "No axioms. Fully verified.",
     "mathlib_version": "4.26.0"
   },
@@ -20,7 +20,7 @@
     "imports": ["Mathlib"],
     "opens": ["FairGamesOQ01"],
     "namespace": "FairGamesOQ02",
-    "lineCount": 145,
+    "lineCount": 159,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 5


### PR DESCRIPTION
## Summary

- **cayley-hamilton-minpoly-oq-05-oq-01-oq-03** (CRITICAL): status verified→formalized, badge verified→wip, sorries 0→3. File was extended with 3 new sorry-bearing theorems after enrichment upgraded status to "verified". Catches overclaim before deployment.
- **cayley-hamilton-minpoly-oq-05-oq-01-oq-04**: badge axiom→wip (has 0 axioms and 5 sorries, badge was wrong type)
- **fair-games-theorem-oq-02**: lineCount 145→159

## Test plan

- [ ] `pnpm build` passes with corrected metadata
- [ ] Verify sorry counts match `grep -c sorry` in Lean source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)