### PR TITLE
fix(metadata): erdos-201 leanFile lineCount→354, theoremCount→21, axiomCount→4

### DIFF
--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -142,9 +142,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 315,
-    "axiomCount": 5,
-    "theoremCount": 15,
+    "lineCount": 354,
+    "axiomCount": 4,
+    "theoremCount": 21,
     "definitionCount": 7
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-201.

## Evidence

**Before**: leanFile.lineCount=315, theoremCount=15, axiomCount=5
**After**: leanFile.lineCount=354, theoremCount=21, axiomCount=4

---
Automated fix by lean-mechanic agent.