### PR TITLE
fix: correct sorry counts and metadata for 3 gallery proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -518,9 +518,9 @@
       "issues": []
     },
     "inverse-galois": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-28T17:48:22Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-03-29T18:45:54Z",
+      "result": "clean",
       "issues": []
     },
     "morleys-theorem": {
@@ -9237,8 +9237,8 @@
       "issues": []
     },
     "inverse-galois-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-25T02:54:55Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-29T18:45:54Z",
       "result": "clean",
       "issues": []
     },
@@ -9946,5 +9946,35 @@
     "auditCount": 1,
     "result": "issues-fixed",
     "agentId": "auditor-cycle-2"
+  },
+  "erdos-744": {
+    "lastAudited": "2026-03-29T18:47:33Z",
+    "auditCount": 1,
+    "result": "issues-fixed",
+    "agentId": "auditor-cycle-3"
+  },
+  "erdos-648": {
+    "lastAudited": "2026-03-29T18:47:33Z",
+    "auditCount": 1,
+    "result": "issues-fixed",
+    "agentId": "auditor-cycle-3"
+  },
+  "erdos-327-oq-01": {
+    "lastAudited": "2026-03-29T18:47:33Z",
+    "auditCount": 1,
+    "result": "issues-fixed",
+    "agentId": "auditor-cycle-3"
+  },
+  "inverse-galois-oq-01": {
+    "lastAudited": "2026-03-29T18:47:33Z",
+    "auditCount": 1,
+    "result": "clean",
+    "agentId": "auditor-cycle-3"
+  },
+  "inverse-galois": {
+    "lastAudited": "2026-03-29T18:47:33Z",
+    "auditCount": 1,
+    "result": "clean",
+    "agentId": "auditor-cycle-3"
   }
 }

--- a/src/data/proofs/erdos-327-oq-01/meta.json
+++ b/src/data/proofs/erdos-327-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (generalized)",
     "sourceUrl": "https://erdosproblems.com/327",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos327OQ01.lean",
     "tags": [
       "erdos",
@@ -23,7 +23,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms. All theorems proved from Mathlib alone. The density conjecture (pair count ~ N log N) is stated as a definition.",
-    "lineCount": 150,
+    "lineCount": 165,
     "relatedProblems": [
       {
         "id": "erdos-327",
@@ -95,7 +95,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 150,
+    "lineCount": 165,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 10,

--- a/src/data/proofs/erdos-648/meta.json
+++ b/src/data/proofs/erdos-648/meta.json
@@ -17,7 +17,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 0,
     "erdosNumber": 648,
     "erdosUrl": "https://erdosproblems.com/648",
     "erdosProblemStatus": "solved",
@@ -82,8 +82,8 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 335,
-    "assumptions": "3 axiom(s) (Cambie's bounds + asymptotic conjecture) and 4 sorry(s). See the Lean source for details."
+    "lineCount": 378,
+    "assumptions": "3 axiom(s) (Cambie's bounds + asymptotic conjecture), 0 sorries. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "The greatest prime factor function $P(n)$ has been studied since the earliest days of analytic number theory. Ramanujan (1915) investigated $P(n)$ in connection with highly composite numbers, and Karl Dickman (1930) established the foundational result on the distribution of $P(n)$: the proportion of integers $n \\le x$ with $P(n) \\le x^{1/u}$ tends to the Dickman function $\\rho(u)$. Nicolaas de Bruijn (1951) refined Dickman's estimates with his celebrated asymptotic for the smooth number counting function $\\Psi(x, y) = |\\{n \\le x : P(n) \\le y\\}|$, which satisfies $\\Psi(x, y) \\sim x \\cdot \\rho(\\log x / \\log y)$. These estimates were further sharpened by Hildebrand and Tenenbaum (1986).\n\nErdős posed Problem #648 as a combinatorial question about $P(n)$: given $n$, how long can an increasing sequence $a_1 < a_2 < \\cdots < a_t < n$ be if the greatest prime factors must strictly decrease: $P(a_1) > P(a_2) > \\cdots > P(a_t)$? The tension between increasing values and decreasing GPF creates a delicate optimization problem at the interface of combinatorics and analytic number theory.\n\nStijn Cambie resolved the problem in 2025, proving $g(n) \\asymp (n/\\log n)^{1/2}$, with the constant $c$ in $g(n) \\sim c\\sqrt{n/\\log n}$ satisfying $2 \\le c \\le 2\\sqrt{2}$. The lower bound uses an explicit construction leveraging smooth numbers (numbers with bounded GPF), while the upper bound employs counting arguments via de Bruijn's $\\Psi$-function estimates. The exact value of $c$ remains an open question.",
@@ -225,7 +225,7 @@
       "Finset"
     ],
     "namespace": "Erdos648",
-    "lineCount": 335,
+    "lineCount": 378,
     "axiomCount": 3,
     "theoremCount": 33,
     "definitionCount": 9

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -17,7 +17,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 744,
     "erdosUrl": "https://erdosproblems.com/744",
     "erdosProblemStatus": "disproved",
@@ -59,8 +59,8 @@
       "erdos_744_statement theorem: combined main result"
     ],
     "axiomCount": 6,
-    "lineCount": 342,
-    "assumptions": "6 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "lineCount": 356,
+    "assumptions": "6 axiom(s) and 1 sorry (edge-deletion existence). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős Problem #744 originates from a question posed by Erdős, Hajnal, and Szemerédi in the early 1980s (references [Er81] and [EHS82]). The problem concerns a fundamental question about the structure of k-chromatic critical graphs: how many edges must be removed to make such a graph bipartite? The function f_k(n) measures the minimum number of edge deletions needed across all k-critical graphs on n vertices.\n\nThe case k = 3 is trivial: the only 3-critical graphs are odd cycles, and removing any single edge yields a path (which is bipartite), so f_3(n) = 1. For k ≥ 4, early results were encouraging for the conjecture. Gallai (1968) established that f_4(n) ≤ O(√n), and Lovász extended this to f_k(n) ≤ O(n^{1-1/(k-2)}) for general k. Erdős and collaborators conjectured that f_k(n) → ∞ as n → ∞, and specifically asked whether f_4(n) grows at least as fast as log(n).\n\nIn a surprising turn, Rödl and Tuza disproved the conjecture entirely in 1985. They showed that for every fixed k ≥ 3, the function f_k(n) is eventually constant: f_k(n) = C(k-1, 2) = (k-1)(k-2)/2 for all sufficiently large n. This means the non-bipartiteness of large k-critical graphs is concentrated in a bounded substructure, regardless of the total graph size.",
@@ -185,7 +185,7 @@
       "Finset"
     ],
     "namespace": "Erdos744",
-    "lineCount": 342,
+    "lineCount": 356,
     "axiomCount": 6,
     "theoremCount": 8,
     "definitionCount": 10


### PR DESCRIPTION
## Summary

- **erdos-744**: sorry count 3→1 (2 sorries eliminated by researchers), lineCount 342→356
- **erdos-648**: sorry count 4→0 (all sorries eliminated), lineCount 335→378
- **erdos-327-oq-01**: status `formalized`→`verified` (0 sorries, 0 axioms), lineCount 150→165

Also re-audited inverse-galois and inverse-galois-oq-01 — both confirmed clean (scanner axiom flags were false positives from comment text).

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery entries render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)