### PR TITLE
fix(metadata): audit erdos-1092 — stale axiom references

### DIFF
--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -29,7 +29,7 @@
     "historicalContext": "Erdős, Hajnal, and Szemerédi introduced this problem as part of their investigation into when local chromatic structure forces global coloring bounds. The function $f_r(n)$ captures a 'local-to-global' threshold: if every subgraph of an $n$-vertex graph can be made $r$-colorable by deleting at most $k$ edges, what is the largest $k$ that still forces $\\chi(G) \\leq r+1$? Rödl's 1982 construction provided a crucial upper bound, showing $f_2(n) = O(n \\cdot (\\log n)^2)$ via probabilistic and algebraic techniques. Tang subsequently observed that Rödl's construction directly addresses Question 1, providing evidence that $f_2(n) \\gg n$ may be false. The problem connects to broader themes in extremal graph theory: the interplay between local substructure (each piece is nearly $r$-colorable) and global properties (the whole graph has bounded chromatic number). Similar local-to-global phenomena appear in Szemerédi's regularity lemma, Brooks' theorem ($\\chi \\leq \\Delta + 1$ from local degree bounds), and Johansson's theorem ($\\chi = O(\\Delta/\\log \\Delta)$ for triangle-free graphs). The problem also relates to Erdős Problem #744, which considers variant chromatic decomposition thresholds.",
     "problemStatement": "Let $f_r(n)$ be the maximum $k$ such that if every $m$-vertex subgraph of an $n$-vertex graph $G$ can have its chromatic number reduced to $\\leq r$ by removing $\\leq k$ edges, then $\\chi(G) \\leq r+1$. Is $f_2(n) \\gg n$? More generally, is $f_r(n) \\gg_r rn$?",
     "text": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to ≤ r while forcing χ(G) ≤ r+1. Is f₂(n) ≫ n? Rödl (1982) gives f₂(n) = O(n·polylog). Open.",
-    "proofStrategy": "The formalization builds custom graph infrastructure (`SGraph`, `edgeCount`, `hasColoring`, `chromaticNum`) and defines chromatic reduction via edge deletion (`CanReduceChromatic`). The threshold function `fThreshold r n` is defined as a supremum via `sSup`. Both main questions were removed (disproved by Rödl). Rödl's upper bound $O(n \\log^2 n)$ is the sole remaining axiom. Two previously axiomatized claims (trivial lower bound and monotonicity in r) were found to be false and removed with documented counterexamples.",
+    "proofStrategy": "The formalization builds custom graph infrastructure (`SGraph`, `edgeCount`, `hasColoring`, `chromaticNum`) and defines chromatic reduction via edge deletion (`CanReduceChromatic`). The threshold function `fThreshold r n` is defined as a supremum via `sSup`. Both main questions were removed (disproved by Rödl). Previously axiomatized claims (questions 1 & 2, trivial lower bound, monotonicity in r) were all found to be false and removed with documented counterexamples. The file now contains 0 axioms: only definitions and 5 proved structural theorems remain.",
     "keyInsights": [
       "The function $f_r(n)$ is a Turán-type extremal quantity for chromatic properties rather than subgraph avoidance: it measures the critical edge-deletion budget separating local reducibility from global colorability failure",
       "Rödl's 1982 construction gives the upper bound $f_2(n) = O(n \\log^2 n)$, the only nontrivial bound known",
@@ -82,16 +82,16 @@
       "title": "The Main Conjectures",
       "startLine": 64,
       "endLine": 75,
-      "summary": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both axiomatized as open problems.",
-      "mathContext": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both axiomatized as open problems."
+      "summary": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by Rödl (1982) and removed; only `True`-valued documentation notes remain.",
+      "mathContext": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by Rödl (1982) and removed; only `True`-valued documentation notes remain."
     },
     {
       "id": "rodl-bounds",
       "title": "Rödl's Construction and Structural Properties",
       "startLine": 94,
-      "endLine": 171,
-      "summary": "Rödl's upper bound $f_2(n) \\leq C \\cdot n \\cdot (\\log n)^2$ (sole remaining axiom). Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection).",
-      "mathContext": "Rödl's upper bound $f_2(n) \\leq C \\cdot n \\cdot (\\log n)^2$ (sole remaining axiom). Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection)."
+      "endLine": 163,
+      "summary": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, Rödl upper bound) with counterexamples. No axioms remain.",
+      "mathContext": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, Rödl upper bound) with counterexamples. No axioms remain."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

- Fixed `overview.proofStrategy` claiming "Rödl's upper bound is the sole remaining axiom" when axiomCount is 0 (all axioms were removed in a prior cleanup)
- Updated section `questions` description from "both axiomatized as open problems" to reflect they were disproved and removed
- Updated section `rodl-bounds` description to remove axiom reference
- Fixed section `rodl-bounds` endLine from 171 to 163 (actual file length)

## Evidence

**meta.json claimed**: "Rödl's upper bound O(n log²n) is the sole remaining axiom"
**Lean file shows**: 0 axioms, 0 sorries, 5 proved structural theorems + 2 True-valued documentation notes

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Discovered during gallery integrity audit.