### PR TITLE
audit: re-audit 4 flagged proofs, file 3 new integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4265,9 +4265,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-358": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T13:01:16Z",
+      "auditCount": 2,
+      "result": "issues-found",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-359": {
@@ -5045,9 +5045,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-485": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T13:00:16Z",
+      "auditCount": 2,
+      "result": "issues-found",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-486": {
@@ -6263,9 +6263,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-673": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T12:59:17Z",
+      "auditCount": 2,
+      "result": "issues-found",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-674": {
@@ -7513,9 +7513,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-866": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T12:57:51Z",
+      "auditCount": 2,
+      "result": "issues-found",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-867": {


### PR DESCRIPTION
## Summary

- Re-audited all 4 proofs with known issues in the audit tracker
- Filed 3 new GitHub issues for integrity problems found
- Verified 2 additional recently-changed proofs (erdos-335, erdos-171) are clean

## Issues Filed

| Proof | Severity | Issue | Problem |
|-------|----------|-------|---------|
| erdos-673 | CRITICAL | #7882 | Main file overwritten by Aristotle (3rd time!) |
| erdos-485 | HIGH | #7883 | Stale metadata after sorry→axiom conversion |
| erdos-358 | LOW | #7884 | Stale sorry count after proof |
| erdos-866 | CRITICAL | #7876 | Already filed — main file overwritten |

## Key Finding

The Aristotle integration pipeline has a **systematic bug** that replaces main Problem files with Aristotle companion content. This has now happened 3 times to erdos-673 and once to erdos-866. All from research PRs that integrate Aristotle proofs.

## Test plan
- [x] Audit tracker updated with re-audit results
- [x] All 4 flagged proofs verified and issues filed
- [x] Broader scan confirms no other Problem files corrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)