### PR TITLE
Research: erdos-358 — power_of_two_obstruction axiom eliminated

### DIFF
--- a/proofs/Proofs/Erdos358Problem.lean
+++ b/proofs/Proofs/Erdos358Problem.lean
@@ -127,10 +127,34 @@ f(n) ≥ 1 for all large n is trivially achieved by A = naturals,
 since every n ≥ 1 equals itself (the sum from n to n).
 -/
 /-- For the naturals sequence, every n ≥ 1 has at least one consecutive sum representation
-    (the trivial one: n = sum from (n-1) to (n-1) of (i+1)). The proof requires showing
-    the representation set is finite (bounded by n), which uses Set.ncard machinery. -/
-axiom naturals_always_representable (n : ℕ) (hn : n ≥ 1) :
-    consecutiveSumCount naturalsSeq n ≥ 1
+    (the trivial one: n = sum from (n-1) to (n-1) of (i+1)). -/
+theorem naturals_always_representable (n : ℕ) (hn : n ≥ 1) :
+    consecutiveSumCount naturalsSeq n ≥ 1 := by
+  unfold consecutiveSumCount
+  -- The set of valid representations
+  set S := {p : ℕ × ℕ | p.1 ≤ p.2 ∧
+    (∑ i ∈ Finset.Icc p.1 p.2, naturalsSeq.seq i) = ↑n}
+  -- Step 1: S is finite (all valid pairs have u, v < n)
+  have hfin : S.Finite := by
+    apply Set.Finite.subset ((Set.finite_Iio n).prod (Set.finite_Iio n))
+    rintro ⟨u, v⟩ ⟨huv, hsum⟩
+    simp only [Set.mem_prod, Set.mem_Iio]
+    -- The sum includes term at v: naturalsSeq.seq v = v+1
+    -- Since all terms are nonneg, sum ≥ v+1, so v+1 ≤ n
+    have hv_mem : v ∈ Finset.Icc u v := Finset.mem_Icc.mpr ⟨huv, le_refl v⟩
+    have hv_le : naturalsSeq.seq v ≤ ∑ i ∈ Finset.Icc u v, naturalsSeq.seq i :=
+      Finset.single_le_sum (fun i _ => by simp [naturalsSeq]; positivity) hv_mem
+    rw [hsum] at hv_le
+    -- hv_le : naturalsSeq.seq v ≤ ↑n, i.e., ↑v + 1 ≤ ↑n
+    simp only [naturalsSeq] at hv_le
+    constructor <;> omega
+  -- Step 2: S is nonempty (witness: (n-1, n-1), single-term sum)
+  have hne : S.Nonempty :=
+    ⟨(n - 1, n - 1), le_refl _, by
+      simp only [Finset.Icc_self, Finset.sum_singleton, naturalsSeq]
+      push_cast; omega⟩
+  -- Step 3: ncard ≥ 1
+  exact Set.ncard_pos hfin |>.mpr hne
 
 /-- Gauss sum: twice the sum of integers from a to b equals (b-a+1)(a+b). -/
 private lemma two_mul_sum_Icc (a b : ℕ) (hab : a ≤ b) :

--- a/proofs/Proofs/Erdos358Problem.lean
+++ b/proofs/Proofs/Erdos358Problem.lean
@@ -132,13 +132,76 @@ since every n ≥ 1 equals itself (the sum from n to n).
 axiom naturals_always_representable (n : ℕ) (hn : n ≥ 1) :
     consecutiveSumCount naturalsSeq n ≥ 1
 
-/--
-**The power of 2 obstruction:**
-For A = naturals restricted to sums of ≥2 terms, powers of 2 have no representation.
-This is the only obstruction.
--/
-axiom power_of_two_obstruction :
-    ∀ k : ℕ, ∀ u v : ℕ, u < v → (∑ i ∈ Finset.Icc (u+1) (v+1), i) ≠ 2^k
+/-- Gauss sum: twice the sum of integers from a to b equals (b-a+1)(a+b). -/
+private lemma two_mul_sum_Icc (a b : ℕ) (hab : a ≤ b) :
+    2 * (∑ i ∈ Finset.Icc a b, i) = (b - a + 1) * (a + b) := by
+  induction b with
+  | zero =>
+    interval_cases a
+    simp [Finset.Icc_self]
+  | succ n ih =>
+    by_cases h : a ≤ n
+    · have hmem : n + 1 ∉ Finset.Icc a n := by simp [Finset.mem_Icc]; omega
+      have hIcc : Finset.Icc a (n + 1) = insert (n + 1) (Finset.Icc a n) := by
+        ext x; simp [Finset.mem_Icc, Finset.mem_insert]; omega
+      rw [hIcc, Finset.sum_insert hmem]
+      set S := ∑ i ∈ Finset.Icc a n, i with hS_def
+      have h_ih := ih h
+      zify [h, show a ≤ n + 1 from by omega] at h_ih ⊢
+      nlinarith
+    · have : a = n + 1 := by omega
+      subst this
+      simp [Finset.Icc_self]
+
+/-- An odd divisor of a power of 2 must be 1. -/
+private lemma odd_dvd_two_pow_eq_one {m j : ℕ} (hm : Odd m) (hdvd : m ∣ 2 ^ j) :
+    m = 1 := by
+  induction j with
+  | zero => simpa using hdvd
+  | succ j ih =>
+    apply ih
+    have hcop : Nat.Coprime m 2 := by
+      unfold Nat.Coprime
+      rw [Nat.gcd_comm, Nat.gcd_rec, Nat.odd_iff.mp hm]
+      norm_num
+    rw [pow_succ] at hdvd
+    exact hcop.dvd_of_dvd_mul_right hdvd
+
+/-- Powers of 2 cannot be expressed as sums of ≥2 consecutive positive integers.
+    Proof: 2·S = (v-u+1)(u+v+2) with sum of factors = 2v+3 (odd), so one factor
+    is odd. An odd divisor of 2^(k+1) is 1, but both factors are ≥ 2. -/
+theorem power_of_two_obstruction :
+    ∀ k : ℕ, ∀ u v : ℕ, u < v → (∑ i ∈ Finset.Icc (u+1) (v+1), i) ≠ 2^k := by
+  intro k u v huv hsum
+  have hab : u + 1 ≤ v + 1 := by omega
+  have h2S := two_mul_sum_Icc (u + 1) (v + 1) hab
+  rw [hsum] at h2S
+  -- Simplify: 2 * 2^k = (v - u + 1) * (u + v + 2)
+  have hvu : v + 1 - (u + 1) + 1 = v - u + 1 := by omega
+  have huv2 : (u + 1) + (v + 1) = u + v + 2 := by omega
+  rw [hvu, huv2] at h2S
+  -- Both factors are at least 2
+  have hf1 : v - u + 1 ≥ 2 := by omega
+  have hf2 : u + v + 2 ≥ 2 := by omega
+  -- Their sum is 2v+3 (odd), so they have different parities
+  rcases Nat.even_or_odd (v - u + 1) with h_even | h_odd
+  · -- (v-u+1) even ⟹ (u+v+2) odd
+    have h_odd2 : Odd (u + v + 2) := by
+      rw [Nat.odd_iff_not_even]
+      intro h_even2
+      have := h_even.add h_even2
+      -- (v-u+1) + (u+v+2) = 2v+3 would be even — contradiction
+      obtain ⟨d, hd⟩ := this
+      omega
+    have h_dvd : (u + v + 2) ∣ 2 ^ (k + 1) :=
+      ⟨v - u + 1, by rw [show 2 ^ (k + 1) = 2 * 2 ^ k from by ring, h2S, mul_comm]⟩
+    have := odd_dvd_two_pow_eq_one h_odd2 h_dvd
+    omega
+  · -- (v-u+1) odd ⟹ contradicts being ≥ 2 and dividing 2^(k+1)
+    have h_dvd : (v - u + 1) ∣ 2 ^ (k + 1) :=
+      ⟨u + v + 2, by rw [show 2 ^ (k + 1) = 2 * 2 ^ k from by ring, h2S]⟩
+    have := odd_dvd_two_pow_eq_one h_odd h_dvd
+    omega
 
 /- ## Part V: The Prime Case -/
 

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -57,9 +57,9 @@
       "PositiveDensityConjecture definition: positive upper density",
       "Classical characterization: n = sum of >=2 consecutive iff n != 2^k"
     ],
-    "axiomCount": 3,
-    "lineCount": 287,
-    "assumptions": "3 axioms: consecutive_sum_char, naturals_count_odd_divisors, naturals_always_representable. power_of_two_obstruction proved via Gauss sum parity argument. strong_implies_weak proved via Filter.tendsto_atTop_atTop."
+    "axiomCount": 2,
+    "lineCount": 311,
+    "assumptions": "2 axioms: consecutive_sum_char, naturals_count_odd_divisors. power_of_two_obstruction and naturals_always_representable proved. strong_implies_weak proved via Filter.tendsto_atTop_atTop."
   },
   "overview": {
     "historicalContext": "Erdos Problem #358 was posed in 1977 [Er77c] and revisited in Erdos-Graham (1980). It asks a deceptively simple question about how many ways an integer can be written as a sum of consecutive terms from a fixed sequence.\n\nErdos himself remarked: \"This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me.\"\n\nThe problem connects to classical results about sums of consecutive integers (which relate to odd divisors) and to the Erdos-Moser conjecture (1963) about consecutive prime sums.",
@@ -167,9 +167,9 @@
       "Finset"
     ],
     "namespace": "Erdos358",
-    "lineCount": 287,
-    "axiomCount": 3,
-    "theoremCount": 7,
+    "lineCount": 311,
+    "axiomCount": 2,
+    "theoremCount": 8,
     "definitionCount": 9
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -57,9 +57,9 @@
       "PositiveDensityConjecture definition: positive upper density",
       "Classical characterization: n = sum of >=2 consecutive iff n != 2^k"
     ],
-    "axiomCount": 4,
-    "lineCount": 224,
-    "assumptions": "6 axioms: consecutive_sum_char, naturals_count_odd_divisors, naturals_always_representable, power_of_two_obstruction, primesSeq, primesSeq_def. All sorries eliminated; strong_implies_weak proved via Filter.tendsto_atTop_atTop."
+    "axiomCount": 3,
+    "lineCount": 287,
+    "assumptions": "3 axioms: consecutive_sum_char, naturals_count_odd_divisors, naturals_always_representable. power_of_two_obstruction proved via Gauss sum parity argument. strong_implies_weak proved via Filter.tendsto_atTop_atTop."
   },
   "overview": {
     "historicalContext": "Erdos Problem #358 was posed in 1977 [Er77c] and revisited in Erdos-Graham (1980). It asks a deceptively simple question about how many ways an integer can be written as a sum of consecutive terms from a fixed sequence.\n\nErdos himself remarked: \"This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me.\"\n\nThe problem connects to classical results about sums of consecutive integers (which relate to odd divisors) and to the Erdos-Moser conjecture (1963) about consecutive prime sums.",
@@ -167,9 +167,9 @@
       "Finset"
     ],
     "namespace": "Erdos358",
-    "lineCount": 224,
-    "axiomCount": 4,
-    "theoremCount": 6,
+    "lineCount": 287,
+    "axiomCount": 3,
+    "theoremCount": 7,
     "definitionCount": 9
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-1051.json
+++ b/src/data/research/problems/erdos-1051.json
@@ -29,17 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ASSESSED: 4 axioms, 0 sorries. series_converges is the most tractable for elimination (needs liminf→summability argument). rapid_growth_irrational is deep (Erdős 1988). simple_series_question is open.",
+    "progressSummary": "COMPLETED: Fixed open-conjecture axiom, added 5 theorems (partial fraction, term bounds, exponential growth). File: 113→166 lines, 1→6 theorems, 4→3 axioms.",
     "builtItems": [
       "Proved series_positive theorem in Erdos1051Problem.lean",
-      "Assessed all 4 axioms: series_converges is provable in principle (liminf → summability), others are deep/open"
+      "partial_fraction: telescoping identity",
+      "term_pos, term_le_reciprocal_sq: term analysis",
+      "strict_mono_pos, exponential_growth_bound: sequence bounds"
     ],
     "insights": [
       "Proved series_positive from series_converges using tsum_pos. Each term 1/(a_n*a_{n+1}) > 0 since a_n > 0.",
-      "series_converges is the most tractable axiom: from lim inf a_n^{1/2^n} > 1, extract r > 1 with a_n ≥ r^{2^n} eventually, giving 1/(a_n*a_{n+1}) ≤ 1/r^{3*2^n} which is summable",
-      "rapid_growth_irrational is Erdős 1988 deep result — requires irrationality measure machinery",
-      "simple_series_question is another open conjecture, cannot be eliminated",
-      "sylvester_fibonacci_example could be proved by explicit construction with Fibonacci subsequence but irrationality of the sum needs telescoping identity"
+      "simple_series_question was incorrectly axiomatized as fact — converted to def (its an open conjecture)",
+      "Partial fraction 1/(xy) = 1/(y-x) · (1/x - 1/y) enables telescoping analysis",
+      "Term bound 1/(aₙ·aₙ₊₁) ≤ 1/aₙ² from strict monotonicity",
+      "Exponential growth aₙ₊₁ ≥ 2aₙ implies aₙ ≥ a₀·2ⁿ (proved by induction)"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-358.json
+++ b/src/data/research/problems/erdos-358.json
@@ -29,15 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 7 axioms + 3 sorries. consecutive_sum_formula most tractable (Gauss sum). consecutive_sum_char is deep. naturals_always_representable needs consecutiveSumCount understanding.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: 4→3 axioms. power_of_two_obstruction proved via Gauss sum parity argument. Remaining: consecutive_sum_char, naturals_count_odd_divisors, naturals_always_representable.",
+    "builtItems": [
+      "Proved two_mul_sum_Icc: Gauss sum formula 2*Σ = (b-a+1)(a+b) by induction + zify",
+      "Proved odd_dvd_two_pow_eq_one: odd divisor of 2^j is 1, by induction on j + coprimality",
+      "Proved power_of_two_obstruction: parity argument on consecutive sum double formula"
+    ],
     "insights": [
       "consecutive_sum_formula sorry is standard arithmetic (Gauss sum) - needs Finset.sum_Icc manipulation",
       "power_of_two_obstruction axiom is a well-known result about consecutive sum representations",
-      "primesSeq axiomatized because Nat.nth is complex - could be defined directly"
+      "primesSeq axiomatized because Nat.nth is complex - could be defined directly",
+      "power_of_two_obstruction proved: key insight is (v-u+1)+(u+v+2)=2v+3 (odd), forcing one factor odd, which must be 1 but both ≥2"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "naturals_always_representable: needs Set.ncard finiteness proof for the representation set",
+      "consecutive_sum_char: needs both directions — odd factor gives representation, and 2^k has no representation"
+    ],
     "markdown": "# Erdős #358 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{a_1<\\cdots\\}$ be an infinite sequence of integers. Let $f(n)$ count the number of solutions to\\[n=\\sum_{u\\leq i\\leq v}a_i.\\]Is there such an $A$ for which $f(n)\\to \\infty$ as $n\\to \\infty$? Or even where $f(n)\\geq 2$ for all large $n$?\n\n\n\n\n\nWhen $a_n=n$ the function $f(n)$ counts the number of odd divisors of $n$.\n\nIn modern language, this asks for the existence of a convex set $A$ such that $1_A\\circ 1_A(n)\\to \\infty$ as $n\\to \\infty$.\n\nErd\\H{o}s and Moser \\cite{Mo63} considered the case when $A$ is the set of primes, and conjectured that the $\\limsup$ of the number of such representations in this case is infinite. They could not even prove that the upper density of the set of integers representable in this form is positive.\n\nIn \\cite{ErGr80} they further asked whether $f(n)\\geq 1$ for all large $n$ is possible, but Egami observed the answer to this is trivially yes, taking $a_n=n$. Perhaps they intended to restrict $f(n)$ to only count those representatives as the sum of at least two consecutive terms. (It is a classical fact that $n$ can be expressed as a sum of at least two consecutive positive integers if and only if $n\\neq 2^k$.)\n\nIn \\cite{Er77c} Erd\\H{o}s writes 'This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me'.\n\nWeisenberg observes that the finite analogue of this problem, asking how many integers up to some $x$ can be written as the sum of consecutive elements, is very similar to [356].\n\nThis is reported in problem C2 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Er77c] Erd\\H{o}s, Paul, Problems and results on combinatorial number theory. III. Number theory day (Proc. Conf., Rockefeller Univ.,\nNew York, 1976) (1977), 43-72.\n\n[ErGr80] Erd\\H{o}s, P. and Graham, R., Old and new problems and results in combinatorial number theory. Monographies de L'Enseignement Mathematique (1980).\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[Mo63] Moser, L., Notes on number theory. III. On the sum of consecutive primes. Canad. Math. Bull. (1963), 159-161.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #356\n- Problem #357\n- Problem #359\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- Mo63\n- ErGr80\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -54,16 +62,16 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:53:52.154Z",
-  "lastUpdate": "2026-03-13T07:52:17.046Z",
+  "lastUpdate": "2026-03-28T23:00:00.000Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/Erdos358Problem.lean",
       "filename": "Erdos358Problem.lean",
-      "lineCount": 225,
-      "theoremCount": 6,
-      "axiomCount": 4,
+      "lineCount": 287,
+      "theoremCount": 7,
+      "axiomCount": 3,
       "defCount": 9,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/erdos-358.json
+++ b/src/data/research/problems/erdos-358.json
@@ -29,11 +29,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 4→3 axioms. power_of_two_obstruction proved via Gauss sum parity argument. Remaining: consecutive_sum_char, naturals_count_odd_divisors, naturals_always_representable.",
+    "progressSummary": "PROGRESS: 4→2 axioms. power_of_two_obstruction and naturals_always_representable proved. Remaining: consecutive_sum_char, naturals_count_odd_divisors.",
     "builtItems": [
       "Proved two_mul_sum_Icc: Gauss sum formula 2*Σ = (b-a+1)(a+b) by induction + zify",
       "Proved odd_dvd_two_pow_eq_one: odd divisor of 2^j is 1, by induction on j + coprimality",
-      "Proved power_of_two_obstruction: parity argument on consecutive sum double formula"
+      "Proved power_of_two_obstruction: parity argument on consecutive sum double formula",
+      "Proved naturals_always_representable: Set.ncard finiteness via Finset.single_le_sum bounding v<n"
     ],
     "insights": [
       "consecutive_sum_formula sorry is standard arithmetic (Gauss sum) - needs Finset.sum_Icc manipulation",
@@ -43,8 +44,8 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "naturals_always_representable: needs Set.ncard finiteness proof for the representation set",
-      "consecutive_sum_char: needs both directions — odd factor gives representation, and 2^k has no representation"
+      "consecutive_sum_char: needs both directions — odd factor gives representation, and 2^k has no representation",
+      "naturals_count_odd_divisors: bijection between representations and odd divisors"
     ],
     "markdown": "# Erdős #358 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{a_1<\\cdots\\}$ be an infinite sequence of integers. Let $f(n)$ count the number of solutions to\\[n=\\sum_{u\\leq i\\leq v}a_i.\\]Is there such an $A$ for which $f(n)\\to \\infty$ as $n\\to \\infty$? Or even where $f(n)\\geq 2$ for all large $n$?\n\n\n\n\n\nWhen $a_n=n$ the function $f(n)$ counts the number of odd divisors of $n$.\n\nIn modern language, this asks for the existence of a convex set $A$ such that $1_A\\circ 1_A(n)\\to \\infty$ as $n\\to \\infty$.\n\nErd\\H{o}s and Moser \\cite{Mo63} considered the case when $A$ is the set of primes, and conjectured that the $\\limsup$ of the number of such representations in this case is infinite. They could not even prove that the upper density of the set of integers representable in this form is positive.\n\nIn \\cite{ErGr80} they further asked whether $f(n)\\geq 1$ for all large $n$ is possible, but Egami observed the answer to this is trivially yes, taking $a_n=n$. Perhaps they intended to restrict $f(n)$ to only count those representatives as the sum of at least two consecutive terms. (It is a classical fact that $n$ can be expressed as a sum of at least two consecutive positive integers if and only if $n\\neq 2^k$.)\n\nIn \\cite{Er77c} Erd\\H{o}s writes 'This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me'.\n\nWeisenberg observes that the finite analogue of this problem, asking how many integers up to some $x$ can be written as the sum of consecutive elements, is very similar to [356].\n\nThis is reported in problem C2 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Er77c] Erd\\H{o}s, Paul, Problems and results on combinatorial number theory. III. Number theory day (Proc. Conf., Rockefeller Univ.,\nNew York, 1976) (1977), 43-72.\n\n[ErGr80] Erd\\H{o}s, P. and Graham, R., Old and new problems and results in combinatorial number theory. Monographies de L'Enseignement Mathematique (1980).\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[Mo63] Moser, L., Notes on number theory. III. On the sum of consecutive primes. Canad. Math. Bull. (1963), 159-161.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #356\n- Problem #357\n- Problem #359\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- Mo63\n- ErGr80\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
@@ -69,9 +70,9 @@
     {
       "path": "Proofs/Erdos358Problem.lean",
       "filename": "Erdos358Problem.lean",
-      "lineCount": 287,
-      "theoremCount": 7,
-      "axiomCount": 3,
+      "lineCount": 311,
+      "theoremCount": 8,
+      "axiomCount": 2,
       "defCount": 9,
       "sorryCount": 0,
       "isAristotle": false,

--- a/src/data/research/problems/hurwitz-three-square-impossibility.json
+++ b/src/data/research/problems/hurwitz-three-square-impossibility.json
@@ -31,14 +31,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ASSESSED: 2 axioms, 0 sorries. The n=3 impossibility proof is the crown jewel (fully proved). eight_square_identity_exists is eliminable but compute-heavy. hurwitz_only_if requires deep algebra.",
+    "progressSummary": "COMPLETED: n=3 impossibility already fully proved in HurwitzTheorem.lean (no_three_square_identity theorem, 0 sorries).",
     "builtItems": [
-      "Assessed both axioms: eight_square_identity_exists is routine but compute-heavy; hurwitz_only_if is deep algebra"
+      "HurwitzTheorem.no_three_square_identity: n=3 impossibility (proved)"
     ],
     "insights": [
-      "eight_square_identity_exists could be eliminated by writing the explicit Degen/Cayley 8-square formula (64 product terms, 8 components), but verification would be very compute-heavy (4-square already needs maxHeartbeats 800000)",
-      "hurwitz_only_if is the deep part (requires Clifford algebras for n=5,6,7 and n>8 cases)",
-      "Mathlib has no Cayley-Dickson construction or octonion type, so no shortcut available"
+      "Proof exists: no_three_square_identity in HurwitzTheorem.lean is fully proved (0 sorries)",
+      "Approach: overdetermined orthonormality system in ℝ³ leads to contradiction",
+      "Infrastructure: NSquareIdentity structure with bilinearity + norm preservation"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Proved `power_of_two_obstruction` axiom, reducing axiom count from 4 to 3
- Added `two_mul_sum_Icc` (Gauss sum formula) and `odd_dvd_two_pow_eq_one` helper lemmas
- Updated gallery metadata and research problem knowledge

## Progress
- **Axiom eliminated**: `power_of_two_obstruction` — powers of 2 cannot be sums of ≥2 consecutive positive integers
- **Proof technique**: Gauss sum formula shows 2·S = (v-u+1)(u+v+2). If S = 2^k, their sum is 2v+3 (odd), so one factor is odd. An odd divisor of 2^(k+1) must be 1, but both factors ≥ 2. Contradiction.
- **Remaining axioms**: `consecutive_sum_char`, `naturals_count_odd_divisors`, `naturals_always_representable`

## Findings
- `naturals_always_representable` is next most tractable (needs Set.ncard finiteness)
- `consecutive_sum_char` needs both directions of odd-factor ↔ non-power-of-2

## Status
**Outcome**: progress (1 axiom eliminated)
**Next Steps**: Prove remaining axioms, starting with `naturals_always_representable`

⚠️ Docker was unavailable for local build verification — CI will validate

🤖 Generated by researcher-2