### PR TITLE
audit: fix erdos-1092 CRITICAL status — True stubs claimed verified

### DIFF
--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
     "tags": [
       "erdos",
@@ -15,14 +15,14 @@
       "extremal-graph-theory",
       "open"
     ],
-    "badge": "verified",
+    "badge": "infrastructure",
     "sorries": 0,
     "erdosNumber": 1092,
     "erdosUrl": "https://erdosproblems.com/1092",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 162,
-    "assumptions": "None. All axioms removed: rodl_upper_bound (unused), f_trivial_lower (FALSE), erdos_744_connection (FALSE), Questions 1&2 (disproved by Rödl).",
+    "assumptions": "Infrastructure only: definitions and structural lemmas. Main conjectures (Questions 1&2) disproved by Rödl. 2 True-stub placeholders documenting removed false axioms. No theorem-level result claimed.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- **CRITICAL**: `erdos-1092` had status `"verified"` and badge `"verified"` but contains 2 True-stub theorems (`erdos_1092_question1_false_note : True := trivial` and `erdos_1092_question2_false_note : True := trivial`)
- These are placeholders documenting removed false conjectures (disproved by Rödl)
- File is Tier D (infrastructure) — provides definitions (`SGraph`, `fThreshold`, `CanReduceChromatic`) and structural lemmas, not a theorem-level result
- Changed status to `"formalized"`, badge to `"infrastructure"`

## Audit Evidence

| Check | meta.json | Lean source | Result |
|-------|-----------|-------------|--------|
| Sorries | 0 | 0 | ✅ Match |
| Axioms | 0 | 0 | ✅ Match |
| True stubs | — | 2 found (lines 88, 92) | ❌ CRITICAL |
| Status | `verified` | Infrastructure only | ❌ Fixed → `formalized` |
| Badge | `verified` | Tier D | ❌ Fixed → `infrastructure` |

## Test plan

- [ ] Verify gallery builds: `pnpm build`

---
Discovered during gallery integrity audit. Severity: **CRITICAL** — overclaiming verified status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)