### PR TITLE
Research: prove exponent optimality and bipartite KST in Erdős #1008

### DIFF
--- a/proofs/Proofs/Erdos1008Problem.lean
+++ b/proofs/Proofs/Erdos1008Problem.lean
@@ -297,7 +297,247 @@ theorem kovari_sos_turan (G : SimpleGraph V) [DecidableRel G.Adj]
         mul_le_mul_of_nonneg_left hsum_sq (Nat.cast_nonneg _)
     _ = n ^ 2 * (n - 1) + 2 * n * m := by ring
 
--- ## Main Theorems (Partially Axiomatized)
+-- ## Bipartite Kővári-Sós-Turán and Exponent Optimality
+-- The exponent 2/3 is optimal, proved via Folkman's K_{n,n²} construction
+-- and a bipartite cherry counting argument.
+
+/-- Complete bipartite graph K_{p,q} on Fin p ⊕ Fin q.
+    Left vertices (Fin p) are adjacent to right vertices (Fin q) only. -/
+private def KB (p q : ℕ) : SimpleGraph (Fin p ⊕ Fin q) where
+  Adj := fun
+    | .inl _, .inr _ | .inr _, .inl _ => True
+    | _, _ => False
+  symm u v := by cases u <;> cases v <;> simp
+  loopless v := by cases v <;> simp
+
+private instance kbDecRel (p q : ℕ) : DecidableRel (KB p q).Adj :=
+  fun u v => by unfold KB; cases u <;> cases v <;> simp <;> exact inferInstance
+
+/-- KB p q has at least p * q edges. -/
+private lemma kb_edges_ge (p q : ℕ) : p * q ≤ (KB p q).edgeFinset.card := by
+  -- Inject Fin p × Fin q into the edge finset via (a, b) ↦ s(.inl a, .inr b)
+  suffices h : (Finset.univ : Finset (Fin p × Fin q)).card ≤ (KB p q).edgeFinset.card by
+    simpa using h
+  apply Finset.card_le_card_of_injOn
+    (fun (ab : Fin p × Fin q) => s(.inl ab.1, .inr ab.2))
+    (fun ⟨a, b⟩ _ => by
+      rw [SimpleGraph.mem_edgeFinset]; show (KB p q).Adj (.inl a) (.inr b); trivial)
+    (fun ⟨a₁, b₁⟩ _ ⟨a₂, b₂⟩ _ h => by
+      rcases Sym2.eq_iff.mp h with ⟨h1, h2⟩ | ⟨h1, h2⟩
+      · exact Prod.ext (Sum.inl_injective h1) (Sum.inr_injective h2)
+      · exact absurd h1 Sum.inl_ne_inr)
+
+/-- Left-side neighborhoods: for right vertex b, its left neighbors in H. -/
+private def leftNbrs {p q : ℕ} (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (b : Fin q) : Finset (Fin p) :=
+  Finset.univ.filter (fun a => H.Adj (.inl a) (.inr b))
+
+/-- In a C₄-free subgraph of KB, the offDiag left-neighborhoods are disjoint
+    across distinct right vertices (via c4free_common_neighbor_unique). -/
+private theorem bip_cherry_disjoint {p q : ℕ}
+    (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (hfree : IsC4Free H) {b₁ b₂ : Fin q} (hne : b₁ ≠ b₂) :
+    Disjoint (leftNbrs H b₁).offDiag (leftNbrs H b₂).offDiag := by
+  rw [Finset.disjoint_left]
+  rintro ⟨a₁, a₂⟩ h₁ h₂
+  rw [Finset.mem_offDiag] at h₁ h₂
+  have ha₁b₁ : H.Adj (.inl a₁) (.inr b₁) := (Finset.mem_filter.mp h₁.1).2
+  have ha₂b₁ : H.Adj (.inl a₂) (.inr b₁) := (Finset.mem_filter.mp h₁.2.1).2
+  have ha₁b₂ : H.Adj (.inl a₁) (.inr b₂) := (Finset.mem_filter.mp h₂.1).2
+  have ha₂b₂ : H.Adj (.inl a₂) (.inr b₂) := (Finset.mem_filter.mp h₂.2.1).2
+  have hne_a : (Sum.inl a₁ : Fin p ⊕ Fin q) ≠ Sum.inl a₂ :=
+    fun heq => h₁.2.2 (Sum.inl_injective heq)
+  exact absurd (Sum.inr_injective
+    (c4free_common_neighbor_unique hfree (.inl a₁) (.inl a₂) hne_a
+      (.inr b₁) (.inr b₂) ha₁b₁ ha₂b₁.symm ha₁b₂ ha₂b₂.symm)) hne
+
+/-- Bipartite cherry count: ∑_b |offDiag(N_L(b))| ≤ |offDiag(Fin p)|. -/
+private theorem bip_cherry_count {p q : ℕ}
+    (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (hfree : IsC4Free H) :
+    ∑ b : Fin q, (leftNbrs H b).offDiag.card ≤
+    (Finset.univ : Finset (Fin p)).offDiag.card := by
+  calc ∑ b : Fin q, (leftNbrs H b).offDiag.card
+      = (Finset.univ.biUnion fun b => (leftNbrs H b).offDiag).card :=
+        (Finset.card_biUnion fun _ _ _ _ h => bip_cherry_disjoint H hfree h).symm
+    _ ≤ (Finset.univ : Finset (Fin p)).offDiag.card :=
+        Finset.card_le_card (by
+          intro ⟨a₁, a₂⟩ hp
+          rw [Finset.mem_biUnion] at hp
+          obtain ⟨_, _, hv⟩ := hp
+          rw [Finset.mem_offDiag] at hv ⊢
+          exact ⟨Finset.mem_univ a₁, Finset.mem_univ a₂, hv.2.2⟩)
+
+/-- Bipartite cherry count (ℕ form). -/
+private theorem bip_cherry_count_nat {p q : ℕ}
+    (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (hfree : IsC4Free H) :
+    ∑ b : Fin q, (leftNbrs H b).card * ((leftNbrs H b).card - 1) ≤ p * (p - 1) := by
+  have h := bip_cherry_count H hfree
+  simp only [Finset.card_offDiag, Finset.card_univ, Fintype.card_fin] at h
+  exact h
+
+/-- For H ≤ KB, degree of a right vertex equals its left-neighbor count. -/
+private lemma bip_degree_right {p q : ℕ}
+    (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (hsub : ∀ u v, H.Adj u v → (KB p q).Adj u v) (b : Fin q) :
+    H.degree (.inr b) = (leftNbrs H b).card := by
+  show (H.neighborFinset (.inr b)).card =
+    (Finset.univ.filter (fun a : Fin p => H.Adj (.inl a) (.inr b))).card
+  suffices h : H.neighborFinset (.inr b) =
+      (Finset.univ.filter (fun a : Fin p => H.Adj (.inl a) (.inr b))).map
+        ⟨Sum.inl, Sum.inl_injective⟩ by
+    rw [h, Finset.card_map]
+  ext v
+  simp only [SimpleGraph.mem_neighborFinset, Finset.mem_map, Finset.mem_filter,
+    Finset.mem_univ, true_and, Function.Embedding.coeFn_mk]
+  constructor
+  · intro hadj
+    have hkb := hsub (.inr b) v hadj
+    rcases v with a | b'
+    · exact ⟨a, hadj.symm, rfl⟩
+    · exfalso; revert hkb; simp [KB]
+  · rintro ⟨a, hadj_sym, rfl⟩
+    exact hadj_sym.symm
+
+/-- Right-side neighborhoods: for left vertex a, its right neighbors in H. -/
+private def rightNbrs {p q : ℕ} (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (a : Fin p) : Finset (Fin q) :=
+  Finset.univ.filter (fun b => H.Adj (.inl a) (.inr b))
+
+/-- For H ≤ KB, degree of a left vertex equals its right-neighbor count. -/
+private lemma bip_degree_left {p q : ℕ}
+    (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (hsub : ∀ u v, H.Adj u v → (KB p q).Adj u v) (a : Fin p) :
+    H.degree (.inl a) = (rightNbrs H a).card := by
+  show (H.neighborFinset (.inl a)).card =
+    (Finset.univ.filter (fun b : Fin q => H.Adj (.inl a) (.inr b))).card
+  suffices h : H.neighborFinset (.inl a) =
+      (Finset.univ.filter (fun b : Fin q => H.Adj (.inl a) (.inr b))).map
+        ⟨Sum.inr, Sum.inr_injective⟩ by
+    rw [h, Finset.card_map]
+  ext v
+  simp only [SimpleGraph.mem_neighborFinset, Finset.mem_map, Finset.mem_filter,
+    Finset.mem_univ, true_and, Function.Embedding.coeFn_mk]
+  constructor
+  · intro hadj
+    have hkb := hsub (.inl a) v hadj
+    rcases v with _ | b
+    · exfalso; revert hkb; simp [KB]
+    · exact ⟨b, hadj, rfl⟩
+  · rintro ⟨b, hadj, rfl⟩; exact hadj
+
+/-- Edge count of a bipartite subgraph equals sum of left-degrees.
+    Proof: double sigma injection + handshaking gives T = m. -/
+private theorem bip_edge_sum {p q : ℕ}
+    (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (hsub : ∀ u v, H.Adj u v → (KB p q).Adj u v) :
+    H.edgeFinset.card = ∑ b : Fin q, (leftNbrs H b).card := by
+  set m := H.edgeFinset.card
+  set T := ∑ b : Fin q, (leftNbrs H b).card
+  set T' := ∑ a : Fin p, (rightNbrs H a).card
+  -- Step 1: T ≤ m (injection from right-side sigma into edgeFinset)
+  have hT_le : T ≤ m := by
+    change ∑ b : Fin q, (leftNbrs H b).card ≤ (H.edgeFinset).card
+    rw [← Finset.card_sigma]
+    apply Finset.card_le_card_of_injOn
+      (fun (x : Σ b, ↥(leftNbrs H b)) => s(.inl x.2.1, .inr x.1))
+      (fun ⟨b, a, ha⟩ _ => by
+        rw [SimpleGraph.mem_edgeFinset]
+        exact (Finset.mem_filter.mp ha).2)
+      (fun ⟨b₁, a₁, _⟩ _ ⟨b₂, a₂, _⟩ _ h => by
+        rcases Sym2.eq_iff.mp h with ⟨h1, h2⟩ | ⟨h1, h2⟩
+        · exact Sigma.ext (Sum.inr_injective h2) (Subtype.ext (Sum.inl_injective h1))
+        · exact absurd h1 Sum.inl_ne_inr)
+  -- Step 2: T' ≤ m (symmetric injection from left-side sigma)
+  have hT'_le : T' ≤ m := by
+    change ∑ a : Fin p, (rightNbrs H a).card ≤ (H.edgeFinset).card
+    rw [← Finset.card_sigma]
+    apply Finset.card_le_card_of_injOn
+      (fun (x : Σ a, ↥(rightNbrs H a)) => s(.inl x.1, .inr x.2.1))
+      (fun ⟨a, b, hb⟩ _ => by
+        rw [SimpleGraph.mem_edgeFinset]
+        exact (Finset.mem_filter.mp hb).2)
+      (fun ⟨a₁, b₁, _⟩ _ ⟨a₂, b₂, _⟩ _ h => by
+        rcases Sym2.eq_iff.mp h with ⟨h1, h2⟩ | ⟨h1, h2⟩
+        · exact Sigma.ext (Sum.inl_injective h1) (Subtype.ext (Sum.inr_injective h2))
+        · exact absurd h1 Sum.inl_ne_inr)
+  -- Step 3: T + T' = 2m (handshaking + degree decomposition)
+  have hsum : T + T' = 2 * m := by
+    have hhand := H.sum_degrees_eq_twice_card_edges
+    -- ∑_v degree(v) = ∑_a degree(.inl a) + ∑_b degree(.inr b)
+    have hsplit : ∑ v : Fin p ⊕ Fin q, H.degree v =
+        ∑ a : Fin p, H.degree (.inl a) + ∑ b : Fin q, H.degree (.inr b) :=
+      Fintype.sum_sum_type _
+    -- ∑_b degree(.inr b) = T
+    have hr : ∑ b : Fin q, H.degree (.inr b) = T := by
+      congr 1; ext b; exact bip_degree_right H hsub b
+    -- ∑_a degree(.inl a) = T'
+    have hl : ∑ a : Fin p, H.degree (.inl a) = T' := by
+      congr 1; ext a; exact bip_degree_left H hsub a
+    linarith
+  -- Step 4: T = m (from T ≤ m, T' ≤ m, T + T' = 2m)
+  omega
+
+/-- Bipartite edge bound: C₄-free subgraph of KB p q has < q + p² edges.
+    Proof via cherry counting + Cauchy-Schwarz + quadratic contradiction. -/
+private theorem bip_edge_bound {p q : ℕ} (hp : 0 < p)
+    (H : SimpleGraph (Fin p ⊕ Fin q)) [DecidableRel H.Adj]
+    (hsub : ∀ u v, H.Adj u v → (KB p q).Adj u v) (hfree : IsC4Free H) :
+    (H.edgeFinset.card : ℝ) < (q : ℝ) + (p : ℝ) ^ 2 := by
+  set m := H.edgeFinset.card
+  -- Step 1: m = ∑ d_L(b) (edge sum formula)
+  have hm : m = ∑ b : Fin q, (leftNbrs H b).card := bip_edge_sum H hsub
+  -- Step 2: Cherry count ∑ d(d-1) ≤ p(p-1)
+  have hcherry := bip_cherry_count_nat H hfree
+  -- Step 3: ∑ d² ≤ p(p-1) + m via d² = d(d-1) + d
+  have hid : ∀ d : ℕ, d ^ 2 = d * (d - 1) + d := by
+    intro d; cases d with | zero => simp | succ n => omega
+  have hsum_sq : ∑ b : Fin q, (leftNbrs H b).card ^ 2 ≤ p * (p - 1) + m := by
+    calc ∑ b : Fin q, (leftNbrs H b).card ^ 2
+        = ∑ b, ((leftNbrs H b).card * ((leftNbrs H b).card - 1) + (leftNbrs H b).card) := by
+          congr 1; ext b; exact hid _
+      _ = ∑ b, (leftNbrs H b).card * ((leftNbrs H b).card - 1) + ∑ b, (leftNbrs H b).card :=
+          Finset.sum_add_distrib
+      _ ≤ p * (p - 1) + m := by linarith [hcherry, hm.symm.le]
+  -- Step 4: Cauchy-Schwarz: m² ≤ q · ∑ d²
+  have hcs_real := sq_sum_le (V := Fin q) (fun b => ((leftNbrs H b).card : ℝ))
+  -- (∑ d)² ≤ q · ∑ d²
+  rw [show Fintype.card (Fin q) = q from Fintype.card_fin q] at hcs_real
+  -- Step 5: Combine to get m² ≤ q(p(p-1) + m) ≤ q(p² + m)
+  -- Then show m < q + p² by contradiction
+  by_contra h
+  push_neg at h  -- h : q + p² ≤ m (in ℝ)
+  -- From CS: (∑ (d : ℝ))² ≤ q · ∑ d²
+  -- ∑ (d : ℝ) = m (as ℝ), ∑ d² ≤ p(p-1) + m ≤ p² + m
+  have hm_real : (∑ b : Fin q, ((leftNbrs H b).card : ℝ)) = (m : ℝ) := by
+    rw [hm]; push_cast; rfl
+  rw [hm_real] at hcs_real
+  have hsumsq_real : ∑ b : Fin q, ((leftNbrs H b).card : ℝ) ^ 2 ≤ (p : ℝ) ^ 2 + (m : ℝ) := by
+    have : ∑ b : Fin q, (leftNbrs H b).card ^ 2 ≤ p * (p - 1) + m := hsum_sq
+    have hp1 : (p : ℝ) * ((p : ℝ) - 1) ≤ (p : ℝ) ^ 2 := by nlinarith
+    push_cast at this ⊢
+    -- Need: ∑ (↑card)² ≤ ↑p² + ↑m, from ∑ card² ≤ p(p-1) + m ≤ p² + m
+    calc (∑ b : Fin q, ((leftNbrs H b).card : ℝ) ^ 2)
+        = ↑(∑ b : Fin q, (leftNbrs H b).card ^ 2) := by push_cast; rfl
+      _ ≤ ↑(p * (p - 1) + m) := by exact_mod_cast hsum_sq
+      _ ≤ (p : ℝ) ^ 2 + (m : ℝ) := by push_cast; nlinarith [Nat.sub_le p 1]
+  -- So m² ≤ q · (p² + m)
+  have hmq : (m : ℝ) ^ 2 ≤ (q : ℝ) * ((p : ℝ) ^ 2 + (m : ℝ)) := by
+    calc (m : ℝ) ^ 2 ≤ (q : ℝ) * ∑ b, ((leftNbrs H b).card : ℝ) ^ 2 := hcs_real
+      _ ≤ (q : ℝ) * ((p : ℝ) ^ 2 + (m : ℝ)) :=
+          mul_le_mul_of_nonneg_left hsumsq_real (Nat.cast_nonneg q)
+  -- m² ≤ qp² + qm, so m² - qm ≤ qp², i.e., m(m-q) ≤ qp²
+  -- But m ≥ q + p², so m(m-q) ≥ (q+p²)·p² = qp² + p⁴ > qp² when p > 0
+  have : (m : ℝ) * ((m : ℝ) - (q : ℝ)) ≤ (q : ℝ) * (p : ℝ) ^ 2 := by nlinarith
+  have : (m : ℝ) * ((m : ℝ) - (q : ℝ)) ≥ ((q : ℝ) + (p : ℝ) ^ 2) * (p : ℝ) ^ 2 := by
+    have hge : (m : ℝ) - (q : ℝ) ≥ (p : ℝ) ^ 2 := by linarith
+    nlinarith
+  -- Contradiction: qp² + p⁴ ≤ qp², so p⁴ ≤ 0, but p > 0
+  have : (0 : ℝ) < (p : ℝ) ^ 4 := by positivity
+  linarith
+
+-- ## Main Theorems
 
 /-- Erdős Problem #1008 (Conlon-Fox-Sudakov 2014):
     Every graph with m edges has a C₄-free subgraph with Ω(m^{2/3}) edges.
@@ -311,14 +551,47 @@ axiom erdos_1008 :
         (H.edgeFinset.card : ℝ) ≥ c * (G.edgeFinset.card : ℝ) ^ ((2 : ℝ) / 3)
 
 /-- The exponent 2/3 is optimal: for every ε > 0, Folkman's K_{n,n²}
-    shows no C₄-free subgraph achieves m^{2/3 + ε} edges. -/
-axiom exponent_optimal :
-  ∀ ε : ℝ, ε > 0 →
-    ∃ (W : Type) (_ : Fintype W) (_ : DecidableEq W) (G : SimpleGraph W) (_ : DecidableRel G.Adj),
-      (G.edgeFinset.card : ℝ) > 0 ∧
-      ∀ (H : SimpleGraph W) (_ : DecidableRel H.Adj),
-        (∀ u v, H.Adj u v → G.Adj u v) → IsC4Free H →
-        (H.edgeFinset.card : ℝ) < (G.edgeFinset.card : ℝ) ^ ((2 : ℝ) / 3 + ε)
+    shows no C₄-free subgraph achieves m^{2/3 + ε} edges.
+
+    Proof: Take G = K_{n,n²} with n large enough that n^{3ε} > 3.
+    By bipartite KST (bip_edge_bound), any C₄-free H ≤ G has
+    |E(H)| < n² + n² = 2n². Since |E(G)| ≥ n³, we get
+    |E(G)|^{2/3+ε} ≥ n^{2+3ε} > 3n² > 2n² > |E(H)|. -/
+theorem exponent_optimal :
+    ∀ ε : ℝ, ε > 0 →
+      ∃ (W : Type) (_ : Fintype W) (_ : DecidableEq W)
+        (G : SimpleGraph W) (_ : DecidableRel G.Adj),
+        (G.edgeFinset.card : ℝ) > 0 ∧
+        ∀ (H : SimpleGraph W) (_ : DecidableRel H.Adj),
+          (∀ u v, H.Adj u v → G.Adj u v) → IsC4Free H →
+          (H.edgeFinset.card : ℝ) < (G.edgeFinset.card : ℝ) ^ ((2 : ℝ) / 3 + ε) := by
+  intro ε hε
+  -- Choose n large enough that (n : ℝ)^(3*ε) > 3
+  -- Such n exists by Archimedean property
+  have h3 : (0 : ℝ) < 3 := by norm_num
+  obtain ⟨n, hn⟩ := exists_nat_gt (3 ^ ((1 : ℝ) / (3 * ε)))
+  have hn_pos : 0 < n := by
+    by_contra h; push_neg at h
+    have : (n : ℝ) ≤ 0 := by exact_mod_cast h
+    linarith [Real.rpow_pos_of_pos h3 ((1 : ℝ) / (3 * ε))]
+  -- Witness: KB n (n*n) on Fin n ⊕ Fin (n*n)
+  refine ⟨Fin n ⊕ Fin (n * n), inferInstance, inferInstance,
+    KB n (n * n), kbDecRel n (n * n), ?_, ?_⟩
+  · -- G has positive edges
+    have : n * (n * n) ≤ (KB n (n * n)).edgeFinset.card := kb_edges_ge n (n * n)
+    have : 0 < n * (n * n) := Nat.mul_pos hn_pos (Nat.mul_pos hn_pos hn_pos)
+    exact_mod_cast show (0 : ℤ) < (KB n (n * n)).edgeFinset.card by omega
+  · -- Every C₄-free subgraph has < |E(G)|^{2/3+ε} edges
+    intro H hdr hsub hfree
+    letI := hdr
+    -- Step 1: |E(H)| < n*n + n² = 2n² (bipartite edge bound)
+    have hbound := bip_edge_bound hn_pos H hsub hfree
+    -- hbound : (H.edgeFinset.card : ℝ) < n*n + n^2 = 2n²
+    -- Step 2: |E(G)| ≥ n³
+    have hedge : n * (n * n) ≤ (KB n (n * n)).edgeFinset.card := kb_edges_ge n (n * n)
+    -- Step 3: Chain the inequalities
+    -- |E(H)| < 2n² < n^{2+3ε} ≤ (n³)^{2/3+ε} ≤ |E(G)|^{2/3+ε}
+    sorry -- Real arithmetic: 2n² < (n³)^{2/3+ε} for n^{3ε} > 3
 
 -- ## Derived Results
 

--- a/proofs/Proofs/Erdos1008ProblemProvable.lean
+++ b/proofs/Proofs/Erdos1008ProblemProvable.lean
@@ -75,9 +75,35 @@ Erdős noted that finding a C₄-free subgraph with Ω(m^{1/2}) edges is trivial
 This follows from the Kővári–Sós–Turán theorem.
 -/
 
-/-- Kővári–Sós–Turán: C₄-free graphs on n vertices have O(n^{3/2}) edges -/
-axiom kovari_sos_turan (G : SimpleGraph V) [DecidableRel G.Adj] :
-  isC4Free G → edgeCount G ≤ (Fintype.card V)^2 / 2
+/-- Kővári–Sós–Turán: C₄-free graphs on n vertices have O(n^{3/2}) edges.
+    Proved via degree sum: 2m = ∑ deg(v) ≤ n(n-1) ≤ n², so m ≤ n²/2.
+    (This weak bound holds for ALL simple graphs, not just C₄-free ones.) -/
+theorem kovari_sos_turan (G : SimpleGraph V) [DecidableRel G.Adj] :
+    isC4Free G → edgeCount G ≤ (Fintype.card V) ^ 2 / 2 := by
+  intro _
+  unfold edgeCount
+  -- Suffices: 2 * |E| ≤ n²
+  suffices h : 2 * G.edgeFinset.card ≤ (Fintype.card V) ^ 2 by omega
+  -- Handshaking: ∑ deg(v) = 2|E|
+  have hhand : ∑ v : V, G.degree v = 2 * G.edgeFinset.card :=
+    G.sum_degrees_eq_twice_card_edges
+  -- Each degree < n, so degree ≤ n - 1
+  have hdeg : ∀ v : V, G.degree v ≤ Fintype.card V - 1 := fun v => by
+    have := G.degree_lt_card_verts v; omega
+  -- Sum of degrees ≤ n * (n - 1)
+  have hsum : ∑ v : V, G.degree v ≤ Fintype.card V * (Fintype.card V - 1) := by
+    calc ∑ v : V, G.degree v
+        ≤ ∑ _v : V, (Fintype.card V - 1) :=
+          Finset.sum_le_sum (fun v _ => hdeg v)
+      _ = Fintype.card V * (Fintype.card V - 1) := by
+          simp [Finset.sum_const, Finset.card_univ, smul_eq_mul]
+  -- Chain: 2|E| = ∑ deg ≤ n(n-1) ≤ n²
+  calc 2 * G.edgeFinset.card
+      = ∑ v : V, G.degree v := hhand.symm
+    _ ≤ Fintype.card V * (Fintype.card V - 1) := hsum
+    _ ≤ (Fintype.card V) ^ 2 := by
+        have := Nat.sub_le (Fintype.card V) 1
+        nlinarith
 
 /-- Trivial bound: every graph has a C₄-free subgraph with Ω(√m) edges -/
 axiom c4free_subgraph_sqrt (G : SimpleGraph V) [DecidableRel G.Adj] :

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -18,13 +18,13 @@
       "zarankiewicz"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1008,
     "erdosUrl": "https://erdosproblems.com/1008",
     "erdosProblemStatus": "solved",
-    "axiomCount": 2,
-    "lineCount": 334,
-    "assumptions": "2 axioms: (1) Conlon-Fox-Sudakov main theorem (Ω(m^{2/3}) C₄-free subgraph), (2) optimality of 2/3 exponent. Proved: Kővári-Sós-Turán C₄-case (4m²≤n²(n-1)+2mn, via cherry counting+Cauchy-Schwarz), K₂₂↔C₄ equivalence, C₄-freeness hereditary/monotone, common neighbor uniqueness, few-edges C₄-free, Folkman ratio.",
+    "axiomCount": 1,
+    "lineCount": 607,
+    "assumptions": "1 axiom: Conlon-Fox-Sudakov main theorem (Ω(m^{2/3}) C₄-free subgraph). Proved: Kővári-Sós-Turán C₄-case (cherry counting+CS), K₂₂↔C₄ equivalence, C₄-freeness hereditary/monotone, common neighbor uniqueness, few-edges C₄-free, Folkman ratio, bipartite KST (cherry counting on K_{n,n²}), exponent 2/3 optimality (1 sorry: rpow arithmetic).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -127,9 +127,9 @@
     "opens": ["SimpleGraph", "Finset"],
     "namespace": "Erdos1008",
     "lineCount": 334,
-    "axiomCount": 2,
-    "theoremCount": 19,
-    "definitionCount": 4
+    "axiomCount": 1,
+    "theoremCount": 27,
+    "definitionCount": 8
   },
   "references": [
     {


### PR DESCRIPTION
## Summary
- Prove **exponent 2/3 optimality** (`exponent_optimal`) via bipartite Kővári-Sós-Turán on K_{n,n²} — complete bipartite graph construction, cherry counting, Cauchy-Schwarz, quadratic edge bound
- Prove `kovari_sos_turan` axiom in ProblemProvable.lean via degree sum argument
- **Axiom count**: Problem.lean 2→1, ProblemProvable.lean 5→4

## Key Infrastructure Added
- `KB`: Complete bipartite graph K_{p,q} on `Fin p ⊕ Fin q`
- `leftNbrs`/`rightNbrs`: bipartite neighborhood finsets
- `bip_cherry_disjoint`/`bip_cherry_count`: bipartite cherry counting (pairwise disjoint offDiag neighborhoods)
- `bip_degree_right`/`bip_degree_left`: bipartite degree equalities
- `bip_edge_sum`: edge count = sum of left-degrees (double injection + handshaking)
- `bip_edge_bound`: C₄-free subgraph of K_{p,q} has < q + p² edges

## Remaining
- 1 sorry in `exponent_optimal`: real `rpow` arithmetic chain (2n² < (n³)^{2/3+ε})
- 1 axiom: `erdos_1008` (deep CFS result, requires probabilistic method)

## Test plan
- [ ] Verify Lean compilation via Docker build
- [ ] Verify gallery build passes

🤖 Generated by researcher-5