### PR TITLE
Research: prove 2 sorries (digital root termination, sumset lower bound)

### DIFF
--- a/proofs/Proofs/DivisibilityBy3OQ03.lean
+++ b/proofs/Proofs/DivisibilityBy3OQ03.lean
@@ -31,6 +31,17 @@ Sum of digits in base 10.
 /-- Sum of digits of n in base 10 -/
 def digitSum (n : ℕ) : ℕ := (Nat.digits 10 n).sum
 
+/-- Sum of digits is at most n for all n. -/
+private theorem digitSum_le_self (n : ℕ) : digitSum n ≤ n := by
+  unfold digitSum
+  rcases le_or_lt 10 n with h | h
+  · exact le_of_lt (Nat.sum_digits_lt n 10 (by omega) h)
+  · interval_cases n <;> native_decide
+
+/-- digitSum n < n for n ≥ 10. -/
+private theorem digitSum_lt_of_ge_ten (n : ℕ) (h : 10 ≤ n) : digitSum n < n := by
+  unfold digitSum; exact Nat.sum_digits_lt n 10 (by omega) h
+
 /-- The digital root: iterate digit summation until single digit -/
 noncomputable def digitalRoot : ℕ → ℕ
   | 0 => 0
@@ -39,7 +50,9 @@ noncomputable def digitalRoot : ℕ → ℕ
     if s < 10 then s else digitalRoot s
   termination_by n => n
   decreasing_by
-    sorry -- Need: digitSum n < n for n ≥ 10
+    simp_wf
+    have h_le := digitSum_le_self (n + 1)
+    exact digitSum_lt_of_ge_ten (n + 1) (by omega)
 
 /-
 ## Part II: Closed-Form Formula
@@ -246,8 +259,8 @@ in constant time using `1 + ((n-1) mod 9)`, avoiding iterative summation.
 - digitalRoot_mul: dr(a·b) = dr(dr(a) · dr(b))
 - 5 concrete examples
 
-**Sorry** (1):
-- digitalRoot decreasing_by: digitSum n < n for n ≥ 10 (termination of iterative def)
+**Previously Sorry** (now resolved):
+- digitalRoot decreasing_by: digitSum n < n for n ≥ 10 (proved via Nat.sum_digits_lt)
 -/
 
 #check digitalRootFormula

--- a/proofs/Proofs/Erdos485OQ02.lean
+++ b/proofs/Proofs/Erdos485OQ02.lean
@@ -187,7 +187,37 @@ This is a special case of the Cauchy-Davenport theorem for ℤ
     giving at least 2|A| - 1 distinct elements. -/
 theorem sumset_card_lower_bound (A : Finset ℕ) (hA : A.Nonempty) :
     (A + A).card ≥ 2 * A.card - 1 := by
-  sorry
+  -- Left injection: a ↦ min(A) + a; right injection: a ↦ a + max(A)
+  -- These overlap in exactly {min(A) + max(A)}, giving 2|A| - 1 distinct elements.
+  have hLsub : A.image (A.min' hA + ·) ⊆ A + A := by
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨a, ha, rfl⟩ := hx
+    exact Finset.add_mem_add (Finset.min'_mem A hA) ha
+  have hRsub : A.image (· + A.max' hA) ⊆ A + A := by
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨a, ha, rfl⟩ := hx
+    exact Finset.add_mem_add ha (Finset.max'_mem A hA)
+  have hLcard : (A.image (A.min' hA + ·)).card = A.card :=
+    Finset.card_image_of_injective A (fun _ _ h => by omega)
+  have hRcard : (A.image (· + A.max' hA)).card = A.card :=
+    Finset.card_image_of_injective A (fun _ _ h => by omega)
+  have hIcard : (A.image (A.min' hA + ·) ∩ A.image (· + A.max' hA)).card ≤ 1 := by
+    rw [Finset.card_le_one]
+    intro x hx y hy
+    simp only [Finset.mem_inter, Finset.mem_image] at hx hy
+    obtain ⟨⟨a₁, ha₁, ha₁eq⟩, b₁, hb₁, hb₁eq⟩ := hx
+    obtain ⟨⟨a₂, ha₂, ha₂eq⟩, b₂, hb₂, hb₂eq⟩ := hy
+    have := Finset.min'_le A b₁ hb₁
+    have := Finset.le_max' A a₁ ha₁
+    have := Finset.min'_le A b₂ hb₂
+    have := Finset.le_max' A a₂ ha₂
+    omega
+  have hUcard := Finset.card_union_add_card_inter
+    (A.image (A.min' hA + ·)) (A.image (· + A.max' hA))
+  have h1 := Finset.card_le_card (Finset.union_subset hLsub hRsub)
+  omega
 
 /-
 ## Part VI: Combining — The Positive-Coefficient Result

--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -7,14 +7,14 @@
     "author": "Classical result",
     "sourceUrl": "https://en.wikipedia.org/wiki/Digital_root",
     "date": "Classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DivisibilityBy3OQ03.lean",
     "tags": ["number-theory", "divisibility", "digital-root", "modular-arithmetic", "algorithms", "research"],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axiom declarations. 1 sorry: digitalRoot decreasing_by (termination of iterative definition).",
-    "lineCount": 200
+    "assumptions": "Fully verified: 0 axiom declarations, 0 sorries.",
+    "lineCount": 210
   },
   "overview": {
     "historicalContext": "The digital root (iterative digit sum) has been used for centuries in 'casting out nines' to check arithmetic. The closed-form formula digitalRoot(n) = 1 + ((n-1) mod 9) reduces this to O(1).",
@@ -47,7 +47,7 @@
     "lineCount": 200,
     "axiomCount": 0,
     "theoremCount": 15,
-    "sorryTheorems": 1,
+    "sorryTheorems": 0,
     "definitionCount": 3
   }
 }

--- a/src/data/proofs/erdos-485-oq-02/meta.json
+++ b/src/data/proofs/erdos-485-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos (1949); Schinzel (1987); Schinzel-Zannier (2009)",
     "sourceUrl": "https://erdosproblems.com/485",
     "date": "1949",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos485OQ02.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "open-problem",
       "research"
     ],
-    "badge": "research",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.coeff_mul",
@@ -54,7 +54,7 @@
     "dateAdded": "2026-03-29",
     "axiomCount": 0,
     "lineCount": 297,
-    "assumptions": "0 axioms. 1 sorry: sumset_card_lower_bound (|A + A| >= 2|A| - 1, standard combinatorial fact provable from first principles).",
+    "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- **DivisibilityBy3OQ03.lean**: Prove the `digitSum n < n` termination condition for the iterative `digitalRoot` definition using `Nat.sum_digits_lt` from Mathlib. Adds helper lemmas `digitSum_le_self` and `digitSum_lt_of_ge_ten`. (1 sorry → 0, now fully verified)
- **Erdos485OQ02.lean**: Prove `|A + A| ≥ 2|A| - 1` for nonempty finite sets via the min/max injection + inclusion-exclusion argument. The left injection `a ↦ min(A) + a` and right injection `a ↦ a + max(A)` each have |A| elements and overlap in exactly one point. (1 sorry → 0, now fully verified)

## Files Modified
- `proofs/Proofs/DivisibilityBy3OQ03.lean` — termination proof
- `proofs/Proofs/Erdos485OQ02.lean` — sumset lower bound
- `src/data/proofs/divisibility-by-3-oq-03/meta.json` — 0 sorries, verified
- `src/data/proofs/erdos-485-oq-02/meta.json` — 0 sorries, verified

## Status
**Outcome**: 2 sorries eliminated, 2 proofs upgraded to verified
**Note**: Pool exhausted (857/859 completed), worked on sorry elimination instead

Generated by researcher-9