### PR TITLE
fix: correct sorry/line counts in 5 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-537/meta.json
+++ b/src/data/proofs/erdos-537/meta.json
@@ -1,197 +1,197 @@
 {
-  "id": "erdos-537",
-  "title": "Erdős Problem #537: Three Numbers with Equal Prime Products",
-  "slug": "erdos-537",
-  "description": "Let ε > 0 and N be large. If A ⊆ {1,...,N} has |A| ≥ εN, must there exist a₁,a₂,a₃ ∈ A and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃? NO, disproved by Ruzsa's counterexample.",
-  "meta": {
-    "author": "Ruzsa (counterexample), described by Erdős",
-    "sourceUrl": "https://erdosproblems.com/537",
-    "date": "",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/Erdos537Problem.lean",
-    "tags": [
-      "erdos",
-      "number-theory",
-      "squarefree",
-      "prime-products",
-      "density",
-      "disproved"
+    "id": "erdos-537",
+    "title": "Erdős Problem #537: Three Numbers with Equal Prime Products",
+    "slug": "erdos-537",
+    "description": "Let ε > 0 and N be large. If A ⊆ {1,...,N} has |A| ≥ εN, must there exist a₁,a₂,a₃ ∈ A and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃? NO, disproved by Ruzsa's counterexample.",
+    "meta": {
+        "author": "Ruzsa (counterexample), described by Erdős",
+        "sourceUrl": "https://erdosproblems.com/537",
+        "date": "",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/Erdos537Problem.lean",
+        "tags": [
+            "erdos",
+            "number-theory",
+            "squarefree",
+            "prime-products",
+            "density",
+            "disproved"
+        ],
+        "badge": "axiom",
+        "sorries": 0,
+        "erdosNumber": 537,
+        "erdosUrl": "https://erdosproblems.com/537",
+        "erdosProblemStatus": "disproved",
+        "dateAdded": "2026-01-23",
+        "mathlib_version": "4.26.0",
+        "mathlibDependencies": [
+            {
+                "theorem": "Nat.Prime",
+                "description": "Prime number predicate",
+                "module": "Mathlib.Data.Nat.Prime.Basic"
+            },
+            {
+                "theorem": "Squarefree",
+                "description": "Squarefree numbers",
+                "module": "Mathlib.Data.Nat.Squarefree"
+            },
+            {
+                "theorem": "Finset",
+                "description": "Finite sets",
+                "module": "Mathlib.Data.Finset.Basic"
+            }
+        ],
+        "originalContributions": [
+            "HasPositiveDensity definition for lower density",
+            "IsDenseSubset definition for dense subsets",
+            "HasThreeEqualPrimeProducts definition for the target pattern",
+            "Erdos537Conjecture formalization",
+            "IsLacunarySquarefree definition for Ruzsa's construction",
+            "RuzsaSet definition for the counterexample",
+            "ruzsa_set_positive_density axiom",
+            "ruzsa_contradiction axiom for the key contradiction",
+            "ratio_bound theorem for interval constraint",
+            "erdos_537_disproved theorem: main disproof"
+        ],
+        "axiomCount": 3,
+        "lineCount": 292,
+        "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
+    },
+    "overview": {
+        "historicalContext": "**Erdős Problem #537: Three Equal Prime Products**\n\nThis problem originates from Erdős's investigations into multiplicative structure within dense sets, first appearing in [Er73]. The question asks whether positive density in $\\{1,\\ldots,N\\}$ forces the existence of three numbers $a_1, a_2, a_3$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$.\n\n**Historical Context:** Erdős posed this as a stepping stone toward Problem #536, which asks an analogous question for two numbers with equal prime products. A positive answer to #537 would have implied #536 by a pigeonhole argument. The problem connects to the broader program of understanding multiplicative coincidences in dense sets, initiated by Erdős and Turán in the 1930s and continued by Erdős-Graham (1980).\n\n**Resolution:** Imre Z. Ruzsa, a leading figure in additive combinatorics (known for the Ruzsa covering lemma and sumset estimates), constructed a decisive counterexample. His construction uses **lacunary squarefree numbers**: integers $n$ where if $p < q$ are consecutive prime divisors of $n$, then $q > 2p$. This ingenious set has positive lower density but the lacunary gap condition prevents any triple of equal prime products.\n\n**Technique:** The proof exploits an interval constraint: restricting to $(N/2, N)$, any ratio $a_i/a_j$ lies in $(1, 2)$, which is incompatible with the gap condition $q > 2p$ for consecutive primes. This pigeonhole-style argument is characteristic of Ruzsa's economical proof style.",
+        "problemStatement": "**Problem Statement (Disproved)**\n\nLet $\\epsilon > 0$ and $N$ be sufficiently large. If $A \\subseteq \\{1,\\ldots,N\\}$ has $|A| \\geq \\epsilon N$, must there exist $a_1, a_2, a_3 \\in A$ and distinct primes $p_1, p_2, p_3$ such that\n$$a_1 p_1 = a_2 p_2 = a_3 p_3?$$\n\n**Answer: NO**\n\nRuzsa constructed a counterexample: the lacunary squarefree numbers (where consecutive prime factors satisfy $p_{i+1} > 2p_i$) have positive density but contain no such triple.",
+        "text": "Let ε > 0 and N be large. If A ⊆ {1,...,N} has |A| ≥ εN, must there exist a₁,a₂,a₃ ∈ A and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃? NO, disproved by Ruzsa's counterexample.",
+        "proofStrategy": "**Formalization Approach**\n\n1. **Density Definitions:** Define $\\underline{d}(A) = \\liminf_{N \\to \\infty} |A \\cap [1,N]|/N > 0$ and $\\text{IsDenseSubset}(A, \\epsilon, N)$ for $|A \\cap [1,N]| \\geq \\epsilon N$.\n\n2. **Conjecture Formalization:** State $\\text{Erdos537Conjecture}$ as $\\forall \\epsilon > 0, \\exists N_0, \\forall N \\geq N_0$, every dense $A$ has three equal prime products.\n\n3. **Ruzsa's Construction:** Define $\\text{IsLacunarySquarefree}(n)$: squarefree and for consecutive prime divisors $p < q$, $q > 2p$. The $\\text{RuzsaSet}(N)$ restricts to $[1,N]$.\n\n4. **Key Properties:** Axiomatize that the Ruzsa set has positive density and that the lacunary condition prevents the triple pattern.\n\n5. **Interval Argument:** For $a_2, a_3 \\in (N/2, N)$ prove $1 < a_2/a_3 < 2$, contradicting $q/p > 2$.\n\n6. **Disproof Assembly:** Combine density, no-triple, and contradiction to negate the conjecture.",
+        "keyInsights": [
+            "**Lacunary Squarefree Numbers:** The set $\\{n \\in \\mathbb{N} : n$ squarefree, consecutive prime divisors satisfy $q > 2p\\}$ has positive lower density $\\underline{d} > 0$ despite the exponential gap condition",
+            "**Interval-Gap Incompatibility:** For $a_2, a_3 \\in (N/2, N)$, the ratio $a_2/a_3 \\in (1, 2)$ while the lacunary condition forces $p_3/p_2 > 2$, giving the contradiction $a_2 p_2 \\neq a_3 p_3$",
+            "**Counterexample Strategy:** Rather than proving the conjecture false for all dense sets, Ruzsa exhibits one specific dense set $A$ with $\\underline{d}(A) > 0$ that avoids the pattern entirely",
+            "**Implication for Problem #536:** A positive answer to #537 would have implied #536 (two equal prime products). Ruzsa's counterexample blocks this approach but does not resolve #536 itself",
+            "**Multiplicative vs. Additive:** Dense sets must contain additive patterns (Szemerédi's theorem) but need NOT contain all multiplicative patterns — the prime factorization structure allows escape"
+        ],
+        "prerequisites": [
+            "Combinatorics and number theory",
+            "Number theory (primes, divisibility)",
+            "Asymptotic density and counting"
+        ]
+    },
+    "sections": [
+        {
+            "id": "imports",
+            "title": "Imports and Setup",
+            "summary": "Imports from Mathlib: $\\text{Nat.Prime}$, $\\text{Squarefree}$, $\\text{Finset}$, and natural number arithmetic",
+            "startLine": 1,
+            "endLine": 34,
+            "mathContext": "Mathematical content: Imports from Mathlib: $\\text{Nat.Prime}$, $\\text{Squarefree}$, $\\text{Finset}$, and natural number arithmetic"
+        },
+        {
+            "id": "basic-definitions",
+            "title": "Density Definitions",
+            "summary": "Defines $\\text{HasPositiveDensity}(A)$ via $\\liminf |A \\cap [1,N]|/N > 0$, and $\\text{IsDenseSubset}(A, \\epsilon, N)$ for $|A| \\geq \\epsilon N$",
+            "startLine": 35,
+            "endLine": 48,
+            "mathContext": "Defines $\\text{HasPositiveDensity}(A)$ via $\\liminf |A \\cap [1,N]|/N > 0$, and $\\text{IsDenseSubset}(A, \\$\\varepsilon$, N)$ for $|A| \\geq \\$\\varepsilon$ N$"
+        },
+        {
+            "id": "three-products",
+            "title": "Three Equal Prime Products",
+            "summary": "Defines $\\text{HasThreeEqualPrimeProducts}(A)$: existence of $a_1, a_2, a_3 \\in A$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$",
+            "startLine": 49,
+            "endLine": 63,
+            "mathContext": "Formal definition: Defines $\\text{HasThreeEqualPrimeProducts}(A)$: existence of $a_1, a_2, a_3 \\in A$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$"
+        },
+        {
+            "id": "conjecture",
+            "title": "The Erdős #537 Conjecture",
+            "summary": "Formalizes the conjecture: $\\forall \\epsilon > 0, \\exists N_0, \\forall N \\geq N_0$, every $\\epsilon$-dense subset has three equal prime products (FALSE)",
+            "startLine": 64,
+            "endLine": 76,
+            "mathContext": "Formalizes the conjecture: $\\forall \\$\\varepsilon$ > 0, \\exists N_0, \\forall N \\geq N_0$, every $\\$\\varepsilon$$-dense subset has three equal prime products (FALSE)"
+        },
+        {
+            "id": "ruzsa-construction",
+            "title": "Ruzsa's Construction",
+            "summary": "Defines $\\text{IsLacunarySquarefree}(n)$: squarefree with consecutive prime divisors satisfying $q > 2p$. The $\\text{RuzsaSet}(N)$ restricts to $[1,N]$ with axiomatized positive density",
+            "startLine": 77,
+            "endLine": 112,
+            "mathContext": "Formal definition: Defines $\\text{IsLacunarySquarefree}(n)$: squarefree with consecutive prime divisors satisfying $q > 2p$. The $\\text{RuzsaSet}(N)$ restricts to $[1,N]$ with axiomatized positive density"
+        },
+        {
+            "id": "key-lemma",
+            "title": "The Key Lemma and Contradiction",
+            "summary": "Gap property: if $pq | n$ with $p < q$ consecutive, then $q > 2p$. The $\\text{ratio\\_bound}$ theorem: for $a_2, a_3 \\in (N/2, N)$, $a_2/a_3 \\in (1,2)$. Axiomatized contradiction via incompatibility",
+            "startLine": 113,
+            "endLine": 157,
+            "mathContext": "Verified: Gap property: if $pq | n$ with $p < q$ consecutive, then $q > 2p$. The $\\text{ratio\\_bound}$ theorem: for $a_2, a_3 \\in (N/2, N)$, $a_2/a_3 \\in (1,2)$. Axiomatized contradiction via incompatibility"
+        },
+        {
+            "id": "disproof",
+            "title": "The Disproof",
+            "summary": "Assembles $\\text{ruzsa\\_no\\_three\\_products}$ (proved) and $\\text{erdos\\_537\\_disproved}$ (1 sorry) to negate the conjecture by exhibiting the Ruzsa set counterexample",
+            "startLine": 158,
+            "endLine": 199,
+            "mathContext": "Mathematical content: Assembles $\\text{ruzsa\\_no\\_three\\_products}$ (proved) and $\\text{erdos\\_537\\_disproved}$ (1 sorry) to negate the conjecture by exhibiting the Ruzsa set counterexample"
+        },
+        {
+            "id": "understanding",
+            "title": "Understanding Ruzsa's Construction",
+            "summary": "Explains why the lacunary condition works: the ratio argument forces $p_3/p_2 > 2$ but $a_2/a_3 < 2$, a simple pigeonhole contradiction. Density estimate via sieve methods",
+            "startLine": 200,
+            "endLine": 226,
+            "mathContext": "Mathematical content: Explains why the lacunary condition works: the ratio argument forces $p_3/p_2 > 2$ but $a_2/a_3 < 2$, a simple pigeonhole contradiction. Density estimate via sieve methods"
+        },
+        {
+            "id": "connections",
+            "title": "Connection to Related Problems",
+            "summary": "Link to Erdős #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemerédi-type questions and the Erdős multiplicative functions program",
+            "startLine": 227,
+            "endLine": 246,
+            "mathContext": "Mathematical content: Link to Erdős #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemerédi-type questions and the Erdős multiplicative functions program"
+        },
+        {
+            "id": "main-results",
+            "title": "Main Results",
+            "summary": "Final theorems: $\\text{erdos\\_537}$ (alias for disproof), $\\text{erdos\\_537\\_summary}$ combining counterexample existence with the negation of the conjecture",
+            "startLine": 247,
+            "endLine": 276,
+            "mathContext": "Verified: Final theorems: $\\text{erdos\\_537}$ (alias for disproof), $\\text{erdos\\_537\\_summary}$ combining counterexample existence with the negation of the conjecture"
+        }
     ],
-    "badge": "axiom",
-    "sorries": 1,
-    "erdosNumber": 537,
-    "erdosUrl": "https://erdosproblems.com/537",
-    "erdosProblemStatus": "disproved",
-    "dateAdded": "2026-01-23",
-    "mathlib_version": "4.26.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "Nat.Prime",
-        "description": "Prime number predicate",
-        "module": "Mathlib.Data.Nat.Prime.Basic"
-      },
-      {
-        "theorem": "Squarefree",
-        "description": "Squarefree numbers",
-        "module": "Mathlib.Data.Nat.Squarefree"
-      },
-      {
-        "theorem": "Finset",
-        "description": "Finite sets",
-        "module": "Mathlib.Data.Finset.Basic"
-      }
+    "conclusion": {
+        "summary": "Erdős Problem #537 is DISPROVED. The conjecture asked whether dense subsets of {1,...,N} must contain three numbers a₁,a₂,a₃ and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃. Ruzsa's construction of lacunary squarefree numbers (where consecutive prime factors satisfy q > 2p) provides a counterexample: these numbers have positive lower density but the lacunary gap property, combined with an interval constraint on ratios, prevents the required pattern.",
+        "implications": "**Theoretical Significance**: **Number-Theoretic Significance**\n\n1. **Multiplicative Structure Gap:** Positive density forces additive patterns (Szemerédi) but not all multiplicative patterns — the prime factorization structure provides an escape mechanism.\n\n2. **Lacunary Squarefree Sets:** Ruzsa's construction reveals that controlling the gap between consecutive prime divisors creates sets with rigid multiplicative structure despite having positive density.\n\n**3. Blocked Implication:** The intended pathway from #537 to #536 is broken. Problem #536 requires a different approach.\n\n4. **Sieve-Theoretic Density:** The positive density of lacunary squarefree numbers is established via sieve methods, connecting this problem to the Selberg-Brun sieve tradition.",
+        "openQuestions": [
+            "What is the exact lower density of the lacunary squarefree numbers? Sieve bounds give estimates but the precise asymptotic is unknown.",
+            "Can Ruzsa's construction be adapted to disprove analogous problems with k > 3 equal prime products?",
+            "What is the status of the related Problem #536 (two equal prime products), now that the #537 pathway is blocked?",
+            "Are there dense sets avoiding three equal prime products that do NOT use the lacunary squarefree construction?",
+            "Can the remaining sorry in erdos_537_disproved be resolved by formalizing the set-theoretic bookkeeping for the interval argument?"
+        ]
+    },
+    "crossReferences": [
+        {
+            "targetId": "erdos-536",
+            "relationship": "related",
+            "description": "Erdős #536 asks whether dense sets contain two numbers with equal prime products. Problem #537 was posed as a stepping stone — a positive answer would have implied #536. Ruzsa's counterexample blocks this approach."
+        },
+        {
+            "targetId": "fundamental-arithmetic",
+            "relationship": "foundational",
+            "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) is the foundation for Problem #537's question about when three distinct integers can have identical sets of prime factors. The multiplicative structure of ℤ governs which prime products can coincide"
+        }
     ],
-    "originalContributions": [
-      "HasPositiveDensity definition for lower density",
-      "IsDenseSubset definition for dense subsets",
-      "HasThreeEqualPrimeProducts definition for the target pattern",
-      "Erdos537Conjecture formalization",
-      "IsLacunarySquarefree definition for Ruzsa's construction",
-      "RuzsaSet definition for the counterexample",
-      "ruzsa_set_positive_density axiom",
-      "ruzsa_contradiction axiom for the key contradiction",
-      "ratio_bound theorem for interval constraint",
-      "erdos_537_disproved theorem: main disproof"
-    ],
-    "axiomCount": 3,
-    "lineCount": 276,
-    "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
-  },
-  "overview": {
-    "historicalContext": "**Erdős Problem #537: Three Equal Prime Products**\n\nThis problem originates from Erdős's investigations into multiplicative structure within dense sets, first appearing in [Er73]. The question asks whether positive density in $\\{1,\\ldots,N\\}$ forces the existence of three numbers $a_1, a_2, a_3$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$.\n\n**Historical Context:** Erdős posed this as a stepping stone toward Problem #536, which asks an analogous question for two numbers with equal prime products. A positive answer to #537 would have implied #536 by a pigeonhole argument. The problem connects to the broader program of understanding multiplicative coincidences in dense sets, initiated by Erdős and Turán in the 1930s and continued by Erdős-Graham (1980).\n\n**Resolution:** Imre Z. Ruzsa, a leading figure in additive combinatorics (known for the Ruzsa covering lemma and sumset estimates), constructed a decisive counterexample. His construction uses **lacunary squarefree numbers**: integers $n$ where if $p < q$ are consecutive prime divisors of $n$, then $q > 2p$. This ingenious set has positive lower density but the lacunary gap condition prevents any triple of equal prime products.\n\n**Technique:** The proof exploits an interval constraint: restricting to $(N/2, N)$, any ratio $a_i/a_j$ lies in $(1, 2)$, which is incompatible with the gap condition $q > 2p$ for consecutive primes. This pigeonhole-style argument is characteristic of Ruzsa's economical proof style.",
-    "problemStatement": "**Problem Statement (Disproved)**\n\nLet $\\epsilon > 0$ and $N$ be sufficiently large. If $A \\subseteq \\{1,\\ldots,N\\}$ has $|A| \\geq \\epsilon N$, must there exist $a_1, a_2, a_3 \\in A$ and distinct primes $p_1, p_2, p_3$ such that\n$$a_1 p_1 = a_2 p_2 = a_3 p_3?$$\n\n**Answer: NO**\n\nRuzsa constructed a counterexample: the lacunary squarefree numbers (where consecutive prime factors satisfy $p_{i+1} > 2p_i$) have positive density but contain no such triple.",
-    "text": "Let ε > 0 and N be large. If A ⊆ {1,...,N} has |A| ≥ εN, must there exist a₁,a₂,a₃ ∈ A and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃? NO, disproved by Ruzsa's counterexample.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Density Definitions:** Define $\\underline{d}(A) = \\liminf_{N \\to \\infty} |A \\cap [1,N]|/N > 0$ and $\\text{IsDenseSubset}(A, \\epsilon, N)$ for $|A \\cap [1,N]| \\geq \\epsilon N$.\n\n2. **Conjecture Formalization:** State $\\text{Erdos537Conjecture}$ as $\\forall \\epsilon > 0, \\exists N_0, \\forall N \\geq N_0$, every dense $A$ has three equal prime products.\n\n3. **Ruzsa's Construction:** Define $\\text{IsLacunarySquarefree}(n)$: squarefree and for consecutive prime divisors $p < q$, $q > 2p$. The $\\text{RuzsaSet}(N)$ restricts to $[1,N]$.\n\n4. **Key Properties:** Axiomatize that the Ruzsa set has positive density and that the lacunary condition prevents the triple pattern.\n\n5. **Interval Argument:** For $a_2, a_3 \\in (N/2, N)$ prove $1 < a_2/a_3 < 2$, contradicting $q/p > 2$.\n\n6. **Disproof Assembly:** Combine density, no-triple, and contradiction to negate the conjecture.",
-    "keyInsights": [
-      "**Lacunary Squarefree Numbers:** The set $\\{n \\in \\mathbb{N} : n$ squarefree, consecutive prime divisors satisfy $q > 2p\\}$ has positive lower density $\\underline{d} > 0$ despite the exponential gap condition",
-      "**Interval-Gap Incompatibility:** For $a_2, a_3 \\in (N/2, N)$, the ratio $a_2/a_3 \\in (1, 2)$ while the lacunary condition forces $p_3/p_2 > 2$, giving the contradiction $a_2 p_2 \\neq a_3 p_3$",
-      "**Counterexample Strategy:** Rather than proving the conjecture false for all dense sets, Ruzsa exhibits one specific dense set $A$ with $\\underline{d}(A) > 0$ that avoids the pattern entirely",
-      "**Implication for Problem #536:** A positive answer to #537 would have implied #536 (two equal prime products). Ruzsa's counterexample blocks this approach but does not resolve #536 itself",
-      "**Multiplicative vs. Additive:** Dense sets must contain additive patterns (Szemerédi's theorem) but need NOT contain all multiplicative patterns — the prime factorization structure allows escape"
-    ],
-    "prerequisites": [
-      "Combinatorics and number theory",
-      "Number theory (primes, divisibility)",
-      "Asymptotic density and counting"
-    ]
-  },
-  "sections": [
-    {
-      "id": "imports",
-      "title": "Imports and Setup",
-      "summary": "Imports from Mathlib: $\\text{Nat.Prime}$, $\\text{Squarefree}$, $\\text{Finset}$, and natural number arithmetic",
-      "startLine": 1,
-      "endLine": 34,
-      "mathContext": "Mathematical content: Imports from Mathlib: $\\text{Nat.Prime}$, $\\text{Squarefree}$, $\\text{Finset}$, and natural number arithmetic"
-    },
-    {
-      "id": "basic-definitions",
-      "title": "Density Definitions",
-      "summary": "Defines $\\text{HasPositiveDensity}(A)$ via $\\liminf |A \\cap [1,N]|/N > 0$, and $\\text{IsDenseSubset}(A, \\epsilon, N)$ for $|A| \\geq \\epsilon N$",
-      "startLine": 35,
-      "endLine": 48,
-      "mathContext": "Defines $\\text{HasPositiveDensity}(A)$ via $\\liminf |A \\cap [1,N]|/N > 0$, and $\\text{IsDenseSubset}(A, \\$\\varepsilon$, N)$ for $|A| \\geq \\$\\varepsilon$ N$"
-    },
-    {
-      "id": "three-products",
-      "title": "Three Equal Prime Products",
-      "summary": "Defines $\\text{HasThreeEqualPrimeProducts}(A)$: existence of $a_1, a_2, a_3 \\in A$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$",
-      "startLine": 49,
-      "endLine": 63,
-      "mathContext": "Formal definition: Defines $\\text{HasThreeEqualPrimeProducts}(A)$: existence of $a_1, a_2, a_3 \\in A$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$"
-    },
-    {
-      "id": "conjecture",
-      "title": "The Erdős #537 Conjecture",
-      "summary": "Formalizes the conjecture: $\\forall \\epsilon > 0, \\exists N_0, \\forall N \\geq N_0$, every $\\epsilon$-dense subset has three equal prime products (FALSE)",
-      "startLine": 64,
-      "endLine": 76,
-      "mathContext": "Formalizes the conjecture: $\\forall \\$\\varepsilon$ > 0, \\exists N_0, \\forall N \\geq N_0$, every $\\$\\varepsilon$$-dense subset has three equal prime products (FALSE)"
-    },
-    {
-      "id": "ruzsa-construction",
-      "title": "Ruzsa's Construction",
-      "summary": "Defines $\\text{IsLacunarySquarefree}(n)$: squarefree with consecutive prime divisors satisfying $q > 2p$. The $\\text{RuzsaSet}(N)$ restricts to $[1,N]$ with axiomatized positive density",
-      "startLine": 77,
-      "endLine": 112,
-      "mathContext": "Formal definition: Defines $\\text{IsLacunarySquarefree}(n)$: squarefree with consecutive prime divisors satisfying $q > 2p$. The $\\text{RuzsaSet}(N)$ restricts to $[1,N]$ with axiomatized positive density"
-    },
-    {
-      "id": "key-lemma",
-      "title": "The Key Lemma and Contradiction",
-      "summary": "Gap property: if $pq | n$ with $p < q$ consecutive, then $q > 2p$. The $\\text{ratio\\_bound}$ theorem: for $a_2, a_3 \\in (N/2, N)$, $a_2/a_3 \\in (1,2)$. Axiomatized contradiction via incompatibility",
-      "startLine": 113,
-      "endLine": 157,
-      "mathContext": "Verified: Gap property: if $pq | n$ with $p < q$ consecutive, then $q > 2p$. The $\\text{ratio\\_bound}$ theorem: for $a_2, a_3 \\in (N/2, N)$, $a_2/a_3 \\in (1,2)$. Axiomatized contradiction via incompatibility"
-    },
-    {
-      "id": "disproof",
-      "title": "The Disproof",
-      "summary": "Assembles $\\text{ruzsa\\_no\\_three\\_products}$ (proved) and $\\text{erdos\\_537\\_disproved}$ (1 sorry) to negate the conjecture by exhibiting the Ruzsa set counterexample",
-      "startLine": 158,
-      "endLine": 199,
-      "mathContext": "Mathematical content: Assembles $\\text{ruzsa\\_no\\_three\\_products}$ (proved) and $\\text{erdos\\_537\\_disproved}$ (1 sorry) to negate the conjecture by exhibiting the Ruzsa set counterexample"
-    },
-    {
-      "id": "understanding",
-      "title": "Understanding Ruzsa's Construction",
-      "summary": "Explains why the lacunary condition works: the ratio argument forces $p_3/p_2 > 2$ but $a_2/a_3 < 2$, a simple pigeonhole contradiction. Density estimate via sieve methods",
-      "startLine": 200,
-      "endLine": 226,
-      "mathContext": "Mathematical content: Explains why the lacunary condition works: the ratio argument forces $p_3/p_2 > 2$ but $a_2/a_3 < 2$, a simple pigeonhole contradiction. Density estimate via sieve methods"
-    },
-    {
-      "id": "connections",
-      "title": "Connection to Related Problems",
-      "summary": "Link to Erdős #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemerédi-type questions and the Erdős multiplicative functions program",
-      "startLine": 227,
-      "endLine": 246,
-      "mathContext": "Mathematical content: Link to Erdős #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemerédi-type questions and the Erdős multiplicative functions program"
-    },
-    {
-      "id": "main-results",
-      "title": "Main Results",
-      "summary": "Final theorems: $\\text{erdos\\_537}$ (alias for disproof), $\\text{erdos\\_537\\_summary}$ combining counterexample existence with the negation of the conjecture",
-      "startLine": 247,
-      "endLine": 276,
-      "mathContext": "Verified: Final theorems: $\\text{erdos\\_537}$ (alias for disproof), $\\text{erdos\\_537\\_summary}$ combining counterexample existence with the negation of the conjecture"
+    "leanFile": {
+        "imports": [
+            "Mathlib.Data.Nat.Prime.Basic",
+            "Mathlib.Data.Nat.Squarefree",
+            "Mathlib.Data.Finset.Basic",
+            "Mathlib.Data.Real.Basic"
+        ],
+        "opens": [],
+        "namespace": "Erdos537",
+        "lineCount": 292,
+        "axiomCount": 3,
+        "theoremCount": 5,
+        "definitionCount": 7
     }
-  ],
-  "conclusion": {
-    "summary": "Erdős Problem #537 is DISPROVED. The conjecture asked whether dense subsets of {1,...,N} must contain three numbers a₁,a₂,a₃ and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃. Ruzsa's construction of lacunary squarefree numbers (where consecutive prime factors satisfy q > 2p) provides a counterexample: these numbers have positive lower density but the lacunary gap property, combined with an interval constraint on ratios, prevents the required pattern.",
-    "implications": "**Theoretical Significance**: **Number-Theoretic Significance**\n\n1. **Multiplicative Structure Gap:** Positive density forces additive patterns (Szemerédi) but not all multiplicative patterns — the prime factorization structure provides an escape mechanism.\n\n2. **Lacunary Squarefree Sets:** Ruzsa's construction reveals that controlling the gap between consecutive prime divisors creates sets with rigid multiplicative structure despite having positive density.\n\n**3. Blocked Implication:** The intended pathway from #537 to #536 is broken. Problem #536 requires a different approach.\n\n4. **Sieve-Theoretic Density:** The positive density of lacunary squarefree numbers is established via sieve methods, connecting this problem to the Selberg-Brun sieve tradition.",
-    "openQuestions": [
-      "What is the exact lower density of the lacunary squarefree numbers? Sieve bounds give estimates but the precise asymptotic is unknown.",
-      "Can Ruzsa's construction be adapted to disprove analogous problems with k > 3 equal prime products?",
-      "What is the status of the related Problem #536 (two equal prime products), now that the #537 pathway is blocked?",
-      "Are there dense sets avoiding three equal prime products that do NOT use the lacunary squarefree construction?",
-      "Can the remaining sorry in erdos_537_disproved be resolved by formalizing the set-theoretic bookkeeping for the interval argument?"
-    ]
-  },
-  "crossReferences": [
-    {
-      "targetId": "erdos-536",
-      "relationship": "related",
-      "description": "Erdős #536 asks whether dense sets contain two numbers with equal prime products. Problem #537 was posed as a stepping stone — a positive answer would have implied #536. Ruzsa's counterexample blocks this approach."
-    },
-    {
-      "targetId": "fundamental-arithmetic",
-      "relationship": "foundational",
-      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) is the foundation for Problem #537's question about when three distinct integers can have identical sets of prime factors. The multiplicative structure of ℤ governs which prime products can coincide"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Data.Nat.Squarefree",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Real.Basic"
-    ],
-    "opens": [],
-    "namespace": "Erdos537",
-    "lineCount": 276,
-    "axiomCount": 3,
-    "theoremCount": 5,
-    "definitionCount": 7
-  }
 }

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -1,257 +1,257 @@
 {
-  "id": "erdos-601",
-  "title": "Erdős #601: Infinite Paths and Independent Sets in Ordinal Graphs",
-  "slug": "erdos-601",
-  "description": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
-  "meta": {
-    "author": "Paul Erdős, András Hajnal, Eric Milner, Jean Larson",
-    "sourceUrl": "https://erdosproblems.com/601",
-    "date": "1970",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/Erdos601Problem.lean",
-    "tags": [
-      "erdos",
-      "graph-theory",
-      "set-theory",
-      "ordinals",
-      "open"
+    "id": "erdos-601",
+    "title": "Erdős #601: Infinite Paths and Independent Sets in Ordinal Graphs",
+    "slug": "erdos-601",
+    "description": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
+    "meta": {
+        "author": "Paul Erdős, András Hajnal, Eric Milner, Jean Larson",
+        "sourceUrl": "https://erdosproblems.com/601",
+        "date": "1970",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/Erdos601Problem.lean",
+        "tags": [
+            "erdos",
+            "graph-theory",
+            "set-theory",
+            "ordinals",
+            "open"
+        ],
+        "badge": "axiom",
+        "sorries": 10,
+        "erdosNumber": 601,
+        "erdosUrl": "https://erdosproblems.com/601",
+        "erdosProblemStatus": "open",
+        "erdosPrizeValue": "$500",
+        "dateAdded": "2026-01-19",
+        "mathlib_version": "4.26.0",
+        "mathlibDependencies": [
+            {
+                "theorem": "Ordinal.Basic",
+                "description": "Basic ordinal operations and properties",
+                "module": "Mathlib.SetTheory.Ordinal.Basic"
+            },
+            {
+                "theorem": "Ordinal.Arithmetic",
+                "description": "Ordinal arithmetic including exponentiation",
+                "module": "Mathlib.SetTheory.Ordinal.Arithmetic"
+            },
+            {
+                "theorem": "Cardinal.Basic",
+                "description": "Cardinal numbers and operations",
+                "module": "Mathlib.SetTheory.Cardinal.Basic"
+            },
+            {
+                "theorem": "SimpleGraph.Basic",
+                "description": "Simple graph definitions and operations",
+                "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+            }
+        ],
+        "originalContributions": [
+            "OrdinalGraph: graphs on ordinal vertex sets",
+            "HasInfinitePath: injective path predicate",
+            "IsIndependent: independence predicate",
+            "HasOrderType: order type of vertex subsets",
+            "PropertyP: path-vs-independent-set dichotomy",
+            "criticalOrdinal: ω₁^{ω+2} definition",
+            "erdos_hajnal_milner: main theorem (1970)",
+            "CriticalCaseConjecture: $250 prize problem",
+            "MartinsAxiom: set-theoretic axiom",
+            "larson_MA: Larson's theorem under MA (1990)",
+            "independenceNumber: cardinal-valued graph invariant",
+            "GeneralConjecture: $500 prize problem"
+        ],
+        "axiomCount": 3,
+        "lineCount": 262,
+        "assumptions": "3 axiom(s) and 14 sorry(s). See the Lean source for details."
+    },
+    "sections": [
+        {
+            "id": "imports",
+            "title": "Imports and Setup",
+            "startLine": 24,
+            "endLine": 33,
+            "summary": "Imports `Mathlib.SetTheory.Ordinal.Arithmetic`, `Cardinal.Basic`, `SimpleGraph.Basic`, and `Tactic`. Opens `Ordinal`, `Cardinal`, `SimpleGraph` namespaces.",
+            "mathContext": "Mathematical content: Imports `Mathlib.SetTheory.Ordinal.Arithmetic`, `Cardinal.Basic`, `SimpleGraph.Basic`, and `Tactic`. Opens `Ordinal`, `Cardinal`, `SimpleGraph` namespaces."
+        },
+        {
+            "id": "basic-defs",
+            "title": "Basic Definitions",
+            "summary": "Defines `OrdinalGraph` ($\\text{SimpleGraph}\\;\\alpha.\\text{toType}$), `HasInfinitePath` (injective $f : \\mathbb{N} \\to V$ with $f(n) \\sim f(n+1)$), `IsIndependent` (no edges in $S$), and `HasOrderType` ($\\text{Ordinal.type}$ of subrelation).",
+            "startLine": 34,
+            "endLine": 50,
+            "mathContext": "Defines `OrdinalGraph` ($\\text{SimpleGraph}\\;\\alpha.\\text{toType}$), `HasInfinitePath` (injective $f : \\mathbb{N} \\to V$ with $f(n) \\sim f(n+1)$), `IsIndependent` (no edges in $S$), and `HasOrderType` ($\\text{Ordinal.type}$ of subrelation)."
+        },
+        {
+            "id": "property-p",
+            "title": "Property $P(\\alpha)$",
+            "summary": "Defines $P(\\alpha)$: every graph on $\\alpha$ has infinite path OR independent set of order type $\\alpha$. Proves equivalence with the contrapositive formulation.",
+            "startLine": 51,
+            "endLine": 64,
+            "mathContext": "Defines $P(\\$\\alpha$)$: every graph on $\\$\\alpha$$ has infinite path OR independent set of order type $\\$\\alpha$$. Proves equivalence with the contrapositive formulation."
+        },
+        {
+            "id": "finite",
+            "title": "Finite Ordinals",
+            "summary": "$P(n)$ holds trivially for all finite $n$: no infinite path exists in a finite graph, so the independent set condition must hold.",
+            "startLine": 65,
+            "endLine": 76,
+            "mathContext": "Mathematical content: $P(n)$ holds trivially for all finite $n$: no infinite path exists in a finite graph, so the independent set condition must hold."
+        },
+        {
+            "id": "omega",
+            "title": "The First Infinite Ordinal: $P(\\omega)$",
+            "summary": "$P(\\omega)$ follows from the infinite Ramsey theorem ($\\omega \\to (\\omega)^2_2$): any graph on $\\omega$ has either an infinite clique (containing a ray) or an infinite independent set.",
+            "startLine": 77,
+            "endLine": 87,
+            "mathContext": "Verified: $P(\\omega)$ follows from the infinite Ramsey theorem ($\\omega \\to (\\omega)^2_2$): any graph on $\\omega$ has either an infinite clique (containing a ray) or an infinite independent set."
+        },
+        {
+            "id": "ehm",
+            "title": "Erdős-Hajnal-Milner Theorem (1970)",
+            "summary": "Defines `criticalOrdinal` $= \\omega_1^{\\omega+2}$ and axiomatizes the main result: $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on Cantor normal form.",
+            "startLine": 88,
+            "endLine": 101,
+            "mathContext": "Defines `criticalOrdinal` $= \\omega_1^{\\omega+2}$ and axiomatizes the main result: $P(\\$\\alpha$)$ holds for all $\\$\\alpha$ < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on Cantor normal form."
+        },
+        {
+            "id": "critical",
+            "title": "The Critical Case: $\\omega_1^{\\omega+2}$ ($250)",
+            "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize.",
+            "startLine": 102,
+            "endLine": 116,
+            "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize."
+        },
+        {
+            "id": "martins-axiom",
+            "title": "Martin's Axiom and Larson's Extension",
+            "summary": "Axiomatizes Martin's Axiom and Larson's theorem (1990): under MA, $P(\\alpha)$ holds for all $\\alpha$ with $|\\alpha| < 2^{\\aleph_0}$, extending the range far beyond $\\omega_1^{\\omega+2}$.",
+            "startLine": 117,
+            "endLine": 134,
+            "mathContext": "Axiomatizes Martin's Axiom and Larson's theorem (1990): under MA, $P(\\$\\alpha$)$ holds for all $\\$\\alpha$$ with $|\\$\\alpha$| < $$2^{{\\aleph_0}$}$$, extending the range far beyond $\\omega_1^{\\omega+2}$."
+        },
+        {
+            "id": "ordinal-arithmetic",
+            "title": "Ordinal Arithmetic and Hierarchy",
+            "summary": "Establishes the ordinal chain $\\omega < \\omega_1 < \\omega_1^\\omega < \\omega_1^{\\omega+1} < \\omega_1^{\\omega+2}$ and proves all countable ordinals satisfy $P$.",
+            "startLine": 135,
+            "endLine": 151,
+            "mathContext": "Verified: Establishes the ordinal chain $\\omega < \\omega_1 < \\omega_1^\\omega < \\omega_1^{\\omega+1} < \\omega_1^{\\omega+2}$ and proves all countable ordinals satisfy $P$."
+        },
+        {
+            "id": "graph-tools",
+            "title": "Graph-Theoretic Tools",
+            "summary": "States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
+            "startLine": 152,
+            "endLine": 165,
+            "mathContext": "Mathematical content: States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
+        },
+        {
+            "id": "independence",
+            "title": "Independence Number",
+            "summary": "Defines `independenceNumber` as $\\sup_{S \\text{ independent}} |S|$ and establishes that $P(\\alpha)$ failure requires $\\alpha(G) < |\\alpha|$ with no infinite path.",
+            "startLine": 166,
+            "endLine": 197,
+            "mathContext": "Defines `independenceNumber` as $\\sup_{S \\text{ independent}} |S|$ and establishes that $P(\\$\\alpha$)$ failure requires $\\$\\alpha$(G) < |\\$\\alpha$|$ with no infinite path."
+        },
+        {
+            "id": "general",
+            "title": "The General Conjecture ($500)",
+            "summary": "States `GeneralConjecture`: $P(\\alpha)$ holds for all limit ordinals $\\alpha$. Proves the partial result (limit ordinals below $\\omega_1^{\\omega+2}$) and the knowledge gap between known and conjectured.",
+            "startLine": 198,
+            "endLine": 247,
+            "mathContext": "States `GeneralConjecture`: $P(\\alpha)$ holds for all limit ordinals $\\alpha$. Proves the partial result (limit ordinals below $\\omega_1^{\\omega+2}$) and the knowledge gap between known and conjectured."
+        }
     ],
-    "badge": "axiom",
-    "sorries": 14,
-    "erdosNumber": 601,
-    "erdosUrl": "https://erdosproblems.com/601",
-    "erdosProblemStatus": "open",
-    "erdosPrizeValue": "$500",
-    "dateAdded": "2026-01-19",
-    "mathlib_version": "4.26.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "Ordinal.Basic",
-        "description": "Basic ordinal operations and properties",
-        "module": "Mathlib.SetTheory.Ordinal.Basic"
-      },
-      {
-        "theorem": "Ordinal.Arithmetic",
-        "description": "Ordinal arithmetic including exponentiation",
-        "module": "Mathlib.SetTheory.Ordinal.Arithmetic"
-      },
-      {
-        "theorem": "Cardinal.Basic",
-        "description": "Cardinal numbers and operations",
-        "module": "Mathlib.SetTheory.Cardinal.Basic"
-      },
-      {
-        "theorem": "SimpleGraph.Basic",
-        "description": "Simple graph definitions and operations",
-        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
-      }
+    "overview": {
+        "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erdős, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erdős-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
+        "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erdős-Hajnal-Milner theorem.",
+        "text": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
+        "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erdős-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, König's lemma, independence number, transfinite induction.",
+        "keyInsights": [
+            "**Erdős-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
+            "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ — new techniques are needed",
+            "**Larson (1990):** Under Martin's Axiom, $P(\\alpha)$ extends to all $\\alpha$ with $|\\alpha| < 2^{\\aleph_0}$, showing set-theoretic dependence",
+            "**Ramsey-type dichotomy:** The problem generalizes the infinite Ramsey theorem from $\\omega$ to arbitrary ordinals with order type requirements",
+            "**Two-tier prize:** $250 for the critical case $P(\\omega_1^{\\omega+2})$, $500 for the full generalization to all limit ordinals"
+        ],
+        "prerequisites": [
+            "Combinatorics and number theory",
+            "Graph theory (vertices, edges, colorings)",
+            "Set theory and cardinality"
+        ]
+    },
+    "conclusion": {
+        "summary": "This formalization captures Erdős Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erdős-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
+        "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms — the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erdős-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
+        "openQuestions": [
+            "Does P(ω₁^{ω+2}) hold? ($250 — the critical boundary case)",
+            "Does P(α) hold for all limit ordinals α? ($500 — the general conjecture)",
+            "Is the answer independent of ZFC (provable under MA but not in ZFC alone)?",
+            "Can the Erdős-Hajnal-Milner bound ω₁^{ω+2} be improved in ZFC?",
+            "What happens for singular cardinals and their ordinal powers?"
+        ]
+    },
+    "leanFile": {
+        "imports": [
+            "Mathlib.SetTheory.Ordinal.Basic",
+            "Mathlib.SetTheory.Ordinal.Arithmetic",
+            "Mathlib.SetTheory.Cardinal.Basic",
+            "Mathlib.Combinatorics.SimpleGraph.Basic",
+            "Mathlib.Tactic"
+        ],
+        "opens": [
+            "Ordinal",
+            "Cardinal",
+            "SimpleGraph"
+        ],
+        "namespace": "Erdos601",
+        "lineCount": 262,
+        "axiomCount": 3,
+        "theoremCount": 19,
+        "definitionCount": 13
+    },
+    "references": [
+        {
+            "key": "EHM70",
+            "citation": "Erdős, Paul, Hajnal, András, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
+            "type": "paper"
+        },
+        {
+            "key": "La90",
+            "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal ω^ω, Ann. Pure Appl. Logic 48 (1990), 253-255.",
+            "type": "paper"
+        },
+        {
+            "key": "EH77",
+            "citation": "Erdős, Paul and Hajnal, András, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
+            "type": "paper"
+        },
+        {
+            "key": "To85",
+            "citation": "Todorcevic, Stevo, Partition Problems in Topology, Contemp. Math. 84, AMS (1989).",
+            "type": "book"
+        },
+        {
+            "key": "EP",
+            "citation": "Erdős Problems, Problem #601, https://erdosproblems.com/601.",
+            "type": "website"
+        }
     ],
-    "originalContributions": [
-      "OrdinalGraph: graphs on ordinal vertex sets",
-      "HasInfinitePath: injective path predicate",
-      "IsIndependent: independence predicate",
-      "HasOrderType: order type of vertex subsets",
-      "PropertyP: path-vs-independent-set dichotomy",
-      "criticalOrdinal: ω₁^{ω+2} definition",
-      "erdos_hajnal_milner: main theorem (1970)",
-      "CriticalCaseConjecture: $250 prize problem",
-      "MartinsAxiom: set-theoretic axiom",
-      "larson_MA: Larson's theorem under MA (1990)",
-      "independenceNumber: cardinal-valued graph invariant",
-      "GeneralConjecture: $500 prize problem"
-    ],
-    "axiomCount": 3,
-    "lineCount": 247,
-    "assumptions": "3 axiom(s) and 14 sorry(s). See the Lean source for details."
-  },
-  "sections": [
-    {
-      "id": "imports",
-      "title": "Imports and Setup",
-      "startLine": 24,
-      "endLine": 33,
-      "summary": "Imports `Mathlib.SetTheory.Ordinal.Arithmetic`, `Cardinal.Basic`, `SimpleGraph.Basic`, and `Tactic`. Opens `Ordinal`, `Cardinal`, `SimpleGraph` namespaces.",
-      "mathContext": "Mathematical content: Imports `Mathlib.SetTheory.Ordinal.Arithmetic`, `Cardinal.Basic`, `SimpleGraph.Basic`, and `Tactic`. Opens `Ordinal`, `Cardinal`, `SimpleGraph` namespaces."
-    },
-    {
-      "id": "basic-defs",
-      "title": "Basic Definitions",
-      "summary": "Defines `OrdinalGraph` ($\\text{SimpleGraph}\\;\\alpha.\\text{toType}$), `HasInfinitePath` (injective $f : \\mathbb{N} \\to V$ with $f(n) \\sim f(n+1)$), `IsIndependent` (no edges in $S$), and `HasOrderType` ($\\text{Ordinal.type}$ of subrelation).",
-      "startLine": 34,
-      "endLine": 50,
-      "mathContext": "Defines `OrdinalGraph` ($\\text{SimpleGraph}\\;\\alpha.\\text{toType}$), `HasInfinitePath` (injective $f : \\mathbb{N} \\to V$ with $f(n) \\sim f(n+1)$), `IsIndependent` (no edges in $S$), and `HasOrderType` ($\\text{Ordinal.type}$ of subrelation)."
-    },
-    {
-      "id": "property-p",
-      "title": "Property $P(\\alpha)$",
-      "summary": "Defines $P(\\alpha)$: every graph on $\\alpha$ has infinite path OR independent set of order type $\\alpha$. Proves equivalence with the contrapositive formulation.",
-      "startLine": 51,
-      "endLine": 64,
-      "mathContext": "Defines $P(\\$\\alpha$)$: every graph on $\\$\\alpha$$ has infinite path OR independent set of order type $\\$\\alpha$$. Proves equivalence with the contrapositive formulation."
-    },
-    {
-      "id": "finite",
-      "title": "Finite Ordinals",
-      "summary": "$P(n)$ holds trivially for all finite $n$: no infinite path exists in a finite graph, so the independent set condition must hold.",
-      "startLine": 65,
-      "endLine": 76,
-      "mathContext": "Mathematical content: $P(n)$ holds trivially for all finite $n$: no infinite path exists in a finite graph, so the independent set condition must hold."
-    },
-    {
-      "id": "omega",
-      "title": "The First Infinite Ordinal: $P(\\omega)$",
-      "summary": "$P(\\omega)$ follows from the infinite Ramsey theorem ($\\omega \\to (\\omega)^2_2$): any graph on $\\omega$ has either an infinite clique (containing a ray) or an infinite independent set.",
-      "startLine": 77,
-      "endLine": 87,
-      "mathContext": "Verified: $P(\\omega)$ follows from the infinite Ramsey theorem ($\\omega \\to (\\omega)^2_2$): any graph on $\\omega$ has either an infinite clique (containing a ray) or an infinite independent set."
-    },
-    {
-      "id": "ehm",
-      "title": "Erdős-Hajnal-Milner Theorem (1970)",
-      "summary": "Defines `criticalOrdinal` $= \\omega_1^{\\omega+2}$ and axiomatizes the main result: $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on Cantor normal form.",
-      "startLine": 88,
-      "endLine": 101,
-      "mathContext": "Defines `criticalOrdinal` $= \\omega_1^{\\omega+2}$ and axiomatizes the main result: $P(\\$\\alpha$)$ holds for all $\\$\\alpha$ < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on Cantor normal form."
-    },
-    {
-      "id": "critical",
-      "title": "The Critical Case: $\\omega_1^{\\omega+2}$ ($250)",
-      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize.",
-      "startLine": 102,
-      "endLine": 116,
-      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize."
-    },
-    {
-      "id": "martins-axiom",
-      "title": "Martin's Axiom and Larson's Extension",
-      "summary": "Axiomatizes Martin's Axiom and Larson's theorem (1990): under MA, $P(\\alpha)$ holds for all $\\alpha$ with $|\\alpha| < 2^{\\aleph_0}$, extending the range far beyond $\\omega_1^{\\omega+2}$.",
-      "startLine": 117,
-      "endLine": 134,
-      "mathContext": "Axiomatizes Martin's Axiom and Larson's theorem (1990): under MA, $P(\\$\\alpha$)$ holds for all $\\$\\alpha$$ with $|\\$\\alpha$| < $$2^{{\\aleph_0}$}$$, extending the range far beyond $\\omega_1^{\\omega+2}$."
-    },
-    {
-      "id": "ordinal-arithmetic",
-      "title": "Ordinal Arithmetic and Hierarchy",
-      "summary": "Establishes the ordinal chain $\\omega < \\omega_1 < \\omega_1^\\omega < \\omega_1^{\\omega+1} < \\omega_1^{\\omega+2}$ and proves all countable ordinals satisfy $P$.",
-      "startLine": 135,
-      "endLine": 151,
-      "mathContext": "Verified: Establishes the ordinal chain $\\omega < \\omega_1 < \\omega_1^\\omega < \\omega_1^{\\omega+1} < \\omega_1^{\\omega+2}$ and proves all countable ordinals satisfy $P$."
-    },
-    {
-      "id": "graph-tools",
-      "title": "Graph-Theoretic Tools",
-      "summary": "States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
-      "startLine": 152,
-      "endLine": 165,
-      "mathContext": "Mathematical content: States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
-    },
-    {
-      "id": "independence",
-      "title": "Independence Number",
-      "summary": "Defines `independenceNumber` as $\\sup_{S \\text{ independent}} |S|$ and establishes that $P(\\alpha)$ failure requires $\\alpha(G) < |\\alpha|$ with no infinite path.",
-      "startLine": 166,
-      "endLine": 197,
-      "mathContext": "Defines `independenceNumber` as $\\sup_{S \\text{ independent}} |S|$ and establishes that $P(\\$\\alpha$)$ failure requires $\\$\\alpha$(G) < |\\$\\alpha$|$ with no infinite path."
-    },
-    {
-      "id": "general",
-      "title": "The General Conjecture ($500)",
-      "summary": "States `GeneralConjecture`: $P(\\alpha)$ holds for all limit ordinals $\\alpha$. Proves the partial result (limit ordinals below $\\omega_1^{\\omega+2}$) and the knowledge gap between known and conjectured.",
-      "startLine": 198,
-      "endLine": 247,
-      "mathContext": "States `GeneralConjecture`: $P(\\alpha)$ holds for all limit ordinals $\\alpha$. Proves the partial result (limit ordinals below $\\omega_1^{\\omega+2}$) and the knowledge gap between known and conjectured."
-    }
-  ],
-  "overview": {
-    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erdős, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erdős-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
-    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erdős-Hajnal-Milner theorem.",
-    "text": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erdős-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, König's lemma, independence number, transfinite induction.",
-    "keyInsights": [
-      "**Erdős-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
-      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ — new techniques are needed",
-      "**Larson (1990):** Under Martin's Axiom, $P(\\alpha)$ extends to all $\\alpha$ with $|\\alpha| < 2^{\\aleph_0}$, showing set-theoretic dependence",
-      "**Ramsey-type dichotomy:** The problem generalizes the infinite Ramsey theorem from $\\omega$ to arbitrary ordinals with order type requirements",
-      "**Two-tier prize:** $250 for the critical case $P(\\omega_1^{\\omega+2})$, $500 for the full generalization to all limit ordinals"
-    ],
-    "prerequisites": [
-      "Combinatorics and number theory",
-      "Graph theory (vertices, edges, colorings)",
-      "Set theory and cardinality"
+    "crossReferences": [
+        {
+            "targetId": "erdos-111",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+        },
+        {
+            "targetId": "erdos-1169",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+        },
+        {
+            "targetId": "erdos-1174",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+        }
     ]
-  },
-  "conclusion": {
-    "summary": "This formalization captures Erdős Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erdős-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
-    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms — the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erdős-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
-    "openQuestions": [
-      "Does P(ω₁^{ω+2}) hold? ($250 — the critical boundary case)",
-      "Does P(α) hold for all limit ordinals α? ($500 — the general conjecture)",
-      "Is the answer independent of ZFC (provable under MA but not in ZFC alone)?",
-      "Can the Erdős-Hajnal-Milner bound ω₁^{ω+2} be improved in ZFC?",
-      "What happens for singular cardinals and their ordinal powers?"
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.SetTheory.Ordinal.Basic",
-      "Mathlib.SetTheory.Ordinal.Arithmetic",
-      "Mathlib.SetTheory.Cardinal.Basic",
-      "Mathlib.Combinatorics.SimpleGraph.Basic",
-      "Mathlib.Tactic"
-    ],
-    "opens": [
-      "Ordinal",
-      "Cardinal",
-      "SimpleGraph"
-    ],
-    "namespace": "Erdos601",
-    "lineCount": 247,
-    "axiomCount": 3,
-    "theoremCount": 19,
-    "definitionCount": 13
-  },
-  "references": [
-    {
-      "key": "EHM70",
-      "citation": "Erdős, Paul, Hajnal, András, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
-      "type": "paper"
-    },
-    {
-      "key": "La90",
-      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal ω^ω, Ann. Pure Appl. Logic 48 (1990), 253-255.",
-      "type": "paper"
-    },
-    {
-      "key": "EH77",
-      "citation": "Erdős, Paul and Hajnal, András, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
-      "type": "paper"
-    },
-    {
-      "key": "To85",
-      "citation": "Todorcevic, Stevo, Partition Problems in Topology, Contemp. Math. 84, AMS (1989).",
-      "type": "book"
-    },
-    {
-      "key": "EP",
-      "citation": "Erdős Problems, Problem #601, https://erdosproblems.com/601.",
-      "type": "website"
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "erdos-111",
-      "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
-    },
-    {
-      "targetId": "erdos-1169",
-      "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
-    },
-    {
-      "targetId": "erdos-1174",
-      "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
-    }
-  ]
 }

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -1,198 +1,198 @@
 {
-  "id": "erdos-666",
-  "title": "Erdős Problem #666: C₆ in Hypercube Subgraphs",
-  "slug": "erdos-666",
-  "description": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
-  "meta": {
-    "author": "Chung (1992 disproof), Brouwer-Dejter-Thomassen (1993), Conder (1993)",
-    "sourceUrl": "https://erdosproblems.com/666",
-    "date": "1992",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/Erdos666Problem.lean",
-    "tags": [
-      "erdos",
-      "graph-theory",
-      "hypercube",
-      "cycles",
-      "extremal-graph-theory",
-      "disproved"
+    "id": "erdos-666",
+    "title": "Erdős Problem #666: C₆ in Hypercube Subgraphs",
+    "slug": "erdos-666",
+    "description": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
+    "meta": {
+        "author": "Chung (1992 disproof), Brouwer-Dejter-Thomassen (1993), Conder (1993)",
+        "sourceUrl": "https://erdosproblems.com/666",
+        "date": "1992",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/Erdos666Problem.lean",
+        "tags": [
+            "erdos",
+            "graph-theory",
+            "hypercube",
+            "cycles",
+            "extremal-graph-theory",
+            "disproved"
+        ],
+        "badge": "axiom",
+        "sorries": 1,
+        "erdosNumber": 666,
+        "erdosUrl": "https://erdosproblems.com/666",
+        "erdosProblemStatus": "disproved",
+        "dateAdded": "2026-01-22",
+        "mathlib_version": "4.26.0",
+        "mathlibDependencies": [
+            {
+                "theorem": "SimpleGraph.Basic",
+                "description": "Basic graph definitions and properties",
+                "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+            },
+            {
+                "theorem": "Nat.popcount",
+                "description": "Population count for XOR-based adjacency",
+                "module": "Mathlib.Data.Nat.Basic"
+            },
+            {
+                "theorem": "Fin",
+                "description": "Finite types for hypercube vertices",
+                "module": "Mathlib.Data.Fin.Basic"
+            }
+        ],
+        "originalContributions": [
+            "Hypercube definition via XOR popcount: vertices adjacent iff differ in exactly one bit",
+            "hypercubeVertices: |V(Qₙ)| = 2ⁿ",
+            "hypercubeEdges: |E(Qₙ)| = n·2ⁿ⁻¹",
+            "hypercube_regular axiom: Qₙ is n-regular",
+            "HasCycle definition: injective sequence with cyclic adjacency",
+            "HasC4, HasC6, HasC2k cycle predicates",
+            "EpsilonDenseSubgraph: subgraph with ε-fraction of edges",
+            "ErdosConjecture: original (disproved) conjecture",
+            "erdos_conjecture_false theorem: main disproof",
+            "chung_1992 axiom: 4-partition into C₆-free subgraphs",
+            "brouwer_dejter_thomassen_1993 axiom: independent 4-coloring",
+            "conder_1993 axiom: improved 3-coloring",
+            "GeneralizedConjecture: open question for C_{2k}"
+        ],
+        "axiomCount": 5,
+        "lineCount": 308,
+        "assumptions": "5 axiom(s) and 2 sorry(s). See the Lean source for details."
+    },
+    "overview": {
+        "historicalContext": "**Erdős Problem #666**\n\nErdős posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Qₙ has 2ⁿ vertices (binary strings of length n) and n·2ⁿ⁻¹ edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Qₙ's edges into C₆-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C₄ and C₆\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Qₙ can be 3-colored with no monochromatic C₄ or C₆. This means subgraphs with 1/3 of all edges need not contain C₆.",
+        "problemStatement": "**Problem Statement (Disproved)**\n\nLet Qₙ be the n-dimensional hypercube (2ⁿ vertices, n·2ⁿ⁻¹ edges).\n\n**Conjecture:** For every ε > 0, if n is sufficiently large, every subgraph of Qₙ with ≥ ε·n·2ⁿ⁻¹ edges contains C₆.\n\n**Answer:** NO\n\n**Counterexamples:**\n- ε = 1/4: Chung's 4-partition (1992)\n- ε = 1/3: Conder's 3-coloring (1993)\n\n**Generalized Conjecture (OPEN):** For C_{2k}, ∃ c > 0 and aₖ < 1 such that ≥ c·n^{aₖ}·2ⁿ edges forces C_{2k}, with aₖ → 0 as k → ∞.",
+        "text": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
+        "proofStrategy": "**Formalization Approach**\n\n1. **Hypercube Definition:** Qₙ defined via XOR popcount - vertices in Fin(2ⁿ) are adjacent iff their XOR has exactly one 1-bit (Hamming distance 1)\n\n2. **Cycle Definitions:**\n   - HasCycle G k: injective k-sequence with cyclic adjacency\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\n\n3. **Density:**\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\n\n4. **Main Results:**\n   - ErdosConjecture: the (false) original conjecture\n   - erdos_conjecture_false: theorem showing it's false\n   - chung_1992 axiom: 4-partition exists\n   - conder_1993 axiom: 3-coloring exists\n\n5. **Why Axioms:** The partition constructions are combinatorial and not in Mathlib",
+        "keyInsights": [
+            "**Hypercube Structure:** Qₙ vertices are binary strings, adjacent iff Hamming distance = 1",
+            "**Size:** |V| = 2ⁿ, |E| = n·2ⁿ⁻¹, degree = n (n-regular)",
+            "**Chung's Partition (1992):** Qₙ edges split into 4 C₆-free parts, each with ~1/4 of edges",
+            "**Conder's Improvement (1993):** Only 3 colors needed - even denser C₆-free subgraphs exist",
+            "**The Disproof:** ε = 1/4 (or 1/3) counterexamples refute the conjecture",
+            "**Open Generalization:** For C_{2k}, what density threshold aₖ forces the cycle?"
+        ],
+        "prerequisites": [
+            "Combinatorics and number theory",
+            "Graph theory (vertices, edges, colorings)",
+            "Extremal graph theory (Turán-type problems)"
+        ]
+    },
+    "sections": [
+        {
+            "id": "hypercube",
+            "title": "Hypercube Graph",
+            "summary": "Definition of Qₙ via XOR, vertices, edges, regularity",
+            "startLine": 36,
+            "endLine": 68,
+            "mathContext": "Formal definition: Definition of Qₙ via XOR, vertices, edges, regularity"
+        },
+        {
+            "id": "cycles",
+            "title": "Cycles in Graphs",
+            "summary": "HasCycle, HasC4, HasC6, HasC2k definitions",
+            "startLine": 69,
+            "endLine": 97,
+            "mathContext": "Formal definition: HasCycle, HasC4, HasC6, HasC2k definitions"
+        },
+        {
+            "id": "density",
+            "title": "Subgraphs and Density",
+            "summary": "DenseSubgraph, EpsilonDenseSubgraph",
+            "startLine": 98,
+            "endLine": 118,
+            "mathContext": "Mathematical content: DenseSubgraph, EpsilonDenseSubgraph"
+        },
+        {
+            "id": "conjecture",
+            "title": "Erdős's Conjecture (Disproved)",
+            "summary": "ErdosConjecture, erdos_conjecture_false",
+            "startLine": 119,
+            "endLine": 141,
+            "mathContext": "Mathematical content: ErdosConjecture, erdos_conjecture_false"
+        },
+        {
+            "id": "chung",
+            "title": "Chung's Result (1992)",
+            "summary": "4-partition into C₆-free subgraphs",
+            "startLine": 142,
+            "endLine": 175,
+            "mathContext": "Mathematical content: 4-partition into C₆-free subgraphs"
+        },
+        {
+            "id": "bdt",
+            "title": "Brouwer-Dejter-Thomassen (1993)",
+            "summary": "Independent 4-coloring result",
+            "startLine": 176,
+            "endLine": 198,
+            "mathContext": "Mathematical content: Independent 4-coloring result"
+        },
+        {
+            "id": "conder",
+            "title": "Conder's Improvement (1993)",
+            "summary": "3-coloring, ε = 1/3 counterexample",
+            "startLine": 199,
+            "endLine": 232,
+            "mathContext": "Mathematical content: 3-coloring, ε = 1/3 counterexample"
+        },
+        {
+            "id": "generalized",
+            "title": "Generalized Conjecture",
+            "summary": "Open question for C_{2k}",
+            "startLine": 233,
+            "endLine": 253,
+            "mathContext": "Mathematical content: Open question for C_{2k}"
+        },
+        {
+            "id": "summary",
+            "title": "Summary",
+            "summary": "Main theorem combining all results",
+            "startLine": 272,
+            "endLine": 306,
+            "mathContext": "Verified: Main theorem combining all results"
+        }
     ],
-    "badge": "axiom",
-    "sorries": 2,
-    "erdosNumber": 666,
-    "erdosUrl": "https://erdosproblems.com/666",
-    "erdosProblemStatus": "disproved",
-    "dateAdded": "2026-01-22",
-    "mathlib_version": "4.26.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "SimpleGraph.Basic",
-        "description": "Basic graph definitions and properties",
-        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
-      },
-      {
-        "theorem": "Nat.popcount",
-        "description": "Population count for XOR-based adjacency",
-        "module": "Mathlib.Data.Nat.Basic"
-      },
-      {
-        "theorem": "Fin",
-        "description": "Finite types for hypercube vertices",
-        "module": "Mathlib.Data.Fin.Basic"
-      }
-    ],
-    "originalContributions": [
-      "Hypercube definition via XOR popcount: vertices adjacent iff differ in exactly one bit",
-      "hypercubeVertices: |V(Qₙ)| = 2ⁿ",
-      "hypercubeEdges: |E(Qₙ)| = n·2ⁿ⁻¹",
-      "hypercube_regular axiom: Qₙ is n-regular",
-      "HasCycle definition: injective sequence with cyclic adjacency",
-      "HasC4, HasC6, HasC2k cycle predicates",
-      "EpsilonDenseSubgraph: subgraph with ε-fraction of edges",
-      "ErdosConjecture: original (disproved) conjecture",
-      "erdos_conjecture_false theorem: main disproof",
-      "chung_1992 axiom: 4-partition into C₆-free subgraphs",
-      "brouwer_dejter_thomassen_1993 axiom: independent 4-coloring",
-      "conder_1993 axiom: improved 3-coloring",
-      "GeneralizedConjecture: open question for C_{2k}"
-    ],
-    "axiomCount": 5,
-    "lineCount": 306,
-    "assumptions": "5 axiom(s) and 2 sorry(s). See the Lean source for details."
-  },
-  "overview": {
-    "historicalContext": "**Erdős Problem #666**\n\nErdős posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Qₙ has 2ⁿ vertices (binary strings of length n) and n·2ⁿ⁻¹ edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Qₙ's edges into C₆-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C₄ and C₆\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Qₙ can be 3-colored with no monochromatic C₄ or C₆. This means subgraphs with 1/3 of all edges need not contain C₆.",
-    "problemStatement": "**Problem Statement (Disproved)**\n\nLet Qₙ be the n-dimensional hypercube (2ⁿ vertices, n·2ⁿ⁻¹ edges).\n\n**Conjecture:** For every ε > 0, if n is sufficiently large, every subgraph of Qₙ with ≥ ε·n·2ⁿ⁻¹ edges contains C₆.\n\n**Answer:** NO\n\n**Counterexamples:**\n- ε = 1/4: Chung's 4-partition (1992)\n- ε = 1/3: Conder's 3-coloring (1993)\n\n**Generalized Conjecture (OPEN):** For C_{2k}, ∃ c > 0 and aₖ < 1 such that ≥ c·n^{aₖ}·2ⁿ edges forces C_{2k}, with aₖ → 0 as k → ∞.",
-    "text": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Hypercube Definition:** Qₙ defined via XOR popcount - vertices in Fin(2ⁿ) are adjacent iff their XOR has exactly one 1-bit (Hamming distance 1)\n\n2. **Cycle Definitions:**\n   - HasCycle G k: injective k-sequence with cyclic adjacency\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\n\n3. **Density:**\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\n\n4. **Main Results:**\n   - ErdosConjecture: the (false) original conjecture\n   - erdos_conjecture_false: theorem showing it's false\n   - chung_1992 axiom: 4-partition exists\n   - conder_1993 axiom: 3-coloring exists\n\n5. **Why Axioms:** The partition constructions are combinatorial and not in Mathlib",
-    "keyInsights": [
-      "**Hypercube Structure:** Qₙ vertices are binary strings, adjacent iff Hamming distance = 1",
-      "**Size:** |V| = 2ⁿ, |E| = n·2ⁿ⁻¹, degree = n (n-regular)",
-      "**Chung's Partition (1992):** Qₙ edges split into 4 C₆-free parts, each with ~1/4 of edges",
-      "**Conder's Improvement (1993):** Only 3 colors needed - even denser C₆-free subgraphs exist",
-      "**The Disproof:** ε = 1/4 (or 1/3) counterexamples refute the conjecture",
-      "**Open Generalization:** For C_{2k}, what density threshold aₖ forces the cycle?"
-    ],
-    "prerequisites": [
-      "Combinatorics and number theory",
-      "Graph theory (vertices, edges, colorings)",
-      "Extremal graph theory (Turán-type problems)"
+    "conclusion": {
+        "summary": "Erdős Problem #666 asked whether ε-dense hypercube subgraphs must contain C₆. The answer is NO: Chung (1992) and Brouwer-Dejter-Thomassen (1993) independently showed Qₙ can be 4-partitioned into C₆-free subgraphs. Conder (1993) improved this to 3 colors.",
+        "implications": "The result shows the hypercube has surprising structure allowing sparse cycle-free subgraphs. This connects to Ramsey-Turán problems in hypercubes and extremal graph theory in structured graphs.",
+        "openQuestions": [
+            "What is the minimum number of colors to avoid monochromatic C₆ in Qₙ?",
+            "For C_{2k}, what density threshold forces the cycle?",
+            "Does aₖ → 0 as k → ∞ in the generalized conjecture?"
+        ]
+    },
+    "leanFile": {
+        "imports": [
+            "Mathlib.Data.Nat.Basic",
+            "Mathlib.Combinatorics.SimpleGraph.Basic",
+            "Mathlib.Data.Fin.Basic"
+        ],
+        "opens": [
+            "Nat",
+            "SimpleGraph"
+        ],
+        "namespace": "Erdos666",
+        "lineCount": 308,
+        "axiomCount": 5,
+        "theoremCount": 4,
+        "definitionCount": 10
+    },
+    "crossReferences": [
+        {
+            "targetId": "erdos-1080",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: cycles, disproved, extremal-graph-theory, graph-theory"
+        },
+        {
+            "targetId": "erdos-1035",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory, hypercube"
+        },
+        {
+            "targetId": "erdos-147",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: disproved, extremal-graph-theory, graph-theory"
+        }
     ]
-  },
-  "sections": [
-    {
-      "id": "hypercube",
-      "title": "Hypercube Graph",
-      "summary": "Definition of Qₙ via XOR, vertices, edges, regularity",
-      "startLine": 36,
-      "endLine": 68,
-      "mathContext": "Formal definition: Definition of Qₙ via XOR, vertices, edges, regularity"
-    },
-    {
-      "id": "cycles",
-      "title": "Cycles in Graphs",
-      "summary": "HasCycle, HasC4, HasC6, HasC2k definitions",
-      "startLine": 69,
-      "endLine": 97,
-      "mathContext": "Formal definition: HasCycle, HasC4, HasC6, HasC2k definitions"
-    },
-    {
-      "id": "density",
-      "title": "Subgraphs and Density",
-      "summary": "DenseSubgraph, EpsilonDenseSubgraph",
-      "startLine": 98,
-      "endLine": 118,
-      "mathContext": "Mathematical content: DenseSubgraph, EpsilonDenseSubgraph"
-    },
-    {
-      "id": "conjecture",
-      "title": "Erdős's Conjecture (Disproved)",
-      "summary": "ErdosConjecture, erdos_conjecture_false",
-      "startLine": 119,
-      "endLine": 141,
-      "mathContext": "Mathematical content: ErdosConjecture, erdos_conjecture_false"
-    },
-    {
-      "id": "chung",
-      "title": "Chung's Result (1992)",
-      "summary": "4-partition into C₆-free subgraphs",
-      "startLine": 142,
-      "endLine": 175,
-      "mathContext": "Mathematical content: 4-partition into C₆-free subgraphs"
-    },
-    {
-      "id": "bdt",
-      "title": "Brouwer-Dejter-Thomassen (1993)",
-      "summary": "Independent 4-coloring result",
-      "startLine": 176,
-      "endLine": 198,
-      "mathContext": "Mathematical content: Independent 4-coloring result"
-    },
-    {
-      "id": "conder",
-      "title": "Conder's Improvement (1993)",
-      "summary": "3-coloring, ε = 1/3 counterexample",
-      "startLine": 199,
-      "endLine": 232,
-      "mathContext": "Mathematical content: 3-coloring, ε = 1/3 counterexample"
-    },
-    {
-      "id": "generalized",
-      "title": "Generalized Conjecture",
-      "summary": "Open question for C_{2k}",
-      "startLine": 233,
-      "endLine": 253,
-      "mathContext": "Mathematical content: Open question for C_{2k}"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "Main theorem combining all results",
-      "startLine": 272,
-      "endLine": 306,
-      "mathContext": "Verified: Main theorem combining all results"
-    }
-  ],
-  "conclusion": {
-    "summary": "Erdős Problem #666 asked whether ε-dense hypercube subgraphs must contain C₆. The answer is NO: Chung (1992) and Brouwer-Dejter-Thomassen (1993) independently showed Qₙ can be 4-partitioned into C₆-free subgraphs. Conder (1993) improved this to 3 colors.",
-    "implications": "The result shows the hypercube has surprising structure allowing sparse cycle-free subgraphs. This connects to Ramsey-Turán problems in hypercubes and extremal graph theory in structured graphs.",
-    "openQuestions": [
-      "What is the minimum number of colors to avoid monochromatic C₆ in Qₙ?",
-      "For C_{2k}, what density threshold forces the cycle?",
-      "Does aₖ → 0 as k → ∞ in the generalized conjecture?"
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Combinatorics.SimpleGraph.Basic",
-      "Mathlib.Data.Fin.Basic"
-    ],
-    "opens": [
-      "Nat",
-      "SimpleGraph"
-    ],
-    "namespace": "Erdos666",
-    "lineCount": 306,
-    "axiomCount": 5,
-    "theoremCount": 4,
-    "definitionCount": 10
-  },
-  "crossReferences": [
-    {
-      "targetId": "erdos-1080",
-      "relationship": "related",
-      "description": "Related Erdős problem sharing themes: cycles, disproved, extremal-graph-theory, graph-theory"
-    },
-    {
-      "targetId": "erdos-1035",
-      "relationship": "related",
-      "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory, hypercube"
-    },
-    {
-      "targetId": "erdos-147",
-      "relationship": "related",
-      "description": "Related Erdős problem sharing themes: disproved, extremal-graph-theory, graph-theory"
-    }
-  ]
 }

--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -1,196 +1,196 @@
 {
-  "id": "erdos-729",
-  "title": "Erdős Problem #729: Factorial Divisibility Modulo Small Primes",
-  "slug": "erdos-729",
-  "description": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C·log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b ≤ n + O(log n) persists even ignoring small primes.",
-  "meta": {
-    "author": "Barreto-Leeham (solution), Erdős (1968)",
-    "sourceUrl": "https://erdosproblems.com/729",
-    "date": "2020s",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/Erdos729Problem.lean",
-    "tags": [
-      "erdos",
-      "number-theory",
-      "factorials",
-      "divisibility",
-      "legendre-formula"
+    "id": "erdos-729",
+    "title": "Erdős Problem #729: Factorial Divisibility Modulo Small Primes",
+    "slug": "erdos-729",
+    "description": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C·log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b ≤ n + O(log n) persists even ignoring small primes.",
+    "meta": {
+        "author": "Barreto-Leeham (solution), Erdős (1968)",
+        "sourceUrl": "https://erdosproblems.com/729",
+        "date": "2020s",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/Erdos729Problem.lean",
+        "tags": [
+            "erdos",
+            "number-theory",
+            "factorials",
+            "divisibility",
+            "legendre-formula"
+        ],
+        "badge": "axiom",
+        "sorries": 0,
+        "erdosNumber": 729,
+        "erdosUrl": "https://erdosproblems.com/729",
+        "erdosProblemStatus": "solved",
+        "mathlibDependencies": [
+            {
+                "theorem": "Nat.factorial",
+                "description": "Factorial function for natural numbers",
+                "module": "Mathlib.Data.Nat.Factorial.Basic"
+            },
+            {
+                "theorem": "padicValNat",
+                "description": "p-adic valuation of natural numbers",
+                "module": "Mathlib.NumberTheory.Padics.PadicVal"
+            },
+            {
+                "theorem": "Real.log",
+                "description": "Natural logarithm for growth bounds",
+                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+            }
+        ],
+        "originalContributions": [
+            "Formalized factorial divisibility modulo small primes",
+            "Axiomatized Barreto-Leeham's extension of Erdős's bound",
+            "Connected Legendre's formula to the divisibility constraint",
+            "Defined relaxed divisibility allowing small prime factors"
+        ],
+        "axiomCount": 6,
+        "lineCount": 225,
+        "assumptions": "7 axiom(s) and 2 sorry(s). See the Lean source for details.",
+        "mathlib_version": "4.26.0"
+    },
+    "overview": {
+        "historicalContext": "Erdős proved in 1968 that if $a!b! \\mid n!$ then $a + b \\leq n + O(\\log n)$, using an elegant argument based on Legendre's formula for $v_2(n!) = n - s_2(n)$, where $s_2(n)$ is the binary digit sum. Problem 729, posed later, asks whether this logarithmic bound can be defeated by \"ignoring\" small primes: specifically, whether there are infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ such that $n!/(a!b!)$ has denominator divisible only by primes $\\leq C$. Barreto and Leeham resolved the problem negatively, showing that large primes alone carry sufficient information to enforce the bound. Their proof adapts the technique from Problem #728, extending it to show that for any prime $p > C$, the constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ already implies $a + b \\leq n + O(\\log n)$. This reveals a fundamental rigidity in factorial arithmetic: the divisibility structure is controlled by all primes collectively, and no finite set of exceptions can weaken it.",
+        "problemStatement": "Let $C > 0$ be a constant. Are there infinitely many integers $a, b, n$ with $a + b > n + C\\log n$ such that the denominator of $n!/(a!b!)$ contains only primes $\\leq C$?",
+        "text": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C·log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b ≤ n + O(log n) persists even ignoring small primes.",
+        "proofStrategy": "The formalization defines `DividesFactorial` and `DividesFactorialModSmall` (allowing small prime factors in the denominator), states `InfinitelyManyExceptions` as the open question, and axiomatizes both Erdős's 1968 result and the Barreto-Leeham resolution. Legendre's formula is stated via `factorialPadicVal` and the digit sum identity. The main theorem `erdos_729_statement` combines both results, and `erdos_729_summary` provides the complete answer. Two `sorry`s remain: `legendre_for_two` and `binomial_rigidity`.",
+        "keyInsights": [
+            "Legendre's formula $v_p(n!) = (n - s_p(n))/(p-1)$ connects factorial divisibility to base-$p$ digit sums, with the special case $v_2(n!) = n - s_2(n)$ being particularly clean",
+            "If $a!b! \\mid n!$, then $v_p(a!) + v_p(b!) \\leq v_p(n!)$ for all primes $p$. Using just $p = 2$ and the digit sum identity gives $a + b \\leq n + s_2(a) + s_2(b) - s_2(n) \\leq n + O(\\log n)$",
+            "The relaxed condition allows multiplying by a factor $k$ with only small prime factors, but this cannot help: for primes $p > C$, the constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ is unaffected by $k$",
+            "Large primes carry the full strength of the divisibility constraint, making the bound robust to ignoring any finite set of primes",
+            "The problem connects to Problem #728 (a similar question about multinomial coefficients) and reveals the rigidity of factorial arithmetic under prime localization"
+        ],
+        "prerequisites": [
+            "Combinatorics and number theory",
+            "Number theory (primes, divisibility)"
+        ]
+    },
+    "sections": [
+        {
+            "id": "basic-definitions",
+            "title": "Basic Definitions",
+            "startLine": 35,
+            "endLine": 56,
+            "summary": "Defines `factorialPadicVal` via Legendre's formula $\\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$, axiomatizes `legendre_formula`, and defines `DividesFactorial n a b` as $a! \\cdot b! \\mid n!$.",
+            "mathContext": "Formal definition: Defines `factorialPadicVal` via Legendre's formula $\\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$, axiomatizes `legendre_formula`, and defines `DividesFactorial n a b` as $a! \\cdot b! \\mid n!$."
+        },
+        {
+            "id": "erdos-classical",
+            "title": "Erdős's Classical Result (1968)",
+            "startLine": 57,
+            "endLine": 74,
+            "summary": "Axiomatizes `erdos_1968_classical`: $a!b! \\mid n! \\implies a + b \\leq n + O(\\log n)$. Proves `erdos_proof_via_powers_of_two` by forwarding to the axiom, documenting that the original proof uses only the $p = 2$ constraint.",
+            "mathContext": "Axiomatizes `erdos_1968_classical`: $a!b! \\implies a + b \\leq n + O(\\log n)$. Proves `erdos_proof_via_powers_of_two` by forwarding to the axiom, documenting that the original proof uses only the $p = 2$ constraint."
+        },
+        {
+            "id": "relaxed-condition",
+            "title": "The Relaxed Condition",
+            "startLine": 75,
+            "endLine": 94,
+            "summary": "Defines `SmallPrimes C` as primes $\\leq C$, and `DividesFactorialModSmall` allowing a correction factor $k$ with only small prime factors. This formalizes 'ignoring small primes in the denominator'.",
+            "mathContext": "Formal definition: Defines `SmallPrimes C` as primes $\\leq C$, and `DividesFactorialModSmall` allowing a correction factor $k$ with only small prime factors. This formalizes 'ignoring small primes in the denominator'."
+        },
+        {
+            "id": "question",
+            "title": "The Question",
+            "startLine": 95,
+            "endLine": 107,
+            "summary": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ and `DividesFactorialModSmall`? This is the formal statement of Erdős Problem 729.",
+            "mathContext": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\$\\log n$$ and `DividesFactorialModSmall`? This is the formal statement of Erdős Problem 729."
+        },
+        {
+            "id": "barreto-leeham",
+            "title": "Barreto-Leeham Resolution",
+            "startLine": 108,
+            "endLine": 123,
+            "summary": "Axiomatizes `barreto_leeham_theorem`: $\\neg\\text{InfinitelyManyExceptions}(C)$ for all $C > 0$. Also states `barreto_leeham_bound`: the bound $a + b \\leq n + D\\log n$ persists with an explicit constant $D$.",
+            "mathContext": "Axiomatizes `barreto_leeham_theorem`: $\\neg\\text{InfinitelyManyExceptions}(C)$ for all $C > 0$. Also states `barreto_leeham_bound`: the bound $a + b \\leq n + D\\log n$ persists with an explicit constant $D$."
+        },
+        {
+            "id": "proof-strategy",
+            "title": "Proof Strategy",
+            "startLine": 124,
+            "endLine": 140,
+            "summary": "Axiomatizes `proof_extends_erdos_argument`: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition, since the correction factor $k$ has no $p$-component.",
+            "mathContext": "Axiomatizes `proof_extends_erdos_argument`: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition, since the correction factor $k$ has no $p$-component."
+        },
+        {
+            "id": "legendre-details",
+            "title": "Legendre's Formula Details",
+            "startLine": 141,
+            "endLine": 160,
+            "summary": "Defines `digitSum p n` recursively and axiomatizes `legendre_identity`: $v_p(n!) = (n - s_p(n))/(p-1)$. The theorem `legendre_for_two` ($v_2(n!) = n - s_2(n)$) has a `sorry`.",
+            "mathContext": "Formal definition: Defines `digitSum p n` recursively and axiomatizes `legendre_identity`: $v_p(n!) = (n - s_p(n))/(p-1)$. The theorem `legendre_for_two` ($v_2(n!) = n - s_2(n)$) has a `sorry`."
+        },
+        {
+            "id": "implications",
+            "title": "Implications and Rigidity",
+            "startLine": 161,
+            "endLine": 178,
+            "summary": "Axiomatizes `factorial_rigidity` and states `binomial_rigidity` (with `sorry`): when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer.",
+            "mathContext": "Axiomatized: Axiomatizes `factorial_rigidity` and states `binomial_rigidity` (with `sorry`): when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer."
+        },
+        {
+            "id": "main-statement",
+            "title": "Main Problem Statement",
+            "startLine": 179,
+            "endLine": 193,
+            "summary": "Proves `erdos_729_statement`: combines `erdos_1968_classical` and `barreto_leeham_theorem` into a single conjunction, establishing both the classical bound and its robustness.",
+            "mathContext": "Verified: Proves `erdos_729_statement`: combines `erdos_1968_classical` and `barreto_leeham_theorem` into a single conjunction, establishing both the classical bound and its robustness."
+        },
+        {
+            "id": "summary",
+            "title": "Summary",
+            "startLine": 194,
+            "endLine": 207,
+            "summary": "Proves `erdos_729_summary`: the answer is NO, and the explicit bound $a + b \\leq n + D\\log n$ holds, combining `barreto_leeham_theorem` and `barreto_leeham_bound`.",
+            "mathContext": "Proves `erdos_729_summary`: the answer is NO, and the explicit bound $a + b \\leq n + D\\$\\log n$$ holds, combining `barreto_leeham_theorem` and `barreto_leeham_bound`."
+        }
     ],
-    "badge": "axiom",
-    "sorries": 2,
-    "erdosNumber": 729,
-    "erdosUrl": "https://erdosproblems.com/729",
-    "erdosProblemStatus": "solved",
-    "mathlibDependencies": [
-      {
-        "theorem": "Nat.factorial",
-        "description": "Factorial function for natural numbers",
-        "module": "Mathlib.Data.Nat.Factorial.Basic"
-      },
-      {
-        "theorem": "padicValNat",
-        "description": "p-adic valuation of natural numbers",
-        "module": "Mathlib.NumberTheory.Padics.PadicVal"
-      },
-      {
-        "theorem": "Real.log",
-        "description": "Natural logarithm for growth bounds",
-        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-      }
+    "conclusion": {
+        "summary": "Erdős Problem 729 is solved negatively: there are NOT infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ where the denominator of $n!/(a!b!)$ has only small prime factors. The formalization captures the classical Erdős bound, the relaxed condition, the Barreto-Leeham resolution, and the proof strategy via large primes, with two remaining `sorry`s on supporting lemmas.",
+        "implications": "The result demonstrates a fundamental rigidity in factorial arithmetic: the constraint $a + b \\leq n + O(\\log n)$ arises from all primes collectively and cannot be circumvented by ignoring finitely many. This connects to the robustness of Legendre's formula under prime localization and suggests that factorial divisibility is determined by the global prime structure, not any local subset.",
+        "openQuestions": [
+            "What is the optimal constant in the $O(\\log n)$ bound? Can it be made explicit as a function of $C$?",
+            "Can the proof of `legendre_for_two` ($v_2(n!) = n - s_2(n)$) be completed in Lean using Mathlib's `padicValNat` machinery?",
+            "How does the bound behave for specific parametric families, e.g., $(a, b, n) = (n/2, n/2, n)$?",
+            "Is there an analogue for multinomial coefficients $n!/(a_1! \\cdots a_k!)$ with $k > 2$?"
+        ]
+    },
+    "crossReferences": [
+        {
+            "targetId": "kummer-theorem",
+            "relationship": "related",
+            "description": "Kummer's theorem and Legendre's formula both connect factorial divisibility to digit structure in various bases"
+        },
+        {
+            "targetId": "erdos-731",
+            "relationship": "related",
+            "description": "Problem 731 also studies divisibility of binomial-type expressions, focusing on central binomial coefficients"
+        },
+        {
+            "targetId": "prime-number-theorem",
+            "relationship": "related",
+            "description": "The distribution of primes underlies the O(log n) bound via digit sum estimates"
+        }
     ],
-    "originalContributions": [
-      "Formalized factorial divisibility modulo small primes",
-      "Axiomatized Barreto-Leeham's extension of Erdős's bound",
-      "Connected Legendre's formula to the divisibility constraint",
-      "Defined relaxed divisibility allowing small prime factors"
-    ],
-    "axiomCount": 6,
-    "lineCount": 215,
-    "assumptions": "7 axiom(s) and 2 sorry(s). See the Lean source for details.",
-    "mathlib_version": "4.26.0"
-  },
-  "overview": {
-    "historicalContext": "Erdős proved in 1968 that if $a!b! \\mid n!$ then $a + b \\leq n + O(\\log n)$, using an elegant argument based on Legendre's formula for $v_2(n!) = n - s_2(n)$, where $s_2(n)$ is the binary digit sum. Problem 729, posed later, asks whether this logarithmic bound can be defeated by \"ignoring\" small primes: specifically, whether there are infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ such that $n!/(a!b!)$ has denominator divisible only by primes $\\leq C$. Barreto and Leeham resolved the problem negatively, showing that large primes alone carry sufficient information to enforce the bound. Their proof adapts the technique from Problem #728, extending it to show that for any prime $p > C$, the constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ already implies $a + b \\leq n + O(\\log n)$. This reveals a fundamental rigidity in factorial arithmetic: the divisibility structure is controlled by all primes collectively, and no finite set of exceptions can weaken it.",
-    "problemStatement": "Let $C > 0$ be a constant. Are there infinitely many integers $a, b, n$ with $a + b > n + C\\log n$ such that the denominator of $n!/(a!b!)$ contains only primes $\\leq C$?",
-    "text": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C·log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b ≤ n + O(log n) persists even ignoring small primes.",
-    "proofStrategy": "The formalization defines `DividesFactorial` and `DividesFactorialModSmall` (allowing small prime factors in the denominator), states `InfinitelyManyExceptions` as the open question, and axiomatizes both Erdős's 1968 result and the Barreto-Leeham resolution. Legendre's formula is stated via `factorialPadicVal` and the digit sum identity. The main theorem `erdos_729_statement` combines both results, and `erdos_729_summary` provides the complete answer. Two `sorry`s remain: `legendre_for_two` and `binomial_rigidity`.",
-    "keyInsights": [
-      "Legendre's formula $v_p(n!) = (n - s_p(n))/(p-1)$ connects factorial divisibility to base-$p$ digit sums, with the special case $v_2(n!) = n - s_2(n)$ being particularly clean",
-      "If $a!b! \\mid n!$, then $v_p(a!) + v_p(b!) \\leq v_p(n!)$ for all primes $p$. Using just $p = 2$ and the digit sum identity gives $a + b \\leq n + s_2(a) + s_2(b) - s_2(n) \\leq n + O(\\log n)$",
-      "The relaxed condition allows multiplying by a factor $k$ with only small prime factors, but this cannot help: for primes $p > C$, the constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ is unaffected by $k$",
-      "Large primes carry the full strength of the divisibility constraint, making the bound robust to ignoring any finite set of primes",
-      "The problem connects to Problem #728 (a similar question about multinomial coefficients) and reveals the rigidity of factorial arithmetic under prime localization"
-    ],
-    "prerequisites": [
-      "Combinatorics and number theory",
-      "Number theory (primes, divisibility)"
-    ]
-  },
-  "sections": [
-    {
-      "id": "basic-definitions",
-      "title": "Basic Definitions",
-      "startLine": 35,
-      "endLine": 56,
-      "summary": "Defines `factorialPadicVal` via Legendre's formula $\\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$, axiomatizes `legendre_formula`, and defines `DividesFactorial n a b` as $a! \\cdot b! \\mid n!$.",
-      "mathContext": "Formal definition: Defines `factorialPadicVal` via Legendre's formula $\\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$, axiomatizes `legendre_formula`, and defines `DividesFactorial n a b` as $a! \\cdot b! \\mid n!$."
-    },
-    {
-      "id": "erdos-classical",
-      "title": "Erdős's Classical Result (1968)",
-      "startLine": 57,
-      "endLine": 74,
-      "summary": "Axiomatizes `erdos_1968_classical`: $a!b! \\mid n! \\implies a + b \\leq n + O(\\log n)$. Proves `erdos_proof_via_powers_of_two` by forwarding to the axiom, documenting that the original proof uses only the $p = 2$ constraint.",
-      "mathContext": "Axiomatizes `erdos_1968_classical`: $a!b! \\implies a + b \\leq n + O(\\log n)$. Proves `erdos_proof_via_powers_of_two` by forwarding to the axiom, documenting that the original proof uses only the $p = 2$ constraint."
-    },
-    {
-      "id": "relaxed-condition",
-      "title": "The Relaxed Condition",
-      "startLine": 75,
-      "endLine": 94,
-      "summary": "Defines `SmallPrimes C` as primes $\\leq C$, and `DividesFactorialModSmall` allowing a correction factor $k$ with only small prime factors. This formalizes 'ignoring small primes in the denominator'.",
-      "mathContext": "Formal definition: Defines `SmallPrimes C` as primes $\\leq C$, and `DividesFactorialModSmall` allowing a correction factor $k$ with only small prime factors. This formalizes 'ignoring small primes in the denominator'."
-    },
-    {
-      "id": "question",
-      "title": "The Question",
-      "startLine": 95,
-      "endLine": 107,
-      "summary": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ and `DividesFactorialModSmall`? This is the formal statement of Erdős Problem 729.",
-      "mathContext": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\$\\log n$$ and `DividesFactorialModSmall`? This is the formal statement of Erdős Problem 729."
-    },
-    {
-      "id": "barreto-leeham",
-      "title": "Barreto-Leeham Resolution",
-      "startLine": 108,
-      "endLine": 123,
-      "summary": "Axiomatizes `barreto_leeham_theorem`: $\\neg\\text{InfinitelyManyExceptions}(C)$ for all $C > 0$. Also states `barreto_leeham_bound`: the bound $a + b \\leq n + D\\log n$ persists with an explicit constant $D$.",
-      "mathContext": "Axiomatizes `barreto_leeham_theorem`: $\\neg\\text{InfinitelyManyExceptions}(C)$ for all $C > 0$. Also states `barreto_leeham_bound`: the bound $a + b \\leq n + D\\log n$ persists with an explicit constant $D$."
-    },
-    {
-      "id": "proof-strategy",
-      "title": "Proof Strategy",
-      "startLine": 124,
-      "endLine": 140,
-      "summary": "Axiomatizes `proof_extends_erdos_argument`: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition, since the correction factor $k$ has no $p$-component.",
-      "mathContext": "Axiomatizes `proof_extends_erdos_argument`: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition, since the correction factor $k$ has no $p$-component."
-    },
-    {
-      "id": "legendre-details",
-      "title": "Legendre's Formula Details",
-      "startLine": 141,
-      "endLine": 160,
-      "summary": "Defines `digitSum p n` recursively and axiomatizes `legendre_identity`: $v_p(n!) = (n - s_p(n))/(p-1)$. The theorem `legendre_for_two` ($v_2(n!) = n - s_2(n)$) has a `sorry`.",
-      "mathContext": "Formal definition: Defines `digitSum p n` recursively and axiomatizes `legendre_identity`: $v_p(n!) = (n - s_p(n))/(p-1)$. The theorem `legendre_for_two` ($v_2(n!) = n - s_2(n)$) has a `sorry`."
-    },
-    {
-      "id": "implications",
-      "title": "Implications and Rigidity",
-      "startLine": 161,
-      "endLine": 178,
-      "summary": "Axiomatizes `factorial_rigidity` and states `binomial_rigidity` (with `sorry`): when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer.",
-      "mathContext": "Axiomatized: Axiomatizes `factorial_rigidity` and states `binomial_rigidity` (with `sorry`): when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer."
-    },
-    {
-      "id": "main-statement",
-      "title": "Main Problem Statement",
-      "startLine": 179,
-      "endLine": 193,
-      "summary": "Proves `erdos_729_statement`: combines `erdos_1968_classical` and `barreto_leeham_theorem` into a single conjunction, establishing both the classical bound and its robustness.",
-      "mathContext": "Verified: Proves `erdos_729_statement`: combines `erdos_1968_classical` and `barreto_leeham_theorem` into a single conjunction, establishing both the classical bound and its robustness."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 194,
-      "endLine": 207,
-      "summary": "Proves `erdos_729_summary`: the answer is NO, and the explicit bound $a + b \\leq n + D\\log n$ holds, combining `barreto_leeham_theorem` and `barreto_leeham_bound`.",
-      "mathContext": "Proves `erdos_729_summary`: the answer is NO, and the explicit bound $a + b \\leq n + D\\$\\log n$$ holds, combining `barreto_leeham_theorem` and `barreto_leeham_bound`."
+    "leanFile": {
+        "imports": [
+            "Mathlib.Data.Nat.Factorial.Basic",
+            "Mathlib.Data.Nat.Prime.Basic",
+            "Mathlib.NumberTheory.Padics.PadicVal",
+            "Mathlib.Data.Real.Basic",
+            "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+        ],
+        "opens": [
+            "Nat",
+            "Real"
+        ],
+        "namespace": "Erdos729",
+        "lineCount": 225,
+        "axiomCount": 6,
+        "theoremCount": 5,
+        "definitionCount": 8
     }
-  ],
-  "conclusion": {
-    "summary": "Erdős Problem 729 is solved negatively: there are NOT infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ where the denominator of $n!/(a!b!)$ has only small prime factors. The formalization captures the classical Erdős bound, the relaxed condition, the Barreto-Leeham resolution, and the proof strategy via large primes, with two remaining `sorry`s on supporting lemmas.",
-    "implications": "The result demonstrates a fundamental rigidity in factorial arithmetic: the constraint $a + b \\leq n + O(\\log n)$ arises from all primes collectively and cannot be circumvented by ignoring finitely many. This connects to the robustness of Legendre's formula under prime localization and suggests that factorial divisibility is determined by the global prime structure, not any local subset.",
-    "openQuestions": [
-      "What is the optimal constant in the $O(\\log n)$ bound? Can it be made explicit as a function of $C$?",
-      "Can the proof of `legendre_for_two` ($v_2(n!) = n - s_2(n)$) be completed in Lean using Mathlib's `padicValNat` machinery?",
-      "How does the bound behave for specific parametric families, e.g., $(a, b, n) = (n/2, n/2, n)$?",
-      "Is there an analogue for multinomial coefficients $n!/(a_1! \\cdots a_k!)$ with $k > 2$?"
-    ]
-  },
-  "crossReferences": [
-    {
-      "targetId": "kummer-theorem",
-      "relationship": "related",
-      "description": "Kummer's theorem and Legendre's formula both connect factorial divisibility to digit structure in various bases"
-    },
-    {
-      "targetId": "erdos-731",
-      "relationship": "related",
-      "description": "Problem 731 also studies divisibility of binomial-type expressions, focusing on central binomial coefficients"
-    },
-    {
-      "targetId": "prime-number-theorem",
-      "relationship": "related",
-      "description": "The distribution of primes underlies the O(log n) bound via digit sum estimates"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.Data.Nat.Factorial.Basic",
-      "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.NumberTheory.Padics.PadicVal",
-      "Mathlib.Data.Real.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-    ],
-    "opens": [
-      "Nat",
-      "Real"
-    ],
-    "namespace": "Erdos729",
-    "lineCount": 215,
-    "axiomCount": 6,
-    "theoremCount": 5,
-    "definitionCount": 8
-  }
 }

--- a/src/data/proofs/erdos-755/meta.json
+++ b/src/data/proofs/erdos-755/meta.json
@@ -1,190 +1,190 @@
 {
-  "id": "erdos-755",
-  "title": "Erd\u0151s Problem #755: Equilateral Triangles in \u211d\u2076",
-  "slug": "erdos-755",
-  "description": "The maximum number of unit equilateral triangles formed by n points in \u211d\u2076 is at most (1/27 + o(1))n\u00b3. YES, proved by Clemen-Dumitrescu-Liu (2025) - even for triangles of any size.",
-  "meta": {
-    "author": "Clemen-Dumitrescu-Liu (2025 solution), Lenz/Erd\u0151s-Purdy (1975 construction)",
-    "sourceUrl": "https://erdosproblems.com/755",
-    "date": "2025",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/Erdos755Problem.lean",
-    "tags": [
-      "erdos",
-      "geometry",
-      "discrete-geometry",
-      "combinatorial-geometry",
-      "equilateral-triangles",
-      "solved"
+    "id": "erdos-755",
+    "title": "Erdős Problem #755: Equilateral Triangles in ℝ⁶",
+    "slug": "erdos-755",
+    "description": "The maximum number of unit equilateral triangles formed by n points in ℝ⁶ is at most (1/27 + o(1))n³. YES, proved by Clemen-Dumitrescu-Liu (2025) - even for triangles of any size.",
+    "meta": {
+        "author": "Clemen-Dumitrescu-Liu (2025 solution), Lenz/Erdős-Purdy (1975 construction)",
+        "sourceUrl": "https://erdosproblems.com/755",
+        "date": "2025",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/Erdos755Problem.lean",
+        "tags": [
+            "erdos",
+            "geometry",
+            "discrete-geometry",
+            "combinatorial-geometry",
+            "equilateral-triangles",
+            "solved"
+        ],
+        "badge": "axiom",
+        "sorries": 1,
+        "erdosNumber": 755,
+        "erdosUrl": "https://erdosproblems.com/755",
+        "erdosProblemStatus": "solved",
+        "dateAdded": "2026-01-19",
+        "mathlib_version": "4.26.0",
+        "mathlibDependencies": [
+            {
+                "theorem": "Real.sqrt",
+                "description": "Square root function",
+                "module": "Mathlib.Data.Real.Basic"
+            },
+            {
+                "theorem": "Finset.sum",
+                "description": "Sum over finite sets",
+                "module": "Mathlib.Data.Finset.Basic"
+            },
+            {
+                "theorem": "Fin",
+                "description": "Finite types for coordinates",
+                "module": "Mathlib.Data.Fin.Basic"
+            }
+        ],
+        "originalContributions": [
+            "IsEquilateralTriangle definition: three points with equal pairwise distances",
+            "IsUnitEquilateralTriangle: equilateral with side length 1",
+            "T6_unit: count of unit equilateral triangles in ℝ⁶",
+            "T6: count of equilateral triangles of any size",
+            "T_d: general dimension counting function",
+            "lenz_construction axiom: lower bound construction",
+            "erdos_conjecture_unit: the original conjecture",
+            "erdos_conjecture_any_size: stronger version",
+            "cdl_2025_main axiom: T₆(n) = (1/27 + o(1))n³",
+            "cdl_general_dimension axiom: formula for even d ≥ 6",
+            "erdos_755_summary: combined main results"
+        ],
+        "axiomCount": 5,
+        "lineCount": 281,
+        "assumptions": "7 axiom(s) and 2 sorry(s). See the Lean source for details."
+    },
+    "overview": {
+        "historicalContext": "**Erdős Problem #755: Equilateral Triangles in ℝ⁶**\n\nThis problem concerns the maximum number of equilateral triangles that can be formed by n points in 6-dimensional Euclidean space.\n\n**Key History:**\n- Lenz (credited by Erdős): Original lower bound construction\n- Erdős-Purdy (1975): Published the orthogonal circles construction\n- Erdős (1994): Conjectured the upper bound T₆ᵘ(n) ≤ (1/27 + o(1))n³\n- Clemen-Dumitrescu-Liu (2025): Proved the conjecture in a stronger form\n\n**Mathematical Setting:**\nIn higher dimensions, point configurations can form many more equilateral triangles than in the plane. The dimension d = 6 is special: it's the first even dimension where cubic growth T_d(n) = Θ(n³) occurs.",
+        "problemStatement": "**Problem Statement (Proved)**\n\nThe number of equilateral triangles of size 1 formed by any set of $n$ points in $\\mathbb{R}^6$ is at most $(\\frac{1}{27}+o(1))n^3$.\n\n**Answer: YES**\n\nClemen-Dumitrescu-Liu (2025) proved:\n- $T_6(n) = (\\frac{1}{27}+o(1))n^3$ even for triangles of ANY size\n- Exact formulas for $T_d(n)$ for all even $d \\geq 6$\n\nThe lower bound $T_6^u(n) \\geq \\frac{n^3}{27} - O(n^2)$ is achieved by the Lenz construction.",
+        "text": "The maximum number of unit equilateral triangles formed by n points in ℝ⁶ is at most (1/27 + o(1))n³. YES, proved by Clemen-Dumitrescu-Liu (2025) - even for triangles of any size.",
+        "proofStrategy": "**Formalization Approach**\n\n1. **Euclidean Setup:** Define distance and equilateral triangles in ℝᵈ.\n\n2. **Counting Functions:** Define T₆ᵘ(n), T₆(n), and T_d(n) as suprema over configurations.\n\n3. **Lenz Construction:** Axiomatize the lower bound using three orthogonal circles.\n\n4. **Erdős's Conjecture:** Formalize both unit and any-size versions.\n\n5. **CDL 2025 Result:** Axiomatize T₆(n) = (1/27 + o(1))n³.\n\n6. **Higher Dimensions:** Axiomatize general formula for even d ≥ 6.\n\n7. **Summary:** Combine to prove the conjecture holds.",
+        "keyInsights": [
+            "**The Constant 1/27:** Comes from partitioning n points into 3 equal groups on orthogonal circles, giving (n/3)³ = n³/27",
+            "**Lenz Construction:** Three mutually orthogonal circles in ℝ⁶, with inscribed squares on each",
+            "**Stronger Result:** The bound holds for triangles of ANY size, not just unit triangles",
+            "**Dimension Threshold:** d = 6 is the first even dimension where cubic growth occurs",
+            "**Exact Formulas:** CDL found exact formulas for T_d(n) for all even d ≥ 6",
+            "**Recent Solution:** Solved in 2025 by Clemen-Dumitrescu-Liu (arXiv:2507.19841)"
+        ],
+        "prerequisites": [
+            "Combinatorics and number theory",
+            "Geometry (Euclidean, combinatorial)"
+        ]
+    },
+    "sections": [
+        {
+            "id": "euclidean",
+            "title": "Euclidean Space Setup",
+            "summary": "Distance definition and equilateral triangle conditions",
+            "startLine": 36,
+            "endLine": 62,
+            "mathContext": "Formal definition: Distance definition and equilateral triangle conditions"
+        },
+        {
+            "id": "counting",
+            "title": "Counting Functions",
+            "summary": "T₆ᵘ(n), T₆(n), T_d(n) definitions",
+            "startLine": 63,
+            "endLine": 99,
+            "mathContext": "Formal definition: T₆ᵘ(n), T₆(n), T_d(n) definitions"
+        },
+        {
+            "id": "lenz",
+            "title": "The Lenz Construction",
+            "summary": "Lower bound T₆ᵘ(n) ≥ n³/27 - O(n²)",
+            "startLine": 100,
+            "endLine": 125,
+            "mathContext": "Lower bound T₆ᵘ(n) $\\geq$ n³/27 - $O(n²)$"
+        },
+        {
+            "id": "conjecture",
+            "title": "Erdős's Conjecture",
+            "summary": "T₆ᵘ(n) ≤ (1/27 + o(1))n³ and stronger any-size version",
+            "startLine": 126,
+            "endLine": 147,
+            "mathContext": "T₆ᵘ(n) $\\leq$ (1/27 + o(1))n³ and stronger any-size version"
+        },
+        {
+            "id": "cdl",
+            "title": "Clemen-Dumitrescu-Liu Solution",
+            "summary": "T₆(n) = (1/27 + o(1))n³ proved in 2025",
+            "startLine": 148,
+            "endLine": 185,
+            "mathContext": "Mathematical content: T₆(n) = (1/27 + o(1))n³ proved in 2025"
+        },
+        {
+            "id": "general",
+            "title": "Higher Dimensions",
+            "summary": "Exact formulas for T_d(n) for even d ≥ 6",
+            "startLine": 186,
+            "endLine": 209,
+            "mathContext": "Exact formulas for T_d(n) for even d $\\geq$ 6"
+        },
+        {
+            "id": "explanation",
+            "title": "Why 1/27?",
+            "summary": "The constant explained via optimal partitioning",
+            "startLine": 210,
+            "endLine": 245,
+            "mathContext": "Mathematical content: The constant explained via optimal partitioning"
+        },
+        {
+            "id": "summary",
+            "title": "Summary",
+            "summary": "Complete answer: YES, with exact asymptotic",
+            "startLine": 246,
+            "endLine": 280,
+            "mathContext": "Mathematical content: Complete answer: YES, with exact asymptotic"
+        }
     ],
-    "badge": "axiom",
-    "sorries": 2,
-    "erdosNumber": 755,
-    "erdosUrl": "https://erdosproblems.com/755",
-    "erdosProblemStatus": "solved",
-    "dateAdded": "2026-01-19",
-    "mathlib_version": "4.26.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "Real.sqrt",
-        "description": "Square root function",
-        "module": "Mathlib.Data.Real.Basic"
-      },
-      {
-        "theorem": "Finset.sum",
-        "description": "Sum over finite sets",
-        "module": "Mathlib.Data.Finset.Basic"
-      },
-      {
-        "theorem": "Fin",
-        "description": "Finite types for coordinates",
-        "module": "Mathlib.Data.Fin.Basic"
-      }
-    ],
-    "originalContributions": [
-      "IsEquilateralTriangle definition: three points with equal pairwise distances",
-      "IsUnitEquilateralTriangle: equilateral with side length 1",
-      "T6_unit: count of unit equilateral triangles in \u211d\u2076",
-      "T6: count of equilateral triangles of any size",
-      "T_d: general dimension counting function",
-      "lenz_construction axiom: lower bound construction",
-      "erdos_conjecture_unit: the original conjecture",
-      "erdos_conjecture_any_size: stronger version",
-      "cdl_2025_main axiom: T\u2086(n) = (1/27 + o(1))n\u00b3",
-      "cdl_general_dimension axiom: formula for even d \u2265 6",
-      "erdos_755_summary: combined main results"
-    ],
-    "axiomCount": 5,
-    "lineCount": 280,
-    "assumptions": "7 axiom(s) and 2 sorry(s). See the Lean source for details."
-  },
-  "overview": {
-    "historicalContext": "**Erd\u0151s Problem #755: Equilateral Triangles in \u211d\u2076**\n\nThis problem concerns the maximum number of equilateral triangles that can be formed by n points in 6-dimensional Euclidean space.\n\n**Key History:**\n- Lenz (credited by Erd\u0151s): Original lower bound construction\n- Erd\u0151s-Purdy (1975): Published the orthogonal circles construction\n- Erd\u0151s (1994): Conjectured the upper bound T\u2086\u1d58(n) \u2264 (1/27 + o(1))n\u00b3\n- Clemen-Dumitrescu-Liu (2025): Proved the conjecture in a stronger form\n\n**Mathematical Setting:**\nIn higher dimensions, point configurations can form many more equilateral triangles than in the plane. The dimension d = 6 is special: it's the first even dimension where cubic growth T_d(n) = \u0398(n\u00b3) occurs.",
-    "problemStatement": "**Problem Statement (Proved)**\n\nThe number of equilateral triangles of size 1 formed by any set of $n$ points in $\\mathbb{R}^6$ is at most $(\\frac{1}{27}+o(1))n^3$.\n\n**Answer: YES**\n\nClemen-Dumitrescu-Liu (2025) proved:\n- $T_6(n) = (\\frac{1}{27}+o(1))n^3$ even for triangles of ANY size\n- Exact formulas for $T_d(n)$ for all even $d \\geq 6$\n\nThe lower bound $T_6^u(n) \\geq \\frac{n^3}{27} - O(n^2)$ is achieved by the Lenz construction.",
-    "text": "The maximum number of unit equilateral triangles formed by n points in \u211d\u2076 is at most (1/27 + o(1))n\u00b3. YES, proved by Clemen-Dumitrescu-Liu (2025) - even for triangles of any size.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Euclidean Setup:** Define distance and equilateral triangles in \u211d\u1d48.\n\n2. **Counting Functions:** Define T\u2086\u1d58(n), T\u2086(n), and T_d(n) as suprema over configurations.\n\n3. **Lenz Construction:** Axiomatize the lower bound using three orthogonal circles.\n\n4. **Erd\u0151s's Conjecture:** Formalize both unit and any-size versions.\n\n5. **CDL 2025 Result:** Axiomatize T\u2086(n) = (1/27 + o(1))n\u00b3.\n\n6. **Higher Dimensions:** Axiomatize general formula for even d \u2265 6.\n\n7. **Summary:** Combine to prove the conjecture holds.",
-    "keyInsights": [
-      "**The Constant 1/27:** Comes from partitioning n points into 3 equal groups on orthogonal circles, giving (n/3)\u00b3 = n\u00b3/27",
-      "**Lenz Construction:** Three mutually orthogonal circles in \u211d\u2076, with inscribed squares on each",
-      "**Stronger Result:** The bound holds for triangles of ANY size, not just unit triangles",
-      "**Dimension Threshold:** d = 6 is the first even dimension where cubic growth occurs",
-      "**Exact Formulas:** CDL found exact formulas for T_d(n) for all even d \u2265 6",
-      "**Recent Solution:** Solved in 2025 by Clemen-Dumitrescu-Liu (arXiv:2507.19841)"
-    ],
-    "prerequisites": [
-      "Combinatorics and number theory",
-      "Geometry (Euclidean, combinatorial)"
+    "conclusion": {
+        "summary": "Erdős Problem #755 asked whether the maximum number of unit equilateral triangles formed by n points in ℝ⁶ is at most (1/27 + o(1))n³. The answer is YES, proved by Clemen-Dumitrescu-Liu in 2025. They showed the stronger result that T₆(n) = (1/27 + o(1))n³ even for triangles of any size, and found exact formulas for all even dimensions d ≥ 6.",
+        "implications": "**Theoretical Significance**: **Implications in Discrete Geometry**\n\n1. **Optimal Construction:** The Lenz construction using orthogonal circles is asymptotically optimal\n\n2. **Dimension Threshold:** d = 6 is special for equilateral triangle counts\n\n**3. Size Independence:** Unit vs arbitrary size makes no asymptotic difference\n\n4. **General Dimension:** Exact formulas exist for all even d ≥ 6\n\n5. **Recent Progress:** Problem solved very recently (2025).",
+        "openQuestions": [
+            "Exact second-order terms in the asymptotic expansion",
+            "Behavior for odd dimensions d = 5, 7, 9, ...",
+            "Algorithmic construction of optimal configurations",
+            "Extension to regular k-simplices in higher dimensions",
+            "Connection to Problem #1086 on related geometric configurations"
+        ]
+    },
+    "leanFile": {
+        "imports": [
+            "Mathlib.Data.Nat.Basic",
+            "Mathlib.Data.Real.Basic",
+            "Mathlib.Data.Fin.Basic",
+            "Mathlib.Analysis.Normed.Field.Basic",
+            "Mathlib.Analysis.InnerProductSpace.Basic"
+        ],
+        "opens": [
+            "Real"
+        ],
+        "namespace": "Erdos755",
+        "lineCount": 281,
+        "axiomCount": 7,
+        "theoremCount": 3,
+        "definitionCount": 7
+    },
+    "crossReferences": [
+        {
+            "targetId": "erdos-223",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: combinatorial-geometry, discrete-geometry, solved"
+        },
+        {
+            "targetId": "erdos-224",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: discrete-geometry, geometry, solved"
+        },
+        {
+            "targetId": "erdos-507",
+            "relationship": "related",
+            "description": "Related Erdős problem sharing themes: combinatorial-geometry, discrete-geometry, geometry"
+        }
     ]
-  },
-  "sections": [
-    {
-      "id": "euclidean",
-      "title": "Euclidean Space Setup",
-      "summary": "Distance definition and equilateral triangle conditions",
-      "startLine": 36,
-      "endLine": 62,
-      "mathContext": "Formal definition: Distance definition and equilateral triangle conditions"
-    },
-    {
-      "id": "counting",
-      "title": "Counting Functions",
-      "summary": "T\u2086\u1d58(n), T\u2086(n), T_d(n) definitions",
-      "startLine": 63,
-      "endLine": 99,
-      "mathContext": "Formal definition: T\u2086\u1d58(n), T\u2086(n), T_d(n) definitions"
-    },
-    {
-      "id": "lenz",
-      "title": "The Lenz Construction",
-      "summary": "Lower bound T\u2086\u1d58(n) \u2265 n\u00b3/27 - O(n\u00b2)",
-      "startLine": 100,
-      "endLine": 125,
-      "mathContext": "Lower bound T\u2086\u1d58(n) $\\geq$ n\u00b3/27 - $O(n\u00b2)$"
-    },
-    {
-      "id": "conjecture",
-      "title": "Erd\u0151s's Conjecture",
-      "summary": "T\u2086\u1d58(n) \u2264 (1/27 + o(1))n\u00b3 and stronger any-size version",
-      "startLine": 126,
-      "endLine": 147,
-      "mathContext": "T\u2086\u1d58(n) $\\leq$ (1/27 + o(1))n\u00b3 and stronger any-size version"
-    },
-    {
-      "id": "cdl",
-      "title": "Clemen-Dumitrescu-Liu Solution",
-      "summary": "T\u2086(n) = (1/27 + o(1))n\u00b3 proved in 2025",
-      "startLine": 148,
-      "endLine": 185,
-      "mathContext": "Mathematical content: T\u2086(n) = (1/27 + o(1))n\u00b3 proved in 2025"
-    },
-    {
-      "id": "general",
-      "title": "Higher Dimensions",
-      "summary": "Exact formulas for T_d(n) for even d \u2265 6",
-      "startLine": 186,
-      "endLine": 209,
-      "mathContext": "Exact formulas for T_d(n) for even d $\\geq$ 6"
-    },
-    {
-      "id": "explanation",
-      "title": "Why 1/27?",
-      "summary": "The constant explained via optimal partitioning",
-      "startLine": 210,
-      "endLine": 245,
-      "mathContext": "Mathematical content: The constant explained via optimal partitioning"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "Complete answer: YES, with exact asymptotic",
-      "startLine": 246,
-      "endLine": 280,
-      "mathContext": "Mathematical content: Complete answer: YES, with exact asymptotic"
-    }
-  ],
-  "conclusion": {
-    "summary": "Erd\u0151s Problem #755 asked whether the maximum number of unit equilateral triangles formed by n points in \u211d\u2076 is at most (1/27 + o(1))n\u00b3. The answer is YES, proved by Clemen-Dumitrescu-Liu in 2025. They showed the stronger result that T\u2086(n) = (1/27 + o(1))n\u00b3 even for triangles of any size, and found exact formulas for all even dimensions d \u2265 6.",
-    "implications": "**Theoretical Significance**: **Implications in Discrete Geometry**\n\n1. **Optimal Construction:** The Lenz construction using orthogonal circles is asymptotically optimal\n\n2. **Dimension Threshold:** d = 6 is special for equilateral triangle counts\n\n**3. Size Independence:** Unit vs arbitrary size makes no asymptotic difference\n\n4. **General Dimension:** Exact formulas exist for all even d \u2265 6\n\n5. **Recent Progress:** Problem solved very recently (2025).",
-    "openQuestions": [
-      "Exact second-order terms in the asymptotic expansion",
-      "Behavior for odd dimensions d = 5, 7, 9, ...",
-      "Algorithmic construction of optimal configurations",
-      "Extension to regular k-simplices in higher dimensions",
-      "Connection to Problem #1086 on related geometric configurations"
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Fin.Basic",
-      "Mathlib.Analysis.Normed.Field.Basic",
-      "Mathlib.Analysis.InnerProductSpace.Basic"
-    ],
-    "opens": [
-      "Real"
-    ],
-    "namespace": "Erdos755",
-    "lineCount": 280,
-    "axiomCount": 7,
-    "theoremCount": 3,
-    "definitionCount": 7
-  },
-  "crossReferences": [
-    {
-      "targetId": "erdos-223",
-      "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorial-geometry, discrete-geometry, solved"
-    },
-    {
-      "targetId": "erdos-224",
-      "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, geometry, solved"
-    },
-    {
-      "targetId": "erdos-507",
-      "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorial-geometry, discrete-geometry, geometry"
-    }
-  ]
 }


### PR DESCRIPTION
## Fix

Research PRs proved sorries but didn't update meta.json. Corrected sorry counts and stale line counts.

## Evidence

| Proof | Sorries (before → after) | Lines (before → after) |
|-------|--------------------------|------------------------|
| erdos-537 | 1 → 0 | 276 → 292 |
| erdos-601 | 14 → 10 | 247 → 262 |
| erdos-666 | 2 → 1 | 306 → 308 |
| erdos-729 | 2 → 0 | 215 → 225 |
| erdos-755 | 2 → 1 | 280 → 281 |

Note: erdos-537 and erdos-729 now have 0 sorries but remain `"axiomatized"` because they still have axiom declarations (3 and 6 respectively).

All JSON validated. Sorry counts verified by grep against Lean source files.

---
Automated fix by lean-mechanic agent.