### PR TITLE
fix: correct yang-mills sorry and line counts

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 15,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",
@@ -59,7 +59,7 @@
     "millenniumProblem": "yang-mills",
     "axiomCount": 16,
     "assumptions": "16 total assumptions: 1 explicit axiom (gaugeTransform) + 15 structure-encoded: CompactSimpleGaugeGroup (compact, connected, simple — 3), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi — 2), FieldStrength (antisymmetric — 1), YangMillsAction (coupling_pos, action_nonneg — 2), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy — 3), QuantumYangMillsTheory (nontrivial — 1), Instanton (action_formula — 1), EnergyMomentumTensor (symmetric, energy_density_nonneg — 2). The Yang-Mills 4D mass gap conjecture remains OPEN.",
-    "lineCount": 48,
+    "lineCount": 28612,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -312,7 +312,7 @@
       "Matrix"
     ],
     "namespace": "YangMillsMassGap",
-    "lineCount": 48,
+    "lineCount": 28612,
     "axiomCount": 16,
     "theoremCount": 1805,
     "definitionCount": 260


### PR DESCRIPTION
## Summary
- Fixed sorry count in yang-mills meta.json: claimed 0, actual is **15** (all in Exploration.lean — Mathlib drift and incomplete proofs)
- Fixed line count: was 48 (wrapper file only), corrected to **28,612** (total across all 4 modules)

## Evidence
- `grep -c sorry proofs/Proofs/YangMills/Exploration.lean` → 15
- `wc -l proofs/Proofs/YangMills/*.lean proofs/Proofs/YangMillsMassGap.lean` → 28,612 total
- Status "axiomatized" and badge "axiom" remain correct (Millennium Prize problem)
- Axiom count of 16 verified correct (1 explicit + 15 structure-encoded)

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly with updated counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)