### PR TITLE
fix: correct erdos-70-oq-01 status/badge for axiomCount=0

### DIFF
--- a/src/data/proofs/erdos-70-oq-01/meta.json
+++ b/src/data/proofs/erdos-70-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Erd\u0151s, Rado (1956); Hajnal, Larson",
     "sourceUrl": "https://erdosproblems.com/70",
     "date": "1956",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos70OQ01Problem.lean",
     "tags": [
       "erdos",
@@ -18,9 +18,10 @@
       "research",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
+    "lineCount": 240,
     "assumptions": [],
     "erdosNumber": 70,
     "erdosUrl": "https://erdosproblems.com/70",


### PR DESCRIPTION
## Fix

Correct erdos-70-oq-01 metadata: status "axiomatized" + badge "axiom" was inconsistent with axiomCount=0. Changed to status "verified", badge "original". Added missing lineCount field.

## Evidence

**Before**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 0`, no lineCount
**After**: `status: "verified"`, `badge: "original"`, `axiomCount: 0`, `lineCount: 240`

The Lean file has 0 axiom declarations, 0 sorries, 0 structure-encoded assumptions. All 12 structural theorems are fully machine-checked.

Closes #7905

---
Automated fix by lean-mechanic agent.