### PR TITLE
Research: 6 problems — new proofs, axiom elimination, infrastructure

### DIFF
--- a/proofs/Proofs/Erdos409Problem.lean
+++ b/proofs/Proofs/Erdos409Problem.lean
@@ -241,13 +241,14 @@ theorem sigma_variant_question :
   ∀ n : ℕ, n > 1 → n.Prime →
     True := fun _ _ _ => trivial
 
-/-- The σ iteration can grow: σ(n) − 1 ≥ n for n > 1.
+/-- The σ iteration can grow: σ(n) − 1 ≥ n for all n > 1.
     Since 1 and n are both divisors and 1 ≠ n (as n > 1),
-    σ(n) ≥ 1 + n, so σ(n) - 1 ≥ n. -/
+    σ(n) ≥ 1 + n, so σ(n) - 1 ≥ n.
+    Note: this holds for primes too (σ(p) = 1 + p, so σ(p) − 1 = p). -/
 theorem sigma_growing :
-    ∀ n : ℕ, n > 1 → ¬n.Prime →
+    ∀ n : ℕ, n > 1 →
       n ≤ (n.divisors.sum id) - 1 := by
-  intro n hn _hnp
+  intro n hn
   -- σ(n) = n.divisors.sum id ≥ 1 + n since {1, n} ⊆ n.divisors
   have h1_dvd : 1 ∈ n.divisors := Nat.mem_divisors.mpr ⟨one_dvd n, by omega⟩
   have hn_dvd : n ∈ n.divisors := Nat.mem_divisors.mpr ⟨dvd_refl n, by omega⟩
@@ -265,6 +266,49 @@ theorem sigma_growing :
             Finset.sum_le_sum_of_subset_of_nonneg hpair (fun _ _ _ => Nat.zero_le _)
          _ = 1 + n := hpair_sum
   omega
+
+/- ## Quantitative Bound -/
+
+/-- φ(n) ≥ 2 for n ≥ 3: φ(n) is even (Nat.totient_even) and positive
+    (Nat.totient_pos), hence ≥ 2. -/
+theorem totient_ge_two (n : ℕ) (hn : n ≥ 3) : n.totient ≥ 2 := by
+  have hpos : 0 < n.totient := Nat.totient_pos (by omega)
+  have heven : Even n.totient := Nat.totient_even (by omega : 2 < n)
+  obtain ⟨k, hk⟩ := heven
+  omega
+
+/-- Any n > 1 reaches a prime in at most n − 2 iterations.
+    This gives the bound F(n) ≤ n − 2, i.e., F(n) = O(n).
+    Proof: strong induction. Primes need 0 steps. For composite n ≥ 4,
+    T(n) < n (by iterate_decreasing) and T(n) > 1 (since φ(n) ≥ 2),
+    so by IH, T(n) reaches prime in ≤ T(n) − 2 steps, giving
+    n reaches prime in ≤ T(n) − 1 ≤ n − 2 steps. -/
+theorem iteration_reaches_prime_in :
+    ∀ n : ℕ, n > 1 → ∃ k : ℕ, k ≤ n - 2 ∧ (totientIterate n k).Prime := by
+  intro n
+  induction n using Nat.strongRecOn with
+  | _ n ih =>
+    intro hn
+    by_cases hp : n.Prime
+    · exact ⟨0, by omega, hp⟩
+    · -- n > 1 and not prime, so n ≥ 4
+      have hn4 : n ≥ 4 := by
+        by_contra h; push_neg at h
+        interval_cases n <;> simp_all [Nat.Prime]
+      have hdec := iterate_decreasing n (by omega) hp
+      -- totientPlusOne n > 1: φ(n) ≥ 2 for n ≥ 3, so φ(n)+1 ≥ 3
+      have hm_gt1 : totientPlusOne n > 1 := by
+        unfold totientPlusOne
+        have := totient_ge_two n (by omega)
+        omega
+      obtain ⟨k, hk_le, hk_prime⟩ := ih (totientPlusOne n) hdec hm_gt1
+      refine ⟨k + 1, ?_, ?_⟩
+      · -- k + 1 ≤ n - 2: k ≤ T(n) - 2 and T(n) ≤ n - 1
+        omega
+      · -- totientIterate n (k+1) = totientIterate (T(n)) k
+        unfold totientIterate
+        rw [Function.iterate_succ, Function.comp_apply]
+        exact hk_prime
 
 /- ## Small Cases -/
 

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/409",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "assumptions": "3 axiom declarations: erdos_409_upper_bound (F(n) = o(n) bound, open), erdos_409_same_prime (infinite basin existence, open), erdos_409_density (basin natural density, open). All three are genuinely open parts of Erdos 409. Proved (12 theorems): iterate_decreasing, iteration_terminates (strong induction), prime_zero_iterations, one_iteration_criterion, one_iteration_infinite (via odd primes: for p odd prime, phi(2p)+1=p), sigma_growing, totient_plus_one_odd, totientIterate_zero, totientIterate_one, two_fixed_point, four_to_three, sigma_variant_question.",
-    "lineCount": 303,
+    "assumptions": "2 axiom declarations: erdos_409_upper_bound (F(n) = o(n) bound, open), erdos_409_same_prime (infinite basin existence, open). Both are genuinely open parts of Erdos 409. Proved (16 theorems): iterate_decreasing, iteration_terminates (strong induction), iteration_reaches_prime_in (F(n) ≤ n−2 bound), totient_ge_two (φ(n) ≥ 2 for n ≥ 3), prime_zero_iterations, one_iteration_criterion, one_iteration_infinite (via odd primes), sigma_growing (strengthened: all n > 1), totient_plus_one_odd, totientPlusOne_eq_self_iff_prime, totientIterate_zero, totientIterate_one, two_fixed_point, four_to_three, sigma_variant_question, erdos_409_density (trivial placeholder).",
+    "lineCount": 347,
     "mathlib_version": "4.26.0",
-    "theoremCount": 12
+    "theoremCount": 16
   },
   "overview": {
     "historicalContext": "This problem originates with Finucane and was popularized by Erdos and Graham in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p. 81). The map $T(n) = \\varphi(n) + 1$ defines a discrete dynamical system on the positive integers: since $\\varphi(n) < n - 1$ for composite $n > 1$, each application strictly decreases the value until a prime fixed point is reached ($T(p) = p$ for primes $p$). The iteration count $F(n) = \\min\\{k \\geq 0 : T^k(n) \\text{ is prime}\\}$ appears as OEIS A039651. Cambie noted that $F(n) = o(n)$ is trivial but the true growth rate remains unknown --- heuristically $F(n) = O(\\log n)$ since $\\varphi(n)/n$ has mean value $6/\\pi^2 \\approx 0.608$, suggesting each step reduces $n$ by a constant factor. Guy discusses the problem in UPINT (B41). The companion problem replacing $\\varphi$ by $\\sigma$ (sum of divisors) yields $n \\mapsto \\sigma(n) - 1$, which is non-decreasing for composites, making termination at a prime an entirely separate open question related to aliquot sequences and the Catalan--Dickson conjecture.",
@@ -102,18 +102,26 @@
       "mathContext": "Mathematical content: Establishes $F(p) = 0$ for primes, the criterion $F(n) = 1 \\iff \\varphi(n) + 1$ is prime, and the parity result that $\\varphi(n) + 1$ is odd for $n \\geq 3$ (since $\\varphi(n)$ is even)."
     },
     {
+      "id": "quantitative-bound",
+      "title": "Quantitative Bound: $F(n) \\leq n - 2$",
+      "startLine": 270,
+      "endLine": 311,
+      "summary": "Proves $F(n) \\leq n - 2$ for all $n > 1$ by strong induction: primes need 0 steps, composites $n \\geq 4$ satisfy $T(n) < n$ and $T(n) > 1$ (since $\\varphi(n) \\geq 2$), so by IH the iterate reaches a prime in $\\leq T(n) - 2 \\leq n - 3$ additional steps. Helper lemma: $\\varphi(n) \\geq 2$ for $n \\geq 3$ via evenness and positivity of the totient.",
+      "mathContext": "Proves $F(n) \\leq n - 2$ for all $n > 1$ by strong induction. The key helper is $\\varphi(n) \\geq 2$ for $n \\geq 3$, which follows from $\\varphi(n)$ being even (Nat.totient_even) and positive (Nat.totient_pos)."
+    },
+    {
       "id": "sigma-variant",
       "title": "Sigma Variant: $n \\mapsto \\sigma(n) - 1$",
-      "startLine": 176,
-      "endLine": 189,
+      "startLine": 235,
+      "endLine": 268,
       "summary": "The companion problem using $\\sigma(n)$ instead of $\\varphi(n)$. Since $\\sigma(n) \\geq 1 + n$ for composites, $\\sigma(n) - 1 \\geq n$, so the sigma iteration is non-decreasing --- a fundamentally different dynamical regime.",
       "mathContext": "The companion problem using $\\sigma(n)$ instead of $\\varphi(n)$. Since $\\sigma(n) \\geq 1 + n$ for composites, $\\sigma(n) - 1 \\geq n$, so the sigma iteration is non-decreasing --- a fundamentally different dynamical regime."
     },
     {
       "id": "small-cases",
       "title": "Small Cases and Fixed Points",
-      "startLine": 191,
-      "endLine": 291,
+      "startLine": 313,
+      "endLine": 347,
       "summary": "Concrete computations: $T(2) = 2$ (fixed point), $T(4) = 3$ (one-step example), and \\textbf{\\texttt{one\\_iteration\\_infinite}}: $F(n) = 1$ infinitely often --- proved by showing that for every odd prime $p$, $\\varphi(2p) + 1 = p$ via Euler totient multiplicativity.",
       "mathContext": "Concrete computations: $T(2) = 2$ (fixed point, proved by $\\texttt{simp}$), $T(4) = 3$ (one-step example), and $F(n) = 1$ infinitely often since $\\{n > 1 : \\varphi(n) + 1 \\text{ is prime}\\}$ is infinite."
     }
@@ -137,9 +145,9 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 303,
+    "lineCount": 347,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 16,
     "definitionCount": 3
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-409.json
+++ b/src/data/research/problems/erdos-409.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "COMPLETE: 16 theorems proved, 0 sorries, 2 axioms (both genuinely open). Added F(n)<=n-2 bound and phi(n)>=2 helper. Strengthened sigma_growing.",
     "builtItems": [
       "Proved sigma_variant_question (was trivially True placeholder)",
       "Proved four_to_three via native_decide",
@@ -44,7 +44,10 @@
       "Proved iterate_decreasing via Finset reasoning (0 and minFac non-coprime)",
       "Proved iteration_terminates via strong induction on iterate_decreasing",
       "Proved totient_plus_one_odd from Nat.totient_even + Even.add_one",
-      "theorem one_iteration_infinite: {n>1 | (phi(n)+1).Prime}.Infinite via odd primes image (Erdos409Problem.lean:271-291)"
+      "theorem one_iteration_infinite: {n>1 | (phi(n)+1).Prime}.Infinite via odd primes image (Erdos409Problem.lean:271-291)",
+      "theorem totient_ge_two: phi(n) >= 2 for n >= 3, via Nat.totient_even + Nat.totient_pos",
+      "theorem iteration_reaches_prime_in: F(n) <= n-2 for all n > 1, by strong induction",
+      "Strengthened sigma_growing: removed unnecessary not-prime hypothesis (holds for all n > 1)"
     ],
     "insights": [
       "sigma_variant_question was a trivially True placeholder axiom",
@@ -62,7 +65,9 @@
       "sigma_growing holds for all n>1 (not just composites) since σ(n)≥1+n whenever 1≠n are both divisors",
       "one_iteration_infinite is PROVABLE (not open): for odd prime p, phi(2p)=phi(2)*phi(p)=1*(p-1)=p-1, so phi(2p)+1=p is prime",
       "Key Mathlib API: Nat.coprime_two_left.mpr, Nat.Prime.odd_of_ne_two, Nat.totient_mul, Nat.totient_prime, Set.Infinite.image",
-      "Remaining 3 axioms are all genuinely open parts of Erdos 409 (upper bound, basin infinity, density)"
+      "Remaining 3 axioms are all genuinely open parts of Erdos 409 (upper bound, basin infinity, density)",
+      "F(n) <= n-2 follows cleanly by strong induction: composites have T(n) > 1 (phi >= 2) and T(n) < n",
+      "phi(n) >= 2 for n >= 3 follows elegantly from evenness (Nat.totient_even) + positivity (Nat.totient_pos)"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -89,8 +94,8 @@
     {
       "path": "Proofs/Erdos409Problem.lean",
       "filename": "Erdos409Problem.lean",
-      "lineCount": 304,
-      "theoremCount": 14,
+      "lineCount": 347,
+      "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
6 research problems addressed across 8 commits:

| Problem | Status | Key Result |
|---------|--------|------------|
| erdos-409 | **Completed** | 2 new theorems (F(n)≤n-2, φ(n)≥2), sigma_growing strengthened |
| shapley-folkman | Progress | Strict weight positivity, proof roadmap for reduce_excess_by_one |
| ptolemys-complex | **Completed** | New proof file (5 theorems, 0 sorries) via complex numbers |
| shannon-entropy-oq-03 | Progress | SSA stated, subadditivity outlined, 3 marginal defs |
| infinitude-primes-oq-03 | Progress | New InfinitudePrimes3k2.lean (4 lemmas, 3k+2 case) |
| erdos-75 | **Completed** | Axiom→theorem conversion (3→2 axioms), pigeonhole |

## Highlights
- **3 problems completed**, 3 with meaningful progress
- **Axiom elimination**: erdos-409 metadata fixed (3→2), erdos-75 (3→2 axioms)
- **New proof files**: PtolemysComplexProof.lean, InfinitudePrimes3k2.lean
- **0 axioms added**, total axiom count reduced across touched files

## Test plan
- [ ] Lean build passes for all modified/new proof files
- [ ] Gallery build (pnpm build) succeeds
- [ ] No regressions in existing proofs

🤖 Generated by researcher-2