### PR TITLE
fix(metadata): erdos-162 sorries 1→0

### DIFF
--- a/src/data/proofs/erdos-162/meta.json
+++ b/src/data/proofs/erdos-162/meta.json
@@ -16,7 +16,7 @@
       "graph-colouring"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 162,
     "erdosUrl": "https://erdosproblems.com/162",
     "erdosProblemStatus": "open",
@@ -24,7 +24,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 7,
     "lineCount": 214,
-    "assumptions": "7 axiom(s) and 1 sorry (colourEdgeCount_total counting lemma). balanced_requires_le_half now fully proved via nlinarith."
+    "assumptions": "7 axiom(s). 0 sorries. colourEdgeCount_total and balanced_requires_le_half now fully proved."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem around 1990, asking for the precise asymptotic of F(n, α) — the largest k such that some 2-colouring of K_n has every induced subgraph on at least k vertices α-balanced (each colour appears on more than α fraction of edges). The problem sits at the intersection of Ramsey theory and discrepancy theory.\n\nThe probabilistic method readily establishes that F(n, α) = Θ(log n) for each fixed 0 < α ≤ 1/2: a random 2-colouring of K_n is α-balanced on all sets of size ≤ c₁ log n with positive probability (via Chernoff bounds and a union bound over subsets), while a Ramsey-type counting argument shows any colouring must have an imbalanced induced subgraph of size ≤ c₂ log n.\n\nThe conjecture goes beyond these order-of-magnitude bounds to assert that the ratio F(n, α)/log n converges to a definite limit c_α. Determining this constant as a function of α would give a precise quantitative understanding of how balanced large 2-colourings can be. The case α = 1/2 is extremal (requiring near-equal colour distribution) and is related to Problems #161, #163, and #617 on balanced colourings. The formalization at 214 lines includes 1 sorry for a counting lemma (colourEdgeCount_total).",


### PR DESCRIPTION
## Fix

Update erdos-162 meta.json sorry count from 1 to 0.

## Evidence

**Before**: `sorries: 1`, assumptions mentioned colourEdgeCount_total sorry
**After**: `sorries: 0`, all lemmas now proved

**Verification**: `grep -c sorry proofs/Proofs/Erdos162Problem.lean` → 0

---
Automated fix by lean-mechanic agent.