### PR TITLE
fix: correct sorry/line counts in 6 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -19,9 +19,9 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "axiomCount": 3,
-    "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 5 sorries in analysis lemmas (liminf/limsup properties, Fekete's lemma, limit characterizations).",
+    "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 4 sorries in analysis lemmas (liminf/limsup properties, Fekete's lemma, limit characterizations).",
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-235/meta.json
+++ b/src/data/proofs/erdos-235/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 0,
     "erdosNumber": 235,
     "erdosUrl": "https://erdosproblems.com/235",
     "erdosProblemStatus": "solved",
@@ -56,7 +56,7 @@
       "mertens_third axiom"
     ],
     "axiomCount": 1,
-    "lineCount": 310,
+    "lineCount": 329,
     "assumptions": "11 axiom(s) and 4 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -201,7 +201,7 @@
       "Topology"
     ],
     "namespace": "Erdos235",
-    "lineCount": 310,
+    "lineCount": 329,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 14

--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -18,7 +18,7 @@
       "asymptotic-analysis"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 309,
     "erdosUrl": "https://erdosproblems.com/309",
     "erdosProblemStatus": "solved",
@@ -67,7 +67,7 @@
       }
     ],
     "axiomCount": 7,
-    "lineCount": 352,
+    "lineCount": 359,
     "assumptions": "7 axiom(s) and 6 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -224,7 +224,7 @@
       "Real"
     ],
     "namespace": "Erdos309",
-    "lineCount": 352,
+    "lineCount": 359,
     "axiomCount": 7,
     "theoremCount": 12,
     "definitionCount": 7

--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 476,
     "erdosUrl": "https://erdosproblems.com/476",
     "erdosProblemStatus": "solved",
@@ -54,7 +54,7 @@
       "combinatorial_nullstellensatz axiom: polynomial method"
     ],
     "axiomCount": 6,
-    "lineCount": 302,
+    "lineCount": 303,
     "assumptions": "7 axiom(s) and 5 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -179,7 +179,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos476",
-    "lineCount": 302,
+    "lineCount": 303,
     "axiomCount": 6,
     "theoremCount": 9,
     "definitionCount": 4

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 6,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",
@@ -70,7 +70,7 @@
       "bound_is_optimal: matching lower bound (partially proved)"
     ],
     "axiomCount": 6,
-    "lineCount": 291,
+    "lineCount": 298,
     "assumptions": "6 axiom(s) and 8 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -198,7 +198,7 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 291,
+    "lineCount": 298,
     "axiomCount": 6,
     "theoremCount": 10,
     "definitionCount": 15

--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -17,7 +17,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 877,
     "erdosUrl": "https://erdosproblems.com/877",
     "erdosProblemStatus": "solved",
@@ -39,7 +39,7 @@
       "erdos_877_solved: combined resolution theorem"
     ],
     "axiomCount": 5,
-    "lineCount": 303,
+    "lineCount": 307,
     "assumptions": "5 axiom(s) and 5 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
@@ -179,7 +179,7 @@
       "Finset"
     ],
     "namespace": "Erdos877",
-    "lineCount": 303,
+    "lineCount": 307,
     "axiomCount": 5,
     "theoremCount": 9,
     "definitionCount": 6


### PR DESCRIPTION
## Fix

Correct stale sorry counts and line counts in 6 gallery meta.json files after recent research proved sorries.

## Evidence

| Slug | Sorries (before→after) | Lines (before→after) |
|------|----------------------|---------------------|
| erdos-117-oq-01 | 5→4 | OK |
| erdos-235 | 4→0 | 310→329 |
| erdos-309 | 4→3 | 352→359 |
| erdos-476 | 5→4 | 302→303 |
| erdos-490 | 8→6 | 291→298 |
| erdos-877 | 5→4 | 303→307 |

Verified by grep-counting `sorry` occurrences in each Lean source file and comparing to meta.json values.

---
Automated fix by lean-mechanic agent.