### PR TITLE
Research: erdos-232-oq-01 — prove lebesgue_ball_area, fix upperDensity (9→8 axioms)

### DIFF
--- a/proofs/Proofs/Erdos232Problem.lean
+++ b/proofs/Proofs/Erdos232Problem.lean
@@ -35,11 +35,13 @@ References:
 
 import Mathlib.Analysis.InnerProductSpace.EuclideanDist
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 import Mathlib.MeasureTheory.Measure.MeasureSpace
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Order.LiminfLimsup
 
-open MeasureTheory Set Metric
+open MeasureTheory Set Metric Filter
 
 namespace Erdos232
 
@@ -104,9 +106,17 @@ def ballR (R : ℝ) : Set (EuclideanSpace ℝ (Fin 2)) :=
 /--
 **Area of ball:**
 The Lebesgue measure of B_R is π R².
+Proved from `EuclideanSpace.volume_closedBall` in Mathlib.
 -/
-axiom lebesgue_ball_area (R : ℝ) (hR : R > 0) :
-    MeasureTheory.volume (ballR R) = ENNReal.ofReal (Real.pi * R ^ 2)
+theorem lebesgue_ball_area (R : ℝ) (hR : R > 0) :
+    MeasureTheory.volume (ballR R) = ENNReal.ofReal (Real.pi * R ^ 2) := by
+  unfold ballR
+  rw [EuclideanSpace.volume_closedBall]
+  simp only [Fintype.card_fin, Nat.cast_ofNat]
+  have harg : (2 : ℝ) / 2 + 1 = 2 := by norm_num
+  rw [harg, Real.Gamma_two, div_one, Real.sq_sqrt (le_of_lt Real.pi_pos),
+      ← ENNReal.ofReal_pow (le_of_lt hR), ← ENNReal.ofReal_mul (sq_nonneg R)]
+  congr 1; ring
 
 /-
 ## Part IV: Upper Density
@@ -118,9 +128,10 @@ The asymptotic density of a set A as R → ∞.
 δ̄(A) = lim sup_{R→∞} λ(A ∩ B_R) / λ(B_R)
 -/
 noncomputable def upperDensity (A : Set (EuclideanSpace ℝ (Fin 2))) : ℝ :=
-  -- The limit superior of the density ratio
-  -- This is well-defined for measurable sets
-  0  -- Placeholder for the actual limsup definition
+  Filter.limsup (fun R : ℝ =>
+    (MeasureTheory.volume (A ∩ Metric.closedBall 0 R)).toReal /
+    (MeasureTheory.volume (Metric.closedBall (0 : EuclideanSpace ℝ (Fin 2)) R)).toReal
+  ) Filter.atTop
 
 /--
 Upper density is always in [0, 1].

--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -67,9 +67,9 @@
         "relationship": "Chromatic number of the plane problem"
       }
     ],
-    "axiomCount": 9,
-    "lineCount": 351,
-    "assumptions": "9 axiom(s) and 0 sorry(s). See the Lean source for details."
+    "axiomCount": 8,
+    "lineCount": 358,
+    "assumptions": "8 axiom(s) and 0 sorry(s). lebesgue_ball_area proved from Mathlib. upperDensity now uses proper Filter.limsup definition."
   },
   "overview": {
     "historicalContext": "**Moser's Problem on Unit-Distance-Avoiding Sets**\n\nLeo Moser posed this problem in 1966 in his collection of 'poorly formulated unsolved problems of combinatorial geometry,' a deliberately provocative title for a set of deceptively deep questions. The problem asks: given a measurable subset $A \\subseteq \\mathbb{R}^2$ containing no two points at Euclidean distance 1, how large can $A$ be in the sense of asymptotic upper density?\n\n**Early Progress (1960s-1970s):**\nThe trivial upper bound $m_1 \\leq 1/2$ follows from a translation argument: for any unit vector $u$, the sets $A$ and $A + u$ must be disjoint, so their combined density cannot exceed 1. For lower bounds, the hexagonal lattice construction -- placing open discs of radius $1/2$ at vertices of a suitably spaced hexagonal lattice -- achieves density $\\pi/(8\\sqrt{3}) \\approx 0.2267$. H.T. Croft improved this in 1967 to $m_1 \\geq 0.22936$ using a modified annular construction.\n\n**Stagnation (1970s-2020s):**\nFor over 50 years, neither the lower bound of 0.22936 nor the trivial upper bound of 1/2 was improved. The problem attracted attention because of its connection to the Hadwiger-Nelson problem (chromatic number of the plane), but the analytic techniques needed for the upper bound seemed out of reach.\n\n**Breakthrough (2023):**\nAmbrus, Csiszarik, Matolcsi, Varga, and Zsamboki proved $m_1 \\leq 0.247$ using Fourier-analytic methods inspired by Delsarte's linear programming bound from coding theory. Their approach studies the autocorrelation of the indicator function $\\mathbf{1}_A$ and exploits the vanishing of its Fourier transform on the unit circle. This definitively answered Erdos's question: YES, $m_1 \\leq 1/4$.\n\n**Current Status:** SOLVED. Best bounds: $0.22936 \\leq m_1 \\leq 0.247$, a gap of only $\\approx 0.018$. The exact value remains unknown.",
@@ -209,12 +209,13 @@
     "opens": [
       "MeasureTheory",
       "Set",
-      "Metric"
+      "Metric",
+      "Filter"
     ],
     "namespace": "Erdos232",
-    "lineCount": 351,
-    "axiomCount": 9,
-    "theoremCount": 11,
+    "lineCount": 358,
+    "axiomCount": 8,
+    "theoremCount": 12,
     "definitionCount": 8
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary
Research session for erdos-232-oq-01 (exact value of m₁ in unit-distance avoidance density).

## Progress
- **Proved `lebesgue_ball_area`** from Mathlib's `EuclideanSpace.volume_closedBall` — eliminated 1 axiom (9→8)
- **Fixed `upperDensity` definition** from placeholder constant `0` to proper `Filter.limsup` using measure-theoretic density ratio
- Added imports: `VolumeOfBalls`, `LiminfLimsup`

## Findings
- The previous `upperDensity := 0` placeholder made the axiom system structurally inconsistent (`croft_lower_bound` asserted `maxDensity ≥ 0.22936` but the placeholder forced `maxDensity = 0`)
- `lebesgue_ball_area` follows directly from `EuclideanSpace.volume_closedBall` with Gamma function simplification
- Remaining 8 axioms classified: `upperDensity_bounds`/`upperDensity_mono` are next targets (provable with measure theory work), deep axioms (Croft, Ambrus et al.) are publication-level results

## Status
**Outcome**: progress
**Next Steps**: Prove `upperDensity_bounds` and `upperDensity_mono` from the proper definition

🤖 Generated by researcher-1