### PR TITLE
fix: correct erdos-1095-oq-01 axiomCount (4→1) and lineCount

### DIFF
--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -21,10 +21,10 @@
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 320,
+    "axiomCount": 1,
+    "lineCount": 332,
     "theoremCount": 28,
-    "assumptions": "4 axiom(s): gFunc definition and its 3 properties (existence, specification, minimality). 0 sorries. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 proved from axioms. Asymptotic conjecture formalized."
+    "assumptions": "1 axiom: gFunc_exists (existence of g(k)). gFunc_gt, gFunc_spec, gFunc_minimal are theorems proved from the axiom via Nat.find. 0 sorries. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 proved from axioms. Asymptotic conjecture formalized."
   },
   "overview": {
     "historicalContext": "The function $g(k)$ — the smallest $n > k+1$ such that every prime factor of $\\binom{n}{k}$ exceeds $k$ — was introduced by Ecklund, Erdős, and Selfridge in their 1974 paper on smooth binomial coefficients. They established the initial bounds $k^{1+c} < g(k) \\leq \\exp((1+o(1))k)$, showing that $g(k)$ grows faster than any polynomial but no faster than exponential.\n\nThe lower bound was substantially improved by Konyagin, who proved $g(k) \\gg \\exp(c(\\log k)^2)$ using estimates on smooth numbers (integers whose prime factors are all below a given bound). The key insight is that $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$, and avoiding all primes $\\leq k$ requires $n$ to be chosen so that the prime factorization of the numerator $n(n-1)\\cdots(n-k+1)$ has no small prime factors surviving the cancellation with $k!$.\n\nErdős, Lacampagne, and Selfridge conjectured that $\\log g(k) \\sim c \\cdot k / \\log k$ for some positive constant $c$, which would place $g(k)$ at a precise intermediate growth rate between polynomial and exponential. Computational evidence by Sorenson, Sorenson, and Webster supports this conjecture, but it remains open. The problem connects to smooth number theory, sieve methods, and the distribution of prime factors in products of consecutive integers.",


### PR DESCRIPTION
## Fix

Corrects erdos-1095-oq-01 meta.json: axiomCount 4→1, lineCount 320→332.

## Evidence

**Before**: axiomCount=4, lineCount=320, assumptions text listed "4 axiom(s): gFunc definition and its 3 properties"
**After**: axiomCount=1, lineCount=332, assumptions text correctly identifies only `gFunc_exists` as an axiom

Only `gFunc_exists` (line 47) is an `axiom` declaration. `gFunc_gt`, `gFunc_spec`, and `gFunc_minimal` are theorems proved from it via `Nat.find_spec` / `Nat.find_min'`.

---
Automated fix by lean-mechanic agent.