### PR TITLE
Research: erdos-404 — digit-sum identity, reduce 3→1 sorry

### DIFF
--- a/proofs/Proofs/Erdos404Problem.lean
+++ b/proofs/Proofs/Erdos404Problem.lean
@@ -12,6 +12,9 @@ Let f(a, p) denote the greatest such k if it exists. How does f(a, p) behave?
 Known results:
 - Lin (1976): f(2, 2) ≤ 254
 
+Axioms: 2 (lin_bound, lin_bound_meaning — Lin 1976 result)
+Sorries: 1 (Nat.log p n / n → 0 in padic_val_factorial_asymp)
+
 Tags: number-theory, p-adic-valuation, factorials, divisibility, open-problem
 -/
 
@@ -58,7 +61,7 @@ axiom lin_bound_meaning : ∀ s : StrictIncSeq 2, ¬(2^255 ∣ factorialSum s)
 /- ## Part IV: p-adic Analysis -/
 
 noncomputable def legendreSum (n p : ℕ) : ℕ :=
-  ∑ i ∈ Finset.range (Nat.log p n + 1), n / p^(i+1)
+  ∑ i ∈ Finset.range (Nat.log p n + 1), n / p ^ (i + 1)
 
 /-- Legendre's formula: ν_p(n!) = ∑_{i=1}^{⌊log_p n⌋+1} ⌊n/p^i⌋.
     Proved from Mathlib's padicValNat_factorial by reindexing. -/
@@ -72,34 +75,158 @@ theorem legendre_formula (n p : ℕ) (hp : p.Prime) (hn : n ≥ 1) :
   rw [h1]
   exact Finset.sum_congr rfl fun k _ => by rw [add_comm]
 
+/- ## Part IV-A: The digit-sum identity and bounds
+
+Key identity: legendreSum(n,p) * (p-1) + baseDigitSum(n,p) = n
+where baseDigitSum is the sum of base-p digits.
+
+This is proved by telescoping: each step uses the division algorithm
+  a = (a/p)*p + a%p
+to show
+  (a/p)*(p-1) + a%p = a - a/p
+and the sum telescopes to n - n/p^(L+1) = n. -/
+
+/-- Sum of base-p digits of n (via iterated division). -/
+def baseDigitSum (n p : ℕ) : ℕ :=
+  ∑ k ∈ Finset.range (Nat.log p n + 1), n / p ^ k % p
+
+/-- n / p^k is weakly decreasing in k for p ≥ 1. -/
+private theorem div_pow_antitone (n p : ℕ) (hp : 1 ≤ p) :
+    ∀ k, n / p ^ (k + 1) ≤ n / p ^ k :=
+  fun k => Nat.div_le_div_left (Nat.pow_le_pow_right (by omega) (Nat.le_succ k)) (by positivity)
+
+/-- Telescoping sum in ℕ for weakly decreasing f. -/
+private theorem sum_telescope_nat (f : ℕ → ℕ) (hf : ∀ k, f (k + 1) ≤ f k) (L : ℕ) :
+    ∑ k ∈ Finset.range (L + 1), (f k - f (k + 1)) = f 0 - f (L + 1) := by
+  induction L with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_range_succ, ih]
+    have h1 : f (m + 2) ≤ f (m + 1) := hf (m + 1)
+    have h2 : f (m + 1) ≤ f 0 := by
+      clear ih h1; induction m with
+      | zero => exact hf 0
+      | succ k ihk => exact le_trans (hf (k + 1)) ihk
+    omega
+
+/-- Key identity: legendreSum * (p-1) + baseDigitSum = n.
+    Proof by telescoping the division algorithm identity. -/
+theorem legendreSum_digitSum_identity (n p : ℕ) (hp : 2 ≤ p) :
+    legendreSum n p * (p - 1) + baseDigitSum n p = n := by
+  unfold legendreSum baseDigitSum
+  set L := Nat.log p n
+  rw [Finset.sum_mul, ← Finset.sum_add_distrib]
+  -- Each term: n/p^(k+1)*(p-1) + n/p^k%p = n/p^k - n/p^(k+1)
+  have h_eq : ∀ k ∈ range (L + 1),
+      n / p ^ (k + 1) * (p - 1) + n / p ^ k % p = n / p ^ k - n / p ^ (k + 1) := by
+    intro k _
+    -- From division algorithm: a = (a/p)*p + a%p where a = n/p^k
+    have h_div_alg := Nat.div_add_mod (n / p ^ k) p
+    -- n/p^k/p = n/p^(k+1)
+    have h_eq_div : n / p ^ k / p = n / p ^ (k + 1) := by
+      rw [Nat.div_div_eq_div_mul]
+      congr 1
+      exact (pow_succ p k).symm
+    -- Monotonicity: n/p^k ≥ n/p^(k+1)
+    have h_mono : n / p ^ (k + 1) ≤ n / p ^ k := div_pow_antitone n p (by omega) k
+    -- From h_div_alg: p * (n/p^k/p) + n/p^k%p = n/p^k
+    -- Rewrite n/p^k/p = n/p^(k+1):
+    -- p * (n/p^(k+1)) + n/p^k%p = n/p^k
+    -- So: n/p^(k+1)*(p-1) + n/p^k%p + n/p^(k+1) = n/p^k
+    -- Therefore: n/p^(k+1)*(p-1) + n/p^k%p = n/p^k - n/p^(k+1)
+    rw [← h_eq_div] at h_div_alg
+    omega
+  rw [Finset.sum_congr rfl h_eq,
+      sum_telescope_nat (fun k => n / p ^ k) (div_pow_antitone n p (by omega)) L]
+  simp only [pow_zero, Nat.div_one]
+  -- n - n/p^(L+1) = n because p^(L+1) > n
+  have h_zero : n / p ^ (L + 1) = 0 :=
+    Nat.div_eq_of_lt (Nat.lt_pow_succ_log_self (by omega : 1 < p) n)
+  omega
+
+/-- Upper bound: ν_p(n!) * (p-1) ≤ n. -/
+theorem padic_val_factorial_upper (n p : ℕ) (hp : p.Prime) (hn : 1 ≤ n) :
+    padicValNat p n.factorial * (p - 1) ≤ n := by
+  rw [legendre_formula n p hp (by omega)]
+  have := legendreSum_digitSum_identity n p hp.two_le
+  omega
+
+/-- Lower bound: n - (p-1)(⌊log_p n⌋ + 1) ≤ ν_p(n!) * (p-1). -/
+theorem padic_val_factorial_lower (n p : ℕ) (hp : p.Prime) (hn : 1 ≤ n) :
+    n - (p - 1) * (Nat.log p n + 1) ≤ padicValNat p n.factorial * (p - 1) := by
+  rw [legendre_formula n p hp (by omega)]
+  have h_id := legendreSum_digitSum_identity n p hp.two_le
+  -- baseDigitSum ≤ (p-1)*(L+1) since each digit < p
+  have h_ds : baseDigitSum n p ≤ (p - 1) * (Nat.log p n + 1) := by
+    unfold baseDigitSum
+    calc ∑ k ∈ Finset.range (Nat.log p n + 1), n / p ^ k % p
+        ≤ ∑ _ ∈ Finset.range (Nat.log p n + 1), (p - 1) := by
+          apply Finset.sum_le_sum; intro k _
+          have := Nat.mod_lt (n / p ^ k) (show 0 < p by omega); omega
+      _ = (p - 1) * (Nat.log p n + 1) := by
+          rw [Finset.sum_const, Finset.card_range, smul_eq_mul]
+  omega
+
 /-- ν_p(n!)/n → 1/(p-1) as n → ∞.
-    Proof: By Legendre's formula, ν_p(n!) = ∑_{k=1}^{L} ⌊n/p^k⌋ where L = ⌊log_p n⌋ + 1.
-    Upper bound: ⌊n/p^k⌋ ≤ n/p^k, so ν_p(n!)/n ≤ ∑ 1/p^k = 1/(p-1).
-    Lower bound: ⌊n/p^k⌋ ≥ n/p^k - 1, so ν_p(n!)/n ≥ 1/(p-1) - L/n - 1/(p^L(p-1)).
-    Since L = O(log n), both L/n → 0 and 1/p^L → 0. Squeeze gives the result. -/
+    Proof by squeeze theorem using the Nat-valued bounds. -/
 theorem padic_val_factorial_asymp (p : ℕ) (hp : p.Prime) :
     Tendsto (fun n => (padicValNat p n.factorial : ℝ) / n) atTop (nhds (1/(p-1))) := by
   haveI : Fact p.Prime := ⟨hp⟩
-  have hp_pos : (0 : ℝ) < p := Nat.cast_pos.mpr hp.pos
   have hp_one_lt : (1 : ℝ) < p := by exact_mod_cast hp.one_lt
-  have hpp1 : (0 : ℝ) < p - 1 := by linarith
-  -- Upper bound: ν_p(n!)/n ≤ 1/(p-1) for all n ≥ 1
-  have h_upper : ∀ᶠ n in atTop, (padicValNat p n.factorial : ℝ) / n ≤ 1 / (p - 1) := by
+  have hpp1 : (0 : ℝ) < (p : ℝ) - 1 := by linarith
+  -- Upper bound: ν/n ≤ 1/(p-1)
+  have h_upper : ∀ᶠ n in atTop, (padicValNat p n.factorial : ℝ) / n ≤ 1 / ((p : ℝ) - 1) := by
     filter_upwards [Filter.eventually_ge_atTop 1] with n hn
-    sorry -- Legendre + ⌊n/p^k⌋ ≤ n/p^k + geometric series ≤ n/(p-1)
-  -- Lower bound: ν_p(n!)/n ≥ 1/(p-1) - (log_p n + 1)/n for all n ≥ 1
-  have h_lower_tendsto : Tendsto (fun n : ℕ =>
-      1 / ((p : ℝ) - 1) - ((Nat.log p n : ℝ) + 1) / n) atTop (nhds (1 / (p - 1))) := by
+    have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
+    rw [div_le_div_iff hn_pos hpp1, one_mul]
+    exact_mod_cast padic_val_factorial_upper n p hp (by omega)
+  -- Lower bound limit: 1/(p-1) - (L+1)/n → 1/(p-1)
+  have h_lower_lim : Tendsto (fun n : ℕ =>
+      1 / ((p : ℝ) - 1) - ((Nat.log p n : ℝ) + 1) / n) atTop (nhds (1 / ((p : ℝ) - 1))) := by
     have : Tendsto (fun n : ℕ => ((Nat.log p n : ℝ) + 1) / n) atTop (nhds 0) := by
-      sorry -- log_p(n)/n → 0
-    rw [show (1 : ℝ) / (p - 1) = 1 / (p - 1) - 0 from by ring]
+      sorry -- Nat.log p n / n → 0 as n → ∞ (sublinear growth)
+    rw [show (1 : ℝ) / ((p : ℝ) - 1) = 1 / ((p : ℝ) - 1) - 0 from by ring]
     exact Tendsto.sub tendsto_const_nhds this
+  -- Lower bound pointwise: ν/n ≥ 1/(p-1) - (L+1)/n
   have h_lower : ∀ᶠ n in atTop, 1 / ((p : ℝ) - 1) - ((Nat.log p n : ℝ) + 1) / n ≤
       (padicValNat p n.factorial : ℝ) / n := by
     filter_upwards [Filter.eventually_ge_atTop 1] with n hn
-    sorry -- Legendre + ⌊n/p^k⌋ ≥ n/p^k - 1 + sum over L terms
-  exact tendsto_of_tendsto_of_tendsto_of_le_of_le h_lower_tendsto tendsto_const_nhds
-    h_lower h_upper
+    have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
+    -- Use additive identity: ν*(p-1) + ds = n, ds ≤ (p-1)*(L+1)
+    have h_id := legendreSum_digitSum_identity n p hp.two_le
+    have h_ds : baseDigitSum n p ≤ (p - 1) * (Nat.log p n + 1) := by
+      unfold baseDigitSum
+      calc ∑ k ∈ Finset.range (Nat.log p n + 1), n / p ^ k % p
+          ≤ ∑ _ ∈ Finset.range (Nat.log p n + 1), (p - 1) := by
+            apply Finset.sum_le_sum; intro k _
+            have := Nat.mod_lt (n / p ^ k) (show 0 < p by omega); omega
+        _ = (p - 1) * (Nat.log p n + 1) := by
+            rw [Finset.sum_const, Finset.card_range, smul_eq_mul]
+    rw [legendre_formula n p hp (by omega)]
+    -- Goal: 1/(p-1) - (L+1)/n ≤ (legendreSum n p : ℝ) / n
+    -- From h_id: (legendreSum : ℝ) * (p-1) = n - (baseDigitSum : ℝ)
+    -- So (legendreSum : ℝ) = (n - ds) / (p-1)
+    -- And (legendreSum : ℝ) / n = 1/(p-1) - ds/(n*(p-1))
+    -- Since ds ≤ (p-1)*(L+1): ds/(n*(p-1)) ≤ (L+1)/n
+    -- Therefore legendreSum/n ≥ 1/(p-1) - (L+1)/n
+    have h_id_real : (legendreSum n p : ℝ) * ((p : ℝ) - 1) + (baseDigitSum n p : ℝ) = (n : ℝ) := by
+      have h1 : (legendreSum n p * (p - 1) + baseDigitSum n p : ℕ) = n := h_id
+      push_cast [Nat.cast_sub hp.one_lt.le] at h1
+      linarith
+    have h_ds_real : (baseDigitSum n p : ℝ) ≤ ((p : ℝ) - 1) * ((Nat.log p n : ℝ) + 1) := by
+      push_cast [Nat.cast_sub hp.one_lt.le] at h_ds
+      linarith
+    -- Now do the algebra
+    have h_leg : (legendreSum n p : ℝ) * ((p : ℝ) - 1) ≥
+        (n : ℝ) - ((p : ℝ) - 1) * ((Nat.log p n : ℝ) + 1) := by linarith
+    rw [ge_iff_le, ← sub_nonneg]
+    rw [ge_iff_le, ← sub_nonneg] at h_leg
+    rw [sub_div]
+    have : (legendreSum n p : ℝ) / (n : ℝ) - (1 / ((p : ℝ) - 1) - ((Nat.log p n : ℝ) + 1) / (n : ℝ)) =
+        ((legendreSum n p : ℝ) * ((p : ℝ) - 1) - ((n : ℝ) - ((p : ℝ) - 1) * ((Nat.log p n : ℝ) + 1))) /
+        ((n : ℝ) * ((p : ℝ) - 1)) := by field_simp
+    linarith [div_nonneg h_leg (mul_pos hn_pos hpp1).le]
+  exact tendsto_of_tendsto_of_tendsto_of_le_of_le h_lower_lim tendsto_const_nhds h_lower h_upper
 
 /- ## Part V: Structure of Factorial Sums -/
 

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 404,
     "erdosUrl": "https://erdosproblems.com/404",
     "erdosProblemStatus": "open",
@@ -65,8 +65,9 @@
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
-    "lineCount": 125,
-    "assumptions": "2 axioms: lin_bound (f(2,2) ≤ 254), lin_bound_meaning (2^255 never divides such sums). 3 sorries in padic_val_factorial_asymp (v_p(n!)/n → 1/(p-1) squeeze argument). legendre_formula is a proved theorem using Mathlib's padicValNat_factorial."
+    "lineCount": 253,
+    "assumptions": "2 axioms: lin_bound (f(2,2) <= 254), lin_bound_meaning (2^255 never divides such sums). 1 sorry in padic_val_factorial_asymp (Nat.log p n / n -> 0). The digit-sum identity, upper bound, and lower bound are all proved.",
+    "theoremCount": 10
   },
   "overview": {
     "historicalContext": "**Prime Power Divisibility of Factorial Sums**\n\nThe interaction between prime divisibility and factorials has deep roots: Legendre's formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ (1808) gives the exact $p$-adic valuation of $n!$, and Kummer's theorem (1852) extends this to binomial coefficients. Erdős and Graham posed Problem #404 in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*: for integers $a \\geq 1$ and primes $p$, define $f(a,p) = \\sup\\{k : p^k \\mid a_1! + \\cdots + a_n!$ for some $a = a_1 < \\cdots < a_n\\}$. Is $f(a,p)$ always finite?\n\n**Chronological Development:**\n- **1808 (Legendre):** Formula for $v_p(n!)$ — the foundational tool\n- **1976 (Lin):** Proved $f(2,2) \\leq 254$ — the only known concrete upper bound for any $(a,p)$ pair. Lin's argument used careful analysis of carries in $p$-adic addition of factorials\n- **1980 (Erdős–Graham):** Problem 404 posed formally, alongside the related Problem #403 on factorial sums modulo primes\n\nThe problem is surprisingly resistant because factorial sums can have cancellation patterns that concentrate $p$-adic valuation. The gap between the known lower bound $f(2,2) \\geq 3$ (from $2^3 \\mid 2! + 3!$) and Lin's upper bound of 254 illustrates how little is understood about the $p$-adic structure of factorial sums.",
@@ -201,9 +202,9 @@
       "Filter"
     ],
     "namespace": "Erdos404",
-    "lineCount": 125,
+    "lineCount": 253,
     "axiomCount": 2,
-    "theoremCount": 4,
+    "theoremCount": 10,
     "definitionCount": 7
   }
 }

--- a/src/data/research/problems/erdos-404.json
+++ b/src/data/research/problems/erdos-404.json
@@ -29,10 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATED: legendre_formula proved from Mathlib padicValNat_factorial (4->3 axioms). Remaining: lin_bound (Lin 1976), lin_bound_meaning, padic_val_factorial_asymp.",
+    "progressSummary": "PROGRESS: Proved digit-sum identity legendreSum*(p-1)+baseDigitSum=n via telescoping. Both bounds (upper+lower) now proved. Reduced 3→1 sorry (Nat.log/n→0 remains). 2A/1S.",
     "builtItems": [
       "Assessment: 4A all appropriate",
-      "PROVED legendre_formula: padicValNat p n! = legendreSum n p (was axiom, now theorem)"
+      "PROVED legendre_formula: padicValNat p n! = legendreSum n p (was axiom, now theorem)",
+      "legendreSum_digitSum_identity: legendreSum*(p-1)+baseDigitSum=n (telescoping proof)",
+      "baseDigitSum: sum of base-p digits via iterated division",
+      "padic_val_factorial_upper: v*(p-1)<=n from identity",
+      "padic_val_factorial_lower: n-(p-1)(L+1)<=v*(p-1) from identity+digit bound",
+      "padic_val_factorial_asymp: v/n->1/(p-1) via squeeze (1 sorry: log/n->0)",
+      "sum_telescope_nat: Nat telescoping sum lemma",
+      "div_pow_antitone: n/p^k decreasing in k"
     ],
     "insights": [
       "lin_bound and lin_bound_meaning both encode Lin 1976 result (f(2,2) ≤ 254) — deep, appropriate",
@@ -42,10 +49,15 @@
       "native_decide examples verify small cases nicely",
       "Well-structured file with good definitions (StrictIncSeq, factorialSum, divisiblePowers)",
       "legendre_formula PROVED from Mathlib padicValNat_factorial — reindex Ico to range via sum_Ico_eq_sum_range",
-      "Key: padicValNat_factorial gives sum over Ico 1 b; our legendreSum uses range with shifted index; these match after reindexing"
+      "Key: padicValNat_factorial gives sum over Ico 1 b; our legendreSum uses range with shifted index; these match after reindexing",
+      "Key insight: digit-sum identity legendreSum*(p-1)+baseDigitSum=n is exact Nat equality, both bounds follow by omega",
+      "Telescoping via division algorithm: (a/p)*(p-1) + a%p = a - a/p, summed over k=0..L",
+      "Remaining sorry (Nat.log p n / n -> 0) needs sublinear bound on Nat.log"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove Nat.log p n / n -> 0: bound by M/p^M -> 0 where M = Nat.log p n"
+    ],
     "markdown": "# Erdős #404 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor which integers $a\\geq 1$ and primes $p$ is there a finite upper bound on those $k$ such that there are $a=a_1<\\cdots<a_n$ with\\[p^k \\mid (a_1!+\\cdots+a_n!)?\\]If $f(a,p)$ is the greatest such $k$, how does this function behave?\n\nIs there a prime $p$ and an infinite sequence $a_1<a_2<\\cdots$ such that if $p^{m_k}$ is the highest power of $p$ dividing $\\sum_{i\\leq k}a_i!$ then $m_k\\to \\infty$?\n\n\n\nSee also [403]. Lin \\cite{Li76} has shown that $f(2,2) \\leq 254$.\n\n\n\n\nReferences\n\n\n[Li76] Lin, S., On two problems of Erd\\H{o}s concerning sums of distinct factorials. Bell Laboratories internal memorandum (1960).\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #403\n- Problem #405\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Li76\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -62,18 +74,18 @@
     "mathlib": []
   },
   "started": "2026-01-13T02:35:40.569Z",
-  "lastUpdate": "2026-03-13T07:52:17.047Z",
+  "lastUpdate": "2026-03-29T00:30:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos404Problem.lean",
       "filename": "Erdos404Problem.lean",
-      "lineCount": 100,
-      "theoremCount": 3,
+      "lineCount": 253,
+      "theoremCount": 10,
       "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos404Problem.lean"
     }


### PR DESCRIPTION
## Summary
- Proved the **digit-sum identity** `legendreSum*(p-1) + baseDigitSum = n` via telescoping the division algorithm
- From this single identity, proved both **upper bound** (`ν*(p-1) ≤ n`) and **lower bound** (`n-(p-1)(L+1) ≤ ν*(p-1)`)
- Reduced sorry count from **3 → 1** in `padic_val_factorial_asymp`
- Remaining sorry: `Nat.log p n / n → 0` (standard sublinear growth of log)

## Key Result
The identity `legendreSum_digitSum_identity` proves that the Legendre sum times (p-1) plus the base-p digit sum equals n exactly. This is an exact ℕ equality (not an approximation), and both factorial valuation bounds follow by `omega`.

## Files Modified
- `proofs/Proofs/Erdos404Problem.lean` — main proof file (+145 lines)
- `src/data/proofs/erdos-404/meta.json` — updated sorry count
- `src/data/research/problems/erdos-404.json` — updated knowledge

## Status
**Outcome**: progress (3→1 sorry)
**Next Steps**: Prove `Nat.log p n / n → 0` (bound by `M/p^M → 0`)

🤖 Generated by researcher-4