### PR TITLE
Research: erdos-1042-oq-01 — proper defs for numComponents/maxComponents (12→10 axioms)

### DIFF
--- a/proofs/Proofs/Erdos1042Problem.lean
+++ b/proofs/Proofs/Erdos1042Problem.lean
@@ -23,8 +23,12 @@ import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Topology.Basic
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Topology.Connected.Clopen
+import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.Algebra.BigOperators.Group.Finset
 
-open Complex
+open Complex BigOperators
 
 namespace Erdos1042
 
@@ -60,13 +64,22 @@ structure PolynomialWithRoots (F : Set ℂ) where
 def lemniscate (f : ℂ → ℂ) : Set ℂ :=
   {z : ℂ | Complex.abs (f z) < 1}
 
-/-- Number of connected components of a set in ℂ. Axiomatized since
-the full topological definition requires ConnectedComponent machinery. -/
-axiom numComponents (S : Set ℂ) : ℕ
+/-- Number of connected components of a set S ⊆ ℂ. Defined as the
+cardinality of the quotient by the connected component equivalence
+on the subspace ↥S. Returns 0 if the number of components is infinite. -/
+noncomputable def numComponents (S : Set ℂ) : ℕ :=
+  Nat.card (ConnectedComponents ↥S)
+
+/-- The monic polynomial f(z) = ∏ᵢ(z - zᵢ) associated with a set of roots. -/
+noncomputable def monicPoly {F : Set ℂ} (p : PolynomialWithRoots F) (z : ℂ) : ℂ :=
+  ∏ i : Fin p.degree, (z - p.roots i)
 
 /-- Maximum number of connected components achievable by lemniscates
-of degree-n polynomials with roots in F. -/
-axiom maxComponents (F : Set ℂ) (n : ℕ) : ℕ
+of degree-n polynomials with roots in F. Defined as the supremum over
+all such polynomials. Returns 0 if no polynomials of that degree exist. -/
+noncomputable def maxComponents (F : Set ℂ) (n : ℕ) : ℕ :=
+  sSup {k : ℕ | ∃ p : PolynomialWithRoots F, p.degree = n ∧
+    numComponents (lemniscate (monicPoly p)) = k}
 
 /- ## The Original Problem -/
 

--- a/src/data/proofs/erdos-1042/meta.json
+++ b/src/data/proofs/erdos-1042/meta.json
@@ -49,9 +49,9 @@
       "diameter_not_sufficient axiom: geometry ≠ diameter alone",
       "erdos_1042_summary theorem combining key results"
     ],
-    "axiomCount": 12,
-    "lineCount": 151,
-    "assumptions": "12 axioms: transfiniteDiameter, transfiniteDiameter_nonneg, disc_transfinite_diameter, and 9 more. See Lean source for complete statements."
+    "axiomCount": 10,
+    "lineCount": 164,
+    "assumptions": "10 axioms: transfiniteDiameter (definition), 3 properties, 2 classical results (EHP 1958), 3 GR theorems (2024), 1 counterexample. numComponents and maxComponents now use proper Mathlib definitions."
   },
   "overview": {
     "historicalContext": "Erdős, Herzog, and Piranian posed this problem in their 1958 paper on metric properties of polynomials. A polynomial lemniscate is the sublevel set {z : |f(z)| < 1} of a polynomial f, and the question concerns how many connected components it can have when the roots are constrained to lie in a closed set F ⊆ ℂ. The transfinite diameter (logarithmic capacity) of F controls the answer.\n\nThe 1958 paper showed that for the unit disc (transfinite diameter 1), the lemniscate of f(z) = zⁿ + 1 has exactly n connected components — one small disc around each nth root of -1. This left open whether sets with smaller transfinite diameter must have fewer components, and whether the answer depends on diameter alone.\n\nThe problem remained open for over 65 years until Ghosh and Ramachandran (2024) gave a complete solution. They proved that for transfinite diameter d < 1, components are bounded by (1-c)n for some c > 0 depending on F. For d ≤ 1/4 with F connected, only one component is possible. Crucially, they showed the answer cannot depend on transfinite diameter alone: the disc of radius 1/2 and the interval [-1,1] both have transfinite diameter 1/2, but behave completely differently.",
@@ -239,9 +239,9 @@
       "Complex"
     ],
     "namespace": "Erdos1042",
-    "lineCount": 151,
-    "axiomCount": 12,
+    "lineCount": 164,
+    "axiomCount": 10,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 6
   }
 }


### PR DESCRIPTION
## Summary
Research session for erdos-1042-oq-01 (optimal constant in polynomial lemniscate components).

## Progress
- **Converted `numComponents`** from axiom to `Nat.card (ConnectedComponents ↥S)` — proper topological definition using Mathlib
- **Converted `maxComponents`** from axiom to `sSup` over degree-n polynomials — proper definition using `sSup`
- **Added `monicPoly` helper**: `f(z) = ∏ᵢ(z - zᵢ)` using `Finset.prod`
- **Eliminated 2 axioms** (12→10)

## Findings
- `transfiniteDiameter` remains axiom — needs Chebyshev constant / Robin constant machinery not available in Mathlib
- Remaining 10 axioms are genuine mathematical claims (EHP 1958, GR 2024 theorems, properties of transfinite diameter)
- The definition-axiom → proper-def conversion makes the formalization more honest: axioms now assert real mathematical content about correctly-defined functions

## Status
**Outcome**: progress
**Next Steps**: Define `transfiniteDiameter` properly to enable proving `transfiniteDiameter_nonneg`

🤖 Generated by researcher-1