### PR TITLE
Research: erdos-256 + erdos-753 — prove theorems, eliminate 2 sorries

### DIFF
--- a/proofs/Proofs/Erdos256Problem.lean
+++ b/proofs/Proofs/Erdos256Problem.lean
@@ -29,6 +29,7 @@ import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
 import Mathlib.Data.Finset.Basic
 
 open Real Complex
@@ -52,7 +53,7 @@ noncomputable def productPoly (a : Fin n → ℕ) (z : ℂ) : ℂ :=
 M(a₁,...,aₙ) = max_{|z|=1} |P(z; a₁,...,aₙ)|
 -/
 noncomputable def maxOnUnitCircle (a : Fin n → ℕ) : ℝ :=
-  sSup {|productPoly a z| | z : ℂ, Complex.abs z = 1}
+  sSup {r : ℝ | ∃ z : ℂ, ‖z‖ = 1 ∧ r = ‖productPoly a z‖}
 
 /--
 **The function f(n):**
@@ -61,38 +62,15 @@ f(n) = min over all choices of a₁ ≤ ... ≤ aₙ of the maximum on unit circ
 Equivalently: f(n) is the largest m such that for ALL choices, max ≥ m.
 -/
 noncomputable def f (n : ℕ) : ℝ :=
-  sInf {maxOnUnitCircle a | a : Fin n → ℕ}
+  sInf {r : ℝ | ∃ a : Fin n → ℕ, r = maxOnUnitCircle a}
 
 /-
 ## Part II: Known Bounds
 -/
 
-/--
-**Erdős-Szekeres (1959) lower bound:**
-f(n) > √(2n)
--/
+/-- **Erdős-Szekeres (1959) lower bound:** f(n) > √(2n) -/
 axiom erdos_szekeres_lower (n : ℕ) (hn : n ≥ 1) :
     f n > Real.sqrt (2 * n)
-
-/--
-**Erdős-Szekeres (1959) growth:**
-lim f(n)^{1/n} = 1
--/
-
-/--
-**Erdős probabilistic bound:**
-log f(n) ≪ n^{1-c} for some c > 0
--/
-
-/--
-**Atkinson (1961):**
-log f(n) ≪ n^{1/2} log n
--/
-
-/--
-**Odlyzko (1982):**
-log f(n) ≪ n^{1/3} (log n)^{4/3}
--/
 
 /-
 ## Part III: The Main Question
@@ -121,59 +99,99 @@ Erdős's question is NO.
 axiom belov_konyagin_bound :
     ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 2, Real.log (f n) ≤ C * (Real.log n)^4
 
-/--
-**The answer: NO**
--/
+/-- **The answer: NO.** Polynomial growth (n^c) exceeds polylogarithmic growth ((log n)^4)
+    for large n, so the two bounds C * n^c ≤ log(f n) ≤ K * (log n)^4 are incompatible. -/
 theorem erdos_256_answer : ¬ErdosQuestion256 := by
   intro ⟨c, hc, C, hC, hbound⟩
   obtain ⟨K, hK, hupper⟩ := belov_konyagin_bound
-  -- Combining bounds: C * n^c ≤ log(f n) ≤ K * (log n)^4 for all large n.
-  -- But n^c / (log n)^4 → ∞ for c > 0 (polynomial beats polylog),
-  -- giving C * n^c > K * (log n)^4 for large enough n. Contradiction.
-  -- Key Mathlib tool: isLittleO_log_rpow_atTop (log x = o(x^ε))
-  sorry
+  -- For all n ≥ 2: C * n^c ≤ log(f n) ≤ K * (log n)^4
+  -- But n^c grows faster than (log n)^4, giving contradiction for large n.
+  -- Step 1: From isLittleO_log_rpow_atTop, log x ≤ x^(c/8) for large x
+  have hc8 : (0 : ℝ) < c / 8 := by linarith
+  obtain ⟨R, hR⟩ := Filter.eventually_atTop.mp
+    ((isLittleO_log_rpow_atTop hc8).bound (show (0 : ℝ) < 1 by norm_num))
+  -- Step 2: Choose N large enough for log bound and constant absorption
+  set N := max ⌈R⌉₊ (max (⌈(K / C) ^ (2 / c)⌉₊ + 1) 2) with hN_def
+  have hN2 : N ≥ 2 := le_trans (le_trans (le_max_right _ _) (le_max_right _ _)) le_rfl
+  have hN_pos : (0 : ℝ) < (↑N : ℝ) := by positivity
+  have hN_nn : (0 : ℝ) ≤ (↑N : ℝ) := le_of_lt hN_pos
+  have hN1 : (1 : ℝ) ≤ (↑N : ℝ) := by exact_mod_cast show 1 ≤ N by omega
+  -- Step 3: log N ≤ N^(c/8) from isLittleO bound
+  have hR_le : (R : ℝ) ≤ (↑N : ℝ) :=
+    le_trans (Nat.le_ceil R) (by exact_mod_cast (show ⌈R⌉₊ ≤ N from le_max_left _ _))
+  have hlog_raw := hR (↑N : ℝ) hR_le
+  rw [Real.norm_eq_abs, Real.norm_eq_abs,
+      abs_of_nonneg (Real.log_nonneg hN1),
+      abs_of_nonneg (rpow_nonneg hN_nn _)] at hlog_raw
+  have hlog : Real.log (↑N : ℝ) ≤ (↑N : ℝ) ^ (c / 8) := by linarith
+  -- Step 4: (log N)^4 ≤ N^(c/2) by squaring the bound twice
+  have hlog_nn : (0 : ℝ) ≤ Real.log (↑N : ℝ) := Real.log_nonneg hN1
+  have hlog_sq : (Real.log (↑N : ℝ)) ^ 2 ≤ (↑N : ℝ) ^ (c / 4) := by
+    calc (Real.log (↑N : ℝ)) ^ 2
+        = Real.log ↑N * Real.log ↑N := by ring
+      _ ≤ (↑N : ℝ) ^ (c / 8) * (↑N : ℝ) ^ (c / 8) :=
+          mul_le_mul hlog hlog hlog_nn (rpow_nonneg hN_nn _)
+      _ = (↑N : ℝ) ^ (c / 4) := by
+          rw [← rpow_add hN_pos]; congr 1; ring
+  have hlog4 : (Real.log (↑N : ℝ)) ^ 4 ≤ (↑N : ℝ) ^ (c / 2) := by
+    calc (Real.log (↑N : ℝ)) ^ 4
+        = (Real.log ↑N) ^ 2 * (Real.log ↑N) ^ 2 := by ring
+      _ ≤ (↑N : ℝ) ^ (c / 4) * (↑N : ℝ) ^ (c / 4) :=
+          mul_le_mul hlog_sq hlog_sq (pow_nonneg hlog_nn _) (rpow_nonneg hN_nn _)
+      _ = (↑N : ℝ) ^ (c / 2) := by
+          rw [← rpow_add hN_pos]; congr 1; ring
+  -- Step 5: K/C < N^(c/2) from N > (K/C)^(2/c)
+  have hKC_pos : (0 : ℝ) < K / C := div_pos hK hC
+  have hN_gt_KC : (↑N : ℝ) > (K / C) ^ (2 / c) := by
+    have h1 : ⌈(K / C) ^ (2 / c)⌉₊ + 1 ≤ N :=
+      le_trans (le_max_left _ _) (le_max_right _ _)
+    calc (↑N : ℝ) ≥ ↑(⌈(K / C) ^ (2 / c)⌉₊ + 1) := by exact_mod_cast h1
+      _ = ↑⌈(K / C) ^ (2 / c)⌉₊ + 1 := by push_cast; ring
+      _ > (K / C) ^ (2 / c) := by linarith [Nat.le_ceil ((K / C) ^ (2 / c))]
+  have hKC_lt : K / C < (↑N : ℝ) ^ (c / 2) := by
+    have h_exp : (2 : ℝ) / c * (c / 2) = 1 := by field_simp
+    have h_eq : K / C = ((K / C) ^ (2 / c)) ^ (c / 2) := by
+      rw [← rpow_mul hKC_pos.le, h_exp, rpow_one]
+    rw [h_eq]
+    exact rpow_lt_rpow (rpow_nonneg hKC_pos.le _) hN_gt_KC (by linarith)
+  -- Step 6: Combine for contradiction
+  have hK_lt : K < C * (↑N : ℝ) ^ (c / 2) := by
+    have h := mul_lt_mul_of_pos_left hKC_lt hC
+    have hsimp : C * (K / C) = K := by field_simp
+    linarith
+  have key : K * (Real.log (↑N : ℝ)) ^ 4 < C * (↑N : ℝ) ^ c := by
+    calc K * (Real.log (↑N : ℝ)) ^ 4
+        ≤ K * (↑N : ℝ) ^ (c / 2) :=
+          mul_le_mul_of_nonneg_left hlog4 hK.le
+      _ < C * (↑N : ℝ) ^ (c / 2) * (↑N : ℝ) ^ (c / 2) := by
+          nlinarith [rpow_pos_of_pos hN_pos (c / 2)]
+      _ = C * (↑N : ℝ) ^ c := by
+          rw [mul_assoc]; congr 1; rw [← rpow_add hN_pos]; congr 1; ring
+  linarith [hbound N hN2, hupper N hN2]
 
 /-
 ## Part V: The Distinct Case
 -/
 
-/--
-**f*(n) for distinct exponents:**
-When we require a₁ < a₂ < ... < aₙ instead of ≤.
--/
+/-- **f*(n) for distinct exponents:** a₁ < a₂ < ... < aₙ instead of ≤. -/
 noncomputable def fDistinct (n : ℕ) : ℝ :=
-  sInf {maxOnUnitCircle a | a : Fin n → ℕ, Function.Injective a}
-
-/--
-**Bourgain-Chang (2018):**
-log f*(n) ≪ (n log n)^{1/2} log log n
--/
+  sInf {r : ℝ | ∃ a : Fin n → ℕ, Function.Injective a ∧ r = maxOnUnitCircle a}
 
 /-
 ## Part VI: Connection to Chowla Cosine Problem
 -/
 
-/--
-**Chowla cosine problem (Problem #510):**
-For a set A of n integers, find θ minimizing ∑_{a ∈ A} cos(aθ).
--/
-def chowlaMinimum (A : Finset ℤ) : ℝ :=
-  sInf {∑ a ∈ A, Real.cos (a * θ) | θ : ℝ}
-
-/--
-**Atkinson's observation:**
-If for any set A of n integers there exists θ with ∑_{a ∈ A} cos(aθ) < -Mₙ,
-then log f*(n) ≪ Mₙ log n.
--/
+/-- **Chowla cosine problem (Problem #510):**
+For a set A of n integers, find θ minimizing ∑_{a ∈ A} cos(aθ). -/
+noncomputable def chowlaMinimum (A : Finset ℤ) : ℝ :=
+  sInf {r : ℝ | ∃ θ : ℝ, r = ∑ a ∈ A, Real.cos (a * θ)}
 
 /-
 ## Part VII: Properties of the Product
 -/
 
-/--
-**Product at roots of unity:**
-When z is a primitive k-th root of unity, z^k = 1.
--/
+/-- **Product at roots of unity:** When z^k = 1, the product only depends
+on the exponents modulo k. -/
 theorem product_at_root_of_unity (a : Fin n → ℕ) (k : ℕ) (hk : k ≥ 1)
     (z : ℂ) (hz : z^k = 1) (hz1 : z ≠ 1) :
     productPoly a z = ∏ i, (1 - z ^ (a i % k)) := by
@@ -181,64 +199,19 @@ theorem product_at_root_of_unity (a : Fin n → ℕ) (k : ℕ) (hk : k ≥ 1)
   apply Finset.prod_congr rfl
   intro i _
   congr 1
-  -- z^(a i) = z^(a i % k) since z^k = 1
-  rw [show a i = k * (a i / k) + a i % k from (Nat.div_add_mod (a i) k).symm,
-      pow_add, pow_mul, hz, one_pow, one_mul]
-
-/--
-**Lower bound at primitive root:**
-There exists a root of unity where the product is not too small.
--/
+  have : z ^ (a i) = z ^ (a i % k) := by
+    conv_lhs => rw [show a i = k * (a i / k) + a i % k from (Nat.div_add_mod (a i) k).symm]
+    rw [pow_add, pow_mul, hz, one_pow, one_mul]
+  exact this
 
 /-
-## Part VIII: Summary of Bounds
+## Part VIII: Summary
 -/
 
-/--
-**Timeline of bounds on log f(n):**
-
-1959 Erdős-Szekeres: f(n) > √(2n), so log f(n) > (1/2) log(2n)
-1959 Erdős: log f(n) ≪ n^{1-c}
-1961 Atkinson: log f(n) ≪ n^{1/2} log n
-1982 Odlyzko: log f(n) ≪ n^{1/3} (log n)^{4/3}
-1996 Belov-Konyagin: log f(n) ≪ (log n)^4  [BEST UPPER]
--/
-
-/--
-**Gap between bounds:**
-Lower: log f(n) ≥ (1/2) log n  (from f(n) > √(2n))
-Upper: log f(n) ≤ C (log n)^4
-
-The true growth rate is somewhere between these.
--/
-
-/-
-## Part IX: Summary
-
-**Erdős Problem #256: SOLVED**
-
-**Question:** Is log f(n) ≫ n^c for some c > 0?
-
-**Answer:** NO (Belov-Konyagin 1996)
-
-**Final bounds:**
-- Lower: log f(n) ≥ (1/2) log n (from Erdős-Szekeres)
-- Upper: log f(n) ≪ (log n)^4 (Belov-Konyagin)
-
-**The true growth:** Somewhere between log n and (log n)^4.
-
-**Key insight:** The maximum of ∏(1 - z^{aᵢ}) on |z| = 1 grows
-only polylogarithmically in the number of factors.
--/
-
-/--
-**Main result: Erdős #256 is SOLVED**
--/
+/-- **Main result: Erdős #256 is SOLVED** -/
 def erdos_256 : ¬ErdosQuestion256 := erdos_256_answer
 
-/--
-**What we know:**
--/
+/-- Summary: the Belov-Konyagin bound and Erdős-Szekeres lower bound. -/
 theorem erdos_256_summary :
     (∃ C > 0, ∀ n ≥ 2, Real.log (f n) ≤ C * (Real.log n)^4) ∧
     (∀ n ≥ 1, f n > Real.sqrt (2 * n)) := by

--- a/proofs/Proofs/Erdos753Problem.lean
+++ b/proofs/Proofs/Erdos753Problem.lean
@@ -28,8 +28,10 @@ import Mathlib.Combinatorics.SimpleGraph.Coloring
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
 
-open SimpleGraph
+open SimpleGraph Real
 
 namespace Erdos753
 
@@ -146,80 +148,127 @@ axiom alon_counterexample :
 **The conjecture is FALSE.**
 -/
 theorem conjecture_false : ¬ERTConjecture := by
-  intro h
-  obtain ⟨c, hc, hconj⟩ := h
+  intro ⟨c, hc, hconj⟩
   obtain ⟨C, hC, hcounter⟩ := alon_counterexample
-  -- For large enough n, (n log n)^{1/2} < n^{1/2 + c}, contradiction
-  sorry
+  -- Strategy: for large N, C * √(N * log N) < N^(1/2+c), contradicting
+  -- the combination of hconj (lower bound) and hcounter (upper bound).
+  -- Step 1: From isLittleO, log x ≤ x^c for large x
+  obtain ⟨R, hR⟩ := Filter.eventually_atTop.mp
+    ((isLittleO_log_rpow_atTop hc).bound (show (0 : ℝ) < 1 by norm_num))
+  -- Step 2: Choose N large enough
+  set N := max ⌈R⌉₊ (max (⌈C ^ (2 / c)⌉₊ + 1) 2)
+  have hN2 : N ≥ 2 := le_trans (le_trans (le_max_right _ _) (le_max_right _ _)) le_rfl
+  have hN_pos : (0 : ℝ) < (↑N : ℝ) := by positivity
+  have hN_nn : (0 : ℝ) ≤ (↑N : ℝ) := le_of_lt hN_pos
+  have hN_ge1 : (1 : ℝ) ≤ (↑N : ℝ) := by exact_mod_cast show 1 ≤ N by omega
+  -- Step 3: Get Alon counterexample at N
+  obtain ⟨V, hFin, hcard, hDecEq, G, hDecAdj, hDecComp, hle⟩ := hcounter N (by omega)
+  -- Step 4: Get ERT lower bound for same graph
+  have hgt := hconj N (by omega) V hFin hcard hDecEq G hDecAdj hDecComp
+  -- Now: N^(1/2+c) < sum ≤ C * √(N * log N). Need contradiction.
+  -- Step 5: log N ≤ N^c (from isLittleO bound)
+  have hR_le : (R : ℝ) ≤ (↑N : ℝ) :=
+    le_trans (Nat.le_ceil R) (by exact_mod_cast (show ⌈R⌉₊ ≤ N from le_max_left _ _))
+  have hlog_raw := hR (↑N : ℝ) hR_le
+  rw [Real.norm_eq_abs, Real.norm_eq_abs,
+      abs_of_nonneg (Real.log_nonneg hN_ge1),
+      abs_of_nonneg (rpow_nonneg hN_nn _)] at hlog_raw
+  have hlog_le : Real.log (↑N : ℝ) ≤ (↑N : ℝ) ^ c := by linarith
+  -- Step 6: N * log N ≤ N^(1+c)
+  have hlog_nn : (0 : ℝ) ≤ Real.log (↑N : ℝ) := Real.log_nonneg hN_ge1
+  have hprod_le : (↑N : ℝ) * Real.log (↑N : ℝ) ≤ (↑N : ℝ) ^ ((1 : ℝ) + c) := by
+    calc (↑N : ℝ) * Real.log (↑N : ℝ)
+        ≤ (↑N : ℝ) * (↑N : ℝ) ^ c :=
+          mul_le_mul_of_nonneg_left hlog_le hN_nn
+      _ = (↑N : ℝ) ^ ((1 : ℝ) + c) := by
+          rw [rpow_add hN_pos, rpow_one]
+  -- Step 7: √(N * log N) ≤ N^((1+c)/2)
+  have hsqrt_le : Real.sqrt ((↑N : ℝ) * Real.log (↑N : ℝ)) ≤ (↑N : ℝ) ^ (((1 : ℝ) + c) / 2) := by
+    have h1 : Real.sqrt ((↑N : ℝ) * Real.log (↑N : ℝ)) ≤
+        Real.sqrt ((↑N : ℝ) ^ ((1 : ℝ) + c)) :=
+      Real.sqrt_le_sqrt hprod_le
+    have h2 : Real.sqrt ((↑N : ℝ) ^ ((1 : ℝ) + c)) = (↑N : ℝ) ^ (((1 : ℝ) + c) / 2) := by
+      rw [Real.sqrt_eq_rpow, ← rpow_mul hN_nn]; congr 1; ring
+    linarith
+  -- Step 8: C < N^(c/2) (from N > C^(2/c))
+  have hC_lt : C < (↑N : ℝ) ^ (c / 2) := by
+    have hN_gt_C : (↑N : ℝ) > C ^ (2 / c) := by
+      have h1 : ⌈C ^ (2 / c)⌉₊ + 1 ≤ N :=
+        le_trans (le_max_left _ _) (le_max_right _ _)
+      calc (↑N : ℝ) ≥ ↑(⌈C ^ (2 / c)⌉₊ + 1) := by exact_mod_cast h1
+        _ = ↑⌈C ^ (2 / c)⌉₊ + 1 := by push_cast; ring
+        _ > C ^ (2 / c) := by linarith [Nat.le_ceil (C ^ (2 / c))]
+    have h_exp : (2 : ℝ) / c * (c / 2) = 1 := by field_simp
+    calc C = (C ^ (2 / c)) ^ (c / 2) := by
+            rw [← rpow_mul hC.le, h_exp, rpow_one]
+      _ < (↑N : ℝ) ^ (c / 2) := rpow_lt_rpow (rpow_nonneg hC.le _) hN_gt_C (by linarith)
+  -- Step 9: C * N^((1+c)/2) < N^(1/2+c)
+  have hfinal : C * (↑N : ℝ) ^ (((1 : ℝ) + c) / 2) < (↑N : ℝ) ^ (1 / 2 + c) := by
+    calc C * (↑N : ℝ) ^ (((1 : ℝ) + c) / 2)
+        < (↑N : ℝ) ^ (c / 2) * (↑N : ℝ) ^ (((1 : ℝ) + c) / 2) := by
+          nlinarith [rpow_pos_of_pos hN_pos (((1 : ℝ) + c) / 2)]
+      _ = (↑N : ℝ) ^ (1 / 2 + c) := by
+          rw [← rpow_add hN_pos]; congr 1; ring
+  -- Step 10: Contradiction
+  have : C * Real.sqrt (↑N * Real.log ↑N) < (↑N : ℝ) ^ (1 / 2 + c) := by
+    calc C * Real.sqrt (↑N * Real.log ↑N)
+        ≤ C * (↑N : ℝ) ^ (((1 : ℝ) + c) / 2) :=
+          mul_le_mul_of_nonneg_left hsqrt_le hC.le
+      _ < (↑N : ℝ) ^ (1 / 2 + c) := hfinal
+  linarith
 
 /-
 ## Part V: Bounds and Relations
 -/
 
-/--
+/-
 **χ_L(G) ≥ χ(G):**
 List chromatic number is at least the ordinary chromatic number.
 -/
 
-/--
+/-
 **Trivial Lower Bound:**
 χ_L(G) + χ_L(G^c) ≥ √n for most graphs.
 -/
 
-/--
+/-
 **Upper Bound:**
 χ_L(G) ≤ Δ(G) + 1 where Δ is max degree (greedy coloring).
 -/
 
 /-
 ## Part VI: Probabilistic Construction
--/
 
-/--
 **Alon's Construction:**
 The counterexample uses random graphs near the threshold p = 1/2.
 The construction exploits the near-balance between G and G^c.
--/
 
-/--
 **Random Graph G(n, 1/2):**
 At probability 1/2, G and G^c have similar structure.
 -/
 
 /-
 ## Part VII: Related Results
--/
 
-/--
 **Ordinary Chromatic Number:**
 χ(G) + χ(G^c) ≥ 2√n (Nordhaus-Gaddum).
--/
 
-/--
 **Nordhaus-Gaddum Upper Bound:**
 χ(G) + χ(G^c) ≤ n + 1.
--/
 
-/--
 **List vs Ordinary:**
 χ_L and χ can differ significantly (Voigt's example).
 -/
 
 /-
 ## Part VIII: Choosability Properties
--/
 
-/--
 **Bipartite Graphs:**
 Not all bipartite graphs are 2-choosable (unlike 2-colorable).
--/
 
-/--
 **Complete Graphs:**
 K_n has χ_L(K_n) = n (same as χ).
--/
 
-/--
 **Complete Bipartite:**
 K_{n,n} has χ_L = 1 + ⌈log₂ n⌉ (Galvin's theorem).
 -/

--- a/src/data/proofs/erdos-256/meta.json
+++ b/src/data/proofs/erdos-256/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 256,
     "erdosUrl": "https://erdosproblems.com/256",
     "erdosProblemStatus": "solved",
@@ -26,19 +26,19 @@
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
-        "theorem": "Complex.abs",
-        "description": "Absolute value on complex numbers",
-        "module": "Mathlib.Data.Complex.Basic"
-      },
-      {
         "theorem": "Real.log",
         "description": "Real logarithm function",
         "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
       },
       {
-        "theorem": "Real.sqrt",
-        "description": "Square root function",
+        "theorem": "Real.rpow",
+        "description": "Real power function",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "isLittleO_log_rpow_atTop",
+        "description": "log x = o(x^ε) — key for polynomial-beats-polylog argument",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics"
       },
       {
         "theorem": "Finset.prod",
@@ -74,7 +74,7 @@
       "Asymptotic analysis (big-O notation, polynomial vs polylogarithmic growth)"
     ],
     "lineCount": 241,
-    "assumptions": "10 axiom(s) and 2 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs."
+    "assumptions": "2 axiom(s): erdos_szekeres_lower (Erdős-Szekeres 1959) and belov_konyagin_bound (Belov-Konyagin 1996). No sorries."
   },
   "overview": {
     "historicalContext": "This problem traces a 37-year arc through 20th-century harmonic analysis. Paul Erdős and George Szekeres introduced the function f(n) in 1959 in the Acad. Serbe Sci. Publ., proving the lower bound f(n) > √(2n) via a counting argument on roots of unity. Erdős himself obtained the first subexponential upper bound, showing log f(n) ≪ n^{1-c}. Frederick Atkinson improved this to n^{1/2} log n in 1961 using estimates on character sums. Andrew Odlyzko pushed the exponent further to n^{1/3}(log n)^{4/3} in 1982 with methods from analytic number theory. For two decades, the question remained: is the growth polynomial in n (as the upper bounds suggested) or could f(n) be even smaller? Alexander Belov and Sergei Konyagin settled this decisively in 1996 by constructing sequences of exponents for which the product maximum grows only polylogarithmically: log f(n) ≪ (log n)⁴. Their construction used sophisticated probabilistic and harmonic analysis techniques, answering Erdős's question in the negative. More recently, Jean Bourgain and Mei-Chu Chang (2018) studied the variant with distinct exponents, showing different but still subpolynomial behavior.",

--- a/src/data/proofs/erdos-753/meta.json
+++ b/src/data/proofs/erdos-753/meta.json
@@ -20,7 +20,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 753,
     "erdosUrl": "https://erdosproblems.com/753",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary
- Prove `erdos_256_answer : ¬ErdosQuestion256` — the main theorem of Erdős Problem #256
- Prove `conjecture_false : ¬ERTConjecture` — the main theorem of Erdős Problem #753
- Both use the same technique: `isLittleO_log_rpow_atTop` from Mathlib (polynomial growth dominates polylogarithmic growth)
- Fix pre-existing Lean 4 syntax issues in both files
- Sorry count reduced: 1 → 0 in each file (2 total)

## Progress

### Erdős #256 (Maxima of Products on the Unit Circle)
- Belov-Konyagin bound `log f(n) ≤ C*(log n)^4` combined with ErdősQuestion `log f(n) ≥ C*n^c` gives contradiction
- Proof: square the log bound twice via isLittleO to get (log N)^4 ≤ N^(c/2), absorb constant K/C < N^(c/2)

### Erdős #753 (List Chromatic Number of Graph and Complement)  
- Alon's `χ_L(G)+χ_L(G^c) ≤ C*√(n log n)` combined with ERT conjecture `> n^(1/2+c)` gives contradiction
- Proof: log N ≤ N^c gives √(N*log N) ≤ N^((1+c)/2), then C < N^(c/2) gives C*N^((1+c)/2) < N^(1/2+c)

## Status
**Outcome**: completed (2 sorry eliminations)
**Axioms remaining**: 2 per file (deep research results)

🤖 Generated by researcher-8