### PR TITLE
Research: eliminate 2 trivial axioms (Erdos585, Erdos76)

### DIFF
--- a/proofs/Proofs/Erdos585Problem.lean
+++ b/proofs/Proofs/Erdos585Problem.lean
@@ -91,9 +91,10 @@ axiom ErdosProblem585 :
 /-- Generalization: for k ≥ 2 pairwise edge-disjoint cycles on the
     same vertex set, graphs avoiding this also have at most
     O(n (log n)^C) edges (Chakraborti et al. 2024) -/
-axiom cjmm_k_cycles (k : ℕ) (hk : 2 ≤ k) :
+theorem cjmm_k_cycles (k : ℕ) (hk : 2 ≤ k) :
   ∃ (C₀ : ℝ) (α : ℝ), C₀ > 0 ∧ α > 0 ∧
     ∀ᶠ n in Filter.atTop,
       ∀ (G : SimpleGraph (Fin n)),
         G.edgeFinset.card > C₀ * (n : ℝ) * Real.log (n : ℝ) ^ α →
           True  -- G contains k pairwise edge-disjoint cycles on the same vertex set
+  := ⟨1, 1, by norm_num, by norm_num, Filter.eventually_of_forall (fun _ _ _ => trivial)⟩

--- a/proofs/Proofs/Stubs/Erdos76Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos76Problem.lean
@@ -156,9 +156,10 @@ axiom gruslys_letzter (n : ℕ) (hn : n ≥ 6) :
     (maxPackingSize c : ℝ) ≥ conjecturedBound n * (1 - 1 / n)
 
 /-- The extremal coloring is essentially unique. -/
-axiom extremal_uniqueness (n : ℕ) (hn : n ≥ 6) (c : EdgeColoring (Fin n)) :
+theorem extremal_uniqueness (n : ℕ) (hn : n ≥ 6) (c : EdgeColoring (Fin n)) :
     (maxPackingSize c : ℝ) = conjecturedBound n + o(1) →
     True  -- c is close to balanced coloring (up to isomorphism)
+    := fun _ => trivial
   where
     o : ℝ → ℝ := fun _ => 0
 

--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -19,7 +19,7 @@
     "erdosNumber": 585,
     "erdosUrl": "https://erdosproblems.com/585",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 99,
     "assumptions": "4 axioms: pyber_rodl_szemeredi, cjmm_upper_bound, ErdosProblem585, and 1 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
@@ -126,7 +126,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 99,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -90,7 +90,7 @@
         "relationship": "Almost bipartite graphs — structural decomposition via bipartite subgraphs"
       }
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 246,
     "assumptions": "3 axiom(s) and 4 sorries(s). See the Lean source for details."
   },
@@ -220,7 +220,7 @@
     ],
     "namespace": "Erdos76",
     "lineCount": 246,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 15
   },


### PR DESCRIPTION
## Summary
- Eliminate 2 trivial axioms with `→ True` conclusions
- Update gallery meta.json axiom counts

## Axiom Eliminations (guaranteed correct)

| File | Axiom | Pattern | New Count |
|------|-------|---------|-----------|
| Erdos585Problem.lean | `cjmm_k_cycles` | `∃ C₀ α, ... → True` | 4→3 |
| Stubs/Erdos76Problem.lean | `extremal_uniqueness` | `... → True` | 3→2 |

🤖 Generated by researcher-5