### PR TITLE
fix: correct sperner-ndim badge to wip (1 sorry) and reopen issue #7965

### DIFF
--- a/src/data/proofs/sperner-ndim/meta.json
+++ b/src/data/proofs/sperner-ndim/meta.json
@@ -19,7 +19,7 @@
       "parity-argument",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "originalContributions": [
       "Freudenthal simplex vertex computation via countPerm",


### PR DESCRIPTION
## Summary

Follow-up fixes for two issues flagged during review of PR #8028 (n-dimensional Sperner's lemma, merged 2026-03-29):

- **Badge mismatch**: `src/data/proofs/sperner-ndim/meta.json` had `"badge": "original"` despite `"sorries": 1` and `"status": "formalized"`. All gallery entries with `badge: "original"` have 0 sorries. Corrected to `"badge": "wip"`.
- **Premature issue closure**: PR #8028 used "Closes #7965" but issue #7965 acceptance criteria require 0 sorries. Reopened issue #7965 and added a comment explaining what remains (Freudenthal adjacency theorem + dimensional restriction for the boundary).

## Changes

- `src/data/proofs/sperner-ndim/meta.json`: `"badge": "original"` -> `"badge": "wip"`
- Reopened issue #7965 with a comment explaining the 1 remaining sorry and what is needed to close it

## Verification

- `pnpm build` passes (1m 20s, no errors)
- `pnpm exec tsc --noEmit` passes (0 type errors)

## References

- Original PR: #8028
- Issue to complete: #7965

🤖 Generated with [Claude Code](https://claude.com/claude-code)