### PR TITLE
Research: erdos-1027-incomplete-01 — sync gallery metadata with current proof (0 sorries)

### DIFF
--- a/src/data/proofs/erdos-1027/annotations.json
+++ b/src/data/proofs/erdos-1027/annotations.json
@@ -23,7 +23,7 @@
     "proofId": "erdos-1027",
     "type": "definition",
     "title": "Set Family, Union, and Uniformity",
-    "content": "`SetFamily α` is `Finset (Finset α)`—a finite collection of finite subsets. `familyUnion F` computes $X = \\bigcup \\mathcal{F}$ via `Finset.sup`. `isNUniform F n` requires every set $A \\in \\mathcal{F}$ to have $|A| = n$ (an $n$-uniform hypergraph). These are the basic objects: $\\mathcal{F}$ is the hypergraph, $X$ is the ground set, and $n$ is the uniformity parameter.",
+    "content": "`SetFamily α` is `Finset (Finset α)`—a finite collection of finite subsets. `familyUnion F` computes $X = \\bigcup \\mathcal{F}$ via `Finset.sup`. `IsNUniform F n` requires every set $A \\in \\mathcal{F}$ to have $|A| = n$ (an $n$-uniform hypergraph). These are the basic objects: $\\mathcal{F}$ is the hypergraph, $X$ is the ground set, and $n$ is the uniformity parameter.",
     "mathContext": "$\\mathcal{F} \\subseteq 2^\\alpha$ finite; $X = \\bigcup_{A \\in \\mathcal{F}} A$; $n$-uniform: $|A| = n \\; \\forall A \\in \\mathcal{F}$",
     "significance": "key",
     "relatedConcepts": [
@@ -41,7 +41,7 @@
     "proofId": "erdos-1027",
     "type": "definition",
     "title": "Good Sets: Intersecting All, Containing None",
-    "content": "The central definition. `intersectsAll B F` requires $(A \\cap B) \\ne \\emptyset$ for all $A \\in \\mathcal{F}$: $B$ 'hits' every hyperedge. `containsNone B F` requires $A \\not\\subseteq B$ for all $A \\in \\mathcal{F}$: $B$ does not swallow any hyperedge. A 'good' set $B$ satisfies both simultaneously—it is a transversal that is not a cover. `goodSets F` collects all good $B \\subseteq X$. In 2-coloring language, $B$ corresponds to the 'true' color class of a proper 2-coloring.",
+    "content": "The central definition. `IntersectsAll B F` requires $(A \\cap B) \\ne \\emptyset$ for all $A \\in \\mathcal{F}$: $B$ 'hits' every hyperedge. `ContainsNone B F` requires $A \\not\\subseteq B$ for all $A \\in \\mathcal{F}$: $B$ does not swallow any hyperedge. A 'good' set $B$ satisfies both simultaneously—it is a transversal that is not a cover. `goodSets F` collects all good $B \\subseteq X$. In 2-coloring language, $B$ corresponds to the 'true' color class of a proper 2-coloring.",
     "mathContext": "$B \\text{ good} \\iff \\forall A \\in \\mathcal{F}: A \\cap B \\ne \\emptyset \\wedge A \\not\\subseteq B$; equivalently, both color classes of $(B, X \\setminus B)$ hit every $A$",
     "significance": "key",
     "relatedConcepts": [
@@ -59,8 +59,8 @@
     "proofId": "erdos-1027",
     "type": "definition",
     "title": "Property B and 2-Colorability",
-    "content": "`hasPropertyB F` holds if at least one good set exists. `is2Colorable F` requires a function $f: \\alpha \\to \\text{Bool}$ such that every $A \\in \\mathcal{F}$ has both true-colored and false-colored elements. The theorem `propertyB_iff_2colorable` shows these are equivalent: a good set $B$ defines the coloring $f(x) = (x \\in B)$, and conversely $B = f^{-1}(\\text{true})$ is a good set. Property B (Bernstein 1908) is the foundational notion of hypergraph 2-colorability.",
-    "mathContext": "$\\text{hasPropertyB}(\\mathcal{F}) \\iff \\exists f: \\alpha \\to \\{0,1\\}, \\forall A \\in \\mathcal{F}: A \\not\\subseteq f^{-1}(0) \\wedge A \\not\\subseteq f^{-1}(1)$",
+    "content": "`HasPropertyB F` holds if at least one good set exists. `Is2Colorable F` requires a function $f: \\alpha \\to \\text{Bool}$ such that every $A \\in \\mathcal{F}$ has both true-colored and false-colored elements. `propertyB_implies_2colorable` and `coloring_implies_propertyB` prove the equivalence: a good set $B$ defines the coloring $f(x) = (x \\in B)$, and conversely $B = f^{-1}(\\text{true})$ is a good set. Both proofs are sorry-free.",
+    "mathContext": "$\\text{HasPropertyB}(\\mathcal{F}) \\iff \\text{Is2Colorable}(\\mathcal{F})$: good sets correspond to proper 2-colorings",
     "significance": "key",
     "relatedConcepts": [
       "Bernstein property",
@@ -77,7 +77,7 @@
     "proofId": "erdos-1027",
     "type": "definition",
     "title": "The Main Conjecture: Exponentially Many Good Sets",
-    "content": "`goodSetCount F` counts good sets via `Finset.filter` on the powerset. `erdos_1027_conjecture c` asserts: for $c > 0$, there exist $\\delta > 0$ and $N$ such that for $n \\ge N$, every $n$-uniform family $\\mathcal{F}$ with $|\\mathcal{F}| \\le c \\cdot 2^n$ has at least $\\delta \\cdot 2^{|X|}$ good sets. The key quantifier structure is: $\\delta$ depends on $c$ but not on $n$ or $\\mathcal{F}$—a constant fraction of all subsets of $X$ are good.",
+    "content": "`goodSetCount F` counts good sets. `goodSetDensity F` computes the ratio $|\\text{good}| / 2^{|X|}$. `Erdos1027Statement` asserts: for $c > 0$, there exist $\\delta > 0$ and $N$ such that for $n \\ge N$, every $n$-uniform family $\\mathcal{F}$ with $|\\mathcal{F}| \\le c \\cdot 2^n$ has at least $\\delta \\cdot 2^{|X|}$ good sets. The key quantifier structure is: $\\delta$ depends on $c$ but not on $n$ or $\\mathcal{F}$—a constant fraction of all subsets of $X$ are good.",
     "mathContext": "$\\forall c > 0, \\exists \\delta > 0, \\exists N, \\forall n \\ge N: |\\mathcal{F}| \\le c \\cdot 2^n \\wedge \\text{uniform}(n) \\Rightarrow |\\text{good}| \\ge \\delta \\cdot 2^{|X|}$",
     "significance": "key",
     "relatedConcepts": [
@@ -87,7 +87,7 @@
     ],
     "prerequisites": [
       "goodSetCount",
-      "isNUniform"
+      "IsNUniform"
     ]
   },
   {
@@ -95,8 +95,8 @@
     "proofId": "erdos-1027",
     "type": "technique",
     "title": "The Solution: Koishi Chan's Theorem",
-    "content": "`erdos_1027_solution` axiomatizes the affirmative answer (proved by Koishi Chan): for every $c > 0$, the conjecture holds. `erdos_1027_solved` derives the explicit statement: there exist $\\delta > 0$ and $N$ such that for all large enough $n$-uniform families of size $\\le c \\cdot 2^n$, the good set count is $\\ge \\delta \\cdot 2^{|X|}$. This resolves Erdős's question: not only does property B hold for bounded families, but the number of witnesses is exponentially large.",
-    "mathContext": "$\\forall c > 0: \\text{erdos\\_1027\\_conjecture}(c)$ holds; i.e., a $\\delta(c)$-fraction of all subsets of $X$ are good",
+    "content": "`erdos_1027_solution` axiomatizes the affirmative answer (proved by Koishi Chan): for every $c > 0$, the conjecture holds. `erdos_1027_solved` derives the explicit statement. This is the single axiom in the file, encoding the external mathematical result. This resolves Erdős's question: not only does property B hold for bounded families, but the number of witnesses is exponentially large.",
+    "mathContext": "$\\forall c > 0: \\text{Erdos1027Statement}$ holds; i.e., a $\\delta(c)$-fraction of all subsets of $X$ are good",
     "significance": "key",
     "relatedConcepts": [
       "abundance of colorings",
@@ -104,17 +104,16 @@
       "supersaturation"
     ],
     "prerequisites": [
-      "erdos_1027_conjecture",
-      "propertyB_for_bounded"
+      "Erdos1027Statement"
     ]
   },
   {
-    "id": "ann-1027-problem901",
+    "id": "ann-1027-abundance",
     "proofId": "erdos-1027",
     "type": "technique",
-    "title": "Connection to Erdős Problem #901",
-    "content": "Problem #901 asks about property B itself—whether bounded families are 2-colorable. Problem #1027 strengthens this: not just one 2-coloring, but exponentially many. `problem_901_connection` states `hasPropertyB F ↔ is2Colorable F` universally, and `problem_901` derives it from `propertyB_iff_2colorable`. This shows #1027 is a quantitative supersaturation of #901.",
-    "mathContext": "$\\text{Problem 901}: \\text{hasPropertyB} \\iff \\text{is2Colorable}$; Problem 1027: $|\\text{good sets}| \\gg_c 2^{|X|}$",
+    "title": "Abundance Implies Property B",
+    "content": "`abundance_implies_propertyB` proves that if `goodSetCount F > 0`, then F has Property B. This bridges the quantitative result (abundance of good sets) to the qualitative one (existence of at least one). It connects Problem #1027 (exponential abundance) to Problem #901 (existence of Property B). Sorry-free.",
+    "mathContext": "$|\\text{good sets}| > 0 \\Rightarrow \\text{HasPropertyB}(\\mathcal{F})$",
     "significance": "key",
     "relatedConcepts": [
       "supersaturation",
@@ -122,80 +121,28 @@
       "quantitative strengthening"
     ],
     "prerequisites": [
-      "hasPropertyB",
-      "is2Colorable"
-    ]
-  },
-  {
-    "id": "ann-1027-existence",
-    "proofId": "erdos-1027",
-    "type": "technique",
-    "title": "Existence and Abundance of Good Sets",
-    "content": "`propertyB_for_bounded` axiomatizes that for $c > 0$ and large $n$, every $n$-uniform family of size $\\le c \\cdot 2^n$ has property B—at least one good set. `single_implies_many` is the key structural insight: from *one* good set $B$, local perturbations (flipping elements near but not in $A$ for each $A$) produce exponentially many good sets. This 'amplification' from existence to abundance is the heart of Koishi Chan's argument.",
-    "mathContext": "$\\exists B \\text{ good} \\Rightarrow \\exists \\delta > 0: |\\text{good sets}| \\ge \\delta \\cdot 2^{|X|}$",
-    "significance": "key",
-    "relatedConcepts": [
-      "amplification",
-      "local perturbation",
-      "density amplification"
-    ],
-    "prerequisites": [
-      "hasPropertyB",
+      "HasPropertyB",
       "goodSetCount"
     ]
   },
   {
-    "id": "ann-1027-probabilistic",
-    "proofId": "erdos-1027",
-    "type": "insight",
-    "title": "Probabilistic Intuition: Random Sets Are Often Good",
-    "content": "Defines the probability that a uniformly random subset $B \\subseteq X$ is good. For a single set $A$ of size $n$: $\\Pr[B \\cap A \\ne \\emptyset] = 1 - 2^{-n}$ and $\\Pr[A \\not\\subseteq B] = 1 - 2^{-n}$. For a family of $m \\le c \\cdot 2^n$ sets, a naive union bound gives $\\mathbb{E}[\\text{good}] \\approx 2^{|X|} \\cdot (1 - 2^{-n})^{2m} \\approx 2^{|X|} \\cdot e^{-2c}$ for large $n$. The theorem `expected_good_positive` formalizes that this expectation is positive for large $n$, but the actual proof requires handling dependencies via the Lovász Local Lemma or a more careful counting argument.",
-    "mathContext": "$\\Pr[B \\text{ good}] \\ge (1 - 2^{-n})^{2|\\mathcal{F}|} \\approx e^{-2c}$ for $|\\mathcal{F}| \\le c \\cdot 2^n$; $\\mathbb{E}[|\\text{good}|] \\approx e^{-2c} \\cdot 2^{|X|}$",
-    "significance": "key",
-    "relatedConcepts": [
-      "first-moment method",
-      "union bound",
-      "Lovász Local Lemma"
-    ],
-    "prerequisites": [
-      "probIntersects",
-      "probNotContains"
-    ]
-  },
-  {
-    "id": "ann-1027-density",
-    "proofId": "erdos-1027",
-    "type": "definition",
-    "title": "Density of Good Sets",
-    "content": "`goodSetDensity F` $= |\\text{good sets}| / 2^{|X|}$: the fraction of all subsets of $X$ that are good. `goodSetDensity_lower` axiomatizes the main result in density form: for bounded families, the density is $\\ge \\delta(c) > 0$—a constant fraction depending only on $c$, not on $n$ or the specific family. This is the strongest form of the result: good sets are not merely numerous but *dense* among all subsets.",
-    "mathContext": "$\\text{density}(\\mathcal{F}) = |\\{B \\subseteq X : B \\text{ good}\\}| / 2^{|X|} \\ge \\delta(c) > 0$",
-    "significance": "key",
-    "relatedConcepts": [
-      "density",
-      "constant fraction",
-      "measure concentration"
-    ],
-    "prerequisites": [
-      "goodSetCount",
-      "familyUnion"
-    ]
-  },
-  {
-    "id": "ann-1027-specialcases",
+    "id": "ann-1027-classical",
     "proofId": "erdos-1027",
     "type": "technique",
-    "title": "Special Cases and Inclusion-Exclusion",
-    "content": "Three verification results. `empty_family_good`: when $\\mathcal{F} = \\emptyset$, all $2^{|\\alpha|}$ subsets are good (vacuously). `singleton_family_good`: for $\\mathcal{F} = \\{A\\}$, good sets are those intersecting $A$ but not containing it, giving $\\ge 2^{|A| - 1}$ good sets. `good_set_inclusion_exclusion`: a general lower bound via inclusion-exclusion, showing $|\\text{good}| \\ge \\frac{1}{4} \\cdot 2^{|X|} - |\\mathcal{F}| \\cdot 2^{|X| - 1}$, which is positive when $|\\mathcal{F}| < \\frac{1}{2}$—a very rough bound that the main theorem far surpasses.",
-    "mathContext": "$\\mathcal{F} = \\emptyset \\Rightarrow |\\text{good}| = 2^{|\\alpha|}$; $\\mathcal{F} = \\{A\\} \\Rightarrow |\\text{good}| \\ge 2^{|A|-1}$; general: $|\\text{good}| \\ge \\frac{1}{4} \\cdot 2^{|X|} - |\\mathcal{F}| \\cdot 2^{|X|-1}$",
-    "significance": "supporting",
+    "title": "Erdős Classical Bound (1963) via the Probabilistic Method",
+    "content": "The largest section. Defines `IsMonochromatic` (all elements of $A$ get the same color). Proves three results: (1) `card_constOn_le`: functions constant $b$ on $A$ number at most $2^{|\\alpha| - |A|}$, proved by injecting into complement functions $(A^c \\to \\text{Bool})$. (2) `card_monochromatic_le`: monochromatic colorings on $A$ bounded by $2 \\cdot 2^{|\\alpha| - |A|}$ (union of all-true and all-false). (3) `erdos_classical_bound`: if $|\\mathcal{F}| \\cdot 2 < 2^t$ and all sets have size $\\ge t$, then F is 2-colorable. The proof counts bad colorings via union bound: each set contributes $\\le 2 \\cdot 2^{|\\alpha| - t}$ bad colorings, total $< 2^{|\\alpha|}$, so a good coloring exists. All sorry-free.",
+    "mathContext": "$|\\mathcal{F}| \\cdot 2 < 2^t, |A| \\ge t \\; \\forall A \\in \\mathcal{F} \\Rightarrow \\text{Is2Colorable}(\\mathcal{F})$. Proof: $|\\text{bad}| \\le \\sum_A 2 \\cdot 2^{|\\alpha| - |A|} \\le |\\mathcal{F}| \\cdot 2 \\cdot 2^{|\\alpha| - t} < 2^{|\\alpha|}$",
+    "significance": "key",
     "relatedConcepts": [
-      "inclusion-exclusion",
-      "base cases",
-      "counting argument"
+      "probabilistic method",
+      "union bound",
+      "monochromatic coloring",
+      "injection argument"
     ],
     "prerequisites": [
-      "goodSetCount",
-      "Finset.powerset"
+      "Finset.biUnion",
+      "Fintype.card_fun",
+      "Finset.card_compl"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -25,7 +25,7 @@
       901
     ],
     "axiomCount": 1,
-    "lineCount": 361,
+    "lineCount": 355,
     "assumptions": "1 axiom: erdos_1027_solution (Koishi Chan's affirmative answer). 0 sorries — card_constOn_le proved via injection into complement functions.",
     "mathlib_version": "4.29.0"
   },
@@ -33,7 +33,7 @@
     "historicalContext": "Property B, named after Felix Bernstein's 1908 work on set partitions and formally introduced by E.W. Miller (1937), asks whether a family of sets can be 2-colored so that no set is monochromatic. Equivalently: does there exist a subset $B$ of the ground set that intersects every family member but contains none? Such a $B$ is called a 'good' set\u2014its existence is precisely property B.\n\nErd\u0151s's 1963 probabilistic bound showed that if $|\\mathcal{F}| < 2^{t-1}$ and all sets have size $\\ge t$, then $\\mathcal{F}$ has property B. The proof is a gem of the probabilistic method: each set of size $s$ is monochromatic under a random 2-coloring with probability $2^{1-s}$, and the union bound gives the result. This bound is tight\u2014Erd\u0151s constructed $2^{t-1}$ sets of size $t$ without property B.\n\nProblem #1027 asks a *quantitative* question that goes far beyond mere existence. Given a bounded family ($|\\mathcal{F}| \\le c \\cdot 2^n$, all sets of size $n$), must there be not just one good set but *exponentially many*? Specifically, are there $\\gg_c 2^{|X|}$ good subsets of $X = \\bigcup \\mathcal{F}$, where the implicit constant depends only on $c$? This is a supersaturation phenomenon: once property B holds, it holds abundantly.\n\nThe problem is closely related to Erd\u0151s Problem #901, which asks about property B for bounded families. Problem #1027 strengthens #901 from an existential statement (at least one good set) to a quantitative one (a constant fraction of all subsets are good).\n\nKoishi Chan resolved the problem affirmatively. The key insight is an amplification argument: given one good set $B$, local perturbations\u2014flipping elements of $B$ that are 'far' from being critical for any family member\u2014produce exponentially many other good sets. The probabilistic intuition is that a random subset $B \\subseteq X$ satisfies $\\Pr[B \\text{ good}] \\ge (1 - 2^{-n})^{2|\\mathcal{F}|} \\approx e^{-2c}$ for large $n$, giving an expected $e^{-2c} \\cdot 2^{|X|}$ good sets. Making this rigorous requires handling the dependencies between the events '$B$ intersects $A$' and '$A \\not\\subseteq B$' for different $A \\in \\mathcal{F}$.\n\nThe result connects to several areas: the Lov\u00e1sz Local Lemma (handling dependent events), supersaturation in extremal combinatorics (Erd\u0151s-Simonovits theory), the entropy method in combinatorics (Shearer's lemma), and the theory of containers (Balogh-Morris-Samotij, Saxton-Thomason), which provides a general framework for counting independent sets in hypergraphs.",
     "problemStatement": "Let $c > 0$ and $n$ be sufficiently large. Suppose $\\mathcal{F}$ is a family of at most $c \\cdot 2^n$ sets, each of size $n$. Let $X = \\bigcup_{A \\in \\mathcal{F}} A$.\n\nMust there exist $\\gg_c 2^{|X|}$ sets $B \\subseteq X$ which intersect every set in $\\mathcal{F}$, yet contain none of them?\n\nMore precisely: does there exist $\\delta = \\delta(c) > 0$ such that for all sufficiently large $n$, every such family has at least $\\delta \\cdot 2^{|X|}$ good sets?\n\n**Status**: SOLVED (YES)\n\n**Answer**: Proved by Koishi Chan. A constant fraction $\\delta(c)$ of all subsets of $X$ are good.",
     "text": "Let F be a family of at most c\u00b72^n sets of size n, and X = \u222aF. Must there exist \u226b_c 2^|X| sets B \u2286 X that intersect every set in F yet contain none? YES (proved by Koishi Chan). Connection to Property B (2-chromatic families).",
-    "proofStrategy": "The formalization builds the theory of good sets and the abundance conjecture in five layers across ~235 lines.\n\n**Layer 1 \u2014 Set family infrastructure (lines 24\u201341)**: Defines `SetFamily \u03b1` as `Finset (Finset \u03b1)`, `familyUnion F` as $\\bigcup \\mathcal{F}$ via `Finset.sup`, and `isNUniform F n` requiring all sets to have size $n$.\n\n**Layer 2 \u2014 Good sets and property B (lines 43\u201385)**: Defines `intersectsAll`, `containsNone`, `isGoodSet`, and `goodSets`. Defines `hasPropertyB` (existence of a good set) and `is2Colorable` (existence of a proper 2-coloring). Proves the equivalence `propertyB_iff_2colorable`.\n\n**Layer 3 \u2014 The conjecture and solution (lines 87\u2013123)**: Defines `goodSetCount` via `Finset.filter` on the powerset, and `erdos_1027_conjecture` with the precise quantifier structure ($\\forall c > 0, \\exists \\delta > 0, \\exists N, \\forall n \\ge N, \\ldots$). Axiomatizes `erdos_1027_solution` (Koishi Chan's theorem) and derives `erdos_1027_solved`.\n\n**Layer 4 \u2014 Problem #901 connection and existence (lines 125\u2013160)**: Links to Problem #901 via `problem_901_connection`. Axiomatizes `propertyB_for_bounded` (existence of one good set) and proves `single_implies_many` (amplification from one to exponentially many).\n\n**Layer 5 \u2014 Probabilistic analysis and special cases (lines 162\u2013235)**: Defines `probIntersects`, `probNotContains`, and `expectedGoodSets` for the first-moment heuristic. Defines `goodSetDensity` and axiomatizes its lower bound. Verifies base cases (empty and singleton families) and provides an inclusion-exclusion lower bound.",
+    "proofStrategy": "The formalization builds the theory of good sets and the abundance conjecture across 7 sections in ~355 lines.\n\n**Section I \u2014 Definitions (lines 36\u201366)**: Defines `SetFamily \u03b1` as `Finset (Finset \u03b1)`, `familyUnion`, `IsNUniform`, `IntersectsAll`, `ContainsNone`, `IsGoodSet`, `goodSets`, and `HasPropertyB`.\n\n**Section II \u2014 Property B and 2-Colorability (lines 69\u2013112)**: Defines `IsProper2Coloring` and `Is2Colorable`. Proves `propertyB_implies_2colorable` and `coloring_implies_propertyB` \u2014 good sets correspond exactly to proper 2-colorings.\n\n**Section III \u2014 Base Cases (lines 114\u2013152)**: Proves `empty_family_propertyB`, `empty_family_all_good`, and `singleton_family_propertyB`.\n\n**Section IV \u2014 Good Set Counting (lines 155\u2013164)**: Defines `goodSetCount` and `goodSetDensity` for the quantitative statement.\n\n**Section V \u2014 The Main Conjecture and Solution (lines 167\u2013191)**: Defines `Erdos1027Statement` with the $\\forall c > 0, \\exists \\delta > 0$ quantifier structure. Axiomatizes `erdos_1027_solution` (Koishi Chan's theorem) and derives `erdos_1027_solved`.\n\n**Section VI \u2014 Connection to Property B (lines 193\u2013209)**: Proves `abundance_implies_propertyB`: positive good set count implies Property B.\n\n**Section VII \u2014 Erd\u0151s Classical Bound (lines 212\u2013353)**: The largest section. Defines `IsMonochromatic`, proves `card_constOn_le` (injection argument: functions constant on $A$ $\\le 2^{|\\alpha| - |A|}$), `card_monochromatic_le` (union of all-true + all-false), and `erdos_classical_bound` (the 1963 probabilistic method result: $|\\mathcal{F}| \\cdot 2 < 2^t$ implies 2-colorability).",
     "keyInsights": [
       "**From existence to abundance (supersaturation)**: The deepest insight is that property B is not a knife-edge phenomenon. Once a family is sparse enough to be 2-colorable, a *constant fraction* $\\delta(c)$ of all subsets of $X$ are good. This is analogous to the Erd\u0151s-Simonovits supersaturation lemma: once a graph has more than $\\text{ex}(n, H)$ edges, it contains not just one copy of $H$ but $\\Omega(n^{|V(H)|})$ copies.",
       "**The probabilistic heuristic is essentially tight**: A random $B \\subseteq X$ fails to intersect a set $A$ of size $n$ with probability $2^{-n}$, and contains $A$ with probability $2^{-n}$. For $|\\mathcal{F}| \\le c \\cdot 2^n$, the expected number of 'bad' events is $\\le 2c$, so $\\Pr[B \\text{ good}] \\ge (1 - 2^{-n})^{2c \\cdot 2^n} \\to e^{-2c} > 0$. The formal proof must handle dependencies, but the heuristic gives the correct order of magnitude.",
@@ -48,96 +48,64 @@
   },
   "sections": [
     {
-      "id": "header",
-      "title": "Problem Documentation and Imports",
-      "summary": "Documents Erd\u0151s Problem #1027 on the abundance of good sets for bounded $n$-uniform families. Imports Mathlib modules for `Finset`, `Fintype`, `Powerset`, and `Real`.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Bound: Documents Erd\u0151s Problem #1027 on the abundance of good sets for bounded $n$-uniform families. Imports Mathlib modules for `Finset`, `Fintype`, `Powerset`, and `Real`."
-    },
-    {
-      "id": "set-families",
-      "title": "Set Family Infrastructure",
-      "summary": "Defines `SetFamily \u03b1` as `Finset (Finset \u03b1)`, `familyUnion F` as $\\bigcup \\mathcal{F}$ via `Finset.sup`, and `isNUniform F n` requiring $|A| = n$ for all $A \\in \\mathcal{F}$. These parametrize the $n$-uniform hypergraph.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Defines `SetFamily \u03b1` as `Finset (Finset \u03b1)`, `familyUnion F` as $\\bigcup \\mathcal{F}$ via `Finset.sup`, and `isNUniform F n` requiring $|A| = n$ for all $A \\in \\mathcal{F}$. These parametrize the $n$-uniform hypergraph."
-    },
-    {
-      "id": "intersecting",
-      "title": "Good Sets: Intersecting All, Containing None",
-      "summary": "Defines `intersectsAll B F` ($B \\cap A \\ne \\emptyset$ for all $A$), `containsNone B F` ($A \\not\\subseteq B$ for all $A$), `isGoodSet` (both conditions), and `goodSets F` (all good $B \\subseteq X$). A good set corresponds to the 'true' class of a proper 2-coloring.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Defines `intersectsAll B F` ($B \\cap A \\ne \\emptyset$ for all $A$), `containsNone B F` ($A \\not\\subseteq B$ for all $A$), `isGoodSet` (both conditions), and `goodSets F` (all good $B \\subseteq X$)."
+      "id": "definitions",
+      "title": "Section I: Definitions",
+      "summary": "Defines `SetFamily \u03b1` as `Finset (Finset \u03b1)`, `familyUnion F` ($\\bigcup \\mathcal{F}$), `IsNUniform F n`, `IntersectsAll`, `ContainsNone`, `IsGoodSet`, `goodSets`, and `HasPropertyB`. These define the core vocabulary: an $n$-uniform family, good sets (transversals that are not covers), and Property B.",
+      "startLine": 36,
+      "endLine": 66,
+      "mathContext": "Defines $\\mathcal{F} \\subseteq 2^\\alpha$, $X = \\bigcup \\mathcal{F}$, good sets ($B \\cap A \\ne \\emptyset \\wedge A \\not\\subseteq B$), and Property B ($\\exists$ good set)."
     },
     {
       "id": "property-b",
-      "title": "Property B and 2-Colorability",
-      "summary": "Defines `hasPropertyB` ($\\exists$ good set), `is2Colorable` ($\\exists$ proper 2-coloring), and proves `propertyB_iff_2colorable`: a good set $B$ defines the coloring $f(x) = (x \\in B)$.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Formal definition: Defines `hasPropertyB` ($\\exists$ good set), `is2Colorable` ($\\exists$ proper 2-coloring), and proves `propertyB_iff_2colorable`: a good set $B$ defines the coloring $f(x) = (x \\in B)$."
+      "title": "Section II: Property B and 2-Colorability",
+      "summary": "Defines `IsProper2Coloring` and `Is2Colorable`. Proves `propertyB_implies_2colorable` (good set $\\to$ coloring via $f(x) = (x \\in B)$) and `coloring_implies_propertyB` (coloring $\\to$ good set via $B = f^{-1}(\\text{true})$). Both are sorry-free.",
+      "startLine": 69,
+      "endLine": 112,
+      "mathContext": "$\\text{HasPropertyB}(\\mathcal{F}) \\iff \\text{Is2Colorable}(\\mathcal{F})$: good sets correspond to proper 2-colorings."
     },
     {
-      "id": "main-question",
-      "title": "The Main Conjecture: Exponential Abundance",
-      "summary": "Defines `goodSetCount` via `Finset.filter` on the powerset. States `erdos_1027_conjecture`: for $c > 0$, $\\exists \\delta > 0, N$ such that every large enough bounded $n$-uniform family has $\\ge \\delta \\cdot 2^{|X|}$ good sets.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Defines `goodSetCount` via `Finset.filter` on the powerset. States `erdos_1027_conjecture`: for $c > 0$, $\\exists \\delta > 0, N$ such that every large enough bounded $n$-uniform family has $\\ge \\delta \\cdot 2^{|X|}$ good sets."
+      "id": "base-cases",
+      "title": "Section III: Base Cases",
+      "summary": "Proves `empty_family_propertyB`, `empty_family_all_good`, and `singleton_family_propertyB`. Empty families: every subset is good. Singleton $\\{A\\}$ with $|A| \\ge 2$: any $\\{x\\}$ for $x \\in A$ is good. All sorry-free.",
+      "startLine": 114,
+      "endLine": 152,
+      "mathContext": "$\\mathcal{F} = \\emptyset \\Rightarrow$ all subsets good; $\\mathcal{F} = \\{A\\}, |A| \\ge 2 \\Rightarrow \\{x\\}$ is good for $x \\in A$."
     },
     {
-      "id": "solution",
-      "title": "Koishi Chan's Theorem",
-      "summary": "Axiomatizes `erdos_1027_solution` (the affirmative answer) and derives `erdos_1027_solved`: a $\\delta(c)$-fraction of all subsets of $X$ are good for bounded families.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Axiomatizes `erdos_1027_solution` (the affirmative answer) and derives `erdos_1027_solved`: a $\\$\\delta$(c)$-fraction of all subsets of $X$ are good for bounded families."
+      "id": "counting",
+      "title": "Section IV: Good Set Counting",
+      "summary": "Defines `goodSetCount F` (cardinality of good sets) and `goodSetDensity F` (ratio $|\\text{good}| / 2^{|X|}$). These are the quantitative measures central to the conjecture.",
+      "startLine": 155,
+      "endLine": 164,
+      "mathContext": "$\\text{goodSetCount}(\\mathcal{F}) = |\\{B \\subseteq X : B \\text{ good}\\}|$; $\\text{density} = \\text{count} / 2^{|X|}$."
     },
     {
-      "id": "problem-901",
-      "title": "Connection to Problem #901",
-      "summary": "Links to Erd\u0151s Problem #901: `problem_901_connection` states property B $\\iff$ 2-colorability universally. Problem #1027 is a quantitative supersaturation of #901.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Mathematical content: Links to Erd\u0151s Problem #901: `problem_901_connection` states property B $\\iff$ 2-colorability universally. Problem #1027 is a quantitative supersaturation of #901."
+      "id": "conjecture-solution",
+      "title": "Section V: The Main Conjecture and Solution",
+      "summary": "Defines `Erdos1027Statement` with the precise quantifier structure ($\\forall c > 0, \\exists \\delta > 0, \\exists N, \\forall n \\ge N, \\ldots$). Axiomatizes `erdos_1027_solution` (Koishi Chan's theorem) and derives `erdos_1027_solved`. This is the single axiom in the file.",
+      "startLine": 167,
+      "endLine": 191,
+      "mathContext": "$\\forall c > 0, \\exists \\delta > 0, \\exists N, \\forall n \\ge N: |\\mathcal{F}| \\le c \\cdot 2^n \\Rightarrow |\\text{good}| \\ge \\delta \\cdot 2^{|X|}$. Axiomatized."
     },
     {
-      "id": "existence",
-      "title": "Existence and Amplification",
-      "summary": "Axiomatizes `propertyB_for_bounded` (one good set exists) and proves `single_implies_many`: from one good set, local perturbations produce exponentially many. This amplification is the core structural insight.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Axiomatizes `propertyB_for_bounded` (one good set exists) and proves `single_implies_many`: from one good set, local perturbations produce exponentially many. This amplification is the core structural insight."
+      "id": "abundance-propertyb",
+      "title": "Section VI: Connection to Property B",
+      "summary": "Proves `abundance_implies_propertyB`: if `goodSetCount F > 0`, then F has Property B. This connects the quantitative abundance result to the qualitative existence question (Problem #901). Sorry-free.",
+      "startLine": 193,
+      "endLine": 209,
+      "mathContext": "$|\\text{good sets}| > 0 \\Rightarrow \\text{HasPropertyB}(\\mathcal{F})$. Links Problem #1027 (abundance) to Problem #901 (existence)."
     },
     {
-      "id": "probabilistic",
-      "title": "Probabilistic Intuition",
-      "summary": "Defines `probIntersects n` $= 1 - 2^{-n}$, `probNotContains n` $= 1 - 2^{-n}$, and `expectedGoodSets`. Proves `expected_good_positive`: the expected count is positive for large $n$, giving $\\mathbb{E} \\approx e^{-2c} \\cdot 2^{|X|}$.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Defines `probIntersects n` $= 1 - 2^{-n}$, `probNotContains n` $= 1 - 2^{-n}$, and `expectedGoodSets`. Proves `expected_good_positive`: the expected count is positive for large $n$, giving $\\mathbb{E} \\approx e^{-2c} \\cdot 2^{|X|}$."
-    },
-    {
-      "id": "density",
-      "title": "Density of Good Sets",
-      "summary": "Defines `goodSetDensity` $= |\\text{good}| / 2^{|X|}$ and axiomatizes `goodSetDensity_lower`: density $\\ge \\delta(c) > 0$ for bounded families. The strongest form of the result.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Defines `goodSetDensity` $= |\\text{good}| / $$2^{{|X|}$}$$ and axiomatizes `goodSetDensity_lower`: density $\\ge \\$\\delta$(c) > 0$ for bounded families. The strongest form of the result."
-    },
-    {
-      "id": "special-cases",
-      "title": "Special Cases and Counting",
-      "summary": "Verifies base cases: empty family ($2^{|\\alpha|}$ good sets), singleton family ($\\ge 2^{n-1}$), and an inclusion-exclusion lower bound $|\\text{good}| \\ge \\frac{1}{4} \\cdot 2^{|X|} - |\\mathcal{F}| \\cdot 2^{|X|-1}$.",
-      "startLine": 1,
-      "endLine": 1,
-      "mathContext": "Verifies base cases: empty family ($2^{|\\alpha|}$ good sets), singleton family ($\\ge 2^{n-1}$), and an inclusion-exclusion lower bound $|\\text{good}| \\ge \\frac{1}{4} \\cdot 2^{|X|} - |\\mathcal{F}| \\cdot 2^{|X|-1}$."
+      "id": "classical-bound",
+      "title": "Section VII: Erd\u0151s Classical Bound (1963)",
+      "summary": "Defines `IsMonochromatic`. Proves `card_constOn_le` (functions constant on $A$ bounded by $2^{|\\alpha| - |A|}$ via injection to complement), `card_monochromatic_le` (monochromatic colorings $\\le 2 \\cdot 2^{|\\alpha| - |A|}$), and `erdos_classical_bound` ($|\\mathcal{F}| \\cdot 2 < 2^t$ and all sets size $\\ge t$ implies 2-colorable). The classical bound uses the probabilistic method: union bound over bad colorings. All sorry-free.",
+      "startLine": 212,
+      "endLine": 353,
+      "mathContext": "Erd\\u0151s 1963: $|\\mathcal{F}| \\cdot 2 < 2^t, |A| \\ge t \\; \\forall A \\Rightarrow \\text{Is2Colorable}(\\mathcal{F})$. Proved via counting: $|\\text{bad}| \\le |\\mathcal{F}| \\cdot 2 \\cdot 2^{|\\alpha| - t} < 2^{|\\alpha|}$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #1027 on the abundance of good sets for bounded set families in a ~235-line Lean file spanning 11 sections. The framework defines good sets (intersecting all, containing none), property B, and the quantitative conjecture ($\\ge \\delta \\cdot 2^{|X|}$ good sets). Koishi Chan's affirmative answer is axiomatized. The probabilistic intuition ($\\Pr[\\text{good}] \\approx e^{-2c}$), the amplification argument (one good set implies exponentially many), and the density formulation are all developed. Connection to Problem #901 established.",
+    "summary": "This formalization captures Erd\u0151s Problem #1027 on the abundance of good sets for bounded set families in a ~355-line Lean file spanning 7 sections. The framework defines good sets (intersecting all, containing none), property B (equivalent to 2-colorability), and the quantitative conjecture ($\\ge \\delta \\cdot 2^{|X|}$ good sets). Koishi Chan's affirmative answer is axiomatized as a single axiom. All 10 theorems are sorry-free, including the Erd\u0151s 1963 classical bound via the probabilistic method (union bound over monochromatic colorings). Connection to Problem #901 established.",
     "implications": "**Theoretical Significance**: This result connects several major themes in combinatorics and probability:\n\n1. **Supersaturation in extremal combinatorics**: Just as the Erd\u0151s-Simonovits supersaturation lemma shows that graphs above the Tur\u00e1n threshold contain not one but polynomially many copies of the forbidden subgraph, Problem #1027 shows that once a family is sparse enough for property B, exponentially many 2-colorings exist. This is a measure-theoretic strengthening: the 'solution set' has positive density.\n\n2. **The probabilistic method and the Lov\u00e1sz Local Lemma**: The probabilistic heuristic gives the right answer ($\\delta \\approx e^{-2c}$) but making it rigorous requires controlling dependencies. The Lov\u00e1sz Local Lemma (1975) is the natural tool: events '$B$ fails to intersect $A$' and '$A \\subseteq B$' have limited dependencies (sets sharing elements). The constructive Moser-Tardos version (2010) would additionally give an efficient algorithm.\n\n**3. The hypergraph container method**: The Balogh-Morris-Samotij (2015) and Saxton-Thomason (2015) container theorems provide a general framework for counting independent sets in hypergraphs. Good sets are independent sets in the 'monochromatic' hypergraph. Containers would show that most subsets of $X$ are contained in a small number of 'containers,' each with many good sets.\n\n4. **Algorithmic implications**: A positive-density result implies that a random subset of $X$ is good with probability $\\ge \\delta(c)$. Thus, a randomized algorithm finds a good set in expected $O(1/\\delta)$ trials\u2014constant time (in terms of $n$) for fixed $c$. This gives an efficient probabilistic algorithm for property B in bounded families.",
     "openQuestions": [
       "What is the optimal constant $\\delta(c)$ as a function of $c$? The probabilistic heuristic suggests $\\delta(c) \\approx e^{-2c}$. Is this tight, or can a better bound be achieved via structural arguments?",
@@ -219,9 +187,9 @@
       "Finset"
     ],
     "namespace": "Erdos1027",
-    "lineCount": 233,
-    "axiomCount": 2,
-    "theoremCount": 7,
-    "definitionCount": 10
+    "lineCount": 355,
+    "axiomCount": 1,
+    "theoremCount": 10,
+    "definitionCount": 14
   }
 }

--- a/src/data/research/problems/erdos-1027-wip-01.json
+++ b/src/data/research/problems/erdos-1027-wip-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-1027-wip-01",
-  "title": "Complete Erd\u0151s Problem #1027: Intersecting Sets and Property B (Work in Progress)",
-  "phase": "NEW",
-  "status": "active",
+  "title": "Complete Erdős Problem #1027: Intersecting Sets and Property B (Work in Progress)",
+  "phase": "COMPLETED",
+  "status": "graduated",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in combinatorics: Complete Erd\u0151s Problem #1027: Intersecting Sets and Property B (Work in Progress).",
+    "plain": "Formal investigation in combinatorics: Complete Erdős Problem #1027: Intersecting Sets and Property B (Work in Progress).",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-03-28T20:57:10.256Z",
     "iteration": 2,
-    "focus": "Proved Erd\u0151s classical bound via probabilistic method",
+    "focus": "All sorries proved, metadata synced with current file",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Erd\u0151s classical bound (1963) added via probabilistic method. 1 axiom, 1 sorry (card_constOn_le \u2014 Aristotle target). New: IsMonochromatic, card_monochromatic_le, erdos_classical_bound.",
+    "progressSummary": "COMPLETED: 0 sorries, 1 axiom (erdos_1027_solution). card_constOn_le proved via injection. Erdős classical bound (1963) fully proved. Gallery metadata updated to match current 355-line file with 7 sections.",
     "builtItems": [
       "SetFamily, familyUnion, IsNUniform, IntersectsAll, ContainsNone, IsGoodSet definitions",
       "goodSets, HasPropertyB, IsProper2Coloring, Is2Colorable definitions",
@@ -42,29 +42,31 @@
       "erdos_1027_conjecture, erdos_1027_solution: axiomatized (2 axioms)",
       "erdos_1027_solved: derives from solution axiom",
       "IsMonochromatic: definition of monochromatic coloring on a set",
-      "card_constOn_le: counting constant-value functions (1 sorry \u2014 Aristotle candidate)",
+      "card_constOn_le: counting constant-value functions (1 sorry — Aristotle candidate)",
       "card_monochromatic_le: monochromatic coloring bound (proved from card_constOn_le)",
-      "erdos_classical_bound: Erd\u0151s 1963 probabilistic method (proved from card_monochromatic_le)",
-      "Erdos1027Aristotle.lean: companion file with card_constOn for Aristotle"
+      "erdos_classical_bound: Erdős 1963 probabilistic method (proved from card_monochromatic_le)",
+      "Erdos1027Aristotle.lean: companion file with card_constOn for Aristotle",
+      "Updated gallery metadata: sections, annotations, leanFile stats to match current file"
     ],
     "insights": [
       "Lean file was corrupted (Aristotle UUID), needed full rewrite",
       "Property B (2-colorability) is equivalent to existence of a good set",
-      "Good set B: intersects every A in F (B\u2229A\u2260\u2205) and contains no A (A\u2284B)",
+      "Good set B: intersects every A in F (B∩A≠∅) and contains no A (A⊄B)",
       "Empty family: trivially has Property B, every subset is good",
-      "Singleton {A} with |A|\u22652: single-element subsets {x} for x\u2208A are good",
-      "Main conjecture quantifier structure: \u2200c>0 \u2203\u03b4>0 \u2203N \u2200n\u2265N \u2200F ...",
-      "Koishi Chan solved: abundance \u03b4\u00b72^|X| of good sets for bounded families",
-      "Erd\u0151s 1963 classical bound: |F|\u00b72 < 2^t and all sets size \u2265 t \u2192 2-colorable",
+      "Singleton {A} with |A|≥2: single-element subsets {x} for x∈A are good",
+      "Main conjecture quantifier structure: ∀c>0 ∃δ>0 ∃N ∀n≥N ∀F ...",
+      "Koishi Chan solved: abundance δ·2^|X| of good sets for bounded families",
+      "Erdős 1963 classical bound: |F|·2 < 2^t and all sets size ≥ t → 2-colorable",
       "Probabilistic method proof via counting: bad colorings < total colorings",
-      "Key counting lemma: functions constant on A form set of size 2^(|\u03b1|-|A|)",
-      "Monochromatic colorings on A bounded by 2\u00b72^(|\u03b1|-|A|) via union of all-true + all-false"
+      "Key counting lemma: functions constant on A form set of size 2^(|α|-|A|)",
+      "Monochromatic colorings on A bounded by 2·2^(|α|-|A|) via union of all-true + all-false",
+      "File was fully rewritten after corruption; old metadata referenced nonexistent code (propertyB_for_bounded, single_implies_many, probIntersects, etc.)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Prove card_constOn_le via bijection with functions on complement (or Aristotle)",
       "Add connection between erdos_classical_bound and abundance result",
-      "Consider stronger bounds via Lov\u00e1sz Local Lemma"
+      "Consider stronger bounds via Lovász Local Lemma"
     ]
   },
   "tags": [
@@ -87,7 +89,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T20:57:10.256Z",
-  "lastUpdate": "2026-03-28T20:57:10.256Z",
+  "lastUpdate": "2026-03-29T16:45:00.000Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
- Synced gallery metadata (meta.json, annotations.json) with current Erdős #1027 proof file
- Previous session proved the last sorry (`card_constOn_le`) and added the full Erdős classical bound (1963), but metadata was never updated
- Fixed `leanFile.axiomCount` 2→1, `lineCount` 233→355, `theoremCount` 7→10, `definitionCount` 10→14
- Replaced 11 stale sections (referencing deleted code) with 7 sections matching the actual file
- Removed 4 annotations for nonexistent code (existence, probabilistic, density, special-cases)
- Added annotation for Section VII: Erdős Classical Bound (probabilistic method)
- Marked problem as completed

## Status
**Outcome**: completed
**Axioms**: 1 (erdos_1027_solution — Koishi Chan's theorem, intentionally axiomatized)
**Sorries**: 0

🤖 Generated by researcher-2