### PR TITLE
Research: Buffon fix + Roth theorems + Wilson proofs + CRT axiom fix

### DIFF
--- a/proofs/Proofs/BuffonsNeedleOQ01OQ02.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ01OQ02.lean
@@ -9,16 +9,19 @@ hyperplanes spaced d apart, the expected number of crossings is:
 
   E[crossings] = c_n · L / d
 
-where c_n = 2 · Vol(S^{n-2}) / Vol(S^{n-1}) is the dimensional constant.
+where c_n = E[|⟨u, e₁⟩|] for uniform u ∈ S^{n-1} is the expected
+absolute cosine between a random direction and the hyperplane normal.
+
+Using Gamma functions: c_n = 2Γ(n/2) / ((n-1)·√π·Γ((n-1)/2))
 
 Key values:
-  c₂ = 2/π  ← classical Buffon's needle
-  c₃ = 1    ← needle among parallel planes in 3D
-  c₄ = 4/π  ← 4-dimensional case
+  c₂ = 2/π     ← classical Buffon's needle
+  c₃ = 1/2     ← needle among parallel planes in 3D
+  c₄ = 4/(3π)  ← 4-dimensional case
 
-The formula follows from the Cauchy-Crofton integral geometry formula:
-the mean projected length of a needle onto random directions equals
-L · c_n, and crossings occur when the projection exceeds the gap.
+The constants decrease with dimension: c₂ > c₃ > c₄ > ⋯ → 0,
+reflecting the concentration of measure phenomenon on high-dimensional
+spheres (random directions become nearly orthogonal to any fixed axis).
 
 Connection to the 2D case:
   For n = 2, c₂ = 2/π gives E = 2L/(πd), matching Buffon-Barbier.
@@ -40,66 +43,72 @@ open Real
 
 /-- The dimensional constant for Buffon's needle in ℝⁿ.
 
-    c_n = 2 · Vol(S^{n-2}) / Vol(S^{n-1})
-
-    Equivalently, c_n is the expected absolute cosine between a
-    random direction u ∈ S^{n-1} and any fixed unit vector e₁:
+    c_n is the expected absolute cosine between a random direction
+    u ∈ S^{n-1} and any fixed unit vector e₁:
       c_n = E[|⟨u, e₁⟩|]
 
     Defined using the Gamma function ratio:
-      c_n = 2 · Γ(n/2) / (√π · Γ((n-1)/2))
+      c_n = 2 · Γ(n/2) / ((n-1) · √π · Γ((n-1)/2))
 
     For n ≤ 1 we set c_n = 0 (degenerate). -/
 noncomputable def buffonConstant (n : ℕ) : ℝ :=
   if n ≤ 1 then 0
-  else 2 * Real.Gamma ((n : ℝ) / 2) / (Real.sqrt π * Real.Gamma (((n : ℝ) - 1) / 2))
+  else 2 * Real.Gamma ((n : ℝ) / 2) /
+    (((n : ℝ) - 1) * Real.sqrt π * Real.Gamma (((n : ℝ) - 1) / 2))
 
--- The Gamma function values Γ(1/2) = √π requires the Gaussian integral.
--- Axiomatize as it may not be directly available in Mathlib.
+-- The Gamma function value Γ(1/2) = √π requires the Gaussian integral.
 /-- Γ(1/2) = √π. Follows from ∫₀^∞ t^{-1/2} e^{-t} dt = √π
     (substitution t = x² reduces to the Gaussian integral). -/
 axiom gamma_one_half : Real.Gamma (1 / 2) = Real.sqrt π
 
 /-- c₂ = 2/π: the classical Buffon constant.
-    Proof: c₂ = 2Γ(1)/(√π · Γ(1/2)) = 2·1/(√π·√π) = 2/π. -/
+    Proof: c₂ = 2Γ(1)/((2-1)·√π·Γ(1/2)) = 2·1/(1·√π·√π) = 2/π. -/
 theorem buffonConstant_two : buffonConstant 2 = 2 / π := by
   unfold buffonConstant
   simp only [show ¬((2 : ℕ) ≤ 1) from by omega, ↓reduceIte]
   have h1 : ((2 : ℕ) : ℝ) / 2 = 1 := by push_cast; ring
   have h2 : (((2 : ℕ) : ℝ) - 1) / 2 = 1 / 2 := by push_cast; ring
-  rw [h1, h2, Real.Gamma_one, gamma_one_half]
-  rw [mul_one, Real.mul_self_sqrt (le_of_lt pi_pos)]
+  have h3 : ((2 : ℕ) : ℝ) - 1 = 1 := by push_cast; ring
+  rw [h1, h2, h3, Real.Gamma_one, gamma_one_half, mul_one, one_mul,
+      Real.mul_self_sqrt (le_of_lt pi_pos)]
 
-/-- c₃ = 1: in 3D, a needle of length L among parallel planes
-    has E = L/d — the simplest possible formula.
-    Proof: c₃ = 2Γ(3/2)/(√π · Γ(1)) = 2·(√π/2)/(√π·1) = 1. -/
-theorem buffonConstant_three : buffonConstant 3 = 1 := by
+/-- c₃ = 1/2: in 3D, a needle of length L among parallel planes
+    has E = L/(2d). The 3D constant is smaller than the 2D constant
+    because random 3D directions are less likely to be nearly parallel
+    to the hyperplane normal.
+    Proof: c₃ = 2Γ(3/2)/(2·√π·Γ(1)) = 2·(√π/2)/(2·√π) = 1/2. -/
+theorem buffonConstant_three : buffonConstant 3 = 1 / 2 := by
   unfold buffonConstant
   simp only [show ¬((3 : ℕ) ≤ 1) from by omega, ↓reduceIte]
   have h1 : ((3 : ℕ) : ℝ) / 2 = 3 / 2 := by push_cast; ring
   have h2 : (((3 : ℕ) : ℝ) - 1) / 2 = 1 := by push_cast; ring
-  rw [h1, h2, Real.Gamma_one, mul_one]
-  have hΓ32 : Real.Gamma (3 / 2 : ℝ) = 1 / 2 * Real.sqrt π := by
-    have h : (3 : ℝ) / 2 = 1 / 2 + 1 := by ring
-    rw [h, Real.Gamma_add_one (by norm_num : (1 : ℝ) / 2 ≠ 0), gamma_one_half]
+  have h3 : ((3 : ℕ) : ℝ) - 1 = 2 := by push_cast; ring
+  rw [h1, h2, h3, Real.Gamma_one, mul_one]
+  have hΓ32 : Real.Gamma (3 / 2 : ℝ) = Real.sqrt π / 2 := by
+    rw [show (3 : ℝ) / 2 = 1 / 2 + 1 from by ring,
+        Real.Gamma_add_one (by norm_num : (1 : ℝ) / 2 ≠ 0), gamma_one_half]
+    ring
   rw [hΓ32]
   have hπ : Real.sqrt π ≠ 0 := ne_of_gt (Real.sqrt_pos.mpr pi_pos)
   field_simp
+  ring
 
-/-- c₄ = 4/π: the 4-dimensional Buffon constant.
-    Proof: c₄ = 2Γ(2)/(√π · Γ(3/2)) = 2·1/(√π·√π/2) = 4/π. -/
-theorem buffonConstant_four : buffonConstant 4 = 4 / π := by
+/-- c₄ = 4/(3π): the 4-dimensional Buffon constant.
+    Proof: c₄ = 2Γ(2)/(3·√π·Γ(3/2)) = 2/(3·√π·√π/2) = 4/(3π). -/
+theorem buffonConstant_four : buffonConstant 4 = 4 / (3 * π) := by
   unfold buffonConstant
   simp only [show ¬((4 : ℕ) ≤ 1) from by omega, ↓reduceIte]
   have h1 : ((4 : ℕ) : ℝ) / 2 = 2 := by push_cast; ring
   have h2 : (((4 : ℕ) : ℝ) - 1) / 2 = 3 / 2 := by push_cast; ring
-  rw [h1, h2]
+  have h3 : ((4 : ℕ) : ℝ) - 1 = 3 := by push_cast; ring
+  rw [h1, h2, h3]
   have hΓ2 : Real.Gamma 2 = 1 := by
     rw [show (2 : ℝ) = 1 + 1 from by ring, Real.Gamma_add_one one_ne_zero,
         Real.Gamma_one, mul_one]
-  have hΓ32 : Real.Gamma (3 / 2 : ℝ) = 1 / 2 * Real.sqrt π := by
+  have hΓ32 : Real.Gamma (3 / 2 : ℝ) = Real.sqrt π / 2 := by
     rw [show (3 : ℝ) / 2 = 1 / 2 + 1 from by ring,
         Real.Gamma_add_one (by norm_num : (1 : ℝ) / 2 ≠ 0), gamma_one_half]
+    ring
   rw [hΓ2, hΓ32]
   have hπ : Real.sqrt π ≠ 0 := ne_of_gt (Real.sqrt_pos.mpr pi_pos)
   have hπ2 : (π : ℝ) ≠ 0 := ne_of_gt pi_pos
@@ -107,17 +116,22 @@ theorem buffonConstant_four : buffonConstant 4 = 4 / π := by
   rw [Real.mul_self_sqrt (le_of_lt pi_pos)]
   ring
 
-/-- The Buffon constant is positive for n ≥ 2 -/
+/-- The Buffon constant is positive for n ≥ 2. -/
 theorem buffonConstant_pos (n : ℕ) (hn : 2 ≤ n) : 0 < buffonConstant n := by
   unfold buffonConstant
   simp only [show ¬(n ≤ 1) from by omega, ↓reduceIte]
+  have hn_cast : (2 : ℝ) ≤ (↑n : ℝ) := by exact_mod_cast hn
+  have h_n_half : (0 : ℝ) < (↑n : ℝ) / 2 := by linarith
+  have h_nm1 : (0 : ℝ) < (↑n : ℝ) - 1 := by linarith
+  have h_nm1_half : (0 : ℝ) < ((↑n : ℝ) - 1) / 2 := by linarith
   apply div_pos
-  · exact mul_pos two_pos (Real.Gamma_pos_of_pos (by positivity))
-  · exact mul_pos (Real.sqrt_pos.mpr pi_pos) (Real.Gamma_pos_of_pos (by positivity))
+  · exact mul_pos two_pos (Real.Gamma_pos_of_pos h_n_half)
+  · exact mul_pos (mul_pos h_nm1 (Real.sqrt_pos.mpr pi_pos))
+      (Real.Gamma_pos_of_pos h_nm1_half)
 
 /-- The Buffon constant is at most 1 for all n ≥ 2.
-    This follows from |⟨u, e₁⟩| ≤ 1 for all unit vectors.
-    The maximum c_n = 1 is achieved at n = 3. -/
+    This follows from |⟨u, e₁⟩| ≤ 1 for all unit vectors u,
+    so E[|⟨u, e₁⟩|] ≤ 1. -/
 axiom buffonConstant_le_one (n : ℕ) (hn : 2 ≤ n) : buffonConstant n ≤ 1
 
 -- ============================================================
@@ -131,17 +145,9 @@ noncomputable def expectedCrossings (n : ℕ) (L d : ℝ) : ℝ :=
 
 /-- **Higher-Dimensional Buffon's Theorem**: A needle of length L in ℝⁿ
     dropped uniformly at random among parallel hyperplanes spaced d apart
-    has expected number of crossings equal to c_n · L / d.
-
-    The proof follows from the Cauchy-Crofton integral geometry formula:
-    E[crossings] = (1/Vol(S^{n-1})) · ∫_{S^{n-1}} |⟨v, u⟩| · L/d dσ(u)
-                 = L/d · 2 · Vol(S^{n-2}) / Vol(S^{n-1})
-                 = c_n · L / d
-
-    where v is the needle direction and the integral averages over
-    random hyperplane normals u ∈ S^{n-1}. -/
-axiom buffon_higher_dim (n : ℕ) (L d : ℝ) (hn : 2 ≤ n) (hL : 0 < L) (hd : 0 < d) :
-  expectedCrossings n L d = buffonConstant n * L / d
+    has expected number of crossings equal to c_n · L / d. -/
+theorem buffon_higher_dim (n : ℕ) (L d : ℝ) (hn : 2 ≤ n) (hL : 0 < L) (hd : 0 < d) :
+  expectedCrossings n L d = buffonConstant n * L / d := rfl
 
 -- ============================================================
 -- Section 3: Structural Properties
@@ -178,37 +184,41 @@ theorem two_dim_consistency (L d : ℝ) :
     expectedCrossings 2 L d = 2 * L / (π * d) := by
   simp only [expectedCrossings, buffonConstant_two]; ring
 
-/-- In 3D, a needle of length L among parallel planes has E = L/d -/
+/-- In 3D, a needle of length L among parallel planes has E = L/(2d) -/
 theorem three_dim_formula (L d : ℝ) :
-    expectedCrossings 3 L d = L / d := by
+    expectedCrossings 3 L d = L / (2 * d) := by
   simp only [expectedCrossings, buffonConstant_three]; ring
 
-/-- In 4D, the formula gives E = 4L/(πd) -/
+/-- In 4D, the formula gives E = 4L/(3πd) -/
 theorem four_dim_formula (L d : ℝ) :
-    expectedCrossings 4 L d = 4 * L / (π * d) := by
+    expectedCrossings 4 L d = 4 * L / (3 * π * d) := by
   simp only [expectedCrossings, buffonConstant_four]; ring
 
 -- ============================================================
 -- Section 5: Dimension Comparison
 -- ============================================================
 
-/-- In 3D, a needle crosses more often than in 2D (c₃ = 1 > 2/π ≈ 0.637).
-    Intuitively: in 3D, the hyperplane captures more random orientations. -/
-theorem three_beats_two : buffonConstant 2 < buffonConstant 3 := by
-  rw [buffonConstant_two, buffonConstant_three, div_lt_one pi_pos]
-  linarith [pi_gt_three]
+/-- The 2D Buffon constant exceeds the 3D constant (c₂ = 2/π > 1/2 = c₃).
+    In higher dimensions, random directions concentrate near the equator
+    (orthogonal to the hyperplane normal), reducing the expected projection. -/
+theorem two_beats_three : buffonConstant 3 < buffonConstant 2 := by
+  rw [buffonConstant_two, buffonConstant_three]
+  rw [div_lt_div_iff two_pos pi_pos]
+  simp only [one_mul]
+  linarith [pi_lt_3141593]
 
-/-- For same needle and spacing, 3D gives more crossings than 2D -/
-theorem crossings_3d_ge_2d (L d : ℝ) (hL : 0 ≤ L) (hd : 0 < d) :
-    expectedCrossings 2 L d ≤ expectedCrossings 3 L d := by
+/-- For same needle and spacing, 2D gives more crossings than 3D -/
+theorem crossings_2d_ge_3d (L d : ℝ) (hL : 0 ≤ L) (hd : 0 < d) :
+    expectedCrossings 3 L d ≤ expectedCrossings 2 L d := by
   simp only [expectedCrossings]
   exact div_le_div_of_nonneg_right
-    (mul_le_mul_of_nonneg_right (le_of_lt three_beats_two) hL) (le_of_lt hd)
+    (mul_le_mul_of_nonneg_right (le_of_lt two_beats_three) hL) (le_of_lt hd)
 
-/-- 4D crossings exceed 2D crossings: c₄ = 4/π > 2/π = c₂ -/
-theorem four_beats_two : buffonConstant 2 < buffonConstant 4 := by
+/-- 2D crossings exceed 4D crossings: c₂ = 2/π > 4/(3π) = c₄ -/
+theorem two_beats_four : buffonConstant 4 < buffonConstant 2 := by
   rw [buffonConstant_two, buffonConstant_four]
-  exact div_lt_div_of_pos_right (by linarith) pi_pos
+  rw [div_lt_div_iff (mul_pos (by norm_num : (0:ℝ) < 3) pi_pos) pi_pos]
+  linarith [pi_pos]
 
 -- ============================================================
 -- Section 6: Mean Width Connection
@@ -219,10 +229,7 @@ theorem four_beats_two : buffonConstant 2 < buffonConstant 4 := by
 noncomputable def meanWidth (n : ℕ) (L : ℝ) : ℝ :=
   L * buffonConstant n
 
-/-- Expected crossings = mean width / spacing.
-    This is the Cauchy-Crofton interpretation:
-    dropping a convex body among parallel hyperplanes spaced d apart,
-    E[crossings] = meanWidth / d. -/
+/-- Expected crossings = mean width / spacing. -/
 theorem crossings_eq_width_div_spacing (n : ℕ) (L d : ℝ) :
     expectedCrossings n L d = meanWidth n L / d := by
   simp [expectedCrossings, meanWidth]; ring
@@ -231,8 +238,8 @@ theorem crossings_eq_width_div_spacing (n : ℕ) (L d : ℝ) :
 theorem meanWidth_two (L : ℝ) : meanWidth 2 L = 2 * L / π := by
   simp [meanWidth, buffonConstant_two]; ring
 
-/-- Mean width in 3D: w = L (every direction contributes equally on average) -/
-theorem meanWidth_three (L : ℝ) : meanWidth 3 L = L := by
+/-- Mean width in 3D: w = L/2 -/
+theorem meanWidth_three (L : ℝ) : meanWidth 3 L = L / 2 := by
   simp [meanWidth, buffonConstant_three]; ring
 
 -- ============================================================
@@ -240,26 +247,28 @@ theorem meanWidth_three (L : ℝ) : meanWidth 3 L = L := by
 -- ============================================================
 
 /-- The Buffon constant satisfies the recurrence
-    c_{n+2} = ((n-1)/n) · c_n for n ≥ 2.
+    c_{n+2} = (n/(n+1)) · c_n for n ≥ 2.
 
-    This follows from the sphere volume recurrence
-    Vol(S^{n+1}) = (2π/n) · Vol(S^{n-1}).
+    This follows from the Gamma function identity Γ(z+1) = zΓ(z)
+    applied to both Gamma arguments in the definition.
 
-    The recurrence shows c_n → 0 as n → ∞, since
-    (n-1)/n < 1 and the product telescopes. -/
+    The recurrence shows c_n → 0 as n → ∞ (concentration of measure),
+    since n/(n+1) < 1 and the product telescopes. -/
 axiom buffonConstant_recurrence (n : ℕ) (hn : 2 ≤ n) :
-  buffonConstant (n + 2) = ((n : ℝ) - 1) / (n : ℝ) * buffonConstant n
+  buffonConstant (n + 2) = (n : ℝ) / ((n : ℝ) + 1) * buffonConstant n
 
-/-- From the recurrence: c₅ = (2/3) · c₃ = 2/3 -/
-theorem buffonConstant_five : buffonConstant 5 = 2 / 3 := by
-  have := buffonConstant_recurrence 3 (by omega)
-  simp [buffonConstant_three] at this
-  linarith
+/-- From the recurrence: c₅ = (3/4) · c₃ = 3/8 -/
+theorem buffonConstant_five : buffonConstant 5 = 3 / 8 := by
+  have h := buffonConstant_recurrence 3 (by omega)
+  rw [buffonConstant_three] at h
+  rw [h]; push_cast; norm_num
 
-/-- From the recurrence: c₆ = (3/4) · c₄ = 3/π -/
-theorem buffonConstant_six : buffonConstant 6 = 3 / π := by
-  have := buffonConstant_recurrence 4 (by omega)
-  rw [buffonConstant_four] at this
-  linarith
+/-- From the recurrence: c₆ = (4/5) · c₄ = 16/(15π) -/
+theorem buffonConstant_six : buffonConstant 6 = 16 / (15 * π) := by
+  have h := buffonConstant_recurrence 4 (by omega)
+  rw [buffonConstant_four] at h
+  rw [h]
+  have hπ : (π : ℝ) ≠ 0 := ne_of_gt pi_pos
+  push_cast; field_simp; ring
 
 end BuffonHigherDim

--- a/proofs/Proofs/Erdos1056Aristotle.lean
+++ b/proofs/Proofs/Erdos1056Aristotle.lean
@@ -4,7 +4,7 @@
   See Erdos1056Problem.lean for the main formalization.
 
   Main target: Prove Wilson's theorem constraint using Mathlib's
-  ZMod.prod_Ico_one_prime, bridging from ZMod to ℕ modular arithmetic.
+  ZMod.wilsons_lemma, bridging from ZMod to ℕ modular arithmetic.
 
   Criteria for inclusion:
   - NOT the main open conjecture
@@ -21,18 +21,46 @@ namespace Erdos1056Aristotle
 
 /-- The product of [1, p) equals (p-1) factorial. -/
 theorem ico_prod_eq_factorial (p : ℕ) (hp : p ≥ 1) :
-    (Finset.Ico 1 p).prod id = Nat.factorial (p - 1) := by sorry
+    (Finset.Ico 1 p).prod id = Nat.factorial (p - 1) := by
+  obtain ⟨n, rfl⟩ : ∃ n, p = n + 1 := ⟨p - 1, by omega⟩
+  simp only [Nat.add_sub_cancel]
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [show Finset.Ico 1 (m + 2) = Finset.Ico 1 (m + 1) ∪ {m + 1} from by
+      ext x; simp only [Finset.mem_Ico, Finset.mem_union, Finset.mem_singleton]; omega]
+    rw [Finset.prod_union (by
+      rw [Finset.disjoint_left]
+      intro x hx
+      simp only [Finset.mem_Ico] at hx
+      simp only [Finset.mem_singleton]
+      omega)]
+    rw [Finset.prod_singleton, id, ih, mul_comm, ← Nat.factorial_succ]
 
 /-- Wilson's theorem in ℕ modular arithmetic:
     (p-1)! % p = p - 1 for any prime p.
     This bridges Mathlib's ZMod.wilsons_lemma to ℕ. -/
 theorem wilson_nat (p : ℕ) (hp : Nat.Prime p) :
-    Nat.factorial (p - 1) % p = p - 1 := by sorry
+    Nat.factorial (p - 1) % p = p - 1 := by
+  haveI : Fact (Nat.Prime p) := ⟨hp⟩
+  haveI : NeZero p := ⟨hp.ne_zero⟩
+  have h := ZMod.wilsons_lemma p
+  -- h : ((p-1)! : ZMod p) = -1
+  -- Bridge via ZMod.val: val maps ZMod p → ℕ as canonical representative
+  have h_lhs : ZMod.val ((Nat.factorial (p - 1) : ℕ) : ZMod p) =
+      Nat.factorial (p - 1) % p := ZMod.val_natCast _
+  have h_rhs : ZMod.val (-1 : ZMod p) = p - 1 := ZMod.val_neg_one
+  calc Nat.factorial (p - 1) % p
+      = ZMod.val ((↑(Nat.factorial (p - 1)) : ZMod p)) := h_lhs.symm
+    _ = ZMod.val (-1 : ZMod p) := congr_arg ZMod.val h
+    _ = p - 1 := h_rhs
 
 /-- **Wilson's constraint for interval products:**
     For any prime p, (Finset.Ico 1 p).prod id % p = p - 1.
     This is the axiom wilson_constraint from Erdos1056Problem.lean. -/
 theorem wilson_constraint (p : ℕ) (hp : Nat.Prime p) :
-    (Finset.Ico 1 p).prod id % p = p - 1 := by sorry
+    (Finset.Ico 1 p).prod id % p = p - 1 := by
+  rw [ico_prod_eq_factorial p (by omega : p ≥ 1)]
+  exact wilson_nat p hp
 
 end Erdos1056Aristotle

--- a/proofs/Proofs/RothTheoremQuantitative.lean
+++ b/proofs/Proofs/RothTheoremQuantitative.lean
@@ -55,6 +55,14 @@ theorem apFree_subset {N : ℕ} {A B : Finset (ZMod N)} (h : B ⊆ A) (hA : APFr
     APFree B :=
   fun a d hd ha had hadd => hA a d hd (h ha) (h had) (h hadd)
 
+/-- For N ≥ 2, ZMod N contains the 3-AP {0, 1, 2}, so is not AP-free. -/
+theorem not_apFree_univ {N : ℕ} (hN : 1 < N) :
+    ¬APFree (Finset.univ : Finset (ZMod N)) := by
+  haveI : NeZero N := ⟨by omega⟩
+  haveI : Fact (1 < N) := ⟨hN⟩
+  intro h
+  exact h 0 1 one_ne_zero (Finset.mem_univ _) (Finset.mem_univ _) (Finset.mem_univ _)
+
 /-- r₃(N) ≤ N: no AP-free subset of ZMod N can exceed N elements. -/
 theorem rothNumber_le (N : ℕ) [NeZero N] : rothNumber N ≤ N := by
   unfold rothNumber
@@ -63,6 +71,22 @@ theorem rothNumber_le (N : ℕ) [NeZero N] : rothNumber N ≤ N := by
   rw [Finset.mem_filter] at hA
   calc A.card ≤ Fintype.card (ZMod N) := Finset.card_le_univ A
     _ = N := ZMod.card N
+
+/-- r₃(N) < N for N ≥ 2: the full ZMod N is never AP-free. -/
+theorem rothNumber_lt {N : ℕ} (hN : 1 < N) : rothNumber N < N := by
+  haveI : NeZero N := ⟨by omega⟩
+  unfold rothNumber
+  rw [Finset.sup_lt_iff (show (0 : ℕ) < N by omega)]
+  intro A hA
+  rw [Finset.mem_filter] at hA
+  by_contra hge; push_neg at hge
+  have hcard : A.card = Fintype.card (ZMod N) :=
+    le_antisymm (Finset.card_le_univ A) (ZMod.card N ▸ hge)
+  exact absurd (Finset.eq_univ_of_card A hcard ▸ hA.2) (not_apFree_univ hN)
+
+/-- r₃(N) ≤ N - 1 for N ≥ 2 (corollary of the strict bound). -/
+theorem rothNumber_le_sub_one {N : ℕ} (hN : 1 < N) : rothNumber N ≤ N - 1 := by
+  have := rothNumber_lt hN; omega
 
 /-- r₃(N) ≥ 1 when N ≥ 1: any singleton is AP-free. -/
 theorem rothNumber_pos (N : ℕ) [NeZero N] : 1 ≤ rothNumber N := by
@@ -82,6 +106,31 @@ theorem card_le_rothNumber {N : ℕ} (A : Finset (ZMod N)) (hA : APFree A) :
   apply Finset.le_sup
   rw [Finset.mem_filter]
   exact ⟨Finset.mem_powerset.mpr (Finset.subset_univ _), hA⟩
+
+/-- The Roth number is achieved: there exists an AP-free set of maximum size. -/
+theorem rothNumber_achieved {N : ℕ} [NeZero N] :
+    ∃ A : Finset (ZMod N), APFree A ∧ A.card = rothNumber N := by
+  set S := Finset.univ.powerset.filter (fun A : Finset (ZMod N) => APFree A)
+  have hne : S.Nonempty :=
+    ⟨∅, Finset.mem_filter.mpr ⟨Finset.mem_powerset.mpr (Finset.empty_subset _), apFree_empty⟩⟩
+  obtain ⟨A, hAS, hmax⟩ := Finset.exists_max_image S Finset.card hne
+  exact ⟨A, (Finset.mem_filter.mp hAS).2,
+    le_antisymm (Finset.le_sup hAS) (Finset.sup_le fun B hB => hmax B hB)⟩
+
+/-- r₃(2) = 1: in ZMod 2, every 2-element set contains the AP {0, 1, 0}. -/
+theorem rothNumber_two : rothNumber 2 = 1 := by
+  have h1 : rothNumber 2 < 2 := rothNumber_lt (by omega)
+  have h2 : 1 ≤ rothNumber 2 := rothNumber_pos 2
+  omega
+
+/-- r₃(3) = 2: {0, 1} is AP-free in ZMod 3, and the full set is not. -/
+theorem rothNumber_three : rothNumber 3 = 2 := by
+  have hlt : rothNumber 3 < 3 := rothNumber_lt (by omega)
+  suffices 2 ≤ rothNumber 3 by omega
+  apply card_le_rothNumber ({0, 1} : Finset (ZMod 3))
+  intro a d hd ha had hadd
+  simp only [Finset.mem_insert, Finset.mem_singleton] at ha had hadd
+  fin_cases a <;> fin_cases d <;> simp_all
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART II: ITERATION BOUND FROM DENSITY INCREMENT
@@ -129,7 +178,8 @@ theorem density_upper_bound_from_iteration {N : ℕ} (hN : 1 < N) (delta : ℝ)
     (hdelta : 0 < delta) (hdelta1 : delta ≤ 1)
     (h_exists : ∃ (A : Finset (ZMod N)), APFree A ∧ (A.card : ℝ) ≥ delta * N) :
     delta ^ 2 ≤ 100 / N := by
-  sorry -- Requires well-founded induction tracking the modulus decay through N steps
+  sorry -- BLOCKED: density_increment_lemma gives M < N with no lower bound on M.
+        -- Need M ≥ √N (or M ≥ N^c) at each step for quantitative iteration.
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART III: QUANTITATIVE BOUNDS (STATEMENTS)
@@ -183,14 +233,10 @@ theorem kelley_meka_upper_bound :
       (rothNumber N : ℝ) ≤ N * Real.exp (-c * (Real.log N) ^ (1/12 : ℝ)) := by
   sorry
 
-/-- **Crude bound from well-founded iteration**: r₃(N) ≤ 10√N.
-
-    The simplest bound from the density increment: each iteration
-    gives M < N, so at most N iterations are possible. Combined with
-    the density bound k ≤ 100/δ², this gives δ ≤ 10/√N. -/
-theorem crude_sqrt_bound :
-    ∀ N : ℕ, 2 ≤ N →
-      (rothNumber N : ℝ) ≤ 10 * Real.sqrt N := by
-  sorry
+-- NOTE: The previously stated crude_sqrt_bound (r₃(N) ≤ 10√N) was FALSE.
+-- Behrend's lower bound gives r₃(N) ≥ N·exp(-c√(log N)) >> √N for large N.
+-- The proof sketch (iterate density_increment N times) does not work because
+-- density_increment_lemma gives M < N with no lower bound on M.
+-- For quantitative bounds, need M ≥ N^c (e.g., M ≥ N^{2/3} in Roth's analysis).
 
 end Szemeredi.Roth.Quantitative

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BUG: buffonConstant definition missing 1/(n-1) factor. Code: c_n=2Γ(n/2)/(√π·Γ((n-1)/2)), correct: c_n=2Γ(n/2)/((n-1)·√π·Γ((n-1)/2)). c₂=2/π is correct (n-1=1 cancels), but c₃=1 (should be 1/2), c₄=4/π (should be 4/(3π)). Code gives c₄>1 contradicting buffonConstant_le_one axiom. Recurrence also wrong ((n-1)/n should be n/(n+1)). Needs rewrite.",
+    "progressSummary": "FIX COMPLETE: Corrected buffonConstant definition (added 1/(n-1) factor). c₃=1/2, c₄=4/(3π). Fixed recurrence n/(n+1). Converted buffon_higher_dim axiom→theorem. Now 3A (was 4A), 19T, 0S.",
     "builtItems": [
       "BuffonsNeedleOQ01OQ02.lean: buffonConstant definition via Gamma functions",
       "Proved buffonConstant_two = 2/π, buffonConstant_three = 1, buffonConstant_four = 4/π",
@@ -37,7 +37,18 @@
       "Proved positivity, linearity, scaling, nonnegativity of expectedCrossings",
       "Proved two_dim_consistency: matches Buffon-Barbier in 2D",
       "Proved three_beats_two: 3D crossings exceed 2D from π > 3",
-      "Gallery entry with full metadata, annotations, cross-references"
+      "Gallery entry with full metadata, annotations, cross-references",
+      "FIXED buffonConstant definition: added ((n:ℝ)-1) factor in denominator",
+      "FIXED buffonConstant_three: 1 → 1/2",
+      "FIXED buffonConstant_four: 4/π → 4/(3π)",
+      "FIXED recurrence axiom: (n-1)/n → n/(n+1)",
+      "FIXED buffonConstant_five: 2/3 → 3/8",
+      "FIXED buffonConstant_six: 3/π → 16/(15π)",
+      "ELIMINATED axiom: buffon_higher_dim → theorem (proved by rfl)",
+      "REVERSED comparisons: two_beats_three, crossings_2d_ge_3d, two_beats_four",
+      "FIXED three_dim_formula: L/d → L/(2d)",
+      "FIXED four_dim_formula: 4L/(πd) → 4L/(3πd)",
+      "FIXED meanWidth_three: L → L/2"
     ],
     "insights": [
       "c_n = 2Γ(n/2)/(√π·Γ((n-1)/2)) unifies all dimensions through the Gamma function",
@@ -47,18 +58,20 @@
       "Mean width interpretation: E = meanWidth/d is the Cauchy-Crofton formula for line segments",
       "BUG: The formula 2Γ(n/2)/(√π·Γ((n-1)/2)) = 2|S^{n-2}|/|S^{n-1}| is NOT the expected |cos θ|. The correct Buffon constant is E[|cos θ|] = 2|S^{n-2}|/((n-1)|S^{n-1}|). Factor 1/(n-1) missing.",
       "BUG evidence: code gives c₃=1 but E[|cos θ|] in 3D = ∫|cosθ|sinθ dθ / ∫sinθ dθ = 1/2. And c₄=4/π≈1.27>1 contradicts buffonConstant_le_one.",
-      "BUG: recurrence axiom says c_{n+2}=(n-1)/n·c_n but correct recurrence is c_{n+2}=n/(n+1)·c_n (from Γ functional equation). Derived values c₅=2/3, c₆=3/π are wrong."
+      "BUG: recurrence axiom says c_{n+2}=(n-1)/n·c_n but correct recurrence is c_{n+2}=n/(n+1)·c_n (from Γ functional equation). Derived values c₅=2/3, c₆=3/π are wrong.",
+      "FIXED: buffonConstant must be 2Γ(n/2)/((n-1)√π·Γ((n-1)/2)), not 2Γ(n/2)/(√π·Γ((n-1)/2)). The (n-1) comes from ∫₀¹ t(1-t²)^{(n-3)/2} dt = 1/(n-1).",
+      "FIXED: Correct values c₃=1/2, c₄=4/(3π) — constants DECREASE with dimension (concentration of measure)",
+      "FIXED: Recurrence is c_{n+2}=n/(n+1)·c_n, derived from Γ(z+1)=zΓ(z) applied twice",
+      "buffon_higher_dim was tautological (definition = definition) — converted from axiom to theorem by rfl"
     ],
     "mathlibGaps": [
       "No direct lemma Real.Gamma_half for Γ(1/2) = √π",
       "No sphere surface area function in Mathlib"
     ],
     "nextSteps": [
-      "FIX BUG: Change buffonConstant to include 1/(n-1) factor: c_n = 2Γ(n/2)/((n-1)√π·Γ((n-1)/2)). Then c₃=1/2, c₄=4/(3π), c₅=3/8.",
-      "FIX BUG: Change recurrence axiom to c_{n+2} = n/(n+1)·c_n and re-derive c₅, c₆",
-      "FIX BUG: buffonConstant_le_one becomes provable once definition is correct",
-      "Prove Γ(1/2)=√π from Mathlib (check Real.Gamma_one_half_eq or derive from reflection formula)",
-      "Extend to convex bodies beyond needles (Cauchy-Crofton for general K)"
+      "Gallery meta.json needs update: axiomCount 4→3, docstring/description corrections",
+      "buffonConstant_le_one could be proved from recurrence + base cases (strong induction) to reduce to 2 axioms",
+      "Prove Γ(1/2)=√π from Mathlib (check Real.Gamma_one_half_eq) to potentially eliminate last analytical axiom"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-1056.json
+++ b/src/data/research/problems/erdos-1056.json
@@ -29,10 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Aristotle companion file for Wilson constraint axiom elimination. Wilson theorem (Mathlib.NumberTheory.Wilson) can prove the axiom but direct import breaks existing native_decide proofs. Companion file bridges the gap.",
+    "progressSummary": "PROGRESS: Proved 3 Wilson theorem sorries in companion file (ico_prod_eq_factorial, wilson_nat, wilson_constraint) using Mathlib ZMod.wilsons_lemma bridge. 0 sorries remain in companion.",
     "builtItems": [
       "Created Erdos1056Aristotle.lean companion file with Wilson bridge lemmas",
-      "Identified Mathlib path: ZMod.prod_Ico_one_prime → wilson_constraint"
+      "Identified Mathlib path: ZMod.prod_Ico_one_prime → wilson_constraint",
+      "Proved ico_prod_eq_factorial by induction on p",
+      "Proved wilson_nat via ZMod.wilsons_lemma + ZMod.val bridge",
+      "Proved wilson_constraint: combines ico_prod_eq_factorial + wilson_nat"
     ],
     "insights": [
       "wilson_constraint axiom IS provable from Mathlib Wilson theorem (ZMod.prod_Ico_one_prime)",


### PR DESCRIPTION
## Summary
Four research problems in one session:

### buffons-needle-oq-01-oq-02: Fix buffonConstant definition
- **Fix mathematical bug**: missing 1/(n-1) factor in denominator
- **Eliminate axiom**: buffon_higher_dim (tautological) → theorem by rfl (4→3 axioms)

### roth-theorem-k3-oq-01: Prove 6 theorems
- not_apFree_univ, rothNumber_lt, rothNumber_le_sub_one, rothNumber_achieved
- **rothNumber_two = 1**, **rothNumber_three = 2** (exact computations)
- Removed FALSE crude_sqrt_bound

### erdos-1056: Prove Wilson theorem sorries (3→0)
- ico_prod_eq_factorial, wilson_nat, wilson_constraint
- Uses ZMod.wilsons_lemma + ZMod.val bridge

### chinese-remainder-constructive-oq-04-oq-03: Fix false axiom (1→0)
- primorial_growth_lower was FALSE for k≥7 (primorial def returns 0)
- Replaced with proved theorem restricted to k≤6

## Status
**Outcome**: 9+ theorems proved, 2 axioms eliminated, 2 false statements fixed, 1 bug fixed

🤖 Generated by researcher-6