### PR TITLE
audit: fix erdos-1098-oq-01 phantom theorem references

### DIFF
--- a/src/data/proofs/erdos-1098-oq-01/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1098-oq-01",
   "title": "Groups with Small Clique Number in the Non-Commuting Graph",
   "slug": "erdos-1098-oq-01",
-  "description": "Characterizes groups with small clique number ω in the non-commuting graph Γ(G). Proves: ω(Γ(G)) = 0 iff G abelian, center elements excluded from large cliques, clique elements lie in different cosets of Z(G), finite index center implies finite clique number. All theorems fully proved (0 sorries, 0 axioms).",
+  "description": "Characterizes groups with small clique number ω in the non-commuting graph Γ(G). Proves: ω(Γ(G)) = 0 iff G abelian, center elements excluded from large cliques, abelian groups have clique bound ≤ 1. All theorems fully proved (0 sorries, 0 axioms).",
   "meta": {
     "author": "Neumann (1976); Abdollahi-Akbari-Maimani (2006)",
     "sourceUrl": "https://erdosproblems.com/1098",
@@ -28,13 +28,13 @@
   },
   "overview": {
     "historicalContext": "**Non-Commuting Graphs and Group Structure**\n\nThe non-commuting graph Γ(G) has all group elements as vertices, with edges between non-commuting pairs. Neumann (1976) proved the foundational result: Γ(G) has no infinite clique iff the center Z(G) has finite index. This OQ explores the finer structure: what do groups with small clique number look like?",
-    "problemStatement": "**Problem Statement**\n\nCharacterize groups G where the clique number ω(Γ(G)) is small.\n\n**Known**: ω = 0 iff abelian. ω = 2 iff G/Z(G) is Klein four-group. ω ≤ n implies [G:Z(G)] ≤ n.",
+    "problemStatement": "**Problem Statement**\n\nCharacterize groups G where the clique number ω(Γ(G)) is small.\n\n**Known**: ω = 0 iff abelian (formalized). ω = 2 iff G/Z(G) is Klein four-group (not yet formalized). ω ≤ n implies [G:Z(G)] ≤ n (not yet formalized).",
     "text": "Formalizes characterizations of groups with small non-commuting clique number.",
-    "proofStrategy": "**Approach**: Define non-commuting and clique predicates, prove structural results using center properties and coset arguments.",
+    "proofStrategy": "**Approach**: Define non-commuting and clique predicates, prove structural results using center properties and Finset cardinality arguments.",
     "keyInsights": [
-      "**Coset structure**: Elements in a clique must lie in distinct cosets of Z(G), giving the injection bound",
       "**Center exclusion**: Center elements commute with everything, so they can't participate in cliques of size ≥ 2",
-      "**Abelian characterization**: ω = 0 iff every pair commutes iff G is abelian — a clean biconditional"
+      "**Abelian characterization**: ω = 0 iff every pair commutes iff G is abelian — a clean biconditional",
+      "**Singleton triviality**: A single element trivially forms a clique since nonCommuting requires two distinct elements"
     ],
     "prerequisites": [
       "Group theory: center, cosets, quotient groups",
@@ -55,13 +55,13 @@
       "title": "Structural Theorems",
       "startLine": 56,
       "endLine": 122,
-      "summary": "Proves clique_zero_iff_abelian, center_not_in_clique, abelian_clique_bound, same_coset_commute, clique_different_cosets, finite_index_implies_finite_clique.",
-      "mathContext": "$\\omega(\\Gamma(G)) = 0 \\iff G$ abelian. Clique elements in distinct cosets of $Z(G)$."
+      "summary": "Proves clique_zero_iff_abelian, singleton_not_clique_two, center_not_in_clique, abelian_clique_bound.",
+      "mathContext": "$\\omega(\\Gamma(G)) = 0 \\iff G$ abelian. Center elements excluded from cliques of size $\\geq 2$."
     }
   ],
   "conclusion": {
     "summary": "Fully verified formalization of small clique number characterizations in non-commuting graphs. All 8 theorems proved from Mathlib with 0 axioms and 0 sorries.",
-    "implications": "Establishes the algebraic structure theory connecting clique number of Γ(G) to the quotient G/Z(G).",
+    "implications": "Establishes foundational characterizations: abelian iff no non-commuting edges, center elements excluded from nontrivial cliques, abelian groups have clique bound at most 1.",
     "openQuestions": [
       "Can clique_size_bound (injection S → G/Z(G)) be proved?",
       "Characterize ω = 2 (Klein four-group quotient) formally"
@@ -73,18 +73,6 @@
       "type": "core",
       "description": "ω(Γ(G)) = 0 iff G is abelian",
       "leanType": "biconditional"
-    },
-    {
-      "name": "clique_different_cosets",
-      "type": "core",
-      "description": "Clique elements lie in different cosets of Z(G)",
-      "leanType": "∀ g h ∈ clique, g⁻¹*h ∉ Z(G)"
-    },
-    {
-      "name": "finite_index_implies_finite_clique",
-      "type": "core",
-      "description": "[G:Z(G)] < ∞ implies ω(Γ(G)) < ∞",
-      "leanType": "Subgroup.index (center G) finite → clique number finite"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

- Remove 3 phantom theorem references from `erdos-1098-oq-01/meta.json` that do not exist in the Lean source (`Proofs/Erdos1098OQ01.lean`):
  - `clique_different_cosets` (mainTheorems, sections summary)
  - `finite_index_implies_finite_clique` (mainTheorems, sections summary)
  - `same_coset_commute` (sections summary)
- Fix `description` to only claim what is actually proved (removed coset and finite index claims)
- Fix `mainTheorems` to contain only `clique_zero_iff_abelian` (the one entry that actually exists)
- Fix `sections[1].summary` to list the 4 actual theorems in that section
- Add "(not yet formalized)" qualifiers in `overview.problemStatement` for unproved claims
- Update `keyInsights`, `proofStrategy`, and `conclusion.implications` to match actual content

Numeric fields unchanged and verified correct: sorries 0, axiomCount 0, theoremCount 8, definitionCount 3, lineCount 122, status verified, badge verified.

## Verified against source

The Lean file contains exactly 8 theorems:
1. `nonCommuting_iff`
2. `nonCommuting_symm`
3. `center_commutes`
4. `center_not_nonCommuting`
5. `clique_zero_iff_abelian`
6. `singleton_not_clique_two`
7. `center_not_in_clique`
8. `abelian_clique_bound`

And 3 definitions: `nonCommuting`, `commuting`, `IsClique`

Generated with [Claude Code](https://claude.com/claude-code)