### PR TITLE
fix: correct stale axiomCount in erdos-1016 and erdos-1095-oq-01

### DIFF
--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": 1016,
     "erdosUrl": "https://erdosproblems.com/1016",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
-    "lineCount": 138,
-    "assumptions": "5 axioms: erdos_1016_conjecture (open), excess_beyond_log (open), bondy_lower_bound (deep), gkw_upper_bound (deep), small_case_4 (FALSE under current model — IsPancyclic doesn't connect edgeCount to hasCycle). Proved: triangle_pancyclic (sSup∅=0), bondy_quadratic_threshold (interval_cases+nlinarith).",
+    "axiomCount": 0,
+    "lineCount": 158,
+    "assumptions": "0 axioms. All 5 former axioms were removed because the abstract IsPancyclic model is flawed (edgeCount disconnected from hasCycle makes axioms FALSE). The mathematical results (Bondy, Griffin, GKW) are correct but require a proper SimpleGraph-based model to formalize.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -232,8 +232,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 126,
-    "axiomCount": 6,
+    "lineCount": 158,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 3
   }

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -21,10 +21,10 @@
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 320,
+    "axiomCount": 1,
+    "lineCount": 332,
     "theoremCount": 28,
-    "assumptions": "4 axiom(s): gFunc definition and its 3 properties (existence, specification, minimality). 0 sorries. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 proved from axioms. Asymptotic conjecture formalized."
+    "assumptions": "1 axiom: gFunc_exists (existence of g(k) for each k). gFunc defined constructively via Nat.find; gFunc_gt, gFunc_spec, gFunc_minimal proved as theorems. 0 sorries. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 proved from axiom."
   },
   "overview": {
     "historicalContext": "The function $g(k)$ — the smallest $n > k+1$ such that every prime factor of $\\binom{n}{k}$ exceeds $k$ — was introduced by Ecklund, Erdős, and Selfridge in their 1974 paper on smooth binomial coefficients. They established the initial bounds $k^{1+c} < g(k) \\leq \\exp((1+o(1))k)$, showing that $g(k)$ grows faster than any polynomial but no faster than exponential.\n\nThe lower bound was substantially improved by Konyagin, who proved $g(k) \\gg \\exp(c(\\log k)^2)$ using estimates on smooth numbers (integers whose prime factors are all below a given bound). The key insight is that $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$, and avoiding all primes $\\leq k$ requires $n$ to be chosen so that the prime factorization of the numerator $n(n-1)\\cdots(n-k+1)$ has no small prime factors surviving the cancellation with $k!$.\n\nErdős, Lacampagne, and Selfridge conjectured that $\\log g(k) \\sim c \\cdot k / \\log k$ for some positive constant $c$, which would place $g(k)$ at a precise intermediate growth rate between polynomial and exponential. Computational evidence by Sorenson, Sorenson, and Webster supports this conjecture, but it remains open. The problem connects to smooth number theory, sieve methods, and the distribution of prime factors in products of consecutive integers.",
@@ -146,8 +146,8 @@
       "Nat"
     ],
     "namespace": "Erdos1095OQ01",
-    "lineCount": 320,
-    "axiomCount": 4,
+    "lineCount": 332,
+    "axiomCount": 1,
     "theoremCount": 17,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Fix

Correct axiomCount mismatches where axioms were removed or proved as theorems but meta.json was not updated.

## Evidence

**erdos-1016** (axiomCount 5→0):
- **Before**: meta.json claims 5 axioms
- **After**: 0 axioms. All 5 were removed/commented out because the abstract `IsPancyclic` model is flawed — `edgeCount` is disconnected from `hasCycle`, making the axioms FALSE under the model. The mathematical results (Bondy, Griffin, GKW) are correct but need a proper `SimpleGraph`-based model.
- lineCount also corrected: 138→158

**erdos-1095-oq-01** (axiomCount 4→1):
- **Before**: meta.json claims 4 axioms (gFunc + 3 properties)
- **After**: 1 axiom (`gFunc_exists`). `gFunc` is now defined via `Nat.find`, and `gFunc_gt`, `gFunc_spec`, `gFunc_minimal` are proved theorems.
- lineCount also corrected: 320→332

---
Automated fix by lean-mechanic agent.