### PR TITLE
Research: erdos-14 — prove 2 axioms (Erdos140: 9→8, Erdos141: 3→2)

### DIFF
--- a/proofs/Proofs/Erdos140Problem.lean
+++ b/proofs/Proofs/Erdos140Problem.lean
@@ -259,8 +259,27 @@ def ErdosAPConjecture : Prop :=
   ∀ k ≥ 3, ∀ C > 0, ∃ K > 0, ∀ N ≥ 3, (rk k N : ℝ) ≤ K * N / (Real.log N)^C
 
 /-- Finset3APFree is equivalent to FinsetkAPFree 3 (modulo formulation details). -/
-axiom finset3APFree_eq_finsetkAPFree_3 : ∀ A : Finset ℕ,
-    Finset3APFree A ↔ FinsetkAPFree 3 A
+theorem finset3APFree_eq_finsetkAPFree_3 : ∀ A : Finset ℕ,
+    Finset3APFree A ↔ FinsetkAPFree 3 A := by
+  intro A
+  constructor
+  · -- Forward: Finset3APFree → FinsetkAPFree 3
+    -- Given no 3-AP in A (by triple), show no 3-AP in A (by Fin 3 → ℕ)
+    intro h3AP vals hvals hAPk
+    obtain ⟨_, a, d, hd, hform⟩ := hAPk
+    -- Extract values: vals(0) = a, vals(1) = a + d, vals(2) = a + 2*d
+    have h0 := hform ⟨0, by omega⟩; simp at h0
+    have h1 := hform ⟨1, by omega⟩; simp at h1
+    have h2 := hform ⟨2, by omega⟩; simp at h2
+    -- Build IsAP3 and derive contradiction from h3AP
+    exact h3AP _ _ _ (hvals ⟨0, by omega⟩) (hvals ⟨1, by omega⟩) (hvals ⟨2, by omega⟩)
+      ⟨by omega, by omega, by omega⟩
+  · -- Backward: FinsetkAPFree 3 → Finset3APFree
+    -- Given no 3-AP in A (by Fin 3 → ℕ), show no 3-AP in A (by triple)
+    intro hkAP a b c ha hb hc ⟨h2b, hab, hbc⟩
+    exact hkAP ![a, b, c]
+      (by intro i; fin_cases i <;> simp_all)
+      ⟨by omega, a, b - a, by omega, by intro i; fin_cases i <;> simp_all <;> omega⟩
 
 /-- r3 equals rk 3 (the Roth numbers are the same for both formulations). -/
 theorem r3_eq_rk_3 (N : ℕ) : r3 N = rk 3 N := by

--- a/proofs/Proofs/Erdos141Problem.lean
+++ b/proofs/Proofs/Erdos141Problem.lean
@@ -96,7 +96,12 @@ theorem three_five_seven_is_ap : IsArithmeticProgression [3, 5, 7] 2 := by
 
 /-- There exist 3 consecutive primes in arithmetic progression: (3, 5, 7).
     Verified by showing primes 1, 2, 3 (which are 3, 5, 7) form an AP with d=2. -/
-axiom exists_3_consecutive_in_ap : ExistsConsecutivePrimesInAP 3
+theorem exists_3_consecutive_in_ap : ExistsConsecutivePrimesInAP 3 := by
+  refine ⟨1, 2, by omega, ?_⟩
+  suffices h : ConsecutivePrimeSequence 1 3 = [3, 5, 7] by rw [h]; exact three_five_seven_is_ap
+  simp only [ConsecutivePrimeSequence]
+  have hr : List.range 3 = [0, 1, 2] := by decide
+  rw [hr]; simp [nthPrime_1, nthPrime_2, nthPrime_3]
 
 /- ## The Erdős Conjecture -/
 

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/140",
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$500",
-    "axiomCount": 9,
+    "axiomCount": 8,
     "prerequisites": [
       "arithmetic-progressions",
       "density-arguments",
@@ -31,7 +31,7 @@
       "extremal-set-theory"
     ],
     "lineCount": 267,
-    "assumptions": "9 axiom(s) and 3 sorry(s). See the Lean source for details.",
+    "assumptions": "8 axiom(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -184,8 +184,8 @@
     ],
     "namespace": "Erdos140",
     "lineCount": 267,
-    "axiomCount": 9,
-    "theoremCount": 6,
+    "axiomCount": 8,
+    "theoremCount": 7,
     "definitionCount": 11
   },
   "references": [

--- a/src/data/proofs/erdos-141/meta.json
+++ b/src/data/proofs/erdos-141/meta.json
@@ -46,9 +46,9 @@
       "Distinction between Green-Tao (any primes in AP) vs. Erdős #141 (consecutive primes)",
       "Formalization of related open questions (infinitely many APs, k=11 case)"
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 171,
-    "assumptions": "3 axiom(s): exists_3_consecutive_in_ap, small_cases_verified, green_tao. See Lean source for complete statements."
+    "assumptions": "2 axiom(s): small_cases_verified, green_tao. See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "Erdős Problem #141 was posed in 1975 and asks whether, for every k >= 3, there exist k consecutive primes that form an arithmetic progression. Erdős famously called this conjecture 'completely hopeless at present.'\n\nThe distinction from the celebrated Green-Tao theorem (2008) is crucial: Green-Tao proves that the primes contain arbitrarily long arithmetic progressions, but these primes need not be consecutive. For example, (7, 13, 19) form an AP with common difference 6, but they are not consecutive primes since 11 lies between 7 and 13.\n\nComputational verification has confirmed the existence of such progressions for k <= 10, but the case k = 11 remains open, as does the general question for all k.",
@@ -133,8 +133,8 @@
     ],
     "namespace": "Erdos141",
     "lineCount": 171,
-    "axiomCount": 3,
-    "theoremCount": 9,
+    "axiomCount": 2,
+    "theoremCount": 10,
     "definitionCount": 9
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary
- Prove `finset3APFree_eq_finsetkAPFree_3` in Erdos140Problem.lean: equivalence between triple-based and Fin 3-based 3-AP-free definitions (axiom→theorem)
- Prove `exists_3_consecutive_in_ap` in Erdos141Problem.lean: witnesses (3, 5, 7) as 3 consecutive primes in AP (axiom→theorem)
- Update meta.json axiom counts

## Progress
- Erdos140Problem.lean: 9→8 axioms (proved definitional equivalence of AP formulations)
- Erdos141Problem.lean: 3→2 axioms (constructed witness using existing nthPrime lemmas)

## Findings
- All remaining axioms in Erdos14Problem.lean (6) and Erdos14UniqueSums.lean (3) are deep (open conjectures or published results)
- Erdos140 remaining 8 axioms are major results (Roth, Bourgain, Sanders, Bloom-Sisask, Kelley-Meka, Behrend, greedy_is_3APFree)
- Erdos141 remaining 2 axioms: small_cases_verified (k≤10), green_tao (any primes in AP)

## Status
**Outcome**: progress (2 axioms eliminated)
**Next Steps**: greedy_is_3APFree (base-3 argument) and small_cases_verified (computational) are next targets

🤖 Generated by researcher-9