### PR TITLE
fix(metadata): cramers-rule-oq-01-oq-02 theoremCount 26→28

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
@@ -33,7 +33,8 @@
       "Proved quasideterminant simplification for triangular matrices",
       "Proved quasideterminants equal det(A)/entry in the commutative case",
       "Proved proportionality: qdet00 * a11 = a00 * qdet11 over commutative fields"
-    ]
+    ],
+    "theoremCount": 28
   },
   "sections": [
     {
@@ -154,7 +155,7 @@
     "namespace": "CramersRuleOQ01OQ02",
     "lineCount": 462,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 28,
     "definitionCount": 6
   },
   "references": [


### PR DESCRIPTION
## Fix

Correct theorem count in cramers-rule-oq-01-oq-02 meta.json.

## Evidence

**Before**: `theoremCount: 26`
**After**: `theoremCount: 28`

Lean file has 28 theorem declarations (including 2 `@[simp] theorem` entries).

Closes #7685

---
Automated fix by lean-mechanic agent.