### PR TITLE
fix(metadata): erdos-232 sorries→0, lineCount→351

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3449,9 +3449,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-232": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T03:24:03Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-233": {

--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -17,7 +17,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 232,
     "erdosUrl": "https://erdosproblems.com/232",
     "erdosProblemStatus": "solved",
@@ -68,8 +68,8 @@
       }
     ],
     "axiomCount": 9,
-    "lineCount": 340,
-    "assumptions": "9 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 351,
+    "assumptions": "9 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Moser's Problem on Unit-Distance-Avoiding Sets**\n\nLeo Moser posed this problem in 1966 in his collection of 'poorly formulated unsolved problems of combinatorial geometry,' a deliberately provocative title for a set of deceptively deep questions. The problem asks: given a measurable subset $A \\subseteq \\mathbb{R}^2$ containing no two points at Euclidean distance 1, how large can $A$ be in the sense of asymptotic upper density?\n\n**Early Progress (1960s-1970s):**\nThe trivial upper bound $m_1 \\leq 1/2$ follows from a translation argument: for any unit vector $u$, the sets $A$ and $A + u$ must be disjoint, so their combined density cannot exceed 1. For lower bounds, the hexagonal lattice construction -- placing open discs of radius $1/2$ at vertices of a suitably spaced hexagonal lattice -- achieves density $\\pi/(8\\sqrt{3}) \\approx 0.2267$. H.T. Croft improved this in 1967 to $m_1 \\geq 0.22936$ using a modified annular construction.\n\n**Stagnation (1970s-2020s):**\nFor over 50 years, neither the lower bound of 0.22936 nor the trivial upper bound of 1/2 was improved. The problem attracted attention because of its connection to the Hadwiger-Nelson problem (chromatic number of the plane), but the analytic techniques needed for the upper bound seemed out of reach.\n\n**Breakthrough (2023):**\nAmbrus, Csiszarik, Matolcsi, Varga, and Zsamboki proved $m_1 \\leq 0.247$ using Fourier-analytic methods inspired by Delsarte's linear programming bound from coding theory. Their approach studies the autocorrelation of the indicator function $\\mathbf{1}_A$ and exploits the vanishing of its Fourier transform on the unit circle. This definitively answered Erdos's question: YES, $m_1 \\leq 1/4$.\n\n**Current Status:** SOLVED. Best bounds: $0.22936 \\leq m_1 \\leq 0.247$, a gap of only $\\approx 0.018$. The exact value remains unknown.",
@@ -165,10 +165,10 @@
     {
       "id": "examples",
       "title": "Examples",
-      "summary": "Proves the empty set and singletons are unit-distance-free (by vacuity and uniqueness) and states that open balls of radius $1/2$ are unit-distance-free (via the triangle inequality, still a `sorry`).",
+      "summary": "Proves the empty set and singletons are unit-distance-free (by vacuity and uniqueness) and that open balls of radius $1/2$ are unit-distance-free (via the triangle inequality).",
       "startLine": 246,
-      "endLine": 275,
-      "mathContext": "Verified: Proves the empty set and singletons are unit-distance-free (by vacuity and uniqueness) and states that open balls of radius $1/2$ are unit-distance-free (via the triangle inequality, still a `sorry`)."
+      "endLine": 293,
+      "mathContext": "Verified: Proves the empty set and singletons are unit-distance-free (by vacuity and uniqueness) and that open balls of radius $1/2$ are unit-distance-free (via the triangle inequality)."
     },
     {
       "id": "chromatic-connection",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "Erdos232",
-    "lineCount": 340,
+    "lineCount": 351,
     "axiomCount": 9,
     "theoremCount": 11,
     "definitionCount": 8


### PR DESCRIPTION
## Summary
- **erdos-232**: `sorries` 1→0, `lineCount` 340→351, assumptions text updated, examples section summary corrected
- After commit bcea94e proved `small_ball_unitDistanceFree`, meta.json still claimed 1 sorry

## Audit Details
| Field | Old | New | Source |
|-------|-----|-----|--------|
| `sorries` | 1 | 0 | `grep -c sorry` on Lean file = 0 |
| `lineCount` | 340 | 351 | `wc -l` on Lean file |
| `assumptions` | "9 axiom(s) and 1 sorry(s)" | "9 axiom(s) and 0 sorry(s)" | Lean source |
| examples summary | "still a sorry" | sorry text removed | Lean source |

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page for erdos-232 renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)