### PR TITLE
fix: correct sorry/line counts in 4 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-1022-oq-01/meta.json
+++ b/src/data/proofs/erdos-1022-oq-01/meta.json
@@ -23,7 +23,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms. All theorems proved from Mathlib. The generalized first-moment bound is stated as a definition.",
-    "lineCount": 160,
+    "lineCount": 164,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -105,7 +105,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 160,
+    "lineCount": 164,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 10,

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -21,7 +21,7 @@
         "erdosUrl": "https://erdosproblems.com/963",
         "erdosProblemStatus": "open",
         "axiomCount": 1,
-        "lineCount": 625,
+        "lineCount": 633,
         "assumptions": "1 axiom: trivial_upper_bound (known result, f(n) ≤ ⌊log₂ n⌋ + 1). greedy_lower_bound now fully proved via greedy_dissociated + Nat.log arithmetic. 0 sorries. Conjecture stated as def ErdosProblem963 (not an axiom).",
         "mathlib_version": "4.26.0"
     },
@@ -136,7 +136,7 @@
         ],
         "opens": [],
         "namespace": null,
-        "lineCount": 430,
+        "lineCount": 633,
         "axiomCount": 2,
         "theoremCount": 17,
         "definitionCount": 4


### PR DESCRIPTION
## Fix

Correct stale sorry counts and line counts in 4 gallery meta.json files after recent research commits.

## Evidence

**Before → After:**
- erdos-1034: sorries 11→9 (2 adjacency count sorries proved in #7998), lineCount 747→768
- erdos-320: sorries 3→2, lineCount 245→246
- erdos-1022-oq-01: lineCount 160→164 (new research in #7999)
- erdos-963: lineCount 625→633 (axiom reductions in #8001)

---
Automated fix by lean-mechanic agent.