### PR TITLE
fix(metadata): sync sorry counts for 9 proofs, upgrade 7 to verified

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Archimedes (c. 250 BCE), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Archimedes",
     "date": "-250",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "geometry",
       "analysis",
@@ -18,8 +18,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "mathlib",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -32,8 +32,8 @@
       "issues": []
     },
     "area-of-circle-oq-03-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T07:04:07Z",
+      "auditCount": 3,
+      "lastAudited": "2026-03-29T10:25:22Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -86,9 +86,9 @@
       "issues": []
     },
     "ballot-problem-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T07:18:02Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-03-29T10:25:22Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1085": {
@@ -188,9 +188,9 @@
       "issues": []
     },
     "bezout-identity-oq-02-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T07:59:25Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-03-29T10:25:22Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "bezout-identity-oq-02-oq-02-oq-01": {
@@ -380,9 +380,9 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-03-24T17:14:18Z",
-      "result": "clean",
+      "auditCount": 5,
+      "lastAudited": "2026-03-29T10:25:23Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-02-oq-01": {
@@ -476,8 +476,8 @@
       "issues": []
     },
     "derangements-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T07:31:27Z",
+      "auditCount": 3,
+      "lastAudited": "2026-03-29T10:25:22Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -572,8 +572,8 @@
       "issues": []
     },
     "erdos-1006-oq-02-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-24T07:31:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-03-29T10:25:22Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -3083,9 +3083,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-140": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T10:25:23Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-141": {
@@ -8143,9 +8143,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-963": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T10:25:23Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-964": {
@@ -9333,9 +9333,9 @@
       "issues": []
     },
     "dirichlets-theorem-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-27T19:11:44Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-29T10:25:23Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "dirichlets-theorem-oq-02-oq-01": {
@@ -9791,6 +9791,12 @@
     "chinese-remainder-constructive-oq-04-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-03-29T09:58:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "kummer-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T10:26:23Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cycle_lemma",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,8 +18,8 @@
       "finset",
       "research"
     ],
-    "badge": "formalized",
-    "sorries": 2,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid; formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euclid%27s_lemma",
     "date": "~300 BCE",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -15,8 +15,8 @@
       "algorithms",
       "research"
     ],
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Int.mul_ediv_cancel'",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,8 +17,8 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",
@@ -185,7 +185,7 @@
     ]
   },
   "sorryCount": 0,
-  "status": "formalized",
+  "status": "verified",
   "badge": "verified",
   "leanFile": {
     "imports": [

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,10 +7,10 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "tags": [
       "combinatorics",
       "permutations",

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Euclid-style argument)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions#Special_cases",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DirichletsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -18,8 +18,8 @@
       "elementary",
       "research"
     ],
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.exists_prime_and_dvd",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -17,7 +17,7 @@
       "kelley-meka"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 140,
     "erdosUrl": "https://erdosproblems.com/140",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -16,13 +16,13 @@
       "number theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 963,
     "erdosUrl": "https://erdosproblems.com/963",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
     "lineCount": 430,
-    "assumptions": "2 axioms: greedy_lower_bound (known result), trivial_upper_bound (known result). 1 sorry: disjoint_pairs_card (combinatorial counting lemma). Conjecture stated as def ErdosProblem963 (not an axiom). Proved: dissociated_subset_sum_count, log_base_gap, powers_of_two_dissociated, maxDissociatedSize_mono, dissociated_subset, dissociated_card_le, dissociated_insert (extension lemma), dissociated_extend (greedy step), diffSumFinset_card_le, greedy_dissociated.",
+    "assumptions": "2 axioms: greedy_lower_bound (known result), trivial_upper_bound (known result). 0 sorries (disjoint_pairs_card now proved). Conjecture stated as def ErdosProblem963 (not an axiom). Proved: dissociated_subset_sum_count, log_base_gap, powers_of_two_dissociated, maxDissociatedSize_mono, dissociated_subset, dissociated_card_le, dissociated_insert (extension lemma), dissociated_extend (greedy step), diffSumFinset_card_le, greedy_dissociated.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Fixed 9 stale sorry counts where researchers proved remaining sorries but meta.json wasn't updated
- Upgraded 7 proofs from `formalized` to `verified` status (0 sorries, 0 axioms)
- Correctly classified `area-of-circle-oq-03-oq-02` as badge `mathlib` (Tier B: derives bounds from Mathlib's pi_gt_d4/pi_lt_d4)
- 2 proofs (`erdos-140`, `erdos-963`) remain `axiomatized` — only sorry count fixed
- Audited new entry `kummer-theorem-oq-02` — clean

**Gallery integrity: 1631/1631 audited, 0 issues, 0 critical**

## Changes per proof

| Proof | Sorries | Status | Badge |
|-------|---------|--------|-------|
| area-of-circle-oq-03-oq-02 | 1→0 | formalized→verified | formalized→mathlib |
| ballot-problem-oq-01-oq-01 | 2→0 | formalized→verified | formalized→original |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | 1→0 | formalized→verified | formalized→original |
| cayley-hamilton-minpoly-oq-05-oq-01 | 1→0 | formalized→verified | formalized→original |
| derangements-oq-02 | 1→0 | formalized→verified | formalized→original |
| dirichlets-theorem-oq-02 | 1→0 | formalized→verified | formalized→original |
| erdos-1006-oq-02-oq-03 | 1→0 | formalized→verified | formalized→original |
| erdos-140 | 3→0 | axiomatized (no change) | axiom (no change) |
| erdos-963 | 1→0 | axiomatized (no change) | axiom (no change) |

## Test plan
- [x] Each Lean source verified for actual sorry/axiom count
- [x] True stub check on all 9 files
- [x] Mathlib wrapper check (area-of-circle correctly classified as Tier B)
- [x] `find-targets.ts --stats` confirms 0 issues remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)