### PR TITLE
fix(metadata): correct erdos-1179-oq-01 sorry count (2 → 1)

### DIFF
--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -19,7 +19,7 @@
       "fourier-analysis"
     ],
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 7,
@@ -27,7 +27,7 @@
     "erdosNumber": 1179,
     "erdosUrl": "https://erdosproblems.com/1179",
     "erdosProblemStatus": "open-question",
-    "assumptions": "Zero axioms. Two sorries remain: (1) reprCount_fourier_expansion (the core Fourier inversion identity on Z/pZ via character orthogonality and subset product identity), (2) fourier_error_bound assembly (combining Fourier expansion with product bounds via triangle inequality). Three previously sorry'd lemmas (norm_one_add_omegap_pow, abs_cos_mul_pi_div_le, fourier_product_bound) are now fully proved. All foundational lemmas and erdos_renyi_decay fully proved.",
+    "assumptions": "Zero axioms. One sorry remains: reprCount_fourier_expansion (the core Fourier inversion identity on Z/pZ via character orthogonality and subset product identity). Previously sorry'd lemmas (norm_one_add_omegap_pow, abs_cos_mul_pi_div_le, fourier_product_bound, fourier_error_bound) are now fully proved. All foundational lemmas and erdos_renyi_decay fully proved.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Corrects sorry count in erdos-1179-oq-01 meta.json from 2 to 1.

## Evidence

**Before**: `sorries: 2`, assumptions text mentioned two sorries
**After**: `sorries: 1`, only `reprCount_fourier_expansion` remains as sorry

Verified: `grep -c '\bsorry\b' proofs/Proofs/Erdos1179OQ01.lean` → 1 (line 237)

---
Automated fix by lean-mechanic agent.