### PR TITLE
fix(metadata): correct erdos-1 status from formalized to verified

### DIFF
--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1931)",
     "sourceUrl": "https://erdosproblems.com/1",
     "date": "1931",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1Problem.lean",
     "tags": [
       "erdos",


### PR DESCRIPTION
## Fix

Correct `status` field from `"formalized"` to `"verified"` in erdos-1 meta.json.

## Evidence

**Before**: `status: "formalized"` with `badge: "verified"`, 0 sorries, 0 axioms — inconsistent
**After**: `status: "verified"` — matches badge, sorry count, and axiom count

The Lean file (`Proofs/Erdos1Problem.lean`) proves all three stated theorems with 0 sorries and 0 axiom declarations. No structure-encoded assumptions.

---
Automated fix by lean-mechanic agent.