### PR TITLE
fix(metadata): erdos-614 lineCount→270, theoremCount→8

### DIFF
--- a/src/data/proofs/erdos-614/meta.json
+++ b/src/data/proofs/erdos-614/meta.json
@@ -52,7 +52,7 @@
       "erdos_614_summary theorem: combines existence and upper bound"
     ],
     "axiomCount": 3,
-    "lineCount": 256,
+    "lineCount": 270,
     "assumptions": "3 axioms: f_lower_bound, f_case_k_eq_1, f_mono_k. f_upper_bound proved via complete graph construction."
   },
   "overview": {
@@ -160,9 +160,9 @@
       "Finset"
     ],
     "namespace": "Erdos614",
-    "lineCount": 256,
+    "lineCount": 270,
     "axiomCount": 3,
-    "theoremCount": 3,
+    "theoremCount": 8,
     "definitionCount": 7
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Correct stale metadata for erdos-614.

## Evidence

**Before**: lineCount=256, leanFile.theoremCount=3
**After**: lineCount=270, leanFile.theoremCount=8

---
Automated fix by lean-mechanic agent.