### PR TITLE
fix(metadata): erdos-40 sorries 1→0

### DIFF
--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -15,11 +15,11 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos40Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/40",
     "erdosUrl": "https://erdosproblems.com/40",
     "axiomCount": 1,
-    "assumptions": "1 axiom (sidon_density_bound: tight Sidon bound), 1 sorry (b2g_counting_sq_bound: pair counting lemma). b2g_density_bound now a theorem. Open conjectures stated as hypotheses.",
+    "assumptions": "1 axiom (sidon_density_bound: tight Sidon bound). 0 sorries. b2g_counting_sq_bound and b2g_density_bound now fully proved. Open conjectures stated as hypotheses.",
     "lineCount": 203,
     "badge": "axiom",
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Fix

Update erdos-40 meta.json sorry count from 1 to 0.

## Evidence

**Before**: `sorries: 1`, assumptions mentioned b2g_counting_sq_bound sorry
**After**: `sorries: 0`, all lemmas now proved

**Verification**: `grep -c sorry proofs/Proofs/Erdos40Problem.lean` → 0

---
Automated fix by lean-mechanic agent.