### PR TITLE
fix(metadata): erdos-299 sorries 1→0

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3875,9 +3875,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-299": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T10:48:39Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-3": {

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -18,7 +18,7 @@
       "additive-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 299,
     "erdosUrl": "https://erdosproblems.com/299",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 324,
-    "assumptions": "1 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #299 asks whether there exists an infinite sequence a₁ < a₂ < ... with bounded gaps (a_{i+1} - a_i = O(1)) such that no finite subset has reciprocals summing to exactly 1.\n\nThis question connects to the ancient study of Egyptian fractions (representing 1 as sums of distinct unit fractions) and modern density arguments. The key insight is that sequences with bounded gaps have positive density.\n\nThe problem was resolved by Thomas Bloom in 2021, who proved the stronger result (Problem #298) that any set of positive upper density contains a finite subset whose reciprocals sum to 1. Since bounded-gap sequences necessarily have positive density, no such sequence can avoid containing a unit fraction sum.\n\nBloom's work built on deep techniques from additive combinatorics and resolved a long-standing conjecture of Erdős and Graham.",


### PR DESCRIPTION
## Summary
- Fixed stale sorry count for `erdos-299` (Bloom's theorem on unit fractions)
- Sorry was proved but meta.json wasn't updated
- Status remains `axiomatized` with 1 axiom (`bloom_theorem`)

Gallery integrity: **1631/1631 audited, 0 issues**

## Test plan
- [x] Verified 0 sorries in Lean source
- [x] Verified 1 axiom declaration matches axiomCount
- [x] No structure-encoded assumptions
- [x] `find-targets.ts --stats` confirms 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)