### PR TITLE
fix: correct erdos-320 meta.json sorry count and stale descriptions

### DIFF
--- a/src/data/proofs/erdos-320/meta.json
+++ b/src/data/proofs/erdos-320/meta.json
@@ -19,7 +19,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 320,
     "erdosUrl": "https://erdosproblems.com/320",
     "erdosProblemStatus": "open",
@@ -62,8 +62,8 @@
       "erdos_320_summary: key values extracted via tuple projections"
     ],
     "axiomCount": 8,
-    "lineCount": 245,
-    "assumptions": "8 axiom(s) and 3 sorry(s). S_one, S_two, S_three proved from oeis_A072207 axiom. Remaining sorries: S_pos, lower_bound_growth, log_S_leading_term."
+    "lineCount": 246,
+    "assumptions": "8 axiom(s) and 2 sorry(s). S_one, S_two, S_three proved from oeis_A072207 axiom. S_pos proved directly. Remaining sorries: lower_bound_growth, log_S_leading_term."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #320: Distinct Sums of Unit Fractions**\n\nThis problem asks for the asymptotic behavior of S(N), the number of distinct rational numbers that can be expressed as sums of distinct unit fractions 1/n with denominators from {1,...,N}. It connects ancient questions about Egyptian fractions to modern combinatorial number theory.\n\n**The Ancient Roots:** Sums of distinct unit fractions — called Egyptian fractions — appear in the Rhind Papyrus (c. 1650 BCE), where scribes represented fractions as ∑ 1/nᵢ with distinct denominators. The number-theoretic question of how many such sums exist for denominators ≤ N was first studied systematically by Bleicher and Erdős in the 1970s.\n\n**The Counting Problem:** Each subset A ⊆ {1,...,N} gives a rational sum ∑_{n∈A} 1/n. There are 2^N subsets, but some may give the same sum — these 'collisions' are rare for small N but become dominant as N grows. The function S(N) = |{∑_{n∈A} 1/n : A ⊆ {1,...,N}}| counts the distinct values.\n\n**Key Discovery — First Collision at N = 8:** For N ≤ 7, every subset gives a distinct sum (S(N) = 2^N). At N = 8, the first collision occurs: two different subsets of {1,...,8} have the same unit fraction sum, giving S(8) = 255 < 256. This reflects the arithmetic of the LCM: lcm(1,...,7) = 420 admits no collisions, but lcm(1,...,8) = 840 does.\n\n**Timeline:**\n- 1975: Bleicher and Erdős prove the lower bound log S(N) ≥ (N/log N)(log 2 · ∏ log_i N), using the prime number theorem to count independent choices among prime denominators\n- 1976: Bleicher and Erdős prove the upper bound log S(N) ≤ (N/log N)(log_r N · ∏ log_i N), using LCD constraints on achievable denominators\n- The gap between these bounds involves iterated logarithms — extraordinarily slowly growing functions — making the problem technically delicate\n- 2025: Bettin, Grenié, Molteni, and Sanna improve the lower bound constant from log 2 to 2 log 2, nearly doubling it, by refining the multiplicative counting argument\n\n**Why It's Hard:** The bounds involve products of iterated logarithms ∏ log_i N, which grow so slowly that distinguishing them computationally is almost impossible. The gap between the constant log 2 (lower) and the function log_r N (upper) is the crux of the open problem. The appearance of iterated logarithms reflects the deeply nested inductive structure of the Bleicher-Erdős argument, where each step peels off one layer of logarithmic composition.",
@@ -96,7 +96,7 @@
       "title": "Part I: Basic Definitions",
       "startLine": 39,
       "endLine": 61,
-      "summary": "Defines the core objects over ℚ for exact arithmetic: harmonicSum H_n = Σ 1/i, subsetSum for arbitrary subsets (with filter for positivity), allSubsetSums via Finset.powerset.image (automatic deduplication), and the central counting function S(N) = |allSubsetSums(N)|. Includes S_pos (sorry) asserting S(N) > 0 from the empty-set sum.",
+      "summary": "Defines the core objects over ℚ for exact arithmetic: harmonicSum H_n = Σ 1/i, subsetSum for arbitrary subsets (with filter for positivity), allSubsetSums via Finset.powerset.image (automatic deduplication), and the central counting function S(N) = |allSubsetSums(N)|. Includes S_pos (proved) asserting S(N) > 0 from the empty-set sum.",
       "mathContext": "Defines the core objects over ℚ for exact arithmetic: harmonicSum H_n = Σ 1/i, subsetSum for arbitrary subsets (with filter for positivity), allSubsetSums via Finset.powerset.image (automatic deduplication), and the central counting function S(N) = |allSubsetSums(N)|."
     },
     {
@@ -152,7 +152,7 @@
       "title": "Part VIII: Specific Values and Bounds",
       "startLine": 167,
       "endLine": 187,
-      "summary": "Individual theorems S_one = 2, S_two = 4, S_three = 8 (all sorry — require Finset computation). The axiom S_small asserts S(N) = 2^N for N ≤ 6. The axiom S_collisions asserts S(N) < 2^N for N ≥ 8. The gap at N = 7: S(7) = 128 = 2^7 (no collision) is covered by the OEIS axiom.",
+      "summary": "Individual theorems S_one = 2, S_two = 4, S_three = 8 (derived from oeis_A072207 axiom). The axiom S_small asserts S(N) = 2^N for N ≤ 6. The axiom S_collisions asserts S(N) < 2^N for N ≥ 8. The gap at N = 7: S(7) = 128 = 2^7 (no collision) is covered by the OEIS axiom.",
       "mathContext": "Individual theorems S_one = 2, S_two = 4, S_three = 8 (all sorry — require Finset computation). The axiom S_small asserts S(N) = 2^N for N ≤ 6. The axiom S_collisions asserts S(N) < 2^N for N ≥ 8. The gap at N = 7: S(7) = 128 = 2^7 (no collision) is covered by the OEIS axiom."
     },
     {
@@ -176,12 +176,12 @@
       "title": "Part XI: Summary",
       "startLine": 219,
       "endLine": 248,
-      "summary": "The theorem erdos_320_summary is GENUINELY PROVED by extracting S(1) = 2, S(2) = 4, S(3) = 8, S(8) = 255 from oeis_A072207 via nested tuple projections. The status string records the OPEN problem with the known bound gap. Final tally: 6 sorries, 8 axioms, 2 genuinely proved theorems (bgms_improves_bleicher_erdos and first_collision plus summary).",
+      "summary": "The theorem erdos_320_summary is GENUINELY PROVED by extracting S(1) = 2, S(2) = 4, S(3) = 8, S(8) = 255 from oeis_A072207 via nested tuple projections. The status string records the OPEN problem with the known bound gap. Final tally: 2 sorries, 8 axioms. Genuinely proved theorems: bgms_improves_bleicher_erdos, first_collision, erdos_320_summary, S_pos, S_one, S_two, S_three.",
       "mathContext": "The theorem erdos_320_summary is GENUINELY PROVED by extracting S(1) = 2, S(2) = 4, S(3) = 8, S(8) = 255 from oeis_A072207 via nested tuple projections. The status string records the OPEN problem with the known bound gap."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #320 asks for the asymptotic behavior of S(N), the count of distinct unit fraction subset sums from {1,...,N}. Bleicher and Erdős established bounds in 1975-76 involving iterated logarithms: log S(N) lies between (N/log N) · log 2 · ∏ log_i N and (N/log N) · log_r N · ∏ log_i N. Bettin, Grenié, Molteni, and Sanna improved the lower bound constant to 2 log 2 in 2025. The formalization captures this complete state of knowledge in 248 lines of Lean 4 with 8 axioms and 6 sorries. Two key results are genuinely proved: the BGMS improvement comparison via nlinarith, and the first collision S(8) = 255 < 2^8 via norm_num. The problem remains OPEN — closing the gap between the constant lower bound and the slowly growing upper bound is the main challenge.",
+    "summary": "Erdős Problem #320 asks for the asymptotic behavior of S(N), the count of distinct unit fraction subset sums from {1,...,N}. Bleicher and Erdős established bounds in 1975-76 involving iterated logarithms: log S(N) lies between (N/log N) · log 2 · ∏ log_i N and (N/log N) · log_r N · ∏ log_i N. Bettin, Grenié, Molteni, and Sanna improved the lower bound constant to 2 log 2 in 2025. The formalization captures this complete state of knowledge in 246 lines of Lean 4 with 8 axioms and 2 sorries. Several results are genuinely proved: the BGMS improvement comparison via nlinarith, and the first collision S(8) = 255 < 2^8 via norm_num. The problem remains OPEN — closing the gap between the constant lower bound and the slowly growing upper bound is the main challenge.",
     "implications": "**Theoretical Significance**: **Connections Across Mathematics**\n\n1. **Egyptian Fractions and Ancient Arithmetic:** S(N) counts the distinct values achievable by Egyptian fraction representations with bounded denominators. The Rhind Papyrus (c. 1650 BCE) tables of unit fraction decompositions represent the oldest known engagement with this counting problem. The modern bounds of Bleicher-Erdős quantify the richness of the Egyptian fraction system\n\n2. **Prime Number Theorem Connection:** The leading term N/log N in all bounds directly reflects the prime counting function π(N) ~ N/log N. Primes serve as 'independent generators' of distinct sums: 1/p cannot be decomposed into sums of unit fractions with smaller denominators, so each prime contributes a binary degree of freedom.\n\nThe iterated-log corrections come from composite numbers\n\n3. **Subset Sum Problem over ℚ:** Problem #320 is a rational variant of the classical subset sum problem. Over ℤ, the subset sum problem is NP-complete; over ℚ with unit fractions, the algebraic structure (denominators, LCMs, prime factorizations) provides more leverage, but the asymptotic counting question remains open\n\n4. **Problem #321 and Representation Counting:** While #320 asks how many distinct sums exist, the companion Problem #321 asks how many subsets represent a given sum. The bound egyptianCount(q, N) ≤ S(N) connects them: understanding S(N) constrains the representation count\n\n5. **Iterated Logarithms in Combinatorics:** The appearance of iterated logarithms is relatively rare in number theory but characteristic of problems where nested inductive arguments peel off one logarithmic layer at a time. Similar phenomena appear in Ramsey theory (Shelah's bounds for Hales-Jewett) and in the inverse Ackermann function in computer science.",
     "openQuestions": [
       "Does log S(N) / (N/log N) converge to a constant, or does it grow like an iterated logarithm? Equivalently, is the true behavior closer to the lower bound (constant coefficient) or the upper bound (growing coefficient)?",
@@ -207,7 +207,7 @@
       "Finset"
     ],
     "namespace": "Erdos320",
-    "lineCount": 245,
+    "lineCount": 246,
     "axiomCount": 8,
     "theoremCount": 9,
     "definitionCount": 15


### PR DESCRIPTION
## Summary
- Fixed sorry count: 3→2 (S_pos is proved, not sorry'd)
- Fixed lineCount: 245→246
- Fixed section descriptions claiming S_one/S_two/S_three use sorry (they derive from oeis_A072207)
- Fixed conclusion summary claiming "6 sorries" (actual: 2)
- Fixed assumptions text listing S_pos as remaining sorry

## Evidence
**meta.json claimed**: 3 sorries, S_pos as sorry, 245 lines, "6 sorries" in summary  
**Lean source shows**: 2 sorries (lower_bound_growth L97, log_S_leading_term L215), S_pos proved L58-61, 246 lines

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)