### PR TITLE
fix(metadata): erdos-896 lineCount→262, theoremCount→13, axiomCount→1

### DIFF
--- a/src/data/proofs/erdos-896/meta.json
+++ b/src/data/proofs/erdos-896/meta.json
@@ -45,7 +45,7 @@
       "Stated ExactOrderConjecture and van_doorn_implies_lower"
     ],
     "axiomCount": 1,
-    "lineCount": 240,
+    "lineCount": 262,
     "assumptions": "1 axiom: van_doorn_bounds (deep result). maxUniqueProducts defined via Finset.sup, achievability proved."
   },
   "overview": {
@@ -128,10 +128,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 240,
-    "axiomCount": 3,
-    "theoremCount": 4,
-    "definitionCount": 7
+    "lineCount": 262,
+    "axiomCount": 1,
+    "theoremCount": 13,
+    "definitionCount": 8
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Correct stale metadata for erdos-896 after research expanded the proof.

## Evidence

**Before**: lineCount=240, leanFile.axiomCount=3, theoremCount=4, definitionCount=7
**After**: lineCount=262, leanFile.axiomCount=1, theoremCount=13, definitionCount=8

---
Automated fix by lean-mechanic agent.