### PR TITLE
Research: erdos-952 — reduce axioms 2→1 (convert unused gaussian_prime_theorem)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos952Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos952Problem.lean
@@ -360,7 +360,7 @@ A "moat" is a region around 0 containing no Gaussian primes beyond a certain nor
 
 -- The critical moat width (if it exists)
 noncomputable def criticalMoatWidth : ℕ :=
-  Nat.find (⟨0, fun x hx => hx.1 0⟩ : ∃ k, ¬ CanEscapeMoat k)
+  Nat.find ⟨0, not_canEscapeMoat_le_27 0 (Nat.zero_le 27)⟩
 
 -- If no walk exists for any k, the conjecture is false
 def StrongNegation : Prop := ∀ k, ¬ CanEscapeMoat k
@@ -379,8 +379,8 @@ noncomputable def gaussianPrimeCount (R : ℕ) : ℕ :=
       IsGaussianPrime z ∧ z.norm ≤ R ^ 2)).card
 
 -- Asymptotic: π_ℤ[i](x) ~ x / log(x)
--- Similar to rational prime counting function
-axiom gaussian_prime_theorem : ∀ ε > 0, ∃ N : ℕ,
+-- Similar to rational prime counting function (analytic number theory, not formalized here)
+def GaussianPrimeTheorem : Prop := ∀ ε > 0, ∃ N : ℕ,
   ∀ R ≥ N, |((gaussianPrimeCount R : ℝ) / R ^ 2) - 1 / Real.log R| < ε
 
 /-
@@ -501,9 +501,11 @@ def RationalPrimeMoat : Prop :=
 - Whether any bounded step size suffices
 - The critical moat width (if the answer is NO)
 
-**Axioms (2):**
+**Axioms (1):**
 - tsuchimura: computational verification (no walk ≤ √26)
-- gaussian_prime_theorem: asymptotic density (analytic number theory)
+
+**Stated (not axiomatized):**
+- GaussianPrimeTheorem: asymptotic density (analytic number theory, as Prop def)
 
 **Proved from Mathlib:**
 - Full Gaussian prime classification (both directions):

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -48,17 +48,18 @@
       "HasBoundedGaps definition: consecutive norm differences bounded",
       "GaussianMoatConjecture definition: existence of bounded walk",
       "jordan_rabung theorem: no walk with steps ≤ 2 (proved from tsuchimura)",
-      "tsuchimura axiom: no walk with steps ≤ √26",
+      "tsuchimura axiom: no walk with steps ≤ √26 (only remaining axiom)",
+      "GaussianPrimeTheorem: asymptotic density stated as Prop def (not axiomatized)",
       "gethner_et_al theorem: step size 4 insufficient (proved from tsuchimura)",
       "CanEscapeMoat definition: moat escapability",
       "criticalMoatWidth definition: smallest non-escapable moat",
       "gaussianPrimeCount definition: counting function",
-      "gaussian_prime_theorem axiom: asymptotic density",
+      "GaussianPrimeTheorem def: asymptotic density (Prop, not axiomatized)",
       "primes_mod_4_connection theorem: proved via factorial construction (arbitrarily long prime-free intervals)"
     ],
-    "axiomCount": 2,
-    "lineCount": 510,
-    "assumptions": "2 axioms: tsuchimura (computational verification), gaussian_prime_theorem (analytic number theory). gaussian_prime_classification proved (both directions). primes_mod_4_connection proved via factorial construction. jordan_rabung and gethner_et_al proved from tsuchimura."
+    "axiomCount": 1,
+    "lineCount": 530,
+    "assumptions": "1 axiom: tsuchimura (computational verification — no walk ≤ √26). GaussianPrimeTheorem stated as Prop def (not axiomatized). gaussian_prime_classification proved (both directions). primes_mod_4_connection proved via factorial construction. jordan_rabung and gethner_et_al proved from tsuchimura."
   },
   "overview": {
     "historicalContext": "This problem is notably NOT actually an Erdős problem. According to Erdős himself, the conjecture originated with Theodore Motzkin, Basil Gordon, and others at a 1963 Pasadena number theory meeting. Erdős popularized it by sharing it widely, and the attribution was eventually forgotten.\n\nThe 'Gaussian moat' refers to prime-free regions in ℤ[i]. The question asks whether one can 'walk' from 0 to infinity on Gaussian primes with bounded step size.\n\nKnown results:\n- Jordan and Rabung (1970): No walk with steps ≤ 2\n- Tsuchimura (2005): No walk with steps ≤ √26\n- Gethner et al.: Step size 4 insufficient\n\nTerence Tao has indicated this problem appears quite difficult.",
@@ -170,10 +171,10 @@
       "GaussianInt"
     ],
     "namespace": "Erdos952",
-    "lineCount": 510,
-    "axiomCount": 2,
+    "lineCount": 530,
+    "axiomCount": 1,
     "theoremCount": 16,
-    "definitionCount": 19
+    "definitionCount": 20
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-952.json
+++ b/src/data/research/problems/erdos-952.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved primes_mod_4_connection axiom (3A→2A). Used factorial construction: [k!+2, k!+k] contains only composites. Now only 2 axioms remain: tsuchimura (computational) and gaussian_prime_theorem (analytic NT).",
+    "progressSummary": "PROGRESS: Reduced to 1 axiom (tsuchimura). Converted unused gaussian_prime_theorem axiom to Prop def (not asserted). Full classification proved both directions. primes_mod_4_connection proved via factorial construction. File near-complete for open problem.",
     "builtItems": [
       "PROVED jordan_rabung from tsuchimura (axiom→theorem)",
       "PROVED gethner_et_al from tsuchimura (axiom→theorem)",
@@ -38,7 +38,9 @@
       "exists_nat_prime_dvd: strong induction helper (Gaussian prime divides some rational prime)",
       "classification_forward: complete proof (was axiom, now theorem ~115 lines)",
       "Removed: duplicate canEscapeMoat_mono, no_walk_up_to_sqrt26",
-      "primes_mod_4_connection: axiom→theorem via factorial argument (~25 lines)"
+      "primes_mod_4_connection: axiom→theorem via factorial argument (~25 lines)",
+      "gaussian_prime_theorem: axiom→def (unused axiom converted to Prop statement, 2A→1A)",
+      "criticalMoatWidth: cleaned existence proof to use not_canEscapeMoat_le_27"
     ],
     "insights": [
       "jordan_rabung and gethner_et_al are weaker results than tsuchimura — proved as consequences (6A→4A)",
@@ -53,12 +55,14 @@
       "For norm=p: sum-of-squares mod 4 argument (same as prime_of_inert) shows p≡1 mod 4",
       "Removed duplicate canEscapeMoat_mono and no_walk_up_to_sqrt26 definitions",
       "primes_mod_4_connection proved: the consequent (arbitrarily long prime-free windows) holds unconditionally via factorial construction, making the conditional implication trivially true",
-      "Key technique: for j in [2, k], j divides k!, so j divides k!+j, making k!+j composite"
+      "Key technique: for j in [2, k], j divides k!, so j divides k!+j, making k!+j composite",
+      "gaussian_prime_theorem was unused by any theorem — safe to convert from axiom to def without loss",
+      "Only remaining axiom (tsuchimura) is genuinely deep: computational verification of moat for step ≤ √26, not provable without significant infrastructure"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Only 2 axioms remain, both deep and appropriate: tsuchimura (computational), gaussian_prime_theorem (analytic NT)",
-      "File is near-complete for an open problem formalization"
+      "Only 1 axiom remains (tsuchimura — computational verification, deep and appropriate)",
+      "File is near-complete for an open problem formalization — only tsuchimura axiom prevents full verification"
     ],
     "markdown": "# Erdős #952 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there an infinite sequence of distinct Gaussian primes $x_1,x_2,\\ldots$ such that\\[\\lvert x_{n+1}-x_n\\rvert \\ll 1?\\]\n\n\n\nThe Gaussian moat problem. This is not actually a problem of Erd\\H{o}s, but has been erroneously attributed to him in the past. In \\cite{Er77c} Erd\\H{o}s recalls: 'The conjecture was told me by Motzkin at the Pasadena number theory meeting 1963 November and it was apparently raised by Basil Gordon and Motzkin. I naturally liked it very much and told it right away to many people, naturally attributing it to Motzkin, but this was later forgotten. Thus the problem is returned to its rightful owners.'\n\n\n\n\nReferences\n\n\n[Er77c] Erd\\H{o}s, Paul, Problems and results on combinatorial number theory. III. Number theory day (Proc. Conf., Rockefeller Univ.,\nNew York, 1976) (1977), 43-72.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #951\n- Problem #953\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -76,18 +80,18 @@
     "mathlib": []
   },
   "started": "2026-01-15T12:22:36.006Z",
-  "lastUpdate": "2026-03-28T00:00:00.000Z",
+  "lastUpdate": "2026-03-29T00:00:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
-      "path": "Proofs/Erdos952Problem.lean",
+      "path": "Proofs/Stubs/Erdos952Problem.lean",
       "filename": "Erdos952Problem.lean",
-      "lineCount": 240,
-      "theoremCount": 1,
-      "axiomCount": 6,
+      "lineCount": 530,
+      "theoremCount": 16,
+      "axiomCount": 1,
       "defCount": 20,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos952Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Convert unused `gaussian_prime_theorem` axiom to `GaussianPrimeTheorem` Prop def (2→1 axioms)
- Clean up `criticalMoatWidth` existence proof to use `not_canEscapeMoat_le_27`
- Fix stale metadata: correct axiomCount, lineCount, file path in problem JSON

## Details
The `gaussian_prime_theorem` axiom (asymptotic density of Gaussian primes) was not used by any theorem in the file. Converting it from an `axiom` to a `def` (Prop statement) preserves the mathematical content without asserting it as an unverified assumption.

Only remaining axiom: `tsuchimura` (computational verification — no walk with step ≤ √26), which is genuinely deep and used by `jordan_rabung`, `gethner_et_al`, and `not_canEscapeMoat_le_27`.

## Files Modified
- `proofs/Proofs/Stubs/Erdos952Problem.lean` — axiom→def conversion, proof cleanup
- `src/data/proofs/erdos-952/meta.json` — axiomCount 2→1, updated assumptions
- `src/data/research/problems/erdos-952.json` — correct path, counts, knowledge

## Status
**Outcome**: completed
**Next Steps**: Only tsuchimura axiom remains (computational, not provable without significant infrastructure)

🤖 Generated by researcher-6