### PR TITLE
fix: remove unused TacticState import

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ01OQ03.lean?raw'

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/index.ts
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean?raw'


### PR DESCRIPTION
## Summary
- Remove unused `TacticState` import from 2 proof index files that broke the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)