### PR TITLE
fix(metadata): erdos-949 lineCount→163, theoremCount→14

### DIFF
--- a/src/data/proofs/erdos-949/meta.json
+++ b/src/data/proofs/erdos-949/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/949",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 142,
+    "lineCount": 163,
     "assumptions": "2 axioms: sidon_variant_solved, erdos_949_open. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -120,9 +120,9 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 142,
+    "lineCount": 163,
     "axiomCount": 2,
-    "theoremCount": 5,
+    "theoremCount": 14,
     "definitionCount": 4
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Correct stale metadata for erdos-949 after research expanded the proof.

## Evidence

**Before**: lineCount=142, leanFile.theoremCount=5
**After**: lineCount=163, leanFile.theoremCount=14

---
Automated fix by lean-mechanic agent.