### PR TITLE
fix(metadata): correct schauder-fixed-point-oq-01 to verified/original

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -15,7 +15,7 @@
       "convex-analysis",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Correct `status` from `"formalized"` to `"verified"` and `badge` from `"wip"` to `"original"` in schauder-fixed-point-oq-01 meta.json.

## Evidence

**Before**: `status: "formalized"`, `badge: "wip"` — but Lean source has 0 sorries, 0 axioms
**After**: `status: "verified"`, `badge: "original"` — matches actual proof state

Original proof of the Schauder projection lemma from first principles (partition of unity construction).

---
Automated fix by lean-mechanic agent.