### PR TITLE
Fix: add Aristotle companion for erdos-901 (7 targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos901Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos901Aristotle.lean
@@ -1,0 +1,138 @@
+/-
+  Aristotle targets for Erdős Problem #901
+  Routine supporting lemmas for automated proof search.
+  See Stubs/Erdos901Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (Erdős-Lovász conjecture)
+  - Known result with standard proof technique
+  - Clean theorem statement with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+
+  Included sorries (7 of 19 from main file):
+  - propertyB_dichotomy: logic exercise (push_neg)
+  - monochromatic_probability: algebraic identity
+  - hypergraph_m2_no_propertyB: finite verification on Fin 4
+  - m_well_defined: existence of n-uniform hypergraph without Property B
+  - m_mono: monotonicity of m(n), standard set argument
+  - connection_list_chromatic: direct from monotonicity
+  - erdos_lower_bound: probabilistic method (counting argument)
+
+  Excluded:
+  - m_2_eq_3, m_3_eq_7, m_4_eq_23: exact values need computational verification
+  - beck_lower_bound, rs_lower_bound, pluhar_lower_bound: research-level bounds
+  - erdos_upper_bound, probabilistic_upper: constructive arguments
+  - current_gap: depends on other sorry results
+  - complete_hypergraph_no_propertyB: construction
+  - lll_property_b: Lovász Local Lemma application
+  - lacks_propertyB_iff_chromatic_ge_3: depends on chromaticNumber infrastructure
+-/
+import Mathlib.Combinatorics.SetFamily.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+namespace Erdos901Aristotle
+
+open Finset Real
+
+/-- An n-uniform hypergraph: a family of n-element subsets of a ground set. -/
+structure UniformHypergraph (V : Type*) [Fintype V] (n : ℕ) where
+  edges : Finset (Finset V)
+  uniform : ∀ e ∈ edges, e.card = n
+
+/-- The number of edges in a hypergraph. -/
+def UniformHypergraph.edgeCount {V : Type*} [Fintype V] {n : ℕ}
+    (H : UniformHypergraph V n) : ℕ :=
+  H.edges.card
+
+/-- A 2-coloring of vertices. -/
+def TwoColoring (V : Type*) := V → Fin 2
+
+/-- An edge is monochromatic under a coloring if all vertices have the same color. -/
+def IsMonochromatic {V : Type*} (c : TwoColoring V) (e : Finset V) : Prop :=
+  (∀ v ∈ e, c v = 0) ∨ (∀ v ∈ e, c v = 1)
+
+/-- Property B: there exists a 2-coloring with no monochromatic edge. -/
+def HasPropertyB {V : Type*} [Fintype V] [DecidableEq V] {n : ℕ}
+    (H : UniformHypergraph V n) : Prop :=
+  ∃ c : TwoColoring V, ∀ e ∈ H.edges, ¬IsMonochromatic c e
+
+/-- Without Property B: every 2-coloring has a monochromatic edge. -/
+def LacksPropertyB {V : Type*} [Fintype V] [DecidableEq V] {n : ℕ}
+    (H : UniformHypergraph V n) : Prop :=
+  ∀ c : TwoColoring V, ∃ e ∈ H.edges, IsMonochromatic c e
+
+/-- m(n) = minimum edges in an n-uniform hypergraph without Property B. -/
+noncomputable def m (n : ℕ) : ℕ :=
+  sInf {k : ℕ | ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V)
+    (H : UniformHypergraph V n), H.edgeCount = k ∧ LacksPropertyB H}
+
+-- ============================================================
+-- TARGET 1: Property B dichotomy (TRIVIAL — push_neg exercise)
+-- ============================================================
+
+/-- Property B and its negation are complementary. -/
+theorem propertyB_dichotomy {V : Type*} [Fintype V] [DecidableEq V] {n : ℕ}
+    (H : UniformHypergraph V n) :
+    HasPropertyB H ↔ ¬LacksPropertyB H := by
+  sorry
+
+-- ============================================================
+-- TARGET 2: Monochromatic probability (TRIVIAL — algebra)
+-- ============================================================
+
+/-- Probability an edge is monochromatic: 2^{1-n} = 2 / 2^n. -/
+theorem monochromatic_probability (n : ℕ) (hn : n ≥ 1) :
+    (2 : ℝ) ^ (1 - (n : ℤ)) = 2 / 2 ^ n := by
+  sorry
+
+-- ============================================================
+-- TARGET 3: Explicit construction for m(2) (TRIVIAL — finite)
+-- ============================================================
+
+/-- Explicit construction for m(2) = 3: Three edges on 4 vertices. -/
+def hypergraph_m2 : UniformHypergraph (Fin 4) 2 where
+  edges := {{0, 1}, {0, 2}, {1, 2}}
+  uniform := by intro e he; simp_all [Finset.card_pair]
+
+/-- The explicit 3-edge hypergraph on 4 vertices lacks Property B. -/
+theorem hypergraph_m2_no_propertyB : LacksPropertyB hypergraph_m2 := by
+  sorry
+
+-- ============================================================
+-- TARGET 4: m(n) well-defined (HARD — existence argument)
+-- ============================================================
+
+/-- m(n) is well-defined for n ≥ 2. -/
+theorem m_well_defined (n : ℕ) (hn : n ≥ 2) : m n > 0 := by
+  sorry
+
+-- ============================================================
+-- TARGET 5: Monotonicity of m (HARD — set theory argument)
+-- ============================================================
+
+/-- m is monotone increasing. -/
+theorem m_mono {n₁ n₂ : ℕ} (h : n₁ ≤ n₂) (hn₁ : n₁ ≥ 2) : m n₁ ≤ m n₂ := by
+  sorry
+
+-- ============================================================
+-- TARGET 6: Connection to list coloring (follows from mono)
+-- ============================================================
+
+/-- Connection to list chromatic number: m(k) ≤ m(k+1). -/
+theorem connection_list_chromatic :
+    ∀ k : ℕ, k ≥ 2 → m k ≤ m (k + 1) := by
+  sorry
+
+-- ============================================================
+-- TARGET 7: Erdős lower bound (HARD — probabilistic method)
+-- ============================================================
+
+/-- Erdős (1963-64) lower bound: m(n) > 2^{n-1}. -/
+theorem erdos_lower_bound (n : ℕ) (hn : n ≥ 2) : m n > 2 ^ (n - 1) := by
+  sorry
+
+end Erdos901Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file `Erdos901Aristotle.lean` with 7 routine proof targets extracted from the 19 sorries in `Erdos901Problem.lean`.

## Evidence

**Before**: erdos-901 had 19 sorries with no Aristotle companion file — no automated proof search possible.

**After**: 7 routine/known-result sorries exposed for Aristotle:
| Target | Difficulty | Description |
|--------|-----------|-------------|
| `propertyB_dichotomy` | TRIVIAL | Logic exercise (push_neg on ∃ vs ∀) |
| `monochromatic_probability` | TRIVIAL | Algebraic identity: 2^(1-n) = 2/2^n |
| `hypergraph_m2_no_propertyB` | TRIVIAL | Finite verification on Fin 4 |
| `m_well_defined` | HARD | Existence of n-uniform hypergraph without Property B |
| `m_mono` | HARD | Monotonicity of m(n) |
| `connection_list_chromatic` | HARD | Direct from monotonicity |
| `erdos_lower_bound` | HARD | Probabilistic method (counting argument) |

**Excluded**: Deep results (Beck/RS/Pluhár bounds, exact values m(2)=3, m(3)=7, m(4)=23, LLL, chromatic number characterization).

**Pre-submission checklist**: No definition sorries, no axiom declarations, no `/-!` sections, no True placeholders.

---
Automated fix by lean-mechanic agent.