### PR TITLE
fix(metadata): audit iteration 3 — 7 fixes + 3 clean audits

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2699,9 +2699,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1092": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T06:19:24Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1093": {
@@ -4547,8 +4547,8 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-404": {
-      "lastAudited": "2026-03-29T05:24:12Z",
-      "auditCount": 2,
+      "lastAudited": "2026-03-29T06:19:24Z",
+      "auditCount": 3,
       "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
@@ -9645,8 +9645,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-29T05:29:30Z",
+      "auditCount": 3,
+      "lastAudited": "2026-03-29T06:19:25Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -9687,8 +9687,44 @@
       "issues": []
     },
     "erdos-1181": {
+      "auditCount": 2,
+      "lastAudited": "2026-03-29T06:19:24Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "angle-trisection-oq-03": {
       "auditCount": 1,
-      "lastAudited": "2026-03-29T03:28:08Z",
+      "lastAudited": "2026-03-29T06:18:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T06:18:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "brouwer-fixed-point-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T06:18:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-rule-of-signs-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T06:19:24Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "euler-identity-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T06:19:24Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "fourier-series-oq-02-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T06:19:24Z",
       "result": "issues-fixed",
       "issues": []
     }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
@@ -21,7 +21,7 @@
       "open-question"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 402,
-    "assumptions": "0 axioms. 2 sorries in ENNReal rpow arithmetic (routine calculations about a^p = a · a^{p-1} and the final division step)."
+    "assumptions": "0 axioms. 1 sorry in minkowski_from_holder_explicit (ENNReal arithmetic combining split + Hölder steps with division)."
   },
   "overview": {
     "historicalContext": "**The Young-Hölder-Minkowski Chain**\n\nThree fundamental inequalities form a logical chain:\n- **Young (1912)**: $ab \\leq a^p/p + b^q/q$ for conjugate exponents\n- **Hölder (1889)**: $\\int|fg| \\leq \\|f\\|_p \\cdot \\|g\\|_q$ for $1/p + 1/q = 1$\n- **Minkowski (1896)**: $\\|f+g\\|_p \\leq \\|f\\|_p + \\|g\\|_p$ for $p \\geq 1$\n\nIn modern Lean/Mathlib, Minkowski is embedded inside the `NormedAddCommGroup` instance for `Lp` spaces, making the chain invisible. This formalization makes each step explicit.",
@@ -148,10 +148,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Answers YES to the open question: the full Lp Minkowski proof via the Hölder chain IS available in Lean 4 without the black-box NormedAddCommGroup instance. The chain Young → Hölder → Minkowski is made explicit, with the factoring trick (splitting |f+g|^p and applying Hölder twice) as the key step. Two sorries remain in ENNReal rpow arithmetic.",
+    "summary": "Answers YES to the open question: the full Lp Minkowski proof via the Hölder chain IS available in Lean 4 without the black-box NormedAddCommGroup instance. The chain Young → Hölder → Minkowski is made explicit, with the factoring trick (splitting |f+g|^p and applying Hölder twice) as the key step. One sorry remains in the final ENNReal division step.",
     "implications": "Making the chain explicit serves both pedagogy and formalization quality. Students see exactly where each inequality is used. Formal verification confirms the logical dependencies are correct. The factoring trick pattern (Hölder → norm inequality) recurs throughout analysis: Sobolev embeddings, interpolation theorems, and more.",
     "openQuestions": [
-      "Can the two remaining sorries (ENNReal rpow arithmetic) be closed with tactic automation?",
+      "Can the remaining sorry (ENNReal rpow division step) be closed with tactic automation?",
       "Can the chain be extended to include Sobolev embeddings as a fourth step?",
       "What is the optimal way to handle the division step when ‖f+g‖_p = 0 or ∞?"
     ]

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -8,15 +8,23 @@
     "date": "1807",
     "status": "formalized",
     "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
-    "tags": ["algebra", "polynomials", "real-algebraic-geometry", "root-isolation"],
+    "tags": [
+      "algebra",
+      "polynomials",
+      "real-algebraic-geometry",
+      "root-isolation"
+    ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 140,
+    "lineCount": 185,
     "dateAdded": "2026-03-28",
-    "assumptions": "3 sorry lemmas: linear_at_most_one_root, rolle_polynomial, root_of_sign_change. All provable from Mathlib (Rolle's theorem, IVT). The full Budan upper bound proof requires ~240-410 more lines.",
+    "assumptions": "0 sorries remaining. All sorry lemmas (linear_at_most_one_root, rolle_polynomial, root_of_sign_change) have been proved.",
     "relatedProblems": [
-      {"id": "descartes-rule-of-signs-oq-02", "relationship": "Proves the budan_upper_bound_axiom from OQ-02"}
+      {
+        "id": "descartes-rule-of-signs-oq-02",
+        "relationship": "Proves the budan_upper_bound_axiom from OQ-02"
+      }
     ]
   },
   "overview": {
@@ -26,15 +34,27 @@
   },
   "leanFile": {
     "namespace": "BudanUpperBound",
-    "lineCount": 140,
+    "lineCount": 185,
     "axiomCount": 0,
     "theoremCount": 5,
     "defCount": 1,
-    "sorries": 3,
+    "sorries": 0,
     "mainTheorems": [
-      {"name": "constant_no_roots", "type": "proved", "description": "Constant nonzero polynomials have no roots"},
-      {"name": "rolle_polynomial", "type": "sorry", "description": "Rolle's theorem for polynomials (building block)"},
-      {"name": "root_of_sign_change", "type": "sorry", "description": "IVT: sign change implies root"}
+      {
+        "name": "constant_no_roots",
+        "type": "proved",
+        "description": "Constant nonzero polynomials have no roots"
+      },
+      {
+        "name": "rolle_polynomial",
+        "type": "sorry",
+        "description": "Rolle's theorem for polynomials (building block)"
+      },
+      {
+        "name": "root_of_sign_change",
+        "type": "sorry",
+        "description": "IVT: sign change implies root"
+      }
     ]
   }
 }

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
     "tags": [
       "erdos",
@@ -15,14 +15,14 @@
       "extremal-graph-theory",
       "open"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 1092,
     "erdosUrl": "https://erdosproblems.com/1092",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 162,
-    "assumptions": "No axioms, no sorries. Fully verified. Definitions and 5 structural theorems proved. Main conjectures (Questions 1&2) disproved by Rödl (1982); false axioms removed with documented counterexamples.",
+    "assumptions": "0 axioms, 0 sorries. 5 structural theorems fully proved. 2 True-stub documentation markers for disproved claims (Q1, Q2 refuted by Rödl 1982). Main conjectures removed; file is primarily graph coloring infrastructure.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-1181/meta.json
+++ b/src/data/proofs/erdos-1181/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 1181,
     "erdosUrl": "https://erdosproblems.com/1181",
     "erdosProblemStatus": "open",
@@ -76,8 +76,8 @@
       "conjectures_compatible theorem stub: compatibility of #457 and #1181"
     ],
     "axiomCount": 4,
-    "lineCount": 235,
-    "assumptions": "4 axioms: trivial_upper_bound (primorial/PNT), erdos_1181 (main open conjecture), pnt_chebyshev (PNT for Chebyshev function), primorial_divides_bound (primorial divides product). Properties of q(n,k) proved constructively."
+    "lineCount": 261,
+    "assumptions": "4 axioms: trivial_upper_bound (primorial/PNT), erdos_1181 (main open conjecture), pnt_chebyshev (PNT for Chebyshev function), primorial_divides_bound (primorial divides product). 1 sorry remaining. Properties of q(n,k) proved constructively."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1181** appears in Erdős [Er79d, p.78] and asks for an upper bound on q(n, log n), the least prime not dividing a product of consecutive integers. The trivial upper bound q(n, log n) ≤ (1+o(1))(log n)² follows from the primorial argument combined with the Prime Number Theorem. The conjecture asks whether the constant can be improved from (1+o(1)) to (1-c) for some fixed c > 0.\n\nThis is the companion upper bound question to Erdős Problem #457, which asks about lower bounds. Together they aim to pin down the growth rate of q(n, log n) between Ω(log n) and O((log n)²). Probabilistic heuristics described by Tao in the context of Problem #457 suggest a much stronger bound of q(n, log n) ≪ (log log n / log log log n) · log n.",
@@ -184,7 +184,7 @@
       "Finset"
     ],
     "namespace": "Erdos1181",
-    "lineCount": 235,
+    "lineCount": 261,
     "axiomCount": 4,
     "theoremCount": 7,
     "definitionCount": 6

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 3,
     "erdosNumber": 404,
     "erdosUrl": "https://erdosproblems.com/404",
     "erdosProblemStatus": "open",
@@ -57,7 +57,7 @@
       "Two proved examples by native_decide",
       "erdos_404_summary: proved conjunction of Lin's bounds"
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "prerequisites": [
       "p-adic valuation (padicValNat) and basic properties",
       "Factorials and divisibility in number theory",
@@ -65,8 +65,8 @@
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
-    "lineCount": 99,
-    "assumptions": "3 axioms: lin_bound (f(2,2) ≤ 254), lin_bound_meaning (2^255 never divides such sums), padic_val_factorial_asymp (v_p(n!)/n → 1/(p-1)). legendre_formula is a proved theorem using Mathlib's padicValNat_factorial."
+    "lineCount": 125,
+    "assumptions": "2 axioms: lin_bound (f(2,2) ≤ 254), lin_bound_meaning (2^255 never divides such sums). 3 sorries in padic_val_factorial_asymp (v_p(n!)/n → 1/(p-1) squeeze argument). legendre_formula is a proved theorem using Mathlib's padicValNat_factorial."
   },
   "overview": {
     "historicalContext": "**Prime Power Divisibility of Factorial Sums**\n\nThe interaction between prime divisibility and factorials has deep roots: Legendre's formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ (1808) gives the exact $p$-adic valuation of $n!$, and Kummer's theorem (1852) extends this to binomial coefficients. Erdős and Graham posed Problem #404 in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*: for integers $a \\geq 1$ and primes $p$, define $f(a,p) = \\sup\\{k : p^k \\mid a_1! + \\cdots + a_n!$ for some $a = a_1 < \\cdots < a_n\\}$. Is $f(a,p)$ always finite?\n\n**Chronological Development:**\n- **1808 (Legendre):** Formula for $v_p(n!)$ — the foundational tool\n- **1976 (Lin):** Proved $f(2,2) \\leq 254$ — the only known concrete upper bound for any $(a,p)$ pair. Lin's argument used careful analysis of carries in $p$-adic addition of factorials\n- **1980 (Erdős–Graham):** Problem 404 posed formally, alongside the related Problem #403 on factorial sums modulo primes\n\nThe problem is surprisingly resistant because factorial sums can have cancellation patterns that concentrate $p$-adic valuation. The gap between the known lower bound $f(2,2) \\geq 3$ (from $2^3 \\mid 2! + 3!$) and Lin's upper bound of 254 illustrates how little is understood about the $p$-adic structure of factorial sums.",
@@ -202,8 +202,8 @@
     ],
     "namespace": "Erdos404",
     "lineCount": 125,
-    "axiomCount": 3,
-    "theoremCount": 3,
+    "axiomCount": 2,
+    "theoremCount": 4,
     "definitionCount": 7
   }
 }

--- a/src/data/proofs/euler-identity-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01/meta.json
@@ -17,8 +17,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 2,
-    "lineCount": 200,
+    "axiomCount": 3,
+    "lineCount": 213,
     "mathlibDependencies": [
       {
         "theorem": "NormedSpace.exp_eq_tsum",
@@ -43,7 +43,7 @@
       "Even/odd tsum splitting",
       "Taylor series for cos and sin"
     ],
-    "assumptions": "2 axioms: (1) tsum_even_add_odd: splitting a summable series by even/odd indices; (2) cos_eq_tsum + sin_eq_tsum: identification of the even/odd subseries with cos and sin Taylor series. Estimated ~200-250 lines to eliminate all.",
+    "assumptions": "3 axioms: (1) tsum_even_add_odd: splitting a summable series by even/odd indices; (2) cos_eq_tsum: cosine as Taylor series; (3) sin_eq_tsum: sine as Taylor series. Estimated ~200-250 lines to eliminate all.",
     "relatedProblems": [
       {
         "id": "euler-identity",
@@ -120,10 +120,13 @@
       "Mathlib.Topology.Algebra.InfiniteSum.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Complex", "Real"],
+    "opens": [
+      "Complex",
+      "Real"
+    ],
     "namespace": "EulerIdentityOQ01",
-    "lineCount": 200,
-    "axiomCount": 2,
+    "lineCount": 213,
+    "axiomCount": 3,
     "theoremCount": 8,
     "defCount": 3,
     "mainTheorems": [

--- a/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
@@ -17,9 +17,9 @@
       "sharp-constants"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 6,
     "axiomCount": 3,
-    "lineCount": 260,
+    "lineCount": 325,
     "mathlibDependencies": [
       {
         "theorem": "fourierCoeff",
@@ -46,7 +46,7 @@
       "Weierstrass uniform convergence theorem",
       "Fourier coefficient infrastructure from Mathlib"
     ],
-    "assumptions": "3 axioms: (1) contour_shift_decay: contour-shifting gives exponential Fourier decay for strip-analytic functions; (2) rate_is_sharp: the exponential rate 2*pi*delta/T cannot be improved; (3) paley_wiener_converse: exponential decay of Fourier coefficients implies strip analyticity. Plus 5 sorry lemmas for structural results (summability, comparison, optimality).",
+    "assumptions": "3 axioms: (1) contour_shift_decay: contour-shifting gives exponential Fourier decay for strip-analytic functions; (2) rate_is_sharp: the exponential rate 2*pi*delta/T cannot be improved; (3) paley_wiener_converse: exponential decay of Fourier coefficients implies strip analyticity. Plus 6 sorry lemmas for structural results (summability, comparison, optimality, exponential-polynomial dominance).",
     "relatedProblems": [
       {
         "id": "fourier-series-oq-02-oq-03",
@@ -195,7 +195,7 @@
       "Filter"
     ],
     "namespace": "FourierAnalyticDecay",
-    "lineCount": 260,
+    "lineCount": 325,
     "structureCount": 0,
     "axiomCount": 3,
     "theoremCount": 10,


### PR DESCRIPTION
## Summary

Gallery integrity audit iteration 3. Consolidates all pending fixes into a single PR (supersedes #7747 and #7764).

**Fixes (7 proofs):**
- **erdos-1092** (CRITICAL): status verified→formalized, badge verified→original (True stubs for disproved claims)
- **erdos-404**: sorries 0→3, axiomCount 3→2, lineCount 99→125
- **cauchy-schwarz-oq02-oq02**: sorries 2→1
- **descartes-oq02-oq01**: sorries 3→0 (all proved!), lineCount 140→185
- **euler-identity-oq-01**: axiomCount 2→3, lineCount 200→213
- **fourier-series-oq02-oq03-oq02**: sorries 5→6, lineCount 260→325
- **erdos-1181**: sorries 2→1, lineCount 235→261

**Clean audits (3 proofs):**
- angle-trisection-oq-03, basel-problem-oq-05, brouwer-fixed-point-oq-02-oq-02

## Test plan

- [ ] `pnpm build` passes
- [ ] Verify sorry/axiom counts match Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)