### PR TITLE
fix(metadata): erdos-256 lineCount→223, erdos-753 lineCount→310 + assumptions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3599,9 +3599,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-256": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T03:51:44Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-257": {
@@ -6787,9 +6787,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-753": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T03:51:44Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-754": {
@@ -9684,6 +9684,12 @@
       "auditCount": 1,
       "lastAudited": "2026-03-29T01:53:59Z",
       "result": "issues-found",
+      "issues": []
+    },
+    "erdos-1181": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T03:49:13Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },

--- a/src/data/proofs/erdos-256/meta.json
+++ b/src/data/proofs/erdos-256/meta.json
@@ -73,7 +73,7 @@
       "Number theory (primitive roots of unity, modular arithmetic)",
       "Asymptotic analysis (big-O notation, polynomial vs polylogarithmic growth)"
     ],
-    "lineCount": 241,
+    "lineCount": 223,
     "assumptions": "2 axiom(s): erdos_szekeres_lower (Erdős-Szekeres 1959) and belov_konyagin_bound (Belov-Konyagin 1996). No sorries."
   },
   "overview": {
@@ -190,7 +190,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "Erdos256",
-    "lineCount": 241,
+    "lineCount": 223,
     "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-753/meta.json
+++ b/src/data/proofs/erdos-753/meta.json
@@ -57,7 +57,7 @@
       "complement_complement: PROVED (G^c)^c = G by ext and case analysis",
       "ERTConjecture: formal statement of the Erdős-Rubin-Taylor conjecture",
       "alon_counterexample: Alon's O(sqrt(n log n)) bound (axiom)",
-      "conjecture_false: ERTConjecture is false (1 sorry in asymptotic analysis)",
+      "conjecture_false: PROVED ERTConjecture is false via asymptotic analysis",
       "list_chromatic_ge_chromatic, trivial_lower_bound: comparison bounds (axioms)",
       "nordhaus_gaddum, nordhaus_gaddum_upper: classical bounds for ordinary chi (axioms)",
       "list_chromatic_differs_from_chromatic: Voigt's example chi_L > chi (axiom)",
@@ -65,8 +65,8 @@
       "erdos_753_summary: PROVED conjunction of conjecture_false and alon_counterexample"
     ],
     "axiomCount": 2,
-    "lineCount": 261,
-    "assumptions": "15 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 310,
+    "assumptions": "2 axiom(s) and 0 sorry(s). Axioms: listChromaticNumber (axiomatized function), alon_counterexample (Alon 1992 O(√(n log n)) bound)."
   },
   "overview": {
     "historicalContext": "**The List Chromatic Number and Nordhaus-Gaddum Bounds**\n\nThe list chromatic number χ_L(G) (choosability) was introduced by Erdős, Rubin, and Taylor as a generalization of ordinary graph coloring. While χ(G) asks for the minimum colors from a shared palette, χ_L(G) asks for the minimum k such that any assignment of k-element color lists to vertices admits a proper coloring.\n\n**The Nordhaus-Gaddum Motivation:**\n\nThe classical Nordhaus-Gaddum theorem (1956) gives tight bounds for ordinary chromatic number: 2√n ≤ χ(G) + χ(G^c) ≤ n + 1. This naturally led Erdős, Rubin, and Taylor to ask whether χ_L(G) + χ_L(G^c) also grows polynomially faster than √n — specifically, whether there exists c > 0 with χ_L(G) + χ_L(G^c) > n^{1/2+c}.\n\n**Alon's Disproof (1992):**\n\nNoga Alon resolved the question negatively using the probabilistic method. Random graphs G(n, 1/2) have the property that G and G^c are identically distributed, and both have list chromatic number approximately √(n log n)/2. This gives counterexamples where χ_L(G) + χ_L(G^c) = O(√(n log n)). Since √(n log n) = o(n^{1/2+c}) for any c > 0, the conjecture fails.\n\n**The Logarithmic Gap:**\n\nThe remaining question is whether the log factor is necessary: the best known bounds are √n ≤ χ_L(G) + χ_L(G^c) ≤ O(√(n log n)). Whether the log factor can be removed (i.e., whether √n is the correct order) remains open.\n\n**List vs Ordinary Chromatic Number:**\n\nThe result highlights fundamental differences between χ and χ_L. While χ_L(G) ≥ χ(G) always holds, the inequality can be strict (Voigt's planar example), and complement sum bounds behave very differently.",
@@ -181,7 +181,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos753",
-    "lineCount": 261,
+    "lineCount": 310,
     "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 6


### PR DESCRIPTION
## Summary
- **erdos-256**: `lineCount` 241→223
- **erdos-753**: `lineCount` 261→310, `assumptions` "15 axiom(s) and 1 sorry(s)"→"2 axiom(s) and 0 sorry(s)", remove stale sorry mention from originalContributions

## Audit Details

### erdos-256
| Field | Old | New |
|-------|-----|-----|
| `lineCount` | 241 | 223 |

### erdos-753 (HIGH: incorrect assumptions text)
| Field | Old | New |
|-------|-----|-----|
| `lineCount` | 261 | 310 |
| `assumptions` | "15 axiom(s) and 1 sorry(s)" | "2 axiom(s) and 0 sorry(s)" |
| `originalContributions` | "(1 sorry in asymptotic analysis)" | "PROVED via asymptotic analysis" |

The erdos-753 assumptions text was severely wrong — claimed 15 axioms when there are only 2, and claimed 1 sorry when the research commit eliminated all sorries.

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)