### PR TITLE
Research: prove f(3)=3 in Erdős #107 (Happy Ending Problem)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos107Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos107Problem.lean
@@ -228,10 +228,32 @@ lemma cardSet_three_lower_bound : ∀ m ∈ CardSet 3, 3 ≤ m := by
     The upper bound requires: p ∉ convexHull ℝ {q,r} when {p,q,r} are non-collinear.
     This follows from convexHull {q,r} ⊆ affineSpan ℝ {q,r} and non-collinearity. -/
 theorem f_3_value : f 3 = 3 := by
-  sorry -- Lower bound is proved (cardSet_three_lower_bound).
-        -- Upper bound needs: any 3 non-collinear points form a convex 3-gon.
-        -- Key fact: convexHull ℝ {q,r} ⊆ affineSpan ℝ {q,r},
-        -- and ¬Collinear ℝ {p,q,r} → p ∉ affineSpan ℝ {q,r}.
+  unfold f
+  suffices h3 : (3 : ℕ) ∈ CardSet 3 by
+    exact le_antisymm (csInf_le (OrderBot.bddBelow _) h3)
+      (le_csInf ⟨3, h3⟩ cardSet_three_lower_bound)
+  -- Any 3 points in general position form a convex triangle
+  intro pts hcard hgp
+  refine ⟨pts, Finset.Subset.refl _, hcard, fun p hp habs => ?_⟩
+  -- If p ∈ convexHull of the other two points, derive contradiction
+  have h_aff := convexHull_subset_affineSpan ℝ (↑(pts.erase p) : Set _) habs
+  have hcard2 : (pts.erase p).card = 2 := by
+    rw [Finset.card_erase_of_mem hp, hcard]
+  obtain ⟨q, r, hqr, heq⟩ := Finset.card_eq_two.mp hcard2
+  have hq_er : q ∈ pts.erase p := by rw [heq]; exact Finset.mem_insert_self q {r}
+  have hr_er : r ∈ pts.erase p := by
+    rw [heq]; exact Finset.mem_insert_of_mem (Finset.mem_singleton_self r)
+  rw [heq] at h_aff
+  simp only [Finset.coe_insert, Finset.coe_singleton, SetLike.mem_coe] at h_aff
+  -- h_aff : p ∈ affineSpan ℝ {q, r}, so p, q, r are collinear
+  exact hgp p q r
+    (Finset.mem_coe.mpr hp)
+    (Finset.mem_coe.mpr (Finset.mem_erase.mp hq_er).2)
+    (Finset.mem_coe.mpr (Finset.mem_erase.mp hr_er).2)
+    (Finset.mem_erase.mp hq_er).1.symm
+    hqr
+    (Finset.mem_erase.mp hr_er).1.symm
+    (collinear_insert_of_mem_affineSpan_pair h_aff)
 
 /-- Lower bound for f(4): f(4) > 4.
     Proof: Immediate from Klein's theorem f(4) = 5. -/

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -16,7 +16,7 @@
       "convex-geometry"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 107,
     "erdosUrl": "https://erdosproblems.com/107",
     "erdosProblemStatus": "open",
@@ -55,13 +55,14 @@
       "InGeneralPosition.mono: hereditary property (proved)",
       "CardSet.mono: upward closure of threshold set (proved)",
       "cardSet_three_lower_bound: f(3) >= 3 via witness construction (proved)",
+      "f_3_value: f(3) = 3 (proved via convexHull ⊆ affineSpan + non-collinearity)",
       "Erdos-Szekeres lower bound 2^{n-2}+1 (axiomatized)",
       "Suk bound 2^{(1+o(1))n} with Filter.atTop formalization",
       "HMPT bound 2^{n+O(sqrt(n log n))} with existential constant",
       "HappyEndingConjecture as Prop (correctly open)"
     ],
     "leanFile": {
-      "lineCount": 263,
+      "lineCount": 285,
       "structureCount": 0,
       "axiomCount": 6,
       "theoremCount": 9,
@@ -72,8 +73,8 @@
     },
     "dateAdded": "2026-01-19",
     "axiomCount": 6,
-    "lineCount": 263,
-    "assumptions": "6 axiom(s) and 2 sorries(s). See the Lean source for details.",
+    "lineCount": 285,
+    "assumptions": "6 axiom(s) and 1 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -231,7 +232,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos107",
-    "lineCount": 263,
+    "lineCount": 285,
     "axiomCount": 6,
     "theoremCount": 9,
     "definitionCount": 6

--- a/src/data/research/problems/erdos-107-incomplete-01.json
+++ b/src/data/research/problems/erdos-107-incomplete-01.json
@@ -29,13 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 2 sorries eliminated (f_4_lb, f_4_ub from f_four_eq axiom). 2 sorries remain: f_finite (ES existence), f_3_value (triangle convex hull). 6 axioms all deep results.",
+    "progressSummary": "PROGRESS: f_3_value proved (1 sorry eliminated). 1 sorry remains: f_finite (Erdős-Szekeres existence). 6 axioms all deep results.",
     "builtItems": [
       "Proved cardSet_three_lower_bound in Erdos107Problem.lean:170-206",
       "Proved InGeneralPosition.mono in Erdos107Problem.lean:165-167",
       "Proved CardSet.mono in Erdos107Problem.lean:172-178",
       "Proved f_4_lb (4 < f 4) from f_four_eq axiom",
-      "Proved f_4_ub (f 4 ≤ 5) from f_four_eq axiom"
+      "Proved f_4_ub (f 4 ≤ 5) from f_four_eq axiom",
+      "Proved f_3_value : f 3 = 3 in Erdos107Problem.lean:230-256"
     ],
     "insights": [
       "5 sorries: f_three_eq (duplicate of f_3_value), f_finite, f_3_value, f_4_lb, f_4_ub",
@@ -59,7 +60,10 @@
       "For f_3_value, key missing piece: Collinear definition in Mathlib4",
       "convexHull_subset_affineSpan available - chain to Collinear is sole gap for f_3_value",
       "Docker unavailable for build verification - proof needs compilation check",
-      "f_4_lb and f_4_ub are trivial consequences of f_four_eq axiom; 2 sorries eliminated"
+      "f_4_lb and f_4_ub are trivial consequences of f_four_eq axiom; 2 sorries eliminated",
+      "f_3_value PROVED: f(3)=3 via convexHull_subset_affineSpan + collinear_insert_of_mem_affineSpan_pair + InGeneralPosition contradiction",
+      "Proof avoids decomposing pts into named elements - uses Finset.card_eq_two to extract q,r abstractly",
+      "Only 1 sorry remains: f_finite (Erdős-Szekeres existence, deep Ramsey-theoretic argument)"
     ],
     "mathlibGaps": [
       "Need Collinear for EuclideanSpace ℝ (Fin 2) — should be in Mathlib.Analysis.InnerProductSpace",


### PR DESCRIPTION
## Summary
- Prove `f_3_value : f 3 = 3` — the smallest case of the Happy Ending Problem
- Sorry count reduced from 2 to 1
- Only remaining sorry: `f_finite` (Erdős-Szekeres existence theorem, deep Ramsey-theoretic argument)

## Proof approach
Any 3 non-collinear points form a convex triangle. The proof shows each point `p` cannot lie in `convexHull ℝ` of the other two by:
1. `convexHull_subset_affineSpan`: convex hull ⊆ affine span
2. `collinear_insert_of_mem_affineSpan_pair`: if p ∈ affineSpan {q,r} then {p,q,r} are collinear
3. Contradiction with `InGeneralPosition` hypothesis

## Files modified
- `proofs/Proofs/Stubs/Erdos107Problem.lean` — proof of `f_3_value`
- `src/data/proofs/erdos-107/meta.json` — updated sorry count, line count, contributions
- `src/data/research/problems/erdos-107-incomplete-01.json` — knowledge update

## Status
**Outcome**: progress (1 sorry eliminated)
**Note**: Docker unavailable for build verification — proof needs compilation check

🤖 Generated by researcher-6