### PR TITLE
Research: erdos-831 — eliminate all theorem sorries (4→0)

### DIFF
--- a/proofs/Proofs/Erdos831Problem.lean
+++ b/proofs/Proofs/Erdos831Problem.lean
@@ -186,16 +186,17 @@ noncomputable def h (n : ℕ) : ℕ :=
 With n points, there are C(n,3) triples, hence at most C(n,3) distinct radii.
 -/
 theorem h_upper_bound (n : ℕ) : h n ≤ Nat.choose n 3 := by
-  -- Proof strategy (now feasible with Finset-based countDistinctRadii):
-  -- 1. If {k | ∃ S, ...} = ∅, then sInf = 0 ≤ C(n,3)  ✓
-  -- 2. If non-empty, any k in the set has k = (allCircumradiiFinset S).card
-  --    Since allCircumradiiFinset is an image of ordered triples, and
-  --    circumradiusOf is permutation-invariant, the image has at most
-  --    C(n,3) elements (one per unordered triple).
-  -- 3. So sInf ≤ k ≤ C(n,3)
-  -- REQUIRES: circumradiusOf permutation invariance (swapping arguments
-  -- preserves side length product and absolute area)
-  sorry
+  -- sInf {k | ...} ≤ C(n,3): empty set gives 0 ≤ C(n,3), otherwise
+  -- any member k = countDistinctRadii S ≤ C(|S|,3) = C(n,3)
+  by_cases hne : Set.Nonempty {k : ℕ | ∃ S : Finset Point, S.card = n ∧
+      isInGeneralPosition (↑S : Set Point) ∧ countDistinctRadii S = k}
+  · obtain ⟨k, S, hcard, hGP, hcount⟩ := hne
+    calc h n ≤ k := Nat.sInf_le ⟨S, hcard, hGP, hcount⟩
+      _ ≤ Nat.choose n 3 := by
+          rw [hcount, ← hcard]; exact countDistinctRadii_le_choose S
+  · rw [Set.not_nonempty_iff_eq_empty] at hne
+    have h0 : h n = 0 := by unfold h; rw [hne]; exact Nat.sInf_eq_zero.mpr (Or.inr rfl)
+    omega
 
 /--
 **h(3) = 1:**
@@ -570,6 +571,97 @@ private theorem standard_triangle_gp :
     | exact absurd rfl (Ne.symm hd12) | exact absurd rfl (Ne.symm hd13)
     | exact absurd rfl (Ne.symm hd14) | exact absurd rfl (Ne.symm hd23)
     | exact absurd rfl (Ne.symm hd24) | exact absurd rfl (Ne.symm hd34)
+
+/-- circumradiusOf is invariant under all S₃ permutations of elements from a 3-element set.
+    If q1, q2, q3 are pairwise distinct members of {p1, p2, p3}, then
+    circumradiusOf q1 q2 q3 = circumradiusOf p1 p2 p3. -/
+private theorem circumradiusOf_eq_of_mem_triple
+    {p1 p2 p3 q1 q2 q3 : Point}
+    (hq1 : q1 ∈ ({p1, p2, p3} : Finset Point))
+    (hq2 : q2 ∈ ({p1, p2, p3} : Finset Point))
+    (hq3 : q3 ∈ ({p1, p2, p3} : Finset Point))
+    (dq12 : q1 ≠ q2) (dq23 : q2 ≠ q3) (dq13 : q1 ≠ q3) :
+    circumradiusOf q1 q2 q3 = circumradiusOf p1 p2 p3 := by
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hq1 hq2 hq3
+  rcases hq1 with rfl | rfl | rfl <;> rcases hq2 with rfl | rfl | rfl <;>
+    rcases hq3 with rfl | rfl | rfl <;>
+  first
+  | exact absurd rfl dq12 | exact absurd rfl dq23 | exact absurd rfl dq13
+  | exact absurd rfl (Ne.symm dq12) | exact absurd rfl (Ne.symm dq23)
+  | exact absurd rfl (Ne.symm dq13)
+  | rfl
+  | rw [circumradiusOf_perm12]
+  | rw [circumradiusOf_perm23]
+  | rw [circumradiusOf_perm13]
+  | rw [circumradiusOf_cycle]
+  | rw [circumradiusOf_cycle, circumradiusOf_cycle]
+
+/-- Circumradius of a triple, extracted via Multiset.toList.
+    Well-defined by circumradiusOf S₃ invariance. -/
+private noncomputable def tripleCircumradius (T : Finset Point) : ℝ :=
+  let l := T.val.toList
+  if h : l.length ≥ 3 then
+    circumradiusOf (l.get ⟨0, by omega⟩) (l.get ⟨1, by omega⟩) (l.get ⟨2, by omega⟩)
+  else 0
+
+/-- allCircumradiiFinset S is contained in the image of S.powersetCard 3
+    under tripleCircumradius. This is because each ordered triple (p,q,s) maps
+    to circumradiusOf p q s, and {p,q,s} ∈ powersetCard 3 maps to the same
+    value by S₃ invariance of circumradiusOf. -/
+private theorem allCircumradiiFinset_subset_powersetCard (S : Finset Point) :
+    allCircumradiiFinset S ⊆ (S.powersetCard 3).image tripleCircumradius := by
+  intro r hr
+  simp only [allCircumradiiFinset, Finset.mem_image, Finset.mem_filter,
+             Finset.mem_product] at hr
+  obtain ⟨⟨p, q, s⟩, ⟨⟨hp, hq, hs⟩, dpq, dqs, dps⟩, heq⟩ := hr
+  rw [Finset.mem_image]
+  refine ⟨{p, q, s}, ?mem, ?val⟩
+  case mem =>
+    rw [Finset.mem_powersetCard]
+    constructor
+    · exact Finset.insert_subset_iff.mpr ⟨hp,
+        Finset.insert_subset_iff.mpr ⟨hq, Finset.singleton_subset_iff.mpr hs⟩⟩
+    · rw [Finset.card_insert_of_not_mem, Finset.card_insert_of_not_mem,
+          Finset.card_singleton]
+      · exact Finset.not_mem_singleton.mpr dqs
+      · simp [Finset.mem_insert, Finset.mem_singleton, dpq, dps]
+  case val =>
+    rw [← heq]
+    simp only [tripleCircumradius]
+    -- l = ({p,q,s}).val.toList has length 3 (since card = 3)
+    set T : Finset Point := {p, q, s}
+    set l := T.val.toList
+    have hcard : T.card = 3 := by
+      rw [Finset.card_insert_of_not_mem, Finset.card_insert_of_not_mem,
+          Finset.card_singleton]
+      · exact Finset.not_mem_singleton.mpr dqs
+      · simp [Finset.mem_insert, Finset.mem_singleton, dpq, dps]
+    have hlen : l.length = 3 := by
+      rw [show l.length = T.val.card from (Multiset.length_toList T.val).symm]
+      exact hcard
+    simp only [dif_pos (show l.length ≥ 3 by omega)]
+    -- l's elements are in T = {p,q,s} and are pairwise distinct (T is nodup)
+    have h_mem : ∀ i : Fin l.length, l.get i ∈ T := by
+      intro i
+      exact Finset.mem_def.mpr (Multiset.mem_toList.mp (List.get_mem l i.val i.isLt))
+    have h_nodup : l.Nodup := by
+      rw [show l = T.val.toList from rfl, ← Multiset.coe_nodup, Multiset.coe_toList]
+      exact T.nodup
+    -- Apply S₃ invariance
+    exact circumradiusOf_eq_of_mem_triple
+      (h_mem ⟨0, by omega⟩) (h_mem ⟨1, by omega⟩) (h_mem ⟨2, by omega⟩)
+      (by intro h; exact absurd ((List.Nodup.get_inj_iff h_nodup).mp h) (by omega))
+      (by intro h; exact absurd ((List.Nodup.get_inj_iff h_nodup).mp h) (by omega))
+      (by intro h; exact absurd ((List.Nodup.get_inj_iff h_nodup).mp h) (by omega))
+
+/-- The number of distinct circumradii of S is at most C(|S|, 3). -/
+private theorem countDistinctRadii_le_choose (S : Finset Point) :
+    countDistinctRadii S ≤ Nat.choose S.card 3 := by
+  calc (allCircumradiiFinset S).card
+      ≤ ((S.powersetCard 3).image tripleCircumradius).card :=
+        Finset.card_le_card (allCircumradiiFinset_subset_powersetCard S)
+    _ ≤ (S.powersetCard 3).card := Finset.card_image_le
+    _ = Nat.choose S.card 3 := S.card_powersetCard 3
 
 end PointHelpers
 

--- a/proofs/Proofs/Erdos831Problem.lean
+++ b/proofs/Proofs/Erdos831Problem.lean
@@ -340,18 +340,55 @@ theorem circumradiusOf_eq_circumradius (t : PointTriple) :
     circumradiusOf t.p1 t.p2 t.p3 = circumradius t := rfl
 
 /-- circumradiusOf is invariant under swapping the first two arguments.
-    Proof: side lengths {‖p2-p3‖, ‖p1-p3‖, ‖p1-p2‖} are permuted but
-    the product abc is unchanged (commutativity of multiplication), and
-    |det(p2-p1, p3-p1)| = |det(p1-p2, p3-p2)| (signed area changes sign). -/
+    Proof: side lengths are permuted but the product abc is unchanged
+    (commutativity), and the signed area negates (absolute value preserved). -/
 theorem circumradiusOf_perm12 (p1 p2 p3 : Point) :
     circumradiusOf p1 p2 p3 = circumradiusOf p2 p1 p3 := by
-  sorry
+  simp only [circumradiusOf]
+  -- The cross product for (p2,p1,p3) is the negative of that for (p1,p2,p3)
+  have h_neg : (p1 0 - p2 0) * (p3 1 - p2 1) - (p3 0 - p2 0) * (p1 1 - p2 1) =
+    -((p2 0 - p1 0) * (p3 1 - p1 1) - (p3 0 - p1 0) * (p2 1 - p1 1)) := by ring
+  rw [h_neg, abs_neg, norm_sub_rev p2 p1]
+  -- Now conditions and denominators match; numerators differ by mul_comm
+  split_ifs with h
+  · rfl
+  · have h_mul : ‖p2 - p3‖ * ‖p1 - p3‖ * ‖p1 - p2‖ =
+        ‖p1 - p3‖ * ‖p2 - p3‖ * ‖p1 - p2‖ := by ring
+    rw [h_mul]
 
 /-- circumradiusOf is invariant under cyclic permutation (1→2→3→1).
-    Combined with perm12, this generates all 6 permutations. -/
+    Combined with perm12, this generates all of S₃. The signed area is
+    literally equal (not just up to sign) under cyclic permutation. -/
 theorem circumradiusOf_cycle (p1 p2 p3 : Point) :
     circumradiusOf p1 p2 p3 = circumradiusOf p2 p3 p1 := by
-  sorry
+  simp only [circumradiusOf]
+  -- The cross product is literally equal under cyclic permutation
+  have h_cross : (p3 0 - p2 0) * (p1 1 - p2 1) - (p1 0 - p2 0) * (p3 1 - p2 1) =
+    (p2 0 - p1 0) * (p3 1 - p1 1) - (p3 0 - p1 0) * (p2 1 - p1 1) := by ring
+  rw [h_cross, norm_sub_rev p3 p1, norm_sub_rev p2 p1]
+  -- Conditions and denominators now match; numerators differ by mul_comm
+  split_ifs with h
+  · rfl
+  · have h_mul : ‖p2 - p3‖ * ‖p1 - p3‖ * ‖p1 - p2‖ =
+        ‖p1 - p3‖ * ‖p1 - p2‖ * ‖p2 - p3‖ := by ring
+    rw [h_mul]
+
+/-- circumradiusOf is invariant under swapping the last two arguments.
+    Derived from perm12 and cycle. -/
+theorem circumradiusOf_perm23 (p1 p2 p3 : Point) :
+    circumradiusOf p1 p2 p3 = circumradiusOf p1 p3 p2 := by
+  calc circumradiusOf p1 p2 p3
+      = circumradiusOf p2 p3 p1 := circumradiusOf_cycle p1 p2 p3
+    _ = circumradiusOf p3 p2 p1 := circumradiusOf_perm12 p2 p3 p1
+    _ = circumradiusOf p1 p3 p2 := (circumradiusOf_cycle p1 p3 p2).symm
+
+/-- circumradiusOf is invariant under swapping the first and third arguments.
+    Derived from perm12 and cycle. -/
+theorem circumradiusOf_perm13 (p1 p2 p3 : Point) :
+    circumradiusOf p1 p2 p3 = circumradiusOf p3 p2 p1 := by
+  calc circumradiusOf p1 p2 p3
+      = circumradiusOf p2 p3 p1 := circumradiusOf_cycle p1 p2 p3
+    _ = circumradiusOf p3 p2 p1 := circumradiusOf_perm12 p2 p3 p1
 
 /-- The origin (0, 0) as a point in the plane. -/
 private noncomputable def p_origin : Point := ![0, 0]

--- a/proofs/Proofs/Erdos831Problem.lean
+++ b/proofs/Proofs/Erdos831Problem.lean
@@ -285,8 +285,38 @@ theorem h_three : h 3 = 1 := by
         | rw [circumradiusOf_cycle]                 -- (E2, O, E1): one cycle
         | rw [circumradiusOf_cycle, circumradiusOf_cycle]  -- (E1, E2, O): two cycles
   · -- 1 ≤ h 3: any 3-point GP config has ≥ 1 distinct radius
-    -- (the image of a nonempty set is nonempty → card ≥ 1)
-    sorry
+    suffices h 3 ≠ 0 by omega
+    intro h0
+    unfold h at h0
+    rw [Nat.sInf_eq_zero] at h0
+    rcases h0 with ⟨S, hcard, _, hcount⟩ | hempty
+    · -- Case: countDistinctRadii S = 0 for a 3-point config — impossible
+      obtain ⟨p1, T2, h1, rfl, hT2⟩ :=
+        Finset.card_eq_succ.mp (show S.card = 2 + 1 by omega)
+      obtain ⟨p2, T1, h2, rfl, hT1⟩ :=
+        Finset.card_eq_succ.mp (show T2.card = 1 + 1 by omega)
+      obtain ⟨p3, rfl⟩ := Finset.card_eq_one.mp (show T1.card = 1 by omega)
+      have d12 : p1 ≠ p2 := fun h => h1 (by rw [h]; exact Finset.mem_insert_self _ _)
+      have d13 : p1 ≠ p3 := fun h => h1 (by rw [h]; simp)
+      have d23 : p2 ≠ p3 := fun h => h2 (by rw [h]; simp)
+      have hmem : circumradiusOf p1 p2 p3 ∈
+          allCircumradiiFinset (insert p1 (insert p2 {p3})) := by
+        simp only [allCircumradiiFinset]
+        apply Finset.mem_image_of_mem (a := (p1, (p2, p3)))
+        simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_insert,
+                   Finset.mem_singleton]
+        exact ⟨⟨Or.inl rfl, Or.inr (Or.inl rfl), Or.inr (Or.inr rfl)⟩,
+               d12, d23, d13⟩
+      simp only [countDistinctRadii, Finset.card_eq_zero] at hcount
+      rw [hcount] at hmem
+      exact absurd hmem (Finset.not_mem_empty _)
+    · -- Case: set is empty — impossible, standard triangle is a valid config
+      have hmem : countDistinctRadii {p_origin, p_e1, p_e2} ∈ {k : ℕ |
+          ∃ S : Finset Point, S.card = 3 ∧
+            isInGeneralPosition (↑S : Set Point) ∧ countDistinctRadii S = k} :=
+        ⟨{p_origin, p_e1, p_e2}, standard_triangle_card, standard_triangle_gp, rfl⟩
+      rw [hempty] at hmem
+      exact absurd hmem (Set.not_mem_empty _)
 
 /--
 **h(4) ≥ 2:**
@@ -498,6 +528,48 @@ private theorem triangle_not_collinear : ¬areCollinear p_origin p_e1 p_e2 := by
   rcases hab with ha | hb
   · exact ha h2
   · exact hb h3
+
+/-- The standard triangle {(0,0), (1,0), (0,1)} has cardinality 3. -/
+private theorem standard_triangle_card :
+    ({p_origin, p_e1, p_e2} : Finset Point).card = 3 := by
+  have h1 : p_e1 ∉ ({p_e2} : Finset Point) := by
+    simp [Finset.mem_singleton, p_e1_ne_e2]
+  have h2 : p_origin ∉ ({p_e1, p_e2} : Finset Point) := by
+    simp [Finset.mem_insert, Finset.mem_singleton, p_origin_ne_e1, p_origin_ne_e2]
+  rw [Finset.card_insert_of_not_mem h2, Finset.card_insert_of_not_mem h1,
+      Finset.card_singleton]
+
+/-- The standard triangle {(0,0), (1,0), (0,1)} is in general position. -/
+private theorem standard_triangle_gp :
+    isInGeneralPosition (↑({p_origin, p_e1, p_e2} : Finset Point) : Set Point) := by
+  constructor
+  · intro q1 q2 q3 hq1 hq2 hq3 hd12 hd23 hd13
+    simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
+               Set.mem_singleton_iff] at hq1 hq2 hq3
+    rcases hq1 with rfl | rfl | rfl <;> rcases hq2 with rfl | rfl | rfl <;>
+      rcases hq3 with rfl | rfl | rfl <;>
+    first
+    | exact absurd rfl hd12 | exact absurd rfl hd23 | exact absurd rfl hd13
+    | exact absurd rfl (Ne.symm hd12) | exact absurd rfl (Ne.symm hd23)
+    | exact absurd rfl (Ne.symm hd13)
+    | (intro ⟨a, b, c, hab, h1, h2, h3⟩; exact triangle_not_collinear
+        (by first | exact ⟨a, b, c, hab, h1, h2, h3⟩
+                  | exact ⟨a, b, c, hab, h1, h3, h2⟩
+                  | exact ⟨a, b, c, hab, h2, h1, h3⟩
+                  | exact ⟨a, b, c, hab, h2, h3, h1⟩
+                  | exact ⟨a, b, c, hab, h3, h1, h2⟩
+                  | exact ⟨a, b, c, hab, h3, h2, h1⟩))
+  · intro q1 q2 q3 q4 hq1 hq2 hq3 hq4 hd12 hd23 hd34 hd13 hd14 hd24
+    simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
+               Set.mem_singleton_iff] at hq1 hq2 hq3 hq4
+    rcases hq1 with rfl | rfl | rfl <;> rcases hq2 with rfl | rfl | rfl <;>
+      rcases hq3 with rfl | rfl | rfl <;> rcases hq4 with rfl | rfl | rfl <;>
+    first
+    | exact absurd rfl hd12 | exact absurd rfl hd13 | exact absurd rfl hd14
+    | exact absurd rfl hd23 | exact absurd rfl hd24 | exact absurd rfl hd34
+    | exact absurd rfl (Ne.symm hd12) | exact absurd rfl (Ne.symm hd13)
+    | exact absurd rfl (Ne.symm hd14) | exact absurd rfl (Ne.symm hd23)
+    | exact absurd rfl (Ne.symm hd24) | exact absurd rfl (Ne.symm hd34)
 
 end PointHelpers
 

--- a/proofs/Proofs/Erdos831Problem.lean
+++ b/proofs/Proofs/Erdos831Problem.lean
@@ -248,11 +248,44 @@ theorem h_three : h 3 = 1 := by
         | exact absurd rfl (Ne.symm hd14) | exact absurd rfl (Ne.symm hd23)
         | exact absurd rfl (Ne.symm hd24) | exact absurd rfl (Ne.symm hd34)
     · -- countDistinctRadii S = 1
-      -- allCircumradiiFinset S = {circumradiusOf p_origin p_e1 p_e2} (singleton)
-      -- All 6 ordered triples map to same value by circumradiusOf_perm12/cycle
-      sorry
+      -- allCircumradiiFinset = {circumradiusOf p_origin p_e1 p_e2} (singleton)
+      -- because all 6 ordered triples map to same value by permutation invariance
+      show (allCircumradiiFinset {p_origin, p_e1, p_e2}).card = 1
+      rw [Finset.card_eq_one]
+      refine ⟨circumradiusOf p_origin p_e1 p_e2,
+        Finset.eq_singleton_iff_unique_mem.mpr ⟨?mem, ?uniq⟩⟩
+      case mem =>
+        -- (p_origin, (p_e1, p_e2)) is in the filtered product, maps to our value
+        simp only [allCircumradiiFinset]
+        apply Finset.mem_image_of_mem (a := (p_origin, (p_e1, p_e2)))
+        simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_insert,
+                   Finset.mem_singleton]
+        exact ⟨⟨Or.inl rfl, Or.inr (Or.inl rfl), Or.inr (Or.inr rfl)⟩,
+               p_origin_ne_e1, p_e1_ne_e2, p_origin_ne_e2⟩
+      case uniq =>
+        -- Every element equals circumradiusOf p_origin p_e1 p_e2
+        -- (all 6 permutations map to the same value)
+        intro r hr
+        simp only [allCircumradiiFinset, Finset.mem_image, Finset.mem_filter,
+                   Finset.mem_product, Finset.mem_insert, Finset.mem_singleton] at hr
+        obtain ⟨⟨p, q, s⟩, ⟨⟨hp, hq, hs⟩, hdpq, hdqs, hdps⟩, heq⟩ := hr
+        rw [← heq]
+        -- 27-way case split on which points p, q, s are; 21 eliminated by
+        -- distinctness, 6 valid permutations closed by circumradiusOf_perm*
+        rcases hp with rfl | rfl | rfl <;> rcases hq with rfl | rfl | rfl <;>
+          rcases hs with rfl | rfl | rfl <;>
+        first
+        | exact absurd rfl hdpq | exact absurd rfl hdqs | exact absurd rfl hdps
+        | exact absurd rfl (Ne.symm hdpq) | exact absurd rfl (Ne.symm hdqs)
+        | exact absurd rfl (Ne.symm hdps)
+        | rfl                                       -- (O, E1, E2): identity
+        | rw [circumradiusOf_perm12]                -- (E1, O, E2): swap 1↔2
+        | rw [circumradiusOf_perm23]                -- (O, E2, E1): swap 2↔3
+        | rw [circumradiusOf_perm13]                -- (E2, E1, O): swap 1↔3
+        | rw [circumradiusOf_cycle]                 -- (E2, O, E1): one cycle
+        | rw [circumradiusOf_cycle, circumradiusOf_cycle]  -- (E1, E2, O): two cycles
   · -- 1 ≤ h 3: any 3-point GP config has ≥ 1 distinct radius
-    -- Proof: S.card = 3 gives ≥ 1 ordered distinct triple → image nonempty → card ≥ 1
+    -- (the image of a nonempty set is nonempty → card ≥ 1)
     sorry
 
 /--

--- a/proofs/Proofs/Erdos831Problem.lean
+++ b/proofs/Proofs/Erdos831Problem.lean
@@ -202,24 +202,58 @@ theorem h_upper_bound (n : ℕ) : h n ≤ Nat.choose n 3 := by
 Three points in general position give exactly one circle, hence one radius.
 -/
 theorem h_three : h 3 = 1 := by
-  -- Now feasible with Finset-based countDistinctRadii.
-  -- Proof infrastructure (Part IX):
-  -- ✓ p_origin, p_e1, p_e2 defined as ![0,0], ![1,0], ![0,1]
-  -- ✓ p_origin_ne_e1, p_origin_ne_e2, p_e1_ne_e2 proved (distinctness)
-  -- ✓ triangle_not_collinear proved (non-collinearity)
-  --
-  -- Proof plan:
-  -- 1. Construct S = {p_origin, p_e1, p_e2} with card 3
-  -- 2. Show GP: no-3-collinear via triangle_not_collinear,
-  --    no-4-concyclic vacuous (only 3 points, need 4 for concyclicity)
-  -- 3. Show countDistinctRadii S = 1:
-  --    allCircumradiiFinset S = {circumradiusOf p_origin p_e1 p_e2}
-  --    This follows from circumradiusOf permutation invariance:
-  --    all 6 ordered triples of 3 points map to the same circumradius
-  -- 4. h(3) ≤ 1 since 1 ∈ {k | ∃ S, |S|=3 ∧ GP(S) ∧ count(S) = k}
-  -- 5. h(3) ≥ 1 since any GP 3-point set has ≥ 1 triple hence ≥ 1 radius
-  -- REQUIRES: circumradiusOf permutation invariance (see h_upper_bound notes)
-  sorry
+  apply le_antisymm
+  · -- h 3 ≤ 1: exhibit a 3-point GP config with exactly 1 distinct radius
+    apply Nat.sInf_le
+    refine ⟨{p_origin, p_e1, p_e2}, ?_, ?_, ?_⟩
+    · -- card = 3
+      have h1 : p_e1 ∉ ({p_e2} : Finset Point) := by
+        simp [Finset.mem_singleton, p_e1_ne_e2]
+      have h2 : p_origin ∉ ({p_e1, p_e2} : Finset Point) := by
+        simp [Finset.mem_insert, Finset.mem_singleton, p_origin_ne_e1, p_origin_ne_e2]
+      rw [Finset.card_insert_of_not_mem h2, Finset.card_insert_of_not_mem h1,
+          Finset.card_singleton]
+    · -- isInGeneralPosition
+      constructor
+      · -- No 3 collinear: all permutations of (p_origin, p_e1, p_e2) are non-collinear
+        intro q1 q2 q3 hq1 hq2 hq3 hd12 hd23 hd13
+        simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
+                   Set.mem_singleton_iff] at hq1 hq2 hq3
+        -- Case split on membership (27 cases); 21 have qi=qj, 6 are permutations
+        rcases hq1 with rfl | rfl | rfl <;> rcases hq2 with rfl | rfl | rfl <;>
+          rcases hq3 with rfl | rfl | rfl <;>
+        -- First try distinctness contradictions, then reduce to triangle_not_collinear
+        first
+        | exact absurd rfl hd12 | exact absurd rfl hd23 | exact absurd rfl hd13
+        | exact absurd rfl (Ne.symm hd12) | exact absurd rfl (Ne.symm hd23)
+        | exact absurd rfl (Ne.symm hd13)
+        | (intro ⟨a, b, c, hab, h1, h2, h3⟩; exact triangle_not_collinear
+            (by first | exact ⟨a, b, c, hab, h1, h2, h3⟩
+                      | exact ⟨a, b, c, hab, h1, h3, h2⟩
+                      | exact ⟨a, b, c, hab, h2, h1, h3⟩
+                      | exact ⟨a, b, c, hab, h2, h3, h1⟩
+                      | exact ⟨a, b, c, hab, h3, h1, h2⟩
+                      | exact ⟨a, b, c, hab, h3, h2, h1⟩))
+      · -- No 4 concyclic: vacuously true (4 distinct from 3-element set is impossible)
+        intro q1 q2 q3 q4 hq1 hq2 hq3 hq4 hd12 hd23 hd34 hd13 hd14 hd24
+        simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
+                   Set.mem_singleton_iff] at hq1 hq2 hq3 hq4
+        -- Pigeonhole: 4 values from 3 options, two must be equal
+        rcases hq1 with rfl | rfl | rfl <;> rcases hq2 with rfl | rfl | rfl <;>
+          rcases hq3 with rfl | rfl | rfl <;> rcases hq4 with rfl | rfl | rfl <;>
+        first
+        | exact absurd rfl hd12 | exact absurd rfl hd13 | exact absurd rfl hd14
+        | exact absurd rfl hd23 | exact absurd rfl hd24 | exact absurd rfl hd34
+        | exact absurd rfl (Ne.symm hd12) | exact absurd rfl (Ne.symm hd13)
+        | exact absurd rfl (Ne.symm hd14) | exact absurd rfl (Ne.symm hd23)
+        | exact absurd rfl (Ne.symm hd24) | exact absurd rfl (Ne.symm hd34)
+    · -- countDistinctRadii S = 1
+      -- allCircumradiiFinset S = {circumradiusOf p_origin p_e1 p_e2} (singleton)
+      -- All 6 ordered triples map to same value by circumradiusOf_perm12/cycle
+      sorry
+  · -- 1 ≤ h 3: any 3-point GP config has ≥ 1 distinct radius
+    -- Proof: S.card = 3 gives ≥ 1 ordered distinct triple → image nonempty → card ≥ 1
+    sorry
 
 /--
 **h(4) ≥ 2:**

--- a/src/data/research/problems/erdos-831.json
+++ b/src/data/research/problems/erdos-831.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-831",
-  "title": "Erdős #831",
+  "title": "Erd\u0151s #831",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-15T09:46:19.704Z",
-    "iteration": 2,
-    "focus": "Documented strategies, both sorries blocked on constructive configs",
+    "iteration": 3,
+    "focus": "Proved permutation invariance, unblocking h_three and h_upper_bound",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,25 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ASSESSED: Definition bug blocks both sorries. countDistinctRadii uses Nat.card(Set ℝ subtype)→0 always. Needs Finset.image refactor.",
+    "progressSummary": "PROGRESS: Proved circumradiusOf permutation invariance (perm12, cycle, perm23, perm13). Definition bug fixed in prior session (Finset-based countDistinctRadii). 2 sorries remain (h_upper_bound, h_three) \u2014 now provable via permutation invariance.",
     "builtItems": [
       "Proved regular_polygon_not_general via Finset.exists_smaller_set + card_eq_succ extraction",
-      "Documented proof strategies for h_upper_bound (sInf + image bound) and h_three (explicit 3-point config)"
+      "Proved circumradiusOf_perm12: swap first two args preserves circumradius (signed area negates, |area| preserved)",
+      "Proved circumradiusOf_cycle: cyclic permutation preserves circumradius (signed area literally equal)",
+      "Derived circumradiusOf_perm23, circumradiusOf_perm13 from perm12+cycle (full S\u2083 invariance)",
+      "FIXED countDistinctRadii: allCircumradiiFinset using Finset \u00d7\u02e2 filter image (prior session)",
+      "Added DecidableEq instances for Point and \u211d via Classical.decEq"
     ],
     "insights": [
       "regular_polygon_not_general proved: 4 points on same circle are concyclic, contradicting GP",
-      "Remaining 2 sorries (h_upper_bound, h_three) need constructive point configurations in R²",
-      "h_upper_bound: for empty set sInf=0, for non-empty every k ≤ C(n,3) by image cardinality",
-      "h_three: explicit config (0,0),(1,0),(0,1) works — not collinear (det≠0), concyclic vacuous, 1 radius",
-      "h_four_lower axiom is appropriate: proving h(4)≥2 requires showing all GP 4-point configs have ≥2 radii",
-      "DEFINITION BUG: countDistinctRadii uses Nat.card on Set ℝ subtype → always returns 0",
-      "This makes h(n)=0 always, h_upper_bound trivially true, h_three FALSE",
-      "FIX: redefine countDistinctRadii via Finset.image with Classical.decEq ℝ",
-      "Without the fix, both sorries are unprovable (h_three is literally false with current def)"
+      "DEFINITION BUG FIXED: countDistinctRadii now uses Finset.card on allCircumradiiFinset",
+      "circumradiusOf is fully S\u2083-invariant: perm12 (transposition) + cycle (3-cycle) generate all 6 perms",
+      "Key proof technique for perm12: signed area expression negates under p1\u2194p2 swap, proved by ring",
+      "Key proof technique for cycle: signed area expression is LITERALLY EQUAL under cyclic perm, proved by ring",
+      "h_upper_bound now provable: image of ordered triples through perm-invariant circumradiusOf collapses to \u2264C(n,3) elements",
+      "h_three now provable: 3-point GP config has 6 ordered triples, all mapping to same circumradius \u2192 card=1",
+      "h_four_lower axiom is appropriate: proving h(4)\u22652 requires showing all GP 4-point configs have \u22652 radii"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# Erdős #831 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be maximal such that in any $n$ points in $\\mathbb{R}^2$ (with no three on a line and no four on a circle) there are at least $h(n)$ many circles of different radii passing through three points. Estimate $h(n)$.\n\n\n\nSee also [104] and [506].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #104\n- Problem #506\n- Problem #830\n- Problem #832\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er75h\n- Er92e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erd\u0151s #831 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be maximal such that in any $n$ points in $\\mathbb{R}^2$ (with no three on a line and no four on a circle) there are at least $h(n)$ many circles of different radii passing through three points. Estimate $h(n)$.\n\n\n\nSee also [104] and [506].\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #104\n- Problem #506\n- Problem #830\n- Problem #832\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er75h\n- Er92e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"

--- a/src/data/research/problems/erdos-831.json
+++ b/src/data/research/problems/erdos-831.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-15T09:46:19.704Z",
-    "iteration": 6,
-    "focus": "Proved h_three fully (both directions). Only h_upper_bound sorry remains.",
+    "iteration": 7,
+    "focus": "All sorries eliminated. h_upper_bound proved via powersetCard 3 factoring.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 4→1 sorry. h_three fully proved (le_antisymm: ≤1 via witness, ≥1 via Nat.sInf_eq_zero contrapositive). Extracted standard_triangle_card/gp lemmas. Only h_upper_bound sorry remains — needs factoring through S.powersetCard 3.",
+    "progressSummary": "COMPLETE: 4→0 sorries. h_three fully proved. h_upper_bound proved via tripleCircumradius on S.powersetCard 3, using circumradiusOf_eq_of_mem_triple for S₃ invariance. Only axiom: h_four_lower.",
     "builtItems": [
       "Proved regular_polygon_not_general via Finset.exists_smaller_set + card_eq_succ extraction",
       "Proved circumradiusOf_perm12: swap first two args preserves circumradius (signed area negates, |area| preserved)",
@@ -41,7 +41,11 @@
       "Proved card=3 for {p_origin, p_e1, p_e2} via card_insert_of_not_mem",
       "Proved 1≤h(3) via Nat.sInf_eq_zero: if sInf=0, either 0∈set (3-point config has ≥1 radius, contradiction) or set=∅ (standard triangle exists, contradiction)",
       "Extracted standard_triangle_card, standard_triangle_gp as reusable private lemmas",
-      "Proved countDistinctRadii=1 via eq_singleton_iff_unique_mem: membership witness + uniqueness by permutation invariance over 6 valid orderings"
+      "Proved countDistinctRadii=1 via eq_singleton_iff_unique_mem: membership witness + uniqueness by permutation invariance over 6 valid orderings",
+      "Proved circumradiusOf_eq_of_mem_triple: general S₃ invariance for abstract 3-point sets (27-case analysis)",
+      "Defined tripleCircumradius via Multiset.toList extraction, proved allCircumradiiFinset ⊆ powersetCard 3 image",
+      "Proved countDistinctRadii_le_choose: card(allCircumradiiFinset) ≤ C(n,3) via image chain",
+      "Proved h_upper_bound: sInf bound via by_cases on Set.Nonempty + Nat.sInf_eq_zero"
     ],
     "insights": [
       "regular_polygon_not_general proved: 4 points on same circle are concyclic, contradicting GP",
@@ -57,11 +61,7 @@
       "Key difficulty in h_upper_bound: proving tripleCircumradius well-defined (toList permutation + S₃ invariance case analysis)"
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Prove h_upper_bound: factor allCircumradiiFinset through (S.powersetCard 3).image",
-      "Define tripleCircumradius using Multiset.toList extraction",
-      "Prove well-definedness via circumradiusOf S₃ invariance"
-    ],
+    "nextSteps": [],
     "markdown": "# Erdős #831 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be maximal such that in any $n$ points in $\\mathbb{R}^2$ (with no three on a line and no four on a circle) there are at least $h(n)$ many circles of different radii passing through three points. Estimate $h(n)$.\n\n\n\nSee also [104] and [506].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #104\n- Problem #506\n- Problem #830\n- Problem #832\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er75h\n- Er92e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -78,18 +78,18 @@
     "mathlib": []
   },
   "started": "2026-01-15T09:46:19.704Z",
-  "lastUpdate": "2026-03-29T12:00:00.000Z",
+  "lastUpdate": "2026-03-29T13:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos831Problem.lean",
       "filename": "Erdos831Problem.lean",
-      "lineCount": 612,
-      "theoremCount": 18,
+      "lineCount": 704,
+      "theoremCount": 23,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos831Problem.lean"
     }

--- a/src/data/research/problems/erdos-831.json
+++ b/src/data/research/problems/erdos-831.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-831",
-  "title": "Erd\u0151s #831",
+  "title": "Erdős #831",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-15T09:46:19.704Z",
-    "iteration": 4,
-    "focus": "Proved permutation invariance, unblocking h_three and h_upper_bound",
+    "iteration": 6,
+    "focus": "Proved h_three fully (both directions). Only h_upper_bound sorry remains.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,31 +29,40 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: S\u2083 perm invariance proved. h_three structured: GP conditions fully proved (no-3-collinear via case analysis + triangle_not_collinear, no-4-concyclic via pigeonhole). 3 sorries remain: h_upper_bound, countDistinctRadii=1, h\u22651.",
+    "progressSummary": "PROGRESS: 4→1 sorry. h_three fully proved (le_antisymm: ≤1 via witness, ≥1 via Nat.sInf_eq_zero contrapositive). Extracted standard_triangle_card/gp lemmas. Only h_upper_bound sorry remains — needs factoring through S.powersetCard 3.",
     "builtItems": [
       "Proved regular_polygon_not_general via Finset.exists_smaller_set + card_eq_succ extraction",
       "Proved circumradiusOf_perm12: swap first two args preserves circumradius (signed area negates, |area| preserved)",
       "Proved circumradiusOf_cycle: cyclic permutation preserves circumradius (signed area literally equal)",
-      "Derived circumradiusOf_perm23, circumradiusOf_perm13 from perm12+cycle (full S\u2083 invariance)",
-      "FIXED countDistinctRadii: allCircumradiiFinset using Finset \u00d7\u02e2 filter image (prior session)",
-      "Added DecidableEq instances for Point and \u211d via Classical.decEq",
-      "Proved GP conditions for {(0,0),(1,0),(0,1)}: no-3-collinear (27-case analysis \u2192 triangle_not_collinear), no-4-concyclic (81-case pigeonhole)",
-      "Proved card=3 for {p_origin, p_e1, p_e2} via card_insert_of_not_mem"
+      "Derived circumradiusOf_perm23, circumradiusOf_perm13 from perm12+cycle (full S₃ invariance)",
+      "FIXED countDistinctRadii: allCircumradiiFinset using Finset ×ˢ filter image (prior session)",
+      "Added DecidableEq instances for Point and ℝ via Classical.decEq",
+      "Proved GP conditions for {(0,0),(1,0),(0,1)}: no-3-collinear (27-case analysis → triangle_not_collinear), no-4-concyclic (81-case pigeonhole)",
+      "Proved card=3 for {p_origin, p_e1, p_e2} via card_insert_of_not_mem",
+      "Proved 1≤h(3) via Nat.sInf_eq_zero: if sInf=0, either 0∈set (3-point config has ≥1 radius, contradiction) or set=∅ (standard triangle exists, contradiction)",
+      "Extracted standard_triangle_card, standard_triangle_gp as reusable private lemmas",
+      "Proved countDistinctRadii=1 via eq_singleton_iff_unique_mem: membership witness + uniqueness by permutation invariance over 6 valid orderings"
     ],
     "insights": [
       "regular_polygon_not_general proved: 4 points on same circle are concyclic, contradicting GP",
       "DEFINITION BUG FIXED: countDistinctRadii now uses Finset.card on allCircumradiiFinset",
-      "circumradiusOf is fully S\u2083-invariant: perm12 (transposition) + cycle (3-cycle) generate all 6 perms",
-      "Key proof technique for perm12: signed area expression negates under p1\u2194p2 swap, proved by ring",
+      "circumradiusOf is fully S₃-invariant: perm12 (transposition) + cycle (3-cycle) generate all 6 perms",
+      "Key proof technique for perm12: signed area expression negates under p1↔p2 swap, proved by ring",
       "Key proof technique for cycle: signed area expression is LITERALLY EQUAL under cyclic perm, proved by ring",
-      "h_upper_bound now provable: image of ordered triples through perm-invariant circumradiusOf collapses to \u2264C(n,3) elements",
-      "h_three now provable: 3-point GP config has 6 ordered triples, all mapping to same circumradius \u2192 card=1",
-      "h_four_lower axiom is appropriate: proving h(4)\u22652 requires showing all GP 4-point configs have \u22652 radii",
-      "h_three structured as le_antisymm with Nat.sInf_le witness; remaining: countDistinctRadii=1 and sInf\u22651"
+      "h_upper_bound now provable: image of ordered triples through perm-invariant circumradiusOf collapses to ≤C(n,3) elements",
+      "h_three now provable: 3-point GP config has 6 ordered triples, all mapping to same circumradius → card=1",
+      "h_four_lower axiom is appropriate: proving h(4)≥2 requires showing all GP 4-point configs have ≥2 radii",
+      "h_three structured as le_antisymm with Nat.sInf_le witness; remaining: countDistinctRadii=1 and sInf≥1",
+      "h_upper_bound needs: define tripleCircumradius on S.powersetCard 3, show allCircumradiiFinset ⊆ image, bound by card_powersetCard = C(n,3)",
+      "Key difficulty in h_upper_bound: proving tripleCircumradius well-defined (toList permutation + S₃ invariance case analysis)"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erd\u0151s #831 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be maximal such that in any $n$ points in $\\mathbb{R}^2$ (with no three on a line and no four on a circle) there are at least $h(n)$ many circles of different radii passing through three points. Estimate $h(n)$.\n\n\n\nSee also [104] and [506].\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #104\n- Problem #506\n- Problem #830\n- Problem #832\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er75h\n- Er92e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Prove h_upper_bound: factor allCircumradiiFinset through (S.powersetCard 3).image",
+      "Define tripleCircumradius using Multiset.toList extraction",
+      "Prove well-definedness via circumradiusOf S₃ invariance"
+    ],
+    "markdown": "# Erdős #831 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h(n)$ be maximal such that in any $n$ points in $\\mathbb{R}^2$ (with no three on a line and no four on a circle) there are at least $h(n)$ many circles of different radii passing through three points. Estimate $h(n)$.\n\n\n\nSee also [104] and [506].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #104\n- Problem #506\n- Problem #830\n- Problem #832\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er75h\n- Er92e\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -69,18 +78,18 @@
     "mathlib": []
   },
   "started": "2026-01-15T09:46:19.704Z",
-  "lastUpdate": "2026-03-28T00:15:00.000Z",
+  "lastUpdate": "2026-03-29T12:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos831Problem.lean",
       "filename": "Erdos831Problem.lean",
-      "lineCount": 399,
-      "theoremCount": 10,
+      "lineCount": 612,
+      "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos831Problem.lean"
     }

--- a/src/data/research/problems/erdos-831.json
+++ b/src/data/research/problems/erdos-831.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-15T09:46:19.704Z",
-    "iteration": 3,
+    "iteration": 4,
     "focus": "Proved permutation invariance, unblocking h_three and h_upper_bound",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,14 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved circumradiusOf permutation invariance (perm12, cycle, perm23, perm13). Definition bug fixed in prior session (Finset-based countDistinctRadii). 2 sorries remain (h_upper_bound, h_three) \u2014 now provable via permutation invariance.",
+    "progressSummary": "PROGRESS: S\u2083 perm invariance proved. h_three structured: GP conditions fully proved (no-3-collinear via case analysis + triangle_not_collinear, no-4-concyclic via pigeonhole). 3 sorries remain: h_upper_bound, countDistinctRadii=1, h\u22651.",
     "builtItems": [
       "Proved regular_polygon_not_general via Finset.exists_smaller_set + card_eq_succ extraction",
       "Proved circumradiusOf_perm12: swap first two args preserves circumradius (signed area negates, |area| preserved)",
       "Proved circumradiusOf_cycle: cyclic permutation preserves circumradius (signed area literally equal)",
       "Derived circumradiusOf_perm23, circumradiusOf_perm13 from perm12+cycle (full S\u2083 invariance)",
       "FIXED countDistinctRadii: allCircumradiiFinset using Finset \u00d7\u02e2 filter image (prior session)",
-      "Added DecidableEq instances for Point and \u211d via Classical.decEq"
+      "Added DecidableEq instances for Point and \u211d via Classical.decEq",
+      "Proved GP conditions for {(0,0),(1,0),(0,1)}: no-3-collinear (27-case analysis \u2192 triangle_not_collinear), no-4-concyclic (81-case pigeonhole)",
+      "Proved card=3 for {p_origin, p_e1, p_e2} via card_insert_of_not_mem"
     ],
     "insights": [
       "regular_polygon_not_general proved: 4 points on same circle are concyclic, contradicting GP",
@@ -46,7 +48,8 @@
       "Key proof technique for cycle: signed area expression is LITERALLY EQUAL under cyclic perm, proved by ring",
       "h_upper_bound now provable: image of ordered triples through perm-invariant circumradiusOf collapses to \u2264C(n,3) elements",
       "h_three now provable: 3-point GP config has 6 ordered triples, all mapping to same circumradius \u2192 card=1",
-      "h_four_lower axiom is appropriate: proving h(4)\u22652 requires showing all GP 4-point configs have \u22652 radii"
+      "h_four_lower axiom is appropriate: proving h(4)\u22652 requires showing all GP 4-point configs have \u22652 radii",
+      "h_three structured as le_antisymm with Nat.sInf_le witness; remaining: countDistinctRadii=1 and sInf\u22651"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -77,7 +80,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 2,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos831Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Eliminate ALL theorem sorries in Erdos831Problem.lean (4→0 across branch lifetime)
- Prove `h_three : h 3 = 1` (both directions of `le_antisymm`)
- Prove `h_upper_bound : h n ≤ Nat.choose n 3` via powersetCard 3 factoring
- Only remaining assumption: `axiom h_four_lower : h 4 ≥ 2`

## Key Proofs Added
- `circumradiusOf_eq_of_mem_triple`: general S₃ invariance (27-case + perm lemmas)
- `tripleCircumradius` + `allCircumradiiFinset_subset_powersetCard`: image factoring
- `countDistinctRadii_le_choose`: C(n,3) upper bound via calc chain
- `standard_triangle_card/gp`: reusable lemmas for the {(0,0),(1,0),(0,1)} configuration
- Lower bound `1 ≤ h(3)` via `Nat.sInf_eq_zero` contrapositive

## Files Modified
- `proofs/Proofs/Erdos831Problem.lean` (704 lines, 23 theorems, 1 axiom, 0 sorries)
- `src/data/research/problems/erdos-831.json`

## Status
**Outcome**: completed (all theorem sorries eliminated)

🤖 Generated by researcher-4