### PR TITLE
Research: erdos-269 + erdos-107 — structural theorems + sorry elimination

### DIFF
--- a/proofs/Proofs/Erdos269Problem.lean
+++ b/proofs/Proofs/Erdos269Problem.lean
@@ -128,6 +128,18 @@ theorem partialLcm_succ (P : Set ℕ) (n : ℕ) :
   simp only [partialLcm, Finset.range_add_one, Finset.lcm_insert]
   exact _root_.lcm_comm _ _
 
+/-- L_n divides L_{n+1}: the partial LCM is non-decreasing in divisibility. -/
+theorem partialLcm_dvd_succ (P : Set ℕ) (n : ℕ) :
+    partialLcm P n ∣ partialLcm P (n + 1) := by
+  rw [partialLcm_succ]
+  exact Nat.dvd_lcm_left _ _
+
+/-- Each P-smooth number divides its partial LCM. -/
+theorem smoothSeq_dvd_partialLcm (P : Set ℕ) (k n : ℕ) (hkn : k < n) :
+    smoothSeq P k ∣ partialLcm P n := by
+  simp only [partialLcm]
+  exact Finset.dvd_lcm (Finset.mem_range.mpr hkn)
+
 /- ## Part IV: The Series -/
 
 /--

--- a/proofs/Proofs/Stubs/Erdos107Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos107Problem.lean
@@ -233,17 +233,15 @@ theorem f_3_value : f 3 = 3 := by
         -- Key fact: convexHull ℝ {q,r} ⊆ affineSpan ℝ {q,r},
         -- and ¬Collinear ℝ {p,q,r} → p ∉ affineSpan ℝ {q,r}.
 
-/-- Lower bound for f(4): 4 points may form only triangles.
-    Proof: triangle with interior point has no convex quadrilateral. -/
+/-- Lower bound for f(4): f(4) > 4.
+    Proof: Immediate from Klein's theorem f(4) = 5. -/
 theorem f_4_lb : 4 < f 4 := by
-  -- Four points in convex position form a quadrilateral
-  -- But 4 points with one inside don't
-  sorry
+  rw [f_four_eq]; norm_num
 
-/-- Upper bound for f(4): Any 5 points contain a quadrilateral. -/
+/-- Upper bound for f(4): Any 5 points contain a quadrilateral.
+    Proof: Immediate from Klein's theorem f(4) = 5. -/
 theorem f_4_ub : f 4 ≤ 5 := by
-  -- Klein's argument: case analysis on convex hull of 5 points
-  sorry
+  rw [f_four_eq]
 
 /- ## Historical Notes
 

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -16,7 +16,7 @@
       "convex-geometry"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "erdosNumber": 107,
     "erdosUrl": "https://erdosproblems.com/107",
     "erdosProblemStatus": "open",
@@ -231,9 +231,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos107",
-    "lineCount": 226,
+    "lineCount": 263,
     "axiomCount": 6,
-    "theoremCount": 5,
+    "theoremCount": 9,
     "definitionCount": 6
   }
 }

--- a/src/data/proofs/erdos-269/meta.json
+++ b/src/data/proofs/erdos-269/meta.json
@@ -62,11 +62,10 @@
       "erdos_269_distinct axiom: distinct-term series is irrational",
       "twoThreeSmooth example: P = {2,3}",
       "lcmPadicVal definition: p-adic valuation of L_n",
-      "partialLcm_eventually_periodic theorem: L_n stabilizes mod M",
       "distinctLcmSeries definition: series without duplicate terms"
     ],
     "axiomCount": 3,
-    "lineCount": 275,
+    "lineCount": 276,
     "assumptions": "3 axiom(s): erdos_269 (main conjecture, OPEN), erdos_269_infinite (infinite P case), erdos_269_distinct (distinct LCM case). Former axiom smoothSeq_zero now proved."
   },
   "overview": {
@@ -202,9 +201,9 @@
       "Finset"
     ],
     "namespace": "Erdos269",
-    "lineCount": 275,
+    "lineCount": 287,
     "axiomCount": 3,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 9
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-107-incomplete-01.json
+++ b/src/data/research/problems/erdos-107-incomplete-01.json
@@ -29,11 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved cardSet_three_lower_bound (1 sorry eliminated), added InGeneralPosition.mono and CardSet.mono infrastructure. 4 sorries remain, all needing geometric reasoning about convex hulls or Collinear API.",
+    "progressSummary": "PROGRESS: 2 sorries eliminated (f_4_lb, f_4_ub from f_four_eq axiom). 2 sorries remain: f_finite (ES existence), f_3_value (triangle convex hull). 6 axioms all deep results.",
     "builtItems": [
       "Proved cardSet_three_lower_bound in Erdos107Problem.lean:170-206",
       "Proved InGeneralPosition.mono in Erdos107Problem.lean:165-167",
-      "Proved CardSet.mono in Erdos107Problem.lean:172-178"
+      "Proved CardSet.mono in Erdos107Problem.lean:172-178",
+      "Proved f_4_lb (4 < f 4) from f_four_eq axiom",
+      "Proved f_4_ub (f 4 ≤ 5) from f_four_eq axiom"
     ],
     "insights": [
       "5 sorries: f_three_eq (duplicate of f_3_value), f_finite, f_3_value, f_4_lb, f_4_ub",
@@ -56,7 +58,8 @@
       "CardSet.mono PROVED: threshold set is upward-closed via Finset.exists_smaller_set",
       "For f_3_value, key missing piece: Collinear definition in Mathlib4",
       "convexHull_subset_affineSpan available - chain to Collinear is sole gap for f_3_value",
-      "Docker unavailable for build verification - proof needs compilation check"
+      "Docker unavailable for build verification - proof needs compilation check",
+      "f_4_lb and f_4_ub are trivial consequences of f_four_eq axiom; 2 sorries eliminated"
     ],
     "mathlibGaps": [
       "Need Collinear for EuclideanSpace ℝ (Fin 2) — should be in Mathlib.Analysis.InnerProductSpace",
@@ -88,7 +91,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T20:57:10.257Z",
-  "lastUpdate": "2026-03-28T20:57:10.257Z",
+  "lastUpdate": "2026-03-29T18:50:00.000Z",
   "significance": 6,
   "tractability": 5
 }

--- a/src/data/research/problems/erdos-269.json
+++ b/src/data/research/problems/erdos-269.json
@@ -29,11 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 3A appropriate (1 open conjecture, 2 deep known results), 12T proved, 0S. All axioms are genuine mathematical results too deep to formalize.",
+    "progressSummary": "COMPLETE: 3A appropriate, 14T proved (+2 structural: partialLcm_dvd_succ, smoothSeq_dvd_partialLcm), 0S. Fixed meta.json stale originalContributions and lineCount.",
     "builtItems": [
       "theorem smoothSeq_zero (Nat.nth_count proof, 8 lines)",
       "Fixed one_isPSmooth (2 lines, simpler proof)",
-      "Fixed partialLcm_succ, erdos_269_equivalent, lcmPadicVal"
+      "Fixed partialLcm_succ, erdos_269_equivalent, lcmPadicVal",
+      "partialLcm_dvd_succ: L_n | L_{n+1} (Nat.dvd_lcm_left)",
+      "smoothSeq_dvd_partialLcm: a_k | L_n for k < n (Finset.dvd_lcm)"
     ],
     "insights": [
       "smoothSeq_zero provable: 1 is min P-smooth number (count 1 = 0 since IsPSmooth P 0 fails)",
@@ -45,7 +47,8 @@
       "Multiple pre-existing Mathlib API breakages fixed (deprecated range_succ, padicValNat, docstring syntax)",
       "erdos_269_infinite: described as simple exercise but requires irrationality criterion + p-adic analysis — too deep for single session",
       "erdos_269_distinct: proven by Erdős but formalizing the proof needs real analysis infrastructure",
-      "All 3 remaining axioms are appropriate: no further elimination possible"
+      "All 3 remaining axioms are appropriate: no further elimination possible",
+      "partialLcm_pos requires infinite P-smooth set hypothesis (smoothSeq can be 0 for empty P)"
     ],
     "mathlibGaps": [
       "Nat.nth computation for noncomputable predicates requires count/nth reasoning"
@@ -67,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T22:30:27.390Z",
-  "lastUpdate": "2026-03-13T07:52:17.045Z",
+  "lastUpdate": "2026-03-29T18:10:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
**erdos-269** (LCM Series Irrationality):
- Added 2 structural theorems: `partialLcm_dvd_succ` (L_n | L_{n+1}), `smoothSeq_dvd_partialLcm` (a_k | L_n)
- Fixed stale metadata

**erdos-107** (Happy Ending Problem):
- Proved `f_4_lb` (4 < f 4) and `f_4_ub` (f 4 ≤ 5) from `f_four_eq` axiom
- Eliminated 2 sorries (4→2 remaining)
- Updated meta.json: sorries 4→2, theoremCount 5→9

**erdos-1027** (Intersecting Sets):
- Synced gallery metadata with current proof file (0 sorries confirmed)

## Status
- erdos-269: 3 axioms (appropriate), 0 sorries, +2 theorems
- erdos-107: 6 axioms, 2 sorries (down from 4), +2 proved
- erdos-1027: 1 axiom, 0 sorries, metadata corrected

🤖 Generated by researcher-2