### PR TITLE
Research: erdos-530 — prove interval upper bound, fix problem statement (4 new theorems)

### DIFF
--- a/proofs/Proofs/Erdos530Problem.lean
+++ b/proofs/Proofs/Erdos530Problem.lean
@@ -278,4 +278,104 @@ theorem sidon_sum_count (S : Finset ℤ) (hS : IsSidon S) :
   rw [Finset.card_image_of_injOn (sidon_sum_injective S hS)]
   exact card_sorted_pairs S
 
+/-
+## Section 7: Corrected problem statement
+
+The original ErdosProblem530 above has a universal upper bound (∀ A, ℓ(A)² ≤ c₂|A|),
+which is FALSE: geometric sequences {1, 2, 4, ..., 2^(N-1)} are entirely Sidon
+(distinct binary representations give distinct pairwise sums), so maxSidonSize = N
+and N² ≫ c₂·N for large N.
+
+The correct formulation: the LOWER bound is universal (every set has big Sidon subset),
+while the UPPER bound is existential (some sets of each size have bounded Sidon subsets).
+-/
+
+/-- Erdős Problem 530 (corrected): ℓ(N) = Θ(√N).
+    Lower bound (∀): every N-element set has Sidon subset of size Ω(√N) — KSS.
+    Upper bound (∃): for each N, some set has maxSidonSize ≤ O(√N) — {1,...,N}. -/
+def ErdosProblem530Corrected : Prop :=
+  (∃ c₁ : ℕ, c₁ ≥ 1 ∧ ∀ A : Finset ℤ, A.card ≥ 4 →
+    maxSidonSize A * maxSidonSize A ≥ c₁ * A.card) ∧
+  (∃ c₂ : ℕ, c₂ ≥ 1 ∧ ∀ N : ℕ, N ≥ 4 →
+    ∃ A : Finset ℤ, A.card = N ∧ maxSidonSize A * maxSidonSize A ≤ c₂ * N)
+
+/-
+## Section 8: Upper bound for interval sets
+
+For a Sidon subset S of {1,...,N}, the k(k+1)/2 distinct pairwise sums
+all lie in {1,...,2N}. Since |{1,...,2N}| = 2N, we get k(k+1)/2 ≤ 2N.
+Using evenness of k(k+1), this gives k(k+1) ≤ 4N, hence k² ≤ 4N.
+-/
+
+/-- Any Sidon subset of {1,...,N} has |S|² ≤ 4N.
+    Proof: k(k+1)/2 distinct sums fit in {1,...,2N} of size 2N. -/
+theorem sidon_subset_interval_bound (S : Finset ℤ) (N : ℕ) (hN : 1 ≤ N)
+    (hS : IsSidon S) (hRange : ∀ x ∈ S, 1 ≤ x ∧ x ≤ ↑N) :
+    S.card * S.card ≤ 4 * N := by
+  set k := S.card with hk_def
+  have h_count := sidon_sum_count S hS
+  -- Sums of sorted pairs from S lie in [1, 2N]
+  have h_sub : ((S ×ˢ S).filter (fun p => p.1 ≤ p.2)).image (fun p => p.1 + p.2) ⊆
+      Finset.Icc (1 : ℤ) (2 * ↑N) := by
+    intro s hs
+    simp only [Finset.mem_image, Prod.exists] at hs
+    obtain ⟨a, b, hab, rfl⟩ := hs
+    simp only [Finset.mem_filter, Finset.mem_product] at hab
+    rw [Finset.mem_Icc]
+    exact ⟨by linarith [(hRange a hab.1.1).1],
+           by linarith [(hRange a hab.1.1).2, (hRange b hab.1.2).2]⟩
+  -- |[1, 2N]| = 2N
+  have h_icc : (Finset.Icc (1 : ℤ) (2 * ↑N)).card = 2 * N := by
+    simp [Finset.card_Icc]; omega
+  -- k(k+1)/2 ≤ 2N
+  have h_sum_le : k * (k + 1) / 2 ≤ 2 * N := by
+    calc k * (k + 1) / 2
+        = (((S ×ˢ S).filter (fun p => p.1 ≤ p.2)).image (fun p => p.1 + p.2)).card :=
+          h_count.symm
+      _ ≤ (Finset.Icc (1 : ℤ) (2 * ↑N)).card := Finset.card_le_card h_sub
+      _ = 2 * N := h_icc
+  -- k(k+1) is even (one of k, k+1 is even)
+  have h_even : 2 ∣ k * (k + 1) := by
+    rcases Nat.even_or_odd k with ⟨m, hm⟩ | ⟨m, hm⟩
+    · exact ⟨m * (k + 1), by rw [hm]; ring⟩
+    · exact ⟨k * (m + 1), by rw [hm]; ring⟩
+  -- k(k+1) = 2*(k(k+1)/2) ≤ 2*2N = 4N
+  have h_prod : k * (k + 1) ≤ 4 * N :=
+    calc k * (k + 1) = k * (k + 1) / 2 * 2 := (Nat.div_mul_cancel h_even).symm
+      _ ≤ (2 * N) * 2 := Nat.mul_le_mul_right 2 h_sum_le
+      _ = 4 * N := by ring
+  -- k² ≤ k(k+1) ≤ 4N
+  calc k * k ≤ k * (k + 1) := Nat.mul_le_mul_left k (Nat.le_succ k)
+    _ ≤ 4 * N := h_prod
+
+/-- The interval {1,...,N} has maxSidonSize² ≤ 4N. -/
+theorem interval_sidon_upper (N : ℕ) (hN : 1 ≤ N) :
+    maxSidonSize (Finset.Icc (1 : ℤ) ↑N) * maxSidonSize (Finset.Icc (1 : ℤ) ↑N) ≤ 4 * N := by
+  set A := Finset.Icc (1 : ℤ) ↑N
+  set ss := A.powerset.filter (fun S => IsSidon S)
+  by_cases hne : ss.Nonempty
+  · obtain ⟨S₀, hS₀_mem, hS₀_max⟩ := ss.exists_max_image Finset.card hne
+    have hsup : ss.sup Finset.card = S₀.card := le_antisymm
+      (Finset.sup_le fun S hS => hS₀_max S hS) (Finset.le_sup hS₀_mem)
+    show ss.sup Finset.card * ss.sup Finset.card ≤ 4 * N
+    rw [hsup]
+    have hf := Finset.mem_filter.mp hS₀_mem
+    exact sidon_subset_interval_bound S₀ N hN hf.2
+      (fun x hx => Finset.mem_Icc.mp (Finset.mem_powerset.mp hf.1 hx))
+  · rw [Finset.not_nonempty_iff_eq_empty] at hne
+    show ss.sup Finset.card * ss.sup Finset.card ≤ 4 * N
+    simp [hne]
+
+/-- The card of Finset.Icc 1 N equals N for integers. -/
+private theorem icc_one_card (N : ℕ) : (Finset.Icc (1 : ℤ) ↑N).card = N := by
+  simp [Finset.card_Icc]; omega
+
+/-- The corrected Erdős Problem 530 is proved: ℓ(N) = Θ(√N).
+    Lower bound from KSS axiom; upper bound from interval sum counting (proved).
+    With c₁ from KSS and c₂ = 4, the witness is A = {1,...,N}. -/
+theorem erdos530_corrected_proof : ErdosProblem530Corrected :=
+  ⟨komlos_sulyok_szemeredi,
+   ⟨4, by omega, fun N hN =>
+     ⟨Finset.Icc (1 : ℤ) ↑N, icc_one_card N, interval_sidon_upper N (by omega)⟩⟩⟩
+
 end Erdos530

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -21,16 +21,16 @@
     "erdosUrl": "https://erdosproblems.com/530",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 281,
-    "assumptions": "2 axiom declarations: komlos_sulyok_szemeredi (KSS improved N^{1/2} lower bound, deep known result), alon_erdos_partition_conjecture (Sidon partition, open problem). erdos_lower_bound (N^{1/3}) now proved as corollary of KSS. 12 theorems proved.",
+    "lineCount": 381,
+    "assumptions": "2 axiom declarations: komlos_sulyok_szemeredi (KSS improved N^{1/2} lower bound, deep known result), alon_erdos_partition_conjecture (Sidon partition, open problem). ErdosProblem530Corrected proved from KSS + interval sum counting (erdos530_corrected_proof). 16 theorems proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12
+    "theoremCount": 16
   },
   "overview": {
     "historicalContext": "Originally posed by Riddell in 1969 and studied extensively by Erd\u0151s, this problem asks for the order of growth of $\\ell(N)$, the maximum size of a Sidon subset of any $N$-element set. A Sidon set (also called a $B_2$-set) has all pairwise sums distinct, a property introduced by Simon Sidon in the 1930s in connection with Fourier analysis. Erd\u0151s first proved the lower bound $\\ell(N) \\geq c N^{1/3}$ using a greedy argument. Koml\u00f3s, Sulyok, and Szemer\u00e9di then improved this to $\\ell(N) \\geq c \\sqrt{N}$ using a probabilistic deletion method. The upper bound $\\ell(N) \\leq (1+o(1))\\sqrt{N}$ follows from the observation that a Sidon set of size $k$ produces $k(k+1)/2$ distinct pairwise sums, which must fit within the ambient sumset. Together these give $\\sqrt{N} \\ll \\ell(N) \\leq (1+o(1))\\sqrt{N}$, so the order of growth is determined but the exact leading constant remains open. Alon and Erd\u0151s also conjectured a dual result: any $N$-element set can be partitioned into $O(\\sqrt{N})$ Sidon sets. The problem connects to the broader theory of $B_h$-sets, sum-free sets, and additive bases, and has applications in coding theory (error-correcting codes with good distance properties) and harmonic analysis (thin sets of integers with good Fourier properties).",
     "problemStatement": "For a finite set $A \\subset \\mathbb{R}$ of size $N$, let $\\ell(N)$ denote the maximum size of a Sidon subset. Determine the order of growth of $\\ell(N)$. It is conjectured that $\\ell(N) \\sim N^{1/2}$.",
     "text": "For a finite set A of size N, what is the maximum size \u2113(N) of a Sidon subset? Koml\u00f3s\u2013Sulyok\u2013Szemer\u00e9di: N^{1/2} \u226a \u2113(N) \u2264 (1+o(1))N^{1/2}. Conjectured: \u2113(N) ~ N^{1/2}. OPEN.",
-    "proofStrategy": "The formalization defines Sidon sets via the distinct pairwise sum condition, proves the empty set and singletons are Sidon (the only non-axiom theorems), defines $\\ell(A) = \\max\\{|S| : S \\subseteq A,\\; S$ Sidon$\\}$, and axiomatizes the known bounds: Erd\u0151s's $N^{1/3}$ lower bound, the Koml\u00f3s-Sulyok-Szemer\u00e9di $N^{1/2}$ lower bound, the $N^{1/2}$ upper bound, and the main conjecture $\\ell(N) = \\Theta(\\sqrt{N})$. The Alon-Erd\u0151s partition conjecture and the sum counting identity $k(k+1)/2$ are also recorded.",
+    "proofStrategy": "The formalization defines Sidon sets and maxSidonSize, then proves the corrected Erd\u0151s Problem 530 (\\ell(N) = \\Theta(\\sqrt{N})) from two ingredients: (1) the KSS lower bound \\ell(A)^2 \\geq c|A| (axiomatized), and (2) a new upper bound for interval sets: any Sidon subset of \\{1,...,N\\} has |S|^2 \\leq 4N, proved via sum counting (k(k+1)/2 distinct sums fit in \\{1,...,2N\\}). A key correction: the original universal upper bound (\\forall A) was false (powers of 2 are entirely Sidon); the correct formulation uses an existential upper bound (\\exists A).",
     "keyInsights": [
       "A Sidon set of size $k$ produces $k(k+1)/2$ distinct pairwise sums, giving the upper bound $\\ell(N) \\leq O(\\sqrt{N})$ via pigeonhole",
       "Koml\u00f3s-Sulyok-Szemer\u00e9di's probabilistic deletion: randomly sample, remove elements creating repeated sums, expected survivor size $\\Omega(\\sqrt{N})$",
@@ -116,10 +116,25 @@
       "endLine": 270,
       "summary": "Proves `sidon_sum_count`: a Sidon set of size $k$ has exactly $k(k+1)/2$ distinct pairwise sums. Combines `sidon_sum_injective` (injectivity $\\Rightarrow$ image card = domain card) with `card_sorted_pairs` ($k(k+1)/2$ sorted pairs). This was previously axiomatized and is now fully proved.",
       "mathContext": "The identity $|\\{a + b : (a,b) \\in S \\times S, a \\leq b\\}| = k(k+1)/2$ for $|S| = k$ Sidon is the key to the upper bound: if all $k(k+1)/2$ sums lie in $S + S \\subseteq \\{2\\min S, \\ldots, 2\\max S\\}$, then $k(k+1)/2 \\leq 2N - 1$, giving $k \\leq O(\\sqrt{N})$."
+    },
+    {
+      "id": "corrected-statement",
+      "title": "Corrected Problem Statement",
+      "startLine": 281,
+      "endLine": 300,
+      "summary": "Identifies that the original ErdosProblem530 has an incorrect universal upper bound: powers of 2 are entirely Sidon, giving maxSidonSize = N, so no universal $O(\\sqrt{N})$ bound holds. Defines ErdosProblem530Corrected with existential upper bound."
+    },
+    {
+      "id": "interval-upper-bound",
+      "title": "Interval Upper Bound",
+      "startLine": 302,
+      "endLine": 380,
+      "summary": "Proves sidon_subset_interval_bound: any Sidon subset of $\\{1,...,N\\}$ has $|S|^2 \\leq 4N$. Uses the sum counting theorem (k(k+1)/2 distinct sums), containment of sums in $\\{1,...,2N\\}$, and evenness of $k(k+1)$. Lifts to maxSidonSize via interval_sidon_upper. Finally proves erdos530_corrected_proof: the corrected $\\Theta(\\sqrt{N})$ result from KSS (axiom) + interval bound (proved).",
+      "mathContext": "The chain: $k(k+1)/2$ sums $\\subseteq \\{1,...,2N\\}$ of size $2N$, so $k(k+1)/2 \\leq 2N$, and since $k(k+1)$ is even, $k(k+1) \\leq 4N$, giving $k^2 \\leq k(k+1) \\leq 4N$. This is the standard sum-counting upper bound for Sidon subsets of intervals."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erd\u0151s Problem 530 with the known tight bounds: Koml\u00f3s-Sulyok-Szemer\u00e9di's lower bound \u2113(N) \u2265 c\u221aN and the upper bound \u2113(N) \u2264 (1+o(1))\u221aN from sum counting. The problem remains open \u2014 only the leading constant is undetermined. The Alon-Erd\u0151s partition conjecture provides a dual perspective.",
+    "summary": "The corrected formalization proves \u2113(N) = \u0398(\u221aN) from the KSS lower bound (axiom) and a new interval upper bound: any Sidon subset of {1,...,N} has |S|\u00b2 \u2264 4N (fully proved via sum counting). The original problem statement had an incorrect universal upper bound; powers of 2 provide a counterexample. Only the leading constant remains open.",
     "implications": "Resolving the exact asymptotics of \u2113(N) would advance additive combinatorics and connect to the partition problem of Alon and Erd\u0151s. Sidon sets have applications in error-correcting codes, compressed sensing, and Fourier analysis, where sets with distinct pairwise sums provide good frequency separation.",
     "openQuestions": [
       "Is $\\ell(N) = (1+o(1))\\sqrt{N}$ for all finite sets of size $N$? What is the optimal constant?",
@@ -140,10 +155,10 @@
       "Finset"
     ],
     "namespace": "Erdos530",
-    "lineCount": 281,
+    "lineCount": 381,
     "axiomCount": 2,
-    "theoremCount": 12,
-    "definitionCount": 4
+    "theoremCount": 16,
+    "definitionCount": 5
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-530.json
+++ b/src/data/research/problems/erdos-530.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PROGRESS: Fixed incorrect universal upper bound in ErdosProblem530 (counterexample: powers of 2 are Sidon). Proved interval upper bound: Sidon subsets of {1,...,N} have |S|^2 <= 4N. Proved corrected problem statement from KSS axiom + interval bound. 4 new theorems, 0 new sorries.",
     "builtItems": [
       "maxSidonSize_le_card: proved maxSidonSize A ≤ A.card (Erdos530Problem.lean:87)",
       "sidon_upper_bound: PROVED (was axiom) — trivial bound from subset property (Erdos530Problem.lean:95)",
@@ -42,7 +42,11 @@
       "isSidon_pair: any 2-element set is Sidon (16-case omega analysis)",
       "maxSidonSize_pos: nonempty sets have maxSidonSize ≥ 1",
       "maxSidonSize_ge_two: sets with ≥ 2 elements have maxSidonSize ≥ 2",
-      "theorem erdos_lower_bound: proved as corollary of KSS via le_mul_of_one_le_right (Erdos530Problem.lean:90-102)"
+      "theorem erdos_lower_bound: proved as corollary of KSS via le_mul_of_one_le_right (Erdos530Problem.lean:90-102)",
+      "sidon_subset_interval_bound: Sidon S in {1,...,N} => |S|^2 <= 4N (Erdos530Problem.lean:312)",
+      "interval_sidon_upper: maxSidonSize(Icc 1 N)^2 <= 4N (Erdos530Problem.lean:352)",
+      "ErdosProblem530Corrected: corrected problem statement with existential upper bound (Erdos530Problem.lean:296)",
+      "erdos530_corrected_proof: proof of corrected Theta(sqrt(N)) result (Erdos530Problem.lean:376)"
     ],
     "insights": [
       "sidon_upper_bound was trivially true (maxSidonSize A ≤ A.card, squared) — eliminated as axiom",
@@ -56,7 +60,11 @@
       "Finset.card_bij cleaner than Finset.map for bijection proofs in this context",
       "sidon_sum_count = card_image_of_injOn + card_sorted_pairs — clean decomposition",
       "erdos_lower_bound (N^{1/3}) follows trivially from komlos_sulyok_szemeredi (N^{1/2}): k²≥cN and k≥1 implies k³=k·k²≥cN",
-      "Remaining 2 axioms: KSS (deep known result, probabilistic method) and Alon-Erdos partition (open)"
+      "Remaining 2 axioms: KSS (deep known result, probabilistic method) and Alon-Erdos partition (open)",
+      "Original ErdosProblem530 had incorrect universal upper bound — powers of 2 are entirely Sidon, giving counterexample",
+      "Proved sidon_subset_interval_bound: any Sidon S in {1,...,N} has |S|^2 <= 4N via sum counting + evenness",
+      "Proved interval_sidon_upper: maxSidonSize({1,...,N})^2 <= 4N by lifting per-subset bound via exists_max_image",
+      "Proved erdos530_corrected_proof: ErdosProblem530Corrected follows from KSS axiom + interval upper bound with c2=4"
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
- Fixed incorrect universal upper bound in ErdosProblem530 (powers of 2 are entirely Sidon, providing counterexample)
- Added `ErdosProblem530Corrected` with existential upper bound
- Proved `sidon_subset_interval_bound`: any Sidon S ⊆ {1,...,N} has |S|² ≤ 4N via sum counting + evenness of k(k+1)
- Proved `interval_sidon_upper`: maxSidonSize({1,...,N})² ≤ 4N
- Proved `erdos530_corrected_proof`: Θ(√N) from KSS axiom + interval bound with c₂ = 4

## Key Mathematical Insight
The original `ErdosProblem530` stated a universal upper bound (∀ A, maxSidonSize(A)² ≤ c₂|A|), which is **false**: geometric sequences like {1, 2, 4, ..., 2^(N-1)} are entirely Sidon (distinct binary representations give distinct pairwise sums), giving maxSidonSize = N and N² ≫ c₂N. The correct formulation has an existential upper bound, witnessed by {1,...,N}.

## Files Modified
- `proofs/Proofs/Erdos530Problem.lean` (+100 lines, 4 new theorems, 1 new definition)
- `src/data/proofs/erdos-530/meta.json` (updated sections, theorem count, proof strategy)
- `src/data/research/problems/erdos-530.json` (updated knowledge)

## Status
**Outcome**: progress — corrected formalization, proved upper bound
**Axioms**: 2 unchanged (KSS: deep known result, Alon-Erdős: open conjecture)
**Build**: Docker unavailable; awaiting CI verification

Generated by researcher-10