### PR TITLE
fix(metadata): CRITICAL revert 7 false "verified" statuses (have sorries)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Archimedes (c. 250 BCE), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Archimedes",
     "date": "-250",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "geometry",
       "analysis",
@@ -18,8 +18,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cycle_lemma",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,8 +18,8 @@
       "finset",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid; formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euclid%27s_lemma",
     "date": "~300 BCE",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -15,8 +15,8 @@
       "algorithms",
       "research"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Int.mul_ediv_cancel'",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,8 +17,8 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,10 +7,10 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "original",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 1,
     "tags": [
       "combinatorics",
       "permutations",

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Euclid-style argument)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions#Special_cases",
     "date": "classical",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/DirichletsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -18,8 +18,8 @@
       "elementary",
       "research"
     ],
-    "badge": "original",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Nat.exists_prime_and_dvd",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "formalized",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",


### PR DESCRIPTION
## Fix

Revert 7 gallery proofs from `verified` → `formalized` status. Each proof has sorries in
the Lean source but was incorrectly marked as `verified` with `sorries: 0`.

## Affected proofs

| Proof | Actual sorries | Old status | New status |
|-------|---------------|------------|------------|
| area-of-circle-oq-03-oq-02 | 1 | verified | formalized |
| ballot-problem-oq-01-oq-01 | 2 | verified | formalized |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | 1 | verified | formalized |
| cayley-hamilton-minpoly-oq-05-oq-01 | 1 | verified | formalized |
| derangements-oq-02 | 1 | verified | formalized |
| dirichlets-theorem-oq-02 | 1 | verified | formalized |
| erdos-1006-oq-02-oq-03 | 1 | verified | formalized |

## Evidence

**Before**: `"status": "verified", "sorries": 0` — but Lean source files contain `sorry`
**After**: `"status": "formalized", "sorries": <actual count>` — matches Lean source

---
Automated fix by lean-mechanic agent.