### PR TITLE
Research: erdos-1181 + erdos-36 — proofs and definition fixes

### DIFF
--- a/proofs/Proofs/Erdos1181Problem.lean
+++ b/proofs/Proofs/Erdos1181Problem.lean
@@ -131,16 +131,31 @@ def tao_heuristic_bound : Prop :=
     (q n ⌊Real.log (n : ℝ)⌋₊ : ℝ) ≤
       C * (Real.log (Real.log n) / Real.log (Real.log (Real.log n))) * Real.log n
 
+/-- Iterated logarithms grow slower than log:
+    C · (log log n / log log log n) < (1/2) · log n eventually.
+    This is because log n → ∞ while log log n / log log log n grows much slower. -/
+theorem iterated_log_sublinear (C : ℝ) (hC : C > 0) :
+    ∀ᶠ (n : ℕ) in atTop,
+      C * (Real.log (Real.log (n : ℝ)) / Real.log (Real.log (Real.log (n : ℝ)))) <
+        (1 : ℝ) / 2 * Real.log (n : ℝ) := by
+  sorry
+
 /-- If Tao's heuristic holds, then Erdős #1181 follows.
     Proof sketch: C · (log log n / log log log n) · log n ≪ (log n)²
     since (log log n / log log log n) → ∞ much slower than log n. -/
 theorem tao_implies_erdos1181 (h : tao_heuristic_bound) : erdos1181_conjecture := by
   obtain ⟨C, hC, hev⟩ := h
   refine ⟨1/2, by norm_num, ?_⟩
-  filter_upwards [hev] with n hn
+  -- For large n, the Tao bound implies the Erdős bound:
+  -- q ≤ C·(loglog/logloglog)·log n < (1/2)·(log n)² when C·(loglog/logloglog) < (1/2)·log n
+  filter_upwards [hev, iterated_log_sublinear C hC,
+    Filter.eventually_ge_atTop 3] with n hn hgrowth hn3
+  have hln_pos : (0 : ℝ) < Real.log (n : ℝ) := by
+    apply Real.log_pos; push_cast; omega
   calc (q n ⌊Real.log (↑n : ℝ)⌋₊ : ℝ)
       ≤ C * (Real.log (Real.log n) / Real.log (Real.log (Real.log n))) * Real.log n := hn
-    _ < (1 - 1/2) * (Real.log n) ^ 2 := by sorry
+    _ < (1 : ℝ) / 2 * Real.log (n : ℝ) * Real.log (n : ℝ) := by nlinarith
+    _ = (1 - 1 / 2) * (Real.log (n : ℝ)) ^ 2 := by ring
 
 -- ============================================================================
 -- Part VI: Connection to Primorials and PNT
@@ -198,11 +213,22 @@ theorem conjectures_compatible (h457 : erdos457_conjecture) (h1181 : erdos1181_c
   obtain ⟨ε, hε, h457_inf⟩ := h457
   obtain ⟨c, hc, h1181_ev⟩ := h1181
   refine ⟨ε, c, hε, hc, ?_⟩
-  -- The set of n satisfying both conditions is infinite:
-  -- #457 gives infinitely many n with the lower bound,
-  -- #1181 gives all large n satisfy the upper bound,
-  -- so their intersection is infinite.
-  sorry
+  -- The set satisfying the upper bound is cofinite (from the eventually condition).
+  -- The set satisfying the lower bound is infinite (from #457).
+  -- An infinite set minus a finite set is infinite.
+  obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp h1181_ev
+  have h_comp_finite :
+      {n : ℕ | ¬((q n ⌊Real.log (↑n : ℝ)⌋₊ : ℝ) <
+        (1 - c) * (Real.log (↑n : ℝ)) ^ 2)}.Finite := by
+    apply Set.Finite.subset (Set.finite_Iio N)
+    intro n hn
+    simp only [Set.mem_setOf_eq] at hn
+    simp only [Set.mem_Iio]
+    by_contra h_ge
+    push_neg at h_ge
+    exact hn (hN n h_ge)
+  exact (h457_inf.diff h_comp_finite).mono fun n hn =>
+    ⟨hn.1, not_not.mp hn.2⟩
 
 -- ============================================================================
 -- Part VIII: Summary

--- a/proofs/Proofs/Erdos36Problem.lean
+++ b/proofs/Proofs/Erdos36Problem.lean
@@ -16,13 +16,16 @@ Reference: https://erdosproblems.com/36
 Wikipedia: https://en.wikipedia.org/wiki/Minimum_overlap_problem
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Int.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic
+import Mathlib
 
-/- ## Definition -/
+open Finset
+
+-- ============================================================================
+-- Part I: Core Definitions
+-- ============================================================================
+
+/-- The interval {1, ..., 2N} as a finset of integers. -/
+def interval (N : ℕ) : Finset ℤ := Finset.Icc 1 (2 * ↑N)
 
 /-- The overlap of sets A, B at difference k: the number of pairs
     (a, b) with a ∈ A, b ∈ B, a − b = k. -/
@@ -31,53 +34,121 @@ def overlap (A B : Finset ℤ) (k : ℤ) : ℕ :=
 
 /-- The maximum overlap over all integer differences. -/
 noncomputable def maxOverlap (A B : Finset ℤ) : ℕ :=
-  Finset.sup (A.image fun a => a) (fun _ => 0)  -- axiomatized below
+  ((A ×ˢ B).image (fun p : ℤ × ℤ => p.1 - p.2)).sup (overlap A B)
 
 /-- M(N): the minimum maximum overlap over all equal partitions
     of {1, ..., 2N}. -/
-noncomputable def minMaxOverlap : ℕ → ℕ := fun _ => 0  -- axiomatized
+noncomputable def minMaxOverlap (N : ℕ) : ℕ :=
+  let I := interval N
+  let parts := I.powerset.filter (fun A => A.card = N)
+  parts.sup (fun A => maxOverlap A (I \ A))  -- sup works but we want inf; see axiomatized version below
 
-/- ## Main Question -/
+-- NOTE: Lean's ℕ lacks ⊤ for Finset.inf, so minMaxOverlap using Finset.sup
+-- above gives the WRONG quantity (max instead of min). We axiomatize M(N)
+-- directly with achievability and minimality axioms below.
+
+-- ============================================================================
+-- Part II: Basic Properties
+-- ============================================================================
+
+/-- The product cardinality: |A ×ˢ B| = |A| × |B|. -/
+theorem product_card (A B : Finset ℤ) : (A ×ˢ B).card = A.card * B.card :=
+  Finset.card_product A B
+
+-- ============================================================================
+-- Part III: M(N) Definition
+-- ============================================================================
+
+/-- The set of all N-element subsets of {1,...,2N}. -/
+noncomputable def partitions (N : ℕ) : Finset (Finset ℤ) :=
+  (interval N).powerset.filter (fun A => A.card = N)
+
+/-- The set of max overlaps across all partitions. -/
+noncomputable def overlapValues (N : ℕ) : Finset ℕ :=
+  (partitions N).image (fun A => maxOverlap A (interval N \ A))
+
+/-- M(N): the minimum maximum overlap over all equal partitions
+    of {1, ..., 2N}. Defined via Finset.min' on the image of
+    maxOverlap over all N-element subsets. Returns 0 when N = 0
+    (vacuously: only partition is ∅ ⊔ ∅). -/
+noncomputable def M (N : ℕ) : ℕ :=
+  if h : (overlapValues N).Nonempty then (overlapValues N).min' h else 0
 
 /-- **Erdős Problem #36**: Determine the asymptotic constant
     c = lim M(N)/N. The problem is to find the exact value of c. -/
 axiom erdos_36_limit_exists :
   ∃ c : ℝ, c > 0 ∧
     ∀ ε > 0, ∃ N₀ : ℕ, ∀ N ≥ N₀,
-      |((minMaxOverlap N : ℝ) / N) - c| < ε
+      |((M N : ℝ) / N) - c| < ε
 
-/- ## Known Bounds -/
+-- ============================================================================
+-- Part V: Known Bounds
+-- ============================================================================
 
-/-- **Erdős (1955)**: trivial lower bound M(N)/N > 1/4. -/
+/-- **Erdős (1955)**: trivial lower bound M(N)/N > 1/4.
+    Proof sketch: N² pairs in at most 4N-1 differences ⟹
+    max overlap ≥ N²/(4N-1) > N/4. -/
 axiom erdos_lower_quarter :
-  ∀ N : ℕ, N ≥ 1 → (minMaxOverlap N : ℝ) / N > 1 / 4
+  ∀ N : ℕ, N ≥ 1 → (M N : ℝ) / N > 1 / 4
 
 /-- **Scherk (1955)**: improved lower bound M(N)/N > 1 − 1/√2 ≈ 0.293. -/
 axiom scherk_lower :
   ∀ N : ℕ, N ≥ 1 →
-    (minMaxOverlap N : ℝ) / N > 1 - Real.sqrt 2⁻¹
+    (M N : ℝ) / N > 1 - 1 / Real.sqrt 2
 
 /-- **White (2022)**: best known lower bound M(N)/N > 0.379005,
     obtained via Fourier analysis and convex optimization. -/
 axiom white_lower :
   ∀ N : ℕ, N ≥ 1 →
-    (minMaxOverlap N : ℝ) / N > 379005 / 1000000
+    (M N : ℝ) / N > 379005 / 1000000
 
 /-- **Haugland (2016)**: upper bound M(N)/N < 0.380926 via step
     functions. Improved to 0.380876 by TTT-Discover (2026). -/
 axiom upper_bound :
   ∀ N : ℕ, N ≥ 1 →
-    (minMaxOverlap N : ℝ) / N < 380876 / 1000000
+    (M N : ℝ) / N < 380876 / 1000000
 
-/- ## Small Values -/
+-- ============================================================================
+-- Part VI: Small Values
+-- ============================================================================
 
 /-- Known exact values: M(1) = 1, M(2) = 1, M(3) = 2, M(4) = 2, M(5) = 3. -/
 axiom small_values :
-  minMaxOverlap 1 = 1 ∧ minMaxOverlap 2 = 1 ∧
-  minMaxOverlap 3 = 2 ∧ minMaxOverlap 4 = 2 ∧
-  minMaxOverlap 5 = 3
+  M 1 = 1 ∧ M 2 = 1 ∧ M 3 = 2 ∧ M 4 = 2 ∧ M 5 = 3
 
-/- ## Observations -/
+-- ============================================================================
+-- Part VII: Consequences and Observations
+-- ============================================================================
+
+/-- The bounds sandwich the asymptotic constant:
+    0.379005 < c < 0.380876. -/
+theorem constant_bounds :
+  ∀ c : ℝ, (∀ ε > 0, ∃ N₀ : ℕ, ∀ N ≥ N₀, |((M N : ℝ) / N) - c| < ε) →
+    c ≥ 379005 / 1000000 ∧ c ≤ 380876 / 1000000 := by
+  intro c hc
+  constructor
+  · -- Lower bound: from white_lower
+    by_contra h
+    push_neg at h
+    have hε : (0 : ℝ) < 379005 / 1000000 - c := by linarith
+    obtain ⟨N₀, hN₀⟩ := hc _ hε
+    have hN : N₀ + 1 ≥ 1 := by omega
+    have h1 := white_lower (N₀ + 1) hN
+    have h2 := hN₀ (N₀ + 1) (by omega)
+    rw [abs_lt] at h2
+    linarith
+  · -- Upper bound: from upper_bound
+    by_contra h
+    push_neg at h
+    have hε : (0 : ℝ) < c - 380876 / 1000000 := by linarith
+    obtain ⟨N₀, hN₀⟩ := hc _ hε
+    have hN : N₀ + 1 ≥ 1 := by omega
+    have h1 := upper_bound (N₀ + 1) hN
+    have h2 := hN₀ (N₀ + 1) (by omega)
+    rw [abs_lt] at h2
+    linarith
+
+/- ## Historical Notes -/
 
 /- **Erdős' Original Conjecture**: Erdős initially conjectured c = 1/2,
     but this was disproved. The true value is near 0.38. -/

--- a/research/problems/erdos-1181/knowledge.md
+++ b/research/problems/erdos-1181/knowledge.md
@@ -12,7 +12,7 @@ Is it true that there exists some c > 0 such that, for all large n,
 **Formalization Status**: COMPLETE (axiomatized)
 
 **Tractability Score**: 6/10
-**Aristotle Suitable**: Yes (2 theorem sorries)
+**Aristotle Suitable**: Yes (1 theorem sorry: iterated_log_sublinear)
 
 ## Tags
 
@@ -49,6 +49,8 @@ Would be dramatically stronger than the (1-c)(log n)² conjecture.
 - q_prime: from Nat.find_spec
 - q_not_dvd: from Nat.find_spec
 - q_minimal: from Nat.find_min
+- **conjectures_compatible**: infinite set ∩ cofinite set is infinite (Set.Infinite.diff + Filter.eventually_atTop)
+- **tao_implies_erdos1181**: calc proof complete (modulo iterated_log_sublinear)
 
 ### Axioms (4)
 1. trivial_upper_bound: (1+o(1))(log n)² bound via primorial/PNT
@@ -56,9 +58,12 @@ Would be dramatically stronger than the (1-c)(log n)² conjecture.
 3. pnt_chebyshev: PNT for Chebyshev function θ(x) ~ x
 4. primorial_divides_bound: if all primes < q divide m, then θ(q) ≤ log m
 
-### Sorries (2 theorem stubs)
-1. tao_implies_erdos1181: asymptotic comparison (Aristotle candidate)
-2. conjectures_compatible: intersection of infinite set with cofinite set
+### Sorries (1 theorem)
+1. iterated_log_sublinear: C·(loglog n / logloglog n) < (1/2)·log n eventually
+
+### Notes on Axioms
+- **pnt_chebyshev**: PNT is NOT in base Mathlib. The PrimeNumberTheoremAnd external project has it, but it's not integrated.
+- **primorial_divides_bound**: Potential issue — θ sums primes ≤ q_val (inclusive via Icc) but hypothesis covers primes < q_val (strict).
 
 ## References
 
@@ -74,6 +79,12 @@ Would be dramatically stronger than the (1-c)(log n)² conjecture.
 - Built constructive q(n,k) definition (Nat.find, no axioms)
 - Created gallery entry with full annotations
 - 2 Aristotle-suitable theorem sorries identified
+
+### Session 2 (2026-03-29, researcher-6)
+- **Proved conjectures_compatible** (eliminated 1 sorry): Set.Infinite.diff + Filter.eventually_atTop
+- **Restructured tao_implies_erdos1181**: isolated growth comparison as iterated_log_sublinear, proved calc steps
+- Net result: 2 sorries → 1, 7 theorems → 8, 235 → 261 lines
+- Investigated PNT in Mathlib — not in base Mathlib, axiom stays
 
 ---
 

--- a/src/data/proofs/erdos-1181/meta.json
+++ b/src/data/proofs/erdos-1181/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 1181,
     "erdosUrl": "https://erdosproblems.com/1181",
     "erdosProblemStatus": "open",
@@ -73,11 +73,13 @@
       "chebyshev_theta definition: Chebyshev function θ(x)",
       "pnt_chebyshev axiom: PNT for Chebyshev function",
       "erdos457_conjecture definition: related lower bound conjecture",
-      "conjectures_compatible theorem stub: compatibility of #457 and #1181"
+      "conjectures_compatible theorem: proved compatibility of #457 and #1181 (infinite ∩ cofinite)",
+      "iterated_log_sublinear theorem: isolated growth comparison for Aristotle",
+      "tao_implies_erdos1181: restructured with iterated_log_sublinear, main calc proved"
     ],
     "axiomCount": 4,
-    "lineCount": 235,
-    "assumptions": "4 axioms: trivial_upper_bound (primorial/PNT), erdos_1181 (main open conjecture), pnt_chebyshev (PNT for Chebyshev function), primorial_divides_bound (primorial divides product). Properties of q(n,k) proved constructively."
+    "lineCount": 261,
+    "assumptions": "4 axioms: trivial_upper_bound (primorial/PNT), erdos_1181 (main open conjecture), pnt_chebyshev (PNT for Chebyshev function), primorial_divides_bound (primorial divides product). Properties of q(n,k) proved constructively. 1 sorry: iterated_log_sublinear (growth rate comparison for Aristotle)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1181** appears in Erdős [Er79d, p.78] and asks for an upper bound on q(n, log n), the least prime not dividing a product of consecutive integers. The trivial upper bound q(n, log n) ≤ (1+o(1))(log n)² follows from the primorial argument combined with the Prime Number Theorem. The conjecture asks whether the constant can be improved from (1+o(1)) to (1-c) for some fixed c > 0.\n\nThis is the companion upper bound question to Erdős Problem #457, which asks about lower bounds. Together they aim to pin down the growth rate of q(n, log n) between Ω(log n) and O((log n)²). Probabilistic heuristics described by Tao in the context of Problem #457 suggest a much stronger bound of q(n, log n) ≪ (log log n / log log log n) · log n.",
@@ -132,10 +134,10 @@
     {
       "id": "tao-heuristic",
       "title": "Part V: Tao's Heuristic Bound",
-      "startLine": 116,
-      "endLine": 140,
-      "summary": "Tao's heuristic: q ≪ (log log n / log log log n) · log n. Theorem stub: this implies #1181.",
-      "mathContext": "Probabilistic heuristics predict a bound dramatically stronger than the conjecture."
+      "startLine": 118,
+      "endLine": 158,
+      "summary": "Tao's heuristic: q ≪ (log log n / log log log n) · log n. tao_implies_erdos1181 proved modulo iterated_log_sublinear.",
+      "mathContext": "Probabilistic heuristics predict a bound dramatically stronger than the conjecture. The implication is proved by reducing to a growth rate comparison of iterated logarithms."
     },
     {
       "id": "chebyshev-pnt",
@@ -148,10 +150,10 @@
     {
       "id": "connection-457",
       "title": "Part VII: Connection to Problem #457",
-      "startLine": 168,
-      "endLine": 193,
-      "summary": "erdos457_conjecture definition. conjectures_compatible theorem stub.",
-      "mathContext": "Problem #457 (lower bound) and #1181 (upper bound) together sandwich q(n, log n) between Ω(log n) and O((log n)²)."
+      "startLine": 188,
+      "endLine": 231,
+      "summary": "erdos457_conjecture definition. conjectures_compatible theorem proved (infinite ∩ cofinite argument).",
+      "mathContext": "Problem #457 (lower bound) and #1181 (upper bound) together sandwich q(n, log n) between Ω(log n) and O((log n)². Proved that both conjectures holding simultaneously gives infinitely many n with both bounds."
     },
     {
       "id": "summary",
@@ -184,9 +186,9 @@
       "Finset"
     ],
     "namespace": "Erdos1181",
-    "lineCount": 235,
+    "lineCount": 261,
     "axiomCount": 4,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 6
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -49,11 +49,12 @@
     ],
     "originalContributions": [
       "Defined overlap(A,B,k) as representation function of A−B",
-      "Defined maxOverlap and minMaxOverlap M(N) as minimax quantities",
-      "Stated erdos_36_limit_exists: limit c = lim M(N)/N exists and is positive",
-      "Axiomatized four progressively tighter bounds: Erdős (1/4), Scherk (1−1/√2), White (0.379005), Haugland-TTT (0.380876)",
-      "Recorded exact small values M(1)=1 through M(5)=3",
-      "Noted Erdős's disproved c=1/2 conjecture and Fourier-analytic techniques"
+      "Defined maxOverlap via Finset.sup on difference image (proper, not stub)",
+      "Defined M(N) constructively via Finset.min' over partition overlap values",
+      "Defined interval, partitions, overlapValues helper definitions",
+      "Proved constant_bounds: axiom sandwich 0.379005 ≤ c ≤ 0.380876",
+      "Proved product_card from Finset.card_product",
+      "Axiomatized four progressively tighter bounds and small values"
     ],
     "axiomCount": 6,
     "prerequisites": [
@@ -63,7 +64,7 @@
       "Asymptotic analysis: limit of M(N)/N"
     ],
     "assumptions": "6 axiom declarations: erdos_36_limit_exists (the limit c = lim M(N)/N exists — the main open question), erdos_lower_quarter (Erdős's 1/4 lower bound), scherk_lower (Scherk's 1−1/√2 ≈ 0.293 lower bound via Fourier), white_lower (White's 0.379 lower bound via convex optimization), upper_bound (Haugland's 0.381 upper bound), small_values (computed M(N) for small N). The limit existence and bounds are established results.",
-    "lineCount": 91,
+    "lineCount": 162,
     "relatedProblems": [
       {
         "id": "erdos-335",
@@ -76,10 +77,10 @@
     ]
   },
   "leanFile": {
-    "lineCount": 91,
+    "lineCount": 162,
     "axiomCount": 6,
-    "theoremCount": 0,
-    "definitionCount": 3,
+    "theoremCount": 2,
+    "definitionCount": 7,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Int.Basic",

--- a/src/data/research/problems/erdos-1181.json
+++ b/src/data/research/problems/erdos-1181.json
@@ -29,13 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Created full formalization of Erdős #1181 (upper bound on q(n,log n)). Lean file with constructive q definition, trivial upper bound axiom, main conjecture, Tao heuristic, Chebyshev/PNT connection, and link to #457.",
+    "progressSummary": "PROGRESS: Proved conjectures_compatible (sorry eliminated). Restructured tao_implies_erdos1181 — calc proof complete, isolated iterated_log_sublinear as sole remaining sorry. File: 261 lines, 4 axioms, 1 sorry, 8 theorems.",
     "builtItems": [
       "Created proofs/Proofs/Erdos1181Problem.lean (194 lines)",
       "Created src/data/proofs/erdos-1181/ gallery entry (meta.json, annotations.json, index.ts)",
       "Defined consecutiveProduct, q(n,k), chebyshev_theta, erdos1181_conjecture, tao_heuristic_bound, erdos457_conjecture",
       "Proved consecutiveProduct_pos, q_prime, q_not_dvd, q_minimal constructively",
-      "2 theorem sorries: tao_implies_erdos1181 (asymptotic comparison), conjectures_compatible (infinite intersection)"
+      "2 theorem sorries: tao_implies_erdos1181 (asymptotic comparison), conjectures_compatible (infinite intersection)",
+      "Proved conjectures_compatible theorem (was sorry, now complete)",
+      "Created iterated_log_sublinear lemma (Aristotle target, 1 sorry)",
+      "Restructured tao_implies_erdos1181: calc proof complete modulo iterated_log_sublinear"
     ],
     "insights": [
       "No formalization exists - problem needs initial Lean file creation",
@@ -43,13 +46,16 @@
       "Trivial bound (1+o(1))(log n)² follows from primorial argument + PNT",
       "Tao heuristic suggests much stronger bound: q ≪ (log log n / log log log n) · log n",
       "q(n,k) defined constructively via Nat.find (no axioms needed for definition)",
-      "Key properties q_prime, q_not_dvd, q_minimal all proved constructively"
+      "Key properties q_prime, q_not_dvd, q_minimal all proved constructively",
+      "conjectures_compatible proved: infinite set (lower bound) intersected with cofinite set (upper bound eventually) is infinite, using Set.Infinite.diff and Filter.eventually_atTop",
+      "iterated_log_sublinear isolated as standalone lemma for Aristotle — the sole remaining sorry in the file",
+      "PNT is NOT in base Mathlib — pnt_chebyshev axiom must remain until PrimeNumberTheoremAnd or equivalent is integrated"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Submit 2 theorem sorries to Aristotle (tao_implies_erdos1181, conjectures_compatible)",
-      "Investigate if primorial_divides_bound can be proved from Mathlib",
-      "Connect chebyshev_theta to Mathlib ArithmeticFunction if available"
+      "Submit iterated_log_sublinear to Aristotle (growth comparison: C·loglog/logloglog < (1/2)·log n eventually)",
+      "Investigate primorial_divides_bound axiom — may have a bug (θ sums ≤q but hypothesis is <q)",
+      "Long-term: integrate PrimeNumberTheoremAnd to eliminate pnt_chebyshev axiom"
     ],
     "markdown": "# Erdős #1181 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-02-08*\n"
   },

--- a/src/data/research/problems/erdos-36.json
+++ b/src/data/research/problems/erdos-36.json
@@ -29,13 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Erdos368Problem.lean axiom elimination 11→5 (6 eliminated). Proved coprime factorization from Mathlib.",
+    "progressSummary": "PROGRESS: Fixed stub definitions (maxOverlap, M). Proved constant_bounds + product_card. File: 162 lines, 6 axioms, 0 sorries, 2 theorems, 7 defs.",
     "builtItems": [
       "Proved primeFactors_product_coprime from Mathlib Nat.primeFactors_mul",
-      "Converted 5 unused axiom propositions to def Prop"
+      "Converted 5 unused axiom propositions to def Prop",
+      "Fixed maxOverlap: real Finset.sup definition over difference image",
+      "Defined M via Finset.min on overlapValues (constructive, not stub)",
+      "Proved constant_bounds theorem from white_lower + upper_bound axioms",
+      "Added interval, partitions, overlapValues helper definitions"
     ],
     "insights": [
-      "Erdos368Problem.lean: 6 axioms eliminated (11→5). primeFactors_product_coprime proved from Nat.primeFactors_mul (Mathlib). 5 unused axioms converted to def Prop."
+      "Erdos368Problem.lean: 6 axioms eliminated (11→5). primeFactors_product_coprime proved from Nat.primeFactors_mul (Mathlib). 5 unused axioms converted to def Prop.",
+      "maxOverlap and minMaxOverlap were stubs (returning 0), making axioms inconsistent — fixed with proper definitions",
+      "M(N) now constructively defined via Finset.min over partition overlap image",
+      "constant_bounds proved: if c = lim M(N)/N then 0.379005 ≤ c ≤ 0.380876 (from axiom sandwich)"
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Two research problems worked on in this session:

### erdos-1181 (Upper Bound on q(n, log n))
- **Proved `conjectures_compatible`** theorem (was sorry): infinite set ∩ cofinite set argument using `Set.Infinite.diff` + `Filter.eventually_atTop`
- **Restructured `tao_implies_erdos1181`**: isolated growth comparison as standalone `iterated_log_sublinear` lemma (Aristotle target), proved remaining calc steps via `nlinarith` + `ring`
- Net: 2 sorries → 1, 7 theorems → 8, 235 → 261 lines

### erdos-36 (Minimum Overlap Problem)
- **Fixed stub definitions**: `maxOverlap` was returning 0, now properly defined via `Finset.sup` over difference image
- **Defined M(N) constructively** via `Finset.min'` over partition overlap values (was `fun _ => 0`)
- **Proved `constant_bounds`**: if c = lim M(N)/N then 0.379005 ≤ c ≤ 0.380876
- Net: 0 → 2 theorems, 3 → 7 defs, 92 → 162 lines, 6 axioms preserved

## Files Modified
- `proofs/Proofs/Erdos1181Problem.lean` — proof + restructuring
- `proofs/Proofs/Erdos36Problem.lean` — definitions + proofs
- `src/data/proofs/erdos-{1181,36}/meta.json` — updated stats
- `src/data/research/problems/erdos-{1181,36}.json` — knowledge updates
- `research/problems/erdos-1181/knowledge.md` — session notes

## Status
**Outcome**: progress on both problems
**Next Steps**: Submit `iterated_log_sublinear` (erdos-1181) to Aristotle

🤖 Generated by researcher-6