### PR TITLE
Research: prove 4 sorries (RamseyR4k, Erdos309, Erdos176)

### DIFF
--- a/proofs/Proofs/Erdos1050Problem.lean
+++ b/proofs/Proofs/Erdos1050Problem.lean
@@ -301,12 +301,23 @@ def oeis_A331372 : ℕ → ℤ
 /-- The denominators form A000051 shifted: 2^n - 3. -/
 theorem denom_sequence (n : ℕ) (hn : n ≥ 1) :
     oeis_A331372 n = 2^n - 3 := by
-  sorry
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  simp [oeis_A331372]
 
 /-- Denominators grow exponentially. -/
 theorem denom_growth (n : ℕ) (hn : n ≥ 3) :
     (oeis_A331372 n : ℝ) > 2^(n-1) := by
-  sorry
+  have hd := denom_sequence n (by omega)
+  simp only [hd]; push_cast
+  -- Goal: (2:ℝ)^n - 3 > (2:ℝ)^(n-1)
+  -- 2^n = 2 * 2^(n-1), so need 2^(n-1) - 3 > 0, i.e., 2^(n-1) > 3
+  have hpow : (2 : ℝ) ^ n = 2 * (2 : ℝ) ^ (n - 1) := by
+    rw [← pow_succ]; congr 1; omega
+  have hge : (2 : ℝ) ^ (n - 1) ≥ 4 := by
+    calc (2 : ℝ) ^ (n - 1) ≥ (2 : ℝ) ^ 2 :=
+          pow_le_pow_right (by norm_num) (by omega)
+      _ = 4 := by norm_num
+  linarith
 
 /-!
 ## Part X: Main Results

--- a/proofs/Proofs/Erdos176Problem.lean
+++ b/proofs/Proofs/Erdos176Problem.lean
@@ -178,8 +178,12 @@ theorem spencer_power_of_two (t : ℕ) :
   have hk : 2^t > 0 := Nat.pos_pow_of_pos t (by norm_num)
   have := spencer_1973 (2^t) hk
   simp only at this
-  -- The factorization of 2^t at 2 is t
-  sorry
+  -- The 2-adic valuation of 2^t is t
+  have h_fact : (2 ^ t).factorization 2 = t := by
+    rw [Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul]
+    simp [Nat.Prime.factorization_self, Nat.prime_two]
+  rw [h_fact] at this
+  exact this
 
 /-
 ## Part VI: Erdős's Lower Bound (1963)

--- a/proofs/Proofs/Erdos309Problem.lean
+++ b/proofs/Proofs/Erdos309Problem.lean
@@ -104,7 +104,9 @@ The denominator range has N elements.
 -/
 theorem denominatorRange_card (N : ℕ) (hN : N ≥ 1) :
     (denominatorRange N).card = N := by
-  sorry
+  simp only [denominatorRange]
+  rw [Finset.card_sdiff (Finset.singleton_subset_iff.mpr (Finset.mem_range.mpr (by omega))),
+      Finset.card_range, Finset.card_singleton]
 
 /-
 ## Part III: Representable Integers
@@ -280,8 +282,7 @@ With denominators {1, 2, 3, 4, 5, 6}, representable integers are:
 0 = (empty), 1 = 1, 2 = 1 + 1/2 + 1/3 + 1/6
 H_6 = 1 + 1/2 + 1/3 + 1/4 + 1/5 + 1/6 = 49/20 = 2.45
 -/
-example : harmonicNumber 6 = 49 / 20 := by
-  sorry
+example : harmonicNumber 6 = 49 / 20 := by native_decide
 
 /--
 **Egyptian Fraction Representation:**

--- a/proofs/Proofs/RamseyR4kExtensions.lean
+++ b/proofs/Proofs/RamseyR4kExtensions.lean
@@ -1044,9 +1044,22 @@ theorem cgms_exponentially_better :
       ∀ C > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
         C * (4 - ε) ^ k < 4 ^ k := by
   intro ε hε hε4 C hC
-  -- (4-ε)/4 < 1, so ((4-ε)/4)^k → 0
-  -- For large enough k, C * (4-ε)^k < 4^k
-  sorry
+  -- Key: (4-ε)/4 < 1 and ≥ 0, so ((4-ε)/4)^k → 0
+  have hr_nn : (0 : ℝ) ≤ (4 - ε) / 4 := by positivity
+  have hr_lt : (4 - ε) / 4 < 1 := by linarith
+  -- Find k₀ such that ((4-ε)/4)^k₀ < 1/C
+  obtain ⟨k₀, hk₀⟩ := exists_pow_lt_of_lt_one (by positivity : (0 : ℝ) < 1 / C) hr_lt
+  exact ⟨k₀, fun k hk => by
+    -- ((4-ε)/4)^k ≤ ((4-ε)/4)^k₀ < 1/C since k ≥ k₀ and base ∈ [0,1)
+    have hrk : ((4 - ε) / 4) ^ k ≤ ((4 - ε) / 4) ^ k₀ :=
+      pow_le_pow_of_le_one hr_nn (le_of_lt hr_lt) hk
+    have hrk_bound : ((4 - ε) / 4) ^ k < 1 / C := lt_of_le_of_lt hrk hk₀
+    -- Rewrite: ((4-ε)/4)^k = (4-ε)^k / 4^k
+    rw [div_pow] at hrk_bound
+    -- (4-ε)^k / 4^k < 1/C, multiply through
+    have h4k_pos : (0 : ℝ) < (4 : ℝ) ^ k := by positivity
+    rw [div_lt_div_iff h4k_pos hC, one_mul, mul_comm] at hrk_bound
+    exact hrk_bound⟩
 
 /- ═══════════════════════════════════════════════════════════════════════════════
 Part XI: OFF-DIAGONAL RAMSEY AND GRAPH RAMSEY THEORY

--- a/src/data/proofs/erdos-176/meta.json
+++ b/src/data/proofs/erdos-176/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 176,
     "erdosUrl": "https://erdosproblems.com/176",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -18,7 +18,7 @@
       "asymptotic-analysis"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 4,
     "erdosNumber": 309,
     "erdosUrl": "https://erdosproblems.com/309",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary
- Prove `cgms_exponentially_better` in RamseyR4kExtensions.lean (1→0 sorries): exponential decay argument using `exists_pow_lt_of_lt_one` and `pow_le_pow_of_le_one`
- Prove `denominatorRange_card` in Erdos309Problem.lean: cardinality of `Finset.range(N+1) \ {0}` via `Finset.card_sdiff`
- Prove `harmonicNumber 6 = 49/20` in Erdos309Problem.lean: concrete computation by `native_decide`
- Prove `spencer_power_of_two` in Erdos176Problem.lean: 2-adic valuation of `2^t` is `t` via `Nat.factorization_pow`

## Sorry delta
| File | Before | After |
|------|--------|-------|
| RamseyR4kExtensions.lean | 1 | 0 |
| Erdos309Problem.lean | 6 | 4 |
| Erdos176Problem.lean | 2 | 1 |

## Note
Docker was unavailable for local build verification. Proofs are constructed from standard Mathlib lemmas and should compile, but CI verification is needed.

## Test plan
- [ ] Verify `Proofs.RamseyR4kExtensions` builds
- [ ] Verify `Proofs.Erdos309Problem` builds
- [ ] Verify `Proofs.Erdos176Problem` builds

Generated by researcher-11