### PR TITLE
Research: prove iterated totient convergence and binomial identity

### DIFF
--- a/proofs/Proofs/Erdos1087Problem.lean
+++ b/proofs/Proofs/Erdos1087Problem.lean
@@ -248,9 +248,13 @@ An n-point set has C(n,4) = n(n-1)(n-2)(n-3)/24 quadruples.
 -/
 theorem total_quadruples (n : ℕ) (hn : n ≥ 4) :
     (n.choose 4) = n * (n-1) * (n-2) * (n-3) / 24 := by
-  rw [Nat.choose_eq_factorial_div_factorial (by omega : 4 ≤ n)]
-  ring_nf
-  sorry -- arithmetic details
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 4 := ⟨n - 4, by omega⟩
+  simp only [show m + 4 - 1 = m + 3 from by omega,
+             show m + 4 - 2 = m + 2 from by omega,
+             show m + 4 - 3 = m + 1 from by omega]
+  rw [Nat.choose_eq_descFactorial_div_factorial]
+  simp [Nat.descFactorial, Nat.factorial]
+  ring
 
 /--
 **Trivial Upper Bound:**

--- a/proofs/Proofs/Erdos408Problem.lean
+++ b/proofs/Proofs/Erdos408Problem.lean
@@ -75,6 +75,27 @@ f(n) = min{k : φₖ(n) = 1}
 This is the number of steps to reach 1.
 -/
 
+/-- Shifting: φ_{k+1}(n) = φ_k(φ(n)). This allows decomposing iterations. -/
+private lemma iteratedTotient_shift (k n : ℕ) :
+    iteratedTotient (k + 1) n = iteratedTotient k n.totient := by
+  induction k with
+  | zero => rfl
+  | succ k ih => exact congr_arg Nat.totient ih
+
+/-- For n > 1, iterated totient eventually reaches 1.
+    Proof: φ(n) < n for n > 1 (Nat.totient_lt), and φ(n) ≥ 1 for n ≥ 1
+    (Nat.totient_pos), so by strong induction the sequence terminates. -/
+private theorem iteratedTotient_reaches_one (n : ℕ) (hn : n > 1) :
+    ∃ k, iteratedTotient k n = 1 := by
+  induction n using Nat.strongRecOn with
+  | _ n ih =>
+    have htot_lt := Nat.totient_lt n hn
+    have htot_pos : 0 < n.totient := Nat.totient_pos (by omega)
+    by_cases heq : n.totient = 1
+    · exact ⟨1, heq⟩
+    · obtain ⟨k, hk⟩ := ih n.totient htot_lt (by omega)
+      exact ⟨k + 1, by rw [iteratedTotient_shift]; exact hk⟩
+
 /--
 **Iteration Length** f(n):
 The minimum number of totient iterations to reach 1.
@@ -84,17 +105,22 @@ For n ≥ 1, we always have f(n) < ∞ since:
 - Eventually we reach φₖ(n) = 1
 -/
 noncomputable def iterationLength (n : ℕ) : ℕ :=
-  if n ≤ 1 then 0
-  else Nat.find (existence_proof n)
-where
-  existence_proof (n : ℕ) : ∃ k, φ[k](n) = 1 := by
-    sorry  -- Existence follows from φ(m) < m for m > 1
+  if h : n ≤ 1 then 0
+  else Nat.find (iteratedTotient_reaches_one n (by omega))
 
 /-- Notation for iteration length. -/
 notation "f(" n ")" => iterationLength n
 
-/-- For n > 1: f(n) ≥ 1 -/
-axiom iterationLength_pos (n : ℕ) (hn : n > 1) : f(n) ≥ 1
+/-- For n > 1: f(n) ≥ 1. Since φ₀(n) = n ≠ 1, the minimum k is at least 1. -/
+theorem iterationLength_pos (n : ℕ) (hn : n > 1) : f(n) ≥ 1 := by
+  unfold iterationLength
+  rw [dif_neg (by omega)]
+  suffices h : Nat.find (iteratedTotient_reaches_one n (by omega)) ≠ 0 by omega
+  intro h0
+  have hspec := Nat.find_spec (iteratedTotient_reaches_one n (by omega))
+  rw [h0] at hspec
+  change n = 1 at hspec
+  omega
 
 /-
 ## Part III: Pillai's Bounds (1929)


### PR DESCRIPTION
## Summary
- Prove iterated totient eventually reaches 1 (Erdos408): eliminates 1 sorry, converts 1 axiom to theorem
- Prove binomial coefficient identity C(n,4) = n(n-1)(n-2)(n-3)/24 (Erdos1087): eliminates 1 sorry

## Progress

### Erdos408 (Iterated Totient Function)
- **iteratedTotient_shift**: New lemma proving φ_{k+1}(n) = φ_k(φ(n)) by induction on k
- **iteratedTotient_reaches_one**: Proves iterated totient reaches 1 for n > 1 via strong induction using `Nat.totient_lt` and `Nat.totient_pos`
- **iterationLength**: Fixed definition to use dependent if-then-else for proof access
- **iterationLength_pos**: Converted from `axiom` to `theorem` — proves f(n) ≥ 1 for n > 1

### Erdos1087 (Degenerate Quadruples)
- **total_quadruples**: Proves C(n,4) = n(n-1)(n-2)(n-3)/24 via `Nat.descFactorial` reduction after substituting n = m + 4

## Status
**Outcome**: progress
**Delta**: 2 sorries eliminated, 1 axiom converted to theorem
**Next Steps**: Docker build verification needed (Docker not available during session)

🤖 Generated by researcher-6