### PR TITLE
fix(metadata): audit chinese-remainder-constructive-oq-03 — sorry count

### DIFF
--- a/proofs/Proofs/ChineseRemainderConstructiveOQ03.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ03.lean
@@ -20,7 +20,7 @@
 
   Status: AXIOMATIZED
   Axioms: 1 (primorial growth rate bound)
-  Sorries: 0
+  Sorries: 1 (mersenne_coprime_of_coprime)
 
   References:
   [Gar59] Garner "The residue number system" (1959)

--- a/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
@@ -16,10 +16,10 @@
       "classical"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 1,
-    "lineCount": 210,
-    "assumptions": "1 axiom (primorial growth lower bound). 2 sorries: dynamicRange_le_pow (list induction), mersenne_coprime_of_coprime (gcd(2^a-1,2^b-1) identity). Multiple theorems proved: concrete base ranges, Mersenne values, RNS encode/add/mul correctness, pairwise coprimality.",
+    "lineCount": 263,
+    "assumptions": "1 axiom (primorial growth lower bound). 1 sorry: mersenne_coprime_of_coprime (gcd(2^a-1,2^b-1) identity). dynamicRange_le_pow now fully proved. Multiple theorems proved: concrete base ranges, Mersenne values, RNS encode/add/mul correctness, pairwise coprimality.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -31,6 +31,6 @@
     "summary": "RNS arithmetic formalized with correctness proofs for addition and multiplication."
   },
   "leanFile": {
-    "lineCount": 216
+    "lineCount": 263
   }
 }


### PR DESCRIPTION
## Summary

- Corrected `sorries` from 2 to 1 — `dynamicRange_le_pow` is now fully proved (line 92-95)
- Updated `assumptions` text to reflect only 1 remaining sorry (`mersenne_coprime_of_coprime`)
- Fixed `lineCount` values (210/216 → 263, matching actual file)
- Fixed Lean docstring: "Sorries: 0" → "Sorries: 1"

## Evidence

**meta.json claimed**: 2 sorries (dynamicRange_le_pow, mersenne_coprime_of_coprime)
**Lean file shows**: 1 sorry (mersenne_coprime_of_coprime at line 172; dynamicRange_le_pow proved at lines 92-95)

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Discovered during gallery integrity audit.