### PR TITLE
fix(metadata): erdos-1008-oq-01 leanFile lineCount→375, axiomCount→1, theoremCount→15

### DIFF
--- a/src/data/proofs/erdos-1008-oq-01/meta.json
+++ b/src/data/proofs/erdos-1008-oq-01/meta.json
@@ -140,9 +140,9 @@
       "Finset"
     ],
     "namespace": "Erdos1008OQ01",
-    "lineCount": 355,
-    "axiomCount": 2,
-    "theoremCount": 17,
-    "definitionCount": 8
+    "lineCount": 375,
+    "axiomCount": 1,
+    "theoremCount": 15,
+    "definitionCount": 6
   }
 }


### PR DESCRIPTION
## Fix

Correct stale leanFile metadata for erdos-1008-oq-01.

## Evidence

**Before**: leanFile.lineCount=355, axiomCount=2, theoremCount=17, definitionCount=8
**After**: leanFile.lineCount=375, axiomCount=1, theoremCount=15, definitionCount=6

---
Automated fix by lean-mechanic agent.