### PR TITLE
fix(metadata): correct dirichlets-theorem-oq-02 status/badge to verified/original

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Euclid-style argument)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions#Special_cases",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DirichletsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -18,7 +18,7 @@
       "elementary",
       "research"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Correct `status` from `"formalized"` to `"verified"` and `badge` from `"wip"` to `"original"` in dirichlets-theorem-oq-02 meta.json.

## Evidence

**Before**: `status: "formalized"`, `badge: "wip"` — but Lean source has 0 sorries, 0 axioms
**After**: `status: "verified"`, `badge: "original"` — matches actual proof state

The Lean file header explicitly states "Fully proved (0 sorry, 0 axiom)". This is an original elementary proof of infinitely many primes ≡ 3 (mod 4) using Euclid's argument variant.

---
Automated fix by lean-mechanic agent.