### PR TITLE
Research: prove 3 theorems across 3 files (Dirichlet, Erdős #237, #308)

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ03.lean
@@ -107,12 +107,15 @@ def optimalLinnikConjecture : Prop :=
 /-- The optimal conjecture implies linnikConstant ≤ 1 -/
 theorem optimal_implies_le_one (h : optimalLinnikConjecture) :
     linnikConstant ≤ 1 := by
-  apply csInf_le ⟨0, fun L hL => le_of_lt hL.1⟩
-  have := h (1/2) (by norm_num : (1:ℝ)/2 > 0)
-  -- 1 + 1/2 = 3/2 ∈ admissibleExponents, and 3/2 > 1
-  -- But we need something ≤ 1... The conjecture says ∀ ε > 0, 1+ε admissible
-  -- Taking limit: linnikConstant ≤ 1 + ε for all ε > 0
-  sorry
+  by_contra hlt
+  push_neg at hlt
+  -- linnikConstant > 1, so pick ε = (linnikConstant - 1) / 2 > 0
+  set δ := (linnikConstant - 1) / 2
+  have hδ_pos : δ > 0 := by linarith
+  have h1 := h δ hδ_pos  -- (1 + δ) ∈ admissibleExponents
+  have h2 := csInf_le ⟨0, fun L hL => le_of_lt hL.1⟩ h1  -- linnikConstant ≤ 1 + δ
+  -- But 1 + δ = 1 + (linnikConstant - 1)/2 = (linnikConstant + 1)/2 < linnikConstant
+  linarith
 
 /-- Known range: 1 ≤ linnikConstant ≤ 5 -/
 theorem linnikConstant_range :

--- a/proofs/Proofs/Erdos237Problem.lean
+++ b/proofs/Proofs/Erdos237Problem.lean
@@ -134,10 +134,36 @@ theorem erdos_conjecture_true : ErdosConjecture := by
   have hInf : Set.Infinite A := by
     obtain ⟨c, N₀, hc, hDense⟩ := hA
     by_contra hFin
-    push_neg at hFin
-    obtain ⟨k, hk⟩ := Set.finite_iff_bddAbove.mp hFin
-    -- For N large enough, log(N) > k/c, contradiction
-    sorry
+    have hFA : A.Finite := Set.not_infinite.mp hFin
+    obtain ⟨k, hk⟩ := hFA.bddAbove
+    -- For N ≥ k: A ∩ [1,N] = A ∩ [1,k] since A ⊆ Iic k
+    have heq : ∀ N, N ≥ k → A ∩ Set.Icc 1 N = A ∩ Set.Icc 1 k := by
+      intro N hN; ext x
+      simp only [Set.mem_inter_iff, Set.mem_Icc]
+      exact ⟨fun ⟨hA, h1, _⟩ => ⟨hA, h1, hk hA⟩,
+             fun ⟨hA, h1, hk'⟩ => ⟨hA, h1, hk'.trans hN⟩⟩
+    -- Nat.card is constant C for N ≥ k
+    set C := Nat.card ↥(A ∩ Set.Icc 1 k)
+    -- Pick N large enough that c * log N > C
+    obtain ⟨N, hN⟩ := exists_nat_gt (max ↑(max N₀ k) (Real.exp ((↑C + 1) / c)))
+    have hN_max : max N₀ k < N := by
+      exact_mod_cast lt_of_le_of_lt (le_max_left (↑(max N₀ k) : ℝ) _) hN
+    have hN_N0 : N ≥ N₀ := le_of_lt (lt_of_le_of_lt (le_max_left N₀ k) hN_max)
+    have hN_k : N ≥ k := le_of_lt (lt_of_le_of_lt (le_max_right N₀ k) hN_max)
+    -- Nat.card (A ∩ [1,N]) = C since A ∩ [1,N] = A ∩ [1,k]
+    have hcard : Nat.card ↥(A ∩ Set.Icc 1 N) = C := by rw [heq N hN_k]
+    -- c * log N > C (since N > exp((C+1)/c))
+    have hlog : c * Real.log ↑N > ↑C := by
+      have hN_exp : (↑N : ℝ) > Real.exp ((↑C + 1) / c) :=
+        lt_of_le_of_lt (le_max_right _ _) hN
+      have h := Real.log_lt_log (Real.exp_pos _) hN_exp
+      rw [Real.log_exp] at h
+      rw [div_lt_iff hc] at h
+      linarith [mul_comm (Real.log ↑N) c]
+    -- hDense says (C : ℝ) ≥ c * log N, but c * log N > C. Contradiction.
+    have hdens := hDense N hN_N0
+    rw [hcard] at hdens
+    linarith
   exact chen_ding_2022 A hInf
 
 /-

--- a/proofs/Proofs/Erdos308Problem.lean
+++ b/proofs/Proofs/Erdos308Problem.lean
@@ -97,9 +97,25 @@ noncomputable def f (N : ℕ) : ℕ :=
   Nat.find (existence_proof N)
 where
   existence_proof (N : ℕ) : ∃ k, ¬Representable N k := by
-    -- The sum of all unit fractions 1/1 + ... + 1/N is finite
-    -- so there must be integers beyond it
-    sorry
+    -- Any unit fraction sum from {1,...,N} is ≤ N, so N+1 is not representable
+    use N + 1
+    intro ⟨S, hS_sub, _, hS_sum⟩
+    -- Each term 1/d ≤ 1 (d ≥ 1), so sum ≤ |S| ≤ N
+    have h1 : sumUnitFracs (S.map ⟨(· + 1), fun _ _ h => Nat.succ_injective h⟩) ≤ ↑S.card := by
+      unfold sumUnitFracs
+      calc ∑ n ∈ S.map ⟨(· + 1), fun _ _ h => Nat.succ_injective h⟩, (1 : ℚ) / n
+          ≤ ∑ _n ∈ S.map ⟨(· + 1), fun _ _ h => Nat.succ_injective h⟩, (1 : ℚ) := by
+            apply Finset.sum_le_sum; intro n hn
+            obtain ⟨a, _, rfl⟩ := Finset.mem_map.mp hn
+            exact div_le_one_of_le (by push_cast; omega) (by positivity)
+        _ = ↑(S.map ⟨(· + 1), fun _ _ h => Nat.succ_injective h⟩).card := by
+            simp [Finset.sum_const, smul_eq_mul, mul_one]
+        _ = ↑S.card := by rw [Finset.card_map]
+    have h2 : (S.card : ℚ) ≤ ↑N := by
+      exact_mod_cast (Finset.card_le_card hS_sub).trans (Finset.card_range N).le
+    -- Sum = N+1 but sum ≤ S.card ≤ N, contradiction
+    have : (↑(N + 1) : ℚ) ≤ ↑N := hS_sum ▸ h1 |>.trans h2
+    exact absurd this (by push_cast; omega)
 
 /-
 ## Part III: Basic Properties


### PR DESCRIPTION
## Summary
- **DirichletsTheoremOQ03**: prove `optimal_implies_le_one` — if the optimal Linnik conjecture holds (∀ ε > 0, 1+ε is admissible), then linnikConstant ≤ 1. Proof by contradiction: pick δ = (linnikConstant - 1)/2, apply csInf_le.
- **Erdos237Problem**: prove `erdos_conjecture_true` — sets with logarithmic density are infinite (corollary of Chen-Ding 2022). Proof: finite A bounded by k, so A ∩ [1,N] = A ∩ [1,k] for N ≥ k, making Nat.card constant while c·log(N) → ∞.
- **Erdos308Problem**: prove `existence_proof` — for any N, there exists a non-representable integer (N+1). Proof: each unit fraction 1/d ≤ 1, so sum ≤ |S| ≤ N < N+1.

## Test plan
- [ ] CI builds successfully (no Docker needed — proofs use standard Mathlib tactics)
- [ ] `grep -c sorry` shows reduction in each file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

research