### PR TITLE
fix(metadata): audit fixes for 4 proofs — sorry/axiom/line counts

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4547,9 +4547,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-404": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T05:24:12Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-405": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9645,8 +9645,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-02-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-29T00:50:34Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-29T05:29:30Z",
       "result": "issues-fixed",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9525,8 +9525,8 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-28T21:51:07Z",
+      "auditCount": 3,
+      "lastAudited": "2026-03-29T05:28:18Z",
       "result": "issues-fixed",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9519,9 +9519,9 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-28T21:25:09Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-29T05:25:41Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-03": {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
@@ -21,7 +21,7 @@
       "open-question"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -66,8 +66,8 @@
       "minkowski_linfty: L∞ special case from pointwise triangle"
     ],
     "axiomCount": 0,
-    "lineCount": 393,
-    "assumptions": "0 axioms. 2 sorries in ENNReal rpow arithmetic (routine calculations about a^p = a · a^{p-1} and the final division step)."
+    "lineCount": 402,
+    "assumptions": "0 axioms. 1 sorry in minkowski_from_holder_explicit (ENNReal arithmetic combining split + Hölder steps with division)."
   },
   "overview": {
     "historicalContext": "**The Young-Hölder-Minkowski Chain**\n\nThree fundamental inequalities form a logical chain:\n- **Young (1912)**: $ab \\leq a^p/p + b^q/q$ for conjugate exponents\n- **Hölder (1889)**: $\\int|fg| \\leq \\|f\\|_p \\cdot \\|g\\|_q$ for $1/p + 1/q = 1$\n- **Minkowski (1896)**: $\\|f+g\\|_p \\leq \\|f\\|_p + \\|g\\|_p$ for $p \\geq 1$\n\nIn modern Lean/Mathlib, Minkowski is embedded inside the `NormedAddCommGroup` instance for `Lp` spaces, making the chain invisible. This formalization makes each step explicit.",
@@ -148,10 +148,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Answers YES to the open question: the full Lp Minkowski proof via the Hölder chain IS available in Lean 4 without the black-box NormedAddCommGroup instance. The chain Young → Hölder → Minkowski is made explicit, with the factoring trick (splitting |f+g|^p and applying Hölder twice) as the key step. Two sorries remain in ENNReal rpow arithmetic.",
+    "summary": "Answers YES to the open question: the full Lp Minkowski proof via the Hölder chain IS available in Lean 4 without the black-box NormedAddCommGroup instance. The chain Young → Hölder → Minkowski is made explicit, with the factoring trick (splitting |f+g|^p and applying Hölder twice) as the key step. One sorry remains in the final ENNReal division step.",
     "implications": "Making the chain explicit serves both pedagogy and formalization quality. Students see exactly where each inequality is used. Formal verification confirms the logical dependencies are correct. The factoring trick pattern (Hölder → norm inequality) recurs throughout analysis: Sobolev embeddings, interpolation theorems, and more.",
     "openQuestions": [
-      "Can the two remaining sorries (ENNReal rpow arithmetic) be closed with tactic automation?",
+      "Can the remaining sorry (ENNReal rpow division step) be closed with tactic automation?",
       "Can the chain be extended to include Sobolev embeddings as a fourth step?",
       "What is the optimal way to handle the division step when ‖f+g‖_p = 0 or ∞?"
     ]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Based on classical union avoidance argument",
     "sourceUrl": "",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,11 +17,11 @@
       "union-avoidance",
       "finite-fields"
     ],
-    "badge": "axiom",
-    "sorries": 2,
+    "badge": "original",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 268,
-    "assumptions": "0 axioms. 2 sorries: finite union cardinality bound (counting), normalized factor degree bound (algebra). Both routine.",
+    "lineCount": 362,
+    "assumptions": "0 axioms, 0 sorries. Fully machine-verified proof.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -45,29 +45,29 @@
       "id": "union-avoidance",
       "title": "Finite Union Avoidance Lemma",
       "summary": "Proves that a vector space over a finite field K cannot be covered by k proper subspaces when |K| > k. Uses induction with a counting argument replacing the infinite field argument.",
-      "startLine": 57,
-      "endLine": 138,
+      "startLine": 48,
+      "endLine": 159,
       "mathContext": "Union avoidance with finite field bound."
     },
     {
       "id": "helpers",
       "title": "Helper Lemmas",
       "summary": "Reuses helper lemmas from the infinite field version: aeval_ne_zero_of_ne_zero, gcd_aeval_mulVec_eq_zero, ker_mulVecLin_ne_top.",
-      "startLine": 140,
-      "endLine": 195,
+      "startLine": 161,
+      "endLine": 207,
       "mathContext": "Polynomial evaluation and kernel theory."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem (Finite Field Version)",
       "summary": "Proves nonderogatory_has_cyclic_vector_fin: over a field K with |K| > n, nonderogatory matrices have cyclic vectors. Uses the finite union avoidance lemma.",
-      "startLine": 197,
-      "endLine": 268,
+      "startLine": 209,
+      "endLine": 358,
       "mathContext": "Nonderogatory → cyclic vector over finite fields."
     }
   ],
   "conclusion": {
-    "summary": "This formalization proves the nonderogatory → cyclic vector theorem over finite fields with |K| > n, generalizing the infinite field version. Two routine sorries remain: a finite union cardinality bound and a normalized factor degree bound.",
+    "summary": "Fully machine-verified proof that over a field K with |K| > n, nonderogatory matrices have cyclic vectors. Generalizes the infinite field version using a finite union avoidance lemma. 0 sorries, 0 axioms.",
     "openQuestions": [
       "Is the bound |K| > n tight, or can it be weakened further to |K| > k where k is the number of distinct irreducible factors (which may be much less than n)?",
       "Can the union avoidance approach be replaced by a direct algebraic argument that works for all fields?"
@@ -77,7 +77,7 @@
     "imports": ["Mathlib"],
     "opens": ["Matrix", "Polynomial"],
     "namespace": "NonderogatoryFinite",
-    "lineCount": 268,
+    "lineCount": 362,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 2

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.aeval",
@@ -49,13 +49,12 @@
     ],
     "originalContributions": [
       "cyclicSubspace: K-span of {v, Tv, T^2v, ...} for general modules",
-      "IsCyclicVectorOp / IsNonderogatoryOp: Module-theoretic definitions",
-      "polynomialAction: K-linear map p -> p(T)v with range = cyclicSubspace",
-      "annihilatorIdeal: The ideal {p | p(T)v = 0} with full characterization",
-      "aeval_eq_zero_of_cyclic: Cyclic vector annihilation implies operator annihilation",
-      "annihilator_cyclic_eq_span_minpoly: Annihilator = (minpoly) for cyclic vectors",
-      "mulByX / isNonderogatoryOp_mulByX: Infinite-dimensional nonderogatory example",
-      "annihilator_mulByX_one_eq_bot: Trivial annihilator in infinite dimensions"
+      "IsCyclicVector / IsNonderogatory: Module-theoretic definitions",
+      "evalMap: K-linear map p -> p(T)v with range = cyclicSubspace",
+      "range_evalMap_eq_cyclicSubspace: image of evalMap = cyclic subspace",
+      "annihilator_mul_closed / annihilator_congr: annihilator ideal properties",
+      "cyclicSubspace_le_minpoly_degree: orbit dimension bound (proved by induction)",
+      "IsCyclicVectorMatrix / IsNonderogatoryMatrix: finite-dimensional bridge definitions"
     ],
     "dateAdded": "2026-03-28",
     "prerequisites": [
@@ -79,8 +78,8 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 305,
-    "assumptions": "3 sorries: cyclicSubspace_le_minpoly_degree (orbit bound via induction), matrix_nonderogatory_implies_module (defers to OQ05OQ01), structure_theorem_cyclic_iff (needs PID structure theorem).",
+    "lineCount": 347,
+    "assumptions": "2 sorries: matrix_nonderogatory_implies_module (defers to OQ05OQ01), structure_theorem_cyclic_iff (needs PID structure theorem). cyclicSubspace_le_minpoly_degree is now fully proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -103,56 +102,56 @@
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Definitions",
-      "startLine": 35,
-      "endLine": 82,
-      "summary": "Defines cyclicSubspace (K-span of Krylov vectors), IsCyclicVectorOp, IsNonderogatoryOp, polynomialAction (p -> p(T)v as K-linear map), and annihilatorIdeal ({p | p(T)v = 0} as ideal of K[X]).",
-      "mathContext": "The cyclic subspace $\\text{cyc}(T,v) = \\text{span}_K\\{v, Tv, T^2v, \\ldots\\}$ is the Krylov space. The polynomial action $\\varphi_{T,v} : K[X] \\to V$ given by $p \\mapsto p(T)v$ is $K$-linear. Its kernel $\\text{ann}(v) = \\{p \\in K[X] : p(T)v = 0\\}$ is an ideal since $K[X]$ is commutative."
+      "id": "definitions-and-evalmap",
+      "title": "Definitions and Evaluation Map",
+      "startLine": 43,
+      "endLine": 96,
+      "summary": "Defines cyclicSubspace (K-span of Krylov vectors), IsCyclicVector, IsNonderogatory, and evalMap (p -> p(T)v as K-linear map).",
+      "mathContext": "The cyclic subspace $\\text{cyc}(T,v) = \\text{span}_K\\{v, Tv, T^2v, \\ldots\\}$ is the Krylov space. The evaluation map $\\varphi_{T,v} : K[X] \\to V$ given by $p \\mapsto p(T)v$ is $K$-linear."
     },
     {
-      "id": "basic-properties",
-      "title": "Basic Properties of Cyclic Subspaces",
-      "startLine": 84,
-      "endLine": 120,
-      "summary": "Proves: v and T^n v are in the cyclic subspace; the cyclic subspace is T-invariant (T sends it into itself); the cyclic subspace is p(T)-invariant for all polynomials p.",
-      "mathContext": "T-invariance: $T(T^n v) = T^{n+1} v \\in \\text{cyc}(T,v)$. For p(T)-invariance, induct on p: C(c) acts as scalar, addition is additive, and p*X uses $p(T)(Tw) = p(T) \\circ T$ with T-invariance of the IH."
+      "id": "cyclic-subspace-properties",
+      "title": "Cyclic Subspace Properties",
+      "startLine": 98,
+      "endLine": 131,
+      "summary": "Proves: v and T^n v are in the cyclic subspace; the cyclic subspace is T-invariant.",
+      "mathContext": "T-invariance: $T(T^n v) = T^{n+1} v \\in \\text{cyc}(T,v)$."
     },
     {
-      "id": "polynomial-characterization",
-      "title": "Polynomial Action Characterization",
-      "startLine": 122,
-      "endLine": 143,
-      "summary": "Proves cyclicSubspace T v = range(polynomialAction T v) and that v is cyclic iff polynomialAction is surjective.",
-      "mathContext": "$\\text{cyc}(T,v) = \\text{im}(\\varphi_{T,v})$ since generators $T^n v = \\varphi_{T,v}(X^n)$ are in the range, and conversely $p(T)v \\in \\text{cyc}(T,v)$ by $p(T)$-invariance. The surjectivity characterization: $v$ is cyclic $\\iff$ $\\varphi_{T,v}$ is onto $\\iff$ $V \\cong K[X]/\\text{ann}(v)$."
+      "id": "image-and-characterization",
+      "title": "Image of Evaluation Map and Cyclic Vector Characterization",
+      "startLine": 132,
+      "endLine": 184,
+      "summary": "Proves range(evalMap) = cyclicSubspace, and v is cyclic iff evalMap is surjective.",
+      "mathContext": "$\\text{cyc}(T,v) = \\text{im}(\\varphi_{T,v})$ since generators $T^n v = \\varphi_{T,v}(X^n)$ are in the range."
     },
     {
-      "id": "annihilator-structure",
-      "title": "Annihilator Structure for Cyclic Vectors",
-      "startLine": 145,
-      "endLine": 196,
-      "summary": "Proves: minpoly is in the annihilator; for cyclic vectors, p(T)v = 0 implies p(T) = 0 (using commutativity of K[X]); annihilator ideal = span{minpoly} for integral operators with cyclic vectors.",
-      "mathContext": "The key result: for a cyclic vector $v$, $\\text{ann}(v) = (\\mu_T)$ where $\\mu_T$ is the minimal polynomial. Proof: $p(T)v = 0 \\implies p(T)w = p(T)(q(T)v) = q(T)(p(T)v) = 0$ for all $w = q(T)v$, so $p(T) = 0$, hence $\\mu_T | p$."
+      "id": "annihilator-properties",
+      "title": "Annihilator Properties",
+      "startLine": 186,
+      "endLine": 219,
+      "summary": "Proves: minpoly annihilates all vectors; annihilator is closed under multiplication; congruence modulo minpoly preserves annihilation.",
+      "mathContext": "The annihilator $\\{p \\in K[X] : p(T)v = 0\\}$ is an ideal containing the minimal polynomial."
     },
     {
-      "id": "infinite-dim-example",
-      "title": "Infinite-Dimensional Example: K[X] with Multiplication by X",
-      "startLine": 198,
-      "endLine": 235,
-      "summary": "Defines mulByX (multiplication by X on K[X]) and proves: aeval(mulByX)(p) acts as multiplication by p; 1 is a cyclic vector; mulByX is nonderogatory; the annihilator is trivial.",
-      "mathContext": "K[X] is infinite-dimensional over K, yet $\\text{mul}_X$ is nonderogatory with cyclic vector 1. The polynomial action is the identity: $p(\\text{mul}_X)(1) = p$, since $\\text{mul}_X$ IS $X$. The annihilator $\\{p : p \\cdot 1 = 0\\} = \\{0\\}$ is trivial, showing infinite-dimensional operators need not have a minimal polynomial."
+      "id": "orbit-bound-and-finite-dim",
+      "title": "Orbit Dimension Bound and Finite-Dimensional Bridge",
+      "startLine": 221,
+      "endLine": 344,
+      "summary": "Proves cyclicSubspace dimension ≤ deg(minpoly) via induction. Bridges to finite-dimensional matrix definitions. States structure theorem for cyclic iff characterization (sorry).",
+      "mathContext": "For integral T, T^d v lies in span{v,...,T^{d-1}v} where d = deg(minpoly), proved by induction using the minimal polynomial relation."
     }
   ],
   "conclusion": {
-    "summary": "Complete module-theoretic framework for nonderogatory operators on arbitrary K-modules. Defines cyclic subspace, polynomial action, and annihilator ideal with full characterization theorems. Demonstrates the theory in infinite dimensions via the canonical example K[X] with multiplication by X.",
-    "implications": "This extends the finite-dimensional result (OQ-05-OQ-01) to the general setting. The module-theoretic framework connects to the structure theorem for modules over PIDs: a finitely generated K[X]-module is nonderogatory iff its invariant factor decomposition has a single factor. In infinite dimensions, the annihilator can be trivial, giving V = K[X] as K[X]-module (free of rank 1).",
+    "summary": "Module-theoretic framework for nonderogatory operators on arbitrary K-modules. Defines cyclic subspace, evaluation map, and annihilator properties. Proves orbit dimension bound via induction. 2 sorries remain: finite-dimensional bridge and structure theorem characterization.",
+    "implications": "This extends the finite-dimensional result (OQ-05-OQ-01) to the general setting. The module-theoretic framework connects to the structure theorem for modules over PIDs: a finitely generated K[X]-module is nonderogatory iff its invariant factor decomposition has a single factor.",
     "openQuestions": [
       "Formalize the structure theorem for f.g. modules over K[X] and its connection to the rational canonical form",
       "Characterize which operators on countably-dimensional spaces have cyclic vectors",
       "Connect the annihilator ideal to the spectrum of T in the infinite-dimensional case"
     ]
   },
-  "sorryCount": 3,
+  "sorryCount": 2,
   "status": "formalized",
   "badge": "wip",
   "leanFile": {
@@ -163,10 +162,10 @@
       "Polynomial"
     ],
     "namespace": "NonderogatoryModule",
-    "lineCount": 305,
+    "lineCount": 347,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 7
+    "definitionCount": 6
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 3,
     "erdosNumber": 404,
     "erdosUrl": "https://erdosproblems.com/404",
     "erdosProblemStatus": "open",
@@ -52,12 +52,12 @@
       "lin_bound_meaning axiom: 2^255 never divides such sums",
       "legendreSum: Legendre's formula computation",
       "legendre_formula theorem: v_p(n!) = Σ⌊n/p^i⌋ (proved via Mathlib's padicValNat_factorial)",
-      "padic_val_factorial_asymp axiom: v_p(n!)/n → 1/(p-1)",
+      "padic_val_factorial_asymp theorem (3 sorries): v_p(n!)/n → 1/(p-1) squeeze argument",
       "factorial_sum_factored theorem: factorization a₁! + a₂! = a₁!(1 + a₂!/a₁!)",
       "Two proved examples by native_decide",
       "erdos_404_summary: proved conjunction of Lin's bounds"
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "prerequisites": [
       "p-adic valuation (padicValNat) and basic properties",
       "Factorials and divisibility in number theory",
@@ -65,8 +65,8 @@
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
-    "lineCount": 99,
-    "assumptions": "3 axioms: lin_bound (f(2,2) ≤ 254), lin_bound_meaning (2^255 never divides such sums), padic_val_factorial_asymp (v_p(n!)/n → 1/(p-1)). legendre_formula is a proved theorem using Mathlib's padicValNat_factorial."
+    "lineCount": 125,
+    "assumptions": "2 axioms: lin_bound (f(2,2) ≤ 254), lin_bound_meaning (2^255 never divides such sums). 3 sorries in padic_val_factorial_asymp (v_p(n!)/n → 1/(p-1) squeeze argument). legendre_formula is a proved theorem using Mathlib's padicValNat_factorial."
   },
   "overview": {
     "historicalContext": "**Prime Power Divisibility of Factorial Sums**\n\nThe interaction between prime divisibility and factorials has deep roots: Legendre's formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ (1808) gives the exact $p$-adic valuation of $n!$, and Kummer's theorem (1852) extends this to binomial coefficients. Erdős and Graham posed Problem #404 in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*: for integers $a \\geq 1$ and primes $p$, define $f(a,p) = \\sup\\{k : p^k \\mid a_1! + \\cdots + a_n!$ for some $a = a_1 < \\cdots < a_n\\}$. Is $f(a,p)$ always finite?\n\n**Chronological Development:**\n- **1808 (Legendre):** Formula for $v_p(n!)$ — the foundational tool\n- **1976 (Lin):** Proved $f(2,2) \\leq 254$ — the only known concrete upper bound for any $(a,p)$ pair. Lin's argument used careful analysis of carries in $p$-adic addition of factorials\n- **1980 (Erdős–Graham):** Problem 404 posed formally, alongside the related Problem #403 on factorial sums modulo primes\n\nThe problem is surprisingly resistant because factorial sums can have cancellation patterns that concentrate $p$-adic valuation. The gap between the known lower bound $f(2,2) \\geq 3$ (from $2^3 \\mid 2! + 3!$) and Lin's upper bound of 254 illustrates how little is understood about the $p$-adic structure of factorial sums.",
@@ -201,9 +201,9 @@
       "Filter"
     ],
     "namespace": "Erdos404",
-    "lineCount": 99,
-    "axiomCount": 3,
-    "theoremCount": 3,
+    "lineCount": 125,
+    "axiomCount": 2,
+    "theoremCount": 4,
     "definitionCount": 7
   }
 }


### PR DESCRIPTION
## Summary

Gallery integrity audit found and fixed metadata mismatches in 4 proofs:

- **erdos-404**: sorries 0→3, axiomCount 3→2 (padic_val_factorial_asymp is a theorem with sorries, not an axiom), lineCount 99→125
- **cayley-hamilton-minpoly-oq-05-oq-01-oq-01**: **Promoted to verified** — all sorries eliminated (2→0), status formalized→verified, badge axiom→original, lineCount 268→362
- **cayley-hamilton-minpoly-oq-05-oq-01-oq-03**: sorries 3→2 (cyclicSubspace_le_minpoly_degree now proved), removed phantom "infinite-dim-example" section referencing nonexistent mulByX content, lineCount 305→347
- **cauchy-schwarz-integral-oq-02-oq-02**: sorries 2→1 (one sorry eliminated), lineCount 393→402

## Test plan

- [ ] `pnpm build` passes with updated metadata
- [ ] Verify sorry counts match `grep -c sorry` in each Lean file
- [ ] Verify axiom counts match `grep -c "^axiom "` in each Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)