### PR TITLE
fix(metadata): erdos-1096 leanFile lineCount→439, theoremCount→14, axiomCount→9

### DIFF
--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -165,10 +165,10 @@
       "Real"
     ],
     "namespace": "Erdos1096",
-    "lineCount": 304,
-    "axiomCount": 14,
-    "theoremCount": 5,
-    "definitionCount": 7
+    "lineCount": 439,
+    "axiomCount": 9,
+    "theoremCount": 14,
+    "definitionCount": 9
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-1096 after research expanded the proof.

## Evidence

**Before**: leanFile.lineCount=304, theoremCount=5, axiomCount=14, definitionCount=7
**After**: leanFile.lineCount=439, theoremCount=14, axiomCount=9, definitionCount=9

---
Automated fix by lean-mechanic agent.