### PR TITLE
fix(metadata): CRITICAL revert erdos-673 false verified status

### DIFF
--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Terence Tao, Gérald Tenenbaum",
     "sourceUrl": "https://erdosproblems.com/673",
     "date": "1979-1982",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos673Problem.lean",
     "tags": [
       "erdos",
@@ -17,8 +17,8 @@
       "arithmetic-functions",
       "distribution"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 20,
     "erdosNumber": 673,
     "erdosUrl": "https://erdosproblems.com/673",
     "erdosProblemStatus": "solved",
@@ -83,7 +83,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 233,
-    "assumptions": "None. Fully verified.",
+    "assumptions": "20 sorry(s). No axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

**CRITICAL integrity fix.** PR #7818 changed erdos-673 to `status=verified, badge=verified, sorries=0` based on the corrupted Lean file (which contained Aristotle companion content with 0 sorries instead of the actual 20-sorry formalization). PR #7823 restored the correct Lean file, but #7818 merged concurrently, leaving the metadata overclaiming.

- **status**: `verified` → `formalized`
- **badge**: `verified` → `wip`
- **sorries**: `0` → `20`
- **assumptions**: `"None. Fully verified."` → `"20 sorry(s). No axioms."`

This is exactly the kind of cascading error the auditor is designed to catch: file corruption → incorrect metadata "fix" → false "verified" claim on a proof with 20 sorries.

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page shows correct WIP badge for erdos-673

🤖 Generated with [Claude Code](https://claude.com/claude-code)