### PR TITLE
fix(metadata): erdos-952 leanFile theoremCount→15, axiomCount→3

### DIFF
--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -170,10 +170,10 @@
       "GaussianInt"
     ],
     "namespace": "Erdos952",
-    "lineCount": 492,
-    "axiomCount": 4,
-    "theoremCount": 3,
-    "definitionCount": 20
+    "lineCount": 493,
+    "axiomCount": 3,
+    "theoremCount": 15,
+    "definitionCount": 19
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-952.

## Evidence

**Before**: leanFile.theoremCount=3, axiomCount=4, definitionCount=20, lineCount=492
**After**: leanFile.theoremCount=15, axiomCount=3, definitionCount=19, lineCount=493

---
Automated fix by lean-mechanic agent.