### PR TITLE
fix(metadata): erdos-1084 leanFile axiomCount→1, theoremCount→7, definitionCount→2

### DIFF
--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -162,12 +162,12 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 318,
-    "axiomCount": 11,
-    "theoremCount": 4,
-    "substantiveTheoremCount": 4,
+    "lineCount": 319,
+    "axiomCount": 1,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 7,
     "sorryTheorems": 0,
-    "definitionCount": 4
+    "definitionCount": 2
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-1084.

## Evidence

**Before**: leanFile.axiomCount=11, theoremCount=4, definitionCount=4, lineCount=318
**After**: leanFile.axiomCount=1, theoremCount=7, definitionCount=2, lineCount=319

The meta section axiomCount (1) was already correct.

---
Automated fix by lean-mechanic agent.