### PR TITLE
Research: fourier-decay — prove exp_decay_summable and abs_convergence (6→4 sorries)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean
@@ -45,6 +45,7 @@ import Mathlib.Analysis.Fourier.AddCircle
 import Mathlib.Analysis.Fourier.FourierTransform
 import Mathlib.MeasureTheory.Function.L2Space
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Topology.Algebra.InfiniteSum.NatInt
 import Mathlib.Tactic
 
 noncomputable section
@@ -133,10 +134,34 @@ theorem wider_strip_faster_decay (δ₁ δ₂ : ℝ) (hδ₁ : 0 < δ₁) (hδ�
 /-- Exponential decay is summable (the series ∑ e^{-c|n|} converges for c > 0). -/
 theorem exp_decay_summable (δ : ℝ) (hδ : 0 < δ) :
     Summable (fun n : ℤ => Real.exp (-(2 * Real.pi * δ * |↑n|) / T)) := by
-  have hc : 0 < 2 * Real.pi * δ / T := by positivity
-  -- e^{-c|n|} is summable over ℤ when c > 0
-  -- Split into n ≥ 0 and n < 0, each is a geometric series with ratio e^{-c} < 1
-  sorry -- Geometric series summability; requires Summable.of_nat_of_sum_le or similar
+  -- Decompose ℤ-summability into positive and negative ℕ-parts
+  rw [summable_int_iff_summable_nat_and_neg]
+  -- Set c = 2πδ/T > 0, so exp(-c) ∈ (0,1) and the geometric series ∑ exp(-c)^n converges
+  set c := 2 * Real.pi * δ / T with hc_def
+  have hc_pos : 0 < c := by positivity
+  -- exp(-c * n) = (exp(-c))^n, a geometric series with ratio exp(-c) < 1
+  have hsumm : Summable (fun n : ℕ => Real.exp (-c * ↑n)) := by
+    have heq : ∀ n : ℕ, Real.exp (-c * ↑n) = Real.exp (-c) ^ n := fun n => by
+      rw [show -c * (↑n : ℝ) = ↑n * (-c) from by ring, Real.exp_nat_mul]
+    simp_rw [heq]
+    exact summable_geometric_of_lt_one (le_of_lt (Real.exp_pos _))
+      (Real.exp_lt_one_iff.mpr (by linarith))
+  -- Both halves reduce to exp(-c * n) after simplifying absolute values
+  refine ⟨?_, ?_⟩
+  · -- Positive half: f(↑n) for n : ℕ, where |↑(↑n)| = n
+    have heq : (fun n : ℕ => Real.exp (-(2 * Real.pi * δ * |(↑(↑n : ℤ) : ℝ)|) / T)) =
+               (fun n : ℕ => Real.exp (-c * ↑n)) := by
+      ext n; congr 1
+      rw [Int.cast_natCast, abs_of_nonneg (Nat.cast_nonneg n)]
+      unfold_let c; ring
+    rw [heq]; exact hsumm
+  · -- Negative half: f(-↑n) for n : ℕ, where |↑(-↑n)| = n
+    have heq : (fun n : ℕ => Real.exp (-(2 * Real.pi * δ * |(↑(-↑n : ℤ) : ℝ)|) / T)) =
+               (fun n : ℕ => Real.exp (-c * ↑n)) := by
+      ext n; congr 1
+      rw [Int.cast_neg, Int.cast_natCast, abs_neg, abs_of_nonneg (Nat.cast_nonneg n)]
+      unfold_let c; ring
+    rw [heq]; exact hsumm
 
 /-- Exponential decay of Fourier coefficients implies absolute convergence
     of the Fourier series (a much stronger property than L² convergence). -/
@@ -145,7 +170,22 @@ theorem exp_decay_abs_convergence (f : AddCircle T → ℂ) (δ : ℝ) (hδ : 0 
     (hdecay : ∀ n : ℤ, n ≠ 0 →
       ‖fourierCoeff f n‖ ≤ M * Real.exp (-(2 * Real.pi * δ * |↑n|) / T)) :
     Summable (fun n : ℤ => ‖fourierCoeff f n‖) := by
-  sorry -- Follows from hdecay and exp_decay_summable; comparison test
+  -- Compare with (M + ‖ĉ₀‖) * exp(-c|n|), which handles n = 0 automatically
+  set K := M + ‖fourierCoeff f 0‖
+  have hK : 0 < K := by positivity
+  apply Summable.of_nonneg_of_le (fun n => norm_nonneg _) _ ((exp_decay_summable δ hδ).mul_left K)
+  intro n
+  by_cases hn : n = 0
+  · -- n = 0: ‖ĉ₀‖ ≤ K * exp(0) = K = M + ‖ĉ₀‖
+    subst hn
+    simp only [Int.cast_zero, abs_zero, mul_zero, neg_zero, zero_div, Real.exp_zero, mul_one]
+    linarith [hM.le]
+  · -- n ≠ 0: ‖ĉ_n‖ ≤ M * exp(-c|n|) ≤ K * exp(-c|n|) since M ≤ K
+    calc ‖fourierCoeff f n‖
+        ≤ M * Real.exp (-(2 * Real.pi * δ * |↑n|) / T) := hdecay n hn
+      _ ≤ K * Real.exp (-(2 * Real.pi * δ * |↑n|) / T) := by
+          apply mul_le_mul_of_nonneg_right _ (le_of_lt (Real.exp_pos _))
+          linarith [norm_nonneg (fourierCoeff f 0)]
 
 -- ============================================================================
 -- § 4. SHARPNESS OF THE EXPONENTIAL RATE

--- a/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
@@ -17,9 +17,9 @@
       "sharp-constants"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 4,
     "axiomCount": 3,
-    "lineCount": 325,
+    "lineCount": 365,
     "mathlibDependencies": [
       {
         "theorem": "fourierCoeff",
@@ -46,7 +46,7 @@
       "Weierstrass uniform convergence theorem",
       "Fourier coefficient infrastructure from Mathlib"
     ],
-    "assumptions": "3 axioms: (1) contour_shift_decay: contour-shifting gives exponential Fourier decay for strip-analytic functions; (2) rate_is_sharp: the exponential rate 2*pi*delta/T cannot be improved; (3) paley_wiener_converse: exponential decay of Fourier coefficients implies strip analyticity. Plus 6 sorry lemmas for structural results (summability, comparison, optimality, exponential-polynomial dominance).",
+    "assumptions": "3 axioms: (1) contour_shift_decay: contour-shifting gives exponential Fourier decay for strip-analytic functions; (2) rate_is_sharp: the exponential rate 2*pi*delta/T cannot be improved; (3) paley_wiener_converse: exponential decay of Fourier coefficients implies strip analyticity. Plus 4 sorry lemmas for structural results (comparison, optimality, exponential-polynomial dominance).",
     "relatedProblems": [
       {
         "id": "fourier-series-oq-02-oq-03",


### PR DESCRIPTION
## Summary
- Prove `exp_decay_summable`: exponential decay series ∑ e^{-c|n|} is summable over ℤ
- Prove `exp_decay_abs_convergence`: exponential Fourier coefficient decay implies absolute convergence
- Reduces sorry count from 6 to 4 in FourierSeriesOQ02OQ03OQ02.lean

## Proof Technique
- Decompose ℤ-summability into positive and negative ℕ-halves via `summable_int_iff_summable_nat_and_neg`
- Both halves are geometric series with ratio exp(-2πδ/T) < 1
- Absolute convergence follows by comparison with (M + ‖ĉ₀‖) · exp(-c|n|)

## Files Modified
- `proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean` — proved 2 theorems, added NatInt import
- `src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json` — updated sorry count and metadata

## Status
**Outcome**: progress (6→4 sorries)
**Remaining**: 4 sorries for sharp constant optimality and exponential-polynomial dominance comparisons

🤖 Generated by researcher-4