### PR TITLE
Research: erdos-52 + erdos-2 — prove 5 axioms across 2 files

### DIFF
--- a/proofs/Proofs/Erdos2Problem.lean
+++ b/proofs/Proofs/Erdos2Problem.lean
@@ -111,7 +111,10 @@ Every covering system has a modulus at most 10^16.
 This disproved Erdős' conjecture. The proof built on work by
 Filaseta, Ford, Konyagin, Pomerance, and Yu (2007).
 -/
-axiom hough_bound : ∀ cs : CoveringSystem, ∃ c ∈ cs.classes, c.modulus ≤ 10^16
+theorem hough_bound : ∀ cs : CoveringSystem, ∃ c ∈ cs.classes, c.modulus ≤ 10^16 := by
+  intro cs
+  obtain ⟨c, hc, hle⟩ := balister_bound cs
+  exact ⟨c, hc, le_trans hle (by norm_num)⟩
 
 /-- Hough's bound as a specific value. -/
 def hough_N : ℕ := 10^16

--- a/proofs/Proofs/Erdos52Problem.lean
+++ b/proofs/Proofs/Erdos52Problem.lean
@@ -80,22 +80,58 @@ axiom bloom_bound :
 ## Section V: Trivial Bounds
 -/
 
-/-- The sumset is at least as large as the original set. -/
-axiom sumset_card_ge (A : Finset ℤ) (h : A.Nonempty) :
-    A.card ≤ (sumset A).card
+/-- The sumset is at least as large as the original set.
+    Proof: fix a₀ ∈ A; the map a ↦ a + a₀ injects A into sumset A. -/
+theorem sumset_card_ge (A : Finset ℤ) (h : A.Nonempty) :
+    A.card ≤ (sumset A).card := by
+  obtain ⟨a₀, ha₀⟩ := h
+  have hinj : Set.InjOn (· + a₀) (↑A) := fun a _ b _ hab => by linarith
+  have hsub : Finset.image (· + a₀) A ⊆ sumset A := by
+    intro x hx
+    simp only [Finset.mem_image] at hx
+    obtain ⟨a, ha, rfl⟩ := hx
+    simp only [sumset, Finset.mem_image, Finset.mem_product]
+    exact ⟨(a, a₀), ⟨ha, ha₀⟩, rfl⟩
+  calc A.card = (Finset.image (· + a₀) A).card :=
+        (Finset.card_image_of_injOn hinj).symm
+    _ ≤ (sumset A).card := Finset.card_le_card hsub
 
 /-- The product set is at least as large as the original set
-(when A contains no zero and has at least 2 elements). -/
-axiom productset_card_ge (A : Finset ℤ)
+    (when A contains no zero and has at least 2 elements).
+    Proof: fix a₀ ∈ A with a₀ ≠ 0; the map a ↦ a * a₀ injects A into productset A. -/
+theorem productset_card_ge (A : Finset ℤ)
     (h : A.card ≥ 2) (h0 : (0 : ℤ) ∉ A) :
-    A.card ≤ (productset A).card
+    A.card ≤ (productset A).card := by
+  have hne : A.Nonempty := Finset.card_pos.mp (by omega)
+  obtain ⟨a₀, ha₀⟩ := hne
+  have ha₀_ne : a₀ ≠ 0 := fun heq => h0 (heq ▸ ha₀)
+  have hinj : Set.InjOn (· * a₀) (↑A) :=
+    fun a _ b _ hab => mul_right_cancel₀ ha₀_ne hab
+  have hsub : Finset.image (· * a₀) A ⊆ productset A := by
+    intro x hx
+    simp only [Finset.mem_image] at hx
+    obtain ⟨a, ha, rfl⟩ := hx
+    simp only [productset, Finset.mem_image, Finset.mem_product]
+    exact ⟨(a, a₀), ⟨ha, ha₀⟩, rfl⟩
+  calc A.card = (Finset.image (· * a₀) A).card :=
+        (Finset.card_image_of_injOn hinj).symm
+    _ ≤ (productset A).card := Finset.card_le_card hsub
 
-/-- Upper bound: both sumset and product set have at most |A|² elements. -/
-axiom sumset_card_le (A : Finset ℤ) :
-    (sumset A).card ≤ A.card * A.card
+/-- Upper bound: both sumset and product set have at most |A|² elements.
+    Follows from Finset.card_image_le since they are images of A ×ˢ A. -/
+theorem sumset_card_le (A : Finset ℤ) :
+    (sumset A).card ≤ A.card * A.card := by
+  unfold sumset
+  calc (A ×ˢ A).image (fun p => p.1 + p.2) |>.card
+      ≤ (A ×ˢ A).card := Finset.card_image_le
+    _ = A.card * A.card := Finset.card_product A A
 
-axiom productset_card_le (A : Finset ℤ) :
-    (productset A).card ≤ A.card * A.card
+theorem productset_card_le (A : Finset ℤ) :
+    (productset A).card ≤ A.card * A.card := by
+  unfold productset
+  calc (A ×ˢ A).image (fun p => p.1 * p.2) |>.card
+      ≤ (A ×ˢ A).card := Finset.card_image_le
+    _ = A.card * A.card := Finset.card_product A A
 
 /-
 ## Section VI: Higher-Fold Generalizations

--- a/src/data/proofs/erdos-2/meta.json
+++ b/src/data/proofs/erdos-2/meta.json
@@ -29,15 +29,15 @@
         "relation": "Erdős Problem #3 asks about covering systems with all moduli odd (Erdős-Selfridge conjecture)"
       }
     ],
-    "axiomCount": 4,
-    "lineCount": 264,
+    "axiomCount": 3,
+    "lineCount": 267,
     "prerequisites": [
       "Modular arithmetic and congruence classes",
       "Chinese Remainder Theorem",
       "Basic combinatorics and the pigeonhole principle",
       "Lovász Local Lemma (for understanding Hough's proof)"
     ],
-    "assumptions": "4 axioms: hough_bound, balister_bound, owens_construction, and 1 more. See Lean source for complete statements.",
+    "assumptions": "3 axioms: balister_bound, owens_construction, reciprocal_sum_ge_one. hough_bound proved from balister_bound (616000 ≤ 10^16).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -250,9 +250,9 @@
       "Finset"
     ],
     "namespace": "Erdos2",
-    "lineCount": 264,
-    "axiomCount": 4,
-    "theoremCount": 8,
+    "lineCount": 267,
+    "axiomCount": 3,
+    "theoremCount": 9,
     "definitionCount": 17
   }
 }

--- a/src/data/proofs/erdos-52/meta.json
+++ b/src/data/proofs/erdos-52/meta.json
@@ -19,15 +19,15 @@
     "erdosNumber": 52,
     "erdosUrl": "https://erdosproblems.com/52",
     "erdosProblemStatus": "open",
-    "axiomCount": 7,
-    "lineCount": 134,
+    "axiomCount": 3,
+    "lineCount": 155,
     "prerequisites": [
       "Sumsets and product sets of finite sets",
       "Additive combinatorics",
       "Incidence geometry (Szemerédi-Trotter)",
       "Real analysis and arithmetic structure"
     ],
-    "assumptions": "7 axioms: erdos_szemeredi_theorem, bloom_bound, sumset_card_ge, and 4 more. See Lean source for complete statements.",
+    "assumptions": "3 axioms: erdos_szemeredi_theorem, bloom_bound, sum_product_implies_many_representations. Sumset/productset bounds proved from Finset.card_image_le and injections.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -145,9 +145,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 134,
-    "axiomCount": 7,
-    "theoremCount": 0,
+    "lineCount": 155,
+    "axiomCount": 3,
+    "theoremCount": 4,
     "definitionCount": 7
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary
- **erdos-52**: Prove 4 axioms (7→3): sumset/productset bounds from Finset.card_image_le and injections
- **erdos-2**: Prove 1 axiom (4→3): hough_bound from balister_bound via le_trans

## erdos-52 (Sum-Product Conjecture)
- `sumset_card_le`: via `Finset.card_image_le` (sumset is image of A ×ˢ A)
- `productset_card_le`: via `Finset.card_image_le`
- `sumset_card_ge`: via injection `a ↦ a + a₀` for fixed `a₀ ∈ A`
- `productset_card_ge`: via injection `a ↦ a * a₀` for nonzero `a₀ ∈ A`
- Remaining 3 axioms: `erdos_szemeredi_theorem`, `bloom_bound`, `sum_product_implies_many_representations`

## erdos-2 (Covering Systems)
- `hough_bound`: proved from `balister_bound` (616000 ≤ 10^16)
- Remaining 3 axioms: `balister_bound`, `owens_construction`, `reciprocal_sum_ge_one`

## Status
**Outcome**: completed (5 axioms eliminated)

🤖 Generated by researcher-11