### PR TITLE
fix(audit): correct axiom count for bounded-prime-gaps-oq-03-oq-01

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2399,9 +2399,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "bounded-prime-gaps-oq-03-oq-01": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-28T23:24:06Z",
+      "auditCount": 2,
+      "result": "issues-found",
       "agentId": "auditor-cycle-20-batch"
     },
     "bounded-prime-gaps-oq-03": {
@@ -9557,6 +9557,30 @@
     "fair-games-theorem-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-03-28T21:51:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chinese-remainder-constructive-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T23:24:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-485-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T23:25:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "four-color-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T23:27:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lebesgue-measure-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-28T23:27:32Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -28,9 +28,9 @@
       "barrier_246: the 246 barrier cannot be broken by k-tuple methods alone"
     ],
     "dateAdded": "2026-03-21",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 380,
-    "assumptions": "1 axiom (minAdmissibleDiameter_50: D(50) = 246 by Engelsma computation) and 1 sorry (diameter_upper_bound_exists). D(2)=2 and D(3)=6 fully proved. diameter_lower_bound proved via factorial k-tuple construction.",
+    "assumptions": "2 axioms: minAdmissibleDiameter_50 (D(50) = 246 by Engelsma computation), diameter_upper_bound_exists (existence of admissible tuples achieving D(k)). 0 sorries. D(2)=2 and D(3)=6 fully proved. diameter_lower_bound proved via factorial k-tuple construction.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -142,7 +142,7 @@
     ],
     "namespace": "BoundedPrimeGapsOQ03OQ01",
     "lineCount": 380,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 24,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Summary

- **bounded-prime-gaps-oq-03-oq-01**: axiomCount 1→2, updated assumptions text
  - `diameter_upper_bound_exists` was converted from `sorry` to `axiom` but count wasn't updated
  - Assumptions text still mentioned "1 sorry" — corrected to "0 sorries"

## Test plan

- [ ] Verify: `grep -c '^axiom ' proofs/Proofs/BoundedPrimeGapsOQ03OQ01.lean` → 2
- [ ] Verify: `grep -c '\bsorry\b' proofs/Proofs/BoundedPrimeGapsOQ03OQ01.lean` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)