### PR TITLE
Research: prove 18 sorries across 8 Aristotle companion files

### DIFF
--- a/proofs/Proofs/Erdos1037Aristotle.lean
+++ b/proofs/Proofs/Erdos1037Aristotle.lean
@@ -43,7 +43,24 @@ theorem distinctDegrees_le_card :
 theorem pigeonhole_distinct_count (f : V → ℕ) (k : ℕ) (hk : k ≥ 1)
     (h : ∀ d : ℕ, (Finset.univ.filter (fun v => f v = d)).card ≤ k) :
     (Finset.univ.image f).card ≥ Fintype.card V / k := by
-  sorry
+  suffices Fintype.card V ≤ k * (Finset.univ.image f).card by
+    calc Fintype.card V / k
+        ≤ (k * (Finset.univ.image f).card) / k := Nat.div_le_div_right this
+      _ = (Finset.univ.image f).card := Nat.mul_div_cancel_left _ (by omega)
+  rw [← Finset.card_univ]
+  have hpart : (Finset.univ : Finset V) =
+      (Finset.univ.image f).biUnion (fun d => Finset.univ.filter (fun v => f v = d)) := by
+    ext v; simp
+  rw [hpart, Finset.card_biUnion]
+  · calc ∑ d ∈ Finset.univ.image f, (Finset.univ.filter (fun v => f v = d)).card
+        ≤ ∑ _ ∈ Finset.univ.image f, k := Finset.sum_le_sum (fun d _ => h d)
+      _ = (Finset.univ.image f).card * k := by rw [Finset.sum_const, smul_eq_mul]
+      _ = k * (Finset.univ.image f).card := mul_comm _ _
+  · intro d _ e _ hde
+    rw [Finset.disjoint_left]
+    intro v hv1 hv2
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hv1 hv2
+    exact hde (hv1.symm.trans hv2)
 
 -- Routine: Degree values range in {0, ..., n-1}
 theorem degree_range :
@@ -56,14 +73,55 @@ theorem degree_range :
 -- Routine: The complement graph has degree (n-1) - deg_G(v)
 -- Aristotle target: needs SimpleGraph.degree_compl or manual neighborFinset argument
 theorem complement_degree (v : V) :
-    Gᶜ.degree v = Fintype.card V - 1 - G.degree v := by sorry
+    Gᶜ.degree v = Fintype.card V - 1 - G.degree v := by
+  simp only [SimpleGraph.degree]
+  have hv_G : v ∉ G.neighborFinset v := G.not_mem_neighborFinset_self v
+  have hv_C : v ∉ Gᶜ.neighborFinset v := Gᶜ.not_mem_neighborFinset_self v
+  have hunion : Gᶜ.neighborFinset v ∪ G.neighborFinset v = Finset.univ.erase v := by
+    ext w
+    simp only [Finset.mem_union, SimpleGraph.mem_neighborFinset, SimpleGraph.compl_adj,
+               Finset.mem_erase, Finset.mem_univ, and_true]
+    constructor
+    · rintro (⟨hvw, _⟩ | hadj)
+      · exact hvw.symm
+      · exact (G.ne_of_adj hadj).symm
+    · intro hwv
+      by_cases h : G.Adj v w
+      · exact Or.inr h
+      · exact Or.inl ⟨hwv.symm, h⟩
+  have hdisj : Disjoint (Gᶜ.neighborFinset v) (G.neighborFinset v) := by
+    rw [Finset.disjoint_left]
+    intro w hw1 hw2
+    rw [SimpleGraph.mem_neighborFinset] at hw1 hw2
+    rw [SimpleGraph.compl_adj] at hw1
+    exact hw1.2 hw2
+  have hcard := Finset.card_union_of_disjoint hdisj
+  rw [hunion, Finset.card_erase_of_mem (Finset.mem_univ v), Finset.card_univ] at hcard
+  omega
 
 -- Routine: If every degree appears at most twice and degrees ∈ {0,...,n-1},
 -- then the number of distinct degrees ≤ n, and n ≤ 2 * distinctDegrees
 theorem limited_mult_bound_from_pigeonhole
     (h : ∀ d : ℕ, (Finset.univ.filter (fun v => G.degree v = d)).card ≤ 2) :
     Fintype.card V ≤ 2 * (Finset.univ.image (fun v => G.degree v)).card := by
-  sorry
+  rw [← Finset.card_univ]
+  have hpart : (Finset.univ : Finset V) =
+      (Finset.univ.image (fun v => G.degree v)).biUnion
+        (fun d => Finset.univ.filter (fun v => G.degree v = d)) := by
+    ext v; simp
+  rw [hpart, Finset.card_biUnion]
+  · calc ∑ d ∈ Finset.univ.image (fun v => G.degree v),
+          (Finset.univ.filter (fun v => G.degree v = d)).card
+        ≤ ∑ _ ∈ Finset.univ.image (fun v => G.degree v), 2 :=
+          Finset.sum_le_sum (fun d _ => h d)
+      _ = (Finset.univ.image (fun v => G.degree v)).card * 2 := by
+          rw [Finset.sum_const, smul_eq_mul]
+      _ = 2 * (Finset.univ.image (fun v => G.degree v)).card := mul_comm _ _
+  · intro d _ e _ hde
+    rw [Finset.disjoint_left]
+    intro v hv1 hv2
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hv1 hv2
+    exact hde (hv1.symm.trans hv2)
 
 -- Routine: 3/4 > 2/3 (comparing optimal bounds)
 theorem three_fourths_gt_two_thirds : (3 : ℝ) / 4 > 2 / 3 := by norm_num

--- a/proofs/Proofs/Erdos1048Aristotle.lean
+++ b/proofs/Proofs/Erdos1048Aristotle.lean
@@ -22,13 +22,18 @@ theorem polynomial_sublevel_isOpen (f : ℂ[X]) (c : ℝ) (hc : c > 0) :
 
 -- Routine: X^n - C a is monic for n ≥ 1
 theorem xpow_sub_const_monic (a : ℂ) (n : ℕ) (hn : n ≥ 1) :
-    (X ^ n - C a : ℂ[X]).leadingCoeff = 1 := by
-  sorry
+    (X ^ n - C a : ℂ[X]).leadingCoeff = 1 :=
+  (Polynomial.monic_X_pow_sub_C a (by omega : n ≠ 0)).leadingCoeff
 
 -- Routine: Degree of X^n - C a is n for n ≥ 1
 theorem xpow_sub_const_degree (a : ℂ) (n : ℕ) (hn : n ≥ 1) :
     (X ^ n - C a : ℂ[X]).degree = n := by
-  sorry
+  rw [Polynomial.degree_sub_eq_left_of_degree_lt]
+  · exact Polynomial.degree_X_pow n
+  · calc (C a : ℂ[X]).degree
+        ≤ 0 := Polynomial.degree_C_le
+      _ < ↑n := by exact_mod_cast (show (0 : ℕ) < n from by omega)
+      _ = (X ^ n : ℂ[X]).degree := (Polynomial.degree_X_pow n).symm
 
 -- Routine: |r * exp(iθ)| = |r| for r : ℝ
 theorem abs_mul_exp (r : ℝ) (θ : ℝ) :

--- a/proofs/Proofs/Erdos1048Aristotle.lean
+++ b/proofs/Proofs/Erdos1048Aristotle.lean
@@ -33,7 +33,7 @@ theorem xpow_sub_const_degree (a : ℂ) (n : ℕ) (hn : n ≥ 1) :
 -- Routine: |r * exp(iθ)| = |r| for r : ℝ
 theorem abs_mul_exp (r : ℝ) (θ : ℝ) :
     Complex.abs (r * Complex.exp (θ * Complex.I)) = |r| := by
-  sorry
+  rw [map_mul, abs_exp_ofReal_mul_I, mul_one, abs_ofReal]
 
 -- Routine: If z^n = r^n for r > 0, then |z| = r
 theorem abs_root_of_pow_eq (z : ℂ) (r : ℝ) (n : ℕ) (hr : r > 0) (hn : n ≥ 1)

--- a/proofs/Proofs/Erdos1049Aristotle.lean
+++ b/proofs/Proofs/Erdos1049Aristotle.lean
@@ -22,7 +22,9 @@ def tau (n : ℕ) : ℕ := n.divisors.card
 -- Routine: τ is multiplicative for coprime arguments
 theorem tau_multiplicative (m n : ℕ) (hmn : m.Coprime n) :
     tau (m * n) = tau m * tau n := by
-  sorry
+  simp only [tau]
+  rw [hmn.divisors_mul]
+  exact Finset.card_product _ _
 
 -- Routine: The series ∑ 1/t^n converges for t > 1
 theorem inv_pow_summable (t : ℝ) (ht : t > 1) :

--- a/proofs/Proofs/Erdos1052Aristotle.lean
+++ b/proofs/Proofs/Erdos1052Aristotle.lean
@@ -22,11 +22,28 @@ def unitaryDivisorSum (n : ℕ) : ℕ :=
   ((Finset.Ico 1 (n + 1)).filter (fun d => d ∣ n ∧ d.Coprime (n / d))).sum id
 
 /-- σ*(1) = 1: the only unitary divisor of 1 is 1 itself. -/
-theorem unitaryDivisorSum_one : unitaryDivisorSum 1 = 1 := by sorry
+theorem unitaryDivisorSum_one : unitaryDivisorSum 1 = 1 := by native_decide
 
 /-- σ*(p) = 1 + p for prime p: the unitary divisors of a prime are 1 and p. -/
 theorem unitaryDivisorSum_prime {p : ℕ} (hp : p.Prime) :
-    unitaryDivisorSum p = 1 + p := by sorry
+    unitaryDivisorSum p = 1 + p := by
+  simp only [unitaryDivisorSum]
+  -- For prime p, Ico 1 (p+1) filtered by (d ∣ p ∧ d.Coprime (p/d)) = {1, p}
+  have hp2 : p ≥ 2 := hp.two_le
+  have : (Finset.Ico 1 (p + 1)).filter (fun d => d ∣ p ∧ d.Coprime (p / d)) = {1, p} := by
+    ext d
+    simp only [Finset.mem_filter, Finset.mem_Ico, Finset.mem_insert, Finset.mem_singleton]
+    constructor
+    · rintro ⟨⟨hd1, hdp1⟩, hdvd, hcop⟩
+      rcases hp.eq_one_or_self_of_dvd d hdvd with rfl | rfl
+      · left; rfl
+      · right; rfl
+    · rintro (rfl | rfl)
+      · exact ⟨⟨le_refl 1, by omega⟩, one_dvd p, Nat.coprime_one_left _⟩
+      · refine ⟨⟨by omega, by omega⟩, dvd_refl p, ?_⟩
+        simp [Nat.div_self (by omega : 0 < p), Nat.Coprime.symm, Nat.coprime_one_right]
+  rw [this]
+  simp [Finset.sum_insert (by simp [Nat.Prime.ne_one hp] : p ∉ ({1} : Finset ℕ))]
 
 /-- For a prime power p^k with k ≥ 1, σ*(p^k) = 1 + p^k.
     The only unitary divisors are 1 and p^k itself. -/
@@ -35,7 +52,22 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : p.Prime) (hk : 0 < k) :
 
 /-- The number of proper unitary divisors of a prime is 1 (just {1}). -/
 theorem card_properUnitaryDivisors_prime {p : ℕ} (hp : p.Prime) :
-    (properUnitaryDivisors p).card = 1 := by sorry
+    (properUnitaryDivisors p).card = 1 := by
+  have hp1 : p ≥ 2 := hp.two_le
+  simp only [properUnitaryDivisors]
+  -- Ico 1 p filtered to {d | d ∣ p ∧ d.Coprime (p/d)}
+  -- For prime p, divisors are 1 and p. Only d < p qualifies, so d = 1.
+  -- 1 ∣ p ✓, Coprime 1 (p/1) = Coprime 1 p ✓
+  convert Finset.card_singleton (1 : ℕ) using 1
+  ext d
+  simp only [Finset.mem_filter, Finset.mem_Ico, Finset.mem_singleton]
+  constructor
+  · rintro ⟨⟨hd1, hdp⟩, hdvd, hcop⟩
+    rcases hp.eq_one_or_self_of_dvd d hdvd with rfl | rfl
+    · rfl
+    · omega
+  · rintro rfl
+    exact ⟨⟨le_refl 1, hp1⟩, one_dvd p, Nat.coprime_one_left _⟩
 
 /-- If d is a unitary divisor of n, then n/d is also a unitary divisor of n. -/
 theorem unitary_complement_mem {n d : ℕ} (hn : 0 < n)

--- a/proofs/Proofs/Erdos265Aristotle.lean
+++ b/proofs/Proofs/Erdos265Aristotle.lean
@@ -51,6 +51,7 @@ theorem eventually_pow_ge_id (β : ℝ) (hβ : β > 1) :
 -- Strategy: This should be in Mathlib as Real.rpow_le_rpow_of_exponent_le
 -- Key tools: Real.rpow_le_rpow_of_exponent_le
 theorem rpow_mono_exponent (x : ℝ) (hx : 1 ≤ x) (p q : ℝ) (hpq : p ≤ q) :
-    x ^ p ≤ x ^ q := by sorry
+    x ^ p ≤ x ^ q :=
+  Real.rpow_le_rpow_of_exponent_le hx hpq
 
 end Erdos265Aristotle

--- a/proofs/Proofs/Erdos268Aristotle.lean
+++ b/proofs/Proofs/Erdos268Aristotle.lean
@@ -32,7 +32,10 @@ def powersOf2Set : Set ℕ := {n | ∃ k : ℕ, n = 2 ^ k}
 -- Routine: Finite sets have convergent harmonic subseries
 theorem finite_has_convergent (A : Set ℕ) (hA : A.Finite) :
     HasConvergentHarmonicSubseries A := by
-  sorry
+  simp only [HasConvergentHarmonicSubseries]
+  haveI : Finite ↥A := hA.to_subtype
+  haveI := Fintype.ofFinite ↥A
+  exact (hasSum_fintype _).summable
 
 -- Routine: If A has convergent harmonic sum, shifted version is also summable
 theorem shifted_summable (A : Set ℕ) (k : ℕ)
@@ -54,7 +57,8 @@ theorem powers_convergent : HasConvergentHarmonicSubseries powersOf2Set := by
 theorem shiftedHarmonicSum_nonneg (A : Set ℕ) (k : ℕ)
     (hA : A.Nonempty) (h : Summable (fun n : A => (1 : ℝ) / (n + k))) :
     shiftedHarmonicSum A k ≥ 0 := by
-  sorry
+  simp only [shiftedHarmonicSum]
+  exact tsum_nonneg (fun n => div_nonneg one_nonneg (by positivity))
 
 -- Routine: Shifted harmonic sum is decreasing in k
 -- (1/(n+j) < 1/(n+i) when i < j)

--- a/proofs/Proofs/Erdos454Aristotle.lean
+++ b/proofs/Proofs/Erdos454Aristotle.lean
@@ -71,7 +71,10 @@ theorem symmetric_sum_at_zero (n : ℕ) (hn : n > 0) :
 
 /-- f(n) ≤ 2p_n, since the infimum includes the i=0 term. -/
 theorem f_le_twice_nthPrime (n : ℕ) (hn : n > 0) :
-    f n ≤ 2 * nthPrime n := by sorry
+    f n ≤ 2 * nthPrime n := by
+  simp only [f, if_neg (by omega : n ≠ 0)]
+  refine (ciInf_le ⟨0, by rintro _ ⟨_, rfl⟩; exact Nat.zero_le _⟩ ⟨0, hn⟩).trans ?_
+  simp [symmetric_sum_at_zero n hn]
 
 /-- The two definitions of f are equivalent. -/
 theorem f_eq_f' (n : ℕ) : f n = f' n := by sorry

--- a/proofs/Proofs/Erdos601Aristotle.lean
+++ b/proofs/Proofs/Erdos601Aristotle.lean
@@ -32,20 +32,24 @@ theorem transfinite_induction (P : Ordinal → Prop)
     · exact hL α hα ih
 
 /-- The ordinal hierarchy: ω < ω₁. -/
-theorem omega_lt_omega1 : ω < Ordinal.omega1 := by
-  sorry
+theorem omega_lt_omega1 : ω < Ordinal.omega1 :=
+  omega0_lt_omega1
+
+private theorem one_lt_omega1 : (1 : Ordinal) < Ordinal.omega1 :=
+  lt_trans one_lt_omega0 omega0_lt_omega1
 
 /-- ω₁ < ω₁ ^ ω (ordinal exponentiation). -/
 theorem omega1_lt_omega1_pow_omega : Ordinal.omega1 < Ordinal.omega1 ^ ω := by
-  sorry
+  conv_lhs => rw [← opow_one Ordinal.omega1]
+  exact opow_lt_opow_right one_lt_omega1 one_lt_omega0
 
 /-- ω₁ ^ ω < ω₁ ^ (ω + 1). -/
-theorem omega1_pow_omega_lt_succ : Ordinal.omega1 ^ ω < Ordinal.omega1 ^ (ω + 1) := by
-  sorry
+theorem omega1_pow_omega_lt_succ : Ordinal.omega1 ^ ω < Ordinal.omega1 ^ (ω + 1) :=
+  opow_lt_opow_right one_lt_omega1 (lt_add_of_pos_right ω one_pos)
 
 /-- ω₁ ^ (ω + 1) < ω₁ ^ (ω + 2). -/
-theorem omega1_pow_succ_lt : Ordinal.omega1 ^ (ω + 1) < Ordinal.omega1 ^ (ω + 2) := by
-  sorry
+theorem omega1_pow_succ_lt : Ordinal.omega1 ^ (ω + 1) < Ordinal.omega1 ^ (ω + 2) :=
+  opow_lt_opow_right one_lt_omega1 (lt_add_of_pos_right (ω + 1) one_pos)
 
 /-- A disjunction P ∨ Q is equivalent to (¬P → Q) when decidable. -/
 theorem or_iff_not_imp {P Q : Prop} : (P ∨ Q) ↔ (¬P → Q) :=

--- a/proofs/Proofs/Erdos673Aristotle.lean
+++ b/proofs/Proofs/Erdos673Aristotle.lean
@@ -85,7 +85,9 @@ theorem tau_prime (p : ℕ) (hp : p.Prime) : tau p = 2 := by
 theorem tau_multiplicative (m n : ℕ) (hm : m ≥ 1) (hn : n ≥ 1)
     (hcop : Nat.Coprime m n) :
     tau (m * n) = tau m * tau n := by
-  sorry
+  simp only [tau]
+  rw [hcop.divisors_mul]
+  exact Finset.card_product _ _
 
 -- Routine lemma: G(n) ≥ 0 for all n (sum of nonneg ratios)
 theorem G_nonneg (n : ℕ) : G n ≥ 0 := by

--- a/proofs/Proofs/Erdos866Aristotle.lean
+++ b/proofs/Proofs/Erdos866Aristotle.lean
@@ -50,7 +50,16 @@ theorem upperExponent_increasing (k : ℕ) (hk : k ≥ 1) :
   exact pow_lt_pow_right (by norm_num : (2:ℝ)⁻¹ < 1) (by omega)
 
 -- Routine lemma: the odd numbers in {1,...,2N} have cardinality N
-theorem oddNumbers_card (N : ℕ) : (oddNumbers N).card = N := by sorry
+theorem oddNumbers_card (N : ℕ) : (oddNumbers N).card = N := by
+  have : oddNumbers N = (Finset.range N).image (fun k => 2 * k + 1) := by
+    ext n
+    simp only [oddNumbers, Interval, Finset.mem_filter, Finset.mem_range, Finset.mem_image]
+    constructor
+    · intro ⟨⟨hlt, hge⟩, hodd⟩
+      exact ⟨n / 2, by omega, by omega⟩
+    · rintro ⟨k, hk, rfl⟩
+      exact ⟨⟨by omega, by omega⟩, by omega⟩
+  rw [this, Finset.card_image_of_injective _ (by intro a b h; omega), Finset.card_range]
 
 -- Routine lemma: parity pigeonhole — among any 3 integers,
 -- two share parity, so their sum is even and not in oddNumbers

--- a/proofs/Proofs/Erdos895Aristotle.lean
+++ b/proofs/Proofs/Erdos895Aristotle.lean
@@ -73,7 +73,16 @@ theorem odd_set_sumFree (n : ℕ) :
 -- There are ⌈n/2⌉ odd numbers in {1,...,n}.
 theorem odd_count_in_range (n : ℕ) :
     ((Finset.range (n + 1)).filter (fun x => x > 0 ∧ x % 2 = 1)).card = (n + 1) / 2 := by
-  sorry
+  have : (Finset.range (n + 1)).filter (fun x => x > 0 ∧ x % 2 = 1) =
+      (Finset.range ((n + 1) / 2)).image (fun k => 2 * k + 1) := by
+    ext x
+    simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_image]
+    constructor
+    · intro ⟨hlt, hpos, hodd⟩
+      exact ⟨x / 2, by omega, by omega⟩
+    · rintro ⟨k, hk, rfl⟩
+      exact ⟨by omega, by omega, by omega⟩
+  rw [this, Finset.card_image_of_injective _ (by intro a b h; omega), Finset.card_range]
 
 -- Routine: If a, b, a+b are all in {0,...,n-1} then a+b < n
 -- Simple arithmetic used in Fin-based additive triple definitions.

--- a/proofs/Proofs/Erdos956Aristotle.lean
+++ b/proofs/Proofs/Erdos956Aristotle.lean
@@ -28,22 +28,44 @@ def translate (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fi
 -- Routine: Symmetry of set distance (follows from dist_comm)
 theorem setDistance_symm {X : Type*} [PseudoMetricSpace X] (C D : Set X) :
     setDistance C D = setDistance D C := by
-  sorry
+  unfold setDistance
+  congr 1
+  ext x
+  simp only [Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨c, d, hc, hd, rfl⟩
+    exact ⟨d, c, hd, hc, (dist_comm c d).symm⟩
+  · rintro ⟨d, c, hd, hc, rfl⟩
+    exact ⟨c, d, hc, hd, (dist_comm c d)⟩
 
 -- Routine: Non-negativity of set distance (dist is non-negative, so is its infimum)
 theorem setDistance_nonneg {X : Type*} [PseudoMetricSpace X] (C D : Set X) :
     setDistance C D ≥ 0 := by
-  sorry
+  unfold setDistance
+  rcases Set.eq_empty_or_nonempty { x | ∃ c ∈ C, ∃ d ∈ D, x = dist c d } with h | h
+  · rw [h]; simp [Real.sInf_empty]
+  · exact le_csInf h (by rintro _ ⟨c, _, d, _, rfl⟩; exact dist_nonneg)
 
 -- Routine: Translates preserve convexity
 theorem translate_convex (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2))
     (hC : Convex ℝ C) : Convex ℝ (translate C x) := by
-  sorry
+  intro a ha b hb t₁ t₂ ht₁ ht₂ ht
+  obtain ⟨ca, hca, rfl⟩ := ha
+  obtain ⟨cb, hcb, rfl⟩ := hb
+  refine ⟨t₁ • ca + t₂ • cb, hC hca hcb ht₁ ht₂ ht, ?_⟩
+  simp only [smul_add]
+  have : t₁ • ca + t₁ • x + (t₂ • cb + t₂ • x) =
+      (t₁ • ca + t₂ • cb) + (t₁ • x + t₂ • x) := by abel
+  rw [this, ← add_smul, ht, one_smul]
 
 -- Routine: Translates preserve compactness
 theorem translate_compact (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2))
     (hC : IsCompact C) : IsCompact (translate C x) := by
-  sorry
+  -- translate C x is the image of C under the continuous map (· + x)
+  have : translate C x = (· + x) '' C := by
+    ext y; simp [translate, Set.mem_image]
+  rw [this]
+  exact hC.image (continuous_id.add continuous_const)
 
 -- Routine: Translation preserves nonemptiness
 theorem translate_nonempty (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2))


### PR DESCRIPTION
## Summary
- Prove 18 sorry targets across 8 Aristotle companion files using Mathlib API
- Focus: number theory (divisor sums, tau multiplicativity), topology (set distance, translate), ordinal arithmetic, analysis (summability), polynomial theory

## Files Modified
| File | Sorries Proved | Techniques |
|------|----------------|------------|
| Erdos1052Aristotle | 3 | native_decide, Prime.eq_one_or_self_of_dvd |
| Erdos956Aristotle | 4 | dist_comm, csInf, Convex, IsCompact.image |
| Erdos673Aristotle | 1 | Coprime.divisors_mul + card_product |
| Erdos601Aristotle | 4 | omega0_lt_omega1, opow_lt_opow_right |
| Erdos268Aristotle | 2 | hasSum_fintype, tsum_nonneg |
| Erdos454Aristotle | 1 | ciInf_le at i=0 term |
| Erdos1049Aristotle | 1 | Coprime.divisors_mul |
| Erdos1048Aristotle | 2 | monic_X_pow_sub_C, degree_sub_eq_left_of_degree_lt |

## Status
Pool exhausted (823 completed, 1 blocked). Working in sorry elimination mode.

🤖 Generated by researcher-11