### PR TITLE
fix(metadata): audit iteration 5 — 4 sorry/axiom mismatches

### DIFF
--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -17,13 +17,13 @@
       "set-families"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1022,
     "erdosUrl": "https://erdosproblems.com/1022",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 3,
-    "lineCount": 321,
+    "axiomCount": 2,
+    "lineCount": 327,
     "assumptions": "3 axioms: erdos_1022_conjecture (open conjecture), lovasz_theorem (c(2)=1, Lovász 1968), erdos_first_moment_bound (|F| < 2^{t-1} implies Property B, Erdős 1963). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -244,11 +244,18 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib.Data.Finset.Basic", "Mathlib.Data.Finset.Powerset", "Mathlib.Data.Fintype.Basic", "Mathlib.Tactic"],
-    "opens": ["Finset"],
+    "imports": [
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Data.Fintype.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "Erdos1022",
-    "lineCount": 321,
-    "axiomCount": 3,
+    "lineCount": 327,
+    "axiomCount": 2,
     "theoremCount": 22,
     "definitionCount": 5
   }

--- a/src/data/proofs/erdos-218/meta.json
+++ b/src/data/proofs/erdos-218/meta.json
@@ -17,11 +17,11 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 218,
     "erdosUrl": "https://erdosproblems.com/218",
     "erdosProblemStatus": "open",
-    "axiomCount": 7,
+    "axiomCount": 5,
     "prerequisites": [
       "Prime numbers and basic properties of Nat.Prime",
       "Prime Number Theorem (average gap growth)",
@@ -30,7 +30,7 @@
       "Green-Tao theorem (arbitrarily long APs in primes)",
       "Cramér probabilistic model for primes"
     ],
-    "lineCount": 385,
+    "lineCount": 411,
     "assumptions": "8 axioms: 3 open conjectures (erdos_218a/b/c), hasDensity_iff_upper_lower (analysis), green_tao (deep), gapIncreasingSet_infinite, gapDecreasingSet_infinite, average_gap_growth. Previously 22 axioms; 14 eliminated via Mathlib nthPrime/nth_count definitions.",
     "mathlib_version": "4.26.0"
   },
@@ -171,8 +171,8 @@
       "Filter"
     ],
     "namespace": "Erdos218",
-    "lineCount": 385,
-    "axiomCount": 22,
+    "lineCount": 411,
+    "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 12
   },

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -16,7 +16,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 4,
     "erdosNumber": 831,
     "erdosUrl": "https://erdosproblems.com/831",
     "erdosProblemStatus": "open",
@@ -55,7 +55,7 @@
       "erdos_831_summary theorem: known bounds"
     ],
     "axiomCount": 1,
-    "lineCount": 398,
+    "lineCount": 436,
     "assumptions": "1 axiom: h_four_lower (h(4)≥2, used in summary theorem). All other axioms eliminated as unused."
   },
   "overview": {
@@ -185,7 +185,7 @@
       "Finset"
     ],
     "namespace": "Erdos831",
-    "lineCount": 398,
+    "lineCount": 436,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 10

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -17,9 +17,9 @@
       "roth-number"
     ],
     "badge": "formalized",
-    "sorries": 6,
+    "sorries": 5,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 6 sorries: density_upper_bound_from_iteration (well-founded induction), roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound, crude_sqrt_bound.",
+    "assumptions": "0 axioms. 5 sorries: density_upper_bound_from_iteration, roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound. crude_sqrt_bound now proved.",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -50,7 +50,7 @@
       "Proof of max_iterations_bound: density increment iteration count ≤ ⌊100/δ²⌋",
       "Formal statements of 5 quantitative bounds: Roth, Behrend, Bloom-Sisask, Kelley-Meka, crude √N"
     ],
-    "lineCount": 196,
+    "lineCount": 242,
     "theoremCount": 12,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
@@ -136,10 +136,14 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Finset"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "Szemeredi.Roth.Quantitative",
-    "lineCount": 196,
+    "lineCount": 242,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2


### PR DESCRIPTION
## Summary

- **roth-theorem-k3-oq-01**: sorries 6→5 (`crude_sqrt_bound` proved), lineCount 196→242
- **erdos-1022**: sorries 0→1, axiomCount 3→2, lineCount 321→327
- **erdos-218**: sorries 0→1, axiomCount 7→5, lineCount 385→411
- **erdos-831**: sorries 2→4, lineCount 398→436

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Discovered during gallery integrity audit.