### PR TITLE
fix(metadata): erdos-831 sorries 2→0, all proofs complete

### DIFF
--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -16,7 +16,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 831,
     "erdosUrl": "https://erdosproblems.com/831",
     "erdosProblemStatus": "open",
@@ -45,8 +45,8 @@
       "circumradius and circumradiusOf definitions using R = abc/(4A)",
       "allCircumradii, allCircumradiiFinset, countDistinctRadii, h function definitions",
       "circumradiusOf_perm12, circumradiusOf_cycle, circumradiusOf_perm23, circumradiusOf_perm13: full S₃ permutation invariance (proved)",
-      "h_three: h(3) = 1 (≤ 1 direction proved, ≥ 1 sorry)",
-      "h_upper_bound: h(n) ≤ C(n,3) (sorry, needs permutation invariance for unordered triple count)",
+      "h_three: h(3) = 1 (fully proved)",
+      "h_upper_bound: h(n) ≤ C(n,3) (fully proved)",
       "h_four_lower axiom: h(4) ≥ 2",
       "regular_polygon_not_general: proved regular polygons violate GP",
       "isInGeneralPosition_subset, allCircumradii_subset: structural lemmas (proved)",
@@ -54,8 +54,8 @@
       "erdos_831_summary, erdos_831_open_question: summary theorems"
     ],
     "axiomCount": 1,
-    "lineCount": 540,
-    "assumptions": "1 axiom: h_four_lower (h(4)≥2, used in summary theorem). 2 sorries: h_upper_bound (needs circumradiusOf permutation invariance for unordered triple count), h_three (1 ≤ h 3 direction, needs GP config has ≥ 1 radius). circumradiusOf_perm12 and circumradiusOf_cycle now proved."
+    "lineCount": 704,
+    "assumptions": "1 axiom: h_four_lower (h(4)≥2). 0 sorries — h_upper_bound and h_three now fully proved."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #831**\n\nThis geometric extremal problem was posed by Erdős in the 1970s and revisited in the 1990s, documented in [Er75h] and [Er92e].\n\n**Key History:**\n- Erdős asked about the minimum number of distinct circumradii from point configurations\n- Related to classical problems about point-line and point-circle incidences\n- Connects to the unit distance problem and orchard problem\n\n**Mathematical Setting:**\nGiven n points in general position (no three collinear, no four concyclic), each triple determines a unique circumcircle. The question is: over all such configurations, what is the minimum number of distinct radii among these circles?",
@@ -184,10 +184,10 @@
       "Finset"
     ],
     "namespace": "Erdos831",
-    "lineCount": 540,
+    "lineCount": 704,
     "axiomCount": 1,
-    "theoremCount": 18,
-    "definitionCount": 16
+    "theoremCount": 23,
+    "definitionCount": 17
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

- **erdos-831 sorry count**: 2 → 0 (h_upper_bound and h_three now fully proved)
- **Stats**: lineCount 540→704, theoremCount 18→23, definitionCount 16→17
- **Assumptions text**: updated to reflect 0 sorries remaining

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)