### PR TITLE
fix: remove broken .lean/state symlink from git (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ dist-ssr
 .lean/research/problems.json
 .lean/research/problems/
 .lean/research/registry.json
+.lean/state
 .lean/state/
 leanInk/
 

--- a/.lean/state
+++ b/.lean/state
@@ -1,1 +1,0 @@
-/Users/rwalters/GitHub/lean-genius/.lean/state


### PR DESCRIPTION
## Summary
- Removes the self-referencing `.lean/state` symlink that was re-introduced by a researcher merge after the previous fix (#7778)
- Updates `.gitignore` to block both files and directories matching `.lean/state` (the previous pattern `.lean/state/` only matched directories, not symlinks)

## Context
The broken symlink causes `pnpm build` to fail with `candidate-pool.json not found`, blocking all deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)