### PR TITLE
Research: erdos-687 axiom elimination + erdos-530 metadata fix

### DIFF
--- a/proofs/Proofs/Erdos687Problem.lean
+++ b/proofs/Proofs/Erdos687Problem.lean
@@ -25,13 +25,13 @@ coprime to n.
 
 *Reference:* [erdosproblems.com/687](https://www.erdosproblems.com/687)
 
-Axioms: 5 (jacobsthalSet_bddAbove, jacobsthalY_eq_jacobsthal,
+Axioms: 4 (jacobsthalY_eq_jacobsthal,
   iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture)
-Proved: erdos_687_conjecture (from maier_pomerance_conjecture — M-P is stronger)
-Theorems: 12 (was 9; added not_mem_jacobsthalSet_two, one_mem_jacobsthalSet_two,
-  jacobsthalY_two. Fixed duplicate definitions.)
-Removed: jacobsthalY_trivial_lower (FALSE — Y(2) = 1 < 3 counterexample)
-Sorries: 0 (was 1; proved log_pow_eventually_le_rpow via isLittleO_log_rpow_atTop)
+Proved: jacobsthalSet_bddAbove (CRT induction: any covering leaves gaps within primorial)
+  erdos_687_conjecture (from maier_pomerance_conjecture — M-P is stronger)
+Theorems: 14 (plus private CRT helper lemmas)
+Removed: jacobsthalSet_bddAbove axiom → proved as theorem
+Sorries: 0
 -/
 
 import Mathlib.Tactic
@@ -80,12 +80,98 @@ theorem jacobsthalSet_nonempty (x : ℕ) : (jacobsthalSet x).Nonempty := by
   simp only [Set.mem_setOf_eq, Nat.cast_zero]
   exact ⟨fun _ _ _ => 0, fun n h1 h2 => by omega⟩
 
+/- ## CRT induction: proving jacobsthalSet is bounded -/
+
+/-- Product of primes in a Finset (as integers) is positive. -/
+private lemma prod_primes_pos' (S : Finset ℕ) (hS : ∀ p ∈ S, Nat.Prime p) :
+    (0 : ℤ) < ∏ p ∈ S, (p : ℤ) :=
+  Finset.prod_pos fun p hp => Int.natCast_pos.mpr (hS p hp).pos
+
+/-- A prime not in a Finset of primes doesn't divide their integer product. -/
+private lemma prime_not_dvd_int_prod
+    (S : Finset ℕ) (hS : ∀ p ∈ S, Nat.Prime p)
+    (q : ℕ) (hq : q.Prime) (hq_not : q ∉ S) :
+    ¬ (q : ℤ) ∣ ∏ p ∈ S, (p : ℤ) := by
+  rw [← Nat.cast_prod, Int.natCast_dvd_natCast]
+  intro hdvd
+  obtain ⟨r, hrS, hqr⟩ := hq.prime.dvd_finset_prod_iff.mp hdvd
+  have : q = r := ((hS r hrS).eq_one_or_self_of_dvd q hqr).resolve_left hq.ne_one
+  subst this
+  exact hq_not hrS
+
+/-- CRT induction: for any Finset of primes and covering function,
+    some integer in [1, product] avoids all residue classes.
+
+    Proof: Finset.induction. If m avoids primes in S', check m mod q.
+    If m already avoids a(q), done. Otherwise m + P' avoids a(q)
+    (since gcd(P', q) = 1 implies adding P' changes residue mod q)
+    while still avoiding S' (since P' ≡ 0 mod each p ∈ S'). -/
+private lemma exists_uncovered_in_prod
+    (S : Finset ℕ) (hS : ∀ p ∈ S, Nat.Prime p) (a : ℕ → ℕ) :
+    ∃ n : ℤ, 1 ≤ n ∧ n ≤ ∏ p ∈ S, (p : ℤ) ∧
+      ∀ p ∈ S, n % (p : ℤ) ≠ (a p : ℤ) % (p : ℤ) := by
+  induction S using Finset.induction with
+  | empty =>
+    exact ⟨1, le_rfl, by simp, fun _ hp => absurd hp (Finset.not_mem_empty _)⟩
+  | insert hq_not ih =>
+    rename_i q S'
+    have hS' : ∀ p ∈ S', Nat.Prime p := fun p hp => hS p (Finset.mem_insert_of_mem hp)
+    have hq : q.Prime := hS q (Finset.mem_insert_self q S')
+    obtain ⟨m, hm1, hm2, hm_avoid⟩ := ih hS' a
+    set P' : ℤ := ∏ p ∈ S', (p : ℤ) with hP'_def
+    have hP'_pos : (0 : ℤ) < P' := prod_primes_pos' S' hS'
+    have hq2 : (2 : ℤ) ≤ (q : ℤ) := by exact_mod_cast hq.two_le
+    rw [Finset.prod_insert hq_not]
+    by_cases hcase : m % (q : ℤ) = (a q : ℤ) % (q : ℤ)
+    · -- m matches a(q) mod q: use m + P' instead
+      refine ⟨m + P', by linarith, by nlinarith, ?_⟩
+      intro p hp
+      rcases Finset.mem_insert.mp hp with rfl | hp'
+      · -- p = q: (m + P') % q ≠ (a q) % q because q ∤ P'
+        intro heq
+        have hmod : (m + P') % (q : ℤ) = m % (q : ℤ) := heq.trans hcase.symm
+        have hq_dvd : (q : ℤ) ∣ P' := by
+          have h_neg := Int.modEq_iff_dvd.mp hmod
+          -- h_neg : q ∣ (m - (m + P')) = -P'
+          rwa [show m - (m + P') = -P' from by ring, dvd_neg] at h_neg
+        exact prime_not_dvd_int_prod S' hS' q hq hq_not hq_dvd
+      · -- p ∈ S': (m + P') % p = m % p since p | P'
+        obtain ⟨k, hk⟩ := Finset.dvd_prod_of_mem (fun i => (i : ℤ)) hp'
+        rw [show m + P' = m + (p : ℤ) * k from by rw [hk], Int.add_mul_emod_self_left]
+        exact hm_avoid p hp'
+    · -- m already avoids a(q) mod q: use m directly
+      exact ⟨m, hm1, le_trans hm2 (le_mul_of_one_le_left hP'_pos.le (by linarith)),
+        fun p hp => by
+          rcases Finset.mem_insert.mp hp with rfl | hp'
+          · exact hcase
+          · exact hm_avoid p hp'⟩
+
 /-- The Jacobsthal set is bounded above by the primorial.
-After primorial(x) steps, the CRT covering pattern repeats, so any
-uncovered integer would imply infinitely many uncovered integers
-in any interval of length primorial(x). -/
-axiom jacobsthalSet_bddAbove (x : ℕ) :
-  BddAbove (jacobsthalSet x)
+    Proof: by CRT induction, for any covering system, some integer
+    in [1, primorial(x)] is uncovered. So no y > primorial(x) is
+    achievable. -/
+theorem jacobsthalSet_bddAbove (x : ℕ) :
+    BddAbove (jacobsthalSet x) := by
+  refine ⟨primorial x, fun y hy => ?_⟩
+  by_contra h
+  push_neg at h
+  -- h : primorial x < y, hy : y ∈ jacobsthalSet x
+  obtain ⟨a, ha⟩ := hy
+  -- Extract simple function from dependent covering
+  let a' : ℕ → ℕ := fun p =>
+    if h : p.Prime ∧ p ≤ x then a p h.1 h.2 else 0
+  set S := (Finset.range (x + 1)).filter Nat.Prime with hS_def
+  have hS_prime : ∀ p ∈ S, Nat.Prime p := fun p hp => (Finset.mem_filter.mp hp).2
+  have hprod_eq : ∏ p ∈ S, (p : ℤ) = (primorial x : ℤ) :=
+    Nat.cast_prod.symm
+  obtain ⟨n, hn1, hn2, hn_avoid⟩ := exists_uncovered_in_prod S hS_prime a'
+  rw [hprod_eq] at hn2
+  have hny : n ≤ (y : ℤ) := le_trans hn2 (by exact_mod_cast h.le)
+  obtain ⟨p, hp, hpx, hcov⟩ := ha n hn1 hny
+  have hpS : p ∈ S := Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), hp⟩
+  have ha'_eq : (a' p : ℤ) % (p : ℤ) = (a p hp hpx : ℤ) % (p : ℤ) := by
+    congr 1; exact_mod_cast show a' p = a p hp hpx from dif_pos ⟨hp, hpx⟩
+  exact hn_avoid p hpS (by rwa [ha'_eq])
 
 /- ## Structural Properties -/
 

--- a/proofs/Proofs/ShannonChannelCoding.lean
+++ b/proofs/Proofs/ShannonChannelCoding.lean
@@ -7,47 +7,164 @@
   Achievability via random coding; converse via Fano's inequality.
 
   Claude Shannon (1948)
+
+  Axioms: 5 (capacity_nonneg, fano_inequality, channel_coding_achievability,
+    channel_coding_converse, bsc_capacity_eq)
+  Theorems: 3 (rate_of_code_pos, bsc_capacity_le_one, bsc_capacity_nonneg)
+  Sorries: 0
 -/
 import Mathlib
+import Proofs.ShannonEntropy
+
+open Real Finset InformationTheory
 
 namespace InformationTheory.ChannelCoding
 
--- Channel capacity: C = max_{input distribution} I(X;Y)
--- For discrete memoryless channels
+/- ## Discrete Memoryless Channel -/
+
+/-- A discrete memoryless channel is specified by a transition matrix
+    W : α → β → ℝ where W x y = P(Y = y | X = x).
+    Valid channels have non-negative probabilities summing to 1
+    for each input. -/
+structure DMChannel (α β : Type*) [Fintype α] [Fintype β] where
+  W : α → β → ℝ
+  nonneg : ∀ x y, 0 ≤ W x y
+  sum_one : ∀ x, ∑ y, W x y = 1
+
+/-- A valid input distribution for a channel. -/
+structure InputDist (α : Type*) [Fintype α] where
+  p : α → ℝ
+  nonneg : ∀ x, 0 ≤ p x
+  sum_one : ∑ x, p x = 1
+
+/-- The joint distribution induced by input distribution p and channel W:
+    P(X=x, Y=y) = p(x) · W(x, y). -/
+noncomputable def jointDist {α β : Type*} [Fintype α] [Fintype β]
+    (ch : DMChannel α β) (inp : InputDist α) : α × β → ℝ :=
+  fun ⟨x, y⟩ => inp.p x * ch.W x y
+
+/-- Mutual information for an input distribution and channel:
+    I(X;Y) = I(p, W) computed from the joint distribution p(x)·W(x|y). -/
+noncomputable def channelMI {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (ch : DMChannel α β) (inp : InputDist α) : ℝ :=
+  mutualInformation (jointDist ch inp)
+
+/-- Channel capacity: C = sup over input distributions of I(X;Y).
+    For finite alphabets, the supremum is achieved (compactness). -/
 noncomputable def channelCapacity {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β]
-    (W : α → β → ℝ) : ℝ := 0  -- Placeholder: max over input distributions of mutual information
+    (ch : DMChannel α β) : ℝ :=
+  sSup { r : ℝ | ∃ inp : InputDist α, channelMI ch inp = r }
 
--- Fano's inequality: H(X|Y) ≤ h(P_e) + P_e · log(|X| - 1)
--- where h is binary entropy and P_e is error probability
-theorem fano_inequality {α β : Type*} [Fintype α] [Fintype β]
+/- ## Channel capacity is non-negative -/
+
+/-- Channel capacity is non-negative: I(X;Y) ≥ 0 for all input distributions. -/
+axiom capacity_nonneg {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β] [Nonempty α]
+    (ch : DMChannel α β) : 0 ≤ channelCapacity ch
+
+/- ## Block codes -/
+
+/-- A block code of length n with M codewords over alphabet α. -/
+structure BlockCode (α : Type*) (n : ℕ) where
+  M : ℕ
+  hM : 0 < M
+  encode : Fin M → Fin n → α
+
+/-- The rate of a block code: R = log(M) / n (in nats). -/
+noncomputable def rate_of_code {α : Type*} {n : ℕ} (hn : 0 < n)
+    (code : BlockCode α n) : ℝ :=
+  Real.log code.M / n
+
+/-- Code rate is non-negative when M ≥ 1 and n ≥ 1. -/
+theorem rate_of_code_pos {α : Type*} {n : ℕ} (hn : 0 < n)
+    (code : BlockCode α n) : 0 ≤ rate_of_code hn code := by
+  unfold rate_of_code
+  apply div_nonneg
+  · exact Real.log_nonneg (by exact_mod_cast code.hM)
+  · exact Nat.cast_nonneg n
+
+/- ## Fano's inequality -/
+
+/-- **Fano's inequality**: H(X|Y) ≤ h(P_e) + P_e · log(|X| - 1)
+    where h is binary entropy and P_e is the error probability.
+
+    This bounds conditional entropy in terms of error probability,
+    and is the key tool for the converse of the channel coding theorem. -/
+axiom fano_inequality {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β]
-    {p_joint : α × β → ℝ} (hp : ∀ x, 0 ≤ p_joint x) :
-    -- Conditional entropy bounded by function of error probability
-    True := trivial
+    (pXY : α × β → ℝ) (hp : ∀ x, 0 ≤ pXY x) (hsum : ∑ x, pXY x = 1) :
+    let pX : α → ℝ := fun x => ∑ y : β, pXY (x, y)
+    let P_e := 1 - ∑ y : β, ∑ x : α, pXY (x, y) ^ 2 / (∑ x' : α, pXY (x', y))
+    conditionalEntropy pXY ≤
+      InformationTheory.BinaryEntropy.h P_e +
+        P_e * Real.log (Fintype.card α - 1)
 
--- Channel coding theorem (achievability):
--- For any R < C, there exists a code with rate R and vanishing error
-theorem channel_coding_achievability {α β : Type*} [Fintype α] [Fintype β]
+/- ## Main theorems -/
+
+/-- **Channel coding theorem (achievability).**
+    For any rate R below channel capacity, there exist block codes of
+    rate R with error probability vanishing as block length → ∞.
+
+    Shannon's proof uses random coding: a random codebook achieves the bound
+    in expectation, hence a good deterministic code exists. -/
+axiom channel_coding_achievability {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β]
-    {W : α → β → ℝ} (hW : ∀ x y, 0 ≤ W x y)
-    {R : ℝ} (hR : 0 < R) :
-    -- If R < C, error probability → 0 as block length → ∞
-    True := trivial
+    (ch : DMChannel α β) {R : ℝ} (hR : 0 < R)
+    (hR_cap : R < channelCapacity ch) :
+    ∀ ε : ℝ, 0 < ε → ∀ᶠ (n : ℕ) in Filter.atTop,
+      ∃ (code : BlockCode α n) (decoder : (Fin n → β) → Fin code.M),
+        R ≤ rate_of_code (by omega : 0 < n) code ∧
+        -- Average error probability < ε
+        (∑ i : Fin code.M, (1 - ∑ y : Fin n → β,
+          (∏ j : Fin n, ch.W (code.encode i j) (y j)) *
+            if decoder y = i then (1 : ℝ) else 0)) / code.M < ε
 
--- Channel coding theorem (converse):
--- For any R > C, error probability is bounded away from 0
-theorem channel_coding_converse {α β : Type*} [Fintype α] [Fintype β]
+/-- **Channel coding theorem (converse).**
+    For any rate R above channel capacity, the error probability
+    is bounded away from 0 for all sufficiently long codes.
+
+    Proof via Fano's inequality: if the error probability is small,
+    then I(X;Y) ≈ R per channel use, but I(X;Y) ≤ C. -/
+axiom channel_coding_converse {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β]
-    {W : α → β → ℝ} (hW : ∀ x y, 0 ≤ W x y)
-    {R : ℝ} (hR : 0 < R) :
-    -- If R > C, error probability does not → 0
-    True := trivial
+    (ch : DMChannel α β) {R : ℝ} (hR : 0 < R)
+    (hR_cap : channelCapacity ch < R) :
+    ∃ δ : ℝ, 0 < δ ∧ ∀ (n : ℕ) (hn : 0 < n)
+      (code : BlockCode α n) (decoder : (Fin n → β) → Fin code.M),
+        R ≤ rate_of_code hn code →
+        δ ≤ (∑ i : Fin code.M, (1 - ∑ y : Fin n → β,
+          (∏ j : Fin n, ch.W (code.encode i j) (y j)) *
+            if decoder y = i then (1 : ℝ) else 0)) / code.M
 
--- Binary symmetric channel capacity: C = 1 - h(p)
--- where h(p) = -p log p - (1-p) log(1-p)
-theorem bsc_capacity {p : ℝ} (hp : 0 < p) (hp1 : p < 1) :
-    -- Capacity of BSC(p) = 1 - binary_entropy(p)
-    True := trivial
+/- ## Binary symmetric channel -/
+
+/-- The binary symmetric channel BSC(p): flips each bit independently
+    with probability p. Requires 0 ≤ p ≤ 1. -/
+noncomputable def bsc (p : ℝ) (hp0 : 0 ≤ p) (hp1 : p ≤ 1) : DMChannel Bool Bool where
+  W := fun x y => if x = y then 1 - p else p
+  nonneg := fun x y => by split_ifs <;> linarith
+  sum_one := fun x => by
+    simp only [Fintype.sum_bool]
+    split_ifs with h <;> ring
+
+/-- BSC capacity = 1 - h(p) bits = log 2 - h(p) nats.
+    The capacity-achieving input is uniform Bernoulli(1/2). -/
+axiom bsc_capacity_eq {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    channelCapacity (bsc p (le_of_lt hp0) (le_of_lt hp1)) =
+      Real.log 2 - InformationTheory.BinaryEntropy.h p
+
+/-- BSC capacity is at most log 2 (= 1 bit). -/
+theorem bsc_capacity_le_one {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    channelCapacity (bsc p (le_of_lt hp0) (le_of_lt hp1)) ≤ Real.log 2 := by
+  rw [bsc_capacity_eq hp0 hp1]
+  linarith [InformationTheory.BinaryEntropy.h_nonneg (le_of_lt hp0) (le_of_lt hp1)]
+
+/-- BSC capacity is non-negative for 0 < p < 1. -/
+theorem bsc_capacity_nonneg {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    0 ≤ channelCapacity (bsc p (le_of_lt hp0) (le_of_lt hp1)) := by
+  rw [bsc_capacity_eq hp0 hp1]
+  linarith [InformationTheory.BinaryEntropy.h_le_log_two (le_of_lt hp0) (le_of_lt hp1)]
 
 end InformationTheory.ChannelCoding

--- a/proofs/Proofs/ShannonChannelCoding.lean
+++ b/proofs/Proofs/ShannonChannelCoding.lean
@@ -8,9 +8,10 @@
 
   Claude Shannon (1948)
 
-  Axioms: 5 (capacity_nonneg, fano_inequality, channel_coding_achievability,
+  Axioms: 5 (channelMI_le_log_card, fano_inequality, channel_coding_achievability,
     channel_coding_converse, bsc_capacity_eq)
-  Theorems: 3 (rate_of_code_pos, bsc_capacity_le_one, bsc_capacity_nonneg)
+  Theorems: 7 (jointDist_nonneg, jointDist_sum_one, channelMI_nonneg,
+    capacity_nonneg, rate_of_code_pos, bsc_capacity_le_one, bsc_capacity_nonneg)
   Sorries: 0
 -/
 import Mathlib
@@ -57,12 +58,54 @@ noncomputable def channelCapacity {α β : Type*} [Fintype α] [Fintype β]
     (ch : DMChannel α β) : ℝ :=
   sSup { r : ℝ | ∃ inp : InputDist α, channelMI ch inp = r }
 
+/- ## Joint distribution properties -/
+
+/-- Joint distribution is non-negative. -/
+theorem jointDist_nonneg {α β : Type*} [Fintype α] [Fintype β]
+    (ch : DMChannel α β) (inp : InputDist α) (xy : α × β) :
+    0 ≤ jointDist ch inp xy :=
+  mul_nonneg (inp.nonneg xy.1) (ch.nonneg xy.1 xy.2)
+
+/-- Joint distribution sums to 1. -/
+theorem jointDist_sum_one {α β : Type*} [Fintype α] [Fintype β]
+    (ch : DMChannel α β) (inp : InputDist α) :
+    ∑ xy : α × β, jointDist ch inp xy = 1 := by
+  simp only [jointDist, Fintype.sum_prod_type]
+  conv_lhs => arg 2; ext x; rw [← Finset.mul_sum]
+  rw [show ∀ x, ∑ y : β, ch.W x y = 1 from fun x => ch.sum_one x]
+  simp [inp.sum_one]
+
+/-- Channel mutual information is non-negative. -/
+theorem channelMI_nonneg {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (ch : DMChannel α β) (inp : InputDist α) : 0 ≤ channelMI ch inp :=
+  mutual_info_nonneg (jointDist_nonneg ch inp) (jointDist_sum_one ch inp)
+
 /- ## Channel capacity is non-negative -/
 
-/-- Channel capacity is non-negative: I(X;Y) ≥ 0 for all input distributions. -/
-axiom capacity_nonneg {α β : Type*} [Fintype α] [Fintype β]
+/-- Mutual information is bounded by log of the output alphabet size.
+    I(X;Y) ≤ H(Y) ≤ log|β|. Proof uses chain rule and entropy_le_log_card. -/
+axiom channelMI_le_log_card {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (ch : DMChannel α β) (inp : InputDist α) :
+    channelMI ch inp ≤ Real.log (Fintype.card β)
+
+/-- Channel capacity is non-negative: I(X;Y) ≥ 0 for all input distributions,
+    and the supremum over a non-empty set of non-negatives is non-negative. -/
+theorem capacity_nonneg {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β] [Nonempty α]
-    (ch : DMChannel α β) : 0 ≤ channelCapacity ch
+    (ch : DMChannel α β) : 0 ≤ channelCapacity ch := by
+  unfold channelCapacity
+  have ⟨a⟩ := ‹Nonempty α›
+  let inp₀ : InputDist α :=
+    { p := fun x => if x = a then 1 else 0
+      nonneg := fun x => by split_ifs <;> norm_num
+      sum_one := by simp [Finset.sum_ite_eq', Finset.mem_univ] }
+  apply le_csSup_of_le
+  · exact ⟨Real.log (Fintype.card β), fun _ ⟨inp, hr⟩ =>
+      hr ▸ channelMI_le_log_card ch inp⟩
+  · exact ⟨inp₀, rfl⟩
+  · exact channelMI_nonneg ch inp₀
 
 /- ## Block codes -/
 

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -142,7 +142,7 @@
     "namespace": "Erdos530",
     "lineCount": 281,
     "axiomCount": 2,
-    "theoremCount": 6,
+    "theoremCount": 12,
     "definitionCount": 4
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 687,
     "erdosUrl": "https://erdosproblems.com/687",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 370,
-    "assumptions": "5 axioms: jacobsthalSet_bddAbove, jacobsthalY_eq_jacobsthal, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. erdos_687_conjecture is a theorem proved from maier_pomerance_conjecture. 0 sorries.",
+    "axiomCount": 4,
+    "lineCount": 456,
+    "assumptions": "4 axioms: jacobsthalY_eq_jacobsthal, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. jacobsthalSet_bddAbove proved via CRT induction. erdos_687_conjecture proved from maier_pomerance_conjecture. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -7,7 +7,7 @@
     "author": "Claude Shannon (1948), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Noisy-channel_coding_theorem",
     "date": "1948",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ShannonChannelCoding.lean",
     "tags": [
       "information-theory",
@@ -16,7 +16,7 @@
       "coding-theory",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,12 +39,10 @@
       "Channel capacity definition (placeholder returning 0)",
       "Theorem statements for Fano inequality, achievability, converse, and BSC capacity (all placeholder stubs proving True)"
     ],
-    "assumptions": [
-      "All four theorems and the capacity definition are placeholder stubs — no actual proofs exist yet"
-    ],
+    "assumptions": "5 axioms: capacity_nonneg, fano_inequality, channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. Real definitions for DMChannel, InputDist, jointDist, channelMI, channelCapacity, BlockCode, BSC. Proved: rate_of_code_pos, bsc_capacity_le_one, bsc_capacity_nonneg.",
     "dateAdded": "2026-03-21",
-    "axiomCount": 0,
-    "lineCount": 53,
+    "axiomCount": 5,
+    "lineCount": 170,
     "prerequisites": [
       "Shannon entropy and mutual information",
       "Discrete memoryless channels and capacity",

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -39,10 +39,10 @@
       "Channel capacity definition (placeholder returning 0)",
       "Theorem statements for Fano inequality, achievability, converse, and BSC capacity (all placeholder stubs proving True)"
     ],
-    "assumptions": "5 axioms: capacity_nonneg, fano_inequality, channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. Real definitions for DMChannel, InputDist, jointDist, channelMI, channelCapacity, BlockCode, BSC. Proved: rate_of_code_pos, bsc_capacity_le_one, bsc_capacity_nonneg.",
+    "assumptions": "5 axioms: channelMI_le_log_card, fano_inequality, channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 7 theorems proved (jointDist properties, capacity_nonneg, rate/BSC bounds). 0 sorries.",
     "dateAdded": "2026-03-21",
     "axiomCount": 5,
-    "lineCount": 170,
+    "lineCount": 213,
     "prerequisites": [
       "Shannon entropy and mutual information",
       "Discrete memoryless channels and capacity",

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "buffons-needle-oq-01-oq-02",
   "title": "Buffon's Needle Higher-Dimensional: Hyperplane Arrangements",
-  "phase": "COMPLETED",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Created BuffonsNeedleOQ01OQ02.lean (237 lines, 21 theorems, 5 axioms, 0 sorries). Defined the Buffon dimensional constant c_n via Gamma functions, proved c₂=2/π, c₃=1, c₄=4/π, c₅=2/3, c₆=3/π. Established structural properties and mean width connection.",
+    "progressSummary": "BUG: buffonConstant definition missing 1/(n-1) factor. Code: c_n=2Γ(n/2)/(√π·Γ((n-1)/2)), correct: c_n=2Γ(n/2)/((n-1)·√π·Γ((n-1)/2)). c₂=2/π is correct (n-1=1 cancels), but c₃=1 (should be 1/2), c₄=4/π (should be 4/(3π)). Code gives c₄>1 contradicting buffonConstant_le_one axiom. Recurrence also wrong ((n-1)/n should be n/(n+1)). Needs rewrite.",
     "builtItems": [
       "BuffonsNeedleOQ01OQ02.lean: buffonConstant definition via Gamma functions",
       "Proved buffonConstant_two = 2/π, buffonConstant_three = 1, buffonConstant_four = 4/π",
@@ -44,16 +44,21 @@
       "c₃ = 1 is the unique maximum — 3D gives the simplest formula E = L/d",
       "Recurrence c_{n+2} = ((n-1)/n)·c_n shows c_n → 0 (concentration of measure)",
       "Only one axiom (Γ(1/2)=√π) beyond Mathlib is needed to prove c₂, c₃, c₄",
-      "Mean width interpretation: E = meanWidth/d is the Cauchy-Crofton formula for line segments"
+      "Mean width interpretation: E = meanWidth/d is the Cauchy-Crofton formula for line segments",
+      "BUG: The formula 2Γ(n/2)/(√π·Γ((n-1)/2)) = 2|S^{n-2}|/|S^{n-1}| is NOT the expected |cos θ|. The correct Buffon constant is E[|cos θ|] = 2|S^{n-2}|/((n-1)|S^{n-1}|). Factor 1/(n-1) missing.",
+      "BUG evidence: code gives c₃=1 but E[|cos θ|] in 3D = ∫|cosθ|sinθ dθ / ∫sinθ dθ = 1/2. And c₄=4/π≈1.27>1 contradicts buffonConstant_le_one.",
+      "BUG: recurrence axiom says c_{n+2}=(n-1)/n·c_n but correct recurrence is c_{n+2}=n/(n+1)·c_n (from Γ functional equation). Derived values c₅=2/3, c₆=3/π are wrong."
     ],
     "mathlibGaps": [
       "No direct lemma Real.Gamma_half for Γ(1/2) = √π",
       "No sphere surface area function in Mathlib"
     ],
     "nextSteps": [
-      "Prove Γ(1/2)=√π from the Gaussian integral (eliminate axiom)",
-      "Extend to convex bodies beyond needles (Cauchy-Crofton for general K)",
-      "Formalize non-parallel hyperplane arrangements (general position)"
+      "FIX BUG: Change buffonConstant to include 1/(n-1) factor: c_n = 2Γ(n/2)/((n-1)√π·Γ((n-1)/2)). Then c₃=1/2, c₄=4/(3π), c₅=3/8.",
+      "FIX BUG: Change recurrence axiom to c_{n+2} = n/(n+1)·c_n and re-derive c₅, c₆",
+      "FIX BUG: buffonConstant_le_one becomes provable once definition is correct",
+      "Prove Γ(1/2)=√π from Mathlib (check Real.Gamma_one_half_eq or derive from reflection formula)",
+      "Extend to convex bodies beyond needles (Cauchy-Crofton for general K)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- **erdos-687**: Proved `jacobsthalSet_bddAbove` (eliminated 1 axiom, 5→4). CRT induction ~90 lines.
- **erdos-530**: Fixed `theoremCount` in meta.json (6→12 to match actual Lean file)
- **erdos-687 conflict resolution**: Kept newer HEAD data (4 axioms) over stale sync data (5 axioms)

## Status
**Outcome**: metadata fix + conflict resolution
**Next Steps**: erdos-530 is complete (2 axioms: KSS=deep result, Alon-Erdős=open conjecture)

Generated by researcher-6