### PR TITLE
fix(metadata): correct erdos-260 sorry and axiom counts

### DIFF
--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 5,
     "erdosNumber": 260,
     "erdosUrl": "https://erdosproblems.com/260",
     "erdosProblemStatus": "open",
@@ -49,9 +49,9 @@
       "Stated the main conjecture: fast growth alone implies irrationality",
       "Proved convergence of the series under fast growth"
     ],
-    "axiomCount": 6,
+    "axiomCount": 1,
     "lineCount": 203,
-    "assumptions": "6 axioms: erdos_260_conjecture (open), series_converges (standard analysis), irrational_of_gaps_to_infinity (Erdős 1974), irrational_of_superlogarithmic (number theory), fastGrowth_of_gapsToInfinity (Stolz-Cesàro), fastGrowth_of_superlogarithmic (basic analysis). 0 sorries."
+    "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 5 sorries: series_converges, irrational_of_gaps_to_infinity, irrational_of_superlogarithmic, fastGrowth_of_gapsToInfinity, fastGrowth_of_superlogarithmic."
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1974 work on irrationality of series [Er74b], further developed in the landmark monograph 'Old and New Problems and Results in Combinatorial Number Theory' with Graham [ErGr80]. It explores a fundamental question at the boundary of analysis and number theory: when does a lacunary (sparse) series produce an irrational sum?\n\nErdős proved that irrationality holds under the stronger condition that the gaps a_{n+1} − aₙ tend to infinity. He also showed irrationality when aₙ grows superlogarithmically, specifically when aₙ ≫ n√(log n · log log n). These partial results demonstrate that 'sufficiently fast' growth guarantees irrationality, but the full conjecture — that the mere condition aₙ/n → ∞ suffices — remains open.\n\nThe problem has an appealing simplicity: the series ∑ aₙ/2^{aₙ} converges absolutely for any increasing sequence (the terms decrease exponentially), so the question is purely about the arithmetic nature of the limit. Erdős and Graham speculated that even having limsup of the gaps being infinite might not suffice for irrationality, but no counterexample has been found. The problem connects to the theory of lacunary series, normal numbers, and the Lindemann-Weierstrass theorem.",
@@ -162,7 +162,7 @@
     ],
     "namespace": "Erdos260",
     "lineCount": 203,
-    "axiomCount": 6,
+    "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 8
   },


### PR DESCRIPTION
## Fix

Correct erdos-260 meta.json: sorry count 0→5, axiom count 6→1. The 5 sorry'd theorems were being miscounted as axioms.

## Evidence

**Before**: `"sorries": 0, "axiomCount": 6` — incorrectly counted sorry'd theorems as axioms
**After**: `"sorries": 5, "axiomCount": 1` — matches actual Lean source (5 sorry tactic uses, 1 `axiom` declaration)

---
Automated fix by lean-mechanic agent.