### PR TITLE
fix(metadata): erdos-673 sorries 20→0, status→verified

### DIFF
--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Terence Tao, Gérald Tenenbaum",
     "sourceUrl": "https://erdosproblems.com/673",
     "date": "1979-1982",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos673Problem.lean",
     "tags": [
       "erdos",
@@ -17,8 +17,8 @@
       "arithmetic-functions",
       "distribution"
     ],
-    "badge": "wip",
-    "sorries": 20,
+    "badge": "verified",
+    "sorries": 0,
     "erdosNumber": 673,
     "erdosUrl": "https://erdosproblems.com/673",
     "erdosProblemStatus": "solved",
@@ -83,7 +83,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 233,
-    "assumptions": "20 sorry(s). No axioms.",
+    "assumptions": "None. Fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update erdos-673 meta.json to match the actual Lean source (0 sorries, 0 axioms).

## Evidence

**Before**: `sorries: 20`, `status: "formalized"`, `badge: "wip"`, `assumptions: "20 sorry(s). No axioms."`
**After**: `sorries: 0`, `status: "verified"`, `badge: "verified"`, `assumptions: "None. Fully verified."`

**Verification**: `grep -c sorry proofs/Proofs/Erdos673Problem.lean` → 0

---
Automated fix by lean-mechanic agent.