### PR TITLE
fix(aristotle): handle COMPLETE_WITH_ERRORS server status

### DIFF
--- a/scripts/aristotle/check-jobs.sh
+++ b/scripts/aristotle/check-jobs.sh
@@ -202,10 +202,10 @@ update_jobs_file() {
 
         local new_status
         case "$status" in
-            COMPLETE) new_status="completed" ;;
-            FAILED) new_status="failed" ;;
-            NOT_FOUND) new_status="expired" ;;
-            *) continue ;;  # Don't update in-progress jobs
+            COMPLETE|COMPLETE_WITH_ERRORS) new_status="completed" ;;
+            FAILED|OUT_OF_BUDGET) new_status="failed" ;;
+            NOT_FOUND|CANCELED) new_status="expired" ;;
+            *) continue ;;  # Don't update in-progress jobs (QUEUED, IN_PROGRESS, NOT_STARTED)
         esac
 
         # For failed/expired jobs, categorize the failure and count submissions
@@ -425,11 +425,14 @@ main() {
                 QUEUED|NOT_STARTED)
                     echo -e "  ${CYAN}$prob${NC}: QUEUED"
                     ;;
-                FAILED)
-                    echo -e "  ${RED}$prob${NC}: FAILED"
+                COMPLETE_WITH_ERRORS)
+                    echo -e "  ${YELLOW}$prob${NC}: COMPLETE_WITH_ERRORS (results may be partial)"
                     ;;
-                NOT_FOUND)
-                    echo -e "  ${RED}$prob${NC}: NOT_FOUND (expired?)"
+                FAILED|OUT_OF_BUDGET)
+                    echo -e "  ${RED}$prob${NC}: $status"
+                    ;;
+                NOT_FOUND|CANCELED)
+                    echo -e "  ${RED}$prob${NC}: $status (expired?)"
                     ;;
                 *)
                     echo -e "  $prob: $status ($percent%)"

--- a/scripts/aristotle/retrieve-integrate.sh
+++ b/scripts/aristotle/retrieve-integrate.sh
@@ -140,7 +140,9 @@ count_theorems_proved() {
     # Count sorry occurrences in each file (grep -c counts lines, but that's close enough)
     local orig_count new_count
     orig_count=$(grep -c "sorry" "$original" 2>/dev/null || echo 0)
+    orig_count=${orig_count//[^0-9]/}
     new_count=$(grep -c "sorry" "$solution" 2>/dev/null || echo 0)
+    new_count=${new_count//[^0-9]/}
 
     local proved=$((orig_count - new_count))
     if [[ "$proved" -lt 0 ]]; then


### PR DESCRIPTION
## Summary

- **Root cause**: `check-jobs.sh` only handled `COMPLETE`, `FAILED`, and `NOT_FOUND` server statuses. The Aristotle server also returns `COMPLETE_WITH_ERRORS`, `OUT_OF_BUDGET`, and `CANCELED`, which silently fell through to `*) continue`, leaving jobs permanently stuck as "submitted"
- **Impact**: 3 jobs stuck for 60+ hours, blocking all new submissions (85 candidates with 143 sorries sitting idle)
- **Fix**: Map all terminal server statuses to appropriate local states; also fix arithmetic syntax error in `retrieve-integrate.sh`

## Changes

**`scripts/aristotle/check-jobs.sh`**
- `COMPLETE_WITH_ERRORS` → `completed` (results may be partial but retrievable)
- `OUT_OF_BUDGET` → `failed`
- `CANCELED` → `expired`
- Display logic updated to show these statuses clearly

**`scripts/aristotle/retrieve-integrate.sh`**
- Strip non-numeric characters from `grep -c` output to prevent `syntax error in expression` when values contain trailing whitespace

## Test plan

- [x] Verified fix unsticks the 3 blocked jobs (`check-jobs.sh --update` transitions them to "completed")
- [x] Verified `retrieve-integrate.sh` successfully retrieves results (erdos-247: 1→0 sorries)
- [x] Pipeline unblocked: 3 submission slots now available for 85 waiting candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)