### PR TITLE
Research: erdos-1070-incomplete-01 — fix malformed sorry-in-type (16→15 axioms, 0 sorry)

### DIFF
--- a/proofs/Proofs/Erdos1070Problem.lean
+++ b/proofs/Proofs/Erdos1070Problem.lean
@@ -166,8 +166,10 @@ theorem density_insufficient_for_quarter : m1 < 1 / 4 := by
   calc m1 ≤ 0.247 := acmvz_upper_bound
     _ < 1 / 4 := quarter_threshold
 
-/-- The n/4 question remains open -/
-axiom quarter_conjecture_open : ∀ n : ℕ, (f n : ℝ) ≥ n / 4 ↔ sorry
+/-- The n/4 conjecture: is f(n) ≥ n/4 for all n?
+This remains OPEN. The density approach (m₁ ≤ 0.247 < 0.25) shows that
+new techniques beyond density methods are needed to resolve this. -/
+def quarterConjecture : Prop := ∀ n : ℕ, (f n : ℝ) ≥ n / 4
 
 /- ## Connection to Hadwiger-Nelson Problem
 

--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -18,7 +18,7 @@
       "hadwiger-nelson"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1070,
     "erdosUrl": "https://erdosproblems.com/1070",
     "erdosProblemStatus": "open",
@@ -36,9 +36,9 @@
         "relationship": "Strict variant with no distances < 1"
       }
     ],
-    "axiomCount": 16,
+    "axiomCount": 15,
     "lineCount": 246,
-    "assumptions": "16 axiom(s) and 1 sorry(s).",
+    "assumptions": "15 axiom(s) and 0 sorry(s). Malformed quarter_conjecture_open axiom (with sorry in type) replaced with proper def.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -226,7 +226,7 @@
     "opens": [],
     "namespace": "Erdos1070",
     "lineCount": 246,
-    "axiomCount": 16,
+    "axiomCount": 15,
     "theoremCount": 6,
     "definitionCount": 6
   }


### PR DESCRIPTION
## Summary
Fix a malformed axiom in Erdős Problem #1070 (Independence Number of Unit Distance Graphs).

## Progress
- **Fixed**: `axiom quarter_conjecture_open : ... ↔ sorry` had `sorry` in its TYPE
- **Replaced with**: `def quarterConjecture : Prop := ∀ n, (f n : ℝ) ≥ n / 4`
- **Result**: 16→15 axioms, 1→0 sorries

## Issue
The original axiom `quarter_conjecture_open` used `sorry` as part of the biconditional's RHS, making it logically meaningless (asserting the conjecture ↔ sorry). The open question is now properly stated as a `Prop` definition.

## Status
**Outcome**: completed

🤖 Generated by researcher-1