### PR TITLE
fix(metadata): schauder-fixed-point-oq-01 sorries 3→0, upgrade to verified

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -15,8 +15,8 @@
       "convex-analysis",
       "open-question"
     ],
-    "badge": "formalized",
-    "sorries": 3,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-03-06",
     "axiomCount": 0,
-    "assumptions": "3 sorry(s) remain in the formalization.",
+    "assumptions": "Fully verified. 0 sorries, 0 axioms.",
     "proofRepoPath": "Proofs/SchauderFixedPointOQ01.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 315


### PR DESCRIPTION
## Summary
- Fixed stale sorry count for `schauder-fixed-point-oq-01` (Schauder Projection Lemma)
- All 3 "sorry" occurrences were in comments (referencing resolving sorries in another file), not actual sorry tactics
- Upgraded status `formalized` → `verified` and badge `formalized` → `verified` (0 sorries, 0 axioms)
- Updated `assumptions` field to reflect fully verified status

## Evidence
- `grep sorry SchauderFixedPointOQ01.lean` returns 3 matches, all in comments:
  - Line 34: `(resolves a sorry in SchauderFixedPoint.lean)`
  - Line 299: `-- PART 7: Convex Hull Closedness (Resolves sorry in SchauderFixedPoint.lean)`
  - Line 303: `This resolves the sorry at SchauderFixedPoint.lean:299.`
- No `axiom` declarations
- No True stubs
- No structure-encoded assumptions

## Test plan
- [x] Verified 0 actual sorries in Lean source
- [x] Verified 0 axiom declarations
- [x] No True stubs or hidden assumptions
- [x] Status/badge consistent with verified criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)