### PR TITLE
Research: prove birthday product lower bound (2→0 sorries)

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ02OQ01.lean
+++ b/proofs/Proofs/BirthdayProblemOQ02OQ01.lean
@@ -12,32 +12,66 @@ Combined with the upper bound from OQ-02 (P(all distinct) ≤ exp(-k(k-1)/(2d)))
 this gives a two-sided exponential approximation for the birthday collision probability.
 
 ## Key Mathematical Idea
-For 0 ≤ x < 1, we have ln(1-x) ≥ -x - x² (a consequence of the Taylor series).
+For 0 ≤ x ≤ 1/2, we have ln(1-x) ≥ -x - x² (from Taylor with remainder).
 Applied to each factor (1 - i/d) in P(all distinct) = ∏(1-i/d):
 
   ln(∏(1-i/d)) = ∑ ln(1-i/d) ≥ ∑(-i/d - i²/d²) = -k(k-1)/(2d) - S₂/d²
 
 where S₂ = ∑ i² = k(k-1)(2k-1)/6 ≤ k²(k-1)²/4.
 
-## Approach
-- **Foundation:** The key inequality ln(1-x) ≥ -x - x² for 0 ≤ x < 1
-- **Product bound:** Apply to each factor and sum logarithms
-- **Exponentiate:** Obtain the exponential lower bound on the product
+## Important: Hypothesis on k
+The core inequality ln(1-x) ≥ -x - x² requires x ≤ 1/2. For the birthday product,
+this means each factor ratio i/d ≤ 1/2, i.e., (k-1)/d ≤ 1/2, i.e., 2(k-1) ≤ d.
+This covers the birthday problem's regime of interest (k ~ √d ≪ d).
 -/
 
 open Finset Real
 
-/- ## Core Inequality: ln(1-x) ≥ -x - x² for 0 ≤ x < 1 -/
+/- ## Core Inequality: ln(1-x) ≥ -x - x² for 0 ≤ x ≤ 1/2 -/
 
-/-- For 0 ≤ x < 1, we have 1 - x ≥ exp(-x - x²).
-    Equivalently, ln(1-x) ≥ -x - x². This is the key ingredient
-    for the matching lower bound.
+/-- For 0 ≤ x ≤ 1/2, we have 1 - x ≥ exp(-x - x²).
+    Equivalently, ln(1-x) ≥ -x - x².
 
-    Proof strategy: We need exp(-x - x²) ≤ 1 - x, i.e.,
-    exp(-x(1+x)) ≤ 1 - x. -/
-theorem exp_neg_sub_sq_le_one_sub {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x < 1) :
+    Proof: From exp(y) ≥ 1 + y + y²/2 (Taylor, via `sum_le_exp_of_nonneg`),
+    with y = x + x²: (1-x) · exp(x+x²) ≥ (1-x)(1 + (x+x²) + (x+x²)²/2) ≥ 1.
+    The last step uses the algebraic identity that the expanded polynomial
+    equals 1 + x²(1-x-x²-x³)/2 ≥ 1 for x ∈ [0, 1/2].
+
+    Note: The inequality FAILS for x close to 1 (e.g., x = 0.9). -/
+theorem exp_neg_sub_sq_le_one_sub {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x ≤ 1 / 2) :
     Real.exp (-x - x ^ 2) ≤ 1 - x := by
-  sorry -- Deep analytic inequality; candidate for Aristotle or manual Taylor argument
+  have h1mx_pos : (0 : ℝ) < 1 - x := by linarith
+  set y := x + x ^ 2 with hy_def
+  have hy_nn : 0 ≤ y := by positivity
+  -- Step 1: exp(y) ≥ 1 + y + y²/2 from Taylor (n=3 partial sum)
+  have hT := Real.sum_le_exp_of_nonneg hy_nn 3
+  -- Simplify the partial sum: ∑_{i<3} y^i/i! = 1 + y + y²/2
+  have hps : ∑ i ∈ Finset.range 3, y ^ i / (↑(Nat.factorial i) : ℝ) =
+      1 + y + y ^ 2 / 2 := by
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.factorial,
+      Nat.cast_one, Nat.cast_ofNat, pow_zero, pow_one, pow_succ]
+    ring
+  rw [hps] at hT
+  -- hT : 1 + y + y^2/2 ≤ exp(y)
+  -- Step 2: (1-x)(1 + y + y²/2) ≥ 1
+  -- After expanding y = x+x², this is 1 + x²(1-x-x²-x³)/2 ≥ 1
+  have key : 1 ≤ (1 - x) * (1 + y + y ^ 2 / 2) := by
+    rw [hy_def]
+    -- Need: 1 ≤ (1-x)(1 + (x+x²) + (x+x²)²/2)
+    -- This expands to 1 + x²/2 - x³/2 - x⁴/2 - x⁵/2
+    -- For x ∈ [0, 1/2], the polynomial part x²(1-x-x²-x³)/2 ≥ 0
+    have hx2 : x * x ≤ x * (1 / 2) := mul_le_mul_of_nonneg_left hx1 hx0
+    have hx3 : x * x * x ≤ x * x * (1 / 2) := mul_le_mul_of_nonneg_left hx1 (by nlinarith)
+    nlinarith [sq_nonneg x, sq_nonneg (x * x)]
+  -- Step 3: (1-x) * exp(y) ≥ 1
+  have h_prod : 1 ≤ (1 - x) * Real.exp y := by
+    calc (1 : ℝ) ≤ (1 - x) * (1 + y + y ^ 2 / 2) := key
+      _ ≤ (1 - x) * Real.exp y :=
+          mul_le_mul_of_nonneg_left hT (le_of_lt h1mx_pos)
+  -- Step 4: exp(-y) ≤ 1-x
+  rw [show -x - x ^ 2 = -y from by rw [hy_def]; ring, Real.exp_neg, inv_eq_one_div]
+  rw [div_le_iff (Real.exp_pos y)]
+  linarith
 
 /-- The product formula for the probability that k items are all distinct
     among d possibilities. P(all distinct) = ∏_{i=0}^{k-1} (1 - i/d). -/
@@ -81,18 +115,10 @@ theorem sum_sq_formula (k : ℕ) :
     (This follows from k(k-1)(2k-1)/6 ≤ k²(k-1)²/4, i.e., 2(2k-1)/3 ≤ k(k-1).) -/
 theorem sum_sq_le_quartic (k : ℕ) (hk : 1 ≤ k) :
     ∑ i ∈ Finset.range k, (i : ℝ) ^ 2 ≤ (k : ℝ) ^ 2 * (k - 1) ^ 2 / 4 := by
-  -- From sum_sq_formula: 6·∑i² = k(k-1)(2k-1)
-  -- Need: k(k-1)(2k-1)/6 ≤ k²(k-1)²/4, i.e., 4(2k-1) ≤ 6k(k-1) for k ≥ 2
   have hsf := sum_sq_formula k
-  -- Express ∑i² from the formula
-  have h6 : (6 : ℝ) ≠ 0 := by norm_num
   have hsum : ∑ i ∈ Finset.range k, (i : ℝ) ^ 2 = (k : ℝ) * (k - 1) * (2 * k - 1) / 6 := by
     linarith
   rw [hsum]
-  -- Need: k(k-1)(2k-1)/6 ≤ k²(k-1)²/4
-  -- Equivalently: 4k(k-1)(2k-1) ≤ 6k²(k-1)² = 6k(k-1)·k(k-1)
-  -- For k ≥ 2: cancel k(k-1) > 0 to get 4(2k-1) ≤ 6k(k-1)
-  -- For k = 1: both sides are 0
   rcases Nat.eq_or_gt_of_le hk with rfl | hk2
   · simp
   · push_cast
@@ -104,30 +130,87 @@ theorem sum_sq_le_quartic (k : ℕ) (hk : 1 ≤ k) :
 
 /-- **Main Theorem**: Birthday product lower bound.
     P(all distinct) ≥ exp(-k(k-1)/(2d) - k²(k-1)²/(4d²))
-    for 1 ≤ k ≤ d + 1, d ≥ 1.
+    for 1 ≤ k, d ≥ 1, and 2(k-1) ≤ d.
+
+    The constraint 2(k-1) ≤ d ensures each ratio i/d ≤ 1/2, which is needed
+    for the core inequality ln(1-x) ≥ -x-x². This covers the birthday problem's
+    regime of interest where k ~ √d.
 
     This is the matching lower bound for the OQ-02 upper bound:
     P(all distinct) ≤ exp(-k(k-1)/(2d)). -/
-theorem birthdayProduct_lower_bound {k d : ℕ} (hd : 1 ≤ d) (hk : 1 ≤ k) (hkd : k ≤ d + 1) :
+theorem birthdayProduct_lower_bound {k d : ℕ} (hd : 1 ≤ d) (hk : 1 ≤ k)
+    (hkd : 2 * (k - 1) ≤ d) :
     Real.exp (-(k : ℝ) * (k - 1) / (2 * d) - (k : ℝ) ^ 2 * (k - 1) ^ 2 / (4 * (d : ℝ) ^ 2))
       ≤ birthdayProduct k d := by
-  sorry -- Follows from exp_neg_sub_sq_le_one_sub applied to each factor,
-        -- then sum_sq_le_quartic for the quadratic correction term
+  -- Each factor: 1 - i/d ≥ exp(-i/d - (i/d)²) by exp_neg_sub_sq_le_one_sub
+  -- since i/d ≤ (k-1)/d ≤ 1/2
+  unfold birthdayProduct
+  -- Lower bound each factor, then use exp_sum
+  calc Real.exp (-(k : ℝ) * (k - 1) / (2 * d) -
+          (k : ℝ) ^ 2 * (k - 1) ^ 2 / (4 * (d : ℝ) ^ 2))
+      ≤ Real.exp (∑ i ∈ Finset.range k, (-(↑i : ℝ) / ↑d - ((↑i : ℝ) / ↑d) ^ 2)) := by
+        apply Real.exp_le_exp.mpr
+        -- Need: -k(k-1)/(2d) - k²(k-1)²/(4d²) ≤ ∑(-i/d - i²/d²)
+        -- LHS = -∑i/d - k²(k-1)²/(4d²), RHS = -∑i/d - ∑i²/d²
+        -- So need: k²(k-1)²/(4d²) ≥ ∑i²/d²
+        -- i.e., ∑i² ≤ k²(k-1)²/4 (from sum_sq_le_quartic)
+        have hd_pos : (0 : ℝ) < (d : ℝ) := by exact_mod_cast (show 0 < d by omega)
+        have hd_sq_pos : (0 : ℝ) < (d : ℝ) ^ 2 := by positivity
+        -- Compute ∑(-i/d - i²/d²) = -∑i/d - ∑i²/d²
+        have hsum_split : ∑ i ∈ Finset.range k, (-(↑i : ℝ) / ↑d - ((↑i : ℝ) / ↑d) ^ 2) =
+            -(∑ i ∈ Finset.range k, (↑i : ℝ)) / ↑d -
+            (∑ i ∈ Finset.range k, (↑i : ℝ) ^ 2) / (↑d) ^ 2 := by
+          simp only [div_pow, neg_div]
+          rw [← Finset.sum_neg_distrib, ← Finset.sum_div, ← Finset.sum_div]
+          congr 1
+          ext i; ring
+        rw [hsum_split]
+        -- ∑i = k(k-1)/2
+        have hgauss : ∑ i ∈ Finset.range k, (↑i : ℝ) = (↑k : ℝ) * (↑k - 1) / 2 := by
+          have := Finset.sum_range_id_eq_sum_range_succ_div_two k
+          push_cast at this ⊢; linarith
+        rw [hgauss]
+        -- Now need: -k(k-1)/(2d) - k²(k-1)²/(4d²) ≤ -k(k-1)/2/d - ∑i²/d²
+        -- i.e., k²(k-1)²/(4d²) ≥ ∑i²/d²
+        -- i.e., ∑i² ≤ k²(k-1)²/4
+        have hsq := sum_sq_le_quartic k hk
+        have : (∑ i ∈ Finset.range k, (↑i : ℝ) ^ 2) / (↑d) ^ 2 ≤
+            (↑k : ℝ) ^ 2 * (↑k - 1) ^ 2 / 4 / (↑d) ^ 2 :=
+          div_le_div_of_nonneg_right hsq (le_of_lt hd_sq_pos)
+        linarith
+    _ = ∏ i ∈ Finset.range k, Real.exp (-(↑i : ℝ) / ↑d - ((↑i : ℝ) / ↑d) ^ 2) := by
+        rw [Real.exp_sum]
+    _ ≤ ∏ i ∈ Finset.range k, (1 - (↑i : ℝ) / ↑d) := by
+        apply Finset.prod_le_prod
+        · intro i _
+          exact le_of_lt (Real.exp_pos _)
+        · intro i hi
+          rw [Finset.mem_range] at hi
+          apply exp_neg_sub_sq_le_one_sub
+          · exact div_nonneg (Nat.cast_nonneg i) (Nat.cast_nonneg d)
+          · -- i/d ≤ (k-1)/d ≤ 1/2
+            rw [div_le_div_iff (by exact_mod_cast (show 0 < d by omega) : (0:ℝ) < d)
+                               (by norm_num : (0:ℝ) < 2)]
+            push_cast
+            have : (i : ℤ) ≤ k - 1 := by omega
+            have : 2 * ((k : ℤ) - 1) ≤ d := by exact_mod_cast hkd
+            linarith
 
 /-- The two-sided bound: combining with the upper bound from OQ-02,
     P(all distinct) is sandwiched between two exponentials.
     This gives a precise asymptotic: P(all distinct) ≈ exp(-k(k-1)/(2d)). -/
-theorem birthdayProduct_two_sided {k d : ℕ} (hd : 1 ≤ d) (hk : 1 ≤ k) (hkd : k ≤ d + 1) :
+theorem birthdayProduct_two_sided {k d : ℕ} (hd : 1 ≤ d) (hk : 1 ≤ k) (hkd : 2 * (k - 1) ≤ d) :
     Real.exp (-(k : ℝ) * (k - 1) / (2 * d) - (k : ℝ) ^ 2 * (k - 1) ^ 2 / (4 * (d : ℝ) ^ 2))
       ≤ birthdayProduct k d ∧
     birthdayProduct k d ≤ Real.exp (-(k : ℝ) * (k - 1) / (2 * d)) := by
+  have hkd' : k ≤ d + 1 := by omega
   exact ⟨birthdayProduct_lower_bound hd hk hkd, by
     -- Upper bound from OQ-02 (Erdős-style: 1-x ≤ exp(-x))
     unfold birthdayProduct
     calc ∏ i ∈ Finset.range k, (1 - (i : ℝ) / d)
         ≤ ∏ i ∈ Finset.range k, Real.exp (-(i : ℝ) / d) := by
           apply Finset.prod_le_prod
-            (fun i hi => birthdayProduct_factor_nonneg (by omega) hkd i hi)
+            (fun i hi => birthdayProduct_factor_nonneg (by omega) hkd' i hi)
           intro i _
           have h := add_one_le_exp (-↑i / (↑d : ℝ))
           have : -↑i / (↑d : ℝ) + 1 = 1 - ↑i / ↑d := by ring
@@ -136,7 +219,6 @@ theorem birthdayProduct_two_sided {k d : ℕ} (hd : 1 ≤ d) (hk : 1 ≤ k) (hkd
           rw [Real.exp_sum]
       _ = Real.exp (-(↑k : ℝ) * (↑k - 1) / (2 * ↑d)) := by
           congr 1
-          -- ∑_{i<k} (-i/d) = -(1/d) · ∑_{i<k} i = -(1/d) · k(k-1)/2
           rw [show ∀ i : ℕ, -(↑i : ℝ) / ↑d = -(1 / ↑d) * ↑i from fun i => by ring]
           rw [← Finset.mul_sum]
           rw [show ∑ i ∈ Finset.range k, (i : ℝ) = (k : ℝ) * (↑k - 1) / 2 from by

--- a/proofs/Proofs/Erdos261Problem.lean
+++ b/proofs/Proofs/Erdos261Problem.lean
@@ -282,8 +282,26 @@ theorem representable_six : IsRepresentable 6 := by
                 Finset.sum_singleton]
     norm_num
 
-/-- All n from 1 to 6 are representable. -/
-theorem representable_le_6 (n : ℕ) (hn : 1 ≤ n) (hn' : n ≤ 6) : IsRepresentable n := by
+/-- n = 7 is representable: 7/128 = 8/256 + 9/512 + 11/2048 + 15/32768
+    + 20/1048576 + 21/2097152 + 24/16777216. -/
+theorem representable_seven : IsRepresentable 7 := by
+  refine ⟨{8, 9, 11, 15, 20, 21, 24}, ?_, ?_, ?_⟩
+  · simp [Finset.card_insert_of_not_mem, Finset.card_singleton]; omega
+  · intro k hk; simp [Finset.mem_insert, Finset.mem_singleton] at hk
+    rcases hk with rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> omega
+  · show recipPow2Sum {8, 9, 11, 15, 20, 21, 24} = recipPow2Weight 7
+    simp only [recipPow2Sum, recipPow2Weight]
+    simp only [Finset.sum_insert (show (8 : ℕ) ∉ ({9, 11, 15, 20, 21, 24} : Finset ℕ) by decide),
+                Finset.sum_insert (show (9 : ℕ) ∉ ({11, 15, 20, 21, 24} : Finset ℕ) by decide),
+                Finset.sum_insert (show (11 : ℕ) ∉ ({15, 20, 21, 24} : Finset ℕ) by decide),
+                Finset.sum_insert (show (15 : ℕ) ∉ ({20, 21, 24} : Finset ℕ) by decide),
+                Finset.sum_insert (show (20 : ℕ) ∉ ({21, 24} : Finset ℕ) by decide),
+                Finset.sum_insert (show (21 : ℕ) ∉ ({24} : Finset ℕ) by decide),
+                Finset.sum_singleton]
+    norm_num
+
+/-- All n from 1 to 7 are representable. -/
+theorem representable_le_7 (n : ℕ) (hn : 1 ≤ n) (hn' : n ≤ 7) : IsRepresentable n := by
   interval_cases n
   · exact representable_one
   · exact representable_two
@@ -291,6 +309,21 @@ theorem representable_le_6 (n : ℕ) (hn : 1 ≤ n) (hn' : n ≤ 6) : IsRepresen
   · exact representable_four
   · exact representable_five
   · exact representable_six
+  · exact representable_seven
+
+/-- n = 9 is representable: 9/512 = 10/1024 + 11/2048 + 13/8192 + 14/16384. -/
+theorem representable_nine : IsRepresentable 9 := by
+  refine ⟨{10, 11, 13, 14}, ?_, ?_, ?_⟩
+  · simp [Finset.card_insert_of_not_mem, Finset.card_singleton]; omega
+  · intro k hk; simp [Finset.mem_insert, Finset.mem_singleton] at hk
+    rcases hk with rfl | rfl | rfl | rfl <;> omega
+  · show recipPow2Sum {10, 11, 13, 14} = recipPow2Weight 9
+    simp only [recipPow2Sum, recipPow2Weight]
+    simp only [Finset.sum_insert (show (10 : ℕ) ∉ ({11, 13, 14} : Finset ℕ) by decide),
+                Finset.sum_insert (show (11 : ℕ) ∉ ({13, 14} : Finset ℕ) by decide),
+                Finset.sum_insert (show (13 : ℕ) ∉ ({14} : Finset ℕ) by decide),
+                Finset.sum_singleton]
+    norm_num
 
 /-- n = 11 is representable, from the Borwein-Loring family with m = 3:
     11 = 2⁴ - 3 - 2, and 11/2¹¹ = ∑_{k=12}^{14} k/2^k. -/
@@ -301,6 +334,16 @@ theorem representable_eleven : IsRepresentable 11 :=
     26 = 2⁵ - 4 - 2, and 26/2²⁶ = ∑_{k=27}^{30} k/2^k. -/
 theorem representable_26 : IsRepresentable 26 :=
   borwein_loring_family 4 (by omega)
+
+/-- n = 57 is representable, from the Borwein-Loring family with m = 5:
+    57 = 2⁶ - 5 - 2, and 57/2⁵⁷ = ∑_{k=58}^{62} k/2^k. -/
+theorem representable_57 : IsRepresentable 57 :=
+  borwein_loring_family 5 (by omega)
+
+/-- n = 120 is representable, from the Borwein-Loring family with m = 6:
+    120 = 2⁷ - 6 - 2, and 120/2¹²⁰ = ∑_{k=121}^{126} k/2^k. -/
+theorem representable_120 : IsRepresentable 120 :=
+  borwein_loring_family 6 (by omega)
 
 /-- Tengely–Ulas–Zygadło: all n ≤ 10000 are representable -/
 axiom tengely_ulas_zygadlo (n : ℕ) (hn : 1 ≤ n) (hn' : n ≤ 10000) :

--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -34,7 +34,8 @@
     ],
     "axiomCount": 2,
     "lineCount": 351,
-    "assumptions": "3 axioms: borwein_loring_family (provable constructive result), tengely_ulas_zygadlo (computational verification), ErdosProblem261_all (open conjecture). 2 former axioms (continuum/two_reps) proved trivially due to incomplete IsInfiniteRep definition.",
+    "assumptions": "2 axioms: tengely_ulas_zygadlo (computational verification n≤10000), ErdosProblem261_all (open conjecture). Borwein-Loring family fully proved. Explicit representations for n=1..7,9,11,26,57,120.",
+    "lineCount": 394,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01.json
@@ -29,11 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Attempted 2/4 sorry eliminations (sum_sq_le_quartic + Gauss sum). 2 deep sorries remain (exp inequality + main theorem).",
+    "progressSummary": "COMPLETED: All 4 sorries eliminated (2→0 this session). Fixed incorrect hypotheses in 2 theorems. File now 229 lines, 0 sorries, 0 axioms.",
     "builtItems": [
       "Assessment: tractable new formalization, needs Taylor remainder infrastructure",
       "sum_sq_le_quartic: proved ∑i² ≤ k²(k-1)²/4 via sum_sq_formula + nlinarith",
-      "Gauss sum: proved ∑(-i/d) = -k(k-1)/(2d) via Finset.sum_range_id"
+      "Gauss sum: proved ∑(-i/d) = -k(k-1)/(2d) via Finset.sum_range_id",
+      "exp_neg_sub_sq_le_one_sub: proved exp(-x-x²) ≤ 1-x for x ∈ [0,1/2] via Taylor bound",
+      "birthdayProduct_lower_bound: proved matching lower bound with corrected hypothesis 2(k-1)≤d",
+      "birthdayProduct_two_sided: two-sided exponential sandwich for birthday probability"
     ],
     "insights": [
       "No Lean file for OQ-02-OQ-01. Parent files: 5 files, 0A, 0S, 119T — fully proved",
@@ -44,7 +47,10 @@
       "Would need Mathlib Real.log bounds + Taylor/Lagrange remainder for ln",
       "sum_sq_le_quartic: use case split k=1 (trivial) vs k≥2 (nlinarith with sq_nonneg)",
       "Gauss sum: factor -(1/d) then use sum_range_id = k(k-1)/2",
-      "exp_neg_sub_sq_le_one_sub: deep — needs Taylor remainder for ln(1-x) ≥ -x-x²"
+      "exp_neg_sub_sq_le_one_sub: deep — needs Taylor remainder for ln(1-x) ≥ -x-x²",
+      "CRITICAL FIX: original exp(-x-x²) ≤ 1-x had hypothesis x<1 but is FALSE for x>0.69. Changed to x≤1/2.",
+      "CRITICAL FIX: birthdayProduct_lower_bound with k≤d+1 is FALSE (product=0 when k=d+1). Changed to 2(k-1)≤d.",
+      "Proof technique: Taylor bound exp(y) ≥ 1+y+y²/2 via Real.sum_le_exp_of_nonneg, then polynomial algebra"
     ],
     "mathlibGaps": [],
     "nextSteps": []

--- a/src/data/research/problems/erdos-261.json
+++ b/src/data/research/problems/erdos-261.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved n=1,2,3,4 all representable. n=2 via weight coincidence w(1)=w(2), n=3 via {4,6,8}, n=4 via BL family. 2 axioms unchanged (tengely_ulas_zygadlo, ErdosProblem261_all).",
+    "progressSummary": "PROGRESS: Extended explicit representations to n=1..7,9 (from n=1..6). Added BL values n=57,120. n=8,10 need large witness sets (13+ elements). 0 sorries, 2 axioms unchanged.",
     "builtItems": [
       "recipPow2Weight_zero: w(0) = 0",
       "recipPow2Weight_three: w(3) = 3/8",
@@ -47,7 +47,12 @@
       "representable_two: n=2 via weight coincidence with n=1",
       "representable_three: n=3 via explicit set {4,6,8}",
       "representable_four: n=4 from BL family m=2",
-      "representable_le_4: all n in [1,4] are representable"
+      "representable_le_4: all n in [1,4] are representable",
+      "representable_seven: n=7 via {8,9,11,15,20,21,24} (7-element witness)",
+      "representable_nine: n=9 via {10,11,13,14} (4-element witness, clean!)",
+      "representable_le_7: all n in [1,7] proved representable",
+      "representable_57: BL family m=5 (n=57)",
+      "representable_120: BL family m=6 (n=120)"
     ],
     "insights": [
       "borwein_loring_family is the only provable axiom (5 total) — proof requires partial_sum_formula + telescoping + substitution",
@@ -66,13 +71,19 @@
       "Finset.Icc decomposition via ext+omega avoids needing exact Mathlib lemma names for insert/snoc",
       "w(1) = w(2) = 1/2 means representable_one implies representable_two via weight transfer",
       "n=3: representation {4,6,8} found by search: 4/16 + 6/64 + 8/256 = 3/8 = w(3)",
-      "n=4: directly from BL family (m=2), 4 = 2^3 - 2 - 2, set {5,6}"
+      "n=4: directly from BL family (m=2), 4 = 2^3 - 2 - 2, set {5,6}",
+      "n=8 and n=10 require very large witness sets (13+ elements) due to dyadic structure of 1/32 and 5/512",
+      "n=9 has elegant 4-element representation {10,11,13,14} — among the smallest non-BL witnesses",
+      "n=7 needs 7 elements {8,9,11,15,20,21,24} — elements up to 24 make it the largest explicit witness",
+      "BL family gives n=1,4,11,26,57,120,247,... growing doubly-exponentially; covers sparse set of representable n"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "tengely_ulas_zygadlo is a computational axiom (n ≤ 10000) — could verify with native_decide or external check",
-      "ErdosProblem261_all is the main open conjecture — stays as axiom",
-      "ErdosProblem261_continuum and two_reps are open — stay as axioms"
+      "n=8 representation needs 13 elements {9,10,12,14,18,19,21,22,24,26,29,30,32} — prove if verbose Lean proof acceptable",
+      "n=10 likely needs 20+ elements — may not be practical as explicit proof",
+      "Fix IsInfiniteRep definition with tsum/Filter.Tendsto for proper convergence",
+      "Prove monotonicity: w(k) strictly decreasing for k >= 2",
+      "Consider proving greedy algorithm correctness for specific n ranges"
     ],
     "markdown": "# Erdős #261 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nAre there infinitely many $n$ such that there exists some $t\\geq 2$ and distinct integers $a_1,\\ldots,a_t\\geq 1$ such that\\[\\frac{n}{2^n}=\\sum_{1\\leq k\\leq t}\\frac{a_k}{2^{a_k}}?\\]Is this true for all $n$? Is there a rational $x$ such that\\[x = \\sum_{k=1}^\\infty \\frac{a_k}{2^{a_k}}\\]has at least $2^{\\aleph_0}$ solutions?\n\n\n\n\n\nRelated to [260].\n\nIn \\cite{Er88c} Erd\\H{o}s notes that Cusick had a simple proof that there do exist infinitely many such $n$. Erd\\H{o}s does not record what this was, but a later paper by Borwein and Loring \\cite{BoLo90} provides the following proof: for every positive integer $m$ and $n=2^{m+1}-m-2$ we have\\[\\frac{n}{2^n}=\\sum_{n<k\\leq n+m}\\frac{k}{2^k}.\\]Tengely, Ulas, and Zygadlo \\cite{TUZ20} have verified that all $n\\leq 10000$ have the required property.\n\nIn \\cite{Er88c} Erd\\H{o}s weakens the second question to asking for the existence of a rational $x$ which has two solutions.\n\n\n\n\nReferences\n\n\n[BoLo90] Borwein, Peter and Loring, Terry A., Some questions of {E}rd\\H{o}s and {G}raham on numbers of the\nform {$\\sum g_n/2^{g_n}$}. Math. Comp. (1990), 377--394.\n\n[Er88c] Erd\\\"{o}s, P., On the irrationality of certain series: problems and results. New advances in transcendence theory (Durham, 1986) (1988), 102-109.\n\n[TUZ20] Tengely, Szabolcs and Ulas, Maciej and Zygad\\l o, Jakub, On a {D}iophantine equation of {E}rd\\H{o}s and {G}raham. J. Number Theory (2020), 445--459.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #260\n- Problem #262\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er74b\n- ErGr80\n- Er88c\n- BoLo90\n- TUZ20\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },


### PR DESCRIPTION
## Summary
- Fix and prove `exp_neg_sub_sq_le_one_sub`: core inequality exp(-x-x²) ≤ 1-x for x ∈ [0,1/2]
- Fix and prove `birthdayProduct_lower_bound`: matching lower bound for birthday collision probability
- Prove `birthdayProduct_two_sided`: two-sided exponential sandwich

## Critical Fixes
- `exp_neg_sub_sq_le_one_sub` had hypothesis `x < 1` but is FALSE for x > 0.69 → changed to `x ≤ 1/2`
- `birthdayProduct_lower_bound` had `k ≤ d + 1` but is FALSE at k = d+1 (product = 0) → changed to `2(k-1) ≤ d`

## Status
**Outcome**: completed (2→0 sorries)
**Sorries**: 0
**Axioms**: 0

🤖 Generated by researcher-6