### PR TITLE
Research: erdos-952 — prove primes_mod_4_connection (3→2 axioms)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos952Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos952Problem.lean
@@ -401,10 +401,45 @@ noncomputable def splitPrime (p : ℕ) (hp : p.Prime) (hmod : p % 4 = 1) :
   (⟨(a : ℤ), (b : ℤ)⟩, ⟨(a : ℤ), -(b : ℤ)⟩)
 
 -- Connection: large gaps in primes ≡ 1 (mod 4) create large moats
-axiom primes_mod_4_connection :
+-- Proved unconditionally: the factorial construction gives arbitrarily long
+-- prime-free intervals, hence no primes ≡ 1 mod 4 either.
+theorem primes_mod_4_connection :
     (∀ k, ¬ CanEscapeMoat k) →
     ∀ C, ∃ᶠ n in Filter.atTop, ∀ m ∈ Finset.range C,
-      ¬ (n + m).Prime ∨ (n + m) % 4 ≠ 1
+      ¬ (n + m).Prime ∨ (n + m) % 4 ≠ 1 := by
+  intro _ C
+  rw [Filter.frequently_atTop]
+  intro a
+  -- For any window size C, [k!+2, k!+C+1] is entirely composite
+  set k := max a (C + 2)
+  refine ⟨k ! + 2, ?_, ?_⟩
+  · -- k! + 2 ≥ a (since k ≤ k! for k ≥ 1)
+    have : k ≤ k ! := by
+      apply Nat.le_of_dvd (Nat.factorial_pos k)
+      match k, show 1 ≤ k by omega with
+      | n + 1, _ => exact ⟨n !, Nat.factorial_succ n⟩
+    omega
+  · -- Every number in [k!+2, k!+2+C) is composite
+    intro m hm
+    left
+    rw [Finset.mem_range] at hm
+    -- j = m + 2 divides k!, hence divides k! + j, making k!+2+m composite
+    set j := m + 2
+    have hj_le_k : j ≤ k := by omega
+    have hj_dvd_kfact : j ∣ k ! := by
+      apply dvd_trans
+      · -- j ∣ j! (since j! = j * (j-1)!)
+        match j, show 1 ≤ j by omega with
+        | n + 1, _ => exact ⟨n !, Nat.factorial_succ n⟩
+      · exact Nat.factorial_dvd_factorial hj_le_k
+    have hj_dvd : j ∣ (k ! + 2 + m) := by
+      rw [show k ! + 2 + m = k ! + j from by omega]
+      exact dvd_add hj_dvd_kfact (dvd_refl j)
+    -- k!+2+m has proper divisor j (2 ≤ j < k!+2+m), so not prime
+    intro hp
+    rcases hp.eq_one_or_self_of_dvd j hj_dvd with h | h
+    · omega -- j ≥ 2, not 1
+    · have := Nat.factorial_pos k; omega -- j = k!+2+m implies k! = 0, impossible
 
 /-
 # Part 8: Equivalences and Structural Results
@@ -466,15 +501,15 @@ def RationalPrimeMoat : Prop :=
 - Whether any bounded step size suffices
 - The critical moat width (if the answer is NO)
 
-**Axioms (3):**
+**Axioms (2):**
 - tsuchimura: computational verification (no walk ≤ √26)
 - gaussian_prime_theorem: asymptotic density (analytic number theory)
-- primes_mod_4_connection: moat structure from prime gaps
 
 **Proved from Mathlib:**
 - Full Gaussian prime classification (both directions):
   - Backward: 3 norm types → prime (prime_of_prime_natAbs_norm, prime_of_inert, prime_of_split)
   - Forward: prime → one of 3 norm types (classification_forward, via strong induction + mod 4)
+- primes_mod_4_connection: proved via factorial construction (k!+2,...,k!+k all composite)
 - splitPrime definition (via Fermat's two-square theorem)
 - jordan_rabung, gethner_et_al from tsuchimura
 - Moat monotonicity and structural equivalences

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -43,22 +43,22 @@
       "IsGaussianPrime definition: Prime in ℤ[i]",
       "GaussianPrimes definition: set of Gaussian primes",
       "IsNorm2Prime, IsInertPrime, IsSplitPrime: classification of Gaussian primes",
-      "gaussian_prime_classification axiom: complete classification",
+      "gaussian_prime_classification theorem: complete classification (both directions proved)",
       "IsInfiniteGaussianPrimeWalk definition: injective prime sequence",
       "HasBoundedGaps definition: consecutive norm differences bounded",
       "GaussianMoatConjecture definition: existence of bounded walk",
-      "jordan_rabung axiom: no walk with steps ≤ 2",
+      "jordan_rabung theorem: no walk with steps ≤ 2 (proved from tsuchimura)",
       "tsuchimura axiom: no walk with steps ≤ √26",
-      "gethner_et_al axiom: step size 4 insufficient",
+      "gethner_et_al theorem: step size 4 insufficient (proved from tsuchimura)",
       "CanEscapeMoat definition: moat escapability",
       "criticalMoatWidth definition: smallest non-escapable moat",
       "gaussianPrimeCount definition: counting function",
       "gaussian_prime_theorem axiom: asymptotic density",
-      "primes_mod_4_connection axiom: relation to primes ≡ 1 (mod 4)"
+      "primes_mod_4_connection theorem: proved via factorial construction (arbitrarily long prime-free intervals)"
     ],
-    "axiomCount": 3,
-    "lineCount": 492,
-    "assumptions": "4 axioms: gaussian_prime_classification, tsuchimura, gaussian_prime_theorem, primes_mod_4_connection. jordan_rabung and gethner_et_al proved from tsuchimura. 1 sorry (definition)."
+    "axiomCount": 2,
+    "lineCount": 510,
+    "assumptions": "2 axioms: tsuchimura (computational verification), gaussian_prime_theorem (analytic number theory). gaussian_prime_classification proved (both directions). primes_mod_4_connection proved via factorial construction. jordan_rabung and gethner_et_al proved from tsuchimura."
   },
   "overview": {
     "historicalContext": "This problem is notably NOT actually an Erdős problem. According to Erdős himself, the conjecture originated with Theodore Motzkin, Basil Gordon, and others at a 1963 Pasadena number theory meeting. Erdős popularized it by sharing it widely, and the attribution was eventually forgotten.\n\nThe 'Gaussian moat' refers to prime-free regions in ℤ[i]. The question asks whether one can 'walk' from 0 to infinity on Gaussian primes with bounded step size.\n\nKnown results:\n- Jordan and Rabung (1970): No walk with steps ≤ 2\n- Tsuchimura (2005): No walk with steps ≤ √26\n- Gethner et al.: Step size 4 insufficient\n\nTerence Tao has indicated this problem appears quite difficult.",
@@ -170,9 +170,9 @@
       "GaussianInt"
     ],
     "namespace": "Erdos952",
-    "lineCount": 492,
-    "axiomCount": 3,
-    "theoremCount": 15,
+    "lineCount": 510,
+    "axiomCount": 2,
+    "theoremCount": 16,
     "definitionCount": 19
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-952.json
+++ b/src/data/research/problems/erdos-952.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated classification_forward axiom (4A→3A). Proved forward direction of Gaussian prime classification via strong induction + Associated + ZMod 4. Removed duplicate definitions.",
+    "progressSummary": "PROGRESS: Proved primes_mod_4_connection axiom (3A→2A). Used factorial construction: [k!+2, k!+k] contains only composites. Now only 2 axioms remain: tsuchimura (computational) and gaussian_prime_theorem (analytic NT).",
     "builtItems": [
       "PROVED jordan_rabung from tsuchimura (axiom→theorem)",
       "PROVED gethner_et_al from tsuchimura (axiom→theorem)",
@@ -37,7 +37,8 @@
       "no_walk_up_to_sqrt26: blocks all step sizes ≤27 via Tsuchimura + mono",
       "exists_nat_prime_dvd: strong induction helper (Gaussian prime divides some rational prime)",
       "classification_forward: complete proof (was axiom, now theorem ~115 lines)",
-      "Removed: duplicate canEscapeMoat_mono, no_walk_up_to_sqrt26"
+      "Removed: duplicate canEscapeMoat_mono, no_walk_up_to_sqrt26",
+      "primes_mod_4_connection: axiom→theorem via factorial argument (~25 lines)"
     ],
     "insights": [
       "jordan_rabung and gethner_et_al are weaker results than tsuchimura — proved as consequences (6A→4A)",
@@ -50,10 +51,15 @@
       "Key technique: z*star(z)=norm(z), so z|norm(z). By induction z|↑p for some rational prime p. Then norm(z)|p², giving norm=p or p²",
       "For norm=p²: z~↑p (associated), so ↑p prime in ℤ[i], hence p≡3 mod 4 by GaussianInt.prime_iff_mod_four_eq_three_of_nat_prime",
       "For norm=p: sum-of-squares mod 4 argument (same as prime_of_inert) shows p≡1 mod 4",
-      "Removed duplicate canEscapeMoat_mono and no_walk_up_to_sqrt26 definitions"
+      "Removed duplicate canEscapeMoat_mono and no_walk_up_to_sqrt26 definitions",
+      "primes_mod_4_connection proved: the consequent (arbitrarily long prime-free windows) holds unconditionally via factorial construction, making the conditional implication trivially true",
+      "Key technique: for j in [2, k], j divides k!, so j divides k!+j, making k!+j composite"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Only 2 axioms remain, both deep and appropriate: tsuchimura (computational), gaussian_prime_theorem (analytic NT)",
+      "File is near-complete for an open problem formalization"
+    ],
     "markdown": "# Erdős #952 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there an infinite sequence of distinct Gaussian primes $x_1,x_2,\\ldots$ such that\\[\\lvert x_{n+1}-x_n\\rvert \\ll 1?\\]\n\n\n\nThe Gaussian moat problem. This is not actually a problem of Erd\\H{o}s, but has been erroneously attributed to him in the past. In \\cite{Er77c} Erd\\H{o}s recalls: 'The conjecture was told me by Motzkin at the Pasadena number theory meeting 1963 November and it was apparently raised by Basil Gordon and Motzkin. I naturally liked it very much and told it right away to many people, naturally attributing it to Motzkin, but this was later forgotten. Thus the problem is returned to its rightful owners.'\n\n\n\n\nReferences\n\n\n[Er77c] Erd\\H{o}s, Paul, Problems and results on combinatorial number theory. III. Number theory day (Proc. Conf., Rockefeller Univ.,\nNew York, 1976) (1977), 43-72.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #951\n- Problem #953\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Proved `primes_mod_4_connection` axiom → theorem using the classic factorial construction
- Reduced axiom count from 3 to 2 (only `tsuchimura` and `gaussian_prime_theorem` remain)
- Updated meta.json and problem knowledge to reflect current state

## Progress
- **Axiom eliminated**: `primes_mod_4_connection` — the conditional "if moats are impassable, then arbitrarily long prime-free windows exist" is proved unconditionally via: for any C, the interval [k!+2, k!+C+1] contains only composites since j | k!+j for 2 ≤ j ≤ k
- **Remaining 2 axioms** are both deep results not in Mathlib:
  - `tsuchimura`: computational verification (exhaustive search up to √26)
  - `gaussian_prime_theorem`: asymptotic density (analytic number theory)

## Findings
- The consequent of `primes_mod_4_connection` holds unconditionally — the hypothesis about moats is not needed
- The factorial argument gives a clean ~25 line proof using only `Nat.factorial_pos`, `Nat.factorial_succ`, `Nat.factorial_dvd_factorial`, and `Nat.Prime.eq_one_or_self_of_dvd`

## Status
**Outcome**: progress (3A → 2A)
**Next Steps**: File is near-complete for an open problem formalization. Remaining axioms are appropriate.

🤖 Generated by researcher-9