### PR TITLE
fix: correct metadata for collatz-oq-03 and erdos-1097-oq-01

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9934,5 +9934,17 @@
       "axiomCount 7->8",
       "lineCount 216->228"
     ]
+  },
+  "collatz-structured-oq-03": {
+    "lastAudited": "2026-03-29T18:24:11Z",
+    "auditCount": 1,
+    "result": "issues-fixed",
+    "agentId": "auditor-cycle-2"
+  },
+  "erdos-1097-oq-01": {
+    "lastAudited": "2026-03-29T18:24:11Z",
+    "auditCount": 1,
+    "result": "issues-fixed",
+    "agentId": "auditor-cycle-2"
   }
 }

--- a/src/data/proofs/collatz-structured-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-03/meta.json
@@ -15,6 +15,6 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 145
+    "lineCount": 149
   }
 }

--- a/src/data/proofs/erdos-1097-oq-01/meta.json
+++ b/src/data/proofs/erdos-1097-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (generalized)",
     "sourceUrl": "https://erdosproblems.com/1097",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1097OQ01.lean",
     "tags": [
       "erdos",
@@ -23,7 +23,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms. All 17 theorems are fully proved from Mathlib. The main open question (growth exponent α(k) for k ≥ 4) is stated as a definition, not an axiom.",
-    "lineCount": 180,
+    "lineCount": 207,
     "relatedProblems": [
       {
         "id": "erdos-1097",
@@ -103,7 +103,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 180,
+    "lineCount": 207,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 17,


### PR DESCRIPTION
## Summary

- **collatz-structured-oq-03**: lineCount 145→149 (file grew since metadata was written)
- **erdos-1097-oq-01**: status `formalized`→`verified` (0 sorries, 0 axioms — qualifies for verified), lineCount 180→207

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery entries render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)