### PR TITLE
audit: fix cantors-theorem-oq-01-oq-01 missing import + badge

### DIFF
--- a/proofs/Proofs/CantorsTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/CantorsTheoremOQ01OQ01.lean
@@ -1,3 +1,4 @@
+import Proofs.CantorsTheoremOQ01
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.SetTheory.Cardinal.Continuum

--- a/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
@@ -13,11 +13,11 @@
       "continuum hypothesis",
       "independence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 155,
-    "assumptions": "None. All results proved from Mathlib + parent file CantorsTheoremOQ01.lean.",
+    "assumptions": "0 axioms, 0 sorries. Core cardinal facts via Mathlib (Cardinal.cantor, mk_set, aleph_one_le_continuum) and parent file CantorsTheoremOQ01.lean (CH/GCH definitions, conditional results).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -38,10 +38,13 @@
   },
   "leanFile": {
     "imports": [
+      "Proofs.CantorsTheoremOQ01",
       "Mathlib.SetTheory.Cardinal.Basic",
       "Mathlib.SetTheory.Cardinal.Ordinal",
       "Mathlib.SetTheory.Cardinal.Continuum",
-      "Mathlib.SetTheory.Cardinal.Cofinality"
+      "Mathlib.SetTheory.Cardinal.Cofinality",
+      "Mathlib.Order.SuccPred.Basic",
+      "Mathlib.Tactic"
     ],
     "opens": ["Cardinal"],
     "namespace": "CantorsTheoremOQ01OQ01",


### PR DESCRIPTION
## Summary

- **Missing import**: `CantorsTheoremOQ01OQ01.lean` references `CantorsTheoremOQ01.*` 15+ times but had no import statement, likely preventing compilation. Added `import Proofs.CantorsTheoremOQ01`.
- **Badge correction**: Changed badge from `"verified"` to `"mathlib"` — parent file (`cantors-theorem-oq-01`) has badge `mathlib`, and this file's results flow through Mathlib-dependent parent theorems.
- **Meta.json fixes**: Updated import list and assumptions field to accurately reflect dependencies.

## Audit Evidence

| Check | meta.json | Lean source | Result |
|-------|-----------|-------------|--------|
| Sorries | 0 | 0 | ✅ Match |
| Axioms | 0 | 0 | ✅ Match |
| True stubs | — | None | ✅ Clean |
| Parent import | Not listed | Missing | ❌ Fixed |
| Badge | `verified` | Parent is `mathlib` | ❌ Fixed → `mathlib` |

## Test plan

- [ ] Verify Lean file compiles with new import: `./proofs/scripts/docker-build.sh Proofs.CantorsTheoremOQ01OQ01`
- [ ] Verify gallery builds: `pnpm build`

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)