### PR TITLE
fix(audit): correct sorry count for fourier-series-oq-01 (4→5)

### DIFF
--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -20,7 +20,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

- **fourier-series-oq-01**: sorry count 4→5
  - Line 404 has `sorry sorry` (two sorries on one line) filling integrability goals
  - `grep -c` counts lines, not occurrences, so the original count missed the double sorry

## Test plan

- [ ] Verify: `grep -o '\bsorry\b' proofs/Proofs/FourierSeriesOQ01.lean | wc -l` → 5
- [ ] Verify: `grep -c '^axiom ' proofs/Proofs/FourierSeriesOQ01.lean` → 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)