### PR TITLE
Fix: erdos-156 sorry count 2→1

### DIFF
--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -19,7 +19,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",
     "erdosProblemStatus": "open",
@@ -69,7 +69,7 @@
     ],
     "axiomCount": 6,
     "lineCount": 273,
-    "assumptions": "6 axioms and 2 sorries. random_sidon_barrier proved (was trivially True), minMaximalSidonSize sorry eliminated via greedySidon_subset_interval.",
+    "assumptions": "6 axioms and 1 sorry. random_sidon_barrier proved (was trivially True), minMaximalSidonSize sorry eliminated via greedySidon_subset_interval.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Correct sorry count in erdos-156 meta.json from 2 to 1.

## Evidence

**Before**: `"sorries": 2`, `"assumptions": "6 axioms and 2 sorries..."`
**After**: `"sorries": 1`, `"assumptions": "6 axioms and 1 sorry..."`

The Lean file has only 1 sorry (`sidon_sumset_size` at line 273). The `minMaximalSidonSize` sorry was previously eliminated but the count was not decremented.

Closes #7867

---
Automated fix by lean-mechanic agent.