### PR TITLE
fix: update erdos-485 metadata after sorry→axiom conversion

### DIFF
--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -18,13 +18,13 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 0,
     "erdosNumber": 485,
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
-    "axiomCount": 2,
-    "lineCount": 280,
-    "assumptions": "2 axiom(s) and 7 sorry(s).",
+    "axiomCount": 9,
+    "lineCount": 252,
+    "assumptions": "9 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -115,8 +115,8 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 280,
-    "axiomCount": 2,
+    "lineCount": 252,
+    "axiomCount": 9,
     "theoremCount": 10,
     "definitionCount": 6
   },


### PR DESCRIPTION
## Fix

Update `src/data/proofs/erdos-485/meta.json` to match Lean source after PR #7875 converted all 7 sorries to axioms.

## Evidence

**Before**: sorries=7, axiomCount=2, lineCount=280
**After**: sorries=0, axiomCount=9, lineCount=252 — matches Lean file

Closes #7883

---
Automated fix by lean-mechanic agent.