### PR TITLE
fix(metadata): shannon-channel-coding leanFile lineCount→214, theoremCount→7, axiomCount→5

### DIFF
--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -170,10 +170,10 @@
     ],
     "opens": [],
     "namespace": "InformationTheory.ChannelCoding",
-    "lineCount": 53,
-    "axiomCount": 0,
-    "theoremCount": 4,
-    "definitionCount": 1
+    "lineCount": 214,
+    "axiomCount": 5,
+    "theoremCount": 7,
+    "definitionCount": 5
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for shannon-channel-coding. The leanFile section still reflected the original 53-line stub.

## Evidence

**Before**: leanFile.lineCount=53, theoremCount=4, axiomCount=0, definitionCount=1
**After**: leanFile.lineCount=214, theoremCount=7, axiomCount=5, definitionCount=5

---
Automated fix by lean-mechanic agent.