### PR TITLE
fix: correct stale lineCount in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
@@ -66,7 +66,7 @@
       "minkowski_linfty: L∞ special case from pointwise triangle"
     ],
     "axiomCount": 0,
-    "lineCount": 402,
+    "lineCount": 406,
     "assumptions": "0 axioms. 1 sorry in minkowski_from_holder_explicit (ENNReal arithmetic combining split + Hölder steps with division)."
   },
   "overview": {

--- a/src/data/proofs/erdos-1087/meta.json
+++ b/src/data/proofs/erdos-1087/meta.json
@@ -65,7 +65,7 @@
       "erdos_1087 theorem: combining known bounds"
     ],
     "axiomCount": 6,
-    "lineCount": 331,
+    "lineCount": 335,
     "assumptions": "6 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -280,7 +280,7 @@
       "Finset"
     ],
     "namespace": "Erdos1087",
-    "lineCount": 331,
+    "lineCount": 335,
     "axiomCount": 6,
     "theoremCount": 5,
     "definitionCount": 12

--- a/src/data/proofs/erdos-320/meta.json
+++ b/src/data/proofs/erdos-320/meta.json
@@ -62,8 +62,8 @@
       "erdos_320_summary: key values extracted via tuple projections"
     ],
     "axiomCount": 8,
-    "lineCount": 246,
-    "assumptions": "8 axiom(s) and 2 sorry(s). S_one, S_two, S_three proved from oeis_A072207 axiom. S_pos proved directly. Remaining sorries: lower_bound_growth, log_S_leading_term.",
+    "lineCount": 252,
+    "assumptions": "8 axiom(s) and 0 sorry(s). S_one, S_two, S_three proved from oeis_A072207 axiom. S_pos proved directly. lower_bound_growth and log_S_leading_term now fully proved.",
     "dateUpdated": "2026-03-29"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Research PRs proved theorems and modified Lean source files without updating meta.json lineCount values. Also corrects stale assumptions text in erdos-320 where sorries were eliminated.

## Evidence

| Proof | lineCount (before → after) | Other |
|-------|---------------------------|-------|
| cauchy-schwarz-integral-oq-02-oq-02 | 402 → 406 | — |
| erdos-1087 | 331 → 335 | — |
| erdos-320 | 246 → 252 | assumptions text updated (2→0 sorries proved) |

Sorry counts and axiom counts verified correct — only lineCount and stale text needed repair.

---
Automated fix by lean-mechanic agent.