### PR TITLE
fix(metadata): correct sorry/axiom counts for 3 gallery proofs

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -10,11 +10,11 @@
     "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
     "tags": ["algebra", "polynomials", "real-algebraic-geometry", "root-isolation"],
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 185,
+    "lineCount": 207,
     "dateAdded": "2026-03-28",
-    "assumptions": "1 sorry: linear_at_most_one_root (linear polynomial root bound). rolle_polynomial and root_of_sign_change have been proved.",
+    "assumptions": "All building-block lemmas proved (constant_no_roots, linear_at_most_one_root, rolle_polynomial, root_of_sign_change). Proof scaffold for full induction remains incomplete.",
     "relatedProblems": [
       {"id": "descartes-rule-of-signs-oq-02", "relationship": "Proves the budan_upper_bound_axiom from OQ-02"}
     ]
@@ -30,12 +30,12 @@
     "axiomCount": 0,
     "theoremCount": 5,
     "defCount": 1,
-    "sorries": 1,
+    "sorries": 0,
     "mainTheorems": [
       {"name": "constant_no_roots", "type": "proved", "description": "Constant nonzero polynomials have no roots"},
       {"name": "rolle_polynomial", "type": "proved", "description": "Rolle's theorem for polynomials"},
       {"name": "root_of_sign_change", "type": "proved", "description": "IVT: sign change implies root"},
-      {"name": "linear_at_most_one_root", "type": "sorry", "description": "Linear polynomial has at most one root in interval"}
+      {"name": "linear_at_most_one_root", "type": "proved", "description": "Linear polynomial has at most one root in interval"}
     ]
   }
 }

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 358,
     "erdosUrl": "https://erdosproblems.com/358",
     "erdosProblemStatus": "open",
@@ -57,9 +57,9 @@
       "PositiveDensityConjecture definition: positive upper density",
       "Classical characterization: n = sum of >=2 consecutive iff n != 2^k"
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 311,
-    "assumptions": "2 axioms: consecutive_sum_char, naturals_count_odd_divisors. power_of_two_obstruction and naturals_always_representable proved. strong_implies_weak proved via Filter.tendsto_atTop_atTop."
+    "assumptions": "1 axiom: naturals_count_odd_divisors. 1 sorry: not_pow2_representable (even case). consecutive_sum_char is a theorem (not axiom) using the sorry. power_of_two_obstruction and naturals_always_representable proved. strong_implies_weak proved via Filter.tendsto_atTop_atTop."
   },
   "overview": {
     "historicalContext": "Erdos Problem #358 was posed in 1977 [Er77c] and revisited in Erdos-Graham (1980). It asks a deceptively simple question about how many ways an integer can be written as a sum of consecutive terms from a fixed sequence.\n\nErdos himself remarked: \"This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me.\"\n\nThe problem connects to classical results about sums of consecutive integers (which relate to odd divisors) and to the Erdos-Moser conjecture (1963) about consecutive prime sums.",

--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -17,9 +17,9 @@
       "partial-fractions"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 transitive axiom: alternating_harmonic_hasSum (imported from parent OQ03, boundary convergence of Mercator series requires Abel's theorem). 3 sorries: alternating_harmonic_tail, shifted_alternating_hasSum, generalized_alternating_sum (core HasSum manipulation).",
+    "assumptions": "1 transitive axiom: alternating_harmonic_hasSum (imported from parent OQ03, boundary convergence of Mercator series requires Abel's theorem). All 3 former sorries (alternating_harmonic_tail, shifted_alternating_hasSum, generalized_alternating_sum) have been proved.",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Correct stale metadata for 3 gallery proofs where sorry/axiom counts diverged from the actual Lean source.

## Evidence

**triangular-reciprocals-oq-03-oq-02**
- Before: `sorries: 3`
- After: `sorries: 0` — all 3 sorries proved in commit 8db1f11

**descartes-rule-of-signs-oq-02-oq-01**
- Before: `sorries: 1` (linear_at_most_one_root listed as sorry)
- After: `sorries: 0` — linear_at_most_one_root is fully proved

**erdos-358**
- Before: `sorries: 0, axiomCount: 2`
- After: `sorries: 1, axiomCount: 1` — has 1 sorry in not_pow2_representable (even case), and consecutive_sum_char is a theorem (not axiom)

---
Automated fix by lean-mechanic agent.