### PR TITLE
fix(metadata): correct cayley-hamilton-minpoly-oq-05-oq-01 to verified/original

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,7 +17,7 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Correct `status` from `"formalized"` to `"verified"` and `badge` from `"wip"` to `"original"` in cayley-hamilton-minpoly-oq-05-oq-01 meta.json.

## Evidence

**Before**: `status: "formalized"`, `badge: "wip"` — but Lean source has 0 sorries, 0 axioms
**After**: `status: "verified"`, `badge: "original"` — matches actual proof state

Original proof that nonderogatory matrices have cyclic vectors over infinite fields, using union avoidance over irreducible factor kernels.

---
Automated fix by lean-mechanic agent.