### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -7320,11 +7320,12 @@
     },
     {
       "slug": "bounded-prime-gaps-oq-04-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-29T04:28:18.926Z",
-      "status": "active",
-      "lastUpdate": "2026-03-29T04:28:18.986Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:38:13.050Z",
+      "completed": "2026-03-29T05:38:13.049Z"
     },
     {
       "slug": "roth-theorem-k3-oq-01",
@@ -7352,11 +7353,12 @@
     },
     {
       "slug": "euler-identity-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-03-29T04:28:18.977Z",
-      "status": "active",
-      "lastUpdate": "2026-03-29T04:28:18.987Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:38:13.102Z",
+      "completed": "2026-03-29T05:38:13.102Z"
     },
     {
       "slug": "fourier-series-oq-02-oq-03-oq-02",
@@ -7424,11 +7426,12 @@
     },
     {
       "slug": "stirling-formula-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-29T04:28:18.978Z",
-      "status": "active",
-      "lastUpdate": "2026-03-29T04:28:18.988Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:38:13.103Z",
+      "completed": "2026-03-29T05:38:13.103Z"
     },
     {
       "slug": "vietas-formulas-oq-03-oq-01",


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (added 16, updated 468 listings)
- Prune old quality snapshot

Automated deploy cycle sync.