### PR TITLE
audit: fix fourier-series-oq-01 sorry count + 9 new audits

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9584,51 +9584,57 @@
       "result": "clean",
       "issues": []
     },
+    "fourier-series-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:24:06Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
     "angle-trisection-oq-02-oq-04": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T00:12:13Z",
+      "lastAudited": "2026-03-29T00:25:15Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-03-oq-03": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T00:12:13Z",
+      "lastAudited": "2026-03-29T00:26:02Z",
       "result": "clean",
       "issues": []
     },
     "bezout-identity-oq-03-oq-04": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T00:12:13Z",
+      "lastAudited": "2026-03-29T00:26:31Z",
       "result": "clean",
       "issues": []
     },
     "binomial-theorem-oq-02-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T00:12:13Z",
+      "lastAudited": "2026-03-29T00:27:27Z",
       "result": "clean",
       "issues": []
     },
     "borsuk-ulam-oq-02-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T00:12:13Z",
+      "lastAudited": "2026-03-29T00:27:27Z",
       "result": "clean",
       "issues": []
     },
     "central-limit-theorem-oq-01-oq-03": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T00:12:13Z",
+      "lastAudited": "2026-03-29T00:27:27Z",
       "result": "clean",
       "issues": []
     },
     "descartes-rule-of-signs-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T00:12:14Z",
+      "lastAudited": "2026-03-29T00:27:27Z",
       "result": "clean",
       "issues": []
     },
     "euler-polyhedral-formula-oq-01-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T00:12:14Z",
+      "lastAudited": "2026-03-29T00:27:27Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9583,6 +9583,54 @@
       "lastAudited": "2026-03-28T23:27:32Z",
       "result": "clean",
       "issues": []
+    },
+    "angle-trisection-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-03-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "borsuk-ulam-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "central-limit-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-rule-of-signs-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:12:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-polyhedral-formula-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:12:14Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {

--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -20,7 +20,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary
- Fixed `fourier-series-oq-01` sorry count: 4→5 (line 404 has `sorry sorry` — two sorry terms in `fourierPartialSum_add`)
- Audited 9 new proofs, all passing integrity checks
- Gallery now at 1604/1604 audited, 0 open issues

## Audited Proofs
| Proof | Status | Result |
|-------|--------|--------|
| fourier-series-oq-01 | axiomatized | **issues-fixed** (sorry count 4→5) |
| angle-trisection-oq-02-oq-04 | verified | clean |
| area-of-circle-oq-03-oq-03 | verified | clean |
| bezout-identity-oq-03-oq-04 | verified | clean |
| binomial-theorem-oq-02-oq-01 | verified | clean |
| borsuk-ulam-oq-02-oq-02 | verified | clean |
| central-limit-theorem-oq-01-oq-03 | verified | clean |
| descartes-rule-of-signs-oq-01-oq-01 | verified | clean |
| euler-polyhedral-formula-oq-01-oq-02 | verified | clean |

## Test plan
- [ ] Verify `pnpm build` passes with corrected sorry count
- [ ] Confirm gallery renders fourier-series-oq-01 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)