### PR TITLE
Research: erdos-40 — prove b2g_density_bound (axiom→theorem)

### DIFF
--- a/proofs/Proofs/Erdos40Problem.lean
+++ b/proofs/Proofs/Erdos40Problem.lean
@@ -129,12 +129,46 @@ axiom sidon_density_bound :
     ∀ ε : ℝ, ε > 0 → ∃ N₀ : ℕ, ∀ N : ℕ, N > N₀ →
       (countingFn A N : ℝ) ≤ (1 + ε) * Real.sqrt N
 
-/-- For B₂[g] sets (r_A(n) ≤ g for all n), the density is
-    bounded by |A ∩ {1,...,N}| ≤ c·N^{1/2} for a constant
-    depending on g. -/
-axiom b2g_density_bound (g : ℕ) :
+/-- Counting inequality for B₂[g] density: k² ≤ 2g(2N-1) where k = |A ∩ {1,...,N}|.
+
+    The k elements form k(k+1)/2 ≥ k²/2 ordered pairs (a,b) with a ≤ b (by swap
+    symmetry: the upper-triangular part of S×S has at least half the elements).
+    Each pair has sum a+b ∈ {2,...,2N} and contributes to repCount(A, a+b).
+    Since repCount ≤ g and there are 2N-1 possible sums: k²/2 ≤ g(2N-1). -/
+private lemma b2g_counting_sq_bound (A : Set ℕ) (g N : ℕ) (_ : N ≥ 1)
+    (hrep : ∀ n : ℕ, repCount A n ≤ g) :
+    countingFn A N * countingFn A N ≤ 2 * g * (2 * N - 1) := by
+  sorry -- Needs: Finset pair counting via swap injection + fiber decomposition by sum
+
+/-- **PROVED** (modulo counting lemma): For B₂[g] sets (r_A(n) ≤ g for all n),
+    the counting function satisfies |A ∩ {1,...,N}| ≤ 2(g+1)·√N.
+
+    Uses: k² ≤ 2g(2N-1) ≤ 4gN ≤ 4(g+1)²N, so k ≤ 2(g+1)·√N. -/
+theorem b2g_density_bound (g : ℕ) :
   ∃ c : ℝ, c > 0 ∧ ∀ A : Set ℕ, (∀ n : ℕ, repCount A n ≤ g) →
-    ∀ N : ℕ, N ≥ 1 → (countingFn A N : ℝ) ≤ c * Real.sqrt N
+    ∀ N : ℕ, N ≥ 1 → (countingFn A N : ℝ) ≤ c * Real.sqrt N := by
+  refine ⟨2 * (↑g + 1), by positivity, fun A hrep N hN => ?_⟩
+  set k := countingFn A N
+  -- Step 1: k² ≤ 2g(2N-1) from counting lemma
+  have h_count := b2g_counting_sq_bound A g N hN hrep
+  -- Step 2: k² ≤ 4(g+1)²N
+  have h_ksq : k * k ≤ 4 * (g + 1) ^ 2 * N := by
+    calc k * k ≤ 2 * g * (2 * N - 1) := h_count
+      _ ≤ 2 * g * (2 * N) := by apply Nat.mul_le_mul_left; exact Nat.sub_le _ _
+      _ = 4 * g * N := by ring
+      _ ≤ 4 * (g + 1) ^ 2 * N := by nlinarith
+  -- Step 3: (k:ℝ)² ≤ (2(g+1))²·N
+  have h_real : (↑k : ℝ) ^ 2 ≤ (2 * ((↑g : ℝ) + 1)) ^ 2 * ↑N := by
+    have : (k : ℝ) * k ≤ 4 * ((↑g : ℝ) + 1) ^ 2 * ↑N := by exact_mod_cast h_ksq
+    nlinarith
+  -- Step 4: k ≤ 2(g+1)·√N via square root monotonicity
+  calc (↑k : ℝ)
+      = Real.sqrt ((↑k : ℝ) ^ 2) := (Real.sqrt_sq (Nat.cast_nonneg _)).symm
+    _ ≤ Real.sqrt ((2 * ((↑g : ℝ) + 1)) ^ 2 * ↑N) := Real.sqrt_le_sqrt h_real
+    _ = Real.sqrt ((2 * ((↑g : ℝ) + 1)) ^ 2) * Real.sqrt ↑N :=
+        Real.sqrt_mul (by positivity) _
+    _ = 2 * ((↑g : ℝ) + 1) * Real.sqrt ↑N := by
+        rw [Real.sqrt_sq (by positivity : (0 : ℝ) ≤ 2 * ((↑g : ℝ) + 1))]
 
 /- ## Proved Properties -/
 

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -15,12 +15,12 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos40Problem.lean",
-    "sorries": 0,
+    "sorries": 1,
     "sourceUrl": "https://erdosproblems.com/40",
     "erdosUrl": "https://erdosproblems.com/40",
-    "axiomCount": 2,
-    "assumptions": "2 axioms (known results: sidon_density_bound, b2g_density_bound), 0 sorries. Open conjectures (Erdos-Turan #28, Erdos #40) stated as hypotheses, not global axioms.",
-    "lineCount": 171,
+    "axiomCount": 1,
+    "assumptions": "1 axiom (sidon_density_bound: tight Sidon bound), 1 sorry (b2g_counting_sq_bound: pair counting lemma). b2g_density_bound now a theorem. Open conjectures stated as hypotheses.",
+    "lineCount": 203,
     "badge": "axiom",
     "mathlib_version": "4.26.0"
   },
@@ -68,10 +68,10 @@
     {
       "id": "partial-results",
       "title": "Known Partial Results",
-      "summary": "Sidon set bound: $r_A(n) \\leq 1 \\Rightarrow A(N) \\leq (1+o(1))\\sqrt{N}$ (Erdős-Turán 1941, Lindström 1969). $B_2[g]$ bound: $r_A(n) \\leq g \\Rightarrow A(N) \\leq c_g\\sqrt{N}$. Shows $\\sqrt{N}$ is the natural threshold.",
-      "startLine": 79,
-      "endLine": 95,
-      "mathContext": "Sidon ($B_2$) sets: $r_A(n) \\leq 1 \\implies A(N) \\leq (1+o(1))\\sqrt{N}$. $B_2[g]$ sets: $r_A(n) \\leq g \\implies A(N) \\leq c_g \\sqrt{N}$. These establish $\\sqrt{N}$ as the critical density threshold."
+      "summary": "Sidon set bound (axiom): $r_A(n) \\leq 1 \\Rightarrow A(N) \\leq (1+o(1))\\sqrt{N}$ (tight bound, Lindström 1969). $B_2[g]$ bound (**proved** modulo counting lemma): $r_A(n) \\leq g \\Rightarrow A(N) \\leq 2(g+1)\\sqrt{N}$ via pair counting argument.",
+      "startLine": 122,
+      "endLine": 171,
+      "mathContext": "Sidon ($B_2$) sets: $r_A(n) \\leq 1 \\implies A(N) \\leq (1+o(1))\\sqrt{N}$ (axiom: tight bound needs Lindström's argument). $B_2[g]$ sets: $r_A(n) \\leq g \\implies A(N) \\leq 2(g+1)\\sqrt{N}$ (theorem: proved from counting inequality $k^2 \\leq 2g(2N-1) \\leq 4(g+1)^2 N$, sorry in pair counting lemma)."
     },
     {
       "id": "heuristic",
@@ -192,9 +192,9 @@
     ],
     "opens": [],
     "namespace": "",
-    "lineCount": 168,
-    "axiomCount": 4,
-    "theoremCount": 4,
+    "lineCount": 203,
+    "axiomCount": 1,
+    "theoremCount": 5,
     "definitionCount": 5,
     "mainTheorems": [
       {

--- a/src/data/research/problems/erdos-40.json
+++ b/src/data/research/problems/erdos-40.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-40",
-  "title": "Erd\u0151s #40",
+  "title": "Erdős #40",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "(LaTeX not available)",
-    "plain": "For what functions $g(N)\\to \\infty$ is it true that\\[\\lvert A\\cap \\{1,\\ldots,N\\}\\rvert \\gg \\frac{N^{1/2}}{g(N)}\\]implies $\\limsup 1_A\\ast 1_A(n)=\\infty$? This is a stronger form of the Erd\u0151s-Tur\u00e1n conjecture [28] (since establishing this for any function $g(N)\\to \\infty$ would imply a positive solution to [28]). View the LaTeX source",
+    "plain": "For what functions $g(N)\\to \\infty$ is it true that\\[\\lvert A\\cap \\{1,\\ldots,N\\}\\rvert \\gg \\frac{N^{1/2}}{g(N)}\\]implies $\\limsup 1_A\\ast 1_A(n)=\\infty$? This is a stronger form of the Erdős-Turán conjecture [28] (since establishing this for any function $g(N)\\to \\infty$ would imply a positive solution to [28]). View the LaTeX source",
     "whyMatters": []
   },
   "knownResults": {
@@ -17,35 +17,39 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-03-29T01:11:23.654482+00:00",
-    "iteration": 3,
-    "focus": "Session 3: Eliminated 2 unused axioms (open conjectures -> comments)",
+    "since": "2026-03-29T06:05:00+00:00",
+    "iteration": 4,
+    "focus": "Session 4: Converted b2g_density_bound from axiom to theorem",
     "blockers": [],
     "nextAction": "Prove sidon_density_bound from counting argument (known result)",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 4\u21922 axioms. Removed erdos_turan_conjecture and erdos_40_conjecture (unused open-problem axioms, now comments). Remaining: sidon_density_bound, b2g_density_bound (known results, not yet proved).",
+    "progressSummary": "PROGRESS: b2g_density_bound converted from axiom to theorem (1 sorry in counting lemma). Arithmetic chain fully proved. Now: 1 axiom (sidon_density_bound), 1 sorry.",
     "builtItems": [
-      "bounded_rep_not_unbounded: contrapositive of unboundedness \u2014 if rep \u2264 B for all n then \u00acRepUnbounded",
+      "bounded_rep_not_unbounded: contrapositive of unboundedness — if rep ≤ B for all n then ¬RepUnbounded",
       "Removed random_heuristic and threshold_heuristic (were axiom : True, now comments)",
       "repUnbounded_iff and basis2_iff: definition unfoldings for API",
-      "problem_40_implies_28 (PROVED) \u2014 if #40 holds for any g\u2192\u221e then #28 holds, via g(N)=N and countingFn\u22651",
+      "problem_40_implies_28 (PROVED) — if #40 holds for any g→∞ then #28 holds, via g(N)=N and countingFn≥1",
       "rep_set_finite, basis_has_element, countingFn_pos (helper lemmas)",
-      "Removed 2 unused open-conjecture axioms (erdos_turan_conjecture, erdos_40_conjecture)"
+      "Removed 2 unused open-conjecture axioms (erdos_turan_conjecture, erdos_40_conjecture)",
+      "b2g_density_bound: axiom -> theorem via counting lemma + sqrt arithmetic (Erdos40Problem.lean:147)",
+      "b2g_counting_sq_bound: counting lemma (sorry) for k^2 <= 2g(2N-1)"
     ],
     "insights": [
-      "random_heuristic and threshold_heuristic were literally True \u2014 pure comment axioms adding to count for zero value",
-      "problem_40_implies_28 requires showing a basis of order 2 has density \u2265 N^{1/2}/g(N) for some g\u2192\u221e; argument: use g(N)=N, then density condition becomes trivial since basis is infinite",
-      "Sidon set bound axiom is a classical result \u2014 likely not in Mathlib but deep",
-      "The $500 prize is for the strongest form (all g\u2192\u221e); weaker forms may be approachable",
-      "problem_40_implies_28 proof: take g(N)=N, basis gives countingFn\u22651\u2265\u221aN/N for large N",
+      "random_heuristic and threshold_heuristic were literally True — pure comment axioms adding to count for zero value",
+      "problem_40_implies_28 requires showing a basis of order 2 has density ≥ N^{1/2}/g(N) for some g→∞; argument: use g(N)=N, then density condition becomes trivial since basis is infinite",
+      "Sidon set bound axiom is a classical result — likely not in Mathlib but deep",
+      "The $500 prize is for the strongest form (all g→∞); weaker forms may be approachable",
+      "problem_40_implies_28 proof: take g(N)=N, basis gives countingFn≥1≥√N/N for large N",
       "Both open-conjecture axioms were completely unused by any theorem - pure documentation artifacts",
-      "The 2 remaining axioms (sidon_density_bound, b2g_density_bound) are known results provable via counting arguments"
+      "The 2 remaining axioms (sidon_density_bound, b2g_density_bound) are known results provable via counting arguments",
+      "b2g proof chain: k^2 <= 2g(2N-1) <= 4gN <= 4(g+1)^2*N, then sqrt gives k <= 2(g+1)*sqrt(N)",
+      "Counting lemma needs: Finset pair counting via swap injection + fiber decomposition by sum + repCount bound"
     ],
     "mathlibGaps": [
       "Set.ncard reasoning needed for counting function properties",
@@ -56,7 +60,7 @@
       "Prove b2g_density_bound: generalize Sidon argument with multiplicity g",
       "Both proofs need Finset/Set.ncard machinery for pair counting"
     ],
-    "markdown": "# Erd\u0151s #40 - Knowledge Base\n\n## Problem Statement\n\nFor what functions $g(N)\\to \\infty$ is it true that\\[\\lvert A\\cap \\{1,\\ldots,N\\}\\rvert \\gg \\frac{N^{1/2}}{g(N)}\\]implies $\\limsup 1_A\\ast 1_A(n)=\\infty$? This is a stronger form of the Erd\u0151s-Tur\u00e1n conjecture [28] (since establishing this for any function $g(N)\\to \\infty$ would imply a positive solution to [28]). View the LaTeX source\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n**Prize**: $500\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #2\n- Problem #28\n- Problem #39\n- Problem #41\n- Problem #1\n\n## References\n\n- Er95\n- Er97c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "markdown": "# Erdős #40 - Knowledge Base\n\n## Problem Statement\n\nFor what functions $g(N)\\to \\infty$ is it true that\\[\\lvert A\\cap \\{1,\\ldots,N\\}\\rvert \\gg \\frac{N^{1/2}}{g(N)}\\]implies $\\limsup 1_A\\ast 1_A(n)=\\infty$? This is a stronger form of the Erdős-Turán conjecture [28] (since establishing this for any function $g(N)\\to \\infty$ would imply a positive solution to [28]). View the LaTeX source\n\n## Status\n\n**Erdős Database Status**: OPEN\n**Prize**: $500\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #2\n- Problem #28\n- Problem #39\n- Problem #41\n- Problem #1\n\n## References\n\n- Er95\n- Er97c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- Convert `b2g_density_bound` from `axiom` to `theorem` in Erdős #40 formalization
- Prove the arithmetic chain from counting inequality to density bound
- One sorry remains in pair counting lemma (`b2g_counting_sq_bound`)

## Progress
- **Before**: 2 axioms (`sidon_density_bound`, `b2g_density_bound`), 0 sorries
- **After**: 1 axiom (`sidon_density_bound`), 1 sorry (counting lemma)
- Proved: k² ≤ 2g(2N-1) ≤ 4gN ≤ 4(g+1)²N → k ≤ 2(g+1)√N via `Real.sqrt_le_sqrt`

## Files Modified
- `proofs/Proofs/Erdos40Problem.lean` — axiom elimination + theorem proof
- `src/data/proofs/erdos-40/meta.json` — updated axiomCount, sorries, assumptions
- `src/data/research/problems/erdos-40.json` — updated knowledge

## Remaining Sorry
`b2g_counting_sq_bound`: needs Finset pair counting via swap injection + fiber decomposition by sum value. The mathematical argument is elementary (double counting) but requires Set.ncard ↔ Finset.card conversion infrastructure.

## Status
**Outcome**: progress
**Next Steps**: Prove counting lemma, then tackle `sidon_density_bound` (tight Lindström bound)

🤖 Generated by researcher-7