### PR TITLE
fix: re-correct erdos-36 axiomCount (6→4), reverted by sync

### DIFF
--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -56,15 +56,15 @@
       "Proved product_card from Finset.card_product",
       "Axiomatized four progressively tighter bounds and small values"
     ],
-    "axiomCount": 6,
+    "axiomCount": 4,
     "prerequisites": [
       "Additive combinatorics: partitions of {1,...,2N} into equal halves",
       "Fourier analysis on finite groups (Scherk's technique)",
       "Convex optimization (White's improved bounds)",
       "Asymptotic analysis: limit of M(N)/N"
     ],
-    "assumptions": "6 axiom declarations: erdos_36_limit_exists (the limit c = lim M(N)/N exists — the main open question), erdos_lower_quarter (Erdős's 1/4 lower bound), scherk_lower (Scherk's 1−1/√2 ≈ 0.293 lower bound via Fourier), white_lower (White's 0.379 lower bound via convex optimization), upper_bound (Haugland's 0.381 upper bound), small_values (computed M(N) for small N). The limit existence and bounds are established results.",
-    "lineCount": 162,
+    "assumptions": "4 axiom declarations: erdos_36_limit_exists (the limit c = lim M(N)/N exists), white_lower (White's 0.379 lower bound), upper_bound (Haugland's 0.381 upper bound), small_values (computed M(N) for small N). erdos_lower_quarter and scherk_lower are now proved as theorems.",
+    "lineCount": 181,
     "relatedProblems": [
       {
         "id": "erdos-335",
@@ -77,9 +77,9 @@
     ]
   },
   "leanFile": {
-    "lineCount": 162,
-    "axiomCount": 6,
-    "theoremCount": 2,
+    "lineCount": 181,
+    "axiomCount": 4,
+    "theoremCount": 4,
     "definitionCount": 7,
     "imports": [
       "Mathlib.Data.Nat.Basic",


### PR DESCRIPTION
## Fix

Re-applies the erdos-36 axiomCount correction that was reverted by the data sync in #7941.

## Evidence

**Before**: meta.json claims 6 axioms, lineCount 162
**After**: 4 axioms, lineCount 181, theoremCount 4

The Lean file (`Proofs/Erdos36Problem.lean`) has exactly 4 `axiom` declarations:
- `erdos_36_limit_exists`
- `white_lower`
- `upper_bound`
- `small_values`

`erdos_lower_quarter` and `scherk_lower` are proved theorems (not axioms).

**Note**: This fix was previously applied in #7939 but reverted by the data sync in #7941 (`chore: sync research listings and data`).

---
Automated fix by lean-mechanic agent.