### PR TITLE
fix(metadata): erdos-853 sorries 1→0, update assumptions

### DIFF
--- a/src/data/proofs/erdos-853/meta.json
+++ b/src/data/proofs/erdos-853/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 853,
     "erdosUrl": "https://erdosproblems.com/853",
     "erdosProblemStatus": "open",
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 327,
-    "assumptions": "5 axioms: r_upper_bound, erdos_853_weak, erdos_853_strong, maynard_tao_bounded_gaps, cramer_conjecture_bound. 1 sorry(s) remain."
+    "assumptions": "4 axioms: erdos_853_weak, erdos_853_strong, maynard_tao_bounded_gaps, cramer_conjecture_bound. r_upper_bound now proved as theorem. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erd\u0151s Problem #853: Completeness of the Prime Gap Census**\n\nErd\u0151s posed this problem in 1985 [Er85c], asking about the completeness of prime gap sizes. For primes up to $x$, we observe a finite set of gap values $d_n = p_{n+1} - p_n$. The function $r(x)$ measures how far this set is from containing all even integers: it is the smallest even number $\\ge 2$ not appearing as any gap.\n\n**Historical Timeline:**\n- 1849: Polignac conjectured every even number is a prime gap infinitely often\n- 1936: Cram\u00e9r proposed his probabilistic model for prime gaps, predicting maximal gap $\\sim (\\log x)^2$\n- 1985: Erd\u0151s formulated Problem 853, asking whether $r(x) \\to \\infty$\n- 1995: Granville refined Cram\u00e9r's constant to $2e^{-\\gamma} \\approx 1.119$\n- 2013: Zhang proved bounded gaps ($\\liminf d_n \\le 7 \\times 10^7$), the first finite bound\n- 2014: Maynard and Tao independently improved to $\\liminf d_n \\le 246$\n- 2014: Polymath8b project achieved the current bound of 246\n\n**The Key Tension:** The Maynard-Tao theorem guarantees some small gap appears infinitely often, confirming that at least some entries of the gap census grow without bound. But this says nothing about whether ALL even gaps eventually appear. The problem asks about the **completeness** of the gap set $G(x) = \\{d_n : p_n \\le x\\}$, which is a fundamentally different question from the existence of small gaps.\n\n**Notably rich formalization:** This file proves 14 theorems directly from Mathlib (no sorries), including the crucial `primeGap_even` (all gaps after $d_0$ are even), `r_monotone` (the smallest missing gap is weakly increasing), and `weak_implies_all_even_gaps` (the weak conjecture implies gap completeness).",


### PR DESCRIPTION
## Fix

Update erdos-853 meta.json: sorry count 1→0, fix assumptions description.

## Evidence

**Before**: `sorries: 1`, assumptions listed 5 axioms including r_upper_bound
**After**: `sorries: 0`, assumptions list 4 axioms (r_upper_bound now proved as theorem)

**Verification**: `grep -c sorry proofs/Proofs/Erdos853Problem.lean` → 0

---
Automated fix by lean-mechanic agent.