### PR TITLE
Fix: correct 13 badge/status mismatches in gallery metadata

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -18,8 +18,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -18,8 +18,8 @@
       "finset",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -15,8 +15,8 @@
       "algorithms",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Int.mul_ediv_cancel'",

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,8 +20,8 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 5,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_comp_add_right",
@@ -70,7 +70,7 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 390,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -17,8 +17,8 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",

--- a/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
@@ -18,8 +18,8 @@
       "research",
       "open-problem"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "axiomCount": 0,
     "assumptions": "0 axiom declarations, 0 sorries remain. All definitions and key theorems are fully proved including gaussian_cubic_bound (O(n³) bound via term-by-term bounding).",
     "lineCount": 228

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -9,8 +9,8 @@
     "date": "classical",
     "status": "formalized",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "tags": [
       "combinatorics",
       "permutations",

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -18,8 +18,8 @@
       "elementary",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Nat.exists_prime_and_dvd",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -5,7 +5,7 @@
   "description": "For which g(N) → ∞ does |A ∩ {1,...,N}| >> N^{1/2}/g(N) imply limsup r_A(n) = ∞? Solving for any g → ∞ implies the Erdős–Turán conjecture (Problem #28). $500 bounty. Status: OPEN.",
   "meta": {
     "erdosNumber": 40,
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "erdos",
       "number-theory",

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/638",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos638Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -15,8 +15,8 @@
       "convex-analysis",
       "open-question"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",


### PR DESCRIPTION
## Fix

Correct badge/status metadata inconsistencies across 13 gallery proofs found during routine audit scan.

## Evidence

**Category 1 — Status upgrade (3 proofs)**

| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| erdos-40 | status=formalized, badge=verified | status=verified | 0 sorries, 0 axioms in Lean source |
| erdos-638 | status=formalized, badge=verified | status=verified | 0 sorries, 0 axioms in Lean source |
| erdos-1092 | status=formalized, badge=original | status=verified | 0 sorries, 0 axioms in Lean source |

**Category 2 — Badge downgrade + sorry count correction (10 proofs)**

| Proof | sorries (before→after) | badge (before→after) |
|-------|----------------------|---------------------|
| buffons-needle-oq-01-oq-01 | 0→5 | verified→axiom (has 1 axiom) |
| cramers-rule-oq-01-oq-03 | 0→1 | verified→wip |
| derangements-oq-02 | 0→1 | verified→wip |
| area-of-circle-oq-03-oq-02 | 0→1 | verified→wip |
| dirichlets-theorem-oq-02 | 0→1 | verified→wip |
| schauder-fixed-point-oq-01 | 0→3 | verified→wip |
| bezout-identity-oq-02-oq-02-oq-01-oq-01 | 0→1 | verified→wip |
| cayley-hamilton-minpoly-oq-05-oq-01 | 0→1 | verified→wip |
| erdos-1006-oq-02-oq-03 | 0→1 | verified→wip |
| ballot-problem-oq-01-oq-01 | 0→2 | verified→wip |

## Validation

- `pnpm annotations:build` completed successfully (warnings are pre-existing annotation misalignment)
- All sorry/axiom counts verified against actual Lean source files via `grep -cw sorry`

---
Automated fix by lean-mechanic agent.