### PR TITLE
Research: erdos-14 — prove 3 sorries in Erdos140Problem.lean (0 remaining)

### DIFF
--- a/proofs/Proofs/Erdos140Problem.lean
+++ b/proofs/Proofs/Erdos140Problem.lean
@@ -132,21 +132,58 @@ theorem erdos_140_solved : KelleyMekaTheorem := kelley_meka
 theorem r3_superlogarithmic (C : ℝ) (hC : C > 0) :
     ∀ ε > 0, ∃ N₀ : ℕ, ∀ N ≥ N₀, (r3 N : ℝ) < ε * N / (Real.log N)^C := by
   intro ε hε
-  -- Apply Kelley-Meka with exponent C + 1
   obtain ⟨K, hK, hbound⟩ := kelley_meka (C + 1) (by linarith)
-  use max 3 (Nat.ceil (Real.exp (K / ε)))
+  use max 3 (Nat.ceil (Real.exp (K / ε)) + 1)
   intro N hN
   have hN3 : N ≥ 3 := le_of_max_le_left hN
-  -- For large N, r₃(N) ≤ K·N/(log N)^{C+1} < ε·N/(log N)^C
-  sorry
+  have hN_pos : (0 : ℝ) < (N : ℝ) := by positivity
+  have hlogN_pos : 0 < Real.log (N : ℝ) := Real.log_pos (by push_cast; omega)
+  have hlogC1_pos : 0 < (Real.log (N : ℝ)) ^ (C + 1) := rpow_pos_of_pos hlogN_pos _
+  have hlogC_pos : 0 < (Real.log (N : ℝ)) ^ C := rpow_pos_of_pos hlogN_pos _
+  -- Key: exp(K/ε) < N, hence K/ε < log N, hence K < ε · log N
+  have hN_gt_exp : Real.exp (K / ε) < (N : ℝ) := by
+    have h1 : Nat.ceil (Real.exp (K / ε)) + 1 ≤ N := le_of_max_le_right hN
+    have h2 : Real.exp (K / ε) ≤ ↑(Nat.ceil (Real.exp (K / ε))) := Nat.le_ceil _
+    have h3 : (↑(Nat.ceil (Real.exp (K / ε)) + 1) : ℝ) ≤ (N : ℝ) := Nat.cast_le.mpr h1
+    simp only [Nat.cast_add, Nat.cast_one] at h3; linarith
+  have hK_lt : K < ε * Real.log (N : ℝ) := by
+    have hlog_gt : K / ε < Real.log (N : ℝ) := by
+      calc K / ε = Real.log (Real.exp (K / ε)) := (Real.log_exp _).symm
+        _ < Real.log ↑N := Real.log_lt_log (Real.exp_pos _) hN_gt_exp
+    rwa [div_lt_iff hε] at hlog_gt
+  calc (r3 N : ℝ)
+      ≤ K * ↑N / (Real.log ↑N) ^ (C + 1) := hbound N hN3
+    _ < ε * ↑N / (Real.log ↑N) ^ C := by
+        rw [div_lt_div_iff₀ hlogC1_pos hlogC_pos, rpow_add hlogN_pos, rpow_one]
+        calc K * ↑N * (Real.log ↑N) ^ C
+            = K * (↑N * (Real.log ↑N) ^ C) := by ring
+          _ < ε * Real.log ↑N * (↑N * (Real.log ↑N) ^ C) :=
+              mul_lt_mul_of_pos_right hK_lt (mul_pos hN_pos hlogC_pos)
+          _ = ε * ↑N * ((Real.log ↑N) ^ C * Real.log ↑N) := by ring
 
 /-- Density of 3-AP-free sets tends to 0 faster than any inverse power of log. -/
 theorem r3_density_vanishes : ∀ C > 0, Filter.Tendsto
     (fun N => (r3 N : ℝ) * (Real.log N)^C / N) Filter.atTop (nhds 0) := by
   intro C hC
-  -- Follows from Kelley-Meka: (r3 N) * (log N)^C / N ≤ K for all N
-  -- So (r3 N) * (log N)^C / N ≤ K * (log N)^C / (log N)^(C+1) = K / log N → 0
-  sorry
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  obtain ⟨N₀, hN₀⟩ := r3_superlogarithmic C hC ε hε
+  use max N₀ 3
+  intro N hN
+  have hNN₀ : N ≥ N₀ := le_trans (le_max_left _ _) hN
+  have hN3 : N ≥ 3 := le_trans (le_max_right _ _) hN
+  have hN_pos : (0 : ℝ) < (N : ℝ) := by positivity
+  have hlogN_pos : 0 < Real.log (N : ℝ) := Real.log_pos (by push_cast; omega)
+  have hlogC_pos : 0 < (Real.log (N : ℝ)) ^ C := rpow_pos_of_pos hlogN_pos _
+  rw [dist_zero_right, Real.norm_of_nonneg (by positivity)]
+  -- From r3_superlogarithmic: r3(N) < ε * N / (log N)^C
+  -- Multiply by (log N)^C / N to get r3(N) * (log N)^C / N < ε
+  have h := hN₀ N hNN₀
+  rw [div_lt_iff₀ hN_pos]
+  calc (r3 N : ℝ) * (Real.log ↑N) ^ C
+      < ε * ↑N / (Real.log ↑N) ^ C * (Real.log ↑N) ^ C :=
+        mul_lt_mul_of_pos_right h hlogC_pos
+    _ = ε * ↑N := by rw [div_mul_cancel₀ _ hlogC_pos.ne']
 
 /- ## Lower Bounds -/
 
@@ -183,12 +220,20 @@ example : Finset3APFree {1, 2, 4, 5, 10, 11, 13, 14} := by
 
 /- ## The Greedy 3-AP-Free Sequence -/
 
+/-- Convert n to base 3 using only binary digits: the n-th element of the Stanley
+    sequence (A005836). Interprets the binary representation of n in base 3. -/
+private def toBase3Binary : ℕ → ℕ
+  | 0 => 0
+  | n + 1 => (n + 1) % 2 + 3 * toBase3Binary ((n + 1) / 2)
+  decreasing_by exact Nat.div_lt_self (Nat.succ_pos n) (by norm_num)
+
 /-- The greedy 3-AP-free sequence A003278:
     Start with 1, then add the smallest integer that doesn't create a 3-AP.
-    Yields: 1, 2, 4, 5, 10, 11, 13, 14, 28, 29, ... -/
-def greedyAP3Free : ℕ → ℕ
-  | 0 => 1
-  | n + 1 => sorry -- Need to find smallest k > greedyAP3Free n not creating 3-AP
+    Yields: 1, 2, 4, 5, 10, 11, 13, 14, 28, 29, ...
+
+    Equivalent to the Stanley sequence (A005836) shifted by 1: numbers whose
+    base-3 representation uses only digits {0, 1}, plus 1. -/
+def greedyAP3Free (n : ℕ) : ℕ := toBase3Binary n + 1
 
 /-- The greedy sequence is indeed 3-AP-free. -/
 axiom greedy_is_3APFree : ∀ n : ℕ,

--- a/proofs/Proofs/Erdos367Problem.lean
+++ b/proofs/Proofs/Erdos367Problem.lean
@@ -178,8 +178,45 @@ van Doorn showed the strong bound fails for k ≥ 3.
 
 There exist infinitely many n with ∏_{n ≤ m < n+3} B₂(m) ≫ n² · log n,
 so no constant C can satisfy ∏B₂(m) ≤ C · n² for all n.
--/
-axiom strong_bound_fails_k3 : ¬ strongBound 3
+
+Proof: van Doorn's lower bound gives product ≥ c·n²·log(n) for infinitely
+many n. If strongBound 3 held (product ≤ C·n² for all n ≥ 1), then
+C ≥ c·log(n) for arbitrarily large n, contradicting C being fixed. -/
+theorem strong_bound_fails_k3 : ¬ strongBound 3 := by
+  intro ⟨C, hC, hbound⟩
+  obtain ⟨c, hc, hvan⟩ := van_doorn_lower_bound
+  -- Choose M large enough that log(n) > C/c for n ≥ M
+  set M := Nat.ceil (Real.exp (C / c + 1)) + 1 with hM_def
+  obtain ⟨n, hn_ge, hprod⟩ := hvan M
+  have hn1 : (1 : ℕ) ≤ n := by omega
+  have hstrong := hbound n hn1
+  -- Key: c·n²·log(n) ≤ product ≤ C·n²
+  have h_ineq : c * (n : ℝ) ^ 2 * Real.log n ≤ C * (n : ℝ) ^ 2 := by linarith
+  have hnsq_pos : (0 : ℝ) < (n : ℝ) ^ 2 := by positivity
+  -- Dividing by n² > 0: c·log(n) ≤ C
+  have h_clog : c * Real.log n ≤ C := by
+    by_contra h; push_neg at h
+    linarith [mul_lt_mul_of_pos_right h hnsq_pos]
+  -- But n ≥ M ≥ exp(C/c + 1), so log(n) ≥ C/c + 1 > C/c
+  have h_exp_le : Real.exp (C / c + 1) ≤ (n : ℝ) := by
+    calc Real.exp (C / c + 1)
+        ≤ ↑(Nat.ceil (Real.exp (C / c + 1))) :=
+          Nat.le_ceil (Real.exp (C / c + 1))
+      _ ≤ ↑(Nat.ceil (Real.exp (C / c + 1)) + 1) := by
+          exact_mod_cast Nat.le_succ _
+      _ = (M : ℝ) := by rfl
+      _ ≤ (n : ℝ) := by exact_mod_cast hn_ge
+  have h_log_large : C / c + 1 ≤ Real.log n := by
+    calc C / c + 1
+        = Real.log (Real.exp (C / c + 1)) := (Real.log_exp _).symm
+      _ ≤ Real.log ↑n :=
+          Real.log_le_log (Real.exp_pos _) h_exp_le
+  -- So c·log(n) ≥ c·(C/c + 1) = C + c > C
+  have h_clog_large : C < c * Real.log n := by
+    have : c * (C / c + 1) ≤ c * Real.log n :=
+      mul_le_mul_of_nonneg_left h_log_large hc.le
+    linarith [mul_div_cancel₀ C (ne_of_gt hc)]
+  linarith
 
 /--
 **van Doorn's Lower Bound**

--- a/proofs/Proofs/Erdos896Problem.lean
+++ b/proofs/Proofs/Erdos896Problem.lean
@@ -197,6 +197,36 @@ theorem uniqueProductCount_singletons (a b : ℕ) :
   simp [Finset.product_singleton_right, Finset.product_singleton_left,
         Finset.filter_singleton, Finset.image_singleton]
 
+/-- F({a}, B) = |B| for a ≥ 1: the map b ↦ ab is injective, so each product
+    has exactly one representation, making all products unique. -/
+theorem uniqueProductCount_singleton_left (a : ℕ) (B : Finset ℕ) (ha : 0 < a) :
+    uniqueProductCount {a} B = B.card := by
+  unfold uniqueProductCount reprCount
+  -- Image = B.image (a * ·) which has |B| elements by injectivity of (a * ·)
+  have h_img : ({a} ×ˢ B).image (fun p : ℕ × ℕ => p.1 * p.2) = B.image (a * ·) := by
+    ext m; simp only [Finset.mem_image, Finset.mem_product, Finset.mem_singleton, Prod.exists]
+    constructor
+    · rintro ⟨x, y, ⟨rfl, hy⟩, hxy⟩; exact ⟨y, hy, hxy⟩
+    · rintro ⟨y, hy, rfl⟩; exact ⟨a, y, ⟨rfl, hy⟩, rfl⟩
+  -- Each product has reprCount = 1 (unique factorization since a > 0)
+  have h_repr : ∀ m ∈ B.image (a * ·),
+      (({a} ×ˢ B).filter (fun p => p.1 * p.2 = m)).card = 1 := by
+    intro m hm
+    obtain ⟨b, hb, rfl⟩ := Finset.mem_image.mp hm
+    suffices ({a} ×ˢ B).filter (fun p => p.1 * p.2 = a * b) = {(a, b)} by rw [this]; simp
+    ext ⟨x, y⟩
+    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_singleton, Prod.mk.injEq]
+    constructor
+    · rintro ⟨⟨rfl, hy⟩, hxy⟩; exact ⟨rfl, Nat.eq_of_mul_eq_left ha hxy⟩
+    · rintro ⟨rfl, rfl⟩; exact ⟨⟨rfl, hb⟩, rfl⟩
+  rw [h_img, Finset.filter_true_of_mem h_repr,
+      Finset.card_image_of_injective B (fun _ _ h => Nat.eq_of_mul_eq_left ha h)]
+
+/-- F(A, {b}) = |A| for b ≥ 1, by commutativity. -/
+theorem uniqueProductCount_singleton_right (A : Finset ℕ) (b : ℕ) (hb : 0 < b) :
+    uniqueProductCount A {b} = A.card := by
+  rw [uniqueProductCount_comm]; exact uniqueProductCount_singleton_left b A hb
+
 /-- maxUniqueProducts N ≥ 1 for N ≥ 1: singleton subsets {1}×{1} give F = 1. -/
 theorem maxUniqueProducts_pos (N : ℕ) (hN : 1 ≤ N) :
     1 ≤ maxUniqueProducts N := by

--- a/proofs/Proofs/Erdos896Problem.lean
+++ b/proofs/Proofs/Erdos896Problem.lean
@@ -209,6 +209,49 @@ theorem maxUniqueProducts_pos (N : ℕ) (hN : 1 ≤ N) :
         (Finset.mem_Icc.mpr ⟨le_refl 1, hN⟩))⟩)
   exact le_of_eq (uniqueProductCount_singletons 1 1).symm
 
+/-- F(Icc 1 N, {1}) = card(Icc 1 N): for B = {1}, every product a·1 = a
+    has exactly one representation, so all products are unique. -/
+theorem uniqueProductCount_range_one (N : ℕ) :
+    uniqueProductCount (Finset.Icc 1 N) {1} = (Finset.Icc 1 N).card := by
+  unfold uniqueProductCount reprCount
+  -- Image = Icc 1 N (since a·1 = a)
+  have h_img : (Finset.Icc 1 N ×ˢ ({1} : Finset ℕ)).image
+      (fun p : ℕ × ℕ => p.1 * p.2) = Finset.Icc 1 N := by
+    ext m
+    simp only [Finset.mem_image, Finset.mem_product, Finset.mem_Icc,
+      Finset.mem_singleton, Prod.exists]
+    constructor
+    · rintro ⟨a, b, ⟨ha, rfl⟩, hab⟩; simp only [mul_one] at hab; rwa [← hab]
+    · intro hm; exact ⟨m, 1, ⟨hm, rfl⟩, mul_one m⟩
+  -- Each m ∈ Icc 1 N has exactly one pair (m, 1) in the filter
+  have h_repr : ∀ m ∈ Finset.Icc 1 N,
+      ((Finset.Icc 1 N ×ˢ ({1} : Finset ℕ)).filter
+        (fun p => p.1 * p.2 = m)).card = 1 := by
+    intro m hm
+    suffices (Finset.Icc 1 N ×ˢ ({1} : Finset ℕ)).filter
+        (fun p => p.1 * p.2 = m) = {(m, 1)} by rw [this]; simp
+    ext ⟨x, y⟩
+    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_Icc,
+      Finset.mem_singleton, Prod.mk.injEq]
+    constructor
+    · rintro ⟨⟨hx, rfl⟩, hxy⟩; exact ⟨by omega, rfl⟩
+    · rintro ⟨rfl, rfl⟩; exact ⟨⟨hm, rfl⟩, by simp⟩
+  rw [h_img, Finset.filter_true_of_mem h_repr]
+
+/-- maxUniqueProducts N ≥ N for N ≥ 1: the pair A = {1,...,N}, B = {1}
+    gives F(A,{1}) = N since each product a·1 = a is unique. -/
+theorem maxUniqueProducts_ge_range (N : ℕ) (hN : 1 ≤ N) :
+    N ≤ maxUniqueProducts N := by
+  have hcard : (Finset.Icc 1 N).card = N := by rw [Finset.card_Icc]; omega
+  calc N = (Finset.Icc 1 N).card := hcard.symm
+    _ = uniqueProductCount (Finset.Icc 1 N) {1} := (uniqueProductCount_range_one N).symm
+    _ ≤ maxUniqueProducts N := by
+        unfold maxUniqueProducts
+        exact Finset.le_sup (Finset.mem_product.mpr
+          ⟨Finset.mem_powerset.mpr le_rfl,
+           Finset.mem_powerset.mpr (Finset.singleton_subset_iff.mpr
+            (Finset.mem_Icc.mpr ⟨le_refl 1, hN⟩))⟩)
+
 /-
 ## Monotonicity and Bounds
 -/

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-367",
-  "title": "Erdős Problem #367: Products of 2-Full Parts",
+  "title": "Erd\u0151s Problem #367: Products of 2-Full Parts",
   "slug": "erdos-367",
-  "description": "For fixed k ≥ 1, is ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)}? The strong bound ≪ n² holds for k ≤ 2 but fails for k ≥ 3 (van Doorn). OPEN.",
+  "description": "For fixed k \u2265 1, is \u220f_{n \u2264 m < n+k} B\u2082(m) \u226a n^{2+o(1)}? The strong bound \u226a n\u00b2 holds for k \u2264 2 but fails for k \u2265 3 (van Doorn). OPEN.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/367",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos367Problem.lean",
@@ -46,23 +46,23 @@
     ],
     "originalContributions": [
       "squarefreePart: product of primes with exponent 1",
-      "twoFullPart: B₂(n) = n/squarefreePart(n)",
-      "twoFullPartAlt: B₂(n) via prime factorization filter",
+      "twoFullPart: B\u2082(n) = n/squarefreePart(n)",
+      "twoFullPartAlt: B\u2082(n) via prime factorization filter",
       "productTwoFullParts: product over Finset.Ico",
       "weakBound, strongBound: formal propositions for the bounds",
-      "erdos_367_conjecture: weakBound for all k ≥ 1",
+      "erdos_367_conjecture: weakBound for all k \u2265 1",
       "rFullPart: generalization to r-full parts",
       "twoFullPart_eq_rFullPart: proved consistency by rfl",
       "generalizedConjecture: r-full version",
       "erdos_367_summary: proved conjunction of known results",
-      "twoFullPart_le: proved B₂(n) ≤ n from definition",
-      "twoFullPart_dvd: proved B₂(n) | n from definition",
-      "twoFullPart_prime: proved B₂(p) = 1 via squarefreePart computation",
-      "twoFullPart_prime_sq: proved B₂(p²) = p² via squarefreePart computation",
+      "twoFullPart_le: proved B\u2082(n) \u2264 n from definition",
+      "twoFullPart_dvd: proved B\u2082(n) | n from definition",
+      "twoFullPart_prime: proved B\u2082(p) = 1 via squarefreePart computation",
+      "twoFullPart_prime_sq: proved B\u2082(p\u00b2) = p\u00b2 via squarefreePart computation",
       "strong_bound_k1: proved strongBound(1) via twoFullPart_le and Finset.prod_singleton",
       "strong_bound_k2: proved strongBound(2) via twoFullPart_le, mul_le_mul, and nlinarith"
     ],
-    "axiomCount": 5,
+    "axiomCount": 4,
     "prerequisites": [
       "Prime factorization and p-adic valuations",
       "Squarefree numbers and powerful (k-full) numbers",
@@ -72,19 +72,19 @@
     ],
     "date": "1980",
     "lineCount": 388,
-    "assumptions": "5 axioms: strong_bound_fails_k3, van_doorn_lower_bound, twoFullPart_eq_one_iff, twoFullPart_mul_coprime, average_twoFullPart_bounded. 6 former axioms proved: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq, strong_bound_k1, strong_bound_k2."
+    "assumptions": "4 axioms: van_doorn_lower_bound, twoFullPart_eq_one_iff, twoFullPart_mul_coprime, average_twoFullPart_bounded. 7 former axioms proved: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq, strong_bound_k1, strong_bound_k2, strong_bound_fails_k3 (proved from van_doorn_lower_bound via log\u2192\u221e argument)."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #367: Products of 2-Full Parts**\n\nThis problem connects two classical themes in multiplicative number theory: the distribution of powerful numbers and the multiplicative structure of consecutive integers.\n\n**Background:** The 2-full (or squareful) part $B_2(n)$ captures the 'square content' of $n$'s prime factorization. Golomb (1970) introduced powerful numbers (where every prime divides with exponent $\\geq 2$) and studied their distribution. The function $B_2$ generalizes this: $B_2(n) = \\prod_{v_p(n) \\geq 2} p^{v_p(n)}$ extracts the powerful component from any integer.\n\n**The problem:** Erdős asked whether $\\prod_{n \\leq m < n+k} B_2(m) \\ll n^{2+o(1)}$ for every fixed $k$. The exponent 2 is natural: since $B_2(n) \\leq n$, the product of $k$ terms is at most $n^k$, but heuristically most $B_2(m)$ are small, so the 'effective' exponent should be much less than $k$.\n\n**Progress:**\n- For $k \\leq 2$: the strong bound $\\ll n^2$ holds trivially ($B_2(n) \\leq n$).\n- **van Doorn (2023):** Proved the strong bound **fails** for $k \\geq 3$. Specifically, there exist infinitely many $n$ with $\\prod_{m=n}^{n+2} B_2(m) \\gg n^2 \\log n$. The construction uses the Chinese Remainder Theorem to find $n$ where multiple consecutive integers have large square factors.\n- The **weak bound** $n^{2+o(1)}$ (with the logarithmic slack) remains open for all $k \\geq 3$.",
-    "problemStatement": "Let B₂(n) = n/squarefreePart(n) denote the 2-full part. For every fixed k ≥ 1, is it true that ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)}? Or perhaps even ≪_k n²?",
-    "text": "For fixed k ≥ 1, is ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)}? The strong bound ≪ n² holds for k ≤ 2 but fails for k ≥ 3 (van Doorn). OPEN.",
-    "proofStrategy": "The formalization defines squarefreePart, twoFullPart, and productTwoFullParts. Weak and strong bounds are defined as propositions. Known results (k ≤ 2 strong bound, k ≥ 3 failure, van Doorn lower bound) are axioms. Four key properties of B₂ are proved from the definition: B₂(n) ≤ n, B₂(n) | n, B₂(p) = 1 for primes, B₂(p²) = p² for primes. Remaining properties (squarefree characterization, multiplicativity, average bound) are axioms. The r-full generalization is defined with a proved consistency theorem. A summary theorem combines the known results.",
+    "historicalContext": "**Erd\u0151s Problem #367: Products of 2-Full Parts**\n\nThis problem connects two classical themes in multiplicative number theory: the distribution of powerful numbers and the multiplicative structure of consecutive integers.\n\n**Background:** The 2-full (or squareful) part $B_2(n)$ captures the 'square content' of $n$'s prime factorization. Golomb (1970) introduced powerful numbers (where every prime divides with exponent $\\geq 2$) and studied their distribution. The function $B_2$ generalizes this: $B_2(n) = \\prod_{v_p(n) \\geq 2} p^{v_p(n)}$ extracts the powerful component from any integer.\n\n**The problem:** Erd\u0151s asked whether $\\prod_{n \\leq m < n+k} B_2(m) \\ll n^{2+o(1)}$ for every fixed $k$. The exponent 2 is natural: since $B_2(n) \\leq n$, the product of $k$ terms is at most $n^k$, but heuristically most $B_2(m)$ are small, so the 'effective' exponent should be much less than $k$.\n\n**Progress:**\n- For $k \\leq 2$: the strong bound $\\ll n^2$ holds trivially ($B_2(n) \\leq n$).\n- **van Doorn (2023):** Proved the strong bound **fails** for $k \\geq 3$. Specifically, there exist infinitely many $n$ with $\\prod_{m=n}^{n+2} B_2(m) \\gg n^2 \\log n$. The construction uses the Chinese Remainder Theorem to find $n$ where multiple consecutive integers have large square factors.\n- The **weak bound** $n^{2+o(1)}$ (with the logarithmic slack) remains open for all $k \\geq 3$.",
+    "problemStatement": "Let B\u2082(n) = n/squarefreePart(n) denote the 2-full part. For every fixed k \u2265 1, is it true that \u220f_{n \u2264 m < n+k} B\u2082(m) \u226a n^{2+o(1)}? Or perhaps even \u226a_k n\u00b2?",
+    "text": "For fixed k \u2265 1, is \u220f_{n \u2264 m < n+k} B\u2082(m) \u226a n^{2+o(1)}? The strong bound \u226a n\u00b2 holds for k \u2264 2 but fails for k \u2265 3 (van Doorn). OPEN.",
+    "proofStrategy": "The formalization defines squarefreePart, twoFullPart, and productTwoFullParts. Weak and strong bounds are defined as propositions. Known results (k \u2264 2 strong bound, k \u2265 3 failure, van Doorn lower bound) are axioms. Four key properties of B\u2082 are proved from the definition: B\u2082(n) \u2264 n, B\u2082(n) | n, B\u2082(p) = 1 for primes, B\u2082(p\u00b2) = p\u00b2 for primes. Remaining properties (squarefree characterization, multiplicativity, average bound) are axioms. The r-full generalization is defined with a proved consistency theorem. A summary theorem combines the known results.",
     "keyInsights": [
-      "B₂(n) = 1 when n is squarefree; B₂(n) = n when n is a perfect power",
-      "For k ≤ 2, ∏B₂(m) ≤ n² holds trivially since B₂(n) ≤ n",
-      "van Doorn: for k = 3, ∏B₂(m) can be ≫ n²·log n, so strong bound fails",
-      "The weak bound n^{2+o(1)} remains open — the gap is the logarithmic factor",
-      "The problem generalizes to r-full parts B_r(n) for r ≥ 3"
+      "B\u2082(n) = 1 when n is squarefree; B\u2082(n) = n when n is a perfect power",
+      "For k \u2264 2, \u220fB\u2082(m) \u2264 n\u00b2 holds trivially since B\u2082(n) \u2264 n",
+      "van Doorn: for k = 3, \u220fB\u2082(m) can be \u226b n\u00b2\u00b7log n, so strong bound fails",
+      "The weak bound n^{2+o(1)} remains open \u2014 the gap is the logarithmic factor",
+      "The problem generalizes to r-full parts B_r(n) for r \u2265 3"
     ],
     "prerequisites": [
       "Prime factorization and p-adic valuations",
@@ -100,7 +100,7 @@
       "title": "Part 1: The 2-Full Part",
       "startLine": 39,
       "endLine": 73,
-      "summary": "Defines squarefreePart (primes with exponent 1), twoFullPart (B₂ = n/squarefreePart), and twoFullPartAlt (B₂ via factorization filter).",
+      "summary": "Defines squarefreePart (primes with exponent 1), twoFullPart (B\u2082 = n/squarefreePart), and twoFullPartAlt (B\u2082 via factorization filter).",
       "mathContext": "$B_2(n) = \\prod_{v_p(n) \\geq 2} p^{v_p(n)}$, e.g., $B_2(12) = B_2(2^2 \\cdot 3) = 4$"
     },
     {
@@ -108,7 +108,7 @@
       "title": "Part 2: Product over Consecutive Integers",
       "startLine": 74,
       "endLine": 88,
-      "summary": "Defines productTwoFullParts(n, k) = ∏_{m ∈ Ico(n, n+k)} B₂(m), the main object of study.",
+      "summary": "Defines productTwoFullParts(n, k) = \u220f_{m \u2208 Ico(n, n+k)} B\u2082(m), the main object of study.",
       "mathContext": "$\\text{productTwoFullParts}(n, k) = \\prod_{m=n}^{n+k-1} B_2(m)$"
     },
     {
@@ -116,39 +116,39 @@
       "title": "Part 3: The Bounds",
       "startLine": 89,
       "endLine": 112,
-      "summary": "Defines weakBound(k): ∀ε>0, product ≤ C·n^{2+ε}; and strongBound(k): product ≤ C·n². The two asymptotic regimes.",
+      "summary": "Defines weakBound(k): \u2200\u03b5>0, product \u2264 C\u00b7n^{2+\u03b5}; and strongBound(k): product \u2264 C\u00b7n\u00b2. The two asymptotic regimes.",
       "mathContext": "Weak: $\\forall \\varepsilon > 0, \\exists C : \\prod B_2(m) \\leq C n^{2+\\varepsilon}$. Strong: $\\exists C : \\prod B_2(m) \\leq C n^2$"
     },
     {
       "id": "conjecture",
-      "title": "Part 4: The Erdős Conjecture",
+      "title": "Part 4: The Erd\u0151s Conjecture",
       "startLine": 113,
       "endLine": 128,
-      "summary": "erdos_367_conjecture: weakBound(k) holds for all k ≥ 1. The main open question.",
+      "summary": "erdos_367_conjecture: weakBound(k) holds for all k \u2265 1. The main open question.",
       "mathContext": "$\\forall k \\geq 1 : \\prod_{m=n}^{n+k-1} B_2(m) \\ll n^{2+o(1)}$"
     },
     {
       "id": "trivial-cases",
-      "title": "Part 5: Trivial Cases (k ≤ 2)",
+      "title": "Part 5: Trivial Cases (k \u2264 2)",
       "startLine": 129,
       "endLine": 148,
-      "summary": "Proves strongBound for k=1 (B₂(n) ≤ n ≤ n²) and k=2 (B₂(n)·B₂(n+1) ≤ n(n+1) < 2n²) from twoFullPart_le.",
+      "summary": "Proves strongBound for k=1 (B\u2082(n) \u2264 n \u2264 n\u00b2) and k=2 (B\u2082(n)\u00b7B\u2082(n+1) \u2264 n(n+1) < 2n\u00b2) from twoFullPart_le.",
       "mathContext": "$k=1: B_2(n) \\leq n^2$. $k=2: B_2(n) B_2(n+1) \\leq n(n+1) < 2n^2$"
     },
     {
       "id": "failure",
-      "title": "Part 6: Failure of Strong Bound (k ≥ 3)",
+      "title": "Part 6: Failure of Strong Bound (k \u2265 3)",
       "startLine": 149,
       "endLine": 172,
-      "summary": "van Doorn: ¬strongBound(3) and lower bound ∃c>0: ∏B₂(m) ≥ c·n²·log(n) infinitely often.",
+      "summary": "van Doorn: \u00acstrongBound(3) and lower bound \u2203c>0: \u220fB\u2082(m) \u2265 c\u00b7n\u00b2\u00b7log(n) infinitely often.",
       "mathContext": "$\\exists c > 0 : \\forall N, \\exists n \\geq N : \\prod_{m=n}^{n+2} B_2(m) \\geq c n^2 \\log n$"
     },
     {
       "id": "properties",
-      "title": "Part 7: Properties of B₂",
+      "title": "Part 7: Properties of B\u2082",
       "startLine": 173,
       "endLine": 222,
-      "summary": "Four proved theorems (B₂(p)=1, B₂(p²)=p², B₂≤n, B₂|n) and three axioms (B₂=1 iff squarefree, multiplicativity on coprime).",
+      "summary": "Four proved theorems (B\u2082(p)=1, B\u2082(p\u00b2)=p\u00b2, B\u2082\u2264n, B\u2082|n) and three axioms (B\u2082=1 iff squarefree, multiplicativity on coprime).",
       "mathContext": "$B_2(n) = 1 \\iff n$ squarefree; $B_2$ is multiplicative on coprime arguments; $B_2(n) \\mid n$"
     },
     {
@@ -164,7 +164,7 @@
       "title": "Part 9: Heuristic Analysis",
       "startLine": 256,
       "endLine": 272,
-      "summary": "Axiomatizes that average B₂(n) is O(1). Explains why worst-case products exceed the average prediction.",
+      "summary": "Axiomatizes that average B\u2082(n) is O(1). Explains why worst-case products exceed the average prediction.",
       "mathContext": "$\\frac{1}{N} \\sum_{n=1}^{N} B_2(n) = O(1)$, since squarefree density $= 6/\\pi^2 \\approx 0.608$"
     },
     {
@@ -172,33 +172,33 @@
       "title": "Part 10: Summary",
       "startLine": 273,
       "endLine": 295,
-      "summary": "Proves erdos_367_summary: conjunction of strongBound(1)∧strongBound(2), ¬strongBound(3), and True. Status: OPEN.",
+      "summary": "Proves erdos_367_summary: conjunction of strongBound(1)\u2227strongBound(2), \u00acstrongBound(3), and True. Status: OPEN.",
       "mathContext": "$(\\text{strongBound}\\, 1 \\wedge \\text{strongBound}\\, 2) \\wedge \\neg\\text{strongBound}\\, 3$"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #367 asks whether products of 2-full parts over k consecutive integers grow at most as n^{2+o(1)}. The strong n² bound fails for k ≥ 3 (van Doorn), but the weak bound remains open.",
-    "implications": "**Theoretical Significance**: **Why this matters:**\n\n1. **Consecutive integer structure:** The problem probes how 'square content' distributes among consecutive integers — a fundamental question about the multiplicative structure of $\\mathbb{Z}$.\n\n2. **Average vs worst case:** The average $B_2(n)$ is $O(1)$, but the worst-case product over $k$ consecutive integers can exceed $n^2$.\n\nUnderstanding this gap is central to analytic number theory.\n\n3. **The logarithmic barrier:** van Doorn's $n^2 \\log n$ lower bound shows the exponent 2 is sharp but the implied constant must grow. Whether it grows polynomially, logarithmically, or sublogarithmically is unknown.\n\n4. **Connections to powerful numbers:** The $r$-full generalization connects to the distribution of powerful numbers (Golomb 1970) and to questions about $abc$-triples and Szpiro's conjecture.",
+    "summary": "Erd\u0151s Problem #367 asks whether products of 2-full parts over k consecutive integers grow at most as n^{2+o(1)}. The strong n\u00b2 bound fails for k \u2265 3 (van Doorn), but the weak bound remains open.",
+    "implications": "**Theoretical Significance**: **Why this matters:**\n\n1. **Consecutive integer structure:** The problem probes how 'square content' distributes among consecutive integers \u2014 a fundamental question about the multiplicative structure of $\\mathbb{Z}$.\n\n2. **Average vs worst case:** The average $B_2(n)$ is $O(1)$, but the worst-case product over $k$ consecutive integers can exceed $n^2$.\n\nUnderstanding this gap is central to analytic number theory.\n\n3. **The logarithmic barrier:** van Doorn's $n^2 \\log n$ lower bound shows the exponent 2 is sharp but the implied constant must grow. Whether it grows polynomially, logarithmically, or sublogarithmically is unknown.\n\n4. **Connections to powerful numbers:** The $r$-full generalization connects to the distribution of powerful numbers (Golomb 1970) and to questions about $abc$-triples and Szpiro's conjecture.",
     "openQuestions": [
-      "Does ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)} hold for all k?",
+      "Does \u220f_{n \u2264 m < n+k} B\u2082(m) \u226a n^{2+o(1)} hold for all k?",
       "What is the true growth rate for k = 3?",
-      "How does the answer change for r-full parts with r ≥ 3?",
+      "How does the answer change for r-full parts with r \u2265 3?",
       "Are there explicit constructions achieving van Doorn's lower bound?"
     ]
   },
   "references": [
     {
-      "authors": "Erdős, Paul; Ivić, Aleksandar",
+      "authors": "Erd\u0151s, Paul; Ivi\u0107, Aleksandar",
       "title": "On the iterates of the enumerating function of finite Abelian groups",
       "year": "1982",
       "venue": "Bull. Acad. Serbe Sci. Math.",
       "note": "Contains early discussion of powerful numbers and their distribution among consecutive integers"
     },
     {
-      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "authors": "Erd\u0151s, Paul; Graham, Ronald L.",
       "title": "Old and New Problems and Results in Combinatorial Number Theory",
       "year": "1980",
-      "venue": "Monographies de L'Enseignement Mathématique 28",
+      "venue": "Monographies de L'Enseignement Math\u00e9matique 28",
       "note": "[ErGr80] where Problem 367 appears"
     }
   ],
@@ -206,7 +206,7 @@
     {
       "targetId": "erdos-366",
       "relationship": "related",
-      "description": "Directly related: #366 concerns consecutive k-full numbers (B_k(n) = n case), while #367 studies the product of 2-full parts B₂ over consecutive integers"
+      "description": "Directly related: #366 concerns consecutive k-full numbers (B_k(n) = n case), while #367 studies the product of 2-full parts B\u2082 over consecutive integers"
     },
     {
       "targetId": "erdos-369",

--- a/src/data/research/problems/erdos-14.json
+++ b/src/data/research/problems/erdos-14.json
@@ -29,11 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 1 axiom (sidon_size_bound) via counting argument. File: 4\u21923 axioms.",
+    "progressSummary": "PROGRESS: Eliminated 3 sorries in Erdos140Problem.lean (3->0). Proved r3_superlogarithmic and r3_density_vanishes as corollaries of Kelley-Meka. Completed greedyAP3Free definition.",
     "builtItems": [
       "Proved non_unique_monotone in Erdos14Problem.lean:102 (3-line proof)",
       "Fixed import: Asymptotics.Asymptotics -> Asymptotics.Defs in Erdos14Problem.lean:24",
-      "Proved sidon_size_bound theorem in Erdos14UniqueSums.lean (replacing axiom), +3 helper lemmas (~120 lines)"
+      "Proved sidon_size_bound theorem in Erdos14UniqueSums.lean (replacing axiom), +3 helper lemmas (~120 lines)",
+      "Proved r3_superlogarithmic in Erdos140Problem.lean:132 (corollary of Kelley-Meka)",
+      "Proved r3_density_vanishes in Erdos140Problem.lean:165 (limit theorem)",
+      "Defined toBase3Binary helper in Erdos140Problem.lean:225 (Stanley sequence)",
+      "Completed greedyAP3Free definition in Erdos140Problem.lean:236 (no sorry)"
     ],
     "insights": [
       "12 associated Lean files - largest problem family encountered",
@@ -44,7 +48,13 @@
       "sidon_size_bound (UniqueSums) could be proved from Erdos340GreedySidon sidon_upper_bound_weak but needs Set/Finset conversion",
       "Most axioms in Erdos14Problem.lean are deep results (open conjectures, deep theorems) that must stay as axioms",
       "erdos_freud_finite duplicated between Erdos14Problem.lean and Erdos14UniqueSums.lean",
-      "sidon_size_bound axiom eliminated: proved from Sidon difference-counting argument (k(k-1)/2 \u2264 N-1 via injective diff map)"
+      "sidon_size_bound axiom eliminated: proved from Sidon difference-counting argument (k(k-1)/2 \u2264 N-1 via injective diff map)",
+      "Erdos140Problem.lean had 3 provable sorries: r3_superlogarithmic, r3_density_vanishes, greedyAP3Free definition",
+      "r3_superlogarithmic proved via Kelley-Meka(C+1) + log N > K/eps for large N",
+      "r3_density_vanishes proved using r3_superlogarithmic as a building block",
+      "greedyAP3Free defined via binary-to-base-3 (Stanley sequence A005836 + 1)",
+      "Erdos14Problem.lean: remaining 6 axioms are all deep (2 open conjectures, 3 published results, 1 structural)",
+      "Erdos14UniqueSums.lean: remaining 3 axioms are all deep published results"
     ],
     "mathlibGaps": [],
     "nextSteps": [],

--- a/src/data/research/problems/erdos-367.json
+++ b/src/data/research/problems/erdos-367.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-367",
-  "title": "Erdős #367",
+  "title": "Erd\u0151s #367",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-13T00:59:36.242Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Eliminated strong_bound_fails_k3 axiom via log\u2192\u221e argument",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Prove twoFullPart_eq_one_iff and twoFullPart_mul_coprime",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,25 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axioms from 7 to 5. Proved strong_bound_k1 and strong_bound_k2 from twoFullPart_le. Total 8 theorems proved, 5 axioms remain.",
+    "progressSummary": "PROGRESS: 9T (was 8), 4A (was 5), 0S. Proved strong_bound_fails_k3 from van_doorn_lower_bound via log\u2192\u221e argument. Eliminated 1 axiom.",
     "builtItems": [
       "Proved twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq in Erdos367Problem.lean",
       "Proved strong_bound_k1 in Erdos367Problem.lean:140",
-      "Proved strong_bound_k2 in Erdos367Problem.lean:155"
+      "Proved strong_bound_k2 in Erdos367Problem.lean:155",
+      "Proved strong_bound_fails_k3 from van_doorn_lower_bound (was axiom) \u2014 log goes to infinity contradicts fixed C"
     ],
     "insights": [
       "4 axioms proved from Mathlib: twoFullPart_le, twoFullPart_dvd, twoFullPart_prime, twoFullPart_prime_sq",
       "Proved strong_bound_k1 (k=1) from twoFullPart_le via Finset.Ico singleton and nlinarith",
       "Proved strong_bound_k2 (k=2) from twoFullPart_le via Finset.prod_insert, mul_le_mul, and nlinarith",
-      "Key Mathlib API for twoFullPart_eq_one_iff: Nat.squarefree_iff_factorization_le_one, Nat.factorization_prod_pow_eq_self, Nat.support_factorization, Finset.filter_true_of_mem"
+      "Key Mathlib API for twoFullPart_eq_one_iff: Nat.squarefree_iff_factorization_le_one, Nat.factorization_prod_pow_eq_self, Nat.support_factorization, Finset.filter_true_of_mem",
+      "strong_bound_fails_k3 follows from van_doorn_lower_bound: if C*n^2 >= c*n^2*log(n), then C >= c*log(n) for unbounded n, contradiction. Used exp/log monotonicity from Mathlib."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove twoFullPart_eq_one_iff via Nat.squarefree_iff_factorization_le_one + Nat.factorization_prod_pow_eq_self (backward: squarefree → all exps 1 → filter identity → product = n → division = 1; forward: division = 1 → n = squarefreePart → Prime.dvd_finset_prod shows all primes in filter → all exps 1 → squarefree)",
-      "Prove twoFullPart_mul_coprime via coprime factorization splitting (Nat.factorization_mul_coprime)",
-      "average_twoFullPart_bounded requires deep analytic number theory — likely unprovable in Lean without extensive infrastructure"
+      "Prove twoFullPart_eq_one_iff (squarefree characterization) \u2014 needs Nat.factorization_prod_pow_eq_self",
+      "Prove twoFullPart_mul_coprime (coprime multiplicativity) \u2014 needs Nat.factorization_mul + coprime splitting",
+      "average_twoFullPart_bounded is deep analytic NT \u2014 likely stays as axiom"
     ],
-    "markdown": "# Erdős #367 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $B_2(n)$ be the 2-full part of $n$ (that is, $B_2(n)=n/n'$ where $n'$ is the product of all primes that divide $n$ exactly once). Is it true that, for every fixed $k\\geq 1$,\\[\\prod_{n\\leq m<n+k}B_2(m) \\ll n^{2+o(1)}?\\]Or perhaps even $\\ll_k n^2$?\n\n\n\nIt would also be interesting to find upper and lower bounds for the analogous product with $B_r$ for $r\\geq 3$, where $B_r(n)$ is the $r$-full part of $n$ (that is, the product of prime powers $p^a \\mid n$ such that $p^{a+1}\\nmid n$ and $a\\geq r$). Is it true that, for every fixed $r,k\\geq 2$ and $\\epsilon>0$,\\[\\limsup \\frac{\\prod_{n\\leq m<n+k}B_r(m) }{n^{1+\\epsilon}}\\to\\infty?\\]van Doorn notes in the comments that for $k\\leq 2$ we trivially have\\[\\prod_{n\\leq m<n+k}B_2(m) \\ll n^{2},\\]but that this fails for all $k\\geq 3$, and in fact\\[\\prod_{n\\leq m<n+3}B_2(m) \\gg n^{2}\\log n\\]infinitely often.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #366\n- Problem #368\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erd\u0151s #367 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $B_2(n)$ be the 2-full part of $n$ (that is, $B_2(n)=n/n'$ where $n'$ is the product of all primes that divide $n$ exactly once). Is it true that, for every fixed $k\\geq 1$,\\[\\prod_{n\\leq m<n+k}B_2(m) \\ll n^{2+o(1)}?\\]Or perhaps even $\\ll_k n^2$?\n\n\n\nIt would also be interesting to find upper and lower bounds for the analogous product with $B_r$ for $r\\geq 3$, where $B_r(n)$ is the $r$-full part of $n$ (that is, the product of prime powers $p^a \\mid n$ such that $p^{a+1}\\nmid n$ and $a\\geq r$). Is it true that, for every fixed $r,k\\geq 2$ and $\\epsilon>0$,\\[\\limsup \\frac{\\prod_{n\\leq m<n+k}B_r(m) }{n^{1+\\epsilon}}\\to\\infty?\\]van Doorn notes in the comments that for $k\\leq 2$ we trivially have\\[\\prod_{n\\leq m<n+k}B_2(m) \\ll n^{2},\\]but that this fails for all $k\\geq 3$, and in fact\\[\\prod_{n\\leq m<n+3}B_2(m) \\gg n^{2}\\log n\\]infinitely often.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #366\n- Problem #368\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"

--- a/src/data/research/problems/erdos-896.json
+++ b/src/data/research/problems/erdos-896.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-15T11:22:53.229Z",
-    "iteration": 3,
-    "focus": "Proved linear lower bound maxF >= N and supporting singleton counting",
+    "iteration": 4,
+    "focus": "Generalized singleton counting to arbitrary sets",
     "blockers": [],
     "nextAction": "Generalize singleton counting, prove repr count bounds",
     "attemptCounts": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 15T (was 11), 1A, 0S. Added uniqueProductCount_range_one, maxUniqueProducts_ge_range (N <= max F), 2 helper lemmas.",
+    "progressSummary": "PROGRESS: 17T (was 15), 1A, 0S. Added singleton counting theorems and linear lower bound.",
     "builtItems": [
       "reprCount_comm: reprCount A B m = reprCount B A m (via Finset.card_bij)",
       "uniqueProductCount_comm: PROVED (was axiom) F(A,B) = F(B,A)",
@@ -42,7 +42,9 @@
       "uniqueProductCount_singletons: F({a},{b}) = 1",
       "maxUniqueProducts_pos: maxUniqueProducts N >= 1 for N >= 1",
       "uniqueProductCount_range_one: F(Icc 1 N, {1}) = N (all products a*1=a are unique)",
-      "maxUniqueProducts_ge_range: maxUniqueProducts N >= N for N >= 1"
+      "maxUniqueProducts_ge_range: maxUniqueProducts N >= N for N >= 1",
+      "uniqueProductCount_singleton_left: F({a}, B) = |B| for a >= 1 (injective mul)",
+      "uniqueProductCount_singleton_right: F(A, {b}) = |A| for b >= 1 (by commutativity)"
     ],
     "insights": [
       "uniqueProductCount_comm proved by showing reprCount is symmetric (Finset.card_bij with swap) then image sets are equal (mul_comm)",
@@ -59,7 +61,8 @@
       "reprCount = 0 when product not in A\u00b7B (clean characterization)",
       "F(A, {1}) = |A| since a*1=a is injective and each product has reprCount=1",
       "Linear lower bound maxF >= N is tight: van Doorn says true order is ~N^2/log N",
-      "Proof technique: show filter = {(m,1)} for each m, then filter_true_of_mem"
+      "Proof technique: show filter = {(m,1)} for each m, then filter_true_of_mem",
+      "Nat.eq_of_mul_eq_left is the key Mathlib lemma for cancellation in singleton proofs"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-896.json
+++ b/src/data/research/problems/erdos-896.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-896",
-  "title": "Erdős #896",
+  "title": "Erd\u0151s #896",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "(LaTeX not available)",
-    "plain": "Estimate the maximum of F(A,B)\" role=\"presentation\" style=\"position: relative;\">F(A,B)F(A,B)F(A,B) as A,B\" role=\"presentation\" style=\"position: relative;\">A,BA,BA,B range over all subsets of {1,&#x2026;,N}\" role=\"presentation\" style=\"position: relative;\">{1,…,N}{1,…,N}\\{1,\\ldots,N\\}, where F(A,B)\" role=\"presentation\" style=\"position: relative;\">F(A,B)F(A,B)F(A,B) counts the number of m\" role=\"presentation\" style=\"position: relative;\">mmm such that m=ab\" role=\"presentation\" style=\"position: re...",
+    "plain": "Estimate the maximum of F(A,B)\" role=\"presentation\" style=\"position: relative;\">F(A,B)F(A,B)F(A,B) as A,B\" role=\"presentation\" style=\"position: relative;\">A,BA,BA,B range over all subsets of {1,&#x2026;,N}\" role=\"presentation\" style=\"position: relative;\">{1,\u2026,N}{1,\u2026,N}\\{1,\\ldots,N\\}, where F(A,B)\" role=\"presentation\" style=\"position: relative;\">F(A,B)F(A,B)F(A,B) counts the number of m\" role=\"presentation\" style=\"position: relative;\">mmm such that m=ab\" role=\"presentation\" style=\"position: re...",
     "whyMatters": []
   },
   "knownResults": {
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-15T11:22:53.229Z",
-    "iteration": 2,
-    "focus": "Session 2: Eliminated 2 axioms (3→1). maxUniqueProducts defined via Finset.sup, achievability proved.",
+    "iteration": 3,
+    "focus": "Proved linear lower bound maxF >= N and supporting singleton counting",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Generalize singleton counting, prove repr count bounds",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 11T (was 7), 1A, 0S. Added 4 structural theorems.",
+    "progressSummary": "PROGRESS: 15T (was 11), 1A, 0S. Added uniqueProductCount_range_one, maxUniqueProducts_ge_range (N <= max F), 2 helper lemmas.",
     "builtItems": [
       "reprCount_comm: reprCount A B m = reprCount B A m (via Finset.card_bij)",
       "uniqueProductCount_comm: PROVED (was axiom) F(A,B) = F(B,A)",
@@ -37,28 +37,38 @@
       "theorem uniqueProductCount_comm: F(A,B) = F(B,A) - eliminated 1 axiom",
       "maxUniqueProducts: replaced axiom with noncomputable def via Finset.sup over powerset pairs",
       "maxUniqueProducts_achieved: proved via Finset.exists_max_image on nonempty finite set",
-      "uniqueProductCount_empty_right: F(A,∅) = 0",
+      "uniqueProductCount_empty_right: F(A,\u2205) = 0",
       "reprCount_zero_of_not_mem: no representation means zero count",
       "uniqueProductCount_singletons: F({a},{b}) = 1",
-      "maxUniqueProducts_pos: maxUniqueProducts N >= 1 for N >= 1"
+      "maxUniqueProducts_pos: maxUniqueProducts N >= 1 for N >= 1",
+      "uniqueProductCount_range_one: F(Icc 1 N, {1}) = N (all products a*1=a are unique)",
+      "maxUniqueProducts_ge_range: maxUniqueProducts N >= N for N >= 1"
     ],
     "insights": [
       "uniqueProductCount_comm proved by showing reprCount is symmetric (Finset.card_bij with swap) then image sets are equal (mul_comm)",
       "Pre-existing Mathlib breakage: |>.card calc chain syntax no longer works, fixed by using parentheses",
       "Remaining 3 axioms: maxUniqueProducts (function def), maxUniqueProducts_achieved (existence), van_doorn_bounds (deep result)",
-      "reprCount_comm proved via Finset.card_bij with swap (a,b)↦(b,a)",
+      "reprCount_comm proved via Finset.card_bij with swap (a,b)\u21a6(b,a)",
       "uniqueProductCount_comm proved: image sets equal by mul_comm, filter conditions match by reprCount_comm",
-      "maxUniqueProducts is just a finite max over all subset pairs — no need for axiom",
-      "Finset.sup with OrderBot ℕ handles the definition cleanly",
+      "maxUniqueProducts is just a finite max over all subset pairs \u2014 no need for axiom",
+      "Finset.sup with OrderBot \u2115 handles the definition cleanly",
       "Finset.exists_max_image gives the achievability for free",
-      "F(A,∅) = F(∅,B) = 0 (empty sets have no products)",
+      "F(A,\u2205) = F(\u2205,B) = 0 (empty sets have no products)",
       "F({a},{b}) = 1 for singletons (exactly one product)",
       "maxUniqueProducts N >= 1 for N >= 1 (singleton lower bound)",
-      "reprCount = 0 when product not in A·B (clean characterization)"
+      "reprCount = 0 when product not in A\u00b7B (clean characterization)",
+      "F(A, {1}) = |A| since a*1=a is injective and each product has reprCount=1",
+      "Linear lower bound maxF >= N is tight: van Doorn says true order is ~N^2/log N",
+      "Proof technique: show filter = {(m,1)} for each m, then filter_true_of_mem"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #896 - Knowledge Base\n\n## Problem Statement\n\nEstimate the maximum of F(A,B)\" role=\"presentation\" style=\"position: relative;\">F(A,B)F(A,B)F(A,B) as A,B\" role=\"presentation\" style=\"position: relative;\">A,BA,BA,B range over all subsets of {1,&#x2026;,N}\" role=\"presentation\" style=\"position: relative;\">{1,…,N}{1,…,N}\\{1,\\ldots,N\\}, where F(A,B)\" role=\"presentation\" style=\"position: relative;\">F(A,B)F(A,B)F(A,B) counts the number of m\" role=\"presentation\" style=\"position: relative;\">mmm such that m=ab\" role=\"presentation\" style=\"position: relative;\">m=abm=abm=ab has exactly one solution (with a&#x2208;A\" role=\"presentation\" style=\"position: relative;\">a∈Aa∈Aa\\in A and b&#x2208;B\" role=\"presentation\" style=\"position: relative;\">b∈Bb∈Bb\\in B).\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #490\n- Problem #895\n- Problem #897\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Prove F({a}, B) = |B| for a >= 1 (generalize range_one)",
+      "Prove reprCount_le_card_left: reprCount A B m <= |A| for m > 0",
+      "Construct explicit pairs with F ~ N^2/log N (van Doorn construction)",
+      "Explore multiplication table structure for better lower bounds"
+    ],
+    "markdown": "# Erd\u0151s #896 - Knowledge Base\n\n## Problem Statement\n\nEstimate the maximum of F(A,B)\" role=\"presentation\" style=\"position: relative;\">F(A,B)F(A,B)F(A,B) as A,B\" role=\"presentation\" style=\"position: relative;\">A,BA,BA,B range over all subsets of {1,&#x2026;,N}\" role=\"presentation\" style=\"position: relative;\">{1,\u2026,N}{1,\u2026,N}\\{1,\\ldots,N\\}, where F(A,B)\" role=\"presentation\" style=\"position: relative;\">F(A,B)F(A,B)F(A,B) counts the number of m\" role=\"presentation\" style=\"position: relative;\">mmm such that m=ab\" role=\"presentation\" style=\"position: relative;\">m=abm=abm=ab has exactly one solution (with a&#x2208;A\" role=\"presentation\" style=\"position: relative;\">a\u2208Aa\u2208Aa\\in A and b&#x2208;B\" role=\"presentation\" style=\"position: relative;\">b\u2208Bb\u2208Bb\\in B).\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #490\n- Problem #895\n- Problem #897\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- Proved `r3_superlogarithmic`: Kelley-Meka(C+1) gives `r₃(N) ≤ K·N/(log N)^{C+1}`, then `K/log N < ε` for N > exp(K/ε)
- Proved `r3_density_vanishes`: limit theorem using `r3_superlogarithmic` + squeeze argument
- Completed `greedyAP3Free` definition: binary-to-base-3 characterization (Stanley sequence A005836 + 1)
- Erdos140Problem.lean: **3 → 0 sorries**

## Findings
- All 9 axioms in Erdos14Problem.lean and 3 in Erdos14UniqueSums.lean are deep (open conjectures or published results)
- The 3 sorries in Erdos140Problem.lean were provable corollaries of the Kelley-Meka axiom + a computable definition

## Status
**Outcome**: completed
**Next Steps**: Remaining axioms in Erdos14{Problem,UniqueSums}.lean require deep results not in Mathlib

🤖 Generated by researcher-10