### PR TITLE
fix(metadata): audit roth, stirling, triangular — axiom/line corrections

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "formalized",
     "sorries": 6,
-    "axiomCount": 1,
-    "assumptions": "1 axiom: density_increment (proved in RothTheorem.lean, axiomatized here for modularity). 6 sorries: rothNumber_mono (embedding), density_upper_bound_from_iteration (well-founded induction), roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound, crude_sqrt_bound.",
+    "axiomCount": 0,
+    "assumptions": "0 axioms. 6 sorries: density_upper_bound_from_iteration (well-founded induction), roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound, crude_sqrt_bound.",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -50,7 +50,7 @@
       "Proof of max_iterations_bound: density increment iteration count ≤ ⌊100/δ²⌋",
       "Formal statements of 5 quantitative bounds: Roth, Behrend, Bloom-Sisask, Kelley-Meka, crude √N"
     ],
-    "lineCount": 168,
+    "lineCount": 196,
     "theoremCount": 12,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
@@ -139,8 +139,8 @@
     "imports": ["Mathlib"],
     "opens": ["Finset"],
     "namespace": "Szemeredi.Roth.Quantitative",
-    "lineCount": 168,
-    "axiomCount": 1,
+    "lineCount": 196,
+    "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2
   }

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -40,7 +40,7 @@
       "Path to axiom elimination: first correction implies stirling_error_bound_ge_2",
       "error_bound_from_correction: structured proof reducing axiom to first correction"
     ],
-    "lineCount": 160,
+    "lineCount": 177,
     "theoremCount": 9,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
@@ -107,7 +107,7 @@
     "imports": ["Mathlib.Analysis.SpecialFunctions.Stirling", "Mathlib.Analysis.Asymptotics.Defs", "Mathlib.Data.Real.Basic", "Mathlib.Tactic"],
     "opens": ["Stirling", "Real", "Filter"],
     "namespace": "StirlingExpansion",
-    "lineCount": 160,
+    "lineCount": 177,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 2

--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "formalized",
     "sorries": 3,
-    "axiomCount": 0,
-    "assumptions": "1 axiom: alternating_harmonic_hasSum (same as parent OQ03, boundary convergence of Mercator series requires Abel's theorem). 3 sorries: alternating_harmonic_tail, shifted_alternating_hasSum, generalized_alternating_sum (core HasSum manipulation).",
+    "axiomCount": 1,
+    "assumptions": "1 transitive axiom: alternating_harmonic_hasSum (imported from parent OQ03, boundary convergence of Mercator series requires Abel's theorem). 3 sorries: alternating_harmonic_tail, shifted_alternating_hasSum, generalized_alternating_sum (core HasSum manipulation).",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -40,7 +40,7 @@
       "Verification that k=1 gives 2\u00b7log 2 - 1 and k=2 gives 1/4",
       "Even k: logarithmic terms cancel, giving rational answer A_k/k"
     ],
-    "lineCount": 140,
+    "lineCount": 135,
     "theoremCount": 10,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
@@ -132,7 +132,7 @@
       "Real"
     ],
     "namespace": "AlternatingTriangularReciprocals.Generalized",
-    "lineCount": 140,
+    "lineCount": 135,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 1


### PR DESCRIPTION
## Summary

- **roth-theorem-k3-oq-01**: axiomCount 1 → 0 (density_increment axiom never existed in file), removed non-existent rothNumber_mono from assumptions, lineCount 168 → 196
- **stirling-formula-oq-01**: lineCount 160 → 177
- **triangular-reciprocals-oq-03-oq-02**: axiomCount 0 → 1 (reconcile with leanFile section; imports alternating_harmonic_hasSum axiom from parent file), lineCount 140 → 135

## Evidence

**Roth**: `grep -c "^axiom " Proofs/RothTheoremQuantitative.lean` = 0, but meta.axiomCount was 1
**Triangular**: No `axiom` keyword in file, but imports axiom from `TriangularReciprocalAlternatingOQ03.lean` via `open`

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Discovered during gallery integrity audit.