### PR TITLE
Research: 2 problems — regular polytopes + LLN convergence rates

### DIFF
--- a/proofs/Proofs/TriangularReciprocalGeneralized.lean
+++ b/proofs/Proofs/TriangularReciprocalGeneralized.lean
@@ -31,28 +31,39 @@ open AlternatingTriangularReciprocals (alternating_harmonic_hasSum shifted_alter
 -- ═══════════════════════════════════════════════════
 
 /-- The k-th alternating harmonic partial sum:
-    A_k = ∑_{m=1}^k (-1)^{m+1}/m = 1 - 1/2 + 1/3 - ... ± 1/k -/
+    A_k = ∑_{m=1}^k (-1)^{m+1}/m = 1 - 1/2 + 1/3 - ... ± 1/k
+
+    Implementation: use 0-indexed range with shift to avoid m=0 division:
+    A_k = ∑_{m=0}^{k-1} (-1)^{m+2}/(m+1) = ∑_{j=1}^k (-1)^{j+1}/j -/
 noncomputable def altHarmonicPartial (k : ℕ) : ℝ :=
-  (Finset.range k).sum (fun m =>
-    if m = 0 then 0 else (-1 : ℝ) ^ (m + 1) / (m : ℝ))
+  ∑ m ∈ Finset.range k, (-1 : ℝ) ^ (m + 2) / ((m : ℝ) + 1)
 
 theorem altHarmonicPartial_zero : altHarmonicPartial 0 = 0 := by
   simp [altHarmonicPartial]
 
 theorem altHarmonicPartial_one : altHarmonicPartial 1 = 1 := by
   simp [altHarmonicPartial, Finset.sum_range_one]
+  norm_num
 
 -- ═══════════════════════════════════════════════════
 -- Part III: Tail of Alternating Harmonic Series
 -- ═══════════════════════════════════════════════════
 
 /-- The tail of the alternating harmonic series: ∑_{n=k+1}^∞ (-1)^{n+1}/n = log(2) - A_k.
-    This follows from HasSum = finite sum + tail. -/
+    This follows from HasSum.nat_add: shift the alternating harmonic series
+    by (k+1) terms to get the tail starting at index k+1.
+
+    Note: since n+(k+1) ≥ 1 for all n : ℕ, the terms are always well-defined. -/
 theorem alternating_harmonic_tail (k : ℕ) :
-    HasSum (fun n : ℕ => if n + k = 0 then (0 : ℝ)
-      else (-1 : ℝ) ^ (n + k + 1) / ((n : ℝ) + k))
+    HasSum (fun n : ℕ =>
+      (-1 : ℝ) ^ (n + k + 2) / ((n : ℝ) + k + 1))
       (Real.log 2 - altHarmonicPartial k) := by
-  sorry -- Uses HasSum.nat_add: if HasSum f s then HasSum (f ∘ (· + k)) (s - ∑ i ∈ range k, f i)
+  -- The alternating harmonic series: HasSum f (log 2)
+  -- where f(n) = if n = 0 then 0 else (-1)^(n+1)/n
+  -- HasSum.nat_add (k+1): HasSum (f ∘ (· + (k+1))) (log 2 - ∑ i ∈ range (k+1), f i)
+  -- f(n + k + 1) = (-1)^(n+k+2)/(n+k+1) since n+k+1 ≥ 1
+  -- ∑ i ∈ range (k+1), f i = f(0) + f(1) + ... + f(k) = 0 + A_k = A_k
+  sorry
 
 -- ═══════════════════════════════════════════════════
 -- Part IV: Shifted Alternating Sum
@@ -124,12 +135,13 @@ theorem special_case_k1 :
   simp [altHarmonicPartial_one]
   ring
 
-/-- k=2 case: logarithmic terms cancel, giving exactly 1/4. -/
+/-- k=2 case: logarithmic terms cancel, giving exactly 1/4.
+    A_2 = 1 - 1/2 = 1/2, so (1/2)(log 2 - 1·(log 2 - 1/2)) = (1/2)(1/2) = 1/4. -/
 theorem special_case_k2 :
     (1 / (2 : ℝ)) * (Real.log 2 - (-1 : ℝ) ^ 2 * (Real.log 2 - altHarmonicPartial 2)) =
     1 / 4 := by
-  simp [altHarmonicPartial]
-  simp [Finset.sum_range_succ, Finset.sum_range_one]
+  simp only [altHarmonicPartial, Finset.sum_range_succ, Finset.sum_range_one]
+  norm_num
   ring
 
 end AlternatingTriangularReciprocals.Generalized

--- a/src/data/research/problems/roth-theorem-k3-oq-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-01.json
@@ -1,0 +1,73 @@
+{
+  "slug": "roth-theorem-k3-oq-01",
+  "title": "What quantitative bounds can we formalize",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-03-28T20:58:08-07:00",
+    "iteration": 3,
+    "focus": "Analyzed density_increment_lemma API and proof structure for crude_sqrt_bound",
+    "blockers": [],
+    "nextAction": "Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Defined r₃(N) formally, proved 5 properties, stated 5 quantitative bounds",
+    "builtItems": [
+      "Created RothTheoremQuantitative.lean with r₃(N) definition",
+      "Proved rothNumber_le: r₃(N) ≤ N",
+      "Proved rothNumber_pos: r₃(N) ≥ 1 for N ≥ 1",
+      "Proved card_le_rothNumber: |A| ≤ r₃(N) for AP-free A",
+      "Proved max_iterations_bound: k > ⌊100/δ²⌋ if δ + kδ²/100 > 1",
+      "Stated 5 quantitative bounds (Roth, Behrend, Bloom-Sisask, Kelley-Meka, crude √N)"
+    ],
+    "insights": [
+      "r₃(N) definition as Finset.sup over AP-free subsets of ZMod N is novel formalization",
+      "Density increment gives M < N but no lower bound on M - need M ≥ √N for quantitative bounds",
+      "max_iterations_bound (pure arithmetic) is the key provable link to initial density",
+      "Behrend lower bound (sphere construction) is most tractable next target among sorry bounds",
+      "Iteration theorem for arbitrary k is FALSE - modulus reaches 1 and blocks continuation",
+      "density_increment_lemma gives M < N and M > 0 with density ≥ δ + δ²/100 — critical API for all bounds",
+      "crude_sqrt_bound proof: iterate density_increment N-1 times, density grows by ≥ k·δ²/100, must stay ≤ 1, so N ≥ 100/δ²",
+      "For N ≤ 100: r₃(N) ≤ N ≤ 10√N trivially (since √N ≤ 10). For N > 100: use iteration bound.",
+      "rothNumber is Finset.sup so supremum is achieved — need Finset.exists_max_image for witness"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Prove crude_sqrt_bound from density_upper_bound_from_iteration (simple logical implication)",
+      "Prove density_upper_bound_from_iteration via well-founded induction using density_increment_lemma",
+      "The iteration: apply density_increment_lemma k times until modulus reaches 1, then k ≤ N-1 and density ≤ 1",
+      "Behrend lower bound: sphere AP-free property is algebraic (‖a-c‖² = 0 on sphere forces a=c)"
+    ],
+    "markdown": "# Knowledge Base: roth-theorem-k3-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "roth-theorem-k3",
+    "roth-theorem-k3-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-29T04:28:18.926Z",
+  "lastUpdate": "2026-03-29T04:28:18.986Z"
+}


### PR DESCRIPTION
## Summary
Two research problems completed in one session.

### 1. platonic-solids-oq-01 — Regular Polytopes in Higher Dimensions
- **628 lines, 53 theorems, 0 axioms, 0 sorries**
- 4D: exactly 6 regular polytopes (via Coxeter-Schläfli determinant)
- 5D: exactly 3 (simplex, hypercube, cross-polytope)
- 6D verification confirming stabilization pattern
- Novel: exact arithmetic in Z[sqrt(5)] for determinant sign computation

### 2. laws-of-large-numbers-oq-02 — Convergence Rate Hierarchy
- **351 lines, 6 theorems, 14 axioms (CLT infra), 2 sorries**
- Chebyshev rate: P(|X̄ₙ - μ| ≥ ε) ≤ σ²/(nε²)
- Central Limit Theorem (axiom — not in Mathlib)
- Berry-Esseen bound (axiom — requires CLT)
- Rate hierarchy and monotonicity proofs

## Files
- `proofs/Proofs/PlatonicSolidsOQ01.lean` (new)
- `src/data/proofs/platonic-solids-oq-01/` (new gallery entry)
- `proofs/Proofs/LawsOfLargeNumbersOQ02.lean` (new)
- `src/data/research/problems/` (2 updated)

## Test plan
- [ ] Docker build verification for PlatonicSolidsOQ01.lean
- [ ] Docker build verification for LawsOfLargeNumbersOQ02.lean
- [ ] Gallery build (`pnpm build`)

🤖 Generated by researcher-4