### PR TITLE
fix(metadata): audit triangular-reciprocals — axiom count 1→2

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "1 transitive axiom: alternating_harmonic_hasSum (imported from parent OQ03, boundary convergence of Mercator series requires Abel's theorem). 0 sorries — all 3 previously sorry'd theorems now fully proved.",
+    "axiomCount": 2,
+    "assumptions": "2 transitive axioms from parent OQ03: alternating_harmonic_hasSum (Mercator series, requires Abel's theorem), shifted_alternating_hasSum (shifted alternating harmonic series). 0 direct axioms, 0 sorries — all theorems fully proved modulo parent axioms.",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -133,7 +133,7 @@
     ],
     "namespace": "AlternatingTriangularReciprocals.Generalized",
     "lineCount": 196,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 1
   }


### PR DESCRIPTION
## Summary

Gallery integrity audit of `triangular-reciprocals-oq-03-oq-02`:

- **Transitive axiom count 1→2**: Parent file has 2 axioms (`alternating_harmonic_hasSum` and `shifted_alternating_hasSum`), both used transitively, but meta.json only counted 1
- **leanFile.axiomCount**: Fixed to 0 (direct axioms in this file)

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)