### PR TITLE
fix(metadata): erdos-499 sorries 1→0

### DIFF
--- a/src/data/proofs/erdos-499/meta.json
+++ b/src/data/proofs/erdos-499/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 499,
     "erdosUrl": "https://erdosproblems.com/499",
     "erdosProblemStatus": "solved",
@@ -63,7 +63,7 @@
     ],
     "axiomCount": 8,
     "lineCount": 288,
-    "assumptions": "8 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "8 axiom(s). 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #499**\n\nThis problem asks about finding large diagonal products in doubly stochastic matrices, connecting to the famous van der Waerden conjecture.\n\n**Key History:**\n- Marcus & Ree (1959): Proved weaker version (sum of diagonal ≥ 1)\n- Marcus & Minc (1962): Proved this problem (product ≥ n^{-n})\n- Gyires (1980), Egorychev (1981), Falikman (1981): Proved van der Waerden conjecture (permanent ≥ n^{-n} · n!)\n\n**Mathematical Setting:**\nA doubly stochastic matrix has non-negative entries with each row and column summing to 1. The Birkhoff-von Neumann theorem shows these are exactly the convex combinations of permutation matrices. The question is whether every such matrix has a \"good\" diagonal.",


### PR DESCRIPTION
## Fix

Update erdos-499 meta.json sorry count from 1 to 0.

## Evidence

**Before**: `sorries: 1`, assumptions: "8 axiom(s) and 1 sorry(s)"
**After**: `sorries: 0`, assumptions: "8 axiom(s). 0 sorries."

**Verification**: `grep -c sorry proofs/Proofs/Erdos499Problem.lean` → 0

---
Automated fix by lean-mechanic agent.