### PR TITLE
fix(metadata): erdos-687 leanFile lineCount→457, theoremCount→22, axiomCount→4

### DIFF
--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -138,9 +138,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 370,
-    "axiomCount": 5,
-    "theoremCount": 18,
+    "lineCount": 457,
+    "axiomCount": 4,
+    "theoremCount": 22,
     "definitionCount": 5
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-687 after research expanded the proof.

## Evidence

**Before**: leanFile.lineCount=370, theoremCount=18, axiomCount=5
**After**: leanFile.lineCount=457, theoremCount=22, axiomCount=4

---
Automated fix by lean-mechanic agent.