### PR TITLE
fix(metadata): erdos-421 leanFile lineCount→580, theoremCount→25, definitionCount→20

### DIFF
--- a/src/data/proofs/erdos-421/meta.json
+++ b/src/data/proofs/erdos-421/meta.json
@@ -188,10 +188,10 @@
       "Filter"
     ],
     "namespace": "Erdos421",
-    "lineCount": 430,
+    "lineCount": 580,
     "axiomCount": 1,
-    "theoremCount": 3,
-    "definitionCount": 18
+    "theoremCount": 25,
+    "definitionCount": 20
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-421 after research expanded the proof.

## Evidence

**Before**: leanFile.lineCount=430, theoremCount=3, definitionCount=18
**After**: leanFile.lineCount=580, theoremCount=25, definitionCount=20

- meta section (sorries=0, axiomCount=1, lineCount=579) was already correct
- Only the leanFile section was stale

---
Automated fix by lean-mechanic agent.