### PR TITLE
Audit: fix sorry/axiom/line counts in 4 gallery proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1841,9 +1841,9 @@
       "issues": []
     },
     "erdos-1070": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T12:43:50Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T02:27:24Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1071": {
@@ -8131,9 +8131,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-961": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T02:28:28Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-962": {
@@ -9947,6 +9947,18 @@
     "furstenberg-correspondence": {
       "auditCount": 1,
       "lastAudited": "2026-03-30T02:04:20Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "hilbert-14-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T02:29:34Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "roth-theorem-k3-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T02:30:33Z",
       "result": "issues-fixed",
       "issues": []
     }

--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -18,7 +18,7 @@
       "hadwiger-nelson"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1070,
     "erdosUrl": "https://erdosproblems.com/1070",
     "erdosProblemStatus": "open",
@@ -36,16 +36,16 @@
         "relationship": "Strict variant with no distances < 1"
       }
     ],
-    "axiomCount": 16,
-    "lineCount": 247,
-    "assumptions": "16 axiom(s) and 1 sorry(s).",
+    "axiomCount": 15,
+    "lineCount": 248,
+    "assumptions": "15 axiom(s): f, f_is_minimum, f_is_achieved, m1, m1_pos, m1_le_one, larman_rogers_theorem, croft_lower_bound, moser_spindle_exists, moser_spindle_upper_bound, acmvz_upper_bound, chromaticNumberPlane, de_grey_lower_bound, chromatic_upper_bound, independence_chromatic_relation.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "**Unit Distance Graphs, Density, and the Independence Threshold**\n\nA *unit distance graph* (UDG) on $n$ points in $\\mathbb{R}^2$ has edges between points at Euclidean distance exactly 1. The *independence number* $\\alpha(G)$ is the size of the largest subset with no edges. Erdős defined $f(n) = \\min_G \\alpha(G)$ over all $n$-point UDGs and asked for its growth rate — in particular, whether $f(n) \\geq n/4$.\n\n**The Larman-Rogers Bridge (1972)**: The key insight connecting discrete and continuous. Let $m_1 = \\sup\\{\\overline{d}(S) : S \\subseteq \\mathbb{R}^2 \\text{ measurable, unit-distance-free}\\}$ be the maximum density of a measurable set avoiding unit distances. Larman and Rogers proved $f(n) \\geq m_1 \\cdot n$ by a probabilistic argument: a random translate of a high-density unit-distance-free set captures $\\geq m_1 n$ of any $n$ given points in expectation.\n\n**Croft's Construction (1967)**: Croft built explicit unit-distance-free sets from hexagonal lattices, proving $m_1 \\geq 0.22936$. Combined with Larman-Rogers: $f(n) \\geq 0.22936n$. This lower bound has stood for over 55 years.\n\n**The Moser Spindle (1961)**: Leo and William Moser constructed a 7-vertex UDG with independence number exactly 2 (and chromatic number 4). By tiling with $\\lfloor n/7 \\rfloor$ copies: $f(n) \\leq (2/7)n \\approx 0.286n$.\n\n**ACMVZ Barrier (2023)**: Ambrus, Csiszárik, Matolcsi, Varga, and Zsámboki proved $m_1 \\leq 0.247$ using Fourier-analytic methods — the constraint $d(p,q) \\neq 1$ translates to conditions on Bessel function zeros in the Fourier domain. Since $0.247 < 0.25 = 1/4$, this establishes a *barrier*: the density method alone cannot prove $f(n) \\geq n/4$.\n\n**De Grey and Hadwiger-Nelson (2018)**: The chromatic number $\\chi$ of $\\mathbb{R}^2$ satisfies $5 \\leq \\chi \\leq 7$ (de Grey improved the lower bound from 4 to 5). Since $\\alpha(G) \\cdot \\chi(G) \\geq |V(G)|$, we get $f(n) \\geq n/\\chi \\geq n/7$.\n\n**Current State**: Best bounds $0.22936n \\leq f(n) \\leq (2/7)n$, with the $n/4$ question requiring genuinely new techniques beyond density.",
     "problemStatement": "**Problem Statement**\n\nLet f(n) be the maximum k such that any n points in ℝ² contain k points with no two at distance 1. Estimate f(n).\n\n**Main Question**: Is f(n) ≥ n/4?\n\n**Best Known Bounds**: 0.22936n ≤ f(n) ≤ (2/7)n ≈ 0.285n\n\n**Status**: OPEN - bounds established but exact asymptotic unknown",
     "text": "Estimate f(n), the minimum independence number of n-point unit distance graphs in ℝ². Is f(n) ≥ n/4? Best bounds: 0.22936n ≤ f(n) ≤ (2/7)n. The n/4 question cannot be resolved via density methods.",
-    "proofStrategy": "**Three-Layer Formalization with Proved Theorems and Density Barrier**\n\nThe formalization builds from geometric definitions through axiomatized deep results to proved theorems, including a genuine impossibility result.\n\n**Layer 1 — Definitions (fully formalized)**: `euclideanDist` wraps Mathlib's `dist` on `EuclideanSpace \\mathbb{R} (\\text{Fin}\\, 2)`. `isUnitDistance` checks $d(p,q) = 1$. `UnitDistanceGraph n` stores a `Finset` of $n$ points with `card_eq` proof. `IsIndependentSet` requires $S \\subseteq V(G)$ and $\\forall p \\neq q \\in S,\\, d(p,q) \\neq 1$. `independenceNumber` uses `Finset.sup` over `powerset.filter`.\n\n**Layer 2 — Axiomatized quantities and results**: The function `f(n)` is axiomatized with `f_is_minimum` and `f_is_achieved` ensuring it is a valid extremal quantity. The density constant `m1` is axiomatized with positivity and boundedness. Key results axiomatized: `larman_rogers_theorem` ($f(n) \\geq m_1 n$), `croft_lower_bound` ($m_1 \\geq 0.22936$), `moser_spindle_exists` and `moser_spindle_upper_bound` ($f(n) \\leq (2/7)n$), `acmvz_upper_bound` ($m_1 \\leq 0.247$), Hadwiger-Nelson bounds ($5 \\leq \\chi \\leq 7$).\n\n**Layer 3 — Proved theorems**: `f_lower_bound` chains `larman_rogers_theorem` with `croft_lower_bound` via `nlinarith`. `best_known_bounds` packages both bounds via `exact ⟨f_lower_bound n, moser_spindle_upper_bound n⟩`. `quarter_threshold` verifies $0.247 < 1/4$ by `norm_num`. `density_insufficient_for_quarter` chains `acmvz_upper_bound` with `quarter_threshold` via `calc`. The summary theorem packages all three results.\n\n**One sorry remains**: `quarter_conjecture_open` (the $n/4$ question is genuinely open). The previously sorry'd `f_from_chromatic` has been fully proved via explicit fraction clearing and monotonicity arguments.",
+    "proofStrategy": "**Three-Layer Formalization with Proved Theorems and Density Barrier**\n\nThe formalization builds from geometric definitions through axiomatized deep results to proved theorems, including a genuine impossibility result.\n\n**Layer 1 — Definitions (fully formalized)**: `euclideanDist` wraps Mathlib's `dist` on `EuclideanSpace \\mathbb{R} (\\text{Fin}\\, 2)`. `isUnitDistance` checks $d(p,q) = 1$. `UnitDistanceGraph n` stores a `Finset` of $n$ points with `card_eq` proof. `IsIndependentSet` requires $S \\subseteq V(G)$ and $\\forall p \\neq q \\in S,\\, d(p,q) \\neq 1$. `independenceNumber` uses `Finset.sup` over `powerset.filter`.\n\n**Layer 2 — Axiomatized quantities and results**: The function `f(n)` is axiomatized with `f_is_minimum` and `f_is_achieved` ensuring it is a valid extremal quantity. The density constant `m1` is axiomatized with positivity and boundedness. Key results axiomatized: `larman_rogers_theorem` ($f(n) \\geq m_1 n$), `croft_lower_bound` ($m_1 \\geq 0.22936$), `moser_spindle_exists` and `moser_spindle_upper_bound` ($f(n) \\leq (2/7)n$), `acmvz_upper_bound` ($m_1 \\leq 0.247$), Hadwiger-Nelson bounds ($5 \\leq \\chi \\leq 7$).\n\n**Layer 3 — Proved theorems**: `f_lower_bound` chains `larman_rogers_theorem` with `croft_lower_bound` via `nlinarith`. `best_known_bounds` packages both bounds via `exact ⟨f_lower_bound n, moser_spindle_upper_bound n⟩`. `quarter_threshold` verifies $0.247 < 1/4$ by `norm_num`. `density_insufficient_for_quarter` chains `acmvz_upper_bound` with `quarter_threshold` via `calc`. The summary theorem packages all three results.\n\nAll theorems are fully proved (0 sorries). `f_from_chromatic` was proved via explicit fraction clearing and monotonicity arguments; `quarter_conjecture_open` was removed (the $n/4$ question is genuinely open and not formalized as a sorry).",
     "keyInsights": [
       "**Discrete-continuous bridge**: The Larman-Rogers theorem $f(n) \\geq m_1 \\cdot n$ converts the combinatorial independence problem into a continuous density optimization — this is one of the most elegant applications of the probabilistic method in discrete geometry",
       "**Density barrier at $1/4$**: ACMVZ (2023) proved $m_1 \\leq 0.247 < 1/4$, establishing that the Larman-Rogers approach *cannot* prove $f(n) \\geq n/4$ — any such proof requires fundamentally new techniques, perhaps structural rather than density-based",
@@ -225,9 +225,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1070",
-    "lineCount": 247,
-    "axiomCount": 16,
+    "lineCount": 248,
+    "axiomCount": 15,
     "theoremCount": 6,
-    "definitionCount": 6
+    "definitionCount": 7
   }
 }

--- a/src/data/proofs/erdos-961/meta.json
+++ b/src/data/proofs/erdos-961/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 961,
     "erdosUrl": "https://erdosproblems.com/961",
     "erdosProblemStatus": "open",
@@ -62,9 +62,9 @@
       "Axiomatized erdos_1955_bound and jutila_ramachandra_shorey_bound",
       "Defined polylog_conjecture and smooth_gap for connection to #683"
     ],
-    "axiomCount": 4,
-    "lineCount": 262,
-    "assumptions": "4 axiom(s) and 3 sorries(s). Sorries: f_sublinear (line 147), answer(sorry) in polylog_conjecture_open (line 173), f_le_smooth_gap_succ (line 206)."
+    "axiomCount": 3,
+    "lineCount": 261,
+    "assumptions": "3 axiom(s) and 2 sorry(s). Axioms: sylvester_schur, erdos_1955_bound, jutila_ramachandra_shorey_bound. Sorries: f_sublinear (line 147), f_le_smooth_gap_succ (line 206)."
   },
   "overview": {
     "historicalContext": "This problem connects to a classical result by Sylvester (1892) and Schur (1929) showing that among any $k$ consecutive integers greater than $k$, at least one has a prime factor greater than $k$. Erdős published this as Problem #961, asking for better bounds on $f(k)$.\n\nErdős himself improved the bound in 1955 [Er55d] to $f(k) < 3k/\\log k$, showing sublinear growth. The strongest known result came from Jutila (1974) [Ju74] and independently Ramachandra–Shorey (1973) [RaSh73], who proved $f(k) \\ll \\frac{\\log\\log\\log k}{\\log\\log k} \\cdot \\frac{k}{\\log k}$ using sieve methods.\n\nThe problem is essentially equivalent to Problem #683, which asks about gaps between smooth numbers. The conjecture that $f(k)$ grows only polylogarithmically—$f(k) \\ll (\\log k)^C$—remains wide open. The gap between the known $O(k / \\text{polylog})$ and conjectured $O(\\text{polylog})$ is enormous.\n\nSmooth numbers play a central role in computational number theory: the quadratic sieve and number field sieve factoring algorithms depend on finding smooth numbers in specific ranges. Understanding the distribution of smooth numbers in short intervals is both a fundamental problem in analytic number theory and a question of practical importance.\n\n**Status**: OPEN — Polylogarithmic conjecture unresolved. Best known bound: $f(k) \\ll \\frac{\\log\\log\\log k}{\\log\\log k} \\cdot \\frac{k}{\\log k}$.",
@@ -194,10 +194,11 @@
       "Asymptotics"
     ],
     "namespace": "Erdos961",
-    "lineCount": 262,
-    "axiomCount": 4,
+    "lineCount": 261,
+    "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 5
+
   },
   "references": [
     {

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -47,7 +47,7 @@
     ],
     "lineCount": 235,
     "theoremCount": 6,
-    "definitionCount": 4,
+    "definitionCount": 3,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -161,6 +161,6 @@
     "lineCount": 235,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 4
+    "definitionCount": 3
   }
 }

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -47,9 +47,9 @@
       "Edge-disjointness lower bound: edge removal requires >= |A|N edges",
       "Statement of Roth's theorem via triangle removal as alternative to Fourier proof"
     ],
-    "lineCount": 353,
-    "theoremCount": 12,
-    "definitionCount": 5,
+    "lineCount": 357,
+    "theoremCount": 13,
+    "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -172,9 +172,9 @@
       "Finset"
     ],
     "namespace": "Szemeredi.Roth.TriangleRemoval",
-    "lineCount": 353,
+    "lineCount": 357,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 5
+    "theoremCount": 13,
+    "definitionCount": 4
   }
 }


### PR DESCRIPTION
## Summary

- **erdos-1070**: sorries 1→0 (quarter_conjecture_open removed), axiomCount 16→15, lineCount 247→248
- **erdos-961**: sorries 3→2 (polylog_conjecture_open removed), axiomCount 4→3, lineCount 262→261
- **hilbert-14-oq-01**: definitionCount 4→3 (first audit, minor count fix)
- **roth-theorem-k3-oq-02**: lineCount 353→357, theoremCount 12→13, definitionCount 5→4 (first audit)

## Test plan

- [ ] Verify corrected counts match Lean source files
- [ ] `pnpm build` succeeds with updated meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)