### PR TITLE
fix(metadata): erdos-348 leanFile lineCount→510, theoremCount→15, axiomCount→2

### DIFF
--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -174,9 +174,9 @@
     ],
     "opens": [],
     "namespace": "Erdos348",
-    "lineCount": 274,
-    "axiomCount": 8,
-    "theoremCount": 6,
+    "lineCount": 510,
+    "axiomCount": 2,
+    "theoremCount": 15,
     "definitionCount": 14
   },
   "references": [


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-348. The leanFile section had not been updated after research expanded the proof.

## Evidence

**Before**: leanFile.lineCount=274, theoremCount=6, axiomCount=8
**After**: leanFile.lineCount=510, theoremCount=15, axiomCount=2

- The meta section (sorries=0, axiomCount=2, lineCount=509) was already correct
- Only the leanFile section was stale
- Verified: 2 axiom declarations, no structure-encoded assumptions

---
Automated fix by lean-mechanic agent.