### PR TITLE
fix(metadata): correct solution-of-cubic-oq-03-oq-01 status to verified

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
@@ -1,1 +1,24 @@
-{"id":"solution-of-cubic-oq-03-oq-01","title":"Discriminant of the Depressed Cubic","slug":"solution-of-cubic-oq-03-oq-01","description":"Δ = -4p³ - 27q² = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)² for the depressed cubic x³+px+q=0. Includes root nature from discriminant sign.","meta":{"status":"formalized","proofRepoPath":"Proofs/SolutionOfCubicOQ03OQ01.lean","tags":["algebra","polynomials","cubic-equations","discriminant","research"],"badge":"verified","sorries":0,"axiomCount":0,"dateAdded":"2026-03-28"},"sorryCount":0,"status":"formalized","badge":"verified"}
+{
+  "id": "solution-of-cubic-oq-03-oq-01",
+  "title": "Discriminant of the Depressed Cubic",
+  "slug": "solution-of-cubic-oq-03-oq-01",
+  "description": "Δ = -4p³ - 27q² = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)² for the depressed cubic x³+px+q=0. Includes root nature from discriminant sign.",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/SolutionOfCubicOQ03OQ01.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "cubic-equations",
+      "discriminant",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-03-28"
+  },
+  "sorryCount": 0,
+  "status": "verified",
+  "badge": "verified"
+}


### PR DESCRIPTION
## Fix

Correct `status` field from `"formalized"` to `"verified"` in solution-of-cubic-oq-03-oq-01 meta.json (both `meta.status` and top-level `status`).

## Evidence

**Before**: `status: "formalized"` with `badge: "verified"`, 0 sorries, 0 axioms — inconsistent
**After**: `status: "verified"` — matches badge, sorry count, and axiom count

The Lean file (`Proofs/SolutionOfCubicOQ03OQ01.lean`) proves all 3 theorems with 0 sorries and 0 axiom declarations. The `IsRootTriple` structure is a `Prop` (Vieta conditions), not an assumption-encoding structure.

---
Automated fix by lean-mechanic agent.