### PR TITLE
fix(metadata): cayley-hamilton-minpoly-oq-02-oq-03 theorem/line count

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
@@ -1,1 +1,37 @@
-{"id":"cayley-hamilton-minpoly-oq-02-oq-03","title":"Rational Canonical Form: Similarity Invariance","slug":"cayley-hamilton-minpoly-oq-02-oq-03","description":"Proves similarity invariance of characteristic and minimal polynomials. Assesses RCF formalization: ~1800 lines needed, Smith normal form is the main gap.","meta":{"author":"Lean Genius","status":"verified","proofRepoPath":"Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean","tags":["linear algebra","matrices","rational canonical form","similarity"],"badge":"mathlib","sorries":0,"axiomCount":0,"lineCount":130,"assumptions":"0 axioms, 0 sorries. Core results (charpoly_conj_of_isUnit, minpoly_conj_of_isUnit) from Mathlib; this file provides the similarity-framed API.","theoremCount":4,"mathlib_version":"4.26.0"},"leanFile":{"namespace":"CayleyHamiltonMinpolyOQ02OQ03","lineCount":130,"axiomCount":0,"theoremCount":4,"definitionCount":2},"crossReferences":[{"targetId":"cayley-hamilton-minpoly-oq-02","relationship":"extends"}]}
+{
+  "id": "cayley-hamilton-minpoly-oq-02-oq-03",
+  "title": "Rational Canonical Form: Similarity Invariance",
+  "slug": "cayley-hamilton-minpoly-oq-02-oq-03",
+  "description": "Proves similarity invariance of characteristic and minimal polynomials. Assesses RCF formalization: ~1800 lines needed, Smith normal form is the main gap.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean",
+    "tags": [
+      "linear algebra",
+      "matrices",
+      "rational canonical form",
+      "similarity"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 136,
+    "assumptions": "0 axioms, 0 sorries. Core results (charpoly_conj_of_isUnit, minpoly_conj_of_isUnit) from Mathlib; this file provides the similarity-framed API.",
+    "theoremCount": 3,
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "namespace": "CayleyHamiltonMinpolyOQ02OQ03",
+    "lineCount": 136,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 2
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-02",
+      "relationship": "extends"
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

Correct theorem count and line count in cayley-hamilton-minpoly-oq-02-oq-03 meta.json.

## Evidence

**Before**: `theoremCount: 4`, `lineCount: 130`
**After**: `theoremCount: 3`, `lineCount: 136`

Lean file has 3 theorems (charpoly_similar, minpoly_similar, similar_implies_invariant_data) and 136 lines.

Closes #7684

---
Automated fix by lean-mechanic agent.