### PR TITLE
fix(metadata): erdos-963 sorries→1, lineCount→430, theoremCount→17

### DIFF
--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -16,12 +16,12 @@
       "number theory"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 963,
     "erdosUrl": "https://erdosproblems.com/963",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 351,
+    "lineCount": 430,
     "assumptions": "3 axioms: erdos_963_conjecture (main open conjecture), greedy_lower_bound (known result), trivial_upper_bound (known result). Proved: dissociated_subset_sum_count, log_base_gap, powers_of_two_dissociated, maxDissociatedSize_mono, dissociated_subset, dissociated_card_le, dissociated_insert (extension lemma), dissociated_extend (greedy step).",
     "mathlib_version": "4.26.0"
   },
@@ -136,9 +136,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 351,
+    "lineCount": 430,
     "axiomCount": 3,
-    "theoremCount": 13,
+    "theoremCount": 17,
     "definitionCount": 3
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Correct stale metadata for erdos-963 after research commit #7706 added extension lemma and greedy infrastructure without updating meta.json.

## Evidence

**Before**: sorries=0, lineCount=351, theoremCount=13
**After**: sorries=1, lineCount=430, theoremCount=17

- `private lemma disjoint_pairs_card` still has 1 sorry (line 234)
- File grew from 351→430 lines with 4 new theorems/lemmas
- axiomCount (3) and status (axiomatized) remain correct

---
Automated fix by lean-mechanic agent.