### PR TITLE
audit: fix erdos-232 sorry count (1 → 0) and line count

### DIFF
--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -17,7 +17,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 232,
     "erdosUrl": "https://erdosproblems.com/232",
     "erdosProblemStatus": "solved",
@@ -68,8 +68,8 @@
       }
     ],
     "axiomCount": 9,
-    "lineCount": 340,
-    "assumptions": "9 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 351,
+    "assumptions": "9 axioms, 0 sorries. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Moser's Problem on Unit-Distance-Avoiding Sets**\n\nLeo Moser posed this problem in 1966 in his collection of 'poorly formulated unsolved problems of combinatorial geometry,' a deliberately provocative title for a set of deceptively deep questions. The problem asks: given a measurable subset $A \\subseteq \\mathbb{R}^2$ containing no two points at Euclidean distance 1, how large can $A$ be in the sense of asymptotic upper density?\n\n**Early Progress (1960s-1970s):**\nThe trivial upper bound $m_1 \\leq 1/2$ follows from a translation argument: for any unit vector $u$, the sets $A$ and $A + u$ must be disjoint, so their combined density cannot exceed 1. For lower bounds, the hexagonal lattice construction -- placing open discs of radius $1/2$ at vertices of a suitably spaced hexagonal lattice -- achieves density $\\pi/(8\\sqrt{3}) \\approx 0.2267$. H.T. Croft improved this in 1967 to $m_1 \\geq 0.22936$ using a modified annular construction.\n\n**Stagnation (1970s-2020s):**\nFor over 50 years, neither the lower bound of 0.22936 nor the trivial upper bound of 1/2 was improved. The problem attracted attention because of its connection to the Hadwiger-Nelson problem (chromatic number of the plane), but the analytic techniques needed for the upper bound seemed out of reach.\n\n**Breakthrough (2023):**\nAmbrus, Csiszarik, Matolcsi, Varga, and Zsamboki proved $m_1 \\leq 0.247$ using Fourier-analytic methods inspired by Delsarte's linear programming bound from coding theory. Their approach studies the autocorrelation of the indicator function $\\mathbf{1}_A$ and exploits the vanishing of its Fourier transform on the unit circle. This definitively answered Erdos's question: YES, $m_1 \\leq 1/4$.\n\n**Current Status:** SOLVED. Best bounds: $0.22936 \\leq m_1 \\leq 0.247$, a gap of only $\\approx 0.018$. The exact value remains unknown.",
@@ -165,10 +165,10 @@
     {
       "id": "examples",
       "title": "Examples",
-      "summary": "Proves the empty set and singletons are unit-distance-free (by vacuity and uniqueness) and states that open balls of radius $1/2$ are unit-distance-free (via the triangle inequality, still a `sorry`).",
+      "summary": "Proves the empty set, singletons, and open balls of radius 1/2 are unit-distance-free (ball proof via triangle inequality, fully verified).",
       "startLine": 246,
       "endLine": 275,
-      "mathContext": "Verified: Proves the empty set and singletons are unit-distance-free (by vacuity and uniqueness) and states that open balls of radius $1/2$ are unit-distance-free (via the triangle inequality, still a `sorry`)."
+      "mathContext": "Verified: Proves the empty set, singletons, and open balls of radius 1/2 are unit-distance-free."
     },
     {
       "id": "chromatic-connection",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "Erdos232",
-    "lineCount": 340,
+    "lineCount": 351,
     "axiomCount": 9,
     "theoremCount": 11,
     "definitionCount": 8


### PR DESCRIPTION
## Summary
- Fix sorry count mismatch: `small_ball_unitDistanceFree` was previously a `sorry` but has been fully proved via triangle inequality. Update `"sorries": 1` → `"sorries": 0`
- Fix line count: `340` → `351` (actual file length)
- Update assumptions text and examples section description to reflect 0 sorries

## Evidence
- `grep -c sorry proofs/Proofs/Erdos232Problem.lean` → 0
- `wc -l proofs/Proofs/Erdos232Problem.lean` → 351

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)