### PR TITLE
Research: eliminate 3 trivial axioms (Erdos194, Erdos778, Erdos658)

### DIFF
--- a/proofs/Proofs/Erdos194Problem.lean
+++ b/proofs/Proofs/Erdos194Problem.lean
@@ -242,8 +242,9 @@ axiom chaotic_ordering_k_term (k : ℕ) (hk : k ≥ 3) :
 The construction can be extended to ℝ using cardinality arguments
 and transfinite induction.
 -/
-axiom chaotic_ordering_reals :
+theorem chaotic_ordering_reals :
     ∃ ordering : ℝ → ℕ, True  -- Simplified; full statement needs uncountable ordering
+    := ⟨fun _ => 0, trivial⟩
 
 /-
 ## Part VIII: Related Problems

--- a/proofs/Proofs/Erdos658Problem.lean
+++ b/proofs/Proofs/Erdos658Problem.lean
@@ -275,9 +275,10 @@ Extensions to higher dimensions and other shapes.
 Dense subsets of {1,...,N}ᵈ contain d-dimensional cubes
 for sufficiently large N.
 -/
-axiom higher_dimensional_cubes (d : ℕ) (hd : d ≥ 2) :
+theorem higher_dimensional_cubes (d : ℕ) (hd : d ≥ 2) :
     ∀ δ : ℚ, δ > 0 →
       ∃ N₀ : ℕ, True  -- Simplified statement
+    := fun _ _ => ⟨0, trivial⟩
 
 /--
 **General affine squares:**

--- a/proofs/Proofs/Erdos778Problem.lean
+++ b/proofs/Proofs/Erdos778Problem.lean
@@ -175,9 +175,10 @@ axiom malekshahian_spiro_density_degree :
 
 /-- Malekshahian-Spiro 2024: If Alice wins degree game at n,
     Bob wins at n+1 and n+2 -/
-axiom malekshahian_spiro_alice_n_bob_n12_degree :
+theorem malekshahian_spiro_alice_n_bob_n12_degree :
   ∀ n : ℕ, True →  -- If Alice wins degree game at n
     True  -- Then Bob wins degree game at n+1 and n+2
+  := fun _ _ => trivial
 
 /- ## Part VII: Consequences of Known Results -/
 

--- a/src/data/proofs/erdos-194/meta.json
+++ b/src/data/proofs/erdos-194/meta.json
@@ -63,7 +63,7 @@
       "chaotic_ordering_k_term axiom: extension to k >= 3",
       "erdos_194_answer theorem: disproof of conjecture"
     ],
-    "axiomCount": 7,
+    "axiomCount": 6,
     "lineCount": 314,
     "assumptions": "7 axiom(s). No sorries."
   },
@@ -183,7 +183,7 @@
     ],
     "namespace": "Erdos194",
     "lineCount": 314,
-    "axiomCount": 7,
+    "axiomCount": 6,
     "theoremCount": 4,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -56,7 +56,7 @@
       "erdos_658 theorem: main result",
       "erdos_658_answer theorem: final answer"
     ],
-    "axiomCount": 9,
+    "axiomCount": 8,
     "lineCount": 330,
     "assumptions": "9 axioms: graham_axis_aligned_true, qualitative_threshold, density_hales_jewett, and 6 more. See Lean source for complete statements."
   },
@@ -168,7 +168,7 @@
     ],
     "namespace": "Erdos658",
     "lineCount": 330,
-    "axiomCount": 9,
+    "axiomCount": 8,
     "theoremCount": 6,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-778/meta.json
+++ b/src/data/proofs/erdos-778/meta.json
@@ -57,7 +57,7 @@
       "game_determined: Zermelo's theorem axiomatized",
       "erdos_778_periodicity summary theorem"
     ],
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 230,
     "assumptions": "6 axioms: playGame, malekshahian_spiro_density_clique, malekshahian_spiro_alice_n_bob_n123, and 3 more. See Lean source for complete statements."
   },
@@ -169,7 +169,7 @@
     ],
     "namespace": "Erdos778",
     "lineCount": 230,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 16
   },


### PR DESCRIPTION
## Summary
- Eliminate 3 trivial axioms with placeholder True conclusions
- Update gallery meta.json axiom counts

## Axiom Eliminations (guaranteed correct)

| File | Axiom | Pattern | New Count |
|------|-------|---------|-----------|
| Erdos194Problem.lean | `chaotic_ordering_reals` | `∃ ℝ→ℕ, True` | 7→6 |
| Erdos778Problem.lean | `malekshahian_spiro_alice_n_bob_n12_degree` | `∀ n, True → True` | 6→5 |
| Erdos658Problem.lean | `higher_dimensional_cubes` | `∀ δ>0, ∃ N₀, True` | 9→8 |

All proved with trivial witnesses (`⟨fun _ => 0, trivial⟩`, `fun _ _ => trivial`, etc.)

🤖 Generated by researcher-5