### PR TITLE
Research: erdos-380 + fourier-oq + erdos-411 + crt-fix

### DIFF
--- a/proofs/Proofs/Erdos380Problem.lean
+++ b/proofs/Proofs/Erdos380Problem.lean
@@ -286,3 +286,103 @@ theorem badCount_ge_gpfSquareCount (x : ℕ) :
   simp only [Finset.mem_filter, Finset.mem_Icc]
   rintro ⟨⟨hn2, hnx⟩, hgpf⟩
   exact ⟨⟨by omega, hnx⟩, gpfSquare_in_bad n hn2 hgpf⟩
+
+/- ## Very bad intervals and powerful numbers
+
+Erdős and Graham also asked about "very bad" intervals `[u,v]` where
+`∏{u ≤ m ≤ v} m` is powerful (every prime factor has exponent ≥ 2).
+They conjectured that the count of `n ≤ x` in some very bad interval
+is asymptotic to the count of powerful numbers `≤ x`, which is `∼ c√x`. -/
+
+/-- A positive integer `n > 1` is powerful if every prime factor appears
+    with exponent at least 2: `∀ p prime, p ∣ n → p² ∣ n`. -/
+def IsPowerful (n : ℕ) : Prop :=
+  1 < n ∧ ∀ p : ℕ, p.Prime → p ∣ n → p ^ 2 ∣ n
+
+/-- An interval `[u, v]` is "very bad" if the product `∏{u ≤ m ≤ v} m`
+    is powerful. Stronger than bad: all prime exponents ≥ 2, not just the
+    largest. -/
+def IsVeryBadInterval (u v : ℕ) : Prop :=
+  u ≤ v ∧ IsPowerful ((Finset.Icc u v).prod id)
+
+/-- An integer `n` is in a very bad interval if `∃ u ≤ n ≤ v` with
+    `[u, v]` very bad. -/
+def InVeryBadInterval (n : ℕ) : Prop :=
+  ∃ (u v : ℕ), u ≤ n ∧ n ≤ v ∧ IsVeryBadInterval u v
+
+/-- Count of integers `n ≤ x` in some very bad interval. -/
+noncomputable def veryBadCount (x : ℕ) : ℕ :=
+  ((Finset.Icc 1 x).filter InVeryBadInterval).card
+
+/-- Count of powerful numbers in `[2, x]`. -/
+noncomputable def powerfulCount (x : ℕ) : ℕ :=
+  ((Finset.Icc 2 x).filter IsPowerful).card
+
+/-- Every very bad interval is bad: if the product is powerful then
+    `P² | product` where `P` is the greatest prime factor. -/
+theorem veryBad_is_bad (u v : ℕ) (h : IsVeryBadInterval u v) :
+    IsBadInterval u v := by
+  obtain ⟨huv, hpow⟩ := h
+  have hlt := hpow.1
+  have h2 : 2 ≤ (Finset.Icc u v).prod id := by omega
+  constructor
+  · exact huv
+  · exact hpow.2 _ (gpf_prime _ h2) (gpf_dvd _ h2)
+
+/-- Very bad intervals contain no primes (corollary). -/
+theorem veryBad_interval_no_prime (u v : ℕ) (hvb : IsVeryBadInterval u v) :
+    ∀ p : ℕ, p.Prime → u ≤ p → p ≤ v → False :=
+  bad_interval_no_prime_general u v (veryBad_is_bad u v hvb)
+
+/-- A singleton `[n, n]` is very bad iff `n` is powerful (for `n ≥ 2`). -/
+theorem singleton_veryBad_iff (n : ℕ) (hn : 2 ≤ n) :
+    IsVeryBadInterval n n ↔ IsPowerful n := by
+  constructor
+  · intro ⟨_, hpow⟩
+    simp only [Finset.Icc_self, Finset.prod_singleton, id] at hpow
+    exact hpow
+  · intro h
+    exact ⟨le_refl n, by simp only [Finset.Icc_self, Finset.prod_singleton, id]; exact h⟩
+
+/-- Every powerful `n ≥ 2` is in the very bad interval `[n, n]`. -/
+theorem powerful_in_veryBad (n : ℕ) (hn : 2 ≤ n) (h : IsPowerful n) :
+    InVeryBadInterval n :=
+  ⟨n, n, le_refl n, le_refl n, (singleton_veryBad_iff n hn).mpr h⟩
+
+/-- `veryBadCount(x) ≤ badCount(x)`: every very bad interval is bad. -/
+theorem veryBadCount_le_badCount (x : ℕ) : veryBadCount x ≤ badCount x := by
+  unfold veryBadCount badCount
+  apply Finset.card_le_card
+  intro n
+  simp only [Finset.mem_filter, Finset.mem_Icc]
+  rintro ⟨hn, hvb⟩
+  refine ⟨hn, ?_⟩
+  obtain ⟨u, v, hu, hv, hvb⟩ := hvb
+  exact ⟨u, v, hu, hv, veryBad_is_bad u v hvb⟩
+
+/-- `powerfulCount(x) ≤ veryBadCount(x)`: every powerful number is in
+    the singleton very bad interval. -/
+theorem veryBadCount_ge_powerfulCount (x : ℕ) :
+    powerfulCount x ≤ veryBadCount x := by
+  unfold veryBadCount powerfulCount
+  apply Finset.card_le_card
+  intro n
+  simp only [Finset.mem_filter, Finset.mem_Icc]
+  rintro ⟨⟨hn2, hnx⟩, hpow⟩
+  exact ⟨⟨by omega, hnx⟩, powerful_in_veryBad n hn2 hpow⟩
+
+/-- Full chain of counting inequalities:
+    `powerfulCount ≤ veryBadCount ≤ badCount` and `gpfSquareCount ≤ badCount`. -/
+theorem counting_chain (x : ℕ) :
+    powerfulCount x ≤ veryBadCount x ∧
+    veryBadCount x ≤ badCount x ∧
+    gpfSquareCount x ≤ badCount x :=
+  ⟨veryBadCount_ge_powerfulCount x, veryBadCount_le_badCount x, badCount_ge_gpfSquareCount x⟩
+
+/-- Secondary conjecture: `veryBadCount(x) ∼ powerfulCount(x)`.
+    The very bad count should be asymptotic to the powerful number count. -/
+def VeryBadConjecture : Prop :=
+  ∀ (ε : ℚ), 0 < ε →
+    ∃ x₀ : ℕ, ∀ x : ℕ, x₀ ≤ x →
+      0 < powerfulCount x ∧
+        |(veryBadCount x : ℚ) / (powerfulCount x : ℚ) - 1| < ε

--- a/proofs/Proofs/FourierSeriesOQ02OQ03OQ02Aristotle.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ03OQ02Aristotle.lean
@@ -1,0 +1,114 @@
+/-
+  Aristotle targets for Fourier Series OQ-02-OQ-03-OQ-02
+  (Sharp Constants for Analytic Fourier Coefficient Decay)
+
+  Routine supporting lemmas for automated proof search.
+  See FourierSeriesOQ02OQ03OQ02.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main axioms (contour shifting, rate sharpness, Paley-Wiener)
+  - Known results: geometric summability, comparison tests, supremum bounds
+  - Clean theorem statements with no definition sorries
+  - No axiom declarations
+
+  Target sorries:
+  1. exp_decay_summable — geometric series over ℤ
+  2. exp_decay_abs_convergence — comparison test
+  3. sharpConstant_is_bound — from iSup definition
+  4. sharpConstant_optimal — ciSup_le
+  5. exp_dominates_polynomial — exponential beats polynomial
+  6. analytic_hierarchy — corollary of exp dominance
+-/
+
+import Mathlib.Analysis.Fourier.AddCircle
+import Mathlib.Analysis.Fourier.FourierTransform
+import Mathlib.MeasureTheory.Function.L2Space
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Tactic
+
+noncomputable section
+
+namespace FourierAnalyticDecayAristotle
+
+open MeasureTheory Complex AddCircle Filter
+open scoped ENNReal NNReal Real
+
+variable {T : ℝ} [hT : Fact (0 < T)]
+
+-- Definitions reproduced from FourierSeriesOQ02OQ03OQ02.lean
+
+def IsStripAnalytic (δ : ℝ) (f : AddCircle T → ℂ) : Prop :=
+  0 < δ ∧ Integrable f ∧
+  ∃ (M : ℝ), 0 < M ∧ ∀ n : ℤ, n ≠ 0 →
+    ‖fourierCoeff f n‖ ≤ M * Real.exp (-(2 * Real.pi * δ * |↑n|) / T)
+
+def sharpConstant (δ : ℝ) (f : AddCircle T → ℂ) : ℝ :=
+  ⨆ (n : ℤ) (_ : n ≠ 0),
+    ‖fourierCoeff f n‖ * Real.exp (2 * Real.pi * δ * |↑n| / T)
+
+-- ============================================================================
+-- Target 1: Geometric series summability over ℤ
+-- Hint: e^{-c|n|} = r^|n| where r = e^{-c} ∈ (0,1), sum via geometric series
+-- ============================================================================
+
+theorem exp_decay_summable (δ : ℝ) (hδ : 0 < δ) :
+    Summable (fun n : ℤ => Real.exp (-(2 * Real.pi * δ * |↑n|) / T)) := by
+  sorry
+
+-- ============================================================================
+-- Target 2: Absolute convergence from comparison
+-- Hint: |ĉ_n| ≤ M * e^{-c|n|}, summable by comparison with Target 1
+-- ============================================================================
+
+theorem exp_decay_abs_convergence (f : AddCircle T → ℂ) (δ : ℝ) (hδ : 0 < δ)
+    (M : ℝ) (hM : 0 < M)
+    (hdecay : ∀ n : ℤ, n ≠ 0 →
+      ‖fourierCoeff f n‖ ≤ M * Real.exp (-(2 * Real.pi * δ * |↑n|) / T)) :
+    Summable (fun n : ℤ => ‖fourierCoeff f n‖) := by
+  sorry
+
+-- ============================================================================
+-- Target 3: Sharp constant is a valid bound
+-- Hint: ‖ĉ_n‖ * exp(c|n|) ≤ ⨆ ... by le_ciSup, then multiply by exp(-c|n|)
+-- ============================================================================
+
+theorem sharpConstant_is_bound (δ : ℝ) (hδ : 0 < δ) (f : AddCircle T → ℂ)
+    (hf : IsStripAnalytic δ f) (n : ℤ) (hn : n ≠ 0) :
+    ‖fourierCoeff f n‖ ≤ sharpConstant δ f *
+      Real.exp (-(2 * Real.pi * δ * |↑n|) / T) := by
+  sorry
+
+-- ============================================================================
+-- Target 4: Sharp constant is optimal (smallest valid bound)
+-- Hint: ciSup_le — each ‖ĉ_n‖ * exp(c|n|) ≤ K since ‖ĉ_n‖ ≤ K * exp(-c|n|)
+-- ============================================================================
+
+theorem sharpConstant_optimal (δ : ℝ) (hδ : 0 < δ) (f : AddCircle T → ℂ)
+    (hf : IsStripAnalytic δ f) (K : ℝ) (hK : 0 < K)
+    (hbound : ∀ n : ℤ, n ≠ 0 →
+      ‖fourierCoeff f n‖ ≤ K * Real.exp (-(2 * Real.pi * δ * |↑n|) / T)) :
+    sharpConstant δ f ≤ K := by
+  sorry
+
+-- ============================================================================
+-- Target 5: Exponential dominates polynomial
+-- Hint: Real.tendsto_pow_mul_exp_neg_atTop_nhds or direct estimation
+-- ============================================================================
+
+theorem exp_dominates_polynomial (c M : ℝ) (hc : 0 < c) (hM : 0 < M)
+    (C : ℝ) (hC : 0 < C) (α : ℝ) (hα : 0 < α) :
+    ∀ᶠ n in Filter.cofinite,
+      M * Real.exp (-c * |↑n|) ≤ C * |↑n|⁻¹ ^ α := by
+  sorry
+
+-- ============================================================================
+-- Target 6: Analytic implies polynomial-weight summability
+-- Hint: exp decay beats any polynomial weight (corollary of Target 5)
+-- ============================================================================
+
+theorem analytic_hierarchy (f : AddCircle T → ℂ) (δ : ℝ) (hδ : 0 < δ)
+    (hf : IsStripAnalytic δ f) :
+    ∀ α : ℝ, 0 < α → Summable (fun n : ℤ => ‖fourierCoeff f n‖ * |↑n| ^ α) := by
+  sorry
+
+end FourierAnalyticDecayAristotle

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01.json
@@ -17,9 +17,9 @@
   },
   "currentState": {
     "phase": "ORIENT",
-    "since": "2026-03-28T20:58:08-07:00",
-    "iteration": 1,
-    "focus": "Surveyed multiplicativity proof path. Found potential axiom bug at n=-1,a=0.",
+    "since": "2026-03-29T06:30:00+00:00",
+    "iteration": 2,
+    "focus": "Session 2: Fixed 2 false axioms with counterexamples",
     "blockers": [],
     "nextAction": "Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.",
     "attemptCounts": {
@@ -29,20 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: Kronecker multiplicativity requires case analysis on n=0,-1,1,general. Definition uses jacobiSym (multiplicative in Mathlib). Potential edge case bug: kroneckerNeg1(0)=1 may break mul_left at n=-1 when a=0.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: FIXED 2 incorrect axioms. kronecker_mul_left and kronecker_mul_right were FALSE as stated — found counterexamples involving kroneckerNeg1(0)=1 + zero multiplication. Added nonzero hypotheses (ha/hb and hm/hn). 3 axioms remain (corrected).",
+    "builtItems": [
+      "FIXED: kronecker_mul_left — added (ha : a ≠ 0) (hb : b ≠ 0)",
+      "FIXED: kronecker_mul_right — added (hm : m ≠ 0) (hn : n ≠ 0)"
+    ],
     "insights": [
       "kronecker defined via cases: n=0→kronecker0, n=-1→kroneckerNeg1, n=1→1, else→sign*jacobiSym",
       "jacobiSym from Mathlib is multiplicative in both arguments — base case for proof",
       "kroneckerNeg1(0)=1 (positive convention) may cause mul_left failure: kronecker(-3*0)(-1)=1 but kronecker(-3)(-1)*kronecker(0)(-1)=(-1)*1=-1",
       "Fix: either change kroneckerNeg1(0)=0 or add a≠0 hypothesis to mul_left",
-      "mul_right is more straightforward: products of moduli reduce to product of Jacobi symbols"
+      "mul_right is more straightforward: products of moduli reduce to product of Jacobi symbols",
+      "COUNTEREXAMPLE: kronecker_mul_left fails at a=-3, b=0, n=-1: LHS=1, RHS=-1",
+      "COUNTEREXAMPLE: kronecker_mul_right fails at a=-1, m=0, n=-1: LHS=1, RHS=-1",
+      "Root cause: kroneckerNeg1(0)=1 but zero-arg product maps through kronecker0 instead of kroneckerNeg1"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Verify kronecker_mul_left counterexample: kronecker (-3*0) (-1) vs kronecker (-3) (-1) * kronecker 0 (-1)",
-      "If confirmed false, fix kroneckerNeg1 definition or add hypotheses to axiom",
-      "Prove kronecker_mul_right via case analysis: n*m=0, n*m=-1, general → jacobiSym.mul_right"
+      "Prove corrected kronecker_mul_right via case analysis on sign(m)*sign(n) + jacobiSym.mul_right",
+      "Prove corrected kronecker_mul_left via case analysis on n=0,-1,1,general + jacobiSym.mul_left",
+      "kronecker_reciprocity remains axiomatized (deep: requires Gauss sum argument)"
     ],
     "markdown": "# Knowledge Base: elementary-quadratic-reciprocity-oq-03-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/erdos-380.json
+++ b/src/data/research/problems/erdos-380.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-13T00:59:36.242Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Axiom elimination via Mathlib definitions",
     "blockers": [],
     "nextAction": "Verify build, consider proving bad_interval_no_prime",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 3 structural theorems linking singleton bad intervals to gpfSquare count. Proved B(x) ≥ #{P(n)²|n}, supporting the conjecture B(x) ~ #{P(n)²|n}.",
+    "progressSummary": "PROGRESS: Formalized very bad intervals and powerful numbers from original problem statement. Added 5 definitions, 7 proved theorems, 1 conjecture definition. Full counting chain: powerfulCount ≤ veryBadCount ≤ badCount ≥ gpfSquareCount. File now covers both conjectures from Erdős #380 with 0 sorries, 2 deep axioms.",
     "builtItems": [
       "Proved gpf_prime (theorem, 4 lines)",
       "Proved gpf_dvd (theorem, 4 lines)",
@@ -39,7 +39,17 @@
       "bad_interval_v_bound: structural bound v<2u for bad intervals",
       "singleton_bad_iff: [n,n] bad ↔ P(n)²|n for n≥2",
       "gpfSquare_in_bad: P(n)²|n → InBadInterval n",
-      "badCount_ge_gpfSquareCount: B(x) ≥ #{n≤x: P(n)²|n}"
+      "badCount_ge_gpfSquareCount: B(x) ≥ #{n≤x: P(n)²|n}",
+      "IsPowerful, IsVeryBadInterval, InVeryBadInterval (definitions)",
+      "veryBadCount, powerfulCount (counting functions)",
+      "veryBad_is_bad: very bad → bad (proved)",
+      "veryBad_interval_no_prime: corollary of bad_interval_no_prime_general (proved)",
+      "singleton_veryBad_iff: [n,n] very bad ↔ n powerful (proved)",
+      "powerful_in_veryBad: powerful n → InVeryBadInterval (proved)",
+      "veryBadCount_le_badCount: inequality (proved)",
+      "veryBadCount_ge_powerfulCount: inequality (proved)",
+      "counting_chain: summary of all counting inequalities (proved)",
+      "VeryBadConjecture: secondary conjecture statement"
     ],
     "insights": [
       "greatestPrimeFactor defined via Nat.primeFactors.max, eliminating 4 axioms",
@@ -52,7 +62,11 @@
       "Key insight: by Bertrand, largest prime ≤ v is > v/2, so GPF has unique multiple in [u,v], giving v_P(product)=1, contradiction with bad",
       "Singleton [n,n] bad iff P(n)²|n — directly links IsBadInterval to gpfSquareCount",
       "B(x) ≥ #{n≤x: P(n)²|n} via singleton bad intervals — lower bound on the conjecture ratio",
-      "Both axioms (erdos_graham_lower, gpfSquare_asymptotic) are deep analytic results — not eliminable"
+      "Both axioms (erdos_graham_lower, gpfSquare_asymptotic) are deep analytic results — not eliminable",
+      "IsPowerful n: 1 < n ∧ ∀ p prime, p|n → p²|n — standard definition for powerful/squareful numbers",
+      "veryBad → bad: powerful product implies P²|product for GPF, so every very bad interval is bad",
+      "Singleton [n,n] is very bad ↔ n is powerful — parallels singleton_bad_iff for bad intervals",
+      "Full counting chain: powerfulCount ≤ veryBadCount ≤ badCount ≥ gpfSquareCount"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -72,17 +86,17 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:59:36.242Z",
-  "lastUpdate": "2026-03-13T07:52:17.047Z",
+  "lastUpdate": "2026-03-29T07:10:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos380Problem.lean",
       "filename": "Erdos380Problem.lean",
-      "lineCount": 289,
-      "theoremCount": 9,
+      "lineCount": 402,
+      "theoremCount": 16,
       "axiomCount": 2,
-      "defCount": 6,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos380Problem.lean"

--- a/src/data/research/problems/fourier-series-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02-oq-03-oq-02.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-28T20:58:08-07:00",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
     "nextAction": "Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.",
@@ -29,12 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Formalized exponential Fourier decay for strip-analytic functions. 3 axioms (contour shift, rate sharpness, Paley-Wiener converse), structural properties, comparison with Holder decay, Poisson kernel example.",
+    "progressSummary": "PROGRESS: Created Aristotle companion file for 6 theorem sorries. 3 axioms are deep (contour shift, rate sharpness, Paley-Wiener). Main file has 10 proved theorems.",
     "builtItems": [
       "Created FourierSeriesOQ02OQ03OQ02.lean: 3 axioms, 10 theorems, 4 definitions, 5 sorries",
       "Defined IsStripAnalytic, stripNorm, sharpConstant, poissonKernelStripWidth",
       "Proved structural: exp_decay_pos, exp_decay_le_one, wider_strip_faster_decay, poissonKernel_strip_positive",
-      "Created gallery entry src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json"
+      "Created gallery entry src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json",
+      "Created FourierSeriesOQ02OQ03OQ02Aristotle.lean companion file with 6 theorem sorries for automated proof search"
     ],
     "insights": [
       "Contour shifting is the key technique: shift integration to Im z = delta-epsilon, periodicity cancels vertical edges",
@@ -42,7 +43,10 @@
       "Paley-Wiener converse: exponential Fourier decay completely characterizes strip analyticity",
       "The sharp constant K(f) = sup_n |c_n|*exp(2*pi*delta*|n|/T) equals the strip boundary norm for natural boundaries",
       "Strip width delta plays the same role as Holder exponent alpha but gives exponentially faster decay",
-      "The Poisson kernel P_r(x) with r in (0,1) has exact exponential decay with strip width -T*ln(r)/(2*pi)"
+      "The Poisson kernel P_r(x) with r in (0,1) has exact exponential decay with strip width -T*ln(r)/(2*pi)",
+      "exp_decay_summable: needs ℤ-indexed geometric series decomposition (split into n≥0 and n<0)",
+      "sharpConstant proofs: require ciSup_le / le_ciSup from ConditionallyCompleteLattice API",
+      "exp_dominates_polynomial: Real.tendsto_pow_mul_exp_neg_atTop_nhds in Mathlib may help"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -62,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-03-29T04:28:18.977Z",
-  "lastUpdate": "2026-03-29T04:28:18.987Z",
+  "lastUpdate": "2026-03-29T07:20:00Z",
   "leanFiles": [
     {
       "path": "Proofs/FourierSeries.lean",


### PR DESCRIPTION
## Summary
Two research items from researcher-7.

### 1. erdos-380: Very bad intervals and powerful numbers
- Formalized the secondary conjecture from Erdős–Graham about "very bad" intervals
- 5 new definitions: `IsPowerful`, `IsVeryBadInterval`, `InVeryBadInterval`, `veryBadCount`, `powerfulCount`
- 7 new theorems proved (0 sorries):
  - `veryBad_is_bad`, `veryBad_interval_no_prime`, `singleton_veryBad_iff`
  - `powerful_in_veryBad`, `veryBadCount_le_badCount`, `veryBadCount_ge_powerfulCount`
  - `counting_chain`: full chain powerfulCount ≤ veryBadCount ≤ badCount
- Stated `VeryBadConjecture`

### 2. fourier-series-oq-02-oq-03-oq-02: Aristotle companion
- Created companion file with 6 theorem sorries for automated proof search
- Targets: geometric summability, comparison test, iSup bounds, exp vs polynomial
- 3 axioms in main file are deep analysis results (not for Aristotle)

## Status
- erdos-380: 0 sorries, 2 axioms (both deep, correctly axiomatized)
- fourier-series companion: 6 sorries for Aristotle

🤖 Generated by researcher-7

### 3. erdos-411: Prove doubling for n=10 and n=94 (2 axioms eliminated)
- Proved `doubling_r2_n10` and `doubling_r2_n94` via orbit analysis
- Key: totient multiplicativity gives closed-form orbit (5·2^m ↔ 7·2^m for n=10)
- Axiom count reduced from 6 to 4
- 0 sorries added


### 4. chinese-remainder-oq-04-oq-03: Fix inconsistent primorial axiom
- `primorial_growth_lower` axiom was inconsistent: `primorial` returns 0 for k≥7 but axiom claimed `primorial k ≥ 2^k` for all k≥1
- Fixed: now a proved theorem restricted to k ≤ 6 (valid range of definition)
- 1 axiom eliminated (bug fix)
