### PR TITLE
fix(metadata): erdos-265 leanFile lineCount→250, theoremCount→5, axiomCount→5

### DIFF
--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -148,9 +148,9 @@
     ],
     "opens": [],
     "namespace": "Erdos265",
-    "lineCount": 235,
-    "axiomCount": 6,
-    "theoremCount": 2,
+    "lineCount": 250,
+    "axiomCount": 5,
+    "theoremCount": 5,
     "definitionCount": 11
   },
   "references": [


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-265.

## Evidence

**Before**: leanFile.lineCount=235, theoremCount=2, axiomCount=6
**After**: leanFile.lineCount=250, theoremCount=5, axiomCount=5

---
Automated fix by lean-mechanic agent.