### PR TITLE
fix(metadata): correct fourier-series-oq-01 sorry count (4 → 5)

### DIFF
--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -20,7 +20,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Corrects sorry count in fourier-series-oq-01 meta.json from 4 to 5.

## Evidence

**Before**: `"sorries": 4` — undercounted because line 404 has `sorry sorry` (two sorries on one line)
**After**: `"sorries": 5` — matches actual code sorries at lines 292, 313, 341, 404 (×2)

---
Automated fix by lean-mechanic agent.