### PR TITLE
fix: correct sorry counts in 36 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -18,7 +18,7 @@
       "hadwiger-nelson"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1070,
     "erdosUrl": "https://erdosproblems.com/1070",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,14 +37,14 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",
     "erdosPrizeValue": "$500",
     "axiomCount": 8,
     "lineCount": 177,
-    "assumptions": "8 axiom(s) and 5 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "8 axiom(s) and 5 sorries(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-176/meta.json
+++ b/src/data/proofs/erdos-176/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 176,
     "erdosUrl": "https://erdosproblems.com/176",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-179/meta.json
+++ b/src/data/proofs/erdos-179/meta.json
@@ -17,13 +17,13 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 10,
     "erdosNumber": 179,
     "erdosUrl": "https://erdosproblems.com/179",
     "erdosProblemStatus": "solved",
     "axiomCount": 8,
     "lineCount": 235,
-    "assumptions": "8 axiom(s) and 10 sorry(s). See the Lean source for details.",
+    "assumptions": "8 axiom(s) and 10 sorries(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-195/meta.json
+++ b/src/data/proofs/erdos-195/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 195,
     "erdosUrl": "https://erdosproblems.com/195",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 277,
     "erdosUrl": "https://erdosproblems.com/277",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-290/meta.json
+++ b/src/data/proofs/erdos-290/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 290,
     "erdosUrl": "https://erdosproblems.com/290",
     "erdosProblemStatus": "solved",
@@ -63,7 +63,7 @@
     ],
     "axiomCount": 9,
     "lineCount": 266,
-    "assumptions": "9 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "assumptions": "9 axiom(s) and 2 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #290: Denominator Non-Monotonicity in Harmonic Sums**\n\nThis problem concerns a counterintuitive phenomenon in the arithmetic of partial harmonic sums. The partial harmonic sum Σ_{n=a}^{b} 1/n is a rational number p/q in lowest terms. One might expect that extending the sum by one more term (adding 1/(b+1)) would increase the denominator, since we are adding a fraction with a new denominator. But sometimes the opposite occurs: the denominator actually DECREASES.\n\n**The Motivating Example:**\nΣ_{n=3}^{5} 1/n = 1/3 + 1/4 + 1/5 = 47/60 (denominator 60)\nΣ_{n=3}^{6} 1/n = 47/60 + 1/6 = 57/60 = 19/20 (denominator 20)\n\nAdding 1/6 caused the denominator to drop from 60 to 20! The mechanism is GCD cancellation: 47/60 + 1/6 = 57/60, and gcd(57, 60) = 3, so the fraction reduces to 19/20.\n\nErdős asked: does this phenomenon always occur? For any starting point a, must there always exist some b where adding the next term decreases the denominator?\n\n**van Doorn's Resolution (2024):**\nIn a paper posted to arXiv (2411.03073), van Doorn proved the answer is YES. His key innovation was an explicit construction based on powers of 3: for a ∈ (3ᵏ, 3ᵏ⁺¹], taking b = 2·3ᵏ⁺¹ − 1 always gives a denominator drop. This yields the linear upper bound b(a) < 4.374a. He also proved a logarithmic lower bound b(a) > a + 0.54 log a, showing the first drop cannot happen immediately.\n\nThe connection to prime factorization is central: the denominator of a harmonic sum divides the LCM of the summation range, and denominator drops occur when adding a new term enables cancellation in the prime factorization of the numerator-denominator pair. Powers of 3 play a special role because the prime 3 has controlled multiplicity in nearby integers.",

--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -17,7 +17,7 @@
       "distinct-sums"
     ],
     "badge": "axiom",
-    "sorries": 15,
+    "sorries": 16,
     "erdosNumber": 357,
     "erdosUrl": "https://erdosproblems.com/357",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 4,
     "erdosNumber": 378,
     "erdosUrl": "https://erdosproblems.com/378",
     "erdosProblemStatus": "solved",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 326,
-    "assumptions": "10 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "assumptions": "10 axiom(s) and 4 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #378**\n\nThis problem concerns the distribution of squarefree binomial coefficients in Pascal's triangle.\n\n**The Question:**\nFor a given r >= 0, does the density of integers n such that C(n,k) is squarefree for at least r values of 1 <= k < n exist? Is this density positive?\n\n**Resolution:**\nGranville and Ramare (1996) proved that the density eta_m of n having exactly 2m+2 squarefree binomial coefficients exists for each m. Aggarwal and Cambie observed that this resolves Erdos's question: the desired density is 1 - sum of eta_m for small m, which is positive.",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",
@@ -61,7 +61,7 @@
     ],
     "axiomCount": 12,
     "lineCount": 221,
-    "assumptions": "12 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "12 axiom(s) and 3 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős Problem #392 asks about the most efficient way to express n! as a product of bounded factors. Given the constraint that each factor aᵢ ≤ n², what is the minimum number of factors needed?\n\nThe answer involves a beautiful interplay between Stirling's approximation and factor pairing. Stirling tells us log(n!) ≈ n log n, so if each factor is at most n², contributing at most 2 log n to the logarithm, we need roughly (n log n)/(2 log n) = n/2 factors.\n\nCambie observed that the problem with bound n² can be reduced to the variant with bound n via factor pairing. If a₁...aₜ = n! with each aᵢ ≤ n, define a'ᵢ = a₂ᵢ₋₁ · a₂ᵢ. Then each a'ᵢ ≤ n² and we have roughly t/2 factors. The variant with bound n is solved by a greedy algorithm: use n as often as possible, then n-1, and so on.",

--- a/src/data/proofs/erdos-454/meta.json
+++ b/src/data/proofs/erdos-454/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 454,
     "erdosUrl": "https://erdosproblems.com/454",
     "erdosProblemStatus": "open",
@@ -104,7 +104,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 302,
-    "assumptions": "3 axiom(s) and 5 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 4 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős Problem #454 concerns the behavior of symmetric prime sums, arising from Erdős and Graham's 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory.' The function f(n) computes the minimum of p_{n+i} + p_{n-i} over all i < n. If primes were perfectly evenly spaced (like an arithmetic progression), this minimum would equal exactly 2p_n for all n.\n\nCarl Pomerance (born 1947), a distinguished American number theorist known for his work on computational number theory and the AKS primality test, studied this problem in his 1979 paper 'The Prime Number Graph' in Mathematics of Computation. He introduced a graph structure on natural numbers where vertices n and m are connected if p_n + p_m is itself prime. Using properties of this graph — specifically, bounding its chromatic number — Pomerance proved that the limsup of f(n) - 2p_n is at least 2. This means infinitely many n have the property that ALL symmetric prime sums p_{n+i} + p_{n-i} exceed 2p_n + 2.\n\nThe open question is whether these deviations can be arbitrarily large — that is, whether the limsup is infinite. This connects to deep questions about prime gap irregularity. By the Prime Number Theorem (Hadamard and de la Vallée-Poussin, 1896), p_n ~ n log n, so consecutive prime gaps average about log(p_n). But gaps fluctuate wildly: Maier's theorem (1985) shows that short-interval prime counts deviate from their expected values, suggesting the kind of irregularity that could produce large deviations. The Cramér conjecture (1936) predicts gaps as large as (log p_n)^2, which would give deviations of order (log p_n)^2 — far from bounded.",

--- a/src/data/proofs/erdos-545/meta.json
+++ b/src/data/proofs/erdos-545/meta.json
@@ -15,13 +15,13 @@
       "combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 545,
     "erdosUrl": "https://erdosproblems.com/545",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
     "lineCount": 224,
-    "assumptions": "2 axiom(s) and 12 sorry(s). See the Lean source for details.",
+    "assumptions": "2 axiom(s) and 12 sorries(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -17,13 +17,13 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 6,
     "erdosNumber": 548,
     "erdosUrl": "https://erdosproblems.com/548",
     "erdosProblemStatus": "open",
     "axiomCount": 9,
     "lineCount": 320,
-    "assumptions": "9 axiom(s) and 6 sorry(s). See the Lean source for details.",
+    "assumptions": "9 axiom(s) and 6 sorries(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-559/meta.json
+++ b/src/data/proofs/erdos-559/meta.json
@@ -16,13 +16,13 @@
       "extremal-combinatorics"
     ],
     "badge": "mathlib",
-    "sorries": 9,
+    "sorries": 10,
     "erdosNumber": 559,
     "erdosUrl": "https://erdosproblems.com/559",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
     "lineCount": 238,
-    "assumptions": "No axioms. 10 sorry(s) remain in the formalization.",
+    "assumptions": "No axioms. 10 sorries(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 17,
     "erdosNumber": 610,
     "erdosUrl": "https://erdosproblems.com/610",
     "erdosProblemStatus": "open",
@@ -89,7 +89,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 223,
-    "assumptions": "1 axiom(s) and 17 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom(s) and 17 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Clique Transversals: Hitting Every Maximal Clique**\n\nA clique transversal is a set of vertices that intersects every maximal clique in a graph. The clique transversal number τ(G) — the minimum size of such a set — was introduced by Erdős, Gallai, and Tuza in the context of extremal graph theory.\n\n**The Erdős-Gallai-Tuza Bound**\n\nThe trio proved τ(G) ≤ n - √(2n) + O(1) for any n-vertex graph. The proof uses Turán's theorem on an auxiliary 'clique-intersection graph': vertices of G that share no maximal clique form an independent set of size ≥ √(2n), and removing this independent set leaves a transversal. The bound is constructive — the greedy algorithm finds such a transversal in polynomial time.\n\n**Near-Tightness**\n\nConstructions (Paley-type graphs, random graphs) achieve τ ≈ n - √(2n), showing the √(2n) coefficient is essentially correct. This means improving the bound requires new ideas, not just better analysis of existing arguments.\n\n**The Triangle-Free Connection**\n\nThe deep conjecture τ(G) ≤ n - f(n), where f(n) is the minimum independence number among triangle-free n-vertex graphs, would improve √(2n) to √(n log n). Kim's celebrated theorem (1995) establishes f(n) = Θ(√(n log n)) via the semi-random method (Rödl nibble), proving R(3,k) = Θ(k²/log k). The logarithmic improvement factor √(log n) represents a qualitative jump — the difference between constant and growing coefficients of √n.\n\n**Special Graph Classes**\n\nFor bipartite graphs, τ equals the vertex cover number (König's theorem). For chordal graphs, the clique tree structure enables polynomial computation. For perfect graphs, LP duality gives integrality. The general case remains the frontier.",

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -20,7 +20,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 13,
+    "sorries": 15,
     "erdosNumber": 626,
     "erdosUrl": "https://erdosproblems.com/626",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 13,
+    "sorries": 16,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",
@@ -58,7 +58,7 @@
     ],
     "axiomCount": 8,
     "lineCount": 237,
-    "assumptions": "8 axiom(s) and 16 sorry(s).",
+    "assumptions": "8 axiom(s) and 16 sorries(s).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 10,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 15,
     "erdosNumber": 630,
     "erdosUrl": "https://erdosproblems.com/630",
     "erdosProblemStatus": "solved",
@@ -52,7 +52,7 @@
     ],
     "axiomCount": 11,
     "lineCount": 247,
-    "assumptions": "11 axiom(s) and 15 sorry(s).",
+    "assumptions": "11 axiom(s) and 15 sorries(s).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 695,
     "erdosUrl": "https://erdosproblems.com/695",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "mathlib",
-    "sorries": 12,
+    "sorries": 15,
     "erdosNumber": 715,
     "erdosUrl": "https://erdosproblems.com/715",
     "erdosProblemStatus": "solved",
@@ -83,7 +83,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 210,
-    "assumptions": "No axioms. 15 sorry(s) remain in the formalization."
+    "assumptions": "No axioms. 15 sorries(s) remain in the formalization."
   },
   "overview": {
     "historicalContext": "This problem was posed by Berge and Sauer at the 6th Hungarian Combinatorial Colloquium (1976). It asks whether regular graphs of sufficient degree must contain regular subgraphs of smaller degree. Tashkinov (1982) gave the definitive answer: every 4-regular graph contains a 3-regular subgraph. This was strengthened by Alon, Friedland, and Kalai (1984), who showed that every 4-regular graph plus a single edge already contains a 3-regular subgraph, immediately implying the result for all r ≥ 5.\n\nThe threshold r = 4 is sharp: K₄ is 3-regular but has no proper 3-regular subgraph (removing any edge drops some degree below 3). The Petersen graph (10 vertices, 3-regular) is another minimal example. The general question — for which (r, k) pairs does every r-regular graph contain a k-regular subgraph? — remains an active research area for k ≥ 4.",

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -17,7 +17,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 744,
     "erdosUrl": "https://erdosproblems.com/744",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 4,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -18,7 +18,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "erdosNumber": 76,
     "erdosUrl": "https://erdosproblems.com/76",
     "erdosProblemStatus": "solved",
@@ -92,7 +92,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 246,
-    "assumptions": "3 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 4 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Ramsey's theorem (1930) guarantees that any 2-coloring of $K_6$ contains a monochromatic triangle, since $R(3,3) = 6$. This qualitative existence result naturally leads to quantitative questions: how many monochromatic triangles must appear, and how many can be packed edge-disjointly?\n\nErdős, Faudree, and Ordman posed Problem #76: in any 2-coloring of $K_n$, what is the minimum number of edge-disjoint monochromatic triangles? They conjectured the answer is $(1 + o(1)) n^2/12$, achieved by the balanced bipartition coloring — partition $[n]$ into two equal halves, color within-half edges blue and between-half edges red. The red graph $K_{n/2, n/2}$ is bipartite (triangle-free), and each blue clique $K_{n/2}$ packs $\\approx (n/2)(n/2-1)/6 \\approx n^2/24$ edge-disjoint triangles via Steiner triple systems (Kirkman 1847). Two halves yield $n^2/12$ total.\n\nThe conjecture was confirmed by Vytautas Gruslys and Shoham Letzter in their 2020 Combinatorica paper. Their proof applies a variant of the Szemerédi regularity lemma (1978) to decompose the 2-colored $K_n$ into structured regular pairs, then uses a greedy-absorption method to build the packing. They also established a stability result: any coloring achieving the bound must be close to the balanced bipartition (up to isomorphism).\n\nThe problem connects Ramsey theory (existence of monochromatic subgraphs), extremal graph theory (extremal constructions and stability), packing theory (edge-disjointness constraints), and design theory (Steiner triple systems for optimal packings).",

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "erdosNumber": 781,
     "erdosUrl": "https://erdosproblems.com/781",
     "erdosProblemStatus": "disproved",

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 6,
     "erdosNumber": 820,
     "erdosUrl": "https://erdosproblems.com/820",
     "erdosProblemStatus": "open",
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 285,
-    "assumptions": "3 axiom(s) and 6 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 6 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**The GCD Problem for Exponential Sequences**\n\nThis problem originates from Erdős's 1974 paper \"Remarks on some problems in number theory\" in Mathematica Balkanica. The core question studies when powers of different bases minus one are coprime.\n\n**The Function H(n)**\n\nDefine H(n) as the smallest l such that there exists k < l with gcd(k^n - 1, l^n - 1) = 1. This measures how \"rare\" coprimality is among these exponential expressions.\n\n**Computed Values**\n\nFor small n: H(1)=3, H(2)=3, H(3)=3, H(4)=6, H(5)=3, H(6)=18, H(7)=3, H(8)=6, H(9)=3, H(10)=12. The value H(n)=3 occurs frequently, corresponding to gcd(2^n-1, 3^n-1)=1.\n\n**Progress**\n\n1. **Erdős (1974):** Proved H(n) > exp(n^{c/(log log n)²}) for infinitely many n\n2. **van Doorn:** Improved to H(n) > exp(n^{c/log log n}) infinitely often\n3. **OEIS A263647:** Catalogues n where gcd(2^n-1, 3^n-1)=1\n\nThe main conjectures remain OPEN.",

--- a/src/data/proofs/erdos-835/meta.json
+++ b/src/data/proofs/erdos-835/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 835,
     "erdosUrl": "https://erdosproblems.com/835",
     "erdosProblemStatus": "solved",
@@ -45,7 +45,7 @@
     ],
     "axiomCount": 10,
     "lineCount": 197,
-    "assumptions": "10 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "assumptions": "10 axiom(s) and 2 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "This problem was posed by Paul Erdős and Moshe Rosenfeld. It connects to the broader theory of Johnson graphs $J(n,k)$, named after Selmer M. Johnson who studied them in the context of error-correcting codes in the 1960s. Johnson graphs are a fundamental family in algebraic graph theory — they are distance-transitive and their eigenvalues are given by Eberlein polynomials (dual Hahn polynomials). The chromatic number question for Johnson graphs relates to the Kneser graph framework: the Kneser graph $K(n,k)$ has the same vertex set but connects disjoint (rather than nearly-equal) subsets. Lovász's celebrated 1978 proof that $\\chi(K(n,k)) = n - 2k + 2$ using algebraic topology was a landmark of topological combinatorics, but the Johnson graph chromatic problem is structurally different and resists similar techniques. Erdős and Rosenfeld specifically asked whether the $k$-subsets of $\\{1,\\ldots,2k\\}$ can be $(k+1)$-colored so that every $(k+1)$-subset sees all colors — a 'rainbow' condition equivalent to $\\chi(J(2k,k)) = k + 1$. Computational verification (for $3 \\leq k \\leq 8$) shows the answer is NO: the chromatic number always exceeds $k+1$ except for the trivial case $k = 2$.",

--- a/src/data/proofs/erdos-860/meta.json
+++ b/src/data/proofs/erdos-860/meta.json
@@ -20,7 +20,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 3,
     "erdosNumber": 860,
     "erdosUrl": "https://erdosproblems.com/860",
     "erdosProblemStatus": "open",
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 5,
     "lineCount": 206,
-    "assumptions": "5 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "5 axiom(s) and 3 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős and Pomerance posed this problem in 1980 in their paper on matching natural numbers with distinct multiples. Given the first $\\pi(n)$ primes $p_1 < p_2 < \\cdots < p_{\\pi(n)}$, the function $h(n)$ measures the minimum interval length guaranteeing that any interval $(m, m+h(n)]$ contains distinct integers $a_1, \\ldots, a_{\\pi(n)}$ with $p_i \\mid a_i$. This is a covering-by-multiples problem that connects prime distribution to combinatorial matching theory. Erdős and Selfridge established the linear lower bound $h(n) > (3-o(1))n$ by analyzing worst-case intervals where large primes (near $n$) have sparse multiples. Ruzsa strengthened this to $h(n)/n \\to \\infty$, showing superlinear growth via the Chinese Remainder Theorem — by constructing starting points $m$ where small primes 'block' many interval elements, forcing longer intervals. For the upper bound, Erdős and Pomerance proved $h(n) \\leq C n^{3/2}/(\\log n)^{1/2}$ using a greedy assignment strategy. The problem appears as B32 in Guy's 'Unsolved Problems in Number Theory.' The gap between superlinear and $n^{3/2}$ remains one of the most natural open questions about the interaction between prime structure and combinatorial covering.",

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -18,7 +18,7 @@
       "popcount"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 875,
     "erdosUrl": "https://erdosproblems.com/875",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -18,7 +18,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 9,
+    "sorries": 11,
     "erdosNumber": 895,
     "erdosUrl": "https://erdosproblems.com/895",
     "erdosProblemStatus": "solved",
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 188,
-    "assumptions": "No axioms. 11 sorry(s) remain in the formalization.",
+    "assumptions": "No axioms. 11 sorries(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -17,7 +17,7 @@
       "classical"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 8,
     "erdosNumber": 898,
     "erdosUrl": "https://erdosproblems.com/898",
     "erdosProblemStatus": "solved",
@@ -49,7 +49,7 @@
     ],
     "axiomCount": 11,
     "lineCount": 252,
-    "assumptions": "11 axiom(s) and 8 sorry(s). See the Lean source for details.",
+    "assumptions": "11 axiom(s) and 8 sorries(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-900/meta.json
+++ b/src/data/proofs/erdos-900/meta.json
@@ -18,7 +18,7 @@
       "phase-transition"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 900,
     "erdosUrl": "https://erdosproblems.com/900",
     "erdosProblemStatus": "solved",
@@ -52,7 +52,7 @@
     "relatedProblems": [],
     "axiomCount": 19,
     "lineCount": 286,
-    "assumptions": "19 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "19 axiom(s) and 3 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #900: Longest Path in Sparse Random Graphs**\n\nThe study of random graphs began with the seminal 1960 paper of Paul Erdős and Alfréd Rényi, \"On the evolution of random graphs,\" which introduced the $G(n, m)$ model and discovered the **giant component phase transition** at $m = n/2$ (average degree 1). Below this threshold, $G(n, cn)$ is a forest of small trees; above it, a unique giant component of size $\\Theta(n)$ emerges.\n\nErdős asked (c. 1982, [Er82e]): how long is the longest path in $G(n, cn)$ when $c > 1/2$? The giant component has $\\Theta(n)$ vertices, but having many vertices does not guarantee long paths — the component could be bushy rather than elongated.\n\n**Miklós Ajtai, János Komlós, and Endre Szemerédi** resolved this in 1981 in the first volume of *Combinatorica*. They proved there exists a function $f:(1/2, \\infty) \\to (0,1)$ such that $G(n, cn)$ has whp a path of length $(f(c) + o(1))n$, with $f(c) \\to 0$ as $c \\to 1/2^+$ and $f(c) \\to 1$ as $c \\to \\infty$.\n\nThe proof introduced the **rotation-extension technique** (building on Pósa's 1976 method): start with a DFS path, then repeatedly rotate endpoints and extend until the path covers all reachable vertices. The **expansion property** of random graphs — every small vertex set has many external neighbors — ensures this process terminates with a path of length proportional to the giant component.\n\nThe Hamiltonian path threshold was later determined by Komlós and Szemerédi (1983): $G(n, p)$ has a Hamiltonian path whp when $p = (\\log n + \\log\\log n + \\omega(1))/(2n)$, connecting to the minimum degree condition.\n\nThe AKS theorem exemplifies the **probabilistic method** in combinatorics: random graphs achieve near-optimal path lengths, answering a question about deterministic graph structure through probability.",

--- a/src/data/proofs/erdos-934/meta.json
+++ b/src/data/proofs/erdos-934/meta.json
@@ -18,7 +18,7 @@
       "2K2-free"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 8,
     "erdosNumber": 934,
     "erdosUrl": "https://erdosproblems.com/934",
     "erdosProblemStatus": "solved",
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 11,
     "lineCount": 262,
-    "assumptions": "11 axiom(s) and 8 sorry(s). Sorries: h definition existence (line 86), h_1_upper_bound (line 99), h_1_lower_bound (line 103), two_separated_is_2K2 (line 114), erdos_nesetril_conjecture_proved (line 127), h_mono_d (line 175), h_mono_t (line 180), h_polynomial_growth (line 185)."
+    "assumptions": "11 axiom(s) and 8 sorries(s). Sorries: h definition existence (line 86), h_1_upper_bound (line 99), h_1_lower_bound (line 103), two_separated_is_2K2 (line 114), erdos_nesetril_conjecture_proved (line 127), h_mono_d (line 175), h_mono_t (line 180), h_polynomial_growth (line 185)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #934** was posed by Erdős and Nešetřil, studying edge separation in bounded-degree graphs.\n\n**Historical Development:**\n- **1983 (Bermond-Bond-Paoli-Peyrat):** Conjectured h_2(d) ≤ 5d²/4 + 1, with equality for even d.\n- **1988 (Erdős):** Wrote 'This problem seems interesting only if there is a nice expression for h_t(d).'\n- **1990 (Chung-Gyárfás-Tuza-Trotter):** Proved h_2(d) = ⌊5d²/4⌋ + 1 exactly.\n- **2022 (Cambie et al.):** Proved h_3(3) = 23, conjectured h_3(d) ≤ d³-d²+d+2, and established general bounds.\n\nThe problem connects to 2K₂-free graphs and line graph diameter problems.",

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -19,7 +19,7 @@
       "extremal-configuration"
     ],
     "badge": "wip",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 94,
     "erdosUrl": "https://erdosproblems.com/94",
     "erdosProblemStatus": "solved",
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 433,
-    "assumptions": "No axioms. 12 sorry(s) remain in the formalization.",
+    "assumptions": "No axioms. 12 sorries(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-961/meta.json
+++ b/src/data/proofs/erdos-961/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 961,
     "erdosUrl": "https://erdosproblems.com/961",
     "erdosProblemStatus": "open",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 262,
-    "assumptions": "4 axiom(s) and 3 sorry(s). Sorries: f_sublinear (line 147), answer(sorry) in polylog_conjecture_open (line 173), f_le_smooth_gap_succ (line 206)."
+    "assumptions": "4 axiom(s) and 3 sorries(s). Sorries: f_sublinear (line 147), answer(sorry) in polylog_conjecture_open (line 173), f_le_smooth_gap_succ (line 206)."
   },
   "overview": {
     "historicalContext": "This problem connects to a classical result by Sylvester (1892) and Schur (1929) showing that among any $k$ consecutive integers greater than $k$, at least one has a prime factor greater than $k$. Erdős published this as Problem #961, asking for better bounds on $f(k)$.\n\nErdős himself improved the bound in 1955 [Er55d] to $f(k) < 3k/\\log k$, showing sublinear growth. The strongest known result came from Jutila (1974) [Ju74] and independently Ramachandra–Shorey (1973) [RaSh73], who proved $f(k) \\ll \\frac{\\log\\log\\log k}{\\log\\log k} \\cdot \\frac{k}{\\log k}$ using sieve methods.\n\nThe problem is essentially equivalent to Problem #683, which asks about gaps between smooth numbers. The conjecture that $f(k)$ grows only polylogarithmically—$f(k) \\ll (\\log k)^C$—remains wide open. The gap between the known $O(k / \\text{polylog})$ and conjectured $O(\\text{polylog})$ is enormous.\n\nSmooth numbers play a central role in computational number theory: the quadratic sieve and number field sieve factoring algorithms depend on finding smooth numbers in specific ranges. Understanding the distribution of smooth numbers in short intervals is both a fundamental problem in analytic number theory and a question of practical importance.\n\n**Status**: OPEN — Polylogarithmic conjecture unresolved. Best known bound: $f(k) \\ll \\frac{\\log\\log\\log k}{\\log\\log k} \\cdot \\frac{k}{\\log k}$.",

--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -20,7 +20,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

- Corrects sorry count mismatches in 36 gallery meta.json files detected by the auditor
- 35 proofs had **undercounted** sorries (inline `sorry` in expressions like `Nat.find (⟨..., sorry⟩)` missed by the metadata generator)
- 1 proof (erdos-454) had **overcounted** sorries after recent research proved one
- Also updates assumptions text where it referenced stale sorry counts

## Test plan

- [x] Verified each sorry count against actual `sorry` occurrences in Lean source files (comment-aware counting)
- [x] Checked status/badge consistency (no changes needed beyond sorry counts)
- [ ] `pnpm build` gallery renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)