### PR TITLE
fix: correct metadata for 6 gallery proofs (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -518,9 +518,9 @@
       "issues": []
     },
     "inverse-galois": {
-      "auditCount": 4,
-      "lastAudited": "2026-03-29T18:45:54Z",
-      "result": "clean",
+      "auditCount": 5,
+      "lastAudited": "2026-03-29T19:27:31Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "morleys-theorem": {
@@ -734,9 +734,9 @@
       "issues": []
     },
     "erdos-1033": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:17:38Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-29T19:25:53Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1137": {
@@ -2579,9 +2579,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1034": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T19:27:01Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1035": {
@@ -3281,9 +3281,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-207": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-29T19:26:30Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-208": {
@@ -9237,9 +9237,9 @@
       "issues": []
     },
     "inverse-galois-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-29T18:45:54Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-03-29T19:27:16Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "abel-ruffini-oq-04-oq-01": {
@@ -9912,6 +9912,24 @@
       "auditCount": 1,
       "lastAudited": "2026-03-29T17:03:06Z",
       "result": "issues-fixed",
+      "issues": []
+    },
+    "collatz-structured-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T19:27:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1097-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T19:28:02Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-327-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-29T19:28:15Z",
+      "result": "clean",
       "issues": []
     }
   },

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -17,7 +17,7 @@
       "turan-theory"
     ],
     "badge": "axiom",
-    "sorries": 13,
+    "sorries": 11,
     "erdosNumber": 1033,
     "erdosUrl": "https://erdosproblems.com/1033",
     "erdosProblemStatus": "open",
@@ -52,8 +52,8 @@
     ],
     "relatedProblems": [],
     "axiomCount": 6,
-    "lineCount": 367,
-    "assumptions": "6 axioms (turan_has_triangle, erdos_laskar_upper, upper_bound_tight, erdos_laskar_lower, fan_lower, extremal_exists) and 13 sorries. erdosLaskar_approx now proved."
+    "lineCount": 383,
+    "assumptions": "6 axioms (turan_has_triangle, erdos_laskar_upper, upper_bound_tight, erdos_laskar_lower, fan_lower, extremal_exists) and 11 sorries. erdosLaskar_approx now proved."
   },
   "overview": {
     "historicalContext": "Pál Turán proved in 1941 that every graph on $n$ vertices with more than $\\lfloor n^2/4 \\rfloor$ edges contains a triangle — establishing the foundational result of extremal graph theory. This problem, posed by Erdős and Laskar, asks a refined question: given that triangles must exist above the Turán threshold, how large must the degree sum of the *heaviest* triangle be?\n\nErdős and Renu Laskar (1985) proved the initial bounds $(1+c)n \\leq h(n) \\leq 2(\\sqrt{3}-1)n$, where the upper bound $2(\\sqrt{3}-1) \\approx 1.464$ comes from optimizing triangle configurations in nearly-bipartite graphs close to the Turán graph $T(n,2)$. Genghua Fan (1988) improved the lower bound to $(21/16)n = 1.3125n$ via careful degree counting arguments.\n\nThe gap between $1.3125n$ and $1.464n$ remains open. The conjectured answer is $h(n) = (2(\\sqrt{3}-1) - o(1))n$, which would mean the Erdős-Laskar construction is essentially optimal.",
@@ -303,7 +303,7 @@
       "Finset"
     ],
     "namespace": "Erdos1033",
-    "lineCount": 367,
+    "lineCount": 383,
     "axiomCount": 6,
     "theoremCount": 16,
     "definitionCount": 17

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -17,7 +17,7 @@
       "counterexample"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 1034,
     "erdosUrl": "https://erdosproblems.com/1034",
     "erdosProblemStatus": "solved",
@@ -26,8 +26,8 @@
       "erdos-1033"
     ],
     "axiomCount": 3,
-    "lineCount": 743,
-    "assumptions": "3 axiom(s) and 12 sorry(s). See the Lean source for details.",
+    "lineCount": 747,
+    "assumptions": "3 axiom(s) and 11 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -273,7 +273,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 743,
+    "lineCount": 747,
     "axiomCount": 3,
     "theoremCount": 17,
     "definitionCount": 22

--- a/src/data/proofs/erdos-1097-oq-01/meta.json
+++ b/src/data/proofs/erdos-1097-oq-01/meta.json
@@ -6,7 +6,7 @@
     "meta": {
         "author": "Erdős (generalized)",
         "sourceUrl": "https://erdosproblems.com/1097",
-        "status": "formalized",
+        "status": "verified",
         "proofRepoPath": "Proofs/Erdos1097OQ01.lean",
         "tags": [
             "erdos",
@@ -103,7 +103,7 @@
         }
     ],
     "leanFile": {
-        "lineCount": 180,
+        "lineCount": 207,
         "structureCount": 0,
         "axiomCount": 0,
         "theoremCount": 17,

--- a/src/data/proofs/erdos-207/meta.json
+++ b/src/data/proofs/erdos-207/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 207,
     "erdosUrl": "https://erdosproblems.com/207",
     "erdosProblemStatus": "solved",
@@ -54,8 +54,8 @@
       "IsResolvable, kirkmanSchoolgirlProblem definitions"
     ],
     "axiomCount": 4,
-    "lineCount": 279,
-    "assumptions": "4 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "lineCount": 285,
+    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Steiner Triple Systems and High Girth**\n\nA Steiner triple system STS$(n)$ is a collection of 3-element subsets (triples) of an $n$-set such that every pair of elements appears in exactly one triple. These fundamental structures were first studied by **Thomas Kirkman** in 1847, who proved STS$(n)$ exists iff $n \\equiv 1, 3 \\pmod{6}$, predating **Jakob Steiner**'s 1853 formulation.\n\n**The Girth Question**\n\nErdős posed this problem in 1976, asking whether STS with arbitrarily high girth exist for all large admissible orders. The girth condition (any $j$ edges span $\\geq j+3$ vertices) prevents 'tight' configurations. The special case $g = 3$ (Pasch-free STS) was resolved earlier by **Grannell, Griggs, and Whitehead** (2000) and independently by others.\n\n**The Resolution (2022)**\n\n**Matthew Kwan, Ashwin Sah, Mehtaab Sawhney, and Michael Simkin** (arXiv:2201.04554) resolved this completely using a random greedy construction. Their proof combines the **Rödl nibble method** with a novel **spread measure** to control the girth property throughout the construction process, employing concentration inequalities from probabilistic combinatorics.\n\n**The Kirkman Schoolgirl Problem**\n\nThe formalization also includes the 1850 Kirkman schoolgirl problem—the first question in design theory—asking for a resolvable STS$(15)$ where 15 girls walk in groups of 3 for 7 days without repeating companions.",
@@ -178,7 +178,7 @@
       "Finset"
     ],
     "namespace": "Erdos207",
-    "lineCount": 279,
+    "lineCount": 285,
     "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 12

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -25,7 +25,7 @@
         ],
         "badge": "formalized",
         "sorries": 1,
-        "axiomCount": 0,
+        "axiomCount": 1,
         "prerequisites": [
             "Galois theory (Galois groups, splitting fields, fixed fields)",
             "Group theory (symmetric groups, alternating groups, solvability, simplicity)",

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -27,7 +27,7 @@
         ],
         "badge": "axiom",
         "sorries": 0,
-        "axiomCount": 4,
+        "axiomCount": 5,
         "prerequisites": [
             "Galois theory (field extensions, Galois groups, splitting fields)",
             "Cyclotomic fields and Kronecker-Weber theorem",


### PR DESCRIPTION
## Summary
- Audited 8 gallery proofs in cycle 4 (3 new sorry mismatches + 2 recurring axiom undercounts + 3 unaudited)
- Fixed metadata in 6, 2 were clean

## Fixes

| Proof | Issue | Fix |
|-------|-------|-----|
| erdos-1033 | sorry count 13→11, stale lineCount | Corrected to match Lean source |
| erdos-1034 | sorry count 12→11, stale lineCount | Corrected to match Lean source |
| erdos-207 | sorry count 3→2, stale lineCount | Corrected to match Lean source |
| erdos-1097-oq-01 | status "formalized" with 0 sorries/0 axioms | Upgraded to "verified"; fixed leanFile.lineCount |
| inverse-galois-oq-01 | axiomCount 0 ignores transitive axiom | Updated to 1 |
| inverse-galois | axiomCount 4 vs 5 total assumptions | Updated to 5 |

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery pages render correctly for affected proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)