### PR TITLE
fix: correct sorry/line counts in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,16 +18,16 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 2,
-    "lineCount": 137
+    "lineCount": 139
   },
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
     "namespace": "LinnikConstant",
-    "lineCount": 137,
+    "lineCount": 139,
     "axiomCount": 2,
     "theoremCount": 8,
     "sorryTheorems": 3

--- a/src/data/proofs/erdos-237/meta.json
+++ b/src/data/proofs/erdos-237/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 237,
     "erdosUrl": "https://erdosproblems.com/237",
     "erdosProblemStatus": "solved",
@@ -59,8 +59,8 @@
       "squares, primePowers examples"
     ],
     "axiomCount": 6,
-    "lineCount": 244,
-    "assumptions": "6 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 270,
+    "assumptions": "6 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #237: Prime Plus Set Representations**\n\nThis problem belongs to a rich tradition of additive number theory questions about representing integers as sums involving primes. The classical prototype is Goldbach's conjecture (1742): every even integer $\\ge 4$ is a sum of two primes. Problem #237 generalizes this by replacing one of the primes with an element from a structured set $A$.\n\n**Key History:**\n- 1742: Goldbach conjectures $n = p_1 + p_2$ for even $n$\n- 1934: Romanov proves a positive proportion of integers are $p + 2^k$\n- 1937: Vinogradov proves the ternary Goldbach conjecture using the circle method\n- 1950: Erdős proves the representation count is unbounded when $A = \\{2^k\\}$ (powers of two), using sieve methods. He observes that the values $n - 2^k$ lie in distinct residue classes mod small primes\n- 1950s: Erdős poses the general question for sets with logarithmic density $|A \\cap [1,N]| \\gg \\log N$\n- 2022: Chen and Ding prove a dramatically stronger result — **any** infinite set $A$ has unbounded representation count, completely removing the density hypothesis\n\n**Related**: Erdős Problem #236 concerns a related question about sumsets with primes.",
@@ -192,7 +192,7 @@
     ],
     "opens": [],
     "namespace": "Erdos237",
-    "lineCount": 244,
+    "lineCount": 270,
     "axiomCount": 6,
     "theoremCount": 3,
     "definitionCount": 8

--- a/src/data/proofs/erdos-308/meta.json
+++ b/src/data/proofs/erdos-308/meta.json
@@ -17,7 +17,7 @@
       "harmonic"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 308,
     "erdosUrl": "https://erdosproblems.com/308",
     "erdosProblemStatus": "solved",
@@ -51,8 +51,8 @@
     ],
     "dateAdded": "2026-01-22",
     "axiomCount": 3,
-    "lineCount": 261,
-    "assumptions": "19 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 277,
+    "assumptions": "3 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #308** belongs to the rich tradition of *Egyptian fraction theory*, which dates back to the Rhind Mathematical Papyrus (~1650 BCE), where ancient Egyptian scribes represented fractions as sums of distinct unit fractions $\\frac{1}{n}$.\n\n**Historical Development:**\n- **Fibonacci (1202):** Proved in *Liber Abaci* that every positive rational has an Egyptian fraction representation via the greedy algorithm (later called the Fibonacci-Sylvester algorithm).\n- **Erdős and Graham (1980):** Systematically posed problems about Egyptian fractions in *Old and New Problems and Results in Combinatorial Number Theory*. Problem #308 asks: which integers can be represented as sums of distinct unit fractions $\\frac{1}{k}$ with $k \\leq N$?\n- **Croot (1999):** In his paper *On some questions of Erdős and Graham about Egyptian fractions*, proved definitive bounds on $f(N)$, the smallest non-representable integer, showing $f(N) = \\lfloor H_N \\rfloor - \\Theta\\big(\\frac{(\\log\\log N)^2}{\\log N}\\big)$ where the constant lies in $[\\frac{1}{2}, \\frac{9}{2}]$.\n- **Croot also proved** the contiguity conjecture: for sufficiently large $N$, the set of representable integers is $\\{0, 1, \\ldots, m\\}$ for some $m$ — there are no gaps.\n\n**Key Connection:** The harmonic number $H_N = \\sum_{k=1}^N \\frac{1}{k} \\sim \\ln N + \\gamma$ (where $\\gamma \\approx 0.5772$ is the Euler–Mascheroni constant) provides the natural upper bound, since $\\lfloor H_N \\rfloor$ is the largest integer that could possibly be represented.",
@@ -199,7 +199,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos308",
-    "lineCount": 261,
+    "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 9


### PR DESCRIPTION
## Summary

- **erdos-237**: sorries 1→0, lineCount 244→270
- **erdos-308**: sorries 1→0, lineCount 261→277, assumptions text corrected (was "19 axiom(s)", actual 3)
- **dirichlets-theorem-oq-03**: sorries 4→3, lineCount 137→139

## Test plan

- [x] Verified sorry counts by grepping actual Lean source files
- [x] Verified line counts with `wc -l`
- [x] Verified axiom counts with `grep -c "^axiom "`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Discovered during gallery integrity audit.