### PR TITLE
Research: prove 15 theorems, eliminate 6 axioms across 2 files

### DIFF
--- a/proofs/Proofs/Erdos1049Problem.lean
+++ b/proofs/Proofs/Erdos1049Problem.lean
@@ -115,7 +115,31 @@ theorem double_sum_identity (t : ℝ) (ht : t > 1) :
 /-- Geometric series for each d: ∑_{m≥1} 1/t^{dm} = 1/(t^d - 1). -/
 theorem geometric_divisor (t : ℝ) (d : ℕ) (ht : t > 1) (hd : d ≥ 1) :
     (∑' m : ℕ, if m = 0 then (0 : ℝ) else 1 / t ^ (d * m)) = 1 / (t ^ d - 1) := by
-  sorry
+  set q := (1 : ℝ) / t ^ d with hq_def
+  have htd_pos : (0 : ℝ) < t ^ d := by positivity
+  have htd_gt : t ^ d > 1 := by
+    have : t ^ 1 ≤ t ^ d := pow_le_pow_right (le_of_lt ht) hd
+    linarith [pow_one t]
+  have hq_nn : 0 ≤ q := by positivity
+  have hq_lt : q < 1 := by rw [hq_def, div_lt_one htd_pos]; exact htd_gt
+  -- Each term equals q^m with m=0 zeroed out
+  have hterm : ∀ m, (if m = 0 then (0:ℝ) else 1 / t ^ (d * m)) =
+      q ^ m - if m = 0 then 1 else 0 := by
+    intro m; split_ifs with h
+    · subst h; simp
+    · simp only [sub_zero, hq_def, div_pow, one_pow, pow_mul]
+  simp_rw [hterm]
+  have hsumq := summable_geometric_of_lt_one hq_nn hq_lt
+  have hsumind : Summable (fun m : ℕ => if m = 0 then (1:ℝ) else 0) :=
+    summable_of_ne_finset {0} (by intro n hn; simp at hn; simp [hn])
+  rw [tsum_sub hsumq hsumind, tsum_geometric_of_lt_one hq_nn hq_lt,
+      tsum_eq_single 0 (by intro n hn; simp [hn])]
+  simp only [ite_true]
+  rw [hq_def]
+  have h1 : 1 - 1 / t ^ d ≠ 0 := by positivity
+  have h2 : t ^ d - 1 ≠ 0 := by linarith
+  field_simp
+  ring
 
 /-
 ## Part IV: Erdős's Result for Integers
@@ -151,7 +175,8 @@ def ChowlaConjecture : Prop :=
   ∀ t : ℚ, t > 1 → Irrational (S (t : ℝ))
 
 /-- The conjecture remains OPEN. -/
-axiom chowla_conjecture_open : ChowlaConjecture ↔ ChowlaConjecture
+theorem chowla_conjecture_open : ChowlaConjecture ↔ ChowlaConjecture :=
+  Iff.rfl
 
 /-- Erdős's result implies Chowla for integer t ≥ 2. -/
 theorem chowla_for_integers (t : ℕ) (ht : t ≥ 2) :
@@ -197,7 +222,13 @@ def TranscendentalConjecture : Prop :=
 /-- The transcendental conjecture is stronger than Chowla's. -/
 theorem transcendental_implies_chowla :
     TranscendentalConjecture → ChowlaConjecture := by
-  sorry
+  intro hTC t ht
+  have ht1 : (t : ℝ) > 1 := by exact_mod_cast ht
+  have halg : IsAlgebraic ℚ (t : ℝ) := isAlgebraic_algebraMap ℚ t
+  have hna := hTC (t : ℝ) ht1 halg
+  -- S(t) is not algebraic over ℚ; in particular it's not rational, hence irrational
+  intro ⟨q, hq⟩
+  exact hna (by rw [← hq]; exact isAlgebraic_algebraMap ℚ q)
 
 /-- S(t) satisfies no polynomial equation over ℚ(t) (conjectured). -/
 def AlgebraicIndependenceConjecture : Prop :=
@@ -219,9 +250,9 @@ theorem S_as_lambert (t : ℝ) (ht : t > 1) :
   sorry
 
 /-- Lambert series preserve arithmetic structure. -/
-axiom lambert_arithmetic_property :
+theorem lambert_arithmetic_property :
     -- Lambert series of arithmetic functions have special properties
-    True
+    True := trivial
 
 /-
 ## Part IX: Partial Results
@@ -230,14 +261,14 @@ What is known towards Chowla's conjecture.
 -/
 
 /-- S(p/q) is irrational for certain p/q (partial results). -/
-axiom partial_rational_results :
+theorem partial_rational_results :
     -- Some specific rational values have been verified
-    True
+    True := trivial
 
 /-- Linear independence results. -/
-axiom linear_independence_partial :
+theorem linear_independence_partial :
     -- Partial results on linear independence of S values
-    True
+    True := trivial
 
 /-- Approximation bounds for S(t). -/
 theorem S_bounds (t : ℝ) (ht : t > 1) :

--- a/proofs/Proofs/Erdos268Problem.lean
+++ b/proofs/Proofs/Erdos268Problem.lean
@@ -52,13 +52,20 @@ noncomputable def shiftedHarmonicSum (A : Set ℕ) (k : ℕ) : ℝ :=
 /-- Finite sets have convergent harmonic subseries (trivially). -/
 theorem finite_has_convergent (A : Set ℕ) (hA : A.Finite) :
     HasConvergentHarmonicSubseries A := by
-  sorry
+  unfold HasConvergentHarmonicSubseries
+  haveI := hA.to_subtype
+  exact summable_of_finite _
 
 /-- If A has convergent sum, so does any shifted version. -/
 theorem shifted_summable (A : Set ℕ) (k : ℕ)
     (h : HasConvergentHarmonicSubseries A) :
     Summable (fun n : A => (1 : ℝ) / (n + k)) := by
-  sorry
+  apply Summable.of_nonneg_of_le
+  · intro n; exact div_nonneg one_nonneg (by positivity)
+  · intro ⟨n, hn⟩
+    exact div_le_div_of_nonneg_left (by positivity) (by positivity)
+      (by exact_mod_cast Nat.le_add_right n k)
+  · exact h
 
 /- ## Part II: The Point Set X -/
 
@@ -113,13 +120,15 @@ theorem contains_open_ball (d : ℕ) :
     The 2-dimensional version: X ⊆ ℝ² has nonempty interior.
     This was the first case solved, before the general result.
 -/
-axiom erdos_straus_2d : (interior (harmonicPointSet 2)).Nonempty
+theorem erdos_straus_2d : (interior (harmonicPointSet 2)).Nonempty :=
+  erdos_268_solved 2
 
 /-- In dimension 2, the point is (Σ 1/n, Σ 1/(n+1)). -/
 theorem dim2_point_form (A : Set ℕ) (hA : A.Infinite)
     (hconv : HasConvergentHarmonicSubseries A) :
     harmonicPoint 2 A = ![harmonicSubseriesSum A, shiftedHarmonicSum A 1] := by
-  sorry
+  ext i
+  fin_cases i <;> simp [harmonicPoint, shiftedHarmonicSum, harmonicSubseriesSum, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons]
 
 /- ## Part V: The 3-Dimensional Case (Kovač 2024) -/
 
@@ -128,7 +137,8 @@ theorem dim2_point_form (A : Set ℕ) (hA : A.Infinite)
     The 3-dimensional case with explicit open ball construction.
     Kovač gave a constructive proof finding an explicit center and radius.
 -/
-axiom kovac_3d : (interior (harmonicPointSet 3)).Nonempty
+theorem kovac_3d : (interior (harmonicPointSet 3)).Nonempty :=
+  erdos_268_solved 3
 
 /-- Kovač's explicit construction gives a specific open ball. -/
 def kovacBallCenter : Fin 3 → ℝ := ![1.5, 1.2, 1.0]  -- Placeholder values
@@ -158,7 +168,8 @@ def AhmesSeries (A : Set ℕ) : ℝ := harmonicSubseriesSum A
 /-- X is non-empty (take any convergent subseries). -/
 theorem harmonicPointSet_nonempty (d : ℕ) :
     (harmonicPointSet d).Nonempty := by
-  sorry
+  have h := erdos_268_solved d
+  exact ⟨_, interior_subset h.some_mem⟩
 
 /-- X is path-connected. -/
 theorem harmonicPointSet_path_connected (d : ℕ) :
@@ -172,15 +183,13 @@ theorem harmonicPointSet_dense_somewhere (d : ℕ) :
   have h := erdos_268_solved d
   obtain ⟨x, hx⟩ := h
   use interior (harmonicPointSet d)
-  constructor
-  · exact isOpen_interior
-  constructor
-  · exact ⟨x, hx⟩
-  · intro y hy
-    rw [mem_closure_iff]
-    intro U hU hyU
-    have := interior_subset (s := harmonicPointSet d)
-    sorry
+  refine ⟨isOpen_interior, ⟨x, hx⟩, ?_⟩
+  rw [dense_iff_inter_open]
+  intro U hU ⟨y, hy⟩
+  have hI := isOpen_interior (s := harmonicPointSet d)
+  have hUI : IsOpen (U ∩ interior (harmonicPointSet d)) := hU.inter hI
+  rcases hy with ⟨hyU, hyI���
+  exact ⟨y, ⟨⟨interior_subset hyI, hyI⟩, hyU⟩⟩
 
 /- ## Part VIII: Coordinate Properties -/
 
@@ -189,20 +198,36 @@ theorem coordinate_decreasing (A : Set ℕ) (hA : A.Infinite)
     (hconv : HasConvergentHarmonicSubseries A)
     (i j : ℕ) (hij : i < j) :
     shiftedHarmonicSum A j < shiftedHarmonicSum A i := by
-  sorry
+  unfold shiftedHarmonicSum
+  apply tsum_lt_tsum
+  · intro ⟨n, hn⟩
+    apply div_le_div_of_nonneg_left (by positivity : (0:ℝ) < 1) (by positivity) (by positivity)
+    exact_mod_cast Nat.add_le_add_left (Nat.le_of_lt hij) n
+  · obtain ⟨n, hn⟩ := hA.nonempty
+    exact ⟨⟨n, hn⟩, div_lt_div_of_pos_left (by positivity : (0:ℝ) < 1) (by positivity)
+      (by exact_mod_cast Nat.add_lt_add_left hij n)⟩
+  · exact shifted_summable A i hconv
 
 /-- The first coordinate is always the largest. -/
 theorem first_coordinate_largest (d : ℕ) (hd : d ≥ 2) (A : Set ℕ)
     (hA : A.Infinite) (hconv : HasConvergentHarmonicSubseries A) :
     ∀ i : Fin d, (harmonicPoint d A) 0 ≥ (harmonicPoint d A) i := by
-  sorry
+  intro i
+  simp only [harmonicPoint]
+  by_cases hi : i.val = 0
+  · simp [hi]
+  · exact le_of_lt (coordinate_decreasing A hA hconv 0 i.val (Nat.pos_of_ne_zero hi))
 
 /-- All coordinates are positive (for non-empty A). -/
 theorem all_coordinates_positive (d : ℕ) (A : Set ℕ)
     (hA : A.Nonempty) (hconv : HasConvergentHarmonicSubseries A)
     (i : Fin d) :
     (harmonicPoint d A) i > 0 := by
-  sorry
+  simp only [harmonicPoint, shiftedHarmonicSum]
+  apply tsum_pos (shifted_summable A i.val hconv)
+    (fun n => div_nonneg one_nonneg (by positivity))
+  obtain ⟨n, hn⟩ := hA
+  exact ⟨⟨n, hn⟩, div_pos one_pos (by positivity)⟩
 
 /- ## Part IX: Dimension Monotonicity -/
 
@@ -213,7 +238,12 @@ def projectionMap (d₁ d₂ : ℕ) (h : d₁ ≤ d₂) : (Fin d₂ → ℝ) →
 /-- Projection of X_{d₂} lands in X_{d₁} for d₁ ≤ d₂. -/
 theorem projection_preserves (d₁ d₂ : ℕ) (h : d₁ ≤ d₂) :
     projectionMap d₁ d₂ h '' harmonicPointSet d₂ ⊆ harmonicPointSet d₁ := by
-  sorry
+  intro x ⟨y, hy, hxy⟩
+  obtain ⟨A, hAinf, hAconv, hAeq⟩ := hy
+  refine ⟨A, hAinf, hAconv, ?_⟩
+  subst hxy hAeq
+  ext i
+  simp [projectionMap, harmonicPoint]
 
 /- ## Part X: Specific Examples -/
 
@@ -222,7 +252,23 @@ theorem projection_preserves (d₁ d₂ : ℕ) (h : d₁ ≤ d₂) :
 def squaresSet : Set ℕ := {n | ∃ k : ℕ, k ≥ 1 ∧ n = k ^ 2}
 
 theorem squares_convergent : HasConvergentHarmonicSubseries squaresSet := by
-  sorry
+  unfold HasConvergentHarmonicSubseries
+  let e : ℕ → squaresSet := fun k => ⟨(k+1)^2, k+1, by omega, rfl⟩
+  have hinj : Function.Injective e := by
+    intro a b h; simp only [e, Subtype.ext_iff] at h; omega
+  have hsurj : Function.Surjective e := by
+    intro ⟨n, k, hk, hkn⟩; exact ⟨k - 1, by simp only [e, Subtype.ext_iff]; omega⟩
+  rw [← (Equiv.ofBijective e ⟨hinj, hsurj⟩).summable_iff]
+  have hpseries : Summable (fun n : ℕ => ((n : ℝ) ^ (2 : ℝ))⁻¹) :=
+    Real.summable_nat_rpow_inv.mpr (by norm_num : (1 : ℝ) < 2)
+  apply Summable.of_nonneg_of_le
+  · intro k; positivity
+  · intro k
+    show (1 : ℝ) / ↑((k + 1) ^ 2) ≤ ((↑(k + 1) : ℝ) ^ (2 : ℝ))⁻¹
+    rw [Nat.cast_pow, one_div]
+    congr 1
+    push_cast; ring
+  · exact hpseries.comp_injective (fun a b h => by omega : Function.Injective (· + 1))
 
 /-- The harmonic point for the squares set. -/
 noncomputable def squaresPoint (d : ℕ) : Fin d → ℝ :=
@@ -232,7 +278,23 @@ noncomputable def squaresPoint (d : ℕ) : Fin d → ℝ :=
 def powersOf2Set : Set ℕ := {n | ∃ k : ℕ, n = 2 ^ k}
 
 theorem powers_convergent : HasConvergentHarmonicSubseries powersOf2Set := by
-  sorry
+  unfold HasConvergentHarmonicSubseries
+  let e : ℕ → powersOf2Set := fun k => ⟨2^k, k, rfl⟩
+  have hinj : Function.Injective e := by
+    intro a b h
+    simp only [e, Subtype.ext_iff] at h
+    exact Nat.pow_right_injective (by norm_num) h
+  have hsurj : Function.Surjective e := by
+    intro ⟨n, k, hk⟩
+    exact ⟨k, by simp only [e, Subtype.ext_iff]; exact hk.symm⟩
+  rw [← (Equiv.ofBijective e ⟨hinj, hsurj⟩).summable_iff]
+  have : ((fun n : powersOf2Set => (1 : ℝ) / ↑↑n) ∘ (Equiv.ofBijective e ⟨hinj, hsurj⟩)) =
+      fun k => ((1 : ℝ) / 2) ^ k := by
+    ext k
+    simp only [Function.comp, Equiv.ofBijective_apply, e, Subtype.val]
+    rw [Nat.cast_pow, Nat.cast_ofNat, div_pow, one_pow]
+  rw [this]
+  exact summable_geometric_of_lt_one (by positivity) (by norm_num)
 
 /-- The harmonic point for powers of 2.
     Σ 1/2^k = 1, so first coordinate is 1. -/
@@ -273,6 +335,10 @@ harmonic analysis with topology of number-theoretic sets.
 6. Coordinate properties (decreasing, positive)
 7. Examples: squares, powers of 2
 
-**Key axiom**:
-- `erdos_268_solved`: The main result for all dimensions
+**Axioms** (2):
+- `erdos_268_solved`: The main result for all dimensions (Kovač-Tao 2024)
+- `kovac_explicit_ball`: Specific ball in d=3 case (Kovač 2024)
+
+**Sorry** (1):
+- `harmonicPointSet_path_connected`: Requires continuous interpolation of infinite sets
 -/

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 9,
     "erdosNumber": 1049,
     "erdosUrl": "https://erdosproblems.com/1049",
     "erdosProblemStatus": "open",
@@ -65,15 +65,15 @@
       "erdos-1048",
       "erdos-1050"
     ],
-    "axiomCount": 6,
-    "assumptions": "6 axiom declarations: erdos_integer_irrational (Erdős 1948 irrationality for integer t ≥ 2), S_at_2_approx (numerical bound 1.606 < S(2) < 1.607), chowla_conjecture_open (open status marker), lambert_arithmetic_property (Lambert series arithmetic property placeholder), partial_rational_results (partial progress placeholder), linear_independence_partial (linear independence placeholder). The first is Erdős's published result; the numerical bound is computationally verified; the rest encode the open status and known partial progress.",
+    "axiomCount": 2,
+    "assumptions": "2 axioms: erdos_integer_irrational (Erdős 1948: S(t) irrational for integer t ≥ 2), S_at_2_approx (numerical bound 1.606 < S(2) < 1.607). 4 former axioms eliminated: chowla_conjecture_open (tautology, now Iff.rfl), lambert_arithmetic_property/partial_rational_results/linear_independence_partial (trivially True placeholders, now theorems). 9 sorries remain including convergence, the S=D identity, and limit behavior.",
     "prerequisites": [
       "Analytic number theory: divisor function and Lambert series",
       "Irrationality and transcendence theory",
       "Infinite series convergence (tsum)",
       "p-adic analysis (for understanding Erdős's proof technique)"
     ],
-    "lineCount": 282
+    "lineCount": 313
   },
   "overview": {
     "historicalContext": "The study of arithmetic properties of the series S(t) = sum 1/(t^n - 1) originates in classical analytic number theory. The series naturally arises as a Lambert series with constant coefficients, connecting it to the divisor function tau(n) via the identity S(t) = sum tau(n)/t^n. In 1948, Paul Erdos published 'On arithmetical properties of Lambert series' in the Journal of the Indian Mathematical Society, proving that S(t) is irrational whenever t is an integer >= 2. His proof used careful analysis of the p-adic structure of partial sums. Sarvadaman Chowla conjectured that the irrationality should hold for all rational t > 1, not just integers. This conjecture remains open and connects to broader questions about Lambert series, transcendence theory, and the Erdos-Borwein constant E = S(2) ~ 1.606695. The problem appears as #1049 in the Erdos problems collection and is closely related to #1048 (Lambert series generalizations) and #1050 (related irrationality questions).",
@@ -276,8 +276,8 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 282,
-    "axiomCount": 6,
+    "lineCount": 313,
+    "axiomCount": 2,
     "theoremCount": 22,
     "substantiveTheoremCount": 22,
     "trivialSpecializations": 0,

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -18,7 +18,7 @@
       "Egyptian-fractions"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 1,
     "erdosNumber": 268,
     "erdosUrl": "https://erdosproblems.com/268",
     "erdosProblemStatus": "solved",
@@ -56,9 +56,9 @@
       "Dimension monotonicity via projection maps",
       "Concrete examples: squares (Basel problem) and powers of 2 (geometric series)"
     ],
-    "axiomCount": 4,
-    "lineCount": 278,
-    "assumptions": "4 axiom(s) and 12 sorry(s). See the Lean source for details."
+    "axiomCount": 2,
+    "lineCount": 340,
+    "assumptions": "2 axioms: erdos_268_solved (Kovac-Tao 2024: interior nonempty for all d), kovac_explicit_ball (specific ball in d=3 case). 1 sorry: harmonicPointSet_path_connected (requires continuous interpolation of infinite sets)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #268: Interior of Harmonic Subseries Points**\n\nThis problem lies at the intersection of harmonic analysis, number theory, and point-set topology. It originates from a classical question about which real numbers can be represented as sums of distinct unit fractions — a topic with roots in ancient Egyptian mathematics (the Rhind Papyrus, c. 1650 BCE, contains tables of such decompositions, now called Ahmes series or Egyptian fractions).\n\nThe modern formulation involves the set of all infinite subsets A ⊆ ℕ with convergent harmonic subseries Σ_{n∈A} 1/n < ∞. Such sets must be very 'thin' — the harmonic series diverges (proved by Nicole Oresme c. 1350), so A cannot contain too many elements. Examples include {n²} (with sum π²/6, the Basel problem solved by Euler in 1734) and {2ᵏ} (with sum 2, a geometric series).\n\nThe twist in Problem #268 is the passage to higher dimensions: for each qualifying set A, form the d-dimensional point (Σ 1/n, Σ 1/(n+1), ..., Σ 1/(n+d-1)). The set X of all such points is the object of study. Erdős asked: does X have nonempty interior?\n\n**Timeline:**\n- 1950s–60s: Erdős poses the problem, motivated by his work on thin sets and additive number theory\n- Erdős-Straus: Prove the d=2 case using properties of the digamma function ψ(x) and telescoping sum representations\n- Decades of partial results on the 1-dimensional structure of achievable harmonic subseries sums\n- 2024: Kovač proves d=3 with an explicit construction of an open ball inside X₃, giving quantitative geometric information\n- 2024: Kovač and Tao prove the full result for all d ≥ 1, connecting the problem to the theory of Ahmes series and showing that the richness of Egyptian fraction representations guarantees interior in every dimension\n\nThe result is surprising: despite the severe sparsity constraint on A, the resulting points fill out an open region in ℝᵈ. This reflects a deep phenomenon — the space of 'thin' infinite subsets of ℕ is itself rich enough to parameterize open sets in arbitrary dimension.",
@@ -91,7 +91,7 @@
     {
       "id": "harmonic",
       "title": "Harmonic Subseries",
-      "summary": "Defines HasConvergentHarmonicSubseries as Summable (fun n : A => 1/n) and shiftedHarmonicSum for the k-shifted variant. Proves finite sets trivially converge (sorry) and shifted summability follows from comparison (sorry). The subtype-based summation pattern is standard Mathlib.",
+      "summary": "Defines HasConvergentHarmonicSubseries as Summable (fun n : A => 1/n) and shiftedHarmonicSum for the k-shifted variant. Proves finite sets converge (via summable_of_finite) and shifted summability follows from comparison (Summable.of_nonneg_of_le). Both fully proved.",
       "startLine": 38,
       "endLine": 62,
       "mathContext": "Defines HasConvergentHarmonicSubseries as Summable (fun n : A => 1/n) and shiftedHarmonicSum for the k-shifted variant. Proves finite sets trivially converge (sorry) and shifted summability follows from comparison (sorry). The subtype-based summation pattern is standard Mathlib."
@@ -115,18 +115,18 @@
     {
       "id": "dim-2",
       "title": "2-Dimensional Case (Erdős-Straus)",
-      "summary": "Axiomatizes the Erdős-Straus result that (interior (harmonicPointSet 2)).Nonempty. States dim2_point_form showing the concrete 2D point is (harmonicSubseriesSum A, shiftedHarmonicSum A 1) using matrix notation (sorry for the definitional unfolding).",
-      "startLine": 109,
-      "endLine": 123,
-      "mathContext": "Axiomatizes the Erdős-Straus result that (interior (harmonicPointSet 2)).Nonempty. States dim2_point_form showing the concrete 2D point is (harmonicSubseriesSum A, shiftedHarmonicSum A 1) using matrix notation (sorry for the definitional unfolding)."
+      "summary": "Proves erdos_straus_2d as a corollary of erdos_268_solved (eliminating the axiom). Proves dim2_point_form showing the concrete 2D point is (harmonicSubseriesSum A, shiftedHarmonicSum A 1) via ext/fin_cases/simp. Both fully proved.",
+      "startLine": 116,
+      "endLine": 131,
+      "mathContext": "Proves erdos_straus_2d as a corollary of erdos_268_solved (eliminating the axiom). Proves dim2_point_form showing the concrete 2D point is (harmonicSubseriesSum A, shiftedHarmonicSum A 1) via ext/fin_cases/simp."
     },
     {
       "id": "dim-3",
       "title": "3-Dimensional Case (Kovač 2024)",
-      "summary": "Axiomatizes kovac_3d for the d=3 interior result. Defines placeholder kovacBallCenter and kovacBallRadius for Kovač's explicit construction. Axiomatizes kovac_explicit_ball: the ball lies inside harmonicPointSet 3.",
-      "startLine": 124,
-      "endLine": 141,
-      "mathContext": "Axiomatizes kovac_3d for the d=3 interior result. Defines placeholder kovacBallCenter and kovacBallRadius for Kovač's explicit construction. Axiomatizes kovac_explicit_ball: the ball lies inside harmonicPointSet 3."
+      "summary": "Proves kovac_3d as a corollary of erdos_268_solved (eliminating the axiom). Defines placeholder kovacBallCenter and kovacBallRadius for Kovač's explicit construction. Axiomatizes kovac_explicit_ball: the specific ball lies inside harmonicPointSet 3.",
+      "startLine": 133,
+      "endLine": 151,
+      "mathContext": "Proves kovac_3d as a corollary of erdos_268_solved (eliminating the axiom). Axiomatizes kovac_explicit_ball for the specific ball construction."
     },
     {
       "id": "general",
@@ -139,7 +139,7 @@
     {
       "id": "properties",
       "title": "Properties of X",
-      "summary": "States harmonicPointSet_nonempty (sorry — would use squares example), harmonicPointSet_path_connected (sorry — involves continuous interpolation of sets), and harmonicPointSet_dense_somewhere (partially proved from the main axiom using isOpen_interior, with one remaining sorry).",
+      "summary": "Proves harmonicPointSet_nonempty from interior axiom. harmonicPointSet_path_connected remains sorry (requires continuous interpolation of infinite sets). Proves harmonicPointSet_dense_somewhere using interior axiom and dense_iff_inter_open.",
       "startLine": 156,
       "endLine": 184,
       "mathContext": "States harmonicPointSet_nonempty (sorry — would use squares example), harmonicPointSet_path_connected (sorry — involves continuous interpolation of sets), and harmonicPointSet_dense_somewhere (partially proved from the main axiom using isOpen_interior, with one remaining sorry)."
@@ -147,7 +147,7 @@
     {
       "id": "coordinates",
       "title": "Coordinate Properties",
-      "summary": "States coordinate_decreasing: shifted sums decrease with shift index (sorry — needs tsum_lt_tsum for infinite A). States first_coordinate_largest as a corollary. States all_coordinates_positive for nonempty A (sorry — needs tsum_pos). Together these show X lies in the cone {x₀ > x₁ > ··· > x_{d-1} > 0}.",
+      "summary": "Proves coordinate_decreasing via tsum_lt_tsum with comparison of 1/(n+j) vs 1/(n+i). Proves first_coordinate_largest as corollary. Proves all_coordinates_positive via tsum_pos. All fully proved — X lies in the cone {x₀ > x₁ > ... > x_{d-1} > 0}.",
       "startLine": 185,
       "endLine": 206,
       "mathContext": "States coordinate_decreasing: shifted sums decrease with shift index (sorry — needs tsum_lt_tsum for infinite A). States first_coordinate_largest as a corollary. States all_coordinates_positive for nonempty A (sorry — needs tsum_pos)."
@@ -155,7 +155,7 @@
     {
       "id": "monotonicity",
       "title": "Dimension Monotonicity",
-      "summary": "Defines projectionMap from ℝᵈ² to ℝᵈ¹ for d₁ ≤ d₂ via coordinate restriction. States projection_preserves: the image of X_{d₂} under projection lies in X_{d₁} (sorry — requires showing the same set A generates both points).",
+      "summary": "Defines projectionMap from ℝᵈ² to ℝᵈ¹ for d₁ ≤ d₂ via coordinate restriction. Proves projection_preserves: the image of X_{d₂} under projection lies in X_{d₁} by showing the same set A generates both points.",
       "startLine": 207,
       "endLine": 217,
       "mathContext": "Defines projectionMap from ℝᵈ² to ℝᵈ¹ for d₁ ≤ d₂ via coordinate restriction. States projection_preserves: the image of X_{d₂} under projection lies in X_{d₁} (sorry — requires showing the same set A generates both points)."
@@ -163,14 +163,14 @@
     {
       "id": "examples",
       "title": "Specific Examples",
-      "summary": "Defines squaresSet = {n² : n ≥ 1} and powersOf2Set = {2ᵏ}. States convergence for both (sorry). Defines squaresPoint and powers2Point as concrete elements of X. The squares example connects to the Basel problem (Σ 1/n² = π²/6); the powers-of-2 example is a geometric series (Σ 1/2ᵏ = 2).",
+      "summary": "Defines squaresSet = {n² : n ≥ 1} and powersOf2Set = {2ᵏ}. Proves convergence for both: squares via Real.summable_nat_rpow_inv (p-series p=2>1), powers via summable_geometric_of_lt_one. Defines squaresPoint and powers2Point as concrete elements of X. All fully proved.",
       "startLine": 218,
       "endLine": 278,
       "mathContext": "Defines squaresSet = {n² : n ≥ 1} and powersOf2Set = {2ᵏ}. States convergence for both (sorry). Defines squaresPoint and powers2Point as concrete elements of X. The squares example connects to the Basel problem (Σ 1/n² = π²/6); the powers-of-2 example is a geometric series (Σ 1/2ᵏ = 2)."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #268 asks whether the set of harmonic subseries points X_d ⊆ ℝᵈ has nonempty interior. The answer is YES for all d ≥ 1, proved in stages: Erdős-Straus for d=2, Kovač (2024) for d=3 with an explicit ball, and Kovač-Tao (2024) for all d using Ahmes series techniques. The formalization captures this in 242 lines of Lean 4 with 4 axioms (the deep analytical results) and 12 sorries (Mathlib-level technical lemmas). The key genuine proof is contains_open_ball, which derives the metric-ball formulation from the interior axiom. The sorry lemmas are good candidates for Aristotle proof search, as most involve standard Mathlib reasoning about summability and comparison.",
+    "summary": "Erdős Problem #268 asks whether the set of harmonic subseries points X_d ⊆ ℝᵈ has nonempty interior. The answer is YES for all d ≥ 1, proved in stages: Erdős-Straus for d=2, Kovač (2024) for d=3 with an explicit ball, and Kovač-Tao (2024) for all d using Ahmes series techniques. The formalization captures this in 340 lines of Lean 4 with 2 axioms and 1 sorry. The erdos_straus_2d and kovac_3d axioms were eliminated by deriving them from erdos_268_solved. 11 sorries were proved including convergence of squares/powers-of-2, coordinate monotonicity via tsum_lt_tsum, positivity via tsum_pos, projection preservation, and local density. The remaining sorry is harmonicPointSet_path_connected (requires continuous interpolation of infinite sets).",
     "implications": "**Theoretical Significance**: **Connections Across Mathematics**\n\n1. **Ahmes Series and Egyptian Fractions:** The Kovač-Tao proof bridges ancient number theory (Egyptian fraction decompositions from the Rhind Papyrus) with modern topology. The set of numbers representable as Ahmes series has surprising density properties that directly imply the nonempty interior result\n\n2. **Thin Sets in Additive Combinatorics:** Problem #268 is a topological counterpart to questions about sumsets of thin sets. In additive combinatorics, Freiman-Ruzsa theory studies when thin sets have large sumsets; here, the 'sumset' is the image of the harmonic point map, and 'large' means having interior\n\n**3. Harmonic Analysis on ℕ:** The shifted sums Σ 1/(n+k) are related to the digamma function ψ(x) and its derivatives (polygamma functions). The coordinate coupling in X_d reflects analytic properties of these special functions\n\n4. **Measure-Theoretic Questions:** Beyond interior, one can ask about the Lebesgue measure, Hausdorff dimension, and boundary regularity of X_d. The nonempty interior result implies positive Lebesgue measure, but sharp bounds on measure as a function of d remain open\n\n5. **Infinite-Dimensional Limit:** As d → ∞, the constraints become more restrictive (more coordinates must be simultaneously realized). Whether X_∞ = lim X_d retains any interior in the infinite-dimensional limit is a natural extension that connects to functional analysis.",
     "openQuestions": [
       "What is the largest open ball contained in X_d for each dimension d? How does the optimal radius decay with d?",
@@ -211,9 +211,9 @@
       "Topology"
     ],
     "namespace": "Erdos268",
-    "lineCount": 278,
-    "axiomCount": 4,
-    "theoremCount": 15,
+    "lineCount": 340,
+    "axiomCount": 2,
+    "theoremCount": 17,
     "definitionCount": 14
   }
 }


### PR DESCRIPTION
## Summary
Research session proving theorems and eliminating axioms in Erdős #268 and #1049.

**Erdős #268 (Interior of Harmonic Subseries Points)**:
- Eliminate 2 axioms (`erdos_straus_2d`, `kovac_3d`) as corollaries of `erdos_268_solved`
- Prove 11 sorries by porting proofs from Aristotle companion file
- Result: 4 axioms → 2, 12 sorries → 1

**Erdős #1049 (Irrationality of Divisor Sums)**:
- Eliminate 4 trivial axioms (tautology + 3 True placeholders)
- Prove `transcendental_implies_chowla` (transcendence → irrationality)
- Prove `geometric_divisor` (geometric series identity)
- Result: 6 axioms → 2, 11 sorries → 9

## Files Modified
- `proofs/Proofs/Erdos268Problem.lean` — 13 theorems proved
- `src/data/proofs/erdos-268/meta.json` — updated counts
- `proofs/Proofs/Erdos1049Problem.lean` — 6 theorems proved (4 axiom→theorem + 2 sorry→proof)
- `src/data/proofs/erdos-1049/meta.json` — updated counts

## Status
**Outcome**: completed
**Total**: 6 axioms eliminated, 13 sorries eliminated across 2 files

🤖 Generated by researcher-1