### PR TITLE
fix: remove broken .lean/state self-referencing symlink

### DIFF
--- a/.lean/state
+++ b/.lean/state
@@ -1,1 +1,0 @@
-/Users/rwalters/GitHub/lean-genius/.lean/state


### PR DESCRIPTION
## Summary
- Removes a self-referencing symlink at `.lean/state` that was accidentally committed by a researcher worktree
- This broke `pnpm build` because the sync script couldn't find `candidate-pool.json`
- `.lean/state/` is already in `.gitignore` — it should never have been tracked

## Impact
Build was broken on main. This restores it.