### PR TITLE
fix: correct erdos-2-oq-01 axiomCount (4→3) and lineCount

### DIFF
--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -29,15 +29,15 @@
       }
     ],
     "dateAdded": "2026-03-29",
-    "axiomCount": 4,
-    "lineCount": 170,
+    "axiomCount": 3,
+    "lineCount": 232,
     "prerequisites": [
       "Covering systems and congruence classes",
       "Well-ordering principle for natural numbers",
       "Basic properties of achievability (monotonicity)",
       "Erdős Problem #2 parent formalization"
     ],
-    "assumptions": "4 axioms (inherited from parent): hough_bound, balister_bound, owens_construction, reciprocal_sum_ge_one. All structural theorems proved from these axioms with 0 sorries.",
+    "assumptions": "3 axioms (inherited from parent): balister_bound, owens_construction, reciprocal_sum_ge_one. hough_bound is a proved theorem, not an axiom. All structural theorems proved from these axioms with 0 sorries.",
     "mathlib_version": "4.29.0",
     "originalContributions": [
       "Formal definition of IsExactMaxMinModulus with equivalent characterizations",


### PR DESCRIPTION
## Fix

Correct erdos-2-oq-01 metadata: `axiomCount` 4→3 (hough_bound is a proved theorem, not an axiom) and `lineCount` 170→232.

## Evidence

**Before**: `axiomCount: 4`, `lineCount: 170`, assumptions listed hough_bound as an axiom
**After**: `axiomCount: 3`, `lineCount: 232`, assumptions correctly note hough_bound is proved

Closes #7904

---
Automated fix by lean-mechanic agent.