### PR TITLE
audit: fix erdos-1031 sorry count (3→2) and line/theorem counts

### DIFF
--- a/src/data/proofs/erdos-1031/meta.json
+++ b/src/data/proofs/erdos-1031/meta.json
@@ -17,7 +17,7 @@
       "universality"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 1031,
     "erdosUrl": "https://erdosproblems.com/1031",
     "erdosProblemStatus": "solved",
@@ -25,8 +25,8 @@
       "erdos-82"
     ],
     "axiomCount": 6,
-    "lineCount": 312,
-    "assumptions": "6 axioms (deep: Ramsey bounds, Prömel-Rödl, non-Ramsey existence, regular graph existence). 3 sorries remain. 7 new structural theorems added (monotonicity, subset properties).",
+    "lineCount": 516,
+    "assumptions": "6 axioms (deep: Ramsey bounds, Prömel-Rödl, non-Ramsey existence, regular graph existence). 2 sorries remain. 7 new structural theorems added (monotonicity, subset properties).",
     "mathlib_version": "4.29.0"
   },
   "overview": {
@@ -219,9 +219,9 @@
       "Finset"
     ],
     "namespace": "Erdos1031",
-    "lineCount": 280,
+    "lineCount": 516,
     "axiomCount": 6,
-    "theoremCount": 6,
-    "definitionCount": 16
+    "theoremCount": 17,
+    "definitionCount": 18
   }
 }


### PR DESCRIPTION
## Summary

Re-fix of erdos-1031 meta.json after the data sync commit (#7954) overwrote the previous fix (#7947).

**Changes verified against Lean source** (`proofs/Proofs/Erdos1031Problem.lean`, 516 lines):

| Field | Before | After | Source |
|-------|--------|-------|--------|
| `meta.sorries` | 3 | 2 | `sorry` on lines 483, 487 |
| `meta.lineCount` | 312 | 516 | `wc -l` |
| `meta.assumptions` text | "3 sorries remain" | "2 sorries remain" | matches sorry count |
| `leanFile.lineCount` | 280 | 516 | `wc -l` |
| `leanFile.theoremCount` | 6 | 17 | includes private theorems |
| `leanFile.definitionCount` | 16 | 18 | includes noncomputable/private defs |

**Unchanged** (already correct): `axiomCount` (6), `status` (axiomatized), `badge` (axiom).

## Context

PR #7947 originally fixed these values, but the subsequent data sync commit #7954 overwrote the corrections with stale data. This PR re-applies the fixes.

## Test plan

- [ ] Verify `meta.json` values match Lean source counts
- [ ] Confirm `pnpm build` succeeds with updated data