### PR TITLE
Research: 3 problems — erdos-913 Mersenne conditional, erdos-159 Ramsey, erdos-677 prime divisibility

### DIFF
--- a/proofs/Proofs/Erdos159Problem.lean
+++ b/proofs/Proofs/Erdos159Problem.lean
@@ -222,3 +222,71 @@ theorem ramseyC4Kn_ge (n : ℕ) (hn : 1 ≤ n) : n ≤ ramseyC4Kn n := by
     have hfin : Fintype.card (Fin (ramseyC4Kn n)) = ramseyC4Kn n :=
       Fintype.card_fin _
     omega
+
+/- ## Computed Ramsey values -/
+
+/-- R(C₄, K₁) = 1: any graph on a single vertex trivially has a 1-clique
+    in its complement. On 0 vertices, no Finset has cardinality 1. -/
+theorem ramseyC4Kn_one : ramseyC4Kn 1 = 1 := by
+  classical
+  unfold ramseyC4Kn
+  rw [dif_pos (le_refl 1)]
+  apply Nat.find_eq_iff.mpr
+  refine ⟨fun G => Or.inr ⟨{0}, Finset.card_singleton _,
+    fun u hu v hv huv => absurd (Finset.mem_singleton.mp hu ▸
+      Finset.mem_singleton.mp hv) huv⟩, ?_⟩
+  intro k hk hprop
+  have hk0 : k = 0 := by omega
+  subst hk0
+  rcases hprop ⊥ with ⟨a, _⟩ | ⟨S, hcard, _⟩
+  · exact Fin.elim0 a
+  · have := S.card_le_univ; rw [Fintype.card_fin] at this; omega
+
+/-- R(C₄, K₂) = 4: at 4 vertices, every graph either has C₄ (if complete)
+    or has two non-adjacent vertices (K₂ in complement). Below 4, the complete
+    graph on k vertices has no C₄ and its complement has no K₂. -/
+theorem ramseyC4Kn_two : ramseyC4Kn 2 = 4 := by
+  classical
+  unfold ramseyC4Kn
+  rw [dif_pos (by omega : 1 ≤ 2)]
+  apply Nat.find_eq_iff.mpr
+  constructor
+  · -- At N = 4: every graph has C₄ or K₂ in complement
+    intro G
+    by_cases h : ∀ u v : Fin 4, u ≠ v → G.Adj u v
+    · -- G is complete ⟹ has C₄ (K₄ ⊇ C₄)
+      left
+      exact HasClique_four_hasC4
+        ⟨Finset.univ, Finset.card_fin 4, fun u _ v _ huv => h u v huv⟩
+    · -- G is not complete ⟹ Gᶜ has K₂
+      push_neg at h
+      right
+      obtain ⟨u, v, huv, hnadj⟩ := h
+      refine ⟨{u, v}, ?_, ?_⟩
+      · rw [Finset.card_insert_of_not_mem (Finset.not_mem_singleton.mpr huv),
+            Finset.card_singleton]
+      · intro x hx y hy hxy
+        simp only [Finset.mem_insert, Finset.mem_singleton] at hx hy
+        rw [compl_adj]
+        refine ⟨hxy, ?_⟩
+        rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
+        · exact absurd rfl hxy
+        · exact hnadj
+        · exact fun hadj => hnadj (G.adj_comm.mp hadj)
+        · exact absurd rfl hxy
+  · -- Below N = 4: ⊤ (complete graph) on Fin k is a counterexample
+    intro k hk
+    push_neg
+    refine ⟨⊤, ?_, ?_⟩
+    · -- ¬HasC4 ⊤: need 4 distinct vertices but Fin k has k < 4
+      rintro ⟨a, b, c, d, hab, hbc, hcd, hac, had, hbd, -⟩
+      have := a.isLt; have := b.isLt; have := c.isLt; have := d.isLt
+      interval_cases k <;>
+        simp only [Fin.ext_iff] at hab hbc hcd hac had hbd <;>
+        omega
+    · -- ¬HasClique ⊤ᶜ 2: ⊤ᶜ = ⊥ has no edges
+      rintro ⟨S, hcard, hadj⟩
+      obtain ⟨x, hx, y, hy, hxy⟩ := Finset.one_lt_card.mp (by omega : 1 < S.card)
+      have := hadj x hx y hy hxy
+      rw [compl_top] at this
+      exact this

--- a/proofs/Proofs/Erdos677Problem.lean
+++ b/proofs/Proofs/Erdos677Problem.lean
@@ -169,3 +169,27 @@ theorem consecutiveProduct_succ (n k : ℕ) :
 theorem consecutiveProduct_pos (n k : ℕ) : 0 < consecutiveProduct n k := by
   unfold consecutiveProduct
   exact Finset.prod_pos (fun i _ => by omega)
+
+/- ## Prime divisibility -/
+
+/-- Among any `k` consecutive integers starting at `n+1`, at least one is
+    divisible by `p`, provided `p ≤ k` and `p > 0`. -/
+theorem exists_dvd_in_range (n k p : ℕ) (hp : 0 < p) (hpk : p ≤ k) :
+    ∃ i, i < k ∧ p ∣ (n + i + 1) := by
+  rcases Nat.eq_zero_or_pos ((n + 1) % p) with hr | hr
+  · exact ⟨0, by omega, Nat.dvd_of_mod_eq_zero hr⟩
+  · have hmod := Nat.mod_lt (n + 1) hp
+    refine ⟨p - (n + 1) % p, by omega, ?_⟩
+    rw [Nat.dvd_iff_mod_eq_zero,
+        show n + (p - (n + 1) % p) + 1 = (n + 1) + (p - (n + 1) % p) from by omega,
+        Nat.add_mod,
+        Nat.mod_eq_of_lt (show p - (n + 1) % p < p from by omega),
+        show (n + 1) % p + (p - (n + 1) % p) = p from by omega,
+        Nat.mod_self]
+
+/-- Every prime `p ≤ k` divides `lcmInterval n k`:
+    among `k` consecutive integers, at least one is divisible by `p`. -/
+theorem prime_le_dvd_lcmInterval (n k p : ℕ) (hp : p.Prime) (hpk : p ≤ k) :
+    p ∣ lcmInterval n k := by
+  obtain ⟨i, hi, hpi⟩ := exists_dvd_in_range n k p hp.pos hpk
+  exact dvd_trans hpi (dvd_lcmInterval n k i hi)

--- a/proofs/Proofs/Erdos913Problem.lean
+++ b/proofs/Proofs/Erdos913Problem.lean
@@ -271,4 +271,74 @@ for irreducible polynomials satisfying a fixed-divisor condition.
     This is a weaker form than the full Bunyakovsky conjecture. -/
 def Bunyakovsky8 : Prop := PrimePairs8.Infinite
 
+/-
+## Section 7: Mersenne prime conditional
+
+For k ≥ 2 with 2^k - 1 prime (Mersenne prime), n = 2^k - 1 gives
+n(n+1) = (2^k - 1)·2^k with exponents {1, k}, automatically distinct.
+This provides a second conditional path to Erdős #913, independent of
+the 8p²-1 hypothesis: if infinitely many Mersenne primes exist, the
+conjecture is true.
+-/
+
+/-- The set of exponents k ≥ 2 where 2^k - 1 is a Mersenne prime. -/
+def MersennePrimeExponents : Set ℕ := { k | k ≥ 2 ∧ (2 ^ k - 1).Prime }
+
+/-- The map k ↦ 2^k - 1 is injective on ℕ. -/
+private theorem injective_mersenne : Function.Injective (fun k : ℕ => 2 ^ k - 1) := by
+  intro a b hab
+  simp only at hab
+  by_contra hne
+  rcases Nat.lt_or_gt_of_ne hne with h | h
+  · have : 2 ^ a < 2 ^ b := Nat.pow_lt_pow_right (by norm_num : 1 < 2) h
+    omega
+  · have : 2 ^ b < 2 ^ a := Nat.pow_lt_pow_right (by norm_num : 1 < 2) h
+    omega
+
+/-- For a Mersenne prime 2^k - 1 with k ≥ 2, n = 2^k - 1 has distinct exponents:
+    n(n+1) = (2^k - 1)·2^k with exponents {1, k}. -/
+theorem hasDistinctExponents_mersenne (k : ℕ) (hk : k ≥ 2) (hp : (2 ^ k - 1).Prime) :
+    HasDistinctExponents (2 ^ k - 1) := by
+  have hne1 : 2 ^ k - 1 ≠ 0 := hp.ne_zero
+  have hne2 : (2 : ℕ) ^ k ≠ 0 := pow_ne_zero k (by norm_num)
+  have hm : (2 ^ k - 1) * ((2 ^ k - 1) + 1) = (2 ^ k - 1) * 2 ^ k := by congr 1; omega
+  set m := (2 ^ k - 1) * 2 ^ k with hm_def
+  -- (2^k - 1) doesn't divide 2^k: it's an odd prime > 2
+  have hndvd : ¬((2 ^ k - 1) ∣ 2 ^ k) := by
+    intro h
+    have := Nat.le_of_dvd (by positivity) (hp.dvd_of_dvd_pow h)
+    omega
+  -- Factorization at (2^k - 1) = 1
+  have hv1 : m.factorization (2 ^ k - 1) = 1 := by
+    rw [hm_def, factorization_mul hne1 hne2, Finsupp.add_apply,
+        hp.factorization, Finsupp.single_apply, if_pos rfl,
+        factorization_eq_zero_of_not_dvd hndvd, add_zero]
+  -- Factorization at 2 = k
+  have hv2 : m.factorization 2 = k := by
+    rw [hm_def, factorization_mul hne1 hne2, Finsupp.add_apply,
+        hp.factorization, Finsupp.single_apply, if_neg (show 2 ^ k - 1 ≠ 2 from by omega),
+        zero_add]
+    simp only [Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul,
+        Nat.prime_two.factorization, Finsupp.single_eq_same, mul_one]
+  -- Prime factors
+  have hpf : m.primeFactors = {2 ^ k - 1, 2} := by
+    rw [hm_def, primeFactors_mul hne1 hne2, hp.primeFactors,
+        primeFactors_pow (show (2 : ℕ) ≠ 0 from by norm_num) (show k ≠ 0 from by omega),
+        Nat.prime_two.primeFactors, Finset.singleton_union]
+  exact hasDistinctExponents_of_primeFactors_pair hm hpf (by omega)
+
+/-- Conditional: infinitely many Mersenne primes implies Erdős #913 is true. -/
+theorem erdos_913_conditional_mersenne (h : MersennePrimeExponents.Infinite) :
+    DistinctExponentSet.Infinite := by
+  have hinj : Set.InjOn (fun k => 2 ^ k - 1) MersennePrimeExponents :=
+    fun _ _ _ _ h => injective_mersenne h
+  have himg : ((fun k => 2 ^ k - 1) '' MersennePrimeExponents).Infinite := h.image hinj
+  exact himg.mono (by
+    rintro _ ⟨k, hk_mem, rfl⟩
+    exact hasDistinctExponents_mersenne k hk_mem.1 hk_mem.2)
+
+/-- The distinct exponent set is nonempty (witnessed by n = 3). -/
+theorem nonempty_distinctExponentSet : DistinctExponentSet.Nonempty :=
+  ⟨3, example_n3⟩
+
 end Erdos913

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -61,7 +61,7 @@
       "ramseyC4Kn_ge theorem: trivial lower bound R ≥ n proved from specification (was axiom)"
     ],
     "axiomCount": 2,
-    "lineCount": 224,
+    "lineCount": 292,
     "assumptions": "2 axioms: szemeredi_upper (Szemerédi upper bound), spencer_lower (Spencer lower bound). The Ramsey function ramseyC4Kn and its threshold specification are now defined/proved from the finite Ramsey theorem via Nat.find."
   },
   "overview": {
@@ -158,9 +158,9 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 224,
+    "lineCount": 292,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 4
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -141,7 +141,6 @@
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Nat.Factorization.Basic",
-      "Mathlib.Data.Nat.PrimeNormNum",
       "Mathlib.Data.Finsupp.Basic",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Data.Set.Finite.Basic",
@@ -153,9 +152,9 @@
       "Finset"
     ],
     "namespace": "Erdos913",
-    "lineCount": 274,
-    "axiomCount": 3,
-    "theoremCount": 8,
-    "definitionCount": 5
+    "lineCount": 344,
+    "axiomCount": 1,
+    "theoremCount": 16,
+    "definitionCount": 6
   }
 }

--- a/src/data/research/problems/erdos-913.json
+++ b/src/data/research/problems/erdos-913.json
@@ -29,12 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 2 of 3 axioms (3A→1A). Proved exponent_structure and erdos_913_conditional. Only the open Bunyakovsky-type conjecture remains.",
+    "progressSummary": "PROGRESS: Two independent conditional proofs complete. 8p²-1 path (exponents {1,2,3}) and Mersenne path (exponents {1,k}). 1 axiom remains (Bunyakovsky-type, genuinely open). 0 sorries.",
     "builtItems": [
       "Proved hasDistinctExponents_of_primeFactors_triple: helper for 3-prime-factor cases",
       "Proved example_n31: 31·32 = 2^5·31^1",
       "Proved example_n71: 71·72 = 2^3·3^2·71^1 (first 3-factor example, from 8p²-1 with p=3)",
-      "Proved example_n127: 127·128 = 2^7·127^1"
+      "Proved example_n127: 127·128 = 2^7·127^1",
+      "Added MersennePrimeExponents definition: {k | k ≥ 2 ∧ (2^k-1).Prime}",
+      "Proved hasDistinctExponents_mersenne: Mersenne primes give exponents {1,k}",
+      "Proved erdos_913_conditional_mersenne: infinitely many Mersenne primes ⟹ Erdős #913",
+      "Proved nonempty_distinctExponentSet from example_n3",
+      "Proved injective_mersenne: k↦2^k-1 is injective"
     ],
     "insights": [
       "infinite_8p_sq_minus_1_primes is a Bunyakovsky-type conjecture — open",
@@ -44,7 +49,10 @@
       "All 2-prime-factor examples come from Mersenne-prime-minus-1 patterns: n = 2^k - 1 prime",
       "Proved exponent_structure: primeFactors of (8p²-1)(8p²) = {8p²-1, p, 2} using Mathlib factorization API",
       "Proved erdos_913_conditional via Set.Infinite.image + coprime factorization arithmetic",
-      "Fixed pre-existing build issues: removed deprecated PrimeNormNum import, fixed Nat.pow_left_injective signature change, added explicit type hints for native_decide examples"
+      "Fixed pre-existing build issues: removed deprecated PrimeNormNum import, fixed Nat.pow_left_injective signature change, added explicit type hints for native_decide examples",
+      "Mersenne primes provide a second independent conditional path: 2^k-1 prime gives n(n+1)=(2^k-1)·2^k with exponents {1,k}",
+      "Neither the Bunyakovsky-type nor Mersenne prime hypothesis implies the other — both are independent open conjectures",
+      "The existing examples n=31,127 are exactly Mersenne prime instances (2^5-1, 2^7-1)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -75,10 +83,10 @@
     {
       "path": "Proofs/Erdos913Problem.lean",
       "filename": "Erdos913Problem.lean",
-      "lineCount": 275,
-      "theoremCount": 8,
+      "lineCount": 344,
+      "theoremCount": 16,
       "axiomCount": 1,
-      "defCount": 5,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos913Problem.lean"


### PR DESCRIPTION
## Summary
- **erdos-913**: Add Mersenne prime conditional proof (second independent path to Erdős #913). No new axioms.
- **erdos-159**: Compute concrete Ramsey values R(C₄,K₁)=1 and R(C₄,K₂)=4 via Nat.find.
- **erdos-677**: Prove prime divisibility of lcmInterval — every prime p ≤ k divides M(n,k).

## Progress
- erdos-913: 0 sorries, 1 axiom (unchanged), 16 theorems (up from 8)
- erdos-159: 0 sorries, 2 axioms (unchanged), 10 theorems (up from 8)
- erdos-677: 0 sorries, 1 axiom (unchanged), 17 theorems (up from 15)

## Findings
- Mersenne primes give exponents {1,k} vs 8p²-1 construction's {1,2,3} — independent sufficient conditions
- R(C₄,K₂)=4: complete graph on 4 vertices has C₄ (K₄⊇C₄); below 4, pigeonhole prevents distinct 4-tuple
- exists_dvd_in_range: modular arithmetic proof that k consecutive integers contain a multiple of p ≤ k

## Status
**Outcome**: completed (all 3 problems)

🤖 Generated by researcher-3