### PR TITLE
Research: prove 10 sorries across Erdos1033, Erdos1034, Erdos1049, Erdos1050

### DIFF
--- a/proofs/Proofs/Erdos1033Problem.lean
+++ b/proofs/Proofs/Erdos1033Problem.lean
@@ -171,8 +171,9 @@ theorem lower_beats_n : ∃ c > 0, ∃ N : ℕ, ∀ n ≥ N, h n ≥ n := by
   obtain ⟨c, hc, N, hN⟩ := erdos_laskar_lower
   use c, hc, N
   intro n hn
-  have := hN n hn
-  sorry
+  have hle := hN n hn
+  -- (h n : ℝ) ≥ (1 + c) * n ≥ 1 * n = n, so h n ≥ n as naturals
+  exact_mod_cast le_trans (by exact_mod_cast le_refl n) (le_trans (by nlinarith) hle)
 
 /-
 ## Fan's Improved Lower Bound (1988)
@@ -209,12 +210,17 @@ noncomputable def boundGap : ℝ := erdosLaskarConstant - fanConstant
 
 /-- The gap is positive: problem is open. -/
 theorem gap_positive : boundGap > 0 := by
-  unfold boundGap erdosLaskarConstant fanConstant
-  sorry
+  unfold boundGap
+  have h := erdosLaskar_approx
+  have : (fanConstant : ℝ) = 21 / 16 := by norm_num [fanConstant]
+  linarith [h.1, this]
 
 /-- Numerical gap ≈ 0.15. -/
 theorem gap_approx : boundGap > 0.15 ∧ boundGap < 0.16 := by
-  sorry
+  unfold boundGap
+  have h := erdosLaskar_approx
+  have hfan : (fanConstant : ℝ) = 21 / 16 := by norm_num [fanConstant]
+  constructor <;> linarith [h.1, h.2, hfan]
 
 /-
 ## The Main Conjecture
@@ -235,7 +241,21 @@ def h_asymptotic : Prop :=
 /-- The conjecture implies exact asymptotics. -/
 theorem conjecture_gives_asymptotic :
     erdos_1033_conjecture → h_asymptotic := by
-  sorry
+  intro hconj ε hε
+  obtain ⟨N, hN⟩ := hconj (ε / 2) (by linarith)
+  use max N 3
+  intro n hn
+  have hn3 : n ≥ 3 := le_trans (le_max_right N 3) hn
+  have hnN : n ≥ N := le_trans (le_max_left N 3) hn
+  have hn_pos : (0 : ℝ) < n := by exact_mod_cast (show 0 < n by omega)
+  have h_lower := hN n hnN
+  have h_upper := erdos_laskar_upper n hn3
+  have h_div_le : (h n : ℝ) / n ≤ erdosLaskarConstant := by
+    rwa [div_le_iff hn_pos, mul_comm]
+  have h_div_ge : erdosLaskarConstant - ε / 2 ≤ (h n : ℝ) / n := by
+    rwa [le_div_iff hn_pos, mul_comm]
+  rw [abs_lt]
+  constructor <;> linarith
 
 /-
 ## Degree Sum Properties

--- a/proofs/Proofs/Erdos1034Problem.lean
+++ b/proofs/Proofs/Erdos1034Problem.lean
@@ -422,7 +422,11 @@ Note: Expected a function because this term is being applied to the argument
 theorem book_pages_are_good (G : SimpleGraph V) [DecidableRel G.Adj]
     (T : Triangle G) (pages : Finset V) (hBook : isBook G T pages) :
     ∀ p ∈ pages, p ∉ T.vertices → isGoodNeighbor G T p := by
-  sorry
+  intro p hp _
+  obtain ⟨h1, h2, h3⟩ := hBook p hp
+  unfold isGoodNeighbor
+  have := fully_adjacent_is_good G T p h1 h2 h3
+  omega
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 
@@ -513,7 +517,15 @@ unexpected token '['; expected command-/
 
 /-- K₄-free bound is worse (higher) than general bound. -/
 theorem k4free_worse : k4FreeConstant > maTangConstant := by
-  sorry
+  unfold k4FreeConstant maTangConstant
+  -- Need: 2√3 - 3 > 2 - √(5/2), i.e., 2√3 + √(5/2) > 5
+  have h1 : (1.73 : ℝ) < Real.sqrt 3 := by
+    rw [← Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 1.73)]
+    exact Real.sqrt_lt_sqrt (sq_nonneg _) (by norm_num)
+  have h2 : (1.58 : ℝ) < Real.sqrt (5 / 2 : ℝ) := by
+    rw [← Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 1.58)]
+    exact Real.sqrt_lt_sqrt (sq_nonneg _) (by norm_num)
+  linarith
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 
@@ -728,7 +740,10 @@ theorem book_subset_good (G : SimpleGraph V) [DecidableRel G.Adj]
     (T : Triangle G) (pages : Finset V) (hBook : isBook G T pages)
     (hDisjoint : Disjoint pages T.vertices) :
     pages ⊆ goodNeighbors G T := by
-  sorry
+  intro p hp
+  simp only [goodNeighbors, Finset.mem_filter, Finset.mem_univ, true_and]
+  have hp_not_in : p ∉ T.vertices := Finset.disjoint_left.mp hDisjoint hp
+  exact ⟨book_pages_are_good G T pages hBook p hp hp_not_in, hp_not_in⟩
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 

--- a/proofs/Proofs/Erdos1049Problem.lean
+++ b/proofs/Proofs/Erdos1049Problem.lean
@@ -52,7 +52,9 @@ theorem tau_prime_pow (p k : ℕ) (hp : p.Prime) : τ (p ^ k) = k + 1 := by
 /-- τ is multiplicative: τ(mn) = τ(m)τ(n) for coprime m, n. -/
 theorem tau_multiplicative (m n : ℕ) (hmn : m.Coprime n) :
     τ (m * n) = τ m * τ n := by
-  sorry
+  simp only [tau]
+  rw [hmn.divisors_mul]
+  exact Finset.card_product _ _
 
 /-- τ(n) ≥ 1 for n ≥ 1. -/
 theorem tau_pos (n : ℕ) (hn : n ≥ 1) : τ n ≥ 1 := by

--- a/proofs/Proofs/Erdos1050Problem.lean
+++ b/proofs/Proofs/Erdos1050Problem.lean
@@ -42,7 +42,10 @@ noncomputable def sumTwoMinusThree : ℝ :=
 
 /-- The two definitions agree. -/
 theorem S_eq_sumTwoMinusThree : S = sumTwoMinusThree := by
-  sorry
+  simp only [S, T, sumTwoMinusThree]
+  congr 1; ext n
+  split_ifs with h <;> simp_all
+  push_cast; ring
 
 /-!
 ## Part II: Convergence
@@ -62,7 +65,10 @@ theorem S_summable : Summable (fun n : ℕ => if n = 0 then 0 else 1 / (2^n - 3 
 
 /-- The denominators 2^n - 3 are nonzero for n ≥ 2. -/
 theorem denom_nonzero (n : ℕ) (hn : n ≥ 2) : (2 : ℝ)^n - 3 ≠ 0 := by
-  sorry
+  have h : (2 : ℝ) ^ n ≥ 4 := by
+    calc (2 : ℝ) ^ n ≥ 2 ^ 2 := pow_le_pow_right (by norm_num) hn
+      _ = 4 := by norm_num
+  linarith
 
 /-- Note: 2^1 - 3 = -1, so the n=1 term is -1. -/
 theorem first_term : 1 / ((2 : ℝ)^1 - 3) = -1 := by


### PR DESCRIPTION
## Summary
- Prove 4 sorries in Erdos1033Problem.lean (bound gap, asymptotics)
- Prove 3 sorries in Erdos1034Problem.lean (K₄-free constant, book properties)
- Prove 1 sorry in Erdos1049Problem.lean (divisor function multiplicativity)
- Prove 2 sorries in Erdos1050Problem.lean (series identity, denominator nonzero)

### Erdős #1033 (Triangle Degree Sum)
- `lower_beats_n`: h(n) ≥ n from Erdős-Laskar lower bound (ℝ→ℕ cast)
- `gap_positive`: 2(√3-1) - 21/16 > 0 via numerical √3 bounds
- `gap_approx`: 0.15 < gap < 0.16
- `conjecture_gives_asymptotic`: conjecture + upper bound → |h(n)/n - c| < ε

### Erdős #1034 (Good Neighbors)
- `k4free_worse`: 2√3-3 > 2-√(5/2) via √3 and √(5/2) bounds
- `book_pages_are_good`: book pages adjacent to all 3 triangle vertices → good neighbor
- `book_subset_good`: disjoint book pages ⊆ good neighbors

### Erdős #1049 (Divisor Series)
- `tau_multiplicative`: τ(mn) = τ(m)τ(n) for coprime via Coprime.divisors_mul

### Erdős #1050 (2^n - 3 Series)
- `S_eq_sumTwoMinusThree`: T(2,-3) = Σ1/(2^n-3) by cast simplification
- `denom_nonzero`: 2^n-3 ≠ 0 for n≥2 via pow_le_pow_right

## Test plan
- [ ] CI build passes (proof verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)