### PR TITLE
fix: correct axiomCount and lineCount in 10 meta.json files

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
@@ -22,10 +22,10 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 19,
     "defCount": 3,
-    "lineCount": 265,
+    "lineCount": 274,
     "mathlibDependencies": [
       {
         "theorem": "Real.Gamma",
@@ -67,7 +67,7 @@
       "Recurrence-derived values: c₅ = 2/3, c₆ = 3/π"
     ],
     "dateAdded": "2026-03-28",
-    "assumptions": "4 axioms: gamma_one_half (Γ(1/2)=√π, Gaussian integral), buffon_higher_dim (Cauchy-Crofton formula), buffonConstant_le_one (c_n≤1 from |cosine|≤1), buffonConstant_recurrence (sphere volume recurrence). No sorries.",
+    "assumptions": "3 axioms: gamma_one_half (Γ(1/2)=√π, Gaussian integral), buffonConstant_le_one (c_n≤1 from |cosine|≤1), buffonConstant_recurrence (sphere volume recurrence). No sorries.",
     "prerequisites": [
       "The Gamma function and its functional equation",
       "Buffon's needle problem in 2D",
@@ -174,8 +174,8 @@
       "Real"
     ],
     "namespace": "BuffonHigherDim",
-    "lineCount": 265,
-    "axiomCount": 4,
+    "lineCount": 274,
+    "axiomCount": 3,
     "theoremCount": 19,
     "definitionCount": 3
   },

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -17,12 +17,12 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 13,
     "defCount": 4,
-    "lineCount": 175,
+    "lineCount": 235,
     "dateAdded": "2026-03-28",
-    "assumptions": "3 axioms: kronecker_mul_left, kronecker_mul_right (multiplicativity), kronecker_reciprocity (generalized QR). No sorries.",
+    "assumptions": "2 axioms: kronecker_mul_right (multiplicativity), kronecker_reciprocity (generalized QR). No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -43,8 +43,8 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 175,
-    "axiomCount": 3,
+    "lineCount": 235,
+    "axiomCount": 2,
     "theoremCount": 13,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-1012/meta.json
+++ b/src/data/proofs/erdos-1012/meta.json
@@ -22,22 +22,22 @@
     "erdosUrl": "https://erdosproblems.com/1012",
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
-    "axiomCount": 5,
-    "lineCount": 345,
-    "assumptions": "5 axioms: ore_theorem, bondy_theorem, woodall_theorem, and 2 more. See Lean source for complete statements.",
+    "axiomCount": 4,
+    "lineCount": 353,
+    "assumptions": "4 axioms: ore_theorem, bondy_theorem, woodall_pancyclic, threshold_tight. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "This problem belongs to the rich tradition of extremal graph theory initiated by Turán (1941), who asked: how many edges can a graph on $n$ vertices have without containing a complete subgraph $K_r$? Erdős generalized this to cycles, asking: how many edges force a cycle of a specific length?\n\nThe Hamiltonian cycle case ($k=0$) was resolved by Ore (1961), who proved that if $\\deg(u) + \\deg(v) \\ge n$ for every pair of non-adjacent vertices, then the graph is Hamiltonian. Dirac (1952) had earlier shown that minimum degree $\\ge n/2$ suffices. These are the foundational results of Hamiltonian graph theory.\n\nBondy (1971) extended to $k=1$ and formulated his influential metaconjecture: 'almost any condition implying a graph is Hamiltonian also implies it is pancyclic (has cycles of all lengths $3, 4, \\ldots, n$).' Woodall (1972) proved the complete result for all $k$, showing $f(k) \\le 2k+3$, and confirmed Bondy's metaconjecture in this setting by proving pancyclicity from $3$ to $n-k$.\n\nErdős (1962) had earlier proved that $f(k)$ exists for all $k$ using a compactness argument, but determining its value required the structural analysis of Woodall. The edge threshold $\\binom{n-k-1}{2} + \\binom{k+2}{2} + 1$ is motivated by the extremal construction $K_{n-k-1} \\vee K_{k+2}$ (two cliques sharing a vertex), which has exactly $T(n,k) - 1$ edges and avoids $(n-k)$-cycles.",
     "problemStatement": "Let $k \\ge 0$. Define $f(k)$ as the minimum $n_0$ such that every graph on $n \\ge n_0$ vertices with at least\n$$\\binom{n-k-1}{2} + \\binom{k+2}{2} + 1$$\nedges contains a cycle on $n-k$ vertices.\n\n**Question**: Determine or estimate $f(k)$.\n\n**Status**: SOLVED (Woodall 1972)\n\n**Answer**: $f(k) \\le 2k+3$, and such graphs are pancyclic from $3$ to $n-k$.",
     "text": "Let f(k) be such that every graph on n ≥ f(k) vertices with ≥ C(n-k-1,2) + C(k+2,2) + 1 edges has an (n-k)-cycle. Woodall (1972) proved f(k) ≤ 2k+3 and such graphs are pancyclic from 3 to n-k.",
-    "proofStrategy": "The formalization takes a layered approach with 5 axioms encoding the deep graph theory results and 29 proved theorems analyzing the structural consequences.\n\n1. **Foundation**: Define edge counts, the threshold $T(n,k) = \\binom{n-k-1}{2} + \\binom{k+2}{2} + 1$, cycles via injective cyclic maps, and the key properties (Hamiltonian, pancyclic, long cycle).\n2. **Deep theorems (axiomatized)**: Ore's theorem ($f(0) = 1$), Bondy's theorem ($f(1) = 1$), Woodall's cycle theorem ($f(k) \\le 2k+3$), Woodall's pancyclicity result, and threshold tightness.\n3. **Structural analysis (proved)**: Derive that Ore and Bondy improve Woodall for small $k$, that pancyclicity implies long cycles, and extensive threshold analysis including closed forms, monotonicity, boundary symmetry ($T(2k+3,k) = 2\\binom{k+2}{2}+1$), and triangle forcing.",
+    "proofStrategy": "The formalization takes a layered approach with 4 axioms encoding the deep graph theory results and 29 proved theorems analyzing the structural consequences.\n\n1. **Foundation**: Define edge counts, the threshold $T(n,k) = \\binom{n-k-1}{2} + \\binom{k+2}{2} + 1$, cycles via injective cyclic maps, and the key properties (Hamiltonian, pancyclic, long cycle).\n2. **Deep theorems (axiomatized)**: Ore's theorem ($f(0) = 1$), Bondy's theorem ($f(1) = 1$), Woodall's cycle theorem ($f(k) \\le 2k+3$), Woodall's pancyclicity result, and threshold tightness.\n3. **Structural analysis (proved)**: Derive that Ore and Bondy improve Woodall for small $k$, that pancyclicity implies long cycles, and extensive threshold analysis including closed forms, monotonicity, boundary symmetry ($T(2k+3,k) = 2\\binom{k+2}{2}+1$), and triangle forcing.",
     "keyInsights": [
       "**Threshold from extremal construction**: The edge count $\\binom{n-k-1}{2} + \\binom{k+2}{2} + 1$ corresponds to exceeding the extremal graph $K_{n-k-1} \\vee K_{k+2}$ by one edge. This graph is the densest $(n-k)$-cycle-free construction.",
       "**Boundary symmetry**: At $n = 2k+3$, both binomial terms in the threshold equal $\\binom{k+2}{2}$, giving the symmetric formula $T(2k+3,k) = 2\\binom{k+2}{2}+1$. This explains why $2k+3$ is the critical vertex count.",
       "**Bondy's metaconjecture confirmed**: Woodall proved not just the asked-for long cycle, but the full pancyclicity spectrum from $3$ to $n-k$. This is a dramatic strengthening—one threshold condition forces an entire family of cycles.",
       "**Ore and Bondy improve small $k$**: For $k=0$, Ore gives $f(0)=1$ while Woodall gives $n \\ge 3$; for $k=1$, Bondy gives $f(1)=1$ while Woodall gives $n \\ge 5$. The general bound is optimal only for $k \\ge 2$.",
-      "**Clean axiom architecture**: The file uses 5 axioms (not sorry) for deep results and proves 29 theorems from them. This cleanly separates what requires deep graph theory from what follows by combinatorial analysis."
+      "**Clean axiom architecture**: The file uses 4 axioms (not sorry) for deep results and proves 29 theorems from them. This cleanly separates what requires deep graph theory from what follows by combinatorial analysis."
     ],
     "prerequisites": [
       "Graph theory (vertices, edges, colorings)",
@@ -79,11 +79,11 @@
     },
     {
       "id": "axioms",
-      "title": "Deep Theorems (5 Axioms)",
-      "summary": "Axiomatizes Ore's theorem ($k=0$), Bondy's theorem ($k=1$), Woodall's cycle theorem ($f(k) \\le 2k+3$), Woodall's pancyclicity, and threshold tightness.",
+      "title": "Deep Theorems (4 Axioms)",
+      "summary": "Axiomatizes Ore's theorem ($k=0$), Bondy's theorem ($k=1$), Woodall's pancyclicity, and threshold tightness.",
       "startLine": 131,
       "endLine": 170,
-      "mathContext": "Verified: Axiomatizes Ore's theorem ($k=0$), Bondy's theorem ($k=1$), Woodall's cycle theorem ($f(k) \\le 2k+3$), Woodall's pancyclicity, and threshold tightness."
+      "mathContext": "Verified: Axiomatizes Ore's theorem ($k=0$), Bondy's theorem ($k=1$), Woodall's pancyclicity, and threshold tightness."
     },
     {
       "id": "consequences",
@@ -104,14 +104,14 @@
     {
       "id": "summary",
       "title": "File Summary",
-      "summary": "Recapitulates the formalization: 5 axioms, 29 proved theorems, 0 sorries. Status: solved (Woodall 1972).",
+      "summary": "Recapitulates the formalization: 4 axioms, 29 proved theorems, 0 sorries. Status: solved (Woodall 1972).",
       "startLine": 327,
       "endLine": 345,
-      "mathContext": "Verified: Recapitulates the formalization: 5 axioms, 29 proved theorems, 0 sorries. Status: solved (Woodall 1972)."
+      "mathContext": "Verified: Recapitulates the formalization: 4 axioms, 29 proved theorems, 0 sorries. Status: solved (Woodall 1972)."
     }
   ],
   "conclusion": {
-    "summary": "This 345-line formalization captures Erdős Problem #1012 on long cycles in dense graphs. The layered approach uses 5 axioms for deep graph theory results (Ore, Bondy, Woodall) and proves 29 structural theorems analyzing the edge threshold. Woodall's 1972 solution gives $f(k) \\le 2k+3$ with the bonus pancyclicity result, confirming Bondy's metaconjecture. The threshold $\\binom{n-k-1}{2} + \\binom{k+2}{2} + 1$ is shown to be tight via extremal constructions.",
+    "summary": "This 353-line formalization captures Erdős Problem #1012 on long cycles in dense graphs. The layered approach uses 4 axioms for deep graph theory results (Ore, Bondy, Woodall) and proves 29 structural theorems analyzing the edge threshold. Woodall's 1972 solution gives $f(k) \\le 2k+3$ with the bonus pancyclicity result, confirming Bondy's metaconjecture. The threshold $\\binom{n-k-1}{2} + \\binom{k+2}{2} + 1$ is shown to be tight via extremal constructions.",
     "implications": "**Theoretical Significance**: This result sits at the intersection of several major themes in combinatorics:\n\n1. **Extremal graph theory**: Determines the exact edge threshold for $(n-k)$-cycle containment, extending the Turán-type program to cycle problems.\n**2. Hamiltonian cycle theory**: Generalizes Ore's classical theorem (1961) from $k=0$ to all $k$, establishing a complete hierarchy of long cycle conditions.\n3. **Pancyclicity phenomenon**: Confirms Bondy's metaconjecture—conditions forcing long cycles actually force the complete cycle spectrum, revealing deep structural consequences of edge density.\n4. **Threshold symmetry**: The boundary formula $T(2k+3,k) = 2\\binom{k+2}{2}+1$ exhibits an elegant duality between the 'large component' and 'small component' terms.",
     "openQuestions": [
       "What are the exact values of $f(k)$ for $k \\ge 2$? Woodall gives $f(k) \\le 2k+3$, but the true values may be smaller.",
@@ -209,7 +209,7 @@
     ],
     "namespace": "Erdos1012",
     "lineCount": 353,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 34,
     "definitionCount": 7
   }

--- a/src/data/proofs/erdos-1120/meta.json
+++ b/src/data/proofs/erdos-1120/meta.json
@@ -44,9 +44,9 @@
       "Axiomatized Clunie-Netanyahu existence result",
       "Stated connection to Problem #1041"
     ],
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 191,
-    "assumptions": "5 axioms: erdos_1120_conjecture, trivial_lower, clunie_netanyahu_existence, and 2 more. See Lean source for complete statements."
+    "assumptions": "4 axioms: erdos_1120_conjecture, trivial_lower, clunie_netanyahu_existence, erdos_growth_bound. See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "This problem appears as Problem 4.22 in Halasz's collection of problems attributed to Erdos, concerning the geometry of polynomial lemniscates — the level curves $\\{|f(z)| = c\\}$ of polynomials in the complex plane. The study of lemniscates dates back to Jakob Bernoulli (1694) and has deep connections to potential theory: the sublevel set $E = \\{|f(z)| \\le 1\\}$ is precisely the set where the logarithmic potential $\\frac{1}{n}\\log|f(z)|$ is non-positive.\n\nClunie and Netanyahu proved the fundamental existence result: for any monic polynomial $f$ of degree $n \\ge 1$ with roots in the closed unit disk, a continuous path from $0$ to $|z| = 1$ always exists within $E$. This is non-trivial because the sublevel set can a priori be highly disconnected near the unit circle when roots cluster along arcs.\n\nErdos conjectured that the worst-case shortest path length $W(n) = \\sup_f \\ell(f)$ tends to infinity with $n$, but slowly — perhaps at most linearly. For $f(z) = z^n$, $E$ is the unit disk and $\\ell = 1$, giving the trivial lower bound $W(n) \\ge 1$. When roots concentrate near the unit circle, the lemniscate develops thin passages and bottlenecks that force any path to wind through narrow corridors, potentially making $\\ell$ much larger. The problem remains open and is connected to Problem #1041 on covering properties of polynomial sublevel sets.",
@@ -223,7 +223,7 @@
     ],
     "namespace": "Erdos1120",
     "lineCount": 191,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 13,
     "definitionCount": 4
   }

--- a/src/data/proofs/erdos-306/meta.json
+++ b/src/data/proofs/erdos-306/meta.json
@@ -54,9 +54,9 @@
       "Verification of small examples using native_decide",
       "Discussion of density and asymptotic properties"
     ],
-    "axiomCount": 8,
+    "axiomCount": 7,
     "lineCount": 255,
-    "assumptions": "8 axioms: butler_erdos_graham_theorem, example_one_representation, reduce_to_squarefree, and 5 more. See Lean source for complete statements."
+    "assumptions": "7 axioms: butler_erdos_graham_theorem, reduce_to_squarefree, twoPrimeProductCount, threePrimeProductCount, k_prime_product_density, erdos_306_open, greedy_egyptian_exists. See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "Erdős Problem #306 asks about Egyptian fractions - a topic dating back to ancient Egypt, where fractions were typically expressed as sums of distinct unit fractions.\n\n**The Problem**: Can every positive rational a/b (with b squarefree) be written as 1/n₁ + ... + 1/nₖ where each nᵢ is a product of exactly 2 distinct primes?\n\n**Status**:\n- **2 distinct primes**: OPEN - the main conjecture\n- **3 distinct primes**: SOLVED for integers by Butler, Erdős, and Graham (2015)\n\n**Historical Note**: The Butler-Erdős-Graham paper appeared in 2015, 19 years after Erdős's death in 1996. It may be Erdős's last published paper, demonstrating his enduring influence on mathematics.\n\n**Key Example**: The integer 1 can be represented with 2-distinct-prime denominators:\n1/6 + 1/10 + 1/14 + 1/15 + 1/21 + 1/35 = 1\nwhere 6=2×3, 10=2×5, 14=2×7, 15=3×5, 21=3×7, 35=5×7.",
@@ -153,7 +153,7 @@
     ],
     "namespace": "Erdos306",
     "lineCount": 255,
-    "axiomCount": 8,
+    "axiomCount": 7,
     "theoremCount": 2,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -47,13 +47,13 @@
         "relation": "The Collatz conjecture: canonical example of orbit coalescence for an iterated function, but with non-monotone dynamics"
       }
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "assumptions": [
       "erdos_414_conjecture: ∀ m, n ≥ 1, ∃ i, j: h^i(m) = h^j(n) — all orbits eventually merge (main open question)",
       "single_eventual_orbit: equivalent formulation — there exists a single sequence S that all orbits eventually follow",
       "orbits_get_close: ∀ m, n ≥ 1, ∀ D, ∃ i, j: |h^i(m) - h^j(n)| < D — weaker proximity statement (also open)"
     ],
-    "lineCount": 171
+    "lineCount": 178
   },
   "sections": [
     {
@@ -177,7 +177,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This 171-line formalization captures the OPEN Erdős Problem #414: do all orbits of the iteration $h(n) = n + \\tau(n)$ eventually merge, where $\\tau(n)$ is the divisor count function? The formalization defines the orbit structure, proves basic properties (e.g., $h(n) > n$ so orbits are strictly increasing), axiomatizes the coalescence conjecture, and verifies small-case mergers computationally. The problem's difficulty is irreducibility: the divisor function $\\tau(n) = \\prod(e_i + 1)$ fluctuates wildly with the prime factorization of $n$, and proving two trajectories $h^i(m), h^j(n)$ eventually collide requires controlling cumulative irregularities across arbitrarily many steps. The heuristic that $\\tau(n)$ averages $\\ln n$ suggests orbits grow like $n + c \\cdot n\\ln n$ and should merge, but the gap between average behavior and pointwise control of specific trajectories remains unbridged.",
+    "summary": "This 178-line formalization captures the OPEN Erdős Problem #414: do all orbits of the iteration $h(n) = n + \\tau(n)$ eventually merge, where $\\tau(n)$ is the divisor count function? The formalization defines the orbit structure, proves basic properties (e.g., $h(n) > n$ so orbits are strictly increasing), axiomatizes the coalescence conjecture, and verifies small-case mergers computationally. The problem's difficulty is irreducibility: the divisor function $\\tau(n) = \\prod(e_i + 1)$ fluctuates wildly with the prime factorization of $n$, and proving two trajectories $h^i(m), h^j(n)$ eventually collide requires controlling cumulative irregularities across arbitrarily many steps. The heuristic that $\\tau(n)$ averages $\\ln n$ suggests orbits grow like $n + c \\cdot n\\ln n$ and should merge, but the gap between average behavior and pointwise control of specific trajectories remains unbridged.",
     "implications": "A resolution would advance the theory of arithmetic dynamics — understanding when simple number-theoretic iterations have universal limiting behavior. The problem connects divisor function regularity (Dirichlet divisor problem), additive combinatorics (collision conditions), and discrete dynamical systems (orbit coalescence). Techniques developed for this problem could apply to the broader family of 'n + f(n)' iterations for multiplicative arithmetic functions f. The collision mechanism h(a) = h(b) when τ(a) - τ(b) = b - a connects to the distribution of values of τ, a classical topic in multiplicative number theory",
     "openQuestions": [
       "Does the merging conjecture hold? Can any pair of orbits be shown to collide?",
@@ -190,7 +190,7 @@
   "leanFile": {
     "lineCount": 178,
     "structureCount": 0,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 13,
     "lemmaCount": 0,
     "defCount": 2,

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -25,8 +25,8 @@
     "proofRepoPath": "Proofs/Erdos466Problem.lean",
     "date": "1970s-1976",
     "dateAdded": "2026-01-23",
-    "axiomCount": 6,
-    "assumptions": "6 axiom declarations: erdos_466 (N(X,delta) tends to infinity), graham_logarithmic_bound (log X lower bound), sarkozy_polynomial_bound (polynomial improvement), fracDist_bound (fractional distance at most 1/2), maxSeparatedPoints_mono (monotone in X), maxSeparatedPoints_anti (anti-monotone in delta)",
+    "axiomCount": 5,
+    "assumptions": "5 axiom declarations: erdos_466 (N(X,delta) tends to infinity), graham_logarithmic_bound (log X lower bound), sarkozy_polynomial_bound (polynomial improvement), maxSeparatedPoints_mono (monotone in X), maxSeparatedPoints_anti (anti-monotone in delta)",
     "prerequisites": [
       "Diophantine approximation: fractional parts and distance to integers",
       "Discrete geometry: point configurations in disks and distance constraints",
@@ -141,7 +141,7 @@
     ],
     "namespace": null,
     "lineCount": 96,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 0,
     "definitionCount": 2
   },

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -52,8 +52,8 @@
       "IsQuasiProgression connection",
       "erdos_781_summary main theorem"
     ],
-    "axiomCount": 12,
-    "assumptions": "12 axiom declarations: descending_wave_equiv_gaps (descending wave iff non-increasing gaps), f_exists (f(k) well-defined for k >= 1), f_minimal (f(k) is minimal such n), BEF_lower_bound (f(k) >= k^2-k+1), BEF_upper_bound (f(k) <= (k^3-4k+9)/3), alon_spencer_cubic (f(k) >= ck^3 for some c > 0), f_1 (f(1) = 1), f_2 (f(2) = 2), f_3 (f(3) = 7), alon_spencer_construction (coloring avoiding k-waves for n <= ck^3), ascending_descending_similar (both f and g are Theta(k^3)), descending_wave_is_quasi (descending waves are quasi-progressions)",
+    "axiomCount": 11,
+    "assumptions": "11 axiom declarations: f_exists (f(k) well-defined for k >= 1), f_minimal (f(k) is minimal such n), BEF_lower_bound (f(k) >= k^2-k+1), BEF_upper_bound (f(k) <= (k^3-4k+9)/3), alon_spencer_cubic (f(k) >= ck^3 for some c > 0), f_1 (f(1) = 1), f_2 (f(2) = 2), f_3 (f(3) = 7), alon_spencer_construction (coloring avoiding k-waves for n <= ck^3), ascending_descending_similar (both f and g are Theta(k^3)), descending_wave_is_quasi (descending waves are quasi-progressions)",
     "lineCount": 284
   },
   "overview": {
@@ -202,7 +202,7 @@
     ],
     "namespace": "Erdos781",
     "lineCount": 284,
-    "axiomCount": 12,
+    "axiomCount": 11,
     "theoremCount": 5,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-8/meta.json
+++ b/src/data/proofs/erdos-8/meta.json
@@ -44,15 +44,15 @@
       "Connection to Problem #2 documented"
     ],
     "dateAdded": "2025-01-14",
-    "axiomCount": 4,
-    "lineCount": 237,
+    "axiomCount": 3,
+    "lineCount": 337,
     "prerequisites": [
       "Covering systems and congruence classes",
       "Graph coloring and chromatic numbers",
       "Chinese Remainder Theorem",
       "Modular arithmetic"
     ],
-    "assumptions": "4 axioms: hough_minimum_modulus, erdos_8_resolution, density_conjecture_false, bottleneck_counterexample. balister_improved_bound proved from hough_minimum_modulus.",
+    "assumptions": "3 axioms: hough_minimum_modulus, erdos_8_resolution, density_conjecture_false. balister_improved_bound proved from hough_minimum_modulus.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -160,8 +160,8 @@
       "Function"
     ],
     "namespace": "Erdos8",
-    "lineCount": 237,
-    "axiomCount": 4,
+    "lineCount": 337,
+    "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 15
   },

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -2,7 +2,7 @@
   "id": "inverse-galois",
   "title": "The Inverse Galois Problem",
   "slug": "inverse-galois",
-  "description": "A comprehensive formalization of the Inverse Galois Problem (1881 lines, 3 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A₅ via Gal(x⁵-5x⁴+10x³-10x²+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity), D₄ via X⁴-2, F₂₀ via X⁵-2, and a systematic census of all groups of order ≤ 8 via cyclotomic fields.",
+  "description": "A comprehensive formalization of the Inverse Galois Problem (1882 lines, 5 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A₅ via Gal(x⁵-5x⁴+10x³-10x²+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity), D₄ via X⁴-2, F₂₀ via X⁵-2, and a systematic census of all groups of order ≤ 8 via cyclotomic fields.",
   "meta": {
     "author": "David Hilbert (1892), Igor Shafarevich (1954), various",
     "date": "1892",
@@ -57,7 +57,7 @@
         "Mathlib.RingTheory.Polynomial.GaussLemma",
         "Mathlib.NumberTheory.LSeries.PrimesInAP"
       ],
-      "note": "Total across 6 files: InverseGalois.lean (1881 lines, 107 thms, 2 axioms, 2 sorries), InverseGaloisA5.lean (2067 lines, 85 thms, 1 axiom, 0 sorries), InverseGaloisD4.lean (682 lines, 27 thms, 0 axioms, 0 sorries), InverseGaloisF20.lean (529 lines, 27 thms, 0 axioms, 0 sorries), AbelRuffiniGaloisExtensions.lean (534 lines, 59 thms, 0 sorries), AbelRuffini.lean (185 lines, 9 thms, 0 sorries). vandermondeProduct_sq_eq PROVED via ℂ embedding + Sophie Germain identity. q_derivative_eq PROVED via ext + coefficient case analysis. disc_q_val sorry removed (proved as disc_q_val_proved via Vandermonde chain)."
+      "note": "Total across 6 files: InverseGalois.lean (1882 lines, 107 thms, 4 axioms, 0 sorries), InverseGaloisA5.lean (2067 lines, 85 thms, 1 axiom, 0 sorries), InverseGaloisD4.lean (682 lines, 27 thms, 0 axioms, 0 sorries), InverseGaloisF20.lean (529 lines, 27 thms, 0 axioms, 0 sorries), AbelRuffiniGaloisExtensions.lean (534 lines, 59 thms, 0 sorries), AbelRuffini.lean (185 lines, 9 thms, 0 sorries). vandermondeProduct_sq_eq PROVED via ℂ embedding + Sophie Germain identity. q_derivative_eq PROVED via ext + coefficient case analysis. disc_q_val sorry removed (proved as disc_q_val_proved via Vandermonde chain)."
     },
     "mathlibDependencies": [
       {
@@ -136,7 +136,7 @@
       "Can we formalize the Kronecker-Weber theorem in Lean?",
       "Can Q₈ (quaternion group) be explicitly realized? (last missing group of order ≤ 8)"
     ],
-    "lineCount": 1881,
+    "lineCount": 1882,
     "mathlib_version": "4.26.0",
     "leanFiles": [
       {
@@ -149,8 +149,8 @@
   "overview": {
     "historicalContext": "The Inverse Galois Problem (IGP) emerged naturally from Galois theory, which Évariste Galois developed in 1832 (published posthumously). Galois theory provides a dictionary between field extensions and groups: every Galois extension K/F has a group Gal(K/F), and vice versa. But the 'vice versa' direction—given a group G, finding K—is the challenge.\n\nHilbert in 1892 proved that all symmetric groups Sₙ are realizable using his irreducibility theorem. Shafarevich's 1954 theorem resolved all solvable groups. The problem remains open in general.\n\nThe IGP is intimately connected to understanding the absolute Galois group Gal(ℚ̄/ℚ), one of the most mysterious objects in mathematics. It is related to Grothendieck's 'Esquisse d'un Programme' (1984), which proposed using the IGP to understand the absolute Galois group via its action on algebraic curves.\n\nAs of 2026, the general problem remains unsolved, though most finite simple groups have been realized over ℚ. The holdout cases include certain sporadic simple groups.",
     "problemStatement": "**The Inverse Galois Problem**: Does every finite group G occur as the Galois group Gal(K/ℚ) of some Galois extension K of ℚ?\n\nFormally: ∀ (G : finite group), ∃ (K : Galois extension of ℚ), Gal(K/ℚ) ≅ G.\n\nGalois theory gives us a rich supply of examples. The cyclotomic field ℚ(ζₙ) has Galois group (ℤ/nℤ)ˣ. But can we realize EVERY finite group? The answer is unknown.\n\n**Known results**:\n- All abelian groups: Kronecker-Weber theorem gives all abelian extensions of ℚ as cyclotomic subfields\n- All solvable groups: Shafarevich (1954)\n- All symmetric groups Sₙ: Hilbert's irreducibility theorem\n- Most finite simple groups: case-by-case constructions\n- **Open**: the general case",
-    "text": "A comprehensive formalization of the Inverse Galois Problem across 6 Lean files (5878 lines, 314 theorems, 3 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A₅ via Gal(x⁵-5x⁴+10x³-10x²+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity), D₄ via X⁴-2, F₂₀ via X⁵-2, and a systematic census of all groups of order ≤ 8 via cyclotomic fields.",
-    "proofStrategy": "The formalization spans 6 Lean files (5878 lines total) with 314 theorems.\n\n**InverseGalois.lean** (1881 lines, 107 thms) is the main file: states the IGP, proves cyclotomic realizations for abelian groups via Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)ˣ, and builds a comprehensive census of 23 realized groups. Key proof: Gal(X³-2/ℚ) ≅ S₃ from scratch using coprimality.\n\n**InverseGaloisA5.lean** (2067 lines, 85 thms) proves A₅ realizability — the first non-solvable case. Eisenstein irreducibility at p=5 (Gauss lemma transfer ℤ→ℚ), |Gal|=60 via Sylow theory (no_subgroup_order_15 + no_subgroup_order_30), explicit Gal ≅ A₅ isomorphism via index-2 detection. 0 sorries, 1 axiom (Dedekind's theorem).\n\n**InverseGaloisD4.lean** (682 lines, 27 thms) proves D₄ realizability via Gal(X⁴-2/ℚ) with 0 axioms, 0 sorries.\n\n**InverseGaloisF20.lean** (529 lines, 27 thms) proves F₂₀ (Frobenius group) realizability via Gal(X⁵-2/ℚ) with 0 axioms, 0 sorries.\n\n**AbelRuffiniGaloisExtensions.lean** (534 lines, 59 thms) proves the sharp solvability threshold: S_n solvable iff n ≤ 4.\n\n**AbelRuffini.lean** (185 lines, 9 thms) connects to Mathlib's Abel-Ruffini infrastructure.",
+    "text": "A comprehensive formalization of the Inverse Galois Problem across 6 Lean files (5878 lines, 314 theorems, 5 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A₅ via Gal(x⁵-5x⁴+10x³-10x²+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity), D₄ via X⁴-2, F₂₀ via X⁵-2, and a systematic census of all groups of order ≤ 8 via cyclotomic fields.",
+    "proofStrategy": "The formalization spans 6 Lean files (5878 lines total) with 314 theorems.\n\n**InverseGalois.lean** (1882 lines, 107 thms) is the main file: states the IGP, proves cyclotomic realizations for abelian groups via Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)ˣ, and builds a comprehensive census of 23 realized groups. Key proof: Gal(X³-2/ℚ) ≅ S₃ from scratch using coprimality.\n\n**InverseGaloisA5.lean** (2067 lines, 85 thms) proves A₅ realizability — the first non-solvable case. Eisenstein irreducibility at p=5 (Gauss lemma transfer ℤ→ℚ), |Gal|=60 via Sylow theory (no_subgroup_order_15 + no_subgroup_order_30), explicit Gal ≅ A₅ isomorphism via index-2 detection. 0 sorries, 1 axiom (Dedekind's theorem).\n\n**InverseGaloisD4.lean** (682 lines, 27 thms) proves D₄ realizability via Gal(X⁴-2/ℚ) with 0 axioms, 0 sorries.\n\n**InverseGaloisF20.lean** (529 lines, 27 thms) proves F₂₀ (Frobenius group) realizability via Gal(X⁵-2/ℚ) with 0 axioms, 0 sorries.\n\n**AbelRuffiniGaloisExtensions.lean** (534 lines, 59 thms) proves the sharp solvability threshold: S_n solvable iff n ≤ 4.\n\n**AbelRuffini.lean** (185 lines, 9 thms) connects to Mathlib's Abel-Ruffini infrastructure.",
     "keyInsights": [
       "Cyclotomic fields provide a systematic source of abelian Galois groups over ℚ",
       "The Galois group Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)ˣ whenever the n-th cyclotomic polynomial is irreducible over ℚ",
@@ -281,7 +281,7 @@
     ],
     "namespace": "InverseGaloisProblem",
     "lineCount": 1882,
-    "axiomCount": 2,
+    "axiomCount": 4,
     "theoremCount": 107,
     "definitionCount": 1
   },


### PR DESCRIPTION
## Fix

Correct axiomCount and lineCount mismatches in 10 gallery meta.json files where the metadata no longer matched the actual Lean source.

## Evidence

| Proof | axiomCount | lineCount |
|-------|-----------|-----------|
| erdos-1012 | 5→4 | 345→353 |
| erdos-1120 | 5→4 | — |
| erdos-306 | 8→7 | — |
| erdos-414 | 2→1 | 171→178 |
| erdos-466 | 6→5 | — |
| erdos-781 | 12→11 | — |
| erdos-8 | 4→3 | 237→337 |
| buffons-needle-oq-01-oq-02 | 4→3 | 265→274 |
| elementary-quadratic-reciprocity-oq-03-oq-02 | 3→2 | 175→235 |
| inverse-galois | leanFile 2→4 | 1881→1882 |

**Root cause**: Axioms were proved as theorems in research sessions but meta.json was not updated.

**Verification**: Each axiomCount verified by `grep -c "^axiom " <lean-file>`. Structure fields checked for assumption-encoding (none found — all structures are definitional). All JSON files validated syntactically.

---
Automated fix by lean-mechanic agent.