### PR TITLE
Research: prove 4 sorries across 3 Aristotle companion files

### DIFF
--- a/proofs/Proofs/Erdos268Aristotle.lean
+++ b/proofs/Proofs/Erdos268Aristotle.lean
@@ -50,12 +50,49 @@ theorem shifted_summable (A : Set ℕ) (k : ℕ)
 -- Routine: The set of perfect squares has convergent harmonic subseries
 -- (this is ∑ 1/n² = π²/6, well-known convergence)
 theorem squares_convergent : HasConvergentHarmonicSubseries squaresSet := by
-  sorry
+  unfold HasConvergentHarmonicSubseries
+  -- Build bijection ℕ ≃ squaresSet via k ↦ (k+1)²
+  let e : ℕ → squaresSet := fun k => ⟨(k+1)^2, k+1, by omega, rfl⟩
+  have hinj : Function.Injective e := by
+    intro a b h; simp only [e, Subtype.ext_iff] at h; omega
+  have hsurj : Function.Surjective e := by
+    intro ⟨n, k, hk, hkn⟩; exact ⟨k - 1, by simp only [e, Subtype.ext_iff]; omega⟩
+  rw [← (Equiv.ofBijective e ⟨hinj, hsurj⟩).summable_iff]
+  -- Reindexed series: fun k => 1/((k+1)² : ℝ)
+  -- Bounded by p-series ∑ 1/n² (p=2>1, convergent)
+  have hpseries : Summable (fun n : ℕ => ((n : ℝ) ^ (2 : ℝ))⁻¹) :=
+    Real.summable_nat_rpow_inv.mpr (by norm_num : (1 : ℝ) < 2)
+  apply Summable.of_nonneg_of_le
+  · intro k; positivity
+  · intro k
+    show (1 : ℝ) / ↑((k + 1) ^ 2) ≤ ((↑(k + 1) : ℝ) ^ (2 : ℝ))⁻¹
+    rw [Nat.cast_pow, one_div]
+    congr 1
+    push_cast; ring
+  · exact hpseries.comp_injective (fun a b h => by omega : Function.Injective (· + 1))
 
 -- Routine: Powers of 2 have convergent harmonic subseries
 -- (geometric series ∑ 1/2^k = 1)
 theorem powers_convergent : HasConvergentHarmonicSubseries powersOf2Set := by
-  sorry
+  unfold HasConvergentHarmonicSubseries
+  -- Build bijection ℕ ≃ powersOf2Set via k ↦ 2^k
+  let e : ℕ → powersOf2Set := fun k => ⟨2^k, k, rfl⟩
+  have hinj : Function.Injective e := by
+    intro a b h
+    simp only [e, Subtype.ext_iff] at h
+    exact Nat.pow_right_injective (by norm_num) h
+  have hsurj : Function.Surjective e := by
+    intro ⟨n, k, hk⟩
+    exact ⟨k, by simp only [e, Subtype.ext_iff]; exact hk.symm⟩
+  rw [← (Equiv.ofBijective e ⟨hinj, hsurj⟩).summable_iff]
+  -- Reindexed: fun k => 1/(2^k : ℝ) = (1/2)^k, geometric series
+  have : ((fun n : powersOf2Set => (1 : ℝ) / ↑↑n) ∘ (Equiv.ofBijective e ⟨hinj, hsurj⟩)) =
+      fun k => ((1 : ℝ) / 2) ^ k := by
+    ext k
+    simp only [Function.comp, Equiv.ofBijective_apply, e, Subtype.val]
+    rw [Nat.cast_pow, Nat.cast_ofNat, div_pow, one_pow]
+  rw [this]
+  exact summable_geometric_of_lt_one (by positivity) (by norm_num)
 
 -- Routine: Shifted harmonic sum is non-negative for non-empty A
 theorem shiftedHarmonicSum_nonneg (A : Set ℕ) (k : ℕ)

--- a/proofs/Proofs/Erdos798Aristotle.lean
+++ b/proofs/Proofs/Erdos798Aristotle.lean
@@ -46,7 +46,14 @@ noncomputable def t (n : ℕ) : ℕ :=
 -- Lattice grid properties
 /-- The lattice grid {1,...,n}^2 has n^2 points. -/
 theorem latticeGrid_card (n : ℕ) (hn : n ≥ 1) :
-    (latticeGrid n).ncard = n ^ 2 := by sorry
+    (latticeGrid n).ncard = n ^ 2 := by
+  have heq : latticeGrid n = (Set.Icc (1 : ℤ) ↑n) ×ˢ (Set.Icc (1 : ℤ) ↑n) := by
+    ext ⟨x, y⟩; simp [latticeGrid, Set.mem_prod, Set.mem_Icc]
+  rw [heq, Set.ncard_prod (Set.finite_Icc _ _) (Set.finite_Icc _ _)]
+  suffices h : (Set.Icc (1 : ℤ) ↑n).ncard = n by rw [h]; ring
+  rw [Set.ncard_eq_toFinset_card’ (Set.Icc (1 : ℤ) ↑n)]
+  simp only [Set.toFinset_Icc, Finset.card_Icc]
+  omega
 
 /-- The lattice grid is finite. -/
 theorem latticeGrid_finite (n : ℕ) :

--- a/proofs/Proofs/Erdos866Aristotle.lean
+++ b/proofs/Proofs/Erdos866Aristotle.lean
@@ -64,6 +64,15 @@ theorem oddNumbers_card (N : ℕ) : (oddNumbers N).card = N := by
 -- Routine lemma: parity pigeonhole — among any 3 integers,
 -- two share parity, so their sum is even and not in oddNumbers
 theorem oddNumbers_no_triple (N : ℕ) :
-    ¬∃ b : Fin 3 → ℤ, HasAllPairwiseSums (oddNumbers N) b := by sorry
+    ¬∃ b : Fin 3 → ℤ, HasAllPairwiseSums (oddNumbers N) b := by
+  intro ⟨b, hb⟩
+  have h01 := hb 0 1 (by omega)
+  have h02 := hb 0 2 (by omega)
+  have h12 := hb 1 2 (by omega)
+  simp only [oddNumbers, Interval, Finset.mem_filter, Finset.mem_range] at h01 h02 h12
+  obtain ⟨⟨_, _⟩, _⟩ := h01
+  obtain ⟨⟨_, _⟩, _⟩ := h02
+  obtain ⟨⟨_, _⟩, _⟩ := h12
+  omega
 
 end Erdos866


### PR DESCRIPTION
## Summary
- Prove `oddNumbers_no_triple` in Erdos866Aristotle (parity pigeonhole: among 3 integers, can't have all pairwise sums odd)
- Prove `latticeGrid_card` in Erdos798Aristotle (counting {1,...,n}² = n² via Set.Icc product)
- Prove `squares_convergent` in Erdos268Aristotle (perfect squares have convergent harmonic subseries via p-series p=2)
- Prove `powers_convergent` in Erdos268Aristotle (powers of 2 have convergent harmonic subseries via geometric series)

**4 sorries eliminated** across 3 files (6→2 remaining sorries in these files)

## Test plan
- [ ] Lean build passes for all 3 modified files
- [ ] No new axioms introduced
- [ ] Gallery data unchanged (Aristotle companion files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)