### PR TITLE
fix(metadata): audit Green's + Vieta's — badge corrections

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "integration",
       "greens-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No axioms. 0 sorries. All theorems fully proved using Mathlib's integral_integral_swap and ContinuousOn.integrableOn_compact.",
@@ -61,7 +61,7 @@
       "title": "Part I: Fubini for Interval Integrals",
       "startLine": 1,
       "endLine": 55,
-      "summary": "States intervalIntegral_swap: swap iterated interval integrals under measurability + integrability. 1 sorry.",
+      "summary": "Proves intervalIntegral_swap: swap iterated interval integrals under measurability + integrability via Mathlib's integral_integral_swap.",
       "mathContext": "$\\int_c^d \\int_a^b f(x,y)\\,dx\\,dy = \\int_a^b \\int_c^d f(x,y)\\,dy\\,dx$"
     },
     {
@@ -77,7 +77,7 @@
       "title": "Part III: Sufficient Conditions",
       "startLine": 81,
       "endLine": 120,
-      "summary": "Proves fubini_of_continuous and greens_fubini_for_C1: continuous dPdy always satisfies Fubini. 1 sorry.",
+      "summary": "Proves fubini_of_continuous and greens_fubini_for_C1: continuous dPdy always satisfies Fubini. Fully proved via ContinuousOn.integrableOn_compact.",
       "mathContext": "$f \\in C^0([a,b] \\times [c,d]) \\implies$ Fubini holds."
     }
   ],

--- a/src/data/proofs/vietas-formulas-oq-03-oq-01/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-01/meta.json
@@ -19,12 +19,12 @@
       "mv-polynomial",
       "generalization"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 14,
     "defCount": 2,
-    "lineCount": 168,
+    "lineCount": 185,
     "mathlibDependencies": [
       {
         "theorem": "MvPolynomial.mul_esymm_eq_sum",
@@ -166,7 +166,7 @@
       "Finset"
     ],
     "namespace": "GeneralizedNewton",
-    "lineCount": 168,
+    "lineCount": 185,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 2


### PR DESCRIPTION
## Summary

- **greens-theorem-oq-01-oq-01**: Badge `verified` → `mathlib` (core result is bridge to Mathlib's `integral_integral_swap`). Removed stale "1 sorry" from two section descriptions (file has 0 sorries).
- **vietas-formulas-oq-03-oq-01**: Badge `verified` → `mathlib` (Newton identity derived from Mathlib's `mul_esymm_eq_sum`). Fixed lineCount 168 → 185.

## Evidence

**Green's**: `intervalIntegral_swap` calls `MeasureTheory.integral_integral_swap` at line 71 — Tier B (Mathlib bridge)
**Vieta's**: `newton_identity` calls `MvPolynomial.mul_esymm_eq_sum` at line 77 — Tier B (Mathlib bridge)

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery pages render correctly with `mathlib` badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Discovered during gallery integrity audit.