### PR TITLE
fix: remove unused TacticState imports (batch 2)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04/index.ts
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionOQ02OQ04.lean?raw'

--- a/src/data/proofs/area-of-circle-oq-03-oq-03/index.ts
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ03OQ03.lean?raw'

--- a/src/data/proofs/bezout-identity-oq-03-oq-04/index.ts
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ03OQ04.lean?raw'

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/BinomialTheoremOQ02OQ01.lean?raw'


### PR DESCRIPTION
## Summary
- Remove unused `TacticState` import from 4 more proof index.ts files causing TS6196 build errors
- Affected: angle-trisection-oq-02-oq-04, area-of-circle-oq-03-oq-03, bezout-identity-oq-03-oq-04, binomial-theorem-oq-02-oq-01

## Test plan
- [ ] `pnpm build` passes without TS6196 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)