### PR TITLE
Research: prove 5 sorries in Erdos2OQ01Aristotle + Erdos454Aristotle

### DIFF
--- a/proofs/Proofs/Erdos1034Problem.lean
+++ b/proofs/Proofs/Erdos1034Problem.lean
@@ -132,7 +132,11 @@ Note: Expected a function because this term is being applied to the argument
   G-/
 /-- Triangle has exactly 3 vertices. -/
 theorem Triangle.card_vertices (T : Triangle G) : T.vertices.card = 3 := by
-  sorry
+  simp only [Triangle.vertices]
+  rw [Finset.card_insert_of_not_mem, Finset.card_insert_of_not_mem, Finset.card_singleton]
+  · exact Finset.not_mem_singleton.mpr T.distinct23
+  · simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨T.distinct12, T.distinct13⟩
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 

--- a/proofs/Proofs/Erdos207Problem.lean
+++ b/proofs/Proofs/Erdos207Problem.lean
@@ -121,7 +121,13 @@ def stsTripleCount (n : ℕ) : ℕ := n * (n - 1) / 6
 
 theorem sts_triple_count_formula (n : ℕ) (hn : IsAdmissible n) :
     6 ∣ n * (n - 1) := by
-  sorry
+  rcases hn with h1 | h3
+  · -- n ≡ 1 (mod 6), so 6 | (n - 1), hence 6 | n * (n - 1)
+    exact dvd_mul_of_dvd_right (Nat.dvd_of_mod_eq_zero (by omega)) n
+  · -- n ≡ 3 (mod 6): 3 | n and 2 | (n - 1), so n*(n-1) = 3a * 2b = 6ab
+    obtain ⟨a, ha⟩ := Nat.dvd_of_mod_eq_zero (show n % 3 = 0 by omega)
+    obtain ⟨b, hb⟩ := Nat.dvd_of_mod_eq_zero (show (n - 1) % 2 = 0 by omega)
+    exact ⟨a * b, by rw [ha, hb]; ring⟩
 
 /-
 ## Part IV: The Erdős Conjecture

--- a/proofs/Proofs/Erdos2OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos2OQ01Aristotle.lean
@@ -24,7 +24,21 @@ namespace Erdos2OQ01Aristotle
     then the sum of their reciprocals (as rationals) is ≤ length / m. -/
 theorem reciprocal_sum_le_of_min_ge (ns : List ℕ) (m : ℕ) (hm : m ≥ 1)
     (hmin : ∀ n ∈ ns, n ≥ m) :
-    (ns.map (fun n => (1 : ℚ) / n)).sum ≤ ns.length / m := by sorry
+    (ns.map (fun n => (1 : ℚ) / n)).sum ≤ ns.length / m := by
+  induction ns with
+  | nil => simp
+  | cons a tl ih =>
+    simp only [List.map_cons, List.sum_cons, List.length_cons]
+    have ha : a ≥ m := hmin a (List.mem_cons_self _ _)
+    have htl : ∀ n ∈ tl, n ≥ m := fun n hn => hmin n (List.mem_cons_of_mem _ hn)
+    have ihm : (tl.map (fun n => (1 : ℚ) / n)).sum ≤ tl.length / m := ih htl
+    have h1 : (1 : ℚ) / a ≤ 1 / m := by
+      rw [div_le_div_iff (by positivity : (0 : ℚ) < a) (by positivity : (0 : ℚ) < m)]
+      push_cast; linarith
+    calc (1 : ℚ) / a + (tl.map (fun n => (1 : ℚ) / n)).sum
+        ≤ 1 / m + tl.length / m := by linarith
+      _ = (1 + tl.length) / m := by ring
+      _ = (tl.length + 1) / m := by ring_nf
 
 /-- The sum of 1/n for n in [m, m+k) equals the partial harmonic sum H(m,m+k-1). -/
 theorem partial_harmonic_sum_eq (m k : ℕ) (hm : m ≥ 1) :
@@ -32,12 +46,22 @@ theorem partial_harmonic_sum_eq (m k : ℕ) (hm : m ≥ 1) :
     ((List.range k).map (fun i => (1 : ℚ) / (m + i))).sum := by rfl
 
 /-- For m ≥ 2, we have 1/m ≤ 1/2. -/
-theorem one_div_ge_two (m : ℕ) (hm : m ≥ 2) : (1 : ℚ) / m ≤ 1 / 2 := by sorry
+theorem one_div_ge_two (m : ℕ) (hm : m ≥ 2) : (1 : ℚ) / m ≤ 1 / 2 := by
+  rw [div_le_div_iff (by positivity : (0 : ℚ) < m) (by norm_num : (0 : ℚ) < 2)]
+  push_cast
+  linarith
 
 /-- The sum of reciprocals 1/m + 1/(m+1) + ... + 1/(m+k-1) is positive
     when m ≥ 1 and k ≥ 1. -/
 theorem partial_harmonic_pos (m k : ℕ) (hm : m ≥ 1) (hk : k ≥ 1) :
-    ((List.range k).map (fun i => (1 : ℚ) / (m + i))).sum > 0 := by sorry
+    ((List.range k).map (fun i => (1 : ℚ) / (m + i))).sum > 0 := by
+  apply List.sum_pos
+  · intro x hx
+    simp only [List.mem_map, List.mem_range] at hx
+    obtain ⟨i, _, rfl⟩ := hx
+    positivity
+  · simp [List.length_map, List.length_range]
+    omega
 
 -- ══════════════════════════════════════════════════════════════════
 -- § List and Finset Lemmas
@@ -47,12 +71,20 @@ theorem partial_harmonic_pos (m k : ℕ) (hm : m ≥ 1) (hk : k ≥ 1) :
     then the sum of reciprocals is < 1. -/
 theorem reciprocal_sum_lt_one_of_few_terms (ns : List ℕ) (m : ℕ) (hm : m ≥ 1)
     (hlen : ns.length < m) (hmin : ∀ n ∈ ns, n ≥ m) :
-    (ns.map (fun n => (1 : ℚ) / n)).sum < 1 := by sorry
+    (ns.map (fun n => (1 : ℚ) / n)).sum < 1 := by
+  calc (ns.map (fun n => (1 : ℚ) / n)).sum
+      ≤ ns.length / m := reciprocal_sum_le_of_min_ge ns m hm hmin
+    _ < m / m := by
+        apply div_lt_div_of_pos_right
+        · exact_mod_cast hlen
+        · positivity
+    _ = 1 := by rw [div_self (by positivity : (m : ℚ) ≠ 0)]
 
 /-- A list of distinct naturals all ≥ m with k elements has
     sum ≥ m + (m+1) + ... + (m+k-1). -/
 theorem distinct_sum_lower_bound (ns : List ℕ) (m : ℕ)
     (hmin : ∀ n ∈ ns, n ≥ m) (hnodup : ns.Nodup) :
-    ns.sum ≥ (ns.length * (2 * m + ns.length - 1)) / 2 := by sorry
+    ns.sum ≥ (ns.length * (2 * m + ns.length - 1)) / 2 := by
+  sorry -- Needs induction extracting minimum element with distinctness → remaining ≥ min+1
 
 end Erdos2OQ01Aristotle

--- a/proofs/Proofs/Erdos454Aristotle.lean
+++ b/proofs/Proofs/Erdos454Aristotle.lean
@@ -77,25 +77,39 @@ theorem f_le_twice_nthPrime (n : ℕ) (hn : n > 0) :
   simp [symmetric_sum_at_zero n hn]
 
 /-- The two definitions of f are equivalent. -/
-theorem f_eq_f' (n : ℕ) : f n = f' n := by sorry
+theorem f_eq_f' (n : ℕ) : f n = f' n := by
+  sorry -- Needs equivalence between iInf over Fin n and Finset.inf' over range n
 
 -- Conjecture / negation relationship
 /-- The conjecture and its negation are complementary. -/
 theorem conjecture_iff_not_negation :
-    Erdos454Conjecture ↔ ¬Erdos454Negation := by sorry
+    Erdos454Conjecture ↔ ¬Erdos454Negation := by
+  simp only [Erdos454Conjecture, Erdos454Negation]
+  constructor
+  · intro heq ⟨M, hM⟩
+    rw [heq] at hM
+    exact absurd hM (not_le.mpr (WithTop.coe_lt_top M))
+  · intro hne
+    by_contra h
+    apply hne
+    have hne_top : limsup deviationENat atTop ≠ ⊤ := h
+    exact ⟨(limsup deviationENat atTop).toNat,
+      le_of_eq (ENat.coe_toNat hne_top).symm⟩
 
 -- Limsup consequences (assuming Pomerance's result as hypothesis, not axiom)
 /-- If limsup ≥ 2, then infinitely many n have deviationENat ≥ 2. -/
 theorem infinitely_many_deviation_ge_2
     (h : 2 ≤ limsup deviationENat atTop) :
-    {n : ℕ | deviationENat n ≥ 2}.Infinite := by sorry
+    {n : ℕ | deviationENat n ≥ 2}.Infinite := by
+  sorry -- Needs limsup ≥ c → frequently ≥ c argument in ℕ∞
 
 -- Prime gap existence (known result, not open)
 /-- There exist arbitrarily large prime gaps: for any G,
     some consecutive prime gap is ≥ G. Proof: (G+1)!+2, ..., (G+1)!+(G+1)
     are all composite. -/
 theorem large_prime_gaps_exist :
-    ∀ G : ℕ, ∃ k, nthPrime (k + 1) - nthPrime k ≥ G := by sorry
+    ∀ G : ℕ, ∃ k, nthPrime (k + 1) - nthPrime k ≥ G := by
+  sorry -- Needs factorial gap construction: (G+1)!+2,...,(G+1)!+(G+1) are all composite
 
 -- Asymmetric behavior of primes around a central index
 /-- For i > 0, primes at n+i exceed p_n and primes at n-i are below p_n. -/


### PR DESCRIPTION
## Summary
- Proved 4 sorries in `Erdos2OQ01Aristotle.lean` (reciprocal sum bounds for covering systems)
- Proved 1 sorry in `Erdos454Aristotle.lean` (conjecture/negation complementarity)

## Erdos2OQ01Aristotle.lean (4→1 sorries)
- `reciprocal_sum_le_of_min_ge`: sum of 1/n_i ≤ length/m when all n_i ≥ m (induction)
- `one_div_ge_two`: 1/m ≤ 1/2 for m ≥ 2 (div_le_div_iff)
- `partial_harmonic_pos`: partial harmonic sums are positive (List.sum_pos + positivity)
- `reciprocal_sum_lt_one_of_few_terms`: few large terms → sum < 1 (chains with above)
- Remaining: `distinct_sum_lower_bound` needs extraction of minimum from nodup list

## Erdos454Aristotle.lean (4→3 sorries)
- `conjecture_iff_not_negation`: limsup = ⊤ ↔ ¬(∃ M, limsup ≤ ↑M) in ℕ∞
- Remaining: `f_eq_f'` (iInf/inf' equivalence), `infinitely_many_deviation_ge_2`, `large_prime_gaps_exist`

## Test plan
- [ ] CI build passes (Lean type-checking)
- [ ] No regressions in other proof files

🤖 Generated by researcher-11