### PR TITLE
fix(audit): correct sorry/axiom counts for 4 gallery entries

### DIFF
--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 5,
     "erdosNumber": 260,
     "erdosUrl": "https://erdosproblems.com/260",
     "erdosProblemStatus": "open",
@@ -49,9 +49,9 @@
       "Stated the main conjecture: fast growth alone implies irrationality",
       "Proved convergence of the series under fast growth"
     ],
-    "axiomCount": 6,
+    "axiomCount": 1,
     "lineCount": 203,
-    "assumptions": "6 axioms: erdos_260_conjecture (open), series_converges (standard analysis), irrational_of_gaps_to_infinity (Erdős 1974), irrational_of_superlogarithmic (number theory), fastGrowth_of_gapsToInfinity (Stolz-Cesàro), fastGrowth_of_superlogarithmic (basic analysis). 0 sorries."
+    "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 5 sorries: series_converges (convergence argument), irrational_of_gaps_to_infinity (Erdős 1974 theorem), irrational_of_superlogarithmic (number-theoretic result), fastGrowth_of_gapsToInfinity (Stolz-Cesàro argument), fastGrowth_of_superlogarithmic (basic analysis)."
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1974 work on irrationality of series [Er74b], further developed in the landmark monograph 'Old and New Problems and Results in Combinatorial Number Theory' with Graham [ErGr80]. It explores a fundamental question at the boundary of analysis and number theory: when does a lacunary (sparse) series produce an irrational sum?\n\nErdős proved that irrationality holds under the stronger condition that the gaps a_{n+1} − aₙ tend to infinity. He also showed irrationality when aₙ grows superlogarithmically, specifically when aₙ ≫ n√(log n · log log n). These partial results demonstrate that 'sufficiently fast' growth guarantees irrationality, but the full conjecture — that the mere condition aₙ/n → ∞ suffices — remains open.\n\nThe problem has an appealing simplicity: the series ∑ aₙ/2^{aₙ} converges absolutely for any increasing sequence (the terms decrease exponentially), so the question is purely about the arithmetic nature of the limit. Erdős and Graham speculated that even having limsup of the gaps being infinite might not suffice for irrationality, but no counterexample has been found. The problem connects to the theory of lacunary series, normal numbers, and the Lindemann-Weierstrass theorem.",
@@ -162,7 +162,7 @@
     ],
     "namespace": "Erdos260",
     "lineCount": 203,
-    "axiomCount": 6,
+    "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 8
   },

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -16,7 +16,7 @@
       "strong-coupling"
     ],
     "badge": "wip",
-    "sorries": 58,
+    "sorries": 47,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
     "lineCount": 28001,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -17,7 +17,7 @@
       "millennium-prize"
     ],
     "badge": "wip",
-    "sorries": 58,
+    "sorries": 47,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
     "lineCount": 28001,

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 58,
+    "sorries": 47,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",


### PR DESCRIPTION
## Summary

- **erdos-260**: sorries 0→5, axiomCount 6→1 (5 sorry'd theorems were misclassified as axioms; only 1 explicit `axiom` declaration exists)
- **yang-mills**: sorries 58→47 (actual count in Exploration.lean)
- **yang-mills-lattice**: sorries 58→47
- **yang-mills-transfer-matrix**: sorries 58→47

## Test plan

- [ ] Verify `pnpm build` succeeds
- [ ] Verify sorry counts match: `grep -c '\bsorry\b' proofs/Proofs/Erdos260Problem.lean` → 5
- [ ] Verify sorry counts match: `grep -c '\bsorry\b' proofs/Proofs/YangMills/Exploration.lean` → 47
- [ ] Verify axiom count: `grep -c '^axiom ' proofs/Proofs/Erdos260Problem.lean` → 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)