### PR TITLE
fix(metadata): erdos-677 lineCount→196, theoremCount→17

### DIFF
--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "assumptions": "1 axiom: thue_siegel_finiteness (Thue-Siegel theorem: finitely many solutions for fixed k). Four former axioms now proved: lcmInterval_example1/2 (native_decide), lcmInterval_dvd_product (Finset.induction + Nat.lcm_dvd), lcmInterval_pos (dvd + product positivity).",
-    "lineCount": 172,
+    "lineCount": 196,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -112,9 +112,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 172,
+    "lineCount": 196,
     "axiomCount": 1,
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 5
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Correct stale metadata for erdos-677.

## Evidence

**Before**: lineCount=172, leanFile.theoremCount=15
**After**: lineCount=196, leanFile.theoremCount=17

---
Automated fix by lean-mechanic agent.