### PR TITLE
fix(audit): complete batch audit of 12 proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9709,6 +9709,78 @@
       "lastAudited": "2026-03-29T05:54:13Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "angle-trisection-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T07:56:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T07:58:39Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "brouwer-fixed-point-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T07:59:42Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-by-3-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:00:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:01:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "friendship-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:02:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "greens-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:02:39Z",
+      "result": "clean",
+      "issues": []
+    },
+    "platonic-solids-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:03:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "roth-theorem-k3-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:03:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stirling-formula-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:04:57Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "triangular-reciprocals-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:05:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "vietas-formulas-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T08:06:13Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {


### PR DESCRIPTION
## Summary

- Audited all 12 previously unaudited proofs, bringing gallery to 1628/1628 (100%)
- Found 2 issues (both LOW-MEDIUM severity, neither critical):
  - #7801: `basel-problem-oq-05` has a True stub in `euler_coefficient_comparison`
  - #7802: `stirling-formula-oq-01` assumptions text says "3 sorries" but actual count is 2
- 10 proofs audited clean with no issues

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 unaudited
- [x] All audit results recorded in `audit-tracker.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)