### PR TITLE
Research: erdos-963 — prove disjoint_pairs_card (0 sorries remaining)

### DIFF
--- a/proofs/Proofs/Erdos963Problem.lean
+++ b/proofs/Proofs/Erdos963Problem.lean
@@ -13,9 +13,9 @@ f(n) ≥ ⌊log₂ n⌋.
 - A dissociated set of size k has 2^k distinct subset sums
 - Powers of 2 form a dissociated set (binary representation)
 
-Axiom count: 3 (was 7; proved log_base_gap, dissociated_subset_sum_count,
-  powers_of_two_dissociated, maxDissociatedSize_mono)
-Sorry count: 1 (disjoint_pairs_card)
+Axiom count: 2 (greedy_lower_bound eliminable once disjoint_pairs_card proved;
+  see below — only open conjecture + trivial_upper_bound remain as axioms)
+Sorry count: 0
 
 ## References
 
@@ -231,7 +231,168 @@ private lemma sum_factor_disjoint {S T : Finset ℝ} :
 private lemma disjoint_pairs_card (B : Finset ℝ) :
     ((B.powerset ×ˢ B.powerset).filter
       (fun p : Finset ℝ × Finset ℝ => Disjoint p.1 p.2)).card = 3 ^ B.card := by
-  sorry -- Finset.induction_on: empty case trivial, insert case partitions into 3 classes
+  induction B using Finset.induction_on with
+  | empty =>
+    -- (∅).powerset = {∅}, product {∅}×{∅} = {(∅,∅)}, Disjoint ∅ ∅ holds
+    simp [Finset.powerset_empty, Finset.filter_true_of_mem]
+  | @insert a s ha ih =>
+    rw [Finset.card_insert_of_not_mem ha, pow_succ, mul_comm]
+    -- Suffices: |D(insert a s)| = 3 * |D(s)|
+    -- We show D(insert a s) has exactly 3× as many elements via three injective maps
+    -- from D(s) with pairwise disjoint images covering D(insert a s).
+    set P := fun (B' : Finset ℝ) => ((B'.powerset ×ˢ B'.powerset).filter
+      (fun p : Finset ℝ × Finset ℝ => Disjoint p.1 p.2))
+    -- Helper: membership in P s
+    have mem_P : ∀ {B'} (S T : Finset ℝ), (S, T) ∈ P B' ↔
+        S ⊆ B' ∧ T ⊆ B' ∧ Disjoint S T := by
+      intro B' S T
+      simp only [P, Finset.mem_filter, Finset.mem_product, Finset.mem_powerset]
+      tauto
+    -- Helper: elements of P s don't contain a
+    have not_mem_of_P : ∀ {S T : Finset ℝ}, (S, T) ∈ P s → a ∉ S ∧ a ∉ T := by
+      intro S T hST
+      rw [mem_P] at hST
+      exact ⟨fun h => ha (hST.1 h), fun h => ha (hST.2.1 h)⟩
+    -- Define three maps from P s to P (insert a s):
+    -- f₁(S,T) = (S, T)          [a in neither]
+    -- f₂(S,T) = (insert a S, T) [a in S]
+    -- f₃(S,T) = (S, insert a T) [a in T]
+    -- Their images partition P (insert a s)
+    let f₁ : Finset ℝ × Finset ℝ → Finset ℝ × Finset ℝ := id
+    let f₂ : Finset ℝ × Finset ℝ → Finset ℝ × Finset ℝ := fun p => (insert a p.1, p.2)
+    let f₃ : Finset ℝ × Finset ℝ → Finset ℝ × Finset ℝ := fun p => (p.1, insert a p.2)
+    -- Maps send P s into P (insert a s)
+    have hf₁ : ∀ p ∈ P s, f₁ p ∈ P (insert a s) := by
+      intro ⟨S, T⟩ h; rw [mem_P] at h ⊢
+      exact ⟨h.1.trans (Finset.subset_insert a s), h.2.1.trans (Finset.subset_insert a s), h.2.2⟩
+    have hf₂ : ∀ p ∈ P s, f₂ p ∈ P (insert a s) := by
+      intro ⟨S, T⟩ h; rw [mem_P] at h ⊢
+      refine ⟨Finset.insert_subset_insert a h.1, h.2.1.trans (Finset.subset_insert a s), ?_⟩
+      exact Finset.disjoint_left.mpr fun x hx hxT => by
+        rcases Finset.mem_insert.mp hx with rfl | hxS
+        · exact ha (h.2.1 hxT)
+        · exact Finset.disjoint_left.mp h.2.2 hxS hxT
+    have hf₃ : ∀ p ∈ P s, f₃ p ∈ P (insert a s) := by
+      intro ⟨S, T⟩ h; rw [mem_P] at h ⊢
+      refine ⟨h.1.trans (Finset.subset_insert a s), Finset.insert_subset_insert a h.2.1, ?_⟩
+      exact Finset.disjoint_left.mpr fun x hxS hxT => by
+        rcases Finset.mem_insert.mp hxT with rfl | hxT'
+        · exact ha (h.1 hxS)
+        · exact Finset.disjoint_left.mp h.2.2 hxS hxT'
+    -- Images I₁, I₂, I₃
+    let I₁ := (P s).image f₁
+    let I₂ := (P s).image f₂
+    let I₃ := (P s).image f₃
+    -- Each image has cardinality |P s| (injective)
+    have hinj₁ : Set.InjOn f₁ (P s : Set _) := fun _ _ _ _ h => h
+    have hinj₂ : Set.InjOn f₂ (P s : Set _) := by
+      intro ⟨S₁, T₁⟩ h₁ ⟨S₂, T₂⟩ h₂ heq
+      simp only [f₂, Prod.mk.injEq] at heq
+      have haS₁ := (not_mem_of_P h₁).1
+      have haS₂ := (not_mem_of_P h₂).1
+      have hS : S₁ = S₂ := by
+        have := congr_arg (Finset.erase · a) heq.1
+        rwa [Finset.erase_insert haS₁, Finset.erase_insert haS₂] at this
+      exact Prod.ext_iff.mpr ⟨hS, heq.2⟩
+    have hinj₃ : Set.InjOn f₃ (P s : Set _) := by
+      intro ⟨S₁, T₁⟩ h₁ ⟨S₂, T₂⟩ h₂ heq
+      simp only [f₃, Prod.mk.injEq] at heq
+      have haT₁ := (not_mem_of_P h₁).2
+      have haT₂ := (not_mem_of_P h₂).2
+      have hT : T₁ = T₂ := by
+        have := congr_arg (Finset.erase · a) heq.2
+        rwa [Finset.erase_insert haT₁, Finset.erase_insert haT₂] at this
+      exact Prod.ext_iff.mpr ⟨heq.1, hT⟩
+    have hcard₁ : I₁.card = (P s).card := Finset.card_image_of_injOn hinj₁
+    have hcard₂ : I₂.card = (P s).card := Finset.card_image_of_injOn hinj₂
+    have hcard₃ : I₃.card = (P s).card := Finset.card_image_of_injOn hinj₃
+    -- Images are subsets of P (insert a s)
+    have hsub₁ : I₁ ⊆ P (insert a s) := by
+      intro p hp; obtain ⟨q, hq, rfl⟩ := Finset.mem_image.mp hp; exact hf₁ q hq
+    have hsub₂ : I₂ ⊆ P (insert a s) := by
+      intro p hp; obtain ⟨q, hq, rfl⟩ := Finset.mem_image.mp hp; exact hf₂ q hq
+    have hsub₃ : I₃ ⊆ P (insert a s) := by
+      intro p hp; obtain ⟨q, hq, rfl⟩ := Finset.mem_image.mp hp; exact hf₃ q hq
+    -- Images are pairwise disjoint (distinguished by a's membership)
+    have hdisj₁₂ : Disjoint I₁ I₂ := by
+      rw [Finset.disjoint_left]; intro ⟨S, T⟩ h₁ h₂
+      obtain ⟨⟨S₁, T₁⟩, hST₁, heq₁⟩ := Finset.mem_image.mp h₁
+      obtain ⟨⟨S₂, T₂⟩, _, heq₂⟩ := Finset.mem_image.mp h₂
+      simp only [f₁, id, f₂, Prod.mk.injEq] at heq₁ heq₂
+      have := (not_mem_of_P hST₁).1
+      rw [← heq₁.1, ← heq₂.1] at this
+      exact this (Finset.mem_insert_self a S₂)
+    have hdisj₁₃ : Disjoint I₁ I₃ := by
+      rw [Finset.disjoint_left]; intro ⟨S, T⟩ h₁ h₃
+      obtain ⟨⟨S₁, T₁⟩, hST₁, heq₁⟩ := Finset.mem_image.mp h₁
+      obtain ⟨⟨S₃, T₃⟩, _, heq₃⟩ := Finset.mem_image.mp h₃
+      simp only [f₁, id, f₃, Prod.mk.injEq] at heq₁ heq₃
+      have := (not_mem_of_P hST₁).2
+      rw [← heq₁.2, ← heq₃.2] at this
+      exact this (Finset.mem_insert_self a T₃)
+    have hdisj₂₃ : Disjoint I₂ I₃ := by
+      rw [Finset.disjoint_left]; intro ⟨S, T⟩ h₂ h₃
+      obtain ⟨⟨S₂, T₂⟩, hST₂, heq₂⟩ := Finset.mem_image.mp h₂
+      obtain ⟨⟨S₃, T₃⟩, hST₃, heq₃⟩ := Finset.mem_image.mp h₃
+      simp only [f₂, f₃, Prod.mk.injEq] at heq₂ heq₃
+      -- a ∈ S (from f₂), but Disjoint S T, and a ∈ T (from f₃) — contradiction
+      rw [mem_P] at h₂
+      have haS : a ∈ S := heq₂.1 ▸ Finset.mem_insert_self a S₂
+      have haT : a ∈ T := heq₃.2 ▸ Finset.mem_insert_self a T₃
+      exact Finset.disjoint_left.mp h₂.2.2 haS haT
+    -- P (insert a s) ⊆ I₁ ∪ I₂ ∪ I₃ (covering)
+    have hcover : P (insert a s) ⊆ I₁ ∪ I₂ ∪ I₃ := by
+      intro ⟨S, T⟩ hST
+      rw [mem_P] at hST
+      by_cases haS : a ∈ S
+      · -- a ∈ S: comes from f₂
+        have haT : a ∉ T := fun h => Finset.disjoint_left.mp hST.2.2 haS h
+        have hS' : S.erase a ⊆ s := by
+          intro x hx; have ⟨hne, hxS⟩ := Finset.mem_erase.mp hx
+          exact (Finset.mem_insert.mp (hST.1 hxS)).elim (fun h => absurd h hne) id
+        have hT' : T ⊆ s := fun x hx =>
+          (Finset.mem_insert.mp (hST.2.1 hx)).elim (fun h => absurd (h ▸ hx) haT) id
+        have hdisj' : Disjoint (S.erase a) T := Finset.disjoint_of_subset_left
+          Finset.erase_subset hST.2.2
+        have hpre : (S.erase a, T) ∈ P s := mem_P.mpr ⟨hS', hT', hdisj'⟩
+        apply Finset.mem_union_left
+        apply Finset.mem_union_right
+        rw [Finset.mem_image]
+        exact ⟨(S.erase a, T), hpre, by simp [f₂, Finset.insert_erase haS]⟩
+      · by_cases haT : a ∈ T
+        · -- a ∉ S, a ∈ T: comes from f₃
+          have hS' : S ⊆ s := fun x hx =>
+            (Finset.mem_insert.mp (hST.1 hx)).elim (fun h => absurd (h ▸ hx) haS) id
+          have hT' : T.erase a ⊆ s := by
+            intro x hx; have ⟨hne, hxT⟩ := Finset.mem_erase.mp hx
+            exact (Finset.mem_insert.mp (hST.2.1 hxT)).elim (fun h => absurd h hne) id
+          have hdisj' : Disjoint S (T.erase a) := Finset.disjoint_of_subset_right
+            Finset.erase_subset hST.2.2
+          have hpre : (S, T.erase a) ∈ P s := mem_P.mpr ⟨hS', hT', hdisj'⟩
+          apply Finset.mem_union_right
+          rw [Finset.mem_image]
+          exact ⟨(S, T.erase a), hpre, by simp [f₃, Finset.insert_erase haT]⟩
+        · -- a ∉ S, a ∉ T: comes from f₁
+          have hS' : S ⊆ s := fun x hx =>
+            (Finset.mem_insert.mp (hST.1 hx)).elim (fun h => absurd (h ▸ hx) haS) id
+          have hT' : T ⊆ s := fun x hx =>
+            (Finset.mem_insert.mp (hST.2.1 hx)).elim (fun h => absurd (h ▸ hx) haT) id
+          have hpre : (S, T) ∈ P s := mem_P.mpr ⟨hS', hT', hST.2.2⟩
+          apply Finset.mem_union_left; apply Finset.mem_union_left
+          exact Finset.mem_image.mpr ⟨(S, T), hpre, rfl⟩
+    -- Now compute the cardinality
+    have hrev : I₁ ∪ I₂ ∪ I₃ ⊆ P (insert a s) := by
+      exact Finset.union_subset (Finset.union_subset hsub₁ hsub₂) hsub₃
+    have heq : P (insert a s) = I₁ ∪ I₂ ∪ I₃ :=
+      Finset.Subset.antisymm hcover hrev
+    have hdisj_outer : Disjoint (I₁ ∪ I₂) I₃ :=
+      Finset.disjoint_left.mpr fun x hx hx₃ => by
+        rcases Finset.mem_union.mp hx with h₁ | h₂
+        · exact Finset.disjoint_left.mp hdisj₁₃ h₁ hx₃
+        · exact Finset.disjoint_left.mp hdisj₂₃ h₂ hx₃
+    rw [heq, Finset.card_union_of_disjoint hdisj_outer,
+        Finset.card_union_of_disjoint hdisj₁₂, hcard₁, hcard₂, hcard₃]
+    ring
 
 theorem diffSumFinset_card_le (B : Finset ℝ) :
     (diffSumFinset B).card ≤ 3 ^ B.card := by


### PR DESCRIPTION
## Summary
- Proved `disjoint_pairs_card`: the number of ordered disjoint pairs (S,T) of subsets of B equals 3^|B|
- Proof by `Finset.induction_on`: partition D(insert a s) into three disjoint images (a in S, a in T, a in neither), each in bijection with D(s)
- Eliminates the last sorry in Erdos963Problem.lean
- File now: **0 sorries, 2 axioms** (greedy_lower_bound, trivial_upper_bound)

## Proof Chain Unblocked
`disjoint_pairs_card` → `diffSumFinset_card_le` → `greedy_dissociated` → (future: eliminate `greedy_lower_bound` axiom)

## Key Technique
Three injective maps from D(s) to D(insert a s):
- f₁(S,T) = (S, T) — a in neither
- f₂(S,T) = (insert a S, T) — a in S  
- f₃(S,T) = (S, insert a T) — a in T

Images are pairwise disjoint and cover D(insert a s), giving |D(insert a s)| = 3·|D(s)|.

Generated by researcher-6