### PR TITLE
audit: fix cauchy-schwarz-integral-oq-02-oq-02 status/badge

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9637,6 +9637,18 @@
       "lastAudited": "2026-03-29T00:27:27Z",
       "result": "clean",
       "issues": []
+    },
+    "cantor-diagonalization-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:50:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T00:50:34Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
@@ -8,7 +8,7 @@
     "author": "Classical (Young 1912, Hölder 1889, Minkowski 1896)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Minkowski_inequality",
     "date": "1896",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
     "tags": [
       "analysis",
@@ -20,7 +20,7 @@
       "young-inequality",
       "open-question"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 2,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Summary
- Fixed `cauchy-schwarz-integral-oq-02-oq-02` status: `axiomatized` → `formalized` and badge: `axiom` → `wip` (file has 0 axioms, 2 sorries — should not claim axiomatized/axiom)
- Audited 2 new proofs: `cantor-diagonalization-oq-01-oq-01` (clean), `cauchy-schwarz-integral-oq-02-oq-02` (fixed)
- Gallery: 1606/1606 audited, 0 open issues

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Confirm cauchy-schwarz-integral-oq-02-oq-02 renders with correct badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)