### PR TITLE
fix: correct sorry/line counts in 5 gallery meta.json files

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5369,9 +5369,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-537": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T00:46:11Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-538": {
@@ -5795,9 +5795,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-601": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T00:46:11Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-602": {
@@ -6215,9 +6215,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-666": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T00:46:11Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-667": {
@@ -6631,9 +6631,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-729": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T00:46:11Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-73": {
@@ -6799,9 +6799,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-755": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T00:46:11Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-757": {

--- a/src/data/proofs/erdos-537/meta.json
+++ b/src/data/proofs/erdos-537/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-537",
-  "title": "Erdős Problem #537: Three Numbers with Equal Prime Products",
+  "title": "Erd\u0151s Problem #537: Three Numbers with Equal Prime Products",
   "slug": "erdos-537",
-  "description": "Let ε > 0 and N be large. If A ⊆ {1,...,N} has |A| ≥ εN, must there exist a₁,a₂,a₃ ∈ A and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃? NO, disproved by Ruzsa's counterexample.",
+  "description": "Let \u03b5 > 0 and N be large. If A \u2286 {1,...,N} has |A| \u2265 \u03b5N, must there exist a\u2081,a\u2082,a\u2083 \u2208 A and distinct primes p\u2081,p\u2082,p\u2083 with a\u2081p\u2081 = a\u2082p\u2082 = a\u2083p\u2083? NO, disproved by Ruzsa's counterexample.",
   "meta": {
-    "author": "Ruzsa (counterexample), described by Erdős",
+    "author": "Ruzsa (counterexample), described by Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/537",
     "date": "",
     "status": "axiomatized",
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 537,
     "erdosUrl": "https://erdosproblems.com/537",
     "erdosProblemStatus": "disproved",
@@ -58,16 +58,16 @@
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #537: Three Equal Prime Products**\n\nThis problem originates from Erdős's investigations into multiplicative structure within dense sets, first appearing in [Er73]. The question asks whether positive density in $\\{1,\\ldots,N\\}$ forces the existence of three numbers $a_1, a_2, a_3$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$.\n\n**Historical Context:** Erdős posed this as a stepping stone toward Problem #536, which asks an analogous question for two numbers with equal prime products. A positive answer to #537 would have implied #536 by a pigeonhole argument. The problem connects to the broader program of understanding multiplicative coincidences in dense sets, initiated by Erdős and Turán in the 1930s and continued by Erdős-Graham (1980).\n\n**Resolution:** Imre Z. Ruzsa, a leading figure in additive combinatorics (known for the Ruzsa covering lemma and sumset estimates), constructed a decisive counterexample. His construction uses **lacunary squarefree numbers**: integers $n$ where if $p < q$ are consecutive prime divisors of $n$, then $q > 2p$. This ingenious set has positive lower density but the lacunary gap condition prevents any triple of equal prime products.\n\n**Technique:** The proof exploits an interval constraint: restricting to $(N/2, N)$, any ratio $a_i/a_j$ lies in $(1, 2)$, which is incompatible with the gap condition $q > 2p$ for consecutive primes. This pigeonhole-style argument is characteristic of Ruzsa's economical proof style.",
+    "historicalContext": "**Erd\u0151s Problem #537: Three Equal Prime Products**\n\nThis problem originates from Erd\u0151s's investigations into multiplicative structure within dense sets, first appearing in [Er73]. The question asks whether positive density in $\\{1,\\ldots,N\\}$ forces the existence of three numbers $a_1, a_2, a_3$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$.\n\n**Historical Context:** Erd\u0151s posed this as a stepping stone toward Problem #536, which asks an analogous question for two numbers with equal prime products. A positive answer to #537 would have implied #536 by a pigeonhole argument. The problem connects to the broader program of understanding multiplicative coincidences in dense sets, initiated by Erd\u0151s and Tur\u00e1n in the 1930s and continued by Erd\u0151s-Graham (1980).\n\n**Resolution:** Imre Z. Ruzsa, a leading figure in additive combinatorics (known for the Ruzsa covering lemma and sumset estimates), constructed a decisive counterexample. His construction uses **lacunary squarefree numbers**: integers $n$ where if $p < q$ are consecutive prime divisors of $n$, then $q > 2p$. This ingenious set has positive lower density but the lacunary gap condition prevents any triple of equal prime products.\n\n**Technique:** The proof exploits an interval constraint: restricting to $(N/2, N)$, any ratio $a_i/a_j$ lies in $(1, 2)$, which is incompatible with the gap condition $q > 2p$ for consecutive primes. This pigeonhole-style argument is characteristic of Ruzsa's economical proof style.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet $\\epsilon > 0$ and $N$ be sufficiently large. If $A \\subseteq \\{1,\\ldots,N\\}$ has $|A| \\geq \\epsilon N$, must there exist $a_1, a_2, a_3 \\in A$ and distinct primes $p_1, p_2, p_3$ such that\n$$a_1 p_1 = a_2 p_2 = a_3 p_3?$$\n\n**Answer: NO**\n\nRuzsa constructed a counterexample: the lacunary squarefree numbers (where consecutive prime factors satisfy $p_{i+1} > 2p_i$) have positive density but contain no such triple.",
-    "text": "Let ε > 0 and N be large. If A ⊆ {1,...,N} has |A| ≥ εN, must there exist a₁,a₂,a₃ ∈ A and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃? NO, disproved by Ruzsa's counterexample.",
+    "text": "Let \u03b5 > 0 and N be large. If A \u2286 {1,...,N} has |A| \u2265 \u03b5N, must there exist a\u2081,a\u2082,a\u2083 \u2208 A and distinct primes p\u2081,p\u2082,p\u2083 with a\u2081p\u2081 = a\u2082p\u2082 = a\u2083p\u2083? NO, disproved by Ruzsa's counterexample.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Density Definitions:** Define $\\underline{d}(A) = \\liminf_{N \\to \\infty} |A \\cap [1,N]|/N > 0$ and $\\text{IsDenseSubset}(A, \\epsilon, N)$ for $|A \\cap [1,N]| \\geq \\epsilon N$.\n\n2. **Conjecture Formalization:** State $\\text{Erdos537Conjecture}$ as $\\forall \\epsilon > 0, \\exists N_0, \\forall N \\geq N_0$, every dense $A$ has three equal prime products.\n\n3. **Ruzsa's Construction:** Define $\\text{IsLacunarySquarefree}(n)$: squarefree and for consecutive prime divisors $p < q$, $q > 2p$. The $\\text{RuzsaSet}(N)$ restricts to $[1,N]$.\n\n4. **Key Properties:** Axiomatize that the Ruzsa set has positive density and that the lacunary condition prevents the triple pattern.\n\n5. **Interval Argument:** For $a_2, a_3 \\in (N/2, N)$ prove $1 < a_2/a_3 < 2$, contradicting $q/p > 2$.\n\n6. **Disproof Assembly:** Combine density, no-triple, and contradiction to negate the conjecture.",
     "keyInsights": [
       "**Lacunary Squarefree Numbers:** The set $\\{n \\in \\mathbb{N} : n$ squarefree, consecutive prime divisors satisfy $q > 2p\\}$ has positive lower density $\\underline{d} > 0$ despite the exponential gap condition",
       "**Interval-Gap Incompatibility:** For $a_2, a_3 \\in (N/2, N)$, the ratio $a_2/a_3 \\in (1, 2)$ while the lacunary condition forces $p_3/p_2 > 2$, giving the contradiction $a_2 p_2 \\neq a_3 p_3$",
       "**Counterexample Strategy:** Rather than proving the conjecture false for all dense sets, Ruzsa exhibits one specific dense set $A$ with $\\underline{d}(A) > 0$ that avoids the pattern entirely",
       "**Implication for Problem #536:** A positive answer to #537 would have implied #536 (two equal prime products). Ruzsa's counterexample blocks this approach but does not resolve #536 itself",
-      "**Multiplicative vs. Additive:** Dense sets must contain additive patterns (Szemerédi's theorem) but need NOT contain all multiplicative patterns — the prime factorization structure allows escape"
+      "**Multiplicative vs. Additive:** Dense sets must contain additive patterns (Szemer\u00e9di's theorem) but need NOT contain all multiplicative patterns \u2014 the prime factorization structure allows escape"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -102,7 +102,7 @@
     },
     {
       "id": "conjecture",
-      "title": "The Erdős #537 Conjecture",
+      "title": "The Erd\u0151s #537 Conjecture",
       "summary": "Formalizes the conjecture: $\\forall \\epsilon > 0, \\exists N_0, \\forall N \\geq N_0$, every $\\epsilon$-dense subset has three equal prime products (FALSE)",
       "startLine": 64,
       "endLine": 76,
@@ -143,10 +143,10 @@
     {
       "id": "connections",
       "title": "Connection to Related Problems",
-      "summary": "Link to Erdős #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemerédi-type questions and the Erdős multiplicative functions program",
+      "summary": "Link to Erd\u0151s #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemer\u00e9di-type questions and the Erd\u0151s multiplicative functions program",
       "startLine": 227,
       "endLine": 246,
-      "mathContext": "Mathematical content: Link to Erdős #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemerédi-type questions and the Erdős multiplicative functions program"
+      "mathContext": "Mathematical content: Link to Erd\u0151s #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemer\u00e9di-type questions and the Erd\u0151s multiplicative functions program"
     },
     {
       "id": "main-results",
@@ -158,8 +158,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #537 is DISPROVED. The conjecture asked whether dense subsets of {1,...,N} must contain three numbers a₁,a₂,a₃ and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃. Ruzsa's construction of lacunary squarefree numbers (where consecutive prime factors satisfy q > 2p) provides a counterexample: these numbers have positive lower density but the lacunary gap property, combined with an interval constraint on ratios, prevents the required pattern.",
-    "implications": "**Theoretical Significance**: **Number-Theoretic Significance**\n\n1. **Multiplicative Structure Gap:** Positive density forces additive patterns (Szemerédi) but not all multiplicative patterns — the prime factorization structure provides an escape mechanism.\n\n2. **Lacunary Squarefree Sets:** Ruzsa's construction reveals that controlling the gap between consecutive prime divisors creates sets with rigid multiplicative structure despite having positive density.\n\n**3. Blocked Implication:** The intended pathway from #537 to #536 is broken. Problem #536 requires a different approach.\n\n4. **Sieve-Theoretic Density:** The positive density of lacunary squarefree numbers is established via sieve methods, connecting this problem to the Selberg-Brun sieve tradition.",
+    "summary": "Erd\u0151s Problem #537 is DISPROVED. The conjecture asked whether dense subsets of {1,...,N} must contain three numbers a\u2081,a\u2082,a\u2083 and distinct primes p\u2081,p\u2082,p\u2083 with a\u2081p\u2081 = a\u2082p\u2082 = a\u2083p\u2083. Ruzsa's construction of lacunary squarefree numbers (where consecutive prime factors satisfy q > 2p) provides a counterexample: these numbers have positive lower density but the lacunary gap property, combined with an interval constraint on ratios, prevents the required pattern.",
+    "implications": "**Theoretical Significance**: **Number-Theoretic Significance**\n\n1. **Multiplicative Structure Gap:** Positive density forces additive patterns (Szemer\u00e9di) but not all multiplicative patterns \u2014 the prime factorization structure provides an escape mechanism.\n\n2. **Lacunary Squarefree Sets:** Ruzsa's construction reveals that controlling the gap between consecutive prime divisors creates sets with rigid multiplicative structure despite having positive density.\n\n**3. Blocked Implication:** The intended pathway from #537 to #536 is broken. Problem #536 requires a different approach.\n\n4. **Sieve-Theoretic Density:** The positive density of lacunary squarefree numbers is established via sieve methods, connecting this problem to the Selberg-Brun sieve tradition.",
     "openQuestions": [
       "What is the exact lower density of the lacunary squarefree numbers? Sieve bounds give estimates but the precise asymptotic is unknown.",
       "Can Ruzsa's construction be adapted to disprove analogous problems with k > 3 equal prime products?",
@@ -172,12 +172,12 @@
     {
       "targetId": "erdos-536",
       "relationship": "related",
-      "description": "Erdős #536 asks whether dense sets contain two numbers with equal prime products. Problem #537 was posed as a stepping stone — a positive answer would have implied #536. Ruzsa's counterexample blocks this approach."
+      "description": "Erd\u0151s #536 asks whether dense sets contain two numbers with equal prime products. Problem #537 was posed as a stepping stone \u2014 a positive answer would have implied #536. Ruzsa's counterexample blocks this approach."
     },
     {
       "targetId": "fundamental-arithmetic",
       "relationship": "foundational",
-      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) is the foundation for Problem #537's question about when three distinct integers can have identical sets of prime factors. The multiplicative structure of ℤ governs which prime products can coincide"
+      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) is the foundation for Problem #537's question about when three distinct integers can have identical sets of prime factors. The multiplicative structure of \u2124 governs which prime products can coincide"
     }
   ],
   "leanFile": {
@@ -189,7 +189,7 @@
     ],
     "opens": [],
     "namespace": "Erdos537",
-    "lineCount": 276,
+    "lineCount": 292,
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 7

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-601",
-  "title": "Erdős #601: Infinite Paths and Independent Sets in Ordinal Graphs",
+  "title": "Erd\u0151s #601: Infinite Paths and Independent Sets in Ordinal Graphs",
   "slug": "erdos-601",
-  "description": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
+  "description": "For which limit ordinals \u03b1 must every graph on \u03b1 have infinite path OR independent set of order type \u03b1? Known for \u03b1 < \u03c9\u2081^{\u03c9+2}. Prize: $500.",
   "meta": {
-    "author": "Paul Erdős, András Hajnal, Eric Milner, Jean Larson",
+    "author": "Paul Erd\u0151s, Andr\u00e1s Hajnal, Eric Milner, Jean Larson",
     "sourceUrl": "https://erdosproblems.com/601",
     "date": "1970",
     "status": "axiomatized",
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 10,
     "erdosNumber": 601,
     "erdosUrl": "https://erdosproblems.com/601",
     "erdosProblemStatus": "open",
@@ -52,7 +52,7 @@
       "IsIndependent: independence predicate",
       "HasOrderType: order type of vertex subsets",
       "PropertyP: path-vs-independent-set dichotomy",
-      "criticalOrdinal: ω₁^{ω+2} definition",
+      "criticalOrdinal: \u03c9\u2081^{\u03c9+2} definition",
       "erdos_hajnal_milner: main theorem (1970)",
       "CriticalCaseConjecture: $250 prize problem",
       "MartinsAxiom: set-theoretic axiom",
@@ -107,7 +107,7 @@
     },
     {
       "id": "ehm",
-      "title": "Erdős-Hajnal-Milner Theorem (1970)",
+      "title": "Erd\u0151s-Hajnal-Milner Theorem (1970)",
       "summary": "Defines `criticalOrdinal` $= \\omega_1^{\\omega+2}$ and axiomatizes the main result: $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on Cantor normal form.",
       "startLine": 88,
       "endLine": 101,
@@ -116,10 +116,10 @@
     {
       "id": "critical",
       "title": "The Critical Case: $\\omega_1^{\\omega+2}$ ($250)",
-      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize.",
+      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erd\u0151s-Hajnal-Milner induction breaks down. \\$250 prize.",
       "startLine": 102,
       "endLine": 116,
-      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize."
+      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erd\u0151s-Hajnal-Milner induction breaks down. \\$250 prize."
     },
     {
       "id": "martins-axiom",
@@ -140,10 +140,10 @@
     {
       "id": "graph-tools",
       "title": "Graph-Theoretic Tools",
-      "summary": "States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
+      "summary": "States K\u00f6nig's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
       "startLine": 152,
       "endLine": 165,
-      "mathContext": "Mathematical content: States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
+      "mathContext": "Mathematical content: States K\u00f6nig's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
     },
     {
       "id": "independence",
@@ -163,13 +163,13 @@
     }
   ],
   "overview": {
-    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erdős, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erdős-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
-    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erdős-Hajnal-Milner theorem.",
-    "text": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erdős-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, König's lemma, independence number, transfinite induction.",
+    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erd\u0151s, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erd\u0151s-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
+    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erd\u0151s-Hajnal-Milner theorem.",
+    "text": "For which limit ordinals \u03b1 must every graph on \u03b1 have infinite path OR independent set of order type \u03b1? Known for \u03b1 < \u03c9\u2081^{\u03c9+2}. Prize: $500.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erd\u0151s-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, K\u00f6nig's lemma, independence number, transfinite induction.",
     "keyInsights": [
-      "**Erdős-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
-      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ — new techniques are needed",
+      "**Erd\u0151s-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
+      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ \u2014 new techniques are needed",
       "**Larson (1990):** Under Martin's Axiom, $P(\\alpha)$ extends to all $\\alpha$ with $|\\alpha| < 2^{\\aleph_0}$, showing set-theoretic dependence",
       "**Ramsey-type dichotomy:** The problem generalizes the infinite Ramsey theorem from $\\omega$ to arbitrary ordinals with order type requirements",
       "**Two-tier prize:** $250 for the critical case $P(\\omega_1^{\\omega+2})$, $500 for the full generalization to all limit ordinals"
@@ -181,13 +181,13 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erdős-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
-    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms — the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erdős-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
+    "summary": "This formalization captures Erd\u0151s Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erd\u0151s-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
+    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms \u2014 the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erd\u0151s-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
     "openQuestions": [
-      "Does P(ω₁^{ω+2}) hold? ($250 — the critical boundary case)",
-      "Does P(α) hold for all limit ordinals α? ($500 — the general conjecture)",
+      "Does P(\u03c9\u2081^{\u03c9+2}) hold? ($250 \u2014 the critical boundary case)",
+      "Does P(\u03b1) hold for all limit ordinals \u03b1? ($500 \u2014 the general conjecture)",
       "Is the answer independent of ZFC (provable under MA but not in ZFC alone)?",
-      "Can the Erdős-Hajnal-Milner bound ω₁^{ω+2} be improved in ZFC?",
+      "Can the Erd\u0151s-Hajnal-Milner bound \u03c9\u2081^{\u03c9+2} be improved in ZFC?",
       "What happens for singular cardinals and their ordinal powers?"
     ]
   },
@@ -205,7 +205,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos601",
-    "lineCount": 247,
+    "lineCount": 262,
     "axiomCount": 3,
     "theoremCount": 19,
     "definitionCount": 13
@@ -213,17 +213,17 @@
   "references": [
     {
       "key": "EHM70",
-      "citation": "Erdős, Paul, Hajnal, András, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
+      "citation": "Erd\u0151s, Paul, Hajnal, Andr\u00e1s, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
       "type": "paper"
     },
     {
       "key": "La90",
-      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal ω^ω, Ann. Pure Appl. Logic 48 (1990), 253-255.",
+      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal \u03c9^\u03c9, Ann. Pure Appl. Logic 48 (1990), 253-255.",
       "type": "paper"
     },
     {
       "key": "EH77",
-      "citation": "Erdős, Paul and Hajnal, András, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
+      "citation": "Erd\u0151s, Paul and Hajnal, Andr\u00e1s, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
       "type": "paper"
     },
     {
@@ -233,7 +233,7 @@
     },
     {
       "key": "EP",
-      "citation": "Erdős Problems, Problem #601, https://erdosproblems.com/601.",
+      "citation": "Erd\u0151s Problems, Problem #601, https://erdosproblems.com/601.",
       "type": "website"
     }
   ],
@@ -241,17 +241,17 @@
     {
       "targetId": "erdos-111",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
     },
     {
       "targetId": "erdos-1169",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
     },
     {
       "targetId": "erdos-1174",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-666",
-  "title": "Erdős Problem #666: C₆ in Hypercube Subgraphs",
+  "title": "Erd\u0151s Problem #666: C\u2086 in Hypercube Subgraphs",
   "slug": "erdos-666",
-  "description": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
+  "description": "Does every \u03b5-dense subgraph of the n-hypercube Q\u2099 contain C\u2086? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Q\u2099 can be 4-partitioned into C\u2086-free subgraphs.",
   "meta": {
     "author": "Chung (1992 disproof), Brouwer-Dejter-Thomassen (1993), Conder (1993)",
     "sourceUrl": "https://erdosproblems.com/666",
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 666,
     "erdosUrl": "https://erdosproblems.com/666",
     "erdosProblemStatus": "disproved",
@@ -43,15 +43,15 @@
     ],
     "originalContributions": [
       "Hypercube definition via XOR popcount: vertices adjacent iff differ in exactly one bit",
-      "hypercubeVertices: |V(Qₙ)| = 2ⁿ",
-      "hypercubeEdges: |E(Qₙ)| = n·2ⁿ⁻¹",
-      "hypercube_regular axiom: Qₙ is n-regular",
+      "hypercubeVertices: |V(Q\u2099)| = 2\u207f",
+      "hypercubeEdges: |E(Q\u2099)| = n\u00b72\u207f\u207b\u00b9",
+      "hypercube_regular axiom: Q\u2099 is n-regular",
       "HasCycle definition: injective sequence with cyclic adjacency",
       "HasC4, HasC6, HasC2k cycle predicates",
-      "EpsilonDenseSubgraph: subgraph with ε-fraction of edges",
+      "EpsilonDenseSubgraph: subgraph with \u03b5-fraction of edges",
       "ErdosConjecture: original (disproved) conjecture",
       "erdos_conjecture_false theorem: main disproof",
-      "chung_1992 axiom: 4-partition into C₆-free subgraphs",
+      "chung_1992 axiom: 4-partition into C\u2086-free subgraphs",
       "brouwer_dejter_thomassen_1993 axiom: independent 4-coloring",
       "conder_1993 axiom: improved 3-coloring",
       "GeneralizedConjecture: open question for C_{2k}"
@@ -61,32 +61,32 @@
     "assumptions": "5 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #666**\n\nErdős posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Qₙ has 2ⁿ vertices (binary strings of length n) and n·2ⁿ⁻¹ edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Qₙ's edges into C₆-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C₄ and C₆\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Qₙ can be 3-colored with no monochromatic C₄ or C₆. This means subgraphs with 1/3 of all edges need not contain C₆.",
-    "problemStatement": "**Problem Statement (Disproved)**\n\nLet Qₙ be the n-dimensional hypercube (2ⁿ vertices, n·2ⁿ⁻¹ edges).\n\n**Conjecture:** For every ε > 0, if n is sufficiently large, every subgraph of Qₙ with ≥ ε·n·2ⁿ⁻¹ edges contains C₆.\n\n**Answer:** NO\n\n**Counterexamples:**\n- ε = 1/4: Chung's 4-partition (1992)\n- ε = 1/3: Conder's 3-coloring (1993)\n\n**Generalized Conjecture (OPEN):** For C_{2k}, ∃ c > 0 and aₖ < 1 such that ≥ c·n^{aₖ}·2ⁿ edges forces C_{2k}, with aₖ → 0 as k → ∞.",
-    "text": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Hypercube Definition:** Qₙ defined via XOR popcount - vertices in Fin(2ⁿ) are adjacent iff their XOR has exactly one 1-bit (Hamming distance 1)\n\n2. **Cycle Definitions:**\n   - HasCycle G k: injective k-sequence with cyclic adjacency\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\n\n3. **Density:**\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\n\n4. **Main Results:**\n   - ErdosConjecture: the (false) original conjecture\n   - erdos_conjecture_false: theorem showing it's false\n   - chung_1992 axiom: 4-partition exists\n   - conder_1993 axiom: 3-coloring exists\n\n5. **Why Axioms:** The partition constructions are combinatorial and not in Mathlib",
+    "historicalContext": "**Erd\u0151s Problem #666**\n\nErd\u0151s posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Q\u2099 has 2\u207f vertices (binary strings of length n) and n\u00b72\u207f\u207b\u00b9 edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Q\u2099's edges into C\u2086-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C\u2084 and C\u2086\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Q\u2099 can be 3-colored with no monochromatic C\u2084 or C\u2086. This means subgraphs with 1/3 of all edges need not contain C\u2086.",
+    "problemStatement": "**Problem Statement (Disproved)**\n\nLet Q\u2099 be the n-dimensional hypercube (2\u207f vertices, n\u00b72\u207f\u207b\u00b9 edges).\n\n**Conjecture:** For every \u03b5 > 0, if n is sufficiently large, every subgraph of Q\u2099 with \u2265 \u03b5\u00b7n\u00b72\u207f\u207b\u00b9 edges contains C\u2086.\n\n**Answer:** NO\n\n**Counterexamples:**\n- \u03b5 = 1/4: Chung's 4-partition (1992)\n- \u03b5 = 1/3: Conder's 3-coloring (1993)\n\n**Generalized Conjecture (OPEN):** For C_{2k}, \u2203 c > 0 and a\u2096 < 1 such that \u2265 c\u00b7n^{a\u2096}\u00b72\u207f edges forces C_{2k}, with a\u2096 \u2192 0 as k \u2192 \u221e.",
+    "text": "Does every \u03b5-dense subgraph of the n-hypercube Q\u2099 contain C\u2086? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Q\u2099 can be 4-partitioned into C\u2086-free subgraphs.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Hypercube Definition:** Q\u2099 defined via XOR popcount - vertices in Fin(2\u207f) are adjacent iff their XOR has exactly one 1-bit (Hamming distance 1)\n\n2. **Cycle Definitions:**\n   - HasCycle G k: injective k-sequence with cyclic adjacency\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\n\n3. **Density:**\n   - EpsilonDenseSubgraph: at least \u03b5\u00b7n\u00b72\u207f\u207b\u00b9 edges\n\n4. **Main Results:**\n   - ErdosConjecture: the (false) original conjecture\n   - erdos_conjecture_false: theorem showing it's false\n   - chung_1992 axiom: 4-partition exists\n   - conder_1993 axiom: 3-coloring exists\n\n5. **Why Axioms:** The partition constructions are combinatorial and not in Mathlib",
     "keyInsights": [
-      "**Hypercube Structure:** Qₙ vertices are binary strings, adjacent iff Hamming distance = 1",
-      "**Size:** |V| = 2ⁿ, |E| = n·2ⁿ⁻¹, degree = n (n-regular)",
-      "**Chung's Partition (1992):** Qₙ edges split into 4 C₆-free parts, each with ~1/4 of edges",
-      "**Conder's Improvement (1993):** Only 3 colors needed - even denser C₆-free subgraphs exist",
-      "**The Disproof:** ε = 1/4 (or 1/3) counterexamples refute the conjecture",
-      "**Open Generalization:** For C_{2k}, what density threshold aₖ forces the cycle?"
+      "**Hypercube Structure:** Q\u2099 vertices are binary strings, adjacent iff Hamming distance = 1",
+      "**Size:** |V| = 2\u207f, |E| = n\u00b72\u207f\u207b\u00b9, degree = n (n-regular)",
+      "**Chung's Partition (1992):** Q\u2099 edges split into 4 C\u2086-free parts, each with ~1/4 of edges",
+      "**Conder's Improvement (1993):** Only 3 colors needed - even denser C\u2086-free subgraphs exist",
+      "**The Disproof:** \u03b5 = 1/4 (or 1/3) counterexamples refute the conjecture",
+      "**Open Generalization:** For C_{2k}, what density threshold a\u2096 forces the cycle?"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
       "Graph theory (vertices, edges, colorings)",
-      "Extremal graph theory (Turán-type problems)"
+      "Extremal graph theory (Tur\u00e1n-type problems)"
     ]
   },
   "sections": [
     {
       "id": "hypercube",
       "title": "Hypercube Graph",
-      "summary": "Definition of Qₙ via XOR, vertices, edges, regularity",
+      "summary": "Definition of Q\u2099 via XOR, vertices, edges, regularity",
       "startLine": 36,
       "endLine": 68,
-      "mathContext": "Formal definition: Definition of Qₙ via XOR, vertices, edges, regularity"
+      "mathContext": "Formal definition: Definition of Q\u2099 via XOR, vertices, edges, regularity"
     },
     {
       "id": "cycles",
@@ -106,7 +106,7 @@
     },
     {
       "id": "conjecture",
-      "title": "Erdős's Conjecture (Disproved)",
+      "title": "Erd\u0151s's Conjecture (Disproved)",
       "summary": "ErdosConjecture, erdos_conjecture_false",
       "startLine": 119,
       "endLine": 141,
@@ -115,10 +115,10 @@
     {
       "id": "chung",
       "title": "Chung's Result (1992)",
-      "summary": "4-partition into C₆-free subgraphs",
+      "summary": "4-partition into C\u2086-free subgraphs",
       "startLine": 142,
       "endLine": 175,
-      "mathContext": "Mathematical content: 4-partition into C₆-free subgraphs"
+      "mathContext": "Mathematical content: 4-partition into C\u2086-free subgraphs"
     },
     {
       "id": "bdt",
@@ -131,10 +131,10 @@
     {
       "id": "conder",
       "title": "Conder's Improvement (1993)",
-      "summary": "3-coloring, ε = 1/3 counterexample",
+      "summary": "3-coloring, \u03b5 = 1/3 counterexample",
       "startLine": 199,
       "endLine": 232,
-      "mathContext": "Mathematical content: 3-coloring, ε = 1/3 counterexample"
+      "mathContext": "Mathematical content: 3-coloring, \u03b5 = 1/3 counterexample"
     },
     {
       "id": "generalized",
@@ -154,12 +154,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #666 asked whether ε-dense hypercube subgraphs must contain C₆. The answer is NO: Chung (1992) and Brouwer-Dejter-Thomassen (1993) independently showed Qₙ can be 4-partitioned into C₆-free subgraphs. Conder (1993) improved this to 3 colors.",
-    "implications": "The result shows the hypercube has surprising structure allowing sparse cycle-free subgraphs. This connects to Ramsey-Turán problems in hypercubes and extremal graph theory in structured graphs.",
+    "summary": "Erd\u0151s Problem #666 asked whether \u03b5-dense hypercube subgraphs must contain C\u2086. The answer is NO: Chung (1992) and Brouwer-Dejter-Thomassen (1993) independently showed Q\u2099 can be 4-partitioned into C\u2086-free subgraphs. Conder (1993) improved this to 3 colors.",
+    "implications": "The result shows the hypercube has surprising structure allowing sparse cycle-free subgraphs. This connects to Ramsey-Tur\u00e1n problems in hypercubes and extremal graph theory in structured graphs.",
     "openQuestions": [
-      "What is the minimum number of colors to avoid monochromatic C₆ in Qₙ?",
+      "What is the minimum number of colors to avoid monochromatic C\u2086 in Q\u2099?",
       "For C_{2k}, what density threshold forces the cycle?",
-      "Does aₖ → 0 as k → ∞ in the generalized conjecture?"
+      "Does a\u2096 \u2192 0 as k \u2192 \u221e in the generalized conjecture?"
     ]
   },
   "leanFile": {
@@ -173,7 +173,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 306,
+    "lineCount": 308,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 10
@@ -182,17 +182,17 @@
     {
       "targetId": "erdos-1080",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: cycles, disproved, extremal-graph-theory, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: cycles, disproved, extremal-graph-theory, graph-theory"
     },
     {
       "targetId": "erdos-1035",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory, hypercube"
+      "description": "Related Erd\u0151s problem sharing themes: extremal-graph-theory, graph-theory, hypercube"
     },
     {
       "targetId": "erdos-147",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: disproved, extremal-graph-theory, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: disproved, extremal-graph-theory, graph-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-729",
-  "title": "Erdős Problem #729: Factorial Divisibility Modulo Small Primes",
+  "title": "Erd\u0151s Problem #729: Factorial Divisibility Modulo Small Primes",
   "slug": "erdos-729",
-  "description": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C·log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b ≤ n + O(log n) persists even ignoring small primes.",
+  "description": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C\u00b7log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b \u2264 n + O(log n) persists even ignoring small primes.",
   "meta": {
-    "author": "Barreto-Leeham (solution), Erdős (1968)",
+    "author": "Barreto-Leeham (solution), Erd\u0151s (1968)",
     "sourceUrl": "https://erdosproblems.com/729",
     "date": "2020s",
     "status": "axiomatized",
@@ -17,7 +17,7 @@
       "legendre-formula"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 729,
     "erdosUrl": "https://erdosproblems.com/729",
     "erdosProblemStatus": "solved",
@@ -40,7 +40,7 @@
     ],
     "originalContributions": [
       "Formalized factorial divisibility modulo small primes",
-      "Axiomatized Barreto-Leeham's extension of Erdős's bound",
+      "Axiomatized Barreto-Leeham's extension of Erd\u0151s's bound",
       "Connected Legendre's formula to the divisibility constraint",
       "Defined relaxed divisibility allowing small prime factors"
     ],
@@ -50,10 +50,10 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős proved in 1968 that if $a!b! \\mid n!$ then $a + b \\leq n + O(\\log n)$, using an elegant argument based on Legendre's formula for $v_2(n!) = n - s_2(n)$, where $s_2(n)$ is the binary digit sum. Problem 729, posed later, asks whether this logarithmic bound can be defeated by \"ignoring\" small primes: specifically, whether there are infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ such that $n!/(a!b!)$ has denominator divisible only by primes $\\leq C$. Barreto and Leeham resolved the problem negatively, showing that large primes alone carry sufficient information to enforce the bound. Their proof adapts the technique from Problem #728, extending it to show that for any prime $p > C$, the constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ already implies $a + b \\leq n + O(\\log n)$. This reveals a fundamental rigidity in factorial arithmetic: the divisibility structure is controlled by all primes collectively, and no finite set of exceptions can weaken it.",
+    "historicalContext": "Erd\u0151s proved in 1968 that if $a!b! \\mid n!$ then $a + b \\leq n + O(\\log n)$, using an elegant argument based on Legendre's formula for $v_2(n!) = n - s_2(n)$, where $s_2(n)$ is the binary digit sum. Problem 729, posed later, asks whether this logarithmic bound can be defeated by \"ignoring\" small primes: specifically, whether there are infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ such that $n!/(a!b!)$ has denominator divisible only by primes $\\leq C$. Barreto and Leeham resolved the problem negatively, showing that large primes alone carry sufficient information to enforce the bound. Their proof adapts the technique from Problem #728, extending it to show that for any prime $p > C$, the constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ already implies $a + b \\leq n + O(\\log n)$. This reveals a fundamental rigidity in factorial arithmetic: the divisibility structure is controlled by all primes collectively, and no finite set of exceptions can weaken it.",
     "problemStatement": "Let $C > 0$ be a constant. Are there infinitely many integers $a, b, n$ with $a + b > n + C\\log n$ such that the denominator of $n!/(a!b!)$ contains only primes $\\leq C$?",
-    "text": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C·log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b ≤ n + O(log n) persists even ignoring small primes.",
-    "proofStrategy": "The formalization defines `DividesFactorial` and `DividesFactorialModSmall` (allowing small prime factors in the denominator), states `InfinitelyManyExceptions` as the open question, and axiomatizes both Erdős's 1968 result and the Barreto-Leeham resolution. Legendre's formula is stated via `factorialPadicVal` and the digit sum identity. The main theorem `erdos_729_statement` combines both results, and `erdos_729_summary` provides the complete answer. Two `sorry`s remain: `legendre_for_two` and `binomial_rigidity`.",
+    "text": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C\u00b7log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b \u2264 n + O(log n) persists even ignoring small primes.",
+    "proofStrategy": "The formalization defines `DividesFactorial` and `DividesFactorialModSmall` (allowing small prime factors in the denominator), states `InfinitelyManyExceptions` as the open question, and axiomatizes both Erd\u0151s's 1968 result and the Barreto-Leeham resolution. Legendre's formula is stated via `factorialPadicVal` and the digit sum identity. The main theorem `erdos_729_statement` combines both results, and `erdos_729_summary` provides the complete answer. Two `sorry`s remain: `legendre_for_two` and `binomial_rigidity`.",
     "keyInsights": [
       "Legendre's formula $v_p(n!) = (n - s_p(n))/(p-1)$ connects factorial divisibility to base-$p$ digit sums, with the special case $v_2(n!) = n - s_2(n)$ being particularly clean",
       "If $a!b! \\mid n!$, then $v_p(a!) + v_p(b!) \\leq v_p(n!)$ for all primes $p$. Using just $p = 2$ and the digit sum identity gives $a + b \\leq n + s_2(a) + s_2(b) - s_2(n) \\leq n + O(\\log n)$",
@@ -77,7 +77,7 @@
     },
     {
       "id": "erdos-classical",
-      "title": "Erdős's Classical Result (1968)",
+      "title": "Erd\u0151s's Classical Result (1968)",
       "startLine": 57,
       "endLine": 74,
       "summary": "Axiomatizes `erdos_1968_classical`: $a!b! \\mid n! \\implies a + b \\leq n + O(\\log n)$. Proves `erdos_proof_via_powers_of_two` by forwarding to the axiom, documenting that the original proof uses only the $p = 2$ constraint.",
@@ -96,8 +96,8 @@
       "title": "The Question",
       "startLine": 95,
       "endLine": 107,
-      "summary": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ and `DividesFactorialModSmall`? This is the formal statement of Erdős Problem 729.",
-      "mathContext": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\$\\log n$$ and `DividesFactorialModSmall`? This is the formal statement of Erdős Problem 729."
+      "summary": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ and `DividesFactorialModSmall`? This is the formal statement of Erd\u0151s Problem 729.",
+      "mathContext": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\$\\log n$$ and `DividesFactorialModSmall`? This is the formal statement of Erd\u0151s Problem 729."
     },
     {
       "id": "barreto-leeham",
@@ -149,7 +149,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 729 is solved negatively: there are NOT infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ where the denominator of $n!/(a!b!)$ has only small prime factors. The formalization captures the classical Erdős bound, the relaxed condition, the Barreto-Leeham resolution, and the proof strategy via large primes, with two remaining `sorry`s on supporting lemmas.",
+    "summary": "Erd\u0151s Problem 729 is solved negatively: there are NOT infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ where the denominator of $n!/(a!b!)$ has only small prime factors. The formalization captures the classical Erd\u0151s bound, the relaxed condition, the Barreto-Leeham resolution, and the proof strategy via large primes, with two remaining `sorry`s on supporting lemmas.",
     "implications": "The result demonstrates a fundamental rigidity in factorial arithmetic: the constraint $a + b \\leq n + O(\\log n)$ arises from all primes collectively and cannot be circumvented by ignoring finitely many. This connects to the robustness of Legendre's formula under prime localization and suggests that factorial divisibility is determined by the global prime structure, not any local subset.",
     "openQuestions": [
       "What is the optimal constant in the $O(\\log n)$ bound? Can it be made explicit as a function of $C$?",
@@ -188,7 +188,7 @@
       "Real"
     ],
     "namespace": "Erdos729",
-    "lineCount": 215,
+    "lineCount": 225,
     "axiomCount": 6,
     "theoremCount": 5,
     "definitionCount": 8

--- a/src/data/proofs/erdos-755/meta.json
+++ b/src/data/proofs/erdos-755/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 755,
     "erdosUrl": "https://erdosproblems.com/755",
     "erdosProblemStatus": "solved",
@@ -165,7 +165,7 @@
       "Real"
     ],
     "namespace": "Erdos755",
-    "lineCount": 280,
+    "lineCount": 281,
     "axiomCount": 7,
     "theoremCount": 3,
     "definitionCount": 7


### PR DESCRIPTION
## Summary
- Fixed sorry count mismatches in 5 Erdős problem meta.json files after recent researcher PRs proved theorems without updating counts
- Also corrected line counts that drifted

| Proof | Sorries | Lines |
|-------|---------|-------|
| erdos-755 | 2→1 | 280→281 |
| erdos-729 | 2→0 | 215→225 |
| erdos-666 | 2→1 | 306→308 |
| erdos-601 | 14→10 | 247→262 |
| erdos-537 | 1→0 | 276→292 |

## Verification
Each sorry count verified by `grep -n sorry` against the Lean source file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)