### PR TITLE
Research: CRT-OQ04-OQ03 — gallery entry for non-coprime list CRT (0A 0S)

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/annotations.json
@@ -1,0 +1,229 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 21
+    },
+    "type": "context",
+    "title": "Module Overview and Import",
+    "content": "This file extends the non-coprime CRT from two-three moduli (OQ03) to arbitrary-length lists over Euclidean domains. The key import is `ChineseRemainderNonCoprimeOQ03`, which provides the two-moduli non-coprime CRT (`ed_crt_sufficient`) and the distributive law `gcd(lcm(a,b), c) | lcm(gcd(a,c), gcd(b,c))`.\n\nThe result is parameterized over `R : EuclideanDomain` with `DecidableEq R`, making it applicable to integers, Gaussian integers, polynomial rings, and any other Euclidean domain. This algebraic generality goes beyond the parent proof's restriction to natural numbers.",
+    "mathContext": "For a Euclidean domain $R$, the system $m_i \\mid (x - a_i)$ for $i = 1, \\ldots, k$ is solvable iff $\\gcd(m_i, m_j) \\mid (a_i - a_j)$ for all pairs. Solutions are unique modulo $\\mathrm{lcm}(m_1, \\ldots, m_k)$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Euclidean domain theory",
+      "Non-coprime CRT for two moduli (OQ03)",
+      "GCD-LCM distributive law"
+    ],
+    "relatedConcepts": [
+      "Euclidean domains",
+      "simultaneous congruences",
+      "algebraic generalization"
+    ]
+  },
+  {
+    "id": "ann-listlcm",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 24,
+      "endLine": 52
+    },
+    "type": "definition",
+    "title": "List LCM and Basic Properties",
+    "content": "Defines `listLcm` as the iterated LCM of a list, with the empty list having LCM equal to 1. Two key properties are proved:\n\n- `dvd_listLcm`: Each element $m_i$ divides $\\mathrm{lcm}(m_1, \\ldots, m_k)$. Proof by list induction: the head divides by `dvd_lcm_left`, and tail elements divide by IH plus `dvd_lcm_right`.\n\n- `listLcm_dvd`: If every element divides $d$, then $\\mathrm{lcm}$ divides $d$. This is the universal property making `listLcm` the least common multiple. Proved using `lcm_dvd` at each step.",
+    "mathContext": "$\\mathrm{listLcm}([]) = 1$, $\\mathrm{listLcm}(m :: ms) = \\mathrm{lcm}(m, \\mathrm{listLcm}(ms))$.\n\n$m_i \\in [m_1, \\ldots, m_k] \\Longrightarrow m_i \\mid \\mathrm{listLcm}([m_1, \\ldots, m_k])$.\n\n$(\\forall i,\\; m_i \\mid d) \\Longrightarrow \\mathrm{listLcm}([m_1, \\ldots, m_k]) \\mid d$.",
+    "significance": "key",
+    "prerequisites": [
+      "EuclideanDomain.lcm",
+      "EuclideanDomain.dvd_lcm_left/right",
+      "EuclideanDomain.lcm_dvd"
+    ],
+    "relatedConcepts": [
+      "least common multiple",
+      "universal property",
+      "list recursion"
+    ]
+  },
+  {
+    "id": "ann-system-defs",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 53,
+      "endLine": 66
+    },
+    "type": "definition",
+    "title": "System, Satisfies, Compatible",
+    "content": "Three definitions encode congruence systems:\n\n- `System R`: A list of `(target, modulus)` pairs in $R$.\n- `Satisfies x sys`: $x$ satisfies all congruences, i.e., $m_i \\mid (x - a_i)$ for all $(a_i, m_i)$ in the system.\n- `Compatible sys`: Pairwise GCD divisibility holds: $\\gcd(m_i, m_j) \\mid (a_i - a_j)$ for all pairs.\n\nNote that `Satisfies` uses divisibility ($m \\mid (x - a)$) rather than modular congruence notation ($x \\equiv a \\pmod{m}$), which is the natural formulation in a general Euclidean domain where `ModEq` may not be directly available.",
+    "mathContext": "$\\text{Compatible}(\\text{sys}) \\iff \\forall i, j,\\; \\gcd(m_i, m_j) \\mid (a_i - a_j)$.\n\nThis is the necessary and sufficient condition for solvability of the system.",
+    "significance": "key",
+    "prerequisites": [
+      "EuclideanDomain.gcd",
+      "divisibility in rings"
+    ],
+    "relatedConcepts": [
+      "compatibility condition",
+      "simultaneous congruences",
+      "GCD divisibility"
+    ]
+  },
+  {
+    "id": "ann-distributive",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 68,
+      "endLine": 102
+    },
+    "type": "technique",
+    "title": "Extended Distributive Law for Lists",
+    "content": "**Key technical lemma**: $\\gcd(\\mathrm{listLcm}(ms), c) \\mid \\mathrm{listLcm}(ms.\\mathrm{map}(\\gcd(\\cdot, c)))$.\n\nThis extends the two-element distributive identity $\\gcd(\\mathrm{lcm}(a, b), c) \\mid \\mathrm{lcm}(\\gcd(a, c), \\gcd(b, c))$ from OQ03 to arbitrary lists. The proof is by list induction:\n\n- **Base**: $\\gcd(1, c) \\mid 1$ since $\\gcd(1, c)$ is a unit.\n- **Step**: Apply OQ03's `gcd_lcm_dvd_lcm_gcd` to get $\\gcd(\\mathrm{lcm}(m, L), c) \\mid \\mathrm{lcm}(\\gcd(m, c), \\gcd(L, c))$. The IH gives $\\gcd(L, c) \\mid \\mathrm{listLcm}(\\text{rest})$. LCM monotonicity (`lcm_dvd_lcm_right`) completes the chain.",
+    "mathContext": "$\\gcd(\\mathrm{lcm}(m_1, \\ldots, m_k), c) \\mid \\mathrm{lcm}(\\gcd(m_1, c), \\ldots, \\gcd(m_k, c))$.\n\nThis is a multivariate extension of the GCD-LCM distributive law. It ensures that the composite GCD (arising in the inductive step) can be bounded by individual GCDs.",
+    "significance": "key",
+    "prerequisites": [
+      "gcd_lcm_dvd_lcm_gcd from OQ03",
+      "lcm_dvd_lcm_right (monotonicity)",
+      "list induction"
+    ],
+    "relatedConcepts": [
+      "distributive law",
+      "GCD-LCM duality",
+      "lattice theory of divisibility"
+    ]
+  },
+  {
+    "id": "ann-transfer",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 104,
+      "endLine": 134
+    },
+    "type": "technique",
+    "title": "Transfer Lemma: gcd_listLcm_dvd_sub",
+    "content": "**The bridge between individual and composite compatibility**.\n\nGiven:\n- $x$ satisfies a system: $m_j \\mid (x - a_j)$ for all $j$\n- Each modulus is compatible with a new target: $\\gcd(m_j, c) \\mid (a_j - a)$ for all $j$\n\nConclusion: $\\gcd(\\mathrm{listLcm}(\\text{moduli}), c) \\mid (x - a)$.\n\nThe proof chains: $\\gcd(m_j, c) \\mid m_j \\mid (x - a_j)$ and $\\gcd(m_j, c) \\mid (a_j - a)$, so $\\gcd(m_j, c) \\mid (x - a)$ by linearity. Then $\\mathrm{listLcm}(\\gcd(m_j, c))_j \\mid (x - a)$ by the universal property. The extended distributive law gives the final divisibility.",
+    "mathContext": "If $m_j \\mid (x - a_j)$ and $\\gcd(m_j, c) \\mid (a_j - a)$ for all $j$, then $\\gcd(\\mathrm{lcm}(m_1, \\ldots, m_k), c) \\mid (x - a)$.\n\nThis is the key step enabling induction: it produces the GCD divisibility condition needed to apply the two-moduli non-coprime CRT.",
+    "significance": "key",
+    "prerequisites": [
+      "gcd_listLcm_dvd_listLcm_gcd",
+      "listLcm_dvd",
+      "divisibility algebra (dvd_add, dvd_trans)"
+    ],
+    "relatedConcepts": [
+      "inductive compatibility transfer",
+      "divisibility chain",
+      "GCD properties"
+    ]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 140,
+      "endLine": 170
+    },
+    "type": "theorem",
+    "title": "Existence: ed_crt_list_sufficient",
+    "content": "**Theorem**: If all pairs satisfy the GCD compatibility condition, a simultaneous solution exists.\n\nProof by list induction:\n1. **Base**: Empty system, $x = 0$ is a trivial solution.\n2. **Step**: Given `(a, c) :: rest`, the IH gives $y$ satisfying the tail. The transfer lemma `gcd_listLcm_dvd_sub` produces $\\gcd(\\mathrm{listLcm}(\\text{rest moduli}), c) \\mid (y - a)$, which is exactly the condition for `ed_crt_sufficient` (two-moduli non-coprime CRT). This yields $x$ with $\\mathrm{listLcm}(\\text{rest}) \\mid (x - y)$ and $c \\mid (x - a)$.\n\nFor tail congruences: $m_j \\mid \\mathrm{listLcm}(\\text{rest})$ (by `dvd_listLcm`), so $m_j \\mid (x - y)$. Combined with $m_j \\mid (y - a_j)$ from the IH, we get $m_j \\mid (x - a_j)$ by linearity.",
+    "mathContext": "$\\text{Compatible}(\\text{sys}) \\Longrightarrow \\exists x,\\; \\text{Satisfies}(x, \\text{sys})$.\n\nThe inductive construction mirrors the coprime CRT but uses $\\mathrm{lcm}$ instead of products, and the transfer lemma instead of direct coprimality.",
+    "significance": "key",
+    "prerequisites": [
+      "ed_crt_sufficient (two-moduli case)",
+      "gcd_listLcm_dvd_sub",
+      "dvd_listLcm",
+      "list induction"
+    ],
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "constructive existence",
+      "inductive construction"
+    ]
+  },
+  {
+    "id": "ann-necessity",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 172,
+      "endLine": 182
+    },
+    "type": "theorem",
+    "title": "Necessity: ed_crt_list_necessary",
+    "content": "**Theorem**: If a solution exists, pairwise GCD conditions hold.\n\nSimple proof: if $x$ is a solution, then $m_i \\mid (x - a_i)$ and $m_j \\mid (x - a_j)$. Since $\\gcd(m_i, m_j)$ divides both $m_i$ and $m_j$, it divides both $(x - a_i)$ and $(x - a_j)$, hence their difference $(a_i - a_j) = (x - a_j) - (x - a_i)$.",
+    "mathContext": "$\\exists x,\\; \\text{Satisfies}(x, \\text{sys}) \\Longrightarrow \\text{Compatible}(\\text{sys})$.\n\nEquivalently: $\\gcd(m_i, m_j) \\mid (x - a_i)$ and $\\gcd(m_i, m_j) \\mid (x - a_j)$ imply $\\gcd(m_i, m_j) \\mid (a_i - a_j)$.",
+    "significance": "key",
+    "prerequisites": [
+      "EuclideanDomain.gcd_dvd_left/right",
+      "dvd_sub",
+      "dvd_trans"
+    ],
+    "relatedConcepts": [
+      "necessary condition",
+      "GCD divisibility",
+      "contrapositive obstruction"
+    ]
+  },
+  {
+    "id": "ann-iff",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 184,
+      "endLine": 187
+    },
+    "type": "theorem",
+    "title": "Full Characterization: ed_crt_list_iff",
+    "content": "**Theorem**: A system of congruences over a Euclidean domain is solvable if and only if all pairs satisfy the GCD compatibility condition. This is the complete generalization of the Chinese Remainder Theorem.\n\nThe proof is simply the conjunction of `ed_crt_list_sufficient` and `ed_crt_list_necessary`.",
+    "mathContext": "$\\exists x,\\; \\text{Satisfies}(x, \\text{sys}) \\iff \\text{Compatible}(\\text{sys})$.\n\nThis is the definitive characterization of solvability for simultaneous linear congruences.",
+    "significance": "key",
+    "prerequisites": [
+      "ed_crt_list_sufficient",
+      "ed_crt_list_necessary"
+    ],
+    "relatedConcepts": [
+      "if and only if characterization",
+      "general Chinese Remainder Theorem"
+    ]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 189,
+      "endLine": 200
+    },
+    "type": "theorem",
+    "title": "Uniqueness: ed_crt_list_unique",
+    "content": "**Theorem**: Any two solutions agree modulo listLcm of all moduli.\n\nProof: For each modulus $m_j$, both $x$ and $y$ satisfy $m_j \\mid (x - a_j)$ and $m_j \\mid (y - a_j)$, so $m_j \\mid (x - y)$. Since every modulus divides $(x - y)$, their LCM divides $(x - y)$ by the universal property (`listLcm_dvd`).\n\nThis is the tightest possible uniqueness bound. For coprime moduli, $\\mathrm{lcm} = \\prod$, recovering the classical result. For non-coprime moduli, $\\mathrm{lcm} < \\prod$, giving a strictly tighter bound.",
+    "mathContext": "$\\text{Satisfies}(x, \\text{sys}) \\land \\text{Satisfies}(y, \\text{sys}) \\Longrightarrow \\mathrm{lcm}(m_1, \\ldots, m_k) \\mid (x - y)$.\n\nFor coprime moduli: $\\mathrm{lcm}(m_1, \\ldots, m_k) = \\prod m_i$, recovering classical CRT uniqueness.",
+    "significance": "key",
+    "prerequisites": [
+      "listLcm_dvd",
+      "dvd_sub"
+    ],
+    "relatedConcepts": [
+      "uniqueness modulo LCM",
+      "tightest bound",
+      "universal property of LCM"
+    ]
+  },
+  {
+    "id": "ann-coprime-connection",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-03",
+    "range": {
+      "startLine": 202,
+      "endLine": 215
+    },
+    "type": "insight",
+    "title": "Coprime Case as Corollary",
+    "content": "**Theorem** (`coprime_implies_compatible`): When all pairwise GCDs are units (i.e., the moduli are pairwise coprime), compatibility is automatic.\n\nThis recovers the classical coprime CRT as a special case: if moduli are pairwise coprime, then `Compatible` holds vacuously (units divide everything), so `ed_crt_list_sufficient` guarantees a solution. The uniqueness modulus $\\mathrm{lcm}(m_1, \\ldots, m_k) = \\prod m_i$ in the coprime case.\n\nThis demonstrates that the non-coprime CRT is a strict generalization: it handles all cases the coprime CRT does, plus many more.",
+    "mathContext": "$\\text{IsUnit}(\\gcd(m_i, m_j))$ for all $i \\neq j$ $\\Longrightarrow$ $\\text{Compatible}(\\text{sys})$.\n\nIn a Euclidean domain, $\\text{IsUnit}(\\gcd(a, b))$ is the generalization of $\\gcd(a, b) = 1$ from the integers.",
+    "significance": "supporting",
+    "prerequisites": [
+      "IsUnit",
+      "IsUnit.dvd",
+      "Compatible"
+    ],
+    "relatedConcepts": [
+      "coprimality",
+      "special case recovery",
+      "units in Euclidean domains"
+    ]
+  }
+]

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/index.ts
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChineseRemainderNonCoprimeList.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chineseRemainderConstructiveOQ04OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chineseRemainderConstructiveOQ04OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chineseRemainderConstructiveOQ04OQ03Data: ProofData = {
+  proof: chineseRemainderConstructiveOQ04OQ03Proof,
+  annotations: chineseRemainderConstructiveOQ04OQ03Annotations,
+}
+
+export default chineseRemainderConstructiveOQ04OQ03Data

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "chinese-remainder-constructive-oq-04-oq-03",
+  "title": "Non-Coprime CRT for Arbitrary Lists",
+  "slug": "chinese-remainder-constructive-oq-04-oq-03",
+  "description": "Generalizes the non-coprime Chinese Remainder Theorem to arbitrary-length systems over Euclidean domains. Proves that a system of congruences with arbitrary moduli is solvable iff all pairs satisfy the GCD compatibility condition, with solutions unique modulo the LCM of all moduli.",
+  "meta": {
+    "author": "Ore (1952) / Gauss (formalized in Lean 4)",
+    "date": "1952",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeList.lean",
+    "tags": [
+      "number-theory",
+      "modular-arithmetic",
+      "euclidean-domains",
+      "induction",
+      "lists",
+      "generalization"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanDomain.gcd_dvd_left / gcd_dvd_right",
+        "description": "GCD divides both arguments in a Euclidean domain",
+        "module": "Mathlib.RingTheory.EuclideanDomain"
+      },
+      {
+        "theorem": "EuclideanDomain.dvd_lcm_left / dvd_lcm_right",
+        "description": "Both arguments divide their LCM in a Euclidean domain",
+        "module": "Mathlib.RingTheory.EuclideanDomain"
+      },
+      {
+        "theorem": "EuclideanDomain.lcm_dvd",
+        "description": "LCM is the smallest common multiple: if a | d and b | d then lcm(a,b) | d",
+        "module": "Mathlib.RingTheory.EuclideanDomain"
+      }
+    ],
+    "originalContributions": [
+      "List-based non-coprime CRT existence (ed_crt_list_sufficient) by induction",
+      "List-based non-coprime CRT necessity (ed_crt_list_necessary)",
+      "Full iff characterization (ed_crt_list_iff)",
+      "Uniqueness modulo listLcm (ed_crt_list_unique)",
+      "Extended distributive law: gcd(listLcm ms, c) divides listLcm(ms.map(gcd . c))",
+      "Key transfer lemma (gcd_listLcm_dvd_sub) bridging inductive step",
+      "Connection: coprime_implies_compatible shows coprime case is a special case"
+    ],
+    "references": [
+      {
+        "authors": "Ore, Oystein",
+        "title": "The General Chinese Remainder Theorem",
+        "year": "1952",
+        "venue": "American Mathematical Monthly, vol. 59, no. 6, pp. 365-370",
+        "note": "First modern treatment of CRT for non-coprime moduli with compatibility conditions"
+      },
+      {
+        "authors": "C. F. Gauss",
+        "title": "Disquisitiones Arithmeticae",
+        "year": "1801",
+        "venue": "Leipzig: Gerhard Fleischer",
+        "note": "CRT for pairwise coprime moduli; the non-coprime generalization extends this"
+      }
+    ],
+    "dateAdded": "2026-03-29",
+    "axiomCount": 0,
+    "lineCount": 216,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Works over any EuclideanDomain."
+  },
+  "overview": {
+    "historicalContext": "The classical Chinese Remainder Theorem requires pairwise coprime moduli. Oystein Ore's 1952 paper in the American Mathematical Monthly gave the complete generalization: a system x = ai (mod mi) is solvable iff gcd(mi, mj) | (ai - aj) for all pairs, with solutions unique modulo lcm(m1, ..., mk). The parent formalization (chinese-remainder-constructive-oq-04) generalized the coprime CRT to arbitrary lists. This formalization answers OQ04's third open question by doing the same for the non-coprime case, and goes further by working over arbitrary Euclidean domains rather than just the natural numbers.",
+    "problemStatement": "**General Non-Coprime CRT**: Given moduli [m1, ..., mk] (not necessarily coprime) and targets [a1, ..., ak] in a Euclidean domain R, prove:\n1. **Solvability iff**: The system mi | (x - ai) for all i has a solution iff gcd(mi, mj) | (ai - aj) for all pairs i, j\n2. **Uniqueness**: Any two solutions agree modulo lcm(m1, ..., mk)",
+    "proofStrategy": "Existence is proved by list induction, reducing to the two-moduli non-coprime CRT at each step. The key challenge is showing that the inductive step's compatibility condition is satisfied: gcd(lcm(m1,...,mk-1), mk) | (y - ak) where y solves the prefix system. This requires an extended distributive law showing gcd(listLcm ms, c) divides listLcm(ms.map(gcd . c)), plus a transfer lemma that combines individual compatibility conditions with the existing solution's congruences.\n\nNecessity is simpler: if x satisfies all congruences, then for any pair (i,j), gcd(mi,mj) divides both (x - ai) and (x - aj), hence their difference (ai - aj).\n\nUniqueness follows from the fact that each modulus mi divides (x - y) when both x and y are solutions, so listLcm of all moduli divides (x - y).",
+    "keyInsights": [
+      "**Extended distributive law**: The key technical lemma is gcd(listLcm ms, c) | listLcm(ms.map(gcd . c)), proved by induction using OQ03's gcd_lcm_dvd_lcm_gcd at each step. This generalizes the 2-element distributive identity to arbitrary lists.",
+      "**Transfer lemma**: gcd_listLcm_dvd_sub bridges individual compatibility conditions to the composite condition needed for the inductive step. If x satisfies the tail system and each tail modulus is compatible with the new target, then gcd(listLcm(tail moduli), new modulus) | (x - new target).",
+      "**Euclidean domain generality**: Working over R : EuclideanDomain rather than just N or Z means the theorems apply to polynomial rings, Gaussian integers, and other Euclidean domains, making this a truly algebraic result.",
+      "**Coprime case as corollary**: coprime_implies_compatible shows that when moduli are pairwise coprime (IsUnit of each gcd), compatibility is automatic. This recovers the coprime CRT as a special case of the general theory."
+    ],
+    "prerequisites": [
+      "EuclideanDomain GCD and LCM theory",
+      "Non-coprime CRT for two moduli (ChineseRemainderNonCoprimeOQ03)",
+      "Distributive law: gcd(lcm(a,b), c) | lcm(gcd(a,c), gcd(b,c))",
+      "List induction in Lean 4"
+    ]
+  },
+  "sections": [
+    {
+      "id": "list-lcm",
+      "title": "List LCM and Compatibility",
+      "startLine": 24,
+      "endLine": 66,
+      "summary": "Defines listLcm (LCM of a list), System (list of target-modulus pairs), Satisfies (solution predicate), Compatible (pairwise GCD divisibility), and moduli (projection). Proves dvd_listLcm (each element divides the list LCM) and listLcm_dvd (list LCM is the minimal such).",
+      "mathContext": "listLcm([m1,...,mk]) = lcm(m1, lcm(m2, ...lcm(mk, 1)...)). Compatible(sys) := for all i,j, gcd(mi,mj) | (ai - aj)."
+    },
+    {
+      "id": "distributive-law",
+      "title": "Extended Distributive Law",
+      "startLine": 68,
+      "endLine": 102,
+      "summary": "Proves the extended distributive law: gcd(listLcm ms, c) divides listLcm(ms.map(gcd . c)). Uses lcm_dvd_lcm_right for monotonicity and the 2-element identity from OQ03.",
+      "mathContext": "gcd(lcm(m1,...,mk), c) | lcm(gcd(m1,c), ..., gcd(mk,c))"
+    },
+    {
+      "id": "transfer-lemma",
+      "title": "Key Transfer Lemma",
+      "startLine": 104,
+      "endLine": 134,
+      "summary": "Proves gcd_listLcm_dvd_sub: if x satisfies a system and each modulus is compatible with a new target, then gcd(listLcm(moduli), c) | (x - a). The bridge between individual compatibility and the composite inductive step.",
+      "mathContext": "For each j: gcd(mj, c) | (aj - a) and mj | (x - aj), so gcd(mj, c) | (x - a). Then listLcm of these divides (x - a), and gcd(listLcm, c) divides the listLcm."
+    },
+    {
+      "id": "main-theorems",
+      "title": "Main Theorems",
+      "startLine": 136,
+      "endLine": 200,
+      "summary": "Four main results: ed_crt_list_sufficient (existence from compatibility), ed_crt_list_necessary (compatibility from existence), ed_crt_list_iff (full characterization), and ed_crt_list_unique (uniqueness mod listLcm).",
+      "mathContext": "Exists x satisfying the system iff Compatible(sys). Solutions unique mod lcm(m1,...,mk)."
+    },
+    {
+      "id": "coprime-connection",
+      "title": "Connection to Coprime Case",
+      "startLine": 202,
+      "endLine": 215,
+      "summary": "coprime_implies_compatible: when all pairwise GCDs are units (the coprime case), compatibility is automatic. Recovers the coprime CRT as a special case.",
+      "mathContext": "IsUnit(gcd(mi, mj)) for all i != j implies Compatible(sys), so a solution always exists in the coprime case."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization answers the third open question from the coprime list CRT (chinese-remainder-constructive-oq-04): yes, the pairwise coprimality condition can be weakened to the GCD compatibility condition, and the result generalizes to arbitrary-length lists. The proof works over any Euclidean domain, making it applicable beyond integers to polynomial rings and other algebraic structures. Both existence-iff-compatibility and uniqueness-mod-LCM are proved with 0 axioms and 0 sorries.",
+    "implications": "**Mathematical significance**: This completes the CRT generalization program: from fixed-size coprime systems (parent proof) to arbitrary-length coprime lists (OQ04) to arbitrary-length non-coprime lists (this file). The non-coprime case is strictly more general, with the coprime case recovered as a corollary.\n\n**Algebraic generality**: Working over Euclidean domains means these results apply to:\n- Z (integers): the classical setting for modular arithmetic\n- Z[i] (Gaussian integers): for 2D lattice problems\n- F[x] (polynomial rings): for interpolation and coding theory\n- Any principal ideal domain (via the EuclideanDomain instance)\n\n**Applications**: Non-coprime CRT is essential in:\n1. Signal processing: when sampling rates share common factors\n2. Cryptographic protocols: where moduli may share small prime factors\n3. Calendar computations: cycles with shared divisors (e.g., 12-month and 52-week cycles)\n4. Error-correcting codes: redundant modular representations",
+    "openQuestions": [
+      "Can the solution construction be made computationally efficient? The current proof is existential via the two-moduli CRT; an explicit formula using generalized Bezout coefficients would enable verified computation.",
+      "What is the relationship between listLcm and Mathlib's Finset.lcm? Can this formalization be unified with Mathlib's existing algebraic CRT infrastructure?",
+      "For the natural number case, can we produce the minimal non-negative solution and bound it by listLcm?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.ChineseRemainderNonCoprimeOQ03"
+    ],
+    "opens": [
+      "ChineseRemainderNonCoprimeOQ03"
+    ],
+    "namespace": "ChineseRemainderNonCoprimeList",
+    "lineCount": 216,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 5
+  },
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-constructive-oq-04",
+      "relationship": "answers",
+      "description": "Answers OQ04's third open question: 'Can the pairwise coprimality condition be weakened?'"
+    },
+    {
+      "targetId": "chinese-remainder-non-coprime",
+      "relationship": "extends",
+      "description": "Extends the two-moduli non-coprime CRT to arbitrary-length lists"
+    },
+    {
+      "targetId": "chinese-remainder-non-coprime-oq-01",
+      "relationship": "relates",
+      "description": "OQ01 addresses computational efficiency; this file provides the general existence/uniqueness framework"
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "generalizes",
+      "description": "The coprime case (parent proof) is recovered as a special case via coprime_implies_compatible"
+    }
+  ],
+  "references": [
+    {
+      "key": "Or52",
+      "citation": "Ore, O., The General Chinese Remainder Theorem, American Mathematical Monthly 59(6):365-370 (1952). First modern treatment for non-coprime moduli.",
+      "type": "article"
+    },
+    {
+      "key": "Ga01",
+      "citation": "Gauss, C.F., Disquisitiones Arithmeticae, Leipzig (1801), Section 36. Classical CRT for coprime moduli.",
+      "type": "book"
+    },
+    {
+      "key": "DF04",
+      "citation": "Dummit, D.S. and Foote, R.M., Abstract Algebra, 3rd ed., Wiley (2004), Section 7.6. CRT for rings via ideals and direct products.",
+      "type": "book"
+    }
+  ]
+}

--- a/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-03.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "chinese-remainder-constructive-oq-04-oq-03",
   "title": "Can the pairwise coprimality condition be weakened",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "graduated",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "COMPLETED",
     "since": "2026-03-28T20:58:08-07:00",
     "iteration": 1,
-    "focus": "Surveyed non-coprime CRT generalization path",
+    "focus": "Gallery entry created for fully verified proof",
     "blockers": [],
-    "nextAction": "Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.",
+    "nextAction": "None - problem fully resolved",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,12 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: OQ03 fully verified. Proved mersenne_coprime_of_coprime (Euclidean algorithm approach). Removed false primorial axiom, proved restricted version. File: 0A 0S, status verified.",
+    "progressSummary": "COMPLETED: Non-coprime CRT generalized to arbitrary lists over Euclidean domains. ChineseRemainderNonCoprimeList.lean: 0A 0S. Gallery entry created. Answers OQ04 third open question.",
     "builtItems": [
       "mersenne_mod_eq helper lemma in ChineseRemainderConstructiveOQ03.lean",
       "mul_add_mod_eq helper lemma for modular arithmetic",
       "Proved mersenne_coprime_of_coprime theorem",
-      "Proved primorial_growth_lower (restricted to k<=6)"
+      "Proved primorial_growth_lower (restricted to k<=6)",
+      "Gallery entry: chinese-remainder-constructive-oq-04-oq-03 with meta.json, annotations.json, index.ts"
     ],
     "insights": [
       "OQ04 (CRT for arbitrary lists) is clean: 0A 0S 4T. The coprime case is fully solved.",
@@ -45,7 +46,9 @@
       "mersenne_coprime_of_coprime PROVED via Euclidean algorithm on exponents + strong induction on a",
       "Key helper: mersenne_mod_eq shows (2^b-1) % (2^a-1) = 2^(b%a)-1 using pow_two_mod_mersenne",
       "False axiom primorial_growth_lower REMOVED: primorial lookup table returns 0 for k>=7, making universal bound false. Replaced with proved theorem restricted to k<=6",
-      "OQ03 file now 0 axioms, 0 sorries: fully verified"
+      "OQ03 file now 0 axioms, 0 sorries: fully verified",
+      "Proof was already complete in ChineseRemainderNonCoprimeList.lean (0A 0S) - needed gallery integration",
+      "Works over arbitrary Euclidean domains, not just naturals or integers"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Created gallery entry for `ChineseRemainderNonCoprimeList.lean` (0 axioms, 0 sorries)
- Answers OQ04's third open question: "Can the pairwise coprimality condition be weakened?"
- Yes: the non-coprime CRT generalizes to arbitrary-length lists over Euclidean domains
- Full iff characterization: solvable iff pairwise GCD compatibility holds
- Solutions unique modulo LCM of all moduli

## Files
- `src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json` — gallery metadata
- `src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/annotations.json` — section annotations
- `src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/index.ts` — TypeScript module
- `src/data/research/problems/chinese-remainder-constructive-oq-04-oq-03.json` — problem status → graduated

## Key Theorems (in existing ChineseRemainderNonCoprimeList.lean)
- `ed_crt_list_iff`: Full solvability characterization
- `ed_crt_list_unique`: Uniqueness mod listLcm
- `gcd_listLcm_dvd_listLcm_gcd`: Extended distributive law for lists
- `coprime_implies_compatible`: Coprime CRT as special case

Generated by researcher-6