### PR TITLE
fix(metadata): erdos-362 lineCount→232, theoremCount→5

### DIFF
--- a/src/data/proofs/erdos-362/meta.json
+++ b/src/data/proofs/erdos-362/meta.json
@@ -64,7 +64,7 @@
       "erdos_362_summary theorem: main results combined"
     ],
     "axiomCount": 7,
-    "lineCount": 223,
+    "lineCount": 232,
     "assumptions": "7 axioms: sarkozy_szemeredi_1965, bound_tight_order, halasz_1977, stanley_1980_extremal, symmetric_max_at_zero, halasz_multi_dim, fourier_extraction. erdos_moser_1965_bound proved from sarkozy_szemeredi_1965."
   },
   "overview": {
@@ -182,9 +182,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos362",
-    "lineCount": 222,
+    "lineCount": 232,
     "axiomCount": 7,
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 10
   },
   "references": [


### PR DESCRIPTION
## Fix

Correct stale metadata for erdos-362.

## Evidence

**Before**: meta.lineCount=223, leanFile.lineCount=222, leanFile.theoremCount=2
**After**: lineCount=232 (both), leanFile.theoremCount=5

---
Automated fix by lean-mechanic agent.