### PR TITLE
Research: prove 7 sorries across 5 files (Erdos302, 1027, 150, 448, 964)

### DIFF
--- a/proofs/Proofs/Erdos1027Problem.lean
+++ b/proofs/Proofs/Erdos1027Problem.lean
@@ -225,25 +225,21 @@ instance (f : α → Bool) (A : Finset α) :
 lemma card_constOn_le (A : Finset α) (b : Bool) :
     (Finset.univ.filter (fun f : α → Bool => ∀ x ∈ A, f x = b)).card
     ≤ 2 ^ (Fintype.card α - A.card) := by
-  -- Functions constant b on A are determined by their values on α \ A.
-  -- Inject the filtered set into functions on the complement.
-  let restrict : (α → Bool) → ({x : α // x ∉ A} → Bool) := fun f x => f x.val
-  have hinj : Set.InjOn restrict
-      (Finset.univ.filter (fun f : α → Bool => ∀ x ∈ A, f x = b) : Finset (α → Bool)) := by
-    intro f₁ hf₁ f₂ hf₂ heq
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hf₁ hf₂
-    funext x
-    by_cases hx : x ∈ A
-    · exact (hf₁ x hx).trans (hf₂ x hx).symm
-    · exact congr_fun heq ⟨x, hx⟩
-  calc (Finset.univ.filter (fun f : α → Bool => ∀ x ∈ A, f x = b)).card
-      ≤ Fintype.card ({x : α // x ∉ A} → Bool) := by
-        rw [← Finset.card_univ (α := {x : α // x ∉ A} → Bool)]
-        exact Finset.card_le_card_of_injOn restrict (fun _ _ => Finset.mem_univ _) hinj
-    _ = 2 ^ Fintype.card {x : α // x ∉ A} := by
-        simp [Fintype.card_fun, Fintype.card_bool]
+  -- Restriction to Aᶜ is injective on functions constant b on A
+  rw [← Fintype.card_coe]
+  calc Fintype.card ↥(Finset.univ.filter (fun f : α → Bool => ∀ x ∈ A, f x = b))
+      ≤ Fintype.card (↥(Aᶜ : Finset α) → Bool) :=
+        Fintype.card_le_of_injective
+          (fun (p : ↥(Finset.univ.filter (fun f : α → Bool => ∀ x ∈ A, f x = b)))
+               (q : ↥(Aᶜ : Finset α)) => p.val q.val) (by
+          intro ⟨f, hf⟩ ⟨g, hg⟩ heq
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hf hg
+          exact Subtype.ext <| funext fun x => by
+            by_cases hx : x ∈ A
+            · exact (hf x hx).trans (hg x hx).symm
+            · exact congr_fun heq ⟨x, Finset.mem_compl.mpr hx⟩)
     _ = 2 ^ (Fintype.card α - A.card) := by
-        congr 1; simp [Fintype.card_subtype_compl, Fintype.card_coe_sort]
+        simp [Fintype.card_fun, Fintype.card_bool, Fintype.card_coe, Finset.card_compl]
 
 /-- Monochromatic colorings on A number at most 2 · 2^(|α| - |A|):
     at most 2^(|α| - |A|) for all-true plus 2^(|α| - |A|) for all-false. -/
@@ -337,23 +333,21 @@ theorem erdos_classical_bound (F : SetFamily α) (t : ℕ)
 
 **Formalization**: ~320 lines across 7 sections.
 
-**Proved (sorry-free)**:
+**Proved (all sorry-free)**:
+- `card_constOn_le`: counting functions constant on a subset (injection to Aᶜ → Bool)
 - `propertyB_implies_2colorable`: good set → proper 2-coloring
 - `coloring_implies_propertyB`: proper 2-coloring → good set
 - `empty_family_propertyB`: empty family has Property B
 - `empty_family_all_good`: every subset is good for ∅
 - `singleton_family_propertyB`: singleton family with |A| ≥ 2 has Property B
 - `abundance_implies_propertyB`: abundance → Property B
-- `card_monochromatic_le`: bound on monochromatic colorings (modulo `card_constOn_le`)
-- `erdos_classical_bound`: Erdős 1963 probabilistic method bound (modulo `card_constOn_le`)
+- `card_monochromatic_le`: bound on monochromatic colorings
+- `erdos_classical_bound`: Erdős 1963 probabilistic method bound
 
 **Axiomatized (1 axiom)**:
 - `erdos_1027_solution`: Koishi Chan's affirmative answer (= `Erdos1027Statement`)
 
-**Open sorries (1)**:
-- `card_constOn_le`: counting functions constant on a subset (routine combinatorics)
-
-**Status**: axiomatized (1 axiom encoding the solved conjecture, 1 routine sorry)
+**Status**: axiomatized (1 axiom encoding the solved conjecture, 0 sorries)
 -/
 
 end Erdos1027

--- a/proofs/Proofs/Erdos150Problem.lean
+++ b/proofs/Proofs/Erdos150Problem.lean
@@ -184,9 +184,24 @@ The answer to Erdős's question is YES.
 theorem alpha_less_than_two : α < 2 := by
   have h1 : α ≤ (2 : ℝ) ^ binaryEntropy (1/3) := bradac_upper_bound
   have h2 : (2 : ℝ) ^ binaryEntropy (1/3) < 2 := by
-    -- 2^{H(1/3)} ≈ 1.8899 < 2
-    -- Since H(1/3) < 1, we have 2^{H(1/3)} < 2^1 = 2
-    sorry
+    -- H(1/3) < 1, so 2^{H(1/3)} < 2^1 = 2
+    suffices hexp : binaryEntropy (1/3) < 1 by
+      calc (2 : ℝ) ^ binaryEntropy (1/3)
+          < (2 : ℝ) ^ (1 : ℝ) := Real.rpow_lt_rpow_of_exponent_lt (by norm_num) hexp
+        _ = 2 := Real.rpow_one 2
+    rw [binaryEntropy_one_third]
+    -- Goal: log 3 / log 2 - 2/3 < 1, i.e., log 3 / log 2 < 5/3
+    have hlog2_pos : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+    suffices h : Real.log 3 / Real.log 2 < 5 / 3 by linarith
+    rw [div_lt_div_iff hlog2_pos (by norm_num : (0 : ℝ) < 3)]
+    -- Goal: log 3 * 3 < 5 * log 2, i.e., log(27) < log(32)
+    have h27 : Real.log (27 : ℝ) = Real.log ((3 : ℝ) ^ (3 : ℕ)) := by norm_num
+    have h32 : Real.log (32 : ℝ) = Real.log ((2 : ℝ) ^ (5 : ℕ)) := by norm_num
+    have hlog_ineq : Real.log (27 : ℝ) < Real.log 32 :=
+      Real.log_lt_log (by norm_num) (by norm_num)
+    rw [h27, Real.log_pow, h32, Real.log_pow] at hlog_ineq
+    push_cast at hlog_ineq ⊢
+    linarith
   exact lt_of_le_of_lt h1 h2
 
 /-

--- a/proofs/Proofs/Erdos302Problem.lean
+++ b/proofs/Proofs/Erdos302Problem.lean
@@ -180,10 +180,43 @@ axiom cambie_lower_bound :
 /-- Why 5/8: N/8 odd integers plus N/2 upper integers -/
 theorem cambie_count_estimate (N : ℕ) (hN : N ≥ 8) :
     (cambie_set N).card ≥ 5 * N / 8 - 2 := by
-  -- odd integers ≤ N/4: about N/8 elements
-  -- integers in [N/2, N]: about N/2 elements
-  -- Total: about N/8 + N/2 = 5N/8
-  sorry
+  unfold cambie_set
+  -- Step 1: The two sets are disjoint (oddIntegers ≤ N/4 < N/2 ≤ upperHalf)
+  have hdisj : Disjoint (oddIntegers (N / 4)) (upperHalf N) := by
+    rw [Finset.disjoint_left]
+    intro x hx_odd hx_upper
+    simp only [oddIntegers, Finset.mem_filter, Finset.mem_range] at hx_odd
+    simp only [upperHalf, Finset.mem_filter, Finset.mem_range] at hx_upper
+    omega
+  rw [Finset.card_union_of_disjoint hdisj]
+  -- Step 2: Lower bound on oddIntegers(N/4) via injection i ↦ 2i+1
+  have h_odd_lb : (oddIntegers (N / 4)).card ≥ (N / 4 + 1) / 2 := by
+    have hsub : Finset.image (fun i => 2 * i + 1) (Finset.range ((N / 4 + 1) / 2))
+        ⊆ oddIntegers (N / 4) := by
+      intro x hx
+      simp only [Finset.mem_image, Finset.mem_range] at hx
+      obtain ⟨i, hi, rfl⟩ := hx
+      simp only [oddIntegers, Finset.mem_filter, Finset.mem_range]
+      omega
+    have hcard : (Finset.image (fun i => 2 * i + 1)
+        (Finset.range ((N / 4 + 1) / 2))).card = (N / 4 + 1) / 2 := by
+      rw [Finset.card_image_of_injective _ (fun a b (h : 2 * a + 1 = 2 * b + 1) => by omega),
+        Finset.card_range]
+    linarith [Finset.card_le_card hsub]
+  -- Step 3: Lower bound on upperHalf(N) via injection i ↦ i + N/2
+  have h_upper_lb : (upperHalf N).card ≥ N / 2 + 1 := by
+    have hsub : Finset.image (· + N / 2) (Finset.range (N / 2 + 1)) ⊆ upperHalf N := by
+      intro x hx
+      simp only [Finset.mem_image, Finset.mem_range] at hx
+      obtain ⟨i, hi, rfl⟩ := hx
+      simp only [upperHalf, Finset.mem_filter, Finset.mem_range]
+      omega
+    have hcard : (Finset.image (· + N / 2) (Finset.range (N / 2 + 1))).card = N / 2 + 1 := by
+      rw [Finset.card_image_of_injective _ (fun a b (h : a + N / 2 = b + N / 2) => by omega),
+        Finset.card_range]
+    linarith [Finset.card_le_card hsub]
+  -- Step 4: Combine: (N/4+1)/2 + N/2 + 1 ≥ 5*N/8 - 2 for N ≥ 8
+  omega
 
 /-
 ## Part 4: Upper Bound (van Doorn)
@@ -292,14 +325,39 @@ theorem algebraic_form (a b c : ℕ) (ha : a > 0) (hb : b > 0) (hc : c > 0) :
     rw [unit_fraction_equiv a b c ha hb hc]
     linarith [Nat.left_distrib a b c]
 
-/-- If 1/a = 1/b + 1/c with a < b < c, then a < b < c ≤ 2a
-    NOTE: This bound is incorrect as stated. Counterexample: 1/2 = 1/3 + 1/6
-    gives c = 6 > 2a = 4. The correct bound is c ≤ a(a+1) (since b < 2a
-    when b < c forces b-a < a, giving c = ab/(b-a) > 2a). -/
-theorem solution_constraints (a b c : ℕ) (ha : a > 0) (hb : b > 0) (hc : c > 0)
+/-- If 1/a = 1/b + 1/c with a < b < c, then b < 2a.
+    From bc = ab + ac and 2a ≤ b: 2ac ≤ bc = ab + ac, so ac ≤ ab, c ≤ b. Contradiction. -/
+theorem solution_b_lt_2a (a b c : ℕ) (ha : a > 0) (hb : b > 0) (hc : c > 0)
     (hab : a < b) (hbc : b < c) (hsum : UnitFractionSum a b c) :
-    c ≤ 2 * a := by
-  sorry -- False as stated; see docstring
+    b < 2 * a := by
+  obtain ⟨_, _, _, heq⟩ := hsum
+  rw [unit_fraction_equiv a b c ha hb hc] at heq
+  -- heq : b * c = a * (b + c)
+  by_contra h; push_neg at h -- h : 2 * a ≤ b
+  have h1 : b * c = a * b + a * c := by linarith [mul_add a b c]
+  have h2 : 2 * (a * c) ≤ b * c := by
+    calc 2 * (a * c) = (2 * a) * c := by ring
+      _ ≤ b * c := Nat.mul_le_mul_right c h
+  have h3 : a * c ≤ a * b := by linarith
+  exact absurd (Nat.le_of_mul_le_mul_left h3 ha) (by omega)
+
+/-- If 1/a = 1/b + 1/c with a < b < c, then c ≤ a*(a+1).
+    Over ℤ: (b-a-1)(c-a) = a(a+1) - c ≥ 0, so c ≤ a(a+1). -/
+theorem solution_c_bound (a b c : ℕ) (ha : a > 0) (hb : b > 0) (hc : c > 0)
+    (hab : a < b) (hbc : b < c) (hsum : UnitFractionSum a b c) :
+    c ≤ a * (a + 1) := by
+  obtain ⟨_, _, _, heq⟩ := hsum
+  rw [unit_fraction_equiv a b c ha hb hc] at heq
+  have hb_lt : b < 2 * a := solution_b_lt_2a a b c ha hb hc hab hbc hsum
+  -- Work over ℤ to avoid ℕ subtraction issues
+  suffices h : (c : ℤ) ≤ ↑a * (↑a + 1) by exact_mod_cast h
+  have heq' : (b : ℤ) * c = ↑a * (↑b + ↑c) := by exact_mod_cast heq
+  -- Key identity: (b-a-1)(c-a) = a(a+1) - c, using bc = a(b+c)
+  have hprod_eq : (↑b - ↑a - 1 : ℤ) * (↑c - ↑a) = ↑a * (↑a + 1) - ↑c := by nlinarith
+  -- Both factors are non-negative: b ≥ a+1 and c > a
+  have hprod_nn : (0 : ℤ) ≤ (↑b - ↑a - 1) * (↑c - ↑a) :=
+    mul_nonneg (by omega) (by omega)
+  linarith
 
 /-
 ## Part 9: Examples of Solutions

--- a/proofs/Proofs/Erdos448Problem.lean
+++ b/proofs/Proofs/Erdos448Problem.lean
@@ -223,11 +223,9 @@ For highly composite numbers, τ(n) grows much faster than τ⁺(n).
 For n = 2^k, τ(n) = k+1 but τ⁺(n) = k+1 also (each power in its own interval).
 -/
 theorem tau_power_of_two (k : ℕ) : τ(2^k) = k + 1 := by
-  induction k with
-  | zero => native_decide
-  | succ k ih =>
-    simp only [tau, pow_succ]
-    sorry  -- requires divisor counting for prime powers
+  simp only [tau, Nat.divisors_prime_pow (by decide : Nat.Prime 2),
+    Finset.card_image_of_injective _ (Nat.pow_right_injective (by omega : 2 ≤ 2)),
+    Finset.card_range]
 
 /--
 For products of distinct primes, the spread can be significant.

--- a/proofs/Proofs/Erdos964Problem.lean
+++ b/proofs/Proofs/Erdos964Problem.lean
@@ -161,24 +161,36 @@ theorem erdos_964_true : ErdosConjecture964 := by
 τ(2) = 2, τ(1) = 1, so ratio = 2.
 -/
 example : divisorRatio 1 = 2 := by
-  simp [divisorRatio, tau]
-  sorry
+  have h1 : tau 1 ≠ 0 := by native_decide
+  have h2 : tau 1 = 1 := by native_decide
+  have h3 : tau 2 = 2 := by native_decide
+  simp only [divisorRatio, show (1 : ℕ) + 1 = 2 from rfl, h1, h2, h3,
+    ne_eq, not_false_eq_true, dite_true, Nat.cast_ofNat, Nat.cast_one]
+  norm_num
 
 /--
 **Example: τ(3)/τ(2) = 1:**
 τ(3) = 2, τ(2) = 2, so ratio = 1.
 -/
 example : divisorRatio 2 = 1 := by
-  simp [divisorRatio, tau]
-  sorry
+  have h1 : tau 2 ≠ 0 := by native_decide
+  have h2 : tau 2 = 2 := by native_decide
+  have h3 : tau 3 = 2 := by native_decide
+  simp only [divisorRatio, show (2 : ℕ) + 1 = 3 from rfl, h1, h2, h3,
+    ne_eq, not_false_eq_true, dite_true, Nat.cast_ofNat]
+  norm_num
 
 /--
 **Example: τ(4)/τ(3) = 3/2:**
 τ(4) = 3, τ(3) = 2, so ratio = 3/2.
 -/
 example : divisorRatio 3 = 3/2 := by
-  simp [divisorRatio, tau]
-  sorry
+  have h1 : tau 3 ≠ 0 := by native_decide
+  have h2 : tau 3 = 2 := by native_decide
+  have h3 : tau 4 = 3 := by native_decide
+  simp only [divisorRatio, show (3 : ℕ) + 1 = 4 from rfl, h1, h2, h3,
+    ne_eq, not_false_eq_true, dite_true, Nat.cast_ofNat]
+  norm_num
 
 /--
 **Small ratios:**

--- a/src/data/proofs/erdos-150/meta.json
+++ b/src/data/proofs/erdos-150/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 150,
     "erdosUrl": "https://erdosproblems.com/150",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-302/meta.json
+++ b/src/data/proofs/erdos-302/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 302,
     "erdosUrl": "https://erdosproblems.com/302",
     "erdosProblemStatus": "open",
@@ -76,8 +76,8 @@
       "Extremal combinatorics (density arguments)",
       "Asymptotic notation (o(1), liminf, limsup)"
     ],
-    "lineCount": 271,
-    "assumptions": "6 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "lineCount": 425,
+    "assumptions": "6 axiom(s): asymptotic lower bound (Cambie), upper bound (van Doorn), basic lower bound, doubling threshold, coloring (Brown-Rödl), density existence."
   },
   "overview": {
     "historicalContext": "**Unit Fraction Sum-Free Sets**\n\nErdős Problem #302 concerns the equation $\\frac{1}{a} = \\frac{1}{b} + \\frac{1}{c}$, which sits at the intersection of unit fraction theory and extremal combinatorics. The study of unit fraction decompositions traces back to ancient Egypt: the Rhind papyrus (c. 1650 BCE) represents fractions exclusively as sums of distinct unit fractions, and understanding which unit fraction equations have solutions has been a theme in number theory ever since.\n\nThe problem was posed by Erdős and Graham in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory* (Monographies de L'Enseignement Mathématique 28). They asked: if $f(N)$ denotes the size of the largest subset $A \\subseteq \\{1, \\ldots, N\\}$ containing no solution to $\\frac{1}{a} = \\frac{1}{b} + \\frac{1}{c}$ with distinct $a, b, c \\in A$, is it true that $f(N) = (\\frac{1}{2} + o(1))N$?\n\n**Historical Development:**\n- **1980 (Erdős-Graham):** Problem posed with the conjecture $f(N) = (\\frac{1}{2}+o(1))N$, motivated by two natural constructions (odd integers and the upper half $[N/2, N]$) both giving density $\\frac{1}{2}$.\n- **1991 (Brown-Rödl):** Solved the related coloring version (Problem #303): $\\{1, \\ldots, N\\}$ can always be 2-colored with no monochromatic solution.\n- **2023 (Cambie):** Disproved the original conjecture by combining odd integers $\\leq N/4$ with the interval $[N/2, N]$, yielding $f(N) \\geq (\\frac{5}{8}+o(1))N$.\n- **2023 (van Doorn):** Established the first non-trivial upper bound $f(N) \\leq (\\frac{9}{10}+o(1))N$ using structural analysis of solution-rich regions.\n\nThe problem remains open: the asymptotic density of $f(N)/N$ is known to lie in $[\\frac{5}{8}, \\frac{9}{10}] = [0.625, 0.9]$, but the exact value is unknown. This wide gap highlights the difficulty of extremal problems for multiplicative equations.",
@@ -91,7 +91,7 @@
       "**Cambie's combination:** Odd integers ≤ N/4 plus [N/2, N] gives 5N/8 elements",
       "**Standard pattern:** 1/n = 1/(n+1) + 1/(n(n+1)) gives many solutions",
       "**Coloring version solved:** Brown-Rödl showed 2-coloring always works",
-      "**Algebraic constraint $c \\leq 2a$:** For any solution with $a < b < c$, we have $c \\leq 2a$, so each element only interacts with elements in a bounded range — yet this local structure still permits enough solutions to make the global problem hard",
+      "**Algebraic constraints $b < 2a$ and $c \\leq a(a+1)$:** For any solution with $a < b < c$, the range of interaction is bounded — yet this local structure still permits enough solutions to make the global problem hard",
       "**Egyptian fraction connection:** The equation $\\frac{1}{a} = \\frac{1}{b} + \\frac{1}{c}$ is the simplest unit fraction decomposition, linking this problem to a tradition stretching back to the Rhind papyrus"
     ],
     "prerequisites": [
@@ -164,8 +164,8 @@
       "title": "Part 8: Algebraic Structure",
       "startLine": 183,
       "endLine": 201,
-      "summary": "algebraic_form: UnitFractionSum ↔ bc = ab + ac. solution_constraints: if a < b < c, then c ≤ 2a.",
-      "mathContext": "The polynomial form $bc = ab + ac$ reveals that solutions lie on a quadric surface. The constraint $c \\leq 2a$ (for $a < b < c$) follows from $\\frac{1}{c} = \\frac{1}{a} - \\frac{1}{b} \\geq \\frac{1}{a} - \\frac{1}{a+1} > \\frac{1}{2a}$, bounding the range of interaction."
+      "summary": "algebraic_form: UnitFractionSum ↔ bc = ab + ac. solution_b_lt_2a: b < 2a. solution_c_bound: c ≤ a(a+1).",
+      "mathContext": "The polynomial form $bc = ab + ac$ reveals solutions on a quadric. Proved bounds: $b < 2a$ (from $2ac \\leq bc \\Rightarrow c \\leq b$, contradiction) and $c \\leq a(a+1)$ (from $(b{-}a{-}1)(c{-}a) = a(a{+}1){-}c \\geq 0$)."
     },
     {
       "id": "examples",
@@ -234,9 +234,9 @@
     ],
     "opens": [],
     "namespace": "Erdos302",
-    "lineCount": 271,
+    "lineCount": 425,
     "axiomCount": 6,
-    "theoremCount": 15,
+    "theoremCount": 18,
     "definitionCount": 10
   },
   "references": [

--- a/src/data/proofs/erdos-448/meta.json
+++ b/src/data/proofs/erdos-448/meta.json
@@ -17,7 +17,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 448,
     "erdosUrl": "https://erdosproblems.com/448",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-964/meta.json
+++ b/src/data/proofs/erdos-964/meta.json
@@ -17,7 +17,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 5,
     "erdosNumber": 964,
     "erdosUrl": "https://erdosproblems.com/964",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary
- **Erdos302**: Prove remaining 2 sorries, fix false theorem (2→0 sorries)
- **Erdos1027** (`card_constOn_le`): Prove functions constant on A inject into Aᶜ → Bool, giving bound 2^(|α| - |A|). Completes Erdős 1963 probabilistic method (1→0 sorries)
- **Erdos150** (`alpha_less_than_two`): Prove 2^{H(1/3)} < 2 via H(1/3) < 1, reducing to log(27) < log(32). Completes Bradač's α < 2 (1→0 sorries)
- **Erdos448** (`tau_power_of_two`): Prove τ(2^k) = k+1 using Nat.divisors_prime_pow (2→1 sorries)
- **Erdos964**: Prove 3 divisor ratio examples using native_decide + norm_num (8→5 sorries)

**Total: 7 sorries eliminated across 5 files**

## Files Modified
- `proofs/Proofs/Erdos302Problem.lean`
- `proofs/Proofs/Erdos1027Problem.lean`
- `proofs/Proofs/Erdos150Problem.lean`
- `proofs/Proofs/Erdos448Problem.lean`
- `proofs/Proofs/Erdos964Problem.lean`
- `src/data/proofs/erdos-{302,1027,150,448,964}/meta.json`

## Test plan
- [ ] CI Lean build passes for all modified files
- [ ] No regressions in other proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)