### PR TITLE
fix: remove unused TacticState imports breaking build

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-02/index.ts
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-02/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BorsukUlamOQ02OQ02.lean?raw'

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-03/index.ts
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-03/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CentralLimitTheoremOQ01OQ03.lean?raw'

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/index.ts
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/DescartesRuleOfSignsOQ01OQ01.lean?raw'

--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02/index.ts
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/EulerPolyhedralFormulaOQ01OQ02.lean?raw'


### PR DESCRIPTION
## Summary
- Remove unused `TacticState` import from 4 proof index.ts files that were causing TS6196 build errors
- Affected: borsuk-ulam-oq-02-oq-02, central-limit-theorem-oq-01-oq-03, descartes-rule-of-signs-oq-01-oq-01, euler-polyhedral-formula-oq-01-oq-02

## Test plan
- [ ] `pnpm build` passes without TS6196 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)