### PR TITLE
Research: erdos-684 + erdos-190 — axiom elimination (2 proofs)

### DIFF
--- a/proofs/Proofs/Erdos684Problem.lean
+++ b/proofs/Proofs/Erdos684Problem.lean
@@ -234,14 +234,46 @@ The smooth part is determined by primes in [2, k] dividing C(n,k).
 noncomputable def legendreExponent (n p : ℕ) : ℕ :=
   ∑ i ∈ Finset.range (Nat.log p n + 1), n / p^(i + 1)
 
--- Kummer's theorem: v_p(C(n,k)) = number of carries when adding k + (n-k) in base p
--- Equivalently: v_p(C(n,k)) = v_p(n!) - v_p(k!) - v_p((n-k)!)
--- NOTE: Mathlib has Nat.Prime.multiplicity_choose which expresses this via carries.
--- Converting between multiplicity and factorization uses Nat.multiplicity_eq_factorization.
--- TODO: Replace this axiom with Mathlib's version.
-axiom kummer_theorem (n k p : ℕ) (hp : p.Prime) (hk : k ≤ n) :
+-- Helper: factorization of m! equals the Legendre floor-sum formula
+-- Bridges Mathlib's multiplicity_factorial (PartENat/Ico form) to factorization/range form.
+private theorem factorization_factorial_eq_legendreExponent (m p : ℕ) (hp : p.Prime) :
+    (m !).factorization p = legendreExponent m p := by
+  -- Express factorization as Ico sum via multiplicity bridge
+  have h_ico : (m !).factorization p = ∑ i ∈ Ico 1 (Nat.log p m + 2), m / p ^ i := by
+    have h1 : (↑((m !).factorization p) : PartENat) = multiplicity p (m !) :=
+      (multiplicity_eq_factorization hp (factorial_ne_zero m)).symm
+    have h2 : multiplicity p (m !) =
+        (↑(∑ i ∈ Ico 1 (Nat.log p m + 2), m / p ^ i) : PartENat) :=
+      hp.multiplicity_factorial (by omega)
+    exact_mod_cast h1.trans h2
+  rw [h_ico, legendreExponent]
+  -- Re-index: ∑ i ∈ Ico 1 (N+2), m/p^i = ∑ j ∈ range (N+1), m/p^(j+1)
+  symm
+  exact Finset.sum_nbij (· + 1)
+    (fun a ha => mem_Ico.mpr ⟨by omega, by rw [mem_range] at ha; omega⟩)
+    (fun a _ b _ h => by omega)
+    (fun b hb => ⟨b - 1, mem_range.mpr (by rw [mem_Ico] at hb; omega), by omega⟩)
+    (fun _ _ => rfl)
+
+-- Kummer's theorem: v_p(C(n,k)) via Legendre's formula
+-- v_p(C(n,k)) = v_p(n!) - v_p(k!) - v_p((n-k)!)
+-- Proved from Nat.factorization_mul and the identity C(n,k) * k! * (n-k)! = n!.
+theorem kummer_theorem (n k p : ℕ) (hp : p.Prime) (hk : k ≤ n) :
     (Nat.choose n k).factorization p =
-    legendreExponent n p - legendreExponent k p - legendreExponent (n - k) p
+    legendreExponent n p - legendreExponent k p - legendreExponent (n - k) p := by
+  have hid := choose_mul_factorial_mul_factorial hk
+  have hcnk : Nat.choose n k ≠ 0 := (choose_pos hk).ne'
+  have hkf : k ! ≠ 0 := factorial_ne_zero k
+  have hnkf : (n - k) ! ≠ 0 := factorial_ne_zero (n - k)
+  have h_add : (n !).factorization p =
+      (Nat.choose n k).factorization p + (k !).factorization p + ((n - k) !).factorization p := by
+    rw [show n ! = Nat.choose n k * k ! * (n - k) ! from hid.symm,
+        factorization_mul (mul_ne_zero hcnk hkf) hnkf, Finsupp.add_apply,
+        factorization_mul hcnk hkf, Finsupp.add_apply]
+  rw [← factorization_factorial_eq_legendreExponent n p hp,
+      ← factorization_factorial_eq_legendreExponent k p hp,
+      ← factorization_factorial_eq_legendreExponent (n - k) p hp]
+  omega
 
 /-
 # Part 7: Special Cases

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -53,13 +53,13 @@
       "heuristic_bound definition: 2 log n",
       "heuristic_conjecture axiom: f(n) ~ 2 log n for most n",
       "legendreExponent definition: prime power in n!",
-      "kummer_theorem axiom: prime power in C(n,k)",
+      "kummer_theorem theorem: prime power in C(n,k) (proved from Mathlib)",
       "prime_binomial_structure theorem: p divides C(p,k)",
       "fGeneral definition: generalized problem"
     ],
-    "axiomCount": 6,
-    "lineCount": 363,
-    "assumptions": "6 axiom(s) and 0 sorries. Proved below_f_small (sInf property), f_tendsto_infty_weak (from Mahler), f_lower_bound. Remaining axioms: f_property, mahler_ineffective, tang_bound, rh_conditional_bound, heuristic_conjecture, kummer_theorem (all deep)."
+    "axiomCount": 5,
+    "lineCount": 395,
+    "assumptions": "5 axiom(s) and 0 sorries. Proved kummer_theorem (Legendre's formula via Mathlib's multiplicity_factorial + factorial identity), below_f_small, f_tendsto_infty_weak, f_lower_bound. Remaining axioms: f_property, mahler_ineffective, tang_bound, rh_conditional_bound, heuristic_conjecture."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in [Er79d]. For binomial coefficient C(n,k), we decompose it as u·v where u is the k-smooth part (primes ≤ k) and v is the k-rough part (primes > k).\n\nThe function f(n) asks: how small can k be while still having the smooth part exceed n²?\n\nMahler's classical theorem gives an ineffective bound. Recent work by Tang & ChatGPT (2026) proved f(n) ≤ n^{30/43+o(1)}, with n^{2/3+o(1)} conditional on the Riemann Hypothesis.\n\nRemarkably, heuristic arguments by Sothanaphan & ChatGPT suggest f(n) ~ 2 log n for most n - vastly smaller than proven bounds!\n\nThe sequence f(n) is recorded in OEIS A392019.",
@@ -173,9 +173,9 @@
       "Finset"
     ],
     "namespace": "Erdos684",
-    "lineCount": 363,
-    "axiomCount": 6,
-    "theoremCount": 9,
+    "lineCount": 395,
+    "axiomCount": 5,
+    "theoremCount": 11,
     "definitionCount": 10
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary
Two axiom eliminations in a single research session:

### erdos-684: Prove kummer_theorem (6→5 axioms)
- Converted `kummer_theorem` from axiom to theorem using Mathlib's
  `multiplicity_factorial` (Legendre's formula) bridged via
  `multiplicity_eq_factorization`, plus the factorial identity
  `C(n,k) * k! * (n-k)! = n!` with `factorization_mul` additivity.
- Added helper `factorization_factorial_eq_legendreExponent`.

### erdos-190: Fix incorrect H_le_W, prove W_le_H (7→6 axioms)
- Removed **incorrect** axiom `H_le_W` (claimed H(k) ≤ W(k) — wrong direction).
- Proved `W_le_H`: W(k) ≤ H(k) for k ≥ 3. For 2-colorings, rainbow k-APs
  are impossible (Bool has 2 elements, k ≥ 3), so canonical = monochromatic,
  hence H(k) satisfies the van der Waerden property.

## Files Modified
- `proofs/Proofs/Erdos684Problem.lean` — kummer_theorem axiom→theorem
- `proofs/Proofs/Erdos190Problem.lean` — H_le_W removed, W_le_H proved
- `src/data/proofs/erdos-{684,190}/meta.json` — updated counts

## Status
**Note**: Docker unavailable for local build verification — CI will validate

🤖 Generated by researcher-7