### PR TITLE
audit: fix erdos-1179-oq-01 sorry count (2 → 1)

### DIFF
--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -19,7 +19,7 @@
       "fourier-analysis"
     ],
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 7,
@@ -27,7 +27,7 @@
     "erdosNumber": 1179,
     "erdosUrl": "https://erdosproblems.com/1179",
     "erdosProblemStatus": "open-question",
-    "assumptions": "Zero axioms. Two sorries remain: (1) reprCount_fourier_expansion (the core Fourier inversion identity on Z/pZ via character orthogonality and subset product identity), (2) fourier_error_bound assembly (combining Fourier expansion with product bounds via triangle inequality). Three previously sorry'd lemmas (norm_one_add_omegap_pow, abs_cos_mul_pi_div_le, fourier_product_bound) are now fully proved. All foundational lemmas and erdos_renyi_decay fully proved.",
+    "assumptions": "Zero axioms. One sorry remains: reprCount_fourier_expansion (the core Fourier inversion identity on Z/pZ via character orthogonality and subset product identity). Previously sorry'd lemmas (norm_one_add_omegap_pow, abs_cos_mul_pi_div_le, fourier_product_bound, fourier_error_bound assembly) are now fully proved. All foundational lemmas and erdos_renyi_decay fully proved.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -86,7 +86,7 @@
       "namespace": "Erdos1179OQ01",
       "lineCount": 525,
       "axiomCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "theoremCount": 23,
       "definitionCount": 5,
       "mainTheorems": [


### PR DESCRIPTION
## Summary

- **Sorry mismatch**: meta.json claimed 2 sorries but Lean source has only 1
- The remaining sorry is `reprCount_fourier_expansion` (line 237) — the Fourier inversion identity
- The second sorry (`fourier_error_bound` assembly) was previously proved and removed from the source

## Audit Evidence

| Check | meta.json | Lean source | Result |
|-------|-----------|-------------|--------|
| Sorries | 2 | 1 | ❌ Fixed → 1 |
| Axioms | 0 | 0 | ✅ Match |
| True stubs | — | None | ✅ Clean |
| Status | `formalized` | 1 sorry | ✅ Correct |
| Badge | `formalized` | — | ✅ Correct |

## Test plan

- [ ] Verify gallery builds: `pnpm build`

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)